### PR TITLE
fix(workspaces): gate the GitHub palette number match on repo remote identity

### DIFF
--- a/src/main/github/github-remote-identity-parsing.ts
+++ b/src/main/github/github-remote-identity-parsing.ts
@@ -1,12 +1,7 @@
+import { normalizeGitHubRemoteHost } from '../../shared/git-remote-host-alias'
 import type { GitHubOwnerRepo } from '../../shared/types'
 
 export type GitHubRemoteIdentity = GitHubOwnerRepo & { host: string }
-
-export function normalizeGitHubRemoteHost(host: string): string {
-  const normalizedHost = host.toLowerCase()
-  // Why: GitHub documents ssh.github.com as SSH-over-HTTPS for github.com repos.
-  return normalizedHost === 'ssh.github.com' ? 'github.com' : normalizedHost
-}
 
 // Why: HTTP ports identify the GHES web/API endpoint; SSH and git ports are
 // transport-only and must not leak into gh's host identity.

--- a/src/renderer/src/lib/worktree-palette-gitlab-url-match.ts
+++ b/src/renderer/src/lib/worktree-palette-gitlab-url-match.ts
@@ -1,4 +1,4 @@
-import { normalizeGitLabRemoteHost } from '../../../shared/git-remote-host-alias'
+import { foldComparableGitLabHost } from '../../../shared/git-remote-host-alias'
 import {
   matchGitRemoteKeyParts,
   splitGitRemoteKey,
@@ -16,7 +16,7 @@ export type GitLabIssueOrMRLink = NonNullable<ReturnType<typeof parseGitLabIssue
 /** Host + project path, matching how `GitRemoteIdentity.canonicalKey` is built. */
 function gitLabProjectKeyParts(slug: ProjectSlug): GitRemoteKeyParts {
   return {
-    host: normalizeGitLabRemoteHost(slug.host.replace(/:\d+$/, '')),
+    host: foldComparableGitLabHost(slug.host.replace(/:\d+$/, '')),
     tail: slug.path
       .replace(/^\/+/, '')
       .replace(/\/+$/, '')
@@ -41,7 +41,7 @@ function gitLabLinksEqual(left: GitLabIssueOrMRLink, right: GitLabIssueOrMRLink)
 /** Tri-state like `repoMatchesGitHubSlug`: `'unknown'` stays permissive for forks and host aliases. */
 function repoMatchesGitLabSlug(repo: Repo | undefined, slug: ProjectSlug): boolean | 'unknown' {
   const identity = repo?.gitRemoteIdentity
-  const identityParts = splitGitRemoteKey(identity?.canonicalKey, normalizeGitLabRemoteHost)
+  const identityParts = splitGitRemoteKey(identity?.canonicalKey, foldComparableGitLabHost)
   if (!identityParts) {
     return 'unknown'
   }

--- a/src/renderer/src/lib/worktree-palette-gitlab-url-match.ts
+++ b/src/renderer/src/lib/worktree-palette-gitlab-url-match.ts
@@ -1,3 +1,9 @@
+import { normalizeGitLabRemoteHost } from '../../../shared/git-remote-host-alias'
+import {
+  matchGitRemoteKeyParts,
+  splitGitRemoteKey,
+  type GitRemoteKeyParts
+} from '../../../shared/git-remote-identity'
 import type { HostedReviewInfo } from '../../../shared/hosted-review'
 import {
   parseGitLabIssueOrMRLink,
@@ -7,15 +13,21 @@ import type { Repo, Worktree } from '../../../shared/types'
 
 export type GitLabIssueOrMRLink = NonNullable<ReturnType<typeof parseGitLabIssueOrMRLink>>
 
-/** Same shape as `GitRemoteIdentity.canonicalKey`: lowercased host (no port) + normalized project path. */
+/** Host + project path, matching how `GitRemoteIdentity.canonicalKey` is built. */
+function gitLabProjectKeyParts(slug: ProjectSlug): GitRemoteKeyParts {
+  return {
+    host: normalizeGitLabRemoteHost(slug.host.replace(/:\d+$/, '')),
+    tail: slug.path
+      .replace(/^\/+/, '')
+      .replace(/\/+$/, '')
+      .replace(/\.git$/i, '')
+      .toLowerCase()
+  }
+}
+
 function gitLabProjectKey(slug: ProjectSlug): string {
-  const host = slug.host.replace(/:\d+$/, '').toLowerCase()
-  const path = slug.path
-    .replace(/^\/+/, '')
-    .replace(/\/+$/, '')
-    .replace(/\.git$/i, '')
-    .toLowerCase()
-  return `${host}/${path}`
+  const { host, tail } = gitLabProjectKeyParts(slug)
+  return `${host}/${tail}`
 }
 
 function gitLabLinksEqual(left: GitLabIssueOrMRLink, right: GitLabIssueOrMRLink): boolean {
@@ -29,16 +41,18 @@ function gitLabLinksEqual(left: GitLabIssueOrMRLink, right: GitLabIssueOrMRLink)
 /** Tri-state like `repoMatchesGitHubSlug`: `'unknown'` stays permissive for forks and host aliases. */
 function repoMatchesGitLabSlug(repo: Repo | undefined, slug: ProjectSlug): boolean | 'unknown' {
   const identity = repo?.gitRemoteIdentity
-  if (!identity?.canonicalKey) {
+  const identityParts = splitGitRemoteKey(identity?.canonicalKey, normalizeGitLabRemoteHost)
+  if (!identityParts) {
     return 'unknown'
   }
-  if (identity.canonicalKey.replace(/\/+$/, '').toLowerCase() === gitLabProjectKey(slug)) {
-    return true
+  const verdict = matchGitRemoteKeyParts(identityParts, gitLabProjectKeyParts(slug))
+  if (verdict !== false) {
+    return verdict
   }
   // Why not false: identity keeps one remote, chosen when the repo was added and never re-probed.
   // An `upstream` pick means a fork's `origin` existed and is invisible here, so rejecting would
   // drop MR URLs from the fork itself. A stale snapshot can still misjudge a renamed project.
-  return identity.remoteName === 'upstream' ? 'unknown' : false
+  return identity?.remoteName === 'upstream' ? 'unknown' : false
 }
 
 export function worktreeMatchesGitLabUrl(

--- a/src/renderer/src/lib/worktree-palette-task-url-match.test.ts
+++ b/src/renderer/src/lib/worktree-palette-task-url-match.test.ts
@@ -50,6 +50,19 @@ function gitLabRepo(canonicalKey: string): Repo {
   }
 }
 
+/** Basename displayName: the common non-fork case, where only the remote identifies the repo. */
+function gitHubRepo(canonicalKey: string): Repo {
+  return {
+    ...orcaRepo,
+    displayName: 'orca',
+    gitRemoteIdentity: {
+      canonicalKey,
+      remoteName: 'origin',
+      remoteUrl: `git@${canonicalKey.replace('/', ':')}.git`
+    }
+  }
+}
+
 describe('parseCmdJTaskSourceUrl', () => {
   it('parses GitHub issue and pull URLs', () => {
     expect(parseCmdJTaskSourceUrl('https://github.com/stablyai/orca/issues/14198')).toEqual({
@@ -163,6 +176,181 @@ describe('matchWorktreePaletteTaskUrl', () => {
         repo: { ...orcaRepo, displayName: 'Repo 1' }
       })
     ).toMatchObject({ matchedField: 'pr', supportingText: { text: 'PR #12789' } })
+  })
+
+  it('gates a stored GitHub number on the repo remote identity', () => {
+    const intent = parseCmdJTaskSourceUrl('https://github.com/stablyai/orca/pull/12789')
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree({ linkedPR: 12789 }),
+        intent: intent!,
+        repo: gitHubRepo('github.com/other/project')
+      })
+    ).toBeNull()
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree({ linkedPR: 12789 }),
+        intent: intent!,
+        repo: gitHubRepo('github.com/stablyai/orca')
+      })
+    ).toMatchObject({ matchedField: 'pr', supportingText: { text: 'PR #12789' } })
+  })
+
+  it('gates a stored GitHub work item with no URL on the repo remote identity', () => {
+    const intent = parseCmdJTaskSourceUrl('https://github.com/stablyai/orca/issues/14198')
+    const worktree = makeWorktree({
+      linkedWorkItem: { provider: 'github', type: 'issue', number: 14198, title: 'Bug', url: '' }
+    })
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree,
+        intent: intent!,
+        repo: gitHubRepo('github.com/other/project')
+      })
+    ).toBeNull()
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree,
+        intent: intent!,
+        repo: gitHubRepo('github.com/stablyai/orca')
+      })
+    ).toMatchObject({ matchedField: 'issue' })
+  })
+
+  it('does not match a GitHub URL on a different host for the same owner/repo', () => {
+    const intent = parseCmdJTaskSourceUrl('https://ghe.example.com/stablyai/orca/pull/12789')
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree({ linkedPR: 12789 }),
+        intent: intent!,
+        repo: gitHubRepo('github.com/stablyai/orca')
+      })
+    ).toBeNull()
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree({ linkedPR: 12789 }),
+        intent: intent!,
+        repo: gitHubRepo('ghe.example.com/stablyai/orca')
+      })
+    ).toMatchObject({ matchedField: 'pr' })
+  })
+
+  it('normalizes host case, port, and owner case before comparing GitHub identities', () => {
+    const intent = parseCmdJTaskSourceUrl('https://GHE.Example.com:8443/StablyAI/Orca/pull/12789')
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree({ linkedPR: 12789 }),
+        intent: intent!,
+        repo: gitHubRepo('ghe.example.com/stablyai/orca')
+      })
+    ).toMatchObject({ matchedField: 'pr' })
+  })
+
+  it('stays permissive for GitHub numbers when the repo remote identity is unknown', () => {
+    const intent = parseCmdJTaskSourceUrl('https://github.com/stablyai/orca/pull/12789')
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree({ linkedPR: 12789 }),
+        intent: intent!,
+        repo: { ...orcaRepo, displayName: 'orca' }
+      })
+    ).toMatchObject({ matchedField: 'pr' })
+    expect(
+      matchWorktreePaletteTaskUrl({ worktree: makeWorktree({ linkedPR: 12789 }), intent: intent! })
+    ).toMatchObject({ matchedField: 'pr' })
+  })
+
+  it('stays permissive for a GitHub fork whose identity resolved to the upstream remote', () => {
+    // `deriveGitRemoteIdentity` prefers `upstream`, so the fork's own `origin` is not visible here.
+    const forkRepo: Repo = {
+      ...gitHubRepo('github.com/stablyai/orca'),
+      gitRemoteIdentity: {
+        canonicalKey: 'github.com/stablyai/orca',
+        remoteName: 'upstream',
+        remoteUrl: 'git@github.com:stablyai/orca.git'
+      }
+    }
+    const intent = parseCmdJTaskSourceUrl('https://github.com/me/orca/pull/12789')
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree({ linkedPR: 12789 }),
+        intent: intent!,
+        repo: forkRepo
+      })
+    ).toMatchObject({ matchedField: 'pr' })
+    // An `origin`-derived identity is authoritative, so a different repo still loses.
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree({ linkedPR: 12789 }),
+        intent: intent!,
+        repo: gitHubRepo('github.com/stablyai/orca')
+      })
+    ).toBeNull()
+  })
+
+  it('keeps the GitHub number gate type-aware across repos', () => {
+    const prIntent = parseCmdJTaskSourceUrl('https://github.com/stablyai/orca/pull/12789')
+    const issueIntent = parseCmdJTaskSourceUrl('https://github.com/stablyai/orca/issues/12789')
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree({ linkedIssue: 12789 }),
+        intent: prIntent!,
+        repo: gitHubRepo('github.com/stablyai/orca')
+      })
+    ).toBeNull()
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree({ linkedIssue: 12789 }),
+        intent: issueIntent!,
+        repo: gitHubRepo('github.com/other/project')
+      })
+    ).toBeNull()
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree({ linkedIssue: 12789 }),
+        intent: issueIntent!,
+        repo: gitHubRepo('github.com/stablyai/orca')
+      })
+    ).toMatchObject({ matchedField: 'issue', supportingText: { text: 'Issue #12789' } })
+  })
+
+  it('keeps an owner/repo displayName authoritative over a host-alias remote', () => {
+    const intent = parseCmdJTaskSourceUrl('https://github.com/stablyai/orca/pull/12789')
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree({ linkedPR: 12789 }),
+        intent: intent!,
+        repo: {
+          ...orcaRepo,
+          gitRemoteIdentity: {
+            canonicalKey: 'git-mirror.example.com/stablyai/orca',
+            remoteName: 'origin',
+            remoteUrl: 'git@git-mirror.example.com:stablyai/orca.git'
+          }
+        }
+      })
+    ).toMatchObject({ matchedField: 'pr' })
+  })
+
+  it('matches a GitHub PR URL via the linked review URL regardless of remote identity', () => {
+    const intent = parseCmdJTaskSourceUrl('https://github.com/stablyai/orca/pull/12789')
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree(),
+        intent: intent!,
+        repo: gitHubRepo('github.com/other/project'),
+        review: {
+          provider: 'github',
+          number: 12789,
+          title: 'Fork PR',
+          state: 'open',
+          url: 'https://github.com/stablyai/orca/pull/12789',
+          status: 'pending',
+          updatedAt: '2026-01-01T00:00:00Z',
+          mergeable: 'UNKNOWN'
+        }
+      })
+    ).toMatchObject({ matchedField: 'pr' })
   })
 
   it('rejects a GitLab MR URL from a different project than the stored URL', () => {

--- a/src/renderer/src/lib/worktree-palette-task-url-match.test.ts
+++ b/src/renderer/src/lib/worktree-palette-task-url-match.test.ts
@@ -235,6 +235,33 @@ describe('matchWorktreePaletteTaskUrl', () => {
     ).toMatchObject({ matchedField: 'pr' })
   })
 
+  it('matches GitHub remotes whose host is an SSH alias or www form of github.com', () => {
+    const intent = parseCmdJTaskSourceUrl('https://github.com/stablyai/orca/pull/12789')
+    for (const canonicalKey of [
+      // ssh://git@ssh.github.com:443/... — GitHub's port-443 workaround.
+      'ssh.github.com/stablyai/orca',
+      // git@github-work:... — an OpenSSH `Host` alias `git remote -v` cannot expand.
+      'github-work/stablyai/orca',
+      'www.github.com/stablyai/orca'
+    ]) {
+      expect(
+        matchWorktreePaletteTaskUrl({
+          worktree: makeWorktree({ linkedPR: 12789 }),
+          intent: intent!,
+          repo: gitHubRepo(canonicalKey)
+        })
+      ).toMatchObject({ matchedField: 'pr' })
+    }
+    // A real, resolvable host is evidence of a different forge, not an alias.
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree({ linkedPR: 12789 }),
+        intent: intent!,
+        repo: gitHubRepo('ghe.example.com/stablyai/orca')
+      })
+    ).toBeNull()
+  })
+
   it('normalizes host case, port, and owner case before comparing GitHub identities', () => {
     const intent = parseCmdJTaskSourceUrl('https://GHE.Example.com:8443/StablyAI/Orca/pull/12789')
     expect(
@@ -451,6 +478,31 @@ describe('matchWorktreePaletteTaskUrl', () => {
         repo: gitLabRepo('gitlab.com/acme/orca')
       })
     ).toMatchObject({ matchedField: 'pr' })
+  })
+
+  it('matches GitLab remotes whose host is an SSH alias or www form of gitlab.com', () => {
+    const intent = parseCmdJTaskSourceUrl('https://gitlab.com/acme/orca/-/merge_requests/17')
+    for (const canonicalKey of [
+      // altssh.gitlab.com is GitLab's port-443 SSH endpoint; `gitlab-work` is an ssh-config alias.
+      'altssh.gitlab.com/acme/orca',
+      'gitlab-work/acme/orca',
+      'www.gitlab.com/acme/orca'
+    ]) {
+      expect(
+        matchWorktreePaletteTaskUrl({
+          worktree: makeWorktree({ linkedGitLabMR: 17 }),
+          intent: intent!,
+          repo: gitLabRepo(canonicalKey)
+        })
+      ).toMatchObject({ matchedField: 'pr' })
+    }
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree({ linkedGitLabMR: 17 }),
+        intent: intent!,
+        repo: gitLabRepo('gitlab.example.com/acme/orca')
+      })
+    ).toBeNull()
   })
 
   it('stays permissive for GitLab numbers when the repo remote identity is unknown', () => {

--- a/src/renderer/src/lib/worktree-palette-task-url-match.ts
+++ b/src/renderer/src/lib/worktree-palette-task-url-match.ts
@@ -1,4 +1,4 @@
-import { normalizeGitHubRemoteHost } from '../../../shared/git-remote-host-alias'
+import { foldComparableGitHubHost } from '../../../shared/git-remote-host-alias'
 import {
   matchGitRemoteKeyParts,
   splitGitRemoteKey,
@@ -84,14 +84,14 @@ function parseOwnerRepoDisplayName(value: string | null | undefined): RepoSlug |
 /** Host + `owner/repo` tail, matching how `GitRemoteIdentity.canonicalKey` is built. */
 function githubRemoteKeyParts(slug: RepoSlug): GitRemoteKeyParts {
   return {
-    host: normalizeGitHubRemoteHost((slug.host || 'github.com').replace(/:\d+$/, '')),
+    host: foldComparableGitHubHost((slug.host || 'github.com').replace(/:\d+$/, '')),
     tail: `${slug.owner.toLowerCase()}/${slug.repo.replace(/\.git$/i, '').toLowerCase()}`
   }
 }
 
 function remoteIdentityMatchesGitHubSlug(repo: Repo, slug: RepoSlug): boolean | 'unknown' {
   const identity = repo.gitRemoteIdentity
-  const identityParts = splitGitRemoteKey(identity?.canonicalKey, normalizeGitHubRemoteHost)
+  const identityParts = splitGitRemoteKey(identity?.canonicalKey, foldComparableGitHubHost)
   if (!identityParts) {
     return 'unknown'
   }

--- a/src/renderer/src/lib/worktree-palette-task-url-match.ts
+++ b/src/renderer/src/lib/worktree-palette-task-url-match.ts
@@ -75,10 +75,36 @@ function parseOwnerRepoDisplayName(value: string | null | undefined): RepoSlug |
   return { owner: match[1], repo: match[2] }
 }
 
+/** Same shape as `GitRemoteIdentity.canonicalKey`: lowercased host (no port) + `owner/repo`. */
+function githubRemoteKey(slug: RepoSlug): string {
+  const host = (slug.host || 'github.com')
+    .replace(/:\d+$/, '')
+    .replace(/^www\./i, '')
+    .toLowerCase()
+  return `${host}/${slug.owner.toLowerCase()}/${slug.repo.replace(/\.git$/i, '').toLowerCase()}`
+}
+
+function remoteIdentityMatchesGitHubSlug(repo: Repo, slug: RepoSlug): boolean | 'unknown' {
+  const identity = repo.gitRemoteIdentity
+  if (!identity?.canonicalKey) {
+    return 'unknown'
+  }
+  if (identity.canonicalKey.replace(/\/+$/, '').toLowerCase() === githubRemoteKey(slug)) {
+    return true
+  }
+  // Why not false: identity keeps one remote, chosen when the repo was added and never re-probed.
+  // An `upstream` pick means a fork's `origin` existed and is invisible here, so rejecting would
+  // drop URLs from the fork itself. A stale snapshot can still misjudge a renamed repo.
+  return identity.remoteName === 'upstream' ? 'unknown' : false
+}
+
+/** Tri-state: `'unknown'` stays permissive for forks and host aliases. */
 function repoMatchesGitHubSlug(repo: Repo | undefined, slug: RepoSlug): boolean | 'unknown' {
   if (!repo) {
     return 'unknown'
   }
+  // Why displayName first: it is compared host-agnostically, so mirrors and host aliases of the
+  // same owner/repo keep matching; the probed remote only fills in where no name evidence exists.
   const fromName = parseOwnerRepoDisplayName(repo.displayName)
   if (fromName) {
     return githubIdentityKey({ ...fromName, host: slug.host }) === githubIdentityKey(slug)
@@ -86,7 +112,9 @@ function repoMatchesGitHubSlug(repo: Repo | undefined, slug: RepoSlug): boolean 
   if (repo.upstream?.owner && repo.upstream.repo) {
     return githubIdentityKey(repo.upstream) === githubIdentityKey(slug)
   }
-  return 'unknown'
+  // Why: a basename-only displayName is the common non-fork case, and issue/PR numbers are
+  // per-repo, so a bare number must still clear the remote the repo actually points at.
+  return remoteIdentityMatchesGitHubSlug(repo, slug)
 }
 
 export function parseCmdJTaskSourceUrl(query: string): CmdJTaskSourceUrl | null {

--- a/src/renderer/src/lib/worktree-palette-task-url-match.ts
+++ b/src/renderer/src/lib/worktree-palette-task-url-match.ts
@@ -1,3 +1,9 @@
+import { normalizeGitHubRemoteHost } from '../../../shared/git-remote-host-alias'
+import {
+  matchGitRemoteKeyParts,
+  splitGitRemoteKey,
+  type GitRemoteKeyParts
+} from '../../../shared/git-remote-identity'
 import type { HostedReviewInfo } from '../../../shared/hosted-review'
 import {
   parseGitHubIssueOrPRLink,
@@ -75,27 +81,28 @@ function parseOwnerRepoDisplayName(value: string | null | undefined): RepoSlug |
   return { owner: match[1], repo: match[2] }
 }
 
-/** Same shape as `GitRemoteIdentity.canonicalKey`: lowercased host (no port) + `owner/repo`. */
-function githubRemoteKey(slug: RepoSlug): string {
-  const host = (slug.host || 'github.com')
-    .replace(/:\d+$/, '')
-    .replace(/^www\./i, '')
-    .toLowerCase()
-  return `${host}/${slug.owner.toLowerCase()}/${slug.repo.replace(/\.git$/i, '').toLowerCase()}`
+/** Host + `owner/repo` tail, matching how `GitRemoteIdentity.canonicalKey` is built. */
+function githubRemoteKeyParts(slug: RepoSlug): GitRemoteKeyParts {
+  return {
+    host: normalizeGitHubRemoteHost((slug.host || 'github.com').replace(/:\d+$/, '')),
+    tail: `${slug.owner.toLowerCase()}/${slug.repo.replace(/\.git$/i, '').toLowerCase()}`
+  }
 }
 
 function remoteIdentityMatchesGitHubSlug(repo: Repo, slug: RepoSlug): boolean | 'unknown' {
   const identity = repo.gitRemoteIdentity
-  if (!identity?.canonicalKey) {
+  const identityParts = splitGitRemoteKey(identity?.canonicalKey, normalizeGitHubRemoteHost)
+  if (!identityParts) {
     return 'unknown'
   }
-  if (identity.canonicalKey.replace(/\/+$/, '').toLowerCase() === githubRemoteKey(slug)) {
-    return true
+  const verdict = matchGitRemoteKeyParts(identityParts, githubRemoteKeyParts(slug))
+  if (verdict !== false) {
+    return verdict
   }
   // Why not false: identity keeps one remote, chosen when the repo was added and never re-probed.
   // An `upstream` pick means a fork's `origin` existed and is invisible here, so rejecting would
   // drop URLs from the fork itself. A stale snapshot can still misjudge a renamed repo.
-  return identity.remoteName === 'upstream' ? 'unknown' : false
+  return identity?.remoteName === 'upstream' ? 'unknown' : false
 }
 
 /** Tri-state: `'unknown'` stays permissive for forks and host aliases. */

--- a/src/shared/git-remote-host-alias.ts
+++ b/src/shared/git-remote-host-alias.ts
@@ -2,10 +2,16 @@
 // comparison of a probed remote against a pasted URL must fold those to the same identity.
 
 function normalizeRemoteHost(host: string): string {
-  return host
-    .trim()
-    .toLowerCase()
-    .replace(/^www\./, '')
+  return host.trim().toLowerCase()
+}
+
+/**
+ * Fold a `www.` prefix. Deliberately NOT part of the forge normalizers: those feed
+ * `getProjectIdentityKey`, so folding there would re-key already-persisted projects on upgrade.
+ * Only URL-vs-remote comparison may use it.
+ */
+export function foldWwwHostAlias(host: string): string {
+  return normalizeRemoteHost(host).replace(/^www\./, '')
 }
 
 export function normalizeGitHubRemoteHost(host: string): string {
@@ -18,6 +24,15 @@ export function normalizeGitLabRemoteHost(host: string): string {
   const normalizedHost = normalizeRemoteHost(host)
   // Why: GitLab documents altssh.gitlab.com as SSH-over-443 for gitlab.com projects.
   return normalizedHost === 'altssh.gitlab.com' ? 'gitlab.com' : normalizedHost
+}
+
+/** Comparison-only host fold: the forge alias plus `www.`, for matching a remote to a pasted URL. */
+export function foldComparableGitHubHost(host: string): string {
+  return normalizeGitHubRemoteHost(foldWwwHostAlias(host))
+}
+
+export function foldComparableGitLabHost(host: string): string {
+  return normalizeGitLabRemoteHost(foldWwwHostAlias(host))
 }
 
 /**

--- a/src/shared/git-remote-host-alias.ts
+++ b/src/shared/git-remote-host-alias.ts
@@ -1,0 +1,29 @@
+// Why: a remote URL can name a forge through an alias host (SSH-over-443, `www.`), and every
+// comparison of a probed remote against a pasted URL must fold those to the same identity.
+
+function normalizeRemoteHost(host: string): string {
+  return host
+    .trim()
+    .toLowerCase()
+    .replace(/^www\./, '')
+}
+
+export function normalizeGitHubRemoteHost(host: string): string {
+  const normalizedHost = normalizeRemoteHost(host)
+  // Why: GitHub documents ssh.github.com as SSH-over-HTTPS for github.com repos.
+  return normalizedHost === 'ssh.github.com' ? 'github.com' : normalizedHost
+}
+
+export function normalizeGitLabRemoteHost(host: string): string {
+  const normalizedHost = normalizeRemoteHost(host)
+  // Why: GitLab documents altssh.gitlab.com as SSH-over-443 for gitlab.com projects.
+  return normalizedHost === 'altssh.gitlab.com' ? 'gitlab.com' : normalizedHost
+}
+
+/**
+ * A host with no dot is an OpenSSH `Host` alias (`git@github-work:owner/repo`) that only
+ * ~/.ssh/config can expand; `git remote -v` never resolves it, so it is unknown, not wrong.
+ */
+export function isUnresolvedSshHostAlias(host: string): boolean {
+  return !normalizeRemoteHost(host).includes('.')
+}

--- a/src/shared/git-remote-identity.test.ts
+++ b/src/shared/git-remote-identity.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { deriveGitRemoteIdentity, normalizeGitRemoteUrl } from './git-remote-identity'
+import { normalizeGitHubRemoteHost } from './git-remote-host-alias'
+import {
+  deriveGitRemoteIdentity,
+  matchGitRemoteKeyParts,
+  normalizeGitRemoteUrl,
+  splitGitRemoteKey
+} from './git-remote-identity'
 
 describe('normalizeGitRemoteUrl', () => {
   it('normalizes HTTPS and SSH GitHub remotes to the same canonical key', () => {
@@ -74,5 +80,34 @@ describe('deriveGitRemoteIdentity', () => {
       canonicalKey: 'git.company.test/team/sample-app',
       remoteName: 'mirror'
     })
+  })
+})
+
+describe('splitGitRemoteKey / matchGitRemoteKeyParts', () => {
+  const github = (key: string | undefined) => splitGitRemoteKey(key, normalizeGitHubRemoteHost)
+
+  it('rejects keys without both a host and a path', () => {
+    expect(github('github.com')).toBeNull()
+    expect(github('github.com/')).toBeNull()
+    expect(github('/example/sample-app')).toBeNull()
+    expect(github(undefined)).toBeNull()
+  })
+
+  it('normalizes the host and lowercases the path tail', () => {
+    expect(github('SSH.GitHub.com:443/Example/Sample-App')).toEqual({
+      host: 'github.com',
+      tail: 'example/sample-app'
+    })
+  })
+
+  it('treats a dotless probed host as unknown but a real host as a mismatch', () => {
+    const target = { host: 'github.com', tail: 'example/sample-app' }
+    expect(matchGitRemoteKeyParts({ host: 'github-work', tail: target.tail }, target)).toBe(
+      'unknown'
+    )
+    expect(matchGitRemoteKeyParts({ host: 'ghe.example.com', tail: target.tail }, target)).toBe(
+      false
+    )
+    expect(matchGitRemoteKeyParts({ host: 'github-work', tail: 'other/repo' }, target)).toBe(false)
   })
 })

--- a/src/shared/git-remote-identity.ts
+++ b/src/shared/git-remote-identity.ts
@@ -1,7 +1,47 @@
+import { isUnresolvedSshHostAlias } from './git-remote-host-alias'
+
 export type GitRemoteIdentity = {
   canonicalKey: string
   remoteName: string
   remoteUrl: string
+}
+
+export type GitRemoteKeyParts = {
+  host: string
+  tail: string
+}
+
+/** Split a `canonicalKey` into `host` + path tail so the host can be alias-normalized. */
+export function splitGitRemoteKey(
+  canonicalKey: string | null | undefined,
+  normalizeHost: (host: string) => string
+): GitRemoteKeyParts | null {
+  const key = canonicalKey?.trim().replace(/\/+$/, '').toLowerCase() ?? ''
+  const separator = key.indexOf('/')
+  if (separator <= 0 || separator === key.length - 1) {
+    return null
+  }
+  return {
+    host: normalizeHost(key.slice(0, separator).replace(/:\d+$/, '')),
+    tail: key.slice(separator + 1)
+  }
+}
+
+/**
+ * Compare a probed remote against a pasted URL. A host-only mismatch is `'unknown'` when the
+ * probed host is an SSH alias, since `git remote -v` reports it unexpanded.
+ */
+export function matchGitRemoteKeyParts(
+  identity: GitRemoteKeyParts,
+  target: GitRemoteKeyParts
+): boolean | 'unknown' {
+  if (identity.tail !== target.tail) {
+    return false
+  }
+  if (identity.host === target.host) {
+    return true
+  }
+  return isUnresolvedSshHostAlias(identity.host) ? 'unknown' : false
 }
 
 type GitRemoteEntry = {

--- a/src/shared/project-host-setup-projection.test.ts
+++ b/src/shared/project-host-setup-projection.test.ts
@@ -628,3 +628,39 @@ describe('isProjectRemoteIdentityPending', () => {
     ).toBe(false)
   })
 })
+
+describe('derived project identity stability', () => {
+  const base = { id: 'r', path: '/r', displayName: 'r' } as const
+
+  // Why pinned: this id is the persisted Project primary key, so folding a host alias here would
+  // silently re-key existing projects on upgrade and drop their runtime preference.
+  it('keeps a www. remote provider-neutral instead of folding it onto github.com', () => {
+    const projection = projectHostSetupProjectionFromRepos([
+      repo({
+        ...base,
+        gitRemoteIdentity: {
+          canonicalKey: 'www.github.com/acme/app',
+          remoteName: 'origin',
+          remoteUrl: 'https://www.github.com/acme/app.git'
+        }
+      })
+    ])
+    expect(projection.projects.map((project) => project.id)).toEqual([
+      'git:www.github.com/acme/app'
+    ])
+  })
+
+  it('still folds the documented ssh.github.com alias onto github.com', () => {
+    const projection = projectHostSetupProjectionFromRepos([
+      repo({
+        ...base,
+        gitRemoteIdentity: {
+          canonicalKey: 'ssh.github.com/acme/app',
+          remoteName: 'origin',
+          remoteUrl: 'ssh://git@ssh.github.com:443/acme/app.git'
+        }
+      })
+    ])
+    expect(projection.projects.map((project) => project.id)).toEqual(['github:acme/app'])
+  })
+})

--- a/src/shared/project-host-setup-projection.ts
+++ b/src/shared/project-host-setup-projection.ts
@@ -1,4 +1,5 @@
 import { getRepoExecutionHostId } from './execution-host'
+import { normalizeGitHubRemoteHost } from './git-remote-host-alias'
 import { githubRepoIdentityKey, isDefaultGitHubHost } from './github-repository-identity-key'
 import type {
   Project,
@@ -118,11 +119,6 @@ function getProjectId(
   repo: Pick<Repo, 'id' | 'upstream' | 'repoIcon' | 'gitRemoteIdentity'>
 ): string {
   return getProjectIdentityKey(repo)
-}
-
-function normalizeGitHubRemoteHost(host: string): string {
-  const normalizedHost = host.toLowerCase()
-  return normalizedHost === 'ssh.github.com' ? 'github.com' : normalizedHost
 }
 
 function isGitHubRemoteHost(host: string): boolean {


### PR DESCRIPTION
Fixes **STA-4237**. The GitHub twin of #14381, which fixed the same hole on the GitLab path.

## Problem

`repoMatchesGitHubSlug` returns the tri-state `'unknown'` when the repo is missing, **or** when `repo.displayName` is not in `owner/repo` form and `repo.upstream` is absent. The caller gates the number-only fallback on `!== false`, so `'unknown'` passes straight through.

A basename-named non-fork repo — the common case — yields `'unknown'`, so a pasted GitHub issue/PR URL can match a workspace in a **different repo** that happens to share the number. This was reproduced during the review of #14381.

## Fix

Before giving up and returning `'unknown'`, fall back to the probed `repo.gitRemoteIdentity.canonicalKey`, mirroring `repoMatchesGitLabSlug`. New `githubRemoteKey(slug)` builds the canonicalKey shape (`host/owner/repo`, host defaulted to github.com, `:port` / leading `www.` / trailing `.git` stripped, lowercased); `remoteIdentityMatchesGitHubSlug` compares them.

The caller's `!== false` gate is unchanged, so **behavior only tightens where there was previously zero evidence**.

Carried over from #14381: `deriveGitRemoteIdentity` keeps only one remote and ranks `upstream` above `origin`, so a fork checkout's canonicalKey names the upstream and its own `origin` is invisible. Hard-rejecting there would drop URLs from the fork the user actually checked out, so an `upstream`-derived identity returns `'unknown'` rather than `false`.

## Ordering: canonicalKey runs *after* displayName, deliberately

The displayName branch compares host-agnostically (it borrows `slug.host`), which is what keeps internal mirrors and host aliases of the same `owner/repo` matching — a `git-mirror.example.com/stablyai/orca` origin with displayName `stablyai/orca` still matches a github.com URL.

Putting canonicalKey first would flip those to `false` and regress exactly the alias permissiveness the tri-state exists to protect, in exchange for closing a *different*, pre-existing hole. **No repo that resolves via displayName today changes behavior.**

## Tests

Nine new cases; five confirmed **failing before** the fix (5 failed / 22 passed with the source stashed). The other four are deliberate regression guards that pass both before and after — they exist to prove the fix does *not* tighten those paths:

- cross-repo same-number rejection when identity is resolvable and differs
- number-only work item (no URL) gated on identity
- different host, same `owner/repo` → rejected
- host case / port / owner case normalization
- unresolvable identity stays permissive
- upstream-derived fork identity stays permissive
- type-aware across repos (issue vs PR)
- `owner/repo` displayName stays authoritative over a host-alias remote
- review-URL path matches regardless of identity

53/53 across the match and search suites. Typecheck, oxlint, and oxfmt clean.

## Known limits

1. **Deliberately left open**: a repo with displayName `stablyai/orca` whose real remote is `ghe.corp/stablyai/orca` still matches a pasted github.com URL for the same number, because the displayName branch never compares hosts. Fixing it means canonicalKey-first, which regresses mirror matching — that's a product decision, not a drive-by.
2. The upstream carve-out means fork checkouts get no gating at all on either provider. Only fixable once identity keeps more than one remote — see STA-4247.