### PR TITLE
fix(repos): re-probe git remote identity so a stale snapshot stops misjudging identity gates

### DIFF
--- a/src/main/orca-profiles/profile-project-state-file.test.ts
+++ b/src/main/orca-profiles/profile-project-state-file.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest'
+import { getDefaultPersistedState } from '../../shared/constants'
+import type { PersistedState, Project, ProjectHostSetup, Repo } from '../../shared/types'
+import { rebuildRepoBackedProjectState } from './profile-project-state-file'
+
+const upstreamIdentity = {
+  canonicalKey: 'git.example.com/acme/app-upstream',
+  remoteName: 'upstream',
+  remoteUrl: 'git@git.example.com:acme/app-upstream.git'
+}
+
+const makeRepo = (overrides: Partial<Repo> = {}): Repo => ({
+  id: 'r1',
+  path: '/repo',
+  displayName: 'App',
+  badgeColor: '#fff',
+  addedAt: 1,
+  ...overrides
+})
+
+const makeProject = (overrides: Partial<Project> = {}): Project => ({
+  id: 'project-1',
+  displayName: 'App',
+  badgeColor: '#737373',
+  sourceRepoIds: [],
+  createdAt: 1,
+  updatedAt: 1,
+  ...overrides
+})
+
+const makeSetup = (overrides: Partial<ProjectHostSetup> = {}): ProjectHostSetup => ({
+  id: 'setup-1',
+  projectId: 'project-1',
+  hostId: 'local',
+  repoId: '',
+  path: '/repo',
+  displayName: 'App',
+  setupState: 'ready',
+  setupMethod: 'imported-existing-folder',
+  createdAt: 1,
+  updatedAt: 1,
+  ...overrides
+})
+
+function makeState(overrides: Partial<PersistedState>): PersistedState {
+  return { ...getDefaultPersistedState('/home/test'), ...overrides }
+}
+
+describe('rebuildRepoBackedProjectState', () => {
+  it('carries project state and independent setups across a repo remote identity change', () => {
+    const originProjectId = 'git:git.example.com/acme/app'
+    const rebuilt = rebuildRepoBackedProjectState(
+      makeState({
+        repos: [makeRepo({ gitRemoteIdentity: upstreamIdentity })],
+        projects: [
+          makeProject({
+            id: originProjectId,
+            sourceRepoIds: ['r1'],
+            localWindowsRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' }
+          })
+        ],
+        projectHostSetups: [
+          makeSetup({ id: 'r1', projectId: originProjectId, repoId: 'r1' }),
+          makeSetup({
+            id: 'app::gpu-vm',
+            projectId: originProjectId,
+            hostId: 'runtime:gpu-vm',
+            path: '/srv/app'
+          })
+        ]
+      })
+    )
+
+    expect(rebuilt.projects).toEqual([
+      expect.objectContaining({
+        id: 'git:git.example.com/acme/app-upstream',
+        localWindowsRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' }
+      })
+    ])
+    expect(rebuilt.projectHostSetups.find((setup) => setup.id === 'app::gpu-vm')?.projectId).toBe(
+      'git:git.example.com/acme/app-upstream'
+    )
+  })
+
+  it('picks one predecessor project when several prior rows overlap the same repos', () => {
+    const sharedIdentity = {
+      canonicalKey: 'git.example.com/acme/shared',
+      remoteName: 'origin',
+      remoteUrl: 'git@git.example.com:acme/shared.git'
+    }
+    const rebuilt = rebuildRepoBackedProjectState(
+      makeState({
+        repos: [
+          makeRepo({ id: 'r1', path: '/left', gitRemoteIdentity: sharedIdentity }),
+          makeRepo({ id: 'r2', path: '/right', gitRemoteIdentity: sharedIdentity })
+        ],
+        projects: [
+          makeProject({
+            id: 'git:git.example.com/acme/left',
+            sourceRepoIds: ['r1'],
+            updatedAt: 200,
+            localWindowsRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' }
+          }),
+          makeProject({
+            id: 'git:git.example.com/acme/right',
+            sourceRepoIds: ['r2'],
+            updatedAt: 100,
+            localWindowsRuntimePreference: { kind: 'windows-host' }
+          })
+        ],
+        projectHostSetups: [
+          makeSetup({ id: 'r1', projectId: 'git:git.example.com/acme/left', repoId: 'r1' }),
+          makeSetup({ id: 'r2', projectId: 'git:git.example.com/acme/right', repoId: 'r2' })
+        ]
+      })
+    )
+
+    // Equal repo overlap resolves by newest updatedAt; the loser's preference is never merged in.
+    expect(rebuilt.projects).toEqual([
+      expect.objectContaining({
+        id: 'git:git.example.com/acme/shared',
+        sourceRepoIds: ['r1', 'r2'],
+        localWindowsRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' }
+      })
+    ])
+  })
+
+  it('leaves an unclaimed prior project standing with its own independent setups', () => {
+    const rebuilt = rebuildRepoBackedProjectState(
+      makeState({
+        repos: [makeRepo({ gitRemoteIdentity: upstreamIdentity })],
+        projects: [
+          makeProject({
+            id: 'cloud-project',
+            localWindowsRuntimePreference: { kind: 'windows-host' }
+          })
+        ],
+        projectHostSetups: [
+          makeSetup({ id: 'cloud-project::gpu-vm', projectId: 'cloud-project', path: '/srv/cloud' })
+        ]
+      })
+    )
+
+    expect(rebuilt.projects.map((project) => project.id)).toEqual([
+      'git:git.example.com/acme/app-upstream',
+      'cloud-project'
+    ])
+    expect(rebuilt.projectHostSetups.map((setup) => setup.projectId)).toEqual([
+      'git:git.example.com/acme/app-upstream',
+      'cloud-project'
+    ])
+  })
+})

--- a/src/main/orca-profiles/profile-project-state-file.ts
+++ b/src/main/orca-profiles/profile-project-state-file.ts
@@ -5,6 +5,7 @@ import { dirname } from 'node:path'
 import { getDefaultPersistedState, getDefaultWorkspaceSession } from '../../shared/constants'
 import type { ExecutionHostId } from '../../shared/execution-host'
 import { projectHostSetupProjectionFromRepos } from '../../shared/project-host-setup-projection'
+import { carryProjectStateThroughIdentityChange } from '../../shared/project-identity-succession'
 import type {
   PersistedState,
   Project,
@@ -102,16 +103,22 @@ function isRepoBackedProjectHostSetup(
 
 export function rebuildRepoBackedProjectState(state: TransferProfileState): TransferProfileState {
   const projection = projectHostSetupProjectionFromRepos(state.repos)
-  const existingProjectsById = new Map(state.projects.map((project) => [project.id, project]))
+  const succession = carryProjectStateThroughIdentityChange(projection.projects, state.projects)
   const currentRepoIds = new Set(state.repos.map((repo) => repo.id))
   const projectedProjectIds = new Set(projection.projects.map((project) => project.id))
   const projectedSetupIds = new Set(projection.setups.map((setup) => setup.id))
-  const independentSetups = state.projectHostSetups.filter((setup) => {
-    if (projectedSetupIds.has(setup.id)) {
-      return false
-    }
-    return !isRepoBackedProjectHostSetup(setup, currentRepoIds)
-  })
+  const independentSetups = state.projectHostSetups
+    .filter((setup) => {
+      if (projectedSetupIds.has(setup.id)) {
+        return false
+      }
+      return !isRepoBackedProjectHostSetup(setup, currentRepoIds)
+    })
+    // Why: follow the repo's project through a derived-id change so no ghost project row survives.
+    .map((setup) => {
+      const remappedProjectId = succession.remappedProjectIds.get(setup.projectId)
+      return remappedProjectId ? { ...setup, projectId: remappedProjectId } : setup
+    })
   const independentProjectIds = new Set(independentSetups.map((setup) => setup.projectId))
   const independentProjects = state.projects
     .filter(
@@ -121,19 +128,9 @@ export function rebuildRepoBackedProjectState(state: TransferProfileState): Tran
       ...project,
       sourceRepoIds: project.sourceRepoIds.filter((repoId) => currentRepoIds.has(repoId))
     }))
-  const projectedProjects = projection.projects.map((project) => {
-    const existingProject = existingProjectsById.get(project.id)
-    return existingProject?.localWindowsRuntimePreference
-      ? {
-          ...project,
-          localWindowsRuntimePreference: existingProject.localWindowsRuntimePreference,
-          updatedAt: Math.max(project.updatedAt, existingProject.updatedAt)
-        }
-      : project
-  })
   return {
     ...state,
-    projects: [...projectedProjects, ...independentProjects],
+    projects: [...succession.projects, ...independentProjects],
     projectHostSetups: [...projection.setups, ...independentSetups]
   }
 }

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -595,6 +595,124 @@ describe('Store', () => {
     })
   })
 
+  it('carries project state and independent setups across a repo remote identity change', async () => {
+    const originProjectId = 'git:git.example.com/acme/app'
+    writeDataFile({
+      ...getDefaultPersistedState(testState.dir),
+      repos: [
+        makeRepo({
+          id: 'r1',
+          path: '/repo',
+          displayName: 'App',
+          gitRemoteIdentity: {
+            canonicalKey: 'git.example.com/acme/app',
+            remoteName: 'origin',
+            remoteUrl: 'git@git.example.com:acme/app.git'
+          }
+        })
+      ],
+      projects: [
+        makeProject({
+          id: originProjectId,
+          sourceRepoIds: ['r1'],
+          localWindowsRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' }
+        })
+      ],
+      projectHostSetups: [
+        makeProjectHostSetup({ id: 'r1', projectId: originProjectId, repoId: 'r1' }),
+        makeProjectHostSetup({
+          id: 'app::gpu-vm',
+          projectId: originProjectId,
+          hostId: 'runtime:gpu-vm',
+          repoId: '',
+          path: '/srv/app'
+        })
+      ]
+    })
+    const store = await createStore()
+
+    // A re-probe that now prefers the `upstream` remote rewrites the derived project id.
+    store.updateRepo('r1', {
+      gitRemoteIdentity: {
+        canonicalKey: 'git.example.com/acme/app-upstream',
+        remoteName: 'upstream',
+        remoteUrl: 'git@git.example.com:acme/app-upstream.git'
+      }
+    })
+
+    const upstreamProjectId = 'git:git.example.com/acme/app-upstream'
+    expect(store.getProjects().map((project) => project.id)).toEqual([upstreamProjectId])
+    expect(store.getProjects()[0]?.localWindowsRuntimePreference).toEqual({
+      kind: 'wsl',
+      distro: 'Ubuntu'
+    })
+    expect(
+      store.getProjectHostSetups().find((setup) => setup.id === 'app::gpu-vm')?.projectId
+    ).toBe(upstreamProjectId)
+  })
+
+  it('picks one predecessor project when several prior rows overlap the same repos', async () => {
+    const sharedIdentity = {
+      canonicalKey: 'git.example.com/acme/shared',
+      remoteName: 'origin',
+      remoteUrl: 'git@git.example.com:acme/shared.git'
+    }
+    writeDataFile({
+      ...getDefaultPersistedState(testState.dir),
+      repos: [
+        makeRepo({
+          id: 'r1',
+          path: '/left',
+          displayName: 'Left',
+          gitRemoteIdentity: sharedIdentity
+        }),
+        makeRepo({
+          id: 'r2',
+          path: '/right',
+          displayName: 'Right',
+          gitRemoteIdentity: sharedIdentity
+        })
+      ],
+      projects: [
+        makeProject({
+          id: 'git:git.example.com/acme/left',
+          sourceRepoIds: ['r1'],
+          updatedAt: 200,
+          localWindowsRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' }
+        }),
+        makeProject({
+          id: 'git:git.example.com/acme/right',
+          sourceRepoIds: ['r2'],
+          updatedAt: 100,
+          localWindowsRuntimePreference: { kind: 'windows-host' }
+        })
+      ],
+      projectHostSetups: [
+        makeProjectHostSetup({
+          id: 'r1',
+          projectId: 'git:git.example.com/acme/left',
+          repoId: 'r1'
+        }),
+        makeProjectHostSetup({
+          id: 'r2',
+          projectId: 'git:git.example.com/acme/right',
+          repoId: 'r2'
+        })
+      ]
+    })
+
+    const store = await createStore()
+
+    // Equal repo overlap resolves by newest updatedAt; the loser's preference is never merged in.
+    expect(store.getProjects()).toEqual([
+      expect.objectContaining({
+        id: 'git:git.example.com/acme/shared',
+        sourceRepoIds: ['r1', 'r2'],
+        localWindowsRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' }
+      })
+    ])
+  })
+
   it('migrates legacy WSL agent settings into the global Windows runtime default', async () => {
     writeDataFile({
       schemaVersion: 1,

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -79,6 +79,7 @@ import {
   normalizeProjectRuntimePreference
 } from '../shared/project-execution-runtime'
 import { projectHostSetupProjectionFromRepos } from '../shared/project-host-setup-projection'
+import { carryProjectStateThroughIdentityChange } from '../shared/project-identity-succession'
 import { isPluginPanelTabKey } from '../shared/plugins/plugin-manifest'
 import type { GitRemoteIdentity } from '../shared/git-remote-identity'
 import {
@@ -2466,19 +2467,26 @@ function mergeProjectHostSetupCompatibilityState(
   repos: readonly Repo[]
 ): Pick<PersistedState, 'projects' | 'projectHostSetups'> {
   const projection = projectHostSetupProjectionFromRepos(repos)
-  const existingProjectsById = new Map(
-    (state.projects ?? []).map((project) => [project.id, project])
+  const succession = carryProjectStateThroughIdentityChange(
+    projection.projects,
+    state.projects ?? []
   )
   const currentRepoIds = new Set(repos.map((repo) => repo.id))
   const projectedProjectIds = new Set(projection.projects.map((project) => project.id))
   const projectedSetupIds = new Set(projection.setups.map((setup) => setup.id))
   // Why: legacy/repo-backed setup rows reuse the repo id; keep only independent rows so repo deletion leaves no ghosts.
-  const independentSetups = (state.projectHostSetups ?? []).filter((setup) => {
-    if (projectedSetupIds.has(setup.id)) {
-      return false
-    }
-    return !isRepoBackedProjectHostSetup(setup, currentRepoIds)
-  })
+  const independentSetups = (state.projectHostSetups ?? [])
+    .filter((setup) => {
+      if (projectedSetupIds.has(setup.id)) {
+        return false
+      }
+      return !isRepoBackedProjectHostSetup(setup, currentRepoIds)
+    })
+    // Why: follow the repo's project through a derived-id change so no ghost project row survives.
+    .map((setup) => {
+      const remappedProjectId = succession.remappedProjectIds.get(setup.projectId)
+      return remappedProjectId ? { ...setup, projectId: remappedProjectId } : setup
+    })
   const independentProjectIds = new Set(independentSetups.map((setup) => setup.projectId))
   const independentProjects = (state.projects ?? [])
     .filter(
@@ -2488,18 +2496,8 @@ function mergeProjectHostSetupCompatibilityState(
       ...project,
       sourceRepoIds: project.sourceRepoIds.filter((repoId) => currentRepoIds.has(repoId))
     }))
-  const projectedProjects = projection.projects.map((project) => {
-    const existingProject = existingProjectsById.get(project.id)
-    return existingProject?.localWindowsRuntimePreference
-      ? {
-          ...project,
-          localWindowsRuntimePreference: existingProject.localWindowsRuntimePreference,
-          updatedAt: Math.max(project.updatedAt, existingProject.updatedAt)
-        }
-      : project
-  })
   return {
-    projects: [...projectedProjects, ...independentProjects],
+    projects: [...succession.projects, ...independentProjects],
     projectHostSetups: [...projection.setups, ...independentSetups]
   }
 }

--- a/src/main/repo-git-remote-identity-enrichment.test.ts
+++ b/src/main/repo-git-remote-identity-enrichment.test.ts
@@ -38,8 +38,7 @@ function makeRepo(overrides: Partial<Repo> = {}): Repo {
   }
 }
 
-function makeStore(repo: Repo): RepoIdentityStore & { updateRepo: ReturnType<typeof vi.fn> } {
-  const repos = [repo]
+function makeStore(...repos: Repo[]): RepoIdentityStore & { updateRepo: ReturnType<typeof vi.fn> } {
   return {
     getRepos: () => repos,
     getRepo: (id) => repos.find((candidate) => candidate.id === id),
@@ -63,6 +62,27 @@ function deferred<T>(): {
     resolve = resolvePromise
   })
   return { promise, resolve }
+}
+
+const REFRESH_STARTUP_DELAY_MS = 5 * 60 * 1000
+const REFRESH_TTL_MS = 6 * 60 * 60 * 1000
+
+const movedIdentity: GitRemoteIdentity = {
+  canonicalKey: 'git.company.test/platform/sample-app',
+  remoteName: 'upstream',
+  remoteUrl: 'git@git.company.test:platform/sample-app.git'
+}
+
+/** Drains the sequential sweep: each flush only awaits the probe in flight at that moment. */
+async function drainEnrichmentSweep(): Promise<void> {
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    await flushRepoGitRemoteIdentityEnrichmentForTests()
+  }
+}
+
+async function sweep(store: RepoIdentityStore): Promise<void> {
+  enrichMissingRepoGitRemoteIdentities(store)
+  await drainEnrichmentSweep()
 }
 
 afterEach(() => {
@@ -166,6 +186,147 @@ describe('enrichMissingRepoGitRemoteIdentities', () => {
     await flushRepoGitRemoteIdentityEnrichmentForTests()
 
     expect(store.updateRepo).toHaveBeenCalledWith('repo-1', { gitRemoteIdentity: remoteIdentity })
+  })
+
+  it('does not re-probe a resolved identity before the refresh window elapses', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    vi.mocked(probeGitRemoteIdentity).mockResolvedValue(resolvedProbe)
+    const store = makeStore(makeRepo({ gitRemoteIdentity: remoteIdentity }))
+
+    // Why two sweeps: the first only schedules the re-probe, so a restart cannot fan out at launch.
+    await sweep(store)
+    expect(probeGitRemoteIdentity).not.toHaveBeenCalled()
+
+    vi.setSystemTime(1_000 + REFRESH_STARTUP_DELAY_MS + 1)
+    await sweep(store)
+    expect(probeGitRemoteIdentity).toHaveBeenCalledTimes(1)
+
+    vi.setSystemTime(1_000 + REFRESH_STARTUP_DELAY_MS + REFRESH_TTL_MS - 1)
+    await sweep(store)
+    expect(probeGitRemoteIdentity).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-probes a resolved identity after the refresh window elapses', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    vi.mocked(probeGitRemoteIdentity).mockResolvedValue(resolvedProbe)
+    const store = makeStore(makeRepo({ gitRemoteIdentity: remoteIdentity }))
+
+    await sweep(store)
+    vi.setSystemTime(1_000 + REFRESH_STARTUP_DELAY_MS + 1)
+    await sweep(store)
+    vi.setSystemTime(1_000 + REFRESH_STARTUP_DELAY_MS + REFRESH_TTL_MS + 2)
+    await sweep(store)
+
+    expect(probeGitRemoteIdentity).toHaveBeenCalledTimes(2)
+  })
+
+  it('overwrites a resolved identity when the re-probe finds a different canonical key', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    vi.mocked(probeGitRemoteIdentity).mockResolvedValue({
+      status: 'resolved',
+      identity: movedIdentity
+    })
+    const repo = makeRepo({ gitRemoteIdentity: remoteIdentity })
+    const store = makeStore(repo)
+    const onChanged = vi.fn()
+
+    await sweep(store)
+    vi.setSystemTime(1_000 + REFRESH_STARTUP_DELAY_MS + 1)
+    enrichMissingRepoGitRemoteIdentities(store, { onChanged })
+    await drainEnrichmentSweep()
+
+    expect(store.updateRepo).toHaveBeenCalledWith('repo-1', { gitRemoteIdentity: movedIdentity })
+    expect(repo.gitRemoteIdentity).toEqual(movedIdentity)
+    expect(onChanged).toHaveBeenCalledTimes(1)
+  })
+
+  it('writes nothing when the re-probe returns the same canonical key', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    vi.mocked(probeGitRemoteIdentity).mockResolvedValue({
+      status: 'resolved',
+      identity: { ...remoteIdentity, remoteUrl: 'https://git.company.test/team/sample-app.git' }
+    })
+    const store = makeStore(makeRepo({ gitRemoteIdentity: remoteIdentity }))
+    const onChanged = vi.fn()
+
+    await sweep(store)
+    vi.setSystemTime(1_000 + REFRESH_STARTUP_DELAY_MS + 1)
+    enrichMissingRepoGitRemoteIdentities(store, { onChanged })
+    await drainEnrichmentSweep()
+
+    expect(probeGitRemoteIdentity).toHaveBeenCalledTimes(1)
+    expect(store.updateRepo).not.toHaveBeenCalled()
+    expect(onChanged).not.toHaveBeenCalled()
+  })
+
+  it('keeps the existing identity when a re-probe cannot reach the host', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    vi.mocked(probeGitRemoteIdentity).mockResolvedValue({ status: 'unavailable' })
+    const repo = makeRepo({ connectionId: 'builder', gitRemoteIdentity: remoteIdentity })
+    const store = makeStore(repo)
+
+    await sweep(store)
+    vi.setSystemTime(1_000 + REFRESH_STARTUP_DELAY_MS + 1)
+    await sweep(store)
+
+    expect(probeGitRemoteIdentity).toHaveBeenCalledTimes(1)
+    expect(store.updateRepo).not.toHaveBeenCalled()
+    expect(repo.gitRemoteIdentity).toEqual(remoteIdentity)
+  })
+
+  it('keeps the existing identity when a re-probe reports no usable remote', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    vi.mocked(probeGitRemoteIdentity).mockResolvedValue({ status: 'no-remote' })
+    const repo = makeRepo({ gitRemoteIdentity: remoteIdentity })
+    const store = makeStore(repo)
+
+    await sweep(store)
+    vi.setSystemTime(1_000 + REFRESH_STARTUP_DELAY_MS + 1)
+    await sweep(store)
+
+    expect(store.updateRepo).not.toHaveBeenCalled()
+    expect(repo.gitRemoteIdentity).toEqual(remoteIdentity)
+  })
+
+  it('bounds re-probes per sweep so a large repo list drains gradually', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    vi.mocked(probeGitRemoteIdentity).mockResolvedValue(resolvedProbe)
+    const repos = Array.from({ length: 6 }, (_unused, index) =>
+      makeRepo({
+        id: `repo-${index}`,
+        path: `/workspace/sample-app-${index}`,
+        gitRemoteIdentity: remoteIdentity
+      })
+    )
+    const store = makeStore(...repos)
+
+    await sweep(store)
+    vi.setSystemTime(1_000 + REFRESH_STARTUP_DELAY_MS + 1)
+    await sweep(store)
+    expect(probeGitRemoteIdentity).toHaveBeenCalledTimes(4)
+
+    await sweep(store)
+    expect(probeGitRemoteIdentity).toHaveBeenCalledTimes(6)
+  })
+
+  it('does not re-probe folder workspaces', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    vi.mocked(probeGitRemoteIdentity).mockResolvedValue(resolvedProbe)
+    const store = makeStore(makeRepo({ kind: 'folder', gitRemoteIdentity: remoteIdentity }))
+
+    await sweep(store)
+    vi.setSystemTime(1_000 + REFRESH_STARTUP_DELAY_MS + REFRESH_TTL_MS + 1)
+    await sweep(store)
+
+    expect(probeGitRemoteIdentity).not.toHaveBeenCalled()
   })
 
   it('does not write stale identity data after the repo path changes', async () => {

--- a/src/main/repo-git-remote-identity-enrichment.ts
+++ b/src/main/repo-git-remote-identity-enrichment.ts
@@ -2,6 +2,16 @@ import type { Repo } from '../shared/types'
 import { probeGitRemoteIdentity } from './repo-git-remote-identity'
 
 const NO_IDENTITY_RETRY_TTL_MS = 5 * 60 * 1000
+// Why 6h: a resolved identity only changes when a remote is added or the project is renamed or
+// transferred, so this trades a `git remote -v` per repo per quarter-day for identity gates that
+// stop being frozen for the life of the repo record.
+const RESOLVED_IDENTITY_REFRESH_TTL_MS = 6 * 60 * 60 * 1000
+// Why: the deadline map is per-process, so a restart would otherwise make every resolved repo due
+// at once, on the first list call — the worst moment to spawn a subprocess per repo.
+const RESOLVED_IDENTITY_REFRESH_STARTUP_DELAY_MS = 5 * 60 * 1000
+// Why: refreshes are speculative, so a large repo list drains across sweeps instead of stalling one
+// list call behind N sequential probes (each an SSH round trip for off-host repos).
+const MAX_IDENTITY_REFRESHES_PER_SWEEP = 4
 
 type RepoIdentityStore = {
   getRepos(): Repo[]
@@ -14,7 +24,7 @@ type EnrichmentOptions = {
 }
 
 const inFlightProbesByLocation = new Map<string, Promise<boolean>>()
-const noIdentityRetryAfterByLocation = new Map<string, number>()
+const probeRetryAfterByLocation = new Map<string, number>()
 
 function getRepoLocationKey(repo: Pick<Repo, 'path' | 'connectionId'>): string {
   return `${repo.connectionId ?? 'local'}\0${repo.path}`
@@ -24,14 +34,26 @@ function getCurrentRepo(store: RepoIdentityStore, id: string): Repo | undefined 
   return store.getRepo?.(id) ?? store.getRepos().find((repo) => repo.id === id)
 }
 
-function isSameUnenrichedRepo(snapshot: Repo, current: Repo | undefined): boolean {
+function isSameProbedRepo(snapshot: Repo, current: Repo | undefined): current is Repo {
   return (
     !!current &&
     current.kind !== 'folder' &&
-    !current.gitRemoteIdentity &&
     current.path === snapshot.path &&
     (current.connectionId ?? null) === (snapshot.connectionId ?? null)
   )
+}
+
+function shouldWriteProbedIdentity(current: Repo, probed: Repo['gitRemoteIdentity']): boolean {
+  const existing = current.gitRemoteIdentity
+  if (!existing) {
+    // Why: the no-remote marker is re-derived on every retry; skip the redundant
+    // write so repo-list consumers do not churn.
+    return !(probed === null && existing === null)
+  }
+  // Why: a resolved identity is replaced only by a probe that found a genuinely different repo.
+  // Failures and no-remote answers must never clear it — consumers read an absent identity as
+  // "unknown" and gate permissively, so losing one is worse than carrying a stale one.
+  return !!probed && probed.canonicalKey !== existing.canonicalKey
 }
 
 function writeIdentity(
@@ -40,12 +62,10 @@ function writeIdentity(
   gitRemoteIdentity: Repo['gitRemoteIdentity']
 ): boolean {
   const current = getCurrentRepo(store, snapshot.id)
-  if (!isSameUnenrichedRepo(snapshot, current)) {
-    return false
-  }
-  // Why: the no-remote marker is re-derived on every retry; skip the redundant
-  // write so repo-list consumers do not churn.
-  if (gitRemoteIdentity === null && current?.gitRemoteIdentity === null) {
+  if (
+    !isSameProbedRepo(snapshot, current) ||
+    !shouldWriteProbedIdentity(current, gitRemoteIdentity)
+  ) {
     return false
   }
   return !!store.updateRepo(snapshot.id, { gitRemoteIdentity })
@@ -53,7 +73,7 @@ function writeIdentity(
 
 async function enrichRepoGitRemoteIdentity(store: RepoIdentityStore, repo: Repo): Promise<boolean> {
   const locationKey = getRepoLocationKey(repo)
-  const retryAfter = noIdentityRetryAfterByLocation.get(locationKey) ?? 0
+  const retryAfter = probeRetryAfterByLocation.get(locationKey) ?? 0
   if (retryAfter > Date.now()) {
     return false
   }
@@ -61,19 +81,24 @@ async function enrichRepoGitRemoteIdentity(store: RepoIdentityStore, repo: Repo)
   if (inFlight) {
     return inFlight
   }
+  // Why: a failed refresh of an already-resolved repo backs off on the long TTL — an SSH host that
+  // is down for the day must not re-probe every five minutes for an identity we already hold.
+  const missTtlMs = repo.gitRemoteIdentity
+    ? RESOLVED_IDENTITY_REFRESH_TTL_MS
+    : NO_IDENTITY_RETRY_TTL_MS
   const probe = (async () => {
     const result = await probeGitRemoteIdentity(repo.path, repo.connectionId)
     if (result.status !== 'resolved') {
       // Why: repos without a parseable remote are common; cache misses briefly so
       // list calls stay cheap while still allowing recent remote changes to land.
-      noIdentityRetryAfterByLocation.set(locationKey, Date.now() + NO_IDENTITY_RETRY_TTL_MS)
+      probeRetryAfterByLocation.set(locationKey, Date.now() + missTtlMs)
       // Why: only a probe that actually reached git settles "no usable remote".
       // An unreachable host leaves the identity unknown so consumers can keep
       // treating the repo as pending instead of ineligible.
       return result.status === 'no-remote' ? writeIdentity(store, repo, null) : false
     }
 
-    noIdentityRetryAfterByLocation.delete(locationKey)
+    probeRetryAfterByLocation.set(locationKey, Date.now() + RESOLVED_IDENTITY_REFRESH_TTL_MS)
     return writeIdentity(store, repo, result.identity)
   })().finally(() => {
     if (inFlightProbesByLocation.get(locationKey) === probe) {
@@ -84,17 +109,45 @@ async function enrichRepoGitRemoteIdentity(store: RepoIdentityStore, repo: Repo)
   return probe
 }
 
-async function enrichMissingRepoGitRemoteIdentitiesInBackground(
-  store: RepoIdentityStore,
-  options: EnrichmentOptions
-): Promise<void> {
+function isIdentityRefreshDue(repo: Repo, now: number): boolean {
+  const locationKey = getRepoLocationKey(repo)
+  const dueAt = probeRetryAfterByLocation.get(locationKey)
+  if (dueAt === undefined) {
+    probeRetryAfterByLocation.set(locationKey, now + RESOLVED_IDENTITY_REFRESH_STARTUP_DELAY_MS)
+    return false
+  }
+  return dueAt <= now
+}
+
+function selectEnrichmentCandidates(store: RepoIdentityStore): Repo[] {
+  const now = Date.now()
+  const repos = store.getRepos().filter((repo) => repo.kind !== 'folder')
   // Why: the settled `null` marker stays a candidate on purpose — a repo that
   // gains a remote later must still resolve. Do not tighten this to
   // `=== undefined`; the retry TTL already bounds the cost and `writeIdentity`
   // skips the redundant rewrite.
-  const candidates = store
-    .getRepos()
-    .filter((repo) => repo.kind !== 'folder' && !repo.gitRemoteIdentity)
+  const candidates = repos.filter((repo) => !repo.gitRemoteIdentity)
+  // Why re-probe at all: an identity resolved once is otherwise frozen for the life of the repo
+  // record, so a later `git remote add upstream` or a project rename/transfer keeps misjudging
+  // identity gates against the path the repo had when it was added.
+  let refreshes = 0
+  for (const repo of repos) {
+    if (refreshes >= MAX_IDENTITY_REFRESHES_PER_SWEEP) {
+      break
+    }
+    if (repo.gitRemoteIdentity && isIdentityRefreshDue(repo, now)) {
+      candidates.push(repo)
+      refreshes += 1
+    }
+  }
+  return candidates
+}
+
+async function enrichMissingRepoGitRemoteIdentitiesInBackground(
+  store: RepoIdentityStore,
+  options: EnrichmentOptions
+): Promise<void> {
+  const candidates = selectEnrichmentCandidates(store)
   let changed = false
   for (const repo of candidates) {
     // Why: enrichment runs later; capture the location we probed so a mutable
@@ -123,5 +176,5 @@ export async function flushRepoGitRemoteIdentityEnrichmentForTests(): Promise<vo
 
 export function resetRepoGitRemoteIdentityEnrichmentForTests(): void {
   inFlightProbesByLocation.clear()
-  noIdentityRetryAfterByLocation.clear()
+  probeRetryAfterByLocation.clear()
 }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -29634,7 +29634,16 @@ export class OrcaRuntimeService {
     if (probe && reusable) {
       // Why await only here: this is the one branch whose decision needs the probe. A scan-bound
       // caller must never wait on it, or every cold read pays filesystem latency it cannot use.
-      const current = await withTimeout(probe, WORKTREE_SCAN_ADMIN_FINGERPRINT_TIMEOUT_MS, null)
+      const probed = await withTimeoutResult(probe, WORKTREE_SCAN_ADMIN_FINGERPRINT_TIMEOUT_MS)
+      if (!probed.ok) {
+        // Why log: expiry and "fingerprint unavailable" both surface as `null`, so a wedged mount is
+        // otherwise indistinguishable from a repo that simply cannot be fingerprinted.
+        console.warn('[worktree-scan] admin fingerprint probe expired; running a full scan', {
+          repoId: repo.id,
+          timeoutMs: WORKTREE_SCAN_ADMIN_FINGERPRINT_TIMEOUT_MS
+        })
+      }
+      const current = probed.ok ? probed.value : null
       if (current !== null && current === reusable.adminFingerprint) {
         return {
           result: reusable.result,
@@ -36049,6 +36058,8 @@ export const WORKTREE_SCAN_ADMIN_RECONCILE_INTERVAL_MS = 5 * 60_000
 // Why so generous: a healthy but slow host (100+ linked worktrees, Windows Defender, cold dentry
 // cache, cloud placeholders) must still get to reuse its scan. Well under WORKTREE_LIST_TIMEOUT_MS,
 // and expiring yields `null` — the existing "cannot prove unchanged" sentinel, so a real scan runs.
+// Exceeding RESOLVED_WORKTREE_REPO_TIMEOUT_MS is deliberate, not a bug: the payoff is skipping a
+// `git worktree list` subprocess, not cutting this caller's latency — that caller is already capped.
 export const WORKTREE_SCAN_ADMIN_FINGERPRINT_TIMEOUT_MS = 10_000
 const RESOLVED_WORKTREE_REPO_TIMEOUT_MS = 5000
 

--- a/src/shared/project-identity-succession.test.ts
+++ b/src/shared/project-identity-succession.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest'
+import { carryProjectStateThroughIdentityChange } from './project-identity-succession'
+import type { Project } from './types'
+
+const makeProject = (overrides: Partial<Project> = {}): Project => ({
+  id: 'project-1',
+  displayName: 'Project',
+  badgeColor: '#737373',
+  sourceRepoIds: [],
+  createdAt: 1,
+  updatedAt: 1,
+  ...overrides
+})
+
+describe('carryProjectStateThroughIdentityChange', () => {
+  it('keeps the exact-id match and reports no remap', () => {
+    const projected = makeProject({ id: 'git:host/acme/app', sourceRepoIds: ['r1'] })
+    const previous = makeProject({
+      id: 'git:host/acme/app',
+      sourceRepoIds: ['r1'],
+      updatedAt: 50,
+      localWindowsRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' }
+    })
+
+    const result = carryProjectStateThroughIdentityChange([projected], [previous])
+
+    expect(result.projects[0]).toMatchObject({
+      id: 'git:host/acme/app',
+      localWindowsRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' },
+      updatedAt: 50
+    })
+    expect(result.remappedProjectIds.size).toBe(0)
+  })
+
+  it('adopts a prior row through a changed identity key by repo overlap', () => {
+    const projected = makeProject({ id: 'github:acme/app', sourceRepoIds: ['r1'] })
+    const previous = makeProject({
+      id: 'repo:r1',
+      sourceRepoIds: ['r1'],
+      localWindowsRuntimePreference: { kind: 'windows-host' }
+    })
+
+    const result = carryProjectStateThroughIdentityChange([projected], [previous])
+
+    expect(result.projects[0]?.localWindowsRuntimePreference).toEqual({ kind: 'windows-host' })
+    expect([...result.remappedProjectIds]).toEqual([['repo:r1', 'github:acme/app']])
+  })
+
+  it('ignores prior rows that still exist under their own id', () => {
+    const kept = makeProject({ id: 'git:host/acme/app', sourceRepoIds: ['r1'] })
+    const renamed = makeProject({ id: 'git:host/acme/tool', sourceRepoIds: ['r2'] })
+    const previousKept = makeProject({
+      id: 'git:host/acme/app',
+      sourceRepoIds: ['r1', 'r2'],
+      localWindowsRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' }
+    })
+
+    const result = carryProjectStateThroughIdentityChange([kept, renamed], [previousKept])
+
+    expect(result.projects[1]?.localWindowsRuntimePreference).toBeUndefined()
+    expect(result.remappedProjectIds.size).toBe(0)
+  })
+
+  it('prefers the prior row sharing the most repos over the more recently updated one', () => {
+    const projected = makeProject({ id: 'git:host/acme/merged', sourceRepoIds: ['r1', 'r2'] })
+    const wide = makeProject({
+      id: 'git:host/acme/wide',
+      sourceRepoIds: ['r1', 'r2'],
+      updatedAt: 10,
+      localWindowsRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' }
+    })
+    const narrow = makeProject({
+      id: 'git:host/acme/narrow',
+      sourceRepoIds: ['r2'],
+      updatedAt: 900,
+      localWindowsRuntimePreference: { kind: 'windows-host' }
+    })
+
+    const result = carryProjectStateThroughIdentityChange([projected], [wide, narrow])
+
+    expect(result.projects[0]?.localWindowsRuntimePreference).toEqual({
+      kind: 'wsl',
+      distro: 'Ubuntu'
+    })
+    expect([...result.remappedProjectIds.keys()]).toEqual(['git:host/acme/wide'])
+  })
+
+  it('breaks an equal-overlap tie by newest updatedAt, then lowest prior id', () => {
+    const projected = makeProject({ id: 'git:host/acme/merged', sourceRepoIds: ['r1', 'r2'] })
+    const older = makeProject({
+      id: 'git:host/acme/a',
+      sourceRepoIds: ['r1'],
+      updatedAt: 100,
+      localWindowsRuntimePreference: { kind: 'windows-host' }
+    })
+    const newer = makeProject({
+      id: 'git:host/acme/b',
+      sourceRepoIds: ['r2'],
+      updatedAt: 200,
+      localWindowsRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' }
+    })
+
+    expect(
+      carryProjectStateThroughIdentityChange([projected], [older, newer]).projects[0]
+        ?.localWindowsRuntimePreference
+    ).toEqual({ kind: 'wsl', distro: 'Ubuntu' })
+
+    const sameStamp = { ...newer, updatedAt: 100 }
+    // Same overlap and same updatedAt: the lexicographically lowest prior id wins, both orders.
+    for (const previous of [
+      [older, sameStamp],
+      [sameStamp, older]
+    ]) {
+      const result = carryProjectStateThroughIdentityChange([projected], previous)
+      expect(result.projects[0]?.localWindowsRuntimePreference).toEqual({ kind: 'windows-host' })
+      expect([...result.remappedProjectIds.keys()]).toEqual(['git:host/acme/a'])
+    }
+  })
+
+  it('lets one prior row be claimed by only one surviving project', () => {
+    const left = makeProject({ id: 'git:host/acme/left', sourceRepoIds: ['r1'] })
+    const right = makeProject({ id: 'git:host/acme/right', sourceRepoIds: ['r2'] })
+    const previous = makeProject({
+      id: 'repo:r1',
+      sourceRepoIds: ['r1', 'r2'],
+      localWindowsRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' }
+    })
+
+    const result = carryProjectStateThroughIdentityChange([left, right], [previous])
+
+    expect(result.projects[0]?.localWindowsRuntimePreference).toEqual({
+      kind: 'wsl',
+      distro: 'Ubuntu'
+    })
+    expect(result.projects[1]?.localWindowsRuntimePreference).toBeUndefined()
+    expect([...result.remappedProjectIds]).toEqual([['repo:r1', 'git:host/acme/left']])
+  })
+})

--- a/src/shared/project-identity-succession.ts
+++ b/src/shared/project-identity-succession.ts
@@ -1,0 +1,91 @@
+import type { Project } from './types'
+
+export type ProjectIdentitySuccession = {
+  /** Projected projects with user-set state carried forward from their predecessor row. */
+  projects: readonly Project[]
+  /** Predecessor project id -> surviving project id, for rows whose identity key changed. */
+  remappedProjectIds: ReadonlyMap<string, string>
+}
+
+function carryUserState(projected: Project, previous: Project): Project {
+  return previous.localWindowsRuntimePreference
+    ? {
+        ...projected,
+        localWindowsRuntimePreference: previous.localWindowsRuntimePreference,
+        updatedAt: Math.max(projected.updatedAt, previous.updatedAt)
+      }
+    : projected
+}
+
+function countSharedRepoIds(sourceRepoIds: readonly string[], other: ReadonlySet<string>): number {
+  return sourceRepoIds.reduce((count, repoId) => (other.has(repoId) ? count + 1 : count), 0)
+}
+
+function compareStrings(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0
+}
+
+/**
+ * Carries persisted per-project user state (and the rows that point at it) across a
+ * project id change. Project ids are derived from repo identity, so `repo:` -> `git:` ->
+ * `github:` promotion and remote re-probes rewrite them mid-session; matching only on id
+ * would drop the user's runtime preference and leave a ghost row behind.
+ *
+ * Predecessor rule when several prior rows overlap a surviving project: most shared
+ * `sourceRepoIds` wins, then newest `updatedAt`, then lowest prior id (then lowest new id).
+ * Each prior row is claimed by at most one surviving project, so two distinct user
+ * preferences are never merged into one — the unclaimed row keeps its own identity.
+ */
+export function carryProjectStateThroughIdentityChange(
+  projectedProjects: readonly Project[],
+  previousProjects: readonly Project[]
+): ProjectIdentitySuccession {
+  const previousById = new Map(previousProjects.map((project) => [project.id, project]))
+  const projectedIds = new Set(projectedProjects.map((project) => project.id))
+  // Why: a prior row that still exists under its own id is live, not a predecessor.
+  const orphanedPrevious = previousProjects.filter((project) => !projectedIds.has(project.id))
+  const unmatched = projectedProjects.filter((project) => !previousById.has(project.id))
+  const candidates = unmatched.flatMap((project) => {
+    const repoIds = new Set(project.sourceRepoIds)
+    return orphanedPrevious
+      .map((previous) => ({
+        project,
+        previous,
+        shared: countSharedRepoIds(previous.sourceRepoIds, repoIds)
+      }))
+      .filter((candidate) => candidate.shared > 0)
+  })
+  candidates.sort(
+    (left, right) =>
+      right.shared - left.shared ||
+      right.previous.updatedAt - left.previous.updatedAt ||
+      compareStrings(left.previous.id, right.previous.id) ||
+      compareStrings(left.project.id, right.project.id)
+  )
+  const claimedPreviousIds = new Set<string>()
+  const predecessorByProjectId = new Map<string, Project>()
+  for (const candidate of candidates) {
+    if (
+      claimedPreviousIds.has(candidate.previous.id) ||
+      predecessorByProjectId.has(candidate.project.id)
+    ) {
+      continue
+    }
+    claimedPreviousIds.add(candidate.previous.id)
+    predecessorByProjectId.set(candidate.project.id, candidate.previous)
+  }
+  const remappedProjectIds = new Map<string, string>()
+  const projects = projectedProjects.map((project) => {
+    const exact = previousById.get(project.id)
+    if (exact) {
+      return carryUserState(project, exact)
+    }
+    const predecessor = predecessorByProjectId.get(project.id)
+    if (!predecessor) {
+      return project
+    }
+    remappedProjectIds.set(predecessor.id, project.id)
+    return carryUserState(project, predecessor)
+  })
+  return { projects, remappedProjectIds }
+}


### PR DESCRIPTION
Fixes **STA-4247**, found during the readiness review of #14381.

## Problem

`repo.gitRemoteIdentity` was written once and never refreshed:

- set at repo add/clone (`repo-icon-autodetect.ts` → `detectGitRemoteIdentity`);
- background enrichment only considered repos where it was **missing** (`repo-git-remote-identity-enrichment.ts` filtered on `!repo.gitRemoteIdentity`), and `writeIdentity` → `isSameUnenrichedRepo` re-checked `!current.gitRemoteIdentity` before writing.

So a resolved identity was frozen for the life of the repo record. Meanwhile iid provenance is resolved **live** and from a different remote per link type: `getProjectRef` → hardcoded `origin` for MRs, `getIssueProjectRef` → `upstream ?? origin` for issues.

#14381 routes a user-visible palette decision through that frozen snapshot, so a stale snapshot causes a missed Cmd+J match. Two ways in: clone a fork (only `origin`), add it to Orca, then `git remote add upstream` later; or the project is renamed/transferred after the repo was added, so the web URL uses the new path while `canonicalKey` stays frozen at the old one.

## Fix

Fixed at the source, in the enrichment sweep. **The persisted `GitRemoteIdentity` shape and the RPC wire are untouched**, so this is safe under version skew — deliberately not widening the type to carry every remote's key, which would have been a schema + wire-compat change out of proportion to the problem.

- `RESOLVED_IDENTITY_REFRESH_TTL_MS = 6h`. A resolved identity only changes on a `git remote add` or a rename/transfer — rare, user-initiated. 6h caps cost at one `git remote -v` per repo per quarter-day while still unfreezing within a working day.
- `RESOLVED_IDENTITY_REFRESH_STARTUP_DELAY_MS = 5m`. The deadline map is per-process, so without it every resolved repo is due on the first `repos:list` after launch — the worst moment to spawn N subprocesses. First sight only schedules.
- `MAX_IDENTITY_REFRESHES_PER_SWEEP = 4`. Refreshes are speculative, so a large repo list drains across sweeps instead of stalling one sweep behind N sequential probes (each an SSH round trip when off-host).
- A failed refresh of an already-resolved repo backs off on the 6h TTL, not the 5m one — an SSH host down for the day must not re-probe every 5 minutes for an identity we already hold. Repos with **no** identity keep the existing 5m retry exactly.

Write guard: a resolved identity is overwritten only by a `status: 'resolved'` probe whose canonicalKey **differs**. `'unavailable'` and `'no-remote'` never clear or rewrite it — losing an identity is worse than holding a stale one, since consumers treat absent identity as permissive. An unchanged key writes nothing, so repo-list consumers don't churn. Folder (non-git) workspaces stay excluded.

## Also in this PR (adjacent, from the #14379 review)

`WORKTREE_SCAN_ADMIN_FINGERPRINT_TIMEOUT_MS = 10_000` is correct but was under-explained — **two independent reviewers each misread it as a bug** because it exceeds `RESOLVED_WORKTREE_REPO_TIMEOUT_MS` (5s). Added one comment line stating that this is deliberate: the probe's payoff is skipping a `git worktree list` **subprocess** for later refreshes, not cutting the current caller's latency. Value unchanged.

Also swapped `withTimeout(probe, …, null)` for the file's existing `withTimeoutResult` helper so an expiry is distinguishable from a genuinely `null` fingerprint, and added a `console.warn` on expiry — previously a timeout was silent and indistinguishable from "fingerprint unavailable", i.e. the one path that can silently disable the optimization. `probed.ok ? probed.value : null` preserves the prior behavior exactly.

## Tests

Eight new cases; five confirmed **failing before** the fix (5 failed / 11 passed with the source stashed):

- not re-probed before the window; re-probed after
- changed canonicalKey overwrites; unchanged key writes nothing (no churn)
- unreachable host leaves the identity intact
- `no-remote` leaves the identity intact
- per-sweep bound drains gradually
- folder workspaces not probed

16/16 enrichment, plus **14/14 on `worktree-scan-admin-fingerprint-gate.test.ts`** — that suite could not run in the authoring worktree (`Cannot find package 'psl'`), so it was run separately against this branch to cover the `withTimeoutResult` swap. Typecheck, oxlint, oxfmt, and the max-lines ratchet all clean.

## Notes

- The 5m startup delay means a user who quits within 5 minutes of launch never gets a re-probe. Traded against a subprocess-per-repo burst on every restart; easy to shorten if you disagree.
- Cadence is driven by list calls, not a timer, so on an idle app with many repos the drain is slow. Deliberate — it keeps this off any polling path — but the 6h TTL is a floor, not a guarantee.
- `probeRetryAfterByLocation` now holds an entry per resolved repo rather than per unresolved repo. Bounded by repo count and never pruned, which was already true before.