### PR TITLE
fix(terminal): stop leaking raw PTY lifecycle tokens into the error toast

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalErrorToast.test.ts
+++ b/src/renderer/src/components/terminal-pane/TerminalErrorToast.test.ts
@@ -128,7 +128,7 @@ describe('humanizeTerminalError', () => {
 
   it('replaces a raw relay PTY-not-found string and its quoted id', () => {
     const humanized = humanizeTerminalError(
-      "Error invoking remote method 'pty:spawn': Error: PTY \"orca:2f1c@@pty-7\" not found"
+      'Error invoking remote method \'pty:spawn\': Error: PTY "orca:2f1c@@pty-7" not found'
     )
     expect(humanized).not.toContain('not found')
     expect(humanized).not.toContain('orca:2f1c@@pty-7')
@@ -183,7 +183,7 @@ describe('isExplainedTerminalError', () => {
     expect(isExplainedTerminalError('SSH_SESSION_EXPIRED: orca:2f1c@@pty-7')).toBe(true)
     expect(
       isExplainedTerminalError(
-        "Error invoking remote method 'pty:spawn': Error: PTY \"orca:2f1c@@pty-7\" not found"
+        'Error invoking remote method \'pty:spawn\': Error: PTY "orca:2f1c@@pty-7" not found'
       )
     ).toBe(true)
   })

--- a/src/renderer/src/components/terminal-pane/TerminalErrorToast.test.ts
+++ b/src/renderer/src/components/terminal-pane/TerminalErrorToast.test.ts
@@ -109,6 +109,51 @@ describe('humanizeTerminalError', () => {
     expect(humanized).toContain('\nterminal_host_gone_extra')
   })
 
+  it('replaces an expired SSH session token and its internal relay id', () => {
+    const wrapped =
+      "Error invoking remote method 'pty:spawn': Error: SSH_SESSION_EXPIRED: orca:2f1c@@pty-7"
+    const humanized = humanizeTerminalError(wrapped)
+    expect(humanized).not.toContain('SSH_SESSION_EXPIRED')
+    expect(humanized).not.toContain('orca:2f1c@@pty-7')
+    expect(humanized).toContain('Open a new terminal to continue')
+  })
+
+  it('replaces an expired SSH session token carrying the identity-mismatch marker', () => {
+    const humanized = humanizeTerminalError(
+      'SSH_SESSION_EXPIRED: orca:2f1c@@pty-7 SSH_PTY_IDENTITY_MISMATCH'
+    )
+    expect(humanized).not.toContain('SSH_SESSION_EXPIRED')
+    expect(humanized).not.toContain('SSH_PTY_IDENTITY_MISMATCH')
+  })
+
+  it('replaces a raw relay PTY-not-found string and its quoted id', () => {
+    const humanized = humanizeTerminalError(
+      "Error invoking remote method 'pty:spawn': Error: PTY \"orca:2f1c@@pty-7\" not found"
+    )
+    expect(humanized).not.toContain('not found')
+    expect(humanized).not.toContain('orca:2f1c@@pty-7')
+    expect(humanized).toContain('Open a new terminal to continue')
+  })
+
+  it('replaces the identity-mismatch form of PTY-not-found', () => {
+    const humanized = humanizeTerminalError('PTY "orca:2f1c@@pty-7" not found (identity mismatch)')
+    expect(humanized).not.toContain('identity mismatch')
+    expect(humanized).not.toContain('orca:2f1c@@pty-7')
+  })
+
+  // Why: "no such session" from the relay is not proof the remote shell died, so the copy must not claim either.
+  it('does not claim the remote shell is still running or dead', () => {
+    const humanized = humanizeTerminalError('SSH_SESSION_EXPIRED: orca:2f1c@@pty-7')
+    expect(humanized).not.toContain('may still be running')
+    expect(humanized).not.toContain('exited')
+  })
+
+  it('replaces only the unreattachable line in an aggregated error', () => {
+    const humanized = humanizeTerminalError('Paste failed.\nSSH_SESSION_EXPIRED: orca:2f1c@@pty-7')
+    expect(humanized.startsWith('Paste failed.\n')).toBe(true)
+    expect(humanized).not.toContain('SSH_SESSION_EXPIRED')
+  })
+
   it.each(['ENOENT', 'ECONNREFUSED'])(
     'does not combine a %s connection failure with a host endpoint on another line',
     (code) => {
@@ -131,6 +176,15 @@ describe('isExplainedTerminalError', () => {
     expect(isExplainedTerminalError(LEGACY_HOST_GONE)).toBe(true)
     expect(
       isExplainedTerminalError('connect ECONNREFUSED /tmp/orca-terminal-host-v30-14cb7f94b511.sock')
+    ).toBe(true)
+  })
+
+  it('suppresses the issue link for a session the host cannot reattach', () => {
+    expect(isExplainedTerminalError('SSH_SESSION_EXPIRED: orca:2f1c@@pty-7')).toBe(true)
+    expect(
+      isExplainedTerminalError(
+        "Error invoking remote method 'pty:spawn': Error: PTY \"orca:2f1c@@pty-7\" not found"
+      )
     ).toBe(true)
   })
 

--- a/src/renderer/src/components/terminal-pane/TerminalErrorToast.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalErrorToast.tsx
@@ -25,6 +25,19 @@ const TERMINAL_HOST_GONE_PATTERN = new RegExp(TERMINAL_HOST_GONE_SOURCE)
 const TERMINAL_HOST_GONE_REPLACE_PATTERN = new RegExp(TERMINAL_HOST_GONE_SOURCE, 'g')
 const LEGACY_TERMINAL_HOST_GONE_PATTERN =
   /(^|[^a-z])connect (?:ENOENT|ECONNREFUSED) [^\r\n]*orca-terminal-host-v[^\r\n]*/i
+// A reattach the host answered "no such session" for: the SSH provider's expiry token, or the relay's
+// raw not-found string when nothing mapped it. Both carry an internal PTY id, and neither is proof the
+// remote shell died — the copy says only that this pane lost its session. Same lastIndex hazard as above.
+const UNREATTACHABLE_SESSION_SOURCES = [
+  'SSH_SESSION_EXPIRED:[ \\t]*\\S*(?:[ \\t]+SSH_PTY_IDENTITY_MISMATCH)?',
+  'PTY "[^"\\r\\n]*" not found(?: \\(identity mismatch\\))?'
+]
+const UNREATTACHABLE_SESSION_PATTERNS = UNREATTACHABLE_SESSION_SOURCES.map(
+  (source) => new RegExp(source)
+)
+const UNREATTACHABLE_SESSION_REPLACE_PATTERNS = UNREATTACHABLE_SESSION_SOURCES.map(
+  (source) => new RegExp(source, 'g')
+)
 
 function isSshError(error: string): boolean {
   return isSshReconnectOwnedTerminalError(error)
@@ -60,8 +73,21 @@ export function isExplainedTerminalError(error: string): boolean {
     .split('\n')
     .some(
       (line) =>
-        TERMINAL_HOST_GONE_PATTERN.test(line) || LEGACY_TERMINAL_HOST_GONE_PATTERN.test(line)
+        TERMINAL_HOST_GONE_PATTERN.test(line) ||
+        LEGACY_TERMINAL_HOST_GONE_PATTERN.test(line) ||
+        UNREATTACHABLE_SESSION_PATTERNS.some((pattern) => pattern.test(line))
     )
+}
+
+function humanizeUnreattachableSession(error: string): string {
+  const explanation = translate(
+    'auto.components.terminal.pane.TerminalErrorToast.sessionUnavailable',
+    "Orca couldn't reattach to this pane's terminal session on the host. Open a new terminal to continue."
+  )
+  return UNREATTACHABLE_SESSION_REPLACE_PATTERNS.reduce(
+    (message, pattern) => message.replace(pattern, explanation),
+    error
+  )
 }
 
 /** Swaps raw daemon-boundary codes for copy a user can act on. */
@@ -76,6 +102,7 @@ export function humanizeTerminalError(error: string): string {
       )
     )
   }
+  humanized = humanizeUnreattachableSession(humanized)
   if (!isExplainedTerminalError(humanized)) {
     return humanized
   }

--- a/src/renderer/src/components/terminal-pane/TerminalErrorToast.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalErrorToast.tsx
@@ -84,8 +84,9 @@ function humanizeUnreattachableSession(error: string): string {
     'auto.components.terminal.pane.TerminalErrorToast.sessionUnavailable',
     "Orca couldn't reattach to this pane's terminal session on the host. Open a new terminal to continue."
   )
+  // Why a replacer: a translation containing `$&` or `$1` would otherwise be read as a substitution.
   return UNREATTACHABLE_SESSION_REPLACE_PATTERNS.reduce(
-    (message, pattern) => message.replace(pattern, explanation),
+    (message, pattern) => message.replace(pattern, () => explanation),
     error
   )
 }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2875,7 +2875,8 @@
             "5c8ce20be6": "If this persists, please",
             "cc6d997c65": "Restart the terminal daemon from here to clear stale daemon state.",
             "7ee11bc0db": "Orca couldn't confirm whether this terminal's previous session is still running, so it left the session untouched. Reopen this pane to retry.",
-            "e16012e31e": "The terminal daemon that owned this session exited, so the session and its scrollback could not be recovered. Open a new terminal to continue."
+            "e16012e31e": "The terminal daemon that owned this session exited, so the session and its scrollback could not be recovered. Open a new terminal to continue.",
+            "sessionUnavailable": "Orca couldn't reattach to this pane's terminal session on the host. Open a new terminal to continue."
           },
           "TerminalPane": {
             "ac112e9036": "Remove title",


### PR DESCRIPTION
Partially addresses **STA-4238** — but read the scope note first, because the ticket's premise no longer holds on `main`.

## The machinery STA-4238 describes is not on main

The exit-proof apparatus (`SSH_PTY_EXITED: id code=N incarnation=UUID`, `exitProofSupported`, `isProvenSshSessionGoneError`, `src/shared/ssh-pty-failure-tokens.ts`, `reattach-failure-classification.ts`, the "Its shell may still be running" card with its "Try again" button, and the pinned e2e specs) shipped in #13326 and has since been **reverted twice**:

```
#13326  landed the STA-3077 reattach work
#14361  reverted it ("reconnect loses every tab")
#14384  reapplied
#14395  reverted again   ← current main
```

Verified by file existence, `git log -- src/shared/ssh-pty-failure-tokens.ts`, and a repo-wide grep: zero hits for `STA-3077`, `SSH_PTY_EXITED`, or any SSH e2e spec.

Consequences, each checked against code rather than the ticket text:

- **The described failure chain is unreachable on main.** `SshPtyProvider.spawn` routes any `sessionId` through `reattachSshPtySession`, which maps the relay's `PTY "..." not found` to `SSH_SESSION_EXPIRED: <relayId>`. That message does *not* satisfy `isPtyAlreadyGoneError` (`/PTY ".+" not found/i` or `/Session not found/i`), so for SSH `attachStablePaneOwner` rethrows and never reaches the retire branch.
- **The named "blocker"** — `onPtyExit(owner.ptyId, 0, owner.incarnationId)` with a hardcoded `0` — is real code, but no proof on main carries an exit code, so there is no real code to thread. It is also pinned by `pty.test.ts` asserting exactly `(id, 0, incarnation)`. Changing it would have meant inventing a value.
- **The two stale comments** the ticket asks to correct are in a file that does not exist, and at a line that says something else.
- **There is no unreachable-pane card and no terminal "Try again" button** on main. Every `Try again` in `src/renderer` belongs to Jira, worktree visibility, the SSH config picker, the plugin marketplace, or source control.

## What this PR actually ships

A verified-reachable variant of the one item that *is* real on main: raw internal PTY-lifecycle tokens reaching the user-facing error surface.

`pty-transport.ts` only converts `SSH_SESSION_EXPIRED` into a `sessionExpired` result when **both** `connectionId` and `options.sessionId` are set; otherwise it falls through to `onError(msg)`. Main can throw that token with no renderer-supplied sessionId, because `pty:spawn` resolves the pane owner from its own store and pre-adopts it (`adoptStablePane` builds spawnOptions with no sessionId, then attaches with `sessionId: owner.ptyId`). A dead SSH owner there produces a red toast reading:

> `Error invoking remote method 'pty:spawn': Error: SSH_SESSION_EXPIRED: orca:<conn>@@pty-N`

…with a "file an issue" link attached.

The fix is **presentation-only**, in the toast's existing daemon-boundary humanization seam (`humanizeTerminalError`, which already rewrites `terminal_pane_owner_unverified` and `terminal_host_gone`). Both `SSH_SESSION_EXPIRED: <id>` and `PTY "<id>" not found` (with or without the identity-mismatch marker) are replaced with actionable copy, and `isExplainedTerminalError` now recognizes them so the "file an issue" invitation is suppressed. Placing it here fixes the leak for every producer regardless of transport.

**Zero control-flow change**: no respawn authorization, no pty-id identity change, no wire change, no main-process change.

Copy is deliberately neutral on whether the remote shell died — host absence is not proof of exit — and a test pins that it says neither "may still be running" nor "exited".

## Tests

Seven new cases, all written before touching the source and confirmed failing against unmodified `main` (6 failed / 27 passed; the seventh is a guard on the new copy and passes vacuously pre-fix). 33/33 after. 111/111 with `pty-transport.test.ts`, 138/138 across i18n. Typecheck, oxlint, oxfmt clean.

## Recommendation for the ticket

**STA-4238 should be re-triaged or closed as obsoleted-by-revert**, and linked to whoever re-lands the reattach work. The described chain returns the moment that lands, and the real fix — the attach reply carrying `exitedBeforeAttach` plus the real exit code, per §E of `docs/reference/terminal-session-behavior-contract.md` — belongs *inside* that re-land rather than bolted on after. There is already a `Reapply the STA-3077 reattach work` commit in the history, so that work is in flight.

This PR does not make a pane whose SSH owner is gone recover; it makes it say so in plain language instead of leaking a token. If recovery is the goal, that is the reverted work, not this.