### PR TITLE
fix(terminal): deliver Korean-layout Ctrl-C to TUIs

### DIFF
--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -113,6 +113,7 @@ import {
 import type { PaneCwdMap } from './resolve-split-cwd'
 import { installMouseHideWhileTyping } from './mouse-hide-while-typing'
 import type { EffectiveMacOptionAsAlt } from '@/lib/keyboard-layout/detect-option-as-alt'
+import { prefetchLayoutBaseCharacters } from '@/lib/keyboard-layout/layout-base-character'
 import { connectPanePty } from './pty-connection'
 import type { PtyTransport } from './pty-transport'
 import type { PtyTransportRecoveryState } from './pty-transport-types'
@@ -985,6 +986,7 @@ export function useTerminalPaneLifecycle({
         const pendingTerminalImeCandidateKeyReleases =
           createTerminalImePendingCandidateKeyReleases()
         const isMac = navigator.userAgent.includes('Mac')
+        prefetchLayoutBaseCharacters()
         // Why: Android/ChromeOS UAs also contain "Linux"; scope the fcitx candidate-key policy to desktop Linux.
         const isLinux =
           !isMac &&

--- a/src/renderer/src/components/terminal-pane/xterm-bypass-policy-interrupt.test.ts
+++ b/src/renderer/src/components/terminal-pane/xterm-bypass-policy-interrupt.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
+import { _setLayoutMapForTests } from '../../lib/keyboard-layout/layout-base-character'
 import {
   shouldHandleTerminalInterruptKeyboardEvent,
   shouldSuppressTerminalInterruptKeyup,
@@ -20,6 +21,8 @@ function event(overrides: Partial<XtermBypassEvent>): XtermBypassEvent {
     ...overrides
   }
 }
+
+afterEach(() => _setLayoutMapForTests(null))
 
 describe('shouldHandleTerminalInterruptKeyboardEvent', () => {
   it('exports the ETX byte used for terminal interrupts', () => {
@@ -91,6 +94,19 @@ describe('shouldHandleTerminalInterruptKeyboardEvent', () => {
         event({ key: 'Unidentified', keyCode: 67, ctrlKey: true }),
         { isMac: true, hasSelection: false }
       )
+    ).toBe(true)
+  })
+
+  it('handles Korean-layout Ctrl+C through the active layout map', () => {
+    _setLayoutMapForTests(new Map([['KeyC', 'c']]))
+    expect(
+      shouldHandleTerminalInterruptKeyboardEvent(
+        event({ key: 'ㅊ', code: 'KeyC', ctrlKey: true }),
+        { isMac: true, hasSelection: false }
+      )
+    ).toBe(true)
+    expect(
+      shouldSuppressTerminalInterruptKeyup(event({ type: 'keyup', key: 'ㅊ', code: 'KeyC' }))
     ).toBe(true)
   })
 

--- a/src/renderer/src/components/terminal-pane/xterm-bypass-policy.ts
+++ b/src/renderer/src/components/terminal-pane/xterm-bypass-policy.ts
@@ -1,4 +1,5 @@
 import { keybindingMatchesInput } from '../../../../shared/keybindings'
+import { getLayoutBaseCharacterForCode } from '../../lib/keyboard-layout/layout-base-character'
 import {
   isTerminalImeCandidateDigitKeyEvent,
   isTerminalImeCandidateSelectionKeyEvent
@@ -152,7 +153,11 @@ export function shouldPreventDefaultTerminalImeCandidateKey(
 }
 
 function isTerminalInterruptCKey(event: XtermBypassEvent): boolean {
-  const normalizedKey = event.key.toLowerCase()
+  const layoutBaseKey =
+    isSingleNonAsciiPrintableText(event.key) && event.code
+      ? getLayoutBaseCharacterForCode(event.code)
+      : undefined
+  const normalizedKey = layoutBaseKey ?? event.key.toLowerCase()
   const logicalKeyAvailable = normalizedKey !== '' && normalizedKey !== 'unidentified'
   return logicalKeyAvailable ? normalizedKey === 'c' : event.code === 'KeyC' || event.keyCode === 67
 }


### PR DESCRIPTION
## ELI5

With the macOS Korean 2-Set input source active, Electron reports the physical C key as a Hangul character instead of `c`. Orca therefore missed Ctrl+C and Codex stayed open after repeated interrupt attempts. This patch uses Orca's existing keyboard-layout map to recognize that key as C and deliver the normal terminal interrupt.

## What Changed

- Resolve a single non-ASCII `event.key` through the existing `KeyboardLayoutMap` cache when checking for Ctrl+C.
- Prefetch that cache where the xterm key handler is installed.
- Apply the same decision to keydown and keyup so Kitty release sequences cannot leak after the interrupt.

The patch intentionally remains Ctrl+C-specific. It does not introduce another general shortcut state machine or change terminal/session restoration.

## Why

The measured macOS Korean 2-Set event is `key: "ㅊ"`, `code: "KeyC"`, with Ctrl held. Matching only logical `c` misses it, while treating every physical `KeyC` as C would break layouts such as Dvorak.

Orca already caches Chromium's layout-aware base character for a physical code. Consulting that cache only when `key` is one non-ASCII printable character fixes the measured event while leaving ASCII logical keys authoritative and preserving the existing platform and clipboard policies.

## Linked Issue

Fixes #14460

Related: #13331 reports Ctrl+A and Ctrl+U under the same input source; those broader chords are deliberately outside this focused patch.

## Visual Proof

Both recordings use the same isolated Orca E2E profile, the real Codex CLI, and the measured Korean 2-Set event shape. The terminal is cropped and enlarged, and the two Ctrl+C presses share the same timeline for direct comparison.

**Before:** both Ctrl+C presses are swallowed and Codex remains open.

![Before: Korean Ctrl+C is swallowed](https://raw.githubusercontent.com/hgijeon/orca/assets/korean-ctrl-c/korean-ctrl-c/before.gif)

**After:** ETX reaches the terminal and Codex returns to the shell.

![After: Korean Ctrl+C returns to the shell](https://raw.githubusercontent.com/hgijeon/orca/assets/korean-ctrl-c/korean-ctrl-c/after.gif)

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Revalidated on macOS:

- `corepack pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/xterm-bypass-policy-interrupt.test.ts src/renderer/src/components/terminal-pane/xterm-bypass-policy-non-mac.test.ts src/renderer/src/lib/keyboard-layout/layout-base-character.test.ts`
- `corepack pnpm run typecheck`
- Headful Electron Before/After run with the real Codex CLI

The targeted tests cover the Korean event shape, Dvorak logical-key precedence, keyup suppression, unavailable layout maps, and unchanged Windows/Linux Ctrl+C selection behavior. The earlier full local validation also covered lint, production builds, and the macOS native build; CI will repeat the repository-wide checks.

Actually exercised on macOS with Korean 2-Set. Linux and Windows were not manually exercised; their unchanged branches are covered by the non-macOS policy tests.

## AI Disclosure

OpenAI Codex was used for diagnosis, implementation, tests, recording preparation, and PR drafting. The keyboard event and final behavior were also verified in the running Electron app.

## Review

- **Security:** No new IPC, dependencies, persisted data, command execution, or credential handling.
- **Cross-platform:** Existing Windows/Linux selection semantics remain unchanged: Ctrl+C copies with a selection and interrupts otherwise.
- **Alternative layouts:** An ASCII logical key wins over the physical code, preserving Dvorak and similar layouts.
- **Remote SSH:** Classification occurs before terminal transport selection, so local and remote PTYs receive the same ETX.
- **Mobile:** No mobile input path changes.
- **Compatibility/performance:** The existing synchronous cache and idempotent prefetch are reused; no asynchronous work is added per keystroke.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: [@hgijeon](https://x.com/hgijeon)
