### PR TITLE
fix(workspaces): use launch agent for first auto-name

### DIFF
--- a/src/main/agent-hooks/first-work-branch-rename.test.ts
+++ b/src/main/agent-hooks/first-work-branch-rename.test.ts
@@ -93,10 +93,25 @@ describe('maybeAutoRenameBranchOnFirstWork', () => {
       expect.anything(),
       'local',
       'branchName',
-      expect.objectContaining({ id: REPO_ID })
+      expect.objectContaining({ id: REPO_ID }),
+      undefined
     )
     expect(setDisplayName).toHaveBeenCalledWith(WORKTREE_ID, 'Fix auth')
     expect(onRenamed).toHaveBeenCalledWith(REPO_ID)
+  })
+
+  it('uses the first-work agent as the branch-name fallback', async () => {
+    const { deps } = makeDeps()
+
+    await maybeAutoRenameBranchOnFirstWork(workingEvent({ agentType: 'codex' }), deps)
+
+    expect(resolveTextGenerationParamsMock).toHaveBeenCalledWith(
+      expect.anything(),
+      'local',
+      'branchName',
+      expect.objectContaining({ id: REPO_ID }),
+      'codex'
+    )
   })
 
   it('asks to align the on-disk folder with the generated slug after renaming', async () => {
@@ -226,10 +241,29 @@ describe('maybeAutoRenameBranchOnFirstWork', () => {
       expect.anything(),
       'local',
       'branchName',
-      null
+      null,
+      undefined
     )
     expect(setDisplayName).toHaveBeenCalledWith(FOLDER_WORKTREE_ID, 'Fix auth')
     expect(onRenamed).toHaveBeenCalledWith(FOLDER_WORKTREE_ID)
+  })
+
+  it('uses the first-work agent as the folder-workspace title fallback', async () => {
+    const { deps } = makeDeps({
+      resolveWorktreeIdForTab: () => FOLDER_WORKTREE_ID,
+      getFolderWorkspacePath: () => '/workspace/platform',
+      isPendingFirstAgentMessageRename: () => true
+    })
+
+    await maybeAutoRenameBranchOnFirstWork(workingEvent({ agentType: 'codex' }), deps)
+
+    expect(resolveTextGenerationParamsMock).toHaveBeenCalledWith(
+      expect.anything(),
+      'local',
+      'branchName',
+      null,
+      'codex'
+    )
   })
 
   it('does not rename folder workspace titles without the pending marker', async () => {

--- a/src/main/agent-hooks/first-work-branch-rename.ts
+++ b/src/main/agent-hooks/first-work-branch-rename.ts
@@ -1,5 +1,7 @@
 // On first agent work in a fresh workspace, replace the auto-generated creature branch (e.g. `you/Nautilus`) with a short work-derived name.
-import type { GlobalSettings, Repo } from '../../shared/types'
+import type { AgentType } from '../../shared/agent-status-types'
+import { isTuiAgent } from '../../shared/tui-agent-config'
+import type { GlobalSettings, Repo, TuiAgent } from '../../shared/types'
 import { getRepoIdFromWorktreeId, splitWorktreeIdForFilesystem } from '../../shared/worktree-id'
 import { parseWorkspaceKey } from '../../shared/workspace-scope'
 import { parsePaneKey } from '../../shared/stable-pane-id'
@@ -36,6 +38,7 @@ export type FirstWorkBranchRenameEvent = {
   state: string
   prompt: string | undefined
   assistantMessage: string | undefined
+  agentType?: AgentType
   isReplay: boolean | undefined
 }
 
@@ -119,7 +122,13 @@ export async function maybeAutoRenameBranchOnFirstWork(
   inFlightWorktreeIds.add(worktreeId)
   try {
     // settled = definitive verdict (renamed/ineligible); false = transient bail to retry later.
-    const settled = await runAutoRename(worktreeId, prompt, event.assistantMessage, deps)
+    const settled = await runAutoRename(
+      worktreeId,
+      prompt,
+      event.assistantMessage,
+      isTuiAgent(event.agentType) ? event.agentType : undefined,
+      deps
+    )
     if (settled) {
       rememberSettledWorktreeId(worktreeId)
     }
@@ -136,6 +145,7 @@ async function runAutoRename(
   worktreeId: string,
   prompt: string,
   assistantMessage: string | undefined,
+  agentType: TuiAgent | undefined,
   deps: FirstWorkBranchRenameDeps
 ): Promise<boolean> {
   // `stop` = permanent skip (logs which gate bailed); `retry` = transient; `clearError` drops a stale "rename failed" badge on a benign final state.
@@ -157,6 +167,7 @@ async function runAutoRename(
       worktreeId,
       prompt,
       assistantMessage,
+      agentType,
       deps,
       stop,
       retry
@@ -208,7 +219,13 @@ async function runAutoRename(
 
   const settings = deps.getSettings()
   const hostKey = getCommitMessageModelDiscoveryHostKey(repo.connectionId ?? null)
-  const resolvedParams = resolveTextGenerationParams(settings, hostKey, 'branchName', repo)
+  const resolvedParams = resolveTextGenerationParams(
+    settings,
+    hostKey,
+    'branchName',
+    repo,
+    agentType
+  )
   if (!resolvedParams.ok) {
     // Why: a generation-step failure (vs a benign skip) is user-actionable, so surface it on the card.
     deps.setRenameError(worktreeId, resolvedParams.error)

--- a/src/main/agent-hooks/first-work-workspace-title-rename.ts
+++ b/src/main/agent-hooks/first-work-workspace-title-rename.ts
@@ -5,6 +5,7 @@ import {
 } from '../text-generation/commit-message-text-generation'
 import { resolveGenerationTarget } from './first-work-generation-target'
 import type { FirstWorkBranchRenameDeps } from './first-work-branch-rename'
+import type { TuiAgent } from '../../shared/types'
 
 /**
  * Non-git folder workspaces have no branch to rename; the first-work hook
@@ -15,6 +16,7 @@ export async function runFolderWorkspaceTitleAutoRename(
   worktreeId: string,
   prompt: string,
   assistantMessage: string | undefined,
+  agentType: TuiAgent | undefined,
   deps: FirstWorkBranchRenameDeps,
   stop: (reason: string, clearError?: boolean) => true,
   retry: (reason: string) => false
@@ -28,7 +30,13 @@ export async function runFolderWorkspaceTitleAutoRename(
   }
 
   const settings = deps.getSettings()
-  const resolvedParams = resolveTextGenerationParams(settings, 'local', 'branchName', null)
+  const resolvedParams = resolveTextGenerationParams(
+    settings,
+    'local',
+    'branchName',
+    null,
+    agentType
+  )
   if (!resolvedParams.ok) {
     deps.setRenameError(worktreeId, resolvedParams.error)
     return stop(`no generation agent: ${resolvedParams.error}`)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -328,7 +328,7 @@ import {
   shouldDriveSyntheticAgentTitleFromHook,
   type SyntheticAgentTitleProfile
 } from '../shared/synthetic-agent-title'
-import type { AgentStatusState } from '../shared/agent-status-types'
+import type { AgentStatusState, AgentType } from '../shared/agent-status-types'
 import { resolveTuiAgentPermissionMode } from '../shared/tui-agent-permissions'
 import { isAskUserQuestionTool } from '../shared/agent-question-answered-intent'
 import type { TerminalSideEffectBatch } from '../shared/terminal-side-effect-facts'
@@ -517,7 +517,12 @@ function maybeAutoRenameBranchOnFirstWorkFromHook(event: {
   paneKey: string
   tabId: string | undefined
   worktreeId: string | undefined
-  payload: { state: string; prompt?: string; lastAssistantMessage?: string }
+  payload: {
+    state: string
+    prompt?: string
+    lastAssistantMessage?: string
+    agentType?: AgentType
+  }
   isReplay: boolean | undefined
 }): void {
   const currentStore = store
@@ -533,6 +538,7 @@ function maybeAutoRenameBranchOnFirstWorkFromHook(event: {
       state: event.payload.state,
       prompt: event.payload.prompt,
       assistantMessage: event.payload.lastAssistantMessage,
+      agentType: event.payload.agentType,
       isReplay: event.isReplay
     },
     {

--- a/src/main/text-generation/commit-message-text-generation.ts
+++ b/src/main/text-generation/commit-message-text-generation.ts
@@ -165,9 +165,17 @@ export function resolveTextGenerationParams(
   settings: GlobalSettings,
   discoveryHostKey = LOCAL_COMMIT_MESSAGE_HOST_KEY,
   operation: SourceControlAiOperation = 'commitMessage',
-  repo?: Pick<Repo, 'sourceControlAi'> | null
+  repo?: Pick<Repo, 'sourceControlAi'> | null,
+  defaultAgentOverride?: TuiAgent
 ): ResolveCommitMessageSettingsResult {
-  return resolveCommitMessageSettings(settings, discoveryHostKey, operation, repo)
+  const resolved = resolveSourceControlAiForOperation({
+    settings,
+    repo,
+    operation,
+    discoveryHostKey,
+    defaultAgentOverride
+  })
+  return resolved.ok ? { ok: true, params: resolved.value.params } : resolved
 }
 
 function formatAgentCliFailureMessage(

--- a/src/shared/source-control-ai.test.ts
+++ b/src/shared/source-control-ai.test.ts
@@ -60,6 +60,71 @@ function resolve(operation: SourceControlAiOperation, overrides?: RepoSourceCont
 }
 
 describe('source-control AI resolution', () => {
+  it('uses a supported launch agent when branch naming has no explicit agent', () => {
+    const base = settings()
+    base.defaultTuiAgent = 'claude'
+    base.sourceControlAi = {
+      ...base.sourceControlAi!,
+      agentId: null,
+      actions: {
+        ...base.sourceControlAi!.actions,
+        branchName: { commandInputTemplate: '{basePrompt}' }
+      }
+    }
+
+    const result = resolveSourceControlAiForOperation({
+      settings: base,
+      repo: null,
+      operation: 'branchName',
+      defaultAgentOverride: 'codex'
+    })
+
+    expect(result.ok && result.value.params.agentId).toBe('codex')
+  })
+
+  it('keeps an explicit branch-name agent ahead of the launch agent', () => {
+    const base = settings()
+    base.sourceControlAi = {
+      ...base.sourceControlAi!,
+      agentId: null,
+      actions: {
+        ...base.sourceControlAi!.actions,
+        branchName: { agentId: 'claude', commandInputTemplate: '{basePrompt}' }
+      }
+    }
+
+    const result = resolveSourceControlAiForOperation({
+      settings: base,
+      repo: null,
+      operation: 'branchName',
+      defaultAgentOverride: 'codex'
+    })
+
+    expect(result.ok && result.value.params.agentId).toBe('claude')
+  })
+
+  it('ignores a launch agent that cannot generate branch names', () => {
+    const base = settings()
+    base.defaultTuiAgent = 'claude'
+    base.sourceControlAi = {
+      ...base.sourceControlAi!,
+      agentId: null,
+      actions: {
+        ...base.sourceControlAi!.actions,
+        branchName: { commandInputTemplate: '{basePrompt}' }
+      }
+    }
+
+    const result = resolveSourceControlAiForOperation({
+      settings: base,
+      repo: null,
+      operation: 'branchName',
+      defaultAgentOverride: 'command-code'
+    })
+
+    expect(result.ok && result.value.params.agentId).toBe('claude')
+  })
+
   it('uses the global default model for every operation', () => {
     expect(resolve('commitMessage').params.model).toBe('gpt-5.5')
     expect(resolve('pullRequest').params.model).toBe('gpt-5.5')

--- a/src/shared/source-control-ai.test.ts
+++ b/src/shared/source-control-ai.test.ts
@@ -82,6 +82,28 @@ describe('source-control AI resolution', () => {
     expect(result.ok && result.value.params.agentId).toBe('codex')
   })
 
+  it('uses the launch agent before the legacy source-control fallback', () => {
+    const base = settings()
+    base.defaultTuiAgent = 'claude'
+    base.sourceControlAi = {
+      ...base.sourceControlAi!,
+      agentId: 'claude',
+      actions: {
+        ...base.sourceControlAi!.actions,
+        branchName: { commandInputTemplate: '{basePrompt}' }
+      }
+    }
+
+    const result = resolveSourceControlAiForOperation({
+      settings: base,
+      repo: null,
+      operation: 'branchName',
+      defaultAgentOverride: 'codex'
+    })
+
+    expect(result.ok && result.value.params.agentId).toBe('codex')
+  })
+
   it('keeps an explicit branch-name agent ahead of the launch agent', () => {
     const base = settings()
     base.sourceControlAi = {

--- a/src/shared/source-control-ai.ts
+++ b/src/shared/source-control-ai.ts
@@ -74,6 +74,7 @@ type ResolveSourceControlAiInput = {
     Partial<Pick<GlobalSettings, 'disabledTuiAgents'>>
   repo?: Pick<Repo, 'sourceControlAi'> | null
   operation: SourceControlAiOperation
+  defaultAgentOverride?: TuiAgent
   discoveryHostKey?: string
   prCreationProductDefaults?: SourceControlAiPrCreationDefaults
 }
@@ -1214,10 +1215,15 @@ export function resolveSourceControlAiForOperation(
   }
   // Why: action recipes own the new customization model. The legacy global
   // agent remains a fallback so existing users migrate without losing intent.
+  const defaultAgent = input.defaultAgentOverride
+    ? getCommitMessageAgentSpec(input.defaultAgentOverride)
+      ? input.defaultAgentOverride
+      : input.settings.defaultTuiAgent
+    : input.settings.defaultTuiAgent
   const preferredAgent = hasActionAgentRecipe(actionRecipe) ? actionRecipe.agentId : source.agentId
   const agentChoice = resolveCommitMessageAgentChoice(
     preferredAgent,
-    input.settings.defaultTuiAgent,
+    defaultAgent,
     input.settings.disabledTuiAgents
   )
   if (!agentChoice) {

--- a/src/shared/source-control-ai.ts
+++ b/src/shared/source-control-ai.ts
@@ -1207,6 +1207,16 @@ export function resolveSourceControlAiForOperation(
     input.prCreationProductDefaults
   )
   const actionRecipe = resolveActionRecipeForTextOperation(source, repoOverrides, input.operation)
+  const globalActionRecipe = readSourceControlActionDefault(
+    input.settings.sourceControlAi?.actions,
+    input.operation
+  )
+  const repoActionRecipe = repoOverrides?.actionOverrides?.[input.operation]
+  const explicitActionAgent = hasActionAgentRecipe(repoActionRecipe ?? {})
+    ? repoActionRecipe?.agentId
+    : hasActionAgentRecipe(globalActionRecipe)
+      ? globalActionRecipe.agentId
+      : undefined
   if (!actionRecipe.commandInputTemplate.trim()) {
     return {
       ok: false,
@@ -1215,15 +1225,14 @@ export function resolveSourceControlAiForOperation(
   }
   // Why: action recipes own the new customization model. The legacy global
   // agent remains a fallback so existing users migrate without losing intent.
-  const defaultAgent = input.defaultAgentOverride
-    ? getCommitMessageAgentSpec(input.defaultAgentOverride)
+  const launchAgent =
+    input.defaultAgentOverride && getCommitMessageAgentSpec(input.defaultAgentOverride)
       ? input.defaultAgentOverride
-      : input.settings.defaultTuiAgent
-    : input.settings.defaultTuiAgent
-  const preferredAgent = hasActionAgentRecipe(actionRecipe) ? actionRecipe.agentId : source.agentId
+      : undefined
+  const preferredAgent = explicitActionAgent ?? launchAgent ?? source.agentId
   const agentChoice = resolveCommitMessageAgentChoice(
     preferredAgent,
-    defaultAgent,
+    input.settings.defaultTuiAgent,
     input.settings.disabledTuiAgents
   )
   if (!agentChoice) {
@@ -1265,7 +1274,7 @@ export function resolveSourceControlAiForOperation(
   }
 
   const agentId = agentChoice
-  const actionAgentId = actionRecipe.agentId ?? agentId
+  const actionAgentId = explicitActionAgent ?? agentId
   const resolvedActionAgentId =
     actionAgentId === agentId
       ? agentId


### PR DESCRIPTION
## ELI5

When a workspace is opened with a launch agent that supports Source Control AI text generation, Orca now asks that same agent to create the first automatic workspace or branch name. Previously, this path could call a different global default agent. Codex exposed the bug in the reported scenario, but the fix is agent-agnostic.

If the user explicitly selected a Branch Name agent, that setting still wins. Launch agents without an automatic naming specification keep the existing configured/default fallback.

## What Changed

- Forward the actual launch agent from the first-work hook into automatic naming.
- Accept any known TUI agent with a Source Control AI generation specification, rather than special-casing Codex.
- Preserve an explicitly configured Branch Name agent ahead of the launch-agent fallback.
- Retain the existing configured/default fallback for unsupported or missing launch-agent values.
- Apply the behavior to Git worktrees and folder workspaces, including host-scoped SSH model resolution.
- Add regression coverage using Codex as a representative supported agent, plus explicit-agent precedence, unsupported launch agents, and folder workspaces.

## Why

Fixes #14428. Codex was the concrete reproduction because the configured Claude account was unavailable, but the underlying bug affected any supported launch agent that differed from the Source Control AI default.

## Linked Issue

Fixes #14428

## Visual Proof

N/A - no visual or interaction-layout change; this only changes backend agent selection for first-work naming.

## Testing

- `pnpm lint` - passed
- `pnpm typecheck` - passed
- Targeted Vitest suites - 62 tests passed
- `oxfmt --check` on changed files - passed
- `git diff --check` - passed
- Desktop and web production builds - passed
- Full `pnpm test` - two unrelated existing PTY subprocess tests time out on this macOS machine; both reproduce in isolation:
  - repairs a deleted macOS daemon cwd before spawning node-pty
  - repairs a deleted POSIX daemon cwd before Linux node-pty spawn
- Full `pnpm build` - desktop/web completed; the native macOS computer-use Swift manifest then failed to link local `PackageDescription` symbols.

Platform notes: exercised on macOS. The change is platform-neutral TypeScript, preserves host-key model resolution for SSH, supports folder workspaces, and does not change the remote wire shape. Linux and Windows were not manually exercised.

## AI Disclosure

Implementation and tests were assisted by Codex.

## Review

Independent Codex review of commit `f2b5e9df8`: **APPROVE**, no blocking issues.

- Security: only normalized, known TUI agent IDs with generation specifications can become the fallback; no command, path, credential, or wire handling changed.
- Cross-platform: no OS-specific branching was introduced.
- Remote/SSH: existing host-scoped model resolution is preserved.
- Backward compatibility: missing or unsupported `agentType` retains the configured/default fallback, and no wire protocol changed.
- Mobile: no mobile code or shared mobile contract changed.
- Performance: one constant-time lookup occurs only during first-work auto-naming.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included visual proof, or marked it N/A with a reason
- [x] I self-reviewed the diff
- [x] I considered Windows/Linux/macOS, SSH, folder workspaces, and remote compatibility
- [x] Relevant tests, lint, and typecheck pass; CI will cover the documented unrelated local full-suite/build blockers

## Author

- X / Twitter: N/A
