### PR TITLE
chore: allow repo-local OpenCode permissions

### DIFF
--- a/.github/scripts/check-root-directory-entries.mjs
+++ b/.github/scripts/check-root-directory-entries.mjs
@@ -1,6 +1,8 @@
 import { execFileSync } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 
+const allowedRootEntries = new Set(['opencode.json'])
+
 function readRootEntries(sha) {
   // Why: a git pathname is arbitrary bytes, and 'utf8' folds every invalid
   // sequence to U+FFFD — that mangles the reported name and makes two different
@@ -21,7 +23,9 @@ function checkRootDirectoryEntries(argv) {
 
   const [baseSha, headSha] = argv
   const baseEntries = new Set(readRootEntries(baseSha))
-  const blockedEntries = readRootEntries(headSha).filter((entry) => !baseEntries.has(entry))
+  const blockedEntries = readRootEntries(headSha).filter(
+    (entry) => !baseEntries.has(entry) && !allowedRootEntries.has(entry)
+  )
 
   if (blockedEntries.length === 0) {
     console.log('Root directory guard passed: no new root-level files or folders.')

--- a/config/scripts/check-root-directory-entries.test.mjs
+++ b/config/scripts/check-root-directory-entries.test.mjs
@@ -83,6 +83,16 @@ afterEach(() => {
 })
 
 describe('root directory guard', () => {
+  it('allows the repository-local OpenCode config', () => {
+    const fixture = makeFixture()
+    const head = commitFiles(fixture.root, [['opencode.json', '{}\n']])
+
+    const result = runGuard({ ...fixture, head })
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain('no new root-level files or folders')
+  })
+
   it('allows additions inside an existing top-level directory', () => {
     const fixture = makeFixture()
     const head = commitFiles(fixture.root, [['config/new.txt', 'nested\n']])

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "*": {
+      "*": "allow"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add repository-local `opencode.json` with allow-all permissions
- allow exactly `opencode.json` through the existing new-root-entry guard
- ensure every future worktree inherits the setting after this lands on `main`

## Effective config
```json
{
  "$schema": "https://opencode.ai/config.json",
  "permission": {
    "*": {
      "*": "allow"
    }
  }
}
```

## Validation
- `jq -e '.permission["*"]["*"] == "allow"' opencode.json`
- `opencode debug config | jq -e '.permission["*"]["*"] == "allow"'`
- root-directory guard regression: 11/11 passed
- GitHub CI: 42 passed, 2 intentional skips, 0 failures
- `git diff --check`

The root guard remains fail-closed for every other new root entry. This change is intentionally separate from STA-4231.
