### PR TITLE
fix(agent-teams): require an absolute Orca CLI for the tmux shim

### DIFF
--- a/src/main/runtime/claude-agent-teams-service.ts
+++ b/src/main/runtime/claude-agent-teams-service.ts
@@ -26,7 +26,8 @@ export class ClaudeAgentTeamsService {
     leaderHandle: string
     baseEnv: Record<string, string | undefined>
     shimDir: string
-    shimBin: string
+    /** Absolute path only; null leaves the var unset so the shim refuses to guess a cwd-relative CLI. */
+    shimBin: string | null
   }): AgentTeamsLaunchEnv {
     const teamId = `team-${randomUUID()}`
     const token = randomBytes(32).toString('base64url')
@@ -47,8 +48,10 @@ export class ClaudeAgentTeamsService {
       ORCA_AGENT_TEAMS_TEAM_ID: teamId,
       ORCA_AGENT_TEAMS_TOKEN: token,
       ORCA_AGENT_TEAMS_LEADER_PANE: leaderPane,
-      ORCA_AGENT_TEAMS_SHIM_DIR: args.shimDir,
-      ORCA_AGENT_TEAMS_SHIM_BIN: args.shimBin
+      ORCA_AGENT_TEAMS_SHIM_DIR: args.shimDir
+    }
+    if (args.shimBin) {
+      env.ORCA_AGENT_TEAMS_SHIM_BIN = args.shimBin
     }
     if (args.baseEnv.ORCA_PAIRING_CODE) {
       env.ORCA_PAIRING_CODE = args.baseEnv.ORCA_PAIRING_CODE

--- a/src/main/runtime/claude-agent-teams-shim-env.test.ts
+++ b/src/main/runtime/claude-agent-teams-shim-env.test.ts
@@ -1,3 +1,5 @@
+import { spawnSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
 import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -5,7 +7,8 @@ import { afterEach, describe, expect, it } from 'vitest'
 import {
   buildClaudeAgentTeamsLaunchPlan,
   ensureClaudeAgentTeamsShimDir,
-  resolveClaudeAgentTeamsShimBin
+  resolveClaudeAgentTeamsShimBin,
+  windowsClaudeAgentTeamsShimScript
 } from './claude-agent-teams-shim-env'
 
 const roots: string[] = []
@@ -87,5 +90,94 @@ describe('claude agent teams shim env', () => {
     }
 
     expect(resolveClaudeAgentTeamsShimBin({ PATH: root })).toBe(cliPath)
+  })
+
+  it('refuses to resolve a CLI through relative PATH entries or a bare override', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-agent-teams-cli-'))
+    roots.push(root)
+    for (const name of ['orca', 'orca-ide', 'orca.cmd']) {
+      const path = join(root, name)
+      await writeFile(path, '#!/usr/bin/env sh\n', 'utf8')
+      if (process.platform !== 'win32') {
+        await chmod(path, 0o755)
+      }
+    }
+
+    expect(resolveClaudeAgentTeamsShimBin({ PATH: '.' })).toBeNull()
+    expect(resolveClaudeAgentTeamsShimBin({ PATH: '' })).toBeNull()
+    expect(
+      resolveClaudeAgentTeamsShimBin({ PATH: '.', ORCA_AGENT_TEAMS_SHIM_BIN: 'orca' })
+    ).toBeNull()
+    // Why: a bare override is still honored when it maps to a real absolute PATH entry.
+    expect(resolveClaudeAgentTeamsShimBin({ PATH: root, ORCA_AGENT_TEAMS_SHIM_BIN: 'orca' })).toBe(
+      join(root, 'orca')
+    )
+  })
+
+  it('falls back to in-process teammates when no absolute CLI can be qualified', async () => {
+    const createTeamEnv = (): Record<string, string> => {
+      throw new Error('native shim env must not be built without a qualified CLI')
+    }
+
+    await expect(
+      buildClaudeAgentTeamsLaunchPlan({
+        command: 'claude',
+        mode: 'native-panes-shim',
+        baseEnv: { PATH: '.' },
+        createTeamEnv
+      })
+    ).resolves.toEqual({
+      command: 'claude --teammate-mode in-process',
+      env: { CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1' }
+    })
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'never runs a cwd-resolved orca when the shim bin is unqualified',
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), 'orca-agent-teams-shim-'))
+      roots.push(root)
+      await ensureClaudeAgentTeamsShimDir(root)
+      const cwd = await mkdtemp(join(tmpdir(), 'orca-agent-teams-cwd-'))
+      roots.push(cwd)
+      const marker = join(cwd, 'hijacked')
+      for (const name of ['orca', 'orca-ide']) {
+        const decoy = join(cwd, name)
+        await writeFile(decoy, `#!/usr/bin/env sh\ntouch ${JSON.stringify(marker)}\n`, 'utf8')
+        await chmod(decoy, 0o755)
+      }
+
+      const hijack = spawnSync(join(root, 'tmux'), ['display-message', '-p', '#{pane_id}'], {
+        cwd,
+        env: { PATH: `.:${process.env.PATH ?? ''}` },
+        encoding: 'utf8'
+      })
+
+      expect(hijack.status).toBe(127)
+      expect(hijack.stderr).toContain('absolute path')
+      expect(existsSync(marker)).toBe(false)
+
+      const cli = join(cwd, 'fake-orca')
+      await writeFile(cli, '#!/usr/bin/env sh\necho "ran $*"\n', 'utf8')
+      await chmod(cli, 0o755)
+      const qualified = spawnSync(join(root, 'tmux'), ['list-panes'], {
+        cwd,
+        env: { PATH: `.:${process.env.PATH ?? ''}`, ORCA_AGENT_TEAMS_SHIM_BIN: cli },
+        encoding: 'utf8'
+      })
+
+      expect(qualified.status).toBe(0)
+      expect(qualified.stdout.trim()).toBe('ran agent-teams-tmux list-panes')
+    }
+  )
+
+  it('writes a Windows shim that rejects an unqualified shim bin', () => {
+    const script = windowsClaudeAgentTeamsShimScript()
+
+    expect(script).not.toMatch(/^set "ORCA_AGENT_TEAMS_SHIM_BIN=orca/m)
+    expect(script).toContain('if "%ORCA_SHIM_BIN:~1,1%"==":" goto :run')
+    // Why: `call` would re-expand `%2`-style tmux pane args as batch parameters.
+    expect(script).toContain('\r\n"%ORCA_SHIM_BIN%" agent-teams-tmux %*\r\n')
+    expect(script).toContain('exit /b 127')
   })
 })

--- a/src/main/runtime/claude-agent-teams-shim-env.test.ts
+++ b/src/main/runtime/claude-agent-teams-shim-env.test.ts
@@ -114,6 +114,18 @@ describe('claude agent teams shim env', () => {
     )
   })
 
+  it.skipIf(process.platform !== 'win32')(
+    'resolves through the Windows `Path` env spelling',
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), 'orca-agent-teams-cli-'))
+      roots.push(root)
+      const cliPath = join(root, 'orca.cmd')
+      await writeFile(cliPath, '@echo off\r\n', 'utf8')
+
+      expect(resolveClaudeAgentTeamsShimBin({ Path: root })).toBe(cliPath)
+    }
+  )
+
   it('falls back to in-process teammates when no absolute CLI can be qualified', async () => {
     const createTeamEnv = (): Record<string, string> => {
       throw new Error('native shim env must not be built without a qualified CLI')

--- a/src/main/runtime/claude-agent-teams-shim-env.ts
+++ b/src/main/runtime/claude-agent-teams-shim-env.ts
@@ -9,6 +9,7 @@ import {
   type ClaudeAgentTeamsMode
 } from '../../shared/claude-agent-teams-tmux-compat'
 import { getOrcaCliCommandNameForPlatform } from '../../shared/orca-cli-command-name'
+import { resolvePathEnvKey } from '../pty/windows-path-segment-merge'
 
 export type ClaudeAgentTeamsLaunchPlan = {
   command: string
@@ -62,10 +63,12 @@ export async function buildClaudeAgentTeamsLaunchPlan(args: {
 export function resolveClaudeAgentTeamsShimBin(
   env: Record<string, string | undefined> = process.env
 ): string | null {
+  // Why: Windows callers pass an env spelt `Path`; reading only `PATH` there would find no CLI at all.
+  const pathValue = env[resolvePathEnvKey(env, process.platform)]
   const override = env.ORCA_AGENT_TEAMS_SHIM_BIN
   if (override) {
     // Why: a bare override name would be resolved by the shim's shell against its cwd, so qualify it or ignore it.
-    const qualified = isAbsolute(override) ? override : findExecutableOnPath(override, env.PATH)
+    const qualified = isAbsolute(override) ? override : findExecutableOnPath(override, pathValue)
     if (qualified) {
       return qualified
     }
@@ -75,8 +78,8 @@ export function resolveClaudeAgentTeamsShimBin(
     return bundled
   }
   return (
-    findExecutableOnPath(process.platform === 'win32' ? 'orca-dev.cmd' : 'orca-dev', env.PATH) ??
-    findExecutableOnPath(getOrcaCliCommandNameForPlatform(process.platform), env.PATH)
+    findExecutableOnPath(process.platform === 'win32' ? 'orca-dev.cmd' : 'orca-dev', pathValue) ??
+    findExecutableOnPath(getOrcaCliCommandNameForPlatform(process.platform), pathValue)
   )
 }
 

--- a/src/main/runtime/claude-agent-teams-shim-env.ts
+++ b/src/main/runtime/claude-agent-teams-shim-env.ts
@@ -1,7 +1,7 @@
 import { chmod, mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { accessSync, constants, existsSync } from 'node:fs'
 import { homedir } from 'node:os'
-import { delimiter, dirname, join } from 'node:path'
+import { delimiter, dirname, isAbsolute, join } from 'node:path'
 import {
   addClaudeTeammateModeAuto,
   addClaudeTeammateModeInProcess,
@@ -20,7 +20,7 @@ export async function ensureClaudeAgentTeamsShimDir(root = defaultShimRoot()): P
   await mkdir(root, { recursive: true })
   await writeIfChanged(join(root, 'tmux'), unixShimScript())
   if (process.platform === 'win32') {
-    await writeIfChanged(join(root, 'tmux.cmd'), windowsShimScript())
+    await writeIfChanged(join(root, 'tmux.cmd'), windowsClaudeAgentTeamsShimScript())
   }
   return root
 }
@@ -41,8 +41,15 @@ export async function buildClaudeAgentTeamsLaunchPlan(args: {
       env: { CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1' }
     }
   }
-  const shimDir = await ensureClaudeAgentTeamsShimDir()
   const shimBin = resolveClaudeAgentTeamsShimBin(args.baseEnv)
+  if (!shimBin) {
+    // Why: without an absolute CLI path the shim would resolve a bare `orca` against the pane cwd, so degrade instead.
+    return {
+      command: addClaudeTeammateModeInProcess(args.command),
+      env: { CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1' }
+    }
+  }
+  const shimDir = await ensureClaudeAgentTeamsShimDir()
   const env = args.createTeamEnv(shimDir, shimBin)
   return {
     command: addClaudeTeammateModeAuto(args.command),
@@ -51,11 +58,17 @@ export async function buildClaudeAgentTeamsLaunchPlan(args: {
   }
 }
 
+/** Absolute path to the Orca CLI that backs the tmux shim, or null when none can be qualified. */
 export function resolveClaudeAgentTeamsShimBin(
   env: Record<string, string | undefined> = process.env
-): string {
-  if (env.ORCA_AGENT_TEAMS_SHIM_BIN) {
-    return env.ORCA_AGENT_TEAMS_SHIM_BIN
+): string | null {
+  const override = env.ORCA_AGENT_TEAMS_SHIM_BIN
+  if (override) {
+    // Why: a bare override name would be resolved by the shim's shell against its cwd, so qualify it or ignore it.
+    const qualified = isAbsolute(override) ? override : findExecutableOnPath(override, env.PATH)
+    if (qualified) {
+      return qualified
+    }
   }
   const bundled = bundledLauncherPath()
   if (bundled && isExecutableFile(bundled)) {
@@ -63,8 +76,7 @@ export function resolveClaudeAgentTeamsShimBin(
   }
   return (
     findExecutableOnPath(process.platform === 'win32' ? 'orca-dev.cmd' : 'orca-dev', env.PATH) ??
-    findExecutableOnPath(getOrcaCliCommandNameForPlatform(process.platform), env.PATH) ??
-    getOrcaCliCommandNameForPlatform(process.platform)
+    findExecutableOnPath(getOrcaCliCommandNameForPlatform(process.platform), env.PATH)
   )
 }
 
@@ -90,7 +102,8 @@ function bundledLauncherPath(): string | null {
 
 function findExecutableOnPath(command: string, pathValue: string | undefined): string | null {
   for (const directory of pathValue?.split(delimiter) ?? []) {
-    if (!directory) {
+    // Why: empty and relative PATH entries resolve against a cwd we do not control, which is the hijack we are avoiding.
+    if (!directory || !isAbsolute(directory)) {
       continue
     }
     const candidate = join(directory, command)
@@ -113,23 +126,42 @@ function isExecutableFile(candidate: string): boolean {
   }
 }
 
+// Why: an unqualified command name is resolved against the invoking pane's cwd (always on cmd.exe, and via `.`/empty
+// PATH entries on POSIX), so a stray `orca` next to the agent's files would run with the team token. Demand a
+// fully-qualified binary instead of guessing one.
 function unixShimScript(): string {
   return [
     '#!/usr/bin/env sh',
     'set -eu',
-    `exec "\${ORCA_AGENT_TEAMS_SHIM_BIN:-${getOrcaCliCommandNameForPlatform(process.platform)}}" agent-teams-tmux "$@"`,
+    'orca_bin=${ORCA_AGENT_TEAMS_SHIM_BIN:-}',
+    'case $orca_bin in',
+    '  /*|[A-Za-z]:[\\\\/]*) ;;',
+    '  *)',
+    '    echo "orca agent-teams tmux shim: ORCA_AGENT_TEAMS_SHIM_BIN must be an absolute path" >&2',
+    '    exit 127',
+    '    ;;',
+    'esac',
+    'exec "$orca_bin" agent-teams-tmux "$@"',
     ''
   ].join('\n')
 }
 
-function windowsShimScript(): string {
+export function windowsClaudeAgentTeamsShimScript(): string {
   return [
     '@echo off',
     'setlocal',
-    'if "%ORCA_AGENT_TEAMS_SHIM_BIN%"=="" (',
-    `  set "ORCA_AGENT_TEAMS_SHIM_BIN=${getOrcaCliCommandNameForPlatform(process.platform)}"`,
-    ')',
-    '"%ORCA_AGENT_TEAMS_SHIM_BIN%" agent-teams-tmux %*',
+    'set "ORCA_SHIM_BIN=%ORCA_AGENT_TEAMS_SHIM_BIN%"',
+    'if not defined ORCA_SHIM_BIN goto :unqualified',
+    'if "%ORCA_SHIM_BIN:~1,1%"==":" goto :run',
+    'if "%ORCA_SHIM_BIN:~0,2%"=="\\\\" goto :run',
+    'goto :unqualified',
+    ':run',
+    // Why: no `call` — its extra percent-expansion pass would rewrite tmux pane args such as `%2` into batch parameters.
+    '"%ORCA_SHIM_BIN%" agent-teams-tmux %*',
+    'exit /b %ERRORLEVEL%',
+    ':unqualified',
+    'echo orca agent-teams tmux shim: ORCA_AGENT_TEAMS_SHIM_BIN must be an absolute path 1>&2',
+    'exit /b 127',
     ''
   ].join('\r\n')
 }

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -14263,6 +14263,8 @@ describe('OrcaRuntimeService', () => {
       command: 'claude --resume claude-session',
       env: {
         CLAUDE_PROFILE: 'captured',
+        // Why: native panes need an absolute CLI; without one the plan degrades to in-process teammates.
+        ORCA_AGENT_TEAMS_SHIM_BIN: '/opt/orca/bin/orca-ide',
         ORCA_AGENT_TEAMS_TEAM_ID: 'stale-team',
         ORCA_AGENT_TEAMS_TOKEN: 'stale-token',
         TMUX: '/tmp/orca-claude-agent-teams/stale-team,0,1'
@@ -14273,6 +14275,7 @@ describe('OrcaRuntimeService', () => {
         agentArgs: '--teammate-mode auto',
         agentEnv: {
           CLAUDE_PROFILE: 'captured',
+          ORCA_AGENT_TEAMS_SHIM_BIN: '/opt/orca/bin/orca-ide',
           ORCA_AGENT_TEAMS_TEAM_ID: 'stale-team',
           ORCA_AGENT_TEAMS_TOKEN: 'stale-token',
           TMUX: '/tmp/orca-claude-agent-teams/stale-team,0,1'
@@ -14287,6 +14290,7 @@ describe('OrcaRuntimeService', () => {
     expect(spawnCall?.env).toMatchObject({
       CLAUDE_PROFILE: 'captured',
       CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1',
+      ORCA_AGENT_TEAMS_SHIM_BIN: '/opt/orca/bin/orca-ide',
       TMUX_PANE: '%1'
     })
     expect(spawnCall?.env?.ORCA_AGENT_TEAMS_TEAM_ID).toMatch(/^team-/)


### PR DESCRIPTION
## ELI5

Orca hands Claude Code a fake `tmux` so agent teams can open panes as Orca terminals. That fake `tmux` turned around and called plain `orca` by name. On Windows, "call `orca`" means "look in the folder you're standing in first" — so if a checkout happened to contain a file named `orca.cmd`, *that* ran instead of Orca's CLI, and it ran with the team's secret token in its environment. Now the shim only accepts a full, absolute path to the real CLI and refuses to guess.

## What Changed

`src/main/runtime/claude-agent-teams-shim-env.ts`

- `resolveClaudeAgentTeamsShimBin()` returns `string | null` and only ever yields an **absolute** path:
  - relative and empty `PATH` entries are skipped (they resolve against a cwd we do not control),
  - a non-absolute `ORCA_AGENT_TEAMS_SHIM_BIN` override is re-resolved through absolute `PATH` dirs, or ignored,
  - the final bare-command-name fallback is removed.
- `buildClaudeAgentTeamsLaunchPlan()` degrades to `--teammate-mode in-process` (the same path Windows already takes) when no CLI can be qualified, instead of handing the shim a guessable name.
- Both generated shims now hard-fail with exit `127` and a clear stderr message unless the bin is absolute (`/…`, `C:\…`, `C:/…`, or UNC `\\…`).
- The Windows shim invokes the CLI **without** `call`. `call` performs an extra percent-expansion pass, which rewrites tmux pane args such as `%2` into batch parameters (caught during Windows verification — see Testing #2 below).

`src/main/runtime/claude-agent-teams-service.ts`

- `createLaunchEnv` takes `shimBin: string | null` and leaves `ORCA_AGENT_TEAMS_SHIM_BIN` unset rather than exporting an unqualified value.

## Why

`~/.orca/claude-agent-teams-bin/tmux{,.cmd}` fell back to a bare `orca` / `orca.cmd` / `orca-ide`, and `resolveClaudeAgentTeamsShimBin()` returned that bare name as its last resort when nothing was found.

`cmd.exe` resolves an unqualified command against the **current directory before `PATH`**, and `sh` does the same through `.` or empty `PATH` entries. The shim runs with the pane's cwd — i.e. inside a repo checkout — and with `ORCA_AGENT_TEAMS_TEAM_ID` / `ORCA_AGENT_TEAMS_TOKEN` in its environment. A file named `orca.cmd` next to the agent's files was therefore enough to get executed with those credentials.

Failing loudly is the right degradation here: a shim that cannot find the real CLI has nothing safe to fall back to, and the launch path already has a working in-process mode for exactly this situation.

## Linked Issue

STA-4215 — https://linear.app/stably/issue/STA-4215/agent-teams-tmux-shim-invokes-an-unqualified-orcacmd-cwd-first

No GitHub issue exists for this one; it was filed in Linear.

## Visual Proof

N/A — no UI surface. The change is confined to the generated shim scripts and the launch env that feeds them. Terminal transcripts of the before/after behavior are in Testing below.

## Testing

Platforms actually exercised: **macOS** (unit tests + real execution of the generated POSIX shim) and **Windows** (`awin`, via `orca --environment awin`, in both `cmd.exe` and Git Bash). Linux shares the POSIX shim path with macOS. SSH/remote is unaffected — `orca agent-teams-tmux` is explicitly rejected over the SSH relay bridge (`src/main/ssh/ssh-remote-orca-cli.ts`), and the shim is written on the machine that runs the pane.

**1. Before/after on Windows (`cmd.exe`), decoy `orca.cmd` in the pane cwd**

Pre-fix shim, no `ORCA_AGENT_TEAMS_SHIM_BIN`:

```
=== 1. OLD shim, no ORCA_AGENT_TEAMS_SHIM_BIN, decoy orca.cmd in cwd
exit=0
RESULT: OLD_RAN_CWD_DECOY        <-- the cwd file executed
```

Post-fix shim, same setup:

```
=== 1. unset shim bin + decoy orca.cmd in cwd (expect 127, no hijack)
orca agent-teams tmux shim: ORCA_AGENT_TEAMS_SHIM_BIN must be an absolute path
exit=127
RESULT: REFUSED_DECOY
```

**2. Windows argument fidelity + exit codes (post-fix)**

```
=== 2. pane-id args through absolute .cmd target (expect literal %2 preserved, exit=3)
ran agent-teams-tmux send-keys -t %2 "hello world" Enter
exit=3
=== 3. absolute path containing a space (expect ran ..., exit=3)
ran agent-teams-tmux list-panes -F #{pane_id}
exit=3
=== 4. .exe target returns control and propagates exit code (node: expect non-zero)
... Error: Cannot find module '...\agent-teams-tmux'
exit=1
```

An earlier revision of this patch used `call` and produced `send-keys -t -t "hello world" Enter` for case 2 — `%2` had been expanded as a batch parameter. That is why the shim invokes the CLI directly.

**3. POSIX shim under Git Bash on Windows (`C:\` style bin)**

```
=== A. unqualified, decoy ./orca present, PATH starts with . (expect 127, no run)
orca agent-teams tmux shim: ORCA_AGENT_TEAMS_SHIM_BIN must be an absolute path
exit=127
=== B. Windows-style absolute bin C:\Users\neil\AppData\Local\Temp\...\orca (expect ran ..., exit=3)
ran agent-teams-tmux send-keys -t %2 hello world Enter
exit=3
=== C. MSYS-style absolute bin /tmp/.../orca (expect ran ..., exit=3)
ran agent-teams-tmux list-panes
exit=3
```

**4. Automated tests** (`src/main/runtime/claude-agent-teams-shim-env.test.ts`, 4 new cases)

- executes the real generated POSIX shim against a cwd decoy with `PATH=".:$PATH"` — asserts exit 127 and that the decoy never ran (fails on the pre-fix script),
- asserts the same shim still execs an absolute bin and forwards `agent-teams-tmux <args>`,
- `resolveClaudeAgentTeamsShimBin` returns `null` for relative/empty `PATH` and for a bare override that is not on an absolute `PATH` entry, while still honoring a bare override that resolves to a real absolute path,
- `buildClaudeAgentTeamsLaunchPlan` degrades to in-process instead of calling `createTeamEnv`,
- the Windows script asserts the guard, the no-`call` invocation, and exit 127.

Local runs: `claude-agent-teams-*` suites pass (20 tests), `tsc --noEmit -p config/tsconfig.node.json` clean, `oxlint` clean, `oxfmt --check` clean. `src/main/ipc/pty.test.ts` has one failure (`shuts down a split PTY when its expected source binding was retired`, 5s timeout) that reproduces identically on a stashed clean tree — pre-existing and unrelated.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

- **Security**: this is the point of the change — removes a cwd-first command resolution that ran with the agent-teams token in env. Also hardens against `.`/empty `PATH` entries on POSIX and non-absolute overrides.
- **Cross-platform**: verified on macOS and Windows (cmd.exe + Git Bash); Linux uses the same POSIX shim and the `orca-ide` command name, which is still consulted, only now via absolute `PATH` entries. Note Windows still short-circuits to in-process teammates at launch, so `tmux.cmd` is not on the live Windows path today — the hardening matters for Git Bash panes and whenever native panes are enabled there.
- **Remote SSH**: no wire change; no RPC params, stream frames, or published content changed.
- **Backwards compatibility**: `ORCA_AGENT_TEAMS_SHIM_BIN` overrides that are absolute (the shape Orca has always written) behave exactly as before. A bare-name override now resolves through `PATH` instead of being trusted verbatim. Behavior only changes when no CLI can be qualified at all — previously an unqualified guess, now in-process teammates.
- **Mobile / performance**: unaffected; resolution runs once per leader launch.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
  - ran targeted `vitest`, `tsc -p config/tsconfig.node.json`, `oxlint`, `oxfmt --check`; full `pnpm test`/`pnpm build` left to CI

## AI Disclosure

Claude Opus 5 via Claude Code.
