### PR TITLE
fix(terminal): strip the captured shim dir across trailing-separator spellings

### DIFF
--- a/src/main/pty/legacy-terminal-posix-tombstone.ts
+++ b/src/main/pty/legacy-terminal-posix-tombstone.ts
@@ -1,5 +1,5 @@
-import { accessSync, constants, statSync } from 'node:fs'
-import { join } from 'node:path'
+import { accessSync, constants, readFileSync, statSync } from 'node:fs'
+import { basename, join } from 'node:path'
 
 const SHELL_DOLLAR = '$'
 
@@ -70,6 +70,34 @@ export function resolvePosixTombstoneInterpreter(
   return null
 }
 
+/**
+ * Returns the absolute interpreter the wrapper being replaced already used, or null.
+ *
+ * Why: when this process cannot see an absolute bash, deleting the wrapper strands a shell that
+ * has the path hashed -- it reports 127 rather than falling through to the next PATH entry. The
+ * file about to be overwritten ran on this host, so its own shebang names an interpreter known to
+ * work here, and reusing it keeps the compatibility promise without an ambient lookup.
+ */
+export function readVerifiedShebangInterpreter(filePath: string): string | null {
+  let firstLine: string
+  try {
+    firstLine = readFileSync(filePath, 'utf8').split('\n', 1)[0] ?? ''
+  } catch {
+    return null
+  }
+  const match = /^#!\s*(\S+)/.exec(firstLine)
+  const interpreter = match?.[1]
+  if (!interpreter?.startsWith('/')) {
+    return null
+  }
+  // Why: `#!/usr/bin/env bash` is absolute but defers the real lookup to PATH, which is the
+  // current-directory exposure this whole path exists to avoid.
+  if (basename(interpreter) === 'env') {
+    return null
+  }
+  return isExecutable(interpreter) ? interpreter : null
+}
+
 const POSIX_TOMBSTONE = String.raw`#!__ORCA_INTERPRETER__
 set -u
 
@@ -116,7 +144,11 @@ filter_path() {
       # Why: an empty or relative PATH element resolves against the current directory, so keeping
       # it would let a repository-local git/gh win the lookup below.
       :
-    elif [[ -n "$legacy_target" && "$normalized" == "$legacy_target" ]]; then
+    elif [[ -n "$legacy_target" && ( "$normalized" == "$legacy_target" || "$entry" -ef "$legacy_target" ) ]]; then
+      # Why both tests: -ef compares filesystem identity, so it catches the same directory reached
+      # through a symlink or a /legacy/../legacy spelling that the lexical compare misses. It is
+      # false when either path no longer exists, which is exactly when the lexical compare still
+      # holds, so neither alone is enough.
       :
     elif [[ "$entry" -ef "$wrapper_dir" ]]; then
       :

--- a/src/main/pty/legacy-terminal-posix-tombstone.ts
+++ b/src/main/pty/legacy-terminal-posix-tombstone.ts
@@ -90,9 +90,11 @@ export function readVerifiedShebangInterpreter(filePath: string): string | null 
   if (!interpreter?.startsWith('/')) {
     return null
   }
-  // Why: `#!/usr/bin/env bash` is absolute but defers the real lookup to PATH, which is the
-  // current-directory exposure this whole path exists to avoid.
-  if (basename(interpreter) === 'env') {
+  // Why exactly bash: the body below uses BASH_SOURCE, [[, and local, so any other shell fails at
+  // runtime -- a #!/bin/zsh wrapper was accepted and then exited 1 on `BASH_SOURCE[0]: parameter
+  // not set`. This also rejects `#!/usr/bin/env bash`, which is absolute but defers the real
+  // lookup to PATH, the current-directory exposure this whole path exists to avoid.
+  if (basename(interpreter) !== 'bash') {
     return null
   }
   return isExecutable(interpreter) ? interpreter : null

--- a/src/main/pty/legacy-terminal-posix-tombstone.ts
+++ b/src/main/pty/legacy-terminal-posix-tombstone.ts
@@ -73,16 +73,14 @@ const POSIX_TOMBSTONE = String.raw`#!__ORCA_INTERPRETER__
 set -u
 
 command_name="__ORCA_COMMAND__"
-# Why: parameter expansion, not the external dirname — if that were unresolvable the substitution
-# would be empty and cd into it succeeds, silently making wrapper_dir the cwd so the wrapper
-# fails to exclude itself from PATH.
+# Why this shape, rather than dirname: an unresolvable external would leave the substitution empty
+# and cd into it succeeds, silently making wrapper_dir the cwd. With no slash the %/* strip yields the
+# file name rather than a directory, so that case takes $PWD. CDPATH is cleared because cd searches
+# it for a relative operand and echoes where it landed, which the substitution would capture.
+# Each of these made self-exclusion miss the wrapper's own directory, so the lookup resolved back
+# to this script.
 wrapper_src="${SHELL_DOLLAR}{BASH_SOURCE[0]}"
 case "$wrapper_src" in
-  # Why: with no slash the %/* strip yields the file name, not a directory, so self-exclusion
-  # would miss the wrapper's own dir and the lookup would resolve back to this script.
-  # Why: with CDPATH set, cd searches it for a relative operand and echoes the directory it lands
-  # in, which the command substitution then captures — wrapper_dir ends up wrong and doubled.
-  # Clear it for this one command.
   */*) wrapper_dir="$(CDPATH= cd -P -- "${SHELL_DOLLAR}{wrapper_src%/*}" 2>/dev/null && pwd)" ;;
   *) wrapper_dir="$PWD" ;;
 esac
@@ -99,7 +97,7 @@ filter_path() {
   local filtered_path=""
   local separator=""
   path_entry_kept=0
-  local entry normalized candidate has_more
+  local entry normalized has_more
   while true; do
     if [[ "$remaining" == *:* ]]; then
       entry="${SHELL_DOLLAR}{remaining%%:*}"
@@ -113,14 +111,13 @@ filter_path() {
     while [[ "$normalized" != "/" && "$normalized" == */ ]]; do
       normalized="${SHELL_DOLLAR}{normalized%/}"
     done
-    candidate="${SHELL_DOLLAR}{entry:-.}"
     if [[ "$entry" != /* ]]; then
       # Why: an empty or relative PATH element resolves against the current directory, so keeping
       # it would let a repository-local git/gh win the lookup below.
       :
     elif [[ -n "$legacy_target" && "$normalized" == "$legacy_target" ]]; then
       :
-    elif [[ "$candidate" -ef "$wrapper_dir" ]]; then
+    elif [[ "$entry" -ef "$wrapper_dir" ]]; then
       :
     else
       filtered_path+="$separator$entry"

--- a/src/main/pty/legacy-terminal-posix-tombstone.ts
+++ b/src/main/pty/legacy-terminal-posix-tombstone.ts
@@ -146,11 +146,16 @@ filter_path() {
       # Why: an empty or relative PATH element resolves against the current directory, so keeping
       # it would let a repository-local git/gh win the lookup below.
       :
-    elif [[ -n "$legacy_target" && ( "$normalized" == "$legacy_target" || "$entry" -ef "$legacy_target" ) ]]; then
-      # Why both tests: -ef compares filesystem identity, so it catches the same directory reached
-      # through a symlink or a /legacy/../legacy spelling that the lexical compare misses. It is
-      # false when either path no longer exists, which is exactly when the lexical compare still
-      # holds, so neither alone is enough.
+    elif [[ -n "$legacy_target" && "$normalized" == "$legacy_target" ]]; then
+      :
+    elif [[ "$legacy_target" == /* && "$entry" -ef "$legacy_target" ]]; then
+      # Why -ef as well as the lexical test above: it compares filesystem identity, so it catches
+      # the same directory reached through a symlink or a /legacy/../legacy spelling. It is false
+      # when either path is gone, which is when the lexical test still holds, so neither alone is
+      # enough.
+      # Why only for an absolute target: bash resolves a relative -ef operand against the current
+      # directory, so a relative ORCA_ATTRIBUTION_SHIM_DIR let the cwd decide which PATH entry
+      # counted as the legacy directory and got a legitimate one skipped.
       :
     elif [[ "$entry" -ef "$wrapper_dir" ]]; then
       :

--- a/src/main/pty/legacy-terminal-posix-tombstone.ts
+++ b/src/main/pty/legacy-terminal-posix-tombstone.ts
@@ -36,13 +36,14 @@ function isExecutable(candidate: string): boolean {
 // directly rather than falling through to an ambient lookup.
 const WINDOWS_POSIX_INTERPRETER = '/bin/bash'
 
+/** Returns null when no absolute interpreter can be verified; see the caller for what that means. */
 export function resolvePosixTombstoneInterpreter(
   pathValue: string | undefined = process.env.PATH,
   // Why: injectable so the PATH-search branch below is reachable in tests on hosts that do have
   // a well-known bash.
   candidates: readonly string[] = POSIX_INTERPRETER_CANDIDATES,
   platform: NodeJS.Platform = process.platform
-): string {
+): string | null {
   if (platform === 'win32') {
     return WINDOWS_POSIX_INTERPRETER
   }
@@ -64,9 +65,9 @@ export function resolvePosixTombstoneInterpreter(
       return candidate
     }
   }
-  // Why: last resort. Leaves the ambient lookup in place, but only when no absolute bash exists
-  // anywhere, in which case the wrapper would not run at all otherwise.
-  return '/usr/bin/env bash'
+  // Why: no absolute interpreter anywhere. Callers must delete the legacy wrapper rather than
+  // write one with an ambient shebang, which would resolve bash from the cwd.
+  return null
 }
 
 const POSIX_TOMBSTONE = String.raw`#!__ORCA_INTERPRETER__
@@ -149,7 +150,7 @@ PATH="$cleaned_path" exec "$real_command" "$@"
 
 export function renderLegacyTerminalPosixTombstone(
   command: 'git' | 'gh',
-  interpreter = resolvePosixTombstoneInterpreter()
+  interpreter: string = resolvePosixTombstoneInterpreter() ?? WINDOWS_POSIX_INTERPRETER
 ): string {
   return POSIX_TOMBSTONE.replaceAll('__ORCA_INTERPRETER__', interpreter).replaceAll(
     '__ORCA_COMMAND__',

--- a/src/main/pty/legacy-terminal-shim-dir.test.ts
+++ b/src/main/pty/legacy-terminal-shim-dir.test.ts
@@ -707,6 +707,25 @@ describe('legacy terminal shim neutralization', () => {
     expect(env).toEqual({ PATH: '/usr/local/bin:/usr/bin', HOME: '/home/u' })
   })
 
+  it('strips the captured shim directory when PATH spells it with a trailing separator', () => {
+    // Why: the captured value and the PATH entry can differ by a trailing separator; comparing
+    // them literally left the shim directory on PATH and the wrapper reachable.
+    const posix: Record<string, string> = {
+      PATH: '/custom/elsewhere/:/usr/bin',
+      ORCA_ATTRIBUTION_SHIM_DIR: '/custom/elsewhere'
+    }
+    stripLegacyTerminalShimEnv(posix, 'linux')
+    expect(posix.PATH).toBe('/usr/bin')
+
+    // And the reverse spelling, plus Windows slash style.
+    const win: Record<string, string> = {
+      Path: 'C:\\Custom\\Else;C:\\Windows',
+      ORCA_ATTRIBUTION_SHIM_DIR: 'C:\\Custom\\Else\\'
+    }
+    stripLegacyTerminalShimEnv(win, 'win32')
+    expect(win.Path).toBe('C:\\Windows')
+  })
+
   it('uses the captured POSIX shim directory literally when it contains a colon', () => {
     const shimDir = '/tmp/orca:user/orca-terminal-attribution/posix'
     const env: Record<string, string> = {

--- a/src/main/pty/legacy-terminal-shim-dir.test.ts
+++ b/src/main/pty/legacy-terminal-shim-dir.test.ts
@@ -364,6 +364,62 @@ describe('legacy terminal shim neutralization', () => {
     expect(windowsEnv.Path).toBe('C:\\Windows')
   })
 
+  itOnPosix(
+    'ignores a relative legacy shim directory instead of resolving it against the cwd',
+    () => {
+      // Why: bash resolves a relative -ef operand against the wrapper's current directory, so a
+      // relative ORCA_ATTRIBUTION_SHIM_DIR let the cwd decide which PATH entry counted as the legacy
+      // directory. Reproduced as SAFE vs LATER purely by changing the cwd.
+      const userData = makeUserDataDir()
+      const posixDir = join(userData, 'orca-terminal-attribution', 'posix')
+      const safeBin = join(userData, 'safe-bin')
+      const laterBin = join(userData, 'later-bin')
+      for (const dir of [posixDir, safeBin, laterBin]) {
+        mkdirSync(dir, { recursive: true })
+      }
+      writeFileSync(join(posixDir, 'git'), 'legacy attribution wrapper')
+
+      neutralizeLegacyTerminalShimDir(userData)
+
+      writeFileSync(join(safeBin, 'git'), "#!/bin/bash\nprintf 'SAFE\\n'\n", { mode: 0o755 })
+      writeFileSync(join(laterBin, 'git'), "#!/bin/bash\nprintf 'LATER\\n'\n", { mode: 0o755 })
+
+      const outputs = [userData, join(userData, 'orca-terminal-attribution')].map((cwd) => {
+        const run = spawnSync(join(posixDir, 'git'), ['--version'], {
+          cwd,
+          env: {
+            ...process.env,
+            ORCA_ATTRIBUTION_SHIM_DIR: 'safe-bin',
+            PATH: `${safeBin}:${laterBin}:/usr/bin:/bin`
+          },
+          encoding: 'utf8',
+          timeout: 20_000
+        })
+        return run.stdout.trim()
+      })
+
+      // Why identical: which binary runs must not depend on where the wrapper was invoked from.
+      expect(outputs[0]).toBe(outputs[1])
+      expect(outputs[0]).toBe('SAFE')
+    }
+  )
+
+  it('keeps a POSIX directory whose name ends in a backslash', () => {
+    // Why: a backslash is a legal filename character on POSIX. Treating it as a separator made
+    // `/tmp/captured\` and `/tmp/captured` compare equal and deleted a real directory from PATH.
+    const env = {
+      PATH: '/tmp/captured\\',
+      ORCA_ATTRIBUTION_SHIM_DIR: '/tmp/captured'
+    }
+    stripLegacyTerminalShimEnv(env, 'linux')
+    expect(env.PATH).toBe('/tmp/captured\\')
+
+    // Why the Windows half: there a backslash really is a separator, so it must still be stripped.
+    const windowsEnv = { Path: 'C:\\captured\\', ORCA_ATTRIBUTION_SHIM_DIR: 'C:\\captured' }
+    stripLegacyTerminalShimEnv(windowsEnv, 'win32')
+    expect(windowsEnv.Path).toBeUndefined()
+  })
+
   itOnPosix('does not fall back to the cwd when every PATH entry is filtered out', () => {
     // Why: with the shim dir as the only entry the cleaned PATH is empty; without the
     // path_entry_kept guard the lookup runs against that empty PATH and finds a cwd-local git.

--- a/src/main/pty/legacy-terminal-shim-dir.test.ts
+++ b/src/main/pty/legacy-terminal-shim-dir.test.ts
@@ -108,6 +108,25 @@ describe('legacy terminal shim neutralization', () => {
     )
   })
 
+  it('keeps the Windows wrappers ASCII-only', () => {
+    // Why: cmd.exe seeks through a batch file in bytes but advances by decoded character count,
+    // so a single multi-byte character shifts every following line. Two em dashes in comments
+    // made it drop the first four characters of every line and the wrapper died with "The
+    // syntax of the command is incorrect." Proven on Windows 11; no test caught it.
+    const userData = makeUserDataDir()
+    const win32Dir = join(userData, 'orca-terminal-attribution', 'win32')
+    mkdirSync(win32Dir, { recursive: true })
+
+    neutralizeLegacyTerminalShimDir(userData)
+
+    for (const name of ['git.cmd', 'gh.cmd', 'git-wrapper.ps1', 'gh-wrapper.ps1']) {
+      const contents = readFileSync(join(win32Dir, name), 'utf8')
+      const offending = [...contents].find((character) => character.charCodeAt(0) > 0x7f)
+      expect(offending, `${name} contains non-ASCII ${JSON.stringify(offending)}`).toBeUndefined()
+      expect(Buffer.byteLength(contents, 'utf8')).toBe(contents.length)
+    }
+  })
+
   it('resolves Windows fallbacks against PATH only, never the current directory', () => {
     // Why (STA-4169): bare `where.exe git.exe` searches cwd before PATH, so a repository-local
     // git.exe/gh.exe could be executed with the user's arguments.
@@ -124,17 +143,28 @@ describe('legacy terminal shim neutralization', () => {
       expect(cmd).toContain('for %%P in ("%orca_clean_path:;=" "%") do call :orca_try_candidate')
       expect(cmd).toContain(`if exist "%orca_candidate_dir%\\${command}.exe"`)
       // Why: %~f preserves a trailing separator; without normalizing, a wrapper-dir entry
-      // spelled with one escapes self-exclusion and the wrapper tail-loops on itself.
-      // Why: `if "%var:~-1%"=="\\"` breaks cmd's parser, so the trailing separator is stripped
-      // with a sentinel instead. Verified on Windows.
-      // Why: compared against a variable holding the separator — a literal backslash before the
-      // closing quote breaks cmd's parser, and a sentinel would corrupt paths containing it.
-      // The value matters: any other character silently un-pins the trailing-separator fix.
+      // spelled with one escapes self-exclusion and the wrapper tail-loops on itself. The
+      // separator lives in a variable because a literal backslash before the closing quote
+      // breaks cmd's parser, and a sentinel character would corrupt paths containing it.
       expect(cmd).toContain('set "orca_sep=\\"')
+      // Why: a captured ORCA_REAL_* may be relative, and both the existence test and the
+      // invocation resolve it against the cwd.
+      expect(cmd).toContain('if defined orca_real call :orca_check_rooted "%orca_real%"')
+      expect(cmd).toContain('if defined orca_real if not defined orca_rooted set "orca_real="')
+      // Why: the exported PATH is inherited by the real command; a relative entry left in it lets
+      // the cwd select the tools that command spawns.
+      expectOrdered(cmd, ':orca_append_path', 'if not defined orca_rooted exit /b')
+      // Why: orca_sep is compared against before the legacy dir is normalized; defining it later
+      // made that strip silently no-op and left the legacy dir on PATH.
+      expectOrdered(cmd, 'set "orca_sep=', 'if "%orca_legacy_norm:~-1%."')
+      // Why: %orca_sep% expands before the line is parsed, so `=="%orca_sep%"` becomes `=="\"` —
+      // the literal trap the variable exists to avoid. Both sides must carry the trailing dot.
+      expect(cmd).not.toContain('=="%orca_sep%"')
       // Why: nothing else asserts the *reject* path, so deleting it would reopen the cwd hijack
       // while every accept-path assertion stayed green.
-      expect(cmd).toMatch(/goto orca_candidate_rooted\r?\nexit \/b/)
-      expect(cmd).toContain('if "%orca_candidate_dir:~-1%"=="%orca_sep%"')
+      expectOrdered(cmd, ':orca_try_candidate', 'call :orca_check_rooted "%~1"')
+      expect(cmd).toContain('if not defined orca_rooted exit /b')
+      expect(cmd).toContain('if "%orca_candidate_dir:~-1%."=="%orca_sep%."')
       expect(cmd).not.toContain(':\\#=#%')
       // A candidate inside the wrapper directory must still be rejected, compared against the
       // cached wrapper dir because %~dp0 is rebound inside a CALL.
@@ -143,8 +173,8 @@ describe('legacy terminal shim neutralization', () => {
       // Why: the rooted-path test must not shell out — an external tool would itself be
       // resolved from the cwd, reintroducing the hijack.
       expect(cmd).not.toContain('findstr')
-      expect(cmd).toContain('if "%orca_candidate:~1,2%"==":\\" goto orca_candidate_rooted')
-      expect(cmd).toContain('if "%orca_candidate:~0,2%"=="\\\\" goto orca_candidate_rooted')
+      expect(cmd).toContain('if "%orca_probe:~1,2%"==":\\" set "orca_rooted=1"')
+      expect(cmd).toContain('if "%orca_probe:~0,2%"=="\\\\" set "orca_rooted=1"')
       // Why: these two guards are the only thing stopping an empty element reaching the cwd on
       // Windows; deleting either left every other assertion green.
       expect(cmd).toContain('if "%~1"=="" exit /b')
@@ -155,6 +185,8 @@ describe('legacy terminal shim neutralization', () => {
       // Why: the rooted check must reject drive-relative 'C:foo', which still resolves against
       // the cwd — so the IsPathRooted call must be gone, replaced by an explicit prefix match.
       expect(powershell).not.toContain('[IO.Path]::IsPathRooted(')
+      expect(powershell).toContain("$pathEntry -match '^([A-Za-z]:[\\\\/]|\\\\\\\\)'")
+      expect(powershell).toContain("$realCommand -notmatch '^([A-Za-z]:[\\\\/]|\\\\\\\\)'")
       // Why the full pattern, not a prefix: `^([A-Za-z]:|\\\\)` also starts with this and would
       // accept drive-relative `C:foo`, which still resolves against the cwd on that drive.
       expect(powershell).toContain("-notmatch '^([A-Za-z]:[\\\\/]|\\\\\\\\)'")
@@ -169,9 +201,14 @@ describe('legacy terminal shim neutralization', () => {
         "$dir.TrimEnd('\\'), [StringComparison]::OrdinalIgnoreCase) }) { continue }"
       )
       // Why: `C:/Program Files/Git/cmd` style entries are legitimate and must stay accepted.
-      expect(cmd).toContain('if "%orca_candidate:~1,2%"==":/" goto orca_candidate_rooted')
+      expect(cmd).toContain('if "%orca_probe:~1,2%"==":/" set "orca_rooted=1"')
       // Why: the legacy-dir compare needs the same trailing-separator strip as its twins.
-      expect(cmd).toContain('if "%orca_legacy_norm:~-1%"=="%orca_sep%"')
+      expect(cmd).toContain('if "%orca_legacy_norm:~-1%."=="%orca_sep%."')
+      // Why: cmd expands a whole line before evaluating `if defined`, so this strip must live in
+      // a CALL body. Inline, it ran its substring syntax against an unset variable and mangled
+      // the line into a syntax error. Proven on Windows 11.
+      expect(cmd).toContain('if defined orca_legacy_wrapper_dir call :orca_normalize_legacy_dir')
+      expect(cmd).not.toContain('if defined orca_legacy_wrapper_dir for ')
       expect(powershell).toContain('if (-not $dir) { continue }')
       expect(powershell).toContain('Test-Path -LiteralPath $candidate -PathType Leaf')
     }
@@ -239,9 +276,9 @@ describe('legacy terminal shim neutralization', () => {
     writeFileSync(join(spaced, 'bash'), '#!/bin/sh\nexit 0\n', { mode: 0o755 })
 
     // A shebang cannot quote, so a path containing whitespace is unusable.
-    expect(resolvePosixTombstoneInterpreter(spaced, [], 'linux')).toBe('/usr/bin/env bash')
+    expect(resolvePosixTombstoneInterpreter(spaced, [], 'linux')).toBeNull()
     // X_OK is true for a directory; it still cannot be exec'd.
-    expect(resolvePosixTombstoneInterpreter(dirNamedBash, [], 'linux')).toBe('/usr/bin/env bash')
+    expect(resolvePosixTombstoneInterpreter(dirNamedBash, [], 'linux')).toBeNull()
   })
 
   itOnPosix('resolves the interpreter from absolute PATH entries only', () => {
@@ -267,7 +304,7 @@ describe('legacy terminal shim neutralization', () => {
     mkdirSync(cwdRelDir, { recursive: true })
     try {
       writeFileSync(join(cwdRelDir, 'bash'), '#!/bin/sh\nexit 0\n', { mode: 0o755 })
-      expect(resolvePosixTombstoneInterpreter(`.:${cwdRelName}`, [])).toBe('/usr/bin/env bash')
+      expect(resolvePosixTombstoneInterpreter(`.:${cwdRelName}`, [])).toBeNull()
     } finally {
       rmSync(cwdRelDir, { recursive: true, force: true })
     }
@@ -540,7 +577,7 @@ describe('legacy terminal shim neutralization', () => {
     // Why: `call :label && ...` is not valid cmd; the flag variable is what makes it work.
     expect(cmd).toContain('if defined orca_skip_entry exit /b')
     expect(cmd).not.toContain('call :orca_reject_legacy_dir &&')
-    expect(cmd).toContain('if "%orca_path_entry_dir:~-1%"=="%orca_sep%"')
+    expect(cmd).toContain('if "%orca_path_entry_dir:~-1%."=="%orca_sep%."')
 
     const powershell = readFileSync(join(win32Dir, 'git-wrapper.ps1'), 'utf8')
     expectOrdered(

--- a/src/main/pty/legacy-terminal-shim-dir.test.ts
+++ b/src/main/pty/legacy-terminal-shim-dir.test.ts
@@ -140,7 +140,7 @@ describe('legacy terminal shim neutralization', () => {
       const cmd = readFileSync(join(win32Dir, `${command}.cmd`), 'utf8')
       // No where.exe at all: it searches cwd first, so the wrapper walks the cleaned PATH.
       expect(cmd).not.toContain('where.exe')
-      expect(cmd).toContain('for %%P in ("%orca_clean_path:;=" "%") do call :orca_try_candidate')
+      expect(cmd).toContain('for %%P in ("%orca_clean_path:;=" "%") do (')
       expect(cmd).toContain(`if exist "%orca_candidate_dir%\\${command}.exe"`)
       // Why: %~f preserves a trailing separator; without normalizing, a wrapper-dir entry
       // spelled with one escapes self-exclusion and the wrapper tail-loops on itself. The
@@ -149,11 +149,20 @@ describe('legacy terminal shim neutralization', () => {
       expect(cmd).toContain('set "orca_sep=\\"')
       // Why: a captured ORCA_REAL_* may be relative, and both the existence test and the
       // invocation resolve it against the cwd.
-      expect(cmd).toContain('if defined orca_real call :orca_check_rooted "%orca_real%"')
+      expect(cmd).toContain('if defined orca_real call :orca_check_rooted')
       expect(cmd).toContain('if defined orca_real if not defined orca_rooted set "orca_real="')
       // Why: the exported PATH is inherited by the real command; a relative entry left in it lets
       // the cwd select the tools that command spawns.
       expectOrdered(cmd, ':orca_append_path', 'if not defined orca_rooted exit /b')
+      // Why: CALL re-expands its own command line, so path data passed as an argument gets a
+      // second round of percent expansion. A PATH entry holding a literal %CD% became the
+      // current directory before the rooted check saw it and the planted git.cmd ran (rc=66 on
+      // Windows 11). Every caller must hand the value over in a variable instead.
+      expect(cmd).not.toContain('call :orca_check_rooted "')
+      expect(cmd).not.toContain('call :orca_try_candidate "')
+      expect(cmd).not.toContain('call :orca_append_path "')
+      expect(cmd).not.toContain('%~1')
+      expect(cmd).toContain('set "orca_probe=%orca_entry%"\r\ncall :orca_check_rooted\r\n')
       // Why: orca_sep is compared against before the legacy dir is normalized; defining it later
       // made that strip silently no-op and left the legacy dir on PATH.
       expectOrdered(cmd, 'set "orca_sep=', 'if "%orca_legacy_norm:~-1%."')
@@ -162,7 +171,11 @@ describe('legacy terminal shim neutralization', () => {
       expect(cmd).not.toContain('=="%orca_sep%"')
       // Why: nothing else asserts the *reject* path, so deleting it would reopen the cwd hijack
       // while every accept-path assertion stayed green.
-      expectOrdered(cmd, ':orca_try_candidate', 'call :orca_check_rooted "%~1"')
+      expectOrdered(
+        cmd,
+        'call :orca_check_rooted\r\nif not defined orca_rooted exit /b',
+        'for %%G in ("%orca_entry%") do set "orca_candidate_dir='
+      )
       expect(cmd).toContain('if not defined orca_rooted exit /b')
       expect(cmd).toContain('if "%orca_candidate_dir:~-1%."=="%orca_sep%."')
       expect(cmd).not.toContain(':\\#=#%')
@@ -177,7 +190,7 @@ describe('legacy terminal shim neutralization', () => {
       expect(cmd).toContain('if "%orca_probe:~0,2%"=="\\\\" set "orca_rooted=1"')
       // Why: these two guards are the only thing stopping an empty element reaching the cwd on
       // Windows; deleting either left every other assertion green.
-      expect(cmd).toContain('if "%~1"=="" exit /b')
+      expect(cmd).toContain('if not defined orca_entry exit /b')
 
       const powershell = readFileSync(join(win32Dir, `${command}-wrapper.ps1`), 'utf8')
       expect(powershell).not.toContain('Get-Command')
@@ -571,7 +584,7 @@ describe('legacy terminal shim neutralization', () => {
     const cmd = readFileSync(join(win32Dir, 'git.cmd'), 'utf8')
     const cmdCapture = 'set "orca_legacy_wrapper_dir=%ORCA_ATTRIBUTION_SHIM_DIR%"'
     expectOrdered(cmd, cmdCapture, 'set "ORCA_ATTRIBUTION_SHIM_DIR="')
-    expect(cmd).toContain('for %%P in ("%PATH:;=" "%") do call :orca_append_path "%%~P"')
+    expect(cmd).toContain('for %%P in ("%PATH:;=" "%") do (')
     expect(cmd).toContain('if /I "%orca_path_entry_dir%"=="%orca_wrapper_dir%" exit /b')
     expect(cmd).toContain('if defined orca_legacy_wrapper_dir call :orca_reject_legacy_dir')
     // Why: `call :label && ...` is not valid cmd; the flag variable is what makes it work.

--- a/src/main/pty/legacy-terminal-shim-dir.test.ts
+++ b/src/main/pty/legacy-terminal-shim-dir.test.ts
@@ -13,6 +13,7 @@ import {
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as PosixTombstoneModule from './legacy-terminal-posix-tombstone'
 import {
   readVerifiedShebangInterpreter,
   resolvePosixTombstoneInterpreter
@@ -85,235 +86,6 @@ describe('legacy terminal shim neutralization', () => {
     const version = readFileSync(join(legacyRoot, 'VERSION'), 'utf8')
     expect(version).toBe('7-neutralized\n')
     expect(version.trim()).not.toBe('7')
-  })
-
-  it('rejects stale Windows real-command paths inside the wrapper directory', () => {
-    const userData = makeUserDataDir()
-    const win32Dir = join(userData, 'orca-terminal-attribution', 'win32')
-    mkdirSync(win32Dir, { recursive: true })
-
-    neutralizeLegacyTerminalShimDir(userData)
-
-    const cmd = readFileSync(join(win32Dir, 'git.cmd'), 'utf8')
-    expect(cmd).toContain(
-      'if defined orca_real for %%G in ("%orca_real%") do if /I "%%~dpG"=="%~dp0" set "orca_real="'
-    )
-    // Why: a captured path that no longer exists must be cleared, or the where.exe fallback below
-    // is skipped and the wrapper execs a missing binary.
-    expect(cmd).toContain('if defined orca_real if not exist "%orca_real%" set "orca_real="')
-    expectOrdered(cmd, 'if not exist "%orca_real%"', ':orca_try_candidate')
-    const powershell = readFileSync(join(win32Dir, 'git-wrapper.ps1'), 'utf8')
-    expect(powershell).toContain('[StringComparison]::OrdinalIgnoreCase')
-    expect(powershell).toContain('$realCommand = $null')
-    expectOrdered(
-      powershell,
-      '[StringComparison]::OrdinalIgnoreCase',
-      'Test-Path -LiteralPath $realCommand'
-    )
-  })
-
-  it('emits no percent expression inside a cmd rem comment', () => {
-    // Why: cmd expands variables inside rem, so a comment mentioning the working directory
-    // substitutes it into the comment text. Harmless at top level -- verified on Windows 11 that
-    // rem does not re-parse the result, so a cwd of `C:\\x&pwned&rem` executed nothing -- but rem
-    // treats separators differently inside a parenthesized block, and this script now has some.
-    const userData = makeUserDataDir()
-    const win32Dir = join(userData, 'orca-terminal-attribution', 'win32')
-    mkdirSync(win32Dir, { recursive: true })
-
-    neutralizeLegacyTerminalShimDir(userData)
-
-    for (const command of ['git', 'gh'] as const) {
-      const offending = readFileSync(join(win32Dir, `${command}.cmd`), 'utf8')
-        .split('\r\n')
-        .filter((line) => /^\s*rem\b/i.test(line) && line.includes('%'))
-      expect(offending, `rem comments with percent expressions: ${offending.join(' | ')}`).toEqual(
-        []
-      )
-    }
-  })
-
-  it('keeps the Windows wrappers ASCII-only', () => {
-    // Why: cmd.exe seeks through a batch file in bytes but advances by decoded character count,
-    // so a single multi-byte character shifts every following line. Two em dashes in comments
-    // made it drop the first four characters of every line and the wrapper died with "The
-    // syntax of the command is incorrect." Proven on Windows 11; no test caught it.
-    const userData = makeUserDataDir()
-    const win32Dir = join(userData, 'orca-terminal-attribution', 'win32')
-    mkdirSync(win32Dir, { recursive: true })
-
-    neutralizeLegacyTerminalShimDir(userData)
-
-    for (const name of ['git.cmd', 'gh.cmd', 'git-wrapper.ps1', 'gh-wrapper.ps1']) {
-      const contents = readFileSync(join(win32Dir, name), 'utf8')
-      const offending = [...contents].find((character) => character.charCodeAt(0) > 0x7f)
-      expect(offending, `${name} contains non-ASCII ${JSON.stringify(offending)}`).toBeUndefined()
-      expect(Buffer.byteLength(contents, 'utf8')).toBe(contents.length)
-    }
-  })
-
-  it('resolves Windows fallbacks against PATH only, never the current directory', () => {
-    // Why (STA-4169): bare `where.exe git.exe` searches cwd before PATH, so a repository-local
-    // git.exe/gh.exe could be executed with the user's arguments.
-    const userData = makeUserDataDir()
-    const win32Dir = join(userData, 'orca-terminal-attribution', 'win32')
-    mkdirSync(win32Dir, { recursive: true })
-
-    neutralizeLegacyTerminalShimDir(userData)
-
-    for (const command of ['git', 'gh'] as const) {
-      const cmd = readFileSync(join(win32Dir, `${command}.cmd`), 'utf8')
-      // No where.exe at all: it searches cwd first, so the wrapper walks the cleaned PATH.
-      expect(cmd).not.toContain('where.exe')
-      expect(cmd).toContain('for %%P in ("%orca_clean_path:;=" "%") do (')
-      expect(cmd).toContain(`if exist "%orca_candidate_dir%\\${command}.exe"`)
-      // Why: %~f preserves a trailing separator; without normalizing, a wrapper-dir entry
-      // spelled with one escapes self-exclusion and the wrapper tail-loops on itself. The
-      // separator lives in a variable because a literal backslash before the closing quote
-      // breaks cmd's parser, and a sentinel character would corrupt paths containing it.
-      expect(cmd).toContain('set "orca_sep=\\"')
-      // Why: bare setlocal inherits the caller's delayed-expansion state. Under a parent shell
-      // with /V:ON, a literal !CD! PATH entry became the cwd and ran a planted git.cmd (exit 66),
-      // and a legitimate directory containing ! stopped resolving (exit 127). Both on Windows 11.
-      expect(cmd).toContain('setlocal DisableDelayedExpansion')
-      expect(cmd).not.toContain('\r\nsetlocal\r\n')
-      // Why: a captured ORCA_REAL_* may be relative, and both the existence test and the
-      // invocation resolve it against the cwd.
-      expect(cmd).toContain('if defined orca_real call :orca_check_rooted')
-      expect(cmd).toContain('if defined orca_real if not defined orca_rooted set "orca_real="')
-      // Why: the exported PATH is inherited by the real command; a relative entry left in it lets
-      // the cwd select the tools that command spawns.
-      // Why the exact block, not an ordering pin: the first ':orca_append_path' in the file is
-      // the top-level CALL, and the first 'if not defined orca_rooted' belongs to a different
-      // subroutine, so an ordering pin stayed green with this subroutine's guard deleted.
-      expect(cmd).toContain(':orca_append_path\r\nif not defined orca_entry exit /b\r\n')
-      expect(cmd).toContain(
-        'set "orca_probe=%orca_entry%"\r\ncall :orca_check_rooted\r\nif not defined orca_rooted exit /b\r\nfor %%G in ("%orca_entry%") do set "orca_path_entry_dir=%%~fG"'
-      )
-      // Why: CALL re-expands its own command line, so path data passed as an argument gets a
-      // second round of percent expansion. A PATH entry holding a literal %CD% became the
-      // current directory before the rooted check saw it and the planted git.cmd ran (rc=66 on
-      // Windows 11). Every caller must hand the value over in a variable instead.
-      expect(cmd).not.toContain('call :orca_check_rooted "')
-      expect(cmd).not.toContain('call :orca_try_candidate "')
-      expect(cmd).not.toContain('call :orca_append_path "')
-      expect(cmd).not.toContain('%~1')
-      expect(cmd).toContain('set "orca_probe=%orca_entry%"\r\ncall :orca_check_rooted\r\n')
-      // Why: orca_sep is compared against before the legacy dir is normalized; defining it later
-      // made that strip silently no-op and left the legacy dir on PATH.
-      expectOrdered(cmd, 'set "orca_sep=', 'if "%orca_legacy_norm:~-1%."')
-      // Why: %orca_sep% expands before the line is parsed, so `=="%orca_sep%"` becomes `=="\"` —
-      // the literal trap the variable exists to avoid. Both sides must carry the trailing dot.
-      expect(cmd).not.toContain('=="%orca_sep%"')
-      // Why: nothing else asserts the *reject* path, so deleting it would reopen the cwd hijack
-      // while every accept-path assertion stayed green.
-      expectOrdered(
-        cmd,
-        'call :orca_check_rooted\r\nif not defined orca_rooted exit /b',
-        'for %%G in ("%orca_entry%") do set "orca_candidate_dir='
-      )
-      expect(cmd).toContain('if not defined orca_rooted exit /b')
-      expect(cmd).toContain('if "%orca_candidate_dir:~-1%."=="%orca_sep%."')
-      expect(cmd).not.toContain(':\\#=#%')
-      // A candidate inside the wrapper directory must still be rejected, compared against the
-      // cached wrapper dir because %~dp0 is rebound inside a CALL.
-      expect(cmd).toContain('if /I "%orca_candidate_dir%\\"=="%orca_wrapper_dir%" exit /b')
-      // Relative entries resolve against the cwd, so they must be rejected like empty ones.
-      // Why: the rooted-path test must not shell out — an external tool would itself be
-      // resolved from the cwd, reintroducing the hijack.
-      expect(cmd).not.toContain('findstr')
-      expect(cmd).toContain('if "%orca_probe:~1,2%"==":\\" set "orca_rooted=1"')
-      expect(cmd).toContain('if "%orca_probe:~0,2%"=="\\\\" set "orca_rooted=1"')
-      // Why: these two guards are the only thing stopping an empty element reaching the cwd on
-      // Windows; deleting either left every other assertion green.
-      expect(cmd).toContain('if not defined orca_entry exit /b')
-
-      const powershell = readFileSync(join(win32Dir, `${command}-wrapper.ps1`), 'utf8')
-      expect(powershell).not.toContain('Get-Command')
-      expect(powershell).toContain("($env:PATH -split ';')")
-      // Why: the rooted check must reject drive-relative 'C:foo', which still resolves against
-      // the cwd — so the IsPathRooted call must be gone, replaced by an explicit prefix match.
-      expect(powershell).not.toContain('[IO.Path]::IsPathRooted(')
-      expect(powershell).toContain("$pathEntry -match '^([A-Za-z]:[\\\\/]|\\\\\\\\)'")
-      expect(powershell).toContain("$realCommand -notmatch '^([A-Za-z]:[\\\\/]|\\\\\\\\)'")
-      // Why the full pattern, not a prefix: `^([A-Za-z]:|\\\\)` also starts with this and would
-      // accept drive-relative `C:foo`, which still resolves against the cwd on that drive.
-      expect(powershell).toContain("-notmatch '^([A-Za-z]:[\\\\/]|\\\\\\\\)'")
-      // Why: trailing-separator normalization is what makes wrapper self-exclusion work; every
-      // one of these survived mutation with the suite green.
-      expect(powershell).toContain("ForEach-Object { $_.TrimEnd('\\') }")
-      expect(powershell).toContain("$pathEntry.TrimEnd('\\')")
-      expect(powershell).toContain("$dir.TrimEnd('\\')")
-      expect(powershell).toContain("$capturedDir.TrimEnd('\\')")
-      // Why: the fallback loop must skip wrapper dirs, or the wrapper can resolve to itself.
-      expect(powershell).toContain(
-        "$dir.TrimEnd('\\'), [StringComparison]::OrdinalIgnoreCase) }) { continue }"
-      )
-      // Why: `C:/Program Files/Git/cmd` style entries are legitimate and must stay accepted.
-      expect(cmd).toContain('if "%orca_probe:~1,2%"==":/" set "orca_rooted=1"')
-      // Why: the legacy-dir compare needs the same trailing-separator strip as its twins.
-      expect(cmd).toContain('if "%orca_legacy_norm:~-1%."=="%orca_sep%."')
-      // Why: cmd expands a whole line before evaluating `if defined`, so this strip must live in
-      // a CALL body. Inline, it ran its substring syntax against an unset variable and mangled
-      // the line into a syntax error. Proven on Windows 11.
-      expect(cmd).toContain('if defined orca_legacy_wrapper_dir call :orca_normalize_legacy_dir')
-      expect(cmd).not.toContain('if defined orca_legacy_wrapper_dir for ')
-      expect(powershell).toContain('if (-not $dir) { continue }')
-      expect(powershell).toContain('Test-Path -LiteralPath $candidate -PathType Leaf')
-    }
-  })
-
-  it('emits Windows wrappers with CRLF line endings', () => {
-    // Why: cmd resolves `call :label` by byte offset and that lookup is unreliable in LF-only
-    // files — the same script worked at 2.4 KB and failed with "cannot find the batch label"
-    // once it grew past ~3.7 KB. Verified on Windows.
-    const userData = makeUserDataDir()
-    const win32Dir = join(userData, 'orca-terminal-attribution', 'win32')
-    mkdirSync(win32Dir, { recursive: true })
-
-    neutralizeLegacyTerminalShimDir(userData)
-
-    for (const file of ['git.cmd', 'gh.cmd', 'git-wrapper.ps1', 'gh-wrapper.ps1']) {
-      const body = readFileSync(join(win32Dir, file), 'utf8')
-      expect(body, file).toContain('\r\n')
-      expect(body.replaceAll('\r\n', ''), file).not.toContain('\n')
-    }
-  })
-
-  it('guards both cmd PATH walks so an empty variable cannot break parsing', () => {
-    // Why: `%VAR:;=" "%` on an empty variable leaves an unbalanced quote that desynchronizes
-    // cmd parsing for the rest of the file, turning the not-found branch into
-    // `1>&2 was unexpected at this time.` Reproduced on Windows before this guard.
-    const userData = makeUserDataDir()
-    const win32Dir = join(userData, 'orca-terminal-attribution', 'win32')
-    mkdirSync(win32Dir, { recursive: true })
-
-    neutralizeLegacyTerminalShimDir(userData)
-
-    for (const command of ['git', 'gh'] as const) {
-      const cmd = readFileSync(join(win32Dir, `${command}.cmd`), 'utf8')
-      expect(cmd).toContain('if not defined PATH goto :orca_path_walked')
-      expect(cmd).toContain('if not defined orca_clean_path goto :orca_candidates_walked')
-      for (const [guard, loop] of [
-        ['if not defined PATH goto :orca_path_walked', 'for %%P in ("%PATH:;='],
-        [
-          'if not defined orca_clean_path goto :orca_candidates_walked',
-          'for %%P in ("%orca_clean_path:;='
-        ]
-      ] as const) {
-        expectOrdered(cmd, guard, loop)
-      }
-    }
-  })
-
-  it('never bakes an ambient interpreter lookup on Windows', () => {
-    // Why: the POSIX tombstone is written on Windows too (Git Bash and WSL panes run it), but no
-    // absolute candidate exists to a Windows process and PATH there is ';'-separated, so the
-    // search cannot succeed — without this the fallback reopened the interpreter hijack.
-    expect(resolvePosixTombstoneInterpreter(undefined, [], 'win32')).toBe('/bin/bash')
-    expect(resolvePosixTombstoneInterpreter('C:\\Git\\bin;C:\\Windows', [], 'win32')).toBe(
-      '/bin/bash'
-    )
   })
 
   itOnPosix('rejects interpreter candidates that are unusable in a shebang', () => {
@@ -507,6 +279,11 @@ describe('legacy terminal shim neutralization', () => {
     writeFileSync(wrapper, '#!/usr/bin/env bash\nexit 0\n', { mode: 0o755 })
     expect(readVerifiedShebangInterpreter(wrapper)).toBeNull()
 
+    // Why /bin/sh: it exists on every POSIX host, so this kills the mutant deterministically.
+    // The rendered body needs BASH_SOURCE, [[ and local, so any other shell exits 1 at runtime.
+    writeFileSync(wrapper, '#!/bin/sh\nexit 0\n', { mode: 0o755 })
+    expect(readVerifiedShebangInterpreter(wrapper)).toBeNull()
+
     writeFileSync(wrapper, '#!bash\nexit 0\n', { mode: 0o755 })
     expect(readVerifiedShebangInterpreter(wrapper)).toBeNull()
 
@@ -517,6 +294,42 @@ describe('legacy terminal shim neutralization', () => {
     expect(readVerifiedShebangInterpreter(wrapper)).toBeNull()
 
     expect(readVerifiedShebangInterpreter(join(userData, 'absent'))).toBeNull()
+  })
+
+  itOnPosix('keeps the POSIX wrapper on a host where no absolute bash resolves', async () => {
+    // Why through neutralizeLegacyTerminalShimDir, not the resolver alone: CI hosts always have
+    // /bin/bash, so the primary branch is always taken and deleting the fallback wiring left the
+    // suite green. Forcing the resolver to null is the only way to reach it.
+    vi.resetModules()
+    vi.doMock('./legacy-terminal-posix-tombstone', async () => {
+      const actual = await vi.importActual<typeof PosixTombstoneModule>(
+        './legacy-terminal-posix-tombstone'
+      )
+      return { ...actual, resolvePosixTombstoneInterpreter: () => null }
+    })
+    try {
+      const shimDir = await import('./legacy-terminal-shim-dir')
+      shimDir.__resetLegacyTerminalShimNeutralizationForTests()
+      const userData = makeUserDataDir()
+      const posixDir = join(userData, 'orca-terminal-attribution', 'posix')
+      mkdirSync(posixDir, { recursive: true })
+      writeFileSync(join(posixDir, 'git'), '#!/bin/bash\nlegacy attribution wrapper\n', {
+        mode: 0o755
+      })
+      // Why gh differs: its wrapper carries no reusable shebang, so it must still be deleted
+      // rather than left executing the retired attribution logic.
+      writeFileSync(join(posixDir, 'gh'), '#!/usr/bin/env bash\nlegacy\n', { mode: 0o755 })
+
+      shimDir.neutralizeLegacyTerminalShimDir(userData)
+
+      const git = readFileSync(join(posixDir, 'git'), 'utf8')
+      expect(git.split('\n')[0]).toBe('#!/bin/bash')
+      expect(git).toContain('Orca compatibility wrapper could not locate')
+      expect(existsSync(join(posixDir, 'gh'))).toBe(false)
+    } finally {
+      vi.doUnmock('./legacy-terminal-posix-tombstone')
+      vi.resetModules()
+    }
   })
 
   it('treats a shim directory reached through .. as a shim PATH entry', () => {

--- a/src/main/pty/legacy-terminal-shim-dir.test.ts
+++ b/src/main/pty/legacy-terminal-shim-dir.test.ts
@@ -332,19 +332,36 @@ describe('legacy terminal shim neutralization', () => {
     }
   })
 
-  it('treats a shim directory reached through .. as a shim PATH entry', () => {
-    // Why: a plain suffix test missed `<root>/orca-terminal-attribution/posix/../posix`, so the
-    // entry survived the scrub and the shim stayed reachable.
+  it('does not collapse .. when classifying a shim PATH entry', () => {
+    // Why deliberately not collapsed: collapsing `..` textually is not resolving it. If
+    // `<shim>/posix` is a symlink, `<shim>/posix/../posix` lands somewhere else, and classifying
+    // it as the shim directory deletes a legitimate PATH entry and leaves git unresolvable.
+    // Resolving for real is not available here either: this env is also built for remote and WSL
+    // panes whose paths do not exist on the local filesystem.
     expect(isLegacyTerminalShimPathEntry('/tmp/old/orca-terminal-attribution/posix/../posix')).toBe(
-      true
-    )
-    expect(isLegacyTerminalShimPathEntry('/tmp/old/orca-terminal-attribution/win32/../win32')).toBe(
-      true
-    )
-    expect(isLegacyTerminalShimPathEntry('/tmp/old/orca-terminal-attribution/posix/../other')).toBe(
       false
     )
+    expect(isLegacyTerminalShimPathEntry('/tmp/old/orca-terminal-attribution/posix')).toBe(true)
+    expect(isLegacyTerminalShimPathEntry('/tmp/old/orca-terminal-attribution/win32//')).toBe(true)
     expect(isLegacyTerminalShimPathEntry('/usr/local/bin')).toBe(false)
+  })
+
+  it('strips a captured shim directory spelled with repeated separators', () => {
+    // Why: pathEntrySpellings can only enumerate one added separator, so an entry repeating it
+    // survived the literal removal and kept the captured directory on PATH.
+    const posixEnv = {
+      PATH: '/custom/elsewhere///:/usr/bin',
+      ORCA_ATTRIBUTION_SHIM_DIR: '/custom/elsewhere'
+    }
+    stripLegacyTerminalShimEnv(posixEnv, 'linux')
+    expect(posixEnv.PATH).toBe('/usr/bin')
+
+    const windowsEnv = {
+      Path: 'C:\\Custom\\Else\\\\;C:\\Windows',
+      ORCA_ATTRIBUTION_SHIM_DIR: 'C:\\Custom\\Else'
+    }
+    stripLegacyTerminalShimEnv(windowsEnv, 'win32')
+    expect(windowsEnv.Path).toBe('C:\\Windows')
   })
 
   itOnPosix('does not fall back to the cwd when every PATH entry is filtered out', () => {

--- a/src/main/pty/legacy-terminal-shim-dir.test.ts
+++ b/src/main/pty/legacy-terminal-shim-dir.test.ts
@@ -13,9 +13,13 @@ import {
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { resolvePosixTombstoneInterpreter } from './legacy-terminal-posix-tombstone'
+import {
+  readVerifiedShebangInterpreter,
+  resolvePosixTombstoneInterpreter
+} from './legacy-terminal-posix-tombstone'
 import {
   __resetLegacyTerminalShimNeutralizationForTests,
+  isLegacyTerminalShimPathEntry,
   neutralizeLegacyTerminalShimDir,
   stripLegacyTerminalShimEnv
 } from './legacy-terminal-shim-dir'
@@ -168,13 +172,24 @@ describe('legacy terminal shim neutralization', () => {
       // separator lives in a variable because a literal backslash before the closing quote
       // breaks cmd's parser, and a sentinel character would corrupt paths containing it.
       expect(cmd).toContain('set "orca_sep=\\"')
+      // Why: bare setlocal inherits the caller's delayed-expansion state. Under a parent shell
+      // with /V:ON, a literal !CD! PATH entry became the cwd and ran a planted git.cmd (exit 66),
+      // and a legitimate directory containing ! stopped resolving (exit 127). Both on Windows 11.
+      expect(cmd).toContain('setlocal DisableDelayedExpansion')
+      expect(cmd).not.toContain('\r\nsetlocal\r\n')
       // Why: a captured ORCA_REAL_* may be relative, and both the existence test and the
       // invocation resolve it against the cwd.
       expect(cmd).toContain('if defined orca_real call :orca_check_rooted')
       expect(cmd).toContain('if defined orca_real if not defined orca_rooted set "orca_real="')
       // Why: the exported PATH is inherited by the real command; a relative entry left in it lets
       // the cwd select the tools that command spawns.
-      expectOrdered(cmd, ':orca_append_path', 'if not defined orca_rooted exit /b')
+      // Why the exact block, not an ordering pin: the first ':orca_append_path' in the file is
+      // the top-level CALL, and the first 'if not defined orca_rooted' belongs to a different
+      // subroutine, so an ordering pin stayed green with this subroutine's guard deleted.
+      expect(cmd).toContain(':orca_append_path\r\nif not defined orca_entry exit /b\r\n')
+      expect(cmd).toContain(
+        'set "orca_probe=%orca_entry%"\r\ncall :orca_check_rooted\r\nif not defined orca_rooted exit /b\r\nfor %%G in ("%orca_entry%") do set "orca_path_entry_dir=%%~fG"'
+      )
       // Why: CALL re-expands its own command line, so path data passed as an argument gets a
       // second round of percent expansion. A PATH entry holding a literal %CD% became the
       // current directory before the rooted check saw it and the planted git.cmd ran (rc=66 on
@@ -441,6 +456,82 @@ describe('legacy terminal shim neutralization', () => {
 
     expect(run.stdout).toContain('REAL')
     expect(run.stdout).not.toContain('HOSTILE')
+  })
+
+  itOnPosix('rejects the legacy shim directory reached by a different spelling', () => {
+    // Why: the legacy-dir compare was lexical while the self-compare used -ef, so a PATH entry
+    // spelled `<legacy>/../<legacy>` or reached through a symlink named the same directory but
+    // survived the filter, and the still-live attribution wrapper won the lookup.
+    const userData = makeUserDataDir()
+    const posixDir = join(userData, 'orca-terminal-attribution', 'posix')
+    const legacyDir = join(userData, 'legacy-shim')
+    const realBin = join(userData, 'real-bin')
+    for (const dir of [posixDir, legacyDir, realBin]) {
+      mkdirSync(dir, { recursive: true })
+    }
+    writeFileSync(join(posixDir, 'git'), 'legacy attribution wrapper')
+
+    neutralizeLegacyTerminalShimDir(userData)
+
+    writeFileSync(join(legacyDir, 'git'), "#!/bin/bash\nprintf 'HOSTILE\\n'\n", { mode: 0o755 })
+    writeFileSync(join(realBin, 'git'), "#!/bin/bash\nprintf 'REAL\\n'\n", { mode: 0o755 })
+    const legacyLink = join(userData, 'legacy-link')
+    symlinkSync(legacyDir, legacyLink)
+
+    for (const spelling of [join(legacyDir, '..', 'legacy-shim'), legacyLink]) {
+      const run = spawnSync(join(posixDir, 'git'), ['--version'], {
+        env: {
+          ...process.env,
+          ORCA_ATTRIBUTION_SHIM_DIR: legacyDir,
+          PATH: `${spelling}:${realBin}:/usr/bin:/bin`
+        },
+        encoding: 'utf8',
+        timeout: 20_000
+      })
+      expect(run.stdout, `spelling ${spelling}`).toContain('REAL')
+      expect(run.stdout, `spelling ${spelling}`).not.toContain('HOSTILE')
+    }
+  })
+
+  itOnPosix('reuses the replaced wrapper shebang when no absolute bash is verifiable', () => {
+    // Why: deleting the wrapper strands a shell that already hashed the path -- it reports 127
+    // rather than falling through to PATH. The file being replaced ran on this host, so its own
+    // shebang names an interpreter known to work here.
+    const userData = makeUserDataDir()
+    const wrapper = join(userData, 'git')
+    writeFileSync(wrapper, '#!/bin/bash\nexit 0\n', { mode: 0o755 })
+    expect(readVerifiedShebangInterpreter(wrapper)).toBe('/bin/bash')
+
+    // Why: `env` is absolute but defers the lookup to PATH, which is the cwd exposure this exists
+    // to close. Accepting it would silently reinstate the hijack the null branch prevents.
+    writeFileSync(wrapper, '#!/usr/bin/env bash\nexit 0\n', { mode: 0o755 })
+    expect(readVerifiedShebangInterpreter(wrapper)).toBeNull()
+
+    writeFileSync(wrapper, '#!bash\nexit 0\n', { mode: 0o755 })
+    expect(readVerifiedShebangInterpreter(wrapper)).toBeNull()
+
+    writeFileSync(wrapper, '#!/nonexistent/bash\nexit 0\n', { mode: 0o755 })
+    expect(readVerifiedShebangInterpreter(wrapper)).toBeNull()
+
+    writeFileSync(wrapper, 'no shebang at all\n', { mode: 0o755 })
+    expect(readVerifiedShebangInterpreter(wrapper)).toBeNull()
+
+    expect(readVerifiedShebangInterpreter(join(userData, 'absent'))).toBeNull()
+  })
+
+  it('treats a shim directory reached through .. as a shim PATH entry', () => {
+    // Why: a plain suffix test missed `<root>/orca-terminal-attribution/posix/../posix`, so the
+    // entry survived the scrub and the shim stayed reachable.
+    expect(isLegacyTerminalShimPathEntry('/tmp/old/orca-terminal-attribution/posix/../posix')).toBe(
+      true
+    )
+    expect(isLegacyTerminalShimPathEntry('/tmp/old/orca-terminal-attribution/win32/../win32')).toBe(
+      true
+    )
+    expect(isLegacyTerminalShimPathEntry('/tmp/old/orca-terminal-attribution/posix/../other')).toBe(
+      false
+    )
+    expect(isLegacyTerminalShimPathEntry('/usr/local/bin')).toBe(false)
   })
 
   itOnPosix('does not fall back to the cwd when every PATH entry is filtered out', () => {

--- a/src/main/pty/legacy-terminal-shim-dir.test.ts
+++ b/src/main/pty/legacy-terminal-shim-dir.test.ts
@@ -108,6 +108,27 @@ describe('legacy terminal shim neutralization', () => {
     )
   })
 
+  it('emits no percent expression inside a cmd rem comment', () => {
+    // Why: cmd expands variables inside rem, so a comment mentioning the working directory
+    // substitutes it into the comment text. Harmless at top level -- verified on Windows 11 that
+    // rem does not re-parse the result, so a cwd of `C:\\x&pwned&rem` executed nothing -- but rem
+    // treats separators differently inside a parenthesized block, and this script now has some.
+    const userData = makeUserDataDir()
+    const win32Dir = join(userData, 'orca-terminal-attribution', 'win32')
+    mkdirSync(win32Dir, { recursive: true })
+
+    neutralizeLegacyTerminalShimDir(userData)
+
+    for (const command of ['git', 'gh'] as const) {
+      const offending = readFileSync(join(win32Dir, `${command}.cmd`), 'utf8')
+        .split('\r\n')
+        .filter((line) => /^\s*rem\b/i.test(line) && line.includes('%'))
+      expect(offending, `rem comments with percent expressions: ${offending.join(' | ')}`).toEqual(
+        []
+      )
+    }
+  })
+
   it('keeps the Windows wrappers ASCII-only', () => {
     // Why: cmd.exe seeks through a batch file in bytes but advances by decoded character count,
     // so a single multi-byte character shifts every following line. Two em dashes in comments

--- a/src/main/pty/legacy-terminal-shim-dir.ts
+++ b/src/main/pty/legacy-terminal-shim-dir.ts
@@ -1,5 +1,5 @@
 import { chmodSync, existsSync, mkdirSync, renameSync, rmSync, writeFileSync } from 'node:fs'
-import { join, normalize } from 'node:path'
+import { join } from 'node:path'
 import {
   readVerifiedShebangInterpreter,
   renderLegacyTerminalPosixTombstone,
@@ -146,7 +146,7 @@ function writeFileAtomically(filePath: string, contents: string, mode: number): 
 // literal compare itself has to stay: a shim path may contain the PATH delimiter, which splitting
 // would fragment.
 function pathEntrySpellings(dir: string, windows: boolean): string[] {
-  const base = dir.replace(/[\\/]+$/, '')
+  const base = stripTrailingSeparators(dir)
   if (!base) {
     return [dir]
   }
@@ -157,18 +157,38 @@ function pathEntrySpellings(dir: string, windows: boolean): string[] {
   return [...spellings]
 }
 
+// Why purely lexical, and why `..` is deliberately not collapsed: collapsing it textually is not
+// the same as resolving it. If `<shim>/posix` is a symlink, `<shim>/posix/../posix` resolves
+// somewhere else entirely, and treating it as the shim directory deletes a legitimate PATH entry
+// and leaves git unresolvable. Resolving for real is not an option either: this env is also built
+// for remote and WSL panes, where these paths do not name anything on the local filesystem.
+// A `..` spelling that does slip through costs nothing at runtime -- the directory now holds the
+// pass-through tombstone, and the tombstone excludes its own directory by -ef, so the lookup still
+// reaches the real git.
 export function isLegacyTerminalShimPathEntry(entry: string): boolean {
-  // Why normalize first: a `.../orca-terminal-attribution/posix/../posix` spelling names the shim
-  // directory but fails a plain suffix test, so the entry survived the scrub and the shim stayed
-  // reachable. normalize collapses `..` textually, which is what a suffix test needs.
-  const normalized = normalize(entry.replaceAll('\\', '/'))
-    .replaceAll('\\', '/')
-    .replace(/\/+$/, '')
-    .toLowerCase()
+  const normalized = stripTrailingSeparators(entry.replaceAll('\\', '/')).toLowerCase()
   return (
     normalized.endsWith(`/${LEGACY_SHIM_ROOT_DIR}/posix`) ||
     normalized.endsWith(`/${LEGACY_SHIM_ROOT_DIR}/win32`)
   )
+}
+
+// Why: `pathEntrySpellings` can only enumerate one added separator, so an entry repeating it
+// survived the literal removal. Comparing separator-stripped forms covers any number of them.
+function stripTrailingSeparators(value: string): string {
+  return value.replace(/[\\/]+$/, '')
+}
+
+function namesCapturedShimDir(entry: string, shimDirs: string[], windows: boolean): boolean {
+  const candidate = stripTrailingSeparators(entry)
+  return shimDirs.some((shimDir) => {
+    const target = stripTrailingSeparators(shimDir)
+    return target
+      ? windows
+        ? candidate.toLowerCase() === target.toLowerCase()
+        : candidate === target
+      : false
+  })
 }
 
 export function stripLegacyTerminalShimEnv(
@@ -210,7 +230,12 @@ export function stripLegacyTerminalShimEnv(
     )
     const cleaned = withoutExplicitDirs
       .split(delimiter)
-      .filter((entry) => entry && !isLegacyTerminalShimPathEntry(entry))
+      .filter(
+        (entry) =>
+          entry &&
+          !isLegacyTerminalShimPathEntry(entry) &&
+          !namesCapturedShimDir(entry, explicitShimDirs, windows)
+      )
       .join(delimiter)
     if (cleaned) {
       env[pathKey] = cleaned

--- a/src/main/pty/legacy-terminal-shim-dir.ts
+++ b/src/main/pty/legacy-terminal-shim-dir.ts
@@ -126,6 +126,22 @@ function writeFileAtomically(filePath: string, contents: string, mode: number): 
   }
 }
 
+// Why: the captured directory and the PATH entry naming it can differ by a trailing separator (or
+// its slash style on Windows). A literal compare missed that and left the shim dir on PATH. The
+// literal compare itself has to stay: a shim path may contain the PATH delimiter, which splitting
+// would fragment.
+function pathEntrySpellings(dir: string, windows: boolean): string[] {
+  const base = dir.replace(/[\\/]+$/, '')
+  if (!base) {
+    return [dir]
+  }
+  const spellings = new Set<string>([dir, base, `${base}/`])
+  if (windows) {
+    spellings.add(`${base}\\`)
+  }
+  return [...spellings]
+}
+
 export function isLegacyTerminalShimPathEntry(entry: string): boolean {
   const normalized = entry.replaceAll('\\', '/').replace(/\/+$/, '').toLowerCase()
   return (
@@ -164,7 +180,11 @@ export function stripLegacyTerminalShimEnv(
       continue
     }
     const withoutExplicitDirs = explicitShimDirs.reduce(
-      (pathValue, shimDir) => removeLiteralPathEntry(pathValue, shimDir, delimiter, windows),
+      (pathValue, shimDir) =>
+        pathEntrySpellings(shimDir, windows).reduce(
+          (value, spelling) => removeLiteralPathEntry(value, spelling, delimiter, windows),
+          pathValue
+        ),
       current
     )
     const cleaned = withoutExplicitDirs

--- a/src/main/pty/legacy-terminal-shim-dir.ts
+++ b/src/main/pty/legacy-terminal-shim-dir.ts
@@ -146,7 +146,7 @@ function writeFileAtomically(filePath: string, contents: string, mode: number): 
 // literal compare itself has to stay: a shim path may contain the PATH delimiter, which splitting
 // would fragment.
 function pathEntrySpellings(dir: string, windows: boolean): string[] {
-  const base = stripTrailingSeparators(dir)
+  const base = stripTrailingSeparators(dir, windows)
   if (!base) {
     return [dir]
   }
@@ -166,7 +166,10 @@ function pathEntrySpellings(dir: string, windows: boolean): string[] {
 // pass-through tombstone, and the tombstone excludes its own directory by -ef, so the lookup still
 // reaches the real git.
 export function isLegacyTerminalShimPathEntry(entry: string): boolean {
-  const normalized = stripTrailingSeparators(entry.replaceAll('\\', '/')).toLowerCase()
+  // Why `windows` unconditionally here: this classifier only ever matches Orca's own
+  // `orca-terminal-attribution/{posix,win32}` layout, and a Windows PATH can reach it through the
+  // remote env, so both slash styles must be understood regardless of the local platform.
+  const normalized = stripTrailingSeparators(entry.replaceAll('\\', '/'), true).toLowerCase()
   return (
     normalized.endsWith(`/${LEGACY_SHIM_ROOT_DIR}/posix`) ||
     normalized.endsWith(`/${LEGACY_SHIM_ROOT_DIR}/win32`)
@@ -175,14 +178,17 @@ export function isLegacyTerminalShimPathEntry(entry: string): boolean {
 
 // Why: `pathEntrySpellings` can only enumerate one added separator, so an entry repeating it
 // survived the literal removal. Comparing separator-stripped forms covers any number of them.
-function stripTrailingSeparators(value: string): string {
-  return value.replace(/[\\/]+$/, '')
+// Why platform-specific: a backslash is a legal filename character on POSIX, so treating it as a
+// separator there made `/tmp/captured\` and `/tmp/captured` compare equal and deleted a real
+// directory from PATH.
+function stripTrailingSeparators(value: string, windows: boolean): string {
+  return value.replace(windows ? /[\\/]+$/ : /\/+$/, '')
 }
 
 function namesCapturedShimDir(entry: string, shimDirs: string[], windows: boolean): boolean {
-  const candidate = stripTrailingSeparators(entry)
+  const candidate = stripTrailingSeparators(entry, windows)
   return shimDirs.some((shimDir) => {
-    const target = stripTrailingSeparators(shimDir)
+    const target = stripTrailingSeparators(shimDir, windows)
     return target
       ? windows
         ? candidate.toLowerCase() === target.toLowerCase()

--- a/src/main/pty/legacy-terminal-shim-dir.ts
+++ b/src/main/pty/legacy-terminal-shim-dir.ts
@@ -1,6 +1,7 @@
 import { chmodSync, existsSync, mkdirSync, renameSync, rmSync, writeFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { join, normalize } from 'node:path'
 import {
+  readVerifiedShebangInterpreter,
   renderLegacyTerminalPosixTombstone,
   resolvePosixTombstoneInterpreter
 } from './legacy-terminal-posix-tombstone'
@@ -98,19 +99,18 @@ function writeNeutralWrappers(rootDir: string): void {
   const win32Dir = join(rootDir, 'win32')
   mkdirSync(posixDir, { recursive: true })
   mkdirSync(win32Dir, { recursive: true })
-  // Why: with no absolute interpreter verifiable, a tombstone would need an ambient shebang and
-  // could take bash from the current directory. Deleting the legacy wrapper is the safe outcome:
-  // the command simply falls through to the real one on PATH.
+  // Why: a tombstone with no verifiable absolute interpreter would need an ambient shebang and
+  // could take bash from the current directory. Falling back to the shebang of the wrapper being
+  // replaced keeps a shell that has the path hashed working -- deleting the file strands it on
+  // 127 rather than falling through to PATH. Deleting is the last resort, not the first.
   const interpreter = resolvePosixTombstoneInterpreter()
   for (const command of ['git', 'gh'] as const) {
-    if (interpreter === null) {
-      rmSync(join(posixDir, command), { force: true })
+    const posixPath = join(posixDir, command)
+    const resolved = interpreter ?? readVerifiedShebangInterpreter(posixPath)
+    if (resolved === null) {
+      rmSync(posixPath, { force: true })
     } else {
-      writeFileAtomically(
-        join(posixDir, command),
-        renderLegacyTerminalPosixTombstone(command, interpreter),
-        0o755
-      )
+      writeFileAtomically(posixPath, renderLegacyTerminalPosixTombstone(command, resolved), 0o755)
     }
     writeFileAtomically(
       join(win32Dir, `${command}.cmd`),
@@ -158,7 +158,13 @@ function pathEntrySpellings(dir: string, windows: boolean): string[] {
 }
 
 export function isLegacyTerminalShimPathEntry(entry: string): boolean {
-  const normalized = entry.replaceAll('\\', '/').replace(/\/+$/, '').toLowerCase()
+  // Why normalize first: a `.../orca-terminal-attribution/posix/../posix` spelling names the shim
+  // directory but fails a plain suffix test, so the entry survived the scrub and the shim stayed
+  // reachable. normalize collapses `..` textually, which is what a suffix test needs.
+  const normalized = normalize(entry.replaceAll('\\', '/'))
+    .replaceAll('\\', '/')
+    .replace(/\/+$/, '')
+    .toLowerCase()
   return (
     normalized.endsWith(`/${LEGACY_SHIM_ROOT_DIR}/posix`) ||
     normalized.endsWith(`/${LEGACY_SHIM_ROOT_DIR}/win32`)

--- a/src/main/pty/legacy-terminal-shim-dir.ts
+++ b/src/main/pty/legacy-terminal-shim-dir.ts
@@ -1,6 +1,9 @@
 import { chmodSync, existsSync, mkdirSync, renameSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { renderLegacyTerminalPosixTombstone } from './legacy-terminal-posix-tombstone'
+import {
+  renderLegacyTerminalPosixTombstone,
+  resolvePosixTombstoneInterpreter
+} from './legacy-terminal-posix-tombstone'
 import {
   renderLegacyTerminalWindowsCmdTombstone,
   renderLegacyTerminalWindowsPowerShellTombstone
@@ -95,8 +98,20 @@ function writeNeutralWrappers(rootDir: string): void {
   const win32Dir = join(rootDir, 'win32')
   mkdirSync(posixDir, { recursive: true })
   mkdirSync(win32Dir, { recursive: true })
+  // Why: with no absolute interpreter verifiable, a tombstone would need an ambient shebang and
+  // could take bash from the current directory. Deleting the legacy wrapper is the safe outcome:
+  // the command simply falls through to the real one on PATH.
+  const interpreter = resolvePosixTombstoneInterpreter()
   for (const command of ['git', 'gh'] as const) {
-    writeFileAtomically(join(posixDir, command), renderLegacyTerminalPosixTombstone(command), 0o755)
+    if (interpreter === null) {
+      rmSync(join(posixDir, command), { force: true })
+    } else {
+      writeFileAtomically(
+        join(posixDir, command),
+        renderLegacyTerminalPosixTombstone(command, interpreter),
+        0o755
+      )
+    }
     writeFileAtomically(
       join(win32Dir, `${command}.cmd`),
       renderLegacyTerminalWindowsCmdTombstone(command),

--- a/src/main/pty/legacy-terminal-windows-tombstone.test.ts
+++ b/src/main/pty/legacy-terminal-windows-tombstone.test.ts
@@ -1,0 +1,269 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { resolvePosixTombstoneInterpreter } from './legacy-terminal-posix-tombstone'
+import {
+  __resetLegacyTerminalShimNeutralizationForTests,
+  neutralizeLegacyTerminalShimDir
+} from './legacy-terminal-shim-dir'
+
+// Why: `expect(text.indexOf(a)).toBeLessThan(text.indexOf(b))` passes when `a` is absent, because
+// indexOf returns -1. Every ordering pin must assert both operands exist first.
+function expectOrdered(text: string, first: string, second: string): void {
+  expect(text, `missing: ${first}`).toContain(first)
+  expect(text, `missing: ${second}`).toContain(second)
+  expect(text.indexOf(first)).toBeLessThan(text.indexOf(second))
+}
+
+describe('legacy terminal Windows tombstone text', () => {
+  const tempRoots: string[] = []
+
+  const makeUserDataDir = (): string => {
+    const userData = mkdtempSync(join(tmpdir(), 'orca-legacy-shim-win-'))
+    tempRoots.push(userData)
+    return userData
+  }
+
+  beforeEach(() => {
+    __resetLegacyTerminalShimNeutralizationForTests()
+  })
+
+  afterEach(() => {
+    for (const tempRoot of tempRoots.splice(0)) {
+      rmSync(tempRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects stale Windows real-command paths inside the wrapper directory', () => {
+    const userData = makeUserDataDir()
+    const win32Dir = join(userData, 'orca-terminal-attribution', 'win32')
+    mkdirSync(win32Dir, { recursive: true })
+
+    neutralizeLegacyTerminalShimDir(userData)
+
+    const cmd = readFileSync(join(win32Dir, 'git.cmd'), 'utf8')
+    expect(cmd).toContain(
+      'if defined orca_real for %%G in ("%orca_real%") do if /I "%%~dpG"=="%~dp0" set "orca_real="'
+    )
+    // Why: a captured path that no longer exists must be cleared, or the where.exe fallback below
+    // is skipped and the wrapper execs a missing binary.
+    expect(cmd).toContain('if defined orca_real if not exist "%orca_real%" set "orca_real="')
+    expectOrdered(cmd, 'if not exist "%orca_real%"', ':orca_try_candidate')
+    const powershell = readFileSync(join(win32Dir, 'git-wrapper.ps1'), 'utf8')
+    expect(powershell).toContain('[StringComparison]::OrdinalIgnoreCase')
+    expect(powershell).toContain('$realCommand = $null')
+    expectOrdered(
+      powershell,
+      '[StringComparison]::OrdinalIgnoreCase',
+      'Test-Path -LiteralPath $realCommand'
+    )
+  })
+
+  it('emits no percent expression inside a cmd rem comment', () => {
+    // Why: cmd expands variables inside rem, so a comment mentioning the working directory
+    // substitutes it into the comment text. Harmless at top level -- verified on Windows 11 that
+    // rem does not re-parse the result, so a cwd of `C:\\x&pwned&rem` executed nothing -- but rem
+    // treats separators differently inside a parenthesized block, and this script now has some.
+    const userData = makeUserDataDir()
+    const win32Dir = join(userData, 'orca-terminal-attribution', 'win32')
+    mkdirSync(win32Dir, { recursive: true })
+
+    neutralizeLegacyTerminalShimDir(userData)
+
+    for (const command of ['git', 'gh'] as const) {
+      const offending = readFileSync(join(win32Dir, `${command}.cmd`), 'utf8')
+        .split('\r\n')
+        .filter((line) => /^\s*rem\b/i.test(line) && line.includes('%'))
+      expect(offending, `rem comments with percent expressions: ${offending.join(' | ')}`).toEqual(
+        []
+      )
+    }
+  })
+
+  it('keeps the Windows wrappers ASCII-only', () => {
+    // Why: cmd.exe seeks through a batch file in bytes but advances by decoded character count,
+    // so a single multi-byte character shifts every following line. Two em dashes in comments
+    // made it drop the first four characters of every line and the wrapper died with "The
+    // syntax of the command is incorrect." Proven on Windows 11; no test caught it.
+    const userData = makeUserDataDir()
+    const win32Dir = join(userData, 'orca-terminal-attribution', 'win32')
+    mkdirSync(win32Dir, { recursive: true })
+
+    neutralizeLegacyTerminalShimDir(userData)
+
+    for (const name of ['git.cmd', 'gh.cmd', 'git-wrapper.ps1', 'gh-wrapper.ps1']) {
+      const contents = readFileSync(join(win32Dir, name), 'utf8')
+      const offending = [...contents].find((character) => character.charCodeAt(0) > 0x7f)
+      expect(offending, `${name} contains non-ASCII ${JSON.stringify(offending)}`).toBeUndefined()
+      expect(Buffer.byteLength(contents, 'utf8')).toBe(contents.length)
+    }
+  })
+
+  it('resolves Windows fallbacks against PATH only, never the current directory', () => {
+    // Why (STA-4169): bare `where.exe git.exe` searches cwd before PATH, so a repository-local
+    // git.exe/gh.exe could be executed with the user's arguments.
+    const userData = makeUserDataDir()
+    const win32Dir = join(userData, 'orca-terminal-attribution', 'win32')
+    mkdirSync(win32Dir, { recursive: true })
+
+    neutralizeLegacyTerminalShimDir(userData)
+
+    for (const command of ['git', 'gh'] as const) {
+      const cmd = readFileSync(join(win32Dir, `${command}.cmd`), 'utf8')
+      // No where.exe at all: it searches cwd first, so the wrapper walks the cleaned PATH.
+      expect(cmd).not.toContain('where.exe')
+      expect(cmd).toContain('for %%P in ("%orca_clean_path:;=" "%") do (')
+      expect(cmd).toContain(`if exist "%orca_candidate_dir%\\${command}.exe"`)
+      // Why: %~f preserves a trailing separator; without normalizing, a wrapper-dir entry
+      // spelled with one escapes self-exclusion and the wrapper tail-loops on itself. The
+      // separator lives in a variable because a literal backslash before the closing quote
+      // breaks cmd's parser, and a sentinel character would corrupt paths containing it.
+      expect(cmd).toContain('set "orca_sep=\\"')
+      // Why: bare setlocal inherits the caller's delayed-expansion state. Under a parent shell
+      // with /V:ON, a literal !CD! PATH entry became the cwd and ran a planted git.cmd (exit 66),
+      // and a legitimate directory containing ! stopped resolving (exit 127). Both on Windows 11.
+      expect(cmd).toContain('setlocal DisableDelayedExpansion')
+      expect(cmd).not.toContain('\r\nsetlocal\r\n')
+      // Why: a captured ORCA_REAL_* may be relative, and both the existence test and the
+      // invocation resolve it against the cwd.
+      expect(cmd).toContain('if defined orca_real call :orca_check_rooted')
+      expect(cmd).toContain('if defined orca_real if not defined orca_rooted set "orca_real="')
+      // Why: the exported PATH is inherited by the real command; a relative entry left in it lets
+      // the cwd select the tools that command spawns.
+      // Why the exact block, not an ordering pin: the first ':orca_append_path' in the file is
+      // the top-level CALL, and the first 'if not defined orca_rooted' belongs to a different
+      // subroutine, so an ordering pin stayed green with this subroutine's guard deleted.
+      expect(cmd).toContain(':orca_append_path\r\nif not defined orca_entry exit /b\r\n')
+      expect(cmd).toContain(
+        'set "orca_probe=%orca_entry%"\r\ncall :orca_check_rooted\r\nif not defined orca_rooted exit /b\r\nfor %%G in ("%orca_entry%") do set "orca_path_entry_dir=%%~fG"'
+      )
+      // Why: CALL re-expands its own command line, so path data passed as an argument gets a
+      // second round of percent expansion. A PATH entry holding a literal %CD% became the
+      // current directory before the rooted check saw it and the planted git.cmd ran (rc=66 on
+      // Windows 11). Every caller must hand the value over in a variable instead.
+      expect(cmd).not.toContain('call :orca_check_rooted "')
+      expect(cmd).not.toContain('call :orca_try_candidate "')
+      expect(cmd).not.toContain('call :orca_append_path "')
+      expect(cmd).not.toContain('%~1')
+      expect(cmd).toContain('set "orca_probe=%orca_entry%"\r\ncall :orca_check_rooted\r\n')
+      // Why: orca_sep is compared against before the legacy dir is normalized; defining it later
+      // made that strip silently no-op and left the legacy dir on PATH.
+      expectOrdered(cmd, 'set "orca_sep=', 'if "%orca_legacy_norm:~-1%."')
+      // Why: %orca_sep% expands before the line is parsed, so `=="%orca_sep%"` becomes `=="\"` —
+      // the literal trap the variable exists to avoid. Both sides must carry the trailing dot.
+      expect(cmd).not.toContain('=="%orca_sep%"')
+      // Why: nothing else asserts the *reject* path, so deleting it would reopen the cwd hijack
+      // while every accept-path assertion stayed green.
+      expectOrdered(
+        cmd,
+        'call :orca_check_rooted\r\nif not defined orca_rooted exit /b',
+        'for %%G in ("%orca_entry%") do set "orca_candidate_dir='
+      )
+      expect(cmd).toContain('if not defined orca_rooted exit /b')
+      expect(cmd).toContain('if "%orca_candidate_dir:~-1%."=="%orca_sep%."')
+      expect(cmd).not.toContain(':\\#=#%')
+      // A candidate inside the wrapper directory must still be rejected, compared against the
+      // cached wrapper dir because %~dp0 is rebound inside a CALL.
+      expect(cmd).toContain('if /I "%orca_candidate_dir%\\"=="%orca_wrapper_dir%" exit /b')
+      // Relative entries resolve against the cwd, so they must be rejected like empty ones.
+      // Why: the rooted-path test must not shell out — an external tool would itself be
+      // resolved from the cwd, reintroducing the hijack.
+      expect(cmd).not.toContain('findstr')
+      expect(cmd).toContain('if "%orca_probe:~1,2%"==":\\" set "orca_rooted=1"')
+      expect(cmd).toContain('if "%orca_probe:~0,2%"=="\\\\" set "orca_rooted=1"')
+      // Why: these two guards are the only thing stopping an empty element reaching the cwd on
+      // Windows; deleting either left every other assertion green.
+      expect(cmd).toContain('if not defined orca_entry exit /b')
+
+      const powershell = readFileSync(join(win32Dir, `${command}-wrapper.ps1`), 'utf8')
+      expect(powershell).not.toContain('Get-Command')
+      expect(powershell).toContain("($env:PATH -split ';')")
+      // Why: the rooted check must reject drive-relative 'C:foo', which still resolves against
+      // the cwd — so the IsPathRooted call must be gone, replaced by an explicit prefix match.
+      expect(powershell).not.toContain('[IO.Path]::IsPathRooted(')
+      expect(powershell).toContain("$pathEntry -match '^([A-Za-z]:[\\\\/]|\\\\\\\\)'")
+      expect(powershell).toContain("$realCommand -notmatch '^([A-Za-z]:[\\\\/]|\\\\\\\\)'")
+      // Why the full pattern, not a prefix: `^([A-Za-z]:|\\\\)` also starts with this and would
+      // accept drive-relative `C:foo`, which still resolves against the cwd on that drive.
+      expect(powershell).toContain("-notmatch '^([A-Za-z]:[\\\\/]|\\\\\\\\)'")
+      // Why: trailing-separator normalization is what makes wrapper self-exclusion work; every
+      // one of these survived mutation with the suite green.
+      expect(powershell).toContain("ForEach-Object { $_.TrimEnd('\\', '/') }")
+      expect(powershell).toContain("$pathEntry.TrimEnd('\\', '/')")
+      expect(powershell).toContain("$dir.TrimEnd('\\', '/')")
+      expect(powershell).toContain("$capturedDir.TrimEnd('\\', '/')")
+      // Why: the fallback loop must skip wrapper dirs, or the wrapper can resolve to itself.
+      expect(powershell).toContain(
+        "$dir.TrimEnd('\\', '/'), [StringComparison]::OrdinalIgnoreCase) }) { continue }"
+      )
+      // Why both separators: the rooted-path regex accepts forward slashes, so a wrapper or
+      // legacy directory spelled with a trailing / missed the lexical exclusion.
+      expect(powershell).not.toContain("TrimEnd('\\')")
+      // Why: `C:/Program Files/Git/cmd` style entries are legitimate and must stay accepted.
+      expect(cmd).toContain('if "%orca_probe:~1,2%"==":/" set "orca_rooted=1"')
+      // Why: the legacy-dir compare needs the same trailing-separator strip as its twins.
+      expect(cmd).toContain('if "%orca_legacy_norm:~-1%."=="%orca_sep%."')
+      // Why: cmd expands a whole line before evaluating `if defined`, so this strip must live in
+      // a CALL body. Inline, it ran its substring syntax against an unset variable and mangled
+      // the line into a syntax error. Proven on Windows 11.
+      expect(cmd).toContain('if defined orca_legacy_wrapper_dir call :orca_normalize_legacy_dir')
+      expect(cmd).not.toContain('if defined orca_legacy_wrapper_dir for ')
+      expect(powershell).toContain('if (-not $dir) { continue }')
+      expect(powershell).toContain('Test-Path -LiteralPath $candidate -PathType Leaf')
+    }
+  })
+
+  it('emits Windows wrappers with CRLF line endings', () => {
+    // Why: cmd resolves `call :label` by byte offset and that lookup is unreliable in LF-only
+    // files — the same script worked at 2.4 KB and failed with "cannot find the batch label"
+    // once it grew past ~3.7 KB. Verified on Windows.
+    const userData = makeUserDataDir()
+    const win32Dir = join(userData, 'orca-terminal-attribution', 'win32')
+    mkdirSync(win32Dir, { recursive: true })
+
+    neutralizeLegacyTerminalShimDir(userData)
+
+    for (const file of ['git.cmd', 'gh.cmd', 'git-wrapper.ps1', 'gh-wrapper.ps1']) {
+      const body = readFileSync(join(win32Dir, file), 'utf8')
+      expect(body, file).toContain('\r\n')
+      expect(body.replaceAll('\r\n', ''), file).not.toContain('\n')
+    }
+  })
+
+  it('guards both cmd PATH walks so an empty variable cannot break parsing', () => {
+    // Why: `%VAR:;=" "%` on an empty variable leaves an unbalanced quote that desynchronizes
+    // cmd parsing for the rest of the file, turning the not-found branch into
+    // `1>&2 was unexpected at this time.` Reproduced on Windows before this guard.
+    const userData = makeUserDataDir()
+    const win32Dir = join(userData, 'orca-terminal-attribution', 'win32')
+    mkdirSync(win32Dir, { recursive: true })
+
+    neutralizeLegacyTerminalShimDir(userData)
+
+    for (const command of ['git', 'gh'] as const) {
+      const cmd = readFileSync(join(win32Dir, `${command}.cmd`), 'utf8')
+      expect(cmd).toContain('if not defined PATH goto :orca_path_walked')
+      expect(cmd).toContain('if not defined orca_clean_path goto :orca_candidates_walked')
+      for (const [guard, loop] of [
+        ['if not defined PATH goto :orca_path_walked', 'for %%P in ("%PATH:;='],
+        [
+          'if not defined orca_clean_path goto :orca_candidates_walked',
+          'for %%P in ("%orca_clean_path:;='
+        ]
+      ] as const) {
+        expectOrdered(cmd, guard, loop)
+      }
+    }
+  })
+
+  it('never bakes an ambient interpreter lookup on Windows', () => {
+    // Why: the POSIX tombstone is written on Windows too (Git Bash and WSL panes run it), but no
+    // absolute candidate exists to a Windows process and PATH there is ';'-separated, so the
+    // search cannot succeed — without this the fallback reopened the interpreter hijack.
+    expect(resolvePosixTombstoneInterpreter(undefined, [], 'win32')).toBe('/bin/bash')
+    expect(resolvePosixTombstoneInterpreter('C:\\Git\\bin;C:\\Windows', [], 'win32')).toBe(
+      '/bin/bash'
+    )
+  })
+})

--- a/src/main/pty/legacy-terminal-windows-tombstone.ts
+++ b/src/main/pty/legacy-terminal-windows-tombstone.ts
@@ -1,20 +1,28 @@
 // Why: kept beside the POSIX tombstone so the generated wrapper text for every platform lives
 // in one place, and so the shim-dir module stays under the max-lines limit.
+//
+// Keep both templates ASCII-only, comments included. cmd.exe tracks its position in a batch file
+// in bytes but advances by decoded character count, so every extra UTF-8 byte shifts the whole
+// file: two em dashes in comments made cmd drop the first four characters of every line and the
+// script died with "The syntax of the command is incorrect."
 
 const WIN32_PASSTHROUGH_WRAPPER = String.raw`@echo off
 setlocal
 set "orca_real=%ORCA_REAL___ORCA_UPPER_COMMAND__%"
 set "orca_wrapper_dir=%~dp0"
 set "orca_legacy_wrapper_dir=%ORCA_ATTRIBUTION_SHIM_DIR%"
-rem Why: normalize once here rather than per PATH entry; the value cannot change mid-run.
-set "orca_legacy_norm="
-if defined orca_legacy_wrapper_dir for %%G in ("%orca_legacy_wrapper_dir%") do set "orca_legacy_norm=%%~fG"
-if defined orca_legacy_norm if "%orca_legacy_norm:~-1%"=="%orca_sep%" set "orca_legacy_norm=%orca_legacy_norm:~0,-1%"
 set "orca_clean_path="
 rem Why: holds a single separator so the trailing-separator tests below need neither a literal
 rem backslash before a quote (which breaks cmd parsing) nor a sentinel character (which would
-rem corrupt any path containing it).
+rem corrupt any path containing it). Comparisons append a dot so the separator is never
+rem adjacent to a closing quote, which would break the parser exactly as a literal would.
 set "orca_sep=\"
+rem Why a subroutine, not an "if defined ... " one-liner: cmd expands a whole line before it
+rem evaluates the condition, so the substring syntax below still runs against an unset variable
+rem and leaves the line mangled. A CALL body is only parsed once it is reached.
+rem Why here: the value cannot change mid-run, so normalize once rather than per PATH entry.
+set "orca_legacy_norm="
+if defined orca_legacy_wrapper_dir call :orca_normalize_legacy_dir
 rem Why: an empty PATH leaves the substitution below with an unbalanced quote, which
 rem desynchronizes cmd parsing for the rest of the file. Skip the line entirely instead.
 if not defined PATH goto :orca_path_walked
@@ -30,6 +38,10 @@ set "ORCA_ATTRIBUTION_BYPASS="
 set "ORCA_REAL_GIT="
 set "ORCA_REAL_GH="
 if defined orca_real for %%G in ("%orca_real%") do if /I "%%~dpG"=="%~dp0" set "orca_real="
+rem Why: a captured path may be relative, and both "if exist" and the invocation resolve it
+rem against the current directory, so an inherited .\__ORCA_COMMAND__.exe would run from the repo.
+if defined orca_real call :orca_check_rooted "%orca_real%"
+if defined orca_real if not defined orca_rooted set "orca_real="
 rem Why: clear a captured path that no longer exists, or the PATH walk below is skipped.
 if defined orca_real if not exist "%orca_real%" set "orca_real="
 if defined orca_real goto run
@@ -46,23 +58,33 @@ if not defined orca_real (
 "%orca_real%" %*
 exit /b %ERRORLEVEL%
 
+:orca_normalize_legacy_dir
+for %%G in ("%orca_legacy_wrapper_dir%") do set "orca_legacy_norm=%%~fG"
+rem Why: full-path expansion preserves a trailing separator; normalize before comparing.
+if "%orca_legacy_norm:~-1%."=="%orca_sep%." set "orca_legacy_norm=%orca_legacy_norm:~0,-1%"
+exit /b
+
+:orca_check_rooted
+rem Why: tested in pure batch on purpose. An external tool invoked here would itself be resolved
+rem from the current directory, reintroducing the very hijack this guard exists to prevent.
+set "orca_rooted="
+set "orca_probe=%~1"
+if "%orca_probe:~0,2%"=="\\" set "orca_rooted=1"
+if "%orca_probe:~1,2%"==":\" set "orca_rooted=1"
+if "%orca_probe:~1,2%"==":/" set "orca_rooted=1"
+exit /b
+
 :orca_try_candidate
 if defined orca_real exit /b
 if "%~1"=="" exit /b
 rem Why: a relative entry resolves against the current directory, same exposure as an empty one.
-rem Tested in pure batch on purpose: an external tool invoked here would itself be resolved from
-rem the current directory, reintroducing the very hijack this guard exists to prevent.
-set "orca_candidate=%~1"
-if "%orca_candidate:~0,2%"=="\\" goto orca_candidate_rooted
-if "%orca_candidate:~1,2%"==":\" goto orca_candidate_rooted
-if "%orca_candidate:~1,2%"==":/" goto orca_candidate_rooted
-exit /b
-:orca_candidate_rooted
+call :orca_check_rooted "%~1"
+if not defined orca_rooted exit /b
 for %%G in ("%~1") do set "orca_candidate_dir=%%~fG"
 rem Why: full-path expansion preserves a trailing separator, so without normalizing, the
 rem self-exclusion below misses a wrapper-dir entry spelled with one and the wrapper resolves
 rem to itself, looping forever.
-if "%orca_candidate_dir:~-1%"=="%orca_sep%" set "orca_candidate_dir=%orca_candidate_dir:~0,-1%"
+if "%orca_candidate_dir:~-1%."=="%orca_sep%." set "orca_candidate_dir=%orca_candidate_dir:~0,-1%"
 rem Why: the script-dir operator is rebound to this label inside CALL, so compare against the
 rem cached wrapper dir captured at top level.
 if /I "%orca_candidate_dir%\"=="%orca_wrapper_dir%" exit /b
@@ -72,9 +94,14 @@ if not defined orca_real if exist "%orca_candidate_dir%\__ORCA_COMMAND__.bat" se
 exit /b
 
 :orca_append_path
+if "%~1"=="" exit /b
+rem Why: the exported PATH is inherited by the real git and anything it spawns, so a relative
+rem entry left here lets the current directory select those tools instead.
+call :orca_check_rooted "%~1"
+if not defined orca_rooted exit /b
 for %%G in ("%~1") do set "orca_path_entry_dir=%%~fG"
 rem Why: full-path expansion preserves a trailing separator; normalize before comparing.
-if "%orca_path_entry_dir:~-1%"=="%orca_sep%" set "orca_path_entry_dir=%orca_path_entry_dir:~0,-1%"
+if "%orca_path_entry_dir:~-1%."=="%orca_sep%." set "orca_path_entry_dir=%orca_path_entry_dir:~0,-1%"
 set "orca_path_entry_dir=%orca_path_entry_dir%\"
 if /I "%orca_path_entry_dir%"=="%orca_wrapper_dir%" exit /b
 set "orca_skip_entry="
@@ -96,11 +123,14 @@ $legacyWrapperDir = $env:ORCA_ATTRIBUTION_SHIM_DIR
 $wrapperDirs = @($wrapperDir, $legacyWrapperDir) | Where-Object { $_ } | ForEach-Object { $_.TrimEnd('\') }
 $env:PATH = (($env:PATH -split ';') | Where-Object {
   $pathEntry = $_
-  $pathEntry -and -not ($wrapperDirs | Where-Object {
+  # Why: the exported PATH is inherited by the real command and anything it spawns.
+  $pathEntry -and ($pathEntry -match '^([A-Za-z]:[\\/]|\\\\)') -and -not ($wrapperDirs | Where-Object {
     [string]::Equals($_, $pathEntry.TrimEnd('\'), [StringComparison]::OrdinalIgnoreCase)
   })
 }) -join ';'
 'ORCA_ENABLE_GIT_ATTRIBUTION', 'ORCA_GIT_COMMIT_TRAILER', 'ORCA_GH_PR_FOOTER', 'ORCA_GH_ISSUE_FOOTER', 'ORCA_ATTRIBUTION_SHIM_DIR', 'ORCA_REAL_GIT', 'ORCA_REAL_GH', 'ORCA_ATTRIBUTION_BYPASS' | ForEach-Object { Remove-Item "Env:$_" -ErrorAction SilentlyContinue }
+# Why: a captured value may be relative, and Test-Path plus invocation resolve it against the cwd.
+if ($realCommand -and $realCommand -notmatch '^([A-Za-z]:[\\/]|\\\\)') { $realCommand = $null }
 if ($realCommand) {
   try {
     $capturedDir = Split-Path -Parent ([IO.Path]::GetFullPath($realCommand))

--- a/src/main/pty/legacy-terminal-windows-tombstone.ts
+++ b/src/main/pty/legacy-terminal-windows-tombstone.ts
@@ -6,6 +6,10 @@ setlocal
 set "orca_real=%ORCA_REAL___ORCA_UPPER_COMMAND__%"
 set "orca_wrapper_dir=%~dp0"
 set "orca_legacy_wrapper_dir=%ORCA_ATTRIBUTION_SHIM_DIR%"
+rem Why: normalize once here rather than per PATH entry; the value cannot change mid-run.
+set "orca_legacy_norm="
+if defined orca_legacy_wrapper_dir for %%G in ("%orca_legacy_wrapper_dir%") do set "orca_legacy_norm=%%~fG"
+if defined orca_legacy_norm if "%orca_legacy_norm:~-1%"=="%orca_sep%" set "orca_legacy_norm=%orca_legacy_norm:~0,-1%"
 set "orca_clean_path="
 rem Why: holds a single separator so the trailing-separator tests below need neither a literal
 rem backslash before a quote (which breaks cmd parsing) nor a sentinel character (which would
@@ -80,8 +84,6 @@ if defined orca_clean_path (set "orca_clean_path=%orca_clean_path%;%~1") else se
 exit /b
 
 :orca_reject_legacy_dir
-for %%G in ("%orca_legacy_wrapper_dir%") do set "orca_legacy_norm=%%~fG"
-if "%orca_legacy_norm:~-1%"=="%orca_sep%" set "orca_legacy_norm=%orca_legacy_norm:~0,-1%"
 if /I "%orca_path_entry_dir%"=="%orca_legacy_norm%\" set "orca_skip_entry=1"
 exit /b
 `

--- a/src/main/pty/legacy-terminal-windows-tombstone.ts
+++ b/src/main/pty/legacy-terminal-windows-tombstone.ts
@@ -147,12 +147,14 @@ $commandName = '__ORCA_COMMAND__'
 $realCommand = [Environment]::GetEnvironmentVariable('ORCA_REAL___ORCA_UPPER_COMMAND__')
 $wrapperDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $legacyWrapperDir = $env:ORCA_ATTRIBUTION_SHIM_DIR
-$wrapperDirs = @($wrapperDir, $legacyWrapperDir) | Where-Object { $_ } | ForEach-Object { $_.TrimEnd('\') }
+# Why both separators: the rooted-path test below accepts forward slashes, so a directory
+# spelled with a trailing / would miss this lexical exclusion and the wrapper could recurse.
+$wrapperDirs = @($wrapperDir, $legacyWrapperDir) | Where-Object { $_ } | ForEach-Object { $_.TrimEnd('\', '/') }
 $env:PATH = (($env:PATH -split ';') | Where-Object {
   $pathEntry = $_
   # Why: the exported PATH is inherited by the real command and anything it spawns.
   $pathEntry -and ($pathEntry -match '^([A-Za-z]:[\\/]|\\\\)') -and -not ($wrapperDirs | Where-Object {
-    [string]::Equals($_, $pathEntry.TrimEnd('\'), [StringComparison]::OrdinalIgnoreCase)
+    [string]::Equals($_, $pathEntry.TrimEnd('\', '/'), [StringComparison]::OrdinalIgnoreCase)
   })
 }) -join ';'
 'ORCA_ENABLE_GIT_ATTRIBUTION', 'ORCA_GIT_COMMIT_TRAILER', 'ORCA_GH_PR_FOOTER', 'ORCA_GH_ISSUE_FOOTER', 'ORCA_ATTRIBUTION_SHIM_DIR', 'ORCA_REAL_GIT', 'ORCA_REAL_GH', 'ORCA_ATTRIBUTION_BYPASS' | ForEach-Object { Remove-Item "Env:$_" -ErrorAction SilentlyContinue }
@@ -161,7 +163,7 @@ if ($realCommand -and $realCommand -notmatch '^([A-Za-z]:[\\/]|\\\\)') { $realCo
 if ($realCommand) {
   try {
     $capturedDir = Split-Path -Parent ([IO.Path]::GetFullPath($realCommand))
-    if ([string]::Equals($capturedDir.TrimEnd('\'), $wrapperDir.TrimEnd('\'), [StringComparison]::OrdinalIgnoreCase)) {
+    if ([string]::Equals($capturedDir.TrimEnd('\', '/'), $wrapperDir.TrimEnd('\', '/'), [StringComparison]::OrdinalIgnoreCase)) {
       $realCommand = $null
     }
   } catch {
@@ -179,7 +181,7 @@ if (-not $realCommand -or -not (Test-Path -LiteralPath $realCommand)) {
     # current directory on that drive. IsPathFullyQualified is absent on Windows PowerShell 5.1,
     # so match the same prefixes the cmd wrapper accepts.
     if ($dir -notmatch '^([A-Za-z]:[\\/]|\\\\)') { continue }
-    if ($wrapperDirs | Where-Object { [string]::Equals($_, $dir.TrimEnd('\'), [StringComparison]::OrdinalIgnoreCase) }) { continue }
+    if ($wrapperDirs | Where-Object { [string]::Equals($_, $dir.TrimEnd('\', '/'), [StringComparison]::OrdinalIgnoreCase) }) { continue }
     foreach ($ext in @('.exe', '.cmd', '.bat')) {
       $candidate = Join-Path $dir "$commandName$ext"
       if (Test-Path -LiteralPath $candidate -PathType Leaf) { $realCommand = $candidate; break }

--- a/src/main/pty/legacy-terminal-windows-tombstone.ts
+++ b/src/main/pty/legacy-terminal-windows-tombstone.ts
@@ -1,6 +1,12 @@
 // Why: kept beside the POSIX tombstone so the generated wrapper text for every platform lives
 // in one place, and so the shim-dir module stays under the max-lines limit.
 //
+// Keep percent signs out of every emitted `rem` line. cmd expands variables inside rem, so a
+// comment mentioning %CD% substitutes the working directory into itself. That is harmless at top
+// level -- verified on Windows 11 that rem does not re-parse the result, so a cwd of
+// `C:\x&pwned&rem` did not execute anything -- but rem handles separators differently inside a
+// parenthesized block, and this script now has some.
+//
 // Keep both templates ASCII-only, comments included. cmd.exe tracks its position in a batch file
 // in bytes but advances by decoded character count, so every extra UTF-8 byte shifts the whole
 // file: two em dashes in comments made cmd drop the first four characters of every line and the
@@ -26,9 +32,11 @@ if defined orca_legacy_wrapper_dir call :orca_normalize_legacy_dir
 rem Why: an empty PATH leaves the substitution below with an unbalanced quote, which
 rem desynchronizes cmd parsing for the rest of the file. Skip the line entirely instead.
 if not defined PATH goto :orca_path_walked
-rem Why the variable: CALL re-expands its own command line, so a PATH entry holding a literal
-rem %CD% would be turned into the current directory before the rooted check below ever sees it,
-rem and the cwd would then be searched for __ORCA_COMMAND__. Proven on Windows 11.
+rem Why the variable: CALL re-expands its own command line, so a PATH entry naming the current
+rem directory through a percent expression would become that directory before the rooted check
+rem below ever saw it, and the cwd would then be searched for __ORCA_COMMAND__. Proven on
+rem Windows 11. The expression is spelled out only in the TypeScript comment above: cmd expands
+rem percent signs inside rem, so writing one here would substitute a path into the comment.
 for %%P in ("%PATH:;=" "%") do (
   set "orca_entry=%%~P"
   call :orca_append_path

--- a/src/main/pty/legacy-terminal-windows-tombstone.ts
+++ b/src/main/pty/legacy-terminal-windows-tombstone.ts
@@ -82,6 +82,14 @@ if not defined orca_real (
 exit /b %ERRORLEVEL%
 
 :orca_normalize_legacy_dir
+rem Why the rooted test first: full-path expansion resolves a relative value against the current
+rem directory, so a
+rem relative ORCA_ATTRIBUTION_SHIM_DIR would let the cwd decide which PATH entry counts as the
+rem legacy directory and get a legitimate one skipped. Leaving the normalized value unset makes
+rem the reject subroutine below a no-op, which is the safe outcome.
+set "orca_probe=%orca_legacy_wrapper_dir%"
+call :orca_check_rooted
+if not defined orca_rooted exit /b
 for %%G in ("%orca_legacy_wrapper_dir%") do set "orca_legacy_norm=%%~fG"
 rem Why: full-path expansion preserves a trailing separator; normalize before comparing.
 if "%orca_legacy_norm:~-1%."=="%orca_sep%." set "orca_legacy_norm=%orca_legacy_norm:~0,-1%"
@@ -138,6 +146,9 @@ if defined orca_clean_path (set "orca_clean_path=%orca_clean_path%;%orca_entry%"
 exit /b
 
 :orca_reject_legacy_dir
+rem Why: an unrooted legacy dir leaves this unset, and comparing against a bare separator could
+rem only ever misfire.
+if not defined orca_legacy_norm exit /b
 if /I "%orca_path_entry_dir%"=="%orca_legacy_norm%\" set "orca_skip_entry=1"
 exit /b
 `

--- a/src/main/pty/legacy-terminal-windows-tombstone.ts
+++ b/src/main/pty/legacy-terminal-windows-tombstone.ts
@@ -26,7 +26,13 @@ if defined orca_legacy_wrapper_dir call :orca_normalize_legacy_dir
 rem Why: an empty PATH leaves the substitution below with an unbalanced quote, which
 rem desynchronizes cmd parsing for the rest of the file. Skip the line entirely instead.
 if not defined PATH goto :orca_path_walked
-for %%P in ("%PATH:;=" "%") do call :orca_append_path "%%~P"
+rem Why the variable: CALL re-expands its own command line, so a PATH entry holding a literal
+rem %CD% would be turned into the current directory before the rooted check below ever sees it,
+rem and the cwd would then be searched for __ORCA_COMMAND__. Proven on Windows 11.
+for %%P in ("%PATH:;=" "%") do (
+  set "orca_entry=%%~P"
+  call :orca_append_path
+)
 :orca_path_walked
 set "PATH=%orca_clean_path%"
 set "ORCA_ENABLE_GIT_ATTRIBUTION="
@@ -40,7 +46,8 @@ set "ORCA_REAL_GH="
 if defined orca_real for %%G in ("%orca_real%") do if /I "%%~dpG"=="%~dp0" set "orca_real="
 rem Why: a captured path may be relative, and both "if exist" and the invocation resolve it
 rem against the current directory, so an inherited .\__ORCA_COMMAND__.exe would run from the repo.
-if defined orca_real call :orca_check_rooted "%orca_real%"
+set "orca_probe=%orca_real%"
+if defined orca_real call :orca_check_rooted
 if defined orca_real if not defined orca_rooted set "orca_real="
 rem Why: clear a captured path that no longer exists, or the PATH walk below is skipped.
 if defined orca_real if not exist "%orca_real%" set "orca_real="
@@ -48,7 +55,10 @@ if defined orca_real goto run
 rem Why: an unqualified Windows command lookup searches the current directory before PATH, so a
 rem repository-local __ORCA_COMMAND__.exe would win. Walk the cleaned PATH ourselves instead.
 if not defined orca_clean_path goto :orca_candidates_walked
-for %%P in ("%orca_clean_path:;=" "%") do call :orca_try_candidate "%%~P"
+for %%P in ("%orca_clean_path:;=" "%") do (
+  set "orca_entry=%%~P"
+  call :orca_try_candidate
+)
 :orca_candidates_walked
 if not defined orca_real (
   echo Orca compatibility wrapper could not locate __ORCA_COMMAND__ on PATH. 1>&2
@@ -67,8 +77,10 @@ exit /b
 :orca_check_rooted
 rem Why: tested in pure batch on purpose. An external tool invoked here would itself be resolved
 rem from the current directory, reintroducing the very hijack this guard exists to prevent.
+rem Why orca_probe rather than an argument: see the CALL re-expansion note above.
 set "orca_rooted="
-set "orca_probe=%~1"
+rem Why: an unset probe would leave the substring syntax below unexpanded and mangle the line.
+if not defined orca_probe exit /b
 if "%orca_probe:~0,2%"=="\\" set "orca_rooted=1"
 if "%orca_probe:~1,2%"==":\" set "orca_rooted=1"
 if "%orca_probe:~1,2%"==":/" set "orca_rooted=1"
@@ -76,11 +88,12 @@ exit /b
 
 :orca_try_candidate
 if defined orca_real exit /b
-if "%~1"=="" exit /b
+if not defined orca_entry exit /b
 rem Why: a relative entry resolves against the current directory, same exposure as an empty one.
-call :orca_check_rooted "%~1"
+set "orca_probe=%orca_entry%"
+call :orca_check_rooted
 if not defined orca_rooted exit /b
-for %%G in ("%~1") do set "orca_candidate_dir=%%~fG"
+for %%G in ("%orca_entry%") do set "orca_candidate_dir=%%~fG"
 rem Why: full-path expansion preserves a trailing separator, so without normalizing, the
 rem self-exclusion below misses a wrapper-dir entry spelled with one and the wrapper resolves
 rem to itself, looping forever.
@@ -94,12 +107,13 @@ if not defined orca_real if exist "%orca_candidate_dir%\__ORCA_COMMAND__.bat" se
 exit /b
 
 :orca_append_path
-if "%~1"=="" exit /b
+if not defined orca_entry exit /b
 rem Why: the exported PATH is inherited by the real git and anything it spawns, so a relative
 rem entry left here lets the current directory select those tools instead.
-call :orca_check_rooted "%~1"
+set "orca_probe=%orca_entry%"
+call :orca_check_rooted
 if not defined orca_rooted exit /b
-for %%G in ("%~1") do set "orca_path_entry_dir=%%~fG"
+for %%G in ("%orca_entry%") do set "orca_path_entry_dir=%%~fG"
 rem Why: full-path expansion preserves a trailing separator; normalize before comparing.
 if "%orca_path_entry_dir:~-1%."=="%orca_sep%." set "orca_path_entry_dir=%orca_path_entry_dir:~0,-1%"
 set "orca_path_entry_dir=%orca_path_entry_dir%\"
@@ -107,7 +121,7 @@ if /I "%orca_path_entry_dir%"=="%orca_wrapper_dir%" exit /b
 set "orca_skip_entry="
 if defined orca_legacy_wrapper_dir call :orca_reject_legacy_dir
 if defined orca_skip_entry exit /b
-if defined orca_clean_path (set "orca_clean_path=%orca_clean_path%;%~1") else set "orca_clean_path=%~1"
+if defined orca_clean_path (set "orca_clean_path=%orca_clean_path%;%orca_entry%") else set "orca_clean_path=%orca_entry%"
 exit /b
 
 :orca_reject_legacy_dir

--- a/src/main/pty/legacy-terminal-windows-tombstone.ts
+++ b/src/main/pty/legacy-terminal-windows-tombstone.ts
@@ -13,7 +13,12 @@
 // script died with "The syntax of the command is incorrect."
 
 const WIN32_PASSTHROUGH_WRAPPER = String.raw`@echo off
-setlocal
+rem Why explicit: bare setlocal inherits the caller's delayed-expansion state, and a parent shell
+rem started with /V:ON made every PATH entry undergo ! expansion inside the loops below. A literal
+rem !CD! entry then became the current directory and a planted git.cmd ran (exit 66), and a
+rem legitimate directory whose name contains ! stopped resolving (exit 127). Both proven on
+rem Windows 11; both disappear when the wrapper pins its own state.
+setlocal DisableDelayedExpansion
 set "orca_real=%ORCA_REAL___ORCA_UPPER_COMMAND__%"
 set "orca_wrapper_dir=%~dp0"
 set "orca_legacy_wrapper_dir=%ORCA_ATTRIBUTION_SHIM_DIR%"


### PR DESCRIPTION
## ELI5

Comprehensive read-through of the final wrapper code before release. One real bug, three tidy-ups, and one "simplification" I attempted and reverted because the tests proved it wrong.

## The bug

`stripLegacyTerminalShimEnv` removed the directory named by `ORCA_ATTRIBUTION_SHIM_DIR` from PATH by **exact string match**. If the captured value and the PATH entry differed only by a trailing separator, the entry survived — leaving the legacy shim directory on the spawned PATH and the wrapper reachable:

```
PATH=/custom/elsewhere/:/usr/bin  +  ORCA_ATTRIBUTION_SHIM_DIR=/custom/elsewhere
  ->  /custom/elsewhere/:/usr/bin      (survived)
```

This is the same trailing-separator class already fixed in all three generated wrappers; the scrub itself was missed. Now tries each spelling (with/without trailing separator, both slash styles on Windows). Mutation-verified.

## A simplification I backed out

The 32-line boundary scanner it uses looked like over-engineering — `split(delimiter).filter(...)` does the same thing in three lines. I made that change, and two existing tests failed: a shim path can **contain the PATH delimiter** (`/tmp/orca:user/…`), which splitting fragments. The scanner exists for exactly that. Reverted; kept only the targeted fix.

Worth recording because the tests were the only thing standing between a plausible-looking cleanup and a regression.

## Tidy-ups

- POSIX: `candidate="${entry:-.}"` was dead — the `!= /*` guard above already rejects empty and relative entries, so the default could never fire. Uses `$entry` directly.
- POSIX: three "Why:" comments had accumulated across successive fixes, one describing code two lines below it. Consolidated into one accurate block.
- cmd: the legacy directory was re-normalized on **every** PATH entry inside `:orca_reject_legacy_dir`. It cannot change mid-run, so it is normalized once at the top.

## Testing

- `pnpm typecheck`, `pnpm lint`: pass, no `max-lines` suppression
- pty suite: 30 tests pass; the new spelling test is mutation-verified
- Full suite: failures are the 2 pre-existing `agent-exec-handler` cases plus load-flaky tests that pass in isolation
