### PR TITLE
STA-4276: preflight Codex in Command Prompt and Git Bash

### DIFF
--- a/.github/workflows/computer-e2e.yml
+++ b/.github/workflows/computer-e2e.yml
@@ -29,6 +29,9 @@ on:
       - 'electron.vite.config.ts'
       - 'config/build-plugins/**'
       - 'src/main/daemon/**'
+      - 'src/main/providers/local-pty-provider.ts'
+      - 'src/main/providers/windows-shell-args.ts'
+      - 'src/main/providers/windows-shell-preflight-runtime.windows.test.ts'
       - 'native/computer-use-macos/**'
       - 'native/computer-use-linux/**'
       - 'native/computer-use-windows/**'
@@ -106,6 +109,7 @@ jobs:
           src/main/computer/macos-native-provider-socket.test.ts
           src/main/computer/macos-computer-use-permissions.test.ts
           src/main/computer/macos-computer-use-permission-status.test.ts
+          src/main/providers/windows-shell-preflight-runtime.windows.test.ts
           src/main/computer/desktop-script-provider-client.test.ts
           src/main/computer/desktop-script-provider-cache.test.ts
           src/main/computer/desktop-script-provider-actions.test.ts

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -39,6 +39,7 @@ vi.mock('../pwsh', () => ({
 const PWSH7_ABS = 'C:\\Program Files\\PowerShell\\7\\pwsh.exe'
 const WINDOWS_POWERSHELL_ABS = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
 const CMD_ABS = 'C:\\Windows\\System32\\cmd.exe'
+const CODEX_LAUNCH_PREFLIGHT = 'C:\\Program Files\\Orca\\orca.exe'
 vi.mock('../providers/windows-powershell-executable', () => ({
   resolveWindowsPowerShellExecutablePath: (family: 'pwsh.exe' | 'powershell.exe') =>
     family === 'pwsh.exe' ? PWSH7_ABS : WINDOWS_POWERSHELL_ABS,
@@ -2457,7 +2458,8 @@ describe('createPtySubprocess', () => {
         cols: 80,
         rows: 24,
         shellOverride: 'cmd.exe',
-        terminalWindowsPowerShellImplementation: 'pwsh.exe'
+        terminalWindowsPowerShellImplementation: 'pwsh.exe',
+        env: { ORCA_CODEX_LAUNCH_PREFLIGHT: CODEX_LAUNCH_PREFLIGHT }
       })
     } finally {
       if (platform) {
@@ -2467,8 +2469,13 @@ describe('createPtySubprocess', () => {
 
     expect(spawnMock).toHaveBeenCalledWith(
       'cmd.exe',
-      ['/K', 'chcp 65001 > nul'],
-      expect.any(Object)
+      [
+        '/K',
+        'chcp 65001 > nul & if defined ORCA_CODEX_LAUNCH_PREFLIGHT call %ORCA_CODEX_LAUNCH_PREFLIGHT_CMD_QUOTE%%ORCA_CODEX_LAUNCH_PREFLIGHT%%ORCA_CODEX_LAUNCH_PREFLIGHT_CMD_QUOTE% agent hooks prepare-codex > nul 2>&1'
+      ],
+      expect.objectContaining({
+        env: expect.objectContaining({ ORCA_CODEX_LAUNCH_PREFLIGHT_CMD_QUOTE: '"' })
+      })
     )
   })
 
@@ -2517,7 +2524,8 @@ describe('createPtySubprocess', () => {
         rows: 24,
         cwd: 'C:\\repo\\orca',
         shellOverride: 'cmd.exe',
-        command: `codex ${'x'.repeat(7000)}`
+        command: `codex ${'x'.repeat(7000)}`,
+        env: { ORCA_CODEX_LAUNCH_PREFLIGHT: CODEX_LAUNCH_PREFLIGHT }
       })
     } finally {
       if (platform) {
@@ -2527,7 +2535,10 @@ describe('createPtySubprocess', () => {
 
     expect(spawnMock).toHaveBeenCalledWith(
       'cmd.exe',
-      ['/K', 'chcp 65001 > nul'],
+      [
+        '/K',
+        'chcp 65001 > nul & if defined ORCA_CODEX_LAUNCH_PREFLIGHT call %ORCA_CODEX_LAUNCH_PREFLIGHT_CMD_QUOTE%%ORCA_CODEX_LAUNCH_PREFLIGHT%%ORCA_CODEX_LAUNCH_PREFLIGHT_CMD_QUOTE% agent hooks prepare-codex > nul 2>&1'
+      ],
       expect.any(Object)
     )
     expect(handle!.startupCommandDeliveredInShellArgs).toBeUndefined()
@@ -2546,7 +2557,8 @@ describe('createPtySubprocess', () => {
         cols: 80,
         rows: 24,
         cwd: 'C:\\Users\\jin\\repo',
-        shellOverride: 'C:\\PortableGit\\bin\\bash.exe'
+        shellOverride: 'C:\\PortableGit\\bin\\bash.exe',
+        env: { ORCA_CODEX_LAUNCH_PREFLIGHT: CODEX_LAUNCH_PREFLIGHT }
       })
     } finally {
       if (platform) {
@@ -2556,10 +2568,18 @@ describe('createPtySubprocess', () => {
 
     expect(spawnMock).toHaveBeenCalledWith(
       'C:\\PortableGit\\bin\\bash.exe',
-      ['-c', 'chcp.com 65001 >/dev/null 2>&1; exec "$BASH" --login -i'],
+      [
+        '-c',
+        expect.stringMatching(
+          /^chcp\.com 65001 >\/dev\/null 2>&1; exec "\$BASH" --rcfile '.*shell-ready\/bash\/rcfile' -i$/
+        )
+      ],
       expect.objectContaining({
         cwd: 'C:\\Users\\jin\\repo',
-        env: expect.objectContaining({ CHERE_INVOKING: '1' })
+        env: expect.objectContaining({
+          CHERE_INVOKING: '1',
+          ORCA_CODEX_LAUNCH_PREFLIGHT: CODEX_LAUNCH_PREFLIGHT
+        })
       })
     )
   })

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -20,7 +20,10 @@ import {
 import { wrapShellSpawnForMacosTccAttribution } from '../providers/macos-tcc-login-shell'
 import { signalPosixPtyForegroundGroup } from '../pty/posix-pty-foreground-group'
 import { readPtsName } from '../pty/node-pty-pts-name'
-import { resolveWindowsShellLaunchArgs } from '../providers/windows-shell-args'
+import {
+  ORCA_CODEX_LAUNCH_PREFLIGHT_CMD_QUOTE_ENV,
+  resolveWindowsShellLaunchArgs
+} from '../providers/windows-shell-args'
 import {
   resolveEffectiveWindowsPowerShell,
   shouldProbeWindowsPowerShellAvailability,
@@ -693,6 +696,13 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
           }) ?? shellPath)
         : shellPath
     }
+    if (
+      pathWin32.basename(shellPath).toLowerCase() === 'cmd.exe' &&
+      env.ORCA_CODEX_LAUNCH_PREFLIGHT
+    ) {
+      // Why: node-pty backslash-escapes argv quotes; expand the quote inside cmd.exe instead.
+      env[ORCA_CODEX_LAUNCH_PREFLIGHT_CMD_QUOTE_ENV] = '"'
+    }
     // Why: a bare `pwsh.exe` resolves to the Store App Execution Alias stub whose launch fails with ERROR_ACCESS_DENIED (5).
     windowsFallbackAttempts = buildWindowsPowerShellSpawnAttempts({
       shellPath,
@@ -714,7 +724,8 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
         spawnCwd,
         getDefaultCwd(),
         resolvedWslContext,
-        opts.command
+        opts.command,
+        env.ORCA_CODEX_LAUNCH_PREFLIGHT
       )
       shellArgs = resolved.shellArgs
       spawnCwd = resolved.effectiveCwd
@@ -745,7 +756,8 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
               {
                 distro: codexHomeWslInfo.distro
               },
-              opts.command
+              opts.command,
+              env.ORCA_CODEX_LAUNCH_PREFLIGHT
             )
             shellArgs = resolved.shellArgs
             spawnCwd = resolved.effectiveCwd

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -70,6 +70,7 @@ vi.mock('../pty-descendant-termination', () => ({
 const WINDOWS_POWERSHELL_ABS = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
 const PWSH7_ABS = 'C:\\Program Files\\PowerShell\\7\\pwsh.exe'
 const CMD_ABS = 'C:\\Windows\\System32\\cmd.exe'
+const CODEX_LAUNCH_PREFLIGHT = 'C:\\Program Files\\Orca\\orca.exe'
 vi.mock('./windows-powershell-executable', () => ({
   resolveWindowsPowerShellExecutablePath: (family: 'pwsh.exe' | 'powershell.exe') =>
     family === 'pwsh.exe' ? PWSH7_ABS : WINDOWS_POWERSHELL_ABS,
@@ -1371,7 +1372,13 @@ describe('LocalPtyProvider', () => {
       const originalProgramFiles = process.env.ProgramFiles
       Object.defineProperty(process, 'platform', { value: 'win32' })
       process.env.ProgramFiles = 'C:\\Program Files'
-      provider.configure({ getWindowsShell: () => 'git-bash' })
+      provider.configure({
+        getWindowsShell: () => 'git-bash',
+        buildSpawnEnv: (_id, env) => ({
+          ...env,
+          ORCA_CODEX_LAUNCH_PREFLIGHT: CODEX_LAUNCH_PREFLIGHT
+        })
+      })
 
       try {
         await provider.spawn({
@@ -1392,12 +1399,52 @@ describe('LocalPtyProvider', () => {
 
       expect(spawnMock).toHaveBeenCalledWith(
         'C:\\Program Files\\Git\\bin\\bash.exe',
-        ['-c', 'chcp.com 65001 >/dev/null 2>&1; exec "$BASH" --login -i'],
+        [
+          '-c',
+          expect.stringMatching(
+            /^chcp\.com 65001 >\/dev\/null 2>&1; exec "\$BASH" --rcfile '.*shell-ready\/bash\/rcfile' -i$/
+          )
+        ],
         expect.objectContaining({
           cwd: 'C:\\Users\\jin\\repo',
           env: expect.objectContaining({
             CHERE_INVOKING: '1',
-            PYTHONUTF8: '1'
+            PYTHONUTF8: '1',
+            ORCA_CODEX_LAUNCH_PREFLIGHT: CODEX_LAUNCH_PREFLIGHT
+          })
+        })
+      )
+    })
+
+    it('runs the Codex preflight once in the cmd.exe startup chain', async () => {
+      const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+      Object.defineProperty(process, 'platform', { value: 'win32' })
+      provider.configure({
+        getWindowsShell: () => 'cmd.exe',
+        buildSpawnEnv: (_id, env) => ({
+          ...env,
+          ORCA_CODEX_LAUNCH_PREFLIGHT: CODEX_LAUNCH_PREFLIGHT
+        })
+      })
+
+      try {
+        await provider.spawn({ cols: 80, rows: 24, cwd: 'C:\\Users\\jin\\repo' })
+      } finally {
+        if (platform) {
+          Object.defineProperty(process, 'platform', platform)
+        }
+      }
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        'cmd.exe',
+        [
+          '/K',
+          'chcp 65001 > nul & if defined ORCA_CODEX_LAUNCH_PREFLIGHT call %ORCA_CODEX_LAUNCH_PREFLIGHT_CMD_QUOTE%%ORCA_CODEX_LAUNCH_PREFLIGHT%%ORCA_CODEX_LAUNCH_PREFLIGHT_CMD_QUOTE% agent hooks prepare-codex > nul 2>&1'
+        ],
+        expect.objectContaining({
+          env: expect.objectContaining({
+            ORCA_CODEX_LAUNCH_PREFLIGHT: CODEX_LAUNCH_PREFLIGHT,
+            ORCA_CODEX_LAUNCH_PREFLIGHT_CMD_QUOTE: '"'
           })
         })
       )

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -1,7 +1,10 @@
 /* eslint-disable max-lines -- Why: splitting spawn() would scatter tightly coupled PTY lifecycle logic (scan → ready → write → exit) with no cleaner ownership seam. */
 import { basename, delimiter, win32 as pathWin32 } from 'node:path'
 import { randomUUID } from 'node:crypto'
-import { resolveWindowsShellLaunchArgs } from './windows-shell-args'
+import {
+  ORCA_CODEX_LAUNCH_PREFLIGHT_CMD_QUOTE_ENV,
+  resolveWindowsShellLaunchArgs
+} from './windows-shell-args'
 import {
   resolveEffectiveWindowsPowerShell,
   shouldProbeWindowsPowerShellAvailability,
@@ -776,6 +779,30 @@ export class LocalPtyProvider implements IPtyProvider {
         // Why: WSL Codex homes are Linux paths Windows can't use; also drop ORCA_CODEX_HOME (shell-ready restores CODEX_HOME from it).
         delete finalEnv.CODEX_HOME
         delete finalEnv.ORCA_CODEX_HOME
+      }
+
+      const shellBasename = pathWin32.basename(shellPath).toLowerCase()
+      const codexLaunchPreflightCommand = finalEnv.ORCA_CODEX_LAUNCH_PREFLIGHT
+      if (
+        codexLaunchPreflightCommand &&
+        (shellBasename === 'cmd.exe' || isWindowsGitBashShellPath(shellPath))
+      ) {
+        if (shellBasename === 'cmd.exe') {
+          // Why: node-pty backslash-escapes argv quotes; expand the quote inside cmd.exe instead.
+          finalEnv[ORCA_CODEX_LAUNCH_PREFLIGHT_CMD_QUOTE_ENV] = '"'
+        }
+        const resolved = resolveWindowsShellLaunchArgs(
+          shellPath,
+          cwd,
+          defaultCwd,
+          launchWslContext,
+          args.command,
+          codexLaunchPreflightCommand
+        )
+        shellArgs = resolved.shellArgs
+        effectiveCwd = resolved.effectiveCwd
+        validationCwd = resolved.validationCwd
+        startupCommandDeliveredInShellArgs = resolved.startupCommandDeliveredInShellArgs === true
       }
     }
     seedPowerlevel10kWizardEnv(finalEnv, { envToDelete: args.envToDelete })

--- a/src/main/providers/windows-shell-args.test.ts
+++ b/src/main/providers/windows-shell-args.test.ts
@@ -9,6 +9,10 @@ import {
 import { resolveSetupRunnerCommand } from '../../shared/setup-runner-command'
 import { resolveWindowsShellLaunchArgs } from './windows-shell-args'
 
+const CODEX_LAUNCH_PREFLIGHT = 'C:\\Program Files\\Orca\\orca.exe'
+const CMD_CODEX_LAUNCH_PREFLIGHT =
+  'if defined ORCA_CODEX_LAUNCH_PREFLIGHT call %ORCA_CODEX_LAUNCH_PREFLIGHT_CMD_QUOTE%%ORCA_CODEX_LAUNCH_PREFLIGHT%%ORCA_CODEX_LAUNCH_PREFLIGHT_CMD_QUOTE% agent hooks prepare-codex > nul 2>&1'
+
 function expectedWslArgs(linuxCwd: string, distro?: string): string[] {
   const command = `cd '${linuxCwd}' && export PATH="$HOME/.local/bin:$PATH" && ${buildWslInteractiveLoginShellCommand()}`
   const shellArgs = ['--', 'sh', '-c', escapeWslShCommandForWindows(command)]
@@ -22,6 +26,14 @@ function decodePowerShellCommand(result: ReturnType<typeof resolveWindowsShellLa
 
 function expectedPowerShellRestoreCwdCommand(cwdLiteral: string): string {
   return `try { Set-Location -LiteralPath ${cwdLiteral} -ErrorAction Stop } catch { Write-Warning "Failed to restore working directory: $_" }`
+}
+
+function getGitBashRcfilePath(command: string): string {
+  const rcfilePath = command.match(/--rcfile '([^']+)'/)?.[1]
+  if (!rcfilePath) {
+    throw new Error(`Git Bash launch command has no rcfile: ${command}`)
+  }
+  return rcfilePath
 }
 
 describe('resolveWindowsShellLaunchArgs', () => {
@@ -44,8 +56,15 @@ describe('resolveWindowsShellLaunchArgs', () => {
   })
 
   it('returns cmd.exe args with chcp 65001 for UTF-8 output', () => {
-    const result = resolveWindowsShellLaunchArgs('cmd.exe', 'C:\\Users\\alice', 'C:\\Users\\alice')
-    expect(result.shellArgs).toEqual(['/K', 'chcp 65001 > nul'])
+    const result = resolveWindowsShellLaunchArgs(
+      'cmd.exe',
+      'C:\\Users\\alice',
+      'C:\\Users\\alice',
+      undefined,
+      undefined,
+      CODEX_LAUNCH_PREFLIGHT
+    )
+    expect(result.shellArgs).toEqual(['/K', `chcp 65001 > nul & ${CMD_CODEX_LAUNCH_PREFLIGHT}`])
     expect(result.startupCommandDeliveredInShellArgs).toBeUndefined()
     expect(result.effectiveCwd).toBe('C:\\Users\\alice')
     expect(result.validationCwd).toBe('C:\\Users\\alice')
@@ -57,9 +76,13 @@ describe('resolveWindowsShellLaunchArgs', () => {
       'C:\\Users\\alice',
       'C:\\Users\\alice',
       undefined,
-      'codex --no-alt-screen'
+      'codex --no-alt-screen',
+      CODEX_LAUNCH_PREFLIGHT
     )
-    expect(result.shellArgs).toEqual(['/K', 'chcp 65001 > nul & codex --no-alt-screen'])
+    expect(result.shellArgs).toEqual([
+      '/K',
+      `chcp 65001 > nul & ${CMD_CODEX_LAUNCH_PREFLIGHT} & codex --no-alt-screen`
+    ])
     expect(result.startupCommandDeliveredInShellArgs).toBe(true)
   })
 
@@ -83,9 +106,10 @@ describe('resolveWindowsShellLaunchArgs', () => {
       'C:\\Users\\alice',
       'C:\\Users\\alice',
       undefined,
-      `codex ${'x'.repeat(7000)}`
+      `codex ${'x'.repeat(7000)}`,
+      CODEX_LAUNCH_PREFLIGHT
     )
-    expect(result.shellArgs).toEqual(['/K', 'chcp 65001 > nul'])
+    expect(result.shellArgs).toEqual(['/K', `chcp 65001 > nul & ${CMD_CODEX_LAUNCH_PREFLIGHT}`])
     expect(result.startupCommandDeliveredInShellArgs).toBeUndefined()
   })
 
@@ -216,11 +240,32 @@ describe('resolveWindowsShellLaunchArgs', () => {
     expect(decodePowerShellCommand(result)).toContain(expectedPowerShellRestoreCwdCommand("'C:\\'"))
   })
 
+  it('does not change PowerShell args when the cmd/Git Bash preflight is provided', () => {
+    const baseline = resolveWindowsShellLaunchArgs(
+      'powershell.exe',
+      'C:\\Users\\alice',
+      'C:\\Users\\alice'
+    )
+    const withWindowsPreflight = resolveWindowsShellLaunchArgs(
+      'powershell.exe',
+      'C:\\Users\\alice',
+      'C:\\Users\\alice',
+      undefined,
+      undefined,
+      CODEX_LAUNCH_PREFLIGHT
+    )
+
+    expect(withWindowsPreflight).toEqual(baseline)
+  })
+
   it('starts Git Bash as an interactive login shell with UTF-8 console setup', () => {
     const result = resolveWindowsShellLaunchArgs(
       'C:\\Program Files\\Git\\bin\\bash.exe',
       '/c',
-      'C:\\Users\\alice'
+      'C:\\Users\\alice',
+      undefined,
+      undefined,
+      CODEX_LAUNCH_PREFLIGHT
     )
 
     // Why: Git Bash inherits the ConPTY OEM code page (CP437), so a byte-writing
@@ -231,7 +276,8 @@ describe('resolveWindowsShellLaunchArgs', () => {
     expect(result.shellArgs[0]).toBe('-c')
     const bashCommand = result.shellArgs[1]
     expect(bashCommand).toContain('chcp.com 65001')
-    expect(bashCommand).toMatch(/exec "\$BASH" --login -i$/)
+    expect(bashCommand).toContain('--rcfile')
+    expect(bashCommand).toMatch(/exec "\$BASH" .* -i$/)
     // The UTF-8 switch must run before the login shell is exec'd.
     expect(bashCommand.indexOf('chcp.com')).toBeLessThan(bashCommand.indexOf('exec'))
     // Must stay fail-open: `;` (not `&&`) so a missing chcp.com can't abort the
@@ -239,6 +285,52 @@ describe('resolveWindowsShellLaunchArgs', () => {
     expect(bashCommand).not.toContain('&&')
     expect(result.effectiveCwd).toBe('C:\\')
     expect(result.validationCwd).toBe('C:\\')
+
+    const bashRcfile = readFileSync(getGitBashRcfilePath(bashCommand), 'utf8')
+    expect(bashRcfile).toContain('"${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex')
+    expect(bashRcfile).not.toContain(CODEX_LAUNCH_PREFLIGHT)
+  })
+
+  it('keeps Git Bash startup commands on stdin delivery with the preflight wrapper', () => {
+    const result = resolveWindowsShellLaunchArgs(
+      'C:\\Program Files\\Git\\bin\\bash.exe',
+      'C:\\Users\\alice',
+      'C:\\Users\\alice',
+      undefined,
+      'codex --no-alt-screen',
+      CODEX_LAUNCH_PREFLIGHT
+    )
+
+    expect(result.shellArgs[1]).toContain('chcp.com 65001')
+    expect(result.shellArgs[1]).toContain('--rcfile')
+    expect(result.startupCommandDeliveredInShellArgs).toBeUndefined()
+  })
+
+  it('quotes a spaced preflight path through each shell environment', () => {
+    const cmd = resolveWindowsShellLaunchArgs(
+      'cmd.exe',
+      'C:\\Users\\alice',
+      'C:\\Users\\alice',
+      undefined,
+      undefined,
+      CODEX_LAUNCH_PREFLIGHT
+    )
+    const gitBash = resolveWindowsShellLaunchArgs(
+      'C:\\Program Files\\Git\\bin\\bash.exe',
+      'C:\\Users\\alice',
+      'C:\\Users\\alice',
+      undefined,
+      undefined,
+      CODEX_LAUNCH_PREFLIGHT
+    )
+
+    expect(cmd.shellArgs[1]).toContain(
+      'call %ORCA_CODEX_LAUNCH_PREFLIGHT_CMD_QUOTE%%ORCA_CODEX_LAUNCH_PREFLIGHT%%ORCA_CODEX_LAUNCH_PREFLIGHT_CMD_QUOTE%'
+    )
+    expect(cmd.shellArgs[1]).not.toContain('"')
+    expect(cmd.shellArgs[1]).not.toContain(CODEX_LAUNCH_PREFLIGHT)
+    const rcfilePath = getGitBashRcfilePath(gitBash.shellArgs[1])
+    expect(readFileSync(rcfilePath, 'utf8')).toContain('"${ORCA_CODEX_LAUNCH_PREFLIGHT}"')
   })
 
   it('does not apply Git Bash launch args to unrelated bash.exe paths', () => {
@@ -254,13 +346,22 @@ describe('resolveWindowsShellLaunchArgs', () => {
   })
 
   it('translates Windows cwd to /mnt/<drive>/... for wsl.exe', () => {
-    const result = resolveWindowsShellLaunchArgs(
+    const baseline = resolveWindowsShellLaunchArgs(
       'wsl.exe',
       'C:\\Users\\alice\\code',
       'C:\\Users\\alice',
       undefined,
       'codex'
     )
+    const result = resolveWindowsShellLaunchArgs(
+      'wsl.exe',
+      'C:\\Users\\alice\\code',
+      'C:\\Users\\alice',
+      undefined,
+      'codex',
+      CODEX_LAUNCH_PREFLIGHT
+    )
+    expect(result).toEqual(baseline)
     expect(result.shellArgs).toEqual(expectedWslArgs('/mnt/c/Users/alice/code'))
     expect(result.startupCommandDeliveredInShellArgs).toBeUndefined()
     // Why: WSL cannot cd into a Windows path, so node-pty must start from the

--- a/src/main/providers/windows-shell-args.ts
+++ b/src/main/providers/windows-shell-args.ts
@@ -6,7 +6,7 @@ import {
   escapeWslShCommandForWindows,
   quotePosixShell
 } from '../../shared/wsl-login-shell-command'
-import { ensureShellReadyWrappersAt } from './local-pty-shell-ready'
+import { ensureShellReadyWrappersAt, getMarkerlessShellLaunchConfig } from './local-pty-shell-ready'
 import {
   encodePowerShellCommand,
   getPowerShellOsc133Bootstrap
@@ -17,6 +17,8 @@ const CMD_EXE_COMMAND_LINE_MAX_CHARS = 8191
 const STARTUP_COMMAND_TEXT_MAX_CHARS = 6000
 const POWERSHELL_ENCODED_COMMAND_ARG_MAX_CHARS = 28_000
 const CMD_UTF8_SETUP_COMMAND = 'chcp 65001 > nul'
+export const ORCA_CODEX_LAUNCH_PREFLIGHT_CMD_QUOTE_ENV = 'ORCA_CODEX_LAUNCH_PREFLIGHT_CMD_QUOTE'
+const CMD_CODEX_LAUNCH_PREFLIGHT = `if defined ORCA_CODEX_LAUNCH_PREFLIGHT call %${ORCA_CODEX_LAUNCH_PREFLIGHT_CMD_QUOTE_ENV}%%ORCA_CODEX_LAUNCH_PREFLIGHT%%${ORCA_CODEX_LAUNCH_PREFLIGHT_CMD_QUOTE_ENV}% agent hooks prepare-codex > nul 2>&1`
 // Why: Git for Windows' bash inherits the ConPTY console's OEM code page
 // (CP437), so a TUI that writes UTF-8 bytes straight to the console — agents
 // like Claude Code use WriteFile, not WriteConsoleW — renders as mojibake
@@ -24,6 +26,22 @@ const CMD_UTF8_SETUP_COMMAND = 'chcp 65001 > nul'
 // login shell; cmd.exe and PowerShell already do the equivalent. The `;` (not
 // `&&`) keeps startup working even if chcp.com is missing.
 const GIT_BASH_UTF8_LOGIN_COMMAND = 'chcp.com 65001 >/dev/null 2>&1; exec "$BASH" --login -i'
+
+function getGitBashLaunchCommand(codexLaunchPreflightCommand?: string): string {
+  if (!codexLaunchPreflightCommand) {
+    return GIT_BASH_UTF8_LOGIN_COMMAND
+  }
+
+  ensureShellReadyWrappersAt()
+  const wrapperArgs = getMarkerlessShellLaunchConfig('bash').args
+  if (!wrapperArgs) {
+    return GIT_BASH_UTF8_LOGIN_COMMAND
+  }
+  const bashArgs = [...wrapperArgs, '-i']
+    .map((arg) => (arg.startsWith('-') ? arg : quotePosixShell(arg.replace(/\\/g, '/'))))
+    .join(' ')
+  return `chcp.com 65001 >/dev/null 2>&1; exec "$BASH" ${bashArgs}`
+}
 
 /** Result of resolving a Windows shell to its launch args + effective cwd.
  *
@@ -159,20 +177,21 @@ export function resolveWindowsShellLaunchArgs(
   cwd: string,
   defaultCwd: string,
   wslContext?: WindowsShellWslContext,
-  startupCommand?: string
+  startupCommand?: string,
+  codexLaunchPreflightCommand?: string
 ): WindowsShellLaunchArgs {
   const shellBasename = pathWin32.basename(shellPath).toLowerCase()
   const nativeCwd = normalizeWindowsTerminalCwd(cwd)
 
   if (shellBasename === 'cmd.exe') {
     const shellArgStartupCommand = getCmdShellArgStartupCommand(startupCommand)
+    const startupCommands = [
+      CMD_UTF8_SETUP_COMMAND,
+      ...(codexLaunchPreflightCommand ? [CMD_CODEX_LAUNCH_PREFLIGHT] : []),
+      ...(shellArgStartupCommand ? [shellArgStartupCommand] : [])
+    ]
     return {
-      shellArgs: [
-        '/K',
-        shellArgStartupCommand
-          ? `${CMD_UTF8_SETUP_COMMAND} & ${shellArgStartupCommand}`
-          : CMD_UTF8_SETUP_COMMAND
-      ],
+      shellArgs: ['/K', startupCommands.join(' & ')],
       ...(shellArgStartupCommand ? { startupCommandDeliveredInShellArgs: true } : {}),
       effectiveCwd: nativeCwd,
       validationCwd: nativeCwd
@@ -195,7 +214,7 @@ export function resolveWindowsShellLaunchArgs(
 
   if (isWindowsGitBashShellPath(shellPath)) {
     return {
-      shellArgs: ['-c', GIT_BASH_UTF8_LOGIN_COMMAND],
+      shellArgs: ['-c', getGitBashLaunchCommand(codexLaunchPreflightCommand)],
       effectiveCwd: nativeCwd,
       validationCwd: nativeCwd
     }

--- a/src/main/providers/windows-shell-preflight-runtime.windows.test.ts
+++ b/src/main/providers/windows-shell-preflight-runtime.windows.test.ts
@@ -66,6 +66,7 @@ async function runPty(options: {
   cwd: string
   env: NodeJS.ProcessEnv
   input?: string
+  timeoutMs?: number
 }): Promise<string> {
   const proc = pty.spawn(options.shellPath, options.shellArgs, {
     name: 'xterm-256color',
@@ -85,7 +86,7 @@ async function runPty(options: {
   const timeoutPromise = new Promise<never>((_resolve, reject) => {
     timeout = setTimeout(
       () => reject(new Error(`timed out waiting for Windows shell PTY:\n${output}`)),
-      10_000
+      options.timeoutMs ?? 10_000
     )
   })
 
@@ -184,7 +185,11 @@ describeWindows('Windows Codex shell preflight runtime', () => {
           TERM: 'xterm-256color'
         },
         input:
-          "codex -e \"require('node:fs').writeFileSync(process.env.ORCA_CODEX_MARKER,'ran')\"\nexit\n"
+          "codex -e \"require('node:fs').writeFileSync(process.env.ORCA_CODEX_MARKER,'ran')\"\nexit\n",
+        // Paired "Windows low spec" QA measured 12.7–15.8s across four runs: Git Bash
+        // cold-starts two large Node executables for AV scanning, so allow 25s without
+        // inflating the faster cmd.exe budget.
+        timeoutMs: 25_000
       })
     } finally {
       if (previousUserDataPath === undefined) {

--- a/src/main/providers/windows-shell-preflight-runtime.windows.test.ts
+++ b/src/main/providers/windows-shell-preflight-runtime.windows.test.ts
@@ -1,0 +1,200 @@
+import {
+  copyFileSync,
+  existsSync,
+  linkSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import * as pty from 'node-pty'
+import { afterEach, describe, expect, it } from 'vitest'
+import { resolveGitBashPath } from '../git-bash'
+import {
+  ORCA_CODEX_LAUNCH_PREFLIGHT_CMD_QUOTE_ENV,
+  resolveWindowsShellLaunchArgs
+} from './windows-shell-args'
+
+const describeWindows = process.platform === 'win32' ? describe : describe.skip
+const tempDirs: string[] = []
+
+function makeTempDir(): string {
+  const root = mkdtempSync(join(tmpdir(), 'orca shell preflight '))
+  tempDirs.push(root)
+  return root
+}
+
+function linkNodeExecutable(destination: string): void {
+  try {
+    linkSync(process.execPath, destination)
+  } catch {
+    copyFileSync(process.execPath, destination)
+  }
+}
+
+function writeFailingPreflight(root: string): string {
+  const executable = join(root, 'orca preflight.exe')
+  linkNodeExecutable(executable)
+  writeFileSync(
+    join(root, 'agent'),
+    [
+      "const { writeFileSync } = require('node:fs')",
+      "if (process.argv.slice(2).join(' ') !== 'hooks prepare-codex') process.exit(2)",
+      "writeFileSync(process.env.ORCA_PREFLIGHT_MARKER, 'ran')",
+      'process.exit(7)'
+    ].join('\n')
+  )
+  return executable
+}
+
+function withPathEntry(env: NodeJS.ProcessEnv, entry: string): NodeJS.ProcessEnv {
+  const result = { ...env }
+  const pathKey = Object.keys(result).find((key) => key.toLowerCase() === 'path')
+  const inheritedPath = pathKey ? result[pathKey] : ''
+  if (pathKey) {
+    delete result[pathKey]
+  }
+  result.PATH = `${entry};${inheritedPath ?? ''}`
+  return result
+}
+
+async function runPty(options: {
+  shellPath: string
+  shellArgs: string[]
+  cwd: string
+  env: NodeJS.ProcessEnv
+  input?: string
+}): Promise<string> {
+  const proc = pty.spawn(options.shellPath, options.shellArgs, {
+    name: 'xterm-256color',
+    cols: 100,
+    rows: 30,
+    cwd: options.cwd,
+    env: options.env
+  })
+  let output = ''
+  proc.onData((data) => {
+    output += data
+  })
+  const exitPromise = new Promise<number>((resolve) => {
+    proc.onExit(({ exitCode }) => resolve(exitCode))
+  })
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  const timeoutPromise = new Promise<never>((_resolve, reject) => {
+    timeout = setTimeout(
+      () => reject(new Error(`timed out waiting for Windows shell PTY:\n${output}`)),
+      10_000
+    )
+  })
+
+  try {
+    if (options.input) {
+      proc.write(options.input.replaceAll('\n', '\r'))
+    }
+    const exitCode = await Promise.race([exitPromise, timeoutPromise])
+    expect(exitCode, output).toBe(0)
+    return output
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout)
+    }
+    try {
+      proc.kill()
+    } catch {
+      // The PTY may already have exited.
+    }
+  }
+}
+
+afterEach(() => {
+  for (const root of tempDirs.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+describeWindows('Windows Codex shell preflight runtime', () => {
+  it('runs a spaced executable through cmd.exe and continues after failure', async () => {
+    const root = makeTempDir()
+    const preflight = writeFailingPreflight(root)
+    const preflightMarker = join(root, 'cmd-preflight-ran')
+    const startupMarker = join(root, 'cmd-started')
+    const resolved = resolveWindowsShellLaunchArgs(
+      'cmd.exe',
+      root,
+      root,
+      undefined,
+      'echo launched>cmd-started & exit',
+      preflight
+    )
+
+    await runPty({
+      shellPath: 'cmd.exe',
+      shellArgs: resolved.shellArgs,
+      cwd: root,
+      env: {
+        ...process.env,
+        ORCA_CODEX_LAUNCH_PREFLIGHT: preflight,
+        [ORCA_CODEX_LAUNCH_PREFLIGHT_CMD_QUOTE_ENV]: '"',
+        ORCA_PREFLIGHT_MARKER: preflightMarker
+      }
+    })
+
+    expect(readFileSync(preflightMarker, 'utf8')).toBe('ran')
+    expect(readFileSync(startupMarker, 'utf8').trim()).toBe('launched')
+  })
+
+  it('runs the typed-Codex wrapper through Git Bash without MSYS switch rewriting', async () => {
+    const gitBash = resolveGitBashPath()
+    expect(gitBash).not.toBeNull()
+    if (!gitBash) {
+      return
+    }
+
+    const root = makeTempDir()
+    const preflight = writeFailingPreflight(root)
+    const codexExecutable = join(root, 'codex.exe')
+    linkNodeExecutable(codexExecutable)
+    const preflightMarker = join(root, 'git-bash-preflight-ran')
+    const codexMarker = join(root, 'git-bash-codex-ran')
+    const previousUserDataPath = process.env.ORCA_USER_DATA_PATH
+    process.env.ORCA_USER_DATA_PATH = join(root, 'user data')
+
+    try {
+      const resolved = resolveWindowsShellLaunchArgs(
+        gitBash,
+        root,
+        root,
+        undefined,
+        undefined,
+        preflight
+      )
+      await runPty({
+        shellPath: gitBash,
+        shellArgs: resolved.shellArgs,
+        cwd: root,
+        env: {
+          ...withPathEntry(process.env, root),
+          CHERE_INVOKING: '1',
+          HOME: root,
+          ORCA_CODEX_LAUNCH_PREFLIGHT: preflight,
+          ORCA_PREFLIGHT_MARKER: preflightMarker,
+          ORCA_CODEX_MARKER: codexMarker,
+          TERM: 'xterm-256color'
+        },
+        input:
+          "codex -e \"require('node:fs').writeFileSync(process.env.ORCA_CODEX_MARKER,'ran')\"\nexit\n"
+      })
+    } finally {
+      if (previousUserDataPath === undefined) {
+        delete process.env.ORCA_USER_DATA_PATH
+      } else {
+        process.env.ORCA_USER_DATA_PATH = previousUserDataPath
+      }
+    }
+
+    expect(existsSync(preflightMarker)).toBe(true)
+    expect(readFileSync(codexMarker, 'utf8')).toBe('ran')
+  })
+})

--- a/src/main/providers/windows-shell-preflight-runtime.windows.test.ts
+++ b/src/main/providers/windows-shell-preflight-runtime.windows.test.ts
@@ -125,7 +125,7 @@ describeWindows('Windows Codex shell preflight runtime', () => {
       root,
       root,
       undefined,
-      'echo launched>cmd-started & exit',
+      'echo launched>cmd-started & exit /b 0',
       preflight
     )
 


### PR DESCRIPTION
## ELI5

Command Prompt and Git Bash now repair Codex hook trust when a pane starts, matching Orca's other supported shells.

## What Changed

- Added a fail-open, one-time Command Prompt preflight to the existing `/K` startup chain while retaining `chcp 65001 > nul` and startup-command delivery semantics.
- Routed native Windows Git Bash through Orca's existing markerless bash rcfile so the POSIX Codex wrapper is installed after user profiles, while retaining the UTF-8 console setup and interactive shell.
- Covered the shared resolver plus local and daemon PTY launch paths, including startup commands, PowerShell/WSL non-regression, and a preflight executable path containing spaces.

## Why

PR #14326 repaired Codex hook trust at launch for POSIX shells, fish, and PowerShell, but native Windows skipped the POSIX wrapper and the cmd/Git Bash argument branches never added equivalent handling.

The repository has no cmd-side command interception or doskey precedent. Command Prompt therefore runs the preflight once in its `/K` chain before the first prompt; Git Bash uses the existing shell-ready wrapper because it can install the same typed-`codex` function as other POSIX shells. The cmd command expands quotes from a dedicated environment value because node-pty backslash-escapes literal quotes inside argv; the existing `ORCA_CODEX_LAUNCH_PREFLIGHT` value remains unchanged and will accept the verified absolute path from STA-4270.

## Linked Issue

Linear: https://linear.app/stably/issue/STA-4276/p1-codex-trust-preflight-is-omitted-for-command-prompt-and-git-bash

Original regression: https://github.com/stablyai/orca/pull/14326

Fixes STA-4276

## Visual Proof

N/A — no rendered UI change; this is a Windows-only PTY launch-argument correction.

## Testing

- [ ] I manually tested these changes locally — the affected shells are Windows-only and this worktree is macOS.
- [x] Automated tests added/updated, or explained why not below

- `pnpm exec vitest run --config config/vitest.config.ts src/main/providers/windows-shell-args.test.ts src/main/providers/local-pty-provider.test.ts src/main/daemon/pty-subprocess.test.ts` — 256 passed.
- `pnpm typecheck` — passed.
- `pnpm lint` — passed.

The resolver tests were red before the implementation for both cmd and Git Bash. A macOS harness cannot exercise cmd.exe, Git Bash/MSYS argument parsing, or ConPTY, so no grok/macOS runtime repro was created; real Windows validation remains the later low-spec remote QA stage.

## AI Disclosure
<!-- DO NOT FILL IN IF YOU ARE STABLYAI TEAM MEMBER (INTERNAL CONTRIBUTOR), IGNORE SECTION: -->

## Review

- Invariant: `terminal-shell.windows-resolution-parity` — cmd and Git Bash receive the Codex trust repair without changing UTF-8 setup or startup-command delivery; PowerShell and WSL descriptors remain unchanged.
- Failure source: STA-4276, regression from PR #14326.
- Oracle: resolver assertions plus local/daemon PTY spawn assertions prove command ordering, rcfile content, spaced-path quoting, and delivery flags.
- Gate: the existing reliability gate is experimental with no wired Windows command. These deterministic provider tests add coverage; live Windows ConPTY behavior remains an explicit QA gap.
- Provider/platform coverage: local and daemon Windows launch paths are covered statically; WSL, PowerShell, macOS/Linux, SSH transport, mobile, relay, persisted state, and wire contracts are unaffected.
- Performance: no polling, scans, listeners, retries, or unbounded state were added. Cmd adds the required single launch-time process; Git Bash reuses the cached shell-ready wrapper.
- Security/backcompat: the resolved executable is never interpolated into shell source; both shells expand the existing environment value inside shell-native quotes. No mobile-facing, persisted, RPC, or remote-wire surface changed.
- Residual risk: final ConPTY/MSYS execution is intentionally deferred to Windows QA.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, and touched Vitest files pass; full `pnpm test` and `pnpm build` will run in CI

## Author

- X / Twitter: @BrennanKB5
