### PR TITLE
fix(native-chat): keep caller abort ahead of WSL gate refusal

### DIFF
--- a/src/main/native-chat/session-file-resolver-wsl-scan-gate.test.ts
+++ b/src/main/native-chat/session-file-resolver-wsl-scan-gate.test.ts
@@ -130,4 +130,48 @@ describe('Codex WSL scan gate', () => {
       })
     ).rejects.toBe(refusal)
   })
+
+  it('reports the abort, not a refusal, when the hook-path probe races a caller abort', async () => {
+    const controller = new AbortController()
+    const abortReason = new Error('caller went away')
+    mocks.gate.mockImplementation(async (options: { operation?: string; path: string }) => {
+      if (options.operation === 'access') {
+        controller.abort(abortReason)
+        throw new WslTranscriptFsError('timeout', 'slow share')
+      }
+      return []
+    })
+
+    await expect(
+      resolveSessionFilePath(
+        'codex',
+        'session-id',
+        {
+          transcriptPath: `${WSL_SESSIONS_DIR}\\2026\\rollout-1-session-id.jsonl`,
+          codexSessionsDirs: [LOCAL_SESSIONS_DIR]
+        },
+        controller.signal
+      )
+    ).rejects.toBe(abortReason)
+  })
+
+  // The scan layer's own waiter already wins this race; the resolver's post-catch
+  // signal check is the backstop if that ever stops holding.
+  it('reports the abort, not a refusal, when a scanned root is aborted mid-scan', async () => {
+    const controller = new AbortController()
+    const abortReason = new Error('caller went away')
+    mocks.gate.mockImplementation(async () => {
+      controller.abort(abortReason)
+      throw new WslTranscriptFsError('timeout', 'slow share')
+    })
+
+    await expect(
+      resolveSessionFilePath(
+        'codex',
+        'session-id',
+        { codexSessionsDirs: [WSL_SESSIONS_DIR] },
+        controller.signal
+      )
+    ).rejects.toBe(abortReason)
+  })
 })

--- a/src/main/native-chat/session-file-resolver.ts
+++ b/src/main/native-chat/session-file-resolver.ts
@@ -108,6 +108,8 @@ export async function resolveSessionFilePath(
         return hostReadable
       }
     } catch (error) {
+      // A caller abort that races the refusal stays authoritative.
+      signal?.throwIfAborted()
       // Why: the id-based search may still hit; surface the refusal only when
       // it does not, so a stalled distro reads as unavailable, never "missing".
       unavailable = wslTranscriptFsRefusal(error)
@@ -232,6 +234,8 @@ async function findCodexRolloutInDirs(
         return files
       }
     } catch (error) {
+      // A caller abort that races the refusal stays authoritative.
+      signal?.throwIfAborted()
       // Why: one stalled distro must not hide another root's hit.
       unavailable = wslTranscriptFsRefusal(error)
     }


### PR DESCRIPTION
## ELI5

After the WSL transcript gate landed, a lookup that is cancelled at the same moment a share times out could be reported as "the distro is unavailable" instead of "the caller went away." This PR keeps the cancellation as the result.

## What Changed

Follows #14090. That PR turned a stalled WSL share into an unavailability refusal so a miss is not confused with a hang. This PR covers the leftover race: if the caller aborts while that refusal is being classified, the abort stays authoritative and is not rewritten as a gate failure.

The same check is on the hook-path probe and on each scanned Codex root. Two regression tests pin both races.

## Why

A cancelled Native Chat resolve should not look like a stuck distro. Downstream retry and fallback logic treats a `WslTranscriptFsError` as infrastructure unavailability; an abort is "stop, the caller is gone." Mixing them can enqueue work the user already abandoned.

## Linked Issue

Related to STA-3885
Related: #14090

## Visual Proof

N/A — no UI or interaction change. This is resolver error-precedence only.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

`pnpm exec vitest run --config config/vitest.config.ts src/main/native-chat/session-file-resolver-wsl-scan-gate.test.ts` — 8 passed, including the two new abort-vs-refusal races.

Not re-run on Windows/WSL in this follow-up; the race is unit-tested by aborting the signal in the same turn the gate throws.

## AI Disclosure

N/A — internal contributor.

## Review

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

- **Cross-platform:** Windows/WSL UNC path only. Local and Linux/macOS session roots do not enter these catch paths.
- **SSH/remote:** The main process on the host that owns the transcript still resolves; a remote client abort still needs to remain an abort, not an unavailability refusal.
- **Agents:** Codex hook-path and Codex session-dir scan only. Claude/Grok/OMP resolvers are unchanged.
- **Performance:** Two `throwIfAborted()` checks after a failed I/O; no extra filesystem work.
- **Security / UI:** No new user input, no visual surface.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter:
