### PR TITLE
fix(test): deflake relay exec env, project boundary, and speech resume tests

### DIFF
--- a/src/main/speech/model-manager-download-resume.test.ts
+++ b/src/main/speech/model-manager-download-resume.test.ts
@@ -37,6 +37,7 @@ type ModelManagerInternals = {
     redirectCount?: number,
     resumeOffset?: number
   ) => Promise<void>
+  getPartialDownloadBytes: (filePath: string) => number
 }
 
 type ScriptedResponse = {
@@ -288,11 +289,13 @@ describe('ModelManager download resume', () => {
       const manager = new ModelManager(dir) as unknown as ModelManagerInternals
       const filePath = join(dir, 'model.bin')
       let bytesWritten = 0
+      // Why: the ceiling costs 4096 iterations, so read progress from memory —
+      // real per-iteration file I/O stalls this test under parallel load.
+      vi.spyOn(manager, 'getPartialDownloadBytes').mockImplementation(() => bytesWritten)
       // Advances one byte per request against a total larger than the request
       // ceiling, so it makes forward progress forever without ever completing.
       const downloadFileMock = vi.spyOn(manager, 'downloadFile').mockImplementation(() => {
         bytesWritten += 1
-        writeFileSync(filePath, Buffer.alloc(bytesWritten))
         return Promise.resolve()
       })
 

--- a/src/relay/agent-exec-handler.test.ts
+++ b/src/relay/agent-exec-handler.test.ts
@@ -1,5 +1,5 @@
 import { execFile, spawn } from 'node:child_process'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as ChildProcess from 'node:child_process'
 import { createFakeChild, createHandlers, requestContext } from './agent-exec-handler-test-harness'
 import { TERMINAL_GIT_CREDENTIAL_GUARD_POLICY_ENV } from '../shared/terminal-git-credential-guard'
@@ -18,10 +18,29 @@ const execFileMock = vi.mocked(execFile)
 
 type AgentExecResult = { exitCode: number | null; timedOut: boolean }
 
+const GUARD_OWNED_ENV_RE = /^(?:GIT_CONFIG_(?:COUNT|KEY_\d+|VALUE_\d+)|WSLENV)$/
+
 describe('AgentExecHandler', () => {
+  let ambientGuardEnv: Record<string, string | undefined> = {}
+
   beforeEach(() => {
     spawnMock.mockReset()
     execFileMock.mockReset()
+    // Why: the guard rewrites these, so an already-guarded runner (Orca guards
+    // its own agent terminals) would not see its ambient values passed through.
+    ambientGuardEnv = {}
+    for (const key of Object.keys(process.env).filter((name) => GUARD_OWNED_ENV_RE.test(name))) {
+      ambientGuardEnv[key] = process.env[key]
+      delete process.env[key]
+    }
+  })
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(ambientGuardEnv)) {
+      if (value !== undefined) {
+        process.env[key] = value
+      }
+    }
   })
 
   it('executes a non-interactive command with captured output and stdin', async () => {

--- a/src/renderer/src/components/github-project/ProjectViewWrapper.tsx
+++ b/src/renderer/src/components/github-project/ProjectViewWrapper.tsx
@@ -65,6 +65,7 @@ import {
   githubProjectHost,
   githubProjectIdentityKey
 } from '../../../../shared/github/project-identity'
+import { buildProjectWorkItem } from './project-work-item'
 
 type Props = {
   selectedRepoIds: ReadonlySet<string>
@@ -92,43 +93,6 @@ function listProjectViewsForRuntime(
 function getProjectViewSourceScope(settings: Parameters<typeof getActiveRuntimeTarget>[0]): string {
   const target = getActiveRuntimeTarget(settings)
   return target.kind === 'environment' ? `runtime:${target.environmentId}` : 'local'
-}
-
-export function buildProjectWorkItem(
-  row: GitHubProjectRow,
-  repoId: string,
-  host?: string
-): GitHubWorkItem | null {
-  if (row.itemType !== 'ISSUE' && row.itemType !== 'PULL_REQUEST') {
-    return null
-  }
-  if (row.content.number == null || !row.content.url) {
-    return null
-  }
-  const [owner, repo] = row.content.repository?.split('/') ?? []
-  // Why: Project rows can reach mutation controls before detail hydration, so
-  // preserve their host-bearing repository identity on the initial item.
-  const prRepo = owner && repo ? { owner, repo, host: githubProjectHost(host) } : undefined
-  return {
-    id: `${row.itemType === 'PULL_REQUEST' ? 'pr' : 'issue'}:${row.content.number}`,
-    type: row.itemType === 'PULL_REQUEST' ? 'pr' : 'issue',
-    number: row.content.number,
-    title: row.content.title,
-    state:
-      row.content.state === 'MERGED'
-        ? 'merged'
-        : row.content.state === 'CLOSED'
-          ? 'closed'
-          : row.content.isDraft
-            ? 'draft'
-            : 'open',
-    url: row.content.url,
-    labels: row.content.labels.map((label) => label.name),
-    updatedAt: row.updatedAt,
-    author: null,
-    repoId,
-    prRepo
-  }
 }
 
 export default function ProjectViewWrapper({ selectedRepoIds }: Props): React.JSX.Element {

--- a/src/renderer/src/components/github-project/project-view-wrapper-source-context-boundary.test.ts
+++ b/src/renderer/src/components/github-project/project-view-wrapper-source-context-boundary.test.ts
@@ -1,5 +1,3 @@
-// @vitest-environment happy-dom
-
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
@@ -21,7 +19,7 @@ function sourceBetween(source: string, startPattern: string, endPattern: string)
 
 describe('ProjectViewWrapper GitHub source context boundary', () => {
   it('builds project work items with a host-pinned repository identity', async () => {
-    const { buildProjectWorkItem } = await import('./ProjectViewWrapper')
+    const { buildProjectWorkItem } = await import('./project-work-item')
     const row: GitHubProjectRow = {
       id: 'PVTI_1',
       itemType: 'PULL_REQUEST',

--- a/src/renderer/src/components/github-project/project-work-item.ts
+++ b/src/renderer/src/components/github-project/project-work-item.ts
@@ -1,0 +1,40 @@
+import { githubProjectHost } from '../../../../shared/github/project-identity'
+import type { GitHubProjectRow } from '../../../../shared/github/project-types'
+import type { GitHubWorkItem } from '../../../../shared/types'
+
+export function buildProjectWorkItem(
+  row: GitHubProjectRow,
+  repoId: string,
+  host?: string
+): GitHubWorkItem | null {
+  if (row.itemType !== 'ISSUE' && row.itemType !== 'PULL_REQUEST') {
+    return null
+  }
+  if (row.content.number == null || !row.content.url) {
+    return null
+  }
+  const [owner, repo] = row.content.repository?.split('/') ?? []
+  // Why: Project rows can reach mutation controls before detail hydration, so
+  // preserve their host-bearing repository identity on the initial item.
+  const prRepo = owner && repo ? { owner, repo, host: githubProjectHost(host) } : undefined
+  return {
+    id: `${row.itemType === 'PULL_REQUEST' ? 'pr' : 'issue'}:${row.content.number}`,
+    type: row.itemType === 'PULL_REQUEST' ? 'pr' : 'issue',
+    number: row.content.number,
+    title: row.content.title,
+    state:
+      row.content.state === 'MERGED'
+        ? 'merged'
+        : row.content.state === 'CLOSED'
+          ? 'closed'
+          : row.content.isDraft
+            ? 'draft'
+            : 'open',
+    url: row.content.url,
+    labels: row.content.labels.map((label) => label.name),
+    updatedAt: row.updatedAt,
+    author: null,
+    repoId,
+    prRepo
+  }
+}


### PR DESCRIPTION
Three test-suite problems that kept surfacing while landing #14397 / #14403 / #14437. **All three are root-caused in the tests — production behavior is correct in every case.**

## 1. `src/relay/agent-exec-handler.test.ts` — a real failure, and *not* a `main` regression

This one is worth reading, because it looks like a broken `main` and isn't.

Both tests assert `expect.objectContaining({ ...process.env, ... })`, which demands that **every ambient variable reach the child verbatim**. But the handler applies `applyTerminalGitCredentialPromptGuard`, which appends its own entries to Git's indexed-config protocol (`GIT_CONFIG_COUNT` / `KEY_n` / `VALUE_n`).

So when the test runner's own environment already carries that protocol — **exactly what Orca exports into its agent terminals** — the snapshot expects `GIT_CONFIG_COUNT=2` while the correctly-guarded child gets `4`.

> It passes on a bare CI shell and fails when run from a guarded terminal.

That's why CI stayed green on all three merged PRs while this failed locally on every run. #7986 (`1a6abc87d11`) changed both sides at once: it rewrote the assertion into the `objectContaining` form *and* made the handler apply the guard.

The implementation is right — appending the guard after the caller's config is the documented contract. Fixed by clearing the guard-owned keys (`GIT_CONFIG_*`, `WSLENV`) from the ambient env for the duration of the suite and restoring them after, so the passthrough baseline is deterministic. **No assertion weakened or removed.**

## 2. `project-view-wrapper-source-context-boundary.test.ts` — 30s timeout flake

`buildProjectWorkItem` is a pure function, but it lived in `ProjectViewWrapper.tsx` — so importing it pulled in the store, sonner, lucide, and the whole UI kit: **~8.8s of transform and module evaluation for one assertion**, which tipped past 30s under parallel load.

Extracted to `project-work-item.ts` (only dependency: `githubProjectHost`). Both test cases unchanged; dropped the now-unneeded `happy-dom` environment since nothing touches the DOM.

**9.15s → 0.12s.**

## 3. `model-manager-download-resume.test.ts` — 30s timeout flake

The "pathologically tiny segments" case drives the loop to the `MAX_TOTAL_DOWNLOAD_REQUESTS` ceiling of 4096. Each iteration did a real `writeFileSync` plus two `statSync` via `getPartialDownloadBytes` — **~12k synchronous filesystem syscalls in a tight loop**. Fast on an idle disk, but it serializes against every other vitest worker on a loaded machine.

Stubbed `getPartialDownloadBytes` to read the byte counter the test already maintains, so the loop is pure CPU. The file was only ever a stand-in for that counter; ceiling and rejection assertions unchanged.

**332ms → 15ms.**

The two remaining ~1.1s cases in that file sit on the real 1s retry backoff around real stream/file-write plumbing. Left on real timers deliberately — faking them would mean faking the transport too, and 1.1s leaves ample headroom.

## Verification

- All three files pass: **27 tests in 3.43s** (previously: 2 hard failures + two suites near the 30s cliff).
- Cold `tsc --noEmit` green on node, cli, and web (buildinfo deleted first — these projects are `composite: true` and reuse stale caches).
- `buildProjectWorkItem` extraction verified: both call sites in `ProjectViewWrapper.tsx` intact, no other consumers.