### PR TITLE
fix(shell-ready): trim trailing PROMPT_COMMAND separator in the daemon bash wrapper

### DIFF
--- a/src/main/daemon/shell-ready.test.ts
+++ b/src/main/daemon/shell-ready.test.ts
@@ -792,6 +792,23 @@ describePosix('daemon shell-ready launch config', () => {
     expectBashOsc133Lifecycle(output)
   })
 
+  itWithBash('trims a trailing separator so the append cannot form ";;"', async () => {
+    // Why: `zoxide init bash` leaves "__zoxide_hook;" when PROMPT_COMMAND was empty, and
+    // appending ";__orca_osc133_epilogue" to that makes bash reject the whole PROMPT_COMMAND,
+    // which silently takes the OSC 133 markers down with it.
+    const { getDaemonBashShellReadyRcfileContent } = await importFreshShellReady()
+    writeFileSync(
+      join(userDataPath, '.bash_profile'),
+      'PROMPT_COMMAND=\'AFTER_TRAILING_PROMPT=1; printf "PROMPT_TRAILING\\n";\'\n'
+    )
+
+    const output = runInteractiveBashRcfile(getDaemonBashShellReadyRcfileContent(), userDataPath)
+
+    expect(output).not.toContain('syntax error')
+    expect(output).toContain('PROMPT_TRAILING')
+    expectBashOsc133Lifecycle(output)
+  })
+
   it('preserves a real inherited ZDOTDIR as ORCA_ORIG_ZDOTDIR', async () => {
     // Why: only the wrapper self-loop should be rejected; a real user ZDOTDIR must round-trip so their configs load.
     const previousZdotdir = process.env.ZDOTDIR

--- a/src/main/daemon/shell-ready.ts
+++ b/src/main/daemon/shell-ready.ts
@@ -197,6 +197,12 @@ __orca_normalize_prompt_command() {
     done
     PROMPT_COMMAND="$__orca_joined"
   fi
+  # Why: an integration such as zoxide, or a RHEL-family /etc/bashrc, can leave
+  # PROMPT_COMMAND ending in a ";"/whitespace separator; trim it so the append
+  # below never forms ";;", which bash rejects for the whole PROMPT_COMMAND.
+  while [[ "\${PROMPT_COMMAND:-}" == *[[:space:]\\;] ]]; do
+    PROMPT_COMMAND="\${PROMPT_COMMAND%?}"
+  done
 }
 __orca_normalize_prompt_command
 PROMPT_COMMAND="__orca_osc133_precmd\${PROMPT_COMMAND:+;\${PROMPT_COMMAND}};__orca_osc133_epilogue"


### PR DESCRIPTION
## ELI5

If your shell config leaves `PROMPT_COMMAND` ending in a `;`, Orca's daemon wrapper glues its own hooks on and you end up with `;;`, which bash refuses to run. This trims that stray `;` first. The relay wrapper already does this, the daemon wrapper just never got the same guard.

## What Changed

Added the trailing-separator trim to `__orca_normalize_prompt_command` in `src/main/daemon/shell-ready.ts`, mirroring the loop already present in `src/relay/pty-shell-launch.ts`:

```bash
while [[ "${PROMPT_COMMAND:-}" == *[[:space:]\;] ]]; do
  PROMPT_COMMAND="${PROMPT_COMMAND%?}"
done
```

Added a bash integration test alongside the existing array-normalization one, asserting no syntax error and a clean OSC 133 lifecycle when the inherited `PROMPT_COMMAND` ends in a separator.

## Why

`zoxide init bash` emits:

```bash
PROMPT_COMMAND="__zoxide_hook;${PROMPT_COMMAND#;}"
```

If `PROMPT_COMMAND` was empty when zoxide initialised, that leaves `__zoxide_hook;`. The daemon wrapper then does:

```bash
PROMPT_COMMAND="__orca_osc133_precmd${PROMPT_COMMAND:+;${PROMPT_COMMAND}};__orca_osc133_epilogue"
```

The `:+` guard covers an empty value but not a value that is only a separator, so the result is `__orca_osc133_precmd;__zoxide_hook;;__orca_osc133_epilogue` and every prompt prints:

```
bash: PROMPT_COMMAND: line 1: syntax error near unexpected token `;;'
```

The visible error is noise, but the real cost is that the entire `PROMPT_COMMAND` fails to parse, so neither `__orca_osc133_precmd` nor `__orca_osc133_epilogue` runs. No `133;A`, no `133;D`, and because the epilogue never re-arms the DEBUG trap, no `133;C` either. Command lifecycle tracking is silently dead in that terminal.

Trimming in `__orca_normalize_prompt_command` matches where the relay wrapper does it, so both wrappers now normalise the same way before appending.

`src/main/providers/local-pty-shell-ready.ts` has the same missing trim, but it appends nothing after the user's chain, so a trailing separator there yields a harmless `precmd;user_hook;`. I left it alone to keep this focused. Happy to include it if you would rather all three wrappers normalise identically.

## Linked Issue

Fixes #14448

## Visual Proof

`N/A`. Terminal shell integration, no UI surface. The observable change is the absence of the `PROMPT_COMMAND` syntax error and the OSC 133 markers firing again, both covered by the new test.

## Testing

Verified the trim against real bash across the relevant inputs, checking the composed value parses:

```bash
for v in "__zoxide_hook;" "__zoxide_hook; " "__zoxide_hook" "" "a;b;"; do
  PROMPT_COMMAND="$v"
  while [[ "${PROMPT_COMMAND:-}" == *[[:space:]\;] ]]; do PROMPT_COMMAND="${PROMPT_COMMAND%?}"; done
  RESULT="__orca_osc133_precmd${PROMPT_COMMAND:+;${PROMPT_COMMAND}};__orca_osc133_epilogue"
  bash -n <<< "$RESULT" && echo "ok: $RESULT"
done
```

All five parse, including the previously broken `__zoxide_hook;` case, and the empty case still collapses to `precmd;epilogue` with no stray separator.

Reproduced the original bug on Ubuntu 24.04 aarch64, bash 5.2.21, zoxide 0.9.6, Orca v1.4.182, against `orca serve`, and confirmed the trimmed value is what the fixed wrapper should produce.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Platforms: tested on Linux. Not tested on macOS or Windows. The change is bash-only and the trim is a pure string operation on a value the wrapper already owns, so I would not expect platform variance, but I have not run the suite on the other two.

I edited via the GitHub API rather than a local checkout, so `pnpm lint` / `typecheck` / `test` have not been run locally. Relying on CI for those.

## AI Disclosure

Claude Opus 5, used through Claude Code to investigate the failure, locate the existing relay guard, draft the patch and the test, and write this description. Direction and review by me.

## Review

Security: none, no new input is trusted and the trim only removes trailing separators from a value the wrapper already interpolates.

Cross-platform: bash-only path, so macOS and Linux are affected identically and Windows is untouched. Remote SSH and the relay path already had this guard, so this brings the daemon path in line rather than diverging it.

Backwards compatibility: a `PROMPT_COMMAND` with no trailing separator is unchanged, since the loop does not execute. Behaviour only differs for values that previously produced a broken result.

Performance: a bounded string loop once per shell startup.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred). Not run locally, see Testing. CI will cover.

## Author

- X / Twitter: N/A

---

🤖 Generated with Claude Code (Claude Opus 5)
🧑‍💻 Ideated, directed and reviewed by a human, @oliver-mee
