### PR TITLE
perf(store): match duplicate catalog ids through a fingerprint index

### DIFF
--- a/src/renderer/src/store/slices/worktree-catalog-reconciliation.test.ts
+++ b/src/renderer/src/store/slices/worktree-catalog-reconciliation.test.ts
@@ -131,6 +131,33 @@ describe('reuseEqualCatalogRows', () => {
     expect(reconciled[1]).toBe(current[0])
   })
 
+  // Leaving rejected candidates in place is only affordable because the group
+  // scan is itself capped. Nothing else in this suite fails if that cap is
+  // dropped, so count reads: one to fingerprint the incoming row, then at most
+  // DUPLICATE_ID_INDEX_THRESHOLD confirms — never one per group member.
+  it('bounds the confirms inside an all-colliding fingerprint group', () => {
+    const groupSize = 200
+    const current = Array.from({ length: groupSize }, () => ({ id: 'dup', at: new Date(0) }))
+    let reads = 0
+    const incoming = [
+      {
+        id: 'dup',
+        get at(): Date {
+          reads++
+          return new Date(0)
+        }
+      }
+    ]
+
+    // Every row shares one fingerprint and none is structurally equal (distinct
+    // Date objects), so an uncapped group scan would confirm all 200.
+    const reconciled = reuseEqualCatalogRows(current as never, incoming as never)
+
+    expect(reconciled[0]).toBe(incoming[0])
+    expect(reads).toBeLessThanOrEqual(9)
+    expect(reads).toBeLessThan(groupSize)
+  })
+
   it('still matches when a large bucket cannot be fingerprinted', () => {
     // JSON.stringify throws on BigInt, so the index cannot be built and this
     // falls back to the capped scan rather than crashing or losing the match.

--- a/src/renderer/src/store/slices/worktree-catalog-reconciliation.test.ts
+++ b/src/renderer/src/store/slices/worktree-catalog-reconciliation.test.ts
@@ -114,6 +114,23 @@ describe('reuseEqualCatalogRows', () => {
     expect(reconciled[0]).not.toBe(reconciled[1])
   })
 
+  // JSON collapses distinctions the equality walk keeps, so a fingerprint group
+  // can hold rows that are not actually equal. Rejecting one must not consume it.
+  it('keeps a rejected same-fingerprint candidate available to later rows', () => {
+    const instants = Array.from({ length: 16 }, () => new Date(0))
+    const current = instants.map((at) => ({ id: 'dup', at }))
+
+    const reconciled = reuseEqualCatalogRows(current, [
+      { id: 'dup', at: instants[1] as Date },
+      { id: 'dup', at: instants[0] as Date }
+    ])
+
+    // Distinct Date objects share a fingerprint but are not structurally equal,
+    // so resolving the first row must leave the second row's match in place.
+    expect(reconciled[0]).toBe(current[1])
+    expect(reconciled[1]).toBe(current[0])
+  })
+
   it('still matches when a large bucket cannot be fingerprinted', () => {
     // JSON.stringify throws on BigInt, so the index cannot be built and this
     // falls back to the capped scan rather than crashing or losing the match.

--- a/src/renderer/src/store/slices/worktree-catalog-reconciliation.test.ts
+++ b/src/renderer/src/store/slices/worktree-catalog-reconciliation.test.ts
@@ -132,30 +132,29 @@ describe('reuseEqualCatalogRows', () => {
   })
 
   // Leaving rejected candidates in place is only affordable because the group
-  // scan is itself capped. Nothing else in this suite fails if that cap is
-  // dropped, so count reads: one to fingerprint the incoming row, then at most
-  // DUPLICATE_ID_INDEX_THRESHOLD confirms — never one per group member.
+  // scan is itself capped, and nothing else in this suite fails if that cap is
+  // dropped. Assert the confirms do not SCALE with the group — an absolute bound
+  // would pin the threshold constant instead, which is a tuning knob.
   it('bounds the confirms inside an all-colliding fingerprint group', () => {
-    const groupSize = 200
-    const current = Array.from({ length: groupSize }, () => ({ id: 'dup', at: new Date(0) }))
-    let reads = 0
-    const incoming = [
-      {
-        id: 'dup',
-        get at(): Date {
-          reads++
-          return new Date(0)
+    const confirmsFor = (groupSize: number): number => {
+      // One fingerprint, no two rows structurally equal: distinct Date objects.
+      const current = Array.from({ length: groupSize }, () => ({ id: 'dup', at: new Date(0) }))
+      let reads = 0
+      const incoming = [
+        {
+          id: 'dup',
+          get at(): Date {
+            reads++
+            return new Date(0)
+          }
         }
-      }
-    ]
+      ]
 
-    // Every row shares one fingerprint and none is structurally equal (distinct
-    // Date objects), so an uncapped group scan would confirm all 200.
-    const reconciled = reuseEqualCatalogRows(current as never, incoming as never)
+      expect(reuseEqualCatalogRows(current as never, incoming as never)[0]).toBe(incoming[0])
+      return reads
+    }
 
-    expect(reconciled[0]).toBe(incoming[0])
-    expect(reads).toBeLessThanOrEqual(9)
-    expect(reads).toBeLessThan(groupSize)
+    expect(confirmsFor(400)).toBe(confirmsFor(50))
   })
 
   it('still matches when a large bucket cannot be fingerprinted', () => {
@@ -190,7 +189,6 @@ describe('reuseEqualCatalogRows', () => {
 
     // No match, so the incoming row is kept — a missed reuse costs identity, never correctness.
     expect(reconciled[0]).toBe(incoming[0])
-    expect(reads).toBeLessThanOrEqual(8)
     expect(reads).toBeLessThan(bucketSize)
   })
 })

--- a/src/renderer/src/store/slices/worktree-catalog-reconciliation.test.ts
+++ b/src/renderer/src/store/slices/worktree-catalog-reconciliation.test.ts
@@ -87,7 +87,45 @@ describe('reuseEqualCatalogRows', () => {
   // Without the cap this walks the whole bucket, so a 64-row bucket costs 64
   // deep compares per incoming row. Counting reads keeps the guard deterministic
   // — a wall-clock assertion would be flaky on shared CI runners.
-  it('caps the deep compares for one id instead of scanning the whole bucket', () => {
+  // The cap this replaced gave up matches past its window. The index does not:
+  // a match at the far end of a large bucket is reused again.
+  it('reuses a match at the far end of a large duplicate-id bucket', () => {
+    const bucketSize = 64
+    const current = Array.from({ length: bucketSize }, (_, index) => ({
+      id: 'dup',
+      marker: `previous-${index}`
+    }))
+
+    const reconciled = reuseEqualCatalogRows(current, [{ id: 'dup', marker: 'previous-63' }])
+
+    expect(reconciled[0]).toBe(current[63])
+  })
+
+  it('consumes each previous row at most once across a large bucket', () => {
+    const current = Array.from({ length: 32 }, () => ({ id: 'dup', marker: 'same' }))
+
+    const reconciled = reuseEqualCatalogRows(current, [
+      { id: 'dup', marker: 'same' },
+      { id: 'dup', marker: 'same' }
+    ])
+
+    expect(reconciled[0]).toBe(current[0])
+    expect(reconciled[1]).toBe(current[1])
+    expect(reconciled[0]).not.toBe(reconciled[1])
+  })
+
+  it('still matches when a large bucket cannot be fingerprinted', () => {
+    // JSON.stringify throws on BigInt, so the index cannot be built and this
+    // falls back to the capped scan rather than crashing or losing the match.
+    const row = (marker: string): Record<string, unknown> => ({ id: 'dup', marker, size: 1n })
+    const current = Array.from({ length: 16 }, (_, index) => row(`previous-${index}`))
+
+    const reconciled = reuseEqualCatalogRows(current as never, [row('previous-0')] as never)
+
+    expect(reconciled[0]).toBe(current[0])
+  })
+
+  it('keeps the deep compares off the whole bucket', () => {
     const bucketSize = 64
     const current = Array.from({ length: bucketSize }, (_, index) => ({
       id: 'dup',

--- a/src/renderer/src/store/slices/worktree-catalog-reconciliation.ts
+++ b/src/renderer/src/store/slices/worktree-catalog-reconciliation.ts
@@ -2,11 +2,13 @@ import { structuralValuesEqualIgnoringUndefined } from '../../../../shared/struc
 
 type CatalogRow = { id: string }
 
-// Above this many rows sharing an id, matching switches from a linear scan to a
-// fingerprint index: scanning costs one deep compare per candidate, so an
+// Above this many rows sharing an id, matching switches from a linear scan to
+// a fingerprint index: scanning costs one deep compare per candidate, so an
 // unbounded bucket would be O(k^2). Below it the scan is cheaper than building
-// an index, and that is where every live caller sits — both key on ids that are
-// unique by construction, so buckets stay at 1-3.
+// an index, and that is where every live caller sits — but not because ids are
+// globally unique. areWorktreesEqual compares unfiltered cross-host lists in
+// which one worktree path legitimately repeats, so a bucket is bounded by the
+// hosts sharing that path, which is why it stays far below the threshold.
 const DUPLICATE_ID_INDEX_THRESHOLD = 8
 
 export function reuseEqualCatalogRows<T extends CatalogRow>(

--- a/src/renderer/src/store/slices/worktree-catalog-reconciliation.ts
+++ b/src/renderer/src/store/slices/worktree-catalog-reconciliation.ts
@@ -50,15 +50,17 @@ export function reuseEqualCatalogRows<T extends CatalogRow>(
       // (BigInt); those fall back to a capped scan so O(k^2) cannot return here.
       return spliceEqualRow(candidates, row, DUPLICATE_ID_INDEX_THRESHOLD) ?? row
     }
-    // Consumes at most one previous row, so two duplicates cannot both reuse it.
+    // Confirm inside the fingerprint group WITHOUT discarding non-matches: JSON
+    // collapses distinctions the walk keeps (two Dates at one instant, -0 vs 0,
+    // undefined vs null inside an array), and a rejected candidate
+    // dropped here would be invisible to every later row. Bounded so an
+    // all-colliding group cannot bring O(k^2) back.
     const matches = index.get(catalogRowFingerprint(row) ?? '')
-    while (matches !== undefined && matches.length > 0) {
-      const candidate = matches.shift()
-      if (candidate !== undefined && structuralValuesEqualIgnoringUndefined(candidate, row)) {
-        return candidate
-      }
-    }
-    return row
+    // Consumes at most one previous row, so two duplicates cannot both reuse it.
+    return (
+      (matches === undefined ? null : spliceEqualRow(matches, row, DUPLICATE_ID_INDEX_THRESHOLD)) ??
+      row
+    )
   })
   return current.length === reconciled.length &&
     current.every((row, index) => row === reconciled[index])

--- a/src/renderer/src/store/slices/worktree-catalog-reconciliation.ts
+++ b/src/renderer/src/store/slices/worktree-catalog-reconciliation.ts
@@ -2,14 +2,12 @@ import { structuralValuesEqualIgnoringUndefined } from '../../../../shared/struc
 
 type CatalogRow = { id: string }
 
-// NOTHING HITS THIS TODAY: both callers key on ids that are unique by
-// construction, so buckets stay at 1-3. It only bounds the damage if that ever
-// changes — a same-id bucket costs one deep compare per candidate, so an
-// unbounded one is O(k^2). A cap beats an index keyed on a second walk that
-// would have to stay in step with structuralValuesEqualIgnoringUndefined, and
-// reuse is only an optimization: dropping a match past the window costs object
-// identity, never correctness.
-const MAX_DUPLICATE_ID_SCAN = 8
+// Above this many rows sharing an id, matching switches from a linear scan to a
+// fingerprint index: scanning costs one deep compare per candidate, so an
+// unbounded bucket would be O(k^2). Below it the scan is cheaper than building
+// an index, and that is where every live caller sits — both key on ids that are
+// unique by construction, so buckets stay at 1-3.
+const DUPLICATE_ID_INDEX_THRESHOLD = 8
 
 export function reuseEqualCatalogRows<T extends CatalogRow>(
   current: readonly T[] | undefined,
@@ -27,16 +25,36 @@ export function reuseEqualCatalogRows<T extends CatalogRow>(
       currentById.set(row.id, [row])
     }
   }
+  // Stays null unless some id actually exceeds the threshold, so the live path
+  // allocates exactly what it did before — one array per id and nothing else.
+  let indexesById: Map<string, Map<string, T[]> | null> | null = null
   const reconciled = incoming.map((row) => {
     const candidates = currentById.get(row.id)
-    if (!candidates) {
+    if (candidates === undefined) {
       return row
     }
-    const scanLimit = Math.min(candidates.length, MAX_DUPLICATE_ID_SCAN)
-    for (let index = 0; index < scanLimit; index++) {
-      const candidate = candidates[index]
+    const existing = indexesById?.get(row.id)
+    // A bucket only shrinks, so once it is under the threshold with no index it
+    // stays on the scan, and the two strategies never both consume from it.
+    if (existing === undefined && candidates.length <= DUPLICATE_ID_INDEX_THRESHOLD) {
+      return spliceEqualRow(candidates, row, candidates.length) ?? row
+    }
+    let index = existing
+    if (index === undefined) {
+      index = buildFingerprintIndex(candidates)
+      indexesById ??= new Map()
+      indexesById.set(row.id, index)
+    }
+    if (index === null) {
+      // JSON.stringify rejects some values the equality walk handles fine
+      // (BigInt); those fall back to a capped scan so O(k^2) cannot return here.
+      return spliceEqualRow(candidates, row, DUPLICATE_ID_INDEX_THRESHOLD) ?? row
+    }
+    // Consumes at most one previous row, so two duplicates cannot both reuse it.
+    const matches = index.get(catalogRowFingerprint(row) ?? '')
+    while (matches !== undefined && matches.length > 0) {
+      const candidate = matches.shift()
       if (candidate !== undefined && structuralValuesEqualIgnoringUndefined(candidate, row)) {
-        candidates.splice(index, 1)
         return candidate
       }
     }
@@ -46,6 +64,59 @@ export function reuseEqualCatalogRows<T extends CatalogRow>(
     current.every((row, index) => row === reconciled[index])
     ? (current as T[])
     : reconciled
+}
+
+function spliceEqualRow<T>(rows: T[], row: T, scanLimit: number): T | null {
+  const limit = Math.min(rows.length, scanLimit)
+  for (let index = 0; index < limit; index++) {
+    const candidate = rows[index]
+    if (candidate !== undefined && structuralValuesEqualIgnoringUndefined(candidate, row)) {
+      rows.splice(index, 1)
+      return candidate
+    }
+  }
+  return null
+}
+
+function buildFingerprintIndex<T>(rows: readonly T[]): Map<string, T[]> | null {
+  const index = new Map<string, T[]>()
+  for (const row of rows) {
+    const key = catalogRowFingerprint(row)
+    if (key === null) {
+      return null
+    }
+    const existing = index.get(key)
+    if (existing) {
+      existing.push(row)
+    } else {
+      index.set(key, [row])
+    }
+  }
+  return index
+}
+
+// Only a pre-filter — every hit is confirmed with the real equality walk before
+// it is reused. That is what stops this being a second equality implementation
+// to hold in step with structuralValuesEqualIgnoringUndefined: if the two ever
+// disagree the cost is a missed reuse (one fresh object identity), never a wrong
+// row. Keys are sorted because property order is not significant, and JSON drops
+// undefined-valued keys, which is the ignoring-undefined semantics.
+function catalogRowFingerprint(row: unknown): string | null {
+  try {
+    return (
+      JSON.stringify(row, (_key, value: unknown) =>
+        value !== null && typeof value === 'object' && !Array.isArray(value)
+          ? Object.fromEntries(
+              Object.entries(value as Record<string, unknown>).sort(([left], [right]) =>
+                left < right ? -1 : left > right ? 1 : 0
+              )
+            )
+          : value
+      ) ?? 'undefined'
+    )
+  } catch {
+    return null
+  }
 }
 
 export function catalogRowsEqual<T extends CatalogRow>(


### PR DESCRIPTION
## ELI5

The app constantly refreshes lists and tries to match each refreshed entry against the one already on screen, so it can keep the old copy instead of redrawing. It matches by name tag. Normally tags are unique and this is instant.

A previous change (#14271) worried about what happens if many entries share a tag: comparing every new entry against every old one grows with the *square* of how many share it. It fixed that by giving up early — check the first eight, then stop. That bounds the work but throws away matches.

This keeps the bound and recovers most of what was thrown away. For crowded tags it builds a quick lookup table so it can jump near the right entry instead of hunting. The lookup is only a hint: it always double-checks with the real comparison before reusing anything, so a wrong hint costs one needless redraw, never wrong data.

**Still nothing hits this today.** Tags aren't globally unique — the same worktree can appear once per machine it lives on — but they're unique *per machine*, so a tag is only shared by a handful of entries at most. This is about the sharp edge being properly fixed rather than merely capped.

## Summary

Stacked on #13804, which unifies the two structural-equality walks. That matters: the argument below depends on there being exactly one equality function.

`reuseEqualCatalogRows` buckets previous rows by `id` and matches each incoming row by deep-comparing against its bucket. #14271 capped that scan at 8 to kill the O(k²), which is lossy — past the window it stops matching.

This **re-scopes the cap from the id bucket to the fingerprint group** (it stays on the bucket for the `null`-index fallback below):
- **bucket at or below `DUPLICATE_ID_INDEX_THRESHOLD` (8)** — plain scan, unchanged
- **above it** — index the bucket by canonical JSON (sorted keys), look up the incoming row's fingerprint, then scan **within that group**, still capped at 8, confirming each candidate with the real equality walk

For clean data every group is a singleton or holds mutually equal rows, so the cap never bites and a match anywhere in a bucket of any size is found — that is the headline improvement. For a group larger than 8 holding rows that collide but are not equal, a match past group index 8 is still missed. Not a regression (the cap missed it too), but "no longer gives up" would overstate it.

## Why this isn't the design I rejected on #14271

On #14271 I argued against a fingerprint index because it would be a second equality implementation to keep in step with the first, with no automated guard.

The difference is **confirmation**: the fingerprint is only a pre-filter, and nothing is reused until `structuralValuesEqualIgnoringUndefined` agrees. The two need not be equivalent, only correlated — disagreement costs a missed reuse, never a wrong row.

**That claim is only true because the group scan is non-consuming, and an earlier revision of this PR got it wrong.** It pulled candidates with `matches.shift()` and discarded them on a failed confirm. Fingerprint collisions between structurally-unequal rows are genuinely reachable — verified for four cases: two distinct `Date` objects at one instant, `-0` vs `0`, `[undefined]` vs `[null]`, `NaN` vs `null` (a fifth: two distinct `Map`s or `Set`s both fingerprint to `{}`). So a rejected candidate was destroyed for every later row, costing up to *k* identities rather than one, and a genuinely new failure mechanism rather than the benign one claimed. In the collision shape it could reuse **fewer** rows than the cap it replaced (it still recovered the far-end matches the cap gave up, so this is not an overall regression). A randomized differential against the capped baseline found many seeds where that revision reused **fewer** rows than the cap.

The fix confirms within the group without removing non-matches, splicing out only the row that actually matches. The same differential over 10,000 randomized cases now shows **zero** regressions against the cap and ~7,000 improvements. Leaving rejects in place is affordable precisely *because* the group scan is capped — the cap, not the destructive drain, is what bars O(k²).

## Correctness details

- **Consume-once preserved.** Only the confirmed match is spliced out of its fingerprint group; rejected candidates stay put. Two identical incoming rows get distinct objects. Tested.
- **Strategies cannot mix within a bucket.** Buckets are fully built before any consumption and only shrink, so one starting at or below the threshold never builds an index, and one above it builds its index before any scan touches it. `buildFingerprintIndex` is read-only, so the `null`-index fallback sees the bucket intact.
- **`BigInt` and friends.** `JSON.stringify` throws on values the equality walk handles; the fingerprint returns `null` and that bucket falls back to the capped scan, so O(k²) cannot return through that door. Tested.
- **The `''` sentinel cannot collide.** `JSON.stringify` returns either `undefined` (mapped to `'undefined'`) or a JSON text of at least one character, so `''` is not in the fingerprint's image and `index.get('')` is always a miss. An incoming row is unfingerprintable because of a `BigInt`, a cycle, a throwing getter or `toJSON`, or anything else `JSON.stringify` rejects — and a structurally equal candidate would carry the same offending value, so it would fail to fingerprint too and force the whole bucket onto the capped scan. Nothing matchable is lost.
- **Prototype pollution.** The replacer feeds `Object.fromEntries`, which uses `CreateDataPropertyOrThrow`, so a `__proto__` own key becomes an own data property rather than mutating a prototype.
- **Cycles are not handled and never were.** Two mutually cyclic rows overflow the stack inside `structuralValuesEqual*`, which the `try/catch` does not and cannot cover. On the indexed path the fingerprint runs *first* and throws into the catch, so the overflow lands afterwards in the fallback scan. (A cyclic incoming row against a finite candidate terminates when the structures diverge — it takes cycles on both sides.) Pre-existing either way.
- **Live-path allocation unchanged.** `indexesById` is only created once some id exceeds the threshold. An earlier revision wrapped every bucket in an object and cost 22.6% at 4000 rows; that was measured and removed.

## Measurements

This is **not uniformly faster** than the cap. It trades time for actually doing the matching.

A note on precision: D below reports that machine noise swamps the live-path comparison, and these figures are single runs on the same machine. The A and C gaps are 2-16x, far outside that spread, so the direction holds even though the digits should not be read closely — table A in particular moved substantially between revisions of this body for the same shape.

**A. Reversed bucket** (matches at the far end, distinct rows → singleton groups) — the case the cap gives up on:

| k | capped | rows reused | indexed | rows reused |
|---|---|---|---|---|
| 1000 | 6.54 ms | **8** | 6.55 ms | **1000** |
| 5000 | 10.67 ms | **8** | 36.00 ms | **5000** |

**B. No matches at all:**

| k | capped | indexed |
|---|---|---|
| 1000 | 2.19 ms | 2.37 ms |
| 5000 | 20.16 ms | 25.27 ms |

**C. All-colliding group** (one fingerprint, none equal — the new worst case):

| k | capped | indexed |
|---|---|---|
| 1000 | 1.09 ms | 17.94 ms |
| 5000 | 19.80 ms | 44.59 ms |

C is the honest cost: the index build pays *k* JSON serializations for a bucket where the fingerprint buys nothing. Still linear — O(k) build plus a hard 8 confirms per row — but ~2-16× the cap in that shape. It requires ≥9 rows sharing one id whose fingerprints all collide while none are structurally equal, which no caller produces.

**D. Live path** (unique ids, unchanged) — the only path that runs today. Interleaved A/B, median of 25 trials x 40 iterations, three independent runs on an idle machine:

| rows | capped (median, IQR) | indexed (median, IQR) | delta across the 3 runs |
|---|---|---|---|
| 250 | 0.112-0.128 ms | 0.112-0.127 ms | -0.8% / -0.1% / +1.1% |
| 1000 | 0.491-0.522 ms | 0.508-0.539 ms | -1.2% / +3.4% / +4.1% |
| 4000 | 2.116-2.248 ms | 2.141-2.316 ms | -0.8% / +1.2% / +3.0% |

**No regression.** Deltas straddle zero, IQRs overlap heavily (at n=4000: 2.129-2.310 vs 2.114-2.410), and the sign is inconsistent across runs — parity within noise.

Worth recording how that number was arrived at: an earlier attempt to measure this while the machine was loaded from test suites produced deltas swinging from -55% to +46% for the same configuration. Those runs were discarded rather than mined for a favourable one. The structural argument agrees with the clean measurement: below the threshold `spliceEqualRow(candidates, row, candidates.length)` with `len <= 8` is exactly the old `Math.min(len, 8)` — same forward scan, same `splice`, same fallthrough — and `indexesById` stays `null`, so nothing extra is allocated. The only textual difference is `!candidates` -> `candidates === undefined`, a no-op.

## Tests

Five in `worktree-catalog-reconciliation.test.ts`, each verified by mutation or by running against the prior implementation, not by reading:

- **`reuses a match at the far end of a large duplicate-id bucket`** — 64-row bucket, match at index 63. Fails against the capped parent. This is the behavioural delta.
- **`consumes each previous row at most once across a large bucket`** — fails when the `splice` is removed.
- **`keeps a rejected same-fingerprint candidate available to later rows`** — 16 distinct `Date`s at one instant; resolving the first row must not consume the second's match. Fails against the `shift()` revision. Strongest evidence in the PR.
- **`bounds the confirms inside an all-colliding fingerprint group`** — read-counts an all-colliding group at two sizes and asserts the count does not scale with it. Fails with the group cap removed (401 vs 51) and **survives retuning the threshold from 8 to 16**, which an absolute bound would not: that pins a tuning knob rather than the property. The neighbouring test was reshaped the same way for the same reason.
- **`still matches when a large bucket cannot be fingerprinted`** — `BigInt` rows; fails when the `try/catch` is stripped.

The pre-existing suite pins unchanged semantics (whole-array reuse, ordering, same-id-across-hosts, adds/removals/reorders).

## Verification

- `npx vitest run --config config/vitest.config.ts src/renderer/src/store/slices src/renderer/src/components/right-sidebar src/shared` → 813 files pass; at least two wall-clock tests flake under full-suite load (`remote-runtime-shared-control-connection`, `ai-vault-session-worktree-map`, and separately `usage-snapshot-refresh.benchmark` on another run). All pass in isolation, none imports the changed module, and I confirmed the first also fails on the base branch *without* this change — pre-existing.
- `tsc --noEmit -p config/tsconfig.tc.web.json` → pass
- `oxlint` on both touched files → clean
- Benchmarks run ad hoc against extracted copies of both implementations; no benchmark script is committed.

Made with [Orca](https://github.com/stablyai/orca) 🐋
