### PR TITLE
fix(renderer): remove duplicate git history tooltips

### DIFF
--- a/src/renderer/src/components/right-sidebar/GitHistoryPanel.test.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHistoryPanel.test.tsx
@@ -99,5 +99,6 @@ describe('GitHistoryPanel', () => {
     expect(markup).not.toContain('title="main"')
     expect(markup).not.toContain('title="feature"')
     expect(markup).not.toContain('title="v1.0.0"')
+    expect(markup).not.toMatch(/\stitle=/)
   })
 })

--- a/src/renderer/src/components/right-sidebar/GitHistoryPanel.test.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHistoryPanel.test.tsx
@@ -76,4 +76,28 @@ describe('GitHistoryPanel', () => {
     expect(markup).toContain('Fix tab overflow')
     expect(markup).toContain('52ad492')
   })
+
+  it('does not add native title tooltips alongside managed history tooltips', () => {
+    const result = makeHistoryResult()
+    result.items[0].references = [
+      { id: 'refs/heads/main', name: 'main', category: 'branches' },
+      { id: 'refs/heads/feature', name: 'feature', category: 'branches' },
+      { id: 'refs/tags/v1.0.0', name: 'v1.0.0', category: 'tags' }
+    ]
+
+    const markup = renderToStaticMarkup(
+      <GitHistoryPanel
+        state={{ status: 'ready', result }}
+        collapsed={false}
+        onToggle={vi.fn()}
+        onRefresh={vi.fn()}
+        onOpenCommit={vi.fn()}
+      />
+    )
+
+    expect(markup).not.toContain('title="Fix tab overflow"')
+    expect(markup).not.toContain('title="main"')
+    expect(markup).not.toContain('title="feature"')
+    expect(markup).not.toContain('title="v1.0.0"')
+  })
 })

--- a/src/renderer/src/components/right-sidebar/GitHistoryRow.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHistoryRow.tsx
@@ -20,7 +20,6 @@ function GitHistoryRefBadge({ itemRef }: { itemRef: GitHistoryItemRef }): React.
             borderColor: itemRef.color ? graphColor(itemRef.color) : 'var(--border)',
             color: itemRef.color ? graphColor(itemRef.color) : 'var(--muted-foreground)'
           }}
-          title={itemRef.name}
         >
           {itemRef.name}
         </span>
@@ -90,9 +89,7 @@ export const GitHistoryRow = React.forwardRef<HTMLElement, GitHistoryRowProps>(
           )}
           <Tooltip>
             <TooltipTrigger asChild>
-              <span className="block min-w-0 flex-1 truncate text-foreground" title={rowTooltip}>
-                {item.subject}
-              </span>
+              <span className="block min-w-0 flex-1 truncate text-foreground">{item.subject}</span>
             </TooltipTrigger>
             <TooltipContent
               side="bottom"
@@ -112,10 +109,7 @@ export const GitHistoryRow = React.forwardRef<HTMLElement, GitHistoryRowProps>(
             {hiddenRefs.length > 0 && (
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <span
-                    className="shrink-0 text-[10px] leading-none text-muted-foreground"
-                    title={hiddenRefs.map((ref) => ref.name).join(', ')}
-                  >
+                  <span className="shrink-0 text-[10px] leading-none text-muted-foreground">
                     +{hiddenRefs.length}
                   </span>
                 </TooltipTrigger>
@@ -135,7 +129,6 @@ export const GitHistoryRow = React.forwardRef<HTMLElement, GitHistoryRowProps>(
           {...rootProps}
           ref={ref as React.Ref<HTMLDivElement>}
           className={rowClassName}
-          title={rowTooltip}
           data-testid="git-history-row"
         >
           {rowContent}
@@ -157,7 +150,6 @@ export const GitHistoryRow = React.forwardRef<HTMLElement, GitHistoryRowProps>(
         ref={ref as React.Ref<HTMLButtonElement>}
         type="button"
         className={rowClassName}
-        title={rowTooltip}
         aria-expanded={canExpand ? expanded : undefined}
         aria-label={
           canExpand

--- a/tests/e2e/git-history-tooltip-wrap.spec.ts
+++ b/tests/e2e/git-history-tooltip-wrap.spec.ts
@@ -73,7 +73,9 @@ test('keeps conventional commit-message lines intact in the history tooltip', as
 
   const row = orcaPage.getByTestId('git-history-row').filter({ hasText: subject })
   await expect(row).toBeVisible({ timeout: 10_000 })
+  await expect(row).not.toHaveAttribute('title')
   const trigger = row.locator('[data-slot="tooltip-trigger"]').filter({ hasText: subject })
+  await expect(trigger).not.toHaveAttribute('title')
   await trigger.hover({ position: { x: 20, y: 10 } })
   await trigger.hover({ position: { x: 40, y: 10 } })
 


### PR DESCRIPTION
## ELI5

Git history rows were asking the browser and Orca to show the same tooltip at the same time. This removes the browser tooltip so only Orca's styled tooltip appears.

## What Changed

- Removed native HTML `title` attributes from Git history rows, commit subjects, ref badges, and the hidden-ref count.
- Kept the existing Radix tooltip content and accessible row labels unchanged.
- Added unit coverage for the rendered markup and Electron E2E assertions for the tooltip trigger.

## Why

Native `title` tooltips could overlap the managed Radix tooltip, producing the duplicate hover UI reported on Windows. Using the existing managed tooltip as the single tooltip source fixes the overlap without changing the remote protocol or Git behavior.

## Linked Issue

Fixes #14432

## Visual Proof

Before (from the issue report):

![Duplicate native and managed tooltips](https://github.com/user-attachments/assets/eecb1c08-8589-4c52-800e-bf98894a6d1b)

After: captured locally from the Electron E2E at 1440×900; it shows one managed tooltip. The screenshot attachment is pending because the available GitHub browser session is not signed in.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Passed on macOS:

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/GitHistoryPanel.test.tsx` (4 tests)
- Electron Playwright: `git-history-tooltip-wrap.spec.ts` (1 test)

The full `pnpm test` run completed 51,690 passing tests and 20 failures across 11 unrelated files. Re-running those files with one worker cleared 10 load-sensitive failures; the remaining 10 reproduce in four areas outside this diff: newline worktree paths, OSC 8 terminal snapshot links, and resumed IME preedit visibility. CI can confirm those current-main failures independently.

## AI Disclosure

OpenAI Codex was used to inspect the codebase, implement the focused change, add regression coverage, and run verification. The diff and test results were reviewed before submission.

## Review

- Security: no new inputs, privileges, or data flows.
- Cross-platform: removes platform-native tooltip behavior; no platform-specific code added. Verified locally on macOS; the linked report is from Windows.
- SSH/remote/mobile: renderer-only presentation change; no wire or host behavior changes.
- Backwards compatibility and performance: no protocol/state changes and fewer browser tooltip handlers.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: N/A
