### PR TITLE
fix(worktree-scan): keep the admin-fingerprint probe inside the caller's per-repo budget

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -36057,14 +36057,19 @@ const WORKTREE_SCAN_AGENT_SCRATCH_TTL_MS = 5 * 60_000
 // stamp, so a real scan still runs on this interval even while the probe reports "unchanged".
 export const WORKTREE_SCAN_ADMIN_RECONCILE_INTERVAL_MS = 5 * 60_000
 export const RESOLVED_WORKTREE_REPO_TIMEOUT_MS = 5000
-// Why a slice of RESOLVED_WORKTREE_REPO_TIMEOUT_MS and not a generous absolute: this wait runs
-// *inside* that budget, so outlasting it buys the caller nothing — it has already given up and
-// restored persisted rows — while converting a reusable scan into a full-budget stall that repeats
-// on every TTL expiry. What is left of the budget covers the fallback `git worktree list`, so a
-// probe that expires still returns fresh rows. Expiring yields `null`, the existing "cannot prove
-// unchanged" sentinel. A healthy but slow host (100+ linked worktrees, Windows Defender, cold
-// dentry cache, cloud placeholders) still fits: the probe is subprocess-free stats, not Git.
-export const WORKTREE_SCAN_ADMIN_FINGERPRINT_TIMEOUT_MS = 2000
+// Why reserved rather than spent on the probe: when the probe expires the caller still has to run
+// `git worktree list` and answer inside the same budget, so the fallback needs its own room. Sized
+// for a healthy Git on a busy host, well above the tens of milliseconds a warm list costs.
+const WORKTREE_SCAN_FALLBACK_ALLOWANCE_MS = 1500
+// Why derived from the caller's budget instead of a generous absolute: this wait runs *inside*
+// RESOLVED_WORKTREE_REPO_TIMEOUT_MS, so outlasting it buys nothing — the caller has already given up
+// and restored persisted rows — while turning a reusable scan into a full-budget stall that repeats
+// on every TTL expiry. Subtracting keeps that invariant true by construction if either side moves.
+// Why not smaller: the probe reads a subset of what the fallback scan reads, so a probe too slow to
+// fit is a scan that will not fit either — waiting is strictly better right up to the budget.
+// Expiring yields `null`, the existing "cannot prove unchanged" sentinel, so a real scan runs.
+export const WORKTREE_SCAN_ADMIN_FINGERPRINT_TIMEOUT_MS =
+  RESOLVED_WORKTREE_REPO_TIMEOUT_MS - WORKTREE_SCAN_FALLBACK_ALLOWANCE_MS
 
 export function resolveWorktreeScanCacheTtlMs(repo: Pick<Repo, 'path' | 'connectionId'>): number {
   return !repo.connectionId && isAgentScratchRepoRootPath(repo.path)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -29448,7 +29448,6 @@ export class OrcaRuntimeService {
     if (!this.store) {
       return { worktrees: [], platformByRepoId: new Map() }
     }
-    const now = Date.now()
     const metaById = this.store.getAllWorktreeMeta() ?? {}
     const repos = this.store.getRepos()
     const projectRuntimeByRepoId = resolveLocalProjectRuntimesForRepos(this.requireStore(), repos)
@@ -29529,11 +29528,13 @@ export class OrcaRuntimeService {
       this.store?.getAllWorktreeLineage?.() ?? {}
     )
     // Why: short TTL avoids shelling out on every frequent poll while still catching worktree changes made outside Orca.
+    // Why stamped on completion, not entry: a compute that spent longer than the TTL would otherwise publish an
+    // already-expired entry, so the very next poll recomputes and every caller repeats the same slow path.
     if (generation === this.resolvedWorktreeGeneration) {
       this.resolvedWorktreeCache = {
         worktrees,
         platformByRepoId,
-        expiresAt: now + RESOLVED_WORKTREE_CACHE_TTL_MS
+        expiresAt: Date.now() + RESOLVED_WORKTREE_CACHE_TTL_MS
       }
     }
     return { worktrees, platformByRepoId }
@@ -36055,13 +36056,15 @@ const WORKTREE_SCAN_AGENT_SCRATCH_TTL_MS = 5 * 60_000
 // edits are invisible to it and a tip living in packed-refs or reftable only gets an mtime + size
 // stamp, so a real scan still runs on this interval even while the probe reports "unchanged".
 export const WORKTREE_SCAN_ADMIN_RECONCILE_INTERVAL_MS = 5 * 60_000
-// Why so generous: a healthy but slow host (100+ linked worktrees, Windows Defender, cold dentry
-// cache, cloud placeholders) must still get to reuse its scan. Well under WORKTREE_LIST_TIMEOUT_MS,
-// and expiring yields `null` — the existing "cannot prove unchanged" sentinel, so a real scan runs.
-// Exceeding RESOLVED_WORKTREE_REPO_TIMEOUT_MS is deliberate, not a bug: the payoff is skipping a
-// `git worktree list` subprocess, not cutting this caller's latency — that caller is already capped.
-export const WORKTREE_SCAN_ADMIN_FINGERPRINT_TIMEOUT_MS = 10_000
-const RESOLVED_WORKTREE_REPO_TIMEOUT_MS = 5000
+export const RESOLVED_WORKTREE_REPO_TIMEOUT_MS = 5000
+// Why a slice of RESOLVED_WORKTREE_REPO_TIMEOUT_MS and not a generous absolute: this wait runs
+// *inside* that budget, so outlasting it buys the caller nothing — it has already given up and
+// restored persisted rows — while converting a reusable scan into a full-budget stall that repeats
+// on every TTL expiry. What is left of the budget covers the fallback `git worktree list`, so a
+// probe that expires still returns fresh rows. Expiring yields `null`, the existing "cannot prove
+// unchanged" sentinel. A healthy but slow host (100+ linked worktrees, Windows Defender, cold
+// dentry cache, cloud placeholders) still fits: the probe is subprocess-free stats, not Git.
+export const WORKTREE_SCAN_ADMIN_FINGERPRINT_TIMEOUT_MS = 2000
 
 export function resolveWorktreeScanCacheTtlMs(repo: Pick<Repo, 'path' | 'connectionId'>): number {
   return !repo.connectionId && isAgentScratchRepoRootPath(repo.path)

--- a/src/main/runtime/worktree-scan-admin-fingerprint-gate.test.ts
+++ b/src/main/runtime/worktree-scan-admin-fingerprint-gate.test.ts
@@ -50,6 +50,10 @@ const WORKTREE_PATH = '/Users/me/dev/app-feature'
 const WORKTREE_ID = `${REPO_ID}::${WORKTREE_PATH}`
 const MAIN_WORKTREE_ID = `${REPO_ID}::${REPO_PATH}`
 const SCAN_TTL_MS = 30_000
+// A busy host (100+ linked worktrees, Defender, cold dentry cache, cloud placeholders) can spend
+// seconds in pure stat time. Reuse has to survive that, or trimming the probe's deadline to fit the
+// caller budget just trades a repeating stall for a repeating `git worktree list`.
+const SLOW_BUT_HEALTHY_PROBE_MS = 3_000
 
 function makeMeta(overrides: Record<string, unknown> = {}) {
   return {
@@ -469,6 +473,28 @@ describe('worktree scan admin-fingerprint gate', () => {
     expect(WORKTREE_SCAN_ADMIN_FINGERPRINT_TIMEOUT_MS).toBeLessThan(
       RESOLVED_WORKTREE_REPO_TIMEOUT_MS
     )
+  })
+
+  it('still reuses the scan when a slow probe answers inside its deadline', async () => {
+    vi.useFakeTimers()
+    try {
+      const { list } = makeRuntime()
+      await list()
+      expect(scanCount()).toBe(1)
+
+      const releaseSlowProbe = stallProbeOnce()
+      vi.advanceTimersByTime(SCAN_TTL_MS + 1_000)
+      const second = list()
+
+      // Deliberately an absolute figure, not one derived from the deadline: this is the lower end of
+      // the band, and a self-referential advance would still pass however far the deadline is cut.
+      await vi.advanceTimersByTimeAsync(SLOW_BUT_HEALTHY_PROBE_MS)
+      releaseSlowProbe('fp-1')
+      await second
+      expect(scanCount()).toBe(1)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('still returns scanned rows within the per-repo budget when the probe stalls', async () => {

--- a/src/main/runtime/worktree-scan-admin-fingerprint-gate.test.ts
+++ b/src/main/runtime/worktree-scan-admin-fingerprint-gate.test.ts
@@ -39,6 +39,7 @@ vi.mock('./repo-worktree-admin-fingerprint', () => ({
 
 import {
   OrcaRuntimeService,
+  RESOLVED_WORKTREE_REPO_TIMEOUT_MS,
   WORKTREE_SCAN_ADMIN_FINGERPRINT_TIMEOUT_MS,
   WORKTREE_SCAN_ADMIN_RECONCILE_INTERVAL_MS
 } from './orca-runtime'
@@ -116,16 +117,24 @@ function makeRuntime(
 ): {
   runtime: OrcaRuntimeService
   list: () => Promise<unknown>
+  store: ReturnType<typeof makeStore>
 } {
-  const runtime = new OrcaRuntimeService(makeStore(options) as never)
+  const store = makeStore(options)
+  const runtime = new OrcaRuntimeService(store as never)
   return {
     runtime,
-    list: () => (runtime as unknown as RuntimeInternals).listResolvedWorktrees()
+    list: () => (runtime as unknown as RuntimeInternals).listResolvedWorktrees(),
+    store
   }
 }
 
 function scanCount(): number {
   return listWorktreesStrictMock.mock.calls.length
+}
+
+/** Scanned rows carry the mocked tips; the persisted-row fallback publishes empty ones. */
+function heads(worktrees: unknown): string[] {
+  return (worktrees as { git: { head: string } }[]).map((worktree) => worktree.git.head).sort()
 }
 
 /** Let every already-settled promise chain run without advancing the clock, so a stall stays a stall. */
@@ -450,6 +459,58 @@ describe('worktree scan admin-fingerprint gate', () => {
       await drainMicrotasks()
       expect(scanCount()).toBe(2)
       await second
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('bounds the awaited probe by the caller per-repo budget', () => {
+    // The wait runs inside that budget, so outlasting it can only strand the caller on persisted rows.
+    expect(WORKTREE_SCAN_ADMIN_FINGERPRINT_TIMEOUT_MS).toBeLessThan(
+      RESOLVED_WORKTREE_REPO_TIMEOUT_MS
+    )
+  })
+
+  it('still returns scanned rows within the per-repo budget when the probe stalls', async () => {
+    vi.useFakeTimers()
+    try {
+      const { list } = makeRuntime()
+      await list()
+
+      stallProbeOnce()
+      vi.advanceTimersByTime(SCAN_TTL_MS + 1_000)
+      const second = list()
+      const secondSettled = trackSettled(second)
+
+      // The probe's own deadline has to end the wait; if the caller's fallback gets there first the
+      // repo answers with persisted rows on every TTL expiry.
+      await vi.advanceTimersByTimeAsync(WORKTREE_SCAN_ADMIN_FINGERPRINT_TIMEOUT_MS)
+      await drainMicrotasks()
+      expect(secondSettled()).toBe(true)
+      expect(scanCount()).toBe(2)
+      expect(heads(await second)).toEqual(['abc', 'def'])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not publish an already-expired snapshot after a slow compute', async () => {
+    vi.useFakeTimers()
+    try {
+      const { list, store } = makeRuntime()
+      await list()
+
+      stallProbeOnce()
+      vi.advanceTimersByTime(SCAN_TTL_MS + 1_000)
+      const second = list()
+      await vi.advanceTimersByTimeAsync(WORKTREE_SCAN_ADMIN_FINGERPRINT_TIMEOUT_MS)
+      await second
+
+      // The probe deadline outlasts the snapshot TTL, so a start-stamped entry is born expired and
+      // the next poll repeats the whole wait instead of reading the answer that just landed.
+      const getRepos = vi.spyOn(store, 'getRepos')
+      await list()
+      expect(getRepos).not.toHaveBeenCalled()
     } finally {
       vi.useRealTimers()
     }


### PR DESCRIPTION
## ELI5

Orca keeps a cheap "did anything change?" check so it doesn't have to run `git worktree list` for every repo on every poll. That check was allowed to take **10 seconds**, but the thing waiting for it only ever waits **5 seconds** before giving up.

So on a slow disk the wait could never pay off. The caller always gave up first, shrugged, and showed you the last-known worktree rows from disk instead of real ones. Worse, the snapshot it saved afterwards was stamped with the time the work *started*, not the time it *finished* — so a 5-second computation produced a cache entry that was already 4 seconds expired. The very next poll threw it away and did the whole 5-second wait again. And again.

Two one-line-ish fixes: make the inner check's deadline a slice of the outer budget (so it can never outlast its caller), and stamp the cache when the work finishes instead of when it started.

## What Changed

- `WORKTREE_SCAN_ADMIN_FINGERPRINT_TIMEOUT_MS` is now derived — `RESOLVED_WORKTREE_REPO_TIMEOUT_MS - WORKTREE_SCAN_FALLBACK_ALLOWANCE_MS` (5000 − 1500 = 3500ms) — instead of a flat `10_000`. Deriving keeps "the probe deadline fits inside the caller's budget" true by construction if either number moves later, and the reserved allowance leaves room for the fallback `git worktree list` to still answer inside the same budget.
- `computeResolvedWorktrees` stamps `resolvedWorktreeCache.expiresAt` from `Date.now()` at write time rather than a `now` captured on entry. This matches what `worktreeScanCache` already did at `orca-runtime.ts:29588`.
- Four regression tests in `worktree-scan-admin-fingerprint-gate.test.ts`.

## Why

Fixes STA-4275 (P1). Evidence from the report, confirmed present on this branch's base:

- `orca-runtime.ts:29638` awaited the probe for 10s, inside the 5s `withTimeout` at `:29489`. A slow mount therefore *always* lost the race: the caller gave up and republished persisted rows (`head: ''`, `branch: ''` from `listStoredWorktreesForResolution`) instead of the reusable cached scan the probe existed to protect.
- `:29537` stamped the snapshot from a `now` taken at function entry, so any compute slower than the 1s TTL published an already-expired entry. The next poll recomputed, joined the same still-running in-flight scan, and burned another full budget — the "repeats 5s stalls" in the ticket.

Deterministic repeat case: a host where the probe consistently lands between 5s and 10s (cloud placeholders, Defender on a cold dentry cache). Every 30s TTL expiry re-armed the same over-budget wait, so desktop and mobile catalog calls spent 5s and returned stale rows, indefinitely.

The picked value is deliberate rather than minimal. An earlier revision of this PR used a flat 2000ms; that fit the budget but silently dropped fingerprint reuse for hosts in the 2–5s band, which *had* been fitting fine — trading a repeating stall for a repeating subprocess. Subtracting a fallback allowance from the caller budget instead means only probes that could never have fitted get cut. The tests pin both ends: too large fails the budget invariant, too small fails reuse for a slow-but-healthy probe.

## Linked Issue

Fixes STA-4275 — https://linear.app/stably/issue/STA-4275

## Visual Proof

`N/A` — no UI change. The user-visible effect is the absence of a stall and the absence of stale rows; there is no rendered surface that differs in a screenshot.

## Testing

Ran the exact suite pair from `pr.yml`'s Windows boundary step on all three platforms:

| Platform | Node | Git | Result |
|---|---|---|---|
| macOS (arm64, dev machine) | 24 | 2.51 | 33/33 |
| Linux (Ubuntu 24.04, `openclaw`) | 26.1.0 | 2.43.0 | 33/33 |
| Windows 11 (`awin`) | 24.18.0 | 2.55.0.windows.3 | 33/33 |

Each new test was confirmed to **fail without the fix**, reproducing the reported symptoms rather than just passing alongside them:

- `expected [ '', '' ] to deeply equal [ 'abc', 'def' ]` — the stale persisted-row fallback
- `expected "getRepos" to not be called at all, but actually been called 2 times` — the repeated recompute
- the timeout-vs-budget invariant
- and the lower-bound guard fails if the deadline is trimmed too far

Wider run: `src/main/runtime/` + `src/main/ipc/` → 6978 passed. Three failures in `quarter-circle-title-send-authorization.test.ts` and `pty.test.ts` are pre-existing — verified by re-running both files against `origin/main`'s `orca-runtime.ts`, which fails identically (3 failed / 486 passed). `pnpm typecheck`, `oxlint`, and `oxfmt --check` clean.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

- **Security** — no dependency, lockfile, shell, or network surface touched. Two source files.
- **Cross-platform** — validated on macOS, Linux, and Windows above; this suite is in `pr.yml`'s Windows boundary step precisely because the probe's path handling is platform-sensitive. Raising the effective reuse ceiling relative to a flat cut particularly helps Windows, where Defender makes probes genuinely slower.
- **Remote SSH** — `fingerprintCapable` already excludes `repo.connectionId` repos, so the probe path is unreachable for SSH; unchanged. The completion-stamp fix independently *helps* SSH: a repo that previously blew its budget published a born-expired snapshot, so every poll re-hit the network.
- **Mobile** — no mobile-facing contract touched; the constants are confined to `src/main` with no `shared/`, `mobile/`, or renderer importer. The only mobile-visible effect is behavioral (fresh rows instead of stale, sooner).
- **Backwards compatibility** — no persisted state, schema, migration, or serialized contract involved; these are in-memory timeouts. Per the remote-wire rule about *what the host publishes*: the host now publishes real scanned rows in windows where it used to publish degraded placeholders. That is an already-normal value arriving more often, not a new shape, so old clients are unaffected.
- **Performance** — the steady-state guard (`bounds Git fan-out under a sustained 1 Hz polling workload`, 10 repos × 30 min) still holds at 60 `git worktree list` spawns, unchanged from the gate's original budget.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
