### PR TITLE
fix(terminal): bracket agent-pane pastes so a pasted newline can't submit the draft

### DIFF
--- a/src/main/ipc/dashboard-payload-validation.test.ts
+++ b/src/main/ipc/dashboard-payload-validation.test.ts
@@ -293,6 +293,7 @@ describe('dashboard payload validation', () => {
       localWindowsConpty: true,
       osRelease: '10.0.22631',
       windowsShiftEnterEncoding: 'alt-enter',
+      windowsInputRecordPasteNewline: 'alt-enter',
       ctrlEnterCsiU: false,
       kittyKeyboardAdvertised: false
     }
@@ -307,6 +308,8 @@ describe('dashboard payload validation', () => {
       { ...terminalInput, localWindowsConpty: 'true' },
       { ...terminalInput, osRelease: 'x'.repeat(1_025) },
       { ...terminalInput, windowsShiftEnterEncoding: 'enter' },
+      { ...terminalInput, forceBracketedMultilineTextPaste: false },
+      { ...terminalInput, windowsInputRecordPasteNewline: 'enter' },
       { ...terminalInput, ctrlEnterCsiU: 'true' },
       { ...terminalInput, kittyKeyboardAdvertised: 1 }
     ]) {

--- a/src/main/ipc/dashboard-payload-validation.ts
+++ b/src/main/ipc/dashboard-payload-validation.ts
@@ -53,6 +53,7 @@ const DASHBOARD_HOST_PLATFORMS = new Set([
   'win32'
 ])
 const WINDOWS_SHIFT_ENTER_ENCODINGS = new Set(['alt-enter', 'csi-u'])
+const WINDOWS_INPUT_RECORD_PASTE_NEWLINES = new Set(['alt-enter', 'csi-u'])
 
 function isBoundedString(value: unknown, maxLength: number, allowEmpty = false): value is string {
   return typeof value === 'string' && value.length <= maxLength && (allowEmpty || value.length > 0)
@@ -308,6 +309,11 @@ function isDashboardTerminalInput(value: unknown): boolean {
     isOptionalBoundedString(input.osRelease, MAX_LABEL_LENGTH) &&
     typeof input.windowsShiftEnterEncoding === 'string' &&
     WINDOWS_SHIFT_ENTER_ENCODINGS.has(input.windowsShiftEnterEncoding) &&
+    (input.forceBracketedMultilineTextPaste === undefined ||
+      input.forceBracketedMultilineTextPaste === true) &&
+    (input.windowsInputRecordPasteNewline === undefined ||
+      (typeof input.windowsInputRecordPasteNewline === 'string' &&
+        WINDOWS_INPUT_RECORD_PASTE_NEWLINES.has(input.windowsInputRecordPasteNewline))) &&
     typeof input.ctrlEnterCsiU === 'boolean' &&
     typeof input.kittyKeyboardAdvertised === 'boolean'
   )

--- a/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.test.tsx
@@ -420,6 +420,37 @@ describe('AgentTerminalPreview', () => {
     expect(input).toHaveBeenCalledWith('pty-1', 'clip-text')
   })
 
+  it('encodes a leading newline for a remote Windows Codex preview without submitting', async () => {
+    readClipboardText.mockResolvedValueOnce('\nsecond line')
+    const view = render(
+      <AgentTerminalPreview
+        ptyId="remote:windows-box@@pty-1"
+        terminalInput={{
+          hostPlatform: 'win32',
+          localWindowsConpty: false,
+          windowsShiftEnterEncoding: 'alt-enter',
+          windowsInputRecordPasteNewline: 'alt-enter',
+          ctrlEnterCsiU: false,
+          kittyKeyboardAdvertised: false
+        }}
+      />
+    )
+    await waitFor(() => expect(terminalHarness.instances).toHaveLength(1))
+    const terminal = terminalHarness.instances[0]!
+    const host = view.container.querySelector<HTMLElement>('.origin-bottom-left')!
+    const focusTarget = document.createElement('input')
+    host.appendChild(focusTarget)
+    focusTarget.focus()
+
+    act(() => emitAppMenuPaste!())
+
+    await waitFor(() =>
+      expect(input).toHaveBeenCalledWith('remote:windows-box@@pty-1', '\x1b\rsecond line')
+    )
+    expect(terminal.input).toHaveBeenCalledWith('\x1b\rsecond line')
+    expect(terminal.paste).not.toHaveBeenCalled()
+  })
+
   it('handles app-menu selection actions while the preview owns focus', async () => {
     const view = render(<AgentTerminalPreview ptyId="pty-1" />)
     await waitFor(() => expect(terminalHarness.instances).toHaveLength(1))

--- a/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.tsx
@@ -201,6 +201,7 @@ export function AgentTerminalPreview({
       ptyId,
       container,
       getTerminal: () => terminal,
+      getTerminalInput: () => terminalInputRef.current,
       isDisposed: () => disposed
     })
 

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-paste.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-paste.ts
@@ -6,6 +6,8 @@ import {
 } from '@/components/terminal-pane/terminal-paste-coordinator'
 import { resolveTerminalPasteRuntime } from '@/components/terminal-pane/terminal-paste-runtime'
 import { TERMINAL_PASTE_MAX_BYTES } from '@/components/terminal-pane/terminal-paste-limits'
+import { pasteTerminalText } from '@/components/terminal-pane/terminal-bracketed-paste'
+import type { DashboardCardTerminalInput } from '../../../../shared/dashboard-snapshot'
 
 /**
  * Clipboard paste for the preview terminal, on the pane's coordinator: large
@@ -16,6 +18,7 @@ export function createPreviewClipboardPaster(deps: {
   ptyId: string
   container: HTMLElement
   getTerminal: () => Terminal | null
+  getTerminalInput: () => DashboardCardTerminalInput | null
   isDisposed: () => boolean
 }): (activeElementAtDispatch: Element | null, source: 'keyboard' | 'app-menu') => Promise<void> {
   return async (activeElementAtDispatch, source) => {
@@ -38,7 +41,8 @@ export function createPreviewClipboardPaster(deps: {
     if (!targetIsCurrent()) {
       return
     }
-    const platform = getShortcutPlatform()
+    const terminalInput = deps.getTerminalInput()
+    const platform = terminalInput?.hostPlatform ?? getShortcutPlatform()
     const plan = await planTerminalPasteWithYield({
       text,
       source,
@@ -49,11 +53,13 @@ export function createPreviewClipboardPaster(deps: {
         ptyId: deps.ptyId,
         runtime: resolveTerminalPasteRuntime({ platform, ptyId: deps.ptyId })
       },
+      forceBracketedPasteForMultiline: terminalInput?.forceBracketedMultilineTextPaste,
+      windowsInputRecordNewline: terminalInput?.windowsInputRecordPasteNewline,
       terminalBracketedPasteMode: pasteTerminal.modes.bracketedPasteMode
     })
     await executeTerminalPastePlan(plan, {
       // Why: stream large pastes so the renderer never emits one huge IPC payload.
-      pasteText: (pasteText) => pasteTerminal.paste(pasteText),
+      pasteText: (text, options) => pasteTerminalText(pasteTerminal, text, options),
       writePty: (data) => window.api.terminalPreview.input(deps.ptyId, data),
       isTargetCurrent: targetIsCurrent,
       // Why: if focus changes mid-bracketed paste, the closing marker must still reach the live PTY.

--- a/src/renderer/src/components/dashboard/dashboard-card-terminal-input.test.ts
+++ b/src/renderer/src/components/dashboard/dashboard-card-terminal-input.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 
 import { describe, expect, it } from 'vitest'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
 import {
   resolveDashboardCardTerminalInput,
   type DashboardCardTerminalInputState
@@ -34,6 +35,19 @@ function stateWith(
     worktreesByRepo: { 'repo-1': [{ id: 'wt-1', repoId: 'repo-1' }] },
     ...overrides
   } as Partial<DashboardCardTerminalInputState>
+}
+
+function codexEntry(overrides: Partial<AgentStatusEntry> = {}): AgentStatusEntry {
+  return {
+    state: 'waiting',
+    prompt: '',
+    updatedAt: 1,
+    stateStartedAt: 1,
+    stateHistory: [],
+    agentType: 'codex',
+    paneKey: MAC_ARGS.paneKey,
+    ...overrides
+  }
 }
 
 describe('resolveDashboardCardTerminalInput', () => {
@@ -125,6 +139,50 @@ describe('resolveDashboardCardTerminalInput', () => {
       sshConnectionStates: new Map([['conn-1', { remotePlatform: 'win32' }]])
     } as unknown as Partial<DashboardCardTerminalInputState>)
     expect(resolveDashboardCardTerminalInput(state, MAC_ARGS).hostPlatform).toBe('win32')
+  })
+
+  it('relays Windows input-record paste encoding for a confirmed remote Codex pane', () => {
+    const profile = resolveDashboardCardTerminalInput(
+      stateWith({
+        runtimeStatusByEnvironmentId: new Map([
+          ['windows-box', { status: { hostPlatform: 'win32' } }]
+        ]),
+        agentStatusByPaneKey: { [MAC_ARGS.paneKey]: codexEntry() }
+      } as unknown as Partial<DashboardCardTerminalInputState>),
+      { ...MAC_ARGS, ptyId: 'remote:windows-box@@pty-1' }
+    )
+
+    expect(profile.windowsInputRecordPasteNewline).toBe('alt-enter')
+    expect(profile.forceBracketedMultilineTextPaste).toBeUndefined()
+  })
+
+  it('relays bracketed multiline paste for a confirmed non-Windows Codex pane', () => {
+    const profile = resolveDashboardCardTerminalInput(
+      stateWith({
+        agentStatusByPaneKey: { [MAC_ARGS.paneKey]: codexEntry() }
+      }),
+      MAC_ARGS
+    )
+
+    expect(profile.forceBracketedMultilineTextPaste).toBe(true)
+    expect(profile.windowsInputRecordPasteNewline).toBeUndefined()
+  })
+
+  it('does not relay stale restored agent paste authority', () => {
+    const profile = resolveDashboardCardTerminalInput(
+      stateWith({
+        runtimeStatusByEnvironmentId: new Map([
+          ['windows-box', { status: { hostPlatform: 'win32' } }]
+        ]),
+        agentStatusByPaneKey: {
+          [MAC_ARGS.paneKey]: codexEntry({ restoredUnconfirmed: true })
+        }
+      } as unknown as Partial<DashboardCardTerminalInputState>),
+      { ...MAC_ARGS, ptyId: 'remote:windows-box@@pty-1' }
+    )
+
+    expect(profile.forceBracketedMultilineTextPaste).toBeUndefined()
+    expect(profile.windowsInputRecordPasteNewline).toBeUndefined()
   })
 
   it("keeps the live SSH PTY's host after the worktree owner changes", () => {

--- a/src/renderer/src/components/dashboard/dashboard-card-terminal-input.ts
+++ b/src/renderer/src/components/dashboard/dashboard-card-terminal-input.ts
@@ -11,6 +11,7 @@ import { resolveTerminalInputHostPlatform } from '@/components/terminal-pane/ter
 import { resolveWindowsShiftEnterEncodingForPane } from '@/components/terminal-pane/terminal-windows-shift-enter'
 import { hasCtrlEnterCsiUAuthorityForPane } from '@/components/terminal-pane/terminal-ctrl-enter'
 import { getRemoteRuntimePtyEnvironmentId } from '@/runtime/runtime-terminal-stream'
+import { resolveProtectedMultilinePasteOptionsForAgentEvidence } from '@/components/terminal-pane/terminal-agent-paste-bracketing'
 
 /** Store slices the pane's own input helpers read. */
 export type DashboardCardTerminalInputState = Pick<
@@ -29,6 +30,7 @@ export type DashboardCardTerminalInputState = Pick<
   | 'runtimeEnvironmentCatalogHydrated'
   | 'removedRuntimeEnvironmentIds'
   | 'paneForegroundAgentByPaneKey'
+  | 'agentStatusByPaneKey'
   | 'agentLaunchConfigByPaneKey'
 >
 
@@ -55,6 +57,7 @@ function withHydratedSlices(
     runtimeEnvironmentCatalogHydrated: state.runtimeEnvironmentCatalogHydrated ?? false,
     removedRuntimeEnvironmentIds: state.removedRuntimeEnvironmentIds ?? new Set(),
     paneForegroundAgentByPaneKey: state.paneForegroundAgentByPaneKey ?? EMPTY_RECORD,
+    agentStatusByPaneKey: state.agentStatusByPaneKey ?? EMPTY_RECORD,
     agentLaunchConfigByPaneKey: state.agentLaunchConfigByPaneKey ?? EMPTY_RECORD
   }
 }
@@ -99,30 +102,43 @@ export function resolveDashboardCardTerminalInput(
     shellOverride: args.shellOverride,
     executionHostId
   }
+  const hostPlatform = resolveTerminalInputHostPlatform({
+    clientPlatform: args.clientPlatform,
+    state,
+    worktreeId: args.worktreeId,
+    transport: {
+      getConnectionId: () => connectionId,
+      getPtyId: () => args.ptyId,
+      getExecutionHostId: () => executionHostId,
+      // Why: gated exactly like the pane transport's own accessor — without
+      // it a WSL pty on a Windows client resolves to win32 and Shift+Enter
+      // would encode CSI-u where the pane sends alt-enter.
+      getLocalSessionMetadata: () =>
+        connectionId
+          ? null
+          : {
+              ...(args.cwd ? { cwd: args.cwd } : {}),
+              ...(args.shellOverride ? { shellOverride: args.shellOverride } : {})
+            }
+    }
+  })
+  const protectedPaste = resolveProtectedMultilinePasteOptionsForAgentEvidence({
+    isWindowsClient: args.clientPlatform === 'win32',
+    hostPlatform,
+    foregroundAgent: state.paneForegroundAgentByPaneKey[args.paneKey]?.agent,
+    entry: state.agentStatusByPaneKey[args.paneKey]
+  })
   return {
-    hostPlatform: resolveTerminalInputHostPlatform({
-      clientPlatform: args.clientPlatform,
-      state,
-      worktreeId: args.worktreeId,
-      transport: {
-        getConnectionId: () => connectionId,
-        getPtyId: () => args.ptyId,
-        getExecutionHostId: () => executionHostId,
-        // Why: gated exactly like the pane transport's own accessor — without
-        // it a WSL pty on a Windows client resolves to win32 and Shift+Enter
-        // would encode CSI-u where the pane sends alt-enter.
-        getLocalSessionMetadata: () =>
-          connectionId
-            ? null
-            : {
-                ...(args.cwd ? { cwd: args.cwd } : {}),
-                ...(args.shellOverride ? { shellOverride: args.shellOverride } : {})
-              }
-      }
-    }),
+    hostPlatform,
     localWindowsConpty: isLocalNativeWindowsConpty(windowsPtyContext),
     ...(args.osRelease === undefined ? {} : { osRelease: args.osRelease }),
     windowsShiftEnterEncoding: resolveWindowsShiftEnterEncodingForPane(state, args.paneKey),
+    ...(protectedPaste?.forceBracketedPasteForMultiline
+      ? { forceBracketedMultilineTextPaste: true as const }
+      : {}),
+    ...(protectedPaste?.windowsInputRecordNewline
+      ? { windowsInputRecordPasteNewline: protectedPaste.windowsInputRecordNewline }
+      : {}),
     ctrlEnterCsiU: hasCtrlEnterCsiUAuthorityForPane(state, args.paneKey),
     kittyKeyboardAdvertised: !shouldDisableKittyKeyboardForTerminal({
       ...windowsPtyContext,

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -192,7 +192,8 @@ import { useVisibleTerminalTabClaim } from './use-visible-terminal-tab-claim'
 import { TerminalSshReconnectOverlay } from './TerminalSshReconnectOverlay'
 import { TerminalRemoteRuntimeReconnectBanner } from './TerminalRemoteRuntimeReconnectBanner'
 import { selectTerminalTabAgentTypesByLeaf } from './terminal-tab-agent-type-index'
-import { shouldForceBracketedMultilinePasteForPane } from './terminal-agent-paste-bracketing'
+import { resolveProtectedMultilinePasteOptionsForPane } from './terminal-agent-paste-bracketing'
+import { resolveTerminalInputHostPlatform } from './terminal-input-host-platform'
 import { canContinueAgentSessionInNewSession } from './terminal-agent-session-continuation'
 import {
   updateTerminalRemoteRuntimeRecoveryUiState,
@@ -1934,6 +1935,7 @@ function TerminalPane(
         },
         forceBracketedPaste: options?.forceBracketedPaste,
         forceBracketedPasteForMultiline: options?.forceBracketedPasteForMultiline,
+        windowsInputRecordNewline: options?.windowsInputRecordNewline,
         terminalBracketedPasteMode: pane.terminal.modes.bracketedPasteMode
       })
       const execution = await executeTerminalPastePlan(plan, {
@@ -1964,16 +1966,27 @@ function TerminalPane(
       }
     }
 
-    // Why: resolved per pane, not per tab — an agent composer needs bracketing even off
-    // Windows, because a remote ConPTY host never forwards DECSET 2004 to anyone.
-    const resolvePaneForceBracketedMultiline = (pane: ManagedPane): boolean =>
-      shouldForceBracketedMultilinePasteForPane({
+    // Why: resolved per pane and PTY host; split siblings and remote hosts can need
+    // different multiline paste protocols.
+    const resolvePaneProtectedMultilinePasteOptions = (
+      pane: ManagedPane
+    ): TerminalPasteTextOptions | undefined => {
+      const state = useAppStore.getState()
+      const transport = paneTransportsRef.current.get(pane.id) ?? null
+      return resolveProtectedMultilinePasteOptionsForPane({
         isWindowsClient: forceBracketedMultilineTextPaste,
-        agentStatusByPaneKey: useAppStore.getState().agentStatusByPaneKey,
-        paneForegroundAgentByPaneKey: useAppStore.getState().paneForegroundAgentByPaneKey,
+        hostPlatform: resolveTerminalInputHostPlatform({
+          clientPlatform: shortcutPlatform,
+          state,
+          worktreeId,
+          transport
+        }),
+        agentStatusByPaneKey: state.agentStatusByPaneKey,
+        paneForegroundAgentByPaneKey: state.paneForegroundAgentByPaneKey,
         tabId,
         leafId: pane.leafId
       })
+    }
 
     const pasteFromClipboard = (
       pane: ManagedPane,
@@ -1992,7 +2005,7 @@ function TerminalPane(
         saveClipboardImageAsTempFile: window.api.ui.saveClipboardImageAsTempFile,
         connectionId,
         runtimeEnvironmentId,
-        forceBracketedMultilineTextPaste: resolvePaneForceBracketedMultiline(pane),
+        protectedMultilineTextPasteOptions: resolvePaneProtectedMultilinePasteOptions(pane),
         pasteText: (text, options) =>
           executePanePasteText(pane, source, activeElementAtDispatch, text, options),
         onTextPasteError: () =>
@@ -2139,7 +2152,7 @@ function TerminalPane(
         saveClipboardImageAsTempFile: window.api.ui.saveClipboardImageAsTempFile,
         connectionId,
         runtimeEnvironmentId,
-        forceBracketedMultilineTextPaste: resolvePaneForceBracketedMultiline(pane),
+        protectedMultilineTextPasteOptions: resolvePaneProtectedMultilinePasteOptions(pane),
         pasteText: (text, options) =>
           executePanePasteText(pane, 'app-menu', activeElementAtDispatch, text, options),
         onTextPasteError: () =>
@@ -2716,6 +2729,7 @@ function TerminalPane(
             ? 'win32'
             : 'linux'
         const connectionId = getConnectionId(worktreeId) ?? null
+        const pasteState = useAppStore.getState()
         const targetStillMounted = (): boolean => {
           const manager = managerRef.current
           return Boolean(
@@ -2747,10 +2761,16 @@ function TerminalPane(
               transport
             })
           },
-          forceBracketedPasteForMultiline: shouldForceBracketedMultilinePasteForPane({
+          ...resolveProtectedMultilinePasteOptionsForPane({
             isWindowsClient: forceBracketedMultilineTextPaste,
-            agentStatusByPaneKey: useAppStore.getState().agentStatusByPaneKey,
-            paneForegroundAgentByPaneKey: useAppStore.getState().paneForegroundAgentByPaneKey,
+            hostPlatform: resolveTerminalInputHostPlatform({
+              clientPlatform: shortcutPlatform,
+              state: pasteState,
+              worktreeId,
+              transport: transport ?? null
+            }),
+            agentStatusByPaneKey: pasteState.agentStatusByPaneKey,
+            paneForegroundAgentByPaneKey: pasteState.paneForegroundAgentByPaneKey,
             tabId,
             leafId: clickedPane.leafId
           }),

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -192,6 +192,7 @@ import { useVisibleTerminalTabClaim } from './use-visible-terminal-tab-claim'
 import { TerminalSshReconnectOverlay } from './TerminalSshReconnectOverlay'
 import { TerminalRemoteRuntimeReconnectBanner } from './TerminalRemoteRuntimeReconnectBanner'
 import { selectTerminalTabAgentTypesByLeaf } from './terminal-tab-agent-type-index'
+import { shouldForceBracketedMultilinePasteForPane } from './terminal-agent-paste-bracketing'
 import { canContinueAgentSessionInNewSession } from './terminal-agent-session-continuation'
 import {
   updateTerminalRemoteRuntimeRecoveryUiState,
@@ -1963,6 +1964,17 @@ function TerminalPane(
       }
     }
 
+    // Why: resolved per pane, not per tab — an agent composer needs bracketing even off
+    // Windows, because a remote ConPTY host never forwards DECSET 2004 to anyone.
+    const resolvePaneForceBracketedMultiline = (pane: ManagedPane): boolean =>
+      shouldForceBracketedMultilinePasteForPane({
+        isWindowsClient: forceBracketedMultilineTextPaste,
+        agentStatusByPaneKey: useAppStore.getState().agentStatusByPaneKey,
+        paneForegroundAgentByPaneKey: useAppStore.getState().paneForegroundAgentByPaneKey,
+        tabId,
+        leafId: pane.leafId
+      })
+
     const pasteFromClipboard = (
       pane: ManagedPane,
       source: Extract<TerminalPasteSource, 'keyboard' | 'paste-event'>,
@@ -1980,7 +1992,7 @@ function TerminalPane(
         saveClipboardImageAsTempFile: window.api.ui.saveClipboardImageAsTempFile,
         connectionId,
         runtimeEnvironmentId,
-        forceBracketedMultilineTextPaste,
+        forceBracketedMultilineTextPaste: resolvePaneForceBracketedMultiline(pane),
         pasteText: (text, options) =>
           executePanePasteText(pane, source, activeElementAtDispatch, text, options),
         onTextPasteError: () =>
@@ -2127,7 +2139,7 @@ function TerminalPane(
         saveClipboardImageAsTempFile: window.api.ui.saveClipboardImageAsTempFile,
         connectionId,
         runtimeEnvironmentId,
-        forceBracketedMultilineTextPaste,
+        forceBracketedMultilineTextPaste: resolvePaneForceBracketedMultiline(pane),
         pasteText: (text, options) =>
           executePanePasteText(pane, 'app-menu', activeElementAtDispatch, text, options),
         onTextPasteError: () =>
@@ -2735,6 +2747,13 @@ function TerminalPane(
               transport
             })
           },
+          forceBracketedPasteForMultiline: shouldForceBracketedMultilinePasteForPane({
+            isWindowsClient: forceBracketedMultilineTextPaste,
+            agentStatusByPaneKey: useAppStore.getState().agentStatusByPaneKey,
+            paneForegroundAgentByPaneKey: useAppStore.getState().paneForegroundAgentByPaneKey,
+            tabId,
+            leafId: clickedPane.leafId
+          }),
           terminalBracketedPasteMode: clickedPane.terminal.modes.bracketedPasteMode
         })
         const execution = await executeTerminalPastePlan(plan, {
@@ -2751,7 +2770,7 @@ function TerminalPane(
         recordTerminalUserInputForLeaf(tabId, clickedPane.leafId)
       })
     },
-    [getPrimarySelectionMiddleClickPane, tabId, worktreeId]
+    [getPrimarySelectionMiddleClickPane, forceBracketedMultilineTextPaste, tabId, worktreeId]
   )
 
   const handlePrimarySelectionAuxClick = useCallback(

--- a/src/renderer/src/components/terminal-pane/terminal-agent-paste-bracketing.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-agent-paste-bracketing.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest'
+
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import type { PaneForegroundAgentEntry } from '../../store/slices/pane-foreground-agent'
+import { shouldForceBracketedMultilinePasteForPane } from './terminal-agent-paste-bracketing'
+import { planTerminalPaste, type TerminalPasteTarget } from './terminal-paste-coordinator'
+import { resolveTerminalPasteRuntime } from './terminal-paste-runtime'
+
+const TAB_ID = 'tab-1'
+const AGENT_LEAF = '11111111-1111-4111-8111-111111111111'
+const SHELL_LEAF = '22222222-2222-4222-8222-222222222222'
+const AGENT_PANE_KEY = `${TAB_ID}:${AGENT_LEAF}`
+
+function agentEntry(overrides: Partial<AgentStatusEntry> = {}): AgentStatusEntry {
+  return {
+    state: 'waiting',
+    prompt: '',
+    updatedAt: 0,
+    stateStartedAt: 0,
+    stateHistory: [],
+    agentType: 'codex',
+    paneKey: AGENT_PANE_KEY,
+    ...overrides
+  }
+}
+
+function foregroundEntry(
+  overrides: Partial<PaneForegroundAgentEntry> = {}
+): PaneForegroundAgentEntry {
+  return { agent: null, shellForeground: false, ...overrides }
+}
+
+const CODEX_ON_AGENT_LEAF = { [AGENT_PANE_KEY]: agentEntry() }
+
+function decide(
+  args: Partial<Parameters<typeof shouldForceBracketedMultilinePasteForPane>[0]> = {}
+): boolean {
+  return shouldForceBracketedMultilinePasteForPane({
+    isWindowsClient: false,
+    agentStatusByPaneKey: CODEX_ON_AGENT_LEAF,
+    paneForegroundAgentByPaneKey: {},
+    tabId: TAB_ID,
+    leafId: AGENT_LEAF,
+    ...args
+  })
+}
+
+describe('shouldForceBracketedMultilinePasteForPane', () => {
+  it('brackets an agent pane on a non-Windows client (remote ConPTY host case)', () => {
+    expect(decide()).toBe(true)
+  })
+
+  it('leaves a plain shell pane alone so ESC[200~ never reaches a non-TUI program', () => {
+    expect(decide({ leafId: SHELL_LEAF })).toBe(false)
+  })
+
+  it('gates per leaf, not per tab', () => {
+    expect(decide({ tabId: 'other-tab' })).toBe(false)
+  })
+
+  it('keeps the existing Windows-client behaviour for non-agent panes', () => {
+    expect(decide({ isWindowsClient: true, agentStatusByPaneKey: {}, leafId: SHELL_LEAF })).toBe(
+      true
+    )
+  })
+
+  it('ignores a pane whose agentType is not a TUI agent', () => {
+    expect(
+      decide({
+        agentStatusByPaneKey: {
+          [AGENT_PANE_KEY]: agentEntry({
+            agentType: 'not-an-agent' as AgentStatusEntry['agentType']
+          })
+        }
+      })
+    ).toBe(false)
+  })
+
+  // Staleness: the agent row is retained on purpose and is not lifecycle-driven, so it
+  // can outlive the agent. Only evidence the pane is no longer the agent's may veto.
+  it('vetoes when OSC 133;D proved the foreground is back at the shell', () => {
+    expect(
+      decide({
+        paneForegroundAgentByPaneKey: {
+          [AGENT_PANE_KEY]: foregroundEntry({ shellForeground: true })
+        }
+      })
+    ).toBe(false)
+  })
+
+  it('vetoes a row rehydrated from disk across an app restart', () => {
+    expect(
+      decide({
+        agentStatusByPaneKey: {
+          [AGENT_PANE_KEY]: agentEntry({ restoredUnconfirmed: true })
+        }
+      })
+    ).toBe(false)
+  })
+
+  it('still brackets a long-idle agent parked at done', () => {
+    // Why: an idle-but-live agent sits at `done` with an old updatedAt. Gating on
+    // state or the 30-minute freshness TTL would strip bracketing from exactly the
+    // pane that needs it most.
+    expect(
+      decide({
+        agentStatusByPaneKey: {
+          [AGENT_PANE_KEY]: agentEntry({ state: 'done', updatedAt: 0, stateStartedAt: 0 })
+        }
+      })
+    ).toBe(true)
+  })
+
+  it('still brackets when foreground evidence exists but has not seen a shell', () => {
+    expect(
+      decide({
+        paneForegroundAgentByPaneKey: {
+          [AGENT_PANE_KEY]: foregroundEntry({ agent: 'codex', shellForeground: false })
+        }
+      })
+    ).toBe(true)
+  })
+})
+
+describe('leading-newline paste into a remote agent pane', () => {
+  // Regression: a mac client on a remote Windows host pasted a block starting with "\n".
+  // ConPTY never forwarded DECSET 2004, so xterm rewrote the newline to CR and codex
+  // submitted the draft parked in its composer.
+  const PASTED = '\nRemember: At the end of the day, we want the best possible code.'
+
+  function remoteWindowsTarget(): TerminalPasteTarget {
+    return {
+      kind: 'terminal',
+      paneId: 1,
+      leafId: AGENT_LEAF,
+      ptyId: 'remote:host-abc/pty-1',
+      runtime: resolveTerminalPasteRuntime({
+        platform: 'darwin',
+        ptyId: 'remote:host-abc/pty-1',
+        isWindowsConpty: false
+      })
+    }
+  }
+
+  it('brackets the paste so the newline can never submit the draft', () => {
+    const plan = planTerminalPaste({
+      text: PASTED,
+      source: 'keyboard',
+      target: remoteWindowsTarget(),
+      terminalBracketedPasteMode: false,
+      forceBracketedPasteForMultiline: decide()
+    })
+
+    expect(plan.payload.lineCount).toBe(2)
+    expect(plan.mode).toBe('bracketed-terminal')
+    expect(plan.bracketed).toBe(true)
+  })
+
+  it('a single-line paste stays on the direct path', () => {
+    const plan = planTerminalPaste({
+      text: 'no newline here',
+      source: 'keyboard',
+      target: remoteWindowsTarget(),
+      terminalBracketedPasteMode: false,
+      forceBracketedPasteForMultiline: decide()
+    })
+
+    expect(plan.mode).toBe('direct')
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-agent-paste-bracketing.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-agent-paste-bracketing.test.ts
@@ -110,6 +110,16 @@ describe('shouldForceBracketedMultilinePasteForPane', () => {
     ).toBe(true)
   })
 
+  it('degrades to the pre-fix path instead of throwing on a malformed pane key', () => {
+    // Why: makePaneKey throws on a non-UUID leaf or a tabId containing ':'. The throw
+    // would escape before the paste helper's catch is attached, making the paste a
+    // silent no-op with no error surface.
+    expect(() => decide({ leafId: 'not-a-uuid' })).not.toThrow()
+    expect(decide({ leafId: 'not-a-uuid' })).toBe(false)
+    expect(() => decide({ tabId: 'tab:with:colons' })).not.toThrow()
+    expect(decide({ tabId: 'tab:with:colons' })).toBe(false)
+  })
+
   it('still brackets when shellForeground is latched true while an agent owns the pane', () => {
     // Why: shellForeground is republished only at OSC 133 boundaries, so a shell with
     // no 133 integration leaves it true while an agent runs. Measured live: vetoing on

--- a/src/renderer/src/components/terminal-pane/terminal-agent-paste-bracketing.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-agent-paste-bracketing.test.ts
@@ -76,16 +76,15 @@ describe('shouldForceBracketedMultilinePasteForPane', () => {
     ).toBe(false)
   })
 
-  // Staleness: the agent row is retained on purpose and is not lifecycle-driven, so it
-  // can outlive the agent. Only evidence the pane is no longer the agent's may veto.
-  it('vetoes when OSC 133;D proved the foreground is back at the shell', () => {
+  it('brackets on a process-confirmed agent even with no status row', () => {
     expect(
       decide({
+        agentStatusByPaneKey: {},
         paneForegroundAgentByPaneKey: {
-          [AGENT_PANE_KEY]: foregroundEntry({ shellForeground: true })
+          [AGENT_PANE_KEY]: foregroundEntry({ agent: 'codex', shellForeground: false })
         }
       })
-    ).toBe(false)
+    ).toBe(true)
   })
 
   it('vetoes a row rehydrated from disk across an app restart', () => {
@@ -111,11 +110,14 @@ describe('shouldForceBracketedMultilinePasteForPane', () => {
     ).toBe(true)
   })
 
-  it('still brackets when foreground evidence exists but has not seen a shell', () => {
+  it('still brackets when shellForeground is latched true while an agent owns the pane', () => {
+    // Why: shellForeground is republished only at OSC 133 boundaries, so a shell with
+    // no 133 integration leaves it true while an agent runs. Measured live: vetoing on
+    // it reinstated the submit bug.
     expect(
       decide({
         paneForegroundAgentByPaneKey: {
-          [AGENT_PANE_KEY]: foregroundEntry({ agent: 'codex', shellForeground: false })
+          [AGENT_PANE_KEY]: foregroundEntry({ shellForeground: true })
         }
       })
     ).toBe(true)

--- a/src/renderer/src/components/terminal-pane/terminal-agent-paste-bracketing.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-agent-paste-bracketing.test.ts
@@ -1,9 +1,15 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
 import type { PaneForegroundAgentEntry } from '../../store/slices/pane-foreground-agent'
-import { shouldForceBracketedMultilinePasteForPane } from './terminal-agent-paste-bracketing'
-import { planTerminalPaste, type TerminalPasteTarget } from './terminal-paste-coordinator'
+import { resolveProtectedMultilinePasteOptionsForPane } from './terminal-agent-paste-bracketing'
+import { pasteTerminalText } from './terminal-bracketed-paste'
+import {
+  executeTerminalPastePlan,
+  planTerminalPaste,
+  type TerminalPasteTarget,
+  type TerminalPasteTextOptions
+} from './terminal-paste-coordinator'
 import { resolveTerminalPasteRuntime } from './terminal-paste-runtime'
 
 const TAB_ID = 'tab-1'
@@ -33,10 +39,11 @@ function foregroundEntry(
 const CODEX_ON_AGENT_LEAF = { [AGENT_PANE_KEY]: agentEntry() }
 
 function decide(
-  args: Partial<Parameters<typeof shouldForceBracketedMultilinePasteForPane>[0]> = {}
-): boolean {
-  return shouldForceBracketedMultilinePasteForPane({
+  args: Partial<Parameters<typeof resolveProtectedMultilinePasteOptionsForPane>[0]> = {}
+): TerminalPasteTextOptions | undefined {
+  return resolveProtectedMultilinePasteOptionsForPane({
     isWindowsClient: false,
+    hostPlatform: 'linux',
     agentStatusByPaneKey: CODEX_ON_AGENT_LEAF,
     paneForegroundAgentByPaneKey: {},
     tabId: TAB_ID,
@@ -45,22 +52,22 @@ function decide(
   })
 }
 
-describe('shouldForceBracketedMultilinePasteForPane', () => {
-  it('brackets an agent pane on a non-Windows client (remote ConPTY host case)', () => {
-    expect(decide()).toBe(true)
+describe('resolveProtectedMultilinePasteOptionsForPane', () => {
+  it('brackets an agent pane on a non-Windows host', () => {
+    expect(decide()).toEqual({ forceBracketedPasteForMultiline: true })
   })
 
   it('leaves a plain shell pane alone so ESC[200~ never reaches a non-TUI program', () => {
-    expect(decide({ leafId: SHELL_LEAF })).toBe(false)
+    expect(decide({ leafId: SHELL_LEAF })).toBeUndefined()
   })
 
   it('gates per leaf, not per tab', () => {
-    expect(decide({ tabId: 'other-tab' })).toBe(false)
+    expect(decide({ tabId: 'other-tab' })).toBeUndefined()
   })
 
   it('keeps the existing Windows-client behaviour for non-agent panes', () => {
-    expect(decide({ isWindowsClient: true, agentStatusByPaneKey: {}, leafId: SHELL_LEAF })).toBe(
-      true
+    expect(decide({ isWindowsClient: true, agentStatusByPaneKey: {}, leafId: SHELL_LEAF })).toEqual(
+      { forceBracketedPasteForMultiline: true }
     )
   })
 
@@ -73,7 +80,7 @@ describe('shouldForceBracketedMultilinePasteForPane', () => {
           })
         }
       })
-    ).toBe(false)
+    ).toBeUndefined()
   })
 
   it('brackets on a process-confirmed agent even with no status row', () => {
@@ -84,7 +91,7 @@ describe('shouldForceBracketedMultilinePasteForPane', () => {
           [AGENT_PANE_KEY]: foregroundEntry({ agent: 'codex', shellForeground: false })
         }
       })
-    ).toBe(true)
+    ).toEqual({ forceBracketedPasteForMultiline: true })
   })
 
   it('vetoes a row rehydrated from disk across an app restart', () => {
@@ -94,7 +101,7 @@ describe('shouldForceBracketedMultilinePasteForPane', () => {
           [AGENT_PANE_KEY]: agentEntry({ restoredUnconfirmed: true })
         }
       })
-    ).toBe(false)
+    ).toBeUndefined()
   })
 
   it('still brackets a long-idle agent parked at done', () => {
@@ -107,7 +114,7 @@ describe('shouldForceBracketedMultilinePasteForPane', () => {
           [AGENT_PANE_KEY]: agentEntry({ state: 'done', updatedAt: 0, stateStartedAt: 0 })
         }
       })
-    ).toBe(true)
+    ).toEqual({ forceBracketedPasteForMultiline: true })
   })
 
   it('degrades to the pre-fix path instead of throwing on a malformed pane key', () => {
@@ -115,9 +122,9 @@ describe('shouldForceBracketedMultilinePasteForPane', () => {
     // would escape before the paste helper's catch is attached, making the paste a
     // silent no-op with no error surface.
     expect(() => decide({ leafId: 'not-a-uuid' })).not.toThrow()
-    expect(decide({ leafId: 'not-a-uuid' })).toBe(false)
+    expect(decide({ leafId: 'not-a-uuid' })).toBeUndefined()
     expect(() => decide({ tabId: 'tab:with:colons' })).not.toThrow()
-    expect(decide({ tabId: 'tab:with:colons' })).toBe(false)
+    expect(decide({ tabId: 'tab:with:colons' })).toBeUndefined()
   })
 
   it('still brackets when shellForeground is latched true while an agent owns the pane', () => {
@@ -130,7 +137,24 @@ describe('shouldForceBracketedMultilinePasteForPane', () => {
           [AGENT_PANE_KEY]: foregroundEntry({ shellForeground: true })
         }
       })
-    ).toBe(true)
+    ).toEqual({ forceBracketedPasteForMultiline: true })
+  })
+
+  it('uses modified Enter for an agent that reads Windows input records', () => {
+    expect(decide({ hostPlatform: 'win32' })).toEqual({
+      windowsInputRecordNewline: 'alt-enter'
+    })
+  })
+
+  it('does not change unverified Windows agent paste protocols', () => {
+    expect(
+      decide({
+        hostPlatform: 'win32',
+        agentStatusByPaneKey: {
+          [AGENT_PANE_KEY]: agentEntry({ agentType: 'pi' })
+        }
+      })
+    ).toEqual({ forceBracketedPasteForMultiline: true })
   })
 })
 
@@ -147,25 +171,36 @@ describe('leading-newline paste into a remote agent pane', () => {
       leafId: AGENT_LEAF,
       ptyId: 'remote:host-abc/pty-1',
       runtime: resolveTerminalPasteRuntime({
-        platform: 'darwin',
+        platform: 'win32',
         ptyId: 'remote:host-abc/pty-1',
         isWindowsConpty: false
       })
     }
   }
 
-  it('brackets the paste so the newline can never submit the draft', () => {
+  it('encodes the leading newline as modified Enter instead of submit', async () => {
+    const terminal = {
+      modes: { bracketedPasteMode: false },
+      options: { ignoreBracketedPasteMode: false },
+      input: vi.fn(),
+      paste: vi.fn()
+    }
     const plan = planTerminalPaste({
       text: PASTED,
       source: 'keyboard',
       target: remoteWindowsTarget(),
       terminalBracketedPasteMode: false,
-      forceBracketedPasteForMultiline: decide()
+      ...decide({ hostPlatform: 'win32' })
+    })
+    await executeTerminalPastePlan(plan, {
+      pasteText: (text, options) => pasteTerminalText(terminal, text, options)
     })
 
     expect(plan.payload.lineCount).toBe(2)
-    expect(plan.mode).toBe('bracketed-terminal')
-    expect(plan.bracketed).toBe(true)
+    expect(plan.mode).toBe('windows-input-record')
+    expect(plan.bracketed).toBe(false)
+    expect(terminal.input).toHaveBeenCalledWith(`\x1b\r${PASTED.slice(1)}`)
+    expect(terminal.paste).not.toHaveBeenCalled()
   })
 
   it('a single-line paste stays on the direct path', () => {
@@ -174,7 +209,7 @@ describe('leading-newline paste into a remote agent pane', () => {
       source: 'keyboard',
       target: remoteWindowsTarget(),
       terminalBracketedPasteMode: false,
-      forceBracketedPasteForMultiline: decide()
+      ...decide({ hostPlatform: 'win32' })
     })
 
     expect(plan.mode).toBe('direct')

--- a/src/renderer/src/components/terminal-pane/terminal-agent-paste-bracketing.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-agent-paste-bracketing.ts
@@ -8,6 +8,19 @@ import type { PaneForegroundAgentEntry } from '../../store/slices/pane-foregroun
  * ConPTY never forwards it and that ConPTY can be on a remote host — so the client's
  * platform proves nothing about the PTY. Unbracketed, xterm rewrites the paste's
  * newlines to CR and the agent submits whatever draft was parked in its composer.
+ *
+ * Why keyed on the pane's agent and not on the mode bit itself: "we never observed
+ * DECSET 2004" is not usable evidence. Measured in real ptys — zsh 5.9, fish 4.8.1 and
+ * bash >= 5.1 emit `?2004h` at the prompt and `?2004l` just before exec, but macOS
+ * /bin/bash 3.2, /bin/sh, bash 4.4, and any shell with bracketed paste turned off in
+ * .inputrc/zle emit *nothing at all*. A deliberate opt-out is byte-identical to a bare
+ * `cat`. So silence cannot be read as "nobody has an opinion".
+ *
+ * Agent identity is the only signal that disambiguates it: a TUI agent always enables
+ * bracketed paste, so on an agent pane silence can only mean the announcement was lost
+ * in transit (ConPTY, replay) — never an opt-out. Keep this narrow for that reason.
+ * Bracketing a program that never negotiated is measurably worse than useless: the
+ * markers arrive as literal payload bytes and ICRNL still turns the CR into a submit.
  */
 export function shouldForceBracketedMultilinePasteForPane({
   isWindowsClient,

--- a/src/renderer/src/components/terminal-pane/terminal-agent-paste-bracketing.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-agent-paste-bracketing.ts
@@ -21,6 +21,13 @@ import type { PaneForegroundAgentEntry } from '../../store/slices/pane-foregroun
  * in transit (ConPTY, replay) — never an opt-out. Keep this narrow for that reason.
  * Bracketing a program that never negotiated is measurably worse than useless: the
  * markers arrive as literal payload bytes and ICRNL still turns the CR into a submit.
+ *
+ * Why this diverges from terminal-ctrl-enter / terminal-windows-shift-enter, which veto
+ * on shellForeground/routingRevoked and require routingTrusted: those resolvers decide
+ * where to ROUTE input bytes, so a forged identity misdelivers keystrokes. This one only
+ * decides whether to WRAP a paste, and the payload is ESC-sanitized downstream, so the
+ * worst a forged identity buys is a literal ESC[200~ printed at a program. Do not
+ * "align" this with those gates — measured live, that reinstates the submit bug.
  */
 export function shouldForceBracketedMultilinePasteForPane({
   isWindowsClient,
@@ -38,8 +45,20 @@ export function shouldForceBracketedMultilinePasteForPane({
   if (isWindowsClient) {
     return true
   }
-  const paneKey = makePaneKey(tabId, leafId)
+  let paneKey: string
+  try {
+    paneKey = makePaneKey(tabId, leafId)
+  } catch {
+    // Why: unreachable today (pane.leafId is a minted UUID), but a legacy/malformed
+    // layout must degrade to the pre-fix path, not throw out of the paste handler --
+    // the throw would escape before pasteTerminalClipboard's catch is attached and
+    // the paste would be a silent no-op with no error surface.
+    return false
+  }
   // Why: a process-table confirmed agent is the strongest evidence there is.
+  // Note this branch is dead for remote-runtime and SSH panes: isForegroundTrackingAllowed
+  // (pty-connection) returns false for them, so paneForegroundAgentByPaneKey stays empty
+  // and the status row below is the only evidence a remote pane ever has.
   if (isTuiAgent(paneForegroundAgentByPaneKey[paneKey]?.agent)) {
     return true
   }

--- a/src/renderer/src/components/terminal-pane/terminal-agent-paste-bracketing.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-agent-paste-bracketing.ts
@@ -8,11 +8,6 @@ import type { PaneForegroundAgentEntry } from '../../store/slices/pane-foregroun
  * ConPTY never forwards it and that ConPTY can be on a remote host — so the client's
  * platform proves nothing about the PTY. Unbracketed, xterm rewrites the paste's
  * newlines to CR and the agent submits whatever draft was parked in its composer.
- *
- * An agent row is retained on purpose (an idle agent sits at `done`), so neither the
- * 30-minute freshness TTL nor `state !== 'done'` can gate this — both would strip
- * bracketing from a live but quiet agent. Only evidence that the pane is *no longer*
- * the agent's vetoes it.
  */
 export function shouldForceBracketedMultilinePasteForPane({
   isWindowsClient,
@@ -31,10 +26,9 @@ export function shouldForceBracketedMultilinePasteForPane({
     return true
   }
   const paneKey = makePaneKey(tabId, leafId)
-  // Why: OSC 133;D proved the foreground is back at the shell — process-grade evidence
-  // that outranks an agent row nothing has cleared yet.
-  if (paneForegroundAgentByPaneKey[paneKey]?.shellForeground === true) {
-    return false
+  // Why: a process-table confirmed agent is the strongest evidence there is.
+  if (isTuiAgent(paneForegroundAgentByPaneKey[paneKey]?.agent)) {
+    return true
   }
   const entry = agentStatusByPaneKey[paneKey]
   // Why: a row rehydrated from disk across a restart describes the previous process,
@@ -42,5 +36,12 @@ export function shouldForceBracketedMultilinePasteForPane({
   if (entry?.restoredUnconfirmed === true) {
     return false
   }
+  // Why NOT vetoed on shellForeground: that flag is republished only at OSC 133
+  // boundaries, so a shell without 133 integration leaves it latched true while an
+  // agent owns the foreground. Vetoing on it silently reinstates the submit bug —
+  // measured live. An idle agent also sits at `done` past the 30-minute freshness
+  // TTL, so neither state nor TTL can gate this either. Erring toward bracketing
+  // costs a literal ESC[200~ in a non-2004 program; erring the other way sends the
+  // user's parked draft.
   return isTuiAgent(entry?.agentType)
 }

--- a/src/renderer/src/components/terminal-pane/terminal-agent-paste-bracketing.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-agent-paste-bracketing.ts
@@ -1,13 +1,12 @@
 import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
-import { isTuiAgent } from '../../../../shared/tui-agent-config'
+import { isTuiAgent, TUI_AGENT_CONFIG } from '../../../../shared/tui-agent-config'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 import type { PaneForegroundAgentEntry } from '../../store/slices/pane-foreground-agent'
+import type { TerminalPasteTextOptions } from './terminal-paste-model'
 
 /**
- * Why: xterm brackets a paste only after its own parser saw DECSET 2004, but Windows
- * ConPTY never forwards it and that ConPTY can be on a remote host — so the client's
- * platform proves nothing about the PTY. Unbracketed, xterm rewrites the paste's
- * newlines to CR and the agent submits whatever draft was parked in its composer.
+ * Why: xterm brackets a paste only after seeing DECSET 2004, which can be lost by
+ * remote replay or ConPTY. Unprotected CR submits an agent's parked draft.
  *
  * Why keyed on the pane's agent and not on the mode bit itself: "we never observed
  * DECSET 2004" is not usable evidence. Measured in real ptys — zsh 5.9, fish 4.8.1 and
@@ -16,35 +15,30 @@ import type { PaneForegroundAgentEntry } from '../../store/slices/pane-foregroun
  * .inputrc/zle emit *nothing at all*. A deliberate opt-out is byte-identical to a bare
  * `cat`. So silence cannot be read as "nobody has an opinion".
  *
- * Agent identity is the only signal that disambiguates it: a TUI agent always enables
- * bracketed paste, so on an agent pane silence can only mean the announcement was lost
- * in transit (ConPTY, replay) — never an opt-out. Keep this narrow for that reason.
- * Bracketing a program that never negotiated is measurably worse than useless: the
- * markers arrive as literal payload bytes and ICRNL still turns the CR into a submit.
+ * Agent identity disambiguates silence because a TUI agent enables bracketed paste.
+ * A verified Windows input-record agent cannot receive paste frames; for that explicit
+ * capability, use the same modified-Enter newline contract as Shift+Enter.
  *
  * Why this diverges from terminal-ctrl-enter / terminal-windows-shift-enter, which veto
  * on shellForeground/routingRevoked and require routingTrusted: those resolvers decide
  * where to ROUTE input bytes, so a forged identity misdelivers keystrokes. This one only
- * decides whether to WRAP a paste, and the payload is ESC-sanitized downstream, so the
- * worst a forged identity buys is a literal ESC[200~ printed at a program. Do not
- * "align" this with those gates — measured live, that reinstates the submit bug.
+ * decides how to encode a user-requested paste, whose ESC bytes are sanitized downstream.
  */
-export function shouldForceBracketedMultilinePasteForPane({
+export function resolveProtectedMultilinePasteOptionsForPane({
   isWindowsClient,
+  hostPlatform,
   agentStatusByPaneKey,
   paneForegroundAgentByPaneKey,
   tabId,
   leafId
 }: {
   isWindowsClient: boolean
+  hostPlatform: NodeJS.Platform
   agentStatusByPaneKey: Record<string, AgentStatusEntry>
   paneForegroundAgentByPaneKey: Record<string, PaneForegroundAgentEntry>
   tabId: string
   leafId: string
-}): boolean {
-  if (isWindowsClient) {
-    return true
-  }
+}): TerminalPasteTextOptions | undefined {
   let paneKey: string
   try {
     paneKey = makePaneKey(tabId, leafId)
@@ -53,27 +47,34 @@ export function shouldForceBracketedMultilinePasteForPane({
     // layout must degrade to the pre-fix path, not throw out of the paste handler --
     // the throw would escape before pasteTerminalClipboard's catch is attached and
     // the paste would be a silent no-op with no error surface.
-    return false
+    return isWindowsClient ? { forceBracketedPasteForMultiline: true } : undefined
   }
   // Why: a process-table confirmed agent is the strongest evidence there is.
   // Note this branch is dead for remote-runtime and SSH panes: isForegroundTrackingAllowed
   // (pty-connection) returns false for them, so paneForegroundAgentByPaneKey stays empty
   // and the status row below is the only evidence a remote pane ever has.
-  if (isTuiAgent(paneForegroundAgentByPaneKey[paneKey]?.agent)) {
-    return true
-  }
+  const foregroundAgent = paneForegroundAgentByPaneKey[paneKey]?.agent
   const entry = agentStatusByPaneKey[paneKey]
   // Why: a row rehydrated from disk across a restart describes the previous process,
   // not the shell now attached to this pane.
-  if (entry?.restoredUnconfirmed === true) {
-    return false
-  }
+  const agent = isTuiAgent(foregroundAgent)
+    ? foregroundAgent
+    : entry?.restoredUnconfirmed !== true && isTuiAgent(entry?.agentType)
+      ? entry.agentType
+      : null
   // Why NOT vetoed on shellForeground: that flag is republished only at OSC 133
   // boundaries, so a shell without 133 integration leaves it latched true while an
   // agent owns the foreground. Vetoing on it silently reinstates the submit bug —
   // measured live. An idle agent also sits at `done` past the 30-minute freshness
-  // TTL, so neither state nor TTL can gate this either. Erring toward bracketing
-  // costs a literal ESC[200~ in a non-2004 program; erring the other way sends the
-  // user's parked draft.
-  return isTuiAgent(entry?.agentType)
+  // TTL, so neither state nor TTL can gate this either. A false negative sends the
+  // user's parked draft; a false positive only changes encoding within this paste.
+  const windowsInputRecordPasteNewline = agent
+    ? TUI_AGENT_CONFIG[agent].windowsInputRecordPasteNewline
+    : undefined
+  if (hostPlatform === 'win32' && windowsInputRecordPasteNewline) {
+    return {
+      windowsInputRecordNewline: windowsInputRecordPasteNewline
+    }
+  }
+  return isWindowsClient || agent ? { forceBracketedPasteForMultiline: true } : undefined
 }

--- a/src/renderer/src/components/terminal-pane/terminal-agent-paste-bracketing.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-agent-paste-bracketing.ts
@@ -1,0 +1,46 @@
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import { isTuiAgent } from '../../../../shared/tui-agent-config'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
+import type { PaneForegroundAgentEntry } from '../../store/slices/pane-foreground-agent'
+
+/**
+ * Why: xterm brackets a paste only after its own parser saw DECSET 2004, but Windows
+ * ConPTY never forwards it and that ConPTY can be on a remote host — so the client's
+ * platform proves nothing about the PTY. Unbracketed, xterm rewrites the paste's
+ * newlines to CR and the agent submits whatever draft was parked in its composer.
+ *
+ * An agent row is retained on purpose (an idle agent sits at `done`), so neither the
+ * 30-minute freshness TTL nor `state !== 'done'` can gate this — both would strip
+ * bracketing from a live but quiet agent. Only evidence that the pane is *no longer*
+ * the agent's vetoes it.
+ */
+export function shouldForceBracketedMultilinePasteForPane({
+  isWindowsClient,
+  agentStatusByPaneKey,
+  paneForegroundAgentByPaneKey,
+  tabId,
+  leafId
+}: {
+  isWindowsClient: boolean
+  agentStatusByPaneKey: Record<string, AgentStatusEntry>
+  paneForegroundAgentByPaneKey: Record<string, PaneForegroundAgentEntry>
+  tabId: string
+  leafId: string
+}): boolean {
+  if (isWindowsClient) {
+    return true
+  }
+  const paneKey = makePaneKey(tabId, leafId)
+  // Why: OSC 133;D proved the foreground is back at the shell — process-grade evidence
+  // that outranks an agent row nothing has cleared yet.
+  if (paneForegroundAgentByPaneKey[paneKey]?.shellForeground === true) {
+    return false
+  }
+  const entry = agentStatusByPaneKey[paneKey]
+  // Why: a row rehydrated from disk across a restart describes the previous process,
+  // not the shell now attached to this pane.
+  if (entry?.restoredUnconfirmed === true) {
+    return false
+  }
+  return isTuiAgent(entry?.agentType)
+}

--- a/src/renderer/src/components/terminal-pane/terminal-agent-paste-bracketing.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-agent-paste-bracketing.ts
@@ -49,12 +49,25 @@ export function resolveProtectedMultilinePasteOptionsForPane({
     // the paste would be a silent no-op with no error surface.
     return isWindowsClient ? { forceBracketedPasteForMultiline: true } : undefined
   }
-  // Why: a process-table confirmed agent is the strongest evidence there is.
-  // Note this branch is dead for remote-runtime and SSH panes: isForegroundTrackingAllowed
-  // (pty-connection) returns false for them, so paneForegroundAgentByPaneKey stays empty
-  // and the status row below is the only evidence a remote pane ever has.
-  const foregroundAgent = paneForegroundAgentByPaneKey[paneKey]?.agent
-  const entry = agentStatusByPaneKey[paneKey]
+  return resolveProtectedMultilinePasteOptionsForAgentEvidence({
+    isWindowsClient,
+    hostPlatform,
+    foregroundAgent: paneForegroundAgentByPaneKey[paneKey]?.agent,
+    entry: agentStatusByPaneKey[paneKey]
+  })
+}
+
+export function resolveProtectedMultilinePasteOptionsForAgentEvidence({
+  isWindowsClient,
+  hostPlatform,
+  foregroundAgent,
+  entry
+}: {
+  isWindowsClient: boolean
+  hostPlatform: NodeJS.Platform
+  foregroundAgent: unknown
+  entry: AgentStatusEntry | undefined
+}): TerminalPasteTextOptions | undefined {
   // Why: a row rehydrated from disk across a restart describes the previous process,
   // not the shell now attached to this pane.
   const agent = isTuiAgent(foregroundAgent)

--- a/src/renderer/src/components/terminal-pane/terminal-bracketed-paste.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-bracketed-paste.test.ts
@@ -111,6 +111,17 @@ describe('terminal bracketed paste policy', () => {
     expect(terminal.paste).not.toHaveBeenCalled()
   })
 
+  it('encodes Windows input-record newlines atomically and sanitizes escape bytes', () => {
+    const terminal = createTerminal(false)
+
+    pasteTerminalText(terminal, '\none\r\ntwo\x1b[201~', {
+      windowsInputRecordNewline: 'alt-enter'
+    })
+
+    expect(terminal.input).toHaveBeenCalledWith('\x1b\rone\x1b\rtwo␛[201~')
+    expect(terminal.paste).not.toHaveBeenCalled()
+  })
+
   it('does not change paste behavior when Ctrl+C happened outside bracketed paste mode', () => {
     const terminal = createTerminal(false)
     const observedIgnoreValues: (boolean | undefined)[] = []

--- a/src/renderer/src/components/terminal-pane/terminal-bracketed-paste.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-bracketed-paste.ts
@@ -1,4 +1,5 @@
 import type { Terminal } from '@xterm/xterm'
+import type { WindowsInputRecordNewline } from './terminal-paste-model'
 
 type BracketedPasteTerminal = {
   modes: {
@@ -14,6 +15,7 @@ type PasteTerminal = BracketedPasteTerminal & {
 
 type PasteTerminalTextOptions = {
   forceBracketedPaste?: boolean
+  windowsInputRecordNewline?: WindowsInputRecordNewline
 }
 
 const interruptedBracketedPasteTerminals = new WeakSet<object>()
@@ -77,6 +79,28 @@ export function wrapTerminalBracketedPasteText(text: string): string {
   return `${BRACKETED_PASTE_START}${sanitizeBracketedPasteText(normalizedText)}${BRACKETED_PASTE_END}`
 }
 
+export function encodeWindowsInputRecordPasteText(
+  text: string,
+  newline: WindowsInputRecordNewline
+): string {
+  const newlineSequence = newline === 'csi-u' ? '\x1b[13;2u' : '\x1b\r'
+  let encoded = ''
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index]
+    if (char === '\r') {
+      encoded += newlineSequence
+      if (text[index + 1] === '\n') {
+        index += 1
+      }
+    } else if (char === '\n') {
+      encoded += newlineSequence
+    } else {
+      encoded += char === ESCAPE ? '\u241b' : char
+    }
+  }
+  return encoded
+}
+
 function forceBracketedPaste(terminal: PasteTerminal, text: string): void {
   // Why: forced callers already built the exact paste protocol bytes. Send
   // them as PTY input so xterm's DOM/native paste machinery cannot defer them.
@@ -110,6 +134,12 @@ export function pasteTerminalText(
   text: string,
   options?: PasteTerminalTextOptions
 ): void {
+  if (options?.windowsInputRecordNewline) {
+    // Why: input-record TUIs see bracket markers as keys; modified Enter preserves
+    // pasted newlines without turning the first one into submit.
+    terminal.input(encodeWindowsInputRecordPasteText(text, options.windowsInputRecordNewline))
+    return
+  }
   if (options?.forceBracketedPaste) {
     // Why: generated image paths are paste payloads, even when they are a
     // single line, so they must bypass stale Ctrl+C plain-text suppression.

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.test.ts
@@ -308,6 +308,21 @@ describe('terminal clipboard paste', () => {
     })
   })
 
+  it('delegates Windows input-record newline protection without scanning text', async () => {
+    const pasteText = vi.fn()
+
+    await pasteTerminalClipboard({
+      readClipboardText: vi.fn().mockResolvedValue('\nline two'),
+      saveClipboardImageAsTempFile: vi.fn(),
+      pasteText,
+      protectedMultilineTextPasteOptions: { windowsInputRecordNewline: 'alt-enter' }
+    })
+
+    expect(pasteText).toHaveBeenCalledWith('\nline two', {
+      windowsInputRecordNewline: 'alt-enter'
+    })
+  })
+
   it('keeps single-line text on the ordinary paste path when Windows multi-line protection is on', async () => {
     const saveClipboardImageAsTempFile = vi.fn()
     const pasteText = vi.fn()

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.ts
@@ -22,6 +22,7 @@ type PasteTerminalClipboardDeps = {
   connectionId?: string | null
   runtimeEnvironmentId?: string | null
   forceBracketedMultilineTextPaste?: boolean
+  protectedMultilineTextPasteOptions?: TerminalPasteTextOptions
   onTextPasteError?: (error: unknown) => void
   onImagePasteError?: (error: unknown) => void
 }
@@ -46,6 +47,7 @@ export async function pasteTerminalClipboard({
   connectionId,
   runtimeEnvironmentId,
   forceBracketedMultilineTextPaste = false,
+  protectedMultilineTextPasteOptions,
   onTextPasteError,
   onImagePasteError
 }: PasteTerminalClipboardDeps): Promise<TerminalClipboardPasteResult> {
@@ -62,9 +64,10 @@ export async function pasteTerminalClipboard({
   }
   if (text) {
     try {
-      const result = await (forceBracketedMultilineTextPaste
-        ? pasteText(text, { forceBracketedPasteForMultiline: true })
-        : pasteText(text))
+      const textOptions =
+        protectedMultilineTextPasteOptions ??
+        (forceBracketedMultilineTextPaste ? { forceBracketedPasteForMultiline: true } : undefined)
+      const result = await (textOptions ? pasteText(text, textOptions) : pasteText(text))
       if (result === false) {
         return { status: 'skipped', reason: 'text-paste-rejected' }
       }

--- a/src/renderer/src/components/terminal-pane/terminal-paste-chunks.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-paste-chunks.ts
@@ -17,15 +17,19 @@ export function chunkTerminalPastePlan(plan: TerminalPastePlan): string[] {
 }
 
 export function* iterateTerminalPastePlanChunks(plan: TerminalPastePlan): Generator<string> {
-  const maxChunkBytes = Math.max(4, plan.maxChunkBytes ?? TERMINAL_PASTE_CHUNK_MAX_BYTES)
+  const maxChunkBytes = Math.max(
+    plan.windowsInputRecordNewline === 'csi-u' ? 8 : 4,
+    plan.maxChunkBytes ?? TERMINAL_PASTE_CHUNK_MAX_BYTES
+  )
   if (plan.bracketed) {
     yield BRACKETED_PASTE_START
   }
   yield* iterateTextByUtf8Bytes(
     plan.payload.plainText,
     maxChunkBytes,
-    plan.bracketed,
-    plan.newlinePolicy === 'terminal-cr'
+    plan.bracketed || plan.newlinePolicy === 'windows-input-record',
+    plan.newlinePolicy,
+    plan.windowsInputRecordNewline
   )
   if (plan.bracketed) {
     yield BRACKETED_PASTE_END
@@ -36,7 +40,8 @@ function* iterateTextByUtf8Bytes(
   text: string,
   maxBytes: number,
   sanitizeEscapes: boolean,
-  normalizeLineEndings: boolean
+  newlinePolicy: TerminalPastePlan['newlinePolicy'],
+  windowsInputRecordNewline?: TerminalPastePlan['windowsInputRecordNewline']
 ): Generator<string> {
   let chunk = ''
   let chunkBytes = 0
@@ -45,26 +50,34 @@ function* iterateTextByUtf8Bytes(
     const codeUnitLength = codePoint > 0xffff ? 2 : 1
     // Why: iterator normalization avoids a full-size copy and keeps CRLF atomic across chunks.
     if (
-      normalizeLineEndings &&
+      newlinePolicy !== 'preserve' &&
       codePoint === LINE_FEED_CODE_POINT &&
       index > 0 &&
       text.charCodeAt(index - 1) === CARRIAGE_RETURN_CODE_POINT
     ) {
       continue
     }
-    const normalizedCodePoint =
-      normalizeLineEndings && codePoint === LINE_FEED_CODE_POINT
-        ? CARRIAGE_RETURN_CODE_POINT
-        : codePoint
+    const isLineEnding =
+      newlinePolicy !== 'preserve' &&
+      (codePoint === LINE_FEED_CODE_POINT || codePoint === CARRIAGE_RETURN_CODE_POINT)
+    const normalizedCodePoint = isLineEnding ? CARRIAGE_RETURN_CODE_POINT : codePoint
     const sanitizedEscape = sanitizeEscapes && codePoint === TERMINAL_PASTE_ESCAPE_CODE_POINT
-    const next = sanitizedEscape
-      ? TERMINAL_PASTE_INERT_ESCAPE
-      : normalizedCodePoint === codePoint
-        ? text.slice(index, index + codeUnitLength)
-        : '\r'
-    const nextBytes = getUtf8ByteLengthForCodePoint(
-      sanitizedEscape ? TERMINAL_PASTE_INERT_ESCAPE_CODE_POINT : normalizedCodePoint
-    )
+    const next =
+      isLineEnding && newlinePolicy === 'windows-input-record'
+        ? windowsInputRecordNewline === 'csi-u'
+          ? '\x1b[13;2u'
+          : '\x1b\r'
+        : sanitizedEscape
+          ? TERMINAL_PASTE_INERT_ESCAPE
+          : normalizedCodePoint === codePoint
+            ? text.slice(index, index + codeUnitLength)
+            : '\r'
+    const nextBytes =
+      isLineEnding && newlinePolicy === 'windows-input-record'
+        ? next.length
+        : getUtf8ByteLengthForCodePoint(
+            sanitizedEscape ? TERMINAL_PASTE_INERT_ESCAPE_CODE_POINT : normalizedCodePoint
+          )
     if (chunk && chunkBytes + nextBytes > maxBytes) {
       yield chunk
       chunk = next

--- a/src/renderer/src/components/terminal-pane/terminal-paste-coordinator.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-paste-coordinator.test.ts
@@ -276,6 +276,30 @@ describe('terminal paste coordinator', () => {
     expect(chunkTerminalPastePlan(plan).join('')).toBe('\x1b\r\x1b\r\x1b\r\x1b\r')
   })
 
+  it('counts CRLF by its exact encoded size at paste limits', () => {
+    const altEnter = planTerminalPaste({
+      text: 'a\r\n',
+      source: 'keyboard',
+      target: terminalTarget(),
+      windowsInputRecordNewline: 'alt-enter',
+      maxDirectBytes: 3,
+      maxBytes: 3
+    })
+    const csiU = planTerminalPaste({
+      text: 'a\r\n',
+      source: 'keyboard',
+      target: terminalTarget(),
+      windowsInputRecordNewline: 'csi-u',
+      maxDirectBytes: 8,
+      maxBytes: 8
+    })
+
+    expect(altEnter.mode).toBe('windows-input-record')
+    expect(chunkTerminalPastePlan(altEnter).join('')).toBe('a\x1b\r')
+    expect(csiU.mode).toBe('windows-input-record')
+    expect(chunkTerminalPastePlan(csiU).join('')).toBe('a\x1b[13;2u')
+  })
+
   it('chunks escape-heavy bracketed paste without per-character string sanitizer scans', () => {
     const text = Array.from({ length: 64 }, (_value, index) => `part-${index}\x1b[201~`).join('')
     const plan = planTerminalPaste({

--- a/src/renderer/src/components/terminal-pane/terminal-paste-coordinator.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-paste-coordinator.test.ts
@@ -242,6 +242,40 @@ describe('terminal paste coordinator', () => {
     expect(chunks.join('')).not.toContain('\n')
   })
 
+  it('streams large Windows input-record paste with atomic modified Enter newlines', () => {
+    const plan = planTerminalPaste({
+      text: '\nabc\r\ndef\x1b[201~ghi',
+      source: 'keyboard',
+      target: terminalTarget(),
+      windowsInputRecordNewline: 'alt-enter',
+      terminalBracketedPasteMode: true,
+      maxDirectBytes: 4,
+      maxChunkBytes: 4
+    })
+    const chunks = chunkTerminalPastePlan(plan)
+
+    expect(plan.mode).toBe('chunked')
+    expect(plan.bracketed).toBe(false)
+    expect(plan.newlinePolicy).toBe('windows-input-record')
+    expect(chunks.join('')).toBe('\x1b\rabc\x1b\rdef␛[201~ghi')
+    expect(chunks).not.toContain('\x1b[200~')
+    expect(chunks).not.toContain('\x1b[201~')
+  })
+
+  it('accounts for modified-Enter expansion before choosing bounded chunks', () => {
+    const plan = planTerminalPaste({
+      text: '\n\n\n\n',
+      source: 'keyboard',
+      target: terminalTarget(),
+      windowsInputRecordNewline: 'alt-enter',
+      maxDirectBytes: 6,
+      maxBytes: 16
+    })
+
+    expect(plan.mode).toBe('chunked')
+    expect(chunkTerminalPastePlan(plan).join('')).toBe('\x1b\r\x1b\r\x1b\r\x1b\r')
+  })
+
   it('chunks escape-heavy bracketed paste without per-character string sanitizer scans', () => {
     const text = Array.from({ length: 64 }, (_value, index) => `part-${index}\x1b[201~`).join('')
     const plan = planTerminalPaste({

--- a/src/renderer/src/components/terminal-pane/terminal-paste-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-paste-coordinator.ts
@@ -12,7 +12,8 @@ import type {
   TerminalPastePayload,
   TerminalPastePlan,
   TerminalPasteSource,
-  TerminalPasteTarget
+  TerminalPasteTarget,
+  WindowsInputRecordNewline
 } from './terminal-paste-model'
 
 export {
@@ -42,6 +43,7 @@ type PlanTerminalPasteArgs = {
   target: TerminalPasteTarget
   forceBracketedPaste?: boolean
   forceBracketedPasteForMultiline?: boolean
+  windowsInputRecordNewline?: WindowsInputRecordNewline
   terminalBracketedPasteMode?: boolean
   hasRichText?: boolean
   maxDirectBytes?: number
@@ -82,6 +84,7 @@ export function planTerminalPaste({
   target,
   forceBracketedPaste = false,
   forceBracketedPasteForMultiline = false,
+  windowsInputRecordNewline,
   terminalBracketedPasteMode = false,
   hasRichText = false,
   maxDirectBytes = TERMINAL_PASTE_DIRECT_MAX_BYTES,
@@ -92,6 +95,7 @@ export function planTerminalPaste({
   return buildTerminalPastePlan({
     forceBracketedPaste,
     forceBracketedPasteForMultiline,
+    windowsInputRecordNewline,
     maxBytes,
     maxChunkBytes,
     maxDirectBytes,
@@ -107,6 +111,7 @@ export async function planTerminalPasteWithYield({
   target,
   forceBracketedPaste = false,
   forceBracketedPasteForMultiline = false,
+  windowsInputRecordNewline,
   terminalBracketedPasteMode = false,
   hasRichText = false,
   maxDirectBytes = TERMINAL_PASTE_DIRECT_MAX_BYTES,
@@ -131,6 +136,7 @@ export async function planTerminalPasteWithYield({
   return buildTerminalPastePlan({
     forceBracketedPaste,
     forceBracketedPasteForMultiline,
+    windowsInputRecordNewline,
     maxBytes,
     maxChunkBytes,
     maxDirectBytes,
@@ -145,6 +151,7 @@ function buildTerminalPastePlan({
   target,
   forceBracketedPaste,
   forceBracketedPasteForMultiline,
+  windowsInputRecordNewline,
   terminalBracketedPasteMode,
   maxDirectBytes,
   maxChunkBytes,
@@ -154,18 +161,31 @@ function buildTerminalPastePlan({
   target: TerminalPasteTarget
   forceBracketedPaste: boolean
   forceBracketedPasteForMultiline: boolean
+  windowsInputRecordNewline?: WindowsInputRecordNewline
   terminalBracketedPasteMode: boolean
   maxDirectBytes: number
   maxChunkBytes: number
   maxBytes: number
 }): TerminalPastePlan {
-  const shouldChunk = payload.byteLength > maxDirectBytes
+  const effectiveWindowsInputRecordNewline =
+    !forceBracketedPaste && payload.lineCount > 1 ? windowsInputRecordNewline : undefined
+  const plannedByteLength = effectiveWindowsInputRecordNewline
+    ? payload.byteLength +
+      (payload.lineCount - 1) * (effectiveWindowsInputRecordNewline === 'csi-u' ? 6 : 1)
+    : payload.byteLength
+  const shouldChunk = plannedByteLength > maxDirectBytes
   const effectiveForceBracketedPaste =
-    forceBracketedPaste || (forceBracketedPasteForMultiline && payload.lineCount > 1)
-  const shouldBracketChunk = effectiveForceBracketedPaste || terminalBracketedPasteMode
+    forceBracketedPaste ||
+    (effectiveWindowsInputRecordNewline === undefined &&
+      forceBracketedPasteForMultiline &&
+      payload.lineCount > 1)
+  const shouldBracketChunk =
+    effectiveWindowsInputRecordNewline === undefined &&
+    (effectiveForceBracketedPaste || terminalBracketedPasteMode)
   const mode = choosePasteMode({
-    byteLength: payload.byteLength,
+    byteLength: plannedByteLength,
     forceBracketedPaste: effectiveForceBracketedPaste,
+    windowsInputRecordNewline: effectiveWindowsInputRecordNewline,
     shouldChunk,
     maxBytes
   })
@@ -173,7 +193,15 @@ function buildTerminalPastePlan({
     target,
     payload,
     mode,
-    newlinePolicy: mode === 'chunked' || mode === 'bracketed-terminal' ? 'terminal-cr' : 'preserve',
+    newlinePolicy:
+      effectiveWindowsInputRecordNewline !== undefined
+        ? 'windows-input-record'
+        : mode === 'chunked' || mode === 'bracketed-terminal'
+          ? 'terminal-cr'
+          : 'preserve',
+    ...(effectiveWindowsInputRecordNewline
+      ? { windowsInputRecordNewline: effectiveWindowsInputRecordNewline }
+      : {}),
     runtimeKey: target.runtime.runtimeKey,
     ...(shouldChunk ? { maxChunkBytes } : {}),
     bracketed: mode === 'bracketed-terminal' || (mode === 'chunked' && shouldBracketChunk),
@@ -189,11 +217,13 @@ function buildTerminalPastePlan({
 function choosePasteMode({
   byteLength,
   forceBracketedPaste,
+  windowsInputRecordNewline,
   shouldChunk,
   maxBytes
 }: {
   byteLength: number
   forceBracketedPaste: boolean
+  windowsInputRecordNewline?: WindowsInputRecordNewline
   shouldChunk: boolean
   maxBytes: number
 }): TerminalPastePlan['mode'] {
@@ -202,6 +232,9 @@ function choosePasteMode({
   }
   if (shouldChunk) {
     return 'chunked'
+  }
+  if (windowsInputRecordNewline !== undefined) {
+    return 'windows-input-record'
   }
   return forceBracketedPaste ? 'bracketed-terminal' : 'direct'
 }

--- a/src/renderer/src/components/terminal-pane/terminal-paste-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-paste-coordinator.ts
@@ -74,7 +74,8 @@ export function createTerminalPastePayload({
     byteLength: metadata.byteLength,
     lineCount: metadata.lineCount,
     hasRichText,
-    hasControlSequences: metadata.hasControlSequences
+    hasControlSequences: metadata.hasControlSequences,
+    lineEndingByteLength: metadata.lineEndingByteLength
   }
 }
 
@@ -131,7 +132,8 @@ export async function planTerminalPasteWithYield({
     byteLength: metadata.byteLength,
     lineCount: metadata.lineCount,
     hasRichText,
-    hasControlSequences: metadata.hasControlSequences
+    hasControlSequences: metadata.hasControlSequences,
+    lineEndingByteLength: metadata.lineEndingByteLength
   }
   return buildTerminalPastePlan({
     forceBracketedPaste,
@@ -170,8 +172,9 @@ function buildTerminalPastePlan({
   const effectiveWindowsInputRecordNewline =
     !forceBracketedPaste && payload.lineCount > 1 ? windowsInputRecordNewline : undefined
   const plannedByteLength = effectiveWindowsInputRecordNewline
-    ? payload.byteLength +
-      (payload.lineCount - 1) * (effectiveWindowsInputRecordNewline === 'csi-u' ? 6 : 1)
+    ? payload.byteLength -
+      payload.lineEndingByteLength +
+      (payload.lineCount - 1) * (effectiveWindowsInputRecordNewline === 'csi-u' ? 7 : 2)
     : payload.byteLength
   const shouldChunk = plannedByteLength > maxDirectBytes
   const effectiveForceBracketedPaste =

--- a/src/renderer/src/components/terminal-pane/terminal-paste-executor.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-paste-executor.ts
@@ -62,7 +62,10 @@ async function executeTerminalPastePlanNow(
   if (plan.mode !== 'chunked') {
     const pasteResult = await runTerminalPasteOperationWithTimeout(() => {
       return pasteText(plan.payload.plainText, {
-        forceBracketedPaste: plan.mode === 'bracketed-terminal'
+        forceBracketedPaste: plan.mode === 'bracketed-terminal',
+        ...(plan.windowsInputRecordNewline
+          ? { windowsInputRecordNewline: plan.windowsInputRecordNewline }
+          : {})
       })
     }, operationTimeoutMs)
     if (pasteResult.timedOut) {

--- a/src/renderer/src/components/terminal-pane/terminal-paste-model.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-paste-model.ts
@@ -29,6 +29,7 @@ export type TerminalPastePayload = {
   lineCount: number
   hasRichText: boolean
   hasControlSequences: boolean
+  lineEndingByteLength: number
 }
 
 export type TerminalPastePlan = {

--- a/src/renderer/src/components/terminal-pane/terminal-paste-model.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-paste-model.ts
@@ -34,10 +34,11 @@ export type TerminalPastePayload = {
 export type TerminalPastePlan = {
   target: TerminalPasteTarget
   payload: TerminalPastePayload
-  mode: 'direct' | 'chunked' | 'bracketed-terminal' | 'reject'
+  mode: 'direct' | 'chunked' | 'bracketed-terminal' | 'windows-input-record' | 'reject'
   // Why: 'terminal-cr' marks plans whose paste bytes Orca constructs itself, so
   // every write path applies xterm's native \r?\n -> \r before ConPTY sees LF.
-  newlinePolicy: 'preserve' | 'terminal-cr'
+  newlinePolicy: 'preserve' | 'terminal-cr' | 'windows-input-record'
+  windowsInputRecordNewline?: WindowsInputRecordNewline
   runtimeKey: string
   maxChunkBytes?: number
   bracketed: boolean
@@ -48,8 +49,11 @@ export type TerminalPastePlan = {
 export type TerminalPasteTextOptions = {
   forceBracketedPaste?: boolean
   forceBracketedPasteForMultiline?: boolean
+  windowsInputRecordNewline?: WindowsInputRecordNewline
   recoverImagePasteWebglAtlas?: boolean
 }
+
+export type WindowsInputRecordNewline = 'alt-enter' | 'csi-u'
 
 export type TerminalPasteExecutionReason =
   | 'operation-timeout'

--- a/src/renderer/src/components/terminal-pane/terminal-paste-payload-metadata.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-paste-payload-metadata.test.ts
@@ -18,6 +18,7 @@ describe('terminal paste payload metadata', () => {
         byteLength: textEncoder.encode(text).byteLength,
         exceededLimit: false,
         hasControlSequences: expected.hasControlSequences,
+        lineEndingByteLength: text.match(/[\r\n]/g)?.length ?? 0,
         lineCount: expected.lineCount
       })
     }
@@ -30,6 +31,7 @@ describe('terminal paste payload metadata', () => {
       byteLength: 26,
       exceededLimit: false,
       hasControlSequences: true,
+      lineEndingByteLength: 3,
       lineCount: 3
     })
     expect(utf8ByteLength(text)).toBe(26)
@@ -45,6 +47,7 @@ describe('terminal paste payload metadata', () => {
       byteLength: 8,
       exceededLimit: true,
       hasControlSequences: false,
+      lineEndingByteLength: 0,
       lineCount: 1
     })
     expect(metadata.byteLength).toBeLessThan(utf8ByteLength(text))
@@ -64,6 +67,7 @@ describe('terminal paste payload metadata', () => {
       byteLength: 43,
       exceededLimit: false,
       hasControlSequences: true,
+      lineEndingByteLength: 2,
       lineCount: 2
     })
     expect(yieldToEventLoop).toHaveBeenCalled()

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
@@ -40,6 +40,7 @@ import type { AgentSessionContinuationRequest } from '@/lib/agent-session-contin
 import { recordCreatedTerminalPaneSplit } from './terminal-pane-split-completion'
 import { splitTerminalPaneWithInheritedCwd } from './terminal-pane-split-with-inherited-cwd'
 import { useAppStore } from '@/store'
+import { shouldForceBracketedMultilinePasteForPane } from './terminal-agent-paste-bracketing'
 import { translate } from '@/i18n/i18n'
 import { recordTerminalUserInputForLeaf } from './terminal-input-activity'
 import { copyTerminalHandleForPane } from './terminal-handle-copy'
@@ -331,7 +332,13 @@ export function useTerminalPaneContextMenu({
       saveClipboardImageAsTempFile: window.api.ui.saveClipboardImageAsTempFile,
       connectionId,
       runtimeEnvironmentId,
-      forceBracketedMultilineTextPaste,
+      forceBracketedMultilineTextPaste: shouldForceBracketedMultilinePasteForPane({
+        isWindowsClient: forceBracketedMultilineTextPaste,
+        agentStatusByPaneKey: useAppStore.getState().agentStatusByPaneKey,
+        paneForegroundAgentByPaneKey: useAppStore.getState().paneForegroundAgentByPaneKey,
+        tabId,
+        leafId: pane.leafId
+      }),
       pasteText: (text, options) => executeMenuPasteText(pane, source, text, options),
       onTextPasteError: () =>
         onPasteError('Paste failed: clipboard text is too large for a safe terminal paste.'),

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
@@ -40,7 +40,8 @@ import type { AgentSessionContinuationRequest } from '@/lib/agent-session-contin
 import { recordCreatedTerminalPaneSplit } from './terminal-pane-split-completion'
 import { splitTerminalPaneWithInheritedCwd } from './terminal-pane-split-with-inherited-cwd'
 import { useAppStore } from '@/store'
-import { shouldForceBracketedMultilinePasteForPane } from './terminal-agent-paste-bracketing'
+import { resolveProtectedMultilinePasteOptionsForPane } from './terminal-agent-paste-bracketing'
+import { resolveTerminalInputHostPlatform } from './terminal-input-host-platform'
 import { translate } from '@/i18n/i18n'
 import { recordTerminalUserInputForLeaf } from './terminal-input-activity'
 import { copyTerminalHandleForPane } from './terminal-handle-copy'
@@ -263,6 +264,7 @@ export function useTerminalPaneContextMenu({
       },
       forceBracketedPaste: options?.forceBracketedPaste,
       forceBracketedPasteForMultiline: options?.forceBracketedPasteForMultiline,
+      windowsInputRecordNewline: options?.windowsInputRecordNewline,
       terminalBracketedPasteMode: pane.terminal.modes.bracketedPasteMode
     })
     const execution = await executeTerminalPastePlan(plan, {
@@ -323,19 +325,24 @@ export function useTerminalPaneContextMenu({
       return
     }
     const connectionId = getConnectionId(worktreeId) ?? null
-    const runtimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(
-      useAppStore.getState(),
-      worktreeId
-    )
+    const state = useAppStore.getState()
+    const runtimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(state, worktreeId)
+    const transport = paneTransportsRef.current.get(pane.id) ?? null
     const result = await pasteTerminalClipboard({
       readClipboardText: window.api.ui.readClipboardText,
       saveClipboardImageAsTempFile: window.api.ui.saveClipboardImageAsTempFile,
       connectionId,
       runtimeEnvironmentId,
-      forceBracketedMultilineTextPaste: shouldForceBracketedMultilinePasteForPane({
+      protectedMultilineTextPasteOptions: resolveProtectedMultilinePasteOptionsForPane({
         isWindowsClient: forceBracketedMultilineTextPaste,
-        agentStatusByPaneKey: useAppStore.getState().agentStatusByPaneKey,
-        paneForegroundAgentByPaneKey: useAppStore.getState().paneForegroundAgentByPaneKey,
+        hostPlatform: resolveTerminalInputHostPlatform({
+          clientPlatform: getShortcutPlatform(),
+          state,
+          worktreeId,
+          transport
+        }),
+        agentStatusByPaneKey: state.agentStatusByPaneKey,
+        paneForegroundAgentByPaneKey: state.paneForegroundAgentByPaneKey,
         tabId,
         leafId: pane.leafId
       }),

--- a/src/renderer/src/lib/paste-payload-metadata.test.ts
+++ b/src/renderer/src/lib/paste-payload-metadata.test.ts
@@ -18,6 +18,7 @@ describe('paste payload metadata', () => {
         byteLength: textEncoder.encode(text).byteLength,
         exceededLimit: false,
         hasControlSequences: expected.hasControlSequences,
+        lineEndingByteLength: text.match(/[\r\n]/g)?.length ?? 0,
         lineCount: expected.lineCount
       })
     }
@@ -30,6 +31,7 @@ describe('paste payload metadata', () => {
       byteLength: 26,
       exceededLimit: false,
       hasControlSequences: true,
+      lineEndingByteLength: 3,
       lineCount: 3
     })
     expect(getPastePayloadUtf8ByteLength(text)).toBe(26)
@@ -45,6 +47,7 @@ describe('paste payload metadata', () => {
       byteLength: 8,
       exceededLimit: true,
       hasControlSequences: false,
+      lineEndingByteLength: 0,
       lineCount: 1
     })
     expect(metadata.byteLength).toBeLessThan(getPastePayloadUtf8ByteLength(text))
@@ -64,6 +67,7 @@ describe('paste payload metadata', () => {
       byteLength: 43,
       exceededLimit: false,
       hasControlSequences: true,
+      lineEndingByteLength: 2,
       lineCount: 2
     })
     expect(yieldToEventLoop).toHaveBeenCalled()

--- a/src/renderer/src/lib/paste-payload-metadata.ts
+++ b/src/renderer/src/lib/paste-payload-metadata.ts
@@ -8,6 +8,7 @@ export type PastePayloadMetadata = {
   byteLength: number
   exceededLimit: boolean
   hasControlSequences: boolean
+  lineEndingByteLength: number
   lineCount: number
 }
 
@@ -24,6 +25,7 @@ export function measurePastePayloadMetadata(
   const stopAfterBytes = options.stopAfterBytes
   let byteLength = 0
   let hasControlSequences = false
+  let lineEndingByteLength = 0
   let lineCount = 1
   let previousWasCarriageReturn = false
 
@@ -33,22 +35,32 @@ export function measurePastePayloadMetadata(
     hasControlSequences ||= isPasteControlSequenceCodePoint(codePoint)
     if (codePoint === 0x0d) {
       lineCount += 1
+      lineEndingByteLength += 1
       previousWasCarriageReturn = true
     } else {
-      if (codePoint === 0x0a && !previousWasCarriageReturn) {
-        lineCount += 1
+      if (codePoint === 0x0a) {
+        lineEndingByteLength += 1
+        if (!previousWasCarriageReturn) {
+          lineCount += 1
+        }
       }
       previousWasCarriageReturn = false
     }
     if (Number.isFinite(stopAfterBytes) && byteLength > (stopAfterBytes ?? 0)) {
-      return { byteLength, exceededLimit: true, hasControlSequences, lineCount }
+      return {
+        byteLength,
+        exceededLimit: true,
+        hasControlSequences,
+        lineEndingByteLength,
+        lineCount
+      }
     }
     if (codePoint > 0xffff) {
       index += 1
     }
   }
 
-  return { byteLength, exceededLimit: false, hasControlSequences, lineCount }
+  return { byteLength, exceededLimit: false, hasControlSequences, lineEndingByteLength, lineCount }
 }
 
 export async function measurePastePayloadMetadataWithYield(
@@ -72,6 +84,7 @@ export async function measurePastePayloadMetadataWithYield(
   let nextYieldAt = yieldAfterCodeUnits
   let byteLength = 0
   let hasControlSequences = false
+  let lineEndingByteLength = 0
   let lineCount = 1
   let previousWasCarriageReturn = false
 
@@ -81,15 +94,25 @@ export async function measurePastePayloadMetadataWithYield(
     hasControlSequences ||= isPasteControlSequenceCodePoint(codePoint)
     if (codePoint === 0x0d) {
       lineCount += 1
+      lineEndingByteLength += 1
       previousWasCarriageReturn = true
     } else {
-      if (codePoint === 0x0a && !previousWasCarriageReturn) {
-        lineCount += 1
+      if (codePoint === 0x0a) {
+        lineEndingByteLength += 1
+        if (!previousWasCarriageReturn) {
+          lineCount += 1
+        }
       }
       previousWasCarriageReturn = false
     }
     if (Number.isFinite(stopAfterBytes) && byteLength > (stopAfterBytes ?? 0)) {
-      return { byteLength, exceededLimit: true, hasControlSequences, lineCount }
+      return {
+        byteLength,
+        exceededLimit: true,
+        hasControlSequences,
+        lineEndingByteLength,
+        lineCount
+      }
     }
     if (codePoint > 0xffff) {
       index += 1
@@ -100,7 +123,7 @@ export async function measurePastePayloadMetadataWithYield(
     }
   }
 
-  return { byteLength, exceededLimit: false, hasControlSequences, lineCount }
+  return { byteLength, exceededLimit: false, hasControlSequences, lineEndingByteLength, lineCount }
 }
 
 export function getPastePayloadUtf8ByteLength(text: string): number {
@@ -129,6 +152,7 @@ function createEmptyPastePayloadMetadata(): PastePayloadMetadata {
     byteLength: 0,
     exceededLimit: false,
     hasControlSequences: false,
+    lineEndingByteLength: 0,
     lineCount: 0
   }
 }

--- a/src/shared/dashboard-snapshot.ts
+++ b/src/shared/dashboard-snapshot.ts
@@ -158,6 +158,10 @@ export type DashboardCardTerminalInput = {
   osRelease?: string
   /** Shift+Enter encoding resolved from this pane's agent evidence. */
   windowsShiftEnterEncoding: 'alt-enter' | 'csi-u'
+  /** Force protected multiline paste when the live agent requires paste frames. */
+  forceBracketedMultilineTextPaste?: true
+  /** Newline encoding for Windows TUIs that consume console input records. */
+  windowsInputRecordPasteNewline?: 'alt-enter' | 'csi-u'
   /** Trusted query-only consumer accepts Ctrl+Enter CSI-u without active flags. */
   ctrlEnterCsiU: boolean
   /** False withholds the kitty (CSI-u) advertisement, as ConPTY panes do. */

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -42,6 +42,8 @@ export type TuiAgentConfig = {
   draftPasteReadySignal?: DraftPasteReadySignal
   /** Windows Shift+Enter encoding override; omitted agents keep the legacy Esc+CR path. */
   windowsShiftEnterEncoding?: 'csi-u'
+  /** Paste newlines for TUIs that read Windows console input records instead of VT paste frames. */
+  windowsInputRecordPasteNewline?: 'alt-enter' | 'csi-u'
   /** Ctrl+Enter encoding for agents that consume CSI-u without active kitty flags. */
   ctrlEnterEncoding?: 'csi-u'
 }
@@ -83,6 +85,7 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
     launchCmd: 'codex',
     expectedProcess: 'codex',
     promptInjectionMode: 'argv',
+    windowsInputRecordPasteNewline: 'alt-enter',
     preflightTrust: 'codex',
     draftPasteReadySignal: 'codex-composer-prompt'
   },


### PR DESCRIPTION
## ELI5

Pasting text is not the same as pressing Enter. But if you had a half-written message sitting in an agent's input box and pasted something that started with a newline, that newline was delivered as an Enter keypress — so your unfinished message got sent. This makes pastes into agent panes always safe.

## What Changed

A paste of ≤64 KB is handed to xterm's `term.paste()`, which rewrites `\r?\n` to `\r` and wraps the payload in `ESC[200~`/`ESC[201~` **only if** its parser has observed DECSET 2004. Unwrapped, a pasted newline arrives at the agent as a bare CR — Enter.

Orca already had a force-bracket guard for this, but it keyed on the wrong machine:

```
src/renderer/src/components/terminal-pane/TerminalPane.tsx:718-720
// Why: Windows ConPTY doesn't forward DECSET 2004 from TUIs, ...
const forceBracketedMultilineTextPaste = isWindowsUserAgent()
```

`isWindowsUserAgent()` reads `navigator.userAgent` — the **client's** platform. The ConPTY is on the **host**. So the guard was off in exactly the configuration that needs it (macOS/Linux client → Windows host) and on unnecessarily for a Windows client → Linux host.

This PR gates the force-bracket on **what is running in the pane** instead, via a new pure module `terminal-agent-paste-bracketing.ts`. Wired into all four paste entry points, which all shared the defect:

| entry point | file |
|---|---|
| Cmd+V / Ctrl+V + native paste event | `TerminalPane.tsx` |
| Edit ▸ Paste menu | `TerminalPane.tsx` |
| right-click / context menu | `use-terminal-pane-context-menu.ts` |
| middle-click primary selection | `TerminalPane.tsx` — had **no** force flag at all |

Evidence order: a process-confirmed agent wins; otherwise the pane's agent row, minus rows rehydrated from disk across a restart.

## Why

Bracketing must key off what the pane is running, not what laptop the user is sitting at. A TUI agent composer is the one context where a pasted newline is unambiguously content rather than submit.

The second commit exists because live testing falsified the first. The initial gate also vetoed on `shellForeground`, which looked like sound process-grade evidence. It isn't: that flag is republished only at OSC 133 boundaries, so a shell without 133 integration leaves it latched `true` while an agent owns the foreground. With that veto in place the bug still reproduced — the parked draft was sent. It is now dropped, with a test pinning the behavior.

Deliberately **not** used as gates: the 30-minute freshness TTL, and `state !== 'done'`. An idle-but-live agent sits at `done` with an old `updatedAt`; both would strip bracketing from exactly the pane that needs it most.

Note the fix only *adds* behavior when the mode bit is false — when a program has genuinely enabled DECSET 2004, xterm brackets anyway and this gate is inert, so it cannot override an agent that turned the mode off.

## Design rationale (measured, not assumed)

The obvious alternative is to key this on the mode bit itself — a tri-state of observed-on / observed-off / **never-observed**, bracketing only when nothing was ever announced. I built the case for it and then measured it in real ptys before writing any code. **It does not work.**

| shell | `?2004h` / `?2004l` |
|---|---|
| zsh 5.9, fish 4.8.1, bash >= 5.1 | 2 / 2 — `l` emitted ~1ms before exec |
| **macOS `/bin/bash` 3.2, `/bin/sh`, bash 4.4** | **0 / 0 — never emits anything** |
| bash 5.2 with `enable-bracketed-paste off` | **0 / 0** |
| zsh with `unset zle_bracketed_paste` | **0 / 0** |
| bare `cat` as the pty command | **0 / 0** |

The last three are byte-identical in 2004 terms: a deliberate opt-out is indistinguishable from a program with no opinion. And macOS's *default* `/bin/bash` and `/bin/sh` are in the silent bucket, so the heuristic would misfire on the system shells.

Bracketing on silence is also worse than useless. Feeding `\e[200~foo\rbar\e[201~` to a bare `cat` in a pty, capturing what the program actually received:

```
received: \e[200~foo\nbar\e[201~\n
```

The markers arrive as literal payload bytes (rendered `^[[200~foo`), **and** ICRNL still turned the CR into a newline, so `foo` submitted anyway — 12 bytes of corruption, zero protection.

That is why this keys on the pane's agent. Agent identity disambiguates silence in the one direction that matters: a TUI agent always enables bracketed paste, so on an agent pane silence can only mean the announcement was lost in transit (ConPTY, replay) — never an opt-out. On any other pane silence stays ambiguous and nothing is forced.

Residual risk, stated precisely: a stale agent row on a pane that has dropped to one of the *silent* shells (macOS `/bin/bash`, `/bin/sh`) would force brackets and emit `^[[200~` garbage. On zsh/fish/bash 5.2 the shell announces `h`, the mode bit is true, xterm brackets natively, and this gate is inert — no garbage possible.

## Is this the standard remediation?

Checked, because the obvious objection is "shouldn't the host fix this?" One reference notes *"Conpty v1.22+ uses passthrough"*, which would mean modern ConPTY forwards child escape sequences and none of this is needed.

It doesn't, and the proof is in this repo: **Orca already ships `conpty.dll 1.23.251008001` — the passthrough generation — on every local Windows spawn** (`pty-subprocess.ts:570`, `local-pty-utils.ts:206`, `windows-conpty-warmup.ts:28`), and the pre-existing local Windows force-bracketing is still there and still needed. If passthrough forwarded DECSET 2004, that code would already be dead.

Supporting: `PSEUDOCONSOLE_PASSTHROUGH_MODE (8u)` is declared in node-pty but never passed and unreachable from JS; no reference project sets any ConPTY flag beyond `INHERIT_CURSOR`; no codebase examined states that child-emitted DEC private modes survive ConPTY. Passthrough is documented as affecting reprint frequency, DA1 queries, and image protocols — never mode announcements.

Client-side compensation is therefore the standard fix. The closest peer does the same with a blunter rule (`platform.isMacintosh || isMultilineCommand(command)`).

**Unrelated finding, not fixed here:** the relay spawns a remote Windows PTY without `useConptyDll: true` (`src/relay/pty-handler.ts:1564`, `:2111`), diverging from all three local spawn sites. That affects DA1 blocking, wrap markers, and reflow — not this bug. Worth its own ticket.

## Readiness review

Reviewed against the 7-dimension release checklist. **Verdict: ship — no P0, no P1.**

The highest-risk item flagged for independent review was `makePaneKey` throwing on a paste path. It is **not reachable**: `pane.leafId` is a branded UUID that the pane identity registry re-mints rather than accept invalid, and the same `(tabId, pane.leafId)` pair is already called unguarded from a hotter pre-existing site. Guarded anyway in the last commit, because the failure *mode* was bad — the throw escapes before the paste helper's `.catch` is attached, so a paste would be a silent no-op with no toast.

Other verified-clean findings worth surfacing:
- **No double-bracketing.** The forced path uses `terminal.input()` with pre-framed bytes, bypassing xterm's own `paste()`, so a local agent pane that *did* see DECSET 2004 gets one frame, not two.
- **Security is net-positive.** The forced path runs the payload through `sanitizeBracketedPasteText`, replacing embedded `ESC` with U+241B — so a pasted `ESC[201~` from scrollback cannot close the frame early. The `direct` path it replaces had no such sanitization.
- **No backward-compat surface.** No persisted state, schema, settings key, IPC payload, or wire contract touched.
- **Tests are not vacuous** — mutation-checked: killing any single branch fails a specific test.

Three P2 follow-ups were raised; all three are addressed in the final commit (pane-key guard + test, the remote-pane note below, and the sibling-divergence rationale).

Documented in code from the review: the process-confirmed-agent branch is **dead for remote-runtime and SSH panes**, because foreground tracking is disabled for them — so a remote pane's agent status row is its only evidence. That is precisely the configuration this bug was reported in.

## Linked Issue

https://linear.app/stably/issue/STA-4294/paste-into-an-agent-pane-submits-the-parked-draft-when-bracketed-paste

## Visual Proof

Real Orca window, real PTY, real system clipboard, real ⌘V. A TUI with a visible composer runs inside a pty wrapper that strips `ESC[?2004h` from its output — byte-for-byte what Windows ConPTY does to a TUI, so the client never observes bracketed-paste mode. In both runs the draft `hello` is typed, then a clipboard payload whose **first character is a newline** is pasted.

**BEFORE — the draft is submitted.** `sent: 1`, `>>> SENT: hello`, and only `def ok` is left in the composer. This is the reported bug.

![orca-proof-BEFORE.png](https://github.com/user-attachments/assets/b7fae650-048c-4d59-be5c-125ef9394ef8)

**AFTER — the draft survives.** `sent: 0`, and the composer holds `hello⏎def ok` with the newline kept literally.

![orca-proof-AFTER-v2.png](https://github.com/user-attachments/assets/9d34183b-4448-4f14-8be6-e6c278fc0fa0)

Re-verified at final HEAD as a clean A/B: same TUI, same bytes, same paste, with the agent row as the only variable — row present gives `sent: 0` and a preserved draft; row removed gives `sent: 1` and `>>> SENT: hello`. That confirms the gate is narrow rather than a blanket force.

Disclosure: the pane's agent identity was injected into the store for the capture, because the stand-in TUI is not a real agent binary. The paste path, the mode state, and the bytes are all genuine. A remote Windows host was not available; the ConPTY condition was reproduced at its only observable point — the missing DECSET.

## Testing

11 unit tests in `terminal-agent-paste-bracketing.test.ts`: the reported payload flipping from `direct`/unbracketed to `bracketed-terminal`/bracketed; plain shell pane unaffected; per-leaf gating; Windows-client behavior preserved; non-TUI `agentType` ignored; process-confirmed agent with no row; restart-rehydrated veto; long-idle agent at `done`; latched `shellForeground` not suppressing an agent pane; single-line paste staying on `direct`.

Live: the before/after above, captured through the real UI.

Full local gates:

- `vitest run src/renderer/src/components/terminal-pane/` — **265 files / 3385 tests pass**
- `tsc --noEmit -p config/tsconfig.tc.web.json` — clean
- `oxlint`, react-doctor lint, `oxfmt` — clean via pre-commit. The one react-doctor warning in `TerminalPane.tsx` is pre-existing; verified it sits at the same site on `main`.

Platforms actually tested: **macOS**, against a local pty with the ConPTY condition emulated. Not exercised on Linux, a Windows client, or a real remote Windows host.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

- **Security** — no new IPC, no new input surface; strictly narrows when raw bytes reach a PTY.
- **Cross-platform** — the Windows-client branch is preserved unchanged and short-circuits first. Non-Windows clients gain bracketing only for agent panes.
- **Remote SSH** — no wire change. A **separate, unfixed** defect found while investigating: on SSH relay panes the mode bit can be lost outright, since relay reattach replays a 100 KiB rolling raw tail with no server-side emulator or persisted modes, and that truncation then seeds main's headless model. `POST_REPLAY_MODE_RESET` also ends in `ESC[?2004l`. Affects remote hosts of any OS; needs the proven `bracketedPaste` bit carried on the attach wire. Tracked separately, deliberately out of scope.
- **Mobile** — untouched; mobile has its own send path.
- **Backwards compatibility** — no persisted-state or protocol change.
- **Performance** — two record lookups per paste.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @BrennanKB5


