### PR TITLE
fix(runtime): drop a repo's scan generation when its last row is removed

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -18525,9 +18525,10 @@ export class OrcaRuntimeService {
     } catch (err) {
       if (repoWasCreated) {
         // Why: a failed link must not leave a new repo registration or stale host caches behind.
+        // `repoWasCreated` means this id was unknown until now, so removing it retires it entirely.
         this.store?.removeProject?.(initialRepo.id)
         this.invalidateResolvedWorktreeCache()
-        this.invalidateWorktreeScanCacheForRepo(initialRepo.id)
+        this.forgetWorktreeScanStateForRepo(initialRepo.id)
         invalidateAuthorizedRootsCache()
         this.notifyReposChanged()
       }
@@ -19461,7 +19462,11 @@ export class OrcaRuntimeService {
     }
     this.terminalTopologyRevisionByRepoId.delete(repo.id)
     this.invalidateResolvedWorktreeCache()
-    this.invalidateWorktreeScanCacheForRepo(repo.id)
+    if (idExistsOnOtherHost) {
+      this.invalidateWorktreeScanCacheForRepo(repo.id)
+    } else {
+      this.forgetWorktreeScanStateForRepo(repo.id)
+    }
     invalidateAuthorizedRootsCache()
     this.notifyReposChanged()
     return { removed: true }
@@ -29756,6 +29761,24 @@ export class OrcaRuntimeService {
 
   private invalidateWorktreeScanCacheForRepo(repoId: string): void {
     this.worktreeScanGenerations.set(repoId, (this.worktreeScanGenerations.get(repoId) ?? 0) + 1)
+    this.worktreeScanCache.delete(repoId)
+    this.worktreeScanInFlight.delete(repoId)
+  }
+
+  /**
+   * Drop every scan record a repo id leaves behind once its last registration is gone.
+   *
+   * Why not just `invalidateWorktreeScanCacheForRepo`: that one *bumps* the generation rather than
+   * dropping it, because a live repo's next scan still has to out-rank the one it interrupted. A
+   * removed id has no next scan, so the counter guards nothing and would keep one entry per removed
+   * repo for the life of the process. Dropping it is safe because the write-back additionally
+   * requires in-flight promise identity, which this clears in the same breath.
+   *
+   * Only for the last row of an id: sibling execution hosts share these maps by repo id, so a
+   * per-host removal must fall back to plain invalidation.
+   */
+  private forgetWorktreeScanStateForRepo(repoId: string): void {
+    this.worktreeScanGenerations.delete(repoId)
     this.worktreeScanCache.delete(repoId)
     this.worktreeScanInFlight.delete(repoId)
   }

--- a/src/main/runtime/runtime-remove-project-host-scope.test.ts
+++ b/src/main/runtime/runtime-remove-project-host-scope.test.ts
@@ -63,6 +63,12 @@ function createRuntime() {
   return { runtime, repos, removeProject, removeProjectForHost }
 }
 
+/** The scan bookkeeping is private, and its whole point is that nothing observable survives it. */
+function scanGenerations(runtime: OrcaRuntimeService): Map<string, number> {
+  return (runtime as unknown as { worktreeScanGenerations: Map<string, number> })
+    .worktreeScanGenerations
+}
+
 describe('repo.rm with the same repo id on two execution hosts', () => {
   it('removes only the resolved row when a path selector picks the SSH host copy', async () => {
     const { runtime, repos } = createRuntime()
@@ -78,6 +84,27 @@ describe('repo.rm with the same repo id on two execution hosts', () => {
     await runtime.removeProject('name:Dup Local')
 
     expect(repos.map((repo) => repo.path)).toEqual(['/remote/dup'])
+  })
+
+  it('keeps the scan generation while the id still has a row on the sibling host', async () => {
+    const { runtime } = createRuntime()
+    scanGenerations(runtime).set('dup', 4)
+
+    await runtime.removeProject('path:/remote/dup')
+
+    // The surviving local row shares this map key, so its in-flight scan still needs out-ranking.
+    expect(scanGenerations(runtime).get('dup')).toBe(5)
+  })
+
+  it('drops the scan generation once the last row of an id is removed', async () => {
+    const { runtime } = createRuntime()
+    scanGenerations(runtime).set('dup', 4)
+
+    await runtime.removeProject('path:/remote/dup')
+    await runtime.removeProject('path:/laptop/dup')
+
+    // Bumping instead would strand one entry per removed repo for the life of the process.
+    expect(scanGenerations(runtime).has('dup')).toBe(false)
   })
 
   it('refuses a bare duplicated id rather than guessing a host', async () => {

--- a/src/main/runtime/worktree-scan-admin-fingerprint-gate.test.ts
+++ b/src/main/runtime/worktree-scan-admin-fingerprint-gate.test.ts
@@ -97,6 +97,13 @@ function makeStore(options: { connectionId?: string; repoCount?: number; repoPat
       return metaById[id]
     },
     removeWorktreeMeta: () => {},
+    removeProject: (id: string) => {
+      for (let index = repos.length - 1; index >= 0; index -= 1) {
+        if (repos[index].id === id) {
+          repos.splice(index, 1)
+        }
+      }
+    },
     getAllWorktreeLineage: () => ({}),
     getAllWorkspaceLineage: () => ({}),
     removeWorktreeLineage: vi.fn(),
@@ -540,6 +547,34 @@ describe('worktree scan admin-fingerprint gate', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('does not let a scan still in flight repopulate a removed repo', async () => {
+    let releaseScan: (rows: unknown[]) => void = () => {}
+    listWorktreesStrictMock.mockReturnValueOnce(
+      new Promise<unknown[]>((resolve) => {
+        releaseScan = resolve
+      })
+    )
+    const { runtime, list } = makeRuntime()
+    const first = list()
+    await drainMicrotasks()
+
+    await runtime.removeProject(REPO_ID)
+    // Dropping the generation is only safe because the write-back also demands in-flight promise
+    // identity; releasing the scan afterwards is what proves that second guard carries it alone.
+    releaseScan([
+      { path: REPO_PATH, head: 'abc', branch: 'main', isBare: false, isMainWorktree: true }
+    ])
+    await first
+    await drainMicrotasks()
+
+    const runtimeState = runtime as unknown as {
+      worktreeScanCache: Map<string, unknown>
+      worktreeScanGenerations: Map<string, number>
+    }
+    expect(runtimeState.worktreeScanCache.has(REPO_ID)).toBe(false)
+    expect(runtimeState.worktreeScanGenerations.has(REPO_ID)).toBe(false)
   })
 
   it('shares one probe and one scan across concurrent callers', async () => {


### PR DESCRIPTION
## ELI5

When you remove a project from Orca, the runtime forgets its cached worktree rows — but it kept one small counter, forever.

That counter is a "which scan is newest" tag. While a repo is alive the tag has a job: if a scan is already running when something invalidates it, the next scan needs to out-rank the stale one. So invalidation *bumps* the number rather than deleting it.

Repo removal reused that same invalidation helper. But a removed repo has no next scan, so the tag guards nothing — it just sits in a `Map` for as long as the app runs. Add and remove a hundred projects in one session and you keep a hundred dead entries.

Removal now deletes the entry instead of bumping it. Tiny leak, tiny fix.

## What Changed

- New `forgetWorktreeScanStateForRepo(repoId)` in `orca-runtime.ts`, which *deletes* `worktreeScanGenerations` alongside `worktreeScanCache` and `worktreeScanInFlight`, rather than incrementing the generation the way `invalidateWorktreeScanCacheForRepo` does.
- `removeProject` picks between the two based on `idExistsOnOtherHost`, which it already computes.
- `completeProjectHostSetup`'s rollback uses it too — that branch only runs when `repoWasCreated`, so the id was unknown until moments earlier and is fully retired by the rollback.
- Three tests.

## Why

Follow-up to the residual risk noted while reviewing #14454. `worktreeScanGenerations` (`orca-runtime.ts:2890`) is written at two sites and read at two, and never deleted anywhere. Both repo-removal paths routed through `invalidateWorktreeScanCacheForRepo`, which by design does `set(repoId, (get(repoId) ?? 0) + 1)` — so removal left the entry behind permanently.

Impact is small and honest to state: one `Map` entry (a string key and a number) per repo removed, per session. It is not a crash or a user-visible bug. It is on the checklist's "session-lifetime data structure with no eviction" list, and the secondary effect is that re-adding a previously-removed id starts from a stale non-zero counter instead of a clean slate.

**Why the host-scoped case must keep bumping.** These maps are keyed by `repo.id`, and the same id is legitimately registered on two execution hosts (that is what `removeProjectForHost` exists for, see `runtime-remove-project-host-scope.test.ts`). Removing one host's row leaves the sibling live and still sharing the key, so the counter still has a scan to out-rank there. Deleting unconditionally would reset a live repo's fence to zero.

**Why deleting the counter is safe at all.** The scan write-back at `orca-runtime.ts:29579` requires *both* a matching generation and `worktreeScanInFlight.get(repo.id)?.promise === promise`. `forgetWorktreeScanStateForRepo` clears the in-flight entry in the same call, so a scan that was already running when the repo went away fails the identity check no matter what the generation says — including if the id is re-added and a new scan starts first. The generation was belt-and-braces for this particular guard; the belt is still there.

## Linked Issue

No Linear ticket — this came out of the review of #14454 (STA-4275) rather than a filed report.

Fixes #

## Visual Proof

`N/A` — internal bookkeeping with no rendered surface.

## Testing

Three tests, and I checked that each one can actually fail:

- **`drops the scan generation once the last row of an id is removed`** — fails without the fix (`expected true to be false`).
- **`keeps the scan generation while the id still has a row on the sibling host`** — the over-deletion guard. Passes before and after by design; it exists to stop a future simplification from deleting unconditionally.
- **`does not let a scan still in flight repopulate a removed repo`** — the correctness crux. Holds a `git worktree list` open, removes the repo mid-scan, then releases it, and asserts nothing is written back. Verified it catches a weakened guard: dropping the `worktreeScanInFlight.delete` line from the new method makes it fail.

`src/main/runtime/` + `src/main/ipc/`: 6981 passed. The 3 failures in `quarter-circle-title-send-authorization.test.ts` and `pty.test.ts` are pre-existing on `main` — same 3 fail with this branch's `orca-runtime.ts` swapped for `origin/main`'s. `pnpm typecheck`, `oxlint`, `oxfmt --check` clean.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

- **Security** — no dependency, shell, or network surface; one source file plus two test files.
- **Cross-platform** — no path, shell, or process handling involved; pure in-memory `Map` bookkeeping.
- **Remote SSH** — directly relevant and handled: the duplicated-id-across-hosts case is exactly the SSH pairing, and it deliberately keeps the old bump-and-invalidate behavior.
- **Mobile / backwards compatibility** — no persisted state, schema, or wire contract. Nothing a client observes changes.
- **Performance** — one `Map.delete` on a path that already does two.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
