### PR TITLE
fix(terminal): deliver Ctrl+C when a non-Latin input source rewrites the key

### DIFF
--- a/src/renderer/src/components/terminal-pane/xterm-bypass-policy-interrupt.test.ts
+++ b/src/renderer/src/components/terminal-pane/xterm-bypass-policy-interrupt.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
+import { _setLayoutMapForTests } from '../../lib/keyboard-layout/layout-base-character'
 import {
   shouldHandleTerminalInterruptKeyboardEvent,
   shouldSuppressTerminalInterruptKeyup,
@@ -20,6 +21,9 @@ function event(overrides: Partial<XtermBypassEvent>): XtermBypassEvent {
     ...overrides
   }
 }
+
+// The layout map is module-level cache; leaving one set would leak into later cases.
+afterEach(() => _setLayoutMapForTests(null))
 
 describe('shouldHandleTerminalInterruptKeyboardEvent', () => {
   it('exports the ETX byte used for terminal interrupts', () => {
@@ -101,6 +105,90 @@ describe('shouldHandleTerminalInterruptKeyboardEvent', () => {
         hasSelection: false
       })
     ).toBe(false)
+  })
+
+  // #14460: with a non-Latin input source the OS reports the layout's own glyph for `key`
+  // (Hangul jamo on Korean 2-Set, Cyrillic es on Russian), while `code` stays KeyC. A
+  // non-Latin script cannot express a control chord in `key`, so `code` is the only signal
+  // that survives — and without this, Ctrl+C misses the ETX path and gets CSI-u encoded
+  // instead, leaving a TUI running.
+  it.each([
+    ['Korean 2-Set', 'ㅊ'],
+    ['Russian', 'с'],
+    ['Greek', 'ψ'],
+    ['Hangul syllable', '차']
+  ])('handles Ctrl+C when %s reports a non-Latin logical key', (_layout, key) => {
+    expect(
+      shouldHandleTerminalInterruptKeyboardEvent(event({ key, code: 'KeyC', ctrlKey: true }), {
+        isMac: true,
+        hasSelection: false
+      })
+    ).toBe(true)
+  })
+
+  it('suppresses the matching keyup for a non-Latin Ctrl+C', () => {
+    expect(
+      shouldSuppressTerminalInterruptKeyup(
+        event({ type: 'keyup', key: 'ㅊ', code: 'KeyC', ctrlKey: true })
+      )
+    ).toBe(true)
+  })
+
+  // The paired negative, and the reason this cannot simply prefer `code`: a Latin layout that
+  // moves letters around (Dvorak) reports a real ASCII letter, and that letter is authoritative.
+  it('still ignores a Latin layout that maps KeyC to a different ASCII letter', () => {
+    expect(
+      shouldHandleTerminalInterruptKeyboardEvent(event({ key: 'j', code: 'KeyC', ctrlKey: true }), {
+        isMac: true,
+        hasSelection: false
+      })
+    ).toBe(false)
+  })
+
+  // And a non-Latin key on some other physical key must not become an interrupt.
+  it('does not handle a non-Latin logical key on a physical key other than KeyC', () => {
+    expect(
+      shouldHandleTerminalInterruptKeyboardEvent(event({ key: 'ㅁ', code: 'KeyA', ctrlKey: true }), {
+        isMac: true,
+        hasSelection: false
+      })
+    ).toBe(false)
+  })
+
+  // An IME sits on top of a Latin layout, so the layout map still answers for the physical key.
+  // Consulting it is what keeps the non-Latin path precise rather than merely positional.
+  it('uses the layout map when an IME is layered over a Latin layout', () => {
+    _setLayoutMapForTests(new Map([['KeyC', 'c']]))
+    expect(
+      shouldHandleTerminalInterruptKeyboardEvent(event({ key: 'ㅊ', code: 'KeyC', ctrlKey: true }), {
+        isMac: true,
+        hasSelection: false
+      })
+    ).toBe(true)
+  })
+
+  // The case positional matching alone would get wrong: Korean layered over Dvorak, where the
+  // physical KeyC is not the user's C. The layout map says so, and the interrupt declines.
+  it('declines when the layout map shows the physical key is not C', () => {
+    _setLayoutMapForTests(new Map([['KeyC', 'j']]))
+    expect(
+      shouldHandleTerminalInterruptKeyboardEvent(event({ key: 'ㅊ', code: 'KeyC', ctrlKey: true }), {
+        isMac: true,
+        hasSelection: false
+      })
+    ).toBe(false)
+  })
+
+  // A true non-Latin *layout* (not an IME) has a non-Latin map too, so it cannot answer either.
+  // Fall back to physical position, which is how terminals resolve control chords.
+  it('falls back to the physical key when the layout map is itself non-Latin', () => {
+    _setLayoutMapForTests(new Map([['KeyC', 'с']]))
+    expect(
+      shouldHandleTerminalInterruptKeyboardEvent(event({ key: 'с', code: 'KeyC', ctrlKey: true }), {
+        isMac: true,
+        hasSelection: false
+      })
+    ).toBe(true)
   })
 
   it('does not handle modified Ctrl+C chords', () => {

--- a/src/renderer/src/components/terminal-pane/xterm-bypass-policy.ts
+++ b/src/renderer/src/components/terminal-pane/xterm-bypass-policy.ts
@@ -1,4 +1,5 @@
 import { keybindingMatchesInput } from '../../../../shared/keybindings'
+import { getLayoutBaseCharacterForCode } from '../../lib/keyboard-layout/layout-base-character'
 import {
   isTerminalImeCandidateDigitKeyEvent,
   isTerminalImeCandidateSelectionKeyEvent
@@ -151,10 +152,33 @@ export function shouldPreventDefaultTerminalImeCandidateKey(
   )
 }
 
+/**
+ * A logical key a Latin layout could have produced. Only then is `key` authoritative:
+ * Dvorak moving `c` elsewhere is a real remap and must be honoured.
+ */
+function isLatinLetterKey(normalizedKey: string): boolean {
+  return normalizedKey.length === 1 && normalizedKey >= 'a' && normalizedKey <= 'z'
+}
+
 function isTerminalInterruptCKey(event: XtermBypassEvent): boolean {
   const normalizedKey = event.key.toLowerCase()
-  const logicalKeyAvailable = normalizedKey !== '' && normalizedKey !== 'unidentified'
-  return logicalKeyAvailable ? normalizedKey === 'c' : event.code === 'KeyC' || event.keyCode === 67
+  if (isLatinLetterKey(normalizedKey)) {
+    return normalizedKey === 'c'
+  }
+  // A non-Latin input source reports its own glyph here — a Hangul jamo on Korean 2-Set,
+  // Cyrillic es on Russian — and cannot express a control chord in `key` at all. Ask the
+  // layout map what this physical key produces unmodified: for an IME layered over a Latin
+  // layout that answers `c`, and for a Dvorak base it answers `j`, which correctly declines.
+  const layoutBaseKey = event.code
+    ? getLayoutBaseCharacterForCode(event.code)?.toLowerCase()
+    : undefined
+  if (layoutBaseKey !== undefined && isLatinLetterKey(layoutBaseKey)) {
+    return layoutBaseKey === 'c'
+  }
+  // Why the physical fallback: on a true non-Latin *layout* the map is non-Latin too, so it
+  // cannot answer the question either. Terminals resolve control chords by physical position,
+  // so KeyC is the interrupt. Empty and Unidentified land here as they always did.
+  return event.code === 'KeyC' || event.keyCode === 67
 }
 
 function isPlainCtrlC(event: XtermBypassEvent): boolean {


### PR DESCRIPTION
Fixes #14460. Builds on @hgijeon's diagnosis and their patch in #14430 — same root cause, widened, with a hardware measurement that changes the conclusion.

## Where it came from

`isTerminalInterruptCKey` was introduced by **#3941** (`65cab0f5da1`, "fix terminal kitty recovery for codex"). That PR added the ETX bypass so Ctrl+C would stop being CSI-u encoded for Codex — a real fix — but matched the logical key against `c`, which only holds for Latin layouts.

The bypass exists because **#1247** (`eb92ba9448c`) advertises the kitty keyboard protocol. With kitty active and no bypass, Ctrl+C is CSI-u encoded and never becomes ETX. So a non-Latin input source has fallen through since #3941: the bypass that rescues Latin users does not recognise the key.

## Reproduced

Confirmed from the code path, not just the report:

```ts
const normalizedKey = event.key.toLowerCase()          // 'ㅊ' under Korean 2-Set
const logicalKeyAvailable = normalizedKey !== '' && normalizedKey !== 'unidentified'  // true
return logicalKeyAvailable ? normalizedKey === 'c' : event.code === 'KeyC' || ...     // false
```

The `code` fallback only ran when `key` was empty or `Unidentified`. A Hangul jamo is neither, so it short-circuited to `false` and the press missed the ETX path.

Four new cases fail on unmodified `main`. **Not Korean-only** — Russian and Greek fail identically.

## Measured on hardware

macOS, via `UCKeyTranslate` over each installed layout (virtual keycode 8 = physical C):

| layout | KeyC produces |
|---|---|
| `com.apple.keylayout.ABC` | `c` U+0063 |
| `com.apple.keylayout.2SetHangul` | **`ㅊ` U+314A** |
| `com.apple.keylayout.Russian` | `с` U+0441 |
| `com.apple.keylayout.ABC-AZERTY` / `-QWERTZ` | `c` U+0063 |

**Korean 2-Set is a keyboard layout, not an IME layered over QWERTY.** Its `KeyC` genuinely maps to `ㅊ` at the OS level. That is why `key` arrives as a jamo, and it means a fix that asks the layout for the base character gets `ㅊ` back, not `c`.

## The rule

1. `key` is a Latin letter → authoritative. A Dvorak remap of C keeps working (existing test pins `key: "j"` as not-an-interrupt).
2. Otherwise consult the layout map. An IME layered over a Latin layout answers `c`; over a Dvorak base it answers `j` and correctly declines.
3. The map is itself non-Latin, or unavailable → fall back to physical position, which is how terminals have always resolved control chords.

Given the measurement, **Korean 2-Set is resolved by tier 3, not tier 2.** Tier 2 is still worth keeping: it is what makes a genuine IME-over-Latin source precise rather than merely positional, and it is @hgijeon's idea from #14430.

The important property is that the fix does not depend on which tier fires — both return the same answer here.

## On #14430

Their patch resolves a non-ASCII `key` through the layout map and then still compares the result against `c`. Against the measured `2SetHangul` layout that comparison is `'ㅊ' === 'c'`, which is false, so the interrupt would still be swallowed. Their unit test passes because it stubs the map with `[['KeyC', 'c']]`.

Caveat on that claim: my measurement is of the OS layout via `UCKeyTranslate`. Our module reads Chromium's `navigator.keyboard.getLayoutMap()`, and I have not measured Chromium's answer under a live Korean input source — if Chromium substitutes an ASCII-capable layout there, #14430 would work and tier 2 would fire instead. Tier 3 makes that difference immaterial here.

## Tests

`xterm-bypass-policy-interrupt.test.ts`, +7 cases:

- Ctrl+C with a non-Latin `key` (Korean jamo, Cyrillic, Greek, Hangul syllable) → interrupt
- the matching keyup is suppressed, so no release leaks after the interrupt
- Dvorak `key: "j"` on `KeyC` → still not an interrupt
- non-Latin key on a physical key other than `KeyC` → not an interrupt
- layout map says `c` → interrupt; says `j` → declines; is itself non-Latin → positional fallback

Verified on real hosts at this exact commit, not just locally:

- **Windows** — 268 files / 3433 passed, 1 skipped
- **macOS** — 268 files / 3433 passed, 1 skipped

Typecheck clean.

## Not verified

No live end-to-end run with the Korean input source active driving a real TUI. The layout data above is measured; the browser-level event shape comes from @hgijeon's report and their before/after recordings in #14430.

## Credit

@hgijeon reported this with a correct root-cause diagnosis, the measured event shape, a working patch, and before/after recordings against the real Codex CLI.
