### PR TITLE
fix(terminal): keep split error when rejected cleanup throws

### DIFF
--- a/src/main/runtime/orca-runtime-terminal-split-authority.test.ts
+++ b/src/main/runtime/orca-runtime-terminal-split-authority.test.ts
@@ -376,4 +376,28 @@ describe('remote runtime terminal split authority', () => {
     expect(harness.kill).toHaveBeenCalledWith(SPLIT_PTY_ID)
     expect(harness.retireRejectedPty).toHaveBeenCalledWith(SPLIT_PTY_ID)
   })
+
+  it('preserves the split error when kill and retirement throw', async () => {
+    const harness = createHarness(false, {
+      deferReveal: true,
+      includePairedSnapshot: true,
+      sourceIncarnationId: 'projected-before',
+      stopAndWaitResult: false
+    })
+    harness.kill.mockImplementation(() => {
+      throw new Error('kill failed')
+    })
+    harness.retireRejectedPty.mockImplementation(() => {
+      throw new Error('retire failed')
+    })
+
+    const split = harness.runtime.splitTerminal(harness.handle, { direction: 'horizontal' })
+    await vi.waitFor(() => expect(harness.revealTerminalSession).toHaveBeenCalledOnce())
+    harness.replaceSourceIncarnation('projected-after')
+    harness.resolveReveal()
+
+    await expect(split).rejects.toThrow('terminal_split_source_not_found')
+    expect(harness.kill).toHaveBeenCalledWith(SPLIT_PTY_ID)
+    expect(harness.retireRejectedPty).toHaveBeenCalledWith(SPLIT_PTY_ID)
+  })
 })

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -27759,9 +27759,17 @@ export class OrcaRuntimeService {
         // Best-effort fallback below preserves the original split authority error.
       }
       if (!stopped) {
-        this.ptyController.kill(result.id)
+        try {
+          this.ptyController.kill(result.id)
+        } catch {
+          // Best-effort cleanup; retirement below still runs and the original error still throws.
+        }
       }
-      this.ptyController.retireRejectedPty?.(result.id)
+      try {
+        this.ptyController.retireRejectedPty?.(result.id)
+      } catch {
+        // Best-effort cleanup; preserve the original split authority error.
+      }
       throw error
     }
     const committedSourceAuthority = sourceAuthority.persisted


### PR DESCRIPTION
## ELI5

When a terminal split is rejected, Orca still tries to tear down the unused new pane. If that teardown itself throws, you used to lose the real "split failed" error — and skip the last cleanup step. Teardown errors are now ignored so the real split error still surfaces, and the remaining cleanup still runs.

## What Changed

On the rejected-split path, `kill` and `retireRejectedPty` are each wrapped in try/catch. That matches the existing `stopAndWait` best-effort pattern.

A regression test throws from both cleanup steps and still expects `terminal_split_source_not_found`, plus both cleanup calls.

## Why

#14238 already made `stopAndWait` best-effort so an unreachable host would not replace the split-authority error. `kill` and `retireRejectedPty` were still naked. A throw from `kill` skipped retirement (so an SSH pane could keep a late synthetic `-1` exit) and replaced `terminal_split_source_not_found` with the cleanup exception.

## Linked Issue

Related: #14238

## Visual Proof

N/A — no UI or interaction change. This is main-process rejected-split cleanup error handling.

## Testing

- [x] Automated tests added/updated
- [ ] I manually tested these changes locally

Focused unit run:

```bash
pnpm exec vitest run --config config/vitest.config.ts \
  src/main/runtime/orca-runtime-terminal-split-authority.test.ts
```

8 passed, including the new case where both `kill` and `retireRejectedPty` throw.

## AI Disclosure

Grok 4.6 applied the staged cleanup change onto current `main` (the original `fix-split-incarnation-p1` branch was already merged as #14238), added the regression test, and opened this PR.

## Review

- **Security:** no new trust boundary. Cleanup exceptions are swallowed only so the original split error can throw.
- **Cross-platform:** main-process only. No OS-specific paths, shortcuts, or native modules.
- **SSH / remote:** this path covers rejected splits including SSH panes. Retirement still runs after a failed kill so a late synthetic `-1` cannot re-preserve the pane.
- **Mobile:** no mobile-specific change.
- **Compatibility:** optional `retireRejectedPty?` is unchanged. No RPC, stream, or persistence-shape change.
- **Performance:** runs only on an already-failed split. No hot-path cost.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] Focused tests pass; `pnpm lint` / `pnpm typecheck` / `pnpm test` / `pnpm build` left to CI
