### PR TITLE
fix(sidebar): satisfy extracted hook quality gates

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-list/use-pending-sidebar-reveal.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/use-pending-sidebar-reveal.ts
@@ -136,8 +136,6 @@ export function usePendingSidebarReveal(args: PendingSidebarRevealArgs): void {
       cancelled = true
       cancelPendingRevealFrames()
     }
-    // Why: the effect re-reads live inputs through argsRef; only reveal-relevant identities should retrigger it.
-    // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [
     pendingRevealWorktree,
     args.agentSendTargetWorktreeId,
@@ -265,8 +263,6 @@ export function usePendingSidebarReveal(args: PendingSidebarRevealArgs): void {
       cancelled = true
       cancelPendingRevealFrames()
     }
-    // Why: the effect re-reads live inputs through argsRef; only reveal-relevant identities should retrigger it.
-    // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [
     pendingRevealSidebarRow,
     args.repoMap,

--- a/src/renderer/src/components/sidebar/worktree-list/use-primary-active-worktree-row.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/use-primary-active-worktree-row.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useLayoutEffect, useState } from 'react'
 import type { ActiveSurfaceVariant } from '../WorktreeCard'
 import type { HostSectionRow } from '../host-section-rows'
 import type { PinnedWorktreeDisplayPolicy } from '../worktree-list-groups'
@@ -18,7 +18,7 @@ export function usePrimaryActiveWorktreeRow(args: {
     rowKey: string
   } | null>(null)
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (activeWorktreeId === null) {
       setPrimaryActiveWorktreeRow(null)
       return


### PR DESCRIPTION
Follow-up to #14465. Removes two suppressions that became unused after the WorktreeList extraction and uses a layout effect for clicked-row invalidation so stale active-row state cannot paint for one frame.\n\nVerified:\n- pnpm run check:code-quality:changed -- 08027d0d237608acccce793ed460fe97e94c6202\n- pnpm run typecheck\n- sidebar suite: 233 files / 2,146 tests passed