### PR TITLE
fix(renderer): stop git history hover from showing two tooltips

### DIFF
--- a/src/renderer/src/components/right-sidebar/GitHistoryPanel.test.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHistoryPanel.test.tsx
@@ -76,4 +76,33 @@ describe('GitHistoryPanel', () => {
     expect(markup).toContain('Fix tab overflow')
     expect(markup).toContain('52ad492')
   })
+
+  it('does not add native title tooltips alongside managed history tooltips', () => {
+    const result = makeHistoryResult()
+    result.items[0].references = [
+      { id: 'refs/heads/main', name: 'main', category: 'branches' },
+      { id: 'refs/heads/feature', name: 'feature', category: 'branches' },
+      { id: 'refs/tags/v1.0.0', name: 'v1.0.0', category: 'tags' }
+    ]
+
+    const markup = renderToStaticMarkup(
+      <GitHistoryPanel
+        state={{ status: 'ready', result }}
+        collapsed={false}
+        onToggle={vi.fn()}
+        onRefresh={vi.fn()}
+        onOpenCommit={vi.fn()}
+      />
+    )
+
+    expect(markup).toContain('Fix tab overflow')
+    expect(markup).toContain('main')
+    expect(markup).toContain('feature')
+    expect(markup).toContain('+1')
+    expect(markup).not.toContain('title="Fix tab overflow"')
+    expect(markup).not.toContain('title="main"')
+    expect(markup).not.toContain('title="feature"')
+    expect(markup).not.toContain('title="v1.0.0"')
+    expect(markup).not.toMatch(/\stitle=/)
+  })
 })

--- a/src/renderer/src/components/right-sidebar/GitHistoryRow.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHistoryRow.tsx
@@ -20,7 +20,6 @@ function GitHistoryRefBadge({ itemRef }: { itemRef: GitHistoryItemRef }): React.
             borderColor: itemRef.color ? graphColor(itemRef.color) : 'var(--border)',
             color: itemRef.color ? graphColor(itemRef.color) : 'var(--muted-foreground)'
           }}
-          title={itemRef.name}
         >
           {itemRef.name}
         </span>
@@ -90,9 +89,7 @@ export const GitHistoryRow = React.forwardRef<HTMLElement, GitHistoryRowProps>(
           )}
           <Tooltip>
             <TooltipTrigger asChild>
-              <span className="block min-w-0 flex-1 truncate text-foreground" title={rowTooltip}>
-                {item.subject}
-              </span>
+              <span className="block min-w-0 flex-1 truncate text-foreground">{item.subject}</span>
             </TooltipTrigger>
             <TooltipContent
               side="bottom"
@@ -112,10 +109,7 @@ export const GitHistoryRow = React.forwardRef<HTMLElement, GitHistoryRowProps>(
             {hiddenRefs.length > 0 && (
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <span
-                    className="shrink-0 text-[10px] leading-none text-muted-foreground"
-                    title={hiddenRefs.map((ref) => ref.name).join(', ')}
-                  >
+                  <span className="shrink-0 text-[10px] leading-none text-muted-foreground">
                     +{hiddenRefs.length}
                   </span>
                 </TooltipTrigger>
@@ -135,7 +129,6 @@ export const GitHistoryRow = React.forwardRef<HTMLElement, GitHistoryRowProps>(
           {...rootProps}
           ref={ref as React.Ref<HTMLDivElement>}
           className={rowClassName}
-          title={rowTooltip}
           data-testid="git-history-row"
         >
           {rowContent}
@@ -157,7 +150,6 @@ export const GitHistoryRow = React.forwardRef<HTMLElement, GitHistoryRowProps>(
         ref={ref as React.Ref<HTMLButtonElement>}
         type="button"
         className={rowClassName}
-        title={rowTooltip}
         aria-expanded={canExpand ? expanded : undefined}
         aria-label={
           canExpand

--- a/tests/e2e/git-history-tooltip-wrap.spec.ts
+++ b/tests/e2e/git-history-tooltip-wrap.spec.ts
@@ -73,7 +73,9 @@ test('keeps conventional commit-message lines intact in the history tooltip', as
 
   const row = orcaPage.getByTestId('git-history-row').filter({ hasText: subject })
   await expect(row).toBeVisible({ timeout: 10_000 })
+  await expect(row).not.toHaveAttribute('title')
   const trigger = row.locator('[data-slot="tooltip-trigger"]').filter({ hasText: subject })
+  await expect(trigger).not.toHaveAttribute('title')
   await trigger.hover({ position: { x: 20, y: 10 } })
   await trigger.hover({ position: { x: 40, y: 10 } })
 


### PR DESCRIPTION
## ELI5

Hovering a commit in Git history showed the same message twice. This keeps Orca's tooltip and turns off the browser's extra tooltip.

## What Changed

Git history rows, commit subjects, ref badges, and the hidden-ref count no longer set a native HTML `title`. The existing managed tooltip and row `aria-label` stay as they are.

## Why

A native `title` and the Radix tooltip both fired on hover. On Windows that produced two overlapping copies of the same commit message. One tooltip source is enough.

## Linked Issue

Fixes #14432

## Visual Proof

Before (from the issue):

![Duplicate native and managed tooltips](https://github.com/user-attachments/assets/eecb1c08-8589-4c52-800e-bf98894a6d1b)

After: Electron e2e hovered the same commit row. One managed tooltip appeared, and the row/trigger had no `title` attribute. A live after screenshot was not captured from this headless run.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Passed on macOS:

- `oxlint` / `oxfmt` via the pre-commit hook
- `vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/GitHistoryPanel.test.tsx` (4 tests)
- Electron Playwright: `tests/e2e/git-history-tooltip-wrap.spec.ts` (1 test)

The unit test first failed on the native `title` attributes, then passed after they were removed. The e2e still asserts the managed tooltip wraps the commit body, and now also asserts the row and subject trigger have no `title`.

File-path `title`s on expanded commit file rows are unchanged. Those rows have no managed tooltip.

## Review

- Security: no new inputs, privileges, or data flows.
- Cross-platform: removes platform-native tooltip overlap. The report is from Windows; verification ran on macOS.
- SSH/remote/mobile: renderer-only presentation change. No wire or host behavior change. Mobile git history does not use these `title`s.
- Backwards compatibility and performance: no protocol/state changes. Fewer browser tooltip handlers.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: N/A

Related: #14453
