### PR TITLE
fix(terminal): resolve Ctrl chords positionally on a non-Latin layout

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-non-latin-control-chord.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-non-latin-control-chord.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isNonLatinControlChordKeyup,
+  resolveNonLatinControlChordInput,
+  type NonLatinControlChordEvent
+} from './terminal-non-latin-control-chord'
+
+function event(overrides: Partial<NonLatinControlChordEvent>): NonLatinControlChordEvent {
+  return {
+    type: 'keydown',
+    key: 'ㅁ',
+    code: 'KeyA',
+    ctrlKey: true,
+    altKey: false,
+    metaKey: false,
+    shiftKey: false,
+    ...overrides
+  }
+}
+
+describe('resolveNonLatinControlChordInput', () => {
+  // Measured on macOS with UCKeyTranslate: physical A/U/C under Control produce
+  // U+0001/U+0015/U+0003 on 2SetHangul, Russian and Greek alike, matching ABC.
+  it.each([
+    ['Korean 2-Set', 'ㅁ', 'KeyA', '\x01'],
+    ['Korean 2-Set', 'ㅕ', 'KeyU', '\x15'],
+    ['Russian', 'ф', 'KeyA', '\x01'],
+    ['Russian', 'г', 'KeyU', '\x15'],
+    ['Greek', 'α', 'KeyA', '\x01'],
+    ['Greek', 'θ', 'KeyU', '\x15'],
+    ['Hangul syllable', '가', 'KeyD', '\x04']
+  ])('%s: Ctrl+%s on %s sends %j', (_layout, key, code, expected) => {
+    expect(resolveNonLatinControlChordInput(event({ key, code }))).toBe(expected)
+  })
+
+  it('covers the whole letter range, not just the reported keys', () => {
+    for (let index = 0; index < 26; index++) {
+      const letter = String.fromCharCode(0x41 + index)
+      if (letter === 'C') {
+        continue
+      }
+      expect(resolveNonLatinControlChordInput(event({ code: `Key${letter}` }))).toBe(
+        String.fromCharCode(index + 1)
+      )
+    }
+  })
+
+  // Ctrl+C is the interrupt policy's, and that policy declines off macOS when there is a
+  // selection so the copy binding wins. Claiming C here would send ETX in exactly that case.
+  it('leaves Ctrl+C to the interrupt policy', () => {
+    expect(resolveNonLatinControlChordInput(event({ key: 'ㅊ', code: 'KeyC' }))).toBeNull()
+  })
+
+  // An ASCII logical key is authoritative: a Dvorak remap really did move the letter.
+  it('leaves an ASCII logical key to xterm', () => {
+    expect(resolveNonLatinControlChordInput(event({ key: 'a', code: 'KeyA' }))).toBeNull()
+    expect(resolveNonLatinControlChordInput(event({ key: 'j', code: 'KeyC' }))).toBeNull()
+  })
+
+  it('ignores chords that are not a plain Ctrl press', () => {
+    expect(resolveNonLatinControlChordInput(event({ ctrlKey: false }))).toBeNull()
+    expect(resolveNonLatinControlChordInput(event({ altKey: true }))).toBeNull()
+    expect(resolveNonLatinControlChordInput(event({ metaKey: true }))).toBeNull()
+    // Ctrl+Shift has its own encoding; rewriting it would change a correct kitty report.
+    expect(resolveNonLatinControlChordInput(event({ shiftKey: true }))).toBeNull()
+    expect(resolveNonLatinControlChordInput(event({ type: 'keyup' }))).toBeNull()
+  })
+
+  it('ignores physical keys that are not letters', () => {
+    // Digits and punctuation stay ASCII in `key` on these layouts, so xterm still sees them.
+    expect(resolveNonLatinControlChordInput(event({ key: '2', code: 'Digit2' }))).toBeNull()
+    expect(resolveNonLatinControlChordInput(event({ code: 'BracketLeft' }))).toBeNull()
+    expect(resolveNonLatinControlChordInput(event({ code: undefined }))).toBeNull()
+  })
+
+  it('ignores named and empty keys', () => {
+    expect(resolveNonLatinControlChordInput(event({ key: 'Enter' }))).toBeNull()
+    // 'Process' is what some input sources report while an IME owns the key.
+    expect(resolveNonLatinControlChordInput(event({ key: 'Process' }))).toBeNull()
+    expect(resolveNonLatinControlChordInput(event({ key: '' }))).toBeNull()
+  })
+
+  // Any single non-ASCII codepoint on a letter key resolves positionally, astral included.
+  // No layout puts an emoji on KeyA, so this is unreachable in practice — it is pinned to
+  // record that the rule is "not ASCII" rather than a script allowlist that would need
+  // extending for every new writing system.
+  it('treats any single non-ASCII codepoint uniformly', () => {
+    expect(resolveNonLatinControlChordInput(event({ key: '😀' }))).toBe('\x01')
+    expect(resolveNonLatinControlChordInput(event({ key: 'ア' }))).toBe('\x01')
+    expect(resolveNonLatinControlChordInput(event({ key: 'א' }))).toBe('\x01')
+  })
+})
+
+describe('isNonLatinControlChordKeyup', () => {
+  it('matches the claimed press by physical key', () => {
+    expect(isNonLatinControlChordKeyup(event({ type: 'keyup' }), 'KeyA')).toBe(true)
+    // Ctrl may already be up by the time the letter is released.
+    expect(isNonLatinControlChordKeyup(event({ type: 'keyup', ctrlKey: false }), 'KeyA')).toBe(true)
+  })
+
+  it('does not match a different key or an unclaimed press', () => {
+    expect(isNonLatinControlChordKeyup(event({ type: 'keyup', code: 'KeyB' }), 'KeyA')).toBe(false)
+    expect(isNonLatinControlChordKeyup(event({ type: 'keyup' }), null)).toBe(false)
+    expect(isNonLatinControlChordKeyup(event({ type: 'keydown' }), 'KeyA')).toBe(false)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-non-latin-control-chord.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-non-latin-control-chord.ts
@@ -1,0 +1,92 @@
+/**
+ * Control chords on a non-Latin keyboard layout.
+ *
+ * macOS resolves these positionally: measured with `UCKeyTranslate`, physical C/A/U under
+ * Control produce U+0003/U+0001/U+0015 on 2SetHangul, Russian and Greek exactly as they do
+ * on ABC, even though the same keys unmodified produce `ㅊ`/`с`/`ψ`. A native terminal gets
+ * this for free by passing the OS-provided characters through.
+ *
+ * The browser does not expose that translation. `KeyboardEvent.key` carries the layout's
+ * glyph, so anything matching on `key` sees `ㅁ` for Ctrl+A and cannot recognise the chord.
+ * xterm's legacy encoder sidesteps it by reading `keyCode` (65-90), which Chromium reports
+ * from the physical key — but its kitty encoder derives the key number from `key`, and only
+ * consults `code` when Shift or Option is held. Ctrl is not in that gate, so a pane with the
+ * kitty protocol negotiated reports CSI-u for U+3141 instead of `a` and the chord does
+ * nothing (#13331). Ctrl+C escaped this only because it has a hand-written ETX bypass.
+ *
+ * Recovering the byte from `code` reproduces what the OS itself would have produced.
+ */
+
+/** Only a non-ASCII `key` is ambiguous. A Latin layout that moves letters (Dvorak) reports a
+ *  real ASCII letter, and that letter is authoritative — never override it. */
+function hasNonAsciiLogicalKey(key: string): boolean {
+  if (Array.from(key).length !== 1) {
+    return false
+  }
+  return (key.codePointAt(0) ?? 0) > 0x7f
+}
+
+/**
+ * `KeyA`-`KeyZ` except `KeyC`. Digits and punctuation stay ASCII in `key` on these layouts,
+ * so they reach xterm intact and are not this module's to touch.
+ *
+ * `KeyC` is excluded because Ctrl+C is not a plain control chord: off macOS it must yield to
+ * a selection so the copy binding wins, and it resets the pane's kitty flags because a CLI
+ * can die on SIGINT before restoring them. The interrupt policy owns all of that and runs
+ * first; claiming C here would send ETX in the one case that policy deliberately declines.
+ */
+function physicalLetterFromCode(code: string | undefined): string | null {
+  if (!code || code.length !== 4 || !code.startsWith('Key')) {
+    return null
+  }
+  const letter = code.charAt(3)
+  if (letter === 'C') {
+    return null
+  }
+  return letter >= 'A' && letter <= 'Z' ? letter : null
+}
+
+export type NonLatinControlChordEvent = {
+  type: string
+  key: string
+  code?: string
+  ctrlKey: boolean
+  altKey: boolean
+  metaKey: boolean
+  shiftKey: boolean
+}
+
+/**
+ * The C0 byte a plain Ctrl chord should send, or null when this event is not one.
+ *
+ * Shift is excluded deliberately: Ctrl+Shift chords have their own encoding, and rewriting
+ * them here would change what a kitty pane reports for a key it already handles correctly.
+ */
+export function resolveNonLatinControlChordInput(event: NonLatinControlChordEvent): string | null {
+  if (event.type !== 'keydown') {
+    return null
+  }
+  if (!event.ctrlKey || event.altKey || event.metaKey || event.shiftKey) {
+    return null
+  }
+  if (!hasNonAsciiLogicalKey(event.key)) {
+    return null
+  }
+  const letter = physicalLetterFromCode(event.code)
+  if (!letter) {
+    return null
+  }
+  // 'A' -> 0x01 ... 'Z' -> 0x1a, the same arithmetic the OS control table applies.
+  return String.fromCharCode(letter.charCodeAt(0) - 0x40)
+}
+
+/** The matching keyup, so a kitty release report for the swallowed press cannot leak. */
+export function isNonLatinControlChordKeyup(
+  event: NonLatinControlChordEvent,
+  claimedCode: string | null
+): boolean {
+  if (event.type !== 'keyup' || !claimedCode) {
+    return false
+  }
+  return event.code === claimedCode
+}

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -89,6 +89,10 @@ import { copyTerminalSelection } from './terminal-selection-copy'
 import { parseOsc7 } from './parse-osc7'
 import { guardParserHandler } from './terminal-parser-handler-guard'
 import { resolveTerminalJisYenInput } from './terminal-jis-yen-input'
+import {
+  isNonLatinControlChordKeyup,
+  resolveNonLatinControlChordInput
+} from './terminal-non-latin-control-chord'
 import { installTerminalImeCompositionTracker } from './terminal-ime-composition-tracker'
 import { installTerminalImeLinuxCandidateState } from './terminal-ime-linux-candidate-state'
 import {
@@ -982,6 +986,7 @@ export function useTerminalPaneLifecycle({
 
         // Why: let host-handled keys bypass xterm's kitty CSI-u encoder — with kittyKeyboard on it preventDefaults Cmd+C and blocks Chromium's native copy. See xterm-bypass-policy.ts.
         let pendingTerminalInterruptKeyup = false
+        let claimedNonLatinControlChordCode: string | null = null
         const pendingTerminalImeCandidateKeyReleases =
           createTerminalImePendingCandidateKeyReleases()
         const isMac = navigator.userAgent.includes('Mac')
@@ -1076,6 +1081,22 @@ export function useTerminalPaneLifecycle({
             } else {
               pendingTerminalInterruptKeyup = false
             }
+            observeLinuxCandidateEvent()
+            return false
+          }
+          // Why here: after the Ctrl+C interrupt arm, which owns its own ETX and kitty reset.
+          // This covers the other 25 letters, whose only failure is the kitty encoder reading
+          // the layout glyph out of `key`. Sending the C0 byte reproduces what the OS control
+          // table produces for that physical key on any layout.
+          if (isNonLatinControlChordKeyup(e, claimedNonLatinControlChordCode)) {
+            claimedNonLatinControlChordCode = null
+            observeLinuxCandidateEvent()
+            return false
+          }
+          const nonLatinControlChord = resolveNonLatinControlChordInput(e)
+          if (nonLatinControlChord) {
+            claimedNonLatinControlChordCode = e.code
+            pane.terminal.input(nonLatinControlChord)
             observeLinuxCandidateEvent()
             return false
           }


### PR DESCRIPTION
Fixes #13331. Generalises the Ctrl+C fix from #14462 to the rest of the control chords, and grounds it in a measurement of what macOS itself does.

## What the platform does

Measured on real hardware with `UCKeyTranslate`, per layout, at the physical A/U/C keys:

| layout | KeyA plain | **KeyA + Ctrl** | KeyU plain | **KeyU + Ctrl** |
|---|---|---|---|---|
| `keylayout.ABC` | `a` | **U+0001** | `u` | **U+0015** |
| `keylayout.2SetHangul` | `ㅁ` | **U+0001** | `ㅕ` | **U+0015** |
| `keylayout.Russian` | `ф` | **U+0001** | `г` | **U+0015** |
| `keylayout.Greek` | `α` | **U+0001** | `θ` | **U+0015** |

macOS resolves a control chord **by physical key, on every layout**. The `.keylayout` files carry an `anyControl` table that produces the C0 byte regardless of what the key types unmodified.

A native terminal inherits this for free — it reads the OS-provided characters and passes them through. I checked a reference implementation's source: it has no ASCII-capable-layout fallback and no virtual-keycode table anywhere. Its control-byte rule is `charactersIgnoringModifiers` in `'a'..'z'`, and when that misses — which is exactly the non-Latin case — it writes the OS's bytes verbatim. Ctrl+C works there on Russian because Apple's layout says U+0003, not because the terminal does anything layout-aware.

**So positional resolution is the platform-correct answer, and matching it is matching every native terminal.**

## Why we do not get it for free

The browser does not expose that translation. `KeyboardEvent.key` carries the layout glyph (`ㅁ`), and nothing surfaces the OS's control byte.

xterm's **legacy** encoder is fine — it reads `keyCode` (65–90), which Chromium reports from the physical key, so control chords already work when the kitty protocol is off.

xterm's **kitty** encoder is not. It derives the key number from `ev.key`, and only consults `ev.code` when Shift or Option is held:

```ts
if ((ev.shiftKey || (macOptionAsAlt && ev.altKey)) && ev.code) { ... }   // Ctrl is not in this gate
if (ev.key.length === 1) { return ev.key.codePointAt(0)! }               // 'ㅁ' -> U+3141
```

So a pane with kitty negotiated reports `CSI 12609;5u` instead of `CSI 97;5u`, and the chord does nothing. That is #13331, and it is why #3941 needed a hand-written ETX bypass for Ctrl+C in the first place — Ctrl+C was the one letter someone had already rescued.

## The rule

When Ctrl is held alone and `key` is a single **non-ASCII** codepoint, recover the letter from `code` and send the C0 byte — reproducing the OS control table.

- An **ASCII** `key` stays authoritative, so a Dvorak remap is honoured.
- **Shift is excluded.** Ctrl+Shift chords have their own encoding and are already correct under kitty; rewriting them would change a good report.
- **`KeyC` is excluded.** The interrupt policy owns it: off macOS it must yield to a selection so the copy binding wins, and it resets the pane's kitty flags because a CLI can die on SIGINT before restoring them. Claiming C here would have sent ETX in exactly the case that policy deliberately declines — a regression I caught while wiring this up, and the reason the exclusion is explicit rather than incidental.
- Digits and punctuation are untouched: they stay ASCII in `key` on these layouts, so xterm already sees them correctly.

## A note on kitty and the reference implementation

Under the kitty protocol that reference terminal reports the *layout* codepoint too — its modern mapper re-translates through the current layout, so Ctrl+C on Russian yields `CSI 1089;5u`. We deliberately do **not** match that: it is the broken behaviour this issue is about. We match its legacy path, which is the one that works, and which agrees with the OS.

## Tests

New `terminal-non-latin-control-chord.test.ts`, 16 cases, driven by the measured table above:

- Korean / Russian / Greek / Hangul-syllable chords → the C0 byte macOS produces
- the whole A–Z range, so this cannot be letter-by-letter incomplete again
- ASCII `key` (Dvorak `j` on `KeyC`) → untouched
- Ctrl+Shift, Alt, Meta, keyup → untouched
- `KeyC` → left to the interrupt policy
- digits, punctuation, named keys, `Process`, empty `key` → untouched
- the matching keyup is suppressed so a kitty release cannot leak

Verified at this exact commit:

- **macOS** — 265 files / 3400 tests passed, typecheck clean, oxlint + oxfmt clean
- **Windows** — real host via a paired runtime, targeted specs 37/37; full pane suite 264 files passed / 1 skipped, 3398 tests passed / 1 skipped, zero failures

## Not verified

No live end-to-end run with a Korean input source driving a TUI. The layout data is measured; the browser-level event shape comes from the #13331 and #14460 reports.
