### PR TITLE
feat(browser): route paired browser sockets through runtime

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -2581,26 +2581,35 @@
       "surfaces": [
         "client-hosted browser tunnel framing",
         "execution-host TCP credit flow",
-        "main-owned loopback SOCKS5 route"
+        "main-owned loopback SOCKS5 route",
+        "dedicated paired-runtime E2EE tunnel subscription"
       ],
       "platforms": ["macos", "linux", "windows"],
       "providers": ["local", "remote-runtime", "ssh", "wsl"],
       "coveredPlatforms": ["macos"],
-      "coveredProviders": [],
-      "coverageNotes": "Deterministic protocol, injected-socket, and loopback-listener tests cover strict framing, remote-DNS targets, exact write-settlement credit, bounded receive windows, stale generations, retired stream IDs, half-close ordering, SOCKS CONNECT, bind/close races, listener wildcard normalization, unsupported commands, and unavailable routes. No native, paired, SSH, or WSL destination provider is covered yet.",
+      "coveredProviders": ["remote-runtime"],
+      "coverageNotes": "Deterministic protocol, injected-socket, and loopback-listener tests cover strict framing, remote-DNS targets, exact destination-write and source-consumption credit, bounded receive bytes and chunks, stale generations, retired stream IDs, half-close and close ordering, SOCKS CONNECT, bind/close races, listener wildcard normalization, unsupported commands, unavailable routes, and raw/terminal binary-handler isolation. An explicitly injected paired-runtime E2EE method carries SOCKS and HTTP bytes over one dedicated capability- and paired-device-bound socket to a native execution-host destination, then proves route close destroys the destination socket. The production method remains unregistered until lease and route authorization exists. SSH and WSL providers remain uncovered.",
       "motivatingLinks": [
         "https://linear.app/stably/issue/STA-4150/refactor-remote-browser-to-client-hosted-electron-webviews"
       ],
       "invariant": "A client-hosted browser network route preserves destination names for execution-host DNS, admits only versioned bounded frames, replenishes credit only after destination writes settle, rejects stale or reused stream identities, and never falls back to desktop DNS or sockets when the selected route is unavailable. The local SOCKS endpoint accepts only loopback CONNECT and rejects unsupported commands.",
       "oracle": "Encode and decode each tunnel boundary with exact generation, stream, length, opcode, payload, and credit assertions. Drive one injected destination through open, data, write settlement, receive-window exhaustion, half-close, duplicate stream, stale generation, and teardown. Drive a real loopback SOCKS client through greeting and domain CONNECT, assert the final connector receives the unchanged hostname, echo bytes through the injected route, normalize only listener wildcards, reject BIND, and return failure without another connection when the route is offline.",
       "commands": [
-        "pnpm exec vitest run --config config/vitest.config.ts src/shared/browser-network-capabilities.test.ts src/shared/browser-network-tunnel-protocol.test.ts src/main/browser/browser-network-tunnel-session.test.ts src/main/browser/remote-browser-socks-server.test.ts"
+        "pnpm exec vitest run --config config/vitest.config.ts src/shared/browser-network-capabilities.test.ts src/shared/browser-network-tunnel-protocol.test.ts src/main/browser/browser-network-tunnel-session.test.ts src/main/browser/remote-browser-socks-server.test.ts",
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/browser/browser-network-tunnel-client.test.ts src/main/browser/paired-runtime-browser-network-route.test.ts src/main/runtime/runtime-binary-message-router.test.ts src/main/runtime/rpc/methods/browser-network-tunnel.test.ts src/main/runtime/browser-network-tunnel-paired-runtime.integration.test.ts",
+        "pnpm exec vitest run --config config/vitest.config.ts src/shared/remote-runtime-client.test.ts"
       ],
       "testFiles": [
         "src/shared/browser-network-capabilities.test.ts",
         "src/shared/browser-network-tunnel-protocol.test.ts",
         "src/main/browser/browser-network-tunnel-session.test.ts",
-        "src/main/browser/remote-browser-socks-server.test.ts"
+        "src/main/browser/browser-network-tunnel-client.test.ts",
+        "src/main/browser/paired-runtime-browser-network-route.test.ts",
+        "src/main/browser/remote-browser-socks-server.test.ts",
+        "src/main/runtime/runtime-binary-message-router.test.ts",
+        "src/main/runtime/rpc/methods/browser-network-tunnel.test.ts",
+        "src/main/runtime/browser-network-tunnel-paired-runtime.integration.test.ts",
+        "src/shared/remote-runtime-client.test.ts"
       ],
       "assertionRefs": [
         {
@@ -2618,10 +2627,57 @@
           ]
         },
         {
+          "file": "src/main/browser/browser-network-tunnel-client.test.ts",
+          "assertions": [
+            "source writes never exceed granted credit or the bounded data-frame size",
+            "destination credit tracks only browser-facing socket writes that settle after readable consumption",
+            "pending tiny frames stay chunk-bounded and data drains before remote close retirement",
+            "late local settlement after remote close sends no stale credit and leaves the tunnel usable",
+            "stale generations cannot open a stream and route close destroys every source"
+          ]
+        },
+        {
+          "file": "src/main/runtime/runtime-binary-message-router.test.ts",
+          "assertions": [
+            "dedicated raw tunnel traffic cannot replace or be decoded as terminal stream traffic on the same connection"
+          ]
+        },
+        {
           "file": "src/main/browser/remote-browser-socks-server.test.ts",
           "assertions": [
             "domain CONNECT preserves the final execution-host DNS target",
             "unsupported commands and unavailable routes open no fallback destination"
+          ]
+        },
+        {
+          "file": "src/main/runtime/rpc/methods/browser-network-tunnel.test.ts",
+          "assertions": [
+            "the production RPC registry excludes the tunnel until route authorization exists",
+            "unnegotiated and mismatched browser hosts register no binary handler",
+            "subscription cleanup removes the exact connection-owned raw handler"
+          ]
+        },
+        {
+          "file": "src/main/browser/paired-runtime-browser-network-route.test.ts",
+          "assertions": [
+            "route teardown closes a subscription that resolves after startup cancellation",
+            "close after subscription acquisition settles the pending readiness wait",
+            "post-auth readiness has a deadline and runtime close tears down the local route",
+            "listener teardown failures remain visible to the route owner"
+          ]
+        },
+        {
+          "file": "src/main/runtime/browser-network-tunnel-paired-runtime.integration.test.ts",
+          "assertions": [
+            "SOCKS HTTP bytes cross the dedicated authenticated E2EE subscription to runtime-native TCP",
+            "closing the route destroys the execution-host destination socket"
+          ]
+        },
+        {
+          "file": "src/shared/remote-runtime-client.test.ts",
+          "assertions": [
+            "the authenticated socket binds the optional tunnel capability",
+            "the dedicated outbound queue reports hard overflow instead of dropping a frame"
           ]
         }
       ],
@@ -2632,36 +2688,55 @@
           "platform": "macos",
           "command": "pnpm exec vitest run --config config/vitest.config.ts src/shared/browser-network-capabilities.test.ts src/shared/browser-network-tunnel-protocol.test.ts src/main/browser/browser-network-tunnel-session.test.ts src/main/browser/remote-browser-socks-server.test.ts",
           "result": "passed",
-          "durationSeconds": 0.2,
+          "durationSeconds": 0.4,
           "summary": "Four files passed 25 deterministic capability, codec, credit, generation, half-close, SOCKS routing, remote-DNS, and fail-closed tests."
+        },
+        {
+          "date": "2026-08-14",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/browser/browser-network-tunnel-client.test.ts src/main/browser/paired-runtime-browser-network-route.test.ts src/main/runtime/runtime-binary-message-router.test.ts src/main/runtime/rpc/methods/browser-network-tunnel.test.ts src/main/runtime/browser-network-tunnel-paired-runtime.integration.test.ts",
+          "result": "passed",
+          "durationSeconds": 4.7,
+          "summary": "Five files passed 19 source-flow, settled-consumption, chunk-bound, ordered-close, readiness-deadline, cleanup-failure, binary-routing, attach-authorization, and real paired-runtime E2EE SOCKS-to-HTTP tests."
+        },
+        {
+          "date": "2026-08-14",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/shared/remote-runtime-client.test.ts",
+          "result": "passed",
+          "durationSeconds": 3.0,
+          "summary": "Seventeen authenticated subscription tests passed, including tunnel capability binding and hard outbound-queue overflow rejection."
         }
       ],
       "runtimeBudget": {
-        "p95Seconds": 2,
-        "scope": "four deterministic protocol, injected-stream, and loopback-socket test files"
+        "p95Seconds": 5,
+        "scope": "ten deterministic protocol, flow-control, loopback, RPC, and paired-runtime test files"
       },
       "flakeHistory": {
         "status": "unknown",
-        "evidence": "The deterministic suite passed locally; CI and soak history have not started."
+        "evidence": "The deterministic and paired-runtime suites passed locally; CI and soak history have not started for the stacked route stage."
       },
       "redGreenEvidence": {
         "status": "partial",
-        "evidence": "The protocol and tunnel-session oracles fail on origin/main 3246b73add because the modules do not exist, then pass on the candidate. The same source checkout recorded the SOCKS oracle red before its route implementation and green after it. Mutation/revert evidence remains to be collected before promotion."
+        "evidence": "The protocol and tunnel-session oracles fail on origin/main 3246b73add because the modules do not exist, then pass on the candidate. The same source checkout recorded the SOCKS and source-multiplexer oracles red before their implementations and green afterward. The real paired journey failed at the missing network.browserTunnel method before explicit test injection, then passed unchanged while the production registry remained closed. Mutation/revert evidence remains to be collected before promotion."
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "Data frames, send credit, pending destination bytes and chunk counts, streams, SOCKS handshake and pipelined application bytes are bounded. Credit returns only from the destination write callback, and the injected transport must explicitly accept each frame. Aggregate route, browser-host, and process ledgers plus drain-aware fair scheduling remain required before live tunnel advertisement."
+        "evidence": "Data frames, send credit, pending bytes and chunk counts in both directions, streams, SOCKS handshake and pipelined application bytes are bounded. Credit returns only after the execution-host or browser-facing socket write settles, and the injected transport must explicitly accept each frame. Aggregate route, browser-host, and process ledgers plus drain-aware fair scheduling remain required before live tunnel advertisement."
       },
       "promotionCriteria": [
-        "Add aggregate route, browser-host, and process memory ledgers plus fair scheduling.",
+        "Bind the method to a live browser-host lease, authority epoch, exact execution-host revision, and server-owned monotonic route generation before production registration.",
+        "Add bounded pending-open admission and open-rate limits plus aggregate route, browser-host, and process memory ledgers with runtime-wide fair scheduling.",
         "Approve all same-host local processes and users as inside the desktop trust boundary or replace SOCKS no-auth with Chromium-compatible process isolation.",
-        "Run one dedicated paired-runtime binary tunnel journey with old/new peer coverage.",
+        "Add old/new peer coverage to the dedicated paired-runtime binary tunnel journey.",
         "Add SSH2, system SSH, WSL, Linux, and physical Windows evidence.",
         "Prove an Electron partition routes loopback, DNS, HTTP, HTTPS, WebSocket, workers, and speculative traffic without desktop fallback."
       ],
       "knownGaps": [
-        "No runtime capability is advertised and no live paired tunnel or webview uses these primitives yet.",
-        "Aggregate encrypted-WebSocket and destination-buffer accounting is not implemented.",
+        "No runtime capability is advertised, the paired tunnel method is not registered in production, and no Electron webview selects it yet.",
+        "Pending-open and open-rate admission plus aggregate encrypted-WebSocket and destination-buffer accounting are not implemented.",
         "The loopback SOCKS endpoint uses Chromium-compatible no-auth and is not safe to activate until its desktop trust boundary is approved or isolated.",
         "SSH, WSL, browserless serve, Electron proxy policy, UDP denial, and desktop DNS/socket capture are not exercised."
       ],

--- a/src/main/browser/browser-network-tunnel-client-frame-dispatch.ts
+++ b/src/main/browser/browser-network-tunnel-client-frame-dispatch.ts
@@ -1,0 +1,40 @@
+import {
+  BrowserNetworkTunnelOpcode,
+  type BrowserNetworkTunnelFrame
+} from '../../shared/browser-network-tunnel-protocol'
+
+type BrowserNetworkTunnelClientFrameActions = {
+  opened: () => void
+  grantCredit: () => void
+  deliverData: () => void
+  halfClose: () => void
+  close: () => void
+  remoteFailure: (error: Error) => void
+  invalid: () => void
+}
+
+export function dispatchBrowserNetworkTunnelClientFrame(
+  frame: BrowserNetworkTunnelFrame,
+  actions: BrowserNetworkTunnelClientFrameActions
+): void {
+  const action =
+    frame.opcode === BrowserNetworkTunnelOpcode.Opened
+      ? actions.opened
+      : frame.opcode === BrowserNetworkTunnelOpcode.WindowUpdate
+        ? actions.grantCredit
+        : frame.opcode === BrowserNetworkTunnelOpcode.Data
+          ? actions.deliverData
+          : frame.opcode === BrowserNetworkTunnelOpcode.HalfClose
+            ? actions.halfClose
+            : frame.opcode === BrowserNetworkTunnelOpcode.Close
+              ? actions.close
+              : frame.opcode === BrowserNetworkTunnelOpcode.Error
+                ? () =>
+                    actions.remoteFailure(
+                      new Error(
+                        `Browser tunnel destination failed: ${new TextDecoder().decode(frame.payload) || 'destination_error'}`
+                      )
+                    )
+                : actions.invalid
+  action()
+}

--- a/src/main/browser/browser-network-tunnel-client-retirement.ts
+++ b/src/main/browser/browser-network-tunnel-client-retirement.ts
@@ -1,0 +1,28 @@
+import type { BrowserNetworkTunnelClientStream } from './browser-network-tunnel-client-stream'
+
+export function retireBrowserNetworkTunnelClientStream(
+  stream: BrowserNetworkTunnelClientStream,
+  options: { error?: Error; destroySocket: boolean; remove: () => void }
+): void {
+  if (stream.closed) {
+    return
+  }
+  stream.closed = true
+  clearTimeout(stream.connectTimeout)
+  options.remove()
+  if (!stream.opened) {
+    stream.rejectOpen(
+      options.error ?? new Error('Browser tunnel destination closed before opening')
+    )
+  }
+  for (const pending of stream.pendingWrites) {
+    pending.callback(options.error ?? new Error('Browser tunnel stream closed'))
+  }
+  stream.pendingWrites = []
+  stream.pendingWriteBytes = 0
+  stream.pendingToSocket = []
+  stream.pendingToSocketBytes = 0
+  if (options.destroySocket && !stream.socket.destroyed) {
+    stream.socket.destroy(options.error)
+  }
+}

--- a/src/main/browser/browser-network-tunnel-client-stream-frames.ts
+++ b/src/main/browser/browser-network-tunnel-client-stream-frames.ts
@@ -1,0 +1,118 @@
+import {
+  BrowserNetworkTunnelOpcode,
+  decodeBrowserNetworkTunnelWindowUpdate,
+  encodeBrowserNetworkTunnelWindowUpdate,
+  type BrowserNetworkTunnelFrame
+} from '../../shared/browser-network-tunnel-protocol'
+import { dispatchBrowserNetworkTunnelClientFrame } from './browser-network-tunnel-client-frame-dispatch'
+import type { BrowserNetworkTunnelClientStream } from './browser-network-tunnel-client-stream'
+import {
+  finishBrowserNetworkSourceData,
+  queueBrowserNetworkSourceData
+} from './browser-network-tunnel-source-receive-flow'
+import { BROWSER_NETWORK_TUNNEL_INITIAL_WINDOW_BYTES } from './browser-network-tunnel-stream-state'
+
+type BrowserNetworkTunnelClientStreamFrameActions = {
+  send: (
+    opcode: BrowserNetworkTunnelOpcode,
+    streamId: number,
+    payload?: Uint8Array<ArrayBufferLike>
+  ) => boolean
+  closeTunnel: (error: Error) => void
+  flushWrites: (stream: BrowserNetworkTunnelClientStream) => void
+  retire: (stream: BrowserNetworkTunnelClientStream, error?: Error) => void
+}
+
+export function handleBrowserNetworkTunnelClientStreamFrame(
+  stream: BrowserNetworkTunnelClientStream,
+  frame: BrowserNetworkTunnelFrame,
+  actions: BrowserNetworkTunnelClientStreamFrameActions
+): void {
+  dispatchBrowserNetworkTunnelClientFrame(frame, {
+    opened: () => openedStream(stream, actions),
+    grantCredit: () => grantStreamCredit(stream, frame.payload, actions),
+    deliverData: () => deliverStreamData(stream, frame.payload, actions.closeTunnel),
+    halfClose: () => halfCloseStream(stream, actions.closeTunnel),
+    close: () => closeStream(stream, actions),
+    remoteFailure: (error) => actions.retire(stream, error),
+    invalid: () =>
+      actions.closeTunnel(new Error('Browser tunnel received an invalid stream transition'))
+  })
+}
+
+function openedStream(
+  stream: BrowserNetworkTunnelClientStream,
+  actions: BrowserNetworkTunnelClientStreamFrameActions
+): void {
+  if (stream.opened) {
+    actions.closeTunnel(new Error('Browser tunnel received a duplicate opened frame'))
+    return
+  }
+  stream.opened = true
+  clearTimeout(stream.connectTimeout)
+  if (
+    !actions.send(
+      BrowserNetworkTunnelOpcode.WindowUpdate,
+      stream.id,
+      encodeBrowserNetworkTunnelWindowUpdate(BROWSER_NETWORK_TUNNEL_INITIAL_WINDOW_BYTES)
+    )
+  ) {
+    actions.closeTunnel(new Error('Browser tunnel transport rejected initial credit'))
+    return
+  }
+  stream.resolveOpen(stream.socket)
+}
+
+function grantStreamCredit(
+  stream: BrowserNetworkTunnelClientStream,
+  payload: Uint8Array<ArrayBufferLike>,
+  actions: BrowserNetworkTunnelClientStreamFrameActions
+): void {
+  const credit = decodeBrowserNetworkTunnelWindowUpdate(payload)
+  if (
+    !stream.opened ||
+    !credit ||
+    stream.sendCredit + credit > BROWSER_NETWORK_TUNNEL_INITIAL_WINDOW_BYTES
+  ) {
+    actions.closeTunnel(new Error('Browser tunnel received invalid stream credit'))
+    return
+  }
+  stream.sendCredit += credit
+  actions.flushWrites(stream)
+}
+
+function deliverStreamData(
+  stream: BrowserNetworkTunnelClientStream,
+  payload: Uint8Array<ArrayBufferLike>,
+  closeTunnel: (error: Error) => void
+): void {
+  if (!queueBrowserNetworkSourceData(stream, payload)) {
+    closeTunnel(new Error('Browser tunnel received invalid destination data'))
+  }
+}
+
+function halfCloseStream(
+  stream: BrowserNetworkTunnelClientStream,
+  closeTunnel: (error: Error) => void
+): void {
+  if (!stream.opened || !finishBrowserNetworkSourceData(stream)) {
+    closeTunnel(new Error('Browser tunnel received an invalid destination half-close'))
+  }
+}
+
+function closeStream(
+  stream: BrowserNetworkTunnelClientStream,
+  actions: BrowserNetworkTunnelClientStreamFrameActions
+): void {
+  if (!stream.opened || stream.remoteClosed) {
+    actions.closeTunnel(new Error('Browser tunnel received an invalid destination close'))
+    return
+  }
+  stream.remoteClosed = true
+  stream.localEnded = true
+  stream.socket.once('end', () => actions.retire(stream))
+  if (!stream.remoteEnded) {
+    finishBrowserNetworkSourceData(stream)
+  }
+  stream.socket.end()
+}

--- a/src/main/browser/browser-network-tunnel-client-stream.ts
+++ b/src/main/browser/browser-network-tunnel-client-stream.ts
@@ -1,0 +1,72 @@
+import { BrowserNetworkTunnelDuplex } from './browser-network-tunnel-duplex'
+import type { BrowserNetworkTunnelSourceFlowStream } from './browser-network-tunnel-source-flow'
+import {
+  BROWSER_NETWORK_TUNNEL_CONNECT_TIMEOUT_MS,
+  BROWSER_NETWORK_TUNNEL_INITIAL_WINDOW_BYTES
+} from './browser-network-tunnel-stream-state'
+
+export type BrowserNetworkTunnelClientStream = BrowserNetworkTunnelSourceFlowStream & {
+  id: number
+  socket: BrowserNetworkTunnelDuplex
+  opened: boolean
+  closed: boolean
+  localEnded: boolean
+  localHalfCloseSent: boolean
+  remoteEnded: boolean
+  remoteClosed: boolean
+  readableEnded: boolean
+  receiveCredit: number
+  pendingToSocket: Uint8Array<ArrayBufferLike>[]
+  pendingToSocketBytes: number
+  readableDemand: boolean
+  connectTimeout: ReturnType<typeof setTimeout>
+  resolveOpen: (socket: BrowserNetworkTunnelDuplex) => void
+  rejectOpen: (error: Error) => void
+}
+
+type BrowserNetworkTunnelClientStreamCallbacks = {
+  writeBytes: (bytes: Uint8Array<ArrayBufferLike>, callback: (error?: Error | null) => void) => void
+  requestRead: () => void
+  consumeReadBytes: (bytes: number) => void
+  finishWrite: (callback: (error?: Error | null) => void) => void
+  destroyStream: (error: Error | null, callback: (error?: Error | null) => void) => void
+  onConnectTimeout: (stream: BrowserNetworkTunnelClientStream) => void
+}
+
+export function createBrowserNetworkTunnelClientStream(
+  id: number,
+  callbacks: BrowserNetworkTunnelClientStreamCallbacks
+): { stream: BrowserNetworkTunnelClientStream; opening: Promise<BrowserNetworkTunnelDuplex> } {
+  let resolveOpen = (_socket: BrowserNetworkTunnelDuplex): void => {}
+  let rejectOpen = (_error: Error): void => {}
+  const opening = new Promise<BrowserNetworkTunnelDuplex>((resolve, reject) => {
+    resolveOpen = resolve
+    rejectOpen = reject
+  })
+  const socket = new BrowserNetworkTunnelDuplex(callbacks)
+  const stream: BrowserNetworkTunnelClientStream = {
+    id,
+    socket,
+    opened: false,
+    closed: false,
+    localEnded: false,
+    localHalfCloseSent: false,
+    remoteEnded: false,
+    remoteClosed: false,
+    readableEnded: false,
+    sendCredit: 0,
+    receiveCredit: BROWSER_NETWORK_TUNNEL_INITIAL_WINDOW_BYTES,
+    pendingToSocket: [],
+    pendingToSocketBytes: 0,
+    readableDemand: false,
+    pendingWrites: [],
+    pendingWriteBytes: 0,
+    connectTimeout: setTimeout(
+      () => callbacks.onConnectTimeout(stream),
+      BROWSER_NETWORK_TUNNEL_CONNECT_TIMEOUT_MS
+    ),
+    resolveOpen,
+    rejectOpen
+  }
+  return { stream, opening }
+}

--- a/src/main/browser/browser-network-tunnel-client.test.ts
+++ b/src/main/browser/browser-network-tunnel-client.test.ts
@@ -1,0 +1,302 @@
+import { once } from 'node:events'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  BROWSER_NETWORK_TUNNEL_MAX_DATA_BYTES,
+  BrowserNetworkTunnelOpcode,
+  decodeBrowserNetworkTunnelFrame,
+  decodeBrowserNetworkTunnelOpen,
+  decodeBrowserNetworkTunnelWindowUpdate,
+  encodeBrowserNetworkTunnelFrame,
+  encodeBrowserNetworkTunnelWindowUpdate,
+  type BrowserNetworkTunnelFrame
+} from '../../shared/browser-network-tunnel-protocol'
+import { BROWSER_NETWORK_TUNNEL_INITIAL_WINDOW_BYTES } from './browser-network-tunnel-stream-state'
+import { BrowserNetworkTunnelClient } from './browser-network-tunnel-client'
+
+function frame(
+  opcode: BrowserNetworkTunnelOpcode,
+  payload: Uint8Array<ArrayBufferLike> = new Uint8Array(),
+  tunnelGeneration = 7,
+  streamId = 1
+): Uint8Array {
+  return encodeBrowserNetworkTunnelFrame({ opcode, tunnelGeneration, streamId, payload })
+}
+
+describe('BrowserNetworkTunnelClient', () => {
+  it('preserves remote DNS and waits for an opened acknowledgement', async () => {
+    const sent: Uint8Array<ArrayBufferLike>[] = []
+    const client = new BrowserNetworkTunnelClient({
+      tunnelGeneration: 7,
+      sendBinary: (bytes) => {
+        sent.push(bytes)
+        return true
+      }
+    })
+
+    let opened = false
+    const opening = client.open({ host: 'split-horizon.internal', port: 443 }).then((socket) => {
+      opened = true
+      return socket
+    })
+    await Promise.resolve()
+
+    const open = decodeBrowserNetworkTunnelFrame(sent[0]!)
+    expect(open?.opcode).toBe(BrowserNetworkTunnelOpcode.Open)
+    expect(open && decodeBrowserNetworkTunnelOpen(open.payload)).toEqual({
+      host: 'split-horizon.internal',
+      port: 443
+    })
+    expect(sent).toHaveLength(1)
+    expect(opened).toBe(false)
+
+    client.handleBinary(frame(BrowserNetworkTunnelOpcode.Opened, new Uint8Array(), 6))
+    await Promise.resolve()
+    expect(opened).toBe(false)
+
+    client.handleBinary(frame(BrowserNetworkTunnelOpcode.Opened))
+    const socket = await opening
+    socket.on('error', () => {})
+    const credit = decodeBrowserNetworkTunnelFrame(sent[1]!)
+    expect(credit && decodeBrowserNetworkTunnelWindowUpdate(credit.payload)).toBe(
+      BROWSER_NETWORK_TUNNEL_INITIAL_WINDOW_BYTES
+    )
+    client.close()
+  })
+
+  it('sends only credited bytes in bounded frames and replenishes consumed input', async () => {
+    const sent: Uint8Array<ArrayBufferLike>[] = []
+    const client = new BrowserNetworkTunnelClient({
+      tunnelGeneration: 7,
+      sendBinary: (bytes) => {
+        sent.push(bytes)
+        return true
+      }
+    })
+    const opening = client.open({ host: 'localhost', port: 8080 })
+    client.handleBinary(frame(BrowserNetworkTunnelOpcode.Opened))
+    const socket = await opening
+    socket.on('error', () => {})
+    sent.length = 0
+
+    const outbound = Buffer.alloc(BROWSER_NETWORK_TUNNEL_INITIAL_WINDOW_BYTES, 5)
+    const writeCallback = vi.fn()
+    socket.write(outbound, writeCallback)
+    expect(sent).toEqual([])
+
+    client.handleBinary(
+      frame(
+        BrowserNetworkTunnelOpcode.WindowUpdate,
+        encodeBrowserNetworkTunnelWindowUpdate(BROWSER_NETWORK_TUNNEL_INITIAL_WINDOW_BYTES)
+      )
+    )
+    const dataFrames = sent
+      .map(decodeBrowserNetworkTunnelFrame)
+      .filter((candidate): candidate is BrowserNetworkTunnelFrame => candidate !== null)
+    expect(
+      dataFrames.every((candidate) => candidate.opcode === BrowserNetworkTunnelOpcode.Data)
+    ).toBe(true)
+    expect(
+      dataFrames.every(
+        (candidate) => candidate.payload.byteLength <= BROWSER_NETWORK_TUNNEL_MAX_DATA_BYTES
+      )
+    ).toBe(true)
+    expect(dataFrames.reduce((total, candidate) => total + candidate.payload.byteLength, 0)).toBe(
+      BROWSER_NETWORK_TUNNEL_INITIAL_WINDOW_BYTES
+    )
+    await vi.waitFor(() => expect(writeCallback).toHaveBeenCalledOnce())
+
+    sent.length = 0
+    const tailCallback = vi.fn()
+    socket.write(Buffer.alloc(17, 6), tailCallback)
+    expect(tailCallback).not.toHaveBeenCalled()
+    client.handleBinary(
+      frame(BrowserNetworkTunnelOpcode.WindowUpdate, encodeBrowserNetworkTunnelWindowUpdate(17))
+    )
+    await vi.waitFor(() => expect(tailCallback).toHaveBeenCalledOnce())
+
+    sent.length = 0
+    const received = once(socket, 'data')
+    client.handleBinary(frame(BrowserNetworkTunnelOpcode.Data, new Uint8Array([1, 2, 3])))
+    await expect(received).resolves.toEqual([Buffer.from([1, 2, 3])])
+    expect(sent).toEqual([])
+    socket.settleRead(3)
+    await vi.waitFor(() => expect(sent).toHaveLength(1))
+    expect(decodeBrowserNetworkTunnelFrame(sent[0]!)?.opcode).toBe(
+      BrowserNetworkTunnelOpcode.WindowUpdate
+    )
+    client.close()
+  })
+
+  it('destroys every stream when the route closes or rejects a frame', async () => {
+    const client = new BrowserNetworkTunnelClient({
+      tunnelGeneration: 7,
+      sendBinary: () => true
+    })
+    const firstOpening = client.open({ host: 'one.internal', port: 80 })
+    client.handleBinary(frame(BrowserNetworkTunnelOpcode.Opened, new Uint8Array(), 7, 1))
+    const first = await firstOpening
+    first.on('error', () => {})
+    const secondOpening = client.open({ host: 'two.internal', port: 80 })
+    client.handleBinary(frame(BrowserNetworkTunnelOpcode.Opened, new Uint8Array(), 7, 2))
+    const second = await secondOpening
+    second.on('error', () => {})
+
+    client.handleBinary(new Uint8Array([1, 2, 3]))
+
+    expect(first.destroyed).toBe(true)
+    expect(second.destroyed).toBe(true)
+    await expect(client.open({ host: 'three.internal', port: 80 })).rejects.toThrow(
+      'Browser tunnel is closed'
+    )
+  })
+
+  it('retires a remotely failed stream without echoing an error or closing the route', async () => {
+    const sent: Uint8Array<ArrayBufferLike>[] = []
+    const client = new BrowserNetworkTunnelClient({
+      tunnelGeneration: 7,
+      sendBinary: (bytes) => {
+        sent.push(bytes)
+        return true
+      }
+    })
+    const opening = client.open({ host: 'refused.internal', port: 443 })
+    client.handleBinary(frame(BrowserNetworkTunnelOpcode.Opened))
+    const socket = await opening
+    const socketError = once(socket, 'error')
+    sent.length = 0
+
+    client.handleBinary(
+      frame(BrowserNetworkTunnelOpcode.Error, new TextEncoder().encode('destination_error'))
+    )
+
+    await expect(socketError).resolves.toEqual([
+      expect.objectContaining({ message: 'Browser tunnel destination failed: destination_error' })
+    ])
+    expect(sent).toEqual([])
+    const nextOpening = client.open({ host: 'healthy.internal', port: 443 })
+    expect(decodeBrowserNetworkTunnelFrame(sent[0]!)?.opcode).toBe(BrowserNetworkTunnelOpcode.Open)
+    client.handleBinary(frame(BrowserNetworkTunnelOpcode.Opened, new Uint8Array(), 7, 2))
+    const nextSocket = await nextOpening
+    nextSocket.on('error', () => {})
+    client.close()
+  })
+
+  it('withholds destination credit until a readable consumer asks for data', async () => {
+    const sent: Uint8Array<ArrayBufferLike>[] = []
+    const client = new BrowserNetworkTunnelClient({
+      tunnelGeneration: 7,
+      sendBinary: (bytes) => {
+        sent.push(bytes)
+        return true
+      }
+    })
+    const opening = client.open({ host: 'localhost', port: 8080 })
+    client.handleBinary(frame(BrowserNetworkTunnelOpcode.Opened))
+    const socket = await opening
+    socket.on('error', () => {})
+    sent.length = 0
+
+    client.handleBinary(frame(BrowserNetworkTunnelOpcode.Data, new Uint8Array([7, 8, 9])))
+    expect(sent).toEqual([])
+
+    const received = once(socket, 'data')
+    await expect(received).resolves.toEqual([Buffer.from([7, 8, 9])])
+    expect(sent).toEqual([])
+    socket.settleRead(3)
+    await vi.waitFor(() => expect(sent).toHaveLength(1))
+    expect(decodeBrowserNetworkTunnelFrame(sent[0]!)?.opcode).toBe(
+      BrowserNetworkTunnelOpcode.WindowUpdate
+    )
+    client.close()
+  })
+
+  it('replenishes only bytes settled after the readable consumer takes them', async () => {
+    const sent: Uint8Array<ArrayBufferLike>[] = []
+    const client = new BrowserNetworkTunnelClient({
+      tunnelGeneration: 7,
+      sendBinary: (bytes) => {
+        sent.push(bytes)
+        return true
+      }
+    })
+    const opening = client.open({ host: 'localhost', port: 8080 })
+    client.handleBinary(frame(BrowserNetworkTunnelOpcode.Opened))
+    const socket = await opening
+    socket.on('error', () => {})
+    sent.length = 0
+
+    const readable = once(socket, 'readable')
+    client.handleBinary(frame(BrowserNetworkTunnelOpcode.Data, new Uint8Array([1, 2, 3, 4])))
+    await readable
+    expect(socket.read(1)).toEqual(Buffer.from([1]))
+    expect(sent).toEqual([])
+    socket.settleRead(1)
+    expect(
+      decodeBrowserNetworkTunnelWindowUpdate(decodeBrowserNetworkTunnelFrame(sent[0]!)!.payload)
+    ).toBe(1)
+
+    expect(socket.read(3)).toEqual(Buffer.from([2, 3, 4]))
+    socket.settleRead(3)
+    expect(
+      decodeBrowserNetworkTunnelWindowUpdate(decodeBrowserNetworkTunnelFrame(sent[1]!)!.payload)
+    ).toBe(3)
+    client.close()
+  })
+
+  it('fails closed when pending tiny destination frames exceed the chunk cap', async () => {
+    const client = new BrowserNetworkTunnelClient({
+      tunnelGeneration: 7,
+      sendBinary: () => true
+    })
+    const opening = client.open({ host: 'localhost', port: 8080 })
+    client.handleBinary(frame(BrowserNetworkTunnelOpcode.Opened))
+    const socket = await opening
+    socket.on('error', () => {})
+
+    for (let index = 0; index < 257; index += 1) {
+      client.handleBinary(frame(BrowserNetworkTunnelOpcode.Data, new Uint8Array([index])))
+    }
+
+    expect(socket.destroyed).toBe(true)
+    await expect(client.open({ host: 'next.internal', port: 80 })).rejects.toThrow(
+      'Browser tunnel is closed'
+    )
+  })
+
+  it('drains data that precedes a remote close before retiring the socket', async () => {
+    const sent: Uint8Array<ArrayBufferLike>[] = []
+    const client = new BrowserNetworkTunnelClient({
+      tunnelGeneration: 7,
+      sendBinary: (bytes) => {
+        sent.push(bytes)
+        return true
+      }
+    })
+    const opening = client.open({ host: 'localhost', port: 8080 })
+    client.handleBinary(frame(BrowserNetworkTunnelOpcode.Opened))
+    const socket = await opening
+    socket.on('error', () => {})
+    sent.length = 0
+
+    client.handleBinary(frame(BrowserNetworkTunnelOpcode.Data, new Uint8Array([4, 5, 6])))
+    client.handleBinary(frame(BrowserNetworkTunnelOpcode.Close))
+    expect(socket.destroyed).toBe(false)
+
+    const received: Buffer[] = []
+    socket.on('data', (bytes: Buffer) => {
+      received.push(bytes)
+      socket.settleRead(bytes.byteLength)
+    })
+    await once(socket, 'end')
+    await vi.waitFor(() => expect(socket.destroyed).toBe(true))
+    expect(Buffer.concat(received)).toEqual(Buffer.from([4, 5, 6]))
+    expect(sent).toEqual([])
+
+    const nextOpening = client.open({ host: 'next.internal', port: 80 })
+    expect(decodeBrowserNetworkTunnelFrame(sent[0]!)?.opcode).toBe(BrowserNetworkTunnelOpcode.Open)
+    client.handleBinary(frame(BrowserNetworkTunnelOpcode.Opened, new Uint8Array(), 7, 2))
+    const nextSocket = await nextOpening
+    nextSocket.on('error', () => {})
+    client.close()
+  })
+})

--- a/src/main/browser/browser-network-tunnel-client.ts
+++ b/src/main/browser/browser-network-tunnel-client.ts
@@ -1,0 +1,267 @@
+import {
+  BrowserNetworkTunnelOpcode,
+  decodeBrowserNetworkTunnelFrame,
+  encodeBrowserNetworkTunnelOpen,
+  encodeBrowserNetworkTunnelWindowUpdate,
+  type BrowserNetworkTunnelFrame,
+  type BrowserNetworkTunnelOpen
+} from '../../shared/browser-network-tunnel-protocol'
+import { BrowserNetworkTunnelFrameSender } from './browser-network-tunnel-frame-sender'
+import {
+  BROWSER_NETWORK_TUNNEL_INITIAL_WINDOW_BYTES,
+  validateBrowserNetworkTunnelGeneration
+} from './browser-network-tunnel-stream-state'
+import {
+  flushBrowserNetworkSourceWrites,
+  queueBrowserNetworkSourceWrite
+} from './browser-network-tunnel-source-flow'
+import {
+  createBrowserNetworkTunnelClientStream,
+  type BrowserNetworkTunnelClientStream
+} from './browser-network-tunnel-client-stream'
+import type { BrowserNetworkTunnelDuplex } from './browser-network-tunnel-duplex'
+import {
+  beginBrowserNetworkSourceRead,
+  grantBrowserNetworkSourceReceiveCredit
+} from './browser-network-tunnel-source-receive-flow'
+import { retireBrowserNetworkTunnelClientStream } from './browser-network-tunnel-client-retirement'
+import { handleBrowserNetworkTunnelClientStreamFrame } from './browser-network-tunnel-client-stream-frames'
+
+type BrowserNetworkTunnelClientOptions = {
+  tunnelGeneration: number
+  sendBinary: (bytes: Uint8Array<ArrayBufferLike>) => boolean
+}
+
+export class BrowserNetworkTunnelClient {
+  private readonly tunnelGeneration: number
+  private readonly frameSender: BrowserNetworkTunnelFrameSender
+  private readonly streams = new Map<number, BrowserNetworkTunnelClientStream>()
+  private nextStreamId = 1
+  private closed = false
+
+  constructor(options: BrowserNetworkTunnelClientOptions) {
+    validateBrowserNetworkTunnelGeneration(options.tunnelGeneration)
+    this.tunnelGeneration = options.tunnelGeneration
+    this.frameSender = new BrowserNetworkTunnelFrameSender(
+      options.tunnelGeneration,
+      options.sendBinary,
+      () => this.close(new Error('Browser tunnel transport rejected a frame')),
+      () => !this.closed
+    )
+  }
+
+  open(target: BrowserNetworkTunnelOpen): Promise<BrowserNetworkTunnelDuplex> {
+    if (this.closed) {
+      return Promise.reject(new Error('Browser tunnel is closed'))
+    }
+    if (this.streams.size >= 32 || this.nextStreamId > 65_536) {
+      return Promise.reject(new Error('Browser tunnel stream limit exceeded'))
+    }
+    let openPayload: Uint8Array<ArrayBufferLike>
+    try {
+      openPayload = encodeBrowserNetworkTunnelOpen(target)
+    } catch (error) {
+      return Promise.reject(error)
+    }
+    const id = this.nextStreamId++
+    const { stream, opening } = createBrowserNetworkTunnelClientStream(id, {
+      writeBytes: (bytes, callback) => this.writeStream(id, bytes, callback),
+      requestRead: () => this.readStream(id),
+      consumeReadBytes: (bytes) => this.consumeStreamBytes(id, bytes),
+      finishWrite: (callback) => this.endStream(id, callback),
+      destroyStream: (error, callback) => this.destroyStream(id, error, callback),
+      onConnectTimeout: (timedOutStream) =>
+        this.failStream(timedOutStream, new Error('Browser tunnel destination connect timed out'))
+    })
+    this.streams.set(id, stream)
+    if (!this.frameSender.send(BrowserNetworkTunnelOpcode.Open, id, openPayload)) {
+      this.close(new Error('Browser tunnel transport rejected an open frame'))
+    }
+    return opening
+  }
+
+  handleBinary(bytes: Uint8Array<ArrayBufferLike>): void {
+    if (this.closed) {
+      return
+    }
+    const frame = decodeBrowserNetworkTunnelFrame(bytes)
+    if (!frame) {
+      this.close(new Error('Browser tunnel received an invalid frame'))
+      return
+    }
+    if (frame.tunnelGeneration !== this.tunnelGeneration) {
+      return
+    }
+    if (frame.opcode === BrowserNetworkTunnelOpcode.Ping) {
+      this.frameSender.send(BrowserNetworkTunnelOpcode.Pong, frame.streamId, frame.payload)
+      return
+    }
+    if (frame.opcode === BrowserNetworkTunnelOpcode.Pong) {
+      return
+    }
+    const stream = this.streams.get(frame.streamId)
+    if (!stream) {
+      this.close(new Error('Browser tunnel received a frame for an unknown stream'))
+      return
+    }
+    this.handleStreamFrame(stream, frame)
+  }
+
+  close(error = new Error('Browser tunnel is closed')): void {
+    if (this.closed) {
+      return
+    }
+    this.closed = true
+    for (const stream of Array.from(this.streams.values())) {
+      this.retireStream(stream, error)
+    }
+    this.streams.clear()
+  }
+
+  private handleStreamFrame(
+    stream: BrowserNetworkTunnelClientStream,
+    frame: BrowserNetworkTunnelFrame
+  ): void {
+    handleBrowserNetworkTunnelClientStreamFrame(stream, frame, {
+      send: (opcode, streamId, payload) => this.frameSender.send(opcode, streamId, payload),
+      closeTunnel: (error) => this.close(error),
+      flushWrites: (target) => this.flushStreamWrites(target),
+      retire: (target, error) => this.retireStream(target, error)
+    })
+  }
+
+  private writeStream(
+    streamId: number,
+    bytes: Uint8Array<ArrayBufferLike>,
+    callback: (error?: Error | null) => void
+  ): void {
+    const stream = this.streams.get(streamId)
+    if (!stream || !stream.opened || stream.localEnded) {
+      callback(new Error('Browser tunnel stream is not writable'))
+      return
+    }
+    if (!queueBrowserNetworkSourceWrite(stream, bytes, callback)) {
+      const error = new Error('Browser tunnel source buffer overflow')
+      callback(error)
+      this.failStream(stream, error)
+      return
+    }
+    this.flushStreamWrites(stream)
+  }
+
+  private flushStreamWrites(stream: BrowserNetworkTunnelClientStream): void {
+    const flushed = flushBrowserNetworkSourceWrites(
+      stream,
+      (payload) =>
+        this.isCurrent(stream) &&
+        this.frameSender.send(BrowserNetworkTunnelOpcode.Data, stream.id, payload)
+    )
+    if (!flushed) {
+      this.close(new Error('Browser tunnel transport rejected data'))
+      return
+    }
+    if (
+      this.isCurrent(stream) &&
+      stream.localEnded &&
+      !stream.localHalfCloseSent &&
+      stream.pendingWrites.length === 0
+    ) {
+      stream.localHalfCloseSent = true
+      if (!this.frameSender.send(BrowserNetworkTunnelOpcode.HalfClose, stream.id)) {
+        this.close(new Error('Browser tunnel transport rejected a half-close'))
+      }
+    }
+  }
+
+  private readStream(streamId: number): void {
+    const stream = this.streams.get(streamId)
+    if (!stream) {
+      return
+    }
+    beginBrowserNetworkSourceRead(stream)
+  }
+
+  private consumeStreamBytes(streamId: number, bytes: number): void {
+    const stream = this.streams.get(streamId)
+    if (stream) {
+      this.replenishStreamCredit(stream, bytes)
+    }
+  }
+
+  private replenishStreamCredit(stream: BrowserNetworkTunnelClientStream, bytes: number): void {
+    if (!this.isCurrent(stream) || stream.remoteClosed || bytes === 0) {
+      return
+    }
+    if (
+      !grantBrowserNetworkSourceReceiveCredit(
+        stream,
+        bytes,
+        BROWSER_NETWORK_TUNNEL_INITIAL_WINDOW_BYTES
+      )
+    ) {
+      this.close(new Error('Browser tunnel receive credit overflow'))
+      return
+    }
+    if (
+      !this.frameSender.send(
+        BrowserNetworkTunnelOpcode.WindowUpdate,
+        stream.id,
+        encodeBrowserNetworkTunnelWindowUpdate(bytes)
+      )
+    ) {
+      this.close(new Error('Browser tunnel transport rejected receive credit'))
+    }
+  }
+
+  private endStream(streamId: number, callback: (error?: Error | null) => void): void {
+    const stream = this.streams.get(streamId)
+    if (!stream || stream.localEnded) {
+      callback()
+      return
+    }
+    stream.localEnded = true
+    this.flushStreamWrites(stream)
+    callback()
+  }
+
+  private destroyStream(
+    streamId: number,
+    error: Error | null,
+    callback: (error?: Error | null) => void
+  ): void {
+    const stream = this.streams.get(streamId)
+    if (stream && this.isCurrent(stream)) {
+      this.frameSender.send(BrowserNetworkTunnelOpcode.Close, stream.id)
+      this.retireStream(stream, error ?? undefined, false)
+    }
+    callback(error)
+  }
+
+  private failStream(stream: BrowserNetworkTunnelClientStream, error: Error): void {
+    if (!this.isCurrent(stream)) {
+      return
+    }
+    this.frameSender.send(
+      BrowserNetworkTunnelOpcode.Error,
+      stream.id,
+      new TextEncoder().encode(error.message)
+    )
+    this.retireStream(stream, error)
+  }
+
+  private retireStream(
+    stream: BrowserNetworkTunnelClientStream,
+    error?: Error,
+    destroySocket = true
+  ): void {
+    retireBrowserNetworkTunnelClientStream(stream, {
+      error,
+      destroySocket,
+      remove: () => this.streams.delete(stream.id)
+    })
+  }
+
+  private isCurrent(stream: BrowserNetworkTunnelClientStream): boolean {
+    return !this.closed && !stream.closed && this.streams.get(stream.id) === stream
+  }
+}

--- a/src/main/browser/browser-network-tunnel-destination-flow.ts
+++ b/src/main/browser/browser-network-tunnel-destination-flow.ts
@@ -11,7 +11,7 @@ import {
 
 type BrowserNetworkTunnelDestinationFlowActions = {
   isCurrent: () => boolean
-  sendData: (bytes: Uint8Array<ArrayBufferLike>) => void
+  sendData: (bytes: Uint8Array<ArrayBufferLike>) => boolean
   sendHalfClose: () => void
   finalizeClose: () => void
 }
@@ -81,7 +81,9 @@ export function flushBrowserNetworkDestination(
       stream.sendCredit,
       BROWSER_NETWORK_TUNNEL_MAX_DATA_BYTES
     )
-    actions.sendData(next.subarray(0, length))
+    if (!actions.sendData(next.subarray(0, length))) {
+      return
+    }
     stream.sendCredit -= length
     stream.pendingToClientBytes -= length
     if (length === next.byteLength) {

--- a/src/main/browser/browser-network-tunnel-duplex.ts
+++ b/src/main/browser/browser-network-tunnel-duplex.ts
@@ -1,0 +1,46 @@
+import { Duplex } from 'node:stream'
+import { BROWSER_NETWORK_TUNNEL_INITIAL_WINDOW_BYTES } from './browser-network-tunnel-stream-state'
+
+type BrowserNetworkTunnelDuplexOptions = {
+  writeBytes: (bytes: Uint8Array<ArrayBufferLike>, callback: (error?: Error | null) => void) => void
+  requestRead: () => void
+  consumeReadBytes: (bytes: number) => void
+  finishWrite: (callback: (error?: Error | null) => void) => void
+  destroyStream: (error: Error | null, callback: (error?: Error | null) => void) => void
+}
+
+export class BrowserNetworkTunnelDuplex extends Duplex {
+  private readonly options: BrowserNetworkTunnelDuplexOptions
+
+  constructor(options: BrowserNetworkTunnelDuplexOptions) {
+    super({
+      allowHalfOpen: true,
+      readableHighWaterMark: BROWSER_NETWORK_TUNNEL_INITIAL_WINDOW_BYTES
+    })
+    this.options = options
+  }
+
+  override _read(): void {
+    this.options.requestRead()
+  }
+
+  settleRead(bytes: number): void {
+    this.options.consumeReadBytes(bytes)
+  }
+
+  override _write(
+    chunk: Buffer,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void
+  ): void {
+    this.options.writeBytes(chunk, callback)
+  }
+
+  override _final(callback: (error?: Error | null) => void): void {
+    this.options.finishWrite(callback)
+  }
+
+  override _destroy(error: Error | null, callback: (error?: Error | null) => void): void {
+    this.options.destroyStream(error, callback)
+  }
+}

--- a/src/main/browser/browser-network-tunnel-frame-sender.ts
+++ b/src/main/browser/browser-network-tunnel-frame-sender.ts
@@ -1,5 +1,6 @@
 import {
   encodeBrowserNetworkTunnelFrame,
+  type BrowserNetworkTunnelOpcode,
   type BrowserNetworkTunnelFrame
 } from '../../shared/browser-network-tunnel-protocol'
 import type { BrowserNetworkTunnelSessionOptions } from './browser-network-tunnel-stream-state'
@@ -12,5 +13,34 @@ export function sendBrowserNetworkTunnelFrame(
     return sendBinary(encodeBrowserNetworkTunnelFrame(frame))
   } catch {
     return false
+  }
+}
+
+export class BrowserNetworkTunnelFrameSender {
+  constructor(
+    private readonly tunnelGeneration: number,
+    private readonly sendBinary: BrowserNetworkTunnelSessionOptions['sendBinary'],
+    private readonly onRejected?: () => void,
+    private readonly canSend?: () => boolean
+  ) {}
+
+  send(
+    opcode: BrowserNetworkTunnelOpcode,
+    streamId: number,
+    payload: Uint8Array<ArrayBufferLike> = new Uint8Array()
+  ): boolean {
+    if (this.canSend && !this.canSend()) {
+      return false
+    }
+    const accepted = sendBrowserNetworkTunnelFrame(this.sendBinary, {
+      opcode,
+      tunnelGeneration: this.tunnelGeneration,
+      streamId,
+      payload
+    })
+    if (!accepted) {
+      this.onRejected?.()
+    }
+    return accepted
   }
 }

--- a/src/main/browser/browser-network-tunnel-session.ts
+++ b/src/main/browser/browser-network-tunnel-session.ts
@@ -11,7 +11,7 @@ import {
   queueBrowserNetworkDestinationData,
   writeBrowserNetworkDestination
 } from './browser-network-tunnel-destination-flow'
-import { sendBrowserNetworkTunnelFrame } from './browser-network-tunnel-frame-sender'
+import { BrowserNetworkTunnelFrameSender } from './browser-network-tunnel-frame-sender'
 import {
   BROWSER_NETWORK_TUNNEL_CONNECT_TIMEOUT_MS,
   BROWSER_NETWORK_TUNNEL_INITIAL_WINDOW_BYTES,
@@ -27,7 +27,8 @@ const BROWSER_NETWORK_TUNNEL_MAX_STREAMS = 128
 export class BrowserNetworkTunnelSession {
   private readonly tunnelGeneration: number
   private readonly connect: BrowserNetworkTunnelSessionOptions['connect']
-  private readonly sendBinary: BrowserNetworkTunnelSessionOptions['sendBinary']
+  private readonly frameSender: BrowserNetworkTunnelFrameSender
+  private readonly onClose: BrowserNetworkTunnelSessionOptions['onClose']
   private readonly streams = new Map<number, BrowserNetworkTunnelStream>()
   private readonly openedStreamIds = new Set<number>()
   private closed = false
@@ -36,7 +37,13 @@ export class BrowserNetworkTunnelSession {
     validateBrowserNetworkTunnelGeneration(options.tunnelGeneration)
     this.tunnelGeneration = options.tunnelGeneration
     this.connect = options.connect
-    this.sendBinary = options.sendBinary
+    this.frameSender = new BrowserNetworkTunnelFrameSender(
+      options.tunnelGeneration,
+      options.sendBinary,
+      () => this.close(),
+      () => !this.closed
+    )
+    this.onClose = options.onClose
   }
 
   handleBinary(bytes: Uint8Array<ArrayBufferLike>): void {
@@ -63,11 +70,12 @@ export class BrowserNetworkTunnelSession {
       this.retireStream(stream)
     }
     this.streams.clear()
+    this.onClose?.()
   }
 
   private handleFrame(frame: BrowserNetworkTunnelFrame): void {
     if (frame.opcode === BrowserNetworkTunnelOpcode.Ping) {
-      this.send(BrowserNetworkTunnelOpcode.Pong, frame.streamId, frame.payload)
+      this.frameSender.send(BrowserNetworkTunnelOpcode.Pong, frame.streamId, frame.payload)
       return
     }
     if (frame.opcode === BrowserNetworkTunnelOpcode.Pong) {
@@ -94,7 +102,7 @@ export class BrowserNetworkTunnelSession {
     ) {
       this.deleteStream(stream)
     } else {
-      this.failStream(stream, 'invalid_stream_transition')
+      this.failProtocolStream(stream, 'invalid_stream_transition')
     }
   }
 
@@ -155,8 +163,8 @@ export class BrowserNetworkTunnelSession {
     }
     stream.connected = true
     clearTimeout(stream.connectTimeout)
-    this.send(BrowserNetworkTunnelOpcode.Opened, stream.id)
-    this.send(
+    this.frameSender.send(BrowserNetworkTunnelOpcode.Opened, stream.id)
+    this.frameSender.send(
       BrowserNetworkTunnelOpcode.WindowUpdate,
       stream.id,
       encodeBrowserNetworkTunnelWindowUpdate(BROWSER_NETWORK_TUNNEL_INITIAL_WINDOW_BYTES)
@@ -172,14 +180,14 @@ export class BrowserNetworkTunnelSession {
         return
       }
       stream.receiveCredit += bytes
-      this.send(
+      this.frameSender.send(
         BrowserNetworkTunnelOpcode.WindowUpdate,
         stream.id,
         encodeBrowserNetworkTunnelWindowUpdate(bytes)
       )
     })
     if (error) {
-      this.failStream(stream, error)
+      this.failProtocolStream(stream, error)
     }
   }
 
@@ -189,7 +197,7 @@ export class BrowserNetworkTunnelSession {
   ): void {
     const error = grantBrowserNetworkDestinationCredit(stream, payload)
     if (error) {
-      this.failStream(stream, error)
+      this.failProtocolStream(stream, error)
       return
     }
     this.flushDestinationData(stream)
@@ -213,7 +221,7 @@ export class BrowserNetworkTunnelSession {
   private flushDestinationData(stream: BrowserNetworkTunnelStream): void {
     flushBrowserNetworkDestination(stream, {
       isCurrent: () => this.isCurrent(stream),
-      sendData: (bytes) => this.send(BrowserNetworkTunnelOpcode.Data, stream.id, bytes),
+      sendData: (bytes) => this.frameSender.send(BrowserNetworkTunnelOpcode.Data, stream.id, bytes),
       sendHalfClose: () => this.sendDestinationHalfClose(stream),
       finalizeClose: () => this.finalizeDestinationClose(stream)
     })
@@ -251,32 +259,25 @@ export class BrowserNetworkTunnelSession {
     this.deleteStream(stream)
   }
 
-  private sendError(streamId: number, code: string): void {
-    this.send(BrowserNetworkTunnelOpcode.Error, streamId, new TextEncoder().encode(code))
-  }
-
-  private send(
-    opcode: BrowserNetworkTunnelOpcode,
-    streamId: number,
-    payload: Uint8Array<ArrayBufferLike> = new Uint8Array()
-  ): void {
-    if (this.closed) {
+  private failProtocolStream(stream: BrowserNetworkTunnelStream, code: string): void {
+    if (!this.isCurrent(stream)) {
       return
     }
-    const accepted = sendBrowserNetworkTunnelFrame(this.sendBinary, {
-      opcode,
-      tunnelGeneration: this.tunnelGeneration,
+    this.sendError(stream.id, code)
+    this.close()
+  }
+
+  private sendError(streamId: number, code: string): void {
+    this.frameSender.send(
+      BrowserNetworkTunnelOpcode.Error,
       streamId,
-      payload
-    })
-    if (!accepted) {
-      this.close()
-    }
+      new TextEncoder().encode(code)
+    )
   }
 
   private halfCloseDestination(stream: BrowserNetworkTunnelStream): void {
     if (!stream.connected || stream.clientEnded) {
-      this.failStream(stream, 'invalid_client_half_close')
+      this.failProtocolStream(stream, 'invalid_client_half_close')
       return
     }
     stream.clientEnded = true
@@ -288,11 +289,11 @@ export class BrowserNetworkTunnelSession {
       return
     }
     stream.destinationHalfCloseSent = true
-    this.send(BrowserNetworkTunnelOpcode.HalfClose, stream.id)
+    this.frameSender.send(BrowserNetworkTunnelOpcode.HalfClose, stream.id)
   }
 
   private finalizeDestinationClose(stream: BrowserNetworkTunnelStream): void {
-    this.send(BrowserNetworkTunnelOpcode.Close, stream.id)
+    this.frameSender.send(BrowserNetworkTunnelOpcode.Close, stream.id)
     this.deleteStream(stream)
   }
 

--- a/src/main/browser/browser-network-tunnel-source-flow.ts
+++ b/src/main/browser/browser-network-tunnel-source-flow.ts
@@ -1,0 +1,59 @@
+import { BROWSER_NETWORK_TUNNEL_MAX_DATA_BYTES } from '../../shared/browser-network-tunnel-protocol'
+import {
+  BROWSER_NETWORK_TUNNEL_MAX_PENDING_SOCKET_BYTES,
+  BROWSER_NETWORK_TUNNEL_MAX_PENDING_SOCKET_CHUNKS
+} from './browser-network-tunnel-stream-state'
+
+type PendingWrite = {
+  bytes: Uint8Array<ArrayBufferLike>
+  offset: number
+  callback: (error?: Error | null) => void
+}
+
+export type BrowserNetworkTunnelSourceFlowStream = {
+  sendCredit: number
+  pendingWrites: PendingWrite[]
+  pendingWriteBytes: number
+}
+
+export function queueBrowserNetworkSourceWrite(
+  stream: BrowserNetworkTunnelSourceFlowStream,
+  bytes: Uint8Array<ArrayBufferLike>,
+  callback: PendingWrite['callback']
+): boolean {
+  if (
+    stream.pendingWriteBytes + bytes.byteLength > BROWSER_NETWORK_TUNNEL_MAX_PENDING_SOCKET_BYTES ||
+    stream.pendingWrites.length >= BROWSER_NETWORK_TUNNEL_MAX_PENDING_SOCKET_CHUNKS
+  ) {
+    return false
+  }
+  const copy = bytes.slice()
+  stream.pendingWrites.push({ bytes: copy, offset: 0, callback })
+  stream.pendingWriteBytes += copy.byteLength
+  return true
+}
+
+export function flushBrowserNetworkSourceWrites(
+  stream: BrowserNetworkTunnelSourceFlowStream,
+  sendData: (bytes: Uint8Array<ArrayBufferLike>) => boolean
+): boolean {
+  while (stream.sendCredit > 0 && stream.pendingWrites.length > 0) {
+    const pending = stream.pendingWrites[0]!
+    const length = Math.min(
+      pending.bytes.byteLength - pending.offset,
+      stream.sendCredit,
+      BROWSER_NETWORK_TUNNEL_MAX_DATA_BYTES
+    )
+    if (!sendData(pending.bytes.subarray(pending.offset, pending.offset + length))) {
+      return false
+    }
+    pending.offset += length
+    stream.sendCredit -= length
+    stream.pendingWriteBytes -= length
+    if (pending.offset === pending.bytes.byteLength) {
+      stream.pendingWrites.shift()
+      pending.callback()
+    }
+  }
+  return true
+}

--- a/src/main/browser/browser-network-tunnel-source-receive-flow.ts
+++ b/src/main/browser/browser-network-tunnel-source-receive-flow.ts
@@ -1,0 +1,81 @@
+import {
+  BROWSER_NETWORK_TUNNEL_MAX_PENDING_SOCKET_BYTES,
+  BROWSER_NETWORK_TUNNEL_MAX_PENDING_SOCKET_CHUNKS
+} from './browser-network-tunnel-stream-state'
+
+export type BrowserNetworkTunnelSourceReceiveStream = {
+  opened: boolean
+  remoteEnded: boolean
+  readableEnded: boolean
+  receiveCredit: number
+  pendingToSocket: Uint8Array<ArrayBufferLike>[]
+  pendingToSocketBytes: number
+  readableDemand: boolean
+  socket: { push: (bytes: Buffer | null) => boolean }
+}
+
+export function queueBrowserNetworkSourceData(
+  stream: BrowserNetworkTunnelSourceReceiveStream,
+  payload: Uint8Array<ArrayBufferLike>
+): boolean {
+  if (
+    !stream.opened ||
+    stream.remoteEnded ||
+    payload.byteLength === 0 ||
+    payload.byteLength > stream.receiveCredit ||
+    stream.pendingToSocketBytes + payload.byteLength >
+      BROWSER_NETWORK_TUNNEL_MAX_PENDING_SOCKET_BYTES ||
+    stream.pendingToSocket.length >= BROWSER_NETWORK_TUNNEL_MAX_PENDING_SOCKET_CHUNKS
+  ) {
+    return false
+  }
+  stream.receiveCredit -= payload.byteLength
+  stream.pendingToSocket.push(payload.slice())
+  stream.pendingToSocketBytes += payload.byteLength
+  flushBrowserNetworkSourceData(stream)
+  return true
+}
+
+export function beginBrowserNetworkSourceRead(
+  stream: BrowserNetworkTunnelSourceReceiveStream
+): void {
+  stream.readableDemand = true
+  flushBrowserNetworkSourceData(stream)
+}
+
+export function grantBrowserNetworkSourceReceiveCredit(
+  stream: BrowserNetworkTunnelSourceReceiveStream,
+  bytes: number,
+  maxCredit: number
+): boolean {
+  if (stream.receiveCredit + bytes > maxCredit) {
+    return false
+  }
+  stream.receiveCredit += bytes
+  return true
+}
+
+export function finishBrowserNetworkSourceData(
+  stream: BrowserNetworkTunnelSourceReceiveStream
+): boolean {
+  if (stream.remoteEnded) {
+    return false
+  }
+  stream.remoteEnded = true
+  flushBrowserNetworkSourceData(stream)
+  return true
+}
+
+function flushBrowserNetworkSourceData(stream: BrowserNetworkTunnelSourceReceiveStream): void {
+  while (stream.readableDemand && stream.pendingToSocket.length > 0) {
+    const bytes = stream.pendingToSocket.shift()!
+    stream.pendingToSocketBytes -= bytes.byteLength
+    if (!stream.socket.push(Buffer.from(bytes))) {
+      stream.readableDemand = false
+    }
+  }
+  if (stream.remoteEnded && stream.pendingToSocket.length === 0 && !stream.readableEnded) {
+    stream.readableEnded = true
+    stream.socket.push(null)
+  }
+}

--- a/src/main/browser/browser-network-tunnel-stream-state.ts
+++ b/src/main/browser/browser-network-tunnel-stream-state.ts
@@ -61,5 +61,6 @@ export type BrowserNetworkTunnelSessionOptions = {
   tunnelGeneration: number
   connect: (target: BrowserNetworkTunnelOpen) => BrowserNetworkTunnelSocket
   sendBinary: (bytes: Uint8Array<ArrayBufferLike>) => boolean
+  onClose?: () => void
 }
 import type { BrowserNetworkTunnelOpen } from '../../shared/browser-network-tunnel-protocol'

--- a/src/main/browser/paired-runtime-browser-network-route.test.ts
+++ b/src/main/browser/paired-runtime-browser-network-route.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { PairingOffer } from '../../shared/pairing'
+import type {
+  RemoteRuntimeSubscription,
+  RemoteRuntimeSubscriptionCallbacks
+} from '../../shared/remote-runtime-client'
+
+const { subscribeRemoteRuntimeRequestMock } = vi.hoisted(() => ({
+  subscribeRemoteRuntimeRequestMock: vi.fn()
+}))
+
+vi.mock('../../shared/remote-runtime-client', () => ({
+  subscribeRemoteRuntimeRequest: subscribeRemoteRuntimeRequestMock
+}))
+
+import { PairedRuntimeBrowserNetworkRoute } from './paired-runtime-browser-network-route'
+import { RemoteBrowserSocksServer } from './remote-browser-socks-server'
+
+const pairing = {
+  v: 2,
+  endpoint: 'ws://127.0.0.1:6768',
+  deviceToken: 'device-token',
+  publicKeyB64: 'public-key',
+  pairedDeviceId: 'device-a',
+  scope: 'runtime'
+} as PairingOffer
+
+afterEach(() => {
+  subscribeRemoteRuntimeRequestMock.mockReset()
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+})
+
+describe('PairedRuntimeBrowserNetworkRoute', () => {
+  it('closes a subscription that resolves after route teardown', async () => {
+    let resolveSubscription = (_subscription: RemoteRuntimeSubscription): void => {}
+    const closeSubscription = vi.fn()
+    subscribeRemoteRuntimeRequestMock.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveSubscription = resolve
+      })
+    )
+    const route = new PairedRuntimeBrowserNetworkRoute({
+      pairing,
+      authorityRuntimeId: 'runtime-a',
+      browserHostClientId: 'device-a',
+      tunnelGeneration: 7
+    })
+
+    const starting = route.start()
+    await route.close()
+    resolveSubscription({
+      requestId: 'late-subscription',
+      close: closeSubscription,
+      sendBinary: () => true
+    })
+
+    await expect(starting).rejects.toThrow('closed during startup')
+    expect(closeSubscription).toHaveBeenCalledOnce()
+  })
+
+  it('settles startup when close follows subscription acquisition before readiness', async () => {
+    let callbacks: RemoteRuntimeSubscriptionCallbacks | undefined
+    const closeSubscription = vi.fn()
+    subscribeRemoteRuntimeRequestMock.mockImplementationOnce(
+      async (...args: unknown[]): Promise<RemoteRuntimeSubscription> => {
+        callbacks = args[4] as RemoteRuntimeSubscriptionCallbacks
+        return {
+          requestId: 'waiting-subscription',
+          close: closeSubscription,
+          sendBinary: () => true
+        }
+      }
+    )
+    const route = createRoute()
+    const starting = route.start()
+    const rejected = expect(starting).rejects.toThrow('closed during startup')
+    await vi.waitFor(() => expect(callbacks).toBeDefined())
+
+    await route.close(new Error('closed during startup'))
+
+    await rejected
+    expect(closeSubscription).toHaveBeenCalledOnce()
+  })
+
+  it('bounds the post-auth readiness wait', async () => {
+    vi.useFakeTimers()
+    const closeSubscription = vi.fn()
+    subscribeRemoteRuntimeRequestMock.mockResolvedValueOnce({
+      requestId: 'silent-subscription',
+      close: closeSubscription,
+      sendBinary: () => true
+    })
+    const route = createRoute({ timeoutMs: 25 })
+    const starting = route.start()
+    const rejected = expect(starting).rejects.toThrow('Browser tunnel attach timed out')
+    await Promise.resolve()
+
+    await vi.advanceTimersByTimeAsync(25)
+
+    await rejected
+    expect(closeSubscription).toHaveBeenCalledOnce()
+  })
+
+  it('surfaces listener teardown failures', async () => {
+    vi.spyOn(RemoteBrowserSocksServer.prototype, 'close').mockRejectedValueOnce(
+      new Error('listener close failed')
+    )
+    const route = createRoute()
+
+    await expect(route.close()).rejects.toThrow('listener close failed')
+  })
+
+  it('tears down the local route when the runtime closes the tunnel', async () => {
+    let callbacks: RemoteRuntimeSubscriptionCallbacks | undefined
+    const closeSubscription = vi.fn()
+    subscribeRemoteRuntimeRequestMock.mockImplementationOnce(
+      async (...args: unknown[]): Promise<RemoteRuntimeSubscription> => {
+        callbacks = args[4] as RemoteRuntimeSubscriptionCallbacks
+        return {
+          requestId: 'runtime-closed-subscription',
+          close: closeSubscription,
+          sendBinary: () => true
+        }
+      }
+    )
+    const onError = vi.fn()
+    const route = createRoute({ onError })
+    const starting = route.start()
+    await vi.waitFor(() => expect(callbacks).toBeDefined())
+    callbacks!.onResponse({
+      id: 'runtime-closed-subscription',
+      ok: true,
+      result: { type: 'ready', tunnelGeneration: 7 },
+      _meta: { runtimeId: 'runtime-a' }
+    })
+    await starting
+
+    callbacks!.onResponse({
+      id: 'runtime-closed-subscription',
+      ok: true,
+      result: { type: 'closed', tunnelGeneration: 7 },
+      _meta: { runtimeId: 'runtime-a' }
+    })
+
+    await vi.waitFor(() => expect(closeSubscription).toHaveBeenCalledOnce())
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Browser network route closed by the runtime' })
+    )
+  })
+
+  it('finishes failure cleanup when reporting and listener teardown both throw', async () => {
+    let callbacks: RemoteRuntimeSubscriptionCallbacks | undefined
+    const closeSubscription = vi.fn()
+    subscribeRemoteRuntimeRequestMock.mockImplementationOnce(
+      async (...args: unknown[]): Promise<RemoteRuntimeSubscription> => {
+        callbacks = args[4] as RemoteRuntimeSubscriptionCallbacks
+        return {
+          requestId: 'cleanup-failure-subscription',
+          close: closeSubscription,
+          sendBinary: () => true
+        }
+      }
+    )
+    const closeSocks = vi
+      .spyOn(RemoteBrowserSocksServer.prototype, 'close')
+      .mockRejectedValueOnce(new Error('listener close failed'))
+    const route = createRoute({
+      onError: () => {
+        throw new Error('reporting failed')
+      }
+    })
+    const starting = route.start()
+    await vi.waitFor(() => expect(callbacks).toBeDefined())
+    callbacks!.onResponse({
+      id: 'cleanup-failure-subscription',
+      ok: true,
+      result: { type: 'ready', tunnelGeneration: 7 },
+      _meta: { runtimeId: 'runtime-a' }
+    })
+    await starting
+
+    callbacks!.onClose?.()
+
+    await vi.waitFor(() => expect(closeSubscription).toHaveBeenCalledOnce())
+    expect(closeSocks).toHaveBeenCalledOnce()
+  })
+})
+
+function createRoute(
+  overrides: { timeoutMs?: number; onError?: (error: Error) => void } = {}
+): PairedRuntimeBrowserNetworkRoute {
+  return new PairedRuntimeBrowserNetworkRoute({
+    pairing,
+    authorityRuntimeId: 'runtime-a',
+    browserHostClientId: 'device-a',
+    tunnelGeneration: 7,
+    ...overrides
+  })
+}

--- a/src/main/browser/paired-runtime-browser-network-route.ts
+++ b/src/main/browser/paired-runtime-browser-network-route.ts
@@ -1,0 +1,206 @@
+import type { PairingOffer } from '../../shared/pairing'
+import {
+  subscribeRemoteRuntimeRequest,
+  type RemoteRuntimeSubscription,
+  type RemoteRuntimeSubscriptionOptions
+} from '../../shared/remote-runtime-client'
+import { RemoteRuntimeClientError } from '../../shared/remote-runtime-client-error'
+import { BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY } from '../../shared/protocol-version'
+import { BrowserNetworkTunnelClient } from './browser-network-tunnel-client'
+import { RemoteBrowserSocksServer } from './remote-browser-socks-server'
+
+const BROWSER_TUNNEL_WS_SOFT_CAP_BYTES = 1024 * 1024
+const BROWSER_TUNNEL_WS_MAX_QUEUED_BYTES = 7 * 1024 * 1024
+
+type PairedRuntimeBrowserNetworkRouteOptions = {
+  pairing: PairingOffer
+  authorityRuntimeId: string
+  browserHostClientId: string
+  tunnelGeneration: number
+  timeoutMs?: number
+  subscription?: RemoteRuntimeSubscriptionOptions
+  onError?: (error: Error) => void
+}
+
+export class PairedRuntimeBrowserNetworkRoute {
+  private readonly options: PairedRuntimeBrowserNetworkRouteOptions
+  private readonly tunnel: BrowserNetworkTunnelClient
+  private readonly socks: RemoteBrowserSocksServer
+  private subscription: RemoteRuntimeSubscription | null = null
+  private startPromise: Promise<{ host: string; port: number }> | null = null
+  private closePromise: Promise<void> | null = null
+  private rejectReady: ((error: Error) => void) | null = null
+  private closed = false
+  private ready = false
+
+  constructor(options: PairedRuntimeBrowserNetworkRouteOptions) {
+    this.options = options
+    this.tunnel = new BrowserNetworkTunnelClient({
+      tunnelGeneration: options.tunnelGeneration,
+      sendBinary: (bytes) => this.subscription?.sendBinary(bytes) ?? false
+    })
+    this.socks = new RemoteBrowserSocksServer({ open: (target) => this.tunnel.open(target) })
+  }
+
+  start(): Promise<{ host: string; port: number }> {
+    if (this.closed) {
+      return Promise.reject(new Error('Browser network route is closed'))
+    }
+    this.startPromise ??= this.startRoute()
+    return this.startPromise
+  }
+
+  async close(error = new Error('Browser network route is closed')): Promise<void> {
+    if (this.closePromise) {
+      return this.closePromise
+    }
+    this.closed = true
+    this.rejectReady?.(error)
+    this.closePromise = this.closeRoute(error)
+    return this.closePromise
+  }
+
+  private async startRoute(): Promise<{ host: string; port: number }> {
+    const timeoutMs = this.options.timeoutMs ?? 15_000
+    let resolveReady = (): void => {}
+    let rejectReady = (_error: Error): void => {}
+    const ready = new Promise<void>((resolve, reject) => {
+      resolveReady = resolve
+      rejectReady = reject
+    })
+    void ready.catch(() => undefined)
+    let readyTimeout: ReturnType<typeof setTimeout> | null = null
+    try {
+      const subscription = await subscribeRemoteRuntimeRequest(
+        this.options.pairing,
+        'network.browserTunnel',
+        {
+          authorityRuntimeId: this.options.authorityRuntimeId,
+          browserHostClientId: this.options.browserHostClientId,
+          executionHost: { kind: 'native' },
+          tunnelGeneration: this.options.tunnelGeneration
+        },
+        timeoutMs,
+        {
+          onResponse: (response) => {
+            if (!response.ok) {
+              rejectReady(new RemoteRuntimeClientError(response.error.code, response.error.message))
+              return
+            }
+            const result = response.result as { type?: unknown; tunnelGeneration?: unknown }
+            if (
+              result.type === 'ready' &&
+              result.tunnelGeneration === this.options.tunnelGeneration
+            ) {
+              this.ready = true
+              resolveReady()
+            } else if (
+              result.type === 'closed' &&
+              result.tunnelGeneration === this.options.tunnelGeneration
+            ) {
+              this.fail(new Error('Browser network route closed by the runtime'), rejectReady)
+            }
+          },
+          onBinary: (bytes) => this.tunnel.handleBinary(bytes),
+          onError: (routeError) => this.fail(routeError, rejectReady),
+          onClose: () => this.fail(new Error('Browser network route transport closed'), rejectReady)
+        },
+        {
+          ...this.options.subscription,
+          perMessageDeflate: false,
+          outboundQueue: {
+            softCapBytes: BROWSER_TUNNEL_WS_SOFT_CAP_BYTES,
+            maxQueuedBytes: BROWSER_TUNNEL_WS_MAX_QUEUED_BYTES,
+            maxQueuedFrames: 2_048
+          },
+          clientCapabilities: [
+            ...(this.options.subscription?.clientCapabilities ?? []),
+            BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY
+          ]
+        }
+      )
+      if (this.closed) {
+        subscription.close()
+        throw new Error('Browser network route closed during startup')
+      }
+      this.subscription = subscription
+      this.rejectReady = rejectReady
+      readyTimeout = setTimeout(
+        () =>
+          rejectReady(
+            new RemoteRuntimeClientError('runtime_timeout', 'Browser tunnel attach timed out.')
+          ),
+        timeoutMs
+      )
+      await ready
+      if (this.closed) {
+        throw new Error('Browser network route closed during startup')
+      }
+      const address = await this.socks.listen()
+      if (this.closed) {
+        throw new Error('Browser network route closed during startup')
+      }
+      return address
+    } catch (error) {
+      const routeError = error instanceof Error ? error : new Error(String(error))
+      try {
+        await this.close(routeError)
+      } catch (closeError) {
+        throw new AggregateError(
+          [routeError, closeError],
+          'Browser network route startup cleanup failed'
+        )
+      }
+      throw routeError
+    } finally {
+      if (readyTimeout) {
+        clearTimeout(readyTimeout)
+      }
+      this.rejectReady = null
+    }
+  }
+
+  private fail(error: Error, rejectReady: (error: Error) => void): void {
+    if (this.closed) {
+      return
+    }
+    if (!this.ready) {
+      rejectReady(error)
+    }
+    const closing = this.close(error)
+    this.reportError(error)
+    void closing.catch((closeError) =>
+      this.reportError(closeError instanceof Error ? closeError : new Error(String(closeError)))
+    )
+  }
+
+  private async closeRoute(error: Error): Promise<void> {
+    this.tunnel.close(error)
+    const failures: Error[] = []
+    try {
+      this.subscription?.close()
+    } catch (closeError) {
+      failures.push(closeError instanceof Error ? closeError : new Error(String(closeError)))
+    }
+    this.subscription = null
+    try {
+      await this.socks.close()
+    } catch (closeError) {
+      failures.push(closeError instanceof Error ? closeError : new Error(String(closeError)))
+    }
+    if (failures.length === 1) {
+      throw failures[0]
+    }
+    if (failures.length > 1) {
+      throw new AggregateError(failures, 'Browser network route cleanup failed')
+    }
+  }
+
+  private reportError(error: Error): void {
+    try {
+      this.options.onError?.(error)
+    } catch {
+      // A reporting callback cannot prevent route cleanup.
+    }
+  }
+}

--- a/src/main/browser/remote-browser-socks-server.test.ts
+++ b/src/main/browser/remote-browser-socks-server.test.ts
@@ -50,6 +50,8 @@ function domainConnectRequest(host: string, port: number, command = 1): Uint8Arr
 describe('RemoteBrowserSocksServer', () => {
   it('passes domain names unchanged to the execution-host route', async () => {
     const upstream = new PassThrough()
+    const settleRead = vi.fn()
+    Object.assign(upstream, { settleRead })
     const open = vi.fn(async () => upstream)
     const server = new RemoteBrowserSocksServer({ open })
     servers.push(server)
@@ -63,6 +65,7 @@ describe('RemoteBrowserSocksServer', () => {
 
     socket.write('remote bytes')
     expect(new TextDecoder().decode(await readExact(socket, 12))).toBe('remote bytes')
+    await vi.waitFor(() => expect(settleRead).toHaveBeenCalledWith(12))
     socket.destroy()
   })
 

--- a/src/main/browser/remote-browser-socks-server.ts
+++ b/src/main/browser/remote-browser-socks-server.ts
@@ -198,7 +198,7 @@ export class RemoteBrowserSocksServer {
               buffered = Buffer.alloc(0)
             }
             socket.pipe(upstream)
-            upstream.pipe(socket)
+            pipeUpstreamToClient(upstream, socket)
             upstream.once('error', () => socket.destroy())
             upstream.once('close', () => socket.destroy())
             socket.once('close', () => upstream.destroy())
@@ -210,6 +210,22 @@ export class RemoteBrowserSocksServer {
     socket.once('error', cleanup)
     socket.once('close', cleanup)
   }
+}
+
+function pipeUpstreamToClient(upstream: Duplex, socket: Socket): void {
+  upstream.on('data', (chunk: Buffer) => {
+    const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+    const accepted = socket.write(bytes, (error) => {
+      if (!error && 'settleRead' in upstream && typeof upstream.settleRead === 'function') {
+        upstream.settleRead(bytes.byteLength)
+      }
+    })
+    if (!accepted) {
+      upstream.pause()
+    }
+  })
+  socket.on('drain', () => upstream.resume())
+  upstream.once('end', () => socket.end())
 }
 
 function parseSocksRequest(buffer: Uint8Array): SocksRequest | null | undefined {

--- a/src/main/runtime/browser-network-tunnel-paired-runtime.integration.test.ts
+++ b/src/main/runtime/browser-network-tunnel-paired-runtime.integration.test.ts
@@ -1,0 +1,124 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { createServer, connect, type Server, type Socket } from 'node:net'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { PairedRuntimeBrowserNetworkRoute } from '../browser/paired-runtime-browser-network-route'
+import { parsePairingCode } from '../../shared/pairing'
+import { OrcaRuntimeService } from './orca-runtime'
+import { OrcaRuntimeRpcServer } from './runtime-rpc'
+import { ALL_RPC_METHODS } from './rpc/methods'
+import { BROWSER_NETWORK_TUNNEL_METHODS } from './rpc/methods/browser-network-tunnel'
+
+const resources: (() => Promise<void> | void)[] = []
+
+afterEach(async () => {
+  for (const cleanup of resources.splice(0).toReversed()) {
+    await cleanup()
+  }
+})
+
+describe('paired runtime browser network tunnel', () => {
+  it('loads an execution-host HTTP target through SOCKS and the dedicated E2EE socket', async () => {
+    const destinationSockets = new Set<Socket>()
+    const destination = createServer((socket) => {
+      destinationSockets.add(socket)
+      socket.once('close', () => destinationSockets.delete(socket))
+      socket.once('data', () => {
+        socket.write(
+          'HTTP/1.1 200 OK\r\nContent-Length: 25\r\nConnection: keep-alive\r\n\r\nREMOTE_RUNTIME_HTTP_OK\n'
+        )
+      })
+    })
+    const destinationAddress = await listen(destination)
+    resources.push(() => closeServer(destination))
+
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-browser-tunnel-'))
+    resources.push(() => rmSync(userDataPath, { recursive: true, force: true }))
+    const runtime = new OrcaRuntimeService({} as never)
+    const rpc = new OrcaRuntimeRpcServer({
+      runtime,
+      userDataPath,
+      enableWebSocket: true,
+      wsPort: 0,
+      methods: [...ALL_RPC_METHODS, ...BROWSER_NETWORK_TUNNEL_METHODS]
+    })
+    await rpc.start()
+    resources.push(() => rpc.stop())
+
+    const offer = rpc.createPairingOffer({ name: 'browser-tunnel', scope: 'runtime' })
+    if (!offer.available) {
+      throw new Error('Runtime pairing is unavailable')
+    }
+    const pairing = parsePairingCode(offer.pairingUrl)
+    if (!pairing?.pairedDeviceId) {
+      throw new Error('Runtime pairing identity is unavailable')
+    }
+
+    const errors: Error[] = []
+    const route = new PairedRuntimeBrowserNetworkRoute({
+      pairing,
+      authorityRuntimeId: runtime.getRuntimeId(),
+      browserHostClientId: pairing.pairedDeviceId,
+      tunnelGeneration: 7,
+      onError: (error) => errors.push(error)
+    })
+    const socksAddress = await route.start()
+    resources.push(() => route.close())
+
+    const browserSocket = connect(socksAddress)
+    resources.push(() => {
+      browserSocket.destroy()
+    })
+    const responses = collectSocketBytes(browserSocket)
+    browserSocket.write(new Uint8Array([5, 1, 0]))
+    await vi.waitFor(() => expect(responses.bytes().subarray(0, 2)).toEqual(Buffer.from([5, 0])))
+    const host = Buffer.from('127.0.0.1')
+    browserSocket.write(
+      Buffer.concat([
+        Buffer.from([5, 1, 0, 3, host.byteLength]),
+        host,
+        Buffer.from([destinationAddress.port >> 8, destinationAddress.port & 0xff])
+      ])
+    )
+    await vi.waitFor(() => expect(responses.bytes().byteLength).toBeGreaterThanOrEqual(12))
+    expect(responses.bytes().subarray(2, 12)).toEqual(Buffer.from([5, 0, 0, 1, 0, 0, 0, 0, 0, 0]))
+
+    browserSocket.write('GET / HTTP/1.1\r\nHost: runtime-only.test\r\n\r\n')
+    await vi.waitFor(() =>
+      expect(responses.bytes().toString('utf8')).toContain('REMOTE_RUNTIME_HTTP_OK')
+    )
+    expect(errors).toEqual([])
+    expect(destinationSockets.size).toBe(1)
+
+    await route.close()
+    await vi.waitFor(() => expect(destinationSockets.size).toBe(0))
+  })
+})
+
+async function listen(server: Server): Promise<{ host: string; port: number }> {
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  const address = server.address()
+  if (!address || typeof address === 'string') {
+    throw new Error('Test server did not bind a TCP port')
+  }
+  return { host: '127.0.0.1', port: address.port }
+}
+
+async function closeServer(server: Server): Promise<void> {
+  if (!server.listening) {
+    return
+  }
+  await new Promise<void>((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve()))
+  )
+}
+
+function collectSocketBytes(socket: Socket): { bytes: () => Buffer } {
+  const chunks: Buffer[] = []
+  socket.on('data', (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)))
+  return { bytes: () => Buffer.concat(chunks) }
+}

--- a/src/main/runtime/rpc/core.ts
+++ b/src/main/runtime/rpc/core.ts
@@ -105,6 +105,10 @@ export type RpcContext = {
     streamId: number,
     handler: (frame: TerminalStreamFrame) => void
   ) => () => void
+  // Why: non-terminal binary protocols own their dedicated authenticated subscription socket.
+  registerBinaryMessageHandler?: (
+    handler: (bytes: Uint8Array<ArrayBufferLike>) => void
+  ) => () => void
 }
 
 export type RpcHandler<TParams> = (params: TParams, ctx: RpcContext) => unknown

--- a/src/main/runtime/rpc/dispatcher-stream-options.ts
+++ b/src/main/runtime/rpc/dispatcher-stream-options.ts
@@ -16,4 +16,7 @@ export type RpcDispatchStreamingOptions = {
     streamId: number,
     handler: (frame: TerminalStreamFrame) => void
   ) => () => void
+  registerBinaryMessageHandler?: (
+    handler: (bytes: Uint8Array<ArrayBufferLike>) => void
+  ) => () => void
 }

--- a/src/main/runtime/rpc/dispatcher.ts
+++ b/src/main/runtime/rpc/dispatcher.ts
@@ -209,6 +209,7 @@ export class RpcDispatcher {
             pairing: options?.pairing,
             sendBinary: options?.sendBinary,
             registerBinaryStreamHandler: options?.registerBinaryStreamHandler,
+            registerBinaryMessageHandler: options?.registerBinaryMessageHandler,
             legacyCoordinatorRunId,
             legacyCoordinatorAuthority: legacyCoordinator?.authority,
             revalidateLegacyCoordinator: legacyCoordinator?.revalidate,
@@ -266,7 +267,8 @@ export class RpcDispatcher {
           orchestrationCapability: request.orchestrationCapability,
           pairing: options?.pairing,
           sendBinary: options?.sendBinary,
-          registerBinaryStreamHandler: options?.registerBinaryStreamHandler
+          registerBinaryStreamHandler: options?.registerBinaryStreamHandler,
+          registerBinaryMessageHandler: options?.registerBinaryMessageHandler
         },
         emit
       )

--- a/src/main/runtime/rpc/methods/browser-network-tunnel.test.ts
+++ b/src/main/runtime/rpc/methods/browser-network-tunnel.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest'
+import { BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY } from '../../../../shared/protocol-version'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import { RpcDispatcher } from '../dispatcher'
+import { ALL_RPC_METHODS } from './index'
+import { BROWSER_NETWORK_TUNNEL_METHODS } from './browser-network-tunnel'
+
+function request(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'browser-tunnel',
+    authToken: 'bound-by-websocket',
+    method: 'network.browserTunnel',
+    params: {
+      authorityRuntimeId: 'runtime-a',
+      browserHostClientId: 'device-a',
+      executionHost: { kind: 'native' },
+      tunnelGeneration: 7,
+      ...overrides
+    }
+  }
+}
+
+function runtime(cleanups = new Map<string, () => void>()): OrcaRuntimeService {
+  return {
+    getRuntimeId: () => 'runtime-a',
+    getStartedAt: () => 1,
+    registerSubscriptionCleanup: (id: string, cleanup: () => void) => cleanups.set(id, cleanup)
+  } as unknown as OrcaRuntimeService
+}
+
+describe('network.browserTunnel RPC', () => {
+  it('remains outside the production RPC registry until route authorization exists', () => {
+    expect(ALL_RPC_METHODS.some((method) => method.name === 'network.browserTunnel')).toBe(false)
+  })
+
+  it('rejects an unnegotiated or mismatched browser host before registering binary traffic', async () => {
+    const dispatcher = new RpcDispatcher({
+      runtime: runtime(),
+      methods: BROWSER_NETWORK_TUNNEL_METHODS
+    })
+    const replies: string[] = []
+    const registerBinaryMessageHandler = vi.fn()
+    const baseOptions = {
+      connectionId: 'connection-a',
+      clientKind: 'runtime' as const,
+      pairedDeviceId: 'device-a',
+      sendBinary: vi.fn(() => true),
+      registerBinaryMessageHandler
+    }
+
+    await dispatcher.dispatchStreaming(request(), (reply) => replies.push(reply), baseOptions)
+    await dispatcher.dispatchStreaming(
+      request({ browserHostClientId: 'device-b' }),
+      (reply) => replies.push(reply),
+      { ...baseOptions, clientCapabilities: [BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY] }
+    )
+
+    expect(replies.map((reply) => JSON.parse(reply))).toEqual([
+      expect.objectContaining({
+        ok: false,
+        error: expect.objectContaining({ message: 'browser_tunnel_capability_required' })
+      }),
+      expect.objectContaining({
+        ok: false,
+        error: expect.objectContaining({ message: 'browser_tunnel_identity_mismatch' })
+      })
+    ])
+    expect(registerBinaryMessageHandler).not.toHaveBeenCalled()
+  })
+
+  it('binds one raw handler to the connection and removes it during subscription cleanup', async () => {
+    const cleanups = new Map<string, () => void>()
+    const dispatcher = new RpcDispatcher({
+      runtime: runtime(cleanups),
+      methods: BROWSER_NETWORK_TUNNEL_METHODS
+    })
+    const unregister = vi.fn()
+    const registerBinaryMessageHandler = vi.fn(() => unregister)
+    const replies: string[] = []
+    const dispatch = dispatcher.dispatchStreaming(request(), (reply) => replies.push(reply), {
+      connectionId: 'connection-a',
+      clientKind: 'runtime',
+      pairedDeviceId: 'device-a',
+      clientCapabilities: [BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY],
+      sendBinary: vi.fn(() => true),
+      registerBinaryMessageHandler
+    })
+
+    await vi.waitFor(() => expect(registerBinaryMessageHandler).toHaveBeenCalledOnce())
+    expect(replies.map((reply) => JSON.parse(reply))).toEqual([
+      expect.objectContaining({
+        ok: true,
+        streaming: true,
+        result: { type: 'ready', tunnelGeneration: 7 }
+      })
+    ])
+    cleanups.get('browser-network-tunnel:connection-a')?.()
+    await dispatch
+    expect(unregister).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/runtime/rpc/methods/browser-network-tunnel.ts
+++ b/src/main/runtime/rpc/methods/browser-network-tunnel.ts
@@ -1,0 +1,87 @@
+import { connect } from 'node:net'
+import { z } from 'zod'
+import { BrowserNetworkTunnelSession } from '../../../browser/browser-network-tunnel-session'
+import { BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY } from '../../../../shared/protocol-version'
+import { defineStreamingMethod, type RpcAnyMethod } from '../core'
+
+const BrowserNetworkTunnelAttach = z.object({
+  authorityRuntimeId: z.string().min(1),
+  browserHostClientId: z.string().min(1),
+  executionHost: z.object({ kind: z.literal('native') }),
+  tunnelGeneration: z.number().int().min(1).max(0xffff_ffff)
+})
+
+// Why: tests inject this until a live lease and server-owned route generation authorize TCP opens.
+export const BROWSER_NETWORK_TUNNEL_METHODS: RpcAnyMethod[] = [
+  defineStreamingMethod({
+    name: 'network.browserTunnel',
+    params: BrowserNetworkTunnelAttach,
+    handler: async (
+      params,
+      {
+        runtime,
+        connectionId,
+        pairedDeviceId,
+        clientKind,
+        clientCapabilities,
+        sendBinary,
+        registerBinaryMessageHandler,
+        signal
+      },
+      emit
+    ) => {
+      if (
+        clientKind !== 'runtime' ||
+        !connectionId ||
+        !pairedDeviceId ||
+        !sendBinary ||
+        !registerBinaryMessageHandler
+      ) {
+        throw new Error('authenticated_binary_browser_tunnel_required')
+      }
+      if (!clientCapabilities?.includes(BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY)) {
+        throw new Error('browser_tunnel_capability_required')
+      }
+      if (
+        params.authorityRuntimeId !== runtime.getRuntimeId() ||
+        params.browserHostClientId !== pairedDeviceId
+      ) {
+        throw new Error('browser_tunnel_identity_mismatch')
+      }
+
+      let resolveClosed = (): void => {}
+      const closed = new Promise<void>((resolve) => {
+        resolveClosed = resolve
+      })
+      const session = new BrowserNetworkTunnelSession({
+        tunnelGeneration: params.tunnelGeneration,
+        connect: (target) => connect({ ...target, allowHalfOpen: true }),
+        sendBinary: (bytes) => sendBinary(bytes) !== false,
+        onClose: () => {
+          emit({ type: 'closed', tunnelGeneration: params.tunnelGeneration })
+          resolveClosed()
+        }
+      })
+      const unregisterBinary = registerBinaryMessageHandler((bytes) => session.handleBinary(bytes))
+      let cleaned = false
+      const cleanup = (): void => {
+        if (cleaned) {
+          return
+        }
+        cleaned = true
+        unregisterBinary()
+        session.close()
+      }
+      const subscriptionId = `browser-network-tunnel:${connectionId}`
+      try {
+        runtime.registerSubscriptionCleanup(subscriptionId, cleanup, connectionId)
+        signal?.addEventListener('abort', cleanup, { once: true })
+        emit({ type: 'ready', tunnelGeneration: params.tunnelGeneration })
+        await closed
+      } finally {
+        signal?.removeEventListener('abort', cleanup)
+        cleanup()
+      }
+    }
+  })
+]

--- a/src/main/runtime/runtime-binary-message-router.test.ts
+++ b/src/main/runtime/runtime-binary-message-router.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  encodeTerminalStreamFrame,
+  TerminalStreamOpcode
+} from '../../shared/terminal-stream-protocol'
+import { RuntimeBinaryMessageRouter } from './runtime-binary-message-router'
+
+describe('RuntimeBinaryMessageRouter', () => {
+  it('keeps terminal streams and raw browser messages on exclusive connections', () => {
+    const router = new RuntimeBinaryMessageRouter()
+    const terminalHandler = vi.fn()
+    const rawHandler = vi.fn()
+
+    router.registerTerminalStream('terminal-connection', 4, terminalHandler)
+    expect(() => router.registerRawMessage('terminal-connection', rawHandler)).toThrow(
+      'binary_handler_mode_conflict'
+    )
+
+    router.registerRawMessage('browser-connection', rawHandler)
+    expect(() => router.registerTerminalStream('browser-connection', 4, terminalHandler)).toThrow(
+      'binary_handler_mode_conflict'
+    )
+
+    router.dispatch(
+      'terminal-connection',
+      encodeTerminalStreamFrame({
+        opcode: TerminalStreamOpcode.Output,
+        streamId: 4,
+        seq: 1,
+        payload: new Uint8Array([1, 2, 3])
+      })
+    )
+    router.dispatch('browser-connection', new Uint8Array([7, 8, 9]))
+
+    expect(terminalHandler).toHaveBeenCalledOnce()
+    expect(rawHandler).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/runtime/runtime-binary-message-router.ts
+++ b/src/main/runtime/runtime-binary-message-router.ts
@@ -1,0 +1,76 @@
+import {
+  decodeTerminalStreamFrame,
+  type TerminalStreamFrame
+} from '../../shared/terminal-stream-protocol'
+
+type TerminalStreamHandler = (frame: TerminalStreamFrame) => void
+type RawMessageHandler = (bytes: Uint8Array<ArrayBufferLike>) => void
+
+export class RuntimeBinaryMessageRouter {
+  private readonly terminalHandlers = new Map<string, Map<number, TerminalStreamHandler>>()
+  private readonly rawHandlers = new Map<string, RawMessageHandler>()
+
+  registerTerminalStream(
+    connectionId: string | undefined,
+    streamId: number,
+    handler: TerminalStreamHandler
+  ): () => void {
+    if (!connectionId || !Number.isInteger(streamId) || streamId < 0) {
+      return () => {}
+    }
+    if (this.rawHandlers.has(connectionId)) {
+      throw new Error('binary_handler_mode_conflict')
+    }
+    let handlers = this.terminalHandlers.get(connectionId)
+    if (!handlers) {
+      handlers = new Map()
+      this.terminalHandlers.set(connectionId, handlers)
+    }
+    handlers.set(streamId, handler)
+    return () => {
+      const current = this.terminalHandlers.get(connectionId)
+      if (!current || current.get(streamId) !== handler) {
+        return
+      }
+      current.delete(streamId)
+      if (current.size === 0) {
+        this.terminalHandlers.delete(connectionId)
+      }
+    }
+  }
+
+  registerRawMessage(connectionId: string | undefined, handler: RawMessageHandler): () => void {
+    if (!connectionId) {
+      return () => {}
+    }
+    if (this.rawHandlers.has(connectionId) || this.terminalHandlers.has(connectionId)) {
+      throw new Error('binary_handler_mode_conflict')
+    }
+    this.rawHandlers.set(connectionId, handler)
+    return () => {
+      if (this.rawHandlers.get(connectionId) === handler) {
+        this.rawHandlers.delete(connectionId)
+      }
+    }
+  }
+
+  dispatch(connectionId: string | undefined, bytes: Uint8Array<ArrayBufferLike>): void {
+    if (!connectionId) {
+      return
+    }
+    const rawHandler = this.rawHandlers.get(connectionId)
+    if (rawHandler) {
+      rawHandler(bytes)
+      return
+    }
+    const frame = decodeTerminalStreamFrame(bytes)
+    if (frame) {
+      this.terminalHandlers.get(connectionId)?.get(frame.streamId)?.(frame)
+    }
+  }
+
+  deleteConnection(connectionId: string): void {
+    this.terminalHandlers.delete(connectionId)
+    this.rawHandlers.delete(connectionId)
+  }
+}

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -13,7 +13,7 @@ import {
   type RuntimeMetadataOwnershipWatch
 } from './runtime-metadata-ownership-watch'
 import { RpcDispatcher } from './rpc/dispatcher'
-import type { RpcRequest, RpcResponse } from './rpc/core'
+import type { RpcAnyMethod, RpcRequest, RpcResponse } from './rpc/core'
 import { errorResponse } from './rpc/errors'
 import { fingerprintAuthenticatedPairingCredential } from './rpc/orchestration-mutation-executor'
 import type { RpcMessageContext, RpcTransport } from './rpc/transport'
@@ -49,10 +49,8 @@ import type {
 } from '../../shared/mobile-relay-credential-contract'
 import { encodePairingOffer, PAIRING_OFFER_VERSION } from '../../shared/pairing'
 import { resolveAdvertisedPairingEndpoint } from './pairing-endpoint'
-import {
-  decodeTerminalStreamFrame,
-  type TerminalStreamFrame
-} from '../../shared/terminal-stream-protocol'
+import type { TerminalStreamFrame } from '../../shared/terminal-stream-protocol'
+import { RuntimeBinaryMessageRouter } from './runtime-binary-message-router'
 
 const DEFAULT_WS_PORT = 6768
 
@@ -79,6 +77,8 @@ type OrcaRuntimeRpcServerOptions = {
   longPollCap?: number
   // Why: test-only override for the ownership reclaim cadence.
   metadataOwnershipPollMs?: number
+  // Why: tests may inject inert protocol stages before production authorization registers them.
+  methods?: readonly RpcAnyMethod[]
 }
 
 export type PairingOfferUnavailableReason =
@@ -524,10 +524,7 @@ export class OrcaRuntimeRpcServer {
   private mobilePairingOfferGeneration = 0
   private onUnpairedDeviceAuthFailure: (() => void) | null = null
   private unpairedDeviceAuthThrottle: UnpairedDeviceAuthThrottle | null = null
-  private readonly binaryStreamHandlers = new Map<
-    string,
-    Map<number, (frame: TerminalStreamFrame) => void>
-  >()
+  private readonly binaryMessageRouter = new RuntimeBinaryMessageRouter()
   private readonly wsDispatchAbortStates = new Map<
     WebSocket,
     { controllers: Set<AbortController>; abortOnClose: () => void }
@@ -549,10 +546,11 @@ export class OrcaRuntimeRpcServer {
     webClientRoot,
     keepaliveIntervalMs = KEEPALIVE_INTERVAL_MS,
     longPollCap = LONG_POLL_CAP,
-    metadataOwnershipPollMs = RUNTIME_METADATA_OWNERSHIP_POLL_MS
+    metadataOwnershipPollMs = RUNTIME_METADATA_OWNERSHIP_POLL_MS,
+    methods
   }: OrcaRuntimeRpcServerOptions) {
     this.runtime = runtime
-    this.dispatcher = new RpcDispatcher({ runtime })
+    this.dispatcher = new RpcDispatcher({ runtime, methods })
     this.userDataPath = userDataPath
     this.pid = pid
     this.platform = platform
@@ -1005,37 +1003,18 @@ export class OrcaRuntimeRpcServer {
     streamId: number,
     handler: (frame: TerminalStreamFrame) => void
   ): () => void {
-    if (!connectionId || !Number.isInteger(streamId) || streamId < 0) {
-      return () => {}
-    }
-    let handlers = this.binaryStreamHandlers.get(connectionId)
-    if (!handlers) {
-      handlers = new Map()
-      this.binaryStreamHandlers.set(connectionId, handlers)
-    }
-    handlers.set(streamId, handler)
-    return () => {
-      const current = this.binaryStreamHandlers.get(connectionId)
-      if (!current || current.get(streamId) !== handler) {
-        return
-      }
-      current.delete(streamId)
-      if (current.size === 0) {
-        this.binaryStreamHandlers.delete(connectionId)
-      }
-    }
+    return this.binaryMessageRouter.registerTerminalStream(connectionId, streamId, handler)
+  }
+
+  private registerBinaryMessageHandler(
+    connectionId: string | undefined,
+    handler: (bytes: Uint8Array<ArrayBufferLike>) => void
+  ): () => void {
+    return this.binaryMessageRouter.registerRawMessage(connectionId, handler)
   }
 
   private handleWebSocketBinaryMessage(bytes: Uint8Array<ArrayBufferLike>, ws: WebSocket): void {
-    const connectionId = this.mobileSocketWiring?.getConnectionId(ws)
-    if (!connectionId) {
-      return
-    }
-    const frame = decodeTerminalStreamFrame(bytes)
-    if (!frame) {
-      return
-    }
-    this.binaryStreamHandlers.get(connectionId)?.get(frame.streamId)?.(frame)
+    this.binaryMessageRouter.dispatch(this.mobileSocketWiring?.getConnectionId(ws), bytes)
   }
 
   private registerWebSocketDispatchAbort(ws: WebSocket): {
@@ -1340,7 +1319,7 @@ export class OrcaRuntimeRpcServer {
         // Why: subscriptions and binary streams are socket-scoped, but disconnect state is device-scoped across transports.
         this.runtime.cleanupSubscriptionsForConnection(socket.connectionId)
         this.runtime.cancelMobileDictationForConnection(socket.connectionId)
-        this.binaryStreamHandlers.delete(socket.connectionId)
+        this.binaryMessageRouter.deleteConnection(socket.connectionId)
         if (!hasOtherConnections) {
           this.runtime.onClientDisconnected(socket.device.deviceToken)
         }
@@ -1725,7 +1704,9 @@ export class OrcaRuntimeRpcServer {
         signal: abortRegistration?.signal,
         sendBinary,
         registerBinaryStreamHandler: (streamId, handler) =>
-          this.registerBinaryStreamHandler(connectionId, streamId, handler)
+          this.registerBinaryStreamHandler(connectionId, streamId, handler),
+        registerBinaryMessageHandler: (handler) =>
+          this.registerBinaryMessageHandler(connectionId, handler)
       })
     } finally {
       abortRegistration?.dispose()

--- a/src/shared/remote-runtime-client.test.ts
+++ b/src/shared/remote-runtime-client.test.ts
@@ -15,6 +15,7 @@ import { sendRemoteRuntimeRequest, subscribeRemoteRuntimeRequest } from './remot
 import { MAX_TIMER_DELAY_MS } from './timer-delay'
 import {
   AGENT_SESSION_BOUNDARY_RUNTIME_CAPABILITY,
+  BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY,
   SESSION_TAB_CLOSE_INTENT_RUNTIME_CAPABILITY,
   WORKTREE_VISIBILITY_DEFAULTS_RUNTIME_CAPABILITY,
   WORKTREE_VISIBILITY_SOURCE_DEFAULTS_RUNTIME_CAPABILITY
@@ -86,6 +87,40 @@ describe('subscribeRemoteRuntimeRequest', () => {
     await expect(server.nextBinary).resolves.toEqual(bytes)
     expect(onError).not.toHaveBeenCalled()
     subscription.close()
+  })
+
+  it('binds optional capabilities and rejects a hard outbound queue overflow', async () => {
+    const server = await createSubscriptionServer()
+    const onResponse = vi.fn()
+    const onError = vi.fn()
+    const subscription = await subscribeRemoteRuntimeRequest(
+      server.pairing,
+      'network.browserTunnel',
+      {},
+      1000,
+      { onResponse, onError },
+      {
+        clientCapabilities: [BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY],
+        outboundQueue: { softCapBytes: 0, maxQueuedBytes: 1, maxQueuedFrames: 1 }
+      }
+    )
+
+    await vi.waitFor(() => expect(onResponse).toHaveBeenCalled())
+    await expect(server.nextAuth).resolves.toEqual({
+      type: 'e2ee_auth',
+      deviceToken: 'device-token',
+      clientCapabilities: [
+        SESSION_TAB_CLOSE_INTENT_RUNTIME_CAPABILITY,
+        AGENT_SESSION_BOUNDARY_RUNTIME_CAPABILITY,
+        WORKTREE_VISIBILITY_DEFAULTS_RUNTIME_CAPABILITY,
+        WORKTREE_VISIBILITY_SOURCE_DEFAULTS_RUNTIME_CAPABILITY,
+        BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY
+      ]
+    })
+    expect(subscription.sendBinary(new Uint8Array([9]))).toBe(false)
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 'remote_runtime_unavailable' })
+    )
   })
 
   it('detaches subscription socket listeners after close', async () => {

--- a/src/shared/remote-runtime-client.ts
+++ b/src/shared/remote-runtime-client.ts
@@ -26,7 +26,8 @@ import {
   AGENT_SESSION_BOUNDARY_RUNTIME_CAPABILITY,
   SESSION_TAB_CLOSE_INTENT_RUNTIME_CAPABILITY,
   WORKTREE_VISIBILITY_DEFAULTS_RUNTIME_CAPABILITY,
-  WORKTREE_VISIBILITY_SOURCE_DEFAULTS_RUNTIME_CAPABILITY
+  WORKTREE_VISIBILITY_SOURCE_DEFAULTS_RUNTIME_CAPABILITY,
+  type RuntimeCapability
 } from './protocol-version'
 // Re-export so existing value importers of `RemoteRuntimeClientError` are
 // unaffected; the class lives in a ws-free module so type-only consumers
@@ -83,6 +84,16 @@ export type RemoteRuntimeSubscriptionCallbacks<TResult = unknown> = {
   onBinary?: (bytes: Uint8Array<ArrayBufferLike>) => void
   onError: (error: RemoteRuntimeClientError) => void
   onClose?: () => void
+}
+
+export type RemoteRuntimeSubscriptionOptions = RemoteRuntimeSocketLivenessOptions & {
+  clientCapabilities?: readonly RuntimeCapability[]
+  perMessageDeflate?: boolean
+  outboundQueue?: {
+    softCapBytes: number
+    maxQueuedBytes: number
+    maxQueuedFrames: number
+  }
 }
 
 export function sendRemoteRuntimeRequest<TResult>(
@@ -501,7 +512,7 @@ export async function subscribeRemoteRuntimeRequest<TResult>(
   params: unknown,
   timeoutMs: number,
   callbacks: RemoteRuntimeSubscriptionCallbacks<TResult>,
-  livenessOptions?: RemoteRuntimeSocketLivenessOptions
+  options?: RemoteRuntimeSubscriptionOptions
 ): Promise<RemoteRuntimeSubscription> {
   const requestId = randomUUID()
   const serializedRequest = serializeRemoteRuntimeRpcRequest({
@@ -513,12 +524,15 @@ export async function subscribeRemoteRuntimeRequest<TResult>(
   const serializedAuth = serializeRemoteRuntimePayload({
     type: 'e2ee_auth',
     deviceToken: pairing.deviceToken,
-    clientCapabilities: [
-      SESSION_TAB_CLOSE_INTENT_RUNTIME_CAPABILITY,
-      AGENT_SESSION_BOUNDARY_RUNTIME_CAPABILITY,
-      WORKTREE_VISIBILITY_DEFAULTS_RUNTIME_CAPABILITY,
-      WORKTREE_VISIBILITY_SOURCE_DEFAULTS_RUNTIME_CAPABILITY
-    ]
+    clientCapabilities: Array.from(
+      new Set([
+        SESSION_TAB_CLOSE_INTENT_RUNTIME_CAPABILITY,
+        AGENT_SESSION_BOUNDARY_RUNTIME_CAPABILITY,
+        WORKTREE_VISIBILITY_DEFAULTS_RUNTIME_CAPABILITY,
+        WORKTREE_VISIBILITY_SOURCE_DEFAULTS_RUNTIME_CAPABILITY,
+        ...(options?.clientCapabilities ?? [])
+      ])
+    )
   })
   return await new Promise((resolve, reject) => {
     const keyPair = generateKeyPair()
@@ -599,7 +613,8 @@ export async function subscribeRemoteRuntimeRequest<TResult>(
                 'remote_runtime_unavailable',
                 'Remote Orca runtime send buffer overflow; reconnecting.'
               )
-            )
+            ),
+          ...options?.outboundQueue
         })
       }
       return sendQueue
@@ -614,8 +629,7 @@ export async function subscribeRemoteRuntimeRequest<TResult>(
       ) {
         return false
       }
-      ensureSendQueue(ws).enqueue(Buffer.from(encryptBytes(bytes, sharedKey)))
-      return true
+      return ensureSendQueue(ws).enqueue(Buffer.from(encryptBytes(bytes, sharedKey)))
     }
 
     const succeed = (): void => {
@@ -644,7 +658,10 @@ export async function subscribeRemoteRuntimeRequest<TResult>(
     }
 
     try {
-      ws = new WebSocket(pairing.endpoint, { maxPayload: REMOTE_RUNTIME_MAX_WEBSOCKET_FRAME_BYTES })
+      ws = new WebSocket(pairing.endpoint, {
+        maxPayload: REMOTE_RUNTIME_MAX_WEBSOCKET_FRAME_BYTES,
+        ...(options?.perMessageDeflate === false ? { perMessageDeflate: false } : {})
+      })
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       fail(new RemoteRuntimeClientError('invalid_argument', `Invalid remote endpoint: ${message}`))
@@ -755,7 +772,7 @@ export async function subscribeRemoteRuntimeRequest<TResult>(
           // Best-effort terminate; the subscription is already settled.
         }
       },
-      options: livenessOptions
+      options
     })
 
     function handleReadyFrame(frame: string): void {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​803 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​803 |
| Prod | 22 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1317 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​105 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1212 |

<!-- /orca-pr-loc -->

## ELI5

The browser window will eventually live on the desktop that is displaying it, while its network requests still leave from the runtime that owns the workspace. This stage proves that network path: a desktop-side loopback SOCKS route carries bounded TCP frames over a dedicated authenticated paired-runtime connection, and the runtime opens the real destination socket without resolving names on the desktop.

Nothing selects this route in production yet. The RPC method is test-injected only and the client-host/tunnel capabilities remain unadvertised, so existing clients and server-hosted browser placement are unchanged.

## What Changed

- Added the source-side tunnel multiplexer and Duplex bridge with bounded per-stream writes, destination receive credit, generation fencing, ordered half-close/close handling, and stream retirement.
- Added a dedicated raw-binary router that keeps tunnel frames and terminal multiplex frames connection-exclusive.
- Added a paired-runtime route that owns the authenticated E2EE subscription and loopback SOCKS listener, preserves execution-host DNS, disables compression, and fails closed on attach/transport/queue errors.
- Added the native execution-host tunnel RPC behind an explicit test-only method injection. It verifies runtime-scoped pairing, paired-device identity, authority runtime ID, generation, and the optional client capability.
- Made subscription binary enqueue return actual admission and added bounded queue overrides.
- Added deterministic unit and real paired-runtime integration coverage plus a reliability gate.

## Why

STA-4150 needs client-hosted Electron pages to render and accept input locally without giving them the desktop's DNS, localhost, or private-network identity. The tunnel is the first executable cross-boundary route for that architecture. Keeping registration and capability advertisement off prevents this transport from becoming a hidden arbitrary-TCP feature before browser-host leases, server-owned route generations, aggregate accounting, proxy trust, and Electron isolation exist.

This is stacked on #14440, which contains the inert framing, destination-flow, capability, and SOCKS contracts.

## Linked Issue

Part of [STA-4150](https://linear.app/stably/issue/STA-4150/refactor-remote-browser-to-client-hosted-electron-webviews).

## Visual Proof

N/A — this stage has no registered production method, Electron webview, or visible interaction change.

## Testing

- 25/25 shared protocol, destination flow, and SOCKS tests.
- 19/19 source flow, route lifecycle, raw/terminal routing, RPC authorization, and real paired-runtime SOCKS-to-HTTP tests.
- 17/17 authenticated remote-runtime subscription tests.
- 5/5 terminal cross-version wire tests.
- `pnpm run typecheck`
- `pnpm run check:code-quality:changed`
- `pnpm run check:reliability-gates`
- `pnpm run check:max-lines-ratchet`
- `git diff --check`
- Rebased and rerun on `origin/main` at `9e5ee5ef8e` on macOS.

- [x] Automated tests added/updated
- [ ] Electron rendered validation — not applicable until a later stage registers a host and webview

## Review

Please treat these as activation blockers, not follow-ups that can be deferred after registration:

- live browser-host lease, authority epoch, exact execution-host revision, and server-owned route generation;
- bounded pending-open/open-rate admission, aggregate 8 MiB route / 32 MiB browser-host / process accounting, and fair scheduling;
- approved same-host SOCKS no-auth trust boundary or stronger isolation/authentication;
- reconnect with generation replacement and tunnel recycling before stream-ID exhaustion;
- E2EE v2/relay-compatible capability negotiation;
- SSH2, system SSH, exact-distro WSL, browserless, Linux, and physical Windows adapters/evidence;
- Electron partition proxy policy before every request, plus HTTP(S), DNS, WebSocket, worker, redirect, speculative-request, UDP/QUIC/DoH denial, and desktop no-fallback proof.

Existing server/offscreen placement, old callers that omit placement, terminal framing, mobile surfaces, SSH, WSL, folder workspaces, and git worktrees are not activated or semantically changed by this stage.

## Checklist

- [x] This PR is a focused second layer in the STA-4150 stack
- [x] I explained what changed and why
- [x] Visual proof is N/A because there is no UI activation
- [x] Fresh correctness and security/performance reviews completed
- [x] Cross-platform, SSH/remote, mobile, and mixed-version impact considered
- [x] Focused local tests and static/reliability gates pass; full matrix delegated to PR CI
