### PR TITLE
feat(source-control): load the next page of commits on scroll

### DIFF
--- a/src/renderer/src/components/right-sidebar/GitHistoryPanel.auto-load.test.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHistoryPanel.auto-load.test.tsx
@@ -1,0 +1,277 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
+import type { GitHistoryCursor, GitHistoryResult } from '../../../../shared/git-history'
+import { GitHistoryPanel, type GitHistoryPanelState } from './GitHistoryPanel'
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+type StubObserver = {
+  callback: IntersectionObserverCallback
+  root: Element | Document | null
+  rootMargin: string
+  disconnected: boolean
+}
+
+let observers: StubObserver[] = []
+const realIntersectionObserver = globalThis.IntersectionObserver
+
+// Why a stub rather than the environment's own: happy-dom performs no layout, so a real observer
+// would never report an intersection and every assertion here would pass vacuously.
+function installObserverStub(): void {
+  observers = []
+  ;(globalThis as { IntersectionObserver?: unknown }).IntersectionObserver = class {
+    private readonly record: StubObserver
+    constructor(callback: IntersectionObserverCallback, options?: IntersectionObserverInit) {
+      this.record = {
+        callback,
+        root: (options?.root as Element | null) ?? null,
+        rootMargin: options?.rootMargin ?? '',
+        disconnected: false
+      }
+      observers.push(this.record)
+    }
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {
+      this.record.disconnected = true
+    }
+    takeRecords(): [] {
+      return []
+    }
+  }
+}
+
+// The panel re-subscribes whenever the cursor moves, so only the newest live observer is the one
+// watching the trigger the user can actually see.
+function scrollTriggerIntoView(isIntersecting = true): void {
+  const observer = observers.findLast((entry) => !entry.disconnected)
+  if (!observer) {
+    throw new Error('no live IntersectionObserver — the panel never observed a load trigger')
+  }
+  act(() => {
+    observer.callback(
+      [{ isIntersecting } as IntersectionObserverEntry],
+      undefined as unknown as IntersectionObserver
+    )
+  })
+}
+
+afterEach(() => {
+  cleanup()
+  ;(globalThis as { IntersectionObserver?: unknown }).IntersectionObserver =
+    realIntersectionObserver
+})
+
+beforeEach(() => {
+  installObserverStub()
+})
+
+function commitId(index: number): string {
+  return String(index + 1).padStart(40, 'a')
+}
+
+function cursor(loaded: number): GitHistoryCursor {
+  return { anchor: commitId(0), loaded, after: { id: commitId(loaded - 1), parentIds: [] } }
+}
+
+function makeResult({
+  count,
+  nextCursor,
+  continuedCursor
+}: {
+  count: number
+  nextCursor?: GitHistoryCursor
+  continuedCursor?: boolean
+}): GitHistoryResult {
+  return {
+    items: Array.from({ length: count }, (_, index) => ({
+      id: commitId(index),
+      parentIds: index + 1 < count ? [commitId(index + 1)] : [],
+      subject: `Commit ${index + 1}`,
+      message: `Commit ${index + 1}`,
+      displayId: commitId(index).slice(0, 7),
+      author: 'Taylor',
+      timestamp: new Date(2026, 5, 15, 12).getTime() - index * 60_000,
+      references: []
+    })),
+    currentRef: {
+      id: 'refs/heads/main',
+      name: 'main',
+      revision: commitId(0),
+      category: 'branches'
+    },
+    hasIncomingChanges: false,
+    hasOutgoingChanges: false,
+    hasMore: Boolean(nextCursor),
+    limit: 50,
+    continuedCursor,
+    nextCursor
+  }
+}
+
+function panel(state: GitHistoryPanelState, onLoadMore: () => void): React.JSX.Element {
+  return (
+    <GitHistoryPanel
+      state={state}
+      worktreeId="wt-a"
+      collapsed={false}
+      onToggle={vi.fn()}
+      onRefresh={vi.fn()}
+      onLoadMore={onLoadMore}
+      onOpenCommit={vi.fn()}
+    />
+  )
+}
+
+function ready(result: GitHistoryResult): GitHistoryPanelState {
+  return { status: 'ready', result }
+}
+
+describe('git history auto-loads the next page on scroll', () => {
+  it('fetches the next page when the trigger scrolls near the bottom', () => {
+    const onLoadMore = vi.fn()
+    render(panel(ready(makeResult({ count: 3, nextCursor: cursor(3) })), onLoadMore))
+
+    expect(onLoadMore).not.toHaveBeenCalled()
+    scrollTriggerIntoView()
+
+    expect(onLoadMore).toHaveBeenCalledTimes(1)
+  })
+
+  // Why: the observer's root is the panel's own scroller, and the bottom margin is what buys the
+  // fetch a head start. Watching the document instead would fire on page scroll the panel does not
+  // own, and a zero margin would make every page land visibly late.
+  it('watches the panel scroller with a bottom prefetch margin', () => {
+    render(panel(ready(makeResult({ count: 3, nextCursor: cursor(3) })), vi.fn()))
+
+    const observer = observers.findLast((entry) => !entry.disconnected)
+    expect(observer?.root).toBeInstanceOf(Element)
+    expect(observer?.rootMargin).toMatch(/0px 0px [1-9]\d*px 0px/)
+  })
+
+  it('does not fetch the same page twice while it is still on screen', () => {
+    const onLoadMore = vi.fn()
+    render(panel(ready(makeResult({ count: 3, nextCursor: cursor(3) })), onLoadMore))
+
+    scrollTriggerIntoView()
+    scrollTriggerIntoView()
+    scrollTriggerIntoView()
+
+    expect(onLoadMore).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps fetching as each page lands and the trigger stays in view', () => {
+    const onLoadMore = vi.fn()
+    const { rerender } = render(
+      panel(ready(makeResult({ count: 3, nextCursor: cursor(3) })), onLoadMore)
+    )
+
+    scrollTriggerIntoView()
+    rerender(
+      panel(
+        ready(makeResult({ count: 6, nextCursor: cursor(6), continuedCursor: true })),
+        onLoadMore
+      )
+    )
+    scrollTriggerIntoView()
+
+    expect(onLoadMore).toHaveBeenCalledTimes(2)
+  })
+
+  // Why: the retry hazard. A failed page leaves the cursor untouched, so without the once-per-cursor
+  // rule the trigger would reissue it for as long as it stayed on screen.
+  it('does not retry a page that failed', () => {
+    const onLoadMore = vi.fn()
+    const result = makeResult({ count: 3, nextCursor: cursor(3) })
+    const { rerender } = render(panel(ready(result), onLoadMore))
+
+    scrollTriggerIntoView()
+    rerender(panel({ status: 'error', result, error: 'boom' }, onLoadMore))
+    scrollTriggerIntoView()
+
+    expect(onLoadMore).toHaveBeenCalledTimes(1)
+  })
+
+  // The button is the documented escape hatch from the state above.
+  it('still fetches a failed page when the button is pressed', () => {
+    const onLoadMore = vi.fn()
+    const result = makeResult({ count: 3, nextCursor: cursor(3) })
+    const { rerender } = render(panel(ready(result), onLoadMore))
+
+    scrollTriggerIntoView()
+    rerender(panel({ status: 'error', result, error: 'boom' }, onLoadMore))
+    fireEvent.click(screen.getByRole('button', { name: /Load more commits/ }))
+
+    expect(onLoadMore).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not fetch while a page is already in flight', () => {
+    const onLoadMore = vi.fn()
+    const result = makeResult({ count: 3, nextCursor: cursor(3) })
+    render(panel({ status: 'refreshing', result }, onLoadMore))
+
+    scrollTriggerIntoView()
+
+    expect(onLoadMore).not.toHaveBeenCalled()
+  })
+
+  // Why: a replaced list is a different walk. Its first cursor can repeat one already spent on the
+  // walk it replaced, and holding that record would leave auto-loading dead after every refresh.
+  it('auto-loads again after a refresh replaces the list', () => {
+    const onLoadMore = vi.fn()
+    const { rerender } = render(
+      panel(ready(makeResult({ count: 3, nextCursor: cursor(3) })), onLoadMore)
+    )
+
+    scrollTriggerIntoView()
+    expect(onLoadMore).toHaveBeenCalledTimes(1)
+
+    // Same cursor as the first page: a refresh that landed on the same HEAD.
+    rerender(
+      panel(
+        ready(makeResult({ count: 3, nextCursor: cursor(3), continuedCursor: false })),
+        onLoadMore
+      )
+    )
+    scrollTriggerIntoView()
+
+    expect(onLoadMore).toHaveBeenCalledTimes(2)
+  })
+
+  it('stops when the host reports nothing older', () => {
+    const onLoadMore = vi.fn()
+    render(panel(ready(makeResult({ count: 3 })), onLoadMore))
+
+    expect(observers.filter((entry) => !entry.disconnected)).toHaveLength(0)
+    expect(screen.queryByRole('button', { name: /Load more commits/ })).toBeNull()
+    expect(onLoadMore).not.toHaveBeenCalled()
+  })
+
+  // Why: a host too old to page still reports hasMore but echoes no cursor. Auto-loading there
+  // would reissue page one forever.
+  it('does not auto-load when the host echoed no cursor', () => {
+    const onLoadMore = vi.fn()
+    const result = { ...makeResult({ count: 3 }), hasMore: true }
+    render(panel(ready(result), onLoadMore))
+
+    expect(observers.filter((entry) => !entry.disconnected)).toHaveLength(0)
+    expect(onLoadMore).not.toHaveBeenCalled()
+  })
+
+  it('leaves the manual button working where IntersectionObserver is unavailable', () => {
+    const onLoadMore = vi.fn()
+    ;(globalThis as { IntersectionObserver?: unknown }).IntersectionObserver = undefined
+    render(panel(ready(makeResult({ count: 3, nextCursor: cursor(3) })), onLoadMore))
+
+    fireEvent.click(screen.getByRole('button', { name: /Load more commits/ }))
+
+    expect(onLoadMore).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/right-sidebar/GitHistoryPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHistoryPanel.tsx
@@ -13,6 +13,7 @@ import {
 import { GitHistoryRow } from './GitHistoryRow'
 import { GitHistoryCommitFiles } from './GitHistoryCommitFiles'
 import { useGitHistoryCommitExpansion } from './useGitHistoryCommitExpansion'
+import { useGitHistoryAutoLoad } from './useGitHistoryAutoLoad'
 import { GitHistoryVirtualRows } from './git-history-virtual-rows'
 import {
   GitHistoryCommitContextMenu,
@@ -96,12 +97,25 @@ export function GitHistoryPanel({
   const [panelHeight, setPanelHeight] = useState(DEFAULT_GIT_HISTORY_PANEL_HEIGHT)
   // Why: state, not a ref — the virtualizer must re-run once the scroller element attaches.
   const [historyScrollElement, setHistoryScrollElement] = useState<HTMLDivElement | null>(null)
+  // Why: state for the same reason — the observer has nothing to watch until the button mounts,
+  // which happens after the first page decides there is more to load.
+  const [loadMoreTrigger, setLoadMoreTrigger] = useState<HTMLButtonElement | null>(null)
   const resizeSessionRef = useRef<GitHistoryResizeSession | null>(null)
 
   const { expanded, filesByCommit, toggleExpand } = useGitHistoryCommitExpansion({
     result,
     worktreeId,
     onLoadCommitFiles
+  })
+
+  // Scrolling to the bottom fetches the next page on its own; the button stays for keyboard use,
+  // for a page that failed, and for anywhere IntersectionObserver is unavailable.
+  useGitHistoryAutoLoad({
+    trigger: loadMoreTrigger,
+    scrollElement: historyScrollElement,
+    result,
+    enabled: canLoadMore && !loading,
+    onLoadMore: () => onLoadMore?.()
   })
 
   const stopResize = useCallback((): void => {
@@ -354,6 +368,7 @@ export function GitHistoryPanel({
           {canLoadMore && (
             <div className="flex justify-center px-6 py-1.5">
               <Button
+                ref={setLoadMoreTrigger}
                 type="button"
                 variant="ghost"
                 size="xs"
@@ -361,6 +376,7 @@ export function GitHistoryPanel({
                 disabled={loading}
                 onClick={onLoadMore}
               >
+                {loading && <RefreshCw className="size-3 animate-spin" />}
                 {translate(
                   'auto.components.right.sidebar.GitHistoryPanel.loadMoreCommits',
                   'Load more commits'

--- a/src/renderer/src/components/right-sidebar/useGitHistoryAutoLoad.ts
+++ b/src/renderer/src/components/right-sidebar/useGitHistoryAutoLoad.ts
@@ -1,0 +1,97 @@
+import { useEffect, useRef } from 'react'
+import type { GitHistoryCursor, GitHistoryResult } from '../../../../shared/git-history'
+
+// Why: start the next page while the trigger is still below the fold rather than once it lands on
+// it. A page costs one `git log` spawn, and that spawn is not free everywhere — measured at ~122ms
+// on Windows with Defender resident, against ~10ms on Linux — so the fetch needs a head start to
+// stay invisible. Roughly nine collapsed rows of runway at the panel's 26px row height.
+export const GIT_HISTORY_AUTO_LOAD_MARGIN_PX = 240
+
+// Identifies the page a cursor would fetch. Auto-loading the same one twice is the failure mode
+// that matters: the trigger stays mounted while a request is in flight and after one fails.
+function gitHistoryCursorKey(cursor: GitHistoryCursor | undefined): string | undefined {
+  return cursor ? `${cursor.anchor}:${cursor.loaded}` : undefined
+}
+
+/**
+ * Fetches the next page of commits when the load trigger scrolls near the bottom of the panel.
+ *
+ * The trigger stays a real button, and this only presses it: keyboard users, a host too old to page,
+ * and any environment without `IntersectionObserver` all keep the manual path unchanged.
+ *
+ * Auto-loading is allowed once per cursor. That single rule covers both hazards, which are the same
+ * hazard seen twice — the trigger is still mounted and still in view after a page lands, and again
+ * after a page fails. Without it the panel would either page to the end of history unattended or
+ * retry a failing page for as long as it stayed on screen.
+ *
+ * Every landed page re-subscribes rather than re-reading a remembered visibility. `isIntersecting`
+ * is only ever known from the last entry the observer delivered, and a page that pushes the trigger
+ * out of view has not delivered one yet at the moment the page lands — acting on the remembered
+ * value there would fetch a page the user never scrolled to. Re-observing answers the question
+ * against the live layout instead. When the trigger genuinely is still in view — a short list, or a
+ * page that added no height — the fresh entry says so and the next page loads, which is the point.
+ */
+export function useGitHistoryAutoLoad({
+  trigger,
+  scrollElement,
+  result,
+  enabled,
+  onLoadMore
+}: {
+  // The "Load more" button. Observing the real control means auto-loading and clicking cannot
+  // disagree about when another page is available.
+  trigger: HTMLElement | null
+  scrollElement: HTMLElement | null
+  // The page on screen. Its identity — not just the cursor it carries — is what marks a new page,
+  // because a refresh can land the very same cursor the previous walk ended on.
+  result: GitHistoryResult | undefined
+  // False while a request is in flight or when there is nothing further to load.
+  enabled: boolean
+  onLoadMore: () => void
+}): void {
+  const cursorKey = gitHistoryCursorKey(result?.nextCursor)
+  const autoLoadedKeyRef = useRef<string | undefined>(undefined)
+
+  // Read through a ref so the observer subscribes on page and layout inputs alone. Re-subscribing
+  // on every render would make the observer's first entry, not the user's scrolling, decide when
+  // to fetch.
+  const loadIfDueRef = useRef<() => void>(() => {})
+  loadIfDueRef.current = () => {
+    if (!enabled || !cursorKey || autoLoadedKeyRef.current === cursorKey) {
+      return
+    }
+    autoLoadedKeyRef.current = cursorKey
+    onLoadMore()
+  }
+
+  // Why: a replaced list is a different walk, and the cursor it hands back can repeat one already
+  // spent on the walk it replaced — a refresh landing on the same HEAD produces exactly that.
+  // Keying the reset on the cursor would miss that case and leave auto-loading dead until the user
+  // pressed the button once by hand, so it keys on the page itself.
+  useEffect(() => {
+    if (!result?.continuedCursor) {
+      autoLoadedKeyRef.current = undefined
+    }
+  }, [result])
+
+  useEffect(() => {
+    // Why: degrade to the manual button rather than throw. This runs in the renderer, but the
+    // panel is also mounted under test environments that ship no IntersectionObserver.
+    if (!trigger || !scrollElement || typeof IntersectionObserver === 'undefined') {
+      return
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.at(-1)?.isIntersecting) {
+          loadIfDueRef.current()
+        }
+      },
+      { root: scrollElement, rootMargin: `0px 0px ${GIT_HISTORY_AUTO_LOAD_MARGIN_PX}px 0px` }
+    )
+    observer.observe(trigger)
+    return () => {
+      observer.disconnect()
+    }
+    // Why `result` is a dependency: see the re-subscribe note above.
+  }, [trigger, scrollElement, result])
+}


### PR DESCRIPTION
## ELI5

The Commits list can now reach old commits, but only one button press at a time — fifty rows per
click. Scrolling to the bottom now just keeps going: the next page starts loading before you get
there, so the list grows under your cursor instead of stopping and waiting to be asked.

## What Changed

- Scrolling near the bottom of the Commits panel fetches the next page. The fetch starts **240px
  before** the trigger is reached, so the page is usually already in place by the time you would
  have seen a gap.
- The **"Load more commits" button stays, and is the thing being observed**. Auto-loading and
  clicking cannot disagree about when another page exists, because they read the same control.
  Keyboard users, hosts too old to page, and any environment without `IntersectionObserver` keep
  the manual path exactly as it is today.
- Auto-loading is allowed **once per cursor**.
- The button shows a spinner while a page is in flight.

No change to the paging mechanism, the request shape, or any transport. This only decides *when*
the request #14405 already makes gets made.

## Why

Follow-up to #14405. That PR made the whole history reachable; this one makes reaching it not feel
like work. At the 50-row page size #14405 sets, commit 2,000 is forty deliberate clicks away.

The prefetch margin is not decorative, and the number came from measurement rather than taste. A
page costs one `git log` spawn, and a spawn is not free everywhere:

| | per `git log` spawn |
|---|---|
| Windows 11, Defender resident | **~122 ms** (measured over 201 spawns) |
| Linux / macOS | ~5–15 ms |

On Windows the bare floor — `git --version`, which opens no repository — is 218 ms median. So the
dominant cost of a page there is process spawn, not the walk, and a fetch that starts only once the
trigger is on screen lands visibly late. 240px is roughly nine collapsed rows of runway at the
panel's 26px row height.

### The once-per-cursor rule

This is the part worth reviewing closely. The trigger is still mounted and still in view in two
different situations, and both are hazards:

- **After a page lands.** Without the rule the panel would page to the end of history unattended.
- **After a page fails.** A failed page leaves the cursor untouched, so the trigger would reissue
  the same failing request for as long as it stayed on screen.

One rule covers both, because they are the same hazard seen twice. A page that *replaces* the list
rather than extending it clears the record — a refresh can land the very same cursor the previous
walk ended on, and keying the reset on the cursor alone would leave auto-loading dead until the user
pressed the button once by hand. It keys on the page instead.

### Why every landed page re-subscribes

`isIntersecting` is only ever known from the last entry the observer delivered. When a page pushes
the trigger out of view, no entry has been delivered yet at the moment the page lands — so acting on
the remembered value there would fetch a page the user never scrolled to. Re-observing asks the live
layout instead. When the trigger genuinely is still in view — a short list, or a page that added no
height — the fresh entry says so and the next page loads, which is the point.

## Linked Issue

Follow-up to #14405, which fixes #14224.

This PR does not close #14224 on its own; #14405 does. It changes how the paging that PR added is
driven, and should land after it.

<!-- REVIEW NOTE: base branch is brennanb2025/git-history-cursor-paging, not main, so the diff
     shows only this change. Retarget to main once #14405 merges. -->

## Visual Proof

Both clips are the same panel on the same 8,622-commit repository, recorded on Windows 11. Watch the
count beside the `COMMITS` header.

| | Before — this branch as it stands | After — with this PR |
|---|---|---|
| Clicks | 2 | **0** |
| Elapsed | 17.3s | 13.5s |
| Reached | 50 → 150 | 50 → **250** |

Scrolling alone moves the count in the second clip and does nothing in the first. The after clip also
passes 200 without stopping, which is the ceiling this branch removed.

**Before** — scrolling reaches the bottom and stops; each further 50 rows needs the button:

https://github.com/user-attachments/assets/3bda5c8c-ccb9-4c51-9184-704debd102b9




**After** — scrolling only, no click:


https://github.com/user-attachments/assets/6935b5ba-7eab-48b4-a4e1-9c14bb7f8e5d



## Testing

Verified in the running app on **Windows 11** against a repository with 8,622 commits: scrolling
alone grows the COMMITS header count past the old stopping point, with no click.

New unit coverage in `GitHistoryPanel.auto-load.test.tsx` (11 tests), driving a stubbed
`IntersectionObserver` because happy-dom performs no layout and a real one would report no
intersection, passing every assertion vacuously:

- fetches when the trigger scrolls near the bottom
- observes the panel's own scroller, with a non-zero bottom margin
- does not fetch the same page twice while it is still on screen
- keeps fetching as each page lands and the trigger stays in view
- does not retry a page that failed — and the button still does
- does not fetch while a page is in flight
- auto-loads again after a refresh replaces the list
- stops when the host reports nothing older
- does not auto-load when the host echoed no cursor
- leaves the manual button working where `IntersectionObserver` is unavailable

Checks run locally on Windows: `pnpm typecheck` clean, `oxlint` clean, `pnpm build:desktop` exit 0,
and the `right-sidebar` suite at 1,891 passing.

Two notes on the local run, both pre-existing on `main` and unrelated to this change:

1. `pnpm lint` stops at `verify:skill-bundle-manifest` on a stock Windows checkout. With
   `core.autocrlf=true` (the Git for Windows default) the generated JSON under `resources/skills/`
   is checked out CRLF while the generator emits LF, so the byte comparison fails. The same cause
   fails `SourceControl.host-context-boundary.test.ts`, which asserts on `\n`-joined source text —
   re-checking that one file out as LF turns it from 1 failed / 2 passed into 3 passed. Happy to
   open a separate PR adding these paths to `.gitattributes`, alongside the existing
   `/resources/plugins/** text eol=lf` entry that exists for exactly this reason.
2. `pnpm test` and `pnpm dev` cannot start on Windows without Visual Studio Build Tools, because
   `ensure-native-runtime` rebuilds `windows-native-registry` through node-gyp. The module is an
   optional dependency behind a lazy loader, and the app runs correctly with the gate bypassed.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Not exercised on a live SSH/remote host. The auto-load path issues the identical request the button
already issues, so no transport behavior changes — but a real remote run is still worth doing, and
the once-per-cursor rule matters more there, where a slow link keeps the trigger on screen longer.

## AI Disclosure

Claude Opus 5 via Claude Code was used for implementation, tests, the Windows measurements, and
review. I verified it in the running app on Windows 11 and recorded the clips.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Security**: no new input crosses a process boundary. This is renderer view logic observing an
  element the panel already renders; no argv, no path, no request field is constructed here.
- **Cross-platform**: no platform-dependent code. Verified on Windows 11; `IntersectionObserver` is
  a Chromium built-in, and the absence path is covered by a test.
- **Remote SSH**: unchanged transport — the same request the button already sends. Higher latency is
  where the prefetch margin earns the most, and the once-per-cursor rule is what keeps a slow link
  from accumulating duplicate in-flight pages.
- **Backwards compatibility**: a host too old to page echoes no cursor, so `canLoadMore` is false,
  no button renders and nothing is observed. Behavior on those hosts is unchanged.
- **Agents and integrations**: nothing here is agent- or provider-specific. The panel reads history
  through the same executor on every host, and no GitHub/GitLab/Gitea/Linear path is touched. The
  change sits strictly between a scroll position and a callback the panel already had.
- **Mobile**: untouched. The projected web client inherits the renderer change unmodified.
- **UI quality**: the only new visual is a spinner inside the existing button, using the icon and
  `text-muted-foreground` token the panel header already uses, so it follows the styleguide by
  reuse rather than by new styling. Verified in dark theme on Windows; light theme was not exercised
  on a device, though no color is introduced that is not already a token.
- **Performance**: one `IntersectionObserver` on one element. No scroll listener, no polling, no
  timer. It re-subscribes once per landed page, which is once per 50 commits.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

