### PR TITLE
fix(workspace): persist active workspace identity

### DIFF
--- a/src/renderer/src/lib/workspace-session-patch.test.ts
+++ b/src/renderer/src/lib/workspace-session-patch.test.ts
@@ -81,6 +81,25 @@ function createRepo(id: string, connectionId: string | null): Repo {
 }
 
 describe('buildWorkspaceSessionPatch', () => {
+  it('persists active workspace identity changes together', () => {
+    const patch = buildWorkspaceSessionPatch(
+      createSnapshot({
+        activeRepoId: 'repo-2',
+        activeWorkspaceKey: 'worktree:wt-2',
+        activeWorkspaceExecutionHostId: 'runtime:host-2',
+        activeWorktreeId: 'wt-2'
+      }),
+      ['activeRepoId', 'activeWorkspaceKey', 'activeWorkspaceExecutionHostId', 'activeWorktreeId']
+    )
+
+    expect(patch).toEqual({
+      activeRepoId: 'repo-2',
+      activeWorkspaceKey: 'worktree:wt-2',
+      activeWorkspaceExecutionHostId: 'runtime:host-2',
+      activeWorktreeId: 'wt-2'
+    })
+  })
+
   it('returns only the direct key for active tab changes', () => {
     const patch = buildWorkspaceSessionPatch(createSnapshot({ activeTabId: 'tab-2' }), [
       'activeTabId'

--- a/src/renderer/src/lib/workspace-session-patch.ts
+++ b/src/renderer/src/lib/workspace-session-patch.ts
@@ -51,6 +51,12 @@ export function buildWorkspaceSessionPatch(
   if (changed.has('activeRepoId')) {
     patch.activeRepoId = snapshot.activeRepoId
   }
+  if (changed.has('activeWorkspaceKey')) {
+    patch.activeWorkspaceKey = snapshot.activeWorkspaceKey
+  }
+  if (changed.has('activeWorkspaceExecutionHostId')) {
+    patch.activeWorkspaceExecutionHostId = snapshot.activeWorkspaceExecutionHostId
+  }
   if (changed.has('activeWorktreeId')) {
     patch.activeWorktreeId = snapshot.activeWorktreeId
   }

--- a/src/renderer/src/store/slices/worktrees-workspace-selection-state.test.ts
+++ b/src/renderer/src/store/slices/worktrees-workspace-selection-state.test.ts
@@ -112,6 +112,24 @@ describe('setActiveWorktree focus handling', () => {
       }
     }
   })
+
+  it('repairs a stale workspace key when reactivating the current worktree', () => {
+    const store = createTestStore()
+    const worktree = makeWorktree({ id: 'repo1::/path/current', repoId: 'repo1' })
+    store.setState({
+      worktreesByRepo: { repo1: [worktree] },
+      activeWorktreeId: worktree.id,
+      activeWorkspaceKey: 'worktree:repo1::/path/stale',
+      activeWorkspaceExecutionHostId: null,
+      activeTabTypeByWorktree: { [worktree.id]: 'terminal' },
+      rightSidebarExplorerView: 'files',
+      everActivatedWorktreeIds: new Set([worktree.id])
+    } as unknown as Partial<AppState>)
+
+    store.getState().setActiveWorktree(worktree.id)
+
+    expect(store.getState().activeWorkspaceKey).toBe(worktreeWorkspaceKey(worktree.id))
+  })
 })
 
 describe('markWorktreeVisited', () => {

--- a/src/renderer/src/store/slices/worktrees/session/set-active-worktree.ts
+++ b/src/renderer/src/store/slices/worktrees/session/set-active-worktree.ts
@@ -78,6 +78,9 @@ export function createSetActiveWorktree(
         }
       }
 
+      const nextActiveWorkspaceKey = isWorkspaceKey(worktreeId)
+        ? worktreeId
+        : worktreeWorkspaceKey(worktreeId)
       const worktree = findKnownWorktreeById(s, worktreeId, executionHostId)
       shouldClearUnread = Boolean(worktree?.isUnread)
       const {
@@ -157,6 +160,7 @@ export function createSetActiveWorktree(
           : { ...s.activeTabTypeByWorktree, [worktreeId]: activeTabType }
       const hasStateChange =
         s.activeWorktreeId !== worktreeId ||
+        s.activeWorkspaceKey !== nextActiveWorkspaceKey ||
         s.activeWorkspaceExecutionHostId !== (executionHostId ?? null) ||
         // Why: a pending-creation panel can show over the prior worktree; a non-null activePendingCreationId counts as a change.
         s.activePendingCreationId !== null ||
@@ -183,9 +187,7 @@ export function createSetActiveWorktree(
         ...reconciliation?.patch,
         activeRepoId: nextActiveRepoId,
         activeWorktreeId: worktreeId,
-        activeWorkspaceKey: isWorkspaceKey(worktreeId)
-          ? worktreeId
-          : worktreeWorkspaceKey(worktreeId),
+        activeWorkspaceKey: nextActiveWorkspaceKey,
         activeWorkspaceExecutionHostId: executionHostId ?? null,
         activePendingCreationId: null,
         activeFileId,


### PR DESCRIPTION
## Summary

- persist `activeWorkspaceKey` and `activeWorkspaceExecutionHostId` in incremental workspace-session patches
- make same-worktree activation repair a stale workspace key instead of taking the no-op path
- cover both persistence and self-healing with focused regression tests

## Root cause

The session subscriber treated both workspace identity fields as relevant, but `buildWorkspaceSessionPatch` never copied them into the incremental patch. That allowed `activeRepoId` and `activeWorktreeId` to advance while `activeWorkspaceKey` remained on the previous project. The sidebar prefers the scoped workspace key, so reveal and highlight could target the wrong project even though the worktrees still existed.

The activation no-op guard also omitted the expected workspace key, preventing a repeated activation from repairing already-persisted inconsistent state.

## Validation

- `vitest run` for `workspace-session-patch.test.ts` and `worktrees.test.ts`: 297 passed
- Web TypeScript check
- Oxlint and React Doctor lint for all changed files
- Oxfmt check
- max-lines ratchet
- repository `lint-staged` pre-commit checks

Fixes #14474
