### PR TITLE
fix(windows): unblock pnpm lint and a source assertion on a CRLF checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,6 +12,9 @@
 /src/cli/bundled-skill-guides.ts text eol=lf
 # Bundled plugin trees are byte-hashed; CRLF checkout would break the pinned hash.
 /resources/plugins/** text eol=lf
+# Generated skill artifacts are compared to freshly serialized JSON as exact text, so a
+# CRLF checkout fails verify:skill-bundle-manifest on Windows.
+/resources/skills/*.json text eol=lf
 # pnpm hashes every patch byte-for-byte, so a CRLF checkout breaks the install.
 /config/patches/*.patch -text
 # The xterm bundle hunks also make a diff nobody can read; review the hand-written

--- a/src/renderer/src/components/right-sidebar/SourceControl.host-context-boundary.test.ts
+++ b/src/renderer/src/components/right-sidebar/SourceControl.host-context-boundary.test.ts
@@ -2,26 +2,20 @@ import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
-const WORKTREE_CONTEXT_SOURCE = readFileSync(
-  join(__dirname, 'source-control/listing/use-worktree-context.ts'),
-  'utf8'
+// Why normalize: the assertions below span lines, and every file read here is checked out CRLF
+// wherever `core.autocrlf` is on — the Git for Windows default. What is under test is the code
+// shape, not the checkout's line endings, so read these the way the other platforms see them.
+function readSource(relativePath: string): string {
+  return readFileSync(join(__dirname, relativePath), 'utf8').replaceAll('\r\n', '\n')
+}
+
+const WORKTREE_CONTEXT_SOURCE = readSource('source-control/listing/use-worktree-context.ts')
+const PR_GENERATION_SOURCE = readSource('source-control/review/use-pull-request-generation.ts')
+const CREATE_REVIEW_COMPOSER_SOURCE = readSource(
+  'source-control/review/use-create-review-composer.ts'
 )
-const PR_GENERATION_SOURCE = readFileSync(
-  join(__dirname, 'source-control/review/use-pull-request-generation.ts'),
-  'utf8'
-)
-const CREATE_REVIEW_COMPOSER_SOURCE = readFileSync(
-  join(__dirname, 'source-control/review/use-create-review-composer.ts'),
-  'utf8'
-)
-const STATUS_REFRESH_SOURCE = readFileSync(
-  join(__dirname, 'source-control/sync/use-status-refresh.ts'),
-  'utf8'
-)
-const BASE_REF_DEFAULT_SOURCE = readFileSync(
-  join(__dirname, 'source-control/sync/use-base-ref-default.ts'),
-  'utf8'
-)
+const STATUS_REFRESH_SOURCE = readSource('source-control/sync/use-status-refresh.ts')
+const BASE_REF_DEFAULT_SOURCE = readSource('source-control/sync/use-base-ref-default.ts')
 
 function sourceBetween(source: string, startPattern: string, endPattern: string): string {
   const start = source.indexOf(startPattern)
@@ -65,10 +59,7 @@ describe('SourceControl host-context boundaries', () => {
     )
     expect(composerCall).toContain('settings: activeRepoSettings')
 
-    const hookSource = readFileSync(
-      join(__dirname, 'use-create-pull-request-field-generation.ts'),
-      'utf8'
-    )
+    const hookSource = readSource('use-create-pull-request-field-generation.ts')
     const requestContext = sourceBetween(hookSource, 'const requestContext = {', 'const seed = {')
     expect(requestContext).toContain('settings,')
     expect(requestContext).not.toContain('useAppStore.getState().settings')


### PR DESCRIPTION
## ELI5

On Windows, Git turns line endings into CRLF when it writes files out — that is the default and
nobody chooses it. Two things in this repo then compare text and find a difference that isn't really
there, so `pnpm lint` can never pass and one test always fails. This tells Git to leave those
particular files alone, and teaches the one test to ignore line endings.

## What Changed

- `.gitattributes` pins `resources/skills/*.json` to LF, next to the `/resources/plugins/**` entry
  that exists for the same reason.
- `SourceControl.host-context-boundary.test.ts` normalizes line endings when it reads its subject
  back off disk.

## Why

`core.autocrlf=true` is the Git for Windows default, so a stock clone lands the generated skill
artifacts with CRLF. `generate-skill-bundle-manifest.mjs` compares them to freshly serialized JSON as
exact text:

```js
const committedText = await readFile(filePath, 'utf8')
if (committedText !== serialized(value) && !tolerated?.(committedText, artifacts)) {
  stale.push(filePath)
}
```

`serialized()` emits `\n` and the checkout has `\r\n`, so the comparison cannot succeed and
`verify:skill-bundle-manifest` reports all three files stale. That is the fifth step of `pnpm lint`,
which CONTRIBUTING asks contributors to run before opening a PR — so on Windows that instruction
cannot be followed on a fresh clone. Running the generator "fixes" it and leaves three files dirty
in `git status` with an empty `git diff`, which is the tell that only line endings differ.

`.gitattributes` already carries this exact protection for `/resources/plugins/**`, with the comment
*"Bundled plugin trees are byte-hashed; CRLF checkout would break the pinned hash."* The generated
skill artifacts are the same class of file and were simply missed.

The test is a separate symptom of the same cause. It reads its subject back with `readFileSync` and
asserts on a string containing `\n`, so CRLF fails it. What that test is about is the code shape, not
the checkout's line endings, so it normalizes on read rather than being pinned by attribute — pinning
would mean renormalizing source, which is a much larger and more disruptive change than this bug
justifies.

**Deliberately not fixed here:** 17 other test files read repo source through
`readFileSync(join(__dirname, …))` the same way. Only this one asserts across a line break today, so
only this one fails. A shared source-reading helper would be the systemic fix and would touch all 18;
that seemed like the wrong thing to bundle into a bug fix. Happy to follow up if you want it.

## Linked Issue

Fixes #14479

## Visual Proof

`N/A` — no user-facing surface changes. This is a repository attribute and a test's file read.

## Testing

On Windows 11 (Git 2.54.0.windows.1, `core.autocrlf=true`, Node 24.15.0), from the failing state:

| | before | after |
|---|---|---|
| `pnpm lint` | fails at `verify:skill-bundle-manifest` | **exit 0** |
| `SourceControl.host-context-boundary.test.ts` | 1 failed / 2 passed | **3 passed** |

The test result above is with `SourceControl.tsx` still CRLF on disk, so it is the normalization
doing the work rather than a re-checkout.

`pnpm typecheck` also passes. `pnpm test` was not run end-to-end, because it cannot start on Windows
at all — `ensure-native-runtime` fails to rebuild `windows-native-registry` without Visual Studio
Build Tools, which is noted at the bottom of #14479. The affected test was run directly through
vitest instead. `pnpm build` is untouched by this change and was not re-run on this branch.

The attribute change takes effect on checkout, so an existing Windows working tree needs the three
files rewritten once (`rm resources/skills/*.json && git checkout -- resources/skills/`). Fresh
clones need nothing. Nothing changes for macOS or Linux — those checkouts were already LF, and the
committed bytes are unchanged, so this is a no-op there.

- [x] I manually tested these changes locally
- [ ] Automated tests added/updated, or explained why not below

No new test. The regression this prevents is a property of checkout configuration rather than of any
code path, so a test would have to reconfigure git and re-check out files inside the suite to
observe it. The `verify:skill-bundle-manifest` step already fails loudly when the property breaks —
it is what caught this.

## AI Disclosure

Claude Opus 5 via Claude Code was used to diagnose the cause, write the fix, and verify it on
Windows 11.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Security**: none. A Git attribute and a string normalization in a test.
- **Cross-platform**: this is the point of the change. macOS and Linux are unaffected — their
  checkouts were already LF and no committed bytes change.
- **Remote SSH / agents / integrations / mobile**: untouched. Nothing here runs at application
  runtime.
- **Backwards compatibility**: the committed content of the three JSON files is identical; only the
  bytes Git writes into a Windows working tree change.
- **Performance**: none.
- **UI quality**: N/A — no UI.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — `lint` and `typecheck` locally, the affected test directly; `test`/`build` left to CI, see Testing

