### PR TITLE
fix(ai-vault): restore Cursor workspace metadata

### DIFF
--- a/src/main/ai-vault/remote-session-scanner-cursor.ts
+++ b/src/main/ai-vault/remote-session-scanner-cursor.ts
@@ -1,0 +1,72 @@
+import { joinRemotePath, type RemoteHostPlatform } from '../ssh/ssh-remote-platform'
+import { throwIfAiVaultScanCancelled } from './ai-vault-scan-cancellation'
+import {
+  createCursorSessionMetadataResolver,
+  type CursorSessionMetadataResolver
+} from './session-scanner-cursor-metadata'
+import { parseCursorSessionContent } from './session-scanner-cursor-parser'
+import type {
+  RemoteSessionFilesystemProvider,
+  RemoteSessionSource
+} from './remote-session-scanner-types'
+
+export function createRemoteCursorSessionMetadataResolver(args: {
+  provider: RemoteSessionFilesystemProvider
+  hostPlatform: RemoteHostPlatform
+  signal?: AbortSignal
+}): CursorSessionMetadataResolver {
+  return createCursorSessionMetadataResolver({
+    listDirectories: async (path) => {
+      try {
+        throwIfAiVaultScanCancelled(args.signal)
+        const entries = await args.provider.readDir(path)
+        throwIfAiVaultScanCancelled(args.signal)
+        return entries.filter((entry) => entry.isDirectory).map((entry) => entry.name)
+      } catch {
+        throwIfAiVaultScanCancelled(args.signal)
+        return []
+      }
+    },
+    readTextFile: async (path) => {
+      try {
+        throwIfAiVaultScanCancelled(args.signal)
+        const read = await args.provider.readFile(path)
+        throwIfAiVaultScanCancelled(args.signal)
+        return read.isBinary ? null : read.content
+      } catch {
+        throwIfAiVaultScanCancelled(args.signal)
+        return null
+      }
+    },
+    joinPath: (...segments) =>
+      joinRemotePath(args.hostPlatform, segments[0] ?? '', ...segments.slice(1))
+  })
+}
+
+export function remoteCursorSessionSource(
+  remoteHome: string,
+  hostPlatform: RemoteHostPlatform
+): RemoteSessionSource {
+  const chatsDir = joinRemotePath(hostPlatform, remoteHome, '.cursor', 'chats')
+  return {
+    agent: 'cursor',
+    rootDir: joinRemotePath(hostPlatform, remoteHome, '.cursor', 'projects'),
+    extensions: ['.jsonl'],
+    filePredicate: (path) => path.replace(/\\/g, '/').split('/').includes('agent-transcripts'),
+    parse: async (file, content, context) => {
+      const session = await parseCursorSessionContent(
+        file,
+        content,
+        context.hostPlatform.os,
+        {
+          executionHostId: context.executionHostId,
+          executionHostPlatform: context.hostPlatform.os
+        },
+        context.signal
+      )
+      return session
+        ? context.cursorMetadataResolver.enrich(session, chatsDir, context.hostPlatform.os)
+        : null
+    }
+  }
+}

--- a/src/main/ai-vault/remote-session-scanner-sources.ts
+++ b/src/main/ai-vault/remote-session-scanner-sources.ts
@@ -10,7 +10,6 @@ import { parseMessageGraphSessionContent } from './session-scanner-graph-parsers
 import { parseClaudeSessionContent } from './session-scanner-primary-parsers'
 import { parseGeminiSessionContent } from './session-scanner-gemini-parsers'
 import { parseCopilotSessionContent } from './session-scanner-copilot-parser'
-import { parseCursorSessionContent } from './session-scanner-cursor-parser'
 import { parseHermesSessionContent } from './session-scanner-hermes-parser'
 import { partitionSubagentTranscriptPaths } from './session-scanner-subagent-transcripts'
 import { partitionOmpSubagentTranscriptPaths } from './session-scanner-omp-subagent-transcripts'
@@ -22,6 +21,7 @@ import type {
   RemoteScannerContext,
   RemoteSessionSource
 } from './remote-session-scanner-types'
+import { remoteCursorSessionSource } from './remote-session-scanner-cursor'
 
 type RemoteContentParser = (
   file: FileWithMtime,
@@ -69,14 +69,7 @@ export function remoteSessionSources(
       ['.copilot', 'session-state'],
       parseCopilotSessionContent
     ),
-    jsonlSource(
-      'cursor',
-      remoteHome,
-      hostPlatform,
-      ['.cursor', 'projects'],
-      parseCursorSessionContent,
-      (path) => remotePathSegments(path).includes('agent-transcripts')
-    ),
+    remoteCursorSessionSource(remoteHome, hostPlatform),
     source(
       'hermes',
       remoteHome,

--- a/src/main/ai-vault/remote-session-scanner-types.ts
+++ b/src/main/ai-vault/remote-session-scanner-types.ts
@@ -5,6 +5,7 @@ import type { RemoteHostPlatform } from '../ssh/ssh-remote-platform'
 import type { FileWithMtime } from './session-scanner-types'
 import type { SubagentTranscriptPartition } from './session-scanner-subagent-transcripts'
 import type { AntigravityWorkspaceResolver } from './session-scanner-antigravity-history'
+import type { CursorSessionMetadataResolver } from './session-scanner-cursor-metadata'
 
 export type RemoteScannerContext = {
   provider: RemoteSessionFilesystemProvider
@@ -13,6 +14,7 @@ export type RemoteScannerContext = {
   signal?: AbortSignal
   titleCaches: Map<string, Promise<Map<string, string>>>
   antigravityWorkspaceResolver: AntigravityWorkspaceResolver
+  cursorMetadataResolver: CursorSessionMetadataResolver
 }
 
 export type RemoteSessionFilesystemProvider = Pick<

--- a/src/main/ai-vault/remote-session-scanner.test.ts
+++ b/src/main/ai-vault/remote-session-scanner.test.ts
@@ -161,6 +161,47 @@ describe('scanRemoteAiVaultSessions', () => {
     })
   })
 
+  it('joins remote Cursor chat metadata to its transcript', async () => {
+    const provider = new MemoryRemoteProvider()
+    const sessionId = 'cursor-session'
+    provider.addFile(
+      `/home/ada/.cursor/projects/repo/agent-transcripts/${sessionId}/${sessionId}.jsonl`,
+      jsonLines([
+        { role: 'user', message: { content: [{ type: 'text', text: 'Remote Cursor title' }] } },
+        { role: 'assistant', message: { content: [{ type: 'text', text: 'Done' }] } }
+      ]),
+      40
+    )
+    provider.addFile(
+      `/home/ada/.cursor/chats/workspace-md5/${sessionId}/meta.json`,
+      JSON.stringify({
+        createdAtMs: Date.parse('2026-08-14T04:00:00.000Z'),
+        updatedAtMs: Date.parse('2026-08-14T04:05:00.000Z'),
+        cwd: '/home/ada/repo'
+      }),
+      41
+    )
+
+    const result = await scanRemoteAiVaultSessions({
+      provider,
+      executionHostId: 'ssh:dev-box',
+      remoteHome: '/home/ada',
+      hostPlatform: getRemoteHostPlatform('linux-x64')
+    })
+
+    expect(result.issues).toEqual([])
+    expect(result.sessions).toHaveLength(1)
+    expect(result.sessions[0]).toMatchObject({
+      agent: 'cursor',
+      sessionId,
+      title: 'Remote Cursor title',
+      cwd: '/home/ada/repo',
+      createdAt: '2026-08-14T04:00:00.000Z',
+      updatedAt: '2026-08-14T04:05:00.000Z',
+      resumeCommand: "cd '/home/ada/repo' && cursor-agent --resume 'cursor-session'"
+    })
+  })
+
   it('discovers Prime Agent transcripts under the remote home sessions root', async () => {
     const provider = new MemoryRemoteProvider()
     const fixture = primeAgentFixture()

--- a/src/main/ai-vault/remote-session-scanner.ts
+++ b/src/main/ai-vault/remote-session-scanner.ts
@@ -27,6 +27,7 @@ import { throwIfAiVaultScanCancelled } from './ai-vault-scan-cancellation'
 import { recordSessionScanIssue } from './session-scan-issues'
 import { limitRemoteScanFilesystemConcurrency } from './remote-session-scan-concurrency'
 import { aiVaultScanLimit } from '../../shared/ai-vault-session-depth'
+import { createRemoteCursorSessionMetadataResolver } from './remote-session-scanner-cursor'
 
 const REMOTE_SCAN_CONCURRENCY = 8
 const REMOTE_PARSE_CANDIDATE_MULTIPLIER = 2
@@ -70,6 +71,11 @@ export async function scanRemoteAiVaultSessions(args: {
         }
         return null
       }
+    }),
+    cursorMetadataResolver: createRemoteCursorSessionMetadataResolver({
+      provider,
+      hostPlatform: args.hostPlatform,
+      signal: args.signal
     })
   }
   const candidates = dedupeCodexRolloutFileAliases(

--- a/src/main/ai-vault/session-scanner-candidate-parser.ts
+++ b/src/main/ai-vault/session-scanner-candidate-parser.ts
@@ -1,0 +1,62 @@
+import type { ExecutionHostId } from '../../shared/execution-host'
+import type { AiVaultSession } from '../../shared/ai-vault-types'
+import type { AntigravityWorkspaceResolver } from './session-scanner-antigravity-history'
+import type { CursorSessionMetadataResolver } from './session-scanner-cursor-metadata'
+import { parseAgentSessionFileCached, type SessionParseStats } from './session-scanner-parse-cache'
+import type { SessionFileCandidate, SessionParseResult } from './session-scanner-types'
+import { errorMessage } from './session-scanner-values'
+
+export async function parseSessionCandidate(args: {
+  candidate: SessionFileCandidate
+  platform: NodeJS.Platform
+  executionHostId: ExecutionHostId
+  parseStats: SessionParseStats
+  antigravityWorkspaceResolver?: AntigravityWorkspaceResolver
+  cursorMetadataResolver?: CursorSessionMetadataResolver
+}): Promise<SessionParseResult> {
+  const { candidate } = args
+  try {
+    let session = await parseAgentSessionFileCached(candidate, args.platform, args.parseStats)
+    if (session && candidate.antigravityHistoryPath && args.antigravityWorkspaceResolver) {
+      session = await args.antigravityWorkspaceResolver.enrich(
+        session,
+        candidate.antigravityHistoryPath
+      )
+    }
+    if (session && candidate.cursorChatsDir && args.cursorMetadataResolver) {
+      session = await args.cursorMetadataResolver.enrich(
+        session,
+        candidate.cursorChatsDir,
+        args.platform
+      )
+    }
+    return {
+      session: session ? withSessionExecutionHost(session, args.executionHostId) : null,
+      issue: null
+    }
+  } catch (err) {
+    return {
+      session: null,
+      issue: {
+        executionHostId: args.executionHostId,
+        agent: candidate.agent,
+        path: candidate.file.path,
+        message: errorMessage(err)
+      }
+    }
+  }
+}
+
+function withSessionExecutionHost(
+  session: AiVaultSession,
+  executionHostId: ExecutionHostId
+): AiVaultSession {
+  if (session.executionHostId === executionHostId) {
+    return session
+  }
+  return {
+    ...session,
+    executionHostId,
+    id: `${executionHostId}:${session.agent}:${session.sessionId}:${session.filePath}`
+  }
+}

--- a/src/main/ai-vault/session-scanner-cursor-metadata.test.ts
+++ b/src/main/ai-vault/session-scanner-cursor-metadata.test.ts
@@ -1,0 +1,64 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { afterEach, describe, expect, it } from 'vitest'
+import { scanAiVaultSessions } from './session-scanner'
+import { isolatedScanRoots, jsonLines } from './session-scanner-test-fixtures'
+
+describe('Cursor session metadata', () => {
+  const rootsToRemove: string[] = []
+
+  afterEach(async () => {
+    await Promise.all(rootsToRemove.splice(0).map((root) => rm(root, { recursive: true })))
+  })
+
+  it('joins chat metadata to transcripts across workspaces', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-cursor-metadata-'))
+    rootsToRemove.push(root)
+    const roots = isolatedScanRoots(root)
+    const sessionId = '6542b450-4fdf-4899-bb8e-e8f6a220dd53'
+    const transcriptDir = join(
+      roots.cursorProjectsDir,
+      'f-codexFile-cursor',
+      'agent-transcripts',
+      sessionId
+    )
+    const metadataDir = join(roots.cursorChatsDir, 'workspace-md5', sessionId)
+    await Promise.all([
+      mkdir(transcriptDir, { recursive: true }),
+      mkdir(metadataDir, { recursive: true })
+    ])
+    await writeFile(
+      join(transcriptDir, `${sessionId}.jsonl`),
+      jsonLines([
+        { role: 'user', message: { content: [{ type: 'text', text: '你好' }] } },
+        { role: 'assistant', message: { content: [{ type: 'text', text: '已恢复' }] } }
+      ])
+    )
+    await writeFile(
+      join(metadataDir, 'meta.json'),
+      JSON.stringify({
+        schemaVersion: 1,
+        createdAtMs: Date.parse('2026-08-14T04:00:00.000Z'),
+        updatedAtMs: Date.parse('2026-08-14T04:05:00.000Z'),
+        hasConversation: true,
+        cwd: 'F:\\codexFile\\cursor反代'
+      })
+    )
+
+    const result = await scanAiVaultSessions({ ...roots, platform: 'win32' })
+
+    expect(result.issues).toEqual([])
+    expect(result.sessions).toHaveLength(1)
+    expect(result.sessions[0]).toMatchObject({
+      agent: 'cursor',
+      sessionId,
+      title: '你好',
+      cwd: 'F:\\codexFile\\cursor反代',
+      createdAt: '2026-08-14T04:00:00.000Z',
+      updatedAt: '2026-08-14T04:05:00.000Z',
+      resumeCommand:
+        'cmd /d /s /c "cd /d ""F:\\codexFile\\cursor反代"" && cursor-agent --resume ""6542b450-4fdf-4899-bb8e-e8f6a220dd53"""'
+    })
+  })
+})

--- a/src/main/ai-vault/session-scanner-cursor-metadata.ts
+++ b/src/main/ai-vault/session-scanner-cursor-metadata.ts
@@ -1,0 +1,131 @@
+import { readdir, readFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import type { AiVaultSession } from '../../shared/ai-vault-types'
+import { buildAiVaultResumeCommand } from '../../shared/ai-vault-resume-command'
+import { asRecord, extractString } from './session-scanner-values'
+
+type CursorSessionMetadata = {
+  cwd: string | null
+  createdAt: string | null
+  updatedAt: string | null
+}
+
+type CursorMetadataAccess = {
+  listDirectories(path: string): Promise<readonly string[]>
+  readTextFile(path: string): Promise<string | null>
+  joinPath(...segments: string[]): string
+}
+
+export type CursorSessionMetadataResolver = {
+  enrich(
+    session: AiVaultSession,
+    chatsDir: string,
+    platform: NodeJS.Platform
+  ): Promise<AiVaultSession>
+}
+
+export function createCursorSessionMetadataResolver(
+  access: CursorMetadataAccess
+): CursorSessionMetadataResolver {
+  const metadataPathsByRoot = new Map<string, Promise<Map<string, string>>>()
+
+  return {
+    async enrich(session, chatsDir, platform) {
+      if (session.agent !== 'cursor') {
+        return session
+      }
+      const paths = await metadataPaths(chatsDir)
+      const metadataPath = paths.get(session.sessionId)
+      if (!metadataPath) {
+        return session
+      }
+      const content = await access.readTextFile(metadataPath)
+      const metadata = content ? parseCursorSessionMetadata(content) : null
+      if (!metadata) {
+        return session
+      }
+      const cwd = session.cwd ?? metadata.cwd
+      return {
+        ...session,
+        cwd,
+        createdAt: session.createdAt ?? metadata.createdAt,
+        updatedAt: session.updatedAt ?? metadata.updatedAt,
+        resumeCommand: buildAiVaultResumeCommand({
+          agent: 'cursor',
+          sessionId: session.sessionId,
+          cwd,
+          platform
+        })
+      }
+    }
+  }
+
+  async function metadataPaths(chatsDir: string): Promise<Map<string, string>> {
+    let pending = metadataPathsByRoot.get(chatsDir)
+    if (!pending) {
+      pending = indexCursorMetadataPaths(chatsDir, access)
+      metadataPathsByRoot.set(chatsDir, pending)
+    }
+    return pending
+  }
+}
+
+export function createLocalCursorSessionMetadataResolver(): CursorSessionMetadataResolver {
+  return createCursorSessionMetadataResolver({
+    listDirectories: async (path) => {
+      try {
+        return (await readdir(path, { withFileTypes: true }))
+          .filter((entry) => entry.isDirectory())
+          .map((entry) => entry.name)
+      } catch {
+        return []
+      }
+    },
+    readTextFile: async (path) => {
+      try {
+        return await readFile(path, 'utf-8')
+      } catch {
+        return null
+      }
+    },
+    joinPath: join
+  })
+}
+
+export function cursorChatsDirForProjectsDir(projectsDir: string): string {
+  return join(dirname(projectsDir), 'chats')
+}
+
+async function indexCursorMetadataPaths(
+  chatsDir: string,
+  access: CursorMetadataAccess
+): Promise<Map<string, string>> {
+  const paths = new Map<string, string>()
+  for (const workspaceDir of await access.listDirectories(chatsDir)) {
+    const workspacePath = access.joinPath(chatsDir, workspaceDir)
+    for (const sessionId of await access.listDirectories(workspacePath)) {
+      paths.set(sessionId, access.joinPath(workspacePath, sessionId, 'meta.json'))
+    }
+  }
+  return paths
+}
+
+function parseCursorSessionMetadata(content: string): CursorSessionMetadata | null {
+  try {
+    const record = asRecord(JSON.parse(content) as unknown)
+    if (!record) {
+      return null
+    }
+    return {
+      cwd: extractString(record.cwd),
+      createdAt: timestampIso(record.createdAtMs),
+      updatedAt: timestampIso(record.updatedAtMs)
+    }
+  } catch {
+    return null
+  }
+}
+
+function timestampIso(value: unknown): string | null {
+  return typeof value === 'number' && Number.isFinite(value) ? new Date(value).toISOString() : null
+}

--- a/src/main/ai-vault/session-scanner-test-fixtures.ts
+++ b/src/main/ai-vault/session-scanner-test-fixtures.ts
@@ -9,6 +9,7 @@ export function isolatedScanRoots(root: string) {
     antigravityBrainDir: join(root, 'antigravity-brain'),
     copilotSessionsDir: join(root, 'copilot-sessions'),
     cursorProjectsDir: join(root, 'cursor-projects'),
+    cursorChatsDir: join(root, 'cursor-chats'),
     opencodeStorageDir: join(root, 'opencode-storage'),
     // Why: prevent the SQLite scanner from picking up the real
     // ~/.local/share/opencode/opencode.db during tests.

--- a/src/main/ai-vault/session-scanner-types.ts
+++ b/src/main/ai-vault/session-scanner-types.ts
@@ -18,6 +18,7 @@ export type AiVaultScanOptions = {
   antigravityBrainDir?: string
   copilotSessionsDir?: string
   cursorProjectsDir?: string
+  cursorChatsDir?: string
   opencodeStorageDir?: string
   // Why: OpenCode 1.17.x stores sessions in SQLite; tests inject a temp DB
   // here so they don't depend on the real ~/.local/share/opencode.
@@ -67,6 +68,7 @@ export type SessionFileCandidate = {
   file: FileWithMtime
   codexHome: string | null
   antigravityHistoryPath?: string
+  cursorChatsDir?: string
 }
 
 export type SessionFileDiscovery = {

--- a/src/main/ai-vault/session-scanner.ts
+++ b/src/main/ai-vault/session-scanner.ts
@@ -22,11 +22,7 @@ import {
   ensureSessionParseCacheLoaded,
   scheduleSessionParseCachePersist
 } from './session-parse-cache-persistence'
-import {
-  createSessionParseStats,
-  parseAgentSessionFileCached,
-  type SessionParseStats
-} from './session-scanner-parse-cache'
+import { createSessionParseStats, type SessionParseStats } from './session-scanner-parse-cache'
 import { recordSessionScanIssue } from './session-scan-issues'
 import { discoverInScopeClaudeFiles } from './session-scanner-scope-discovery'
 import {
@@ -36,12 +32,17 @@ import {
 import type {
   AiVaultScanOptions,
   SessionFileCandidate,
-  SessionFileDiscovery,
-  SessionParseResult
+  SessionFileDiscovery
 } from './session-scanner-types'
-import { clampPositiveInteger, errorMessage } from './session-scanner-values'
+import { clampPositiveInteger } from './session-scanner-values'
 import { throwIfAiVaultScanCancelled } from './ai-vault-scan-cancellation'
 import { DEFAULT_AI_VAULT_SCAN_LIMIT } from '../../shared/ai-vault-session-depth'
+import {
+  createLocalCursorSessionMetadataResolver,
+  cursorChatsDirForProjectsDir,
+  type CursorSessionMetadataResolver
+} from './session-scanner-cursor-metadata'
+import { parseSessionCandidate } from './session-scanner-candidate-parser'
 
 const SESSION_PARSE_CONCURRENCY = 8
 const SESSION_PARSE_CANDIDATE_MULTIPLIER = 2
@@ -75,6 +76,7 @@ export async function scanAiVaultSessions(
     const antigravityWorkspaceResolver = createAntigravityWorkspaceResolver(
       readLocalAntigravityHistory
     )
+    const cursorMetadataResolver = createLocalCursorSessionMetadataResolver()
     // Why: persisted entries must be seeded before any candidate is parsed, or
     // the cold scan gains nothing from the cache file (#9210).
     throwIfAiVaultScanCancelled(options.signal)
@@ -99,6 +101,10 @@ export async function scanAiVaultSessions(
               antigravityHistoryPath:
                 discovery.agent === 'antigravity'
                   ? antigravityHistoryPathForBrainDir(discovery.rootDir)
+                  : undefined,
+              cursorChatsDir:
+                discovery.agent === 'cursor'
+                  ? (options.cursorChatsDir ?? cursorChatsDirForProjectsDir(discovery.rootDir))
                   : undefined
             })
           )
@@ -120,7 +126,8 @@ export async function scanAiVaultSessions(
       issues,
       parseStats,
       signal: options.signal,
-      antigravityWorkspaceResolver
+      antigravityWorkspaceResolver,
+      cursorMetadataResolver
     })
 
     const cappedSessions = dedupeCodexSessionsBySessionId(parsedSessions)
@@ -230,6 +237,7 @@ async function parseSessionCandidates(args: {
   parseStats: SessionParseStats
   signal?: AbortSignal
   antigravityWorkspaceResolver?: AntigravityWorkspaceResolver
+  cursorMetadataResolver?: CursorSessionMetadataResolver
 }): Promise<AiVaultSession[]> {
   const sessions: AiVaultSession[] = []
   let index = 0
@@ -246,13 +254,14 @@ async function parseSessionCandidates(args: {
     const batch = args.candidates.slice(index, index + batchSize)
     const results = await Promise.all(
       batch.map((candidate) =>
-        parseSessionCandidate(
+        parseSessionCandidate({
           candidate,
-          args.platform,
-          args.executionHostId,
-          args.parseStats,
-          args.antigravityWorkspaceResolver
-        )
+          platform: args.platform,
+          executionHostId: args.executionHostId,
+          parseStats: args.parseStats,
+          antigravityWorkspaceResolver: args.antigravityWorkspaceResolver,
+          cursorMetadataResolver: args.cursorMetadataResolver
+        })
       )
     )
 
@@ -277,49 +286,6 @@ async function parseSessionCandidates(args: {
   // partial parse is never cached or returned as a complete scan.
   throwIfAiVaultScanCancelled(args.signal)
   return sessions
-}
-
-async function parseSessionCandidate(
-  candidate: SessionFileCandidate,
-  platform: NodeJS.Platform,
-  executionHostId: ExecutionHostId,
-  parseStats: SessionParseStats,
-  antigravityWorkspaceResolver?: AntigravityWorkspaceResolver
-): Promise<SessionParseResult> {
-  try {
-    let session = await parseAgentSessionFileCached(candidate, platform, parseStats)
-    if (session && candidate.antigravityHistoryPath && antigravityWorkspaceResolver) {
-      session = await antigravityWorkspaceResolver.enrich(session, candidate.antigravityHistoryPath)
-    }
-    return {
-      session: session ? withSessionExecutionHost(session, executionHostId) : null,
-      issue: null
-    }
-  } catch (err) {
-    return {
-      session: null,
-      issue: {
-        executionHostId,
-        agent: candidate.agent,
-        path: candidate.file.path,
-        message: errorMessage(err)
-      }
-    }
-  }
-}
-
-function withSessionExecutionHost(
-  session: AiVaultSession,
-  executionHostId: ExecutionHostId
-): AiVaultSession {
-  if (session.executionHostId === executionHostId) {
-    return session
-  }
-  return {
-    ...session,
-    executionHostId,
-    id: `${executionHostId}:${session.agent}:${session.sessionId}:${session.filePath}`
-  }
 }
 
 function canStopParsingSessions(


### PR DESCRIPTION
## Summary

- Restore Cursor CLI session workspace metadata by joining transcript session IDs with `.cursor/chats/*/*/meta.json`.
- Populate `cwd`, creation/update timestamps, and the workspace-aware resume command so workspace filters no longer hide Cursor sessions.
- Apply the same metadata enrichment to local, WSL-discovered, and remote SSH Cursor sessions.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` - code-quality, reliability, and max-lines checks pass; the command then stops because the current upstream skill bundle manifests are stale (`current-manifest.json`, `snapshot-registry.json`, and `release-mapping.json`).
- [x] `pnpm typecheck`
- [ ] `pnpm test` - blocked before Vitest starts because the local Windows install lacks a loadable `windows-native-registry` native binary for Node 25.2.1.
- [x] `pnpm build`
- [x] Added regression coverage for local multi-workspace metadata joins and remote SSH metadata joins. The focused suite passes: 3 files, 27 tests.

## AI Review Report

The final diff was reviewed after rebasing onto the current `main`. The review checked metadata precedence, missing or malformed metadata, duplicate session IDs, scan cancellation, scan issue reporting, and preservation of the newer Antigravity scan path. The rebase conflict in `session-scanner.ts` was resolved by retaining upstream's current issue recorder and Antigravity history reader while adding Cursor enrichment.

Cross-platform behavior was explicitly reviewed for Windows, macOS, Linux, WSL discovery, and remote SSH paths. Local paths use Node's platform path utilities, remote paths use Orca's `joinRemotePath`, and resume commands continue to use the existing `buildAiVaultResumeCommand` quoting behavior. No shortcuts, labels, renderer UI, or Electron IPC contracts are changed.

## Security Audit

The change only reads `meta.json` below Cursor's known chat history root. JSON parsing is guarded, unreadable or binary remote files are ignored, and metadata content is never executed. Resume commands are produced by Orca's existing escaped command builder. There are no auth, secret, dependency, network, database, or IPC changes. The only additional path traversal is bounded to directory entries returned below the configured Cursor chats root.

## Notes

Cursor transcripts remain the source of conversation content. Chat metadata only fills fields missing from the transcript parser, so existing parser values retain precedence.
