### PR TITLE
feat(browser): fence client host leases

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -2713,7 +2713,7 @@
           "command": "pnpm exec vitest run --config config/vitest.config.ts src/shared/browser-client-host-protocol.test.ts src/main/runtime/browser-host-lease-registry.test.ts src/main/runtime/rpc/methods/browser-client-host.test.ts src/main/runtime/rpc/methods/browser-network-tunnel.test.ts src/main/browser/paired-runtime-browser-host-lease.test.ts src/main/browser/paired-runtime-browser-network-route.test.ts src/main/runtime/browser-network-tunnel-paired-runtime.integration.test.ts src/main/browser/browser-network-tunnel-client.test.ts src/main/browser/browser-network-tunnel-session.test.ts src/main/browser/remote-browser-socks-server.test.ts",
           "result": "passed",
           "durationSeconds": 3.4,
-          "summary": "Ten files passed 55 lease, authority, placement, capability, route-generation, exact-revocation, lifecycle, flow-control, SOCKS, and real paired E2EE tests."
+          "summary": "Ten files passed 60 lease, authority, placement, capability, route-generation, adversarial-revocation, lifecycle, flow-control, SOCKS, and real paired E2EE tests."
         },
         {
           "date": "2026-08-13",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -2582,26 +2582,32 @@
         "client-hosted browser tunnel framing",
         "execution-host TCP credit flow",
         "main-owned loopback SOCKS5 route",
+        "runtime-owned browser-host lease and placement authority",
         "dedicated paired-runtime E2EE tunnel subscription"
       ],
       "platforms": ["macos", "linux", "windows"],
       "providers": ["local", "remote-runtime", "ssh", "wsl"],
       "coveredPlatforms": ["macos"],
       "coveredProviders": ["remote-runtime"],
-      "coverageNotes": "Deterministic protocol, injected-socket, and loopback-listener tests cover strict framing, remote-DNS targets, exact destination-write and source-consumption credit, bounded receive bytes and chunks, stale generations, retired stream IDs, half-close and close ordering, SOCKS CONNECT, bind/close races, listener wildcard normalization, unsupported commands, unavailable routes, and raw/terminal binary-handler isolation. An explicitly injected paired-runtime E2EE method carries SOCKS and HTTP bytes over one dedicated capability- and paired-device-bound socket to a native execution-host destination, then proves route close destroys the destination socket. The production method remains unregistered until lease and route authorization exists. SSH and WSL providers remain uncovered.",
+      "coverageNotes": "Deterministic protocol, registry, injected-socket, and loopback-listener tests cover strict framing, remote-DNS targets, exact destination-write and source-consumption credit, bounded receive bytes and chunks, authority epochs, exact host selection, monotonic host/page/route generations, connection-owned cleanup, exact client revocation, stale and replaced fences, retired stream IDs, half-close and close ordering, SOCKS CONNECT, bind/close races, listener wildcard normalization, unsupported commands, unavailable routes, and raw/terminal binary-handler isolation. Explicitly injected browser-host and paired-runtime tunnel methods lease one exact host, then carry SOCKS and HTTP bytes over a dedicated E2EE socket to the fenced native execution-host revision and prove route close destroys the destination socket. Both methods and capabilities remain disabled in production. SSH and WSL providers remain uncovered.",
       "motivatingLinks": [
         "https://linear.app/stably/issue/STA-4150/refactor-remote-browser-to-client-hosted-electron-webviews"
       ],
-      "invariant": "A client-hosted browser network route preserves destination names for execution-host DNS, admits only versioned bounded frames, replenishes credit only after destination writes settle, rejects stale or reused stream identities, and never falls back to desktop DNS or sockets when the selected route is unavailable. The local SOCKS endpoint accepts only loopback CONNECT and rejects unsupported commands.",
-      "oracle": "Encode and decode each tunnel boundary with exact generation, stream, length, opcode, payload, and credit assertions. Drive one injected destination through open, data, write settlement, receive-window exhaustion, half-close, duplicate stream, stale generation, and teardown. Drive a real loopback SOCKS client through greeting and domain CONNECT, assert the final connector receives the unchanged hostname, echo bytes through the injected route, normalize only listener wildcards, reject BIND, and return failure without another connection when the route is offline.",
+      "invariant": "A client-hosted browser network route exists only for an exact live server-owned browser-host lease, authority epoch, host generation, paired identity, execution-host revision, and server-owned route generation. Host selection never chooses arbitrarily, stale cleanup cannot remove a replacement, destination names remain unresolved until the execution host, credit returns only after writes settle, and route loss never falls back to desktop DNS or sockets. The local SOCKS endpoint accepts only loopback CONNECT and rejects unsupported commands.",
+      "oracle": "Attach two browser hosts and require unqualified selection to fail ambiguous while exact selection succeeds. Replace one same-device connection, require the old subscription and route to fence, then prove late old cleanup leaves the new generation live. Reject missing, stale, wrong-device, wrong-epoch, and wrong-execution-revision tunnel requests before binary registration. Drive the accepted lease through a real paired E2EE SOCKS-to-HTTP journey, then exercise exact frame, credit, half-close, stale-stream, remote-DNS, unsupported-command, offline, and teardown assertions.",
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/shared/browser-network-capabilities.test.ts src/shared/browser-network-tunnel-protocol.test.ts src/main/browser/browser-network-tunnel-session.test.ts src/main/browser/remote-browser-socks-server.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/main/browser/browser-network-tunnel-client.test.ts src/main/browser/paired-runtime-browser-network-route.test.ts src/main/runtime/runtime-binary-message-router.test.ts src/main/runtime/rpc/methods/browser-network-tunnel.test.ts src/main/runtime/browser-network-tunnel-paired-runtime.integration.test.ts",
+        "pnpm exec vitest run --config config/vitest.config.ts src/shared/browser-client-host-protocol.test.ts src/main/runtime/browser-host-lease-registry.test.ts src/main/runtime/rpc/methods/browser-client-host.test.ts src/main/runtime/rpc/methods/browser-network-tunnel.test.ts src/main/browser/paired-runtime-browser-host-lease.test.ts src/main/browser/paired-runtime-browser-network-route.test.ts src/main/runtime/browser-network-tunnel-paired-runtime.integration.test.ts src/main/browser/browser-network-tunnel-client.test.ts src/main/browser/browser-network-tunnel-session.test.ts src/main/browser/remote-browser-socks-server.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/shared/remote-runtime-client.test.ts"
       ],
       "testFiles": [
         "src/shared/browser-network-capabilities.test.ts",
+        "src/shared/browser-client-host-protocol.test.ts",
         "src/shared/browser-network-tunnel-protocol.test.ts",
+        "src/main/runtime/browser-host-lease-registry.test.ts",
+        "src/main/runtime/rpc/methods/browser-client-host.test.ts",
+        "src/main/browser/paired-runtime-browser-host-lease.test.ts",
         "src/main/browser/browser-network-tunnel-session.test.ts",
         "src/main/browser/browser-network-tunnel-client.test.ts",
         "src/main/browser/paired-runtime-browser-network-route.test.ts",
@@ -2612,6 +2618,23 @@
         "src/shared/remote-runtime-client.test.ts"
       ],
       "assertionRefs": [
+        {
+          "file": "src/main/runtime/browser-host-lease-registry.test.ts",
+          "assertions": [
+            "multiple live hosts require exact selection instead of first-connected routing",
+            "same-device replacement increments generation and fences the old connection",
+            "late cleanup cannot remove a newer lease or route generation",
+            "page placement generations are monotonic and stale lease authority is rejected"
+          ]
+        },
+        {
+          "file": "src/main/runtime/rpc/methods/browser-client-host.test.ts",
+          "assertions": [
+            "the control method stays out of production registration",
+            "only a negotiated authenticated paired-runtime connection receives a server-owned epoch and generation",
+            "connection cleanup releases the exact lease and replacement emits an epoch-and-generation-bound revocation"
+          ]
+        },
         {
           "file": "src/shared/browser-network-tunnel-protocol.test.ts",
           "assertions": [
@@ -2653,7 +2676,8 @@
           "file": "src/main/runtime/rpc/methods/browser-network-tunnel.test.ts",
           "assertions": [
             "the production RPC registry excludes the tunnel until route authorization exists",
-            "unnegotiated and mismatched browser hosts register no binary handler",
+            "unnegotiated, self-asserted, stale, and wrong-execution-revision browser hosts register no binary handler",
+            "the server allocates route generations and fences the replaced route",
             "subscription cleanup removes the exact connection-owned raw handler"
           ]
         },
@@ -2682,6 +2706,15 @@
         }
       ],
       "evidenceRuns": [
+        {
+          "date": "2026-08-14",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/shared/browser-client-host-protocol.test.ts src/main/runtime/browser-host-lease-registry.test.ts src/main/runtime/rpc/methods/browser-client-host.test.ts src/main/runtime/rpc/methods/browser-network-tunnel.test.ts src/main/browser/paired-runtime-browser-host-lease.test.ts src/main/browser/paired-runtime-browser-network-route.test.ts src/main/runtime/browser-network-tunnel-paired-runtime.integration.test.ts src/main/browser/browser-network-tunnel-client.test.ts src/main/browser/browser-network-tunnel-session.test.ts src/main/browser/remote-browser-socks-server.test.ts",
+          "result": "passed",
+          "durationSeconds": 3.4,
+          "summary": "Ten files passed 55 lease, authority, placement, capability, route-generation, exact-revocation, lifecycle, flow-control, SOCKS, and real paired E2EE tests."
+        },
         {
           "date": "2026-08-13",
           "runner": "local",
@@ -2712,7 +2745,7 @@
       ],
       "runtimeBudget": {
         "p95Seconds": 5,
-        "scope": "ten deterministic protocol, flow-control, loopback, RPC, and paired-runtime test files"
+        "scope": "deterministic lease, protocol, flow-control, loopback, RPC, and paired-runtime test files"
       },
       "flakeHistory": {
         "status": "unknown",
@@ -2720,14 +2753,13 @@
       },
       "redGreenEvidence": {
         "status": "partial",
-        "evidence": "The protocol and tunnel-session oracles fail on origin/main 3246b73add because the modules do not exist, then pass on the candidate. The same source checkout recorded the SOCKS and source-multiplexer oracles red before their implementations and green afterward. The real paired journey failed at the missing network.browserTunnel method before explicit test injection, then passed unchanged while the production registry remained closed. Mutation/revert evidence remains to be collected before promotion."
+        "evidence": "The protocol and tunnel-session oracles fail on origin/main 3246b73add because the modules do not exist, then pass on the candidate. The lease registry and control-client suites were recorded red at missing modules before implementation. The unchanged tunnel authorization oracle was behaviorally red because an authenticated socket could self-assert its paired device ID and received ready generation 7 without a lease; it is green after server-owned lease and route fencing. The real paired journey failed at the missing network.browserTunnel method before explicit test injection, then passed with an exact control lease while both production registries remained closed. Full mutation/revert evidence remains to be collected before promotion."
       },
       "performanceBudget": {
         "required": true,
         "evidence": "Data frames, send credit, pending bytes and chunk counts in both directions, streams, SOCKS handshake and pipelined application bytes are bounded. Credit returns only after the execution-host or browser-facing socket write settles, and the injected transport must explicitly accept each frame. Aggregate route, browser-host, and process ledgers plus drain-aware fair scheduling remain required before live tunnel advertisement."
       },
       "promotionCriteria": [
-        "Bind the method to a live browser-host lease, authority epoch, exact execution-host revision, and server-owned monotonic route generation before production registration.",
         "Add bounded pending-open admission and open-rate limits plus aggregate route, browser-host, and process memory ledgers with runtime-wide fair scheduling.",
         "Approve all same-host local processes and users as inside the desktop trust boundary or replace SOCKS no-auth with Chromium-compatible process isolation.",
         "Add old/new peer coverage to the dedicated paired-runtime binary tunnel journey.",
@@ -2740,7 +2772,7 @@
         "The loopback SOCKS endpoint uses Chromium-compatible no-auth and is not safe to activate until its desktop trust boundary is approved or isolated.",
         "SSH, WSL, browserless serve, Electron proxy policy, UDP denial, and desktop DNS/socket capture are not exercised."
       ],
-      "demotionRule": "Keep experimental or demote if a route can resolve names on the desktop, exceed a byte or stream bound, replenish credit before destination settlement, accept a stale generation or reused stream ID, expose the SOCKS listener off-loopback, accept BIND/UDP, or fall back when the selected route is unavailable."
+      "demotionRule": "Keep experimental or demote if a self-asserted or ambiguous host can receive a route, late cleanup can remove a replacement, a route can resolve names on the desktop, exceed a byte or stream bound, replenish credit before destination settlement, accept a stale generation or reused stream ID, expose the SOCKS listener off-loopback, accept BIND/UDP, or fall back when the selected route is unavailable."
     },
     {
       "id": "browser-stream.bounded-reconnect",

--- a/src/main/browser/browser-network-tunnel-client.ts
+++ b/src/main/browser/browser-network-tunnel-client.ts
@@ -50,6 +50,10 @@ export class BrowserNetworkTunnelClient {
     )
   }
 
+  get generation(): number {
+    return this.tunnelGeneration
+  }
+
   open(target: BrowserNetworkTunnelOpen): Promise<BrowserNetworkTunnelDuplex> {
     if (this.closed) {
       return Promise.reject(new Error('Browser tunnel is closed'))

--- a/src/main/browser/paired-runtime-browser-host-lease.test.ts
+++ b/src/main/browser/paired-runtime-browser-host-lease.test.ts
@@ -152,7 +152,98 @@ describe('PairedRuntimeBrowserHostLease', () => {
       expect.objectContaining({ message: 'Browser host lease revoked: replaced' })
     )
   })
+
+  it('rejects revocation before adopting lease authority', async () => {
+    const { callbacks, close } = await subscribeLease()
+    const lease = createLease()
+    const starting = lease.start()
+    await vi.waitFor(() => expect(callbacks.current).toBeDefined())
+
+    callbacks.current!.onResponse({
+      id: 'browser-host',
+      ok: true,
+      result: {
+        type: 'revoked',
+        authorityEpoch: 'epoch-a',
+        browserHostGeneration: 4,
+        reason: 'released'
+      },
+      _meta: { runtimeId: 'runtime-a' }
+    })
+
+    await expect(starting).rejects.toThrow('Invalid browser host lease revocation')
+    expect(close).toHaveBeenCalledOnce()
+  })
+
+  it.each([
+    ['wrong epoch', 'epoch-b', 4, 'replaced', 'Invalid browser host lease revocation'],
+    ['wrong generation', 'epoch-a', 5, 'released', 'Invalid browser host lease revocation'],
+    ['malformed reason', 'epoch-a', 4, 'unknown', 'Invalid browser host lease response']
+  ])(
+    'fails closed on %s after readiness',
+    async (_caseName, authorityEpoch, browserHostGeneration, reason, expectedError) => {
+      const { callbacks, close } = await subscribeLease()
+      const onError = vi.fn()
+      const lease = createLease({ onError })
+      const starting = lease.start()
+      await vi.waitFor(() => expect(callbacks.current).toBeDefined())
+      callbacks.current!.onResponse({
+        id: 'browser-host',
+        ok: true,
+        result: { type: 'ready', authorityEpoch: 'epoch-a', browserHostGeneration: 4 },
+        _meta: { runtimeId: 'runtime-a' }
+      })
+      await starting
+
+      callbacks.current!.onResponse({
+        id: 'browser-host',
+        ok: true,
+        result: { type: 'revoked', authorityEpoch, browserHostGeneration, reason },
+        _meta: { runtimeId: 'runtime-a' }
+      })
+
+      await vi.waitFor(() => expect(close).toHaveBeenCalledOnce())
+      expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: expectedError }))
+    }
+  )
+
+  it('keeps duplicate readiness and events after local close idempotent', async () => {
+    const { callbacks, close } = await subscribeLease()
+    const onError = vi.fn()
+    const lease = createLease({ onError })
+    const starting = lease.start()
+    await vi.waitFor(() => expect(callbacks.current).toBeDefined())
+    const ready = {
+      id: 'browser-host',
+      ok: true as const,
+      result: { type: 'ready', authorityEpoch: 'epoch-a', browserHostGeneration: 4 },
+      _meta: { runtimeId: 'runtime-a' }
+    }
+    callbacks.current!.onResponse(ready)
+    await starting
+    callbacks.current!.onResponse(ready)
+    await lease.close()
+    callbacks.current!.onClose?.()
+
+    expect(close).toHaveBeenCalledOnce()
+    expect(onError).not.toHaveBeenCalled()
+  })
 })
+
+async function subscribeLease(): Promise<{
+  callbacks: { current?: RemoteRuntimeSubscriptionCallbacks }
+  close: ReturnType<typeof vi.fn>
+}> {
+  const callbacks: { current?: RemoteRuntimeSubscriptionCallbacks } = {}
+  const close = vi.fn()
+  subscribeRemoteRuntimeRequestMock.mockImplementationOnce(
+    async (...args: unknown[]): Promise<RemoteRuntimeSubscription> => {
+      callbacks.current = args[4] as RemoteRuntimeSubscriptionCallbacks
+      return { requestId: 'browser-host', close, sendBinary: () => false }
+    }
+  )
+  return { callbacks, close }
+}
 
 function createLease(
   overrides: { onError?: (error: Error) => void } = {}

--- a/src/main/browser/paired-runtime-browser-host-lease.test.ts
+++ b/src/main/browser/paired-runtime-browser-host-lease.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { PairingOffer } from '../../shared/pairing'
+import { BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY } from '../../shared/protocol-version'
+import type {
+  RemoteRuntimeSubscription,
+  RemoteRuntimeSubscriptionCallbacks
+} from '../../shared/remote-runtime-client'
+
+const { subscribeRemoteRuntimeRequestMock } = vi.hoisted(() => ({
+  subscribeRemoteRuntimeRequestMock: vi.fn()
+}))
+
+vi.mock('../../shared/remote-runtime-client', () => ({
+  subscribeRemoteRuntimeRequest: subscribeRemoteRuntimeRequestMock
+}))
+
+import { PairedRuntimeBrowserHostLease } from './paired-runtime-browser-host-lease'
+
+const pairing = {
+  v: 2,
+  endpoint: 'ws://127.0.0.1:6768',
+  deviceToken: 'device-token',
+  publicKeyB64: 'public-key',
+  pairedDeviceId: 'device-a',
+  scope: 'runtime'
+} as PairingOffer
+
+afterEach(() => {
+  subscribeRemoteRuntimeRequestMock.mockReset()
+  vi.restoreAllMocks()
+})
+
+describe('PairedRuntimeBrowserHostLease', () => {
+  it('returns only the runtime-issued epoch and generation', async () => {
+    let callbacks: RemoteRuntimeSubscriptionCallbacks | undefined
+    const close = vi.fn()
+    subscribeRemoteRuntimeRequestMock.mockImplementationOnce(
+      async (...args: unknown[]): Promise<RemoteRuntimeSubscription> => {
+        callbacks = args[4] as RemoteRuntimeSubscriptionCallbacks
+        return { requestId: 'browser-host', close, sendBinary: () => false }
+      }
+    )
+    const lease = createLease()
+    const starting = lease.start()
+    await vi.waitFor(() => expect(callbacks).toBeDefined())
+    callbacks!.onResponse({
+      id: 'browser-host',
+      ok: true,
+      result: { type: 'ready', authorityEpoch: 'epoch-a', browserHostGeneration: 4 },
+      _meta: { runtimeId: 'runtime-a' }
+    })
+
+    await expect(starting).resolves.toEqual({
+      authorityRuntimeId: 'runtime-a',
+      authorityEpoch: 'epoch-a',
+      browserHostClientId: 'host-a',
+      browserHostGeneration: 4
+    })
+    expect(subscribeRemoteRuntimeRequestMock).toHaveBeenCalledWith(
+      pairing,
+      'browser.clientHost.attach',
+      {
+        authorityRuntimeId: 'runtime-a',
+        browserHostClientId: 'host-a',
+        hostCapabilities: ['webview']
+      },
+      15_000,
+      expect.any(Object),
+      expect.objectContaining({
+        clientCapabilities: [BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY]
+      })
+    )
+    await lease.close()
+    expect(close).toHaveBeenCalledOnce()
+  })
+
+  it('rejects malformed lease authority instead of adopting it', async () => {
+    let callbacks: RemoteRuntimeSubscriptionCallbacks | undefined
+    const close = vi.fn()
+    subscribeRemoteRuntimeRequestMock.mockImplementationOnce(
+      async (...args: unknown[]): Promise<RemoteRuntimeSubscription> => {
+        callbacks = args[4] as RemoteRuntimeSubscriptionCallbacks
+        return { requestId: 'browser-host', close, sendBinary: () => false }
+      }
+    )
+    const lease = createLease()
+    const starting = lease.start()
+    await vi.waitFor(() => expect(callbacks).toBeDefined())
+    callbacks!.onResponse({
+      id: 'browser-host',
+      ok: true,
+      result: { type: 'ready', authorityEpoch: '', browserHostGeneration: 0 },
+      _meta: { runtimeId: 'runtime-a' }
+    })
+
+    await expect(starting).rejects.toThrow('Invalid browser host lease response')
+    expect(close).toHaveBeenCalledOnce()
+  })
+
+  it('closes a subscription acquired after local teardown', async () => {
+    let resolveSubscription = (_subscription: RemoteRuntimeSubscription): void => {}
+    const close = vi.fn()
+    subscribeRemoteRuntimeRequestMock.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveSubscription = resolve
+      })
+    )
+    const lease = createLease()
+    const starting = lease.start()
+    await lease.close()
+    resolveSubscription({ requestId: 'late-host', close, sendBinary: () => false })
+
+    await expect(starting).rejects.toThrow('closed during startup')
+    expect(close).toHaveBeenCalledOnce()
+  })
+
+  it('closes and reports an exact server revocation after readiness', async () => {
+    let callbacks: RemoteRuntimeSubscriptionCallbacks | undefined
+    const close = vi.fn()
+    const onError = vi.fn()
+    subscribeRemoteRuntimeRequestMock.mockImplementationOnce(
+      async (...args: unknown[]): Promise<RemoteRuntimeSubscription> => {
+        callbacks = args[4] as RemoteRuntimeSubscriptionCallbacks
+        return { requestId: 'browser-host', close, sendBinary: () => false }
+      }
+    )
+    const lease = createLease({ onError })
+    const starting = lease.start()
+    await vi.waitFor(() => expect(callbacks).toBeDefined())
+    callbacks!.onResponse({
+      id: 'browser-host',
+      ok: true,
+      result: { type: 'ready', authorityEpoch: 'epoch-a', browserHostGeneration: 4 },
+      _meta: { runtimeId: 'runtime-a' }
+    })
+    await starting
+
+    callbacks!.onResponse({
+      id: 'browser-host',
+      ok: true,
+      result: {
+        type: 'revoked',
+        authorityEpoch: 'epoch-a',
+        browserHostGeneration: 4,
+        reason: 'replaced'
+      },
+      _meta: { runtimeId: 'runtime-a' }
+    })
+
+    await vi.waitFor(() => expect(close).toHaveBeenCalledOnce())
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Browser host lease revoked: replaced' })
+    )
+  })
+})
+
+function createLease(
+  overrides: { onError?: (error: Error) => void } = {}
+): PairedRuntimeBrowserHostLease {
+  return new PairedRuntimeBrowserHostLease({
+    pairing,
+    authorityRuntimeId: 'runtime-a',
+    browserHostClientId: 'host-a',
+    hostCapabilities: ['webview'],
+    ...overrides
+  })
+}

--- a/src/main/browser/paired-runtime-browser-host-lease.ts
+++ b/src/main/browser/paired-runtime-browser-host-lease.ts
@@ -1,0 +1,185 @@
+import {
+  BrowserClientHostEvent,
+  type BrowserHostLeaseAuthority
+} from '../../shared/browser-client-host-protocol'
+import type { PairingOffer } from '../../shared/pairing'
+import { BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY } from '../../shared/protocol-version'
+import {
+  subscribeRemoteRuntimeRequest,
+  type RemoteRuntimeSubscription,
+  type RemoteRuntimeSubscriptionOptions
+} from '../../shared/remote-runtime-client'
+import { RemoteRuntimeClientError } from '../../shared/remote-runtime-client-error'
+
+type PairedRuntimeBrowserHostLeaseOptions = {
+  pairing: PairingOffer
+  authorityRuntimeId: string
+  browserHostClientId: string
+  hostCapabilities: readonly string[]
+  timeoutMs?: number
+  subscription?: RemoteRuntimeSubscriptionOptions
+  onError?: (error: Error) => void
+}
+
+export class PairedRuntimeBrowserHostLease {
+  private subscription: RemoteRuntimeSubscription | null = null
+  private startPromise: Promise<BrowserHostLeaseAuthority> | null = null
+  private closePromise: Promise<void> | null = null
+  private rejectReady: ((error: Error) => void) | null = null
+  private authority: BrowserHostLeaseAuthority | null = null
+  private closed = false
+
+  constructor(private readonly options: PairedRuntimeBrowserHostLeaseOptions) {}
+
+  start(): Promise<BrowserHostLeaseAuthority> {
+    if (this.closed) {
+      return Promise.reject(new Error('Browser host lease is closed'))
+    }
+    this.startPromise ??= this.startLease()
+    return this.startPromise
+  }
+
+  async close(error = new Error('Browser host lease is closed')): Promise<void> {
+    if (this.closePromise) {
+      return this.closePromise
+    }
+    this.closed = true
+    this.rejectReady?.(error)
+    this.closePromise = this.closeLease()
+    return this.closePromise
+  }
+
+  private async startLease(): Promise<BrowserHostLeaseAuthority> {
+    const timeoutMs = this.options.timeoutMs ?? 15_000
+    let resolveReady = (_authority: BrowserHostLeaseAuthority): void => {}
+    let rejectReady = (_error: Error): void => {}
+    const ready = new Promise<BrowserHostLeaseAuthority>((resolve, reject) => {
+      resolveReady = resolve
+      rejectReady = reject
+    })
+    void ready.catch(() => undefined)
+    let readyTimeout: ReturnType<typeof setTimeout> | null = null
+    try {
+      const subscription = await subscribeRemoteRuntimeRequest(
+        this.options.pairing,
+        'browser.clientHost.attach',
+        {
+          authorityRuntimeId: this.options.authorityRuntimeId,
+          browserHostClientId: this.options.browserHostClientId,
+          hostCapabilities: [...this.options.hostCapabilities]
+        },
+        timeoutMs,
+        {
+          onResponse: (response) => {
+            if (!response.ok) {
+              this.fail(
+                new RemoteRuntimeClientError(response.error.code, response.error.message),
+                rejectReady
+              )
+              return
+            }
+            const parsed = BrowserClientHostEvent.safeParse(response.result)
+            if (!parsed.success || response._meta.runtimeId !== this.options.authorityRuntimeId) {
+              this.fail(new Error('Invalid browser host lease response'), rejectReady)
+              return
+            }
+            if (parsed.data.type === 'revoked') {
+              if (
+                !this.authority ||
+                this.authority.authorityEpoch !== parsed.data.authorityEpoch ||
+                this.authority.browserHostGeneration !== parsed.data.browserHostGeneration
+              ) {
+                this.fail(new Error('Invalid browser host lease revocation'), rejectReady)
+                return
+              }
+              this.fail(new Error(`Browser host lease revoked: ${parsed.data.reason}`), rejectReady)
+              return
+            }
+            const authority = {
+              authorityRuntimeId: this.options.authorityRuntimeId,
+              authorityEpoch: parsed.data.authorityEpoch,
+              browserHostClientId: this.options.browserHostClientId,
+              browserHostGeneration: parsed.data.browserHostGeneration
+            }
+            if (this.authority) {
+              if (!sameAuthority(this.authority, authority)) {
+                this.fail(new Error('Browser host lease authority changed in place'), rejectReady)
+              }
+              return
+            }
+            this.authority = authority
+            resolveReady(authority)
+          },
+          onError: (leaseError) => this.fail(leaseError, rejectReady),
+          onClose: () => this.fail(new Error('Browser host lease transport closed'), rejectReady)
+        },
+        {
+          ...this.options.subscription,
+          clientCapabilities: [
+            ...(this.options.subscription?.clientCapabilities ?? []),
+            BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY
+          ]
+        }
+      )
+      if (this.closed) {
+        subscription.close()
+        throw new Error('Browser host lease closed during startup')
+      }
+      this.subscription = subscription
+      this.rejectReady = rejectReady
+      readyTimeout = setTimeout(
+        () =>
+          rejectReady(
+            new RemoteRuntimeClientError('runtime_timeout', 'Browser host lease attach timed out.')
+          ),
+        timeoutMs
+      )
+      return await ready
+    } catch (error) {
+      const leaseError = error instanceof Error ? error : new Error(String(error))
+      await this.close(leaseError)
+      throw leaseError
+    } finally {
+      if (readyTimeout) {
+        clearTimeout(readyTimeout)
+      }
+      this.rejectReady = null
+    }
+  }
+
+  private fail(error: Error, rejectReady: (error: Error) => void): void {
+    if (this.closed) {
+      return
+    }
+    if (!this.authority) {
+      rejectReady(error)
+    }
+    const closing = this.close(error)
+    this.reportError(error)
+    void closing.catch((closeError) =>
+      this.reportError(closeError instanceof Error ? closeError : new Error(String(closeError)))
+    )
+  }
+
+  private async closeLease(): Promise<void> {
+    this.subscription?.close()
+    this.subscription = null
+  }
+
+  private reportError(error: Error): void {
+    try {
+      this.options.onError?.(error)
+    } catch {
+      // A reporting callback cannot prevent lease cleanup.
+    }
+  }
+}
+
+function sameAuthority(left: BrowserHostLeaseAuthority, right: BrowserHostLeaseAuthority): boolean {
+  return (
+    left.authorityRuntimeId === right.authorityRuntimeId &&
+    left.authorityEpoch === right.authorityEpoch &&
+    left.browserHostClientId === right.browserHostClientId &&
+    left.browserHostGeneration === right.browserHostGeneration
+  )
+}

--- a/src/main/browser/paired-runtime-browser-network-route.test.ts
+++ b/src/main/browser/paired-runtime-browser-network-route.test.ts
@@ -25,6 +25,13 @@ const pairing = {
   scope: 'runtime'
 } as PairingOffer
 
+const lease = {
+  authorityRuntimeId: 'runtime-a',
+  authorityEpoch: 'epoch-a',
+  browserHostClientId: 'host-a',
+  browserHostGeneration: 3
+}
+
 afterEach(() => {
   subscribeRemoteRuntimeRequestMock.mockReset()
   vi.restoreAllMocks()
@@ -42,9 +49,8 @@ describe('PairedRuntimeBrowserNetworkRoute', () => {
     )
     const route = new PairedRuntimeBrowserNetworkRoute({
       pairing,
-      authorityRuntimeId: 'runtime-a',
-      browserHostClientId: 'device-a',
-      tunnelGeneration: 7
+      lease,
+      executionHostRevision: 1
     })
 
     const starting = route.start()
@@ -192,9 +198,8 @@ function createRoute(
 ): PairedRuntimeBrowserNetworkRoute {
   return new PairedRuntimeBrowserNetworkRoute({
     pairing,
-    authorityRuntimeId: 'runtime-a',
-    browserHostClientId: 'device-a',
-    tunnelGeneration: 7,
+    lease,
+    executionHostRevision: 1,
     ...overrides
   })
 }

--- a/src/main/browser/paired-runtime-browser-network-route.ts
+++ b/src/main/browser/paired-runtime-browser-network-route.ts
@@ -1,11 +1,18 @@
 import type { PairingOffer } from '../../shared/pairing'
 import {
+  BrowserNetworkTunnelEvent,
+  type BrowserHostLeaseAuthority
+} from '../../shared/browser-client-host-protocol'
+import {
   subscribeRemoteRuntimeRequest,
   type RemoteRuntimeSubscription,
   type RemoteRuntimeSubscriptionOptions
 } from '../../shared/remote-runtime-client'
 import { RemoteRuntimeClientError } from '../../shared/remote-runtime-client-error'
-import { BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY } from '../../shared/protocol-version'
+import {
+  BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY,
+  BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY
+} from '../../shared/protocol-version'
 import { BrowserNetworkTunnelClient } from './browser-network-tunnel-client'
 import { RemoteBrowserSocksServer } from './remote-browser-socks-server'
 
@@ -14,9 +21,8 @@ const BROWSER_TUNNEL_WS_MAX_QUEUED_BYTES = 7 * 1024 * 1024
 
 type PairedRuntimeBrowserNetworkRouteOptions = {
   pairing: PairingOffer
-  authorityRuntimeId: string
-  browserHostClientId: string
-  tunnelGeneration: number
+  lease: BrowserHostLeaseAuthority
+  executionHostRevision: number
   timeoutMs?: number
   subscription?: RemoteRuntimeSubscriptionOptions
   onError?: (error: Error) => void
@@ -24,7 +30,7 @@ type PairedRuntimeBrowserNetworkRouteOptions = {
 
 export class PairedRuntimeBrowserNetworkRoute {
   private readonly options: PairedRuntimeBrowserNetworkRouteOptions
-  private readonly tunnel: BrowserNetworkTunnelClient
+  private tunnel: BrowserNetworkTunnelClient | null = null
   private readonly socks: RemoteBrowserSocksServer
   private subscription: RemoteRuntimeSubscription | null = null
   private startPromise: Promise<{ host: string; port: number }> | null = null
@@ -35,11 +41,9 @@ export class PairedRuntimeBrowserNetworkRoute {
 
   constructor(options: PairedRuntimeBrowserNetworkRouteOptions) {
     this.options = options
-    this.tunnel = new BrowserNetworkTunnelClient({
-      tunnelGeneration: options.tunnelGeneration,
-      sendBinary: (bytes) => this.subscription?.sendBinary(bytes) ?? false
+    this.socks = new RemoteBrowserSocksServer({
+      open: (target) => this.requireTunnel().open(target)
     })
-    this.socks = new RemoteBrowserSocksServer({ open: (target) => this.tunnel.open(target) })
   }
 
   start(): Promise<{ host: string; port: number }> {
@@ -75,33 +79,67 @@ export class PairedRuntimeBrowserNetworkRoute {
         this.options.pairing,
         'network.browserTunnel',
         {
-          authorityRuntimeId: this.options.authorityRuntimeId,
-          browserHostClientId: this.options.browserHostClientId,
-          executionHost: { kind: 'native' },
-          tunnelGeneration: this.options.tunnelGeneration
+          ...this.options.lease,
+          executionHost: {
+            kind: 'native',
+            runtimeId: this.options.lease.authorityRuntimeId,
+            revision: this.options.executionHostRevision
+          }
         },
         timeoutMs,
         {
           onResponse: (response) => {
             if (!response.ok) {
-              rejectReady(new RemoteRuntimeClientError(response.error.code, response.error.message))
+              this.fail(
+                new RemoteRuntimeClientError(response.error.code, response.error.message),
+                rejectReady
+              )
               return
             }
-            const result = response.result as { type?: unknown; tunnelGeneration?: unknown }
+            const parsed = BrowserNetworkTunnelEvent.safeParse(response.result)
             if (
-              result.type === 'ready' &&
-              result.tunnelGeneration === this.options.tunnelGeneration
+              !parsed.success ||
+              response._meta.runtimeId !== this.options.lease.authorityRuntimeId
             ) {
+              this.fail(new Error('Invalid browser network route response'), rejectReady)
+              return
+            }
+            const result = parsed.data
+            if (result.type === 'ready') {
+              if (this.tunnel) {
+                if (this.tunnel.generation !== result.tunnelGeneration) {
+                  this.fail(
+                    new Error('Browser network route generation changed in place'),
+                    rejectReady
+                  )
+                }
+                return
+              }
+              this.tunnel = new BrowserNetworkTunnelClient({
+                tunnelGeneration: result.tunnelGeneration,
+                sendBinary: (bytes) => this.subscription?.sendBinary(bytes) ?? false
+              })
               this.ready = true
               resolveReady()
-            } else if (
-              result.type === 'closed' &&
-              result.tunnelGeneration === this.options.tunnelGeneration
-            ) {
+            } else if (this.tunnel?.generation === result.tunnelGeneration) {
               this.fail(new Error('Browser network route closed by the runtime'), rejectReady)
+            } else {
+              this.fail(
+                new Error('Browser network route closed with an unknown generation'),
+                rejectReady
+              )
             }
           },
-          onBinary: (bytes) => this.tunnel.handleBinary(bytes),
+          onBinary: (bytes) => {
+            if (!this.tunnel) {
+              this.fail(
+                new Error('Browser network route received binary data before readiness'),
+                rejectReady
+              )
+              return
+            }
+            this.tunnel.handleBinary(bytes)
+          },
           onError: (routeError) => this.fail(routeError, rejectReady),
           onClose: () => this.fail(new Error('Browser network route transport closed'), rejectReady)
         },
@@ -115,6 +153,7 @@ export class PairedRuntimeBrowserNetworkRoute {
           },
           clientCapabilities: [
             ...(this.options.subscription?.clientCapabilities ?? []),
+            BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY,
             BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY
           ]
         }
@@ -175,7 +214,8 @@ export class PairedRuntimeBrowserNetworkRoute {
   }
 
   private async closeRoute(error: Error): Promise<void> {
-    this.tunnel.close(error)
+    this.tunnel?.close(error)
+    this.tunnel = null
     const failures: Error[] = []
     try {
       this.subscription?.close()
@@ -202,5 +242,12 @@ export class PairedRuntimeBrowserNetworkRoute {
     } catch {
       // A reporting callback cannot prevent route cleanup.
     }
+  }
+
+  private requireTunnel(): BrowserNetworkTunnelClient {
+    if (!this.tunnel) {
+      throw new Error('Browser network route is not ready')
+    }
+    return this.tunnel
   }
 }

--- a/src/main/runtime/browser-host-lease-registry.test.ts
+++ b/src/main/runtime/browser-host-lease-registry.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+import { BrowserHostLeaseRegistry } from './browser-host-lease-registry'
+
+const registry = (): BrowserHostLeaseRegistry =>
+  new BrowserHostLeaseRegistry({ authorityRuntimeId: 'runtime-a', authorityEpoch: 'epoch-a' })
+
+describe('BrowserHostLeaseRegistry', () => {
+  it('selects only an exact host when more than one lease is live', () => {
+    const leases = registry()
+    leases.attach({
+      browserHostClientId: 'host-a',
+      connectionId: 'connection-a',
+      pairedDeviceId: 'device-a',
+      hostCapabilities: ['webview']
+    })
+    leases.attach({
+      browserHostClientId: 'host-b',
+      connectionId: 'connection-b',
+      pairedDeviceId: 'device-b',
+      hostCapabilities: ['webview']
+    })
+
+    expect(() => leases.select()).toThrow('browser_host_ambiguous')
+    expect(leases.select('host-a')).toMatchObject({
+      authorityEpoch: 'epoch-a',
+      browserHostClientId: 'host-a',
+      browserHostGeneration: 1
+    })
+    expect(() => leases.select('missing')).toThrow('browser_host_unavailable')
+  })
+
+  it('fences a same-device replacement without letting old cleanup remove it', async () => {
+    const leases = registry()
+    const first = leases.attach({
+      browserHostClientId: 'host-a',
+      connectionId: 'connection-a',
+      pairedDeviceId: 'device-a',
+      hostCapabilities: ['webview']
+    })
+    const replacement = leases.attach({
+      browserHostClientId: 'host-a',
+      connectionId: 'connection-b',
+      pairedDeviceId: 'device-a',
+      hostCapabilities: ['webview']
+    })
+
+    await expect(first.whenFenced).resolves.toBe('replaced')
+    expect(replacement.lease.browserHostGeneration).toBe(2)
+    first.release()
+    expect(leases.select('host-a')).toEqual(replacement.lease)
+    expect(() =>
+      leases.attach({
+        browserHostClientId: 'host-a',
+        connectionId: 'connection-c',
+        pairedDeviceId: 'device-b',
+        hostCapabilities: ['webview']
+      })
+    ).toThrow('browser_host_identity_conflict')
+  })
+
+  it('allocates monotonic page generations and rejects a stale host generation', () => {
+    const leases = registry()
+    const first = leases.attach({
+      browserHostClientId: 'host-a',
+      connectionId: 'connection-a',
+      pairedDeviceId: 'device-a',
+      hostCapabilities: ['webview']
+    })
+
+    expect(leases.placeServerPage('page-a')).toEqual({ kind: 'server' })
+    expect(leases.placeClientPage('page-a', 'host-a')).toEqual({
+      kind: 'client',
+      browserHostClientId: 'host-a',
+      browserHostGeneration: 1,
+      pageHostGeneration: 1
+    })
+    first.release()
+    leases.attach({
+      browserHostClientId: 'host-a',
+      connectionId: 'connection-b',
+      pairedDeviceId: 'device-a',
+      hostCapabilities: ['webview']
+    })
+
+    expect(() =>
+      leases.requireLease({
+        authorityEpoch: 'epoch-a',
+        browserHostClientId: 'host-a',
+        browserHostGeneration: 1,
+        pairedDeviceId: 'device-a'
+      })
+    ).toThrow('browser_host_lease_stale')
+    expect(leases.placeClientPage('page-a', 'host-a')).toMatchObject({
+      browserHostGeneration: 2,
+      pageHostGeneration: 2
+    })
+  })
+
+  it('binds tunnel generations to the lease and fences replaced routes', async () => {
+    const leases = registry()
+    const host = leases.attach({
+      browserHostClientId: 'host-a',
+      connectionId: 'connection-a',
+      pairedDeviceId: 'device-a',
+      hostCapabilities: ['webview']
+    })
+    const identity = {
+      authorityEpoch: 'epoch-a',
+      browserHostClientId: 'host-a',
+      browserHostGeneration: 1,
+      pairedDeviceId: 'device-a',
+      executionHostKey: 'native:runtime-a'
+    }
+    const firstRoute = leases.openTunnel(identity)
+    const replacementRoute = leases.openTunnel(identity)
+
+    expect(firstRoute.tunnelGeneration).toBe(1)
+    expect(replacementRoute.tunnelGeneration).toBe(2)
+    await expect(firstRoute.whenFenced).resolves.toBe('replaced')
+    host.release()
+    await expect(replacementRoute.whenFenced).resolves.toBe('lease_released')
+    expect(() => leases.openTunnel(identity)).toThrow('browser_host_lease_required')
+  })
+})

--- a/src/main/runtime/browser-host-lease-registry.ts
+++ b/src/main/runtime/browser-host-lease-registry.ts
@@ -1,0 +1,275 @@
+import { randomUUID } from 'node:crypto'
+
+const MAX_GENERATION = 0xffff_ffff
+
+export type RuntimeBrowserPlacement =
+  | { kind: 'server' }
+  | {
+      kind: 'client'
+      browserHostClientId: string
+      browserHostGeneration: number
+      pageHostGeneration: number
+    }
+
+export type BrowserHostLease = Readonly<{
+  authorityRuntimeId: string
+  authorityEpoch: string
+  browserHostClientId: string
+  browserHostGeneration: number
+  connectionId: string
+  pairedDeviceId: string
+  hostCapabilities: readonly string[]
+}>
+
+export type BrowserHostLeaseIdentity = Pick<
+  BrowserHostLease,
+  'authorityEpoch' | 'browserHostClientId' | 'browserHostGeneration' | 'pairedDeviceId'
+>
+
+type FenceReason = 'replaced' | 'released' | 'lease_released' | 'lease_replaced'
+
+type Fence = {
+  promise: Promise<FenceReason>
+  resolve: (reason: FenceReason) => void
+}
+
+type LeaseState = {
+  token: symbol
+  lease: BrowserHostLease
+  fence: Fence
+  routes: Set<RouteState>
+}
+
+type RouteState = {
+  token: symbol
+  lease: LeaseState
+  key: string
+  tunnelGeneration: number
+  fence: Fence
+}
+
+export type BrowserHostLeaseHandle = Readonly<{
+  lease: BrowserHostLease
+  whenFenced: Promise<FenceReason>
+  release: () => void
+}>
+
+export type BrowserTunnelLeaseHandle = Readonly<{
+  tunnelGeneration: number
+  whenFenced: Promise<FenceReason>
+  release: () => void
+}>
+
+export class BrowserHostLeaseRegistry {
+  readonly authorityRuntimeId: string
+  readonly authorityEpoch: string
+  private nextHostGeneration = 1
+  private nextTunnelGeneration = 1
+  private readonly nextPageGenerationByPageId = new Map<string, number>()
+  private readonly leasesByClientId = new Map<string, LeaseState>()
+  private readonly routesByKey = new Map<string, RouteState>()
+  private readonly placementsByPageId = new Map<string, RuntimeBrowserPlacement>()
+
+  constructor(options: { authorityRuntimeId: string; authorityEpoch?: string }) {
+    this.authorityRuntimeId = options.authorityRuntimeId
+    this.authorityEpoch = options.authorityEpoch ?? randomUUID()
+  }
+
+  attach(input: {
+    browserHostClientId: string
+    connectionId: string
+    pairedDeviceId: string
+    hostCapabilities: readonly string[]
+  }): BrowserHostLeaseHandle {
+    const existing = this.leasesByClientId.get(input.browserHostClientId)
+    if (existing) {
+      if (existing.lease.pairedDeviceId !== input.pairedDeviceId) {
+        throw new Error('browser_host_identity_conflict')
+      }
+    }
+    const generation = this.takeGeneration('host')
+    if (existing) {
+      this.fenceLease(existing, 'replaced')
+    }
+    const state: LeaseState = {
+      token: Symbol(input.browserHostClientId),
+      lease: Object.freeze({
+        authorityRuntimeId: this.authorityRuntimeId,
+        authorityEpoch: this.authorityEpoch,
+        browserHostClientId: input.browserHostClientId,
+        browserHostGeneration: generation,
+        connectionId: input.connectionId,
+        pairedDeviceId: input.pairedDeviceId,
+        hostCapabilities: Object.freeze([...input.hostCapabilities])
+      }),
+      fence: createFence(),
+      routes: new Set()
+    }
+    this.leasesByClientId.set(input.browserHostClientId, state)
+    return {
+      lease: state.lease,
+      whenFenced: state.fence.promise,
+      release: () => this.releaseLease(state)
+    }
+  }
+
+  select(browserHostClientId?: string): BrowserHostLease {
+    if (browserHostClientId) {
+      const exact = this.leasesByClientId.get(browserHostClientId)
+      if (!exact) {
+        throw new Error('browser_host_unavailable')
+      }
+      return exact.lease
+    }
+    if (this.leasesByClientId.size === 0) {
+      throw new Error('browser_host_unavailable')
+    }
+    if (this.leasesByClientId.size > 1) {
+      throw new Error('browser_host_ambiguous')
+    }
+    return this.leasesByClientId.values().next().value!.lease
+  }
+
+  requireLease(identity: BrowserHostLeaseIdentity): BrowserHostLease {
+    if (identity.authorityEpoch !== this.authorityEpoch) {
+      throw new Error('browser_host_lease_stale')
+    }
+    const state = this.leasesByClientId.get(identity.browserHostClientId)
+    if (!state) {
+      throw new Error('browser_host_lease_required')
+    }
+    if (
+      state.lease.browserHostGeneration !== identity.browserHostGeneration ||
+      state.lease.pairedDeviceId !== identity.pairedDeviceId
+    ) {
+      throw new Error('browser_host_lease_stale')
+    }
+    return state.lease
+  }
+
+  placeServerPage(browserPageId: string): RuntimeBrowserPlacement {
+    const placement = Object.freeze({ kind: 'server' as const })
+    this.placementsByPageId.set(browserPageId, placement)
+    return placement
+  }
+
+  placeClientPage(browserPageId: string, browserHostClientId?: string): RuntimeBrowserPlacement {
+    const lease = this.select(browserHostClientId)
+    const pageHostGeneration = this.takePageGeneration(browserPageId)
+    const placement = Object.freeze({
+      kind: 'client' as const,
+      browserHostClientId: lease.browserHostClientId,
+      browserHostGeneration: lease.browserHostGeneration,
+      pageHostGeneration
+    })
+    this.placementsByPageId.set(browserPageId, placement)
+    return placement
+  }
+
+  getPlacement(browserPageId: string): RuntimeBrowserPlacement | undefined {
+    return this.placementsByPageId.get(browserPageId)
+  }
+
+  openTunnel(
+    identity: BrowserHostLeaseIdentity & { executionHostKey: string }
+  ): BrowserTunnelLeaseHandle {
+    this.requireLease(identity)
+    const lease = this.leasesByClientId.get(identity.browserHostClientId)!
+    const key = `${identity.browserHostClientId}\u0000${identity.executionHostKey}`
+    const existing = this.routesByKey.get(key)
+    const tunnelGeneration = this.takeGeneration('tunnel')
+    if (existing) {
+      this.fenceRoute(existing, 'replaced')
+    }
+    const state: RouteState = {
+      token: Symbol(key),
+      lease,
+      key,
+      tunnelGeneration,
+      fence: createFence()
+    }
+    lease.routes.add(state)
+    this.routesByKey.set(key, state)
+    return {
+      tunnelGeneration: state.tunnelGeneration,
+      whenFenced: state.fence.promise,
+      release: () => this.fenceRoute(state, 'released')
+    }
+  }
+
+  private releaseLease(state: LeaseState): void {
+    this.fenceLease(state, 'lease_released')
+  }
+
+  private fenceLease(state: LeaseState, reason: FenceReason): void {
+    if (this.leasesByClientId.get(state.lease.browserHostClientId)?.token !== state.token) {
+      return
+    }
+    this.leasesByClientId.delete(state.lease.browserHostClientId)
+    for (const route of state.routes) {
+      this.fenceRoute(route, reason === 'replaced' ? 'lease_replaced' : 'lease_released')
+    }
+    state.fence.resolve(reason)
+  }
+
+  private fenceRoute(state: RouteState, reason: FenceReason): void {
+    state.lease.routes.delete(state)
+    if (this.routesByKey.get(state.key)?.token === state.token) {
+      this.routesByKey.delete(state.key)
+    }
+    state.fence.resolve(reason)
+  }
+
+  private takeGeneration(kind: 'host' | 'tunnel'): number {
+    const value = kind === 'host' ? this.nextHostGeneration : this.nextTunnelGeneration
+    if (value > MAX_GENERATION) {
+      throw new Error(`browser_${kind}_generation_exhausted`)
+    }
+    if (kind === 'host') {
+      this.nextHostGeneration += 1
+    } else {
+      this.nextTunnelGeneration += 1
+    }
+    return value
+  }
+
+  private takePageGeneration(browserPageId: string): number {
+    const value = this.nextPageGenerationByPageId.get(browserPageId) ?? 1
+    if (value > MAX_GENERATION) {
+      throw new Error('browser_page_generation_exhausted')
+    }
+    this.nextPageGenerationByPageId.set(browserPageId, value + 1)
+    return value
+  }
+}
+
+const registries = new WeakMap<object, BrowserHostLeaseRegistry>()
+
+export function getBrowserHostLeaseRegistry(runtime: {
+  getRuntimeId(): string
+}): BrowserHostLeaseRegistry {
+  let registry = registries.get(runtime)
+  if (!registry) {
+    registry = new BrowserHostLeaseRegistry({ authorityRuntimeId: runtime.getRuntimeId() })
+    registries.set(runtime, registry)
+  }
+  return registry
+}
+
+function createFence(): Fence {
+  let settled = false
+  let settle = (_reason: FenceReason): void => {}
+  const promise = new Promise<FenceReason>((resolve) => {
+    settle = resolve
+  })
+  return {
+    promise,
+    resolve: (reason) => {
+      if (settled) {
+        return
+      }
+      settled = true
+      settle(reason)
+    }
+  }
+}

--- a/src/main/runtime/browser-network-tunnel-paired-runtime.integration.test.ts
+++ b/src/main/runtime/browser-network-tunnel-paired-runtime.integration.test.ts
@@ -4,11 +4,13 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { PairedRuntimeBrowserNetworkRoute } from '../browser/paired-runtime-browser-network-route'
+import { PairedRuntimeBrowserHostLease } from '../browser/paired-runtime-browser-host-lease'
 import { parsePairingCode } from '../../shared/pairing'
 import { OrcaRuntimeService } from './orca-runtime'
 import { OrcaRuntimeRpcServer } from './runtime-rpc'
 import { ALL_RPC_METHODS } from './rpc/methods'
 import { BROWSER_NETWORK_TUNNEL_METHODS } from './rpc/methods/browser-network-tunnel'
+import { BROWSER_CLIENT_HOST_METHODS } from './rpc/methods/browser-client-host'
 
 const resources: (() => Promise<void> | void)[] = []
 
@@ -41,7 +43,11 @@ describe('paired runtime browser network tunnel', () => {
       userDataPath,
       enableWebSocket: true,
       wsPort: 0,
-      methods: [...ALL_RPC_METHODS, ...BROWSER_NETWORK_TUNNEL_METHODS]
+      methods: [
+        ...ALL_RPC_METHODS,
+        ...BROWSER_CLIENT_HOST_METHODS,
+        ...BROWSER_NETWORK_TUNNEL_METHODS
+      ]
     })
     await rpc.start()
     resources.push(() => rpc.stop())
@@ -56,11 +62,19 @@ describe('paired runtime browser network tunnel', () => {
     }
 
     const errors: Error[] = []
-    const route = new PairedRuntimeBrowserNetworkRoute({
+    const hostLease = new PairedRuntimeBrowserHostLease({
       pairing,
       authorityRuntimeId: runtime.getRuntimeId(),
-      browserHostClientId: pairing.pairedDeviceId,
-      tunnelGeneration: 7,
+      browserHostClientId: 'integration-browser-host',
+      hostCapabilities: ['webview'],
+      onError: (error) => errors.push(error)
+    })
+    const lease = await hostLease.start()
+    resources.push(() => hostLease.close())
+    const route = new PairedRuntimeBrowserNetworkRoute({
+      pairing,
+      lease,
+      executionHostRevision: runtime.getStartedAt(),
       onError: (error) => errors.push(error)
     })
     const socksAddress = await route.start()

--- a/src/main/runtime/rpc/methods/browser-client-host.test.ts
+++ b/src/main/runtime/rpc/methods/browser-client-host.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi } from 'vitest'
+import { BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY } from '../../../../shared/protocol-version'
+import { getBrowserHostLeaseRegistry } from '../../browser-host-lease-registry'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import { RpcDispatcher } from '../dispatcher'
+import { BROWSER_CLIENT_HOST_METHODS } from './browser-client-host'
+import { ALL_RPC_METHODS } from './index'
+
+function request(browserHostClientId = 'host-a') {
+  return {
+    id: `browser-host:${browserHostClientId}`,
+    authToken: 'bound-by-websocket',
+    method: 'browser.clientHost.attach',
+    params: {
+      authorityRuntimeId: 'runtime-a',
+      browserHostClientId,
+      hostCapabilities: ['webview']
+    }
+  }
+}
+
+function runtime(cleanups = new Map<string, () => void>()): OrcaRuntimeService {
+  return {
+    getRuntimeId: () => 'runtime-a',
+    getStartedAt: () => 1,
+    registerSubscriptionCleanup: (id: string, cleanup: () => void) => cleanups.set(id, cleanup)
+  } as unknown as OrcaRuntimeService
+}
+
+describe('browser.clientHost.attach RPC', () => {
+  it('remains outside the production registry while Electron hosting is inactive', () => {
+    expect(ALL_RPC_METHODS.some((method) => method.name === 'browser.clientHost.attach')).toBe(
+      false
+    )
+  })
+
+  it('requires an authenticated negotiated paired-runtime connection', async () => {
+    const hostRuntime = runtime()
+    const dispatcher = new RpcDispatcher({
+      runtime: hostRuntime,
+      methods: BROWSER_CLIENT_HOST_METHODS
+    })
+    const replies: string[] = []
+
+    await dispatcher.dispatchStreaming(request(), (reply) => replies.push(reply), {
+      connectionId: 'connection-a',
+      clientKind: 'runtime',
+      pairedDeviceId: 'device-a'
+    })
+
+    expect(replies.map((reply) => JSON.parse(reply))).toEqual([
+      expect.objectContaining({
+        ok: false,
+        error: expect.objectContaining({ message: 'browser_client_host_capability_required' })
+      })
+    ])
+    expect(() => getBrowserHostLeaseRegistry(hostRuntime).select('host-a')).toThrow(
+      'browser_host_unavailable'
+    )
+  })
+
+  it('publishes server-owned epoch and generation then releases on cleanup', async () => {
+    const cleanups = new Map<string, () => void>()
+    const hostRuntime = runtime(cleanups)
+    const dispatcher = new RpcDispatcher({
+      runtime: hostRuntime,
+      methods: BROWSER_CLIENT_HOST_METHODS
+    })
+    const replies: string[] = []
+    const dispatch = dispatcher.dispatchStreaming(request(), (reply) => replies.push(reply), {
+      connectionId: 'connection-a',
+      clientKind: 'runtime',
+      pairedDeviceId: 'device-a',
+      clientCapabilities: [BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY]
+    })
+
+    await vi.waitFor(() => expect(replies).toHaveLength(1))
+    const ready = JSON.parse(replies[0]!).result
+    expect(ready).toMatchObject({ type: 'ready', browserHostGeneration: 1 })
+    expect(ready.authorityEpoch).toEqual(expect.any(String))
+    expect(getBrowserHostLeaseRegistry(hostRuntime).select('host-a')).toMatchObject({
+      connectionId: 'connection-a',
+      pairedDeviceId: 'device-a',
+      authorityEpoch: ready.authorityEpoch,
+      browserHostGeneration: 1
+    })
+
+    cleanups.get('browser-client-host:host-a')?.()
+    await dispatch
+    expect(JSON.parse(replies[1]!).result).toMatchObject({
+      type: 'revoked',
+      authorityEpoch: ready.authorityEpoch,
+      browserHostGeneration: 1,
+      reason: 'released'
+    })
+    expect(() => getBrowserHostLeaseRegistry(hostRuntime).select('host-a')).toThrow(
+      'browser_host_unavailable'
+    )
+  })
+
+  it('fences a replaced subscription and increments its host generation', async () => {
+    const hostRuntime = runtime()
+    const dispatcher = new RpcDispatcher({
+      runtime: hostRuntime,
+      methods: BROWSER_CLIENT_HOST_METHODS
+    })
+    const firstReplies: string[] = []
+    const secondReplies: string[] = []
+    const options = {
+      clientKind: 'runtime' as const,
+      pairedDeviceId: 'device-a',
+      clientCapabilities: [BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY]
+    }
+    const first = dispatcher.dispatchStreaming(request(), (reply) => firstReplies.push(reply), {
+      ...options,
+      connectionId: 'connection-a'
+    })
+    await vi.waitFor(() => expect(firstReplies).toHaveLength(1))
+    const second = dispatcher.dispatchStreaming(request(), (reply) => secondReplies.push(reply), {
+      ...options,
+      connectionId: 'connection-b'
+    })
+
+    await first
+    await vi.waitFor(() => expect(secondReplies).toHaveLength(1))
+    expect(JSON.parse(firstReplies[1]!).result).toMatchObject({
+      type: 'revoked',
+      browserHostGeneration: 1,
+      reason: 'replaced'
+    })
+    expect(JSON.parse(secondReplies[0]!).result).toMatchObject({ browserHostGeneration: 2 })
+    getBrowserHostLeaseRegistry(hostRuntime).select('host-a')
+    getBrowserHostLeaseRegistry(hostRuntime)
+      .attach({
+        browserHostClientId: 'host-a',
+        connectionId: 'connection-c',
+        pairedDeviceId: 'device-a',
+        hostCapabilities: ['webview']
+      })
+      .release()
+    await second
+  })
+})

--- a/src/main/runtime/rpc/methods/browser-client-host.ts
+++ b/src/main/runtime/rpc/methods/browser-client-host.ts
@@ -1,0 +1,66 @@
+import { BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY } from '../../../../shared/protocol-version'
+import { BrowserClientHostAttachParams } from '../../../../shared/browser-client-host-protocol'
+import { getBrowserHostLeaseRegistry } from '../../browser-host-lease-registry'
+import { defineStreamingMethod, type RpcAnyMethod } from '../core'
+
+export const BROWSER_CLIENT_HOST_METHODS: RpcAnyMethod[] = [
+  defineStreamingMethod({
+    name: 'browser.clientHost.attach',
+    params: BrowserClientHostAttachParams,
+    handler: async (
+      params,
+      { runtime, connectionId, pairedDeviceId, clientKind, clientCapabilities, signal },
+      emit
+    ) => {
+      if (clientKind !== 'runtime' || !connectionId || !pairedDeviceId) {
+        throw new Error('authenticated_browser_client_host_required')
+      }
+      if (!clientCapabilities?.includes(BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY)) {
+        throw new Error('browser_client_host_capability_required')
+      }
+      if (params.authorityRuntimeId !== runtime.getRuntimeId()) {
+        throw new Error('browser_client_host_authority_mismatch')
+      }
+
+      const registry = getBrowserHostLeaseRegistry(runtime)
+      const handle = registry.attach({
+        browserHostClientId: params.browserHostClientId,
+        connectionId,
+        pairedDeviceId,
+        hostCapabilities: params.hostCapabilities
+      })
+      let cleaned = false
+      const cleanup = (): void => {
+        if (cleaned) {
+          return
+        }
+        cleaned = true
+        handle.release()
+      }
+      const subscriptionId = `browser-client-host:${params.browserHostClientId}`
+      try {
+        runtime.registerSubscriptionCleanup(subscriptionId, cleanup, connectionId)
+        signal?.addEventListener('abort', cleanup, { once: true })
+        if (signal?.aborted) {
+          cleanup()
+          return
+        }
+        emit({
+          type: 'ready',
+          authorityEpoch: handle.lease.authorityEpoch,
+          browserHostGeneration: handle.lease.browserHostGeneration
+        })
+        const reason = await handle.whenFenced
+        emit({
+          type: 'revoked',
+          authorityEpoch: handle.lease.authorityEpoch,
+          browserHostGeneration: handle.lease.browserHostGeneration,
+          reason: reason === 'replaced' ? 'replaced' : 'released'
+        })
+      } finally {
+        signal?.removeEventListener('abort', cleanup)
+        cleanup()
+      }
+    }
+  })
+]

--- a/src/main/runtime/rpc/methods/browser-network-tunnel.test.ts
+++ b/src/main/runtime/rpc/methods/browser-network-tunnel.test.ts
@@ -1,20 +1,28 @@
 import { describe, expect, it, vi } from 'vitest'
-import { BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY } from '../../../../shared/protocol-version'
+import {
+  BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY,
+  BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY
+} from '../../../../shared/protocol-version'
+import {
+  getBrowserHostLeaseRegistry,
+  type BrowserHostLease
+} from '../../browser-host-lease-registry'
 import type { OrcaRuntimeService } from '../../orca-runtime'
 import { RpcDispatcher } from '../dispatcher'
 import { ALL_RPC_METHODS } from './index'
 import { BROWSER_NETWORK_TUNNEL_METHODS } from './browser-network-tunnel'
 
-function request(overrides: Record<string, unknown> = {}) {
+function request(lease?: BrowserHostLease, overrides: Record<string, unknown> = {}) {
   return {
     id: 'browser-tunnel',
     authToken: 'bound-by-websocket',
     method: 'network.browserTunnel',
     params: {
       authorityRuntimeId: 'runtime-a',
-      browserHostClientId: 'device-a',
-      executionHost: { kind: 'native' },
-      tunnelGeneration: 7,
+      authorityEpoch: lease?.authorityEpoch ?? 'epoch-without-lease',
+      browserHostClientId: lease?.browserHostClientId ?? 'host-a',
+      browserHostGeneration: lease?.browserHostGeneration ?? 1,
+      executionHost: { kind: 'native', runtimeId: 'runtime-a', revision: 1 },
       ...overrides
     }
   }
@@ -28,14 +36,30 @@ function runtime(cleanups = new Map<string, () => void>()): OrcaRuntimeService {
   } as unknown as OrcaRuntimeService
 }
 
+function attachLease(hostRuntime: OrcaRuntimeService): BrowserHostLease {
+  return getBrowserHostLeaseRegistry(hostRuntime).attach({
+    browserHostClientId: 'host-a',
+    connectionId: 'host-control-connection',
+    pairedDeviceId: 'device-a',
+    hostCapabilities: ['webview']
+  }).lease
+}
+
+const negotiatedCapabilities = [
+  BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY,
+  BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY
+]
+
 describe('network.browserTunnel RPC', () => {
   it('remains outside the production RPC registry until route authorization exists', () => {
     expect(ALL_RPC_METHODS.some((method) => method.name === 'network.browserTunnel')).toBe(false)
   })
 
-  it('rejects an unnegotiated or mismatched browser host before registering binary traffic', async () => {
+  it('rejects missing capabilities before registering binary traffic', async () => {
+    const hostRuntime = runtime()
+    const lease = attachLease(hostRuntime)
     const dispatcher = new RpcDispatcher({
-      runtime: runtime(),
+      runtime: hostRuntime,
       methods: BROWSER_NETWORK_TUNNEL_METHODS
     })
     const replies: string[] = []
@@ -48,12 +72,11 @@ describe('network.browserTunnel RPC', () => {
       registerBinaryMessageHandler
     }
 
-    await dispatcher.dispatchStreaming(request(), (reply) => replies.push(reply), baseOptions)
-    await dispatcher.dispatchStreaming(
-      request({ browserHostClientId: 'device-b' }),
-      (reply) => replies.push(reply),
-      { ...baseOptions, clientCapabilities: [BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY] }
-    )
+    await dispatcher.dispatchStreaming(request(lease), (reply) => replies.push(reply), baseOptions)
+    await dispatcher.dispatchStreaming(request(lease), (reply) => replies.push(reply), {
+      ...baseOptions,
+      clientCapabilities: [BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY]
+    })
 
     expect(replies.map((reply) => JSON.parse(reply))).toEqual([
       expect.objectContaining({
@@ -62,26 +85,94 @@ describe('network.browserTunnel RPC', () => {
       }),
       expect.objectContaining({
         ok: false,
-        error: expect.objectContaining({ message: 'browser_tunnel_identity_mismatch' })
+        error: expect.objectContaining({ message: 'browser_client_host_capability_required' })
       })
     ])
     expect(registerBinaryMessageHandler).not.toHaveBeenCalled()
   })
 
-  it('binds one raw handler to the connection and removes it during subscription cleanup', async () => {
-    const cleanups = new Map<string, () => void>()
+  it('rejects a self-asserted or stale browser host lease', async () => {
+    const hostRuntime = runtime()
+    const lease = attachLease(hostRuntime)
     const dispatcher = new RpcDispatcher({
-      runtime: runtime(cleanups),
+      runtime: hostRuntime,
+      methods: BROWSER_NETWORK_TUNNEL_METHODS
+    })
+    const replies: string[] = []
+    const options = {
+      connectionId: 'connection-a',
+      clientKind: 'runtime' as const,
+      pairedDeviceId: 'device-a',
+      clientCapabilities: negotiatedCapabilities,
+      sendBinary: vi.fn(() => true),
+      registerBinaryMessageHandler: vi.fn(() => vi.fn())
+    }
+
+    await dispatcher.dispatchStreaming(request(), (reply) => replies.push(reply), options)
+    await dispatcher.dispatchStreaming(
+      request(lease, { browserHostGeneration: lease.browserHostGeneration + 1 }),
+      (reply) => replies.push(reply),
+      options
+    )
+
+    expect(replies.map((reply) => JSON.parse(reply))).toEqual([
+      expect.objectContaining({
+        ok: false,
+        error: expect.objectContaining({ message: 'browser_host_lease_stale' })
+      }),
+      expect.objectContaining({
+        ok: false,
+        error: expect.objectContaining({ message: 'browser_host_lease_stale' })
+      })
+    ])
+  })
+
+  it('rejects an execution-host revision not owned by this runtime', async () => {
+    const hostRuntime = runtime()
+    const lease = attachLease(hostRuntime)
+    const dispatcher = new RpcDispatcher({
+      runtime: hostRuntime,
+      methods: BROWSER_NETWORK_TUNNEL_METHODS
+    })
+    const replies: string[] = []
+
+    await dispatcher.dispatchStreaming(
+      request(lease, { executionHost: { kind: 'native', runtimeId: 'runtime-a', revision: 2 } }),
+      (reply) => replies.push(reply),
+      {
+        connectionId: 'connection-a',
+        clientKind: 'runtime',
+        pairedDeviceId: 'device-a',
+        clientCapabilities: negotiatedCapabilities,
+        sendBinary: vi.fn(() => true),
+        registerBinaryMessageHandler: vi.fn(() => vi.fn())
+      }
+    )
+
+    expect(JSON.parse(replies[0]!)).toEqual(
+      expect.objectContaining({
+        ok: false,
+        error: expect.objectContaining({ message: 'browser_tunnel_execution_host_mismatch' })
+      })
+    )
+  })
+
+  it('allocates the tunnel generation and removes its raw handler on cleanup', async () => {
+    const cleanups = new Map<string, () => void>()
+    const hostRuntime = runtime(cleanups)
+    const lease = attachLease(hostRuntime)
+    const dispatcher = new RpcDispatcher({
+      runtime: hostRuntime,
       methods: BROWSER_NETWORK_TUNNEL_METHODS
     })
     const unregister = vi.fn()
     const registerBinaryMessageHandler = vi.fn(() => unregister)
     const replies: string[] = []
-    const dispatch = dispatcher.dispatchStreaming(request(), (reply) => replies.push(reply), {
+    const dispatch = dispatcher.dispatchStreaming(request(lease), (reply) => replies.push(reply), {
       connectionId: 'connection-a',
       clientKind: 'runtime',
       pairedDeviceId: 'device-a',
-      clientCapabilities: [BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY],
+      clientCapabilities: negotiatedCapabilities,
       sendBinary: vi.fn(() => true),
       registerBinaryMessageHandler
     })
@@ -91,11 +182,59 @@ describe('network.browserTunnel RPC', () => {
       expect.objectContaining({
         ok: true,
         streaming: true,
-        result: { type: 'ready', tunnelGeneration: 7 }
+        result: { type: 'ready', tunnelGeneration: 1 }
       })
     ])
     cleanups.get('browser-network-tunnel:connection-a')?.()
     await dispatch
     expect(unregister).toHaveBeenCalledOnce()
+  })
+
+  it('fences an older route when the same lease replaces it', async () => {
+    const hostRuntime = runtime()
+    const lease = attachLease(hostRuntime)
+    const dispatcher = new RpcDispatcher({
+      runtime: hostRuntime,
+      methods: BROWSER_NETWORK_TUNNEL_METHODS
+    })
+    const firstReplies: string[] = []
+    const secondReplies: string[] = []
+    const baseOptions = {
+      clientKind: 'runtime' as const,
+      pairedDeviceId: 'device-a',
+      clientCapabilities: negotiatedCapabilities,
+      sendBinary: vi.fn(() => true),
+      registerBinaryMessageHandler: vi.fn(() => vi.fn())
+    }
+    const first = dispatcher.dispatchStreaming(
+      request(lease),
+      (reply) => firstReplies.push(reply),
+      {
+        ...baseOptions,
+        connectionId: 'connection-a'
+      }
+    )
+    await vi.waitFor(() => expect(firstReplies).toHaveLength(1))
+    const second = dispatcher.dispatchStreaming(
+      request(lease),
+      (reply) => secondReplies.push(reply),
+      { ...baseOptions, connectionId: 'connection-b' }
+    )
+
+    await first
+    await vi.waitFor(() => expect(secondReplies).toHaveLength(1))
+    expect(JSON.parse(secondReplies[0]!).result).toEqual({
+      type: 'ready',
+      tunnelGeneration: 2
+    })
+    getBrowserHostLeaseRegistry(hostRuntime)
+      .attach({
+        browserHostClientId: 'host-a',
+        connectionId: 'host-control-replacement',
+        pairedDeviceId: 'device-a',
+        hostCapabilities: ['webview']
+      })
+      .release()
+    await second
   })
 })

--- a/src/main/runtime/rpc/methods/browser-network-tunnel.ts
+++ b/src/main/runtime/rpc/methods/browser-network-tunnel.ts
@@ -1,21 +1,18 @@
 import { connect } from 'node:net'
-import { z } from 'zod'
 import { BrowserNetworkTunnelSession } from '../../../browser/browser-network-tunnel-session'
-import { BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY } from '../../../../shared/protocol-version'
+import { BrowserNetworkTunnelAttachParams } from '../../../../shared/browser-client-host-protocol'
+import {
+  BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY,
+  BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY
+} from '../../../../shared/protocol-version'
+import { getBrowserHostLeaseRegistry } from '../../browser-host-lease-registry'
 import { defineStreamingMethod, type RpcAnyMethod } from '../core'
-
-const BrowserNetworkTunnelAttach = z.object({
-  authorityRuntimeId: z.string().min(1),
-  browserHostClientId: z.string().min(1),
-  executionHost: z.object({ kind: z.literal('native') }),
-  tunnelGeneration: z.number().int().min(1).max(0xffff_ffff)
-})
 
 // Why: tests inject this until a live lease and server-owned route generation authorize TCP opens.
 export const BROWSER_NETWORK_TUNNEL_METHODS: RpcAnyMethod[] = [
   defineStreamingMethod({
     name: 'network.browserTunnel',
-    params: BrowserNetworkTunnelAttach,
+    params: BrowserNetworkTunnelAttachParams,
     handler: async (
       params,
       {
@@ -42,27 +39,33 @@ export const BROWSER_NETWORK_TUNNEL_METHODS: RpcAnyMethod[] = [
       if (!clientCapabilities?.includes(BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY)) {
         throw new Error('browser_tunnel_capability_required')
       }
-      if (
-        params.authorityRuntimeId !== runtime.getRuntimeId() ||
-        params.browserHostClientId !== pairedDeviceId
-      ) {
+      if (!clientCapabilities.includes(BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY)) {
+        throw new Error('browser_client_host_capability_required')
+      }
+      if (params.authorityRuntimeId !== runtime.getRuntimeId()) {
         throw new Error('browser_tunnel_identity_mismatch')
       }
+      if (
+        params.executionHost.runtimeId !== runtime.getRuntimeId() ||
+        params.executionHost.revision !== runtime.getStartedAt()
+      ) {
+        throw new Error('browser_tunnel_execution_host_mismatch')
+      }
+
+      const route = getBrowserHostLeaseRegistry(runtime).openTunnel({
+        authorityEpoch: params.authorityEpoch,
+        browserHostClientId: params.browserHostClientId,
+        browserHostGeneration: params.browserHostGeneration,
+        pairedDeviceId,
+        executionHostKey: `native:${params.executionHost.runtimeId}:${params.executionHost.revision}`
+      })
 
       let resolveClosed = (): void => {}
       const closed = new Promise<void>((resolve) => {
         resolveClosed = resolve
       })
-      const session = new BrowserNetworkTunnelSession({
-        tunnelGeneration: params.tunnelGeneration,
-        connect: (target) => connect({ ...target, allowHalfOpen: true }),
-        sendBinary: (bytes) => sendBinary(bytes) !== false,
-        onClose: () => {
-          emit({ type: 'closed', tunnelGeneration: params.tunnelGeneration })
-          resolveClosed()
-        }
-      })
-      const unregisterBinary = registerBinaryMessageHandler((bytes) => session.handleBinary(bytes))
+      let session: BrowserNetworkTunnelSession | null = null
+      let unregisterBinary = (): void => {}
       let cleaned = false
       const cleanup = (): void => {
         if (cleaned) {
@@ -70,13 +73,29 @@ export const BROWSER_NETWORK_TUNNEL_METHODS: RpcAnyMethod[] = [
         }
         cleaned = true
         unregisterBinary()
-        session.close()
+        session?.close()
+        route.release()
       }
       const subscriptionId = `browser-network-tunnel:${connectionId}`
       try {
+        session = new BrowserNetworkTunnelSession({
+          tunnelGeneration: route.tunnelGeneration,
+          connect: (target) => connect({ ...target, allowHalfOpen: true }),
+          sendBinary: (bytes) => sendBinary(bytes) !== false,
+          onClose: () => {
+            emit({ type: 'closed', tunnelGeneration: route.tunnelGeneration })
+            resolveClosed()
+          }
+        })
+        void route.whenFenced.then(() => session?.close())
+        unregisterBinary = registerBinaryMessageHandler((bytes) => session?.handleBinary(bytes))
         runtime.registerSubscriptionCleanup(subscriptionId, cleanup, connectionId)
         signal?.addEventListener('abort', cleanup, { once: true })
-        emit({ type: 'ready', tunnelGeneration: params.tunnelGeneration })
+        if (signal?.aborted) {
+          cleanup()
+          return
+        }
+        emit({ type: 'ready', tunnelGeneration: route.tunnelGeneration })
         await closed
       } finally {
         signal?.removeEventListener('abort', cleanup)

--- a/src/shared/browser-client-host-protocol.test.ts
+++ b/src/shared/browser-client-host-protocol.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import {
+  BrowserClientHostAttachParams,
+  BrowserClientHostEvent,
+  BrowserClientHostReady,
+  BrowserNetworkTunnelAttachParams,
+  BrowserNetworkTunnelEvent
+} from './browser-client-host-protocol'
+
+describe('browser client-host control protocol', () => {
+  it('decodes a bounded host attach and server-issued lease fence', () => {
+    expect(
+      BrowserClientHostAttachParams.parse({
+        authorityRuntimeId: 'runtime-a',
+        browserHostClientId: 'host-a',
+        hostCapabilities: ['webview']
+      })
+    ).toEqual({
+      authorityRuntimeId: 'runtime-a',
+      browserHostClientId: 'host-a',
+      hostCapabilities: ['webview']
+    })
+    expect(
+      BrowserClientHostReady.parse({
+        type: 'ready',
+        authorityEpoch: 'epoch-a',
+        browserHostGeneration: 2
+      })
+    ).toEqual({ type: 'ready', authorityEpoch: 'epoch-a', browserHostGeneration: 2 })
+  })
+
+  it('requires every lease and execution-host fence on tunnel attach', () => {
+    expect(() =>
+      BrowserNetworkTunnelAttachParams.parse({
+        authorityRuntimeId: 'runtime-a',
+        browserHostClientId: 'host-a',
+        browserHostGeneration: 1,
+        executionHost: { kind: 'native', runtimeId: 'runtime-a', revision: 1 }
+      })
+    ).toThrow()
+    expect(
+      BrowserNetworkTunnelAttachParams.parse({
+        authorityRuntimeId: 'runtime-a',
+        authorityEpoch: 'epoch-a',
+        browserHostClientId: 'host-a',
+        browserHostGeneration: 1,
+        executionHost: { kind: 'native', runtimeId: 'runtime-a', revision: 1 }
+      })
+    ).toMatchObject({ authorityEpoch: 'epoch-a', browserHostGeneration: 1 })
+  })
+
+  it('rejects invalid server-owned route generations', () => {
+    expect(() => BrowserNetworkTunnelEvent.parse({ type: 'ready', tunnelGeneration: 0 })).toThrow()
+    expect(BrowserNetworkTunnelEvent.parse({ type: 'ready', tunnelGeneration: 3 })).toEqual({
+      type: 'ready',
+      tunnelGeneration: 3
+    })
+  })
+
+  it('binds revocation to the exact authority and host generation', () => {
+    expect(
+      BrowserClientHostEvent.parse({
+        type: 'revoked',
+        authorityEpoch: 'epoch-a',
+        browserHostGeneration: 3,
+        reason: 'replaced'
+      })
+    ).toEqual({
+      type: 'revoked',
+      authorityEpoch: 'epoch-a',
+      browserHostGeneration: 3,
+      reason: 'replaced'
+    })
+  })
+})

--- a/src/shared/browser-client-host-protocol.ts
+++ b/src/shared/browser-client-host-protocol.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod'
+
+const Generation = z.number().int().min(1).max(0xffff_ffff)
+const Identity = z.string().min(1).max(256)
+
+export const BrowserClientHostAttachParams = z.object({
+  authorityRuntimeId: Identity,
+  browserHostClientId: Identity,
+  hostCapabilities: z.array(z.string().min(1).max(128)).max(32)
+})
+
+export const BrowserClientHostReady = z.object({
+  type: z.literal('ready'),
+  authorityEpoch: Identity,
+  browserHostGeneration: Generation
+})
+
+export const BrowserClientHostEvent = z.discriminatedUnion('type', [
+  BrowserClientHostReady,
+  z.object({
+    type: z.literal('revoked'),
+    authorityEpoch: Identity,
+    browserHostGeneration: Generation,
+    reason: z.enum(['replaced', 'released'])
+  })
+])
+
+export const BrowserHostLeaseAuthority = z.object({
+  authorityRuntimeId: Identity,
+  authorityEpoch: Identity,
+  browserHostClientId: Identity,
+  browserHostGeneration: Generation
+})
+
+export type BrowserHostLeaseAuthority = z.infer<typeof BrowserHostLeaseAuthority>
+
+export const BrowserNetworkTunnelAttachParams = BrowserHostLeaseAuthority.extend({
+  executionHost: z.object({
+    kind: z.literal('native'),
+    runtimeId: Identity,
+    revision: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER)
+  })
+})
+
+export const BrowserNetworkTunnelEvent = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('ready'), tunnelGeneration: Generation }),
+  z.object({ type: z.literal('closed'), tunnelGeneration: Generation })
+])


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​786 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​28 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​758 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​732 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​56 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​676 |

<!-- /orca-pr-loc -->

## Summary

- add runtime-owned browser-host leases, authority epochs, exact host selection, and monotonic host/page/tunnel generations
- bind tunnel authorization to the paired device and exact native execution-host runtime revision
- notify replaced or released desktop hosts with an epoch-and-generation-bound revocation
- prove the lease-to-SOCKS-to-runtime HTTP path over an isolated paired E2EE subscription

This is the third inert layer for [STA-4150](https://linear.app/stably/issue/STA-4150/refactor-remote-browser-to-client-hosted-electron-webviews), stacked on #14470. Neither RPC method is registered in production and neither capability is advertised, so this does not change live browser behavior or mixed-version peers.

## Causal evidence

Before lease enforcement, an authenticated paired runtime could self-assert its paired device ID and receive a ready tunnel generation without any server-owned browser-host lease. The unchanged authorization oracle failed before this layer and passes after exact lease, epoch, host-generation, device, and execution-revision validation.

A fresh review also found that server-side replacement alone left the old desktop believing its lease was live. The final implementation emits an exact revocation; server and client tests cover replacement, release, premature and mismatched events, malformed reasons, duplicate readiness, closure, and reporting.

## Validation

- 10 focused files / 60 lease, route, SOCKS, flow-control, lifecycle, and paired E2EE tests
- 14 files / 85 unique tunnel, lease, binary-router, and remote-runtime tests
- cross-version terminal wire: 5 tests
- `pnpm typecheck`
- native and type-aware code-quality audits
- reliability-gate manifest and max-lines ratchet
- fresh correctness and security/performance reviews: no inert-stage blockers

## Deliberately deferred before activation

- bounded attach/open admission, aggregate route/host/process memory ledgers, and fair scheduling
- page-placement retirement
- SOCKS local-process trust decision
- SSH/WSL/Linux/physical-Windows and old/new-peer journeys
- Electron partition proxy/no-fallback proof and UI activation
