### PR TITLE
revert: restore git history tooltip change for community PR

### DIFF
--- a/src/renderer/src/components/right-sidebar/GitHistoryPanel.test.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHistoryPanel.test.tsx
@@ -76,33 +76,4 @@ describe('GitHistoryPanel', () => {
     expect(markup).toContain('Fix tab overflow')
     expect(markup).toContain('52ad492')
   })
-
-  it('does not add native title tooltips alongside managed history tooltips', () => {
-    const result = makeHistoryResult()
-    result.items[0].references = [
-      { id: 'refs/heads/main', name: 'main', category: 'branches' },
-      { id: 'refs/heads/feature', name: 'feature', category: 'branches' },
-      { id: 'refs/tags/v1.0.0', name: 'v1.0.0', category: 'tags' }
-    ]
-
-    const markup = renderToStaticMarkup(
-      <GitHistoryPanel
-        state={{ status: 'ready', result }}
-        collapsed={false}
-        onToggle={vi.fn()}
-        onRefresh={vi.fn()}
-        onOpenCommit={vi.fn()}
-      />
-    )
-
-    expect(markup).toContain('Fix tab overflow')
-    expect(markup).toContain('main')
-    expect(markup).toContain('feature')
-    expect(markup).toContain('+1')
-    expect(markup).not.toContain('title="Fix tab overflow"')
-    expect(markup).not.toContain('title="main"')
-    expect(markup).not.toContain('title="feature"')
-    expect(markup).not.toContain('title="v1.0.0"')
-    expect(markup).not.toMatch(/\stitle=/)
-  })
 })

--- a/src/renderer/src/components/right-sidebar/GitHistoryRow.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHistoryRow.tsx
@@ -20,6 +20,7 @@ function GitHistoryRefBadge({ itemRef }: { itemRef: GitHistoryItemRef }): React.
             borderColor: itemRef.color ? graphColor(itemRef.color) : 'var(--border)',
             color: itemRef.color ? graphColor(itemRef.color) : 'var(--muted-foreground)'
           }}
+          title={itemRef.name}
         >
           {itemRef.name}
         </span>
@@ -89,7 +90,9 @@ export const GitHistoryRow = React.forwardRef<HTMLElement, GitHistoryRowProps>(
           )}
           <Tooltip>
             <TooltipTrigger asChild>
-              <span className="block min-w-0 flex-1 truncate text-foreground">{item.subject}</span>
+              <span className="block min-w-0 flex-1 truncate text-foreground" title={rowTooltip}>
+                {item.subject}
+              </span>
             </TooltipTrigger>
             <TooltipContent
               side="bottom"
@@ -109,7 +112,10 @@ export const GitHistoryRow = React.forwardRef<HTMLElement, GitHistoryRowProps>(
             {hiddenRefs.length > 0 && (
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <span className="shrink-0 text-[10px] leading-none text-muted-foreground">
+                  <span
+                    className="shrink-0 text-[10px] leading-none text-muted-foreground"
+                    title={hiddenRefs.map((ref) => ref.name).join(', ')}
+                  >
                     +{hiddenRefs.length}
                   </span>
                 </TooltipTrigger>
@@ -129,6 +135,7 @@ export const GitHistoryRow = React.forwardRef<HTMLElement, GitHistoryRowProps>(
           {...rootProps}
           ref={ref as React.Ref<HTMLDivElement>}
           className={rowClassName}
+          title={rowTooltip}
           data-testid="git-history-row"
         >
           {rowContent}
@@ -150,6 +157,7 @@ export const GitHistoryRow = React.forwardRef<HTMLElement, GitHistoryRowProps>(
         ref={ref as React.Ref<HTMLButtonElement>}
         type="button"
         className={rowClassName}
+        title={rowTooltip}
         aria-expanded={canExpand ? expanded : undefined}
         aria-label={
           canExpand

--- a/tests/e2e/git-history-tooltip-wrap.spec.ts
+++ b/tests/e2e/git-history-tooltip-wrap.spec.ts
@@ -73,9 +73,7 @@ test('keeps conventional commit-message lines intact in the history tooltip', as
 
   const row = orcaPage.getByTestId('git-history-row').filter({ hasText: subject })
   await expect(row).toBeVisible({ timeout: 10_000 })
-  await expect(row).not.toHaveAttribute('title')
   const trigger = row.locator('[data-slot="tooltip-trigger"]').filter({ hasText: subject })
-  await expect(trigger).not.toHaveAttribute('title')
   await trigger.hover({ position: { x: 20, y: 10 } })
   await trigger.hover({ position: { x: 40, y: 10 } })
 


### PR DESCRIPTION
## ELI5

This takes our earlier tooltip fix off `main` so the original community PR can land instead.

## What Changed

Reverts #14468. The same fix comes back through #14453, authored by @dngur6344.

## Why

#14453 already had the same change. Landing theirs gives the contributor credit for the work they submitted first.

## Linked Issue

Related: #14432

## Visual Proof

N/A — revert only. Behavior is restored by #14453.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

No new tests. This restores the pre-#14468 tree for the three tooltip files so #14453 can merge cleanly.

## Review

- Security / SSH / mobile / performance: revert of a renderer-only tooltip change.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: N/A
