### PR TITLE
fix(linear): label Start workspace and add Open on Linear

### DIFF
--- a/src/renderer/src/components/LinearIssueWorkspace.tsx
+++ b/src/renderer/src/components/LinearIssueWorkspace.tsx
@@ -10,10 +10,11 @@ import {
   ChevronLeft,
   ChevronRight,
   Clipboard,
+  Copy,
+  ExternalLink,
   FolderKanban,
   FolderOpen,
   GitBranch,
-  Link,
   LoaderCircle,
   Plus,
   RefreshCw,
@@ -782,6 +783,7 @@ export default function LinearIssueWorkspace({
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
+                type="button"
                 variant="ghost"
                 size="icon-sm"
                 onClick={() => void copyTextToClipboard(displayed.url, 'URL')}
@@ -790,7 +792,7 @@ export default function LinearIssueWorkspace({
                   'Copy Linear URL'
                 )}
               >
-                <Link className="size-4" />
+                <Copy className="size-4" />
               </Button>
             </TooltipTrigger>
             <TooltipContent side="bottom" sideOffset={6}>
@@ -800,19 +802,20 @@ export default function LinearIssueWorkspace({
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
+                type="button"
                 variant="ghost"
                 size="icon-sm"
-                onClick={() => void copyTextToClipboard(displayed.identifier, 'Identifier')}
+                onClick={() => void window.api.shell.openUrl(displayed.url)}
                 aria-label={translate(
-                  'auto.components.LinearIssueWorkspace.9e3c49beb8',
-                  'Copy issue identifier'
+                  'auto.components.LinearIssueWorkspace.openOnLinear',
+                  'Open on Linear'
                 )}
               >
-                <Clipboard className="size-4" />
+                <ExternalLink className="size-4" />
               </Button>
             </TooltipTrigger>
             <TooltipContent side="bottom" sideOffset={6}>
-              {translate('auto.components.LinearIssueWorkspace.30c1242f3a', 'Copy identifier')}
+              {translate('auto.components.LinearIssueWorkspace.openOnLinear', 'Open on Linear')}
             </TooltipContent>
           </Tooltip>
           {attachedWorkspace ? (
@@ -858,24 +861,19 @@ export default function LinearIssueWorkspace({
               </DropdownMenuContent>
             </DropdownMenu>
           ) : (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon-sm"
-                  onClick={handleOpenOrUseIssue}
-                  aria-label={translate(
-                    'auto.components.LinearIssueWorkspace.30a7f56c0a',
-                    'Start workspace from issue'
-                  )}
-                >
-                  <ArrowRight className="size-4" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom" sideOffset={6}>
-                {translate('auto.components.LinearIssueWorkspace.e1e0a9bca9', 'Start workspace')}
-              </TooltipContent>
-            </Tooltip>
+            <Button
+              type="button"
+              size="sm"
+              onClick={handleOpenOrUseIssue}
+              className="gap-1.5 whitespace-nowrap"
+              aria-label={translate(
+                'auto.components.LinearIssueWorkspace.30a7f56c0a',
+                'Start workspace from issue'
+              )}
+            >
+              {translate('auto.components.LinearIssueWorkspace.e1e0a9bca9', 'Start workspace')}
+              <ArrowRight className="size-3.5" />
+            </Button>
           )}
           {variant === 'sheet' ? (
             <Tooltip>

--- a/src/renderer/src/components/linear-issue-workspace-header.test.ts
+++ b/src/renderer/src/components/linear-issue-workspace-header.test.ts
@@ -24,6 +24,7 @@ describe('LinearIssueWorkspace header actions', () => {
     expect(header).toContain("'Start workspace'")
     expect(header).toContain("'Start workspace from issue'")
     expect(header).not.toContain("'Copy issue identifier'")
-    expect(header).not.toContain('size="icon-sm"\n                  onClick={handleOpenOrUseIssue}')
+    expect(header).toMatch(/size="sm"[\s\S]*onClick=\{handleOpenOrUseIssue\}/)
+    expect(header).not.toMatch(/size="icon-sm"\s+onClick=\{handleOpenOrUseIssue\}/)
   })
 })

--- a/src/renderer/src/components/linear-issue-workspace-header.test.ts
+++ b/src/renderer/src/components/linear-issue-workspace-header.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const source = readFileSync(join(__dirname, 'LinearIssueWorkspace.tsx'), 'utf8')
+
+function headerSource(): string {
+  const start = source.indexOf('<header className="flex h-[61px]')
+  const end = source.indexOf('</header>', start)
+  expect(start).toBeGreaterThanOrEqual(0)
+  expect(end).toBeGreaterThan(start)
+  return source.slice(start, end)
+}
+
+describe('LinearIssueWorkspace header actions', () => {
+  it('exposes copy, open-on-Linear, and a labeled start-workspace control', () => {
+    const header = headerSource()
+
+    expect(header).toContain("copyTextToClipboard(displayed.url, 'URL')")
+    expect(header).toContain('window.api.shell.openUrl(displayed.url)')
+    expect(header).toContain("'Open on Linear'")
+    expect(header).toContain('<Copy className="size-4" />')
+    expect(header).toContain('<ExternalLink className="size-4" />')
+    expect(header).toContain("'Start workspace'")
+    expect(header).toContain("'Start workspace from issue'")
+    expect(header).not.toContain("'Copy issue identifier'")
+    expect(header).not.toContain('size="icon-sm"\n                  onClick={handleOpenOrUseIssue}')
+  })
+})

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -1361,6 +1361,7 @@
         "519c3587f3": "Add to project",
         "openAttachedWorkspace": "Open workspace attached to issue",
         "openWorkspace": "Open workspace",
+        "openOnLinear": "Open on Linear",
         "moreWorkspaceActions": "More issue workspace actions",
         "startNewWorkspace": "Start new workspace",
         "workspaceSection": "Workspace",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -1242,6 +1242,7 @@
         "519c3587f3": "Agregar al proyecto",
         "openAttachedWorkspace": "Abrir el espacio de trabajo vinculado al issue",
         "openWorkspace": "Abrir espacio de trabajo",
+        "openOnLinear": "Abrir en Linear",
         "moreWorkspaceActions": "Más acciones del espacio de trabajo del issue",
         "startNewWorkspace": "Iniciar un espacio de trabajo nuevo",
         "workspaceSection": "Espacio de trabajo",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -1242,6 +1242,7 @@
         "519c3587f3": "プロジェクトに追加",
         "openAttachedWorkspace": "Issue にリンクされたワークスペースを開く",
         "openWorkspace": "ワークスペースを開く",
+        "openOnLinear": "Linear で開く",
         "moreWorkspaceActions": "Issue ワークスペースのその他の操作",
         "startNewWorkspace": "新規ワークスペースを開始",
         "workspaceSection": "ワークスペース",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -1242,6 +1242,7 @@
         "519c3587f3": "프로젝트에 추가",
         "openAttachedWorkspace": "이슈에 연결된 워크스페이스 열기",
         "openWorkspace": "워크스페이스 열기",
+        "openOnLinear": "Linear에서 열기",
         "moreWorkspaceActions": "이슈 워크스페이스 작업 더 보기",
         "startNewWorkspace": "새 워크스페이스 시작",
         "workspaceSection": "워크스페이스",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -1242,6 +1242,7 @@
         "519c3587f3": "添加到项目",
         "openAttachedWorkspace": "打开关联到议题的工作区",
         "openWorkspace": "打开工作区",
+        "openOnLinear": "在 Linear 中打开",
         "moreWorkspaceActions": "更多议题工作区操作",
         "startNewWorkspace": "启动新工作区",
         "workspaceSection": "工作区",


### PR DESCRIPTION
## ELI5

The Linear issue page used to hide the important actions behind three look-alike icons. The arrow was "start a workspace," which was easy to miss. This matches the GitHub issue page: a quiet copy button, an Open on Linear button, and a labeled Start workspace button.

## What Changed

- Replace the unlabeled Start workspace arrow with a filled **Start workspace** button.
- Add **Open on Linear** (external-link icon). It opens the issue URL in the system browser, same as Open on GitHub.
- Keep copy as a clipboard icon. Move identifier copy out of the header; it already lives under Actions.
- If a workspace is already attached, keep **Open workspace** plus the chevron for **Start new workspace**.

## Why

The Linear header was harder to use than the GitHub issue page. The primary action did not look like a button, and there was no way to open the real Linear issue without copying the URL.

## Linked Issue

No tracker linked.

## Visual Proof

**Before** — three unlabeled icons (link, copy, arrow):

![before](https://github.com/user-attachments/assets/4febcd1b-4abd-4f36-8ca5-e98163f3b820)

**After** — copy, Open on Linear, labeled Start workspace:

![after](https://github.com/user-attachments/assets/4852ca95-5a64-4599-aa09-f0e72abd2be3)

## Testing

- Vitest: `src/renderer/src/components/linear-issue-workspace-header.test.ts` (source contract for header actions)
- Manually opened a Linear issue page in a local Orca build on macOS and confirmed Copy, Open on Linear tooltip, and labeled Start workspace render. Did not click Open on Linear through to the system browser.
- Not retested on Linux, Windows, or SSH. `shell.openUrl` is the same path GitHub already uses.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

- Security: opens the issue's existing `url` through `window.api.shell.openUrl`. No new URL construction.
- Cross-platform: no new shortcuts or path logic. `shell.openUrl` already used by GitHub/Linear drawer.
- SSH/remote: Tasks page header is renderer-local. Opening Linear does not depend on a workspace runtime.
- Mobile: desktop-only surface.
- Performance: header markup only.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @JinjingLiang
