### PR TITLE
feat(browser): bound host admission

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -2589,16 +2589,16 @@
       "providers": ["local", "remote-runtime", "ssh", "wsl"],
       "coveredPlatforms": ["macos"],
       "coveredProviders": ["remote-runtime"],
-      "coverageNotes": "Deterministic protocol, registry, injected-socket, and loopback-listener tests cover strict framing, remote-DNS targets, exact destination-write and source-consumption credit, bounded receive bytes and chunks, authority epochs, exact host selection, monotonic host/page/route generations, connection-owned cleanup, exact client revocation, stale and replaced fences, retired stream IDs, half-close and close ordering, SOCKS CONNECT, bind/close races, listener wildcard normalization, unsupported commands, unavailable routes, and raw/terminal binary-handler isolation. Explicitly injected browser-host and paired-runtime tunnel methods lease one exact host, then carry SOCKS and HTTP bytes over a dedicated E2EE socket to the fenced native execution-host revision and prove route close destroys the destination socket. Both methods and capabilities remain disabled in production. SSH and WSL providers remain uncovered.",
+      "coverageNotes": "Deterministic protocol, registry, injected-socket, and loopback-listener tests cover strict framing, remote-DNS targets, exact destination-write and source-consumption credit, bounded receive bytes and chunks, authority epochs, exact host selection, one host per authenticated connection, four hosts per paired device, long-poll metering and disconnect abort, monotonic host/page/route generations without page tombstones, connection-owned cleanup, exact client revocation, stale and replaced fences, retired stream IDs, half-close and close ordering, SOCKS CONNECT, bind/close races, listener wildcard normalization, unsupported commands, unavailable routes, and raw/terminal binary-handler isolation. Explicitly injected browser-host and paired-runtime tunnel methods lease one exact host, then carry SOCKS and HTTP bytes over a dedicated E2EE socket to the fenced native execution-host revision and prove route close destroys the destination socket. Both methods and capabilities remain disabled in production. SSH and WSL providers remain uncovered.",
       "motivatingLinks": [
         "https://linear.app/stably/issue/STA-4150/refactor-remote-browser-to-client-hosted-electron-webviews"
       ],
       "invariant": "A client-hosted browser network route exists only for an exact live server-owned browser-host lease, authority epoch, host generation, paired identity, execution-host revision, and server-owned route generation. Host selection never chooses arbitrarily, stale cleanup cannot remove a replacement, destination names remain unresolved until the execution host, credit returns only after writes settle, and route loss never falls back to desktop DNS or sockets. The local SOCKS endpoint accepts only loopback CONNECT and rejects unsupported commands.",
-      "oracle": "Attach two browser hosts and require unqualified selection to fail ambiguous while exact selection succeeds. Replace one same-device connection, require the old subscription and route to fence, then prove late old cleanup leaves the new generation live. Reject missing, stale, wrong-device, wrong-epoch, and wrong-execution-revision tunnel requests before binary registration. Drive the accepted lease through a real paired E2EE SOCKS-to-HTTP journey, then exercise exact frame, credit, half-close, stale-stream, remote-DNS, unsupported-command, offline, and teardown assertions.",
+      "oracle": "Attach two browser hosts and require unqualified selection to fail ambiguous while exact selection succeeds. Reject a second identity on one connection and a fifth identity for one paired device, release one exact lease, then admit its replacement without starving another device. Saturate the browser-host long-poll sub-cap, require an ordinary wait to remain admitted, close the socket, and prove both counters and handlers release. Replace one same-device connection, require the old subscription and route to fence, then prove late old cleanup leaves the new generation live. Retire a closed page placement by exact token, reject delayed cleanup against a replacement and server placement, and require its reused ID to receive a higher global generation without retaining a tombstone. Reject missing, stale, wrong-device, wrong-epoch, and wrong-execution-revision tunnel requests before binary registration. Drive the accepted lease through a real paired E2EE SOCKS-to-HTTP journey, then exercise exact frame, credit, half-close, stale-stream, remote-DNS, unsupported-command, offline, and teardown assertions.",
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/shared/browser-network-capabilities.test.ts src/shared/browser-network-tunnel-protocol.test.ts src/main/browser/browser-network-tunnel-session.test.ts src/main/browser/remote-browser-socks-server.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/main/browser/browser-network-tunnel-client.test.ts src/main/browser/paired-runtime-browser-network-route.test.ts src/main/runtime/runtime-binary-message-router.test.ts src/main/runtime/rpc/methods/browser-network-tunnel.test.ts src/main/runtime/browser-network-tunnel-paired-runtime.integration.test.ts",
-        "pnpm exec vitest run --config config/vitest.config.ts src/shared/browser-client-host-protocol.test.ts src/main/runtime/browser-host-lease-registry.test.ts src/main/runtime/rpc/methods/browser-client-host.test.ts src/main/runtime/rpc/methods/browser-network-tunnel.test.ts src/main/browser/paired-runtime-browser-host-lease.test.ts src/main/browser/paired-runtime-browser-network-route.test.ts src/main/runtime/browser-network-tunnel-paired-runtime.integration.test.ts src/main/browser/browser-network-tunnel-client.test.ts src/main/browser/browser-network-tunnel-session.test.ts src/main/browser/remote-browser-socks-server.test.ts",
+        "pnpm exec vitest run --config config/vitest.config.ts src/shared/browser-client-host-protocol.test.ts src/main/runtime/browser-host-lease-registry.test.ts src/main/runtime/runtime-rpc-browser-host-admission.test.ts src/main/runtime/rpc/methods/browser-client-host.test.ts src/main/runtime/rpc/methods/browser-network-tunnel.test.ts src/main/browser/paired-runtime-browser-host-lease.test.ts src/main/browser/paired-runtime-browser-network-route.test.ts src/main/runtime/browser-network-tunnel-paired-runtime.integration.test.ts src/main/browser/browser-network-tunnel-client.test.ts src/main/browser/browser-network-tunnel-session.test.ts src/main/browser/remote-browser-socks-server.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/shared/remote-runtime-client.test.ts"
       ],
       "testFiles": [
@@ -2606,6 +2606,7 @@
         "src/shared/browser-client-host-protocol.test.ts",
         "src/shared/browser-network-tunnel-protocol.test.ts",
         "src/main/runtime/browser-host-lease-registry.test.ts",
+        "src/main/runtime/runtime-rpc-browser-host-admission.test.ts",
         "src/main/runtime/rpc/methods/browser-client-host.test.ts",
         "src/main/browser/paired-runtime-browser-host-lease.test.ts",
         "src/main/browser/browser-network-tunnel-session.test.ts",
@@ -2622,9 +2623,19 @@
           "file": "src/main/runtime/browser-host-lease-registry.test.ts",
           "assertions": [
             "multiple live hosts require exact selection instead of first-connected routing",
+            "one connection and one paired device cannot retain more than their exact host limits",
             "same-device replacement increments generation and fences the old connection",
             "late cleanup cannot remove a newer lease or route generation",
+            "late page cleanup cannot remove a replacement client generation or server placement",
+            "retired page placement leaves no tombstone and a reused ID receives a higher global generation",
             "page placement generations are monotonic and stale lease authority is rejected"
+          ]
+        },
+        {
+          "file": "src/main/runtime/runtime-rpc-browser-host-admission.test.ts",
+          "assertions": [
+            "browser-host attachment has a dedicated sub-cap that preserves ordinary wait admission",
+            "socket close aborts the exact host and wait handlers and releases both counters"
           ]
         },
         {
@@ -2632,6 +2643,7 @@
           "assertions": [
             "the control method stays out of production registration",
             "only a negotiated authenticated paired-runtime connection receives a server-owned epoch and generation",
+            "a second browser-host identity on one authenticated connection is rejected",
             "connection cleanup releases the exact lease and replacement emits an epoch-and-generation-bound revocation"
           ]
         },
@@ -2710,10 +2722,10 @@
           "date": "2026-08-14",
           "runner": "local",
           "platform": "macos",
-          "command": "pnpm exec vitest run --config config/vitest.config.ts src/shared/browser-client-host-protocol.test.ts src/main/runtime/browser-host-lease-registry.test.ts src/main/runtime/rpc/methods/browser-client-host.test.ts src/main/runtime/rpc/methods/browser-network-tunnel.test.ts src/main/browser/paired-runtime-browser-host-lease.test.ts src/main/browser/paired-runtime-browser-network-route.test.ts src/main/runtime/browser-network-tunnel-paired-runtime.integration.test.ts src/main/browser/browser-network-tunnel-client.test.ts src/main/browser/browser-network-tunnel-session.test.ts src/main/browser/remote-browser-socks-server.test.ts",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/shared/browser-client-host-protocol.test.ts src/main/runtime/browser-host-lease-registry.test.ts src/main/runtime/runtime-rpc-browser-host-admission.test.ts src/main/runtime/rpc/methods/browser-client-host.test.ts src/main/runtime/rpc/methods/browser-network-tunnel.test.ts src/main/browser/paired-runtime-browser-host-lease.test.ts src/main/browser/paired-runtime-browser-network-route.test.ts src/main/runtime/browser-network-tunnel-paired-runtime.integration.test.ts src/main/browser/browser-network-tunnel-client.test.ts src/main/browser/browser-network-tunnel-session.test.ts src/main/browser/remote-browser-socks-server.test.ts",
           "result": "passed",
           "durationSeconds": 3.4,
-          "summary": "Ten files passed 60 lease, authority, placement, capability, route-generation, adversarial-revocation, lifecycle, flow-control, SOCKS, and real paired E2EE tests."
+          "summary": "Eleven files passed 67 lease, reserved long-poll and host admission, token-safe placement retirement, authority, capability, route-generation, adversarial-revocation, lifecycle, flow-control, SOCKS, and real paired E2EE tests."
         },
         {
           "date": "2026-08-13",
@@ -2753,11 +2765,11 @@
       },
       "redGreenEvidence": {
         "status": "partial",
-        "evidence": "The protocol and tunnel-session oracles fail on origin/main 3246b73add because the modules do not exist, then pass on the candidate. The lease registry and control-client suites were recorded red at missing modules before implementation. The unchanged tunnel authorization oracle was behaviorally red because an authenticated socket could self-assert its paired device ID and received ready generation 7 without a lease; it is green after server-owned lease and route fencing. The real paired journey failed at the missing network.browserTunnel method before explicit test injection, then passed with an exact control lease while both production registries remained closed. Full mutation/revert evidence remains to be collected before promotion."
+        "evidence": "The protocol and tunnel-session oracles fail on origin/main 3246b73add because the modules do not exist, then pass on the candidate. The lease registry and control-client suites were recorded red at missing modules before implementation. The unchanged tunnel authorization oracle was behaviorally red because an authenticated socket could self-assert its paired device ID and received ready generation 7 without a lease; it is green after server-owned lease and route fencing. On c9a41abf24, the unchanged admission oracle failed three ways: a second identity on one connection and a fifth identity for one paired device were both admitted, and closed page placement had no retirement API. All three pass after bounded admission and tombstone-free global page generations. The real paired journey failed at the missing network.browserTunnel method before explicit test injection, then passed with an exact control lease while both production registries remained closed. Full mutation/revert evidence remains to be collected before promotion."
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "Data frames, send credit, pending bytes and chunk counts in both directions, streams, SOCKS handshake and pipelined application bytes are bounded. Credit returns only after the execution-host or browser-facing socket write settles, and the injected transport must explicitly accept each frame. Aggregate route, browser-host, and process ledgers plus drain-aware fair scheduling remain required before live tunnel advertisement."
+        "evidence": "Data frames, send credit, pending bytes and chunk counts in both directions, streams, SOCKS handshake and pipelined application bytes are bounded. One authenticated connection retains at most one browser host and one paired device at most four, with exact release restoring admission. Permanent browser-host polls use at most one quarter of the shared long-poll slots, and real injected dispatch proves an ordinary wait remains admitted and socket close releases both classes. Credit returns only after the execution-host or browser-facing socket write settles, and the injected transport must explicitly accept each frame. Pending-open/rate admission, aggregate route/browser-host/process byte ledgers, and drain-aware fair scheduling remain required before live tunnel advertisement."
       },
       "promotionCriteria": [
         "Add bounded pending-open admission and open-rate limits plus aggregate route, browser-host, and process memory ledgers with runtime-wide fair scheduling.",
@@ -2768,6 +2780,7 @@
       ],
       "knownGaps": [
         "No runtime capability is advertised, the paired tunnel method is not registered in production, and no Electron webview selects it yet.",
+        "The token-safe page-retirement API has no production lifecycle caller until client placement activates.",
         "Pending-open and open-rate admission plus aggregate encrypted-WebSocket and destination-buffer accounting are not implemented.",
         "The loopback SOCKS endpoint uses Chromium-compatible no-auth and is not safe to activate until its desktop trust boundary is approved or isolated.",
         "SSH, WSL, browserless serve, Electron proxy policy, UDP denial, and desktop DNS/socket capture are not exercised."

--- a/src/main/runtime/browser-host-lease-registry.test.ts
+++ b/src/main/runtime/browser-host-lease-registry.test.ts
@@ -58,6 +58,72 @@ describe('BrowserHostLeaseRegistry', () => {
     ).toThrow('browser_host_identity_conflict')
   })
 
+  it('admits only one distinct browser host per authenticated connection', () => {
+    const leases = registry()
+    const first = leases.attach({
+      browserHostClientId: 'host-a',
+      connectionId: 'connection-a',
+      pairedDeviceId: 'device-a',
+      hostCapabilities: ['webview']
+    })
+
+    expect(() =>
+      leases.attach({
+        browserHostClientId: 'host-b',
+        connectionId: 'connection-a',
+        pairedDeviceId: 'device-a',
+        hostCapabilities: ['webview']
+      })
+    ).toThrow('browser_host_connection_capacity')
+    first.release()
+    expect(
+      leases.attach({
+        browserHostClientId: 'host-b',
+        connectionId: 'connection-a',
+        pairedDeviceId: 'device-a',
+        hostCapabilities: ['webview']
+      }).lease.browserHostClientId
+    ).toBe('host-b')
+  })
+
+  it('bounds distinct browser hosts per paired device without starving another device', () => {
+    const leases = registry()
+    const handles = Array.from({ length: 4 }, (_, index) =>
+      leases.attach({
+        browserHostClientId: `host-${index}`,
+        connectionId: `connection-${index}`,
+        pairedDeviceId: 'device-a',
+        hostCapabilities: ['webview']
+      })
+    )
+
+    expect(() =>
+      leases.attach({
+        browserHostClientId: 'host-overflow',
+        connectionId: 'connection-overflow',
+        pairedDeviceId: 'device-a',
+        hostCapabilities: ['webview']
+      })
+    ).toThrow('browser_host_device_capacity')
+    expect(
+      leases.attach({
+        browserHostClientId: 'host-other-device',
+        connectionId: 'connection-other-device',
+        pairedDeviceId: 'device-b',
+        hostCapabilities: ['webview']
+      }).lease.browserHostClientId
+    ).toBe('host-other-device')
+    handles[0]!.release()
+    expect(
+      leases.attach({
+        browserHostClientId: 'host-after-release',
+        connectionId: 'connection-after-release',
+        pairedDeviceId: 'device-a',
+        hostCapabilities: ['webview']
+      }).lease.browserHostClientId
+    ).toBe('host-after-release')
+  })
+
   it('allocates monotonic page generations and rejects a stale host generation', () => {
     const leases = registry()
     const first = leases.attach({
@@ -94,6 +160,43 @@ describe('BrowserHostLeaseRegistry', () => {
       browserHostGeneration: 2,
       pageHostGeneration: 2
     })
+  })
+
+  it('retires closed page placement without reusing its generation', () => {
+    const leases = registry()
+    leases.attach({
+      browserHostClientId: 'host-a',
+      connectionId: 'connection-a',
+      pairedDeviceId: 'device-a',
+      hostCapabilities: ['webview']
+    })
+    const first = leases.placeClientPage('page-a', 'host-a')
+
+    expect(leases.retirePage('page-a', first)).toBe(true)
+
+    expect(leases.getPlacement('page-a')).toBeUndefined()
+    expect(leases.placeClientPage('page-a', 'host-a')).toMatchObject({
+      pageHostGeneration: first.kind === 'client' ? first.pageHostGeneration + 1 : Number.NaN
+    })
+  })
+
+  it('does not let late cleanup retire a replacement or server placement', () => {
+    const leases = registry()
+    leases.attach({
+      browserHostClientId: 'host-a',
+      connectionId: 'connection-a',
+      pairedDeviceId: 'device-a',
+      hostCapabilities: ['webview']
+    })
+    const first = leases.placeClientPage('page-a', 'host-a')
+    const replacement = leases.placeClientPage('page-a', 'host-a')
+
+    expect(leases.retirePage('page-a', first)).toBe(false)
+    expect(leases.getPlacement('page-a')).toBe(replacement)
+    const server = leases.placeServerPage('page-a')
+    expect(leases.retirePage('page-a', replacement)).toBe(false)
+    expect(leases.getPlacement('page-a')).toBe(server)
+    expect(leases.retirePage('page-a', server)).toBe(true)
   })
 
   it('binds tunnel generations to the lease and fences replaced routes', async () => {

--- a/src/main/runtime/browser-host-lease-registry.ts
+++ b/src/main/runtime/browser-host-lease-registry.ts
@@ -1,6 +1,9 @@
 import { randomUUID } from 'node:crypto'
 
 const MAX_GENERATION = 0xffff_ffff
+const MAX_BROWSER_HOSTS_PER_CONNECTION = 1
+// Why: tolerate brief desktop restart/update overlap while keeping one paired identity bounded.
+const MAX_BROWSER_HOSTS_PER_PAIRED_DEVICE = 4
 
 export type RuntimeBrowserPlacement =
   | { kind: 'server' }
@@ -64,8 +67,9 @@ export class BrowserHostLeaseRegistry {
   readonly authorityRuntimeId: string
   readonly authorityEpoch: string
   private nextHostGeneration = 1
+  // Why: a global counter lets closed page IDs leave no tombstone without reusing a stale generation.
+  private nextPageGeneration = 1
   private nextTunnelGeneration = 1
-  private readonly nextPageGenerationByPageId = new Map<string, number>()
   private readonly leasesByClientId = new Map<string, LeaseState>()
   private readonly routesByKey = new Map<string, RouteState>()
   private readonly placementsByPageId = new Map<string, RuntimeBrowserPlacement>()
@@ -87,6 +91,7 @@ export class BrowserHostLeaseRegistry {
         throw new Error('browser_host_identity_conflict')
       }
     }
+    this.assertLeaseAdmission(input, existing)
     const generation = this.takeGeneration('host')
     if (existing) {
       this.fenceLease(existing, 'replaced')
@@ -155,7 +160,7 @@ export class BrowserHostLeaseRegistry {
 
   placeClientPage(browserPageId: string, browserHostClientId?: string): RuntimeBrowserPlacement {
     const lease = this.select(browserHostClientId)
-    const pageHostGeneration = this.takePageGeneration(browserPageId)
+    const pageHostGeneration = this.takePageGeneration()
     const placement = Object.freeze({
       kind: 'client' as const,
       browserHostClientId: lease.browserHostClientId,
@@ -168,6 +173,13 @@ export class BrowserHostLeaseRegistry {
 
   getPlacement(browserPageId: string): RuntimeBrowserPlacement | undefined {
     return this.placementsByPageId.get(browserPageId)
+  }
+
+  retirePage(browserPageId: string, expected: RuntimeBrowserPlacement): boolean {
+    if (this.placementsByPageId.get(browserPageId) !== expected) {
+      return false
+    }
+    return this.placementsByPageId.delete(browserPageId)
   }
 
   openTunnel(
@@ -199,6 +211,31 @@ export class BrowserHostLeaseRegistry {
 
   private releaseLease(state: LeaseState): void {
     this.fenceLease(state, 'lease_released')
+  }
+
+  private assertLeaseAdmission(
+    input: { connectionId: string; pairedDeviceId: string },
+    replacement: LeaseState | undefined
+  ): void {
+    let connectionLeases = 0
+    let deviceLeases = 0
+    for (const state of this.leasesByClientId.values()) {
+      if (state === replacement) {
+        continue
+      }
+      if (state.lease.connectionId === input.connectionId) {
+        connectionLeases += 1
+      }
+      if (state.lease.pairedDeviceId === input.pairedDeviceId) {
+        deviceLeases += 1
+      }
+    }
+    if (connectionLeases >= MAX_BROWSER_HOSTS_PER_CONNECTION) {
+      throw new Error('browser_host_connection_capacity')
+    }
+    if (deviceLeases >= MAX_BROWSER_HOSTS_PER_PAIRED_DEVICE) {
+      throw new Error('browser_host_device_capacity')
+    }
   }
 
   private fenceLease(state: LeaseState, reason: FenceReason): void {
@@ -233,12 +270,12 @@ export class BrowserHostLeaseRegistry {
     return value
   }
 
-  private takePageGeneration(browserPageId: string): number {
-    const value = this.nextPageGenerationByPageId.get(browserPageId) ?? 1
+  private takePageGeneration(): number {
+    const value = this.nextPageGeneration
     if (value > MAX_GENERATION) {
       throw new Error('browser_page_generation_exhausted')
     }
-    this.nextPageGenerationByPageId.set(browserPageId, value + 1)
+    this.nextPageGeneration += 1
     return value
   }
 }

--- a/src/main/runtime/rpc/methods/browser-client-host.test.ts
+++ b/src/main/runtime/rpc/methods/browser-client-host.test.ts
@@ -140,4 +140,40 @@ describe('browser.clientHost.attach RPC', () => {
       .release()
     await second
   })
+
+  it('rejects a second browser-host identity on one authenticated connection', async () => {
+    const cleanups = new Map<string, () => void>()
+    const hostRuntime = runtime(cleanups)
+    const dispatcher = new RpcDispatcher({
+      runtime: hostRuntime,
+      methods: BROWSER_CLIENT_HOST_METHODS
+    })
+    const firstReplies: string[] = []
+    const rejectedReplies: string[] = []
+    const options = {
+      connectionId: 'connection-a',
+      clientKind: 'runtime' as const,
+      pairedDeviceId: 'device-a',
+      clientCapabilities: [BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY]
+    }
+    const first = dispatcher.dispatchStreaming(
+      request('host-a'),
+      (reply) => firstReplies.push(reply),
+      options
+    )
+    await vi.waitFor(() => expect(firstReplies).toHaveLength(1))
+
+    await dispatcher.dispatchStreaming(
+      request('host-b'),
+      (reply) => rejectedReplies.push(reply),
+      options
+    )
+
+    expect(JSON.parse(rejectedReplies[0]!)).toMatchObject({
+      ok: false,
+      error: { message: 'browser_host_connection_capacity' }
+    })
+    cleanups.get('browser-client-host:host-a')?.()
+    await first
+  })
 })

--- a/src/main/runtime/runtime-rpc-browser-host-admission.test.ts
+++ b/src/main/runtime/runtime-rpc-browser-host-admission.test.ts
@@ -1,0 +1,104 @@
+import { EventEmitter } from 'node:events'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import type { WebSocket } from 'ws'
+import { DeviceRegistry } from './device-registry'
+import { OrcaRuntimeService } from './orca-runtime'
+import { defineStreamingMethod, type RpcRequest } from './rpc/core'
+import { classifyRuntimeLongPoll, OrcaRuntimeRpcServer } from './runtime-rpc'
+
+const request = (method: string, params?: unknown): RpcRequest => ({
+  id: method,
+  authToken: 'test-token',
+  method,
+  params
+})
+
+describe('runtime RPC browser-host admission', () => {
+  it('classifies host attachment for bounded disconnect-aware admission', () => {
+    expect(classifyRuntimeLongPoll(request('browser.clientHost.attach'))).toBe('browser-host')
+    expect(classifyRuntimeLongPoll(request('terminal.wait'))).toBe('wait')
+    expect(classifyRuntimeLongPoll(request('orchestration.ask'))).toBe('ask')
+    expect(classifyRuntimeLongPoll(request('orchestration.check', { wait: true }))).toBe('wait')
+    expect(classifyRuntimeLongPoll(request('status.get'))).toBeNull()
+  })
+
+  it('reserves wait capacity and releases host admission on socket close', async () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-browser-host-admission-'))
+    const aborted = vi.fn()
+    const blockingMethod = (name: 'browser.clientHost.attach' | 'terminal.wait') =>
+      defineStreamingMethod({
+        name,
+        params: null,
+        handler: async (_params, { signal }) => {
+          await new Promise<void>((resolve) => {
+            signal?.addEventListener(
+              'abort',
+              () => {
+                aborted(name)
+                resolve()
+              },
+              { once: true }
+            )
+          })
+        }
+      })
+    const server = new OrcaRuntimeRpcServer({
+      runtime: new OrcaRuntimeService(),
+      userDataPath,
+      longPollCap: 4,
+      methods: [blockingMethod('browser.clientHost.attach'), blockingMethod('terminal.wait')]
+    })
+    server['deviceRegistry'] = new DeviceRegistry(userDataPath)
+    const device = server['deviceRegistry'].addDevice('runtime-test', 'runtime')
+    server['mobileSocketWiring'] = {
+      getConnectionId: () => 'connection-a'
+    } as unknown as NonNullable<(typeof server)['mobileSocketWiring']>
+    const socket = new FakeWebSocket()
+    const replies: Record<string, unknown>[] = []
+    const dispatch = (id: string, method: string) =>
+      server['handleWebSocketMessage'](
+        JSON.stringify({ id, method, deviceToken: device.token }),
+        (reply) => replies.push(JSON.parse(reply) as Record<string, unknown>),
+        () => {},
+        undefined,
+        socket as unknown as WebSocket
+      )
+
+    try {
+      const host = dispatch('host-a', 'browser.clientHost.attach')
+      await vi.waitFor(() => expect(server['activeBrowserHostLongPolls']).toBe(1))
+      await dispatch('host-overflow', 'browser.clientHost.attach')
+      expect(replies).toContainEqual(
+        expect.objectContaining({
+          id: 'host-overflow',
+          ok: false,
+          error: expect.objectContaining({
+            message: 'browser-host capacity reached; retry with backoff'
+          })
+        })
+      )
+
+      const wait = dispatch('wait-a', 'terminal.wait')
+      await vi.waitFor(() => expect(server['activeLongPolls']).toBe(2))
+
+      socket.readyState = 3
+      socket.emit('close')
+      await Promise.all([host, wait])
+      expect(server['activeLongPolls']).toBe(0)
+      expect(server['activeBrowserHostLongPolls']).toBe(0)
+      expect(aborted).toHaveBeenCalledWith('browser.clientHost.attach')
+      expect(aborted).toHaveBeenCalledWith('terminal.wait')
+    } finally {
+      await server.stop()
+      rmSync(userDataPath, { recursive: true, force: true })
+    }
+  })
+})
+
+class FakeWebSocket extends EventEmitter {
+  readonly OPEN = 1
+  readyState = this.OPEN
+}

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -158,6 +158,8 @@ const LONG_POLL_CAP = 16
 // workers would otherwise hold every slot and starve the mobile/web/CLI/relay
 // clients sharing this runtime. Reserve half the budget for the other classes.
 const ASK_LONG_POLL_SHARE = 0.5
+// Why: permanent browser-host leases may use only one quarter, preserving capacity for waits and asks.
+const BROWSER_HOST_LONG_POLL_SHARE = 0.25
 
 function createWebClientUrl(endpoint: string, pairingUrl: string): string {
   const url = new URL(endpoint)
@@ -442,10 +444,13 @@ const MOBILE_RPC_METHOD_ALLOWLIST = new Set([
 ])
 
 // Why: 'ask' is metered separately from 'wait' — same keepalive/abort wiring, its own sub-cap.
-type LongPollClass = 'ask' | 'wait'
+export type RuntimeLongPollClass = 'ask' | 'browser-host' | 'wait'
 
 // Why: single classifier for long-poll requests (handlers that block on an external event), shared by counter/abort/keepalive. See §3.1.
-function longPollClassOf(request: RpcRequest): LongPollClass | null {
+export function classifyRuntimeLongPoll(request: RpcRequest): RuntimeLongPollClass | null {
+  if (request.method === 'browser.clientHost.attach') {
+    return 'browser-host'
+  }
   if (request.method === 'terminal.wait') {
     return 'wait'
   }
@@ -501,6 +506,7 @@ export class OrcaRuntimeRpcServer {
   private readonly longPollCap: number
   private readonly metadataOwnershipPollMs: number
   private readonly askLongPollCap: number
+  private readonly browserHostLongPollCap: number
   private readonly relayRevokeOutbox: RelayRevokeOutbox
   private deviceRegistry: DeviceRegistry | null = null
   private e2eeKeypair: E2EEKeypair | null = null
@@ -533,6 +539,7 @@ export class OrcaRuntimeRpcServer {
   private activeLongPolls = 0
   // Why: subset of activeLongPolls held by orchestration.ask, fenced by askLongPollCap.
   private activeAskLongPolls = 0
+  private activeBrowserHostLongPolls = 0
 
   constructor({
     runtime,
@@ -564,6 +571,10 @@ export class OrcaRuntimeRpcServer {
     this.metadataOwnershipPollMs = metadataOwnershipPollMs
     // Why: derived, not configurable — the reservation must hold for whatever cap a caller picks.
     this.askLongPollCap = Math.max(1, Math.floor(longPollCap * ASK_LONG_POLL_SHARE))
+    this.browserHostLongPollCap = Math.max(
+      1,
+      Math.floor(longPollCap * BROWSER_HOST_LONG_POLL_SHARE)
+    )
     this.relayRevokeOutbox = new RelayRevokeOutbox(userDataPath)
   }
 
@@ -1513,7 +1524,7 @@ export class OrcaRuntimeRpcServer {
     const request = parsed.request
 
     // Why: long-poll admission fence; short RPCs bypass the counter. See §7 risk #2.
-    const longPoll = longPollClassOf(request)
+    const longPoll = classifyRuntimeLongPoll(request)
     const rejection = this.admitLongPoll(longPoll)
     if (rejection) {
       return this.buildError(request.id, 'runtime_busy', rejection)
@@ -1535,7 +1546,7 @@ export class OrcaRuntimeRpcServer {
   // Why: one fence for both transports — the total cap protects short RPCs, the ask
   // sub-cap protects terminal.wait / check --wait from slow reply-blocked asks.
   // Returns the rejection message, or null once the slot is reserved.
-  private admitLongPoll(longPoll: LongPollClass | null): string | null {
+  private admitLongPoll(longPoll: RuntimeLongPollClass | null): string | null {
     if (!longPoll) {
       return null
     }
@@ -1545,20 +1556,30 @@ export class OrcaRuntimeRpcServer {
     if (longPoll === 'ask' && this.activeAskLongPolls >= this.askLongPollCap) {
       return 'orchestration.ask capacity reached; retry with backoff'
     }
+    if (
+      longPoll === 'browser-host' &&
+      this.activeBrowserHostLongPolls >= this.browserHostLongPollCap
+    ) {
+      return 'browser-host capacity reached; retry with backoff'
+    }
     this.activeLongPolls += 1
     if (longPoll === 'ask') {
       this.activeAskLongPolls += 1
+    } else if (longPoll === 'browser-host') {
+      this.activeBrowserHostLongPolls += 1
     }
     return null
   }
 
-  private releaseLongPoll(longPoll: LongPollClass | null): void {
+  private releaseLongPoll(longPoll: RuntimeLongPollClass | null): void {
     if (!longPoll) {
       return
     }
     this.activeLongPolls = Math.max(0, this.activeLongPolls - 1)
     if (longPoll === 'ask') {
       this.activeAskLongPolls = Math.max(0, this.activeAskLongPolls - 1)
+    } else if (longPoll === 'browser-host') {
+      this.activeBrowserHostLongPolls = Math.max(0, this.activeBrowserHostLongPolls - 1)
     }
   }
 
@@ -1650,7 +1671,7 @@ export class OrcaRuntimeRpcServer {
       wsTransport.setClientId(ws, token)
     }
 
-    const longPoll = longPollClassOf(request)
+    const longPoll = classifyRuntimeLongPoll(request)
     const rejection = this.admitLongPoll(longPoll)
     if (rejection) {
       reply(JSON.stringify(this.buildError(request.id, 'runtime_busy', rejection)))


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​243 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​243 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​89 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​18 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​71 |

<!-- /orca-pr-loc -->

## Summary

- cap one browser-host identity per authenticated connection and four per paired device, with exact release restoring capacity
- meter permanent browser-host subscriptions under a dedicated 25% long-poll sub-cap so terminal/orchestration waits retain capacity
- replace per-page generation tombstones with one global monotonic generation
- make placement retirement token-safe so delayed cleanup cannot delete a newer client generation or server placement

This is the fourth inert layer for [STA-4150](https://linear.app/stably/issue/STA-4150/refactor-remote-browser-to-client-hosted-electron-webviews), stacked on #14484. Production RPC registration and capability advertisement remain disabled.

## Causal evidence

On the parent branch, one unchanged oracle failed three ways: a second identity on one connection was admitted, a fifth identity for one paired device was admitted, and closed page placement had no retirement API. Those cases are now bounded and exact.

Fresh review then found two additional lifecycle failures before publication: delayed cleanup could erase a replacement placement, and four devices could occupy all 16 shared long-poll slots. Retirement now requires the exact placement object, and a real injected WebSocket test proves host saturation still admits an ordinary wait and socket close aborts/releases both classes.

## Validation

- 11 focused files / 67 tests
- 15 unique tunnel/lease/runtime files / 92 tests
- full runtime RPC suite / 90 tests
- cross-version terminal wire / 5 tests
- `pnpm typecheck`
- native and type-aware code-quality audits
- reliability-gate manifest and max-lines ratchet
- fresh correctness rereview: no remaining findings

## Deliberately deferred before activation

- pending tunnel-open/rate admission and aggregate route/host/process byte ledgers
- wiring token-safe placement retirement into the future production page lifecycle
- drain-aware stream fairness and SOCKS local-process trust decision
- SSH/WSL/Linux/physical-Windows and old/new-peer journeys
- Electron partition proxy/no-fallback proof and UI activation

