### PR TITLE
fix(computer-use): reap detached macOS helper processes on every teardown path

### DIFF
--- a/src/main/computer/macos-native-provider-client.test.ts
+++ b/src/main/computer/macos-native-provider-client.test.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'node:events'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { PROVIDER_SIGKILL_GRACE_MS } from './macos-native-provider-process-reaping'
 
 const {
   chmodSyncMock,
@@ -63,8 +64,15 @@ class FakeSocket extends EventEmitter {
 }
 
 class FakeProvider extends EventEmitter {
+  exitCode: number | null = null
+  signalCode: string | null = null
   kill = vi.fn()
   unref = vi.fn()
+
+  exit(code = 0): void {
+    this.exitCode = code
+    this.emit('exit', code, null)
+  }
 }
 
 function pendingConnectThatRejectsOnAbort(signal?: AbortSignal): Promise<never> {
@@ -425,15 +433,15 @@ describe('MacOSNativeProviderClient', () => {
   })
 
   it('terminates the helper process when socket startup fails', async () => {
-    const providerKill = vi.fn()
-    spawnMock.mockReturnValueOnce({ unref: vi.fn(), kill: providerKill })
+    const provider = new FakeProvider()
+    spawnMock.mockReturnValueOnce(provider)
     connectMacOSProviderSocketMock.mockRejectedValueOnce(new Error('socket did not open'))
     const { MacOSNativeProviderClient } = await loadClientModule()
     const client = new MacOSNativeProviderClient()
 
     await expect(client.capabilities()).rejects.toThrow('socket did not open')
 
-    expect(providerKill).toHaveBeenCalledWith('SIGTERM')
+    expect(provider.kill).toHaveBeenCalledWith('SIGTERM')
     expect(rmSyncMock).toHaveBeenCalledWith(expect.stringContaining('orca-computer-use-'), {
       recursive: true,
       force: true
@@ -478,6 +486,162 @@ describe('MacOSNativeProviderClient', () => {
     await expect(call).rejects.toThrow('native macOS helper app exited before connecting: code 13')
     expect(connectSignal.aborted).toBe(true)
     expect(providers[0]!.kill).toHaveBeenCalledWith('SIGTERM')
+  })
+
+  it('escalates to SIGKILL when a helper ignores terminate and SIGTERM', async () => {
+    const { MacOSNativeProviderClient } = await loadClientModule()
+    const client = new MacOSNativeProviderClient()
+
+    const call = client.capabilities()
+    const rejection = expect(call).rejects.toThrow('native macOS provider handshake timed out')
+    await vi.waitFor(() => expect(sockets).toHaveLength(1))
+    const socket = sockets[0]!
+    await vi.waitFor(() => expect(socket.writes).toHaveLength(1))
+
+    await vi.advanceTimersByTimeAsync(60_000)
+    await rejection
+
+    const provider = providers[0]!
+    // Why: a wedged helper never reads `terminate`, so the socket write alone
+    // is what used to leak the process on every request timeout.
+    expect(socket.writes.at(-1)).toContain('"method":"terminate"')
+    expect(provider.kill).toHaveBeenCalledWith('SIGTERM')
+    expect(provider.kill).not.toHaveBeenCalledWith('SIGKILL')
+
+    await vi.advanceTimersByTimeAsync(PROVIDER_SIGKILL_GRACE_MS)
+    expect(provider.kill).toHaveBeenCalledWith('SIGKILL')
+  })
+
+  it('does not escalate to SIGKILL when the helper exits after SIGTERM', async () => {
+    const { MacOSNativeProviderClient } = await loadClientModule()
+    const client = new MacOSNativeProviderClient()
+
+    const call = client.capabilities()
+    const rejection = expect(call).rejects.toThrow('native macOS provider handshake timed out')
+    await vi.waitFor(() => expect(sockets).toHaveLength(1))
+    await vi.waitFor(() => expect(sockets[0]!.writes).toHaveLength(1))
+
+    await vi.advanceTimersByTimeAsync(60_000)
+    await rejection
+
+    const provider = providers[0]!
+    expect(provider.kill).toHaveBeenCalledWith('SIGTERM')
+    provider.exit(0)
+
+    await vi.advanceTimersByTimeAsync(PROVIDER_SIGKILL_GRACE_MS * 2)
+    expect(provider.kill).not.toHaveBeenCalledWith('SIGKILL')
+  })
+
+  it('reaps the previous helper process before a replacement is started', async () => {
+    const { MacOSNativeProviderClient } = await loadClientModule()
+    const client = new MacOSNativeProviderClient()
+
+    const firstCall = client.capabilities()
+    const firstRejection = expect(firstCall).rejects.toThrow('active helper failed')
+    await vi.waitFor(() => expect(sockets).toHaveLength(1))
+    await vi.waitFor(() => expect(sockets[0]!.writes).toHaveLength(1))
+    sockets[0]!.emit('error', new Error('active helper failed'))
+    await firstRejection
+
+    expect(providers[0]!.kill).toHaveBeenCalledWith('SIGTERM')
+
+    const secondCall = client.capabilities()
+    await vi.waitFor(() => expect(providers).toHaveLength(2))
+    // Why: the replacement must not inherit the previous generation's teardown.
+    expect(providers[1]!.kill).not.toHaveBeenCalled()
+
+    const secondSocket = sockets[1]!
+    await vi.waitFor(() => expect(secondSocket.writes).toHaveLength(1))
+    const secondRequest = JSON.parse(secondSocket.writes[0]!) as { id: number }
+    secondSocket.emit(
+      'data',
+      `${JSON.stringify({
+        id: secondRequest.id,
+        ok: true,
+        result: { protocolVersion: 1, supports: {} }
+      })}\n`
+    )
+    await expect(secondCall).resolves.toMatchObject({ protocolVersion: 1 })
+  })
+
+  it('reaps the helper process when the active socket closes on its own', async () => {
+    const { MacOSNativeProviderClient } = await loadClientModule()
+    const client = new MacOSNativeProviderClient()
+
+    const call = client.capabilities()
+    const rejection = expect(call).rejects.toThrow('native macOS helper app connection closed')
+    await vi.waitFor(() => expect(sockets).toHaveLength(1))
+    await vi.waitFor(() => expect(sockets[0]!.writes).toHaveLength(1))
+
+    // Why: a helper that dies takes its socket down with a bare 'close', with no
+    // preceding 'error' — the teardown path most likely to run in the wild.
+    sockets[0]!.emit('close')
+    await rejection
+
+    expect(providers[0]!.kill).toHaveBeenCalledWith('SIGTERM')
+  })
+
+  it('does not signal a helper that already exited before teardown', async () => {
+    const { MacOSNativeProviderClient } = await loadClientModule()
+    const client = new MacOSNativeProviderClient()
+
+    const call = client.capabilities()
+    const rejection = expect(call).rejects.toThrow('native macOS helper app connection closed')
+    await vi.waitFor(() => expect(sockets).toHaveLength(1))
+    await vi.waitFor(() => expect(sockets[0]!.writes).toHaveLength(1))
+
+    const provider = providers[0]!
+    provider.exitCode = 0
+    sockets[0]!.emit('close')
+    await rejection
+
+    // Why: signalling a reaped pid is how a recycled pid gets hit.
+    expect(provider.kill).not.toHaveBeenCalled()
+  })
+
+  it('reaps the helper process of a superseded startup', async () => {
+    const pendingConnects: {
+      resolve: (socket: FakeSocket) => void
+    }[] = []
+    connectMacOSProviderSocketMock.mockImplementation(
+      async () =>
+        await new Promise<FakeSocket>((resolve) => {
+          pendingConnects.push({ resolve })
+        })
+    )
+    const { MacOSNativeProviderClient } = await loadClientModule()
+    const client = new MacOSNativeProviderClient()
+
+    const firstCall = client.capabilities()
+    await vi.waitFor(() => expect(pendingConnects).toHaveLength(1))
+
+    client.shutdown()
+
+    const secondCall = client.capabilities()
+    await vi.waitFor(() => expect(pendingConnects).toHaveLength(2))
+    const secondSocket = new FakeSocket()
+    pendingConnects[1]!.resolve(secondSocket)
+    await vi.waitFor(() => expect(secondSocket.writes).toHaveLength(1))
+    const secondRequest = JSON.parse(secondSocket.writes[0]!) as { id: number }
+
+    pendingConnects[0]!.resolve(new FakeSocket())
+    await expect(firstCall).rejects.toThrow('native macOS provider startup was superseded')
+
+    // Why: the superseded throw is caught by this function's own catch, so the
+    // helper must be reaped exactly once, not once per handler.
+    expect(providers[0]!.kill).toHaveBeenCalledTimes(1)
+    expect(providers[0]!.kill).toHaveBeenCalledWith('SIGTERM')
+    expect(providers[1]!.kill).not.toHaveBeenCalled()
+
+    secondSocket.emit(
+      'data',
+      `${JSON.stringify({
+        id: secondRequest.id,
+        ok: true,
+        result: { protocolVersion: 1, supports: {} }
+      })}\n`
+    )
+    await expect(secondCall).resolves.toMatchObject({ protocolVersion: 1 })
   })
 })
 

--- a/src/main/computer/macos-native-provider-client.ts
+++ b/src/main/computer/macos-native-provider-client.ts
@@ -18,6 +18,7 @@ import {
   writeNativeProviderLine
 } from './macos-native-provider-contract'
 import { resolveMacOSComputerUseExecutablePath } from './macos-native-provider-paths'
+import { MacOSProviderProcessOwner } from './macos-native-provider-process-reaping'
 import {
   attachMacOSNativeProviderSocketListeners,
   consumeNativeProviderLines,
@@ -31,6 +32,7 @@ const REQUEST_TIMEOUT_MS = 60_000
 
 export class MacOSNativeProviderClient {
   private socket: net.Socket | null = null
+  private readonly providerProcess = new MacOSProviderProcessOwner()
   private socketStartPromise: Promise<net.Socket> | null = null
   private socketPath: string | null = null
   private socketDirectory: string | null = null
@@ -84,7 +86,7 @@ export class MacOSNativeProviderClient {
       )
       this.pending.delete(id)
     }
-    this.cleanupSocketDirectory()
+    this.releaseHelperGeneration()
   }
   private async call(method: NativeMethod, params: unknown): Promise<unknown> {
     if (method !== 'handshake') {
@@ -124,7 +126,7 @@ export class MacOSNativeProviderClient {
         clearTimeout(pending.timer)
         this.pending.delete(id)
       }
-      this.invalidateActiveSocketAfterWriteFailure(transport, wrapped)
+      this.invalidateActiveSocket(transport, wrapped)
       throw wrapped
     }
     return await result
@@ -192,7 +194,8 @@ export class MacOSNativeProviderClient {
       helperExecutablePath,
       isCurrent: (socketPath) =>
         this.socketStartGeneration === startGeneration &&
-        (this.socketPath === null || this.socketPath === socketPath)
+        (this.socketPath === null || this.socketPath === socketPath),
+      providerProcess: this.providerProcess
     })
     this.socketDirectory = started.socketDirectory
     this.socketPath = started.socketPath
@@ -246,43 +249,37 @@ export class MacOSNativeProviderClient {
     this.cleanupActiveSocketListeners()
     this.socket = null
     this.socketBuffer = ''
-    this.cleanupSocketDirectory()
+    this.releaseHelperGeneration()
     this.rejectPending(
       new RuntimeClientError('accessibility_error', 'native macOS helper app connection closed')
     )
   }
   private handleTransportError(socket: net.Socket, error: Error): void {
-    // Why: stale socket errors can arrive after shutdown/restart.
-    if (this.socket !== socket) {
-      return
-    }
-    this.cleanupActiveSocketListeners()
-    // Why: an active transport error makes the helper socket unreliable for the next request.
-    this.socket = null
-    this.socketBuffer = ''
-    if (!socket.destroyed) {
-      socket.destroy()
-    }
-    this.cleanupSocketDirectory()
-    this.rejectPending(new RuntimeClientError('accessibility_error', error.message))
+    this.invalidateActiveSocket(
+      socket,
+      new RuntimeClientError('accessibility_error', error.message)
+    )
   }
-  private invalidateActiveSocketAfterWriteFailure(
-    socket: net.Socket,
-    error: RuntimeClientError
-  ): void {
+  private invalidateActiveSocket(socket: net.Socket, error: RuntimeClientError): void {
+    // Why: stale socket errors and late write failures can arrive after
+    // shutdown/restart; only the active socket may tear down this generation.
     if (this.socket !== socket) {
       return
     }
     this.cleanupActiveSocketListeners()
+    // Why: a failed transport makes the helper socket unreliable for the next request.
     this.socket = null
     this.socketBuffer = ''
     if (!socket.destroyed) {
       socket.destroy()
     }
-    this.cleanupSocketDirectory()
+    this.releaseHelperGeneration()
     this.rejectPending(error)
   }
-  private cleanupSocketDirectory(): void {
+  private releaseHelperGeneration(): void {
+    // Why: `terminate` only lands if the helper is still reading its socket, and
+    // the wedged helpers this reaps are exactly the ones that are not.
+    this.providerProcess.reap()
     if (!this.socketDirectory) {
       return
     }

--- a/src/main/computer/macos-native-provider-process-reaping.ts
+++ b/src/main/computer/macos-native-provider-process-reaping.ts
@@ -1,0 +1,49 @@
+import type { ChildProcess } from 'node:child_process'
+
+export const PROVIDER_SIGKILL_GRACE_MS = 2_000
+
+const reaped = new WeakSet<ChildProcess>()
+
+// Why: signal the child handle, not a raw pid. Node no-ops once the child has
+// exited, so a recycled pid can never be signalled.
+export function reapMacOSProviderProcess(provider: ChildProcess): void {
+  if (reaped.has(provider) || hasProviderExited(provider)) {
+    return
+  }
+  reaped.add(provider)
+  // Why: SIGTERM must land synchronously. The sidecar's SIGTERM handler calls
+  // process.exit(0) straight after shutdown(), so no deferred timer runs there.
+  provider.kill('SIGTERM')
+  const escalation = setTimeout(() => {
+    if (!hasProviderExited(provider)) {
+      provider.kill('SIGKILL')
+    }
+  }, PROVIDER_SIGKILL_GRACE_MS)
+  escalation.unref?.()
+  provider.once('exit', () => clearTimeout(escalation))
+}
+
+export class MacOSProviderProcessOwner {
+  private provider: ChildProcess | null = null
+
+  // Why: adopting a new generation must never strand the previous one, whatever
+  // teardown did or did not run first.
+  adopt(provider: ChildProcess): void {
+    this.reap()
+    this.provider = provider
+  }
+
+  reap(): void {
+    const provider = this.provider
+    this.provider = null
+    if (provider) {
+      reapMacOSProviderProcess(provider)
+    }
+  }
+}
+
+// Why: typeof, not `!== null` — test doubles leave these undefined, which
+// `!== null` would read as "already exited" and silently skip the reap.
+function hasProviderExited(provider: ChildProcess): boolean {
+  return typeof provider.exitCode === 'number' || typeof provider.signalCode === 'string'
+}

--- a/src/main/computer/macos-native-provider-transport.ts
+++ b/src/main/computer/macos-native-provider-transport.ts
@@ -5,6 +5,10 @@ import { release, tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { randomUUID } from 'node:crypto'
 import { connectMacOSProviderSocket } from './macos-native-provider-socket'
+import {
+  reapMacOSProviderProcess,
+  type MacOSProviderProcessOwner
+} from './macos-native-provider-process-reaping'
 import { RuntimeClientError } from './runtime-client-error'
 
 const HELPER_CONNECT_TIMEOUT_MS = 10_000
@@ -65,10 +69,12 @@ export function consumeNativeProviderLines(
 
 export async function startMacOSNativeProviderSocket({
   helperExecutablePath,
-  isCurrent
+  isCurrent,
+  providerProcess
 }: {
   helperExecutablePath: string
   isCurrent: (socketPath: string) => boolean
+  providerProcess: MacOSProviderProcessOwner
 }): Promise<StartedMacOSProviderSocket> {
   const socketDirectory = mkdtempSync(join(tmpdir(), 'orca-computer-use-'))
   chmodSync(socketDirectory, 0o700)
@@ -79,6 +85,9 @@ export async function startMacOSNativeProviderSocket({
   // Why: launching the nested helper via LaunchServices can make TCC evaluate
   // Orca.app as responsible; the signed helper executable owns this grant.
   const provider = spawnProvider(helperExecutablePath, socketPath, socketTokenPath)
+  // Why: own the helper from birth. Adopting only after connect leaves a window
+  // where a quit during startup strands it with nobody holding the handle.
+  providerProcess.adopt(provider)
   const providerFailure = waitForProviderLaunchFailure(provider)
   const connectAbort = new AbortController()
   try {
@@ -100,9 +109,9 @@ export async function startMacOSNativeProviderSocket({
   } catch (error) {
     connectAbort.abort()
     providerFailure.cleanup()
-    // Why: connect failures happen after spawn; terminate the detached helper
-    // so repeated startup attempts do not leave orphan providers.
-    provider.kill('SIGTERM')
+    // Why: connect failures and superseded startups both happen after spawn;
+    // escalate so a helper that ignores SIGTERM cannot outlive the attempt.
+    reapMacOSProviderProcess(provider)
     if (isCurrent(socketPath)) {
       cleanupSocketDirectory(socketDirectory)
     }


### PR DESCRIPTION
Fixes #9141.

## Summary

On macOS, `computer-use` leaks helper processes until the machine runs out of memory. #9141 reports ~200 `orca-computer-use-macos` processes in 3 hours and 40-50 GB of memory, ending in the "system has run out of application memory" dialog and forced restarts.

I hit this on my own machine on 2026-07-16, a day before #9141 was filed — free memory down to ~80 MB, no new app would launch, and dozens of `orca-computer-use-macos` processes sitting in state `T`.

After this change every abandoned helper is reclaimed, so the process count stays flat instead of growing with each request. #9141 asks for helpers to be pooled or registered with RunningBoard/jetsam; this takes a third option — reclaiming abandoned helpers at the source — which removes the unbounded growth without changing how helpers are spawned or authorized.

**Root cause.** The helper is spawned `detached` and no handle escapes the spawn function:

```ts
const provider = spawn(helperExecutablePath, [...], { detached: true, stdio: 'ignore' })
provider.unref()
```

`startMacOSNativeProviderSocket()` returned only socket fields, so the sole way to stop a running helper was a socket message — and **`terminate` only lands if the helper is still reading its socket, which a wedged helper by definition is not.** Every path that abandoned a socket (request timeout, socket close, transport error, write failure, app quit) dropped it and left the process running; `detached: true` means it also survives Orca quitting. The next request then spawns a fresh helper with no reclamation of the previous generation. That is the unbounded growth, and it is consistent with #9141's observed rate of roughly one new helper per 54 seconds against the 60s `REQUEST_TIMEOUT_MS`.

The pre-existing `catch` in the transport already did `provider.kill('SIGTERM')`, so startup failures — including superseded startups, whose `throw` lands in that same `catch` — were handled. The gap was every path *after* a successful connect.

**Fix.** New `macos-native-provider-process-reaping.ts`:

- `reapMacOSProviderProcess(provider)` — SIGTERM, then SIGKILL after a 2s grace if the process has not exited.
- Signals go to the **`ChildProcess` handle, not a raw pid**. Node no-ops once the child has exited, so a recycled pid can never be signalled.
- A `WeakSet` makes reaping exactly-once per process, so overlapping teardown paths cannot stack duplicate signals or timers.
- `MacOSProviderProcessOwner` holds the current generation; `adopt()` reaps the outgoing one, so no generation can be dropped even if its teardown path did not run.

Wiring:

- The transport takes the owner and **adopts the helper immediately after `spawn`**, not after connect. Adopting on connect left a window up to `HELPER_CONNECT_TIMEOUT_MS` (10s) where nothing held the handle: a quit during startup reaped nothing and the connect continuation never ran, stranding the helper.
- `cleanupSocketDirectory()` became `releaseHelperGeneration()`, reaping the process alongside the socket directory. All four client-side abandon paths already called it, so all four now reclaim the process.
- `handleTransportError` and `invalidateActiveSocketAfterWriteFailure` had identical bodies apart from the error they reject with, so they are merged into `invalidateActiveSocket`; the file ends up three lines shorter. This also keeps it under the 300-line `max-lines` cap the added wiring would otherwise have crossed. Happy to split the merge into its own PR if you'd rather review it separately.
- The helper handle is no longer returned from the transport, since ownership now transfers at spawn.

Four files under `src/main/computer/`, +249 / −30.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Six regressions in `macos-native-provider-client.test.ts`:

1. A helper that ignores `terminate` gets SIGTERM, then SIGKILL after the grace period.
2. A helper that exits after SIGTERM is **not** SIGKILLed.
3. The previous generation is reaped before a replacement starts, and the replacement is left alone.
4. A helper whose socket closes on its own — a bare `close` with no preceding `error` — is reaped. This is the path most likely to run in the wild.
5. A helper that already exited before teardown is **not** signalled, covering the recycled-pid guard.
6. A superseded startup reaps its helper exactly once.

With the reaping call stubbed to a no-op, five of the six fail, along with three existing tests covering the transport's `catch` branch. Case 5 asserts that *no* signal is sent, so it holds either way by construction — it pins the recycled-pid guard rather than the reaping.

`src/main/computer` is 16 files / 97 tests, all passing. On the full suite I see 52,133 pass and 6 fail, none under `src/main/computer`. The same 6 fail on a clean `upstream/main` checkout, so they are not from this change, and they look environment-specific here: 1 in `automation-schedules` is my non-English locale (`'일요일s'` vs `'Sundays'`; passes under `LC_ALL=en_US.UTF-8`), 4 in `codex-fetcher-pty-settle` pick up real Codex state on this machine instead of `session: null`, and 1 is the `#13767` shell-ready repro. I'd expect all 6 green in CI — happy to re-run if CI disagrees.

The reclamation logic is covered directly by the six tests above. What I could not do is reproduce the `T`-state wedge on demand, since a dev-built helper gets a different code identity and therefore a fresh TCC row.

## AI Review Report

Reviewed with an AI coding agent across three passes — general correctness, process lifetime and concurrency, and test adequacy — with each finding checked by hand against the diff before it was applied.

What it flagged and what changed as a result:

- **Helper owned too late.** Ownership transferred after connect, leaving a ~10s window where a quit during startup stranded the helper. Moved `adopt()` to immediately after `spawn`.
- **Generation could be dropped.** `adopt()` overwrote the previous handle without reaping it, so a teardown path that did not run meant a lost helper. `adopt()` now reaps the outgoing generation.
- **Duplicate reaping.** An early draft reaped the superseded-startup branch explicitly, but that `throw` is caught by the same function's `catch`, which already reaps — two SIGTERMs, two timers, two listeners. Removed, and a `WeakSet` now makes reaping exactly-once regardless of overlapping paths.
- **Untested teardown path.** `handleSocketClose` on the active socket — a helper dying and taking its socket down with a bare `close` — had no coverage. Added as test 4, plus tests 5 and 6.
- **Rejected suggestion.** Replacing the `typeof` checks in `hasProviderExited()` with `!== null` was proposed for idiomatic style; it would read the test doubles' `undefined` as "already exited" and silently skip reaping, so the `typeof` form was kept and the reason recorded in a comment.

**Cross-platform compatibility was explicitly checked for macOS, Linux, and Windows.** Every changed file is under the `darwin`-gated native-provider path; Linux and Windows go through `DesktopScriptProviderClient`, and provider selection in `computer-provider-lifecycle.ts` is unchanged. No keyboard shortcuts, accelerators, or user-facing labels are touched, so there are no `CmdOrCtrl` or `⌘`/`Ctrl+` concerns. Paths are built with `path.join` via the existing `macos-native-provider-paths` helpers; none were added or changed. No shell is invoked — `spawn` is called with an argv array and no `shell: true`. The Electron-specific surface touched is process teardown ordering in the computer-use sidecar, which exists only on the macOS native path.

## Security Audit

- **Command execution**: no new command or executable is invoked. The existing `spawn` call is unchanged, still argv-array form with no `shell: true`, so no argument-injection surface is added. The change only sends signals to a process this code already owned.
- **Signal targeting**: signals go to the `ChildProcess` handle rather than a numeric pid. Node treats the handle as inert once the child has exited, which removes the recycled-pid hazard that `process.kill(pid)` would introduce — this is a reduction in risk, not an addition. Process-group signalling (`kill(-pid)`) was deliberately not used, since it would reopen that hazard.
- **Path handling**: no new path construction. Socket directory creation, `chmod 0o700`, and cleanup are untouched apart from being called from a renamed method.
- **Auth and secrets**: socket token generation, the `0o600` token file, and its removal after connect are unchanged. No token is logged, and no new value is written to disk.
- **IPC**: no new IPC surface. No change to `REQUIRED_MACOS_PROVIDER_PROTOCOL_VERSION`, the wire format, capability negotiation, or peer authorization.
- **Dependencies**: none added or updated.
- **Follow-up**: the pre-existing `isCurrent` guard on the transport's `catch` can leave `provider.token` in `tmpdir()` when a startup is superseded. It is a `0o600` file inside a `0o700` directory, so exposure is limited, but it should be cleaned up — noted below rather than fixed here to keep this PR single-topic.

## Notes

**Platform-specific behavior.** macOS only. Windows and Linux are untouched.

Behavior changes worth flagging:

- **A healthy helper is now usually stopped by SIGTERM rather than by its own `terminate` handling.** `shutdown()` writes `terminate`, then signals synchronously; the write only reaches the kernel buffer, so the signal typically wins. This is deliberate: `sidecar-entry.ts` calls `process.exit(0)` immediately after `shutdownProviders()` on the SIGTERM path, so a deferred grace period would never execute there. The `terminate` write is kept ahead of the signal so a helper that reads it promptly still exits on its own terms.
- **That path depends on the helper not installing a SIGTERM handler.** It currently does not — there is no `signal()` / `sigaction` / `DispatchSourceSignal` anywhere in `native/computer-use-macos/Sources/`. Happy to add a note on the Swift side so a future handler doesn't silently regress this.
- **On the `beforeExit` path the SIGKILL escalation cannot fire**, since the timer is `unref()`d and the loop is already draining. That path relies on SIGTERM alone, which is sufficient given the point above.
- **Already-stranded helpers and their temp directories are not swept.** This stops new leaks; existing ones still need a restart.

Out of scope, happy to file separately: a cap on concurrent helpers, an orphan sweep at startup, process-group teardown, and the `provider.token` cleanup noted above.

**Relation to prior work.** #11425 and #11441 covered this gap; #11481 rolled them back with the wider process-boundary effort. This is not a re-land of that effort. No supervisor protocol, no main-process ownership, no peer-PID authorization, and no change to the Swift helper. Helper ownership stays in the computer-use sidecar where it is today, and the client-side change extends `cleanupSocketDirectory()` — a function every teardown path already called.

**Possible lead on the wedge itself**, not part of this PR: the helper shells out with unbounded waits in two places — `openBundle()` runs `/usr/bin/open -b <bundleId>` and `processField()` runs `/bin/ps`, both with `waitUntilExit()` and no deadline (`main.swift:1189`, `main.swift:3813`). A LaunchServices stall there would wedge the helper exactly the way #9141 describes. I can open a separate issue for it.

#9141 is assigned to @OrcaWin. If that work is already underway I'm happy to hand this over — otherwise the issue has had no activity since it was filed and this is contained enough to land on its own.
