### PR TITLE
fix(daemon): persist the pending-output counter across empty incremental takes (STA-4297)

### DIFF
--- a/src/main/daemon/daemon-restore-scrollback-depth.test.ts
+++ b/src/main/daemon/daemon-restore-scrollback-depth.test.ts
@@ -486,9 +486,7 @@ describe('STA-4091 previously recoverable restore depth', () => {
       )
     })
 
-    // Why depth and not the counter: an empty take persists no batch, so advancing the pending-output
-    // seq leaves the log behind and the first post-reattach compact commits the live window over the
-    // deep checkpoint. Assert the recovered depth survives, which is the whole point of durable history.
+    // Assert durable depth, not the sequence that merely enables it.
     it('preserves durable depth when an empty incremental take precedes a warm reattach', async () => {
       const { id } = await adapter.spawn({
         cols: 80,

--- a/src/main/daemon/daemon-restore-scrollback-depth.test.ts
+++ b/src/main/daemon/daemon-restore-scrollback-depth.test.ts
@@ -486,6 +486,57 @@ describe('STA-4091 previously recoverable restore depth', () => {
       )
     })
 
+    // Why depth and not the counter: an empty take persists no batch, so advancing the pending-output
+    // seq leaves the log behind and the first post-reattach compact commits the live window over the
+    // deep checkpoint. Assert the recovered depth survives, which is the whole point of durable history.
+    it('preserves durable depth when an empty incremental take precedes a warm reattach', async () => {
+      const { id } = await adapter.spawn({
+        cols: 80,
+        rows: 24,
+        sessionId: 'empty-take-depth',
+        cwd: '/tmp'
+      })
+      lastSubprocess.emitData(numberedOutput(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT))
+      await adapter.getBufferSnapshot(id)
+      lastSubprocess.emitData(`${FRESH_AFTER_CHECKPOINT}\r\n`)
+
+      const oldInternals = adapter as unknown as { checkpointDirtySessions: () => Promise<void> }
+      await oldInternals.checkpointDirtySessions()
+      const beforeReattach = await new HistoryReader(historyDir).detectColdRestore(id, {
+        ignoreCleanEnd: true
+      })
+      expect(snapshotText(beforeReattach ?? {})).toContain(OLDEST_WRITTEN_LINE)
+
+      // The trigger: a dirty mark with no new PTY records (the mock swallows the write, nothing echoes back).
+      adapter.write(id, 'noop')
+      await oldInternals.checkpointDirtySessions()
+
+      simulateAdapterCrash(adapter)
+      adapter = new DaemonPtyAdapter({
+        socketPath: getDaemonSocketPath(dir),
+        tokenPath: join(dir, 'test.token'),
+        historyPath: historyDir
+      })
+
+      const reattach = await adapter.spawn({ cols: 80, rows: 24, sessionId: id, cwd: '/tmp' })
+      expect(reattach.snapshot).toContain(FRESH_AFTER_CHECKPOINT)
+      expect(reattach.snapshot).toContain(OLDEST_WRITTEN_LINE)
+
+      // First post-reattach compact runs the continuity proof; it must not flatten the deep checkpoint.
+      const newInternals = adapter as unknown as {
+        checkpointDirtySessions: () => Promise<void>
+      }
+      adapter.write(id, 'noop')
+      await newInternals.checkpointDirtySessions()
+
+      const restored = await new HistoryReader(historyDir).detectColdRestore(id, {
+        ignoreCleanEnd: true
+      })
+      expect(snapshotText(restored ?? {})).toContain(OLDEST_WRITTEN_LINE)
+      expect(snapshotText(restored ?? {})).toContain(PREVIOUSLY_RECOVERABLE_LINE)
+      expect(restored?.scrollbackLines).toBeGreaterThan(DAEMON_SESSION_SCROLLBACK_ROWS)
+    })
+
     it('falls back to the live window when durable history cannot be read', async () => {
       const { id } = await adapter.spawn({
         cols: 80,

--- a/src/main/daemon/session-pending-output.test.ts
+++ b/src/main/daemon/session-pending-output.test.ts
@@ -96,22 +96,6 @@ describe('Session pending output', () => {
     expect(empty!.records).toEqual([])
   })
 
-  // Why: an empty take writes no log batch, so advancing the seq would strand the log behind the
-  // counter and fail the next reattach's continuity proof (STA-4297). Depth coverage lives in
-  // daemon-restore-scrollback-depth.test.ts; this guards the counter at its source.
-  it('holds the batch sequence across an empty take and resumes contiguously', () => {
-    const subprocess = createMockSubprocess()
-    const live = createSession(subprocess)
-
-    subprocess.simulateData('first')
-    const first = live.takePendingOutput(false)
-
-    expect(live.takePendingOutput(false)!.seq).toBe(first!.seq)
-
-    subprocess.simulateData('second')
-    expect(live.takePendingOutput(false)!.seq).toBe(first!.seq + 1)
-  })
-
   it('flags overflow past the cap and recovers after a take', () => {
     const subprocess = createMockSubprocess()
     const live = createSession(subprocess)

--- a/src/main/daemon/session-pending-output.test.ts
+++ b/src/main/daemon/session-pending-output.test.ts
@@ -96,6 +96,22 @@ describe('Session pending output', () => {
     expect(empty!.records).toEqual([])
   })
 
+  // Why: an empty take writes no log batch, so advancing the seq would strand the log behind the
+  // counter and fail the next reattach's continuity proof (STA-4297). Depth coverage lives in
+  // daemon-restore-scrollback-depth.test.ts; this guards the counter at its source.
+  it('holds the batch sequence across an empty take and resumes contiguously', () => {
+    const subprocess = createMockSubprocess()
+    const live = createSession(subprocess)
+
+    subprocess.simulateData('first')
+    const first = live.takePendingOutput(false)
+
+    expect(live.takePendingOutput(false)!.seq).toBe(first!.seq)
+
+    subprocess.simulateData('second')
+    expect(live.takePendingOutput(false)!.seq).toBe(first!.seq + 1)
+  })
+
   it('flags overflow past the cap and recovers after a take', () => {
     const subprocess = createMockSubprocess()
     const live = createSession(subprocess)

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -494,11 +494,7 @@ export class Session {
     this.pendingOutputRecords = []
     this.pendingOutputBytes = 0
     this.pendingOutputOverflowed = false
-    // Why conditional: the seq is the log's continuity ledger, and an empty incremental take writes no
-    // batch (the adapter returns early; HistoryManager also refuses empty appends). Advancing it anyway
-    // leaves the counter ahead of the log forever, so the next reattach's continuity proof fails and
-    // flattens a deep durable checkpoint to the live window (STA-4297). A snapshot take always persists
-    // the seq into the checkpoint, and an overflow is a real log hole, so both still advance.
+    // Empty incremental takes are not persisted; advancing them would create a false reattach gap.
     if (includeSnapshot || records.length > 0 || overflowed) {
       this.pendingOutputSeq += 1
     }

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -494,7 +494,14 @@ export class Session {
     this.pendingOutputRecords = []
     this.pendingOutputBytes = 0
     this.pendingOutputOverflowed = false
-    this.pendingOutputSeq += 1
+    // Why conditional: the seq is the log's continuity ledger, and an empty incremental take writes no
+    // batch (the adapter returns early; HistoryManager also refuses empty appends). Advancing it anyway
+    // leaves the counter ahead of the log forever, so the next reattach's continuity proof fails and
+    // flattens a deep durable checkpoint to the live window (STA-4297). A snapshot take always persists
+    // the seq into the checkpoint, and an overflow is a real log hole, so both still advance.
+    if (includeSnapshot || records.length > 0 || overflowed) {
+      this.pendingOutputSeq += 1
+    }
     return {
       records: includeSnapshot
         ? releasedHeldBytes

--- a/src/main/daemon/types.ts
+++ b/src/main/daemon/types.ts
@@ -285,9 +285,11 @@ export type TakePendingOutputResult = {
   /** Drained pending queue. Absent on older daemons. includeSnapshot still
    *  keeps `records` as held-only so mixed-version adapters do not double-replay. */
   drainedRecords?: PendingOutputRecord[]
-  /** Monotonic per-session batch sequence. The history log stores it so the
+  /** Non-decreasing per-session batch sequence. The history log stores it so the
    *  cold-restore reader can detect a lost batch (gap) and discard the log
-   *  instead of replaying a stream with missing bytes. */
+   *  instead of replaying a stream with missing bytes. It advances only for takes
+   *  that get persisted, so an empty incremental take repeats the previous value
+   *  rather than stranding the log behind the counter (STA-4297). */
   seq: number
   /** True when the session's pending buffer exceeded its cap and records were
    *  dropped. The caller must fall back to a full snapshot checkpoint. */

--- a/src/main/daemon/types.ts
+++ b/src/main/daemon/types.ts
@@ -287,9 +287,8 @@ export type TakePendingOutputResult = {
   drainedRecords?: PendingOutputRecord[]
   /** Non-decreasing per-session batch sequence. The history log stores it so the
    *  cold-restore reader can detect a lost batch (gap) and discard the log
-   *  instead of replaying a stream with missing bytes. It advances only for takes
-   *  that get persisted, so an empty incremental take repeats the previous value
-   *  rather than stranding the log behind the counter (STA-4297). */
+   *  instead of replaying a stream with missing bytes. Snapshot, record, and
+   *  overflow takes advance it; empty incremental takes repeat the prior value. */
   seq: number
   /** True when the session's pending buffer exceeded its cap and records were
    *  dropped. The caller must fall back to a full snapshot checkpoint. */


### PR DESCRIPTION
## ELI5

The daemon keeps a counter that says "this is batch number N of your terminal's history." Every time it drains pending output it bumped that counter — even when there was nothing to drain, in which case nothing gets written to disk. So the counter said "batch 5" while the disk only ever got up to batch 4.

Later, when the app reattaches to that terminal, it checks "does the disk agree with the counter?" before trusting the deep saved history. It didn't agree, so it threw away the deep history and kept only the last ~1000 visible rows. Now only an empty drain leaves the counter unchanged; snapshots, records, and overflow still advance it, so genuine lost writes remain detectable while empty ticks no longer manufacture a false gap.

## What Changed

`Session.takePendingOutput` now advances `pendingOutputSeq` only for takes that carry persistence state:

- a snapshot take (the seq is stamped into the checkpoint file), or
- a take carrying records, or one flagged `overflowed` (a real log hole worth recording).

An empty incremental take repeats the previous seq instead of advancing it. `TakePendingOutputResult.seq`'s doc comment now states the exact contract: snapshot, record, and overflow takes advance; empty incremental takes repeat the prior value.

Scope is deliberately one condition in `session.ts`. Nothing in checkpoint admission, the per-session queue, `runWithDeadline`, or final-checkpoint deadline behavior is touched (STA-4228 / STA-4229 territory, #14346 / #14385). #14193 and #13061 are unmodified.

## Why

An empty incremental take advanced the counter without ever writing a log batch, so the in-memory seq ran permanently ahead of the log:

- `session.ts` `takePendingOutput` bumped `pendingOutputSeq` unconditionally, including on zero records.
- `daemon-pty-adapter.ts` returns early on `take.records.length === 0`, *before* `historyManager.appendIncrements` — so that advanced seq is never persisted.
- After a warm reattach the adapter requires `restoreInfo.pendingOutputSeq === take.seq - 1`.
- `history-reader.ts` stamps `pendingOutputSeq` from the last log batch (or, when the log is header-only, from the checkpoint).

Net: the first post-reattach compact fails the continuity proof and commits the live snapshot over the deep checkpoint. No corruption, but it destroys exactly the restore depth #14193 exists to provide.

**Why this shape.** The release owner named two options: (a) skip the continuity proof on empty takes, or (b) persist an empty-batch marker so the log tracks the counter. This implements (a)'s intent — an empty take does not participate in the continuity ledger — at the single place the divergence is created.

- Literal (a), skipping the proof at *checkpoint* time, does not fix the defect: the take that fails the proof is the checkpoint take (usually non-empty), while the empty take that poisoned the counter happened earlier and is long gone. Suppressing the proof there would also gut the guard #14193 added.
- (b) was rejected on existing precedent. Both layers below already treat "empty" as "nothing happened": `HistoryManager.appendIncrementsUntracked` returns `ok` without writing when `records.length === 0`, and the adapter returns `done` on an empty take. Only `session.ts` disagreed. Making the log record no-op batches would contradict that rule and, because idle sessions are the common case, would spend the 5MB log cap and force checkpoint rotations on sessions producing zero output.

This also keeps the adapter's `take.seq - 1` proof arithmetic unchanged, and incidentally repairs `pendingRecordsAreComplete: take.seq === 1` — idle ticks before a session's first real output used to push the seq past 1 and defeat that check.

**Remote wire compatibility.** No wire shape change; `seq` is still a number on the same RPC. A mixed-version pairing is safe in both directions because an old adapter already early-returns on an empty take and never uses the seq it was handed, so a repeated value is never observed. Only what the host publishes for empty takes changes, and only in the direction that makes disk and memory agree.

## Linked Issue

STA-4297 — https://linear.app/stably/issue/STA-4297

This is **item 2 of the dropped durable-history unit**. It is intended for the **1.4.184** pick set, **not** today's 1.4.183 cut, so a later daily can cherry-pick the durable-history unit as a complete stack.

Fixes #

## Visual Proof

`N/A` — no UI or interaction surface. The change is a daemon-side counter condition; the observable effect (restore depth after reattach) is asserted by the automated test below rather than being a visual diff.

## Testing

`src/main/daemon/daemon-restore-scrollback-depth.test.ts` — "preserves durable depth when an empty incremental take precedes a warm reattach". It asserts the **outcome (recovered depth)**, not the counter: after the empty take plus a warm reattach it requires the restored history to still contain `LINE_00001` and `LINE_01000` and `scrollbackLines` to exceed the live window, so a fix that merely made the bookkeeping agree while still flattening the checkpoint would not pass.

Repro path in the test follows production, not internals: 5000 lines of output → deep durable checkpoint → `adapter.write()` marks the session dirty while the mock PTY echoes nothing back (a dirty mark with zero new records) → `checkpointDirtySessions()` runs the empty take → adapter crash + fresh adapter → warm reattach.

**RED verified on unmodified `origin/main`** (`a6a64439a0`), exact output:

```
FAIL  src/main/daemon/daemon-restore-scrollback-depth.test.ts > STA-4091 previously recoverable restore depth > adapter remount and restart > preserves durable depth when an empty incremental take precedes a warm reattach
AssertionError: expected 'LINE_03979\r\nLINE_03980\r\nLINE_0398…' to contain 'LINE_00001'
 ❯ src/main/daemon/daemon-restore-scrollback-depth.test.ts:523:33
 Test Files  1 failed (1)
      Tests  1 failed | 21 skipped (22)
```

`LINE_03979` onward is the ~1000-row live window — the deep checkpoint was flattened, which is the defect.

**Control run** (to prove the RED is caused by the empty take and not incidental setup): removing only the two trigger lines, with every other line of the test identical, passes on unmodified main. Adding them back fails. So the empty incremental take is the sole cause.

The depth test is the sole regression oracle; no test asserts the counter directly. No matching entry exists in `config/reliability-gates.jsonc`, so that manifest coverage is an accepted gap for this focused patch; the existing `[history] durable continuity unproven; using live snapshot:` warning remains the diagnostic for genuine gaps. Live restore-depth reproduction on SSH, WSL, Linux, and Windows remains unverified; the changed arithmetic is provider- and platform-neutral, while CI covers cross-version compatibility and native smoke.

Checks run locally on macOS:

- `pnpm vitest run --config config/vitest.config.ts src/main/daemon` → **1471 passed**, 3 skipped (107 files). Includes the two sibling tests that must *still* lose depth (`uses the live window when a crashed adapter left a pending-output gap`, `uses the live window when durable history disappears after a prior drain`) — the fix does not weaken them.
- `pnpm vitest run --config config/vitest.config.ts src/main` → **21423 passed**, 90 skipped on the PR branch; **21422 passed**, 90 skipped with all four scoped files restored exactly to `origin/main` (`a6a64439a0`). `src/main/ipc/pty.test.ts` separately passed **480/480** on both states. The previously reported 10 overlay-environment failures did not reproduce, so they are not claimed as pre-existing evidence.
- `pnpm run typecheck:node` → clean.
- `oxlint` (default + `oxlint-code-quality-native-plugins` + `--type-aware oxlint-code-quality-type-aware`, `--deny-warnings`) → clean. No `max-lines` disable added and no `mobile/.oxlintrc.json` bump; `check:max-lines-ratchet` reports no new bypasses.
- `oxfmt --check` → clean (this repo formats with oxfmt, not prettier).

Platforms: the changed code is platform-neutral (an integer counter in the daemon session, no paths, no shell, no keybindings) and runs identically for local, SSH, and WSL hosts and for both git-worktree and folder workspaces. Verified on macOS; no platform-conditional behavior added.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

- **Security** — no new surface; no input parsing, no IPC/RPC shape change, no filesystem paths.
- **Cross-platform** — platform-neutral integer bookkeeping; no path, shell, or accelerator logic.
- **Remote SSH** — covered above under Remote wire compatibility; safe in mixed-version pairings in both directions.
- **Mobile** — unaffected; no mobile code touched.
- **Backwards compatibility** — on-disk checkpoint and log formats unchanged, so existing histories are read exactly as before. The change only stops the counter from drifting ahead of them.
- **Performance** — no I/O, allocation, scan, polling, or subprocess work is added; empty ticks skip one counter mutation. Opt-in 10 MiB session-ingest samples overlapped the base for both workload shapes (ASCII 68.3–80.5 vs 75.1–78.4 MB/s; TUI 110.4–112.1 vs 110.7–111.9 MB/s), with no regression signal.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @BrennanKB5


