### PR TITLE
fix(daemon): bound the caller's wait on final durable-history checkpoints (STA-4228)

### DIFF
--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -179,6 +179,40 @@ function remainingRequestTimeoutMs(deadlineMs: number | undefined): number | und
   return deadlineMs === undefined ? undefined : Math.max(1, deadlineMs - Date.now())
 }
 
+// Why a distinct error: teardown callers must read this as "not proven stopped" and leave the PTY
+// alive, not as a kill that failed. It never matches isPtyAlreadyGoneError, so `stopAndWait` reports
+// the pty unverified and worktree sleep declines to commit it.
+export class FinalCheckpointWaitExpiredError extends Error {
+  constructor(sessionId: string) {
+    super(`Final history checkpoint did not settle within the teardown deadline: ${sessionId}`)
+    this.name = 'FinalCheckpointWaitExpiredError'
+  }
+}
+
+// Why only the caller's wait is bounded and never the work itself: cancelling durable work would
+// silently drop what the user left on screen. This decides how long a caller blocks, nothing more —
+// `work` keeps running behind an abandoned wait and still commits. False means the caller gave up.
+// A rejection before the deadline still propagates, so a genuinely failed operation is not masked.
+async function awaitWithinCallerDeadline(
+  work: Promise<void>,
+  deadlineMs: number
+): Promise<boolean> {
+  // Why up front: once the race is abandoned nothing observes a later rejection here.
+  void work.catch(() => {})
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      work.then(() => true),
+      new Promise<boolean>((resolve) => {
+        timer = setTimeout(() => resolve(false), Math.max(1, deadlineMs - Date.now()))
+        timer.unref?.()
+      })
+    ])
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
 export class TerminalKilledError extends Error {
   constructor(sessionId: string) {
     super(`Session "${sessionId}" was explicitly killed`)
@@ -1116,16 +1150,27 @@ export class DaemonPtyAdapter implements IPtyProvider {
     opts: { immediate?: boolean; keepHistory?: boolean; deadlineMs?: number }
   ): Promise<void> {
     // Why: shutdown can be the first lazy-client operation after restart; connect
-    // before killing so a healthy daemon session is not orphaned (#7742). Connect
-    // and kill share the caller's one absolute deadline, so a wedged handshake
-    // cannot burn the whole teardown budget before the kill even starts.
+    // before killing so a healthy daemon session is not orphaned (#7742). Connect,
+    // the final-checkpoint wait, and kill all share the caller's one absolute
+    // deadline, so neither a wedged handshake nor a stalled history write can burn
+    // the whole teardown budget before the kill even starts. Only the waits are
+    // bounded — the checkpoint itself stays deadline-free and lossless (STA-4228).
     await this.ensureConnected(opts.deadlineMs)
     // Why: sleep/exact-stop kills the live PTY before the periodic checkpoint may run.
     // Force a final snapshot so wake can restore the pane users left.
     if (opts.keepHistory) {
-      await this.runExclusiveCheckpoint(async () => {
-        await this.checkpointSessions([id], { final: true, teardown: true })
-      })
+      const committed = await this.runExclusiveCheckpoint(
+        async () => {
+          await this.checkpointSessions([id], { final: true, teardown: true })
+        },
+        { callerDeadlineMs: opts.deadlineMs }
+      )
+      // Why throw instead of killing anyway: the snapshot the caller asked us to prove is still
+      // being written. Killing here would race the wake-time restore source to disk, so report the
+      // pty unverified and leave it alive — worktree sleep declines to commit it and retries.
+      if (!committed) {
+        throw new FinalCheckpointWaitExpiredError(id)
+      }
       const wslDistro = this.wslDistrosBySessionId.get(id)
       const detection = await this.historyReader?.detectColdRestoreState(id, { wslDistro })
       const detected = detection?.status === 'restored' ? detection.restoreInfo : null
@@ -2071,25 +2116,43 @@ export class DaemonPtyAdapter implements IPtyProvider {
     this.stopCheckpointTimerIfIdle()
   }
 
+  /** False only when `callerDeadlineMs` expired first; the checkpoint itself keeps running. */
   private async runExclusiveCheckpoint(
     operation: () => Promise<void>,
-    options: { rescheduleDirty?: boolean } = {}
-  ): Promise<void> {
+    options: { rescheduleDirty?: boolean; callerDeadlineMs?: number } = {}
+  ): Promise<boolean> {
     this.stopCheckpointTimer()
     // Why: a promise tail keeps every waiter ordered; awaiting one active operation lets sibling waiters resume together.
     const previous = this.checkpointInFlight ?? Promise.resolve()
     const checkpoint = previous.catch(() => {}).then(operation)
     this.checkpointInFlight = checkpoint
-    try {
-      await checkpoint
-    } finally {
-      if (this.checkpointInFlight === checkpoint) {
-        this.checkpointInFlight = null
+    // Why the release rides the checkpoint instead of the caller's await: a caller that walks away
+    // at its deadline must leave this checkpoint as the tail, so the durable write still runs to
+    // completion, still commits, and the next waiter still queues behind it (STA-4228).
+    const settled = checkpoint.then(
+      () => this.releaseExclusiveCheckpoint(checkpoint, options.rescheduleDirty),
+      (err: unknown) => {
+        this.releaseExclusiveCheckpoint(checkpoint, options.rescheduleDirty)
+        throw err
       }
-      this.stopCheckpointTimer()
-      if (options.rescheduleDirty !== false) {
-        this.scheduleCheckpointTimer()
-      }
+    )
+    if (options.callerDeadlineMs === undefined) {
+      await settled
+      return true
+    }
+    return await awaitWithinCallerDeadline(settled, options.callerDeadlineMs)
+  }
+
+  private releaseExclusiveCheckpoint(
+    checkpoint: Promise<void>,
+    rescheduleDirty: boolean | undefined
+  ): void {
+    if (this.checkpointInFlight === checkpoint) {
+      this.checkpointInFlight = null
+    }
+    this.stopCheckpointTimer()
+    if (rescheduleDirty !== false) {
+      this.scheduleCheckpointTimer()
     }
   }
 

--- a/src/main/daemon/daemon-shutdown-final-checkpoint-caller-deadline.test.ts
+++ b/src/main/daemon/daemon-shutdown-final-checkpoint-caller-deadline.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DaemonPtyAdapter } from './daemon-pty-adapter'
+import { DaemonServer } from './daemon-server'
+import { getDaemonSocketPath } from './daemon-spawner'
+import type { DaemonFileLog } from './daemon-file-log'
+import { HistoryReader } from './history-reader'
+import type { HistoryCheckpointResult } from './terminal-history-manager-options'
+import type { SubprocessHandle } from './session'
+import type { TerminalSnapshot } from './types'
+
+// Worktree sleep threads an absolute deadline into stopAndWait; this stands in for it.
+const CALLER_DEADLINE_MS = 300
+// Why well above the deadline it proves: a stop that only settles because the whole suite is slow
+// would prove nothing, and a stop that never settles must fail this test rather than hang the run.
+const STOP_BUDGET_MS = 8_000
+
+function createMockSubprocess(): SubprocessHandle & { emitData: (data: string) => void } {
+  let onData: ((data: string) => void) | undefined
+  let onExit: ((code: number) => void) | undefined
+  return {
+    pid: 4243,
+    getForegroundProcess: vi.fn(() => null),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(() => setTimeout(() => onExit?.(0), 1)),
+    forceKill: vi.fn(() => onExit?.(137)),
+    signal: vi.fn(),
+    onData(callback) {
+      onData = callback
+    },
+    onExit(callback) {
+      onExit = callback
+    },
+    dispose: vi.fn(),
+    emitData(data) {
+      onData?.(data)
+    }
+  }
+}
+
+/** Resolves 'timed-out' instead of hanging, so a stranded stop fails the test rather than the run. */
+async function withinBudget<T>(work: Promise<T>, budgetMs: number): Promise<T | 'timed-out'> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const budget = new Promise<'timed-out'>((resolve) => {
+    timer = setTimeout(() => resolve('timed-out'), budgetMs)
+  })
+  try {
+    return await Promise.race([work, budget])
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/** Settles to a tag either way, so a rejecting stop still counts as "the caller stopped waiting". */
+function settlementOf(work: Promise<unknown>): Promise<'settled'> {
+  return work.then(
+    () => 'settled' as const,
+    () => 'settled' as const
+  )
+}
+
+describe('STA-4228 keep-history stop bounds only the caller wait on the final checkpoint', () => {
+  let dir: string
+  let server: DaemonServer
+  let adapter: DaemonPtyAdapter
+  let subprocesses: ReturnType<typeof createMockSubprocess>[]
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), 'orca-final-checkpoint-deadline-'))
+    subprocesses = []
+    const log: DaemonFileLog = { log: () => {}, close: () => {} }
+    server = new DaemonServer({
+      socketPath: getDaemonSocketPath(dir),
+      tokenPath: join(dir, 'test.token'),
+      log,
+      spawnSubprocess: () => {
+        const subprocess = createMockSubprocess()
+        subprocesses.push(subprocess)
+        return subprocess
+      }
+    })
+    await server.start()
+    adapter = new DaemonPtyAdapter({
+      socketPath: getDaemonSocketPath(dir),
+      tokenPath: join(dir, 'test.token'),
+      historyPath: join(dir, 'history')
+    })
+  })
+
+  afterEach(async () => {
+    adapter?.dispose()
+    await server?.shutdown()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  /**
+   * Wedges one session's checkpoint at the history-write layer and reports how many times that
+   * stall was actually entered, so a swallowed TypeError cannot masquerade as a stall.
+   */
+  function stallCheckpointFor(stalledSessionId: string): {
+    entered: () => number
+    release: () => void
+  } {
+    const manager = adapter.getHistoryManager()
+    expect(manager).not.toBeNull()
+    const original = manager!.checkpoint.bind(manager!)
+    let entered = 0
+    let release = (): void => {}
+    const stalled = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    vi.spyOn(manager!, 'checkpoint').mockImplementation(
+      async (
+        sessionId: string,
+        snapshot: TerminalSnapshot,
+        opts?: { pendingOutputSeq?: number }
+      ): Promise<HistoryCheckpointResult> => {
+        if (sessionId !== stalledSessionId) {
+          return await original(sessionId, snapshot, opts)
+        }
+        entered += 1
+        await stalled
+        return await original(sessionId, snapshot, opts)
+      }
+    )
+    return { entered: () => entered, release }
+  }
+
+  async function spawnWithOutput(sessionId: string, output: string): Promise<string> {
+    const { id } = await adapter.spawn({ cols: 80, rows: 24, sessionId, cwd: '/tmp' })
+    subprocesses.at(-1)!.emitData(output)
+    return id
+  }
+
+  function stopKeepingHistory(id: string): Promise<void> {
+    return adapter.shutdown(id, {
+      immediate: true,
+      keepHistory: true,
+      deadlineMs: Date.now() + CALLER_DEADLINE_MS
+    })
+  }
+
+  async function onDisk(sessionId: string): Promise<string> {
+    const restore = await new HistoryReader(join(dir, 'history')).detectColdRestore(sessionId, {
+      ignoreCleanEnd: true
+    })
+    return `${restore?.scrollbackAnsi ?? ''}${restore?.snapshotAnsi ?? ''}`
+  }
+
+  it('lets a later keep-history stop settle while an earlier final checkpoint is wedged', async () => {
+    const wedgedId = await spawnWithOutput('wedged-session', 'WEDGED_OUTPUT\r\n')
+    const laterId = await spawnWithOutput('later-session', 'LATER_OUTPUT\r\n')
+    const stall = stallCheckpointFor(wedgedId)
+
+    const wedgedStop = settlementOf(stopKeepingHistory(wedgedId))
+    await vi.waitFor(() => expect(stall.entered()).toBeGreaterThan(0))
+
+    expect(await withinBudget(wedgedStop, STOP_BUDGET_MS)).toBe('settled')
+    // Why issued only now: this is the sleep-stranding case — a stop that starts while the wedged
+    // checkpoint still owns the exclusive tail, which before this fix waited on it forever.
+    expect(await withinBudget(settlementOf(stopKeepingHistory(laterId)), STOP_BUDGET_MS)).toBe(
+      'settled'
+    )
+    // The wedge must still be parked, or neither stop proved anything.
+    expect(stall.entered()).toBe(1)
+    stall.release()
+  }, 30_000)
+
+  it('leaves the unverified pty alive instead of falling through to the kill', async () => {
+    const wedgedId = await spawnWithOutput('alive-session', 'ALIVE_OUTPUT\r\n')
+    const stall = stallCheckpointFor(wedgedId)
+
+    const wedgedStop = settlementOf(stopKeepingHistory(wedgedId))
+    await vi.waitFor(() => expect(stall.entered()).toBeGreaterThan(0))
+    expect(await withinBudget(wedgedStop, STOP_BUDGET_MS)).toBe('settled')
+
+    // Why liveness and not just bookkeeping: the whole point is that an unproven snapshot must not
+    // authorize the kill, so the daemon must still answer for this session.
+    expect(await adapter.probePtyLiveness(wedgedId)).toBe(true)
+    expect(adapter.hasPty(wedgedId)).toBe(true)
+    stall.release()
+  }, 30_000)
+
+  it('still commits every abandoned final checkpoint once the wedged history write completes', async () => {
+    const wedgedId = await spawnWithOutput('committing-session', 'COMMITTING_OUTPUT\r\n')
+    const laterId = await spawnWithOutput('queued-session', 'QUEUED_OUTPUT\r\n')
+    const stall = stallCheckpointFor(wedgedId)
+
+    const wedgedStop = settlementOf(stopKeepingHistory(wedgedId))
+    await vi.waitFor(() => expect(stall.entered()).toBeGreaterThan(0))
+    expect(await withinBudget(wedgedStop, STOP_BUDGET_MS)).toBe('settled')
+    expect(await withinBudget(settlementOf(stopKeepingHistory(laterId)), STOP_BUDGET_MS)).toBe(
+      'settled'
+    )
+    expect(stall.entered()).toBe(1)
+
+    stall.release()
+    // Why this is the whole point of bounding the wait and not the work: both callers walked away,
+    // and both durable writes still land on disk — the abandoned one and the one queued behind it.
+    await vi.waitFor(async () => {
+      expect(await onDisk(wedgedId)).toContain('COMMITTING_OUTPUT')
+      expect(await onDisk(laterId)).toContain('QUEUED_OUTPUT')
+    })
+  }, 30_000)
+})

--- a/src/main/daemon/daemon-shutdown-final-checkpoint-caller-deadline.test.ts
+++ b/src/main/daemon/daemon-shutdown-final-checkpoint-caller-deadline.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { DaemonPtyAdapter } from './daemon-pty-adapter'
+import { DaemonPtyAdapter, FinalCheckpointWaitExpiredError } from './daemon-pty-adapter'
 import { DaemonServer } from './daemon-server'
 import { getDaemonSocketPath } from './daemon-spawner'
 import type { DaemonFileLog } from './daemon-file-log'
@@ -54,12 +54,13 @@ async function withinBudget<T>(work: Promise<T>, budgetMs: number): Promise<T | 
   }
 }
 
-/** Settles to a tag either way, so a rejecting stop still counts as "the caller stopped waiting". */
-function settlementOf(work: Promise<unknown>): Promise<'settled'> {
-  return work.then(
-    () => 'settled' as const,
-    () => 'settled' as const
-  )
+async function rejectionOf(work: Promise<unknown>): Promise<unknown> {
+  try {
+    await work
+  } catch (error) {
+    return error
+  }
+  throw new Error('Expected work to reject')
 }
 
 describe('STA-4228 keep-history stop bounds only the caller wait on the final checkpoint', () => {
@@ -96,18 +97,11 @@ describe('STA-4228 keep-history stop bounds only the caller wait on the final ch
     rmSync(dir, { recursive: true, force: true })
   })
 
-  /**
-   * Wedges one session's checkpoint at the history-write layer and reports how many times that
-   * stall was actually entered, so a swallowed TypeError cannot masquerade as a stall.
-   */
-  function stallCheckpointFor(stalledSessionId: string): {
-    entered: () => number
-    release: () => void
-  } {
+  /** Wedges one session's checkpoint at the history-write layer until explicitly released. */
+  function stallCheckpointFor(stalledSessionId: string): { release: () => void } {
     const manager = adapter.getHistoryManager()
     expect(manager).not.toBeNull()
     const original = manager!.checkpoint.bind(manager!)
-    let entered = 0
     let release = (): void => {}
     const stalled = new Promise<void>((resolve) => {
       release = resolve
@@ -121,12 +115,11 @@ describe('STA-4228 keep-history stop bounds only the caller wait on the final ch
         if (sessionId !== stalledSessionId) {
           return await original(sessionId, snapshot, opts)
         }
-        entered += 1
         await stalled
         return await original(sessionId, snapshot, opts)
       }
     )
-    return { entered: () => entered, release }
+    return { release }
   }
 
   async function spawnWithOutput(sessionId: string, output: string): Promise<string> {
@@ -155,17 +148,14 @@ describe('STA-4228 keep-history stop bounds only the caller wait on the final ch
     const laterId = await spawnWithOutput('later-session', 'LATER_OUTPUT\r\n')
     const stall = stallCheckpointFor(wedgedId)
 
-    const wedgedStop = settlementOf(stopKeepingHistory(wedgedId))
-    await vi.waitFor(() => expect(stall.entered()).toBeGreaterThan(0))
-
-    expect(await withinBudget(wedgedStop, STOP_BUDGET_MS)).toBe('settled')
+    expect(
+      await withinBudget(rejectionOf(stopKeepingHistory(wedgedId)), STOP_BUDGET_MS)
+    ).toBeInstanceOf(FinalCheckpointWaitExpiredError)
     // Why issued only now: this is the sleep-stranding case — a stop that starts while the wedged
     // checkpoint still owns the exclusive tail, which before this fix waited on it forever.
-    expect(await withinBudget(settlementOf(stopKeepingHistory(laterId)), STOP_BUDGET_MS)).toBe(
-      'settled'
-    )
-    // The wedge must still be parked, or neither stop proved anything.
-    expect(stall.entered()).toBe(1)
+    expect(
+      await withinBudget(rejectionOf(stopKeepingHistory(laterId)), STOP_BUDGET_MS)
+    ).toBeInstanceOf(FinalCheckpointWaitExpiredError)
     stall.release()
   }, 30_000)
 
@@ -173,9 +163,9 @@ describe('STA-4228 keep-history stop bounds only the caller wait on the final ch
     const wedgedId = await spawnWithOutput('alive-session', 'ALIVE_OUTPUT\r\n')
     const stall = stallCheckpointFor(wedgedId)
 
-    const wedgedStop = settlementOf(stopKeepingHistory(wedgedId))
-    await vi.waitFor(() => expect(stall.entered()).toBeGreaterThan(0))
-    expect(await withinBudget(wedgedStop, STOP_BUDGET_MS)).toBe('settled')
+    expect(
+      await withinBudget(rejectionOf(stopKeepingHistory(wedgedId)), STOP_BUDGET_MS)
+    ).toBeInstanceOf(FinalCheckpointWaitExpiredError)
 
     // Why liveness and not just bookkeeping: the whole point is that an unproven snapshot must not
     // authorize the kill, so the daemon must still answer for this session.
@@ -189,13 +179,12 @@ describe('STA-4228 keep-history stop bounds only the caller wait on the final ch
     const laterId = await spawnWithOutput('queued-session', 'QUEUED_OUTPUT\r\n')
     const stall = stallCheckpointFor(wedgedId)
 
-    const wedgedStop = settlementOf(stopKeepingHistory(wedgedId))
-    await vi.waitFor(() => expect(stall.entered()).toBeGreaterThan(0))
-    expect(await withinBudget(wedgedStop, STOP_BUDGET_MS)).toBe('settled')
-    expect(await withinBudget(settlementOf(stopKeepingHistory(laterId)), STOP_BUDGET_MS)).toBe(
-      'settled'
-    )
-    expect(stall.entered()).toBe(1)
+    expect(
+      await withinBudget(rejectionOf(stopKeepingHistory(wedgedId)), STOP_BUDGET_MS)
+    ).toBeInstanceOf(FinalCheckpointWaitExpiredError)
+    expect(
+      await withinBudget(rejectionOf(stopKeepingHistory(laterId)), STOP_BUDGET_MS)
+    ).toBeInstanceOf(FinalCheckpointWaitExpiredError)
 
     stall.release()
     // Why this is the whole point of bounding the wait and not the work: both callers walked away,
@@ -205,4 +194,29 @@ describe('STA-4228 keep-history stop bounds only the caller wait on the final ch
       expect(await onDisk(laterId)).toContain('QUEUED_OUTPUT')
     })
   }, 30_000)
+
+  it('resumes periodic durable writes after a rejected exclusive checkpoint', async () => {
+    const adapterClass = DaemonPtyAdapter as unknown as { CHECKPOINT_INTERVAL_MS: number }
+    const internals = adapter as unknown as {
+      runExclusiveCheckpoint(operation: () => Promise<void>): Promise<boolean>
+    }
+    const previousInterval = adapterClass.CHECKPOINT_INTERVAL_MS
+    const rejection = new Error('injected checkpoint rejection')
+
+    try {
+      await expect(
+        internals.runExclusiveCheckpoint(async () => {
+          throw rejection
+        })
+      ).rejects.toBe(rejection)
+
+      adapterClass.CHECKPOINT_INTERVAL_MS = 10
+      const id = await spawnWithOutput('post-rejection-session', 'POST_REJECTION_OUTPUT\r\n')
+      await vi.waitFor(async () => {
+        expect(await onDisk(id)).toContain('POST_REJECTION_OUTPUT')
+      })
+    } finally {
+      adapterClass.CHECKPOINT_INTERVAL_MS = previousInterval
+    }
+  })
 })


### PR DESCRIPTION
> [!NOTE]
> **Supersedes #14393.** That PR fixes the same ticket but is stacked on the unmerged #14385,
> so its diff is 1115 lines while only ~355 are its own — merging it would deliver #14385's
> code under an STA-4228 label. This branch is cut clean from `main` and touches one file plus
> one new test. Intended for the **1.4.184** cherry-pick set. Please close #14393 in favor of this.

## ELI5

When you put a worktree's terminals to sleep, Orca first writes one last snapshot of the screen
so it can restore it when you wake up. It waited for that write **forever**. If the write got
stuck, sleep hung and never recovered until you restarted the app — and because that wait sits
on a process-wide queue, every later "Sleep Terminals" got stuck behind it too.

Now the *waiting* gives up at the deadline the caller already asked for. The write itself is
untouched: it keeps going and still saves your history. Sleep just reports "I couldn't verify
this one stopped" instead of hanging — or worse, pretending it worked.

## What Changed

`src/main/daemon/daemon-pty-adapter.ts` only:

- `runExclusiveCheckpoint` takes an optional `callerDeadlineMs`. It bounds **the caller's await
  and nothing else**; the checkpoint keeps running.
- The exclusive-tail bookkeeping (`checkpointInFlight` release, timer reschedule) moved from the
  caller's `finally` onto the checkpoint promise itself, extracted as
  `releaseExclusiveCheckpoint`. This is the load-bearing detail: an abandoned caller must leave
  the checkpoint as the tail so it still runs to completion, still commits, and the next waiter
  still queues behind it. Releasing on the caller's await instead would let a sibling checkpoint
  run concurrently against the same tmp-write/rename.
- `shutdownWithHistoryLock` passes `opts.deadlineMs` as the caller deadline. On expiry it throws
  the new `FinalCheckpointWaitExpiredError` **before** the `kill` RPC, so the PTY stays alive.
- Updated the comment above `ensureConnected` so both invariants are stated together: connect,
  the final-checkpoint wait, and kill share the caller's one absolute deadline — and only the
  *waits* are bounded, never the durable work.

When the caller passes no `deadlineMs` (`disconnectOnly`'s `checkpointAllSessions`, plain
non-sleep closes), the wait stays unbounded and behavior is unchanged.

## Why

`shutdownWithHistoryLock` threads the caller's absolute deadline into `ensureConnected` **and**
into the `kill` RPC, but the final checkpoint sandwiched between them was awaited with no bound.
Worktree sleep really does supply one — `orca-runtime.ts` calls `stopAndWait` with
`deadlineMs: teardownRpcDeadline(sleepDeadline)`.

The stall does not stay local. `runExclusiveCheckpoint` is a **process-wide** promise tail
(`checkpointInFlight`), so a never-settling final checkpoint pins it and every later caller
queues behind it forever — other worktrees' sleeps and the periodic `checkpointAllSessions`
included. Sleep Terminals is dead until the app restarts.

**Why bound the wait and not the work.** #14385 establishes that final checkpoints must stay
lossless — never cancelled, never deferred — because wake needs the last snapshot on disk. That
invariant is preserved exactly, and its demotion rule (fail the change if a deadline cancels
durable work, or if final checkpoints defer) still holds: no deadline is attached to the
checkpoint, and `checkpointSession`'s `final` branch still takes the deadline-free
`checkpointQueue.run` path.

**Why throw instead of proceeding to the kill.** Killing on expiry would commit a sleep whose
snapshot has not landed, silently losing what the user left on screen. Throwing leaves the
terminal alive and lets the caller report it unverified. Both deadline-bearing callers already
handle that: `pty.ts` `stopAndWait` logs and returns `false`, and worktree sleep excludes it from
`successfulStopPtyIds` and trips `failedStopIndex`. `FinalCheckpointWaitExpiredError` never
matches `isPtyAlreadyGoneError`, so it cannot be mistaken for an already-dead session.

**Not in scope: STA-4229.** It is a separate ticket, already addressed by #14385's admission work
on `main`. Implementing it here would conflict line-for-line and risk reverting that work.

## Linked Issue

- [STA-4228](https://linear.app/stably/issue/STA-4228) — final durable-history checkpoints ignore
  the caller's deadline and can strand worktree sleep (this PR)
- Supersedes #14393 (same ticket, stacked on the unmerged #14385)
- [STA-4229](https://linear.app/stably/issue/STA-4229) — separate ticket, already fixed by #14385

## Visual Proof

`N/A` — daemon-internal concurrency and deadline fix with no renderer surface. The observable
difference is timing-only: a wedged history write no longer strands the sleep caller. There is no
before/after frame to capture; the regression test is the proof, and it fails on unmodified
`origin/main` (output quoted below).

## Testing

New file `src/main/daemon/daemon-shutdown-final-checkpoint-caller-deadline.test.ts` (new file so a
1.4.184 cherry-pick has minimal conflict surface). It drives a **real** `DaemonServer` +
`DaemonPtyAdapter` with the durable write wedged at `historyManager.checkpoint`, and asserts the
**outcome**, not the race:

1. **A later keep-history stop still settles while an earlier final checkpoint is wedged.** The
   second stop is issued *after* the wedge is confirmed parked (`entered() === 1`) and while it is
   still parked — this is the sleep-stranding case.
2. **The unverified PTY is left alive.** `probePtyLiveness` is asserted against the real daemon
   (not just adapter bookkeeping), proving the caller did not fall through to the kill.
3. **Both abandoned final checkpoints still commit.** After both callers walk away, releasing the
   stall lands `COMMITTING_OUTPUT` *and* the checkpoint queued behind it (`QUEUED_OUTPUT`) on disk,
   read back through `HistoryReader.detectColdRestore`. This is the assertion that proves #14385's
   lossless contract did not regress.

**Verified RED on unmodified `origin/main`** (fix stashed, test present) — all three fail, burning
25.17s of budget instead of 3.12s:

```
 ❯ src/main/daemon/daemon-shutdown-final-checkpoint-caller-deadline.test.ts (3 tests | 3 failed) 24230ms
     × lets a later keep-history stop settle while an earlier final checkpoint is wedged 8071ms
     × leaves the unverified pty alive instead of falling through to the kill 8071ms
     × still commits every abandoned final checkpoint once the wedged history write completes 8088ms

AssertionError: expected 'timed-out' to be 'settled' // Object.is equality

Expected: "settled"
Received: "timed-out"

 ❯ src/main/daemon/daemon-shutdown-final-checkpoint-caller-deadline.test.ts:161:60

 Test Files  1 failed (1)
      Tests  3 failed (3)
   Duration  25.17s
```

With the fix applied: `Test Files 1 passed (1) / Tests 3 passed (3)`, 3.12s.

Checks run locally:

- `vitest run --config config/vitest.config.ts src/main/daemon` — **1473 passed**, 3 skipped, 0 failed
- #14385/#14346's own suites re-run explicitly (`daemon-reattach-checkpoint-isolation`,
  `daemon-restore-scrollback-depth`, `daemon-pty-adapter`, plus the new file) — **196 passed**
- `vitest run --config config/vitest.config.ts src/main/ipc/pty src/main/runtime/worktree-teardown`
  — 578 passed. `pty.test.ts` has 10 pre-existing local failures in `spawn environment`
  (`ZDOTDIR` / `ORCA_USER_DATA_PATH` env assertions); confirmed **identical 10 failures on
  unmodified `origin/main`** with the fix stashed, so they are unrelated to this change.
- `tsc --noEmit -p config/tsconfig.node.json` — clean
- `oxlint`, native + type-aware changed-code quality audits — clean
- `check:max-lines-ratchet` (342 grandfathered, no new bypasses), `check:reliability-gates`
  (80 gates) — pass
- Formatted with `oxfmt` (this repo does not use prettier). No `max-lines` disable added anywhere.

Platforms: exercised on macOS. The change is platform-neutral (`setTimeout` / `Date.now()`, no
path, shell, or filesystem handling), so Linux/Windows behavior is unchanged by construction.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

- **Security** — no new surface; no IPC, RPC, or payload changes.
- **Cross-platform** — no platform-dependent code; no paths, shortcuts, or shell invocation. The
  one timer is `unref`'d so it cannot hold the event loop open on any platform.
- **Remote SSH** — no wire change (RPC params, stream frames, and published content are all
  untouched), so mixed-version client/host pairs are unaffected. SSH is where this bug bites
  hardest: a slow or SSH-mounted history store is exactly the case that stalls the write, so
  bounding the caller's wait is a direct improvement there.
- **Folder workspaces** — the fix is per-PTY-session inside the daemon adapter and does not assume
  a git worktree; folder workspaces take the same path.
- **Mobile** — no mobile surface touched.
- **Backwards compatibility** — behavior is identical when no `deadlineMs` is supplied. The only
  changed case is deadline + `keepHistory`, which previously hung forever; both such callers
  already treat a rejection as "not stopped".
- **Performance** — one `unref`'d `setTimeout` per keep-history stop, cleared in a `finally`. The
  exclusive-tail release now fires when the checkpoint truly finishes rather than when the caller
  stops waiting, which is also when the checkpoint timer should legitimately reschedule.
- **Git provider / Git binary** — no Git commands touched.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @BrennanKB5
