### PR TITLE
Fix macOS agent completion notifications from dashboard

### DIFF
--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
@@ -10,6 +10,7 @@ import { buildAgentNotificationId } from '../../../../shared/agent-notification-
 type MockState = {
   activeWorktreeId: string | null
   activeTabId: string | null
+  agentDashboardDrawerOpen: boolean
   tabsByWorktree: Record<string, { id: string; ptyId?: string | null }[]>
   ptyIdsByTabId: Record<string, string[]>
   suppressedPtyExitIds: Record<string, boolean>
@@ -102,6 +103,7 @@ describe('dispatchTerminalNotification', () => {
     mockState = {
       activeWorktreeId: 'wt-secondary',
       activeTabId: 'tab-1',
+      agentDashboardDrawerOpen: false,
       tabsByWorktree: {
         'wt-primary': [{ id: 'tab-1', ptyId: 'pty-1' }]
       },
@@ -277,6 +279,25 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markTerminalTabUnread).not.toHaveBeenCalled()
     expect(mockState.markTerminalPaneUnread).not.toHaveBeenCalled()
     expect(mockState.markAgentCompletionPaneUnread).not.toHaveBeenCalled()
+  })
+
+  it('dispatches a focused active-worktree completion while the agent dashboard is open', () => {
+    mockState.activeWorktreeId = 'wt-primary'
+    mockState.agentDashboardDrawerOpen = true
+    stubDocumentFocus({ visibilityState: 'visible', focused: true })
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey
+    })
+
+    expect(window.api.notifications.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'agent-task-complete',
+        isActiveWorktree: false
+      })
+    )
   })
 
   it('marks a hidden tab in the focused worktree unread', () => {

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
@@ -224,7 +224,9 @@ export function dispatchTerminalNotification(
       worktreeLabel: worktree?.displayName || worktree?.branch || worktreeId,
       hasMultipleActiveRepos: countReposNeedingNotificationDisambiguation(state) > 1,
       terminalTitle: event.terminalTitle,
-      isActiveWorktree: state.activeWorktreeId === worktreeId,
+      // The dashboard covers the workspace surface, so a completion there is
+      // not already visible even when it belongs to the selected worktree.
+      isActiveWorktree: state.activeWorktreeId === worktreeId && !state.agentDashboardDrawerOpen,
       ...agentSnapshot
     })
     .then((result) => {


### PR DESCRIPTION
## ELI5

Orca treated the selected workspace as already visible even when the in-window Agent Dashboard was covering it. With "suppress when focused" enabled, that caused the main process to skip the macOS completion notification. The dashboard-covered workspace is now treated as not actively viewed, so the notification is delivered.

## What Changed

- Exclude the selected worktree from focused-worktree notification suppression while the Agent Dashboard drawer is open.
- Add a regression test for an agent completion in the focused active worktree with the dashboard open.

## Why

The main notification gate suppresses alerts when Orca is focused and the request says its worktree is active. The dashboard is a separate surface that covers the workspace, so work happening behind it should still be eligible for a native completion alert.

## Linked Issue

Fixes #14422

## Visual Proof

N/A — this changes native notification delivery, not Orca's rendered UI. The before/after behavior is covered by the regression test.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- Focused notification-dispatch test: 29 passed
- Full Vitest run: 52,169 passed; the tag-dependent cross-version suite was then rerun after fetching release tags and all 5 tests passed
- Web TypeScript typecheck passed
- Formatting check passed
- Native and type-aware oxlint checks passed for both changed files
- Full build was not run locally; CI can cover the remaining platform build matrix

## AI Disclosure

OpenAI Codex (GPT-5) was used to investigate the issue, implement the fix and regression test, run validation, and draft this PR.

## Review

- Security: no new inputs, permissions, IPC fields, or data handling.
- Cross-platform: renderer-only boolean gating; no platform-specific API or path behavior changed. Native delivery remains owned by the existing platform notification implementation.
- Local / Remote SSH: worktree and pane routing are unchanged; the dashboard-open state is local UI state and the behavior is connection-neutral.
- Agents / integrations: provider-neutral completion dispatch remains unchanged.
- Backwards compatibility: no persisted state, shared wire format, or public API change.
- Performance: one constant-time boolean check on notification dispatch.
- UI quality: no rendered UI change.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (targeted checks and tests pass; CI will cover the remaining full checks)

## Author

- X / Twitter: Not provided
