### PR TITLE
feat(browser): bound host tunnel memory

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -2589,15 +2589,17 @@
       "providers": ["local", "remote-runtime", "ssh", "wsl"],
       "coveredPlatforms": ["macos"],
       "coveredProviders": ["remote-runtime"],
-      "coverageNotes": "Deterministic protocol, registry, injected-socket, and loopback-listener tests cover strict framing, remote-DNS targets, exact destination-write and source-consumption credit, at most 16 pending opens, 128 admitted opens per 10-second monotonic window, an 8 MiB aggregate application-buffer ledger across both traffic directions, bounded per-stream receive bytes and chunks, authority epochs, exact host selection, one host per authenticated connection, four hosts per paired device, long-poll metering and disconnect abort, monotonic host/page/route generations without page tombstones, connection-owned cleanup, exact client revocation, stale and replaced fences, retired stream IDs, half-close and close ordering, SOCKS CONNECT, bind/close races, listener wildcard normalization, unsupported commands, unavailable routes, and raw/terminal binary-handler isolation. Explicitly injected browser-host and paired-runtime tunnel methods lease one exact host, then carry SOCKS and HTTP bytes over a dedicated E2EE socket to the fenced native execution-host revision and prove route close destroys the destination socket. Both methods and capabilities remain disabled in production. Encrypted transport buffers, browser-host/process ledgers, SSH, and WSL remain uncovered.",
+      "coverageNotes": "Deterministic protocol, registry, injected-socket, and loopback-listener tests cover strict framing, remote-DNS targets, exact destination-write and source-consumption credit, at most 16 pending opens, 128 admitted opens per 10-second monotonic window, an 8 MiB per-route application-buffer ledger, shared 32 MiB browser-host and 128 MiB process ledgers across application copies, encrypted client queues, and native WebSocket bufferedAmount, bounded byte/claim/socket-source counts, a four-frame queued-drain quantum, authority epochs, exact host selection, one host per authenticated connection, four hosts per paired device, long-poll metering and disconnect abort, monotonic host/page/route generations without page tombstones, connection-owned cleanup, exact client revocation, stale and replaced fences, retired stream IDs, half-close and close ordering, SOCKS CONNECT, bind/close races, listener wildcard normalization, unsupported commands, unavailable routes, and raw/terminal binary-handler isolation. The execution runtime charges route application bytes to the same per-host/process policy; its existing E2EE owner separately caps native outbound buffers process-wide. Explicitly injected browser-host and paired-runtime tunnel methods lease one exact host, then carry SOCKS and HTTP bytes over a dedicated E2EE socket to the fenced native execution-host revision and prove route close destroys the destination socket. Both methods and capabilities remain disabled in production. Node stream-internal high-water bytes, strict cross-route scheduling, SSH, and WSL remain uncovered.",
       "motivatingLinks": [
         "https://linear.app/stably/issue/STA-4150/refactor-remote-browser-to-client-hosted-electron-webviews"
       ],
-      "invariant": "A client-hosted browser network route exists only for an exact live server-owned browser-host lease, authority epoch, host generation, paired identity, execution-host revision, and server-owned route generation. Host selection never chooses arbitrarily, stale cleanup cannot remove a replacement, destination names remain unresolved until the execution host, credit returns only after writes settle, and route loss never falls back to desktop DNS or sockets. Pending opens, admitted open rate, and session-retained application bytes remain bounded with exact release on settlement and retirement. The local SOCKS endpoint accepts only loopback CONNECT and rejects unsupported commands.",
-      "oracle": "Attach two browser hosts and require unqualified selection to fail ambiguous while exact selection succeeds. Reject a second identity on one connection and a fifth identity for one paired device, release one exact lease, then admit its replacement without starving another device. Saturate the browser-host long-poll sub-cap, require an ordinary wait to remain admitted, close the socket, and prove both counters and handlers release. Replace one same-device connection, require the old subscription and route to fence, then prove late old cleanup leaves the new generation live. Retire a closed page placement by exact token, reject delayed cleanup against a replacement and server placement, and require its reused ID to receive a higher global generation without retaining a tombstone. Admit 16 pending destination opens and reject the seventeenth until one connects; admit 128 opens in one monotonic 10-second window and reject the 129th until the window expires. Fill 8 MiB across destination-to-client queues and separately across unsettled client-to-destination writes, release one exact retired stream, admit one replacement, and require the next byte claim to close the route without stale-callback or reentrant-close underflow. Reject missing, stale, wrong-device, wrong-epoch, and wrong-execution-revision tunnel requests before binary registration. Drive the accepted lease through a real paired E2EE SOCKS-to-HTTP journey, then exercise exact frame, credit, half-close, stale-stream, remote-DNS, unsupported-command, offline, and teardown assertions.",
+      "invariant": "A client-hosted browser network route exists only for an exact live server-owned browser-host lease, authority epoch, host generation, paired identity, execution-host revision, and server-owned route generation. Host selection never chooses arbitrarily, stale cleanup cannot remove a replacement, destination names remain unresolved until the execution host, credit returns only after writes settle, and route loss never falls back to desktop DNS or sockets. Pending opens, admitted open rate, per-route application bytes, aggregate browser-host/process bytes, claims, and socket sources remain bounded with exact release on settlement and retirement. Queued transport drain yields after a bounded quantum. The local SOCKS endpoint accepts only loopback CONNECT and rejects unsupported commands.",
+      "oracle": "Attach two browser hosts and require unqualified selection to fail ambiguous while exact selection succeeds. Reject a second identity on one connection and a fifth identity for one paired device, release one exact lease, then admit its replacement without starving another device. Saturate the browser-host long-poll sub-cap, require an ordinary wait to remain admitted, close the socket, and prove both counters and handlers release. Replace one same-device connection, require the old subscription and route to fence, then prove late old cleanup leaves the new generation live. Retire a closed page placement by exact token, reject delayed cleanup against a replacement and server placement, and require its reused ID to receive a higher global generation without retaining a tombstone. Admit 16 pending destination opens and reject the seventeenth until one connects; admit 128 opens in one monotonic 10-second window and reject the 129th until the window expires. Fill 8 MiB across destination-to-client queues and separately across unsettled client-to-destination writes, release one exact retired stream, admit one replacement, and require the next byte claim to close the route without stale-callback or reentrant-close underflow. Across multiple routes, charge application copies, encrypted queue entries, and dynamic native socket bytes to one 32 MiB browser-host and 128 MiB process ceiling; reject zero-byte claim/socket-source floods, fence released leases, synchronously release JavaScript queue claims while retaining native claims through exact socket close, and yield a parked queue after four frames without reordering. Reject missing, stale, wrong-device, wrong-epoch, wrong-execution-revision, and memory-exhausted tunnel requests before binary registration. Drive the accepted lease through a real paired E2EE SOCKS-to-HTTP journey, then exercise exact frame, credit, half-close, stale-stream, remote-DNS, unsupported-command, offline, and teardown assertions.",
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/shared/browser-network-capabilities.test.ts src/shared/browser-network-tunnel-protocol.test.ts src/main/browser/browser-network-tunnel-session.test.ts src/main/browser/remote-browser-socks-server.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/main/browser/browser-network-tunnel-client.test.ts src/main/browser/paired-runtime-browser-network-route.test.ts src/main/runtime/runtime-binary-message-router.test.ts src/main/runtime/rpc/methods/browser-network-tunnel.test.ts src/main/runtime/browser-network-tunnel-paired-runtime.integration.test.ts",
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/browser/browser-network-tunnel-outbound-memory-budget.test.ts src/main/browser/browser-network-tunnel-client-memory-budget.test.ts src/main/browser/browser-network-tunnel-session-aggregate-memory.test.ts src/shared/ws-outbound-backpressure-queue.test.ts src/shared/remote-runtime-client.test.ts",
+        "pnpm exec vitest run --config config/vitest.config.ts src/shared/browser-client-host-protocol.test.ts src/shared/ws-outbound-backpressure-queue.test.ts src/shared/remote-runtime-client.test.ts src/main/runtime/browser-host-lease-registry.test.ts src/main/runtime/runtime-rpc-browser-host-admission.test.ts src/main/runtime/rpc/methods/browser-client-host.test.ts src/main/runtime/rpc/methods/browser-network-tunnel.test.ts src/main/browser/paired-runtime-browser-host-lease.test.ts src/main/browser/paired-runtime-browser-network-route.test.ts src/main/runtime/browser-network-tunnel-paired-runtime.integration.test.ts src/main/browser/browser-network-tunnel-client.test.ts src/main/browser/browser-network-tunnel-client-memory-budget.test.ts src/main/browser/browser-network-tunnel-session.test.ts src/main/browser/browser-network-tunnel-session-aggregate-memory.test.ts src/main/browser/browser-network-tunnel-outbound-memory-budget.test.ts src/main/browser/remote-browser-socks-server.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/shared/browser-client-host-protocol.test.ts src/main/runtime/browser-host-lease-registry.test.ts src/main/runtime/runtime-rpc-browser-host-admission.test.ts src/main/runtime/rpc/methods/browser-client-host.test.ts src/main/runtime/rpc/methods/browser-network-tunnel.test.ts src/main/browser/paired-runtime-browser-host-lease.test.ts src/main/browser/paired-runtime-browser-network-route.test.ts src/main/runtime/browser-network-tunnel-paired-runtime.integration.test.ts src/main/browser/browser-network-tunnel-client.test.ts src/main/browser/browser-network-tunnel-session.test.ts src/main/browser/remote-browser-socks-server.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/shared/remote-runtime-client.test.ts"
       ],
@@ -2610,13 +2612,17 @@
         "src/main/runtime/rpc/methods/browser-client-host.test.ts",
         "src/main/browser/paired-runtime-browser-host-lease.test.ts",
         "src/main/browser/browser-network-tunnel-session.test.ts",
+        "src/main/browser/browser-network-tunnel-session-aggregate-memory.test.ts",
         "src/main/browser/browser-network-tunnel-client.test.ts",
+        "src/main/browser/browser-network-tunnel-client-memory-budget.test.ts",
+        "src/main/browser/browser-network-tunnel-outbound-memory-budget.test.ts",
         "src/main/browser/paired-runtime-browser-network-route.test.ts",
         "src/main/browser/remote-browser-socks-server.test.ts",
         "src/main/runtime/runtime-binary-message-router.test.ts",
         "src/main/runtime/rpc/methods/browser-network-tunnel.test.ts",
         "src/main/runtime/browser-network-tunnel-paired-runtime.integration.test.ts",
-        "src/shared/remote-runtime-client.test.ts"
+        "src/shared/remote-runtime-client.test.ts",
+        "src/shared/ws-outbound-backpressure-queue.test.ts"
       ],
       "assertionRefs": [
         {
@@ -2665,6 +2671,13 @@
           ]
         },
         {
+          "file": "src/main/browser/browser-network-tunnel-session-aggregate-memory.test.ts",
+          "assertions": [
+            "multiple execution-host routes share browser-host application-byte admission in both traffic directions",
+            "route close releases aggregate claims exactly before stale destination-write callbacks"
+          ]
+        },
+        {
           "file": "src/main/browser/browser-network-tunnel-client.test.ts",
           "assertions": [
             "source writes never exceed granted credit or the bounded data-frame size",
@@ -2672,6 +2685,24 @@
             "pending tiny frames stay chunk-bounded and data drains before remote close retirement",
             "late local settlement after remote close sends no stale credit and leaves the tunnel usable",
             "stale generations cannot open a stream and route close destroys every source"
+          ]
+        },
+        {
+          "file": "src/main/browser/browser-network-tunnel-client-memory-budget.test.ts",
+          "assertions": [
+            "multiple client routes on one browser host share source-write application admission",
+            "destination copies remain charged through browser-facing socket settlement",
+            "credited transport handoff transfers application ownership before callback settlement"
+          ]
+        },
+        {
+          "file": "src/main/browser/browser-network-tunnel-outbound-memory-budget.test.ts",
+          "assertions": [
+            "application, encrypted-queue, and native socket bytes share one host ceiling",
+            "distinct hosts share one process ceiling with exact release",
+            "zero-byte claims, socket sources, hosts, and leases have independent bounds",
+            "released leases cannot admit work and retained owners keep exact accounting alive",
+            "unavailable native-buffer evidence fails closed until its exact source releases"
           ]
         },
         {
@@ -2692,8 +2723,10 @@
           "assertions": [
             "the production RPC registry excludes the tunnel until route authorization exists",
             "unnegotiated, self-asserted, stale, and wrong-execution-revision browser hosts register no binary handler",
+            "memory exhaustion opens no route or binary handler",
             "the server allocates route generations and fences the replaced route",
-            "subscription cleanup removes the exact connection-owned raw handler"
+            "subscription cleanup removes the exact connection-owned raw handler",
+            "raw-handler cleanup failure cannot retain route memory or lease authority"
           ]
         },
         {
@@ -2702,7 +2735,8 @@
             "route teardown closes a subscription that resolves after startup cancellation",
             "close after subscription acquisition settles the pending readiness wait",
             "post-auth readiness has a deadline and runtime close tears down the local route",
-            "listener teardown failures remain visible to the route owner"
+            "listener teardown failures remain visible to the route owner",
+            "the route binds and releases its exact host/process memory lease and four-frame drain quantum"
           ]
         },
         {
@@ -2716,11 +2750,29 @@
           "file": "src/shared/remote-runtime-client.test.ts",
           "assertions": [
             "the authenticated socket binds the optional tunnel capability",
-            "the dedicated outbound queue reports hard overflow instead of dropping a frame"
+            "the dedicated outbound queue reports hard overflow instead of dropping a frame",
+            "encrypted queue claims release synchronously while native socket ownership remains charged through exact close"
+          ]
+        },
+        {
+          "file": "src/shared/ws-outbound-backpressure-queue.test.ts",
+          "assertions": [
+            "direct and already-retained queued frames use distinct aggregate admission semantics",
+            "queued drain yields after its configured frame quantum without reordering",
+            "aggregate queue claims release on drain, denial, disposal, and close"
           ]
         }
       ],
       "evidenceRuns": [
+        {
+          "date": "2026-08-14",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/shared/browser-client-host-protocol.test.ts src/shared/ws-outbound-backpressure-queue.test.ts src/shared/remote-runtime-client.test.ts src/main/runtime/browser-host-lease-registry.test.ts src/main/runtime/runtime-rpc-browser-host-admission.test.ts src/main/runtime/rpc/methods/browser-client-host.test.ts src/main/runtime/rpc/methods/browser-network-tunnel.test.ts src/main/browser/paired-runtime-browser-host-lease.test.ts src/main/browser/paired-runtime-browser-network-route.test.ts src/main/runtime/browser-network-tunnel-paired-runtime.integration.test.ts src/main/browser/browser-network-tunnel-client.test.ts src/main/browser/browser-network-tunnel-client-memory-budget.test.ts src/main/browser/browser-network-tunnel-session.test.ts src/main/browser/browser-network-tunnel-session-aggregate-memory.test.ts src/main/browser/browser-network-tunnel-outbound-memory-budget.test.ts src/main/browser/remote-browser-socks-server.test.ts",
+          "result": "passed",
+          "durationSeconds": 8.0,
+          "summary": "Sixteen files passed 123 route, lease, aggregate application/encrypted/native memory, exact release, bounded-drain, SOCKS, and real paired E2EE tests; the full runtime-RPC suite separately passed 1,349 tests with one skip."
+        },
         {
           "date": "2026-08-14",
           "runner": "local",
@@ -2768,8 +2820,8 @@
         }
       ],
       "runtimeBudget": {
-        "p95Seconds": 5,
-        "scope": "deterministic lease, protocol, flow-control, loopback, RPC, and paired-runtime test files"
+        "p95Seconds": 10,
+        "scope": "deterministic lease, protocol, aggregate-memory, flow-control, loopback, RPC, and paired-runtime test files"
       },
       "flakeHistory": {
         "status": "unknown",
@@ -2777,14 +2829,14 @@
       },
       "redGreenEvidence": {
         "status": "partial",
-        "evidence": "The protocol and tunnel-session oracles fail on origin/main 3246b73add because the modules do not exist, then pass on the candidate. The lease registry and control-client suites were recorded red at missing modules before implementation. The unchanged tunnel authorization oracle was behaviorally red because an authenticated socket could self-assert its paired device ID and received ready generation 7 without a lease; it is green after server-owned lease and route fencing. On c9a41abf24, the unchanged admission oracle failed three ways: a second identity on one connection and a fifth identity for one paired device were both admitted, and closed page placement had no retirement API. All three pass after bounded admission and tombstone-free global page generations. On parent 392d13be9f, the deterministic resource oracle admitted 17 pending opens, admitted a 129th open inside 10 seconds, and retained more than 8 MiB across one route; all three failed assertions pass on the candidate, which also covers unsettled writes and reentrant exact release. The real paired journey failed at the missing network.browserTunnel method before explicit test injection, then passed with an exact control lease while both production registries remained closed. Full mutation/revert evidence remains to be collected before promotion."
+        "evidence": "The protocol and tunnel-session oracles fail on origin/main 3246b73add because the modules do not exist, then pass on the candidate. The lease registry and control-client suites were recorded red at missing modules before implementation. The unchanged tunnel authorization oracle was behaviorally red because an authenticated socket could self-assert its paired device ID and received ready generation 7 without a lease; it is green after server-owned lease and route fencing. On c9a41abf24, the unchanged admission oracle failed three ways: a second identity on one connection and a fifth identity for one paired device were both admitted, and closed page placement had no retirement API. All three pass after bounded admission and tombstone-free global page generations. On parent 392d13be9f, the deterministic resource oracle admitted 17 pending opens, admitted a 129th open inside 10 seconds, and retained more than 8 MiB across one route; all three failed assertions pass on the candidate, which also covers unsettled writes and reentrant exact release. With aggregate enforcement replaced by a no-op scaffold on parent b32610e365, all three host/process memory assertions failed: host bytes, process bytes, claims, and socket sources were independently unbounded. They pass with exact owner release, client and execution-host application charging, encrypted queue/native socket charging, and bounded drain. The real paired journey failed at the missing network.browserTunnel method before explicit test injection, then passed with an exact control lease while both production registries remained closed. Full mutation/revert evidence remains to be collected before promotion."
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "Data frames, send credit, pending bytes and chunk counts in both directions, streams, SOCKS handshake, and pipelined application bytes are bounded. Each route admits at most 16 pending opens, 128 opens per monotonic 10-second window, and 8 MiB of session-owned queued or unsettled application bytes with exact settlement and retirement release. One authenticated connection retains at most one browser host and one paired device at most four, with exact release restoring admission. Permanent browser-host polls use at most one quarter of the shared long-poll slots, and real injected dispatch proves an ordinary wait remains admitted and socket close releases both classes. Credit returns only after the execution-host or browser-facing socket write settles, and the injected transport must explicitly accept each frame. Encrypted WebSocket/native buffers, aggregate browser-host/process ledgers, and drain-aware fair scheduling remain required before live tunnel advertisement."
+        "evidence": "Data frames, send credit, pending bytes and chunk counts in both directions, streams, SOCKS handshake, and pipelined application bytes are bounded. Each route admits at most 16 pending opens, 128 opens per monotonic 10-second window, and 8 MiB of session-owned queued or unsettled application bytes with exact settlement and retirement release. Multiple client routes share a 32 MiB browser-host and 128 MiB process ceiling across application copies, encrypted queue frames, and dynamic native socket buffers; the execution runtime uses the same per-host/process application policy. Claims, socket sources, host records, and leases have independent count caps; explicit close releases JavaScript queue claims synchronously while native socket ownership remains charged until exact socket close. Parked encrypted queues hand at most four frames to the native socket per immediate cooperative drain turn. One authenticated connection retains at most one browser host and one paired device at most four, with exact release restoring admission. Permanent browser-host polls use at most one quarter of the shared long-poll slots, and real injected dispatch proves an ordinary wait remains admitted and socket close releases both classes. Credit returns only after the execution-host or browser-facing socket write settles, and the injected transport must explicitly accept each frame. Node stream-internal high-water bytes and strict cross-route scheduling evidence remain required before live tunnel advertisement."
       },
       "promotionCriteria": [
-        "Complete aggregate accounting across encrypted transport/native buffers, browser hosts, and the process with runtime-wide fair scheduling.",
+        "Charge Node stream-internal high-water bytes and prove cross-route fairness under slow physical links; add a strict scheduler if the four-frame yield quantum is insufficient.",
         "Approve all same-host local processes and users as inside the desktop trust boundary or replace SOCKS no-auth with Chromium-compatible process isolation.",
         "Add old/new peer coverage to the dedicated paired-runtime binary tunnel journey.",
         "Add SSH2, system SSH, WSL, Linux, and physical Windows evidence.",
@@ -2793,7 +2845,8 @@
       "knownGaps": [
         "No runtime capability is advertised, the paired tunnel method is not registered in production, and no Electron webview selects it yet.",
         "The token-safe page-retirement API has no production lifecycle caller until client placement activates.",
-        "Session-owned application buffers are bounded, but encrypted WebSocket/native buffers and aggregate browser-host/process accounting are not implemented.",
+        "Application, encrypted queue, and native WebSocket bytes are aggregated, but Node stream-internal high-water bytes are only per-stream bounded and not charged to the host/process ledger.",
+        "A four-frame queued-drain quantum yields between timers, but strict cross-route fairness and slow-link soak evidence are not complete.",
         "The loopback SOCKS endpoint uses Chromium-compatible no-auth and is not safe to activate until its desktop trust boundary is approved or isolated.",
         "SSH, WSL, browserless serve, Electron proxy policy, UDP denial, and desktop DNS/socket capture are not exercised."
       ],

--- a/src/main/browser/browser-network-tunnel-client-memory-budget.test.ts
+++ b/src/main/browser/browser-network-tunnel-client-memory-budget.test.ts
@@ -1,0 +1,121 @@
+import { once } from 'node:events'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  BrowserNetworkTunnelOpcode,
+  encodeBrowserNetworkTunnelFrame,
+  encodeBrowserNetworkTunnelWindowUpdate
+} from '../../shared/browser-network-tunnel-protocol'
+import { BrowserNetworkTunnelClient } from './browser-network-tunnel-client'
+import type { BrowserNetworkTunnelDuplex } from './browser-network-tunnel-duplex'
+import {
+  BrowserNetworkTunnelOutboundMemoryBudgetRegistry,
+  type BrowserNetworkTunnelOutboundMemoryLease
+} from './browser-network-tunnel-outbound-memory-budget'
+
+const TUNNEL_GENERATION = 7
+
+function frame(
+  opcode: BrowserNetworkTunnelOpcode,
+  payload: Uint8Array<ArrayBufferLike> = new Uint8Array(),
+  streamId = 1
+): Uint8Array {
+  return encodeBrowserNetworkTunnelFrame({
+    opcode,
+    tunnelGeneration: TUNNEL_GENERATION,
+    streamId,
+    payload
+  })
+}
+
+describe('BrowserNetworkTunnelClient aggregate memory', () => {
+  it('shares application-write admission across routes on one browser host', async () => {
+    const registry = new BrowserNetworkTunnelOutboundMemoryBudgetRegistry({
+      hostMaxBytes: 10,
+      processMaxBytes: 100
+    })
+    const first = createClient(registry.acquire('host-a')!)
+    const second = createClient(registry.acquire('host-a')!)
+    const firstSocket = await open(first.client)
+    const secondSocket = await open(second.client)
+    firstSocket.on('error', () => undefined)
+    secondSocket.on('error', () => undefined)
+
+    firstSocket.write(Buffer.alloc(6), vi.fn())
+    secondSocket.write(Buffer.alloc(5), vi.fn())
+
+    expect(registry.evidence().retainedBytes).toBe(6)
+    expect(secondSocket.destroyed).toBe(true)
+
+    firstSocket.destroy()
+    await vi.waitFor(() => expect(registry.evidence().retainedBytes).toBe(0))
+    const replacement = await open(second.client, 2)
+    replacement.on('error', () => undefined)
+    replacement.write(Buffer.alloc(5), vi.fn())
+    expect(registry.evidence().retainedBytes).toBe(5)
+
+    first.client.close()
+    second.client.close()
+  })
+
+  it('retains destination bytes until the browser-facing socket write settles', async () => {
+    const registry = new BrowserNetworkTunnelOutboundMemoryBudgetRegistry({
+      hostMaxBytes: 10,
+      processMaxBytes: 100
+    })
+    const route = createClient(registry.acquire('host-a')!)
+    const socket = await open(route.client)
+    socket.on('error', () => undefined)
+
+    route.client.handleBinary(frame(BrowserNetworkTunnelOpcode.Data, new Uint8Array([1, 2, 3])))
+    expect(registry.evidence().retainedBytes).toBe(3)
+
+    const received = once(socket, 'data')
+    await received
+    expect(registry.evidence().retainedBytes).toBe(3)
+    socket.settleRead(3)
+    expect(registry.evidence().retainedBytes).toBe(0)
+    route.client.close()
+  })
+
+  it('releases a source-write claim only after credited transport handoff', async () => {
+    const registry = new BrowserNetworkTunnelOutboundMemoryBudgetRegistry({
+      hostMaxBytes: 10,
+      processMaxBytes: 100
+    })
+    const route = createClient(registry.acquire('host-a')!)
+    const socket = await open(route.client)
+    socket.on('error', () => undefined)
+    const settled = vi.fn()
+
+    socket.write(Buffer.alloc(4), settled)
+    expect(registry.evidence().retainedBytes).toBe(4)
+    route.client.handleBinary(
+      frame(BrowserNetworkTunnelOpcode.WindowUpdate, encodeBrowserNetworkTunnelWindowUpdate(4))
+    )
+
+    await vi.waitFor(() => expect(settled).toHaveBeenCalledOnce())
+    expect(registry.evidence().retainedBytes).toBe(0)
+    route.client.close()
+  })
+})
+
+function createClient(
+  outboundMemory: Pick<BrowserNetworkTunnelOutboundMemoryLease, 'claimApplicationBytes'>
+): { client: BrowserNetworkTunnelClient } {
+  return {
+    client: new BrowserNetworkTunnelClient({
+      tunnelGeneration: TUNNEL_GENERATION,
+      sendBinary: () => true,
+      outboundMemory
+    })
+  }
+}
+
+async function open(
+  client: BrowserNetworkTunnelClient,
+  streamId = 1
+): Promise<BrowserNetworkTunnelDuplex> {
+  const opening = client.open({ host: 'localhost', port: 8080 })
+  client.handleBinary(frame(BrowserNetworkTunnelOpcode.Opened, new Uint8Array(), streamId))
+  return opening
+}

--- a/src/main/browser/browser-network-tunnel-client-retirement.ts
+++ b/src/main/browser/browser-network-tunnel-client-retirement.ts
@@ -15,14 +15,29 @@ export function retireBrowserNetworkTunnelClientStream(
       options.error ?? new Error('Browser tunnel destination closed before opening')
     )
   }
-  for (const pending of stream.pendingWrites) {
-    pending.callback(options.error ?? new Error('Browser tunnel stream closed'))
+  const pendingWrites = stream.pendingWrites
+  const writeError = options.error ?? new Error('Browser tunnel stream closed')
+  for (const pending of pendingWrites) {
+    pending.releaseApplicationBytes()
+  }
+  for (const pending of stream.pendingToSocket) {
+    pending.releaseApplicationBytes()
+  }
+  for (const settlement of stream.unsettledToSocket) {
+    settlement.releaseApplicationBytes()
   }
   stream.pendingWrites = []
   stream.pendingWriteBytes = 0
   stream.pendingToSocket = []
   stream.pendingToSocketBytes = 0
-  if (options.destroySocket && !stream.socket.destroyed) {
-    stream.socket.destroy(options.error)
+  stream.unsettledToSocket = []
+  try {
+    for (const pending of pendingWrites) {
+      pending.callback(writeError)
+    }
+  } finally {
+    if (options.destroySocket && !stream.socket.destroyed) {
+      stream.socket.destroy(options.error)
+    }
   }
 }

--- a/src/main/browser/browser-network-tunnel-client-stream-frames.ts
+++ b/src/main/browser/browser-network-tunnel-client-stream-frames.ts
@@ -20,6 +20,7 @@ type BrowserNetworkTunnelClientStreamFrameActions = {
   ) => boolean
   closeTunnel: (error: Error) => void
   flushWrites: (stream: BrowserNetworkTunnelClientStream) => void
+  claimApplicationBytes: (bytes: number) => (() => void) | null
   retire: (stream: BrowserNetworkTunnelClientStream, error?: Error) => void
 }
 
@@ -31,7 +32,8 @@ export function handleBrowserNetworkTunnelClientStreamFrame(
   dispatchBrowserNetworkTunnelClientFrame(frame, {
     opened: () => openedStream(stream, actions),
     grantCredit: () => grantStreamCredit(stream, frame.payload, actions),
-    deliverData: () => deliverStreamData(stream, frame.payload, actions.closeTunnel),
+    deliverData: () =>
+      deliverStreamData(stream, frame.payload, actions.claimApplicationBytes, actions.closeTunnel),
     halfClose: () => halfCloseStream(stream, actions.closeTunnel),
     close: () => closeStream(stream, actions),
     remoteFailure: (error) => actions.retire(stream, error),
@@ -84,9 +86,10 @@ function grantStreamCredit(
 function deliverStreamData(
   stream: BrowserNetworkTunnelClientStream,
   payload: Uint8Array<ArrayBufferLike>,
+  claimApplicationBytes: (bytes: number) => (() => void) | null,
   closeTunnel: (error: Error) => void
 ): void {
-  if (!queueBrowserNetworkSourceData(stream, payload)) {
+  if (!queueBrowserNetworkSourceData(stream, payload, claimApplicationBytes)) {
     closeTunnel(new Error('Browser tunnel received invalid destination data'))
   }
 }

--- a/src/main/browser/browser-network-tunnel-client-stream.ts
+++ b/src/main/browser/browser-network-tunnel-client-stream.ts
@@ -1,28 +1,23 @@
 import { BrowserNetworkTunnelDuplex } from './browser-network-tunnel-duplex'
 import type { BrowserNetworkTunnelSourceFlowStream } from './browser-network-tunnel-source-flow'
+import type { BrowserNetworkTunnelSourceReceiveStream } from './browser-network-tunnel-source-receive-flow'
 import {
   BROWSER_NETWORK_TUNNEL_CONNECT_TIMEOUT_MS,
   BROWSER_NETWORK_TUNNEL_INITIAL_WINDOW_BYTES
 } from './browser-network-tunnel-stream-state'
 
-export type BrowserNetworkTunnelClientStream = BrowserNetworkTunnelSourceFlowStream & {
-  id: number
-  socket: BrowserNetworkTunnelDuplex
-  opened: boolean
-  closed: boolean
-  localEnded: boolean
-  localHalfCloseSent: boolean
-  remoteEnded: boolean
-  remoteClosed: boolean
-  readableEnded: boolean
-  receiveCredit: number
-  pendingToSocket: Uint8Array<ArrayBufferLike>[]
-  pendingToSocketBytes: number
-  readableDemand: boolean
-  connectTimeout: ReturnType<typeof setTimeout>
-  resolveOpen: (socket: BrowserNetworkTunnelDuplex) => void
-  rejectOpen: (error: Error) => void
-}
+export type BrowserNetworkTunnelClientStream = BrowserNetworkTunnelSourceFlowStream &
+  BrowserNetworkTunnelSourceReceiveStream & {
+    id: number
+    socket: BrowserNetworkTunnelDuplex
+    closed: boolean
+    localEnded: boolean
+    localHalfCloseSent: boolean
+    remoteClosed: boolean
+    connectTimeout: ReturnType<typeof setTimeout>
+    resolveOpen: (socket: BrowserNetworkTunnelDuplex) => void
+    rejectOpen: (error: Error) => void
+  }
 
 type BrowserNetworkTunnelClientStreamCallbacks = {
   writeBytes: (bytes: Uint8Array<ArrayBufferLike>, callback: (error?: Error | null) => void) => void
@@ -58,6 +53,7 @@ export function createBrowserNetworkTunnelClientStream(
     receiveCredit: BROWSER_NETWORK_TUNNEL_INITIAL_WINDOW_BYTES,
     pendingToSocket: [],
     pendingToSocketBytes: 0,
+    unsettledToSocket: [],
     readableDemand: false,
     pendingWrites: [],
     pendingWriteBytes: 0,

--- a/src/main/browser/browser-network-tunnel-client.ts
+++ b/src/main/browser/browser-network-tunnel-client.ts
@@ -7,6 +7,7 @@ import {
   type BrowserNetworkTunnelOpen
 } from '../../shared/browser-network-tunnel-protocol'
 import { BrowserNetworkTunnelFrameSender } from './browser-network-tunnel-frame-sender'
+import type { BrowserNetworkTunnelOutboundMemoryLease } from './browser-network-tunnel-outbound-memory-budget'
 import {
   BROWSER_NETWORK_TUNNEL_INITIAL_WINDOW_BYTES,
   validateBrowserNetworkTunnelGeneration
@@ -22,7 +23,8 @@ import {
 import type { BrowserNetworkTunnelDuplex } from './browser-network-tunnel-duplex'
 import {
   beginBrowserNetworkSourceRead,
-  grantBrowserNetworkSourceReceiveCredit
+  grantBrowserNetworkSourceReceiveCredit,
+  settleBrowserNetworkSourceData
 } from './browser-network-tunnel-source-receive-flow'
 import { retireBrowserNetworkTunnelClientStream } from './browser-network-tunnel-client-retirement'
 import { handleBrowserNetworkTunnelClientStreamFrame } from './browser-network-tunnel-client-stream-frames'
@@ -30,11 +32,13 @@ import { handleBrowserNetworkTunnelClientStreamFrame } from './browser-network-t
 type BrowserNetworkTunnelClientOptions = {
   tunnelGeneration: number
   sendBinary: (bytes: Uint8Array<ArrayBufferLike>) => boolean
+  outboundMemory?: Pick<BrowserNetworkTunnelOutboundMemoryLease, 'claimApplicationBytes'>
 }
 
 export class BrowserNetworkTunnelClient {
   private readonly tunnelGeneration: number
   private readonly frameSender: BrowserNetworkTunnelFrameSender
+  private readonly outboundMemory: BrowserNetworkTunnelClientOptions['outboundMemory']
   private readonly streams = new Map<number, BrowserNetworkTunnelClientStream>()
   private nextStreamId = 1
   private closed = false
@@ -42,6 +46,7 @@ export class BrowserNetworkTunnelClient {
   constructor(options: BrowserNetworkTunnelClientOptions) {
     validateBrowserNetworkTunnelGeneration(options.tunnelGeneration)
     this.tunnelGeneration = options.tunnelGeneration
+    this.outboundMemory = options.outboundMemory
     this.frameSender = new BrowserNetworkTunnelFrameSender(
       options.tunnelGeneration,
       options.sendBinary,
@@ -130,6 +135,7 @@ export class BrowserNetworkTunnelClient {
       send: (opcode, streamId, payload) => this.frameSender.send(opcode, streamId, payload),
       closeTunnel: (error) => this.close(error),
       flushWrites: (target) => this.flushStreamWrites(target),
+      claimApplicationBytes: (bytes) => this.claimApplicationBytes(bytes),
       retire: (target, error) => this.retireStream(target, error)
     })
   }
@@ -144,7 +150,11 @@ export class BrowserNetworkTunnelClient {
       callback(new Error('Browser tunnel stream is not writable'))
       return
     }
-    if (!queueBrowserNetworkSourceWrite(stream, bytes, callback)) {
+    if (
+      !queueBrowserNetworkSourceWrite(stream, bytes, callback, (pendingBytes) =>
+        this.claimApplicationBytes(pendingBytes)
+      )
+    ) {
       const error = new Error('Browser tunnel source buffer overflow')
       callback(error)
       this.failStream(stream, error)
@@ -187,8 +197,10 @@ export class BrowserNetworkTunnelClient {
 
   private consumeStreamBytes(streamId: number, bytes: number): void {
     const stream = this.streams.get(streamId)
-    if (stream) {
+    if (stream && settleBrowserNetworkSourceData(stream, bytes)) {
       this.replenishStreamCredit(stream, bytes)
+    } else if (stream) {
+      this.close(new Error('Browser tunnel settled invalid destination bytes'))
     }
   }
 
@@ -267,5 +279,12 @@ export class BrowserNetworkTunnelClient {
 
   private isCurrent(stream: BrowserNetworkTunnelClientStream): boolean {
     return !this.closed && !stream.closed && this.streams.get(stream.id) === stream
+  }
+
+  private claimApplicationBytes(bytes: number): (() => void) | null {
+    if (!this.outboundMemory) {
+      return () => undefined
+    }
+    return this.outboundMemory.claimApplicationBytes(bytes)
   }
 }

--- a/src/main/browser/browser-network-tunnel-outbound-memory-budget.test.ts
+++ b/src/main/browser/browser-network-tunnel-outbound-memory-budget.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest'
+import { BrowserNetworkTunnelOutboundMemoryBudgetRegistry } from './browser-network-tunnel-outbound-memory-budget'
+
+describe('BrowserNetworkTunnelOutboundMemoryBudgetRegistry', () => {
+  it('shares one host ceiling across application, encrypted queue, and native buffers', () => {
+    const registry = new BrowserNetworkTunnelOutboundMemoryBudgetRegistry({
+      hostMaxBytes: 10,
+      processMaxBytes: 100
+    })
+    const first = registry.acquire('host-a')!
+    const second = registry.acquire('host-a')!
+    const releaseApplication = first.claimApplicationBytes(4)
+    const releaseQueued = second.claimQueuedBytes(3)
+    let buffered = 2
+    const socket = second.registerBufferedAmount(() => buffered)!
+
+    expect(releaseApplication).not.toBeNull()
+    expect(releaseQueued).not.toBeNull()
+    expect(socket.canSend(1)).toBe(true)
+    expect(socket.canSend(2)).toBe(false)
+    buffered = 3
+    expect(first.claimApplicationBytes(1)).toBeNull()
+
+    releaseQueued?.()
+    expect(first.claimApplicationBytes(1)).not.toBeNull()
+  })
+
+  it('shares one process ceiling across distinct browser hosts and restores exact admission', () => {
+    const registry = new BrowserNetworkTunnelOutboundMemoryBudgetRegistry({
+      hostMaxBytes: 100,
+      processMaxBytes: 10
+    })
+    const first = registry.acquire('host-a')!
+    const second = registry.acquire('host-b')!
+    const releaseFirst = first.claimApplicationBytes(6)
+    const releaseSecond = second.claimQueuedBytes(4)
+
+    expect(releaseFirst).not.toBeNull()
+    expect(releaseSecond).not.toBeNull()
+    expect(second.claimApplicationBytes(1)).toBeNull()
+
+    releaseFirst?.()
+    expect(second.claimApplicationBytes(1)).not.toBeNull()
+  })
+
+  it('bounds claims and socket sources independently of byte size', () => {
+    const registry = new BrowserNetworkTunnelOutboundMemoryBudgetRegistry({
+      hostMaxBytes: 100,
+      processMaxBytes: 100,
+      hostMaxClaims: 2,
+      processMaxClaims: 3,
+      hostMaxSocketSources: 1,
+      processMaxSocketSources: 2
+    })
+    const first = registry.acquire('host-a')!
+    const second = registry.acquire('host-b')!
+    const releaseFirst = first.claimApplicationBytes(0)
+    const releaseSecond = first.claimQueuedBytes(0)
+
+    expect(releaseFirst).not.toBeNull()
+    expect(releaseSecond).not.toBeNull()
+    expect(first.claimQueuedBytes(0)).toBeNull()
+    expect(second.claimQueuedBytes(0)).not.toBeNull()
+    expect(second.claimQueuedBytes(0)).toBeNull()
+
+    const socket = first.registerBufferedAmount(() => 0)
+    expect(socket).not.toBeNull()
+    expect(first.registerBufferedAmount(() => 0)).toBeNull()
+    socket?.release()
+    expect(first.registerBufferedAmount(() => 0)).not.toBeNull()
+  })
+
+  it('fences released leases and retains accounting until every exact owner releases', () => {
+    const registry = new BrowserNetworkTunnelOutboundMemoryBudgetRegistry({ processMaxHosts: 1 })
+    const lease = registry.acquire('host-a')!
+    const releaseClaim = lease.claimApplicationBytes(3)
+    const socket = lease.registerBufferedAmount(() => 2)!
+
+    expect(registry.acquire('host-b')).toBeNull()
+    lease.release()
+    expect(lease.claimApplicationBytes(1)).toBeNull()
+    expect(lease.registerBufferedAmount(() => 0)).toBeNull()
+    expect(socket.canSend(1)).toBe(false)
+    expect(registry.evidence()).toMatchObject({ hosts: 1, leases: 0, retainedBytes: 3 })
+
+    releaseClaim?.()
+    socket.release()
+    expect(registry.evidence()).toMatchObject({
+      hosts: 0,
+      leases: 0,
+      retainedBytes: 0,
+      bufferedBytes: 0,
+      claims: 0,
+      socketSources: 0
+    })
+    expect(registry.acquire('host-b')).not.toBeNull()
+  })
+
+  it('treats unavailable native-buffer evidence as full until the source releases', () => {
+    const registry = new BrowserNetworkTunnelOutboundMemoryBudgetRegistry({
+      hostMaxBytes: 10,
+      processMaxBytes: 10
+    })
+    const lease = registry.acquire('host-a')!
+    const socket = lease.registerBufferedAmount(() => {
+      throw new Error('socket unavailable')
+    })!
+
+    expect(socket.canSend(1)).toBe(false)
+    expect(lease.claimApplicationBytes(1)).toBeNull()
+    socket.release()
+    expect(lease.claimApplicationBytes(1)).not.toBeNull()
+  })
+})

--- a/src/main/browser/browser-network-tunnel-outbound-memory-budget.ts
+++ b/src/main/browser/browser-network-tunnel-outbound-memory-budget.ts
@@ -1,0 +1,234 @@
+export const BROWSER_NETWORK_TUNNEL_HOST_MAX_OUTBOUND_BYTES = 32 * 1024 * 1024
+export const BROWSER_NETWORK_TUNNEL_PROCESS_MAX_OUTBOUND_BYTES = 128 * 1024 * 1024
+
+const DEFAULT_HOST_MAX_CLAIMS = 16_384
+const DEFAULT_PROCESS_MAX_CLAIMS = 65_536
+const DEFAULT_HOST_MAX_SOCKET_SOURCES = 8
+const DEFAULT_PROCESS_MAX_SOCKET_SOURCES = 32
+const DEFAULT_HOST_MAX_LEASES = 8
+const DEFAULT_PROCESS_MAX_LEASES = 64
+const DEFAULT_PROCESS_MAX_HOSTS = 32
+
+export type BrowserNetworkTunnelOutboundSocketMemory = {
+  canSend: (bytes: number, alreadyRetained?: boolean) => boolean
+  release: () => void
+}
+
+export type BrowserNetworkTunnelOutboundMemoryLease = {
+  claimApplicationBytes: (bytes: number) => (() => void) | null
+  claimQueuedBytes: (bytes: number) => (() => void) | null
+  registerBufferedAmount: (
+    readBufferedAmount: () => number
+  ) => BrowserNetworkTunnelOutboundSocketMemory | null
+  release: () => void
+}
+
+type BrowserHostMemoryState = {
+  leases: number
+  retainedBytes: number
+  claims: number
+  bufferedSources: Set<() => number>
+}
+
+type BrowserNetworkTunnelOutboundMemoryBudgetOptions = {
+  hostMaxBytes?: number
+  processMaxBytes?: number
+  hostMaxClaims?: number
+  processMaxClaims?: number
+  hostMaxSocketSources?: number
+  processMaxSocketSources?: number
+  hostMaxLeases?: number
+  processMaxLeases?: number
+  processMaxHosts?: number
+}
+
+export class BrowserNetworkTunnelOutboundMemoryBudgetRegistry {
+  private readonly hostMaxBytes: number
+  private readonly processMaxBytes: number
+  private readonly hostMaxClaims: number
+  private readonly processMaxClaims: number
+  private readonly hostMaxSocketSources: number
+  private readonly processMaxSocketSources: number
+  private readonly hostMaxLeases: number
+  private readonly processMaxLeases: number
+  private readonly processMaxHosts: number
+  private readonly hosts = new Map<string, BrowserHostMemoryState>()
+  private readonly bufferedSources = new Set<() => number>()
+  private retainedBytes = 0
+  private claims = 0
+  private leases = 0
+
+  constructor(options: BrowserNetworkTunnelOutboundMemoryBudgetOptions = {}) {
+    this.hostMaxBytes = options.hostMaxBytes ?? BROWSER_NETWORK_TUNNEL_HOST_MAX_OUTBOUND_BYTES
+    this.processMaxBytes =
+      options.processMaxBytes ?? BROWSER_NETWORK_TUNNEL_PROCESS_MAX_OUTBOUND_BYTES
+    this.hostMaxClaims = options.hostMaxClaims ?? DEFAULT_HOST_MAX_CLAIMS
+    this.processMaxClaims = options.processMaxClaims ?? DEFAULT_PROCESS_MAX_CLAIMS
+    this.hostMaxSocketSources = options.hostMaxSocketSources ?? DEFAULT_HOST_MAX_SOCKET_SOURCES
+    this.processMaxSocketSources =
+      options.processMaxSocketSources ?? DEFAULT_PROCESS_MAX_SOCKET_SOURCES
+    this.hostMaxLeases = options.hostMaxLeases ?? DEFAULT_HOST_MAX_LEASES
+    this.processMaxLeases = options.processMaxLeases ?? DEFAULT_PROCESS_MAX_LEASES
+    this.processMaxHosts = options.processMaxHosts ?? DEFAULT_PROCESS_MAX_HOSTS
+  }
+
+  acquire(browserHostClientId: string): BrowserNetworkTunnelOutboundMemoryLease | null {
+    if (
+      !browserHostClientId ||
+      browserHostClientId.length > 256 ||
+      this.leases >= this.processMaxLeases
+    ) {
+      return null
+    }
+    let host = this.hosts.get(browserHostClientId)
+    if (!host) {
+      if (this.hosts.size >= this.processMaxHosts) {
+        return null
+      }
+      host = { leases: 0, retainedBytes: 0, claims: 0, bufferedSources: new Set() }
+      this.hosts.set(browserHostClientId, host)
+    }
+    if (host.leases >= this.hostMaxLeases) {
+      this.deleteEmptyHost(browserHostClientId, host)
+      return null
+    }
+    host.leases += 1
+    this.leases += 1
+    return this.createLease(browserHostClientId, host)
+  }
+
+  evidence(): {
+    hosts: number
+    leases: number
+    retainedBytes: number
+    bufferedBytes: number
+    claims: number
+    socketSources: number
+  } {
+    return {
+      hosts: this.hosts.size,
+      leases: this.leases,
+      retainedBytes: this.retainedBytes,
+      bufferedBytes: readBufferedBytes(this.bufferedSources),
+      claims: this.claims,
+      socketSources: this.bufferedSources.size
+    }
+  }
+
+  private createLease(
+    browserHostClientId: string,
+    host: BrowserHostMemoryState
+  ): BrowserNetworkTunnelOutboundMemoryLease {
+    let active = true
+    const claim = (bytes: number): (() => void) | null => {
+      if (!active || !this.canClaim(host, bytes)) {
+        return null
+      }
+      host.retainedBytes += bytes
+      host.claims += 1
+      this.retainedBytes += bytes
+      this.claims += 1
+      return createRelease(() => {
+        host.retainedBytes -= bytes
+        host.claims -= 1
+        this.retainedBytes -= bytes
+        this.claims -= 1
+        this.deleteEmptyHost(browserHostClientId, host)
+      })
+    }
+    return {
+      claimApplicationBytes: claim,
+      claimQueuedBytes: claim,
+      registerBufferedAmount: (readBufferedAmount) => {
+        if (
+          !active ||
+          host.bufferedSources.size >= this.hostMaxSocketSources ||
+          this.bufferedSources.size >= this.processMaxSocketSources
+        ) {
+          return null
+        }
+        const source = (): number => readBufferedAmount()
+        host.bufferedSources.add(source)
+        this.bufferedSources.add(source)
+        let registered = true
+        return {
+          canSend: (bytes, alreadyRetained = false) =>
+            registered && active && this.canFitBytes(host, bytes, alreadyRetained ? 0 : bytes),
+          release: createRelease(() => {
+            registered = false
+            host.bufferedSources.delete(source)
+            this.bufferedSources.delete(source)
+            this.deleteEmptyHost(browserHostClientId, host)
+          })
+        }
+      },
+      release: createRelease(() => {
+        active = false
+        host.leases -= 1
+        this.leases -= 1
+        this.deleteEmptyHost(browserHostClientId, host)
+      })
+    }
+  }
+
+  private canClaim(host: BrowserHostMemoryState, bytes: number): boolean {
+    return (
+      host.claims < this.hostMaxClaims &&
+      this.claims < this.processMaxClaims &&
+      this.canFitBytes(host, bytes, bytes)
+    )
+  }
+
+  private canFitBytes(host: BrowserHostMemoryState, bytes: number, addedBytes: number): boolean {
+    if (!Number.isSafeInteger(bytes) || bytes < 0) {
+      return false
+    }
+    const hostBufferedBytes = readBufferedBytes(host.bufferedSources)
+    const processBufferedBytes = readBufferedBytes(this.bufferedSources)
+    return (
+      host.retainedBytes + hostBufferedBytes + addedBytes <= this.hostMaxBytes &&
+      this.retainedBytes + processBufferedBytes + addedBytes <= this.processMaxBytes
+    )
+  }
+
+  private deleteEmptyHost(browserHostClientId: string, host: BrowserHostMemoryState): void {
+    if (
+      host.leases === 0 &&
+      host.claims === 0 &&
+      host.bufferedSources.size === 0 &&
+      this.hosts.get(browserHostClientId) === host
+    ) {
+      this.hosts.delete(browserHostClientId)
+    }
+  }
+}
+
+function readBufferedBytes(sources: Set<() => number>): number {
+  let total = 0
+  for (const read of sources) {
+    try {
+      const bytes = read()
+      if (!Number.isSafeInteger(bytes) || bytes < 0) {
+        return Number.POSITIVE_INFINITY
+      }
+      total += bytes
+      if (!Number.isSafeInteger(total)) {
+        return Number.POSITIVE_INFINITY
+      }
+    } catch {
+      return Number.POSITIVE_INFINITY
+    }
+  }
+  return total
+}
+
+function createRelease(release: () => void): () => void {
+  let released = false
+  return () => {
+    if (released) {
+      return
+    }
+    released = true
+    release()
+  }
+}

--- a/src/main/browser/browser-network-tunnel-resource-budget.ts
+++ b/src/main/browser/browser-network-tunnel-resource-budget.ts
@@ -1,17 +1,29 @@
 import { performance } from 'node:perf_hooks'
+import type { BrowserNetworkTunnelSessionOptions } from './browser-network-tunnel-stream-state'
 
 const MAX_PENDING_OPENS = 16
 const MAX_OPENS_PER_WINDOW = 128
 const OPEN_RATE_WINDOW_MS = 10_000
 const MAX_RETAINED_BYTES = 8 * 1024 * 1024
 
+export function createBrowserNetworkTunnelResourceBudget(
+  options: BrowserNetworkTunnelSessionOptions
+): BrowserNetworkTunnelResourceBudget {
+  return new BrowserNetworkTunnelResourceBudget(options.now, options.claimAggregateRetainedBytes)
+}
+
 export class BrowserNetworkTunnelResourceBudget {
   private readonly recentOpenAttempts: number[] = []
   private pendingOpenCount = 0
   private retainedBytes = 0
   private lastOpenAttemptAt = Number.NEGATIVE_INFINITY
+  private readonly aggregateClaims: ({ remaining: number; release: () => void } | undefined)[] = []
+  private aggregateClaimHead = 0
 
-  constructor(private readonly now: () => number = () => performance.now()) {}
+  constructor(
+    private readonly now: () => number = () => performance.now(),
+    private readonly claimAggregateRetainedBytes?: (bytes: number) => (() => void) | null
+  ) {}
 
   admitOpenAttempt(): boolean {
     const observedAt = this.now()
@@ -53,7 +65,19 @@ export class BrowserNetworkTunnelResourceBudget {
     if (bytes < 0 || bytes > MAX_RETAINED_BYTES - this.retainedBytes) {
       return false
     }
+    if (bytes === 0) {
+      return true
+    }
+    let releaseAggregate = (): void => undefined
+    if (this.claimAggregateRetainedBytes) {
+      const aggregateClaim = this.claimAggregateRetainedBytes(bytes)
+      if (!aggregateClaim) {
+        return false
+      }
+      releaseAggregate = aggregateClaim
+    }
     this.retainedBytes += bytes
+    this.aggregateClaims.push({ remaining: bytes, release: releaseAggregate })
     return true
   }
 
@@ -76,5 +100,23 @@ export class BrowserNetworkTunnelResourceBudget {
       throw new Error('Browser tunnel retained-byte accounting underflow')
     }
     this.retainedBytes -= bytes
+    let remaining = bytes
+    while (remaining > 0) {
+      const claim = this.aggregateClaims[this.aggregateClaimHead]
+      if (!claim) {
+        throw new Error('Browser tunnel aggregate-byte accounting underflow')
+      }
+      const released = Math.min(remaining, claim.remaining)
+      claim.remaining -= released
+      remaining -= released
+      if (claim.remaining === 0) {
+        claim.release()
+        this.aggregateClaims[this.aggregateClaimHead++] = undefined
+      }
+    }
+    if (this.aggregateClaimHead >= 64) {
+      this.aggregateClaims.splice(0, this.aggregateClaimHead)
+      this.aggregateClaimHead = 0
+    }
   }
 }

--- a/src/main/browser/browser-network-tunnel-session-aggregate-memory.test.ts
+++ b/src/main/browser/browser-network-tunnel-session-aggregate-memory.test.ts
@@ -1,0 +1,111 @@
+import { EventEmitter } from 'node:events'
+import { describe, expect, it } from 'vitest'
+import {
+  BrowserNetworkTunnelOpcode,
+  encodeBrowserNetworkTunnelFrame,
+  encodeBrowserNetworkTunnelOpen
+} from '../../shared/browser-network-tunnel-protocol'
+import { BrowserNetworkTunnelOutboundMemoryBudgetRegistry } from './browser-network-tunnel-outbound-memory-budget'
+import { BrowserNetworkTunnelSession } from './browser-network-tunnel-session'
+import type { BrowserNetworkTunnelSocket } from './browser-network-tunnel-stream-state'
+
+class AggregateMemorySocket extends EventEmitter implements BrowserNetworkTunnelSocket {
+  readonly writeCallbacks: (() => void)[] = []
+  destroyed = false
+
+  setNoDelay(): this {
+    return this
+  }
+
+  pause(): this {
+    return this
+  }
+
+  resume(): this {
+    return this
+  }
+
+  write(_bytes: Uint8Array<ArrayBufferLike>, callback?: () => void): boolean {
+    if (callback) {
+      this.writeCallbacks.push(callback)
+    }
+    return true
+  }
+
+  end(): this {
+    return this
+  }
+
+  destroy(): this {
+    this.destroyed = true
+    return this
+  }
+}
+
+describe('BrowserNetworkTunnelSession aggregate memory', () => {
+  it('shares destination queue admission across routes for one browser host', () => {
+    const registry = createRegistry()
+    const first = createSession(registry.acquire('host-a')!.claimApplicationBytes)
+    const second = createSession(registry.acquire('host-a')!.claimApplicationBytes)
+
+    first.socket.emit('data', new Uint8Array(6))
+    second.socket.emit('data', new Uint8Array(5))
+
+    expect(registry.evidence().retainedBytes).toBe(6)
+    expect(first.socket.destroyed).toBe(false)
+    expect(second.socket.destroyed).toBe(true)
+
+    first.session.close()
+    expect(registry.evidence().retainedBytes).toBe(0)
+  })
+
+  it('shares unsettled destination writes and releases them exactly on route close', () => {
+    const registry = createRegistry()
+    const first = createSession(registry.acquire('host-a')!.claimApplicationBytes)
+    const second = createSession(registry.acquire('host-a')!.claimApplicationBytes)
+
+    first.session.handleBinary(frame(BrowserNetworkTunnelOpcode.Data, new Uint8Array(6)))
+    second.session.handleBinary(frame(BrowserNetworkTunnelOpcode.Data, new Uint8Array(5)))
+
+    expect(registry.evidence().retainedBytes).toBe(6)
+    expect(second.socket.destroyed).toBe(true)
+    first.session.close()
+    first.socket.writeCallbacks[0]?.()
+    expect(registry.evidence().retainedBytes).toBe(0)
+  })
+})
+
+function createRegistry(): BrowserNetworkTunnelOutboundMemoryBudgetRegistry {
+  return new BrowserNetworkTunnelOutboundMemoryBudgetRegistry({
+    hostMaxBytes: 10,
+    processMaxBytes: 100
+  })
+}
+
+function createSession(claimAggregateRetainedBytes: (bytes: number) => (() => void) | null): {
+  session: BrowserNetworkTunnelSession
+  socket: AggregateMemorySocket
+} {
+  const socket = new AggregateMemorySocket()
+  const session = new BrowserNetworkTunnelSession({
+    tunnelGeneration: 7,
+    connect: () => socket,
+    sendBinary: () => true,
+    claimAggregateRetainedBytes
+  })
+  session.handleBinary(
+    frame(
+      BrowserNetworkTunnelOpcode.Open,
+      encodeBrowserNetworkTunnelOpen({ host: 'remote.internal', port: 443 })
+    )
+  )
+  socket.emit('connect')
+  return { session, socket }
+}
+
+function frame(
+  opcode: BrowserNetworkTunnelOpcode,
+  payload: Uint8Array<ArrayBufferLike>
+): Uint8Array {
+  return encodeBrowserNetworkTunnelFrame({ opcode, tunnelGeneration: 7, streamId: 1, payload })
+}

--- a/src/main/browser/browser-network-tunnel-session.ts
+++ b/src/main/browser/browser-network-tunnel-session.ts
@@ -13,7 +13,7 @@ import {
   writeBrowserNetworkDestination
 } from './browser-network-tunnel-destination-flow'
 import { BrowserNetworkTunnelFrameSender } from './browser-network-tunnel-frame-sender'
-import { BrowserNetworkTunnelResourceBudget } from './browser-network-tunnel-resource-budget'
+import { createBrowserNetworkTunnelResourceBudget } from './browser-network-tunnel-resource-budget'
 import {
   BROWSER_NETWORK_TUNNEL_INITIAL_WINDOW_BYTES,
   reserveBrowserNetworkTunnelStreamId,
@@ -34,7 +34,7 @@ export class BrowserNetworkTunnelSession {
   private readonly connect: BrowserNetworkTunnelSessionOptions['connect']
   private readonly frameSender: BrowserNetworkTunnelFrameSender
   private readonly onClose: BrowserNetworkTunnelSessionOptions['onClose']
-  private readonly resourceBudget: BrowserNetworkTunnelResourceBudget
+  private readonly resourceBudget: ReturnType<typeof createBrowserNetworkTunnelResourceBudget>
   private readonly streams = new Map<number, BrowserNetworkTunnelStream>()
   private readonly openedStreamIds = new Set<number>()
   private closed = false
@@ -50,7 +50,7 @@ export class BrowserNetworkTunnelSession {
       () => !this.closed
     )
     this.onClose = options.onClose
-    this.resourceBudget = new BrowserNetworkTunnelResourceBudget(options.now)
+    this.resourceBudget = createBrowserNetworkTunnelResourceBudget(options)
   }
 
   handleBinary(bytes: Uint8Array<ArrayBufferLike>): void {

--- a/src/main/browser/browser-network-tunnel-source-flow.ts
+++ b/src/main/browser/browser-network-tunnel-source-flow.ts
@@ -8,6 +8,7 @@ type PendingWrite = {
   bytes: Uint8Array<ArrayBufferLike>
   offset: number
   callback: (error?: Error | null) => void
+  releaseApplicationBytes: () => void
 }
 
 export type BrowserNetworkTunnelSourceFlowStream = {
@@ -19,7 +20,8 @@ export type BrowserNetworkTunnelSourceFlowStream = {
 export function queueBrowserNetworkSourceWrite(
   stream: BrowserNetworkTunnelSourceFlowStream,
   bytes: Uint8Array<ArrayBufferLike>,
-  callback: PendingWrite['callback']
+  callback: PendingWrite['callback'],
+  claimApplicationBytes: (bytes: number) => (() => void) | null
 ): boolean {
   if (
     stream.pendingWriteBytes + bytes.byteLength > BROWSER_NETWORK_TUNNEL_MAX_PENDING_SOCKET_BYTES ||
@@ -27,8 +29,12 @@ export function queueBrowserNetworkSourceWrite(
   ) {
     return false
   }
+  const releaseApplicationBytes = claimApplicationBytes(bytes.byteLength)
+  if (!releaseApplicationBytes) {
+    return false
+  }
   const copy = bytes.slice()
-  stream.pendingWrites.push({ bytes: copy, offset: 0, callback })
+  stream.pendingWrites.push({ bytes: copy, offset: 0, callback, releaseApplicationBytes })
   stream.pendingWriteBytes += copy.byteLength
   return true
 }
@@ -52,6 +58,7 @@ export function flushBrowserNetworkSourceWrites(
     stream.pendingWriteBytes -= length
     if (pending.offset === pending.bytes.byteLength) {
       stream.pendingWrites.shift()
+      pending.releaseApplicationBytes()
       pending.callback()
     }
   }

--- a/src/main/browser/browser-network-tunnel-source-receive-flow.ts
+++ b/src/main/browser/browser-network-tunnel-source-receive-flow.ts
@@ -8,15 +8,27 @@ export type BrowserNetworkTunnelSourceReceiveStream = {
   remoteEnded: boolean
   readableEnded: boolean
   receiveCredit: number
-  pendingToSocket: Uint8Array<ArrayBufferLike>[]
+  pendingToSocket: BrowserNetworkTunnelSourceData[]
   pendingToSocketBytes: number
+  unsettledToSocket: BrowserNetworkTunnelSourceDataSettlement[]
   readableDemand: boolean
   socket: { push: (bytes: Buffer | null) => boolean }
 }
 
+type BrowserNetworkTunnelSourceData = {
+  bytes: Uint8Array<ArrayBufferLike>
+  releaseApplicationBytes: () => void
+}
+
+type BrowserNetworkTunnelSourceDataSettlement = {
+  bytes: number
+  releaseApplicationBytes: () => void
+}
+
 export function queueBrowserNetworkSourceData(
   stream: BrowserNetworkTunnelSourceReceiveStream,
-  payload: Uint8Array<ArrayBufferLike>
+  payload: Uint8Array<ArrayBufferLike>,
+  claimApplicationBytes: (bytes: number) => (() => void) | null
 ): boolean {
   if (
     !stream.opened ||
@@ -29,10 +41,38 @@ export function queueBrowserNetworkSourceData(
   ) {
     return false
   }
+  const releaseApplicationBytes = claimApplicationBytes(payload.byteLength)
+  if (!releaseApplicationBytes) {
+    return false
+  }
   stream.receiveCredit -= payload.byteLength
-  stream.pendingToSocket.push(payload.slice())
+  stream.pendingToSocket.push({ bytes: payload.slice(), releaseApplicationBytes })
   stream.pendingToSocketBytes += payload.byteLength
   flushBrowserNetworkSourceData(stream)
+  return true
+}
+
+export function settleBrowserNetworkSourceData(
+  stream: BrowserNetworkTunnelSourceReceiveStream,
+  bytes: number
+): boolean {
+  if (!Number.isSafeInteger(bytes) || bytes < 0) {
+    return false
+  }
+  let remaining = bytes
+  while (remaining > 0) {
+    const settlement = stream.unsettledToSocket[0]
+    if (!settlement) {
+      return false
+    }
+    const consumed = Math.min(remaining, settlement.bytes)
+    settlement.bytes -= consumed
+    remaining -= consumed
+    if (settlement.bytes === 0) {
+      stream.unsettledToSocket.shift()
+      settlement.releaseApplicationBytes()
+    }
+  }
   return true
 }
 
@@ -68,8 +108,13 @@ export function finishBrowserNetworkSourceData(
 
 function flushBrowserNetworkSourceData(stream: BrowserNetworkTunnelSourceReceiveStream): void {
   while (stream.readableDemand && stream.pendingToSocket.length > 0) {
-    const bytes = stream.pendingToSocket.shift()!
+    const pending = stream.pendingToSocket.shift()!
+    const bytes = pending.bytes
     stream.pendingToSocketBytes -= bytes.byteLength
+    stream.unsettledToSocket.push({
+      bytes: bytes.byteLength,
+      releaseApplicationBytes: pending.releaseApplicationBytes
+    })
     if (!stream.socket.push(Buffer.from(bytes))) {
       stream.readableDemand = false
     }

--- a/src/main/browser/browser-network-tunnel-stream-state.ts
+++ b/src/main/browser/browser-network-tunnel-stream-state.ts
@@ -65,5 +65,6 @@ export type BrowserNetworkTunnelSessionOptions = {
   sendBinary: (bytes: Uint8Array<ArrayBufferLike>) => boolean
   onClose?: () => void
   now?: () => number
+  claimAggregateRetainedBytes?: (bytes: number) => (() => void) | null
 }
 import type { BrowserNetworkTunnelOpen } from '../../shared/browser-network-tunnel-protocol'

--- a/src/main/browser/paired-runtime-browser-network-route.test.ts
+++ b/src/main/browser/paired-runtime-browser-network-route.test.ts
@@ -14,6 +14,7 @@ vi.mock('../../shared/remote-runtime-client', () => ({
 }))
 
 import { PairedRuntimeBrowserNetworkRoute } from './paired-runtime-browser-network-route'
+import { BrowserNetworkTunnelOutboundMemoryBudgetRegistry } from './browser-network-tunnel-outbound-memory-budget'
 import { RemoteBrowserSocksServer } from './remote-browser-socks-server'
 
 const pairing = {
@@ -191,10 +192,52 @@ describe('PairedRuntimeBrowserNetworkRoute', () => {
     await vi.waitFor(() => expect(closeSubscription).toHaveBeenCalledOnce())
     expect(closeSocks).toHaveBeenCalledOnce()
   })
+
+  it('binds and releases the exact browser-host outbound memory lease', async () => {
+    let callbacks: RemoteRuntimeSubscriptionCallbacks | undefined
+    let subscriptionOptions: Record<string, unknown> | undefined
+    const registry = new BrowserNetworkTunnelOutboundMemoryBudgetRegistry()
+    subscribeRemoteRuntimeRequestMock.mockImplementationOnce(
+      async (...args: unknown[]): Promise<RemoteRuntimeSubscription> => {
+        callbacks = args[4] as RemoteRuntimeSubscriptionCallbacks
+        subscriptionOptions = args[5] as Record<string, unknown>
+        return { requestId: 'budgeted', close: vi.fn(), sendBinary: () => true }
+      }
+    )
+    const route = createRoute({ outboundMemoryBudgetRegistry: registry })
+    const starting = route.start()
+    await vi.waitFor(() => expect(callbacks).toBeDefined())
+
+    expect(subscriptionOptions?.outboundMemoryBudget).toBeDefined()
+    expect(subscriptionOptions?.outboundQueue).toMatchObject({ maxDrainFramesPerTurn: 4 })
+    expect(registry.evidence()).toMatchObject({ hosts: 1, leases: 1 })
+    callbacks!.onResponse({
+      id: 'budgeted',
+      ok: true,
+      result: { type: 'ready', tunnelGeneration: 7 },
+      _meta: { runtimeId: 'runtime-a' }
+    })
+    await starting
+
+    await route.close()
+    expect(registry.evidence()).toMatchObject({ hosts: 0, leases: 0 })
+  })
+
+  it('opens no subscription when browser-host memory admission is exhausted', async () => {
+    const registry = new BrowserNetworkTunnelOutboundMemoryBudgetRegistry({ processMaxLeases: 0 })
+    const route = createRoute({ outboundMemoryBudgetRegistry: registry })
+
+    await expect(route.start()).rejects.toThrow('outbound memory admission failed')
+    expect(subscribeRemoteRuntimeRequestMock).not.toHaveBeenCalled()
+  })
 })
 
 function createRoute(
-  overrides: { timeoutMs?: number; onError?: (error: Error) => void } = {}
+  overrides: {
+    timeoutMs?: number
+    onError?: (error: Error) => void
+    outboundMemoryBudgetRegistry?: BrowserNetworkTunnelOutboundMemoryBudgetRegistry
+  } = {}
 ): PairedRuntimeBrowserNetworkRoute {
   return new PairedRuntimeBrowserNetworkRoute({
     pairing,

--- a/src/main/browser/paired-runtime-browser-network-route.ts
+++ b/src/main/browser/paired-runtime-browser-network-route.ts
@@ -14,10 +14,15 @@ import {
   BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY
 } from '../../shared/protocol-version'
 import { BrowserNetworkTunnelClient } from './browser-network-tunnel-client'
+import {
+  BrowserNetworkTunnelOutboundMemoryBudgetRegistry,
+  type BrowserNetworkTunnelOutboundMemoryLease
+} from './browser-network-tunnel-outbound-memory-budget'
 import { RemoteBrowserSocksServer } from './remote-browser-socks-server'
 
 const BROWSER_TUNNEL_WS_SOFT_CAP_BYTES = 1024 * 1024
 const BROWSER_TUNNEL_WS_MAX_QUEUED_BYTES = 7 * 1024 * 1024
+const outboundMemoryBudgets = new BrowserNetworkTunnelOutboundMemoryBudgetRegistry()
 
 type PairedRuntimeBrowserNetworkRouteOptions = {
   pairing: PairingOffer
@@ -25,6 +30,7 @@ type PairedRuntimeBrowserNetworkRouteOptions = {
   executionHostRevision: number
   timeoutMs?: number
   subscription?: RemoteRuntimeSubscriptionOptions
+  outboundMemoryBudgetRegistry?: BrowserNetworkTunnelOutboundMemoryBudgetRegistry
   onError?: (error: Error) => void
 }
 
@@ -33,6 +39,7 @@ export class PairedRuntimeBrowserNetworkRoute {
   private tunnel: BrowserNetworkTunnelClient | null = null
   private readonly socks: RemoteBrowserSocksServer
   private subscription: RemoteRuntimeSubscription | null = null
+  private outboundMemory: BrowserNetworkTunnelOutboundMemoryLease | null = null
   private startPromise: Promise<{ host: string; port: number }> | null = null
   private closePromise: Promise<void> | null = null
   private rejectReady: ((error: Error) => void) | null = null
@@ -75,6 +82,12 @@ export class PairedRuntimeBrowserNetworkRoute {
     void ready.catch(() => undefined)
     let readyTimeout: ReturnType<typeof setTimeout> | null = null
     try {
+      this.outboundMemory = (
+        this.options.outboundMemoryBudgetRegistry ?? outboundMemoryBudgets
+      ).acquire(this.options.lease.browserHostClientId)
+      if (!this.outboundMemory) {
+        throw new Error('Browser network route outbound memory admission failed')
+      }
       const subscription = await subscribeRemoteRuntimeRequest(
         this.options.pairing,
         'network.browserTunnel',
@@ -117,7 +130,8 @@ export class PairedRuntimeBrowserNetworkRoute {
               }
               this.tunnel = new BrowserNetworkTunnelClient({
                 tunnelGeneration: result.tunnelGeneration,
-                sendBinary: (bytes) => this.subscription?.sendBinary(bytes) ?? false
+                sendBinary: (bytes) => this.subscription?.sendBinary(bytes) ?? false,
+                outboundMemory: this.outboundMemory ?? undefined
               })
               this.ready = true
               resolveReady()
@@ -149,8 +163,10 @@ export class PairedRuntimeBrowserNetworkRoute {
           outboundQueue: {
             softCapBytes: BROWSER_TUNNEL_WS_SOFT_CAP_BYTES,
             maxQueuedBytes: BROWSER_TUNNEL_WS_MAX_QUEUED_BYTES,
-            maxQueuedFrames: 2_048
+            maxQueuedFrames: 2_048,
+            maxDrainFramesPerTurn: 4
           },
+          outboundMemoryBudget: this.outboundMemory,
           clientCapabilities: [
             ...(this.options.subscription?.clientCapabilities ?? []),
             BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY,
@@ -214,15 +230,21 @@ export class PairedRuntimeBrowserNetworkRoute {
   }
 
   private async closeRoute(error: Error): Promise<void> {
-    this.tunnel?.close(error)
-    this.tunnel = null
     const failures: Error[] = []
+    try {
+      this.tunnel?.close(error)
+    } catch (closeError) {
+      failures.push(closeError instanceof Error ? closeError : new Error(String(closeError)))
+    }
+    this.tunnel = null
     try {
       this.subscription?.close()
     } catch (closeError) {
       failures.push(closeError instanceof Error ? closeError : new Error(String(closeError)))
     }
     this.subscription = null
+    this.outboundMemory?.release()
+    this.outboundMemory = null
     try {
       await this.socks.close()
     } catch (closeError) {

--- a/src/main/runtime/rpc/methods/browser-network-tunnel.test.ts
+++ b/src/main/runtime/rpc/methods/browser-network-tunnel.test.ts
@@ -8,9 +8,13 @@ import {
   type BrowserHostLease
 } from '../../browser-host-lease-registry'
 import type { OrcaRuntimeService } from '../../orca-runtime'
+import { BrowserNetworkTunnelOutboundMemoryBudgetRegistry } from '../../../browser/browser-network-tunnel-outbound-memory-budget'
 import { RpcDispatcher } from '../dispatcher'
 import { ALL_RPC_METHODS } from './index'
-import { BROWSER_NETWORK_TUNNEL_METHODS } from './browser-network-tunnel'
+import {
+  BROWSER_NETWORK_TUNNEL_METHODS,
+  createBrowserNetworkTunnelMethods
+} from './browser-network-tunnel'
 
 function request(lease?: BrowserHostLease, overrides: Record<string, unknown> = {}) {
   return {
@@ -157,6 +161,38 @@ describe('network.browserTunnel RPC', () => {
     )
   })
 
+  it('opens no route or binary handler when process memory admission is exhausted', async () => {
+    const hostRuntime = runtime()
+    const lease = attachLease(hostRuntime)
+    const memoryBudgets = new BrowserNetworkTunnelOutboundMemoryBudgetRegistry({
+      processMaxLeases: 0
+    })
+    const dispatcher = new RpcDispatcher({
+      runtime: hostRuntime,
+      methods: createBrowserNetworkTunnelMethods(memoryBudgets)
+    })
+    const replies: string[] = []
+    const registerBinaryMessageHandler = vi.fn()
+
+    await dispatcher.dispatchStreaming(request(lease), (reply) => replies.push(reply), {
+      connectionId: 'connection-a',
+      clientKind: 'runtime',
+      pairedDeviceId: 'device-a',
+      clientCapabilities: negotiatedCapabilities,
+      sendBinary: vi.fn(() => true),
+      registerBinaryMessageHandler
+    })
+
+    expect(JSON.parse(replies[0]!)).toEqual(
+      expect.objectContaining({
+        ok: false,
+        error: expect.objectContaining({ message: 'browser_tunnel_memory_admission_failed' })
+      })
+    )
+    expect(registerBinaryMessageHandler).not.toHaveBeenCalled()
+    expect(memoryBudgets.evidence()).toMatchObject({ hosts: 0, leases: 0 })
+  })
+
   it('allocates the tunnel generation and removes its raw handler on cleanup', async () => {
     const cleanups = new Map<string, () => void>()
     const hostRuntime = runtime(cleanups)
@@ -188,6 +224,35 @@ describe('network.browserTunnel RPC', () => {
     cleanups.get('browser-network-tunnel:connection-a')?.()
     await dispatch
     expect(unregister).toHaveBeenCalledOnce()
+  })
+
+  it('releases route memory when binary-handler cleanup throws', async () => {
+    const cleanups = new Map<string, () => void>()
+    const hostRuntime = runtime(cleanups)
+    const lease = attachLease(hostRuntime)
+    const memoryBudgets = new BrowserNetworkTunnelOutboundMemoryBudgetRegistry()
+    const dispatcher = new RpcDispatcher({
+      runtime: hostRuntime,
+      methods: createBrowserNetworkTunnelMethods(memoryBudgets)
+    })
+    const replies: string[] = []
+    const dispatch = dispatcher.dispatchStreaming(request(lease), (reply) => replies.push(reply), {
+      connectionId: 'connection-a',
+      clientKind: 'runtime',
+      pairedDeviceId: 'device-a',
+      clientCapabilities: negotiatedCapabilities,
+      sendBinary: vi.fn(() => true),
+      registerBinaryMessageHandler: vi.fn(() => () => {
+        throw new Error('unregister failed')
+      })
+    })
+    await vi.waitFor(() => expect(replies).toHaveLength(1))
+
+    expect(() => cleanups.get('browser-network-tunnel:connection-a')?.()).toThrow(
+      'unregister failed'
+    )
+    await dispatch
+    expect(memoryBudgets.evidence()).toMatchObject({ hosts: 0, leases: 0 })
   })
 
   it('fences an older route when the same lease replaces it', async () => {

--- a/src/main/runtime/rpc/methods/browser-network-tunnel.ts
+++ b/src/main/runtime/rpc/methods/browser-network-tunnel.ts
@@ -1,5 +1,6 @@
 import { connect } from 'node:net'
 import { BrowserNetworkTunnelSession } from '../../../browser/browser-network-tunnel-session'
+import { BrowserNetworkTunnelOutboundMemoryBudgetRegistry } from '../../../browser/browser-network-tunnel-outbound-memory-budget'
 import { BrowserNetworkTunnelAttachParams } from '../../../../shared/browser-client-host-protocol'
 import {
   BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY,
@@ -8,99 +9,133 @@ import {
 import { getBrowserHostLeaseRegistry } from '../../browser-host-lease-registry'
 import { defineStreamingMethod, type RpcAnyMethod } from '../core'
 
-// Why: tests inject this until a live lease and server-owned route generation authorize TCP opens.
-export const BROWSER_NETWORK_TUNNEL_METHODS: RpcAnyMethod[] = [
-  defineStreamingMethod({
-    name: 'network.browserTunnel',
-    params: BrowserNetworkTunnelAttachParams,
-    handler: async (
-      params,
-      {
-        runtime,
-        connectionId,
-        pairedDeviceId,
-        clientKind,
-        clientCapabilities,
-        sendBinary,
-        registerBinaryMessageHandler,
-        signal
-      },
-      emit
-    ) => {
-      if (
-        clientKind !== 'runtime' ||
-        !connectionId ||
-        !pairedDeviceId ||
-        !sendBinary ||
-        !registerBinaryMessageHandler
-      ) {
-        throw new Error('authenticated_binary_browser_tunnel_required')
-      }
-      if (!clientCapabilities?.includes(BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY)) {
-        throw new Error('browser_tunnel_capability_required')
-      }
-      if (!clientCapabilities.includes(BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY)) {
-        throw new Error('browser_client_host_capability_required')
-      }
-      if (params.authorityRuntimeId !== runtime.getRuntimeId()) {
-        throw new Error('browser_tunnel_identity_mismatch')
-      }
-      if (
-        params.executionHost.runtimeId !== runtime.getRuntimeId() ||
-        params.executionHost.revision !== runtime.getStartedAt()
-      ) {
-        throw new Error('browser_tunnel_execution_host_mismatch')
-      }
+const outboundMemoryBudgets = new BrowserNetworkTunnelOutboundMemoryBudgetRegistry()
 
-      const route = getBrowserHostLeaseRegistry(runtime).openTunnel({
-        authorityEpoch: params.authorityEpoch,
-        browserHostClientId: params.browserHostClientId,
-        browserHostGeneration: params.browserHostGeneration,
-        pairedDeviceId,
-        executionHostKey: `native:${params.executionHost.runtimeId}:${params.executionHost.revision}`
-      })
-
-      let resolveClosed = (): void => {}
-      const closed = new Promise<void>((resolve) => {
-        resolveClosed = resolve
-      })
-      let session: BrowserNetworkTunnelSession | null = null
-      let unregisterBinary = (): void => {}
-      let cleaned = false
-      const cleanup = (): void => {
-        if (cleaned) {
-          return
+export function createBrowserNetworkTunnelMethods(
+  memoryBudgets: BrowserNetworkTunnelOutboundMemoryBudgetRegistry = outboundMemoryBudgets
+): RpcAnyMethod[] {
+  return [
+    defineStreamingMethod({
+      name: 'network.browserTunnel',
+      params: BrowserNetworkTunnelAttachParams,
+      handler: async (
+        params,
+        {
+          runtime,
+          connectionId,
+          pairedDeviceId,
+          clientKind,
+          clientCapabilities,
+          sendBinary,
+          registerBinaryMessageHandler,
+          signal
+        },
+        emit
+      ) => {
+        if (
+          clientKind !== 'runtime' ||
+          !connectionId ||
+          !pairedDeviceId ||
+          !sendBinary ||
+          !registerBinaryMessageHandler
+        ) {
+          throw new Error('authenticated_binary_browser_tunnel_required')
         }
-        cleaned = true
-        unregisterBinary()
-        session?.close()
-        route.release()
-      }
-      const subscriptionId = `browser-network-tunnel:${connectionId}`
-      try {
-        session = new BrowserNetworkTunnelSession({
-          tunnelGeneration: route.tunnelGeneration,
-          connect: (target) => connect({ ...target, allowHalfOpen: true }),
-          sendBinary: (bytes) => sendBinary(bytes) !== false,
-          onClose: () => {
-            emit({ type: 'closed', tunnelGeneration: route.tunnelGeneration })
-            resolveClosed()
-          }
+        if (!clientCapabilities?.includes(BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY)) {
+          throw new Error('browser_tunnel_capability_required')
+        }
+        if (!clientCapabilities.includes(BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY)) {
+          throw new Error('browser_client_host_capability_required')
+        }
+        if (params.authorityRuntimeId !== runtime.getRuntimeId()) {
+          throw new Error('browser_tunnel_identity_mismatch')
+        }
+        if (
+          params.executionHost.runtimeId !== runtime.getRuntimeId() ||
+          params.executionHost.revision !== runtime.getStartedAt()
+        ) {
+          throw new Error('browser_tunnel_execution_host_mismatch')
+        }
+
+        const leaseRegistry = getBrowserHostLeaseRegistry(runtime)
+        const tunnelIdentity = {
+          authorityEpoch: params.authorityEpoch,
+          browserHostClientId: params.browserHostClientId,
+          browserHostGeneration: params.browserHostGeneration,
+          pairedDeviceId,
+          executionHostKey: `native:${params.executionHost.runtimeId}:${params.executionHost.revision}`
+        }
+        leaseRegistry.requireLease(tunnelIdentity)
+        const outboundMemory = memoryBudgets.acquire(
+          `${pairedDeviceId}:${params.browserHostClientId}`
+        )
+        if (!outboundMemory) {
+          throw new Error('browser_tunnel_memory_admission_failed')
+        }
+        let route: ReturnType<ReturnType<typeof getBrowserHostLeaseRegistry>['openTunnel']>
+        try {
+          route = leaseRegistry.openTunnel(tunnelIdentity)
+        } catch (error) {
+          outboundMemory.release()
+          throw error
+        }
+
+        let resolveClosed = (): void => {}
+        const closed = new Promise<void>((resolve) => {
+          resolveClosed = resolve
         })
-        void route.whenFenced.then(() => session?.close())
-        unregisterBinary = registerBinaryMessageHandler((bytes) => session?.handleBinary(bytes))
-        runtime.registerSubscriptionCleanup(subscriptionId, cleanup, connectionId)
-        signal?.addEventListener('abort', cleanup, { once: true })
-        if (signal?.aborted) {
-          cleanup()
-          return
+        let session: BrowserNetworkTunnelSession | null = null
+        let unregisterBinary = (): void => {}
+        let cleaned = false
+        const cleanup = (): void => {
+          if (cleaned) {
+            return
+          }
+          cleaned = true
+          try {
+            unregisterBinary()
+          } finally {
+            try {
+              session?.close()
+            } finally {
+              outboundMemory.release()
+              route.release()
+            }
+          }
         }
-        emit({ type: 'ready', tunnelGeneration: route.tunnelGeneration })
-        await closed
-      } finally {
-        signal?.removeEventListener('abort', cleanup)
-        cleanup()
+        const subscriptionId = `browser-network-tunnel:${connectionId}`
+        try {
+          session = new BrowserNetworkTunnelSession({
+            tunnelGeneration: route.tunnelGeneration,
+            connect: (target) => connect({ ...target, allowHalfOpen: true }),
+            sendBinary: (bytes) => sendBinary(bytes) !== false,
+            claimAggregateRetainedBytes: outboundMemory.claimApplicationBytes,
+            onClose: () => {
+              try {
+                emit({ type: 'closed', tunnelGeneration: route.tunnelGeneration })
+              } finally {
+                resolveClosed()
+              }
+            }
+          })
+          void route.whenFenced.then(() => session?.close())
+          unregisterBinary = registerBinaryMessageHandler((bytes) => session?.handleBinary(bytes))
+          runtime.registerSubscriptionCleanup(subscriptionId, cleanup, connectionId)
+          signal?.addEventListener('abort', cleanup, { once: true })
+          if (signal?.aborted) {
+            cleanup()
+            return
+          }
+          emit({ type: 'ready', tunnelGeneration: route.tunnelGeneration })
+          await closed
+        } finally {
+          signal?.removeEventListener('abort', cleanup)
+          cleanup()
+        }
       }
-    }
-  })
-]
+    })
+  ]
+}
+
+// Why: tests inject this until a live lease and server-owned route generation authorize TCP opens.
+export const BROWSER_NETWORK_TUNNEL_METHODS = createBrowserNetworkTunnelMethods()

--- a/src/shared/remote-runtime-client.test.ts
+++ b/src/shared/remote-runtime-client.test.ts
@@ -123,6 +123,77 @@ describe('subscribeRemoteRuntimeRequest', () => {
     )
   })
 
+  it('accounts encrypted queues and native socket buffers in an injected aggregate budget', async () => {
+    const server = await createSubscriptionServer()
+    const releaseQueued = vi.fn()
+    const releaseSocket = vi.fn()
+    const canSend = vi.fn(() => false)
+    let readBufferedAmount: (() => number) | undefined
+    const outboundMemoryBudget = {
+      claimQueuedBytes: vi.fn(() => releaseQueued),
+      registerBufferedAmount: vi.fn((read: () => number) => {
+        readBufferedAmount = read
+        return { canSend, release: releaseSocket }
+      })
+    }
+    const onResponse = vi.fn()
+    const onClose = vi.fn()
+    const subscription = await subscribeRemoteRuntimeRequest(
+      server.pairing,
+      'network.browserTunnel',
+      {},
+      1000,
+      { onResponse, onError: vi.fn(), onClose },
+      {
+        outboundMemoryBudget,
+        outboundQueue: { softCapBytes: 1, maxQueuedBytes: 1024, maxQueuedFrames: 8 }
+      }
+    )
+    await vi.waitFor(() => expect(onResponse).toHaveBeenCalled())
+
+    expect(subscription.sendBinary(new Uint8Array([9]))).toBe(true)
+    expect(outboundMemoryBudget.registerBufferedAmount).toHaveBeenCalledOnce()
+    expect(readBufferedAmount?.()).toBeGreaterThanOrEqual(0)
+    expect(canSend).toHaveBeenCalledWith(expect.any(Number), false)
+    expect(outboundMemoryBudget.claimQueuedBytes).toHaveBeenCalledWith(expect.any(Number))
+
+    subscription.close()
+    subscription.close()
+    expect(releaseQueued).toHaveBeenCalledOnce()
+    expect(releaseSocket).not.toHaveBeenCalled()
+    await vi.waitFor(() => expect(onClose).toHaveBeenCalledOnce())
+    expect(releaseSocket).toHaveBeenCalledOnce()
+  })
+
+  it('keeps native socket bytes charged through failure cleanup and a later close', async () => {
+    const server = await createSubscriptionServer()
+    const releaseSocket = vi.fn()
+    const onError = vi.fn()
+    const subscription = await subscribeRemoteRuntimeRequest(
+      server.pairing,
+      'network.browserTunnel',
+      {},
+      1000,
+      { onResponse: vi.fn(), onError },
+      {
+        outboundMemoryBudget: {
+          claimQueuedBytes: vi.fn(() => vi.fn()),
+          registerBufferedAmount: vi.fn(() => ({ canSend: () => false, release: releaseSocket }))
+        },
+        outboundQueue: { softCapBytes: 1, maxQueuedBytes: 1, maxQueuedFrames: 1 }
+      }
+    )
+
+    expect(subscription.sendBinary(new Uint8Array([9]))).toBe(false)
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 'remote_runtime_unavailable' })
+    )
+    subscription.close()
+    expect(releaseSocket).not.toHaveBeenCalled()
+
+    await vi.waitFor(() => expect(releaseSocket).toHaveBeenCalledOnce())
+  })
+
   it('detaches subscription socket listeners after close', async () => {
     const offSpy = vi.spyOn(WebSocketClient.prototype, 'off')
     try {

--- a/src/shared/remote-runtime-client.ts
+++ b/src/shared/remote-runtime-client.ts
@@ -93,7 +93,21 @@ export type RemoteRuntimeSubscriptionOptions = RemoteRuntimeSocketLivenessOption
     softCapBytes: number
     maxQueuedBytes: number
     maxQueuedFrames: number
+    maxDrainFramesPerTurn?: number
   }
+  outboundMemoryBudget?: RemoteRuntimeOutboundMemoryBudget
+}
+
+export type RemoteRuntimeOutboundSocketMemory = {
+  canSend: (bytes: number, alreadyRetained?: boolean) => boolean
+  release: () => void
+}
+
+export type RemoteRuntimeOutboundMemoryBudget = {
+  claimQueuedBytes: (bytes: number) => (() => void) | null
+  registerBufferedAmount: (
+    readBufferedAmount: () => number
+  ) => RemoteRuntimeOutboundSocketMemory | null
 }
 
 export function sendRemoteRuntimeRequest<TResult>(
@@ -542,14 +556,40 @@ export async function subscribeRemoteRuntimeRequest<TResult>(
     let settled = false
     let ws: WebSocket | null = null
     let liveness: RemoteRuntimeSocketLivenessMonitor | null = null
+    let outboundSocketMemoryCloseSource: WebSocket | null = null
+
+    const releaseOutboundQueueMemory = (): void => {
+      sendQueue?.dispose()
+      sendQueue = null
+    }
+
+    const releaseOutboundSocketMemory = (): void => {
+      outboundSocketMemory?.release()
+      outboundSocketMemory = null
+      outboundSocketMemoryCloseSource = null
+    }
+
+    const retainOutboundSocketMemoryUntilClose = (socket: WebSocket): void => {
+      if (socket.readyState === WebSocket.CLOSED) {
+        releaseOutboundSocketMemory()
+        return
+      }
+      if (outboundSocketMemoryCloseSource === socket) {
+        return
+      }
+      outboundSocketMemoryCloseSource = socket
+      socket.once('close', releaseOutboundSocketMemory)
+    }
 
     const cleanupSocketListeners = (): WebSocket | null => {
       liveness?.stop()
       liveness = null
-      sendQueue?.dispose()
-      sendQueue = null
+      releaseOutboundQueueMemory()
       const socket = ws
       if (!socket) {
+        if (!outboundSocketMemoryCloseSource) {
+          releaseOutboundSocketMemory()
+        }
         return null
       }
       socket.off('open', onOpen)
@@ -559,6 +599,7 @@ export async function subscribeRemoteRuntimeRequest<TResult>(
       socket.off('pong', onLivenessSignal)
       socket.off('ping', onLivenessSignal)
       ws = null
+      retainOutboundSocketMemoryUntilClose(socket)
       // Why: startup failures detach Orca callbacks before closing the ws,
       // but ws can still emit a late transport error while close is in flight.
       if (socket.readyState !== WebSocket.CLOSED) {
@@ -586,6 +627,12 @@ export async function subscribeRemoteRuntimeRequest<TResult>(
     }, timeoutMs)
 
     const close = (): void => {
+      releaseOutboundQueueMemory()
+      if (ws) {
+        retainOutboundSocketMemoryUntilClose(ws)
+      } else if (!outboundSocketMemoryCloseSource) {
+        releaseOutboundSocketMemory()
+      }
       try {
         ws?.close()
       } catch {
@@ -598,10 +645,24 @@ export async function subscribeRemoteRuntimeRequest<TResult>(
     // drain as it clears; a wedged link (hard cap) fails the socket so the
     // renderer resubscribes and replays a fresh snapshot.
     let sendQueue: ReturnType<typeof createWsOutboundBackpressureQueue<Buffer>> | null = null
+    let outboundSocketMemory: RemoteRuntimeOutboundSocketMemory | null = null
     const ensureSendQueue = (
       socket: WebSocket
-    ): ReturnType<typeof createWsOutboundBackpressureQueue<Buffer>> => {
+    ): ReturnType<typeof createWsOutboundBackpressureQueue<Buffer>> | null => {
       if (!sendQueue) {
+        const memoryBudget = options?.outboundMemoryBudget
+        if (memoryBudget && !outboundSocketMemory) {
+          outboundSocketMemory = memoryBudget.registerBufferedAmount(() => socket.bufferedAmount)
+          if (!outboundSocketMemory) {
+            fail(
+              new RemoteRuntimeClientError(
+                'remote_runtime_unavailable',
+                'Remote Orca runtime outbound memory admission failed; reconnecting.'
+              )
+            )
+            return null
+          }
+        }
         sendQueue = createWsOutboundBackpressureQueue<Buffer>({
           send: (frame) => socket.send(frame, { binary: true }),
           byteLengthOf: (frame) => frame.byteLength,
@@ -614,7 +675,14 @@ export async function subscribeRemoteRuntimeRequest<TResult>(
                 'Remote Orca runtime send buffer overflow; reconnecting.'
               )
             ),
-          ...options?.outboundQueue
+          ...options?.outboundQueue,
+          canSend: (bytes, alreadyRetained) =>
+            outboundSocketMemory?.canSend(bytes, alreadyRetained) ?? true,
+          ...(memoryBudget
+            ? {
+                claimQueuedBytes: (bytes: number) => memoryBudget.claimQueuedBytes(bytes)
+              }
+            : {})
         })
       }
       return sendQueue
@@ -629,7 +697,7 @@ export async function subscribeRemoteRuntimeRequest<TResult>(
       ) {
         return false
       }
-      return ensureSendQueue(ws).enqueue(Buffer.from(encryptBytes(bytes, sharedKey)))
+      return ensureSendQueue(ws)?.enqueue(Buffer.from(encryptBytes(bytes, sharedKey))) ?? false
     }
 
     const succeed = (): void => {

--- a/src/shared/ws-outbound-backpressure-queue.test.ts
+++ b/src/shared/ws-outbound-backpressure-queue.test.ts
@@ -8,6 +8,7 @@ function createHarness(overrides?: {
   softCapBytes?: number
   maxQueuedBytes?: number
   maxQueuedFrames?: number
+  maxDrainFramesPerTurn?: number
   writable?: boolean
   parkAfterSend?: boolean
   throwOnSend?: boolean
@@ -17,6 +18,7 @@ function createHarness(overrides?: {
   let writable = overrides?.writable ?? true
   const overflow = vi.fn()
   let pendingTimer: (() => void) | null = null
+  let pendingTimerDelay: number | null = null
 
   const softCapBytes = overrides?.softCapBytes ?? 100
   const queue = createWsOutboundBackpressureQueue<string>({
@@ -36,13 +38,16 @@ function createHarness(overrides?: {
     softCapBytes,
     maxQueuedBytes: overrides?.maxQueuedBytes ?? 1000,
     maxQueuedFrames: overrides?.maxQueuedFrames,
+    maxDrainFramesPerTurn: overrides?.maxDrainFramesPerTurn,
     drainPollMs: 10,
-    setTimer: (cb) => {
+    setTimer: (cb, delay) => {
       pendingTimer = cb
+      pendingTimerDelay = delay
       return 1 as unknown as ReturnType<typeof setTimeout>
     },
     clearTimer: () => {
       pendingTimer = null
+      pendingTimerDelay = null
     }
   })
 
@@ -59,9 +64,11 @@ function createHarness(overrides?: {
     runTimer: () => {
       const cb = pendingTimer
       pendingTimer = null
+      pendingTimerDelay = null
       cb?.()
     },
-    hasTimer: () => pendingTimer !== null
+    hasTimer: () => pendingTimer !== null,
+    timerDelay: () => pendingTimerDelay
   }
 }
 
@@ -88,22 +95,53 @@ describe('ws outbound backpressure queue', () => {
 
   it('applies prospective admission to a direct-send frame', () => {
     const sent = vi.fn()
-    const canSend = vi.fn(() => false)
+    const canSend = vi.fn().mockReturnValueOnce(false).mockReturnValue(true)
+    let pendingTimer: (() => void) | null = null
     const queue = createWsOutboundBackpressureQueue<string>({
       send: sent,
       byteLengthOf: (frame) => frame.length,
       getBufferedAmount: () => 0,
       isWritable: () => true,
       canSend,
-      onOverflow: vi.fn()
+      onOverflow: vi.fn(),
+      setTimer: (callback) => {
+        pendingTimer = callback
+        return 1 as unknown as ReturnType<typeof setTimeout>
+      },
+      clearTimer: () => {
+        pendingTimer = null
+      }
     })
 
     expect(queue.enqueue('frame')).toBe(true)
 
-    expect(canSend).toHaveBeenCalledWith(5)
+    expect(canSend).toHaveBeenCalledWith(5, false)
     expect(sent).not.toHaveBeenCalled()
     expect(queue.queuedBytes()).toBe(5)
+
+    const scheduled = pendingTimer as (() => void) | null
+    scheduled?.()
+    expect(canSend).toHaveBeenLastCalledWith(5, true)
+    expect(sent).toHaveBeenCalledWith('frame')
     queue.dispose()
+  })
+
+  it('yields after a configured drain quantum while preserving FIFO order', () => {
+    const h = createHarness({ maxDrainFramesPerTurn: 2 })
+    h.setBuffered(101)
+    h.queue.enqueue('a')
+    h.queue.enqueue('b')
+    h.queue.enqueue('c')
+    h.setBuffered(0)
+
+    h.runTimer()
+    expect(h.sent).toEqual(['a', 'b'])
+    expect(h.hasTimer()).toBe(true)
+    expect(h.timerDelay()).toBe(0)
+
+    h.runTimer()
+    expect(h.sent).toEqual(['a', 'b', 'c'])
+    expect(h.hasTimer()).toBe(false)
   })
 
   it('rejects an oversized frame before the direct-send fast path', () => {
@@ -133,6 +171,7 @@ describe('ws outbound backpressure queue', () => {
     // Nothing sent yet; all held in order.
     expect(h.sent).toEqual([])
     expect(h.queue.queuedBytes()).toBe('one'.length + 'two'.length + 'three'.length)
+    expect(h.timerDelay()).toBe(10)
 
     // Link recovers; the drain timer flushes everything in FIFO order.
     h.setBuffered(0)

--- a/src/shared/ws-outbound-backpressure-queue.ts
+++ b/src/shared/ws-outbound-backpressure-queue.ts
@@ -20,7 +20,7 @@ export type WsOutboundBackpressureQueueOptions<TFrame> = {
   /** True when the socket can still accept sends (OPEN and keyed). */
   isWritable: () => boolean
   /** Optional process-wide native-buffer admission check. */
-  canSend?: (frameBytes: number) => boolean
+  canSend?: (frameBytes: number, alreadyRetained: boolean) => boolean
   /**
    * Called once when queued bytes exceed maxQueuedBytes — the link is wedged.
    * The caller should tear the connection down so a fresh subscription can
@@ -37,6 +37,8 @@ export type WsOutboundBackpressureQueueOptions<TFrame> = {
   maxQueuedFrames?: number
   /** Poll interval used to re-check bufferedAmount while parked. */
   drainPollMs?: number
+  /** Maximum frames handed to the native socket in one event-loop turn. */
+  maxDrainFramesPerTurn?: number
   /** Process-wide admission for frames retained in this JavaScript queue. */
   claimQueuedBytes?: (bytes: number) => (() => void) | null
   /** Injectable scheduler for deterministic tests. */
@@ -78,6 +80,13 @@ export function createWsOutboundBackpressureQueue<TFrame>(
   const maxFrameBytes = options.maxFrameBytes ?? maxQueuedBytes
   const maxQueuedFrames = options.maxQueuedFrames ?? DEFAULT_MAX_QUEUED_FRAMES
   const drainPollMs = options.drainPollMs ?? DEFAULT_DRAIN_POLL_MS
+  const configuredDrainFramesPerTurn = options.maxDrainFramesPerTurn
+  const maxDrainFramesPerTurn =
+    typeof configuredDrainFramesPerTurn === 'number' &&
+    Number.isSafeInteger(configuredDrainFramesPerTurn) &&
+    configuredDrainFramesPerTurn > 0
+      ? configuredDrainFramesPerTurn
+      : Number.POSITIVE_INFINITY
   const setTimer = options.setTimer ?? ((cb, ms) => setTimeout(cb, ms))
   const clearTimer = options.clearTimer ?? ((timer) => clearTimeout(timer))
 
@@ -197,10 +206,12 @@ export function createWsOutboundBackpressureQueue<TFrame>(
       return
     }
     advanceQueueHead()
+    let drainedFrames = 0
     while (
       queuedFrames > 0 &&
+      drainedFrames < maxDrainFramesPerTurn &&
       bufferedAmount() <= softCapBytes &&
-      (options.canSend?.(queue[queueHead]!.bytes) ?? true)
+      (options.canSend?.(queue[queueHead]!.bytes, true) ?? true)
     ) {
       const entry = queue[queueHead++]!
       queue[queueHead - 1] = undefined
@@ -214,9 +225,11 @@ export function createWsOutboundBackpressureQueue<TFrame>(
       if (!sendFrame(frame)) {
         return
       }
+      drainedFrames += 1
     }
     if (queuedFrames > 0) {
-      timer = setTimer(drain, drainPollMs)
+      const nextDrainDelay = drainedFrames >= maxDrainFramesPerTurn ? 0 : drainPollMs
+      timer = setTimer(drain, nextDrainDelay)
     } else {
       // Why: resetting the drained array keeps enqueue/drain O(1) per frame;
       // repeated Array.shift() would make recovery from a large backlog O(n²).
@@ -238,7 +251,7 @@ export function createWsOutboundBackpressureQueue<TFrame>(
       queuedFrames === 0 &&
       options.isWritable() &&
       bufferedAmount() <= softCapBytes &&
-      (options.canSend?.(bytes) ?? true)
+      (options.canSend?.(bytes, false) ?? true)
     ) {
       return {
         accepted: sendFrame(frame),


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​571 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​564 |
| Prod | 15 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​705 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​152 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​553 |

<!-- /orca-pr-loc -->

## Summary

- share a 32 MiB browser-host and 128 MiB desktop/runtime process memory ledger across application copies, encrypted WebSocket queues, and native buffered bytes
- bound retained claims, socket sources, host records, and leases independently of byte size
- keep native socket bytes charged through exact close and drain queued frames with an immediate four-frame cooperative quantum

## Causal evidence

With aggregate enforcement replaced by a no-op scaffold on parent b32610e365, the unchanged oracle failed all three initial assertions: browser-host totals, process totals, and claim/socket-source counts were independently unbounded. The candidate makes those assertions green and covers exact transfer/release across browser-facing writes, execution-host writes, encrypted queue settlement, native socket close, cleanup failure, stale callbacks, and repeated close.

Fresh review caught and the candidate fixes two additional causal failures before publication: a four-frame quantum incorrectly inherited the 25 ms backpressure poll, and WebSocket ownership was released while native buffered bytes could remain in CLOSING for up to the transport timeout.

## Compatibility and activation

This is an inert STA-4150 layer stacked on #14495. It does not advertise a capability, register a production RPC method, add a shipped stream opcode, change existing server/offscreen placement, or depend on the merged #14402 implementation. Old clients and current server-hosted browsing remain unchanged.

Still blocked before activation: Node stream-internal high-water accounting; strict cross-route fairness and slow-link soak proof; reconnect/generation replacement and stream-ID recycling; relay E2EE negotiation; SSH/WSL adapters; browserless/headless behavior; SOCKS process isolation; mixed-version journeys; Electron proxy/no-fallback proof; Linux and physical Windows evidence.

## Validation

- 16 focused files / 123 tests
- full runtime RPC suite / 1,349 passed, 1 skipped
- full typecheck
- native and type-aware code-quality audits
- reliability manifest and max-lines ratchet
- git diff check
- two fresh read-only correctness/security/performance reviews

Linear: https://linear.app/stably/issue/STA-4150/refactor-remote-browser-to-client-hosted-electron-webviews
