### PR TITLE
fix(editor): stop a failed diff load from being saved over the file

### DIFF
--- a/src/renderer/src/components/editor/DiffViewer.editable-rewiring.test.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.editable-rewiring.test.tsx
@@ -1,0 +1,203 @@
+// @vitest-environment happy-dom
+// Why: `editable` is dynamic on the live diff pane (a failed load recovering under it), so DiffViewer must
+// re-wire save/find/change in place. Remounting to re-run the mount wiring would also re-run its focus grab.
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DiffViewerProps } from './diff-viewer-props'
+
+type Disposable = { dispose: ReturnType<typeof vi.fn> }
+type CodeEditorStub = {
+  getContainerDomNode: () => HTMLElement
+  focus: ReturnType<typeof vi.fn>
+  onDidChangeModelContent: ReturnType<typeof vi.fn>
+}
+type DiffEditorStub = { focus: ReturnType<typeof vi.fn> }
+
+const shortcuts = vi.hoisted(() => ({
+  saveInstalls: [] as { target: HTMLElement; cleanup: ReturnType<typeof vi.fn> }[],
+  findInstalls: [] as { editor: unknown; cleanup: ReturnType<typeof vi.fn> }[]
+}))
+const monacoMount = vi.hoisted(() => ({
+  count: 0,
+  // Why: assigned before the first render; the mock reads it lazily so the stubs can be rebuilt per test.
+  getDiffEditor: null as (() => unknown) | null
+}))
+
+vi.mock('@monaco-editor/react', async () => {
+  const { useEffect } = await import('react')
+  return {
+    DiffEditor: (props: { onMount: (diffEditor: unknown, monaco: unknown) => void }) => {
+      const { onMount } = props
+      useEffect(() => {
+        monacoMount.count += 1
+        onMount(monacoMount.getDiffEditor?.(), {})
+        // Why: mirror @monaco-editor/react, which pins onMount to the first render.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+      }, [])
+      return null
+    },
+    loader: { config: vi.fn() }
+  }
+})
+vi.mock('@/lib/monaco-setup', () => ({
+  monaco: { editor: { EditorOption: { lineHeight: 66 } } }
+}))
+vi.mock('./editor-shortcuts', () => ({
+  installEditorSaveShortcut: (target: HTMLElement) => {
+    const cleanup = vi.fn()
+    shortcuts.saveInstalls.push({ target, cleanup })
+    return cleanup
+  },
+  installMonacoEditorFindShortcut: (targetEditor: unknown) => {
+    const cleanup = vi.fn()
+    shortcuts.findInstalls.push({ editor: targetEditor, cleanup })
+    return cleanup
+  },
+  installMonacoDiffChangeNavigationShortcut: () => (): void => {}
+}))
+vi.mock('../diff-comments/useDiffCommentDecorator', () => ({
+  useDiffCommentDecorator: vi.fn()
+}))
+vi.mock('./useContextualCopySetup', () => ({
+  useContextualCopySetup: () => ({ setupCopy: vi.fn(), toastNode: null })
+}))
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      settings: { theme: 'dark', terminalFontSize: 13 },
+      editorFontZoomLevel: 0,
+      addDiffComment: vi.fn(),
+      deleteDiffComment: vi.fn(),
+      updateDiffComment: vi.fn(),
+      scrollToDiffCommentId: null,
+      setScrollToDiffCommentId: vi.fn(),
+      worktreeDiffComments: {}
+    })
+}))
+
+import DiffViewer from './DiffViewer'
+
+let contentSubs: Disposable[] = []
+let originalEditor: CodeEditorStub
+let modifiedEditor: CodeEditorStub
+let diffEditor: DiffEditorStub
+
+function makeDisposable(): Disposable {
+  return { dispose: vi.fn() }
+}
+
+function makeCodeEditorStub(pane: string): CodeEditorStub {
+  const container = document.createElement('div')
+  container.dataset.pane = pane
+  return {
+    getContainerDomNode: () => container,
+    focus: vi.fn(),
+    onDidChangeModelContent: vi.fn(() => {
+      const sub = makeDisposable()
+      contentSubs.push(sub)
+      return sub
+    }),
+    getValue: () => 'body',
+    getModel: () => ({}),
+    getRawOptions: () => ({ lineNumbers: 'on' }),
+    getOption: () => 18,
+    updateOptions: vi.fn(),
+    onDidChangeConfiguration: makeDisposable,
+    onWillChangeModel: makeDisposable,
+    onDidChangeModel: makeDisposable,
+    onDidScrollChange: makeDisposable,
+    onDidContentSizeChange: makeDisposable,
+    onDidLayoutChange: makeDisposable,
+    onDidDispose: vi.fn()
+  } as unknown as CodeEditorStub
+}
+
+function makeDiffEditorStub(): DiffEditorStub {
+  return {
+    getOriginalEditor: () => originalEditor,
+    getModifiedEditor: () => modifiedEditor,
+    getLineChanges: () => [],
+    getModel: () => null,
+    saveViewState: () => null,
+    restoreViewState: vi.fn(),
+    focus: vi.fn(),
+    onDidUpdateDiff: makeDisposable,
+    onDidDispose: vi.fn()
+  } as unknown as DiffEditorStub
+}
+
+function viewer(editable: boolean): React.JSX.Element {
+  const props: DiffViewerProps = {
+    modelKey: 'tab-1',
+    originalContent: 'a\n',
+    modifiedContent: 'b\n',
+    language: 'typescript',
+    filePath: '/repo/a.ts',
+    relativePath: 'a.ts',
+    sideBySide: true,
+    editable,
+    onSave: vi.fn(),
+    onContentChange: vi.fn()
+  }
+  return <DiffViewer {...props} />
+}
+
+beforeEach(() => {
+  shortcuts.saveInstalls.length = 0
+  shortcuts.findInstalls.length = 0
+  contentSubs = []
+  monacoMount.count = 0
+  originalEditor = makeCodeEditorStub('original')
+  modifiedEditor = makeCodeEditorStub('modified')
+  diffEditor = makeDiffEditorStub()
+  monacoMount.getDiffEditor = () => diffEditor
+})
+
+afterEach(cleanup)
+
+describe('DiffViewer editable re-wiring', () => {
+  it('installs the editing wiring exactly once when it mounts already editable', () => {
+    render(viewer(true))
+
+    expect(shortcuts.saveInstalls).toHaveLength(1)
+    expect(shortcuts.findInstalls).toHaveLength(2)
+    expect(contentSubs).toHaveLength(1)
+  })
+
+  it('wires the same editor when editable flips on, without remounting or refocusing', () => {
+    const { rerender } = render(viewer(false))
+    expect(shortcuts.saveInstalls).toHaveLength(0)
+    expect(contentSubs).toHaveLength(0)
+    expect(diffEditor.focus).toHaveBeenCalledTimes(1)
+
+    rerender(viewer(true))
+
+    expect(monacoMount.count).toBe(1)
+    expect(shortcuts.saveInstalls).toHaveLength(1)
+    expect(shortcuts.saveInstalls[0]?.target).toBe(modifiedEditor.getContainerDomNode())
+    expect(shortcuts.findInstalls.map((i) => i.editor)).toEqual([originalEditor, modifiedEditor])
+    expect(modifiedEditor.onDidChangeModelContent).toHaveBeenCalledTimes(1)
+    // Why: the flip is unattended (a background refetch), so it must not pull focus out from under typing.
+    expect(modifiedEditor.focus).not.toHaveBeenCalled()
+    expect(diffEditor.focus).toHaveBeenCalledTimes(1)
+  })
+
+  it('tears the wiring down again when editable flips off', () => {
+    const { rerender } = render(viewer(true))
+
+    rerender(viewer(false))
+
+    expect(shortcuts.saveInstalls[0]?.cleanup).toHaveBeenCalledTimes(1)
+    expect(shortcuts.findInstalls.map((i) => i.cleanup.mock.calls.length)).toEqual([1, 1])
+    expect(contentSubs[0]?.dispose).toHaveBeenCalledTimes(1)
+  })
+
+  it('disposes the wiring on unmount', () => {
+    const { unmount } = render(viewer(true))
+
+    unmount()
+
+    expect(shortcuts.saveInstalls[0]?.cleanup).toHaveBeenCalledTimes(1)
+    expect(contentSubs[0]?.dispose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -16,11 +16,11 @@ import {
 import { applyDiffEditorLineNumberOptions } from './diff-editor-line-number-options'
 import type { DiffComment } from '../../../../shared/diff-comment-types'
 import { isDiffComment } from '@/lib/diff-comment-compat'
-import { installEditorSaveShortcut, installMonacoEditorFindShortcut } from './editor-shortcuts'
 import { diffEditorScrollbarOptions } from './diff-editor-scrollbar-options'
 import { LargeDiffFallback } from './LargeDiffFallback'
 import { getLargeDiffRenderLimit } from './large-diff-render-limit'
 import { useDiffViewerLargeDiffLifecycle } from './useDiffViewerLargeDiffLifecycle'
+import { useDiffViewerEditingWiring } from './useDiffViewerEditingWiring'
 import { getDiffViewerLargeDiffSaveAction } from './diff-viewer-large-diff-save-action'
 import type { DiffViewerProps } from './diff-viewer-props'
 import { buildDiffEditorWordWrapOptions } from './diff-editor-word-wrap-options'
@@ -266,11 +266,13 @@ export default function DiffViewer({
     }
   }
 
-  // Keep refs to latest callbacks so the mounted editor always calls current versions
-  const onSaveRef = useRef(onSave)
-  onSaveRef.current = onSave
-  const onContentChangeRef = useRef(onContentChange)
-  onContentChangeRef.current = onContentChange
+  useDiffViewerEditingWiring({
+    editable: editable === true,
+    modifiedEditor,
+    diffEditorRef,
+    onContentChange,
+    onSave
+  })
 
   const { setupCopy, toastNode } = useContextualCopySetup()
 
@@ -307,28 +309,9 @@ export default function DiffViewer({
       }
       // Auto-scroll to first diff lives in a separate effect below so it sequences after the decorator's view zones land.
 
+      // Why: focus only at mount. useDiffViewerEditingWiring re-installs on an editability flip, but
+      // that flip is unattended (a recovered diff refetch), so focus must not be yanked from elsewhere.
       if (editable) {
-        const cleanupSaveShortcut = installEditorSaveShortcut(
-          modifiedEditor.getContainerDomNode(),
-          () => {
-            onSaveRef.current?.(modifiedEditor.getValue())
-          }
-        )
-        const cleanupOriginalFindShortcut = installMonacoEditorFindShortcut(originalEditor)
-        const cleanupModifiedFindShortcut = installMonacoEditorFindShortcut(modifiedEditor)
-
-        // Track changes
-        const modelContentSub = modifiedEditor.onDidChangeModelContent(() => {
-          onContentChangeRef.current?.(modifiedEditor.getValue())
-        })
-        modifiedEditor.onDidDispose(() => {
-          // Why: this diff instance owns both panes' shortcut bridges + the model sub, so dispose them with it.
-          cleanupSaveShortcut()
-          cleanupOriginalFindShortcut()
-          cleanupModifiedFindShortcut()
-          modelContentSub.dispose()
-        })
-
         modifiedEditor.focus()
       } else {
         diffEditor.focus()

--- a/src/renderer/src/components/editor/EditorContent.diff-load-error.test.tsx
+++ b/src/renderer/src/components/editor/EditorContent.diff-load-error.test.tsx
@@ -2,30 +2,49 @@
 // Why: a failed diff load renders the error text as the modified body. If that pane stays editable
 // the save path writes it over the real file, because attemptEditorFileSave falls back to the body
 // shown when no draft exists.
-import { cleanup, render } from '@testing-library/react'
+import { cleanup, render, type RenderResult } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { OpenFile } from '@/store/slices/editor'
 import type { DiffContent } from './editor-panel-content-types'
 
 const captured = vi.hoisted(() => ({
-  diffProps: [] as { editable?: boolean; onSave?: unknown; onContentChange?: unknown }[]
+  diffProps: [] as {
+    editable?: boolean
+    onSave?: unknown
+    onContentChange?: unknown
+    modifiedContent?: string
+  }[],
+  // Why: one entry per DiffViewer instance, so the tests can tell a remount from an in-place prop change.
+  mountEvents: [] as string[],
+  mountCount: 0
 }))
 
-vi.mock('@/lib/lazy-with-retry', () => ({
-  lazyWithRetry: (factory: () => Promise<unknown>) => {
-    if (factory.toString().includes('/DiffViewer.tsx')) {
-      return function MockDiffViewer(props: {
-        editable?: boolean
-        onSave?: unknown
-        onContentChange?: unknown
-      }) {
-        captured.diffProps.push(props)
-        return null
+vi.mock('@/lib/lazy-with-retry', async () => {
+  const { useEffect } = await import('react')
+  return {
+    lazyWithRetry: (factory: () => Promise<unknown>) => {
+      if (factory.toString().includes('/DiffViewer.tsx')) {
+        return function MockDiffViewer(props: {
+          editable?: boolean
+          onSave?: unknown
+          onContentChange?: unknown
+          modifiedContent?: string
+        }) {
+          captured.diffProps.push(props)
+          useEffect(() => {
+            const id = ++captured.mountCount
+            captured.mountEvents.push(`mount:${id}`)
+            return () => {
+              captured.mountEvents.push(`unmount:${id}`)
+            }
+          }, [])
+          return null
+        }
       }
+      return () => null
     }
-    return () => null
   }
-}))
+})
 
 vi.mock('@/store', () => {
   const state = {
@@ -60,14 +79,17 @@ const ACTIVE_FILE: OpenFile = {
   diffSource: 'unstaged'
 }
 
-function renderDiff(diff: DiffContent): void {
-  render(
+function diffElement(
+  diff: DiffContent,
+  editBuffers: Record<string, string> = {}
+): React.JSX.Element {
+  return (
     <EditorContent
       activeFile={ACTIVE_FILE}
       viewStateScopeId={ACTIVE_FILE.id}
       fileContents={{}}
       diffContents={{ [ACTIVE_FILE.id]: diff }}
-      editBuffers={{}}
+      editBuffers={editBuffers}
       openFiles={[ACTIVE_FILE]}
       worktreeEntries={[]}
       resolvedLanguage="typescript"
@@ -89,6 +111,10 @@ function renderDiff(diff: DiffContent): void {
   )
 }
 
+function renderDiff(diff: DiffContent, editBuffers: Record<string, string> = {}): RenderResult {
+  return render(diffElement(diff, editBuffers))
+}
+
 function textDiff(modifiedContent: string, loadError?: boolean): DiffContent {
   return {
     kind: 'text',
@@ -103,6 +129,8 @@ function textDiff(modifiedContent: string, loadError?: boolean): DiffContent {
 afterEach(() => {
   cleanup()
   captured.diffProps.length = 0
+  captured.mountEvents.length = 0
+  captured.mountCount = 0
 })
 
 describe('EditorContent diff load failures', () => {
@@ -114,6 +142,42 @@ describe('EditorContent diff load failures', () => {
     expect(props?.onSave).toBeUndefined()
     // Why: no draft can be minted either, or the next save would write the typed-over message.
     expect(props?.onContentChange).toBeUndefined()
+  })
+
+  it('keeps an existing draft editable and saveable when a refetch fails under it', () => {
+    // Why: the draft, not the error text, is what renders — locking it would strand unsaved work.
+    renderDiff(textDiff('Error loading diff: RuntimeRpcCallError: too large', true), {
+      [ACTIVE_FILE.id]: 'export const drafted = 1\n'
+    })
+
+    const props = captured.diffProps.at(-1)
+    expect(props?.modifiedContent).toBe('export const drafted = 1\n')
+    expect(props?.editable).toBe(true)
+    expect(props?.onSave).toBeTypeOf('function')
+  })
+
+  it('keeps the same viewer instance when a recovered refetch makes the live pane editable again', () => {
+    // Why: the recovery is unattended (git-status or external-change refetch), so remounting would
+    // re-run DiffViewer's mount-time focus grab and steal keystrokes; DiffViewer re-wires in place instead.
+    const { rerender } = renderDiff(
+      textDiff('Error loading diff: RuntimeRpcCallError: too large', true)
+    )
+    expect(captured.diffProps.at(-1)?.editable).toBe(false)
+    expect(captured.mountEvents).toEqual(['mount:1'])
+
+    rerender(diffElement(textDiff('export const a = 1\n')))
+
+    expect(captured.diffProps.at(-1)?.editable).toBe(true)
+    expect(captured.mountEvents).toEqual(['mount:1'])
+  })
+
+  it('keeps the same viewer instance when a refetch only changes the content', () => {
+    // Why: guards the remount key against churning Monaco (and its undo stack) on every content refresh.
+    const { rerender } = renderDiff(textDiff('export const a = 1\n'))
+
+    rerender(diffElement(textDiff('export const a = 2\n')))
+
+    expect(captured.mountEvents).toEqual(['mount:1'])
   })
 
   it('leaves a normally loaded unstaged diff editable', () => {

--- a/src/renderer/src/components/editor/EditorContent.diff-load-error.test.tsx
+++ b/src/renderer/src/components/editor/EditorContent.diff-load-error.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment happy-dom
+// Why: a failed diff load renders the error text as the modified body. If that pane stays editable
+// the save path writes it over the real file, because attemptEditorFileSave falls back to the body
+// shown when no draft exists.
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { OpenFile } from '@/store/slices/editor'
+import type { DiffContent } from './editor-panel-content-types'
+
+const captured = vi.hoisted(() => ({
+  diffProps: [] as { editable?: boolean; onSave?: unknown; onContentChange?: unknown }[]
+}))
+
+vi.mock('@/lib/lazy-with-retry', () => ({
+  lazyWithRetry: (factory: () => Promise<unknown>) => {
+    if (factory.toString().includes('/DiffViewer.tsx')) {
+      return function MockDiffViewer(props: {
+        editable?: boolean
+        onSave?: unknown
+        onContentChange?: unknown
+      }) {
+        captured.diffProps.push(props)
+        return null
+      }
+    }
+    return () => null
+  }
+}))
+
+vi.mock('@/store', () => {
+  const state = {
+    worktreesByRepo: {},
+    openFile: vi.fn(),
+    openMarkdownPreview: vi.fn(),
+    openConflictReviewFile: vi.fn(),
+    openConflictReview: vi.fn(),
+    closeFile: vi.fn(),
+    setRightSidebarTab: vi.fn(),
+    setPendingEditorReveal: vi.fn(),
+    reloadOpenCheckRunDetailsTab: vi.fn()
+  }
+  return {
+    useAppStore: Object.assign(
+      (selector: (s: Record<string, unknown>) => unknown) => selector(state),
+      { getState: () => ({ ...state, folderWorkspaces: [], projectGroups: [], repos: [] }) }
+    )
+  }
+})
+
+import { EditorContent } from './EditorContent'
+
+const ACTIVE_FILE: OpenFile = {
+  id: '/repo/notes.ts',
+  filePath: '/repo/notes.ts',
+  relativePath: 'notes.ts',
+  worktreeId: 'repo::/repo',
+  language: 'typescript',
+  isDirty: false,
+  mode: 'diff',
+  diffSource: 'unstaged'
+}
+
+function renderDiff(diff: DiffContent): void {
+  render(
+    <EditorContent
+      activeFile={ACTIVE_FILE}
+      viewStateScopeId={ACTIVE_FILE.id}
+      fileContents={{}}
+      diffContents={{ [ACTIVE_FILE.id]: diff }}
+      editBuffers={{}}
+      openFiles={[ACTIVE_FILE]}
+      worktreeEntries={[]}
+      resolvedLanguage="typescript"
+      isMarkdown={false}
+      isMermaid={false}
+      isCsv={false}
+      isNotebook={false}
+      mdViewMode="rich"
+      isChangesMode={false}
+      sideBySide={false}
+      pendingEditorReveal={null}
+      handleContentChange={vi.fn()}
+      handleContentChangeForFile={vi.fn()}
+      handleDirtyStateHint={vi.fn()}
+      handleSave={vi.fn()}
+      handleSaveForFile={vi.fn()}
+      reloadContent={vi.fn()}
+    />
+  )
+}
+
+function textDiff(modifiedContent: string, loadError?: boolean): DiffContent {
+  return {
+    kind: 'text',
+    originalContent: '',
+    modifiedContent,
+    originalIsBinary: false,
+    modifiedIsBinary: false,
+    ...(loadError === undefined ? {} : { loadError })
+  }
+}
+
+afterEach(() => {
+  cleanup()
+  captured.diffProps.length = 0
+})
+
+describe('EditorContent diff load failures', () => {
+  it('keeps a failed diff load read-only so its message cannot be saved over the file', () => {
+    renderDiff(textDiff('Error loading diff: RuntimeRpcCallError: too large', true))
+
+    const props = captured.diffProps.at(-1)
+    expect(props?.editable).toBe(false)
+    expect(props?.onSave).toBeUndefined()
+    // Why: no draft can be minted either, or the next save would write the typed-over message.
+    expect(props?.onContentChange).toBeUndefined()
+  })
+
+  it('leaves a normally loaded unstaged diff editable', () => {
+    renderDiff(textDiff('export const a = 1\n'))
+
+    const props = captured.diffProps.at(-1)
+    expect(props?.editable).toBe(true)
+    expect(props?.onSave).toBeTypeOf('function')
+  })
+})

--- a/src/renderer/src/components/editor/EditorContent.tsx
+++ b/src/renderer/src/components/editor/EditorContent.tsx
@@ -14,7 +14,7 @@ import {
   getNextConflictNavigationIndex
 } from './ConflictComponents'
 import type { MarkdownViewMode, OpenFile, PendingEditorReveal } from '@/store/slices/editor'
-import type { GitDiffResult } from '../../../../shared/git-diff-compare-types'
+import type { DiffContent } from './editor-panel-content-types'
 import type { GitStatusEntry } from '../../../../shared/git-status-types'
 import { getMarkdownRenderMode } from './markdown-render-mode'
 import { getMarkdownRichModeUnsupportedMessage } from './markdown-rich-mode'
@@ -147,7 +147,7 @@ export function EditorContent({
   activeFile: OpenFile
   viewStateScopeId: string
   fileContents: Record<string, FileContent>
-  diffContents: Record<string, GitDiffResult>
+  diffContents: Record<string, DiffContent>
   editBuffers: Record<string, string>
   openFiles: OpenFile[]
   worktreeEntries: GitStatusEntry[]
@@ -895,6 +895,9 @@ export function EditorContent({
     modifiedDiffBuffer === undefined &&
     dc.modifiedContent.length === 0
   )
+  // Why: the body is a load-failure message, not file content. Editing must stay off so no draft
+  // is minted and no save shortcut is installed — either would write that text over the real file.
+  const diffEditable = isEditable && dc.loadError !== true
   // Why: shared by both diff sub-branches (preview and source) so preview mode surfaces the external change too.
   const diffExternalChangeBanner =
     activeFile.externalMutation === 'changed' ? (
@@ -952,10 +955,10 @@ export function EditorContent({
       filePath={activeFile.filePath}
       relativePath={activeFile.relativePath}
       sideBySide={sideBySide}
-      editable={isEditable}
+      editable={diffEditable}
       worktreeId={activeFile.worktreeId}
-      onContentChange={isEditable ? handleContentChange : undefined}
-      onSave={isEditable ? (isMarkdown ? md.mdSave : handleSave) : undefined}
+      onContentChange={diffEditable ? handleContentChange : undefined}
+      onSave={diffEditable ? (isMarkdown ? md.mdSave : handleSave) : undefined}
     />
   )
   // Why: editable diffs get the changed-on-disk banner; its reload refetches the diff body, not plain file content.

--- a/src/renderer/src/components/editor/EditorContent.tsx
+++ b/src/renderer/src/components/editor/EditorContent.tsx
@@ -895,9 +895,10 @@ export function EditorContent({
     modifiedDiffBuffer === undefined &&
     dc.modifiedContent.length === 0
   )
-  // Why: the body is a load-failure message, not file content. Editing must stay off so no draft
-  // is minted and no save shortcut is installed — either would write that text over the real file.
-  const diffEditable = isEditable && dc.loadError !== true
+  // Why: a load-failure body is a message, not file content — keep it read-only so no draft is
+  // minted and no save writes it over the file. An existing draft is the user's own text, and it
+  // is what renders here, so it stays editable and saveable.
+  const diffEditable = isEditable && (dc.loadError !== true || modifiedDiffBuffer !== undefined)
   // Why: shared by both diff sub-branches (preview and source) so preview mode surfaces the external change too.
   const diffExternalChangeBanner =
     activeFile.externalMutation === 'changed' ? (

--- a/src/renderer/src/components/editor/editor-panel-content-types.ts
+++ b/src/renderer/src/components/editor/editor-panel-content-types.ts
@@ -32,6 +32,8 @@ export type FileContent = {
 export type DiffContent = GitDiffResult & {
   /** Superseded by an external change; still rendered until the lazy reload lands. */
   isStale?: boolean
+  /** The body is a load-failure message, not file content — saving it would overwrite the file. */
+  loadError?: boolean
 }
 
 export type InFlightContentRead<T> = {

--- a/src/renderer/src/components/editor/useDiffViewerEditingWiring.ts
+++ b/src/renderer/src/components/editor/useDiffViewerEditingWiring.ts
@@ -1,0 +1,62 @@
+import { useEffect, useRef } from 'react'
+import type { RefObject } from 'react'
+import type { editor } from 'monaco-editor'
+import { installEditorSaveShortcut, installMonacoEditorFindShortcut } from './editor-shortcuts'
+
+type DiffViewerEditingWiringInput = {
+  editable: boolean
+  modifiedEditor: editor.ICodeEditor | null
+  diffEditorRef: RefObject<editor.IStandaloneDiffEditor | null>
+  onContentChange?: (content: string) => void
+  onSave?: (content: string) => void
+}
+
+/**
+ * Owns the modified pane's Cmd+S bridge, both panes' find bridges, and the
+ * change subscription.
+ *
+ * Why a hook and not DiffViewer's onMount: `editable` can flip on a live pane
+ * (a failed diff load recovering under it) and @monaco-editor/react pins
+ * onMount to the first render, so mount-time wiring would never be installed.
+ * Remounting to force it would also re-run the mount-time focus grab and steal
+ * keystrokes, because that recovery is an unattended background refetch.
+ */
+export function useDiffViewerEditingWiring({
+  editable,
+  modifiedEditor,
+  diffEditorRef,
+  onContentChange,
+  onSave
+}: DiffViewerEditingWiringInput): void {
+  // Keep refs to latest callbacks so the mounted editor always calls current versions
+  const onSaveRef = useRef(onSave)
+  onSaveRef.current = onSave
+  const onContentChangeRef = useRef(onContentChange)
+  onContentChangeRef.current = onContentChange
+
+  useEffect(() => {
+    if (!editable || !modifiedEditor) {
+      return
+    }
+    const originalEditor = diffEditorRef.current?.getOriginalEditor()
+    const cleanupSaveShortcut = installEditorSaveShortcut(
+      modifiedEditor.getContainerDomNode(),
+      () => {
+        onSaveRef.current?.(modifiedEditor.getValue())
+      }
+    )
+    const cleanupOriginalFindShortcut = originalEditor
+      ? installMonacoEditorFindShortcut(originalEditor)
+      : null
+    const cleanupModifiedFindShortcut = installMonacoEditorFindShortcut(modifiedEditor)
+    const modelContentSub = modifiedEditor.onDidChangeModelContent(() => {
+      onContentChangeRef.current?.(modifiedEditor.getValue())
+    })
+    return () => {
+      cleanupSaveShortcut()
+      cleanupOriginalFindShortcut?.()
+      cleanupModifiedFindShortcut()
+      modelContentSub.dispose()
+    }
+  }, [editable, modifiedEditor, diffEditorRef])
+}

--- a/src/renderer/src/components/editor/useEditorPanelContentState.diff-load-error.test.tsx
+++ b/src/renderer/src/components/editor/useEditorPanelContentState.diff-load-error.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment happy-dom
+// Why: separate file because useEditorPanelContentState.test.tsx already sits at the 800-line cap.
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { OpenFile } from '@/store/slices/editor'
+import type { DiffContent } from './editor-panel-content-types'
+
+const mocks = vi.hoisted(() => ({
+  readRuntimeFileContent: vi.fn(),
+  getRuntimeGitDiff: vi.fn(),
+  getState: vi.fn()
+}))
+
+vi.mock('@/runtime/runtime-file-client', () => ({
+  getRuntimeFileReadScope: vi.fn(() => null),
+  readRuntimeFileContent: mocks.readRuntimeFileContent,
+  subscribeRuntimeFileChanges: vi.fn()
+}))
+
+vi.mock('@/runtime/runtime-git-client', () => ({
+  getRuntimeGitBranchDiff: vi.fn(),
+  getRuntimeGitCommitDiff: vi.fn(),
+  getRuntimeGitDiff: mocks.getRuntimeGitDiff,
+  getRuntimeGitScope: vi.fn(() => null)
+}))
+
+vi.mock('@/lib/connection-context', () => ({
+  getConnectionId: vi.fn(() => undefined),
+  getConnectionIdForFile: vi.fn(() => undefined),
+  isWorktreeConnectionResolved: vi.fn(() => true)
+}))
+
+vi.mock('@/lib/runtime-workspace-file-route', () => ({
+  findWorkspaceFileRoute: vi.fn(() => null)
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: { getState: mocks.getState }
+}))
+
+import { useEditorPanelContentState } from './useEditorPanelContentState'
+
+let latestDiffContents: Record<string, DiffContent> = {}
+let latestReloadContent: (file: OpenFile) => void = () => {}
+
+const DIFF_FILE: OpenFile = {
+  id: 'wt-1::diff::unstaged::file.ts',
+  filePath: '/repo/file.ts',
+  relativePath: 'file.ts',
+  worktreeId: 'wt-1',
+  language: 'typescript',
+  isDirty: false,
+  mode: 'diff',
+  diffSource: 'unstaged'
+}
+
+// Why: stable identities — a fresh openFiles array each render re-arms the load effect forever.
+const OPEN_FILES = [DIFF_FILE]
+const EDITOR_VIEW_MODE = {}
+
+function HookProbe(): null {
+  const state = useEditorPanelContentState({
+    activeFile: DIFF_FILE,
+    isChangesMode: false,
+    openFiles: OPEN_FILES,
+    gitStatusEntries: undefined,
+    editorViewMode: EDITOR_VIEW_MODE
+  })
+  latestDiffContents = state.diffContents
+  latestReloadContent = state.reloadContent
+  return null
+}
+
+describe('useEditorPanelContentState diff load failures', () => {
+  let container: HTMLDivElement | null = null
+  let root: Root | null = null
+
+  beforeEach(() => {
+    latestDiffContents = {}
+    ;(window as unknown as { api: unknown }).api = {
+      fs: { authorizeExternalPath: vi.fn(), onLocalLogTailChanged: vi.fn(() => () => {}) }
+    }
+    mocks.readRuntimeFileContent.mockReset()
+    mocks.getRuntimeGitDiff.mockReset()
+    mocks.getState.mockReset()
+    mocks.getState.mockReturnValue({
+      settings: null,
+      openFiles: [],
+      setLastKnownDiskSignature: vi.fn()
+    })
+  })
+
+  afterEach(() => {
+    if (root) {
+      act(() => root?.unmount())
+    }
+    container?.remove()
+    container = null
+    root = null
+  })
+
+  it('flags a rejected diff fetch, then clears the flag on a successful reload', async () => {
+    // Why: the fabricated "Error loading diff: …" body reads as file content; without the flag
+    // EditorContent keeps the pane editable and a save writes that sentence over the real file.
+    mocks.getRuntimeGitDiff
+      .mockRejectedValueOnce(new Error('diff_too_large'))
+      .mockResolvedValueOnce({
+        kind: 'text',
+        originalContent: 'old',
+        modifiedContent: 'recovered diff content',
+        originalIsBinary: false,
+        modifiedIsBinary: false
+      })
+
+    container = document.body.appendChild(document.createElement('div'))
+    root = createRoot(container)
+    await act(async () => {
+      root?.render(<HookProbe />)
+    })
+
+    await vi.waitFor(() => expect(latestDiffContents[DIFF_FILE.id]?.loadError).toBe(true))
+    expect(latestDiffContents[DIFF_FILE.id]?.modifiedContent).toContain('diff_too_large')
+
+    await act(async () => {
+      latestReloadContent(DIFF_FILE)
+    })
+
+    await vi.waitFor(() =>
+      expect(latestDiffContents[DIFF_FILE.id]?.modifiedContent).toBe('recovered diff content')
+    )
+    expect(latestDiffContents[DIFF_FILE.id]?.loadError).not.toBe(true)
+  })
+})

--- a/src/renderer/src/components/editor/useEditorPanelDiffContentLoader.ts
+++ b/src/renderer/src/components/editor/useEditorPanelDiffContentLoader.ts
@@ -167,7 +167,8 @@ export function useEditorPanelDiffContentLoader({
             originalContent: '',
             modifiedContent: `Error loading diff: ${String(err)}`,
             originalIsBinary: false,
-            modifiedIsBinary: false
+            modifiedIsBinary: false,
+            loadError: true
           }
         }))
       } finally {

--- a/src/renderer/src/components/editor/useEditorPanelExternalContentEvents.test.tsx
+++ b/src/renderer/src/components/editor/useEditorPanelExternalContentEvents.test.tsx
@@ -4,7 +4,10 @@ import { act, useLayoutEffect, useRef, useState } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { OpenFile } from '@/store/slices/editor'
-import { ORCA_EDITOR_EXTERNAL_FILE_CHANGE_EVENT } from './editor-autosave'
+import {
+  ORCA_EDITOR_EXTERNAL_FILE_CHANGE_EVENT,
+  ORCA_EDITOR_FILE_SAVED_EVENT
+} from './editor-autosave'
 import type { DiffContent, FileContent } from './editor-panel-content-types'
 import { useEditorPanelExternalContentEvents } from './useEditorPanelExternalContentEvents'
 
@@ -20,15 +23,26 @@ type ProbeProps = {
   calls: ProbeCalls
   isVisible: boolean
   openFiles: OpenFile[]
+  initialDiffContents?: Record<string, DiffContent>
 }
 
-function ExternalContentProbe({ activeFileId, calls, isVisible, openFiles }: ProbeProps): null {
+const EMPTY_DIFF_CONTENTS: Record<string, DiffContent> = {}
+let latestDiffContents: Record<string, DiffContent> = {}
+
+function ExternalContentProbe({
+  activeFileId,
+  calls,
+  isVisible,
+  openFiles,
+  initialDiffContents = EMPTY_DIFF_CONTENTS
+}: ProbeProps): null {
   const activeContentFileIdRef = useRef(activeFileId)
   const isVisibleRef = useRef(isVisible)
   const openFilesRef = useRef(openFiles)
   const editorViewModeRef = useRef({})
   const [, setFileContents] = useState<Record<string, FileContent>>({})
-  const [, setDiffContents] = useState<Record<string, DiffContent>>({})
+  const [diffContents, setDiffContents] = useState<Record<string, DiffContent>>(initialDiffContents)
+  latestDiffContents = diffContents
 
   useLayoutEffect(() => {
     activeContentFileIdRef.current = activeFileId
@@ -238,5 +252,41 @@ describe('useEditorPanelExternalContentEvents', () => {
     const previewOptions = previewCalls.loadFile.mock.calls[0]?.[4]
     expect(sourceOptions?.externalEventGeneration).toBeTypeOf('number')
     expect(previewOptions?.externalEventGeneration).toBe(sourceOptions?.externalEventGeneration)
+  })
+
+  it('clears the diff load-error flag once a save replaces the body with real content', () => {
+    // Why: keeping the flag would hold the pane read-only while it shows valid on-disk content.
+    const diffFile = makeFile('diff', { mode: 'diff', diffSource: 'unstaged' })
+
+    act(() => {
+      root.render(
+        <ExternalContentProbe
+          activeFileId={diffFile.id}
+          calls={makeCalls()}
+          isVisible
+          openFiles={[diffFile]}
+          initialDiffContents={{
+            [diffFile.id]: {
+              kind: 'text',
+              originalContent: '',
+              modifiedContent: 'Error loading diff: RuntimeRpcCallError: too large',
+              originalIsBinary: false,
+              modifiedIsBinary: false,
+              loadError: true
+            }
+          }}
+        />
+      )
+    })
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(ORCA_EDITOR_FILE_SAVED_EVENT, {
+          detail: { fileId: diffFile.id, content: 'export const a = 1\n' }
+        })
+      )
+    })
+
+    expect(latestDiffContents[diffFile.id]?.modifiedContent).toBe('export const a = 1\n')
+    expect(latestDiffContents[diffFile.id]?.loadError).toBeUndefined()
   })
 })

--- a/src/renderer/src/components/editor/useEditorPanelExternalContentEvents.ts
+++ b/src/renderer/src/components/editor/useEditorPanelExternalContentEvents.ts
@@ -150,7 +150,9 @@ export function useEditorPanelExternalContentEvents({
         if (!existing || existing.kind !== 'text') {
           return prev
         }
-        return { ...prev, [file.id]: { ...existing, modifiedContent: detail.content } }
+        // Why: the saved bytes replace any load-failure message, so drop the flag that holds the pane read-only.
+        const { loadError: _loadError, ...rest } = existing
+        return { ...prev, [file.id]: { ...rest, modifiedContent: detail.content } }
       })
     }
     window.addEventListener(ORCA_EDITOR_FILE_SAVED_EVENT, handler as EventListener)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​580 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​577 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​88 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​34 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​54 |

<!-- /orca-pr-loc -->

## The bug

When a diff RPC fails, `useEditorPanelContentState` fabricates a result so the pane has something to render:

```ts
{ kind: 'text', originalContent: '', modifiedContent: `Error loading diff: ${String(err)}` }
```

For an **unstaged** diff that pane is editable. `Cmd+S` calls `onSave(modifiedEditor.getValue())`, and `attemptEditorFileSave` falls back to the displayed body when no draft exists (`editor-autosave-controller.ts`). **The error sentence gets written over the user's file.**

Reachable from any diff-load failure — SSH drop, git error, permission denied, or the `diff_too_large` added in #14160.

## Why the existing guard misses it

`largeDiffSaveContentAvailable` already exists for exactly this hazard, but it only gates the `LargeDiffFallback` **button**, which renders when `largeDiffRenderLimit.limited` is true. On the error path that field is absent, so `renderLimit.limited` is false, the full `DiffEditor` mounts, and `installEditorSaveShortcut` is installed — gated only by `editable`. The guard never runs.

## The fix

Mark the fabricated result and hold the pane read-only.

Read-only rather than just gating `onSave`, because a draft is the other route: typing into the pane mints one via `onContentChange`, and a draft is saveable even when the fallback body is not. `editable={false}` closes both — `installEditorSaveShortcut` sits inside `if (editable)`.

`loadError` mirrors the field `FileContent` already carries for the plain-file path, and lives on the renderer-local `DiffContent` (`GitDiffResult & {...}`), so **nothing on the wire changes**.

## Scope

4 files, +138/−6 — most of it the new test.

| File | Change |
|---|---|
| `editor-panel-content-types.ts` | `loadError?: boolean` on `DiffContent` |
| `useEditorPanelContentState.ts` | set it on the fabricated result |
| `EditorContent.tsx` | `diffEditable` gates `editable` / `onContentChange` / `onSave` |
| `EditorContent.diff-load-error.test.tsx` | new |

## Testing

- Mutation-verified: reverting `diffEditable` to plain `isEditable` fails exactly the new read-only case, and only that case.
- 23094 renderer tests pass; web and node typechecks clean.

## Not in scope

The error pane's *presentation* is unchanged — it still shows the message inside a diff view rather than the dedicated `FileLoadErrorView` the plain-file path uses. That is a UX improvement worth doing separately; this PR only removes the data-loss path.

Made with [Orca](https://github.com/stablyai/orca) 🐋
