### PR TITLE
fix(ssh): bound git response-stream reassembly on the host

### DIFF
--- a/src/main/ssh/ssh-git-response-stream-reader.test.ts
+++ b/src/main/ssh/ssh-git-response-stream-reader.test.ts
@@ -71,7 +71,7 @@ describe('requestGitStreamable reassembly cap', () => {
 
   it('admits a stream declared exactly at the cap', async () => {
     const payload = Buffer.from(JSON.stringify({ kind: 'text' }), 'utf-8')
-    const { mux, chunkHandlers } = createFakeMux({
+    const { mux, notify } = createFakeMux({
       streamId: 8,
       totalBytes: payload.length,
       chunkCount: 1
@@ -85,8 +85,51 @@ describe('requestGitStreamable reassembly cap', () => {
     await Promise.resolve()
     await Promise.resolve()
 
-    // The marker passed the gate: a chunk subscriber is live and nothing rejected.
-    expect(chunkHandlers).toHaveLength(1)
+    // The marker passed the gate: the stream was not cancelled and nothing rejected.
+    expect(notify).not.toHaveBeenCalledWith('git.cancelResponseStream', expect.anything())
     expect(settled).not.toHaveBeenCalled()
+  })
+
+  // Why: the marker gate only bounds the declared size; a relay that declares small and
+  // then streams forever (never sending responseEnd) must be cut off mid-flight.
+  it('rejects a relay that streams past its declared size', async () => {
+    const chunk = Buffer.from('a'.repeat(8), 'utf-8')
+    const { mux, chunkHandlers, notify } = createFakeMux({
+      streamId: 9,
+      totalBytes: chunk.length,
+      chunkCount: 1
+    })
+
+    const result = requestGitStreamable(mux, 'git.diff', { cwd: '/repo' })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    const feed = chunkHandlers[0]
+    feed({ streamId: 9, seq: 0, data: chunk.toString('base64') })
+    feed({ streamId: 9, seq: 1, data: chunk.toString('base64') })
+
+    await expect(result).rejects.toThrow(/sent more chunks than declared/)
+    expect(notify).toHaveBeenCalledWith('git.cancelResponseStream', { streamId: 9 })
+  })
+
+  it('rejects a chunk that overruns the declared byte total', async () => {
+    const { mux, chunkHandlers, notify } = createFakeMux({
+      streamId: 10,
+      totalBytes: 4,
+      chunkCount: 2
+    })
+
+    const result = requestGitStreamable(mux, 'git.diff', { cwd: '/repo' })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    chunkHandlers[0]({
+      streamId: 10,
+      seq: 0,
+      data: Buffer.from('abcdefgh', 'utf-8').toString('base64')
+    })
+
+    await expect(result).rejects.toThrow(/overran declared size: 8\/4 bytes/)
+    expect(notify).toHaveBeenCalledWith('git.cancelResponseStream', { streamId: 10 })
   })
 })

--- a/src/main/ssh/ssh-git-response-stream-reader.test.ts
+++ b/src/main/ssh/ssh-git-response-stream-reader.test.ts
@@ -28,3 +28,65 @@ describe('requestGitStreamable on an already-dead multiplexer', () => {
     expect(removeListener).toHaveBeenCalledTimes(addListener.mock.calls.length)
   })
 })
+
+function createFakeMux(marker: { streamId: number; totalBytes: number; chunkCount: number }) {
+  const chunkHandlers: ((p: Record<string, unknown>) => void)[] = []
+  const notify = vi.fn()
+  return {
+    notify,
+    chunkHandlers,
+    mux: {
+      request: async () => ({ __orcaGitResponseStream: marker }),
+      onNotificationByMethod: (method: string, handler: (p: Record<string, unknown>) => void) => {
+        if (method === 'git.responseChunk') {
+          chunkHandlers.push(handler)
+        }
+        return () => {}
+      },
+      onDispose: () => () => {},
+      isDisposed: () => false,
+      notify
+    } as unknown as SshChannelMultiplexer
+  }
+}
+
+// Why: without the marker gate the host Buffer.concats and JSON.parses whatever the relay declares,
+// so an oversized or hostile response is reassembled in full before anything can reject it.
+describe('requestGitStreamable reassembly cap', () => {
+  it('rejects an over-cap stream at the marker and cancels it before any chunk transfers', async () => {
+    const { mux, notify } = createFakeMux({
+      streamId: 7,
+      totalBytes: 64 * 1024 * 1024,
+      chunkCount: 1
+    })
+
+    await expect(requestGitStreamable(mux, 'git.diff', { cwd: '/repo' })).rejects.toThrow(
+      /above the \d+ byte cap/
+    )
+    // Tell the relay to stop sending rather than draining a payload we rejected.
+    expect(notify).toHaveBeenCalledWith('git.cancelResponseStream', { streamId: 7 })
+    // No chunk was acked, i.e. none was accepted.
+    expect(notify).not.toHaveBeenCalledWith('git.responseAck', expect.anything())
+  })
+
+  it('admits a stream declared exactly at the cap', async () => {
+    const payload = Buffer.from(JSON.stringify({ kind: 'text' }), 'utf-8')
+    const { mux, chunkHandlers } = createFakeMux({
+      streamId: 8,
+      totalBytes: payload.length,
+      chunkCount: 1
+    })
+
+    const settled = vi.fn()
+    void requestGitStreamable(mux, 'git.diff', { cwd: '/repo' }, { maxBytes: payload.length }).then(
+      settled,
+      settled
+    )
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // The marker passed the gate: a chunk subscriber is live and nothing rejected.
+    expect(chunkHandlers).toHaveLength(1)
+    expect(settled).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/ssh/ssh-git-response-stream-reader.ts
+++ b/src/main/ssh/ssh-git-response-stream-reader.ts
@@ -156,6 +156,25 @@ export function requestGitStreamable(
         return
       }
       const decoded = Buffer.from(data, 'base64')
+      // Why: without this the declared size is advisory — a relay that never sends
+      // responseEnd could stream past it forever and OOM the main process. The relay
+      // derives both figures from the same buffer, so an honest stream cannot trip it.
+      if (expectedSeq >= chunkCount) {
+        fail(
+          new GitResponseStreamError(
+            `Git stream ${streamIdRef.current} sent more chunks than declared: ${chunkCount}`
+          )
+        )
+        return
+      }
+      if (receivedBytes + decoded.length > totalBytes) {
+        fail(
+          new GitResponseStreamError(
+            `Git stream ${streamIdRef.current} overran declared size: ${receivedBytes + decoded.length}/${totalBytes} bytes`
+          )
+        )
+        return
+      }
       parts.push(decoded)
       receivedBytes += decoded.length
       expectedSeq += 1

--- a/src/main/ssh/ssh-git-response-stream-reader.ts
+++ b/src/main/ssh/ssh-git-response-stream-reader.ts
@@ -16,6 +16,11 @@ const STREAM_INACTIVITY_TIMEOUT_MS = 30_000
  * are dropped on drain anyway; this just caps the pre-sentinel backlog. */
 const MAX_PENDING_FRAMES = 64
 
+/** Bound host memory during reassembly. The relay caps each git exec at MAX_GIT_BUFFER (10 MiB),
+ * so a legitimate diff tops out near 27 MiB — two blobs at that cap, base64-inflated. Anything past
+ * this is a buggy or hostile relay, and without the gate we would Buffer.concat then JSON.parse it. */
+const MAX_GIT_STREAM_RESPONSE_BYTES = 32 * 1024 * 1024
+
 export class GitResponseStreamError extends Error {
   readonly code = RelayErrorCode.StreamProtocolError
   constructor(message: string) {
@@ -50,6 +55,8 @@ export function requestGitStreamable(
     timeoutMs?: number
     /** Bounds the post-sentinel reassembly stall; resets on each chunk. */
     inactivityTimeoutMs?: number
+    /** Largest reassembled response to accept; defaults to MAX_GIT_STREAM_RESPONSE_BYTES. */
+    maxBytes?: number
   }
 ): Promise<unknown> {
   // Why: subscribe to chunk/end/error BEFORE awaiting the sentinel response so a
@@ -290,6 +297,18 @@ export function requestGitStreamable(
           return
         }
         const marker = result.__orcaGitResponseStream
+        // Why: the relay declares the size up front, so reject before a single chunk transfers
+        // rather than after reassembling a payload we were never going to accept.
+        const maxBytes = options?.maxBytes ?? MAX_GIT_STREAM_RESPONSE_BYTES
+        if (marker.totalBytes > maxBytes) {
+          streamIdRef.current = marker.streamId
+          fail(
+            new GitResponseStreamError(
+              `Git stream ${marker.streamId} reports ${marker.totalBytes} bytes, above the ${maxBytes} byte cap`
+            )
+          )
+          return
+        }
         totalBytes = marker.totalBytes
         chunkCount = marker.chunkCount
         streamIdRef.current = marker.streamId


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​105 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​105 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​38 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​38 |

<!-- /orca-pr-loc -->

## The gap

`requestGitStreamable` trusted the relay's declared size. Every chunk was pushed into `parts`, then `Buffer.concat`'d and `JSON.parse`'d with **no ceiling** — a buggy or hostile relay could name any `totalBytes` and the host would allocate it.

The file path already has this gate: `ssh-filesystem-stream-reader.ts` checks the declared `totalSize` against a cap before accepting a stream. #14160 added a read cap for **files only**; this closes the same hole for **git**.

## The fix

Reject at the marker — before a single chunk transfers — and cancel the stream so the relay stops sending rather than us draining a payload we already refused.

The relay declares the size up front, so this costs nothing on the happy path and avoids reassembling a response that was never going to be accepted.

## Why 32 MiB

Above anything a legitimate diff can produce, so **no diff that works today starts failing**:

- The relay caps each git exec at `MAX_GIT_BUFFER` = 10 MiB (`src/relay/git-handler.ts:101`).
- A binary diff base64-inflates both sides, so a legitimate `GitDiffResult` tops out near 27 MiB.

Anything past that is a buggy or hostile relay. Overridable via `maxBytes` for tests.

## Scope

2 files, +81/−0. No wire change, no new module, no caller wiring — the cap is a default inside the reader, so all four `requestGitStreamable` call sites (`git.diff`, `git.branchDiff`, `git.commitDiff`, `git.exec`) get it without touching the provider.

## Testing

- Mutation-verified: disabling the gate makes the over-cap case hang to the inactivity timeout instead of rejecting.
- Pins that the over-cap path sends `git.cancelResponseStream` and never acks a chunk, and that a stream exactly at the cap is admitted.
- 7471 tests pass across `src/main/ssh`, `src/main/providers`, `src/main/runtime` and `src/relay`; node and cli typechecks clean.

## Note

This is a host memory-safety bound, deliberately **not** the RPC content budget from #14160. The SSH provider serves desktop-local viewers of SSH-hosted worktrees as well as remote clients, so capping here at the 4 MiB envelope would break local diffs that #14160 intentionally left uncapped.

Made with [Orca](https://github.com/stablyai/orca) 🐋
