### PR TITLE
feat(browser): route tunnels through execution hosts

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -2581,6 +2581,7 @@
       "surfaces": [
         "client-hosted browser tunnel framing",
         "execution-host TCP credit flow",
+        "capability-gated native and SSH execution-host adapters",
         "main-owned loopback SOCKS5 route",
         "runtime-owned browser-host lease and placement authority",
         "dedicated paired-runtime E2EE tunnel subscription"
@@ -2588,20 +2589,22 @@
       "platforms": ["macos", "linux", "windows"],
       "providers": ["local", "remote-runtime", "ssh", "wsl"],
       "coveredPlatforms": ["macos"],
-      "coveredProviders": ["remote-runtime"],
-      "coverageNotes": "Deterministic protocol, registry, injected-socket, and loopback-listener tests cover strict framing, remote-DNS targets, exact destination-write and source-consumption credit, at most 16 pending opens, 128 admitted opens per 10-second monotonic window, an 8 MiB per-route application-buffer ledger, shared 32 MiB browser-host and 128 MiB process ledgers across application copies, encrypted client queues, and native WebSocket bufferedAmount, bounded byte/claim/socket-source counts, a four-frame queued-drain quantum, authority epochs, exact host selection, one host per authenticated connection, four hosts per paired device, long-poll metering and disconnect abort, monotonic host/page/route generations without page tombstones, connection-owned cleanup, exact client revocation, stale and replaced fences, retired stream IDs, half-close and close ordering, SOCKS CONNECT, bind/close races, listener wildcard normalization, unsupported commands, unavailable routes, and raw/terminal binary-handler isolation. A stable local listener rejects CONNECT while offline or reconnecting, retains its address across replacement, requires a strictly increasing tunnel generation, ignores late superseded callbacks, propagates tunnel protocol failure to the route owner, and recycles exhausted stream IDs only after generation replacement. Reconnect uses the unchanged v1 attach payload and capability pair. The execution runtime charges route application bytes to the same per-host/process policy; its existing E2EE owner separately caps native outbound buffers process-wide. Explicitly injected browser-host and paired-runtime tunnel methods lease one exact host, then carry SOCKS and HTTP bytes over a dedicated E2EE socket to the fenced native execution-host revision and prove route close destroys the destination socket. Both methods and capabilities remain disabled in production. Node stream-internal high-water bytes, strict cross-route scheduling, SSH, and WSL remain uncovered.",
+      "coveredProviders": ["remote-runtime", "ssh"],
+      "coverageNotes": "Deterministic protocol, registry, injected-socket, and loopback-listener tests cover strict framing, remote-DNS targets, exact destination-write and source-consumption credit, at most 16 pending opens, 128 admitted opens per 10-second monotonic window, an 8 MiB per-route application-buffer ledger, shared 32 MiB browser-host and 128 MiB process ledgers across application copies, encrypted client queues, and native WebSocket bufferedAmount, bounded byte/claim/socket-source counts, a four-frame queued-drain quantum, authority epochs, exact host selection, one host per authenticated connection, four hosts per paired device, long-poll metering and disconnect abort, monotonic host/page/route generations without page tombstones, connection-owned cleanup, exact client revocation, stale and replaced fences, retired stream IDs, half-close and close ordering, SOCKS CONNECT, bind/close races, listener wildcard normalization, unsupported commands, unavailable routes, and raw/terminal binary-handler isolation. A stable local listener rejects CONNECT while offline or reconnecting, retains its address across replacement, requires a strictly increasing tunnel generation, ignores late superseded callbacks, propagates tunnel protocol failure to the route owner, and recycles exhausted stream IDs only after generation replacement. Reconnect uses the unchanged native v1 attach payload and capability pair; SSH descriptors alone add an execution-host capability and require a runtime-minted grant bound to the exact browser-host lease. Exact SSH provider epoch and connection generation fence ssh2 forwardOut and one non-interactive standalone system-SSH dynamic forward per route. Unit tests preserve domain-form SOCKS requests, sanitize remote errors, bound stderr, cancel startup, release timed-out and synchronously failed sockets, and release routes once. An ephemeral Docker sshd resolves a container-only domain and returns a unique HTTP marker through both ssh2 and the actual system-OpenSSH dynamic-forward adapter without touching the user's SSH files; authority loss fences the ssh2 route. The execution runtime charges route application bytes to the same per-host/process policy; its existing E2EE owner separately caps native outbound buffers process-wide. Explicitly injected browser-host and paired-runtime tunnel methods lease one exact host, then carry SOCKS and HTTP bytes over a dedicated E2EE socket to the fenced execution-host revision and prove route close destroys the destination socket. Both methods and capabilities remain disabled in production. Node stream-internal high-water bytes, strict cross-route scheduling, WSL, and physical cross-platform evidence remain uncovered.",
       "motivatingLinks": [
         "https://linear.app/stably/issue/STA-4150/refactor-remote-browser-to-client-hosted-electron-webviews"
       ],
-      "invariant": "A client-hosted browser network route exists only for an exact live server-owned browser-host lease, authority epoch, host generation, paired identity, execution-host revision, and server-owned route generation. Host selection never chooses arbitrarily, stale cleanup cannot remove a replacement, destination names remain unresolved until the execution host, credit returns only after writes settle, and route loss never falls back to desktop DNS or sockets. A main-owned local listener remains stable across upstream transport loss, rejects CONNECT while offline, accepts only a strictly newer tunnel generation, ignores superseded callbacks, and never reuses a stream ID within one generation. Pending opens, admitted open rate, per-route application bytes, aggregate browser-host/process bytes, claims, and socket sources remain bounded with exact release on settlement and retirement. Queued transport drain yields after a bounded quantum. The local SOCKS endpoint accepts only loopback CONNECT and rejects unsupported commands.",
-      "oracle": "Attach two browser hosts and require unqualified selection to fail ambiguous while exact selection succeeds. Reject a second identity on one connection and a fifth identity for one paired device, release one exact lease, then admit its replacement without starving another device. Saturate the browser-host long-poll sub-cap, require an ordinary wait to remain admitted, close the socket, and prove both counters and handlers release. Replace one same-device connection, require the old subscription and route to fence, then prove late old cleanup leaves the new generation live. Retire a closed page placement by exact token, reject delayed cleanup against a replacement and server placement, and require its reused ID to receive a higher global generation without retaining a tombstone. Admit 16 pending destination opens and reject the seventeenth until one connects; admit 128 opens in one monotonic 10-second window and reject the 129th until the window expires. Fill 8 MiB across destination-to-client queues and separately across unsettled client-to-destination writes, release one exact retired stream, admit one replacement, and require the next byte claim to close the route without stale-callback or reentrant-close underflow. Across multiple routes, charge application copies, encrypted queue entries, and dynamic native socket bytes to one 32 MiB browser-host and 128 MiB process ceiling; reject zero-byte claim/socket-source floods, fence released leases, synchronously release JavaScript queue claims while retaining native claims through exact socket close, and yield a parked queue after four frames without reordering. Drop an authenticated transport, require the same listener to reject CONNECT before and during reconnect, attach the exact existing v1 payload and capability pair to a strictly newer generation, ignore late old callbacks, and roll an exhausted stream-ID ledger only by replacing the generation. Reject missing, stale, wrong-device, wrong-epoch, wrong-execution-revision, and memory-exhausted tunnel requests before binary registration. Drive the accepted lease through a real paired E2EE SOCKS-to-HTTP journey, then exercise exact frame, credit, half-close, stale-stream, remote-DNS, unsupported-command, offline, and teardown assertions.",
+      "invariant": "A client-hosted browser network route exists only for an exact live server-owned browser-host lease, authority epoch, host generation, paired identity, execution-host revision or SSH provider authority, and server-owned route generation. Non-native descriptors require explicit capability negotiation and an exact runtime-minted lease-bound execution-host grant. Host selection never chooses arbitrarily, stale cleanup cannot remove a replacement, destination names remain unresolved until the execution host, credit returns only after writes settle, and route loss never falls back to desktop DNS or sockets. A main-owned local listener remains stable across upstream transport loss, rejects CONNECT while offline, accepts only a strictly newer tunnel generation, ignores superseded callbacks, and never reuses a stream ID within one generation. Pending opens, admitted open rate, per-route application bytes, aggregate browser-host/process bytes, claims, and socket sources remain bounded with exact release on settlement and retirement. Queued transport drain yields after a bounded quantum. The local SOCKS endpoint accepts only loopback CONNECT and rejects unsupported commands.",
+      "oracle": "Attach two browser hosts and require unqualified selection to fail ambiguous while exact selection succeeds. Reject a second identity on one connection and a fifth identity for one paired device, release one exact lease, then admit its replacement without starving another device. Saturate the browser-host long-poll sub-cap, require an ordinary wait to remain admitted, close the socket, and prove both counters and handlers release. Replace one same-device connection, require the old subscription and route to fence, then prove late old cleanup leaves the new generation live. Mint an exact execution-host grant, reject a different key, prove late old grant cleanup leaves its replacement, and invalidate every grant with lease replacement. Retire a closed page placement by exact token, reject delayed cleanup against a replacement and server placement, and require its reused ID to receive a higher global generation without retaining a tombstone. Admit 16 pending destination opens and reject the seventeenth until one connects; admit 128 opens in one monotonic 10-second window and reject the 129th until the window expires. Fill 8 MiB across destination-to-client queues and separately across unsettled client-to-destination writes, release one exact retired stream, admit one replacement, and require the next byte claim to close the route without stale-callback or reentrant-close underflow. Across multiple routes, charge application copies, encrypted queue entries, and dynamic native socket bytes to one 32 MiB browser-host and 128 MiB process ceiling; reject zero-byte claim/socket-source floods, fence released leases, synchronously release JavaScript queue claims while retaining native claims through exact socket close, and yield a parked queue after four frames without reordering. Drop an authenticated transport, require the same listener to reject CONNECT before and during reconnect, attach the exact existing native v1 payload and capability pair to a strictly newer generation, ignore late old callbacks, and roll an exhausted stream-ID ledger only by replacing the generation. Require SSH descriptors to add the execution-host capability and exact grant, reject missing grants and stale provider authority before resolver or binary registration, pass exact domains to ssh2 and system-SSH SOCKS without local resolution, sanitize connector diagnostics, and close every stream and standalone route process once on timeout, synchronous failure, or rotation. Drive the accepted lease through real paired E2EE native SOCKS-to-HTTP and ephemeral Docker ssh2 remote-only DNS journeys, then exercise exact frame, credit, half-close, stale-stream, remote-DNS, unsupported-command, offline, and teardown assertions.",
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/shared/browser-network-capabilities.test.ts src/shared/browser-network-tunnel-protocol.test.ts src/main/browser/browser-network-tunnel-session.test.ts src/main/browser/remote-browser-socks-server.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/main/browser/browser-network-tunnel-client.test.ts src/main/browser/paired-runtime-browser-network-route.test.ts src/main/runtime/runtime-binary-message-router.test.ts src/main/runtime/rpc/methods/browser-network-tunnel.test.ts src/main/runtime/browser-network-tunnel-paired-runtime.integration.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/main/browser/browser-network-tunnel-outbound-memory-budget.test.ts src/main/browser/browser-network-tunnel-client-memory-budget.test.ts src/main/browser/browser-network-tunnel-session-aggregate-memory.test.ts src/shared/ws-outbound-backpressure-queue.test.ts src/shared/remote-runtime-client.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/shared/browser-client-host-protocol.test.ts src/shared/ws-outbound-backpressure-queue.test.ts src/shared/remote-runtime-client.test.ts src/main/runtime/browser-host-lease-registry.test.ts src/main/runtime/runtime-rpc-browser-host-admission.test.ts src/main/runtime/rpc/methods/browser-client-host.test.ts src/main/runtime/rpc/methods/browser-network-tunnel.test.ts src/main/browser/paired-runtime-browser-host-lease.test.ts src/main/browser/paired-runtime-browser-network-route.test.ts src/main/runtime/browser-network-tunnel-paired-runtime.integration.test.ts src/main/browser/browser-network-tunnel-client.test.ts src/main/browser/browser-network-tunnel-client-memory-budget.test.ts src/main/browser/browser-network-tunnel-session.test.ts src/main/browser/browser-network-tunnel-session-aggregate-memory.test.ts src/main/browser/browser-network-tunnel-outbound-memory-budget.test.ts src/main/browser/remote-browser-socks-server.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/shared/browser-client-host-protocol.test.ts src/main/runtime/browser-host-lease-registry.test.ts src/main/runtime/runtime-rpc-browser-host-admission.test.ts src/main/runtime/rpc/methods/browser-client-host.test.ts src/main/runtime/rpc/methods/browser-network-tunnel.test.ts src/main/browser/paired-runtime-browser-host-lease.test.ts src/main/browser/paired-runtime-browser-network-route.test.ts src/main/runtime/browser-network-tunnel-paired-runtime.integration.test.ts src/main/browser/browser-network-tunnel-client.test.ts src/main/browser/browser-network-tunnel-session.test.ts src/main/browser/remote-browser-socks-server.test.ts",
-        "pnpm exec vitest run --config config/vitest.config.ts src/shared/remote-runtime-client.test.ts"
+        "pnpm exec vitest run --config config/vitest.config.ts src/shared/remote-runtime-client.test.ts",
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/browser-host-lease-registry.test.ts src/main/browser/browser-network-deferred-socket.test.ts src/main/browser/browser-network-execution-route.test.ts src/main/browser/paired-runtime-browser-network-route.test.ts src/main/runtime/rpc/methods/browser-network-tunnel.test.ts src/main/browser/ssh-browser-network-execution-route.test.ts src/main/browser/system-ssh-socks-client-socket.test.ts src/main/ssh/system-ssh-dynamic-forward-process.test.ts src/shared/browser-client-host-protocol.test.ts src/shared/browser-network-capabilities.test.ts src/main/ssh/system-ssh-forward-process.test.ts src/main/ssh/ssh-system-fallback.test.ts src/main/ssh/ssh-port-forward.test.ts",
+        "ORCA_RUN_DOCKER_SSH_BROWSER_E2E=1 pnpm exec vitest run --config config/vitest.config.ts tests/e2e/ssh-browser-network-execution-route.docker.unit.test.ts"
       ],
       "testFiles": [
         "src/shared/browser-network-capabilities.test.ts",
@@ -2616,13 +2619,20 @@
         "src/main/browser/browser-network-tunnel-client.test.ts",
         "src/main/browser/browser-network-tunnel-client-memory-budget.test.ts",
         "src/main/browser/browser-network-tunnel-outbound-memory-budget.test.ts",
+        "src/main/browser/browser-network-deferred-socket.test.ts",
+        "src/main/browser/browser-network-execution-route.test.ts",
         "src/main/browser/paired-runtime-browser-network-route.test.ts",
+        "src/main/browser/ssh-browser-network-execution-route.test.ts",
+        "src/main/browser/system-ssh-socks-client-socket.test.ts",
+        "src/main/ssh/system-ssh-dynamic-forward-process.test.ts",
+        "src/main/ssh/ssh-port-forward.test.ts",
         "src/main/browser/remote-browser-socks-server.test.ts",
         "src/main/runtime/runtime-binary-message-router.test.ts",
         "src/main/runtime/rpc/methods/browser-network-tunnel.test.ts",
         "src/main/runtime/browser-network-tunnel-paired-runtime.integration.test.ts",
         "src/shared/remote-runtime-client.test.ts",
-        "src/shared/ws-outbound-backpressure-queue.test.ts"
+        "src/shared/ws-outbound-backpressure-queue.test.ts",
+        "tests/e2e/ssh-browser-network-execution-route.docker.unit.test.ts"
       ],
       "assertionRefs": [
         {
@@ -2632,6 +2642,8 @@
             "one connection and one paired device cannot retain more than their exact host limits",
             "same-device replacement increments generation and fences the old connection",
             "late cleanup cannot remove a newer lease or route generation",
+            "execution-host grants bind to one exact lease and key while stale cleanup cannot remove a replacement",
+            "lease replacement invalidates every grant from the old host generation",
             "late page cleanup cannot remove a replacement client generation or server placement",
             "retired page placement leaves no tombstone and a reused ID receives a higher global generation",
             "page placement generations are monotonic and stale lease authority is rejected"
@@ -2723,7 +2735,12 @@
           "file": "src/main/runtime/rpc/methods/browser-network-tunnel.test.ts",
           "assertions": [
             "the production RPC registry excludes the tunnel until route authorization exists",
-            "unnegotiated, self-asserted, stale, and wrong-execution-revision browser hosts register no binary handler",
+            "unnegotiated, self-asserted, stale, wrong-execution-revision, and stale-SSH-authority browser hosts register no binary handler",
+            "SSH execution-host descriptors require a separately negotiated capability",
+            "ungranted or wrong-key SSH routes are rejected before resolver, memory, or binary registration",
+            "connector diagnostics are mapped to a stable public error without local path disclosure",
+            "grant revocation aborts connector startup immediately and cannot race through route admission",
+            "execution-host invalidation closes the session and releases its connector exactly once",
             "memory exhaustion opens no route or binary handler",
             "the server allocates route generations and fences the replaced route",
             "subscription cleanup removes the exact connection-owned raw handler",
@@ -2740,10 +2757,63 @@
             "the route binds and releases its exact host/process memory lease and four-frame drain quantum",
             "one listener stays fail-closed and address-stable through reconnect",
             "replacement generations advance strictly and remain fenced after ready-close races",
-            "reconnect retains the exact existing v1 attach payload and capability pair",
+            "reconnect retains the exact existing native v1 attach payload and capability pair",
+            "only an SSH descriptor adds the execution-host capability",
             "late superseded callbacks cannot replace or close the current transport",
             "a current-generation protocol failure retires the transport and remains reconnectable",
             "stream-ID exhaustion replaces the generation before recycling an ID"
+          ]
+        },
+        {
+          "file": "src/main/browser/browser-network-deferred-socket.test.ts",
+          "assertions": [
+            "destroy before source attachment emits one close and destroys a late source",
+            "source close after destroy cannot emit duplicate wrapper close"
+          ]
+        },
+        {
+          "file": "src/main/browser/browser-network-execution-route.test.ts",
+          "assertions": [
+            "execution-host route keys cannot collide on delimiter-containing identities",
+            "native routing accepts only the exact runtime revision without retaining an invalidation callback"
+          ]
+        },
+        {
+          "file": "src/main/browser/ssh-browser-network-execution-route.test.ts",
+          "assertions": [
+            "missing and stale SSH provider authority is rejected before destination open",
+            "ssh2 forwardOut receives the exact domain and port without desktop resolution",
+            "a synchronous forwardOut disconnect releases the exact deferred socket once",
+            "provider rotation invalidates and releases the exact route once",
+            "one system-SSH dynamic forward is owned by the whole route",
+            "grant revocation aborts an in-progress system-SSH dynamic forward"
+          ]
+        },
+        {
+          "file": "src/main/browser/system-ssh-socks-client-socket.test.ts",
+          "assertions": [
+            "the internal SOCKS5 client encodes the exact destination as a domain request"
+          ]
+        },
+        {
+          "file": "src/main/ssh/system-ssh-dynamic-forward-process.test.ts",
+          "assertions": [
+            "system SSH uses BatchMode=yes, disables ControlMaster, and positions one dynamic forward before the destination",
+            "authority invalidation cancels an in-progress SSH launch and destroys its active readiness probe immediately"
+          ]
+        },
+        {
+          "file": "src/main/ssh/ssh-port-forward.test.ts",
+          "assertions": [
+            "static system-SSH forwards receive the connection's complete resolved build options"
+          ]
+        },
+        {
+          "file": "tests/e2e/ssh-browser-network-execution-route.docker.unit.test.ts",
+          "assertions": [
+            "an ephemeral sshd resolves a container-only domain and returns a unique HTTP marker",
+            "the real ssh2 forwardOut receives that exact domain and provider loss fences the route",
+            "one non-interactive system-OpenSSH dynamic forward passes the same remote-only oracle and closes cleanly"
           ]
         },
         {
@@ -2771,6 +2841,24 @@
         }
       ],
       "evidenceRuns": [
+        {
+          "date": "2026-08-14",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/browser-host-lease-registry.test.ts src/main/browser/browser-network-deferred-socket.test.ts src/main/browser/browser-network-execution-route.test.ts src/main/browser/paired-runtime-browser-network-route.test.ts src/main/runtime/rpc/methods/browser-network-tunnel.test.ts src/main/browser/ssh-browser-network-execution-route.test.ts src/main/browser/system-ssh-socks-client-socket.test.ts src/main/ssh/system-ssh-dynamic-forward-process.test.ts src/shared/browser-client-host-protocol.test.ts src/shared/browser-network-capabilities.test.ts src/main/ssh/system-ssh-forward-process.test.ts src/main/ssh/ssh-system-fallback.test.ts src/main/ssh/ssh-port-forward.test.ts",
+          "result": "passed",
+          "durationSeconds": 2.6,
+          "summary": "Thirteen files passed 142 structural route-key, native-shape, live lease-bound SSH grant, startup cancellation, diagnostic redaction, deferred-socket release, capability negotiation, exact SSH authority and client, ssh2 forwarding, standalone system-SSH dynamic-forward, active-probe cleanup, static-forward option reuse, internal SOCKS domain, and exact release tests."
+        },
+        {
+          "date": "2026-08-14",
+          "runner": "local",
+          "platform": "macos",
+          "command": "ORCA_RUN_DOCKER_SSH_BROWSER_E2E=1 pnpm exec vitest run --config config/vitest.config.ts tests/e2e/ssh-browser-network-execution-route.docker.unit.test.ts",
+          "result": "passed",
+          "durationSeconds": 1.3,
+          "summary": "Two tests passed: an ephemeral Linux sshd resolved remote-only.internal and returned the sta-4150-remote-only HTTP marker over real ssh2 forwardOut and one real system-OpenSSH dynamic forward; the ssh2 route also fenced on authority invalidation."
+        },
         {
           "date": "2026-08-14",
           "runner": "local",
@@ -2836,17 +2924,18 @@
       },
       "redGreenEvidence": {
         "status": "partial",
-        "evidence": "The protocol and tunnel-session oracles fail on origin/main 3246b73add because the modules do not exist, then pass on the candidate. The lease registry and control-client suites were recorded red at missing modules before implementation. The unchanged tunnel authorization oracle was behaviorally red because an authenticated socket could self-assert its paired device ID and received ready generation 7 without a lease; it is green after server-owned lease and route fencing. On c9a41abf24, the unchanged admission oracle failed three ways: a second identity on one connection and a fifth identity for one paired device were both admitted, and closed page placement had no retirement API. All three pass after bounded admission and tombstone-free global page generations. On parent 392d13be9f, the deterministic resource oracle admitted 17 pending opens, admitted a 129th open inside 10 seconds, and retained more than 8 MiB across one route; all three failed assertions pass on the candidate, which also covers unsettled writes and reentrant exact release. With aggregate enforcement replaced by a no-op scaffold on parent b32610e365, all three host/process memory assertions failed: host bytes, process bytes, claims, and socket sources were independently unbounded. They pass with exact owner release, client and execution-host application charging, encrypted queue/native socket charging, and bounded drain. On parent a089829521, stream exhaustion was not distinguishable, transport loss closed the local listener with ECONNREFUSED, reconnect opened no replacement subscription, and a ready generation that closed before await continuation could be replayed. The initial reconnect candidate also retained a dead transport after a client-side protocol failure and therefore refused replacement. The reviewed candidate keeps one fail-closed address, propagates protocol closure, strictly fences observed generations, ignores superseded callbacks, and recycles stream IDs only after replacement while preserving the v1 attach shape. The real paired journey failed at the missing network.browserTunnel method before explicit test injection, then passed with an exact control lease while both production registries remained closed. Full mutation/revert evidence remains to be collected before promotion."
+        "evidence": "The protocol and tunnel-session oracles fail on origin/main 3246b73add because the modules do not exist, then pass on the candidate. The lease registry and control-client suites were recorded red at missing modules before implementation. The unchanged tunnel authorization oracle was behaviorally red because an authenticated socket could self-assert its paired device ID and received ready generation 7 without a lease; it is green after server-owned lease and route fencing. On c9a41abf24, the unchanged admission oracle failed three ways: a second identity on one connection and a fifth identity for one paired device were both admitted, and closed page placement had no retirement API. All three pass after bounded admission and tombstone-free global page generations. On parent 392d13be9f, the deterministic resource oracle admitted 17 pending opens, admitted a 129th open inside 10 seconds, and retained more than 8 MiB across one route; all three failed assertions pass on the candidate, which also covers unsettled writes and reentrant exact release. With aggregate enforcement replaced by a no-op scaffold on parent b32610e365, all three host/process memory assertions failed: host bytes, process bytes, claims, and socket sources were independently unbounded. They pass with exact owner release, client and execution-host application charging, encrypted queue/native socket charging, and bounded drain. On parent a089829521, stream exhaustion was not distinguishable, transport loss closed the local listener with ECONNREFUSED, reconnect opened no replacement subscription, and a ready generation that closed before await continuation could be replayed. The initial reconnect candidate also retained a dead transport after a client-side protocol failure and therefore refused replacement. The reviewed candidate keeps one fail-closed address, propagates protocol closure, strictly fences observed generations, ignores superseded callbacks, and recycles stream IDs only after replacement while preserving the v1 attach shape. Parent 9889adf4c5 accepts only a native executionHost schema and its handler unconditionally reads native runtimeId and revision; widening the schema made node typecheck fail at those exact assumptions before adapter integration. The candidate keeps native subscription bytes and capabilities unchanged, capability-gates SSH, rejects stale authority before binary registration, and passes exact domains through both adapter contracts. Before the reviewed authorization and lifecycle fix, 10 of 34 focused assertions failed: an ungranted SSH key reached the resolver, grants did not exist, native routes exposed a global never-settling invalidation promise, pre-attach destroy emitted no close, synchronous forwardOut escaped without cleanup, OpenSSH did not force a standalone process, and raw connector detail crossed the RPC boundary. The same 34 assertions pass with exact tokenized grants, optional native invalidation, one-close deferred sockets, caught synchronous opens, standalone OpenSSH, and stable public errors. The real paired journey failed at the missing network.browserTunnel method before explicit test injection, then passed with an exact control lease while both production registries remained closed. Full mutation/revert evidence remains to be collected before promotion."
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "Data frames, send credit, pending bytes and chunk counts in both directions, streams, SOCKS handshake, and pipelined application bytes are bounded. Each route admits at most 16 pending opens, 128 opens per monotonic 10-second window, and 8 MiB of session-owned queued or unsettled application bytes with exact settlement and retirement release. Multiple client routes share a 32 MiB browser-host and 128 MiB process ceiling across application copies, encrypted queue frames, and dynamic native socket buffers; the execution runtime uses the same per-host/process application policy. Claims, socket sources, host records, and leases have independent count caps; explicit close releases JavaScript queue claims synchronously while native socket ownership remains charged until exact socket close. Parked encrypted queues hand at most four frames to the native socket per immediate cooperative drain turn. One authenticated connection retains at most one browser host and one paired device at most four, with exact release restoring admission. Permanent browser-host polls use at most one quarter of the shared long-poll slots, and real injected dispatch proves an ordinary wait remains admitted and socket close releases both classes. Credit returns only after the execution-host or browser-facing socket write settles, and the injected transport must explicitly accept each frame. Node stream-internal high-water bytes and strict cross-route scheduling evidence remain required before live tunnel advertisement."
+        "evidence": "Data frames, send credit, pending bytes and chunk counts in both directions, streams, SOCKS handshake, and pipelined application bytes are bounded. Each route admits at most 16 pending opens, 128 opens per monotonic 10-second window, and 8 MiB of session-owned queued or unsettled application bytes with exact settlement and retirement release. Multiple client routes share a 32 MiB browser-host and 128 MiB process ceiling across application copies, encrypted queue frames, and dynamic native socket buffers; the execution runtime uses the same per-host/process application policy. Claims, socket sources, host records, and leases have independent count caps; explicit close releases JavaScript queue claims synchronously while native socket ownership remains charged until exact socket close. Parked encrypted queues hand at most four frames to the native socket per immediate cooperative drain turn. One authenticated connection retains at most one browser host and one paired device at most four, with exact release restoring admission. Permanent browser-host polls use at most one quarter of the shared long-poll slots, and real injected dispatch proves an ordinary wait remains admitted and socket close releases both classes. Each SSH route owns one ssh2 authority or one standalone system-SSH dynamic-forward process, keeps at most 64 KiB of stderr tail, and releases every adapter/socket on exact route close or provider rotation. The system-SSH process exposes a separate no-auth loopback SOCKS listener outside application stream/rate/memory accounting, so it remains an explicit activation blocker. Credit returns only after the execution-host or browser-facing socket write settles, and the injected transport must explicitly accept each frame. Node stream-internal high-water bytes and strict cross-route scheduling evidence remain required before live tunnel advertisement."
       },
       "promotionCriteria": [
         "Charge Node stream-internal high-water bytes and prove cross-route fairness under slow physical links; add a strict scheduler if the four-frame yield quantum is insufficient.",
         "Approve all same-host local processes and users as inside the desktop trust boundary or replace SOCKS no-auth with Chromium-compatible process isolation.",
+        "Isolate or authenticate the system-SSH dynamic SOCKS listener, prove the bound listener belongs to the owned child, and preserve authenticated ControlMaster-only targets without persistent forwarding.",
         "Add old/new peer coverage to the dedicated paired-runtime binary tunnel journey.",
-        "Add SSH2, system SSH, WSL, Linux, and physical Windows evidence.",
+        "Add WSL, headed Linux, and physical Windows evidence.",
         "Prove an Electron partition routes loopback, DNS, HTTP, HTTPS, WebSocket, workers, and speculative traffic without desktop fallback."
       ],
       "knownGaps": [
@@ -2855,9 +2944,12 @@
         "Application, encrypted queue, and native WebSocket bytes are aggregated, but Node stream-internal high-water bytes are only per-stream bounded and not charged to the host/process ledger.",
         "A four-frame queued-drain quantum yields between timers, but strict cross-route fairness and slow-link soak evidence are not complete.",
         "The loopback SOCKS endpoint uses Chromium-compatible no-auth and is not safe to activate until its desktop trust boundary is approved or isolated.",
-        "SSH, WSL, browserless serve, Electron proxy policy, UDP denial, and desktop DNS/socket capture are not exercised."
+        "The system-SSH adapter opens another no-auth loopback SOCKS listener outside tunnel accounting; its release-and-bind port can be claimed by a sibling process, and readiness proves only that some TCP listener answered.",
+        "Standalone system-SSH cleanup is exact, but targets that require an already-authenticated ControlMaster, passphrase, PIN, or keyboard-interactive prompt can fail non-interactive route startup.",
+        "Execution-host grant keys are not independently capped or ref-counted; activation requires one server-owned page or partition lifetime and bounded per-lease grant admission.",
+        "SSH2 and system OpenSSH have isolated Docker evidence, but WSL, browserless serve, Electron proxy policy, UDP denial, and desktop DNS/socket capture are not exercised."
       ],
-      "demotionRule": "Keep experimental or demote if a self-asserted or ambiguous host can receive a route, late cleanup can remove a replacement, a route can resolve names on the desktop, exceed a byte or stream bound, replenish credit before destination settlement, accept a stale or non-increasing generation, reuse a stream ID within one generation, lose or bypass its fail-closed listener during reconnect, expose the SOCKS listener off-loopback, accept BIND/UDP, or fall back when the selected route is unavailable."
+      "demotionRule": "Keep experimental or demote if a self-asserted or ambiguous host can receive a route, an SSH descriptor bypasses capability, lease-bound grant, or provider-authority checks, late cleanup can remove a replacement, a route can resolve names on the desktop, exceed a byte or stream bound, replenish credit before destination settlement, accept a stale or non-increasing generation, reuse a stream ID within one generation, lose or bypass its fail-closed listener during reconnect, expose the SOCKS listener off-loopback, accept BIND/UDP, or fall back when the selected route is unavailable."
     },
     {
       "id": "browser-stream.bounded-reconnect",

--- a/src/main/browser/browser-network-deferred-socket.test.ts
+++ b/src/main/browser/browser-network-deferred-socket.test.ts
@@ -1,0 +1,32 @@
+import { PassThrough } from 'node:stream'
+import { describe, expect, it, vi } from 'vitest'
+import { BrowserNetworkDeferredSocket } from './browser-network-deferred-socket'
+
+describe('BrowserNetworkDeferredSocket', () => {
+  it('emits close once when destroyed before its source attaches', () => {
+    const socket = new BrowserNetworkDeferredSocket()
+    const source = new PassThrough()
+    const onClose = vi.fn()
+    socket.on('close', onClose)
+
+    socket.destroy()
+    socket.attach(source)
+    source.emit('close')
+
+    expect(onClose).toHaveBeenCalledOnce()
+    expect(source.destroyed).toBe(true)
+  })
+
+  it('emits one close when an attached source closes after destroy', async () => {
+    const socket = new BrowserNetworkDeferredSocket()
+    const source = new PassThrough()
+    const onClose = vi.fn()
+    socket.on('close', onClose)
+    socket.attach(source)
+
+    socket.destroy()
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/browser/browser-network-deferred-socket.ts
+++ b/src/main/browser/browser-network-deferred-socket.ts
@@ -1,0 +1,100 @@
+import { EventEmitter } from 'node:events'
+import type { Duplex } from 'node:stream'
+import type { BrowserNetworkTunnelSocket } from './browser-network-tunnel-stream-state'
+
+type DeferredSocketSource = Duplex & { setNoDelay?: (noDelay?: boolean) => unknown }
+
+export class BrowserNetworkDeferredSocket
+  extends EventEmitter
+  implements BrowserNetworkTunnelSocket
+{
+  destroyed = false
+  private source: DeferredSocketSource | null = null
+  private paused = false
+  private noDelay = false
+  private closeEmitted = false
+
+  attach(source: DeferredSocketSource): void {
+    if (this.destroyed || this.source) {
+      source.destroy()
+      return
+    }
+    this.source = source
+    source.setNoDelay?.(this.noDelay)
+    source.on('data', (bytes) => this.emit('data', bytes))
+    source.on('end', () => this.emit('end'))
+    source.on('close', () => {
+      this.destroyed = true
+      this.emitClose()
+    })
+    source.on('error', (error) => this.emit('error', error))
+    if (this.paused) {
+      source.pause()
+    } else {
+      source.resume()
+    }
+    queueMicrotask(() => {
+      if (!this.destroyed && this.source === source) {
+        this.emit('connect')
+      }
+    })
+  }
+
+  fail(error: Error): void {
+    if (this.destroyed) {
+      return
+    }
+    this.destroyed = true
+    this.emit('error', error)
+    this.emitClose()
+  }
+
+  setNoDelay(noDelay = true): this {
+    this.noDelay = noDelay
+    this.source?.setNoDelay?.(noDelay)
+    return this
+  }
+
+  pause(): this {
+    this.paused = true
+    this.source?.pause()
+    return this
+  }
+
+  resume(): this {
+    this.paused = false
+    this.source?.resume()
+    return this
+  }
+
+  write(bytes: Uint8Array<ArrayBufferLike>, callback?: () => void): boolean {
+    if (!this.source || this.destroyed) {
+      callback?.()
+      return false
+    }
+    return this.source.write(bytes, callback)
+  }
+
+  end(): this {
+    this.source?.end()
+    return this
+  }
+
+  destroy(): this {
+    if (this.destroyed) {
+      return this
+    }
+    this.destroyed = true
+    this.source?.destroy()
+    this.emitClose()
+    return this
+  }
+
+  private emitClose(): void {
+    if (this.closeEmitted) {
+      return
+    }
+    this.closeEmitted = true
+    this.emit('close')
+  }
+}

--- a/src/main/browser/browser-network-execution-route.test.ts
+++ b/src/main/browser/browser-network-execution-route.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import {
+  browserNetworkExecutionHostKey,
+  resolveNativeBrowserNetworkExecutionRoute
+} from './browser-network-execution-route'
+
+describe('browser network execution route', () => {
+  it('uses structural keys for delimiter-containing execution-host identities', () => {
+    const first = browserNetworkExecutionHostKey({
+      kind: 'ssh',
+      targetId: 'a:b',
+      providerEpoch: 'c',
+      connectionGeneration: 2
+    })
+    const second = browserNetworkExecutionHostKey({
+      kind: 'ssh',
+      targetId: 'a',
+      providerEpoch: 'b:c',
+      connectionGeneration: 2
+    })
+
+    expect(first).not.toBe(second)
+  })
+
+  it('accepts only this runtime native revision', () => {
+    const route = resolveNativeBrowserNetworkExecutionRoute({
+      executionHost: { kind: 'native', runtimeId: 'runtime-a', revision: 2 },
+      runtimeId: 'runtime-a',
+      runtimeRevision: 2
+    })
+
+    expect(route.key).toBe('["native","runtime-a",2]')
+    expect(route.whenInvalidated).toBeUndefined()
+    expect(() =>
+      resolveNativeBrowserNetworkExecutionRoute({
+        executionHost: { kind: 'native', runtimeId: 'runtime-a', revision: 1 },
+        runtimeId: 'runtime-a',
+        runtimeRevision: 2
+      })
+    ).toThrow('browser_tunnel_execution_host_mismatch')
+  })
+})

--- a/src/main/browser/browser-network-execution-route.ts
+++ b/src/main/browser/browser-network-execution-route.ts
@@ -1,0 +1,49 @@
+import { connect } from 'node:net'
+import type { BrowserNetworkExecutionHost } from '../../shared/browser-client-host-protocol'
+import type { BrowserNetworkTunnelOpen } from '../../shared/browser-network-tunnel-protocol'
+import type { BrowserNetworkTunnelSocket } from './browser-network-tunnel-stream-state'
+
+export type BrowserNetworkExecutionRoute = {
+  key: string
+  connect: (target: BrowserNetworkTunnelOpen) => BrowserNetworkTunnelSocket
+  whenInvalidated?: Promise<void>
+  isValid: () => boolean
+  close: () => void | Promise<void>
+}
+
+export type BrowserNetworkExecutionRouteContext = {
+  executionHost: BrowserNetworkExecutionHost
+  runtimeId: string
+  runtimeRevision: number
+  signal?: AbortSignal
+}
+
+export type BrowserNetworkExecutionRouteResolver = (
+  context: BrowserNetworkExecutionRouteContext
+) => Promise<BrowserNetworkExecutionRoute>
+
+export function browserNetworkExecutionHostKey(host: BrowserNetworkExecutionHost): string {
+  if (host.kind === 'native') {
+    return JSON.stringify(['native', host.runtimeId, host.revision])
+  }
+  return JSON.stringify(['ssh', host.targetId, host.providerEpoch, host.connectionGeneration])
+}
+
+export function resolveNativeBrowserNetworkExecutionRoute(
+  context: BrowserNetworkExecutionRouteContext
+): BrowserNetworkExecutionRoute {
+  const host = context.executionHost
+  if (
+    host.kind !== 'native' ||
+    host.runtimeId !== context.runtimeId ||
+    host.revision !== context.runtimeRevision
+  ) {
+    throw new Error('browser_tunnel_execution_host_mismatch')
+  }
+  return {
+    key: browserNetworkExecutionHostKey(host),
+    connect: (target) => connect({ ...target, allowHalfOpen: true }),
+    isValid: () => true,
+    close: () => {}
+  }
+}

--- a/src/main/browser/paired-runtime-browser-network-route.test.ts
+++ b/src/main/browser/paired-runtime-browser-network-route.test.ts
@@ -6,6 +6,7 @@ import {
   decodeBrowserNetworkTunnelFrame,
   encodeBrowserNetworkTunnelFrame
 } from '../../shared/browser-network-tunnel-protocol'
+import type { BrowserNetworkExecutionHost } from '../../shared/browser-client-host-protocol'
 import type { PairingOffer } from '../../shared/pairing'
 import type {
   RemoteRuntimeSubscription,
@@ -306,6 +307,34 @@ describe('PairedRuntimeBrowserNetworkRoute', () => {
     await route.close()
   })
 
+  it('negotiates execution-host routing only for an SSH descriptor', async () => {
+    const attempts = mockSubscriptionAttempts()
+    const executionHost = {
+      kind: 'ssh' as const,
+      targetId: 'target-a',
+      providerEpoch: 'provider-epoch-a',
+      connectionGeneration: 2
+    }
+    const route = createRoute({ executionHost })
+    const starting = route.start()
+    await vi.waitFor(() => expect(attempts).toHaveLength(1))
+    ready(attempts[0]!, 7)
+    await starting
+
+    expect(attempts[0]).toMatchObject({
+      method: 'network.browserTunnel',
+      params: { ...lease, executionHost },
+      options: {
+        clientCapabilities: [
+          'browser.clientHost.v1',
+          'network.browserTunnel.v1',
+          'network.browserTunnel.executionHosts.v1'
+        ]
+      }
+    })
+    await route.close()
+  })
+
   it('ignores late callbacks from a superseded transport', async () => {
     const attempts = mockSubscriptionAttempts()
     const route = createRoute()
@@ -476,6 +505,7 @@ function createRoute(
     outboundMemoryBudgetRegistry?: BrowserNetworkTunnelOutboundMemoryBudgetRegistry
     maxStreamIdsPerTunnel?: number
     subscription?: RemoteRuntimeSubscriptionOptions
+    executionHost?: BrowserNetworkExecutionHost
   } = {}
 ): PairedRuntimeBrowserNetworkRoute {
   return new PairedRuntimeBrowserNetworkRoute({

--- a/src/main/browser/paired-runtime-browser-network-route.ts
+++ b/src/main/browser/paired-runtime-browser-network-route.ts
@@ -1,4 +1,7 @@
-import type { BrowserHostLeaseAuthority } from '../../shared/browser-client-host-protocol'
+import type {
+  BrowserHostLeaseAuthority,
+  BrowserNetworkExecutionHost
+} from '../../shared/browser-client-host-protocol'
 import type { BrowserNetworkTunnelOpen } from '../../shared/browser-network-tunnel-protocol'
 import type { PairingOffer } from '../../shared/pairing'
 import type { RemoteRuntimeSubscriptionOptions } from '../../shared/remote-runtime-client'
@@ -15,6 +18,7 @@ type PairedRuntimeBrowserNetworkRouteOptions = {
   pairing: PairingOffer
   lease: BrowserHostLeaseAuthority
   executionHostRevision: number
+  executionHost?: BrowserNetworkExecutionHost
   timeoutMs?: number
   subscription?: RemoteRuntimeSubscriptionOptions
   outboundMemoryBudgetRegistry?: BrowserNetworkTunnelOutboundMemoryBudgetRegistry
@@ -112,7 +116,11 @@ export class PairedRuntimeBrowserNetworkRoute {
     const transport = new PairedRuntimeBrowserNetworkTransport({
       pairing: this.options.pairing,
       lease: this.options.lease,
-      executionHostRevision: this.options.executionHostRevision,
+      executionHost: this.options.executionHost ?? {
+        kind: 'native',
+        runtimeId: this.options.lease.authorityRuntimeId,
+        revision: this.options.executionHostRevision
+      },
       timeoutMs: this.options.timeoutMs ?? 15_000,
       subscription: this.options.subscription,
       outboundMemory,

--- a/src/main/browser/paired-runtime-browser-network-transport.ts
+++ b/src/main/browser/paired-runtime-browser-network-transport.ts
@@ -1,6 +1,7 @@
 import {
   BrowserNetworkTunnelEvent,
-  type BrowserHostLeaseAuthority
+  type BrowserHostLeaseAuthority,
+  type BrowserNetworkExecutionHost
 } from '../../shared/browser-client-host-protocol'
 import type { PairingOffer } from '../../shared/pairing'
 import {
@@ -11,6 +12,7 @@ import {
 import { RemoteRuntimeClientError } from '../../shared/remote-runtime-client-error'
 import {
   BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY,
+  BROWSER_NETWORK_EXECUTION_HOSTS_RUNTIME_CAPABILITY,
   BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY
 } from '../../shared/protocol-version'
 import { BrowserNetworkTunnelClient } from './browser-network-tunnel-client'
@@ -22,7 +24,7 @@ const BROWSER_TUNNEL_WS_MAX_QUEUED_BYTES = 7 * 1024 * 1024
 type PairedRuntimeBrowserNetworkTransportOptions = {
   pairing: PairingOffer
   lease: BrowserHostLeaseAuthority
-  executionHostRevision: number
+  executionHost: BrowserNetworkExecutionHost
   timeoutMs: number
   subscription?: RemoteRuntimeSubscriptionOptions
   outboundMemory: BrowserNetworkTunnelOutboundMemoryLease
@@ -96,11 +98,7 @@ export class PairedRuntimeBrowserNetworkTransport {
         'network.browserTunnel',
         {
           ...this.options.lease,
-          executionHost: {
-            kind: 'native',
-            runtimeId: this.options.lease.authorityRuntimeId,
-            revision: this.options.executionHostRevision
-          }
+          executionHost: this.options.executionHost
         },
         this.options.timeoutMs,
         {
@@ -166,7 +164,10 @@ export class PairedRuntimeBrowserNetworkTransport {
           clientCapabilities: [
             ...(this.options.subscription?.clientCapabilities ?? []),
             BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY,
-            BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY
+            BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY,
+            ...(this.options.executionHost.kind === 'native'
+              ? []
+              : [BROWSER_NETWORK_EXECUTION_HOSTS_RUNTIME_CAPABILITY])
           ]
         }
       )

--- a/src/main/browser/ssh-browser-network-execution-route.test.ts
+++ b/src/main/browser/ssh-browser-network-execution-route.test.ts
@@ -1,0 +1,236 @@
+import { EventEmitter, once } from 'node:events'
+import type { ChildProcess } from 'node:child_process'
+import { PassThrough } from 'node:stream'
+import { describe, expect, it, vi } from 'vitest'
+import type { SshConnection } from '../ssh/ssh-connection'
+import type { SshProviderEpoch } from '../../shared/ssh-types'
+import { resolveSshBrowserNetworkExecutionRoute } from './ssh-browser-network-execution-route'
+
+const executionHost = {
+  kind: 'ssh' as const,
+  targetId: 'target-a',
+  providerEpoch: 'provider-epoch-a',
+  connectionGeneration: 2
+}
+
+function fakeConnection(client: unknown): SshConnection {
+  return {
+    getState: () => ({
+      targetId: 'target-a',
+      status: 'connected',
+      error: null,
+      reconnectAttempt: 0
+    }),
+    getClient: () => client,
+    usesSystemSshTransport: () => client === null,
+    getTarget: () => ({
+      id: 'target-a',
+      label: 'Target A',
+      host: 'ssh.example.com',
+      port: 22,
+      username: 'orca'
+    }),
+    getSystemSshBuildArgsOptions: () => ({})
+  } as unknown as SshConnection
+}
+
+describe('SSH browser network execution route', () => {
+  it('rejects an unavailable or stale authority before opening a destination', async () => {
+    const connection = fakeConnection({ forwardOut: vi.fn() })
+    const registerAuthorityAbort = vi.fn()
+
+    await expect(
+      resolveSshBrowserNetworkExecutionRoute(
+        { executionHost, runtimeId: 'runtime-a', runtimeRevision: 1 },
+        {
+          connectionManager: { getConnection: () => connection },
+          isCurrentAuthority: () => false,
+          registerAuthorityAbort
+        }
+      )
+    ).rejects.toThrow('browser_tunnel_execution_host_unavailable')
+    expect(registerAuthorityAbort).not.toHaveBeenCalled()
+  })
+
+  it('passes the exact domain and port to ssh2 forwardOut and fences rotation', async () => {
+    const channel = new PassThrough() as PassThrough & { close: ReturnType<typeof vi.fn> }
+    channel.close = vi.fn(() => channel.destroy())
+    const forwardOut = vi.fn(
+      (
+        _sourceHost: string,
+        _sourcePort: number,
+        _host: string,
+        _port: number,
+        callback: (error: Error | undefined, channel: PassThrough) => void
+      ) => callback(undefined, channel)
+    )
+    const connection = fakeConnection({ forwardOut })
+    let current = true
+    let authorityAbort: AbortController | undefined
+    const removeAuthorityAbort = vi.fn()
+    const route = await resolveSshBrowserNetworkExecutionRoute(
+      { executionHost, runtimeId: 'runtime-a', runtimeRevision: 1 },
+      {
+        connectionManager: { getConnection: () => connection },
+        isCurrentAuthority: (authority) =>
+          current &&
+          authority.providerEpoch === ('provider-epoch-a' as SshProviderEpoch) &&
+          authority.connectionGeneration === 2,
+        registerAuthorityAbort: (_authority, controller) => {
+          authorityAbort = controller
+          return removeAuthorityAbort
+        }
+      }
+    )
+
+    const socket = route.connect({ host: 'split-horizon.internal', port: 8443 })
+    await once(socket as unknown as EventEmitter, 'connect')
+    expect(forwardOut).toHaveBeenCalledWith(
+      '127.0.0.1',
+      0,
+      'split-horizon.internal',
+      8443,
+      expect.any(Function)
+    )
+
+    current = false
+    authorityAbort?.abort()
+    await route.whenInvalidated
+    expect(route.isValid()).toBe(false)
+    await route.close()
+    await route.close()
+    expect(removeAuthorityAbort).toHaveBeenCalledOnce()
+    expect(socket.destroyed).toBe(true)
+  })
+
+  it('does not adopt a replacement ssh2 client under the captured authority', async () => {
+    const firstForwardOut = vi.fn()
+    const secondForwardOut = vi.fn()
+    let client = { forwardOut: firstForwardOut }
+    const connection = {
+      getState: () => ({
+        targetId: 'target-a',
+        status: 'connected',
+        error: null,
+        reconnectAttempt: 0
+      }),
+      getClient: () => client,
+      usesSystemSshTransport: () => false
+    } as unknown as SshConnection
+    const route = await resolveSshBrowserNetworkExecutionRoute(
+      { executionHost, runtimeId: 'runtime-a', runtimeRevision: 1 },
+      {
+        connectionManager: { getConnection: () => connection },
+        isCurrentAuthority: () => true,
+        registerAuthorityAbort: () => () => {}
+      }
+    )
+
+    client = { forwardOut: secondForwardOut }
+    const socket = route.connect({ host: 'must-not-open.internal', port: 443 })
+    socket.on('error', () => {})
+    await vi.waitFor(() => expect(socket.destroyed).toBe(true))
+
+    expect(route.isValid()).toBe(false)
+    expect(firstForwardOut).not.toHaveBeenCalled()
+    expect(secondForwardOut).not.toHaveBeenCalled()
+    await route.close()
+  })
+
+  it('releases a deferred socket when forwardOut throws during disconnect', async () => {
+    const forwardOut = vi.fn(() => {
+      throw new Error('Not connected')
+    })
+    const connection = fakeConnection({ forwardOut })
+    const route = await resolveSshBrowserNetworkExecutionRoute(
+      { executionHost, runtimeId: 'runtime-a', runtimeRevision: 1 },
+      {
+        connectionManager: { getConnection: () => connection },
+        isCurrentAuthority: () => true,
+        registerAuthorityAbort: () => () => {}
+      }
+    )
+    const socket = route.connect({ host: 'remote-only.internal', port: 443 })
+    socket.on('error', () => {})
+    const close = vi.fn()
+    socket.on('close', close)
+
+    await vi.waitFor(() => expect(close).toHaveBeenCalledOnce())
+    expect(socket.destroyed).toBe(true)
+    await route.close()
+    expect(close).toHaveBeenCalledOnce()
+  })
+
+  it('owns one system dynamic forward for the whole execution route', async () => {
+    const connection = fakeConnection(null)
+    const process = new EventEmitter() as EventEmitter & {
+      exitCode: number | null
+      signalCode: NodeJS.Signals | null
+    }
+    process.exitCode = null
+    process.signalCode = null
+    const dispose = vi.fn()
+    const close = vi.fn(async () => {})
+    const startDynamicForward = vi.fn(async () => ({
+      localPort: 45678,
+      process: process as unknown as ChildProcess,
+      stderrTail: () => '',
+      dispose,
+      close
+    }))
+    const route = await resolveSshBrowserNetworkExecutionRoute(
+      { executionHost, runtimeId: 'runtime-a', runtimeRevision: 1 },
+      {
+        connectionManager: { getConnection: () => connection },
+        isCurrentAuthority: () => true,
+        registerAuthorityAbort: () => () => {},
+        startDynamicForward
+      }
+    )
+
+    expect(startDynamicForward).toHaveBeenCalledOnce()
+    process.emit('error', new Error('dynamic forward failed'))
+    await route.whenInvalidated
+    expect(route.isValid()).toBe(false)
+    await route.close()
+    await route.close()
+    expect(dispose).toHaveBeenCalledOnce()
+    expect(close).toHaveBeenCalledOnce()
+  })
+
+  it('aborts system SSH startup when route authorization is revoked', async () => {
+    const connection = fakeConnection(null)
+    const controller = new AbortController()
+    const removeAuthorityAbort = vi.fn()
+    const startDynamicForward = vi.fn(
+      async (_connection: SshConnection, signal: AbortSignal) =>
+        new Promise<never>((_resolve, reject) =>
+          signal.addEventListener(
+            'abort',
+            () => reject(new Error('system_ssh_dynamic_forward_aborted')),
+            { once: true }
+          )
+        )
+    )
+    const resolving = resolveSshBrowserNetworkExecutionRoute(
+      {
+        executionHost,
+        runtimeId: 'runtime-a',
+        runtimeRevision: 1,
+        signal: controller.signal
+      },
+      {
+        connectionManager: { getConnection: () => connection },
+        isCurrentAuthority: () => true,
+        registerAuthorityAbort: () => removeAuthorityAbort,
+        startDynamicForward
+      }
+    )
+    await vi.waitFor(() => expect(startDynamicForward).toHaveBeenCalledOnce())
+
+    controller.abort()
+
+    await expect(resolving).rejects.toThrow('system_ssh_dynamic_forward_aborted')
+    expect(removeAuthorityAbort).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/browser/ssh-browser-network-execution-route.ts
+++ b/src/main/browser/ssh-browser-network-execution-route.ts
@@ -1,0 +1,240 @@
+import type { DirectSshAuthority, SshProviderEpoch } from '../../shared/ssh-types'
+import type { SshConnection } from '../ssh/ssh-connection'
+import type { SshConnectionManager } from '../ssh/ssh-connection-manager'
+import type { Client as SshClient } from 'ssh2'
+import {
+  startSystemSshDynamicForwardProcess,
+  type SystemSshDynamicForwardProcess
+} from '../ssh/system-ssh-dynamic-forward-process'
+import { BrowserNetworkDeferredSocket } from './browser-network-deferred-socket'
+import {
+  browserNetworkExecutionHostKey,
+  type BrowserNetworkExecutionRoute,
+  type BrowserNetworkExecutionRouteContext
+} from './browser-network-execution-route'
+import type { BrowserNetworkTunnelSocket } from './browser-network-tunnel-stream-state'
+import { SystemSshSocksClientSocket } from './system-ssh-socks-client-socket'
+
+export type SshBrowserNetworkExecutionRouteDependencies = {
+  connectionManager: Pick<SshConnectionManager, 'getConnection'>
+  isCurrentAuthority: (authority: DirectSshAuthority) => boolean
+  registerAuthorityAbort: (authority: DirectSshAuthority, controller: AbortController) => () => void
+  startDynamicForward?: (
+    connection: SshConnection,
+    signal: AbortSignal
+  ) => Promise<SystemSshDynamicForwardProcess>
+}
+
+export async function resolveSshBrowserNetworkExecutionRoute(
+  context: BrowserNetworkExecutionRouteContext,
+  dependencies: SshBrowserNetworkExecutionRouteDependencies
+): Promise<BrowserNetworkExecutionRoute> {
+  const host = context.executionHost
+  if (host.kind !== 'ssh') {
+    throw new Error('browser_tunnel_execution_host_mismatch')
+  }
+  const authority: DirectSshAuthority = {
+    targetId: host.targetId,
+    providerEpoch: host.providerEpoch as SshProviderEpoch,
+    connectionGeneration: host.connectionGeneration
+  }
+  const connection = dependencies.connectionManager.getConnection(host.targetId)
+  if (
+    connection?.getState().status !== 'connected' ||
+    !dependencies.isCurrentAuthority(authority)
+  ) {
+    throw new Error('browser_tunnel_execution_host_unavailable')
+  }
+  const invalidation = new AbortController()
+  const removeAuthorityAbort = dependencies.registerAuthorityAbort(authority, invalidation)
+  const abortFromContext = (): void => invalidation.abort()
+  context.signal?.addEventListener('abort', abortFromContext, { once: true })
+  const releaseInvalidation = (): void => {
+    context.signal?.removeEventListener('abort', abortFromContext)
+    removeAuthorityAbort()
+  }
+  if (context.signal?.aborted) {
+    releaseInvalidation()
+    throw new Error('browser_tunnel_execution_host_stale')
+  }
+  if (!dependencies.isCurrentAuthority(authority)) {
+    releaseInvalidation()
+    throw new Error('browser_tunnel_execution_host_stale')
+  }
+  const base = {
+    key: browserNetworkExecutionHostKey(host),
+    authority,
+    connection,
+    invalidation,
+    releaseInvalidation,
+    dependencies
+  }
+  const client = connection.getClient()
+  if (client) {
+    return createSsh2ExecutionRoute(base, client)
+  }
+  if (!connection.usesSystemSshTransport()) {
+    releaseInvalidation()
+    throw new Error('browser_tunnel_execution_host_unavailable')
+  }
+  return createSystemSshExecutionRoute(base, dependencies.startDynamicForward)
+}
+
+type RouteBase = {
+  key: string
+  authority: DirectSshAuthority
+  connection: SshConnection
+  invalidation: AbortController
+  releaseInvalidation: () => void
+  dependencies: SshBrowserNetworkExecutionRouteDependencies
+}
+
+function createSsh2ExecutionRoute(
+  base: RouteBase,
+  client: SshClient
+): BrowserNetworkExecutionRoute {
+  const sockets = new Set<BrowserNetworkDeferredSocket>()
+  let closed = false
+  const isValid = (): boolean =>
+    !closed &&
+    !base.invalidation.signal.aborted &&
+    base.connection.getClient() === client &&
+    base.connection.getState().status === 'connected' &&
+    base.dependencies.connectionManager.getConnection(base.authority.targetId) ===
+      base.connection &&
+    base.dependencies.isCurrentAuthority(base.authority)
+  const close = (): void => {
+    if (closed) {
+      return
+    }
+    closed = true
+    base.releaseInvalidation()
+    base.invalidation.abort()
+    for (const socket of sockets) {
+      socket.destroy()
+    }
+    sockets.clear()
+  }
+  return {
+    key: base.key,
+    isValid,
+    whenInvalidated: abortPromise(base.invalidation.signal),
+    connect: (target): BrowserNetworkTunnelSocket => {
+      const socket = new BrowserNetworkDeferredSocket()
+      sockets.add(socket)
+      socket.once('close', () => sockets.delete(socket))
+      if (!isValid()) {
+        queueMicrotask(() => socket.fail(new Error('browser_tunnel_execution_host_stale')))
+        return socket
+      }
+      try {
+        client.forwardOut('127.0.0.1', 0, target.host, target.port, (error, channel) => {
+          queueMicrotask(() => {
+            if (error) {
+              socket.fail(error)
+            } else if (!isValid()) {
+              channel.close()
+              socket.fail(new Error('browser_tunnel_execution_host_stale'))
+            } else {
+              socket.attach(channel)
+            }
+          })
+        })
+      } catch (error) {
+        queueMicrotask(() => socket.fail(asError(error)))
+      }
+      return socket
+    },
+    close
+  }
+}
+
+async function createSystemSshExecutionRoute(
+  base: RouteBase,
+  startDynamicForward: SshBrowserNetworkExecutionRouteDependencies['startDynamicForward'] = defaultStartDynamicForward
+): Promise<BrowserNetworkExecutionRoute> {
+  let forward: SystemSshDynamicForwardProcess
+  try {
+    forward = await startDynamicForward(base.connection, base.invalidation.signal)
+  } catch (error) {
+    base.releaseInvalidation()
+    base.invalidation.abort()
+    throw error
+  }
+  const sockets = new Set<SystemSshSocksClientSocket>()
+  let closed = false
+  const isValid = (): boolean =>
+    !closed &&
+    !base.invalidation.signal.aborted &&
+    forward.process.exitCode === null &&
+    forward.process.signalCode === null &&
+    base.connection.getState().status === 'connected' &&
+    base.dependencies.connectionManager.getConnection(base.authority.targetId) ===
+      base.connection &&
+    base.dependencies.isCurrentAuthority(base.authority)
+  const onExit = (): void => base.invalidation.abort()
+  const onError = (): void => base.invalidation.abort()
+  forward.process.once('exit', onExit)
+  forward.process.once('error', onError)
+  if (!isValid()) {
+    forward.process.off('exit', onExit)
+    forward.process.off('error', onError)
+    forward.dispose()
+    await forward.close()
+    base.releaseInvalidation()
+    throw new Error('browser_tunnel_execution_host_stale')
+  }
+  const close = async (): Promise<void> => {
+    if (closed) {
+      return
+    }
+    closed = true
+    base.releaseInvalidation()
+    base.invalidation.abort()
+    forward.process.off('exit', onExit)
+    forward.process.off('error', onError)
+    for (const socket of sockets) {
+      socket.destroy()
+    }
+    sockets.clear()
+    forward.dispose()
+    await forward.close()
+  }
+  return {
+    key: base.key,
+    isValid,
+    whenInvalidated: abortPromise(base.invalidation.signal),
+    connect: (target) => {
+      const socket = new SystemSshSocksClientSocket(forward.localPort, target)
+      sockets.add(socket)
+      socket.once('close', () => sockets.delete(socket))
+      if (!isValid()) {
+        queueMicrotask(() => socket.destroy())
+      }
+      return socket
+    },
+    close
+  }
+}
+
+function defaultStartDynamicForward(
+  connection: SshConnection,
+  signal: AbortSignal
+): Promise<SystemSshDynamicForwardProcess> {
+  return startSystemSshDynamicForwardProcess(
+    connection.getTarget(),
+    connection.getSystemSshBuildArgsOptions(),
+    signal
+  )
+}
+
+function abortPromise(signal: AbortSignal): Promise<void> {
+  if (signal.aborted) {
+    return Promise.resolve()
+  }
+  return new Promise((resolve) => signal.addEventListener('abort', () => resolve(), { once: true }))
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error))
+}

--- a/src/main/browser/system-ssh-socks-client-socket.test.ts
+++ b/src/main/browser/system-ssh-socks-client-socket.test.ts
@@ -1,0 +1,47 @@
+import { once } from 'node:events'
+import { createServer, type AddressInfo, type Socket } from 'node:net'
+import { afterEach, describe, expect, it } from 'vitest'
+import { SystemSshSocksClientSocket } from './system-ssh-socks-client-socket'
+
+const servers: ReturnType<typeof createServer>[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map((server) => new Promise<void>((resolve) => server.close(() => resolve())))
+  )
+})
+
+describe('SystemSshSocksClientSocket', () => {
+  it('carries the exact destination domain through the internal SOCKS handshake', async () => {
+    let accepted: Socket | undefined
+    let request: Buffer | undefined
+    const server = createServer((socket) => {
+      accepted = socket
+      socket.once('data', (greeting) => {
+        expect([...greeting]).toEqual([5, 1, 0])
+        socket.write(new Uint8Array([5, 0]))
+        socket.once('data', (connectRequest) => {
+          request =
+            typeof connectRequest === 'string' ? Buffer.from(connectRequest) : connectRequest
+          socket.write(new Uint8Array([5, 0, 0, 1, 0, 0, 0, 0, 0, 0]))
+        })
+      })
+    })
+    servers.push(server)
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+    const address = server.address() as AddressInfo
+    const socket = new SystemSshSocksClientSocket(address.port, {
+      host: 'split-horizon.internal',
+      port: 8443
+    })
+    socket.on('error', () => {})
+    await once(socket, 'connect')
+
+    const host = new TextEncoder().encode('split-horizon.internal')
+    expect(request).toEqual(
+      Buffer.from([5, 1, 0, 3, host.byteLength, ...host, (8443 >>> 8) & 0xff, 8443 & 0xff])
+    )
+    socket.destroy()
+    accepted?.destroy()
+  })
+})

--- a/src/main/browser/system-ssh-socks-client-socket.ts
+++ b/src/main/browser/system-ssh-socks-client-socket.ts
@@ -1,0 +1,181 @@
+import { EventEmitter } from 'node:events'
+import { connect, type Socket } from 'node:net'
+import type { BrowserNetworkTunnelOpen } from '../../shared/browser-network-tunnel-protocol'
+import type { BrowserNetworkTunnelSocket } from './browser-network-tunnel-stream-state'
+
+const SOCKS_VERSION = 5
+const SOCKS_NO_AUTH = 0
+const SOCKS_CONNECT = 1
+const SOCKS_DOMAIN = 3
+const MAX_HANDSHAKE_BYTES = 512
+
+export class SystemSshSocksClientSocket extends EventEmitter implements BrowserNetworkTunnelSocket {
+  destroyed = false
+  private readonly socket: Socket
+  private readonly connectRequest: Uint8Array
+  private paused = false
+  private handshake: Uint8Array<ArrayBufferLike> = new Uint8Array()
+  private phase: 'method' | 'connect' | 'ready' = 'method'
+
+  constructor(localPort: number, target: BrowserNetworkTunnelOpen) {
+    super()
+    this.connectRequest = encodeConnectRequest(target)
+    this.socket = connect({ host: '127.0.0.1', port: localPort, allowHalfOpen: true })
+    this.socket.once('connect', () => {
+      this.socket.write(new Uint8Array([SOCKS_VERSION, 1, SOCKS_NO_AUTH]))
+    })
+    this.socket.on('data', (bytes) =>
+      this.onHandshakeData(typeof bytes === 'string' ? Buffer.from(bytes) : bytes)
+    )
+    this.socket.on('end', () => this.emit('end'))
+    this.socket.on('close', () => {
+      this.destroyed = true
+      this.emit('close')
+    })
+    this.socket.on('error', (error) => this.emit('error', error))
+  }
+
+  setNoDelay(noDelay = true): this {
+    this.socket.setNoDelay(noDelay)
+    return this
+  }
+
+  pause(): this {
+    this.paused = true
+    if (this.phase === 'ready') {
+      this.socket.pause()
+    }
+    return this
+  }
+
+  resume(): this {
+    this.paused = false
+    if (this.phase === 'ready') {
+      this.socket.resume()
+    }
+    return this
+  }
+
+  write(bytes: Uint8Array<ArrayBufferLike>, callback?: () => void): boolean {
+    if (this.phase !== 'ready' || this.destroyed) {
+      callback?.()
+      return false
+    }
+    return this.socket.write(bytes, callback)
+  }
+
+  end(): this {
+    this.socket.end()
+    return this
+  }
+
+  destroy(): this {
+    this.destroyed = true
+    this.socket.destroy()
+    return this
+  }
+
+  private onHandshakeData(bytes: Buffer): void {
+    if (this.phase === 'ready') {
+      this.emit('data', bytes)
+      return
+    }
+    this.handshake = appendBytes(this.handshake, bytes)
+    if (this.handshake.byteLength > MAX_HANDSHAKE_BYTES) {
+      this.fail(new Error('system_ssh_socks_handshake_overflow'))
+      return
+    }
+    if (this.phase === 'method') {
+      if (this.handshake.byteLength < 2) {
+        return
+      }
+      if (this.handshake[0] !== SOCKS_VERSION || this.handshake[1] !== SOCKS_NO_AUTH) {
+        this.fail(new Error('system_ssh_socks_auth_rejected'))
+        return
+      }
+      this.handshake = this.handshake.slice(2)
+      this.phase = 'connect'
+      this.socket.write(this.connectRequest)
+    }
+    this.finishConnectHandshake()
+  }
+
+  private finishConnectHandshake(): void {
+    const replyLength = socksReplyLength(this.handshake)
+    if (replyLength === null) {
+      return
+    }
+    if (
+      replyLength < 0 ||
+      this.handshake[0] !== SOCKS_VERSION ||
+      this.handshake[1] !== 0 ||
+      this.handshake[2] !== 0
+    ) {
+      this.fail(new Error('system_ssh_socks_connect_rejected'))
+      return
+    }
+    const remaining = this.handshake.slice(replyLength)
+    this.handshake = new Uint8Array()
+    this.phase = 'ready'
+    if (this.paused) {
+      this.socket.pause()
+    }
+    this.emit('connect')
+    if (remaining.byteLength > 0) {
+      this.emit('data', remaining)
+    }
+  }
+
+  private fail(error: Error): void {
+    if (this.destroyed) {
+      return
+    }
+    this.emit('error', error)
+    this.socket.destroy()
+  }
+}
+
+function encodeConnectRequest(target: BrowserNetworkTunnelOpen): Uint8Array {
+  const host = new TextEncoder().encode(target.host)
+  if (host.byteLength === 0 || host.byteLength > 255) {
+    throw new Error('system_ssh_socks_target_invalid')
+  }
+  return new Uint8Array([
+    SOCKS_VERSION,
+    SOCKS_CONNECT,
+    0,
+    SOCKS_DOMAIN,
+    host.byteLength,
+    ...host,
+    (target.port >>> 8) & 0xff,
+    target.port & 0xff
+  ])
+}
+
+function socksReplyLength(bytes: Uint8Array<ArrayBufferLike>): number | null {
+  if (bytes.byteLength < 5) {
+    return null
+  }
+  const addressType = bytes[3]
+  if (addressType === 1) {
+    return bytes.byteLength >= 10 ? 10 : null
+  }
+  if (addressType === SOCKS_DOMAIN) {
+    const length = 7 + bytes[4]!
+    return bytes.byteLength >= length ? length : null
+  }
+  if (addressType === 4) {
+    return bytes.byteLength >= 22 ? 22 : null
+  }
+  return -1
+}
+
+function appendBytes(
+  left: Uint8Array<ArrayBufferLike>,
+  right: Uint8Array<ArrayBufferLike>
+): Uint8Array<ArrayBufferLike> {
+  const combined = new Uint8Array(left.byteLength + right.byteLength)
+  combined.set(left)
+  combined.set(right, left.byteLength)
+  return combined
+}

--- a/src/main/runtime/browser-execution-host-grant-registry.ts
+++ b/src/main/runtime/browser-execution-host-grant-registry.ts
@@ -1,0 +1,52 @@
+type GrantState = {
+  token: symbol
+  revocations: Map<symbol, () => void>
+}
+
+export class BrowserExecutionHostGrantRegistry {
+  private readonly grants = new Map<string, GrantState>()
+
+  grant(key: string): { release: () => void } {
+    const existing = this.grants.get(key)
+    if (existing) {
+      this.revoke(key, existing)
+    }
+    const state = { token: Symbol(key), revocations: new Map<symbol, () => void>() }
+    this.grants.set(key, state)
+    return { release: () => this.revoke(key, state) }
+  }
+
+  require(key: string): void {
+    if (!this.grants.has(key)) {
+      throw new Error('browser_tunnel_execution_host_not_granted')
+    }
+  }
+
+  link(key: string, onRevoked: () => void): () => void {
+    const state = this.grants.get(key)
+    if (!state) {
+      throw new Error('browser_tunnel_execution_host_not_granted')
+    }
+    const token = Symbol(key)
+    state.revocations.set(token, onRevoked)
+    return () => state.revocations.delete(token)
+  }
+
+  clear(): void {
+    for (const [key, state] of this.grants) {
+      this.revoke(key, state)
+    }
+  }
+
+  private revoke(key: string, state: GrantState): void {
+    if (this.grants.get(key)?.token !== state.token) {
+      return
+    }
+    this.grants.delete(key)
+    const revocations = [...state.revocations.values()]
+    state.revocations.clear()
+    for (const revoke of revocations) {
+      revoke()
+    }
+  }
+}

--- a/src/main/runtime/browser-host-lease-fence.ts
+++ b/src/main/runtime/browser-host-lease-fence.ts
@@ -1,0 +1,24 @@
+export type BrowserHostFenceReason = 'replaced' | 'released' | 'lease_released' | 'lease_replaced'
+
+export type BrowserHostFence = {
+  promise: Promise<BrowserHostFenceReason>
+  resolve: (reason: BrowserHostFenceReason) => void
+}
+
+export function createBrowserHostFence(): BrowserHostFence {
+  let settled = false
+  let settle = (_reason: BrowserHostFenceReason): void => {}
+  const promise = new Promise<BrowserHostFenceReason>((resolve) => {
+    settle = resolve
+  })
+  return {
+    promise,
+    resolve: (reason) => {
+      if (settled) {
+        return
+      }
+      settled = true
+      settle(reason)
+    }
+  }
+}

--- a/src/main/runtime/browser-host-lease-registry.test.ts
+++ b/src/main/runtime/browser-host-lease-registry.test.ts
@@ -224,4 +224,71 @@ describe('BrowserHostLeaseRegistry', () => {
     await expect(replacementRoute.whenFenced).resolves.toBe('lease_released')
     expect(() => leases.openTunnel(identity)).toThrow('browser_host_lease_required')
   })
+
+  it('grants one exact execution host without letting old cleanup remove a replacement', async () => {
+    const leases = registry()
+    const host = leases.attach({
+      browserHostClientId: 'host-a',
+      connectionId: 'connection-a',
+      pairedDeviceId: 'device-a',
+      hostCapabilities: ['webview']
+    })
+    const identity = {
+      authorityEpoch: 'epoch-a',
+      browserHostClientId: 'host-a',
+      browserHostGeneration: 1,
+      pairedDeviceId: 'device-a'
+    }
+    const first = leases.grantExecutionHost(identity, 'ssh:target-a')
+    const replacement = leases.grantExecutionHost(identity, 'ssh:target-a')
+    const route = leases.openTunnel(
+      { ...identity, executionHostKey: 'ssh:target-a' },
+      { requireExecutionHostGrant: true }
+    )
+
+    first.release()
+    expect(() => leases.requireExecutionHost(identity, 'ssh:target-a')).not.toThrow()
+    expect(() => leases.requireExecutionHost(identity, 'ssh:target-b')).toThrow(
+      'browser_tunnel_execution_host_not_granted'
+    )
+    replacement.release()
+    await expect(route.whenFenced).resolves.toBe('released')
+    expect(() => leases.requireExecutionHost(identity, 'ssh:target-a')).toThrow(
+      'browser_tunnel_execution_host_not_granted'
+    )
+    host.release()
+  })
+
+  it('invalidates execution-host grants with their exact lease generation', () => {
+    const leases = registry()
+    const first = leases.attach({
+      browserHostClientId: 'host-a',
+      connectionId: 'connection-a',
+      pairedDeviceId: 'device-a',
+      hostCapabilities: ['webview']
+    })
+    const firstIdentity = {
+      authorityEpoch: 'epoch-a',
+      browserHostClientId: 'host-a',
+      browserHostGeneration: 1,
+      pairedDeviceId: 'device-a'
+    }
+    const oldGrant = leases.grantExecutionHost(firstIdentity, 'ssh:target-a')
+
+    leases.attach({
+      browserHostClientId: 'host-a',
+      connectionId: 'connection-b',
+      pairedDeviceId: 'device-a',
+      hostCapabilities: ['webview']
+    })
+
+    expect(() => leases.requireExecutionHost(firstIdentity, 'ssh:target-a')).toThrow(
+      'browser_host_lease_stale'
+    )
+    oldGrant.release()
+    first.release()
+    expect(() =>
+      leases.requireExecutionHost({ ...firstIdentity, browserHostGeneration: 2 }, 'ssh:target-a')
+    ).toThrow('browser_tunnel_execution_host_not_granted')
+  })
 })

--- a/src/main/runtime/browser-host-lease-registry.ts
+++ b/src/main/runtime/browser-host-lease-registry.ts
@@ -1,4 +1,10 @@
 import { randomUUID } from 'node:crypto'
+import { BrowserExecutionHostGrantRegistry } from './browser-execution-host-grant-registry'
+import {
+  createBrowserHostFence,
+  type BrowserHostFence,
+  type BrowserHostFenceReason
+} from './browser-host-lease-fence'
 
 const MAX_GENERATION = 0xffff_ffff
 const MAX_BROWSER_HOSTS_PER_CONNECTION = 1
@@ -29,18 +35,12 @@ export type BrowserHostLeaseIdentity = Pick<
   'authorityEpoch' | 'browserHostClientId' | 'browserHostGeneration' | 'pairedDeviceId'
 >
 
-type FenceReason = 'replaced' | 'released' | 'lease_released' | 'lease_replaced'
-
-type Fence = {
-  promise: Promise<FenceReason>
-  resolve: (reason: FenceReason) => void
-}
-
 type LeaseState = {
   token: symbol
   lease: BrowserHostLease
-  fence: Fence
+  fence: BrowserHostFence
   routes: Set<RouteState>
+  executionHostGrants: BrowserExecutionHostGrantRegistry
 }
 
 type RouteState = {
@@ -48,18 +48,19 @@ type RouteState = {
   lease: LeaseState
   key: string
   tunnelGeneration: number
-  fence: Fence
+  fence: BrowserHostFence
+  releaseGrantLink?: () => void
 }
 
 export type BrowserHostLeaseHandle = Readonly<{
   lease: BrowserHostLease
-  whenFenced: Promise<FenceReason>
+  whenFenced: Promise<BrowserHostFenceReason>
   release: () => void
 }>
 
 export type BrowserTunnelLeaseHandle = Readonly<{
   tunnelGeneration: number
-  whenFenced: Promise<FenceReason>
+  whenFenced: Promise<BrowserHostFenceReason>
   release: () => void
 }>
 
@@ -107,8 +108,9 @@ export class BrowserHostLeaseRegistry {
         pairedDeviceId: input.pairedDeviceId,
         hostCapabilities: Object.freeze([...input.hostCapabilities])
       }),
-      fence: createFence(),
-      routes: new Set()
+      fence: createBrowserHostFence(),
+      routes: new Set(),
+      executionHostGrants: new BrowserExecutionHostGrantRegistry()
     }
     this.leasesByClientId.set(input.browserHostClientId, state)
     return {
@@ -136,6 +138,10 @@ export class BrowserHostLeaseRegistry {
   }
 
   requireLease(identity: BrowserHostLeaseIdentity): BrowserHostLease {
+    return this.requireLeaseState(identity).lease
+  }
+
+  private requireLeaseState(identity: BrowserHostLeaseIdentity): LeaseState {
     if (identity.authorityEpoch !== this.authorityEpoch) {
       throw new Error('browser_host_lease_stale')
     }
@@ -149,7 +155,23 @@ export class BrowserHostLeaseRegistry {
     ) {
       throw new Error('browser_host_lease_stale')
     }
-    return state.lease
+    return state
+  }
+
+  grantExecutionHost(identity: BrowserHostLeaseIdentity, executionHostKey: string) {
+    return this.requireLeaseState(identity).executionHostGrants.grant(executionHostKey)
+  }
+
+  requireExecutionHost(identity: BrowserHostLeaseIdentity, executionHostKey: string): void {
+    this.requireLeaseState(identity).executionHostGrants.require(executionHostKey)
+  }
+
+  linkExecutionHostGrant(
+    identity: BrowserHostLeaseIdentity,
+    executionHostKey: string,
+    onRevoked: () => void
+  ): () => void {
+    return this.requireLeaseState(identity).executionHostGrants.link(executionHostKey, onRevoked)
   }
 
   placeServerPage(browserPageId: string): RuntimeBrowserPlacement {
@@ -183,7 +205,8 @@ export class BrowserHostLeaseRegistry {
   }
 
   openTunnel(
-    identity: BrowserHostLeaseIdentity & { executionHostKey: string }
+    identity: BrowserHostLeaseIdentity & { executionHostKey: string },
+    options?: { requireExecutionHostGrant?: boolean }
   ): BrowserTunnelLeaseHandle {
     this.requireLease(identity)
     const lease = this.leasesByClientId.get(identity.browserHostClientId)!
@@ -198,7 +221,12 @@ export class BrowserHostLeaseRegistry {
       lease,
       key,
       tunnelGeneration,
-      fence: createFence()
+      fence: createBrowserHostFence()
+    }
+    if (options?.requireExecutionHostGrant) {
+      state.releaseGrantLink = lease.executionHostGrants.link(identity.executionHostKey, () =>
+        this.fenceRoute(state, 'released')
+      )
     }
     lease.routes.add(state)
     this.routesByKey.set(key, state)
@@ -238,7 +266,7 @@ export class BrowserHostLeaseRegistry {
     }
   }
 
-  private fenceLease(state: LeaseState, reason: FenceReason): void {
+  private fenceLease(state: LeaseState, reason: BrowserHostFenceReason): void {
     if (this.leasesByClientId.get(state.lease.browserHostClientId)?.token !== state.token) {
       return
     }
@@ -246,10 +274,13 @@ export class BrowserHostLeaseRegistry {
     for (const route of state.routes) {
       this.fenceRoute(route, reason === 'replaced' ? 'lease_replaced' : 'lease_released')
     }
+    state.executionHostGrants.clear()
     state.fence.resolve(reason)
   }
 
-  private fenceRoute(state: RouteState, reason: FenceReason): void {
+  private fenceRoute(state: RouteState, reason: BrowserHostFenceReason): void {
+    state.releaseGrantLink?.()
+    state.releaseGrantLink = undefined
     state.lease.routes.delete(state)
     if (this.routesByKey.get(state.key)?.token === state.token) {
       this.routesByKey.delete(state.key)
@@ -291,22 +322,4 @@ export function getBrowserHostLeaseRegistry(runtime: {
     registries.set(runtime, registry)
   }
   return registry
-}
-
-function createFence(): Fence {
-  let settled = false
-  let settle = (_reason: FenceReason): void => {}
-  const promise = new Promise<FenceReason>((resolve) => {
-    settle = resolve
-  })
-  return {
-    promise,
-    resolve: (reason) => {
-      if (settled) {
-        return
-      }
-      settled = true
-      settle(reason)
-    }
-  }
 }

--- a/src/main/runtime/rpc/methods/browser-network-tunnel.test.ts
+++ b/src/main/runtime/rpc/methods/browser-network-tunnel.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
   BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY,
+  BROWSER_NETWORK_EXECUTION_HOSTS_RUNTIME_CAPABILITY,
   BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY
 } from '../../../../shared/protocol-version'
 import {
@@ -9,6 +10,11 @@ import {
 } from '../../browser-host-lease-registry'
 import type { OrcaRuntimeService } from '../../orca-runtime'
 import { BrowserNetworkTunnelOutboundMemoryBudgetRegistry } from '../../../browser/browser-network-tunnel-outbound-memory-budget'
+import {
+  browserNetworkExecutionHostKey,
+  type BrowserNetworkExecutionRoute,
+  type BrowserNetworkExecutionRouteResolver
+} from '../../../browser/browser-network-execution-route'
 import { RpcDispatcher } from '../dispatcher'
 import { ALL_RPC_METHODS } from './index'
 import {
@@ -47,6 +53,22 @@ function attachLease(hostRuntime: OrcaRuntimeService): BrowserHostLease {
     pairedDeviceId: 'device-a',
     hostCapabilities: ['webview']
   }).lease
+}
+
+function grantExecutionHost(
+  hostRuntime: OrcaRuntimeService,
+  lease: BrowserHostLease,
+  executionHost: Parameters<typeof browserNetworkExecutionHostKey>[0]
+) {
+  return getBrowserHostLeaseRegistry(hostRuntime).grantExecutionHost(
+    {
+      authorityEpoch: lease.authorityEpoch,
+      browserHostClientId: lease.browserHostClientId,
+      browserHostGeneration: lease.browserHostGeneration,
+      pairedDeviceId: lease.pairedDeviceId
+    },
+    browserNetworkExecutionHostKey(executionHost)
+  )
 }
 
 const negotiatedCapabilities = [
@@ -93,6 +115,301 @@ describe('network.browserTunnel RPC', () => {
       })
     ])
     expect(registerBinaryMessageHandler).not.toHaveBeenCalled()
+  })
+
+  it('rejects SSH routing without the execution-host capability', async () => {
+    const hostRuntime = runtime()
+    const lease = attachLease(hostRuntime)
+    const dispatcher = new RpcDispatcher({
+      runtime: hostRuntime,
+      methods: BROWSER_NETWORK_TUNNEL_METHODS
+    })
+    const replies: string[] = []
+    const registerBinaryMessageHandler = vi.fn()
+
+    await dispatcher.dispatchStreaming(
+      request(lease, {
+        executionHost: {
+          kind: 'ssh',
+          targetId: 'target-a',
+          providerEpoch: 'provider-epoch-a',
+          connectionGeneration: 2
+        }
+      }),
+      (reply) => replies.push(reply),
+      {
+        connectionId: 'connection-a',
+        clientKind: 'runtime',
+        pairedDeviceId: 'device-a',
+        clientCapabilities: negotiatedCapabilities,
+        sendBinary: vi.fn(() => true),
+        registerBinaryMessageHandler
+      }
+    )
+
+    expect(JSON.parse(replies[0]!)).toEqual(
+      expect.objectContaining({
+        ok: false,
+        error: expect.objectContaining({
+          message: 'browser_tunnel_execution_hosts_capability_required'
+        })
+      })
+    )
+    expect(registerBinaryMessageHandler).not.toHaveBeenCalled()
+  })
+
+  it('rejects an ungranted SSH route before resolver or binary registration', async () => {
+    const hostRuntime = runtime()
+    const lease = attachLease(hostRuntime)
+    grantExecutionHost(hostRuntime, lease, {
+      kind: 'ssh',
+      targetId: 'target-b',
+      providerEpoch: 'provider-epoch-b',
+      connectionGeneration: 1
+    })
+    const resolveExecutionRoute = vi.fn()
+    const dispatcher = new RpcDispatcher({
+      runtime: hostRuntime,
+      methods: createBrowserNetworkTunnelMethods(
+        new BrowserNetworkTunnelOutboundMemoryBudgetRegistry(),
+        resolveExecutionRoute
+      )
+    })
+    const replies: string[] = []
+    const registerBinaryMessageHandler = vi.fn()
+
+    await dispatcher.dispatchStreaming(
+      request(lease, {
+        executionHost: {
+          kind: 'ssh',
+          targetId: 'target-a',
+          providerEpoch: 'provider-epoch-a',
+          connectionGeneration: 2
+        }
+      }),
+      (reply) => replies.push(reply),
+      {
+        connectionId: 'connection-a',
+        clientKind: 'runtime',
+        pairedDeviceId: 'device-a',
+        clientCapabilities: [
+          ...negotiatedCapabilities,
+          BROWSER_NETWORK_EXECUTION_HOSTS_RUNTIME_CAPABILITY
+        ],
+        sendBinary: vi.fn(() => true),
+        registerBinaryMessageHandler
+      }
+    )
+
+    expect(JSON.parse(replies[0]!).error.message).toBe('browser_tunnel_execution_host_not_granted')
+    expect(resolveExecutionRoute).not.toHaveBeenCalled()
+    expect(registerBinaryMessageHandler).not.toHaveBeenCalled()
+  })
+
+  it('opens no binary handler when the execution-host authority is stale', async () => {
+    const hostRuntime = runtime()
+    const lease = attachLease(hostRuntime)
+    const resolveExecutionRoute = vi
+      .fn()
+      .mockRejectedValue(new Error('browser_tunnel_execution_host_stale'))
+    const dispatcher = new RpcDispatcher({
+      runtime: hostRuntime,
+      methods: createBrowserNetworkTunnelMethods(
+        new BrowserNetworkTunnelOutboundMemoryBudgetRegistry(),
+        resolveExecutionRoute
+      )
+    })
+    const replies: string[] = []
+    const registerBinaryMessageHandler = vi.fn()
+    const executionHost = {
+      kind: 'ssh' as const,
+      targetId: 'target-a',
+      providerEpoch: 'provider-epoch-a',
+      connectionGeneration: 2
+    }
+    grantExecutionHost(hostRuntime, lease, executionHost)
+
+    await dispatcher.dispatchStreaming(
+      request(lease, { executionHost }),
+      (reply) => replies.push(reply),
+      {
+        connectionId: 'connection-a',
+        clientKind: 'runtime',
+        pairedDeviceId: 'device-a',
+        clientCapabilities: [
+          ...negotiatedCapabilities,
+          BROWSER_NETWORK_EXECUTION_HOSTS_RUNTIME_CAPABILITY
+        ],
+        sendBinary: vi.fn(() => true),
+        registerBinaryMessageHandler
+      }
+    )
+
+    expect(resolveExecutionRoute).toHaveBeenCalledWith({
+      executionHost,
+      runtimeId: 'runtime-a',
+      runtimeRevision: 1,
+      signal: expect.any(AbortSignal)
+    })
+    expect(JSON.parse(replies[0]!).error.message).toBe('browser_tunnel_execution_host_stale')
+    expect(registerBinaryMessageHandler).not.toHaveBeenCalled()
+  })
+
+  it('closes an invalidated execution route and releases it once', async () => {
+    const cleanups = new Map<string, () => void>()
+    const hostRuntime = runtime(cleanups)
+    const lease = attachLease(hostRuntime)
+    const invalidated = new AbortController()
+    const closeExecutionRoute = vi.fn()
+    const memoryBudgets = new BrowserNetworkTunnelOutboundMemoryBudgetRegistry()
+    const dispatcher = new RpcDispatcher({
+      runtime: hostRuntime,
+      methods: createBrowserNetworkTunnelMethods(memoryBudgets, async ({ executionHost }) => ({
+        key: browserNetworkExecutionHostKey(executionHost),
+        connect: () => {
+          throw new Error('unexpected destination open')
+        },
+        whenInvalidated: new Promise((resolve) =>
+          invalidated.signal.addEventListener('abort', () => resolve(), { once: true })
+        ),
+        isValid: () => true,
+        close: closeExecutionRoute
+      }))
+    })
+    const unregister = vi.fn()
+    const registerBinaryMessageHandler = vi.fn(() => unregister)
+    const replies: string[] = []
+    const executionHost = {
+      kind: 'ssh' as const,
+      targetId: 'target-a',
+      providerEpoch: 'provider-epoch-a',
+      connectionGeneration: 2
+    }
+    grantExecutionHost(hostRuntime, lease, executionHost)
+    const dispatch = dispatcher.dispatchStreaming(
+      request(lease, { executionHost }),
+      (reply) => replies.push(reply),
+      {
+        connectionId: 'connection-a',
+        clientKind: 'runtime',
+        pairedDeviceId: 'device-a',
+        clientCapabilities: [
+          ...negotiatedCapabilities,
+          BROWSER_NETWORK_EXECUTION_HOSTS_RUNTIME_CAPABILITY
+        ],
+        sendBinary: vi.fn(() => true),
+        registerBinaryMessageHandler
+      }
+    )
+    await vi.waitFor(() => expect(registerBinaryMessageHandler).toHaveBeenCalledOnce())
+
+    invalidated.abort()
+    await dispatch
+
+    expect(unregister).toHaveBeenCalledOnce()
+    expect(closeExecutionRoute).toHaveBeenCalledOnce()
+    expect(memoryBudgets.evidence()).toMatchObject({ hosts: 0, leases: 0 })
+  })
+
+  it('does not expose execution-route diagnostic detail to the paired caller', async () => {
+    const hostRuntime = runtime()
+    const lease = attachLease(hostRuntime)
+    const executionHost = {
+      kind: 'ssh' as const,
+      targetId: 'target-a',
+      providerEpoch: 'provider-epoch-a',
+      connectionGeneration: 2
+    }
+    grantExecutionHost(hostRuntime, lease, executionHost)
+    const dispatcher = new RpcDispatcher({
+      runtime: hostRuntime,
+      methods: createBrowserNetworkTunnelMethods(
+        new BrowserNetworkTunnelOutboundMemoryBudgetRegistry(),
+        vi.fn().mockRejectedValue(new Error('Bad owner or permissions on /Users/alice/.ssh/key'))
+      )
+    })
+    const replies: string[] = []
+
+    await dispatcher.dispatchStreaming(
+      request(lease, { executionHost }),
+      (reply) => replies.push(reply),
+      {
+        connectionId: 'connection-a',
+        clientKind: 'runtime',
+        pairedDeviceId: 'device-a',
+        clientCapabilities: [
+          ...negotiatedCapabilities,
+          BROWSER_NETWORK_EXECUTION_HOSTS_RUNTIME_CAPABILITY
+        ],
+        sendBinary: vi.fn(() => true),
+        registerBinaryMessageHandler: vi.fn()
+      }
+    )
+
+    expect(JSON.parse(replies[0]!).error.message).toBe('browser_tunnel_execution_host_unavailable')
+    expect(replies[0]).not.toContain('/Users/alice')
+  })
+
+  it('rejects a grant revoked during connector startup and closes the connector', async () => {
+    const hostRuntime = runtime()
+    const lease = attachLease(hostRuntime)
+    const executionHost = {
+      kind: 'ssh' as const,
+      targetId: 'target-a',
+      providerEpoch: 'provider-epoch-a',
+      connectionGeneration: 2
+    }
+    const grant = grantExecutionHost(hostRuntime, lease, executionHost)
+    let resolveExecutionRoute: ((route: BrowserNetworkExecutionRoute) => void) | undefined
+    let executionRouteSignal: AbortSignal | undefined
+    const close = vi.fn()
+    const resolver: BrowserNetworkExecutionRouteResolver = vi.fn((context) => {
+      executionRouteSignal = context.signal
+      return new Promise<BrowserNetworkExecutionRoute>((resolve) => {
+        resolveExecutionRoute = resolve
+      })
+    })
+    const dispatcher = new RpcDispatcher({
+      runtime: hostRuntime,
+      methods: createBrowserNetworkTunnelMethods(
+        new BrowserNetworkTunnelOutboundMemoryBudgetRegistry(),
+        resolver
+      )
+    })
+    const replies: string[] = []
+    const registerBinaryMessageHandler = vi.fn()
+    const dispatch = dispatcher.dispatchStreaming(
+      request(lease, { executionHost }),
+      (reply) => replies.push(reply),
+      {
+        connectionId: 'connection-a',
+        clientKind: 'runtime',
+        pairedDeviceId: 'device-a',
+        clientCapabilities: [
+          ...negotiatedCapabilities,
+          BROWSER_NETWORK_EXECUTION_HOSTS_RUNTIME_CAPABILITY
+        ],
+        sendBinary: vi.fn(() => true),
+        registerBinaryMessageHandler
+      }
+    )
+    await vi.waitFor(() => expect(resolver).toHaveBeenCalledOnce())
+
+    grant.release()
+    expect(executionRouteSignal?.aborted).toBe(true)
+    resolveExecutionRoute?.({
+      key: browserNetworkExecutionHostKey(executionHost),
+      connect: () => {
+        throw new Error('unexpected destination open')
+      },
+      isValid: () => true,
+      close
+    })
+    await dispatch
+
+    expect(JSON.parse(replies[0]!).error.message).toBe('browser_tunnel_execution_host_not_granted')
+    expect(registerBinaryMessageHandler).not.toHaveBeenCalled()
+    expect(close).toHaveBeenCalledOnce()
   })
 
   it('rejects a self-asserted or stale browser host lease', async () => {
@@ -221,7 +538,7 @@ describe('network.browserTunnel RPC', () => {
         result: { type: 'ready', tunnelGeneration: 1 }
       })
     ])
-    cleanups.get('browser-network-tunnel:connection-a')?.()
+    cleanups.values().next().value?.()
     await dispatch
     expect(unregister).toHaveBeenCalledOnce()
   })
@@ -248,9 +565,7 @@ describe('network.browserTunnel RPC', () => {
     })
     await vi.waitFor(() => expect(replies).toHaveLength(1))
 
-    expect(() => cleanups.get('browser-network-tunnel:connection-a')?.()).toThrow(
-      'unregister failed'
-    )
+    expect(() => cleanups.values().next().value?.()).toThrow('unregister failed')
     await dispatch
     expect(memoryBudgets.evidence()).toMatchObject({ hosts: 0, leases: 0 })
   })

--- a/src/main/runtime/rpc/methods/browser-network-tunnel.ts
+++ b/src/main/runtime/rpc/methods/browser-network-tunnel.ts
@@ -1,9 +1,14 @@
-import { connect } from 'node:net'
 import { BrowserNetworkTunnelSession } from '../../../browser/browser-network-tunnel-session'
 import { BrowserNetworkTunnelOutboundMemoryBudgetRegistry } from '../../../browser/browser-network-tunnel-outbound-memory-budget'
+import {
+  browserNetworkExecutionHostKey,
+  resolveNativeBrowserNetworkExecutionRoute,
+  type BrowserNetworkExecutionRouteResolver
+} from '../../../browser/browser-network-execution-route'
 import { BrowserNetworkTunnelAttachParams } from '../../../../shared/browser-client-host-protocol'
 import {
   BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY,
+  BROWSER_NETWORK_EXECUTION_HOSTS_RUNTIME_CAPABILITY,
   BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY
 } from '../../../../shared/protocol-version'
 import { getBrowserHostLeaseRegistry } from '../../browser-host-lease-registry'
@@ -12,7 +17,8 @@ import { defineStreamingMethod, type RpcAnyMethod } from '../core'
 const outboundMemoryBudgets = new BrowserNetworkTunnelOutboundMemoryBudgetRegistry()
 
 export function createBrowserNetworkTunnelMethods(
-  memoryBudgets: BrowserNetworkTunnelOutboundMemoryBudgetRegistry = outboundMemoryBudgets
+  memoryBudgets: BrowserNetworkTunnelOutboundMemoryBudgetRegistry = outboundMemoryBudgets,
+  resolveExecutionRoute: BrowserNetworkExecutionRouteResolver = resolveBrowserNetworkExecutionRoute
 ): RpcAnyMethod[] {
   return [
     defineStreamingMethod({
@@ -47,14 +53,14 @@ export function createBrowserNetworkTunnelMethods(
         if (!clientCapabilities.includes(BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY)) {
           throw new Error('browser_client_host_capability_required')
         }
+        if (
+          params.executionHost.kind !== 'native' &&
+          !clientCapabilities.includes(BROWSER_NETWORK_EXECUTION_HOSTS_RUNTIME_CAPABILITY)
+        ) {
+          throw new Error('browser_tunnel_execution_hosts_capability_required')
+        }
         if (params.authorityRuntimeId !== runtime.getRuntimeId()) {
           throw new Error('browser_tunnel_identity_mismatch')
-        }
-        if (
-          params.executionHost.runtimeId !== runtime.getRuntimeId() ||
-          params.executionHost.revision !== runtime.getStartedAt()
-        ) {
-          throw new Error('browser_tunnel_execution_host_mismatch')
         }
 
         const leaseRegistry = getBrowserHostLeaseRegistry(runtime)
@@ -63,20 +69,69 @@ export function createBrowserNetworkTunnelMethods(
           browserHostClientId: params.browserHostClientId,
           browserHostGeneration: params.browserHostGeneration,
           pairedDeviceId,
-          executionHostKey: `native:${params.executionHost.runtimeId}:${params.executionHost.revision}`
+          executionHostKey: browserNetworkExecutionHostKey(params.executionHost)
         }
         leaseRegistry.requireLease(tunnelIdentity)
+        if (params.executionHost.kind !== 'native') {
+          leaseRegistry.requireExecutionHost(tunnelIdentity, tunnelIdentity.executionHostKey)
+        }
+        if (signal?.aborted) {
+          return
+        }
+        const executionRouteAbort = new AbortController()
+        const abortExecutionRoute = (): void => executionRouteAbort.abort()
+        const unlinkExecutionGrant =
+          params.executionHost.kind === 'native'
+            ? () => {}
+            : leaseRegistry.linkExecutionHostGrant(
+                tunnelIdentity,
+                tunnelIdentity.executionHostKey,
+                abortExecutionRoute
+              )
+        signal?.addEventListener('abort', abortExecutionRoute, { once: true })
         const outboundMemory = memoryBudgets.acquire(
           `${pairedDeviceId}:${params.browserHostClientId}`
         )
         if (!outboundMemory) {
+          unlinkExecutionGrant()
+          signal?.removeEventListener('abort', abortExecutionRoute)
           throw new Error('browser_tunnel_memory_admission_failed')
+        }
+        let executionRoute
+        try {
+          executionRoute = await resolveExecutionRoute({
+            executionHost: params.executionHost,
+            runtimeId: runtime.getRuntimeId(),
+            runtimeRevision: runtime.getStartedAt(),
+            signal: executionRouteAbort.signal
+          })
+          if (executionRoute.key !== tunnelIdentity.executionHostKey || !executionRoute.isValid()) {
+            await executionRoute.close()
+            throw new Error('browser_tunnel_execution_host_stale')
+          }
+          if (signal?.aborted) {
+            outboundMemory.release()
+            await executionRoute.close()
+            return
+          }
+        } catch (error) {
+          outboundMemory.release()
+          throw publicExecutionRouteError(error)
+        } finally {
+          unlinkExecutionGrant()
+          signal?.removeEventListener('abort', abortExecutionRoute)
         }
         let route: ReturnType<ReturnType<typeof getBrowserHostLeaseRegistry>['openTunnel']>
         try {
-          route = leaseRegistry.openTunnel(tunnelIdentity)
+          route = leaseRegistry.openTunnel(tunnelIdentity, {
+            requireExecutionHostGrant: params.executionHost.kind !== 'native'
+          })
         } catch (error) {
-          outboundMemory.release()
+          try {
+            outboundMemory.release()
+          } finally {
+            await executionRoute.close()
+          }
           throw error
         }
 
@@ -86,6 +141,18 @@ export function createBrowserNetworkTunnelMethods(
         })
         let session: BrowserNetworkTunnelSession | null = null
         let unregisterBinary = (): void => {}
+        let executionRouteClose: Promise<void> | null = null
+        const closeExecutionRoute = (): Promise<void> => {
+          if (!executionRouteClose) {
+            try {
+              executionRouteClose = Promise.resolve(executionRoute.close())
+            } catch (error) {
+              executionRouteClose = Promise.reject(error)
+            }
+            void executionRouteClose.catch(() => {})
+          }
+          return executionRouteClose
+        }
         let cleaned = false
         const cleanup = (): void => {
           if (cleaned) {
@@ -96,18 +163,32 @@ export function createBrowserNetworkTunnelMethods(
             unregisterBinary()
           } finally {
             try {
-              session?.close()
+              const activeSession = session
+              session = null
+              activeSession?.close()
             } finally {
-              outboundMemory.release()
-              route.release()
+              try {
+                outboundMemory.release()
+              } finally {
+                try {
+                  route.release()
+                } finally {
+                  void closeExecutionRoute()
+                }
+              }
             }
           }
         }
-        const subscriptionId = `browser-network-tunnel:${connectionId}`
+        const subscriptionId = JSON.stringify([
+          'browser-network-tunnel',
+          connectionId,
+          params.browserHostClientId,
+          tunnelIdentity.executionHostKey
+        ])
         try {
           session = new BrowserNetworkTunnelSession({
             tunnelGeneration: route.tunnelGeneration,
-            connect: (target) => connect({ ...target, allowHalfOpen: true }),
+            connect: executionRoute.connect,
             sendBinary: (bytes) => sendBinary(bytes) !== false,
             claimAggregateRetainedBytes: outboundMemory.claimApplicationBytes,
             onClose: () => {
@@ -119,10 +200,11 @@ export function createBrowserNetworkTunnelMethods(
             }
           })
           void route.whenFenced.then(() => session?.close())
+          void executionRoute.whenInvalidated?.then(() => session?.close())
           unregisterBinary = registerBinaryMessageHandler((bytes) => session?.handleBinary(bytes))
           runtime.registerSubscriptionCleanup(subscriptionId, cleanup, connectionId)
           signal?.addEventListener('abort', cleanup, { once: true })
-          if (signal?.aborted) {
+          if (signal?.aborted || !executionRoute.isValid()) {
             cleanup()
             return
           }
@@ -130,12 +212,51 @@ export function createBrowserNetworkTunnelMethods(
           await closed
         } finally {
           signal?.removeEventListener('abort', cleanup)
-          cleanup()
+          try {
+            cleanup()
+          } finally {
+            await closeExecutionRoute().catch(() => {})
+          }
         }
       }
     })
   ]
 }
 
+const PUBLIC_EXECUTION_ROUTE_ERRORS = new Set([
+  'browser_tunnel_execution_host_mismatch',
+  'browser_tunnel_execution_host_stale',
+  'browser_tunnel_execution_host_unavailable'
+])
+
+function publicExecutionRouteError(error: unknown): Error {
+  if (error instanceof Error && PUBLIC_EXECUTION_ROUTE_ERRORS.has(error.message)) {
+    return error
+  }
+  return new Error('browser_tunnel_execution_host_unavailable', { cause: error })
+}
+
 // Why: tests inject this until a live lease and server-owned route generation authorize TCP opens.
 export const BROWSER_NETWORK_TUNNEL_METHODS = createBrowserNetworkTunnelMethods()
+
+async function resolveBrowserNetworkExecutionRoute(
+  context: Parameters<BrowserNetworkExecutionRouteResolver>[0]
+) {
+  if (context.executionHost.kind === 'native') {
+    return resolveNativeBrowserNetworkExecutionRoute(context)
+  }
+  const [{ getSshConnectionManager }, authority, sshRoute] = await Promise.all([
+    import('../../../ipc/ssh'),
+    import('../../../ssh/ssh-provider-authority'),
+    import('../../../browser/ssh-browser-network-execution-route')
+  ])
+  const connectionManager = getSshConnectionManager()
+  if (!connectionManager) {
+    throw new Error('browser_tunnel_execution_host_unavailable')
+  }
+  return sshRoute.resolveSshBrowserNetworkExecutionRoute(context, {
+    connectionManager,
+    isCurrentAuthority: authority.isCurrentSshProviderAuthority,
+    registerAuthorityAbort: authority.registerSshProviderRequestAbort
+  })
+}

--- a/src/main/ssh/ssh-connection.ts
+++ b/src/main/ssh/ssh-connection.ts
@@ -1146,7 +1146,7 @@ export class SshConnection {
     return channel
   }
 
-  private getSystemSshBuildArgsOptions(): SystemSshBuildArgsOptions {
+  getSystemSshBuildArgsOptions(): SystemSshBuildArgsOptions {
     const options: SystemSshBuildArgsOptions = {}
     if (this.systemSshResolvedConfig) {
       options.resolvedConfig = this.systemSshResolvedConfig

--- a/src/main/ssh/ssh-port-forward.test.ts
+++ b/src/main/ssh/ssh-port-forward.test.ts
@@ -42,7 +42,7 @@ function createSystemSshConn() {
   return {
     getClient: vi.fn().mockReturnValue(null),
     usesSystemSshTransport: vi.fn().mockReturnValue(true),
-    getSystemSshResolvedConfig: vi.fn().mockReturnValue(null),
+    getSystemSshBuildArgsOptions: vi.fn().mockReturnValue({}),
     getTarget: vi.fn().mockReturnValue({
       id: 'target-1',
       label: 'container',
@@ -153,7 +153,8 @@ describe('SshPortForwardManager', () => {
       conn.getTarget(),
       3000,
       '127.0.0.1',
-      8080
+      8080,
+      {}
     )
     expect(forward.waitForStartup).toHaveBeenCalled()
     expect(entry).toMatchObject({
@@ -169,16 +170,18 @@ describe('SshPortForwardManager', () => {
     const forward = createFakeSystemSshForward()
     startSystemSshPortForwardProcessMock.mockReturnValue(forward)
     const conn = createSystemSshConn()
-    conn.getSystemSshResolvedConfig.mockReturnValue({
-      hostname: 'resolved.example.com',
-      port: 2222,
-      user: 'vscode',
-      identityFile: ['/home/user/.ssh/work'],
-      forwardAgent: false,
-      identitiesOnly: true,
-      proxyUseFdpass: true,
-      controlMaster: 'no',
-      controlPersist: 'no'
+    conn.getSystemSshBuildArgsOptions.mockReturnValue({
+      resolvedConfig: {
+        hostname: 'resolved.example.com',
+        port: 2222,
+        user: 'vscode',
+        identityFile: ['/home/user/.ssh/work'],
+        forwardAgent: false,
+        identitiesOnly: true,
+        proxyUseFdpass: true,
+        controlMaster: 'no',
+        controlPersist: 'no'
+      }
     })
 
     await manager.addForward('conn-1', conn as never, 3000, '127.0.0.1', 8080)

--- a/src/main/ssh/ssh-system-fallback.test.ts
+++ b/src/main/ssh/ssh-system-fallback.test.ts
@@ -268,6 +268,15 @@ describe('spawnSystemSsh', () => {
     expect(args).not.toContain('ProxyCommand=ignored')
   })
 
+  it('passes an explicit main-owned OpenSSH config as one argument', () => {
+    const args = buildSshArgs(createTarget({ configHost: 'isolated-host', source: 'ssh-config' }), {
+      configFile: '/tmp/orca isolated/ssh_config'
+    })
+
+    expect(args.slice(0, 2)).toEqual(['-F', '/tmp/orca isolated/ssh_config'])
+    expect(args).toContain('isolated-host')
+  })
+
   it('passes explicit options for manual targets with implicit configHost', () => {
     const args = buildSshArgs(
       createTarget({

--- a/src/main/ssh/system-ssh-args.ts
+++ b/src/main/ssh/system-ssh-args.ts
@@ -2,16 +2,21 @@ import type { SshTarget } from '../../shared/ssh-types'
 import { getControlSocketPath, type SystemSshResolvedConfig } from './ssh-control-socket'
 
 export type SystemSshBuildArgsOptions = {
+  configFile?: string
   resolvedConfig?: SystemSshResolvedConfig | null
   disableControlMaster?: boolean
   suppressOrcaControlMaster?: boolean
   gssapiOnly?: boolean
+  nonInteractive?: boolean
 }
 
 export function buildSshArgs(target: SshTarget, options?: SystemSshBuildArgsOptions): string[] {
   const args: string[] = []
 
-  args.push('-o', options?.gssapiOnly ? 'BatchMode=yes' : 'BatchMode=no')
+  if (options?.configFile) {
+    args.push('-F', options.configFile)
+  }
+  args.push('-o', options?.gssapiOnly || options?.nonInteractive ? 'BatchMode=yes' : 'BatchMode=no')
   if (options?.gssapiOnly) {
     // Why: the probe must neither authenticate with a key nor open an OpenSSH
     // credential prompt; failure belongs to Orca's existing ssh2 prompt path.
@@ -99,6 +104,9 @@ export function getSystemSshBuildArgsFromOperationOptions(
   options: SystemSshBuildArgsOptions | undefined
 ): SystemSshBuildArgsOptions | undefined {
   const buildArgsOptions: SystemSshBuildArgsOptions = {}
+  if (options?.configFile !== undefined) {
+    buildArgsOptions.configFile = options.configFile
+  }
   if (options?.resolvedConfig !== undefined) {
     buildArgsOptions.resolvedConfig = options.resolvedConfig
   }
@@ -110,6 +118,9 @@ export function getSystemSshBuildArgsFromOperationOptions(
   }
   if (options?.gssapiOnly === true) {
     buildArgsOptions.gssapiOnly = true
+  }
+  if (options?.nonInteractive === true) {
+    buildArgsOptions.nonInteractive = true
   }
   return Object.keys(buildArgsOptions).length === 0 ? undefined : buildArgsOptions
 }

--- a/src/main/ssh/system-ssh-dynamic-forward-process.test.ts
+++ b/src/main/ssh/system-ssh-dynamic-forward-process.test.ts
@@ -1,0 +1,124 @@
+import { EventEmitter } from 'node:events'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { spawnMock, connectMock, createServerMock, waitForStopMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+  connectMock: vi.fn(),
+  createServerMock: vi.fn(),
+  waitForStopMock: vi.fn(async () => {})
+}))
+
+vi.mock('node:child_process', () => ({ spawn: spawnMock }))
+vi.mock('node:net', () => ({ connect: connectMock, createServer: createServerMock }))
+vi.mock('./ssh-system-fallback', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return { ...actual, findSystemSsh: () => '/usr/bin/ssh' }
+})
+vi.mock('./system-ssh-forward-process', () => ({
+  waitForSystemSshForwardStop: waitForStopMock
+}))
+
+import { startSystemSshDynamicForwardProcess } from './system-ssh-dynamic-forward-process'
+
+function fakeServer() {
+  const server = new EventEmitter() as EventEmitter & {
+    listen: ReturnType<typeof vi.fn>
+    address: ReturnType<typeof vi.fn>
+    close: ReturnType<typeof vi.fn>
+  }
+  server.listen = vi.fn((_port, _host, callback: () => void) => {
+    queueMicrotask(callback)
+    return server
+  })
+  server.address = vi.fn(() => ({ address: '127.0.0.1', family: 'IPv4', port: 45678 }))
+  server.close = vi.fn((callback?: (error?: Error) => void) => callback?.())
+  return server
+}
+
+function fakeProcess() {
+  const process = new EventEmitter() as EventEmitter & {
+    stderr: EventEmitter
+    exitCode: number | null
+    signalCode: NodeJS.Signals | null
+    kill: ReturnType<typeof vi.fn>
+  }
+  process.stderr = new EventEmitter()
+  process.exitCode = null
+  process.signalCode = null
+  process.kill = vi.fn(() => true)
+  return process
+}
+
+function fakeProbe(connects: boolean) {
+  const socket = new EventEmitter() as EventEmitter & {
+    destroy: ReturnType<typeof vi.fn>
+    removeAllListeners: EventEmitter['removeAllListeners']
+  }
+  socket.destroy = vi.fn()
+  if (connects) {
+    queueMicrotask(() => socket.emit('connect'))
+  }
+  return socket
+}
+
+const target = {
+  id: 'target-a',
+  label: 'Target A',
+  host: 'ssh.example.com',
+  port: 2222,
+  username: 'orca',
+  identityFile: '/tmp/id_ed25519'
+}
+
+describe('system SSH dynamic forward process', () => {
+  beforeEach(() => {
+    spawnMock.mockReset().mockImplementation(fakeProcess)
+    connectMock.mockReset().mockImplementation(() => fakeProbe(true))
+    createServerMock.mockReset().mockImplementation(fakeServer)
+    waitForStopMock.mockClear()
+  })
+
+  afterEach(() => vi.useRealTimers())
+
+  it('starts one non-interactive dynamic forward before the destination', async () => {
+    const forward = await startSystemSshDynamicForwardProcess(target)
+    const args = spawnMock.mock.calls[0]![1] as string[]
+
+    expect(args).toEqual(
+      expect.arrayContaining([
+        '-o',
+        'BatchMode=yes',
+        '-S',
+        'none',
+        '-p',
+        '2222',
+        '-i',
+        '/tmp/id_ed25519',
+        '-D',
+        '127.0.0.1:45678'
+      ])
+    )
+    expect(args.indexOf('-D')).toBeLessThan(args.indexOf('--'))
+    expect(args[args.indexOf('--') + 1]).toBe('orca@ssh.example.com')
+    expect(spawnMock).toHaveBeenCalledOnce()
+
+    await forward.close()
+    expect(waitForStopMock).toHaveBeenCalledOnce()
+  })
+
+  it('kills startup immediately when SSH authority is invalidated', async () => {
+    connectMock.mockImplementation(() => fakeProbe(false))
+    const controller = new AbortController()
+    const starting = startSystemSshDynamicForwardProcess(target, undefined, controller.signal)
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledOnce())
+    const process = spawnMock.mock.results[0]!.value as ReturnType<typeof fakeProcess>
+    const probe = connectMock.mock.results[0]!.value as ReturnType<typeof fakeProbe>
+
+    controller.abort()
+
+    await expect(starting).rejects.toThrow('system_ssh_dynamic_forward_aborted')
+    expect(process.kill).toHaveBeenCalledWith('SIGTERM')
+    expect(probe.destroy).toHaveBeenCalledOnce()
+    expect(waitForStopMock).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/ssh/system-ssh-dynamic-forward-process.ts
+++ b/src/main/ssh/system-ssh-dynamic-forward-process.ts
@@ -1,0 +1,183 @@
+import { spawn, type ChildProcess } from 'node:child_process'
+import { connect, createServer, type AddressInfo, type Socket } from 'node:net'
+import type { SshTarget } from '../../shared/ssh-types'
+import { buildSshArgs, findSystemSsh, type SystemSshBuildArgsOptions } from './ssh-system-fallback'
+import { waitForSystemSshForwardStop } from './system-ssh-forward-process'
+
+const STARTUP_TIMEOUT_MS = 10_000
+const PROBE_INTERVAL_MS = 50
+
+export type SystemSshDynamicForwardProcess = {
+  localPort: number
+  process: ChildProcess
+  stderrTail: () => string
+  close: () => Promise<void>
+  dispose: () => void
+}
+
+export async function startSystemSshDynamicForwardProcess(
+  target: SshTarget,
+  options?: SystemSshBuildArgsOptions,
+  signal?: AbortSignal
+): Promise<SystemSshDynamicForwardProcess> {
+  const sshPath = findSystemSsh()
+  if (!sshPath) {
+    throw new Error('No system ssh binary found. Install OpenSSH to use browser tunneling.')
+  }
+  const localPort = await allocateLoopbackPort()
+  if (signal?.aborted) {
+    throw new Error('system_ssh_dynamic_forward_aborted')
+  }
+  const args = buildSshArgs(target, {
+    ...options,
+    suppressOrcaControlMaster: true,
+    disableControlMaster: true,
+    nonInteractive: true
+  })
+  const destinationIndex = args.lastIndexOf('--')
+  const dynamicArgs = ['-N', '-o', 'ExitOnForwardFailure=yes', '-D', `127.0.0.1:${localPort}`]
+  args.splice(destinationIndex === -1 ? 0 : destinationIndex, 0, ...dynamicArgs)
+  const process = spawn(sshPath, args, {
+    stdio: ['ignore', 'ignore', 'pipe'],
+    windowsHide: true
+  })
+  let stderr = ''
+  const onStderr = (chunk: Buffer): void => {
+    stderr = `${stderr}${chunk.toString('utf-8')}`.slice(-64 * 1024)
+  }
+  const onAbort = (): void => {
+    try {
+      process.kill('SIGTERM')
+    } catch {
+      /* best-effort cancellation */
+    }
+  }
+  process.stderr?.on('data', onStderr)
+  signal?.addEventListener('abort', onAbort, { once: true })
+  try {
+    await waitForDynamicForward(process, localPort, () => stderr, signal)
+  } catch (error) {
+    process.stderr?.off('data', onStderr)
+    signal?.removeEventListener('abort', onAbort)
+    await waitForSystemSshForwardStop(process)
+    throw error
+  }
+  return {
+    localPort,
+    process,
+    stderrTail: () => stderr,
+    close: async () => {
+      try {
+        await waitForSystemSshForwardStop(process)
+      } finally {
+        process.stderr?.off('data', onStderr)
+        signal?.removeEventListener('abort', onAbort)
+      }
+    },
+    dispose: () => {
+      try {
+        process.kill('SIGTERM')
+      } catch {
+        /* best-effort teardown */
+      }
+    }
+  }
+}
+
+function allocateLoopbackPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer()
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address() as AddressInfo | null
+      if (!address) {
+        server.close()
+        reject(new Error('system_ssh_dynamic_forward_port_unavailable'))
+        return
+      }
+      server.close((error) => (error ? reject(error) : resolve(address.port)))
+    })
+  })
+}
+
+function waitForDynamicForward(
+  process: ChildProcess,
+  localPort: number,
+  stderr: () => string,
+  signal?: AbortSignal
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let settled = false
+    let probeTimer: ReturnType<typeof setTimeout> | undefined
+    let probeSocket: Socket | undefined
+    const timeout = setTimeout(
+      () => finish(() => reject(dynamicForwardError(null, stderr(), 'startup timeout'))),
+      STARTUP_TIMEOUT_MS
+    )
+    const cleanup = (): void => {
+      clearTimeout(timeout)
+      clearTimeout(probeTimer)
+      probeSocket?.removeAllListeners()
+      probeSocket?.destroy()
+      probeSocket = undefined
+      process.off('error', onError)
+      process.off('exit', onExit)
+      signal?.removeEventListener('abort', onAbort)
+    }
+    const finish = (settle: () => void): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      cleanup()
+      settle()
+    }
+    const onError = (error: Error): void => finish(() => reject(error))
+    const onAbort = (): void =>
+      finish(() => reject(new Error('system_ssh_dynamic_forward_aborted')))
+    const onExit = (code: number | null): void =>
+      finish(() => reject(dynamicForwardError(code, stderr())))
+    const probe = (): void => {
+      const socket = connect({ host: '127.0.0.1', port: localPort })
+      probeSocket = socket
+      const closeProbe = (): void => {
+        if (probeSocket === socket) {
+          probeSocket = undefined
+        }
+        socket.removeAllListeners()
+        socket.destroy()
+      }
+      socket.once('connect', () => {
+        closeProbe()
+        finish(resolve)
+      })
+      socket.once('error', () => {
+        closeProbe()
+        if (!settled) {
+          probeTimer = setTimeout(probe, PROBE_INTERVAL_MS)
+        }
+      })
+    }
+    process.once('error', onError)
+    process.once('exit', onExit)
+    signal?.addEventListener('abort', onAbort, { once: true })
+    if (signal?.aborted) {
+      onAbort()
+      return
+    }
+    probe()
+  })
+}
+
+function dynamicForwardError(code: number | null, stderr: string, fallback = ''): Error {
+  const detail =
+    stderr
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .findLast(Boolean) ?? fallback
+  return new Error(
+    `System SSH dynamic forward failed${code === null ? '' : ` (exit ${code})`}${
+      detail ? `: ${detail}` : ''
+    }`
+  )
+}

--- a/src/main/ssh/system-ssh-port-forward-provider.ts
+++ b/src/main/ssh/system-ssh-port-forward-provider.ts
@@ -16,21 +16,13 @@ export class SystemSshPortForwardProvider implements SshPortForwardProvider {
 
   async start(conn: SshConnection, options: PortForwardStartOptions): Promise<StartedPortForward> {
     const target = conn.getTarget()
-    const resolvedConfig = conn.getSystemSshResolvedConfig()
-    const forward = resolvedConfig
-      ? await startSystemSshPortForwardProcess(
-          target,
-          options.localPort,
-          options.remoteHost,
-          options.remotePort,
-          { resolvedConfig }
-        )
-      : await startSystemSshPortForwardProcess(
-          target,
-          options.localPort,
-          options.remoteHost,
-          options.remotePort
-        )
+    const forward = await startSystemSshPortForwardProcess(
+      target,
+      options.localPort,
+      options.remoteHost,
+      options.remotePort,
+      conn.getSystemSshBuildArgsOptions()
+    )
 
     await forward.waitForStartup()
     // Why: this stderr stays attached for the forward's whole lifetime but is

--- a/src/shared/browser-client-host-protocol.test.ts
+++ b/src/shared/browser-client-host-protocol.test.ts
@@ -49,6 +49,43 @@ describe('browser client-host control protocol', () => {
     ).toMatchObject({ authorityEpoch: 'epoch-a', browserHostGeneration: 1 })
   })
 
+  it('decodes an exact SSH provider authority without changing native v1 attaches', () => {
+    const authority = {
+      authorityRuntimeId: 'runtime-a',
+      authorityEpoch: 'epoch-a',
+      browserHostClientId: 'host-a',
+      browserHostGeneration: 1
+    }
+    expect(
+      BrowserNetworkTunnelAttachParams.parse({
+        ...authority,
+        executionHost: { kind: 'native', runtimeId: 'runtime-a', revision: 1 }
+      })
+    ).toEqual({
+      ...authority,
+      executionHost: { kind: 'native', runtimeId: 'runtime-a', revision: 1 }
+    })
+    expect(
+      BrowserNetworkTunnelAttachParams.parse({
+        ...authority,
+        executionHost: {
+          kind: 'ssh',
+          targetId: 'target-a',
+          providerEpoch: 'provider-epoch-a',
+          connectionGeneration: 2
+        }
+      })
+    ).toEqual({
+      ...authority,
+      executionHost: {
+        kind: 'ssh',
+        targetId: 'target-a',
+        providerEpoch: 'provider-epoch-a',
+        connectionGeneration: 2
+      }
+    })
+  })
+
   it('rejects invalid server-owned route generations', () => {
     expect(() => BrowserNetworkTunnelEvent.parse({ type: 'ready', tunnelGeneration: 0 })).toThrow()
     expect(BrowserNetworkTunnelEvent.parse({ type: 'ready', tunnelGeneration: 3 })).toEqual({

--- a/src/shared/browser-client-host-protocol.ts
+++ b/src/shared/browser-client-host-protocol.ts
@@ -34,12 +34,28 @@ export const BrowserHostLeaseAuthority = z.object({
 
 export type BrowserHostLeaseAuthority = z.infer<typeof BrowserHostLeaseAuthority>
 
+const BrowserNetworkNativeExecutionHost = z.object({
+  kind: z.literal('native'),
+  runtimeId: Identity,
+  revision: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER)
+})
+
+const BrowserNetworkSshExecutionHost = z.object({
+  kind: z.literal('ssh'),
+  targetId: Identity,
+  providerEpoch: Identity,
+  connectionGeneration: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER)
+})
+
+export const BrowserNetworkExecutionHost = z.discriminatedUnion('kind', [
+  BrowserNetworkNativeExecutionHost,
+  BrowserNetworkSshExecutionHost
+])
+
+export type BrowserNetworkExecutionHost = z.infer<typeof BrowserNetworkExecutionHost>
+
 export const BrowserNetworkTunnelAttachParams = BrowserHostLeaseAuthority.extend({
-  executionHost: z.object({
-    kind: z.literal('native'),
-    runtimeId: Identity,
-    revision: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER)
-  })
+  executionHost: BrowserNetworkExecutionHost
 })
 
 export const BrowserNetworkTunnelEvent = z.discriminatedUnion('type', [

--- a/src/shared/browser-network-capabilities.test.ts
+++ b/src/shared/browser-network-capabilities.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY,
+  BROWSER_NETWORK_EXECUTION_HOSTS_RUNTIME_CAPABILITY,
   BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY,
   BROWSER_SCREENCAST_RUNTIME_CAPABILITY,
   RUNTIME_CAPABILITIES
@@ -10,12 +11,16 @@ describe('browser network capabilities', () => {
   it('keeps client hosting, network tunneling, and screencast independent', () => {
     expect(BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY).toBe('browser.clientHost.v1')
     expect(BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY).toBe('network.browserTunnel.v1')
+    expect(BROWSER_NETWORK_EXECUTION_HOSTS_RUNTIME_CAPABILITY).toBe(
+      'network.browserTunnel.executionHosts.v1'
+    )
     expect(BROWSER_SCREENCAST_RUNTIME_CAPABILITY).toBe('browser.screencast.v1')
   })
 
   it('does not advertise unregistered client-host or tunnel implementations', () => {
     expect(RUNTIME_CAPABILITIES).not.toContain(BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY)
     expect(RUNTIME_CAPABILITIES).not.toContain(BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY)
+    expect(RUNTIME_CAPABILITIES).not.toContain(BROWSER_NETWORK_EXECUTION_HOSTS_RUNTIME_CAPABILITY)
     expect(RUNTIME_CAPABILITIES).toContain(BROWSER_SCREENCAST_RUNTIME_CAPABILITY)
   })
 })

--- a/src/shared/protocol-version.ts
+++ b/src/shared/protocol-version.ts
@@ -62,6 +62,8 @@ export const BROWSER_TAB_CREATE_KNOWN_ID_RUNTIME_CAPABILITY =
   'browser.tab-create-known-id.v1' as const
 export const BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY = 'browser.clientHost.v1' as const
 export const BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY = 'network.browserTunnel.v1' as const
+export const BROWSER_NETWORK_EXECUTION_HOSTS_RUNTIME_CAPABILITY =
+  'network.browserTunnel.executionHosts.v1' as const
 // Why: hosts without this strip terminal.send's inputKind (zod object drops
 // unknown keys), so a mobile xterm query reply would land as ordinary
 // floor-taking input. Mobile must not forward replies unless advertised.

--- a/tests/e2e/ssh-browser-network-execution-route.docker.unit.test.ts
+++ b/tests/e2e/ssh-browser-network-execution-route.docker.unit.test.ts
@@ -1,0 +1,206 @@
+import { once } from 'node:events'
+import { readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { Client } from 'ssh2'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import type { TestInfo } from '@stablyai/playwright-test'
+import type { SshConnection } from '../../src/main/ssh/ssh-connection'
+import type { SshProviderEpoch } from '../../src/shared/ssh-types'
+import { ensureDockerSshRelayImage } from './helpers/docker-ssh-relay-image'
+import {
+  cleanupDockerSshRelayTarget,
+  execDockerSshRelayTargetCommand,
+  shellQuote,
+  startDockerSshRelayTarget,
+  type DockerSshRelayTarget
+} from './helpers/docker-ssh-relay-target'
+import { resolveSshBrowserNetworkExecutionRoute } from '../../src/main/browser/ssh-browser-network-execution-route'
+
+const runDocker = process.env.ORCA_RUN_DOCKER_SSH_BROWSER_E2E === '1'
+const executionHost = {
+  kind: 'ssh' as const,
+  targetId: 'target-a',
+  providerEpoch: 'provider-epoch-a',
+  connectionGeneration: 2
+}
+
+describe.runIf(runDocker)('SSH browser network execution route Docker journey', () => {
+  let target: DockerSshRelayTarget | null = null
+  let client: Client | null = null
+
+  beforeAll(async () => {
+    ensureDockerSshRelayImage(process.cwd())
+    target = startDockerSshRelayTarget({ workerIndex: 0 } as TestInfo)
+    execDockerSshRelayTargetCommand(
+      target,
+      "grep -q 'remote-only.internal' /etc/hosts || printf '127.0.0.1 remote-only.internal\\n' >> /etc/hosts"
+    )
+    const server = [
+      "const http=require('http')",
+      "http.createServer((_request,response)=>response.end('sta-4150-remote-only')).listen(18080,'127.0.0.1')"
+    ].join(';')
+    execDockerSshRelayTargetCommand(
+      target,
+      `nohup node -e ${shellQuote(server)} >/tmp/sta-4150-http.log 2>&1 </dev/null &`
+    )
+    const waitForServer = [
+      "const net=require('net')",
+      'const deadline=Date.now()+5000',
+      "const probe=()=>{const socket=net.connect(18080,'127.0.0.1')",
+      "socket.once('connect',()=>{socket.destroy();process.exit(0)})",
+      "socket.once('error',()=>{socket.destroy();if(Date.now()>=deadline)process.exit(1);setTimeout(probe,25)})}",
+      'probe()'
+    ].join(';')
+    execDockerSshRelayTargetCommand(target, `node -e ${shellQuote(waitForServer)}`)
+    client = new Client()
+    await new Promise<void>((resolve, reject) => {
+      client!.once('ready', resolve)
+      client!.once('error', reject)
+      client!.connect({
+        host: target!.host,
+        port: target!.port,
+        username: 'root',
+        privateKey: readFileSync(target!.identityFile),
+        hostVerifier: () => true
+      })
+    })
+  }, 120_000)
+
+  afterAll(() => {
+    if (client) {
+      client.end()
+    }
+    cleanupDockerSshRelayTarget(target)
+  })
+
+  it('resolves and connects the exact remote-only domain on the SSH host', async () => {
+    const connection = {
+      getState: () => ({
+        targetId: 'target-a',
+        status: 'connected',
+        error: null,
+        reconnectAttempt: 0
+      }),
+      getClient: () => client,
+      usesSystemSshTransport: () => false
+    } as unknown as SshConnection
+    const authorityAbort = new AbortController()
+    const forwardOut = vi.spyOn(client!, 'forwardOut')
+    const route = await resolveSshBrowserNetworkExecutionRoute(
+      { executionHost, runtimeId: 'runtime-a', runtimeRevision: 1 },
+      {
+        connectionManager: { getConnection: () => connection },
+        isCurrentAuthority: (authority) =>
+          authority.providerEpoch === ('provider-epoch-a' as SshProviderEpoch) &&
+          authority.connectionGeneration === 2,
+        registerAuthorityAbort: (_authority, controller) => {
+          authorityAbort.signal.addEventListener('abort', () => controller.abort(), { once: true })
+          return () => {}
+        }
+      }
+    )
+    const socket = route.connect({ host: 'remote-only.internal', port: 18080 })
+    socket.on('error', () => {})
+    await once(socket as never, 'connect')
+    const response = readHttpResponse(socket)
+    socket.resume()
+    socket.write(
+      new TextEncoder().encode(
+        'GET / HTTP/1.1\r\nHost: remote-only.internal\r\nConnection: close\r\n\r\n'
+      )
+    )
+
+    await expect(response).resolves.toContain('sta-4150-remote-only')
+    expect(forwardOut).toHaveBeenCalledWith(
+      '127.0.0.1',
+      0,
+      'remote-only.internal',
+      18080,
+      expect.any(Function)
+    )
+    authorityAbort.abort()
+    await route.whenInvalidated
+    expect(route.isValid()).toBe(false)
+    await route.close()
+  })
+
+  it('runs the same remote-only journey through one system-SSH dynamic forward', async () => {
+    const configFile = path.join(target!.tempDir, 'browser-tunnel-ssh-config')
+    writeFileSync(
+      configFile,
+      [
+        'Host sta-4150-docker',
+        `  HostName ${target!.host}`,
+        `  Port ${target!.port}`,
+        '  User root',
+        `  IdentityFile ${target!.identityFile}`,
+        '  IdentitiesOnly yes',
+        '  StrictHostKeyChecking no',
+        '  UserKnownHostsFile /dev/null'
+      ].join('\n')
+    )
+    const connection = {
+      getState: () => ({
+        targetId: 'target-a',
+        status: 'connected',
+        error: null,
+        reconnectAttempt: 0
+      }),
+      getClient: () => null,
+      usesSystemSshTransport: () => true,
+      getTarget: () => ({
+        id: 'target-a',
+        label: 'Docker system SSH',
+        configHost: 'sta-4150-docker',
+        host: target!.host,
+        port: target!.port,
+        username: 'root',
+        source: 'ssh-config' as const
+      }),
+      getSystemSshBuildArgsOptions: () => ({ configFile })
+    } as unknown as SshConnection
+    const route = await resolveSshBrowserNetworkExecutionRoute(
+      { executionHost, runtimeId: 'runtime-a', runtimeRevision: 1 },
+      {
+        connectionManager: { getConnection: () => connection },
+        isCurrentAuthority: () => true,
+        registerAuthorityAbort: () => () => {}
+      }
+    )
+    const socket = route.connect({ host: 'remote-only.internal', port: 18080 })
+    socket.on('error', () => {})
+    await once(socket as never, 'connect')
+    const response = readHttpResponse(socket)
+    socket.resume()
+    socket.write(
+      new TextEncoder().encode(
+        'GET / HTTP/1.1\r\nHost: remote-only.internal\r\nConnection: close\r\n\r\n'
+      )
+    )
+
+    await expect(response).resolves.toContain('sta-4150-remote-only')
+    await route.close()
+  })
+})
+
+function readHttpResponse(socket: {
+  on(event: 'data', listener: (bytes: Uint8Array<ArrayBufferLike>) => void): unknown
+  on(event: 'end', listener: () => void): unknown
+  on(event: 'error', listener: (error: Error) => void): unknown
+}): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Uint8Array<ArrayBufferLike>[] = []
+    socket.on('data', (bytes) => chunks.push(bytes.slice()))
+    socket.on('error', reject)
+    socket.on('end', () => {
+      const length = chunks.reduce((total, chunk) => total + chunk.byteLength, 0)
+      const response = new Uint8Array(length)
+      let offset = 0
+      for (const chunk of chunks) {
+        response.set(chunk, offset)
+        offset += chunk.byteLength
+      }
+      resolve(new TextDecoder().decode(response))
+    })
+  })
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1169 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​16 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1153 |
| Prod | 17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1184 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​99 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1085 |

<!-- /orca-pr-loc -->

## Summary

Adds the inert execution-host routing layer for [STA-4150](https://linear.app/stably/issue/STA-4150/refactor-remote-browser-to-client-hosted-electron-webviews), stacked on #14507.

- preserves the exact native v1 attach payload and capability pair
- adds a separately capability-gated SSH execution-host descriptor
- binds non-native routes to an exact runtime-minted, lease-generation-scoped grant
- routes domains through ssh2 `forwardOut` or one owned standalone system-OpenSSH dynamic forward, keeping DNS on the execution host
- fences pending and live routes on lease, grant, RPC, provider-epoch, connection-generation, or tunnel-generation loss
- sanitizes connector errors and releases deferred sockets, probes, processes, handlers, and memory ownership exactly once

Production capability advertisement and RPC registration remain disabled. This PR does not activate client-hosted Electron browsing or change current server/offscreen placement.

## Compatibility

- old clients and servers keep the byte-identical native v1 shape
- SSH requires both `network.browserTunnel.executionHosts.v1` and a live exact grant
- unknown peers never receive the new descriptor
- domains are not resolved on the desktop
- folder workspaces and git worktrees are unaffected; routing keys are structural and platform-independent
- #14402 remains the independent Stage 0 server-hosted compatibility fix

## Evidence

- focused execution-host gate: 13 files, 142 tests passed
- ephemeral Docker sshd: 2/2 passed through real ssh2 and real system OpenSSH to a container-only DNS name
- full runtime RPC: 138 files, 1,355 passed, 1 skipped
- mixed-version terminal wire: 5/5 passed
- Node, web, and CLI typecheck passed
- native, type-aware, changed-code, reliability, and max-lines gates passed
- three fresh correctness/security/performance reviews found no P0/P1/P2 publication blocker

## Activation blockers

- both local SOCKS layers are no-auth; the system-SSH listener is outside application stream/rate/memory accounting
- system-SSH port allocation/readiness cannot yet prove child ownership and remains raceable
- standalone `BatchMode=yes -S none` does not preserve every ControlMaster-only, passphrase, PIN, or keyboard-interactive target
- execution-host grants need bounded, ref-counted page/partition ownership
- Node stream-internal accounting and strict cross-route fairness are incomplete
- WSL, browserless serve, headed Linux, physical Windows/macOS, and mixed old/new tunnel journeys are not yet proven
- Electron route/profile partitions, proxy verification before navigation, exact WebContents registration, crash/reload reconciliation, and no-fallback proof are later stages

Do not merge this layer as feature activation; it is reviewable infrastructure for the staged STA-4150 stack.
