### PR TITLE
feat(browser): prepare route-scoped Electron partitions

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -2083,7 +2083,7 @@
       "platforms": ["macos", "linux", "windows"],
       "providers": ["remote-runtime", "ssh"],
       "coveredPlatforms": ["macos"],
-      "coveredProviders": ["remote-runtime", "ssh"],
+      "coveredProviders": [],
       "coverageNotes": "A headed macOS desktop host and separate paired Electron client exercise a real mirrored terminal link, owner-asserted host browser creation, exact host/client page identity, rendered DOM, explicit browser-tab activation, client external-browser suppression, exact host/client close convergence, and continued original-PTY liveness. Unit contracts cover OSC, WebLinksAddon, click fallback, explicit System Browser routing, failed creation, incapable runtimes, and unchanged direct SSH behavior.",
       "motivatingLinks": [
         "https://stablygroup.slack.com/archives/C0AK2T3JEF4/p1786567689897109",
@@ -2950,6 +2950,125 @@
         "SSH2 and system OpenSSH have isolated Docker evidence, but WSL, browserless serve, Electron proxy policy, UDP denial, and desktop DNS/socket capture are not exercised."
       ],
       "demotionRule": "Keep experimental or demote if a self-asserted or ambiguous host can receive a route, an SSH descriptor bypasses capability, lease-bound grant, or provider-authority checks, late cleanup can remove a replacement, a route can resolve names on the desktop, exceed a byte or stream bound, replenish credit before destination settlement, accept a stale or non-increasing generation, reuse a stream ID within one generation, lose or bypass its fail-closed listener during reconnect, expose the SOCKS listener off-loopback, accept BIND/UDP, or fall back when the selected route is unavailable."
+    },
+    {
+      "id": "browser-client-host.route-partition-policy",
+      "title": "Client-hosted browser partitions apply route policy before attachment",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "browser-runtime",
+      "layer": "electron-main-session-security-boundary",
+      "surfaces": [
+        "route- and profile-scoped Electron partitions",
+        "persistent partition binding metadata",
+        "fixed SOCKS5 session policy",
+        "webview partition allowlist"
+      ],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["remote-runtime", "ssh", "wsl"],
+      "coveredPlatforms": ["macos"],
+      "coveredProviders": [],
+      "coverageNotes": "Deterministic main-process tests cover versioned delimiter-safe aggregate partition derivation, path-safe opaque names, durable collision metadata, oversized or corrupt metadata refusal, missing-sidecar Chromium-data refusal, bounded binding/live-page admission, exact SOCKS5 configuration with Chromium loopback bypass disabled, inherited-connection closure, exact proxy verification before allowlisting, concurrent setup coalescing, live proxy-retarget refusal, token-safe page replacement, existing browser-profile policy installation, active Orca-profile storage scoping, blank-only initial attachment, and arbitrary initial-navigation denial. No production caller prepares a route partition. Persisted-worker containment, UDP/DoH/WebRTC denial, exact WebContents registration, provider journeys, and real Electron traffic capture remain uncovered.",
+      "motivatingLinks": [
+        "https://linear.app/stably/issue/STA-4150/refactor-remote-browser-to-client-hosted-electron-webviews"
+      ],
+      "invariant": "A client-hosted partition is derived only in main from stable Orca-profile, browser-profile, authority-connection, and execution-host identities. Raw identities and individually linkable component hashes never enter its path-safe partition name. Durable binding metadata must match and precede Chromium partition data before reuse. One live partition never changes execution host or proxy endpoint, and no partition enters the webview allowlist until its existing browser policy is installed, fixed SOCKS5 proxy is applied, inherited connections are closed, and resolveProxy returns exactly that one listener. Initial route-partition attachment is blank-only; later navigation remains unavailable because exact WebContents registration does not exist. Distinct live partitions, retained logical page generations, durable bindings, and binding-file reads remain bounded.",
+      "oracle": "Derive two delimiter-adversarial identities and require distinct full-digest path-safe partitions with no raw IDs or component hashes. Persist one binding, reload it, and reject replacement, malformed or oversized state, Chromium data without matching metadata, and the 513th binding. Prepare one partition and require policy setup, setProxy with <-loopback>, closeAllConnections, and exact SOCKS5 resolveProxy in order while isAllowedPartition remains false; then require it to become live. Reject DIRECT, a different proxy endpoint, the 65th live partition, and the 65th page generation. Replace one exact page token and prove stale cleanup cannot retire the replacement. In the window boundary, allow only blank initial attachment for a live route partition and reject direct HTTPS attachment.",
+      "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/browser/browser-route-identity.test.ts src/main/browser/browser-route-partition-binding-store.test.ts src/main/browser/browser-route-session-registry.test.ts src/main/browser/browser-session-registry.test.ts src/main/browser/browser-session-startup.test.ts src/main/window/createMainWindow.test.ts"
+      ],
+      "testFiles": [
+        "src/main/browser/browser-route-identity.test.ts",
+        "src/main/browser/browser-route-partition-binding-store.test.ts",
+        "src/main/browser/browser-route-session-registry.test.ts",
+        "src/main/browser/browser-session-registry.test.ts",
+        "src/main/browser/browser-session-startup.test.ts",
+        "src/main/window/createMainWindow.test.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/main/browser/browser-route-identity.test.ts",
+          "assertions": [
+            "aggregate partition and durable binding fingerprints are stable and opaque",
+            "delimiter-containing identities remain structurally distinct",
+            "individual component equality and Windows-illegal path separators are absent",
+            "empty and unbounded identity components are rejected"
+          ]
+        },
+        {
+          "file": "src/main/browser/browser-route-partition-binding-store.test.ts",
+          "assertions": [
+            "opaque bindings survive restart",
+            "replacement and malformed metadata fail closed",
+            "oversized metadata and Chromium data without a binding fail closed",
+            "persisted binding count is bounded"
+          ]
+        },
+        {
+          "file": "src/main/browser/browser-route-session-registry.test.ts",
+          "assertions": [
+            "policy, proxy, connection closure, and verification finish before allowlisting",
+            "DIRECT and endpoint retargeting are rejected",
+            "non-loopback listeners and invalid page generations are rejected before persistence",
+            "missing browser profiles consume no durable binding capacity",
+            "partial setup cleanup and concurrent setup settle exactly once",
+            "partition and page-generation counts are bounded",
+            "stale page cleanup cannot retire its replacement"
+          ]
+        },
+        {
+          "file": "src/main/window/createMainWindow.test.ts",
+          "assertions": [
+            "a live route partition may attach only the normalized blank document",
+            "an arbitrary URL cannot be the initial route-partition document"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-08-14",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/browser/browser-route-identity.test.ts src/main/browser/browser-route-partition-binding-store.test.ts src/main/browser/browser-route-session-registry.test.ts src/main/browser/browser-session-registry.test.ts src/main/browser/browser-session-startup.test.ts src/main/window/createMainWindow.test.ts",
+          "result": "passed",
+          "durationSeconds": 0.5,
+          "summary": "Six files passed 150 opaque identity, durable collision binding, bounded partition/page, proxy-before-allowlist, policy reuse, profile startup, and blank-only attach tests."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 2,
+        "scope": "deterministic identity, binding-store, session-policy, and window-boundary tests"
+      },
+      "flakeHistory": {
+        "status": "unknown",
+        "evidence": "The deterministic suite passes locally; CI and real Electron soak history have not started."
+      },
+      "redGreenEvidence": {
+        "status": "partial",
+        "evidence": "The identity, binding-store, and route-session suites failed at missing modules before implementation. The unchanged main-window and startup oracles then failed behaviorally because a live route partition was denied even for blank attachment and active-profile startup never scoped route bindings. A focused policy-failure oracle proved partial session policy setup was not cleared, and a capacity oracle proved a second page remained admitted behind a one-page cap. All four behaviors pass after integration. Real Electron mutation/revert and network-capture evidence remain required before activation."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "Derivation performs one bounded full SHA-256 aggregate partition hash and one binding hash. The registry admits at most 64 live or pending partitions, 64 logical page generations per partition, and 512 durable bindings per Orca profile. Concurrent preparation shares one promise and one Electron proxy application per partition. Binding-file reads are capped at 128 KiB. Writes are bounded synchronous profile-local JSON, fsync the temporary file before Windows-retried rename, and fsync the containing directory where supported."
+      },
+      "promotionCriteria": [
+        "Use Playwright CDP in real Electron to prove proxy application before the first HTTP, HTTPS, WebSocket, DNS, worker, popup, redirect, and speculative request.",
+        "Hold or stop persisted workers until proxy verification and prove network-service restart cannot reset the partition to DIRECT or system proxy.",
+        "Register the exact WebContents and page generation before navigation, and fence reload, popup, restore, profile-switch, renderer-crash, and stale-cleanup paths.",
+        "Disable or capture every UDP, QUIC, DoH, WebRTC, and non-SOCKS desktop egress path on macOS, Linux, and Windows."
+      ],
+      "knownGaps": [
+        "No production method calls preparePage, so the registry and allowlist remain inert.",
+        "Creating a persistent Electron Session may wake an existing service worker before setProxy; worker hold or termination proof is required.",
+        "The route partition permits only blank initial attachment; exact WebContents registration and later navigation permission do not exist yet.",
+        "Real Electron proxy syntax, loopback coverage, network-service recovery, popup/worker behavior, and desktop packet capture are not validated because the required Electron skill is unavailable in this workspace.",
+        "QUIC, DoH, WebRTC, WebTransport, and other UDP/direct-network paths are not yet disabled or proven fail closed.",
+        "Partition deletion, download/transfer draining, idle route release, disk quotas, and browser-profile cloning are later lifecycle stages.",
+        "Binding writes serialize in Electron main, and packaged hosts rely on Orca's per-userData single-instance lock. Activation still needs an explicit guard for dev instances that share userData or a cross-process CAS/lock.",
+        "Sequential proxy or policy setup failures retain durable bindings and can exhaust the 512-binding ledger. Activation requires bounded tombstone recovery and partition garbage collection.",
+        "Each preparePage synchronously reads and parses bounded binding metadata on Electron main; activation requires latency evidence or a safely invalidated cache before this becomes frequent."
+      ],
+      "demotionRule": "Keep experimental or demote if raw identities enter a partition path, a durable binding mismatch is reused, a partition retargets to another execution host or live listener, a route partition becomes attachable before exact proxy verification, initial attachment can navigate beyond blank, stale cleanup retires a replacement, admission exceeds a declared cap, or any browser request reaches desktop DNS, TCP, UDP, localhost, or system proxy outside the selected route."
     },
     {
       "id": "browser-stream.bounded-reconnect",

--- a/src/main/browser/browser-route-identity.test.ts
+++ b/src/main/browser/browser-route-identity.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { deriveBrowserRoutePartition } from './browser-route-identity'
+
+const identity = {
+  orcaProfileId: 'orca/profile:alpha',
+  browserProfileId: 'browser/profile:default',
+  authorityConnectionIdentity: 'paired/runtime:authority',
+  executionHostIdentity: 'ssh/target:private.example'
+}
+
+describe('browser route partition identity', () => {
+  it('derives a stable opaque cross-platform partition and binding fingerprint', () => {
+    const first = deriveBrowserRoutePartition(identity)
+    const second = deriveBrowserRoutePartition({ ...identity })
+
+    expect(second).toEqual(first)
+    expect(first.partition).toMatch(/^persist:orca-browser-v1-[a-f0-9]{64}$/)
+    expect(first.bindingFingerprint).toMatch(/^[a-f0-9]{64}$/)
+    expect(first.partition.slice('persist:'.length)).toMatch(/^[a-z0-9-]+$/)
+    for (const rawIdentity of Object.values(identity)) {
+      expect(first.partition).not.toContain(rawIdentity)
+    }
+    expect(first.partition).not.toContain('private.example')
+  })
+
+  it('keeps delimiter-containing components structurally distinct', () => {
+    const left = deriveBrowserRoutePartition({
+      ...identity,
+      orcaProfileId: 'a',
+      browserProfileId: 'b:c'
+    })
+    const right = deriveBrowserRoutePartition({
+      ...identity,
+      orcaProfileId: 'a:b',
+      browserProfileId: 'c'
+    })
+
+    expect(left).not.toEqual(right)
+  })
+
+  it('does not expose equality of individual identity components', () => {
+    const baseline = deriveBrowserRoutePartition(identity).partition
+    const sameProfile = deriveBrowserRoutePartition({
+      ...identity,
+      executionHostIdentity: 'ssh/target:other.example'
+    }).partition
+
+    expect(baseline.split('-').at(-1)).not.toBe(sameProfile.split('-').at(-1))
+    expect(baseline).not.toMatch(/:[a-f0-9]{16}:/)
+  })
+
+  it('rejects empty and unbounded identity components', () => {
+    expect(() => deriveBrowserRoutePartition({ ...identity, executionHostIdentity: '' })).toThrow(
+      'browser_route_partition_identity_invalid'
+    )
+    expect(() =>
+      deriveBrowserRoutePartition({ ...identity, authorityConnectionIdentity: 'x'.repeat(513) })
+    ).toThrow('browser_route_partition_identity_invalid')
+    expect(() =>
+      deriveBrowserRoutePartition({ ...identity, authorityConnectionIdentity: 'é'.repeat(257) })
+    ).toThrow('browser_route_partition_identity_invalid')
+    expect(() =>
+      deriveBrowserRoutePartition({ ...identity, authorityConnectionIdentity: 'é'.repeat(256) })
+    ).not.toThrow()
+  })
+})

--- a/src/main/browser/browser-route-identity.ts
+++ b/src/main/browser/browser-route-identity.ts
@@ -1,0 +1,58 @@
+import { createHash } from 'node:crypto'
+
+const MAX_IDENTITY_LENGTH = 512
+const PARTITION_IDENTITY_VERSION = 1
+const BROWSER_ROUTE_PARTITION_RE = /^persist:orca-browser-v1-[a-f0-9]{64}$/
+
+export type BrowserRoutePartitionIdentity = Readonly<{
+  orcaProfileId: string
+  browserProfileId: string
+  authorityConnectionIdentity: string
+  executionHostIdentity: string
+}>
+
+export type DerivedBrowserRoutePartition = Readonly<{
+  partition: string
+  bindingFingerprint: string
+}>
+
+export function deriveBrowserRoutePartition(
+  identity: BrowserRoutePartitionIdentity
+): DerivedBrowserRoutePartition {
+  const components = [
+    ['orca-profile', identity.orcaProfileId],
+    ['browser-profile', identity.browserProfileId],
+    ['authority-connection', identity.authorityConnectionIdentity],
+    ['execution-host', identity.executionHostIdentity]
+  ] as const
+  for (const [, value] of components) {
+    if (
+      typeof value !== 'string' ||
+      value.length === 0 ||
+      Buffer.byteLength(value, 'utf8') > MAX_IDENTITY_LENGTH
+    ) {
+      throw new Error('browser_route_partition_identity_invalid')
+    }
+  }
+
+  return {
+    partition: `persist:orca-browser-v${PARTITION_IDENTITY_VERSION}-${digest([
+      'orca-browser-route-partition',
+      PARTITION_IDENTITY_VERSION,
+      ...components
+    ])}`,
+    bindingFingerprint: digest([
+      'orca-browser-route-partition-binding',
+      PARTITION_IDENTITY_VERSION,
+      ...components
+    ])
+  }
+}
+
+export function isBrowserRoutePartition(value: string): boolean {
+  return BROWSER_ROUTE_PARTITION_RE.test(value)
+}
+
+function digest(value: unknown): string {
+  return createHash('sha256').update(JSON.stringify(value), 'utf8').digest('hex')
+}

--- a/src/main/browser/browser-route-partition-binding-store.test.ts
+++ b/src/main/browser/browser-route-partition-binding-store.test.ts
@@ -1,0 +1,103 @@
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { BrowserRoutePartitionBindingStore } from './browser-route-partition-binding-store'
+
+const partition =
+  'persist:orca-browser-v1-1111111111111111222222222222222233333333333333334444444444444444'
+const fingerprint = 'a'.repeat(64)
+
+function createPath(): string {
+  return join(mkdtempSync(join(tmpdir(), 'orca-browser-route-bindings-')), 'bindings.json')
+}
+
+function createStorePaths(): { filePath: string; partitionDataRoot: string } {
+  const root = mkdtempSync(join(tmpdir(), 'orca-browser-route-store-'))
+  return {
+    filePath: join(root, 'profile', 'bindings.json'),
+    partitionDataRoot: join(root, 'Partitions')
+  }
+}
+
+describe('BrowserRoutePartitionBindingStore', () => {
+  it('persists an opaque binding for restart-time collision checks', () => {
+    const filePath = createPath()
+    const first = new BrowserRoutePartitionBindingStore({ filePath })
+    first.set(partition, fingerprint)
+
+    expect(new BrowserRoutePartitionBindingStore({ filePath }).get(partition)).toBe(fingerprint)
+    const serialized = readFileSync(filePath, 'utf8')
+    expect(serialized).not.toContain('authority-a')
+    expect(JSON.parse(serialized)).toEqual({ version: 1, bindings: { [partition]: fingerprint } })
+  })
+
+  it('rejects replacement and invalid binding shapes', () => {
+    const store = new BrowserRoutePartitionBindingStore({ filePath: createPath() })
+    store.set(partition, fingerprint)
+
+    expect(() => store.set(partition, 'b'.repeat(64))).toThrow(
+      'browser_route_partition_binding_conflict'
+    )
+    expect(() => store.set('persist:unowned', fingerprint)).toThrow(
+      'browser_route_partition_binding_invalid'
+    )
+    expect(() => store.set(partition, 'short')).toThrow('browser_route_partition_binding_invalid')
+  })
+
+  it('fails closed on corrupt or malformed persisted metadata', () => {
+    const filePath = createPath()
+    writeFileSync(filePath, '{broken')
+    expect(() => new BrowserRoutePartitionBindingStore({ filePath }).get(partition)).toThrow(
+      'browser_route_partition_binding_store_invalid'
+    )
+
+    writeFileSync(filePath, JSON.stringify({ version: 2, bindings: {} }))
+    expect(() => new BrowserRoutePartitionBindingStore({ filePath }).get(partition)).toThrow(
+      'browser_route_partition_binding_store_invalid'
+    )
+  })
+
+  it('rejects an oversized binding file before parsing it', () => {
+    const filePath = createPath()
+    writeFileSync(filePath, JSON.stringify({ version: 1, bindings: {}, padding: 'x'.repeat(256) }))
+
+    expect(() =>
+      new BrowserRoutePartitionBindingStore({ filePath, maxFileBytes: 128 }).get(partition)
+    ).toThrow('browser_route_partition_binding_store_invalid')
+  })
+
+  it('fails closed when Chromium data exists without matching binding metadata', () => {
+    const paths = createStorePaths()
+    mkdirSync(join(paths.partitionDataRoot, partition.slice('persist:'.length)), {
+      recursive: true
+    })
+    const store = new BrowserRoutePartitionBindingStore(paths)
+
+    expect(() => store.get(partition)).toThrow('browser_route_partition_binding_store_invalid')
+    expect(() => store.set(partition, fingerprint)).toThrow(
+      'browser_route_partition_binding_store_invalid'
+    )
+  })
+
+  it('accepts existing Chromium data only with matching durable metadata', () => {
+    const paths = createStorePaths()
+    const store = new BrowserRoutePartitionBindingStore(paths)
+    store.set(partition, fingerprint)
+    mkdirSync(join(paths.partitionDataRoot, partition.slice('persist:'.length)), {
+      recursive: true
+    })
+
+    expect(store.get(partition)).toBe(fingerprint)
+  })
+
+  it('bounds distinct persisted bindings', () => {
+    const store = new BrowserRoutePartitionBindingStore({ filePath: createPath(), maxBindings: 1 })
+    store.set(partition, fingerprint)
+    const secondPartition = partition.replace(/1{16}/, '5555555555555555')
+
+    expect(() => store.set(secondPartition, 'b'.repeat(64))).toThrow(
+      'browser_route_partition_binding_capacity'
+    )
+  })
+})

--- a/src/main/browser/browser-route-partition-binding-store.ts
+++ b/src/main/browser/browser-route-partition-binding-store.ts
@@ -1,0 +1,181 @@
+import { closeSync, existsSync, fstatSync, mkdirSync, openSync, readSync, statSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { grantDirAcl, isPermissionError } from '../win32-utils'
+import { durableWriteTempPath, writeFileDurableSync } from '../durable-file-write'
+import { isBrowserRoutePartition } from './browser-route-identity'
+
+const BINDING_STORE_VERSION = 1
+const DEFAULT_MAX_BINDINGS = 512
+const DEFAULT_MAX_FILE_BYTES = 128 * 1024
+const FINGERPRINT_RE = /^[a-f0-9]{64}$/
+const PERSIST_PARTITION_PREFIX = 'persist:'
+
+type BindingState = {
+  version: typeof BINDING_STORE_VERSION
+  bindings: Record<string, string>
+}
+
+export class BrowserRoutePartitionBindingStore {
+  private readonly maxBindings: number
+  private readonly maxFileBytes: number
+
+  constructor(
+    private readonly options: {
+      filePath: string
+      partitionDataRoot?: string
+      maxBindings?: number
+      maxFileBytes?: number
+    }
+  ) {
+    this.maxBindings = options.maxBindings ?? DEFAULT_MAX_BINDINGS
+    this.maxFileBytes = options.maxFileBytes ?? DEFAULT_MAX_FILE_BYTES
+  }
+
+  get(partition: string): string | null {
+    assertBinding(partition, 'a'.repeat(64))
+    const state = this.load()
+    this.assertMetadataPrecedesPartitionData(partition, state)
+    return state.bindings[partition] ?? null
+  }
+
+  set(partition: string, fingerprint: string): void {
+    assertBinding(partition, fingerprint)
+    const state = this.load()
+    this.assertMetadataPrecedesPartitionData(partition, state)
+    const existing = state.bindings[partition]
+    if (existing === fingerprint) {
+      return
+    }
+    if (existing !== undefined) {
+      throw new Error('browser_route_partition_binding_conflict')
+    }
+    if (Object.keys(state.bindings).length >= this.maxBindings) {
+      throw new Error('browser_route_partition_binding_capacity')
+    }
+    const next: BindingState = {
+      version: BINDING_STORE_VERSION,
+      bindings: { ...state.bindings, [partition]: fingerprint }
+    }
+    mkdirSync(dirname(this.options.filePath), { recursive: true })
+    this.writeDurably(`${JSON.stringify(next)}\n`)
+  }
+
+  private load(): BindingState {
+    if (!existsSync(this.options.filePath)) {
+      return { version: BINDING_STORE_VERSION, bindings: {} }
+    }
+    try {
+      const parsed: unknown = JSON.parse(
+        readBoundedUtf8File(this.options.filePath, this.maxFileBytes)
+      )
+      if (!isBindingState(parsed, this.maxBindings)) {
+        throw new Error('invalid binding state')
+      }
+      return parsed
+    } catch {
+      throw new Error('browser_route_partition_binding_store_invalid')
+    }
+  }
+
+  private assertMetadataPrecedesPartitionData(partition: string, state: BindingState): void {
+    if (state.bindings[partition] !== undefined || !this.options.partitionDataRoot) {
+      return
+    }
+    const partitionPath = join(
+      this.options.partitionDataRoot,
+      partition.slice(PERSIST_PARTITION_PREFIX.length)
+    )
+    try {
+      statSync(partitionPath)
+    } catch (error) {
+      if (hasErrorCode(error, 'ENOENT')) {
+        return
+      }
+      throw new Error('browser_route_partition_binding_store_invalid')
+    }
+    throw new Error('browser_route_partition_binding_store_invalid')
+  }
+
+  private writeDurably(contents: string): void {
+    try {
+      writeFileDurableSync(
+        durableWriteTempPath(this.options.filePath),
+        this.options.filePath,
+        contents
+      )
+    } catch (error) {
+      if (!isPermissionError(error) || process.platform !== 'win32') {
+        throw error
+      }
+      grantDirAcl(dirname(this.options.filePath))
+      writeFileDurableSync(
+        durableWriteTempPath(this.options.filePath),
+        this.options.filePath,
+        contents
+      )
+    }
+  }
+}
+
+function readBoundedUtf8File(filePath: string, maxBytes: number): string {
+  const fd = openSync(filePath, 'r')
+  try {
+    const size = fstatSync(fd).size
+    if (!Number.isSafeInteger(size) || size < 0 || size > maxBytes) {
+      throw new Error('binding file size invalid')
+    }
+    const contents = Buffer.alloc(size)
+    let offset = 0
+    while (offset < size) {
+      const bytesRead = readSync(fd, contents, offset, size - offset, null)
+      if (bytesRead === 0) {
+        throw new Error('binding file truncated')
+      }
+      offset += bytesRead
+    }
+    const overflowProbe = Buffer.alloc(1)
+    if (readSync(fd, overflowProbe, 0, 1, null) !== 0) {
+      throw new Error('binding file grew during read')
+    }
+    return contents.toString('utf8')
+  } finally {
+    closeSync(fd)
+  }
+}
+
+function hasErrorCode(error: unknown, code: string): boolean {
+  return Boolean(error && typeof error === 'object' && 'code' in error && error.code === code)
+}
+
+function isBindingState(value: unknown, maxBindings: number): value is BindingState {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+  const candidate = value as Partial<BindingState>
+  if (
+    candidate.version !== BINDING_STORE_VERSION ||
+    !candidate.bindings ||
+    typeof candidate.bindings !== 'object' ||
+    Array.isArray(candidate.bindings)
+  ) {
+    return false
+  }
+  const entries = Object.entries(candidate.bindings)
+  return (
+    entries.length <= maxBindings &&
+    entries.every(([partition, fingerprint]) => {
+      try {
+        assertBinding(partition, fingerprint)
+        return true
+      } catch {
+        return false
+      }
+    })
+  )
+}
+
+function assertBinding(partition: string, fingerprint: string): void {
+  if (!isBrowserRoutePartition(partition) || !FINGERPRINT_RE.test(fingerprint)) {
+    throw new Error('browser_route_partition_binding_invalid')
+  }
+}

--- a/src/main/browser/browser-route-session-registry.test.ts
+++ b/src/main/browser/browser-route-session-registry.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  BrowserRouteSessionRegistry,
+  type BrowserRouteElectronSession,
+  type BrowserRouteSessionRegistryDependencies
+} from './browser-route-session-registry'
+
+const identity = {
+  orcaProfileId: 'orca-profile-a',
+  browserProfileId: 'browser-profile-a',
+  authorityConnectionIdentity: 'authority-a',
+  executionHostIdentity: 'execution-host-a'
+}
+
+function createHarness(
+  options: {
+    resolvedProxy?: string
+    maxLivePartitions?: number
+    maxPagesPerPartition?: number
+    setupError?: Error
+    profileError?: Error
+  } = {}
+) {
+  const order: string[] = []
+  const bindings = new Map<string, string>()
+  let registry: BrowserRouteSessionRegistry
+  const session: BrowserRouteElectronSession = {
+    setProxy: vi.fn(async () => {
+      order.push('set-proxy')
+      expect(registry.isAllowedPartition('persist:route-a')).toBe(false)
+    }),
+    closeAllConnections: vi.fn(async () => {
+      order.push('close-connections')
+      expect(registry.isAllowedPartition('persist:route-a')).toBe(false)
+    }),
+    resolveProxy: vi.fn(async () => {
+      order.push('resolve-proxy')
+      expect(registry.isAllowedPartition('persist:route-a')).toBe(false)
+      return options.resolvedProxy ?? 'SOCKS5 127.0.0.1:43123'
+    })
+  }
+  const dependencies: BrowserRouteSessionRegistryDependencies = {
+    derivePartition: (input) => ({
+      partition:
+        input.executionHostIdentity === 'execution-host-b' ? 'persist:route-b' : 'persist:route-a',
+      bindingFingerprint:
+        input.executionHostIdentity === 'execution-host-b' ? 'b'.repeat(64) : 'a'.repeat(64)
+    }),
+    validateProfile: vi.fn(() => {
+      order.push('validate-profile')
+      if (options.profileError) {
+        throw options.profileError
+      }
+    }),
+    getSession: vi.fn(() => {
+      order.push('get-session')
+      return session
+    }),
+    setupPolicies: vi.fn(() => {
+      order.push('setup-policies')
+      if (options.setupError) {
+        throw options.setupError
+      }
+    }),
+    clearPolicies: vi.fn(() => order.push('clear-policies')),
+    bindingStore: {
+      get: vi.fn((partition) => bindings.get(partition) ?? null),
+      set: vi.fn((partition, fingerprint) => {
+        order.push('persist-binding')
+        bindings.set(partition, fingerprint)
+      })
+    },
+    maxLivePartitions: options.maxLivePartitions,
+    maxPagesPerPartition: options.maxPagesPerPartition
+  }
+  registry = new BrowserRouteSessionRegistry(dependencies)
+  return { bindings, dependencies, order, registry, session }
+}
+
+function prepare(registry: BrowserRouteSessionRegistry, overrides: Record<string, unknown> = {}) {
+  return registry.preparePage({
+    identity,
+    browserPageId: 'page-a',
+    pageHostGeneration: 1,
+    proxyEndpoint: { host: '127.0.0.1', port: 43123 },
+    ...overrides
+  })
+}
+
+describe('BrowserRouteSessionRegistry', () => {
+  it('applies and verifies the exact fail-closed proxy before allowlisting', async () => {
+    const { dependencies, order, registry, session } = createHarness()
+
+    const handle = await prepare(registry)
+
+    expect(handle.partition).toBe('persist:route-a')
+    expect(order).toEqual([
+      'validate-profile',
+      'persist-binding',
+      'get-session',
+      'setup-policies',
+      'set-proxy',
+      'close-connections',
+      'resolve-proxy'
+    ])
+    expect(session.setProxy).toHaveBeenCalledWith({
+      mode: 'fixed_servers',
+      proxyRules: 'socks5://127.0.0.1:43123',
+      proxyBypassRules: '<-loopback>'
+    })
+    expect(session.resolveProxy).toHaveBeenCalledWith('http://browser-route-probe.invalid/')
+    expect(registry.isAllowedPartition(handle.partition)).toBe(true)
+
+    handle.release()
+    expect(registry.isAllowedPartition(handle.partition)).toBe(false)
+    expect(dependencies.clearPolicies).toHaveBeenCalledTimes(1)
+  })
+
+  it('never allowlists a partition whose proxy resolves direct or elsewhere', async () => {
+    const { dependencies, registry } = createHarness({ resolvedProxy: 'DIRECT' })
+
+    await expect(prepare(registry)).rejects.toThrow(
+      'browser_route_partition_proxy_verification_failed'
+    )
+    expect(registry.isAllowedPartition('persist:route-a')).toBe(false)
+    expect(dependencies.clearPolicies).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears partially installed policies when policy setup fails', async () => {
+    const { dependencies, registry, session } = createHarness({
+      setupError: new Error('policy setup failed')
+    })
+
+    await expect(prepare(registry)).rejects.toThrow('policy setup failed')
+    expect(session.setProxy).not.toHaveBeenCalled()
+    expect(dependencies.clearPolicies).toHaveBeenCalledTimes(1)
+    expect(registry.isAllowedPartition('persist:route-a')).toBe(false)
+  })
+
+  it('rejects a binding collision before opening an Electron session', async () => {
+    const { bindings, dependencies, registry } = createHarness()
+    bindings.set('persist:route-a', 'c'.repeat(64))
+
+    await expect(prepare(registry)).rejects.toThrow('browser_route_partition_binding_conflict')
+    expect(dependencies.getSession).not.toHaveBeenCalled()
+  })
+
+  it('rejects a missing browser profile before consuming durable binding capacity', async () => {
+    const { dependencies, registry } = createHarness({
+      profileError: new Error('browser_route_partition_profile_unavailable')
+    })
+
+    await expect(prepare(registry)).rejects.toThrow('browser_route_partition_profile_unavailable')
+    expect(dependencies.bindingStore.set).not.toHaveBeenCalled()
+    expect(dependencies.getSession).not.toHaveBeenCalled()
+  })
+
+  it('rejects invalid listener and page identities before binding persistence', async () => {
+    const { dependencies, registry } = createHarness()
+
+    await expect(
+      prepare(registry, { proxyEndpoint: { host: '0.0.0.0', port: 43123 } })
+    ).rejects.toThrow('browser_route_partition_proxy_invalid')
+    await expect(prepare(registry, { browserPageId: '' })).rejects.toThrow(
+      'browser_route_partition_page_invalid'
+    )
+    await expect(prepare(registry, { pageHostGeneration: 0 })).rejects.toThrow(
+      'browser_route_partition_page_invalid'
+    )
+    expect(dependencies.bindingStore.set).not.toHaveBeenCalled()
+    expect(dependencies.getSession).not.toHaveBeenCalled()
+  })
+
+  it('shares one prepared partition and fences stale page-handle cleanup', async () => {
+    const { dependencies, registry, session } = createHarness()
+    const first = await prepare(registry)
+    const replacement = await prepare(registry)
+
+    expect(session.setProxy).toHaveBeenCalledTimes(1)
+    first.release()
+    expect(registry.isAllowedPartition(first.partition)).toBe(true)
+    replacement.release()
+    expect(registry.isAllowedPartition(first.partition)).toBe(false)
+    expect(dependencies.clearPolicies).toHaveBeenCalledTimes(1)
+  })
+
+  it('coalesces concurrent setup and refuses live proxy retargeting', async () => {
+    const { registry, session } = createHarness()
+    const [first, second] = await Promise.all([
+      prepare(registry),
+      prepare(registry, { browserPageId: 'page-b' })
+    ])
+
+    expect(session.setProxy).toHaveBeenCalledTimes(1)
+    await expect(
+      prepare(registry, {
+        browserPageId: 'page-c',
+        proxyEndpoint: { host: '127.0.0.1', port: 43124 }
+      })
+    ).rejects.toThrow('browser_route_partition_proxy_retarget')
+    first.release()
+    second.release()
+  })
+
+  it('bounds distinct live and pending partitions', async () => {
+    const { registry } = createHarness({ maxLivePartitions: 1 })
+    const first = await prepare(registry)
+
+    await expect(
+      prepare(registry, {
+        browserPageId: 'page-b',
+        identity: { ...identity, executionHostIdentity: 'execution-host-b' }
+      })
+    ).rejects.toThrow('browser_route_partition_capacity')
+    first.release()
+  })
+
+  it('bounds distinct page generations retained by one partition', async () => {
+    const { registry } = createHarness({ maxPagesPerPartition: 1 })
+    const first = await prepare(registry)
+
+    await expect(prepare(registry, { browserPageId: 'page-b' })).rejects.toThrow(
+      'browser_route_partition_page_capacity'
+    )
+    first.release()
+  })
+})

--- a/src/main/browser/browser-route-session-registry.ts
+++ b/src/main/browser/browser-route-session-registry.ts
@@ -1,0 +1,248 @@
+import {
+  deriveBrowserRoutePartition,
+  type BrowserRoutePartitionIdentity,
+  type DerivedBrowserRoutePartition
+} from './browser-route-identity'
+
+const DEFAULT_MAX_LIVE_PARTITIONS = 64
+const DEFAULT_MAX_PAGES_PER_PARTITION = 64
+const MAX_PAGE_ID_LENGTH = 256
+const MAX_PAGE_HOST_GENERATION = 0xffff_ffff
+const PROXY_PROBE_URL = 'http://browser-route-probe.invalid/'
+
+export type BrowserRouteElectronSession = {
+  setProxy(config: {
+    mode: 'fixed_servers'
+    proxyRules: string
+    proxyBypassRules: string
+  }): Promise<void>
+  closeAllConnections(): Promise<void>
+  resolveProxy(url: string): Promise<string>
+}
+
+export type BrowserRoutePartitionBindingStore = {
+  get(partition: string): string | null
+  set(partition: string, fingerprint: string): void
+}
+
+export type BrowserRouteSessionRegistryDependencies = {
+  derivePartition?: (identity: BrowserRoutePartitionIdentity) => DerivedBrowserRoutePartition
+  validateProfile(browserProfileId: string): void
+  getSession(partition: string): BrowserRouteElectronSession
+  setupPolicies(input: {
+    partition: string
+    browserProfileId: string
+    session: BrowserRouteElectronSession
+  }): void
+  clearPolicies(input: { partition: string; session: BrowserRouteElectronSession }): void
+  bindingStore: BrowserRoutePartitionBindingStore
+  maxLivePartitions?: number
+  maxPagesPerPartition?: number
+}
+
+export type BrowserRouteSessionHandle = Readonly<{
+  partition: string
+  release: () => void
+}>
+
+type ProxyEndpoint = Readonly<{ host: '127.0.0.1'; port: number }>
+
+type PreparedPartition = {
+  partition: string
+  bindingFingerprint: string
+  browserProfileId: string
+  proxyEndpoint: ProxyEndpoint
+  session: BrowserRouteElectronSession
+  pageTokens: Map<string, symbol>
+}
+
+type PendingPartition = {
+  bindingFingerprint: string
+  proxyEndpoint: ProxyEndpoint
+  promise: Promise<PreparedPartition>
+}
+
+export class BrowserRouteSessionRegistry {
+  private readonly derivePartition: NonNullable<
+    BrowserRouteSessionRegistryDependencies['derivePartition']
+  >
+  private readonly maxLivePartitions: number
+  private readonly maxPagesPerPartition: number
+  private readonly live = new Map<string, PreparedPartition>()
+  private readonly pending = new Map<string, PendingPartition>()
+
+  constructor(private readonly dependencies: BrowserRouteSessionRegistryDependencies) {
+    this.derivePartition = dependencies.derivePartition ?? deriveBrowserRoutePartition
+    this.maxLivePartitions = dependencies.maxLivePartitions ?? DEFAULT_MAX_LIVE_PARTITIONS
+    this.maxPagesPerPartition = dependencies.maxPagesPerPartition ?? DEFAULT_MAX_PAGES_PER_PARTITION
+  }
+
+  isAllowedPartition(partition: string): boolean {
+    return this.live.has(partition)
+  }
+
+  async preparePage(input: {
+    identity: BrowserRoutePartitionIdentity
+    browserPageId: string
+    pageHostGeneration: number
+    proxyEndpoint: ProxyEndpoint
+  }): Promise<BrowserRouteSessionHandle> {
+    assertProxyEndpoint(input.proxyEndpoint)
+    assertPageIdentity(input.browserPageId, input.pageHostGeneration)
+    const derived = this.derivePartition(input.identity)
+    this.dependencies.validateProfile(input.identity.browserProfileId)
+    this.assertBinding(derived)
+    let state = this.live.get(derived.partition)
+    if (state) {
+      this.assertReusable(state, derived, input.proxyEndpoint)
+      return this.linkPage(state, input.browserPageId, input.pageHostGeneration)
+    }
+
+    const pending = this.pending.get(derived.partition)
+    if (pending) {
+      this.assertReusable(pending, derived, input.proxyEndpoint)
+      state = await pending.promise
+      return this.linkPage(state, input.browserPageId, input.pageHostGeneration)
+    }
+
+    if (this.live.size + this.pending.size >= this.maxLivePartitions) {
+      throw new Error('browser_route_partition_capacity')
+    }
+    if (this.dependencies.bindingStore.get(derived.partition) === null) {
+      this.dependencies.bindingStore.set(derived.partition, derived.bindingFingerprint)
+    }
+    const promise = this.preparePartition(
+      derived,
+      input.identity.browserProfileId,
+      input.proxyEndpoint
+    )
+    const pendingState = {
+      bindingFingerprint: derived.bindingFingerprint,
+      proxyEndpoint: input.proxyEndpoint,
+      promise
+    }
+    this.pending.set(derived.partition, pendingState)
+    try {
+      state = await promise
+      this.live.set(derived.partition, state)
+    } finally {
+      if (this.pending.get(derived.partition) === pendingState) {
+        this.pending.delete(derived.partition)
+      }
+    }
+    return this.linkPage(state, input.browserPageId, input.pageHostGeneration)
+  }
+
+  private assertBinding(derived: DerivedBrowserRoutePartition): void {
+    const persisted = this.dependencies.bindingStore.get(derived.partition)
+    if (persisted !== null && persisted !== derived.bindingFingerprint) {
+      throw new Error('browser_route_partition_binding_conflict')
+    }
+  }
+
+  private assertReusable(
+    state: Pick<PreparedPartition, 'bindingFingerprint' | 'proxyEndpoint'>,
+    derived: DerivedBrowserRoutePartition,
+    proxyEndpoint: ProxyEndpoint
+  ): void {
+    if (state.bindingFingerprint !== derived.bindingFingerprint) {
+      throw new Error('browser_route_partition_binding_conflict')
+    }
+    if (!sameProxyEndpoint(state.proxyEndpoint, proxyEndpoint)) {
+      throw new Error('browser_route_partition_proxy_retarget')
+    }
+  }
+
+  private async preparePartition(
+    derived: DerivedBrowserRoutePartition,
+    browserProfileId: string,
+    proxyEndpoint: ProxyEndpoint
+  ): Promise<PreparedPartition> {
+    const session = this.dependencies.getSession(derived.partition)
+    try {
+      this.dependencies.setupPolicies({ partition: derived.partition, browserProfileId, session })
+      await session.setProxy({
+        mode: 'fixed_servers',
+        proxyRules: `socks5://${proxyEndpoint.host}:${proxyEndpoint.port}`,
+        proxyBypassRules: '<-loopback>'
+      })
+      await session.closeAllConnections()
+      const resolved = await session.resolveProxy(PROXY_PROBE_URL)
+      if (resolved.trim() !== `SOCKS5 ${proxyEndpoint.host}:${proxyEndpoint.port}`) {
+        throw new Error('browser_route_partition_proxy_verification_failed')
+      }
+    } catch (error) {
+      try {
+        this.dependencies.clearPolicies({ partition: derived.partition, session })
+      } catch {
+        // The partition remains outside the allowlist even if policy cleanup fails.
+      }
+      throw error
+    }
+    return {
+      partition: derived.partition,
+      bindingFingerprint: derived.bindingFingerprint,
+      browserProfileId,
+      proxyEndpoint,
+      session,
+      pageTokens: new Map()
+    }
+  }
+
+  private linkPage(
+    state: PreparedPartition,
+    browserPageId: string,
+    pageHostGeneration: number
+  ): BrowserRouteSessionHandle {
+    const pageKey = JSON.stringify([browserPageId, pageHostGeneration])
+    if (!state.pageTokens.has(pageKey) && state.pageTokens.size >= this.maxPagesPerPartition) {
+      throw new Error('browser_route_partition_page_capacity')
+    }
+    const token = Symbol(pageKey)
+    state.pageTokens.set(pageKey, token)
+    return {
+      partition: state.partition,
+      release: () => {
+        if (state.pageTokens.get(pageKey) !== token) {
+          return
+        }
+        state.pageTokens.delete(pageKey)
+        if (state.pageTokens.size !== 0 || this.live.get(state.partition) !== state) {
+          return
+        }
+        this.live.delete(state.partition)
+        this.dependencies.clearPolicies({ partition: state.partition, session: state.session })
+      }
+    }
+  }
+}
+
+function assertProxyEndpoint(
+  endpoint: Readonly<{ host: string; port: number }>
+): asserts endpoint is ProxyEndpoint {
+  if (
+    endpoint.host !== '127.0.0.1' ||
+    !Number.isInteger(endpoint.port) ||
+    endpoint.port < 1 ||
+    endpoint.port > 65_535
+  ) {
+    throw new Error('browser_route_partition_proxy_invalid')
+  }
+}
+
+function sameProxyEndpoint(left: ProxyEndpoint, right: ProxyEndpoint): boolean {
+  return left.host === right.host && left.port === right.port
+}
+
+function assertPageIdentity(browserPageId: string, pageHostGeneration: number): void {
+  if (
+    typeof browserPageId !== 'string' ||
+    browserPageId.length === 0 ||
+    browserPageId.length > MAX_PAGE_ID_LENGTH ||
+    !Number.isInteger(pageHostGeneration) ||
+    pageHostGeneration < 1 ||
+    pageHostGeneration > MAX_PAGE_HOST_GENERATION
+  ) {
+    throw new Error('browser_route_partition_page_invalid')
+  }
+}

--- a/src/main/browser/browser-route-session-runtime.ts
+++ b/src/main/browser/browser-route-session-runtime.ts
@@ -1,0 +1,43 @@
+import { app, session } from 'electron'
+import { join } from 'node:path'
+import { BrowserRoutePartitionBindingStore } from './browser-route-partition-binding-store'
+import { BrowserRouteSessionRegistry } from './browser-route-session-registry'
+import { browserSessionRegistry } from './browser-session-registry'
+
+const BINDING_FILE_NAME = 'browser-route-partition-bindings.json'
+const PARTITION_DATA_DIRECTORY_NAME = 'Partitions'
+let bindingFilePathOverride: string | null = null
+
+const bindingStore = {
+  get(partition: string): string | null {
+    return currentBindingStore().get(partition)
+  },
+  set(partition: string, fingerprint: string): void {
+    currentBindingStore().set(partition, fingerprint)
+  }
+}
+
+export const browserRouteSessionRegistry = new BrowserRouteSessionRegistry({
+  validateProfile: (browserProfileId) => {
+    browserSessionRegistry.requireRouteBrowserProfile(browserProfileId)
+  },
+  getSession: (partition) => session.fromPartition(partition),
+  setupPolicies: ({ partition, browserProfileId }) => {
+    browserSessionRegistry.setupRoutePartitionPolicies(partition, browserProfileId)
+  },
+  clearPolicies: ({ partition }) => {
+    browserSessionRegistry.clearRoutePartitionPolicies(partition)
+  },
+  bindingStore
+})
+
+export function configureRouteSessionsForOrcaProfile(options: { profileDirectory: string }): void {
+  bindingFilePathOverride = join(options.profileDirectory, BINDING_FILE_NAME)
+}
+
+function currentBindingStore(): BrowserRoutePartitionBindingStore {
+  return new BrowserRoutePartitionBindingStore({
+    filePath: bindingFilePathOverride ?? join(app.getPath('userData'), BINDING_FILE_NAME),
+    partitionDataRoot: join(app.getPath('userData'), PARTITION_DATA_DIRECTORY_NAME)
+  })
+}

--- a/src/main/browser/browser-session-registry.test.ts
+++ b/src/main/browser/browser-session-registry.test.ts
@@ -235,6 +235,32 @@ describe('BrowserSessionRegistry', () => {
     expect(mockSession?.setDevicePermissionHandler).toHaveBeenCalled()
   })
 
+  it('applies and clears existing browser-profile policy on an opaque route partition', () => {
+    const partition =
+      'persist:orca-browser-v1-1111111111111111222222222222222233333333333333334444444444444444'
+
+    browserSessionRegistry.setupRoutePartitionPolicies(partition, 'default')
+
+    expect(sessionFromPartitionMock).toHaveBeenCalledWith(partition)
+    const configuredSession = sessionFromPartitionMock.mock.results[0]?.value
+    expect(configuredSession.setPermissionRequestHandler).toHaveBeenCalled()
+    expect(configuredSession.setPermissionCheckHandler).toHaveBeenCalled()
+
+    browserSessionRegistry.clearRoutePartitionPolicies(partition)
+    const clearedSession = sessionFromPartitionMock.mock.results.at(-1)?.value
+    expect(clearedSession.setPermissionRequestHandler).toHaveBeenCalledWith(null)
+    expect(clearedSession.setPermissionCheckHandler).toHaveBeenCalledWith(null)
+  })
+
+  it('rejects route partitions for missing browser profiles', () => {
+    const partition =
+      'persist:orca-browser-v1-aaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbccccccccccccccccdddddddddddddddd'
+
+    expect(() =>
+      browserSessionRegistry.setupRoutePartitionPolicies(partition, 'missing-profile')
+    ).toThrow('browser_route_partition_profile_unavailable')
+  })
+
   it('auto-grants pointer lock for browser partitions', () => {
     browserSessionRegistry.createProfile('isolated', 'Pointer Lock Test')
     const mockSession = sessionFromPartitionMock.mock.results[0]?.value

--- a/src/main/browser/browser-session-registry.ts
+++ b/src/main/browser/browser-session-registry.ts
@@ -12,6 +12,7 @@ import type {
   BrowserSessionProfileCreateOptions,
   BrowserSessionProfileScope
 } from '../../shared/browser-workspace-types'
+import { isBrowserRoutePartition } from './browser-route-identity'
 import {
   applyPendingBrowserCookieImports,
   clearPendingBrowserCookieImport,
@@ -175,6 +176,29 @@ class BrowserSessionRegistry {
       return this.defaultPartition
     }
     return this.profiles.get(profileId)?.partition ?? null
+  }
+
+  setupRoutePartitionPolicies(partition: string, browserProfileId: string): void {
+    const profile = this.profiles.get(browserProfileId)
+    if (!profile || !isBrowserRoutePartition(partition)) {
+      throw new Error('browser_route_partition_profile_unavailable')
+    }
+    installBrowserSessionPartitionPolicies({ ...profile, partition })
+  }
+
+  requireRouteBrowserProfile(browserProfileId: string): void {
+    if (!this.profiles.has(browserProfileId)) {
+      throw new Error('browser_route_partition_profile_unavailable')
+    }
+  }
+
+  clearRoutePartitionPolicies(partition: string): void {
+    if (!isBrowserRoutePartition(partition)) {
+      return
+    }
+    const sess = session.fromPartition(partition)
+    clearBrowserSessionUserAgentMode(sess)
+    clearBrowserSessionPartitionPolicies(partition, sess)
   }
 
   createProfile(

--- a/src/main/browser/browser-session-startup.test.ts
+++ b/src/main/browser/browser-session-startup.test.ts
@@ -2,10 +2,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 function installRegistryMock(): {
   configureForOrcaProfileMock: ReturnType<typeof vi.fn>
+  configureRouteSessionsForOrcaProfileMock: ReturnType<typeof vi.fn>
   applyPendingCookieImportMock: ReturnType<typeof vi.fn>
   initializeBrowserSessionsFromPersistedStateMock: ReturnType<typeof vi.fn>
 } {
   const configureForOrcaProfileMock = vi.fn()
+  const configureRouteSessionsForOrcaProfileMock = vi.fn()
   const applyPendingCookieImportMock = vi.fn()
   const initializeBrowserSessionsFromPersistedStateMock = vi.fn()
 
@@ -16,9 +18,13 @@ function installRegistryMock(): {
       initializeBrowserSessionsFromPersistedState: initializeBrowserSessionsFromPersistedStateMock
     }
   }))
+  vi.doMock('./browser-route-session-runtime', () => ({
+    configureRouteSessionsForOrcaProfile: configureRouteSessionsForOrcaProfileMock
+  }))
 
   return {
     configureForOrcaProfileMock,
+    configureRouteSessionsForOrcaProfileMock,
     applyPendingCookieImportMock,
     initializeBrowserSessionsFromPersistedStateMock
   }
@@ -47,6 +53,7 @@ describe('initializeBrowserSessionsForApp', () => {
   it('configures the active Orca profile before replaying browser sessions', async () => {
     const {
       configureForOrcaProfileMock,
+      configureRouteSessionsForOrcaProfileMock,
       applyPendingCookieImportMock,
       initializeBrowserSessionsFromPersistedStateMock
     } = installRegistryMock()
@@ -61,7 +68,13 @@ describe('initializeBrowserSessionsForApp', () => {
       orcaProfileId: 'local-work',
       profileDirectory: '/profiles/local-work'
     })
+    expect(configureRouteSessionsForOrcaProfileMock).toHaveBeenCalledWith({
+      profileDirectory: '/profiles/local-work'
+    })
     expect(configureForOrcaProfileMock.mock.invocationCallOrder[0]).toBeLessThan(
+      applyPendingCookieImportMock.mock.invocationCallOrder[0]
+    )
+    expect(configureRouteSessionsForOrcaProfileMock.mock.invocationCallOrder[0]).toBeLessThan(
       applyPendingCookieImportMock.mock.invocationCallOrder[0]
     )
     expect(applyPendingCookieImportMock.mock.invocationCallOrder[0]).toBeLessThan(

--- a/src/main/browser/browser-session-startup.ts
+++ b/src/main/browser/browser-session-startup.ts
@@ -1,5 +1,6 @@
 import { browserSessionRegistry } from './browser-session-registry'
 import type { BrowserSessionRegistryProfileOptions } from './browser-session-registry'
+import { configureRouteSessionsForOrcaProfile } from './browser-route-session-runtime'
 
 let initialized = false
 
@@ -12,6 +13,7 @@ export function initializeBrowserSessionsForApp(
 
   if (activeProfile) {
     browserSessionRegistry.configureForOrcaProfile(activeProfile)
+    configureRouteSessionsForOrcaProfile({ profileDirectory: activeProfile.profileDirectory })
   }
 
   // Why: cookie replay must happen before the first session.fromPartition()

--- a/src/main/durable-file-write.ts
+++ b/src/main/durable-file-write.ts
@@ -3,9 +3,10 @@
 // empty-file symptom as issue #1158, from a different cause. The .bak ring recovers it at up to an
 // hour's loss; fsync stops it from happening.
 
-import { closeSync, fsyncSync, openSync, renameSync, writeFileSync } from 'node:fs'
+import { closeSync, fsyncSync, openSync, rmSync, writeFileSync } from 'node:fs'
 import { open, readdir, rename, rm, stat } from 'node:fs/promises'
 import { basename, dirname, join } from 'node:path'
+import { renameFileWithWindowsRetry } from './codex-accounts/fs-utils'
 
 /**
  * fsync a directory so a rename within it is durable. Best-effort by design: Windows cannot open a
@@ -138,13 +139,21 @@ export async function removeStaleDurableWriteTempFiles(
 
 /** Synchronous counterpart for quit and crash paths that cannot await. */
 export function writeFileDurableSync(tmpPath: string, finalPath: string, payload: string): void {
-  writeFileSync(tmpPath, payload, 'utf-8')
-  const fd = openSync(tmpPath, 'r+')
+  let renamed = false
   try {
-    fsyncSync(fd)
+    writeFileSync(tmpPath, payload, 'utf-8')
+    const fd = openSync(tmpPath, 'r+')
+    try {
+      fsyncSync(fd)
+    } finally {
+      closeSync(fd)
+    }
+    renameFileWithWindowsRetry(tmpPath, finalPath)
+    renamed = true
+    syncDirectorySync(dirname(finalPath))
   } finally {
-    closeSync(fd)
+    if (!renamed) {
+      rmSync(tmpPath, { force: true })
+    }
   }
-  renameSync(tmpPath, finalPath)
-  syncDirectorySync(dirname(finalPath))
 }

--- a/src/main/window/createMainWindow-test-harness.ts
+++ b/src/main/window/createMainWindow-test-harness.ts
@@ -22,6 +22,7 @@ export const notificationMock: Mock<(...args: unknown[]) => { show: MainWindowSp
 )
 export const powerMonitorOnMock: MainWindowSpy = vi.fn()
 export const powerMonitorRemoveListenerMock: MainWindowSpy = vi.fn()
+export const routePartitionAllowedMock: Mock<(partition: string) => boolean> = vi.fn(() => false)
 export const isMock = { dev: false }
 export const macosTahoeMock = { value: false }
 
@@ -117,6 +118,8 @@ export function resetMainWindowMocks(): void {
   notificationShowMock.mockClear()
   powerMonitorOnMock.mockReset()
   powerMonitorRemoveListenerMock.mockReset()
+  routePartitionAllowedMock.mockReset()
+  routePartitionAllowedMock.mockReturnValue(false)
   isMock.dev = false
   macosTahoeMock.value = false
   ipcMainMock.on.mockReset()

--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -13,6 +13,11 @@ vi.mock('../app-icon', async () => (await import('./createMainWindow-test-harnes
 vi.mock('../browser/browser-manager', async () =>
   (await import('./createMainWindow-test-harness')).browserManagerMock()
 )
+vi.mock('../browser/browser-route-session-runtime', async () => ({
+  browserRouteSessionRegistry: {
+    isAllowedPartition: (await import('./createMainWindow-test-harness')).routePartitionAllowedMock
+  }
+}))
 
 import { createMainWindow, loadMainWindow } from './createMainWindow'
 import { ipcMain } from 'electron'
@@ -24,6 +29,7 @@ import {
   openExternalMock,
   powerMonitorOnMock,
   resetMainWindowMocks,
+  routePartitionAllowedMock,
   withPlatform
 } from './createMainWindow-test-harness'
 
@@ -183,6 +189,29 @@ describe('createMainWindow', () => {
       preload: expect.stringMatching(/browser-window-close-preload\.js$/),
       sandbox: true
     })
+
+    routePartitionAllowedMock.mockImplementation(
+      (partition) => partition === 'persist:orca-browser-v1-route-partition'
+    )
+    const allowRouteEvent = { preventDefault: vi.fn() }
+    const allowRoutePrefs = { partition: 'persist:orca-browser-v1-route-partition' }
+    windowHandlers['will-attach-webview'](
+      allowRouteEvent as never,
+      allowRoutePrefs as never,
+      { src: 'about:blank' } as never
+    )
+    expect(allowRouteEvent.preventDefault).not.toHaveBeenCalled()
+    expect(allowRoutePrefs).toMatchObject({
+      partition: 'persist:orca-browser-v1-route-partition',
+      sandbox: true
+    })
+    const denyRouteNavigationEvent = { preventDefault: vi.fn() }
+    windowHandlers['will-attach-webview'](
+      denyRouteNavigationEvent as never,
+      { partition: 'persist:orca-browser-v1-route-partition' } as never,
+      { src: 'https://example.com/' } as never
+    )
+    expect(denyRouteNavigationEvent.preventDefault).toHaveBeenCalledOnce()
 
     const denyInlineHtmlEvent = { preventDefault: vi.fn() }
     windowHandlers['will-attach-webview'](

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -15,9 +15,11 @@ import type { Store } from '../persistence'
 import { getAppIconPath } from '../app-icon'
 import { browserManager } from '../browser/browser-manager'
 import { browserSessionRegistry } from '../browser/browser-session-registry'
+import { browserRouteSessionRegistry } from '../browser/browser-route-session-runtime'
 import { translateMain } from '../i18n/main-i18n'
 import { normalizeBrowserNavigationUrl } from '../../shared/browser-url'
 import { ORCA_BROWSER_GUEST_WEB_PREFERENCES } from '../../shared/browser-guest-web-preferences'
+import { ORCA_BROWSER_BLANK_URL } from '../../shared/constants'
 import { isCrashReportReason } from '../../shared/crash-reporting'
 import { markSystemSessionEnding } from '../crash-reporting/expected-teardown-state'
 import {
@@ -467,9 +469,15 @@ export function createMainWindow(
     const src = typeof params.src === 'string' ? params.src : ''
     const normalizedSrc = normalizeBrowserNavigationUrl(src)
     const partition = typeof webPreferences.partition === 'string' ? webPreferences.partition : ''
+    const isProfilePartition = browserSessionRegistry.isAllowedPartition(partition)
+    const isRoutePartition = browserRouteSessionRegistry.isAllowedPartition(partition)
 
     // Why: fail closed — deny any src or partition not in the registry allowlist so a renderer bug can't smuggle preload/Node into an unprivileged guest.
-    if (!normalizedSrc || !browserSessionRegistry.isAllowedPartition(partition)) {
+    if (
+      !normalizedSrc ||
+      (!isProfilePartition && !isRoutePartition) ||
+      (isRoutePartition && normalizedSrc !== ORCA_BROWSER_BLANK_URL)
+    ) {
       event.preventDefault()
       return
     }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​464 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​464 |
| Prod | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​704 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​695 |

<!-- /orca-pr-loc -->

## Summary

- Derive route and browser-profile scoped persistent Electron partitions from one full, path-safe SHA-256 aggregate.
- Persist durable collision bindings before Chromium partition creation and fail closed on corrupt, oversized, mismatched, or sidecar-less partition state.
- Apply existing browser session policy, fixed SOCKS5 routing, inherited-connection closure, and exact proxy verification before a partition enters the webview allowlist.
- Permit only a blank initial webview attachment for a live route partition.

## Why this stage is inert

- No production code calls `preparePage()`.
- Client-host and tunnel capabilities plus RPC registration remain disabled.
- Exact WebContents ownership and any post-attach navigation grant do not exist.
- Existing server-hosted and offscreen browser placement is unchanged.
- STA-4231 / #14402 remains the separate merged Stage 0 compatibility fix.

## Compatibility

This PR changes no RPC field, stream opcode, capability advertisement, or host publication. Old and new clients continue using current server placement. The contracts remain main-process only and do not assume a git worktree, local execution, headed host, browser-capable host, or one operating system. SSH, WSL, folder workspaces, browserless/headless hosts, and mixed versions remain unaffected until a later capability-gated activation stage.

## Evidence

Red-before tests failed on component-linkable and Windows-unsafe names, unbounded binding reads, and Chromium data without binding metadata. The candidate is green on:

- 6 focused files, 150 tests
- full main browser suite: 55 files, 739 tests
- durable-writer suite: 3 files, 28 tests
- full Node, web, and CLI typecheck
- cross-version terminal wire: 5 tests
- native, type-aware, changed-code, reliability, and max-lines gates
- fresh correctness and security/performance rereviews

Parent #14513 CI is fully green, including Linux and Windows packaging.

## Activation blockers

Before any production caller is added, later stages must prove exact WebContents and page-generation registration, popup containment, persisted-worker hold, network-service recovery, teardown and partition GC, failed-binding reclamation, dev multi-writer fencing, UDP/QUIC/DoH/WebRTC denial, and real Electron traffic isolation on macOS, Linux, and Windows.

Stacked on #14513. Tracks [STA-4150](https://linear.app/stably/issue/STA-4150/refactor-remote-browser-to-client-hosted-electron-webviews).