### PR TITLE
feat(browser): quarantine client-hosted WebContents before navigation

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -2968,11 +2968,11 @@
       "providers": ["remote-runtime", "ssh", "wsl"],
       "coveredPlatforms": ["macos"],
       "coveredProviders": [],
-      "coverageNotes": "Deterministic main-process tests cover versioned delimiter-safe aggregate partition derivation, path-safe opaque names, durable collision metadata, oversized or corrupt metadata refusal, missing-sidecar Chromium-data refusal, bounded binding/live-page admission, exact SOCKS5 configuration with Chromium loopback bypass disabled, inherited-connection closure, exact proxy verification before allowlisting, concurrent setup coalescing, live proxy-retarget refusal, token-safe page replacement, existing browser-profile policy installation, active Orca-profile storage scoping, blank-only initial attachment, and arbitrary initial-navigation denial. No production caller prepares a route partition. Persisted-worker containment, UDP/DoH/WebRTC denial, exact WebContents registration, provider journeys, and real Electron traffic capture remain uncovered.",
+      "coverageNotes": "Deterministic main-process tests cover versioned delimiter-safe aggregate partition derivation, path-safe opaque names, durable collision metadata, oversized or corrupt metadata refusal, missing-sidecar Chromium-data refusal, bounded binding/live-page admission, exact SOCKS5 configuration with Chromium loopback bypass disabled, inherited-connection closure, exact proxy verification before allowlisting, concurrent setup coalescing, live proxy-retarget refusal, token-safe page replacement, existing browser-profile policy installation, active Orca-profile storage scoping, blank-only initial attachment, and arbitrary initial-navigation denial. The exact WebContents primitive now has separate deterministic coverage, but no production caller prepares, registers, or grants a route page. Persisted-worker containment, UDP/DoH/WebRTC denial, provider journeys, and real Electron traffic capture remain uncovered.",
       "motivatingLinks": [
         "https://linear.app/stably/issue/STA-4150/refactor-remote-browser-to-client-hosted-electron-webviews"
       ],
-      "invariant": "A client-hosted partition is derived only in main from stable Orca-profile, browser-profile, authority-connection, and execution-host identities. Raw identities and individually linkable component hashes never enter its path-safe partition name. Durable binding metadata must match and precede Chromium partition data before reuse. One live partition never changes execution host or proxy endpoint, and no partition enters the webview allowlist until its existing browser policy is installed, fixed SOCKS5 proxy is applied, inherited connections are closed, and resolveProxy returns exactly that one listener. Initial route-partition attachment is blank-only; later navigation remains unavailable because exact WebContents registration does not exist. Distinct live partitions, retained logical page generations, durable bindings, and binding-file reads remain bounded.",
+      "invariant": "A client-hosted partition is derived only in main from stable Orca-profile, browser-profile, authority-connection, and execution-host identities. Raw identities and individually linkable component hashes never enter its path-safe partition name. Durable binding metadata must match and precede Chromium partition data before reuse. One live partition never changes execution host or proxy endpoint, and no partition enters the webview allowlist until its existing browser policy is installed, fixed SOCKS5 proxy is applied, inherited connections are closed, and resolveProxy returns exactly that one listener. Initial route-partition attachment is blank-only; later navigation remains unavailable in production because no caller registers and grants the exact WebContents. Distinct live partitions, retained logical page generations, durable bindings, and binding-file reads remain bounded.",
       "oracle": "Derive two delimiter-adversarial identities and require distinct full-digest path-safe partitions with no raw IDs or component hashes. Persist one binding, reload it, and reject replacement, malformed or oversized state, Chromium data without matching metadata, and the 513th binding. Prepare one partition and require policy setup, setProxy with <-loopback>, closeAllConnections, and exact SOCKS5 resolveProxy in order while isAllowedPartition remains false; then require it to become live. Reject DIRECT, a different proxy endpoint, the 65th live partition, and the 65th page generation. Replace one exact page token and prove stale cleanup cannot retire the replacement. In the window boundary, allow only blank initial attachment for a live route partition and reject direct HTTPS attachment.",
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/main/browser/browser-route-identity.test.ts src/main/browser/browser-route-partition-binding-store.test.ts src/main/browser/browser-route-session-registry.test.ts src/main/browser/browser-session-registry.test.ts src/main/browser/browser-session-startup.test.ts src/main/window/createMainWindow.test.ts"
@@ -3054,13 +3054,13 @@
       "promotionCriteria": [
         "Use Playwright CDP in real Electron to prove proxy application before the first HTTP, HTTPS, WebSocket, DNS, worker, popup, redirect, and speculative request.",
         "Hold or stop persisted workers until proxy verification and prove network-service restart cannot reset the partition to DIRECT or system proxy.",
-        "Register the exact WebContents and page generation before navigation, and fence reload, popup, restore, profile-switch, renderer-crash, and stale-cleanup paths.",
+        "Activate a trusted exact-WebContents registration/grant flow before navigation, and fence reload, popup, restore, profile-switch, renderer-crash, and stale-cleanup paths.",
         "Disable or capture every UDP, QUIC, DoH, WebRTC, and non-SOCKS desktop egress path on macOS, Linux, and Windows."
       ],
       "knownGaps": [
         "No production method calls preparePage, so the registry and allowlist remain inert.",
         "Creating a persistent Electron Session may wake an existing service worker before setProxy; worker hold or termination proof is required.",
-        "The route partition permits only blank initial attachment; exact WebContents registration and later navigation permission do not exist yet.",
+        "The route partition permits only blank initial attachment; exact WebContents registration and grant primitives are inert because no production caller exists.",
         "Real Electron proxy syntax, loopback coverage, network-service recovery, popup/worker behavior, and desktop packet capture are not validated because the required Electron skill is unavailable in this workspace.",
         "QUIC, DoH, WebRTC, WebTransport, and other UDP/direct-network paths are not yet disabled or proven fail closed.",
         "Partition deletion, download/transfer draining, idle route release, disk quotas, and browser-profile cloning are later lifecycle stages.",
@@ -3069,6 +3069,108 @@
         "Each preparePage synchronously reads and parses bounded binding metadata on Electron main; activation requires latency evidence or a safely invalidated cache before this becomes frequent."
       ],
       "demotionRule": "Keep experimental or demote if raw identities enter a partition path, a durable binding mismatch is reused, a partition retargets to another execution host or live listener, a route partition becomes attachable before exact proxy verification, initial attachment can navigate beyond blank, stale cleanup retires a replacement, admission exceeds a declared cap, or any browser request reaches desktop DNS, TCP, UDP, localhost, or system proxy outside the selected route."
+    },
+    {
+      "id": "browser-client-host.webcontents-quarantine",
+      "title": "Route guests stay blank and popup-denied until exact registration",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "browser-runtime",
+      "layer": "electron-main-webcontents-authority",
+      "surfaces": [
+        "route guest did-attach lifecycle",
+        "exact host renderer and WebContents ownership",
+        "logical page-generation registration",
+        "post-registration navigation grant",
+        "route popup fail-closed policy"
+      ],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["remote-runtime", "ssh", "wsl"],
+      "coveredPlatforms": ["macos"],
+      "coveredProviders": [],
+      "coverageNotes": "Deterministic main-process fakes cover route-Session recognition after logical release, generic-policy-before-route-lockdown ordering, blank quarantine, exact guest/renderer/partition/logical-page registration, opaque page-authority replacement, a separate navigation grant, repeated navigation, invalid-scheme denial, dynamic page-authority revocation, popup denial, delayed/failed admission closure, mutable input isolation, page conflicts, and token-safe destroyed cleanup. Normal browser Sessions bypass the route registry. No production caller prepares a route page, registers a route guest, or grants navigation. Real Electron event ordering, renderer IPC, process swaps, active-request teardown, and provider journeys remain uncovered.",
+      "motivatingLinks": [
+        "https://linear.app/stably/issue/STA-4150/refactor-remote-browser-to-client-hosted-electron-webviews"
+      ],
+      "invariant": "A WebContents whose Electron Session has belonged to a prepared route partition is quarantined synchronously after generic guest policy installation, including when page authority disappears between will-attach and did-attach. It must be a live blank webview owned by the exact renderer WebContents. Nonblank navigation remains denied until main matches the exact partition, browser page, page-host generation, guest WebContents, renderer WebContents, and opaque live page authority, then issues a separate grant. Every later navigation rechecks the same opaque authority, so reusing a logical tuple cannot revive a stale guest. Route popups remain denied, including after navigation grant and while rejected attachment closure is delayed or fails. Registry maps are bounded, stale destroyed callbacks cannot retire replacements, and non-route browser guests retain existing behavior.",
+      "oracle": "Attach a blank route guest and require nonblank navigation plus every popup to be denied. Reject a wrong renderer, wrong page generation, nonblank initial document, wrong WebContents type, destroyed guest, and excess attachment; delay or fail its close and require navigation and popups to remain denied. Register the exact prepared tuple and prove navigation remains denied until a second grant; then allow repeated HTTP(S) navigation while continuing to deny file navigation and popups. Release logical page authority and require redirects and late attachments to fail closed immediately. Reprepare the same tuple, require a new opaque authority, deny the stale guest, and admit an exact replacement. Destroy a registered guest under real destroyed state, verify best-effort listener release, replay stale cleanup, and prove its replacement remains grantable. Mutate caller input after registration and prove main-owned authority is unchanged. Attach a normal browser Session and require no route-registry mutation.",
+      "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/browser/browser-route-session-registry.test.ts src/main/browser/browser-route-webcontents-registry.test.ts src/main/window/createMainWindow.test.ts"
+      ],
+      "testFiles": [
+        "src/main/browser/browser-route-session-registry.test.ts",
+        "src/main/browser/browser-route-webcontents-registry.test.ts",
+        "src/main/window/createMainWindow.test.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/main/browser/browser-route-session-registry.test.ts",
+          "assertions": [
+            "a prepared Electron Session remains recognizable for late-attachment quarantine",
+            "page release removes logical authority and tuple reuse receives a new opaque token"
+          ]
+        },
+        {
+          "file": "src/main/browser/browser-route-webcontents-registry.test.ts",
+          "assertions": [
+            "route guests remain blank and popup-denied before exact registration and grant",
+            "guest, renderer, partition, and logical page generation must all match",
+            "later navigation rechecks live page authority and invalid schemes remain denied",
+            "late, excess, and close-failed attachments remain navigation- and popup-denied",
+            "opaque authority replacement, page conflicts, mutable inputs, and stale cleanup fail closed",
+            "normal browser Sessions remain outside the route registry"
+          ]
+        },
+        {
+          "file": "src/main/window/createMainWindow.test.ts",
+          "assertions": [
+            "generic guest policy installs before route lockdown can override popup behavior",
+            "every attached webview is offered to the route registry without changing normal guests"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-08-14",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/browser/browser-route-session-registry.test.ts src/main/browser/browser-route-webcontents-registry.test.ts src/main/window/createMainWindow.test.ts",
+          "result": "passed",
+          "durationSeconds": 0.9,
+          "summary": "Three files passed 113 Session-index, late/rejected route-WebContents quarantine, opaque-authority fencing, exact registration, navigation-grant, popup-denial, and main-window ordering tests."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 2,
+        "scope": "deterministic route Session, WebContents authority, and did-attach boundary tests"
+      },
+      "flakeHistory": {
+        "status": "unknown",
+        "evidence": "The deterministic suite passes locally; CI and real Electron soak history have not started."
+      },
+      "redGreenEvidence": {
+        "status": "partial",
+        "evidence": "The route-WebContents oracle first failed because no registry existed, and the Session oracle failed because no exact Session/page index existed. A first candidate blocked every navigation after the initial document committed because it incorrectly required the current URL to remain blank; repeated-navigation evidence failed until blank validation was limited to registration and grant. Mutable-input evidence then proved caller-owned data could alter stored authority until the registry copied it. Fresh review found late and rejected attachments could keep generic navigation policy, destroyed cleanup skipped listener release, and tuple reuse revived stale grants; the added deterministic cases fail that candidate and pass with retained Session recognition, deny-first admission, best-effort destroyed cleanup, and opaque authority tokens. Real Electron mutation/revert and traffic evidence remain required before activation."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "Session, guest, and page lookups are O(1), install no polling, and retain at most 256 attached route guests in registry maps in addition to the lower 64-partition and 64-logical-page-per-partition bounds. Historical Session recognition uses weak keys. Normal guests perform one bounded Session lookup at did-attach. Destroyed guests synchronously release exact mappings and attempt each listener removal independently."
+      },
+      "promotionCriteria": [
+        "Expose a trusted renderer registration flow that cannot navigate before main acknowledges exact registration and grant.",
+        "Use Playwright CDP in real Electron to prove did-attach lockdown precedes page script, popup, redirect, worker, and speculative activity.",
+        "Fence and close exact WebContents plus active requests on page release, process swap, renderer crash, profile switch, lease replacement, and app shutdown.",
+        "Implement bounded generation-scoped popup reservations without any shell.openExternal or native-window fallback."
+      ],
+      "knownGaps": [
+        "No production method calls preparePage, registerGuest, or grantNavigation, so exact route guest ownership remains inert.",
+        "No renderer IPC or preload surface carries main-owned route page registration yet.",
+        "Real Electron did-attach timing, close behavior, process swaps, and traffic isolation are unvalidated because the required Electron skill is unavailable in this workspace.",
+        "Logical page release blocks future navigation but does not close the WebContents, stop active requests or workers, close connections, or clear persistent storage.",
+        "Popup reservations do not exist; every route guest popup is denied.",
+        "The future caller still must derive the renderer, authority, page, host generation, and route identity from live main-owned state."
+      ],
+      "demotionRule": "Keep inert or demote if a route guest can navigate nonblank before exact registration and grant, a mismatched or released page remains authoritative, tuple reuse revives stale authority, a popup reaches shell.openExternal or an unregistered native window, a rejected attachment retains navigation or popup capability, stale cleanup retires a replacement, normal browser guests change behavior, or any claimed exact identity is sourced only from renderer input."
     },
     {
       "id": "browser-stream.bounded-reconnect",

--- a/src/main/browser/browser-route-session-registry.test.ts
+++ b/src/main/browser/browser-route-session-registry.test.ts
@@ -116,6 +116,60 @@ describe('BrowserRouteSessionRegistry', () => {
     expect(dependencies.clearPolicies).toHaveBeenCalledTimes(1)
   })
 
+  it('indexes only exact live page generations by their Electron session', async () => {
+    const { registry, session } = createHarness()
+    const handle = await prepare(registry)
+
+    expect(registry.getPartitionForSession(session)).toBe(handle.partition)
+    expect(
+      registry.getPreparedPageAuthority({
+        partition: handle.partition,
+        browserPageId: 'page-a',
+        pageHostGeneration: 1
+      })
+    ).not.toBeNull()
+    expect(
+      registry.getPreparedPageAuthority({
+        partition: handle.partition,
+        browserPageId: 'page-a',
+        pageHostGeneration: 2
+      })
+    ).toBeNull()
+
+    handle.release()
+    expect(registry.getPartitionForSession(session)).toBe(handle.partition)
+    expect(
+      registry.getPreparedPageAuthority({
+        partition: handle.partition,
+        browserPageId: 'page-a',
+        pageHostGeneration: 1
+      })
+    ).toBeNull()
+  })
+
+  it('changes opaque page authority when the same logical tuple is prepared again', async () => {
+    const { registry } = createHarness()
+    const first = await prepare(registry)
+    const firstAuthority = registry.getPreparedPageAuthority({
+      partition: first.partition,
+      browserPageId: 'page-a',
+      pageHostGeneration: 1
+    })
+    first.release()
+
+    const replacement = await prepare(registry)
+    const replacementAuthority = registry.getPreparedPageAuthority({
+      partition: replacement.partition,
+      browserPageId: 'page-a',
+      pageHostGeneration: 1
+    })
+
+    expect(firstAuthority).not.toBeNull()
+    expect(replacementAuthority).not.toBeNull()
+    expect(replacementAuthority).not.toBe(firstAuthority)
+    replacement.release()
+  })
+
   it('never allowlists a partition whose proxy resolves direct or elsewhere', async () => {
     const { dependencies, registry } = createHarness({ resolvedProxy: 'DIRECT' })
 

--- a/src/main/browser/browser-route-session-registry.ts
+++ b/src/main/browser/browser-route-session-registry.ts
@@ -70,6 +70,7 @@ export class BrowserRouteSessionRegistry {
   private readonly maxPagesPerPartition: number
   private readonly live = new Map<string, PreparedPartition>()
   private readonly pending = new Map<string, PendingPartition>()
+  private readonly partitionBySession = new WeakMap<BrowserRouteElectronSession, string>()
 
   constructor(private readonly dependencies: BrowserRouteSessionRegistryDependencies) {
     this.derivePartition = dependencies.derivePartition ?? deriveBrowserRoutePartition
@@ -79,6 +80,22 @@ export class BrowserRouteSessionRegistry {
 
   isAllowedPartition(partition: string): boolean {
     return this.live.has(partition)
+  }
+
+  getPartitionForSession(session: BrowserRouteElectronSession): string | null {
+    return this.partitionBySession.get(session) ?? null
+  }
+
+  getPreparedPageAuthority(input: {
+    partition: string
+    browserPageId: string
+    pageHostGeneration: number
+  }): symbol | null {
+    const state = this.live.get(input.partition)
+    if (!state || !isValidPageIdentity(input.browserPageId, input.pageHostGeneration)) {
+      return null
+    }
+    return state.pageTokens.get(pageKey(input.browserPageId, input.pageHostGeneration)) ?? null
   }
 
   async preparePage(input: {
@@ -125,6 +142,7 @@ export class BrowserRouteSessionRegistry {
     try {
       state = await promise
       this.live.set(derived.partition, state)
+      this.partitionBySession.set(state.session, state.partition)
     } finally {
       if (this.pending.get(derived.partition) === pendingState) {
         this.pending.delete(derived.partition)
@@ -194,19 +212,19 @@ export class BrowserRouteSessionRegistry {
     browserPageId: string,
     pageHostGeneration: number
   ): BrowserRouteSessionHandle {
-    const pageKey = JSON.stringify([browserPageId, pageHostGeneration])
-    if (!state.pageTokens.has(pageKey) && state.pageTokens.size >= this.maxPagesPerPartition) {
+    const key = pageKey(browserPageId, pageHostGeneration)
+    if (!state.pageTokens.has(key) && state.pageTokens.size >= this.maxPagesPerPartition) {
       throw new Error('browser_route_partition_page_capacity')
     }
-    const token = Symbol(pageKey)
-    state.pageTokens.set(pageKey, token)
+    const token = Symbol(key)
+    state.pageTokens.set(key, token)
     return {
       partition: state.partition,
       release: () => {
-        if (state.pageTokens.get(pageKey) !== token) {
+        if (state.pageTokens.get(key) !== token) {
           return
         }
-        state.pageTokens.delete(pageKey)
+        state.pageTokens.delete(key)
         if (state.pageTokens.size !== 0 || this.live.get(state.partition) !== state) {
           return
         }
@@ -235,14 +253,22 @@ function sameProxyEndpoint(left: ProxyEndpoint, right: ProxyEndpoint): boolean {
 }
 
 function assertPageIdentity(browserPageId: string, pageHostGeneration: number): void {
-  if (
-    typeof browserPageId !== 'string' ||
-    browserPageId.length === 0 ||
-    browserPageId.length > MAX_PAGE_ID_LENGTH ||
-    !Number.isInteger(pageHostGeneration) ||
-    pageHostGeneration < 1 ||
-    pageHostGeneration > MAX_PAGE_HOST_GENERATION
-  ) {
+  if (!isValidPageIdentity(browserPageId, pageHostGeneration)) {
     throw new Error('browser_route_partition_page_invalid')
   }
+}
+
+function isValidPageIdentity(browserPageId: string, pageHostGeneration: number): boolean {
+  return (
+    typeof browserPageId === 'string' &&
+    browserPageId.length > 0 &&
+    browserPageId.length <= MAX_PAGE_ID_LENGTH &&
+    Number.isInteger(pageHostGeneration) &&
+    pageHostGeneration >= 1 &&
+    pageHostGeneration <= MAX_PAGE_HOST_GENERATION
+  )
+}
+
+function pageKey(browserPageId: string, pageHostGeneration: number): string {
+  return JSON.stringify([browserPageId, pageHostGeneration])
 }

--- a/src/main/browser/browser-route-session-runtime.ts
+++ b/src/main/browser/browser-route-session-runtime.ts
@@ -2,6 +2,7 @@ import { app, session } from 'electron'
 import { join } from 'node:path'
 import { BrowserRoutePartitionBindingStore } from './browser-route-partition-binding-store'
 import { BrowserRouteSessionRegistry } from './browser-route-session-registry'
+import { BrowserRouteWebContentsRegistry } from './browser-route-webcontents-registry'
 import { browserSessionRegistry } from './browser-session-registry'
 
 const BINDING_FILE_NAME = 'browser-route-partition-bindings.json'
@@ -29,6 +30,12 @@ export const browserRouteSessionRegistry = new BrowserRouteSessionRegistry({
     browserSessionRegistry.clearRoutePartitionPolicies(partition)
   },
   bindingStore
+})
+
+export const browserRouteWebContentsRegistry = new BrowserRouteWebContentsRegistry({
+  getPartitionForSession: (routeSession) =>
+    browserRouteSessionRegistry.getPartitionForSession(routeSession),
+  getPreparedPageAuthority: (page) => browserRouteSessionRegistry.getPreparedPageAuthority(page)
 })
 
 export function configureRouteSessionsForOrcaProfile(options: { profileDirectory: string }): void {

--- a/src/main/browser/browser-route-webcontents-registry.test.ts
+++ b/src/main/browser/browser-route-webcontents-registry.test.ts
@@ -1,0 +1,310 @@
+import type { Session, WebContents } from 'electron'
+import { describe, expect, it, vi } from 'vitest'
+import { BrowserRouteWebContentsRegistry } from './browser-route-webcontents-registry'
+
+const partition = `persist:orca-browser-v1-${'a'.repeat(64)}`
+const page = {
+  partition,
+  browserPageId: 'page-a',
+  pageHostGeneration: 7,
+  webContentsId: 41,
+  rendererWebContentsId: 11
+}
+
+function createHarness(options: { maxGuests?: number } = {}) {
+  const routeSession = { marker: 'route-session' } as unknown as Session
+  let prepared = true
+  let pageAuthority = Symbol('page-authority')
+  const registry = new BrowserRouteWebContentsRegistry({
+    getPartitionForSession: (session) => (session === routeSession ? partition : null),
+    getPreparedPageAuthority: (input) =>
+      prepared &&
+      input.partition === partition &&
+      input.browserPageId === page.browserPageId &&
+      input.pageHostGeneration === page.pageHostGeneration
+        ? pageAuthority
+        : null,
+    maxGuests: options.maxGuests
+  })
+  return {
+    registry,
+    routeSession,
+    setPrepared: (value: boolean) => {
+      prepared = value
+    },
+    replaceAuthority: () => {
+      pageAuthority = Symbol('replacement-page-authority')
+    }
+  }
+}
+
+function createGuest(options: {
+  id?: number
+  session?: Session
+  rendererWebContentsId?: number
+  type?: string
+  url?: string
+  destroyed?: boolean
+  closeDestroys?: boolean
+  closeError?: Error
+}) {
+  const listeners = new Map<string, Set<(...args: unknown[]) => void>>()
+  let destroyed = options.destroyed ?? false
+  let currentUrl = options.url ?? 'about:blank'
+  let windowOpenHandler: (() => { action: 'deny' }) | null = null
+  const guest = {
+    id: options.id ?? page.webContentsId,
+    session: options.session,
+    hostWebContents: { id: options.rendererWebContentsId ?? page.rendererWebContentsId },
+    getType: vi.fn(() => options.type ?? 'webview'),
+    getURL: vi.fn(() => currentUrl),
+    isDestroyed: vi.fn(() => destroyed),
+    close: vi.fn(() => {
+      if (options.closeError) {
+        throw options.closeError
+      }
+      if (options.closeDestroys !== false) {
+        destroyed = true
+      }
+    }),
+    on: vi.fn((event: string, listener: (...args: unknown[]) => void) => {
+      const eventListeners = listeners.get(event) ?? new Set()
+      eventListeners.add(listener)
+      listeners.set(event, eventListeners)
+    }),
+    off: vi.fn((event: string, listener: (...args: unknown[]) => void) => {
+      listeners.get(event)?.delete(listener)
+    }),
+    setWindowOpenHandler: vi.fn((handler: () => { action: 'deny' }) => {
+      windowOpenHandler = handler
+    })
+  }
+  return {
+    guest: guest as unknown as WebContents,
+    emit: (event: string, ...args: unknown[]) => {
+      for (const listener of listeners.get(event) ?? []) {
+        listener(...args)
+      }
+    },
+    setUrl: (url: string) => {
+      currentUrl = url
+    },
+    openWindow: () => windowOpenHandler?.(),
+    destroy: () => {
+      destroyed = true
+      for (const listener of listeners.get('destroyed') ?? []) {
+        listener()
+      }
+    }
+  }
+}
+
+function navigationEvent(): { preventDefault: ReturnType<typeof vi.fn> } {
+  return { preventDefault: vi.fn() }
+}
+
+describe('BrowserRouteWebContentsRegistry', () => {
+  it('holds navigation and popups until exact registration and an explicit grant', () => {
+    const { registry, routeSession } = createHarness()
+    const guest = createGuest({ session: routeSession })
+
+    expect(registry.attachGuest(guest.guest)).toBe(true)
+    const beforeRegistration = navigationEvent()
+    guest.emit('will-navigate', beforeRegistration, 'https://example.com/')
+    expect(beforeRegistration.preventDefault).toHaveBeenCalledOnce()
+    expect(guest.openWindow()).toEqual({ action: 'deny' })
+
+    expect(registry.registerGuest({ ...page, rendererWebContentsId: 12 })).toBe(false)
+    expect(registry.grantNavigation(page)).toBe(false)
+    expect(registry.registerGuest(page)).toBe(true)
+
+    const beforeGrant = navigationEvent()
+    guest.emit('will-navigate', beforeGrant, 'https://example.com/')
+    expect(beforeGrant.preventDefault).toHaveBeenCalledOnce()
+
+    expect(registry.grantNavigation(page)).toBe(true)
+    const afterGrant = navigationEvent()
+    guest.emit('will-navigate', afterGrant, 'https://example.com/')
+    expect(afterGrant.preventDefault).not.toHaveBeenCalled()
+    guest.setUrl('https://example.com/')
+    const laterNavigation = navigationEvent()
+    guest.emit('will-navigate', laterNavigation, 'https://example.org/')
+    expect(laterNavigation.preventDefault).not.toHaveBeenCalled()
+    expect(guest.openWindow()).toEqual({ action: 'deny' })
+  })
+
+  it('allows blank navigation while quarantined but blocks invalid schemes after a grant', () => {
+    const { registry, routeSession } = createHarness()
+    const guest = createGuest({ session: routeSession })
+    registry.attachGuest(guest.guest)
+
+    const blank = navigationEvent()
+    guest.emit('will-navigate', blank, 'about:blank')
+    expect(blank.preventDefault).not.toHaveBeenCalled()
+
+    expect(registry.registerGuest(page)).toBe(true)
+    expect(registry.grantNavigation(page)).toBe(true)
+    const localFile = navigationEvent()
+    guest.emit('will-navigate', localFile, 'file:///etc/passwd')
+    expect(localFile.preventDefault).toHaveBeenCalledOnce()
+  })
+
+  it('destroys invalid route guests but ignores unrelated browser sessions', () => {
+    const { registry, routeSession } = createHarness()
+    const unrelated = createGuest({
+      session: { marker: 'profile-session' } as unknown as Session
+    })
+    expect(registry.attachGuest(unrelated.guest)).toBe(false)
+    expect(unrelated.guest.close).not.toHaveBeenCalled()
+
+    for (const invalid of [
+      createGuest({ session: routeSession, type: 'window' }),
+      createGuest({ session: routeSession, url: 'https://example.com/' }),
+      createGuest({ session: routeSession, rendererWebContentsId: 0 })
+    ]) {
+      expect(registry.attachGuest(invalid.guest)).toBe(false)
+      expect(invalid.guest.close).toHaveBeenCalledOnce()
+    }
+    const alreadyDestroyed = createGuest({ session: routeSession, destroyed: true })
+    expect(registry.attachGuest(alreadyDestroyed.guest)).toBe(false)
+    expect(alreadyDestroyed.guest.close).not.toHaveBeenCalled()
+  })
+
+  it('bounds unregistered route guests and destroys excess attachments', () => {
+    const { registry, routeSession } = createHarness({ maxGuests: 1 })
+    const first = createGuest({ session: routeSession })
+    const second = createGuest({ id: 42, session: routeSession })
+
+    expect(registry.attachGuest(first.guest)).toBe(true)
+    expect(registry.attachGuest(second.guest)).toBe(false)
+    expect(second.guest.close).toHaveBeenCalledOnce()
+  })
+
+  it('keeps delayed or failed admission closure navigation- and popup-denied', () => {
+    const { registry, routeSession } = createHarness({ maxGuests: 1 })
+    registry.attachGuest(createGuest({ session: routeSession }).guest)
+    for (const rejected of [
+      createGuest({ id: 42, session: routeSession, closeDestroys: false }),
+      createGuest({ id: 43, session: routeSession, closeError: new Error('close failed') })
+    ]) {
+      expect(registry.attachGuest(rejected.guest)).toBe(false)
+      const navigation = navigationEvent()
+      rejected.emit('will-navigate', navigation, 'https://example.com/')
+      expect(navigation.preventDefault).toHaveBeenCalledOnce()
+      expect(rejected.openWindow()).toEqual({ action: 'deny' })
+    }
+  })
+
+  it('rejects page conflicts and stale destroyed callbacks cannot retire a replacement', () => {
+    const { registry, routeSession } = createHarness()
+    const first = createGuest({ session: routeSession })
+    registry.attachGuest(first.guest)
+    expect(registry.registerGuest(page)).toBe(true)
+
+    const conflicting = createGuest({ id: 42, session: routeSession })
+    registry.attachGuest(conflicting.guest)
+    expect(registry.registerGuest({ ...page, webContentsId: 42 })).toBe(false)
+
+    first.destroy()
+    expect(registry.registerGuest({ ...page, webContentsId: 42 })).toBe(true)
+    first.emit('destroyed')
+    expect(registry.grantNavigation({ ...page, webContentsId: 42 })).toBe(true)
+    expect(first.guest.off).toHaveBeenCalledWith('will-navigate', expect.any(Function))
+    expect(first.guest.off).toHaveBeenCalledWith('will-redirect', expect.any(Function))
+    expect(first.guest.off).toHaveBeenCalledWith('destroyed', expect.any(Function))
+  })
+
+  it('revokes navigation immediately when the logical page is no longer prepared', () => {
+    const { registry, routeSession, setPrepared } = createHarness()
+    const guest = createGuest({ session: routeSession })
+    registry.attachGuest(guest.guest)
+    registry.registerGuest(page)
+    registry.grantNavigation(page)
+    setPrepared(false)
+
+    const afterRelease = navigationEvent()
+    guest.emit('will-redirect', afterRelease, 'https://example.com/', false, true)
+    expect(afterRelease.preventDefault).toHaveBeenCalledOnce()
+  })
+
+  it('quarantines a late attachment after its logical page authority is released', () => {
+    const { registry, routeSession, setPrepared } = createHarness()
+    setPrepared(false)
+    const guest = createGuest({ session: routeSession })
+
+    expect(registry.attachGuest(guest.guest)).toBe(true)
+    expect(registry.registerGuest(page)).toBe(false)
+    const navigation = navigationEvent()
+    guest.emit('will-navigate', navigation, 'https://example.com/')
+    expect(navigation.preventDefault).toHaveBeenCalledOnce()
+    expect(guest.openWindow()).toEqual({ action: 'deny' })
+  })
+
+  it('does not retain mutable registration input as page authority', () => {
+    const { registry, routeSession } = createHarness()
+    const guest = createGuest({ session: routeSession })
+    const registration = { ...page }
+    registry.attachGuest(guest.guest)
+
+    expect(registry.registerGuest(registration)).toBe(true)
+    registration.browserPageId = 'mutated-page'
+    expect(registry.grantNavigation(page)).toBe(true)
+  })
+
+  it('does not revive a stale guest when the same logical page tuple is prepared again', () => {
+    const { registry, replaceAuthority, routeSession } = createHarness()
+    const stale = createGuest({ session: routeSession })
+    registry.attachGuest(stale.guest)
+    registry.registerGuest(page)
+    registry.grantNavigation(page)
+    replaceAuthority()
+
+    const staleNavigation = navigationEvent()
+    stale.emit('will-navigate', staleNavigation, 'https://example.com/')
+    expect(staleNavigation.preventDefault).toHaveBeenCalledOnce()
+    expect(registry.registerGuest(page)).toBe(false)
+
+    const replacement = createGuest({ id: 42, session: routeSession })
+    expect(registry.attachGuest(replacement.guest)).toBe(true)
+    expect(registry.registerGuest({ ...page, webContentsId: 42 })).toBe(true)
+    expect(registry.grantNavigation({ ...page, webContentsId: 42 })).toBe(true)
+  })
+
+  it('fails closed when Electron guest inspection races destruction', () => {
+    const { registry, routeSession } = createHarness()
+    const guest = createGuest({ session: routeSession })
+    vi.mocked(guest.guest.getURL).mockImplementation(() => {
+      throw new Error('guest destroyed')
+    })
+
+    expect(() => registry.attachGuest(guest.guest)).not.toThrow()
+    expect(guest.guest.close).toHaveBeenCalledOnce()
+  })
+
+  it('turns registration-time inspection failures into navigation denial', () => {
+    const { registry, routeSession } = createHarness()
+    const guest = createGuest({ session: routeSession })
+    registry.attachGuest(guest.guest)
+    registry.registerGuest(page)
+    registry.grantNavigation(page)
+    vi.mocked(guest.guest.getType).mockImplementation(() => {
+      throw new Error('guest swapped')
+    })
+
+    const navigation = navigationEvent()
+    expect(() => guest.emit('will-navigate', navigation, 'https://example.com/')).not.toThrow()
+    expect(navigation.preventDefault).toHaveBeenCalledOnce()
+  })
+
+  it('rejects registration without throwing when blank-document inspection fails', () => {
+    const { registry, routeSession } = createHarness()
+    const guest = createGuest({ session: routeSession })
+    registry.attachGuest(guest.guest)
+    vi.mocked(guest.guest.getURL).mockImplementation(() => {
+      throw new Error('guest unavailable')
+    })
+
+    expect(() => registry.registerGuest(page)).not.toThrow()
+    expect(registry.registerGuest(page)).toBe(false)
+  })
+})

--- a/src/main/browser/browser-route-webcontents-registry.ts
+++ b/src/main/browser/browser-route-webcontents-registry.ts
@@ -1,0 +1,289 @@
+import type { Event, Session, WebContents } from 'electron'
+import { ORCA_BROWSER_BLANK_URL } from '../../shared/constants'
+import { normalizeBrowserNavigationUrl } from '../../shared/browser-url'
+
+const DEFAULT_MAX_GUESTS = 256
+const MAX_PAGE_ID_LENGTH = 256
+const MAX_PAGE_HOST_GENERATION = 0xffff_ffff
+
+export type BrowserRoutePageGuestIdentity = Readonly<{
+  partition: string
+  browserPageId: string
+  pageHostGeneration: number
+  webContentsId: number
+  rendererWebContentsId: number
+}>
+
+type BrowserRoutePageIdentity = Pick<
+  BrowserRoutePageGuestIdentity,
+  'partition' | 'browserPageId' | 'pageHostGeneration'
+>
+
+type BrowserRouteWebContentsRegistryDependencies = {
+  getPartitionForSession(session: Session): string | null
+  getPreparedPageAuthority(input: BrowserRoutePageIdentity): symbol | null
+  maxGuests?: number
+}
+
+type GuestState = {
+  guest: WebContents
+  partition: string
+  registration: BrowserRoutePageGuestIdentity | null
+  pageAuthority: symbol | null
+  navigationGranted: boolean
+  onNavigate: (event: Event, url: string) => void
+  onDestroyed: () => void
+}
+
+export class BrowserRouteWebContentsRegistry {
+  private readonly maxGuests: number
+  private readonly guests = new Map<number, GuestState>()
+  private readonly guestsByPage = new Map<string, GuestState>()
+
+  constructor(private readonly dependencies: BrowserRouteWebContentsRegistryDependencies) {
+    this.maxGuests = dependencies.maxGuests ?? DEFAULT_MAX_GUESTS
+  }
+
+  attachGuest(guest: WebContents): boolean {
+    let partition: string | null
+    try {
+      partition = this.dependencies.getPartitionForSession(guest.session)
+    } catch {
+      destroyGuest(guest)
+      return false
+    }
+    if (partition === null) {
+      return false
+    }
+    const existing = this.guests.get(guest.id)
+    if (existing?.guest === guest) {
+      return true
+    }
+    const state = this.createGuestState(guest, partition)
+    try {
+      this.installGuestQuarantine(state)
+    } catch {
+      destroyGuest(guest)
+      return false
+    }
+    let isValid = false
+    try {
+      isValid = isValidBlankRouteGuest(guest)
+    } catch {
+      // Electron may destroy a guest between did-attach and main inspection.
+    }
+    if (existing || this.guests.size >= this.maxGuests || !isValid) {
+      destroyGuest(guest)
+      if (isDestroyed(guest)) {
+        this.releaseGuest(state)
+      }
+      return false
+    }
+
+    this.guests.set(guest.id, state)
+    return true
+  }
+
+  registerGuest(registration: BrowserRoutePageGuestIdentity): boolean {
+    if (!isValidRegistration(registration)) {
+      return false
+    }
+    const state = this.guests.get(registration.webContentsId)
+    if (
+      !state ||
+      !isBlankGuest(state.guest) ||
+      !this.registrationMatchesGuest(state, registration)
+    ) {
+      return false
+    }
+    const pageAuthority = this.dependencies.getPreparedPageAuthority(registration)
+    if (pageAuthority === null) {
+      return false
+    }
+    const pageKey = routePageKey(registration)
+    const existingPage = this.guestsByPage.get(pageKey)
+    if (existingPage && existingPage !== state && this.hasLivePageAuthority(existingPage)) {
+      return false
+    }
+    if (state.registration) {
+      return routePageKey(state.registration) === pageKey && state.pageAuthority === pageAuthority
+    }
+    if (existingPage && existingPage !== state) {
+      existingPage.registration = null
+      existingPage.pageAuthority = null
+    }
+    state.registration = { ...registration }
+    state.pageAuthority = pageAuthority
+    this.guestsByPage.set(pageKey, state)
+    return true
+  }
+
+  grantNavigation(registration: BrowserRoutePageGuestIdentity): boolean {
+    if (!isValidRegistration(registration)) {
+      return false
+    }
+    const state = this.guests.get(registration.webContentsId)
+    if (
+      !state?.registration ||
+      routePageKey(state.registration) !== routePageKey(registration) ||
+      !isBlankGuest(state.guest) ||
+      !this.registrationMatchesGuest(state, registration) ||
+      !this.hasLivePageAuthority(state)
+    ) {
+      return false
+    }
+    state.navigationGranted = true
+    return true
+  }
+
+  private createGuestState(guest: WebContents, partition: string): GuestState {
+    const state: GuestState = {
+      guest,
+      partition,
+      registration: null,
+      pageAuthority: null,
+      navigationGranted: false,
+      onNavigate: (event, url) => {
+        if (!this.navigationAllowed(state, url)) {
+          event.preventDefault()
+        }
+      },
+      onDestroyed: () => this.releaseGuest(state)
+    }
+    return state
+  }
+
+  private installGuestQuarantine(state: GuestState): void {
+    state.guest.setWindowOpenHandler(() => ({ action: 'deny' }))
+    state.guest.on('will-navigate', state.onNavigate)
+    state.guest.on('will-redirect', state.onNavigate)
+    state.guest.on('destroyed', state.onDestroyed)
+  }
+
+  private navigationAllowed(state: GuestState, url: string): boolean {
+    try {
+      const normalized = normalizeBrowserNavigationUrl(url)
+      if (normalized === ORCA_BROWSER_BLANK_URL) {
+        return true
+      }
+      return Boolean(
+        normalized &&
+        !normalized.startsWith('file:') &&
+        state.navigationGranted &&
+        state.registration &&
+        this.registrationMatchesGuest(state, state.registration) &&
+        this.hasLivePageAuthority(state)
+      )
+    } catch {
+      return false
+    }
+  }
+
+  private registrationMatchesGuest(
+    state: GuestState,
+    registration: BrowserRoutePageGuestIdentity
+  ): boolean {
+    try {
+      const guest = state.guest
+      return (
+        !guest.isDestroyed() &&
+        guest.getType() === 'webview' &&
+        guest.id === registration.webContentsId &&
+        guest.hostWebContents?.id === registration.rendererWebContentsId &&
+        state.partition === registration.partition &&
+        this.dependencies.getPartitionForSession(guest.session) === registration.partition
+      )
+    } catch {
+      return false
+    }
+  }
+
+  private hasLivePageAuthority(state: GuestState): boolean {
+    return Boolean(
+      state.registration &&
+      state.pageAuthority !== null &&
+      this.dependencies.getPreparedPageAuthority(state.registration) === state.pageAuthority
+    )
+  }
+
+  private releaseGuest(state: GuestState): void {
+    if (this.guests.get(state.guest.id) === state) {
+      this.guests.delete(state.guest.id)
+    }
+    if (state.registration) {
+      const pageKey = routePageKey(state.registration)
+      if (this.guestsByPage.get(pageKey) === state) {
+        this.guestsByPage.delete(pageKey)
+      }
+    }
+    try {
+      state.guest.off('will-navigate', state.onNavigate)
+    } catch {}
+    try {
+      state.guest.off('will-redirect', state.onNavigate)
+    } catch {}
+    try {
+      state.guest.off('destroyed', state.onDestroyed)
+    } catch {}
+  }
+}
+
+function isValidBlankRouteGuest(guest: WebContents): boolean {
+  return (
+    !guest.isDestroyed() &&
+    guest.getType() === 'webview' &&
+    Number.isInteger(guest.id) &&
+    guest.id > 0 &&
+    Number.isInteger(guest.hostWebContents?.id) &&
+    (guest.hostWebContents?.id ?? 0) > 0 &&
+    isBlankGuest(guest)
+  )
+}
+
+function isBlankGuest(guest: WebContents): boolean {
+  try {
+    return normalizeBrowserNavigationUrl(guest.getURL()) === ORCA_BROWSER_BLANK_URL
+  } catch {
+    return false
+  }
+}
+
+function isValidRegistration(value: BrowserRoutePageGuestIdentity): boolean {
+  return Boolean(
+    value &&
+    typeof value.partition === 'string' &&
+    typeof value.browserPageId === 'string' &&
+    value.browserPageId.length > 0 &&
+    value.browserPageId.length <= MAX_PAGE_ID_LENGTH &&
+    Number.isInteger(value.pageHostGeneration) &&
+    value.pageHostGeneration > 0 &&
+    value.pageHostGeneration <= MAX_PAGE_HOST_GENERATION &&
+    Number.isInteger(value.webContentsId) &&
+    value.webContentsId > 0 &&
+    Number.isInteger(value.rendererWebContentsId) &&
+    value.rendererWebContentsId > 0
+  )
+}
+
+function routePageKey(page: BrowserRoutePageIdentity): string {
+  return JSON.stringify([page.partition, page.browserPageId, page.pageHostGeneration])
+}
+
+function destroyGuest(guest: WebContents): void {
+  try {
+    if (guest.isDestroyed()) {
+      return
+    }
+    guest.close()
+  } catch {
+    // The route remains unavailable even if Electron races guest destruction.
+  }
+}
+
+function isDestroyed(guest: WebContents): boolean {
+  try {
+    return guest.isDestroyed()
+  } catch {
+    return true
+  }
+}

--- a/src/main/window/createMainWindow-test-harness.ts
+++ b/src/main/window/createMainWindow-test-harness.ts
@@ -12,6 +12,7 @@ export const browserWindowMock: Mock<
 > = vi.fn()
 export const openExternalMock: MainWindowSpy = vi.fn()
 export const attachGuestPoliciesMock: MainWindowSpy = vi.fn()
+export const attachRouteGuestMock: MainWindowSpy = vi.fn(() => false)
 export const buildFromTemplateMock: Mock<(...args: unknown[]) => { popup: MainWindowSpy }> = vi.fn(
   () => ({ popup: menuPopupMock })
 )
@@ -112,6 +113,8 @@ export function resetMainWindowMocks(): void {
   browserWindowMock.mockReset()
   openExternalMock.mockReset()
   attachGuestPoliciesMock.mockReset()
+  attachRouteGuestMock.mockReset()
+  attachRouteGuestMock.mockReturnValue(false)
   buildFromTemplateMock.mockClear()
   menuPopupMock.mockClear()
   notificationMock.mockClear()

--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -16,6 +16,9 @@ vi.mock('../browser/browser-manager', async () =>
 vi.mock('../browser/browser-route-session-runtime', async () => ({
   browserRouteSessionRegistry: {
     isAllowedPartition: (await import('./createMainWindow-test-harness')).routePartitionAllowedMock
+  },
+  browserRouteWebContentsRegistry: {
+    attachGuest: (await import('./createMainWindow-test-harness')).attachRouteGuestMock
   }
 }))
 
@@ -24,6 +27,7 @@ import { ipcMain } from 'electron'
 import { resetExpectedTeardownStateForTest } from '../crash-reporting/expected-teardown-state'
 import {
   attachGuestPoliciesMock,
+  attachRouteGuestMock,
   browserWindowMock,
   macosTahoeMock,
   openExternalMock,
@@ -224,6 +228,10 @@ describe('createMainWindow', () => {
     const guest = { marker: 'guest' }
     windowHandlers['did-attach-webview']({} as never, guest as never)
     expect(attachGuestPoliciesMock).toHaveBeenCalledWith(guest)
+    expect(attachRouteGuestMock).toHaveBeenCalledWith(guest)
+    expect(attachGuestPoliciesMock.mock.invocationCallOrder[0]).toBeLessThan(
+      attachRouteGuestMock.mock.invocationCallOrder[0]
+    )
 
     const untrustedPreloadParams = {
       src: 'data:text/html,',
@@ -245,6 +253,7 @@ describe('createMainWindow', () => {
     const secondGuest = { marker: 'second-guest' }
     windowHandlers['did-attach-webview']({} as never, secondGuest as never)
     expect(attachGuestPoliciesMock).toHaveBeenLastCalledWith(secondGuest)
+    expect(attachRouteGuestMock).toHaveBeenLastCalledWith(secondGuest)
   })
 
   it('sets platform-specific titlebar and frame options for every desktop platform', () => {

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -15,7 +15,10 @@ import type { Store } from '../persistence'
 import { getAppIconPath } from '../app-icon'
 import { browserManager } from '../browser/browser-manager'
 import { browserSessionRegistry } from '../browser/browser-session-registry'
-import { browserRouteSessionRegistry } from '../browser/browser-route-session-runtime'
+import {
+  browserRouteSessionRegistry,
+  browserRouteWebContentsRegistry
+} from '../browser/browser-route-session-runtime'
 import { translateMain } from '../i18n/main-i18n'
 import { normalizeBrowserNavigationUrl } from '../../shared/browser-url'
 import { ORCA_BROWSER_GUEST_WEB_PREFERENCES } from '../../shared/browser-guest-web-preferences'
@@ -504,6 +507,8 @@ export function createMainWindow(
   mainWindow.webContents.on('did-attach-webview', (_event, guest) => {
     // Why: attach guest popup/nav policy at creation; waiting for renderer registration races target=_blank/early redirects past it.
     browserManager.attachGuestPolicies(guest)
+    // Why: route guests override the generic popup fallback and stay blank until exact main-owned registration.
+    browserRouteWebContentsRegistry.attachGuest(guest)
   })
 
   // Why: mirror markdown-editor focus so before-input-event skips Cmd/Ctrl+B while TipTap owns focus (docs/markdown-cmd-b-bold-design.md).


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​373 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​373 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​451 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​19 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​432 |

<!-- /orca-pr-loc -->

## Summary

Adds the next inert STA-4150 layer on top of #14516:

- recognizes prepared and recently released route Sessions at WebContents attachment
- installs blank-only navigation and popup quarantine before route-guest validation or closure
- registers the exact guest, owning renderer, partition, page, and page-host generation
- binds registration to an opaque per-prepare authority token so tuple reuse cannot revive stale guests
- requires a separate navigation grant and rechecks live authority on every later navigation
- bounds retained guest/page mappings and cleans exact destroyed mappings without stale-callback damage

## Causal evidence

The first candidate had three deterministic failure modes found during fresh review: a page release between will-attach and did-attach could leave the generic HTTP(S)/popup policy active; delayed or throwing admission closure could leave a rejected guest usable; and re-preparing the same logical tuple could revive a stale grant. Focused tests now pin all three cases plus mutable-input, inspection-race, page-conflict, attachment-cap, and destroyed-listener cleanup behavior.

## Validation

- 3 focused files / 113 tests
- 56 main-browser files / 754 tests
- full typecheck
- native and type-aware code-quality audits
- changed-code, reliability-manifest, max-lines, formatting, and diff checks
- fresh correctness and security/performance rereviews: no publication blockers

## Compatibility and rollout

No exchanged field, RPC, capability advertisement, persisted schema, renderer IPC, or production page-preparation/registration/grant caller changes in this PR. Existing local/server/offscreen browsers, older clients, SSH/WSL routes, folder workspaces, and git worktrees retain current placement and behavior. Normal browser Sessions do one bounded lookup and remain on the existing policy path.

This PR must remain inert. Activation still requires exact release/crash teardown, authenticated main-owned registration, real Electron ordering and traffic proof, persisted-worker and network-service recovery, UDP/QUIC/DoH/WebRTC containment, headed/headless/browserless journeys, and physical macOS/Linux/Windows coverage.

Linear: https://linear.app/stably/issue/STA-4150/refactor-remote-browser-to-client-hosted-electron-webviews

Stack: #14471
Parent: #14516