### PR TITLE
feat(editor): copy markdown from the panel header

### DIFF
--- a/src/renderer/src/components/editor/EditorPanel.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.tsx
@@ -4,6 +4,7 @@ import { getConnectionId } from '@/lib/connection-context'
 import { detectLanguage } from '@/lib/language-detect'
 import { canShowWorkspaceFileBrowserAction, openFilePreviewToSide } from '@/lib/file-preview'
 import { getEditorHeaderCopyState } from './editor-header'
+import { getEditorPanelMarkdownHeaderState } from './editor-panel-markdown-header-state'
 import { isLocalPathOpenBlocked, showLocalPathOpenBlockedToast } from '@/lib/local-path-open-guard'
 import { settingsForRuntimeOwner } from '@/runtime/runtime-rpc-client'
 import { exportActiveMarkdownToPdf } from './export-active-markdown'
@@ -17,13 +18,11 @@ import { useEditorCmdSaveRequest } from './useEditorCmdSaveRequest'
 import { useEditorPanelContentState } from './useEditorPanelContentState'
 import { useMarkdownPreviewShortcut } from './useMarkdownPreviewShortcut'
 import { useUntitledFileRename } from './useUntitledFileRename'
-import { extractFrontMatter } from './markdown-frontmatter'
 import {
   selectEditorPanelGitBranchEntries,
   selectEditorPanelGitStatusEntries
 } from './editor-panel-git-entry-selector'
 import { createEditorPanelDraftSelector } from './editor-panel-draft-selector'
-import { createCurrentMarkdownArtifactRequest } from './markdown-artifact-upload'
 import { useEditorPanelSave } from './useEditorPanelSave'
 
 function EditorPanelInner({
@@ -318,37 +317,18 @@ function EditorPanelInner({
     )?.activeRuntimeEnvironmentId?.trim() ||
     (renameDialogFile ? getConnectionId(renameDialogFile.worktreeId) : null)
   )
-  const markdownDocumentStateFileId =
-    activeFile.mode === 'markdown-preview'
-      ? (activeFile.markdownPreviewSourceFileId ?? activeFile.filePath)
-      : activeFile.id
-  let activeMarkdownContent: string | null = null
-  if (activeFile.mode === 'markdown-preview') {
-    activeMarkdownContent =
-      editorDrafts[markdownDocumentStateFileId] ?? fileContents[activeFile.id]?.content ?? null
-  } else if (activeFile.mode === 'edit') {
-    activeMarkdownContent =
-      editorDrafts[activeFile.id] ?? fileContents[activeFile.id]?.content ?? null
-  }
-  const canShowMarkdownFrontmatterToggle = Boolean(
-    model.isMarkdown &&
-    (activeFile.mode === 'markdown-preview' || model.mdViewMode !== 'source') &&
-    activeMarkdownContent &&
-    extractFrontMatter(activeMarkdownContent)
-  )
+  const mdHeader = getEditorPanelMarkdownHeaderState({
+    activeFile,
+    isMarkdown: model.isMarkdown,
+    isDiffSurface: model.isDiffSurface,
+    mdViewMode: model.mdViewMode,
+    editorDrafts,
+    fileContents
+  })
+  const mdDocId = mdHeader.markdownDocumentStateFileId
   // Why: front-matter shows by default; the map only carries per-file hide overrides.
-  const isMarkdownFrontmatterVisible =
-    markdownFrontmatterVisible[markdownDocumentStateFileId] ?? true
-  const isMarkdownTableOfContentsVisible =
-    markdownTableOfContentsVisible[markdownDocumentStateFileId] ?? false
-  const createActiveMarkdownArtifactRequest = () =>
-    Promise.resolve(
-      createCurrentMarkdownArtifactRequest(
-        activeFile,
-        markdownDocumentStateFileId,
-        activeMarkdownContent ?? ''
-      )
-    )
+  const isMarkdownFrontmatterVisible = markdownFrontmatterVisible[mdDocId] ?? true
+  const isMarkdownTableOfContentsVisible = markdownTableOfContentsVisible[mdDocId] ?? false
 
   return (
     // Why: each split pane needs an isolated bridge between its diff editor and header controls.
@@ -359,8 +339,9 @@ function EditorPanelInner({
         activeViewStateId={activeViewStateId}
         model={model}
         copiedPathVisible={copiedPathToast?.fileId === activeFile.id}
+        canCopyMarkdown={mdHeader.markdownCopyState.canCopy}
         showMarkdownTableOfContents={isMarkdownTableOfContentsVisible}
-        canShowMarkdownFrontmatterToggle={canShowMarkdownFrontmatterToggle}
+        canShowMarkdownFrontmatterToggle={mdHeader.canShowMarkdownFrontmatterToggle}
         markdownFrontmatterVisible={isMarkdownFrontmatterVisible}
         sideBySide={sideBySide}
         openFiles={openFiles}
@@ -372,6 +353,7 @@ function EditorPanelInner({
         renameError={renameError}
         disableRenameBrowse={disableRenameBrowse}
         onCopyPath={() => void handleCopyPath()}
+        onCopyMarkdown={mdHeader.copyMarkdown}
         onOpenDiffTargetFile={handleOpenDiffTargetFile}
         onOpenPreviewToSide={handleOpenPreviewToSide}
         onOpenMarkdownPreview={handleOpenMarkdownPreview}
@@ -379,19 +361,18 @@ function EditorPanelInner({
         onToggleSideBySide={() => setSideBySide((prev) => !prev)}
         onEditorToggleChange={handleEditorToggleChange}
         onToggleMarkdownTableOfContents={() =>
-          setMarkdownTableOfContentsVisible(
-            markdownDocumentStateFileId,
-            !isMarkdownTableOfContentsVisible
-          )
+          setMarkdownTableOfContentsVisible(mdDocId, !isMarkdownTableOfContentsVisible)
         }
         onToggleMarkdownFrontmatter={() =>
-          setMarkdownFrontmatterVisible(markdownDocumentStateFileId, !isMarkdownFrontmatterVisible)
+          setMarkdownFrontmatterVisible(mdDocId, !isMarkdownFrontmatterVisible)
         }
         onExportMarkdownToPdf={() =>
           void exportActiveMarkdownToPdf({ fileId: activeFile.id, root: panelRef.current })
         }
         createMarkdownArtifactRequest={
-          activeMarkdownContent === null ? undefined : createActiveMarkdownArtifactRequest
+          mdHeader.activeMarkdownContent === null
+            ? undefined
+            : mdHeader.createActiveMarkdownArtifactRequest
         }
         onContentChange={handleContentChange}
         onContentChangeForFile={handleContentChangeForFile}
@@ -399,9 +380,7 @@ function EditorPanelInner({
         onSave={handleSave}
         onSaveForFile={handleSaveForFile}
         onReloadContent={reloadContent}
-        onCloseMarkdownTableOfContents={() =>
-          setMarkdownTableOfContentsVisible(markdownDocumentStateFileId, false)
-        }
+        onCloseMarkdownTableOfContents={() => setMarkdownTableOfContentsVisible(mdDocId, false)}
         onCloseRenameDialog={closeRenameDialog}
         onRenameConfirm={handleRenameConfirm}
         markdownAnnotationsEnabled={markdownAnnotationsEnabled}

--- a/src/renderer/src/components/editor/EditorPanelHeader.test.tsx
+++ b/src/renderer/src/components/editor/EditorPanelHeader.test.tsx
@@ -86,7 +86,9 @@ const baseProps = {
   markdownFrontmatterVisible: false,
   sideBySide: false,
   openFileState: { canOpen: false },
+  canCopyMarkdown: false,
   onCopyPath: vi.fn(),
+  onCopyMarkdown: vi.fn(async () => false),
   onOpenDiffTargetFile: vi.fn(),
   onOpenPreviewToSide: vi.fn(),
   onOpenMarkdownPreview: vi.fn(),
@@ -137,5 +139,36 @@ describe('EditorPanelHeader', () => {
         createMarkdownArtifactRequest: createRequest
       })
     ).not.toContain('data-artifact-publish')
+  })
+
+  it('offers copy markdown only on non-diff Markdown surfaces', () => {
+    expect(
+      renderHeader({
+        isDiffSurface: false,
+        isMarkdown: true,
+        canCopyMarkdown: true
+      })
+    ).toContain('aria-label="Copy markdown"')
+    expect(
+      renderHeader({
+        isDiffSurface: true,
+        isMarkdown: true,
+        canCopyMarkdown: true
+      })
+    ).not.toContain('aria-label="Copy markdown"')
+    expect(
+      renderHeader({
+        isDiffSurface: false,
+        isMarkdown: false,
+        canCopyMarkdown: true
+      })
+    ).not.toContain('aria-label="Copy markdown"')
+    expect(
+      renderHeader({
+        isDiffSurface: false,
+        isMarkdown: true,
+        canCopyMarkdown: false
+      })
+    ).toContain('aria-label="Markdown is not ready to copy"')
   })
 })

--- a/src/renderer/src/components/editor/EditorPanelHeader.tsx
+++ b/src/renderer/src/components/editor/EditorPanelHeader.tsx
@@ -12,6 +12,7 @@ import type { EditorToggleValue } from './EditorViewToggle'
 import type { EditorHeaderOpenFileState } from './editor-header'
 import { DiffNotesSendMenu } from './DiffNotesSendMenu'
 import { EditorPanelMarkdownActionsMenu } from './EditorPanelMarkdownActionsMenu'
+import { EditorPanelMarkdownCopyButton } from './EditorPanelMarkdownCopyButton'
 import { translate } from '@/i18n/i18n'
 import { EditorPanelHeaderPath } from './EditorPanelHeaderPath'
 import { useDiffNavigation } from './diff-navigation-context'
@@ -43,7 +44,9 @@ type EditorPanelHeaderProps = {
   markdownFrontmatterVisible: boolean
   sideBySide: boolean
   openFileState: EditorHeaderOpenFileState
+  canCopyMarkdown: boolean
   onCopyPath: () => void
+  onCopyMarkdown: () => Promise<boolean>
   onOpenDiffTargetFile: (preferredMarkdownViewMode?: 'rich') => void
   onOpenPreviewToSide: () => void
   onOpenMarkdownPreview: () => void
@@ -78,7 +81,9 @@ export function EditorPanelHeader({
   markdownFrontmatterVisible,
   sideBySide,
   openFileState,
+  canCopyMarkdown,
   onCopyPath,
+  onCopyMarkdown,
   onOpenDiffTargetFile,
   onOpenPreviewToSide,
   onOpenMarkdownPreview,
@@ -315,6 +320,9 @@ export function EditorPanelHeader({
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>
+      )}
+      {isMarkdown && !isDiffSurface && (
+        <EditorPanelMarkdownCopyButton canCopy={canCopyMarkdown} onCopy={onCopyMarkdown} />
       )}
       {isMarkdown && !isDiffSurface && createMarkdownArtifactRequest ? (
         <ArtifactPublishButton

--- a/src/renderer/src/components/editor/EditorPanelMarkdownCopyButton.tsx
+++ b/src/renderer/src/components/editor/EditorPanelMarkdownCopyButton.tsx
@@ -1,0 +1,75 @@
+import { useCallback, useRef, useState } from 'react'
+import { Check, Copy } from 'lucide-react'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { translate } from '@/i18n/i18n'
+
+type EditorPanelMarkdownCopyButtonProps = {
+  canCopy: boolean
+  onCopy: () => Promise<boolean>
+}
+
+export function EditorPanelMarkdownCopyButton({
+  canCopy,
+  onCopy
+}: EditorPanelMarkdownCopyButtonProps): React.JSX.Element {
+  const [copied, setCopied] = useState(false)
+  const copiedResetTimerRef = useRef<number | null>(null)
+  const mountedRef = useRef(false)
+  const clearCopiedResetTimer = useCallback((): void => {
+    if (copiedResetTimerRef.current === null) {
+      return
+    }
+    window.clearTimeout(copiedResetTimerRef.current)
+    copiedResetTimerRef.current = null
+  }, [])
+  const setButtonRef = useCallback(
+    (node: HTMLButtonElement | null) => {
+      mountedRef.current = node !== null
+      if (node === null) {
+        clearCopiedResetTimer()
+      }
+    },
+    [clearCopiedResetTimer]
+  )
+  const handleCopy = useCallback((): void => {
+    void onCopy().then((didCopy) => {
+      if (!didCopy || !mountedRef.current) {
+        return
+      }
+      clearCopiedResetTimer()
+      setCopied(true)
+      copiedResetTimerRef.current = window.setTimeout(() => {
+        copiedResetTimerRef.current = null
+        setCopied(false)
+      }, 1500)
+    })
+  }, [clearCopiedResetTimer, onCopy])
+  const label = canCopy
+    ? translate('auto.components.editor.EditorPanelHeader.copyMarkdown', 'Copy markdown')
+    : translate(
+        'auto.components.editor.EditorPanelHeader.copyMarkdownUnavailable',
+        'Markdown is not ready to copy'
+      )
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            ref={setButtonRef}
+            type="button"
+            className="p-1 rounded hover:bg-accent text-muted-foreground hover:text-foreground transition-colors flex-shrink-0 disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
+            onClick={handleCopy}
+            disabled={!canCopy}
+            aria-label={label}
+          >
+            {copied ? <Check size={14} /> : <Copy size={14} />}
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" sideOffset={4}>
+          {label}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}

--- a/src/renderer/src/components/editor/EditorPanelShell.tsx
+++ b/src/renderer/src/components/editor/EditorPanelShell.tsx
@@ -20,6 +20,7 @@ type EditorPanelShellProps = {
   activeViewStateId: string | null | undefined
   model: EditorPanelRenderModel
   copiedPathVisible: boolean
+  canCopyMarkdown: boolean
   showMarkdownTableOfContents: boolean
   canShowMarkdownFrontmatterToggle: boolean
   markdownFrontmatterVisible: boolean
@@ -33,6 +34,7 @@ type EditorPanelShellProps = {
   renameError: string | null
   disableRenameBrowse: boolean
   onCopyPath: () => void
+  onCopyMarkdown: () => Promise<boolean>
   onOpenDiffTargetFile: (preferredMarkdownViewMode?: 'rich') => void
   onOpenPreviewToSide: () => void
   onOpenMarkdownPreview: () => void
@@ -61,6 +63,7 @@ export function EditorPanelShell({
   activeViewStateId,
   model,
   copiedPathVisible,
+  canCopyMarkdown,
   showMarkdownTableOfContents,
   canShowMarkdownFrontmatterToggle,
   markdownFrontmatterVisible,
@@ -74,6 +77,7 @@ export function EditorPanelShell({
   renameError,
   disableRenameBrowse,
   onCopyPath,
+  onCopyMarkdown,
   onOpenDiffTargetFile,
   onOpenPreviewToSide,
   onOpenMarkdownPreview,
@@ -120,7 +124,9 @@ export function EditorPanelShell({
           markdownFrontmatterVisible={markdownFrontmatterVisible}
           sideBySide={sideBySide}
           openFileState={model.openFileState}
+          canCopyMarkdown={canCopyMarkdown}
           onCopyPath={onCopyPath}
+          onCopyMarkdown={onCopyMarkdown}
           onOpenDiffTargetFile={onOpenDiffTargetFile}
           onOpenPreviewToSide={onOpenPreviewToSide}
           onOpenMarkdownPreview={onOpenMarkdownPreview}

--- a/src/renderer/src/components/editor/editor-header.test.ts
+++ b/src/renderer/src/components/editor/editor-header.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { getEditorHeaderCopyState, getEditorHeaderOpenFileState } from './editor-header'
+import {
+  getEditorHeaderCopyMarkdownState,
+  getEditorHeaderCopyState,
+  getEditorHeaderOpenFileState
+} from './editor-header'
 import type { OpenFile } from '@/store/slices/editor'
 
 function makeOpenFile(overrides: Partial<OpenFile> = {}): OpenFile {
@@ -176,5 +180,67 @@ describe('getEditorHeaderOpenFileState', () => {
         null
       )
     ).toEqual({ canOpen: true })
+  })
+})
+
+describe('getEditorHeaderCopyMarkdownState', () => {
+  it('hides the action on non-markdown and diff surfaces', () => {
+    expect(
+      getEditorHeaderCopyMarkdownState({
+        isMarkdown: false,
+        isDiffSurface: false,
+        content: '# Hello'
+      })
+    ).toEqual({ canShow: false, canCopy: false })
+    expect(
+      getEditorHeaderCopyMarkdownState({
+        isMarkdown: true,
+        isDiffSurface: true,
+        content: '# Hello'
+      })
+    ).toEqual({ canShow: false, canCopy: false })
+  })
+
+  it('allows copying loaded markdown, including an empty document', () => {
+    expect(
+      getEditorHeaderCopyMarkdownState({
+        isMarkdown: true,
+        isDiffSurface: false,
+        content: '# Hello'
+      })
+    ).toEqual({ canShow: true, canCopy: true })
+    expect(
+      getEditorHeaderCopyMarkdownState({
+        isMarkdown: true,
+        isDiffSurface: false,
+        content: ''
+      })
+    ).toEqual({ canShow: true, canCopy: true })
+  })
+
+  it('keeps the button visible but disabled while content is missing or unreadable', () => {
+    expect(
+      getEditorHeaderCopyMarkdownState({
+        isMarkdown: true,
+        isDiffSurface: false,
+        content: null
+      })
+    ).toEqual({ canShow: true, canCopy: false })
+    expect(
+      getEditorHeaderCopyMarkdownState({
+        isMarkdown: true,
+        isDiffSurface: false,
+        content: '# Hello',
+        isBinary: true
+      })
+    ).toEqual({ canShow: true, canCopy: false })
+    expect(
+      getEditorHeaderCopyMarkdownState({
+        isMarkdown: true,
+        isDiffSurface: false,
+        content: '# Hello',
+        hasLoadError: true
+      })
+    ).toEqual({ canShow: true, canCopy: false })
   })
 })

--- a/src/renderer/src/components/editor/editor-header.ts
+++ b/src/renderer/src/components/editor/editor-header.ts
@@ -14,6 +14,28 @@ export type EditorHeaderOpenFileState = {
   canOpen: boolean
 }
 
+export type EditorHeaderCopyMarkdownState = {
+  canShow: boolean
+  canCopy: boolean
+}
+
+export function getEditorHeaderCopyMarkdownState(params: {
+  isMarkdown: boolean
+  isDiffSurface: boolean
+  content: string | null
+  isBinary?: boolean
+  hasLoadError?: boolean
+}): EditorHeaderCopyMarkdownState {
+  if (!params.isMarkdown || params.isDiffSurface) {
+    return { canShow: false, canCopy: false }
+  }
+  // Why: empty markdown is still a real document; only block unload/binary/error.
+  if (params.isBinary || params.hasLoadError || params.content === null) {
+    return { canShow: true, canCopy: false }
+  }
+  return { canShow: true, canCopy: true }
+}
+
 export function getEditorHeaderCopyState(file: OpenFile): EditorHeaderCopyState {
   if (file.mode === 'conflict-review') {
     return {

--- a/src/renderer/src/components/editor/editor-panel-markdown-header-state.test.ts
+++ b/src/renderer/src/components/editor/editor-panel-markdown-header-state.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import type { OpenFile } from '@/store/slices/editor'
+import {
+  getActiveMarkdownDocumentContent,
+  getEditorPanelMarkdownDocumentStateFileId,
+  getEditorPanelMarkdownHeaderState
+} from './editor-panel-markdown-header-state'
+
+function makeFile(overrides: Partial<OpenFile> = {}): OpenFile {
+  return {
+    id: '/repo/readme.md',
+    filePath: '/repo/readme.md',
+    relativePath: 'readme.md',
+    worktreeId: 'wt-1',
+    language: 'markdown',
+    isDirty: false,
+    mode: 'edit',
+    ...overrides
+  }
+}
+
+describe('getActiveMarkdownDocumentContent', () => {
+  it('prefers the edit draft over the last loaded bytes', () => {
+    expect(
+      getActiveMarkdownDocumentContent(
+        makeFile(),
+        { '/repo/readme.md': '# Draft' },
+        { '/repo/readme.md': { content: '# Saved', isBinary: false } }
+      )
+    ).toBe('# Draft')
+  })
+
+  it('reads preview drafts from the source file id', () => {
+    const preview = makeFile({
+      id: 'preview:/repo/readme.md',
+      mode: 'markdown-preview',
+      markdownPreviewSourceFileId: '/repo/readme.md'
+    })
+    expect(getEditorPanelMarkdownDocumentStateFileId(preview)).toBe('/repo/readme.md')
+    expect(
+      getActiveMarkdownDocumentContent(
+        preview,
+        { '/repo/readme.md': '# From source' },
+        { 'preview:/repo/readme.md': { content: '# Preview load', isBinary: false } }
+      )
+    ).toBe('# From source')
+  })
+})
+
+describe('getEditorPanelMarkdownHeaderState', () => {
+  it('enables copy for a loaded markdown edit tab', () => {
+    const state = getEditorPanelMarkdownHeaderState({
+      activeFile: makeFile(),
+      isMarkdown: true,
+      isDiffSurface: false,
+      mdViewMode: 'rich',
+      editorDrafts: {},
+      fileContents: { '/repo/readme.md': { content: '# Hello', isBinary: false } }
+    })
+    expect(state.activeMarkdownContent).toBe('# Hello')
+    expect(state.markdownCopyState).toEqual({ canShow: true, canCopy: true })
+  })
+
+  it('disables copy when the loaded file is binary', () => {
+    const state = getEditorPanelMarkdownHeaderState({
+      activeFile: makeFile(),
+      isMarkdown: true,
+      isDiffSurface: false,
+      mdViewMode: 'rich',
+      editorDrafts: {},
+      fileContents: { '/repo/readme.md': { content: '', isBinary: true } }
+    })
+    expect(state.markdownCopyState.canCopy).toBe(false)
+  })
+})

--- a/src/renderer/src/components/editor/editor-panel-markdown-header-state.ts
+++ b/src/renderer/src/components/editor/editor-panel-markdown-header-state.ts
@@ -1,0 +1,88 @@
+import type { OpenFile } from '@/store/slices/editor'
+import { extractFrontMatter } from './markdown-frontmatter'
+import { createCurrentMarkdownArtifactRequest } from './markdown-artifact-upload'
+import {
+  getEditorHeaderCopyMarkdownState,
+  type EditorHeaderCopyMarkdownState
+} from './editor-header'
+import { copyMarkdownDocument } from './markdown-header-copy'
+import type { FileContent } from './editor-panel-content-types'
+import type { ArtifactWriteRequest } from '../../../../shared/artifacts'
+
+export function getEditorPanelMarkdownDocumentStateFileId(file: OpenFile): string {
+  return file.mode === 'markdown-preview'
+    ? (file.markdownPreviewSourceFileId ?? file.filePath)
+    : file.id
+}
+
+export function getActiveMarkdownDocumentContent(
+  file: OpenFile,
+  editorDrafts: Record<string, string>,
+  fileContents: Record<string, FileContent>
+): string | null {
+  if (file.mode === 'markdown-preview') {
+    return (
+      editorDrafts[getEditorPanelMarkdownDocumentStateFileId(file)] ??
+      fileContents[file.id]?.content ??
+      null
+    )
+  }
+  if (file.mode === 'edit') {
+    return editorDrafts[file.id] ?? fileContents[file.id]?.content ?? null
+  }
+  return null
+}
+
+export function getEditorPanelMarkdownHeaderState(params: {
+  activeFile: OpenFile
+  isMarkdown: boolean
+  isDiffSurface: boolean
+  mdViewMode: string
+  editorDrafts: Record<string, string>
+  fileContents: Record<string, FileContent>
+}): {
+  markdownDocumentStateFileId: string
+  activeMarkdownContent: string | null
+  canShowMarkdownFrontmatterToggle: boolean
+  markdownCopyState: EditorHeaderCopyMarkdownState
+  createActiveMarkdownArtifactRequest: () => Promise<ArtifactWriteRequest>
+  copyMarkdown: () => Promise<boolean>
+} {
+  const { activeFile, editorDrafts, fileContents } = params
+  const markdownDocumentStateFileId = getEditorPanelMarkdownDocumentStateFileId(activeFile)
+  const activeMarkdownContent = getActiveMarkdownDocumentContent(
+    activeFile,
+    editorDrafts,
+    fileContents
+  )
+  const loadedContent = fileContents[activeFile.id]
+  return {
+    markdownDocumentStateFileId,
+    activeMarkdownContent,
+    canShowMarkdownFrontmatterToggle: Boolean(
+      params.isMarkdown &&
+      (activeFile.mode === 'markdown-preview' || params.mdViewMode !== 'source') &&
+      activeMarkdownContent &&
+      extractFrontMatter(activeMarkdownContent)
+    ),
+    markdownCopyState: getEditorHeaderCopyMarkdownState({
+      isMarkdown: params.isMarkdown,
+      isDiffSurface: params.isDiffSurface,
+      content: activeMarkdownContent,
+      isBinary: loadedContent?.isBinary === true,
+      hasLoadError: Boolean(loadedContent?.loadError)
+    }),
+    createActiveMarkdownArtifactRequest: () =>
+      Promise.resolve(
+        createCurrentMarkdownArtifactRequest(
+          activeFile,
+          markdownDocumentStateFileId,
+          activeMarkdownContent ?? ''
+        )
+      ),
+    copyMarkdown: () =>
+      activeMarkdownContent === null
+        ? Promise.resolve(false)
+        : copyMarkdownDocument(activeMarkdownContent)
+  }
+}

--- a/src/renderer/src/components/editor/markdown-header-copy.test.ts
+++ b/src/renderer/src/components/editor/markdown-header-copy.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { toastError } = vi.hoisted(() => ({
+  toastError: vi.fn()
+}))
+
+vi.mock('sonner', () => ({ toast: { error: toastError } }))
+vi.mock('@/i18n/i18n', () => ({ translate: (_key: string, fallback: string) => fallback }))
+
+import { copyMarkdownDocument } from './markdown-header-copy'
+
+describe('copyMarkdownDocument', () => {
+  const writeClipboardText = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(window as unknown as { api: unknown }).api = { ui: { writeClipboardText } }
+  })
+
+  it('writes the markdown source and reports success', async () => {
+    writeClipboardText.mockResolvedValue(undefined)
+
+    await expect(copyMarkdownDocument('# Hello')).resolves.toBe(true)
+    expect(writeClipboardText).toHaveBeenCalledWith('# Hello')
+    expect(toastError).not.toHaveBeenCalled()
+  })
+
+  it('toasts and reports failure when the clipboard write rejects', async () => {
+    writeClipboardText.mockRejectedValue(new Error('clipboard unavailable'))
+
+    await expect(copyMarkdownDocument('# Hello')).resolves.toBe(false)
+    expect(toastError).toHaveBeenCalledWith('Failed to copy markdown')
+  })
+})

--- a/src/renderer/src/components/editor/markdown-header-copy.ts
+++ b/src/renderer/src/components/editor/markdown-header-copy.ts
@@ -1,0 +1,14 @@
+import { toast } from 'sonner'
+import { translate } from '@/i18n/i18n'
+
+export async function copyMarkdownDocument(content: string): Promise<boolean> {
+  try {
+    await window.api.ui.writeClipboardText(content)
+    return true
+  } catch {
+    toast.error(
+      translate('auto.components.editor.markdownHeaderCopy.copyFailed', 'Failed to copy markdown')
+    )
+    return false
+  }
+}


### PR DESCRIPTION
## ELI5

Markdown tabs now have a copy button in the header. It puts the current file text on the clipboard, including edits you have not saved yet.

## What Changed

Added a Copy icon on markdown edit/preview headers (not diffs). It writes the live source. The button stays visible but disabled while the file is loading, binary, or failed to load. Clicking the path still copies the path.

## Why

Select-all was the only way to grab a whole `.md` file. Code blocks and review notes already have copy actions; the document itself did not.

## Linked Issue

Fixes #14526

## Visual Proof

N/A for a screenshot in this PR. The control is a 14px Copy icon in the existing header row, same muted chrome as TOC / preview. After a successful copy it flips to a check for 1.5s.

## Testing

- [x] Automated tests for visibility, disabled states, draft vs loaded content, and clipboard success/failure
- [ ] I manually tested these changes locally

```
pnpm exec vitest run --config config/vitest.config.ts \
  src/renderer/src/components/editor/editor-header.test.ts \
  src/renderer/src/components/editor/markdown-header-copy.test.ts \
  src/renderer/src/components/editor/EditorPanelHeader.test.tsx \
  src/renderer/src/components/editor/editor-panel-markdown-header-state.test.ts
```

22 passed. macOS only for the unit run. Clipboard goes through `window.api.ui.writeClipboardText`, so local / WSL / SSH should behave the same.

## Review

Header-only. No shortcuts, no path changes, no wire format.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)


Made with [Cursor](https://cursor.com)