### PR TITLE
feat(browser): qualify client page host capabilities

### DIFF
--- a/src/main/runtime/browser-host-capability-selection.test.ts
+++ b/src/main/runtime/browser-host-capability-selection.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+import { BrowserHostLeaseRegistry } from './browser-host-lease-registry'
+
+const registry = (): BrowserHostLeaseRegistry =>
+  new BrowserHostLeaseRegistry({ authorityRuntimeId: 'runtime-a', authorityEpoch: 'epoch-a' })
+
+describe('browser host capability selection', () => {
+  it('selects the only host satisfying every requested capability', () => {
+    const leases = registry()
+    attach(leases, 'webview-only', ['webview'])
+    attach(leases, 'commands', ['webview', 'commands.v1'])
+
+    expect(leases.select(undefined, ['webview', 'commands.v1'])).toMatchObject({
+      browserHostClientId: 'host-commands'
+    })
+    expect(() => leases.select('host-webview-only', ['commands.v1'])).toThrow(
+      'browser_host_capability_unavailable'
+    )
+    expect(() => leases.select(undefined, ['mirror.v1'])).toThrow('browser_host_unavailable')
+  })
+
+  it('keeps multiple qualified hosts ambiguous without arbitrary routing', () => {
+    const leases = registry()
+    attach(leases, 'a', ['webview', 'commands.v1'])
+    attach(leases, 'b', ['webview', 'commands.v1'])
+
+    expect(() => leases.select(undefined, ['commands.v1'])).toThrow('browser_host_ambiguous')
+  })
+
+  it('requires webview plus page-specific capabilities before placement', () => {
+    const leases = registry()
+    attach(leases, 'a', ['webview'])
+
+    expect(() => leases.placeClientPage('page-a', 'host-a', ['commands.v1'])).toThrow(
+      'browser_host_capability_unavailable'
+    )
+    expect(leases.getPlacement('page-a')).toBeUndefined()
+    attach(leases, 'a', ['webview', 'commands.v1'], 'connection-b')
+    expect(leases.placeClientPage('page-a', 'host-a', ['commands.v1'])).toMatchObject({
+      browserHostGeneration: 2,
+      pageHostGeneration: 1
+    })
+  })
+
+  it('rejects a client page on a host without webview support', () => {
+    const leases = registry()
+    attach(leases, 'a', ['commands.v1'])
+
+    expect(() => leases.placeClientPage('page-a', 'host-a')).toThrow(
+      'browser_host_capability_unavailable'
+    )
+    expect(leases.getPlacement('page-a')).toBeUndefined()
+  })
+
+  it('suspends placement after a reconnect capability downgrade', () => {
+    const leases = registry()
+    attach(leases, 'a', ['webview', 'commands.v1'])
+    const placement = leases.placeClientPage('page-a', 'host-a', ['commands.v1'])
+    attach(leases, 'a', ['webview'], 'connection-b')
+
+    expect(() =>
+      leases.requireClientPage({
+        authorityRuntimeId: 'runtime-a',
+        authorityEpoch: 'epoch-a',
+        browserPageId: 'page-a',
+        browserHostClientId: 'host-a',
+        browserHostGeneration: 1,
+        pageHostGeneration: 1
+      })
+    ).toThrow('browser_host_lease_stale')
+    expect(() => leases.placeClientPage('page-a', 'host-a', ['commands.v1'])).toThrow(
+      'browser_host_capability_unavailable'
+    )
+    expect(leases.getPlacement('page-a')).toBe(placement)
+  })
+})
+
+function attach(
+  leases: BrowserHostLeaseRegistry,
+  suffix: string,
+  hostCapabilities: readonly string[],
+  connectionId = `connection-${suffix}`
+): void {
+  leases.attach({
+    browserHostClientId: `host-${suffix}`,
+    connectionId,
+    pairedDeviceId: `device-${suffix}`,
+    hostCapabilities
+  })
+}

--- a/src/main/runtime/browser-host-capability-selection.ts
+++ b/src/main/runtime/browser-host-capability-selection.ts
@@ -1,0 +1,42 @@
+export const BROWSER_HOST_WEBVIEW_CAPABILITY = 'webview'
+
+type BrowserHostCapabilityLease = Readonly<{ hostCapabilities: readonly string[] }>
+type BrowserHostLeaseStateView<T extends BrowserHostCapabilityLease> = Readonly<{ lease: T }>
+
+export function selectBrowserHostLease<T extends BrowserHostCapabilityLease>(
+  leasesByClientId: ReadonlyMap<string, BrowserHostLeaseStateView<T>>,
+  browserHostClientId?: string,
+  requiredCapabilities: readonly string[] = []
+): T {
+  if (browserHostClientId) {
+    const exact = leasesByClientId.get(browserHostClientId)
+    if (!exact) {
+      throw new Error('browser_host_unavailable')
+    }
+    if (!hasCapabilities(exact.lease, requiredCapabilities)) {
+      throw new Error('browser_host_capability_unavailable')
+    }
+    return exact.lease
+  }
+  let selected: T | undefined
+  for (const state of leasesByClientId.values()) {
+    if (!hasCapabilities(state.lease, requiredCapabilities)) {
+      continue
+    }
+    if (selected) {
+      throw new Error('browser_host_ambiguous')
+    }
+    selected = state.lease
+  }
+  if (!selected) {
+    throw new Error('browser_host_unavailable')
+  }
+  return selected
+}
+
+function hasCapabilities(
+  lease: BrowserHostCapabilityLease,
+  requiredCapabilities: readonly string[]
+): boolean {
+  return requiredCapabilities.every((capability) => lease.hostCapabilities.includes(capability))
+}

--- a/src/main/runtime/browser-host-lease-registry.ts
+++ b/src/main/runtime/browser-host-lease-registry.ts
@@ -11,6 +11,10 @@ import {
   type BrowserHostFence,
   type BrowserHostFenceReason
 } from './browser-host-lease-fence'
+import {
+  BROWSER_HOST_WEBVIEW_CAPABILITY,
+  selectBrowserHostLease
+} from './browser-host-capability-selection'
 
 const MAX_GENERATION = 0xffff_ffff
 const MAX_BROWSER_HOSTS_PER_CONNECTION = 1
@@ -121,21 +125,11 @@ export class BrowserHostLeaseRegistry {
     }
   }
 
-  select(browserHostClientId?: string): BrowserHostLease {
-    if (browserHostClientId) {
-      const exact = this.leasesByClientId.get(browserHostClientId)
-      if (!exact) {
-        throw new Error('browser_host_unavailable')
-      }
-      return exact.lease
-    }
-    if (this.leasesByClientId.size === 0) {
-      throw new Error('browser_host_unavailable')
-    }
-    if (this.leasesByClientId.size > 1) {
-      throw new Error('browser_host_ambiguous')
-    }
-    return this.leasesByClientId.values().next().value!.lease
+  select(
+    browserHostClientId?: string,
+    requiredCapabilities: readonly string[] = []
+  ): BrowserHostLease {
+    return selectBrowserHostLease(this.leasesByClientId, browserHostClientId, requiredCapabilities)
   }
 
   requireLease(identity: BrowserHostLeaseIdentity): BrowserHostLease {
@@ -179,8 +173,15 @@ export class BrowserHostLeaseRegistry {
     return this.pagePlacements.placeServerPage(browserPageId)
   }
 
-  placeClientPage(browserPageId: string, browserHostClientId?: string): RuntimeBrowserPlacement {
-    const lease = this.select(browserHostClientId)
+  placeClientPage(
+    browserPageId: string,
+    browserHostClientId?: string,
+    requiredCapabilities: readonly string[] = []
+  ): RuntimeBrowserPlacement {
+    const lease = this.select(browserHostClientId, [
+      BROWSER_HOST_WEBVIEW_CAPABILITY,
+      ...requiredCapabilities
+    ])
     return this.pagePlacements.placeClientPage(browserPageId, {
       browserHostClientId: lease.browserHostClientId,
       browserHostGeneration: lease.browserHostGeneration


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​90 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​90 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​60 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​43 |

<!-- /orca-pr-loc -->

## ELI5

Before the runtime assigns a browser page to a desktop, it now checks that the desktop actually promises every browser-engine feature that page needs. Previously the lease stored those promises but placement ignored them, so an incompatible host could be selected.

## What Changed

- Filter automatic host selection by every requested host capability.
- Fail closed when an explicitly requested host lacks a requirement.
- Require `webview` support for every client-hosted page before allocating its page generation.
- Preserve explicit ambiguity when multiple eligible hosts exist; never route arbitrarily.
- Prove reconnect capability downgrade fences the old page and does not silently replace it.

## Why

STA-4150 requires runtime-owned, explicit browser placement. Capability-qualified selection is the next inert authority boundary before authenticated page-command delivery: a runtime must never place a page on a host that cannot implement it, and must never fall back to server placement implicitly.

This remains scaffolding only. It does not advertise a runtime capability, register an RPC or event, change an exchanged field, add an Electron/renderer caller, or enable client placement. Existing server-hosted behavior and old clients are unchanged.

## Linked Issue

[STA-4150](https://linear.app/stably/issue/STA-4150/refactor-remote-browser-to-client-hosted-electron-webviews)

## Visual Proof

N/A — no rendered UI or production behavior is activated.

## Testing

- Parent behavior: 3/3 new causal assertions failed because capability requirements were ignored.
- Focused candidate: 22/22 placement, lease, and downgrade tests passed.
- Full `src/main/runtime` + `src/main/browser`: 4,941 passed, 5 existing skips.
- Adjacent RPC/protocol/mixed-version wire: 31/31 passed.
- Full typecheck, native/type-aware audits, changed-code audit, formatting, reliability manifest, max-lines ratchet, and diff checks passed.
- Two fresh correctness and security/performance reviews found no publication blocker.

- [x] I manually validated the deterministic runtime behavior locally
- [x] Automated tests added

## Review

Please review capability matching, ambiguity, downgrade fencing, mixed-version/server-placement neutrality, and the intentionally inactive production surface.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why, including ELI5
- [x] Visual proof is N/A because no UI path is active
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, mobile, and backward-compatibility impact considered
- [x] Relevant local tests, typecheck, audits, and quality gates pass; package builds are covered by CI
