### PR TITLE
fix(terminal): retire resume state after confirmed agent exit

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection-main-side-effect-authority.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-main-side-effect-authority.test.ts
@@ -5,6 +5,7 @@ import { flushAsyncTicks } from './pty-connection-test-async'
 import { AGENT_TASK_COMPLETE_NOTIFICATION_MAX_WAIT_MS } from './pty-connection-test-constants'
 import {
   LEAF_1,
+  LEAF_2,
   createMockTransport,
   createPane,
   createManager,
@@ -389,6 +390,70 @@ describe('connectPanePty', () => {
 
       expect(mockStoreState.dropAgentStatus).toHaveBeenCalledWith(paneKey)
       expect(mockStoreState.removeAgentStatus).not.toHaveBeenCalled()
+    })
+
+    it('retires only the confirmed agent exit recovery record before immediate PTY teardown', async () => {
+      enableMainAuthority()
+      const { connectPanePty } = await import('./pty-connection')
+      const handler = await import('./terminal-side-effect-facts-handler')
+      const transport = createMockTransport('pty-agent-exit')
+      transportFactoryQueue.push(transport)
+      const paneKey = 'tab-1:1'
+      const duplicatePaneKey = 'tab-1:2'
+      const siblingPaneKey = makePaneKey('tab-1', LEAF_2)
+      const record = {
+        paneKey,
+        tabId: 'tab-1',
+        worktreeId: 'wt-1',
+        agent: 'claude',
+        providerSession: { key: 'session_id', id: 'session-1' },
+        state: 'working',
+        capturedAt: 1,
+        updatedAt: 1
+      }
+      const duplicateRecord = { ...record, paneKey: duplicatePaneKey, capturedAt: 2, updatedAt: 2 }
+      const siblingRecord = {
+        paneKey: siblingPaneKey,
+        tabId: 'tab-1',
+        worktreeId: 'wt-1',
+        agent: 'claude',
+        providerSession: { key: 'session_id', id: 'session-2' },
+        state: 'working',
+        capturedAt: 1,
+        updatedAt: 1
+      }
+      mockStoreState.sleepingAgentSessionsByPaneKey = {
+        [paneKey]: record,
+        [duplicatePaneKey]: duplicateRecord,
+        [siblingPaneKey]: siblingRecord
+      }
+      const deps = createDeps()
+
+      connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+      const onPtySpawn = createdTransportOptions[0]?.onPtySpawn as (ptyId: string) => void
+      onPtySpawn('pty-agent-exit')
+
+      handler._dispatchTerminalSideEffectBatchForTest({
+        ptyId: 'pty-agent-exit',
+        seq: 1,
+        facts: [{ kind: 'agent-exited' }]
+      })
+      const onPtyExit = createdTransportOptions[0]?.onPtyExit as (ptyId: string) => void
+      onPtyExit('pty-agent-exit')
+
+      expect(mockStoreState.clearSleepingAgentSession).toHaveBeenCalledWith(paneKey)
+      expect(mockStoreState.clearSleepingAgentSession).toHaveBeenCalledWith(duplicatePaneKey)
+      expect(mockStoreState.sleepingAgentSessionsByPaneKey[paneKey]).toBeUndefined()
+      expect(mockStoreState.sleepingAgentSessionsByPaneKey[duplicatePaneKey]).toBeUndefined()
+      expect(mockStoreState.sleepingAgentSessionsByPaneKey[siblingPaneKey]).toBe(siblingRecord)
+      expect(deps.onAgentExitedRef.current).toHaveBeenCalledWith(LEAF_1)
+      // Why: two clearSleepingAgentSession calls land here (paneKey + duplicatePaneKey alias).
+      // Compare the last one, not just the first, so a regression that reorders the alias
+      // cleanup after the exit callback still fails this test.
+      const clearCallOrders = mockStoreState.clearSleepingAgentSession.mock.invocationCallOrder
+      expect(clearCallOrders.at(-1)).toBeLessThan(
+        deps.onAgentExitedRef.current.mock.invocationCallOrder[0]
+      )
     })
 
     it('routes pr-link facts to the worktree PR observer', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection/agent-idle-working-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/agent-idle-working-handlers.ts
@@ -31,8 +31,14 @@ export function installAgentIdleWorkingHandlers(session: ConnectPanePtySession):
     }
   }
   session.onAgentExited = (): void => {
-    // Why: eligibility can disappear transiently during reconnect, but a
-    // confirmed shell-title transition is authoritative for native-chat exit.
+    // Why: a bare PTY exit may be recoverable, but a shell transition confirmed
+    // against the foreground process means the agent ended before its terminal.
+    // Retire that exact resume authority so a later app restart cannot resurrect it.
+    const state = useAppStore.getState()
+    const sleepingRecordEntry = session.getSleepingRecordForPane(state)
+    if (sleepingRecordEntry) {
+      session.clearSleepingRecordProviderDuplicates(state, sleepingRecordEntry)
+    }
     session.deps.onAgentExitedRef.current(session.pane.leafId)
     session.clearSuppressedTitleSideEffects()
     session.clearCommandInferredPaneAgent()

--- a/src/renderer/src/store/slices/terminal-tab-retirement-store.test.ts
+++ b/src/renderer/src/store/slices/terminal-tab-retirement-store.test.ts
@@ -169,7 +169,7 @@ describe('terminal tab retirement store boundary', () => {
     expect(store.getState().pendingColdRestoreByPtyId['pty-shared']).toBe(coldRestore)
   })
 
-  it('reconciles natural exit without issuing teardown or revoking resume authority', async () => {
+  it('preserves resume authority after an unexpected PTY loss', async () => {
     const store = createRetirementStore()
     const record = sleepingRecord('tab-1:leaf-1', 'tab-1')
     seedStore(store, {


### PR DESCRIPTION
## ELI5

When a user exits Claude normally and later closes its shell, Orca should not bring that finished agent back after an app restart.

## What Changed

- Clear the resolved pane resume record when foreground-process evidence confirms that the agent returned to the shell.
- Clear legacy aliases that claim the same provider session.
- Keep sibling pane recovery records untouched.
- Preserve existing recovery behavior for unexpected PTY loss.
- Add regression coverage for confirmed agent exit followed immediately by PTY teardown, legacy aliases, exact-pane isolation, and cleanup ordering.

## Why

A bare PTY exit is ambiguous and may represent a recoverable crash, so Orca intentionally preserves resume authority in that path. The existing agent-exited fact is emitted only after foreground-process verification confirms that the agent has returned to the shell. That confirmed transition is the safe point to retire the pane resume authority.

Without this cleanup, the persisted sleeping-session record can survive shell exit and cause a deliberately finished Claude session to be resumed after restarting Orca.

Prior work: #14376 explored Claude SessionEnd hooks but was closed after verification showed that /exit does not emit SessionEnd. Its conclusion was that process-exit or liveness evidence must be the real backstop; this PR uses the existing process-confirmed agent-exited fact.

## Linked Issue

Fixes #14228

## Visual Proof

After fix on macOS: exit Claude, exit the shell, restart Orca, and verify that the completed Claude session is not resumed.

https://github.com/user-attachments/assets/94bace52-587a-474d-87fc-ccdb783cb5e1

The recording uses an isolated local project. Account email and provider session identifiers were redacted before upload.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Manual verification on macOS:
1. Started Claude Code in a local project.
2. Exited Claude and then exited the shell.
3. Restarted Orca with the same isolated profile.
4. Verified that no Claude resume process started and only a normal shell was restored.

Automated verification:
- affected renderer and terminal lifecycle suites: 667 tests passed
- focused final impact suite after review fixes: 588 tests passed
- pnpm lint
- pnpm typecheck
- pnpm build
- formatting, oxlint, and diff checks

The full local suite reaches pre-existing machine-specific Codex HOME/auth and updater failures; the affected suites are green and CI will run in a clean repository environment.

## AI Disclosure

OpenAI Codex was used to assist with investigation, implementation, test drafting, and review. I reviewed the focused diff and manually verified the end-to-end behavior.

## Review

- Security: no new external input or privilege boundary.
- Cross-platform: renderer lifecycle state cleanup only; no OS-specific implementation.
- Remote SSH: uses the existing process-confirmed agent-exited fact and resolved pane key.
- Mobile: no mobile-specific path changed.
- Backwards compatibility: unexpected PTY loss remains recoverable.
- Performance: exact-key store deletion plus bounded duplicate-alias cleanup on confirmed agent exit.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or N/A with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] pnpm lint, pnpm typecheck, pnpm test, and pnpm build pass (or CI will cover; local preferred)

The affected test suites, lint, typecheck, and build pass locally. Repository CI will cover the clean full-suite environment because the local full suite encounters unrelated machine-specific Codex authentication and updater fixtures.

## Author

- X / Twitter: @erishforG