### PR TITLE
fix(terminal): keep the shell wrapper parseable under zsh global aliases

### DIFF
--- a/src/main/daemon/shell-ready.test.ts
+++ b/src/main/daemon/shell-ready.test.ts
@@ -625,7 +625,7 @@ describePosix('daemon shell-ready launch config', () => {
     const codexRestoreLine =
       '[[ -n "${ORCA_CODEX_HOME:-}" ]] && export CODEX_HOME="${ORCA_CODEX_HOME}"'
     const agentTeamsPathRestoreLine = '[[ -n "${ORCA_AGENT_TEAMS_SHIM_DIR:-}" ]] || return 0'
-    const ompWrapperLine = 'command omp --extension "${ORCA_OMP_STATUS_EXTENSION}" "$@"'
+    const ompWrapperLine = `command omp '--extension' "\${ORCA_OMP_STATUS_EXTENSION}" "$@"`
     expect(zshrc).toContain(restoreLine)
     expect(zlogin).toContain(restoreLine)
     expect(bashRc).toContain(restoreLine)

--- a/src/main/providers/local-pty-shell-ready.test.ts
+++ b/src/main/providers/local-pty-shell-ready.test.ts
@@ -1195,6 +1195,8 @@ export MY_VAR=foo
 
     it('still skips the OMP extension for every documented literal', async () => {
       // Why: quoting the case patterns must not change which tokens match.
+      writeFileSync(join(testHome, '.zshrc'), "alias -g config='not-config'\n")
+
       const { getShellReadyLaunchConfig } = await importFreshLocalPtyShellReady()
       const config = getShellReadyLaunchConfig('/bin/zsh')
 

--- a/src/main/providers/local-pty-shell-ready.test.ts
+++ b/src/main/providers/local-pty-shell-ready.test.ts
@@ -526,7 +526,7 @@ describePosix('local PTY shell-ready launch config', () => {
     const codexRestoreLine =
       '[[ -n "${ORCA_CODEX_HOME:-}" ]] && export CODEX_HOME="${ORCA_CODEX_HOME}"'
     const agentTeamsPathRestoreLine = '[[ -n "${ORCA_AGENT_TEAMS_SHIM_DIR:-}" ]] || return 0'
-    const ompWrapperLine = 'command omp --extension "${ORCA_OMP_STATUS_EXTENSION}" "$@"'
+    const ompWrapperLine = `command omp '--extension' "\${ORCA_OMP_STATUS_EXTENSION}" "$@"`
     expect(zshrc).toContain(restoreLine)
     expect(zlogin).toContain(restoreLine)
     expect(bashRc).toContain(restoreLine)
@@ -1160,6 +1160,70 @@ export MY_VAR=foo
       expect(result.status).toBe(0)
       // Syntax error causes discovery to fail, falls back to HOME
       expect(result.stdout).toContain(`ORCA_ORIG_ZDOTDIR=${testHome}`)
+    })
+
+    it('survives a user global alias that matches a wrapper literal', async () => {
+      // Why: zsh `alias -g` expands bare words anywhere on a line, including inside a
+      // `case` pattern list. An unquoted `--help` pattern inherited the alias body and
+      // its `>&` aborted the parse of the whole wrapper, silently dropping every helper
+      // defined after it (OMP wrapper and the OSC 133 lifecycle hooks alike).
+      writeFileSync(
+        join(testHome, '.zshrc'),
+        "alias -g -- --help='--help 2>&1 | bat --language=help --style=plain'\n"
+      )
+
+      const { getShellReadyLaunchConfig } = await importFreshLocalPtyShellReady()
+      const config = getShellReadyLaunchConfig('/bin/zsh')
+
+      const cleanEnv: Record<string, string | undefined> = { ...process.env, HOME: testHome }
+      delete cleanEnv.ZDOTDIR
+      delete cleanEnv.ORCA_ORIG_ZDOTDIR
+      cleanEnv.ZDOTDIR = config.env.ZDOTDIR
+
+      const result = spawnSync(
+        'zsh',
+        ['-i', '-c', 'whence -w __orca_omp_should_skip_extension; whence -w __orca_osc133_precmd'],
+        { env: cleanEnv as NodeJS.ProcessEnv, encoding: 'utf8' }
+      )
+
+      expect(result.stderr).not.toContain('parse error')
+      expect(result.status).toBe(0)
+      // Both helpers prove the wrapper parsed past the aliased token to the end of the file.
+      expect(result.stdout).toContain('__orca_omp_should_skip_extension: function')
+      expect(result.stdout).toContain('__orca_osc133_precmd: function')
+    })
+
+    it('still skips the OMP extension for every documented literal', async () => {
+      // Why: quoting the case patterns must not change which tokens match.
+      const { getShellReadyLaunchConfig } = await importFreshLocalPtyShellReady()
+      const config = getShellReadyLaunchConfig('/bin/zsh')
+
+      const cleanEnv: Record<string, string | undefined> = { ...process.env, HOME: testHome }
+      delete cleanEnv.ZDOTDIR
+      delete cleanEnv.ORCA_ORIG_ZDOTDIR
+      cleanEnv.ZDOTDIR = config.env.ZDOTDIR
+
+      const result = spawnSync(
+        'zsh',
+        [
+          '-i',
+          '-c',
+          `set -- 'help' '--help' '-h' '--version' '-v' 'config' 'worktree' 'wt' 'launch' 'ask' ''
+for __t in "$@"; do
+  if __orca_omp_should_skip_extension "$__t"; then print -r -- "skip[$__t]=YES"; else print -r -- "skip[$__t]=NO"; fi
+done`
+        ],
+        { env: cleanEnv as NodeJS.ProcessEnv, encoding: 'utf8' }
+      )
+
+      expect(result.status).toBe(0)
+      for (const token of ['help', '--help', '-h', '--version', '-v', 'config', 'worktree', 'wt']) {
+        expect(result.stdout).toContain(`skip[${token}]=YES`)
+      }
+      // `launch` and `ask` are real OMP invocations that must keep the status extension.
+      expect(result.stdout).toContain('skip[launch]=NO')
+      expect(result.stdout).toContain('skip[ask]=NO')
+      expect(result.stdout).toContain('skip[]=NO')
     })
 
     it('handles framework pattern with ${ZDOTDIR:-$HOME}', async () => {

--- a/src/main/providers/windows-shell-args.test.ts
+++ b/src/main/providers/windows-shell-args.test.ts
@@ -285,7 +285,9 @@ describe('resolveWindowsShellLaunchArgs', () => {
     const bashRcfile = readFileSync(join(userDataPath, 'shell-ready', 'bash', 'rcfile'), 'utf8')
     const zshLogin = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zlogin'), 'utf8')
     for (const wrapperFile of [bashRcfile, zshLogin]) {
-      expect(wrapperFile).toContain('command omp --extension "${ORCA_OMP_STATUS_EXTENSION}" "$@"')
+      expect(wrapperFile).toContain(
+        `command omp '--extension' "\${ORCA_OMP_STATUS_EXTENSION}" "$@"`
+      )
       expect(wrapperFile).toContain('omp() { __orca_omp "$@"; }')
       expect(wrapperFile).not.toContain('prime-agent()')
       expect(wrapperFile).not.toContain('__orca_prime_agent')

--- a/src/main/pty/omp-shell-wrapper.ts
+++ b/src/main/pty/omp-shell-wrapper.ts
@@ -40,13 +40,17 @@ const OMP_SUBCOMMANDS = [
 ] as const
 
 export function getPosixOmpShellWrapper(): string {
-  const subcommands = OMP_SUBCOMMANDS.join('|')
+  // Why: quote every literal token — zsh `alias -g` expands bare words anywhere on a
+  // line, so an unquoted `--help` pattern inherits the user's alias body (e.g. the
+  // common `alias -g -- --help='--help 2>&1 | bat'`) and the injected `>&` aborts the
+  // parse of Orca's whole rc file. Quoting is inert for these metachar-free tokens.
+  const subcommands = OMP_SUBCOMMANDS.map((value) => `'${value}'`).join('|')
   return `# Why: OMP does not auto-load Orca's managed status extension; wrap only
 # interactive launch invocations so subcommands such as \`omp config\` keep
 # their normal argv shape.
 __orca_omp_should_skip_extension() {
   case "\${1:-}" in
-    help|--help|-h|--version|-v) return 0 ;;
+    'help'|'--help'|'-h'|'--version'|'-v') return 0 ;;
     ${subcommands}) return 0 ;;
   esac
   return 1
@@ -57,9 +61,9 @@ __orca_omp() {
   if [[ $__orca_use_extension -eq 1 && -n "\${ORCA_OMP_STATUS_EXTENSION:-}" && -f "\${ORCA_OMP_STATUS_EXTENSION}" ]]; then
     if [[ "\${1:-}" == "launch" ]]; then
       shift
-      command omp launch --extension "\${ORCA_OMP_STATUS_EXTENSION}" "$@"
+      command omp 'launch' '--extension' "\${ORCA_OMP_STATUS_EXTENSION}" "$@"
     else
-      command omp --extension "\${ORCA_OMP_STATUS_EXTENSION}" "$@"
+      command omp '--extension' "\${ORCA_OMP_STATUS_EXTENSION}" "$@"
     fi
   else
     command omp "$@"

--- a/src/relay/pty-handler.test.ts
+++ b/src/relay/pty-handler.test.ts
@@ -3032,7 +3032,7 @@ describe('PtyHandler', () => {
         'export OPENCODE_CONFIG_DIR="${ORCA_OPENCODE_CONFIG_DIR}"'
       )
       expect(readFileSync(rcfile, 'utf8')).not.toContain('ORCA_PI_CODING_AGENT_DIR')
-      expect(readFileSync(rcfile, 'utf8')).toContain('command omp --extension')
+      expect(readFileSync(rcfile, 'utf8')).toContain(`command omp '--extension'`)
 
       rmSync(homeDir, { recursive: true, force: true })
     }


### PR DESCRIPTION
## ELI5

Some people put a shortcut in their zsh config that rewrites the word `--help` so long help text gets piped through a pretty pager. zsh applies that kind of shortcut to *every* `--help` on a line — including one sitting inside Orca's own startup script. That rewrite injected a `|` and a `2>&1` into the middle of a `case` statement, zsh gave up parsing the file, and everything Orca defines after that point silently vanished.

Putting quotes around the literal words stops zsh from touching them.

## What Changed

`getPosixOmpShellWrapper()` now emits its `case` patterns and command-literal arguments single-quoted:

```diff
-    help|--help|-h|--version|-v) return 0 ;;
-    __complete|acp|agents|…) return 0 ;;
+    'help'|'--help'|'-h'|'--version'|'-v') return 0 ;;
+    '__complete'|'acp'|'agents'|…) return 0 ;;
…
-      command omp launch --extension "${ORCA_OMP_STATUS_EXTENSION}" "$@"
+      command omp 'launch' '--extension' "${ORCA_OMP_STATUS_EXTENSION}" "$@"
```

Three existing tests that pinned the old unquoted literal were updated to the new form. No behavior change beyond parse-time alias immunity.

## Why

zsh `alias -g` (global alias) expands bare words **anywhere** on a command line, not just in command position. The widely-used dotfiles pattern

```zsh
alias -g -- --help='--help 2>&1 | bat --language=help --style=plain --paging=never --color always'
```

turned Orca's generated `case` pattern into a list containing `2>&1 |`, producing:

```
~/…/shell-ready/zsh/.zshrc:33: parse error near `>&'
~/…/shell-ready/zsh/.zlogin:32: parse error near `>&'
```

A zsh parse error aborts the **entire** rc file, so the blast radius is much larger than the OMP wrapper: the OSC 133 `precmd`/`preexec` hooks are declared later in the same file and were never defined either. That is Orca's command-lifecycle signal — losing it is the same class as a stuck `working` spinner.

Quoting is the right fix because these patterns are exact, metachar-free tokens; quoting them is semantically inert for matching but removes them from alias expansion at parse time. The wrapper already uses this idiom in `__orca_restore_agent_teams_path`, whose quoted `case` patterns are immune today.

Note `zsh -n` does **not** catch this — a syntax-only check does not expand aliases — which is why it survived existing static checks.

## Linked Issue

Fixes STA-4102

## Visual Proof

N/A — terminal shell startup only; the observable difference is the absence of a parse-error line. Before/after terminal output is quoted under Testing.

## Testing

**Live reproduction (macOS 15.5, Apple Silicon, real Orca PTY, Orca's real generated wrapper):**

```
$ env ORCA_ORIG_ZDOTDIR=<rc with the global alias> \
      ZDOTDIR="~/Library/Application Support/Orca/shell-ready/zsh" zsh -i -c '…'
~/Library/Application Support/Orca/shell-ready/zsh/.zshrc:33: parse error near `>&'
MARKER_RC=1
__orca_omp_should_skip_extension: none      <-- wrapper lost
__orca_osc133_precmd: none                  <-- OSC 133 lifecycle lost
```

`zsh -l -i` additionally hit `.zlogin:32`, matching the report.

**After the fix (same rig, wrapper regenerated from this branch):**

```
MARKER_RC=1
__orca_omp_should_skip_extension: function
__orca_osc133_precmd: function
```

Login-shell (`.zlogin`) path re-verified clean as well.

**bash parity** (the same generator feeds the bash rcfile) — loaded the generated rcfile in real bash and confirmed identical skip decisions: `help/--help/-h/--version/-v/config/worktree/wt` → skip, `launch`/`ask` → no skip. `bash -n` clean.

**Automated** — two new real-zsh subprocess tests in `local-pty-shell-ready.test.ts`, added to the existing `describeIfZsh` suite:
- `survives a user global alias that matches a wrapper literal` — writes the alias into the user rc, spawns real `zsh -i` against the generated wrapper, asserts no `parse error` **and** that both `__orca_omp_should_skip_extension` and `__orca_osc133_precmd` are defined (proves the file parsed to the end).
- `still skips the OMP extension for every documented literal` — pins matching semantics so the quoting cannot silently change which tokens skip.

Non-vacuity proof: with the generator change reverted, the first test fails with the exact reported error —
`AssertionError: expected '…/shell-ready/zsh/.zshrc:33: parse error near '>&'' not to contain 'parse error'`.

Suites run green: `src/main/providers/`, `src/main/pty/`, `src/main/daemon/shell-ready.test.ts`, `src/relay/` — 136 files, 1664 passed, 1 skipped. `tsc --noEmit` (node project) clean, `oxlint` + `oxfmt` clean.

Platforms: reproduced and fixed on **macOS**; the reporter hit it on **Arch Linux** with the same generated wrapper (shared code path). The generator also feeds the daemon/SSH and relay wrappers, so remote hosts get the same fix; PowerShell/fish wrappers are untouched (neither has zsh-style global aliases). No wire-format, IPC, or persisted-state change.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

- **Security**: none — quoting narrows, never widens, what the shell interprets.
- **Cross-platform**: POSIX wrapper only (macOS/Linux, plus WSL). PowerShell and fish generators untouched.
- **Remote SSH / daemon / relay**: same generator, so hosts pick up the fix; the emitted script stays POSIX-portable with no new builtins.
- **Backwards compatibility**: the wrapper is regenerated on launch, so no migration. Skip-list semantics proven byte-identical.
- **Performance**: none — parse-time only.

## Residual (not in scope here)

Quoting cannot protect a *function name* (`omp() { … }`) or a bare command word from a global alias on that same name. Those are implausible user configs and unfixable by quoting; flagging rather than expanding this PR's scope.
