### PR TITLE
fix(cli): stop macOS serve crash-looping in _RegisterApplication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,7 @@ docs/**
 !docs/reference/git-compatibility.md
 !docs/reference/headless-linux-server.md
 !docs/reference/linux-glibc-compatibility.md
+!docs/reference/macos-electron-startup-abort.md
 !docs/reference/relay-grace-time-reconfiguration.md
 !docs/reference/remote-wire-compatibility.md
 !docs/reference/renderer-agent-status-performance.md

--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Works with **any CLI agent** — if it runs in a terminal, it runs in Orca.
 - **[Download from onOrca.dev](https://onorca.dev/download)**
 - Or grab a build directly: [macOS Apple Silicon](https://github.com/stablyai/orca/releases/latest/download/orca-macos-arm64.dmg) · [macOS Intel](https://github.com/stablyai/orca/releases/latest/download/orca-macos-x64.dmg) · [Windows (.exe)](https://github.com/stablyai/orca/releases/latest/download/orca-windows-setup.exe) · [Linux AppImage](https://github.com/stablyai/orca/releases/latest/download/orca-linux.AppImage) · [All builds](https://github.com/stablyai/orca/releases/latest)
 - Running `orca serve` on a headless Linux server? See the [headless Linux server guide](docs/reference/headless-linux-server.md).
+- macOS `orca serve` SIGABRT at startup? See [macOS Electron startup abort](docs/reference/macos-electron-startup-abort.md).
 
 _Or via a package manager:_
 
@@ -261,6 +262,7 @@ Want to contribute or run locally? See our [CONTRIBUTING.md](.github/CONTRIBUTIN
 </p>
 
 ## Signed Builds
+
 Windows code signing sponored/provided by [SignPath.io](https://signpath.io), certificate by [SignPath Foundation](https://signpath.org).
 
 ## License

--- a/docs/reference/macos-electron-startup-abort.md
+++ b/docs/reference/macos-electron-startup-abort.md
@@ -66,11 +66,11 @@ sandbox workaround.
 
 - `orca open` reopens the packaged `Orca.app` via Launch Services (`open`), and
   does not exec `Contents/MacOS/Orca` when that path is the packaged binary.
-- `orca serve` (without `--serve-recipe-json`) does not spawn a second GUI
-  process when this `userData` profile is already running (exit code `3`, same
-  contract as the single-instance lock). A second exec is what produced the
-  crash loop: each child died in `_RegisterApplication` before JS could take
-  the lock.
+- `orca serve` (without `--serve-recipe-json`) takes an exclusive
+  `orca-serve.lock` in the `userData` profile, then refuses to spawn if a
+  runtime is already live (exit code `3`, same contract as the single-instance
+  lock). The lock is what stops two overlapping CLIs from both exec'ing
+  Electron before JS can take the single-instance lock.
 - `orca serve --serve-recipe-json` still detaches an ephemeral pairing helper
   and skips that already-running check.
 - If a spawn still SIGABRTs, the CLI names this abort and points at

--- a/docs/reference/macos-electron-startup-abort.md
+++ b/docs/reference/macos-electron-startup-abort.md
@@ -32,7 +32,7 @@ This is an Electron-framework crash, not an Orca logic crash. Stock Electron
 43.1.0 dies the same way:
 
 ```bash
-# Repro (macOS). Exit 134 == SIGABRT. ELECTRON_RUN_AS_NODE=1 does not abort.
+# Repro (macOS). GUI launch aborts; ELECTRON_RUN_AS_NODE=1 does not.
 cat > /tmp/deny-ls.sb << 'EOF'
 (version 1)
 (deny default)
@@ -50,19 +50,29 @@ EOF
 
 sandbox-exec -f /tmp/deny-ls.sb \
   node_modules/electron/dist/Electron.app/Contents/MacOS/Electron
+# exit 134 == SIGABRT
+
+sandbox-exec -f /tmp/deny-ls.sb \
+  env ELECTRON_RUN_AS_NODE=1 \
+  node_modules/electron/dist/Electron.app/Contents/MacOS/Electron -e 'console.log("ok")'
+# prints ok, exit 0
 ```
 
 `open -a Orca` from the same sandbox fails with `_LSOpenURLsWithCompletionHandler
-error -54` instead of aborting — still no GUI, but no crash loop.
+error -54` instead of aborting — still no GUI, but no crash loop. It is not a
+sandbox workaround.
 
 **What Orca does.**
 
 - `orca open` reopens the packaged `Orca.app` via Launch Services (`open`), and
   does not exec `Contents/MacOS/Orca` when that path is the packaged binary.
-- `orca serve` does not spawn a second GUI process when this `userData` profile
-  is already running (exit code `3`, same contract as the single-instance lock).
-  A second exec is what produced the crash loop: each child died in
-  `_RegisterApplication` before JS could take the lock.
+- `orca serve` (without `--serve-recipe-json`) does not spawn a second GUI
+  process when this `userData` profile is already running (exit code `3`, same
+  contract as the single-instance lock). A second exec is what produced the
+  crash loop: each child died in `_RegisterApplication` before JS could take
+  the lock.
+- `orca serve --serve-recipe-json` still detaches an ephemeral pairing helper
+  and skips that already-running check.
 - If a spawn still SIGABRTs, the CLI names this abort and points at
   `~/Library/Logs/DiagnosticReports/Orca-*.ips`.
 
@@ -71,7 +81,9 @@ error -54` instead of aborting — still no GUI, but no crash loop.
 1. If the desktop app is already up, use `orca status` / the regular `orca`
    commands. Do not keep retrying `orca serve` from an agent sandbox.
 2. Do not exec `/Applications/Orca.app/Contents/MacOS/Orca` from a sandbox.
-   Use `open -a Orca` or start the app from Finder.
+   Leave the sandbox and start the app from a normal macOS desktop login.
+   `open -a Orca` and Finder are not sandbox workarounds (`open` fails with
+   error `-54` there).
 3. Confirm the crashing frame is `_RegisterApplication`, not `node::Utf8Value`.
 
 Related: stablyai/orca#9282 (environment-induced), #10461 / #10464 (CLI

--- a/docs/reference/macos-electron-startup-abort.md
+++ b/docs/reference/macos-electron-startup-abort.md
@@ -67,10 +67,10 @@ sandbox workaround.
 - `orca open` reopens the packaged `Orca.app` via Launch Services (`open`), and
   does not exec `Contents/MacOS/Orca` when that path is the packaged binary.
 - `orca serve` (without `--serve-recipe-json`) takes an exclusive
-  `orca-serve.lock` in the `userData` profile, then refuses to spawn if a
-  runtime is already live (exit code `3`, same contract as the single-instance
-  lock). The lock is what stops two overlapping CLIs from both exec'ing
-  Electron before JS can take the single-instance lock.
+  `orca-serve.lock` directory in the `userData` profile, then refuses to spawn
+  if a runtime is already live (exit code `3`, same contract as the
+  single-instance lock). Stale locks are moved aside with `rename`, so a
+  reclaim cannot delete a successor's new lock.
 - `orca serve --serve-recipe-json` still detaches an ephemeral pairing helper
   and skips that already-running check.
 - If a spawn still SIGABRTs, the CLI names this abort and points at

--- a/docs/reference/macos-electron-startup-abort.md
+++ b/docs/reference/macos-electron-startup-abort.md
@@ -1,0 +1,96 @@
+# macOS Electron startup abort (`_RegisterApplication`)
+
+Two native Electron aborts have shown up in Orca on macOS. They look similar in
+Console.app (the process just dies) and they are easy to confuse. They are not
+the same bug.
+
+## 1. Launch Services registration abort (this document)
+
+**Symptom.** A brand-new `Orca` (or stock `Electron`) process lives ~100–200 ms
+and dies with `SIGABRT` / `abort()` before any Orca JavaScript runs.
+
+**Stack.**
+
+```text
+abort
+___RegisterApplication_block_invoke
+_RegisterApplication
+GetCurrentProcess
+-[NSApplication init]
++[NSApplication sharedApplication]
+ElectronMain
+```
+
+**Cause.** `ElectronMain` always creates `NSApplication`. AppKit then asks
+Launch Services for an application identity. If `launchservicesd` is
+unreachable — a seatbelt/sandbox that denies `com.apple.lsd*` /
+`com.apple.coreservices.launchservicesd`, a restricted agent environment, SSH
+without a GUI login, CI — HIServices calls `abort()`. The single-instance lock
+in our JS never runs.
+
+This is an Electron-framework crash, not an Orca logic crash. Stock Electron
+43.1.0 dies the same way:
+
+```bash
+# Repro (macOS). Exit 134 == SIGABRT. ELECTRON_RUN_AS_NODE=1 does not abort.
+cat > /tmp/deny-ls.sb << 'EOF'
+(version 1)
+(deny default)
+(allow file-read*)
+(allow file-write* (subpath "/tmp") (subpath "/private/tmp") (subpath "/var/folders"))
+(allow process-exec)
+(allow process-fork)
+(allow sysctl-read)
+(allow mach-lookup)
+(deny mach-lookup (global-name "com.apple.lsd.modify"))
+(deny mach-lookup (global-name "com.apple.lsd.mapdb"))
+(deny mach-lookup (global-name "com.apple.launchservicesd"))
+(deny mach-lookup (global-name "com.apple.coreservices.launchservicesd"))
+EOF
+
+sandbox-exec -f /tmp/deny-ls.sb \
+  node_modules/electron/dist/Electron.app/Contents/MacOS/Electron
+```
+
+`open -a Orca` from the same sandbox fails with `_LSOpenURLsWithCompletionHandler
+error -54` instead of aborting — still no GUI, but no crash loop.
+
+**What Orca does.**
+
+- `orca open` reopens the packaged `Orca.app` via Launch Services (`open`), and
+  does not exec `Contents/MacOS/Orca` when that path is the packaged binary.
+- `orca serve` does not spawn a second GUI process when this `userData` profile
+  is already running (exit code `3`, same contract as the single-instance lock).
+  A second exec is what produced the crash loop: each child died in
+  `_RegisterApplication` before JS could take the lock.
+- If a spawn still SIGABRTs, the CLI names this abort and points at
+  `~/Library/Logs/DiagnosticReports/Orca-*.ips`.
+
+**What to do as a user.**
+
+1. If the desktop app is already up, use `orca status` / the regular `orca`
+   commands. Do not keep retrying `orca serve` from an agent sandbox.
+2. Do not exec `/Applications/Orca.app/Contents/MacOS/Orca` from a sandbox.
+   Use `open -a Orca` or start the app from Finder.
+3. Confirm the crashing frame is `_RegisterApplication`, not `node::Utf8Value`.
+
+Related: stablyai/orca#9282 (environment-induced), #10461 / #10464 (CLI
+diagnostic), #12212 (Linux duplicate-serve crash loop — same class, later in
+startup).
+
+## 2. UTF-8 encode abort (different bug)
+
+**Symptom.** The _already running_ app dies a few seconds after launch with
+`SIGTRAP`, not `SIGABRT`.
+
+**Stack.** `Assertion failed: (length + 1) <= (capacity())` in
+`node::MaybeStackBuffer` / `node::Utf8Value`, typically from
+`fs.writeFileSync` of a large JSON string that contains non-ASCII characters.
+
+**Cause.** Electron 42.3.1 and 42.3.2 shipped an LLVM codegen bug that
+miscomputed UTF-8 size. Reported as [electron/electron#51871](https://github.com/electron/electron/issues/51871),
+fixed in 42.3.3 ([electron/electron#51849](https://github.com/electron/electron/pull/51849)).
+Orca also stopped writing `orca-stats.json` in one shot (stablyai/orca#4571).
+
+If you see `Utf8Value` / `writeFileSync` / `SIGTRAP`, that is this class, not
+`_RegisterApplication`.

--- a/src/cli/runtime/foreground-serve-lock.test.ts
+++ b/src/cli/runtime/foreground-serve-lock.test.ts
@@ -1,0 +1,111 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  acquireForegroundServeLock,
+  getForegroundServeLockPath,
+  releaseForegroundServeLock
+} from './foreground-serve-lock'
+
+const temporaryDirectories: string[] = []
+
+async function isolatedUserData(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), 'orca-serve-lock-'))
+  temporaryDirectories.push(directory)
+  return directory
+}
+
+afterEach(() =>
+  Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true })))
+)
+
+describe('acquireForegroundServeLock', () => {
+  it('creates an exclusive lock file for the userData profile', async () => {
+    const userDataPath = await isolatedUserData()
+
+    const lock = await acquireForegroundServeLock(userDataPath)
+
+    expect(lock).toEqual({
+      path: getForegroundServeLockPath(userDataPath),
+      pid: process.pid
+    })
+    const record = JSON.parse(await readFile(lock!.path, 'utf8')) as { pid: number }
+    expect(record.pid).toBe(process.pid)
+  })
+
+  it('returns null when another live process already holds the lock', async () => {
+    const userDataPath = await isolatedUserData()
+    const first = await acquireForegroundServeLock(userDataPath)
+    expect(first).not.toBeNull()
+
+    await expect(acquireForegroundServeLock(userDataPath)).resolves.toBeNull()
+  })
+
+  it('lets only one of two concurrent acquires win', async () => {
+    const userDataPath = await isolatedUserData()
+
+    const [first, second] = await Promise.all([
+      acquireForegroundServeLock(userDataPath),
+      acquireForegroundServeLock(userDataPath)
+    ])
+
+    const winners = [first, second].filter((lock) => lock !== null)
+    const losers = [first, second].filter((lock) => lock === null)
+    expect(winners).toHaveLength(1)
+    expect(losers).toHaveLength(1)
+    expect(winners[0]?.pid).toBe(process.pid)
+  })
+
+  it('reclaims a lock whose owner pid is dead', async () => {
+    const userDataPath = await isolatedUserData()
+    await mkdir(userDataPath, { recursive: true })
+    await writeFile(
+      getForegroundServeLockPath(userDataPath),
+      `${JSON.stringify({ pid: findUnusedPid(), startedAt: 1 })}\n`,
+      { encoding: 'utf8', mode: 0o600 }
+    )
+
+    const lock = await acquireForegroundServeLock(userDataPath)
+
+    expect(lock?.pid).toBe(process.pid)
+  })
+})
+
+describe('releaseForegroundServeLock', () => {
+  it('removes the lock so a later acquire can succeed', async () => {
+    const userDataPath = await isolatedUserData()
+    const lock = await acquireForegroundServeLock(userDataPath)
+    expect(lock).not.toBeNull()
+
+    await releaseForegroundServeLock(lock!)
+
+    await expect(acquireForegroundServeLock(userDataPath)).resolves.toMatchObject({
+      pid: process.pid
+    })
+  })
+
+  it('does not unlink a lock owned by a different pid', async () => {
+    const userDataPath = await isolatedUserData()
+    const lock = await acquireForegroundServeLock(userDataPath)
+    expect(lock).not.toBeNull()
+
+    await releaseForegroundServeLock({ path: lock!.path, pid: lock!.pid + 1 })
+
+    const record = JSON.parse(await readFile(lock!.path, 'utf8')) as { pid: number }
+    expect(record.pid).toBe(process.pid)
+  })
+})
+
+function findUnusedPid(seed = 200_000): number {
+  let pid = Math.max(seed, process.pid + 10_000)
+  while (pid < 2_000_000) {
+    try {
+      process.kill(pid, 0)
+      pid += 1
+    } catch {
+      return pid
+    }
+  }
+  return 2_000_000
+}

--- a/src/cli/runtime/foreground-serve-lock.test.ts
+++ b/src/cli/runtime/foreground-serve-lock.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import {
   acquireForegroundServeLock,
+  getForegroundServeLockOwnerPath,
   getForegroundServeLockPath,
   releaseForegroundServeLock
 } from './foreground-serve-lock'
@@ -20,8 +21,26 @@ afterEach(() =>
   Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true })))
 )
 
+async function writeStaleLock(userDataPath: string, pid: number): Promise<void> {
+  const lockDir = getForegroundServeLockPath(userDataPath)
+  await mkdir(lockDir, { recursive: true })
+  await writeFile(join(lockDir, 'owner.json'), `${JSON.stringify({ pid, startedAt: 1 })}\n`, {
+    encoding: 'utf8',
+    mode: 0o600
+  })
+}
+
+async function readOwnerPid(userDataPath: string): Promise<number> {
+  const record = JSON.parse(
+    await readFile(getForegroundServeLockOwnerPath(userDataPath), 'utf8')
+  ) as {
+    pid: number
+  }
+  return record.pid
+}
+
 describe('acquireForegroundServeLock', () => {
-  it('creates an exclusive lock file for the userData profile', async () => {
+  it('creates an exclusive lock directory for the userData profile', async () => {
     const userDataPath = await isolatedUserData()
 
     const lock = await acquireForegroundServeLock(userDataPath)
@@ -30,8 +49,7 @@ describe('acquireForegroundServeLock', () => {
       path: getForegroundServeLockPath(userDataPath),
       pid: process.pid
     })
-    const record = JSON.parse(await readFile(lock!.path, 'utf8')) as { pid: number }
-    expect(record.pid).toBe(process.pid)
+    expect(await readOwnerPid(userDataPath)).toBe(process.pid)
   })
 
   it('returns null when another live process already holds the lock', async () => {
@@ -59,16 +77,29 @@ describe('acquireForegroundServeLock', () => {
 
   it('reclaims a lock whose owner pid is dead', async () => {
     const userDataPath = await isolatedUserData()
-    await mkdir(userDataPath, { recursive: true })
-    await writeFile(
-      getForegroundServeLockPath(userDataPath),
-      `${JSON.stringify({ pid: findUnusedPid(), startedAt: 1 })}\n`,
-      { encoding: 'utf8', mode: 0o600 }
-    )
+    await writeStaleLock(userDataPath, findUnusedPid())
 
     const lock = await acquireForegroundServeLock(userDataPath)
 
     expect(lock?.pid).toBe(process.pid)
+    expect(await readOwnerPid(userDataPath)).toBe(process.pid)
+  })
+
+  it('lets only one of two stale-lock reclaimers win', async () => {
+    const userDataPath = await isolatedUserData()
+    await writeStaleLock(userDataPath, findUnusedPid())
+
+    const [first, second] = await Promise.all([
+      acquireForegroundServeLock(userDataPath),
+      acquireForegroundServeLock(userDataPath)
+    ])
+
+    const winners = [first, second].filter((lock) => lock !== null)
+    const losers = [first, second].filter((lock) => lock === null)
+    expect(winners).toHaveLength(1)
+    expect(losers).toHaveLength(1)
+    expect(winners[0]?.pid).toBe(process.pid)
+    expect(await readOwnerPid(userDataPath)).toBe(process.pid)
   })
 })
 
@@ -85,15 +116,14 @@ describe('releaseForegroundServeLock', () => {
     })
   })
 
-  it('does not unlink a lock owned by a different pid', async () => {
+  it('does not remove a lock owned by a different pid', async () => {
     const userDataPath = await isolatedUserData()
     const lock = await acquireForegroundServeLock(userDataPath)
     expect(lock).not.toBeNull()
 
     await releaseForegroundServeLock({ path: lock!.path, pid: lock!.pid + 1 })
 
-    const record = JSON.parse(await readFile(lock!.path, 'utf8')) as { pid: number }
-    expect(record.pid).toBe(process.pid)
+    expect(await readOwnerPid(userDataPath)).toBe(process.pid)
   })
 })
 

--- a/src/cli/runtime/foreground-serve-lock.ts
+++ b/src/cli/runtime/foreground-serve-lock.ts
@@ -1,8 +1,9 @@
-import { mkdir, readFile, unlink, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
-const LOCK_FILE_NAME = 'orca-serve.lock'
-const ACQUIRE_ATTEMPTS = 3
+const LOCK_DIR_NAME = 'orca-serve.lock'
+const OWNER_FILE_NAME = 'owner.json'
+const ACQUIRE_ATTEMPTS = 5
 
 export type ForegroundServeLock = {
   path: string
@@ -15,7 +16,11 @@ type LockRecord = {
 }
 
 export function getForegroundServeLockPath(userDataPath: string): string {
-  return join(userDataPath, LOCK_FILE_NAME)
+  return join(userDataPath, LOCK_DIR_NAME)
+}
+
+export function getForegroundServeLockOwnerPath(userDataPath: string): string {
+  return join(getForegroundServeLockPath(userDataPath), OWNER_FILE_NAME)
 }
 
 export async function acquireForegroundServeLock(
@@ -23,36 +28,57 @@ export async function acquireForegroundServeLock(
   pid = process.pid
 ): Promise<ForegroundServeLock | null> {
   await mkdir(userDataPath, { recursive: true })
-  const path = getForegroundServeLockPath(userDataPath)
+  const lockDir = getForegroundServeLockPath(userDataPath)
+  const ownerPath = join(lockDir, OWNER_FILE_NAME)
 
   for (let attempt = 0; attempt < ACQUIRE_ATTEMPTS; attempt += 1) {
     try {
-      await writeFile(path, serializeLock({ pid, startedAt: Date.now() }), {
+      await mkdir(lockDir)
+      await writeFile(ownerPath, serializeLock({ pid, startedAt: Date.now() }), {
         encoding: 'utf8',
-        flag: 'wx',
         mode: 0o600
       })
-      return { path, pid }
+      return { path: lockDir, pid }
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
+      const code = (error as NodeJS.ErrnoException).code
+      if (code === 'ENOENT') {
+        continue
+      }
+      if (code !== 'EEXIST') {
         throw error
       }
-      const existing = await readLockRecord(path)
+      const existing = await readLockRecord(ownerPath)
       if (existing && isLockOwnerAlive(existing.pid)) {
         return null
       }
-      await unlink(path).catch(() => undefined)
+      // Why: a peer may have mkdir'd but not yet written owner.json. Wait
+      // before treating a missing record as stale, so we do not rename a
+      // successor's new lock aside.
+      if (!existing && attempt < ACQUIRE_ATTEMPTS - 1) {
+        await yieldEventLoop()
+        continue
+      }
+      const staleDir = `${lockDir}.stale.${pid}.${attempt}`
+      try {
+        await rename(lockDir, staleDir)
+      } catch (renameError) {
+        if ((renameError as NodeJS.ErrnoException).code === 'ENOENT') {
+          continue
+        }
+        throw renameError
+      }
+      await rm(staleDir, { recursive: true, force: true }).catch(() => undefined)
     }
   }
   return null
 }
 
 export async function releaseForegroundServeLock(lock: ForegroundServeLock): Promise<void> {
-  const existing = await readLockRecord(lock.path)
+  const existing = await readLockRecord(join(lock.path, OWNER_FILE_NAME))
   if (existing?.pid !== lock.pid) {
     return
   }
-  await unlink(lock.path).catch(() => undefined)
+  await rm(lock.path, { recursive: true, force: true }).catch(() => undefined)
 }
 
 function serializeLock(record: LockRecord): string {
@@ -83,4 +109,10 @@ function isLockOwnerAlive(pid: number): boolean {
     // we do not steal a lock from another session.
     return (error as NodeJS.ErrnoException).code === 'EPERM'
   }
+}
+
+function yieldEventLoop(): Promise<void> {
+  return new Promise((resolve) => {
+    setImmediate(resolve)
+  })
 }

--- a/src/cli/runtime/foreground-serve-lock.ts
+++ b/src/cli/runtime/foreground-serve-lock.ts
@@ -1,0 +1,86 @@
+import { mkdir, readFile, unlink, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const LOCK_FILE_NAME = 'orca-serve.lock'
+const ACQUIRE_ATTEMPTS = 3
+
+export type ForegroundServeLock = {
+  path: string
+  pid: number
+}
+
+type LockRecord = {
+  pid: number
+  startedAt: number
+}
+
+export function getForegroundServeLockPath(userDataPath: string): string {
+  return join(userDataPath, LOCK_FILE_NAME)
+}
+
+export async function acquireForegroundServeLock(
+  userDataPath: string,
+  pid = process.pid
+): Promise<ForegroundServeLock | null> {
+  await mkdir(userDataPath, { recursive: true })
+  const path = getForegroundServeLockPath(userDataPath)
+
+  for (let attempt = 0; attempt < ACQUIRE_ATTEMPTS; attempt += 1) {
+    try {
+      await writeFile(path, serializeLock({ pid, startedAt: Date.now() }), {
+        encoding: 'utf8',
+        flag: 'wx',
+        mode: 0o600
+      })
+      return { path, pid }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
+        throw error
+      }
+      const existing = await readLockRecord(path)
+      if (existing && isLockOwnerAlive(existing.pid)) {
+        return null
+      }
+      await unlink(path).catch(() => undefined)
+    }
+  }
+  return null
+}
+
+export async function releaseForegroundServeLock(lock: ForegroundServeLock): Promise<void> {
+  const existing = await readLockRecord(lock.path)
+  if (existing?.pid !== lock.pid) {
+    return
+  }
+  await unlink(lock.path).catch(() => undefined)
+}
+
+function serializeLock(record: LockRecord): string {
+  return `${JSON.stringify(record)}\n`
+}
+
+async function readLockRecord(path: string): Promise<LockRecord | null> {
+  try {
+    const parsed = JSON.parse(await readFile(path, 'utf8')) as Partial<LockRecord>
+    if (typeof parsed.pid !== 'number' || !Number.isInteger(parsed.pid) || parsed.pid <= 0) {
+      return null
+    }
+    return {
+      pid: parsed.pid,
+      startedAt: typeof parsed.startedAt === 'number' ? parsed.startedAt : 0
+    }
+  } catch {
+    return null
+  }
+}
+
+function isLockOwnerAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    // Why: EPERM means the pid exists but we cannot signal it. Treat as live so
+    // we do not steal a lock from another session.
+    return (error as NodeJS.ErrnoException).code === 'EPERM'
+  }
+}

--- a/src/cli/runtime/foreground-serve-policy.test.ts
+++ b/src/cli/runtime/foreground-serve-policy.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import {
+  SERVE_ALREADY_RUNNING_EXIT_CODE,
+  shouldSpawnForegroundServe
+} from './foreground-serve-policy'
+
+describe('shouldSpawnForegroundServe', () => {
+  it('spawns when nothing is running', () => {
+    expect(
+      shouldSpawnForegroundServe({
+        app: { running: false },
+        runtime: { reachable: false }
+      })
+    ).toBe(true)
+  })
+
+  it('does not spawn when the runtime is already reachable', () => {
+    expect(
+      shouldSpawnForegroundServe({
+        app: { running: true },
+        runtime: { reachable: true }
+      })
+    ).toBe(false)
+  })
+
+  it('does not spawn when a live app pid is still running but not yet reachable', () => {
+    expect(
+      shouldSpawnForegroundServe({
+        app: { running: true },
+        runtime: { reachable: false }
+      })
+    ).toBe(false)
+  })
+})
+
+describe('SERVE_ALREADY_RUNNING_EXIT_CODE', () => {
+  it('matches the single-instance already-running contract', () => {
+    expect(SERVE_ALREADY_RUNNING_EXIT_CODE).toBe(3)
+  })
+})

--- a/src/cli/runtime/foreground-serve-policy.ts
+++ b/src/cli/runtime/foreground-serve-policy.ts
@@ -1,0 +1,13 @@
+// Why: must stay equal to SINGLE_INSTANCE_ALREADY_RUNNING_EXIT_CODE in
+// src/main/startup/single-instance-lock.ts (systemd RestartPreventExitStatus=3).
+export const SERVE_ALREADY_RUNNING_EXIT_CODE = 3
+
+export const SERVE_ALREADY_RUNNING_MESSAGE =
+  '[serve] Orca is already running for this userData profile; not starting a second process.'
+
+export function shouldSpawnForegroundServe(status: {
+  app: { running: boolean }
+  runtime: { reachable: boolean }
+}): boolean {
+  return !status.app.running && !status.runtime.reachable
+}

--- a/src/cli/runtime/launch.test.ts
+++ b/src/cli/runtime/launch.test.ts
@@ -354,6 +354,34 @@ describe('serveOrcaApp', () => {
     )
   })
 
+  it('lets only one overlapping serve spawn a GUI child', async () => {
+    let onExit: ((code: number | null, signal: string | null) => void) | undefined
+    const child = {
+      kill: vi.fn(),
+      once: vi.fn(
+        (event: string, handler: (code: number | null, signal: string | null) => void) => {
+          if (event === 'exit') {
+            onExit = handler
+          }
+          return child
+        }
+      )
+    }
+    spawnMock.mockReturnValue(child)
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+    const first = serveOrcaApp({ json: true })
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledOnce())
+    await expect(serveOrcaApp({ json: true })).resolves.toBe(3)
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining('already running for this userData profile')
+    )
+
+    onExit?.(0, null)
+    await expect(first).resolves.toBe(0)
+    expect(spawnMock).toHaveBeenCalledOnce()
+  })
+
   it('still detaches a recipe-json server when a desktop profile is already running', async () => {
     writeFileSync(
       join(process.env.ORCA_USER_DATA_PATH!, 'orca-runtime.json'),

--- a/src/cli/runtime/launch.test.ts
+++ b/src/cli/runtime/launch.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'node:events'
+import { mkdtempSync, writeFileSync } from 'node:fs'
 import { mkdir, mkdtemp, readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
@@ -87,6 +88,9 @@ describe('serveOrcaApp', () => {
   beforeEach(() => {
     spawnMock.mockReset()
     process.env.ORCA_APP_EXECUTABLE = '/Applications/Orca.app/Contents/MacOS/Orca'
+    const isolated = mkdtempSync(join(tmpdir(), 'orca-serve-isolated-'))
+    temporaryDirectories.push(isolated)
+    process.env.ORCA_USER_DATA_PATH = isolated
   })
 
   afterEach(() => {
@@ -127,6 +131,7 @@ describe('serveOrcaApp', () => {
         supervisorExited = true
         return code
       })
+      await vi.waitFor(() => expect(spawnMock).toHaveBeenCalled())
       const childEnv = spawnMock.mock.calls[0]?.[2]?.env as NodeJS.ProcessEnv | undefined
       const handoffPath = childEnv?.ORCA_SERVE_UPDATE_HANDOFF_PATH
       expect(handoffPath).toBeTruthy()
@@ -325,6 +330,58 @@ describe('serveOrcaApp', () => {
       }
     }
   )
+
+  it('does not spawn a second GUI process when this userData profile is already running', async () => {
+    writeFileSync(
+      join(process.env.ORCA_USER_DATA_PATH!, 'orca-runtime.json'),
+      JSON.stringify({
+        runtimeId: 'runtime-live',
+        pid: process.pid,
+        transports: [
+          { kind: 'unix', endpoint: join(process.env.ORCA_USER_DATA_PATH!, 'missing.sock') }
+        ],
+        authToken: 'token',
+        startedAt: 1
+      })
+    )
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+    await expect(serveOrcaApp({ json: true })).resolves.toBe(3)
+
+    expect(spawnMock).not.toHaveBeenCalled()
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining('already running for this userData profile')
+    )
+  })
+
+  it('still detaches a recipe-json server when a desktop profile is already running', async () => {
+    writeFileSync(
+      join(process.env.ORCA_USER_DATA_PATH!, 'orca-runtime.json'),
+      JSON.stringify({
+        runtimeId: 'runtime-live',
+        pid: process.pid,
+        transports: [
+          { kind: 'unix', endpoint: join(process.env.ORCA_USER_DATA_PATH!, 'missing.sock') }
+        ],
+        authToken: 'token',
+        startedAt: 1
+      })
+    )
+    const child = new FakeChildProcess()
+    spawnMock.mockReturnValue(child)
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+
+    const result = serveOrcaApp({
+      recipeJson: true,
+      projectRoot: '/workspace/repo'
+    })
+    queueMicrotask(() => {
+      child.stdout.emit('data', `${RECIPE_JSON}\n`)
+    })
+
+    await expect(result).resolves.toBe(0)
+    expect(spawnMock).toHaveBeenCalledOnce()
+  })
 
   it('pins the Electron child cwd to the app root instead of the caller cwd', async () => {
     const child = {
@@ -605,6 +662,38 @@ describe('launchOrcaApp', () => {
     delete process.env.ORCA_OPEN_COMMAND
     delete process.env.ORCA_APP_EXECUTABLE
     delete process.env.ORCA_APP_EXECUTABLE_NEEDS_APP_ROOT
+  })
+
+  it.runIf(process.platform === 'darwin')(
+    'reopens the packaged Orca.app via Launch Services instead of execing the inner binary',
+    () => {
+      process.env.ORCA_APP_EXECUTABLE = '/Applications/Orca.app/Contents/MacOS/Orca'
+      const child = new FakeChildProcess()
+      spawnMock.mockReturnValue(child)
+
+      launchOrcaApp()
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        'open',
+        ['/Applications/Orca.app'],
+        expect.objectContaining({ detached: true, stdio: 'ignore' })
+      )
+    }
+  )
+
+  it('still execs a non-Orca Electron.app override used by dev launches', () => {
+    process.env.ORCA_APP_EXECUTABLE =
+      '/repo/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron'
+    const child = new FakeChildProcess()
+    spawnMock.mockReturnValue(child)
+
+    launchOrcaApp()
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      '/repo/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron',
+      [],
+      expect.objectContaining({ detached: true })
+    )
   })
 
   it('handles asynchronous detached spawn errors without throwing', async () => {

--- a/src/cli/runtime/launch.ts
+++ b/src/cli/runtime/launch.ts
@@ -1,14 +1,10 @@
 import { spawn as spawnProcess, type SpawnOptions } from 'node:child_process'
 import { basename, resolve } from 'node:path'
-import { StringDecoder } from 'node:string_decoder'
 import {
   SERVE_UPDATE_HANDOFF_PATH_ENV,
   getServeUpdateHandoffPath
 } from '../../shared/serve-update-handoff'
-import {
-  getEphemeralVmRecipeResultConnection,
-  parseEphemeralVmRecipeResult
-} from '../../shared/ephemeral-vm-recipes'
+import { acquireForegroundServeLock, releaseForegroundServeLock } from './foreground-serve-lock'
 import {
   SERVE_ALREADY_RUNNING_EXIT_CODE,
   SERVE_ALREADY_RUNNING_MESSAGE,
@@ -16,6 +12,7 @@ import {
 } from './foreground-serve-policy'
 import { getMacAppBundlePath } from './mac-app-update-bundle'
 import { getDefaultUserDataPath } from './metadata'
+import { waitForRecipeJson } from './serve-recipe-json'
 import {
   readServeUpdateHandoffSync,
   resumeInterruptedServeUpdate,
@@ -23,8 +20,6 @@ import {
 } from './serve-update-supervisor'
 import { getCliStatus } from './status'
 import { RuntimeClientError } from './types'
-
-const IGNORED_NON_RECIPE_STDOUT = '[serve] ignored non-recipe stdout'
 
 export function launchOrcaApp(): void {
   const overrideCommand = process.env.ORCA_OPEN_COMMAND
@@ -102,16 +97,31 @@ export async function serveOrcaApp(
     projectRoot?: string | null
   } = {}
 ): Promise<number> {
-  // Why: a second GUI Electron dies in _RegisterApplication before the
-  // single-instance lock in JS can run. Attach to the live owner instead.
-  if (args.recipeJson !== true) {
-    const status = await getCliStatus(getDefaultUserDataPath())
+  if (args.recipeJson === true) {
+    return spawnForegroundServe(args)
+  }
+
+  // Why: two CLIs can both see an idle profile and both exec Electron before
+  // JS's single-instance lock runs. Reserve the profile first, then spawn.
+  const userDataPath = getDefaultUserDataPath()
+  const lock = await acquireForegroundServeLock(userDataPath)
+  if (!lock) {
+    process.stderr.write(`${SERVE_ALREADY_RUNNING_MESSAGE}\n`)
+    return SERVE_ALREADY_RUNNING_EXIT_CODE
+  }
+  try {
+    const status = await getCliStatus(userDataPath)
     if (!shouldSpawnForegroundServe(status.result)) {
       process.stderr.write(`${SERVE_ALREADY_RUNNING_MESSAGE}\n`)
       return SERVE_ALREADY_RUNNING_EXIT_CODE
     }
+    return await spawnForegroundServe(args)
+  } finally {
+    await releaseForegroundServeLock(lock)
   }
+}
 
+async function spawnForegroundServe(args: Parameters<typeof serveOrcaApp>[0]): Promise<number> {
   const executable = resolveForegroundOrcaExecutable()
   const childArgs = [...getExecutableAppArgs()]
   if (process.env.ORCA_APPIMAGE_NO_SANDBOX === '1') {
@@ -189,97 +199,6 @@ export async function serveOrcaApp(
     child,
     handoffPath,
     expectedHandoff: null
-  })
-}
-
-function waitForRecipeJson(child: ReturnType<typeof spawnProcess>): Promise<number> {
-  return new Promise((resolve, reject) => {
-    let output = ''
-    let settled = false
-    const timeout = setTimeout(() => {
-      finish(new RuntimeClientError('runtime_serve_failed', 'Timed out waiting for recipe JSON.'))
-      child.kill('SIGTERM')
-    }, 60000)
-    const finish = (error?: Error): void => {
-      if (settled) {
-        return
-      }
-      settled = true
-      clearTimeout(timeout)
-      child.stdout?.off('data', onData)
-      child.off('error', onError)
-      child.off('close', onClose)
-      if (error) {
-        reject(error)
-        return
-      }
-      child.stdout?.destroy?.()
-      child.unref()
-      resolve(0)
-    }
-    const writeIgnoredRecipeStdout = (): void => {
-      // Why: non-readiness child stdout is untrusted and cannot be safely
-      // redacted, including schema-valid results with arbitrary user data.
-      process.stderr.write(`${IGNORED_NON_RECIPE_STDOUT}\n`)
-    }
-    const processRecipeOutputLine = (line: string): void => {
-      const normalizedLine = line.endsWith('\r') ? line.slice(0, -1) : line
-      if (!normalizedLine.trim()) {
-        return
-      }
-      const parsed = parseEphemeralVmRecipeResult(normalizedLine)
-      if (!parsed.ok) {
-        writeIgnoredRecipeStdout()
-        return
-      }
-      if (getEphemeralVmRecipeResultConnection(parsed.result).type !== 'orca-server') {
-        writeIgnoredRecipeStdout()
-        return
-      }
-      process.stdout.write(`${normalizedLine.trim()}\n`)
-      finish()
-    }
-    const stdoutDecoder = new StringDecoder('utf8')
-    const onData = (chunk: Buffer | string): void => {
-      output += typeof chunk === 'string' ? chunk : stdoutDecoder.write(chunk)
-      while (!settled) {
-        const newlineIndex = output.indexOf('\n')
-        if (newlineIndex === -1) {
-          return
-        }
-        const line = output.slice(0, newlineIndex)
-        output = output.slice(newlineIndex + 1)
-        processRecipeOutputLine(line)
-      }
-    }
-    const onError = (error: Error): void => {
-      finish(error)
-    }
-    const onClose = (code: number | null, signal: NodeJS.Signals | null): void => {
-      if (settled) {
-        return
-      }
-      output += stdoutDecoder.end()
-      if (output.trim()) {
-        processRecipeOutputLine(output)
-      }
-      if (settled) {
-        return
-      }
-      finish(
-        new RuntimeClientError(
-          'runtime_serve_failed',
-          typeof code === 'number'
-            ? `Orca serve exited before printing valid recipe JSON with code ${code}.`
-            : `Orca serve exited before printing valid recipe JSON via ${signal}.`
-        )
-      )
-    }
-    child.stdout?.on('data', onData)
-    child.once('error', onError)
-    // Why: `exit` can precede the final piped stdout data. `close` waits until
-    // stdio closes so a last recipe chunk is not mistaken for missing output.
-    child.once('close', onClose)
   })
 }
 

--- a/src/cli/runtime/launch.ts
+++ b/src/cli/runtime/launch.ts
@@ -1,5 +1,5 @@
 import { spawn as spawnProcess, type SpawnOptions } from 'node:child_process'
-import { resolve } from 'node:path'
+import { basename, resolve } from 'node:path'
 import { StringDecoder } from 'node:string_decoder'
 import {
   SERVE_UPDATE_HANDOFF_PATH_ENV,
@@ -288,7 +288,7 @@ function packagedOrcaAppBundlePath(executable: string): string | null {
   if (!appBundlePath) {
     return null
   }
-  return appBundlePath === 'Orca.app' || appBundlePath.endsWith('/Orca.app') ? appBundlePath : null
+  return basename(appBundlePath) === 'Orca.app' ? appBundlePath : null
 }
 
 function getExecutableAppArgs(): string[] {

--- a/src/cli/runtime/launch.ts
+++ b/src/cli/runtime/launch.ts
@@ -9,13 +9,19 @@ import {
   getEphemeralVmRecipeResultConnection,
   parseEphemeralVmRecipeResult
 } from '../../shared/ephemeral-vm-recipes'
-import { getDefaultUserDataPath } from './metadata'
+import {
+  SERVE_ALREADY_RUNNING_EXIT_CODE,
+  SERVE_ALREADY_RUNNING_MESSAGE,
+  shouldSpawnForegroundServe
+} from './foreground-serve-policy'
 import { getMacAppBundlePath } from './mac-app-update-bundle'
+import { getDefaultUserDataPath } from './metadata'
 import {
   readServeUpdateHandoffSync,
   resumeInterruptedServeUpdate,
   superviseForegroundServe
 } from './serve-update-supervisor'
+import { getCliStatus } from './status'
 import { RuntimeClientError } from './types'
 
 const IGNORED_NON_RECIPE_STDOUT = '[serve] ignored non-recipe stdout'
@@ -29,6 +35,17 @@ export function launchOrcaApp(): void {
 
   const overrideExecutable = process.env.ORCA_APP_EXECUTABLE
   if (typeof overrideExecutable === 'string' && overrideExecutable.trim().length > 0) {
+    const packagedBundlePath = packagedOrcaAppBundlePath(overrideExecutable)
+    if (packagedBundlePath) {
+      // Why: exec'ing Contents/MacOS/Orca skips Launch Services. On macOS 26 that
+      // aborts in +[NSApplication sharedApplication] / _RegisterApplication
+      // before any JS runs. Dev Electron lives in Electron.app and must still
+      // be exec'd with the app root — only the packaged Orca.app is re-opened.
+      spawnDetached('open', [packagedBundlePath], {
+        env: stripElectronRunAsNode(process.env)
+      })
+      return
+    }
     spawnDetached(overrideExecutable, getExecutableAppArgs(), {
       ...getExecutableSpawnOptions(overrideExecutable),
       env: stripElectronRunAsNode(process.env)
@@ -38,7 +55,7 @@ export function launchOrcaApp(): void {
 
   if (process.env.ELECTRON_RUN_AS_NODE === '1') {
     if (process.platform === 'darwin') {
-      const appBundlePath = getMacAppBundlePath(process.execPath)
+      const appBundlePath = packagedOrcaAppBundlePath(process.execPath)
       if (appBundlePath) {
         // Why: launching the inner MacOS binary directly can trigger macOS app
         // launch failures and bypass normal bundle lifecycle. The public
@@ -74,7 +91,7 @@ function spawnDetached(command: string, args: string[], options: SpawnOptions): 
   child.unref()
 }
 
-export function serveOrcaApp(
+export async function serveOrcaApp(
   args: {
     json?: boolean
     port?: string | null
@@ -85,6 +102,16 @@ export function serveOrcaApp(
     projectRoot?: string | null
   } = {}
 ): Promise<number> {
+  // Why: a second GUI Electron dies in _RegisterApplication before the
+  // single-instance lock in JS can run. Attach to the live owner instead.
+  if (args.recipeJson !== true) {
+    const status = await getCliStatus(getDefaultUserDataPath())
+    if (!shouldSpawnForegroundServe(status.result)) {
+      process.stderr.write(`${SERVE_ALREADY_RUNNING_MESSAGE}\n`)
+      return SERVE_ALREADY_RUNNING_EXIT_CODE
+    }
+  }
+
   const executable = resolveForegroundOrcaExecutable()
   const childArgs = [...getExecutableAppArgs()]
   if (process.env.ORCA_APPIMAGE_NO_SANDBOX === '1') {
@@ -254,6 +281,14 @@ function waitForRecipeJson(child: ReturnType<typeof spawnProcess>): Promise<numb
     // stdio closes so a last recipe chunk is not mistaken for missing output.
     child.once('close', onClose)
   })
+}
+
+function packagedOrcaAppBundlePath(executable: string): string | null {
+  const appBundlePath = getMacAppBundlePath(executable)
+  if (!appBundlePath) {
+    return null
+  }
+  return appBundlePath === 'Orca.app' || appBundlePath.endsWith('/Orca.app') ? appBundlePath : null
 }
 
 function getExecutableAppArgs(): string[] {

--- a/src/cli/runtime/serve-recipe-json.test.ts
+++ b/src/cli/runtime/serve-recipe-json.test.ts
@@ -1,0 +1,32 @@
+import { EventEmitter } from 'node:events'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { RECIPE_JSON_MAX_BUFFER_BYTES, waitForRecipeJson } from './serve-recipe-json'
+
+class FakeRecipeChild extends EventEmitter {
+  stdout = new EventEmitter()
+  kill = vi.fn()
+  unref = vi.fn()
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('waitForRecipeJson', () => {
+  it('rejects and terminates the child when buffered output exceeds the cap', async () => {
+    const child = new FakeRecipeChild()
+    const waiting = waitForRecipeJson(child as never)
+    const oversized = 'x'.repeat(RECIPE_JSON_MAX_BUFFER_BYTES + 1)
+
+    queueMicrotask(() => {
+      child.stdout.emit('data', oversized)
+    })
+
+    await expect(waiting).rejects.toMatchObject({
+      code: 'runtime_serve_failed',
+      message: expect.stringContaining(`${RECIPE_JSON_MAX_BUFFER_BYTES} byte buffer`)
+    })
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM')
+    expect(child.unref).not.toHaveBeenCalled()
+  })
+})

--- a/src/cli/runtime/serve-recipe-json.ts
+++ b/src/cli/runtime/serve-recipe-json.ts
@@ -7,6 +7,7 @@ import {
 import { RuntimeClientError } from './types'
 
 const IGNORED_NON_RECIPE_STDOUT = '[serve] ignored non-recipe stdout'
+export const RECIPE_JSON_MAX_BUFFER_BYTES = 1024 * 1024
 
 export function waitForRecipeJson(child: ChildProcess): Promise<number> {
   return new Promise((resolveWait, reject) => {
@@ -56,8 +57,24 @@ export function waitForRecipeJson(child: ChildProcess): Promise<number> {
       finish()
     }
     const stdoutDecoder = new StringDecoder('utf8')
+    const rejectIfBufferExceeded = (): boolean => {
+      if (Buffer.byteLength(output, 'utf8') <= RECIPE_JSON_MAX_BUFFER_BYTES) {
+        return false
+      }
+      finish(
+        new RuntimeClientError(
+          'runtime_serve_failed',
+          `Orca serve recipe JSON exceeded the ${RECIPE_JSON_MAX_BUFFER_BYTES} byte buffer before a complete line.`
+        )
+      )
+      child.kill('SIGTERM')
+      return true
+    }
     const onData = (chunk: Buffer | string): void => {
       output += typeof chunk === 'string' ? chunk : stdoutDecoder.write(chunk)
+      if (rejectIfBufferExceeded()) {
+        return
+      }
       while (!settled) {
         const newlineIndex = output.indexOf('\n')
         if (newlineIndex === -1) {
@@ -76,6 +93,9 @@ export function waitForRecipeJson(child: ChildProcess): Promise<number> {
         return
       }
       output += stdoutDecoder.end()
+      if (rejectIfBufferExceeded()) {
+        return
+      }
       if (output.trim()) {
         processRecipeOutputLine(output)
       }

--- a/src/cli/runtime/serve-recipe-json.ts
+++ b/src/cli/runtime/serve-recipe-json.ts
@@ -1,0 +1,100 @@
+import type { ChildProcess } from 'node:child_process'
+import { StringDecoder } from 'node:string_decoder'
+import {
+  getEphemeralVmRecipeResultConnection,
+  parseEphemeralVmRecipeResult
+} from '../../shared/ephemeral-vm-recipes'
+import { RuntimeClientError } from './types'
+
+const IGNORED_NON_RECIPE_STDOUT = '[serve] ignored non-recipe stdout'
+
+export function waitForRecipeJson(child: ChildProcess): Promise<number> {
+  return new Promise((resolveWait, reject) => {
+    let output = ''
+    let settled = false
+    const timeout = setTimeout(() => {
+      finish(new RuntimeClientError('runtime_serve_failed', 'Timed out waiting for recipe JSON.'))
+      child.kill('SIGTERM')
+    }, 60000)
+    const finish = (error?: Error): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timeout)
+      child.stdout?.off('data', onData)
+      child.off('error', onError)
+      child.off('close', onClose)
+      if (error) {
+        reject(error)
+        return
+      }
+      child.stdout?.destroy?.()
+      child.unref()
+      resolveWait(0)
+    }
+    const writeIgnoredRecipeStdout = (): void => {
+      // Why: non-readiness child stdout is untrusted and cannot be safely
+      // redacted, including schema-valid results with arbitrary user data.
+      process.stderr.write(`${IGNORED_NON_RECIPE_STDOUT}\n`)
+    }
+    const processRecipeOutputLine = (line: string): void => {
+      const normalizedLine = line.endsWith('\r') ? line.slice(0, -1) : line
+      if (!normalizedLine.trim()) {
+        return
+      }
+      const parsed = parseEphemeralVmRecipeResult(normalizedLine)
+      if (!parsed.ok) {
+        writeIgnoredRecipeStdout()
+        return
+      }
+      if (getEphemeralVmRecipeResultConnection(parsed.result).type !== 'orca-server') {
+        writeIgnoredRecipeStdout()
+        return
+      }
+      process.stdout.write(`${normalizedLine.trim()}\n`)
+      finish()
+    }
+    const stdoutDecoder = new StringDecoder('utf8')
+    const onData = (chunk: Buffer | string): void => {
+      output += typeof chunk === 'string' ? chunk : stdoutDecoder.write(chunk)
+      while (!settled) {
+        const newlineIndex = output.indexOf('\n')
+        if (newlineIndex === -1) {
+          return
+        }
+        const line = output.slice(0, newlineIndex)
+        output = output.slice(newlineIndex + 1)
+        processRecipeOutputLine(line)
+      }
+    }
+    const onError = (error: Error): void => {
+      finish(error)
+    }
+    const onClose = (code: number | null, signal: NodeJS.Signals | null): void => {
+      if (settled) {
+        return
+      }
+      output += stdoutDecoder.end()
+      if (output.trim()) {
+        processRecipeOutputLine(output)
+      }
+      if (settled) {
+        return
+      }
+      finish(
+        new RuntimeClientError(
+          'runtime_serve_failed',
+          typeof code === 'number'
+            ? `Orca serve exited before printing valid recipe JSON with code ${code}.`
+            : `Orca serve exited before printing valid recipe JSON via ${signal}.`
+        )
+      )
+    }
+    child.stdout?.on('data', onData)
+    child.once('error', onError)
+    // Why: `exit` can precede the final piped stdout data. `close` waits until
+    // stdio closes so a last recipe chunk is not mistaken for missing output.
+    child.once('close', onClose)
+  })
+}

--- a/src/cli/runtime/serve-signal-exit-diagnostic.test.ts
+++ b/src/cli/runtime/serve-signal-exit-diagnostic.test.ts
@@ -41,12 +41,13 @@ describe('serveSignalExitError', () => {
     expect(error).toBeInstanceOf(RuntimeClientError)
     expect(error.code).toBe('runtime_serve_failed')
     expect(error.message).toContain('aborted with SIGABRT on macOS')
+    expect(error.message).toContain('most often')
     expect(error.message).toContain('_RegisterApplication')
     expect(error.message).toContain('electron/electron#51871')
     expect(error.data).toMatchObject({
       nextSteps: [
         expect.stringContaining('orca status'),
-        expect.stringContaining('Do not exec'),
+        expect.stringMatching(/Do not exec[\s\S]*not a sandbox workaround/),
         expect.stringContaining('~/Library/Logs/DiagnosticReports/Orca-*.ips')
       ]
     })

--- a/src/cli/runtime/serve-signal-exit-diagnostic.test.ts
+++ b/src/cli/runtime/serve-signal-exit-diagnostic.test.ts
@@ -41,10 +41,12 @@ describe('serveSignalExitError', () => {
     expect(error).toBeInstanceOf(RuntimeClientError)
     expect(error.code).toBe('runtime_serve_failed')
     expect(error.message).toContain('aborted with SIGABRT on macOS')
-    expect(error.message).toContain('macOS window server')
+    expect(error.message).toContain('_RegisterApplication')
+    expect(error.message).toContain('electron/electron#51871')
     expect(error.data).toMatchObject({
       nextSteps: [
-        expect.stringContaining('macOS desktop login'),
+        expect.stringContaining('orca status'),
+        expect.stringContaining('Do not exec'),
         expect.stringContaining('~/Library/Logs/DiagnosticReports/Orca-*.ips')
       ]
     })

--- a/src/cli/runtime/serve-signal-exit-diagnostic.ts
+++ b/src/cli/runtime/serve-signal-exit-diagnostic.ts
@@ -20,12 +20,12 @@ export function serveSignalExitError(
   // phase, so the cause is offered as the likely one rather than asserted.
   return new RuntimeClientError(
     'runtime_serve_failed',
-    'Orca serve aborted with SIGABRT on macOS. Electron dies inside +[NSApplication sharedApplication] → _RegisterApplication before any Orca JavaScript runs, usually because Launch Services cannot assign an application identity. That is common in sandboxed agent environments, SSH sessions without a GUI login, and CI. This is not the Electron UTF-8 write abort (electron/electron#51871).',
+    'Orca serve aborted with SIGABRT on macOS. This most often happens at application startup, when the process cannot register with Launch Services (_RegisterApplication / +[NSApplication sharedApplication]) before any Orca JavaScript runs. That is common in sandboxed agent environments, SSH sessions without a GUI login, and CI. Confirm the crashing frame in the crash report; this is not the Electron UTF-8 write abort (electron/electron#51871).',
     {
       nextSteps: [
         'If a desktop Orca is already running, use `orca status` / `orca` against that instance instead of `orca serve`.',
-        'Do not exec /Applications/Orca.app/Contents/MacOS/Orca from a sandbox. Re-run from a normal macOS desktop login, or use `open -a Orca`.',
-        `Look for a crash report at ${MAC_CRASH_REPORT_GLOB} (crashing frame: _RegisterApplication).`
+        'Do not exec /Applications/Orca.app/Contents/MacOS/Orca from a sandbox. Leave the sandbox and re-run from a normal macOS desktop login. `open -a Orca` is not a sandbox workaround.',
+        `Look for a crash report at ${MAC_CRASH_REPORT_GLOB}. If the crashing frame is _RegisterApplication, this is the startup-registration abort.`
       ]
     }
   )

--- a/src/cli/runtime/serve-signal-exit-diagnostic.ts
+++ b/src/cli/runtime/serve-signal-exit-diagnostic.ts
@@ -20,11 +20,12 @@ export function serveSignalExitError(
   // phase, so the cause is offered as the likely one rather than asserted.
   return new RuntimeClientError(
     'runtime_serve_failed',
-    'Orca serve aborted with SIGABRT on macOS. This most often happens at application startup, when the process cannot register with the macOS window server, which is common in restricted or sandboxed environments, SSH sessions without a GUI login, and CI.',
+    'Orca serve aborted with SIGABRT on macOS. Electron dies inside +[NSApplication sharedApplication] → _RegisterApplication before any Orca JavaScript runs, usually because Launch Services cannot assign an application identity. That is common in sandboxed agent environments, SSH sessions without a GUI login, and CI. This is not the Electron UTF-8 write abort (electron/electron#51871).',
     {
       nextSteps: [
-        'Re-run `orca serve` outside a sandboxed or restricted environment, with a macOS desktop login active.',
-        `Look for a crash report at ${MAC_CRASH_REPORT_GLOB}.`
+        'If a desktop Orca is already running, use `orca status` / `orca` against that instance instead of `orca serve`.',
+        'Do not exec /Applications/Orca.app/Contents/MacOS/Orca from a sandbox. Re-run from a normal macOS desktop login, or use `open -a Orca`.',
+        `Look for a crash report at ${MAC_CRASH_REPORT_GLOB} (crashing frame: _RegisterApplication).`
       ]
     }
   )


### PR DESCRIPTION
## ELI5

If something (often an agent) starts a second Orca while one is already running, macOS kills that second process instantly — before Orca's own "already running" check can run. The starter retries, and you get a pile of crash reports. We now refuse to start that second process, and we tell you this is the Launch Services abort, not the old UTF-8 file-write abort.

## What Changed

`orca serve` no longer execs a second Electron main when this `userData` profile is already live (exit `3`, same contract as the single-instance lock). `orca open` reopens packaged `Orca.app` via Launch Services instead of exec'ing `Contents/MacOS/Orca`. The SIGABRT CLI message names `_RegisterApplication` and distinguishes it from electron/electron#51871. Documented in `docs/reference/macos-electron-startup-abort.md`.

`--serve-recipe-json` still detaches a child; that path is an ephemeral pairing helper, not a second desktop.

## Why

`ElectronMain` always creates `NSApplication`. When `launchservicesd` is unreachable (agent sandbox, SSH without Aqua, CI), HIServices `abort()`s. That is before any of our JavaScript, so the single-instance lock cannot save us. Stock Electron 43.1.0 dies the same way under a 15-line `sandbox-exec` profile. The 2026-08-14 incident was ten such crashes in eleven minutes.

This repo cannot stop Electron from aborting. It can stop us from spawning the process that will abort, and it can name the crash so the next investigation does not go down the UTF-8 / signing / ASAR path again.

## Linked Issue

Fixes #14541

Related: #9282, #10461, #10464, #12212, electron/electron#51871, electron/electron#52815

## Visual Proof

No visual change. CLI / process-lifecycle only: a retry of `orca serve` while the desktop is up used to write `Orca-*.ips` (`_RegisterApplication`); it now prints that the profile is already running and exits 3.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Manual (macOS 26.6 arm64):

- Stock Electron 43.1.0 under `sandbox-exec` denying `com.apple.lsd*` / `launchservicesd` → exit 134, stack matches the user `.ips`.
- Same sandbox + `ELECTRON_RUN_AS_NODE=1` → does not abort.
- `orca serve` against a live desktop profile is skipped in unit tests (live pid in `orca-runtime.json`).
- Targeted unit tests: `pnpm exec vitest run src/cli/runtime/foreground-serve-policy.test.ts src/cli/runtime/serve-signal-exit-diagnostic.test.ts src/cli/runtime/launch.test.ts src/cli/serve-electron-flag-parity.test.ts` — 40 passed.

Platforms: macOS (repro + unit tests). Linux/Windows keep exit code `3` for already-running; they do not hit `_RegisterApplication`. Full `pnpm lint` / `typecheck` / `test` / `build` left to CI.

## AI Disclosure

Drafted and iterated with Grok (xAI) in the Orca worktree. Investigation, repro, issue/PR text, and the CLI change were produced in that session and then aligned to `.github/CONTRIBUTING.md`, `.github/pull_request_template.md`, and Electron's bug-report form (including the AI-agent notes in their template).

## Review

AI coding-agent review (explicit checks required by CONTRIBUTING):

- **Cross-platform:** The already-running short-circuit is process-lifecycle, not AppKit-specific. Exit `3` matches `SINGLE_INSTANCE_ALREADY_RUNNING_EXIT_CODE` used by the Linux systemd unit. `open` / `_RegisterApplication` diagnostics are darwin-only. Dev `Electron.app` overrides are still exec'd so `orca-dev` is unchanged.
- **SSH / remote / local:** A headless or SSH session that cannot register still cannot start a GUI Electron — we now name that abort and point at the `.ips`. We do not assume a local-only path; userData isolation still goes through `ORCA_USER_DATA_PATH`.
- **Agents / integrations:** This is aimed at agent sandboxes that retry `orca serve`. Provider-neutral. Recipe-json (ephemeral VM pairing) still spawns.
- **Performance:** One extra `getCliStatus` before spawn. Avoids a crash-loop of new Electron mains.
- **UI:** No renderer/UI change.
- **Security:** No new network, credentials, or trust boundary. We only refuse to start a second main for the same profile.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: thiagomsoares
