### PR TITLE
feat(browser): negotiate client page commands

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -2591,7 +2591,7 @@
       "providers": ["local", "remote-runtime", "ssh", "wsl"],
       "coveredPlatforms": ["macos"],
       "coveredProviders": ["remote-runtime", "ssh"],
-      "coverageNotes": "Deterministic protocol, registry, injected-socket, and loopback-listener tests cover strict framing, remote-DNS targets, exact destination-write and source-consumption credit, at most 16 pending opens, 128 admitted opens per 10-second monotonic window, an 8 MiB per-route application-buffer ledger, shared 32 MiB browser-host and 128 MiB process ledgers across application copies, encrypted client queues, and native WebSocket bufferedAmount, bounded byte/claim/socket-source counts, a four-frame queued-drain quantum, authority epochs, exact host selection, one host per authenticated connection, four hosts per paired device, long-poll metering and disconnect abort, monotonic host/page/route generations without page tombstones, two-phase exact page retirement with cancellation, connection-owned cleanup, exact client revocation, stale and replaced fences, retired stream IDs, half-close and close ordering, SOCKS CONNECT, bind/close races, listener wildcard normalization, unsupported commands, unavailable routes, and raw/terminal binary-handler isolation. A stable local listener rejects CONNECT while offline or reconnecting, retains its address across replacement, requires a strictly increasing tunnel generation, ignores late superseded callbacks, propagates tunnel protocol failure to the route owner, and recycles exhausted stream IDs only after generation replacement. Reconnect uses the unchanged native v1 attach payload and capability pair; SSH descriptors alone add an execution-host capability and require a runtime-minted grant bound to the exact browser-host lease. Exact SSH provider epoch and connection generation fence ssh2 forwardOut and one non-interactive standalone system-SSH dynamic forward per route. Unit tests preserve domain-form SOCKS requests, sanitize remote errors, bound stderr, cancel startup, release timed-out and synchronously failed sockets, and release routes once. An ephemeral Docker sshd resolves a container-only domain and returns a unique HTTP marker through both ssh2 and the actual system-OpenSSH dynamic-forward adapter without touching the user's SSH files; authority loss fences the ssh2 route. The execution runtime charges route application bytes to the same per-host/process policy; its existing E2EE owner separately caps native outbound buffers process-wide. Explicitly injected browser-host and paired-runtime tunnel methods lease one exact host, then carry SOCKS and HTTP bytes over a dedicated E2EE socket to the fenced execution-host revision and prove route close destroys the destination socket. Both methods and capabilities remain disabled in production. Node stream-internal high-water bytes, strict cross-route scheduling, WSL, and physical cross-platform evidence remain uncovered.",
+      "coverageNotes": "Deterministic protocol, registry, injected-socket, and loopback-listener tests cover strict framing, remote-DNS targets, exact destination-write and source-consumption credit, at most 16 pending opens, 128 admitted opens per 10-second monotonic window, an 8 MiB per-route application-buffer ledger, shared 32 MiB browser-host and 128 MiB process ledgers across application copies, encrypted client queues, and native WebSocket bufferedAmount, bounded byte/claim/socket-source counts, a four-frame queued-drain quantum, authority epochs, exact host selection, one host per authenticated connection, four hosts per paired device, long-poll metering and disconnect abort, monotonic host/page/route generations without page tombstones, two-phase exact page retirement with cancellation, connection-owned cleanup, exact client revocation, stale and replaced fences, retired stream IDs, half-close and close ordering, SOCKS CONNECT, bind/close races, listener wildcard normalization, unsupported commands, unavailable routes, and raw/terminal binary-handler isolation. Page commands use a separately echoed v1 attach negotiation, exact authority/host/page generations, bounded command IDs and sequences, and bounded create/navigate payloads; legacy attaches still receive only the unchanged ready/revoked event shapes. A stable local listener rejects CONNECT while offline or reconnecting, retains its address across replacement, requires a strictly increasing tunnel generation, ignores late superseded callbacks, propagates tunnel protocol failure to the route owner, and recycles exhausted stream IDs only after generation replacement. Reconnect uses the unchanged native v1 attach payload and capability pair; SSH descriptors alone add an execution-host capability and require a runtime-minted grant bound to the exact browser-host lease. Exact SSH provider epoch and connection generation fence ssh2 forwardOut and one non-interactive standalone system-SSH dynamic forward per route. Unit tests preserve domain-form SOCKS requests, sanitize remote errors, bound stderr, cancel startup, release timed-out and synchronously failed sockets, and release routes once. An ephemeral Docker sshd resolves a container-only domain and returns a unique HTTP marker through both ssh2 and the actual system-OpenSSH dynamic-forward adapter without touching the user's SSH files; authority loss fences the ssh2 route. The execution runtime charges route application bytes to the same per-host/process policy; its existing E2EE owner separately caps native outbound buffers process-wide. Explicitly injected browser-host and paired-runtime tunnel methods lease one exact host, then carry SOCKS and HTTP bytes over a dedicated E2EE socket to the fenced execution-host revision and prove route close destroys the destination socket. Both methods and capabilities remain disabled in production. Node stream-internal high-water bytes, strict cross-route scheduling, command-result RPC admission and dedupe/replay, WSL, and physical cross-platform evidence remain uncovered.",
       "motivatingLinks": [
         "https://linear.app/stably/issue/STA-4150/refactor-remote-browser-to-client-hosted-electron-webviews"
       ],
@@ -2690,10 +2690,27 @@
           ]
         },
         {
+          "file": "src/shared/browser-client-host-protocol.test.ts",
+          "assertions": [
+            "page-command v1 negotiation is optional and independent of the legacy ready/revoked stream",
+            "create and navigate commands bind bounded IDs and sequences to exact runtime, epoch, host, and page generations",
+            "unknown versions, command kinds, invalid generations, and oversized identities fail before delivery"
+          ]
+        },
+        {
+          "file": "src/main/browser/paired-runtime-browser-host-lease.test.ts",
+          "assertions": [
+            "a client requests commands only with a delivery handler and accepts them only after an exact v1 echo",
+            "an old host that omits the echo cannot deliver a command",
+            "stale authority commands close the exact lease before handler delivery"
+          ]
+        },
+        {
           "file": "src/main/runtime/rpc/methods/browser-client-host.test.ts",
           "assertions": [
             "the control method stays out of production registration",
             "only a negotiated authenticated paired-runtime connection receives a server-owned epoch and generation",
+            "page-command v1 is echoed only to an explicit v1 attach while legacy event shapes remain unchanged",
             "a second browser-host identity on one authenticated connection is rejected",
             "connection cleanup releases the exact lease and replacement emits an epoch-and-generation-bound revocation"
           ]
@@ -2874,6 +2891,15 @@
         }
       ],
       "evidenceRuns": [
+        {
+          "date": "2026-08-14",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/shared/browser-client-host-protocol.test.ts src/shared/ws-outbound-backpressure-queue.test.ts src/shared/remote-runtime-client.test.ts src/main/runtime/browser-host-lease-registry.test.ts src/main/runtime/runtime-rpc-browser-host-admission.test.ts src/main/runtime/rpc/methods/browser-client-host.test.ts src/main/runtime/rpc/methods/browser-network-tunnel.test.ts src/main/browser/paired-runtime-browser-host-lease.test.ts src/main/browser/paired-runtime-browser-network-route.test.ts src/main/runtime/browser-network-tunnel-paired-runtime.integration.test.ts src/main/browser/browser-network-tunnel-client.test.ts src/main/browser/browser-network-tunnel-client-memory-budget.test.ts src/main/browser/browser-network-tunnel-session.test.ts src/main/browser/browser-network-tunnel-session-aggregate-memory.test.ts src/main/browser/browser-network-tunnel-outbound-memory-budget.test.ts src/main/browser/remote-browser-socks-server.test.ts",
+          "result": "passed",
+          "durationSeconds": 3.9,
+          "summary": "Sixteen files passed 154 bounded page-command negotiation, legacy ready/revoked compatibility, exact authority, unnegotiated and stale-command delivery, lease, tunnel, memory, flow-control, SOCKS, and paired E2EE tests."
+        },
         {
           "date": "2026-08-14",
           "runner": "local",

--- a/src/main/browser/paired-runtime-browser-host-lease.test.ts
+++ b/src/main/browser/paired-runtime-browser-host-lease.test.ts
@@ -74,6 +74,156 @@ describe('PairedRuntimeBrowserHostLease', () => {
     expect(close).toHaveBeenCalledOnce()
   })
 
+  it('uses page commands only after the host echoes the requested protocol', async () => {
+    const { callbacks, close } = await subscribeLease()
+    const onPageCommand = vi.fn()
+    const lease = createLease({ pageCommandProtocolVersion: 1, onPageCommand })
+    const starting = lease.start()
+    await vi.waitFor(() => expect(callbacks.current).toBeDefined())
+    callbacks.current!.onResponse({
+      id: 'browser-host',
+      ok: true,
+      result: {
+        type: 'ready',
+        authorityEpoch: 'epoch-a',
+        browserHostGeneration: 4,
+        pageCommandProtocolVersion: 1
+      },
+      _meta: { runtimeId: 'runtime-a' }
+    })
+
+    await expect(starting).resolves.toMatchObject({ pageCommandProtocolVersion: 1 })
+    expect(subscribeRemoteRuntimeRequestMock).toHaveBeenCalledWith(
+      pairing,
+      'browser.clientHost.attach',
+      expect.objectContaining({ pageCommandProtocolVersion: 1 }),
+      15_000,
+      expect.any(Object),
+      expect.any(Object)
+    )
+    callbacks.current!.onResponse({
+      id: 'browser-host',
+      ok: true,
+      result: {
+        type: 'command',
+        pageCommandProtocolVersion: 1,
+        authorityRuntimeId: 'runtime-a',
+        authorityEpoch: 'epoch-a',
+        browserHostClientId: 'host-a',
+        browserHostGeneration: 4,
+        browserPageId: 'page-a',
+        pageHostGeneration: 1,
+        commandSequence: 1,
+        commandId: 'command-a',
+        command: {
+          type: 'createPage',
+          browserProfileId: 'default',
+          executionHostKey: 'native:runtime-a:1'
+        }
+      },
+      _meta: { runtimeId: 'runtime-a' }
+    })
+
+    expect(onPageCommand).toHaveBeenCalledOnce()
+    expect(close).not.toHaveBeenCalled()
+    await lease.close()
+  })
+
+  it('rejects page commands when an old host did not negotiate them', async () => {
+    const { callbacks, close } = await subscribeLease()
+    const onError = vi.fn()
+    const onPageCommand = vi.fn()
+    const lease = createLease({ pageCommandProtocolVersion: 1, onPageCommand, onError })
+    const starting = lease.start()
+    await vi.waitFor(() => expect(callbacks.current).toBeDefined())
+    callbacks.current!.onResponse({
+      id: 'browser-host',
+      ok: true,
+      result: { type: 'ready', authorityEpoch: 'epoch-a', browserHostGeneration: 4 },
+      _meta: { runtimeId: 'runtime-a' }
+    })
+    await starting
+
+    callbacks.current!.onResponse({
+      id: 'browser-host',
+      ok: true,
+      result: {
+        type: 'command',
+        pageCommandProtocolVersion: 1,
+        authorityRuntimeId: 'runtime-a',
+        authorityEpoch: 'epoch-a',
+        browserHostClientId: 'host-a',
+        browserHostGeneration: 4,
+        browserPageId: 'page-a',
+        pageHostGeneration: 1,
+        commandSequence: 1,
+        commandId: 'command-a',
+        command: {
+          type: 'createPage',
+          browserProfileId: 'default',
+          executionHostKey: 'native:runtime-a:1'
+        }
+      },
+      _meta: { runtimeId: 'runtime-a' }
+    })
+
+    await vi.waitFor(() => expect(close).toHaveBeenCalledOnce())
+    expect(onPageCommand).not.toHaveBeenCalled()
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Unnegotiated browser host page command' })
+    )
+  })
+
+  it('rejects a negotiated command from a stale authority before delivery', async () => {
+    const { callbacks, close } = await subscribeLease()
+    const onError = vi.fn()
+    const onPageCommand = vi.fn()
+    const lease = createLease({ pageCommandProtocolVersion: 1, onPageCommand, onError })
+    const starting = lease.start()
+    await vi.waitFor(() => expect(callbacks.current).toBeDefined())
+    callbacks.current!.onResponse({
+      id: 'browser-host',
+      ok: true,
+      result: {
+        type: 'ready',
+        authorityEpoch: 'epoch-a',
+        browserHostGeneration: 4,
+        pageCommandProtocolVersion: 1
+      },
+      _meta: { runtimeId: 'runtime-a' }
+    })
+    await starting
+
+    callbacks.current!.onResponse({
+      id: 'browser-host',
+      ok: true,
+      result: {
+        type: 'command',
+        pageCommandProtocolVersion: 1,
+        authorityRuntimeId: 'runtime-a',
+        authorityEpoch: 'epoch-b',
+        browserHostClientId: 'host-a',
+        browserHostGeneration: 4,
+        browserPageId: 'page-a',
+        pageHostGeneration: 1,
+        commandSequence: 1,
+        commandId: 'command-a',
+        command: {
+          type: 'createPage',
+          browserProfileId: 'default',
+          executionHostKey: 'native:runtime-a:1'
+        }
+      },
+      _meta: { runtimeId: 'runtime-a' }
+    })
+
+    await vi.waitFor(() => expect(close).toHaveBeenCalledOnce())
+    expect(onPageCommand).not.toHaveBeenCalled()
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Stale browser host page command' })
+    )
+  })
+
   it('rejects malformed lease authority instead of adopting it', async () => {
     let callbacks: RemoteRuntimeSubscriptionCallbacks | undefined
     const close = vi.fn()
@@ -246,7 +396,11 @@ async function subscribeLease(): Promise<{
 }
 
 function createLease(
-  overrides: { onError?: (error: Error) => void } = {}
+  overrides: {
+    onError?: (error: Error) => void
+    onPageCommand?: (command: unknown) => void | Promise<void>
+    pageCommandProtocolVersion?: 1
+  } = {}
 ): PairedRuntimeBrowserHostLease {
   return new PairedRuntimeBrowserHostLease({
     pairing,

--- a/src/main/browser/paired-runtime-browser-host-lease.ts
+++ b/src/main/browser/paired-runtime-browser-host-lease.ts
@@ -1,6 +1,7 @@
 import {
   BrowserClientHostEvent,
-  type BrowserHostLeaseAuthority
+  type BrowserClientHostCommandEvent,
+  type BrowserClientHostLeaseAuthority
 } from '../../shared/browser-client-host-protocol'
 import type { PairingOffer } from '../../shared/pairing'
 import { BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY } from '../../shared/protocol-version'
@@ -16,6 +17,8 @@ type PairedRuntimeBrowserHostLeaseOptions = {
   authorityRuntimeId: string
   browserHostClientId: string
   hostCapabilities: readonly string[]
+  pageCommandProtocolVersion?: 1
+  onPageCommand?: (command: BrowserClientHostCommandEvent) => void | Promise<void>
   timeoutMs?: number
   subscription?: RemoteRuntimeSubscriptionOptions
   onError?: (error: Error) => void
@@ -23,15 +26,15 @@ type PairedRuntimeBrowserHostLeaseOptions = {
 
 export class PairedRuntimeBrowserHostLease {
   private subscription: RemoteRuntimeSubscription | null = null
-  private startPromise: Promise<BrowserHostLeaseAuthority> | null = null
+  private startPromise: Promise<BrowserClientHostLeaseAuthority> | null = null
   private closePromise: Promise<void> | null = null
   private rejectReady: ((error: Error) => void) | null = null
-  private authority: BrowserHostLeaseAuthority | null = null
+  private authority: BrowserClientHostLeaseAuthority | null = null
   private closed = false
 
   constructor(private readonly options: PairedRuntimeBrowserHostLeaseOptions) {}
 
-  start(): Promise<BrowserHostLeaseAuthority> {
+  start(): Promise<BrowserClientHostLeaseAuthority> {
     if (this.closed) {
       return Promise.reject(new Error('Browser host lease is closed'))
     }
@@ -49,28 +52,33 @@ export class PairedRuntimeBrowserHostLease {
     return this.closePromise
   }
 
-  private async startLease(): Promise<BrowserHostLeaseAuthority> {
+  private async startLease(): Promise<BrowserClientHostLeaseAuthority> {
     const timeoutMs = this.options.timeoutMs ?? 15_000
-    let resolveReady = (_authority: BrowserHostLeaseAuthority): void => {}
+    let resolveReady = (_authority: BrowserClientHostLeaseAuthority): void => {}
     let rejectReady = (_error: Error): void => {}
-    const ready = new Promise<BrowserHostLeaseAuthority>((resolve, reject) => {
+    const ready = new Promise<BrowserClientHostLeaseAuthority>((resolve, reject) => {
       resolveReady = resolve
       rejectReady = reject
     })
     void ready.catch(() => undefined)
     let readyTimeout: ReturnType<typeof setTimeout> | null = null
     try {
+      const pageCommandProtocolVersion = this.requestedPageCommandProtocolVersion()
       const subscription = await subscribeRemoteRuntimeRequest(
         this.options.pairing,
         'browser.clientHost.attach',
         {
           authorityRuntimeId: this.options.authorityRuntimeId,
           browserHostClientId: this.options.browserHostClientId,
-          hostCapabilities: [...this.options.hostCapabilities]
+          hostCapabilities: [...this.options.hostCapabilities],
+          ...(pageCommandProtocolVersion ? { pageCommandProtocolVersion } : {})
         },
         timeoutMs,
         {
           onResponse: (response) => {
+            if (this.closed) {
+              return
+            }
             if (!response.ok) {
               this.fail(
                 new RemoteRuntimeClientError(response.error.code, response.error.message),
@@ -81,6 +89,10 @@ export class PairedRuntimeBrowserHostLease {
             const parsed = BrowserClientHostEvent.safeParse(response.result)
             if (!parsed.success || response._meta.runtimeId !== this.options.authorityRuntimeId) {
               this.fail(new Error('Invalid browser host lease response'), rejectReady)
+              return
+            }
+            if (parsed.data.type === 'command') {
+              this.handlePageCommand(parsed.data, rejectReady)
               return
             }
             if (parsed.data.type === 'revoked') {
@@ -95,11 +107,21 @@ export class PairedRuntimeBrowserHostLease {
               this.fail(new Error(`Browser host lease revoked: ${parsed.data.reason}`), rejectReady)
               return
             }
+            if (
+              parsed.data.pageCommandProtocolVersion !== undefined &&
+              parsed.data.pageCommandProtocolVersion !== pageCommandProtocolVersion
+            ) {
+              this.fail(new Error('Invalid browser host lease response'), rejectReady)
+              return
+            }
             const authority = {
               authorityRuntimeId: this.options.authorityRuntimeId,
               authorityEpoch: parsed.data.authorityEpoch,
               browserHostClientId: this.options.browserHostClientId,
-              browserHostGeneration: parsed.data.browserHostGeneration
+              browserHostGeneration: parsed.data.browserHostGeneration,
+              ...(parsed.data.pageCommandProtocolVersion
+                ? { pageCommandProtocolVersion: parsed.data.pageCommandProtocolVersion }
+                : {})
             }
             if (this.authority) {
               if (!sameAuthority(this.authority, authority)) {
@@ -161,6 +183,44 @@ export class PairedRuntimeBrowserHostLease {
     )
   }
 
+  private requestedPageCommandProtocolVersion(): 1 | undefined {
+    return this.options.onPageCommand ? this.options.pageCommandProtocolVersion : undefined
+  }
+
+  private handlePageCommand(
+    command: BrowserClientHostCommandEvent,
+    rejectReady: (error: Error) => void
+  ): void {
+    const authority = this.authority
+    if (
+      !authority?.pageCommandProtocolVersion ||
+      !this.options.onPageCommand ||
+      command.pageCommandProtocolVersion !== authority.pageCommandProtocolVersion
+    ) {
+      this.fail(new Error('Unnegotiated browser host page command'), rejectReady)
+      return
+    }
+    if (
+      command.authorityRuntimeId !== authority.authorityRuntimeId ||
+      command.authorityEpoch !== authority.authorityEpoch ||
+      command.browserHostClientId !== authority.browserHostClientId ||
+      command.browserHostGeneration !== authority.browserHostGeneration
+    ) {
+      this.fail(new Error('Stale browser host page command'), rejectReady)
+      return
+    }
+    try {
+      const delivered = this.options.onPageCommand(command)
+      if (delivered) {
+        void delivered.catch((error) =>
+          this.fail(error instanceof Error ? error : new Error(String(error)), rejectReady)
+        )
+      }
+    } catch (error) {
+      this.fail(error instanceof Error ? error : new Error(String(error)), rejectReady)
+    }
+  }
+
   private async closeLease(): Promise<void> {
     this.subscription?.close()
     this.subscription = null
@@ -175,11 +235,15 @@ export class PairedRuntimeBrowserHostLease {
   }
 }
 
-function sameAuthority(left: BrowserHostLeaseAuthority, right: BrowserHostLeaseAuthority): boolean {
+function sameAuthority(
+  left: BrowserClientHostLeaseAuthority,
+  right: BrowserClientHostLeaseAuthority
+): boolean {
   return (
     left.authorityRuntimeId === right.authorityRuntimeId &&
     left.authorityEpoch === right.authorityEpoch &&
     left.browserHostClientId === right.browserHostClientId &&
-    left.browserHostGeneration === right.browserHostGeneration
+    left.browserHostGeneration === right.browserHostGeneration &&
+    left.pageCommandProtocolVersion === right.pageCommandProtocolVersion
   )
 }

--- a/src/main/browser/paired-runtime-browser-network-route.test.ts
+++ b/src/main/browser/paired-runtime-browser-network-route.test.ts
@@ -307,6 +307,26 @@ describe('PairedRuntimeBrowserNetworkRoute', () => {
     await route.close()
   })
 
+  it('keeps page-command negotiation off the independent tunnel attach', async () => {
+    const attempts = mockSubscriptionAttempts()
+    const commandLease = { ...lease, pageCommandProtocolVersion: 1 }
+    const route = new PairedRuntimeBrowserNetworkRoute({
+      pairing,
+      lease: commandLease,
+      executionHostRevision: 1
+    })
+    const starting = route.start()
+    await vi.waitFor(() => expect(attempts).toHaveLength(1))
+    ready(attempts[0]!, 7)
+    await starting
+
+    expect(attempts[0]!.params).toEqual({
+      ...lease,
+      executionHost: { kind: 'native', runtimeId: 'runtime-a', revision: 1 }
+    })
+    await route.close()
+  })
+
   it('negotiates execution-host routing only for an SSH descriptor', async () => {
     const attempts = mockSubscriptionAttempts()
     const executionHost = {

--- a/src/main/browser/paired-runtime-browser-network-transport.ts
+++ b/src/main/browser/paired-runtime-browser-network-transport.ts
@@ -97,7 +97,10 @@ export class PairedRuntimeBrowserNetworkTransport {
         this.options.pairing,
         'network.browserTunnel',
         {
-          ...this.options.lease,
+          authorityRuntimeId: this.options.lease.authorityRuntimeId,
+          authorityEpoch: this.options.lease.authorityEpoch,
+          browserHostClientId: this.options.lease.browserHostClientId,
+          browserHostGeneration: this.options.lease.browserHostGeneration,
           executionHost: this.options.executionHost
         },
         this.options.timeoutMs,

--- a/src/main/runtime/rpc/methods/browser-client-host.test.ts
+++ b/src/main/runtime/rpc/methods/browser-client-host.test.ts
@@ -6,7 +6,7 @@ import { RpcDispatcher } from '../dispatcher'
 import { BROWSER_CLIENT_HOST_METHODS } from './browser-client-host'
 import { ALL_RPC_METHODS } from './index'
 
-function request(browserHostClientId = 'host-a') {
+function request(browserHostClientId = 'host-a', pageCommandProtocolVersion?: 1) {
   return {
     id: `browser-host:${browserHostClientId}`,
     authToken: 'bound-by-websocket',
@@ -14,7 +14,8 @@ function request(browserHostClientId = 'host-a') {
     params: {
       authorityRuntimeId: 'runtime-a',
       browserHostClientId,
-      hostCapabilities: ['webview']
+      hostCapabilities: ['webview'],
+      ...(pageCommandProtocolVersion ? { pageCommandProtocolVersion } : {})
     }
   }
 }
@@ -77,6 +78,7 @@ describe('browser.clientHost.attach RPC', () => {
     await vi.waitFor(() => expect(replies).toHaveLength(1))
     const ready = JSON.parse(replies[0]!).result
     expect(ready).toMatchObject({ type: 'ready', browserHostGeneration: 1 })
+    expect(ready).not.toHaveProperty('pageCommandProtocolVersion')
     expect(ready.authorityEpoch).toEqual(expect.any(String))
     expect(getBrowserHostLeaseRegistry(hostRuntime).select('host-a')).toMatchObject({
       connectionId: 'connection-a',
@@ -96,6 +98,35 @@ describe('browser.clientHost.attach RPC', () => {
     expect(() => getBrowserHostLeaseRegistry(hostRuntime).select('host-a')).toThrow(
       'browser_host_unavailable'
     )
+  })
+
+  it('echoes page-command negotiation only to an explicit v1 client', async () => {
+    const cleanups = new Map<string, () => void>()
+    const hostRuntime = runtime(cleanups)
+    const dispatcher = new RpcDispatcher({
+      runtime: hostRuntime,
+      methods: BROWSER_CLIENT_HOST_METHODS
+    })
+    const replies: string[] = []
+    const dispatch = dispatcher.dispatchStreaming(
+      request('host-a', 1),
+      (reply) => replies.push(reply),
+      {
+        connectionId: 'connection-a',
+        clientKind: 'runtime',
+        pairedDeviceId: 'device-a',
+        clientCapabilities: [BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY]
+      }
+    )
+
+    await vi.waitFor(() => expect(replies).toHaveLength(1))
+    expect(JSON.parse(replies[0]!).result).toMatchObject({
+      type: 'ready',
+      pageCommandProtocolVersion: 1
+    })
+    cleanups.get('browser-client-host:host-a')?.()
+    await dispatch
+    expect(JSON.parse(replies[1]!).result).not.toHaveProperty('pageCommandProtocolVersion')
   })
 
   it('fences a replaced subscription and increments its host generation', async () => {

--- a/src/main/runtime/rpc/methods/browser-client-host.ts
+++ b/src/main/runtime/rpc/methods/browser-client-host.ts
@@ -48,7 +48,10 @@ export const BROWSER_CLIENT_HOST_METHODS: RpcAnyMethod[] = [
         emit({
           type: 'ready',
           authorityEpoch: handle.lease.authorityEpoch,
-          browserHostGeneration: handle.lease.browserHostGeneration
+          browserHostGeneration: handle.lease.browserHostGeneration,
+          ...(params.pageCommandProtocolVersion
+            ? { pageCommandProtocolVersion: params.pageCommandProtocolVersion }
+            : {})
         })
         const reason = await handle.whenFenced
         emit({

--- a/src/shared/browser-client-host-protocol.test.ts
+++ b/src/shared/browser-client-host-protocol.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import {
   BrowserClientHostAttachParams,
+  BrowserClientHostCommandEvent,
+  BrowserClientHostCommandResultParams,
   BrowserClientHostEvent,
+  BrowserClientHostLeaseEvent,
   BrowserClientHostReady,
   BrowserNetworkTunnelAttachParams,
   BrowserNetworkTunnelEvent
@@ -27,6 +30,115 @@ describe('browser client-host control protocol', () => {
         browserHostGeneration: 2
       })
     ).toEqual({ type: 'ready', authorityEpoch: 'epoch-a', browserHostGeneration: 2 })
+  })
+
+  it('negotiates page commands independently of the legacy lease stream', () => {
+    expect(
+      BrowserClientHostAttachParams.parse({
+        authorityRuntimeId: 'runtime-a',
+        browserHostClientId: 'host-a',
+        hostCapabilities: ['webview'],
+        pageCommandProtocolVersion: 1
+      })
+    ).toMatchObject({ pageCommandProtocolVersion: 1 })
+    expect(
+      BrowserClientHostReady.parse({
+        type: 'ready',
+        authorityEpoch: 'epoch-a',
+        browserHostGeneration: 2,
+        pageCommandProtocolVersion: 1
+      })
+    ).toMatchObject({ pageCommandProtocolVersion: 1 })
+    expect(
+      BrowserClientHostAttachParams.parse({
+        authorityRuntimeId: 'runtime-a',
+        browserHostClientId: 'host-a',
+        hostCapabilities: ['webview']
+      })
+    ).not.toHaveProperty('pageCommandProtocolVersion')
+  })
+
+  it('binds create-page commands and results to exact bounded authority', () => {
+    const authority = {
+      authorityRuntimeId: 'runtime-a',
+      authorityEpoch: 'epoch-a',
+      browserHostClientId: 'host-a',
+      browserHostGeneration: 2,
+      browserPageId: 'page-a',
+      pageHostGeneration: 3
+    }
+    const command = {
+      type: 'command' as const,
+      pageCommandProtocolVersion: 1 as const,
+      ...authority,
+      commandSequence: 4,
+      commandId: 'command-a',
+      command: {
+        type: 'createPage' as const,
+        browserProfileId: 'default',
+        executionHostKey: 'native:runtime-a:5'
+      }
+    }
+
+    expect(BrowserClientHostCommandEvent.parse(command)).toEqual(command)
+    expect(BrowserClientHostEvent.parse(command)).toEqual(command)
+    expect(() => BrowserClientHostLeaseEvent.parse(command)).toThrow()
+    expect(
+      BrowserClientHostCommandEvent.parse({
+        ...command,
+        commandSequence: 5,
+        commandId: 'command-b',
+        command: { type: 'navigate', url: 'https://remote.internal/path' }
+      })
+    ).toMatchObject({ command: { type: 'navigate', url: 'https://remote.internal/path' } })
+    expect(
+      BrowserClientHostCommandResultParams.parse({
+        pageCommandProtocolVersion: 1,
+        ...authority,
+        commandSequence: 4,
+        commandId: 'command-a',
+        result: { status: 'completed' }
+      })
+    ).toMatchObject({ result: { status: 'completed' } })
+  })
+
+  it.each([
+    ['zero sequence', { commandSequence: 0 }],
+    ['wrong protocol', { pageCommandProtocolVersion: 2 }],
+    ['empty command id', { commandId: '' }],
+    ['unknown command', { command: { type: 'openAnything' } }],
+    ['oversized navigation', { command: { type: 'navigate', url: `https://${'x'.repeat(8192)}` } }],
+    [
+      'oversized profile',
+      {
+        command: {
+          type: 'createPage',
+          browserProfileId: 'x'.repeat(257),
+          executionHostKey: 'native:runtime-a:1'
+        }
+      }
+    ]
+  ])('rejects %s before page-command delivery', (_name, override) => {
+    expect(() =>
+      BrowserClientHostCommandEvent.parse({
+        type: 'command',
+        pageCommandProtocolVersion: 1,
+        authorityRuntimeId: 'runtime-a',
+        authorityEpoch: 'epoch-a',
+        browserHostClientId: 'host-a',
+        browserHostGeneration: 2,
+        browserPageId: 'page-a',
+        pageHostGeneration: 3,
+        commandSequence: 4,
+        commandId: 'command-a',
+        command: {
+          type: 'createPage',
+          browserProfileId: 'default',
+          executionHostKey: 'native:runtime-a:5'
+        },
+        ...override
+      })
+    ).toThrow()
   })
 
   it('requires every lease and execution-host fence on tunnel attach', () => {

--- a/src/shared/browser-client-host-protocol.ts
+++ b/src/shared/browser-client-host-protocol.ts
@@ -2,28 +2,31 @@ import { z } from 'zod'
 
 const Generation = z.number().int().min(1).max(0xffff_ffff)
 const Identity = z.string().min(1).max(256)
+const CommandSequence = z.number().int().min(1).max(Number.MAX_SAFE_INTEGER)
+
+export const BROWSER_CLIENT_HOST_PAGE_COMMAND_PROTOCOL_VERSION = 1 as const
+const PageCommandProtocolVersion = z.literal(BROWSER_CLIENT_HOST_PAGE_COMMAND_PROTOCOL_VERSION)
 
 export const BrowserClientHostAttachParams = z.object({
   authorityRuntimeId: Identity,
   browserHostClientId: Identity,
-  hostCapabilities: z.array(z.string().min(1).max(128)).max(32)
+  hostCapabilities: z.array(z.string().min(1).max(128)).max(32),
+  pageCommandProtocolVersion: PageCommandProtocolVersion.optional()
 })
 
 export const BrowserClientHostReady = z.object({
   type: z.literal('ready'),
   authorityEpoch: Identity,
-  browserHostGeneration: Generation
+  browserHostGeneration: Generation,
+  pageCommandProtocolVersion: PageCommandProtocolVersion.optional()
 })
 
-export const BrowserClientHostEvent = z.discriminatedUnion('type', [
-  BrowserClientHostReady,
-  z.object({
-    type: z.literal('revoked'),
-    authorityEpoch: Identity,
-    browserHostGeneration: Generation,
-    reason: z.enum(['replaced', 'released'])
-  })
-])
+const BrowserClientHostRevoked = z.object({
+  type: z.literal('revoked'),
+  authorityEpoch: Identity,
+  browserHostGeneration: Generation,
+  reason: z.enum(['replaced', 'released'])
+})
 
 export const BrowserHostLeaseAuthority = z.object({
   authorityRuntimeId: Identity,
@@ -33,6 +36,12 @@ export const BrowserHostLeaseAuthority = z.object({
 })
 
 export type BrowserHostLeaseAuthority = z.infer<typeof BrowserHostLeaseAuthority>
+
+export const BrowserClientHostLeaseAuthority = BrowserHostLeaseAuthority.extend({
+  pageCommandProtocolVersion: PageCommandProtocolVersion.optional()
+})
+
+export type BrowserClientHostLeaseAuthority = z.infer<typeof BrowserClientHostLeaseAuthority>
 
 const BrowserNetworkNativeExecutionHost = z.object({
   kind: z.literal('native'),
@@ -53,6 +62,57 @@ export const BrowserNetworkExecutionHost = z.discriminatedUnion('kind', [
 ])
 
 export type BrowserNetworkExecutionHost = z.infer<typeof BrowserNetworkExecutionHost>
+
+const BrowserClientPageCommandAuthority = BrowserClientHostLeaseAuthority.extend({
+  pageCommandProtocolVersion: PageCommandProtocolVersion,
+  browserPageId: Identity,
+  pageHostGeneration: Generation,
+  commandSequence: CommandSequence,
+  commandId: Identity
+})
+
+const BrowserClientHostCreatePageCommand = z.object({
+  type: z.literal('createPage'),
+  browserProfileId: Identity,
+  executionHostKey: Identity
+})
+
+const BrowserClientHostNavigateCommand = z.object({
+  type: z.literal('navigate'),
+  url: z.string().min(1).max(8192)
+})
+
+export const BrowserClientHostCommandEvent = BrowserClientPageCommandAuthority.extend({
+  type: z.literal('command'),
+  command: z.discriminatedUnion('type', [
+    BrowserClientHostCreatePageCommand,
+    BrowserClientHostNavigateCommand
+  ])
+})
+
+export type BrowserClientHostCommandEvent = z.infer<typeof BrowserClientHostCommandEvent>
+
+export const BrowserClientHostCommandResult = z.discriminatedUnion('status', [
+  z.object({ status: z.literal('completed') }),
+  z.object({ status: z.literal('failed'), errorCode: Identity })
+])
+
+export type BrowserClientHostCommandResult = z.infer<typeof BrowserClientHostCommandResult>
+
+export const BrowserClientHostCommandResultParams = BrowserClientPageCommandAuthority.extend({
+  result: BrowserClientHostCommandResult
+})
+
+export const BrowserClientHostLeaseEvent = z.discriminatedUnion('type', [
+  BrowserClientHostReady,
+  BrowserClientHostRevoked
+])
+
+export const BrowserClientHostEvent = z.discriminatedUnion('type', [
+  BrowserClientHostReady,
+  BrowserClientHostRevoked,
+  BrowserClientHostCommandEvent
+])
 
 export const BrowserNetworkTunnelAttachParams = BrowserHostLeaseAuthority.extend({
   executionHost: BrowserNetworkExecutionHost


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​320 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​317 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​181 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​25 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​156 |

<!-- /orca-pr-loc -->

STA-4150: https://linear.app/stably/issue/STA-4150/refactor-remote-browser-to-client-hosted-electron-webviews

Stacked on #14539. This inert layer adds an optional page-command v1 request/echo handshake, bounded create/navigate command and result schemas, and exact runtime/epoch/host/page fencing in the paired client. Legacy attaches continue to receive only the unchanged ready/revoked shapes, and page-command negotiation is kept out of the independent browser-tunnel attach.

Causal evidence: five initial assertions failed on parent b9f45c0d07 because the version was stripped, no echo or command/result schema existed, and every command was rejected as an invalid lease event. The candidate passes the exact 16-file reliability command with 154 tests, 4,956 runtime/browser tests with 5 existing skips, full typecheck, mixed-version terminal wire, native and type-aware audits, changed-code quality, reliability/max-lines checks, formatting, and two fresh reviews.

No runtime capability, production RPC registration, server command emission, result handler, renderer surface, Electron behavior, or placement default changes here. Activation remains blocked on page-generation admission, FIFO ordering, command-ID dedupe/result replay, bounded callback cancellation/joining, authenticated result admission, server-authoritative executionHostKey resolution, navigation policy, and headed/headless/WSL/mixed-version E2E proof.