### PR TITLE
fix(orchestration): reject reopening tasks with active dispatches

### DIFF
--- a/src/main/runtime/orchestration/db.ts
+++ b/src/main/runtime/orchestration/db.ts
@@ -4582,6 +4582,23 @@ export class OrchestrationDb {
   }
 
   updateTaskStatus(id: string, status: TaskStatus, result?: string): TaskRow | undefined {
+    if (status === 'ready') {
+      const activeDispatch = this.db
+        .prepare(
+          `SELECT id FROM dispatch_contexts
+           WHERE task_id = ? AND status IN ('pending', 'dispatched')
+           ORDER BY rowid DESC
+           LIMIT 1`
+        )
+        .get(id) as Pick<DispatchContextRow, 'id'> | undefined
+      if (activeDispatch) {
+        throw new OrchestrationError(
+          'request_mismatch',
+          `Task ${id} has active dispatch ${activeDispatch.id}; settle or release it before returning the task to ready.`
+        )
+      }
+    }
+
     const completedAt =
       status === 'completed' || status === 'failed' ? new Date().toISOString() : null
     this.db

--- a/src/main/runtime/orchestration/db.ts
+++ b/src/main/runtime/orchestration/db.ts
@@ -4594,7 +4594,8 @@ export class OrchestrationDb {
       if (activeDispatch) {
         throw new OrchestrationError(
           'request_mismatch',
-          `Task ${id} has active dispatch ${activeDispatch.id}; settle or release it before returning the task to ready.`
+          `Task ${id} has active dispatch ${activeDispatch.id}; settle or release it before returning the task to ready.`,
+          { taskId: id, dispatchId: activeDispatch.id }
         )
       }
     }

--- a/src/main/runtime/rpc/methods/orchestration-tasks-dispatch.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-tasks-dispatch.test.ts
@@ -185,6 +185,32 @@ describe('orchestration RPC methods', () => {
       expect(db.getActiveDispatchForTerminal('term_a')).toBeUndefined()
     })
 
+    it.each(['pending', 'dispatched'] as const)(
+      'rejects reopening a task while its dispatch is %s',
+      async (dispatchStatus) => {
+        setup()
+        const task = db.createTask({ spec: 'work' })
+        const dispatch =
+          dispatchStatus === 'pending'
+            ? db.createStartingWorkerDispatch({ taskId: task.id, startOptions: {} }).dispatch
+            : db.createDispatchContext(task.id, 'term_a')
+
+        await expect(
+          call('orchestration.taskUpdate', {
+            id: task.id,
+            status: 'ready'
+          })
+        ).rejects.toMatchObject({
+          code: 'request_mismatch',
+          data: { taskId: task.id, dispatchId: dispatch.id }
+        })
+
+        expect(db.getTask(task.id)?.status).toBe('dispatched')
+        expect(db.getDispatchContext(task.id)?.status).toBe(dispatchStatus)
+        expect(db.getDispatchContext(task.id)?.id).toBe(dispatch.id)
+      }
+    )
+
     it('throws on nonexistent task', async () => {
       setup()
       await expect(


### PR DESCRIPTION
## ELI5

Orca now refuses to move a Task back to `ready` while that Task still owns a pending or dispatched Dispatch. This prevents a second worker from being assigned while the original worker remains authoritative.

## What Changed

- Reject `task-update --status ready` while the Task owns a pending or dispatched Dispatch.
- Return structured `request_mismatch` data containing the Task and Dispatch IDs.
- Preserve both Task and Dispatch state when the invalid transition is attempted.
- Cover both active Dispatch states in RPC regression tests.

## Why

Previously, a coordinator could move a dispatched Task back to `ready` without settling its active Dispatch. The Task then became eligible for another assignment while the original Dispatch remained authoritative, producing split-brain worker ownership.

This also removes the unsupported manual step used in the reproduction for #11499. A coordinator must settle or stop/release the active Dispatch before retrying the Task; a first-class supersede/cancel lifecycle can be designed separately.

## Linked Issue

Related to #11499.

## Visual Proof

N/A. This is a backend orchestration invariant with no UI change.

## Testing

- [x] Pending Dispatch rejects reopening with `request_mismatch` and the exact Task/Dispatch IDs.
- [x] Dispatched Dispatch rejects reopening with the same structured contract.
- [x] Task and Dispatch states remain unchanged after rejection.
- [x] Focused Vitest set: 225 passed.
- [x] Node TypeScript check.
- [x] Oxlint on changed files.
- [x] `git diff --check`.

## AI Disclosure

Implemented with OpenAI Codex. CodeRabbit requested the pending-Dispatch and structured-error coverage; commit `35c6556e7` addresses both.

## Review

The change is intentionally limited to the Task/Dispatch state invariant and its RPC contract. It does not add supersede/cancel behavior or alter worker settlement.

## Checklist

- [x] Focused change with regression coverage.
- [x] No UI, schema migration, credential, or external-state changes.
- [x] Existing completion/settlement behavior remains unchanged.

## Author

- GitHub: @guanbear
- X: @guanbear