### PR TITLE
fix(daemon): stop losing a startup command when the shell-ready marker is late

### DIFF
--- a/src/main/daemon/repro-13642-late-shell-ready-startup-command.test.ts
+++ b/src/main/daemon/repro-13642-late-shell-ready-startup-command.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Real-PTY reproduction for #13642.
+ *
+ * The daemon holds a startup command behind the `orca-shell-ready` marker. When a shell reaches
+ * its first prompt after the shell-ready deadline, the pre-fix delivery path (`session.write`)
+ * released the command into a PTY whose shell was not reading yet, and the launch was lost with
+ * no error anywhere.
+ *
+ * Nothing here is mocked: the daemon's own `createPtySubprocess` spawns a real shell process on a
+ * real PTY, real timers run, and the two delivery paths — the pre-fix `write` and the fix's
+ * `writeStartupCommand` — drive that same session. The injected shell-ready timeout is short so
+ * the marker is late by construction rather than by luck.
+ */
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { setTimeout as delay } from 'node:timers/promises'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { createPtySubprocess } from './pty-subprocess'
+import { Session } from './session'
+
+const SHELL_READY_TIMEOUT_MS = 250
+const LATE_MARKER_GRACE_MS = 20_000
+// Why 20 reads of up to 100ms each: the fixture shell must still be discarding input when the
+// deadline flush fires, however late a loaded machine runs that timer. The window only ever
+// grows under load, never shrinks below the injected timeout.
+const DISCARD_READS = 20
+const WAIT_TIMEOUT_MS = 25_000
+
+/** A shell that reaches its first prompt long after the shell-ready deadline.
+ *
+ * Why the drain: a shell whose line editor takes the terminal with tcsetattr(TCSAFLUSH) throws
+ * away everything typed before it got there, and that discard is the reason the shell-ready
+ * barrier exists. The fixture reproduces it with an explicit non-canonical drain so the window is
+ * bounded by the fixture rather than by the host's shell version. The `buffer` mode covers the
+ * other kind of shell, which keeps typeahead — there the fix must still deliver exactly once. */
+function getFixtureShellScript(): string {
+  return `#!/bin/bash
+if [ "\${ORCA_REPRO_13642_TYPEAHEAD:-discard}" = "buffer" ]; then
+  sleep "\${ORCA_REPRO_13642_BUFFER_SECONDS:-2}"
+else
+  stty -icanon min 0 time 1
+  reads=0
+  while [ "$reads" -lt "\${ORCA_REPRO_13642_DISCARD_READS:-1}" ]; do
+    dd of=/dev/null bs=65536 count=1 2>/dev/null
+    reads=$((reads + 1))
+  done
+  stty icanon
+fi
+if [ -n "\${ORCA_REPRO_13642_EXIT_BEFORE_MARKER:-}" ]; then
+  exit 3
+fi
+printf '\\033]777;orca-shell-ready\\007'
+printf 'fixture $ '
+while IFS= read -r line; do
+  printf 'RAN:%s\\n' "$line"
+done
+`
+}
+
+type StartupDelivery = 'pre-fix-write' | 'startup-command'
+
+type LateMarkerRun = {
+  startupRuns: number
+  sentinelRuns: number
+  output: string
+  shellState: string
+}
+
+const describeOnPosix = process.platform === 'win32' ? describe.skip : describe
+
+describeOnPosix('#13642 startup command across a late shell-ready marker (real PTY)', () => {
+  let fixtureDir: string
+  let fixtureShellPath: string
+
+  beforeAll(() => {
+    fixtureDir = mkdtempSync(join(tmpdir(), 'orca-repro-13642-'))
+    fixtureShellPath = join(fixtureDir, 'late-prompt-shell.sh')
+    writeFileSync(fixtureShellPath, getFixtureShellScript())
+    chmodSync(fixtureShellPath, 0o755)
+  })
+
+  afterAll(() => {
+    rmSync(fixtureDir, { recursive: true, force: true })
+  })
+
+  async function waitUntil(predicate: () => boolean, description: string): Promise<void> {
+    const deadline = Date.now() + WAIT_TIMEOUT_MS
+    while (Date.now() < deadline) {
+      if (predicate()) {
+        return
+      }
+      await delay(10)
+    }
+    throw new Error(`Timed out waiting for ${description}`)
+  }
+
+  function countOccurrences(haystack: string, needle: string): number {
+    return haystack.split(needle).length - 1
+  }
+
+  function createLateMarkerSession(token: string, extraEnv: Record<string, string> = {}) {
+    const sessionId = `repro-13642-${token}`
+    const subprocess = createPtySubprocess({
+      sessionId,
+      cols: 80,
+      rows: 24,
+      cwd: fixtureDir,
+      shellOverride: fixtureShellPath,
+      env: { ORCA_REPRO_13642_DISCARD_READS: String(DISCARD_READS), ...extraEnv },
+      // Why: an Orca shim inherited from the developer's own shell would rewrite the fixture's
+      // launch args; drop them so the spawn is the same on every machine.
+      envToDelete: [
+        'ORCA_ATTRIBUTION_SHIM_DIR',
+        'ORCA_OPENCODE_CONFIG_DIR',
+        'ORCA_MIMOCODE_HOME',
+        'ORCA_OMP_STATUS_EXTENSION',
+        'ORCA_CODEX_HOME',
+        'ORCA_AGENT_TEAMS_SHIM_DIR'
+      ]
+    })
+    const chunks: string[] = []
+    const session = new Session({
+      sessionId,
+      cols: 80,
+      rows: 24,
+      subprocess,
+      shellReadySupported: true,
+      shellReadyTimeoutMs: SHELL_READY_TIMEOUT_MS,
+      shellReadyLateMarkerGraceMs: LATE_MARKER_GRACE_MS
+    })
+    let exited = false
+    session.attachClient({
+      onData: (data) => chunks.push(data),
+      onExit: () => {
+        exited = true
+      }
+    })
+    return {
+      session,
+      output: () => chunks.join(''),
+      hasExited: () => exited,
+      dispose: () => {
+        session.dispose()
+        subprocess.kill()
+      }
+    }
+  }
+
+  function deliverStartupCommand(
+    session: Session,
+    delivery: StartupDelivery,
+    command: string
+  ): void {
+    if (delivery === 'pre-fix-write') {
+      // The literal pre-fix call site: terminal-host-session-create.ts wrote the startup command
+      // with session.write() before this change.
+      session.write(command)
+      return
+    }
+    // Why the lookup instead of a direct call: reverting the fix removes writeStartupCommand, and
+    // the harness must then fail on the delivery assertion below, not on a TypeError.
+    const writeStartupCommand = (session as Partial<Session>).writeStartupCommand
+    if (typeof writeStartupCommand === 'function') {
+      writeStartupCommand.call(session, command)
+      return
+    }
+    session.write(command)
+  }
+
+  async function runLateMarkerDelivery(
+    delivery: StartupDelivery,
+    token: string,
+    extraEnv: Record<string, string> = {}
+  ): Promise<LateMarkerRun> {
+    const harness = createLateMarkerSession(token, extraEnv)
+    const startupCommand = `startup-${token}`
+    const sentinel = `sentinel-${token}`
+    try {
+      deliverStartupCommand(harness.session, delivery, `${startupCommand}\n`)
+
+      // The boundary itself: the deadline expires while the shell is still discarding input.
+      await waitUntil(
+        () => harness.session.shellState === 'timed_out',
+        'the injected shell-ready deadline to expire before the marker'
+      )
+      expect(harness.output()).not.toContain(`RAN:${startupCommand}`)
+
+      // Pre-fix, a session that already timed out stops scanning, so the late marker never flips
+      // it to 'ready' — wait on the marker bytes reaching the pane instead.
+      await waitUntil(
+        () =>
+          harness.session.shellState === 'ready' ||
+          harness.output().includes('orca-shell-ready') ||
+          harness.hasExited(),
+        'the late shell-ready marker'
+      )
+
+      // A keystroke behind the startup command: once the shell echoes it back, anything the
+      // session delivered earlier has already been read, so nothing is merely still in flight.
+      harness.session.write(`${sentinel}\n`)
+      await waitUntil(
+        () => harness.output().includes(`RAN:${sentinel}`),
+        'the shell to run the sentinel keystroke'
+      )
+
+      const output = harness.output()
+      return {
+        startupRuns: countOccurrences(output, `RAN:${startupCommand}`),
+        sentinelRuns: countOccurrences(output, `RAN:${sentinel}`),
+        output,
+        shellState: harness.session.shellState
+      }
+    } finally {
+      harness.dispose()
+    }
+  }
+
+  it('loses the startup command when the pre-fix path releases it at the deadline', async () => {
+    const run = await runLateMarkerDelivery('pre-fix-write', 'prefix')
+
+    // The shell is alive and reading — it ran the later keystroke — but the launch is gone.
+    expect(run.sentinelRuns).toBe(1)
+    expect(run.startupRuns).toBe(0)
+  })
+
+  it('delivers the startup command exactly once when the marker arrives late', async () => {
+    const run = await runLateMarkerDelivery('startup-command', 'fixed')
+
+    expect(run.startupRuns).toBe(1)
+    expect(run.sentinelRuns).toBe(1)
+    expect(run.shellState).toBe('ready')
+    // Held until the marker, so it lands ahead of input typed after the shell was ready.
+    expect(run.output.indexOf('RAN:startup-fixed')).toBeLessThan(
+      run.output.indexOf('RAN:sentinel-fixed')
+    )
+  })
+
+  // Why: a re-delivery that fired on both the deadline and the marker would launch an agent twice.
+  it('still delivers exactly once when the late shell buffered typeahead instead', async () => {
+    const run = await runLateMarkerDelivery('startup-command', 'buffered', {
+      ORCA_REPRO_13642_TYPEAHEAD: 'buffer'
+    })
+
+    expect(run.startupRuns).toBe(1)
+    expect(run.sentinelRuns).toBe(1)
+  })
+
+  it('reports the startup command a shell exited before ever reading', async () => {
+    const harness = createLateMarkerSession('exit', { ORCA_REPRO_13642_EXIT_BEFORE_MARKER: '1' })
+    const warnings: string[] = []
+    const originalWarn = console.warn
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map(String).join(' '))
+    }
+    try {
+      deliverStartupCommand(harness.session, 'startup-command', 'startup-exit\n')
+      await waitUntil(() => harness.hasExited(), 'the fixture shell to exit without a marker')
+
+      expect(harness.output()).not.toContain('RAN:startup-exit')
+      expect(warnings.some((line) => line.includes('never delivered'))).toBe(true)
+    } finally {
+      console.warn = originalWarn
+      harness.dispose()
+    }
+  })
+})

--- a/src/main/daemon/session.test.ts
+++ b/src/main/daemon/session.test.ts
@@ -624,6 +624,23 @@ describe('Session', () => {
         expect(warn).toHaveBeenCalledWith(expect.stringContaining('never delivered'))
       })
 
+      it('names the deadline this session waited, not the default one', () => {
+        createSession({
+          shellReadySupported: true,
+          shellReadyTimeoutMs: 2_000,
+          shellReadyLateMarkerGraceMs: 5_000
+        })
+        session.writeStartupCommand('claude\n')
+
+        vi.advanceTimersByTime(2_000 + 5_000)
+
+        expect(subprocess.written).toEqual(['claude\n'])
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('after 7000ms'))
+        expect(warn).not.toHaveBeenCalledWith(
+          expect.stringContaining(`after ${SHELL_READY_TIMEOUT_MS + 5_000}ms`)
+        )
+      })
+
       // Why: shortening the barrier is how Codex opts out of marker-gated delivery.
       it('gives no grace window to a session that shortened the barrier', () => {
         createSession({ shellReadySupported: true, shellReadyTimeoutMs: 300 })

--- a/src/main/daemon/session.test.ts
+++ b/src/main/daemon/session.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { SESSION_FORCE_KILL_RETRY_MS, Session } from './session'
+import {
+  SESSION_FORCE_KILL_RETRY_MS,
+  SHELL_READY_LATE_MARKER_GRACE_MS,
+  SHELL_READY_TIMEOUT_MS,
+  Session
+} from './session'
 import type { SessionState, ShellReadyState } from './types'
 import type { TuiAgent } from '../../shared/types'
 
@@ -103,6 +108,7 @@ describe('Session', () => {
   function createSession(opts?: {
     shellReadySupported?: boolean
     shellReadyTimeoutMs?: number
+    shellReadyLateMarkerGraceMs?: number
     cols?: number
     rows?: number
     launchAgent?: TuiAgent
@@ -125,6 +131,9 @@ describe('Session', () => {
       ...(opts?.startupIngress ? { startupIngress: opts.startupIngress } : {}),
       ...(opts?.shellReadyTimeoutMs !== undefined
         ? { shellReadyTimeoutMs: opts.shellReadyTimeoutMs }
+        : {}),
+      ...(opts?.shellReadyLateMarkerGraceMs !== undefined
+        ? { shellReadyLateMarkerGraceMs: opts.shellReadyLateMarkerGraceMs }
         : {})
     })
     return session
@@ -535,6 +544,96 @@ describe('Session', () => {
       vi.advanceTimersByTime(1)
       expect(session.shellState).toBe('timed_out' satisfies ShellReadyState)
       expect(subprocess.written).toEqual(['codex\n'])
+    })
+
+    // A startup command has no one to notice it was dropped, so it is not released by the ready
+    // deadline the way keystrokes are — it waits for the marker, and every path that ends without
+    // one says so. See SHELL_READY_LATE_MARKER_GRACE_MS.
+    describe('startup command delivery', () => {
+      let warn: ReturnType<typeof vi.spyOn>
+
+      beforeEach(() => {
+        warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      })
+
+      afterEach(() => {
+        warn.mockRestore()
+      })
+
+      it('delivers the startup command once the marker arrives', () => {
+        createSession({ shellReadySupported: true })
+        session.writeStartupCommand('claude\n')
+
+        subprocess.simulateData('\x1b]777;orca-shell-ready\x07\r\nuser@host $ ')
+        vi.advanceTimersByTime(30)
+
+        expect(session.shellState).toBe('ready' satisfies ShellReadyState)
+        expect(subprocess.written).toEqual(['claude\n'])
+        expect(warn).not.toHaveBeenCalled()
+      })
+
+      it('keeps holding the startup command past the deadline while keystrokes go through', () => {
+        createSession({ shellReadySupported: true })
+        session.writeStartupCommand('claude\n')
+        session.write('typed')
+
+        vi.advanceTimersByTime(SHELL_READY_TIMEOUT_MS)
+
+        expect(session.shellState).toBe('timed_out' satisfies ShellReadyState)
+        expect(subprocess.written).toEqual(['typed'])
+      })
+
+      it('delivers the startup command on a marker that arrives after the deadline', () => {
+        createSession({ shellReadySupported: true })
+        const received: string[] = []
+        session.attachClient({ onData: (data) => received.push(data), onExit: () => {} })
+        session.writeStartupCommand('claude\n')
+
+        vi.advanceTimersByTime(SHELL_READY_TIMEOUT_MS + SHELL_READY_LATE_MARKER_GRACE_MS - 1)
+        expect(subprocess.written).toEqual([])
+
+        subprocess.simulateData('\x1b]777;orca-shell-ready\x07\r\nuser@host $ ')
+        vi.advanceTimersByTime(30)
+
+        expect(session.shellState).toBe('ready' satisfies ShellReadyState)
+        expect(subprocess.written).toEqual(['claude\n'])
+        // The late marker is still stripped, so it never reaches the pane.
+        expect(received.join('')).toBe('\r\nuser@host $ ')
+        expect(warn).not.toHaveBeenCalled()
+      })
+
+      it('writes the startup command without proof once the grace deadline passes, and says so', () => {
+        createSession({ shellReadySupported: true })
+        session.writeStartupCommand('claude\n')
+
+        vi.advanceTimersByTime(SHELL_READY_TIMEOUT_MS + SHELL_READY_LATE_MARKER_GRACE_MS)
+
+        expect(subprocess.written).toEqual(['claude\n'])
+        expect(session.shellState).toBe('timed_out' satisfies ShellReadyState)
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('without proof'))
+      })
+
+      it('reports a startup command the shell exited before ever reading', () => {
+        createSession({ shellReadySupported: true })
+        session.writeStartupCommand('claude\n')
+
+        vi.advanceTimersByTime(SHELL_READY_TIMEOUT_MS)
+        subprocess.simulateExit(1)
+
+        expect(subprocess.written).toEqual([])
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('never delivered'))
+      })
+
+      // Why: shortening the barrier is how Codex opts out of marker-gated delivery.
+      it('gives no grace window to a session that shortened the barrier', () => {
+        createSession({ shellReadySupported: true, shellReadyTimeoutMs: 300 })
+        session.writeStartupCommand('codex\n')
+
+        vi.advanceTimersByTime(300)
+
+        expect(subprocess.written).toEqual(['codex\n'])
+        expect(warn).not.toHaveBeenCalled()
+      })
     })
 
     it('detects marker split across data chunks', () => {

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -132,6 +132,7 @@ export class Session {
   private attachedClients: AttachedClient[] = []
   private preReadyStdinQueue: string[] = []
   private heldStartupCommand: string | null = null
+  private readonly shellReadyTimeoutMs: number
   private readonly shellReadyLateMarkerGraceMs: number
   private shellReadyLateMarkerTimer: ReturnType<typeof setTimeout> | null = null
   private releaseStartupDeviceAttributesResponder: (() => void) | null = null
@@ -179,6 +180,9 @@ export class Session {
         ? undefined
         : opts.historySeedChunks.every((chunk) => this.emulator.writeSync(chunk))
 
+    // Why: the late-marker warning has to name the deadline this session actually waited, so the
+    // effective timeout is resolved once here instead of re-derived from the default at print time.
+    this.shellReadyTimeoutMs = opts.shellReadyTimeoutMs ?? SHELL_READY_TIMEOUT_MS
     this.shellReadyLateMarkerGraceMs =
       opts.shellReadyLateMarkerGraceMs ??
       (opts.shellReadyTimeoutMs === undefined ? SHELL_READY_LATE_MARKER_GRACE_MS : 0)
@@ -197,7 +201,7 @@ export class Session {
       this.startupDeviceAttributesQueryFilter = new StartupDeviceAttributesQueryFilter()
       this.shellReadyTimer = setTimeout(() => {
         this.onShellReadyTimeout()
-      }, opts.shellReadyTimeoutMs ?? SHELL_READY_TIMEOUT_MS)
+      }, this.shellReadyTimeoutMs)
     } else {
       this._shellState = 'unsupported'
     }
@@ -826,7 +830,7 @@ export class Session {
     }
     console.warn(
       `[daemon/session] ${this.sessionId}: no shell-ready marker after ${
-        SHELL_READY_TIMEOUT_MS + this.shellReadyLateMarkerGraceMs
+        this.shellReadyTimeoutMs + this.shellReadyLateMarkerGraceMs
       }ms; writing the startup command without proof the shell is reading it`
     )
     this.releaseHeldShellReadyBytes()

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -34,7 +34,12 @@ import type {
 import type { PtyOwnerBackend } from '../../shared/pty-owner-backend'
 import { createPtySlaveEchoProbe } from '../../shared/pty-slave-line-discipline-echo'
 
-const SHELL_READY_TIMEOUT_MS = 15_000
+export const SHELL_READY_TIMEOUT_MS = 15_000
+// Why: a cold worktree under load has been measured taking ~30s to reach its first prompt,
+// twice SHELL_READY_TIMEOUT_MS. Past that deadline queued keystrokes are released so the pane
+// stays typeable, but the startup command keeps waiting for the marker for this much longer —
+// written into a shell that is not reading yet it is swallowed and the launch is lost silently.
+export const SHELL_READY_LATE_MARKER_GRACE_MS = 30_000
 // Why: Codex skips marker-gated command delivery; this only bounds older daemon/local paths that still report shell-ready for Codex.
 export const CODEX_SHELL_READY_TIMEOUT_MS = 300
 const KILL_TIMEOUT_MS = 5_000
@@ -90,6 +95,10 @@ export type SessionOptions = {
   subprocess: SubprocessHandle
   shellReadySupported: boolean
   shellReadyTimeoutMs?: number
+  /** Extra wait for a late ready marker before the startup command is written without proof.
+   *  Defaults to 0 whenever shellReadyTimeoutMs is set: shortening the barrier is how a caller
+   *  (Codex) opts out of marker-gated delivery, and it must not inherit the longer wait. */
+  shellReadyLateMarkerGraceMs?: number
   historySeedChunks?: readonly string[]
   scrollback?: number
   wslDistro?: string
@@ -122,6 +131,9 @@ export class Session {
   private readonly onSessionExit?: (code: number) => void
   private attachedClients: AttachedClient[] = []
   private preReadyStdinQueue: string[] = []
+  private heldStartupCommand: string | null = null
+  private readonly shellReadyLateMarkerGraceMs: number
+  private shellReadyLateMarkerTimer: ReturnType<typeof setTimeout> | null = null
   private releaseStartupDeviceAttributesResponder: (() => void) | null = null
   private startupDeviceAttributesQueryFilter: StartupDeviceAttributesQueryFilter | null = null
   private shellReadyScanState: ShellReadyScanState | null = null
@@ -167,6 +179,10 @@ export class Session {
         ? undefined
         : opts.historySeedChunks.every((chunk) => this.emulator.writeSync(chunk))
 
+    this.shellReadyLateMarkerGraceMs =
+      opts.shellReadyLateMarkerGraceMs ??
+      (opts.shellReadyTimeoutMs === undefined ? SHELL_READY_LATE_MARKER_GRACE_MS : 0)
+
     if (opts.shellReadySupported) {
       this._shellState = 'pending'
       this.shellReadyScanState = createShellReadyScanState()
@@ -186,7 +202,9 @@ export class Session {
       this._shellState = 'unsupported'
     }
 
-    this.postReadyFlushGate = new PostReadyFlushGate(() => this.flushPreReadyQueue())
+    this.postReadyFlushGate = new PostReadyFlushGate(() =>
+      this.flushPreReadyQueue({ includeStartupCommand: true })
+    )
     const echoProbe = createPtySlaveEchoProbe(this.subprocess.slavePath)
     this.startupIngress = new PtyStartupIngress({
       ...(opts.startupIngress ? { intent: opts.startupIngress } : {}),
@@ -260,6 +278,22 @@ export class Session {
     }
 
     this.subprocess.write(data)
+  }
+
+  /** Delivery path for the command a session is launched with. Unlike `write`, it is not released
+   *  by the shell-ready deadline: a startup command written before the shell reads its PTY is
+   *  swallowed, and the caller is left with a healthy-looking session that never ran anything. It
+   *  waits for the ready marker instead, and the daemon logs the two outcomes that are not proof
+   *  of delivery — the grace deadline expiring, and the shell exiting while it is still held. */
+  writeStartupCommand(data: string): void {
+    if (this._state === 'exited' || this._disposed) {
+      return
+    }
+    if (this._shellState === 'pending' && this.heldStartupCommand === null) {
+      this.heldStartupCommand = data
+      return
+    }
+    this.write(data)
   }
 
   resize(cols: number, rows: number): void {
@@ -599,10 +633,8 @@ export class Session {
       clearTimeout(this.killTimer)
       this.killTimer = null
     }
-    if (this.shellReadyTimer) {
-      clearTimeout(this.shellReadyTimer)
-      this.shellReadyTimer = null
-    }
+    this.clearShellReadyTimers()
+    this.reportUndeliveredStartupCommand()
     this.shellReadyScanState = null
     this.preReadyStdinQueue = []
     this.postReadyFlushGate.clear()
@@ -649,7 +681,9 @@ export class Session {
     }
 
     let releaseStartupDeviceAttributes = false
-    if (this._shellState === 'pending' && this.shellReadyScanState) {
+    // Why the scan state, not the 'pending' state: it outlives the deadline while a held startup
+    // command waits on a late marker, and the marker bytes must be stripped whenever it does.
+    if (this.shellReadyScanState) {
       const scanned = scanForShellReady(this.shellReadyScanState, data)
       data = scanned.output
       if (scanned.matched) {
@@ -708,10 +742,8 @@ export class Session {
       clearTimeout(this.killTimer)
       this.killTimer = null
     }
-    if (this.shellReadyTimer) {
-      clearTimeout(this.shellReadyTimer)
-      this.shellReadyTimer = null
-    }
+    this.clearShellReadyTimers()
+    this.reportUndeliveredStartupCommand()
     this.postReadyFlushGate.clear()
 
     // Why: release the ptmx fd here or node-pty's _socket leaks the master fd until GC (docs/fix-pty-fd-leak.md).
@@ -759,11 +791,8 @@ export class Session {
   private transitionToReady(postMarkerBytesObserved = false): void {
     this._shellState = 'ready'
     this.shellReadyScanState = null
-    if (this.shellReadyTimer) {
-      clearTimeout(this.shellReadyTimer)
-      this.shellReadyTimer = null
-    }
-    if (this.preReadyStdinQueue.length === 0) {
+    this.clearShellReadyTimers()
+    if (this.preReadyStdinQueue.length === 0 && this.heldStartupCommand === null) {
       return
     }
     this.postReadyFlushGate.arm(postMarkerBytesObserved)
@@ -776,15 +805,71 @@ export class Session {
     }
     this._shellState = 'timed_out'
     this.releaseStartupDeviceAttributes()
-    this.releaseHeldShellReadyBytes()
-    this.flushPreReadyQueue()
+    if (this.heldStartupCommand === null || this.shellReadyLateMarkerGraceMs <= 0) {
+      this.releaseHeldShellReadyBytes()
+      this.flushPreReadyQueue({ includeStartupCommand: true })
+      return
+    }
+    // Why the queue splits here: keystrokes must go through or the pane is unusable, but the
+    // startup command has no one to notice it was dropped, so it keeps waiting. The marker scanner
+    // stays armed — a late marker is still proof the shell reads, and still has to be stripped.
+    this.flushPreReadyQueue({ includeStartupCommand: false })
+    this.shellReadyLateMarkerTimer = setTimeout(() => {
+      this.onShellReadyLateMarkerGraceExpired()
+    }, this.shellReadyLateMarkerGraceMs)
   }
 
-  private flushPreReadyQueue(): void {
+  private onShellReadyLateMarkerGraceExpired(): void {
+    this.shellReadyLateMarkerTimer = null
+    if (this._shellState !== 'timed_out' || this.heldStartupCommand === null) {
+      return
+    }
+    console.warn(
+      `[daemon/session] ${this.sessionId}: no shell-ready marker after ${
+        SHELL_READY_TIMEOUT_MS + this.shellReadyLateMarkerGraceMs
+      }ms; writing the startup command without proof the shell is reading it`
+    )
+    this.releaseHeldShellReadyBytes()
+    this.flushPreReadyQueue({ includeStartupCommand: true })
+  }
+
+  private flushPreReadyQueue(opts: { includeStartupCommand: boolean }): void {
+    const startupCommand = opts.includeStartupCommand ? this.heldStartupCommand : null
+    if (startupCommand !== null) {
+      this.heldStartupCommand = null
+    }
     const queued = this.preReadyStdinQueue
     this.preReadyStdinQueue = []
+    // Why first: the host writes it before any client input can arrive, so releasing it ahead of
+    // the queue is what preserves the order the caller asked for.
+    if (startupCommand !== null) {
+      this.subprocess.write(startupCommand)
+    }
     for (const data of queued) {
       this.subprocess.write(data)
+    }
+  }
+
+  /** The other non-delivery outcome: the session ended before the shell ever proved it was reading,
+   *  so the launch never happened. Silence here is what makes a lost session look like a healthy one. */
+  private reportUndeliveredStartupCommand(): void {
+    if (this.heldStartupCommand === null) {
+      return
+    }
+    this.heldStartupCommand = null
+    console.warn(
+      `[daemon/session] ${this.sessionId}: session ended before the shell-ready marker; its startup command was never delivered`
+    )
+  }
+
+  private clearShellReadyTimers(): void {
+    if (this.shellReadyTimer) {
+      clearTimeout(this.shellReadyTimer)
+      this.shellReadyTimer = null
+    }
+    if (this.shellReadyLateMarkerTimer) {
+      clearTimeout(this.shellReadyLateMarkerTimer)
+      this.shellReadyLateMarkerTimer = null
     }
   }
 

--- a/src/main/daemon/terminal-host-session-create.ts
+++ b/src/main/daemon/terminal-host-session-create.ts
@@ -123,7 +123,7 @@ export async function createOrAttachTerminalSession(
   if (opts.command && !subprocess.startupCommandDeliveredInShellArgs) {
     const submit = process.platform === 'win32' ? '\r' : '\n'
     // Why: only Orca-wrapped shells advertise the paste-safe startup barrier.
-    session.write(
+    session.writeStartupCommand(
       buildStartupCommandSubmission(opts.command, {
         submit,
         bracketedPasteSafe: shellReadySupported

--- a/src/renderer/src/components/settings/manage-sessions-format.ts
+++ b/src/renderer/src/components/settings/manage-sessions-format.ts
@@ -32,5 +32,10 @@ export function formatState(session: PtyManagementSession): string {
   if (session.shellState === 'pending') {
     return 'starting'
   }
+  // Why surfaced: the shell never proved it was reading, so any startup command this session was
+  // launched with may have gone nowhere. Reporting it beats a session that reads as healthy.
+  if (session.shellState === 'timed_out') {
+    return 'starting (unconfirmed)'
+  }
   return session.state
 }


### PR DESCRIPTION
Supersedes #13642, which @Jinwoo-H closed pending a deterministic reproduction. **That reproduction exists and is what this PR adds.**

A new pull request rather than a reopen, for a mechanical reason worth stating: I pushed the harness to the same branch on 2026-08-12 and answered the four clauses in a comment there, but **a closed pull request does not track new pushes** — #13642 still lists two commits and a head of `f8f2da3`, so the harness commit `442b11a` is invisible on it. `gh pr reopen 13642` fails with `GraphQL: Could not open the pull request. (reopenPullRequest)` on every attempt from my side. So from your view the ask looked unanswered. It was not, and this PR makes it visible.

**The fix is byte-for-byte the one you reviewed.** The two original commits are unchanged. The only new commit is the test file.

## The harness

`src/main/daemon/repro-13642-late-shell-ready-startup-command.test.ts`, run with:

```
npx vitest run --config config/vitest.config.ts src/main/daemon/repro-13642-late-shell-ready-startup-command.test.ts
```

The daemon's own `createPtySubprocess` starts a real shell on a real PTY and a real `Session` drives it — no mock subprocess, no fake timers. The fixture shell reaches its first prompt about two seconds in, long after the injected **250 ms** shell-ready deadline, and discards what was typed at it until then via a non-canonical `stty` plus `dd` drain, which is what a line editor does to typeahead when it takes the terminal with `tcsetattr(TCSAFLUSH)`. Only then does it emit `\033]777;orca-shell-ready\007` and start echoing each line it reads as `RAN:<line>`. The assertions count `RAN:` lines, so they measure what the shell **executed**, not what the tty echoed.

Your four points, in your order:

1. **Base: the marker arrives after the timeout and the command is lost.** `loses the startup command when the pre-fix path releases it at the deadline` delivers exactly the way `terminal-host-session-create.ts` did before this PR — `session.write()`, released when the deadline expires. It first waits for `shellState === 'timed_out'`, so the deadline provably expires before the marker, then types a sentinel after the marker: `sentinelRuns === 1`, `startupRuns === 0`. The pane is alive and reading; the launch is gone.
2. **Candidate: it executes exactly once when that late marker arrives.** `startupRuns === 1`, `shellState === 'ready'`, and the startup command ran before the later keystroke. A second case runs the same session against a shell that *buffers* typeahead instead of discarding it, guarding the doubled-send failure — a re-delivery firing at both the deadline and the marker would type an agent's launch line twice. It does not.
3. **Reverting the fix makes it fail again.** Both ways. Case 1 *is* the base behaviour, expressed as a delivery mode rather than a checkout, so red-before and green-after run side by side on every CI run. And the literal revert of `session.ts` + `terminal-host-session-create.ts` to `upstream/main` turns two cases red on the delivery assertion — behavioural, not a missing symbol, because the harness looks `writeStartupCommand` up and falls back to `write` when absent.
4. **Real daemon/session-to-PTY path, not mocked timers.** No fake timers, no stub subprocess: `createPtySubprocess` → real `bash` child → real PTY master/slave → `Session`. Every assertion is on bytes the child executed. The only injected value is the 250 ms deadline you said was fine to shorten.

A fourth case covers the other non-delivery outcome across the process boundary: the shell exits before ever emitting a marker, the command is never written, and the daemon logs "never delivered" instead of staying silent.

## Scope note, stated plainly

The harness drives `Session` rather than `createOrAttachTerminalSession`. Injecting a short timeout at the host level would disable the very behaviour under test — a caller-supplied `shellReadyTimeoutMs` is how Codex opts out of marker-gated delivery, and it sets the grace window to zero. Reaching through the host would have needed a new option on the create path, which is more surface than this PR should carry. That one-line host call site stays covered by the existing `terminal-host.test.ts` case, "queues startup commands through the session shell-ready barrier".

## Runs

Four cases green on this branch, five runs in a row at ~9 s each, including one with 24 CPU spinners pinning the machine. Nothing sleeps on wall-clock beyond the injected deadline — it waits on session state and on bytes from the child, and the discard window only widens under load. Windows is `describe.skip`, since the fixture shell is POSIX. `pnpm typecheck` and `pnpm lint` clean; `session.test.ts` and `terminal-host.test.ts` 98 passed.

The full point-by-point answer, including the re-measured field numbers and what did and did not reproduce on a second machine, is in [this comment on #13642](https://github.com/stablyai/orca/issues/13642#issuecomment-5263460690).

I have not touched the default timeout in this round — you asked for proof of the boundary, not a longer default.
