### PR TITLE
feat(browser): compose paired client host lifecycle

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -2588,6 +2588,7 @@
         "bounded client page-command dispatch and replay",
         "server-owned page-command issue and result ledger",
         "same-socket paired-runtime control requests",
+        "paired desktop browser-host lifecycle composition",
         "dedicated paired-runtime E2EE tunnel subscription"
       ],
       "platforms": ["macos", "linux", "windows"],
@@ -2598,7 +2599,7 @@
       "motivatingLinks": [
         "https://linear.app/stably/issue/STA-4150/refactor-remote-browser-to-client-hosted-electron-webviews"
       ],
-      "invariant": "A client-hosted browser network route exists only for an exact live server-owned browser-host lease, authority epoch, host generation, paired identity, execution-host revision or SSH provider authority, and server-owned route generation. A client page is usable only when its runtime ID, authority epoch, host identity and generation, logical page ID, page-host generation, current placement, and still-live lease all match atomically; a retired, retirement-pending, or server-placed page cannot be claimed as live client placement. Live logical placements and their identities are bounded, an occupied logical page cannot change placement until exact two-phase retirement completes, cancellation restores the same authority, and the runtime-wide page generation stays monotonic without tombstones. Server-issued page commands and results remain bounded, FIFO per page, immutable after admission, authenticated to the exact paired lease, attach connection, and live placement, replayable only when byte-equivalent, and outcome-unknown after authority or result-transport loss. Non-native descriptors require explicit capability negotiation and an exact runtime-minted lease-bound execution-host grant. Host selection never chooses arbitrarily, stale cleanup or settlement cannot remove a replacement, destination names remain unresolved until the execution host, credit returns only after writes settle, and route loss never falls back to desktop DNS or sockets. A main-owned local listener remains stable across upstream transport loss, rejects CONNECT while offline, accepts only a strictly newer tunnel generation, ignores superseded callbacks, and never reuses a stream ID within one generation. Pending opens, admitted open rate, nested control requests, per-route application bytes, aggregate browser-host/process bytes, claims, and socket sources remain bounded with exact release on settlement and retirement. Queued transport drain yields after a bounded quantum. The local SOCKS endpoint accepts only loopback CONNECT and rejects unsupported commands.",
+      "invariant": "A client-hosted browser network route exists only for an exact live server-owned browser-host lease, authority epoch, host generation, paired identity, execution-host revision or SSH provider authority, and server-owned route generation. A client page is usable only when its runtime ID, authority epoch, host identity and generation, logical page ID, page-host generation, current placement, and still-live lease all match atomically; a retired, retirement-pending, or server-placed page cannot be claimed as live client placement. Live logical placements and their identities are bounded, an occupied logical page cannot change placement until exact two-phase retirement completes, cancellation restores the same authority, and the runtime-wide page generation stays monotonic without tombstones. Server-issued page commands and results remain bounded, FIFO per page, immutable after admission, authenticated to the exact paired lease, attach connection, and live placement, replayable only when byte-equivalent, and outcome-unknown after authority or result-transport loss. Desktop composition installs exact command authority before delivery, keeps result settlements below nested-request capacity, and closes transport before aborting owned handlers. Non-native descriptors require explicit capability negotiation and an exact runtime-minted lease-bound execution-host grant. Host selection never chooses arbitrarily, stale cleanup or settlement cannot remove a replacement, destination names remain unresolved until the execution host, credit returns only after writes settle, and route loss never falls back to desktop DNS or sockets. A main-owned local listener remains stable across upstream transport loss, rejects CONNECT while offline, accepts only a strictly newer tunnel generation, ignores superseded callbacks, and never reuses a stream ID within one generation. Pending opens, admitted open rate, nested control requests, per-route application bytes, aggregate browser-host/process bytes, claims, and socket sources remain bounded with exact release on settlement and retirement. Queued transport drain yields after a bounded quantum. The local SOCKS endpoint accepts only loopback CONNECT and rejects unsupported commands.",
       "oracle": "Attach two browser hosts and require unqualified selection to fail ambiguous while exact selection succeeds. Reject a second identity on one connection and a fifth identity for one paired device, release one exact lease, then admit its replacement without starving another device. Saturate the browser-host long-poll sub-cap, require an ordinary wait to remain admitted, close the socket, and prove both counters and handlers release. Replace one same-device connection, require the old subscription and route to fence, then prove late old cleanup leaves the new generation live. Mint an exact execution-host grant, reject a different key, prove late old grant cleanup leaves its replacement, and invalidate every grant with lease replacement. Reject client-to-client, client-to-server, server-to-server, and server-to-client placement overwrite until exact retirement. Begin retirement once idempotently, reject client use and every replacement while pending, cancel the exact token to restore the same placement, and reject delayed cancellation or completion after a newer retirement begins. Complete only the exact pending token, retain capacity until completion, and require a reused client page ID to receive a higher global generation without retaining a tombstone. Require a client page through the exact runtime, epoch, host, and page tuple; reject every mismatch, released or replaced leases, retirement-pending pages, retired pages, server placements, invalid identities, and the 257th live placement. Admit 16 pending destination opens and reject the seventeenth until one connects; admit 128 opens in one monotonic 10-second window and reject the 129th until the window expires. Fill 8 MiB across destination-to-client queues and separately across unsettled client-to-destination writes, release one exact retired stream, admit one replacement, and require the next byte claim to close the route without stale-callback or reentrant-close underflow. Across multiple routes, charge application copies, encrypted queue entries, and dynamic native socket bytes to one 32 MiB browser-host and 128 MiB process ceiling; reject zero-byte claim/socket-source floods, fence released leases, synchronously release JavaScript queue claims while retaining native claims through exact socket close, and yield a parked queue after four frames without reordering. Route nested responses by exact ID under reordering, reject unknown and duplicate IDs, cap pending requests and queued bytes, and tear down every concurrent waiter once on timeout or close. Drive one real paired attach, command, and result through one exact connection ID; reject missing send support and malformed or wrong-runtime acknowledgements while preserving old non-v1 attaches. Drop an authenticated transport, require the same listener to reject CONNECT before and during reconnect, attach the exact existing native v1 payload and capability pair to a strictly newer generation, ignore late old callbacks, and roll an exhausted stream-ID ledger only by replacing the generation. Require SSH descriptors to add an execution-host capability and exact grant, reject missing grants and stale provider authority before resolver or binary registration, pass exact domains to ssh2 and system-SSH SOCKS without local resolution, sanitize connector diagnostics, and close every stream and standalone route process once on timeout, synchronous failure, or rotation. Drive the accepted lease through real paired E2EE native SOCKS-to-HTTP and ephemeral Docker ssh2 remote-only DNS journeys, then exercise exact frame, credit, half-close, stale-stream, remote-DNS, unsupported-command, offline, and teardown assertions.",
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/browser-host-page-retirement.test.ts src/main/runtime/browser-host-page-placement-replacement.test.ts src/main/runtime/browser-host-page-placement.test.ts src/main/runtime/browser-host-lease-registry.test.ts",
@@ -2610,6 +2611,7 @@
         "pnpm exec vitest run --config config/vitest.config.ts src/shared/remote-runtime-client.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/shared/remote-runtime-subscription-request.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/main/browser/browser-client-host-command-dispatcher.test.ts",
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/browser/paired-runtime-browser-client-host.test.ts src/main/browser/paired-runtime-browser-host-lease.test.ts src/main/browser/browser-client-host-command-dispatcher.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/browser-host-command-ledger.test.ts src/main/runtime/browser-host-command-ledger-capacity.test.ts src/main/runtime/browser-host-lease-registry.test.ts src/main/runtime/rpc/methods/browser-client-host.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/browser-host-lease-registry.test.ts src/main/browser/browser-network-deferred-socket.test.ts src/main/browser/browser-network-execution-route.test.ts src/main/browser/paired-runtime-browser-network-route.test.ts src/main/runtime/rpc/methods/browser-network-tunnel.test.ts src/main/browser/ssh-browser-network-execution-route.test.ts src/main/browser/system-ssh-socks-client-socket.test.ts src/main/ssh/system-ssh-dynamic-forward-process.test.ts src/shared/browser-client-host-protocol.test.ts src/shared/browser-network-capabilities.test.ts src/main/ssh/system-ssh-forward-process.test.ts src/main/ssh/ssh-system-fallback.test.ts src/main/ssh/ssh-port-forward.test.ts",
         "ORCA_RUN_DOCKER_SSH_BROWSER_E2E=1 pnpm exec vitest run --config config/vitest.config.ts tests/e2e/ssh-browser-network-execution-route.docker.unit.test.ts"
@@ -2627,6 +2629,7 @@
         "src/main/runtime/runtime-rpc-browser-host-admission.test.ts",
         "src/main/runtime/rpc/methods/browser-client-host.test.ts",
         "src/main/browser/paired-runtime-browser-host-lease.test.ts",
+        "src/main/browser/paired-runtime-browser-client-host.test.ts",
         "src/main/browser/browser-client-host-command-dispatcher.test.ts",
         "src/main/browser/browser-network-tunnel-session.test.ts",
         "src/main/browser/browser-network-tunnel-session-aggregate-memory.test.ts",
@@ -2717,7 +2720,19 @@
             "stale authority commands close the exact lease before handler delivery",
             "completed and failed results submit exact command authority on the established subscription",
             "missing result transport, handler failure, server rejection, and malformed or wrong-runtime acknowledgement close the lease",
-            "exact duplicate result acknowledgement remains idempotent"
+            "exact duplicate result acknowledgement remains idempotent",
+            "result settlement concurrency stays below nested-request capacity and excess unsettled results fail closed"
+          ]
+        },
+        {
+          "file": "src/main/browser/paired-runtime-browser-client-host.test.ts",
+          "assertions": [
+            "exact dispatcher authority exists before the first same-socket command can arrive",
+            "explicit close shuts transport before aborting every owned page handler",
+            "dispatcher abort still runs when lease cleanup rejects",
+            "lease transport failure aborts every owned handler and reports one terminal error",
+            "retirement and forgetting accept only the exact owned page generation",
+            "timed-out retirement stays fenced until the exact late handler settles"
           ]
         },
         {
@@ -2953,6 +2968,15 @@
         }
       ],
       "evidenceRuns": [
+        {
+          "date": "2026-08-14",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/browser/paired-runtime-browser-client-host.test.ts src/main/browser/paired-runtime-browser-host-lease.test.ts src/main/browser/browser-client-host-command-dispatcher.test.ts",
+          "result": "passed",
+          "durationSeconds": 0.8,
+          "summary": "Fifty tests passed synchronous authority activation, hard 16/256 result bounds, exact transport-close-before-handler-abort ordering, cleanup rejection with guaranteed abort, same-socket result settlement, exact page retirement and forgetting, and late non-cooperative retirement settlement. The broader runtime/browser/shared run passed 9,711 tests with 24 existing skips."
+        },
         {
           "date": "2026-08-14",
           "runner": "local",

--- a/src/main/browser/browser-client-host-command-authority.ts
+++ b/src/main/browser/browser-client-host-command-authority.ts
@@ -23,3 +23,16 @@ export function snapshotBrowserClientHostLeaseAuthority(
 ): BrowserClientHostLeaseAuthority {
   return Object.freeze({ ...authority })
 }
+
+export function sameBrowserClientHostLeaseAuthority(
+  left: BrowserClientHostLeaseAuthority,
+  right: BrowserClientHostLeaseAuthority
+): boolean {
+  return (
+    left.authorityRuntimeId === right.authorityRuntimeId &&
+    left.authorityEpoch === right.authorityEpoch &&
+    left.browserHostClientId === right.browserHostClientId &&
+    left.browserHostGeneration === right.browserHostGeneration &&
+    left.pageCommandProtocolVersion === right.pageCommandProtocolVersion
+  )
+}

--- a/src/main/browser/browser-host-command-result-settler.ts
+++ b/src/main/browser/browser-host-command-result-settler.ts
@@ -1,0 +1,117 @@
+import type {
+  BrowserClientHostCommandEvent,
+  BrowserClientHostCommandResult
+} from '../../shared/browser-client-host-protocol'
+
+// Preserve half of the subscription's 32 nested-request slots for future control traffic.
+const DEFAULT_MAX_CONCURRENT_COMMAND_RESULTS = 16
+// Mirror the server ledger ceiling so an honest host never over-admits completed work.
+const DEFAULT_MAX_UNSETTLED_COMMAND_RESULTS = 256
+
+export type BrowserHostCommandResultAdmission = { active: boolean }
+
+type PendingCommandResult = {
+  admission: BrowserHostCommandResultAdmission
+  command: BrowserClientHostCommandEvent
+  result: BrowserClientHostCommandResult
+  rejectReady: (error: Error) => void
+}
+
+type BrowserHostCommandResultSettlerOptions = {
+  maxConcurrent?: number
+  maxUnsettled?: number
+  submit: (
+    command: BrowserClientHostCommandEvent,
+    result: BrowserClientHostCommandResult
+  ) => Promise<void>
+  onError: (error: Error, rejectReady: (error: Error) => void) => void
+}
+
+export class BrowserHostCommandResultSettler {
+  private readonly maxConcurrent: number
+  private readonly maxUnsettled: number
+  private readonly pending: PendingCommandResult[] = []
+  private unsettled = 0
+  private inFlight = 0
+  private closed = false
+
+  constructor(private readonly options: BrowserHostCommandResultSettlerOptions) {
+    this.maxConcurrent = boundedLimit(options.maxConcurrent, DEFAULT_MAX_CONCURRENT_COMMAND_RESULTS)
+    this.maxUnsettled = boundedLimit(options.maxUnsettled, DEFAULT_MAX_UNSETTLED_COMMAND_RESULTS)
+    if (this.maxConcurrent > this.maxUnsettled) {
+      throw new Error('Browser host command result limits are inconsistent')
+    }
+  }
+
+  admit(): BrowserHostCommandResultAdmission | null {
+    if (this.closed || this.unsettled >= this.maxUnsettled) {
+      return null
+    }
+    this.unsettled += 1
+    return { active: true }
+  }
+
+  enqueue(
+    admission: BrowserHostCommandResultAdmission,
+    command: BrowserClientHostCommandEvent,
+    result: BrowserClientHostCommandResult,
+    rejectReady: (error: Error) => void
+  ): void {
+    if (this.closed) {
+      this.release(admission)
+      return
+    }
+    this.pending.push({ admission, command, result, rejectReady })
+    this.drain()
+  }
+
+  release(admission: BrowserHostCommandResultAdmission): void {
+    if (!admission.active) {
+      return
+    }
+    admission.active = false
+    this.unsettled -= 1
+  }
+
+  close(): void {
+    if (this.closed) {
+      return
+    }
+    this.closed = true
+    for (const pending of this.pending) {
+      this.release(pending.admission)
+    }
+    this.pending.length = 0
+  }
+
+  private drain(): void {
+    while (!this.closed && this.inFlight < this.maxConcurrent && this.pending.length > 0) {
+      const pending = this.pending.shift()
+      if (!pending) {
+        return
+      }
+      this.inFlight += 1
+      void Promise.resolve()
+        .then(() => this.options.submit(pending.command, pending.result))
+        .catch((error) =>
+          this.options.onError(
+            error instanceof Error ? error : new Error(String(error)),
+            pending.rejectReady
+          )
+        )
+        .finally(() => {
+          this.inFlight -= 1
+          this.release(pending.admission)
+          this.drain()
+        })
+    }
+  }
+}
+
+function boundedLimit(value: number | undefined, maximum: number): number {
+  const resolved = value ?? maximum
+  if (!Number.isInteger(resolved) || resolved < 1 || resolved > maximum) {
+    throw new Error('Browser host command result limit is invalid')
+  }
+  return resolved
+}

--- a/src/main/browser/paired-runtime-browser-client-host.test.ts
+++ b/src/main/browser/paired-runtime-browser-client-host.test.ts
@@ -1,0 +1,313 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { PairingOffer } from '../../shared/pairing'
+import type {
+  BrowserClientHostCommandEvent,
+  BrowserClientHostCommandResult
+} from '../../shared/browser-client-host-protocol'
+import type {
+  RemoteRuntimeSubscription,
+  RemoteRuntimeSubscriptionCallbacks
+} from '../../shared/remote-runtime-client'
+import { RemoteRuntimeClientError } from '../../shared/remote-runtime-client-error'
+
+const { subscribeRemoteRuntimeRequestMock } = vi.hoisted(() => ({
+  subscribeRemoteRuntimeRequestMock: vi.fn()
+}))
+
+vi.mock('../../shared/remote-runtime-client', () => ({
+  subscribeRemoteRuntimeRequest: subscribeRemoteRuntimeRequestMock
+}))
+
+import { PairedRuntimeBrowserClientHost } from './paired-runtime-browser-client-host'
+import { PairedRuntimeBrowserHostLease } from './paired-runtime-browser-host-lease'
+
+const pairing = {
+  v: 2,
+  endpoint: 'ws://127.0.0.1:6768',
+  deviceToken: 'device-token',
+  publicKeyB64: 'public-key',
+  pairedDeviceId: 'device-a',
+  scope: 'runtime'
+} as PairingOffer
+
+afterEach(() => {
+  subscribeRemoteRuntimeRequestMock.mockReset()
+  vi.restoreAllMocks()
+})
+
+describe('PairedRuntimeBrowserClientHost', () => {
+  it('constructs command authority before the first command can arrive', async () => {
+    const { callbacks, sendRequest } = subscribeHost()
+    const handler = vi.fn((_command: BrowserClientHostCommandEvent, _signal: AbortSignal) => ({
+      status: 'completed' as const
+    }))
+    const host = createHost(handler)
+    const starting = host.start()
+    await vi.waitFor(() => expect(callbacks.current).toBeDefined())
+
+    callbacks.current!.onResponse(readyResponse())
+    callbacks.current!.onResponse(commandResponse())
+
+    await expect(starting).resolves.toMatchObject({
+      authorityRuntimeId: 'runtime-a',
+      authorityEpoch: 'epoch-a',
+      browserHostGeneration: 4,
+      pageCommandProtocolVersion: 1
+    })
+    await vi.waitFor(() => expect(handler).toHaveBeenCalledOnce())
+    expect(handler.mock.calls[0][0]).toMatchObject({
+      browserPageId: 'page-a',
+      pageHostGeneration: 1
+    })
+    await vi.waitFor(() => expect(sendRequest).toHaveBeenCalledOnce())
+    await host.close()
+  })
+
+  it('closes transport first and aborts every owned page handler', async () => {
+    const { callbacks, close } = subscribeHost()
+    const order: string[] = []
+    close.mockImplementation(() => {
+      order.push('transport-close')
+    })
+    const observed: { signal: AbortSignal | null } = { signal: null }
+    const handler = vi.fn(
+      (_command: BrowserClientHostCommandEvent, signal: AbortSignal) =>
+        new Promise<BrowserClientHostCommandResult>((resolve) => {
+          observed.signal = signal
+          signal.addEventListener(
+            'abort',
+            () => {
+              order.push('handler-abort')
+              resolve({ status: 'failed', errorCode: 'browser_host_command_cancelled' })
+            },
+            { once: true }
+          )
+        })
+    )
+    const host = createHost(handler)
+    const starting = host.start()
+    await vi.waitFor(() => expect(callbacks.current).toBeDefined())
+    callbacks.current!.onResponse(readyResponse())
+    await starting
+    callbacks.current!.onResponse(commandResponse())
+    await vi.waitFor(() => expect(handler).toHaveBeenCalledOnce())
+
+    await expect(host.close()).resolves.toBe(true)
+
+    expect(close).toHaveBeenCalledOnce()
+    expect(observed.signal?.aborted).toBe(true)
+    expect(order).toEqual(['transport-close', 'handler-abort'])
+  })
+
+  it('aborts owned handlers even when lease cleanup rejects', async () => {
+    const { callbacks } = subscribeHost()
+    let aborted = false
+    const host = createHost(
+      (_command, signal) =>
+        new Promise<BrowserClientHostCommandResult>((resolve) => {
+          signal.addEventListener(
+            'abort',
+            () => {
+              aborted = true
+              resolve({ status: 'failed', errorCode: 'browser_host_command_cancelled' })
+            },
+            { once: true }
+          )
+        })
+    )
+    const starting = host.start()
+    await vi.waitFor(() => expect(callbacks.current).toBeDefined())
+    callbacks.current!.onResponse(readyResponse())
+    await starting
+    callbacks.current!.onResponse(commandResponse())
+    await vi.waitFor(() => expect(aborted).toBe(false))
+    vi.spyOn(PairedRuntimeBrowserHostLease.prototype, 'close').mockRejectedValueOnce(
+      new Error('lease cleanup failed')
+    )
+
+    await expect(host.close()).rejects.toThrow('lease cleanup failed')
+    expect(aborted).toBe(true)
+  })
+
+  it('preserves a falsy lease cleanup rejection across cached close calls', async () => {
+    const host = createHost(() => ({ status: 'completed' }))
+    vi.spyOn(PairedRuntimeBrowserHostLease.prototype, 'close').mockRejectedValueOnce(undefined)
+
+    await expect(host.close()).rejects.toThrow('undefined')
+    await expect(host.close()).rejects.toThrow('undefined')
+  })
+
+  it('aborts owned handlers when the lease transport fails', async () => {
+    const { callbacks } = subscribeHost()
+    const onError = vi.fn()
+    let aborted = false
+    const host = createHost(
+      (_command, signal) =>
+        new Promise<BrowserClientHostCommandResult>((resolve) => {
+          signal.addEventListener(
+            'abort',
+            () => {
+              aborted = true
+              resolve({ status: 'failed', errorCode: 'browser_host_command_cancelled' })
+            },
+            { once: true }
+          )
+        }),
+      onError
+    )
+    const starting = host.start()
+    await vi.waitFor(() => expect(callbacks.current).toBeDefined())
+    callbacks.current!.onResponse(readyResponse())
+    await starting
+    callbacks.current!.onResponse(commandResponse())
+    await vi.waitFor(() => expect(aborted).toBe(false))
+
+    callbacks.current!.onError(
+      new RemoteRuntimeClientError('remote_runtime_unavailable', 'transport failed')
+    )
+
+    await vi.waitFor(() => expect(aborted).toBe(true))
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'transport failed' }))
+  })
+
+  it('retires and forgets only the exact page generation', async () => {
+    const { callbacks } = subscribeHost()
+    const handler = vi.fn(
+      (_command: BrowserClientHostCommandEvent, signal: AbortSignal) =>
+        new Promise<BrowserClientHostCommandResult>((resolve) => {
+          signal.addEventListener(
+            'abort',
+            () => resolve({ status: 'failed', errorCode: 'browser_host_command_cancelled' }),
+            { once: true }
+          )
+        })
+    )
+    const host = createHost(handler)
+    const starting = host.start()
+    await vi.waitFor(() => expect(callbacks.current).toBeDefined())
+    callbacks.current!.onResponse(readyResponse())
+    await starting
+    callbacks.current!.onResponse(commandResponse())
+    await vi.waitFor(() => expect(handler).toHaveBeenCalledOnce())
+
+    await expect(host.retirePage('page-a', 2)).rejects.toThrow('browser_host_page_generation_stale')
+    await expect(host.retirePage('page-a', 1)).resolves.toBe(true)
+    expect(host.forgetPage('page-a', 2)).toBe(false)
+    expect(host.forgetPage('page-a', 1)).toBe(true)
+    await host.close()
+  })
+
+  it('keeps timed-out retirement fenced until the exact late handler settles', async () => {
+    const { callbacks } = subscribeHost()
+    const stuck = deferredCommandResult()
+    const host = createHost(() => stuck.promise, undefined, { joinTimeoutMs: 10 })
+    const starting = host.start()
+    await vi.waitFor(() => expect(callbacks.current).toBeDefined())
+    callbacks.current!.onResponse(readyResponse())
+    await starting
+    callbacks.current!.onResponse(commandResponse())
+
+    await expect(host.retirePage('page-a', 1)).resolves.toBe(false)
+    expect(host.forgetPage('page-a', 1)).toBe(false)
+    stuck.resolve({ status: 'completed' })
+    await expect(host.retirePage('page-a', 1)).resolves.toBe(true)
+    expect(host.forgetPage('page-a', 1)).toBe(true)
+    await host.close()
+  })
+})
+
+function subscribeHost(): {
+  callbacks: { current?: RemoteRuntimeSubscriptionCallbacks }
+  close: ReturnType<typeof vi.fn>
+  sendRequest: ReturnType<typeof vi.fn>
+} {
+  const callbacks: { current?: RemoteRuntimeSubscriptionCallbacks } = {}
+  const close = vi.fn()
+  const sendRequest = vi.fn().mockResolvedValue({
+    id: 'command-result',
+    ok: true,
+    result: { accepted: true },
+    _meta: { runtimeId: 'runtime-a' }
+  })
+  subscribeRemoteRuntimeRequestMock.mockImplementationOnce(
+    async (...args: unknown[]): Promise<RemoteRuntimeSubscription> => {
+      callbacks.current = args[4] as RemoteRuntimeSubscriptionCallbacks
+      return {
+        requestId: 'browser-host',
+        close,
+        sendBinary: () => false,
+        sendRequest
+      }
+    }
+  )
+  return { callbacks, close, sendRequest }
+}
+
+function createHost(
+  handler: (
+    command: BrowserClientHostCommandEvent,
+    signal: AbortSignal
+  ) => BrowserClientHostCommandResult | Promise<BrowserClientHostCommandResult>,
+  onError?: (error: Error) => void,
+  dispatcher?: { joinTimeoutMs?: number }
+): PairedRuntimeBrowserClientHost {
+  return new PairedRuntimeBrowserClientHost({
+    pairing,
+    authorityRuntimeId: 'runtime-a',
+    browserHostClientId: 'host-a',
+    hostCapabilities: ['webview'],
+    handler,
+    onError,
+    dispatcher
+  })
+}
+
+function deferredCommandResult(): {
+  promise: Promise<BrowserClientHostCommandResult>
+  resolve: (result: BrowserClientHostCommandResult) => void
+} {
+  let resolve = (_result: BrowserClientHostCommandResult): void => {}
+  const promise = new Promise<BrowserClientHostCommandResult>((innerResolve) => {
+    resolve = innerResolve
+  })
+  return { promise, resolve }
+}
+
+function readyResponse() {
+  return {
+    id: 'browser-host',
+    ok: true as const,
+    result: {
+      type: 'ready' as const,
+      authorityEpoch: 'epoch-a',
+      browserHostGeneration: 4,
+      pageCommandProtocolVersion: 1 as const
+    },
+    _meta: { runtimeId: 'runtime-a' }
+  }
+}
+
+function commandResponse() {
+  return {
+    id: 'browser-host',
+    ok: true as const,
+    result: {
+      type: 'command' as const,
+      pageCommandProtocolVersion: 1 as const,
+      authorityRuntimeId: 'runtime-a',
+      authorityEpoch: 'epoch-a',
+      browserHostClientId: 'host-a',
+      browserHostGeneration: 4,
+      browserPageId: 'page-a',
+      pageHostGeneration: 1,
+      commandSequence: 1,
+      commandId: 'command-a',
+      command: {
+        type: 'createPage' as const,
+        browserProfileId: 'default',
+        executionHostKey: 'native:runtime-a:1'
+      }
+    },
+    _meta: { runtimeId: 'runtime-a' }
+  }
+}

--- a/src/main/browser/paired-runtime-browser-client-host.ts
+++ b/src/main/browser/paired-runtime-browser-client-host.ts
@@ -1,0 +1,122 @@
+import type {
+  BrowserClientHostCommandEvent,
+  BrowserClientHostCommandResult,
+  BrowserClientHostLeaseAuthority
+} from '../../shared/browser-client-host-protocol'
+import type { PairingOffer } from '../../shared/pairing'
+import type { RemoteRuntimeSubscriptionOptions } from '../../shared/remote-runtime-client'
+import { BrowserClientHostCommandDispatcher } from './browser-client-host-command-dispatcher'
+import type { CommandHandler, DispatcherOptions } from './browser-client-host-command-state'
+import { PairedRuntimeBrowserHostLease } from './paired-runtime-browser-host-lease'
+
+type DispatcherLimits = Omit<DispatcherOptions, 'authority' | 'handler'>
+
+export type PairedRuntimeBrowserClientHostOptions = {
+  pairing: PairingOffer
+  authorityRuntimeId: string
+  browserHostClientId: string
+  hostCapabilities: readonly string[]
+  handler: CommandHandler
+  dispatcher?: DispatcherLimits
+  timeoutMs?: number
+  subscription?: RemoteRuntimeSubscriptionOptions
+  maxConcurrentCommandResults?: number
+  maxUnsettledCommandResults?: number
+  onError?: (error: Error) => void
+}
+
+export class PairedRuntimeBrowserClientHost {
+  private readonly lease: PairedRuntimeBrowserHostLease
+  private dispatcher: BrowserClientHostCommandDispatcher | null = null
+  private closePromise: Promise<boolean> | null = null
+  private closed = false
+  private errorReported = false
+
+  constructor(private readonly options: PairedRuntimeBrowserClientHostOptions) {
+    this.lease = new PairedRuntimeBrowserHostLease({
+      pairing: options.pairing,
+      authorityRuntimeId: options.authorityRuntimeId,
+      browserHostClientId: options.browserHostClientId,
+      hostCapabilities: options.hostCapabilities,
+      pageCommandProtocolVersion: 1,
+      onAuthority: (authority) => this.activateDispatcher(authority),
+      onPageCommand: (command) => this.dispatch(command),
+      timeoutMs: options.timeoutMs,
+      subscription: options.subscription,
+      maxConcurrentCommandResults: options.maxConcurrentCommandResults,
+      maxUnsettledCommandResults: options.maxUnsettledCommandResults,
+      onError: (error) => this.handleLeaseError(error)
+    })
+  }
+
+  start(): Promise<BrowserClientHostLeaseAuthority> {
+    if (this.closed) {
+      return Promise.reject(new Error('Browser client host is closed'))
+    }
+    return this.lease.start()
+  }
+
+  close(error = new Error('Browser client host is closed')): Promise<boolean> {
+    this.closePromise ??= this.closeHost(error)
+    return this.closePromise
+  }
+
+  retirePage(browserPageId: string, pageHostGeneration: number): Promise<boolean> {
+    if (!this.dispatcher || this.closed) {
+      return Promise.reject(new Error('Browser client host dispatcher is unavailable'))
+    }
+    return this.dispatcher.retirePage(browserPageId, pageHostGeneration)
+  }
+
+  forgetPage(browserPageId: string, pageHostGeneration: number): boolean {
+    return this.dispatcher?.forgetPage(browserPageId, pageHostGeneration) ?? false
+  }
+
+  private activateDispatcher(authority: BrowserClientHostLeaseAuthority): void {
+    if (this.closed || this.dispatcher) {
+      throw new Error('Browser client host authority is unavailable')
+    }
+    this.dispatcher = new BrowserClientHostCommandDispatcher({
+      authority,
+      handler: this.options.handler,
+      ...this.options.dispatcher
+    })
+  }
+
+  private dispatch(
+    command: BrowserClientHostCommandEvent
+  ): Promise<BrowserClientHostCommandResult> {
+    if (!this.dispatcher || this.closed) {
+      return Promise.reject(new Error('Browser client host dispatcher is unavailable'))
+    }
+    return this.dispatcher.dispatch(command)
+  }
+
+  private async closeHost(error: Error): Promise<boolean> {
+    this.closed = true
+    let leaseError: Error | null = null
+    try {
+      await this.lease.close(error)
+    } catch (caught) {
+      leaseError = caught instanceof Error ? caught : new Error(String(caught))
+    }
+    const settled = this.dispatcher ? await this.dispatcher.close() : true
+    if (leaseError !== null) {
+      throw leaseError
+    }
+    return settled
+  }
+
+  private handleLeaseError(error: Error): void {
+    void this.close(error).catch(() => undefined)
+    if (this.errorReported) {
+      return
+    }
+    this.errorReported = true
+    try {
+      this.options.onError?.(error)
+    } catch {
+      // Reporting cannot retain a failed browser host.
+    }
+  }
+}

--- a/src/main/browser/paired-runtime-browser-host-lease-options.ts
+++ b/src/main/browser/paired-runtime-browser-host-lease-options.ts
@@ -1,0 +1,24 @@
+import type {
+  BrowserClientHostCommandEvent,
+  BrowserClientHostCommandResult,
+  BrowserClientHostLeaseAuthority
+} from '../../shared/browser-client-host-protocol'
+import type { PairingOffer } from '../../shared/pairing'
+import type { RemoteRuntimeSubscriptionOptions } from '../../shared/remote-runtime-client'
+
+export type PairedRuntimeBrowserHostLeaseOptions = {
+  pairing: PairingOffer
+  authorityRuntimeId: string
+  browserHostClientId: string
+  hostCapabilities: readonly string[]
+  pageCommandProtocolVersion?: 1
+  onPageCommand?: (
+    command: BrowserClientHostCommandEvent
+  ) => BrowserClientHostCommandResult | Promise<BrowserClientHostCommandResult>
+  onAuthority?: (authority: BrowserClientHostLeaseAuthority) => void
+  maxConcurrentCommandResults?: number
+  maxUnsettledCommandResults?: number
+  timeoutMs?: number
+  subscription?: RemoteRuntimeSubscriptionOptions
+  onError?: (error: Error) => void
+}

--- a/src/main/browser/paired-runtime-browser-host-lease.test.ts
+++ b/src/main/browser/paired-runtime-browser-host-lease.test.ts
@@ -35,6 +35,14 @@ afterEach(() => {
 })
 
 describe('PairedRuntimeBrowserHostLease', () => {
+  it.each([
+    [{ maxConcurrentCommandResults: 17 }, 'limit is invalid'],
+    [{ maxUnsettledCommandResults: 257 }, 'limit is invalid'],
+    [{ maxConcurrentCommandResults: 2, maxUnsettledCommandResults: 1 }, 'limits are inconsistent']
+  ])('rejects unsafe command-result limits', (limits, expectedMessage) => {
+    expect(() => createLease(limits)).toThrow(expectedMessage)
+  })
+
   it('returns only the runtime-issued epoch and generation', async () => {
     let callbacks: RemoteRuntimeSubscriptionCallbacks | undefined
     const close = vi.fn()
@@ -177,6 +185,81 @@ describe('PairedRuntimeBrowserHostLease', () => {
     await vi.waitFor(() => expect(sendRequest).toHaveBeenCalledTimes(2))
     expect(close).not.toHaveBeenCalled()
     await lease.close()
+  })
+
+  it('bounds concurrent command-result requests below the subscription request ceiling', async () => {
+    const acknowledgements = Array.from({ length: 8 }, () => deferredCommandResultAck())
+    let active = 0
+    let peak = 0
+    const sendRequest = vi.fn().mockImplementation(() => {
+      const acknowledgement = acknowledgements[sendRequest.mock.calls.length - 1]
+      active += 1
+      peak = Math.max(peak, active)
+      return acknowledgement.promise.finally(() => {
+        active -= 1
+      })
+    })
+    const { callbacks } = await subscribeLease({ sendRequest })
+    const lease = createLease({
+      maxConcurrentCommandResults: 4,
+      pageCommandProtocolVersion: 1,
+      onPageCommand: () => ({ status: 'completed' })
+    })
+    const starting = lease.start()
+    await vi.waitFor(() => expect(callbacks.current).toBeDefined())
+    callbacks.current!.onResponse(readyResponse({ pageCommandProtocolVersion: 1 }))
+    await starting
+
+    for (let index = 0; index < acknowledgements.length; index += 1) {
+      callbacks.current!.onResponse(
+        commandResponse({
+          browserPageId: `page-${index}`,
+          pageHostGeneration: index + 1,
+          commandId: `command-${index}`
+        })
+      )
+    }
+
+    await vi.waitFor(() => expect(sendRequest).toHaveBeenCalledTimes(4))
+    expect(peak).toBe(4)
+    acknowledgements[0].resolve(commandResultAck(true))
+    await vi.waitFor(() => expect(sendRequest).toHaveBeenCalledTimes(5))
+    expect(peak).toBe(4)
+    await lease.close()
+  })
+
+  it('fails closed when unsettled command results exceed the explicit lease bound', async () => {
+    const never = new Promise<never>(() => {})
+    const { callbacks, close } = await subscribeLease({
+      sendRequest: vi.fn(() => never)
+    })
+    const onError = vi.fn()
+    const lease = createLease({
+      maxConcurrentCommandResults: 1,
+      maxUnsettledCommandResults: 2,
+      pageCommandProtocolVersion: 1,
+      onPageCommand: () => ({ status: 'completed' }),
+      onError
+    })
+    const starting = lease.start()
+    await vi.waitFor(() => expect(callbacks.current).toBeDefined())
+    callbacks.current!.onResponse(readyResponse({ pageCommandProtocolVersion: 1 }))
+    await starting
+
+    for (let index = 0; index < 3; index += 1) {
+      callbacks.current!.onResponse(
+        commandResponse({
+          browserPageId: `page-${index}`,
+          pageHostGeneration: index + 1,
+          commandId: `command-${index}`
+        })
+      )
+    }
+
+    await vi.waitFor(() => expect(close).toHaveBeenCalledOnce())
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Browser host command result capacity reached' })
+    )
   })
 
   it.each([
@@ -560,6 +643,8 @@ async function subscribeLease(options?: { sendRequest?: ReturnType<typeof vi.fn>
 
 function createLease(
   overrides: {
+    maxConcurrentCommandResults?: number
+    maxUnsettledCommandResults?: number
     onError?: (error: Error) => void
     onPageCommand?: (
       command: BrowserClientHostCommandEvent
@@ -590,7 +675,13 @@ function readyResponse(overrides: { pageCommandProtocolVersion?: 1 } = {}) {
   }
 }
 
-function commandResponse() {
+function commandResponse(
+  overrides: {
+    browserPageId?: string
+    pageHostGeneration?: number
+    commandId?: string
+  } = {}
+) {
   return {
     id: 'browser-host',
     ok: true as const,
@@ -609,10 +700,22 @@ function commandResponse() {
         type: 'createPage' as const,
         browserProfileId: 'default',
         executionHostKey: 'native:runtime-a:1'
-      }
+      },
+      ...overrides
     },
     _meta: { runtimeId: 'runtime-a' }
   }
+}
+
+function deferredCommandResultAck(): {
+  promise: Promise<ReturnType<typeof commandResultAck>>
+  resolve: (value: ReturnType<typeof commandResultAck>) => void
+} {
+  let resolve = (_value: ReturnType<typeof commandResultAck>): void => {}
+  const promise = new Promise<ReturnType<typeof commandResultAck>>((innerResolve) => {
+    resolve = innerResolve
+  })
+  return { promise, resolve }
 }
 
 function commandResultAck(accepted: boolean, runtimeId = 'runtime-a') {

--- a/src/main/browser/paired-runtime-browser-host-lease.ts
+++ b/src/main/browser/paired-runtime-browser-host-lease.ts
@@ -6,28 +6,18 @@ import {
   type BrowserClientHostCommandResult as BrowserClientHostCommandResultType,
   type BrowserClientHostLeaseAuthority
 } from '../../shared/browser-client-host-protocol'
-import type { PairingOffer } from '../../shared/pairing'
 import { BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY } from '../../shared/protocol-version'
 import {
   subscribeRemoteRuntimeRequest,
-  type RemoteRuntimeSubscription,
-  type RemoteRuntimeSubscriptionOptions
+  type RemoteRuntimeSubscription
 } from '../../shared/remote-runtime-client'
 import { RemoteRuntimeClientError } from '../../shared/remote-runtime-client-error'
-
-type PairedRuntimeBrowserHostLeaseOptions = {
-  pairing: PairingOffer
-  authorityRuntimeId: string
-  browserHostClientId: string
-  hostCapabilities: readonly string[]
-  pageCommandProtocolVersion?: 1
-  onPageCommand?: (
-    command: BrowserClientHostCommandEvent
-  ) => BrowserClientHostCommandResultType | Promise<BrowserClientHostCommandResultType>
-  timeoutMs?: number
-  subscription?: RemoteRuntimeSubscriptionOptions
-  onError?: (error: Error) => void
-}
+import { sameBrowserClientHostLeaseAuthority } from './browser-client-host-command-authority'
+import {
+  BrowserHostCommandResultSettler,
+  type BrowserHostCommandResultAdmission
+} from './browser-host-command-result-settler'
+import type { PairedRuntimeBrowserHostLeaseOptions } from './paired-runtime-browser-host-lease-options'
 
 export class PairedRuntimeBrowserHostLease {
   private subscription: RemoteRuntimeSubscription | null = null
@@ -35,9 +25,17 @@ export class PairedRuntimeBrowserHostLease {
   private closePromise: Promise<void> | null = null
   private rejectReady: ((error: Error) => void) | null = null
   private authority: BrowserClientHostLeaseAuthority | null = null
+  private readonly commandResultSettler: BrowserHostCommandResultSettler
   private closed = false
 
-  constructor(private readonly options: PairedRuntimeBrowserHostLeaseOptions) {}
+  constructor(private readonly options: PairedRuntimeBrowserHostLeaseOptions) {
+    this.commandResultSettler = new BrowserHostCommandResultSettler({
+      maxConcurrent: options.maxConcurrentCommandResults,
+      maxUnsettled: options.maxUnsettledCommandResults,
+      submit: (command, result) => this.submitPageCommandResult(command, result),
+      onError: (error, rejectReady) => this.fail(error, rejectReady)
+    })
+  }
 
   start(): Promise<BrowserClientHostLeaseAuthority> {
     if (this.closed) {
@@ -123,7 +121,7 @@ export class PairedRuntimeBrowserHostLease {
               this.fail(new Error('Browser host command result transport unavailable'), rejectReady)
               return
             }
-            const authority = {
+            const authority = Object.freeze({
               authorityRuntimeId: this.options.authorityRuntimeId,
               authorityEpoch: parsed.data.authorityEpoch,
               browserHostClientId: this.options.browserHostClientId,
@@ -131,11 +129,17 @@ export class PairedRuntimeBrowserHostLease {
               ...(parsed.data.pageCommandProtocolVersion
                 ? { pageCommandProtocolVersion: parsed.data.pageCommandProtocolVersion }
                 : {})
-            }
+            })
             if (this.authority) {
-              if (!sameAuthority(this.authority, authority)) {
+              if (!sameBrowserClientHostLeaseAuthority(this.authority, authority)) {
                 this.fail(new Error('Browser host lease authority changed in place'), rejectReady)
               }
+              return
+            }
+            try {
+              this.options.onAuthority?.(authority)
+            } catch (error) {
+              this.fail(error instanceof Error ? error : new Error(String(error)), rejectReady)
               return
             }
             this.authority = authority
@@ -218,15 +222,32 @@ export class PairedRuntimeBrowserHostLease {
       this.fail(new Error('Stale browser host page command'), rejectReady)
       return
     }
+    const admission = this.commandResultSettler.admit()
+    if (!admission) {
+      this.fail(new Error('Browser host command result capacity reached'), rejectReady)
+      return
+    }
     try {
       void Promise.resolve(this.options.onPageCommand(command))
-        .then((result) => this.submitPageCommandResult(command, result))
-        .catch((error) =>
+        .then((result) => this.enqueuePageCommandResult(admission, command, result, rejectReady))
+        .catch((error) => {
+          this.commandResultSettler.release(admission)
           this.fail(error instanceof Error ? error : new Error(String(error)), rejectReady)
-        )
+        })
     } catch (error) {
+      this.commandResultSettler.release(admission)
       this.fail(error instanceof Error ? error : new Error(String(error)), rejectReady)
     }
+  }
+
+  private enqueuePageCommandResult(
+    admission: BrowserHostCommandResultAdmission,
+    command: BrowserClientHostCommandEvent,
+    candidate: BrowserClientHostCommandResultType,
+    rejectReady: (error: Error) => void
+  ): void {
+    const result = BrowserClientHostCommandResult.parse(candidate)
+    this.commandResultSettler.enqueue(admission, command, result, rejectReady)
   }
 
   private async submitPageCommandResult(
@@ -269,6 +290,7 @@ export class PairedRuntimeBrowserHostLease {
   }
 
   private async closeLease(): Promise<void> {
+    this.commandResultSettler.close()
     this.subscription?.close()
     this.subscription = null
   }
@@ -280,17 +302,4 @@ export class PairedRuntimeBrowserHostLease {
       // A reporting callback cannot prevent lease cleanup.
     }
   }
-}
-
-function sameAuthority(
-  left: BrowserClientHostLeaseAuthority,
-  right: BrowserClientHostLeaseAuthority
-): boolean {
-  return (
-    left.authorityRuntimeId === right.authorityRuntimeId &&
-    left.authorityEpoch === right.authorityEpoch &&
-    left.browserHostClientId === right.browserHostClientId &&
-    left.browserHostGeneration === right.browserHostGeneration &&
-    left.pageCommandProtocolVersion === right.pageCommandProtocolVersion
-  )
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​418 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​416 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​348 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​39 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​309 |

<!-- /orca-pr-loc -->

## Summary

- Compose the authenticated paired-runtime browser-host lease with the bounded per-page command dispatcher.
- Install exact lease authority synchronously before the first page command can run.
- Keep command-result settlement at a hard maximum of 16 concurrent and 256 unsettled, beneath the same-socket 32-request transport ceiling.
- Close result transport before aborting owned handlers, while preserving cleanup failures and exact page-generation retirement fences.

## Why this stage

Draft PR #14557 proves command results can settle on the exact authenticated attach socket, but intentionally leaves desktop lifecycle ownership and the 32-request versus 256-command capacity policy unresolved. This stage closes those two inert composition gaps before any Electron page handler, capability advertisement, or placement activation exists.

The pinned T3Code reference also keeps logical preview metadata on the server while Electron main owns per-tab WebContents registration and queues navigation until the guest exists. Orca follows that lifecycle shape, but retains stricter execution-host proxy partitions, authenticated authority generations, and fail-closed remote DNS.

## Causal evidence

On parent 31f812ab02, the deterministic oracle failed because the composed host module did not exist, eight completed results immediately exceeded a configured four-request ceiling, and excess unsettled results did not fence the lease. The candidate passes synchronous ready-plus-command delivery, bounded settlement, overflow teardown, transport-close-before-abort ordering, throwing and falsy cleanup failures, exact retirement, and late non-cooperative handler settlement.

## Compatibility

This remains production-inert. No RPC registration, runtime capability advertisement, client-placement selection, Electron renderer IPC, BrowserPane behavior, server/offscreen placement, SSH or WSL routing, folder/worktree behavior, or browser.screencast.v1 behavior changes. Old and non-v1 peers keep the existing ready/revoked path; future activation must capability-gate this v1-only facade and preserve server placement for older or browserless clients.

## Validation

- 50 focused lifecycle, lease, and dispatcher tests passed.
- 810 runtime/browser/shared test files passed: 9,711 tests, with 24 existing skips.
- Full node, CLI, and web typecheck passed.
- Native/type-aware zero-warning audits and changed-code quality passed.
- Reliability-gate, max-lines, formatting, and diff checks passed.
- Cross-version wire compatibility passed 5/5.
- CLI build and executable artifact verification passed.
- Three fresh correctness, lifecycle/compatibility, and security/performance rereviews are clean.

One initial unbounded parallel run had an unrelated shared-client socket test fail to connect; that file passed 19/19 in isolation and the full four-worker rerun passed cleanly.

## Remaining activation blockers

- Compose the exact execution-host route, route-scoped Electron session, quarantined WebContents generation, and renderer registration into the command handler.
- Add capability-qualified production registration without changing legacy or server placement.
- Prove headed, headless, and browserless paired-runtime behavior, renderer crash/reload reconciliation, reconnect inventory, and physical macOS/Linux/Windows, SSH, and WSL coverage.
- Keep default client placement and all live migration disabled until those gates pass.

STA-4150

Stacked on #14557. Do not merge.