### PR TITLE
fix(proxy): preserve worktree forwarded host

### DIFF
--- a/src/main/localhost-worktree-label-proxy.test.ts
+++ b/src/main/localhost-worktree-label-proxy.test.ts
@@ -5,6 +5,12 @@ import { LocalhostWorktreeLabelProxy } from './localhost-worktree-label-proxy'
 
 const upstreamServers: http.Server[] = []
 
+type ProxyRequestOptions = {
+  method?: string
+  headers?: http.OutgoingHttpHeaders
+  body?: string
+}
+
 afterEach(async () => {
   await Promise.all(
     upstreamServers
@@ -23,7 +29,8 @@ async function startUpstream(
 }
 
 function fetchThroughProxy(
-  labeledUrl: string
+  labeledUrl: string,
+  options: ProxyRequestOptions = {}
 ): Promise<{ status: number; body: string; headers: http.IncomingHttpHeaders }> {
   const url = new URL(labeledUrl)
   return new Promise((resolve, reject) => {
@@ -34,7 +41,8 @@ function fetchThroughProxy(
         host: '127.0.0.1',
         port: Number(url.port),
         path: `${url.pathname}${url.search}`,
-        headers: { host: url.host }
+        method: options.method,
+        headers: { ...options.headers, host: url.host }
       },
       (response) => {
         const chunks: Buffer[] = []
@@ -49,7 +57,7 @@ function fetchThroughProxy(
       }
     )
     request.on('error', reject)
-    request.end()
+    request.end(options.body)
   })
 }
 
@@ -88,6 +96,53 @@ describe('localhost worktree label proxy', () => {
     // with no injected favicon/title and the CSP header intact.
     expect(result.body).toBe('<html><head></head><body>hello</body></html>')
     expect(result.headers['content-security-policy']).toBe("default-src 'self'")
+  })
+
+  it('forwards the browser-facing host authoritatively on POST requests', async () => {
+    let upstreamRequest: Record<string, unknown> | undefined
+    const port = await startUpstream((request, response) => {
+      const chunks: Buffer[] = []
+      request.on('data', (chunk) => chunks.push(Buffer.from(chunk)))
+      request.on('end', () => {
+        upstreamRequest = {
+          method: request.method,
+          host: request.headers.host,
+          forwardedHost: request.headers['x-forwarded-host'],
+          origin: request.headers.origin,
+          url: request.url,
+          body: Buffer.concat(chunks).toString('utf8')
+        }
+        response.writeHead(200, { 'content-type': 'text/plain' })
+        response.end('ok')
+      })
+    })
+    const proxy = new LocalhostWorktreeLabelProxy()
+    const { url } = await proxy.registerRoute({
+      targetUrl: `http://localhost:${port}/`,
+      projectName: 'Snap Studio',
+      worktreeName: 'analytics'
+    })
+    const labeledUrl = new URL('/action', url)
+
+    const result = await fetchThroughProxy(labeledUrl.toString(), {
+      method: 'POST',
+      headers: {
+        origin: labeledUrl.origin,
+        'x-forwarded-host': 'attacker.example'
+      },
+      body: 'action'
+    })
+
+    expect(upstreamRequest).toEqual({
+      method: 'POST',
+      host: `localhost:${port}`,
+      forwardedHost: labeledUrl.host,
+      origin: labeledUrl.origin,
+      url: '/action',
+      body: 'action'
+    })
+    expect(result.status).toBe(200)
+    expect(result.body).toBe('ok')
   })
 
   it('normalizes a 0.0.0.0 target to a connectable loopback host', async () => {

--- a/src/main/localhost-worktree-label-proxy.ts
+++ b/src/main/localhost-worktree-label-proxy.ts
@@ -242,7 +242,13 @@ function targetUrlForRequest(target: URL, request: IncomingMessage): URL {
 }
 
 function requestHeadersForTarget(request: IncomingMessage, target: URL): http.OutgoingHttpHeaders {
+  const originalHost = request.headers.host
   const headers: http.OutgoingHttpHeaders = { ...request.headers }
   headers.host = target.host
+  if (originalHost) {
+    headers['x-forwarded-host'] = originalHost
+  } else {
+    delete headers['x-forwarded-host']
+  }
   return headers
 }


### PR DESCRIPTION
## ELI5

Orca gives each workspace dev server a readable `*.orca.localhost` URL. It still needs to connect to the real localhost port, so it rewrites `Host` for the upstream server. It was not separately preserving the browser-facing host, which caused frameworks such as Next.js to reject secure forwarded actions. The proxy now sends both identities in their proper headers.

## What Changed

- preserve the incoming labeled host as `x-forwarded-host`
- keep `Host` pointed at the upstream localhost server
- overwrite spoofed incoming `x-forwarded-host` values
- remove an inherited `x-forwarded-host` if no incoming `Host` is available
- add a real HTTP proxy regression test for POST headers, body streaming, and the downstream response

## Why

The proxy needs to preserve two different host identities:

- upstream routing identity: `Host` must identify the registered localhost development server
- browser/public forwarding identity: `x-forwarded-host` must identify the original `*.orca.localhost` host, including the proxy port

Next.js Server Actions compare the public forwarding identity with `Origin` as a request-integrity check. Rewriting only `Host` loses that distinction. Orca now authors `x-forwarded-host` from the same incoming `Host` that successfully routed the label, while preserving `Origin` unchanged.

## Linked Issue

Fixes #14535

## Visual Proof

N/A — no visual or interaction change; this only corrects forwarded request headers.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- `pnpm exec vitest run --config config/vitest.config.ts src/main/localhost-worktree-label-proxy.test.ts`
  - before the implementation: 1 regression failed because upstream received `attacker.example`
  - after the implementation: 6/6 tests passed
- `pnpm run typecheck:node` — passed
- `pnpm exec oxlint src/main/localhost-worktree-label-proxy.ts src/main/localhost-worktree-label-proxy.test.ts --deny-warnings` — passed
- `pnpm exec oxfmt --check src/main/localhost-worktree-label-proxy.ts src/main/localhost-worktree-label-proxy.test.ts` — passed
- `pnpm run check:reliability-gates` — passed
- `pnpm run check:max-lines-ratchet` — passed
- `git diff --check` — passed
- `pnpm lint` — passed
- `pnpm typecheck` — passed
- `pnpm build` — passed; it reported the existing Swift deprecation warning and a non-fatal local `/usr/local/bin/orca-dev` symlink permission warning
- `pnpm test` — 52,222 passed and 122 skipped; three timing-sensitive tests failed under full-suite load:
  - `config/scripts/macos-computer-helper-owner-loss-processes.test.mjs`: temporary child PID file was not ready
  - `src/main/startup/run-electron-vite-dev.test.ts`: condition wait timed out
  - `src/main/runtime/rpc/terminal-output-frame-chunks-equivalence.test.ts`: 30-second fuzz timeout
- Each exact failure passed immediately when rerun alone with its test-name filter:
  - macOS helper process cleanup: 1 passed
  - Electron rebuild: 1 passed
  - terminal-output fuzz: 1 passed
- GitHub Actions: `Track Community PRs` passed; `PR Checks` is `action_required` with zero jobs, pending maintainer approval for the fork workflow.

The direct HTTP integration regression is the authoritative functional check; no disposable Next.js application or Desktop route-registration UI verification was run.

## AI Disclosure

OpenAI Codex (GPT-5) was used to implement, test, and review this change.

## Review

- **Security:** client-provided `x-forwarded-host` is overwritten, never appended; `Origin` remains unchanged; unknown labels still fail before forwarding; loopback target restrictions are unchanged.
- **Cross-platform:** this is pure Node HTTP header logic with no operating-system, path, or shell dependency, so it behaves the same on macOS, Linux, and Windows.
- **Folder workspaces:** behavior depends only on an existing registered proxy route, not on a Git worktree filesystem assumption.
- **SSH / remote wire:** the localhost-label proxy runs in the main process; no RPC fields, stream frames, mixed-version wire contract, or SSH provider behavior changed.
- **HTTP / upgrade:** both request paths consume the corrected `requestHeadersForTarget()` helper, so WebSocket upgrades receive the same authoritative forwarded host without a separate large harness.
- **Mobile / backwards compatibility:** no mobile code, route registration, target parsing, response headers, or external proxy behavior changed.
- **Performance:** one header lookup, branch, and assignment per forwarded request; no new state, listeners, polling, or caching.
- **Known overlap:** #13318 refactors the same proxy forwarding code but does not currently implement this invariant, so a rebase may be needed if it lands first.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @promptprobe
