### PR TITLE
fix(browser): keep mobile-driven browser pages painting when the workbench is hidden

### DIFF
--- a/mobile/src/browser/MobileBrowserPane.tsx
+++ b/mobile/src/browser/MobileBrowserPane.tsx
@@ -155,7 +155,6 @@ export function MobileBrowserPane({
   const [frameMetadata, setFrameMetadata] = useState<BrowserScreencastFrameMetadata | null>(
     cachedInitialFrame?.metadata ?? null
   )
-  const [ready, setReady] = useState(cachedInitialFrame !== null)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [dialog, setDialog] = useState<BrowserDialogState | null>(null)
@@ -305,10 +304,7 @@ export function MobileBrowserPane({
       busyRef.current = false
       setBusy(false)
     }
-    if (!readyRef.current) {
-      readyRef.current = true
-      setReady(true)
-    }
+    readyRef.current = true
   }, [])
 
   const clearFrameThrottle = useCallback(() => {
@@ -397,7 +393,6 @@ export function MobileBrowserPane({
         setFrameUri(cachedFrame.uri)
         setFrameMetadata(cachedFrame.metadata)
         readyRef.current = true
-        setReady(true)
       } else {
         frameUriRef.current = null
         frameMountedRef.current = false
@@ -405,7 +400,6 @@ export function MobileBrowserPane({
         setFrameMetadata(null)
         frameMetadataRef.current = null
         readyRef.current = false
-        setReady(false)
       }
     } else {
       frameMountedRef.current = true
@@ -474,10 +468,7 @@ export function MobileBrowserPane({
         }
         if (event.type === 'ready') {
           clearStartupTimer()
-          if (!readyRef.current) {
-            readyRef.current = true
-            setReady(true)
-          }
+          readyRef.current = true
           if (busyRef.current) {
             busyRef.current = false
             setBusy(false)
@@ -491,10 +482,7 @@ export function MobileBrowserPane({
           }
         } else if (event.type === 'end') {
           clearStartupTimer()
-          if (readyRef.current) {
-            readyRef.current = false
-            setReady(false)
-          }
+          readyRef.current = false
           if (busyRef.current) {
             busyRef.current = false
             setBusy(false)
@@ -514,10 +502,7 @@ export function MobileBrowserPane({
           }
           const message = event.message ?? event.error?.message ?? 'Browser stream failed.'
           if (shouldSurfaceBrowserError(message)) {
-            if (readyRef.current) {
-              readyRef.current = false
-              setReady(false)
-            }
+            readyRef.current = false
             setError(message)
           }
         }
@@ -1219,7 +1204,11 @@ export function MobileBrowserPane({
         ) : null}
         {!renderedFrameSource || busy || error ? (
           <View pointerEvents="none" style={styles.overlay}>
-            {busy || (!ready && !error) ? (
+            {/* Why: a stream can report ready and then deliver no frames — the host
+                stops painting whenever the desktop hides the workbench. Keying the
+                indicator off `ready` painted an unexplained black pane in that state,
+                so key it off actually having pixels. */}
+            {busy || (!renderedFrameSource && !error) ? (
               <ActivityIndicator size="small" color={colors.textSecondary} />
             ) : null}
             {error ? <Text style={styles.errorText}>{error}</Text> : null}

--- a/mobile/src/browser/mobile-browser-frameless-stream.test.tsx
+++ b/mobile/src/browser/mobile-browser-frameless-stream.test.tsx
@@ -1,0 +1,154 @@
+import { Buffer } from 'buffer'
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  BrowserScreencastOpcode,
+  type BrowserScreencastFrame
+} from '../transport/browser-screencast-protocol'
+import type { RpcClient } from '../transport/rpc-client'
+import { MobileBrowserPane, type MobileBrowserTab } from './MobileBrowserPane'
+
+vi.mock('react-native', () => ({
+  ActivityIndicator: 'ActivityIndicator',
+  AppState: { currentState: 'active', addEventListener: () => ({ remove: () => {} }) },
+  Image: 'Image',
+  PanResponder: { create: () => ({ panHandlers: {} }) },
+  PixelRatio: { get: () => 2 },
+  Platform: { OS: 'android' },
+  Pressable: 'Pressable',
+  StyleSheet: {
+    absoluteFillObject: { position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 },
+    create: (styles: unknown) => styles
+  },
+  Text: 'Text',
+  TextInput: 'TextInput',
+  View: 'View'
+}))
+
+vi.mock('lucide-react-native', () => ({
+  ArrowUp: 'ArrowUp',
+  ChevronLeft: 'ChevronLeft',
+  ChevronRight: 'ChevronRight',
+  RefreshCw: 'RefreshCw'
+}))
+
+type Subscription = {
+  listener: (payload: unknown) => void
+  onBinaryFrame?: (frame: BrowserScreencastFrame) => void
+}
+
+let pageCounter = 0
+
+function makeFrame(): BrowserScreencastFrame {
+  return {
+    opcode: BrowserScreencastOpcode.Frame,
+    seq: 1,
+    format: 'jpeg',
+    metadata: { deviceWidth: 360, deviceHeight: 640, pageScaleFactor: 1 },
+    image: new TextEncoder().encode('frame')
+  }
+}
+
+function spinnerCount(renderer: ReactTestRenderer): number {
+  return renderer.root.findAllByType('ActivityIndicator').length
+}
+
+async function renderPane(): Promise<{ renderer: ReactTestRenderer; stream: Subscription }> {
+  pageCounter += 1
+  const subscriptions: Subscription[] = []
+  const client = {
+    subscribe: (
+      _method: string,
+      _params: unknown,
+      listener: (payload: unknown) => void,
+      options?: { onBinaryFrame?: (frame: BrowserScreencastFrame) => void }
+    ) => {
+      subscriptions.push({ listener, onBinaryFrame: options?.onBinaryFrame })
+      return () => {}
+    },
+    request: vi.fn()
+  } as unknown as RpcClient
+
+  const tab: MobileBrowserTab = {
+    type: 'browser',
+    id: `tab-${pageCounter}`,
+    title: 'Dashboard',
+    browserWorkspaceId: 'bw-1',
+    browserPageId: `page-${pageCounter}`,
+    url: 'https://dashboard.example',
+    loading: false,
+    canGoBack: false,
+    canGoForward: false,
+    isActive: true
+  }
+
+  let renderer: ReactTestRenderer | null = null
+  await act(async () => {
+    renderer = create(
+      createElement(MobileBrowserPane, {
+        client,
+        // Why: unique worktree id keeps each test on a cold module-level frame cache.
+        worktreeId: `wt-${pageCounter}`,
+        tab,
+        screencastSupported: true,
+        keyboardLift: 0,
+        bottomInset: 0,
+        onToast: () => {}
+      }),
+      { createNodeMock: () => ({ setNativeProps: () => {} }) }
+    )
+    await Promise.resolve()
+  })
+  if (!renderer) {
+    throw new Error('MobileBrowserPane did not render')
+  }
+  const mounted: ReactTestRenderer = renderer
+  const viewport = mounted.root
+    .findAllByType('View')
+    .find((node) => typeof node.props.onLayout === 'function')
+  if (!viewport) {
+    throw new Error('Viewport with onLayout not found')
+  }
+  act(() => {
+    viewport.props.onLayout({ nativeEvent: { layout: { width: 360, height: 640 } } })
+  })
+  const stream = subscriptions[0]
+  if (!stream) {
+    throw new Error('browser.screencast subscription not created')
+  }
+  return { renderer: mounted, stream }
+}
+
+describe('MobileBrowserPane with a stream that reports ready but sends no frames', () => {
+  // Why: the host stops painting whenever the desktop hides the workbench (e.g. the
+  // user opens Settings), so `ready` arrives and frames never do. The pane used to
+  // clear its indicator on `ready`, leaving an unexplained black rectangle.
+  it('keeps showing the loading indicator instead of an empty black pane', async () => {
+    const { renderer, stream } = await renderPane()
+
+    act(() => {
+      stream.listener({ type: 'ready', tab: { url: 'https://dashboard.example' } })
+    })
+
+    expect(spinnerCount(renderer)).toBeGreaterThan(0)
+  })
+
+  it('clears the indicator once real pixels arrive', async () => {
+    const { renderer, stream } = await renderPane()
+
+    act(() => {
+      stream.listener({ type: 'ready', tab: { url: 'https://dashboard.example' } })
+    })
+    act(() => {
+      stream.onBinaryFrame?.(makeFrame())
+    })
+
+    expect(spinnerCount(renderer)).toBe(0)
+    const source = renderer.root
+      .findAllByType('Image')
+      .map((image) => (image.props.source as { uri?: string } | null)?.uri)
+      .find((uri) => typeof uri === 'string')
+    expect(source).toContain(Buffer.from(makeFrame().image).toString('base64'))
+  })
+})

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -44,6 +44,11 @@ import {
 import { useAppStore } from './store'
 import { WORKTREE_REFRESH_CONCURRENCY } from './store/slices/worktrees'
 import { useShallow } from 'zustand/react/shallow'
+import { useBrowserMobileDriverForAny } from './lib/pane-manager/browser-mobile-driver-state'
+import {
+  TERMINAL_WORKBENCH_CLASS_NAMES,
+  resolveTerminalWorkbenchPaintMode
+} from './components/terminal-workbench-paintability'
 import { isRemoteWorkspaceSnapshotApplyInProgress, useIpcEvents } from './hooks/useIpcEvents'
 import { useAutomationDispatchEvents } from './hooks/useAutomationDispatchEvents'
 import RetainedAgentsSyncGate from './components/dashboard/RetainedAgentsSyncGate'
@@ -226,6 +231,7 @@ import { useRemoteRuntimeRecoveryTriggers } from './runtime/use-remote-runtime-r
 
 // Why: bound the resume-record loss window on a hard kill to ~1 min; capture skips unchanged records so per-tick cost is negligible.
 const SLEEPING_AGENT_RESUME_CAPTURE_INTERVAL_MS = 60_000
+const EMPTY_BROWSER_PAGE_IDS: string[] = []
 
 const isMac = navigator.userAgent.includes('Mac')
 const isWindows = !isMac && navigator.userAgent.includes('Windows')
@@ -577,6 +583,24 @@ function App(): React.JSX.Element {
     activeView === 'terminal' && activeWorktreeId !== null && !creationLayoutActive
   const terminalWorkbenchVisible =
     activeView === 'terminal' && activeWorktreeId !== null && !creationLayoutActive
+  // Why: only pay the cross-worktree scan while the workbench is hidden — that
+  // is the only time a mobile driver has to keep it painting.
+  const hiddenWorkbenchBrowserPageIds = useAppStore(
+    useShallow((state) =>
+      terminalWorkbenchVisible
+        ? EMPTY_BROWSER_PAGE_IDS
+        : Object.values(state.browserTabsByWorktree).flatMap((tabs) =>
+            (tabs ?? []).flatMap((tab) =>
+              tab.pageIds && tab.pageIds.length > 0 ? tab.pageIds : [tab.activePageId ?? tab.id]
+            )
+          )
+    )
+  )
+  const hasMobileDrivenBrowser = useBrowserMobileDriverForAny(hiddenWorkbenchBrowserPageIds)
+  const workbenchPaintMode = resolveTerminalWorkbenchPaintMode({
+    isWorkbenchVisible: terminalWorkbenchVisible,
+    hasMobileDrivenBrowser
+  })
   // Why: once the floating workspace owns tabs, keep it mounted while closed so hidden terminal/browser/editor panes retain local state.
   const shouldMountFloatingTerminalPanel =
     floatingTerminalEnabled && (floatingTerminalOpen || floatingVisibleTabCount > 0)
@@ -2366,11 +2390,10 @@ function App(): React.JSX.Element {
                         <div className="flex flex-1 min-w-0 min-h-0 flex-col">
                           {shouldMountTerminalWorkbench ? (
                             <div
-                              className={
-                                !terminalWorkbenchVisible
-                                  ? 'hidden flex-1 min-w-0 min-h-0'
-                                  : 'flex flex-1 min-w-0 min-h-0'
-                              }
+                              className={TERMINAL_WORKBENCH_CLASS_NAMES[workbenchPaintMode]}
+                              // Why: a paintable-but-hidden workbench must stay unreachable by Tab / assistive tech.
+                              inert={!terminalWorkbenchVisible}
+                              aria-hidden={!terminalWorkbenchVisible}
                             >
                               <Suspense fallback={null}>
                                 <RecoverableRenderErrorBoundary

--- a/src/renderer/src/components/terminal-workbench-paintability.test.ts
+++ b/src/renderer/src/components/terminal-workbench-paintability.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import {
+  TERMINAL_WORKBENCH_CLASS_NAMES,
+  resolveTerminalWorkbenchPaintMode
+} from './terminal-workbench-paintability'
+
+describe('resolveTerminalWorkbenchPaintMode', () => {
+  it('renders normally while the workspace view is showing', () => {
+    expect(
+      resolveTerminalWorkbenchPaintMode({
+        isWorkbenchVisible: true,
+        hasMobileDrivenBrowser: false
+      })
+    ).toBe('visible')
+  })
+
+  it('keeps the workbench painting when a phone drives a browser page off-workspace', () => {
+    expect(
+      resolveTerminalWorkbenchPaintMode({
+        isWorkbenchVisible: false,
+        hasMobileDrivenBrowser: true
+      })
+    ).toBe('paintable-hidden')
+  })
+
+  it('parks the workbench when nothing remote needs its pixels', () => {
+    expect(
+      resolveTerminalWorkbenchPaintMode({
+        isWorkbenchVisible: false,
+        hasMobileDrivenBrowser: false
+      })
+    ).toBe('parked')
+  })
+})
+
+describe('TERMINAL_WORKBENCH_CLASS_NAMES', () => {
+  it('never applies display:none to a mobile-driven workbench', () => {
+    // Why: `hidden` is what stops screencast frames; opacity keeps compositing.
+    expect(TERMINAL_WORKBENCH_CLASS_NAMES['paintable-hidden']).not.toMatch(/\bhidden\b/)
+    expect(TERMINAL_WORKBENCH_CLASS_NAMES['paintable-hidden']).toContain('opacity-0')
+  })
+
+  it('keeps the hidden workbench out of flow and non-interactive', () => {
+    // Why: the active page is a flex sibling — an in-flow workbench would
+    // halve its height, and a hittable one would swallow its clicks.
+    expect(TERMINAL_WORKBENCH_CLASS_NAMES['paintable-hidden']).toContain('absolute')
+    expect(TERMINAL_WORKBENCH_CLASS_NAMES['paintable-hidden']).toContain('pointer-events-none')
+  })
+
+  it('still parks with display:none when no mobile client needs frames', () => {
+    expect(TERMINAL_WORKBENCH_CLASS_NAMES.parked).toContain('hidden')
+  })
+})

--- a/src/renderer/src/components/terminal-workbench-paintability.ts
+++ b/src/renderer/src/components/terminal-workbench-paintability.ts
@@ -1,0 +1,29 @@
+export type TerminalWorkbenchPaintabilityState = {
+  isWorkbenchVisible: boolean
+  hasMobileDrivenBrowser: boolean
+}
+
+export type TerminalWorkbenchPaintMode = 'visible' | 'paintable-hidden' | 'parked'
+
+// Why: Chromium never paints inside a display:none subtree, so parking the
+// workbench that way also kills screencast frames for browser pages a phone is
+// driving — the pane-level paintability escape hatch cannot override an
+// ancestor. Keep the workbench composited (out of flow, invisible, inert)
+// whenever a mobile client is driving one of its pages.
+export function resolveTerminalWorkbenchPaintMode({
+  isWorkbenchVisible,
+  hasMobileDrivenBrowser
+}: TerminalWorkbenchPaintabilityState): TerminalWorkbenchPaintMode {
+  if (isWorkbenchVisible) {
+    return 'visible'
+  }
+  return hasMobileDrivenBrowser ? 'paintable-hidden' : 'parked'
+}
+
+export const TERMINAL_WORKBENCH_CLASS_NAMES: Record<TerminalWorkbenchPaintMode, string> = {
+  visible: 'flex flex-1 min-w-0 min-h-0',
+  // Why: absolute keeps the invisible workbench out of the flex column so the
+  // active page (Settings, Tasks, …) still gets the full content area.
+  'paintable-hidden': 'absolute inset-0 flex opacity-0 pointer-events-none',
+  parked: 'hidden flex-1 min-w-0 min-h-0'
+}


### PR DESCRIPTION
## Problem

The mobile app's browser pane freezes, or renders solid black, while the URL bar and tab title stay populated and no spinner or error is shown.

The cause is host-side. Orca backs each browser tab with a `<webview>` guest inside the desktop renderer window, and Chromium never paints inside a `display:none` subtree — so the page stops emitting CDP screencast frames entirely. The mobile client keeps a healthy subscription against a host that has stopped painting, and there is no stall detection on either side.

Orca already models this: `isBrowserPagePanePaintable()` keeps a pane composited when it is active, automation-visible, **or mobile-driven**, using `opacity: 0` rather than `display: none` precisely so a phone-driven page keeps producing frames. That escape hatch cannot override an ancestor, and the workbench container in `App.tsx` was hardcoded:

```tsx
className={!terminalWorkbenchVisible ? 'hidden flex-1 min-w-0 min-h-0' : 'flex flex-1 min-w-0 min-h-0'}
```

`terminalWorkbenchVisible` is false whenever `activeView !== 'terminal'`, there is no active worktree, or the creation surface is open — with no `isMobileDriven` term. Opening Settings therefore `display:none`s every browser guest in the app.

## How to reproduce

1. Pair a phone (or an Android emulator) with desktop Orca.
2. Open a workspace on the phone and switch to a browser tab showing a page that updates on its own — a live clock works well.
3. Confirm the page is streaming to the phone.
4. On the desktop, click **Settings** (or Tasks, or any non-workspace view) and leave it there.

The phone's browser pane freezes on its last frame for as long as the desktop stays off the workspace view, and resumes when you return to it. Frames stop within a second; the URL bar and tab title keep updating throughout, because those come from the stream's `ready` event rather than from frames.

For the solid-black variant, do the same but force-quit and relaunch the phone app while the desktop is on Settings. The pane mounts with no cached frame, receives none, and paints an empty black viewport with no spinner and no error.

Verified with this change applied: the page keeps streaming the entire time the desktop sits on Settings.

## Changes

**Host / renderer — the fix.** New `terminal-workbench-paintability.ts` resolves the workbench to `visible`, `paintable-hidden`, or `parked`. When hidden with a mobile-driven browser page it becomes `absolute inset-0 flex opacity-0 pointer-events-none` instead of `hidden`, so the guests keep compositing. `absolute` matters: the workbench and the active page are flex siblings, so an in-flow invisible workbench would halve the page's height. The container is also marked `inert` / `aria-hidden` while hidden, matching the existing treatment in `Terminal.tsx`. The cross-worktree scan is skipped while the workbench is visible.

**Mobile client — a safety net.** The pane keyed its loading indicator off `ready`, so a stream that reported ready and then delivered no frames cleared the spinner and left an unexplained black rectangle. It now keys off actually having pixels. This still matters for stalls that cannot be fixed in CSS.

## Known gaps

- A decode failure on the visible layer can still leave a blank pane; not reproduced, so not addressed here.
- Minimized, occluded, another-Space, and display-asleep hosts stop producing frames regardless of CSS, since Chromium will not paint an unmapped window. The mobile-side change means those now show a spinner rather than an unexplained black pane, but the frames genuinely stop.

## Testing

- `terminal-workbench-paintability.test.ts` — asserts a mobile-driven hidden workbench never resolves to `display:none`, and stays out of flow and non-interactive.
- `mobile-browser-frameless-stream.test.tsx` — drives a stream that reports ready and sends no frames, asserting the indicator stays up; fails on `main`. A second case guards the happy path.
- Full desktop and mobile suites pass, apart from failures that reproduce identically on `main` (`cross-version-terminal-wire`, `mobile-create-pr-action`).
- Manually verified end to end on an Android emulator against a dev desktop build, using the reproduction above.
