### PR TITLE
fix(orchestration): infer worker identity in preambles

### DIFF
--- a/src/main/runtime/orchestration/__snapshots__/preamble.test.ts.snap
+++ b/src/main/runtime/orchestration/__snapshots__/preamble.test.ts.snap
@@ -23,7 +23,7 @@ Slack, GitHub comments, or any other channel to reach a human during the run.
   # Never encode failure only in prose and never silently exit.
   # Include BOTH taskId and dispatchId in the payload so a late completion
   # from a failed retry cannot complete the current dispatch.
-  orca orchestration send --from term_WORKER \\
+  orca orchestration send \\
     --type worker_done --subject "<short status>" \\
     --body "<3-sentence summary: what you did, what you found, what's left>" \\
     --task-id task_SNAP --dispatch-id ctx_SNAP --outcome succeeded \\
@@ -40,7 +40,7 @@ Slack, GitHub comments, or any other channel to reach a human during the run.
   # attributes the heartbeat to the specific dispatch context, not just
   # the task, so a straggler heartbeat from a previously-failed dispatch
   # cannot mask a hung retry.
-  orca orchestration send --from term_WORKER \\
+  orca orchestration send \\
     --type heartbeat --subject "alive" \\
     --task-id task_SNAP --dispatch-id ctx_SNAP \\
     --phase "<short: investigating|implementing|reviewing|waiting>"
@@ -57,20 +57,20 @@ Slack, GitHub comments, or any other channel to reach a human during the run.
   # blocks until the coordinator replies, then prints the reply body. If the
   # call times out or disconnects, resume with the returned message ID instead
   # of creating a duplicate question.
-  orca orchestration ask --from term_WORKER \\
+  orca orchestration ask \\
     --question "<your question>" \\
     --options "<optional,comma,separated>" \\
     --timeout-ms 600000
 
   # Escalate a blocker or failure (pre-completion, when you need the
   # coordinator to do something before you can continue):
-  orca orchestration send --from term_WORKER \\
+  orca orchestration send \\
     --type escalation --subject "Blocked: <reason>" \\
     --body "<details>" \\
     --task-id task_SNAP
 
   # Check for messages from the coordinator:
-  orca orchestration check --terminal term_WORKER
+  orca orchestration check
 
 === AFTER YOU SEND worker_done ===
 

--- a/src/main/runtime/orchestration/coordinator.ts
+++ b/src/main/runtime/orchestration/coordinator.ts
@@ -456,7 +456,6 @@ export class Coordinator {
       // Why (§3.4): strippedSpec drops the allow-stale-base line so the worker doesn't read the infra flag as an instruction.
       taskSpec: strippedSpec,
       coordinatorHandle: this.opts.coordinatorHandle,
-      workerHandle: targetHandle,
       devMode: process.env.ORCA_USER_DATA_PATH?.includes('orca-dev'),
       ...(this.runtime.getTerminalOrchestrationCliCommand
         ? { cliCommand: this.runtime.getTerminalOrchestrationCliCommand(targetHandle) }

--- a/src/main/runtime/orchestration/preamble.test.ts
+++ b/src/main/runtime/orchestration/preamble.test.ts
@@ -8,7 +8,6 @@ function baseParams(overrides: Partial<Parameters<typeof buildDispatchPreamble>[
     dispatchId: 'ctx_def456',
     taskSpec: 'Implement the login form',
     coordinatorHandle: 'term_coord',
-    workerHandle: 'term_worker',
     ...overrides
   }
 }
@@ -49,7 +48,7 @@ describe('buildDispatchPreamble', () => {
     expect(result).toContain('replace it with --outcome failed')
     expect(result).toContain('--files-modified "path/a,path/b"')
     expect(result).toContain('--report-path "<optional: path to the full artifact>"')
-    expect(result).toMatch(/orchestration send --from term_worker/)
+    expect(result).not.toContain('--from')
     expect(result).not.toContain('orchestration send --to term_coord')
   })
 
@@ -88,12 +87,12 @@ describe('buildDispatchPreamble', () => {
     expect(result).toContain('--task-id task_abc123')
     expect(result).toContain('--dispatch-id ctx_def456')
     expect(result).toContain('--phase "<short: investigating|implementing|reviewing|waiting>"')
-    expect(result).toMatch(/orchestration send --from term_worker/)
+    expect(result).not.toContain('--from')
   })
 
   it('includes ask block with BEHAVIOR RULE #1 forbidding AskUserQuestion', () => {
     const result = buildDispatchPreamble(baseParams())
-    expect(result).toMatch(/orchestration ask --from term_worker/)
+    expect(result).toMatch(/orchestration ask \\/)
     expect(result).toContain('--question')
     expect(result).toContain('--timeout-ms 600000')
     // Why: the exact phrase is asserted so the rule can't be trimmed away by
@@ -107,12 +106,13 @@ describe('buildDispatchPreamble', () => {
     expect(occurrences).toBe(2)
   })
 
-  it('binds every injected worker command to the dispatched terminal', () => {
+  it('lets every injected worker command bind to the current pane identity', () => {
     const result = buildDispatchPreamble(baseParams())
 
-    expect(result).toMatch(/orchestration ask --from term_worker/)
-    expect(result).toMatch(/orchestration send --from term_worker \\\n    --type escalation/)
-    expect(result).toContain('orchestration check --terminal term_worker')
+    expect(result).not.toContain('--from')
+    expect(result).not.toContain('--terminal')
+    expect(result).toMatch(/orchestration send \\\n    --type escalation/)
+    expect(result).toContain('orchestration check')
   })
 
   it('carries the minted Dispatch capability on lifecycle and question commands', () => {
@@ -205,7 +205,6 @@ describe('buildDispatchPreamble', () => {
       dispatchId: 'ctx_x',
       taskSpec: 'do stuff',
       coordinatorHandle: 'term_c',
-      workerHandle: 'term_w',
       baseDrift: {
         base: 'origin/main',
         behind: 7,
@@ -228,7 +227,6 @@ describe('buildDispatchPreamble', () => {
       dispatchId: 'ctx_x',
       taskSpec: 'do stuff',
       coordinatorHandle: 'term_c',
-      workerHandle: 'term_w',
       baseDrift: {
         base: 'origin/main',
         behind: 0,
@@ -245,8 +243,7 @@ describe('buildDispatchPreamble', () => {
       taskId: 'task_x',
       dispatchId: 'ctx_x',
       taskSpec: 'do stuff',
-      coordinatorHandle: 'term_c',
-      workerHandle: 'term_w'
+      coordinatorHandle: 'term_c'
     })
 
     expect(result).not.toContain('--- BASE DRIFT ---')
@@ -259,7 +256,6 @@ describe('buildDispatchPreamble', () => {
       dispatchId: 'ctx_x',
       taskSpec: 'do stuff',
       coordinatorHandle: 'term_c',
-      workerHandle: 'term_w',
       baseDrift: {
         base: 'origin/main',
         behind: 3,
@@ -282,8 +278,7 @@ describe('buildDispatchPreamble', () => {
       taskId: 'task_SNAP',
       dispatchId: 'ctx_SNAP',
       taskSpec: 'TASK_BODY',
-      coordinatorHandle: 'term_COORD',
-      workerHandle: 'term_WORKER'
+      coordinatorHandle: 'term_COORD'
     })
     expect(result).toMatchSnapshot()
   })

--- a/src/main/runtime/orchestration/preamble.ts
+++ b/src/main/runtime/orchestration/preamble.ts
@@ -11,7 +11,6 @@ export type PreambleParams = {
   dispatchCapability?: string
   taskSpec: string
   coordinatorHandle: string
-  workerHandle: string
   devMode?: boolean
   // Why: packaged WSL panes install the scoped launcher as `orca-ide`;
   // other execution hosts keep their existing bare `orca` bridge.
@@ -57,6 +56,8 @@ export function buildDispatchPreamble(params: PreambleParams): string {
     ? ` --dispatch-capability ${params.dispatchCapability}`
     : ''
 
+  // Why: the CLI binds lifecycle authority from the current pane; rendering a
+  // terminal UUID makes model transcription errors an unnecessary input.
   const header = `You are working inside Orca, a multi-agent IDE. You are a dispatched worker.
 Your coordinator's terminal handle is: ${params.coordinatorHandle}
 Your task ID is: ${params.taskId}
@@ -79,7 +80,7 @@ Slack, GitHub comments, or any other channel to reach a human during the run.
   # Never encode failure only in prose and never silently exit.
   # Include BOTH taskId and dispatchId in the payload so a late completion
   # from a failed retry cannot complete the current dispatch.
-  ${cli} orchestration send --from ${params.workerHandle}${capabilityFlag} \\
+  ${cli} orchestration send${capabilityFlag} \\
     --type worker_done --subject "<short status>" \\
     --body "<3-sentence summary: what you did, what you found, what's left>" \\
     --task-id ${params.taskId} --dispatch-id ${params.dispatchId} --outcome succeeded \\
@@ -96,7 +97,7 @@ Slack, GitHub comments, or any other channel to reach a human during the run.
   # attributes the heartbeat to the specific dispatch context, not just
   # the task, so a straggler heartbeat from a previously-failed dispatch
   # cannot mask a hung retry.
-  ${cli} orchestration send --from ${params.workerHandle}${capabilityFlag} \\
+  ${cli} orchestration send${capabilityFlag} \\
     --type heartbeat --subject "alive" \\
     --task-id ${params.taskId} --dispatch-id ${params.dispatchId} \\
     --phase "<short: investigating|implementing|reviewing|waiting>"
@@ -113,20 +114,20 @@ Slack, GitHub comments, or any other channel to reach a human during the run.
   # blocks until the coordinator replies, then prints the reply body. If the
   # call times out or disconnects, resume with the returned message ID instead
   # of creating a duplicate question.
-  ${cli} orchestration ask --from ${params.workerHandle}${capabilityFlag} \\
+  ${cli} orchestration ask${capabilityFlag} \\
     --question "<your question>" \\
     --options "<optional,comma,separated>" \\
     --timeout-ms 600000
 
   # Escalate a blocker or failure (pre-completion, when you need the
   # coordinator to do something before you can continue):
-  ${cli} orchestration send --from ${params.workerHandle}${capabilityFlag} \\
+  ${cli} orchestration send${capabilityFlag} \\
     --type escalation --subject "Blocked: <reason>" \\
     --body "<details>" \\
     --task-id ${params.taskId}
 
   # Check for messages from the coordinator:
-  ${cli} orchestration check --terminal ${params.workerHandle}
+  ${cli} orchestration check
 
 ${postDoneInstructions}`
 

--- a/src/main/runtime/rpc/methods/orchestration-federation.ts
+++ b/src/main/runtime/rpc/methods/orchestration-federation.ts
@@ -232,7 +232,6 @@ export const ORCHESTRATION_FEDERATION_ATTACH_METHODS: RpcMethod[] = [
             dispatchId: params.dispatchId,
             taskSpec: params.taskSpec,
             coordinatorHandle: 'Run home (relayed by Orca)',
-            workerHandle: terminalHandle,
             dispatchCapability: capability,
             devMode: params.devMode,
             cliCommand: runtime.getTerminalOrchestrationCliCommand(terminalHandle)

--- a/src/main/runtime/rpc/methods/orchestration-workers.ts
+++ b/src/main/runtime/rpc/methods/orchestration-workers.ts
@@ -226,7 +226,6 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
           dispatchId: started.dispatch.id,
           taskSpec: task.spec,
           coordinatorHandle: params.from,
-          workerHandle: terminalHandle,
           dispatchCapability: capability,
           devMode: params.devMode,
           cliCommand: runtime.getTerminalOrchestrationCliCommand(terminalHandle)

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -1269,7 +1269,6 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
           dispatchId: 'ctx_dryrun',
           taskSpec: task.spec,
           coordinatorHandle: params.from ?? 'coordinator',
-          workerHandle: params.to ?? 'worker',
           devMode: params.devMode,
           ...(params.to
             ? { cliCommand: runtime.getTerminalOrchestrationCliCommand(params.to) }
@@ -1335,7 +1334,6 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
         dispatchId: ctx.id,
         taskSpec: task.spec,
         coordinatorHandle: params.from ?? 'coordinator',
-        workerHandle: to,
         dispatchCapability,
         devMode: params.devMode,
         cliCommand: runtime.getTerminalOrchestrationCliCommand(to)
@@ -1383,7 +1381,6 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
           dispatchId: ctx?.id ?? 'ctx_preview',
           taskSpec: task.spec,
           coordinatorHandle: params.from ?? 'coordinator',
-          workerHandle,
           devMode: params.devMode,
           ...(ctx ? { cliCommand: runtime.getTerminalOrchestrationCliCommand(workerHandle) } : {})
         })


### PR DESCRIPTION
## ELI5

Orca currently asks workers to copy a long terminal ID into lifecycle commands. When two similar IDs appear in the same prompt, a worker can splice them together and Orca correctly rejects the result. This change stops asking the worker to copy that ID and lets the existing CLI identify its own pane.

## What Changed

- Removed `workerHandle` from the dispatch-preamble contract and all coordinator/manual/composed/federated call sites.
- Removed generated `--from <worker UUID>` and `--terminal <worker UUID>` arguments from worker lifecycle, question, escalation, and check examples.
- Updated the strict preamble snapshot and regression tests to require implicit current-pane binding.

## Why

A real supervised worker combined the worker UUID prefix with the coordinator UUID suffix, producing rejected heartbeat and `worker_done` messages and requiring operator recovery. The CLI already binds sender identity from `ORCA_TERMINAL_HANDLE` / `ORCA_PANE_KEY`, and the bundled orchestration guide already tells workers not to supply Run/server/terminal identity. Removing the model-supplied selector is the smallest reliable fix and does not weaken authorization.

## Linked Issue

Fixes #14570

## Visual Proof

N/A — generated worker command text changes; there is no desktop UI or interaction layout change.

## Testing

- [ ] I manually tested these changes locally — requires a released app containing this commit; the installed 1.4.182 predates it.
- [x] Automated tests added/updated: 68 focused preamble/CLI identity tests passed; 60 worker recovery/manual-release focused tests passed.
- [x] `pnpm run typecheck:node`
- [x] Focused `oxlint`, `oxfmt --check`, and `git diff --check`
- [x] `pnpm run build:electron-vite`
- Full local `pnpm test`: 52,217 passed; 7 unrelated baseline failures under unsupported Node 22 (zsh Unicode fixture, csh/tcsh wrapper assertions, and Electron cookie fixture timeouts). CI on the required Node 24 remains authoritative.

Platforms reviewed: generated commands are platform-neutral; existing CLI tests cover pane identity, Windows/WSL command selection, worker recovery, manual release, and remote/federated call sites. Physical runtime execution was on macOS arm64.

## AI Disclosure

OpenAI Codex (GPT-5 family) was used for diagnosis, implementation, tests, and self-review. CodeRabbit also reviewed the submitted diff and reported minimal merge risk with no actionable code comments.

## Review

- Security: Dispatch capability, task/Dispatch IDs, pane/process verification, and rejection behavior are unchanged.
- Cross-platform: removes arguments only; no shell/path/shortcut/platform branch added.
- Remote SSH/federation: all preamble call sites use the same implicit CLI identity contract; no wire change.
- Mobile/UI: N/A; no renderer or mobile surface changed.
- Compatibility: existing CLI implicit identity behavior is used; no new RPC field or runtime fallback.
- Performance: no runtime hot-path change.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — focused lint/typecheck/build pass; CI will cover the required Node 24 full suite.

## Author

- GitHub: @jackyzhang69