### PR TITLE
Refresh current LAN endpoints while a phone is on Relay

### DIFF
--- a/mobile/src/transport/mobile-direct-endpoint-refresh.test.ts
+++ b/mobile/src/transport/mobile-direct-endpoint-refresh.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  mergeAdvertisedDirectEndpoints,
+  refreshHostDirectEndpoints
+} from './mobile-direct-endpoint-refresh'
+import type { HostProfile, RpcResponse } from './types'
+import type { RpcClient } from './rpc-client'
+
+const relay = {
+  v: 1 as const,
+  directorUrl: 'https://relay.onorca.dev',
+  cellUrl: 'https://relay-c1.onorca.dev',
+  assignmentEpoch: 7,
+  relayHostId: 'AbCdEf0123_-xyZ9',
+  e2eeFraming: 2 as const
+}
+
+const host: HostProfile = {
+  id: 'host-1',
+  name: 'Desk',
+  endpoint: 'ws://192.168.1.10:6768',
+  deviceToken: 'device-token',
+  publicKeyB64: 'A'.repeat(44),
+  lastConnected: 1,
+  endpoints: [
+    { id: 'direct-primary', kind: 'lan', url: 'ws://192.168.1.10:6768' },
+    { id: 'stale-cafe', kind: 'lan', url: 'ws://10.0.0.8:6768' },
+    {
+      id: 'relay-primary',
+      kind: 'relay',
+      url: 'wss://relay-c1.onorca.dev/v1/connect/AbCdEf0123_-xyZ9'
+    }
+  ],
+  relayHostId: relay.relayHostId,
+  relay
+}
+
+function client(response: RpcResponse): RpcClient {
+  return { sendRequest: vi.fn(async () => response) } as unknown as RpcClient
+}
+
+describe('mergeAdvertisedDirectEndpoints', () => {
+  it('replaces pair-time LAN instead of accumulating cafe and NIC history', () => {
+    const next = mergeAdvertisedDirectEndpoints(host, {
+      v: 1,
+      selected: { kind: 'lan', url: 'ws://192.168.1.50:6768' },
+      endpoints: [
+        { kind: 'lan', url: 'ws://192.168.1.50:6768' },
+        { kind: 'tailscale', url: 'ws://100.64.0.2:6768' }
+      ]
+    })
+    expect(next.endpoint).toBe('ws://192.168.1.50:6768')
+    expect(next.endpoints).toEqual([
+      { id: 'direct-primary', kind: 'lan', url: 'ws://192.168.1.50:6768' },
+      { id: 'direct-2', kind: 'tailscale', url: 'ws://100.64.0.2:6768' },
+      {
+        id: 'relay-primary',
+        kind: 'relay',
+        url: 'wss://relay-c1.onorca.dev/v1/connect/AbCdEf0123_-xyZ9'
+      }
+    ])
+  })
+
+  it('keeps pair-time LAN when the desktop advertises nothing', () => {
+    expect(
+      mergeAdvertisedDirectEndpoints(host, { v: 1, selected: null, endpoints: [] })
+    ).toBe(host)
+  })
+
+  it('never grows the overlay past 16 entries', () => {
+    const endpoints = Array.from({ length: 20 }, (_, index) => ({
+      kind: 'lan' as const,
+      url: `ws://10.0.0.${index + 1}:6768`
+    }))
+    const next = mergeAdvertisedDirectEndpoints(host, {
+      v: 1,
+      selected: endpoints[0]!,
+      endpoints
+    })
+    expect(next.endpoints).toHaveLength(16)
+    expect(next.endpoints?.some(({ kind }) => kind === 'relay')).toBe(true)
+  })
+})
+
+describe('refreshHostDirectEndpoints', () => {
+  it('keeps pair-time LAN when an old desktop returns method_not_found', async () => {
+    const saveHost = vi.fn()
+    const rpc = client({
+      id: 'rpc-1',
+      ok: false,
+      error: { code: 'method_not_found', message: 'Unknown method' },
+      _meta: { runtimeId: 'runtime-1' }
+    })
+    const unsupported = { current: false }
+    await expect(
+      refreshHostDirectEndpoints({ client: rpc, host, saveHost, unsupported })
+    ).resolves.toBe(host)
+    expect(saveHost).not.toHaveBeenCalled()
+    expect(unsupported.current).toBe(true)
+    await refreshHostDirectEndpoints({ client: rpc, host, saveHost, unsupported })
+    expect(rpc.sendRequest).toHaveBeenCalledOnce()
+  })
+
+  it('persists the advertised current LAN', async () => {
+    const saveHost = vi.fn(async () => {})
+    const next = await refreshHostDirectEndpoints({
+      client: client({
+        id: 'rpc-1',
+        ok: true,
+        result: {
+          v: 1,
+          selected: { kind: 'lan', url: 'ws://192.168.1.50:6768' },
+          endpoints: [{ kind: 'lan', url: 'ws://192.168.1.50:6768' }]
+        },
+        _meta: { runtimeId: 'runtime-1' }
+      }),
+      host,
+      saveHost
+    })
+    expect(next.endpoint).toBe('ws://192.168.1.50:6768')
+    expect(saveHost).toHaveBeenCalledWith(next)
+  })
+})

--- a/mobile/src/transport/mobile-direct-endpoint-refresh.ts
+++ b/mobile/src/transport/mobile-direct-endpoint-refresh.ts
@@ -1,0 +1,95 @@
+import {
+  PairingGetDirectEndpointsResultSchema,
+  type PairingGetDirectEndpointsResult
+} from '../../../src/shared/mobile-relay-credential-contract'
+import type { MobileAccessEndpoint } from './mobile-relay-host-overlay'
+import type { RpcClient } from './rpc-client'
+import type { HostProfile } from './types'
+
+const OVERLAY_ENDPOINT_MAX = 16
+
+export function mergeAdvertisedDirectEndpoints(
+  host: HostProfile,
+  advertised: PairingGetDirectEndpointsResult
+): HostProfile {
+  if (!advertised.selected && advertised.endpoints.length === 0) {
+    return host
+  }
+  const selectedUrl = advertised.selected?.url ?? advertised.endpoints[0]?.url
+  if (!selectedUrl) {
+    return host
+  }
+  const seen = new Set<string>()
+  const direct: MobileAccessEndpoint[] = []
+  for (const endpoint of [advertised.selected, ...advertised.endpoints]) {
+    if (!endpoint || seen.has(endpoint.url)) {
+      continue
+    }
+    seen.add(endpoint.url)
+    direct.push({
+      id: endpoint.url === selectedUrl ? 'direct-primary' : `direct-${direct.length + 1}`,
+      kind: endpoint.kind,
+      url: endpoint.url
+    })
+  }
+  const relay = (host.endpoints ?? []).filter(({ kind }) => kind === 'relay')
+  const endpoints = [
+    ...direct.slice(0, Math.max(0, OVERLAY_ENDPOINT_MAX - relay.length)),
+    ...relay
+  ]
+  if (endpoints.length === 0) {
+    return { ...host, endpoint: selectedUrl, endpoints: undefined }
+  }
+  return { ...host, endpoint: selectedUrl, endpoints }
+}
+
+export async function refreshHostDirectEndpoints(args: {
+  client: RpcClient
+  host: HostProfile
+  saveHost: (host: HostProfile) => Promise<void>
+  unsupported?: { current: boolean }
+}): Promise<HostProfile> {
+  if (args.unsupported?.current) {
+    return args.host
+  }
+  try {
+    const response = await args.client.sendRequest('pairing.getDirectEndpoints', {})
+    if (!response.ok) {
+      if (response.error.code === 'method_not_found' && args.unsupported) {
+        args.unsupported.current = true
+      }
+      return args.host
+    }
+    const advertised = PairingGetDirectEndpointsResultSchema.parse(response.result)
+    const next = mergeAdvertisedDirectEndpoints(args.host, advertised)
+    if (next === args.host || hostDirectStateEqual(args.host, next)) {
+      return args.host
+    }
+    await args.saveHost(next)
+    return next
+  } catch {
+    return args.host
+  }
+}
+
+function hostDirectStateEqual(left: HostProfile, right: HostProfile): boolean {
+  return (
+    left.endpoint === right.endpoint &&
+    JSON.stringify(left.endpoints ?? null) === JSON.stringify(right.endpoints ?? null)
+  )
+}
+
+export class HostDirectEndpointRefresh {
+  private readonly unsupported = { current: false }
+
+  constructor(private readonly saveHost: (host: HostProfile) => Promise<void>) {}
+
+  apply(client: RpcClient, host: HostProfile): Promise<HostProfile> {
+    return refreshHostDirectEndpoints({
+      client,
+      host,
+      saveHost: this.saveHost,
+      unsupported: this.unsupported
+    })
+  }
+}

--- a/mobile/src/transport/mobile-direct-return-probe.ts
+++ b/mobile/src/transport/mobile-direct-return-probe.ts
@@ -21,6 +21,7 @@ export class DirectReturnProbe {
     private readonly hooks: {
       hysteresis: MobileEndpointHysteresis
       host: () => HostProfile
+      refreshDirectEndpoints: () => Promise<void>
       canSchedule: () => boolean
       canAttempt: () => boolean
       beginOperation: () => void
@@ -55,6 +56,7 @@ export class DirectReturnProbe {
     this.hooks.beginOperation()
     let successful: Awaited<ReturnType<typeof openAuthenticatedDirectEndpoint>> = null
     try {
+      await this.hooks.refreshDirectEndpoints()
       successful = await openAuthenticatedDirectEndpoint(
         this.hooks.host(),
         this.deps.openDirect,

--- a/mobile/src/transport/mobile-endpoint-supervisor-nudge.test.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor-nudge.test.ts
@@ -202,6 +202,7 @@ describe('mobile endpoint supervisor nudges', () => {
       recordMigration: vi.fn(),
       scheduleLease: vi.fn(),
       scheduleDirectProbe: vi.fn(),
+      refreshDirectEndpoints: vi.fn(async () => {}),
       onBookkeepingError: vi.fn(),
       onDialFailure: vi.fn()
     })

--- a/mobile/src/transport/mobile-endpoint-supervisor.test.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.test.ts
@@ -847,4 +847,41 @@ describe('mobile endpoint supervisor', () => {
     expect(logical.getActivePath()).toBe('relay')
     supervisor.stop()
   })
+
+  it('refreshes current LAN while on Relay without skipping hysteresis', async () => {
+    const logical = new FakeLogicalClient('disconnected', 'lan')
+    const advertised = {
+      v: 1 as const,
+      selected: { kind: 'lan' as const, url: 'ws://192.168.1.50:6768' },
+      endpoints: [{ kind: 'lan' as const, url: 'ws://192.168.1.50:6768' }]
+    }
+    const relaySession = new FakeRelaySession('connected')
+    relaySession.sendRequest.mockResolvedValue({
+      id: 'rpc-1',
+      ok: true,
+      result: advertised,
+      _meta: { runtimeId: 'runtime-1' }
+    })
+    logical.sendRequest.mockResolvedValue({
+      id: 'rpc-1',
+      ok: true,
+      result: advertised,
+      _meta: { runtimeId: 'runtime-1' }
+    })
+    const deps = dependencies({ openRelay: vi.fn(() => relaySession) })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+    await vi.waitFor(() =>
+      expect(deps.saveHost).toHaveBeenCalledWith(
+        expect.objectContaining({ endpoint: 'ws://192.168.1.50:6768' })
+      )
+    )
+    expect(logical.getActivePath()).toBe('relay')
+
+    await vi.advanceTimersByTimeAsync(15_000)
+    expect(logical.getActivePath()).toBe('relay')
+    expect(logical.migrateTo.mock.calls.some(([, path]) => path !== 'relay')).toBe(false)
+    supervisor.stop()
+  })
 })

--- a/mobile/src/transport/mobile-endpoint-supervisor.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.ts
@@ -1,5 +1,6 @@
 import type { MobileEndpointSupervisorDependencies } from './mobile-endpoint-supervisor-contract'
 import { DirectReturnProbe } from './mobile-direct-return-probe'
+import { HostDirectEndpointRefresh } from './mobile-direct-endpoint-refresh'
 import { RelayReconnectController } from './mobile-relay-reconnect-controller'
 import { RelayLeaseRotationTimer } from './mobile-relay-lease-rotation-timer'
 import { MobileEndpointHysteresis } from './mobile-endpoint-hysteresis'
@@ -43,6 +44,7 @@ export class MobileEndpointSupervisor {
   private readonly directProbe: DirectReturnProbe
   private readonly directGrace: MobileRelayDirectGraceTimer
   private readonly sessionEstablisher: MobileRelaySessionEstablisher
+  private readonly directEndpointRefresh: HostDirectEndpointRefresh
 
   constructor(
     private readonly logical: StableLogicalRpcClient,
@@ -76,6 +78,7 @@ export class MobileEndpointSupervisor {
     this.directGrace = new MobileRelayDirectGraceTimer(dependencies, logical, () => {
       void this.recoverRelay(true, true)
     })
+    this.directEndpointRefresh = new HostDirectEndpointRefresh(dependencies.saveHost)
     this.sessionEstablisher = new MobileRelaySessionEstablisher({
       logical,
       controller: this.relayReconnect,
@@ -101,6 +104,9 @@ export class MobileEndpointSupervisor {
       scheduleLease: (expiry) =>
         this.leaseRotation.scheduleFromLease(this.stopped || !this.foreground ? null : expiry),
       scheduleDirectProbe: () => this.directProbe.schedule(),
+      refreshDirectEndpoints: async (client) => {
+        this.host = await this.directEndpointRefresh.apply(client, this.host)
+      },
       onBookkeepingError: (error) =>
         this.logRelay('relay bookkeeping failed after migration', error.message.slice(0, 80)),
       onDialFailure: (error) =>
@@ -109,6 +115,9 @@ export class MobileEndpointSupervisor {
     this.directProbe = new DirectReturnProbe(dependencies, {
       hysteresis: this.hysteresis,
       host: () => this.host,
+      refreshDirectEndpoints: async () => {
+        this.host = await this.directEndpointRefresh.apply(this.logical, this.host)
+      },
       canSchedule: () =>
         !this.stopped && this.foreground && this.logical.getActivePath() === 'relay',
       canAttempt: () => !this.stopped && this.foreground && !this.operationInFlight,
@@ -334,4 +343,5 @@ export class MobileEndpointSupervisor {
       }
     }
   }
+
 }

--- a/mobile/src/transport/mobile-relay-session-establisher.ts
+++ b/mobile/src/transport/mobile-relay-session-establisher.ts
@@ -10,6 +10,7 @@ import type { MobileRelayCredentialBundle } from './mobile-relay-credential-bund
 import type { RelayReconnectController } from './mobile-relay-reconnect-controller'
 import type { StableLogicalRpcClient } from './stable-logical-rpc-client'
 import type { MobileRelayEndpoint } from '../../../src/shared/mobile-relay-credential-contract'
+import type { RpcClient } from './rpc-client'
 import type { HostProfile } from './types'
 
 type EstablishResult = { ok: true } | { ok: false; error: Error }
@@ -42,6 +43,7 @@ export class MobileRelaySessionEstablisher {
       // Owns the stopped/background null-out so a late resolve never re-arms a stale timer.
       scheduleLease: (expiry: number | null) => void
       scheduleDirectProbe: () => void
+      refreshDirectEndpoints: (client: RpcClient) => Promise<void>
       onBookkeepingError: (error: Error) => void
       onDialFailure: (error: Error) => void
     }
@@ -129,6 +131,11 @@ export class MobileRelaySessionEstablisher {
     } catch (error) {
       // Why: the session is live and registered — reporting bookkeeping as a dial
       // failure would book backoff against it and can suspend the healthy session.
+      args.onBookkeepingError(toError(error))
+    }
+    try {
+      await args.refreshDirectEndpoints(session)
+    } catch (error) {
       args.onBookkeepingError(toError(error))
     }
     args.scheduleDirectProbe()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3142,6 +3142,7 @@ void app.whenReady().then(async () => {
         onDeviceRevokeQueued: (item) => relayService.onDeviceRevokeQueued(item),
         onDemandStateChanged: () => relayService.demandStateChanged(),
         getEndpoints: (context, params) => relayService.getEndpoints(context, params),
+        getDirectEndpoints: (context, params) => relayService.getDirectEndpoints(context, params),
         provisionRelay: (context, params) => relayService.provisionRelay(context, params)
       })
       relayService.start()

--- a/src/main/runtime/pairing-direct-endpoints.test.ts
+++ b/src/main/runtime/pairing-direct-endpoints.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import {
+  advertisePairingDirectEndpoints,
+  MAX_ADVERTISED_DIRECT_ENDPOINTS,
+  resolveDesktopDirectEndpoints
+} from './pairing-direct-endpoints'
+import type { PairingNetworkInterface } from '../../shared/pairing-address-auto-selection'
+
+const LAN: PairingNetworkInterface = { name: 'en0', address: '192.168.1.20' }
+const TAILSCALE: PairingNetworkInterface = { name: 'tailscale0', address: '100.64.0.2' }
+const DOCKER: PairingNetworkInterface = { name: 'docker0', address: '172.17.0.1' }
+const LOOPBACK: PairingNetworkInterface = { name: 'lo0', address: '127.0.0.1' }
+const FAKE_IP: PairingNetworkInterface = { name: 'utun4', address: '198.18.0.1' }
+
+describe('advertisePairingDirectEndpoints', () => {
+  it('advertises the current LAN and Tailscale addresses on a wide bind', () => {
+    expect(
+      advertisePairingDirectEndpoints({
+        boundEndpoint: 'ws://0.0.0.0:6768',
+        interfaces: [LAN, TAILSCALE]
+      })
+    ).toEqual({
+      v: 1,
+      selected: { kind: 'tailscale', url: 'ws://100.64.0.2:6768' },
+      endpoints: [
+        { kind: 'tailscale', url: 'ws://100.64.0.2:6768' },
+        { kind: 'lan', url: 'ws://192.168.1.20:6768' }
+      ]
+    })
+  })
+
+  it('uses the actual bound WebSocket port', () => {
+    expect(
+      advertisePairingDirectEndpoints({
+        boundEndpoint: 'ws://0.0.0.0:7443',
+        interfaces: [LAN]
+      }).selected
+    ).toEqual({ kind: 'lan', url: 'ws://192.168.1.20:7443' })
+  })
+
+  it('does not advertise LAN while the listener is still loopback-bound', () => {
+    expect(
+      advertisePairingDirectEndpoints({
+        boundEndpoint: 'ws://127.0.0.1:6768',
+        interfaces: [LAN, TAILSCALE]
+      })
+    ).toEqual({ v: 1, selected: null, endpoints: [] })
+  })
+
+  it('never advertises loopback, docker bridges, or proxy fake IPs', () => {
+    expect(
+      advertisePairingDirectEndpoints({
+        boundEndpoint: 'ws://0.0.0.0:6768',
+        interfaces: [LOOPBACK, DOCKER, FAKE_IP, LAN]
+      })
+    ).toEqual({
+      v: 1,
+      selected: { kind: 'lan', url: 'ws://192.168.1.20:6768' },
+      endpoints: [{ kind: 'lan', url: 'ws://192.168.1.20:6768' }]
+    })
+  })
+
+  it('caps the ranked list so the overlay stays within 16', () => {
+    const interfaces = Array.from({ length: 20 }, (_, index) => ({
+      name: `en${index}`,
+      address: `10.0.0.${index + 1}`
+    }))
+    const result = advertisePairingDirectEndpoints({
+      boundEndpoint: 'ws://0.0.0.0:6768',
+      interfaces
+    })
+    expect(result.endpoints).toHaveLength(MAX_ADVERTISED_DIRECT_ENDPOINTS)
+    expect(result.endpoints.length).toBeLessThan(16)
+  })
+})
+
+describe('resolveDesktopDirectEndpoints', () => {
+  it('does not invent a path for local-only devices', async () => {
+    await expect(
+      resolveDesktopDirectEndpoints({
+        connectionMode: 'local-only',
+        boundEndpoint: 'ws://0.0.0.0:6768'
+      })
+    ).resolves.toEqual({ v: 1, selected: null, endpoints: [] })
+  })
+})

--- a/src/main/runtime/pairing-direct-endpoints.ts
+++ b/src/main/runtime/pairing-direct-endpoints.ts
@@ -1,0 +1,95 @@
+import {
+  isVirtualBridgeInterface,
+  selectAutoAdvertisedPairingAddress,
+  type PairingNetworkInterface
+} from '../../shared/pairing-address-auto-selection'
+import { classifyRemotePairingHostname } from '../../shared/remote-pairing-address'
+import { isTailnetIPv4Address } from '../../shared/tailnet-address'
+import type { PairingGetDirectEndpointsResult } from '../../shared/mobile-relay-credential-contract'
+import { resolveAdvertisedPairingEndpoint } from './pairing-endpoint'
+import { getPairingNetworkInterfaces } from './pairing-network-interfaces'
+
+// Why: overlay max is 16 including the relay row; keep a short ranked LAN list.
+export const MAX_ADVERTISED_DIRECT_ENDPOINTS = 8
+
+const EMPTY_DIRECT_ENDPOINTS: PairingGetDirectEndpointsResult = {
+  v: 1,
+  selected: null,
+  endpoints: []
+}
+
+export function isLoopbackWebSocketBind(endpoint: string): boolean {
+  try {
+    const hostname = new URL(endpoint).hostname.replace(/^\[|\]$/g, '')
+    return classifyRemotePairingHostname(hostname) === 'loopback'
+  } catch {
+    return true
+  }
+}
+
+export function advertisePairingDirectEndpoints(args: {
+  boundEndpoint: string | null
+  interfaces: readonly PairingNetworkInterface[]
+}): PairingGetDirectEndpointsResult {
+  const bound = args.boundEndpoint
+  if (!bound || isLoopbackWebSocketBind(bound)) {
+    return EMPTY_DIRECT_ENDPOINTS
+  }
+
+  const advertisable = args.interfaces.filter(
+    (iface) =>
+      !isVirtualBridgeInterface(iface.name, iface.hasDefaultRoute) &&
+      classifyRemotePairingHostname(iface.address) !== 'loopback' &&
+      !/^198\.(?:18|19)\./.test(iface.address)
+  )
+  const selectedAddress = selectAutoAdvertisedPairingAddress(advertisable)
+  const ordered = [
+    ...advertisable.filter((iface) => iface.address === selectedAddress),
+    ...advertisable.filter((iface) => iface.address !== selectedAddress)
+  ]
+
+  const endpoints: PairingGetDirectEndpointsResult['endpoints'] = []
+  const seen = new Set<string>()
+  for (const iface of ordered) {
+    const resolved = resolveAdvertisedPairingEndpoint(bound, iface.address)
+    if (!resolved.ok || seen.has(resolved.endpoint)) {
+      continue
+    }
+    let hostname: string
+    try {
+      hostname = new URL(resolved.endpoint).hostname.replace(/^\[|\]$/g, '')
+    } catch {
+      continue
+    }
+    if (classifyRemotePairingHostname(hostname) === 'loopback') {
+      continue
+    }
+    seen.add(resolved.endpoint)
+    endpoints.push({
+      kind: isTailnetIPv4Address(hostname) ? 'tailscale' : 'lan',
+      url: resolved.endpoint
+    })
+    if (endpoints.length >= MAX_ADVERTISED_DIRECT_ENDPOINTS) {
+      break
+    }
+  }
+
+  return {
+    v: 1,
+    selected: endpoints[0] ?? null,
+    endpoints
+  }
+}
+
+export async function resolveDesktopDirectEndpoints(args: {
+  connectionMode: string | undefined
+  boundEndpoint: string | null
+}): Promise<PairingGetDirectEndpointsResult> {
+  if (args.connectionMode === 'local-only') {
+    return { v: 1, selected: null, endpoints: [] }
+  }
+  return advertisePairingDirectEndpoints({
+    boundEndpoint: args.boundEndpoint,
+    interfaces: await getPairingNetworkInterfaces()
+  })
+}

--- a/src/main/runtime/relay/desktop-relay-service.test.ts
+++ b/src/main/runtime/relay/desktop-relay-service.test.ts
@@ -123,5 +123,10 @@ describe('local-only mobile pairing', () => {
         newResumeTokenHash: 'A'.repeat(43)
       })
     ).rejects.toThrow('relay_disabled_for_device')
+    await expect(service.getDirectEndpoints(context({ transport: 'direct' }), {})).resolves.toEqual({
+      v: 1,
+      selected: null,
+      endpoints: []
+    })
   })
 })

--- a/src/main/runtime/relay/desktop-relay-service.ts
+++ b/src/main/runtime/relay/desktop-relay-service.ts
@@ -2,10 +2,13 @@ import type { OrcaCloudAuthConfig } from '../../orca-profiles/profile-cloud-auth
 import type { MobilePairingConnectionContext, OrcaRuntimeRpcServer } from '../runtime-rpc'
 import type {
   DeviceCredentialInstalled,
+  PairingGetDirectEndpointsParams,
+  PairingGetDirectEndpointsResult,
   PairingGetEndpointsParams,
   PairingGetEndpointsResult,
   PairingProvisionRelayParams
 } from '../../../shared/mobile-relay-credential-contract'
+import { resolveDesktopDirectEndpoints } from '../pairing-direct-endpoints'
 import { readRelayAuthContext } from './relay-auth-context'
 import { RelayAuthCoordinator } from './relay-auth-coordinator'
 import { RelaySessionBroker, type RelayBrokerStatus } from './relay-session-broker'
@@ -187,6 +190,23 @@ export class DesktopRelayService {
         )
       }
       return result
+    })
+  }
+
+  async getDirectEndpoints(
+    context: MobilePairingConnectionContext,
+    _params: PairingGetDirectEndpointsParams
+  ): Promise<PairingGetDirectEndpointsResult> {
+    this.requireMobileDevice(context.deviceId)
+    const connectionMode = this.runtimeRpc
+      .getDeviceRegistry()
+      ?.getMobilePairingConnectionMode(context.deviceId)
+    if (connectionMode === 'local-only') {
+      return { v: 1, selected: null, endpoints: [] }
+    }
+    return resolveDesktopDirectEndpoints({
+      connectionMode,
+      boundEndpoint: this.runtimeRpc.getWebSocketEndpoint()
     })
   }
 

--- a/src/main/runtime/rpc/core.ts
+++ b/src/main/runtime/rpc/core.ts
@@ -4,6 +4,8 @@ import type { TerminalStreamFrame } from '../../../shared/terminal-stream-protoc
 import type { OrcaRuntimeService, OrchestrationCompatibilityCallerAuthority } from '../orca-runtime'
 import type {
   DeviceCredentialInstalled,
+  PairingGetDirectEndpointsParams,
+  PairingGetDirectEndpointsResult,
   PairingGetEndpointsParams,
   PairingGetEndpointsResult,
   PairingProvisionRelayParams
@@ -13,6 +15,9 @@ import type { OrchestrationCompatibilityEvidence } from '../../../shared/orchest
 
 export type PairingRpcContext = {
   getEndpoints(params: PairingGetEndpointsParams): Promise<PairingGetEndpointsResult>
+  getDirectEndpoints(
+    params: PairingGetDirectEndpointsParams
+  ): Promise<PairingGetDirectEndpointsResult>
   provisionRelay(params: PairingProvisionRelayParams): Promise<DeviceCredentialInstalled>
 }
 

--- a/src/main/runtime/rpc/methods/pairing.test.ts
+++ b/src/main/runtime/rpc/methods/pairing.test.ts
@@ -30,7 +30,7 @@ describe('pairing RPC methods', () => {
       currentVersion: 1,
       resumeExpiresAt: Date.now() + 60_000
     })
-    const pairing = { getEndpoints: vi.fn(), provisionRelay }
+    const pairing = { getEndpoints: vi.fn(), getDirectEndpoints: vi.fn(), provisionRelay }
 
     await expect(
       dispatchPairing(
@@ -46,7 +46,7 @@ describe('pairing RPC methods', () => {
   })
 
   it('rejects caller-selected identity and authorization metadata', async () => {
-    const pairing = { getEndpoints: vi.fn(), provisionRelay: vi.fn() }
+    const pairing = { getEndpoints: vi.fn(), getDirectEndpoints: vi.fn(), provisionRelay: vi.fn() }
 
     for (const injected of [
       { relayDeviceId: 'attacker-device' },
@@ -73,3 +73,37 @@ describe('pairing RPC methods', () => {
     expect(pairing.getEndpoints).not.toHaveBeenCalled()
   })
 })
+
+  it('rejects extra keys on pairing.getDirectEndpoints and dispatches an empty object', async () => {
+    const getDirectEndpoints = vi.fn().mockResolvedValue({ v: 1, selected: null, endpoints: [] })
+    const pairing = { getEndpoints: vi.fn(), getDirectEndpoints, provisionRelay: vi.fn() }
+
+    await expect(
+      dispatchPairing('pairing.getDirectEndpoints', { injected: true }, pairing)
+    ).resolves.toMatchObject({ ok: false, error: { code: 'invalid_argument' } })
+    expect(getDirectEndpoints).not.toHaveBeenCalled()
+
+    await expect(dispatchPairing('pairing.getDirectEndpoints', {}, pairing)).resolves.toMatchObject({
+      ok: true,
+      result: { v: 1, selected: null, endpoints: [] }
+    })
+    expect(getDirectEndpoints).toHaveBeenCalledWith({})
+  })
+
+  it('returns method_not_found on an old desktop that never registered the RPC', async () => {
+    const pairing = { getEndpoints: vi.fn(), getDirectEndpoints: vi.fn(), provisionRelay: vi.fn() }
+    const result = await new Promise<Record<string, unknown>>((resolve) => {
+      const dispatcher = new RpcDispatcher({
+        runtime: new OrcaRuntimeService(),
+        methods: PAIRING_METHODS.filter((method) => method.name !== 'pairing.getDirectEndpoints')
+      })
+      void dispatcher.dispatchStreaming(
+        { id: 'request-1', authToken: '', method: 'pairing.getDirectEndpoints', params: {} },
+        (response) => resolve(JSON.parse(response) as Record<string, unknown>),
+        { pairing }
+      )
+    })
+    expect(result).toMatchObject({ ok: false, error: { code: 'method_not_found' } })
+    expect(pairing.getDirectEndpoints).not.toHaveBeenCalled()
+  })
+

--- a/src/main/runtime/rpc/methods/pairing.ts
+++ b/src/main/runtime/rpc/methods/pairing.ts
@@ -1,5 +1,6 @@
 import { defineMethod, type RpcAnyMethod } from '../core'
 import {
+  PairingGetDirectEndpointsParamsSchema,
   PairingGetEndpointsParamsSchema,
   PairingProvisionRelayParamsSchema
 } from '../../../../shared/mobile-relay-credential-contract'
@@ -13,6 +14,16 @@ export const PAIRING_METHODS: readonly RpcAnyMethod[] = [
         throw new Error('pairing_context_unavailable')
       }
       return await ctx.pairing.getEndpoints(params)
+    }
+  }),
+  defineMethod({
+    name: 'pairing.getDirectEndpoints',
+    params: PairingGetDirectEndpointsParamsSchema,
+    handler: async (params, ctx) => {
+      if (!ctx.pairing) {
+        throw new Error('pairing_context_unavailable')
+      }
+      return await ctx.pairing.getDirectEndpoints(params)
     }
   }),
   defineMethod({

--- a/src/main/runtime/rpc/streaming.test.ts
+++ b/src/main/runtime/rpc/streaming.test.ts
@@ -24,6 +24,7 @@ describe('RpcDispatcher streaming', () => {
   it('passes pairing authority to streaming handlers', async () => {
     const pairing = {
       getEndpoints: vi.fn(),
+      getDirectEndpoints: vi.fn(),
       provisionRelay: vi.fn()
     }
     let receivedPairing: unknown

--- a/src/main/runtime/runtime-rpc-pairing-mode-persistence.test.ts
+++ b/src/main/runtime/runtime-rpc-pairing-mode-persistence.test.ts
@@ -42,6 +42,7 @@ describe('OrcaRuntimeRpcServer', () => {
       createPairingRelay,
       onDeviceRevokeQueued: vi.fn(),
       getEndpoints: vi.fn(),
+      getDirectEndpoints: vi.fn(),
       provisionRelay: vi.fn()
     })
 
@@ -101,6 +102,7 @@ describe('OrcaRuntimeRpcServer', () => {
       }),
       onDeviceRevokeQueued: vi.fn(),
       getEndpoints: vi.fn(),
+      getDirectEndpoints: vi.fn(),
       provisionRelay: vi.fn()
     })
 
@@ -151,6 +153,7 @@ describe('OrcaRuntimeRpcServer', () => {
       }),
       onDeviceRevokeQueued,
       getEndpoints: vi.fn(),
+      getDirectEndpoints: vi.fn(),
       provisionRelay: vi.fn()
     })
 
@@ -206,6 +209,7 @@ describe('OrcaRuntimeRpcServer', () => {
       }),
       onDeviceRevokeQueued: vi.fn(),
       getEndpoints: vi.fn(),
+      getDirectEndpoints: vi.fn(),
       provisionRelay: vi.fn()
     })
 
@@ -264,6 +268,7 @@ describe('OrcaRuntimeRpcServer', () => {
       }),
       onDeviceRevokeQueued,
       getEndpoints: vi.fn(),
+      getDirectEndpoints: vi.fn(),
       provisionRelay: vi.fn()
     })
 
@@ -319,6 +324,7 @@ describe('OrcaRuntimeRpcServer', () => {
         registryPresence.push(server.getDeviceRegistry()?.getDevice(item.relayDeviceId) !== null)
       },
       getEndpoints: vi.fn(),
+      getDirectEndpoints: vi.fn(),
       provisionRelay: vi.fn()
     })
 
@@ -355,6 +361,7 @@ describe('OrcaRuntimeRpcServer', () => {
       wsPort: 0
     })
     const getEndpoints = vi.fn().mockResolvedValue({ v: 1, relay: null })
+    const getDirectEndpoints = vi.fn().mockResolvedValue({ v: 1, selected: null, endpoints: [] })
     const provisionRelay = vi.fn().mockResolvedValue({
       v: 1,
       reqId: 'install-1',
@@ -366,6 +373,7 @@ describe('OrcaRuntimeRpcServer', () => {
       createPairingRelay: vi.fn(),
       onDeviceRevokeQueued: vi.fn(),
       getEndpoints,
+      getDirectEndpoints,
       provisionRelay
     })
 

--- a/src/main/runtime/runtime-rpc-relay-pairing.test.ts
+++ b/src/main/runtime/runtime-rpc-relay-pairing.test.ts
@@ -52,6 +52,7 @@ describe('OrcaRuntimeRpcServer', () => {
       }),
       onDeviceRevokeQueued: vi.fn(),
       getEndpoints: vi.fn(),
+      getDirectEndpoints: vi.fn(),
       provisionRelay: vi.fn()
     })
 
@@ -112,6 +113,7 @@ describe('OrcaRuntimeRpcServer', () => {
       }),
       onDeviceRevokeQueued,
       getEndpoints: vi.fn(),
+      getDirectEndpoints: vi.fn(),
       provisionRelay: vi.fn()
     })
 
@@ -160,6 +162,7 @@ describe('OrcaRuntimeRpcServer', () => {
       createPairingRelay: vi.fn().mockRejectedValue(new Error('relay offline')),
       onDeviceRevokeQueued: vi.fn(),
       getEndpoints: vi.fn(),
+      getDirectEndpoints: vi.fn(),
       provisionRelay: vi.fn()
     })
 
@@ -241,6 +244,7 @@ describe('OrcaRuntimeRpcServer', () => {
       createPairingRelay,
       onDeviceRevokeQueued: vi.fn(),
       getEndpoints: vi.fn(),
+      getDirectEndpoints: vi.fn(),
       provisionRelay: vi.fn()
     })
 
@@ -296,6 +300,7 @@ describe('OrcaRuntimeRpcServer', () => {
       createPairingRelay,
       onDeviceRevokeQueued: vi.fn(),
       getEndpoints: vi.fn(),
+      getDirectEndpoints: vi.fn(),
       provisionRelay: vi.fn()
     })
 
@@ -358,6 +363,7 @@ describe('OrcaRuntimeRpcServer', () => {
       createPairingRelay,
       onDeviceRevokeQueued,
       getEndpoints: vi.fn(),
+      getDirectEndpoints: vi.fn(),
       provisionRelay: vi.fn()
     })
 
@@ -429,6 +435,7 @@ describe('OrcaRuntimeRpcServer', () => {
       createPairingRelay,
       onDeviceRevokeQueued,
       getEndpoints: vi.fn(),
+      getDirectEndpoints: vi.fn(),
       provisionRelay: vi.fn()
     })
 
@@ -490,6 +497,7 @@ describe('OrcaRuntimeRpcServer', () => {
       },
       onDeviceRevokeQueued,
       getEndpoints: vi.fn(),
+      getDirectEndpoints: vi.fn(),
       provisionRelay: vi.fn()
     })
 
@@ -549,6 +557,7 @@ describe('OrcaRuntimeRpcServer', () => {
       }),
       onDeviceRevokeQueued,
       getEndpoints: vi.fn(),
+      getDirectEndpoints: vi.fn(),
       provisionRelay: vi.fn()
     })
 
@@ -605,6 +614,7 @@ describe('OrcaRuntimeRpcServer', () => {
       },
       onDeviceRevokeQueued: vi.fn(),
       getEndpoints: vi.fn(),
+      getDirectEndpoints: vi.fn(),
       provisionRelay: vi.fn()
     })
 
@@ -619,6 +629,7 @@ describe('OrcaRuntimeRpcServer', () => {
         createPairingRelay: vi.fn(),
         onDeviceRevokeQueued,
         getEndpoints: vi.fn(),
+        getDirectEndpoints: vi.fn(),
         provisionRelay: vi.fn()
       })
       resolveRelay?.()
@@ -665,6 +676,7 @@ describe('OrcaRuntimeRpcServer', () => {
       },
       onDeviceRevokeQueued: vi.fn(),
       getEndpoints: vi.fn(),
+      getDirectEndpoints: vi.fn(),
       provisionRelay: vi.fn()
     })
 
@@ -685,6 +697,7 @@ describe('OrcaRuntimeRpcServer', () => {
         createPairingRelay: vi.fn(),
         onDeviceRevokeQueued: vi.fn(),
         getEndpoints: vi.fn(),
+        getDirectEndpoints: vi.fn(),
         provisionRelay: vi.fn()
       })
       resolveRelay?.()
@@ -727,6 +740,7 @@ describe('OrcaRuntimeRpcServer', () => {
       }),
       onDeviceRevokeQueued,
       getEndpoints: vi.fn(),
+      getDirectEndpoints: vi.fn(),
       provisionRelay: vi.fn()
     })
 

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -43,6 +43,8 @@ import {
 } from './relay/relay-revoke-outbox'
 import type {
   DeviceCredentialInstalled,
+  PairingGetDirectEndpointsParams,
+  PairingGetDirectEndpointsResult,
   PairingGetEndpointsParams,
   PairingGetEndpointsResult,
   PairingProvisionRelayParams
@@ -135,6 +137,10 @@ type MobileRelayPairingProvider = {
     context: MobilePairingConnectionContext,
     params: PairingGetEndpointsParams
   ): Promise<PairingGetEndpointsResult>
+  getDirectEndpoints(
+    context: MobilePairingConnectionContext,
+    params: PairingGetDirectEndpointsParams
+  ): Promise<PairingGetDirectEndpointsResult>
   provisionRelay(
     context: MobilePairingConnectionContext,
     params: PairingProvisionRelayParams
@@ -352,6 +358,7 @@ const MOBILE_RPC_METHOD_ALLOWLIST = new Set([
   'notifications.subscribe',
   'notifications.unsubscribe',
   'pairing.getEndpoints',
+  'pairing.getDirectEndpoints',
   'pairing.provisionRelay',
   'preflight.check',
   'preflight.detectAgents',
@@ -1693,6 +1700,15 @@ export class OrcaRuntimeRpcServer {
         ? {
             getEndpoints: (params: PairingGetEndpointsParams) =>
               pairingProvider.getEndpoints(
+                {
+                  deviceId: authenticatedSocket.device.deviceId,
+                  connectionId: authenticatedSocket.connectionId,
+                  transport: authenticatedSocket.transport
+                },
+                params
+              ),
+            getDirectEndpoints: (params: PairingGetDirectEndpointsParams) =>
+              pairingProvider.getDirectEndpoints(
                 {
                   deviceId: authenticatedSocket.device.deviceId,
                   connectionId: authenticatedSocket.connectionId,

--- a/src/shared/mobile-relay-credential-contract.test.ts
+++ b/src/shared/mobile-relay-credential-contract.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import {
+  PairingGetDirectEndpointsResultSchema,
+  PairingGetEndpointsResultSchema
+} from './mobile-relay-credential-contract'
+
+const relay = {
+  v: 1 as const,
+  directorUrl: 'https://relay.onorca.dev',
+  cellUrl: 'https://relay-c1.onorca.dev',
+  assignmentEpoch: 7,
+  relayHostId: 'AbCdEf0123_-xyZ9',
+  e2eeFraming: 2 as const
+}
+
+describe('pairing endpoint contract', () => {
+  it('keeps getEndpoints v1 strict so extra LAN keys fail old-phone resume-confirm', () => {
+    expect(
+      PairingGetEndpointsResultSchema.safeParse({
+        v: 1,
+        relay,
+        selected: { kind: 'lan', url: 'ws://192.168.1.10:6768' },
+        endpoints: [{ kind: 'lan', url: 'ws://192.168.1.10:6768' }]
+      }).success
+    ).toBe(false)
+    expect(PairingGetEndpointsResultSchema.parse({ v: 1, relay })).toEqual({ v: 1, relay })
+  })
+
+  it('accepts a ranked getDirectEndpoints v1 payload', () => {
+    const selected = { kind: 'tailscale' as const, url: 'ws://100.64.0.2:6768' }
+    expect(
+      PairingGetDirectEndpointsResultSchema.parse({
+        v: 1,
+        selected,
+        endpoints: [selected, { kind: 'lan', url: 'ws://192.168.1.20:6768' }]
+      })
+    ).toEqual({
+      v: 1,
+      selected,
+      endpoints: [selected, { kind: 'lan', url: 'ws://192.168.1.20:6768' }]
+    })
+  })
+})

--- a/src/shared/mobile-relay-credential-contract.ts
+++ b/src/shared/mobile-relay-credential-contract.ts
@@ -84,8 +84,30 @@ export const PairingGetEndpointsResultSchema = z
   })
   .strict()
 
+// Why: a new RPC, not extra getEndpoints v1 keys — that schema is .strict() and
+// old phones parse resume-confirm with it.
+export const PairingGetDirectEndpointsParamsSchema = z.object({}).strict()
+
+export const PairingDirectEndpointSchema = z
+  .object({
+    kind: z.enum(['lan', 'tailscale']),
+    url: z.string().min(1).max(2048)
+  })
+  .strict()
+
+export const PairingGetDirectEndpointsResultSchema = z
+  .object({
+    v: z.literal(1),
+    selected: PairingDirectEndpointSchema.nullable(),
+    endpoints: z.array(PairingDirectEndpointSchema).max(16)
+  })
+  .strict()
+
 export type PairingProvisionRelayParams = z.infer<typeof PairingProvisionRelayParamsSchema>
 export type PairingGetEndpointsParams = z.infer<typeof PairingGetEndpointsParamsSchema>
+export type PairingGetDirectEndpointsParams = z.infer<typeof PairingGetDirectEndpointsParamsSchema>
+export type PairingDirectEndpoint = z.infer<typeof PairingDirectEndpointSchema>
+export type PairingGetDirectEndpointsResult = z.infer<typeof PairingGetDirectEndpointsResultSchema>
 export type DeviceCredentialInstalled = z.infer<typeof DeviceCredentialInstalledSchema>
 export type DeviceCredentialInstallStatusResult = z.infer<
   typeof DeviceCredentialInstallStatusResultSchema


### PR DESCRIPTION
## ELI5

When you pair your phone with the desktop, the phone stores the desktop LAN (and Tailscale) addresses from that moment. If the desktop later changes Wi-Fi -- cafe DHCP, a new NIC, leaving the pair-time subnet -- those stored IPs go stale. The phone keeps probing a dead address and stays on Relay even when a live direct path exists. This PR lets the phone, while still on Relay, ask the desktop for its current LAN/Tailscale addresses and replace the stale overlay rows. Switching the host card to Direct still waits for the existing hysteresis / DirectReturnProbe (consecutive authenticated successes + dwell); advertising a new IP is not enough.

## What Changed

- New RPC `pairing.getDirectEndpoints`. Do **not** extend `pairing.getEndpoints` v1: that result schema is `.strict()`, and extra keys break old phones on resume-confirm.
- While the phone is on Relay, it refreshes overlay direct rows (and `host.endpoint`) after resume confirm and again before each `DirectReturnProbe`.
- Old desktops return `method_not_found`; the pair-time LAN is kept.
- Tests added for advertise filters, strict `getEndpoints`, merge cap 16, and hysteresis not skipped.

## Why

The pair-time LAN/Tailscale snapshot goes stale (cafe DHCP, new NIC). The phone keeps probing a dead address and sticks on Relay even when a live direct path exists.

## Linked Issue

None / not filed.

## Visual Proof

No visual change. Backend/RPC + mobile transport only; the host card still uses the existing path labels after hysteresis.

## Testing
CI on the fork is waiting for maintainer workflow approval (`action_required`). Automated tests were added and updated:

- mobile/src/transport/mobile-direct-endpoint-refresh.test.ts (new)
- src/main/runtime/pairing-direct-endpoints.test.ts (new)
- src/shared/mobile-relay-credential-contract.test.ts (new)
- plus updates in supervisor, pairing RPC, relay-service, and runtime-rpc pairing tests

Coverage includes: desktop advertises current LAN/Tailscale on a wide bind using the actual WS port;
loopback / docker / WSL / bridge / vEthernet / 198.18 fake-IPs are not advertised; local-only devices get an empty list;
pairing.getEndpoints v1 stays strict; old desktop without the RPC returns method_not_found and pair-time LAN is kept;
phone merge replaces cafe/NIC history and does not grow past 16; advertising a new LAN does not skip hysteresis.

We did not run the full local suite (lint, typecheck, test, build) on a Mac or dev machine.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

This change was implemented with AI assistance (Grok Bot / coding agent) from analysis through the PR. Human author: OrdinarySF.

## Review

- Cross-platform: desktop RPC uses existing Node/Electron network-interface helpers; no macOS-only APIs. Mobile TS is already cross-platform.
- SSH/remote/local: pairing/LAN advertise is about the desktop local NICs for the phone, not git worktrees. Does not assume a local-only repo path.
- Agents/integrations: provider-neutral; pairing transport only.
- Performance: refresh on resume confirm + before probe cadence, not a hot render path. Overlay capped at 16.
- UI: no UI change.
- Security: does not advertise loopback; filters docker/WSL/bridge/vEthernet/198.18; empty list for local-only devices; additive RPC.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

Additive RPC only; no protocol version bump. Relay stays the default pairing mode. Hysteresis is unchanged.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @OrdinarySF
