### PR TITLE
feat(native-chat): Extra high grok effort per model

### DIFF
--- a/src/renderer/src/components/native-chat/native-chat-pty-session-options.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pty-session-options.test.ts
@@ -719,7 +719,7 @@ describe('native chat PTY session options', () => {
     expect(surface.getSnapshot()[0]).toMatchObject({
       id: 'model',
       valueSource: 'default',
-      kind: { currentValue: 'grok-4.5' }
+      kind: { currentValue: 'grok-4.6' }
     })
 
     // Regression: the effort row hangs off that default model, so resolving the apply
@@ -735,9 +735,9 @@ describe('native chat PTY session options', () => {
 
   it('does not adopt grok’s unprobed seed default as a persisted launch model', async () => {
     // Regression: setting an option under the CLI default wrote `model` into settings,
-    // so every later grok launch app-wide emitted `-m grok-4.5` — on an account without
+    // so every later grok launch app-wide emitted `-m grok-4.6` — on an account without
     // that model, a fatal launch the user never opted into. No discovery has run here,
-    // so `grok-4.5` is still only the seed's guess.
+    // so `grok-4.6` is still only the seed's guess.
     let persisted: PersistedNativeChatSessionOptions = {}
     const surface = createNativeChatPtySessionOptions({
       agent: 'grok',
@@ -760,7 +760,7 @@ describe('native chat PTY session options', () => {
 
     expect(persisted.grok?.model).toBeUndefined()
     // The scoped value is still remembered for a later explicit pick of that model.
-    expect(persisted.grok?.valuesByModel?.['grok-4.5']?.effort).toBe('low')
+    expect(persisted.grok?.valuesByModel?.['grok-4.6']?.effort).toBe('low')
     expect(resolveNativeChatSessionOptionDefaults(persisted, 'grok')).toBeUndefined()
 
     // A model the user actually picks still becomes the launch default.

--- a/src/shared/agent-model-probe-spec.test.ts
+++ b/src/shared/agent-model-probe-spec.test.ts
@@ -11,7 +11,7 @@ describe('getAgentModelProbeSpec', () => {
       binary: 'grok',
       modelSource: 'dynamic',
       models: [],
-      defaultModelId: 'grok-4.5'
+      defaultModelId: 'grok-4.6'
     })
     expect(spec?.modelDiscovery).toMatchObject({ binary: 'grok', args: ['models'] })
   })

--- a/src/shared/agent-model-probe-spec.ts
+++ b/src/shared/agent-model-probe-spec.ts
@@ -21,7 +21,7 @@ const MODEL_DISCOVERY_ONLY_SPECS: Partial<Record<TuiAgent, AgentModelProbeSpec>>
     // Why: empty so a failed probe degrades to the catalog seed instead of a
     // second model list here that can drift from it.
     models: [],
-    defaultModelId: 'grok-4.5'
+    defaultModelId: 'grok-4.6'
   }
 }
 

--- a/src/shared/agent-session-option-catalog-grok.test.ts
+++ b/src/shared/agent-session-option-catalog-grok.test.ts
@@ -10,8 +10,13 @@ import { GROK_SESSION_OPTION_CATALOG } from './agent-session-option-catalog-grok
 import { resolveAgentSessionOptionLaunch } from './agent-session-option-launch'
 import { parseBuiltSessionOptionCommand } from './native-chat-session-option-commands'
 
-function grokEffortOption(): CatalogOption {
-  return GROK_SESSION_OPTION_CATALOG.models[0].options.find((option) => option.id === 'effort')!
+function grokEffortOption(modelId = 'grok-4.6'): CatalogOption {
+  const model = GROK_SESSION_OPTION_CATALOG.models.find((candidate) => candidate.id === modelId)!
+  return model.options.find((option) => option.id === 'effort')!
+}
+
+function effortValues(option: CatalogOption): string[] {
+  return option.kind.type === 'select' ? option.kind.choices.map((choice) => choice.value) : []
 }
 
 describe('grok session option catalog', () => {
@@ -19,34 +24,50 @@ describe('grok session option catalog', () => {
     expect(getAgentSessionOptionCatalog('grok')).toBe(GROK_SESSION_OPTION_CATALOG)
   })
 
-  it('seeds only the one verified model, with an effort menu', () => {
-    expect(GROK_SESSION_OPTION_CATALOG.models.map(({ id, label }) => ({ id, label }))).toEqual([
-      { id: 'grok-4.5', label: 'Grok 4.5' }
+  it('seeds only the verified models, defaulting to the newest', () => {
+    expect(
+      GROK_SESSION_OPTION_CATALOG.models.map(({ id, label, isDefault }) => ({
+        id,
+        label,
+        isDefault
+      }))
+    ).toEqual([
+      { id: 'grok-4.6', label: 'Grok 4.6', isDefault: true },
+      { id: 'grok-4.5', label: 'Grok 4.5', isDefault: undefined }
     ])
-    expect(GROK_SESSION_OPTION_CATALOG.models[0].isDefault).toBe(true)
+  })
+
+  it('keeps the effort option shaped the way the picker and the wire expect', () => {
     const effort = grokEffortOption()
     // The id must stay `effort`: `LaunchPreferences` is a strict zod object, so a
     // novel id is dropped client-side and rejected on the wire.
     expect(effort.id).toBe('effort')
     expect(effort.category).toBe('thought_level')
+    // `high` is each model's own reported default, so an untouched picker never escalates.
     expect(effort.kind).toMatchObject({ type: 'select', defaultValue: 'high' })
-    expect(effort.kind.type === 'select' ? effort.kind.choices.map((c) => c.value) : []).toEqual([
-      'low',
-      'medium',
-      'high'
-    ])
+    expect(grokEffortOption('grok-4.5').kind).toMatchObject({ defaultValue: 'high' })
+  })
+
+  it('offers each model only the tiers its own grok menu advertises', () => {
+    // grok warns and ignores a tier the active model lacks, so 4.5 must not list xhigh.
+    expect(effortValues(grokEffortOption('grok-4.6'))).toEqual(['low', 'medium', 'high', 'xhigh'])
+    expect(effortValues(grokEffortOption('grok-4.5'))).toEqual(['low', 'medium', 'high'])
   })
 
   it('offers only effort values the shared option labels localize', () => {
     const localized = ['minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra']
-    const effort = grokEffortOption()
-    for (const choice of effort.kind.type === 'select' ? effort.kind.choices : []) {
-      expect(localized).toContain(choice.value)
+    for (const model of GROK_SESSION_OPTION_CATALOG.models) {
+      for (const value of effortValues(grokEffortOption(model.id))) {
+        expect(localized).toContain(value)
+      }
     }
   })
 
-  it('gives unknown model ids the same effort menu launch reads from the seed', () => {
-    expect(GROK_SESSION_OPTION_CATALOG.unknownModelOptions?.map(({ id }) => id)).toEqual(['effort'])
+  it('gives unknown model ids the widest effort menu launch reads from the seed', () => {
+    const unknown = GROK_SESSION_OPTION_CATALOG.unknownModelOptions ?? []
+    expect(unknown.map(({ id }) => id)).toEqual(['effort'])
+    // A tier the menu withholds is unreachable, while an unsupported one only warns.
+    expect(effortValues(unknown[0])).toEqual(['low', 'medium', 'high', 'xhigh'])
   })
 
   it('treats a successful discovery as authoritative, unlike the other agents', () => {
@@ -65,14 +86,30 @@ describe('grok launch args', () => {
     })
   })
 
+  it('carries the xhigh tier through to argv on a model that advertises it', () => {
+    expect(resolveAgentSessionOptionLaunch('grok', { model: 'grok-4.6', effort: 'xhigh' })).toEqual(
+      {
+        args: ['-m', 'grok-4.6', '--reasoning-effort', 'xhigh'],
+        appliedValues: { model: 'grok-4.6', effort: 'xhigh' }
+      }
+    )
+  })
+
   it('emits exactly the two model tokens', () => {
-    expect(GROK_SESSION_OPTION_CATALOG.modelApply.launchArgs!('grok-4.5')).toEqual([
+    expect(GROK_SESSION_OPTION_CATALOG.modelApply.launchArgs!('grok-4.6')).toEqual([
       '-m',
-      'grok-4.5'
+      'grok-4.6'
     ])
   })
 
   it('falls back to the seeded effort default when none is stored', () => {
+    // `high`, not the menu's ceiling: xhigh is opt-in, never a silent escalation.
+    expect(resolveAgentSessionOptionLaunch('grok', { model: 'grok-4.6' }).args).toEqual([
+      '-m',
+      'grok-4.6',
+      '--reasoning-effort',
+      'high'
+    ])
     expect(resolveAgentSessionOptionLaunch('grok', { model: 'grok-4.5' }).args).toEqual([
       '-m',
       'grok-4.5',
@@ -101,6 +138,15 @@ describe('grok launch args', () => {
         appliedValues: { model: 'grok-build', effort: 'low' }
       }
     )
+  })
+
+  it('carries xhigh onto an unseeded model, whose menu is the widest one', () => {
+    expect(
+      resolveAgentSessionOptionLaunch('grok', { model: 'grok-build', effort: 'xhigh' })
+    ).toEqual({
+      args: ['-m', 'grok-build', '--reasoning-effort', 'xhigh'],
+      appliedValues: { model: 'grok-build', effort: 'xhigh' }
+    })
   })
 
   it('drops an effort value the menu does not offer on an unseeded model', () => {
@@ -219,6 +265,10 @@ describe('mergeDiscoveredAuthoritativeModels', () => {
   const seed = GROK_SESSION_OPTION_CATALOG.models
   const discovered = (...ids: string[]): CatalogModel[] =>
     ids.map((id) => ({ id, label: id, options: [] }))
+  const mergedEffortValues = (model: CatalogModel): string[] => {
+    const effort = model.options.find((option) => option.id === 'effort')
+    return effort?.kind.type === 'select' ? effort.kind.choices.map((choice) => choice.value) : []
+  }
 
   it('keeps a matched seed model’s option menu, which discovery never carries', () => {
     const merged = mergeDiscoveredAuthoritativeModels(seed, [
@@ -226,7 +276,8 @@ describe('mergeDiscoveredAuthoritativeModels', () => {
     ])
     expect(merged).toHaveLength(1)
     expect(merged[0]).toMatchObject({ id: 'grok-4.5', label: 'Grok 4.5 (live)' })
-    expect(merged[0].options.map(({ id }) => id)).toEqual(['effort'])
+    // Its own narrower menu, not the default row's — 4.5 has no xhigh tier.
+    expect(mergedEffortValues(merged[0])).toEqual(['low', 'medium', 'high'])
   })
 
   it('takes the default flag from the probe and drops the seed’s stale one', () => {
@@ -250,10 +301,8 @@ describe('mergeDiscoveredAuthoritativeModels', () => {
   })
 
   it('gives a matched seed row its own menu, not the default row’s', () => {
-    // Only a seed carrying two distinct menus can tell inheritance apart from a
-    // real match; grok's one-model seed makes the two branches look identical.
     const multiSeed: CatalogModel[] = [
-      { id: 'grok-4.5', label: 'Grok 4.5', isDefault: true, options: seed[0].options },
+      { id: 'grok-4.6', label: 'Grok 4.6', isDefault: true, options: seed[0].options },
       { id: 'grok-lite', label: 'Grok Lite', options: [] }
     ]
     const merged = mergeDiscoveredAuthoritativeModels(multiSeed, discovered('grok-lite'))
@@ -267,17 +316,18 @@ describe('mergeDiscoveredAuthoritativeModels', () => {
   })
 
   it('adds discovered models absent from the seed, lending them the default’s options', () => {
-    // Effort is a global grok flag rather than a per-model capability, so an
-    // unseeded model still gets the menu instead of rendering an option-less pill.
+    // An unseeded model gets the default row's menu instead of an option-less pill,
+    // while a seeded sibling keeps the narrower one its own grok listing advertises.
     const merged = mergeDiscoveredAuthoritativeModels(seed, discovered('grok-4.5', 'grok-build'))
     expect(merged.map(({ id }) => id)).toEqual(['grok-4.5', 'grok-build'])
-    expect(merged[1].options.map(({ id }) => id)).toEqual(['effort'])
+    expect(mergedEffortValues(merged[0])).toEqual(['low', 'medium', 'high'])
+    expect(mergedEffortValues(merged[1])).toEqual(['low', 'medium', 'high', 'xhigh'])
   })
 
   it('takes the inherited options from the default seed row, not the first one', () => {
     const multiSeed: CatalogModel[] = [
       { id: 'legacy', label: 'Legacy', options: [] },
-      { id: 'grok-4.5', label: 'Grok 4.5', isDefault: true, options: seed[0].options }
+      { id: 'grok-4.6', label: 'Grok 4.6', isDefault: true, options: seed[0].options }
     ]
     const merged = mergeDiscoveredAuthoritativeModels(multiSeed, discovered('grok-build'))
     expect(merged[0].options.map(({ id }) => id)).toEqual(['effort'])
@@ -301,6 +351,7 @@ describe('mergeDiscoveredAuthoritativeModels', () => {
 
   it('drops the unmatched seed row the additive merge would have kept', () => {
     expect(mergeCatalogModels(seed, discovered('grok-build')).map(({ id }) => id)).toEqual([
+      'grok-4.6',
       'grok-4.5',
       'grok-build'
     ])

--- a/src/shared/agent-session-option-catalog-grok.ts
+++ b/src/shared/agent-session-option-catalog-grok.ts
@@ -6,27 +6,38 @@ import type {
 } from './agent-session-option-catalog-types'
 import { parseGrokModelList } from './grok-model-list-probe'
 
-const GROK_EFFORT: CatalogOption = {
-  // Why: `LaunchPreferences` is a strict zod object over model/effort/mode, so a
-  // novel id is dropped client-side and rejected on the wire.
-  id: 'effort',
-  label: 'Reasoning effort',
-  category: 'thought_level',
-  kind: {
-    type: 'select',
-    // Why: only values `native-chat-session-option-labels.ts` localizes; grok's
-    // `none` tier and per-model menu ids would render untranslated.
-    choices: [
-      { value: 'low', label: 'Low' },
-      { value: 'medium', label: 'Medium' },
-      { value: 'high', label: 'High' }
-    ],
-    defaultValue: 'high'
-  },
-  apply: {
-    launchArgs: (value) => ['--reasoning-effort', String(value)],
-    agentArgsOverride: (tokens) => hasFlag(tokens, ['--effort', '--reasoning-effort']),
-    midSession: { kind: 'command', build: (value) => `/effort ${String(value)}` }
+// The offered slice of grok's canonical ladder, low to high. Its `none` tier is
+// omitted because `native-chat-session-option-labels.ts` leaves it untranslated;
+// `minimal` and `max` because no grok model's menu has ever advertised them.
+const GROK_EFFORT_CHOICES = [
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+  { value: 'xhigh', label: 'Extra high' }
+]
+
+// Why: grok accepts only the tiers the model's own menu advertises and merely warns
+// on the rest, so expose each model's ceiling rather than one shared menu.
+function grokEffort(ceiling: 'high' | 'xhigh'): CatalogOption {
+  const ceilingIndex = GROK_EFFORT_CHOICES.findIndex((choice) => choice.value === ceiling)
+  return {
+    // Why: `LaunchPreferences` is a strict zod object over model/effort/mode, so a
+    // novel id is dropped client-side and rejected on the wire.
+    id: 'effort',
+    label: 'Reasoning effort',
+    category: 'thought_level',
+    kind: {
+      type: 'select',
+      choices: GROK_EFFORT_CHOICES.slice(0, ceilingIndex + 1),
+      // Why: every grok model reports `reasoning_effort: "high"` as its own default,
+      // so an untouched picker must not silently escalate past it.
+      defaultValue: 'high'
+    },
+    apply: {
+      launchArgs: (value) => ['--reasoning-effort', String(value)],
+      agentArgsOverride: (tokens) => hasFlag(tokens, ['--effort', '--reasoning-effort']),
+      midSession: { kind: 'command', build: (value) => `/effort ${String(value)}` }
+    }
   }
 }
 
@@ -41,11 +52,17 @@ export const GROK_SESSION_OPTION_CATALOG: AgentSessionOptionCatalog = {
   // config. Seed only what is verified; discovery supplies the rest.
   models: [
     {
+      id: 'grok-4.6',
+      label: 'Grok 4.6',
+      description: "xAI's latest frontier model",
+      isDefault: true,
+      options: [grokEffort('xhigh')]
+    },
+    {
       id: 'grok-4.5',
       label: 'Grok 4.5',
-      description: "xAI's frontier model",
-      isDefault: true,
-      options: [GROK_EFFORT]
+      description: "xAI's previous frontier model",
+      options: [grokEffort('high')]
     }
   ],
   modelApply: {
@@ -55,14 +72,15 @@ export const GROK_SESSION_OPTION_CATALOG: AgentSessionOptionCatalog = {
     // agent picker…" and never persist a model, so `-m` would never be emitted.
     midSession: { kind: 'command', build: (value) => `/model ${String(value)}` }
   },
-  // Why: `--reasoning-effort` is a global grok flag, not a per-model capability, and
-  // launch resolves against this static seed. Without this, a discovered id the seed
-  // does not carry shows the effort menu but launches with the flag dropped.
-  unknownModelOptions: [GROK_EFFORT],
+  // Why: launch resolves against this static seed, so without it a discovered id the
+  // seed does not carry shows the effort menu but launches with the flag dropped. The
+  // widest menu is the safe guess: grok warns on a tier a model lacks, but a tier the
+  // menu withholds is unreachable.
+  unknownModelOptions: [grokEffort('xhigh')],
   // Why: grok's selectable ids retire between releases, so a stale seed entry
   // must be droppable — picking one is a fatal launch, not a warning.
   discoveredModelsAreAuthoritative: true,
-  // Why: `grok models` prints `Default model: grok-4.5` and marks the row `(default)`,
+  // Why: `grok models` prints `Default model: grok-4.6` and marks the row `(default)`,
   // so the seed states the CLI's own choice rather than a preference of ours.
   defaultModelIsCliDefault: true,
   listModels: { command: 'grok models', parse: parseGrokCatalogModels }

--- a/src/shared/grok-model-list-probe.test.ts
+++ b/src/shared/grok-model-list-probe.test.ts
@@ -6,10 +6,11 @@ import { GROK_MODEL_LIST_ARGS, parseGrokModelList } from './grok-model-list-prob
 const SIGNED_IN_STDOUT = [
   'You are logged in with grok.com.',
   '',
-  'Default model: grok-4.5',
+  'Default model: grok-4.6',
   '',
   'Available models:',
-  '  * grok-4.5 (default)',
+  '  * grok-4.6 (default)',
+  '  - grok-4.5',
   ''
 ].join('\n')
 
@@ -19,8 +20,12 @@ describe('parseGrokModelList', () => {
   })
 
   it('parses the signed-in listing into exactly the bulleted models', () => {
+    // Regression: grok stars only the default row and dashes the rest, so a `*`-only
+    // bullet pattern published a one-model list and dropped every other model —
+    // and discovery is authoritative, so the dropped rows left the picker entirely.
     expect(parseGrokModelList(SIGNED_IN_STDOUT)).toEqual([
-      { id: 'grok-4.5', label: 'Grok 4.5', isDefault: true }
+      { id: 'grok-4.6', label: 'Grok 4.6', isDefault: true },
+      { id: 'grok-4.5', label: 'Grok 4.5' }
     ])
   })
 
@@ -48,11 +53,23 @@ describe('parseGrokModelList', () => {
   })
 
   it('ignores the decoy ids that sit above the header', () => {
-    // `Default model: grok-4.5` is a valid-looking id and the login line holds a
+    // `Default model: grok-4.6` is a valid-looking id and the login line holds a
     // dotted token; both precede the header, so neither may become a model.
     const parsed = parseGrokModelList(SIGNED_IN_STDOUT)
-    expect(parsed).toHaveLength(1)
+    expect(parsed).toHaveLength(2)
     expect(parsed.some(({ id }) => id.includes('grok.com'))).toBe(false)
+  })
+
+  it('reads the default marker off a dashed row too', () => {
+    // The bullet grok uses is presentational; only the annotation is the claim.
+    expect(
+      parseGrokModelList('Available models:\n  - grok-build\n  - grok-4.5 (default)\n').map(
+        ({ id, isDefault }) => [id, isDefault]
+      )
+    ).toEqual([
+      ['grok-build', undefined],
+      ['grok-4.5', true]
+    ])
   })
 
   it('strips a trailing parenthetical annotation from the id, spaced or not', () => {

--- a/src/shared/grok-model-list-probe.ts
+++ b/src/shared/grok-model-list-probe.ts
@@ -6,7 +6,9 @@ import { labelFromModelId } from './model-id-label'
 export const GROK_MODEL_LIST_ARGS = ['models']
 
 const AVAILABLE_MODELS_HEADER = 'Available models:'
-const MODEL_BULLET = /^\s*\*\s+([^\s(]+)(.*)$/
+// Why: grok bullets the default row with `*` and every other row with `-`, so a
+// `*`-only pattern silently publishes a one-model list and drops the rest.
+const MODEL_BULLET = /^\s*[*-]\s+([^\s(]+)(.*)$/
 // Why: read off the row rather than the earlier `Default model:` line, so the marker
 // cannot name an id the listing does not actually offer.
 const DEFAULT_MARKER = /\(default\)/

--- a/src/shared/native-chat-session-option-commands.test.ts
+++ b/src/shared/native-chat-session-option-commands.test.ts
@@ -288,11 +288,25 @@ describe('recordNativeChatSessionOptionCommand for grok', () => {
   })
 
   it('tracks nothing for an effort tier outside the seeded choices', () => {
-    // grok accepts `xhigh`, but the picker only offers values the shared labels
-    // localize, so tracking it would render an untranslated pill.
+    // grok's canonical ladder has a `none` tier, but the picker only offers values
+    // the shared labels localize, so tracking it would render an untranslated pill.
     const record = grokRecord('grok-4.5')
-    recordGrok(record, '/effort xhigh')
+    recordGrok(record, '/effort none')
     expect(record.valuesByModel['grok-4.5']?.effort).toBeUndefined()
+  })
+
+  it('gates xhigh on the tracked model’s own menu, not grok’s canonical ladder', () => {
+    // grok warns and ignores a tier the active model lacks, so 4.5 must not record it.
+    const older = grokRecord('grok-4.5')
+    recordGrok(older, '/effort xhigh')
+    expect(older.valuesByModel['grok-4.5']?.effort).toBeUndefined()
+
+    const newer = grokRecord('grok-4.6')
+    recordGrok(newer, '/effort xhigh')
+    expect(newer.valuesByModel['grok-4.6']?.effort).toEqual({
+      value: 'xhigh',
+      source: 'dispatched'
+    })
   })
 
   it('rejects grok’s two-argument /model form and any other prose', () => {
@@ -327,11 +341,11 @@ describe('recordNativeChatSessionOptionCommand for grok', () => {
         persist
       })
     ).toEqual({ changed: true, opensAgentPicker: false })
-    expect(record.valuesByModel['grok-4.5']?.effort).toEqual({
+    expect(record.valuesByModel['grok-4.6']?.effort).toEqual({
       value: 'low',
       source: 'dispatched'
     })
-    expect(persist).toHaveBeenCalledWith('grok-4.5', 'effort', 'low')
+    expect(persist).toHaveBeenCalledWith('grok-4.6', 'effort', 'low')
   })
 
   it('does not reset tracked state when the typed model is the CLI default already shown', () => {
@@ -339,8 +353,8 @@ describe('recordNativeChatSessionOptionCommand for grok', () => {
     // already displays looked like a switch and deleted that model's options.
     const record = grokRecord()
     recordGrok(record, '/effort low')
-    recordGrok(record, '/model grok-4.5')
-    expect(record.valuesByModel['grok-4.5']?.effort).toEqual({
+    recordGrok(record, '/model grok-4.6')
+    expect(record.valuesByModel['grok-4.6']?.effort).toEqual({
       value: 'low',
       source: 'dispatched'
     })
@@ -359,7 +373,7 @@ describe('recordNativeChatSessionOptionCommand for grok', () => {
       command: '/model grok-build'
     })
     expect(record.model).toEqual({ value: 'grok-build', source: 'dispatched' })
-    expect(record.valuesByModel['grok-4.5']?.effort).toEqual({
+    expect(record.valuesByModel['grok-4.6']?.effort).toEqual({
       value: 'low',
       source: 'dispatched'
     })

--- a/src/shared/native-chat-session-option-snapshot.test.ts
+++ b/src/shared/native-chat-session-option-snapshot.test.ts
@@ -187,7 +187,9 @@ describe('buildNativeChatSessionOptionSnapshot', () => {
 
       const reconciled = withTrackedNativeChatModel(GROK_SESSION_OPTION_CATALOG, discovered, record)
       expect(reconciled.map(({ id }) => id)).toEqual(['grok-build', 'grok-4.5'])
-      expect(reconciled.at(-1)).toBe(GROK_SESSION_OPTION_CATALOG.models[0])
+      expect(reconciled.at(-1)).toBe(
+        GROK_SESSION_OPTION_CATALOG.models.find((model) => model.id === 'grok-4.5')
+      )
       expect(reconciled.at(-1)!.options.map(({ id }) => id)).toEqual(['effort'])
 
       const snapshot = buildNativeChatSessionOptionSnapshot({
@@ -254,7 +256,7 @@ describe('defaults on load', () => {
   it('shows the default model before anything is picked', () => {
     const model = grokDraft()[0]!
     expect(model).toMatchObject({ id: 'model', valueSource: 'default' })
-    expect(model.kind.type === 'select' ? model.kind.currentValue : null).toBe('grok-4.5')
+    expect(model.kind.type === 'select' ? model.kind.currentValue : null).toBe('grok-4.6')
   })
 
   it('offers the effort row under that default model without naming its value', () => {
@@ -270,7 +272,7 @@ describe('defaults on load', () => {
     // default — as true of a running session as of a draft.
     const live = grokDraft(GROK_SESSION_OPTION_CATALOG.models, 'live')
     expect(live[0]).toMatchObject({ id: 'model', valueSource: 'default' })
-    expect(live[0]!.kind.type === 'select' ? live[0]!.kind.currentValue : null).toBe('grok-4.5')
+    expect(live[0]!.kind.type === 'select' ? live[0]!.kind.currentValue : null).toBe('grok-4.6')
     expect(live.find((descriptor) => descriptor.id === 'effort')).toMatchObject({
       valueSource: 'unknown'
     })


### PR DESCRIPTION
## Summary

Grok's Reasoning effort picker in desktop native chat now offers **Extra high** (`xhigh`), and the menu is **per-model** instead of one shared list.

`grokEffort(ceiling)` slices the same low→high ladder the way `codexEffort` already does in `agent-session-option-catalog-claude-codex.ts`. Seeded models:

- `grok-4.6` (CLI default, `isDefault`) → Low / Medium / High / Extra high
- `grok-4.5` → Low / Medium / High

`unknownModelOptions` uses the widest menu so a discovered/unseeded id can still reach Extra high. `defaultValue` stays `high` on every slice, so an untouched picker never silently escalates and existing users see no argv change.

## Why per-model

`~/.grok/models_cache.json` shows grok-4.6 advertising `xhigh,high,medium,low` and grok-4.5 advertising only `high,medium,low`. The grok binary's own strings say a model accepts only the levels its menu advertises and merely **warns** on the rest — so exposing a ceiling the model does not advertise is noise, while withholding Extra high from an unknown id would make that tier unreachable. The widest menu is the safe guess for unseeded ids.

`grok models` prints `Default model: grok-4.6` (and marks the row `(default)`), which is why the seed default and `defaultModelIsCliDefault` moved to 4.6 rather than a preference of ours.

## Second fix (found during UI validation)

`parseGrokModelList`'s `MODEL_BULLET` only matched `*`, but grok stars only the default row and dashes the rest:

```
  * grok-4.6 (default)
  - grok-4.5
```

With `discoveredModelsAreAuthoritative: true`, discovery published a one-model list and grok-4.5 disappeared from the picker on every real host. The pattern is now `[*-]`. The test fixture is the real two-bullet listing, plus a dashed-default-marker case.

## Testing

- `npx vitest run --config config/vitest.config.ts src/shared src/renderer/src/components/native-chat` → 5419 passed, 0 failed
- `npm run typecheck` clean
- `npx oxlint`, `audit:code-quality:native`, `audit:code-quality:type-aware`, `check:reliability-gates`, `check:max-lines-ratchet` all clean

`npm run lint` as a whole cannot complete in this checkout because `node_modules/i18next-cli` is missing, so `verify:localization-extraction` fails. That is a pre-existing environment gap. This change adds no new translation keys (`xhigh` → "Extra high" was already localized in en/es/ja/ko/zh).

## Validation

Rendered-UI proof via Playwright CDP against a dev build of this branch (full restart, not HMR):

1. Grok 4.6 → Effort lists Low, Medium, High, Extra high
2. Grok 4.5 → Effort lists only Low, Medium, High (no Extra high). This is the load-bearing half: a shared menu would show Extra high on both.
3. Selecting Extra high under 4.6 applies: the pill reads Extra high and the live session dispatches `/effort xhigh`

### 3b — Grok 4.5 has no Extra high

![FINAL-still-3b-grok45-no-extra-high.png](https://github.com/user-attachments/assets/428d41d9-ed1b-497c-9a24-e6cd139ef063)

### 3a — Grok 4.6 includes Extra high

![FINAL-still-3a-grok46-extra-high-menu.png](https://github.com/user-attachments/assets/2c13013f-cb30-41e7-9a5b-00ff15103670)

### 3c — Extra high applies (`/effort xhigh`)

![FINAL-still-3c-extra-high-applied.png](https://github.com/user-attachments/assets/5287b810-61f4-4ec2-9509-2c7130dc1a49)

### Video

https://github.com/user-attachments/assets/cf302684-bee7-4f5b-b5a9-67b8cbddd5c4
