### PR TITLE
Keep other-client workspace filter visible for remote hosts

### DIFF
--- a/src/renderer/src/components/sidebar/SidebarWorkspaceFilterSection.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarWorkspaceFilterSection.test.tsx
@@ -35,10 +35,7 @@ function setState(overrides: Record<string, unknown> = {}): void {
     setHideDetachedHeadWorkspaces: vi.fn(),
     hideWorkspacesFromOtherDevices: false,
     setHideWorkspacesFromOtherDevices: vi.fn(),
-    worktreesByRepo: {},
-    folderWorkspaces: [],
     runtimeEnvironments: [],
-    runtimeStatusByEnvironmentId: new Map(),
     alwaysShowDefaultBranchWorkspace: true,
     setAlwaysShowDefaultBranchWorkspace: vi.fn(),
     ...overrides
@@ -90,37 +87,17 @@ describe('SidebarWorkspaceFilterSection', () => {
     expect(rowLabels()).not.toContain(EXEMPTION_LABEL)
   })
 
-  it('shows the other-client filter only when it can hide a known workspace', () => {
+  it('shows the other-client filter when a remote server is configured', () => {
     setState({
-      worktreesByRepo: {
-        repo: [
-          {
-            id: 'other',
-            runtimeOwnerEnvironmentId: 'server',
-            creatorProvenance: { kind: 'paired-device', deviceId: 'other-client' }
-          }
-        ]
-      },
-      runtimeEnvironments: [{ id: 'server', pairedDeviceId: 'this-client' }]
+      runtimeEnvironments: [{ id: 'server' }]
     })
     render()
 
     expect(rowLabels()).toContain('Hide other-client workspaces')
   })
 
-  it('hides the other-client filter when every known workspace belongs to this client', () => {
-    setState({
-      worktreesByRepo: {
-        repo: [
-          {
-            id: 'own',
-            runtimeOwnerEnvironmentId: 'server',
-            creatorProvenance: { kind: 'paired-device', deviceId: 'this-client' }
-          }
-        ]
-      },
-      runtimeEnvironments: [{ id: 'server', pairedDeviceId: 'this-client' }]
-    })
+  it('hides the other-client filter for local-only clients', () => {
+    setState()
     render()
 
     expect(rowLabels()).not.toContain('Hide other-client workspaces')

--- a/src/renderer/src/components/sidebar/SidebarWorkspaceFilterSection.tsx
+++ b/src/renderer/src/components/sidebar/SidebarWorkspaceFilterSection.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 import {
   CalendarClock,
   GitBranch,
@@ -9,13 +9,7 @@ import {
 } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { translate } from '@/i18n/i18n'
-import { getIndexedAllWorktrees } from '@/store/worktree-repo-index'
 import { FilterToggleRow } from './FilterToggleRow'
-import {
-  getPairedDeviceIdsByEnvironment,
-  isFolderWorkspaceFromOtherDevice,
-  isWorkspaceFromOtherDevice
-} from './workspace-creator-visibility'
 
 const SidebarWorkspaceFilterSection = React.memo(function SidebarWorkspaceFilterSection() {
   const showSleepingWorkspaces = useAppStore((s) => s.showSleepingWorkspaces)
@@ -32,41 +26,12 @@ const SidebarWorkspaceFilterSection = React.memo(function SidebarWorkspaceFilter
   const setHideDetachedHeadWorkspaces = useAppStore((s) => s.setHideDetachedHeadWorkspaces)
   const hideWorkspacesFromOtherDevices = useAppStore((s) => s.hideWorkspacesFromOtherDevices)
   const setHideWorkspacesFromOtherDevices = useAppStore((s) => s.setHideWorkspacesFromOtherDevices)
-  const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
-  const folderWorkspaces = useAppStore((s) => s.folderWorkspaces)
   const runtimeEnvironments = useAppStore((s) => s.runtimeEnvironments)
-  const runtimeStatusByEnvironmentId = useAppStore((s) => s.runtimeStatusByEnvironmentId)
   const alwaysShowDefaultBranchWorkspace = useAppStore((s) => s.alwaysShowDefaultBranchWorkspace)
   const setAlwaysShowDefaultBranchWorkspace = useAppStore(
     (s) => s.setAlwaysShowDefaultBranchWorkspace
   )
-  const showOtherClientFilter = useMemo(() => {
-    if (hideWorkspacesFromOtherDevices) {
-      return true
-    }
-    const pairedDeviceIds = getPairedDeviceIdsByEnvironment(
-      runtimeEnvironments,
-      runtimeStatusByEnvironmentId
-    )
-    const worktrees = getIndexedAllWorktrees(worktreesByRepo)
-    return (
-      worktrees.some(
-        (worktree) => !worktree.isArchived && isWorkspaceFromOtherDevice(worktree, pairedDeviceIds)
-      ) ||
-      folderWorkspaces.some((workspace) => {
-        if (workspace.isArchived) {
-          return false
-        }
-        return isFolderWorkspaceFromOtherDevice(workspace, pairedDeviceIds)
-      })
-    )
-  }, [
-    folderWorkspaces,
-    hideWorkspacesFromOtherDevices,
-    runtimeEnvironments,
-    runtimeStatusByEnvironmentId,
-    worktreesByRepo
-  ])
+  const showOtherClientFilter = runtimeEnvironments.length > 0 || hideWorkspacesFromOtherDevices
 
   return (
     <>


### PR DESCRIPTION
## Summary
- show **Hide other-client workspaces** whenever a remote Orca server is configured
- keep the control visible through disconnect/reconnect and while the preference is enabled
- remove the workspace-catalog scan that made the control disappear before it could be useful

Follow-up to #13718.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/SidebarWorkspaceFilterSection.test.tsx`
- 74-test broader sidebar/filter suite
- `pnpm typecheck`
- `pnpm lint`
- Electron desktop validation with a configured remote runtime, including off → on → off