### PR TITLE
fix(linear-cli): resolve --assignee me on save-issue instead of dropping it silently

### DIFF
--- a/src/cli/handlers/linear.test.ts
+++ b/src/cli/handlers/linear.test.ts
@@ -591,6 +591,31 @@ describe('orca linear CLI handlers', () => {
     )
   })
 
+  it('carries save-issue current-user assignment to the RPC request', async () => {
+    queueFixtures(callMock, okFixture('req_save', createResult()))
+
+    await main(
+      [
+        'linear',
+        'save-issue',
+        '--team',
+        'ENG',
+        '--title',
+        'Assigned issue',
+        '--assignee',
+        'me',
+        '--json'
+      ],
+      '/tmp/repo'
+    )
+
+    expect(callMock).toHaveBeenCalledWith(
+      'linear.saveIssue',
+      expect.objectContaining({ assignee: 'me', assigneeMe: true }),
+      { timeoutMs: 75_000 }
+    )
+  })
+
   it('rejects duplicate body inputs before dispatch', async () => {
     await main(
       ['linear', 'create', '--title', 'Bug', '--body', 'one', '--body-file', 'body.md'],

--- a/src/cli/linear-save-issue-request.ts
+++ b/src/cli/linear-save-issue-request.ts
@@ -30,6 +30,7 @@ export async function buildSaveIssueRequest(
   if (body !== undefined && description !== undefined) {
     throw new RuntimeClientError('invalid_argument', 'Use either --description or --body, not both')
   }
+  const assignee = getNullableStringFlag(flags, 'assignee')
   return {
     input,
     current,
@@ -39,7 +40,8 @@ export async function buildSaveIssueRequest(
     title: getOptionalStringFlag(flags, 'title'),
     description: description ?? body,
     state: getOptionalStringFlag(flags, 'state'),
-    assignee: getNullableStringFlag(flags, 'assignee'),
+    assignee,
+    assigneeMe: assignee?.toLocaleLowerCase() === 'me' || undefined,
     priority: flags.has('priority') ? getPriorityFlag(flags, 'priority') : undefined,
     estimate: getOptionalNullableNumberFlag(flags, 'estimate'),
     dueDate: flags.has('due-date') ? getNullableDueDateFlag(flags, 'due-date') : undefined,

--- a/src/main/linear/issues.test.ts
+++ b/src/main/linear/issues.test.ts
@@ -746,7 +746,7 @@ describe('Linear issue queries', () => {
     ).rejects.toMatchObject({ kind: 'unconfirmed' })
   })
 
-  it('creates parented agent issues with a client supplied id and project id', async () => {
+  it('creates parented agent issues with client supplied issue, project, and assignee ids', async () => {
     const createIssue = vi.fn().mockResolvedValue({
       success: true,
       issue: Promise.resolve({ id: 'issue-created' })
@@ -776,7 +776,8 @@ describe('Linear issue queries', () => {
       createIssueForAgent('team-1', 'Follow up', 'Details', 'workspace-1', {
         id: '33333333-3333-4333-8333-333333333333',
         parentId: 'issue-parent',
-        projectId: 'project-1'
+        projectId: 'project-1',
+        assigneeId: 'viewer-1'
       })
     ).resolves.toMatchObject({
       id: 'issue-created',
@@ -790,7 +791,8 @@ describe('Linear issue queries', () => {
       title: 'Follow up',
       description: 'Details',
       parentId: 'issue-parent',
-      projectId: 'project-1'
+      projectId: 'project-1',
+      assigneeId: 'viewer-1'
     })
     expect(rawRequest.mock.calls.at(-1)?.[0]).toContain('description')
   })

--- a/src/main/runtime/linear-save-issue.test.ts
+++ b/src/main/runtime/linear-save-issue.test.ts
@@ -25,10 +25,14 @@ type SaveIssueInternals = {
   resolveLinearAssignee(input: string, teamId: string, workspaceId: string): Promise<string>
   resolveLinearAgentState(input: string, states: unknown[]): unknown
   buildLinearSaveUpdate(
-    params: { labels?: string[] },
+    params: { assignee?: string | null; assigneeMe?: boolean; labels?: string[] },
     current: typeof issue,
     workspaceId: string
-  ): Promise<{ labelIds?: string[] }>
+  ): Promise<{ assigneeId?: string | null; labelIds?: string[] }>
+  resolveLinearCreateFields(
+    params: { assignee?: string; assigneeMe?: boolean },
+    team: { id: string; workspaceId: string }
+  ): Promise<{ assigneeId?: string | null }>
 }
 
 afterEach(() => {
@@ -53,6 +57,26 @@ describe('Linear save issue', () => {
         title: 'New issue',
         workspaceId: 'workspace-1'
       })
+    )
+  })
+
+  it('delegates save-issue current-user assignment intent to create', async () => {
+    const runtime = new OrcaRuntimeService()
+    const create = vi.spyOn(runtime, 'linearIssueCreate').mockResolvedValue({
+      issue,
+      meta: { workspaceId: 'workspace-1', writeId: 'write-1', deduplicated: false }
+    })
+
+    await runtime.linearSaveIssue({
+      team: 'ENG',
+      title: 'Assigned issue',
+      assignee: 'me',
+      assigneeMe: true,
+      workspaceId: 'workspace-1'
+    })
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({ assignee: 'me', assigneeMe: true })
     )
   })
 
@@ -131,6 +155,45 @@ describe('Linear save issue', () => {
     await expect(
       runtime.resolveLinearAssignee('ADA@EXAMPLE.COM', 'team-1', 'workspace-1')
     ).resolves.toBe('user-1')
+  })
+
+  it('turns save-issue current-user intent into the viewer assignee id', async () => {
+    const runtime = new OrcaRuntimeService() as unknown as SaveIssueInternals
+    vi.spyOn(linearTeams, 'getViewerForWorkspaceOrThrow').mockResolvedValue({
+      id: 'viewer-1',
+      displayName: 'Ada',
+      avatarUrl: null
+    })
+
+    await expect(
+      runtime.resolveLinearCreateFields(
+        { assignee: 'me', assigneeMe: true },
+        { id: 'team-1', workspaceId: 'workspace-1' }
+      )
+    ).resolves.toEqual({ assigneeId: 'viewer-1' })
+    await expect(
+      runtime.buildLinearSaveUpdate({ assignee: 'me', assigneeMe: true }, issue, 'workspace-1')
+    ).resolves.toEqual({ assigneeId: 'viewer-1' })
+  })
+
+  it('rejects an unresolved save-issue assignee instead of dropping it', async () => {
+    const runtime = new OrcaRuntimeService() as unknown as SaveIssueInternals
+    vi.spyOn(linearTeams, 'getTeamMembersOrThrow').mockResolvedValue([])
+
+    await expect(
+      runtime.buildLinearSaveUpdate({ assignee: 'Missing User' }, issue, 'workspace-1')
+    ).rejects.toMatchObject({
+      code: 'linear_invalid_assignee',
+      message: 'No team member exactly matched "Missing User".'
+    })
+  })
+
+  it('keeps explicit save-issue assignee clears', async () => {
+    const runtime = new OrcaRuntimeService() as unknown as SaveIssueInternals
+
+    await expect(
+      runtime.buildLinearSaveUpdate({ assignee: null }, issue, 'workspace-1')
+    ).resolves.toEqual({ assigneeId: null })
   })
 
   it('resolves workflow lifecycle types while preferring exact state names', () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -33847,6 +33847,7 @@ export class OrcaRuntimeService {
         teamInput: params.team,
         state: params.state,
         assignee: params.assignee ?? undefined,
+        assigneeMe: params.assigneeMe,
         priority: params.priority,
         estimate: params.estimate ?? undefined,
         dueDate: params.dueDate ?? undefined,
@@ -34102,6 +34103,7 @@ export class OrcaRuntimeService {
     teamKey?: string
     state?: string
     assignee?: string
+    assigneeMe?: boolean
     priority?: number
     estimate?: number
     dueDate?: string
@@ -34390,7 +34392,9 @@ export class OrcaRuntimeService {
       }
       fields.stateId = state.id
     }
-    if (params.assignee !== undefined) {
+    if (params.assigneeMe) {
+      fields.assigneeId = (await this.getLinearViewerForWrite(workspaceId)).id
+    } else if (params.assignee !== undefined) {
       fields.assigneeId =
         params.assignee === null
           ? null
@@ -34509,6 +34513,7 @@ export class OrcaRuntimeService {
     params: {
       state?: string
       assignee?: string
+      assigneeMe?: boolean
       priority?: number
       estimate?: number
       dueDate?: string
@@ -34530,7 +34535,9 @@ export class OrcaRuntimeService {
       }
       fields.stateId = state.id
     }
-    if (params.assignee) {
+    if (params.assigneeMe) {
+      fields.assigneeId = (await this.getLinearViewerForWrite(team.workspaceId)).id
+    } else if (params.assignee) {
       fields.assigneeId = await this.resolveLinearAssignee(
         params.assignee,
         team.id,

--- a/src/main/runtime/rpc/methods/linear-agent-access.test.ts
+++ b/src/main/runtime/rpc/methods/linear-agent-access.test.ts
@@ -261,6 +261,32 @@ describe('Linear agent access RPC methods', () => {
     expect(runtime.linearIssueAddComment).not.toHaveBeenCalled()
   })
 
+  it('preserves save-issue current-user assignment intent', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      linearSaveIssue: vi.fn().mockResolvedValue({ ok: true })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: LINEAR_AGENT_ACCESS_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('linear.saveIssue', {
+        team: 'ENG',
+        title: 'Assigned issue',
+        assignee: 'me',
+        assigneeMe: true
+      })
+    )
+
+    expect(response.ok).toBe(true)
+    expect(runtime.linearSaveIssue).toHaveBeenCalledWith({
+      team: 'ENG',
+      title: 'Assigned issue',
+      assignee: 'me',
+      assigneeMe: true,
+      writeId: undefined
+    })
+  })
+
   it('rejects workspace all for direct write RPC calls', async () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',

--- a/src/main/runtime/rpc/methods/linear-agent-access.ts
+++ b/src/main/runtime/rpc/methods/linear-agent-access.ts
@@ -136,6 +136,7 @@ const LinearSaveIssue = LinearWriteTarget.extend({
   description: z.string().optional(),
   state: OptionalString,
   assignee: z.string().nullable().optional(),
+  assigneeMe: z.boolean().optional(),
   priority: z.number().int().min(0).max(4).optional(),
   estimate: z.number().min(0).nullable().optional(),
   dueDate: OptionalLinearDueDateOrClear,

--- a/src/main/ssh/ssh-remote-linear-save-issue.test.ts
+++ b/src/main/ssh/ssh-remote-linear-save-issue.test.ts
@@ -94,6 +94,30 @@ describe('SSH remote Linear save issue', () => {
     )
   })
 
+  it('forwards current-user assignee intent through the SSH RPC path', async () => {
+    const { runtime, linearSaveIssue } = createRuntime()
+    const result = await runRemoteOrcaCli(runtime, {
+      argv: [
+        'linear',
+        'save-issue',
+        '--team',
+        'ENG',
+        '--title',
+        'Assigned issue',
+        '--assignee',
+        'me',
+        '--json'
+      ],
+      cwd: '/home/alice/remote-repo',
+      env: { ORCA_TERMINAL_HANDLE: 'term_ssh' }
+    })
+
+    expect(result.exitCode).toBe(0)
+    expect(linearSaveIssue).toHaveBeenCalledWith(
+      expect.objectContaining({ assignee: 'me', assigneeMe: true })
+    )
+  })
+
   it('rejects remote body paths instead of reading from the wrong filesystem', async () => {
     const { runtime, linearSaveIssue } = createRuntime()
     const result = await runRemoteOrcaCli(runtime, {

--- a/src/main/ssh/ssh-remote-linear-save-issue.ts
+++ b/src/main/ssh/ssh-remote-linear-save-issue.ts
@@ -60,13 +60,15 @@ export async function dispatchRemoteLinearSaveIssue(
       'Use either --description or --body, not both'
     )
   }
+  const assignee = nullableString(parsed.flags, 'assignee')
   return await call(dispatcher, 'linear.saveIssue', {
     ...buildOptionalRemoteTargetRequest(parsed, env),
     team: optionalString(parsed.flags, 'team'),
     title: optionalString(parsed.flags, 'title'),
     description: description ?? body,
     state: optionalString(parsed.flags, 'state'),
-    assignee: nullableString(parsed.flags, 'assignee'),
+    assignee,
+    assigneeMe: assignee?.toLocaleLowerCase() === 'me' || undefined,
     priority: parsed.flags.has('priority') ? priorityFlag(parsed.flags, 'priority') : undefined,
     estimate: nullableNonNegativeInteger(parsed.flags, 'estimate'),
     dueDate: nullableDueDate(parsed.flags, 'due-date'),

--- a/src/shared/linear/agent-access.ts
+++ b/src/shared/linear/agent-access.ts
@@ -176,6 +176,7 @@ export type LinearSaveIssueRequest = LinearWriteTargetRequest & {
   description?: string
   state?: string
   assignee?: string | null
+  assigneeMe?: boolean
   priority?: number
   estimate?: number | null
   dueDate?: string | null


### PR DESCRIPTION
## ELI5

`orca linear save-issue --assignee me` now carries an explicit “assign this to the authenticated Linear user” intent all the way to the runtime instead of relying only on the generic assignee text path.

## What Changed

- Added the optional `assigneeMe` intent to save-issue requests and RPC validation.
- Set that intent for both local and SSH CLI paths while retaining `assignee: "me"` as a mixed-version fallback.
- Reused the runtime's authenticated-viewer lookup for create and update, then sent the resolved user ID as Linear's `assigneeId`.
- Added outcome coverage across CLI request construction, RPC dispatch, create/update resolution, the Linear mutation payload, SSH forwarding, explicit clears, and unresolved-name errors.

Named users and `--assignee null` were already working; their behavior is preserved and covered. An unknown named user continues to fail with `linear_invalid_assignee` rather than returning a silent success.

## Why

The help text explicitly documents `--assignee me`, but the reported command returned `ok: true` and created STA-4369 without an assignee. The dedicated current-user intent used by `orca linear assignee set --me` did not cross the save-issue request boundary.

Reference review confirmed that current-user assignment should resolve the authenticated `viewer`, while issue create/update mutations expect that user's identifier in `assigneeId`. It also confirmed that an unresolved assignee should be rejected instead of omitted, which shaped both the resolution path and the regression assertions.

Follow-up observation: save-issue and assignee-set use different flag names (`--assignee` versus `--me`/`--to-id`); this PR intentionally does not unify them because existing automation depends on the current interface.

## Linked Issue

Fixes: N/A — no GitHub issue was provided. Linear reproduction: STA-4369 (not closed by this PR).

## Visual Proof

N/A — this changes CLI/runtime behavior only; no UI changed.

## Testing

- [ ] I manually tested these changes locally — no live Linear issue was created to avoid another production mutation.
- [x] Automated tests added/updated, or explained why not below

RED on unmodified `origin/main`:

```text
FAIL  src/cli/handlers/linear.test.ts > orca linear CLI handlers > carries save-issue current-user assignment to the RPC request
AssertionError: expected "vi.fn()" to be called with arguments: [ 'linear.saveIssue', …(2) ]

-   ObjectContaining {
+   {
      "assignee": "me",
-     "assigneeMe": true,
```

Passing checks:

- `pnpm vitest run src/cli/handlers/linear.test.ts src/main/linear/issues.test.ts src/main/runtime/linear-save-issue.test.ts src/main/runtime/rpc/methods/linear-agent-access.test.ts src/main/ssh/ssh-remote-linear-save-issue.test.ts --config config/vitest.config.ts` — 86 passed
- `pnpm typecheck`
- `pnpm oxlint`
- `pnpm check:max-lines-ratchet`

Validated on macOS. The platform-neutral request/runtime paths cover macOS, Linux, and Windows; the SSH remote CLI path has dedicated regression coverage. Mobile is unaffected.

## Review

Security: no credential or authorization behavior changed. Compatibility: the new RPC field is optional, old clients still use the existing string path, and new clients retain the string fallback for older hosts. Performance: only `--assignee me` performs the existing authenticated-viewer lookup required to resolve `assigneeId`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] Required focused tests, `pnpm typecheck`, and `pnpm oxlint` pass; full-suite/build coverage is left to CI

## Author

- X / Twitter: @BrennanKB5
