### PR TITLE
fix(source-control-ai): stop duplicating singleton CLI flags in agent argv

### DIFF
--- a/src/shared/commit-message-agent-spec.ts
+++ b/src/shared/commit-message-agent-spec.ts
@@ -44,6 +44,10 @@ export type CommitMessageAgentSpec = {
   /** Where the prompt is delivered. Large diffs go via stdin to avoid argv limits. */
   promptDelivery: 'argv' | 'stdin'
   buildArgs: (params: { prompt: string; model: string; thinkingLevel?: string }) => string[]
+  /** Alias groups the CLI accepts at most once. Recipe CLI arguments repeating one
+   *  replace the generated flag instead of being appended: yargs-based CLIs collapse
+   *  a repeated flag into an array and crash. Defaults to the model flag alone. */
+  singletonOptions?: readonly (readonly string[])[]
   /** Whether the model list is static or discovered from the agent CLI. */
   modelSource: 'static' | 'dynamic'
   /** Command used by the main process to discover models when modelSource is dynamic. */
@@ -392,6 +396,8 @@ export const COMMIT_MESSAGE_AGENT_SPECS: Partial<Record<TuiAgent, CommitMessageA
       model,
       ...(thinkingLevel ? ['-c', `model_reasoning_effort=${thinkingLevel}`] : [])
     ],
+    // `-c` is intentionally absent: Codex accepts repeated overrides.
+    singletonOptions: [['--model', '-m']],
     modelSource: 'dynamic',
     modelDiscovery: {
       binary: 'codex',
@@ -461,6 +467,7 @@ export const COMMIT_MESSAGE_AGENT_SPECS: Partial<Record<TuiAgent, CommitMessageA
       'default',
       ...(thinkingLevel ? ['--variant', thinkingLevel] : [])
     ],
+    singletonOptions: [['--model', '-m'], ['--agent'], ['--format'], ['--variant']],
     modelSource: 'dynamic',
     modelDiscovery: { binary: 'opencode', args: ['models'], parse: parseLineModels },
     models: [
@@ -524,6 +531,8 @@ export const COMMIT_MESSAGE_AGENT_SPECS: Partial<Record<TuiAgent, CommitMessageA
       model,
       ...(thinkingLevel ? ['--effort', thinkingLevel] : [])
     ],
+    // Amp selects the model with `--mode`, not `--model`.
+    singletonOptions: [['--mode']],
     modelSource: 'static',
     models: [
       { id: 'smart', label: 'Smart' },

--- a/src/shared/commit-message-plan.test.ts
+++ b/src/shared/commit-message-plan.test.ts
@@ -311,13 +311,71 @@ describe('planCommitMessageGeneration', () => {
     })
   })
 
-  it('appends per-action CLI arguments for stdin agents', () => {
+  it('lets OpenCode recipe args override the generated model instead of repeating it', () => {
     const result = planCommitMessageGeneration(
       {
         agentId: 'opencode',
         model: 'opencode/gpt-5.4-mini',
         agentArgs: '--model opencode/gpt-5.5'
       },
+      'PROMPT'
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      plan: {
+        args: ['run', '--model', 'opencode/gpt-5.5', '--agent', 'build', '--format', 'default'],
+        stdinPayload: 'PROMPT'
+      }
+    })
+  })
+
+  it('overrides the generated OpenCode model from a short-form recipe alias', () => {
+    const result = planCommitMessageGeneration(
+      { agentId: 'opencode', model: 'opencode/gpt-5.4-mini', agentArgs: '-m opencode/gpt-5.5' },
+      'PROMPT'
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      plan: {
+        args: ['run', '-m', 'opencode/gpt-5.5', '--agent', 'build', '--format', 'default']
+      }
+    })
+  })
+
+  it('overrides OpenCode singleton flags beyond the model', () => {
+    const result = planCommitMessageGeneration(
+      {
+        agentId: 'opencode',
+        model: 'opencode/gpt-5.4-mini',
+        thinkingLevel: 'high',
+        agentArgs: '--agent plan --format json --variant low'
+      },
+      'PROMPT'
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      plan: {
+        args: [
+          'run',
+          '--model',
+          'opencode/gpt-5.4-mini',
+          '--agent',
+          'plan',
+          '--format',
+          'json',
+          '--variant',
+          'low'
+        ]
+      }
+    })
+  })
+
+  it('appends per-action CLI arguments that do not repeat a generated OpenCode flag', () => {
+    const result = planCommitMessageGeneration(
+      { agentId: 'opencode', model: 'opencode/gpt-5.4-mini', agentArgs: '--share' },
       'PROMPT'
     )
 
@@ -332,10 +390,89 @@ describe('planCommitMessageGeneration', () => {
           'build',
           '--format',
           'default',
-          '--model',
-          'opencode/gpt-5.5'
+          '--share'
         ],
         stdinPayload: 'PROMPT'
+      }
+    })
+  })
+
+  it('collapses a singleton flag the user typed twice in one field', () => {
+    const result = planCommitMessageGeneration(
+      {
+        agentId: 'opencode',
+        model: 'opencode/gpt-5.4-mini',
+        agentArgs: '--model opencode/first -m opencode/second'
+      },
+      'PROMPT'
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      plan: {
+        args: ['run', '--model', 'opencode/first', '--agent', 'build', '--format', 'default']
+      }
+    })
+  })
+
+  it('overrides the generated Amp mode rather than repeating it', () => {
+    const result = planCommitMessageGeneration(
+      { agentId: 'amp', model: 'smart', agentArgs: '--mode rush' },
+      'PROMPT'
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      plan: {
+        args: ['--execute', '--no-notifications', '--no-ide', '--no-jetbrains', '--mode', 'rush']
+      }
+    })
+  })
+
+  it('folds a model flag from an agent command override into the generated slot', () => {
+    const result = planCommitMessageGeneration(
+      {
+        agentId: 'opencode',
+        model: 'opencode/gpt-5.4-mini',
+        agentCommandOverride: 'npx opencode --model opencode/gpt-5.5'
+      },
+      'PROMPT'
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      plan: {
+        binary: 'npx',
+        args: [
+          'opencode',
+          'run',
+          '--model',
+          'opencode/gpt-5.5',
+          '--agent',
+          'build',
+          '--format',
+          'default'
+        ]
+      }
+    })
+  })
+
+  it('lets recipe args outrank a command override that also sets the model', () => {
+    const result = planCommitMessageGeneration(
+      {
+        agentId: 'opencode',
+        model: 'opencode/gpt-5.4-mini',
+        agentCommandOverride: 'opencode --model opencode/from-override',
+        agentArgs: '--model opencode/from-recipe'
+      },
+      'PROMPT'
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      plan: {
+        binary: 'opencode',
+        args: ['run', '--model', 'opencode/from-recipe', '--agent', 'build', '--format', 'default']
       }
     })
   })

--- a/src/shared/commit-message-plan.test.ts
+++ b/src/shared/commit-message-plan.test.ts
@@ -429,12 +429,12 @@ describe('planCommitMessageGeneration', () => {
     })
   })
 
-  it('folds a model flag from an agent command override into the generated slot', () => {
+  it('keeps a model flag in the agent command override and removes the generated duplicate', () => {
     const result = planCommitMessageGeneration(
       {
         agentId: 'opencode',
         model: 'opencode/gpt-5.4-mini',
-        agentCommandOverride: 'npx opencode --model opencode/gpt-5.5'
+        agentCommandOverride: 'npx opencode --model opencode/gpt-5.5 --log-level DEBUG'
       },
       'PROMPT'
     )
@@ -445,9 +445,42 @@ describe('planCommitMessageGeneration', () => {
         binary: 'npx',
         args: [
           'opencode',
-          'run',
           '--model',
           'opencode/gpt-5.5',
+          '--log-level',
+          'DEBUG',
+          'run',
+          '--agent',
+          'build',
+          '--format',
+          'default'
+        ]
+      }
+    })
+  })
+
+  it('does not move command override options across an option terminator', () => {
+    const result = planCommitMessageGeneration(
+      {
+        agentId: 'opencode',
+        model: 'opencode/gpt-5.4-mini',
+        agentCommandOverride: 'opencode --model opencode/from-override -- --model literal'
+      },
+      'PROMPT'
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      plan: {
+        args: [
+          '--model',
+          'opencode/from-override',
+          '--',
+          '--model',
+          'literal',
+          'run',
+          '--model',
+          'opencode/gpt-5.4-mini',
           '--agent',
           'build',
           '--format',

--- a/src/shared/commit-message-plan.ts
+++ b/src/shared/commit-message-plan.ts
@@ -68,7 +68,7 @@ function planAdditionalAgentArgs(
   return { ok: true, args: tokenized.tokens }
 }
 
-const CODEX_MODEL_OPTION_ALIASES = ['--model', '-m'] as const
+const DEFAULT_SINGLETON_OPTIONS: readonly (readonly string[])[] = [['--model']]
 
 function matchesOption(token: string, aliases: readonly string[]): boolean {
   return aliases.some(
@@ -129,6 +129,70 @@ function applyRecipeOptionOverride(args: {
       ...args.recipeArgs.slice(recipeOption.index + recipeOption.consumed)
     ]
   }
+}
+
+function removeAllOptionOccurrences(tokens: string[], aliases: readonly string[]): string[] {
+  let result = tokens
+  while (true) {
+    const found = findOptionOccurrence(result, aliases, true)
+    if (!found) {
+      return result
+    }
+    result = [...result.slice(0, found.index), ...result.slice(found.index + found.consumed)]
+  }
+}
+
+/** Drops every occurrence after the first, so a user who types the same singleton
+ *  twice in one field still gets a single flag rather than a rejected argv. */
+function keepFirstOptionOccurrence(tokens: string[], aliases: readonly string[]): string[] {
+  let result = tokens
+  while (true) {
+    const first = findOptionOccurrence(result, aliases, true)
+    if (!first) {
+      return result
+    }
+    const tail = result.slice(first.index + first.consumed)
+    const duplicate = findOptionOccurrence(tail, aliases, true)
+    if (!duplicate) {
+      return result
+    }
+    const offset = first.index + first.consumed
+    result = [
+      ...result.slice(0, offset + duplicate.index),
+      ...result.slice(offset + duplicate.index + duplicate.consumed)
+    ]
+  }
+}
+
+/** Folds every user-supplied singleton option into the generated argv slot so the
+ *  spawned CLI never sees the same flag twice. Precedence: recipe args (per-action)
+ *  beat a command-override prefix (per-agent), which beats Orca's generated value. */
+function applySingletonOptionOverrides(args: {
+  generatedArgs: string[]
+  prefixArgs: string[]
+  recipeArgs: string[]
+  singletonOptions: readonly (readonly string[])[]
+}): { generatedArgs: string[]; prefixArgs: string[]; recipeArgs: string[] } {
+  let generatedArgs = args.generatedArgs
+  let prefixArgs = args.prefixArgs
+  let recipeArgs = args.recipeArgs
+
+  for (const aliases of args.singletonOptions) {
+    recipeArgs = keepFirstOptionOccurrence(recipeArgs, aliases)
+    prefixArgs = findOptionOccurrence(recipeArgs, aliases, true)
+      ? removeAllOptionOccurrences(prefixArgs, aliases)
+      : keepFirstOptionOccurrence(prefixArgs, aliases)
+    // Why: applying the prefix first and the recipe second leaves the recipe's value
+    // in the slot, since each pass overwrites the same generated position.
+    const withPrefix = applyRecipeOptionOverride({ generatedArgs, recipeArgs: prefixArgs, aliases })
+    generatedArgs = withPrefix.generatedArgs
+    prefixArgs = withPrefix.recipeArgs
+    const withRecipe = applyRecipeOptionOverride({ generatedArgs, recipeArgs, aliases })
+    generatedArgs = withRecipe.generatedArgs
+    recipeArgs = withRecipe.recipeArgs
+  }
+
+  return { generatedArgs, prefixArgs, recipeArgs }
 }
 
 function insertAdditionalAgentArgs(args: {
@@ -227,31 +291,29 @@ export function planCommitMessageGeneration(
   if (!agentArgs.ok) {
     return agentArgs
   }
-  // Why: Codex rejects repeated singleton model flags. Recipe CLI arguments
-  // are the more specific setting, so they replace Orca's generated model.
-  const overriddenArgs =
-    input.agentId === 'codex'
-      ? applyRecipeOptionOverride({
-          generatedArgs: baseArgs,
-          recipeArgs: agentArgs.args,
-          aliases: CODEX_MODEL_OPTION_ALIASES
-        })
-      : { generatedArgs: baseArgs, recipeArgs: agentArgs.args }
-  const args = insertAdditionalAgentArgs({
-    baseArgs: overriddenArgs.generatedArgs,
-    agentArgs: overriddenArgs.recipeArgs,
-    promptDelivery: spec.promptDelivery,
-    prompt: argvPrompt
-  })
   const command = planAgentBinary(spec.binary, input.agentCommandOverride)
   if (!command.ok) {
     return { ok: false, error: command.error }
   }
+  // Why: repeating a singleton flag makes yargs-based CLIs parse it as an array and
+  // crash (OpenCode's `model.split('/')`). User values replace Orca's, never stack.
+  const merged = applySingletonOptionOverrides({
+    generatedArgs: baseArgs,
+    prefixArgs: command.prefixArgs,
+    recipeArgs: agentArgs.args,
+    singletonOptions: spec.singletonOptions ?? DEFAULT_SINGLETON_OPTIONS
+  })
+  const args = insertAdditionalAgentArgs({
+    baseArgs: merged.generatedArgs,
+    agentArgs: merged.recipeArgs,
+    promptDelivery: spec.promptDelivery,
+    prompt: argvPrompt
+  })
   return {
     ok: true,
     plan: {
       binary: command.binary,
-      args: [...command.prefixArgs, ...args],
+      args: [...merged.prefixArgs, ...args],
       stdinPayload: spec.promptDelivery === 'stdin' ? prompt : null,
       label: spec.label
     }

--- a/src/shared/commit-message-plan.ts
+++ b/src/shared/commit-message-plan.ts
@@ -164,9 +164,8 @@ function keepFirstOptionOccurrence(tokens: string[], aliases: readonly string[])
   }
 }
 
-/** Folds every user-supplied singleton option into the generated argv slot so the
- *  spawned CLI never sees the same flag twice. Precedence: recipe args (per-action)
- *  beat a command-override prefix (per-agent), which beats Orca's generated value. */
+/** Removes generated singleton options shadowed by user input. Recipe args
+ *  outrank a command-override prefix, which outranks Orca's generated value. */
 function applySingletonOptionOverrides(args: {
   generatedArgs: string[]
   prefixArgs: string[]
@@ -179,14 +178,22 @@ function applySingletonOptionOverrides(args: {
 
   for (const aliases of args.singletonOptions) {
     recipeArgs = keepFirstOptionOccurrence(recipeArgs, aliases)
-    prefixArgs = findOptionOccurrence(recipeArgs, aliases, true)
-      ? removeAllOptionOccurrences(prefixArgs, aliases)
-      : keepFirstOptionOccurrence(prefixArgs, aliases)
-    // Why: applying the prefix first and the recipe second leaves the recipe's value
-    // in the slot, since each pass overwrites the same generated position.
-    const withPrefix = applyRecipeOptionOverride({ generatedArgs, recipeArgs: prefixArgs, aliases })
-    generatedArgs = withPrefix.generatedArgs
-    prefixArgs = withPrefix.recipeArgs
+    prefixArgs = keepFirstOptionOccurrence(prefixArgs, aliases)
+    const recipeOption = findOptionOccurrence(recipeArgs, aliases, true)
+    const prefixOption = findOptionOccurrence(prefixArgs, aliases, true)
+    const prefixHasTerminator = prefixArgs.includes('--')
+    if (recipeOption && !prefixHasTerminator) {
+      prefixArgs = removeAllOptionOccurrences(prefixArgs, aliases)
+    } else if (prefixOption && !prefixHasTerminator) {
+      const generatedOption = findOptionOccurrence(generatedArgs, aliases, false)
+      if (generatedOption) {
+        generatedArgs = [
+          ...generatedArgs.slice(0, generatedOption.index),
+          ...generatedArgs.slice(generatedOption.index + generatedOption.consumed)
+        ]
+      }
+      continue
+    }
     const withRecipe = applyRecipeOptionOverride({ generatedArgs, recipeArgs, aliases })
     generatedArgs = withRecipe.generatedArgs
     recipeArgs = withRecipe.recipeArgs


### PR DESCRIPTION
## ELI5

If you typed `--model something` into a Source Control AI recipe's **CLI arguments** box, Orca handed the agent CLI that flag *twice* — once its own, once yours. OpenCode crashes on a repeated `--model`. Now your value replaces Orca's instead of stacking on top of it.

## What Changed

- `CommitMessageAgentSpec` gains `singletonOptions`: the option alias groups a CLI accepts at most once. OpenCode declares `--model`/`-m`, `--agent`, `--format`, `--variant`; Codex `--model`/`-m`; Amp `--mode` (its model selector). Everything else defaults to `[['--model']]`.
- `planCommitMessageGeneration` runs the override for **every** agent instead of only Codex, and now covers the agent command-override prefix too. Precedence: recipe CLI arguments (per-action) > command-override prefix (per-agent) > Orca's generated value.
- A singleton typed twice in one field collapses to the first occurrence rather than being passed through.

Deliberately unchanged: `--` terminators still shield literal text, `-c` stays repeatable for Codex, and `-s read-only` + `--sandbox workspace-write` still coexist.

## Why

`commit-message-plan.ts` had exactly one dedup path, gated on `input.agentId === 'codex'`. Every other agent fell through to a plain concat, so a branch-name recipe of `agentId: opencode` + `agentArgs: --model …` spawned:

```
opencode run --model opencode/deepseek-v4-flash-free --agent build --format default --model deepseek-v4-flash
```

yargs' `duplicate-arguments-array` turns that into an array, and OpenCode's `parseModel` calls `.split('/')` on it — the `j.split is not a function` crash in #12305. Branch auto-name then failed permanently on the card with no way for the user to see why the flag was the problem.

The command-override prefix at the end of the planner was never deduped for **any** agent, Codex included.

Measured behavior per CLI (real binaries, not inferred):

| CLI | duplicated flag | result |
| --- | --- | --- |
| OpenCode | `--model` | **crash**, exit 1, `j.split is not a function` |
| OpenCode | `--agent` | exit 0, silently joins to `"build,plan"` → falls back to default agent |
| OpenCode | `--format` | exit 0, silently ignored |
| Codex | `--model` in exec args | exit 2, `cannot be used multiple times` |
| Codex | `--model` in prefix | exit 0, last-wins (hygiene only) |
| Claude | `--model` | exit 0, last-wins (hygiene only) |

The two OpenCode exit-0 rows are why `--agent`/`--format`/`--variant` are in scope: they never surfaced an error, they just silently ran the wrong agent.

## Linked Issue

Fixes #12305

## Visual Proof

Same configuration in both: `Branch name` recipe → OpenCode → CLI arguments containing a `--model`.

| Before | After |
| --- | --- |
| Card stuck on `rename failed` | Branch renamed from the agent's first message |
| ![before-2-rename-failed-badge.png](https://github.com/user-attachments/assets/7e34eb2e-dd02-4506-bf5d-fdce3d127626) | ![after-1-branch-renamed.png](https://github.com/user-attachments/assets/0d25d74b-c966-4c2a-9683-b361fd051ca6) |

<details>
<summary><b>Before</b> — the failure dialog, verbatim stderr from the duplicated flag</summary>

![before-1-auto-name-failed-dialog.png](https://github.com/user-attachments/assets/7c4d2562-cf1a-4a78-a7a0-2596b3ecb691)

</details>

<details>
<summary><b>Config used for both</b> — Branch name → OpenCode → CLI arguments <code>--model opencode/deepseek-v4-flash-free</code></summary>

![config-opencode-model-cli-argument.png](https://github.com/user-attachments/assets/0a1b68e0-9de5-4250-9e3c-0768b51fef8a)

</details>

The "after" shot is a live dev build on an isolated profile: worktree `Narwhal` renamed to `feat-input-validation-multiply` after a real agent's first message, sidebar and shell prompt both updated, no failure badge. The "before" pair is the original bug report on the same recipe shape.

## Testing

Ran against a real Orca dev build on an isolated profile (`ORCA_DEV_USER_DATA_PATH`) with a scratch git repo, driven over CDP.

- **End-to-end auto-rename (macOS):** configured `Branch name` → OpenCode with CLI arguments `--model opencode/deepseek-v4-flash-free`, created a worktree on the auto-generated branch `Narwhal`, ran a real agent in its terminal. Branch renamed to `feat-input-validation-multiply`; sidebar and shell prompt both updated; no failure badge.
- **Real spawn through the app:** `window.api.git.generateCommitMessage` with `agentId: opencode` + `agentArgs: '--model …'` returns success. The same call with `--model X -m Y` (same singleton typed twice) succeeded on the hardened build and reproduced the exact `j.split` crash on the build without it.
- **CLI acceptance matrix:** ran old vs new argv shapes against real `opencode`, `codex`, `claude` binaries — results in the table above. `agy` is inconclusive (dies at `authentication required` before model resolution). `amp`, `pi`, `cursor-agent` not installed, so untested — their `singletonOptions` are declarative and covered by unit tests only.
- **Unit:** `src/shared/commit-message-plan.test.ts` 26 pass. One pre-existing test (`appends per-action CLI arguments for stdin agents`) was **asserting the crashing argv** — it expected two `--model` entries for OpenCode — and is rewritten. Added coverage for long/short alias override, non-model args still appending, the `--agent`/`--format`/`--variant` group, Amp `--mode`, prefix folding, recipe-beats-prefix precedence, and the typed-twice collapse.
- 11 related suites (spec, source-control-ai, text-generation): 201 pass. `tsc --noEmit` clean on node + web. oxlint/oxfmt clean.

Not tested: Linux, Windows, SSH/remote hosts. The change is pure argv construction in `src/shared` with no platform or transport branch, and the SSH path delegates to this same planner.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

- **Security:** none — no new process spawning, no new user input surface; strictly removes tokens from an argv Orca already built.
- **Cross-platform:** pure array manipulation in shared code, no path or shell handling.
- **Remote SSH:** `planCommitMessageGeneration` is the shared planner the SSH provider delegates to over the relay, so hosts get the same argv. No wire-format change — the planner runs on whichever side executes, and `singletonOptions` is spec-local, never serialized.
- **Mobile:** not reached.
- **Backwards compatibility:** a recipe that previously relied on the duplicate reaching the CLI now gets a single flag. For OpenCode that path was a crash; for Codex `exec` it was a hard reject; for Codex-prefix and Claude it was last-wins and the user's value already won, so the effective model is unchanged.
- **Performance:** bounded loop over a handful of argv tokens at spawn time.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @BrennanKB5
