### PR TITLE
fix(packaging): gate bundled zod runtime integrity (STA-4316)

### DIFF
--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -9,7 +9,8 @@ const {
 const {
   createPackagedRuntimeNodeModuleResources,
   prunePackagedRuntimeNodeModules,
-  verifyPackagedMainRuntimeDeps
+  verifyPackagedMainRuntimeDeps,
+  verifyPackagedZodRuntime
 } = require('./packaged-runtime-node-modules.cjs')
 const { verifyLinuxGlibcFloor } = require('./scripts/verify-linux-glibc-floor.cjs')
 const { writeMacBuildCompatibility } = require('./scripts/mac-build-compatibility.cjs')
@@ -22,8 +23,7 @@ const { verifySkillsCliRuntime } = require('./scripts/verify-skills-cli-runtime.
 const isMacHourly = process.env.ORCA_MAC_HOURLY === '1'
 const isMacDaily = process.env.ORCA_MAC_DAILY === '1'
 const isMacAdhoc = process.env.ORCA_MAC_ADHOC === '1'
-const isMacRelease =
-  process.env.ORCA_MAC_RELEASE === '1' || isMacHourly || isMacDaily || isMacAdhoc
+const isMacRelease = process.env.ORCA_MAC_RELEASE === '1' || isMacHourly || isMacDaily || isMacAdhoc
 const isLinuxArm64Release = process.env.ORCA_LINUX_ARM64_RELEASE === '1'
 const localBuildVersion = isMacRelease ? undefined : process.env.ORCA_LOCAL_BUILD_VERSION
 const devChannelBuildVersion = isMacHourly
@@ -241,6 +241,7 @@ module.exports = {
     }
     prunePackagedRuntimeNodeModules(resourcesDir, context.electronPlatformName, context.arch)
     verifyPackagedMainRuntimeDeps(resourcesDir)
+    verifyPackagedZodRuntime(join(resourcesDir, 'node_modules', 'zod'))
     // Why: boot the packaged daemon-entry under plain Node, but only for the
     // slice matching the packaging host's arch — daemon-entry.js is JS, yet it
     // require()s the native (N-API) node-pty for the TARGET arch, which the host

--- a/config/packaged-runtime-node-modules.cjs
+++ b/config/packaged-runtime-node-modules.cjs
@@ -54,6 +54,16 @@ const ELECTRON_ARCHITECTURE_BY_ENUM = {
 const PACKAGED_NATIVE_ARCHITECTURES = new Set(['ia32', 'x64', 'arm', 'arm64'])
 const TYPE_DECLARATION_ARTIFACT_RE = /\.d\.(?:c|m)?ts(?:\.map)?$/
 const VERSIONED_ONNXRUNTIME_DYLIB_RE = /^libonnxruntime\.\d[\d.]*\.dylib$/
+const PACKAGED_ZOD_RUNTIME_EXPORTS = [
+  '.',
+  './mini',
+  './locales',
+  './v3',
+  './v4',
+  './v4-mini',
+  './v4/core',
+  './v4/mini'
+]
 
 const NODE_BUILTINS = new Set([
   ...builtinModules,
@@ -250,6 +260,25 @@ function verifyPackagedMainRuntimeDeps(resourcesDir, asar = require('@electron/a
         ...missing
       ].join(', ')}`
     )
+  }
+}
+
+function verifyPackagedZodRuntime(zodPackageDir) {
+  const packageJsonPath = join(zodPackageDir, 'package.json')
+  if (!existsSync(packageJsonPath)) {
+    throw new Error(`Packaged zod package is missing ${packageJsonPath}`)
+  }
+
+  const requireFromZod = createRequire(packageJsonPath)
+  for (const exportPath of PACKAGED_ZOD_RUNTIME_EXPORTS) {
+    const specifier = exportPath === '.' ? 'zod' : `zod/${exportPath.slice(2)}`
+    try {
+      requireFromZod(specifier)
+    } catch (error) {
+      throw new Error(
+        `Packaged zod runtime export ${specifier} failed to load: ${error instanceof Error ? error.message : String(error)}`
+      )
+    }
   }
 }
 
@@ -476,5 +505,6 @@ module.exports = {
   prunePackagedSherpaOnnx,
   prunePackagedRuntimeTypeDeclarations,
   prunePackagedZodSources,
+  verifyPackagedZodRuntime,
   verifyPackagedMainRuntimeDeps
 }

--- a/config/scripts/electron-builder-config.test.mjs
+++ b/config/scripts/electron-builder-config.test.mjs
@@ -1,3 +1,4 @@
+import { realpathSync } from 'node:fs'
 import { cp, mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
 import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
@@ -19,7 +20,8 @@ const {
   prunePackagedSherpaOnnx,
   prunePackagedRuntimeTypeDeclarations,
   prunePackagedZodSources,
-  verifyPackagedMainRuntimeDeps
+  verifyPackagedMainRuntimeDeps,
+  verifyPackagedZodRuntime
 } = require('../packaged-runtime-node-modules.cjs')
 
 describe('electron-builder config', () => {
@@ -508,6 +510,40 @@ describe('electron-builder config', () => {
     } finally {
       await rm(resourcesDir, { recursive: true, force: true })
     }
+  })
+
+  it('requires representative zod runtime exports after packaging prunes source files', async () => {
+    const resourcesDir = await mkdtemp(join(tmpdir(), 'orca-zod-runtime-'))
+    try {
+      const sourcePackageDir = realpathSync(join(REPO_ROOT, 'node_modules', 'zod'))
+      const validResourcesDir = join(resourcesDir, 'valid')
+      const brokenResourcesDir = join(resourcesDir, 'broken')
+      const validPackageDir = join(validResourcesDir, 'node_modules', 'zod')
+      const brokenPackageDir = join(brokenResourcesDir, 'node_modules', 'zod')
+      await cp(sourcePackageDir, validPackageDir, { recursive: true })
+      await cp(sourcePackageDir, brokenPackageDir, { recursive: true })
+      prunePackagedRuntimeTypeDeclarations(validResourcesDir)
+      prunePackagedZodSources(validResourcesDir)
+      prunePackagedRuntimeTypeDeclarations(brokenResourcesDir)
+      prunePackagedZodSources(brokenResourcesDir)
+
+      await rm(join(brokenPackageDir, 'v4', 'classic', 'external.cjs'))
+      expect(() => verifyPackagedZodRuntime(brokenPackageDir)).toThrow(
+        /Packaged zod runtime export zod failed to load/
+      )
+      expect(() => verifyPackagedZodRuntime(validPackageDir)).not.toThrow()
+    } finally {
+      await rm(resourcesDir, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps the zod runtime closure and gate on every desktop target', () => {
+    for (const platform of ['win32', 'darwin', 'linux']) {
+      expect(createPackagedRuntimeNodeModuleResources(platform)).toEqual(
+        expect.arrayContaining([expect.objectContaining({ to: join('node_modules', 'zod') })])
+      )
+    }
+    expect(electronBuilderConfig.asarUnpack).toContain('node_modules/zod/**')
   })
 
   it('fails when the packaged resources directory is missing', async () => {

--- a/config/scripts/verify-packaged-zod-runtime.cjs
+++ b/config/scripts/verify-packaged-zod-runtime.cjs
@@ -1,0 +1,16 @@
+const { resolve } = require('node:path')
+const { verifyPackagedZodRuntime } = require('../packaged-runtime-node-modules.cjs')
+
+const packageDir = readPackageDir(process.argv.slice(2))
+verifyPackagedZodRuntime(resolve(packageDir))
+console.log(`[verify-packaged-zod-runtime] OK — ${resolve(packageDir)}`)
+
+function readPackageDir(args) {
+  const argument = args.find((value) => value.startsWith('--package-dir='))
+  if (!argument) {
+    throw new Error(
+      'Usage: node config/scripts/verify-packaged-zod-runtime.cjs --package-dir=<path>'
+    )
+  }
+  return argument.slice('--package-dir='.length)
+}


### PR DESCRIPTION
## Summary\n- add a post-pack oracle that requires representative public zod exports from the actual packaged resources tree\n- run it after runtime pruning for Windows, macOS, and Linux packages\n- add regression coverage for the reported missing ./v4/classic/external.cjs failure and cross-platform staging\n\n## Reproduction evidence\n- The published v1.4.180 Windows installer was safely extracted without installation; its bundled zod has the built v3/v4/v4-mini trees and all representative requires pass, so the exact published installer failure was not reproducible from the authoritative asset.\n- Latest origin/main unpacked Windows packaging also passed the same oracle.\n- A copy with only 4/classic/external.cjs removed fails deterministically with MODULE_NOT_FOUND and exit 1.\n\n## Validation\n- pnpm exec vitest run config/scripts/electron-builder-config.test.mjs config/scripts/package-electron-runtime-contract.test.mjs --config config/vitest.config.ts\n- pnpm run typecheck\n- pnpm exec oxlint ... --deny-warnings\n- pnpm exec electron-builder --config config/electron-builder.config.cjs --win --dir\n- identical standalone oracle on source install, clean zod@4.4.3 tarball extraction, v1.4.180 extraction, and candidate artifact\n\nRefs STA-4316\nFixes #14502