### PR TITLE
fix(file-explorer): cancel in-flight ripgrep listings (STA-4310)

### DIFF
--- a/src/main/ipc/filesystem-list-files.test.ts
+++ b/src/main/ipc/filesystem-list-files.test.ts
@@ -335,6 +335,49 @@ describe('filesystem-list-files', () => {
     }
   })
 
+  it('settles promptly when an in-flight rg listing is cancelled', async () => {
+    vi.useFakeTimers()
+
+    try {
+      const p1 = createMockProcess()
+      const p2 = createMockProcess()
+      spawnMock.mockImplementation((_cmd, args: string[]) => (isIgnoredRgPass(args) ? p2 : p1))
+
+      const controller = new AbortController()
+      const cancellation = new FileListingCancelledError('superseded')
+      const promise = listQuickOpenFiles(
+        '/mock/root',
+        {} as unknown as Store,
+        undefined,
+        controller.signal
+      )
+      await flushMicrotasks()
+      expect(spawnMock).toHaveBeenCalledTimes(2)
+
+      const outcome = promise.then(
+        () => null,
+        (error) => error
+      )
+      controller.abort(cancellation)
+      const raced = Promise.race([
+        outcome,
+        new Promise((resolve) => setTimeout(() => resolve('timeout'), 100))
+      ])
+      await vi.advanceTimersByTimeAsync(100)
+
+      await expect(raced).resolves.toBe(cancellation)
+      expect(p1.kill).toHaveBeenCalled()
+      expect(p2.kill).toHaveBeenCalled()
+      for (const child of [p1, p2]) {
+        expect((child.stdout as unknown as EventEmitter).listenerCount('data')).toBe(0)
+        expect(child.listenerCount('close')).toBe(0)
+      }
+    } finally {
+      await vi.advanceTimersByTimeAsync(10_000)
+      vi.useRealTimers()
+    }
+  })
+
   it('filters out .next, .cache, .stably, .vscode, .idea', async () => {
     const p1 = createMockProcess()
     const p2 = createMockProcess()

--- a/src/main/ipc/filesystem-list-files.ts
+++ b/src/main/ipc/filesystem-list-files.ts
@@ -17,6 +17,7 @@ import {
 import { isQuickOpenReaddirBudgetError } from '../../shared/quick-open-readdir-walk'
 import { buildInstallRgMessage } from '../../shared/quick-open-install-rg'
 import { listFilesWithGit } from './filesystem-list-files-git-fallback'
+import { fileListingCancellationError } from '../../shared/file-listing-cancellation'
 import {
   absorbPendingRipgrepSpawnError,
   isRipgrepUnavailableExit,
@@ -72,7 +73,7 @@ export async function listQuickOpenFiles(
   const children: {
     child: ChildProcess
     isDone: () => boolean
-    finish: () => void
+    finish: (error?: Error) => void
   }[] = []
   // Why: WSL-routed rg can emit Linux-native absolute paths. UNC repos carry
   // their distro in the path; Windows-path repos carry it in project runtime.
@@ -89,11 +90,16 @@ export async function listQuickOpenFiles(
 
   const runRg = (args: string[]): Promise<void> => {
     return new Promise((resolve, reject) => {
+      if (signal?.aborted) {
+        reject(fileListingCancellationError(signal))
+        return
+      }
       let buf = ''
       let done = false
       let parseablePathCount = 0
       let processErrorObserved = false
       let unavailableExitObserved = false
+      let onAbort: (() => void) | undefined
 
       const processLine = (rawLine: string): boolean => {
         const translated =
@@ -196,6 +202,9 @@ export async function listQuickOpenFiles(
         }
         done = true
         clearTimeout(timer)
+        if (onAbort) {
+          signal?.removeEventListener('abort', onAbort)
+        }
         // Why: child.kill() is advisory. If rg ignores it, detach our
         // closures so repeated Quick Open attempts do not retain old scans.
         child.stdout!.off('data', handleStdoutData)
@@ -220,6 +229,14 @@ export async function listQuickOpenFiles(
       child.stderr!.on('data', handleStderrData)
       child.once('error', handleError)
       child.once('close', handleClose)
+      onAbort = (): void => {
+        const error = fileListingCancellationError(signal)
+        finish(error)
+        if (child.exitCode === null && child.signalCode === null) {
+          killSpawnedRipgrepProcess(child)
+        }
+      }
+      signal?.addEventListener('abort', onAbort, { once: true })
       timer = setTimeout(() => {
         // Why: on timeout, the buffer is likely truncated mid-path. Discard
         // it so Quick Open never displays a malformed entry.


### PR DESCRIPTION
## Summary
- Cancel active local ripgrep passes when the File Explorer/Find Files request is superseded.
- Reject with the typed file-list cancellation error, detach listeners, and use the existing process-tree-safe kill helper.
- Add a regression test covering both parallel passes and prompt cleanup.

Fixes #14488
Refs STA-4310

## Reproduction evidence
- Baseline: latest `origin/main` (`e2d309e9cd`) headed Windows 2 run rendered the populated File Explorer tree and resolved `README` to `README.md`; the lower-layer in-flight-rg cancellation oracle failed because the request remained pending until the 10-second timeout.
- Candidate: same headed Windows 2 Electron scenario rendered `README.md`; the cancellation oracle passed promptly and verified both child kills plus listener detachment.
- Disabled/reverted fix: the same oracle failed with the identical timeout result.

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/filesystem-list-files.test.ts src/main/ipc/filesystem.test.ts` (135 passed)
- `pnpm typecheck` (passed)
- `pnpm exec oxlint --config .oxlintrc.json src/main/ipc/filesystem-list-files.ts src/main/ipc/filesystem-list-files.test.ts` (passed)
- Headed Windows 2 Electron E2E on isolated profile/fixture: visible tree + name filter success, screenshot captured.

## Scope and gaps
- No RPC/stream opcode or serialized wire shape changed; the existing cancellation signal/process ownership path is completed.
- Physical Windows local coverage is proven. WSL, SSH/paired-host, and remote-server live topologies were not available in this run; their existing provider/relay cancellation tests remain unchanged and should be covered by CI.
- Do not merge automatically.