### PR TITLE
fix(win32): hide console for SSH and browser helpers

### DIFF
--- a/src/main/browser/agent-browser-bridge.test.ts
+++ b/src/main/browser/agent-browser-bridge.test.ts
@@ -1465,6 +1465,17 @@ describe('AgentBrowserBridge', () => {
     )
     expect(closeCall).toBeTruthy()
     expect(closeCall![1]).toEqual(['--session', 'orca-tab-tab-1', 'close'])
+    expect(closeCall![2]).toEqual(expect.objectContaining({ windowsHide: true }))
+  })
+
+  it('hides the agent-browser console window for ordinary commands', async () => {
+    succeedWith({ snapshot: 'tree' })
+    await bridge.snapshot()
+
+    const snapshotCall = execFileMock.mock.calls.find((call: unknown[]) =>
+      (call[1] as string[]).includes('snapshot')
+    )
+    expect(snapshotCall?.[2]).toEqual(expect.objectContaining({ windowsHide: true }))
   })
 
   it('repairs per-worktree active routing when the active tab closes', async () => {

--- a/src/main/browser/agent-browser-bridge.ts
+++ b/src/main/browser/agent-browser-bridge.ts
@@ -2604,7 +2604,7 @@ export class AgentBrowserBridge {
         child = execFile(
           this.agentBrowserBin,
           ['--session', sessionName, 'close'],
-          { timeout: STALE_SESSION_CLOSE_TIMEOUT_MS },
+          { timeout: STALE_SESSION_CLOSE_TIMEOUT_MS, windowsHide: true },
           (error) =>
             finish(
               error
@@ -2667,6 +2667,7 @@ export class AgentBrowserBridge {
         {
           timeout: execOptions?.timeoutMs ?? EXEC_TIMEOUT_MS,
           maxBuffer: 50 * 1024 * 1024,
+          windowsHide: true,
           env: execOptions?.envOverrides
             ? { ...process.env, ...execOptions.envOverrides }
             : process.env

--- a/src/main/browser/browser-cookie-import.test.ts
+++ b/src/main/browser/browser-cookie-import.test.ts
@@ -576,6 +576,41 @@ describe('importCookiesFromBrowser Chromium', () => {
     }
   })
 
+  it('hides the DPAPI PowerShell console window on Windows', async () => {
+    const sourceCookiesPath = join(tmpDir, 'Chrome', 'Default', 'Network', 'Cookies')
+    const targetCookiesPath = join(tmpDir, 'userData', 'Partitions', 'test', 'Network', 'Cookies')
+    createChromiumCookieTestDatabase(sourceCookiesPath, [
+      { name: 'sid', value: '', encryptedValue: Buffer.from('v10-encrypted') }
+    ]).close()
+    createChromiumCookieTestDatabase(targetCookiesPath, []).close()
+    const localState = join(tmpDir, 'localappdata', 'Google', 'Chrome', 'User Data', 'Local State')
+    mkdirSync(join(localState, '..'), { recursive: true })
+    writeFileSync(
+      localState,
+      JSON.stringify({
+        os_crypt: { encrypted_key: Buffer.from('DPAPIsealed-key').toString('base64') }
+      })
+    )
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    const previousLocalAppData = process.env.LOCALAPPDATA
+    process.env.LOCALAPPDATA = join(tmpDir, 'localappdata')
+
+    try {
+      await importCookiesFromBrowser(chromeBrowser(sourceCookiesPath), 'persist:test')
+      const powershellCall = execFileSyncMock.mock.calls.find(
+        ([command]) => command === 'powershell'
+      )
+      expect(powershellCall?.[2]).toEqual(expect.objectContaining({ windowsHide: true }))
+    } finally {
+      platformSpy.mockRestore()
+      if (previousLocalAppData === undefined) {
+        delete process.env.LOCALAPPDATA
+      } else {
+        process.env.LOCALAPPDATA = previousLocalAppData
+      }
+    }
+  })
+
   it('removes staging data when the OS key is unavailable', async () => {
     const sourceCookiesPath = join(tmpDir, 'Chrome', 'Default', 'Network', 'Cookies')
     const targetCookiesPath = join(tmpDir, 'userData', 'Partitions', 'test', 'Network', 'Cookies')

--- a/src/main/browser/browser-cookie-import.ts
+++ b/src/main/browser/browser-cookie-import.ts
@@ -1054,7 +1054,7 @@ function getWindowsEncryptionKey(browser: DetectedBrowser): EncryptionKeyResult 
     const result = execFileSync(
       'powershell',
       ['-NoProfile', '-NonInteractive', '-Command', script],
-      { encoding: 'utf-8', timeout: 10_000, input: dpapiData }
+      { encoding: 'utf-8', timeout: 10_000, input: dpapiData, windowsHide: true }
     ).trim()
 
     return { key: Buffer.from(result, 'base64'), mode: 'aes-256-gcm' }

--- a/src/main/ssh/ssh-config-resolver.test.ts
+++ b/src/main/ssh/ssh-config-resolver.test.ts
@@ -51,7 +51,7 @@ describe('resolveWithSshG', () => {
     expect(mockExecFile).toHaveBeenCalledWith(
       'ssh',
       ['-G', '--', 'testserver'],
-      expect.objectContaining({ timeout: 5000 }),
+      expect.objectContaining({ timeout: 5000, windowsHide: true }),
       expect.any(Function)
     )
   })

--- a/src/main/ssh/ssh-g-config-resolution.ts
+++ b/src/main/ssh/ssh-g-config-resolution.ts
@@ -82,7 +82,7 @@ export function resolveWithSshG(host: string): Promise<SshResolvedConfig | null>
       child = execFile(
         'ssh',
         sshGArgsForHost(host),
-        { timeout: SSH_G_TIMEOUT_MS },
+        { timeout: SSH_G_TIMEOUT_MS, windowsHide: true },
         (err, stdout) => {
           if (err) {
             settle(() => resolve(null))

--- a/src/main/ssh/ssh-proxy-command.test.ts
+++ b/src/main/ssh/ssh-proxy-command.test.ts
@@ -118,6 +118,35 @@ describe('spawnProxyCommand', () => {
     )
   })
 
+  it('hides console windows for jump-host and ProxyCommand spawns', () => {
+    spawnMock.mockReturnValue(createMockProxyProcess())
+
+    spawnProxyCommand(
+      { kind: 'jump-host', jumpHost: 'bastion.example.com' },
+      'target.example.com',
+      22,
+      'deploy'
+    )
+    expect(spawnMock).toHaveBeenCalledWith(
+      'ssh',
+      ['-W', 'target.example.com:22', '--', 'bastion.example.com'],
+      expect.objectContaining({ windowsHide: true })
+    )
+
+    spawnMock.mockClear()
+    spawnProxyCommand(
+      { kind: 'proxy-command', command: 'nc %h %p' },
+      'target.example.com',
+      22,
+      'deploy'
+    )
+    expect(spawnMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Array),
+      expect.objectContaining({ windowsHide: true })
+    )
+  })
+
   it('pauses the proxy stdout when the transport stream applies backpressure', () => {
     const proc = createMockProxyProcess()
     spawnMock.mockReturnValue(proc)

--- a/src/main/ssh/ssh-proxy-command.ts
+++ b/src/main/ssh/ssh-proxy-command.ts
@@ -103,7 +103,8 @@ export function spawnProxyCommand(
       ? // Why: ProxyJump is structured input, not a shell snippet. Spawn ssh
         // directly so jump-host values cannot escape through shell parsing.
         spawn('ssh', jumpHostSpawnArgs(proxy.jumpHost, host, port), {
-          stdio: ['pipe', 'pipe', 'pipe']
+          stdio: ['pipe', 'pipe', 'pipe'],
+          windowsHide: true
         })
       : (() => {
           const escape = process.platform === 'win32' ? cmdEscape : shellEscape
@@ -114,6 +115,7 @@ export function spawnProxyCommand(
           const shell = getShellSpawnConfig(expanded)
           return spawn(shell.file, shell.args, {
             stdio: ['pipe', 'pipe', 'pipe'],
+            windowsHide: true,
             windowsVerbatimArguments: shell.windowsVerbatimArguments
           })
         })()


### PR DESCRIPTION
## ELI5

On Windows, some background helper tasks — checking SSH connection settings, routing SSH traffic through jump hosts or proxies, closing stale browser-automation sessions, and reading encrypted browser cookies — could briefly flash a black command-prompt window over whatever you were doing, sometimes stealing keyboard focus from the app you were typing in. This change makes sure every such helper window stays hidden. Nothing else changes: the helpers run exactly as before, just invisibly. If you never noticed the flashes, this PR simply guarantees you won't.

## Summary

On Windows, console-subsystem helpers launched by Orca's console-less Electron main process can create a visible console host that flashes over the user's work and steals keyboard focus. This combines the current-main versions of the SSH and browser hypotheses from #10497 and #10636 into one fresh patch for STA-4337 / #14543 / #10488.

The fix passes `windowsHide: true` at all six currently uncovered relevant call sites:

- SSH `-G` configuration resolution
- SSH ProxyJump
- SSH ProxyCommand's explicit `cmd.exe` wrapper
- agent-browser stale-session close
- agent-browser ordinary commands
- Windows Chromium DPAPI PowerShell extraction

No argv, stdio, env, timeout, output, exit-status, quoting, or cleanup behavior changes.

## Validation

- Current `origin/main` was reproduced as source-level broken: all six call shapes lacked `windowsHide`.
- The six new regression assertions fail when only the production flags are disabled and pass with the fix restored.
- Focused suite: 144 passed.
- Browser module: 40 files / 639 passed.
- Full three-project TypeScript typecheck: passed.
- Changed-file oxlint and oxfmt: passed.
- Performance audit: no added process creation, retry, polling, buffering, or retained memory; only one option property per existing spawn.
- Fresh architecture and reproduction review lanes: clean.

A temporary isolated Electron GUI-parent oracle on Windows 2 exercised the exact argv/exit/output shapes. Windows Terminal made `GetConsoleWindow()` and foreground APIs unusable for this session and the independent top-level watcher saw no child console, so this run does not claim visual baseline/candidate proof. The regression tests intentionally cover the CI-suitable option boundary; the remaining OS-level visual/focus proof needs a Windows session with a reliable console-host/foreground oracle.

Full lint is currently blocked by stale generated skill manifests already present on main. The full SSH module is not a valid Windows baseline here: its unrelated failures depend on POSIX `/bin/sh`, system-OpenSSH path assumptions, and relay test environment. The changed SSH tests pass.

Original implementation attribution is preserved in commit `410a193249` via co-authorship with Wooseong Kim (@innocarpe).

Refs: STA-4337, #14543, #10488


## Visual Proof

N/A — Windows-only fix that keeps background helper console windows HIDDEN (SSH config checks, proxy command, browser helpers). By design nothing appears on screen on any platform; not demonstrable on macOS.
