### PR TITLE
fix(terminal): stop a recovery snapshot erasing scrollback it cannot replace

### DIFF
--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -101,17 +101,6 @@ type SnapshotFrameOptions = {
   pendingEscapeTailAnsi?: string
   /** Effective kitty flags proven at this frame's own `seq`. */
   kittyKeyboardFlags?: number
-  /**
-   * Whether `data` carries scrollback as well as the visible screen. Desktop
-   * snapshots are serialized with `scrollbackRows: 0`, so a client that erases
-   * its own scrollback to apply one destroys history the frame cannot replace.
-   */
-  scrollbackIncluded?: boolean
-}
-
-/** Whether a serialized snapshot's payload carries scrollback, not just the visible screen. */
-function snapshotCarriesScrollback(snapshot: SerializedSnapshot): boolean {
-  return Boolean(snapshot && (snapshot.scrollbackRows > 0 || snapshot.scrollbackAnsi))
 }
 
 type SerializedSnapshot = {
@@ -671,9 +660,6 @@ function sendSnapshotFrames(
         ...(typeof options.seq === 'number' && options.kittyKeyboardFlags !== undefined
           ? { kittyKeyboardFlags: options.kittyKeyboardFlags }
           : {}),
-        // Why additive on the same rule: absence means "unknown", and a client
-        // that cannot read it keeps its existing behavior.
-        ...(options.scrollbackIncluded === true ? { scrollbackIncluded: true } : {}),
         truncated: options.truncated === true,
         truncatedByByteBudget: options.truncatedByByteBudget === true
       })
@@ -1868,7 +1854,6 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
               source: serialized.source,
               kittyKeyboardFlags: serialized.kittyKeyboardFlags,
               truncatedByByteBudget: serialized.truncatedByByteBudget,
-              scrollbackIncluded: snapshotCarriesScrollback(serialized),
               data: serialized.data
             }
           )
@@ -2362,7 +2347,6 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
             truncatedByByteBudget: serialized?.truncatedByByteBudget,
             // Why: no serializer answered, which is not proof the pane is empty — say so instead of passing off '' as the buffer.
             unavailable: serialized ? undefined : 'no-serializable-buffer',
-            scrollbackIncluded: snapshotCarriesScrollback(serialized),
             data: serialized?.data ?? ''
           })
         } catch (error) {

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -101,6 +101,17 @@ type SnapshotFrameOptions = {
   pendingEscapeTailAnsi?: string
   /** Effective kitty flags proven at this frame's own `seq`. */
   kittyKeyboardFlags?: number
+  /**
+   * Whether `data` carries scrollback as well as the visible screen. Desktop
+   * snapshots are serialized with `scrollbackRows: 0`, so a client that erases
+   * its own scrollback to apply one destroys history the frame cannot replace.
+   */
+  scrollbackIncluded?: boolean
+}
+
+/** Whether a serialized snapshot's payload carries scrollback, not just the visible screen. */
+function snapshotCarriesScrollback(snapshot: SerializedSnapshot): boolean {
+  return Boolean(snapshot && (snapshot.scrollbackRows > 0 || snapshot.scrollbackAnsi))
 }
 
 type SerializedSnapshot = {
@@ -660,6 +671,9 @@ function sendSnapshotFrames(
         ...(typeof options.seq === 'number' && options.kittyKeyboardFlags !== undefined
           ? { kittyKeyboardFlags: options.kittyKeyboardFlags }
           : {}),
+        // Why additive on the same rule: absence means "unknown", and a client
+        // that cannot read it keeps its existing behavior.
+        ...(options.scrollbackIncluded === true ? { scrollbackIncluded: true } : {}),
         truncated: options.truncated === true,
         truncatedByByteBudget: options.truncatedByByteBudget === true
       })
@@ -1854,6 +1868,7 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
               source: serialized.source,
               kittyKeyboardFlags: serialized.kittyKeyboardFlags,
               truncatedByByteBudget: serialized.truncatedByByteBudget,
+              scrollbackIncluded: snapshotCarriesScrollback(serialized),
               data: serialized.data
             }
           )
@@ -2347,6 +2362,7 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
             truncatedByByteBudget: serialized?.truncatedByByteBudget,
             // Why: no serializer answered, which is not proof the pane is empty — say so instead of passing off '' as the buffer.
             unavailable: serialized ? undefined : 'no-serializable-buffer',
+            scrollbackIncluded: snapshotCarriesScrollback(serialized),
             data: serialized?.data ?? ''
           })
         } catch (error) {

--- a/src/renderer/src/runtime/remote-runtime-terminal-frame-drop-resync.test.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-frame-drop-resync.test.ts
@@ -14,6 +14,13 @@ import {
 } from './remote-runtime-terminal-multiplexer'
 import { replaceRuntimeEnvironmentRevisions } from './runtime-environment-revision'
 
+// Why screen-only: a resync reply is serialized with `scrollbackRows: 0`, so it
+// carries the visible screen and nothing else. Erasing the client's scrollback
+// (`\x1b[3J`) to apply it would destroy history the frame cannot put back. The
+// host sets `scrollbackIncluded` when a payload does carry scrollback, and only
+// then is the full clear correct.
+const RECOVERY_SCREEN_CLEAR = '\x1b[2J\x1b[H'
+
 // Why: reproduces the silent frame-drop corruption. The server multiplex path
 // drops Output frames when the websocket buffer is over its cap
 // (encryptedBinaryReply returns false); the wire `seq` is an output high-water, so
@@ -243,7 +250,7 @@ describe('remote terminal frame-drop resync', () => {
     expect(data).toEqual(['aaa'])
     expect(server.droppedFrames).toBe(1)
     // Instead, a fresh authoritative snapshot recovers the terminal.
-    expect(snapshots).toEqual(['INITIAL', '\x1b[2J\x1b[3J\x1b[HRECOVERED'])
+    expect(snapshots).toEqual(['INITIAL', `${RECOVERY_SCREEN_CLEAR}RECOVERED`])
 
     server.replaySnapshotCoveredOutput('ccc')
     server.output('ddd')
@@ -270,7 +277,7 @@ describe('remote terminal frame-drop resync', () => {
       expect(server.snapshotRequests).toEqual([undefined, undefined])
 
       server.output('eee')
-      expect(snapshots).toEqual(['INITIAL', '\x1b[2J\x1b[3J\x1b[HRECOVERED'])
+      expect(snapshots).toEqual(['INITIAL', `${RECOVERY_SCREEN_CLEAR}RECOVERED`])
       expect(data).toEqual(['aaa', 'eee'])
     } finally {
       vi.useRealTimers()
@@ -298,7 +305,7 @@ describe('remote terminal frame-drop resync', () => {
     server.output('eee')
 
     expect(server.snapshotRequests).toEqual([undefined, undefined])
-    expect(snapshots).toEqual(['INITIAL', '\x1b[2J\x1b[3J\x1b[HRECOVERED'])
+    expect(snapshots).toEqual(['INITIAL', `${RECOVERY_SCREEN_CLEAR}RECOVERED`])
     expect(data).toEqual(['aaa', 'eee'])
   })
 
@@ -321,7 +328,7 @@ describe('remote terminal frame-drop resync', () => {
     await expect(manualSnapshot).rejects.toThrow('stream failed')
 
     expect(server.snapshotRequests).toEqual([expect.any(Number), undefined])
-    expect(snapshots).toEqual(['INITIAL', '\x1b[2J\x1b[3J\x1b[HRECOVERED'])
+    expect(snapshots).toEqual(['INITIAL', `${RECOVERY_SCREEN_CLEAR}RECOVERED`])
 
     server.output('ddd')
     expect(data).toEqual(['aaa', 'ddd'])
@@ -342,7 +349,7 @@ describe('remote terminal frame-drop resync', () => {
       server.output('eee')
 
       expect(server.snapshotRequests).toEqual([undefined, undefined])
-      expect(snapshots).toEqual(['INITIAL', '\x1b[2J\x1b[3J\x1b[HRECOVERED'])
+      expect(snapshots).toEqual(['INITIAL', `${RECOVERY_SCREEN_CLEAR}RECOVERED`])
       expect(data).toEqual(['aaa', 'eee'])
     } finally {
       vi.useRealTimers()
@@ -452,7 +459,7 @@ describe('remote terminal frame-drop resync', () => {
     await Promise.resolve()
 
     expect(data).toEqual([])
-    expect(snapshots).toEqual(['INITIAL', '\x1b[2J\x1b[3J\x1b[HRECOVERED'])
+    expect(snapshots).toEqual(['INITIAL', `${RECOVERY_SCREEN_CLEAR}RECOVERED`])
   })
 
   it('uses UTF-16 sequence units when detecting gaps in multibyte output', async () => {
@@ -466,7 +473,7 @@ describe('remote terminal frame-drop resync', () => {
     await Promise.resolve()
 
     expect(data).toEqual(['é'])
-    expect(snapshots).toEqual(['INITIAL', '\x1b[2J\x1b[3J\x1b[HRECOVERED'])
+    expect(snapshots).toEqual(['INITIAL', `${RECOVERY_SCREEN_CLEAR}RECOVERED`])
   })
 
   it('defers recovery until an in-flight manual snapshot finishes', async () => {
@@ -489,7 +496,7 @@ describe('remote terminal frame-drop resync', () => {
 
     await expect(manualSnapshot).resolves.toMatchObject({ data: 'MANUAL' })
     expect(server.snapshotRequests).toHaveLength(2)
-    expect(snapshots).toEqual(['INITIAL', '\x1b[2J\x1b[3J\x1b[HRECOVERED'])
+    expect(snapshots).toEqual(['INITIAL', `${RECOVERY_SCREEN_CLEAR}RECOVERED`])
 
     server.output('ddd')
     expect(data).toEqual(['aaa', 'ddd'])

--- a/src/renderer/src/runtime/remote-runtime-terminal-frame-drop-resync.test.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-frame-drop-resync.test.ts
@@ -16,9 +16,7 @@ import { replaceRuntimeEnvironmentRevisions } from './runtime-environment-revisi
 
 // Why screen-only: a resync reply is serialized with `scrollbackRows: 0`, so it
 // carries the visible screen and nothing else. Erasing the client's scrollback
-// (`\x1b[3J`) to apply it would destroy history the frame cannot put back. The
-// host sets `scrollbackIncluded` when a payload does carry scrollback, and only
-// then is the full clear correct.
+// (`\x1b[3J`) to apply it would destroy history the frame cannot put back.
 const RECOVERY_SCREEN_CLEAR = '\x1b[2J\x1b[H'
 
 // Why: reproduces the silent frame-drop corruption. The server multiplex path

--- a/src/renderer/src/runtime/remote-runtime-terminal-frame-drop-resync.test.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-frame-drop-resync.test.ts
@@ -49,8 +49,10 @@ class FakeMultiplexServer {
   holdNextRecoverySnapshot = false
   emptyNextRecoverySnapshot = false
   unavailableNextRecoverySnapshot = false
+  unavailableRecoverySnapshots = false
   pendingEscapeTailAnsiNextRecoverySnapshot: string | undefined
   snapshotRequests: (number | undefined)[] = []
+  unsubscribeRequests = 0
   private heldManualRequestId: number | null = null
   private snapshotData = 'INITIAL'
 
@@ -90,7 +92,10 @@ class FakeMultiplexServer {
         this.emptyNextRecoverySnapshot = false
         this.snapshotData = ''
       }
-      if (typeof payload?.requestId !== 'number' && this.unavailableNextRecoverySnapshot) {
+      if (
+        typeof payload?.requestId !== 'number' &&
+        (this.unavailableNextRecoverySnapshot || this.unavailableRecoverySnapshots)
+      ) {
         this.unavailableNextRecoverySnapshot = false
         this.snapshotData = ''
         recoveryOptions.unavailable = 'no-serializable-buffer'
@@ -118,6 +123,10 @@ class FakeMultiplexServer {
         return
       }
       this.sendSnapshot(payload?.requestId, recoveryOptions)
+      return
+    }
+    if (frame.opcode === TerminalStreamOpcode.Unsubscribe) {
+      this.unsubscribeRequests += 1
     }
   }
 
@@ -234,7 +243,9 @@ describe('remote terminal frame-drop resync', () => {
     vi.unstubAllGlobals()
   })
 
-  async function subscribeClient(): Promise<{
+  async function subscribeClient(
+    onTransportClose?: (event: { recoverable: boolean }) => void
+  ): Promise<{
     data: string[]
     metas: { seq?: number; rawLength?: number; transformed?: boolean }[]
     snapshots: string[]
@@ -257,7 +268,8 @@ describe('remote terminal frame-drop resync', () => {
         onSnapshot: (chunk, meta) => {
           snapshots.push(chunk)
           snapshotMetas.push(meta ?? {})
-        }
+        },
+        onTransportClose
       }
     })
     // Let the initial snapshot round-trip settle.
@@ -342,6 +354,47 @@ describe('remote terminal frame-drop resync', () => {
 
       server.output('eee')
       expect(data).toEqual(['aaa', 'eee'])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('replaces the stream after five unavailable recovery attempts', async () => {
+    vi.useFakeTimers()
+    try {
+      const onTransportClose = vi.fn()
+      const first = await subscribeClient(onTransportClose)
+      const unavailableServer = server
+      unavailableServer.unavailableRecoverySnapshots = true
+
+      unavailableServer.output('aaa')
+      unavailableServer.dropNextOutput = true
+      unavailableServer.output('bbb')
+      unavailableServer.output('ccc')
+      unavailableServer.output('corrupt-live-tail')
+
+      expect(unavailableServer.snapshotRequests).toEqual([undefined])
+      expect(first.snapshots).toEqual(['INITIAL'])
+      expect(first.data).toEqual(['aaa'])
+
+      await vi.advanceTimersByTimeAsync(500 + 1_000 + 2_000 + 4_000)
+
+      expect(unavailableServer.snapshotRequests).toEqual(Array(5).fill(undefined))
+      expect(unavailableServer.unsubscribeRequests).toBe(1)
+      expect(onTransportClose).toHaveBeenCalledOnce()
+      expect(onTransportClose).toHaveBeenCalledWith({ recoverable: true })
+      expect(first.snapshots).toEqual(['INITIAL'])
+      expect(first.data).toEqual(['aaa'])
+      expect(vi.getTimerCount()).toBe(0)
+
+      await vi.advanceTimersByTimeAsync(60_000)
+      expect(unavailableServer.snapshotRequests).toHaveLength(5)
+
+      const replacement = await subscribeClient()
+      server.output('later-live-output')
+      expect(subscribe).toHaveBeenCalledTimes(2)
+      expect(replacement.snapshots).toEqual(['INITIAL'])
+      expect(replacement.data).toEqual(['later-live-output'])
     } finally {
       vi.useRealTimers()
     }

--- a/src/renderer/src/runtime/remote-runtime-terminal-frame-drop-resync.test.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-frame-drop-resync.test.ts
@@ -47,6 +47,9 @@ class FakeMultiplexServer {
   truncateNextRecoverySnapshot = false
   dropNextRecoverySnapshotEnd = false
   holdNextRecoverySnapshot = false
+  emptyNextRecoverySnapshot = false
+  unavailableNextRecoverySnapshot = false
+  pendingEscapeTailAnsiNextRecoverySnapshot: string | undefined
   snapshotRequests: (number | undefined)[] = []
   private heldManualRequestId: number | null = null
   private snapshotData = 'INITIAL'
@@ -79,6 +82,26 @@ class FakeMultiplexServer {
       // Resync request: the server serializes the *current* buffer, so recovery
       // includes everything the client missed.
       this.snapshotData = 'RECOVERED'
+      const recoveryOptions: {
+        unavailable?: 'no-serializable-buffer'
+        pendingEscapeTailAnsi?: string
+      } = {}
+      if (typeof payload?.requestId !== 'number' && this.emptyNextRecoverySnapshot) {
+        this.emptyNextRecoverySnapshot = false
+        this.snapshotData = ''
+      }
+      if (typeof payload?.requestId !== 'number' && this.unavailableNextRecoverySnapshot) {
+        this.unavailableNextRecoverySnapshot = false
+        this.snapshotData = ''
+        recoveryOptions.unavailable = 'no-serializable-buffer'
+      }
+      if (
+        typeof payload?.requestId !== 'number' &&
+        this.pendingEscapeTailAnsiNextRecoverySnapshot !== undefined
+      ) {
+        recoveryOptions.pendingEscapeTailAnsi = this.pendingEscapeTailAnsiNextRecoverySnapshot
+        this.pendingEscapeTailAnsiNextRecoverySnapshot = undefined
+      }
       if (typeof payload?.requestId !== 'number' && this.holdNextRecoverySnapshot) {
         // The reply's binary frames were all dropped under backpressure.
         this.holdNextRecoverySnapshot = false
@@ -94,7 +117,7 @@ class FakeMultiplexServer {
         this.sendSnapshot(undefined, { omitEnd: true })
         return
       }
-      this.sendSnapshot(payload?.requestId)
+      this.sendSnapshot(payload?.requestId, recoveryOptions)
     }
   }
 
@@ -104,7 +127,12 @@ class FakeMultiplexServer {
 
   private sendSnapshot(
     requestId?: number,
-    options?: { truncated?: boolean; omitEnd?: boolean }
+    options?: {
+      truncated?: boolean
+      omitEnd?: boolean
+      unavailable?: 'no-serializable-buffer'
+      pendingEscapeTailAnsi?: string
+    }
   ): void {
     this.send(
       TerminalStreamOpcode.SnapshotStart,
@@ -113,7 +141,9 @@ class FakeMultiplexServer {
         rows: 24,
         seq: options?.truncated ? undefined : this.cursorUnits,
         requestId,
-        truncated: options?.truncated
+        truncated: options?.truncated,
+        unavailable: options?.unavailable,
+        pendingEscapeTailAnsi: options?.pendingEscapeTailAnsi
       }),
       0
     )
@@ -208,11 +238,13 @@ describe('remote terminal frame-drop resync', () => {
     data: string[]
     metas: { seq?: number; rawLength?: number; transformed?: boolean }[]
     snapshots: string[]
+    snapshotMetas: { pendingEscapeTailAnsi?: string; seq?: number }[]
     stream: RemoteRuntimeMultiplexedTerminal
   }> {
     const data: string[] = []
     const metas: { seq?: number; rawLength?: number; transformed?: boolean }[] = []
     const snapshots: string[] = []
+    const snapshotMetas: { pendingEscapeTailAnsi?: string; seq?: number }[] = []
     const multiplexer = getRemoteRuntimeTerminalMultiplexer('env-1')
     const stream = await multiplexer.subscribeTerminal({
       terminal: 'terminal-1',
@@ -222,13 +254,16 @@ describe('remote terminal frame-drop resync', () => {
           data.push(chunk)
           metas.push(meta ?? {})
         },
-        onSnapshot: (chunk) => snapshots.push(chunk)
+        onSnapshot: (chunk, meta) => {
+          snapshots.push(chunk)
+          snapshotMetas.push(meta ?? {})
+        }
       }
     })
     // Let the initial snapshot round-trip settle.
     await Promise.resolve()
     await Promise.resolve()
-    return { data, metas, snapshots, stream }
+    return { data, metas, snapshots, snapshotMetas, stream }
   }
 
   it('detects a dropped Output frame via the seq gap and resyncs', async () => {
@@ -253,6 +288,78 @@ describe('remote terminal frame-drop resync', () => {
     server.replaySnapshotCoveredOutput('ccc')
     server.output('ddd')
     expect(data).toEqual(['aaa', 'ddd'])
+  })
+
+  it('applies an authoritative empty recovery while preserving scrollback', async () => {
+    const { Terminal } = await import('@xterm/headless')
+    const { data, snapshots } = await subscribeClient()
+    server.emptyNextRecoverySnapshot = true
+
+    server.output('aaa')
+    server.dropNextOutput = true
+    server.output('bbb')
+    server.output('ccc')
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(snapshots).toEqual(['INITIAL', RECOVERY_SCREEN_CLEAR])
+    expect(snapshots[1]).not.toContain('\x1b[3J')
+
+    const terminal = new Terminal({ cols: 20, rows: 2, scrollback: 100 })
+    const write = (text: string): Promise<void> =>
+      new Promise((resolve) => terminal.write(text, resolve))
+    await write('history-1\r\nhistory-2\r\nvisible')
+    const baseYBeforeRecovery = terminal.buffer.active.baseY
+    await write(snapshots[1])
+    expect(baseYBeforeRecovery).toBeGreaterThan(0)
+    expect(terminal.buffer.active.baseY).toBe(baseYBeforeRecovery)
+    expect(terminal.buffer.active.getLine(0)?.translateToString(true)).toBe('history-1')
+    terminal.dispose()
+
+    server.output('ddd')
+    expect(data).toEqual(['aaa', 'ddd'])
+  })
+
+  it('retries an explicitly unavailable recovery without repainting or accepting output', async () => {
+    vi.useFakeTimers()
+    try {
+      const { data, snapshots } = await subscribeClient()
+      server.unavailableNextRecoverySnapshot = true
+
+      server.output('aaa')
+      server.dropNextOutput = true
+      server.output('bbb')
+      server.output('ccc')
+      server.output('ddd')
+
+      expect(server.snapshotRequests).toEqual([undefined])
+      expect(snapshots).toEqual(['INITIAL'])
+      expect(data).toEqual(['aaa'])
+
+      await vi.advanceTimersByTimeAsync(500)
+      expect(server.snapshotRequests).toEqual([undefined, undefined])
+      expect(snapshots).toEqual(['INITIAL', `${RECOVERY_SCREEN_CLEAR}RECOVERED`])
+
+      server.output('eee')
+      expect(data).toEqual(['aaa', 'eee'])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('replays a pending escape tail after clearing an empty recovered screen', async () => {
+    const { snapshots, snapshotMetas } = await subscribeClient()
+    server.emptyNextRecoverySnapshot = true
+    server.pendingEscapeTailAnsiNextRecoverySnapshot = '\x1b[38;5'
+
+    server.dropNextOutput = true
+    server.output('dropped')
+    server.output('gap')
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(snapshots).toEqual(['INITIAL', RECOVERY_SCREEN_CLEAR])
+    expect(snapshotMetas[1]).toMatchObject({ pendingEscapeTailAnsi: '\x1b[38;5' })
   })
 
   it('retries a truncated recovery on a backoff without accepting output across the gap', async () => {

--- a/src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts
@@ -234,6 +234,7 @@ const REMOTE_TERMINAL_RESYNC_TIMEOUT_MS = 10_000
 // retrying once per incoming chunk would stampede it, so back off instead.
 const REMOTE_TERMINAL_RESYNC_RETRY_BASE_MS = 500
 const REMOTE_TERMINAL_RESYNC_RETRY_MAX_MS = 5_000
+const REMOTE_TERMINAL_RESYNC_MAX_ATTEMPTS = 5
 // Why: exported so the transport can classify it as benign — the snapshot was
 // skipped but live output continues, so it must not surface a fatal red banner.
 export const REMOTE_TERMINAL_SNAPSHOT_TOO_LARGE =
@@ -1021,6 +1022,7 @@ class RemoteRuntimeTerminalMultiplexer {
   private sendResyncSnapshot(stream: RemoteRuntimeMultiplexedTerminalState): void {
     stream.resyncPendingSend = false
     this.startResyncTimer(stream)
+    stream.resyncAttempts += 1
     const sent = this.sendFrame(
       stream.streamId,
       TerminalStreamOpcode.SnapshotRequest,
@@ -1030,13 +1032,17 @@ class RemoteRuntimeTerminalMultiplexer {
       // Transport is down; the reconnect path re-subscribes from scratch.
       clearResyncTimer(stream)
       stream.resyncInFlight = false
+      stream.resyncAttempts -= 1
     }
   }
 
   // Why: keep the gate shut across the backoff — the post-gap tail is corrupt
   // either way — and heal even if the flood ends with no further output.
   private scheduleResyncRetry(stream: RemoteRuntimeMultiplexedTerminalState): void {
-    stream.resyncAttempts += 1
+    if (stream.resyncAttempts >= REMOTE_TERMINAL_RESYNC_MAX_ATTEMPTS) {
+      this.recoverStalledStream(stream)
+      return
+    }
     const delay = Math.min(
       REMOTE_TERMINAL_RESYNC_RETRY_MAX_MS,
       REMOTE_TERMINAL_RESYNC_RETRY_BASE_MS * 2 ** Math.min(stream.resyncAttempts - 1, 4)

--- a/src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts
@@ -217,10 +217,6 @@ type RemoteRuntimeSnapshotInfo = {
   // must write it AFTER the replay reset so the next live chunk completes it
   // instead of rendering literally (#7329).
   pendingEscapeTailAnsi?: string
-  // Why: whether the payload carries scrollback as well as the screen. Absent
-  // from older hosts, which is why the recovery path treats false as "do not
-  // erase scrollback" rather than "there is none".
-  scrollbackIncluded?: boolean
 }
 
 type RemoteRuntimeSnapshotRequest = {
@@ -908,19 +904,19 @@ class RemoteRuntimeTerminalMultiplexer {
             kittyKeyboardFlags: info?.kittyKeyboardFlags
           })
         } else if (target === 'recovery') {
-          // Why: a recovery repaint must never destroy more than it replaces.
-          // `\x1b[3J` erases xterm's scrollback, but desktop snapshots are
-          // serialized with `scrollbackRows: 0`, so the frame cannot put that
-          // history back — clear the screen alone unless the host says this
-          // payload carries scrollback. An absent flag means an older host,
-          // which never sends scrollback on this path either.
-          const clearAnsi = info?.scrollbackIncluded ? '\x1b[2J\x1b[3J\x1b[H' : '\x1b[2J\x1b[H'
+          // Why the screen only, never `\x1b[3J`: that erases xterm's scrollback,
+          // and every payload reaching this branch is screen-only by
+          // construction — the ack-recovery emit serializes with
+          // `scrollbackRows: 0`, and the untagged resync request carries no
+          // scrollback either. Erasing history the frame cannot put back is
+          // silent data loss. A payload that DOES carry scrollback arrives
+          // tagged, and the request branch above never clears.
           // Why not an empty repaint: with no payload there is nothing to put
           // on screen, so applying one only blanks a pane the host could not
           // describe. A mid-escape tail still has to replay so the next live
           // chunk completes it instead of rendering literally (#7329).
           if (data) {
-            stream.callbacks.onSnapshot(`${clearAnsi}${data}`, {
+            stream.callbacks.onSnapshot(`\x1b[2J\x1b[H${data}`, {
               pendingEscapeTailAnsi: info?.pendingEscapeTailAnsi,
               seq: info?.seq,
               kittyKeyboardFlags: info?.kittyKeyboardFlags
@@ -1565,7 +1561,6 @@ function decodeSnapshotInfo(
     requestId?: unknown
     truncated?: unknown
     unavailable?: unknown
-    scrollbackIncluded?: unknown
     pendingEscapeTailAnsi?: unknown
     kittyKeyboardFlags?: unknown
   }>(payload)
@@ -1582,7 +1577,6 @@ function decodeSnapshotInfo(
     requestId: typeof raw.requestId === 'number' ? raw.requestId : undefined,
     truncated: raw.truncated === true,
     unavailable: parseTerminalSnapshotUnavailableReason(raw.unavailable),
-    scrollbackIncluded: raw.scrollbackIncluded === true,
     pendingEscapeTailAnsi:
       typeof raw.pendingEscapeTailAnsi === 'string' ? raw.pendingEscapeTailAnsi : undefined
   }

--- a/src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts
@@ -876,6 +876,7 @@ class RemoteRuntimeTerminalMultiplexer {
       const info = stream.snapshotInfo
       const pendingRequest = stream.pendingSnapshotRequest
       const snapshotApplied = !stream.snapshotOverflowed && info?.truncated !== true
+      const recoverySnapshotApplied = snapshotApplied && info?.unavailable === undefined
       const matchesPendingRequest =
         target === 'request' &&
         pendingRequest &&
@@ -903,31 +904,13 @@ class RemoteRuntimeTerminalMultiplexer {
             seq: info?.seq,
             kittyKeyboardFlags: info?.kittyKeyboardFlags
           })
-        } else if (target === 'recovery') {
-          // Why the screen only, never `\x1b[3J`: that erases xterm's scrollback,
-          // and every payload reaching this branch is screen-only by
-          // construction — the ack-recovery emit serializes with
-          // `scrollbackRows: 0`, and the untagged resync request carries no
-          // scrollback either. Erasing history the frame cannot put back is
-          // silent data loss. A payload that DOES carry scrollback arrives
-          // tagged, and the request branch above never clears.
-          // Why not an empty repaint: with no payload there is nothing to put
-          // on screen, so applying one only blanks a pane the host could not
-          // describe. A mid-escape tail still has to replay so the next live
-          // chunk completes it instead of rendering literally (#7329).
-          if (data) {
-            stream.callbacks.onSnapshot(`\x1b[2J\x1b[H${data}`, {
-              pendingEscapeTailAnsi: info?.pendingEscapeTailAnsi,
-              seq: info?.seq,
-              kittyKeyboardFlags: info?.kittyKeyboardFlags
-            })
-          } else if (info?.pendingEscapeTailAnsi) {
-            stream.callbacks.onSnapshot('', {
-              pendingEscapeTailAnsi: info.pendingEscapeTailAnsi,
-              seq: info?.seq,
-              kittyKeyboardFlags: info?.kittyKeyboardFlags
-            })
-          }
+        } else if (target === 'recovery' && recoverySnapshotApplied) {
+          // Untagged resync and ACK-overflow replies are screen-only; preserve client scrollback.
+          stream.callbacks.onSnapshot(`\x1b[2J\x1b[H${data ?? ''}`, {
+            pendingEscapeTailAnsi: info?.pendingEscapeTailAnsi,
+            seq: info?.seq,
+            kittyKeyboardFlags: info?.kittyKeyboardFlags
+          })
         }
       } else if (matchesPendingRequest) {
         pendingRequest.resolve({
@@ -948,7 +931,7 @@ class RemoteRuntimeTerminalMultiplexer {
       } else if (target === 'recovery') {
         // Why: only an applied recovery is authoritative; retaining the prior
         // high-water after a discarded snapshot keeps the gap detectable.
-        if (snapshotApplied) {
+        if (recoverySnapshotApplied) {
           clearResyncTimer(stream)
           stream.expectedSeq = typeof info?.seq === 'number' ? info.seq : undefined
           stream.commandProbeBaselineSeq = undefined

--- a/src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts
@@ -217,6 +217,10 @@ type RemoteRuntimeSnapshotInfo = {
   // must write it AFTER the replay reset so the next live chunk completes it
   // instead of rendering literally (#7329).
   pendingEscapeTailAnsi?: string
+  // Why: whether the payload carries scrollback as well as the screen. Absent
+  // from older hosts, which is why the recovery path treats false as "do not
+  // erase scrollback" rather than "there is none".
+  scrollbackIncluded?: boolean
 }
 
 type RemoteRuntimeSnapshotRequest = {
@@ -904,15 +908,30 @@ class RemoteRuntimeTerminalMultiplexer {
             kittyKeyboardFlags: info?.kittyKeyboardFlags
           })
         } else if (target === 'recovery') {
-          // Why: a server-pushed recovery snapshot replaces terminal state
-          // mid-session; clear the screen and scrollback before applying it.
-          // An empty snapshot is still applied so stale dropped output does
-          // not linger on a terminal the model says is blank.
-          stream.callbacks.onSnapshot(`\x1b[2J\x1b[3J\x1b[H${data ?? ''}`, {
-            pendingEscapeTailAnsi: info?.pendingEscapeTailAnsi,
-            seq: info?.seq,
-            kittyKeyboardFlags: info?.kittyKeyboardFlags
-          })
+          // Why: a recovery repaint must never destroy more than it replaces.
+          // `\x1b[3J` erases xterm's scrollback, but desktop snapshots are
+          // serialized with `scrollbackRows: 0`, so the frame cannot put that
+          // history back — clear the screen alone unless the host says this
+          // payload carries scrollback. An absent flag means an older host,
+          // which never sends scrollback on this path either.
+          const clearAnsi = info?.scrollbackIncluded ? '\x1b[2J\x1b[3J\x1b[H' : '\x1b[2J\x1b[H'
+          // Why not an empty repaint: with no payload there is nothing to put
+          // on screen, so applying one only blanks a pane the host could not
+          // describe. A mid-escape tail still has to replay so the next live
+          // chunk completes it instead of rendering literally (#7329).
+          if (data) {
+            stream.callbacks.onSnapshot(`${clearAnsi}${data}`, {
+              pendingEscapeTailAnsi: info?.pendingEscapeTailAnsi,
+              seq: info?.seq,
+              kittyKeyboardFlags: info?.kittyKeyboardFlags
+            })
+          } else if (info?.pendingEscapeTailAnsi) {
+            stream.callbacks.onSnapshot('', {
+              pendingEscapeTailAnsi: info.pendingEscapeTailAnsi,
+              seq: info?.seq,
+              kittyKeyboardFlags: info?.kittyKeyboardFlags
+            })
+          }
         }
       } else if (matchesPendingRequest) {
         pendingRequest.resolve({
@@ -994,7 +1013,7 @@ class RemoteRuntimeTerminalMultiplexer {
 
   // Why: on a detected gap, discard the corrupt tail and pull a fresh
   // authoritative snapshot. The request carries no requestId so the server
-  // reply renders through the initial-snapshot path (full reset), self-healing
+  // reply renders through the recovery path (screen reset), self-healing
   // without surfacing an error to the user.
   private requestResyncSnapshot(stream: RemoteRuntimeMultiplexedTerminalState): void {
     if (stream.resyncInFlight) {
@@ -1546,6 +1565,7 @@ function decodeSnapshotInfo(
     requestId?: unknown
     truncated?: unknown
     unavailable?: unknown
+    scrollbackIncluded?: unknown
     pendingEscapeTailAnsi?: unknown
     kittyKeyboardFlags?: unknown
   }>(payload)
@@ -1562,6 +1582,7 @@ function decodeSnapshotInfo(
     requestId: typeof raw.requestId === 'number' ? raw.requestId : undefined,
     truncated: raw.truncated === true,
     unavailable: parseTerminalSnapshotUnavailableReason(raw.unavailable),
+    scrollbackIncluded: raw.scrollbackIncluded === true,
     pendingEscapeTailAnsi:
       typeof raw.pendingEscapeTailAnsi === 'string' ? raw.pendingEscapeTailAnsi : undefined
   }

--- a/src/renderer/src/runtime/runtime-terminal-stream.test.ts
+++ b/src/renderer/src/runtime/runtime-terminal-stream.test.ts
@@ -586,16 +586,37 @@ describe('remote runtime terminal multiplex ACK gate', () => {
       },
       'recovered state'
     )
-    // Why: an unsolicited recovery snapshot replaces terminal state, so it
-    // clears screen and scrollback first and must not replay the subscribe
-    // lifecycle.
-    expect(onSnapshot).toHaveBeenCalledWith(`\x1b[2J\x1b[3J\x1b[H${'recovered state'}`, {
+    // Why only the screen: an unsolicited recovery snapshot replaces terminal
+    // state without replaying the subscribe lifecycle, but this frame carries
+    // no scrollback, so erasing the client's history would destroy output the
+    // frame cannot put back.
+    expect(onSnapshot).toHaveBeenCalledWith(`\x1b[2J\x1b[H${'recovered state'}`, {
       pendingEscapeTailAnsi: undefined
     })
     expect(onSubscribed).toHaveBeenCalledTimes(1)
 
-    // Why: an empty recovery snapshot means the model terminal is blank, so
-    // the client must still clear stale dropped output.
+    // Why scrollback may be erased here: the host states the payload carries
+    // it, so the frame replaces the history it removes.
+    injectSnapshot(
+      {
+        kind: 'scrollback',
+        cols: 120,
+        rows: 40,
+        reason: 'ack-pending-overflow',
+        truncated: false,
+        scrollbackIncluded: true
+      },
+      'restored with history'
+    )
+    expect(onSnapshot).toHaveBeenCalledWith(`\x1b[2J\x1b[3J\x1b[H${'restored with history'}`, {
+      pendingEscapeTailAnsi: undefined
+    })
+
+    // Why nothing at all: this replaced the previous rule, which read an empty
+    // payload as an authoritative blank and cleared on it. An empty payload is
+    // the host failing to describe the pane, not proof the pane is empty, and
+    // applying it only blanks a terminal the user can still read.
+    const snapshotCallsBeforeEmpty = onSnapshot.mock.calls.length
     injectSnapshot(
       {
         kind: 'scrollback',
@@ -606,9 +627,7 @@ describe('remote runtime terminal multiplex ACK gate', () => {
       },
       ''
     )
-    expect(onSnapshot).toHaveBeenCalledWith('\x1b[2J\x1b[3J\x1b[H', {
-      pendingEscapeTailAnsi: undefined
-    })
+    expect(onSnapshot).toHaveBeenCalledTimes(snapshotCallsBeforeEmpty)
     expect(onSubscribed).toHaveBeenCalledTimes(1)
 
     stream.close()

--- a/src/renderer/src/runtime/runtime-terminal-stream.test.ts
+++ b/src/renderer/src/runtime/runtime-terminal-stream.test.ts
@@ -595,11 +595,8 @@ describe('remote runtime terminal multiplex ACK gate', () => {
     })
     expect(onSubscribed).toHaveBeenCalledTimes(1)
 
-    // Why nothing at all: this replaced the previous rule, which read an empty
-    // payload as an authoritative blank and cleared on it. An empty payload is
-    // the host failing to describe the pane, not proof the pane is empty, and
-    // applying it only blanks a terminal the user can still read.
-    const snapshotCallsBeforeEmpty = onSnapshot.mock.calls.length
+    // A successful empty snapshot authoritatively clears only the visible
+    // screen; unavailable replies carry an explicit wire reason instead.
     injectSnapshot(
       {
         kind: 'scrollback',
@@ -610,7 +607,9 @@ describe('remote runtime terminal multiplex ACK gate', () => {
       },
       ''
     )
-    expect(onSnapshot).toHaveBeenCalledTimes(snapshotCallsBeforeEmpty)
+    expect(onSnapshot).toHaveBeenLastCalledWith('\x1b[2J\x1b[H', {
+      pendingEscapeTailAnsi: undefined
+    })
     expect(onSubscribed).toHaveBeenCalledTimes(1)
 
     stream.close()

--- a/src/renderer/src/runtime/runtime-terminal-stream.test.ts
+++ b/src/renderer/src/runtime/runtime-terminal-stream.test.ts
@@ -595,23 +595,6 @@ describe('remote runtime terminal multiplex ACK gate', () => {
     })
     expect(onSubscribed).toHaveBeenCalledTimes(1)
 
-    // Why scrollback may be erased here: the host states the payload carries
-    // it, so the frame replaces the history it removes.
-    injectSnapshot(
-      {
-        kind: 'scrollback',
-        cols: 120,
-        rows: 40,
-        reason: 'ack-pending-overflow',
-        truncated: false,
-        scrollbackIncluded: true
-      },
-      'restored with history'
-    )
-    expect(onSnapshot).toHaveBeenCalledWith(`\x1b[2J\x1b[3J\x1b[H${'restored with history'}`, {
-      pendingEscapeTailAnsi: undefined
-    })
-
     // Why nothing at all: this replaced the previous rule, which read an empty
     // payload as an authoritative blank and cleared on it. An empty payload is
     // the host failing to describe the pane, not proof the pane is empty, and


### PR DESCRIPTION
## ELI5

When a remote terminal recovers from a hiccup, the server sends back just what is on screen—not the terminal history. We were erasing the history before painting that screen, so scrollback vanished and the recovery frame could not replace it. Now recovery replaces only the visible screen and leaves existing history intact.

## What Changed

**Client only—no host change and no wire change.** The recovery branch in `remote-runtime-terminal-multiplexer.ts` now clears only the visible screen (`\x1b[2J\x1b[H`) before applying a screen-only snapshot; it no longer emits the scrollback erase (`\x1b[3J`).

- A successful empty recovery snapshot is authoritative: it clears the visible screen while preserving scrollback, then advances recovery.
- A recovery snapshot carrying the existing `unavailable` reason is not painted or accepted; the client remains gated for at most five snapshot attempts, then replaces only that stream through the existing recoverable unsubscribe/resubscribe path.
- A pending mid-escape tail still replays after an empty recovery so the next live chunk completes it rather than rendering literally (#7329).
- Corrected a comment that claimed a resync reply rendered through the initial-snapshot path; it renders through the recovery path.

## Why

`\x1b[3J` erases terminal scrollback, but both producers that can reach this recovery branch serialize screen-only data:

- ACK-overflow recovery calls `serializeBudgetedRequestedSnapshot(runtime, ptyId, 0)` with literal `0` scrollback rows.
- Untagged gap resync omits `scrollbackRows`, which normalizes to `0`.
- A request that can include scrollback is tagged with `requestId`; that response takes the request branch, which does not prepend a clear.

The old client therefore destroyed history the recovery frame could not put back. This path runs for ordinary sequence-gap detection and ACK-pending overflow, not only disconnects.

An earlier revision added a `scrollbackIncluded` wire flag. It was deleted because it could never be true on either recovery producer and no consumer needed it; the final change uses the construction of the existing protocol paths instead of adding dead wire state.

## Linked Issue

Fixes #14593

This is plausibly also the cause of #9562 ("cannot scroll up" after remote host restart). Not claiming #6106: that SSH/daemon transport carries scrollback and likely loses history through a different path.

## Visual Proof

The headful paired-runtime test drops a real remote output frame, observes the host advance, recovers the visible terminal via a snapshot without replacing its PTY/tab, and accepts subsequent live input. The uncropped final frame shows the post-gap command and `LIVE:` response in the real Orca terminal UI.

![Post-gap recovery with continued live output](https://github.com/user-attachments/assets/901f7afb-24a7-4f34-993b-8438f7de79ce)

https://github.com/user-attachments/assets/841e1cd4-3f98-4899-be61-ec27312edda7

Linux SSH evidence and cleanup details: https://github.com/stablyai/orca/pull/14594#issuecomment-5299786006

## Testing

The pinned assertions now state why recovery may clear the screen but never history. Added deterministic coverage for:

- non-empty gap recovery with a screen-only clear;
- authoritative empty recovery with a real `@xterm/headless` scrollback oracle;
- explicit unavailability remaining gated and retrying without repaint or sequence advance;
- persistent unavailability stopping after exactly five requests, cleaning its timer, suppressing the corrupt tail, and escalating through recoverable stream replacement;
- pending escape-tail replay after an empty recovery;
- manual/tagged snapshots remaining isolated from the recovery clear.

Validation on final HEAD `8a20f55bc8abd50f7c6ece01de845c8155b9dc9b`:

- renderer runtime: 77 files / 782 tests passed;
- terminal pane: 266 files / 3,451 tests passed, including SSH and Windows paths;
- relevant host recovery contracts: 80 tests passed;
- mixed-version terminal wire: 5 tests passed;
- both `config/tsconfig.tc.web.json` and `config/tsconfig.node.json` typechecks passed;
- oxlint, changed-file oxfmt, max-lines ratchet, and `git diff --check` passed;

Current-head Electron/CDP smoke also confirmed the intended worktree identity and zero console errors.

Carried-forward end-to-end evidence from `df535b6b2e3fe86caee06024e0784f230c9cfcfe` (the final commit only changes the persistent-unavailability fallback):

- headful paired-runtime recovery passed and was recorded;
- disposable Linux SSH target used a real `demo-project`, built and deployed the relay, exercised a remote PTY, preserved seeded scrollback through a live gap, verified remote backing state/logs, and was cleaned up.

One unrelated existing randomized equivalence test can exceed its hardcoded 30-second timeout under load; its other 19 cases pass, and this PR does not touch that path.

- [x] Automated tests added/updated
- [x] Manually validated in Electron and through a disposable Linux SSH target

## Review

- **Remote wire compatibility:** no schema, field, opcode, or host behavior changes. The client only consumes the already-existing optional unavailability reason.
- **Cross-platform / SSH / mobile:** the changed branch is the desktop multiplex recovery path. macOS Electron and a real Linux SSH remote PTY were validated; Windows packaging and the changed terminal test paths are green. No mobile-facing surface changed.
- **Performance:** the normal recovery path emits one fewer control sequence and adds no polling, listener, timer, or buffer growth. Explicitly unavailable snapshots reuse the existing backoff, make at most five requests, then cleanly replace the affected stream.

## Supersedes #14202

#14202 gated only on payload emptiness, so it left non-empty screen-only recoveries erasing scrollback. Its proposed host-side suppression was not carried over: contentless data can be a valid authoritative blank screen, while serializer failure is represented by explicit unavailability. The final client behavior handles both cases correctly across host versions without a new host or wire change.
