### PR TITLE
Keep other-client workspace filter visible during catalog hydration

### DIFF
--- a/src/renderer/src/components/sidebar/SidebarWorkspaceFilterSection.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarWorkspaceFilterSection.test.tsx
@@ -36,6 +36,7 @@ function setState(overrides: Record<string, unknown> = {}): void {
     hideWorkspacesFromOtherDevices: false,
     setHideWorkspacesFromOtherDevices: vi.fn(),
     runtimeEnvironments: [],
+    runtimeEnvironmentCatalogHydrated: true,
     alwaysShowDefaultBranchWorkspace: true,
     setAlwaysShowDefaultBranchWorkspace: vi.fn(),
     ...overrides
@@ -96,8 +97,15 @@ describe('SidebarWorkspaceFilterSection', () => {
     expect(rowLabels()).toContain('Hide other-client workspaces')
   })
 
+  it('keeps the other-client filter visible while the remote catalog loads', () => {
+    setState({ runtimeEnvironmentCatalogHydrated: false })
+    render()
+
+    expect(rowLabels()).toContain('Hide other-client workspaces')
+  })
+
   it('hides the other-client filter for local-only clients', () => {
-    setState()
+    setState({ runtimeEnvironmentCatalogHydrated: true })
     render()
 
     expect(rowLabels()).not.toContain('Hide other-client workspaces')

--- a/src/renderer/src/components/sidebar/SidebarWorkspaceFilterSection.tsx
+++ b/src/renderer/src/components/sidebar/SidebarWorkspaceFilterSection.tsx
@@ -27,11 +27,15 @@ const SidebarWorkspaceFilterSection = React.memo(function SidebarWorkspaceFilter
   const hideWorkspacesFromOtherDevices = useAppStore((s) => s.hideWorkspacesFromOtherDevices)
   const setHideWorkspacesFromOtherDevices = useAppStore((s) => s.setHideWorkspacesFromOtherDevices)
   const runtimeEnvironments = useAppStore((s) => s.runtimeEnvironments)
+  const runtimeEnvironmentCatalogHydrated = useAppStore((s) => s.runtimeEnvironmentCatalogHydrated)
   const alwaysShowDefaultBranchWorkspace = useAppStore((s) => s.alwaysShowDefaultBranchWorkspace)
   const setAlwaysShowDefaultBranchWorkspace = useAppStore(
     (s) => s.setAlwaysShowDefaultBranchWorkspace
   )
-  const showOtherClientFilter = runtimeEnvironments.length > 0 || hideWorkspacesFromOtherDevices
+  const showOtherClientFilter =
+    !runtimeEnvironmentCatalogHydrated ||
+    runtimeEnvironments.length > 0 ||
+    hideWorkspacesFromOtherDevices
 
   return (
     <>


### PR DESCRIPTION
## ELI5

Do not briefly hide the remote-workspace filter while Orca is still loading its saved remote servers.

## What Changed

- treat an unhydrated runtime catalog as unknown instead of local-only
- keep **Hide other-client workspaces** visible until the catalog loads successfully
- add regression coverage for unhydrated, hydrated local-only, configured-remote, and enabled-filter states

## Why

`runtimeEnvironments: []` represents both the initial unhydrated state and a successfully loaded local-only catalog. The previous visibility condition could therefore hide the row during startup for users with remote servers. Reading the existing `runtimeEnvironmentCatalogHydrated` flag distinguishes those states without changing persisted data or the remote wire.

Follow-up to #14579 and CodeRabbit discussion https://github.com/stablyai/orca/pull/14579#discussion_r3786850966.

## Linked Issue

N/A — narrow review follow-up to #14579; no separate issue exists.

## Visual Proof

N/A — this only removes a transient pre-hydration disappearance; the steady-state row is visually unchanged.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/SidebarWorkspaceFilterSection.test.tsx src/renderer/src/components/sidebar/visible-worktrees.test.ts src/renderer/src/components/sidebar/workspace-creator-visibility.test.ts` (48/48)
- `pnpm typecheck`
- `pnpm lint`
- independent OpenCode read-only verification via Orca CLI (6/6 focused, 68/68 sidebar, web TypeScript and lint)

Tested on macOS. The change is renderer-only and does not alter remote RPCs, persisted workspace metadata, filesystem paths, SSH execution, or server behavior.

## Review

Reviewed for security, macOS/Linux/Windows behavior, Remote SSH, folder workspaces, mixed client/server versions, performance, and backwards compatibility. No wire or host-side changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (lint/typecheck/focused tests pass; full test/build left to CI)

## Author

- X / Twitter: N/A