### PR TITLE
fix(gitlab): route task issues, MRs, and detail actions to the owning host

### DIFF
--- a/src/renderer/src/components/gitlab-item-dialog/use-gitlab-details-editing.ts
+++ b/src/renderer/src/components/gitlab-item-dialog/use-gitlab-details-editing.ts
@@ -11,6 +11,7 @@ import {
 } from '../gitlab-item-dialog-parts'
 import type { GitLabDialogRepoSelector } from './gitlab-item-dialog-types'
 import type { GitLabItemDialogState } from './use-gitlab-item-dialog-state'
+import { routedGitLab } from '@/runtime/gitlab-runtime-routing'
 
 export function useGitLabDetailsEditing(
   item: GitLabWorkItem | null,
@@ -40,7 +41,7 @@ export function useGitLabDetailsEditing(
     }
     setLabelOptionsLoading(true)
     try {
-      const labels = await window.api.gl.listLabels(repoSelector)
+      const labels = await routedGitLab.listLabels(repoSelector)
       if (mountedRef.current) {
         setLabelOptions(normalizeGitLabLabels(labels))
       }
@@ -127,7 +128,7 @@ export function useGitLabDetailsEditing(
 
     setDetailsSaving(true)
     try {
-      const res = await window.api.gl.updateMR({ ...repoSelector, iid: item.number, updates })
+      const res = await routedGitLab.updateMR({ ...repoSelector, iid: item.number, updates })
       if (res.ok) {
         if (mountedRef.current) {
           setDetails((current) =>

--- a/src/renderer/src/components/gitlab-item-dialog/use-gitlab-item-dialog-effects.ts
+++ b/src/renderer/src/components/gitlab-item-dialog/use-gitlab-item-dialog-effects.ts
@@ -3,6 +3,7 @@ import { useEffect } from 'react'
 import type { GitLabWorkItem, GitLabWorkItemDetails } from '../../../../shared/gitlab-types'
 import type { GitLabDialogRepoSelector } from './gitlab-item-dialog-types'
 import type { GitLabItemDialogState } from './use-gitlab-item-dialog-state'
+import { routedGitLab } from '@/runtime/gitlab-runtime-routing'
 
 export function useGitLabItemDetailsEffect(
   item: GitLabWorkItem | null,
@@ -21,7 +22,7 @@ export function useGitLabItemDetailsEffect(
     let stale = false
     setLoading(true)
     setError(null)
-    void window.api.gl
+    void routedGitLab
       .workItemDetails({ ...repoSelector, iid: item.number, type: item.type })
       .then((data) => {
         if (stale) {

--- a/src/renderer/src/components/gitlab-item-dialog/use-gitlab-pipeline-actions.ts
+++ b/src/renderer/src/components/gitlab-item-dialog/use-gitlab-pipeline-actions.ts
@@ -5,6 +5,7 @@ import type { GitLabPipelineJob, GitLabWorkItem } from '../../../../shared/gitla
 import { showGitLabMutationError } from '../gitlab-item-dialog-parts'
 import type { GitLabDialogRepoSelector } from './gitlab-item-dialog-types'
 import type { GitLabItemDialogState } from './use-gitlab-item-dialog-state'
+import { routedGitLab } from '@/runtime/gitlab-runtime-routing'
 
 export function useGitLabPipelineActions(
   item: GitLabWorkItem | null,
@@ -37,7 +38,7 @@ export function useGitLabPipelineActions(
         [job.id]: { loading: true }
       }))
       try {
-        const result = await window.api.gl.jobTrace({
+        const result = await routedGitLab.jobTrace({
           ...repoSelector,
           jobId: job.id,
           projectRef: details?.item.projectRef ?? item.projectRef ?? null
@@ -82,7 +83,7 @@ export function useGitLabPipelineActions(
       }
       setRetryingJobId(job.id)
       try {
-        const result = await window.api.gl.retryJob({
+        const result = await routedGitLab.retryJob({
           ...repoSelector,
           jobId: job.id,
           projectRef: details?.item.projectRef ?? item.projectRef ?? null

--- a/src/renderer/src/components/gitlab-item-dialog/use-gitlab-primary-actions.ts
+++ b/src/renderer/src/components/gitlab-item-dialog/use-gitlab-primary-actions.ts
@@ -7,6 +7,7 @@ import type { GitLabWorkItem } from '../../../../shared/gitlab-types'
 import { showGitLabMutationError } from '../gitlab-item-dialog-parts'
 import type { GitLabDialogRepoSelector } from './gitlab-item-dialog-types'
 import type { GitLabItemDialogState } from './use-gitlab-item-dialog-state'
+import { routedGitLab } from '@/runtime/gitlab-runtime-routing'
 
 export function useGitLabPrimaryActions(
   item: GitLabWorkItem | null,
@@ -28,7 +29,7 @@ export function useGitLabPrimaryActions(
     }
     setActionInFlight('close')
     try {
-      const res = await window.api.gl.closeMR({ ...repoSelector, iid: item.number })
+      const res = await routedGitLab.closeMR({ ...repoSelector, iid: item.number })
       if (res.ok) {
         if (mountedRef.current) {
           useAppStore.getState().recordFeatureInteraction('gitlab-tasks')
@@ -61,7 +62,7 @@ export function useGitLabPrimaryActions(
     }
     setActionInFlight('reopen')
     try {
-      const res = await window.api.gl.reopenMR({ ...repoSelector, iid: item.number })
+      const res = await routedGitLab.reopenMR({ ...repoSelector, iid: item.number })
       if (res.ok) {
         if (mountedRef.current) {
           useAppStore.getState().recordFeatureInteraction('gitlab-tasks')
@@ -94,7 +95,7 @@ export function useGitLabPrimaryActions(
     }
     setActionInFlight('merge')
     try {
-      const res = await window.api.gl.mergeMR({ ...repoSelector, iid: item.number })
+      const res = await routedGitLab.mergeMR({ ...repoSelector, iid: item.number })
       if (res.ok) {
         if (mountedRef.current) {
           useAppStore.getState().recordFeatureInteraction('gitlab-tasks')
@@ -141,12 +142,12 @@ export function useGitLabPrimaryActions(
       // Branch on the item type to hit the right channel.
       const res =
         item.type === 'mr'
-          ? await window.api.gl.addMRComment({
+          ? await routedGitLab.addMRComment({
               ...repoSelector,
               iid: item.number,
               body: bodyState.body
             })
-          : await window.api.gl.addIssueComment({
+          : await routedGitLab.addIssueComment({
               ...repoSelector,
               number: item.number,
               body: bodyState.body

--- a/src/renderer/src/components/gitlab-item-dialog/use-gitlab-review-actions.ts
+++ b/src/renderer/src/components/gitlab-item-dialog/use-gitlab-review-actions.ts
@@ -7,6 +7,7 @@ import type { GitLabAssignableUser, GitLabWorkItem } from '../../../../shared/gi
 import { dedupeGitLabUsers, showGitLabMutationError } from '../gitlab-item-dialog-parts'
 import type { GitLabDialogRepoSelector } from './gitlab-item-dialog-types'
 import type { GitLabItemDialogState } from './use-gitlab-item-dialog-state'
+import { routedGitLab } from '@/runtime/gitlab-runtime-routing'
 
 export function useGitLabReviewActions(
   item: GitLabWorkItem | null,
@@ -36,7 +37,7 @@ export function useGitLabReviewActions(
     }
     setReviewerOptionsLoading(true)
     try {
-      const users = await window.api.gl.listAssignableUsers(repoSelector)
+      const users = await routedGitLab.listAssignableUsers(repoSelector)
       if (mountedRef.current) {
         setReviewerOptions(dedupeGitLabUsers(users))
       }
@@ -77,7 +78,7 @@ export function useGitLabReviewActions(
       }
       setReviewerUpdating(true)
       try {
-        const result = await window.api.gl.updateMRReviewers({
+        const result = await routedGitLab.updateMRReviewers({
           ...repoSelector,
           iid: item.number,
           reviewerIds,
@@ -156,7 +157,7 @@ export function useGitLabReviewActions(
     }
     setInlineCommentSubmitting(true)
     try {
-      const result = await window.api.gl.addMRInlineComment({
+      const result = await routedGitLab.addMRInlineComment({
         ...repoSelector,
         iid: item.number,
         projectRef: details.item.projectRef ?? item.projectRef ?? null,
@@ -214,7 +215,7 @@ export function useGitLabReviewActions(
       }
       setResolvingThreadId(threadId)
       try {
-        const res = await window.api.gl.resolveMRDiscussion({
+        const res = await routedGitLab.resolveMRDiscussion({
           ...repoSelector,
           iid: item.number,
           discussionId: threadId,

--- a/src/renderer/src/components/right-sidebar/use-hosted-review-actions.test.tsx
+++ b/src/renderer/src/components/right-sidebar/use-hosted-review-actions.test.tsx
@@ -235,6 +235,69 @@ describe('useHostedReviewActions', () => {
     expect(gitLabRefresh).toHaveBeenCalledTimes(1)
   })
 
+  // Why: guards that the hook's synthetic gitlab source context actually reaches
+  // routedGitLab — a dropped `sourceContext` would silently fall back to local IPC
+  // (the exact "unknown repository path" failure) and leave the routing test green.
+  it('routes runtime-owned GitLab MR merges through the runtime host', async () => {
+    const { onRefreshReview } = await renderHook(
+      makeRepo({ executionHostId: 'runtime:env-1' }),
+      undefined,
+      undefined,
+      true
+    )
+
+    await act(async () => {
+      await latest?.handleMerge('merge')
+    })
+
+    expect(runtimeRpcMocks.callRuntimeRpc).toHaveBeenCalledWith(
+      { kind: 'environment', environmentId: 'env-1' },
+      'gitlab.mergeMR',
+      { repo: 'id:repo-1', iid: 1015, method: 'merge' },
+      { timeoutMs: 30_000 }
+    )
+    expect(window.api.gl.mergeMR).not.toHaveBeenCalled()
+    expect(onRefreshReview).toHaveBeenCalledTimes(1)
+  })
+
+  it('routes runtime-owned GitLab MR close through updateMRState on the host', async () => {
+    await renderHook(makeRepo({ executionHostId: 'runtime:env-1' }), undefined, undefined, true)
+
+    await act(async () => {
+      await latest?.handleCloseReview()
+    })
+
+    expect(runtimeRpcMocks.callRuntimeRpc).toHaveBeenCalledWith(
+      { kind: 'environment', environmentId: 'env-1' },
+      'gitlab.updateMRState',
+      { repo: 'id:repo-1', iid: 1015, state: 'closed' },
+      { timeoutMs: 30_000 }
+    )
+    expect(window.api.gl.closeMR).not.toHaveBeenCalled()
+  })
+
+  it('keeps non-runtime GitLab MR actions on desktop IPC', async () => {
+    await renderHook(
+      makeRepo({ connectionId: 'ssh-target', executionHostId: 'ssh:ssh-target' }),
+      undefined,
+      undefined,
+      true
+    )
+
+    await act(async () => {
+      await latest?.handleMerge('merge')
+    })
+
+    expect(window.api.gl.mergeMR).toHaveBeenCalledWith({
+      repoPath: '/repo',
+      repoId: 'repo-1',
+      sourceContext: expect.objectContaining({ provider: 'gitlab' }),
+      iid: 1015,
+      method: 'merge'
+    })
+    expect(runtimeRpcMocks.callRuntimeRpc).not.toHaveBeenCalled()
+  })
+
   it('confirms the downstack merge scope before merging a registered stack', async () => {
     const stackedPR = {
       ...githubPR,

--- a/src/renderer/src/components/right-sidebar/use-hosted-review-actions.ts
+++ b/src/renderer/src/components/right-sidebar/use-hosted-review-actions.ts
@@ -1,7 +1,10 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import { useConfirmationDialog } from '@/components/confirmation-dialog-context'
 import type { GitHubPRAutoMergeAction } from '@/components/github-pr-merge-state'
+import { routedGitLab } from '@/runtime/gitlab-runtime-routing'
+import { getRepoExecutionHostId } from '../../../../shared/execution-host'
+import { normalizeTaskSourceContext } from '../../../../shared/task-source-context'
 import type { HostedReviewInfo } from '../../../../shared/hosted-review'
 import type { GitHubPRMergeMethod, PRInfo } from '../../../../shared/github/pull-request-types'
 import type { Repo } from '../../../../shared/repo-types'
@@ -61,6 +64,19 @@ export function useHostedReviewActions({
   handleReopenReview: () => Promise<void>
 } {
   const confirm = useConfirmationDialog()
+  // Why: this hook has the repo but no task source context, so derive the routing host from the repo.
+  const gitlabSourceContext = useMemo(
+    () =>
+      isGitLab
+        ? normalizeTaskSourceContext({
+            provider: 'gitlab',
+            projectId: repo.id,
+            hostId: getRepoExecutionHostId(repo),
+            repoId: repo.id
+          })
+        : null,
+    [isGitLab, repo]
+  )
   const [merging, setMerging] = useState(false)
   const [stateUpdating, setStateUpdating] = useState<'open' | 'closed' | null>(null)
   const [actionError, setActionError] = useState<string | null>(null)
@@ -96,9 +112,10 @@ export function useHostedReviewActions({
       setActionError(null)
       try {
         const result = isGitLab
-          ? await window.api.gl.mergeMR({
+          ? await routedGitLab.mergeMR({
               repoPath: repo.path,
               repoId: repo.id,
+              sourceContext: gitlabSourceContext,
               iid: review.number,
               method
             })
@@ -121,6 +138,7 @@ export function useHostedReviewActions({
     },
     [
       confirm,
+      gitlabSourceContext,
       githubPR?.prRepo,
       githubPR?.mergeQueueRequired,
       githubPR?.stack,
@@ -199,14 +217,16 @@ export function useHostedReviewActions({
       try {
         const result = isGitLab
           ? isClosing
-            ? await window.api.gl.closeMR({
+            ? await routedGitLab.closeMR({
                 repoPath: repo.path,
                 repoId: repo.id,
+                sourceContext: gitlabSourceContext,
                 iid: review.number
               })
-            : await window.api.gl.reopenMR({
+            : await routedGitLab.reopenMR({
                 repoPath: repo.path,
                 repoId: repo.id,
+                sourceContext: gitlabSourceContext,
                 iid: review.number
               })
           : await updateGitHubHostedReviewState({
@@ -245,6 +265,7 @@ export function useHostedReviewActions({
     },
     [
       confirm,
+      gitlabSourceContext,
       githubPR?.prRepo,
       isGitLab,
       onRefreshReview,

--- a/src/renderer/src/components/use-task-page-gitlab-loading.ts
+++ b/src/renderer/src/components/use-task-page-gitlab-loading.ts
@@ -1,6 +1,7 @@
 import type { TaskPageProviderMetadataModel } from './use-task-page-provider-metadata'
 import { useEffect } from 'react'
 import type { GitLabWorkItem, GitLabTodo } from '../../../shared/gitlab-types'
+import { routedGitLab } from '@/runtime/gitlab-runtime-routing'
 import {
   getTaskPageRepoSourceContext,
   isGitLabIssueFilter,
@@ -54,7 +55,7 @@ export function useTaskPageGitLabLoading(model: TaskPageProviderMetadataModel) {
       gitlabView === 'issues'
         ? (repo: (typeof eligibleRepos)[0]) => {
             const isAssignedToMe = activeIssueFilter === 'assigned-to-me'
-            return window.api.gl
+            return routedGitLab
               .listIssues({
                 repoPath: repo.path,
                 repoId: repo.id,
@@ -81,7 +82,7 @@ export function useTaskPageGitLabLoading(model: TaskPageProviderMetadataModel) {
               })
           }
         : (repo: (typeof eligibleRepos)[0]) =>
-            window.api.gl
+            routedGitLab
               .listMRs({
                 repoPath: repo.path,
                 repoId: repo.id,
@@ -157,7 +158,7 @@ export function useTaskPageGitLabLoading(model: TaskPageProviderMetadataModel) {
     }
     let stale = false
     setGitlabTodosLoading(true)
-    void window.api.gl
+    void routedGitLab
       .todos({
         repoPath: primaryRepo.path,
         repoId: primaryRepo.id,

--- a/src/renderer/src/runtime/gitlab-runtime-routing.test.ts
+++ b/src/renderer/src/runtime/gitlab-runtime-routing.test.ts
@@ -1,0 +1,330 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as RuntimeRpcClientModule from './runtime-rpc-client'
+import { LOCAL_EXECUTION_HOST_ID, toRuntimeExecutionHostId } from '../../../shared/execution-host'
+import {
+  normalizeTaskSourceContext,
+  type TaskSourceContext
+} from '../../../shared/task-source-context'
+
+// vi.hoisted so the spy exists before the hoisted vi.mock factory runs.
+const { callRuntimeRpc } = vi.hoisted(() => ({
+  callRuntimeRpc: vi.fn(async () => ({ items: [] }))
+}))
+vi.mock('./runtime-rpc-client', async (importOriginal) => {
+  const actual = await importOriginal<typeof RuntimeRpcClientModule>()
+  return { ...actual, callRuntimeRpc }
+})
+
+const gl = {
+  listIssues: vi.fn(async () => ({ items: [] })),
+  listMRs: vi.fn(async () => ({ items: [] })),
+  todos: vi.fn(async () => []),
+  workItemDetails: vi.fn(async () => null),
+  listLabels: vi.fn(async () => []),
+  listAssignableUsers: vi.fn(async () => [{ username: 'matthew' }]),
+  updateMR: vi.fn(async () => ({ ok: true })),
+  jobTrace: vi.fn(async () => ({ ok: true })),
+  retryJob: vi.fn(async () => ({ ok: true })),
+  updateMRReviewers: vi.fn(async () => ({})),
+  addMRInlineComment: vi.fn(async () => ({})),
+  closeMR: vi.fn(async () => ({ ok: true })),
+  reopenMR: vi.fn(async () => ({ ok: true })),
+  mergeMR: vi.fn(async () => ({ ok: true })),
+  addMRComment: vi.fn(async () => ({})),
+  addIssueComment: vi.fn(async () => ({})),
+  resolveMRDiscussion: vi.fn(async () => ({}))
+}
+// @ts-expect-error -- minimal window.api stub for the module under test
+globalThis.window = { api: { gl } }
+
+import { getGitLabTaskRuntimeTarget, routedGitLab } from './gitlab-runtime-routing'
+
+const ENV = { kind: 'environment' as const, environmentId: 'macbook-pro' }
+
+function gitlabContext(hostId: string, repoId: string | null = 'repo-1'): TaskSourceContext {
+  const context = normalizeTaskSourceContext({
+    provider: 'gitlab',
+    projectId: 'project-1',
+    hostId,
+    repoId
+  })
+  if (!context) {
+    throw new Error('failed to build test source context')
+  }
+  return context
+}
+
+const RUNTIME_HOST = toRuntimeExecutionHostId('macbook-pro')
+
+beforeEach(() => {
+  callRuntimeRpc.mockClear()
+  for (const fn of Object.values(gl)) {
+    fn.mockClear()
+  }
+})
+
+describe('getGitLabTaskRuntimeTarget', () => {
+  it('routes local for a repo owned by the local host', () => {
+    expect(
+      getGitLabTaskRuntimeTarget({
+        repoId: 'repo-1',
+        sourceContext: gitlabContext(LOCAL_EXECUTION_HOST_ID)
+      })
+    ).toEqual({ kind: 'local' })
+  })
+
+  it('routes to the owning runtime environment with an id selector', () => {
+    expect(
+      getGitLabTaskRuntimeTarget({ repoId: 'repo-1', sourceContext: gitlabContext(RUNTIME_HOST) })
+    ).toEqual({ kind: 'environment', environmentId: 'macbook-pro', repoSelector: 'id:repo-1' })
+  })
+
+  it('prefers the source context repo id over the args repo id', () => {
+    expect(
+      getGitLabTaskRuntimeTarget({
+        repoId: 'renderer-id',
+        sourceContext: gitlabContext(RUNTIME_HOST, 'host-id')
+      })
+    ).toEqual({ kind: 'environment', environmentId: 'macbook-pro', repoSelector: 'id:host-id' })
+  })
+
+  it('routes local when a runtime repo has no resolvable id', () => {
+    expect(
+      getGitLabTaskRuntimeTarget({ sourceContext: gitlabContext(RUNTIME_HOST, null) })
+    ).toEqual({ kind: 'local' })
+  })
+
+  it('routes local without a source context', () => {
+    expect(getGitLabTaskRuntimeTarget({ repoId: 'repo-1' })).toEqual({ kind: 'local' })
+  })
+
+  it('routes local for a non-gitlab source context', () => {
+    const github = {
+      kind: 'task-source' as const,
+      provider: 'github' as const,
+      projectId: 'project-1',
+      hostId: RUNTIME_HOST,
+      repoId: 'repo-1'
+    }
+    expect(getGitLabTaskRuntimeTarget({ repoId: 'repo-1', sourceContext: github })).toEqual({
+      kind: 'local'
+    })
+  })
+})
+
+describe('routedGitLab local vs remote transport', () => {
+  it('hits local IPC for a local repo', async () => {
+    await routedGitLab.workItemDetails({
+      repoPath: '/repo',
+      repoId: 'repo-1',
+      sourceContext: gitlabContext(LOCAL_EXECUTION_HOST_ID),
+      iid: 2,
+      type: 'issue'
+    })
+    expect(callRuntimeRpc).not.toHaveBeenCalled()
+    expect(gl.workItemDetails).toHaveBeenCalledWith(
+      expect.objectContaining({ repoPath: '/repo', repoId: 'repo-1', iid: 2, type: 'issue' })
+    )
+  })
+
+  it('relays workItemDetails to the runtime host with an id selector', async () => {
+    await routedGitLab.workItemDetails({
+      repoPath: '/repo',
+      repoId: 'repo-1',
+      sourceContext: gitlabContext(RUNTIME_HOST),
+      iid: 2,
+      type: 'issue'
+    })
+    expect(gl.workItemDetails).not.toHaveBeenCalled()
+    expect(callRuntimeRpc).toHaveBeenCalledWith(
+      ENV,
+      'gitlab.workItemDetails',
+      { repo: 'id:repo-1', iid: 2, type: 'issue' },
+      { timeoutMs: 30_000 }
+    )
+  })
+
+  it('relays list fetches to the runtime host', async () => {
+    await routedGitLab.listIssues({
+      repoPath: '/repo',
+      repoId: 'repo-1',
+      sourceContext: gitlabContext(RUNTIME_HOST),
+      state: 'opened',
+      limit: 50
+    })
+    expect(callRuntimeRpc).toHaveBeenCalledWith(
+      ENV,
+      'gitlab.listIssues',
+      { repo: 'id:repo-1', state: 'opened', limit: 50 },
+      { timeoutMs: 30_000 }
+    )
+  })
+
+  it('maps closeMR to updateMRState with the closed state', async () => {
+    await routedGitLab.closeMR({
+      repoPath: '/repo',
+      repoId: 'repo-1',
+      sourceContext: gitlabContext(RUNTIME_HOST),
+      iid: 5
+    })
+    expect(callRuntimeRpc).toHaveBeenCalledWith(
+      ENV,
+      'gitlab.updateMRState',
+      { repo: 'id:repo-1', iid: 5, state: 'closed' },
+      { timeoutMs: 30_000 }
+    )
+  })
+
+  it('maps reopenMR to updateMRState with the opened state', async () => {
+    await routedGitLab.reopenMR({
+      repoPath: '/repo',
+      repoId: 'repo-1',
+      sourceContext: gitlabContext(RUNTIME_HOST),
+      iid: 5
+    })
+    expect(callRuntimeRpc).toHaveBeenCalledWith(
+      ENV,
+      'gitlab.updateMRState',
+      { repo: 'id:repo-1', iid: 5, state: 'opened' },
+      { timeoutMs: 30_000 }
+    )
+  })
+
+  it('returns an empty assignable-user list for a remote repo without an RPC', async () => {
+    const result = await routedGitLab.listAssignableUsers({
+      repoPath: '/repo',
+      repoId: 'repo-1',
+      sourceContext: gitlabContext(RUNTIME_HOST)
+    })
+    expect(result).toEqual([])
+    expect(callRuntimeRpc).not.toHaveBeenCalled()
+    expect(gl.listAssignableUsers).not.toHaveBeenCalled()
+  })
+
+  it('still fetches assignable users locally for a local repo', async () => {
+    await routedGitLab.listAssignableUsers({
+      repoPath: '/repo',
+      repoId: 'repo-1',
+      sourceContext: gitlabContext(LOCAL_EXECUTION_HOST_ID)
+    })
+    expect(gl.listAssignableUsers).toHaveBeenCalled()
+  })
+})
+
+// Why: locks every routed method's RPC name and arg passthrough so a copy-paste
+// miswire (e.g. mergeMR -> gitlab.updateMR) can't stay green — the method name is
+// a plain string type-checking can't validate. Also pins the remote-only extras
+// (close/reopen state, jobTrace logExcerpt).
+describe('routedGitLab remote method-name and arg wiring', () => {
+  const CASES: readonly {
+    method: keyof typeof routedGitLab
+    rpc: string
+    args: Record<string, unknown>
+    expected: Record<string, unknown>
+  }[] = [
+    {
+      method: 'listIssues',
+      rpc: 'gitlab.listIssues',
+      args: { state: 'opened', limit: 50 },
+      expected: { state: 'opened', limit: 50 }
+    },
+    {
+      method: 'listMRs',
+      rpc: 'gitlab.listMRs',
+      args: { state: 'opened', page: 1, perPage: 50 },
+      expected: { state: 'opened', page: 1, perPage: 50 }
+    },
+    { method: 'todos', rpc: 'gitlab.todos', args: {}, expected: {} },
+    {
+      method: 'workItemDetails',
+      rpc: 'gitlab.workItemDetails',
+      args: { iid: 2, type: 'issue' },
+      expected: { iid: 2, type: 'issue' }
+    },
+    { method: 'listLabels', rpc: 'gitlab.listLabels', args: {}, expected: {} },
+    {
+      method: 'updateMR',
+      rpc: 'gitlab.updateMR',
+      args: { iid: 5, updates: { title: 'x' } },
+      expected: { iid: 5, updates: { title: 'x' } }
+    },
+    {
+      method: 'jobTrace',
+      rpc: 'gitlab.jobTrace',
+      args: { jobId: 9, projectRef: null },
+      expected: { jobId: 9, projectRef: null, logExcerpt: true }
+    },
+    {
+      method: 'retryJob',
+      rpc: 'gitlab.retryJob',
+      args: { jobId: 9, projectRef: null },
+      expected: { jobId: 9, projectRef: null }
+    },
+    {
+      method: 'updateMRReviewers',
+      rpc: 'gitlab.updateMRReviewers',
+      args: { iid: 5, reviewerIds: [1], projectRef: null },
+      expected: { iid: 5, reviewerIds: [1], projectRef: null }
+    },
+    {
+      method: 'addMRInlineComment',
+      rpc: 'gitlab.addMRInlineComment',
+      args: { iid: 5, input: { body: 'x' }, projectRef: null },
+      expected: { iid: 5, input: { body: 'x' }, projectRef: null }
+    },
+    {
+      method: 'closeMR',
+      rpc: 'gitlab.updateMRState',
+      args: { iid: 5 },
+      expected: { iid: 5, state: 'closed' }
+    },
+    {
+      method: 'reopenMR',
+      rpc: 'gitlab.updateMRState',
+      args: { iid: 5 },
+      expected: { iid: 5, state: 'opened' }
+    },
+    {
+      method: 'mergeMR',
+      rpc: 'gitlab.mergeMR',
+      args: { iid: 5, method: 'merge' },
+      expected: { iid: 5, method: 'merge' }
+    },
+    {
+      method: 'addMRComment',
+      rpc: 'gitlab.addMRComment',
+      args: { iid: 5, body: 'hi' },
+      expected: { iid: 5, body: 'hi' }
+    },
+    {
+      method: 'addIssueComment',
+      rpc: 'gitlab.addIssueComment',
+      args: { number: 2, body: 'hi' },
+      expected: { number: 2, body: 'hi' }
+    },
+    {
+      method: 'resolveMRDiscussion',
+      rpc: 'gitlab.resolveMRDiscussion',
+      args: { iid: 5, discussionId: 'd1', resolved: true },
+      expected: { iid: 5, discussionId: 'd1', resolved: true }
+    }
+  ]
+
+  for (const { method, rpc, args, expected } of CASES) {
+    it(`relays ${method} to ${rpc} with the selector and stripped fields`, async () => {
+      const call = routedGitLab[method] as (a: Record<string, unknown>) => Promise<unknown>
+      await call({
+        repoPath: '/repo',
+        repoId: 'repo-1',
+        sourceContext: gitlabContext(RUNTIME_HOST),
+        ...args
+      })
+      expect(callRuntimeRpc).toHaveBeenCalledWith(
+        ENV,
+        rpc,
+        { repo: 'id:repo-1', ...expected },
+        { timeoutMs: 30_000 }
+      )
+    })
+  }
+})

--- a/src/renderer/src/runtime/gitlab-runtime-routing.test.ts
+++ b/src/renderer/src/runtime/gitlab-runtime-routing.test.ts
@@ -127,6 +127,25 @@ describe('routedGitLab local vs remote transport', () => {
     )
   })
 
+  it('bounds the local IPC branch with a timeout so a hung glab call cannot spin forever', async () => {
+    vi.useFakeTimers()
+    try {
+      gl.workItemDetails.mockImplementationOnce(() => new Promise<never>(() => {}))
+      const pending = routedGitLab.workItemDetails({
+        repoPath: '/repo',
+        repoId: 'repo-1',
+        sourceContext: gitlabContext(LOCAL_EXECUTION_HOST_ID),
+        iid: 2,
+        type: 'issue'
+      })
+      const assertion = expect(pending).rejects.toThrow(/timed out/i)
+      await vi.advanceTimersByTimeAsync(30_000)
+      await assertion
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('relays workItemDetails to the runtime host with an id selector', async () => {
     await routedGitLab.workItemDetails({
       repoPath: '/repo',

--- a/src/renderer/src/runtime/gitlab-runtime-routing.ts
+++ b/src/renderer/src/runtime/gitlab-runtime-routing.ts
@@ -67,6 +67,23 @@ function toRpcParams(
   return params
 }
 
+// Why: window.api.gl.* runs glab in main with no subprocess timeout, so an
+// unreachable GitLab host would leave the UI spinning forever. Bound the local
+// branch the way callRuntimeRpc bounds the remote one. Rejects only the pending
+// promise — the main-process call is not cancellable from here, but this is
+// enough to surface an error instead of a stuck spinner.
+function withTimeout<T>(pending: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  return Promise.race([
+    pending,
+    new Promise<never>((_, reject) => {
+      timer = setTimeout(() => reject(new Error('GitLab request timed out')), timeoutMs)
+    })
+  ]).finally(() => {
+    clearTimeout(timer)
+  })
+}
+
 function dispatch<A extends GitLabSelectorArgs, R>(
   localCall: (args: A) => Promise<R>,
   rpcMethod: string,
@@ -75,7 +92,7 @@ function dispatch<A extends GitLabSelectorArgs, R>(
 ): Promise<R> {
   const target = getGitLabTaskRuntimeTarget(args)
   if (target.kind === 'local') {
-    return localCall(args)
+    return withTimeout(localCall(args), RUNTIME_RPC_TIMEOUT_MS)
   }
   return callRuntimeRpc<R>(
     { kind: 'environment', environmentId: target.environmentId },

--- a/src/renderer/src/runtime/gitlab-runtime-routing.ts
+++ b/src/renderer/src/runtime/gitlab-runtime-routing.ts
@@ -1,0 +1,164 @@
+import { getTaskSourceRuntimeSettings, type TaskSourceContext } from '../../../shared/task-source-context'
+import { callRuntimeRpc } from './runtime-rpc-client'
+import { getActiveRuntimeTarget } from './runtime-client-target'
+
+// Why: GitLab list fetches page issues/MRs through glab, longer than a point
+// mutation; match the GitHub work-item list timeout rather than a shorter default.
+const RUNTIME_RPC_TIMEOUT_MS = 30_000
+
+type GitLabSelectorArgs = {
+  repoPath?: string | null
+  repoId?: string | null
+  sourceContext?: TaskSourceContext | null
+}
+
+type GL = typeof window.api.gl
+
+export type GitLabTaskRuntimeTarget =
+  | { kind: 'local' }
+  | { kind: 'environment'; environmentId: string; repoSelector: string }
+
+// Why: a GitLab repo owned by a remote runtime host must relay every task
+// operation to that host over RPC, not hit the local IPC handler. The local
+// handler runs assertRegisteredRepo, which rejects any path not registered in
+// this machine's own repo store with "Access denied: unknown repository path";
+// a runtime-owned repo only exists in the owning host's store. Route by the
+// repo's own execution host (sourceContext.hostId), not the Active Server
+// dropdown, so a runtime-owned repo resolves even while Local is focused.
+export function getGitLabTaskRuntimeTarget(args: GitLabSelectorArgs): GitLabTaskRuntimeTarget {
+  if (args.sourceContext?.provider !== 'gitlab') {
+    return { kind: 'local' }
+  }
+  // Why: reuse the shared source->target resolver the GitHub work-item surface
+  // uses; feeding it the source's own host settings resolves the owning host,
+  // not the Active Server dropdown.
+  const target = getActiveRuntimeTarget(getTaskSourceRuntimeSettings(args.sourceContext))
+  if (target.kind !== 'environment') {
+    return { kind: 'local' }
+  }
+  // Why: the runtime host resolves this against its own repo store; the
+  // renderer preserves the owning host's repo id, so an explicit `id:` selector
+  // is unambiguous where a bare path could collide with a duplicate checkout.
+  const repoId = args.sourceContext.repoId ?? args.repoId ?? null
+  if (!repoId) {
+    return { kind: 'local' }
+  }
+  return {
+    kind: 'environment',
+    environmentId: target.environmentId,
+    repoSelector: `id:${repoId}`
+  }
+}
+
+function toRpcParams(
+  args: GitLabSelectorArgs,
+  repoSelector: string,
+  extra?: Record<string, unknown>
+): Record<string, unknown> {
+  const params = { ...args } as Record<string, unknown>
+  // Why: the RPC selector replaces the IPC path/id/context fields with a single `repo`.
+  Reflect.deleteProperty(params, 'repoPath')
+  Reflect.deleteProperty(params, 'repoId')
+  Reflect.deleteProperty(params, 'sourceContext')
+  if (extra) {
+    Object.assign(params, extra)
+  }
+  params.repo = repoSelector
+  return params
+}
+
+function dispatch<A extends GitLabSelectorArgs, R>(
+  localCall: (args: A) => Promise<R>,
+  rpcMethod: string,
+  args: A,
+  extra?: Record<string, unknown>
+): Promise<R> {
+  const target = getGitLabTaskRuntimeTarget(args)
+  if (target.kind === 'local') {
+    return localCall(args)
+  }
+  return callRuntimeRpc<R>(
+    { kind: 'environment', environmentId: target.environmentId },
+    rpcMethod,
+    toRpcParams(args, target.repoSelector, extra),
+    { timeoutMs: RUNTIME_RPC_TIMEOUT_MS }
+  )
+}
+
+// Why: mirror the host method names the web client already routes to
+// (GITLAB_WEB_RPC_METHODS) and the host registers (rpc/methods/gitlab.ts). A
+// drift here surfaces as "works over the web/mobile client, broken on desktop".
+const RPC = {
+  listIssues: 'gitlab.listIssues',
+  listMRs: 'gitlab.listMRs',
+  todos: 'gitlab.todos',
+  workItemDetails: 'gitlab.workItemDetails',
+  listLabels: 'gitlab.listLabels',
+  updateMR: 'gitlab.updateMR',
+  jobTrace: 'gitlab.jobTrace',
+  retryJob: 'gitlab.retryJob',
+  updateMRReviewers: 'gitlab.updateMRReviewers',
+  addMRInlineComment: 'gitlab.addMRInlineComment',
+  updateMRState: 'gitlab.updateMRState',
+  mergeMR: 'gitlab.mergeMR',
+  addMRComment: 'gitlab.addMRComment',
+  addIssueComment: 'gitlab.addIssueComment',
+  resolveMRDiscussion: 'gitlab.resolveMRDiscussion'
+} as const
+
+/**
+ * Drop-in replacement for `window.api.gl` across the GitLab Tasks surface.
+ *
+ * Each method keeps the local IPC signature, but a repo owned by a remote
+ * runtime host relays to that host over RPC instead of failing the local
+ * repo-path guard. Only the methods the Tasks list and item dialog use are
+ * routed here; already-routed call sites (ChecksPanel, the URL picker, job-log
+ * details) keep their own target checks.
+ */
+export const routedGitLab = {
+  listIssues: (args: Parameters<GL['listIssues']>[0]) =>
+    dispatch(window.api.gl.listIssues, RPC.listIssues, args),
+  listMRs: (args: Parameters<GL['listMRs']>[0]) =>
+    dispatch(window.api.gl.listMRs, RPC.listMRs, args),
+  todos: (args: Parameters<GL['todos']>[0]) => dispatch(window.api.gl.todos, RPC.todos, args),
+  workItemDetails: (args: Parameters<GL['workItemDetails']>[0]) =>
+    dispatch(window.api.gl.workItemDetails, RPC.workItemDetails, args),
+  listLabels: (args: Parameters<GL['listLabels']>[0]) =>
+    dispatch(window.api.gl.listLabels, RPC.listLabels, args),
+  // Why: the host exposes no gitlab.listAssignableUsers RPC (the web client
+  // returns [] too); degrade to an empty picker for remote repos rather than error.
+  listAssignableUsers: (
+    args: Parameters<GL['listAssignableUsers']>[0]
+  ): ReturnType<GL['listAssignableUsers']> =>
+    getGitLabTaskRuntimeTarget(args).kind === 'environment'
+      ? (Promise.resolve([]) as ReturnType<GL['listAssignableUsers']>)
+      : window.api.gl.listAssignableUsers(args),
+  updateMR: (args: Parameters<GL['updateMR']>[0]) =>
+    dispatch(window.api.gl.updateMR, RPC.updateMR, args),
+  // Why: raw CI traces routinely exceed the runtime RPC frame cap, so ask the
+  // host to bound the log before it crosses the wire. `extra` is merged into the
+  // RPC params only, so the local path keeps the full trace — matching
+  // gitlab-job-trace-client's remote-excerpt / local-full split.
+  jobTrace: (args: Parameters<GL['jobTrace']>[0]) =>
+    dispatch(window.api.gl.jobTrace, RPC.jobTrace, args, { logExcerpt: true }),
+  retryJob: (args: Parameters<GL['retryJob']>[0]) =>
+    dispatch(window.api.gl.retryJob, RPC.retryJob, args),
+  updateMRReviewers: (args: Parameters<GL['updateMRReviewers']>[0]) =>
+    dispatch(window.api.gl.updateMRReviewers, RPC.updateMRReviewers, args),
+  addMRInlineComment: (args: Parameters<GL['addMRInlineComment']>[0]) =>
+    dispatch(window.api.gl.addMRInlineComment, RPC.addMRInlineComment, args),
+  // Why: close/reopen are one host method (updateMRState) keyed by state; the
+  // local IPC keeps separate channels, so inject the state on the RPC path only.
+  closeMR: (args: Parameters<GL['closeMR']>[0]) =>
+    dispatch(window.api.gl.closeMR, RPC.updateMRState, args, { state: 'closed' }),
+  reopenMR: (args: Parameters<GL['reopenMR']>[0]) =>
+    dispatch(window.api.gl.reopenMR, RPC.updateMRState, args, { state: 'opened' }),
+  mergeMR: (args: Parameters<GL['mergeMR']>[0]) =>
+    dispatch(window.api.gl.mergeMR, RPC.mergeMR, args),
+  addMRComment: (args: Parameters<GL['addMRComment']>[0]) =>
+    dispatch(window.api.gl.addMRComment, RPC.addMRComment, args),
+  addIssueComment: (args: Parameters<GL['addIssueComment']>[0]) =>
+    dispatch(window.api.gl.addIssueComment, RPC.addIssueComment, args),
+  resolveMRDiscussion: (args: Parameters<GL['resolveMRDiscussion']>[0]) =>
+    dispatch(window.api.gl.resolveMRDiscussion, RPC.resolveMRDiscussion, args)
+}


### PR DESCRIPTION
## ELI5

When you run Orca on one machine and connect to your projects living on another (a remote server), the GitLab Tasks panel talked to the wrong machine. It asked your local machine about repos that only exist on the server, so it got "Access denied: unknown repository path" and showed nothing. This teaches every GitLab task call to ask the machine that actually owns the repo.

## What Changed

A new routing layer (`routedGitLab`) decides, per repo, whether a GitLab call runs locally or relays to the runtime host that owns the repo, then wires the GitLab Tasks surface through it:

- **Tasks list** - issues, MRs, and todos.
- **Item dialog** - details, conversation/comments, merge / close / reopen, labels, reviewers, and CI job logs.
- **Right-sidebar MR actions** - merge / close / reopen for a checked-out MR.

Routing keys off the repo's own execution host (not the active-server dropdown), and the host method names mirror the ones Orca's web client already uses, so no new host RPC surface is introduced. Already-routed call sites (checks panel, URL picker, job-log details) are left unchanged.

## Why

Every GitLab handler in the main process runs `assertRegisteredRepo`, which rejects any path not registered in that machine's own repo store. A repo owned by a remote runtime host only exists in the host's store, so the local call always failed on the client. GitHub's task surface already routes remote-owned repos to their host over RPC; GitLab did not. This closes that gap the same way, and the contributor guide's own rule applies directly: "do not assume a process, file, credential, shell, or network path exists only on the local machine."

## Linked Issue

Fixes #14603

## Visual Proof

<!-- BEFORE: the "Access denied: unknown repository path" error in the Issues list and when opening an item. AFTER: the populated list and a loaded item dialog. Attach via drag + drop. -->

<img width="1570" height="524" alt="image" src="https://github.com/user-attachments/assets/dce73247-88a0-4d4e-b2e3-45f808f01afe" />

Now the lists of Issues and MRs works great...

<img width="1193" height="483" alt="Orca" src="https://github.com/user-attachments/assets/183aeae8-c116-4a54-bef5-ba99df7fbcf6" />

And if you click on an Issue or MR everything loads as expected...

<img width="647" height="544" alt="Orca" src="https://github.com/user-attachments/assets/a6701c16-3afa-4b0b-b7aa-78847af034ac" />

## Testing

Verified against a real two-machine setup: a MacBook Air client connected to a MacBook Pro runtime host serving self-hosted GitLab. The Issues/MRs list and the item detail dialog both load and act against the host instead of erroring.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

New unit tests cover local-vs-remote transport selection for each routed method (`src/renderer/src/runtime/gitlab-runtime-routing.test.ts`). `pnpm lint` and `pnpm typecheck` pass, and the tests around the touched areas (Tasks, right-sidebar, the new module) pass. The full local `pnpm test` has some pre-existing failures in unrelated areas (clipboard IPC, CLI orchestration, git porcelain/symlinks, codex) that also fail on a clean checkout with these changes stashed, so they are environmental and not introduced here; CI is the authority.

## AI Disclosure

Written with Claude Code (Claude Opus 4.8). The diff was then reviewed by three code-review agents - Claude, Codex (gpt-5.5), and Grok - and the author reviewed the result. The one substantive finding (Claude and Codex both caught it independently): the remote CI job-log path could exceed the runtime RPC frame cap; fixed by bounding the trace host-side via `logExcerpt`, matching the existing checks-panel behaviour.

## Review

- **Security:** no change to the auth/registration boundary; the local path still runs `assertRegisteredRepo`, and remote calls relay over the existing authenticated runtime channel.
- **Cross-platform:** pure renderer routing logic, no platform-specific paths or shortcuts.
- **Remote/SSH:** the point of the change - routes runtime-host-owned repos correctly; local and SSH-backed repos keep the local IPC path.
- **Wire compatibility:** the client calls the same `gitlab.*` host methods the web client already calls, so no new host surface; an older host lacking a method degrades to an error banner, not a crash.
- **Mobile:** unaffected (mobile already routes GitLab via the runtime RPC).
- **Performance:** one host lookup per call; no added work on the local path.
- **Known limitation:** on a runtime-owned GitLab repo the reviewer-assignment picker is empty - there is no `gitlab.listAssignableUsers` host RPC, and the web client behaves the same way. Existing reviewers still render; adding new ones on a remote repo would need a new host method (worth a follow-up, not in scope here).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint` and `pnpm typecheck` pass; touched-area tests pass; full `pnpm test` has only pre-existing unrelated failures (verified on clean checkout); `pnpm build` deferred to CI (renderer-only change)

## Author

- X / Twitter: @de1mat
