### PR TITLE
fix(terminal): settle CLI prompts for Claude and Codex

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -9073,13 +9073,13 @@
       "providers": ["local", "daemon", "ssh", "remote-runtime"],
       "coveredPlatforms": ["macos", "windows"],
       "coveredProviders": ["local"],
-      "coverageNotes": "Source-built macOS and physical Windows Electron journeys cover the public CLI through RPC, runtime identity, real PTY/ConPTY writes, and a delayed fake Codex composer. Focused units enumerate every configured TUI agent, cover cursor-marker and generic output-quiescence policies, preserve an unidentified fresh-agent quiet window, and prove speculative CLI sends do not poll wrapper foregrounds. SSH, daemon, remote-runtime, and live non-marker agents remain explicit gaps.",
+      "coverageNotes": "Source-built macOS and physical Windows Electron journeys cover the public CLI through RPC, runtime identity, real PTY/ConPTY writes, and a delayed fake Codex composer. Focused units cover CLI intent, fresh Claude/Codex foreground identity, framing bytes, stale-agent shell fallback, and exact legacy behavior for every other configured agent. SSH, daemon, and remote-runtime remain explicit gaps.",
       "motivatingLinks": [
         "https://linear.app/stably/issue/STA-4328",
         "https://github.com/stablyai/orca/issues/14525"
       ],
-      "invariant": "A public CLI send containing non-empty text plus Enter and no interrupt identifies agent-prompt intent. The owning runtime uses bracketed-paste and settled submit only when the exact target is a running recognized agent on a desktop call; shells, text-only input, bare Enter, interrupts, mobile input, query replies, and older clients keep the direct terminal contract.",
-      "oracle": "Launch a bare fake Codex through the real Electron PTY and delay its composer render for 1,200 ms, beyond the legacy generic 500 ms gap. Send a 557-byte prompt with the public CLI and require the marker, zero premature Enter, no rescue Enter, and one submission. POSIX child stdin must retain one bracketed-paste frame; Windows ConPTY consumes that control frame, so runtime tests require the frame at the PTY write boundary while the Windows child requires the exact prompt. The same harness against the installed pre-fix runtime must record one premature Enter and require one bare rescue Enter. Focused units require CLI intent only for text plus Enter, settled routing after recognized-agent confirmation, every configured TUI agent to wait for output quiescence, unidentified fresh prompts to wait 1.5 seconds, wrapper foregrounds to avoid speculative polling, and byte-for-byte direct fallback for a non-agent target.",
+      "invariant": "A public CLI send containing non-empty text plus Enter and no interrupt identifies agent-prompt intent. The owning runtime uses bracketed-paste and settled submit only when a fresh foreground-process read positively identifies the exact target as Claude or Codex on a desktop call; every other agent, stale agent metadata over a shell, text-only input, bare Enter, interrupts, mobile input, query replies, and older clients keep the direct terminal contract.",
+      "oracle": "Launch a bare fake Codex through the real Electron PTY and delay its composer render for 1,200 ms, beyond the legacy generic 500 ms gap. Send a 557-byte prompt with the public CLI and require the marker, zero premature Enter, no rescue Enter, and one submission. POSIX child stdin must retain one bracketed-paste frame; Windows ConPTY consumes that control frame, so runtime tests require the frame at the PTY write boundary while the Windows child requires the exact prompt. The same harness against the installed pre-fix runtime must record one premature Enter and require one bare rescue Enter. Focused units require CLI intent only for text plus Enter, settlement only for freshly identified Claude/Codex, the legacy platform delay for every other configured agent, stale Codex launch identity over a shell to fall back, no wrapper polling, and byte-for-byte direct delivery for non-targets.",
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/cli/handlers/terminal.test.ts src/main/runtime/rpc/terminal-agent-prompt-send.test.ts src/main/runtime/rpc/terminal-send.test.ts src/main/runtime/orca-runtime.test.ts src/shared/agent-prompt-injection.test.ts",
         "pnpm run build:cli && pnpm exec playwright test tests/e2e/terminal-send-agent-prompt-submit.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
@@ -9106,15 +9106,15 @@
         {
           "file": "src/main/runtime/rpc/terminal-agent-prompt-send.test.ts",
           "assertions": [
-            "a recognized desktop agent uses settled prompt delivery",
-            "a non-agent target preserves the existing direct send"
+            "a freshly proven Claude or Codex desktop target uses settled prompt delivery",
+            "a non-target agent or shell preserves the existing direct send"
           ]
         },
         {
           "file": "src/main/runtime/orca-runtime.test.ts",
           "assertions": [
-            "every configured TUI agent waits for composer output quiescence before submit",
-            "an unidentified silent fresh composer receives a full quiet window",
+            "Claude and Codex wait for marker-gated composer quiescence before submit",
+            "every other configured TUI agent retains the legacy platform delay",
             "a speculative CLI prompt check does not poll wrapper foregrounds",
             "the PTY write boundary retains bracketed framing and one delayed submit"
           ]
@@ -9157,13 +9157,13 @@
           "summary": "Two independent physical Windows source-built Electron/CLI/ConPTY journeys passed at cf814f2f46 with the prompt marker received, zero premature Enter, and no rescue send (47.6s and 47.1s)."
         },
         {
-          "date": "2026-08-14",
+          "date": "2026-08-15",
           "runner": "local",
           "platform": "macos",
           "command": "pnpm exec vitest run --config config/vitest.config.ts src/cli/handlers/terminal.test.ts src/main/runtime/rpc/terminal-agent-prompt-send.test.ts src/main/runtime/rpc/terminal-send.test.ts src/main/runtime/orca-runtime.test.ts src/shared/agent-prompt-injection.test.ts",
           "result": "passed",
-          "durationSeconds": 73.06,
-          "summary": "The final focused runtime/CLI/RPC suite passed 1,158 tests with one skip, including the new foreground-Codex metadata-lag contract."
+          "durationSeconds": 23.2,
+          "summary": "After rebasing onto current main, the final narrowed runtime/CLI/RPC suite passed 1,201 tests with one skip, including fresh Claude/Codex identity, stale-agent shell fallback, and legacy timing for every other configured agent."
         }
       ],
       "runtimeBudget": {
@@ -9180,15 +9180,15 @@
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "Only a CLI request with non-empty text plus Enter and no interrupt adds one recognized-agent status evaluation; this speculative path performs at most one foreground read and never enters the 6.5-second wrapper retry loop. Confirmed agents reuse the O(prompt bytes) chunked prompt sender plus one PTY-local listener: cursor-marker agents wait for post-marker quiescence, while every other recognized or metadata-late prompt waits for 1.5 seconds of output quiescence with an 8-second continuous-output bound. Non-agent CLI targets retain the existing 500 ms direct-send path. Text-only, bare Enter, interrupt, mobile, renderer stream input, and query replies add no work."
+        "evidence": "Only a CLI request with non-empty text plus Enter and no interrupt adds a bounded fresh foreground read and one non-retrying liveness check. Positively identified Claude and Codex reuse the O(prompt bytes) chunked prompt sender plus one PTY-local listener until post-marker quiescence or the bounded fallback. Every other agent and shell retains the existing direct-send path. Text-only, bare Enter, interrupt, mobile, renderer stream input, and query replies add no work."
       },
       "promotionCriteria": [
-        "Collect live Codex, Claude, and Cursor CLI sends on representative slow systems.",
+        "Collect live Codex and Claude CLI sends on representative slow systems.",
         "Retain mixed-version evidence that old hosts strip the optional intent and new hosts accept old clients without a protocol bump."
       ],
       "knownGaps": [
         "Live SSH/daemon/remote-runtime evidence is not yet attached.",
-        "Agents without a validated cursor marker use generic output quiescence plus the bounded silent fallback; live traces have not yet tuned that policy per agent.",
+        "Only Claude and Codex opt into settlement; every other agent retains the legacy behavior until independently validated.",
         "A new CLI talking to an old host safely loses the optional field and therefore keeps the old timing behavior until the host updates.",
         "The E2E fake agent models the submission race without requiring external agent authentication; live account-backed agents are covered separately."
       ],
@@ -9212,14 +9212,14 @@
       "providers": ["local", "daemon", "ssh", "remote-runtime"],
       "coveredPlatforms": ["macos"],
       "coveredProviders": ["local"],
-      "coverageNotes": "Local macOS evidence covers the runtime PTY write contract, live Codex orchestration, a dev-runtime CLI repro, Claude and Codex composer traces, and deterministic settlement for every configured TUI agent. The render gate stays on the PTY-owning runtime, so paired and SSH callers use the same provider write/output path without a wire change. SSH, daemon, remote-runtime, Linux, Windows, and live non-marker-agent journeys remain gaps.",
+      "coverageNotes": "Local macOS evidence covers the runtime PTY write contract, live Codex orchestration, a dev-runtime CLI repro, and Claude and Codex composer traces. The render gate stays on the PTY-owning runtime, so paired and SSH callers use the same provider write/output path without a wire change. SSH, daemon, remote-runtime, Linux, and Windows live journeys remain gaps.",
       "motivatingLinks": [
         "https://github.com/stablyai/orca/issues/7226",
         "https://github.com/stablyai/orca/issues/13821",
         "https://github.com/stablyai/orca/issues/14347"
       ],
-      "invariant": "Injected orchestration task prompts for recognized agent CLIs must send the prompt body inside one bracketed-paste frame, sanitize embedded ESC bytes, preserve chunk boundaries without losing the frame, and submit exactly once only after the agent can accept Enter. Validated cursor-marker agents must observe their marker and then settle, while every other configured or metadata-late agent must receive a bounded output-quiescence window before submit.",
-      "oracle": "Runtime tests enumerate every configured TUI agent and assert the exact PTY write sequence, failure cleanup, marker-gated multi-frame renders, generic output quiescence, and an unidentified silent-composer fallback where the legacy 500 ms delay is premature. The candidate resets settlement on later frames, gives a late marker a fresh bounded window, and still submits once at the hard deadline if output never settles. Orchestration tests assert dispatch/coordinator use the agent prompt path; the live CLI harness covers long Codex-like framing.",
+      "invariant": "Injected orchestration task prompts for recognized agent CLIs must send the prompt body inside one bracketed-paste frame, sanitize embedded ESC bytes, preserve chunk boundaries without losing the frame, and submit exactly once only after the agent can accept Enter. Claude and Codex must emit a post-paste composer marker and then settle, or reach the bounded fallback first; every other agent retains the platform delay.",
+      "oracle": "Runtime tests assert the exact PTY write sequence, failure cleanup, Claude/Codex marker-gated multi-frame renders, and the legacy platform delay for every other configured agent. The candidate resets settlement on later frames, gives a late marker a fresh bounded window, and still submits once at the hard deadline if output never settles. Orchestration tests assert dispatch/coordinator use the agent prompt path; the live CLI harness covers long Codex-like framing.",
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/shared/agent-prompt-injection.test.ts src/main/runtime/orca-runtime.test.ts src/main/runtime/rpc/methods/orchestration-tasks-dispatch.test.ts src/main/runtime/orchestration/coordinator.test.ts",
         "node tests/tools/repro-orchestration-long-prompt.mjs --cli out/bin/orca-dev --mode codex-like --size-kb 32 --timeout-ms 20000"
@@ -9245,9 +9245,8 @@
           "file": "src/main/runtime/orca-runtime.test.ts",
           "assertions": [
             "runtime writes bracketed paste before a delayed submit",
-            "every configured TUI agent waits for output quiescence before one submit",
-            "validated marker agents ignore unrelated and split pre-marker output",
-            "an unidentified silent composer waits for the generic quiet fallback",
+            "Claude and Codex ignore unrelated and split pre-marker output, then wait for render quiescence before one submit",
+            "every other configured TUI agent retains the platform delay",
             "a late Codex marker receives a fresh settlement window before one submit",
             "a silent Claude composer reaches one bounded fallback submit",
             "a marked Claude composer with continuous render output reaches one bounded fallback submit",
@@ -9340,7 +9339,7 @@
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "Agent prompt dispatch remains O(prompt bytes) with existing 16KB chunking. Every prompt adds one PTY-local output listener until 1.5 seconds of output quiescence or the bounded fallback; validated cursor-marker agents begin quiescence after their marker, and each later frame resets one quiet timer. No polling, provider listing, subprocess churn, hidden-pane wakeups, renderer work, or wire traffic is added."
+        "evidence": "Agent prompt dispatch remains O(prompt bytes) with existing 16KB chunking. Claude and Codex add one PTY-local output listener until 1.5 seconds of post-marker output quiescence or the bounded fallback; each later frame resets one quiet timer. Other agents retain the platform delay. No polling, provider listing, subprocess churn, hidden-pane wakeups, renderer work, or wire traffic is added."
       },
       "promotionCriteria": [
         "Run the live harness in soak with a self-starting dev runtime or provider-contract fixture.",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -9073,13 +9073,13 @@
       "providers": ["local", "daemon", "ssh", "remote-runtime"],
       "coveredPlatforms": ["macos", "windows"],
       "coveredProviders": ["local"],
-      "coverageNotes": "Source-built macOS and physical Windows Electron journeys cover the public CLI through RPC, runtime identity, real PTY/ConPTY writes, and a delayed fake Codex composer. Focused units cover CLI intent, recognized-agent routing, late foreground-agent identity, framing bytes, and exact direct-input fallback. SSH, daemon, remote-runtime, and live Cursor remain explicit gaps.",
+      "coverageNotes": "Source-built macOS and physical Windows Electron journeys cover the public CLI through RPC, runtime identity, real PTY/ConPTY writes, and a delayed fake Codex composer. Focused units enumerate every configured TUI agent, cover cursor-marker and generic output-quiescence policies, preserve an unidentified fresh-agent quiet window, and prove speculative CLI sends do not poll wrapper foregrounds. SSH, daemon, remote-runtime, and live non-marker agents remain explicit gaps.",
       "motivatingLinks": [
         "https://linear.app/stably/issue/STA-4328",
         "https://github.com/stablyai/orca/issues/14525"
       ],
       "invariant": "A public CLI send containing non-empty text plus Enter and no interrupt identifies agent-prompt intent. The owning runtime uses bracketed-paste and settled submit only when the exact target is a running recognized agent on a desktop call; shells, text-only input, bare Enter, interrupts, mobile input, query replies, and older clients keep the direct terminal contract.",
-      "oracle": "Launch a bare fake Codex through the real Electron PTY and delay its composer render for 1,200 ms, beyond the legacy generic 500 ms gap. Send a 557-byte prompt with the public CLI and require the marker, zero premature Enter, no rescue Enter, and one submission. POSIX child stdin must retain one bracketed-paste frame; Windows ConPTY consumes that control frame, so runtime tests require the frame at the PTY write boundary while the Windows child requires the exact prompt. The same harness against the installed pre-fix runtime must record one premature Enter and require one bare rescue Enter. Focused units require CLI intent only for text plus Enter, settled routing after recognized-agent confirmation even when launch metadata lags, and byte-for-byte direct fallback for a non-agent target.",
+      "oracle": "Launch a bare fake Codex through the real Electron PTY and delay its composer render for 1,200 ms, beyond the legacy generic 500 ms gap. Send a 557-byte prompt with the public CLI and require the marker, zero premature Enter, no rescue Enter, and one submission. POSIX child stdin must retain one bracketed-paste frame; Windows ConPTY consumes that control frame, so runtime tests require the frame at the PTY write boundary while the Windows child requires the exact prompt. The same harness against the installed pre-fix runtime must record one premature Enter and require one bare rescue Enter. Focused units require CLI intent only for text plus Enter, settled routing after recognized-agent confirmation, every configured TUI agent to wait for output quiescence, unidentified fresh prompts to wait 1.5 seconds, wrapper foregrounds to avoid speculative polling, and byte-for-byte direct fallback for a non-agent target.",
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/cli/handlers/terminal.test.ts src/main/runtime/rpc/terminal-agent-prompt-send.test.ts src/main/runtime/rpc/terminal-send.test.ts src/main/runtime/orca-runtime.test.ts src/shared/agent-prompt-injection.test.ts",
         "pnpm run build:cli && pnpm exec playwright test tests/e2e/terminal-send-agent-prompt-submit.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
@@ -9113,7 +9113,9 @@
         {
           "file": "src/main/runtime/orca-runtime.test.ts",
           "assertions": [
-            "a foreground Codex discovered after terminal creation receives the render-settled policy",
+            "every configured TUI agent waits for composer output quiescence before submit",
+            "an unidentified silent fresh composer receives a full quiet window",
+            "a speculative CLI prompt check does not poll wrapper foregrounds",
             "the PTY write boundary retains bracketed framing and one delayed submit"
           ]
         },
@@ -9178,7 +9180,7 @@
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "Only a CLI request with non-empty text plus Enter and no interrupt adds one existing bounded recognized-agent status evaluation. Confirmed agents reuse the existing O(prompt bytes) chunked prompt sender and render settlement gate; if launch identity has not arrived, that gate performs one existing foreground-process refresh before choosing timing. Non-agent CLI targets retain the existing 500 ms direct-send path. Text-only, bare Enter, interrupt, mobile, renderer stream input, and query replies add no work. No polling, provider listing, renderer wakeup, stream opcode, or recurring timer is added."
+        "evidence": "Only a CLI request with non-empty text plus Enter and no interrupt adds one recognized-agent status evaluation; this speculative path performs at most one foreground read and never enters the 6.5-second wrapper retry loop. Confirmed agents reuse the O(prompt bytes) chunked prompt sender plus one PTY-local listener: cursor-marker agents wait for post-marker quiescence, while every other recognized or metadata-late prompt waits for 1.5 seconds of output quiescence with an 8-second continuous-output bound. Non-agent CLI targets retain the existing 500 ms direct-send path. Text-only, bare Enter, interrupt, mobile, renderer stream input, and query replies add no work."
       },
       "promotionCriteria": [
         "Collect live Codex, Claude, and Cursor CLI sends on representative slow systems.",
@@ -9186,7 +9188,7 @@
       ],
       "knownGaps": [
         "Live SSH/daemon/remote-runtime evidence is not yet attached.",
-        "Cursor uses the existing platform-specific structured-prompt delay because no Cursor render-marker trace has been collected; Codex and Claude use output settlement.",
+        "Agents without a validated cursor marker use generic output quiescence plus the bounded silent fallback; live traces have not yet tuned that policy per agent.",
         "A new CLI talking to an old host safely loses the optional field and therefore keeps the old timing behavior until the host updates.",
         "The E2E fake agent models the submission race without requiring external agent authentication; live account-backed agents are covered separately."
       ],
@@ -9210,14 +9212,14 @@
       "providers": ["local", "daemon", "ssh", "remote-runtime"],
       "coveredPlatforms": ["macos"],
       "coveredProviders": ["local"],
-      "coverageNotes": "Local macOS evidence covers the runtime PTY write contract, live Codex orchestration, a dev-runtime CLI repro, and Claude and Codex composer traces. The render gate stays on the PTY-owning runtime, so paired and SSH callers use the same provider write/output path without a wire change. SSH, daemon, remote-runtime, Linux, and Windows live journeys remain gaps.",
+      "coverageNotes": "Local macOS evidence covers the runtime PTY write contract, live Codex orchestration, a dev-runtime CLI repro, Claude and Codex composer traces, and deterministic settlement for every configured TUI agent. The render gate stays on the PTY-owning runtime, so paired and SSH callers use the same provider write/output path without a wire change. SSH, daemon, remote-runtime, Linux, Windows, and live non-marker-agent journeys remain gaps.",
       "motivatingLinks": [
         "https://github.com/stablyai/orca/issues/7226",
         "https://github.com/stablyai/orca/issues/13821",
         "https://github.com/stablyai/orca/issues/14347"
       ],
-      "invariant": "Injected orchestration task prompts for recognized agent CLIs must send the prompt body inside one bracketed-paste frame, sanitize embedded ESC bytes, preserve chunk boundaries without losing the frame, and submit exactly once only after the agent can accept Enter. Claude and Codex must emit a post-paste composer marker and then settle, or reach the bounded fallback first; a late marker receives a fresh settlement window.",
-      "oracle": "Runtime tests assert the exact PTY write sequence, failure cleanup, and Claude- and Codex-shaped multi-frame renders where the legacy platform delay and first show-cursor marker are both premature. The candidate waits for post-marker output quiescence before one submit, resets that window on later frames, gives a late marker a fresh bounded window, and still submits once at the hard deadline if output never settles. Orchestration tests assert dispatch/coordinator use the agent prompt path; the live CLI harness covers long Codex-like framing.",
+      "invariant": "Injected orchestration task prompts for recognized agent CLIs must send the prompt body inside one bracketed-paste frame, sanitize embedded ESC bytes, preserve chunk boundaries without losing the frame, and submit exactly once only after the agent can accept Enter. Validated cursor-marker agents must observe their marker and then settle, while every other configured or metadata-late agent must receive a bounded output-quiescence window before submit.",
+      "oracle": "Runtime tests enumerate every configured TUI agent and assert the exact PTY write sequence, failure cleanup, marker-gated multi-frame renders, generic output quiescence, and an unidentified silent-composer fallback where the legacy 500 ms delay is premature. The candidate resets settlement on later frames, gives a late marker a fresh bounded window, and still submits once at the hard deadline if output never settles. Orchestration tests assert dispatch/coordinator use the agent prompt path; the live CLI harness covers long Codex-like framing.",
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/shared/agent-prompt-injection.test.ts src/main/runtime/orca-runtime.test.ts src/main/runtime/rpc/methods/orchestration-tasks-dispatch.test.ts src/main/runtime/orchestration/coordinator.test.ts",
         "node tests/tools/repro-orchestration-long-prompt.mjs --cli out/bin/orca-dev --mode codex-like --size-kb 32 --timeout-ms 20000"
@@ -9243,7 +9245,9 @@
           "file": "src/main/runtime/orca-runtime.test.ts",
           "assertions": [
             "runtime writes bracketed paste before a delayed submit",
-            "Claude and Codex ignore unrelated and split pre-marker output, then wait for post-marker render quiescence before one submit",
+            "every configured TUI agent waits for output quiescence before one submit",
+            "validated marker agents ignore unrelated and split pre-marker output",
+            "an unidentified silent composer waits for the generic quiet fallback",
             "a late Codex marker receives a fresh settlement window before one submit",
             "a silent Claude composer reaches one bounded fallback submit",
             "a marked Claude composer with continuous render output reaches one bounded fallback submit",
@@ -9336,7 +9340,7 @@
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "Agent prompt dispatch remains O(prompt bytes) with existing 16KB chunking. Claude and Codex add one PTY-local output listener until 1.5s of post-marker output quiescence or an 8s fallback; a late first marker restarts the bounded window and each later frame resets one quiet timer. Other agents retain the platform delay. No polling, provider listing, subprocess churn, hidden-pane wakeups, renderer work, or wire traffic is added."
+        "evidence": "Agent prompt dispatch remains O(prompt bytes) with existing 16KB chunking. Every prompt adds one PTY-local output listener until 1.5 seconds of output quiescence or the bounded fallback; validated cursor-marker agents begin quiescence after their marker, and each later frame resets one quiet timer. No polling, provider listing, subprocess churn, hidden-pane wakeups, renderer work, or wire traffic is added."
       },
       "promotionCriteria": [
         "Run the live harness in soak with a self-starting dev runtime or provider-contract fixture.",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -9056,6 +9056,143 @@
       "demotionRule": "Keep non-blocking or demote to protection none if a generic busy title authorizes without exact title, verified-launch, or foreground identity; provider confirmation becomes unconditional; exact-PTY mismatch can write bytes; unsupported providers fail open; or the focused gate flakes without an actionable product or harness defect."
     },
     {
+      "id": "terminal-input.cli-agent-prompt-submit",
+      "title": "CLI text plus Enter settles recognized agent composers before submit",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "terminal-input",
+      "layer": "cli-rpc-runtime-pty-contract",
+      "surfaces": [
+        "terminal send CLI",
+        "terminal.send RPC",
+        "agent prompt injection",
+        "PTY writes",
+        "bracketed paste"
+      ],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local", "daemon", "ssh", "remote-runtime"],
+      "coveredPlatforms": ["macos", "windows"],
+      "coveredProviders": ["local"],
+      "coverageNotes": "Source-built macOS and physical Windows Electron journeys cover the public CLI through RPC, runtime identity, real PTY/ConPTY writes, and a delayed fake Codex composer. Focused units cover CLI intent, recognized-agent routing, late foreground-agent identity, framing bytes, and exact direct-input fallback. SSH, daemon, remote-runtime, and live Cursor remain explicit gaps.",
+      "motivatingLinks": [
+        "https://linear.app/stably/issue/STA-4328",
+        "https://github.com/stablyai/orca/issues/14525"
+      ],
+      "invariant": "A public CLI send containing non-empty text plus Enter and no interrupt identifies agent-prompt intent. The owning runtime uses bracketed-paste and settled submit only when the exact target is a running recognized agent on a desktop call; shells, text-only input, bare Enter, interrupts, mobile input, query replies, and older clients keep the direct terminal contract.",
+      "oracle": "Launch a bare fake Codex through the real Electron PTY and delay its composer render for 1,200 ms, beyond the legacy generic 500 ms gap. Send a 557-byte prompt with the public CLI and require the marker, zero premature Enter, no rescue Enter, and one submission. POSIX child stdin must retain one bracketed-paste frame; Windows ConPTY consumes that control frame, so runtime tests require the frame at the PTY write boundary while the Windows child requires the exact prompt. The same harness against the installed pre-fix runtime must record one premature Enter and require one bare rescue Enter. Focused units require CLI intent only for text plus Enter, settled routing after recognized-agent confirmation even when launch metadata lags, and byte-for-byte direct fallback for a non-agent target.",
+      "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts src/cli/handlers/terminal.test.ts src/main/runtime/rpc/terminal-agent-prompt-send.test.ts src/main/runtime/rpc/terminal-send.test.ts src/main/runtime/orca-runtime.test.ts src/shared/agent-prompt-injection.test.ts",
+        "pnpm run build:cli && pnpm exec playwright test tests/e2e/terminal-send-agent-prompt-submit.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
+        "pnpm.cmd exec playwright test tests/e2e/terminal-send-agent-prompt-submit.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
+        "node tests/tools/repro-terminal-send-submit.mjs --cli orca --worktree <registered-worktree> --discard-report"
+      ],
+      "testFiles": [
+        "src/cli/handlers/terminal.test.ts",
+        "src/main/runtime/rpc/terminal-agent-prompt-send.test.ts",
+        "src/main/runtime/rpc/terminal-send.test.ts",
+        "src/main/runtime/orca-runtime.test.ts",
+        "src/shared/agent-prompt-injection.test.ts",
+        "tests/e2e/terminal-send-agent-prompt-submit.spec.ts",
+        "tests/tools/repro-terminal-send-submit.mjs"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/cli/handlers/terminal.test.ts",
+          "assertions": [
+            "combined text and Enter carries explicit agent-prompt intent",
+            "text-only and bare Enter remain direct terminal input"
+          ]
+        },
+        {
+          "file": "src/main/runtime/rpc/terminal-agent-prompt-send.test.ts",
+          "assertions": [
+            "a recognized desktop agent uses settled prompt delivery",
+            "a non-agent target preserves the existing direct send"
+          ]
+        },
+        {
+          "file": "src/main/runtime/orca-runtime.test.ts",
+          "assertions": [
+            "a foreground Codex discovered after terminal creation receives the render-settled policy",
+            "the PTY write boundary retains bracketed framing and one delayed submit"
+          ]
+        },
+        {
+          "file": "tests/e2e/terminal-send-agent-prompt-submit.spec.ts",
+          "assertions": [
+            "the public source-built CLI submits after a delayed composer render without rescue",
+            "the fake agent receives the marker and zero premature Enter on macOS and Windows",
+            "POSIX preserves one bracketed-paste frame while Windows validates the ConPTY-observable payload"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-08-14",
+          "runner": "local",
+          "platform": "macos",
+          "command": "node tests/tools/repro-terminal-send-submit.mjs --cli orca --worktree <registered-worktree> --discard-report",
+          "result": "failed",
+          "durationSeconds": 5.46,
+          "summary": "The installed pre-fix runtime received all 567 prompt bytes but no bracketed-paste frame; Enter arrived before the 1,200 ms composer render and one later bare Enter was required."
+        },
+        {
+          "date": "2026-08-14",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm run build:cli && pnpm exec playwright test tests/e2e/terminal-send-agent-prompt-submit.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
+          "result": "passed",
+          "durationSeconds": 38.5,
+          "summary": "Two independent final source-built CLI/RPC/runtime/PTY journeys passed with one bracketed-paste frame, zero premature Enter, and no rescue send (36.5s and 38.5s)."
+        },
+        {
+          "date": "2026-08-14",
+          "runner": "manual",
+          "platform": "windows",
+          "command": "pnpm.cmd exec playwright test tests/e2e/terminal-send-agent-prompt-submit.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
+          "result": "passed",
+          "durationSeconds": 47.6,
+          "summary": "Two independent physical Windows source-built Electron/CLI/ConPTY journeys passed at cf814f2f46 with the prompt marker received, zero premature Enter, and no rescue send (47.6s and 47.1s)."
+        },
+        {
+          "date": "2026-08-14",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/cli/handlers/terminal.test.ts src/main/runtime/rpc/terminal-agent-prompt-send.test.ts src/main/runtime/rpc/terminal-send.test.ts src/main/runtime/orca-runtime.test.ts src/shared/agent-prompt-injection.test.ts",
+          "result": "passed",
+          "durationSeconds": 73.06,
+          "summary": "The final focused runtime/CLI/RPC suite passed 1,158 tests with one skip, including the new foreground-Codex metadata-lag contract."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 90,
+        "scope": "focused units plus one isolated Electron CLI/PTY journey"
+      },
+      "flakeHistory": {
+        "status": "unknown",
+        "evidence": "The final oracle passed twice in independent macOS app launches and twice on physical Windows. A shared --repeat-each fixture mode failed before test execution because only one seeded worktree loaded; supported isolated invocations were used for product evidence. CI history is not yet collected."
+      },
+      "redGreenEvidence": {
+        "status": "partial",
+        "evidence": "The fake-composer oracle was red against the installed pre-fix runtime with prematureEnters=1 and rescueSent=true. It also caught a source-built late-identity race with a complete paste frame but one premature Enter before the render gate began resolving foreground identity. The final candidate is green on macOS and Windows with prematureEnters=0 and rescueSent=false."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "Only a CLI request with non-empty text plus Enter and no interrupt adds one existing bounded recognized-agent status evaluation. Confirmed agents reuse the existing O(prompt bytes) chunked prompt sender and render settlement gate; if launch identity has not arrived, that gate performs one existing foreground-process refresh before choosing timing. Non-agent CLI targets retain the existing 500 ms direct-send path. Text-only, bare Enter, interrupt, mobile, renderer stream input, and query replies add no work. No polling, provider listing, renderer wakeup, stream opcode, or recurring timer is added."
+      },
+      "promotionCriteria": [
+        "Collect live Codex, Claude, and Cursor CLI sends on representative slow systems.",
+        "Retain mixed-version evidence that old hosts strip the optional intent and new hosts accept old clients without a protocol bump."
+      ],
+      "knownGaps": [
+        "Live SSH/daemon/remote-runtime evidence is not yet attached.",
+        "Cursor uses the existing platform-specific structured-prompt delay because no Cursor render-marker trace has been collected; Codex and Claude use output settlement.",
+        "A new CLI talking to an old host safely loses the optional field and therefore keeps the old timing behavior until the host updates.",
+        "The E2E fake agent models the submission race without requiring external agent authentication; live account-backed agents are covered separately."
+      ],
+      "demotionRule": "Keep experimental or demote to protection none if direct shell/mobile/query input is reframed, an unrecognized target receives bracketed paste, a prompt can emit duplicate Enter, mixed-version decoding rejects the optional field, or the deterministic fake-composer candidate requires a rescue send."
+    },
+    {
       "id": "terminal-input.agent-prompt-injection",
       "title": "Orchestration agent prompts arrive as bracketed paste before submit",
       "maturity": "experimental",

--- a/src/cli/handlers/terminal.test.ts
+++ b/src/cli/handlers/terminal.test.ts
@@ -61,3 +61,77 @@ describe('terminal close CLI', () => {
     expect(help).toContain('durable persistence')
   })
 })
+
+describe('terminal send CLI', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('marks combined text and Enter as an agent prompt candidate', async () => {
+    const call = vi.fn().mockResolvedValue({
+      result: { send: { handle: 'term-1', accepted: true, bytesWritten: 7 } }
+    })
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await TERMINAL_HANDLERS['terminal send']({
+      flags: new Map<string, string | true>([
+        ['terminal', 'term-1'],
+        ['text', 'review'],
+        ['enter', true]
+      ]),
+      client: { call } as unknown as RuntimeClient,
+      cwd: '/tmp/worktree',
+      json: true
+    })
+
+    expect(call).toHaveBeenCalledWith('terminal.send', {
+      terminal: 'term-1',
+      text: 'review',
+      enter: true,
+      interrupt: false,
+      agentPrompt: true,
+      client: { id: 'orca-cli', type: 'desktop' }
+    })
+  })
+
+  it('keeps text-only and bare Enter sends as direct terminal input', async () => {
+    const call = vi.fn().mockResolvedValue({
+      result: { send: { handle: 'term-1', accepted: true, bytesWritten: 1 } }
+    })
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await TERMINAL_HANDLERS['terminal send']({
+      flags: new Map<string, string | true>([
+        ['terminal', 'term-1'],
+        ['text', 'x']
+      ]),
+      client: { call } as unknown as RuntimeClient,
+      cwd: '/tmp/worktree',
+      json: true
+    })
+    await TERMINAL_HANDLERS['terminal send']({
+      flags: new Map<string, string | true>([
+        ['terminal', 'term-1'],
+        ['enter', true]
+      ]),
+      client: { call } as unknown as RuntimeClient,
+      cwd: '/tmp/worktree',
+      json: true
+    })
+
+    expect(call).toHaveBeenNthCalledWith(1, 'terminal.send', {
+      terminal: 'term-1',
+      text: 'x',
+      enter: false,
+      interrupt: false,
+      client: { id: 'orca-cli', type: 'desktop' }
+    })
+    expect(call).toHaveBeenNthCalledWith(2, 'terminal.send', {
+      terminal: 'term-1',
+      text: undefined,
+      enter: true,
+      interrupt: false,
+      client: { id: 'orca-cli', type: 'desktop' }
+    })
+  })
+})

--- a/src/cli/handlers/terminal.ts
+++ b/src/cli/handlers/terminal.ts
@@ -84,11 +84,15 @@ export const TERMINAL_HANDLERS: Record<string, CommandHandler> = {
     printResult(result, json, formatTerminalRead)
   },
   'terminal send': async ({ flags, client, cwd, json }) => {
+    const text = getOptionalStringFlag(flags, 'text')
+    const enter = flags.get('enter') === true
+    const interrupt = flags.get('interrupt') === true
     const result = await client.call<{ send: RuntimeTerminalSend }>('terminal.send', {
       terminal: await getTerminalHandle(flags, cwd, client),
-      text: getOptionalStringFlag(flags, 'text'),
-      enter: flags.get('enter') === true,
-      interrupt: flags.get('interrupt') === true,
+      text,
+      enter,
+      interrupt,
+      ...(text && enter && !interrupt ? { agentPrompt: true } : {}),
       client: { id: 'orca-cli', type: 'desktop' }
     })
     printResult(result, json, formatTerminalSend)

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -16847,6 +16847,44 @@ describe('OrcaRuntimeService', () => {
     }
   )
 
+  it('settles a foreground Codex prompt when launch metadata has not arrived', async () => {
+    vi.useFakeTimers()
+    try {
+      const writes: string[] = []
+      let composerReady = false
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+        write: (_ptyId, data) => {
+          writes.push(data)
+          if (data.includes(AGENT_PROMPT_BRACKETED_PASTE_END)) {
+            setTimeout(() => {
+              composerReady = true
+              runtime.onPtyData('pty-bg', '\x1b[?25hcomposer rendered', Date.now())
+            }, 1_200)
+          }
+          return true
+        },
+        kill: () => true,
+        getForegroundProcess: async () => 'codex'
+      })
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+
+      const sendPromise = runtime.sendTerminalAgentPrompt(handle, 'review this change')
+      await vi.advanceTimersByTimeAsync(1_199)
+      expect(writes).not.toContain('\r')
+      await vi.advanceTimersByTimeAsync(1_500)
+      expect(writes).not.toContain('\r')
+      await vi.advanceTimersByTimeAsync(1)
+      await sendPromise
+
+      expect(composerReady).toBe(true)
+      expect(writes.filter((data) => data === '\r')).toHaveLength(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('submits a silent Claude composer once after the bounded render fallback', async () => {
     vi.useFakeTimers()
     try {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -90,6 +90,7 @@ import { MAX_QUICK_COMMANDS } from '../../shared/terminal-quick-commands'
 import {
   AGENT_PROMPT_BRACKETED_PASTE_END,
   AGENT_PROMPT_BRACKETED_PASTE_START,
+  AGENT_PROMPT_SUBMIT_DELAY_MS,
   buildAgentPromptPasteBytes
 } from '../../shared/agent-prompt-injection'
 import { CLIPBOARD_TEXT_MEASURE_YIELD_CODE_UNITS } from '../../shared/clipboard-text'
@@ -16776,8 +16777,8 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
-  it.each(Object.keys(TUI_AGENT_CONFIG) as TuiAgent[])(
-    'waits for every %s composer output frame to settle before one submit',
+  it.each(['claude', 'codex'] as const)(
+    'waits for %s composer output frames to settle before one submit',
     async (agent) => {
       vi.useFakeTimers()
       try {
@@ -16849,7 +16850,11 @@ describe('OrcaRuntimeService', () => {
     }
   )
 
-  it('gives an unidentified silent composer a full quiet window before submit', async () => {
+  it.each(
+    (Object.keys(TUI_AGENT_CONFIG) as TuiAgent[]).filter(
+      (agent) => agent !== 'claude' && agent !== 'codex'
+    )
+  )('preserves the legacy fixed submit delay for %s', async (agent) => {
     vi.useFakeTimers()
     try {
       const writes: string[] = []
@@ -16863,10 +16868,12 @@ describe('OrcaRuntimeService', () => {
         kill: () => true,
         getForegroundProcess: async () => null
       })
-      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+        launchAgent: agent
+      })
 
       const sendPromise = runtime.sendTerminalAgentPrompt(handle, 'review this change')
-      await vi.advanceTimersByTimeAsync(1_499)
+      await vi.advanceTimersByTimeAsync(AGENT_PROMPT_SUBMIT_DELAY_MS - 1)
       expect(writes).not.toContain('\r')
 
       await vi.advanceTimersByTimeAsync(1)
@@ -16900,6 +16907,7 @@ describe('OrcaRuntimeService', () => {
       })
       const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
 
+      await expect(runtime.isTerminalRunningSettledPromptAgent(handle)).resolves.toBe(true)
       const sendPromise = runtime.sendTerminalAgentPrompt(handle, 'review this change')
       await vi.advanceTimersByTimeAsync(1_199)
       expect(writes).not.toContain('\r')
@@ -24007,6 +24015,54 @@ describe('OrcaRuntimeService', () => {
       runtime.isTerminalRunningAgent(handle, { retryForegroundWrappers: false })
     ).resolves.toBe(false)
     expect(getForegroundProcess).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(['claude', 'codex'] as const)(
+    'authorizes settled CLI prompts only after positive %s foreground identity',
+    async (agent) => {
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess: async () => agent
+      })
+      syncSinglePty(runtime, 'pty-1', { paneTitle: 'bash' })
+      const [terminal] = (await runtime.listTerminals()).terminals
+
+      await expect(runtime.isTerminalRunningSettledPromptAgent(terminal.handle)).resolves.toBe(true)
+    }
+  )
+
+  it('keeps a recognized non-target agent on legacy CLI prompt delivery', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => 'gemini'
+    })
+    syncSinglePty(runtime, 'pty-1', { paneTitle: 'bash' })
+    const [terminal] = (await runtime.listTerminals()).terminals
+
+    await expect(runtime.isTerminalRunningAgent(terminal.handle)).resolves.toBe(true)
+    await expect(runtime.isTerminalRunningSettledPromptAgent(terminal.handle)).resolves.toBe(false)
+  })
+
+  it('keeps stale Codex launch identity on legacy delivery after the shell returns', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => 'zsh'
+    })
+    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+      command: 'codex',
+      title: 'Codex working',
+      launchAgent: 'codex'
+    })
+
+    await expect(runtime.isTerminalRunningAgent(handle)).resolves.toBe(true)
+    await expect(runtime.isTerminalRunningSettledPromptAgent(handle)).resolves.toBe(false)
   })
 
   it('waits for delayed wrapper foreground cache enrichment', async () => {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -123,6 +123,8 @@ import type {
   AgentSessionSurfaceBinding
 } from '../../shared/agent-session-host-authority'
 import { FOLDER_WORKSPACE_INSTANCE_SEPARATOR } from '../../shared/worktree/id'
+import { TUI_AGENT_CONFIG } from '../../shared/tui-agent-config'
+import type { TuiAgent } from '../../shared/tui-agent'
 import { RpcDispatcher } from './rpc/dispatcher'
 import type { RpcRequest } from './rpc/core'
 import { TERMINAL_METHODS } from './rpc/methods/terminal'
@@ -16774,8 +16776,8 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
-  it.each(['claude', 'codex'] as const)(
-    'waits for %s output to settle after its first render marker before one submit',
+  it.each(Object.keys(TUI_AGENT_CONFIG) as TuiAgent[])(
+    'waits for every %s composer output frame to settle before one submit',
     async (agent) => {
       vi.useFakeTimers()
       try {
@@ -16846,6 +16848,34 @@ describe('OrcaRuntimeService', () => {
       }
     }
   )
+
+  it('gives an unidentified silent composer a full quiet window before submit', async () => {
+    vi.useFakeTimers()
+    try {
+      const writes: string[] = []
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+        write: (_ptyId, data) => {
+          writes.push(data)
+          return true
+        },
+        kill: () => true,
+        getForegroundProcess: async () => null
+      })
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+
+      const sendPromise = runtime.sendTerminalAgentPrompt(handle, 'review this change')
+      await vi.advanceTimersByTimeAsync(1_499)
+      expect(writes).not.toContain('\r')
+
+      await vi.advanceTimersByTimeAsync(1)
+      await sendPromise
+      expect(writes.filter((data) => data === '\r')).toHaveLength(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 
   it('settles a foreground Codex prompt when launch metadata has not arrived', async () => {
     vi.useFakeTimers()
@@ -23950,6 +23980,33 @@ describe('OrcaRuntimeService', () => {
 
     await expect(runtime.isTerminalRunningAgent(handle)).resolves.toBe(true)
     expect(getForegroundProcess).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not poll a wrapper foreground for a speculative CLI prompt send', async () => {
+    const getForegroundProcess = vi
+      .fn()
+      .mockResolvedValueOnce('node')
+      .mockResolvedValueOnce('codex')
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess
+    })
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, { tabs: [], leaves: [] })
+    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+      command: 'bash',
+      title: 'bash'
+    })
+
+    syncSinglePty(runtime, 'pty-bg', { paneTitle: 'bash' })
+
+    await expect(
+      runtime.isTerminalRunningAgent(handle, { retryForegroundWrappers: false })
+    ).resolves.toBe(false)
+    expect(getForegroundProcess).toHaveBeenCalledTimes(1)
   })
 
   it('waits for delayed wrapper foreground cache enrichment', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -93,6 +93,7 @@ import {
 import {
   AGENT_PROMPT_BRACKETED_PASTE_END,
   AGENT_PROMPT_SUBMIT,
+  AGENT_PROMPT_SUBMIT_DELAY_MS,
   buildAgentPromptPasteBytes
 } from '../../shared/agent-prompt-injection'
 import {
@@ -1879,7 +1880,7 @@ const BRACKETED_PASTE_END = '\x1b[201~'
 const BRACKETED_PASTE_QUIET_MS = 1500
 const AGENT_PROMPT_RENDER_TIMEOUT_MS = 8000
 const AGENT_PROMPT_RENDER_QUIET_MS = 1500
-// Why: validated composers emit show-cursor after accepting bracketed paste.
+// Why: Claude and Codex emit show-cursor after accepting bracketed paste.
 const AGENT_PROMPT_RENDER_MARKER = '\x1b[?25h'
 const MOBILE_TERMINAL_SURFACE_TIMEOUT_MS = 10_000
 // Why: the split already failed; the caller waits on this teardown only to learn whether the
@@ -17645,7 +17646,7 @@ export class OrcaRuntimeService {
         const nextChunk = chunks.next()
         await options.beforeWrite?.(ptyId)
         if (nextChunk.done) {
-          renderGate.arm()
+          renderGate?.arm()
         }
         const wrote = this.ptyController?.write(ptyId, chunk.value) ?? false
         if (!wrote) {
@@ -17662,12 +17663,16 @@ export class OrcaRuntimeService {
       if (wrotePasteBytes && !completedPaste) {
         this.ptyController?.write(ptyId, AGENT_PROMPT_BRACKETED_PASTE_END)
       }
-      renderGate.dispose()
+      renderGate?.dispose()
       throw error
     }
 
-    await renderGate.wait()
-    renderGate.dispose()
+    if (renderGate) {
+      await renderGate.wait()
+      renderGate.dispose()
+    } else {
+      await new Promise((resolve) => setTimeout(resolve, AGENT_PROMPT_SUBMIT_DELAY_MS))
+    }
     try {
       await options.beforeWrite?.(ptyId)
     } catch (error) {
@@ -17686,16 +17691,14 @@ export class OrcaRuntimeService {
     arm: () => void
     wait: () => Promise<void>
     dispose: () => void
-  } {
+  } | null {
     const pty = this.ptysById.get(ptyId)
     const agent = pty?.launchAgent ?? pty?.foregroundAgent
-    const readySignal = agent ? TUI_AGENT_CONFIG[agent].draftPasteReadySignal : undefined
-    const requiresRenderMarker =
-      agent === 'claude' ||
-      agent === 'codex' ||
-      readySignal === 'render-cursor-after-bracketed-paste'
+    if (!isTerminalSendSettlementAgent(agent)) {
+      return null
+    }
     let armed = false
-    let canSettle = !requiresRenderMarker
+    let canSettle = false
     let settled = false
     let markerCarry = ''
     let quietTimer: NodeJS.Timeout | null = null
@@ -17753,9 +17756,6 @@ export class OrcaRuntimeService {
         armed = true
         markerCarry = ''
         armHardTimer()
-        if (canSettle) {
-          armQuietTimer()
-        }
       },
       wait: async () => {
         if (settled) {
@@ -32478,6 +32478,30 @@ export class OrcaRuntimeService {
     }
   }
 
+  async isTerminalRunningSettledPromptAgent(handle: string): Promise<boolean> {
+    try {
+      const livePty = this.getLivePtyForHandle(handle)
+      const leaf = livePty ? null : this.getLiveLeafForHandle(handle).leaf
+      const ptyId = livePty?.pty.ptyId ?? leaf?.ptyId ?? null
+      const trackedPty = livePty?.pty ?? (ptyId ? this.ptysById.get(ptyId) : null)
+      if (!ptyId || !trackedPty || !this.ptyController) {
+        return false
+      }
+      const recognized = recognizeAgentProcess(await this.ptyController.getForegroundProcess(ptyId))
+      const recognizedAgent = recognized?.agent
+      if (!isTerminalSendSettlementAgent(recognizedAgent)) {
+        return false
+      }
+      if (!(await this.isTerminalRunningAgent(handle, { retryForegroundWrappers: false }))) {
+        return false
+      }
+      trackedPty.foregroundAgent = recognizedAgent
+      return true
+    } catch {
+      return false
+    }
+  }
+
   private async isPtyRunningAgent(
     pty: RuntimePtyWorktreeRecord,
     leaf: RuntimeLeafRecord | null = null,
@@ -38364,6 +38388,12 @@ function classifyAgentTitle(title: string | null): 'agent' | 'management' | 'neu
     return 'management'
   }
   return detectAgentStatusFromTitle(title) !== null ? 'agent' : 'neutral'
+}
+
+function isTerminalSendSettlementAgent(
+  agent: TuiAgent | null | undefined
+): agent is 'claude' | 'codex' {
+  return agent === 'claude' || agent === 'codex'
 }
 
 function terminalTitleBlocksExplicitAgentStatus(title: string | null): boolean {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -93,7 +93,6 @@ import {
 import {
   AGENT_PROMPT_BRACKETED_PASTE_END,
   AGENT_PROMPT_SUBMIT,
-  AGENT_PROMPT_SUBMIT_DELAY_MS,
   buildAgentPromptPasteBytes
 } from '../../shared/agent-prompt-injection'
 import {
@@ -1880,7 +1879,7 @@ const BRACKETED_PASTE_END = '\x1b[201~'
 const BRACKETED_PASTE_QUIET_MS = 1500
 const AGENT_PROMPT_RENDER_TIMEOUT_MS = 8000
 const AGENT_PROMPT_RENDER_QUIET_MS = 1500
-// Why: Claude and Codex emit show-cursor while rendering pasted composer content.
+// Why: validated composers emit show-cursor after accepting bracketed paste.
 const AGENT_PROMPT_RENDER_MARKER = '\x1b[?25h'
 const MOBILE_TERMINAL_SURFACE_TIMEOUT_MS = 10_000
 // Why: the split already failed; the caller waits on this teardown only to learn whether the
@@ -17636,7 +17635,7 @@ export class OrcaRuntimeService {
       suffixFailureError?: string
     } = {}
   ): Promise<void> {
-    const renderGate = await this.createAgentPromptRenderGate(ptyId)
+    const renderGate = this.createAgentPromptRenderGate(ptyId)
     let wrotePasteBytes = false
     let completedPaste = false
     try {
@@ -17646,7 +17645,7 @@ export class OrcaRuntimeService {
         const nextChunk = chunks.next()
         await options.beforeWrite?.(ptyId)
         if (nextChunk.done) {
-          renderGate?.arm()
+          renderGate.arm()
         }
         const wrote = this.ptyController?.write(ptyId, chunk.value) ?? false
         if (!wrote) {
@@ -17663,16 +17662,12 @@ export class OrcaRuntimeService {
       if (wrotePasteBytes && !completedPaste) {
         this.ptyController?.write(ptyId, AGENT_PROMPT_BRACKETED_PASTE_END)
       }
-      renderGate?.dispose()
+      renderGate.dispose()
       throw error
     }
 
-    if (renderGate) {
-      await renderGate.wait()
-      renderGate.dispose()
-    } else {
-      await new Promise((resolve) => setTimeout(resolve, AGENT_PROMPT_SUBMIT_DELAY_MS))
-    }
+    await renderGate.wait()
+    renderGate.dispose()
     try {
       await options.beforeWrite?.(ptyId)
     } catch (error) {
@@ -17687,22 +17682,20 @@ export class OrcaRuntimeService {
     }
   }
 
-  private async createAgentPromptRenderGate(ptyId: string): Promise<{
+  private createAgentPromptRenderGate(ptyId: string): {
     arm: () => void
     wait: () => Promise<void>
     dispose: () => void
-  } | null> {
-    let pty = this.ptysById.get(ptyId)
-    if (pty && !pty.launchAgent && pty.foregroundAgent === null) {
-      await this.refreshPtyForegroundAgentFromController(ptyId)
-      pty = this.ptysById.get(ptyId)
-    }
+  } {
+    const pty = this.ptysById.get(ptyId)
     const agent = pty?.launchAgent ?? pty?.foregroundAgent
-    if (agent !== 'claude' && agent !== 'codex') {
-      return null
-    }
+    const readySignal = agent ? TUI_AGENT_CONFIG[agent].draftPasteReadySignal : undefined
+    const requiresRenderMarker =
+      agent === 'claude' ||
+      agent === 'codex' ||
+      readySignal === 'render-cursor-after-bracketed-paste'
     let armed = false
-    let observedMarker = false
+    let canSettle = !requiresRenderMarker
     let settled = false
     let markerCarry = ''
     let quietTimer: NodeJS.Timeout | null = null
@@ -17743,13 +17736,13 @@ export class OrcaRuntimeService {
       if (!armed || settled) {
         return
       }
-      if (!observedMarker) {
+      if (!canSettle) {
         const combined = markerCarry + data
         markerCarry = combined.slice(-(AGENT_PROMPT_RENDER_MARKER.length - 1))
         if (!combined.includes(AGENT_PROMPT_RENDER_MARKER)) {
           return
         }
-        observedMarker = true
+        canSettle = true
         // Why: a slow initial redraw must still receive the full settlement window.
         armHardTimer()
       }
@@ -17759,13 +17752,14 @@ export class OrcaRuntimeService {
       arm: () => {
         armed = true
         markerCarry = ''
+        armHardTimer()
+        if (canSettle) {
+          armQuietTimer()
+        }
       },
       wait: async () => {
         if (settled) {
           return
-        }
-        if (!hardTimer) {
-          armHardTimer()
         }
         await rendered
       },
@@ -32417,12 +32411,15 @@ export class OrcaRuntimeService {
   }
 
   // Why: title is the tightest agent-presence signal, but a Claude management title is negative evidence for task activity.
-  async isTerminalRunningAgent(handle: string): Promise<boolean> {
+  async isTerminalRunningAgent(
+    handle: string,
+    options: { retryForegroundWrappers?: boolean } = {}
+  ): Promise<boolean> {
     try {
       const pty = this.getLivePtyForHandle(handle)
       if (pty) {
         const leaf = this.getPrimaryLeafForPty(pty.pty.ptyId)
-        return await this.isPtyRunningAgent(pty.pty, leaf)
+        return await this.isPtyRunningAgent(pty.pty, leaf, options)
       }
       const { leaf } = this.getLiveLeafForHandle(handle)
       const trackedPty = leaf.ptyId ? this.ptysById.get(leaf.ptyId) : null
@@ -32473,7 +32470,8 @@ export class OrcaRuntimeService {
       }
       // Why: review-note delivery auto-submits with Enter, so only known agent processes are safe (not arbitrary focused TUIs).
       return await this.isRecognizedForegroundAgentProcess(leaf.ptyId, fg, {
-        suppressClaude: shouldSuppressClaudeForeground
+        suppressClaude: shouldSuppressClaudeForeground,
+        retryWrappers: options.retryForegroundWrappers !== false
       })
     } catch {
       return false
@@ -32482,7 +32480,8 @@ export class OrcaRuntimeService {
 
   private async isPtyRunningAgent(
     pty: RuntimePtyWorktreeRecord,
-    leaf: RuntimeLeafRecord | null = null
+    leaf: RuntimeLeafRecord | null = null,
+    options: { retryForegroundWrappers?: boolean } = {}
   ): Promise<boolean> {
     const leafTitle = leaf
       ? getLatestAgentCandidateTitle(
@@ -32541,14 +32540,15 @@ export class OrcaRuntimeService {
     }
     // Why: review-note delivery auto-submits with Enter, so only known agent processes are safe (not arbitrary focused TUIs).
     return await this.isRecognizedForegroundAgentProcess(pty.ptyId, fg, {
-      suppressClaude: shouldSuppressClaudeForeground
+      suppressClaude: shouldSuppressClaudeForeground,
+      retryWrappers: options.retryForegroundWrappers !== false
     })
   }
 
   private async isRecognizedForegroundAgentProcess(
     ptyId: string,
     foregroundProcess: string,
-    options: { suppressClaude?: boolean } = {}
+    options: { suppressClaude?: boolean; retryWrappers?: boolean } = {}
   ): Promise<boolean> {
     const initialRecognition = recognizeAgentProcess(foregroundProcess)
     if (initialRecognition !== null) {
@@ -32557,7 +32557,11 @@ export class OrcaRuntimeService {
         isExpectedAgentProcess(initialRecognition.processName, 'claude')
       )
     }
-    if (!this.isAgentWrapperForegroundProcess(foregroundProcess) || !this.ptyController) {
+    if (
+      options.retryWrappers === false ||
+      !this.isAgentWrapperForegroundProcess(foregroundProcess) ||
+      !this.ptyController
+    ) {
       return false
     }
     const startedAt = Date.now()

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -17636,7 +17636,7 @@ export class OrcaRuntimeService {
       suffixFailureError?: string
     } = {}
   ): Promise<void> {
-    const renderGate = this.createAgentPromptRenderGate(ptyId)
+    const renderGate = await this.createAgentPromptRenderGate(ptyId)
     let wrotePasteBytes = false
     let completedPaste = false
     try {
@@ -17687,12 +17687,16 @@ export class OrcaRuntimeService {
     }
   }
 
-  private createAgentPromptRenderGate(ptyId: string): {
+  private async createAgentPromptRenderGate(ptyId: string): Promise<{
     arm: () => void
     wait: () => Promise<void>
     dispose: () => void
-  } | null {
-    const pty = this.ptysById.get(ptyId)
+  } | null> {
+    let pty = this.ptysById.get(ptyId)
+    if (pty && !pty.launchAgent && pty.foregroundAgent === null) {
+      await this.refreshPtyForegroundAgentFromController(ptyId)
+      pty = this.ptysById.get(ptyId)
+    }
     const agent = pty?.launchAgent ?? pty?.foregroundAgent
     if (agent !== 'claude' && agent !== 'codex') {
       return null

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -896,6 +896,8 @@ const TerminalSend = TerminalHandle.extend({
   text: OptionalString,
   enter: z.unknown().optional(),
   interrupt: z.unknown().optional(),
+  // Why: older hosts strip this optional intent and retain their direct-send behavior.
+  agentPrompt: z.literal(true).optional(),
   resolvedLaunchDraft: z
     .object({
       text: z.string(),
@@ -1234,6 +1236,7 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           !isTerminalQueryReply(params.text) ||
           params.enter === true ||
           params.interrupt === true ||
+          params.agentPrompt === true ||
           params.requireAgentStatus !== undefined ||
           params.client?.type !== 'mobile' ||
           !queryReplyClientId ||
@@ -1351,6 +1354,13 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
       const mobileFloorClientId = resolveMobileFloorClientId(driver, params.client)
       const mobileFloorClaim: MobileInputFloorClaimHolder = { current: null }
       const beforeWrite = assertSendPreconditions
+      const useSettledAgentPrompt =
+        params.agentPrompt === true &&
+        hasText &&
+        params.enter === true &&
+        params.interrupt !== true &&
+        params.client?.type === 'desktop' &&
+        (await runtime.isTerminalRunningAgent(params.terminal))
       const reserveWrite =
         params.inputKind !== 'query-reply' && leaf?.ptyId && mobileFloorClientId
           ? (ptyId: string): void => {
@@ -1363,21 +1373,23 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           : undefined
       let result
       try {
-        result = await runtime.sendTerminal(
-          params.terminal,
-          {
-            text: params.text,
-            enter: params.enter === true,
-            interrupt: params.interrupt === true
-          },
-          {
-            beforeWrite,
-            ...(reserveWrite ? { reserveWrite } : {}),
-            ...(params.inputKind !== 'query-reply' && mobileFloorClientId
-              ? { afterWrite: () => commitMobileInputFloorClaim(mobileFloorClaim) }
-              : {})
-          }
-        )
+        result = useSettledAgentPrompt
+          ? await runtime.sendTerminalAgentPrompt(params.terminal, params.text!, { beforeWrite })
+          : await runtime.sendTerminal(
+              params.terminal,
+              {
+                text: params.text,
+                enter: params.enter === true,
+                interrupt: params.interrupt === true
+              },
+              {
+                beforeWrite,
+                ...(reserveWrite ? { reserveWrite } : {}),
+                ...(params.inputKind !== 'query-reply' && mobileFloorClientId
+                  ? { afterWrite: () => commitMobileInputFloorClaim(mobileFloorClaim) }
+                  : {})
+              }
+            )
       } catch (error) {
         mobileFloorClaim.current?.rollback()
         const refusedReason = getTerminalSendGuardRefusedReason(error)

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -1360,7 +1360,9 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
         params.enter === true &&
         params.interrupt !== true &&
         params.client?.type === 'desktop' &&
-        (await runtime.isTerminalRunningAgent(params.terminal))
+        (await runtime.isTerminalRunningAgent(params.terminal, {
+          retryForegroundWrappers: false
+        }))
       const reserveWrite =
         params.inputKind !== 'query-reply' && leaf?.ptyId && mobileFloorClientId
           ? (ptyId: string): void => {

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -1360,9 +1360,7 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
         params.enter === true &&
         params.interrupt !== true &&
         params.client?.type === 'desktop' &&
-        (await runtime.isTerminalRunningAgent(params.terminal, {
-          retryForegroundWrappers: false
-        }))
+        (await runtime.isTerminalRunningSettledPromptAgent(params.terminal))
       const reserveWrite =
         params.inputKind !== 'query-reply' && leaf?.ptyId && mobileFloorClientId
           ? (ptyId: string): void => {

--- a/src/main/runtime/rpc/terminal-agent-prompt-send.test.ts
+++ b/src/main/runtime/rpc/terminal-agent-prompt-send.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { OrcaRuntimeService } from '../orca-runtime'
+import type { RpcRequest } from './core'
+import { RpcDispatcher } from './dispatcher'
+import { TERMINAL_METHODS } from './methods/terminal'
+
+function makeRequest(params: unknown): RpcRequest {
+  return { id: 'request', authToken: 'token', method: 'terminal.send', params }
+}
+
+function makeRuntime(overrides: Partial<OrcaRuntimeService>): OrcaRuntimeService {
+  return {
+    getRuntimeId: () => 'test-runtime',
+    ...overrides
+  } as OrcaRuntimeService
+}
+
+describe('terminal agent prompt send RPC', () => {
+  it('routes an explicit CLI agent prompt through settled prompt delivery', async () => {
+    const sendTerminal = vi.fn()
+    const sendTerminalAgentPrompt = vi.fn().mockResolvedValue({
+      handle: 'terminal-1',
+      accepted: true,
+      bytesWritten: 19
+    })
+    const runtime = makeRuntime({
+      resolveLiveLeafForHandle: vi.fn().mockReturnValue({ ptyId: 'pty-1' }),
+      getDriver: vi.fn().mockReturnValue({ kind: 'idle' }),
+      isTerminalRunningAgent: vi.fn().mockResolvedValue(true),
+      sendTerminal,
+      sendTerminalAgentPrompt
+    })
+    const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest({
+        terminal: 'terminal-1',
+        text: 'review this change',
+        enter: true,
+        agentPrompt: true,
+        client: { id: 'orca-cli', type: 'desktop' }
+      })
+    )
+
+    expect(response.ok).toBe(true)
+    expect(runtime.isTerminalRunningAgent).toHaveBeenCalledWith('terminal-1')
+    expect(sendTerminalAgentPrompt).toHaveBeenCalledWith('terminal-1', 'review this change', {
+      beforeWrite: undefined
+    })
+    expect(sendTerminal).not.toHaveBeenCalled()
+  })
+
+  it('preserves direct input when the CLI target is not a running agent', async () => {
+    const sendTerminal = vi.fn().mockResolvedValue({
+      handle: 'terminal-1',
+      accepted: true,
+      bytesWritten: 7
+    })
+    const sendTerminalAgentPrompt = vi.fn()
+    const runtime = makeRuntime({
+      resolveLiveLeafForHandle: vi.fn().mockReturnValue({ ptyId: 'pty-1' }),
+      getDriver: vi.fn().mockReturnValue({ kind: 'idle' }),
+      isTerminalRunningAgent: vi.fn().mockResolvedValue(false),
+      sendTerminal,
+      sendTerminalAgentPrompt
+    })
+    const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest({
+        terminal: 'terminal-1',
+        text: 'echo x',
+        enter: true,
+        agentPrompt: true,
+        client: { id: 'orca-cli', type: 'desktop' }
+      })
+    )
+
+    expect(response.ok).toBe(true)
+    expect(sendTerminal).toHaveBeenCalledWith(
+      'terminal-1',
+      { text: 'echo x', enter: true, interrupt: false },
+      { beforeWrite: undefined }
+    )
+    expect(sendTerminalAgentPrompt).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/runtime/rpc/terminal-agent-prompt-send.test.ts
+++ b/src/main/runtime/rpc/terminal-agent-prompt-send.test.ts
@@ -43,7 +43,9 @@ describe('terminal agent prompt send RPC', () => {
     )
 
     expect(response.ok).toBe(true)
-    expect(runtime.isTerminalRunningAgent).toHaveBeenCalledWith('terminal-1')
+    expect(runtime.isTerminalRunningAgent).toHaveBeenCalledWith('terminal-1', {
+      retryForegroundWrappers: false
+    })
     expect(sendTerminalAgentPrompt).toHaveBeenCalledWith('terminal-1', 'review this change', {
       beforeWrite: undefined
     })

--- a/src/main/runtime/rpc/terminal-agent-prompt-send.test.ts
+++ b/src/main/runtime/rpc/terminal-agent-prompt-send.test.ts
@@ -26,7 +26,7 @@ describe('terminal agent prompt send RPC', () => {
     const runtime = makeRuntime({
       resolveLiveLeafForHandle: vi.fn().mockReturnValue({ ptyId: 'pty-1' }),
       getDriver: vi.fn().mockReturnValue({ kind: 'idle' }),
-      isTerminalRunningAgent: vi.fn().mockResolvedValue(true),
+      isTerminalRunningSettledPromptAgent: vi.fn().mockResolvedValue(true),
       sendTerminal,
       sendTerminalAgentPrompt
     })
@@ -43,16 +43,14 @@ describe('terminal agent prompt send RPC', () => {
     )
 
     expect(response.ok).toBe(true)
-    expect(runtime.isTerminalRunningAgent).toHaveBeenCalledWith('terminal-1', {
-      retryForegroundWrappers: false
-    })
+    expect(runtime.isTerminalRunningSettledPromptAgent).toHaveBeenCalledWith('terminal-1')
     expect(sendTerminalAgentPrompt).toHaveBeenCalledWith('terminal-1', 'review this change', {
       beforeWrite: undefined
     })
     expect(sendTerminal).not.toHaveBeenCalled()
   })
 
-  it('preserves direct input when the CLI target is not a running agent', async () => {
+  it('preserves direct input when the CLI target is not a proven settlement agent', async () => {
     const sendTerminal = vi.fn().mockResolvedValue({
       handle: 'terminal-1',
       accepted: true,
@@ -62,7 +60,7 @@ describe('terminal agent prompt send RPC', () => {
     const runtime = makeRuntime({
       resolveLiveLeafForHandle: vi.fn().mockReturnValue({ ptyId: 'pty-1' }),
       getDriver: vi.fn().mockReturnValue({ kind: 'idle' }),
-      isTerminalRunningAgent: vi.fn().mockResolvedValue(false),
+      isTerminalRunningSettledPromptAgent: vi.fn().mockResolvedValue(false),
       sendTerminal,
       sendTerminalAgentPrompt
     })

--- a/tests/e2e/terminal-send-agent-prompt-submit.spec.ts
+++ b/tests/e2e/terminal-send-agent-prompt-submit.spec.ts
@@ -1,0 +1,89 @@
+import { execFile } from 'node:child_process'
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { promisify } from 'node:util'
+import { expect, test } from './helpers/orca-app'
+import { waitForSessionReady } from './helpers/store'
+
+const execFileAsync = promisify(execFile)
+const fixtureRoot = mkdtempSync(path.join(os.tmpdir(), 'orca-terminal-send-agent-prompt-'))
+const fixtureBin = path.join(fixtureRoot, 'bin')
+const fixtureReport = path.join(fixtureRoot, 'report.json')
+const fixtureMarker = `ORCA_TERMINAL_SEND_E2E_${process.pid}`
+const fixtureScript = path.join(process.cwd(), 'tests', 'tools', 'repro-terminal-send-submit.mjs')
+const fakeCodex = path.join(fixtureBin, process.platform === 'win32' ? 'codex.cmd' : 'codex')
+
+mkdirSync(fixtureBin)
+writeFileSync(
+  fakeCodex,
+  process.platform === 'win32'
+    ? `@echo off\r\n"${process.execPath}" "${fixtureScript}" --fake-agent --report "%ORCA_FAKE_AGENT_REPORT%" --marker "%ORCA_FAKE_AGENT_MARKER%" --allow-unframed-paste\r\n`
+    : `#!/usr/bin/env sh\nexec "${process.execPath}" "${fixtureScript}" --fake-agent --report "$ORCA_FAKE_AGENT_REPORT" --marker "$ORCA_FAKE_AGENT_MARKER"\n`,
+  'utf8'
+)
+if (process.platform !== 'win32') {
+  chmodSync(fakeCodex, 0o755)
+}
+
+test.use({
+  orcaAppExtraEnv: {
+    PATH: `${fixtureBin}${path.delimiter}${process.env.PATH ?? ''}`,
+    ORCA_FAKE_AGENT_REPORT: fixtureReport,
+    ORCA_FAKE_AGENT_MARKER: fixtureMarker
+  }
+})
+
+test.afterAll(() => {
+  rmSync(fixtureRoot, { recursive: true, force: true })
+})
+
+test('CLI text plus Enter waits for a slow agent composer before submitting', async ({
+  electronApp,
+  orcaPage,
+  testRepoPath
+}) => {
+  test.setTimeout(90_000)
+  await waitForSessionReady(orcaPage)
+  const userDataDir = await electronApp.evaluate(({ app }) => app.getPath('userData'))
+  const repoRoot = process.cwd()
+  let stdout = ''
+  try {
+    const result = await execFileAsync(
+      process.execPath,
+      [
+        path.join(repoRoot, 'tests', 'tools', 'repro-terminal-send-submit.mjs'),
+        '--cli',
+        path.join(repoRoot, 'config', 'scripts', 'orca-dev.mjs'),
+        '--worktree',
+        testRepoPath,
+        '--agent-command',
+        'codex',
+        '--report',
+        fixtureReport,
+        '--marker',
+        fixtureMarker,
+        '--discard-report'
+      ],
+      {
+        cwd: repoRoot,
+        env: { ...process.env, ORCA_DEV_USER_DATA_PATH: userDataDir },
+        timeout: 60_000
+      }
+    )
+    stdout = result.stdout
+  } catch (error) {
+    const failed = error as Error & { stdout?: string; stderr?: string }
+    throw new Error([failed.message, failed.stdout, failed.stderr].filter(Boolean).join('\n'))
+  }
+
+  expect(JSON.parse(stdout)).toMatchObject({
+    rescueSent: false,
+    contractOk: true,
+    submitted: true,
+    prematureEnters: 0,
+    pasteFramingRequired: process.platform !== 'win32',
+    ...(process.platform === 'win32' ? {} : { hasBracketedPasteFrame: true }),
+    markerReceived: true
+  })
+})

--- a/tests/tools/repro-terminal-send-submit.mjs
+++ b/tests/tools/repro-terminal-send-submit.mjs
@@ -1,0 +1,305 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process'
+import { mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+const SCRIPT_PATH = import.meta.filename
+const BEGIN = '\x1b[200~'
+const END = '\x1b[201~'
+const DEFAULT_TIMEOUT_MS = 15_000
+const COMPOSER_RENDER_MS = 1_200
+
+function argValue(name, fallback = undefined) {
+  const prefix = `--${name}=`
+  const inline = process.argv.find((arg) => arg.startsWith(prefix))
+  if (inline) {
+    return inline.slice(prefix.length)
+  }
+  const index = process.argv.indexOf(`--${name}`)
+  return index === -1 ? fallback : (process.argv[index + 1] ?? fallback)
+}
+
+function hasFlag(name) {
+  return process.argv.includes(`--${name}`)
+}
+
+function parsePositiveInteger(name, fallback) {
+  const value = Number(argValue(name, fallback))
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`--${name} must be a positive integer`)
+  }
+  return value
+}
+
+function shellQuote(value) {
+  if (process.platform === 'win32') {
+    return `"${String(value).replace(/"/g, '\\"')}"`
+  }
+  return `'${String(value).replace(/'/g, `'\\''`)}'`
+}
+
+function runCommand(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk
+    })
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk
+    })
+    child.on('error', reject)
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve({ stdout, stderr })
+        return
+      }
+      const detail = stderr.trim() || stdout.trim()
+      reject(
+        Object.assign(
+          new Error(`${command} ${args.join(' ')} exited ${code}${detail ? `: ${detail}` : ''}`),
+          { stderr }
+        )
+      )
+    })
+  })
+}
+
+async function callOrca(cli, args, cwd) {
+  const command = cli.endsWith('.mjs') ? process.execPath : cli
+  const prefixArgs = cli.endsWith('.mjs') ? [cli] : []
+  const { stdout } = await runCommand(command, [...prefixArgs, ...args, '--json'], { cwd })
+  const parsed = JSON.parse(stdout.trim())
+  if (parsed.ok === false) {
+    throw new Error(parsed.error?.message ?? JSON.stringify(parsed.error))
+  }
+  return parsed.result ?? parsed
+}
+
+async function readReport(reportPath, timeoutMs) {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    try {
+      return JSON.parse(await readFile(reportPath, 'utf8'))
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    }
+  }
+  return null
+}
+
+async function closeTerminal(cli, handle, cwd) {
+  try {
+    await callOrca(cli, ['terminal', 'close', '--terminal', handle], cwd)
+  } catch {
+    // Best-effort fixture cleanup.
+  }
+}
+
+async function waitForWorktreeSelector(cli, repoId, cwd) {
+  const deadline = Date.now() + 10_000
+  const expectedPath = path.resolve(cwd)
+  while (Date.now() < deadline) {
+    const listed = await callOrca(cli, ['worktree', 'list', '--repo', `id:${repoId}`], cwd)
+    const worktree = listed.worktrees?.find((candidate) => {
+      const candidatePath = path.resolve(candidate.path)
+      return process.platform === 'win32'
+        ? candidatePath.toLowerCase() === expectedPath.toLowerCase()
+        : candidatePath === expectedPath
+    })
+    if (worktree?.id) {
+      return `id:${worktree.id}`
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100))
+  }
+  throw new Error(`worktree did not materialize for repo ${repoId}`)
+}
+
+async function createFakeCodexCommand(tempDir, args) {
+  if (process.platform === 'win32') {
+    const launcherPath = path.join(tempDir, 'codex.cmd')
+    await writeFile(
+      launcherPath,
+      `@echo off\r\n"${process.execPath}" "${SCRIPT_PATH}" %*\r\n`,
+      'utf8'
+    )
+    return [shellQuote(launcherPath), ...args].join(' ')
+  }
+  const launcherPath = path.join(tempDir, 'codex')
+  await symlink(process.execPath, launcherPath)
+  return [shellQuote(launcherPath), shellQuote(SCRIPT_PATH), ...args].join(' ')
+}
+
+async function parentMain() {
+  const cli = argValue('cli', process.env.ORCA_REPRO_CLI ?? 'orca')
+  const cwd = path.resolve(argValue('worktree', process.cwd()))
+  const timeoutMs = parsePositiveInteger('timeout-ms', DEFAULT_TIMEOUT_MS)
+  const tempDir = path.join(tmpdir(), `orca-terminal-send-submit-${process.pid}-${Date.now()}`)
+  const reportPath = path.resolve(argValue('report', path.join(tempDir, 'report.json')))
+  const marker = argValue('marker', `ORCA_TERMINAL_SEND_${process.pid}_${Date.now()}`)
+  const prompt = `${marker} ${'slow composer payload '.repeat(24)}`
+  await mkdir(tempDir, { recursive: true })
+
+  const command =
+    argValue('agent-command') ??
+    (await createFakeCodexCommand(tempDir, [
+      '--fake-agent',
+      '--report',
+      shellQuote(reportPath),
+      '--marker',
+      shellQuote(marker),
+      '--timeout-ms',
+      String(timeoutMs),
+      ...(process.platform === 'win32' ? ['--allow-unframed-paste'] : [])
+    ]))
+  const added = await callOrca(cli, ['repo', 'add', '--path', cwd], cwd)
+  const repoId = added.repo?.id
+  if (!repoId) {
+    throw new Error('repo add returned no id')
+  }
+  const worktreeSelector = await waitForWorktreeSelector(cli, repoId, cwd)
+  const created = await callOrca(
+    cli,
+    [
+      'terminal',
+      'create',
+      '--worktree',
+      worktreeSelector,
+      '--title',
+      'terminal send submit repro',
+      '--command',
+      command
+    ],
+    cwd
+  )
+  const handle = created.terminal?.handle
+  if (!handle) {
+    throw new Error('terminal create returned no handle')
+  }
+
+  try {
+    await callOrca(
+      cli,
+      ['terminal', 'wait', '--terminal', handle, '--for', 'tui-idle', '--timeout-ms', '10000'],
+      cwd
+    )
+    await callOrca(
+      cli,
+      ['terminal', 'send', '--terminal', handle, '--text', prompt, '--enter'],
+      cwd
+    )
+    let report = await readReport(reportPath, 1_000)
+    let rescueSent = false
+    if (!report) {
+      rescueSent = true
+      await callOrca(cli, ['terminal', 'send', '--terminal', handle, '--enter'], cwd)
+      report = await readReport(reportPath, timeoutMs)
+    }
+    if (!report) {
+      throw new Error('fake agent did not write a report')
+    }
+    const summary = {
+      handle,
+      promptBytes: Buffer.byteLength(prompt, 'utf8'),
+      rescueSent,
+      ...report
+    }
+    console.log(JSON.stringify(summary, null, 2))
+    if (!report.contractOk || rescueSent) {
+      process.exitCode = 1
+    }
+  } finally {
+    if (!hasFlag('keep-terminal')) {
+      await closeTerminal(cli, handle, cwd)
+    }
+    if (hasFlag('discard-report')) {
+      await rm(tempDir, { recursive: true, force: true })
+    }
+  }
+}
+
+async function fakeAgentMain() {
+  const reportPath = argValue('report')
+  const marker = argValue('marker')
+  const timeoutMs = parsePositiveInteger('timeout-ms', DEFAULT_TIMEOUT_MS)
+  const pasteFramingRequired = !hasFlag('allow-unframed-paste')
+  if (!reportPath || !marker) {
+    throw new Error('--fake-agent requires --report and --marker')
+  }
+  if (process.stdin.isTTY) {
+    process.stdin.setRawMode(true)
+  }
+  process.stdin.resume()
+  process.stdout.write('OpenAI Codex\nmodel: fake\ndirectory: fixture\n> ')
+
+  let input = ''
+  let countedCarriages = 0
+  let prematureEnters = 0
+  let composerReady = false
+  let renderScheduled = false
+  let finished = false
+
+  const finish = async () => {
+    if (finished) {
+      return
+    }
+    finished = true
+    const hasBracketedPasteFrame = input.includes(BEGIN) && input.includes(END)
+    const report = {
+      contractOk: prematureEnters === 0 && (!pasteFramingRequired || hasBracketedPasteFrame),
+      submitted: true,
+      prematureEnters,
+      pasteFramingRequired,
+      hasBracketedPasteFrame,
+      markerReceived: input.includes(marker),
+      receivedBytes: Buffer.byteLength(input, 'utf8')
+    }
+    await writeFile(reportPath, JSON.stringify(report, null, 2))
+    process.stdout.write(`\nORCA_TERMINAL_SEND_REPORT ${report.contractOk ? 'ok' : 'rescued'}\n`)
+    process.exit(report.contractOk ? 0 : 7)
+  }
+
+  const timeout = setTimeout(() => process.exit(8), timeoutMs)
+  process.stdin.on('data', (chunk) => {
+    input += chunk.toString('utf8')
+    if (!renderScheduled && input.includes(marker)) {
+      renderScheduled = true
+      setTimeout(() => {
+        composerReady = true
+        process.stdout.write('\x1b[?25hcomposer rendered')
+      }, COMPOSER_RENDER_MS)
+    }
+    let nextCarriage = input.indexOf('\r', countedCarriages)
+    while (nextCarriage !== -1) {
+      countedCarriages = nextCarriage + 1
+      if (composerReady) {
+        clearTimeout(timeout)
+        void finish()
+        return
+      }
+      prematureEnters += 1
+      nextCarriage = input.indexOf('\r', countedCarriages)
+    }
+  })
+}
+
+async function main() {
+  if (hasFlag('fake-agent')) {
+    await fakeAgentMain()
+    return
+  }
+  await parentMain()
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? (error.stack ?? error.message) : error)
+  process.exit(1)
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | +707 | −1 | +706 |
| Prod | 4 | +231 | −37 | +194 |

<!-- /orca-pr-loc -->

## Summary

- mark non-empty CLI `terminal send --text ... --enter` calls as optional agent-prompt intent
- use bracketed-paste settlement only when a fresh foreground-process read positively identifies Claude or Codex
- keep the exact legacy direct-send path for shells, stale agent metadata over a returned shell, OpenCode, every other agent, text-only input, bare Enter, interrupts, mobile input, and query replies
- avoid the 6.5-second wrapper retry loop during speculative CLI classification
- preserve mixed-version behavior: old hosts strip the optional intent and retain current timing

Fixes #14347
Fixes #14525
Tracks STA-4328

## Root cause

The generic CLI path pastes text, waits a fixed 500 ms on POSIX (1.5 s on Windows), then sends Enter. Slow or busy composers can still be processing the paste, so Enter is consumed before submission is ready and the completed prompt remains in the composer.

The generic writer is byte-identical across the inspected 1.4.170–1.4.183 release range, so no recent Orca source first-bad boundary was found. This is a latent timing race that became more visible with long handoff prompts and TUI/runtime timing changes.

## Narrow fix

For freshly identified Claude and Codex terminals only, the owning runtime:

1. sends one sanitized bracketed-paste frame;
2. waits for the observed post-paste show-cursor marker;
3. waits for 1.5 seconds of render quiescence;
4. sends exactly one Enter, with an 8-second fallback window.

Unknown, wrapper-only, stale, and non-target identities fail open to the pre-existing direct behavior. OpenCode was deliberately removed from this PR after review because its existing startup-ready cursor signal is not proof of a post-paste render marker.

## Validation

- rebased onto current `origin/main` (`931cb037c5`)
- focused CLI/RPC/runtime suite: 1,201 passed, 1 existing skip
- `pnpm typecheck:node`
- `pnpm typecheck:cli`
- changed-file standard and type-aware lint
- reliability manifest: 85 gates valid
- deterministic source-built macOS public CLI → RPC → runtime → real PTY delayed-composer E2E passed with zero premature Enter and no rescue send
- physical Windows source-built Electron/CLI/ConPTY journey passed twice for the same delayed Codex oracle
- real Claude 2.1.233 source-built public-CLI test submitted a ~23 KB prompt and produced the exact requested assistant reply without manual Enter
- three fresh OpenCode agents reviewed routing safety, timer behavior, and coverage; their stale-identity finding was reproduced and fixed, scratch/doc issues were cleaned up, and their OpenCode-evidence concern caused OpenCode to be excluded

## Risk and tradeoffs

- Claude/Codex sends that previously happened to work after 500 ms may now take about 1.5 seconds after the marker. A missing marker falls back after 8 seconds; a very late marker receives a fresh bounded settlement window, so pathological total latency can approach 16 seconds.
- If fresh foreground identity cannot be proven, Orca preserves the old behavior. That minimizes regression risk but means an unusually wrapped fresh Claude/Codex process can retain the old race.
- OpenCode and all other agents are intentionally unchanged and remain follow-up work once their post-paste settlement signals are independently validated.
- No required RPC field, stream opcode, or protocol-version change is introduced.
