### PR TITLE
fix(agent-status): stop reconnect replay re-arming a stale working row (STA-4144)

### DIFF
--- a/src/main/agent-hooks/reconnect-replay-status-freshness.test.ts
+++ b/src/main/agent-hooks/reconnect-replay-status-freshness.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AgentHookServer } from './server'
+import {
+  AGENT_STATUS_STALE_AFTER_MS,
+  isFreshNonDoneAgentStatus
+} from '../../shared/agent-status-types'
+import { makePaneKey } from '../../shared/stable-pane-id'
+
+vi.mock('../telemetry/client', () => ({ track: vi.fn() }))
+vi.mock('../telemetry/cohort-classifier', () => ({ getCohortAtEmit: vi.fn(() => ({})) }))
+
+const LEAF_1 = '11111111-1111-4111-8111-111111111111'
+const PANE = makePaneKey('tab-1', LEAF_1)
+const T0 = 1_700_000_000_000
+
+const workingEvent = {
+  paneKey: PANE,
+  hookEventName: 'PreToolUse',
+  payload: {
+    state: 'working' as const,
+    prompt: 'fix the typecheck failures',
+    agentType: 'claude' as const,
+    toolName: 'Bash',
+    toolInput: 'pnpm run typecheck'
+  }
+}
+
+/** The sidebar reads the IPC row; mirror its freshness gate on the real snapshot. */
+function paneRow(server: AgentHookServer): {
+  state: string
+  updatedAt: number
+  stateStartedAt: number
+} {
+  const row = server.getStatusSnapshot()[0]
+  if (!row) {
+    throw new Error('expected a cached status row')
+  }
+  return {
+    state: row.state,
+    updatedAt: row.receivedAt,
+    stateStartedAt: row.stateStartedAt
+  }
+}
+
+function isRenderedAsWorking(server: AgentHookServer, now: number): boolean {
+  const row = paneRow(server)
+  return isFreshNonDoneAgentStatus({ state: row.state as 'working', updatedAt: row.updatedAt }, now)
+}
+
+describe('reconnect replay does not re-arm agent status freshness (STA-4144)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(T0)
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('keeps a replayed unchanged working row stale so it decays to idle', () => {
+    const server = new AgentHookServer()
+    server.ingestRemote(workingEvent, 'conn-1')
+    expect(isRenderedAsWorking(server, Date.now())).toBe(true)
+
+    // The turn ends while the relay is disconnected (sleep / restart), so the
+    // matching Stop never reaches this client and the row freezes at working.
+    const afterStaleWindow = T0 + AGENT_STATUS_STALE_AFTER_MS + 60_000
+    vi.setSystemTime(afterStaleWindow)
+    expect(isRenderedAsWorking(server, afterStaleWindow)).toBe(false)
+
+    // Reconnect: the host replays its cached statuses one frame per pane.
+    server.ingestRemote({ ...workingEvent, isReplay: true }, 'conn-1')
+
+    const row = paneRow(server)
+    // Regression: the replay must not look newer than the evidence behind it.
+    expect(row.updatedAt).toBe(T0)
+    expect(row.stateStartedAt).toBe(T0)
+    expect(isRenderedAsWorking(server, afterStaleWindow)).toBe(false)
+  })
+
+  it('still lets a replay deliver a completion this client never saw', () => {
+    const server = new AgentHookServer()
+    server.ingestRemote(workingEvent, 'conn-1')
+
+    const later = T0 + AGENT_STATUS_STALE_AFTER_MS + 60_000
+    vi.setSystemTime(later)
+    server.ingestRemote(
+      {
+        ...workingEvent,
+        isReplay: true,
+        payload: { ...workingEvent.payload, state: 'done' as const }
+      },
+      'conn-1'
+    )
+
+    const row = paneRow(server)
+    expect(row.state).toBe('done')
+    expect(row.updatedAt).toBe(later)
+  })
+
+  it('still refreshes freshness for a live same-state working ping', () => {
+    const server = new AgentHookServer()
+    server.ingestRemote(workingEvent, 'conn-1')
+
+    const later = T0 + 20 * 60_000
+    vi.setSystemTime(later)
+    server.ingestRemote(workingEvent, 'conn-1')
+
+    const row = paneRow(server)
+    expect(row.updatedAt).toBe(later)
+    // A genuinely active agent stays working past the original stale deadline.
+    expect(isRenderedAsWorking(server, T0 + AGENT_STATUS_STALE_AFTER_MS + 60_000)).toBe(true)
+    // The displayed age still tracks when the state began, not the last ping.
+    expect(row.stateStartedAt).toBe(T0)
+  })
+})

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -1276,7 +1276,16 @@ export class AgentHookServer {
       this.maybeTrackAgentPromptSent(effectivePayload, previous)
     }
     const cachedPayload = resolveCachedClaudeCompactOwnership(previous, effectivePayload)
-    const enriched = this.attachStatusTiming(cachedPayload, now)
+    // Why: a reconnect replay re-delivers evidence we already hold, so stamping it
+    // `now` re-arms the 30-minute staleness clock while attachStatusTiming keeps the
+    // old stateStartedAt — a finished pane then spins forever showing an hours-old
+    // age, re-armed by every reconnect (STA-4144). A replay carrying a NEW state is
+    // real news (it may be the completion this client missed) and keeps live timing.
+    const replayPreservedReceivedAt =
+      cachedPayload.isReplay === true && previous?.payload.state === cachedPayload.payload.state
+        ? previous?.receivedAt
+        : undefined
+    const enriched = this.attachStatusTiming(cachedPayload, replayPreservedReceivedAt ?? now)
     // Why: an identity-matched event can still leave the aggregate backed only by another restored child; keep liveness reconciliation eligible.
     if (enriched.restoredUnconfirmed) {
       this.runtimeObservedStatusPaneKeys.delete(enriched.paneKey)


### PR DESCRIPTION
## ELI5

When Orca reconnects to an agent host, the host re-sends ("replays") the last status it had for each pane. Orca was treating that re-send as if it were brand-new news that *just* happened. So a pane that had finished long ago came back looking busy again, and the "it's been quiet for 30 minutes, stop the spinner" safety net kept getting reset. Every reconnect restarted the clock, so the spinner never stopped.

## What Changed

In `applyNormalizedStatus`, a replayed event that carries **the same state** we already have cached now keeps the cached `receivedAt` instead of being stamped with the current time.

A replay carrying a **new** state still gets live timing — that path is how a client learns about a completion it missed while disconnected, so it must stay fresh.

One-line behavioral diff; 10 lines with the comment.

## Why

`attachStatusTiming` deliberately preserves `stateStartedAt` when the state is unchanged, but unconditionally sets `receivedAt = now`:

```ts
const stateStartedAt =
  previous && previous.payload.state === payload.payload.state && !commandCodeNewTurn
    ? previous.stateStartedAt   // preserved
    : now
return { ...payload, receivedAt: now, stateStartedAt }   // always advanced
```

`receivedAt` becomes the renderer's `updatedAt` (`useIpcEvents.ts` → `setAgentStatus`), which is the only input to the staleness gate:

```ts
// pane-agent-evidence.ts
return entry.restoredUnconfirmed !== true && now - entry.updatedAt <= staleAfterMs
```

Stale `working` rows are supposed to decay to `idle` in `worktree-agent-rows.ts:236`. That decay is the *only* recovery when a terminating hook is lost — and a lost `Stop` is exactly what a sleep, an app restart, or a relay drop produces.

So the failure is: turn ends while disconnected → `Stop` never arrives → row frozen at `working` → reconnect replays the cached `working` → `receivedAt` jumps to now, `stateStartedAt` stays put → row is "fresh working" again, showing an hours-old age → decay can never fire, and every subsequent reconnect re-arms it.

That reproduces the reported artifact exactly: an amber spinner with tool detail (`Bash: pnpm run typecheck…`, which only renders when `state === 'working'`) next to an age of `6h`.

`isReplay` already rides the envelope through `ingestRemote` and was consulted for interrupt-suppression and `claudeRunningNonAgentTask`, but never for timing.

### Which reconnects hit this

The replay must land while the cached entry still exists, so `stateStartedAt` survives:

- **WSL relay** — `wsl-hook-relay-manager.ts:295` requests a replay on every (re)connect and never clears cached statuses first (no `clearStatusEntriesForConnection` in that manager at all).
- **Host-side relay restart** — `relay.ts` → `replayCachedPayloadsForPanes()` replays while the client session stays up, so the client never tore down.

The local `setListener` replay (`server.ts:640`) was already safe: it re-emits enriched payloads with their original `receivedAt`.

## Linked Issue

Linear **STA-4144** — "Claude code stuck in loading after work completes" (Urgent, In Progress).
Duplicates: **STA-3532**, **STA-3522** (both Urgent, screenshot-only reports of the same symptom).
Related: **STA-3524** (reconnect replays are not idempotent — same root, notification-side symptom).

No GitHub issue exists for this one; it came in via Slack.

Fixes #

## Visual Proof

**Not captured — stating this plainly rather than approximating it.** The stuck state needs a lost `Stop` plus a relay reconnect, which I could not stage live inside this worktree without disrupting the running desktop session.

The "before" artifact is the reporter's screenshot on STA-4144: sidebar row `Fix issues - Bash: pnpm run typecheck > /tm…` showing the amber working spinner at age **6h**, while the pane's TUI is plainly idle (`❯` prompt, recap printed). That combination is only reachable with a fresh `updatedAt` and an old `stateStartedAt`, which is the state this PR makes unreachable for replays.

The behavior is pinned by a deterministic test on real state transitions instead (below).

## Testing

New: `src/main/agent-hooks/reconnect-replay-status-freshness.test.ts` — drives the real `AgentHookServer` through `ingestRemote` (no mocking of the logic under test) and asserts on the real cached row via `getStatusSnapshot()`, gated by the shared `isFreshNonDoneAgentStatus` predicate the UI actually uses.

Red/green oracle — with the fix reverted, case 1 fails on the real symptom:

```
AssertionError: expected 1700001860000 to be 1700000000000
  ❯ expect(row.updatedAt).toBe(T0)
```

i.e. the replay pushed `updatedAt` forward 31 minutes. The other two cases pass without the fix (they assert preserved behavior, so they are guards, not filler):

1. replayed unchanged `working` past the stale window stays stale → decays to idle **(fails without the fix)**
2. a replay carrying `done` still applies with live timing — the missed-completion path
3. a live same-state `working` ping still refreshes freshness, and still reports `stateStartedAt` as the state's start

Scoped checks run (per instruction, no full typecheck):

- `vitest src/main/agent-hooks/` → **40 files, 615 passed**, 4 skipped
- `vitest src/relay/agent-hook-server.test.ts src/main/ssh/ssh-relay-session-agent-hooks.integration.test.ts` → **25 passed**
- `tsc --noEmit -p config/tsconfig.node.json --composite false` → clean
- `oxlint` + `oxfmt --check` on both changed files → clean

Platforms: logic is platform-independent and sits in the shared ingest path. The two reconnect paths it fixes are WSL (Windows) and SSH/remote relay; exercised through the integration suites above, not on live Windows/SSH hosts.

### Investigated and ruled out

Recorded so the next person doesn't re-walk these:

- **Backgrounded `Bash` leaving an unbalanced hook pair** — disproved on real Claude Code 2.1.227 with a hook recorder: `run_in_background` yields `PreToolUse → PostToolUse` 0.11s apart, then `Stop`. Perfectly balanced, no late tool event.
- **Replay resetting the clock via the local path** — disproved by reading `setListener`; it preserves `receivedAt`.
- **Renderer burst-queue coalescing (#13974) dropping the terminal `done`** — real but separate: teardown at `useIpcEvents.ts` clears `liveAgentStatusBurstQueue` without draining, so a `done` sitting in the 33ms window is discarded on effect teardown. Narrow, and not the reported mechanism. Not touched here.

### Known remaining gap (not fixed here)

When a reconnect *does* clear first — the SSH path calls `clearStatusEntriesForConnection` on teardown — the replay recreates the row with **both** `receivedAt` and `stateStartedAt` set to now. The pane then shows a working spinner aged "now" for 30 minutes even if the agent finished long ago. Closing that needs the original observation time carried on the replay envelope (a new optional wire field, safe per `docs/reference/remote-wire-compatibility.md`). Deliberately out of scope to keep this focused.

## Review

- **Security** — none; no new input, no trust-boundary change.
- **Cross-platform** — no platform branch; fixes a WSL-only reconnect path and a shared relay path.
- **Remote SSH** — the changed path is remote ingest. No wire change, so mixed client/host versions are unaffected: the fix is entirely client-side over a field (`isReplay`) that already crosses the wire.
- **Mobile** — reads the same status rows; strictly fewer spurious `working` rows.
- **Backwards compatibility** — no persisted-format or wire change.
- **Performance** — one comparison per ingested event.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes — **not captured**; reasoned above
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] Scoped lint / typecheck / tests pass locally (full typecheck skipped per instruction — OOM risk)

## Author

- X / Twitter: @BrennanKB5
