### PR TITLE
fix(codex): seed the spawn-window agent status from launch metadata

### DIFF
--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -9173,3 +9173,171 @@ describe('AgentHookServer closed-tab suppression bound', () => {
     expect(internals.closedAgentStatusTabIds.has(`closed-tab-${total - 1}`)).toBe(true)
   })
 })
+
+describe('seedLaunchAgentStatus', () => {
+  const SEED = { paneKey: PANE, tabId: 'tab-1', worktreeId: 'wt-1', agentType: 'codex' as const }
+
+  it('publishes a working row at spawn, before any hook arrives', () => {
+    const server = new AgentHookServer()
+
+    server.seedLaunchAgentStatus({ ...SEED, prompt: 'say hi' })
+
+    expect(server.getStatusSnapshot()).toEqual([
+      expect.objectContaining({
+        paneKey: PANE,
+        tabId: 'tab-1',
+        worktreeId: 'wt-1',
+        state: 'working',
+        prompt: 'say hi',
+        agentType: 'codex'
+      })
+    ])
+  })
+
+  it('publishes an idle session-boundary row for a promptless spawn', () => {
+    const server = new AgentHookServer()
+
+    server.seedLaunchAgentStatus({ ...SEED, prompt: '' })
+
+    expect(server.getStatusSnapshot()).toEqual([
+      expect.objectContaining({
+        paneKey: PANE,
+        state: 'done',
+        prompt: '',
+        agentType: 'codex',
+        sessionBoundary: true
+      })
+    ])
+  })
+
+  it('stays one row under duplicate seeds and notifies once', () => {
+    const server = new AgentHookServer()
+    const changeListener = vi.fn()
+    server.subscribeStatusChanges(changeListener)
+
+    server.seedLaunchAgentStatus({ ...SEED, prompt: 'say hi' })
+    const afterFirst = server.getStatusSnapshot()
+    server.seedLaunchAgentStatus({ ...SEED, prompt: 'say hi' })
+
+    expect(server.getStatusSnapshot()).toEqual(afterFirst)
+    expect(changeListener).toHaveBeenCalledTimes(1)
+  })
+
+  it('never overwrites a status the pane already reported', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      const env = server.buildPtyEnv()
+      await fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/codex`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+        },
+        body: JSON.stringify(buildBody({ hook_event_name: 'PermissionRequest', tool_name: 'Bash' }))
+      })
+
+      server.seedLaunchAgentStatus({ ...SEED, prompt: 'say hi' })
+
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({ state: 'waiting', agentType: 'codex' })
+      ])
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('does not resurrect a retired pane', () => {
+    const server = new AgentHookServer()
+    server.retirePaneAuthority(PANE)
+
+    server.seedLaunchAgentStatus({ ...SEED, prompt: 'say hi' })
+
+    expect(server.getStatusSnapshot()).toEqual([])
+  })
+
+  it('lets the first real turn replace the seed and keeps its provider session', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      const env = server.buildPtyEnv()
+      const postCodexHook = (payload: Record<string, unknown>): Promise<Response> =>
+        fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/codex`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+          },
+          body: JSON.stringify(buildBody(payload))
+        })
+      server.seedLaunchAgentStatus({ ...SEED, prompt: '' })
+
+      // Measured on codex-cli 0.147: SessionStart never arrives while the TUI is
+      // idle — it fires alongside the first UserPromptSubmit, on the same turn.
+      await postCodexHook({ hook_event_name: 'SessionStart', session_id: 'codex-session-1' })
+      await postCodexHook({
+        hook_event_name: 'UserPromptSubmit',
+        session_id: 'codex-session-1',
+        prompt: 'say hi'
+      })
+
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({
+          state: 'working',
+          prompt: 'say hi',
+          agentType: 'codex',
+          sessionBoundary: undefined,
+          providerSession: expect.objectContaining({ key: 'session_id', id: 'codex-session-1' })
+        })
+      ])
+
+      await postCodexHook({ hook_event_name: 'Stop', last_assistant_message: 'Hi!' })
+
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({
+          state: 'done',
+          agentType: 'codex',
+          lastAssistantMessage: 'Hi!',
+          sessionBoundary: undefined
+        })
+      ])
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('stays a single row when the same hook event is delivered twice', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      const env = server.buildPtyEnv()
+      const postCodexHook = (payload: Record<string, unknown>): Promise<Response> =>
+        fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/codex`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+          },
+          body: JSON.stringify(buildBody(payload))
+        })
+      server.seedLaunchAgentStatus({ ...SEED, prompt: 'say hi' })
+
+      // Two managed hook installs (user home + per-account home) can both deliver.
+      await postCodexHook({ hook_event_name: 'UserPromptSubmit', prompt: 'say hi' })
+      await postCodexHook({ hook_event_name: 'UserPromptSubmit', prompt: 'say hi' })
+
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({ state: 'working', prompt: 'say hi', agentType: 'codex' })
+      ])
+
+      await postCodexHook({ hook_event_name: 'Stop', last_assistant_message: 'Hi!' })
+      await postCodexHook({ hook_event_name: 'Stop', last_assistant_message: 'Hi!' })
+
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({ state: 'done', agentType: 'codex' })
+      ])
+    } finally {
+      server.stop()
+    }
+  })
+})

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -63,6 +63,7 @@ import {
   type ParsedAgentStatusPayload,
   normalizeAgentStatusPayload
 } from '../../shared/agent-status-types'
+import { buildLaunchStatusSeedPayload } from '../../shared/agent-launch-status-seed'
 import {
   resolveAgentStatusIdentity,
   shouldSuppressInheritedTerminalStatus
@@ -1786,6 +1787,42 @@ export class AgentHookServer {
     } else {
       this.state.claudeActiveSessionCronPaneKeys.delete(paneKey)
     }
+  }
+
+  /**
+   * Publish the spawn-window row for a runtime-spawned pane whose agent stays
+   * hook-silent until its first prompt (#6643). Renderer-mounted panes seed
+   * themselves from `paneStartup.initialAgentStatus`; a runtime-spawned PTY has
+   * no such pane, so main seeds it from the same launch metadata.
+   *
+   * Any existing row wins — a real hook or OSC status that already landed (a
+   * `PermissionRequest` waiting, say) is never overwritten, and later events
+   * replace the seed normally.
+   */
+  seedLaunchAgentStatus(seed: {
+    paneKey: string
+    tabId?: string
+    worktreeId?: string
+    agentType: AgentType
+    prompt: string
+  }): void {
+    const paneKey = this.resolvePaneKeyAlias(seed.paneKey.trim())
+    if (this.state.lastStatusByPaneKey.has(paneKey)) {
+      return
+    }
+    const payload = normalizeAgentStatusPayload(
+      buildLaunchStatusSeedPayload(seed.agentType, seed.prompt)
+    )
+    if (!payload) {
+      return
+    }
+    this.ingestTerminalStatus({
+      paneKey: seed.paneKey,
+      ...(seed.tabId ? { tabId: seed.tabId } : {}),
+      ...(seed.worktreeId ? { worktreeId: seed.worktreeId } : {}),
+      connectionId: null,
+      payload
+    })
   }
 
   ingestTerminalStatus(event: {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines -- Why: runtime behavior is stateful and cross-cutting, so these tests stay in one file to preserve the end-to-end invariants around handles, waits, and graph sync. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { agentHookServer } from '../agent-hooks/server'
 import type * as GitUsernameModule from '../git/git-username'
 import { performance } from 'node:perf_hooks'
 import { EventEmitter } from 'node:events'
@@ -44291,6 +44292,162 @@ describe('OrcaRuntimeService', () => {
       })
     )
     expect(metaById[result.worktree.id]).toMatchObject({ createdWithAgent: 'codex' })
+  })
+
+  it('seeds the spawn-window Codex status for a CLI-created local worktree', async () => {
+    // Why: a runtime-spawned startup terminal mounts no renderer pane, so nothing
+    // else covers Codex's hook-silent spawn window (#6643).
+    const seedSpy = vi.spyOn(agentHookServer, 'seedLaunchAgentStatus').mockImplementation(() => {})
+    // Why: vi.spyOn reuses an existing spy on the shared agentHookServer singleton,
+    // so a sibling test's call would otherwise carry into this count.
+    seedSpy.mockClear()
+    const metaById: Record<string, WorktreeMeta> = {}
+    const runtimeStore = {
+      ...store,
+      getSettings: () => ({ ...store.getSettings(), agentCmdOverrides: {} }),
+      getAllWorktreeMeta: () => metaById,
+      getWorktreeMeta: (worktreeId: string) => metaById[worktreeId],
+      setWorktreeMeta: (worktreeId: string, meta: Partial<WorktreeMeta>) => {
+        metaById[worktreeId] = { ...(metaById[worktreeId] ?? makeWorktreeMeta()), ...meta }
+        return metaById[worktreeId]
+      }
+    }
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-cli-codex-seed' }),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    runtime.setNotifier({
+      worktreesChanged: vi.fn(),
+      reposChanged: vi.fn(),
+      activateWorktree: vi.fn(),
+      createTerminal: vi.fn(),
+      revealTerminalSession: vi.fn().mockResolvedValue({ tabId: 'tab-cli-codex-seed' }),
+      splitTerminal: vi.fn(),
+      renameTerminal: vi.fn(),
+      focusTerminal: vi.fn(),
+      closeTerminal: vi.fn(),
+      sleepWorktree: vi.fn(),
+      terminalFitOverrideChanged: vi.fn(),
+      terminalDriverChanged: vi.fn()
+    })
+    runtime.attachWindow(1)
+    vi.spyOn(runtime, 'createTerminal').mockResolvedValue({
+      handle: 'term-cli-codex-seed',
+      tabId: 'tab-cli-codex-seed',
+      paneKey: 'tab-cli-codex-seed:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      ptyId: 'pty-cli-codex-seed',
+      worktreeId: 'unused',
+      title: null,
+      surface: 'background'
+    } as never)
+
+    computeWorktreePathMock.mockReturnValue('/tmp/workspaces/runtime-cli-codex-seed')
+    ensurePathWithinWorkspaceMock.mockReturnValue('/tmp/workspaces/runtime-cli-codex-seed')
+    vi.mocked(listWorktrees).mockResolvedValue([
+      {
+        path: '/tmp/workspaces/runtime-cli-codex-seed',
+        head: 'def',
+        branch: 'runtime-cli-codex-seed',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    const result = await runtime.createManagedWorktree({
+      repoSelector: TEST_REPO_ID,
+      name: 'runtime-cli-codex-seed',
+      startupAgent: 'codex',
+      startupPrompt: 'hi'
+    })
+
+    expect(seedSpy).toHaveBeenCalledTimes(1)
+    expect(seedSpy).toHaveBeenCalledWith({
+      paneKey: 'tab-cli-codex-seed:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      tabId: 'tab-cli-codex-seed',
+      worktreeId: result.worktree.id,
+      agentType: 'codex',
+      prompt: 'hi'
+    })
+  })
+
+  it('keeps the startup terminal successful when Codex status seeding throws', async () => {
+    // Why: seeding is best-effort presence state — the terminal already spawned,
+    // so a seeding failure must not surface as a startup-terminal warning.
+    const seedSpy = vi.spyOn(agentHookServer, 'seedLaunchAgentStatus').mockImplementation(() => {
+      throw new Error('seed boom')
+    })
+    seedSpy.mockClear()
+    const metaById: Record<string, WorktreeMeta> = {}
+    const runtimeStore = {
+      ...store,
+      getSettings: () => ({ ...store.getSettings(), agentCmdOverrides: {} }),
+      getAllWorktreeMeta: () => metaById,
+      getWorktreeMeta: (worktreeId: string) => metaById[worktreeId],
+      setWorktreeMeta: (worktreeId: string, meta: Partial<WorktreeMeta>) => {
+        metaById[worktreeId] = { ...(metaById[worktreeId] ?? makeWorktreeMeta()), ...meta }
+        return metaById[worktreeId]
+      }
+    }
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-cli-codex-seed-throw' }),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    runtime.setNotifier({
+      worktreesChanged: vi.fn(),
+      reposChanged: vi.fn(),
+      activateWorktree: vi.fn(),
+      createTerminal: vi.fn(),
+      revealTerminalSession: vi.fn().mockResolvedValue({ tabId: 'tab-cli-codex-seed-throw' }),
+      splitTerminal: vi.fn(),
+      renameTerminal: vi.fn(),
+      focusTerminal: vi.fn(),
+      closeTerminal: vi.fn(),
+      sleepWorktree: vi.fn(),
+      terminalFitOverrideChanged: vi.fn(),
+      terminalDriverChanged: vi.fn()
+    })
+    runtime.attachWindow(1)
+    vi.spyOn(runtime, 'createTerminal').mockResolvedValue({
+      handle: 'term-cli-codex-seed-throw',
+      tabId: 'tab-cli-codex-seed-throw',
+      paneKey: 'tab-cli-codex-seed-throw:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      ptyId: 'pty-cli-codex-seed-throw',
+      worktreeId: 'unused',
+      title: null,
+      surface: 'background'
+    } as never)
+
+    computeWorktreePathMock.mockReturnValue('/tmp/workspaces/runtime-cli-codex-seed-throw')
+    ensurePathWithinWorkspaceMock.mockReturnValue('/tmp/workspaces/runtime-cli-codex-seed-throw')
+    vi.mocked(listWorktrees).mockResolvedValue([
+      {
+        path: '/tmp/workspaces/runtime-cli-codex-seed-throw',
+        head: 'def',
+        branch: 'runtime-cli-codex-seed-throw',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    const result = await runtime.createManagedWorktree({
+      repoSelector: TEST_REPO_ID,
+      name: 'runtime-cli-codex-seed-throw',
+      startupAgent: 'codex',
+      startupPrompt: 'hi'
+    })
+
+    expect(seedSpy).toHaveBeenCalledTimes(1)
+    expect(result.warning).toBeUndefined()
+    expect(result.startupTerminal).toMatchObject({
+      spawned: true,
+      handle: 'term-cli-codex-seed-throw'
+    })
   })
 
   it('sends follow-up prompts for CLI-created stdin-after-start startup agents', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -52,7 +52,7 @@ import {
   type AgentStatusEntry
 } from '../../shared/agent-status-types'
 import { indexAgentStatusRowsByPaneKey } from '../agent-hooks/agent-status-pane-index'
-import type { AgentHookAuthorityAttestation } from '../agent-hooks/server'
+import { agentHookServer, type AgentHookAuthorityAttestation } from '../agent-hooks/server'
 import type {
   AgentSessionClaimedSpawnResult,
   AgentSessionExecutionClaim,
@@ -453,6 +453,7 @@ import {
   buildAgentStartupPlan
 } from '../../shared/tui-agent-startup'
 import { repoIsRemote } from '../../shared/agent-launch-remote'
+import { agentSeedsLaunchStatus } from '../../shared/agent-launch-status-seed'
 import {
   isAgentForegroundWrapperProcess,
   isExpectedAgentProcess,
@@ -22193,6 +22194,44 @@ export class OrcaRuntimeService {
     })
   }
 
+  /**
+   * Seed the spawn-window status row for a startup terminal the runtime spawned
+   * itself. Renderer-mounted panes seed from `paneStartup.initialAgentStatus`,
+   * but a runtime-spawned PTY (CLI create, automation, backend-spawned startup)
+   * mounts no such pane, so nothing else covers Codex's hook-silent spawn window
+   * (#6643). Best-effort: the terminal already spawned, so a seeding failure is
+   * logged rather than reported as a startup-terminal failure.
+   *
+   * Local repos only — a remote pane's rows arrive relay-stamped with a
+   * connectionId that this local-connection row would contradict.
+   */
+  private seedRuntimeLaunchAgentStatus(options: {
+    repo: { connectionId?: string | null }
+    agent: TuiAgent | undefined
+    paneKey: string | null | undefined
+    tabId: string | null | undefined
+    worktreeId: string
+    prompt: string
+  }): void {
+    if (!agentSeedsLaunchStatus(options.agent) || repoIsRemote(options.repo) || !options.paneKey) {
+      return
+    }
+    try {
+      agentHookServer.seedLaunchAgentStatus({
+        paneKey: options.paneKey,
+        ...(options.tabId ? { tabId: options.tabId } : {}),
+        worktreeId: options.worktreeId,
+        agentType: options.agent,
+        prompt: options.prompt
+      })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      console.warn(
+        `[worktree-create] Failed to seed the launch status for ${options.worktreeId}: ${message}`
+      )
+    }
+  }
+
   async createManagedWorktree(args: {
     repoSelector: string
     name: string
@@ -22375,6 +22414,16 @@ export class OrcaRuntimeService {
             ...(terminal.ptyId ? { ptyId: terminal.ptyId } : {}),
             surface: 'background'
           }
+          this.seedRuntimeLaunchAgentStatus({
+            repo,
+            agent: effectiveCreatedWithAgent,
+            paneKey: terminal.paneKey,
+            tabId: terminal.tabId,
+            worktreeId: worktree.id,
+            // Why: a draft paste leaves the prompt unsent, so it seeds the idle
+            // presence row rather than claiming a turn is already running.
+            prompt: effectiveDraftPaste || !agentStartup ? '' : (args.startupPrompt ?? '')
+          })
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err)
           warning = `Failed to create the startup terminal for ${worktree.path}: ${message}`
@@ -23125,6 +23174,16 @@ export class OrcaRuntimeService {
         startupTerminalTabId = terminal.tabId ?? null
         startupTerminalPaneKey = terminal.paneKey ?? null
         startupTerminalPtyId = terminal.ptyId ?? null
+        this.seedRuntimeLaunchAgentStatus({
+          repo,
+          agent: effectiveCreatedWithAgent,
+          paneKey: terminal.paneKey,
+          tabId: terminal.tabId,
+          worktreeId: worktree.id,
+          // Why: a draft paste leaves the prompt unsent, so it seeds the idle
+          // presence row rather than claiming a turn is already running.
+          prompt: effectiveDraftPaste || !agentStartup ? '' : (args.startupPrompt ?? '')
+        })
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
         warning = warning

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -4127,6 +4127,82 @@ describe('connectPanePty', () => {
     )
   })
 
+  it('seeds a Codex spawn row over SSH before any hook arrives', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const sshPtyId = toAppSshPtyId('ssh-a', 'pty-codex-seed')
+    const transport = createMockTransport(sshPtyId)
+    transport.getConnectionId.mockReturnValue('ssh-a')
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] },
+      repos: [{ id: 'repo1', connectionId: 'ssh-a' }],
+      sshConnectionStates: new Map([['ssh-a', { status: 'connected' }]])
+    }
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps({
+      startup: {
+        command: "codex 'Fix the status'",
+        initialAgentStatus: { agent: 'codex', prompt: 'Fix the status' }
+      }
+    })
+
+    connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks()
+    const onPtySpawn = createdTransportOptions[0]?.onPtySpawn as
+      | ((ptyId: string) => void)
+      | undefined
+    onPtySpawn?.(sshPtyId)
+
+    expect(mockStoreState.setAgentStatus).toHaveBeenCalledWith(
+      makePaneKey('tab-1', LEAF_1),
+      { state: 'working', prompt: 'Fix the status', agentType: 'codex' },
+      undefined,
+      undefined,
+      { connectionId: 'ssh-a' }
+    )
+  })
+
+  it('seeds a promptless Codex spawn as an idle session-boundary row, not a spinner', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const sshPtyId = toAppSshPtyId('ssh-a', 'pty-codex-idle-seed')
+    const transport = createMockTransport(sshPtyId)
+    transport.getConnectionId.mockReturnValue('ssh-a')
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] },
+      repos: [{ id: 'repo1', connectionId: 'ssh-a' }],
+      sshConnectionStates: new Map([['ssh-a', { status: 'connected' }]])
+    }
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps({
+      startup: {
+        command: 'codex',
+        initialAgentStatus: { agent: 'codex', prompt: '' }
+      }
+    })
+
+    connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks()
+    const onPtySpawn = createdTransportOptions[0]?.onPtySpawn as
+      | ((ptyId: string) => void)
+      | undefined
+    onPtySpawn?.(sshPtyId)
+
+    expect(mockStoreState.setAgentStatus).toHaveBeenCalledWith(
+      makePaneKey('tab-1', LEAF_1),
+      { state: 'done', prompt: '', agentType: 'codex', sessionBoundary: true },
+      undefined,
+      undefined,
+      { connectionId: 'ssh-a' }
+    )
+  })
+
   it('seeds a working status from Command Code thinking output without a startup prompt', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -304,6 +304,7 @@ import {
   normalizeCompatibleAgentTitleForOwner,
   resolveCompatibleAgentTypeForOwner
 } from '../../../../shared/agent-title-owner'
+import { buildLaunchStatusSeedPayload } from '../../../../shared/agent-launch-status-seed'
 import { resolvePaneAgentOwner } from '../../../../shared/pane-agent-owner'
 import { resolveCommittedTitleAgentType } from '@/lib/pane-agent-evidence'
 import {
@@ -1292,6 +1293,9 @@ export function connectPanePty(
   const launchToken = paneStartup?.launchConfig
     ? (paneStartup.launchToken ?? createBrowserUuid())
     : undefined
+  // Why: the seed's prompt is empty when the launch does not submit one; only a
+  // non-empty prompt means "this launch already started a turn".
+  const submittedInitialStatusPrompt = paneStartup?.initialAgentStatus?.prompt || undefined
   const startupDraftAgent = paneStartup?.launchAgent ?? paneStartup?.initialAgentStatus?.agent
   const startupDraftAgentConfig = startupDraftAgent ? TUI_AGENT_CONFIG[startupDraftAgent] : null
   const startupDraftPrompt =
@@ -2863,14 +2867,10 @@ export function connectPanePty(
     if (!initialStatus || !routing) {
       return
     }
-    const statusPayload = {
-      state: 'working' as const,
-      prompt: initialStatus.prompt,
-      agentType: resolveCompatibleAgentTypeForOwner(
-        initialStatus.agent,
-        getAuthoritativePaneAgent()
-      )
-    }
+    const statusPayload = buildLaunchStatusSeedPayload(
+      resolveCompatibleAgentTypeForOwner(initialStatus.agent, getAuthoritativePaneAgent()),
+      initialStatus.prompt
+    )
     if (paneStartup.launchConfig) {
       useAppStore
         .getState()
@@ -3835,10 +3835,12 @@ export function connectPanePty(
     ...(paneStartup?.resumeProviderSession
       ? { resumeProviderSession: paneStartup.resumeProviderSession }
       : {}),
-    ...((paneStartup?.initialAgentStatus?.prompt ?? paneStartup?.draftPrompt)
-      ? { agentPrompt: paneStartup?.initialAgentStatus?.prompt ?? paneStartup?.draftPrompt }
+    // Why: a promptless launch seed carries an empty prompt (it only asks for an
+    // idle presence row), so it must not shadow the pane's unsent draft here.
+    ...((submittedInitialStatusPrompt ?? paneStartup?.draftPrompt)
+      ? { agentPrompt: submittedInitialStatusPrompt ?? paneStartup?.draftPrompt }
       : {}),
-    ...(paneStartup?.initialAgentStatus?.prompt
+    ...(submittedInitialStatusPrompt
       ? { agentPromptDelivery: 'auto-submit' as const }
       : paneStartup?.draftPrompt
         ? { agentPromptDelivery: 'draft' as const }

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -52,6 +52,7 @@ import type {
 } from '../../../shared/orca-yaml-hook-types'
 import type { ProjectGroup } from '../../../shared/project-group-types'
 import type { TuiAgent } from '../../../shared/tui-agent'
+import { agentSeedsLaunchStatus } from '../../../shared/agent-launch-status-seed'
 import type { WorkspaceSource as WorkspaceCreateTelemetrySource } from '../../../shared/workspace-source'
 import type { SetupDecision, SparsePreset } from '../../../shared/worktree/create-types'
 import type { WorktreeMeta } from '../../../shared/worktree/meta-types'
@@ -3812,8 +3813,11 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         shell: selectedRepoStartupShell,
         isRemote: selectedRepoIsRemote
       })
-      const shouldSeedInitialAgentStatus =
-        tuiAgent === 'command-code' && submitStartupPrompt.trim().length > 0
+      // Why: these agents publish no hook until their first prompt, so the new
+      // workspace's tab status stays empty for the whole spawn window unless
+      // launch metadata seeds it. An unsent draft seeds the idle row, not `working`.
+      const shouldSeedInitialAgentStatus = agentSeedsLaunchStatus(tuiAgent)
+      const seededStartupPrompt = startupPlan?.draftPrompt ? '' : submitStartupPrompt.trim()
 
       // Why: backend startup is safe only for self-contained launch commands; agents needing post-ready paste stay on the renderer path.
       const composerTelemetry: AgentStartedTelemetry = {
@@ -3933,7 +3937,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
                   ? {
                       initialAgentStatus: {
                         agent: tuiAgent,
-                        prompt: submitStartupPrompt.trim()
+                        prompt: seededStartupPrompt
                       }
                     }
                   : {}),

--- a/src/renderer/src/lib/launch-agent-in-new-tab-launch-status-seed.test.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab-launch-status-seed.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockQueueTabStartupCommand = vi.fn()
+
+const store = {
+  settings: {
+    agentCmdOverrides: {},
+    agentDefaultArgs: {},
+    agentDefaultEnv: {},
+    activeRuntimeEnvironmentId: null as string | null
+  },
+  repos: [{ id: 'repo-1', connectionId: null as string | null, path: '/repo' }],
+  allWorktrees: vi.fn(() => [{ id: 'wt-1', repoId: 'repo-1', path: '/repo/worktree' }]),
+  tabsByWorktree: { 'wt-1': [{ id: 'tab-1' }] },
+  openFiles: [] as { id: string; worktreeId: string }[],
+  browserTabsByWorktree: {} as Record<string, { id: string }[]>,
+  tabBarOrderByWorktree: {} as Record<string, string[]>,
+  createTab: vi.fn(() => ({ id: 'tab-1' })),
+  queueTabInitialCwd: vi.fn(),
+  queueTabStartupCommand: mockQueueTabStartupCommand,
+  setActiveTabType: vi.fn(),
+  setTabBarOrder: vi.fn(),
+  seedNativeChatLaunchDraft: vi.fn()
+}
+
+vi.mock('@/store', () => ({ useAppStore: { getState: () => store } }))
+vi.mock('@/lib/new-workspace', () => ({ CLIENT_PLATFORM: 'darwin' }))
+vi.mock('@/lib/connection-context', () => ({ getConnectionIdFromState: () => null }))
+vi.mock('@/lib/native-chat-transcript-readability', () => ({
+  isNativeChatTranscriptLocalReadable: () => true
+}))
+vi.mock('@/runtime/web-runtime-session', () => ({
+  isWebRuntimeSessionActive: () => false,
+  isWebTerminalSurfaceTabId: () => false
+}))
+vi.mock('@/lib/worktree-runtime-owner', () => ({
+  getRuntimeEnvironmentIdForWorktree: () => null
+}))
+vi.mock('@/lib/agent-paste-draft', () => ({
+  pasteDraftWhenAgentReady: vi.fn().mockResolvedValue(true)
+}))
+vi.mock('@/components/tab-bar/reconcile-order', () => ({
+  reconcileTabOrder: (_stored: unknown, terminalIds: string[]) => terminalIds
+}))
+vi.mock('@/lib/telemetry', () => ({
+  track: vi.fn(),
+  tuiAgentToAgentKind: (agent: string) => agent
+}))
+vi.mock('@/components/native-chat/native-chat-session-option-cache', () => ({
+  seedNativeChatAppliedSessionOptions: vi.fn()
+}))
+
+// Why: Codex posts no hook while its TUI idles (measured on codex-cli 0.147 —
+// SessionStart fires only alongside the first UserPromptSubmit), so the launch
+// must carry the spawn-window status itself or the pane stays absent (#6643).
+describe('launchAgentInNewTab launch-status seed', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    store.createTab.mockReturnValue({ id: 'tab-1' })
+  })
+
+  it('queues a working seed for a Codex argv prompt launch', async () => {
+    const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
+
+    launchAgentInNewTab({ agent: 'codex', worktreeId: 'wt-1', prompt: 'fix the spinner' })
+
+    expect(mockQueueTabStartupCommand).toHaveBeenCalledWith(
+      'tab-1',
+      expect.objectContaining({
+        initialAgentStatus: { agent: 'codex', prompt: 'fix the spinner' }
+      })
+    )
+  })
+
+  it('queues a promptless Codex seed so the pane is present at spawn', async () => {
+    const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
+
+    launchAgentInNewTab({ agent: 'codex', worktreeId: 'wt-1' })
+
+    expect(mockQueueTabStartupCommand).toHaveBeenCalledWith(
+      'tab-1',
+      expect.objectContaining({ initialAgentStatus: { agent: 'codex', prompt: '' } })
+    )
+  })
+
+  it('seeds an unsent Codex draft as presence only, never as a running turn', async () => {
+    const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
+
+    launchAgentInNewTab({
+      agent: 'codex',
+      worktreeId: 'wt-1',
+      prompt: 'fix the spinner',
+      promptDelivery: 'draft'
+    })
+
+    expect(mockQueueTabStartupCommand).toHaveBeenCalledWith(
+      'tab-1',
+      expect.objectContaining({ initialAgentStatus: { agent: 'codex', prompt: '' } })
+    )
+  })
+
+  it('keeps seeding Command Code, which shares the hook-silent spawn window', async () => {
+    const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
+
+    launchAgentInNewTab({ agent: 'command-code', worktreeId: 'wt-1', prompt: 'fix the spinner' })
+
+    expect(mockQueueTabStartupCommand).toHaveBeenCalledWith(
+      'tab-1',
+      expect.objectContaining({
+        initialAgentStatus: { agent: 'command-code', prompt: 'fix the spinner' }
+      })
+    )
+  })
+
+  it('leaves agents that publish a startup row unseeded', async () => {
+    const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
+
+    launchAgentInNewTab({ agent: 'claude', worktreeId: 'wt-1', prompt: 'fix the spinner' })
+
+    expect(mockQueueTabStartupCommand).toHaveBeenCalledWith(
+      'tab-1',
+      expect.not.objectContaining({ initialAgentStatus: expect.anything() })
+    )
+  })
+})

--- a/src/renderer/src/lib/launch-agent-in-new-tab.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.ts
@@ -22,6 +22,7 @@ import {
 } from '../../../shared/tui-agent-launch-defaults'
 import { resolveLocalWindowsAgentStartupShell } from '../../../shared/windows-terminal-shell'
 import { TUI_AGENT_CONFIG } from '../../../shared/tui-agent-config'
+import { agentSeedsLaunchStatus } from '../../../shared/agent-launch-status-seed'
 import { repoIsRemote } from '../../../shared/agent-launch-remote'
 import { seedCommandCodeSubmittedPromptStatus } from '@/lib/command-code-prompt-status-seed'
 import type { TuiAgent } from '../../../shared/tui-agent'
@@ -195,8 +196,19 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
     ...(startupPlan.startupCommandDelivery
       ? { startupCommandDelivery: startupPlan.startupCommandDelivery }
       : {}),
-    ...(agent === 'command-code' && hasPrompt && promptDelivery === 'auto-submit'
-      ? { initialAgentStatus: { agent, prompt: trimmedPrompt } }
+    // Why: these agents publish no hook until their first prompt, so the tab
+    // status stays empty for the whole spawn window unless launch metadata
+    // seeds it. An unsent draft seeds the idle row, not `working`.
+    ...(agentSeedsLaunchStatus(agent)
+      ? {
+          initialAgentStatus: {
+            agent,
+            prompt:
+              hasPrompt && promptDelivery === 'auto-submit' && !startupPlan.draftPrompt
+                ? trimmedPrompt
+                : ''
+          }
+        }
       : {}),
     telemetry: {
       agent_kind: tuiAgentToAgentKind(agent),

--- a/src/renderer/src/lib/worktree-creation-flow-startup.test.ts
+++ b/src/renderer/src/lib/worktree-creation-flow-startup.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { WorktreeCreationRequest } from '@/lib/pending-worktree-creation'
+import { buildWorktreeCreationStartupOpt } from './worktree-creation-flow-startup'
+
+vi.mock('@/store', () => ({ useAppStore: { getState: () => ({ settings: {} }) } }))
+vi.mock('@/runtime/runtime-rpc-client', () => ({
+  getActiveRuntimeTarget: () => ({ kind: 'local' })
+}))
+
+function makeRequest(overrides: Partial<WorktreeCreationRequest>): WorktreeCreationRequest {
+  return {
+    repoId: 'repo-1',
+    name: 'wt',
+    quickPrompt: '',
+    startupPlan: { launchCommand: 'codex', launchConfig: undefined },
+    ...overrides
+  } as WorktreeCreationRequest
+}
+
+// Why: Codex posts no hook while its TUI idles (measured on codex-cli 0.147 —
+// SessionStart fires only alongside the first UserPromptSubmit), so a new
+// workspace's first pane stays absent from the status surface unless the launch
+// metadata carries the spawn-window row (#6643).
+describe('buildWorktreeCreationStartupOpt launch-status seed', () => {
+  it('seeds a working row for a Codex workspace created with a prompt', () => {
+    const startup = buildWorktreeCreationStartupOpt(
+      makeRequest({ agent: 'codex', quickPrompt: '  fix the spinner  ' }),
+      false
+    )
+
+    expect(startup?.initialAgentStatus).toEqual({ agent: 'codex', prompt: 'fix the spinner' })
+  })
+
+  it('seeds a promptless Codex workspace so the pane is present at spawn', () => {
+    const startup = buildWorktreeCreationStartupOpt(makeRequest({ agent: 'codex' }), false)
+
+    expect(startup?.initialAgentStatus).toEqual({ agent: 'codex', prompt: '' })
+  })
+
+  it('does not claim a running turn when the prompt rides as an unsent draft', () => {
+    const startup = buildWorktreeCreationStartupOpt(
+      makeRequest({
+        agent: 'codex',
+        quickPrompt: 'fix the spinner',
+        startupPlan: {
+          launchCommand: 'codex',
+          draftPrompt: 'fix the spinner'
+        } as WorktreeCreationRequest['startupPlan']
+      }),
+      false
+    )
+
+    expect(startup?.initialAgentStatus).toEqual({ agent: 'codex', prompt: '' })
+  })
+
+  it('leaves agents that publish a startup row unseeded', () => {
+    const startup = buildWorktreeCreationStartupOpt(
+      makeRequest({ agent: 'claude', quickPrompt: 'fix the spinner' }),
+      false
+    )
+
+    expect(startup?.initialAgentStatus).toBeUndefined()
+  })
+
+  it('seeds nothing when the backend already spawned the first terminal', () => {
+    const startup = buildWorktreeCreationStartupOpt(
+      makeRequest({ agent: 'codex', quickPrompt: 'fix the spinner' }),
+      true
+    )
+
+    expect(startup).toBeUndefined()
+  })
+})

--- a/src/renderer/src/lib/worktree-creation-flow-startup.ts
+++ b/src/renderer/src/lib/worktree-creation-flow-startup.ts
@@ -1,5 +1,6 @@
 import { useAppStore } from '@/store'
 import { getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
+import { agentSeedsLaunchStatus } from '../../../shared/agent-launch-status-seed'
 import type { WorktreeStartupPayload } from '@/lib/worktree-activation'
 import type {
   WorktreeCreationPhase,
@@ -27,10 +28,16 @@ export function buildWorktreeCreationStartupOpt(
     // the sole signal that this launch starts with unsent context in the TUI.
     ...(request.launchDraftPrompt ? { launchDraftText: request.launchDraftPrompt } : {}),
     ...(plan.startupCommandDelivery ? { startupCommandDelivery: plan.startupCommandDelivery } : {}),
-    // Why: command-code shows its prompt in the tab status before the first
-    // hook fires, so the prompt is threaded through here.
-    ...(request.agent === 'command-code' && request.quickPrompt.trim().length > 0
-      ? { initialAgentStatus: { agent: request.agent, prompt: request.quickPrompt.trim() } }
+    // Why: these agents publish no hook until their first prompt, so the tab
+    // status stays empty for the whole spawn window unless launch metadata
+    // seeds it. An unsent draft seeds the idle row, not `working`.
+    ...(agentSeedsLaunchStatus(request.agent)
+      ? {
+          initialAgentStatus: {
+            agent: request.agent,
+            prompt: plan.draftPrompt || request.launchDraftPrompt ? '' : request.quickPrompt.trim()
+          }
+        }
       : {}),
     ...(request.quickTelemetry ? { telemetry: request.quickTelemetry } : {})
   }

--- a/src/shared/agent-launch-status-seed.test.ts
+++ b/src/shared/agent-launch-status-seed.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { agentSeedsLaunchStatus, buildLaunchStatusSeedPayload } from './agent-launch-status-seed'
+
+describe('agentSeedsLaunchStatus', () => {
+  it('covers Codex, whose idle TUI posts no hook until the first prompt', () => {
+    expect(agentSeedsLaunchStatus('codex')).toBe(true)
+  })
+
+  it('keeps covering Command Code', () => {
+    expect(agentSeedsLaunchStatus('command-code')).toBe(true)
+  })
+
+  it('excludes agents that publish a SessionStart row at TUI open', () => {
+    expect(agentSeedsLaunchStatus('claude')).toBe(false)
+    expect(agentSeedsLaunchStatus('gemini')).toBe(false)
+  })
+
+  it('is false for an unknown launch agent', () => {
+    expect(agentSeedsLaunchStatus(undefined)).toBe(false)
+  })
+})
+
+describe('buildLaunchStatusSeedPayload', () => {
+  it('reports working when the launch submits a prompt', () => {
+    expect(buildLaunchStatusSeedPayload('codex', 'say hi')).toEqual({
+      state: 'working',
+      prompt: 'say hi',
+      agentType: 'codex'
+    })
+  })
+
+  it('trims the submitted prompt', () => {
+    expect(buildLaunchStatusSeedPayload('codex', '  say hi  ')).toMatchObject({
+      state: 'working',
+      prompt: 'say hi'
+    })
+  })
+
+  it('lands an idle session-boundary row when the launch submits nothing', () => {
+    expect(buildLaunchStatusSeedPayload('codex', '')).toEqual({
+      state: 'done',
+      prompt: '',
+      agentType: 'codex',
+      sessionBoundary: true
+    })
+  })
+
+  it('treats a whitespace-only prompt as no prompt, so no phantom spinner runs', () => {
+    expect(buildLaunchStatusSeedPayload('codex', '   \n ')).toMatchObject({
+      state: 'done',
+      sessionBoundary: true
+    })
+  })
+})

--- a/src/shared/agent-launch-status-seed.ts
+++ b/src/shared/agent-launch-status-seed.ts
@@ -1,0 +1,34 @@
+import type { AgentType, ParsedAgentStatusPayload } from './agent-status-types'
+import type { TuiAgent } from './tui-agent'
+import { TUI_AGENT_CONFIG } from './tui-agent-config'
+
+/** Launch metadata for a pane whose agent publishes no hook until its first prompt.
+ *  `prompt` is empty when the launch does not submit one. */
+export type AgentLaunchStatusSeed = { agent: TuiAgent; prompt: string }
+
+/**
+ * True when the agent's hook stream stays silent until the user's first prompt,
+ * so Orca must seed the spawn-window row from launch metadata instead (#6643).
+ */
+export function agentSeedsLaunchStatus(agent: TuiAgent | null | undefined): agent is TuiAgent {
+  return agent != null && TUI_AGENT_CONFIG[agent].seedsLaunchStatus === true
+}
+
+/**
+ * The status row a launch publishes before any hook arrives.
+ *
+ * A submitted prompt means the turn is already running, so the row is `working`.
+ * A promptless launch lands the same idle session-boundary `done` row Claude's
+ * SessionStart uses (STA-3386): `working` would spin on an idle TUI, and
+ * `sessionBoundary` keeps completion-reactive consumers (notifications,
+ * automation runs, unread badges) out of it.
+ */
+export function buildLaunchStatusSeedPayload(
+  agentType: AgentType | undefined,
+  prompt: string
+): ParsedAgentStatusPayload {
+  const trimmed = prompt.trim()
+  return trimmed
+    ? { state: 'working', prompt: trimmed, ...(agentType ? { agentType } : {}) }
+    : { state: 'done', prompt: '', ...(agentType ? { agentType } : {}), sessionBoundary: true }
+}

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -44,6 +44,10 @@ export type TuiAgentConfig = {
   windowsShiftEnterEncoding?: 'csi-u'
   /** Ctrl+Enter encoding for agents that consume CSI-u without active kitty flags. */
   ctrlEnterEncoding?: 'csi-u'
+  /** This agent publishes no hook until the user's first prompt, so a launched
+   *  pane has no status row during the spawn window. Orca seeds one from launch
+   *  metadata instead — see agent-launch-status-seed.ts (#6643). */
+  seedsLaunchStatus?: true
 }
 
 export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
@@ -84,7 +88,10 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
     expectedProcess: 'codex',
     promptInjectionMode: 'argv',
     preflightTrust: 'codex',
-    draftPasteReadySignal: 'codex-composer-prompt'
+    draftPasteReadySignal: 'codex-composer-prompt',
+    // Why: measured on codex-cli 0.147 — an idle TUI (fresh or `resume`) posts zero
+    // hooks; SessionStart fires only alongside the first UserPromptSubmit.
+    seedsLaunchStatus: true
   },
   autohand: {
     detectCmd: 'autohand',
@@ -231,7 +238,8 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
     // Why: `--trust` skips the first-run trust prompt so it doesn't consume the task text.
     launchCmd: 'command-code --trust',
     expectedProcess: 'command-code',
-    promptInjectionMode: 'argv'
+    promptInjectionMode: 'argv',
+    seedsLaunchStatus: true
   },
   continue: {
     // Why: Continue's CLI binary is `cn`; `continue` is a bash/zsh builtin and would resolve to the shell keyword.


### PR DESCRIPTION
## ELI5

When you start a Codex agent in Orca, the agent row in the status surface used to be missing entirely until you sent your first message. That's because Codex's CLI doesn't tell Orca anything while it's sitting at an idle prompt — it only starts reporting once you actually submit something. This PR fills that gap with what Orca already knows at launch time: which agent it started and whether it started it with a prompt.

## What Changed

- New `seedsLaunchStatus` capability on `TUI_AGENT_CONFIG`, set for `codex` and the already-covered `command-code`. It names the property those two share: no hook until the first prompt.
- New `src/shared/agent-launch-status-seed.ts` — one predicate and one payload builder shared by every seeding site:
  - launch submits a prompt → `working` row carrying that prompt
  - promptless launch, or a prompt delivered as an unsent draft → idle `done` row with `sessionBoundary: true`
- Generalized the existing `paneStartup.initialAgentStatus` seam (previously hardcoded to `command-code`) across its three producers — new agent tab, workspace-creation flow, new-workspace composer — and its consumer in `pty-connection.ts`.
- `AgentHookServer.seedLaunchAgentStatus` + a call from `createManagedWorktree`'s two local startup-terminal sites, for runtime-spawned panes (CLI `worktree create --agent codex`, automations, backend-spawned startups) that mount no renderer pane. Any status the pane already reported always wins.

### Behavior changes worth calling out

- A promptless `command-code` tab now also gets the idle presence row. Previously it was seeded only when launched with a prompt. This falls out of the single uniform rule; special-casing it back would reintroduce the per-agent hardcoding this PR removes.
- The idle row is a `sessionBoundary` `done`, the same shape Claude's `SessionStart` has landed since STA-3386, so notifications, automation runs, unread badges and finished timestamps already ignore it.

## Why

Measured on **codex-cli 0.147.0** (macOS, all eight managed hook events trusted via `codex app-server` `hooks/list` + `config/batchWrite`, captive receiver on a temp `CODEX_HOME`):

| Scenario | Hooks received |
| --- | ---: |
| Fresh TUI, 40 s idle | **0** |
| `codex resume --last`, 40 s idle | **0** |
| `/clear` on a live session | **0** |
| `/new` on a live session | **0** |
| First prompt submitted | 3 — `SessionStart` (`source: startup`), `UserPromptSubmit`, `Stop` |

`SessionStart` and `UserPromptSubmit` landed in the same wall-clock second. So the spawn window is genuinely hook-free: no change to hook handling can put a row on screen there, and launch metadata is the only signal Orca has. That is why this fix lives at launch time rather than in the normalizer.

`paneStartup.initialAgentStatus` already existed for exactly this problem — the code comment read "command-code shows its prompt in the tab status before the first hook fires" — so this makes that seam agent-declarative instead of adding a parallel mechanism.

### Relationship to the other open PRs on this cluster

- **Supersedes #6829** (mine). It threaded a new `InitialAgentStatusSeed` type through IPC/RPC/preload/store/PTY-bind. That plumbing has since landed in a narrower form as `paneStartup.initialAgentStatus`, so the remaining gap is only the agent gate — this PR closes it without new wire fields.
- **Supersedes #14222** (thanks @tonite31 — the spawn-window diagnosis and the `sessionBoundary` idle-row choice are theirs, and both are kept here). Differences: that PR seeds only runtime-built spawns and assumes the renderer path already covers UI-created panes, but on current `main` the renderer path is gated to `command-code`, so UI-launched Codex panes stayed uncovered. It also skipped seeding whenever the caller supplied `startup`, which is a case where the renderer also skips (the renderer only seeds when `backendSpawned === false`), leaving a hole. Here the runtime seeds exactly when it spawned the terminal itself, so the two halves are complementary by construction.
- **Does not supersede #8292** (@bbingz). That PR is independent, not subsumed, and its premise did not reproduce for me. It stops Codex `SessionStart` mapping to `working` to avoid an "idle running flash" — but per the table above, `SessionStart` never arrives while the TUI is idle, and when it does arrive `UserPromptSubmit` follows in the same second with the same `working` state, so there is no observable flash on codex-cli 0.147.0. Its other contents (subagent lifecycle, interrupt handling, richer tool previews) have largely landed on `main` since. I have deliberately not bundled its normalizer/relay changes here; whether the remaining pieces (remote hook prepend + trust-key migration, native "Action Required" title detection) should land is a separate call on their own evidence, and I have not commented on that PR.
- **#11941 is a third, separate root cause** — SSH Codex emitting zero hooks when the TUI reuses a pre-existing `app-server`. It is inside Codex's own launch path and is untouched here.

## Linked Issue

Fixes #6643
Refs #7950, #11941

## Visual Proof

`N/A` — no visual redesign. The change is which status row exists for a pane during the spawn window; there is no new UI surface, token, layout or copy. The reviewer-checkable evidence is the measurement table above plus the assertions in the tests below, which pin the exact published payloads (`working` + prompt, or `done` + `sessionBoundary`).

## Testing

Automated (all added tests fail when `seedsLaunchStatus` is removed from `codex`, or when the payload builder is reverted to the old hardcoded `working` shape — verified by reverting each and re-running):

- `src/shared/agent-launch-status-seed.test.ts` — predicate coverage and both payload shapes, including whitespace-only prompts
- `src/main/agent-hooks/server.test.ts` — `seedLaunchAgentStatus`: a row exists at spawn before any hook; promptless spawn lands the idle boundary row; duplicate seeds stay one row and notify once; an existing `PermissionRequest` waiting is never overwritten; a retired pane is not resurrected; the first real turn replaces the seed and keeps its provider session; duplicate identical hook delivery stays a single row
- `src/main/runtime/orca-runtime.test.ts` — CLI-created local worktree seeds with the injected prompt; a seeding failure does not turn into a startup-terminal warning
- `src/renderer/src/lib/launch-agent-in-new-tab-launch-status-seed.test.ts` and `worktree-creation-flow-startup.test.ts` — producer gating, including draft launches seeding presence only and hook-at-startup agents staying unseeded
- `src/renderer/src/components/terminal-pane/pty-connection.test.ts` — consumer publishes the right payload for both shapes, over an SSH-connected pane

Commands run locally (macOS):

- `pnpm exec vitest run --config config/vitest.config.ts <the six affected files>` — 6 files, 2000 passed / 1 skipped
- Adjacent suites: `useComposerState-host-*`, `worktree-creation-flow`, `agent-status-types`, `store/slices/agent-status` — 5 files, 166 passed
- `tsc --noEmit` for `tsconfig.node.json`, `tsconfig.cli.json`, `tsconfig.web.json` — all clean
- `oxlint`, `oxlint --config config/oxlint-react-doctor.json`, `oxfmt --check` on every changed file — clean
- `node config/scripts/check-changed-code-quality.mjs` — 0 new findings across 14 files
- `pnpm check:max-lines-ratchet` — OK, no new bypasses (new renderer tests went into their own file rather than pushing `launch-agent-in-new-tab.test.ts` past the 800-line cap)

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Manual: the live measurement above was run against real `codex` 0.147.0 through a pty with a captive hook receiver, which is what establishes the spawn window is hook-free. Not yet exercised: an Electron pass on Windows/Linux, and a live SSH Codex launch.

## AI Disclosure

Claude Opus 5 via Claude Code.

## Review

- **Security** — no new IPC method, command, credential, dependency or persisted secret. The seed reuses `ingestTerminalStatus`, so it passes the same pane-key validation, length bound and disposition checks as OSC-derived status.
- **Cross-platform** — no path, shell, keyboard or platform-conditional code; the capability is a static config flag.
- **Remote / SSH** — the renderer seam is transport-agnostic and publishes through the pane's existing `AgentStatusRouting`, so SSH panes are stamped with their real `connectionId` (covered by the SSH-pane test). The main-process seed is deliberately local-only: it would have to write `connectionId: null`, which would contradict the relay-stamped rows a remote pane's hooks produce.
- **Folder workspaces** — the runtime seed is called on both `createManagedWorktree` branches, git worktree and folder workspace.
- **Backwards compatibility** — no wire, RPC or payload shape change. `initialAgentStatus` is renderer-internal startup metadata and `sessionBoundary` is an existing optional field older clients already handle.
- **Performance** — one extra status publication per agent spawn, replacing a row that would have been published moments later anyway. No polling, no new subscriptions, no hot-path work.
- **Mobile** — mobile reads the same `AgentStatusEntry` rows; a `sessionBoundary` `done` is already the shape it receives from Claude.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
      — targeted lint/format/quality gates, all three `tsc` projects, and the affected + adjacent vitest files were run locally; the full suite and `pnpm build` are left to CI.

## Author

- X / Twitter: @BrennanKB5
