### PR TITLE
fix(opencode): emit a default export the plugin loader accepts (STA-3097)

### DIFF
--- a/src/main/opencode/hook-plugin-module-contract.test.ts
+++ b/src/main/opencode/hook-plugin-module-contract.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const { getPathMock } = vi.hoisted(() => ({
+  getPathMock: vi.fn<(name: string) => string>()
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: getPathMock
+  }
+}))
+
+import { _internals } from './hook-service'
+
+/**
+ * OpenCode loads a plugin file either through a named factory export or through the
+ * module default export. The default-export loader rejects the module outright unless
+ * the default is an object exposing `server()` — verified against opencode 1.18.18,
+ * which logs `failed to load plugin … must default export an object with server()` for
+ * a default of `{ id, setup }` and accepts `{ id, server }`. These tests execute the
+ * generated module so the shipped file is checked against both loaders, not a substring.
+ */
+describe('OpenCode status plugin module contract', () => {
+  type PluginHooks = {
+    event: (input: { event: unknown }) => Promise<void>
+    dispose?: () => Promise<void>
+  }
+  type PluginModule = {
+    default?: { id?: unknown; server?: (ctx: unknown) => Promise<PluginHooks> }
+    OrcaOpenCodeStatusPlugin?: (ctx: unknown) => Promise<PluginHooks>
+  }
+
+  // Why: the plugin resolves hook coords from the endpoint file first and only then from
+  // env. Pin every input here so the run does not depend on the developer's Orca session
+  // (an inherited ORCA_AGENT_HOOK_ENDPOINT would otherwise redirect the post to a live app).
+  const ENV_KEYS = [
+    'ORCA_PANE_KEY',
+    'ORCA_AGENT_HOOK_ENDPOINT',
+    'ORCA_AGENT_HOOK_PORT',
+    'ORCA_AGENT_HOOK_TOKEN'
+  ] as const
+
+  let tempDir: string
+  let savedFetch: typeof globalThis.fetch
+  let savedEnv: Record<string, string | undefined>
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'orca-opencode-plugin-contract-'))
+    savedFetch = globalThis.fetch
+    savedEnv = {}
+    for (const key of ENV_KEYS) {
+      savedEnv[key] = process.env[key]
+    }
+    delete process.env.ORCA_AGENT_HOOK_ENDPOINT
+    process.env.ORCA_AGENT_HOOK_PORT = '59999'
+    process.env.ORCA_AGENT_HOOK_TOKEN = 'test-token'
+  })
+
+  afterEach(() => {
+    globalThis.fetch = savedFetch
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = savedEnv[key]
+      }
+    }
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  async function loadPluginModule(): Promise<PluginModule> {
+    // Why: a unique basename per load defeats the ESM module cache between cases.
+    const pluginPath = join(
+      tempDir,
+      `orca-opencode-status-${Math.random().toString(36).slice(2)}.mjs`
+    )
+    writeFileSync(pluginPath, _internals.getOpenCodePluginSource())
+    return (await import(pathToFileURL(pluginPath).href)) as PluginModule
+  }
+
+  it('exposes a default export carrying a string id and a callable server()', async () => {
+    const module = await loadPluginModule()
+
+    expect(module.default).toBeTypeOf('object')
+    expect(typeof module.default?.id).toBe('string')
+    expect(module.default?.id).toBe('orca-opencode-status')
+    expect(module.default?.server).toBeTypeOf('function')
+  })
+
+  it('rejects the shape OpenCode refuses: a default export without server()', async () => {
+    const module = await loadPluginModule()
+
+    // Why: pins the specific reason the loader fails a module — `setup` alone is not
+    // accepted, so a default export must never regress to it.
+    expect(module.default).not.toBeUndefined()
+    expect(Object.hasOwn(module.default ?? {}, 'server')).toBe(true)
+  })
+
+  it('keeps the named factory export so the factory-based loader still resolves', async () => {
+    const module = await loadPluginModule()
+
+    expect(module.OrcaOpenCodeStatusPlugin).toBeTypeOf('function')
+  })
+
+  it('returns an event handler from the default export server(), like the named factory', async () => {
+    const module = await loadPluginModule()
+
+    const fromDefault = await module.default?.server?.({})
+    const fromNamed = await module.OrcaOpenCodeStatusPlugin?.({})
+
+    expect(fromDefault?.event).toBeTypeOf('function')
+    expect(fromNamed?.event).toBeTypeOf('function')
+  })
+
+  it('reports a session lifecycle event through the hook endpoint when driven via the default export', async () => {
+    process.env.ORCA_PANE_KEY = 'tab-1:leaf-1'
+    const posts: { url: string; body: unknown }[] = []
+    globalThis.fetch = vi.fn(async (input: unknown, init?: { body?: unknown }) => {
+      posts.push({ url: String(input), body: JSON.parse(String(init?.body ?? '{}')) })
+      return { ok: true } as Response
+    }) as unknown as typeof globalThis.fetch
+
+    const module = await loadPluginModule()
+    const hooks = await module.default?.server?.({
+      client: {
+        session: {
+          // Why: a root session (no parentID) must pass the child-session filter,
+          // otherwise every event is dropped before it can post.
+          get: async () => ({ data: { id: 'ses_root', parentID: undefined } })
+        }
+      }
+    })
+
+    await hooks?.event({
+      event: {
+        type: 'session.status',
+        properties: { sessionID: 'ses_root', status: { type: 'busy' } }
+      }
+    })
+    // Why: lifecycle delivery is queued; let the plugin's FIFO drain before asserting.
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    const hookPosts = posts.filter((post) => post.url.includes('/hook/opencode'))
+    expect(hookPosts.length).toBeGreaterThan(0)
+    expect(hookPosts[0]?.body).toMatchObject({
+      paneKey: 'tab-1:leaf-1',
+      payload: { hook_event_name: 'SessionBusy' }
+    })
+  })
+})

--- a/src/main/opencode/hook-service.ts
+++ b/src/main/opencode/hook-service.ts
@@ -994,6 +994,15 @@ export function getOpenCodeFamilyPluginSource(hookPathname: string): string {
     '  },',
     '  };',
     '};',
+    '',
+    '// Why: OpenCode also resolves plugins through the module default export, and that',
+    '// loader rejects the module unless the default exposes `server()` ("must default',
+    '// export an object with server()"). `setup()` does not satisfy it. Keep the named',
+    '// export so the factory-based loader still finds the same instance.',
+    'export default {',
+    '  id: "orca-opencode-status",',
+    '  server: OrcaOpenCodeStatusPlugin,',
+    '};',
     ''
   ].join('\n')
 }


### PR DESCRIPTION
## ELI5

Orca tells OpenCode "here is a plugin file, load it and report status back to me." OpenCode has two ways to find the plugin inside that file: a named export, or the file's `default` export. Orca only wrote the named one. This adds the `default` one too, so both of OpenCode's loaders find it.

## What Changed

`getOpenCodePluginSource()` now appends a default export to the generated `orca-opencode-status.js`:

```js
export default {
  id: "orca-opencode-status",
  server: OrcaOpenCodeStatusPlugin,
};
```

The existing named `OrcaOpenCodeStatusPlugin` factory export is unchanged, so the factory-based loader resolves exactly as before. Both exports hand back the same factory — there is no second implementation to keep in sync.

New test file `src/main/opencode/hook-plugin-module-contract.test.ts` (there was no dedicated test for the plugin module contract). It writes the generated source to disk and `import()`s it, so it checks the module OpenCode actually loads rather than asserting on substrings of the generator.

## Why

STA-3097 reports that `orca-opencode-status.js` fails to load and the sidebar never leaves "Done - OpenCode". The ticket's stated cause is the plugin using a named-export factory where the default export is required.

I verified the contract directly against the installed `opencode 1.18.18` binary rather than working from the ticket, by dropping four differently-shaped plugin files into `$OPENCODE_CONFIG_DIR/plugins/` and reading the startup log:

| default export | named factory export | result |
| --- | --- | --- |
| `{ id, setup }` | — | **rejected**: `failed to load plugin … must default export an object with server()` |
| `{ id, server }` | — | loads |
| — | factory | loads |
| `{ id, server, setup }` | factory | loads |

Two things follow, and both shaped this PR:

1. **The required key is `server()`, not `setup()`.** A default export built around `setup` is rejected outright. `@opencode-ai/plugin@1.18.18`'s `v2/promise` `PluginContext` also has no `event` member (`options`, `agent`, `aisdk`, `catalog`, `command`, `integration`, `plugin`, `reference`, `skill`), so a `setup`-based handler has no session-event stream to subscribe to.
2. **The current named-export-only plugin is not rejected by 1.18.18.** The load failure in the ticket does not reproduce on this version, so this change is compatibility hardening for the default-export loader, not a fix for a break I could observe on 1.18.18. I want that stated plainly rather than implied.

## Linked Issue

STA-3097 — OpenCode status plugin (`orca-opencode-status.js`) fails to load under opencode V2.

Supersedes #11792, which targets the same defect. That PR emits `{ id, server, setup }` and its tests assert `setup: async (ctx) =>` plus `ctx?.event?.subscribe`. The `server` key is what the loader actually requires, so its module does load; the `setup` half is unreachable given the context type above. This PR ships only the part the loader reads and pins the contract with an executable test.

Fixes #

## Visual Proof

`N/A` — no UI, layout, or styling change. The change is one export added to a generated plugin file. The observable effect is whether OpenCode's default-export loader can resolve the plugin; evidence is the live capture under Testing.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Platform: macOS (Apple silicon), `opencode 1.18.18` installed via Homebrew.

**Live end-to-end, real binary, with the fix applied.** Generated the patched plugin, placed it in an isolated `OPENCODE_CONFIG_DIR`, pointed `ORCA_AGENT_HOOK_ENDPOINT` at a scratch endpoint file targeting a local sink, and ran a real turn:

```
load errors: 0
turn output: "Hi!"
hook POSTs to /hook/opencode: 5
  2 "hook_event_name":"SessionBusy"
  2 "hook_event_name":"MessagePart"
  1 "hook_event_name":"SessionIdle"
```

That is the full working → done lifecycle, so the added default export does not disturb the path that already works. A caveat worth recording: the endpoint file outranks `process.env` in `resolveHookCoords()`, so an inherited `ORCA_AGENT_HOOK_ENDPOINT` from a live Orca session silently redirects these posts to the running app. My first capture read as "zero posts" for exactly that reason before I pinned the endpoint file.

**Unit tests** — 5 cases; 4 fail with the fix reverted, verified by removing the default export and re-running:

```
× exposes a default export carrying a string id and a callable server()
× rejects the shape OpenCode refuses: a default export without server()
× returns an event handler from the default export server(), like the named factory
× reports a session lifecycle event through the hook endpoint when driven via the default export
```

The fifth (`keeps the named factory export…`) passes either way by design — it guards the export this PR must not remove. The last case drives a `session.status` busy event through `default.server()` and asserts a `SessionBusy` POST with the right `paneKey`, so it covers behaviour rather than module shape alone.

The test pins `ORCA_AGENT_HOOK_ENDPOINT`/`PORT`/`TOKEN` itself. Confirmed it passes both with a developer's Orca environment inherited and under `env -u` with those variables stripped — without that pinning it passed locally and would have failed in CI.

```
pnpm exec vitest run --config config/vitest.config.ts src/main/opencode/   # 7 files, 99 tests pass
pnpm exec oxlint --config config/oxlint-code-quality-native-plugins.json <changed files> --deny-warnings   # clean
pnpm exec oxlint --type-aware --config config/oxlint-code-quality-type-aware.json <changed files> --deny-warnings   # clean
pnpm exec oxfmt --check <changed files>   # clean
```

Full typecheck deliberately not run (OOM risk); both changed files are `src/main/`-only and covered by the type-aware lint above.

## Review

- **Security**: no new input handling, no command execution, no path interpolation. The added object is static and references the existing factory; the token/port path is untouched.
- **Cross-platform**: the plugin file is generated identically on macOS, Linux, and Windows — no path, shell, or platform branch is involved. `getEndpointFileName()` already handles the `endpoint.env` / `endpoint.cmd` split and is not touched.
- **Remote SSH / WSL**: the plugin is written into the OpenCode config dir wherever OpenCode runs; adding an export does not change transport or the hook POST target.
- **Mobile / remote clients**: no wire change. Status still arrives over the existing `/hook/opencode` POST.
- **Backwards compatibility**: additive. Older OpenCode builds that read only the named factory export are unaffected — verified above that a module carrying both exports loads on 1.18.18.
- **Performance**: none; one extra object literal in a generated file.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] Focused lint / tests pass locally; full `pnpm typecheck` / `pnpm build` left to CI

## Author

- X / Twitter: @BrennanKB5
