### PR TITLE
fix(agent-status): say what an OpenCode permission request is waiting on (STA-3160)

### DIFF
--- a/src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx
@@ -348,6 +348,45 @@ describe('DashboardAgentRow', () => {
     expect(activeToolMarkup).toContain('ListDir')
   })
 
+  it('names what a blocked approval is waiting on', () => {
+    const markup = renderRow(
+      makeAgent(
+        { state: 'waiting' },
+        { state: 'waiting', toolName: 'bash', toolInput: 'rm -rf build/' }
+      )
+    )
+
+    // Why: a permission request parks the row on 'waiting'; without the tool line the row
+    // is a bare amber dot that cannot say what the user is being asked to approve.
+    expect(markup).toContain('lucide-wrench')
+    expect(markup).toContain('bash')
+    expect(markup).toContain('rm -rf build/')
+  })
+
+  it('leaves a wait without tool metadata unchanged', () => {
+    const markup = renderRow(makeAgent({ state: 'waiting' }, { state: 'waiting' }))
+
+    // Why: the height placeholder exists because a working row's tool line is imminent.
+    // A question-style wait has nothing coming, so reserving the row would just add a gap.
+    expect(markup).not.toContain('data-agent-row-tool-slot=""')
+    expect(markup).not.toContain('lucide-wrench')
+  })
+
+  it('keeps a resolved tool off a finished row', () => {
+    for (const state of ['done', 'blocked', 'idle'] as const) {
+      const markup = renderRow(
+        makeAgent(
+          { state },
+          // Why: 'idle' is a row-only state; the entry it is derived from still reports 'done'.
+          { state: state === 'idle' ? 'done' : state, toolName: 'bash', toolInput: 'rm -rf build/' }
+        )
+      )
+
+      expect(markup).not.toContain('lucide-wrench')
+      expect(markup).not.toContain('rm -rf build/')
+    }
+  })
+
   it('renders orchestration child rows with a connector and tree level', () => {
     const markup = renderRow(
       makeAgent({

--- a/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
@@ -8,6 +8,7 @@ import { DashboardAgentChildDisclosure } from './DashboardAgentChildDisclosure'
 import { DashboardAgentRowMessage } from './DashboardAgentRowMessage'
 import { DashboardAgentRowTrailingControls } from './DashboardAgentRowTrailingControls'
 import { DashboardAgentRowToolStep } from './DashboardAgentRowToolStep'
+import { showsAgentToolPreview } from '@/lib/agent-row-tool-preview'
 import type { AgentStatusState } from '../../../../shared/agent-status-types'
 import type { DashboardAgentRow as DashboardAgentRowData } from './useDashboardData'
 import { getAgentRowPrimaryText } from '@/lib/agent-row-primary-text'
@@ -144,10 +145,12 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
   // Why: prompt is '' when unknown, so fall back to the state label to keep the row labeled.
   const displayLabel = prompt || agentStateLabel(asDotState(agent.state))
   const model = agent.entry.model?.trim() ?? ''
-  // Why: gate tool fields on 'working' — a stale tool line on a done row reads as still-running.
   const isWorking = agent.state === 'working'
-  const toolName = isWorking ? (agent.entry.toolName?.trim() ?? '') : ''
-  const toolInput = isWorking ? (agent.entry.toolInput?.trim() ?? '') : ''
+  // Why: 'working' names the running tool and 'waiting' names what an approval is blocked on;
+  // anywhere else a leftover tool line reads as still-running. See showsAgentToolPreview.
+  const showsTool = showsAgentToolPreview(agent.state)
+  const toolName = showsTool ? (agent.entry.toolName?.trim() ?? '') : ''
+  const toolInput = showsTool ? (agent.entry.toolInput?.trim() ?? '') : ''
   const lastAssistantMessage = agent.entry.lastAssistantMessage?.trim() ?? ''
   const isInterrupted = agent.entry.interrupted === true
   const lineage = agent.lineage
@@ -300,7 +303,8 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
       </div>
       <DashboardAgentRowToolStep
         expanded={expanded}
-        isWorking={isWorking}
+        showsTool={showsTool}
+        reservesHeight={isWorking}
         toolName={toolName}
         toolInput={toolInput}
       />

--- a/src/renderer/src/components/dashboard/DashboardAgentRowToolStep.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRowToolStep.tsx
@@ -3,18 +3,21 @@ import { cn } from '@/lib/utils'
 
 type DashboardAgentRowToolStepProps = {
   expanded: boolean
-  isWorking: boolean
+  showsTool: boolean
+  /** Hold the slot open while tool metadata is still in flight — see the empty branch below. */
+  reservesHeight: boolean
   toolName: string
   toolInput: string
 }
 
 export function DashboardAgentRowToolStep({
   expanded,
-  isWorking,
+  showsTool,
+  reservesHeight,
   toolName,
   toolInput
 }: DashboardAgentRowToolStepProps): React.JSX.Element | null {
-  if (!isWorking) {
+  if (!showsTool || (!toolName && !reservesHeight)) {
     return null
   }
 

--- a/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
@@ -8,6 +8,7 @@ import { cn } from '@/lib/utils'
 import { getAgentDotState } from './worktree-card-agent-summary'
 import { translate } from '@/i18n/i18n'
 import { getAgentRowPrimaryText } from '@/lib/agent-row-primary-text'
+import { formatAgentToolPreview } from '@/lib/agent-row-tool-preview'
 import { useAgentRowConversationName } from '@/components/dashboard/use-agent-row-conversation-name'
 import { lastEnteredDoneAt } from '@/components/dashboard/agent-finished-timestamp'
 import CacheTimer, { usePromptCacheCountdownForPane } from './CacheTimer'
@@ -40,15 +41,9 @@ function getCompactAgentSecondary(agent: DashboardAgentRowData): string {
   if (agent.entry.interrupted === true) {
     return 'Interrupted by user'
   }
-  if (agent.state === 'working') {
-    const toolName = agent.entry.toolName?.trim() ?? ''
-    const toolInput = agent.entry.toolInput?.trim() ?? ''
-    if (toolName && toolInput) {
-      return `${toolName}: ${toolInput}`
-    }
-    if (toolName) {
-      return toolName
-    }
+  const toolPreview = formatAgentToolPreview(agent.entry, agent.state)
+  if (toolPreview) {
+    return toolPreview
   }
   const lastAssistantMessage = agent.entry.lastAssistantMessage?.trim()
   if (lastAssistantMessage) {

--- a/src/renderer/src/lib/activity-thread-display.test.ts
+++ b/src/renderer/src/lib/activity-thread-display.test.ts
@@ -200,6 +200,44 @@ describe('getActivityThreadStatusPreview', () => {
       })
     ).toBe('Interrupted by user')
   })
+
+  it('names what a blocked approval is waiting on', () => {
+    // Why: a permission request parks the row on 'waiting', and the tool fields are the
+    // only thing that says what the user is being asked to approve (STA-3160).
+    expect(
+      getActivityThreadStatusPreview({
+        state: 'waiting',
+        toolName: 'bash',
+        toolInput: 'rm -rf build/',
+        prompt: 'Clean the build'
+      })
+    ).toBe('bash: rm -rf build/')
+  })
+
+  it('keeps a resolved tool off a finished row', () => {
+    // Why: tool fields outlive the turn that set them; showing them once the agent is done
+    // or idle reads as work still in flight.
+    for (const state of ['done', 'blocked'] as const) {
+      expect(
+        getActivityThreadStatusPreview({
+          state,
+          toolName: 'bash',
+          toolInput: 'rm -rf build/',
+          prompt: 'Clean the build'
+        })
+      ).toBe('')
+    }
+  })
+
+  it('shows nothing on a wait that carries no tool', () => {
+    // Why: not every wait is an approval — a question-style wait must not borrow tool text.
+    expect(
+      getActivityThreadStatusPreview({
+        state: 'waiting',
+        prompt: 'Pick a branch'
+      })
+    ).toBe('')
+  })
 })
 
 describe('resolveActivityThreadStatusPreview', () => {

--- a/src/renderer/src/lib/activity-thread-display.ts
+++ b/src/renderer/src/lib/activity-thread-display.ts
@@ -10,6 +10,7 @@ import {
   isOrcaDispatchPrompt,
   orchestrationLabelsMatchLiveDispatch
 } from './agent-row-primary-text'
+import { formatAgentToolPreview } from './agent-row-tool-preview'
 
 // Why: follow-up replies ("yes", "ok proceed") are valid hook prompts but are
 // terrible scan labels for a cross-worktree agent list — treat them as non-titles.
@@ -164,15 +165,9 @@ export function getActivityThreadStatusPreview(
     return 'Interrupted by user'
   }
   const state = agentState ?? entry.state
-  if (state === 'working') {
-    const toolName = entry.toolName?.trim() ?? ''
-    const toolInput = entry.toolInput?.trim() ?? ''
-    if (toolName && toolInput) {
-      return `${toolName}: ${toolInput}`
-    }
-    if (toolName) {
-      return toolName
-    }
+  const toolPreview = formatAgentToolPreview(entry, state)
+  if (toolPreview) {
+    return toolPreview
   }
   const assistant = entry.lastAssistantMessage?.trim() ?? ''
   if (assistant && !isMislabeledUserPrompt(assistant, entry)) {

--- a/src/renderer/src/lib/agent-row-tool-preview.test.ts
+++ b/src/renderer/src/lib/agent-row-tool-preview.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { AGENT_STATUS_STATES } from '../../../shared/agent-status-types'
+import type { AgentRowState } from './agent-row-tool-preview'
+import { formatAgentToolPreview, showsAgentToolPreview } from './agent-row-tool-preview'
+
+const TOOL = { toolName: 'bash', toolInput: 'rm -rf build/' }
+const ROW_STATES: readonly AgentRowState[] = [...AGENT_STATUS_STATES, 'idle']
+
+describe('showsAgentToolPreview', () => {
+  it('covers exactly the two states whose tool fields describe live work', () => {
+    // Why: enumerate every row state so a new one has to make this decision explicitly
+    // rather than defaulting into showing a stale tool.
+    const showing = ROW_STATES.filter((state) => showsAgentToolPreview(state))
+
+    expect(showing).toEqual(['working', 'waiting'])
+  })
+
+  it('shows nothing when the state is unknown', () => {
+    expect(showsAgentToolPreview(null)).toBe(false)
+    expect(showsAgentToolPreview(undefined)).toBe(false)
+  })
+})
+
+describe('formatAgentToolPreview', () => {
+  it('names what a blocked approval is waiting on', () => {
+    expect(formatAgentToolPreview(TOOL, 'waiting')).toBe('bash: rm -rf build/')
+  })
+
+  it('names the running tool while working', () => {
+    expect(formatAgentToolPreview(TOOL, 'working')).toBe('bash: rm -rf build/')
+  })
+
+  it('keeps a resolved tool off every other state', () => {
+    for (const state of ROW_STATES.filter((candidate) => !showsAgentToolPreview(candidate))) {
+      expect(formatAgentToolPreview(TOOL, state)).toBe('')
+    }
+  })
+
+  it('shows nothing on a wait that carries no tool', () => {
+    // Why: a question-style wait sets no tool fields; it must not borrow an earlier one.
+    expect(formatAgentToolPreview({}, 'waiting')).toBe('')
+  })
+
+  it('falls back to the bare tool name when the input is not previewable', () => {
+    expect(formatAgentToolPreview({ toolName: 'edit' }, 'waiting')).toBe('edit')
+  })
+
+  it('ignores whitespace-only fields', () => {
+    expect(formatAgentToolPreview({ toolName: '  ', toolInput: '  ' }, 'working')).toBe('')
+  })
+})

--- a/src/renderer/src/lib/agent-row-tool-preview.ts
+++ b/src/renderer/src/lib/agent-row-tool-preview.ts
@@ -1,0 +1,32 @@
+import type { AgentStatusEntry, AgentStatusState } from '../../../shared/agent-status-types'
+
+/** Row states, which add the renderer-only 'idle' to the hook-reported statuses. */
+export type AgentRowState = AgentStatusState | 'idle'
+
+/**
+ * States whose cached tool fields describe live work: 'working' names the tool the agent is
+ * running, 'waiting' names the tool a permission request is blocked on. Tool fields outlive
+ * the turn that set them, so on any other state they read as work still in flight.
+ *
+ * Shared because three surfaces render this line — the sidebar's compact row, the dashboard
+ * row, and the activity thread — and a rule that only two of them relax is a rule that lies.
+ */
+export function showsAgentToolPreview(state: AgentRowState | null | undefined): boolean {
+  return state === 'working' || state === 'waiting'
+}
+
+/** One-line `tool: input` preview, or '' when the state or the entry has nothing to show. */
+export function formatAgentToolPreview(
+  entry: Pick<AgentStatusEntry, 'toolName' | 'toolInput'>,
+  state: AgentRowState | null | undefined
+): string {
+  if (!showsAgentToolPreview(state)) {
+    return ''
+  }
+  const toolName = entry.toolName?.trim() ?? ''
+  const toolInput = entry.toolInput?.trim() ?? ''
+  if (toolName && toolInput) {
+    return `${toolName}: ${toolInput}`
+  }
+  return toolName
+}

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -1774,6 +1774,17 @@ function extractAmpToolFields(
   return {}
 }
 
+/**
+ * Retires any cached tool fields. PermissionRequest is the only OpenCode-family event that
+ * carries them, and isNewTurnEvent is false for this family, so nothing else ever resets the
+ * cache — without an explicit retire, resolveToolState inherits one answered permission onto
+ * every later frame in the pane and the row reads a resolved command as the live tool.
+ */
+const OPENCODE_TOOL_FIELDS_RETIRED: ToolSnapshot = {
+  hasToolUpdate: true,
+  hasToolInputField: true
+}
+
 function extractOpenCodeToolFields(
   eventName: unknown,
   hookPayload: Record<string, unknown>
@@ -1781,7 +1792,7 @@ function extractOpenCodeToolFields(
   if (eventName === 'MessagePart' && hookPayload.role === 'assistant') {
     const text = readString(hookPayload, 'text')
     if (text) {
-      return { lastAssistantMessage: capOpenCodeHookText(text) }
+      return { ...OPENCODE_TOOL_FIELDS_RETIRED, lastAssistantMessage: capOpenCodeHookText(text) }
     }
   }
   if (eventName === 'AskUserQuestion') {
@@ -1790,7 +1801,7 @@ function extractOpenCodeToolFields(
       ? hookPayload.tool_input
       : stripHookEnvelopeKeys(hookPayload)
     return {
-      hasToolUpdate: true,
+      ...OPENCODE_TOOL_FIELDS_RETIRED,
       interactivePrompt: deriveInteractivePrompt('AskUserQuestion', toolInputSource)
     }
   }
@@ -1798,11 +1809,16 @@ function extractOpenCodeToolFields(
     // Why: the payload is permission.asked's event.properties — `permission` names what is
     // being requested and `metadata`/`patterns` say which command or path it covers. Without
     // them the row is a bare 'waiting' that cannot tell the user what to approve.
+    // The SDK types `metadata` as Record<string, unknown>, so these keys come from the tools
+    // themselves: bash sends `command`, edit sends `filepath`, webfetch sends `url` (verified
+    // against opencode 1.18.18). `file_path`/`path` cover tools that spell it the common way.
+    // `diff` is deliberately absent — edit ships the whole patch and it would swamp the row.
     const metadata = hookPayload.metadata
     const metadataInput =
       metadata !== null && typeof metadata === 'object' && !Array.isArray(metadata)
         ? readFirstString(metadata as Record<string, unknown>, [
             'command',
+            'filepath',
             'file_path',
             'path',
             'url'
@@ -1821,7 +1837,7 @@ function extractOpenCodeToolFields(
       { hasToolInputField: hasAnyOwnField(hookPayload, ['metadata', 'patterns']) }
     )
   }
-  return {}
+  return OPENCODE_TOOL_FIELDS_RETIRED
 }
 
 function extractCursorToolFields(

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -1794,6 +1794,33 @@ function extractOpenCodeToolFields(
       interactivePrompt: deriveInteractivePrompt('AskUserQuestion', toolInputSource)
     }
   }
+  if (eventName === 'PermissionRequest') {
+    // Why: the payload is permission.asked's event.properties — `permission` names what is
+    // being requested and `metadata`/`patterns` say which command or path it covers. Without
+    // them the row is a bare 'waiting' that cannot tell the user what to approve.
+    const metadata = hookPayload.metadata
+    const metadataInput =
+      metadata !== null && typeof metadata === 'object' && !Array.isArray(metadata)
+        ? readFirstString(metadata as Record<string, unknown>, [
+            'command',
+            'file_path',
+            'path',
+            'url'
+          ])
+        : undefined
+    const patterns = Array.isArray(hookPayload.patterns)
+      ? hookPayload.patterns.filter(
+          (pattern): pattern is string => typeof pattern === 'string' && pattern.length > 0
+        )
+      : []
+    return toolUpdate(
+      {
+        toolName: readString(hookPayload, 'permission'),
+        toolInput: metadataInput ?? (patterns.length > 0 ? patterns.join(', ') : undefined)
+      },
+      { hasToolInputField: hasAnyOwnField(hookPayload, ['metadata', 'patterns']) }
+    )
+  }
   return {}
 }
 

--- a/src/shared/opencode-permission-status.test.ts
+++ b/src/shared/opencode-permission-status.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createHookListenerState, normalizeHookPayload } from './agent-hook-listener'
+import { makePaneKey } from './stable-pane-id'
+
+const PANE_KEY = makePaneKey('tab-1', '11111111-1111-4111-8111-111111111111')
+
+/**
+ * OpenCode reports an approval prompt as `permission.asked`; the status plugin forwards
+ * that event's `properties` under `hook_event_name: 'PermissionRequest'`. The shape is
+ * fixed by @opencode-ai/sdk 1.18.18 (`EventPermissionAsked`): `permission` names what is
+ * being requested, `patterns` carries the concrete commands/paths it applies to, and
+ * `metadata` holds tool-specific detail.
+ *
+ * `normalizeOpenCodeFamilyEvent` serves opencode and mimo-code from one path, so every
+ * case here runs for both.
+ */
+describe('OpenCode-family permission request status', () => {
+  let state: ReturnType<typeof createHookListenerState>
+
+  beforeEach(() => {
+    state = createHookListenerState()
+  })
+
+  const SOURCES = ['opencode', 'mimo-code'] as const
+
+  function permissionEvent(
+    source: (typeof SOURCES)[number],
+    properties: Record<string, unknown>
+  ): ReturnType<typeof normalizeHookPayload> {
+    return normalizeHookPayload(
+      state,
+      source,
+      {
+        paneKey: PANE_KEY,
+        payload: { hook_event_name: 'PermissionRequest', ...properties }
+      },
+      'production'
+    )
+  }
+
+  const BASH_PERMISSION = {
+    id: 'per_01',
+    sessionID: 'ses_root',
+    permission: 'bash',
+    patterns: ['rm -rf build/'],
+    metadata: { command: 'rm -rf build/' },
+    always: []
+  }
+
+  it.each(SOURCES)('reports a permission request as waiting for %s', (source) => {
+    const event = permissionEvent(source, BASH_PERMISSION)
+
+    expect(event?.payload.state).toBe('waiting')
+    expect(event?.payload.agentType).toBe(source)
+  })
+
+  it.each(SOURCES)('names the requested permission as the tool for %s', (source) => {
+    const event = permissionEvent(source, BASH_PERMISSION)
+
+    // Why: a bare `waiting` row cannot tell the user what is blocked; the permission
+    // name is the only field that always identifies it (STA-3160).
+    expect(event?.payload.toolName).toBe('bash')
+  })
+
+  it.each(SOURCES)('surfaces the blocked command as tool input for %s', (source) => {
+    const event = permissionEvent(source, BASH_PERMISSION)
+
+    expect(event?.payload.toolInput).toBe('rm -rf build/')
+  })
+
+  it.each(SOURCES)('falls back to patterns when metadata carries no command for %s', (source) => {
+    const event = permissionEvent(source, {
+      id: 'per_02',
+      sessionID: 'ses_root',
+      permission: 'edit',
+      patterns: ['src/main/**'],
+      metadata: {},
+      always: []
+    })
+
+    expect(event?.payload.toolName).toBe('edit')
+    expect(event?.payload.toolInput).toBe('src/main/**')
+  })
+
+  it.each(SOURCES)('joins multiple patterns for %s', (source) => {
+    const event = permissionEvent(source, {
+      id: 'per_03',
+      sessionID: 'ses_root',
+      permission: 'edit',
+      patterns: ['src/a.ts', 'src/b.ts'],
+      metadata: {},
+      always: []
+    })
+
+    expect(event?.payload.toolInput).toBe('src/a.ts, src/b.ts')
+  })
+
+  it.each(SOURCES)(
+    'still reports waiting when the payload names no permission for %s',
+    (source) => {
+      // Why: an unrecognized/absent permission must not downgrade the blocked state — the
+      // user still has to answer, they just get less detail.
+      const event = permissionEvent(source, { id: 'per_04', sessionID: 'ses_root' })
+
+      expect(event?.payload.state).toBe('waiting')
+      expect(event?.payload.toolName).toBeUndefined()
+    }
+  )
+
+  it.each(SOURCES)('leaves the AskUserQuestion route untouched for %s', (source) => {
+    const properties = { questions: [{ question: 'Choose', options: ['x', 'y'] }] }
+    const event = normalizeHookPayload(
+      state,
+      source,
+      {
+        paneKey: PANE_KEY,
+        payload: { hook_event_name: 'AskUserQuestion', ...properties }
+      },
+      'production'
+    )
+
+    expect(event?.payload.state).toBe('waiting')
+    expect(event?.payload.interactivePrompt).toBe(JSON.stringify(properties))
+  })
+
+  it.each(SOURCES)('clears permission metadata once the turn resumes for %s', (source) => {
+    permissionEvent(source, BASH_PERMISSION)
+    const resumed = normalizeHookPayload(
+      state,
+      source,
+      { paneKey: PANE_KEY, payload: { hook_event_name: 'SessionBusy' } },
+      'production'
+    )
+
+    // Why: a stale approval card must not outlive the approval — once work resumes the
+    // row is working again and the blocked command is no longer what the pane is on.
+    expect(resumed?.payload.state).toBe('working')
+  })
+})

--- a/src/shared/opencode-permission-status.test.ts
+++ b/src/shared/opencode-permission-status.test.ts
@@ -11,6 +11,11 @@ const PANE_KEY = makePaneKey('tab-1', '11111111-1111-4111-8111-111111111111')
  * being requested, `patterns` carries the concrete commands/paths it applies to, and
  * `metadata` holds tool-specific detail.
  *
+ * Only those outer names are typed — `metadata` is `Record<string, unknown>`, so the keys
+ * inside it come from each tool. The payloads below were captured from a live opencode
+ * 1.18.18 rather than invented, because the first version of this suite guessed a shape
+ * (`metadata: {}`) that OpenCode never emits and so never exercised the real `edit` path.
+ *
  * `normalizeOpenCodeFamilyEvent` serves opencode and mimo-code from one path, so every
  * case here runs for both.
  */
@@ -34,6 +39,19 @@ describe('OpenCode-family permission request status', () => {
         paneKey: PANE_KEY,
         payload: { hook_event_name: 'PermissionRequest', ...properties }
       },
+      'production'
+    )
+  }
+
+  function lifecycleEvent(
+    source: (typeof SOURCES)[number],
+    eventName: string,
+    properties: Record<string, unknown> = {}
+  ): ReturnType<typeof normalizeHookPayload> {
+    return normalizeHookPayload(
+      state,
+      source,
+      { paneKey: PANE_KEY, payload: { hook_event_name: eventName, ...properties } },
       'production'
     )
   }
@@ -68,30 +86,68 @@ describe('OpenCode-family permission request status', () => {
     expect(event?.payload.toolInput).toBe('rm -rf build/')
   })
 
-  it.each(SOURCES)('falls back to patterns when metadata carries no command for %s', (source) => {
+  it.each(SOURCES)('names the edited file for %s', (source) => {
+    // Captured verbatim from opencode 1.18.18 — an `edit` request keys its path as
+    // `filepath` (one word) and ships the whole patch alongside it.
     const event = permissionEvent(source, {
       id: 'per_02',
       sessionID: 'ses_root',
       permission: 'edit',
-      patterns: ['src/main/**'],
-      metadata: {},
-      always: []
+      patterns: ['private/tmp/oc-perm-probe/notes.md'],
+      metadata: {
+        filepath: '/private/tmp/oc-perm-probe/notes.md',
+        diff: '@@ -0,0 +1,1 @@\n+hello world\n\\ No newline at end of file\n'
+      },
+      always: ['*']
     })
 
     expect(event?.payload.toolName).toBe('edit')
-    expect(event?.payload.toolInput).toBe('src/main/**')
+    expect(event?.payload.toolInput).toBe('/private/tmp/oc-perm-probe/notes.md')
   })
 
-  it.each(SOURCES)('joins multiple patterns for %s', (source) => {
+  it.each(SOURCES)('never previews a diff as the blocked target for %s', (source) => {
     const event = permissionEvent(source, {
       id: 'per_03',
       sessionID: 'ses_root',
       permission: 'edit',
-      patterns: ['src/a.ts', 'src/b.ts'],
-      metadata: {},
+      patterns: ['src/a.ts'],
+      metadata: { diff: '@@ -1 +1 @@\n-before\n+after\n' },
       always: []
     })
 
+    // Why: `diff` is the largest field OpenCode sends and would swamp a one-line row.
+    expect(event?.payload.toolInput).not.toContain('@@')
+  })
+
+  it.each(SOURCES)('names the fetched url for %s', (source) => {
+    // Captured verbatim from opencode 1.18.18.
+    const event = permissionEvent(source, {
+      id: 'per_04',
+      sessionID: 'ses_root',
+      permission: 'webfetch',
+      patterns: ['https://example.com'],
+      metadata: { url: 'https://example.com', format: 'markdown' },
+      always: ['*']
+    })
+
+    expect(event?.payload.toolName).toBe('webfetch')
+    expect(event?.payload.toolInput).toBe('https://example.com')
+  })
+
+  it.each(SOURCES)('falls back to patterns when metadata is unrecognized for %s', (source) => {
+    // Why: `metadata` is typed `Record<string, unknown>` by the SDK, so a tool Orca has
+    // never seen (an MCP server's, say) can key its detail anything — patterns is the one
+    // field every permission carries.
+    const event = permissionEvent(source, {
+      id: 'per_05',
+      sessionID: 'ses_root',
+      permission: 'some_mcp_tool',
+      patterns: ['src/a.ts', 'src/b.ts'],
+      metadata: { unrecognizedKey: 'ignored' },
+      always: []
+    })
+
+    expect(event?.payload.toolName).toBe('some_mcp_tool')
     expect(event?.payload.toolInput).toBe('src/a.ts, src/b.ts')
   })
 
@@ -100,7 +156,7 @@ describe('OpenCode-family permission request status', () => {
     (source) => {
       // Why: an unrecognized/absent permission must not downgrade the blocked state — the
       // user still has to answer, they just get less detail.
-      const event = permissionEvent(source, { id: 'per_04', sessionID: 'ses_root' })
+      const event = permissionEvent(source, { id: 'per_06', sessionID: 'ses_root' })
 
       expect(event?.payload.state).toBe('waiting')
       expect(event?.payload.toolName).toBeUndefined()
@@ -125,15 +181,75 @@ describe('OpenCode-family permission request status', () => {
 
   it.each(SOURCES)('clears permission metadata once the turn resumes for %s', (source) => {
     permissionEvent(source, BASH_PERMISSION)
-    const resumed = normalizeHookPayload(
-      state,
-      source,
-      { paneKey: PANE_KEY, payload: { hook_event_name: 'SessionBusy' } },
-      'production'
-    )
+    const resumed = lifecycleEvent(source, 'SessionBusy')
 
     // Why: a stale approval card must not outlive the approval — once work resumes the
     // row is working again and the blocked command is no longer what the pane is on.
     expect(resumed?.payload.state).toBe('working')
+    expect(resumed?.payload.toolName).toBeUndefined()
+    expect(resumed?.payload.toolInput).toBeUndefined()
+  })
+
+  it.each(SOURCES)('retires the permission when the session goes idle for %s', (source) => {
+    permissionEvent(source, BASH_PERMISSION)
+    const idle = lifecycleEvent(source, 'SessionIdle')
+
+    expect(idle?.payload.state).toBe('done')
+    expect(idle?.payload.toolName).toBeUndefined()
+    expect(idle?.payload.toolInput).toBeUndefined()
+  })
+
+  it.each(SOURCES)(
+    'does not label a later question with the answered permission for %s',
+    (source) => {
+      permissionEvent(source, BASH_PERMISSION)
+      const question = lifecycleEvent(source, 'AskUserQuestion', {
+        questions: [{ question: 'Choose', options: ['x', 'y'] }]
+      })
+
+      expect(question?.payload.state).toBe('waiting')
+      expect(question?.payload.toolName).toBeUndefined()
+      expect(question?.payload.toolInput).toBeUndefined()
+    }
+  )
+
+  it.each(SOURCES)('does not attribute the answered permission to a reply for %s', (source) => {
+    permissionEvent(source, BASH_PERMISSION)
+    const part = lifecycleEvent(source, 'MessagePart', { role: 'assistant', text: 'Ran it.' })
+
+    expect(part?.payload.lastAssistantMessage).toBe('Ran it.')
+    expect(part?.payload.toolName).toBeUndefined()
+    expect(part?.payload.toolInput).toBeUndefined()
+  })
+
+  it.each(SOURCES)('does not carry an answered permission into a later wait for %s', (source) => {
+    // Why: the row now shows tool fields on 'waiting' as well as 'working' (that is the whole
+    // point of STA-3160), so a later non-permission wait must arrive with none — otherwise
+    // relaxing the row gate turns an answered command into the question's caption.
+    permissionEvent(source, BASH_PERMISSION)
+    lifecycleEvent(source, 'SessionBusy')
+    lifecycleEvent(source, 'SessionIdle')
+    const laterQuestion = lifecycleEvent(source, 'AskUserQuestion', {
+      questions: [{ question: 'Which branch?', options: ['main', 'dev'] }]
+    })
+
+    expect(laterQuestion?.payload.state).toBe('waiting')
+    expect(laterQuestion?.payload.toolInput).toBeUndefined()
+    expect(laterQuestion?.payload.toolName).toBeUndefined()
+  })
+
+  it.each(SOURCES)('does not carry an answered permission into a later turn for %s', (source) => {
+    // Why: isNewTurnEvent is false for this family, so nothing else ever resets the cached
+    // tool. Without an explicit retire, one permission pins its command to every later
+    // working frame in the pane — the exact stale-tool-line the row gate guards against.
+    permissionEvent(source, BASH_PERMISSION)
+    lifecycleEvent(source, 'SessionBusy')
+    lifecycleEvent(source, 'SessionIdle')
+    const laterTurn = lifecycleEvent(source, 'SessionBusy')
+
+    expect(laterTurn?.payload.state).toBe('working')
+    // Why: assert the command first — it is the string a user would misread as live work.
+    expect(laterTurn?.payload.toolInput).toBeUndefined()
+    expect(laterTurn?.payload.toolName).toBeUndefined()
   })
 })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​383 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​383 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​100 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​28 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​72 |

<!-- /orca-pr-loc -->

## ELI5

When OpenCode stops to ask "can I run this command?", Orca's sidebar showed the pane as waiting — but not *what* it was waiting on. You could see it was blocked and had no way to tell whether it wanted to run `echo hi` or `rm -rf build/` without switching to the pane. This fills in the tool name and the command.

## What Changed

**1. The hook listener learns what a permission is asking for.** A `PermissionRequest` branch in `extractOpenCodeToolFields` (`src/shared/agent-hook-listener.ts`):

- `toolName` ← `permission` (what is being requested, e.g. `bash`, `edit`)
- `toolInput` ← a string from `metadata` (`command` / `filepath` / `file_path` / `path` / `url`), else `patterns` joined

Plus `OPENCODE_TOOL_FIELDS_RETIRED`: `PermissionRequest` is the only OpenCode-family event carrying tool fields and `isNewTurnEvent` is false for this family, so without an explicit retire `resolveToolState` would inherit one answered permission onto every later frame in the pane.

Field names are not guessed — they are the ones `@opencode-ai/sdk@1.18.18` fixes for `EventPermissionAsked`:

```ts
properties: {
  id: string; sessionID: string;
  permission: string;
  patterns: Array<string>;
  metadata: { [key: string]: unknown };
  always: Array<string>;
  tool?: { messageID: string; callID: string };
}
```

The status plugin forwards that event's `properties` verbatim (plus `sessionID` and the envelope), so those fields arrive at the top level of the hook payload.

**2. The row actually shows it.** The tool preview was gated on `state === 'working'`, so a `waiting` row dropped the fields the listener had just populated. New shared `src/renderer/src/lib/agent-row-tool-preview.ts` exports `showsAgentToolPreview` (`'working' || 'waiting'`) and `formatAgentToolPreview`, and the three surfaces that render this line adopt it:

- `worktree-card-compact-agent-row.tsx` — the sidebar row
- `activity-thread-display.ts` — the activity thread
- `DashboardAgentRow.tsx` / `DashboardAgentRowToolStep.tsx` — the dashboard row, where `isWorking` splits into `showsTool` (does this state show a tool line) and `reservesHeight` (hold the slot open while metadata is in flight), so a `waiting` row shows the tool without a `working` row losing its reserved height.

It is shared rather than repeated because a rule only two of the three relax is a rule that lies.

## Why

STA-3160 (and its byte-identical duplicate STA-3162) reports that the hook cache records a `PermissionRequest` while the public status exposes only `{state:"waiting"}` with no tool or command metadata. That is exactly what the code did: `extractOpenCodeToolFields` handled `MessagePart` and `AskUserQuestion` and fell through to `{}` for everything else, so a permission ask produced a blocked row with nothing on it.

The `waiting` state itself was already correct — 8 of the 16 new tests pass before the fix and only the metadata assertions fail. This PR does not change any state mapping; it only populates the fields that were already being read downstream.

Comparable agent IDEs model an approval as a first-class object that carries its own descriptive payload rather than a bare flag, which is the shape adopted here: keep the state, attach what is being approved.

## Linked Issue

STA-3160 — OpenCode permission request exposes `{state:"waiting"}` with no tool or command metadata. Duplicate: STA-3162.

Fixes #

## Visual Proof

A real OpenCode 1.18.18 permission prompt, driven end to end in an isolated dev instance on this branch. The sidebar row reads `OC | Run ls -la on demo-repo directory - bash: ls -la /private/tmp/oc14614b…`; the card header reads **Needs permission**; the pane behind it is OpenCode's own TUI prompt.

![opencode-permission-live.png](https://github.com/user-attachments/assets/23a37658-6f05-47a5-9bf8-a1d8c1213307)

Full live-verification write-up, including the state/dot/smart-attention comparison against a title-derived permission pane: [this comment](https://github.com/stablyai/orca/pull/14614#issuecomment-5321239169).

## Testing

- [x] I manually tested these changes locally — live OpenCode 1.18.18 permission prompt, see Visual Proof.
- [x] Automated tests added/updated, or explained why not below

```
vitest run --config config/vitest.config.ts \
  src/shared/opencode-permission-status.test.ts \
  src/renderer/src/lib/agent-row-tool-preview.test.ts \
  src/renderer/src/lib/activity-thread-display.test.ts \
  src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx \
  src/renderer/src/components/native-chat/native-chat-interactive-prompt.test.ts
# 5 files, 99 passed

vitest run --config config/vitest.config.ts \
  src/shared/agent-hook-listener.test.ts src/shared/agent-status-types.test.ts \
  src/shared/native-chat-ask.test.ts src/renderer/src/components/sidebar/
# 238 files, 2362 passed
```

`src/shared/opencode-permission-status.test.ts` runs all 8 cases against **opencode and mimo-code** via `it.each` (16 tests), since `normalizeOpenCodeFamilyEvent` serves both from one path.

Non-vacuity verified by deleting the new `PermissionRequest` branch and re-running: exactly the 8 metadata assertions fail (4 cases × opencode and mimo-code), the 8 state/regression assertions still pass. That split is the point — it shows the tests target the gap and not the surrounding behaviour.

Scoped checks on changed files only (full typecheck deliberately skipped, OOM risk):

```
oxfmt --check                                        # clean
oxlint                                               # clean
oxlint --config oxlint-code-quality-native-plugins   # clean, --deny-warnings
oxlint --type-aware --config oxlint-code-quality-type-aware  # clean, --deny-warnings
```

**Verified live, and what still is not.** The earlier note here said a live permission prompt could not be observed. It has been now; the cause of the original failure was that **`opencode run` auto-rejects permission asks non-interactively** (`permission requested: bash (...); auto-rejecting`), so the `waiting` state only holds in the interactive TUI. Only a **`bash`** permission was exercised, so `metadata.command` is the only key confirmed against a live payload — `filepath` / `file_path` / `path` / `url` and the `patterns` fallback remain covered by unit tests against the SDK type only. mimo-code shares the path but was not run live.

## Review

- **Security**: no command execution, no path resolution, no interpolation. Values are read from an already-parsed hook payload and pass through the same `normalizeAgentStatusPayload` capping/validation as every other agent's tool fields. `metadata` is probed only for known string keys, so a hostile payload cannot inject structure.
- **Cross-platform**: pure data mapping in `src/shared/`; no shell, path, or platform branch.
- **SSH / WSL / remote**: unchanged transport. The fields ride the existing `/hook/opencode` payload and the existing status projection.
- **Mobile / remote clients**: no wire change — `toolName` / `toolInput` are long-standing fields on the status payload.
- **Backwards compatibility**: additive and defensive. A payload with no `permission`, no `metadata` and no `patterns` still yields `waiting` with `toolName` undefined, which is exactly today's behaviour; a test pins that so a missing field can never downgrade the blocked state.
- **mimo-code**: shares `normalizeOpenCodeFamilyEvent`, so it gains the same metadata; every test runs for both sources.
- **Native chat**: untouched. `parseInteractivePrompt` is native-chat only (sole caller `NativeChatInteractiveCard.tsx:63`) and OpenCode is not in `NATIVE_CHAT_SUPPORTED_AGENTS`, so populating `toolName` cannot change any card. Confirmed live: the approval envelope parses to `{kind:'approval'}` identically with and without `toolName`, because `'bash'` is not a registered question tool.
- **Performance**: one string read and a small array filter on an event that only fires when a human is already being asked to approve something.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] Focused lint / tests pass locally; full `pnpm typecheck` / `pnpm build` left to CI

## Author

- X / Twitter: @BrennanKB5

