### PR TITLE
fix(ai-vault): attribute Cursor legacy transcripts without inventing cwd

### DIFF
--- a/src/main/agent-trust-presets.ts
+++ b/src/main/agent-trust-presets.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, realpathSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { basename, dirname, join, resolve } from 'node:path'
+import { cursorWorkspaceSlug } from '../shared/cursor-workspace-slug'
 import { writeFileAtomically } from './codex-accounts/fs-utils'
 import { getOrcaManagedCodexHomePath } from './codex/codex-home-paths'
 import { upsertProjectTrustLevel } from './codex/config-toml-trust'
@@ -166,12 +167,4 @@ function canonicalize(p: string): string {
     // Fall through to the raw input.
   }
   return p
-}
-
-function cursorWorkspaceSlug(absPath: string): string {
-  const stripped = absPath.replace(/^[\\/]+/, '')
-  // Why: Windows absolute paths include characters such as ":" that cannot
-  // be used in the ~/.cursor/projects/<slug> directory name.
-  const slug = stripped.replace(/[\\/:*?"<>|]+/g, '-')
-  return slug
 }

--- a/src/main/ai-vault/remote-session-scanner.ts
+++ b/src/main/ai-vault/remote-session-scanner.ts
@@ -3,7 +3,7 @@ import type {
   AiVaultScanIssue,
   AiVaultSession
 } from '../../shared/ai-vault-types'
-import { isPathInsideOrEqual } from '../../shared/cross-platform-path'
+import { isAiVaultSessionInWorkspace } from '../../shared/ai-vault-session-filters'
 import type { ExecutionHostId } from '../../shared/execution-host'
 import { setImmediate as yieldToEventLoop } from 'node:timers/promises'
 import type { RemoteHostPlatform } from '../ssh/ssh-remote-platform'
@@ -269,8 +269,7 @@ function mergeRemoteSessions(
 }
 
 function isRemoteSessionInScope(session: AiVaultSession, scopePaths: readonly string[]): boolean {
-  const cwd = session.cwd
-  return Boolean(cwd && scopePaths.some((scopePath) => isPathInsideOrEqual(scopePath, cwd)))
+  return scopePaths.some((scopePath) => isAiVaultSessionInWorkspace(session, scopePath))
 }
 
 function normalizeRemoteScopePaths(scopePaths: readonly string[]): string[] {

--- a/src/main/ai-vault/session-scanner-cursor-parser.test.ts
+++ b/src/main/ai-vault/session-scanner-cursor-parser.test.ts
@@ -1,0 +1,72 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { cursorWorkspaceSlug } from '../../shared/cursor-workspace-slug'
+import { parseCursorSessionContent, parseCursorSessionFile } from './session-scanner-cursor-parser'
+import { resetCursorTrustedCwdCacheForTests } from './session-scanner-cursor-project-cwd'
+
+const tempDirs: string[] = []
+
+afterEach(() => {
+  resetCursorTrustedCwdCacheForTests()
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop()
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  }
+})
+
+const jsonl = [
+  JSON.stringify({
+    role: 'user',
+    message: { content: [{ type: 'text', text: 'Hello' }] },
+    timestamp: '2026-08-12T00:00:00.000Z'
+  }),
+  JSON.stringify({
+    role: 'assistant',
+    message: { content: [{ type: 'text', text: 'Hi' }] },
+    timestamp: '2026-08-12T00:00:01.000Z'
+  })
+].join('\n')
+
+describe('parseCursorSessionFile cwd attribution', () => {
+  it('sets cwd from an existing workspace decoded from the Cursor project slug', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-cursor-parse-'))
+    tempDirs.push(root)
+    const workspace = join(tmpdir(), 'orcacwdparseopc')
+    mkdirSync(workspace, { recursive: true })
+    tempDirs.push(workspace)
+    const transcripts = join(
+      root,
+      '.cursor',
+      'projects',
+      cursorWorkspaceSlug(workspace),
+      'agent-transcripts'
+    )
+    mkdirSync(transcripts, { recursive: true })
+    const filePath = join(transcripts, 'cursor-session.jsonl')
+    writeFileSync(filePath, jsonl)
+
+    const session = await parseCursorSessionFile({ path: filePath, mtimeMs: 1, modifiedAt: '' })
+    expect(session?.cwd).toBe(workspace)
+    expect(session?.sessionId).toBe('cursor-session')
+  })
+})
+
+describe('parseCursorSessionContent cwd attribution', () => {
+  it('does not invent a remote cwd from a lossy slug or the local filesystem', async () => {
+    const session = await parseCursorSessionContent(
+      {
+        path: 'C:\\Users\\u\\.cursor\\projects\\c-Dev-simulations-opc\\agent-transcripts\\sid.jsonl',
+        mtimeMs: 1,
+        modifiedAt: ''
+      },
+      jsonl,
+      'win32'
+    )
+    expect(session?.cwd).toBeNull()
+    expect(session?.sessionId).toBe('sid')
+  })
+})

--- a/src/main/ai-vault/session-scanner-cursor-parser.ts
+++ b/src/main/ai-vault/session-scanner-cursor-parser.ts
@@ -15,6 +15,7 @@ import {
   sessionIdFromFileName,
   updateTimeline
 } from './session-scanner-accumulator'
+import { resolveCursorTranscriptCwd } from './session-scanner-cursor-project-cwd'
 import {
   asRecord,
   extractContentText,
@@ -36,7 +37,7 @@ export async function parseCursorSessionFile(
     input: openTranscriptReadStream(file.path, { encoding: 'utf-8' }, 'scan'),
     crlfDelay: Infinity
   })
-  return parseCursorSessionLines({ file, lines, platform })
+  return parseCursorSessionLines({ file, lines, platform, readTrustFile: true })
 }
 
 export async function parseCursorSessionContent(
@@ -50,7 +51,8 @@ export async function parseCursorSessionContent(
     file,
     lines: remoteSessionContentLines(content, signal),
     platform,
-    options
+    options,
+    readTrustFile: false
   })
 }
 
@@ -75,11 +77,20 @@ function consumeCursorRecordLine(accumulator: SessionAccumulator, line: string):
   }
 }
 
-export function createCursorSessionResumeState(file: FileWithMtime): ResumableSessionParseState {
-  return accumulatorFoldResumeState(
-    createAccumulator({ agent: 'cursor', file, sessionId: sessionIdFromFileName(file.path) }),
-    consumeCursorRecordLine
-  )
+export function createCursorSessionResumeState(
+  file: FileWithMtime,
+  options: { readTrustFile?: boolean } = {}
+): ResumableSessionParseState {
+  const accumulator = createAccumulator({
+    agent: 'cursor',
+    file,
+    sessionId: sessionIdFromFileName(file.path)
+  })
+  // Why: Cursor JSONL has no cwd field. Legacy buckets encode the workspace
+  // only as ~/.cursor/projects/<slug>/…; without this, sessions group under
+  // "Unknown location" and drop out of Workspace scope (#13931).
+  accumulator.cwd = resolveCursorTranscriptCwd(file.path, options)
+  return accumulatorFoldResumeState(accumulator, consumeCursorRecordLine)
 }
 
 async function parseCursorSessionLines(args: {
@@ -87,8 +98,9 @@ async function parseCursorSessionLines(args: {
   lines: AsyncIterable<string> | Iterable<string>
   platform: NodeJS.Platform
   options?: ParserSessionOptions
+  readTrustFile?: boolean
 }): Promise<AiVaultSession | null> {
-  const state = createCursorSessionResumeState(args.file)
+  const state = createCursorSessionResumeState(args.file, { readTrustFile: args.readTrustFile })
   for await (const line of args.lines) {
     state.consumeLine(line)
   }

--- a/src/main/ai-vault/session-scanner-cursor-project-cwd.test.ts
+++ b/src/main/ai-vault/session-scanner-cursor-project-cwd.test.ts
@@ -1,0 +1,146 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { cursorWorkspaceSlug } from '../../shared/cursor-workspace-slug'
+import {
+  cursorProjectDirFromTranscriptPath,
+  resetCursorTrustedCwdCacheForTests,
+  resolveCursorTranscriptCwd
+} from './session-scanner-cursor-project-cwd'
+
+const tempDirs: string[] = []
+
+afterEach(() => {
+  resetCursorTrustedCwdCacheForTests()
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop()
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  }
+})
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'orca-cursor-cwd-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+describe('cursorProjectDirFromTranscriptPath', () => {
+  it('returns the projects/<slug> dir only for Cursor transcript layouts', () => {
+    expect(
+      cursorProjectDirFromTranscriptPath(
+        '/home/u/.cursor/projects/Users-u-repo/agent-transcripts/sid/sid.jsonl'
+      )
+    ).toBe('/home/u/.cursor/projects/Users-u-repo')
+    expect(
+      cursorProjectDirFromTranscriptPath(
+        'C:\\Users\\u\\.cursor\\projects\\c-Dev-simulations-opc\\agent-transcripts\\sid.jsonl'
+      )
+    ).toBe('C:\\Users\\u\\.cursor\\projects\\c-Dev-simulations-opc')
+    expect(
+      cursorProjectDirFromTranscriptPath('/tmp/unrelated/agent-transcripts/sid.jsonl')
+    ).toBeNull()
+  })
+})
+
+describe('resolveCursorTranscriptCwd', () => {
+  it('prefers .workspace-trusted workspacePath over slug decode', () => {
+    const root = tempDir()
+    const projectDir = join(root, '.cursor', 'projects', 'c-Dev-simulations-opc')
+    const transcripts = join(projectDir, 'agent-transcripts', 'sid')
+    mkdirSync(transcripts, { recursive: true })
+    writeFileSync(
+      join(projectDir, '.workspace-trusted'),
+      JSON.stringify({
+        trustedAt: '2026-08-12T00:00:00.000Z',
+        workspacePath: 'C:\\Dev\\simulations\\opc'
+      })
+    )
+    expect(resolveCursorTranscriptCwd(join(transcripts, 'sid.jsonl'))).toBe(
+      'C:\\Dev\\simulations\\opc'
+    )
+  })
+
+  it('reads the drive-letter sibling trust file Cursor and Orca can split', () => {
+    const root = tempDir()
+    const cursorDir = join(root, '.cursor', 'projects', 'c-Dev-simulations-opc')
+    const orcaDir = join(root, '.cursor', 'projects', 'C-Dev-simulations-opc')
+    mkdirSync(join(cursorDir, 'agent-transcripts'), { recursive: true })
+    mkdirSync(orcaDir, { recursive: true })
+    writeFileSync(
+      join(orcaDir, '.workspace-trusted'),
+      JSON.stringify({ workspacePath: 'C:\\Dev\\simulations\\opc' })
+    )
+    expect(resolveCursorTranscriptCwd(join(cursorDir, 'agent-transcripts', 'sid.jsonl'))).toBe(
+      'C:\\Dev\\simulations\\opc'
+    )
+  })
+
+  it('publishes a decoded slug only when that workspace path exists', () => {
+    const workspace = join(tmpdir(), 'orcacwdopc')
+    mkdirSync(workspace, { recursive: true })
+    tempDirs.push(workspace)
+    const root = tempDir()
+    const projectDir = join(root, '.cursor', 'projects', cursorWorkspaceSlug(workspace))
+    mkdirSync(join(projectDir, 'agent-transcripts'), { recursive: true })
+    expect(resolveCursorTranscriptCwd(join(projectDir, 'agent-transcripts', 'session.jsonl'))).toBe(
+      workspace
+    )
+  })
+
+  it('does not invent a cwd for a hyphenated folder slug whose decode does not exist', () => {
+    const root = tempDir()
+    const projectDir = join(
+      root,
+      '.cursor',
+      'projects',
+      'c-Users-neil-orca-workspaces-orca-pr-13935-internal-review'
+    )
+    mkdirSync(join(projectDir, 'agent-transcripts'), { recursive: true })
+    expect(
+      resolveCursorTranscriptCwd(join(projectDir, 'agent-transcripts', 'session.jsonl'))
+    ).toBeNull()
+  })
+
+  it('does not read a trust file or invent cwd for a WSL UNC transcript path', () => {
+    expect(
+      resolveCursorTranscriptCwd(
+        '\\\\wsl.localhost\\Ubuntu\\home\\ada\\.cursor\\projects\\home-ada-repo\\agent-transcripts\\sid.jsonl'
+      )
+    ).toBeNull()
+  })
+
+  it('picks up a trust file written after an earlier miss once the scan cache resets', () => {
+    const root = tempDir()
+    const projectDir = join(root, '.cursor', 'projects', 'c-Dev-simulations-opc')
+    const filePath = join(projectDir, 'agent-transcripts', 'sid.jsonl')
+    mkdirSync(join(projectDir, 'agent-transcripts'), { recursive: true })
+    expect(resolveCursorTranscriptCwd(filePath)).toBeNull()
+    writeFileSync(
+      join(projectDir, '.workspace-trusted'),
+      JSON.stringify({ workspacePath: 'C:\\Dev\\simulations\\opc' })
+    )
+    expect(resolveCursorTranscriptCwd(filePath)).toBeNull()
+    resetCursorTrustedCwdCacheForTests()
+    expect(resolveCursorTranscriptCwd(filePath)).toBe('C:\\Dev\\simulations\\opc')
+  })
+
+  it('skips the local trust file when remote content is parsed', () => {
+    const root = tempDir()
+    const projectDir = join(root, '.cursor', 'projects', 'c-Dev-simulations-opc')
+    const transcripts = join(projectDir, 'agent-transcripts')
+    mkdirSync(transcripts, { recursive: true })
+    writeFileSync(
+      join(projectDir, '.workspace-trusted'),
+      JSON.stringify({ workspacePath: 'C:\\Dev\\simulations\\my-project' })
+    )
+    expect(resolveCursorTranscriptCwd(join(transcripts, 'sid.jsonl'))).toBe(
+      'C:\\Dev\\simulations\\my-project'
+    )
+    expect(
+      resolveCursorTranscriptCwd(join(transcripts, 'sid.jsonl'), { readTrustFile: false })
+    ).toBeNull()
+  })
+})

--- a/src/main/ai-vault/session-scanner-cursor-project-cwd.ts
+++ b/src/main/ai-vault/session-scanner-cursor-project-cwd.ts
@@ -1,0 +1,124 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import type { AiVaultAgent, AiVaultSession } from '../../shared/ai-vault-types'
+import { isWslUncPath } from '../../shared/wsl-paths'
+import {
+  cursorProjectSlugFromTranscriptPath,
+  decodeCursorProjectSlug
+} from '../../shared/cursor-workspace-slug'
+import { extractString, parseJsonObject } from './session-scanner-values'
+
+const TRUSTED_CWD_CACHE_MAX = 2048
+const trustedCwdCache = new Map<string, string | null>()
+
+export function resetCursorTrustedCwdCache(): void {
+  trustedCwdCache.clear()
+}
+
+export function resetCursorTrustedCwdCacheForTests(): void {
+  resetCursorTrustedCwdCache()
+}
+
+export function refreshCachedCursorCwd(session: AiVaultSession): AiVaultSession {
+  const cwd = resolveCursorTranscriptCwd(session.filePath)
+  return cwd === session.cwd ? session : { ...session, cwd }
+}
+
+export function maybeRefreshCachedCursorCwd(
+  agent: AiVaultAgent,
+  session: AiVaultSession | null
+): AiVaultSession | null {
+  return agent === 'cursor' && session ? refreshCachedCursorCwd(session) : session
+}
+
+export function resolveCursorTranscriptCwd(
+  filePath: string,
+  options: { readTrustFile?: boolean } = {}
+): string | null {
+  const slug = cursorProjectSlugFromTranscriptPath(filePath)
+  if (!slug) {
+    return null
+  }
+  const projectDir = cursorProjectDirFromTranscriptPath(filePath)
+  // Why: never raw-read WSL UNC 9P or a remote host path as if it were local.
+  if (options.readTrustFile !== false && projectDir && !isWslUncPath(filePath)) {
+    const trusted = readCachedTrustedWorkspacePath(projectDir)
+    if (trusted) {
+      return trusted
+    }
+  }
+  // Why: inverse slug decode is lossy for hyphenated folder names. Only publish
+  // it as cwd when the reconstructed path actually exists on this host.
+  if (options.readTrustFile === false || isWslUncPath(filePath)) {
+    return null
+  }
+  const decoded = decodeCursorProjectSlug(slug)
+  return decoded && existsSync(decoded) ? decoded : null
+}
+
+export function cursorProjectDirFromTranscriptPath(filePath: string): string | null {
+  if (!cursorProjectSlugFromTranscriptPath(filePath)) {
+    return null
+  }
+  const segments = filePath.split(/[\\/]+/).filter(Boolean)
+  const marker = segments.lastIndexOf('agent-transcripts')
+  return joinPathSegments(segments.slice(0, marker), filePath)
+}
+
+function readCachedTrustedWorkspacePath(projectDir: string): string | null {
+  if (trustedCwdCache.has(projectDir)) {
+    return trustedCwdCache.get(projectDir) ?? null
+  }
+  const cwd =
+    readCursorWorkspaceTrustedPath(projectDir) ??
+    readCursorWorkspaceTrustedPath(driveCaseSiblingProjectDir(projectDir))
+  if (trustedCwdCache.size >= TRUSTED_CWD_CACHE_MAX) {
+    const oldest = trustedCwdCache.keys().next()
+    if (!oldest.done) {
+      trustedCwdCache.delete(oldest.value)
+    }
+  }
+  trustedCwdCache.set(projectDir, cwd)
+  return cwd
+}
+
+function readCursorWorkspaceTrustedPath(projectDir: string | null): string | null {
+  if (!projectDir) {
+    return null
+  }
+  try {
+    const record = parseJsonObject(readFileSync(join(projectDir, '.workspace-trusted'), 'utf-8'))
+    return extractString(record?.workspacePath)?.trim() || null
+  } catch {
+    return null
+  }
+}
+
+function driveCaseSiblingProjectDir(projectDir: string): string | null {
+  const segments = projectDir.split(/[\\/]+/).filter(Boolean)
+  const slug = segments.at(-1)
+  if (!slug) {
+    return null
+  }
+  const flipped = slug.replace(/^([A-Za-z])-/, (_, drive: string) => {
+    const next = drive === drive.toLowerCase() ? drive.toUpperCase() : drive.toLowerCase()
+    return `${next}-`
+  })
+  if (flipped === slug) {
+    return null
+  }
+  segments[segments.length - 1] = flipped
+  return joinPathSegments(segments, projectDir)
+}
+
+function joinPathSegments(segments: string[], originalPath: string): string {
+  if (segments.length === 0) {
+    return originalPath.startsWith('/') ? '/' : ''
+  }
+  const useBackslash = originalPath.includes('\\') && !originalPath.includes('/')
+  const joined = segments.join(useBackslash ? '\\' : '/')
+  if (originalPath.startsWith('/') && !/^[A-Za-z]:/.test(segments[0] ?? '')) {
+    return `/${joined}`
+  }
+  return joined
+}

--- a/src/main/ai-vault/session-scanner-fs-import-guard.test.ts
+++ b/src/main/ai-vault/session-scanner-fs-import-guard.test.ts
@@ -28,7 +28,10 @@ const ALLOWLIST = new Set([
   'session-scanner-claude-subagents.ts',
   'session-scanner-omp-subagent-listing.ts',
   // Test-only fixture builder.
-  'session-scanner-test-fixtures.ts'
+  'session-scanner-test-fixtures.ts',
+  // Local ~/.cursor/projects/<slug>/.workspace-trusted only. WSL UNC
+  // transcripts skip this read in resolveCursorTranscriptCwd.
+  'session-scanner-cursor-project-cwd.ts'
 ])
 
 const FS_IMPORT = /import\s+([\s\S]*?)\s+from\s+['"]node:fs(?:\/promises)?['"]/g

--- a/src/main/ai-vault/session-scanner-parse-cache-refresh.ts
+++ b/src/main/ai-vault/session-scanner-parse-cache-refresh.ts
@@ -1,0 +1,36 @@
+import type { AiVaultSession } from '../../shared/ai-vault-types'
+import { refreshCachedCodexTitle } from './session-scanner-codex-cached-title'
+import { refreshCachedCursorCwd } from './session-scanner-cursor-project-cwd'
+import { countOmpSubagentTranscripts } from './session-scanner-omp-subagent-transcripts'
+import { countSubagentTranscripts } from './session-scanner-subagent-transcripts'
+import type { SessionFileCandidate } from './session-scanner-types'
+
+export async function refreshCachedSessionSideChannels(
+  candidate: SessionFileCandidate,
+  session: AiVaultSession
+): Promise<AiVaultSession> {
+  // Why: a zero-turn transcript usually never changes again, but its sibling
+  // subagent dir can gain files after the parent's last write.
+  let next = session
+  if (next.messageCount === 0) {
+    const subagentTranscriptCount =
+      candidate.agent === 'claude'
+        ? await countSubagentTranscripts(candidate.file.path)
+        : candidate.agent === 'omp'
+          ? await countOmpSubagentTranscripts(candidate.file.path)
+          : null
+    if (
+      subagentTranscriptCount !== null &&
+      subagentTranscriptCount !== next.subagentTranscriptCount
+    ) {
+      next = { ...next, subagentTranscriptCount }
+    }
+  }
+  if (candidate.agent === 'codex') {
+    next = await refreshCachedCodexTitle(candidate, next)
+  }
+  if (candidate.agent === 'cursor') {
+    next = refreshCachedCursorCwd(next)
+  }
+  return next
+}

--- a/src/main/ai-vault/session-scanner-parse-cache.ts
+++ b/src/main/ai-vault/session-scanner-parse-cache.ts
@@ -12,10 +12,9 @@ import { createClaudeSessionResumeState } from './session-scanner-primary-parser
 import { createGeminiJsonlSessionResumeState } from './session-scanner-gemini-parsers'
 import { createCopilotSessionResumeState } from './session-scanner-copilot-parser'
 import { createCursorSessionResumeState } from './session-scanner-cursor-parser'
-import { countSubagentTranscripts } from './session-scanner-subagent-transcripts'
-import { countOmpSubagentTranscripts } from './session-scanner-omp-subagent-transcripts'
 import type { ResumableSessionParseState, SessionFileCandidate } from './session-scanner-types'
-import { refreshCachedCodexTitle } from './session-scanner-codex-cached-title'
+import { refreshCachedSessionSideChannels } from './session-scanner-parse-cache-refresh'
+import { maybeRefreshCachedCursorCwd } from './session-scanner-cursor-project-cwd'
 
 // Sized past the default recency cap (1000) plus the in-scope cap (2000) so a
 // full steady-state result set stays resident between forced rescans.
@@ -189,27 +188,8 @@ export async function parseAgentSessionFileCached(
     if (stats) {
       stats.reused++
     }
-    // A zero-turn transcript usually never changes again, but its sibling
-    // subagent dir (Claude `<session>/subagents/`, OMP's same-named artifact
-    // dir) can gain files after the parent's last write (a still-running
-    // subagent finishing). The mtime+size key can't see that, so refresh the
-    // cheap directory count on reuse.
-    if (entry.session && entry.session.messageCount === 0) {
-      const subagentTranscriptCount =
-        candidate.agent === 'claude'
-          ? await countSubagentTranscripts(file.path)
-          : candidate.agent === 'omp'
-            ? await countOmpSubagentTranscripts(file.path)
-            : null
-      if (
-        subagentTranscriptCount !== null &&
-        subagentTranscriptCount !== entry.session.subagentTranscriptCount
-      ) {
-        entry.session = { ...entry.session, subagentTranscriptCount }
-      }
-    }
-    if (entry.session && candidate.agent === 'codex') {
-      entry.session = await refreshCachedCodexTitle(candidate, entry.session)
+    if (entry.session) {
+      entry.session = await refreshCachedSessionSideChannels(candidate, entry.session)
     }
     storeEntry(file.path, entry)
     return entry.session
@@ -296,7 +276,10 @@ async function parseResumableCandidate(args: {
     mtimeMs: file.mtimeMs,
     sizeBytes: file.sizeBytes ?? null,
     platform: args.platform,
-    session: await displayState.finalize(args.platform),
+    session: maybeRefreshCachedCursorCwd(
+      args.candidate.agent,
+      await displayState.finalize(args.platform)
+    ),
     resume: { state, byteOffset: readResult.consumedThrough }
   }
 }

--- a/src/main/ai-vault/session-scanner.ts
+++ b/src/main/ai-vault/session-scanner.ts
@@ -42,6 +42,7 @@ import type {
 import { clampPositiveInteger, errorMessage } from './session-scanner-values'
 import { throwIfAiVaultScanCancelled } from './ai-vault-scan-cancellation'
 import { DEFAULT_AI_VAULT_SCAN_LIMIT } from '../../shared/ai-vault-session-depth'
+import { resetCursorTrustedCwdCache } from './session-scanner-cursor-project-cwd'
 
 const SESSION_PARSE_CONCURRENCY = 8
 const SESSION_PARSE_CANDIDATE_MULTIPLIER = 2
@@ -78,6 +79,7 @@ export async function scanAiVaultSessions(
     // Why: persisted entries must be seeded before any candidate is parsed, or
     // the cold scan gains nothing from the cache file (#9210).
     throwIfAiVaultScanCancelled(options.signal)
+    resetCursorTrustedCwdCache()
     await ensureSessionParseCacheLoaded()
     const discoveries = await discoverAiVaultSessionSources({ options, limitPerAgent, issues })
     throwIfAiVaultScanCancelled(options.signal)

--- a/src/main/remote-agent-trust-presets.ts
+++ b/src/main/remote-agent-trust-presets.ts
@@ -7,6 +7,7 @@ import {
   isWindowsAbsolutePathLike,
   normalizeRuntimePathSeparators
 } from '../shared/cross-platform-path'
+import { cursorWorkspaceSlug } from '../shared/cursor-workspace-slug'
 
 export async function markRemoteAgentWorkspaceTrusted(args: {
   preset: AgentTrustPreset
@@ -100,7 +101,7 @@ async function markRemoteCursorWorkspaceTrusted(
   remoteHome: string,
   workspacePath: string
 ): Promise<void> {
-  const slug = workspacePath.replace(/^[\\/]+/, '').replace(/[\\/:*?"<>|]+/g, '-')
+  const slug = cursorWorkspaceSlug(workspacePath)
   if (!slug) {
     return
   }

--- a/src/shared/ai-vault-session-depth.test.ts
+++ b/src/shared/ai-vault-session-depth.test.ts
@@ -82,4 +82,21 @@ describe('Agent Session History depth', () => {
     ])
     expect(truncateAiVaultListResult(loaded, 'unlimited')).toBe(loaded)
   })
+
+  it('keeps cwd-less Cursor sessions whose project slug matches the workspace', () => {
+    const cursor = {
+      ...session('cursor-legacy', '', 1),
+      agent: 'cursor' as const,
+      cwd: null,
+      filePath: '/home/ada/.cursor/projects/home-ada-repo/agent-transcripts/sid.jsonl'
+    }
+    const loaded = result([
+      session('global-1', '/other', 3),
+      session('global-2', '/other', 2),
+      cursor
+    ])
+    expect(
+      truncateAiVaultListResult(loaded, 1, ['/home/ada/repo']).sessions.map(({ id }) => id)
+    ).toEqual(['global-1', 'cursor-legacy'])
+  })
 })

--- a/src/shared/ai-vault-session-depth.ts
+++ b/src/shared/ai-vault-session-depth.ts
@@ -1,5 +1,5 @@
-import { isPathInsideOrEqual } from './cross-platform-path'
 import type { AiVaultListArgs, AiVaultListResult } from './ai-vault-types'
+import { isAiVaultSessionInWorkspace } from './ai-vault-session-filters'
 
 export const DEFAULT_AI_VAULT_SCAN_LIMIT = 1000
 
@@ -42,8 +42,7 @@ export function truncateAiVaultListResult(
   if (scopePaths.length > 0) {
     let scopedCount = 0
     for (const session of result.sessions) {
-      const cwd = session.cwd
-      if (cwd && scopePaths.some((scopePath) => isPathInsideOrEqual(scopePath, cwd))) {
+      if (scopePaths.some((scopePath) => isAiVaultSessionInWorkspace(session, scopePath))) {
         selectedIds.add(session.id)
         if (++scopedCount >= depth) {
           break

--- a/src/shared/ai-vault-session-filters.test.ts
+++ b/src/shared/ai-vault-session-filters.test.ts
@@ -197,4 +197,26 @@ describe('/shared ai-vault-session-filters (lifted core)', () => {
   it('builds preview search text from conversation turns', () => {
     expect(sessionPreviewSearchText(baseSession)).toContain('scope tabs')
   })
+
+  it('keeps Cursor sessions in Workspace scope via the project slug when cwd is missing', () => {
+    const cursorSession: AiVaultSession = {
+      ...baseSession,
+      id: 'cursor:legacy',
+      agent: 'cursor',
+      sessionId: 'sid',
+      cwd: null,
+      filePath:
+        'C:\\Users\\neil\\.cursor\\projects\\c-Users-neil-orca-workspaces-orca-pr-13935-internal-review\\agent-transcripts\\sid.jsonl'
+    }
+    expect(
+      filterAiVaultSessions([cursorSession], {
+        query: '',
+        agents: ['cursor'],
+        scope: 'workspace',
+        sort: 'updated',
+        activeWorktreePaths: ['C:\\Users\\neil\\orca\\workspaces\\orca\\pr-13935-internal-review'],
+        hideEmptySessions: true
+      }).map((session) => session.id)
+    ).toEqual(['cursor:legacy'])
+  })
 })

--- a/src/shared/ai-vault-session-filters.ts
+++ b/src/shared/ai-vault-session-filters.ts
@@ -8,6 +8,7 @@ import {
   normalizeRuntimePathSeparators
 } from './cross-platform-path'
 import { isClipboardTextByteLengthOverLimit } from './clipboard-text'
+import { isCursorTranscriptInWorkspace } from './cursor-workspace-slug'
 import { parseWslUncPath } from './wsl-paths'
 import type {
   AiVaultAgent,
@@ -96,16 +97,11 @@ export function filterAiVaultSessions(
       ) {
         return false
       }
-      if (filters.scope === 'workspace') {
-        const cwd = session.cwd
-        if (
-          !cwd ||
-          !filters.activeWorktreePaths.some((pathValue) =>
-            isAiVaultSessionInWorkspacePath(pathValue, cwd)
-          )
-        ) {
-          return false
-        }
+      if (
+        filters.scope === 'workspace' &&
+        !isAiVaultSessionInActiveWorkspace(session, filters.activeWorktreePaths)
+      ) {
+        return false
       }
       if (filters.scope === 'project') {
         if (!filters.activeProjectKey) {
@@ -274,6 +270,27 @@ function getGroupIdentity(
     }
   }
   return { key: folderGroupKey(session.cwd), label: folderLabel(session.cwd) }
+}
+
+export function isAiVaultSessionInWorkspace(
+  session: Pick<AiVaultSession, 'agent' | 'cwd' | 'filePath'>,
+  workspacePath: string
+): boolean {
+  if (session.cwd && isAiVaultSessionInWorkspacePath(workspacePath, session.cwd)) {
+    return true
+  }
+  // Why: Cursor JSONL has no cwd and slug decode is lossy for hyphenated
+  // folder workspaces. Matching the encoded project bucket is lossless.
+  return (
+    session.agent === 'cursor' && isCursorTranscriptInWorkspace(workspacePath, session.filePath)
+  )
+}
+
+function isAiVaultSessionInActiveWorkspace(
+  session: AiVaultSession,
+  activeWorktreePaths: readonly string[]
+): boolean {
+  return activeWorktreePaths.some((pathValue) => isAiVaultSessionInWorkspace(session, pathValue))
 }
 
 function isAiVaultSessionInWorkspacePath(workspacePath: string, sessionCwd: string): boolean {

--- a/src/shared/cursor-workspace-slug.test.ts
+++ b/src/shared/cursor-workspace-slug.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import {
+  cursorProjectSlugFromTranscriptPath,
+  cursorWorkspaceSlug,
+  decodeCursorProjectSlug,
+  isCursorTranscriptInWorkspace
+} from './cursor-workspace-slug'
+
+describe('cursorWorkspaceSlug', () => {
+  it('encodes POSIX paths the way Cursor names project buckets', () => {
+    expect(cursorWorkspaceSlug('/Users/ada/code/orca')).toBe('Users-ada-code-orca')
+  })
+
+  it('encodes Windows drive paths, including the colon', () => {
+    expect(cursorWorkspaceSlug('C:\\Dev\\simulations\\opc')).toBe('C-Dev-simulations-opc')
+    expect(cursorWorkspaceSlug('C:/Users/alice/platform')).toBe('C-Users-alice-platform')
+  })
+})
+
+describe('cursorProjectSlugFromTranscriptPath', () => {
+  it('requires the .cursor/projects/<slug>/agent-transcripts layout', () => {
+    expect(
+      cursorProjectSlugFromTranscriptPath(
+        '/home/u/.cursor/projects/Users-u-repo/agent-transcripts/sid/sid.jsonl'
+      )
+    ).toBe('Users-u-repo')
+    expect(
+      cursorProjectSlugFromTranscriptPath(
+        'C:\\Users\\u\\.cursor\\projects\\c-Dev-simulations-opc\\agent-transcripts\\sid.jsonl'
+      )
+    ).toBe('c-Dev-simulations-opc')
+    expect(
+      cursorProjectSlugFromTranscriptPath('/home/u/.cursor/projects/slug/sid.jsonl')
+    ).toBeNull()
+    expect(
+      cursorProjectSlugFromTranscriptPath('/tmp/unrelated/agent-transcripts/sid.jsonl')
+    ).toBeNull()
+  })
+})
+
+describe('decodeCursorProjectSlug', () => {
+  it('reconstructs Windows drive paths, including a drive root', () => {
+    expect(decodeCursorProjectSlug('c-Dev-simulations-opc')).toBe('C:\\Dev\\simulations\\opc')
+    expect(decodeCursorProjectSlug('c-')).toBe('C:\\')
+  })
+
+  it('reconstructs POSIX paths with the leading slash restored', () => {
+    expect(decodeCursorProjectSlug('Users-ada-code-orca')).toBe('/Users/ada/code/orca')
+  })
+
+  it('rejects empty, relative, and parent-segment slugs', () => {
+    expect(decodeCursorProjectSlug('')).toBeNull()
+    expect(decodeCursorProjectSlug('..')).toBeNull()
+    expect(decodeCursorProjectSlug('foo-..-bar')).toBeNull()
+  })
+})
+
+describe('isCursorTranscriptInWorkspace', () => {
+  it('matches a Windows folder workspace whose slug Cursor lowercased', () => {
+    expect(
+      isCursorTranscriptInWorkspace(
+        'C:\\Users\\neil\\orca\\workspaces\\orca\\pr-13935-internal-review',
+        'C:\\Users\\neil\\.cursor\\projects\\c-Users-neil-orca-workspaces-orca-pr-13935-internal-review\\agent-transcripts\\sid.jsonl'
+      )
+    ).toBe(true)
+  })
+
+  it('does not match a different Windows workspace', () => {
+    expect(
+      isCursorTranscriptInWorkspace(
+        'C:\\Dev\\simulations\\opc',
+        'C:\\Users\\u\\.cursor\\projects\\c-Dev-other\\agent-transcripts\\sid.jsonl'
+      )
+    ).toBe(false)
+  })
+
+  it('matches a WSL UNC workspace against a Linux Cursor project slug', () => {
+    expect(
+      isCursorTranscriptInWorkspace(
+        '\\\\wsl.localhost\\Ubuntu\\home\\ada\\repo',
+        '/home/ada/.cursor/projects/home-ada-repo/agent-transcripts/sid.jsonl'
+      )
+    ).toBe(true)
+  })
+})

--- a/src/shared/cursor-workspace-slug.ts
+++ b/src/shared/cursor-workspace-slug.ts
@@ -1,0 +1,84 @@
+import { isWindowsAbsolutePathLike } from './cross-platform-path'
+import { parseWslUncPath } from './wsl-paths'
+
+/**
+ * Cursor stores per-workspace state under `~/.cursor/projects/<slug>/`.
+ * The slug is the absolute path with a leading slash stripped and reserved
+ * path characters (`/ \ : * ? " < > |`) replaced with `-`.
+ *
+ * Inverse decode is lossy when a path segment itself contains `-`. Prefer
+ * `.workspace-trusted` workspacePath, or match by encoding the workspace.
+ */
+export function cursorWorkspaceSlug(absPath: string): string {
+  const stripped = absPath.replace(/^[\\/]+/, '')
+  return stripped.replace(/[\\/:*?"<>|]+/g, '-')
+}
+
+export function cursorProjectSlugFromTranscriptPath(filePath: string): string | null {
+  const segments = splitPathSegments(filePath)
+  const marker = segments.lastIndexOf('agent-transcripts')
+  if (
+    marker < 3 ||
+    segments[marker - 3] !== '.cursor' ||
+    segments[marker - 2] !== 'projects' ||
+    !segments[marker - 1]
+  ) {
+    return null
+  }
+  return segments[marker - 1] ?? null
+}
+
+export function decodeCursorProjectSlug(slug: string): string | null {
+  const trimmed = slug.trim()
+  if (!trimmed || trimmed === '.' || trimmed === '..') {
+    return null
+  }
+  const windowsDrive = trimmed.match(/^([A-Za-z])-(.*)$/)
+  const decoded = windowsDrive
+    ? `${windowsDrive[1].toUpperCase()}:\\${windowsDrive[2].replace(/-/g, '\\')}`
+    : `/${trimmed.replace(/-/g, '/')}`
+  if (splitPathSegments(decoded).includes('..')) {
+    return null
+  }
+  return decoded
+}
+
+export function isCursorTranscriptInWorkspace(
+  workspacePath: string,
+  transcriptPath: string
+): boolean {
+  const transcriptSlug = cursorProjectSlugFromTranscriptPath(transcriptPath)
+  if (!transcriptSlug) {
+    return false
+  }
+  return workspaceSlugSources(workspacePath).some((source) =>
+    cursorWorkspaceSlugCandidates(source).some((candidate) =>
+      slugsMatch(source, candidate, transcriptSlug)
+    )
+  )
+}
+
+function workspaceSlugSources(workspacePath: string): string[] {
+  const wsl = parseWslUncPath(workspacePath)
+  return wsl ? [workspacePath, wsl.linuxPath] : [workspacePath]
+}
+
+function cursorWorkspaceSlugCandidates(absPath: string): string[] {
+  const slug = cursorWorkspaceSlug(absPath)
+  if (!slug) {
+    return []
+  }
+  const driveFolded = slug.replace(/^([A-Za-z])-/, (_, drive: string) => `${drive.toLowerCase()}-`)
+  return driveFolded === slug ? [slug] : [slug, driveFolded]
+}
+
+function slugsMatch(workspacePath: string, encoded: string, transcriptSlug: string): boolean {
+  if (isWindowsAbsolutePathLike(workspacePath) || /^[A-Za-z]-/.test(transcriptSlug)) {
+    return encoded.toLowerCase() === transcriptSlug.toLowerCase()
+  }
+  return encoded === transcriptSlug
+}
+
+function splitPathSegments(filePath: string): string[] {
+  return filePath.split(/[\\/]+/).filter(Boolean)
+}


### PR DESCRIPTION
## ELI5

Cursor Agent Session History rows on Windows were showing up under **Unknown location** and disappearing from the **Workspace** tab. Orca found the transcripts, but they had no folder attached. This PR attaches them to the right project when we can do it safely, and still shows them in Workspace even when the folder name has hyphens.

## What Changed

- Shared Cursor project-slug encode/decode used by trust presets and Agent Session History.
- Local scans set `cwd` from `.workspace-trusted` (including the `C-` / `c-` drive-letter sibling) or from a decoded slug **only if that path exists**.
- Remote/WSL parses never invent a cwd and never read the local disk.
- Workspace scope, scan-depth truncation, and remote SSH scope match Cursor transcripts by encoding the workspace path (lossless for hyphenated folder workspaces).

## Why

Cursor `agent-transcripts` JSONL has no `cwd` field. Decoding the project slug is lossy when a folder name contains `-` (e.g. `pr-13935-internal-review` becomes `pr\13935\internal\review`). Publishing that guess as `cwd` can hide sessions from the real folder and leak them into a parent path. Encoding the workspace and comparing it to `~/.cursor/projects/<slug>` is lossless.

## Linked Issue

Fixes #13931
Related #13935

## Visual Proof

N/A — no layout, copy, or control change. Grouping/filter membership is non-visual; proven with unit tests for the reported Windows slug `c-Dev-simulations-opc`, hyphenated folder workspaces, remote parse (no local fs), and trust-file sibling lookup.

## Testing

- [x] Automated tests added/updated
- [ ] I manually tested these changes locally (this Windows host has no `~/.cursor/projects` transcripts; Electron golden-path not run)

Windows unit tests:

- `pnpm run typecheck:node`
- `oxlint` on touched files
- focused vitest (filters, slug, cwd resolver, parser, parse-cache, scanner, remote scanner, trust presets) — 111+ passing

## AI Disclosure

Maintainer replacement review. Credit: #13935 by @bbingz.

## Review

Checked: no invented cwd on remote/WSL; WSL UNC skips raw `readFileSync`; slug match used for desktop, scan depth, and SSH scope; drive-letter sibling trust file; parse-cache refresh after a late trust write.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

Maintainer replacement for community PR #13935.