### PR TITLE
fix(agent-status): stop foreground-idle Claude from rendering as active foreground work (STA-4119)

### DIFF
--- a/src/main/agent-hooks/hook-status-session-tabs-invalidation.test.ts
+++ b/src/main/agent-hooks/hook-status-session-tabs-invalidation.test.ts
@@ -35,7 +35,8 @@ describe('createHookStatusSessionTabsInvalidator', () => {
     ['agentType', { agentType: 'codex' }],
     ['toolName', { toolName: 'Bash' }],
     ['interactivePrompt', { interactivePrompt: '{"questions":[]}' }],
-    ['interrupted', { interrupted: true }]
+    ['interrupted', { interrupted: true }],
+    ['backgroundOnly', { backgroundOnly: true }]
   ])('invalidates when %s changes', (_field, payload) => {
     const changed = createHookStatusSessionTabsInvalidator()
     changed(working())

--- a/src/main/agent-hooks/hook-status-session-tabs-invalidation.ts
+++ b/src/main/agent-hooks/hook-status-session-tabs-invalidation.ts
@@ -28,7 +28,8 @@ export function createHookStatusSessionTabsInvalidator(): {
       (previous.agentType ?? null) !== (next.agentType ?? null) ||
       (previous.toolName ?? null) !== (next.toolName ?? null) ||
       (previous.interactivePrompt ?? null) !== (next.interactivePrompt ?? null) ||
-      (previous.interrupted ?? false) !== (next.interrupted ?? false)
+      (previous.interrupted ?? false) !== (next.interrupted ?? false) ||
+      (previous.backgroundOnly ?? false) !== (next.backgroundOnly ?? false)
     )
   }
   // Why: a cleared pane must re-arm, else the memo swallows the first event of the

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -429,7 +429,10 @@ function equivalentParsedAgentStatusPayload(
     a.interrupted === b.interrupted &&
     // Why: a session-boundary done must never be deduped against a cached real done —
     // the flag has to reach receivers deterministically (STA-3386).
-    a.sessionBoundary === b.sessionBoundary
+    a.sessionBoundary === b.sessionBoundary &&
+    // Why: the whole STA-4119 transition is working → working with only this flag
+    // flipping; deduping it would drop the turn-ended edge before any receiver sees it.
+    a.backgroundOnly === b.backgroundOnly
   )
 }
 
@@ -917,6 +920,7 @@ export class AgentHookServer {
         prompt: payload.prompt,
         agentType: payload.agentType,
         ...(restored.state === 'done' && restored.interrupted ? { interrupted: true } : {}),
+        ...(restored.backgroundOnly ? { backgroundOnly: true } : {}),
         ...(payload.subagents ? { subagents: payload.subagents } : {})
       }
     })

--- a/src/main/ipc/dashboard-payload-validation.test.ts
+++ b/src/main/ipc/dashboard-payload-validation.test.ts
@@ -99,6 +99,19 @@ function imageIconSrc(bodyBytes: number, withWhitespace = false): string {
 describe('dashboard payload validation', () => {
   it('accepts a complete dashboard snapshot', () => {
     expect(isDashboardSnapshot(SNAPSHOT)).toBe(true)
+    expect(
+      isDashboardSnapshot({
+        ...SNAPSHOT,
+        cards: [
+          {
+            ...SNAPSHOT.cards[0],
+            bucket: 'working',
+            dotState: 'working',
+            backgroundOnly: true
+          }
+        ]
+      })
+    ).toBe(true)
   })
 
   it('rejects malformed or unbounded snapshot fields', () => {
@@ -107,6 +120,18 @@ describe('dashboard payload validation', () => {
       isDashboardSnapshot({
         ...SNAPSHOT,
         cards: [{ ...SNAPSHOT.cards[0], bucket: 'unexpected' }]
+      })
+    ).toBe(false)
+    expect(
+      isDashboardSnapshot({
+        ...SNAPSHOT,
+        cards: [{ ...SNAPSHOT.cards[0], backgroundOnly: 'true' }]
+      })
+    ).toBe(false)
+    expect(
+      isDashboardSnapshot({
+        ...SNAPSHOT,
+        cards: [{ ...SNAPSHOT.cards[0], backgroundOnly: true }]
       })
     ).toBe(false)
     expect(

--- a/src/main/ipc/dashboard-payload-validation.ts
+++ b/src/main/ipc/dashboard-payload-validation.ts
@@ -256,6 +256,8 @@ function isDashboardCard(value: unknown): boolean {
     DASHBOARD_BUCKETS.has(card.bucket) &&
     typeof card.dotState === 'string' &&
     DASHBOARD_DOT_STATES.has(card.dotState) &&
+    (card.backgroundOnly === undefined ||
+      (card.backgroundOnly === true && card.dotState === 'working')) &&
     isBoundedString(card.task, AGENT_STATUS_MAX_FIELD_LENGTH, true) &&
     isOptionalBoundedString(card.lastUserMessage, AGENT_STATUS_MAX_FIELD_LENGTH) &&
     isOptionalBoundedString(card.lastAgentMessage, AGENT_STATUS_ASSISTANT_MESSAGE_MAX_LENGTH) &&

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -19258,13 +19258,25 @@ describe('OrcaRuntimeService', () => {
 
     runtime.onPtyData(
       'hook-only-pty',
-      '\x1b]9999;{"state":"waiting","prompt":"fix the tests","agentType":"opencode"}\x07',
+      '\x1b]9999;{"state":"working","prompt":"fix the tests","agentType":"opencode","backgroundOnly":true}\x07',
       101
     )
 
     await waitForMobileSessionTabsEvents(events, 2)
     expect(events).toHaveLength(2)
     expect(events[1]?.tabs[0]?.type === 'terminal' && events[1].tabs[0].agentStatus).toEqual(
+      expect.objectContaining({ state: 'working', backgroundOnly: true })
+    )
+
+    runtime.onPtyData(
+      'hook-only-pty',
+      '\x1b]9999;{"state":"waiting","prompt":"fix the tests","agentType":"opencode"}\x07',
+      102
+    )
+
+    await waitForMobileSessionTabsEvents(events, 3)
+    expect(events).toHaveLength(3)
+    expect(events[2]?.tabs[0]?.type === 'terminal' && events[2].tabs[0].agentStatus).toEqual(
       expect.objectContaining({ state: 'waiting' })
     )
 
@@ -36714,7 +36726,8 @@ describe('OrcaRuntimeService', () => {
           lastAssistantMessage: 'on it',
           connectionId: null,
           receivedAt: now,
-          stateStartedAt: now - 100
+          stateStartedAt: now - 100,
+          backgroundOnly: true
         }
       ]
     })
@@ -36772,6 +36785,7 @@ describe('OrcaRuntimeService', () => {
         taskTitle: 'Dispatch prompt work',
         displayName: 'Review dispatch prompts and make worker labels distinct',
         lastAssistantMessage: 'on it',
+        backgroundOnly: true,
         stateStartedAt: now - 100,
         updatedAt: now
       })

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -10928,7 +10928,8 @@ export class OrcaRuntimeService {
       (previous.payload.agentType ?? null) !== (payload.agentType ?? null) ||
       (previous.payload.toolName ?? null) !== (payload.toolName ?? null) ||
       (previous.payload.interactivePrompt ?? null) !== (payload.interactivePrompt ?? null) ||
-      (previous.payload.interrupted ?? false) !== (payload.interrupted ?? false)
+      (previous.payload.interrupted ?? false) !== (payload.interrupted ?? false) ||
+      (previous.payload.backgroundOnly ?? false) !== (payload.backgroundOnly ?? false)
     )
   }
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -18406,6 +18406,7 @@ export class OrcaRuntimeService {
         stateStartedAt: number
         updatedAt: number
         restoredUnconfirmed?: boolean
+        backgroundOnly?: boolean
       }
     >()
     for (const snapshot of this.latestAgentStatusByPaneKey.values()) {
@@ -18424,7 +18425,8 @@ export class OrcaRuntimeService {
         toolInput: payload.toolInput ?? null,
         interrupted: payload.interrupted ?? false,
         stateStartedAt: snapshot.stateStartedAt,
-        updatedAt: snapshot.updatedAt
+        updatedAt: snapshot.updatedAt,
+        ...(payload.backgroundOnly ? { backgroundOnly: true } : {})
       })
     }
     for (const entry of this.getAgentStatusSnapshotFn?.() ?? []) {
@@ -18451,7 +18453,8 @@ export class OrcaRuntimeService {
         interrupted: entry.interrupted ?? false,
         stateStartedAt: entry.stateStartedAt,
         updatedAt: entry.receivedAt,
-        ...(entry.restoredUnconfirmed ? { restoredUnconfirmed: true } : {})
+        ...(entry.restoredUnconfirmed ? { restoredUnconfirmed: true } : {}),
+        ...(entry.backgroundOnly ? { backgroundOnly: true } : {})
       })
     }
     if (rowSources.size === 0) {
@@ -18516,7 +18519,8 @@ export class OrcaRuntimeService {
         interrupted: src.interrupted,
         stateStartedAt: src.stateStartedAt,
         updatedAt: src.updatedAt,
-        ...(src.restoredUnconfirmed ? { restoredUnconfirmed: true } : {})
+        ...(src.restoredUnconfirmed ? { restoredUnconfirmed: true } : {}),
+        ...(src.backgroundOnly ? { backgroundOnly: true } : {})
       }
       // Why: SSH/runtime projections can spell an equivalent path differently;
       // bucket by the canonical summary id so mobile keeps the agent activity.

--- a/src/renderer/src/components/AgentStateDot.tsx
+++ b/src/renderer/src/components/AgentStateDot.tsx
@@ -17,6 +17,11 @@ import { AgentWorkingSpinner } from '@/components/AgentWorkingSpinner'
 
 export type AgentDotState =
   | 'working'
+  // Why: the foreground turn ended but registered background work (shell,
+  // subagent, monitor, session cron) keeps the pane live. Same yellow ring as
+  // 'working' — work really is running — but still, because nothing is
+  // happening in the turn the user is watching (STA-4119).
+  | 'background'
   | 'blocked'
   | 'waiting'
   | 'interrupted'
@@ -37,6 +42,8 @@ export function agentStateLabel(state: AgentDotState): string {
   switch (state) {
     case 'working':
       return 'Working'
+    case 'background':
+      return 'Background work'
     case 'blocked':
       return 'Blocked'
     case 'waiting':
@@ -70,13 +77,13 @@ export const AgentStateDot = React.memo(function AgentStateDot({
   const inner = size === 'md' ? 'size-2' : 'size-1.5'
   const icon = size === 'md' ? 'size-3' : 'size-2.5'
 
-  if (state === 'working') {
+  if (state === 'working' || state === 'background') {
     return (
       <span
         className={cn('inline-flex shrink-0 items-center justify-center', box, className)}
         aria-label={agentStateLabel(state)}
       >
-        <AgentWorkingSpinner className={inner} />
+        <AgentWorkingSpinner className={inner} paused={state === 'background'} />
       </span>
     )
   }

--- a/src/renderer/src/components/AgentWorkingSpinner.tsx
+++ b/src/renderer/src/components/AgentWorkingSpinner.tsx
@@ -32,16 +32,28 @@ function handleSpinnerAnimationStart(event: React.AnimationEvent<HTMLSpanElement
 // Why: the working-state ring animates via CSS (.agent-working-spinner in
 // main.css) so rotation runs on the compositor and never touches the input
 // thread. Callers size it via className (size-2 etc.).
-export function AgentWorkingSpinner({ className }: { className?: string }): React.JSX.Element {
+// `paused` renders the same ring complete and still — the reduced-motion form —
+// for work that is running but not in the foreground turn (STA-4119).
+export function AgentWorkingSpinner({
+  className,
+  paused = false
+}: {
+  className?: string
+  paused?: boolean
+}): React.JSX.Element {
   return (
     <span
-      onAnimationStart={handleSpinnerAnimationStart}
+      onAnimationStart={paused ? undefined : handleSpinnerAnimationStart}
       data-agent-spinner=""
+      data-agent-spinner-paused={paused ? '' : undefined}
       className={cn(
+        'block rounded-full border-2 border-yellow-500',
         // Why: under reduced motion the animation is disabled, so fill the top
         // border too — a frozen transparent-top ring reads as a broken
         // spinner; a complete ring reads as an intentional static marker (#9515).
-        'agent-working-spinner block rounded-full border-2 border-yellow-500 border-t-transparent motion-reduce:border-t-yellow-500',
+        paused
+          ? 'opacity-70'
+          : 'agent-working-spinner border-t-transparent motion-reduce:border-t-yellow-500',
         className
       )}
     />

--- a/src/renderer/src/components/activity/ActivityPrototypePage.test.ts
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.test.ts
@@ -21,6 +21,7 @@ import {
   buildActivityThreadGroups,
   buildActivityEvents,
   buildAgentPaneThreads,
+  getActivityThreadDotState,
   getActivityThreadGroup,
   groupActivityThreadsByStatus,
   isActivitySearchQueryTooLarge
@@ -586,6 +587,21 @@ describe('buildActivityEvents', () => {
       [PANE_KEY_2],
       [PANE_KEY_3]
     ])
+  })
+
+  it('settles a background-only row without changing its working group', () => {
+    const result = makeActivityResult({
+      entries: {
+        [PANE_KEY]: { ...makeWorkingEntryWithoutHistory(), backgroundOnly: true }
+      }
+    })
+    const thread = makeThreads(result)[0]
+
+    expect(getActivityThreadDotState(thread)).toBe('background')
+    expect(getActivityThreadGroup(thread, 'status')).toEqual({
+      key: 'working',
+      label: 'Working'
+    })
   })
 })
 

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -11,7 +11,7 @@ import {
   TerminalSquare
 } from 'lucide-react'
 
-import { AgentStateDot, agentStateLabel } from '@/components/AgentStateDot'
+import { AgentStateDot, agentStateLabel, type AgentDotState } from '@/components/AgentStateDot'
 import { AgentIcon } from '@/lib/agent-catalog'
 import {
   agentTypeToIconAgent,
@@ -84,6 +84,7 @@ import {
   resolveActivityThreadStatusPreview
 } from '@/lib/activity-thread-display'
 import { getAgentRowPrimaryText } from '@/lib/agent-row-primary-text'
+import { isBackgroundOnlyAgentActivity } from '../../../../shared/agent-background-only-activity'
 
 type ThreadReadFilter = 'all' | 'unread'
 type ActivityGroupBy = 'status' | 'project' | 'worktree' | 'agent'
@@ -964,12 +965,19 @@ function threadAgentState(thread: AgentPaneThread): AgentStatusState {
   return thread.currentAgentState ?? thread.latestEvent?.state ?? 'done'
 }
 
-function threadAgentStateLabel(thread: AgentPaneThread): string {
+export function getActivityThreadDotState(thread: AgentPaneThread): AgentDotState {
   const state = threadAgentState(thread)
   if (!thread.currentAgentState && state === 'done' && thread.latestEvent?.entry.interrupted) {
-    return 'Interrupted'
+    return 'interrupted'
   }
-  return agentStateLabel(state)
+  if (state === 'working' && isBackgroundOnlyAgentActivity(thread.currentAgentEntry ?? undefined)) {
+    return 'background'
+  }
+  return state
+}
+
+function threadAgentStateLabel(thread: AgentPaneThread): string {
+  return agentStateLabel(getActivityThreadDotState(thread))
 }
 
 export function getActivityThreadGroup(
@@ -981,7 +989,8 @@ export function getActivityThreadGroup(
     if (!thread.currentAgentState && state === 'done' && thread.latestEvent?.entry.interrupted) {
       return { key: 'done:interrupted', label: threadAgentStateLabel(thread) }
     }
-    return { key: state, label: threadAgentStateLabel(thread) }
+    // Background-only rows keep the working group; only their own foreground presentation settles.
+    return { key: state, label: agentStateLabel(state) }
   }
   if (groupBy === 'project') {
     return thread.repo
@@ -1164,7 +1173,7 @@ export function handleActivityFilterFocusShortcut({
 }
 
 function ThreadAgentStateIndicator({ thread }: { thread: AgentPaneThread }): React.JSX.Element {
-  const state = threadAgentState(thread)
+  const state = getActivityThreadDotState(thread)
   const label = threadAgentStateLabel(thread)
   return (
     <Tooltip>

--- a/src/renderer/src/components/dashboard-popout/AgentKanbanCard.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanCard.test.tsx
@@ -19,7 +19,9 @@ vi.mock('@/lib/agent-catalog', () => ({
 }))
 
 vi.mock('@/components/AgentStateDot', () => ({
-  AgentStateDot: () => <span data-testid="state-dot" />
+  AgentStateDot: ({ state }: { state: string }) => (
+    <span data-testid="state-dot" data-state={state} />
+  )
 }))
 
 function card(overrides: Partial<DashboardCard> = {}): DashboardCard {
@@ -76,6 +78,23 @@ describe('AgentKanbanCard', () => {
     renderCard({ card: card({ startedAt: 0 }), now: 2_000_000_000 })
 
     expect(screen.queryByText(/\d+d/)).not.toBeInTheDocument()
+  })
+
+  it('renders background-only work without an active foreground spinner', () => {
+    const { rerender } = renderCard({ card: card(), now: 2_000 })
+    expect(screen.getByTestId('state-dot')).toHaveAttribute('data-state', 'working')
+
+    rerender(
+      <TooltipProvider>
+        <AgentKanbanCard
+          card={card({ backgroundOnly: true })}
+          now={2_000}
+          onOpenTerminal={vi.fn()}
+        />
+      </TooltipProvider>
+    )
+
+    expect(screen.getByTestId('state-dot')).toHaveAttribute('data-state', 'background')
   })
 
   it('shows the question glyph once when a summary is available', () => {

--- a/src/renderer/src/components/dashboard-popout/AgentKanbanCard.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanCard.tsx
@@ -87,6 +87,7 @@ function sameCard(a: DashboardCard, b: DashboardCard): boolean {
     a.agentType === b.agentType &&
     a.bucket === b.bucket &&
     a.dotState === b.dotState &&
+    a.backgroundOnly === b.backgroundOnly &&
     a.task === b.task &&
     a.lastUserMessage === b.lastUserMessage &&
     a.lastAgentMessage === b.lastAgentMessage &&
@@ -208,6 +209,8 @@ export const AgentKanbanCard = memo(
     // it". Everything else stays neutral so the tint keeps meaning something.
     const needsYou = card.bucket === 'attention'
     const displayState = dashboardCardDisplayState(card)
+    const dotState =
+      card.backgroundOnly === true && displayState === 'working' ? 'background' : displayState
     const isDone = displayState === 'done'
     // Why: the session's own name heads the card. Without one the worktree is
     // the best heading left — and then the footer drops it rather than say it
@@ -248,7 +251,7 @@ export const AgentKanbanCard = memo(
             >
               {heading}
             </span>
-            {card.askSummary ? null : <AgentStateDot state={displayState} className="ml-auto" />}
+            {card.askSummary ? null : <AgentStateDot state={dotState} className="ml-auto" />}
           </div>
 
           {card.lastUserMessage || card.lastAgentMessage ? (

--- a/src/renderer/src/components/dashboard-popout/AgentMapWorktreeRingNode.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentMapWorktreeRingNode.tsx
@@ -18,6 +18,7 @@ import { AgentMapQuestionMarker } from './AgentMapQuestionMarker'
 import type { AgentMapFlareStatus } from './agent-map-node-metadata'
 import {
   agentMapAttentionMarkerScale,
+  agentMapDotState,
   agentMapStatusLabel,
   agentName,
   formatDuration,
@@ -111,13 +112,10 @@ function WorktreeDetails({
                     {agentName(agent.card)}
                   </span>
                   <span className="block truncate text-[11px] text-muted-foreground">
-                    {agentMapStatusLabel(agent.status)} · {formatDuration(agent.durationMinutes)}
+                    {agentMapStatusLabel(agent)} · {formatDuration(agent.durationMinutes)}
                   </span>
                 </span>
-                <AgentStateDot
-                  state={agent.status === 'done-seen' ? 'done' : agent.status}
-                  size="md"
-                />
+                <AgentStateDot state={agentMapDotState(agent)} size="md" />
               </button>
             ))
           )}
@@ -321,7 +319,7 @@ export const AgentMapWorktreeRingNode = memo(function AgentMapWorktreeRingNode({
                   tabIndex={agentExiting ? -1 : 0}
                   aria-hidden={agentExiting || undefined}
                   aria-pressed={selectedPaneKey === agent.card.paneKey}
-                  aria-label={`${agentName(agent.card)}, ${agentMapStatusLabel(agent.status)}${agent.card.unseen ? ', unread' : ''}, ${formatDuration(agent.durationMinutes)}, ${worktree.name}, ${project.name}`}
+                  aria-label={`${agentName(agent.card)}, ${agentMapStatusLabel(agent)}${agent.card.unseen ? ', unread' : ''}, ${formatDuration(agent.durationMinutes)}, ${worktree.name}, ${project.name}`}
                   className={`agent-map-agent-node fleet-status-${agent.status}${selectedPaneKey === agent.card.paneKey ? ' is-selected' : ''}${agent.motionState ? ` is-${agent.motionState}` : ''}`}
                   transform={`translate(${agent.x} ${agent.y})`}
                   onClick={(event) => {

--- a/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.test.tsx
@@ -118,6 +118,19 @@ describe('AgentTerminalDialog', () => {
     expect(screen.getByText(/Claude · Done/)).toBeInTheDocument()
   })
 
+  it('labels background-only work without claiming the foreground turn is working', () => {
+    render(
+      <AgentTerminalDialog
+        card={card({ backgroundOnly: true })}
+        onOpenChange={() => {}}
+        onReveal={() => {}}
+      />
+    )
+
+    expect(screen.getByText(/Claude · Background work/)).toBeInTheDocument()
+    expect(screen.queryByText(/Claude · Working/)).not.toBeInTheDocument()
+  })
+
   it('preserves the execution host when revealing a colliding worktree ID', () => {
     const onReveal = vi.fn()
     render(

--- a/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.tsx
@@ -39,6 +39,9 @@ function AgentTerminalFrame({
   onOpenChange,
   onReveal
 }: AgentTerminalFrameProps): React.JSX.Element {
+  const displayState = dashboardCardDisplayState(card)
+  const foregroundState =
+    card.backgroundOnly === true && displayState === 'working' ? 'background' : displayState
   const reveal = (): void => {
     onReveal({
       repoId: card.repoId,
@@ -58,8 +61,7 @@ function AgentTerminalFrame({
         </span>
         {title}
         <span className="text-[11px] text-muted-foreground">
-          {formatAgentTypeLabel(card.agentType)} ·{' '}
-          {agentStateLabel(dashboardCardDisplayState(card))}
+          {formatAgentTypeLabel(card.agentType)} · {agentStateLabel(foregroundState)}
         </span>
         <Button
           type="button"

--- a/src/renderer/src/components/dashboard-popout/agent-map-node-presentation.test.ts
+++ b/src/renderer/src/components/dashboard-popout/agent-map-node-presentation.test.ts
@@ -1,17 +1,34 @@
 import { describe, expect, it, vi } from 'vitest'
-import { agentMapStatusLabel } from './agent-map-node-presentation'
+import { agentMapDotState, agentMapStatusLabel } from './agent-map-node-presentation'
+import type { AgentMapAgentNode } from './agent-map-layout'
 
 vi.mock('@/i18n/i18n', () => ({
   translate: (key: string, fallback: string) => `${key}:${fallback}`
 }))
 
 describe('agentMapStatusLabel', () => {
+  function node(status: AgentMapAgentNode['status'], backgroundOnly = false): AgentMapAgentNode {
+    return {
+      status,
+      card: backgroundOnly ? { backgroundOnly: true } : {}
+    } as AgentMapAgentNode
+  }
+
   it('localizes the map-only acknowledged completion state', () => {
-    expect(agentMapStatusLabel('done-seen')).toBe('dashboardPopout.map.status.doneSeen:Done, seen')
+    expect(agentMapStatusLabel(node('done-seen'))).toBe(
+      'dashboardPopout.map.status.doneSeen:Done, seen'
+    )
   })
 
   it('keeps shared agent states on their existing labels', () => {
-    expect(agentMapStatusLabel('working')).toBe('Working')
-    expect(agentMapStatusLabel('done')).toBe('Done')
+    expect(agentMapStatusLabel(node('working'))).toBe('Working')
+    expect(agentMapStatusLabel(node('done'))).toBe('Done')
+  })
+
+  it('presents a background-only working node without changing its map status', () => {
+    const background = node('working', true)
+    expect(agentMapDotState(background)).toBe('background')
+    expect(agentMapStatusLabel(background)).toBe('Background work')
+    expect(background.status).toBe('working')
   })
 })

--- a/src/renderer/src/components/dashboard-popout/agent-map-node-presentation.ts
+++ b/src/renderer/src/components/dashboard-popout/agent-map-node-presentation.ts
@@ -1,19 +1,25 @@
-import { agentStateLabel } from '@/components/AgentStateDot'
+import { agentStateLabel, type AgentDotState } from '@/components/AgentStateDot'
 import { translate } from '@/i18n/i18n'
 import type { DashboardCard } from '../../../../shared/dashboard-snapshot'
 import { agentMapDirectLineageChevronPath } from './agent-map-lineage-chevron-path'
 import type { AgentMapAgentNode } from './agent-map-layout'
-import type { AgentMapNodeStatus } from './agent-map-node-metadata'
 
 /** Lives here, not in `agent-map-node-metadata`: `agentStateLabel` drags in React and
  *  lucide-react, and that module is on the layout and filter paths, which must stay
  *  free of component imports. `agentStateLabel` is shared with every other dot
  *  renderer, so the map's extra state gets its label here rather than widening
  *  `AgentDotState`. */
-export function agentMapStatusLabel(status: AgentMapNodeStatus): string {
-  return status === 'done-seen'
+export function agentMapDotState(node: AgentMapAgentNode): AgentDotState {
+  if (node.card.backgroundOnly === true && node.status === 'working') {
+    return 'background'
+  }
+  return node.status === 'done-seen' ? 'done' : node.status
+}
+
+export function agentMapStatusLabel(node: AgentMapAgentNode): string {
+  return node.status === 'done-seen'
     ? translate('dashboardPopout.map.status.doneSeen', 'Done, seen')
-    : agentStateLabel(status)
+    : agentStateLabel(agentMapDotState(node))
 }
 
 export function formatDuration(minutes: number): string {

--- a/src/renderer/src/components/dashboard-popout/dashboard-agent-status-patch.test.ts
+++ b/src/renderer/src/components/dashboard-popout/dashboard-agent-status-patch.test.ts
@@ -86,6 +86,25 @@ describe('patchDashboardSnapshotFromAgentStatus', () => {
     })
   })
 
+  it('updates background-only presentation without changing the working bucket', () => {
+    const marked = patchDashboardSnapshotFromAgentStatus(
+      snapshot(),
+      event({ state: 'working', backgroundOnly: true })
+    ).snapshot.cards[0]
+
+    expect(marked).toMatchObject({
+      bucket: 'working',
+      dotState: 'working',
+      backgroundOnly: true
+    })
+
+    const cleared = patchDashboardSnapshotFromAgentStatus(
+      snapshot([{ ...marked, statusUpdatedAt: 300 }]),
+      event({ state: 'working', backgroundOnly: undefined, receivedAt: 301 })
+    ).snapshot.cards[0]
+    expect(cleared.backgroundOnly).toBeUndefined()
+  })
+
   it('ignores stale, wrong-workspace, and session-only events', () => {
     const original = snapshot()
     expect(

--- a/src/renderer/src/components/dashboard-popout/dashboard-agent-status-patch.ts
+++ b/src/renderer/src/components/dashboard-popout/dashboard-agent-status-patch.ts
@@ -6,6 +6,7 @@ import {
   type DashboardSnapshot
 } from '../../../../shared/dashboard-snapshot'
 import { dashboardBucketForDotState } from '../dashboard/dashboard-card-bucket'
+import { isBackgroundOnlyAgentActivity } from '../../../../shared/agent-background-only-activity'
 
 export type DashboardAgentStatusPatchResult = {
   matched: boolean
@@ -62,6 +63,7 @@ export function patchDashboardSnapshotFromAgentStatus(
       : {}),
     bucket,
     dotState,
+    backgroundOnly: isBackgroundOnlyAgentActivity(event) || undefined,
     unseen,
     stateChangedAt: stateChanged ? event.stateStartedAt : card.stateChangedAt,
     statusUpdatedAt: event.receivedAt,

--- a/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
@@ -8,24 +8,11 @@ import { DashboardAgentChildDisclosure } from './DashboardAgentChildDisclosure'
 import { DashboardAgentRowMessage } from './DashboardAgentRowMessage'
 import { DashboardAgentRowTrailingControls } from './DashboardAgentRowTrailingControls'
 import { DashboardAgentRowToolStep } from './DashboardAgentRowToolStep'
-import type { AgentStatusState } from '../../../../shared/agent-status-types'
 import type { DashboardAgentRow as DashboardAgentRowData } from './useDashboardData'
+import { getAgentDotState } from '@/components/sidebar/worktree-card-agent-summary'
 import { getAgentRowPrimaryText } from '@/lib/agent-row-primary-text'
 import { useAgentRowConversationName } from './use-agent-row-conversation-name'
 import { lastEnteredDoneAt } from './agent-finished-timestamp'
-
-// Why: narrow the dashboard's rollup states to shared dot states, defaulting unknowns to 'idle' so a row never crashes.
-function asDotState(state: AgentStatusState | 'idle'): AgentDotState {
-  switch (state) {
-    case 'working':
-    case 'blocked':
-    case 'waiting':
-    case 'done':
-    case 'idle':
-      return state
-  }
-  return 'idle'
-}
 
 function formatTimeAgo(ts: number, now: number): string {
   const delta = now - ts
@@ -142,10 +129,14 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
   const conversationName = useAgentRowConversationName(agent)
   const prompt = conversationName ?? getAgentRowPrimaryText(agent.entry)
   // Why: prompt is '' when unknown, so fall back to the state label to keep the row labeled.
-  const displayLabel = prompt || agentStateLabel(asDotState(agent.state))
+  // Why: interrupted is a terminal outcome and a background-only 'working' is a settled
+  // turn; both are resolved once, by the same seam the sidebar rows use.
+  const dotState: AgentDotState = getAgentDotState(agent)
+  const displayLabel = prompt || agentStateLabel(dotState)
   const model = agent.entry.model?.trim() ?? ''
-  // Why: gate tool fields on 'working' — a stale tool line on a done row reads as still-running.
-  const isWorking = agent.state === 'working'
+  // Why: gate tool fields on foreground 'working' — a stale tool line on a done or
+  // background-only row reads as still-running.
+  const isWorking = dotState === 'working'
   const toolName = isWorking ? (agent.entry.toolName?.trim() ?? '') : ''
   const toolInput = isWorking ? (agent.entry.toolInput?.trim() ?? '') : ''
   const lastAssistantMessage = agent.entry.lastAssistantMessage?.trim() ?? ''
@@ -160,8 +151,6 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
           lineageChildCount === 1 ? 'agent' : 'agents'
         }`
       : [formatAgentTypeLabel(agent.agentType), model].filter(Boolean).join(' · ')
-  // Why: interrupted is a terminal outcome, so surface it in the leading state dot.
-  const dotState: AgentDotState = isInterrupted ? 'interrupted' : asDotState(agent.state)
   const dotTooltipLabel = stateDotTooltipLabel(agent, dotState)
 
   // Why: always show the chevron so the row's right edge doesn't flicker as content grows/shrinks.

--- a/src/renderer/src/components/dashboard/build-dashboard-snapshot.test.ts
+++ b/src/renderer/src/components/dashboard/build-dashboard-snapshot.test.ts
@@ -200,6 +200,23 @@ describe('buildDashboardSnapshot', () => {
     expect(card.unseen).toBe(true)
   })
 
+  it('preserves background-only presentation without moving the live card', () => {
+    const snapshot = buildDashboardSnapshot(
+      baseState({
+        agentStatusByPaneKey: {
+          [PANE_KEY]: entry({ state: 'working', backgroundOnly: true })
+        }
+      }),
+      NOW
+    )
+
+    expect(snapshot.cards[0]).toMatchObject({
+      bucket: 'working',
+      dotState: 'working',
+      backgroundOnly: true
+    })
+  })
+
   it('publishes terminal-backed orchestrated workers under their direct parent', () => {
     const snapshot = buildDashboardSnapshot(
       baseState({

--- a/src/renderer/src/components/dashboard/build-dashboard-snapshot.ts
+++ b/src/renderer/src/components/dashboard/build-dashboard-snapshot.ts
@@ -56,6 +56,7 @@ import {
 } from './dashboard-worktree-launch-options'
 import { buildDashboardSnapshotFilterOptions } from './dashboard-snapshot-filter-options'
 import { dashboardBucketForDotState } from './dashboard-card-bucket'
+import { isBackgroundOnlyAgentActivity } from '../../../../shared/agent-background-only-activity'
 
 /** The store slices the snapshot builder reads. Kept as a Pick so unit tests
  *  can pass a partial store without constructing the whole AppState. */
@@ -255,7 +256,6 @@ export function buildDashboardSnapshot(
               osRelease: clientHost.osRelease
             })
           : null
-      const finishedAt = lastEnteredDoneAt(row)
       const hostMetadata = includeCardDetails
         ? dashboardCardMapWorkspaceMetadata(
             workspace,
@@ -266,13 +266,13 @@ export function buildDashboardSnapshot(
         : undefined
       // Only repos that actually contribute a card ship their icon.
       repoIconsByRepoId[workspace.projectId] = workspace.repoIcon
-
       cards.push({
         paneKey: row.paneKey,
         ptyId,
         agentType: row.agentType,
         bucket,
         dotState,
+        ...(isBackgroundOnlyAgentActivity(row.entry) ? { backgroundOnly: true } : {}),
         task: isTitleDerived ? '' : rowTask(row),
         repoId: workspace.projectId,
         worktreeId,
@@ -296,7 +296,7 @@ export function buildDashboardSnapshot(
         lastUserMessage: isTitleDerived ? undefined : nonEmpty(row.entry.prompt),
         lastAgentMessage: isTitleDerived ? undefined : nonEmpty(row.entry.lastAssistantMessage),
         startedAt: row.startedAt,
-        finishedAt,
+        finishedAt: lastEnteredDoneAt(row),
         stateChangedAt: row.entry.stateStartedAt || row.startedAt,
         statusUpdatedAt: row.entry.updatedAt,
         // Same derivation as WorktreeCardAgents' unvisitedByPaneKey, so the

--- a/src/renderer/src/components/editor/ReviewNotesSendMenuContent.test.tsx
+++ b/src/renderer/src/components/editor/ReviewNotesSendMenuContent.test.tsx
@@ -118,6 +118,8 @@ vi.mock('@/components/AgentStateDot', () => ({
     switch (state) {
       case 'working':
         return 'Working'
+      case 'background':
+        return 'Background work'
       case 'blocked':
         return 'Blocked'
       case 'waiting':
@@ -193,7 +195,8 @@ function agentRow({
   title,
   agentType,
   state = 'done',
-  startedAt = harness.now
+  startedAt = harness.now,
+  backgroundOnly = false
 }: {
   paneKey: string
   tabId: string
@@ -201,11 +204,15 @@ function agentRow({
   agentType: TuiAgent
   state?: AgentStatusState | 'idle'
   startedAt?: number
+  backgroundOnly?: boolean
 }): DashboardAgentRowData {
   const entryState: AgentStatusState = state === 'idle' ? 'working' : state
   return {
     paneKey,
-    entry: agentEntry(paneKey, agentType, entryState, startedAt),
+    entry: {
+      ...agentEntry(paneKey, agentType, entryState, startedAt),
+      ...(backgroundOnly ? { backgroundOnly: true } : {})
+    },
     tab: tab(tabId, { title }) as DashboardAgentRowData['tab'],
     agentType,
     state,
@@ -448,6 +455,36 @@ describe('ReviewNotesSendMenuContent', () => {
     expect(collectText(items[0])).toContain('2m ago')
     expect(collectText(items[0])).toContain('Second session')
     expect(collectText(items[1])).toContain('Claude')
+  })
+
+  it('labels a background-only target without foreground working presentation', () => {
+    const paneKey = makePaneKey(TAB_A, LEAF_A)
+    harness.worktreeAgentRows = [
+      agentRow({
+        paneKey,
+        tabId: TAB_A,
+        title: 'Background session',
+        agentType: 'claude',
+        state: 'working',
+        backgroundOnly: true
+      })
+    ]
+    harness.noteTargets = [
+      {
+        paneKey,
+        tabId: TAB_A,
+        leafId: LEAF_A,
+        agentType: 'claude',
+        tabTitle: 'Background session',
+        status: 'eligible'
+      }
+    ]
+
+    const item = findByType(render(), 'DropdownMenuItem')
+    const dot = findByType(item, 'AgentStateDot')
+
+    expect(dot.props.state).toBe('background')
+    expect(collectText(item)).toContain('Background work')
   })
 
   it('does not target title-detected rows skipped by target derivation', async () => {

--- a/src/renderer/src/components/editor/ReviewNotesSendMenuContent.tsx
+++ b/src/renderer/src/components/editor/ReviewNotesSendMenuContent.tsx
@@ -34,6 +34,7 @@ import { useWorktreeAgentRows } from '@/components/sidebar/useWorktreeAgentRows'
 import type { LaunchSource } from '../../../../shared/telemetry-events'
 import type { AgentStatusState } from '../../../../shared/agent-status-types'
 import { translate } from '@/i18n/i18n'
+import { getAgentDotState } from '@/components/sidebar/worktree-card-agent-summary'
 
 type OrderedSendTarget = {
   target: NotesSendAgentTarget
@@ -245,7 +246,7 @@ function AgentTargetMenuItem({
   onSend: (target: NotesSendAgentTarget) => void
 }): React.JSX.Element {
   const tabTitle = target.tabTitle.trim()
-  const state = asDotState(agent?.state ?? 'idle')
+  const state = agent ? getAgentDotState(agent) : asDotState('idle')
   const timeAgo = agent ? formatAgentRelativeTime(agent, now) : null
   const secondaryParts = [
     agentStateLabel(state),

--- a/src/renderer/src/components/sidebar/background-only-agent-presentation.test.ts
+++ b/src/renderer/src/components/sidebar/background-only-agent-presentation.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import type { TerminalTab } from '../../../../shared/terminal-tab-types'
+import {
+  resetTerminalTabActivityFlagsCacheForTest,
+  resolveTerminalTabActivityStatus
+} from '../tab-bar/terminal-tab-activity-status'
+import { selectWorktreeAgentActivitySummary } from './worktree-agent-activity-summary'
+import { getAgentDotState } from './worktree-card-agent-summary'
+import { buildWorktreeAgentRows } from './worktree-agent-rows'
+
+// STA-4119 / #14253. The pane stays `working` (liveness, keep-awake, hibernation
+// and teardown all read `state`), but every surface that renders FOREGROUND
+// activity must stop drawing a finished turn as an active spinner.
+
+const TAB_ID = 'tab-4119'
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+const PANE_KEY = `${TAB_ID}:${LEAF_ID}`
+const WORKTREE_ID = 'wt-4119'
+const NOW = 100_000
+
+const TAB: TerminalTab = {
+  id: TAB_ID,
+  title: 'Claude',
+  worktreeId: WORKTREE_ID,
+  launchAgent: 'claude'
+} as TerminalTab
+
+function entry(overrides: Partial<AgentStatusEntry> = {}): AgentStatusEntry {
+  return {
+    paneKey: PANE_KEY,
+    state: 'working',
+    prompt: 'ship the thing',
+    updatedAt: NOW,
+    stateStartedAt: NOW,
+    stateHistory: [],
+    agentType: 'claude',
+    tabId: TAB_ID,
+    worktreeId: WORKTREE_ID,
+    ...overrides
+  }
+}
+
+function summaryFor(row: AgentStatusEntry) {
+  return selectWorktreeAgentActivitySummary(
+    {
+      // Why: the summary memo keys on this epoch; a fresh value per case avoids
+      // one test's cached flags answering the next.
+      agentStatusEpoch: Math.random(),
+      agentStatusByPaneKey: { [row.paneKey]: row },
+      migrationUnsupportedByPtyId: {},
+      retainedAgentsByPaneKey: {},
+      tabsByWorktree: { [WORKTREE_ID]: [{ id: TAB_ID }] }
+    } as Parameters<typeof selectWorktreeAgentActivitySummary>[0],
+    WORKTREE_ID
+  )
+}
+
+function tabStatusFor(row: AgentStatusEntry) {
+  resetTerminalTabActivityFlagsCacheForTest()
+  return resolveTerminalTabActivityStatus({
+    tab: TAB,
+    agentStatusByPaneKey: { [row.paneKey]: row },
+    agentStatusEpoch: Math.random(),
+    ptyIdsByTabId: { [TAB_ID]: ['pty-1'] }
+  })
+}
+
+function rowsFor(row: AgentStatusEntry) {
+  return buildWorktreeAgentRows({ tabs: [TAB], entries: [row], retained: [], now: NOW })
+}
+
+beforeEach(() => {
+  resetTerminalTabActivityFlagsCacheForTest()
+  vi.useFakeTimers()
+  vi.setSystemTime(NOW)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  resetTerminalTabActivityFlagsCacheForTest()
+})
+
+describe('worktree card dot', () => {
+  it('reports a foreground working pane as working', () => {
+    expect(summaryFor(entry())).toMatchObject({ hasLiveWorking: true, hasLiveDone: false })
+  })
+
+  it('reports a background-only pane as done, not working', () => {
+    expect(summaryFor(entry({ backgroundOnly: true }))).toMatchObject({
+      hasLiveWorking: false,
+      hasLiveDone: true
+    })
+  })
+
+  it('ignores a stale marker on a non-working row', () => {
+    expect(summaryFor(entry({ state: 'waiting', backgroundOnly: true }))).toMatchObject({
+      hasPermission: true,
+      hasLiveDone: false
+    })
+  })
+})
+
+describe('terminal tab glyph', () => {
+  it('spins for a foreground working pane', () => {
+    expect(tabStatusFor(entry())).toBe('working')
+  })
+
+  it('shows done for a background-only pane', () => {
+    expect(tabStatusFor(entry({ backgroundOnly: true }))).toBe('done')
+  })
+})
+
+describe('sidebar agent row dot', () => {
+  it('renders a foreground working pane with the spinner state', () => {
+    const rows = rowsFor(entry())
+    expect(getAgentDotState(rows[0])).toBe('working')
+  })
+
+  it('renders a background-only pane as background work', () => {
+    const rows = rowsFor(entry({ backgroundOnly: true }))
+    expect(getAgentDotState(rows[0])).toBe('background')
+  })
+
+  it('keeps live subagent child rows working under a background-only parent', () => {
+    const rows = rowsFor(
+      entry({
+        backgroundOnly: true,
+        subagents: [{ id: 'a1', state: 'working', startedAt: NOW - 1_000, agentType: 'explore' }]
+      })
+    )
+    const child = rows.find((row) => row.rowSource === 'subagent')
+    expect(child).toBeDefined()
+    // Why: muting the parent must not pretend the background child is dead.
+    expect(getAgentDotState(child!)).toBe('working')
+  })
+
+  it('still reports an interrupted pane as interrupted', () => {
+    const rows = rowsFor(entry({ state: 'done', interrupted: true }))
+    expect(getAgentDotState(rows[0])).toBe('interrupted')
+  })
+})
+
+describe('liveness is unchanged', () => {
+  it('keeps the pane a fresh non-done row so keep-awake and hibernation still see live work', async () => {
+    const { isFreshNonDoneAgentStatus } = await import('../../../../shared/agent-status-types')
+    const row = entry({ backgroundOnly: true })
+    expect(row.state).toBe('working')
+    expect(isFreshNonDoneAgentStatus(row, NOW)).toBe(true)
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-agent-activity-summary.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-activity-summary.ts
@@ -6,6 +6,7 @@ import {
   parseAgentStatusPaneIdentity,
   resolveAgentStatusWorktreeId
 } from '@/lib/agent-status-worktree-attribution'
+import { isBackgroundOnlyAgentActivity } from '../../../../shared/agent-background-only-activity'
 import {
   AGENT_STATUS_STALE_AFTER_MS,
   type AgentStatusEntry,
@@ -214,10 +215,14 @@ function agentStatusPaneIdsByTabIdEqual(
 
 function applyLiveAgentState(
   summary: WorktreeAgentActivitySummary,
-  entry: Pick<AgentStatusEntry, 'state'>
+  entry: Pick<AgentStatusEntry, 'state' | 'backgroundOnly'>
 ): void {
   if (entry.state === 'blocked' || entry.state === 'waiting') {
     summary.hasPermission = true
+  } else if (isBackgroundOnlyAgentActivity(entry)) {
+    // Why: the card dot reports the foreground turn, which finished; the pane's own
+    // row still shows the live background work (STA-4119).
+    summary.hasLiveDone = true
   } else if (entry.state === 'working') {
     summary.hasLiveWorking = true
   } else if (entry.state === 'done') {

--- a/src/renderer/src/components/sidebar/worktree-card-agent-summary.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-agent-summary.ts
@@ -1,6 +1,7 @@
 import type { AgentDotState } from '@/components/AgentStateDot'
 import type { DashboardAgentRow as DashboardAgentRowData } from '@/components/dashboard/useDashboardData'
 import { formatAgentTypeLabel } from '@/lib/agent-status'
+import { isBackgroundOnlyAgentActivity } from '../../../../shared/agent-background-only-activity'
 import type { AgentStatusState } from '../../../../shared/agent-status-types'
 
 export type SummaryAgentGroup = {
@@ -13,6 +14,7 @@ const SUMMARY_STATE_ORDER: AgentDotState[] = [
   'blocked',
   'interrupted',
   'working',
+  'background',
   'done',
   'idle'
 ]
@@ -30,7 +32,16 @@ function asDotState(state: AgentStatusState | 'idle'): AgentDotState {
 }
 
 export function getAgentDotState(agent: DashboardAgentRowData): AgentDotState {
-  return agent.entry.interrupted === true ? 'interrupted' : asDotState(agent.state)
+  if (agent.entry.interrupted === true) {
+    return 'interrupted'
+  }
+  // Why: the row's own `state` is the gated pane state; only the entry marker says the
+  // foreground turn already ended. Subagent child rows build their own entry without it,
+  // so live children keep spinning under a settled parent (STA-4119).
+  if (agent.state === 'working' && isBackgroundOnlyAgentActivity(agent.entry)) {
+    return 'background'
+  }
+  return asDotState(agent.state)
 }
 
 export function formatSummaryStateLabel(state: AgentDotState): string {
@@ -45,6 +56,8 @@ export function formatSummaryStateLabel(state: AgentDotState): string {
       return 'failed'
     case 'working':
       return 'working'
+    case 'background':
+      return 'running in background'
     case 'done':
       return 'done'
     case 'idle':

--- a/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
@@ -40,7 +40,9 @@ function getCompactAgentSecondary(agent: DashboardAgentRowData): string {
   if (agent.entry.interrupted === true) {
     return 'Interrupted by user'
   }
-  if (agent.state === 'working') {
+  // Why: gate on the resolved dot state — a background-only row's tool line is from the
+  // turn that already ended and would read as still-running (STA-4119).
+  if (getAgentDotState(agent) === 'working') {
     const toolName = agent.entry.toolName?.trim() ?? ''
     const toolInput = agent.entry.toolInput?.trim() ?? ''
     if (toolName && toolInput) {

--- a/src/renderer/src/components/tab-bar/terminal-tab-activity-status.ts
+++ b/src/renderer/src/components/tab-bar/terminal-tab-activity-status.ts
@@ -1,5 +1,6 @@
 import { isExplicitAgentStatusFresh } from '@/lib/agent-status'
 import { resolveWorktreeStatus, type WorktreeStatus } from '@/lib/worktree-status'
+import { isBackgroundOnlyAgentActivity } from '../../../../shared/agent-background-only-activity'
 import {
   AGENT_STATUS_STALE_AFTER_MS,
   type AgentStatusEntry
@@ -74,6 +75,10 @@ function getTerminalTabActivityFlags(
     flags.paneIds.add(identity.paneId)
     if (entry.state === 'blocked' || entry.state === 'waiting') {
       flags.hasPermission = true
+    } else if (isBackgroundOnlyAgentActivity(entry)) {
+      // Why: mirrors the sidebar summary — a finished turn holding background work
+      // is not foreground activity, so the tab glyph must not spin (STA-4119).
+      flags.hasLiveDone = true
     } else if (entry.state === 'working') {
       flags.hasLiveWorking = true
     } else if (entry.state === 'done') {

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -3182,6 +3182,8 @@ export function useIpcEvents(): void {
         lastAssistantMessage: data.lastAssistantMessage,
         interrupted: data.interrupted,
         sessionBoundary: data.sessionBoundary,
+        // Why: same whitelist trap — dropping it renders a finished turn as active foreground work for the whole background lifetime (STA-4119).
+        backgroundOnly: data.backgroundOnly,
         // Why: same trap as interactivePrompt — this rebuild is a field whitelist, so subagent child rows vanish if omitted.
         subagents: data.subagents
       })

--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -1987,6 +1987,64 @@ describe('applyWebSessionTabsSnapshot', () => {
     expect(patch.sortEpoch).toBe(1)
   })
 
+  it('invalidates mirrored presentation caches when only background work remains', () => {
+    const hostPaneKey = makePaneKey('host-tab-1', LEAF_ID)
+    const snapshot = makeSnapshot([
+      {
+        type: 'terminal',
+        id: HOST_SURFACE_ID,
+        title: 'claude [working]',
+        parentTabId: 'host-tab-1',
+        leafId: LEAF_ID,
+        isActive: true,
+        status: 'ready',
+        terminal: 'terminal-1',
+        agentStatus: {
+          state: 'working',
+          prompt: 'run the server',
+          updatedAt: NOW - 100,
+          stateStartedAt: NOW - 1_000,
+          agentType: 'claude',
+          paneKey: hostPaneKey,
+          tabId: 'host-tab-1',
+          worktreeId: WT,
+          stateHistory: []
+        }
+      }
+    ])
+    const initial = applyWebSessionTabsSnapshot(
+      makeState(),
+      snapshot,
+      ENV,
+      NOW
+    ) as Partial<WebSessionTabsSyncState>
+    const mirroredPaneKey = Object.keys(initial.agentStatusByPaneKey ?? {})[0]!
+    const background = applyWebSessionTabsSnapshot(
+      makeState({ ...initial }),
+      {
+        ...snapshot,
+        snapshotVersion: 2,
+        tabs: snapshot.tabs.map((tab) =>
+          tab.type === 'terminal' && tab.agentStatus
+            ? {
+                ...tab,
+                agentStatus: { ...tab.agentStatus, backgroundOnly: true }
+              }
+            : tab
+        )
+      },
+      ENV,
+      NOW
+    ) as Partial<WebSessionTabsSyncState>
+
+    expect(background.agentStatusByPaneKey?.[mirroredPaneKey]).toMatchObject({
+      state: 'working',
+      backgroundOnly: true
+    })
+    expect(background.agentStatusEpoch).toBe(2)
+    expect(background.sortEpoch).toBe(2)
+  })
+
   it('applies a marker-only host restart degradation to mirrored agent status', () => {
     const hostPaneKey = makePaneKey('host-tab-1', LEAF_ID)
     const snapshot = makeSnapshot([

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -1293,9 +1293,11 @@ function buildMirroredAgentStatusPatch(
       existing?.state === 'done' &&
       entry.state === 'done' &&
       agentEntryCompletionAt(existing) !== agentEntryCompletionAt(entry)
+    const backgroundOnlyChanged = existing?.backgroundOnly !== entry.backgroundOnly
     const entrySortRelevantChange =
       !existing ||
       existing.state !== entry.state ||
+      backgroundOnlyChanged ||
       !isAgentStatusFresh(existing, now) ||
       entryFreshnessChanged ||
       entryAttributionChanged ||

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -1947,6 +1947,7 @@ function agentStatusEntryEqual(a: AgentStatusEntry | undefined, b: AgentStatusEn
     a.interrupted === b.interrupted &&
     a.promptInteractionKey === b.promptInteractionKey &&
     a.restoredUnconfirmed === b.restoredUnconfirmed &&
+    a.backgroundOnly === b.backgroundOnly &&
     agentProviderSessionsEqual(a.agentType, a.providerSession, b.providerSession) &&
     sameAgentStateHistory(a.stateHistory, b.stateHistory)
   )

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -2150,6 +2150,9 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
           ...(providerSession ? { providerSession } : {}),
           ...(promptInteractionKey ? { promptInteractionKey } : {}),
           ...(payload.restoredUnconfirmed ? { restoredUnconfirmed: true } : {}),
+          // Why: working-only marker; parseAgentStatusPayload already clamps it, and a plain
+          // working ping must clear it so a new foreground turn spins again.
+          ...(payload.backgroundOnly ? { backgroundOnly: true } : {}),
           // Why: `interrupted` is done-only; parseAgentStatusPayload already clamps it for non-done states, so write it through directly.
           interrupted: payload.interrupted,
           // Why: done→done repaints (OSC 9999, reconnect snapshot replays) re-deliver a
@@ -2193,9 +2196,13 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
           existing?.state === 'done' &&
           entry.state === 'done' &&
           agentEntryCompletionAt(existing) !== agentEntryCompletionAt(entry)
+        // Why: the STA-4119 edge is working → working with only this flag flipping; without it
+        // the epoch never bumps and the memoized card/tab summaries keep the stale spinner.
+        const backgroundOnlyChanged = existing?.backgroundOnly !== entry.backgroundOnly
         const sortRelevantChange =
           !existing ||
           existing.state !== payload.state ||
+          backgroundOnlyChanged ||
           !wasFresh ||
           attributionChanged ||
           commandCodeNewTurn ||

--- a/src/shared/agent-background-only-activity.ts
+++ b/src/shared/agent-background-only-activity.ts
@@ -1,0 +1,17 @@
+import type { AgentStatusEntry } from './agent-status-types'
+
+/**
+ * True when a `working` row is held up only by registered background work
+ * (background shell, subagent, monitor, session cron) whose owning foreground
+ * turn already ended — Claude sitting at its idle `❯` prompt (#14253 / STA-4119).
+ *
+ * Presentation-only. The row stays `working` everywhere that gates on `state`
+ * (liveness, keep-awake, auto-hibernation, teardown), because the background
+ * work is genuinely running; only surfaces that render FOREGROUND activity
+ * consult this.
+ */
+export function isBackgroundOnlyAgentActivity(
+  entry: Pick<AgentStatusEntry, 'state' | 'backgroundOnly'> | undefined
+): boolean {
+  return entry?.state === 'working' && entry.backgroundOnly === true
+}

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -4047,8 +4047,12 @@ describe('shared agent-hook-listener', () => {
       expect(wait?.payload.state).toBe('waiting')
 
       // Why: the lead already finished; the answer resumes the child, so the
-      // emitted state is gated up to working only while that child still runs.
-      expect(clearClaudeAnsweredQuestionWait(state, PANE_KEY)).toEqual({ state: 'working' })
+      // emitted state is gated up to working only while that child still runs,
+      // and carries the background-only provenance for presentation (STA-4119).
+      expect(clearClaudeAnsweredQuestionWait(state, PANE_KEY)).toEqual({
+        state: 'working',
+        backgroundOnly: true
+      })
       expect(state.claudeLeadStateByPaneKey.get(PANE_KEY)).toEqual({ state: 'done' })
 
       const drained = claudeEvent({ hook_event_name: 'SubagentStop', agent_id: 'a1' })

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2580,21 +2580,30 @@ function updateClaudeRunningNonAgentTask(
   }
 }
 
+/** The pane state to report, plus whether a lead `done` was gated up to `working`
+ *  purely by leftover background work. That provenance is what lets presentation
+ *  surfaces stop drawing a finished turn as active foreground work (STA-4119)
+ *  while liveness, keep-awake, hibernation and teardown keep seeing `working`. */
+type ClaudePaneStateResolution = {
+  state: AgentStatusState
+  backgroundOnly?: true
+}
+
 function resolveClaudePaneState(
   state: HookListenerState,
   paneKey: string,
   lead: Pick<ClaudeLeadTurnState, 'state' | 'interrupted'>
-): AgentStatusState {
+): ClaudePaneStateResolution {
   if (lead.state !== 'done') {
-    return lead.state
+    return { state: lead.state }
   }
   const roster = state.claudeSubagentRosterByPaneKey.get(paneKey)
   return claudeRosterHasWorkingSubagent(roster) ||
     (!lead.interrupted &&
       (state.claudeRunningNonAgentTaskPaneKeys.has(paneKey) ||
         state.claudeActiveSessionCronPaneKeys.has(paneKey)))
-    ? 'working'
-    : 'done'
+    ? { state: 'working', backgroundOnly: true }
+    : { state: 'done' }
 }
 
 /** SubagentStart/Stop/TeammateIdle update the roster and re-emit the lead's last known state with the fresh child list, so the sidebar reflects spawn/finish even when a background child outlives the lead turn with no other hook traffic. */
@@ -2753,7 +2762,7 @@ function clearClaudePendingWaitForAgent(
 export function clearClaudeAnsweredQuestionWait(
   state: HookListenerState,
   paneKey: string
-): Pick<ClaudeLeadTurnState, 'state' | 'interrupted'> {
+): Pick<ClaudeLeadTurnState, 'state' | 'interrupted'> & { backgroundOnly?: true } {
   const lead = state.claudeLeadStateByPaneKey.get(paneKey)
   const restored =
     lead?.state === 'waiting'
@@ -2767,8 +2776,10 @@ export function clearClaudeAnsweredQuestionWait(
       ? { lastAssistantMessage: previousTool.lastAssistantMessage }
       : {}
   )
-  const effectiveState = resolveClaudePaneState(state, paneKey, restored)
-  return effectiveState === restored.state ? restored : { state: effectiveState }
+  const resolved = resolveClaudePaneState(state, paneKey, restored)
+  return resolved.state === restored.state
+    ? restored
+    : { state: resolved.state, ...(resolved.backgroundOnly ? { backgroundOnly: true } : {}) }
 }
 
 /** Re-emit the cached lead state without touching its tool/prompt caches; child churn and parallel completions must not dismiss live cards. */
@@ -2796,11 +2807,13 @@ function buildClaudeCachedLeadStatusPayload(
       return null
     }
   }
+  const resolved = resolveClaudePaneState(state, paneKey, {
+    state: leadState,
+    interrupted: lead?.interrupted
+  })
   return buildClaudeStatusPayload(state, eventName, '', paneKey, hookPayload, {
-    stateName: resolveClaudePaneState(state, paneKey, {
-      state: leadState,
-      interrupted: lead?.interrupted
-    }),
+    stateName: resolved.state,
+    backgroundOnly: resolved.backgroundOnly,
     updateToolSnapshot: false,
     interrupted: lead?.interrupted
   })
@@ -2966,8 +2979,10 @@ function normalizeClaudeEvent(
     // Restore the stashed lead state, not this child's 'working': the lead may already be done, and the done-gate never upgrades working back to done once the roster drains.
     const restored = lead.stateBeforeWait ?? { state: 'working' as const }
     state.claudeLeadStateByPaneKey.set(paneKey, restored)
+    const resolvedRestored = resolveClaudePaneState(state, paneKey, restored)
     return buildClaudeStatusPayload(state, eventName, promptText, paneKey, hookPayload, {
-      stateName: resolveClaudePaneState(state, paneKey, restored),
+      stateName: resolvedRestored.state,
+      backgroundOnly: resolvedRestored.backgroundOnly,
       updateToolSnapshot: true,
       interrupted: restored.interrupted
     })
@@ -3018,10 +3033,11 @@ function normalizeClaudeEvent(
     state.claudeActiveSessionCronPaneKeys.delete(paneKey)
   }
 
-  const effectiveState = resolveClaudePaneState(state, paneKey, {
+  const resolved = resolveClaudePaneState(state, paneKey, {
     state: reportedStateName,
     interrupted
   })
+  const effectiveState = resolved.state
   const effectiveRoster = state.claudeSubagentRosterByPaneKey.get(paneKey)
   if (
     isTurnBoundary &&
@@ -3038,6 +3054,7 @@ function normalizeClaudeEvent(
 
   return buildClaudeStatusPayload(state, eventName, promptText, paneKey, hookPayload, {
     stateName: effectiveState,
+    backgroundOnly: resolved.backgroundOnly,
     updateToolSnapshot: true,
     interrupted
   })
@@ -3054,6 +3071,7 @@ function buildClaudeStatusPayload(
     updateToolSnapshot: boolean
     interrupted?: boolean
     sessionBoundary?: boolean
+    backgroundOnly?: true
   }
 ): ParsedAgentStatusPayload | null {
   // Why: child-driven refreshes are roster bookkeeping, not lead tool activity; read the cached snapshot without merging so they can't clear a live AskUserQuestion card or clobber the tool preview.
@@ -3078,6 +3096,7 @@ function buildClaudeStatusPayload(
     lastAssistantMessage: snapshot.lastAssistantMessage,
     interrupted: options.interrupted,
     sessionBoundary: options.sessionBoundary,
+    backgroundOnly: options.backgroundOnly,
     subagents: claudeRosterToSnapshots(state.claudeSubagentRosterByPaneKey.get(paneKey))
   })
 }

--- a/src/shared/agent-status-types.ts
+++ b/src/shared/agent-status-types.ts
@@ -135,6 +135,10 @@ export type AgentStatusEntry = {
   interrupted?: boolean
   /** True when this `done` is a session boundary, not a completed turn. See AgentStatusPayload. */
   sessionBoundary?: boolean
+  /** True when this `working` is held up only by registered background work
+   *  (shell, subagent, monitor, session cron) after the foreground turn ended.
+   *  See AgentStatusPayload. */
+  backgroundOnly?: boolean
   /** Orchestration dispatch context for panes spawned by another agent.
    *  Why: parent/child hierarchy is pane-level state, not worktree lineage — workers often share the coordinator's worktree. */
   orchestration?: AgentStatusOrchestrationContext
@@ -184,6 +188,13 @@ export type AgentStatusPayload = {
    *  completions (notifications, automation runs, unread badges, finished timestamps)
    *  must ignore it. Only meaningful on `done`. */
   sessionBoundary?: boolean
+  /** True when the pane's `working` is held up only by registered background work
+   *  (background shell, subagent, monitor, session cron) whose owning foreground
+   *  turn has already ended. The pane is still genuinely live — liveness,
+   *  keep-awake, hibernation and teardown must keep treating it as `working` —
+   *  but presentation surfaces must not render it as active foreground work
+   *  (#14253 / STA-4119). Only meaningful on `working`. */
+  backgroundOnly?: boolean
   /** Live in-process children of the reporting session. See AgentStatusEntry. */
   subagents?: AgentSubagentSnapshot[]
 }
@@ -217,6 +228,7 @@ export function pickParsedAgentStatusPayload(
       : {}),
     ...(row.interrupted !== undefined ? { interrupted: row.interrupted } : {}),
     ...(row.sessionBoundary !== undefined ? { sessionBoundary: row.sessionBoundary } : {}),
+    ...(row.backgroundOnly !== undefined ? { backgroundOnly: row.backgroundOnly } : {}),
     ...(row.subagents !== undefined ? { subagents: row.subagents } : {})
   }
 }
@@ -417,6 +429,8 @@ function normalizeAgentStatusObject(parsed: unknown): ParsedAgentStatusPayload |
     // Why: only meaningful on `done`; coerce to undefined elsewhere so it can't leak stale truth across transitions.
     interrupted: obj.interrupted === true && state === 'done' ? true : undefined,
     sessionBoundary: obj.sessionBoundary === true && state === 'done' ? true : undefined,
+    // Why: only meaningful on `working`; a stale marker on any other state would let a presentation surface mute a real foreground turn.
+    backgroundOnly: obj.backgroundOnly === true && state === 'working' ? true : undefined,
     subagents: normalizeSubagentsField(obj.subagents)
   }
 }

--- a/src/shared/claude-foreground-idle-background-work-status.test.ts
+++ b/src/shared/claude-foreground-idle-background-work-status.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from 'vitest'
+import {
+  clearClaudeAnsweredQuestionWait,
+  createHookListenerState,
+  normalizeHookPayload,
+  seedClaudeSubagentRosterFromSnapshots,
+  type HookListenerState
+} from './agent-hook-listener'
+import { isBackgroundOnlyAgentActivity } from './agent-background-only-activity'
+import {
+  normalizeAgentStatusPayload,
+  pickParsedAgentStatusPayload,
+  type ParsedAgentStatusPayload
+} from './agent-status-types'
+import { makePaneKey } from './stable-pane-id'
+
+// STA-4119 / #14253. Claude sits at its idle `❯` prompt (so `orca terminal wait
+// --for tui-idle` is satisfied) while a background shell / subagent / monitor is
+// still registered. `resolveClaudePaneState` keeps the pane `working` so
+// liveness, keep-awake, hibernation and teardown stay correct — the pane really
+// is live. These pin that the emitted row also carries `backgroundOnly`, which
+// is the only thing presentation surfaces can use to stop drawing a finished
+// turn as active foreground work.
+
+const PANE_KEY = makePaneKey('tab-4119', '11111111-1111-4111-8111-111111111111')
+
+function claudeEvent(
+  state: HookListenerState,
+  payload: Record<string, unknown>
+): ParsedAgentStatusPayload | undefined {
+  return normalizeHookPayload(state, 'claude', { paneKey: PANE_KEY, payload }, 'production')
+    ?.payload
+}
+
+function runningTurn(state: HookListenerState, prompt = 'do the thing'): void {
+  claudeEvent(state, { hook_event_name: 'UserPromptSubmit', prompt })
+}
+
+const RUNNING_MONITOR = { id: 'monitor-1', type: 'monitor', status: 'running' }
+const RUNNING_SHELL = {
+  id: 'shell-1',
+  type: 'shell',
+  status: 'running',
+  command: 'npm run dev'
+}
+
+describe('Claude foreground-idle pane with live background work', () => {
+  it('marks the lead Stop background-only while a monitor is still running', () => {
+    const state = createHookListenerState()
+    runningTurn(state)
+
+    const stop = claudeEvent(state, {
+      hook_event_name: 'Stop',
+      background_tasks: [RUNNING_MONITOR]
+    })
+
+    // Why: the pane stays `working` on purpose — every liveness/keep-awake/
+    // hibernation gate reads `state`, and the monitor is genuinely running.
+    expect(stop?.state).toBe('working')
+    expect(stop?.backgroundOnly).toBe(true)
+    expect(isBackgroundOnlyAgentActivity(stop)).toBe(true)
+  })
+
+  it('marks the lead Stop background-only for a long-lived background shell', () => {
+    const state = createHookListenerState()
+    runningTurn(state, 'start the dev server')
+
+    const stop = claudeEvent(state, {
+      hook_event_name: 'Stop',
+      background_tasks: [RUNNING_SHELL]
+    })
+
+    expect(stop).toMatchObject({ state: 'working', backgroundOnly: true })
+  })
+
+  it('marks the lead Stop background-only for a background subagent and keeps its row working', () => {
+    const state = createHookListenerState()
+    runningTurn(state, 'spawn a child')
+    claudeEvent(state, {
+      hook_event_name: 'SubagentStart',
+      agent_id: 'a1',
+      agent_type: 'explore'
+    })
+
+    const stop = claudeEvent(state, {
+      hook_event_name: 'Stop',
+      background_tasks: [{ id: 'a1', type: 'subagent', status: 'running' }]
+    })
+
+    expect(stop).toMatchObject({ state: 'working', backgroundOnly: true })
+    // Why: the child is the background work; muting the parent must not hide it.
+    expect(stop?.subagents).toEqual([expect.objectContaining({ id: 'a1', state: 'working' })])
+  })
+
+  it('marks the lead Stop background-only for an active session cron', () => {
+    const state = createHookListenerState()
+    runningTurn(state)
+
+    const stop = claudeEvent(state, {
+      hook_event_name: 'Stop',
+      background_tasks: [],
+      session_crons: [{ id: 'cron-1' }]
+    })
+
+    expect(stop).toMatchObject({ state: 'working', backgroundOnly: true })
+  })
+
+  it('drops the marker on the later all-clear', () => {
+    const state = createHookListenerState()
+    runningTurn(state, 'spawn a child')
+    claudeEvent(state, { hook_event_name: 'SubagentStart', agent_id: 'a1' })
+    claudeEvent(state, {
+      hook_event_name: 'Stop',
+      background_tasks: [{ id: 'a1', type: 'subagent', status: 'running' }]
+    })
+
+    const allClear = claudeEvent(state, { hook_event_name: 'SubagentStop', agent_id: 'a1' })
+
+    expect(allClear?.state).toBe('done')
+    expect(allClear?.backgroundOnly).toBeUndefined()
+  })
+
+  it('clears the marker when a new foreground turn starts while background work persists', () => {
+    const state = createHookListenerState()
+    runningTurn(state)
+    const stop = claudeEvent(state, {
+      hook_event_name: 'Stop',
+      background_tasks: [RUNNING_SHELL]
+    })
+    expect(stop?.backgroundOnly).toBe(true)
+
+    const nextTurn = claudeEvent(state, {
+      hook_event_name: 'UserPromptSubmit',
+      prompt: 'now do the next thing'
+    })
+
+    // Why: the shell is still registered, but the user is watching a live turn again —
+    // the pane must spin, not sit in the muted background presentation.
+    expect(nextTurn?.state).toBe('working')
+    expect(nextTurn?.backgroundOnly).toBeUndefined()
+
+    const secondStop = claudeEvent(state, {
+      hook_event_name: 'Stop',
+      background_tasks: [RUNNING_SHELL]
+    })
+    expect(secondStop).toMatchObject({ state: 'working', backgroundOnly: true })
+  })
+
+  it('never marks an interrupted turn — the interrupt already retires background work', () => {
+    const state = createHookListenerState()
+    runningTurn(state)
+
+    const interrupted = claudeEvent(state, {
+      hook_event_name: 'Stop',
+      is_interrupt: true,
+      background_tasks: [RUNNING_SHELL]
+    })
+
+    expect(interrupted?.state).toBe('done')
+    expect(interrupted?.backgroundOnly).toBeUndefined()
+  })
+
+  it('marks the restored lead when an answered child question resumes background work', () => {
+    const state = createHookListenerState()
+    runningTurn(state)
+    claudeEvent(state, { hook_event_name: 'SubagentStart', agent_id: 'a1' })
+    claudeEvent(state, { hook_event_name: 'Stop' })
+    claudeEvent(state, {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'AskUserQuestion',
+      agent_id: 'a1',
+      tool_input: { questions: [{ question: 'Continue?' }] }
+    })
+
+    expect(clearClaudeAnsweredQuestionWait(state, PANE_KEY)).toEqual({
+      state: 'working',
+      backgroundOnly: true
+    })
+  })
+
+  it('marks a hydrated roster gated back up to working after a restart', () => {
+    const state = createHookListenerState()
+    seedClaudeSubagentRosterFromSnapshots(state, PANE_KEY, [
+      { id: 'a1', state: 'working', startedAt: 1, agentType: 'explore' }
+    ])
+
+    // Why: a restart empties the lead cache; the pane's next real turn boundary is
+    // still gated up by the restored child, so it must present as background work.
+    const stop = claudeEvent(state, { hook_event_name: 'Stop' })
+
+    expect(stop).toMatchObject({ state: 'working', backgroundOnly: true })
+  })
+})
+
+describe('backgroundOnly wire contract', () => {
+  it('is clamped to working so it cannot mute a done or waiting row', () => {
+    for (const state of ['done', 'waiting', 'blocked'] as const) {
+      expect(normalizeAgentStatusPayload({ state, backgroundOnly: true })?.backgroundOnly).toBe(
+        undefined
+      )
+    }
+    expect(
+      normalizeAgentStatusPayload({ state: 'working', backgroundOnly: true })?.backgroundOnly
+    ).toBe(true)
+  })
+
+  it('rejects non-boolean values from an untrusted hook payload', () => {
+    for (const value of ['true', 1, {}, []]) {
+      expect(
+        normalizeAgentStatusPayload({ state: 'working', backgroundOnly: value })?.backgroundOnly
+      ).toBe(undefined)
+    }
+  })
+
+  it('survives the paired-client projection', () => {
+    const row = normalizeAgentStatusPayload({ state: 'working', backgroundOnly: true })
+    expect(row).not.toBeNull()
+    expect(pickParsedAgentStatusPayload(row!).backgroundOnly).toBe(true)
+  })
+
+  it('reads an older peer that never stamps the field as ordinary foreground work', () => {
+    // Why: SSH relays and paired hosts update independently. An old host emits the
+    // same gated `working` with no marker, so the receiver renders today's spinner.
+    const legacyRow = normalizeAgentStatusPayload({ state: 'working' })
+    expect(legacyRow?.backgroundOnly).toBeUndefined()
+    expect(isBackgroundOnlyAgentActivity(legacyRow ?? undefined)).toBe(false)
+  })
+
+  it('ignores the field on an older receiver by dropping unknown keys', () => {
+    // Why: `normalizeAgentStatusObject` rebuilds field-by-field, so a new host's
+    // marker cannot corrupt an old receiver — it simply does not survive the parse.
+    const { backgroundOnly, ...withoutMarker } = normalizeAgentStatusPayload({
+      state: 'working',
+      backgroundOnly: true
+    })!
+    expect(backgroundOnly).toBe(true)
+    expect(normalizeAgentStatusPayload(withoutMarker)?.backgroundOnly).toBeUndefined()
+  })
+})

--- a/src/shared/dashboard-snapshot.ts
+++ b/src/shared/dashboard-snapshot.ts
@@ -84,6 +84,9 @@ export type DashboardCard = {
   agentType: AgentType
   bucket: DashboardBucket
   dotState: DashboardCardDotState
+  /** Presentation-only marker for a finished foreground turn whose registered
+   *  background work keeps the card in the working bucket. */
+  backgroundOnly?: true
   /** One-line task/prompt text shown on the card. */
   task: string
   /** The most recent message the user sent this agent (its current prompt). */

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -761,6 +761,9 @@ export type RuntimeWorktreeAgentRow = {
   updatedAt: number
   /** See AgentStatusEntry.restoredUnconfirmed — set for hydrated nonterminal rows so clients don't render them as confirmed activity. */
   restoredUnconfirmed?: boolean
+  /** See AgentStatusEntry.backgroundOnly — a `working` row whose foreground turn
+   *  already ended. Clients that predate the field render it as plain `working`. */
+  backgroundOnly?: boolean
 }
 
 export type RuntimeWorktreePsSummary = {


### PR DESCRIPTION
## ELI5

When Claude finishes a turn but leaves something running in the background — a dev server it started as a background shell, a subagent, a monitor, a session cron — Orca keeps the pane marked `working`. That is correct: the pane really is still live, and keep-awake, auto-hibernation and teardown all depend on it.

But the *picture* was wrong. The worktree card, the tab glyph and the agent row all drew the spinning "Claude is working right now" indicator, forever, while the TUI sat at its idle `❯` prompt. This PR keeps the pane live and stops it from *looking* like active foreground work.

## What Changed

`resolveClaudePaneState` (`src/shared/agent-hook-listener.ts`) already knows the difference between "the lead turn is running" and "the lead turn ended but background work gated it back up to `working`". It threw that provenance away. Now it returns it, and the emitted row carries an optional `backgroundOnly` marker.

`state` is unchanged — still `working`. Only surfaces that render **foreground** activity consult the marker:

| Surface | main | this PR |
|---|---|---|
| Worktree card dot | `working` (yellow spinner) | `done` (green) |
| Terminal tab glyph | `working` | `done` (check) |
| Sidebar / dashboard agent row | `working` (spinning ring) | new `background` dot — the same yellow ring, **complete and still**, labeled "Background work" |
| Subagent child rows | `working` | **unchanged** — live children keep spinning |
| Row tool line (`Bash: npm run dev`) | shown | dropped (it belongs to the turn that ended) |
| `entry.state` | `working` | `working` |
| Liveness / keep-awake / auto-hibernation / teardown | live | **live, byte-identical** |

The marker is cleared the moment a new foreground turn starts, so the next prompt spins again even while the dev server keeps running.

New module `src/shared/agent-background-only-activity.ts` holds the one predicate all four presentation seams share.

## Why

`resolveClaudePaneState` gating up to `working` is correct and must stay — it is the only thing keeping the pane out of the hibernation planner and the keep-awake reaper while a real dev server runs. So the fix cannot be "report `done`". It has to be "report `working`, and say *why*".

Keeping `state` fixed is what makes this narrow: every liveness consumer reads `state` and is untouched by construction. There is no new state in `AGENT_STATUS_STATES`, no capability negotiation, and no behavior change for panes with no background work (the marker is only ever set on the gated branch).

### Relationship to #14580 — independent behavior, shared plumbing

**#14580 fixes notification timing. This PR fixes the picture. Neither behavior depends on the other, but both carry additive metadata through the same agent-status pipeline, so they share plumbing and will need conflict resolution if both land.**

- #14580 stamps `turnCompletedAt` and changes *when the completion banner fires*; it explicitly preserves the spinner.
- This PR stamps `backgroundOnly` and changes *what the sidebar draws*. It does not change notification identity or completion coordination.
- The fields are orthogonal: `turnCompletedAt` is a timestamp keyed to announcement identity; `backgroundOnly` is a boolean keyed to presentation. Together they provide the complete behavior requested by the issue.
- The branches overlap in eight files: `src/main/agent-hooks/server.ts`, `src/main/runtime/orca-runtime.ts`, `src/renderer/src/hooks/useIpcEvents.ts`, `src/renderer/src/runtime/web-session-tabs-sync.ts`, `src/shared/agent-hook-listener.test.ts`, `src/shared/agent-hook-listener.ts`, `src/shared/agent-status-types.ts`, and `src/shared/runtime-types.ts`.
- A merge-tree check shows real textual conflicts in that shared plumbing. If #14580 lands first, this branch must be rebased and resolved by preserving both additive fields and their dedupe/projection paths; the product decisions remain independent.

**Not a duplicate of #14375** (merged). That one narrows when a *phantom* `working` may be minted after a restart with no cached lead — `buildClaudeCachedLeadStatusPayload`'s evidence path. This PR does not change any state value at all; it annotates a `working` that #14375 already agrees is legitimate. The evidence-minted `working` in that path is correctly left unmarked here: no lead boundary was observed, so there is nothing to claim finished.

## Linked Issue

Related: #14253 (presentation half only; completion notifications remain tracked separately).

Linear: **STA-4119**. Same mechanism as #13245.

## Visual Proof

Captured live over CDP against an isolated Orca dev instance launched from this worktree, driving the real store through `setAgentStatus` and reading the rendered accessibility tree.

**Worktree card + agent rows** — before (all spinning) → after (card green, rows static ring, **child row still spinning**):

![4119-before-card.png](https://github.com/user-attachments/assets/779d271c-bf63-4a31-b2a5-2d1001131711)

![4119-after-card.png](https://github.com/user-attachments/assets/dc34ee45-2c97-4188-ad89-6d4c46942146)

**Terminal tab glyph** — before → after:

![4119-before-tab1.png](https://github.com/user-attachments/assets/13ffb938-f5fb-43bf-9c83-a87f84265181)

![4119-after-tab1.png](https://github.com/user-attachments/assets/b722ac05-8f37-4550-9a2e-e261088fd788)

Rendered accessibility tree, same instance, same panes:

| node | before | after |
|---|---|---|
| worktree card | `Working main primary` | `Done main primary` |
| tab 1 | `Working Terminal 1` | `Done Terminal 1` |
| tab 2 | `Working Terminal 2` | `Done Terminal 2` |
| agent row 1 | `Working wire up the release checklist - Bash: npm run dev` | `Background work wire up the release checklist - Claude` |
| agent row 2 | `Working start the dev server - Bash: npm run dev` | `Background work start the dev server - Claude` |
| subagent child | `Working scan the repo - explore` | `Working scan the repo - explore` |

Then re-published a plain `working` (a new foreground turn while the background work persists) on the same panes: card, both tabs and both rows all returned to `Working`. The marker round-trips.

Design: no new tokens, no new color tier. `background` reuses the existing `AgentWorkingSpinner` ring in its documented reduced-motion form (complete ring, no rotation — `#9515` already established that as "an intentional static marker"), so it stays in the `working` color family because work really is running, and loses the motion because nothing is happening in the turn the user is watching.

## Testing

- [x] I manually tested these changes locally — live Electron/CDP session above (macOS).
- [x] Automated tests added/updated

Two new suites, **24 cases**, both proven red on `main` by reverting each production seam in turn:

`src/shared/claude-foreground-idle-background-work-status.test.ts` (14) — replays real hook sequences through the real `normalizeHookPayload`:
- live monitor at lead `Stop`; long-lived background shell; background subagent (and its row stays `working`); active session cron
- the later all-clear drops the marker
- a new foreground turn while background work persists clears it, and the *next* `Stop` re-sets it
- an interrupted turn is never marked
- an answered child question restoring a finished lead is marked
- a roster hydrated from a restart snapshot is marked
- wire contract: clamped to `working`; non-boolean values rejected; survives `pickParsedAgentStatusPayload`; an older peer that never stamps it reads as ordinary foreground work; an older receiver drops it on parse

`src/renderer/src/components/sidebar/background-only-agent-presentation.test.ts` (10) — card summary, tab glyph, row dot:
- foreground `working` still spins on every surface
- background-only reports `hasLiveDone` / `done` / `background`
- a stale marker on a non-`working` row is ignored
- **live subagent child rows stay `working` under a background-only parent**
- interrupted still wins
- the row is still a fresh non-`done` status, so keep-awake and hibernation see live work

Reverting `agent-hook-listener.ts` alone turns 7 listener cases red; reverting the three presentation seams turns 3 presentation cases red.

Also run: `pnpm typecheck` (node + cli + web) exit 0; `oxlint` + `oxfmt --check` clean on every touched file; `pnpm exec vitest run` over `src/shared`, `src/main`, `src/renderer/src/components`, `src/renderer/src/store`, `src/renderer/src/hooks`, `src/renderer/src/lib`, `src/renderer/src/runtime` — 800 files / 7998 tests green.

## Review

- **Security** — `backgroundOnly` arrives from an untrusted agent hook payload. It is accepted only as literal `true` and only on `working`; every other type or state normalizes to `undefined`, exactly like `interrupted` and `sessionBoundary`. It is never parsed, formatted into a path, or interpolated into a command. Worst case a hostile value makes that pane's own dot quieter; it cannot cross panes or suppress another agent's state.
- **Cross-platform** — pure state resolution plus renderer presentation. No shell, path, keyboard, label, or Electron platform branch. The reporter is on Windows; nothing here is platform-conditional.
- **Remote SSH / mixed versions** — the field rides `ParsedAgentStatusPayload`, which is what `AgentHookRelayEnvelope.payload` already carries and what `ingestRemote` re-validates at the trust boundary, so the relay path needs no change. New host → old client: `normalizeAgentStatusObject` rebuilds field-by-field and drops the unknown key, so the client renders today's spinner. Old host → new client: the field is simply absent and the row reads as ordinary foreground work. Additive-optional both ways, no new stream opcode, **no capability gate needed** — unlike `sessionBoundary`, an old peer cannot *mis*act on it, since ignoring it reproduces current behavior exactly. Both directions are pinned by tests.
- **Folder workspaces** — nothing here reads git state, worktree kind, or repo layout; attribution is by `paneKey` / `tabId` as before.
- **Mobile** — `RuntimeWorktreeAgentRow.backgroundOnly` is forwarded so `worktree ps` and paired clients can see it. Mobile's own row rendering is **deliberately unchanged** in this PR (same scope call `#14375` made for `restoredUnconfirmed`); paired clients that predate the field decode fine and render `working`. Mobile presentation parity is a clean follow-up on top of the now-available field.
- **Backwards compatibility** — a pane with no background work never reaches the marked branch, so the overwhelmingly common case is byte-identical. `AGENT_STATUS_STATES` is unchanged; `AgentStatusState` gains no member.
- **Performance** — one boolean per gated event, and one extra `!==` in the store's sort-relevance check. The new epoch term is required, not incidental: the whole transition is `working → working`, so without it the memoized card/tab summaries would never recompute. Same reason `equivalentParsedAgentStatusPayload` in `agent-hooks/server.ts` now compares it — deduping that edge would drop the fix before any receiver saw it.

### Deliberately out of scope

- **Smart sort / smart attention** is unchanged: a background-only pane stays in Class 3 (`working`). Background work is real work, so ordering by it is not a false claim, and the honest completion timestamp for the ranking is `turnCompletedAt` — which is #14580's field, not this one. Worth revisiting once both land.
- **Mobile row rendering**, as above.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] Focused typecheck / lint / tests pass locally (full `pnpm build` left to CI)

## Author

- X / Twitter: @BrennanKB5

