### PR TITLE
fix(agent-hooks): report hook status per host, and stop remote Codex reusing an env-less app-server (#8711, #11941)

### DIFF
--- a/config/scripts/smoke-managed-hook-runtime-node18.mjs
+++ b/config/scripts/smoke-managed-hook-runtime-node18.mjs
@@ -38,7 +38,24 @@ try {
   })
 
   const summary = await runtimes[0].installManagedHooks({ agents: ['codex', 'claude'] })
-  assert.deepEqual(summary, { installers: 2, errors: 0 })
+  assert.equal(summary.installers, 2)
+  assert.equal(summary.errors, 0)
+  // Why: #8711 made the runtime return per-agent statuses so a host reports
+  // which agent failed instead of a bare count. Sorted because install order
+  // is not the caller's agent order.
+  assert.deepEqual(
+    [...summary.statuses]
+      .sort((a, b) => a.agent.localeCompare(b.agent))
+      .map(({ agent, state, managedHooksPresent }) => ({ agent, state, managedHooksPresent })),
+    [
+      { agent: 'claude', state: 'installed', managedHooksPresent: true },
+      { agent: 'codex', state: 'installed', managedHooksPresent: true }
+    ]
+  )
+  for (const status of summary.statuses) {
+    // Each status must name a path on the host that was actually installed to.
+    assert.equal(status.configPath.startsWith(home), true, `${status.agent} configPath under home`)
+  }
 
   const codexHooks = await readFile(join(home, '.codex', 'hooks.json'), 'utf8')
   const claudeSettings = await readFile(join(home, '.claude', 'settings.json'), 'utf8')

--- a/src/cli/handlers/agent-hooks-host-status.test.ts
+++ b/src/cli/handlers/agent-hooks-host-status.test.ts
@@ -1,0 +1,166 @@
+// Why (#8711): reproduced live — with an SSH host connected and its remote
+// `~/.codex/hooks.json` absent, `orca agent hooks status` printed
+// `codex: installed` from the local managed home, naming no host at all. These
+// tests fail against that behavior: the report must name each host, and must
+// never let the local answer stand in for a host it did not check.
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getDefaultPersistedState } from '../../shared/constants'
+import type { AgentHookHostReport } from '../../shared/agent-hook-host-status'
+import type { AgentHookInstallStatus } from '../../shared/agent-hook-types'
+
+const { callMock, getCliStatusMock, getDefaultUserDataPathMock, getManagedAgentHookStatusesMock } =
+  vi.hoisted(() => ({
+    callMock: vi.fn(),
+    getCliStatusMock: vi.fn(),
+    getDefaultUserDataPathMock: vi.fn(),
+    getManagedAgentHookStatusesMock: vi.fn()
+  }))
+
+vi.mock('../runtime-client', () => {
+  class RuntimeClient {
+    call = callMock
+    getCliStatus = getCliStatusMock
+  }
+  class RuntimeClientError extends Error {
+    readonly code: string
+    constructor(code: string, message: string) {
+      super(message)
+      this.code = code
+    }
+  }
+  return { RuntimeClient, RuntimeClientError, getDefaultUserDataPath: getDefaultUserDataPathMock }
+})
+
+vi.mock('../../main/agent-hooks/managed-agent-hook-controls', () => ({
+  applyAgentStatusHooksEnabled: vi.fn(),
+  getManagedAgentHookStatuses: getManagedAgentHookStatusesMock,
+  prepareManagedCodexHomeBeforeShellLaunch: vi.fn()
+}))
+
+import { main } from '../index'
+
+const LOCAL_CODEX_INSTALLED: AgentHookInstallStatus = {
+  agent: 'codex',
+  state: 'installed',
+  configPath: '/Users/dev/Library/Application Support/orca/codex-runtime-home/home/hooks.json',
+  managedHooksPresent: true,
+  detail: null
+}
+
+function sshHostReport(state: AgentHookHostReport['state']): AgentHookHostReport {
+  return {
+    host: { kind: 'ssh', targetId: 'ssh-1', label: 'my-linux-box' },
+    state,
+    detail: state === 'skipped' ? 'No managed agent CLI was detected on the remote host.' : null,
+    statuses:
+      state === 'skipped'
+        ? []
+        : [
+            {
+              agent: 'codex',
+              state: 'not_installed',
+              configPath: '/home/dev/.codex/hooks.json',
+              managedHooksPresent: false,
+              detail: null
+            }
+          ]
+  }
+}
+
+describe('orca agent hooks status — per-host truthfulness', () => {
+  let userDataPath: string
+  let logged: string[]
+
+  beforeEach(() => {
+    userDataPath = mkdtempSync(join(tmpdir(), 'orca-hooks-host-'))
+    mkdirSync(userDataPath, { recursive: true })
+    writeFileSync(
+      join(userDataPath, 'orca-data.json'),
+      JSON.stringify(getDefaultPersistedState(userDataPath), null, 2),
+      'utf-8'
+    )
+    getDefaultUserDataPathMock.mockReturnValue(userDataPath)
+    getManagedAgentHookStatusesMock.mockReturnValue([LOCAL_CODEX_INSTALLED])
+    callMock.mockReset()
+    getCliStatusMock.mockReset()
+    logged = []
+    vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      logged.push(args.map(String).join(' '))
+    })
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    process.exitCode = undefined
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    rmSync(userDataPath, { recursive: true, force: true })
+  })
+
+  async function runStatus(json = false): Promise<string> {
+    await main(['agent', 'hooks', 'status', ...(json ? ['--json'] : [])], userDataPath)
+    return logged.join('\n')
+  }
+
+  it('names the SSH host that runs the agent instead of only the local machine', async () => {
+    callMock.mockResolvedValue({
+      result: { hosts: [localReport(), sshHostReport('partial')] }
+    })
+
+    const output = await runStatus()
+
+    expect(callMock).toHaveBeenCalledWith('agentHooks.status', undefined, { timeoutMs: 10_000 })
+    expect(output).toContain('local: installed')
+    expect(output).toContain('ssh:my-linux-box: partial')
+    expect(output).toContain('codex: not_installed')
+  })
+
+  it('does not report the SSH host as installed when Codex is missing there', async () => {
+    callMock.mockResolvedValue({ result: { hosts: [localReport(), sshHostReport('skipped')] } })
+
+    const output = await runStatus()
+
+    expect(output).toContain('ssh:my-linux-box: skipped')
+    expect(output).toContain('No managed agent CLI was detected on the remote host.')
+    expect(output).not.toMatch(/ssh:my-linux-box: installed/)
+  })
+
+  it('says SSH host status is unavailable when the runtime cannot be reached', async () => {
+    callMock.mockRejectedValue(new Error('runtime_unreachable'))
+
+    const output = await runStatus()
+
+    expect(output).toContain('local: installed')
+    expect(output).toContain('ssh: unknown')
+    expect(output).toContain('SSH host hook status is unavailable from this machine.')
+    // Why: the notice belongs to the hosts Orca could not check, not to the
+    // local host — attaching it there would mislabel a healthy local install.
+    expect(output).not.toMatch(/local: \w+ — Orca is not running/)
+  })
+
+  it('scopes every JSON status line to a named host', async () => {
+    callMock.mockResolvedValue({ result: { hosts: [localReport(), sshHostReport('partial')] } })
+
+    const parsed = JSON.parse(await runStatus(true)) as {
+      result: { hosts: AgentHookHostReport[] }
+    }
+
+    expect(parsed.result.hosts.map((host) => host.host.kind)).toEqual(['local', 'ssh'])
+    for (const host of parsed.result.hosts) {
+      expect(host.host).toBeDefined()
+      expect(host.state).toBeDefined()
+    }
+  })
+})
+
+function localReport(): AgentHookHostReport {
+  return {
+    host: { kind: 'local' },
+    state: 'installed',
+    detail: null,
+    statuses: [LOCAL_CODEX_INSTALLED]
+  }
+}

--- a/src/cli/handlers/agent-hooks.ts
+++ b/src/cli/handlers/agent-hooks.ts
@@ -11,6 +11,11 @@ import {
   getDefaultUserDataPath
 } from '../runtime-client'
 import type { AgentHookInstallStatus } from '../../shared/agent-hook-types'
+import {
+  formatAgentHookHostReports,
+  summarizeAgentHookHostState,
+  type AgentHookHostReport
+} from '../../shared/agent-hook-host-status'
 import { getDefaultPersistedState } from '../../shared/constants'
 import { normalizeDisabledTuiAgents } from '../../shared/tui-agent-selection'
 import type { GlobalSettings } from '../../shared/global-settings-types'
@@ -26,6 +31,10 @@ type AgentHookCommandResult = {
   settingsPath: string
   appliedBy: 'runtime' | 'offline'
   statuses: AgentHookInstallStatus[]
+  /** Per-host managed hook state, local host first. `statuses` above stays for
+   *  compatibility but describes the local host only — read `hosts` to learn
+   *  whether the host that runs the agent can fire its hooks at all (#8711). */
+  hosts: AgentHookHostReport[]
 }
 
 function getDataPath(): string {
@@ -174,17 +183,55 @@ function localSuccess<TResult>(result: TResult): RuntimeRpcSuccess<TResult> {
 }
 
 function formatAgentHookCommandResult(result: AgentHookCommandResult): string {
-  const statusSummary = result.statuses
-    .map((status) => `${status.agent}: ${status.state}`)
-    .join('\n')
   return [
     `agentStatusHooksEnabled: ${result.enabled}`,
     `appliedBy: ${result.appliedBy}`,
     `settingsPath: ${result.settingsPath}`,
-    statusSummary
+    formatAgentHookHostReports(result.hosts),
+    result.appliedBy === 'offline' ? RUNTIME_UNREACHABLE_NOTICE : ''
   ]
     .filter(Boolean)
     .join('\n')
+}
+
+function localOnlyHosts(statuses: AgentHookInstallStatus[]): AgentHookHostReport[] {
+  return [
+    {
+      host: { kind: 'local' },
+      state: summarizeAgentHookHostState(statuses),
+      detail: null,
+      statuses
+    }
+  ]
+}
+
+/** Why (#8711): without the runtime, this command can see the local machine and
+ *  nothing else. It must say so — a bare local list reads as a verdict for every
+ *  host, which is what made `codex: installed` misdirect SSH debugging. */
+const RUNTIME_UNREACHABLE_NOTICE =
+  'ssh: unknown — Orca is not running; SSH host hook status is unavailable from this machine.'
+
+async function readAgentHookHostReports(client: RuntimeClient): Promise<{
+  hosts: AgentHookHostReport[]
+  appliedBy: 'runtime' | 'offline'
+}> {
+  try {
+    const response = await client.call<{ hosts?: AgentHookHostReport[] }>(
+      'agentHooks.status',
+      undefined,
+      { timeoutMs: 10_000 }
+    )
+    const hosts = response.result.hosts
+    if (Array.isArray(hosts) && hosts.length > 0) {
+      return { hosts, appliedBy: 'runtime' }
+    }
+  } catch {
+    // Fall through to the local-only report below.
+  }
+  return {
+    hosts: localOnlyHosts(getManagedAgentHookStatuses()),
+    appliedBy: 'offline'
+  }
 }
 
 async function setAgentHooksEnabled(
@@ -197,11 +244,15 @@ async function setAgentHooksEnabled(
   const statuses = updatedRuntime
     ? getManagedAgentHookStatuses()
     : await applyAgentStatusHooksEnabled(enabled, offlineUpdate?.settings)
+  const hosts = updatedRuntime
+    ? (await readAgentHookHostReports(client)).hosts
+    : localOnlyHosts(statuses)
   return {
     enabled,
     settingsPath,
     appliedBy: updatedRuntime ? 'runtime' : 'offline',
-    statuses
+    statuses,
+    hosts
   }
 }
 
@@ -214,12 +265,15 @@ export const AGENT_HOOK_HANDLERS: Record<string, CommandHandler> = {
         settings.agentStatusHooksEnabled && !settings.disabledTuiAgents.includes('codex')
     })
   },
-  'agent hooks status': async ({ json }) => {
+  'agent hooks status': async ({ client, json }) => {
+    const { hosts, appliedBy } = await readAgentHookHostReports(client)
+    const local = hosts.find((report) => report.host.kind === 'local')
     const result: AgentHookCommandResult = {
       enabled: readHookSettingsFromDisk().agentStatusHooksEnabled,
       settingsPath: getDataPath(),
-      appliedBy: 'offline',
-      statuses: getManagedAgentHookStatuses()
+      appliedBy,
+      statuses: [...(local?.statuses ?? [])],
+      hosts
     }
     printResult(localSuccess(result), json, formatAgentHookCommandResult)
   },

--- a/src/main/agent-hooks/agent-hook-host-reports.ts
+++ b/src/main/agent-hooks/agent-hook-host-reports.ts
@@ -1,0 +1,33 @@
+// Why (#8711): one place assembles "which hosts did Orca check, and what did
+// each one say", so the CLI, the runtime RPC, and any future surface cannot
+// drift back into reporting the local machine as if it spoke for every host.
+
+import {
+  summarizeAgentHookHostState,
+  type AgentHookHostReport
+} from '../../shared/agent-hook-host-status'
+import { getManagedAgentHookStatuses } from './managed-agent-hook-controls'
+
+export function getLocalAgentHookHostReport(): AgentHookHostReport {
+  const statuses = getManagedAgentHookStatuses()
+  return {
+    host: { kind: 'local' },
+    state: summarizeAgentHookHostState(statuses),
+    detail: null,
+    statuses
+  }
+}
+
+export function getAgentHookHostReports(
+  listSshReports: () => AgentHookHostReport[]
+): AgentHookHostReport[] {
+  let sshReports: AgentHookHostReport[]
+  try {
+    sshReports = listSshReports()
+  } catch {
+    // Why: an unavailable SSH layer must not silently shrink the report to the
+    // local host — that is the exact shape of the lie this fixes.
+    sshReports = []
+  }
+  return [getLocalAgentHookHostReport(), ...sshReports]
+}

--- a/src/main/agent-hooks/managed-hook-runtime.test.ts
+++ b/src/main/agent-hooks/managed-hook-runtime.test.ts
@@ -130,7 +130,11 @@ describe.runIf(process.platform !== 'win32')('installManagedHooks', () => {
       const home = await createTempHome()
       await stubLoginShell(home)
 
-      await expect(installManagedHooks(options)).resolves.toEqual({ installers: 0, errors: 0 })
+      await expect(installManagedHooks(options)).resolves.toEqual({
+        installers: 0,
+        errors: 0,
+        statuses: []
+      })
 
       // Why: no agent config home, no ~/.orca install lock, and no GROK_HOME login-shell probe.
       expect(await readdir(home)).toEqual([SHELL_NAME])
@@ -150,9 +154,12 @@ describe.runIf(process.platform !== 'win32')('installManagedHooks', () => {
     const home = await createTempHome()
     await stubLoginShell(home)
 
-    await expect(installManagedHooks({ agents: ['claude'] })).resolves.toEqual({
+    // Why (#8711): the per-agent results now travel back to the client so
+    // `agent hooks status` can name what happened on this host.
+    await expect(installManagedHooks({ agents: ['claude'] })).resolves.toMatchObject({
       installers: 1,
-      errors: 0
+      errors: 0,
+      statuses: [{ agent: 'claude', state: 'installed' }]
     })
 
     expect((await readdir(home)).sort()).toEqual(['.claude', '.orca', SHELL_NAME, SHELL_RUNS_NAME])

--- a/src/main/agent-hooks/managed-hook-runtime.ts
+++ b/src/main/agent-hooks/managed-hook-runtime.ts
@@ -3,7 +3,7 @@ import { basename } from 'node:path'
 import { homedir, userInfo } from 'node:os'
 import { promisify } from 'node:util'
 import { installRemoteManagedAgentHooks } from './remote-managed-hook-installers'
-import type { AgentHookTarget } from '../../shared/agent-hook-types'
+import type { AgentHookInstallStatus, AgentHookTarget } from '../../shared/agent-hook-types'
 import { createManagedHookLocalFilesystem } from './managed-hook-local-filesystem'
 import { withManagedHookInstallLock } from './managed-hook-install-lock'
 import {
@@ -18,6 +18,10 @@ const GROK_HOME_PROBE_TIMEOUT_MS = 8_000
 export type ManagedHookInstallSummary = {
   installers: number
   errors: number
+  /** Per-agent results, so the client can report which agent failed on this
+   *  host instead of a bare count. Optional on the wire: a relay that predates
+   *  the field answers without it and the client reports `unknown` (#8711). */
+  statuses: AgentHookInstallStatus[]
 }
 
 function defaultGrokHome(home: string): string {
@@ -82,7 +86,7 @@ export async function installManagedHooks(options?: {
   // Why: empty/omitted allowlist fails closed before any home/host probes.
   const agents = options?.agents ?? []
   if (agents.length === 0) {
-    return { installers: 0, errors: 0 }
+    return { installers: 0, errors: 0, statuses: [] }
   }
   const home = homedir()
   const grokHomeDir = await resolveRelayGrokHome(home, options?.signal)
@@ -106,7 +110,8 @@ export async function installManagedHooks(options?: {
       )
       return {
         installers: results.length,
-        errors: results.filter((result) => result.state === 'error').length
+        errors: results.filter((result) => result.state === 'error').length,
+        statuses: results
       }
     },
     hostIdentity

--- a/src/main/agent-hooks/remote-hook-install-outcome.test.ts
+++ b/src/main/agent-hooks/remote-hook-install-outcome.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import { readManagedHookInstallOutcome } from './remote-hook-install-outcome'
+import type { AgentHookInstallStatus } from '../../shared/agent-hook-types'
+
+function status(
+  agent: AgentHookInstallStatus['agent'],
+  state: AgentHookInstallStatus['state'],
+  detail: string | null = null
+): AgentHookInstallStatus {
+  return { agent, state, configPath: `/home/dev/.${agent}`, managedHooksPresent: true, detail }
+}
+
+describe('readManagedHookInstallOutcome', () => {
+  it('reports installed when every agent installed on that host', () => {
+    const outcome = readManagedHookInstallOutcome({
+      installers: 2,
+      errors: 0,
+      statuses: [status('claude', 'installed'), status('codex', 'installed')]
+    })
+    expect(outcome.state).toBe('installed')
+    expect(outcome.statuses.map((entry) => entry.agent)).toEqual(['claude', 'codex'])
+  })
+
+  it('reports partial and keeps the failing agent visible', () => {
+    const outcome = readManagedHookInstallOutcome({
+      installers: 2,
+      errors: 1,
+      statuses: [
+        status('claude', 'installed'),
+        status('codex', 'error', 'Could not parse remote Codex hooks.json')
+      ]
+    })
+    expect(outcome.state).toBe('partial')
+    expect(outcome.detail).toContain('1 agent hook install(s) failed')
+    expect(outcome.statuses.find((entry) => entry.agent === 'codex')?.detail).toBe(
+      'Could not parse remote Codex hooks.json'
+    )
+  })
+
+  it('never calls a host installed when Codex did not install there', () => {
+    const outcome = readManagedHookInstallOutcome({
+      installers: 2,
+      errors: 0,
+      statuses: [status('claude', 'installed'), status('codex', 'not_installed')]
+    })
+    expect(outcome.state).not.toBe('installed')
+    expect(outcome.state).toBe('partial')
+  })
+
+  it('reports skipped when the host installed nothing at all', () => {
+    expect(readManagedHookInstallOutcome({ installers: 0, errors: 0 }).state).toBe('skipped')
+  })
+
+  it('falls back to counts from a relay that predates the per-agent field', () => {
+    const outcome = readManagedHookInstallOutcome({ installers: 3, errors: 1 })
+    expect(outcome.state).toBe('partial')
+    expect(outcome.statuses).toEqual([])
+    expect(outcome.detail).toContain('1 of 3')
+  })
+
+  it('reports unknown — never installed — when the relay says nothing usable', () => {
+    for (const result of [null, undefined, {}, { statuses: 'nope' }, 'garbage']) {
+      expect(readManagedHookInstallOutcome(result).state).toBe('unknown')
+    }
+  })
+
+  it('drops malformed status entries instead of trusting them', () => {
+    const outcome = readManagedHookInstallOutcome({
+      installers: 1,
+      errors: 0,
+      statuses: [{ agent: 'not-an-agent', state: 'installed' }, { state: 'installed' }]
+    })
+    expect(outcome.state).toBe('unknown')
+    expect(outcome.statuses).toEqual([])
+  })
+})

--- a/src/main/agent-hooks/remote-hook-install-outcome.ts
+++ b/src/main/agent-hooks/remote-hook-install-outcome.ts
@@ -1,0 +1,99 @@
+// Why (#8711): the managed-hook install RPC used to answer with counts that the
+// client threw away after a console.warn, so `agent hooks status` had nothing to
+// say about the host that actually runs the agent. This turns one relay answer
+// into the host outcome the diagnostic prints — and keeps a pre-#8711 relay,
+// which answers without `statuses`, from reading as a clean install.
+
+import {
+  summarizeAgentHookHostState,
+  type AgentHookHostOutcome
+} from '../../shared/agent-hook-host-status'
+import { AGENT_HOOK_TARGETS, type AgentHookInstallStatus } from '../../shared/agent-hook-types'
+
+const INSTALL_STATES = new Set(['installed', 'not_installed', 'partial', 'error', 'skipped'])
+const AGENTS = new Set<string>(AGENT_HOOK_TARGETS)
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function parseStatus(value: unknown): AgentHookInstallStatus | null {
+  if (!isRecord(value)) {
+    return null
+  }
+  const { agent, state } = value
+  if (typeof agent !== 'string' || !AGENTS.has(agent)) {
+    return null
+  }
+  if (typeof state !== 'string' || !INSTALL_STATES.has(state)) {
+    return null
+  }
+  return {
+    agent: agent as AgentHookInstallStatus['agent'],
+    state: state as AgentHookInstallStatus['state'],
+    configPath: typeof value.configPath === 'string' ? value.configPath : '',
+    managedHooksPresent: value.managedHooksPresent === true,
+    detail: typeof value.detail === 'string' ? value.detail : null,
+    ...(typeof value.skipReason === 'string'
+      ? { skipReason: value.skipReason as AgentHookInstallStatus['skipReason'] }
+      : {})
+  }
+}
+
+export function readManagedHookInstallOutcome(result: unknown): AgentHookHostOutcome {
+  if (!isRecord(result)) {
+    return { state: 'unknown', detail: 'Remote host returned no install result.', statuses: [] }
+  }
+  const reportedStatuses = Array.isArray(result.statuses) ? result.statuses : null
+  const statuses = (reportedStatuses ?? []).flatMap((entry) => {
+    const parsed = parseStatus(entry)
+    return parsed ? [parsed] : []
+  })
+  // Why: a host that answered with per-agent results Orca cannot read is a host
+  // Orca did not understand — falling back to the counts would let a garbled
+  // answer print as a clean install, which is the bug this whole path fixes.
+  if (reportedStatuses !== null && reportedStatuses.length > 0 && statuses.length === 0) {
+    return {
+      state: 'unknown',
+      detail: 'Remote host reported managed hook results Orca could not read.',
+      statuses: []
+    }
+  }
+  if (statuses.length > 0) {
+    const state = summarizeAgentHookHostState(statuses)
+    const failed = statuses.filter((status) => status.state === 'error')
+    return {
+      state,
+      detail:
+        failed.length > 0 ? `${failed.length} agent hook install(s) failed on this host.` : null,
+      statuses
+    }
+  }
+  // Why: a relay that predates the per-agent field still answers with counts.
+  // They are enough for a host verdict but not for a per-agent breakdown, and
+  // an install that ran zero installers is not an install that succeeded.
+  const errors = typeof result.errors === 'number' ? result.errors : null
+  const installers = typeof result.installers === 'number' ? result.installers : null
+  if (errors === null || installers === null) {
+    return {
+      state: 'unknown',
+      detail: 'Remote host did not report managed hook install results.',
+      statuses: []
+    }
+  }
+  if (installers === 0) {
+    return { state: 'skipped', detail: 'No managed agent hooks were installed.', statuses: [] }
+  }
+  if (errors === 0) {
+    return {
+      state: 'installed',
+      detail: `${installers} agent hook install(s) reported by an older remote runtime.`,
+      statuses: []
+    }
+  }
+  return {
+    state: errors >= installers ? 'error' : 'partial',
+    detail: `${errors} of ${installers} agent hook install(s) failed on this host.`,
+    statuses: []
+  }
+}

--- a/src/main/ipc/ssh.ts
+++ b/src/main/ipc/ssh.ts
@@ -11,6 +11,7 @@ import type { SshConnection, SshConnectionCallbacks } from '../ssh/ssh-connectio
 import { SshConnectionManager } from '../ssh/ssh-connection-manager'
 import type { SshChannelMultiplexer } from '../ssh/ssh-channel-multiplexer'
 import { SshRelaySession, type SshRelayAiVaultHostInfo } from '../ssh/ssh-relay-session'
+import type { AgentHookHostReport } from '../../shared/agent-hook-host-status'
 import type {
   SshAiVaultRelayListParams,
   SshAiVaultRelayTitleParams
@@ -161,6 +162,29 @@ export function getActiveSshAiVaultHostInfo(targetId: string): SshRelayAiVaultHo
     return null
   }
   return activeSessions.get(targetId)?.getAiVaultHostInfo() ?? null
+}
+
+/** Managed-hook state for every SSH host Orca currently reaches, named by the
+ *  host that actually runs the agents there (#8711). A connected host always
+ *  appears, even when its install never reported — silence would let the local
+ *  answer stand in for a host Orca could not check. */
+export function listActiveSshAgentHookReports(): AgentHookHostReport[] {
+  const labels = new Map(listRegisteredSshTargets().map((target) => [target.id, target.label]))
+  return [...activeSessions.values()].flatMap((session) => {
+    if (isRuntimeOwnedSshTargetId(session.targetId)) {
+      return []
+    }
+    return [
+      {
+        host: {
+          kind: 'ssh' as const,
+          targetId: session.targetId,
+          label: labels.get(session.targetId) ?? session.targetId
+        },
+        ...session.getManagedHookOutcome()
+      }
+    ]
+  })
 }
 
 export function getActiveSshAiVaultHostInfos(): SshRelayAiVaultHostInfo[] {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -6079,7 +6079,8 @@ describe('OrcaRuntimeService', () => {
       expect(spawn).toHaveBeenCalledWith(
         expect.objectContaining({
           cwd: '/remote/agent-feature',
-          command: "codex '--dangerously-bypass-approvals-and-sandbox' 'hi'",
+          command:
+            "codex '-c' 'features.hooks=true' '--dangerously-bypass-approvals-and-sandbox' 'hi'",
           worktreeId: result.worktree.id
         })
       )
@@ -46004,7 +46005,7 @@ describe('OrcaRuntimeService', () => {
       expect(spawn).toHaveBeenCalledWith(
         expect.objectContaining({
           cwd: '/remote/mobile-codex-draft',
-          command: "codex '--dangerously-bypass-approvals-and-sandbox'",
+          command: "codex '-c' 'features.hooks=true' '--dangerously-bypass-approvals-and-sandbox'",
           connectionId: 'ssh-1',
           worktreeId: result.worktree.id
         })

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -23251,7 +23251,8 @@ export class OrcaRuntimeService {
       agentEnv: resolveTuiAgentLaunchEnv(agent, settings.agentDefaultEnv),
       platform: agentLaunchPlatform,
       shell: queuedShell,
-      isRemote
+      isRemote,
+      agentStatusHookSettings: settings
     })
     if (draftLaunchPlan) {
       return {
@@ -23276,6 +23277,7 @@ export class OrcaRuntimeService {
       platform: agentLaunchPlatform,
       shell: queuedShell,
       isRemote,
+      agentStatusHookSettings: settings,
       allowEmptyPromptLaunch: true
     })
     if (!startupPlan) {
@@ -23329,6 +23331,7 @@ export class OrcaRuntimeService {
       platform: agentLaunchPlatform,
       shell: queuedShell,
       isRemote,
+      agentStatusHookSettings: settings,
       allowEmptyPromptLaunch: true
     })
     if (!startupPlan) {
@@ -27155,6 +27158,7 @@ export class OrcaRuntimeService {
       platform,
       shell: queuedShell,
       isRemote,
+      agentStatusHookSettings: settings,
       allowEmptyPromptLaunch: true
     })
     if (!startupPlan) {
@@ -27299,7 +27303,8 @@ export class OrcaRuntimeService {
       sessionOptions: this.toAgentSessionOptions(request.launchPreferences),
       platform,
       shell,
-      isRemote
+      isRemote,
+      agentStatusHookSettings: settings
     })
     if (!startup) {
       throw new Error('agent_session_identity_required')
@@ -27461,7 +27466,8 @@ export class OrcaRuntimeService {
         sessionOptions: this.toAgentSessionOptions(request.launchPreferences),
         platform,
         shell,
-        isRemote
+        isRemote,
+        agentStatusHookSettings: settings
       }
       const startup =
         request.promptDelivery === 'draft'
@@ -28506,6 +28512,7 @@ export class OrcaRuntimeService {
       platform,
       shell: queuedShell,
       isRemote,
+      agentStatusHookSettings: settings,
       allowEmptyPromptLaunch: true
     })
     if (!startupPlan) {

--- a/src/main/runtime/rpc/methods/agent-hooks.ts
+++ b/src/main/runtime/rpc/methods/agent-hooks.ts
@@ -1,0 +1,14 @@
+import { defineMethod, type RpcMethod } from '../core'
+import { getAgentHookHostReports } from '../../../agent-hooks/agent-hook-host-reports'
+import { listActiveSshAgentHookReports } from '../../../ipc/ssh'
+
+export const AGENT_HOOK_METHODS: RpcMethod[] = [
+  defineMethod({
+    name: 'agentHooks.status',
+    params: null,
+    // Why (#8711): only the running runtime knows which SSH hosts are live, so
+    // the truthful per-host answer has to come from here — the CLI on its own
+    // can see nothing but the local machine.
+    handler: () => ({ hosts: getAgentHookHostReports(listActiveSshAgentHookReports) })
+  })
+]

--- a/src/main/runtime/rpc/methods/index.ts
+++ b/src/main/runtime/rpc/methods/index.ts
@@ -39,6 +39,7 @@ import { EMULATOR_METHODS } from './emulator'
 import { PAIRING_METHODS } from './pairing'
 import { UPDATER_METHODS } from './updater'
 import { AGENT_SESSION_METHODS } from './agent-session'
+import { AGENT_HOOK_METHODS } from './agent-hooks'
 import { ARTIFACT_METHODS } from './artifacts'
 
 // Why: a flat manifest keeps registration order explicit and provides one
@@ -52,6 +53,7 @@ export const ALL_RPC_METHODS: readonly RpcAnyMethod[] = [
   ...REPO_METHODS,
   ...WORKTREE_METHODS,
   ...AGENT_SESSION_METHODS,
+  ...AGENT_HOOK_METHODS,
   ...TERMINAL_METHODS,
   ...TERMINAL_ORPHAN_METHODS,
   ...BROWSER_CORE_METHODS,

--- a/src/main/ssh/ssh-relay-session-managed-hook-outcome.test.ts
+++ b/src/main/ssh/ssh-relay-session-managed-hook-outcome.test.ts
@@ -1,0 +1,239 @@
+// Why (#8711): reproduced live against a real Linux SSH target — the remote
+// managed hook install produced no `~/.codex/hooks.json` and no
+// `~/.orca/agent-hooks/` script, yet the client discarded the install result
+// after a console.warn, so `agent hooks status` had nothing but the local
+// machine to report. Every outcome now leaves a per-host verdict behind, and
+// the default is `unknown` rather than silence.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { SshRelaySession } from './ssh-relay-session'
+import type { SshConnection } from './ssh-connection'
+import { AGENT_HOOK_INSTALL_MANAGED_HOOKS_METHOD } from '../../shared/agent-hook-relay'
+import { createMockDeps, mockDeploySuccess } from './ssh-relay-session-test-fixtures'
+
+const { acceptOutputDataMock, muxRequestMock, openConsumerSessionMock, pauseAdapterMock } =
+  vi.hoisted(() => ({
+    acceptOutputDataMock: vi.fn().mockResolvedValue(undefined),
+    muxRequestMock: vi.fn(),
+    openConsumerSessionMock: vi.fn(),
+    pauseAdapterMock: vi.fn()
+  }))
+
+vi.mock('./ssh-relay-deploy', () => ({
+  deployAndLaunchRelay: vi.fn()
+}))
+
+vi.mock('./ssh-pty-consumer-session', () => ({
+  openSshPtyConsumerSession: openConsumerSessionMock
+}))
+
+vi.mock('../ipc/ssh-pty-output-intake-registry', () => ({
+  acceptSshPtyOutputData: acceptOutputDataMock,
+  acceptSshPtyOutputExit: vi.fn().mockResolvedValue(undefined),
+  allocateSshPtyProviderGeneration: vi.fn(() => 41),
+  beginSshPtyOutputGenerationMigration: vi.fn(() => ({
+    byPty: new Map(),
+    completion: Promise.resolve()
+  })),
+  closeSshPtyOutputGeneration: vi.fn(),
+  getSshPtyAcceptedSourceCheckpoints: vi.fn(() => []),
+  applySshPtySourceCancellationProof: vi.fn(() => true),
+  applySshPtySourceRecoveryCancellationProof: vi.fn(() => true),
+  installSshPtySourceAckPublisher: vi.fn(() => () => {}),
+  installSshPtySourceCancellationPublisher: vi.fn(() => () => {})
+}))
+
+vi.mock('./ssh-relay-deploy-helpers', () => ({
+  execCommand: vi.fn().mockResolvedValue('')
+}))
+
+vi.mock('./ssh-channel-multiplexer', () => {
+  return {
+    SshChannelMultiplexer: class MockSshChannelMultiplexer {
+      notify = vi.fn()
+      notifyWithSettlement = vi.fn()
+      request = muxRequestMock
+      onNotification = vi.fn().mockReturnValue(() => {})
+      onNotificationByMethod = vi.fn().mockReturnValue(() => {})
+      onRequest = vi.fn().mockReturnValue(() => {})
+      onDispose = vi.fn().mockReturnValue(() => {})
+      dispose = vi.fn()
+      isDisposed = vi.fn().mockReturnValue(false)
+    }
+  }
+})
+
+vi.mock('../providers/ssh-pty-provider', () => ({
+  isSshPtyNotFoundError: (err: unknown) =>
+    (err instanceof Error ? err.message : String(err)).includes('not found'),
+  isSshPtyIdentityMismatchError: (err: unknown) =>
+    (err instanceof Error ? err.message : String(err)).includes('identity mismatch'),
+  SshPtyProvider: class MockSshPtyProvider {
+    onData = vi.fn().mockReturnValue(() => {})
+    onReplay = vi.fn().mockReturnValue(() => {})
+    onExit = vi.fn().mockReturnValue(() => {})
+    attach = vi.fn().mockResolvedValue(undefined)
+    attachForReconnect = vi.fn().mockResolvedValue({})
+    setPtyDeliveryPauseAdapter = pauseAdapterMock
+    dispose = vi.fn()
+  }
+}))
+
+vi.mock('../providers/ssh-filesystem-provider', () => ({
+  SshFilesystemProvider: class MockSshFilesystemProvider {
+    dispose = vi.fn()
+  }
+}))
+
+vi.mock('../providers/ssh-git-provider', () => ({
+  SshGitProvider: class MockSshGitProvider {}
+}))
+
+vi.mock('../ipc/pty', () => ({
+  registerSshPtyProvider: vi.fn(),
+  unregisterSshPtyProvider: vi.fn(),
+  getSshPtyProvider: vi.fn().mockReturnValue({
+    dispose: vi.fn(),
+    attach: vi.fn().mockResolvedValue(undefined),
+    attachForReconnect: vi.fn().mockResolvedValue({})
+  }),
+  getPtyIdsForConnection: vi.fn().mockReturnValue([]),
+  clearPtyOwnershipForConnection: vi.fn(),
+  clearProviderPtyState: vi.fn(),
+  deletePtyOwnership: vi.fn(),
+  setPtyOwnership: vi.fn(),
+  restorePtyIncarnation: vi.fn(),
+  isCurrentPtyExit: vi.fn(() => true)
+}))
+
+vi.mock('../providers/ssh-filesystem-dispatch', () => ({
+  registerSshFilesystemProvider: vi.fn(),
+  unregisterSshFilesystemProvider: vi.fn(),
+  getSshFilesystemProvider: vi.fn().mockReturnValue({ dispose: vi.fn() })
+}))
+
+vi.mock('../providers/ssh-git-dispatch', () => ({
+  registerSshGitProvider: vi.fn(),
+  unregisterSshGitProvider: vi.fn()
+}))
+
+function createSession(): SshRelaySession {
+  const { mockStore, mockPortForward, getMainWindow } = createMockDeps()
+  return new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
+}
+
+async function establishAndSettle(session: SshRelaySession): Promise<void> {
+  await session.establish({} as SshConnection)
+  await vi.waitFor(() => expect(session.getManagedHookOutcome().state).not.toBe('unknown'))
+}
+
+describe('SshRelaySession managed hook outcome', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    delete process.env.ORCA_FEATURE_REMOTE_AGENT_HOOKS
+    openConsumerSessionMock.mockImplementation(async (_mux, options) => ({
+      mode: 'legacy-fallback',
+      clientInstanceId: options.clientInstanceId,
+      serverBuildId: 'test-relay-build'
+    }))
+    muxRequestMock.mockReset()
+    muxRequestMock.mockResolvedValue([])
+    mockDeploySuccess()
+  })
+
+  it('defaults to unknown before the install reports — never to the local answer', () => {
+    expect(createSession().getManagedHookOutcome()).toMatchObject({ state: 'unknown' })
+  })
+
+  it('records the per-agent result the remote host reported', async () => {
+    muxRequestMock.mockImplementation(async (method: string) => {
+      if (method === 'preflight.detectAgents') {
+        return { agents: ['codex'] }
+      }
+      if (method === AGENT_HOOK_INSTALL_MANAGED_HOOKS_METHOD) {
+        return {
+          installers: 1,
+          errors: 1,
+          statuses: [
+            {
+              agent: 'codex',
+              state: 'error',
+              configPath: '/home/dev/.codex/hooks.json',
+              managedHooksPresent: false,
+              detail: 'Could not parse remote Codex hooks.json'
+            }
+          ]
+        }
+      }
+      return { ok: true }
+    })
+    const session = createSession()
+
+    await establishAndSettle(session)
+
+    const outcome = session.getManagedHookOutcome()
+    expect(outcome.state).toBe('error')
+    expect(outcome.statuses[0]).toMatchObject({ agent: 'codex', state: 'error' })
+  })
+
+  it('records skipped — not installed — when the remote host has no agent CLI', async () => {
+    muxRequestMock.mockImplementation(async (method: string) => {
+      if (method === 'preflight.detectAgents') {
+        return { agents: [] }
+      }
+      return { ok: true }
+    })
+    const session = createSession()
+
+    await establishAndSettle(session)
+
+    expect(session.getManagedHookOutcome()).toMatchObject({
+      state: 'skipped',
+      detail: 'No managed agent CLI was detected on the remote host.'
+    })
+    expect(
+      muxRequestMock.mock.calls.some(
+        ([method]) => method === AGENT_HOOK_INSTALL_MANAGED_HOOKS_METHOD
+      )
+    ).toBe(false)
+  })
+
+  it('records error when the install RPC throws for a live connection', async () => {
+    muxRequestMock.mockImplementation(async (method: string) => {
+      if (method === 'preflight.detectAgents') {
+        return { agents: ['codex'] }
+      }
+      if (method === AGENT_HOOK_INSTALL_MANAGED_HOOKS_METHOD) {
+        throw new Error('remote install blew up')
+      }
+      return { ok: true }
+    })
+    const session = createSession()
+
+    await establishAndSettle(session)
+
+    expect(session.getManagedHookOutcome()).toMatchObject({
+      state: 'error',
+      detail: 'remote install blew up'
+    })
+  })
+
+  it('stays unknown when the connection dropped mid-install rather than blaming the host', async () => {
+    muxRequestMock.mockImplementation(async (method: string) => {
+      if (method === 'preflight.detectAgents') {
+        return { agents: ['codex'] }
+      }
+      if (method === AGENT_HOOK_INSTALL_MANAGED_HOOKS_METHOD) {
+        throw Object.assign(new Error('connection lost'), { code: 'CONNECTION_LOST' })
+      }
+      return { ok: true }
+    })
+    const session = createSession()
+    await session.establish({} as SshConnection)
+    await vi.waitFor(() =>
+      expect(session.getManagedHookOutcome().detail).toContain('could not be confirmed')
+    )
+
+    expect(session.getManagedHookOutcome().state).toBe('unknown')
+  })
+})

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -17,6 +17,9 @@ import { SshFilesystemProvider } from '../providers/ssh-filesystem-provider'
 import { isMethodNotFoundError } from './ssh-filesystem-stream-reader'
 import { SshGitProvider } from '../providers/ssh-git-provider'
 import { agentHookServer } from '../agent-hooks/server'
+import type { AgentHookHostOutcome, AgentHookHostState } from '../../shared/agent-hook-host-status'
+import { readManagedHookInstallOutcome } from '../agent-hooks/remote-hook-install-outcome'
+import type { AgentHookInstallStatus } from '../../shared/agent-hook-types'
 import { isAgentStatusHooksEnabled } from '../agent-hooks/managed-agent-hook-controls'
 import {
   buildManagedHookDetectionCommands,
@@ -314,6 +317,9 @@ export class SshRelaySession {
   private currentConnection: SshConnection | null = null
   private hostPlatform: RemoteHostPlatform | null = null
   private remoteCliBridgeEnv: RemoteCliBridgeEnv | null = null
+  // Why (#8711): `agent hooks status` must answer for the host that runs the
+  // agent, so the last remote managed-hook result outlives the install call.
+  private managedHookOutcome: AgentHookHostOutcome | null = null
   private aiVaultListMethodSupported: boolean | null = null
   private aiVaultTitleMethodSupported: boolean | null = null
   private pendingPtyReattaches = new Map<string, PendingPtyReattach>()
@@ -1267,15 +1273,38 @@ export class SshRelaySession {
     })
   }
 
+  /** Last known managed-hook state on the host this session reaches. Defaults
+   *  to `unknown`, so a diagnostic asked while the install is still in flight —
+   *  or after it silently never ran — says so instead of falling back to the
+   *  local machine's answer (#8711). */
+  getManagedHookOutcome(): AgentHookHostOutcome {
+    return (
+      this.managedHookOutcome ?? {
+        state: 'unknown',
+        detail: 'Remote managed hook install has not reported yet.',
+        statuses: []
+      }
+    )
+  }
+
+  private recordManagedHookOutcome(
+    state: AgentHookHostState,
+    detail: string | null,
+    statuses: readonly AgentHookInstallStatus[] = []
+  ): void {
+    this.managedHookOutcome = { state, detail, statuses }
+  }
+
   private async installManagedHooksOnRemote(
     mux: SshChannelMultiplexer,
     shouldContinue?: () => boolean
   ): Promise<void> {
-    if (
-      !isRemoteAgentHooksEnabled() ||
-      !this.areAgentStatusHooksEnabled() ||
-      (shouldContinue && !shouldContinue())
-    ) {
+    if (!isRemoteAgentHooksEnabled() || !this.areAgentStatusHooksEnabled()) {
+      this.recordManagedHookOutcome('skipped', 'Agent status hooks are disabled.')
+      return
+    }
+    if (shouldContinue && !shouldContinue()) {
+      this.recordManagedHookOutcome('unknown', 'Connection closed before the install started.')
       return
     }
     if (
@@ -1283,6 +1312,10 @@ export class SshRelaySession {
       isWindowsRemoteHost(this.remoteCliBridgeEnv.hostPlatform)
     ) {
       // Why: managed hook installers emit POSIX-only scripts/paths; Windows remotes rely on relay-injected env + plugin overlays instead.
+      this.recordManagedHookOutcome(
+        'skipped',
+        'Windows remote: managed hook scripts are not installed on this host.'
+      )
       return
     }
 
@@ -1292,7 +1325,15 @@ export class SshRelaySession {
         commands: buildManagedHookDetectionCommands(store.getSettings?.() ?? null, 'linux')
       })) as { agents?: unknown }
       const agents = detectedManagedHookAgents(detected?.agents)
-      if (agents.length === 0 || (shouldContinue && !shouldContinue())) {
+      if (agents.length === 0) {
+        this.recordManagedHookOutcome(
+          'skipped',
+          'No managed agent CLI was detected on the remote host.'
+        )
+        return
+      }
+      if (shouldContinue && !shouldContinue()) {
+        this.recordManagedHookOutcome('unknown', 'Connection closed before the install completed.')
         return
       }
       const hostKeyFingerprint = this.requireReadyConnection().getHostKeyFingerprint?.()
@@ -1302,7 +1343,10 @@ export class SshRelaySession {
       }
       const result = (await mux.request(AGENT_HOOK_INSTALL_MANAGED_HOOKS_METHOD, params)) as {
         errors?: unknown
+        statuses?: unknown
       }
+      const outcome = readManagedHookInstallOutcome(result)
+      this.recordManagedHookOutcome(outcome.state, outcome.detail, outcome.statuses)
       if (typeof result.errors === 'number' && result.errors > 0) {
         console.warn(
           `[ssh-relay-session] ${result.errors} remote managed hook installers failed for ${this.targetId}`
@@ -1311,6 +1355,7 @@ export class SshRelaySession {
     } catch (error) {
       // Why: teardown routinely cancels this best-effort request; only warn for
       // installer failures that survive the connection lifecycle.
+      const detail = error instanceof Error ? error.message : String(error)
       const code = (error as { code?: unknown })?.code
       if (
         code === -32601 ||
@@ -1318,12 +1363,14 @@ export class SshRelaySession {
         code === 'DISPOSED' ||
         mux.isDisposed()
       ) {
+        // Why: a torn-down connection proves nothing about the remote install,
+        // so leave the host unknown rather than claiming it failed or worked.
+        this.recordManagedHookOutcome('unknown', `Install could not be confirmed: ${detail}`)
         return
       }
+      this.recordManagedHookOutcome('error', detail)
       console.warn(
-        `[ssh-relay-session] relay managed hook install failed for ${this.targetId}: ${
-          error instanceof Error ? error.message : String(error)
-        }`
+        `[ssh-relay-session] relay managed hook install failed for ${this.targetId}: ${detail}`
       )
     }
   }

--- a/src/relay/managed-hook-installer.ts
+++ b/src/relay/managed-hook-installer.ts
@@ -4,12 +4,16 @@ import {
   type AgentHookInstallManagedHooksParams
 } from '../shared/agent-hook-relay'
 import type { RelayDispatcher, RequestContext } from './dispatcher'
-import type { AgentHookTarget } from '../shared/agent-hook-types'
+import type { AgentHookInstallStatus, AgentHookTarget } from '../shared/agent-hook-types'
 import { isManagedAgentHookTarget } from '../shared/managed-agent-hook-targets'
 
 export type ManagedHookInstallSummary = {
   installers: number
   errors: number
+  /** Optional on the wire: clients older than #8711 ignore it, and a client
+   *  talking to a relay that predates it must report the host as `unknown`
+   *  rather than assuming the per-agent results were all green. */
+  statuses?: AgentHookInstallStatus[]
 }
 
 export type ManagedHookRuntime = {

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalWindowControls.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalWindowControls.tsx
@@ -79,7 +79,8 @@ export function FloatingTerminalWindowControls({
       agentArgs: resolveTuiAgentLaunchArgs(defaultAgent, state.settings?.agentDefaultArgs),
       agentEnv: resolveTuiAgentLaunchEnv(defaultAgent, state.settings?.agentDefaultEnv),
       platform: CLIENT_PLATFORM,
-      allowEmptyPromptLaunch: true
+      allowEmptyPromptLaunch: true,
+      agentStatusHookSettings: state.settings ?? null
     })
     if (!startupPlan) {
       toast.error(

--- a/src/renderer/src/components/right-sidebar/buildSourceControlAgentDeliveryPlan.ts
+++ b/src/renderer/src/components/right-sidebar/buildSourceControlAgentDeliveryPlan.ts
@@ -50,7 +50,8 @@ export function buildSourceControlAgentDeliveryPlan({
     cmdOverrides: settings?.agentCmdOverrides,
     terminalWindowsShell: settings?.terminalWindowsShell,
     platform: launchPlatform,
-    isRemote
+    isRemote,
+    agentStatusHookSettings: settings ?? null
   })
   if (!result.ok) {
     return { status: 'error', error: result.error }

--- a/src/renderer/src/components/sidebar/folder-workspace-composer-submit.test.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-composer-submit.test.ts
@@ -31,7 +31,7 @@ import { decideInitialAgentTabViewMode } from '@/lib/native-chat-initial-view-mo
 import { resolveStartupLaunchDraftText } from '@/lib/worktree-startup-payload'
 import {
   getFolderWorkspaceAgentLaunchPlatform,
-  submitFolderWorkspaceCreate
+  submitFolderWorkspaceCreate as submitFolderWorkspaceCreateImpl
 } from './folder-workspace-composer-submit'
 
 function makeProjectGroup(): ProjectGroup {
@@ -66,6 +66,15 @@ function makeFolderWorkspace(overrides: Partial<FolderWorkspace> = {}): FolderWo
     updatedAt: 1,
     ...overrides
   }
+}
+
+// Why: these tests predate the hooks settings param and assert unrelated
+// behavior. One default keeps them honest without restating it 21 times; the
+// hooks decision itself is pinned in tui-agent-launch-command.codex-remote-hooks.
+function submitFolderWorkspaceCreate(
+  params: Omit<Parameters<typeof submitFolderWorkspaceCreateImpl>[0], 'agentStatusHookSettings'>
+): ReturnType<typeof submitFolderWorkspaceCreateImpl> {
+  return submitFolderWorkspaceCreateImpl({ ...params, agentStatusHookSettings: null })
 }
 
 describe('submitFolderWorkspaceCreate', () => {

--- a/src/renderer/src/components/sidebar/folder-workspace-composer-submit.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-composer-submit.ts
@@ -3,14 +3,9 @@ import {
   ensureAgentStartupInTerminal,
   type LinkedWorkItemSummary
 } from '@/lib/new-workspace'
-import { resolveQuickCreateLinkedWorkItemPrompt } from '@/lib/linked-work-item-context'
 import { seedNativeChatLaunchDraftForAgentTab } from '@/lib/agent-launch-prompt-delivery'
 import { createBrowserUuid } from '@/lib/browser-uuid'
-import {
-  buildAgentDraftLaunchPlan,
-  buildAgentStartupPlan,
-  type AgentStartupPlan
-} from '@/lib/tui-agent-startup'
+import { buildAgentStartupPlan } from '@/lib/tui-agent-startup'
 import { tuiAgentToAgentKind } from '@/lib/telemetry'
 import { activateAndRevealFolderWorkspace } from '@/lib/worktree-activation'
 import { isWorkItemLookupText } from '@/lib/work-item-lookup-text'
@@ -21,7 +16,6 @@ import type { ProjectGroup } from '../../../../shared/project-group-types'
 import type { TuiAgent } from '../../../../shared/tui-agent'
 import { isWslUncPath } from '../../../../shared/wsl-paths'
 import { resolveLocalWindowsAgentStartupShell } from '../../../../shared/windows-terminal-shell'
-import type { AgentStartupShell } from '../../../../shared/tui-agent-startup-shell'
 import type { LaunchSource } from '../../../../shared/telemetry-events'
 import type { SessionOptionValue } from '../../../../shared/native-chat-session-options'
 import type { TaskSourceContext } from '../../../../shared/task-source-context'
@@ -30,6 +24,14 @@ import {
   getLinkedItemDisplayName,
   toFolderWorkspaceLinkedTask
 } from './folder-workspace-composer-helpers'
+export {
+  buildFolderWorkspaceLinkedStartupPlan,
+  resolveFolderWorkspaceLaunchDraft
+} from './folder-workspace-linked-startup-plan'
+import {
+  buildFolderWorkspaceLinkedStartupPlan,
+  resolveFolderWorkspaceLaunchDraft
+} from './folder-workspace-linked-startup-plan'
 
 type FolderWorkspaceCreateInput = {
   projectGroupId: string
@@ -55,6 +57,8 @@ type SubmitFolderWorkspaceCreateParams = {
   agentEnv?: Record<string, string>
   sessionOptions?: Record<string, SessionOptionValue>
   terminalWindowsShell?: string | null
+  /** Orca's managed status hooks are on for the launched agent (#11941). */
+  agentStatusHooksEnabled?: boolean
   isRemote?: boolean
   launchSource?: LaunchSource
   runtimeEnvironmentId?: string | null
@@ -70,80 +74,6 @@ export function getFolderWorkspaceAgentLaunchPlatform(
     return isWindowsAbsolutePathLike(parentPath) ? 'win32' : 'linux'
   }
   return parentPath && isWslUncPath(parentPath) ? 'linux' : CLIENT_PLATFORM
-}
-
-/**
- * The launch context a linked folder-workspace agent starts with in its TUI
- * input but never submits — delivered as argv prefill or a startup paste
- * depending on the agent.
- */
-export function resolveFolderWorkspaceLaunchDraft(
-  linkedWorkItem: LinkedWorkItemSummary,
-  note: string
-): string | null {
-  const { prompt, draftPrompt } = resolveQuickCreateLinkedWorkItemPrompt(linkedWorkItem, note)
-  return (draftPrompt ?? prompt.trim()) || null
-}
-
-export function buildFolderWorkspaceLinkedStartupPlan(args: {
-  agent: TuiAgent
-  linkedWorkItem: LinkedWorkItemSummary
-  note: string
-  agentCmdOverrides: Record<string, string> | undefined
-  agentArgs?: string | null
-  agentEnv?: Record<string, string>
-  sessionOptions?: Record<string, SessionOptionValue>
-  platform: NodeJS.Platform
-  shell?: AgentStartupShell
-  isRemote: boolean
-}): AgentStartupPlan | null {
-  const linkedDraftPrompt = resolveFolderWorkspaceLaunchDraft(args.linkedWorkItem, args.note)
-  const draftLaunchPlan = linkedDraftPrompt
-    ? buildAgentDraftLaunchPlan({
-        agent: args.agent,
-        draft: linkedDraftPrompt,
-        cmdOverrides: args.agentCmdOverrides ?? {},
-        agentArgs: args.agentArgs,
-        agentEnv: args.agentEnv,
-        sessionOptions: args.sessionOptions,
-        platform: args.platform,
-        shell: args.shell,
-        isRemote: args.isRemote
-      })
-    : null
-  if (draftLaunchPlan) {
-    return {
-      agent: draftLaunchPlan.agent,
-      launchCommand: draftLaunchPlan.launchCommand,
-      expectedProcess: draftLaunchPlan.expectedProcess,
-      followupPrompt: null,
-      launchConfig: draftLaunchPlan.launchConfig,
-      ...(draftLaunchPlan.sessionOptions ? { sessionOptions: draftLaunchPlan.sessionOptions } : {}),
-      ...(draftLaunchPlan.startupCommandDelivery
-        ? { startupCommandDelivery: draftLaunchPlan.startupCommandDelivery }
-        : {}),
-      ...(draftLaunchPlan.env ? { env: draftLaunchPlan.env } : {})
-    }
-  }
-
-  const startupPlan = buildAgentStartupPlan({
-    agent: args.agent,
-    // Why: linked context must stay reviewable; launch empty, then paste the
-    // draft after the agent is ready instead of submitting it on argv/stdin.
-    prompt: '',
-    cmdOverrides: args.agentCmdOverrides ?? {},
-    agentArgs: args.agentArgs,
-    agentEnv: args.agentEnv,
-    sessionOptions: args.sessionOptions,
-    platform: args.platform,
-    shell: args.shell,
-    isRemote: args.isRemote,
-    allowEmptyPromptLaunch: true
-  })
-  if (startupPlan && linkedDraftPrompt) {
-    startupPlan.draftPrompt = linkedDraftPrompt
-  }
-  return startupPlan
 }
 
 async function preflightFolderWorkspaceAgentTrust(args: {
@@ -183,6 +113,7 @@ export async function submitFolderWorkspaceCreate({
   agentEnv,
   sessionOptions,
   terminalWindowsShell,
+  agentStatusHooksEnabled,
   launchSource = 'sidebar',
   runtimeEnvironmentId = null,
   createFolderWorkspace,
@@ -215,7 +146,8 @@ export async function submitFolderWorkspaceCreate({
           sessionOptions,
           platform: launchPlatform,
           shell: launchShell,
-          isRemote: launchIsRemote
+          isRemote: launchIsRemote,
+          agentStatusHooksEnabled: agentStatusHooksEnabled ?? true
         })
       : quickAgent
         ? buildAgentStartupPlan({
@@ -228,6 +160,7 @@ export async function submitFolderWorkspaceCreate({
             platform: launchPlatform,
             shell: launchShell,
             isRemote: launchIsRemote,
+            agentStatusHooksEnabled: agentStatusHooksEnabled ?? true,
             allowEmptyPromptLaunch: true
           })
         : null

--- a/src/renderer/src/components/sidebar/folder-workspace-composer-submit.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-composer-submit.ts
@@ -1,3 +1,4 @@
+import type { AgentStatusHookSettings } from '../../../../shared/agent-status-hooks-for-agent'
 import {
   CLIENT_PLATFORM,
   ensureAgentStartupInTerminal,
@@ -57,8 +58,9 @@ type SubmitFolderWorkspaceCreateParams = {
   agentEnv?: Record<string, string>
   sessionOptions?: Record<string, SessionOptionValue>
   terminalWindowsShell?: string | null
-  /** Orca's managed status hooks are on for the launched agent (#11941). */
-  agentStatusHooksEnabled?: boolean
+  /** Settings that decide Orca's managed status hooks for the launched agent.
+   *  Passed whole so the plan builder applies the per-agent opt-out too (#11941). */
+  agentStatusHookSettings: AgentStatusHookSettings | null
   isRemote?: boolean
   launchSource?: LaunchSource
   runtimeEnvironmentId?: string | null
@@ -113,7 +115,7 @@ export async function submitFolderWorkspaceCreate({
   agentEnv,
   sessionOptions,
   terminalWindowsShell,
-  agentStatusHooksEnabled,
+  agentStatusHookSettings,
   launchSource = 'sidebar',
   runtimeEnvironmentId = null,
   createFolderWorkspace,
@@ -147,7 +149,7 @@ export async function submitFolderWorkspaceCreate({
           platform: launchPlatform,
           shell: launchShell,
           isRemote: launchIsRemote,
-          agentStatusHooksEnabled: agentStatusHooksEnabled ?? true
+          agentStatusHookSettings
         })
       : quickAgent
         ? buildAgentStartupPlan({
@@ -160,7 +162,7 @@ export async function submitFolderWorkspaceCreate({
             platform: launchPlatform,
             shell: launchShell,
             isRemote: launchIsRemote,
-            agentStatusHooksEnabled: agentStatusHooksEnabled ?? true,
+            agentStatusHookSettings,
             allowEmptyPromptLaunch: true
           })
         : null

--- a/src/renderer/src/components/sidebar/folder-workspace-linked-startup-plan.test.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-linked-startup-plan.test.ts
@@ -18,7 +18,8 @@ describe('buildFolderWorkspaceLinkedStartupPlan', () => {
       agentArgs: '--provider "value with space"',
       platform: 'win32',
       shell: 'cmd',
-      isRemote: false
+      isRemote: false,
+      agentStatusHookSettings: null
     })
 
     expect(plan?.launchCommand).toBe('hermes --tui "--provider" "value with space"')

--- a/src/renderer/src/components/sidebar/folder-workspace-linked-startup-plan.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-linked-startup-plan.ts
@@ -1,0 +1,92 @@
+// Why: the linked-workspace launch plan is its own decision — which of the two
+// startup shapes a linked work item gets — and it needs room to grow alongside
+// the agent launch contract without pushing the submit flow over its size cap.
+
+import {
+  buildAgentDraftLaunchPlan,
+  buildAgentStartupPlan,
+  type AgentStartupPlan
+} from '@/lib/tui-agent-startup'
+import type { LinkedWorkItemSummary } from '@/lib/new-workspace'
+import type { SessionOptionValue } from '../../../../shared/native-chat-session-options'
+import type { TuiAgent } from '../../../../shared/tui-agent'
+import type { AgentStartupShell } from '../../../../shared/tui-agent-startup-shell'
+import { resolveQuickCreateLinkedWorkItemPrompt } from '@/lib/linked-work-item-context'
+
+/**
+ * The launch context a linked folder-workspace agent starts with in its TUI
+ * input but never submits — delivered as argv prefill or a startup paste
+ * depending on the agent.
+ */
+export function resolveFolderWorkspaceLaunchDraft(
+  linkedWorkItem: LinkedWorkItemSummary,
+  note: string
+): string | null {
+  const { prompt, draftPrompt } = resolveQuickCreateLinkedWorkItemPrompt(linkedWorkItem, note)
+  return (draftPrompt ?? prompt.trim()) || null
+}
+
+export function buildFolderWorkspaceLinkedStartupPlan(args: {
+  agent: TuiAgent
+  linkedWorkItem: LinkedWorkItemSummary
+  note: string
+  agentCmdOverrides: Record<string, string> | undefined
+  agentArgs?: string | null
+  agentEnv?: Record<string, string>
+  sessionOptions?: Record<string, SessionOptionValue>
+  platform: NodeJS.Platform
+  shell?: AgentStartupShell
+  isRemote: boolean
+  /** Orca's managed status hooks are on for this agent (#11941). */
+  agentStatusHooksEnabled?: boolean
+}): AgentStartupPlan | null {
+  const linkedDraftPrompt = resolveFolderWorkspaceLaunchDraft(args.linkedWorkItem, args.note)
+  const draftLaunchPlan = linkedDraftPrompt
+    ? buildAgentDraftLaunchPlan({
+        agent: args.agent,
+        draft: linkedDraftPrompt,
+        cmdOverrides: args.agentCmdOverrides ?? {},
+        agentArgs: args.agentArgs,
+        agentEnv: args.agentEnv,
+        sessionOptions: args.sessionOptions,
+        platform: args.platform,
+        shell: args.shell,
+        isRemote: args.isRemote,
+        agentStatusHooksEnabled: args.agentStatusHooksEnabled
+      })
+    : null
+  if (draftLaunchPlan) {
+    return {
+      agent: draftLaunchPlan.agent,
+      launchCommand: draftLaunchPlan.launchCommand,
+      expectedProcess: draftLaunchPlan.expectedProcess,
+      followupPrompt: null,
+      launchConfig: draftLaunchPlan.launchConfig,
+      ...(draftLaunchPlan.sessionOptions ? { sessionOptions: draftLaunchPlan.sessionOptions } : {}),
+      ...(draftLaunchPlan.startupCommandDelivery
+        ? { startupCommandDelivery: draftLaunchPlan.startupCommandDelivery }
+        : {}),
+      ...(draftLaunchPlan.env ? { env: draftLaunchPlan.env } : {})
+    }
+  }
+
+  const startupPlan = buildAgentStartupPlan({
+    agent: args.agent,
+    // Why: linked context must stay reviewable; launch empty, then paste the
+    // draft after the agent is ready instead of submitting it on argv/stdin.
+    prompt: '',
+    cmdOverrides: args.agentCmdOverrides ?? {},
+    agentArgs: args.agentArgs,
+    agentEnv: args.agentEnv,
+    sessionOptions: args.sessionOptions,
+    platform: args.platform,
+    shell: args.shell,
+    isRemote: args.isRemote,
+    agentStatusHooksEnabled: args.agentStatusHooksEnabled,
+    allowEmptyPromptLaunch: true
+  })
+  if (startupPlan && linkedDraftPrompt) {
+    startupPlan.draftPrompt = linkedDraftPrompt
+  }
+  return startupPlan
+}

--- a/src/renderer/src/components/sidebar/folder-workspace-linked-startup-plan.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-linked-startup-plan.ts
@@ -10,6 +10,7 @@ import {
 import type { LinkedWorkItemSummary } from '@/lib/new-workspace'
 import type { SessionOptionValue } from '../../../../shared/native-chat-session-options'
 import type { TuiAgent } from '../../../../shared/tui-agent'
+import type { AgentStatusHookSettings } from '../../../../shared/agent-status-hooks-for-agent'
 import type { AgentStartupShell } from '../../../../shared/tui-agent-startup-shell'
 import { resolveQuickCreateLinkedWorkItemPrompt } from '@/lib/linked-work-item-context'
 
@@ -37,8 +38,9 @@ export function buildFolderWorkspaceLinkedStartupPlan(args: {
   platform: NodeJS.Platform
   shell?: AgentStartupShell
   isRemote: boolean
-  /** Orca's managed status hooks are on for this agent (#11941). */
-  agentStatusHooksEnabled?: boolean
+  /** Settings that decide Orca's managed status hooks; the builder derives
+   *  the per-agent answer itself (#11941). */
+  agentStatusHookSettings: AgentStatusHookSettings | null
 }): AgentStartupPlan | null {
   const linkedDraftPrompt = resolveFolderWorkspaceLaunchDraft(args.linkedWorkItem, args.note)
   const draftLaunchPlan = linkedDraftPrompt
@@ -52,7 +54,7 @@ export function buildFolderWorkspaceLinkedStartupPlan(args: {
         platform: args.platform,
         shell: args.shell,
         isRemote: args.isRemote,
-        agentStatusHooksEnabled: args.agentStatusHooksEnabled
+        agentStatusHookSettings: args.agentStatusHookSettings
       })
     : null
   if (draftLaunchPlan) {
@@ -82,7 +84,7 @@ export function buildFolderWorkspaceLinkedStartupPlan(args: {
     platform: args.platform,
     shell: args.shell,
     isRemote: args.isRemote,
-    agentStatusHooksEnabled: args.agentStatusHooksEnabled,
+    agentStatusHookSettings: args.agentStatusHookSettings,
     allowEmptyPromptLaunch: true
   })
   if (startupPlan && linkedDraftPrompt) {

--- a/src/renderer/src/components/terminal-pane/pty-connection-cold-restore-resume-command.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-cold-restore-resume-command.test.ts
@@ -218,7 +218,8 @@ describe('connectPanePty', () => {
       expect(transport.connect).toHaveBeenNthCalledWith(
         2,
         expect.objectContaining({
-          command: "codex '--dangerously-bypass-approvals-and-sandbox' 'resume' 'codex-session-1'",
+          command:
+            "codex '-c' 'features.hooks=true' '--dangerously-bypass-approvals-and-sandbox' 'resume' 'codex-session-1'",
           commandDelivery: 'provider',
           startupCommandDelivery: 'shell-ready',
           env: expect.objectContaining({
@@ -231,7 +232,7 @@ describe('connectPanePty', () => {
         })
       )
       expect(transport.sendInput).not.toHaveBeenCalledWith(
-        "codex '--dangerously-bypass-approvals-and-sandbox' 'resume' 'codex-session-1'\r"
+        "codex '-c' 'features.hooks=true' '--dangerously-bypass-approvals-and-sandbox' 'resume' 'codex-session-1'\r"
       )
     } finally {
       globalThis.setTimeout = originalSetTimeout

--- a/src/renderer/src/components/terminal-pane/pty-connection-remote-runtime-attach.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-remote-runtime-attach.test.ts
@@ -368,10 +368,12 @@ describe('connectPanePty', () => {
     expect(transport.connect).toHaveBeenCalledTimes(1)
     expect(transport.connect).toHaveBeenCalledWith(
       expect.objectContaining({
-        command: "codex '--dangerously-bypass-approvals-and-sandbox' 'resume' 'codex-session-1'",
+        command:
+          "codex '-c' 'features.hooks=true' '--dangerously-bypass-approvals-and-sandbox' 'resume' 'codex-session-1'",
         launchAgent: 'codex',
         launchConfig: {
-          agentCommand: "codex '--dangerously-bypass-approvals-and-sandbox'",
+          agentCommand:
+            "codex '-c' 'features.hooks=true' '--dangerously-bypass-approvals-and-sandbox'",
           agentArgs: '--dangerously-bypass-approvals-and-sandbox',
           agentEnv: {}
         },

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -5066,7 +5066,9 @@ export function connectPanePty(
           ? { ompResumeFilePath: launchConfig.ompResumeFilePath }
           : {}),
         platform: resumeTarget.platform,
-        shell: resumeTarget.shell
+        shell: resumeTarget.shell,
+        isRemote: resumeTarget.isRemote,
+        agentStatusHookSettings: state.settings ?? null
       })
       if (!startupPlan) {
         return null

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -21,6 +21,7 @@ import {
   type WorktreeCreationRequest
 } from '@/lib/pending-worktree-creation'
 import { buildAgentDraftLaunchPlan, buildAgentStartupPlan } from '@/lib/tui-agent-startup'
+import { areAgentStatusHooksEnabledForAgent } from '../../../shared/agent-status-hooks-for-agent'
 import { filterEnabledTuiAgents, isTuiAgentEnabled } from '../../../shared/tui-agent-selection'
 import { repoIsRemote } from '../../../shared/agent-launch-remote'
 import { resolveLocalWindowsAgentStartupShell } from '../../../shared/windows-terminal-shell'
@@ -1213,6 +1214,11 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     () => (detectedAgentList ? new Set(detectedAgentList) : null),
     [detectedAgentList]
   )
+
+  // Why (#11941): a remote Codex launch needs to know whether Orca's managed
+  // hooks are on for that agent, and the launch callbacks already track the
+  // derived disabled list rather than the whole settings object.
+  const statusHooksEnabledSetting = settings?.agentStatusHooksEnabled !== false
 
   const [yamlHooks, setYamlHooks] = useState<OrcaHooks | null>(null)
   const [checkedHooksContextKey, setCheckedHooksContextKey] = useState<string | null>(null)
@@ -3497,6 +3503,12 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
           quickAgent: agent,
           autoRenameBranchFromWork: settings?.autoRenameBranchFromWork,
           agentCmdOverrides: settings?.agentCmdOverrides,
+          agentStatusHooksEnabled: agent
+            ? areAgentStatusHooksEnabledForAgent(
+                { agentStatusHooksEnabled: statusHooksEnabledSetting, disabledTuiAgents },
+                agent
+              )
+            : undefined,
           agentArgs: agent
             ? resolveTuiAgentLaunchArgs(agent, settings?.agentDefaultArgs)
             : undefined,
@@ -3562,6 +3574,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       clearNewWorkspaceDraft,
       createFolderWorkspace,
       disabledTuiAgents,
+      statusHooksEnabledSetting,
       folderCreateDisabled,
       folderTargetConnectionId,
       folderTargetIsRemote,
@@ -3846,7 +3859,11 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         ),
         platform: selectedRepoAgentLaunchPlatform,
         shell: selectedRepoStartupShell,
-        isRemote: selectedRepoIsRemote
+        isRemote: selectedRepoIsRemote,
+        agentStatusHooksEnabled: areAgentStatusHooksEnabledForAgent(
+          { agentStatusHooksEnabled: statusHooksEnabledSetting, disabledTuiAgents },
+          tuiAgent
+        )
       })
       const shouldSeedInitialAgentStatus =
         tuiAgent === 'command-code' && submitStartupPrompt.trim().length > 0
@@ -4065,6 +4082,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     telemetrySource,
     fallbackDefaultAgent,
     disabledTuiAgents,
+    statusHooksEnabledSetting,
     tuiAgent,
     shouldWaitForIssueAutomationCheck,
     shouldWaitForSetupCheck,
@@ -4423,7 +4441,11 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
                 sessionOptions: quickSessionOptions,
                 platform: selectedRepoAgentLaunchPlatform,
                 shell: selectedRepoStartupShell,
-                isRemote: selectedRepoIsRemote
+                isRemote: selectedRepoIsRemote,
+                agentStatusHooksEnabled: areAgentStatusHooksEnabledForAgent(
+                  { agentStatusHooksEnabled: statusHooksEnabledSetting, disabledTuiAgents },
+                  agent
+                )
               })
 
         let startupPlan: ReturnType<typeof buildAgentStartupPlan> = null
@@ -4453,6 +4475,10 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
             platform: selectedRepoAgentLaunchPlatform,
             shell: selectedRepoStartupShell,
             isRemote: selectedRepoIsRemote,
+            agentStatusHooksEnabled: areAgentStatusHooksEnabledForAgent(
+              { agentStatusHooksEnabled: statusHooksEnabledSetting, disabledTuiAgents },
+              agent
+            ),
             allowEmptyPromptLaunch: true
           })
           if (startupPlan && quickDraftPrompt) {
@@ -4657,6 +4683,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       settings?.agentCmdOverrides,
       settings?.agentDefaultArgs,
       settings?.agentDefaultEnv,
+      statusHooksEnabledSetting,
       settings?.autoRenameBranchFromWork,
       settings?.experimentalNativeChat,
       settings?.nativeChatSessionOptions,

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -21,7 +21,6 @@ import {
   type WorktreeCreationRequest
 } from '@/lib/pending-worktree-creation'
 import { buildAgentDraftLaunchPlan, buildAgentStartupPlan } from '@/lib/tui-agent-startup'
-import { areAgentStatusHooksEnabledForAgent } from '../../../shared/agent-status-hooks-for-agent'
 import { filterEnabledTuiAgents, isTuiAgentEnabled } from '../../../shared/tui-agent-selection'
 import { repoIsRemote } from '../../../shared/agent-launch-remote'
 import { resolveLocalWindowsAgentStartupShell } from '../../../shared/windows-terminal-shell'
@@ -1219,6 +1218,12 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   // hooks are on for that agent, and the launch callbacks already track the
   // derived disabled list rather than the whole settings object.
   const statusHooksEnabledSetting = settings?.agentStatusHooksEnabled !== false
+  // Why: launch plan builders derive the per-agent hooks answer themselves, so
+  // every composer launch hands them the same settings pair (#11941).
+  const agentStatusHookSettings = useMemo(
+    () => ({ agentStatusHooksEnabled: statusHooksEnabledSetting, disabledTuiAgents }),
+    [statusHooksEnabledSetting, disabledTuiAgents]
+  )
 
   const [yamlHooks, setYamlHooks] = useState<OrcaHooks | null>(null)
   const [checkedHooksContextKey, setCheckedHooksContextKey] = useState<string | null>(null)
@@ -3503,12 +3508,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
           quickAgent: agent,
           autoRenameBranchFromWork: settings?.autoRenameBranchFromWork,
           agentCmdOverrides: settings?.agentCmdOverrides,
-          agentStatusHooksEnabled: agent
-            ? areAgentStatusHooksEnabledForAgent(
-                { agentStatusHooksEnabled: statusHooksEnabledSetting, disabledTuiAgents },
-                agent
-              )
-            : undefined,
+          agentStatusHookSettings,
           agentArgs: agent
             ? resolveTuiAgentLaunchArgs(agent, settings?.agentDefaultArgs)
             : undefined,
@@ -3574,7 +3574,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       clearNewWorkspaceDraft,
       createFolderWorkspace,
       disabledTuiAgents,
-      statusHooksEnabledSetting,
+      agentStatusHookSettings,
       folderCreateDisabled,
       folderTargetConnectionId,
       folderTargetIsRemote,
@@ -3860,10 +3860,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         platform: selectedRepoAgentLaunchPlatform,
         shell: selectedRepoStartupShell,
         isRemote: selectedRepoIsRemote,
-        agentStatusHooksEnabled: areAgentStatusHooksEnabledForAgent(
-          { agentStatusHooksEnabled: statusHooksEnabledSetting, disabledTuiAgents },
-          tuiAgent
-        )
+        agentStatusHookSettings
       })
       const shouldSeedInitialAgentStatus =
         tuiAgent === 'command-code' && submitStartupPrompt.trim().length > 0
@@ -4082,7 +4079,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     telemetrySource,
     fallbackDefaultAgent,
     disabledTuiAgents,
-    statusHooksEnabledSetting,
+    agentStatusHookSettings,
     tuiAgent,
     shouldWaitForIssueAutomationCheck,
     shouldWaitForSetupCheck,
@@ -4442,10 +4439,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
                 platform: selectedRepoAgentLaunchPlatform,
                 shell: selectedRepoStartupShell,
                 isRemote: selectedRepoIsRemote,
-                agentStatusHooksEnabled: areAgentStatusHooksEnabledForAgent(
-                  { agentStatusHooksEnabled: statusHooksEnabledSetting, disabledTuiAgents },
-                  agent
-                )
+                agentStatusHookSettings
               })
 
         let startupPlan: ReturnType<typeof buildAgentStartupPlan> = null
@@ -4475,10 +4469,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
             platform: selectedRepoAgentLaunchPlatform,
             shell: selectedRepoStartupShell,
             isRemote: selectedRepoIsRemote,
-            agentStatusHooksEnabled: areAgentStatusHooksEnabledForAgent(
-              { agentStatusHooksEnabled: statusHooksEnabledSetting, disabledTuiAgents },
-              agent
-            ),
+            agentStatusHookSettings,
             allowEmptyPromptLaunch: true
           })
           if (startupPlan && quickDraftPrompt) {
@@ -4683,7 +4674,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       settings?.agentCmdOverrides,
       settings?.agentDefaultArgs,
       settings?.agentDefaultEnv,
-      statusHooksEnabledSetting,
+      agentStatusHookSettings,
       settings?.autoRenameBranchFromWork,
       settings?.experimentalNativeChat,
       settings?.nativeChatSessionOptions,

--- a/src/renderer/src/lib/agent-resume-launch-target.test.ts
+++ b/src/renderer/src/lib/agent-resume-launch-target.test.ts
@@ -29,7 +29,7 @@ const LOCAL_WINDOWS_ARGS: AgentResumeLaunchTargetArgs = {
 
 async function resolveWith(
   overrides: Partial<AgentResumeLaunchTargetArgs>
-): Promise<{ platform: NodeJS.Platform; shell: string | undefined }> {
+): Promise<{ platform: NodeJS.Platform; shell: string | undefined; isRemote: boolean }> {
   const { resolveAgentResumeLaunchTarget } = await import('./agent-resume-launch-target')
   return resolveAgentResumeLaunchTarget({
     ...LOCAL_WINDOWS_ARGS,
@@ -52,7 +52,8 @@ describe('resolveAgentResumeLaunchTarget on a Windows client', () => {
   it('quotes for cmd.exe when the global Windows shell is cmd.exe', async () => {
     await expect(resolveWith({ terminalWindowsShell: 'cmd.exe' })).resolves.toEqual({
       platform: 'win32',
-      shell: 'cmd'
+      shell: 'cmd',
+      isRemote: false
     })
   })
 
@@ -62,20 +63,22 @@ describe('resolveAgentResumeLaunchTarget on a Windows client', () => {
         terminalWindowsShell: 'powershell.exe',
         tabShellOverride: 'C:\\WINDOWS\\system32\\cmd.exe'
       })
-    ).resolves.toEqual({ platform: 'win32', shell: 'cmd' })
+    ).resolves.toEqual({ platform: 'win32', shell: 'cmd', isRemote: false })
   })
 
   it('quotes for POSIX on a Git Bash tab', async () => {
     await expect(resolveWith({ terminalWindowsShell: 'git-bash' })).resolves.toEqual({
       platform: 'win32',
-      shell: 'posix'
+      shell: 'posix',
+      isRemote: false
     })
   })
 
   it('keeps PowerShell quoting when no Windows shell is configured', async () => {
     await expect(resolveWith({})).resolves.toEqual({
       platform: 'win32',
-      shell: 'powershell'
+      shell: 'powershell',
+      isRemote: false
     })
   })
 
@@ -86,7 +89,7 @@ describe('resolveAgentResumeLaunchTarget on a Windows client', () => {
         executionHostId: 'ssh:ssh-1',
         terminalWindowsShell: 'cmd.exe'
       })
-    ).resolves.toEqual({ platform: 'linux', shell: undefined })
+    ).resolves.toEqual({ platform: 'linux', shell: undefined, isRemote: true })
   })
 
   it('does not describe a remote runtime host with the local Windows shell setting', async () => {
@@ -95,7 +98,15 @@ describe('resolveAgentResumeLaunchTarget on a Windows client', () => {
         executionHostId: 'runtime:prod-box',
         terminalWindowsShell: 'cmd.exe'
       })
-    ).resolves.toEqual({ platform: 'win32', shell: undefined })
+    ).resolves.toEqual({ platform: 'win32', shell: undefined, isRemote: true })
+  })
+
+  // Why: the shell branch reads an absent executionHostId as remote (null !==
+  // 'local'). A launch decision must not — an unowned local pane is still local.
+  it('does not call an unowned local pane remote', async () => {
+    await expect(resolveWith({ executionHostId: null })).resolves.toMatchObject({
+      isRemote: false
+    })
   })
 
   it('keeps POSIX quoting for a WSL UNC worktree', async () => {
@@ -104,7 +115,7 @@ describe('resolveAgentResumeLaunchTarget on a Windows client', () => {
         worktreePath: '\\\\wsl.localhost\\Ubuntu\\home\\neil\\repo',
         terminalWindowsShell: 'cmd.exe'
       })
-    ).resolves.toEqual({ platform: 'linux', shell: undefined })
+    ).resolves.toEqual({ platform: 'linux', shell: undefined, isRemote: false })
   })
 
   it('keeps POSIX quoting for a project pinned to a WSL runtime', async () => {
@@ -122,7 +133,7 @@ describe('resolveAgentResumeLaunchTarget on a Windows client', () => {
         } as AgentResumeLaunchTargetArgs['projectRuntime'],
         terminalWindowsShell: 'cmd.exe'
       })
-    ).resolves.toEqual({ platform: 'linux', shell: undefined })
+    ).resolves.toEqual({ platform: 'linux', shell: undefined, isRemote: false })
   })
 })
 
@@ -144,6 +155,6 @@ describe('resolveAgentResumeLaunchTarget off Windows', () => {
         worktreePath: '/Users/neil/repo',
         terminalWindowsShell: 'cmd.exe'
       })
-    ).resolves.toEqual({ platform: 'darwin', shell: undefined })
+    ).resolves.toEqual({ platform: 'darwin', shell: undefined, isRemote: false })
   })
 })

--- a/src/renderer/src/lib/agent-resume-launch-target.ts
+++ b/src/renderer/src/lib/agent-resume-launch-target.ts
@@ -10,6 +10,9 @@ export type AgentResumeLaunchTarget = {
   platform: NodeJS.Platform
   /** undefined keeps the platform default: PowerShell on win32, POSIX elsewhere. */
   shell: AgentStartupShell | undefined
+  /** The resumed agent runs off this machine, so it needs the plain `orca` shim
+   *  and the remote Codex hooks override a fresh launch gets (#11941). */
+  isRemote: boolean
 }
 
 export type AgentResumeLaunchTargetArgs = {
@@ -47,8 +50,13 @@ export function resolveAgentResumeLaunchTarget(
   args: AgentResumeLaunchTargetArgs
 ): AgentResumeLaunchTarget {
   const platform = resolveResumeLaunchPlatform(args)
+  const parsedHost = parseExecutionHostId(args.executionHostId)
   return {
     platform,
+    // Why not the shell branch's expression below: an absent executionHostId
+    // parses to null, which that one reads as remote. A launch decision must
+    // not call an unowned local pane remote.
+    isRemote: Boolean(args.connectionId) || (parsedHost !== null && parsedHost.kind !== 'local'),
     shell: resolveLocalWindowsAgentStartupShell({
       platform,
       isRemote:

--- a/src/renderer/src/lib/ai-vault-omp-cold-resume.test.ts
+++ b/src/renderer/src/lib/ai-vault-omp-cold-resume.test.ts
@@ -88,7 +88,8 @@ describe('AI Vault OMP cold resume', () => {
       agentEnv: record.launchConfig?.agentEnv,
       agentCommand: record.launchConfig?.agentCommand,
       ompResumeFilePath: record.launchConfig?.ompResumeFilePath,
-      platform: 'linux'
+      platform: 'linux',
+      agentStatusHookSettings: null
     })
 
     expect(record).toMatchObject({

--- a/src/renderer/src/lib/ai-vault-resume-command.test.ts
+++ b/src/renderer/src/lib/ai-vault-resume-command.test.ts
@@ -551,7 +551,7 @@ describe('ai vault resume command runtime', () => {
         }
       })
     ).toMatchObject({
-      command: "codex 'resume' 'session one'",
+      command: "codex '-c' 'features.hooks=true' 'resume' 'session one'",
       cwd: '/home/alice/repo',
       envToDelete: ['CODEX_HOME', 'ORCA_CODEX_HOME'],
       providerSession: { key: 'session_id', id: 'session one' }
@@ -576,7 +576,7 @@ describe('ai vault resume command runtime', () => {
           resumeCommand: "CODEX_HOME='/root/.codex' codex resume 'session one'"
         }
       })
-    ).toBe("codex 'resume' 'session one'")
+    ).toBe("codex '-c' 'features.hooks=true' 'resume' 'session one'")
   })
 
   it('copies remote real-home Codex commands with explicit environment cleanup', () => {
@@ -598,7 +598,7 @@ describe('ai vault resume command runtime', () => {
     })
 
     expect(command).toBe(
-      `cd '/home/alice/repo' && env -u CODEX_HOME -u ORCA_CODEX_HOME codex 'resume' 'session one'`
+      `cd '/home/alice/repo' && env -u CODEX_HOME -u ORCA_CODEX_HOME codex '-c' 'features.hooks=true' 'resume' 'session one'`
     )
     expect(command).not.toContain('/retired/shared-home')
   })
@@ -621,7 +621,7 @@ describe('ai vault resume command runtime', () => {
           resumeCommand: "CODEX_HOME='/root/.codex' codex resume 'session one'"
         }
       })
-    ).toBe("my-codex 'resume' 'session one'")
+    ).toBe("my-codex '-c' 'features.hooks=true' 'resume' 'session one'")
   })
 
   it('rebuilds overridden remote commands with the recorded remote host platform', () => {

--- a/src/renderer/src/lib/ai-vault-resume-command.ts
+++ b/src/renderer/src/lib/ai-vault-resume-command.ts
@@ -170,6 +170,8 @@ function buildAiVaultResumeForWorktree(
       },
       platform,
       shell: liveShell,
+      isRemote: !isLocalSession,
+      agentStatusHookSettings: args.state.settings ?? null,
       agentArgs: resolveTuiAgentLaunchArgs(
         args.session.agent,
         args.state.settings?.agentDefaultArgs

--- a/src/renderer/src/lib/launch-agent-background-session-remote.test.ts
+++ b/src/renderer/src/lib/launch-agent-background-session-remote.test.ts
@@ -198,7 +198,8 @@ describe('launchAgentBackgroundSession remote runtime and SSH startup delivery',
 
       expect(mockSpawn.mock.calls[0]?.[0]).toEqual(
         expect.objectContaining({
-          command: "codex '--dangerously-bypass-approvals-and-sandbox' 'run the automation'",
+          command:
+            "codex '-c' 'features.hooks=true' '--dangerously-bypass-approvals-and-sandbox' 'run the automation'",
           startupCommandDelivery: 'shell-ready'
         })
       )
@@ -212,7 +213,7 @@ describe('launchAgentBackgroundSession remote runtime and SSH startup delivery',
 
       expect(mockWrite).toHaveBeenCalledWith(
         'pty-1',
-        "codex '--dangerously-bypass-approvals-and-sandbox' 'run the automation'\r"
+        "codex '-c' 'features.hooks=true' '--dangerously-bypass-approvals-and-sandbox' 'run the automation'\r"
       )
     } finally {
       vi.useRealTimers()
@@ -238,7 +239,7 @@ describe('launchAgentBackgroundSession remote runtime and SSH startup delivery',
 
       expect(mockWrite).toHaveBeenCalledWith(
         'pty-1',
-        "codex '--dangerously-bypass-approvals-and-sandbox' 'run the automation'\r"
+        "codex '-c' 'features.hooks=true' '--dangerously-bypass-approvals-and-sandbox' 'run the automation'\r"
       )
     } finally {
       vi.useRealTimers()
@@ -262,7 +263,7 @@ describe('launchAgentBackgroundSession remote runtime and SSH startup delivery',
 
       expect(mockWrite).toHaveBeenCalledWith(
         'pty-1',
-        "codex '--dangerously-bypass-approvals-and-sandbox' 'run the automation'\r"
+        "codex '-c' 'features.hooks=true' '--dangerously-bypass-approvals-and-sandbox' 'run the automation'\r"
       )
     } finally {
       vi.useRealTimers()
@@ -289,7 +290,7 @@ describe('launchAgentBackgroundSession remote runtime and SSH startup delivery',
       expect(mockSpawn.mock.calls[0]?.[0]).toEqual(
         expect.objectContaining({
           command:
-            "codex --prefill 'draft from override' '--dangerously-bypass-approvals-and-sandbox'"
+            "codex --prefill 'draft from override' '-c' 'features.hooks=true' '--dangerously-bypass-approvals-and-sandbox'"
         })
       )
       expect(mockSpawn.mock.calls[0]?.[0]).not.toHaveProperty('startupCommandDelivery')
@@ -303,7 +304,7 @@ describe('launchAgentBackgroundSession remote runtime and SSH startup delivery',
 
       expect(mockWrite).toHaveBeenCalledWith(
         'pty-1',
-        "codex --prefill 'draft from override' '--dangerously-bypass-approvals-and-sandbox'\r"
+        "codex --prefill 'draft from override' '-c' 'features.hooks=true' '--dangerously-bypass-approvals-and-sandbox'\r"
       )
     } finally {
       vi.useRealTimers()

--- a/src/renderer/src/lib/launch-agent-background-session.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.ts
@@ -94,7 +94,8 @@ export async function launchAgentBackgroundSession(
     platform: launchPlatform,
     shell: startupShell,
     isRemote,
-    allowEmptyPromptLaunch: !hasPrompt || isFollowupPath
+    allowEmptyPromptLaunch: !hasPrompt || isFollowupPath,
+    agentStatusHookSettings: store.settings ?? null
   })
   if (!startupPlan) {
     return null

--- a/src/renderer/src/lib/launch-agent-in-new-tab-remote-codex-hooks.test.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab-remote-codex-hooks.test.ts
@@ -1,0 +1,188 @@
+// Why this file exists: the tab bar's "New tab -> Codex" was the launch surface
+// proved broken over real SSH — it built its startup plan without the hooks
+// settings, so a remote Codex launch silently dropped `-c features.hooks=true`
+// while the folder-workspace composer carried it. These pin that arm (#11941).
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockCreateTab = vi.fn()
+const mockQueueTabStartupCommand = vi.fn()
+const mockPasteDraftWhenAgentReady = vi.fn()
+
+const store = {
+  activeRepoId: 'repo-1',
+  activeWorktreeId: 'wt-1',
+  settings: {
+    agentCmdOverrides: {},
+    agentDefaultArgs: {} as Record<string, string>,
+    agentDefaultEnv: {} as Record<string, Record<string, string>>,
+    activeRuntimeEnvironmentId: null as string | null
+  } as {
+    agentCmdOverrides: Record<string, string>
+    agentDefaultArgs: Record<string, string>
+    agentDefaultEnv: Record<string, Record<string, string>>
+    activeRuntimeEnvironmentId: string | null
+    terminalWindowsShell?: string
+    agentStatusHooksEnabled?: boolean
+    disabledTuiAgents?: readonly string[]
+  },
+  projects: [
+    {
+      id: 'repo-1',
+      localWindowsRuntimePreference: { kind: 'inherit-global' as const }
+    }
+  ] as {
+    id: string
+    localWindowsRuntimePreference:
+      | { kind: 'inherit-global' }
+      | { kind: 'windows-host' }
+      | { kind: 'wsl'; distro: string | null }
+  }[],
+  repos: [{ id: 'repo-1', connectionId: null as string | null, path: '/repo' }],
+  sshConnectionStates: new Map([['ssh-a', { status: 'connected' }]]),
+  transientClearedAgentStatusConnectionIds: {} as Record<string, true>,
+  worktreesByRepo: {
+    'repo-1': [
+      {
+        id: 'wt-1',
+        repoId: 'repo-1',
+        projectId: 'repo-1',
+        path: '/repo/worktree',
+        displayName: 'main'
+      }
+    ]
+  },
+  allWorktrees: vi.fn(() => store.worktreesByRepo['repo-1']),
+  tabsByWorktree: {
+    'wt-1': [{ id: 'tab-1' }]
+  },
+  openFiles: [] as { id: string; worktreeId: string }[],
+  browserTabsByWorktree: {} as Record<string, { id: string }[]>,
+  tabBarOrderByWorktree: {} as Record<string, string[]>,
+  terminalLayoutsByTabId: {} as Record<
+    string,
+    { activeLeafId: string | null; ptyIdsByLeafId?: Record<string, string> }
+  >,
+  ptyIdsByTabId: {} as Record<string, string[]>,
+  createTab: mockCreateTab,
+  closeTab: vi.fn(),
+  queueTabStartupCommand: mockQueueTabStartupCommand,
+  setActiveTabType: vi.fn(),
+  setTabBarOrder: vi.fn(),
+  setAgentStatus: vi.fn(),
+  seedNativeChatLaunchPrompt: vi.fn(),
+  seedNativeChatLaunchDraft: vi.fn(),
+  markNativeChatLaunchPromptFailed: vi.fn()
+}
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: () => store
+  }
+}))
+
+vi.mock('sonner', () => ({
+  toast: { message: vi.fn(), error: vi.fn() }
+}))
+
+vi.mock('@/components/tab-bar/reconcile-order', () => ({
+  reconcileTabOrder: vi.fn(
+    (_stored, termIds: string[], editorIds: string[], browserIds: string[]) => [
+      ...termIds,
+      ...editorIds,
+      ...browserIds
+    ]
+  )
+}))
+
+vi.mock('@/lib/agent-paste-draft', () => ({
+  pasteDraftWhenAgentReady: mockPasteDraftWhenAgentReady
+}))
+
+vi.mock('@/lib/telemetry', () => ({
+  track: vi.fn(),
+  tuiAgentToAgentKind: (agent: string) => agent
+}))
+
+vi.mock('@/runtime/web-runtime-session', () => ({
+  createWebRuntimeSessionTerminal: vi.fn(),
+  isWebRuntimeSessionActive: vi.fn(() => false),
+  isWebTerminalSurfaceTabId: vi.fn(() => false)
+}))
+
+describe('launchAgentInNewTab remote Codex hooks override', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    store.activeRepoId = 'repo-1'
+    store.activeWorktreeId = 'wt-1'
+    store.settings = {
+      agentCmdOverrides: {},
+      agentDefaultArgs: {},
+      agentDefaultEnv: {},
+      activeRuntimeEnvironmentId: null
+    }
+    store.projects = [{ id: 'repo-1', localWindowsRuntimePreference: { kind: 'inherit-global' } }]
+    store.repos = [{ id: 'repo-1', connectionId: 'ssh-a', path: '/work/demo-project' }]
+    store.sshConnectionStates = new Map([['ssh-a', { status: 'connected' }]])
+    store.transientClearedAgentStatusConnectionIds = {}
+    store.worktreesByRepo = {
+      'repo-1': [
+        {
+          id: 'wt-1',
+          repoId: 'repo-1',
+          projectId: 'repo-1',
+          path: '/work/demo-project',
+          displayName: 'main'
+        }
+      ]
+    }
+    store.tabsByWorktree = { 'wt-1': [{ id: 'tab-1' }] }
+    store.openFiles = []
+    store.browserTabsByWorktree = {}
+    store.tabBarOrderByWorktree = {}
+    store.terminalLayoutsByTabId = {}
+    store.ptyIdsByTabId = {}
+    mockCreateTab.mockReturnValue({ id: 'tab-1' })
+    mockPasteDraftWhenAgentReady.mockResolvedValue(true)
+  })
+
+  it('carries the hooks override into a remote Codex tab launch', async () => {
+    const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
+
+    launchAgentInNewTab({ agent: 'codex', worktreeId: 'wt-1', launchPlatform: 'linux' })
+
+    const command = mockQueueTabStartupCommand.mock.calls[0]?.[1]?.command ?? ''
+    expect(command).toContain("'-c' 'features.hooks=true'")
+  })
+
+  it('leaves a local Codex tab launch without the override', async () => {
+    store.repos = [{ id: 'repo-1', connectionId: null, path: '/repo' }]
+    const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
+
+    launchAgentInNewTab({ agent: 'codex', worktreeId: 'wt-1', launchPlatform: 'linux' })
+
+    const command = mockQueueTabStartupCommand.mock.calls[0]?.[1]?.command ?? ''
+    expect(command).not.toContain('features.hooks')
+  })
+
+  it('respects the global hooks toggle being off', async () => {
+    store.settings.agentStatusHooksEnabled = false
+    const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
+
+    launchAgentInNewTab({ agent: 'codex', worktreeId: 'wt-1', launchPlatform: 'linux' })
+
+    const command = mockQueueTabStartupCommand.mock.calls[0]?.[1]?.command ?? ''
+    expect(command).not.toContain('features.hooks')
+  })
+
+  it('does not overrule a user hooks=false in their Codex default args', async () => {
+    store.settings.agentDefaultArgs = { codex: '-c features.hooks=false' }
+    const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
+
+    launchAgentInNewTab({ agent: 'codex', worktreeId: 'wt-1', launchPlatform: 'linux' })
+
+    const command = mockQueueTabStartupCommand.mock.calls[0]?.[1]?.command ?? ''
+    expect(command).toContain('features.hooks=false')
+    expect(command.match(/features\.hooks/g)).toHaveLength(1)
+  })
+})

--- a/src/renderer/src/lib/launch-agent-in-new-tab.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.ts
@@ -130,7 +130,8 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
     isRemote,
     agentArgs: effectiveAgentArgs,
     agentEnv,
-    sessionOptions: resolveInitialNativeChatSessionOptions(store.settings, initialViewModeOptions)
+    sessionOptions: resolveInitialNativeChatSessionOptions(store.settings, initialViewModeOptions),
+    agentStatusHookSettings: store.settings ?? null
   }
   const { startupPlan, pasteDraftAfterLaunch, submitPastedPrompt } = planLaunchAgentStartupPrompt({
     base: startupPlanBase,

--- a/src/renderer/src/lib/launch-work-item-direct-agent.ts
+++ b/src/renderer/src/lib/launch-work-item-direct-agent.ts
@@ -18,6 +18,7 @@ import {
 import { translate } from '@/i18n/i18n'
 import { resolveInitialNativeChatSessionOptions } from '@/components/native-chat/native-chat-launch-session-options'
 import type { PersistedNativeChatSessionOptions } from '../../../shared/native-chat-session-options'
+import { areAgentStatusHooksEnabledForAgent } from '../../../shared/agent-status-hooks-for-agent'
 
 export function buildDirectWorkItemAgentStartupPlan(args: {
   agent: TuiAgent | null
@@ -70,6 +71,7 @@ export function buildDirectWorkItemAgentStartupPlan(args: {
           cmdOverrides: args.settings?.agentCmdOverrides ?? {},
           platform: args.launchPlatform,
           isRemote: args.isRemote,
+          agentStatusHooksEnabled: areAgentStatusHooksEnabledForAgent(args.settings, args.agent),
           agentArgs: effectiveAgentArgs,
           agentEnv: effectiveAgentEnv,
           sessionOptions
@@ -102,6 +104,7 @@ export function buildDirectWorkItemAgentStartupPlan(args: {
     cmdOverrides: args.settings?.agentCmdOverrides ?? {},
     platform: args.launchPlatform,
     isRemote: args.isRemote,
+    agentStatusHooksEnabled: areAgentStatusHooksEnabledForAgent(args.settings, args.agent),
     agentArgs: effectiveAgentArgs,
     agentEnv: effectiveAgentEnv,
     sessionOptions,

--- a/src/renderer/src/lib/launch-work-item-direct-agent.ts
+++ b/src/renderer/src/lib/launch-work-item-direct-agent.ts
@@ -33,6 +33,9 @@ export function buildDirectWorkItemAgentStartupPlan(args: {
         experimentalNativeChat?: boolean
         openAgentTabsInChatByDefault?: boolean
         nativeChatSessionOptions?: PersistedNativeChatSessionOptions
+        // Both gate managed status hooks; the launch plan needs each (#11941).
+        agentStatusHooksEnabled?: boolean
+        disabledTuiAgents?: readonly string[]
       }
     | null
     | undefined

--- a/src/renderer/src/lib/launch-work-item-direct-agent.ts
+++ b/src/renderer/src/lib/launch-work-item-direct-agent.ts
@@ -18,7 +18,6 @@ import {
 import { translate } from '@/i18n/i18n'
 import { resolveInitialNativeChatSessionOptions } from '@/components/native-chat/native-chat-launch-session-options'
 import type { PersistedNativeChatSessionOptions } from '../../../shared/native-chat-session-options'
-import { areAgentStatusHooksEnabledForAgent } from '../../../shared/agent-status-hooks-for-agent'
 
 export function buildDirectWorkItemAgentStartupPlan(args: {
   agent: TuiAgent | null
@@ -74,7 +73,7 @@ export function buildDirectWorkItemAgentStartupPlan(args: {
           cmdOverrides: args.settings?.agentCmdOverrides ?? {},
           platform: args.launchPlatform,
           isRemote: args.isRemote,
-          agentStatusHooksEnabled: areAgentStatusHooksEnabledForAgent(args.settings, args.agent),
+          agentStatusHookSettings: args.settings ?? null,
           agentArgs: effectiveAgentArgs,
           agentEnv: effectiveAgentEnv,
           sessionOptions
@@ -107,7 +106,7 @@ export function buildDirectWorkItemAgentStartupPlan(args: {
     cmdOverrides: args.settings?.agentCmdOverrides ?? {},
     platform: args.launchPlatform,
     isRemote: args.isRemote,
-    agentStatusHooksEnabled: areAgentStatusHooksEnabledForAgent(args.settings, args.agent),
+    agentStatusHookSettings: args.settings ?? null,
     agentArgs: effectiveAgentArgs,
     agentEnv: effectiveAgentEnv,
     sessionOptions,

--- a/src/renderer/src/lib/launch-work-item-direct.test.ts
+++ b/src/renderer/src/lib/launch-work-item-direct.test.ts
@@ -407,7 +407,8 @@ describe('launchWorkItemDirect', () => {
       agentEnv: {},
       sessionOptions: undefined,
       platform: 'win32',
-      isRemote: false
+      isRemote: false,
+      agentStatusHooksEnabled: true
     })
     expect(buildAgentStartupPlan).not.toHaveBeenCalledWith(
       expect.objectContaining({
@@ -598,7 +599,8 @@ describe('launchWorkItemDirect', () => {
       agentEnv: {},
       sessionOptions: undefined,
       platform: 'linux',
-      isRemote: true
+      isRemote: true,
+      agentStatusHooksEnabled: true
     })
     expect(buildAgentStartupPlan).toHaveBeenCalledWith({
       agent: 'cursor',
@@ -609,6 +611,7 @@ describe('launchWorkItemDirect', () => {
       sessionOptions: undefined,
       platform: 'linux',
       isRemote: true,
+      agentStatusHooksEnabled: true,
       allowEmptyPromptLaunch: true
     })
     expect(mocks.activateAndRevealWorktree).toHaveBeenCalledWith(

--- a/src/renderer/src/lib/launch-work-item-direct.test.ts
+++ b/src/renderer/src/lib/launch-work-item-direct.test.ts
@@ -408,7 +408,9 @@ describe('launchWorkItemDirect', () => {
       sessionOptions: undefined,
       platform: 'win32',
       isRemote: false,
-      agentStatusHooksEnabled: true
+      // Why: the builder derives hooks itself now, so the launch surface is
+      // asserted to hand it the real settings rather than a pre-chewed boolean.
+      agentStatusHookSettings: mocks.store.settings
     })
     expect(buildAgentStartupPlan).not.toHaveBeenCalledWith(
       expect.objectContaining({
@@ -600,7 +602,7 @@ describe('launchWorkItemDirect', () => {
       sessionOptions: undefined,
       platform: 'linux',
       isRemote: true,
-      agentStatusHooksEnabled: true
+      agentStatusHookSettings: mocks.store.settings
     })
     expect(buildAgentStartupPlan).toHaveBeenCalledWith({
       agent: 'cursor',
@@ -611,7 +613,7 @@ describe('launchWorkItemDirect', () => {
       sessionOptions: undefined,
       platform: 'linux',
       isRemote: true,
-      agentStatusHooksEnabled: true,
+      agentStatusHookSettings: mocks.store.settings,
       allowEmptyPromptLaunch: true
     })
     expect(mocks.activateAndRevealWorktree).toHaveBeenCalledWith(

--- a/src/renderer/src/lib/onboarding-folder-agent-startup.ts
+++ b/src/renderer/src/lib/onboarding-folder-agent-startup.ts
@@ -56,7 +56,8 @@ export function buildOnboardingFolderAgentStartup(
       nativeChatTranscriptIsLocalReadable
     }),
     platform: getClientPlatform(),
-    allowEmptyPromptLaunch: true
+    allowEmptyPromptLaunch: true,
+    agentStatusHookSettings: settings
   })
   if (!startupPlan) {
     return undefined

--- a/src/renderer/src/lib/sleeping-agent-session-launch-windows-quoting.test.ts
+++ b/src/renderer/src/lib/sleeping-agent-session-launch-windows-quoting.test.ts
@@ -136,6 +136,8 @@ describe('launchSleepingAgentSession Windows shell quoting', () => {
     )
   })
 
+  // Why: an SSH resume carries the launch-scoped hooks override a fresh remote
+  // Codex launch gets, so it does not re-attach to an env-less app-server (#11941).
   it('ignores the local Windows shell setting for an SSH workspace', async () => {
     store.settings.terminalWindowsShell = 'cmd.exe'
     store.repos = [{ id: 'repo-1', connectionId: 'ssh-1', path: '/home/neil/repo' }]
@@ -151,7 +153,7 @@ describe('launchSleepingAgentSession Windows shell quoting', () => {
     }
 
     await expect(launch()).resolves.toBe(
-      `codex '--dangerously-bypass-approvals-and-sandbox' 'resume' '${SESSION_ID}'`
+      `codex '-c' 'features.hooks=true' '--dangerously-bypass-approvals-and-sandbox' 'resume' '${SESSION_ID}'`
     )
   })
 })

--- a/src/renderer/src/lib/sleeping-agent-session-launch.ts
+++ b/src/renderer/src/lib/sleeping-agent-session-launch.ts
@@ -86,7 +86,9 @@ export function launchSleepingAgentSession(
       ? { ompResumeFilePath: launchConfig.ompResumeFilePath }
       : {}),
     platform: resumeTarget.platform,
-    shell: resumeTarget.shell
+    shell: resumeTarget.shell,
+    isRemote: resumeTarget.isRemote,
+    agentStatusHookSettings: state.settings ?? null
   })
   if (!startupPlan) {
     toast.error(

--- a/src/renderer/src/lib/source-control-agent-action-plan.test.ts
+++ b/src/renderer/src/lib/source-control-agent-action-plan.test.ts
@@ -10,7 +10,8 @@ describe('planSourceControlAgentActionLaunch', () => {
         promptDelivery: 'submit-after-ready',
         detectedAgents: ['codex'],
         disabledAgents: ['codex'],
-        platform: 'darwin'
+        platform: 'darwin',
+        agentStatusHookSettings: null
       })
     ).toEqual({ ok: false, error: 'The selected agent is disabled in Settings.' })
   })
@@ -22,7 +23,8 @@ describe('planSourceControlAgentActionLaunch', () => {
         commandInput: 'Fix checks',
         promptDelivery: 'submit-after-ready',
         detectedAgents: ['codex'],
-        platform: 'linux'
+        platform: 'linux',
+        agentStatusHookSettings: null
       })
     ).toEqual({ ok: false, error: 'The selected agent was not detected on this workspace host.' })
   })
@@ -33,7 +35,8 @@ describe('planSourceControlAgentActionLaunch', () => {
       commandInput: 'Fix checks',
       promptDelivery: 'submit-after-ready',
       detectedAgents: ['codex'],
-      platform: 'linux'
+      platform: 'linux',
+      agentStatusHookSettings: null
     })
 
     expect(result.ok && result.delivery).toBe('paste-submit')
@@ -49,7 +52,8 @@ describe('planSourceControlAgentActionLaunch', () => {
       agentArgs: '--model gpt-5.5',
       promptDelivery: 'submit-after-ready',
       detectedAgents: ['codex'],
-      platform: 'linux'
+      platform: 'linux',
+      agentStatusHookSettings: null
     })
 
     expect(result.ok && result.commandLabel).toBe("codex '--model' 'gpt-5.5'")
@@ -73,7 +77,8 @@ describe('planSourceControlAgentActionLaunch', () => {
         promptDelivery: 'auto-submit',
         detectedAgents: ['hermes'],
         platform: 'win32',
-        terminalWindowsShell
+        terminalWindowsShell,
+        agentStatusHookSettings: null
       })
 
       expect(result.ok && result.plan.launchCommand).toContain(expectedCommand)
@@ -89,7 +94,8 @@ describe('planSourceControlAgentActionLaunch', () => {
         agentArgs: '--model "unterminated',
         promptDelivery: 'submit-after-ready',
         detectedAgents: ['codex'],
-        platform: 'linux'
+        platform: 'linux',
+        agentStatusHookSettings: null
       })
     ).toEqual({
       ok: false,
@@ -103,7 +109,8 @@ describe('planSourceControlAgentActionLaunch', () => {
       commandInput: 'Fix checks',
       promptDelivery: 'draft',
       detectedAgents: ['claude'],
-      platform: 'darwin'
+      platform: 'darwin',
+      agentStatusHookSettings: null
     })
 
     expect(result.ok && result.delivery).toBe('draft-native')

--- a/src/renderer/src/lib/source-control-agent-action-plan.ts
+++ b/src/renderer/src/lib/source-control-agent-action-plan.ts
@@ -1,3 +1,4 @@
+import type { AgentStatusHookSettings } from '../../../shared/agent-status-hooks-for-agent'
 import {
   buildAgentDraftLaunchPlan,
   buildAgentStartupPlan,
@@ -43,6 +44,8 @@ export function planSourceControlAgentActionLaunch(args: {
   /** Why: SSH remotes deploy the CLI shim as plain `orca`, so the Linux-only
    * `orca-ide` rename must not be applied for remote launches. */
   isRemote?: boolean
+  /** Settings that decide Orca's managed status hooks for the launched agent (#11941). */
+  agentStatusHookSettings: AgentStatusHookSettings | null
 }): SourceControlLaunchPlanResult {
   const agent = args.agent
   if (!agent) {
@@ -110,6 +113,7 @@ export function planSourceControlAgentActionLaunch(args: {
       isRemote,
       agentArgs: args.agentArgs,
       sessionOptions: args.sessionOptions,
+      agentStatusHookSettings: args.agentStatusHookSettings,
       allowEmptyPromptLaunch: true
     })
     delivery = 'paste-submit'
@@ -122,7 +126,8 @@ export function planSourceControlAgentActionLaunch(args: {
       shell,
       isRemote,
       agentArgs: args.agentArgs,
-      sessionOptions: args.sessionOptions
+      sessionOptions: args.sessionOptions,
+      agentStatusHookSettings: args.agentStatusHookSettings
     })
     if (draftLaunchPlan) {
       startupPlan = {
@@ -150,6 +155,7 @@ export function planSourceControlAgentActionLaunch(args: {
         isRemote,
         agentArgs: args.agentArgs,
         sessionOptions: args.sessionOptions,
+        agentStatusHookSettings: args.agentStatusHookSettings,
         allowEmptyPromptLaunch: true
       })
       delivery = 'draft-paste'
@@ -164,6 +170,7 @@ export function planSourceControlAgentActionLaunch(args: {
       isRemote,
       agentArgs: args.agentArgs,
       sessionOptions: args.sessionOptions,
+      agentStatusHookSettings: args.agentStatusHookSettings,
       allowEmptyPromptLaunch: true
     })
     delivery = 'draft-paste'
@@ -177,6 +184,7 @@ export function planSourceControlAgentActionLaunch(args: {
       isRemote,
       agentArgs: args.agentArgs,
       sessionOptions: args.sessionOptions,
+      agentStatusHookSettings: args.agentStatusHookSettings,
       allowEmptyPromptLaunch: false
     })
     delivery = 'argv'

--- a/src/renderer/src/lib/tui-agent-startup.test.ts
+++ b/src/renderer/src/lib/tui-agent-startup.test.ts
@@ -19,7 +19,8 @@ describe('buildAgentStartupPlan', () => {
         agent: 'claude',
         prompt: 'Fix the bug',
         cmdOverrides: {},
-        platform: 'darwin'
+        platform: 'darwin',
+        agentStatusHookSettings: null
       })
     ).toEqual({
       agent: 'claude',
@@ -36,7 +37,8 @@ describe('buildAgentStartupPlan', () => {
         agent: 'gemini',
         prompt: 'Investigate this regression',
         cmdOverrides: {},
-        platform: 'linux'
+        platform: 'linux',
+        agentStatusHookSettings: null
       })
     ).toEqual({
       agent: 'gemini',
@@ -53,7 +55,8 @@ describe('buildAgentStartupPlan', () => {
         agent: 'antigravity',
         prompt: 'Investigate this regression',
         cmdOverrides: {},
-        platform: 'linux'
+        platform: 'linux',
+        agentStatusHookSettings: null
       })
     ).toEqual({
       agent: 'antigravity',
@@ -70,7 +73,8 @@ describe('buildAgentStartupPlan', () => {
         agent: 'aider',
         prompt: 'Refactor the parser',
         cmdOverrides: {},
-        platform: 'linux'
+        platform: 'linux',
+        agentStatusHookSettings: null
       })
     ).toEqual({
       agent: 'aider',
@@ -87,7 +91,8 @@ describe('buildAgentStartupPlan', () => {
         agent: 'autohand',
         prompt: 'Add tests for the parser',
         cmdOverrides: {},
-        platform: 'linux'
+        platform: 'linux',
+        agentStatusHookSettings: null
       })
     ).toEqual({
       agent: 'autohand',
@@ -104,7 +109,8 @@ describe('buildAgentStartupPlan', () => {
         agent: 'ante',
         prompt: 'Summarize the failing tests',
         cmdOverrides: {},
-        platform: 'linux'
+        platform: 'linux',
+        agentStatusHookSettings: null
       })
     ).toEqual({
       agent: 'ante',
@@ -121,7 +127,8 @@ describe('buildAgentStartupPlan', () => {
         agent: 'trae',
         prompt: 'Summarize the failing tests',
         cmdOverrides: {},
-        platform: 'linux'
+        platform: 'linux',
+        agentStatusHookSettings: null
       })
     ).toEqual({
       agent: 'trae',
@@ -139,7 +146,8 @@ describe('buildAgentStartupPlan', () => {
         agent: 'trae',
         prompt: 'help me name this config',
         cmdOverrides: {},
-        platform: 'linux'
+        platform: 'linux',
+        agentStatusHookSettings: null
       })?.launchCommand
     ).toBe("traecli -- 'help me name this config'")
   })
@@ -150,7 +158,8 @@ describe('buildAgentStartupPlan', () => {
         agent: 'prime-agent',
         prompt: 'Summarize the failing tests',
         cmdOverrides: {},
-        platform: 'linux'
+        platform: 'linux',
+        agentStatusHookSettings: null
       })
     ).toEqual({
       agent: 'prime-agent',
@@ -168,7 +177,8 @@ describe('buildAgentStartupPlan', () => {
         agent: 'prime-agent',
         prompt: 'help me name this config',
         cmdOverrides: {},
-        platform: 'linux'
+        platform: 'linux',
+        agentStatusHookSettings: null
       })?.launchCommand
     ).toBe("prime-agent -- 'help me name this config'")
   })
@@ -179,7 +189,8 @@ describe('buildAgentStartupPlan', () => {
         agent: 'cursor',
         prompt: 'Review this file',
         cmdOverrides: {},
-        platform: 'darwin'
+        platform: 'darwin',
+        agentStatusHookSettings: null
       })
     ).toEqual({
       agent: 'cursor',
@@ -196,7 +207,8 @@ describe('buildAgentStartupPlan', () => {
         agent: 'droid',
         prompt: 'Ship the fix',
         cmdOverrides: { droid: '/opt/factory/bin/droid' },
-        platform: 'linux'
+        platform: 'linux',
+        agentStatusHookSettings: null
       })
     ).toEqual({
       agent: 'droid',
@@ -213,7 +225,8 @@ describe('buildAgentStartupPlan', () => {
         agent: 'copilot',
         prompt: 'Fix the bug',
         cmdOverrides: {},
-        platform: 'darwin'
+        platform: 'darwin',
+        agentStatusHookSettings: null
       })
     ).toEqual({
       agent: 'copilot',
@@ -230,7 +243,8 @@ describe('buildAgentStartupPlan', () => {
         agent: 'grok',
         prompt: 'Trace the failing test',
         cmdOverrides: {},
-        platform: 'linux'
+        platform: 'linux',
+        agentStatusHookSettings: null
       })
     ).toEqual({
       agent: 'grok',
@@ -248,7 +262,8 @@ describe('buildAgentStartupPlan', () => {
         prompt: 'Trace the failing test',
         cmdOverrides: {},
         agentArgs: resolveTuiAgentLaunchArgs('devin', null),
-        platform: 'linux'
+        platform: 'linux',
+        agentStatusHookSettings: null
       })
     ).toEqual({
       agent: 'devin',
@@ -269,7 +284,8 @@ describe('buildAgentStartupPlan', () => {
         agent: 'command-code',
         prompt: 'Fix the issue',
         cmdOverrides: {},
-        platform: 'win32'
+        platform: 'win32',
+        agentStatusHookSettings: null
       })
     ).toEqual({
       agent: 'command-code',
@@ -286,7 +302,8 @@ describe('buildAgentStartupPlan', () => {
         agent: 'codex',
         prompt: '   ',
         cmdOverrides: {},
-        platform: 'darwin'
+        platform: 'darwin',
+        agentStatusHookSettings: null
       })
     ).toBeNull()
   })
@@ -297,7 +314,8 @@ describe('buildAgentStartupPlan', () => {
         agent: 'copilot',
         prompt: 'Fix the bug',
         cmdOverrides: {},
-        platform: 'darwin'
+        platform: 'darwin',
+        agentStatusHookSettings: null
       })
     ).toEqual({
       agent: 'copilot',
@@ -316,7 +334,8 @@ describe('buildAgentDraftLaunchPlan', () => {
         agent: 'claude',
         draft: 'https://github.com/acme/repo/issues/42',
         cmdOverrides: {},
-        platform: 'darwin'
+        platform: 'darwin',
+        agentStatusHookSettings: null
       })
     ).toEqual({
       agent: 'claude',
@@ -332,7 +351,8 @@ describe('buildAgentDraftLaunchPlan', () => {
         agent: 'codex',
         draft: 'https://github.com/acme/repo/issues/42',
         cmdOverrides: {},
-        platform: 'darwin'
+        platform: 'darwin',
+        agentStatusHookSettings: null
       })
     ).toBeNull()
   })
@@ -348,7 +368,8 @@ describe('buildAgentDraftLaunchPlan', () => {
         agent: 'pi',
         draft: 'https://github.com/acme/repo/issues/42',
         cmdOverrides: {},
-        platform: 'darwin'
+        platform: 'darwin',
+        agentStatusHookSettings: null
       })
     ).toEqual({
       agent: 'pi',
@@ -365,7 +386,8 @@ describe('buildAgentDraftLaunchPlan', () => {
         agent: 'claude',
         draft: '   ',
         cmdOverrides: {},
-        platform: 'darwin'
+        platform: 'darwin',
+        agentStatusHookSettings: null
       })
     ).toBeNull()
   })
@@ -376,7 +398,8 @@ describe('buildAgentDraftLaunchPlan', () => {
         agent: 'claude',
         draft: 'review this',
         cmdOverrides: { claude: '/opt/anthropic/bin/claude' },
-        platform: 'linux'
+        platform: 'linux',
+        agentStatusHookSettings: null
       })
     ).toEqual({
       agent: 'claude',
@@ -392,7 +415,8 @@ describe('buildAgentDraftLaunchPlan', () => {
         agent: 'openclaude',
         draft: 'review this',
         cmdOverrides: {},
-        platform: 'linux'
+        platform: 'linux',
+        agentStatusHookSettings: null
       })
     ).toEqual({
       agent: 'openclaude',

--- a/src/shared/agent-hook-host-status.test.ts
+++ b/src/shared/agent-hook-host-status.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import {
+  describeAgentHookHost,
+  formatAgentHookHostReports,
+  summarizeAgentHookHostState
+} from './agent-hook-host-status'
+import type { AgentHookInstallStatus } from './agent-hook-types'
+
+function status(
+  agent: AgentHookInstallStatus['agent'],
+  state: AgentHookInstallStatus['state']
+): AgentHookInstallStatus {
+  return { agent, state, configPath: '', managedHooksPresent: state === 'installed', detail: null }
+}
+
+describe('summarizeAgentHookHostState', () => {
+  it('treats an empty result as unknown, not installed', () => {
+    expect(summarizeAgentHookHostState([])).toBe('unknown')
+  })
+
+  it('is installed only when every agent installed', () => {
+    expect(summarizeAgentHookHostState([status('claude', 'installed')])).toBe('installed')
+    expect(
+      summarizeAgentHookHostState([status('claude', 'installed'), status('codex', 'not_installed')])
+    ).toBe('partial')
+  })
+
+  it('reports error only when nothing succeeded', () => {
+    expect(summarizeAgentHookHostState([status('codex', 'error')])).toBe('error')
+    expect(
+      summarizeAgentHookHostState([status('claude', 'installed'), status('codex', 'error')])
+    ).toBe('partial')
+  })
+
+  it('reports skipped when Orca deliberately installed nothing', () => {
+    expect(summarizeAgentHookHostState([status('codex', 'skipped')])).toBe('skipped')
+  })
+})
+
+describe('describeAgentHookHost', () => {
+  it('names each host kind', () => {
+    expect(describeAgentHookHost({ kind: 'local' })).toBe('local')
+    expect(describeAgentHookHost({ kind: 'ssh', targetId: 't', label: 'box' })).toBe('ssh:box')
+    expect(describeAgentHookHost({ kind: 'wsl', distro: 'Ubuntu' })).toBe('wsl:Ubuntu')
+  })
+})
+
+describe('formatAgentHookHostReports', () => {
+  it('prefixes every agent line with the host it belongs to', () => {
+    const output = formatAgentHookHostReports([
+      {
+        host: { kind: 'local' },
+        state: 'installed',
+        detail: null,
+        statuses: [status('codex', 'installed')]
+      },
+      {
+        host: { kind: 'ssh', targetId: 't', label: 'box' },
+        state: 'partial',
+        detail: '1 agent hook install(s) failed on this host.',
+        statuses: [status('codex', 'error')]
+      }
+    ])
+
+    expect(output.split('\n')).toEqual([
+      'local: installed',
+      '  codex: installed',
+      'ssh:box: partial — 1 agent hook install(s) failed on this host.',
+      '  codex: error'
+    ])
+  })
+})

--- a/src/shared/agent-hook-host-status.ts
+++ b/src/shared/agent-hook-host-status.ts
@@ -1,0 +1,84 @@
+// Why (#8711): managed hook state is per-host, but `orca agent hooks status`
+// only ever read the machine running Orca. For an SSH worktree the agent runs
+// somewhere else entirely, so a green local report validated a file the agent
+// could never read. Every status surface now names the host it checked, and a
+// host Orca could not check reports `unknown` rather than borrowing the local
+// answer.
+
+import type { AgentHookInstallStatus } from './agent-hook-types'
+
+/** The host that actually executes the agent whose hooks are being reported. */
+export type AgentHookHost =
+  | { kind: 'local' }
+  | { kind: 'ssh'; targetId: string; label: string }
+  | { kind: 'wsl'; distro: string }
+
+export type AgentHookHostState =
+  | 'installed'
+  | 'partial'
+  | 'error'
+  /** Orca deliberately did not install here (hooks off, Windows remote, no agent CLI). */
+  | 'skipped'
+  /** Orca could not determine this host's state — never treat as installed. */
+  | 'unknown'
+
+/** A host's managed-hook state before it is attached to a named host. */
+export type AgentHookHostOutcome = {
+  state: AgentHookHostState
+  detail: string | null
+  /** Per-agent detail, when the host could report it. Empty for `unknown`, and
+   *  for hosts whose relay predates the per-agent field on the install RPC. */
+  statuses: readonly AgentHookInstallStatus[]
+}
+
+export type AgentHookHostReport = AgentHookHostOutcome & {
+  host: AgentHookHost
+}
+
+export function describeAgentHookHost(host: AgentHookHost): string {
+  switch (host.kind) {
+    case 'local':
+      return 'local'
+    case 'ssh':
+      return `ssh:${host.label}`
+    case 'wsl':
+      return `wsl:${host.distro}`
+  }
+}
+
+/** Rolls per-agent results into one host verdict. An empty list is `unknown`:
+ *  "nothing to report" and "nothing was checked" must not both read as green. */
+export function summarizeAgentHookHostState(
+  statuses: readonly AgentHookInstallStatus[]
+): AgentHookHostState {
+  if (statuses.length === 0) {
+    return 'unknown'
+  }
+  if (statuses.some((status) => status.state === 'error')) {
+    return statuses.every((status) => status.state === 'error') ? 'error' : 'partial'
+  }
+  if (statuses.every((status) => status.state === 'skipped')) {
+    return 'skipped'
+  }
+  if (statuses.some((status) => status.state === 'not_installed' || status.state === 'partial')) {
+    return 'partial'
+  }
+  return 'installed'
+}
+
+function formatAgentLine(status: AgentHookInstallStatus): string {
+  const detail = status.detail ? ` — ${status.detail}` : ''
+  return `  ${status.agent}: ${status.state}${detail}`
+}
+
+export function formatAgentHookHostReport(report: AgentHookHostReport): string {
+  const detail = report.detail ? ` — ${report.detail}` : ''
+  return [
+    `${describeAgentHookHost(report.host)}: ${report.state}${detail}`,
+    ...report.statuses.map(formatAgentLine)
+  ].join('\n')
+}
+
+export function formatAgentHookHostReports(reports: readonly AgentHookHostReport[]): string {
+  return reports.map(formatAgentHookHostReport).join('\n')
+}

--- a/src/shared/agent-resume-argv-drop.test.ts
+++ b/src/shared/agent-resume-argv-drop.test.ts
@@ -13,7 +13,8 @@ function planFor(platform: NodeJS.Platform, agentArgs?: string): string {
     providerSession: CODEX_SESSION,
     cmdOverrides: {},
     platform,
-    ...(agentArgs ? { agentArgs } : {})
+    ...(agentArgs ? { agentArgs } : {}),
+    agentStatusHookSettings: null
   })
   if (!plan) {
     throw new Error('expected a codex resume plan')

--- a/src/shared/agent-resume-launch-command.test.ts
+++ b/src/shared/agent-resume-launch-command.test.ts
@@ -516,7 +516,8 @@ describe('buildAgentResumeStartupPlan claude selector guard', () => {
         agentArgs: '--resume',
         platform,
         shell,
-        allowEmptyPromptLaunch: true
+        allowEmptyPromptLaunch: true,
+        agentStatusHookSettings: null
       })
       expect(initial).not.toBeNull()
       const restored = buildAgentResumeStartupPlan({
@@ -526,7 +527,8 @@ describe('buildAgentResumeStartupPlan claude selector guard', () => {
         agentArgs: initial?.launchConfig.agentArgs,
         agentCommand: initial?.launchConfig.agentCommand,
         platform,
-        shell
+        shell,
+        agentStatusHookSettings: null
       })
       expect(restored).not.toBeNull()
       expectSingleAuthoritativeResume(restored?.launchCommand ?? '', shell)
@@ -539,7 +541,8 @@ describe('buildAgentResumeStartupPlan claude selector guard', () => {
       providerSession,
       cmdOverrides: {},
       agentArgs: '--resume stale-session --model sonnet',
-      platform: 'linux'
+      platform: 'linux',
+      agentStatusHookSettings: null
     })
     expect(restored?.launchCommand).toBe(`claude '--model' 'sonnet' '--resume' '${SESSION_ID}'`)
   })
@@ -550,7 +553,8 @@ describe('buildAgentResumeStartupPlan claude selector guard', () => {
       providerSession,
       cmdOverrides: {},
       agentCommand: 'claude --model $(cat ~/.claude-model) "unterminated',
-      platform: 'darwin'
+      platform: 'darwin',
+      agentStatusHookSettings: null
     })
     expect(restored).not.toBeNull()
     expect(restored?.launchCommand.endsWith(`'--resume' '${SESSION_ID}'`)).toBe(true)
@@ -562,7 +566,8 @@ describe('buildAgentResumeStartupPlan claude selector guard', () => {
       providerSession,
       cmdOverrides: {},
       agentArgs: '--resume',
-      platform: 'linux'
+      platform: 'linux',
+      agentStatusHookSettings: null
     })
     expect(restored?.launchCommand).toBe(`gemini '--resume' '--resume' '${SESSION_ID}'`)
   })
@@ -573,7 +578,8 @@ describe('buildAgentResumeStartupPlan claude selector guard', () => {
       providerSession,
       cmdOverrides: {},
       agentCommand: "claude '--resume'",
-      platform: 'linux'
+      platform: 'linux',
+      agentStatusHookSettings: null
     })
     expect(restored?.launchConfig.agentCommand).toBe("claude '--resume'")
   })

--- a/src/shared/agent-status-hooks-for-agent.ts
+++ b/src/shared/agent-status-hooks-for-agent.ts
@@ -1,0 +1,19 @@
+// Why: launch surfaces need one answer to "are Orca's managed status hooks on
+// for this agent" — the global toggle and the per-agent opt-out both count, and
+// a surface that checks only one of them plans the wrong launch (#11941).
+
+import { normalizeDisabledTuiAgents } from './tui-agent-selection'
+import type { TuiAgent } from './tui-agent'
+
+export function areAgentStatusHooksEnabledForAgent(
+  settings:
+    | { agentStatusHooksEnabled?: boolean; disabledTuiAgents?: readonly string[] }
+    | null
+    | undefined,
+  agent: TuiAgent
+): boolean {
+  if (settings?.agentStatusHooksEnabled === false) {
+    return false
+  }
+  return !normalizeDisabledTuiAgents(settings?.disabledTuiAgents).includes(agent)
+}

--- a/src/shared/agent-status-hooks-for-agent.ts
+++ b/src/shared/agent-status-hooks-for-agent.ts
@@ -5,11 +5,15 @@
 import { normalizeDisabledTuiAgents } from './tui-agent-selection'
 import type { TuiAgent } from './tui-agent'
 
+/** The settings a launch surface must hand a plan builder so the builder can
+ *  decide hooks itself. Structural, so callers pass `GlobalSettings` directly. */
+export type AgentStatusHookSettings = {
+  agentStatusHooksEnabled?: boolean
+  disabledTuiAgents?: readonly string[]
+}
+
 export function areAgentStatusHooksEnabledForAgent(
-  settings:
-    | { agentStatusHooksEnabled?: boolean; disabledTuiAgents?: readonly string[] }
-    | null
-    | undefined,
+  settings: AgentStatusHookSettings | null | undefined,
   agent: TuiAgent
 ): boolean {
   if (settings?.agentStatusHooksEnabled === false) {

--- a/src/shared/codex-remote-hook-launch.test.ts
+++ b/src/shared/codex-remote-hook-launch.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import {
+  launchTokensDecideCodexHooks,
+  planCodexRemoteHookLaunchArgs
+} from './codex-remote-hook-launch'
+
+const REMOTE_POSIX = {
+  agent: 'codex' as const,
+  platform: 'linux' as NodeJS.Platform,
+  isRemote: true,
+  hooksEnabled: true
+}
+
+describe('planCodexRemoteHookLaunchArgs', () => {
+  it('gives a remote POSIX Codex launch its own app-server via a hooks override', () => {
+    expect(planCodexRemoteHookLaunchArgs(REMOTE_POSIX)).toEqual(['-c', 'features.hooks=true'])
+  })
+
+  it('leaves local Codex launches unchanged', () => {
+    expect(planCodexRemoteHookLaunchArgs({ ...REMOTE_POSIX, isRemote: false })).toEqual([])
+    expect(planCodexRemoteHookLaunchArgs({ ...REMOTE_POSIX, isRemote: undefined })).toEqual([])
+  })
+
+  it('leaves Windows remotes unchanged', () => {
+    expect(planCodexRemoteHookLaunchArgs({ ...REMOTE_POSIX, platform: 'win32' })).toEqual([])
+  })
+
+  it('emits nothing when Orca status hooks are off for this agent', () => {
+    expect(planCodexRemoteHookLaunchArgs({ ...REMOTE_POSIX, hooksEnabled: false })).toEqual([])
+    expect(planCodexRemoteHookLaunchArgs({ ...REMOTE_POSIX, hooksEnabled: undefined })).toEqual([])
+  })
+
+  it('never touches other agents', () => {
+    for (const agent of ['claude', 'gemini', 'droid'] as const) {
+      expect(planCodexRemoteHookLaunchArgs({ ...REMOTE_POSIX, agent })).toEqual([])
+    }
+  })
+
+  it('defers to a user who already decided the hooks feature', () => {
+    const cases: string[][] = [
+      ['--disable', 'hooks'],
+      ['--enable', 'hooks'],
+      ['-c', 'features.hooks=false'],
+      ['--config', 'features.hooks=true'],
+      ['-cfeatures.hooks=false'],
+      ['--config=features.hooks=false']
+    ]
+    for (const launchTokens of cases) {
+      expect(planCodexRemoteHookLaunchArgs({ ...REMOTE_POSIX, launchTokens })).toEqual([])
+    }
+  })
+
+  it('still applies when the user set an unrelated flag or feature', () => {
+    expect(
+      planCodexRemoteHookLaunchArgs({
+        ...REMOTE_POSIX,
+        launchTokens: ['--enable', 'unified_exec', '-c', 'model="gpt-5"', '--search']
+      })
+    ).toEqual(['-c', 'features.hooks=true'])
+  })
+})
+
+describe('launchTokensDecideCodexHooks', () => {
+  it('does not treat a bare "hooks" word as a decision', () => {
+    expect(launchTokensDecideCodexHooks(['resume', 'hooks'])).toBe(false)
+  })
+
+  it('reads the value that follows --enable / --disable', () => {
+    expect(launchTokensDecideCodexHooks(['--enable', 'hooks'])).toBe(true)
+    expect(launchTokensDecideCodexHooks(['--disable', 'plugin_hooks'])).toBe(false)
+  })
+})

--- a/src/shared/codex-remote-hook-launch.ts
+++ b/src/shared/codex-remote-hook-launch.ts
@@ -1,0 +1,75 @@
+// Why (#11941): an interactive Codex TUI can attach to an app-server that was
+// already running before Orca opened the pane. Hook commands then execute in
+// that daemon's environment, which has none of the pane-scoped
+// ORCA_AGENT_HOOK_* values, and Orca's managed hook script exits successfully
+// when they are missing — so every lifecycle event is silently dropped.
+//
+// Codex only reuses an implicit local daemon for a launch that carries no
+// config override, so a launch-scoped `-c features.hooks=true` gives this pane
+// its own app-server, started from the PTY that has Orca's hook coordinates.
+// The override is also the honest statement of intent: Orca needs hooks on for
+// the session it is launching.
+//
+// `-c` rather than `--enable hooks`: `--enable` is validated against the CLI's
+// feature registry and hard-errors on a key it does not know, which would turn
+// a hook gap into a launch failure on older Codex builds. An unrecognized
+// `[features]` key in a `-c` override is ignored instead.
+
+import type { TuiAgent } from './tui-agent'
+
+export const CODEX_HOOK_FEATURE_KEY = 'features.hooks'
+const CODEX_HOOK_LAUNCH_OVERRIDE = `${CODEX_HOOK_FEATURE_KEY}=true`
+
+function decidesHooks(token: string): boolean {
+  const trimmed = token.trim()
+  if (trimmed === 'hooks') {
+    return false
+  }
+  return (
+    trimmed.startsWith(`${CODEX_HOOK_FEATURE_KEY}=`) ||
+    trimmed === `-c${CODEX_HOOK_FEATURE_KEY}` ||
+    trimmed.startsWith(`-c${CODEX_HOOK_FEATURE_KEY}=`) ||
+    trimmed.startsWith(`--config=${CODEX_HOOK_FEATURE_KEY}=`)
+  )
+}
+
+/** True when the user's own tokens already decide the hooks feature, in which
+ *  case Orca must not overrule them (an explicit `--disable hooks` included). */
+export function launchTokensDecideCodexHooks(tokens: readonly string[]): boolean {
+  return tokens.some((token, index) => {
+    if (decidesHooks(token)) {
+      return true
+    }
+    if (token === '--enable' || token === '--disable') {
+      return tokens[index + 1]?.trim() === 'hooks'
+    }
+    if (token === '-c' || token === '--config') {
+      return decidesHooks(tokens[index + 1] ?? '')
+    }
+    return false
+  })
+}
+
+export function planCodexRemoteHookLaunchArgs(input: {
+  agent: TuiAgent
+  /** The platform the agent command runs on, not the machine driving Orca. */
+  platform: NodeJS.Platform
+  isRemote?: boolean
+  /** Orca's managed hooks are on for this agent on this host. */
+  hooksEnabled?: boolean
+  /** Tokens the launch already carries: user CLI args and command override. */
+  launchTokens?: readonly string[]
+}): readonly string[] {
+  if (input.agent !== 'codex' || !input.isRemote || !input.hooksEnabled) {
+    return []
+  }
+  // Why: Windows remotes take the relay-injected env path, and the POSIX
+  // app-server reuse this works around does not apply there.
+  if (input.platform === 'win32') {
+    return []
+  }
+  if (launchTokensDecideCodexHooks(input.launchTokens ?? [])) {
+    return []
+  }
+  return ['-c', CODEX_HOOK_LAUNCH_OVERRIDE]
+}

--- a/src/shared/tui-agent-launch-command.codex-remote-hooks.test.ts
+++ b/src/shared/tui-agent-launch-command.codex-remote-hooks.test.ts
@@ -1,0 +1,99 @@
+// Why (#11941): the planner is unit-tested next door; this asserts the override
+// actually reaches the command string a remote Codex PTY runs, and that the
+// local command — the one #8711's env injection already covers — is untouched.
+
+import { describe, expect, it } from 'vitest'
+import { resolveAgentLaunchCommand } from './tui-agent-launch-command'
+import { buildAgentStartupPlan } from './tui-agent-startup'
+
+const BASE = {
+  cmdOverrides: {},
+  platform: 'linux' as NodeJS.Platform,
+  shell: 'posix' as const
+}
+
+describe('resolveAgentLaunchCommand — remote Codex hooks override', () => {
+  it('adds the launch-scoped hooks override for a remote Codex launch', () => {
+    const result = resolveAgentLaunchCommand({
+      ...BASE,
+      agent: 'codex',
+      isRemote: true,
+      agentStatusHooksEnabled: true
+    })
+    expect(result.ok).toBe(true)
+    expect(result.ok && result.command).toContain("'-c' 'features.hooks=true'")
+  })
+
+  it('keeps the local Codex command byte-for-byte unchanged', () => {
+    const local = resolveAgentLaunchCommand({
+      ...BASE,
+      agent: 'codex',
+      isRemote: false,
+      agentStatusHooksEnabled: true
+    })
+    const baseline = resolveAgentLaunchCommand({ ...BASE, agent: 'codex', isRemote: false })
+    expect(local.ok && baseline.ok && local.command).toBe(baseline.ok ? baseline.command : null)
+    expect(local.ok && local.command).not.toContain('features.hooks')
+  })
+
+  it('keeps remote Claude unchanged', () => {
+    const result = resolveAgentLaunchCommand({
+      ...BASE,
+      agent: 'claude',
+      isRemote: true,
+      agentStatusHooksEnabled: true
+    })
+    expect(result.ok && result.command).not.toContain('features.hooks')
+  })
+
+  it('emits nothing when the user already disabled hooks in their CLI args', () => {
+    const result = resolveAgentLaunchCommand({
+      ...BASE,
+      agent: 'codex',
+      isRemote: true,
+      agentStatusHooksEnabled: true,
+      agentArgs: '--disable hooks'
+    })
+    expect(result.ok && result.command).not.toContain('features.hooks=true')
+  })
+
+  it('emits nothing when a command override already decides hooks', () => {
+    const result = resolveAgentLaunchCommand({
+      ...BASE,
+      agent: 'codex',
+      cmdOverrides: { codex: 'codex -c features.hooks=false' },
+      isRemote: true,
+      agentStatusHooksEnabled: true
+    })
+    expect(result.ok && result.command).not.toContain('features.hooks=true')
+  })
+
+  it('keeps the override ahead of the prompt on the argv launch path', () => {
+    const plan = buildAgentStartupPlan({
+      agent: 'codex',
+      prompt: 'do the thing',
+      cmdOverrides: {},
+      platform: 'linux',
+      shell: 'posix',
+      isRemote: true,
+      agentStatusHooksEnabled: true
+    })
+    expect(plan).not.toBeNull()
+    const command = plan?.launchCommand ?? ''
+    expect(command).toContain("'-c' 'features.hooks=true'")
+    expect(command.indexOf('features.hooks=true')).toBeLessThan(command.indexOf('do the thing'))
+  })
+
+  it('omits the override for a remote Codex launch when hooks are disabled', () => {
+    const plan = buildAgentStartupPlan({
+      agent: 'codex',
+      prompt: 'do the thing',
+      cmdOverrides: {},
+      platform: 'linux',
+      shell: 'posix',
+      isRemote: true,
+      agentStatusHooksEnabled: false
+    })
+    expect(plan?.launchCommand).not.toContain('features.hooks')
+  })
+})

--- a/src/shared/tui-agent-launch-command.codex-remote-hooks.test.ts
+++ b/src/shared/tui-agent-launch-command.codex-remote-hooks.test.ts
@@ -4,12 +4,13 @@
 
 import { describe, expect, it } from 'vitest'
 import { resolveAgentLaunchCommand } from './tui-agent-launch-command'
-import { buildAgentStartupPlan } from './tui-agent-startup'
+import { buildAgentResumeStartupPlan, buildAgentStartupPlan } from './tui-agent-startup'
 
 const BASE = {
   cmdOverrides: {},
   platform: 'linux' as NodeJS.Platform,
-  shell: 'posix' as const
+  shell: 'posix' as const,
+  agentStatusHookSettings: { agentStatusHooksEnabled: true }
 }
 
 describe('resolveAgentLaunchCommand — remote Codex hooks override', () => {
@@ -17,8 +18,7 @@ describe('resolveAgentLaunchCommand — remote Codex hooks override', () => {
     const result = resolveAgentLaunchCommand({
       ...BASE,
       agent: 'codex',
-      isRemote: true,
-      agentStatusHooksEnabled: true
+      isRemote: true
     })
     expect(result.ok).toBe(true)
     expect(result.ok && result.command).toContain("'-c' 'features.hooks=true'")
@@ -28,10 +28,14 @@ describe('resolveAgentLaunchCommand — remote Codex hooks override', () => {
     const local = resolveAgentLaunchCommand({
       ...BASE,
       agent: 'codex',
-      isRemote: false,
-      agentStatusHooksEnabled: true
+      isRemote: false
     })
-    const baseline = resolveAgentLaunchCommand({ ...BASE, agent: 'codex', isRemote: false })
+    const baseline = resolveAgentLaunchCommand({
+      ...BASE,
+      agent: 'codex',
+      isRemote: false,
+      agentStatusHookSettings: { agentStatusHooksEnabled: false }
+    })
     expect(local.ok && baseline.ok && local.command).toBe(baseline.ok ? baseline.command : null)
     expect(local.ok && local.command).not.toContain('features.hooks')
   })
@@ -40,8 +44,7 @@ describe('resolveAgentLaunchCommand — remote Codex hooks override', () => {
     const result = resolveAgentLaunchCommand({
       ...BASE,
       agent: 'claude',
-      isRemote: true,
-      agentStatusHooksEnabled: true
+      isRemote: true
     })
     expect(result.ok && result.command).not.toContain('features.hooks')
   })
@@ -51,7 +54,6 @@ describe('resolveAgentLaunchCommand — remote Codex hooks override', () => {
       ...BASE,
       agent: 'codex',
       isRemote: true,
-      agentStatusHooksEnabled: true,
       agentArgs: '--disable hooks'
     })
     expect(result.ok && result.command).not.toContain('features.hooks=true')
@@ -62,8 +64,7 @@ describe('resolveAgentLaunchCommand — remote Codex hooks override', () => {
       ...BASE,
       agent: 'codex',
       cmdOverrides: { codex: 'codex -c features.hooks=false' },
-      isRemote: true,
-      agentStatusHooksEnabled: true
+      isRemote: true
     })
     expect(result.ok && result.command).not.toContain('features.hooks=true')
   })
@@ -76,7 +77,7 @@ describe('resolveAgentLaunchCommand — remote Codex hooks override', () => {
       platform: 'linux',
       shell: 'posix',
       isRemote: true,
-      agentStatusHooksEnabled: true
+      agentStatusHookSettings: { agentStatusHooksEnabled: true }
     })
     expect(plan).not.toBeNull()
     const command = plan?.launchCommand ?? ''
@@ -92,8 +93,97 @@ describe('resolveAgentLaunchCommand — remote Codex hooks override', () => {
       platform: 'linux',
       shell: 'posix',
       isRemote: true,
-      agentStatusHooksEnabled: false
+      agentStatusHookSettings: { agentStatusHooksEnabled: false }
     })
     expect(plan?.launchCommand).not.toContain('features.hooks')
+  })
+
+  // The named regression guard: a user who puts `-c features.hooks=false` in
+  // their Codex default args must see exactly that, once, on the remote line.
+  it('leaves a user hooks=false default args untouched, with one hooks decision', () => {
+    const plan = buildAgentStartupPlan({
+      agent: 'codex',
+      prompt: 'do the thing',
+      cmdOverrides: {},
+      platform: 'linux',
+      shell: 'posix',
+      isRemote: true,
+      agentArgs: '-c features.hooks=false',
+      agentStatusHookSettings: { agentStatusHooksEnabled: true }
+    })
+    const command = plan?.launchCommand ?? ''
+    expect(command).toContain('features.hooks=false')
+    expect(command).not.toContain('features.hooks=true')
+    expect(command.match(/features\.hooks/g)).toHaveLength(1)
+  })
+
+  // Why: the flag used to be an optional boolean each launch surface derived for
+  // itself, and most of them never did. These pin the derivation the builder now
+  // owns, so a surface can only get it wrong by passing the wrong settings.
+  it('honours the per-agent opt-out even when the global toggle is on', () => {
+    const plan = buildAgentStartupPlan({
+      agent: 'codex',
+      prompt: 'do the thing',
+      cmdOverrides: {},
+      platform: 'linux',
+      shell: 'posix',
+      isRemote: true,
+      agentStatusHookSettings: { agentStatusHooksEnabled: true, disabledTuiAgents: ['codex'] }
+    })
+    expect(plan?.launchCommand).not.toContain('features.hooks')
+  })
+
+  it('treats absent settings as the shipped default, which is hooks on', () => {
+    const plan = buildAgentStartupPlan({
+      agent: 'codex',
+      prompt: 'do the thing',
+      cmdOverrides: {},
+      platform: 'linux',
+      shell: 'posix',
+      isRemote: true,
+      agentStatusHookSettings: null
+    })
+    expect(plan?.launchCommand).toContain("'-c' 'features.hooks=true'")
+  })
+
+  it('carries the override into a remote Codex resume', () => {
+    const plan = buildAgentResumeStartupPlan({
+      agent: 'codex',
+      providerSession: { key: 'session_id', id: '9f3d1c2e-0000-4000-8000-000000000001' },
+      cmdOverrides: {},
+      platform: 'linux',
+      shell: 'posix',
+      isRemote: true,
+      agentStatusHookSettings: { agentStatusHooksEnabled: true }
+    })
+    expect(plan?.launchCommand).toContain("'-c' 'features.hooks=true'")
+  })
+
+  it('leaves a local Codex resume without the override', () => {
+    const plan = buildAgentResumeStartupPlan({
+      agent: 'codex',
+      providerSession: { key: 'session_id', id: '9f3d1c2e-0000-4000-8000-000000000001' },
+      cmdOverrides: {},
+      platform: 'linux',
+      shell: 'posix',
+      isRemote: false,
+      agentStatusHookSettings: { agentStatusHooksEnabled: true }
+    })
+    expect(plan?.launchCommand).not.toContain('features.hooks')
+  })
+
+  it('does not overrule a user who disabled hooks in their resume CLI args', () => {
+    const plan = buildAgentResumeStartupPlan({
+      agent: 'codex',
+      providerSession: { key: 'session_id', id: '9f3d1c2e-0000-4000-8000-000000000001' },
+      cmdOverrides: {},
+      platform: 'linux',
+      shell: 'posix',
+      isRemote: true,
+      agentArgs: '-c features.hooks=false',
+      agentStatusHookSettings: { agentStatusHooksEnabled: true }
+    })
+    expect(plan?.launchCommand).toContain('features.hooks=false')
+    expect(plan?.launchCommand).not.toContain('features.hooks=true')
   })
 })

--- a/src/shared/tui-agent-launch-command.ts
+++ b/src/shared/tui-agent-launch-command.ts
@@ -11,6 +11,7 @@ import {
   type AgentStartupShell
 } from './tui-agent-startup-shell'
 import type { TuiAgent } from './tui-agent'
+import { planCodexRemoteHookLaunchArgs } from './codex-remote-hook-launch'
 
 export type ResolvedAgentLaunchCommand =
   | {
@@ -30,9 +31,13 @@ export function resolveAgentLaunchCommand(args: {
   sessionOptions?: Record<string, SessionOptionValue>
   sessionOptionsOverrideAgentArgs?: boolean
   isRemote?: boolean
+  /** Orca's managed status hooks are enabled for this agent. Remote Codex
+   *  launches carry a launch-scoped hooks override so the TUI does not attach
+   *  to a pre-existing app-server that never saw the pane's hook env (#11941). */
+  agentStatusHooksEnabled?: boolean
 }): ResolvedAgentLaunchCommand {
   const override = args.cmdOverrides[args.agent]
-  const command =
+  const baseLaunchCommand =
     override ||
     getTuiAgentLaunchCommand(TUI_AGENT_CONFIG[args.agent], args.platform, {
       isRemote: args.isRemote
@@ -76,6 +81,16 @@ export function resolveAgentLaunchCommand(args: {
       }
     }
   }
+  const hookArgs = planCodexRemoteHookLaunchArgs({
+    agent: args.agent,
+    platform: args.platform,
+    isRemote: args.isRemote,
+    hooksEnabled: args.agentStatusHooksEnabled,
+    launchTokens: [...tokenizeCommandOverride(override, args.shell), ...trailingTokens.tokens]
+  })
+  const command = hookArgs.length
+    ? `${baseLaunchCommand} ${hookArgs.map((arg) => quoteStartupArg(arg, args.shell)).join(' ')}`
+    : baseLaunchCommand
   const optionSuffix = resolvedOptions.args.map((arg) => quoteStartupArg(arg, args.shell)).join(' ')
   const commandWithoutSessionOptions = suffix.suffix ? `${command} ${suffix.suffix}` : command
   const commandWithOptions = optionSuffix ? `${command} ${optionSuffix}` : command
@@ -106,4 +121,18 @@ function insertBeforeTerminator(tokens: readonly string[], inserted: readonly st
     return [...tokens, ...inserted]
   }
   return [...tokens.slice(0, terminator), ...inserted, ...tokens.slice(terminator)]
+}
+
+// Why: an override can name the agent's own hooks decision, so its tokens have
+// to be visible to the remote-hook planner. A malformed override is not this
+// function's error to raise — it is reported by the existing override check.
+function tokenizeCommandOverride(
+  override: string | undefined,
+  shell: AgentStartupShell
+): readonly string[] {
+  if (!override) {
+    return []
+  }
+  const tokens = tokenizeStartupCommand(override, shell)
+  return tokens.ok ? tokens.tokens : []
 }

--- a/src/shared/tui-agent-launch-command.ts
+++ b/src/shared/tui-agent-launch-command.ts
@@ -12,6 +12,10 @@ import {
 } from './tui-agent-startup-shell'
 import type { TuiAgent } from './tui-agent'
 import { planCodexRemoteHookLaunchArgs } from './codex-remote-hook-launch'
+import {
+  areAgentStatusHooksEnabledForAgent,
+  type AgentStatusHookSettings
+} from './agent-status-hooks-for-agent'
 
 export type ResolvedAgentLaunchCommand =
   | {
@@ -31,10 +35,11 @@ export function resolveAgentLaunchCommand(args: {
   sessionOptions?: Record<string, SessionOptionValue>
   sessionOptionsOverrideAgentArgs?: boolean
   isRemote?: boolean
-  /** Orca's managed status hooks are enabled for this agent. Remote Codex
-   *  launches carry a launch-scoped hooks override so the TUI does not attach
-   *  to a pre-existing app-server that never saw the pane's hook env (#11941). */
-  agentStatusHooksEnabled?: boolean
+  /** Settings deciding Orca's managed status hooks. Resolved here rather than by
+   *  each caller: a remote Codex launch carries a launch-scoped hooks override so
+   *  the TUI does not attach to an app-server that never saw the pane's hook env,
+   *  and every launch surface used to have to remember that for itself (#11941). */
+  agentStatusHookSettings: AgentStatusHookSettings | null
 }): ResolvedAgentLaunchCommand {
   const override = args.cmdOverrides[args.agent]
   const baseLaunchCommand =
@@ -85,7 +90,7 @@ export function resolveAgentLaunchCommand(args: {
     agent: args.agent,
     platform: args.platform,
     isRemote: args.isRemote,
-    hooksEnabled: args.agentStatusHooksEnabled,
+    hooksEnabled: areAgentStatusHooksEnabledForAgent(args.agentStatusHookSettings, args.agent),
     launchTokens: [...tokenizeCommandOverride(override, args.shell), ...trailingTokens.tokens]
   })
   const command = hookArgs.length

--- a/src/shared/tui-agent-startup-resume.test.ts
+++ b/src/shared/tui-agent-startup-resume.test.ts
@@ -1,0 +1,104 @@
+// Resume-plan cases, split out of tui-agent-startup.test.ts to keep both files
+// inside the max-lines budget. Same subject: the argv a resumed agent launches with.
+
+import { describe, expect, it } from 'vitest'
+import { buildAgentResumeStartupPlan } from './tui-agent-startup'
+
+describe('tui agent resume startup plans', () => {
+  it('builds Windows resume plans that PowerShell can invoke', () => {
+    const plan = buildAgentResumeStartupPlan({
+      agent: 'codex',
+      providerSession: { key: 'session_id', id: 's1' },
+      cmdOverrides: {},
+      platform: 'win32',
+      agentStatusHookSettings: null
+    })
+
+    expect(plan?.launchCommand).toBe("codex 'resume' 's1'")
+  })
+
+  it('quotes Windows resume argv for cmd.exe when shell is cmd', () => {
+    const plan = buildAgentResumeStartupPlan({
+      agent: 'grok',
+      providerSession: { key: 'session_id', id: '019fc272-80fa-7a91-80a2-9c461ef1a9da' },
+      cmdOverrides: {},
+      agentArgs: '--permission-mode bypassPermissions',
+      platform: 'win32',
+      shell: 'cmd',
+      agentStatusHookSettings: null
+    })
+
+    // Why: cmd.exe treats single quotes as literal characters. Resume must use
+    // double quotes (or unquoted tokens) so the CLI receives clean argv.
+    expect(plan?.launchCommand).toBe(
+      'grok "--permission-mode" "bypassPermissions" "--resume" "019fc272-80fa-7a91-80a2-9c461ef1a9da"'
+    )
+  })
+
+  it('keeps cmd-quoted agentCommand aligned with cmd resume suffix', () => {
+    const plan = buildAgentResumeStartupPlan({
+      agent: 'grok',
+      providerSession: { key: 'session_id', id: '019fc272-80fa-7a91-80a2-9c461ef1a9da' },
+      cmdOverrides: {},
+      agentCommand: 'grok "--permission-mode" "bypassPermissions"',
+      platform: 'win32',
+      shell: 'cmd',
+      agentStatusHookSettings: null
+    })
+
+    // Regression: agentCommand from a prior cmd launch + PowerShell-default resume
+    // suffix produced mixed quoting and broke reboot restore on cmd.exe tabs.
+    expect(plan?.launchCommand).toBe(
+      'grok "--permission-mode" "bypassPermissions" "--resume" "019fc272-80fa-7a91-80a2-9c461ef1a9da"'
+    )
+  })
+
+  it('honors command overrides when building POSIX resume plans', () => {
+    const plan = buildAgentResumeStartupPlan({
+      agent: 'codex',
+      providerSession: { key: 'session_id', id: 's1' },
+      cmdOverrides: { codex: 'codex --profile work' },
+      platform: 'linux',
+      agentStatusHookSettings: null
+    })
+
+    expect(plan?.launchCommand).toBe("codex --profile work 'resume' 's1'")
+  })
+
+  it('uses a captured launch command when building resume plans after overrides change', () => {
+    const plan = buildAgentResumeStartupPlan({
+      agent: 'codex',
+      providerSession: { key: 'session_id', id: 's1' },
+      cmdOverrides: { codex: 'codex --profile changed' },
+      agentCommand: 'codex --profile captured',
+      platform: 'linux',
+      agentStatusHookSettings: null
+    })
+
+    expect(plan?.launchCommand).toBe("codex --profile captured 'resume' 's1'")
+    expect(plan?.launchConfig).toEqual({
+      agentCommand: 'codex --profile captured',
+      agentArgs: '',
+      agentEnv: {}
+    })
+  })
+
+  it('keeps an AI Vault OMP file locator separate from provider identity', () => {
+    const plan = buildAgentResumeStartupPlan({
+      agent: 'omp',
+      providerSession: { key: 'session_id', id: 'omp-session-1' },
+      cmdOverrides: {},
+      ompResumeFilePath: '/custom/root/project/session.jsonl',
+      platform: 'linux',
+      agentStatusHookSettings: null
+    })
+
+    expect(plan?.launchCommand).toBe("omp '--resume' '/custom/root/project/session.jsonl'")
+    expect(plan?.launchConfig).toEqual({
+      agentCommand: 'omp',
+      agentArgs: '',
+      agentEnv: {},
+      ompResumeFilePath: '/custom/root/project/session.jsonl'
+    })
+  })
+})

--- a/src/shared/tui-agent-startup-resume.test.ts
+++ b/src/shared/tui-agent-startup-resume.test.ts
@@ -3,6 +3,8 @@
 
 import { describe, expect, it } from 'vitest'
 import { buildAgentResumeStartupPlan } from './tui-agent-startup'
+import { RESUMABLE_TUI_AGENTS } from './agent-session-resume'
+import { getTuiAgentLaunchCommand, TUI_AGENT_CONFIG } from './tui-agent-config'
 
 describe('tui agent resume startup plans', () => {
   it('builds Windows resume plans that PowerShell can invoke', () => {
@@ -101,4 +103,23 @@ describe('tui agent resume startup plans', () => {
       ompResumeFilePath: '/custom/root/project/session.jsonl'
     })
   })
+
+  // Why this is pinned: wiring `isRemote` into the resume paths (#11941) makes
+  // it reach two consumers — the Codex hooks override, which is the point, and
+  // `getTuiAgentLaunchCommand`, which drops the local-only `orca-ide` rename on
+  // Linux. The second is unreachable here: `launchCmdByPlatform` is declared by
+  // exactly one agent, `claude-agent-teams`, and that agent is not resumable.
+  // If someone adds `launchCmdByPlatform` to a resumable agent, or makes
+  // claude-agent-teams resumable, a remote resume would silently start emitting
+  // a different binary name and process recognition would be the thing that
+  // notices. This turns that into a failing test instead.
+  it.each(RESUMABLE_TUI_AGENTS)(
+    'resolves the same Linux launch binary remote or local for %s',
+    (agent) => {
+      const config = TUI_AGENT_CONFIG[agent]
+      expect(getTuiAgentLaunchCommand(config, 'linux', { isRemote: true })).toBe(
+        getTuiAgentLaunchCommand(config, 'linux', { isRemote: false })
+      )
+    }
+  )
 })

--- a/src/shared/tui-agent-startup-session-options.test.ts
+++ b/src/shared/tui-agent-startup-session-options.test.ts
@@ -15,7 +15,8 @@ describe('tui agent startup session options', () => {
       platform: 'linux',
       allowEmptyPromptLaunch: true,
       sessionOptions: { model: 'opus', effort: 'xhigh', fastMode: true },
-      agentArgs: '--model haiku'
+      agentArgs: '--model haiku',
+      agentStatusHookSettings: null
     })
     expect(plan?.launchCommand).toBe("claude '--model' 'opus' '--effort' 'xhigh' '--model' 'haiku'")
     expect(plan?.sessionOptions).toBeUndefined()
@@ -29,7 +30,8 @@ describe('tui agent startup session options', () => {
       platform: 'linux',
       allowEmptyPromptLaunch: true,
       sessionOptions: { model: 'opus', effort: 'xhigh' },
-      agentArgs: '--effort low'
+      agentArgs: '--effort low',
+      agentStatusHookSettings: null
     })
     expect(plan?.sessionOptions).toEqual({ model: 'opus' })
   })
@@ -43,7 +45,8 @@ describe('tui agent startup session options', () => {
       allowEmptyPromptLaunch: true,
       sessionOptions: { model: 'custom-codex-model', effort: 'high' },
       sessionOptionsOverrideAgentArgs: true,
-      agentArgs: '-m gpt-5.5 -c model_reasoning_effort=low'
+      agentArgs: '-m gpt-5.5 -c model_reasoning_effort=low',
+      agentStatusHookSettings: null
     })
     expect(plan?.launchCommand).toBe(
       "codex '-m' 'custom-codex-model' '-c' 'model_reasoning_effort=high'"
@@ -63,7 +66,8 @@ describe('tui agent startup session options', () => {
       allowEmptyPromptLaunch: true,
       sessionOptions: { model: 'custom-codex-model', effort: 'high' },
       sessionOptionsOverrideAgentArgs: true,
-      agentArgs: '--dangerously-bypass-approvals-and-sandbox -- literal'
+      agentArgs: '--dangerously-bypass-approvals-and-sandbox -- literal',
+      agentStatusHookSettings: null
     })
     expect(plan?.launchCommand).toBe(
       "codex '--dangerously-bypass-approvals-and-sandbox' '-m' 'custom-codex-model' '-c' 'model_reasoning_effort=high' '--' 'literal'"
@@ -78,7 +82,8 @@ describe('tui agent startup session options', () => {
         platform: 'linux',
         shell: 'posix',
         sessionOptions: { model: 'custom-codex-model', effort: 'high' },
-        sessionOptionsOverrideAgentArgs: true
+        sessionOptionsOverrideAgentArgs: true,
+        agentStatusHookSettings: null
       })
     ).toEqual({
       ok: false,
@@ -95,7 +100,8 @@ describe('tui agent startup session options', () => {
       platform: 'linux',
       allowEmptyPromptLaunch: true,
       sessionOptions: { model: 'gpt-5.6-sol', effort: 'medium' },
-      agentArgs: '--model gpt-5.5'
+      agentArgs: '--model gpt-5.5',
+      agentStatusHookSettings: null
     })
     expect(plan?.sessionOptions).toBeUndefined()
   })
@@ -108,7 +114,8 @@ describe('tui agent startup session options', () => {
       platform: 'linux',
       allowEmptyPromptLaunch: true,
       sessionOptions: { model: 'gpt-5.6-sol', effort: 'medium' },
-      agentArgs: '--dangerously-bypass-approvals-and-sandbox'
+      agentArgs: '--dangerously-bypass-approvals-and-sandbox',
+      agentStatusHookSettings: null
     })
     expect(plan?.launchConfig.agentCommand).toBe(
       "codex '--dangerously-bypass-approvals-and-sandbox'"
@@ -123,7 +130,8 @@ describe('tui agent startup session options', () => {
       platform: 'linux',
       isRemote: true,
       allowEmptyPromptLaunch: true,
-      sessionOptions: { model: "team's-model", effort: 'high' }
+      sessionOptions: { model: "team's-model", effort: 'high' },
+      agentStatusHookSettings: null
     })
     expect(plan?.launchCommand).toContain(`'team'"'"'s-model'`)
   })
@@ -134,7 +142,8 @@ describe('tui agent startup session options', () => {
       draft: 'review this',
       cmdOverrides: {},
       platform: 'linux',
-      sessionOptions: { model: 'opus', effort: 'high' }
+      sessionOptions: { model: 'opus', effort: 'high' },
+      agentStatusHookSettings: null
     })
     expect(plan?.launchCommand).toContain("claude '--model' 'opus' '--effort' 'high'")
     expect(plan?.sessionOptions).toEqual({ model: 'opus', effort: 'high' })
@@ -146,7 +155,8 @@ describe('tui agent startup session options', () => {
       providerSession: { key: 'session_id', id: 'thread-1' },
       cmdOverrides: {},
       platform: 'linux',
-      sessionOptions: { model: 'gpt-5.5', effort: 'high' }
+      sessionOptions: { model: 'gpt-5.5', effort: 'high' },
+      agentStatusHookSettings: null
     })
     expect(plan?.launchCommand).toBe("codex 'resume' 'thread-1'")
     expect(plan?.sessionOptions).toBeUndefined()

--- a/src/shared/tui-agent-startup-shell.test.ts
+++ b/src/shared/tui-agent-startup-shell.test.ts
@@ -139,7 +139,8 @@ describe('one Unix startup dialect', () => {
       agent: 'pi',
       draft: 'hello',
       cmdOverrides: {},
-      platform: 'darwin'
+      platform: 'darwin',
+      agentStatusHookSettings: null
     })
 
     expect(plan?.launchCommand).toBe(

--- a/src/shared/tui-agent-startup.test.ts
+++ b/src/shared/tui-agent-startup.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildAgentDraftLaunchPlan,
-  buildAgentResumeStartupPlan,
   buildAgentStartupPlan,
   buildShellCommandFromArgv,
   planAgentCliArgsSuffix
@@ -39,7 +38,8 @@ describe('draft prefill teardown ordering (#14975)', () => {
       agent: 'pi',
       draft: 'hello',
       cmdOverrides: {},
-      platform: 'darwin'
+      platform: 'darwin',
+      agentStatusHookSettings: null
     })
 
     const command = plan?.launchCommand ?? ''
@@ -64,7 +64,8 @@ describe('tui agent startup plans', () => {
       agent: 'claude',
       prompt: "fix Bob's branch",
       cmdOverrides: {},
-      platform: 'linux'
+      platform: 'linux',
+      agentStatusHookSettings: null
     })
 
     expect(plan?.launchCommand).toBe("claude 'fix Bob'\"'\"'s branch'")
@@ -75,7 +76,8 @@ describe('tui agent startup plans', () => {
       agent: 'claude',
       prompt: 'fix Bob\'s "quoted" branch',
       cmdOverrides: {},
-      platform: 'win32'
+      platform: 'win32',
+      agentStatusHookSettings: null
     })
 
     expect(plan?.launchCommand).toBe("claude 'fix Bob''s \"quoted\" branch'")
@@ -93,7 +95,8 @@ describe('tui agent startup plans', () => {
       prompt: 'fix "quoted" & %PATH%',
       cmdOverrides: {},
       platform: 'win32',
-      shell: 'cmd'
+      shell: 'cmd',
+      agentStatusHookSettings: null
     })
 
     expect(plan?.launchCommand).toBe('claude "fix ^"quoted^" ^& ^%PATH^%"')
@@ -104,7 +107,8 @@ describe('tui agent startup plans', () => {
       agent: 'grok',
       prompt: '--version',
       cmdOverrides: {},
-      platform: 'linux'
+      platform: 'linux',
+      agentStatusHookSettings: null
     })
 
     expect(plan?.launchCommand).toBe("grok -- '--version'")
@@ -115,7 +119,8 @@ describe('tui agent startup plans', () => {
       agent: 'grok',
       prompt: '-h',
       cmdOverrides: {},
-      platform: 'win32'
+      platform: 'win32',
+      agentStatusHookSettings: null
     })
 
     expect(plan?.launchCommand).toBe("grok -- '-h'")
@@ -127,7 +132,8 @@ describe('tui agent startup plans', () => {
       prompt: 'help',
       cmdOverrides: {},
       platform: 'win32',
-      shell: 'cmd'
+      shell: 'cmd',
+      agentStatusHookSettings: null
     })
 
     expect(plan?.launchCommand).toBe('grok -- "help"')
@@ -139,7 +145,8 @@ describe('tui agent startup plans', () => {
       prompt: '--version',
       cmdOverrides: {},
       agentArgs: '--always-approve',
-      platform: 'win32'
+      platform: 'win32',
+      agentStatusHookSettings: null
     })
 
     expect(plan?.launchCommand).toBe("grok '--always-approve' -- '--version'")
@@ -150,7 +157,8 @@ describe('tui agent startup plans', () => {
       agent: 'codex',
       prompt: '--version',
       cmdOverrides: {},
-      platform: 'linux'
+      platform: 'linux',
+      agentStatusHookSettings: null
     })
 
     expect(plan?.launchCommand).toBe("codex '--version'")
@@ -168,7 +176,8 @@ describe('tui agent startup plans', () => {
       cmdOverrides: {},
       agentArgs: '--yolo',
       platform: testCase.platform,
-      shell: testCase.shell
+      shell: testCase.shell,
+      agentStatusHookSettings: null
     })
 
     expect(plan?.launchCommand).not.toContain(prompt)
@@ -200,7 +209,8 @@ describe('tui agent startup plans', () => {
       agent: 'hermes',
       prompt: 'run it',
       cmdOverrides: {},
-      platform: 'linux'
+      platform: 'linux',
+      agentStatusHookSettings: null
     })
 
     expect(plan?.launchCommand).toMatch(/^sh -c /)
@@ -218,7 +228,8 @@ describe('tui agent startup plans', () => {
       prompt: 'run privately',
       cmdOverrides: { hermes: 'hermes --tui --provider anthropic' },
       agentArgs: '--yolo',
-      platform: 'linux'
+      platform: 'linux',
+      agentStatusHookSettings: null
     })
 
     const script = unwrapPosixShellScript(plan?.launchCommand)
@@ -243,7 +254,8 @@ describe('tui agent startup plans', () => {
       prompt: 'run it',
       cmdOverrides: { hermes: testCase.override },
       platform: 'win32',
-      shell: testCase.shell
+      shell: testCase.shell,
+      agentStatusHookSettings: null
     })
 
     expect(unwrapPowerShellScript(plan?.launchCommand)).toContain(testCase.expected)
@@ -255,7 +267,8 @@ describe('tui agent startup plans', () => {
       prompt: 'run it',
       cmdOverrides: { hermes: 'hermes --provider copilot chat --tui' },
       agentArgs: '--provider copilot chat --yolo',
-      platform: 'linux'
+      platform: 'linux',
+      agentStatusHookSettings: null
     })
 
     const script = unwrapPosixShellScript(plan?.launchCommand)
@@ -268,7 +281,8 @@ describe('tui agent startup plans', () => {
       agent: 'hermes',
       prompt: 'run it',
       cmdOverrides: { hermes: 'hermes --profile chat --tui' },
-      platform: 'linux'
+      platform: 'linux',
+      agentStatusHookSettings: null
     })
 
     expect(unwrapPosixShellScript(plan?.launchCommand)).toContain("'--profile' 'chat'")
@@ -280,7 +294,8 @@ describe('tui agent startup plans', () => {
       prompt: 'automation prompt',
       cmdOverrides: { hermes: 'hermes --query override --cli' },
       agentArgs: '-q=second-override --query=third-override -qfourth-override --tui',
-      platform: 'linux'
+      platform: 'linux',
+      agentStatusHookSettings: null
     })
 
     const script = unwrapPosixShellScript(plan?.launchCommand)
@@ -296,7 +311,8 @@ describe('tui agent startup plans', () => {
       agent: 'hermes',
       prompt: 'run it',
       cmdOverrides: { hermes: 'uv run hermes --tui' },
-      platform: 'linux'
+      platform: 'linux',
+      agentStatusHookSettings: null
     })
 
     expect(unwrapPosixShellScript(plan?.launchCommand)).toContain("'uv' 'run' 'hermes' 'chat'")
@@ -307,7 +323,8 @@ describe('tui agent startup plans', () => {
       agent: 'hermes',
       prompt: 'run it',
       cmdOverrides: { hermes: 'sudo -u hermes hermes --tui' },
-      platform: 'linux'
+      platform: 'linux',
+      agentStatusHookSettings: null
     })
 
     expect(unwrapPosixShellScript(plan?.launchCommand)).toContain(
@@ -320,7 +337,8 @@ describe('tui agent startup plans', () => {
       agent: 'hermes',
       prompt: 'run it',
       cmdOverrides: { hermes: 'sudo -u hermes hermes chat --tui' },
-      platform: 'linux'
+      platform: 'linux',
+      agentStatusHookSettings: null
     })
 
     const script = unwrapPosixShellScript(plan?.launchCommand)
@@ -333,7 +351,8 @@ describe('tui agent startup plans', () => {
       agent: 'hermes',
       prompt: 'run it',
       cmdOverrides: { hermes: 'hermes chat --resume hermes --tui' },
-      platform: 'linux'
+      platform: 'linux',
+      agentStatusHookSettings: null
     })
 
     const script = unwrapPosixShellScript(plan?.launchCommand)
@@ -346,7 +365,8 @@ describe('tui agent startup plans', () => {
       agent: 'hermes',
       prompt: 'run it',
       cmdOverrides: { hermes: 'HERMES_HOME=/tmp/test uv run hermes --tui' },
-      platform: 'linux'
+      platform: 'linux',
+      agentStatusHookSettings: null
     })
 
     expect(unwrapPosixShellScript(plan?.launchCommand)).toContain(
@@ -360,7 +380,8 @@ describe('tui agent startup plans', () => {
         agent: 'hermes',
         prompt: 'run it',
         cmdOverrides: { hermes: 'custom-agent --tui' },
-        platform: 'linux'
+        platform: 'linux',
+        agentStatusHookSettings: null
       })
     ).toBeNull()
   })
@@ -370,7 +391,8 @@ describe('tui agent startup plans', () => {
       agent: 'hermes',
       prompt: 'x'.repeat(24_000),
       cmdOverrides: {},
-      platform: 'win32'
+      platform: 'win32',
+      agentStatusHookSettings: null
     })
 
     expect(plan).toBeNull()
@@ -384,7 +406,8 @@ describe('tui agent startup plans', () => {
         prompt,
         cmdOverrides: {},
         platform: 'win32',
-        shell: 'cmd'
+        shell: 'cmd',
+        agentStatusHookSettings: null
       })
 
       expect(plan?.launchCommand).not.toContain(prompt)
@@ -398,7 +421,8 @@ describe('tui agent startup plans', () => {
       prompt: 'run remotely',
       cmdOverrides: {},
       platform: 'win32',
-      isRemote: true
+      isRemote: true,
+      agentStatusHookSettings: null
     })
 
     expect(unwrapPowerShellScript(plan?.launchCommand)).toContain(
@@ -411,7 +435,8 @@ describe('tui agent startup plans', () => {
       agent: 'hermes',
       prompt: '界'.repeat(50_000),
       cmdOverrides: {},
-      platform: 'linux'
+      platform: 'linux',
+      agentStatusHookSettings: null
     })
 
     expect(plan).toBeNull()
@@ -423,7 +448,8 @@ describe('tui agent startup plans', () => {
       prompt: '',
       cmdOverrides: {},
       platform: 'linux',
-      allowEmptyPromptLaunch: true
+      allowEmptyPromptLaunch: true,
+      agentStatusHookSettings: null
     })
 
     expect(plan?.launchCommand).toBe('hermes --tui')
@@ -435,7 +461,8 @@ describe('tui agent startup plans', () => {
       agent: 'codex',
       prompt: 'fix it',
       cmdOverrides: {},
-      platform: 'linux'
+      platform: 'linux',
+      agentStatusHookSettings: null
     })
 
     expect(plan?.launchCommand).toBe("codex 'fix it'")
@@ -448,7 +475,8 @@ describe('tui agent startup plans', () => {
       prompt: '',
       cmdOverrides: {},
       platform: 'linux',
-      allowEmptyPromptLaunch: true
+      allowEmptyPromptLaunch: true,
+      agentStatusHookSettings: null
     })
 
     expect(plan).toEqual({
@@ -465,7 +493,8 @@ describe('tui agent startup plans', () => {
       agent: 'claude',
       prompt: 'fix it',
       cmdOverrides: {},
-      platform: 'linux'
+      platform: 'linux',
+      agentStatusHookSettings: null
     })
 
     expect(plan?.launchCommand).toBe("claude 'fix it'")
@@ -478,7 +507,8 @@ describe('tui agent startup plans', () => {
       prompt: '',
       cmdOverrides: {},
       platform: 'linux',
-      allowEmptyPromptLaunch: true
+      allowEmptyPromptLaunch: true,
+      agentStatusHookSettings: null
     })
 
     expect(plan?.launchCommand).toBe('orca-ide claude-teams')
@@ -495,7 +525,8 @@ describe('tui agent startup plans', () => {
       cmdOverrides: {},
       platform: 'linux',
       isRemote: true,
-      allowEmptyPromptLaunch: true
+      allowEmptyPromptLaunch: true,
+      agentStatusHookSettings: null
     })
 
     expect(plan?.launchCommand).toBe('orca claude-teams')
@@ -510,7 +541,8 @@ describe('tui agent startup plans', () => {
       cmdOverrides: {},
       platform: 'win32',
       isRemote: true,
-      allowEmptyPromptLaunch: true
+      allowEmptyPromptLaunch: true,
+      agentStatusHookSettings: null
     })
 
     expect(plan?.launchCommand).toBe('orca.cmd claude-teams')
@@ -526,7 +558,8 @@ describe('tui agent startup plans', () => {
       cmdOverrides: {},
       platform: 'linux',
       isRemote: false,
-      allowEmptyPromptLaunch: true
+      allowEmptyPromptLaunch: true,
+      agentStatusHookSettings: null
     })
 
     expect(plan?.launchCommand).toBe('orca-ide claude-teams')
@@ -537,7 +570,8 @@ describe('tui agent startup plans', () => {
       agent: 'openclaude',
       prompt: 'fix it',
       cmdOverrides: {},
-      platform: 'linux'
+      platform: 'linux',
+      agentStatusHookSettings: null
     })
 
     expect(plan).toEqual({
@@ -554,7 +588,8 @@ describe('tui agent startup plans', () => {
       agent: 'mistral-vibe',
       prompt: 'fix it',
       cmdOverrides: {},
-      platform: 'linux'
+      platform: 'linux',
+      agentStatusHookSettings: null
     })
 
     expect(plan).toEqual({
@@ -571,7 +606,8 @@ describe('tui agent startup plans', () => {
       agent: 'qwen-code',
       prompt: 'fix it',
       cmdOverrides: {},
-      platform: 'linux'
+      platform: 'linux',
+      agentStatusHookSettings: null
     })
 
     expect(plan).toEqual({
@@ -588,7 +624,8 @@ describe('tui agent startup plans', () => {
       agent: 'claude',
       prompt: 'fix it',
       cmdOverrides: { claude: 'claude --dangerously-skip-permissions' },
-      platform: 'linux'
+      platform: 'linux',
+      agentStatusHookSettings: null
     })
 
     expect(plan?.launchCommand).toBe("claude --dangerously-skip-permissions 'fix it'")
@@ -599,101 +636,11 @@ describe('tui agent startup plans', () => {
       agent: 'codex',
       prompt: 'fix it',
       cmdOverrides: { codex: 'codex --profile work' },
-      platform: 'linux'
+      platform: 'linux',
+      agentStatusHookSettings: null
     })
 
     expect(plan?.launchCommand).toBe("codex --profile work 'fix it'")
-  })
-
-  it('builds Windows resume plans that PowerShell can invoke', () => {
-    const plan = buildAgentResumeStartupPlan({
-      agent: 'codex',
-      providerSession: { key: 'session_id', id: 's1' },
-      cmdOverrides: {},
-      platform: 'win32'
-    })
-
-    expect(plan?.launchCommand).toBe("codex 'resume' 's1'")
-  })
-
-  it('quotes Windows resume argv for cmd.exe when shell is cmd', () => {
-    const plan = buildAgentResumeStartupPlan({
-      agent: 'grok',
-      providerSession: { key: 'session_id', id: '019fc272-80fa-7a91-80a2-9c461ef1a9da' },
-      cmdOverrides: {},
-      agentArgs: '--permission-mode bypassPermissions',
-      platform: 'win32',
-      shell: 'cmd'
-    })
-
-    // Why: cmd.exe treats single quotes as literal characters. Resume must use
-    // double quotes (or unquoted tokens) so the CLI receives clean argv.
-    expect(plan?.launchCommand).toBe(
-      'grok "--permission-mode" "bypassPermissions" "--resume" "019fc272-80fa-7a91-80a2-9c461ef1a9da"'
-    )
-  })
-
-  it('keeps cmd-quoted agentCommand aligned with cmd resume suffix', () => {
-    const plan = buildAgentResumeStartupPlan({
-      agent: 'grok',
-      providerSession: { key: 'session_id', id: '019fc272-80fa-7a91-80a2-9c461ef1a9da' },
-      cmdOverrides: {},
-      agentCommand: 'grok "--permission-mode" "bypassPermissions"',
-      platform: 'win32',
-      shell: 'cmd'
-    })
-
-    // Regression: agentCommand from a prior cmd launch + PowerShell-default resume
-    // suffix produced mixed quoting and broke reboot restore on cmd.exe tabs.
-    expect(plan?.launchCommand).toBe(
-      'grok "--permission-mode" "bypassPermissions" "--resume" "019fc272-80fa-7a91-80a2-9c461ef1a9da"'
-    )
-  })
-
-  it('honors command overrides when building POSIX resume plans', () => {
-    const plan = buildAgentResumeStartupPlan({
-      agent: 'codex',
-      providerSession: { key: 'session_id', id: 's1' },
-      cmdOverrides: { codex: 'codex --profile work' },
-      platform: 'linux'
-    })
-
-    expect(plan?.launchCommand).toBe("codex --profile work 'resume' 's1'")
-  })
-
-  it('uses a captured launch command when building resume plans after overrides change', () => {
-    const plan = buildAgentResumeStartupPlan({
-      agent: 'codex',
-      providerSession: { key: 'session_id', id: 's1' },
-      cmdOverrides: { codex: 'codex --profile changed' },
-      agentCommand: 'codex --profile captured',
-      platform: 'linux'
-    })
-
-    expect(plan?.launchCommand).toBe("codex --profile captured 'resume' 's1'")
-    expect(plan?.launchConfig).toEqual({
-      agentCommand: 'codex --profile captured',
-      agentArgs: '',
-      agentEnv: {}
-    })
-  })
-
-  it('keeps an AI Vault OMP file locator separate from provider identity', () => {
-    const plan = buildAgentResumeStartupPlan({
-      agent: 'omp',
-      providerSession: { key: 'session_id', id: 'omp-session-1' },
-      cmdOverrides: {},
-      ompResumeFilePath: '/custom/root/project/session.jsonl',
-      platform: 'linux'
-    })
-
-    expect(plan?.launchCommand).toBe("omp '--resume' '/custom/root/project/session.jsonl'")
-    expect(plan?.launchConfig).toEqual({
-      agentCommand: 'omp',
-      agentArgs: '',
-      agentEnv: {},
-      ompResumeFilePath: '/custom/root/project/session.jsonl'
-    })
   })
 
   it('appends shell-quoted CLI arguments before prompt delivery flags', () => {
@@ -702,7 +649,8 @@ describe('tui agent startup plans', () => {
       prompt: 'fix it',
       cmdOverrides: {},
       agentArgs: '--model sonnet --add-dir "path with spaces"',
-      platform: 'linux'
+      platform: 'linux',
+      agentStatusHookSettings: null
     })
 
     expect(plan?.launchCommand).toBe(
@@ -716,7 +664,8 @@ describe('tui agent startup plans', () => {
       prompt: 'fix it',
       cmdOverrides: {},
       agentArgs: '--model sonnet --name "Bob\'s"',
-      platform: 'win32'
+      platform: 'win32',
+      agentStatusHookSettings: null
     })
 
     expect(plan?.launchCommand).toBe("claude '--model' 'sonnet' '--name' 'Bob''s' 'fix it'")
@@ -729,7 +678,8 @@ describe('tui agent startup plans', () => {
       cmdOverrides: {},
       agentEnv: { GOOSE_MODE: 'auto' },
       platform: 'linux',
-      allowEmptyPromptLaunch: true
+      allowEmptyPromptLaunch: true,
+      agentStatusHookSettings: null
     })
 
     expect(plan?.launchCommand).toBe('goose')
@@ -749,7 +699,8 @@ describe('tui agent startup plans', () => {
       agentArgs: '',
       agentEnv: {},
       platform: 'linux',
-      allowEmptyPromptLaunch: true
+      allowEmptyPromptLaunch: true,
+      agentStatusHookSettings: null
     })
 
     expect(plan?.launchConfig).toEqual({ agentCommand: 'claude', agentArgs: '', agentEnv: {} })
@@ -764,7 +715,8 @@ describe('tui agent startup plans', () => {
       prompt: 'fix it',
       cmdOverrides: {},
       agentArgs: resolveTuiAgentLaunchArgs('opencode', agentDefaultArgs),
-      platform: 'linux'
+      platform: 'linux',
+      agentStatusHookSettings: null
     })
 
     expect(plan?.launchCommand).toBe("opencode --prompt 'fix it'")
@@ -788,7 +740,8 @@ describe('tui agent startup plans', () => {
         agent: 'opencode',
         draft: 'x',
         cmdOverrides: {},
-        platform: 'darwin'
+        platform: 'darwin',
+        agentStatusHookSettings: null
       })
     ).toBeNull()
     expect(
@@ -796,7 +749,8 @@ describe('tui agent startup plans', () => {
         agent: 'mimo-code',
         draft: 'x',
         cmdOverrides: {},
-        platform: 'darwin'
+        platform: 'darwin',
+        agentStatusHookSettings: null
       })
     ).toBeNull()
   })
@@ -813,7 +767,8 @@ describe('tui agent startup plans', () => {
         agent: 'grok',
         draft: 'x',
         cmdOverrides: {},
-        platform: 'darwin'
+        platform: 'darwin',
+        agentStatusHookSettings: null
       })
     ).toBeNull()
   })
@@ -824,7 +779,8 @@ describe('tui agent startup plans', () => {
       prompt: 'fix it',
       cmdOverrides: {},
       agentArgs: '--trust-all-tools',
-      platform: 'linux'
+      platform: 'linux',
+      agentStatusHookSettings: null
     })
 
     expect(plan?.launchCommand).toBe("kiro-cli chat --tui '--trust-all-tools'")
@@ -836,7 +792,8 @@ describe('tui agent startup plans', () => {
       prompt: 'fix it',
       cmdOverrides: {},
       agentArgs: '--allow "*"',
-      platform: 'linux'
+      platform: 'linux',
+      agentStatusHookSettings: null
     })
 
     expect(plan?.launchCommand).toBe("cn '--allow' '*'")
@@ -848,7 +805,8 @@ describe('tui agent startup plans', () => {
         agent: 'pi',
         draft: 'https://github.com/acme/repo/issues/42',
         cmdOverrides: {},
-        platform: 'win32'
+        platform: 'win32',
+        agentStatusHookSettings: null
       })?.launchCommand
     ).toBe('pi; Remove-Item Env:ORCA_PI_PREFILL -ErrorAction SilentlyContinue')
 
@@ -858,7 +816,8 @@ describe('tui agent startup plans', () => {
         draft: 'https://github.com/acme/repo/issues/42',
         cmdOverrides: {},
         platform: 'win32',
-        shell: 'cmd'
+        shell: 'cmd',
+        agentStatusHookSettings: null
       })?.launchCommand
     ).toBe('pi & set "ORCA_PI_PREFILL="')
   })
@@ -873,7 +832,8 @@ describe('tui agent startup plans', () => {
       agent: 'omp',
       draft: 'fix the omp regression',
       cmdOverrides: {},
-      platform: 'linux'
+      platform: 'linux',
+      agentStatusHookSettings: null
     })
 
     expect(plan).not.toBeNull()
@@ -890,7 +850,8 @@ describe('tui agent startup plans', () => {
         agent: 'claude',
         draft: 'x'.repeat(25_000),
         cmdOverrides: {},
-        platform: 'win32'
+        platform: 'win32',
+        agentStatusHookSettings: null
       })
     ).toBeNull()
   })
@@ -901,7 +862,8 @@ describe('tui agent startup plans', () => {
         agent: 'pi',
         draft: 'x'.repeat(25_000),
         cmdOverrides: {},
-        platform: 'win32'
+        platform: 'win32',
+        agentStatusHookSettings: null
       })
     ).toBeNull()
   })
@@ -912,7 +874,8 @@ describe('tui agent startup plans', () => {
       prompt: 'fix the tests',
       cmdOverrides: {},
       agentArgs: resolveTuiAgentLaunchArgs('devin', null),
-      platform: 'linux'
+      platform: 'linux',
+      agentStatusHookSettings: null
     })
     expect(plan).toEqual({
       agent: 'devin',
@@ -933,7 +896,8 @@ describe('tui agent startup plans', () => {
       draft: 'prefill text',
       cmdOverrides: {},
       agentEnv: { ORCA_AGENT_MODE: 'managed' },
-      platform: 'linux'
+      platform: 'linux',
+      agentStatusHookSettings: null
     })
 
     expect(plan?.env).toEqual({ ORCA_AGENT_MODE: 'managed', ORCA_PI_PREFILL: 'prefill text' })

--- a/src/shared/tui-agent-startup.ts
+++ b/src/shared/tui-agent-startup.ts
@@ -55,6 +55,8 @@ export function buildAgentStartupPlan(args: {
   /** Why: SSH remotes deploy the CLI shim as plain `orca`, so the Linux-only
    * `orca-ide` rename must be skipped for remote launches. */
   isRemote?: boolean
+  /** Orca's managed status hooks are enabled for this agent (#11941). */
+  agentStatusHooksEnabled?: boolean
 }): AgentStartupPlan | null {
   const { agent, prompt, cmdOverrides, platform, allowEmptyPromptLaunch = false } = args
   const shell = resolveStartupShell(platform, args.shell)
@@ -69,7 +71,8 @@ export function buildAgentStartupPlan(args: {
     agentArgs: usesQuery ? null : args.agentArgs,
     sessionOptions: args.sessionOptions,
     sessionOptionsOverrideAgentArgs: args.sessionOptionsOverrideAgentArgs,
-    isRemote: args.isRemote
+    isRemote: args.isRemote,
+    agentStatusHooksEnabled: args.agentStatusHooksEnabled
   })
   if (!baseCommand.ok) {
     return null
@@ -254,6 +257,9 @@ export function buildAgentDraftLaunchPlan(args: {
   sessionOptions?: Record<string, SessionOptionValue>
   /** Why: see buildAgentStartupPlan — remote launches use the plain `orca` shim. */
   isRemote?: boolean
+  /** Why: see buildAgentStartupPlan — a remote Codex draft launch needs the
+   *  same hooks override as a prompt launch (#11941). */
+  agentStatusHooksEnabled?: boolean
 }): AgentDraftLaunchPlan | null {
   const { agent, draft, cmdOverrides, platform } = args
   const shell = resolveStartupShell(platform, args.shell)
@@ -269,7 +275,8 @@ export function buildAgentDraftLaunchPlan(args: {
     shell,
     agentArgs: args.agentArgs,
     sessionOptions: args.sessionOptions,
-    isRemote: args.isRemote
+    isRemote: args.isRemote,
+    agentStatusHooksEnabled: args.agentStatusHooksEnabled
   })
   if (!baseCommand.ok) {
     return null

--- a/src/shared/tui-agent-startup.ts
+++ b/src/shared/tui-agent-startup.ts
@@ -1,4 +1,5 @@
 import { isShellProcess } from './agent-detection'
+import type { AgentStatusHookSettings } from './agent-status-hooks-for-agent'
 import {
   getAgentResumeArgv,
   type AgentProviderSessionMetadata,
@@ -41,23 +42,31 @@ function appliedSessionOptionProps(values: Record<string, SessionOptionValue>) {
   return Object.keys(values).length > 0 ? { sessionOptions: { ...values } } : {}
 }
 
-export function buildAgentStartupPlan(args: {
-  agent: TuiAgent
-  prompt: string
+/** Inputs every launch plan resolves its base command from. */
+type AgentLaunchPlanCommonArgs = {
   cmdOverrides: Partial<Record<TuiAgent, string>>
   platform: NodeJS.Platform
   shell?: AgentStartupShell
-  allowEmptyPromptLaunch?: boolean
   agentArgs?: string | null
   agentEnv?: Record<string, string> | null
   sessionOptions?: Record<string, SessionOptionValue>
-  sessionOptionsOverrideAgentArgs?: boolean
   /** Why: SSH remotes deploy the CLI shim as plain `orca`, so the Linux-only
    * `orca-ide` rename must be skipped for remote launches. */
   isRemote?: boolean
-  /** Orca's managed status hooks are enabled for this agent (#11941). */
-  agentStatusHooksEnabled?: boolean
-}): AgentStartupPlan | null {
+  /** Required, not optional (#11941): the old optional boolean defaulted to
+   * "hooks off", inverting the shipped default for every surface that forgot it.
+   * Passed as settings, not a flag, so no caller repeats the derivation. */
+  agentStatusHookSettings: AgentStatusHookSettings | null
+}
+
+export function buildAgentStartupPlan(
+  args: AgentLaunchPlanCommonArgs & {
+    agent: TuiAgent
+    prompt: string
+    allowEmptyPromptLaunch?: boolean
+    sessionOptionsOverrideAgentArgs?: boolean
+  }
+): AgentStartupPlan | null {
   const { agent, prompt, cmdOverrides, platform, allowEmptyPromptLaunch = false } = args
   const shell = resolveStartupShell(platform, args.shell)
   const trimmedPrompt = prompt.trim()
@@ -72,7 +81,7 @@ export function buildAgentStartupPlan(args: {
     sessionOptions: args.sessionOptions,
     sessionOptionsOverrideAgentArgs: args.sessionOptionsOverrideAgentArgs,
     isRemote: args.isRemote,
-    agentStatusHooksEnabled: args.agentStatusHooksEnabled
+    agentStatusHookSettings: args.agentStatusHookSettings
   })
   if (!baseCommand.ok) {
     return null
@@ -188,20 +197,17 @@ export function buildAgentStartupPlan(args: {
   }
 }
 
-export function buildAgentResumeStartupPlan(args: {
-  agent: ResumableTuiAgent
-  providerSession: AgentProviderSessionMetadata
-  cmdOverrides: Partial<Record<TuiAgent, string>>
-  platform: NodeJS.Platform
-  shell?: AgentStartupShell
-  agentArgs?: string | null
-  agentEnv?: Record<string, string> | null
-  agentCommand?: string | null
-  ompResumeFilePath?: string | null
-  sessionOptions?: Record<string, SessionOptionValue>
-  /** Why: see buildAgentStartupPlan — remote launches use the plain `orca` shim. */
-  isRemote?: boolean
-}): AgentStartupPlan | null {
+// Why the hooks settings matter on resume: a resumed remote Codex re-attaches to
+// the same env-less app-server a fresh launch does. A stored `agentCommand`
+// already carries the override, so only the rebuild path needs it.
+export function buildAgentResumeStartupPlan(
+  args: AgentLaunchPlanCommonArgs & {
+    agent: ResumableTuiAgent
+    providerSession: AgentProviderSessionMetadata
+    agentCommand?: string | null
+    ompResumeFilePath?: string | null
+  }
+): AgentStartupPlan | null {
   const argv = getAgentResumeArgv(args.agent, args.providerSession, args.ompResumeFilePath)
   if (!argv) {
     return null
@@ -217,7 +223,8 @@ export function buildAgentResumeStartupPlan(args: {
         platform: args.platform,
         shell,
         agentArgs: args.agentArgs,
-        isRemote: args.isRemote
+        isRemote: args.isRemote,
+        agentStatusHookSettings: args.agentStatusHookSettings
       })
   if (!baseCommand.ok) {
     return null
@@ -246,21 +253,9 @@ export type AgentDraftLaunchPlan = {
   sessionOptions?: Record<string, SessionOptionValue>
 }
 
-export function buildAgentDraftLaunchPlan(args: {
-  agent: TuiAgent
-  draft: string
-  cmdOverrides: Partial<Record<TuiAgent, string>>
-  platform: NodeJS.Platform
-  shell?: AgentStartupShell
-  agentArgs?: string | null
-  agentEnv?: Record<string, string> | null
-  sessionOptions?: Record<string, SessionOptionValue>
-  /** Why: see buildAgentStartupPlan — remote launches use the plain `orca` shim. */
-  isRemote?: boolean
-  /** Why: see buildAgentStartupPlan — a remote Codex draft launch needs the
-   *  same hooks override as a prompt launch (#11941). */
-  agentStatusHooksEnabled?: boolean
-}): AgentDraftLaunchPlan | null {
+export function buildAgentDraftLaunchPlan(
+  args: AgentLaunchPlanCommonArgs & { agent: TuiAgent; draft: string }
+): AgentDraftLaunchPlan | null {
   const { agent, draft, cmdOverrides, platform } = args
   const shell = resolveStartupShell(platform, args.shell)
   const config = TUI_AGENT_CONFIG[agent]
@@ -276,7 +271,7 @@ export function buildAgentDraftLaunchPlan(args: {
     agentArgs: args.agentArgs,
     sessionOptions: args.sessionOptions,
     isRemote: args.isRemote,
-    agentStatusHooksEnabled: args.agentStatusHooksEnabled
+    agentStatusHookSettings: args.agentStatusHookSettings
   })
   if (!baseCommand.ok) {
     return null


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 27 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1413 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​232 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1181 |
| Prod | 30 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​756 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​153 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​603 |

<!-- /orca-pr-loc -->

## ELI5

`orca agent hooks status` only ever looked at your own Mac. Over SSH the agent runs on a different machine, so it happily said `codex: installed` while the remote box had no Orca hooks at all. Now every line says which host it is talking about, and a host Orca cannot check says `unknown` instead of borrowing the local answer. Remote Codex also gets a launch flag so it starts its own app-server instead of reusing one that never saw Orca's hook environment.

## What Changed

**Truthful, host-scoped diagnostics (#8711 / STA-1806)**

- `SshRelaySession` keeps its remote managed-hook result instead of discarding it after a `console.warn`. Every path records an outcome: `skipped` (hooks off, Windows remote, no agent CLI detected), `installed` / `partial` / `error` from the relay, and `unknown` when the connection dropped mid-install. It defaults to `unknown` — a host that never reported is never silently absent.
- The relay's managed-hook install RPC now returns per-agent `statuses` alongside the existing counts. New optional field on an existing response, so an older relay simply omits it (wire Rule 1); `readManagedHookInstallOutcome` falls back to the counts, and reports `unknown` — never `installed` — when the answer is unreadable.
- New `agentHooks.status` runtime RPC returns `{ hosts: AgentHookHostReport[] }` — the local host plus every live SSH host.
- `orca agent hooks status` prints per host. When the runtime is unreachable it prints the local host and an explicit `ssh: unknown — Orca is not running; SSH host hook status is unavailable from this machine.` rather than a bare list that reads as a global verdict.

**Remote Codex hooks fire for Orca-launched panes (#11941 / STA-3147) — a partial mitigation, read the scope note**

> **Scope, stated plainly.** This half only reaches launches **Orca constructs**. A user who types `codex` at a remote prompt, or uses a shell alias, never passes through this code — their pane still attaches to the pre-existing app-server and still drops every lifecycle event. That is the majority path for most users. This does not regress it; it does not fix it either.
>
> The launch-independent fix is to make the hook **endpoint file** discoverable at a well-known path. The managed hook script already sources that file to recover `ORCA_AGENT_HOOK_PORT`/`TOKEN`/`ENV`/`VERSION` when the environment has gone stale — it just cannot locate the file without `ORCA_AGENT_HOOK_ENDPOINT` already set. Fixing that would make hooks work regardless of how the agent was started, which is the actual requirement. Adjacent to #7282 (STA-1284).

- Remote POSIX Codex launches carry a launch-scoped `-c features.hooks=true`. Codex only reuses an implicit local app-server for a launch with no config override, so this gives the pane its own server — started from the PTY that has `ORCA_AGENT_HOOK_*`. Without it, hook commands run in a daemon environment that predates the pane and Orca's managed script exits silently.
- `-c` rather than `--enable hooks`: `--enable` is validated against the CLI's feature registry and hard-errors on an unknown key, which would turn a hook gap into a launch failure on older Codex builds. An unrecognized `[features]` key in a `-c` override is ignored.
- Gated to Codex, remote, non-Windows, hooks-enabled-for-that-agent, and skipped entirely when the user's own args or command override already decide hooks (`--enable hooks`, `--disable hooks`, `-c features.hooks=…`, `--config=features.hooks=…`). Local commands are byte-for-byte unchanged.

**The flag is resolved once, not remembered by 25 call sites**

The first cut of this PR passed `agentStatusHooksEnabled` as an *optional boolean* that each launch surface derived for itself. Four surfaces did. Twenty-one did not — including the tab bar's "New tab → Codex", which is how the gap was caught over real SSH: the folder-workspace composer sent `codex -c features.hooks=true …` while the tab bar, same host and same binary minutes apart, sent `codex …` with no flag.

That was a design defect, not twenty-one oversights. An optional boolean defaults to falsy, so *omitting* it meant "hooks off" — the exact inverse of the shipped default (`agentStatusHooksEnabled: true`). Forgetting it was silent and produced the wrong launch.

So the parameter is now **required, and carries settings rather than a pre-derived flag**:

- `buildAgentStartupPlan`, `buildAgentDraftLaunchPlan`, and `buildAgentResumeStartupPlan` take `agentStatusHookSettings: AgentStatusHookSettings | null`. Omitting it is a compile error, so the twenty-second launch surface cannot repeat this.
- `resolveAgentLaunchCommand` — the single chokepoint all three builders already funnel through — calls `areAgentStatusHooksEnabledForAgent` itself. No caller derives the answer, so no caller can derive it wrong. That also removes a live second-order bug: the folder-workspace composer resolved it as `agentStatusHooksEnabled ?? true`, ignoring the per-agent `disabledTuiAgents` opt-out.
- All 25 call sites (17 renderer, 8 in `orca-runtime.ts`) now hand over the settings they already had in scope — every one was zero or one hop from a `settings` object, so nothing is threaded down a chain.

**Resume was missing the flag entirely.** `buildAgentResumeStartupPlan` had no hooks parameter at all, and the three renderer resume paths (`pty-connection.ts` cold restore, `ai-vault-resume-command.ts`, `sleeping-agent-session-launch.ts`) did not pass `isRemote` either — so a resumed remote Codex re-attached to the very env-less app-server this PR exists to avoid. All three now pass both. `resolveAgentResumeLaunchTarget` gained an `isRemote` field for this; note it deliberately does **not** reuse the expression the shell branch uses two lines below, because that one reads an absent `executionHostId` as remote (`null !== 'local'`), which is fine for picking a shell but wrong for a launch decision.

A resume that replays a *stored* `launchConfig.agentCommand` skips command rebuilding entirely. Commands captured before this change therefore resume without the override; they self-heal on the next fresh launch. Sessions captured after it already carry the flag in the stored command.

`buildFolderWorkspaceLinkedStartupPlan` and `resolveFolderWorkspaceLaunchDraft` moved to `folder-workspace-linked-startup-plan.ts` to keep the submit module under its size cap (re-exported, no call-site churn).

## Why

#8711's headline is the dead hooks, but its own conclusion is that the lying diagnostic is worse: it cost the reporter a day of debugging because they trusted `installed` and ruled out the real cause. Current `main` already installs file-scoped hooks into the remote `~/.codex`, so the original `CODEX_HOME` injection gap is closed — what survives is a status command that cannot see the host that runs the agent, and a launch path where Codex never invokes the installed hook.

Both are fixed at the layer that owns the fact: the session that talked to the host owns its verdict, and the launch planner owns the launch flag.

### Supersedes #8848

#8848 (open, `CONFLICTING`) covers the diagnostic half with a similar design, and its scope note reaching the same conclusion about the install half is what let me focus this PR. This supersedes it and adds what it does not cover: the `unknown` default so a host that never reported cannot read as green, the old-relay wire fallback, and the #11941 launch fix. Close #8848 in favor of this.

## Linked Issue

Fixes #8711
Refs #11941 — the diagnostic half is fixed; the launch half is a partial mitigation covering Orca-constructed launches only, so #11941 stays open until hook delivery no longer depends on how the agent was started.

STA-1806, STA-3147

## Visual Proof

N/A — CLI diagnostic output, captured under Testing below. No UI surface changes.

## Testing

**Live SSH reproduction (both halves, before the fix)**

Throwaway `ubuntu:22.04` Docker container as the SSH target (linux-arm64, key-based root login, build toolchain + node 22 installed, a real git repo at `/work/demo-project`, `codex` on `PATH`). The PR worktree ran as an isolated Electron dev instance (`ORCA_DEV_USER_DATA_PATH` under the run's temp dir, own CDP port, `getIdentity()` verified as `Orca: brennanb2025/codex-ssh-hooks-8711`), `pnpm build:relay` before connecting, target registered and connected through the real `ssh.connect` path.

Relay came up cleanly:

```
[ssh-relay] Platform: linux-arm64
[ssh-relay] Relay started successfully
[relay] Handshake OK from version=0.1.0+fb3da39c704e
```

Remote host, with that connection live:

```
$ ls -la /root/.codex
ls: cannot access '/root/.codex': No such file or directory
$ ls -laR /root/.orca
ls: cannot access '/root/.orca': No such file or directory
```

Both directories are genuinely absent — but that fact proves the *diagnostic* was lying, not that the installer had run and failed. This container had no Codex CLI on `PATH` at that point, and with the relay connected and no agent CLI detected the install correctly resolves to `skipped`: there is nothing to install hooks for. Once a `codex` binary exists on the remote, the installer does run. The bug on display here is entirely the client-side one below — a green `codex: installed` for a host that was never asked. At the same moment, on the client:

```
$ orca agent hooks status
agentStatusHooksEnabled: true
appliedBy: offline
settingsPath: …/orca-data.json
claude: installed
codex: installed          ← green, and no host named anywhere
gemini: installed
…
```

That is #8711's second half proven live: the diagnostic reports `installed` for a host where nothing is installed, and its `configPath` is a local macOS path the remote agent will never read.

**After the fix**, the same command against the same profile:

```
agentStatusHooksEnabled: true
appliedBy: offline
settingsPath: …/orca-data.json
local: partial
  claude: installed
  codex: installed
  …
ssh: unknown — Orca is not running; SSH host hook status is unavailable from this machine.
```

Every agent line is now scoped under a named host, and SSH status is explicitly `unknown` instead of being implied by the local answer.

**Automated**

Full suite: `pnpm exec vitest run --config config/vitest.config.ts` — **5765 files / 53820 tests pass**. Three pre-existing failures are unrelated to this diff and reproduce identically at this branch's HEAD commit with the working tree clean (verified in a detached `git worktree` at HEAD): two in `terminal-ime-xterm-cancelled-preedit-visibility.test.ts` (from #14982, already on `main`) and one full-suite-only flake in `macos-computer-helper-owner-loss-processes.test.mjs` that passes in isolation.

`oxfmt` and `oxlint` clean on all 39 changed files, with the lint gate proven live by injecting `Array<string>` and a `debugger` statement and confirming both were reported. `tsc --noEmit` clean on all three projects (`tsconfig.web`, `tsconfig.node`, `tsconfig.cli`).

New coverage for the flag wiring, each **mutation-tested** — the fix was reverted and the assertion confirmed to go red:

- `launch-agent-in-new-tab-remote-codex-hooks.test.ts` (new) — pins the arm that was proven broken over SSH. Remote Codex tab launch carries the override; local does not; the global toggle off suppresses it; a user's `-c features.hooks=false` in Codex default args survives with **exactly one** `features.hooks` token on the line. Reverting the one-line fix in `launch-agent-in-new-tab.ts` turns the first case red.
- `tui-agent-launch-command.codex-remote-hooks.test.ts` — extended to 13 cases: the per-agent `disabledTuiAgents` opt-out suppresses the flag even with the global toggle on; `null` settings resolve to the shipped default (hooks on); remote Codex **resume** carries the override, local resume does not, and a resume whose CLI args say `features.hooks=false` is not overruled. Dropping the derivation from the resume branch turns the resume case red; hardcoding `hooksEnabled: true` turns the two opt-out cases red.
- Behavior changes landed in existing expectations rather than being suppressed: remote Codex commands in `ai-vault-resume-command`, `sleeping-agent-session-launch-windows-quoting`, `launch-agent-background-session-remote`, `pty-connection-cold-restore-resume-command`, `pty-connection-remote-runtime-attach`, and two SSH cases in `orca-runtime.test.ts` now assert the flag. Every **local** counterpart in those same files was left unchanged and still passes — which is the byte-for-byte-unchanged guarantee, checked case by case rather than assumed.
- `agent-resume-launch-target.test.ts` asserts the new `isRemote` per case, including that an absent `executionHostId` is **not** treated as remote.

`tui-agent-startup.test.ts` was split (resume cases moved to `tui-agent-startup-resume.test.ts`) and the composer-submit fixture duplication collapsed, to stay inside `max-lines` without disabling the rule.

**SSH re-validation of the flag wiring — attempted, not completed.** A fresh throwaway rig was built for it (Docker `node:20-bookworm`, linux-arm64, key-only root SSH on a random loopback port, build toolchain, a real `demo-project` cloned from a local git bundle because the GitHub clone is auth-blocked, and an argv-recording `codex` shim on `PATH` so the exact remote command line could be captured). `pnpm build:relay` first; the PR worktree ran as an isolated Electron dev instance with its own `ORCA_DEV_USER_DATA_PATH` and CDP port, `getIdentity()` verified as `Orca: brennanb2025/codex-ssh-hooks-8711` before every interaction.

What that rig did prove over real SSH: the relay deployed to linux-arm64, installed native deps, started and later reconnected cleanly, and Orca performed genuine remote work through it — the container recorded Orca running `codex --version` on the remote host for agent detection.

What it could not prove: in 4 of 4 attempts, including on a clean profile with no orphaned relay and no repo registered, the Electron main process stopped answering both the CDP endpoint and the `orca` CLI runtime socket shortly after `Relay started successfully`, and did not recover within 3 minutes. A `sample` of the blocked process shows its main thread pinned inside a JS stream-read callback. That is upstream of anything this diff touches — it happens at connect, before any launch-plan code runs — but it blocked the UI-driven arms, so **the tab-bar and folder-composer launches were not re-proved on a live remote command line.** They are proved instead by the mutation-tested unit coverage above, which drives the real `launchAgentInNewTab` against an SSH-connected repo fixture.

Platforms: macOS client → **Linux SSH remote** exercised live for relay deploy and remote agent detection. Windows-remote and WSL paths are gated off by explicit checks and covered by unit tests, not run on hardware.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

**Not verified live:** the #11941 end-to-end callback (an authenticated interactive Codex TUI over SSH emitting `SessionStart`/`UserPromptSubmit`/`Stop` with a pre-existing app-server running) needs a signed-in Codex on the remote, which this container rig cannot provide. The reuse condition is confirmed from the Codex CLI's own launch logic — an implicit local daemon is reused only when the launch carries no config override — and the flag emission is unit-tested; the live callback comparison in #11941 is the reporter's evidence, not mine.

**Known gap — a disconnected host disappears instead of reading `unknown`.** `listActiveSshAgentHookReports` (`src/main/ipc/ssh.ts:171-188`) enumerates `activeSessions`, so a registered SSH host that is currently *disconnected* contributes no row at all. The report then shrinks back to just `local`, which reads as a global verdict — the exact confusion #8711 is about. This PR fixes the case where the host is connected and unverifiable; the host-is-down case is still reachable and deserves a follow-up that reports registered-but-disconnected targets as `unknown` rather than omitting them.

## Review

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

- **Remote wire**: the relay's install response gains an optional `statuses` field — Rule 1. A newer client against an older relay falls back to the existing counts; an older client against a newer relay ignores the field. No new opcode, no protocol bump. Both directions are covered by `remote-hook-install-outcome.test.ts`.
- **Cross-platform**: Windows remotes are excluded from the launch override and record `skipped` with a reason. No hardcoded separators or platform assumptions added.
- **Folder workspaces**: the launch flag flows through the folder-workspace submit path as well as the git-worktree path.
- **Agent-identity check on the new `isRemote`**: wiring `isRemote` into the three resume paths makes it reach two consumers — `planCodexRemoteHookLaunchArgs` (the intended hooks override) and `getTuiAgentLaunchCommand`, which drops the local-only `orca-ide` rename on Linux. The second is **unreachable from resume**: `launchCmdByPlatform` is declared by exactly one agent, `claude-agent-teams`, and that agent is not in `RESUMABLE_TUI_AGENTS`, so `buildAgentResumeStartupPlan` cannot be called with it. Every resumable agent resolves the same Linux binary with `isRemote` true or false, so no resumed pane changes process name and nothing in `PROCESS_TO_AGENT` / `recognizeAgentProcess` is affected. Pinned by an `it.each` over `RESUMABLE_TUI_AGENTS` in `tui-agent-startup-resume.test.ts`, mutation-tested by giving `codex` a `launchCmdByPlatform.linux` and confirming it fails — so if a resumable agent ever gains a platform-specific launch command, or `claude-agent-teams` becomes resumable, this fails loudly instead of silently renaming a remote process.
  (For the record: an earlier revision of this description claimed the `orca-ide` rename *did* change for Linux-remote resumes. That was wrong — it is unreachable, as above.)
- **Required-parameter churn**: making `agentStatusHookSettings` required touches 25 call sites. That is the point — it converts 21 silent omissions into compile errors — but it is why the diff is wider than the behavior change alone.
- **Backwards compatibility**: `AgentHookCommandResult.statuses` is retained (now explicitly the local host's) so existing `--json` consumers keep working; `hosts` is additive.
- **Security**: no new credentials or hook permissions; per-agent install detail already crossed this boundary as counts.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — `oxlint` (incl. React Doctor) and `oxfmt` clean on all 39 changed files, `tsc --noEmit` clean on web/node/cli, full vitest suite green apart from three documented pre-existing failures.

## Author

- X / Twitter: @BrennanKB5



