### PR TITLE
fix(mobile): keep polling session tabs while an active terminal is pending-handle (STA-4256)

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -207,6 +207,7 @@ import {
   confirmsMirroredTabSelection,
   type AppliedSnapshotMarker
 } from '../../../../src/session/session-tab-snapshot-gate'
+import { hasPendingTerminalHandleRecoveryNeed } from '../../../../src/session/pending-terminal-handle-recovery'
 import {
   createInitialSessionAutoCreateState,
   useInitialSessionTerminalAutoCreate,
@@ -2283,6 +2284,10 @@ export default function SessionScreen() {
     () =>
       closedTabTombstonesRef.current.size > 0 ||
       pendingBrowserFocusPageIdRef.current !== null ||
+      // Why: a pending-handle terminal only turns ready in a fresh snapshot. A live
+      // stream otherwise parks the poll, and a host that mints the handle without
+      // republishing strands the pane on its spinner forever (STA-4256).
+      hasPendingTerminalHandleRecoveryNeed(sessionTabsRef.current, activeSessionTabIdRef.current) ||
       // Why: a chat-covered handle that ran out of rearms and left `terminal.list`
       // was reminted by a desktop graph reload. Only a fresh tab snapshot carries
       // the replacement handle, so force one instead of holding the composer locked.

--- a/mobile/src/session/mobile-session-startup-source.test.ts
+++ b/mobile/src/session/mobile-session-startup-source.test.ts
@@ -186,4 +186,17 @@ describe('mobile session startup', () => {
       newTabActions.indexOf("label: 'Markdown Note'")
     )
   })
+
+  it('counts a pending-handle active terminal as a tabs recovery need (STA-4256)', () => {
+    const recoveryNeed = sliceBetween(
+      'const hasSessionTabsRecoveryNeed = useCallback(',
+      'const getSessionTabsApplicationRevision ='
+    )
+
+    expect(recoveryNeed).toContain('hasPendingTerminalHandleRecoveryNeed(')
+    expect(recoveryNeed).toContain('sessionTabsRef.current')
+    expect(recoveryNeed).toContain('activeSessionTabIdRef.current')
+    // The predicate only reaches the poll loop through this hook's option.
+    expect(source).toContain('hasRecoveryNeed: hasSessionTabsRecoveryNeed')
+  })
 })

--- a/mobile/src/session/pending-terminal-handle-recovery.test.ts
+++ b/mobile/src/session/pending-terminal-handle-recovery.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { RpcClient } from '../transport/rpc-client'
+import type { RpcResponse } from '../transport/types'
+import type { MobileSessionTab, SessionTabsResult } from './mobile-session-route-types'
+import { hasPendingTerminalHandleRecoveryNeed } from './pending-terminal-handle-recovery'
+import {
+  MobileSessionTabsStreamHealth,
+  type SessionTabsApplyOutcome
+} from './mobile-session-tabs-stream-health'
+
+const TAB_ID = 'tab-1::f47ac10b-58cc-4372-a567-0e02b2c3d479'
+
+function terminalTab(terminal: string | null): MobileSessionTab {
+  return {
+    type: 'terminal',
+    id: TAB_ID,
+    title: 'zsh',
+    parentTabId: 'tab-1',
+    leafId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+    status: terminal === null ? 'pending-handle' : 'ready',
+    terminal,
+    isActive: true
+  }
+}
+
+function snapshot(terminal: string | null, type?: 'snapshot' | 'updated'): SessionTabsResult {
+  return {
+    worktree: 'id:repo::worktree',
+    publicationEpoch: 'host:1',
+    snapshotVersion: 1,
+    tabs: [terminalTab(terminal)],
+    activeTabId: TAB_ID,
+    activeTabType: 'terminal',
+    ...(type ? { type } : {})
+  } as SessionTabsResult
+}
+
+describe('hasPendingTerminalHandleRecoveryNeed', () => {
+  it('reports a need while the active terminal tab has no handle', () => {
+    expect(hasPendingTerminalHandleRecoveryNeed([terminalTab(null)], TAB_ID)).toBe(true)
+  })
+
+  it('clears once the host publishes the materialized handle', () => {
+    expect(hasPendingTerminalHandleRecoveryNeed([terminalTab('term-1')], TAB_ID)).toBe(false)
+  })
+
+  it('ignores a pending terminal the user is not looking at', () => {
+    const other: MobileSessionTab = {
+      type: 'markdown',
+      id: 'md-1',
+      title: 'NOTES.md',
+      filePath: '/w/NOTES.md',
+      relativePath: 'NOTES.md',
+      isDirty: false,
+      isActive: false,
+      documentVersion: '1'
+    }
+    expect(hasPendingTerminalHandleRecoveryNeed([terminalTab(null), other], 'md-1')).toBe(false)
+  })
+
+  it('reports no need with no selection or an unknown selection', () => {
+    expect(hasPendingTerminalHandleRecoveryNeed([terminalTab(null)], null)).toBe(false)
+    expect(hasPendingTerminalHandleRecoveryNeed([terminalTab(null)], 'gone')).toBe(false)
+  })
+})
+
+/**
+ * STA-4256: the phone rendered its spinner forever because a `live` tabs stream
+ * parks `poll()`, so a host that mints the handle without republishing was never
+ * asked again. These drive the real controller to prove the predicate is what
+ * keeps `session.tabs.list` flowing, and that it stops once the handle lands.
+ */
+describe('pending-handle recovery through MobileSessionTabsStreamHealth', () => {
+  function makeHarness() {
+    const pending: Array<(response: RpcResponse) => void> = []
+    const sendRequest = vi.fn(
+      () =>
+        new Promise<RpcResponse>((resolve) => {
+          pending.push(resolve)
+        })
+    )
+    const client = { sendRequest, getGeneration: () => 1 } as unknown as RpcClient
+    let tabs: MobileSessionTab[] = []
+    let activeTabId: string | null = null
+    const controller = new MobileSessionTabsStreamHealth<SessionTabsResult, MobileSessionTab>({
+      client,
+      scope: 'id:repo::worktree',
+      apply: (result): SessionTabsApplyOutcome<MobileSessionTab> => {
+        tabs = result.tabs
+        activeTabId = result.activeTabId
+        return { accepted: true, effectiveTabs: result.tabs }
+      },
+      consumeAccepted: () => {},
+      hasRecoveryNeed: () => hasPendingTerminalHandleRecoveryNeed(tabs, activeTabId)
+    })
+    return {
+      controller,
+      sendRequest,
+      resolveNext(result: SessionTabsResult) {
+        const resolve = pending.shift()
+        expect(resolve).toBeDefined()
+        resolve?.({ id: 'list', ok: true, result, _meta: { runtimeId: 'runtime-1' } })
+      },
+      readTabs: () => tabs
+    }
+  }
+
+  async function settle(): Promise<void> {
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+  }
+
+  /** Subscribe, snapshot, updated — the sequence that certifies the stream `live`. */
+  async function driveToLiveStream(
+    harness: ReturnType<typeof makeHarness>,
+    terminal: string | null
+  ) {
+    harness.controller.setReconciliationActive(true)
+    const subscription = harness.controller.beginSubscription()
+    subscription.listener(snapshot(terminal, 'snapshot'))
+    await settle()
+    harness.resolveNext(snapshot(terminal))
+    await settle()
+    subscription.listener(snapshot(terminal, 'updated'))
+    await settle()
+    harness.sendRequest.mockClear()
+    expect(harness.controller.isCertified()).toBe(true)
+  }
+
+  it('keeps polling session.tabs.list while the active terminal has no handle', async () => {
+    const harness = makeHarness()
+    await driveToLiveStream(harness, null)
+
+    expect(harness.controller.poll()).not.toBeNull()
+    await settle()
+    expect(harness.sendRequest).toHaveBeenCalledWith('session.tabs.list', {
+      worktree: 'id:repo::worktree'
+    })
+  })
+
+  it('stops polling once a fresh snapshot carries the handle', async () => {
+    const harness = makeHarness()
+    await driveToLiveStream(harness, null)
+
+    expect(harness.controller.poll()).not.toBeNull()
+    await settle()
+    harness.resolveNext(snapshot('term-1'))
+    await settle()
+
+    expect(harness.readTabs()[0]).toMatchObject({ status: 'ready', terminal: 'term-1' })
+    expect(harness.controller.poll()).toBeNull()
+  })
+
+  it('parks the poll when the active terminal already has its handle', async () => {
+    const harness = makeHarness()
+    await driveToLiveStream(harness, 'term-1')
+
+    expect(harness.controller.poll()).toBeNull()
+    expect(harness.sendRequest).not.toHaveBeenCalled()
+  })
+})

--- a/mobile/src/session/pending-terminal-handle-recovery.ts
+++ b/mobile/src/session/pending-terminal-handle-recovery.ts
@@ -1,0 +1,24 @@
+import type { MobileSessionTab } from './mobile-session-route-types'
+
+/**
+ * Whether the tab the user is looking at is a terminal the host published
+ * without a PTY handle (`status: 'pending-handle'`). The session screen renders
+ * a spinner for that tab and can only leave it when a snapshot carries the
+ * materialized handle — so while this holds, the tabs reconciler must keep
+ * asking. Without it a `live` stream parks the poll, and a host that mints the
+ * handle without republishing strands the pane on the spinner forever
+ * (STA-4256).
+ *
+ * Mirrors the route's `activePendingTerminalTab` derivation exactly, so this is
+ * true precisely when the spinner is on screen.
+ */
+export function hasPendingTerminalHandleRecoveryNeed(
+  tabs: readonly MobileSessionTab[],
+  activeTabId: string | null
+): boolean {
+  if (activeTabId === null) {
+    return false
+  }
+  const active = tabs.find((tab) => tab.id === activeTabId)
+  return active?.type === 'terminal' && typeof active.terminal !== 'string'
+}


### PR DESCRIPTION
## ELI5

On the phone, opening an agent session sometimes shows a spinner that never goes away. The phone was waiting to be *told* the terminal was ready — but it had stopped asking. Now it keeps asking until the terminal shows up, then stops asking again.

## What Changed

`hasSessionTabsRecoveryNeed` in the mobile session route now also returns `true` while the **active** session tab is a terminal the host published as `status: 'pending-handle'` (no PTY handle yet).

- New pure predicate `mobile/src/session/pending-terminal-handle-recovery.ts`, mirroring the route's existing `activePendingTerminalTab` derivation exactly — so it is `true` precisely when the spinner is on screen.
- Wired into the existing recovery-need option that `MobileSessionTabsStreamHealth.poll()` already consults every 2s.

Client-only. No RPC, frame, opcode, or published-content change — it reuses `session.tabs.list`, so [remote wire compatibility](docs/reference/remote-wire-compatibility.md) Rules 1–3 are untouched.

## Why

A terminal tab with no handle renders the session screen's `ActivityIndicator` + tab title. Leaving that state requires a snapshot carrying the materialized handle.

The tabs reconciler stops asking for one once the subscription is certified `live`:

```ts
// mobile-session-tabs-stream-health.ts
poll(): Promise<void> | null {
  if (!this.reconciliationActive ||
      (this.health === 'live' && !this.options.hasRecoveryNeed() &&
       this.requirementRevision <= this.satisfiedRevision)) {
    return null   // <- parked
  }
  ...
}
```

`hasRecoveryNeed()` covered close-tombstones, pending browser focus, and native-chat handle rearm — but **not** a pending terminal. So a host that mints the handle without emitting a new tabs publication was never asked again, and the pane spun forever.

The fix is the same shape as the native-chat case already in that predicate ("keep polling until a replacement handle arrives"), applied to the plain terminal view.

### Which failure mode this is

Measured on the emulator with the session screen open and the host answering `ready`, over 90s:

| RPC | count |
|---|---|
| `session.tabs.list` | **2** (both from initial load) |
| `session.tabs.activate` | **1** (fired once, never retried) |
| `terminal.list` | ~45 (every 2s) |

So it is **not** a request that never resolves (both list calls completed) and **not** a re-render loop (no churn). It is a status that never settles: the client stops asking, and `terminal.list` firing on the same 2s interval proves the app was alive and foregrounded the whole time.

## Linked Issue

Addresses #14421

## Visual Proof

Both frames: iOS Simulator, session screen open, host publishing the active terminal tab. Between them nothing changed but the code — the host answers `ready` in **both** frames, and no stream event was pushed.

**BEFORE** — 90s after the host started answering `ready`, still spinning:

![BEFORE-stuck-spinner.png](https://github.com/user-attachments/assets/15a9f861-0cb0-4183-8a55-a4402b25cfcc)

**AFTER** — recovers within one poll (~2s) of the handle becoming available:

![AFTER-recovered.png](https://github.com/user-attachments/assets/3a51e4a5-6263-4004-8274-d5762133e3bb)

## Testing

Platforms: macOS host + iOS Simulator (iPhone 17 Pro, iOS 26.5). All mobile UI interaction driven through `orca emulator`, by accessibility label — never fixed coordinates, never computer-use.

**Live A/B** (mock host publishing the active terminal tab, flipped `pending-handle` → `ready` *without* pushing a stream event, so recovery can only come from a client-initiated `session.tabs.list`):

1. Open a workspace session while the host publishes `status: 'pending-handle'` → spinner + tab title. Reproduced.
2. Flip the host to `ready`. **Before:** 0 further `session.tabs.list` in 90s; still spinning. **After:** ~15 polls / 30s while pending, recovery within ~10s of the flip, then polling parks again (30 → 31 calls, i.e. one more poll, then quiet).

**Automated** (`mobile/vitest.config.ts`):

- `mobile/src/session/pending-terminal-handle-recovery.test.ts` — 7 tests. 4 cover the predicate; 3 drive the **real** `MobileSessionTabsStreamHealth` through subscribe → snapshot → updated (certifying the stream `live`) and assert `poll()` still issues `session.tabs.list` while pending, stops once a snapshot carries the handle, and never fires when the handle is already there.
- `mobile/src/session/mobile-session-startup-source.test.ts` — asserts the route actually passes the predicate into `hasRecoveryNeed`, so it cannot become dead code.

Non-vacuity check: with `hasRecoveryNeed` forced to `false`, the 2 behavioural tests fail with `expected null not to be null` — the exact live symptom.

```
mobile/src/session  128 files | 1126 tests  passed
oxlint + oxfmt      clean on changed files
tsc -p mobile/tsconfig.json   clean (plus a scoped pass over the new test files,
                              which that tsconfig excludes)
```

Not run: full-repo typecheck (OOM risk on this machine); desktop suites are untouched by this change.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

- **Wire/backcompat:** no wire change. Reuses `session.tabs.list`, which every paired host already serves; the predicate reads a field (`terminal`) the client has always read. An older host that never publishes `pending-handle` simply never trips it.
- **Performance:** the poll is bounded by the state it recovers from — it runs *only* while the spinner is on screen and stops on the first snapshot carrying the handle (verified live: 30 → 31 calls after recovery). It rides the reconciler's existing 2s interval, adds no timer, and `useFocusEffect` already suspends it when the screen is unfocused or the app is backgrounded.
- **SSH / remote / folder workspaces:** the predicate is transport- and workspace-agnostic; it reads the published tab shape only.
- **Cross-platform:** no platform-conditional code, no paths, no shortcuts.

### Scope note

STA-517 (incorrect ACTIVE status for SSH worktrees on mobile) was investigated alongside this and is **deliberately not** in this PR. It is a different root cause — `getWorktreeStatus` in `mobile/src/worktree/workspace-list-ordering.ts` deriving `'active'` from `liveTerminalCount > 0` / `hasHostSidebarActivity` on the *workspace list*, not the session tab's handle state. Bundling them would have been a guess, and STA-517 has no reproduction details to verify a fix against.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — scoped mobile lint/format/typecheck/tests run locally; full-repo typecheck and build left to CI

## Author

- X / Twitter: @BrennanKB5

