### PR TITLE
fix(agents): lift the pane retirement fence when a live PTY re-attaches (STA-4114)

### DIFF
--- a/src/main/agent-hooks/server-closed-tab-suppression.test.ts
+++ b/src/main/agent-hooks/server-closed-tab-suppression.test.ts
@@ -372,6 +372,260 @@ describe('AgentHookServer listener replay', () => {
     }
   })
 
+  // STA-4114: retirement fences every alias of a pane and deletes the alias itself.
+  // Restoring only the owner key leaves the physical key the live process still posts
+  // fenced forever — the detached pane, which is the canonical re-attach case.
+  it('re-attaching a detached pane accepts hooks on the pane key its process launched under', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      const detachedPane = makePaneKey('tab-2', LEAF_2)
+      const env = server.buildPtyEnv()
+      const postHook = (payload: Record<string, unknown>): Promise<Response> =>
+        fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/pi`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+          },
+          body: JSON.stringify(buildBody(payload, { launchToken: 'detached-token' }))
+        })
+
+      await postHook({ hook_event_name: 'before_agent_start', prompt: 'turn in flight' })
+      // Detach into another tab. The live process keeps posting PANE (server.ts:1614),
+      // so the alias is the only thing routing it to its new owner.
+      server.transferPaneAuthority(PANE, detachedPane, 'pty-detached')
+      server.retirePaneAuthority(detachedPane)
+      expect(server.restorePaneAuthority(detachedPane)).toBe(true)
+
+      await postHook({ hook_event_name: 'agent_end' })
+      // One row under the OWNER key. Lifting the fence without rebuilding the alias
+      // mints a second row on the stale key instead.
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({ paneKey: detachedPane, state: 'done' })
+      ])
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('re-attaching restores a legacy numeric pane key alias', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      const legacyPane = 'tab-1:0'
+      const env = server.buildPtyEnv()
+      const postHook = (payload: Record<string, unknown>): Promise<Response> =>
+        fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/pi`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+          },
+          body: JSON.stringify(
+            buildBody(payload, { paneKey: legacyPane, launchToken: 'legacy-token' })
+          )
+        })
+
+      server.registerPaneKeyAlias(legacyPane, PANE, 'pty-legacy')
+      await postHook({ hook_event_name: 'before_agent_start', prompt: 'legacy turn' })
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({ paneKey: PANE, state: 'working' })
+      ])
+
+      server.retirePaneAuthority(PANE)
+      expect(server.restorePaneAuthority(PANE)).toBe(true)
+
+      await postHook({ hook_event_name: 'agent_end' })
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({ paneKey: PANE, state: 'done' })
+      ])
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('does not rebuild a detached pane alias into a closed tab', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      const detachedPane = makePaneKey('tab-2', LEAF_2)
+      const env = server.buildPtyEnv()
+      const postHook = (payload: Record<string, unknown>): Promise<Response> =>
+        fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/pi`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+          },
+          body: JSON.stringify(buildBody(payload, { launchToken: 'detached-closed-token' }))
+        })
+
+      await postHook({ hook_event_name: 'before_agent_start', prompt: 'turn in flight' })
+      server.transferPaneAuthority(PANE, detachedPane, 'pty-detached')
+      server.retirePaneAuthority(detachedPane)
+      // The tab the pane was detached into is closed: the stronger claim wins, and the
+      // alias must not be resurrected to route a live process into a closed tab.
+      server.dropStatusEntriesByTabPrefix('tab-2')
+      expect(server.restorePaneAuthority(detachedPane)).toBe(false)
+
+      await postHook({ hook_event_name: 'agent_end' })
+      expect(server.getStatusSnapshot()).toEqual([])
+    } finally {
+      server.stop()
+    }
+  })
+
+  // Why: the guard above short-circuits on the closed owner, so it never reaches the
+  // alias rebuild. Restoring the ORIGINAL key does reach it — and rebuilding the alias
+  // there would route a live process into the closed tab and silence it again.
+  it('re-opens the original pane instead of rebuilding an alias into a closed tab', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      const detachedPane = makePaneKey('tab-2', LEAF_2)
+      const env = server.buildPtyEnv()
+      const postHook = (payload: Record<string, unknown>): Promise<Response> =>
+        fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/pi`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+          },
+          body: JSON.stringify(buildBody(payload, { launchToken: 'reopen-origin-token' }))
+        })
+
+      await postHook({ hook_event_name: 'before_agent_start', prompt: 'turn in flight' })
+      server.transferPaneAuthority(PANE, detachedPane, 'pty-detached')
+      server.retirePaneAuthority(detachedPane)
+      server.dropStatusEntriesByTabPrefix('tab-2')
+
+      // The pane the process actually lives in is tab-1, which is still open.
+      expect(server.restorePaneAuthority(PANE)).toBe(true)
+
+      await postHook({ hook_event_name: 'agent_end' })
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({ paneKey: PANE, state: 'done' })
+      ])
+    } finally {
+      server.stop()
+    }
+  })
+
+  // Why: closedAgentStatusTabIds is LRU-bounded, so the tab fence is not permanent.
+  // If restoring a sibling key lifted the closed tab's PANE fence too, eviction of the
+  // tab id would leave nothing at all holding that pane shut.
+  it('leaves a closed tab pane fenced once its tab id is evicted', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      const detachedPane = makePaneKey('tab-2', LEAF_2)
+      const env = server.buildPtyEnv()
+      const postHook = (
+        payload: Record<string, unknown>,
+        overrides: Record<string, unknown> = {}
+      ): Promise<Response> =>
+        fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/pi`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+          },
+          body: JSON.stringify(buildBody(payload, { launchToken: 'evict-token', ...overrides }))
+        })
+
+      await postHook({ hook_event_name: 'before_agent_start', prompt: 'turn in flight' })
+      server.transferPaneAuthority(PANE, detachedPane, 'pty-detached')
+      server.retirePaneAuthority(detachedPane)
+      server.dropStatusEntriesByTabPrefix('tab-2')
+      expect(server.restorePaneAuthority(PANE)).toBe(true)
+
+      for (let i = 0; i <= CLOSED_AGENT_STATUS_TAB_IDS_MAX; i += 1) {
+        server.dropStatusEntriesByTabPrefix(`tab-evict-${i}`)
+      }
+
+      await postHook(
+        { hook_event_name: 'before_agent_start', prompt: 'after eviction' },
+        { paneKey: detachedPane, tabId: 'tab-2' }
+      )
+      expect(server.getStatusSnapshot()).toEqual([])
+    } finally {
+      server.stop()
+    }
+  })
+
+  // Why: a detach re-points a legacy numeric alias at an owner in another tab, so the
+  // fence can hold keys from two tabs at once. A legacy key never parses as a stable
+  // one, so a stable-only tab check would wave it through when its own tab is closed.
+  it('keeps a legacy alias fenced when its own tab closed but the owner tab did not', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      const legacyPane = 'tab-1:0'
+      const detachedPane = makePaneKey('tab-2', LEAF_2)
+      const env = server.buildPtyEnv()
+      const postHook = (payload: Record<string, unknown>): Promise<Response> =>
+        fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/pi`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+          },
+          body: JSON.stringify(
+            buildBody(payload, { paneKey: legacyPane, launchToken: 'legacy-cross-tab-token' })
+          )
+        })
+
+      server.registerPaneKeyAlias(legacyPane, PANE, 'pty-cross')
+      server.transferPaneAuthority(PANE, detachedPane, 'pty-cross')
+      server.retirePaneAuthority(detachedPane)
+      server.dropStatusEntriesByTabPrefix('tab-1')
+
+      // The owner tab is open, so the restore proceeds — but the legacy key's own tab
+      // is closed, and its alias must not be rebuilt into the still-open owner.
+      expect(server.restorePaneAuthority(detachedPane)).toBe(true)
+
+      await postHook({ hook_event_name: 'before_agent_start', prompt: 'after tab-1 close' })
+      expect(server.getStatusSnapshot()).toEqual([])
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('does not clobber a newer alias when replaying a retired fence', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      const legacyPane = 'tab-1:0'
+      const reboundPane = makePaneKey('tab-1', LEAF_3)
+      const env = server.buildPtyEnv()
+      const postHook = (payload: Record<string, unknown>): Promise<Response> =>
+        fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/pi`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+          },
+          body: JSON.stringify(
+            buildBody(payload, { paneKey: legacyPane, launchToken: 'rebind-token' })
+          )
+        })
+
+      server.registerPaneKeyAlias(legacyPane, PANE, 'pty-old')
+      server.retirePaneAuthority(PANE)
+      // The pane rebound to a different owner before the restore landed.
+      server.registerPaneKeyAlias(legacyPane, reboundPane, 'pty-new')
+      server.restorePaneAuthority(PANE)
+
+      await postHook({ hook_event_name: 'before_agent_start', prompt: 'after rebind' })
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({ paneKey: reboundPane, state: 'working' })
+      ])
+    } finally {
+      server.stop()
+    }
+  })
+
   it('accepts a resumed-session SessionStart after launch authority retires in a reusable pane', async () => {
     const server = new AgentHookServer()
     await server.start({ env: 'production' })

--- a/src/main/agent-hooks/server-closed-tab-suppression.test.ts
+++ b/src/main/agent-hooks/server-closed-tab-suppression.test.ts
@@ -267,6 +267,103 @@ describe('AgentHookServer listener replay', () => {
     }
   })
 
+  // STA-4114: a detach/reattach cycle retires the pane, and nothing lifted the fence.
+  // Reviving only on a new turn cannot help a pane re-attached mid-turn (its remaining
+  // events are agent_end, not a new-turn event) or one re-attached idle.
+  for (const kind of ['pi', 'omp', 'prime-agent'] as const) {
+    it(`re-attaching a retired ${kind} pane restores status without needing a new turn`, async () => {
+      const server = new AgentHookServer()
+      await server.start({ env: 'production' })
+      try {
+        const env = server.buildPtyEnv()
+        const postHook = (payload: Record<string, unknown>): Promise<Response> =>
+          fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/${kind}`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+            },
+            body: JSON.stringify(buildBody(payload, { launchToken: `retired-${kind}-token` }))
+          })
+
+        await postHook({ hook_event_name: 'before_agent_start', prompt: 'turn in flight' })
+        server.retirePaneAuthority(PANE)
+
+        // The turn was already running, so only its completion is left to report —
+        // and while retired it is suppressed. This is the reported permanent failure.
+        await postHook({ hook_event_name: 'agent_end' })
+        expect(server.getStatusSnapshot()).toEqual([])
+
+        expect(server.restorePaneAuthority(PANE)).toBe(true)
+
+        await postHook({ hook_event_name: 'agent_end' })
+        expect(server.getStatusSnapshot()).toEqual([
+          expect.objectContaining({ paneKey: PANE, state: 'done' })
+        ])
+      } finally {
+        server.stop()
+      }
+    })
+  }
+
+  it('re-attaching a retired pane while idle re-opens it for a much later first turn', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      const env = server.buildPtyEnv()
+      const postHook = (payload: Record<string, unknown>): Promise<Response> =>
+        fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/pi`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+          },
+          body: JSON.stringify(buildBody(payload, { launchToken: 'idle-reattach-token' }))
+        })
+
+      // Nothing in flight: the pane is retired and re-attached while the agent sits idle.
+      server.retirePaneAuthority(PANE)
+      expect(server.restorePaneAuthority(PANE)).toBe(true)
+
+      await postHook({ hook_event_name: 'before_agent_start', prompt: 'much later turn' })
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({ paneKey: PANE, state: 'working', prompt: 'much later turn' })
+      ])
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('re-attach does not lift a closed-tab tombstone', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      const env = server.buildPtyEnv()
+      const postHook = (payload: Record<string, unknown>): Promise<Response> =>
+        fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/pi`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+          },
+          body: JSON.stringify(buildBody(payload, { launchToken: 'closed-tab-token' }))
+        })
+
+      // Pane fence AND tab fence are both standing; re-attach may lift neither.
+      server.retirePaneAuthority(PANE)
+      server.dropStatusEntriesByTabPrefix('tab-1')
+      expect(server.restorePaneAuthority(PANE)).toBe(false)
+
+      await postHook({ hook_event_name: 'before_agent_start', prompt: 'after tab close' })
+      expect(server.getStatusSnapshot()).toEqual([])
+
+      // The pane fence must still be standing too, not silently lifted underneath.
+      expect(server.restorePaneAuthority(PANE)).toBe(false)
+    } finally {
+      server.stop()
+    }
+  })
+
   it('accepts a resumed-session SessionStart after launch authority retires in a reusable pane', async () => {
     const server = new AgentHookServer()
     await server.start({ env: 'production' })

--- a/src/main/agent-hooks/server-closed-tab-suppression.test.ts
+++ b/src/main/agent-hooks/server-closed-tab-suppression.test.ts
@@ -325,6 +325,14 @@ describe('AgentHookServer listener replay', () => {
       server.retirePaneAuthority(PANE)
       expect(server.restorePaneAuthority(PANE)).toBe(true)
 
+      // Why: prove the fence is already down before any turn event arrives. Asserting
+      // only on before_agent_start would also pass if a turn boundary lifted the fence,
+      // so it cannot distinguish re-attach revival from turn-triggered revival (#14626).
+      await postHook({ hook_event_name: 'agent_end' })
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({ paneKey: PANE, state: 'done' })
+      ])
+
       await postHook({ hook_event_name: 'before_agent_start', prompt: 'much later turn' })
       expect(server.getStatusSnapshot()).toEqual([
         expect.objectContaining({ paneKey: PANE, state: 'working', prompt: 'much later turn' })

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -154,6 +154,12 @@ type PaneKeyAliasEntry = {
   updatedAt: number
   authorityVerified: boolean
 }
+type RetiredPaneAlias = { physicalPaneKey: string; entry: PaneKeyAliasEntry }
+/** What one retirement fenced, so a re-attach can lift exactly that set and no more. */
+type RetiredPaneFence = {
+  paneKeys: readonly string[]
+  aliases: readonly RetiredPaneAlias[]
+}
 
 // Why: co-located with the endpoint file in userData/agent-hooks/ so hook-server cross-restart artifacts stay together.
 const LAST_STATUS_FILE_NAME = 'last-status.json'
@@ -177,6 +183,7 @@ const HYDRATE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
 export const CLOSED_AGENT_STATUS_TAB_IDS_MAX = 1024
 export const CLOSED_AGENT_STATUS_PANE_KEYS_MAX = 1024
 export const PANE_KEY_ALIASES_MAX = 1024
+export const RETIRED_PANE_FENCES_MAX = 1024
 
 type LastStatusFile = {
   version: number
@@ -622,6 +629,10 @@ export class AgentHookServer {
   private revokedHydratedAuthorityCommitments = new WeakSet<AgentHookAuthorityEvidence>()
   private currentAuthorityObservations = new Map<string, AgentHookAuthorityEvidence>()
   private legacyPaneKeyAliases = new Map<string, PaneKeyAliasEntry>()
+  // Why: indexed by every key the retirement fenced, so a re-attach on any of them
+  // (owner, physical, or a deleted alias) finds the same record. Bounded like the maps
+  // it mirrors; an evicted record simply degrades to lifting the key it was handed.
+  private retiredPaneFencesByKey = new Map<string, RetiredPaneFence>()
   private paneKeyAliasPersistenceListener: PaneKeyAliasPersistenceListener | null = null
   // Why: on-disk last-status cache path; null without a userDataPath (tests), where persistence is a no-op and only in-memory replay applies.
   private lastStatusFilePath: string | null = null
@@ -1021,6 +1032,33 @@ export class AgentHookServer {
       return 'restart'
     }
     return 'suppress'
+  }
+
+  // Why: a fence can span tabs (a pane detached into another tab), and legacy numeric
+  // keys never parse as stable ones — resolve both forms so neither slips the tab check.
+  private isClosedAgentStatusTabForPaneKey(paneKey: string): boolean {
+    const tabId =
+      parsePaneKey(paneKey)?.tabId ?? parseLegacyNumericPaneKey(paneKey)?.tabId ?? undefined
+    return tabId !== undefined && this.closedAgentStatusTabIds.has(tabId)
+  }
+
+  private recordRetiredPaneFence(
+    paneKeys: ReadonlySet<string>,
+    aliases: readonly RetiredPaneAlias[]
+  ): void {
+    const fence: RetiredPaneFence = { paneKeys: [...paneKeys], aliases }
+    for (const key of paneKeys) {
+      // Delete-then-set keeps the newest fence most-recent so eviction sheds only the oldest.
+      this.retiredPaneFencesByKey.delete(key)
+      this.retiredPaneFencesByKey.set(key, fence)
+    }
+    while (this.retiredPaneFencesByKey.size > RETIRED_PANE_FENCES_MAX) {
+      const oldest = this.retiredPaneFencesByKey.keys().next().value
+      if (oldest === undefined) {
+        break
+      }
+      this.retiredPaneFencesByKey.delete(oldest)
+    }
   }
 
   private markPaneClosedForAgentStatus(paneKey: string): void {
@@ -1630,15 +1668,18 @@ export class AgentHookServer {
   retirePaneAuthority(paneKey: string): void {
     const ownerPaneKey = this.resolvePaneKeyAlias(paneKey)
     const paneKeys = new Set([paneKey, ownerPaneKey])
+    const retiredAliases: RetiredPaneAlias[] = []
     let aliasChanged = false
     for (const [physicalPaneKey, entry] of this.legacyPaneKeyAliases) {
       if (physicalPaneKey === paneKey || entry.stablePaneKey === ownerPaneKey) {
         this.legacyPaneKeyAliases.delete(physicalPaneKey)
+        retiredAliases.push({ physicalPaneKey, entry })
         paneKeys.add(physicalPaneKey)
         paneKeys.add(entry.stablePaneKey)
         aliasChanged = true
       }
     }
+    this.recordRetiredPaneFence(paneKeys, retiredAliases)
     const authorityChanged = this.revokeHydratedAuthorityForPaneKeys(paneKeys)
     const hadStatus = [...paneKeys].some((key) => this.state.lastStatusByPaneKey.has(key))
     for (const key of paneKeys) {
@@ -1659,6 +1700,37 @@ export class AgentHookServer {
     }
   }
 
+  // Why: retirement fences a pane and every alias of it, then deletes those aliases.
+  // Lifting only the key we are handed strands the rest — a detached pane's process
+  // keeps posting the key it launched under, so it would stay suppressed forever with
+  // the fence apparently lifted. Replay the recorded fence instead: same key set, same
+  // aliases. Keys and aliases belonging to a closed tab are skipped, so the stronger
+  // claim survives and a live process is never routed back into a closed tab.
+  private restoreRetiredPaneFence(fence: RetiredPaneFence): void {
+    let aliasChanged = false
+    for (const { physicalPaneKey, entry } of fence.aliases) {
+      if (
+        this.isClosedAgentStatusTabForPaneKey(physicalPaneKey) ||
+        this.isClosedAgentStatusTabForPaneKey(entry.stablePaneKey) ||
+        // Why: the pane was rebound in the meantime; the newer alias is the truth.
+        this.legacyPaneKeyAliases.has(physicalPaneKey)
+      ) {
+        continue
+      }
+      this.legacyPaneKeyAliases.set(physicalPaneKey, entry)
+      aliasChanged = true
+    }
+    for (const key of fence.paneKeys) {
+      if (this.retiredPaneFencesByKey.get(key) === fence) {
+        this.retiredPaneFencesByKey.delete(key)
+      }
+    }
+    if (aliasChanged) {
+      this.boundPaneKeyAliases()
+      this.notifyPaneKeyAliasPersistenceListener()
+    }
+  }
+
   // Why: retirement is a claim that a pane is gone. Re-attaching a live PTY to that
   // exact pane disproves the claim at the moment it stops being true, so the fence
   // lifts here instead of waiting for the agent to speak again — an agent re-attached
@@ -1666,15 +1738,22 @@ export class AgentHookServer {
   // (STA-4114). A closed *tab* is a separate, stronger claim and is left standing.
   restorePaneAuthority(paneKey: string): boolean {
     const ownerPaneKey = this.resolvePaneKeyAlias(paneKey)
-    const tabId = parsePaneKey(ownerPaneKey)?.tabId
-    if (tabId && this.closedAgentStatusTabIds.has(tabId)) {
+    if (this.isClosedAgentStatusTabForPaneKey(ownerPaneKey)) {
       return false
     }
+    const fence =
+      this.retiredPaneFencesByKey.get(paneKey) ?? this.retiredPaneFencesByKey.get(ownerPaneKey)
     let restored = false
-    for (const key of new Set([paneKey, ownerPaneKey])) {
+    for (const key of new Set([paneKey, ownerPaneKey, ...(fence?.paneKeys ?? [])])) {
+      if (this.isClosedAgentStatusTabForPaneKey(key)) {
+        continue
+      }
       if (this.closedAgentStatusPaneKeys.delete(key)) {
         restored = true
       }
+    }
+    if (fence) {
+      this.restoreRetiredPaneFence(fence)
     }
     return restored
   }
@@ -2260,6 +2339,7 @@ export class AgentHookServer {
     this.promptSentDedupeByPaneKey.clear()
     this.closedAgentStatusTabIds.clear()
     this.closedAgentStatusPaneKeys.clear()
+    this.retiredPaneFencesByKey.clear()
     this.connectionTimestampWatermarkById.clear()
     this.legacyPaneKeyAliases.clear()
     clearAllListenerCaches(this.state)

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -1659,6 +1659,26 @@ export class AgentHookServer {
     }
   }
 
+  // Why: retirement is a claim that a pane is gone. Re-attaching a live PTY to that
+  // exact pane disproves the claim at the moment it stops being true, so the fence
+  // lifts here instead of waiting for the agent to speak again — an agent re-attached
+  // mid-turn or left idle would otherwise stay suppressed for the rest of its life
+  // (STA-4114). A closed *tab* is a separate, stronger claim and is left standing.
+  restorePaneAuthority(paneKey: string): boolean {
+    const ownerPaneKey = this.resolvePaneKeyAlias(paneKey)
+    const tabId = parsePaneKey(ownerPaneKey)?.tabId
+    if (tabId && this.closedAgentStatusTabIds.has(tabId)) {
+      return false
+    }
+    let restored = false
+    for (const key of new Set([paneKey, ownerPaneKey])) {
+      if (this.closedAgentStatusPaneKeys.delete(key)) {
+        restored = true
+      }
+    }
+    return restored
+  }
+
   clearPaneKeyAliasesForPty(
     ptyId: string,
     options?: { shouldClearStablePaneKey?: (paneKey: string) => boolean }

--- a/src/main/ipc/agent-pane-authority-ipc.ts
+++ b/src/main/ipc/agent-pane-authority-ipc.ts
@@ -12,7 +12,18 @@ export function registerAgentPaneAuthorityIpcHandlers(
   ownership: AgentPaneAuthorityOwnership
 ): void {
   ipcMain.removeAllListeners('agentStatus:retirePaneAuthority')
+  ipcMain.removeAllListeners('agentStatus:restorePaneAuthority')
   ipcMain.removeAllListeners('agentStatus:transferPaneAuthority')
+  ipcMain.on('agentStatus:restorePaneAuthority', (_event, paneKey: unknown) => {
+    if (typeof paneKey !== 'string' || !isValidPaneKey(paneKey)) {
+      return
+    }
+    try {
+      agentHookServer.restorePaneAuthority(paneKey)
+    } catch (err) {
+      console.warn('[agent-hooks] restorePaneAuthority failed:', err)
+    }
+  })
   ipcMain.on('agentStatus:retirePaneAuthority', (_event, paneKey: unknown) => {
     if (typeof paneKey !== 'string' || !isValidPaneKey(paneKey)) {
       return

--- a/src/preload/api/agent-status-api.ts
+++ b/src/preload/api/agent-status-api.ts
@@ -34,6 +34,8 @@ export type AgentStatusApi = {
   dropByTabPrefix: (tabId: string) => void
   /** Permanently retire one pane's hook authority while siblings stay live. */
   retirePaneAuthority: (paneKey: string) => void
+  /** Lift one pane's retirement fence when a live PTY re-attaches to it. Closed tabs stay retired. */
+  restorePaneAuthority: (paneKey: string) => void
   /** Move hook authority when a live pane is detached into another tab. */
   transferPaneAuthority: (args: { fromPaneKey: string; toPaneKey: string; ptyId?: string }) => void
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4990,6 +4990,9 @@ const api = {
     retirePaneAuthority: (paneKey: string): void => {
       ipcRenderer.send('agentStatus:retirePaneAuthority', paneKey)
     },
+    restorePaneAuthority: (paneKey: string): void => {
+      ipcRenderer.send('agentStatus:restorePaneAuthority', paneKey)
+    },
     transferPaneAuthority: (args: {
       fromPaneKey: string
       toPaneKey: string

--- a/src/renderer/src/components/terminal-pane/pty-connection-direct-ssh-reattach-retry.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-direct-ssh-reattach-retry.test.ts
@@ -1,6 +1,7 @@
 import type * as React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { toAppSshPtyId } from '../../../../shared/ssh-pty-id'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
 import { flushAsyncTicks, createDeferred } from './pty-connection-test-async'
 import {
   LEAF_1,
@@ -273,6 +274,11 @@ describe('connectPanePty', () => {
       restoredPtyId,
       undefined,
       pendingRetry.attemptId
+    )
+    // Why: binding a reattached PTY is what lifts the pane's retirement fence, so a
+    // pane re-attached mid-turn or idle is not suppressed forever (STA-4114).
+    expect(mockStoreState.restoreAgentPaneAuthority).toHaveBeenCalledWith(
+      makePaneKey('tab-1', LEAF_1)
     )
   })
 

--- a/src/renderer/src/components/terminal-pane/pty-connection-test-store-fixtures.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-test-store-fixtures.ts
@@ -91,6 +91,7 @@ export function createInitialStoreState(getState: () => StoreState): StoreState 
     removeAgentStatus: vi.fn(),
     dropAgentStatus: vi.fn(),
     retireAgentPaneAuthority: vi.fn(),
+    restoreAgentPaneAuthority: vi.fn(),
     setPaneForegroundAgent: vi.fn((paneKey: string, entry: PaneForegroundAgentEntry) => {
       getState().paneForegroundAgentByPaneKey[paneKey] = entry
     }),

--- a/src/renderer/src/components/terminal-pane/pty-connection-test-store-state.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-test-store-state.ts
@@ -118,6 +118,7 @@ export type StoreState = {
   removeAgentStatus: ReturnType<typeof vi.fn>
   dropAgentStatus: ReturnType<typeof vi.fn>
   retireAgentPaneAuthority: ReturnType<typeof vi.fn>
+  restoreAgentPaneAuthority: ReturnType<typeof vi.fn>
   setPaneForegroundAgent: ReturnType<typeof vi.fn>
   clearPaneForegroundAgent: ReturnType<typeof vi.fn>
   markTerminalTabUnread: ReturnType<typeof vi.fn>

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -3009,6 +3009,10 @@ export function connectPanePty(
     registerSideEffectFactConsumerForPty(ptyId)
     syncHiddenRendererPtyDelivery()
     deps.syncPanePtyLayoutBinding(pane.id, ptyId)
+    // Why: binding a live PTY here is the proof that this pane is current again, so
+    // lift any retirement fence left by a detach/reattach cycle before hooks arrive.
+    // Waiting for a new turn would strand a pane re-attached mid-turn or idle (STA-4114).
+    useAppStore.getState().restoreAgentPaneAuthority?.(cacheKey)
     notifyCodexPaneBoundForStaleSweep(ptyId)
     const tabPtyIds = useAppStore.getState().ptyIdsByTabId?.[deps.tabId] ?? []
     const directSshRetryAttemptId =
@@ -8187,6 +8191,9 @@ export function connectPanePty(
       registerSideEffectFactConsumerForPty(ptyId)
       syncHiddenRendererPtyDelivery()
       deps.syncPanePtyLayoutBinding(pane.id, ptyId)
+      // Why: this is the daemon-backed reattach path — the live PTY outlived the
+      // renderer, so the pane is current the moment it binds (STA-4114).
+      useAppStore.getState().restoreAgentPaneAuthority?.(cacheKey)
       notifyCodexPaneBoundForStaleSweep(ptyId)
       if (capturedDirectSshRetryPtyAccepted && directSshRetryAttempt) {
         deps.updateTabPtyId(deps.tabId, ptyId, undefined, directSshRetryAttempt.attemptId)

--- a/src/renderer/src/store/slices/agent-pane-authority.test.ts
+++ b/src/renderer/src/store/slices/agent-pane-authority.test.ts
@@ -15,6 +15,7 @@ const FINAL = makePaneKey('tab-final', '33333333-3333-4333-8333-333333333333')
 const SIBLING = makePaneKey('tab-target', '44444444-4444-4444-8444-444444444444')
 
 const retirePaneAuthority = vi.fn()
+const restorePaneAuthority = vi.fn()
 const transferPaneAuthority = vi.fn()
 const dropByTabPrefix = vi.fn()
 
@@ -25,6 +26,7 @@ beforeEach(() => {
     api: {
       agentStatus: {
         retirePaneAuthority,
+        restorePaneAuthority,
         transferPaneAuthority,
         dropByTabPrefix,
         drop: vi.fn()
@@ -70,6 +72,60 @@ describe('agent pane authority', () => {
     expect(state.agentStatusByPaneKey[SIBLING]).toBeDefined()
     expect(state.recentlyRetiredAgentStatusPaneKeys[TARGET]).toBe(true)
     expect(retirePaneAuthority).toHaveBeenCalledWith(TARGET)
+  })
+
+  // STA-4114: the renderer tombstone outlived the detach/reattach cycle, so a pane
+  // that was still running never showed status again for the rest of its life.
+  it('lifts the retirement fence on re-attach so an in-flight turn can still report done', () => {
+    const store = createTestStore()
+    store.getState().setAgentStatus(TARGET, { state: 'working', prompt: 'turn in flight' })
+    store.getState().retireAgentPaneAuthority(TARGET)
+
+    // The pane re-attached mid-turn: the agent never starts a NEW turn, it only
+    // finishes the one already running, so a turn-triggered revival cannot fire.
+    store.getState().setAgentStatus(TARGET, { state: 'done', prompt: 'turn in flight' })
+    expect(store.getState().agentStatusByPaneKey[TARGET]).toBeUndefined()
+
+    store.getState().restoreAgentPaneAuthority(TARGET)
+    expect(store.getState().recentlyRetiredAgentStatusPaneKeys[TARGET]).toBeUndefined()
+    expect(restorePaneAuthority).toHaveBeenCalledWith(TARGET)
+
+    store.getState().setAgentStatus(TARGET, { state: 'done', prompt: 'turn in flight' })
+    expect(store.getState().agentStatusByPaneKey[TARGET]?.state).toBe('done')
+  })
+
+  it('re-opens a pane re-attached while idle for a turn that starts much later', () => {
+    const store = createTestStore()
+    store.getState().retireAgentPaneAuthority(TARGET)
+    store.getState().restoreAgentPaneAuthority(TARGET)
+
+    store.getState().setAgentStatus(TARGET, { state: 'working', prompt: 'much later turn' })
+    expect(store.getState().agentStatusByPaneKey[TARGET]?.state).toBe('working')
+  })
+
+  it('does not lift a closed-tab tombstone on re-attach', () => {
+    const store = createTestStore()
+    store.getState().setAgentStatus(TARGET, { state: 'working', prompt: 'before close' })
+    store.getState().dropAgentStatusByTabPrefix('tab-target')
+
+    store.getState().restoreAgentPaneAuthority(TARGET)
+    expect(restorePaneAuthority).not.toHaveBeenCalled()
+
+    store.getState().setAgentStatus(TARGET, { state: 'working', prompt: 'after close' })
+    expect(store.getState().agentStatusByPaneKey[TARGET]).toBeUndefined()
+  })
+
+  it('leaves sibling panes untouched when one pane is restored', () => {
+    const store = createTestStore()
+    store.getState().retireAgentPaneAuthority(TARGET)
+    store.getState().retireAgentPaneAuthority(SIBLING)
+
+    store.getState().restoreAgentPaneAuthority(TARGET)
+
+    expect(store.getState().recentlyRetiredAgentStatusPaneKeys[TARGET]).toBeUndefined()
+    expect(store.getState().recentlyRetiredAgentStatusPaneKeys[SIBLING]).toBe(true)
+    store.getState().setAgentStatus(SIBLING, { state: 'working', prompt: 'still fenced' })
+    expect(store.getState().agentStatusByPaneKey[SIBLING]).toBeUndefined()
   })
 
   it('can retire live pane authority while retaining a migration recovery fence', () => {

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -1577,6 +1577,13 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         }
         return { recentlyRetiredAgentStatusPaneKeys: next }
       })
+      // Why: deliberately OUTSIDE the guard above, and not gated on having cleared
+      // anything here. This map is not a mirror of main's — main fences panes the
+      // renderer never hears about (retirePtyAgentLaunchAuthority on command-finished
+      // and PTY exit calls the hook server directly, and nothing pushes that back), and
+      // this map is per-window and non-persisted, so a renderer reload empties it while
+      // main's survives. Gating the send on a local tombstone reintroduces STA-4114 for
+      // exactly those panes. The send is idempotent and main refuses closed tabs itself.
       if (typeof window !== 'undefined') {
         window.api?.agentStatus?.restorePaneAuthority?.(ownerPaneKey)
       }

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -204,6 +204,8 @@ export type AgentStatusSlice = {
     paneKey: string,
     options?: { preserveSleepingAgentSession?: boolean }
   ) => void
+  /** Lift a pane's retirement fence once a live PTY re-attaches to it. Closed tabs stay retired. */
+  restoreAgentPaneAuthority: (paneKey: string) => void
   transferAgentPaneAuthority: (args: {
     fromPaneKey: string
     toPaneKey: string
@@ -1542,6 +1544,41 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
       }
       if (typeof window !== 'undefined') {
         window.api?.agentStatus?.retirePaneAuthority?.(ownerPaneKey)
+      }
+    },
+
+    // Why: the tombstone claims this pane is gone; a live PTY binding to it proves
+    // otherwise. Lift the fence on that proof rather than on the next hook event —
+    // a pane re-attached mid-turn or while idle emits no new-turn event, so a
+    // turn-triggered revival leaves exactly the reported permanent suppression
+    // (STA-4114). This deliberately does NOT restore the rows retirement dropped;
+    // those are genuinely stale. It only re-opens the pane to future status.
+    restoreAgentPaneAuthority: (paneKey) => {
+      const ownerPaneKey = resolveAgentPaneAuthorityKey(paneKey)
+      // Why: a closed tab is a stronger, separate claim — re-attach must not undo it.
+      if (
+        isRecentlyClosedAgentStatusTab(
+          get().recentlyClosedAgentStatusTabIds,
+          getTabIdFromPaneKey(ownerPaneKey)
+        )
+      ) {
+        return
+      }
+      set((s) => {
+        const restorable = [paneKey, ownerPaneKey].filter(
+          (key) => key in s.recentlyRetiredAgentStatusPaneKeys
+        )
+        if (restorable.length === 0) {
+          return s
+        }
+        const next = { ...s.recentlyRetiredAgentStatusPaneKeys }
+        for (const key of restorable) {
+          delete next[key]
+        }
+        return { recentlyRetiredAgentStatusPaneKeys: next }
+      })
+      if (typeof window !== 'undefined') {
+        window.api?.agentStatus?.restorePaneAuthority?.(ownerPaneKey)
       }
     },
 

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -942,6 +942,7 @@ function createWebPreloadApi(): Partial<PreloadApi> {
       drop: () => {},
       dropByTabPrefix: () => {},
       retirePaneAuthority: () => {},
+      restorePaneAuthority: () => {},
       transferPaneAuthority: () => {}
     },
     mobile: {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​421 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​421 |
| Prod | 9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​170 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​170 |

<!-- /orca-pr-loc -->

## ELI5

When a terminal pane is detached and re-attached, Orca had written down "this pane is gone" in two places and never crossed it out. Pi kept running fine in the same PTY, but every status update it sent was thrown away forever. Now the note gets crossed out the moment a live PTY re-attaches to the pane — because that is the moment it stops being true.

## What Changed

Two independent tombstones both survived the re-attach, so a fix on either side alone still leaves the other suppressing. Both are now lifted at re-attach:

- **Main:** new `AgentHookServer.restorePaneAuthority(paneKey)` clears `closedAgentStatusPaneKeys` for the pane and its resolved owner alias.
- **Renderer:** new `restoreAgentPaneAuthority(paneKey)` store action clears `recentlyRetiredAgentStatusPaneKeys`, and forwards to main over a new `agentStatus:restorePaneAuthority` channel (preload + web-preload stub wired to match the existing retire path).
- **Call sites:** the spawn/attach chokepoint (`bindActivePanePty`) and the daemon-backed reattach path in `pty-connection.ts`, which inlines its own bind rather than calling the chokepoint — that second one is the exact path in this report.
- Closed-**tab** tombstones are explicitly preserved on both sides.

## Why

Retirement is a *claim*: "this pane is gone." Binding a live PTY to that exact pane is *proof the claim is false*, available at the precise moment it stops being true. So the fence lifts on that proof.

**The question this PR has to answer: is reviving on a live new turn sufficient, or should re-attach itself clear the tombstone? Re-attach itself — reactive revival is not sufficient.** Turn-triggered revival infers pane liveness from a downstream symptom, and the inference has a gap the authoritative signal does not:

1. **Re-attached mid-turn.** The agent is already running. Its remaining events are `agent_end`, not a new-turn event — so nothing revives the pane, and the turn's completion checkmark never lands. If that turn runs for twenty minutes, the pane reads dead for twenty minutes.
2. **Re-attached while idle.** No new-turn event is ever emitted. Under turn-triggered revival the pane stays suppressed indefinitely — the reported bug in a narrower form.
3. `before_agent_start` is the only pi/omp/prime-agent new-turn event (`isNewTurnEvent`, `agent-hook-listener.ts:2421`). Every other pi lifecycle event a re-attached pane emits stays suppressed.

Waiting for a hook to prove what the attach already proved is the same shape as the spinner bug in #14618: the fact was available at a lifecycle boundary, and the code chose to rediscover it later from a symptom. Bind to the boundary.

This is also the contract the codebase already uses elsewhere — `server.ts` clears `closedAgentStatusPaneKeys` when a pane key migrates to a new owner (the alias-transfer path). Authoritative re-binding already lifts the fence there; the detach/reattach path simply never got wired up. This PR makes the two consistent.

**On the alternative in #14560** (revive on a live new turn): its instinct is right and its supporting work is genuinely good — reusing the shared source-aware `isNewTurnEvent` instead of the hardcoded Claude predicate, and splitting classification from mutation in `getAgentStatusDisposition` so a remote envelope that later fails payload validation cannot desync main from renderer (a race this report did not identify). But it is the wrong *primary* contract for the reasons above, and it carries a compatibility risk worth flagging: its new guard requires `event.source !== undefined`, while `source` is optional on the payload type (`agent-hook-listener.ts:329`). A source-less remote envelope that previously restarted a retired pane would now suppress — its own test diff had to add `source: 'claude'` to three previously source-less `ingestRemote` calls. Per `docs/reference/remote-wire-compatibility.md` that is a mixed-version concern.

**This PR does not supersede #14560.** It deliberately does not touch `getAgentStatusDisposition`'s event predicate, so the two are orthogonal: proactive clearing is the primary contract, and a live-new-turn revival remains a reasonable secondary net for panes whose re-attach one side never observed (a remote relay, or main restarted without a renderer re-attach). If #14560 lands, the `source`-optional guard should be resolved first.

**Deliberate non-goal:** restoring does *not* bring back the rows retirement dropped — those are genuinely stale. It only re-opens the pane to future status.

## Linked Issue

Fixes #14236

## Visual Proof

N/A — no UI surface changed. The visible effect is that an existing surface (the working spinner / completion checkmark on a re-attached Pi pane) stops being suppressed. Capturing it needs a live detach/reattach of a running Pi process, which I could not stage here (see Testing).

## Testing

**Limitation stated plainly: the pi CLI is not installed on this machine, so this was fixed without a live reproduction.** I did not observe the suppression or the fix in a running Pi pane and am not claiming otherwise. The manual-testing box below is unchecked.

To compensate, every new assertion was proven non-vacuous by mutating the source and confirming the test fails:

- **Neutered the restore on both sides** (kept the API, made it a no-op): **7 of 9 tests fail** — all three pi/omp/prime-agent re-attach tests, the idle re-attach test, and the three renderer tests. The two closed-tab tests correctly still pass, which is the right signature for negative tests.
- **Removed the closed-tab guards:** the remaining **2 tests fail** — one per side. So all 9 are behavioral.
- **Removed the `pty-connection.ts` call sites:** the reattach wiring assertion fails, confirming the attach path really is what lifts the fence.

Coverage, main (`server.test.ts`): re-attach restores status without a new turn for **pi, omp, and prime-agent** (each posts to its own `/hook/<kind>` and asserts `agent_end` alone is suppressed while retired, then accepted after restore); re-attach while **idle** re-opens the pane for a much later first turn; re-attach lifts neither the pane nor tab fence once the tab is closed.

Coverage, renderer (`agent-pane-authority.test.ts`): fence lifts so an in-flight turn can still report `done`; idle re-attach re-opens for a later turn; closed-tab tombstone is not lifted and main is not notified; sibling panes stay fenced when one pane is restored.

- `vitest run src/main/agent-hooks/server.test.ts src/renderer/src/store/slices/ src/renderer/src/hooks/useIpcEvents.test.ts` — 2699 + 302 passed.
- `vitest run src/renderer/src/components/terminal-pane/pty-connection.test.ts` — 579 passed.
- `pnpm run typecheck:node` and `pnpm run typecheck:web` — both pass. The third project was deliberately not run (OOM risk on this machine); no CLI code changed.
- `oxlint` + `oxfmt` on all changed files, plus pre-commit hooks including React Doctor — clean.

One robustness note found *by* the tests: the attach path treats a throw here as a failed reattach ("Reattach FAILED"), so the store call is an optional call — a status side effect must never be able to break terminal attach.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated

## AI Disclosure

<!-- internal contributor -->

## Review

- **Security:** the new IPC channel validates its pane key with the same `isValidPaneKey` guard as the existing retire channel, and can only *narrow* suppression for a pane the renderer is actively binding. It cannot resurrect a closed tab.
- **Cross-platform:** no path, shell, or platform-dependent logic; pure in-memory state plus one IPC message.
- **Remote SSH:** no wire fields changed on the client/host relay, so no mixed-version exposure. The web preload gets a no-op stub matching how `retirePaneAuthority` already behaves there.
- **Mobile:** N/A — no mobile surface touched.
- **Backwards compatibility:** additive. `closedAgentStatusPaneKeys` is in-memory only (never persisted or hydrated), so there is no stored state to migrate.
- **Performance:** two set/record deletions on an attach that already does substantially more work; the renderer action returns the existing object identity when there is nothing to clear, so it cannot churn subscribers.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — scoped checks passed (see Testing); full suites left to CI

## Author

- X / Twitter: @BrennanKB5
