### PR TITLE
fix(agent-hooks): detect IDS-truncated hook POSTs instead of failing open silently (STA-2870)

### DIFF
--- a/src/main/agent-hooks/server-transport-interference.test.ts
+++ b/src/main/agent-hooks/server-transport-interference.test.ts
@@ -1,0 +1,156 @@
+// Reproduces #11217's mechanism without an IDS: an authenticated hook POST whose body is cut
+// short of its own Content-Length. The listener fails open on every request error, so the only
+// way this stays diagnosable is if the truncation is classified before it is swallowed.
+import { connect } from 'node:net'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { HookTransportInterferenceReport } from '../../shared/agent-hook-transport-interference'
+import { AgentHookServer } from './server'
+
+async function postTruncatedHook(
+  port: number,
+  token: string,
+  options: { pathname?: string; sentBytes?: string; announcedLength?: number } = {}
+): Promise<void> {
+  const {
+    pathname = '/hook/claude',
+    sentBytes = 'paneKey=tab',
+    announcedLength = 100_000
+  } = options
+  await new Promise<void>((resolve, reject) => {
+    const socket = connect({ port, host: '127.0.0.1' }, () => {
+      socket.write(
+        `POST ${pathname} HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/x-www-form-urlencoded\r\nX-Orca-Agent-Hook-Token: ${token}\r\nContent-Length: ${announcedLength}\r\n\r\n${sentBytes}`
+      )
+      // Why: an RST mid-body is what an inspecting IDS does; a FIN would be an ordinary client hangup.
+      setTimeout(() => {
+        socket.resetAndDestroy()
+        resolve()
+      }, 20)
+    })
+    socket.on('error', () => {
+      resolve()
+    })
+    socket.setTimeout(2_000, () => {
+      socket.destroy()
+      reject(new Error('truncated post never connected'))
+    })
+  })
+  // Why: the server settles the request on 'close', which lands a tick after the client's reset.
+  await new Promise((resolve) => setTimeout(resolve, 50))
+}
+
+/** Opens a POST that announces a body and then never sends it, so Orca's own slowloris cap ends it. */
+async function postStalledHook(port: number, token: string): Promise<void> {
+  const socket = connect({ port, host: '127.0.0.1' })
+  await new Promise<void>((resolve) => socket.on('connect', () => resolve()))
+  socket.write(
+    `POST /hook/claude HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/x-www-form-urlencoded\r\nX-Orca-Agent-Hook-Token: ${token}\r\nContent-Length: 100000\r\n\r\n`
+  )
+  await new Promise<void>((resolve) => {
+    socket.on('close', () => resolve())
+    socket.on('error', () => resolve())
+  })
+  await new Promise((resolve) => setTimeout(resolve, 50))
+}
+
+async function postCompleteHook(port: number, token: string): Promise<void> {
+  const body = 'paneKey=tab%3Aleaf&payload=%7B%7D'
+  const response = await fetch(`http://127.0.0.1:${port}/hook/claude`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'X-Orca-Agent-Hook-Token': token
+    },
+    body
+  })
+  expect(response.status).toBe(204)
+}
+
+describe('AgentHookServer transport interference', () => {
+  const servers: AgentHookServer[] = []
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+  afterEach(() => {
+    for (const server of servers) {
+      server.stop()
+    }
+    servers.length = 0
+    warn.mockClear()
+  })
+
+  async function startServer(): Promise<{
+    server: AgentHookServer
+    port: number
+    token: string
+    reports: HookTransportInterferenceReport[]
+  }> {
+    const server = new AgentHookServer()
+    servers.push(server)
+    const reports: HookTransportInterferenceReport[] = []
+    server.setTransportInterferenceListener((report) => {
+      reports.push(report)
+    })
+    await server.start()
+    const env = server.buildPtyEnv()
+    return {
+      server,
+      port: Number(env.ORCA_AGENT_HOOK_PORT),
+      token: env.ORCA_AGENT_HOOK_TOKEN,
+      reports
+    }
+  }
+
+  it('reports once after repeated truncated POSTs and names the route', async () => {
+    const { port, token, reports } = await startServer()
+
+    await postTruncatedHook(port, token)
+    await postTruncatedHook(port, token)
+    expect(reports).toEqual([])
+
+    await postTruncatedHook(port, token, { pathname: '/hook/codex' })
+    expect(reports).toEqual([
+      { count: 3, source: 'codex', bytesRead: expect.any(Number), contentLength: 100_000 }
+    ])
+    expect(warn.mock.calls.flat().join(' ')).toContain('security software')
+
+    // Why: warn-once — a blocked fleet must not turn every hook event into a log line.
+    await postTruncatedHook(port, token)
+    expect(reports).toHaveLength(1)
+  }, 20_000)
+
+  it('never reports for POSTs that deliver their whole body', async () => {
+    const { port, token, reports } = await startServer()
+
+    for (let i = 0; i < 5; i++) {
+      await postCompleteHook(port, token)
+    }
+
+    expect(reports).toEqual([])
+  }, 20_000)
+
+  it('excludes requests the slowloris cap destroyed, so the count stays honest', async () => {
+    const { port, token, reports } = await startServer()
+
+    await postTruncatedHook(port, token)
+    await postTruncatedHook(port, token)
+    // Why: Orca destroys this one itself at HOOK_REQUEST_SLOWLORIS_MS; counting it would make
+    // every stalled agent look like an IDS block.
+    await postStalledHook(port, token)
+    expect(reports).toEqual([])
+
+    await postTruncatedHook(port, token)
+    expect(reports).toHaveLength(1)
+    expect(reports[0].count).toBe(3)
+  }, 30_000)
+
+  it('never reports for unauthenticated probes', async () => {
+    const { port, reports } = await startServer()
+
+    // Why: a port scanner is not interference; only a request that cleared the token check can be.
+    await postTruncatedHook(port, 'wrong-token')
+    await postTruncatedHook(port, 'wrong-token')
+    await postTruncatedHook(port, 'wrong-token')
+
+    expect(reports).toEqual([])
+  }, 20_000)
+})

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -41,6 +41,12 @@ import {
   type HookListenerState
 } from '../../shared/agent-hook-listener'
 import {
+  createHookTransportInterferenceTracker,
+  describeHookTransportInterference,
+  isHookRequestTruncatedError,
+  type HookTransportInterferenceReport
+} from '../../shared/agent-hook-transport-interference'
+import {
   claudeTeammateIdMatchesName,
   claudeRosterHasRestoredSnapshotSubagent,
   claudeRosterHasWorkingSubagent,
@@ -683,6 +689,11 @@ export class AgentHookServer {
   private endpointFileWritten = false
   // Why: per-instance (not module-level) so tests can spin up multiple servers without state cross-contamination.
   private state: HookListenerState = createHookListenerState()
+  private onTransportInterference: ((report: HookTransportInterferenceReport) => void) | null = null
+  private transportInterference = createHookTransportInterferenceTracker((report) => {
+    console.warn(describeHookTransportInterference(report))
+    this.onTransportInterference?.(report)
+  })
   // Why: hydrated rows give UI continuity but aren't evidence of live agent work in this runtime.
   private runtimeObservedStatusPaneKeys = new Set<string>()
   private hydratedAuthorityCommitments: readonly AgentHookAuthorityEvidence[] = Object.freeze([])
@@ -706,6 +717,17 @@ export class AgentHookServer {
   private connectionTimestampWatermarkById = new Map<string, number>()
   // Why: skip disk writes when the JSON exactly matches the last write; guards against re-firing trailing timers when nothing changed.
   private lastWrittenJson: string | null = null
+
+  /**
+   * Notified once per process when repeated hook POSTs are cut off mid-body (#11217).
+   * Why: the listener fails open on every request error, so without this the only symptom is
+   * agent status quietly going stale — for every runtime at once, since they share this transport.
+   */
+  setTransportInterferenceListener(
+    listener: ((report: HookTransportInterferenceReport) => void) | null
+  ): void {
+    this.onTransportInterference = listener
+  }
 
   setListener(listener: ((payload: EnrichedAgentHookEventPayload) => void) | null): void {
     this.onAgentStatus = listener
@@ -2251,13 +2273,16 @@ export class AgentHookServer {
       }
 
       // Why: bound request time so a stalled client can't hold a socket open (slowloris).
+      // Why: track our own destroy so the slowloris cap can't be misread as outside interference.
+      let destroyedBySlowlorisCap = false
       req.setTimeout(HOOK_REQUEST_SLOWLORIS_MS, () => {
+        destroyedBySlowlorisCap = true
         req.destroy()
       })
 
+      const pathname = new URL(req.url ?? '/', 'http://127.0.0.1').pathname
       try {
         const body = await readRequestBody(req)
-        const pathname = new URL(req.url ?? '/', 'http://127.0.0.1').pathname
         if (pathname === CLAUDE_STATUSLINE_PATHNAME) {
           const statusLineEvent = parseClaudeStatusLineBody(body)
           if (statusLineEvent) {
@@ -2296,7 +2321,13 @@ export class AgentHookServer {
 
         res.writeHead(204)
         res.end()
-      } catch {
+      } catch (error) {
+        // Why (#11217): an authenticated POST whose body dies short of its own Content-Length was cut
+        // by something on the loopback path, not by a bad payload. Fail open as before, but count it —
+        // this is the one failure mode that silently stops status for every runtime at once.
+        if (isHookRequestTruncatedError(error) && !destroyedBySlowlorisCap) {
+          this.transportInterference.record({ source: resolveHookSource(pathname) ?? null, error })
+        }
         // Why: fail open — return success on malformed payloads so a broken hook never blocks the agent.
         res.writeHead(204)
         res.end()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -998,6 +998,12 @@ function startTerminalRuntimeStartupServices(): WindowsDesktopStartupServices {
         return
       }
       logStartupMilestone('startup-service-start', { service: 'agent-hook-server' })
+      // Why (#11217): the hook listener fails open on every request error, so an IDS resetting
+      // loopback POSTs mid-body stops agent status for every runtime with no symptom but staleness.
+      // Log + telemetry (the daemon_start_failed pattern) so it is diagnosable without a packet capture.
+      agentHookServer.setTransportInterferenceListener((report) => {
+        track('agent_hook_transport_blocked', { count: report.count })
+      })
       await agentHookServer.start({
         env: app.isPackaged ? 'production' : 'development',
         // Why: hooks source this endpoint file at invocation time so old PTY env reaches the current process after restart; dev namespaces it (worktrees share `orca-dev`).

--- a/src/relay/agent-hook-server.ts
+++ b/src/relay/agent-hook-server.ts
@@ -23,6 +23,11 @@ import {
   type HookListenerState
 } from '../shared/agent-hook-listener'
 import {
+  createHookTransportInterferenceTracker,
+  describeHookTransportInterference,
+  isHookRequestTruncatedError
+} from '../shared/agent-hook-transport-interference'
+import {
   REMOTE_AGENT_HOOK_ENV,
   type AgentHookRelayEnvelope,
   type AgentHookSource
@@ -62,6 +67,9 @@ export class RelayAgentHookServer {
   private endpointFilePath: string
   private endpointFileWritten = false
   private state: HookListenerState = createHookListenerState()
+  private transportInterference = createHookTransportInterferenceTracker((report) => {
+    process.stderr.write(`${describeHookTransportInterference(report)}\n`)
+  })
   // Why: retain envelope metadata so replays match live POSTs.
   // Invariant: keys mirror state.lastStatusByPaneKey, populated/cleared in lockstep.
   private lastEnvelopeMetaByPaneKey = new Map<
@@ -225,7 +233,10 @@ export class RelayAgentHookServer {
       res.end()
       return
     }
+    // Why: track our own destroy so the slowloris cap can't be misread as outside interference.
+    let destroyedBySlowlorisCap = false
     req.setTimeout(HOOK_REQUEST_SLOWLORIS_MS, () => {
+      destroyedBySlowlorisCap = true
       req.destroy()
     })
     try {
@@ -252,6 +263,11 @@ export class RelayAgentHookServer {
       res.writeHead(204)
       res.end()
     } catch (err) {
+      // Why (#11217): a remote host can run the same IDS; count truncations here so a blocked SSH
+      // relay reports the cause instead of an anonymous "hook request failed".
+      if (isHookRequestTruncatedError(err) && !destroyedBySlowlorisCap) {
+        this.transportInterference.record({ source: null, error: err })
+      }
       // Why: hooks fail open (204 on any error) so a buggy agent never blocks the run; still log so the 204 doesn't mask bugs.
       process.stderr.write(
         `[relay-hook-server] hook request failed: ${err instanceof Error ? err.message : String(err)}\n`

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -76,6 +76,7 @@ import {
   resolveGrokSessionsDir
 } from './grok-session-paths'
 import { sweepStaleAgentHookEndpointTemps } from './agent-hook-endpoint-temp-cleanup'
+import { classifyTruncatedHookRequest } from './agent-hook-transport-interference'
 import { assertJsonTextStructureWithinLimits } from './json-text-structure-limit'
 
 /** Maximum request body size accepted by the listener (1 MB). */
@@ -534,12 +535,20 @@ export function readRequestBody(req: IncomingMessage): Promise<unknown> {
         settleReject(error)
       }
     }
+    // Why (#11217): a body cut short of its own Content-Length is the fingerprint of an IDS
+    // resetting the connection mid-inspection. Classify on every path that ends the request without
+    // 'end' — a peer RST surfaces as 'error' (ECONNRESET) and only a local destroy reaches 'close' first.
+    const settleUnfinished = (fallback: Error): void => {
+      settleReject(
+        classifyTruncatedHookRequest(req.headers['content-length'], byteLength) ?? fallback
+      )
+    }
     const onError = (err: Error): void => {
-      settleReject(err)
+      settleUnfinished(err)
     }
     // Why: req.destroy() (slowloris timer) emits 'close' but not 'end'/'error'; without this the promise never settles and buffers leak.
     const onClose = (): void => {
-      settleReject(new Error('aborted'))
+      settleUnfinished(new Error('aborted'))
     }
     req.on('data', onData)
     req.on('end', onEnd)

--- a/src/shared/agent-hook-transport-interference.test.ts
+++ b/src/shared/agent-hook-transport-interference.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  classifyTruncatedHookRequest,
+  createHookTransportInterferenceTracker,
+  describeHookTransportInterference,
+  HookRequestTruncatedError,
+  isHookRequestTruncatedError
+} from './agent-hook-transport-interference'
+
+describe('classifyTruncatedHookRequest', () => {
+  it('reports truncation when fewer bytes arrived than Content-Length promised', () => {
+    const error = classifyTruncatedHookRequest('4096', 512)
+    expect(isHookRequestTruncatedError(error)).toBe(true)
+    expect(error).toMatchObject({ bytesRead: 512, contentLength: 4096 })
+  })
+
+  it('reports truncation when the connection died before any body byte', () => {
+    expect(classifyTruncatedHookRequest('4096', 0)).toBeInstanceOf(HookRequestTruncatedError)
+  })
+
+  it('stays silent for a complete body', () => {
+    expect(classifyTruncatedHookRequest('512', 512)).toBeNull()
+  })
+
+  it('stays silent without a usable Content-Length', () => {
+    // Why: chunked bodies and malformed headers prove nothing — reporting them would drown the signal.
+    expect(classifyTruncatedHookRequest(undefined, 10)).toBeNull()
+    expect(classifyTruncatedHookRequest('', 10)).toBeNull()
+    expect(classifyTruncatedHookRequest('not-a-number', 10)).toBeNull()
+  })
+
+  it('reads the first value when the header arrives duplicated', () => {
+    expect(classifyTruncatedHookRequest(['4096', '4096'], 12)).toBeInstanceOf(
+      HookRequestTruncatedError
+    )
+  })
+})
+
+describe('createHookTransportInterferenceTracker', () => {
+  const truncation = { source: 'claude', error: new HookRequestTruncatedError(10, 900) }
+
+  it('stays quiet below the threshold so a single crashed writer is not an alarm', () => {
+    const onThreshold = vi.fn()
+    const tracker = createHookTransportInterferenceTracker(onThreshold, 3)
+    tracker.record(truncation)
+    tracker.record(truncation)
+    expect(onThreshold).not.toHaveBeenCalled()
+    expect(tracker.getCount()).toBe(2)
+  })
+
+  it('reports exactly once at the threshold and keeps counting after', () => {
+    const onThreshold = vi.fn()
+    const tracker = createHookTransportInterferenceTracker(onThreshold, 3)
+    for (let i = 0; i < 6; i++) {
+      tracker.record(truncation)
+    }
+    expect(onThreshold).toHaveBeenCalledTimes(1)
+    expect(onThreshold).toHaveBeenCalledWith({
+      count: 3,
+      source: 'claude',
+      bytesRead: 10,
+      contentLength: 900
+    })
+    expect(tracker.getCount()).toBe(6)
+  })
+
+  it('re-arms after reset', () => {
+    const onThreshold = vi.fn()
+    const tracker = createHookTransportInterferenceTracker(onThreshold, 1)
+    tracker.record(truncation)
+    tracker.reset()
+    tracker.record(truncation)
+    expect(onThreshold).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('describeHookTransportInterference', () => {
+  it('names the cause and the consequence so the log line is actionable', () => {
+    const message = describeHookTransportInterference({
+      count: 3,
+      source: 'codex',
+      bytesRead: 10,
+      contentLength: 900
+    })
+    expect(message).toContain('/hook/codex')
+    expect(message).toContain('10/900 bytes')
+    expect(message).toContain('security software')
+    // Why: the client's own --max-time can truncate too; a single-cause message would misdiagnose a stall.
+    expect(message).toContain('stalled past the hook client timeout')
+  })
+
+  it('omits the route when the truncation happened before it resolved', () => {
+    const message = describeHookTransportInterference({
+      count: 3,
+      source: null,
+      bytesRead: 0,
+      contentLength: 900
+    })
+    expect(message).not.toContain('/hook/')
+  })
+})

--- a/src/shared/agent-hook-transport-interference.ts
+++ b/src/shared/agent-hook-transport-interference.ts
@@ -1,0 +1,105 @@
+// Transport background and the allowlisting answer for security teams: docs/reference/agent-hook-transport.md
+//
+// Why (#11217): enterprise IDS/AV products inspect loopback HTTP bodies and reset the hook POST
+// mid-flight when the agent's own tool I/O happens to match an LFI/command-injection signature.
+// The listener fails open on every error, so a reset arrives as a swallowed exception and agent
+// status stops with no diagnostic anywhere. Classifying the truncation is what makes it reportable.
+
+/** Thrown by the listener when a request closed before `end` with fewer bytes than `Content-Length` promised. */
+export class HookRequestTruncatedError extends Error {
+  readonly bytesRead: number
+  readonly contentLength: number
+
+  constructor(bytesRead: number, contentLength: number) {
+    super(`hook request truncated after ${bytesRead} of ${contentLength} bytes`)
+    this.name = 'HookRequestTruncatedError'
+    this.bytesRead = bytesRead
+    this.contentLength = contentLength
+  }
+}
+
+export function isHookRequestTruncatedError(error: unknown): error is HookRequestTruncatedError {
+  return error instanceof HookRequestTruncatedError
+}
+
+/**
+ * Truncation is only interference when Orca did not cause it. `Content-Length` must be present and
+ * unmet: a chunked body or a completed one proves nothing, and reporting those would make the
+ * signal useless.
+ */
+export function classifyTruncatedHookRequest(
+  contentLengthHeader: string | string[] | undefined,
+  bytesRead: number
+): HookRequestTruncatedError | null {
+  const raw = Array.isArray(contentLengthHeader) ? contentLengthHeader[0] : contentLengthHeader
+  if (!raw || !/^\d+$/.test(raw.trim())) {
+    return null
+  }
+  const contentLength = Number(raw.trim())
+  return bytesRead < contentLength ? new HookRequestTruncatedError(bytesRead, contentLength) : null
+}
+
+/** Why: one truncation can be a crashed agent mid-write; a repeat is a device on the loopback path. */
+export const HOOK_TRANSPORT_INTERFERENCE_THRESHOLD = 3
+
+export type HookTransportInterferenceReport = {
+  /** Total authenticated-but-truncated hook POSTs observed since start. */
+  count: number
+  /** The hook route of the most recent truncation, when the URL resolved to one. */
+  source: string | null
+  bytesRead: number
+  contentLength: number
+}
+
+export type HookTransportInterferenceTracker = {
+  record: (detail: { source: string | null; error: HookRequestTruncatedError }) => void
+  getCount: () => number
+  reset: () => void
+}
+
+/**
+ * Counts truncated hook POSTs and reports exactly once, at `threshold`. Counting continues after
+ * the report so a diagnostics reader can still see the magnitude without re-notifying per event.
+ */
+export function createHookTransportInterferenceTracker(
+  onThresholdReached: (report: HookTransportInterferenceReport) => void,
+  threshold: number = HOOK_TRANSPORT_INTERFERENCE_THRESHOLD
+): HookTransportInterferenceTracker {
+  let count = 0
+  let reported = false
+  return {
+    record: ({ source, error }) => {
+      count += 1
+      if (reported || count < threshold) {
+        return
+      }
+      reported = true
+      onThresholdReached({
+        count,
+        source,
+        bytesRead: error.bytesRead,
+        contentLength: error.contentLength
+      })
+    },
+    getCount: () => count,
+    reset: () => {
+      count = 0
+      reported = false
+    }
+  }
+}
+
+/**
+ * Shared operator-facing text. Names the likely cause first but not exclusively: the hook client's
+ * own `--max-time` can also cut a body if this process stalls, and claiming certainty would send a
+ * user to their IT department over a main-thread hang.
+ */
+export function describeHookTransportInterference(report: HookTransportInterferenceReport): string {
+  return (
+    `[agent-hooks] ${report.count} agent-status POSTs were cut off mid-body on loopback ` +
+    `(last: ${report.bytesRead}/${report.contentLength} bytes${report.source ? `, /hook/${report.source}` : ''}). ` +
+    'Agent status will be missing for every runtime until this stops. Most likely local network ' +
+    'security software is inspecting and blocking loopback HTTP; less likely, this process stalled ' +
+    'past the hook client timeout. See docs/reference/agent-hook-transport.md.'
+  )
+}

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -781,6 +781,11 @@ const agentHookUnattributedSchema = z
   .object({ reason: z.enum(['empty_pane_key', 'unknown_tab_id']) })
   .strict()
 
+// Why (#11217): loopback hook POSTs reset mid-body by local security software kill agent status for
+// every runtime at once. Count only — the truncated bodies carry user prompts and tool I/O, so
+// nothing derived from them may reach the wire.
+const agentHookTransportBlockedSchema = z.object({ count: z.number().int().nonnegative() }).strict()
+
 // ── Onboarding ──────────────────────────────────────────────────────────
 // Closed enums only — no raw paths/repo names/URLs/error strings (measures activation, not repo debugging).
 // Why: event names still carry legacy seven-step payloads; keep validation backward-compatible for old rows.
@@ -1444,6 +1449,7 @@ export const eventSchemas = {
   agent_error: agentErrorSchema,
   agent_hook_install_failed: agentHookInstallFailedSchema,
   agent_hook_unattributed: agentHookUnattributedSchema,
+  agent_hook_transport_blocked: agentHookTransportBlockedSchema,
 
   daemon_start_failed: daemonStartFailedSchema,
   main_thread_hang_detected: mainThreadHangDetectedSchema,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​257 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​257 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​177 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​173 |

<!-- /orca-pr-loc -->

## ELI5

Orca's agent status arrives over a tiny local web server. Some corporate antivirus reads that
traffic, decides the developer's own `grep "/etc/passwd"` looks like an attack, and kills the
connection. Orca is built to never let a broken hook wedge an agent, so it shrugs off the failure —
and status silently dies in every pane, for every agent. This PR makes Orca notice, and writes down
the answer for security teams. It does not change the transport; the analysis below says why not,
and what the real fix costs.

## What Changed

- `src/shared/agent-hook-transport-interference.ts` (new): classifies a hook POST that clears the
  auth check and then ends short of its own `Content-Length`, plus a warn-once tracker.
- `readRequestBody` now types that case instead of rejecting with an anonymous `aborted`. It
  classifies on `error` *and* `close` — a peer RST surfaces as `ECONNRESET` on `error` first, which
  is what actually happens here (the first draft only handled `close` and caught nothing).
- `AgentHookServer` and the SSH relay's listener count them and report once at 3, excluding
  requests Orca destroyed itself via the slowloris cap and requests that never passed the token check.
- `agent_hook_transport_blocked` telemetry: **count only**. The truncated bodies carry prompts and
  tool output, so nothing derived from them goes on the wire.
- `docs/reference/agent-hook-transport.md` (new): what the traffic is, why it trips signatures, and
  the exact allowlist to hand IT — the doc STA-1284 asked for.

Everything still fails open: same `204`, same behavior for agents.

---

# Analysis

## 1. What does the IDS actually object to?

**Supported by evidence: the body content, read out of loopback HTTP.** #11217 pins one detection
byte-for-byte. `Attack.LocalFileInclusion.1` fired at 2026-07-28 15:40:45Z against a `PreToolUse`
for a Bash call whose pattern was `/etc/passwd\|/proc/self\|php://\|file:///[a-zA-Z]\{0,20\}`. Four
canonical LFI tokens in one request body — the user's own search string. 25 detections in 8 days on
a host with zero in the prior 21 months.

**Also supported, as an amplifier: the URL-encoding.** `--data-urlencode` turns `../../../` into
`..%2F..%2F..%2F`, which scores higher on LFI signatures than raw `../`. 14 of 25 detections were
`Attack.LocalFileInclusion.*`, consistent with encoded-traversal being the dominant trigger.

**Not supported: "unauthenticated-looking POST."** STA-1284 frames it that way, and it is wrong on
the facts. Every request carries `X-Orca-Agent-Hook-Token`; `server.ts` `403`s a mismatch before
reading the body. The AV matched a signature, it did not flag missing auth.

**Not supported: the TCP connection itself.** If the connection were blocked on reputation or
destination, it would be blocked always. It fires on specific bodies and only on specific bodies.

The distinction that matters: (1) survives any encoding, (2) does not. **Anything that keeps the
bodies inside an HTTP-over-TCP flow leaves an inspector reading the developer's commands and files,
and it will keep matching.** That is the load-bearing conclusion for the options below.

**Speculative, stated as such:** that the reset reaches Node at all. To match on a body, the
inspector must have let the body flow, so it must reset an established connection — which is what
this PR's detector keys on. But a product that blacklists the flow after the first hit could refuse
at SYN afterwards, and then Orca observes nothing. The detector catches the first occurrences,
which is enough to raise the flag; it is not a complete oracle, and the doc says so.

## 2. Options

### A. JSON bodies instead of form-urlencoded (#11292)

Kills the `..%2F` amplifier. Does **not** stop the confirmed detection — `/etc/passwd`, `php://`,
`file:///` are literal in JSON too.

- Cross-platform: fine, no new dependency.
- Agent scripts: they change, but they are Orca-generated, and the server has accepted
  `application/json` since before this PR (`agent-hook-listener.ts` content-type branch), so old
  scripts keep working.
- Wire: #11292 moves `paneKey`/`tabId`/`launchToken` into **headers**. A new POSIX script talking to
  an **older SSH relay** would have those dropped — Rule 3 skew, worth a look on that PR
  specifically. #11292 scopes itself to Claude/Codex POSIX, leaving 16 routes and all of Windows
  form-encoded.

**Verdict: complementary, and worth landing — but it is a partial mitigation and should not be
described as fixing #11217.** It is not superseded by anything here; the two do not overlap.

### B. Unix domain socket / named pipe

The reporter's suggestion, and the only option that actually removes the traffic from HTTP
inspection scope. `curl --unix-socket` is curl ≥ 7.40 and present on macOS system curl and every
mainstream Linux.

**Windows is the problem, and "use named pipes" does not solve it.** Node on Windows maps
`listen(path)` to a named pipe; it cannot listen on an `AF_UNIX` socket file. `curl.exe`
`--unix-socket` speaks `AF_UNIX` and cannot open a named pipe. So there is no
`Node-listens` / `curl-connects` pairing on Windows — it needs a PowerShell client, which is the
~300 ms per-hook startup cost the codebase deliberately removed (`installer-utils.ts`), or it keeps
TCP. **WSL is a second hole**: a guest-side hook cannot reach a Windows-host socket path, so the
relay keeps TCP regardless.

Cost, honestly: dual-listen on the server, a new endpoint-file field, ~11 hook-service script
builders, the WSL relay, the SSH remote installers, plus the macOS 104-byte `sun_path` limit against
namespaced dev userData paths. Then QA across macOS / Linux / SSH / WSL / Windows.

- Wire: additive if done right. A new optional `ORCA_AGENT_HOOK_SOCKET` in the endpoint file is
  Rule 1 — `parseAgentHookEndpointFile` already ignores unknown keys. No stream opcode, so Rule 2
  does not apply. But an old installed script on a remote host keeps posting TCP, so **the TCP
  listener can never be removed**, only de-preferred.

**Verdict: correct direction, wrong size for one PR, and it collides head-on with #7282**, which is
already rewriting every one of those script builders. Sequencing it after #7282 lands is not
optional — doing it now guarantees a conflict in Brennan's own open PR.

### C. Reuse OSC 9999 in-band

`src/shared/agent-status-osc.ts` is real and Orca parses it on every PTY before xterm with no agent
gate. It is not a substitute here:

- Hooks are separate processes. Reaching the pane's PTY means writing to `/dev/tty`, which requires
  a controlling terminal — headless, background, and orchestration-dispatched agents have none.
- Claude appends hook **stdout** to the prompt context, which is why #7282 keeps the Claude hook
  silent on stdout. Emitting status there is the wrong channel by construction.
- The parser is a 64 KB-bounded status channel. Hook payloads are capped at 1 MB and carry tool
  responses; they are a different order of data and get per-provider normalization the OSC shape has
  no room for.

**Verdict: not an alternative transport for the 18 hook routes. It is a native status channel for
runtimes that emit it themselves. Correctly identified as relevant; it does not solve this.**

### D. Auth headers

Already implemented. It cannot help: the IDS matched content, not credentials. **Rejected as a
non-answer**, and worth writing down so it stops being proposed.

### E. Base64 the payload field (not in the brief; enumerated and rejected)

Would defeat every signature, is a two-line script change, and is the **wrong** answer. It is
literally detection evasion — the shape malware uses — many products score opaque bodies as
suspicious on their own, and it takes the traffic away from a control the enterprise is entitled to
run. "We obfuscated our payloads" is a worse position with a security team than "we moved off the
network stack." Rejected on principle, not on cost.

## 3. Recommendation

**Ship the detector now (this PR). Sequence the unix-socket transport (B) after #7282 lands, as its
own PR. Land #11292 (A) on its own merits, described as a partial mitigation.**

The reasoning: #11217 names its own user-visible bug, and it is not the encoding —

> "Silent functional loss. `|| true` swallows the blocked POST. Agent status in Orca goes stale with
> no diagnostic. **This is the user-visible bug.**"

Fail-open is correct policy and must stay. Fail-open *and silent* is the defect, and it is the
reason this sat unexplained across two reports and thirteen months. Nothing about the transport
question changes the value of removing the silence, and every transport option is easier to verify
once a blocked POST is observable — including B's own rollout, which otherwise has no way to prove
it worked on a machine that actually has the IDS.

I am not going to force B through under a bug ticket. It is a real design change that touches every
hook script on three platforms plus two relay paths, it has an unsolved Windows story that "use
named pipes" does not close, and it must not be authored on top of an open PR that is rewriting the
same files. That is a design doc and a sequenced rollout, not a same-day patch.

## Why (this PR specifically)

`readRequestBody`'s `close`/`error` handlers threw away the one signal that distinguishes "your
security stack cut this connection" from "an agent sent junk." A body that dies short of its own
`Content-Length`, on a request that already passed the token check, was cut by something on the
loopback path. Both false-positive sources are excluded: Orca's own slowloris destroy is flagged at
the source, and unauthenticated probes never reach the read. Threshold 3 keeps one crashed writer
from being an alarm.

The log line deliberately names the second possible cause (a main-process stall past the client's
`--max-time 1.5`) rather than asserting IDS. Sending a user to their IT department over a hang would
be worse than saying less.

## Linked Issue

Fixes #11217

## Visual Proof

`N/A` — no UI surface. The output is a main-process log line and a telemetry event; both are
asserted in tests, and the log wording is quoted in `docs/reference/agent-hook-transport.md`.

## Testing

`src/main/agent-hooks/server-transport-interference.test.ts` drives a **real** `AgentHookServer` over
a raw socket — no mocks:

- 3 authenticated POSTs with `Content-Length: 100000`, body cut by `resetAndDestroy()` → reports once
  at count 3, names `/hook/codex`, and a 4th does not re-report.
- 5 complete POSTs → never reports.
- 2 truncations + 1 request left to Orca's own 5 s slowloris cap → still silent; a 4th truncation
  then reports at count **3**, proving the cap was excluded and not merely uncounted. (This test
  really spends the 5 s.)
- 3 truncations with a wrong token → never reports.

Both truncation tests are load-bearing: the first version of this change classified only in the
`close` handler and the report test failed with `[]`, which is how the `ECONNRESET`-on-`error` path
was found.

`src/shared/agent-hook-transport-interference.test.ts` covers classification (short body, zero
bytes, complete body, absent/chunked/malformed `Content-Length`, duplicated header) and the tracker.

Suites run: `src/main/agent-hooks`, `src/shared/agent-hook-listener.test.ts`,
`src/relay/agent-hook-server.test.ts`, `src/shared/telemetry-events.test.ts` — 43 files, 816
passed. `pnpm typecheck` and `pnpm lint` clean.

Platforms: written and run on macOS. The change is platform-independent Node socket handling — no
paths, no shell, no platform branch — and the hook scripts are untouched, so Windows/Linux/SSH
behavior is unchanged by construction. Not exercised against a live IDS; nobody on the team has the
Bitdefender stack the reporter has, which is exactly why the detector emits telemetry.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

- **Security**: strictly additive detection. No auth change, no CORS change, no bind change, no new
  listener. Telemetry carries an integer count and nothing derived from a body.
- **Cross-platform**: no platform-conditional code; hook scripts untouched.
- **Remote SSH**: the relay listener gets the same detection, writing to stderr (it has no telemetry
  client). Same fail-open `204`.
- **Mobile**: not on this path.
- **Backwards compatibility**: no wire change. No RPC param, no stream opcode, no change to what
  either side publishes — Rules 1–3 of `docs/reference/remote-wire-compatibility.md` are not engaged.
  A truncated request already produced a `204`; it still does.
- **Performance**: one boolean and one integer per request; classification runs only on the failure
  path.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test` pass

## Author

- X / Twitter: @BrennanKB5
