### PR TITLE
fix(agent-hooks): reopen a retired pane on any provider's turn boundary (#12686)

### DIFF
--- a/src/main/agent-hooks/retired-pane-turn-restart.test.ts
+++ b/src/main/agent-hooks/retired-pane-turn-restart.test.ts
@@ -1,0 +1,186 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { AgentHookServer, _internals } from './server'
+import { makePaneKey } from '../../shared/stable-pane-id'
+
+vi.mock('../telemetry/client', () => ({ track: vi.fn() }))
+vi.mock('../telemetry/cohort-classifier', () => ({
+  getCohortAtEmit: vi.fn(() => ({ nth_repo_added: 2 }))
+}))
+
+const LEAF = '11111111-1111-4111-8111-111111111111'
+const PANE = makePaneKey('tab-1', LEAF)
+
+beforeEach(() => {
+  _internals.resetCachesForTests()
+})
+
+async function withServer(run: (server: AgentHookServer) => Promise<void>): Promise<void> {
+  const server = new AgentHookServer()
+  await server.start({ env: 'production' })
+  try {
+    await run(server)
+  } finally {
+    server.stop()
+  }
+}
+
+function postHook(
+  server: AgentHookServer,
+  source: string,
+  payload: Record<string, unknown>
+): Promise<Response> {
+  const env = server.buildPtyEnv()
+  return fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/${source}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+    },
+    body: JSON.stringify({
+      paneKey: PANE,
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      env: 'production',
+      launchToken: 'retired-launch-token',
+      payload
+    })
+  })
+}
+
+describe('retired reusable pane accepts each provider new-turn boundary', () => {
+  it('completes a Cursor turn after launch authority retires (#12686)', async () => {
+    await withServer(async (server) => {
+      await postHook(server, 'cursor', {
+        hook_event_name: 'beforeSubmitPrompt',
+        prompt: 'first Cursor turn'
+      })
+      server.retirePaneAuthority(PANE)
+
+      // The reused shell pane runs a whole new Cursor turn. Before the fix every
+      // event here was suppressed, so the pane never reached `done` — and the
+      // hook-driven synthetic spinner that main starts on `working` was never
+      // stopped, leaving the pane visibly stuck on Working.
+      await postHook(server, 'cursor', {
+        hook_event_name: 'beforeSubmitPrompt',
+        prompt: 'restored Cursor turn'
+      })
+      await postHook(server, 'cursor', { hook_event_name: 'stop', status: 'completed' })
+
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({
+          paneKey: PANE,
+          agentType: 'cursor',
+          state: 'done',
+          prompt: 'restored Cursor turn'
+        })
+      ])
+    })
+  })
+
+  // Why: each provider names its own turn boundary. Before the fix only Claude's two
+  // names could reopen a retired pane, so every other provider stayed suppressed.
+  it.each([
+    ['cursor', { hook_event_name: 'beforeSubmitPrompt' }],
+    ['cursor', { hook_event_name: 'sessionStart' }],
+    ['gemini', { hook_event_name: 'BeforeAgent' }],
+    ['antigravity', { hook_event_name: 'PreInvocation' }],
+    ['pi', { hook_event_name: 'before_agent_start' }],
+    ['claude', { hook_event_name: 'UserPromptSubmit' }],
+    ['claude', { hook_event_name: 'SessionStart', source: 'resume' }]
+  ])('reopens a retired pane for %s %o', async (source, payload) => {
+    await withServer(async (server) => {
+      await postHook(server, source, payload)
+      server.retirePaneAuthority(PANE)
+      expect(server.getStatusSnapshot()).toEqual([])
+
+      await postHook(server, source, payload)
+
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({ paneKey: PANE, agentType: source })
+      ])
+    })
+  })
+
+  it('still reopens a retired pane for a relay frame that carries no source', () => {
+    // Why: an older remote client omits `source`; its Claude panes must keep reopening.
+    const server = new AgentHookServer()
+    server.retirePaneAuthority(PANE)
+    server.ingestRemote(
+      {
+        paneKey: PANE,
+        hookEventName: 'UserPromptSubmit',
+        payload: { state: 'working', prompt: 'legacy relay restart', agentType: 'claude' }
+      },
+      'conn-1'
+    )
+
+    expect(server.getStatusSnapshot()).toEqual([
+      expect.objectContaining({ paneKey: PANE, state: 'working', prompt: 'legacy relay restart' })
+    ])
+  })
+
+  it('keeps a retired pane suppressed for a mid-turn Cursor event', async () => {
+    await withServer(async (server) => {
+      await postHook(server, 'cursor', {
+        hook_event_name: 'beforeSubmitPrompt',
+        prompt: 'first Cursor turn'
+      })
+      server.retirePaneAuthority(PANE)
+
+      // Why: only a live turn boundary may reopen a retired pane — a late tool
+      // event from the previous turn must not resurrect it.
+      await postHook(server, 'cursor', { hook_event_name: 'postToolUse' })
+      await postHook(server, 'cursor', { hook_event_name: 'stop', status: 'completed' })
+
+      expect(server.getStatusSnapshot()).toEqual([])
+    })
+  })
+
+  it('rejects a replayed Cursor turn boundary in a retired pane', () => {
+    const server = new AgentHookServer()
+    server.ingestRemote(
+      {
+        paneKey: PANE,
+        source: 'cursor',
+        hookEventName: 'beforeSubmitPrompt',
+        launchToken: 'retired-launch-token',
+        payload: { state: 'working', prompt: 'first Cursor turn', agentType: 'cursor' }
+      },
+      'conn-1'
+    )
+    server.retirePaneAuthority(PANE)
+
+    server.ingestRemote(
+      {
+        paneKey: PANE,
+        source: 'cursor',
+        hookEventName: 'beforeSubmitPrompt',
+        launchToken: 'retired-launch-token',
+        isReplay: true,
+        payload: { state: 'working', prompt: 'stale Cursor replay', agentType: 'cursor' }
+      },
+      'conn-1'
+    )
+    expect(server.getStatusSnapshot()).toEqual([])
+
+    server.ingestRemote(
+      {
+        paneKey: PANE,
+        source: 'cursor',
+        hookEventName: 'beforeSubmitPrompt',
+        launchToken: 'retired-launch-token',
+        payload: { state: 'working', prompt: 'live Cursor restart', agentType: 'cursor' }
+      },
+      'conn-1'
+    )
+
+    expect(server.getStatusSnapshot()).toEqual([
+      expect.objectContaining({
+        paneKey: PANE,
+        state: 'working',
+        prompt: 'live Cursor restart',
+        connectionId: 'conn-1'
+      })
+    ])
+  })
+})

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -23,6 +23,7 @@ import {
   MAX_PANE_KEY_LEN,
   movePaneCacheState,
   canAcceptClaudeCompactTransition,
+  isAgentHookNewTurnEvent,
   normalizeClaudePromptId,
   normalizeHookPayload,
   parseFormEncodedBody,
@@ -996,7 +997,7 @@ export class AgentHookServer {
 
   private getAgentStatusDisposition(
     paneKey: string,
-    event?: { hookEventName?: string; isReplay?: boolean }
+    event?: { source?: AgentHookSource; hookEventName?: string; isReplay?: boolean }
   ): 'accept' | 'restart' | 'suppress' {
     const ownerPaneKey = this.resolvePaneKeyAlias(paneKey)
     const paneRetired =
@@ -1010,12 +1011,19 @@ export class AgentHookServer {
       return 'accept'
     }
     // Why: command completion retires launch authority but leaves its shell pane reusable.
-    // A live SessionStart proves a new agent process owns the retired pane just like a
-    // fresh prompt does — without it, a session resumed in a reused pane stays rowless (STA-3386).
-    if (
-      (event?.hookEventName === 'UserPromptSubmit' || event?.hookEventName === 'SessionStart') &&
-      event.isReplay !== true
-    ) {
+    // A live turn boundary proves a new agent process owns the retired pane — without it, a
+    // session resumed in a reused pane stays rowless (STA-3386). Ask each provider's own
+    // boundary table: hardcoding Claude's names stranded Cursor's `beforeSubmitPrompt`, so its
+    // `stop` stayed suppressed and the pane never left Working (#12686).
+    const isLiveTurnBoundary =
+      event !== undefined &&
+      event.isReplay !== true &&
+      (event.source !== undefined
+        ? isAgentHookNewTurnEvent(event.source, event.hookEventName)
+        : // Why: a relay frame from an older client carries no `source`; keep the legacy
+          // Claude-vocabulary check so its panes reopen exactly as they did before.
+          event.hookEventName === 'UserPromptSubmit' || event.hookEventName === 'SessionStart')
+    if (isLiveTurnBoundary) {
       this.closedAgentStatusPaneKeys.delete(paneKey)
       this.closedAgentStatusPaneKeys.delete(ownerPaneKey)
       return 'restart'
@@ -1952,6 +1960,7 @@ export class AgentHookServer {
         ? envelope.compactTrigger
         : undefined
     const statusDisposition = this.getAgentStatusDisposition(paneKey, {
+      ...(source ? { source } : {}),
       hookEventName,
       isReplay: envelope.isReplay === true
     })
@@ -2156,6 +2165,7 @@ export class AgentHookServer {
         const normalized = this.normalizeLocalHookPayload(source, aliasedBody)
         const statusDisposition = normalized.event
           ? this.getAgentStatusDisposition(normalized.event.paneKey, {
+              source,
               hookEventName: normalized.event.hookEventName,
               isReplay: normalized.event.isReplay
             })

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2418,6 +2418,11 @@ function isGrokIdleNotification(message: string | undefined): boolean {
   )
 }
 
+// Why: the canonical per-provider turn-boundary table. Also gates whether a live hook
+// may reopen a retired-but-reusable pane, so every provider is judged by its own
+// vocabulary instead of Claude's (#12686).
+export { isNewTurnEvent as isAgentHookNewTurnEvent }
+
 function isNewTurnEvent(source: AgentHookSource, eventName: unknown): boolean {
   // Why: exhaustive switch so a new AgentHookSource fails typecheck here instead of falling through to false.
   switch (source) {


### PR DESCRIPTION
## ELI5

Orca lets a finished agent pane be reused as a plain shell. When that happens it "retires" the pane, then waits for a hook that proves a new agent has taken it over. It only knew how to recognize Claude saying "new turn." Cursor says it with a different word, so Orca never noticed Cursor came back — it ignored everything Cursor sent afterwards, including "I'm done." The pane sat there spinning on **Working** forever. Now Orca listens for each agent's own word.

## What Changed

- `getAgentStatusDisposition` no longer hardcodes Claude's `UserPromptSubmit` / `SessionStart` when deciding whether a live hook may reopen a retired-but-reusable pane. It now asks `isNewTurnEvent(source, hookEventName)` — the per-provider turn-boundary table that already exists in `agent-hook-listener.ts` — exported as `isAgentHookNewTurnEvent`.
- Both hook-status call sites (local HTTP `/hook/<source>` and `ingestRemote`) now pass the hook `source`, which each already had in scope.
- Relay frames that carry no `source` fall back to the previous Claude-vocabulary check, so older remote clients behave exactly as before.
- New focused suite `src/main/agent-hooks/retired-pane-turn-restart.test.ts`.

No behavior changes for a pane that was never retired, for a closed tab, or for replayed events.

## Why

#12686 reports Cursor panes stuck on `Working` even though Cursor emitted a completed `stop` hook. The reported trace shows the affected pane had **no persisted authority commitment** while the control pane did — i.e. its authority had been retired.

The retired-pane gate at `server.ts:1013` only accepted Claude's two event names. Cursor's turn boundary is `beforeSubmitPrompt` (see the `cursor` case in `isNewTurnEvent`), so a retired Cursor pane could never be reopened: `beforeSubmitPrompt`, `stop`, and `afterAgentResponse` were all suppressed at the status-ingest boundary. That matches the issue's observation that the events "are being rejected or dropped at the pane-authority/status-ingest boundary."

**Why the symptom is "stuck Working" rather than "no row":** `main/index.ts` starts the 80 ms synthetic spinner (`⠋ Cursor Agent`) from the *accepted*-status listener, and only stops it when an accepted terminal-state hook arrives (`driveSyntheticTitleFromHook` → `stopSyntheticTitleSpinner`). A suppressed `stop` never reaches that listener, so the spinner keeps re-asserting a working OSC title forever and the pane stays visibly Working. One root cause, both halves of the symptom.

This was never Cursor-specific. Every provider whose boundary is not spelled the Claude way was equally stranded — `gemini` (`BeforeAgent`), `antigravity` (`PreInvocation`), `amp` (`agent.start`), `pi`/`omp`/`prime-agent` (`before_agent_start`), `hermes`, `grok`. `codex`, `kimi`, `droid`, `devin`, and `copilot` only worked because they happen to use Claude-compatible names. Reusing the existing exhaustive table fixes them all and makes a newly added `AgentHookSource` fail typecheck rather than silently regress.

The change is strictly widening: no source loses the ability to reopen a pane, and the `isReplay` guard plus the closed-tab fence are untouched.

### Superseded / related

- **Supersedes #12714** (@ckdwns9121, draft) — same diagnosis and same file, but it hardcodes `beforeSubmitPrompt` alongside Claude's names, fixing only Cursor and leaving the other providers broken. It is also stale: main has since added `SessionStart` (STA-3386), which that branch's diff would drop.
- Does **not** overlap #11127 (#11075 title flicker) or #10391 (#10258 title-derived rows) — see below.
- Likely also relevant to **#14434 / STA-4265** (Cursor status on Windows), which is owned by another worker. I did **not** verify on Windows; nothing here is platform-specific (no paths, shells, shortcuts, or platform branches).

### On the flicker cluster (#11075), deliberately not bundled

I tested the flicker hypothesis before writing code, and it is a **different** defect, so it is not in this PR:

- `isDecorativeAgentTitleFrameChange('⠋ Cursor Agent', '⠙ Cursor Agent')` is already `true` on main, so spinner-frame churn is already collapsed in the tab-title path (`terminal-tab-title-batch.ts:182`, `terminals.ts:2100`). That machinery post-dates #11075.
- The `⠋ Cursor Agent` ↔ bare `cursor agent` alternation is *not* collapsed by that guard (the native literal detects as `null` status), but `applyObservedTitle` already suppresses the native re-emission while a Cursor-owned title holds the pane (`shouldSuppressCursorNativeTitle`).
- The remaining churn the reporter describes is the sidebar compact row's `toolName: toolInput` secondary, which rewrites on every hook — a renderer-presentation concern in a different subsystem.

I also checked the "hook row appears/disappears" hypothesis: a stale hook row **decays to `idle`** in `worktree-agent-rows.ts:236` rather than disappearing, so the title-derived fallback does not take over and oscillate.

## Linked Issue

Fixes #12686

## Visual Proof

`N/A` — no UI code is touched. The change is in main-process hook status ingestion; the user-visible effect (pane leaves Working) is asserted by the automated tests below rather than by a rendered-UI diff.

## Testing

`src/main/agent-hooks/retired-pane-turn-restart.test.ts` — 11 tests, driven through the real hook HTTP server and `ingestRemote`:

- Reproduces #12686 end-to-end: retire authority, then run a full Cursor turn (`beforeSubmitPrompt` → `stop status=completed`) and assert the pane reaches `done`.
- Table-driven per-provider boundary coverage: `cursor beforeSubmitPrompt`, `cursor sessionStart`, `gemini BeforeAgent`, `antigravity PreInvocation`, `pi before_agent_start`, plus `claude UserPromptSubmit` / `claude SessionStart` as unchanged controls.
- Negative controls that must keep suppressing: a mid-turn `postToolUse` must not reopen a retired pane, and a **replayed** `beforeSubmitPrompt` must not either.
- Wire compatibility: a relay frame with no `source` still reopens on `UserPromptSubmit`.

**Proven non-vacuous.** With the test file kept and only the two source files reverted (`git stash push -- <sources>`), the suite goes **7 failed / 4 passed**; with the fix applied it is **11 passed**. The 4 that pass pre-fix are exactly the controls the fix must not change (both Claude cases, the sourceless relay frame, and mid-turn suppression).

Scoped checks run locally (full `pnpm typecheck` skipped deliberately — OOM risk on this box; the node project is the one this diff touches):

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/agent-hooks/` — 41 files, 756 passed / 4 skipped
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/agent-hooks/server.test.ts` — 276 passed
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/shared/agent-hook` — 8 files, 173 passed
- [x] `tsc --noEmit -p config/tsconfig.node.json --composite false` — clean
- [x] All three changed-code quality scans (oxlint, `--type-aware`, React Doctor) — clean
- [x] `oxfmt --write` on the changed files

Platforms actually exercised: macOS. The remote/relay path is covered by unit tests rather than a live SSH host.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

- **Security:** no change to hook authentication. The HTTP token requirement, the `isReplay` fence, the closed-tab fence, and the launch-token strip on the `restart` path are all untouched. The gate is still narrow — only a live, non-replayed turn boundary reopens a pane.
- **Backwards compatibility:** strictly widening. Every source that could reopen a pane before still can, with identical event names. `opencode`, `mimo-code`, and `command-code` return `false` from the table and keep their existing never-reopen behavior.
- **Remote / SSH:** `ingestRemote` reads `source`, an existing relay field the server already consumes for `providerPromptId` and `compactTrigger` — no new wire field and no new opcode. Frames without it keep the old Claude-vocabulary behavior, so a mixed-version client/host pair is safe in both directions.
- **Cross-platform:** no paths, shell invocations, shortcuts, accelerator labels, or platform branches. Identical on macOS, Linux, and Windows.
- **Mobile:** unaffected; this is main-process status ingestion.
- **Performance:** one extra table lookup, and only on the already-rare retired-pane path.

## Author

- X / Twitter: @BrennanKB5
