### PR TITLE
feat(agent-status): surface the model each Codex subagent is running

### DIFF
--- a/src/shared/codex-subagent-roster.test.ts
+++ b/src/shared/codex-subagent-roster.test.ts
@@ -7,6 +7,7 @@ import {
 import {
   codexRosterToSnapshots,
   finishCodexSubagent,
+  setCodexSubagentModel,
   upsertCodexSubagent,
   type CodexSubagentRoster
 } from './codex-subagent-roster'
@@ -60,5 +61,55 @@ describe('Codex subagent roster', () => {
 
     expect(roster.size).toBe(AGENT_STATUS_MAX_SUBAGENTS)
     expect(roster.has('replacement')).toBe(true)
+  })
+
+  describe('setCodexSubagentModel', () => {
+    it('records the model without disturbing the child lifecycle or label', () => {
+      const roster: CodexSubagentRoster = new Map()
+      upsertCodexSubagent(roster, 'child-1', { description: '/root/audit', state: 'waiting' }, 10)
+
+      setCodexSubagentModel(roster, 'child-1', ' gpt-5.6-terra ')
+
+      expect(codexRosterToSnapshots(roster)).toEqual([
+        {
+          id: 'child-1',
+          agentType: undefined,
+          description: '/root/audit',
+          model: 'gpt-5.6-terra',
+          state: 'waiting',
+          startedAt: 10
+        }
+      ])
+    })
+
+    it('never creates a row for a child that is no longer tracked', () => {
+      const roster: CodexSubagentRoster = new Map()
+      upsertCodexSubagent(roster, 'child-1', { state: 'working' }, 10)
+      finishCodexSubagent(roster, 'child-1')
+
+      // A model read racing a completed child must not resurrect its row.
+      setCodexSubagentModel(roster, 'child-1', 'gpt-5.6-terra')
+
+      expect(roster.size).toBe(0)
+    })
+
+    it('keeps a known model when the new value is empty', () => {
+      const roster: CodexSubagentRoster = new Map()
+      upsertCodexSubagent(roster, 'child-1', { model: 'gpt-5.6-sol', state: 'working' }, 10)
+
+      setCodexSubagentModel(roster, 'child-1', '   ')
+      setCodexSubagentModel(roster, 'child-1', undefined)
+
+      expect(roster.get('child-1')?.model).toBe('gpt-5.6-sol')
+    })
+
+    it('bounds an oversized model to the shared cap', () => {
+      const roster: CodexSubagentRoster = new Map()
+      upsertCodexSubagent(roster, 'child-1', { state: 'working' }, 10)
+
+      setCodexSubagentModel(roster, 'child-1', 'x'.repeat(AGENT_MODEL_MAX_LENGTH + 50))
+
+      expect(roster.get('child-1')?.model).toHaveLength(AGENT_MODEL_MAX_LENGTH)
+    })
   })
 })

--- a/src/shared/codex-subagent-roster.ts
+++ b/src/shared/codex-subagent-roster.ts
@@ -61,6 +61,28 @@ export function finishCodexSubagent(roster: CodexSubagentRoster, id: string): vo
   roster.delete(id.trim())
 }
 
+/**
+ * Record the model a already-tracked child is running. Deliberately narrower
+ * than `upsertCodexSubagent`: it never creates a roster entry and never touches
+ * `state`, so late model discovery from a child rollout cannot resurrect a
+ * finished child nor move any child's lifecycle.
+ */
+export function setCodexSubagentModel(
+  roster: CodexSubagentRoster,
+  id: string,
+  model: string | undefined
+): void {
+  const normalizedModel = normalizeOptionalField(model, AGENT_MODEL_MAX_LENGTH)
+  if (!normalizedModel) {
+    return
+  }
+  const existing = roster.get(id.trim())
+  if (!existing) {
+    return
+  }
+  existing.model = normalizedModel
+}
+
 export function seedCodexSubagentRoster(
   roster: CodexSubagentRoster,
   snapshots: readonly AgentSubagentSnapshot[]

--- a/src/shared/codex-subagent-transcript.test.ts
+++ b/src/shared/codex-subagent-transcript.test.ts
@@ -1,7 +1,22 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import type * as NodeFs from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+
+// Why: ESM namespaces are not configurable, so counting rollout opens needs a
+// delegating mock rather than vi.spyOn. Every other export stays real.
+const openSyncCalls = vi.hoisted(() => vi.fn())
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFs>()
+  return {
+    ...actual,
+    openSync: (...args: Parameters<typeof actual.openSync>) => {
+      openSyncCalls(...args)
+      return actual.openSync(...args)
+    }
+  }
+})
 
 import {
   createCodexSubagentTranscriptState,
@@ -154,5 +169,123 @@ describe('Codex subagent transcript reconciliation', () => {
 
     expect(hasTrackedCodexTranscriptSubagents(state)).toBe(false)
     expect(roster.size).toBe(0)
+  })
+
+  describe('child model identity', () => {
+    function turnContext(model: string): unknown {
+      return { type: 'turn_context', payload: { turn_id: 'turn-1', model } }
+    }
+
+    function started(): unknown {
+      return { type: 'event_msg', payload: { type: 'task_started' } }
+    }
+
+    /** Parent rollout with one live child, plus that child's own rollout. */
+    function seedPair(childRecords: unknown[]): {
+      parentPath: string
+      childPath: string
+    } {
+      const dir = mkdtempSync(join(tmpdir(), 'codex-subagent-model-'))
+      dirs.push(dir)
+      const parentPath = join(dir, 'rollout-parent.jsonl')
+      const childPath = join(dir, `rollout-child-${CHILD_ID}.jsonl`)
+      writeFileSync(parentPath, jsonl([turnContext('gpt-5.6-sol'), activity('started')]))
+      writeFileSync(childPath, jsonl(childRecords))
+      return { parentPath, childPath }
+    }
+
+    it('reports the model from the child rollout, not the parent model', () => {
+      const { parentPath } = seedPair([started(), turnContext('gpt-5.6-terra')])
+      const state = createCodexSubagentTranscriptState()
+      const roster: CodexSubagentRoster = new Map()
+
+      reconcileCodexSubagentTranscript(state, roster, parentPath)
+
+      // The parent runs sol; only the child's own turn_context may set its model.
+      expect(codexRosterToSnapshots(roster)?.[0]?.model).toBe('gpt-5.6-terra')
+    })
+
+    it('keeps the discovered model when a later poll carries no turn_context', () => {
+      const { parentPath, childPath } = seedPair([started(), turnContext('gpt-5.6-terra')])
+      const state = createCodexSubagentTranscriptState()
+      const roster: CodexSubagentRoster = new Map()
+      reconcileCodexSubagentTranscript(state, roster, parentPath)
+
+      // The cursor is incremental: this appended line is all the next read sees.
+      writeFileSync(
+        childPath,
+        jsonl([
+          started(),
+          turnContext('gpt-5.6-terra'),
+          { type: 'event_msg', payload: { type: 'agent_message' } }
+        ])
+      )
+      reconcileCodexSubagentTranscript(state, roster, parentPath)
+
+      expect(codexRosterToSnapshots(roster)?.[0]?.model).toBe('gpt-5.6-terra')
+    })
+
+    it('tracks the newest model when the child switches mid-session', () => {
+      const { parentPath } = seedPair([
+        started(),
+        turnContext('gpt-5.6-terra'),
+        turnContext('gpt-5.6-sol')
+      ])
+      const state = createCodexSubagentTranscriptState()
+      const roster: CodexSubagentRoster = new Map()
+
+      reconcileCodexSubagentTranscript(state, roster, parentPath)
+
+      expect(codexRosterToSnapshots(roster)?.[0]?.model).toBe('gpt-5.6-sol')
+    })
+
+    it('leaves the child working and keeps its identity while reading the model', () => {
+      const { parentPath } = seedPair([started(), turnContext('gpt-5.6-terra')])
+      const state = createCodexSubagentTranscriptState()
+      const roster: CodexSubagentRoster = new Map()
+
+      reconcileCodexSubagentTranscript(state, roster, parentPath)
+
+      // Model discovery must not move lifecycle or overwrite the child's label.
+      expect(codexRosterToSnapshots(roster)).toEqual([
+        {
+          id: CHILD_ID,
+          description: '/root/sidebar_repro',
+          state: 'working',
+          startedAt: 1234,
+          agentType: undefined,
+          model: 'gpt-5.6-terra'
+        }
+      ])
+    })
+
+    it('does not resurrect a child that completed in the same read', () => {
+      const { parentPath } = seedPair([
+        started(),
+        turnContext('gpt-5.6-terra'),
+        { type: 'event_msg', payload: { type: 'task_complete' } }
+      ])
+      const state = createCodexSubagentTranscriptState()
+      const roster: CodexSubagentRoster = new Map()
+
+      reconcileCodexSubagentTranscript(state, roster, parentPath)
+
+      expect(roster.size).toBe(0)
+      expect(hasTrackedCodexTranscriptSubagents(state)).toBe(false)
+    })
+
+    it('reads the model without opening any file beyond the parent and child rollouts', () => {
+      const { parentPath } = seedPair([started(), turnContext('gpt-5.6-terra')])
+      const state = createCodexSubagentTranscriptState()
+      const roster: CodexSubagentRoster = new Map()
+      openSyncCalls.mockClear()
+
+      reconcileCodexSubagentTranscript(state, roster, parentPath)
+
+      // Why: model extraction reuses the records already read for completion
+      // detection, so it must add no file I/O of its own.
+      expect(openSyncCalls).toHaveBeenCalledTimes(2)
+      expect(codexRosterToSnapshots(roster)?.[0]?.model).toBe('gpt-5.6-terra')
+    })
   })
 })

--- a/src/shared/codex-subagent-transcript.ts
+++ b/src/shared/codex-subagent-transcript.ts
@@ -3,6 +3,7 @@ import { basename, dirname, extname, isAbsolute, join } from 'node:path'
 
 import {
   finishCodexSubagent,
+  setCodexSubagentModel,
   upsertCodexSubagent,
   type CodexSubagentRoster
 } from './codex-subagent-roster'
@@ -22,6 +23,10 @@ type JsonlCursor = {
 
 type TrackedTranscriptSubagent = JsonlCursor & {
   description?: string
+  /** Latest model seen in the child's own rollout. Retained across polls
+   *  because the cursor is incremental: `turn_context` is emitted once per
+   *  turn, so a later read usually carries no model at all. */
+  model?: string
   startedAt: number
   unresolvedSince?: number
 }
@@ -199,6 +204,24 @@ function readActivity(recordValue: JsonRecord):
   }
 }
 
+/** Latest model from the child's own `turn_context` records. A child can be
+ *  launched on a different model than its parent, so this is read from the
+ *  child rollout rather than inherited. */
+function readChildModel(records: JsonRecord[]): string | undefined {
+  let model: string | undefined
+  for (const recordValue of records) {
+    if (recordValue.type !== 'turn_context') {
+      continue
+    }
+    const payload = record(recordValue.payload)
+    const value = typeof payload?.model === 'string' ? payload.model.trim() : ''
+    if (value) {
+      model = value
+    }
+  }
+  return model
+}
+
 function childIsComplete(records: JsonRecord[]): boolean {
   let complete = false
   for (const recordValue of records) {
@@ -289,6 +312,11 @@ export function reconcileCodexSubagentTranscript(
       }
     } else {
       tracked.unresolvedSince = undefined
+      tracked.model = readChildModel(records) ?? tracked.model
+      // Why: re-applied every reconcile, not just on discovery — the parent's
+      // own activity upsert can rebuild this child's roster entry, which would
+      // otherwise drop a model found on an earlier poll.
+      setCodexSubagentModel(roster, id, tracked.model)
       if (!childIsComplete(records)) {
         continue
       }


### PR DESCRIPTION
## ELI5

When a Codex session spins up sub-agents, Orca already shows them as indented rows under the parent. But the rows never said **which model** each child was running — the space where the model goes was just blank. This fills it in, by reading the model out of the child's own session log.

## What Changed

`src/shared/codex-subagent-transcript.ts` now reads each child's `turn_context.model` out of the child rollout and records it on the roster.

- `readChildModel()` scans for the newest `turn_context` record and takes `payload.model`.
- `setCodexSubagentModel()` (new, in `codex-subagent-roster.ts`) writes it. It is deliberately narrower than `upsertCodexSubagent`: it **never creates** a roster entry and **never touches `state`**, so a late model read cannot resurrect a finished child or move any child's lifecycle.
- The model is retained on the tracked child and re-applied each reconcile, because the rollout cursor is incremental — `turn_context` is emitted once per turn, so later polls usually carry no model at all.

No UI was added. `AgentSubagentSnapshot.model` has existed since #9637 and both row components already render `entry.model` (`DashboardAgentRow.tsx:272`, `worktree-card-compact-agent-row.tsx:218`). The field was simply never populated for transcript-discovered children, so every Codex child rendered an empty model chip.

## Why

#8251 acceptance criterion 3 — "Multi-model runs show enough identity to distinguish orchestrator model vs sub-agent model" — is the one part of the visible-rows scope that is still unmet on `main`. It is also the original user report consolidated into #8251 from #9528:

> I told it to use the SOL model as the orchestrator and to run a sub-agent with the 5.6 Terra model at medium, but I can't visually tell if it's actually running that agent or if it's using sol

The child's model is authoritative in the child's own rollout, not the parent's — verified against real rollouts in `~/.codex/sessions` (a parent on `gpt-5.6-sol` with children each carrying their own `turn_context.model`). So it is read per child rather than inherited.

### Render / scan cost (explicitly, per STA-3354)

This change is deliberately free on the hot path:

- **No new rows.** It populates an existing optional field on rows that already render. Row count is unchanged.
- **No new file I/O.** `readChildModel()` iterates the *same* `records` array `readJsonlCursor()` already produced for `childIsComplete()`. No added `openSync`/`statSync`/`readSync`. There is a regression test asserting exactly two file opens per reconcile (parent + child).
- **Poll cadence unchanged.** Still gated on `hasCodexTranscriptSubagents` — Orca only polls while a child is actually tracked. This PR does **not** widen that gate.
- **Per-reconcile work** is O(records appended since the last poll), already bounded by the incremental cursor and the existing 1 MiB read cap. `setCodexSubagentModel` is one `Map.get` plus a field assign, O(1) per tracked child.
- **Renderer untouched.** No new component, no new pass over the global agent-status map.

### Relationship to the open PRs on this cluster

- **#8270 (`fix(agent): show Codex subagents in sidebar status`) is obsolete — recommend closing.** Its stated premise is "Codex does not emit the `subagents` payload used by other providers," so it builds a parallel roster from `collaborationspawn_agent` / `collaborationinterrupt_agent` hooks. That premise no longer holds: #9637 and #11059 landed transcript-derived rosters on `main`, which strictly dominate — they discover children whether or not a hook fires, and they detect **per-child** completion, which #8270 explicitly cannot ("Codex currently provides worker-start events but no authoritative per-worker completion event… child rows therefore remain working until the root `Stop`"). It would also add a second `codex-collaboration-roster.ts` beside the existing `codex-subagent-roster.ts`.
- **#12311 is a different scope and is not superseded by this PR.** It implements #12621 (clickable child rows opening a read-only progress sheet), not the sidebar rows themselves. It is orthogonal to this change. Two notes for whoever reviews it: it has never run CI ("no checks reported on the branch"), and it widens the poll gate from `hasCodexTranscriptSubagents` to `hasCodexParentTranscript`, which makes **every** Codex pane poll the filesystem every second indefinitely even with zero subagents — worth weighing against STA-3354. It also edits `codex-subagent-transcript.ts`, so expect a small, mechanical conflict with this PR.

## Linked Issue

Refs #8251 — advances the umbrella by closing acceptance criterion 3 (and the #9528 report merged into it). It does not close #8251, which still covers cross-worktree orchestration edges (criterion 6), worker dedup (7), and hierarchy restore (8).

## Visual Proof

Same seeded Codex pane with three children, before and after. Note the children now resolve **independently**: two on `gpt-5.6-terra`, one on `gpt-5.6-sol`, under a `gpt-5.6-sol` parent — proving the model is read per child, not inherited from the parent.

**Before** — parent shows `gpt-5.6-sol`; every child's model is blank.

![before-2x.png](https://github.com/user-attachments/assets/ef003a5c-2ed2-4158-8985-8a162bbd4f2c)

**After** — each child shows its own model.

![after-2x.png](https://github.com/user-attachments/assets/cc69de1d-0ad2-443d-8259-1f75a50178c8)

Captured on this branch in an isolated Orca dev instance (own `ORCA_DEV_USER_DATA_PATH`, own renderer/CDP ports) via the Electron skill + Playwright CDP. Because this PR only changes *what value* reaches an already-rendered field, the two states are the field populated vs. empty at the render boundary — the components themselves are untouched.

One honest note visible in the shots: on a narrow sidebar the child's name truncates a little sooner to make room for the chip. That is the existing row layout (`truncate` label + `shrink-0` chip), unchanged here — it is the same tradeoff the parent row has always had.

## Testing

- [x] I manually tested these changes locally (macOS; isolated Electron dev instance, screenshots above)
- [x] Automated tests added/updated

Scoped runs (full typecheck deliberately skipped — OOM risk on this repo):

```
npx vitest run --config config/vitest.config.ts \
  src/shared/codex-subagent-transcript.test.ts \
  src/shared/codex-subagent-roster.test.ts
→ 17 passed

# broader regression surface
+ src/renderer/src/components/sidebar/useWorktreeAgentRows.test.ts
+ src/main/agent-hooks/server.test.ts
→ 322 passed
```

Also green: all 4 `*codex*subagent*` test files (21 tests), `oxlint`, `oxlint --config config/oxlint-react-doctor.json`, `oxfmt`.

**Non-vacuity proof.** Reverting only the two source files and re-running the same tests fails **9 of 17**, while all 8 pre-existing tests still pass:

```
AssertionError: expected undefined to be 'gpt-5.6-terra'
Tests  9 failed | 8 passed (17)
```

One new case ("does not resurrect a child that completed in the same read") passes both before and after by design — it is a regression guard against the subagent-clobbers-parent class (STA-2112/2035, STA-2243, STA-1607), not a fix-detector.

New coverage:
- model comes from the child rollout, not the parent's
- model survives a later poll that carries no `turn_context` (incremental cursor)
- newest model wins when a child switches mid-session
- reading the model leaves state/description/`startedAt` untouched
- a completed child is not resurrected by a model read
- exactly 2 file opens per reconcile (no added I/O)
- `setCodexSubagentModel` never creates a row, keeps a known model when the new value is empty, and bounds an oversized model to the shared cap

## Review

- **Security** — read-only parse of a rollout file Orca already reads. Model string goes through the same `normalizeOptionalField` + `AGENT_MODEL_MAX_LENGTH` cap as every other roster field; a hostile rollout gets truncated, not trusted. No new IPC, network, or shell path.
- **Cross-platform** — pure JSONL parsing, no new path or shell assumptions; unchanged on macOS/Linux/Windows.
- **Remote SSH / folder workspaces** — no new host routing. It reads whatever transcript the existing reconcile already resolved, so SSH and folder-workspace behavior is unchanged.
- **Remote wire compatibility** — no wire change. `subagents[].model` is an existing optional field already published and already tolerated by older clients; this only starts populating it. Older clients ignore it, newer clients render it.
- **Backwards compatibility** — a child whose rollout has no `turn_context` (or an older Codex) simply keeps `model: undefined` and renders exactly as it does today.
- **Performance** — see the explicit cost breakdown above; no added I/O, no added rows, no renderer change.
- **Mobile** — no mobile surface touched.

## Checklist

- [x] This PR is small and focused (4 files, +234 / −0)
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots attached
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] Scoped `lint` / `test` pass locally; full `typecheck` + `build` left to CI (local full typecheck OOMs)

## Author

- X / Twitter: @BrennanKB5
