### PR TITLE
fix(workspace-cleanup): make the Filters panel scrollable

### DIFF
--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-filter-bar.test.tsx
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-filter-bar.test.tsx
@@ -6,39 +6,55 @@ import { WorkspaceCleanupFilterBar } from './workspace-cleanup-filter-bar'
 
 afterEach(cleanup)
 
+function renderFilterBar(facetPanelOpen = false): void {
+  render(
+    <WorkspaceCleanupFilterBar
+      facetProps={{
+        filters: createDefaultWorkspaceCleanupFilterState(),
+        counts: {
+          activity: 0,
+          size: 0,
+          status: 0,
+          agent: 0,
+          git: 0,
+          review: 0,
+          ticket: 0,
+          context: 0,
+          location: 0,
+          safety: 0
+        },
+        totalCount: 100,
+        options: { workspaceStatuses: [], hostIds: [], repos: [], reviewProviders: [] },
+        onPatch: vi.fn()
+      }}
+      facetPanelOpen={facetPanelOpen}
+      onFacetPanelOpenChange={vi.fn()}
+      activeFacetGroupCount={0}
+      matchedCount={100}
+      hasActiveFilters={false}
+      gitEvidence={{ pendingCount: 0, totalCount: 0 }}
+      onQueryChange={vi.fn()}
+      onClearFilters={vi.fn()}
+    />
+  )
+}
+
 describe('WorkspaceCleanupFilterBar', () => {
   it('keeps size measurement out of the browse controls', () => {
-    render(
-      <WorkspaceCleanupFilterBar
-        facetProps={{
-          filters: createDefaultWorkspaceCleanupFilterState(),
-          counts: {
-            activity: 0,
-            size: 0,
-            status: 0,
-            agent: 0,
-            git: 0,
-            review: 0,
-            ticket: 0,
-            context: 0,
-            location: 0,
-            safety: 0
-          },
-          totalCount: 100,
-          options: { workspaceStatuses: [], hostIds: [], repos: [], reviewProviders: [] },
-          onPatch: vi.fn()
-        }}
-        facetPanelOpen={false}
-        onFacetPanelOpenChange={vi.fn()}
-        activeFacetGroupCount={0}
-        matchedCount={100}
-        hasActiveFilters={false}
-        gitEvidence={{ pendingCount: 0, totalCount: 0 }}
-        onQueryChange={vi.fn()}
-        onClearFilters={vi.fn()}
-      />
-    )
+    renderFilterBar()
 
     expect(screen.queryByRole('button', { name: 'Scan' })).toBeNull()
+  })
+
+  it('caps the facet panel height on the scroll viewport so it stays scrollable', () => {
+    renderFilterBar(true)
+
+    // Why: on the ScrollArea Root the cap only clips — the h-full viewport
+    // collapses under an indefinite height and the last facet groups become
+    // unreachable behind the footer.
+    const viewport = document.querySelector('[data-slot="scroll-area-viewport"]')
+    const root = document.querySelector('[data-slot="scroll-area"]')
+    expect(viewport?.className).toContain('max-h-[420px]')
+    expect(root?.className).not.toContain('max-h-')
   })
 })

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-filter-bar.test.tsx
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-filter-bar.test.tsx
@@ -46,15 +46,14 @@ describe('WorkspaceCleanupFilterBar', () => {
     expect(screen.queryByRole('button', { name: 'Scan' })).toBeNull()
   })
 
-  it('caps the facet panel height on the scroll viewport so it stays scrollable', () => {
+  it('keeps the footer visible while the facet panel scrolls', () => {
     renderFilterBar(true)
 
-    // Why: on the ScrollArea Root the cap only clips — the h-full viewport
-    // collapses under an indefinite height and the last facet groups become
-    // unreachable behind the footer.
-    const viewport = document.querySelector('[data-slot="scroll-area-viewport"]')
+    const content = document.querySelector('[data-slot="popover-content"]')
     const root = document.querySelector('[data-slot="scroll-area"]')
-    expect(viewport?.className).toContain('max-h-[420px]')
-    expect(root?.className).not.toContain('max-h-')
+    expect(content?.className).toContain(
+      'h-[min(471px,var(--radix-popover-content-available-height))]'
+    )
+    expect(root?.className).toContain('min-h-0 flex-1')
   })
 })

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-filter-bar.tsx
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-filter-bar.tsx
@@ -67,12 +67,13 @@ export function WorkspaceCleanupFilterBar({
             ) : null}
           </Button>
         </PopoverTrigger>
-        <PopoverContent align="end" sideOffset={6} className="w-[320px] p-0">
-          {/* Why: the cap must sit on the scroll viewport. On the Root it only
-              clips — the viewport is h-full, which collapses to auto under an
-              indefinite height, so the panel grew past the cap unscrollably and
-              hid the last facet groups behind the footer. */}
-          <ScrollArea viewportClassName="max-h-[420px]">
+        <PopoverContent
+          align="end"
+          sideOffset={6}
+          className="flex h-[min(471px,var(--radix-popover-content-available-height))] w-[320px] flex-col p-0"
+        >
+          {/* 471px preserves the 420px facet viewport plus the fixed footer at full height. */}
+          <ScrollArea className="min-h-0 flex-1">
             <WorkspaceCleanupLifecycleFacets {...facetProps} />
             <WorkspaceCleanupGitReviewFacets {...facetProps} />
           </ScrollArea>

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-filter-bar.tsx
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-filter-bar.tsx
@@ -68,7 +68,11 @@ export function WorkspaceCleanupFilterBar({
           </Button>
         </PopoverTrigger>
         <PopoverContent align="end" sideOffset={6} className="w-[320px] p-0">
-          <ScrollArea className="max-h-[420px]">
+          {/* Why: the cap must sit on the scroll viewport. On the Root it only
+              clips — the viewport is h-full, which collapses to auto under an
+              indefinite height, so the panel grew past the cap unscrollably and
+              hid the last facet groups behind the footer. */}
+          <ScrollArea viewportClassName="max-h-[420px]">
             <WorkspaceCleanupLifecycleFacets {...facetProps} />
             <WorkspaceCleanupGitReviewFacets {...facetProps} />
           </ScrollArea>


### PR DESCRIPTION
## ELI5

The filter panel in the workspace cleanup dialog was too tall for its box and could not be scrolled, so the bottom filters were stuck behind the footer. This makes the filter list scroll while keeping the footer visible, including in short windows.

## What Changed

- Bound the Filters popover to the smaller of its normal 471px height and Radix's available popover height.
- Made the facet ScrollArea the shrinking `min-h-0 flex-1` body of the popover.
- Kept the result/footer row as a separate fixed flex item.
- Added a focused regression test for the bounded popover and scroll-body layout.

## Why

The old ScrollArea Root had only `max-height` while its Radix viewport used `h-full`. Without a definite height, the viewport expanded to the full facet content, so the Root clipped the panel instead of providing a scrollable region.

Giving the popover a definite, available-height-aware flex layout lets the facet body shrink and scroll. The 471px normal cap preserves the previous 420px facet area plus its footer, while short windows reduce the scroll body instead of clipping the footer.

## Linked Issue

Fixes #14628

## Visual Proof

**BEFORE** — panel clipped at the cap, no scrollbar; `ARCHIVED` collides with the footer and its controls are unreachable:

<img width="478" alt="filters panel clipped, Archived unreachable" src="https://github.com/user-attachments/assets/5b5bf39c-6989-4ec8-a85c-abfa86c35614" />

**AFTER** — exact-head Electron screenshots are attached in the QA comment below, covering normal height, a 500px-tall renderer, and the final controls after scrolling.

## Testing

Verified locally on macOS:

- Focused filter-bar Vitest: 2 passed.
- `pnpm run typecheck` clean.
- Direct oxlint, formatting, React Doctor changed-lines, and `git diff --check` clean.
- Electron/CDP on exact HEAD `583166d0b29b8f4f4ca37d2a963323fcd2dd9ecf`:
  - Normal height: 420px viewport with 2090px scrollable content; footer visible.
  - 500px renderer height: scroll body shrank to 312px; footer remained fully visible.
  - Scrolled to and clicked the final Safety control without footer overlap.

- [x] Manually tested in the rendered Electron app
- [x] Automated regression test added

## Review

- **Security:** no new IPC, data flow, dependency, or permission change.
- **Cross-platform (Linux/Windows/macOS):** Chromium CSS/layout only; no paths, shells, shortcuts, or platform branches.
- **Remote SSH:** renderer-local chrome only; no scan, transport, or host-state change.
- **Mobile:** no mobile-facing surface touched; this dialog is desktop-only.
- **Backwards compatibility:** no persisted state, schema, IPC, RPC, or wire contract.
- **Performance:** neutral; no new work, renders, polling, listeners, or allocations.

## Checklist

- [x] Small and focused on #14628
- [x] Root cause and responsive behavior documented
- [x] Before/after visual proof attached
- [x] Security, performance, compatibility, and remoting reviewed
- [x] Focused local gates pass

## Author

- X / Twitter: @BrennanKB5
