### PR TITLE
feat(sidebar): filter the workspace list by card status (#13996)

### DIFF
--- a/src/main/runtime/rpc/methods/client-ui-workspace-filter-fields.ts
+++ b/src/main/runtime/rpc/methods/client-ui-workspace-filter-fields.ts
@@ -7,5 +7,6 @@ export const ClientUiWorkspaceFilterFields = {
   hideDetachedHeadWorkspaces: z.boolean().optional(),
   hideWorkspacesFromOtherDevices: z.boolean().optional(),
   alwaysShowDefaultBranchWorkspace: z.boolean().optional(),
-  filterRepoIds: z.array(z.string()).optional()
+  filterRepoIds: z.array(z.string()).optional(),
+  filterWorkspaceStatuses: z.array(z.string()).optional()
 }

--- a/src/renderer/src/app-shell/use-persisted-ui-writer.ts
+++ b/src/renderer/src/app-shell/use-persisted-ui-writer.ts
@@ -32,6 +32,7 @@ export function usePersistedUIWriter(): void {
       alwaysShowDefaultBranchWorkspace: s.alwaysShowDefaultBranchWorkspace,
       showDotfilesByWorktree: s.showDotfilesByWorktree,
       filterRepoIds: s.filterRepoIds,
+      filterWorkspaceStatuses: s.filterWorkspaceStatuses,
       // Why: rides the same debounced save so dashboard auto-acks (which fire on focus/
       // visibility) and the in-memory ack cleanup paths in agent-status.ts (close/dismiss)
       // both flow to disk through map identity changes. Without persisting, agent rows that
@@ -52,7 +53,8 @@ export function usePersistedUIWriter(): void {
         hideSleepingWorkspaces: !ui.showSleepingWorkspaces,
         // Why: the store keeps this readonly for identity stability, but PersistedUI crosses to
         // main, which owns a mutable array — copy at the boundary rather than widening the wire type.
-        filterRepoIds: [...ui.filterRepoIds]
+        filterRepoIds: [...ui.filterRepoIds],
+        filterWorkspaceStatuses: [...ui.filterWorkspaceStatuses]
       })
     }, 150)
 

--- a/src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx
+++ b/src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx
@@ -18,6 +18,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { DEFAULT_SHOW_SLEEPING_WORKSPACES } from '../../../../shared/constants'
 import { isSleepingSweepExemptionNarrowingList } from './visible-worktrees'
 import SidebarRepositoryFilterSection from './SidebarRepositoryFilterSection'
+import SidebarWorkspaceStatusFilterSection from './SidebarWorkspaceStatusFilterSection'
 import SidebarWorkspaceFilterSection from './SidebarWorkspaceFilterSection'
 import { getSidebarHostVisibilityLabel, shouldShowHostScopeControls } from './sidebar-host-options'
 import { useSidebarHostScopeOptions } from './use-sidebar-host-scope-options'
@@ -44,6 +45,8 @@ const SidebarWorkspaceOptionsMenu = React.memo(function SidebarWorkspaceOptionsM
   const hideWorkspacesFromOtherDevices = useAppStore((s) => s.hideWorkspacesFromOtherDevices)
   const alwaysShowDefaultBranchWorkspace = useAppStore((s) => s.alwaysShowDefaultBranchWorkspace)
   const filterRepoIds = useAppStore((s) => s.filterRepoIds)
+  const filterWorkspaceStatuses = useAppStore((s) => s.filterWorkspaceStatuses)
+  const workspaceStatuses = useAppStore((s) => s.workspaceStatuses)
   const repos = useAppStore((s) => s.repos)
   const setWorkspaceHostScope = useAppStore((s) => s.setWorkspaceHostScope)
   const visibleWorkspaceHostIds = useAppStore((s) => s.visibleWorkspaceHostIds)
@@ -79,6 +82,22 @@ const SidebarWorkspaceOptionsMenu = React.memo(function SidebarWorkspaceOptionsM
     return count
   }, [repos, filterRepoIds])
   const hasRepoFilter = selectedCount > 0
+  // Why derive from the catalog, same as repos: a stale id from a deleted
+  // status must not inflate the badge for a filter the pipeline ignores.
+  const selectedStatusCount = useMemo(() => {
+    let count = 0
+    for (const status of workspaceStatuses) {
+      if (filterWorkspaceStatuses.includes(status.id)) {
+        count += 1
+      }
+    }
+    // Why zero when everything is selected: that narrows nothing, so it is not
+    // an active filter the Clear Filters escape hatch needs to advertise.
+    return count === workspaceStatuses.length ? 0 : count
+  }, [workspaceStatuses, filterWorkspaceStatuses])
+  const hasStatusFilter = selectedStatusCount > 0
+  // Why: one status can't narrow anything; the section hides itself on the same rule.
+  const showStatusFilter = workspaceStatuses.length > 1
   const hasSleepingFilter = showSleepingWorkspaces !== DEFAULT_SHOW_SLEEPING_WORKSPACES
   const hasHostVisibilityFilter = visibleWorkspaceHostIds !== null
   // Why gated on the parent row: the exemption only narrows the list during the
@@ -96,6 +115,7 @@ const SidebarWorkspaceOptionsMenu = React.memo(function SidebarWorkspaceOptionsM
     hideWorkspacesFromOtherDevices ||
     hasSleepingExemptionFilter ||
     hasRepoFilter ||
+    hasStatusFilter ||
     hasHostVisibilityFilter
   const activeFilterCount =
     (hasSleepingFilter ? 1 : 0) +
@@ -106,7 +126,8 @@ const SidebarWorkspaceOptionsMenu = React.memo(function SidebarWorkspaceOptionsM
     (hideWorkspacesFromOtherDevices ? 1 : 0) +
     (hasSleepingExemptionFilter ? 1 : 0) +
     (hasHostVisibilityFilter ? 1 : 0) +
-    selectedCount
+    selectedCount +
+    selectedStatusCount
   const activeFilterLabel = `${activeFilterCount} ${activeFilterCount === 1 ? 'filter' : 'filters'}`
   const sortLabel = SORT_OPTIONS.find((opt) => opt.id === sortBy)?.label ?? 'Sort'
   const projectOrderLabel =
@@ -173,7 +194,7 @@ const SidebarWorkspaceOptionsMenu = React.memo(function SidebarWorkspaceOptionsM
       >
         {/* Why: host + project filters share one section and the same single-row
             shell as Sort by (label left, value right) so the menu stays flat. */}
-        {(showHostScopeControls || repos.length > 1) && (
+        {(showHostScopeControls || repos.length > 1 || showStatusFilter) && (
           <>
             <DropdownMenuLabel>
               {translate('auto.components.sidebar.SidebarWorkspaceOptionsMenu.showSection', 'Show')}
@@ -189,6 +210,9 @@ const SidebarWorkspaceOptionsMenu = React.memo(function SidebarWorkspaceOptionsM
               />
             )}
             <SidebarRepositoryFilterSection
+              preserveWorkspaceBoardOpen={preserveWorkspaceBoardOpen}
+            />
+            <SidebarWorkspaceStatusFilterSection
               preserveWorkspaceBoardOpen={preserveWorkspaceBoardOpen}
             />
             <DropdownMenuSeparator />

--- a/src/renderer/src/components/sidebar/SidebarWorkspaceStatusFilterSection.test.ts
+++ b/src/renderer/src/components/sidebar/SidebarWorkspaceStatusFilterSection.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getWorkspaceStatusFilterLabel,
+  toggleFilterWorkspaceStatus
+} from './SidebarWorkspaceStatusFilterSection'
+import { DEFAULT_WORKSPACE_STATUSES } from '../../../../shared/workspace-statuses'
+import type { WorkspaceStatusDefinition } from '../../../../shared/worktree/types'
+
+const STATUSES: readonly WorkspaceStatusDefinition[] = DEFAULT_WORKSPACE_STATUSES
+const ALL_IDS = STATUSES.map((status) => status.id)
+
+describe('toggleFilterWorkspaceStatus', () => {
+  it('selects a status from the empty "all" selection', () => {
+    expect(toggleFilterWorkspaceStatus([], STATUSES, 'completed')).toEqual(['completed'])
+  })
+
+  it('adds a second status in catalog order, not click order', () => {
+    expect(toggleFilterWorkspaceStatus(['completed'], STATUSES, 'todo')).toEqual([
+      'todo',
+      'completed'
+    ])
+  })
+
+  it('deselects a status that was selected', () => {
+    expect(toggleFilterWorkspaceStatus(['todo', 'completed'], STATUSES, 'todo')).toEqual([
+      'completed'
+    ])
+  })
+
+  it('collapses back to "all" when the last selected status is deselected', () => {
+    // Otherwise the click would empty the sidebar from inside the menu.
+    expect(toggleFilterWorkspaceStatus(['todo'], STATUSES, 'todo')).toEqual([])
+  })
+
+  it('collapses back to "all" when every status ends up selected', () => {
+    // Selecting everything narrows nothing, so it must not read as a filter.
+    const allButLast = ALL_IDS.slice(0, -1)
+    expect(toggleFilterWorkspaceStatus(allButLast, STATUSES, ALL_IDS.at(-1)!)).toEqual([])
+  })
+
+  it('drops stale ids while toggling instead of carrying them forward', () => {
+    expect(toggleFilterWorkspaceStatus(['deleted-custom'], STATUSES, 'todo')).toEqual(['todo'])
+  })
+
+  it('returns the same array identity for a no-op on an already-empty selection', () => {
+    const empty: string[] = []
+    expect(toggleFilterWorkspaceStatus(empty, [STATUSES[0]], STATUSES[0].id)).toBe(empty)
+  })
+})
+
+describe('getWorkspaceStatusFilterLabel', () => {
+  it('reads "All statuses" for an empty selection', () => {
+    expect(getWorkspaceStatusFilterLabel(STATUSES, [])).toBe('All statuses')
+  })
+
+  it('reads "All statuses" when every status is selected', () => {
+    expect(getWorkspaceStatusFilterLabel(STATUSES, ALL_IDS)).toBe('All statuses')
+  })
+
+  it('names the single selected status', () => {
+    expect(getWorkspaceStatusFilterLabel(STATUSES, ['completed'])).toBe('Done')
+  })
+
+  it('counts a multi-status selection', () => {
+    expect(getWorkspaceStatusFilterLabel(STATUSES, ['todo', 'completed'])).toBe('2 statuses')
+  })
+
+  it('ignores stale ids when counting', () => {
+    // A deleted custom status must not inflate the label past what filters.
+    expect(getWorkspaceStatusFilterLabel(STATUSES, ['todo', 'deleted-custom'])).toBe('Todo')
+  })
+})

--- a/src/renderer/src/components/sidebar/SidebarWorkspaceStatusFilterSection.tsx
+++ b/src/renderer/src/components/sidebar/SidebarWorkspaceStatusFilterSection.tsx
@@ -1,0 +1,167 @@
+import React, { useCallback, useMemo } from 'react'
+import { useAppStore } from '@/store'
+import {
+  DropdownMenuCheckboxItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger
+} from '@/components/ui/dropdown-menu'
+import type { WorkspaceStatus, WorkspaceStatusDefinition } from '../../../../shared/worktree/types'
+import { getWorkspaceStatusVisualMeta } from './workspace-status'
+import { translate } from '@/i18n/i18n'
+
+/**
+ * Next selection after clicking `statusId`, in catalog order.
+ *
+ * Selecting every status collapses back to the empty "all" selection so the
+ * filter badge and Clear Filters agree with what the list actually shows.
+ * Deselecting the last remaining status does the same rather than emptying the
+ * sidebar with no visible cause.
+ */
+export function toggleFilterWorkspaceStatus(
+  selected: readonly WorkspaceStatus[],
+  statuses: readonly WorkspaceStatusDefinition[],
+  statusId: WorkspaceStatus
+): readonly WorkspaceStatus[] {
+  const next = new Set(selected.filter((id) => statuses.some((status) => status.id === id)))
+  if (!next.delete(statusId)) {
+    next.add(statusId)
+  }
+  if (next.size === 0 || next.size === statuses.length) {
+    // Why the same array back when already empty: a fresh [] would churn store
+    // identity into the debounced persisted-UI write for a no-op click.
+    return selected.length === 0 ? selected : []
+  }
+  return statuses.filter((status) => next.has(status.id)).map((status) => status.id)
+}
+
+export function getWorkspaceStatusFilterLabel(
+  statuses: readonly WorkspaceStatusDefinition[],
+  selected: readonly WorkspaceStatus[]
+): string {
+  const selectedDefinitions = statuses.filter((status) => selected.includes(status.id))
+  if (selectedDefinitions.length === 0 || selectedDefinitions.length === statuses.length) {
+    return translate(
+      'auto.components.sidebar.SidebarWorkspaceStatusFilterSection.allStatuses',
+      'All statuses'
+    )
+  }
+  if (selectedDefinitions.length === 1) {
+    return selectedDefinitions[0]?.label ?? ''
+  }
+  return translate(
+    'auto.components.sidebar.SidebarWorkspaceStatusFilterSection.selectedStatusesCount',
+    '{{value0}} statuses',
+    { value0: selectedDefinitions.length }
+  )
+}
+
+type SidebarWorkspaceStatusFilterSectionProps = {
+  preserveWorkspaceBoardOpen?: boolean
+}
+
+/**
+ * Card-status visibility for the sidebar workspace list, mirroring the Hosts
+ * row: one Sort-by-style row whose nested panel holds the checkboxes.
+ */
+const SidebarWorkspaceStatusFilterSection = React.memo(
+  function SidebarWorkspaceStatusFilterSection({
+    preserveWorkspaceBoardOpen = false
+  }: SidebarWorkspaceStatusFilterSectionProps) {
+    const workspaceStatuses = useAppStore((s) => s.workspaceStatuses)
+    const filterWorkspaceStatuses = useAppStore((s) => s.filterWorkspaceStatuses)
+    const setFilterWorkspaceStatuses = useAppStore((s) => s.setFilterWorkspaceStatuses)
+
+    // Why derive from the catalog: a stale id left by a deleted status must not
+    // check a row or inflate the count while the pipeline ignores it.
+    const selectedStatusIds = useMemo(() => {
+      const set = new Set<WorkspaceStatus>()
+      for (const status of workspaceStatuses) {
+        if (filterWorkspaceStatuses.includes(status.id)) {
+          set.add(status.id)
+        }
+      }
+      return set
+    }, [workspaceStatuses, filterWorkspaceStatuses])
+    const allVisible =
+      selectedStatusIds.size === 0 || selectedStatusIds.size === workspaceStatuses.length
+
+    const toggleStatus = useCallback(
+      (statusId: WorkspaceStatus) => {
+        const next = toggleFilterWorkspaceStatus(
+          filterWorkspaceStatuses,
+          workspaceStatuses,
+          statusId
+        )
+        if (next !== filterWorkspaceStatuses) {
+          setFilterWorkspaceStatuses(next)
+        }
+      },
+      [filterWorkspaceStatuses, setFilterWorkspaceStatuses, workspaceStatuses]
+    )
+
+    const showAllStatuses = useCallback(() => {
+      if (filterWorkspaceStatuses.length > 0) {
+        setFilterWorkspaceStatuses([])
+      }
+    }, [filterWorkspaceStatuses, setFilterWorkspaceStatuses])
+
+    if (workspaceStatuses.length < 2) {
+      return null
+    }
+
+    return (
+      <DropdownMenuSub>
+        <DropdownMenuSubTrigger>
+          <span className="flex flex-1 items-center justify-between gap-3">
+            <span>
+              {translate(
+                'auto.components.sidebar.SidebarWorkspaceStatusFilterSection.status',
+                'Status'
+              )}
+            </span>
+            <span className="min-w-0 truncate text-[11px] font-medium text-muted-foreground">
+              {getWorkspaceStatusFilterLabel(workspaceStatuses, filterWorkspaceStatuses)}
+            </span>
+          </span>
+        </DropdownMenuSubTrigger>
+        <DropdownMenuSubContent
+          className="w-56"
+          data-workspace-board-preserve-open={preserveWorkspaceBoardOpen ? '' : undefined}
+        >
+          <DropdownMenuCheckboxItem
+            checked={allVisible}
+            // Why not disabled when already checked: unchecking "All" has no
+            // sensible target status, so swallow it rather than offer a control
+            // that empties the list.
+            onCheckedChange={showAllStatuses}
+            onSelect={(e) => e.preventDefault()}
+          >
+            {translate(
+              'auto.components.sidebar.SidebarWorkspaceStatusFilterSection.allStatuses',
+              'All statuses'
+            )}
+          </DropdownMenuCheckboxItem>
+          {workspaceStatuses.map((status) => {
+            const StatusIcon = getWorkspaceStatusVisualMeta(status).icon
+            return (
+              <DropdownMenuCheckboxItem
+                key={status.id}
+                checked={selectedStatusIds.has(status.id)}
+                onCheckedChange={() => toggleStatus(status.id)}
+                onSelect={(e) => e.preventDefault()}
+              >
+                <span className="inline-flex min-w-0 items-center gap-2">
+                  <StatusIcon className="size-3.5 text-muted-foreground" />
+                  <span className="truncate">{status.label}</span>
+                </span>
+              </DropdownMenuCheckboxItem>
+            )
+          })}
+        </DropdownMenuSubContent>
+      </DropdownMenuSub>
+    )
+  }
+)
+
+export default SidebarWorkspaceStatusFilterSection

--- a/src/renderer/src/components/sidebar/sidebar-filter-actions.ts
+++ b/src/renderer/src/components/sidebar/sidebar-filter-actions.ts
@@ -13,6 +13,7 @@ export function sidebarHasActiveFilters(state: SidebarFilterState): boolean {
   return (
     state.showSleepingWorkspaces !== DEFAULT_SHOW_SLEEPING_WORKSPACES ||
     state.filterRepoIds.length > 0 ||
+    (state.filterWorkspaceStatuses?.length ?? 0) > 0 ||
     state.hideDefaultBranchWorkspace ||
     state.hideAutomationGeneratedWorkspaces ||
     state.hideCliCreatedWorkspaces ||
@@ -31,6 +32,7 @@ export function sidebarHasActiveFilters(state: SidebarFilterState): boolean {
 export type ClearFilterActions = {
   resetShowSleepingWorkspaces: boolean
   resetFilterRepoIds: boolean
+  resetFilterWorkspaceStatuses: boolean
   resetHideDefaultBranchWorkspace: boolean
   resetHideAutomationGeneratedWorkspaces: boolean
   resetHideCliCreatedWorkspaces: boolean
@@ -54,6 +56,7 @@ export function computeClearFilterActions(state: SidebarFilterState): ClearFilte
   return {
     resetShowSleepingWorkspaces: state.showSleepingWorkspaces !== DEFAULT_SHOW_SLEEPING_WORKSPACES,
     resetFilterRepoIds: state.filterRepoIds.length > 0,
+    resetFilterWorkspaceStatuses: (state.filterWorkspaceStatuses?.length ?? 0) > 0,
     resetHideDefaultBranchWorkspace: state.hideDefaultBranchWorkspace,
     resetHideAutomationGeneratedWorkspaces: state.hideAutomationGeneratedWorkspaces,
     resetHideCliCreatedWorkspaces: state.hideCliCreatedWorkspaces,

--- a/src/renderer/src/components/sidebar/sidebar-filter-state.test.ts
+++ b/src/renderer/src/components/sidebar/sidebar-filter-state.test.ts
@@ -149,6 +149,7 @@ describe('computeClearFilterActions', () => {
     expect(computeClearFilterActions(filterState())).toEqual({
       resetShowSleepingWorkspaces: false,
       resetFilterRepoIds: false,
+      resetFilterWorkspaceStatuses: false,
       resetHideDefaultBranchWorkspace: false,
       resetHideAutomationGeneratedWorkspaces: false,
       resetHideCliCreatedWorkspaces: false,
@@ -166,6 +167,7 @@ describe('computeClearFilterActions', () => {
     expect(computeClearFilterActions(filterState({ hideDefaultBranchWorkspace: true }))).toEqual({
       resetShowSleepingWorkspaces: false,
       resetFilterRepoIds: false,
+      resetFilterWorkspaceStatuses: false,
       resetHideDefaultBranchWorkspace: true,
       resetHideAutomationGeneratedWorkspaces: false,
       resetHideCliCreatedWorkspaces: false,
@@ -182,6 +184,7 @@ describe('computeClearFilterActions', () => {
     ).toEqual({
       resetShowSleepingWorkspaces: false,
       resetFilterRepoIds: false,
+      resetFilterWorkspaceStatuses: false,
       resetHideDefaultBranchWorkspace: false,
       resetHideAutomationGeneratedWorkspaces: true,
       resetHideCliCreatedWorkspaces: false,
@@ -196,6 +199,7 @@ describe('computeClearFilterActions', () => {
     expect(computeClearFilterActions(filterState({ hideCliCreatedWorkspaces: true }))).toEqual({
       resetShowSleepingWorkspaces: false,
       resetFilterRepoIds: false,
+      resetFilterWorkspaceStatuses: false,
       resetHideDefaultBranchWorkspace: false,
       resetHideAutomationGeneratedWorkspaces: false,
       resetHideCliCreatedWorkspaces: true,
@@ -210,6 +214,7 @@ describe('computeClearFilterActions', () => {
     expect(computeClearFilterActions(filterState({ hideDetachedHeadWorkspaces: true }))).toEqual({
       resetShowSleepingWorkspaces: false,
       resetFilterRepoIds: false,
+      resetFilterWorkspaceStatuses: false,
       resetHideDefaultBranchWorkspace: false,
       resetHideAutomationGeneratedWorkspaces: false,
       resetHideCliCreatedWorkspaces: false,
@@ -237,6 +242,7 @@ describe('computeClearFilterActions', () => {
     expect(computeClearFilterActions(filterState({ workspaceHostScope: 'ssh:host-1' }))).toEqual({
       resetShowSleepingWorkspaces: false,
       resetFilterRepoIds: false,
+      resetFilterWorkspaceStatuses: false,
       resetHideDefaultBranchWorkspace: false,
       resetHideAutomationGeneratedWorkspaces: false,
       resetHideCliCreatedWorkspaces: false,
@@ -253,6 +259,7 @@ describe('computeClearFilterActions', () => {
     ).toEqual({
       resetShowSleepingWorkspaces: false,
       resetFilterRepoIds: false,
+      resetFilterWorkspaceStatuses: false,
       resetHideDefaultBranchWorkspace: false,
       resetHideAutomationGeneratedWorkspaces: false,
       resetHideCliCreatedWorkspaces: false,
@@ -277,6 +284,7 @@ describe('computeClearFilterActions', () => {
     ).toEqual({
       resetShowSleepingWorkspaces: true,
       resetFilterRepoIds: true,
+      resetFilterWorkspaceStatuses: false,
       resetHideDefaultBranchWorkspace: true,
       resetHideAutomationGeneratedWorkspaces: true,
       resetHideCliCreatedWorkspaces: false,

--- a/src/renderer/src/components/sidebar/use-visible-workspace-kanban-worktree-ids.ts
+++ b/src/renderer/src/components/sidebar/use-visible-workspace-kanban-worktree-ids.ts
@@ -45,6 +45,12 @@ export function useVisibleWorkspaceKanbanWorktreeIds({
   const visibleWorkspaceHostIds = useAppStore((s) => s.visibleWorkspaceHostIds)
   const settings = useAppStore((s) => s.settings)
   const filterRepoIds = useAppStore((s) => s.filterRepoIds)
+  const filterWorkspaceStatuses = useAppStore((s) => s.filterWorkspaceStatuses)
+  // Why gated: without a status filter the catalog is unused here, and
+  // subscribing would rerun the board's visibility pass on every status edit.
+  const workspaceStatuses = useAppStore((s) =>
+    s.filterWorkspaceStatuses.length > 0 ? s.workspaceStatuses : undefined
+  )
   const tabsByWorktree = useAppStore((s) => (!showSleepingWorkspaces ? s.tabsByWorktree : null))
   const ptyIdsByTabId = useAppStore((s) => (!showSleepingWorkspaces ? s.ptyIdsByTabId : null))
   const browserTabsByWorktree = useAppStore((s) =>
@@ -71,6 +77,8 @@ export function useVisibleWorkspaceKanbanWorktreeIds({
     return new Set(
       computeVisibleWorktrees(worktreesByRepo, sortedIds, {
         filterRepoIds,
+        filterWorkspaceStatuses,
+        workspaceStatuses,
         showSleepingWorkspaces,
         tabsByWorktree,
         ptyIdsByTabId,
@@ -99,6 +107,8 @@ export function useVisibleWorkspaceKanbanWorktreeIds({
     allWorktrees,
     browserTabsByWorktree,
     filterRepoIds,
+    filterWorkspaceStatuses,
+    workspaceStatuses,
     hideDefaultBranchWorkspace,
     hideAutomationGeneratedWorkspaces,
     hideCliCreatedWorkspaces,

--- a/src/renderer/src/components/sidebar/visible-worktree-kinds.ts
+++ b/src/renderer/src/components/sidebar/visible-worktree-kinds.ts
@@ -1,5 +1,5 @@
 import type { ExecutionHostId, ExecutionHostScope } from '../../../../shared/execution-host'
-import type { Worktree } from '../../../../shared/worktree/types'
+import type { Worktree, WorkspaceStatus } from '../../../../shared/worktree/types'
 import { getWorktreeGitIdentityDisplay } from '@/lib/worktree-git-identity-display'
 
 /**
@@ -52,6 +52,8 @@ export function isDetachedHeadWorkspace(worktree: Worktree): boolean {
 export type SidebarFilterState = {
   showSleepingWorkspaces: boolean
   filterRepoIds: readonly string[]
+  /** Selected workspace-status ids; empty means every status is shown. */
+  filterWorkspaceStatuses?: readonly WorkspaceStatus[]
   hideDefaultBranchWorkspace: boolean
   hideAutomationGeneratedWorkspaces: boolean
   hideCliCreatedWorkspaces: boolean

--- a/src/renderer/src/components/sidebar/visible-worktree-status-filter.ts
+++ b/src/renderer/src/components/sidebar/visible-worktree-status-filter.ts
@@ -1,0 +1,34 @@
+import { getWorkspaceStatus } from '../../../../shared/workspace-statuses'
+import type {
+  Worktree,
+  WorkspaceStatus,
+  WorkspaceStatusDefinition
+} from '../../../../shared/worktree/types'
+
+/**
+ * Narrows rows to the selected card statuses; an empty selection shows every status.
+ *
+ * Split out of visible-worktrees to keep that file under the line cap.
+ *
+ * Why the two arguments fail *open* together: resolving a row's effective status
+ * needs the live catalog to fall back on, so ids without the catalog would resolve
+ * every row to the default id and collapse the list to one status. Omit either and
+ * nothing filters.
+ *
+ * Why this operates on worktrees rather than ids: two execution hosts can publish
+ * the same worktree id (STA-4343), and each of those rows carries its own status.
+ * Filtering by id would fold them together and judge both on one row's status.
+ */
+export function filterWorktreesByWorkspaceStatus(
+  worktrees: Worktree[],
+  filterWorkspaceStatuses: readonly WorkspaceStatus[] | undefined,
+  workspaceStatuses: readonly WorkspaceStatusDefinition[] | undefined
+): Worktree[] {
+  if (!filterWorkspaceStatuses?.length || !workspaceStatuses) {
+    return worktrees
+  }
+  const selected = new Set(filterWorkspaceStatuses)
+  return worktrees.filter((worktree) =>
+    selected.has(getWorkspaceStatus(worktree, workspaceStatuses))
+  )
+}

--- a/src/renderer/src/components/sidebar/visible-worktrees-status-filter.test.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees-status-filter.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest'
+import { computeVisibleWorktreeIds, sidebarHasActiveFilters } from './visible-worktrees'
+import type { Repo } from '../../../../shared/repo-types'
+import type { Worktree, WorkspaceStatusDefinition } from '../../../../shared/worktree/types'
+import { LOCAL_EXECUTION_HOST_ID } from '../../../../shared/execution-host'
+import { DEFAULT_WORKSPACE_STATUSES } from '../../../../shared/workspace-statuses'
+
+const STATUSES: readonly WorkspaceStatusDefinition[] = DEFAULT_WORKSPACE_STATUSES
+
+function makeWorktree(id: string, workspaceStatus?: string): Worktree {
+  return {
+    id,
+    repoId: 'repo1',
+    path: `/tmp/${id}`,
+    head: 'abc123',
+    branch: 'refs/heads/main',
+    isBare: false,
+    isMainWorktree: false,
+    displayName: id,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    ...(workspaceStatus ? { workspaceStatus } : {})
+  }
+}
+
+const repoMap = new Map<string, Repo>([
+  ['repo1', { id: 'repo1', path: '/repo1', displayName: 'Repo 1', badgeColor: '#000', addedAt: 0 }]
+])
+
+type VisibleOptions = Parameters<typeof computeVisibleWorktreeIds>[2]
+
+function visibleOptions(overrides: Partial<VisibleOptions> = {}): VisibleOptions {
+  return {
+    filterRepoIds: [],
+    showSleepingWorkspaces: true,
+    tabsByWorktree: {},
+    ptyIdsByTabId: {},
+    browserTabsByWorktree: {},
+    worktreeIdsWithLiveAgent: new Set(),
+    hideDefaultBranchWorkspace: false,
+    hideAutomationGeneratedWorkspaces: false,
+    hideCliCreatedWorkspaces: false,
+    hideDetachedHeadWorkspaces: false,
+    hideWorkspacesFromOtherDevices: false,
+    pairedDeviceIdsByEnvironment: new Map(),
+    repoMap,
+    workspaceHostScope: 'all',
+    defaultHostId: LOCAL_EXECUTION_HOST_ID,
+    worktreeLineageById: {},
+    ...overrides
+  }
+}
+
+// One workspace per default status, plus one that has never been assigned a
+// status (so it resolves to the catalog default, 'in-progress').
+const todo = makeWorktree('wt-todo', 'todo')
+const inProgress = makeWorktree('wt-in-progress', 'in-progress')
+const inReview = makeWorktree('wt-in-review', 'in-review')
+const done = makeWorktree('wt-done', 'completed')
+const unset = makeWorktree('wt-unset')
+
+const worktreesByRepo = { repo1: [todo, inProgress, inReview, done, unset] }
+const sortedIds = ['wt-todo', 'wt-in-progress', 'wt-in-review', 'wt-done', 'wt-unset']
+
+function visibleWith(overrides: Partial<VisibleOptions>): string[] {
+  return computeVisibleWorktreeIds(worktreesByRepo, sortedIds, visibleOptions(overrides))
+}
+
+describe('computeVisibleWorktreeIds workspace-status filter', () => {
+  it('shows every status when the selection is empty', () => {
+    expect(visibleWith({ filterWorkspaceStatuses: [], workspaceStatuses: STATUSES })).toEqual(
+      sortedIds
+    )
+  })
+
+  it('narrows the list to a single selected status', () => {
+    expect(
+      visibleWith({ filterWorkspaceStatuses: ['completed'], workspaceStatuses: STATUSES })
+    ).toEqual(['wt-done'])
+  })
+
+  it('unions multiple selected statuses in sort order', () => {
+    expect(
+      visibleWith({
+        filterWorkspaceStatuses: ['todo', 'in-review'],
+        workspaceStatuses: STATUSES
+      })
+    ).toEqual(['wt-todo', 'wt-in-review'])
+  })
+
+  it('resolves an unset workspaceStatus to the catalog default', () => {
+    // 'in-progress' is the catalog default, so the never-assigned workspace
+    // must ride along with the explicitly in-progress one.
+    expect(
+      visibleWith({ filterWorkspaceStatuses: ['in-progress'], workspaceStatuses: STATUSES })
+    ).toEqual(['wt-in-progress', 'wt-unset'])
+  })
+
+  it('returns an empty list when no workspace holds a selected status', () => {
+    // The empty-result state the sidebar's "No workspaces found" + Clear
+    // Filters escape hatch renders against.
+    const custom: WorkspaceStatusDefinition[] = [
+      ...STATUSES,
+      { id: 'blocked', label: 'Blocked', color: 'rose', icon: 'ban' }
+    ]
+    const visible = visibleWith({
+      filterWorkspaceStatuses: ['blocked'],
+      workspaceStatuses: custom
+    })
+
+    expect(visible).toEqual([])
+    // An empty list is only acceptable because Clear Filters can undo it.
+    expect(
+      sidebarHasActiveFilters({
+        showSleepingWorkspaces: true,
+        filterRepoIds: [],
+        filterWorkspaceStatuses: ['blocked'],
+        hideDefaultBranchWorkspace: false,
+        hideAutomationGeneratedWorkspaces: false,
+        hideCliCreatedWorkspaces: false,
+        hideDetachedHeadWorkspaces: false,
+        hideWorkspacesFromOtherDevices: false
+      })
+    ).toBe(true)
+  })
+
+  it('fails open when the catalog is missing, rather than collapsing to the default status', () => {
+    // Why: a caller that forwards ids without the catalog would otherwise
+    // resolve every row to the default id and silently show one status.
+    expect(visibleWith({ filterWorkspaceStatuses: ['completed'] })).toEqual(sortedIds)
+  })
+
+  it('ignores a selected id that is not in the catalog instead of hiding everything', () => {
+    // A stale id (deleted custom status) reaching the pipeline must not empty
+    // the list on its own; it simply matches nothing beyond the live ids.
+    expect(
+      visibleWith({
+        filterWorkspaceStatuses: ['deleted-custom', 'todo'],
+        workspaceStatuses: STATUSES
+      })
+    ).toEqual(['wt-todo'])
+  })
+
+  it('intersects with the other sidebar filters rather than replacing them', () => {
+    const archived = { ...makeWorktree('wt-archived', 'completed'), isArchived: true }
+    const visible = computeVisibleWorktreeIds(
+      { repo1: [...worktreesByRepo.repo1, archived] },
+      [...sortedIds, 'wt-archived'],
+      visibleOptions({ filterWorkspaceStatuses: ['completed'], workspaceStatuses: STATUSES })
+    )
+
+    expect(visible).toEqual(['wt-done'])
+  })
+})

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -26,7 +26,7 @@ import type {
   WorkspaceStatus,
   WorkspaceStatusDefinition
 } from '../../../../shared/worktree/types'
-import { getWorkspaceStatus } from '../../../../shared/workspace-statuses'
+import { filterWorktreesByWorkspaceStatus } from './visible-worktree-status-filter'
 import { buildWorktreeComparator, sortWorktreesSmart } from './smart-sort'
 import { getWorktreeIdsWithLiveAgent, isInactiveWorkspace } from '@/lib/worktree-activity-state'
 import { useAppStore } from '@/store'
@@ -68,15 +68,9 @@ import { getWorktreeHostIdentity } from '../../../../shared/worktree/host-qualif
  */
 type VisibleWorktreeOptions = {
   filterRepoIds: readonly string[]
-  /**
-   * Selected workspace-status ids; empty shows every status.
-   *
-   * Why optional, and why paired with `workspaceStatuses`: resolving a
-   * worktree's effective status needs the live catalog to fall back on. A
-   * caller that passes ids without the catalog would resolve every row to the
-   * default id and narrow the list to one status, so the pair fails *open* —
-   * omit either and no status filtering happens.
-   */
+  /** Selected workspace-status ids; empty shows every status. Why paired with
+   *  `workspaceStatuses`: resolving a row's effective status needs the catalog
+   *  to fall back on, so the pair fails *open* — omit either and nothing filters. */
   filterWorkspaceStatuses?: readonly WorkspaceStatus[]
   workspaceStatuses?: readonly WorkspaceStatusDefinition[]
   showSleepingWorkspaces: boolean
@@ -157,15 +151,10 @@ export function computeVisibleWorktrees(
     all = all.filter((w) => selectedRepoIds.has(w.repoId))
   }
 
-  // Filter by workspace (card) status. Empty selection shows every status.
-  // Why here and not per row at render time: workspaceStatus is a plain field
-  // on the worktree, so this is one O(worktrees) pass with a Set lookup inside
-  // the pipeline that already runs once per filter/sort snapshot.
-  if (opts.filterWorkspaceStatuses?.length && opts.workspaceStatuses) {
-    const selectedStatusIds = new Set(opts.filterWorkspaceStatuses)
-    const statuses = opts.workspaceStatuses
-    all = all.filter((w) => selectedStatusIds.has(getWorkspaceStatus(w, statuses)))
-  }
+  // Why here and not per row at render time: workspaceStatus is a plain field on
+  // the worktree, so this is one O(worktrees) pass inside the pipeline that
+  // already runs once per filter/sort snapshot.
+  all = filterWorktreesByWorkspaceStatus(all, opts.filterWorkspaceStatuses, opts.workspaceStatuses)
 
   if (!opts.showSleepingWorkspaces) {
     // Why no !hideDefaultBranchWorkspace term: that filter already ran above, so

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -21,7 +21,12 @@ import {
   getVisibleWorkspaceHostIdSet,
   worktreeMatchesVisibleHost
 } from './visible-worktree-host-scope'
-import type { Worktree } from '../../../../shared/worktree/types'
+import type {
+  Worktree,
+  WorkspaceStatus,
+  WorkspaceStatusDefinition
+} from '../../../../shared/worktree/types'
+import { getWorkspaceStatus } from '../../../../shared/workspace-statuses'
 import { buildWorktreeComparator, sortWorktreesSmart } from './smart-sort'
 import { getWorktreeIdsWithLiveAgent, isInactiveWorkspace } from '@/lib/worktree-activity-state'
 import { useAppStore } from '@/store'
@@ -63,6 +68,17 @@ import { getWorktreeHostIdentity } from '../../../../shared/worktree/host-qualif
  */
 type VisibleWorktreeOptions = {
   filterRepoIds: readonly string[]
+  /**
+   * Selected workspace-status ids; empty shows every status.
+   *
+   * Why optional, and why paired with `workspaceStatuses`: resolving a
+   * worktree's effective status needs the live catalog to fall back on. A
+   * caller that passes ids without the catalog would resolve every row to the
+   * default id and narrow the list to one status, so the pair fails *open* —
+   * omit either and no status filtering happens.
+   */
+  filterWorkspaceStatuses?: readonly WorkspaceStatus[]
+  workspaceStatuses?: readonly WorkspaceStatusDefinition[]
   showSleepingWorkspaces: boolean
   tabsByWorktree: Record<string, Pick<TerminalTab, 'id'>[]> | null
   ptyIdsByTabId: Record<string, string[]> | null
@@ -139,6 +155,16 @@ export function computeVisibleWorktrees(
   if (opts.filterRepoIds.length > 0) {
     const selectedRepoIds = new Set(opts.filterRepoIds)
     all = all.filter((w) => selectedRepoIds.has(w.repoId))
+  }
+
+  // Filter by workspace (card) status. Empty selection shows every status.
+  // Why here and not per row at render time: workspaceStatus is a plain field
+  // on the worktree, so this is one O(worktrees) pass with a Set lookup inside
+  // the pipeline that already runs once per filter/sort snapshot.
+  if (opts.filterWorkspaceStatuses?.length && opts.workspaceStatuses) {
+    const selectedStatusIds = new Set(opts.filterWorkspaceStatuses)
+    const statuses = opts.workspaceStatuses
+    all = all.filter((w) => selectedStatusIds.has(getWorkspaceStatus(w, statuses)))
   }
 
   if (!opts.showSleepingWorkspaces) {
@@ -301,6 +327,8 @@ export function getVisibleWorktreeIds(): string[] {
 
   const visibleIds = computeVisibleWorktreeIds(state.worktreesByRepo, sortedIds, {
     filterRepoIds: state.filterRepoIds,
+    filterWorkspaceStatuses: state.filterWorkspaceStatuses,
+    workspaceStatuses: state.workspaceStatuses,
     showSleepingWorkspaces: state.showSleepingWorkspaces,
     tabsByWorktree: state.tabsByWorktree,
     ptyIdsByTabId: state.ptyIdsByTabId,

--- a/src/renderer/src/components/sidebar/worktree-list/listing/active-workspace-survives-status-filter.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/active-workspace-survives-status-filter.test.ts
@@ -1,0 +1,157 @@
+// @vitest-environment happy-dom
+
+import { cleanup, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { useAppStore } from '@/store'
+import { makeWorktree } from '@/store/slices/store-test-helpers'
+import { getDefaultSettings } from '../../../../../../shared/constants'
+import { LOCAL_EXECUTION_HOST_ID } from '../../../../../../shared/execution-host'
+import type { Repo } from '../../../../../../shared/repo-types'
+import { DEFAULT_WORKSPACE_STATUSES } from '../../../../../../shared/workspace-statuses'
+import { useVisibleSidebarWorktrees } from './use-visible-worktrees'
+import type { SidebarWorktreeFilters } from './use-filters'
+
+const initialState = useAppStore.getInitialState()
+
+const REPO: Repo = {
+  id: 'repo1',
+  path: '/tmp/repo1',
+  displayName: 'Repo 1',
+  badgeColor: '#000',
+  addedAt: 0
+}
+
+// The active workspace sits on a status the filter excludes — the state you land
+// in by running "Move to Status" on the row you are working in.
+const ACTIVE_ID = 'repo1::/tmp/active'
+const TODO_ID = 'repo1::/tmp/todo'
+
+const WORKTREES = {
+  repo1: [
+    makeWorktree({ id: ACTIVE_ID, repoId: 'repo1', displayName: 'active', path: '/tmp/active' }),
+    makeWorktree({ id: TODO_ID, repoId: 'repo1', displayName: 'todo', path: '/tmp/todo' })
+  ]
+}
+
+function filterState(
+  overrides: Partial<SidebarWorktreeFilters['filterState']> = {}
+): SidebarWorktreeFilters['filterState'] {
+  return {
+    showSleepingWorkspaces: true,
+    filterRepoIds: [],
+    filterWorkspaceStatuses: [],
+    hideDefaultBranchWorkspace: false,
+    hideAutomationGeneratedWorkspaces: false,
+    hideCliCreatedWorkspaces: false,
+    hideDetachedHeadWorkspaces: false,
+    hideWorkspacesFromOtherDevices: false,
+    alwaysShowDefaultBranchWorkspace: true,
+    visibleWorkspaceHostIds: null,
+    workspaceHostScope: 'all',
+    ...overrides
+  }
+}
+
+function seed(activeStatus: string, selected: readonly string[]): void {
+  useAppStore.setState(
+    {
+      ...initialState,
+      settings: getDefaultSettings('/tmp'),
+      repos: [REPO],
+      worktreesByRepo: {
+        repo1: [
+          { ...WORKTREES.repo1[0]!, workspaceStatus: activeStatus },
+          { ...WORKTREES.repo1[1]!, workspaceStatus: 'todo' }
+        ]
+      },
+      workspaceStatuses: [...DEFAULT_WORKSPACE_STATUSES],
+      filterWorkspaceStatuses: selected,
+      activeWorktreeId: ACTIVE_ID
+    },
+    true
+  )
+}
+
+function renderVisibleIds(
+  overrides: Partial<SidebarWorktreeFilters['filterState']> = {}
+): string[] {
+  const state = useAppStore.getState()
+  const worktrees = state.worktreesByRepo.repo1 ?? []
+  const { result } = renderHook(() =>
+    useVisibleSidebarWorktrees({
+      filterState: filterState(overrides),
+      sortBy: 'manual',
+      sortedIds: worktrees.map((w) => w.id),
+      repoMap: new Map([[REPO.id, REPO]]),
+      worktreeMap: new Map(worktrees.map((w) => [w.id, w])),
+      worktreeLineageById: {},
+      settings: state.settings,
+      agentSendTargetWorktreeId: null
+    })
+  )
+  return result.current.visibleWorktrees.map((w) => w.id)
+}
+
+afterEach(() => {
+  cleanup()
+  useAppStore.setState(initialState, true)
+})
+
+describe('active workspace under a card-status filter', () => {
+  it('keeps the active workspace listed after its status is filtered out', () => {
+    seed('completed', ['todo'])
+
+    const ids = renderVisibleIds({ filterWorkspaceStatuses: ['todo'] })
+
+    // Without the active-workspace pin this is just ['repo1::/tmp/todo'] — the
+    // row you are working in disappears while its panes stay open.
+    expect(ids).toContain(ACTIVE_ID)
+    expect(ids).toContain(TODO_ID)
+  })
+
+  it('still filters non-active workspaces off the excluded status', () => {
+    seed('todo', ['todo'])
+    useAppStore.setState({
+      worktreesByRepo: {
+        repo1: [
+          { ...WORKTREES.repo1[0]!, workspaceStatus: 'todo' },
+          { ...WORKTREES.repo1[1]!, workspaceStatus: 'completed' }
+        ]
+      }
+    })
+
+    const ids = renderVisibleIds({ filterWorkspaceStatuses: ['todo'] })
+
+    expect(ids).toEqual([ACTIVE_ID])
+  })
+
+  // Why: the pin is gated on the status filter precisely so it does not widen
+  // any other filter. Status is the only dimension reachable from the row.
+  it('does not pin the active workspace when no status filter is set', () => {
+    seed('completed', [])
+    useAppStore.setState({
+      worktreesByRepo: {
+        repo1: [
+          { ...WORKTREES.repo1[0]!, workspaceStatus: 'completed', repoId: 'repo1' },
+          { ...WORKTREES.repo1[1]!, workspaceStatus: 'todo' }
+        ]
+      }
+    })
+
+    const ids = renderVisibleIds({ filterRepoIds: ['repo-other'] })
+
+    expect(ids).toEqual([])
+  })
+})
+
+// Keeps the fixture honest: the excluded status must really be in the catalog,
+// otherwise sanitization would drop the filter and the first case would pass
+// for the wrong reason.
+describe('fixture', () => {
+  it('uses catalog statuses the filter can actually select', () => {
+    const ids = DEFAULT_WORKSPACE_STATUSES.map((s) => s.id)
+    expect(ids).toContain('todo')
+    expect(ids).toContain('completed')
+    expect(LOCAL_EXECUTION_HOST_ID).toBeTruthy()
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-list/listing/active-workspace-survives-status-filter.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/active-workspace-survives-status-filter.test.ts
@@ -83,7 +83,6 @@ function renderVisibleIds(
       sortBy: 'manual',
       sortedIds: worktrees.map((w) => w.id),
       repoMap: new Map([[REPO.id, REPO]]),
-      worktreeMap: new Map(worktrees.map((w) => [w.id, w])),
       worktreeLineageById: {},
       settings: state.settings,
       agentSendTargetWorktreeId: null

--- a/src/renderer/src/components/sidebar/worktree-list/listing/use-filters.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/use-filters.ts
@@ -9,6 +9,7 @@ export type SidebarWorktreeFilters = ReturnType<typeof useSidebarWorktreeFilters
 export function useSidebarWorktreeFilters() {
   const showSleepingWorkspaces = useAppStore((s) => s.showSleepingWorkspaces)
   const filterRepoIds = useAppStore((s) => s.filterRepoIds)
+  const filterWorkspaceStatuses = useAppStore((s) => s.filterWorkspaceStatuses)
   const hideDefaultBranchWorkspace = useAppStore((s) => s.hideDefaultBranchWorkspace)
   const hideAutomationGeneratedWorkspaces = useAppStore((s) => s.hideAutomationGeneratedWorkspaces)
   const hideCliCreatedWorkspaces = useAppStore((s) => s.hideCliCreatedWorkspaces)
@@ -30,6 +31,7 @@ export function useSidebarWorktreeFilters() {
     (s) => s.setAlwaysShowDefaultBranchWorkspace
   )
   const setFilterRepoIds = useAppStore((s) => s.setFilterRepoIds)
+  const setFilterWorkspaceStatuses = useAppStore((s) => s.setFilterWorkspaceStatuses)
   const setVisibleWorkspaceHostIds = useAppStore((s) => s.setVisibleWorkspaceHostIds)
 
   // Why: count hideDefaultBranchWorkspace as a filter so the Clear Filters escape hatch stays reachable when it alone empties the list.
@@ -37,6 +39,7 @@ export function useSidebarWorktreeFilters() {
     () => ({
       showSleepingWorkspaces,
       filterRepoIds,
+      filterWorkspaceStatuses,
       hideDefaultBranchWorkspace,
       hideAutomationGeneratedWorkspaces,
       hideCliCreatedWorkspaces,
@@ -49,6 +52,7 @@ export function useSidebarWorktreeFilters() {
     [
       showSleepingWorkspaces,
       filterRepoIds,
+      filterWorkspaceStatuses,
       hideDefaultBranchWorkspace,
       hideAutomationGeneratedWorkspaces,
       hideCliCreatedWorkspaces,
@@ -67,6 +71,9 @@ export function useSidebarWorktreeFilters() {
     }
     if (actions.resetFilterRepoIds) {
       setFilterRepoIds([])
+    }
+    if (actions.resetFilterWorkspaceStatuses) {
+      setFilterWorkspaceStatuses([])
     }
     if (actions.resetHideDefaultBranchWorkspace) {
       setHideDefaultBranchWorkspace(false)
@@ -92,6 +99,7 @@ export function useSidebarWorktreeFilters() {
   }, [
     setShowSleepingWorkspaces,
     setFilterRepoIds,
+    setFilterWorkspaceStatuses,
     setHideDefaultBranchWorkspace,
     setHideAutomationGeneratedWorkspaces,
     setHideCliCreatedWorkspaces,

--- a/src/renderer/src/components/sidebar/worktree-list/listing/use-visible-worktrees.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/use-visible-worktrees.test.tsx
@@ -30,6 +30,7 @@ describe('useVisibleSidebarWorktrees', () => {
         filterState: {
           showSleepingWorkspaces: true,
           filterRepoIds: [],
+          filterWorkspaceStatuses: [],
           hideDefaultBranchWorkspace: false,
           hideAutomationGeneratedWorkspaces: false,
           hideCliCreatedWorkspaces: false,
@@ -65,6 +66,7 @@ describe('useVisibleSidebarWorktrees', () => {
         filterState: {
           showSleepingWorkspaces: true,
           filterRepoIds: [],
+          filterWorkspaceStatuses: [],
           hideDefaultBranchWorkspace: false,
           hideAutomationGeneratedWorkspaces: false,
           hideCliCreatedWorkspaces: false,

--- a/src/renderer/src/components/sidebar/worktree-list/listing/use-visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/use-visible-worktrees.ts
@@ -52,6 +52,15 @@ export function useVisibleSidebarWorktrees(args: {
   const workspaceStatuses = useAppStore((s) =>
     filterWorkspaceStatuses?.length ? s.workspaceStatuses : undefined
   )
+  // Why pin the active workspace while a status filter is on: "Move to Status"
+  // sits on the row itself, so restatusing the workspace you are working in
+  // would otherwise delete its row while its panes stay open, with nothing on
+  // screen explaining why. Status is the only filter dimension reachable from
+  // the row, so no other filter can be turned against the row that turned it —
+  // hence the gate rather than pinning the active row unconditionally.
+  const activeWorktreeId = useAppStore((s) =>
+    filterWorkspaceStatuses?.length ? s.activeWorktreeId : null
+  )
   const agentStatusEpoch = useAppStore((s) => (!showSleepingWorkspaces ? s.agentStatusEpoch : 0))
   const runtimeEnvironments = useAppStore((s) => s.runtimeEnvironments)
   const runtimeStatusByEnvironmentId = useAppStore((s) => s.runtimeStatusByEnvironmentId)
@@ -103,12 +112,13 @@ export function useVisibleSidebarWorktrees(args: {
       visibleWorkspaceHostIds,
       defaultHostId: getSettingsFocusedExecutionHostId(settings),
       worktreeLineageById,
-      forcedVisibleWorktreeIds: args.agentSendTargetWorktreeId
-        ? [args.agentSendTargetWorktreeId]
-        : undefined
+      forcedVisibleWorktreeIds: [args.agentSendTargetWorktreeId, activeWorktreeId].filter(
+        (id): id is string => id != null
+      )
     })
   }, [
     args.agentSendTargetWorktreeId,
+    activeWorktreeId,
     agentStatusEpoch,
     filterRepoIds,
     filterWorkspaceStatuses,

--- a/src/renderer/src/components/sidebar/worktree-list/listing/use-visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/use-visible-worktrees.ts
@@ -84,6 +84,10 @@ export function useVisibleSidebarWorktrees(args: {
 
   const recomputedVisibleWorktrees = useMemo(() => {
     void agentStatusEpoch
+    // Either, both or neither may be set; stay undefined when neither is.
+    const forcedVisibleWorktreeIds = [args.agentSendTargetWorktreeId, activeWorktreeId].filter(
+      (id): id is string => id != null
+    )
     return computeVisibleWorktrees(worktreesByRepo, sortedIds, {
       filterRepoIds,
       filterWorkspaceStatuses,
@@ -112,9 +116,8 @@ export function useVisibleSidebarWorktrees(args: {
       visibleWorkspaceHostIds,
       defaultHostId: getSettingsFocusedExecutionHostId(settings),
       worktreeLineageById,
-      forcedVisibleWorktreeIds: [args.agentSendTargetWorktreeId, activeWorktreeId].filter(
-        (id): id is string => id != null
-      )
+      forcedVisibleWorktreeIds:
+        forcedVisibleWorktreeIds.length > 0 ? forcedVisibleWorktreeIds : undefined
     })
   }, [
     args.agentSendTargetWorktreeId,

--- a/src/renderer/src/components/sidebar/worktree-list/listing/use-visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/use-visible-worktrees.ts
@@ -35,6 +35,7 @@ export function useVisibleSidebarWorktrees(args: {
   const {
     showSleepingWorkspaces,
     filterRepoIds,
+    filterWorkspaceStatuses,
     hideDefaultBranchWorkspace,
     hideAutomationGeneratedWorkspaces,
     hideCliCreatedWorkspaces,
@@ -45,6 +46,12 @@ export function useVisibleSidebarWorktrees(args: {
     workspaceHostScope
   } = filterState
   const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
+  // Why read the catalog only while a status filter is set: subscribing
+  // unconditionally would rerun this pipeline on every status rename/recolor
+  // for the majority of users who never filter by status.
+  const workspaceStatuses = useAppStore((s) =>
+    filterWorkspaceStatuses?.length ? s.workspaceStatuses : undefined
+  )
   const agentStatusEpoch = useAppStore((s) => (!showSleepingWorkspaces ? s.agentStatusEpoch : 0))
   const runtimeEnvironments = useAppStore((s) => s.runtimeEnvironments)
   const runtimeStatusByEnvironmentId = useAppStore((s) => s.runtimeStatusByEnvironmentId)
@@ -70,6 +77,8 @@ export function useVisibleSidebarWorktrees(args: {
     void agentStatusEpoch
     return computeVisibleWorktrees(worktreesByRepo, sortedIds, {
       filterRepoIds,
+      filterWorkspaceStatuses,
+      workspaceStatuses,
       showSleepingWorkspaces,
       tabsByWorktree,
       ptyIdsByTabId,
@@ -102,6 +111,8 @@ export function useVisibleSidebarWorktrees(args: {
     args.agentSendTargetWorktreeId,
     agentStatusEpoch,
     filterRepoIds,
+    filterWorkspaceStatuses,
+    workspaceStatuses,
     showSleepingWorkspaces,
     hideDefaultBranchWorkspace,
     hideAutomationGeneratedWorkspaces,

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5018,6 +5018,11 @@
           "allProjects": "All projects",
           "selectedProjectsCount": "{{value0}} projects"
         },
+        "SidebarWorkspaceStatusFilterSection": {
+          "status": "Status",
+          "allStatuses": "All statuses",
+          "selectedStatusesCount": "{{value0}} statuses"
+        },
         "SidebarSettingsHelpMenu": {
           "ad3d3ed7f1": "Restart Orca",
           "29c56f30ee": "Check for Updates",

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -24,6 +24,7 @@ import {
 } from './folder-workspace-path-status'
 import { toast } from 'sonner'
 import { isDetachedHeadWorkspace } from '@/components/sidebar/visible-worktrees'
+import { getWorkspaceStatus } from '../../../shared/workspace-statuses'
 import type { ExecutionHostId } from '../../../shared/execution-host'
 import { findFolderWorkspaceOwner } from './folder-workspace-runtime-owner'
 import type { WorktreeStartupPayload } from '@/lib/worktree-startup-payload'
@@ -223,6 +224,15 @@ export function activateAndRevealWorktree(
   }
   if (state.hideDetachedHeadWorkspaces && isDetachedHeadWorkspace(wt)) {
     state.setHideDetachedHeadWorkspaces(false)
+  }
+  // Why clear rather than add the target's status: matching the repo-filter
+  // rule above, and a one-status widening would still hide the neighbours the
+  // user is about to scroll through.
+  if (
+    state.filterWorkspaceStatuses.length > 0 &&
+    !state.filterWorkspaceStatuses.includes(getWorkspaceStatus(wt, state.workspaceStatuses))
+  ) {
+    state.setFilterWorkspaceStatuses([])
   }
 
   // 6. Reveal in sidebar

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -29,7 +29,7 @@ import type {
   WorktreeCardProperty
 } from '../../../../shared/ui-chrome-types'
 import type { ChangelogData, UpdateStatus } from '../../../../shared/update-status-types'
-import type { WorkspaceStatusDefinition } from '../../../../shared/worktree/types'
+import type { WorkspaceStatus, WorkspaceStatusDefinition } from '../../../../shared/worktree/types'
 import {
   applyManualRepoOrder,
   normalizeManualRepoOrder
@@ -99,7 +99,8 @@ import {
   clampWorkspaceBoardColumnWidth,
   clampWorkspaceBoardOpacity,
   cloneDefaultWorkspaceStatuses,
-  normalizeWorkspaceStatuses
+  normalizeWorkspaceStatuses,
+  sanitizeFilterWorkspaceStatuses
 } from '../../../../shared/workspace-statuses'
 import { clampMarkdownTocPanelWidth } from '../../../../shared/markdown-toc-panel-width'
 import { clampCombinedDiffFileTreeWidth } from '../../../../shared/combined-diff-file-tree-width'
@@ -914,6 +915,9 @@ export type UISlice = {
   toggleShowDotfilesForWorktree: (worktreeId: string) => void
   filterRepoIds: readonly string[]
   setFilterRepoIds: (ids: readonly string[]) => void
+  /** Selected workspace-status ids; empty means every status is shown. */
+  filterWorkspaceStatuses: readonly WorkspaceStatus[]
+  setFilterWorkspaceStatuses: (ids: readonly WorkspaceStatus[]) => void
   collapsedGroups: Set<string>
   toggleCollapsedGroup: (key: string) => void
   worktreeCardProperties: WorktreeCardProperty[]
@@ -2161,6 +2165,11 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
   filterRepoIds: [],
   setFilterRepoIds: (ids) => set({ filterRepoIds: ids }),
 
+  // Why bare set, like filterRepoIds: persistence rides the debounced
+  // usePersistedUIWriter save rather than a write per checkbox click.
+  filterWorkspaceStatuses: [],
+  setFilterWorkspaceStatuses: (ids) => set({ filterWorkspaceStatuses: ids }),
+
   collapsedGroups: new Set<string>(),
   toggleCollapsedGroup: (key) =>
     set((s) => {
@@ -2209,8 +2218,17 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
   workspaceStatuses: cloneDefaultWorkspaceStatuses(),
   setWorkspaceStatuses: (statuses) => {
     const normalized = normalizeWorkspaceStatuses(statuses)
-    window.api.ui.set({ workspaceStatuses: normalized }).catch(console.error)
-    set({ workspaceStatuses: normalized })
+    // Why prune here: an edit that deletes or renames a status would otherwise
+    // leave a filter id matching nothing, emptying the sidebar with the menu
+    // still reading "All statuses".
+    const filterWorkspaceStatuses = sanitizeFilterWorkspaceStatuses(
+      get().filterWorkspaceStatuses,
+      normalized
+    )
+    window.api.ui
+      .set({ workspaceStatuses: normalized, filterWorkspaceStatuses: [...filterWorkspaceStatuses] })
+      .catch(console.error)
+    set({ workspaceStatuses: normalized, filterWorkspaceStatuses })
   },
 
   workspaceBoardOpacity: 1,
@@ -2434,6 +2452,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
       const validRepoIds = new Set(s.repos.map((repo) => repo.id))
       const validRepoHostIdentities = new Set(s.repos.map(getRepoHostIdentity))
       const persistedFilterRepoIds = sanitizePersistedRepoIds(ui.filterRepoIds)
+      const persistedWorkspaceStatuses = normalizeWorkspaceStatuses(ui.workspaceStatuses)
       // Why: pre-rename builds used sidekick* keys; read as fallback only so new pet* writes win after upgrade.
       const customPets = Array.isArray(ui.customPets)
         ? ui.customPets
@@ -2546,7 +2565,14 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
         worktreeCardProperties: normalizeWorktreeCardProperties(ui.worktreeCardProperties),
         _worktreeCardModeDefaulted: ui._worktreeCardModeDefaulted === true,
         agentActivityDisplayMode: normalizeAgentActivityDisplayMode(ui.agentActivityDisplayMode),
-        workspaceStatuses: normalizeWorkspaceStatuses(ui.workspaceStatuses),
+        workspaceStatuses: persistedWorkspaceStatuses,
+        // Why validate against the same normalized catalog: a filter naming a
+        // since-deleted custom status would hide every workspace on restart,
+        // with no visible cause and no obvious way back.
+        filterWorkspaceStatuses: sanitizeFilterWorkspaceStatuses(
+          ui.filterWorkspaceStatuses,
+          persistedWorkspaceStatuses
+        ),
         workspaceBoardOpacity: clampWorkspaceBoardOpacity(ui.workspaceBoardOpacity),
         workspaceBoardColumnWidth: clampWorkspaceBoardColumnWidth(ui.workspaceBoardColumnWidth),
         syncTaskStatusFromWorkspaceBoard: ui.syncTaskStatusFromWorkspaceBoard === true,

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -486,6 +486,7 @@ export function getDefaultUIState(): PersistedUIState {
     alwaysShowDefaultBranchWorkspace: true,
     showDotfilesByWorktree: {},
     filterRepoIds: [],
+    filterWorkspaceStatuses: [],
     collapsedGroups: [],
     uiZoomLevel: 0,
     editorFontZoomLevel: 0,

--- a/src/shared/persisted-ui-state-types.ts
+++ b/src/shared/persisted-ui-state-types.ts
@@ -70,6 +70,8 @@ export type PersistedUIState = {
   /** Per-worktree Explorer dotfile visibility. Missing entries inherit the default: show. */
   showDotfilesByWorktree?: Record<string, boolean>
   filterRepoIds: string[]
+  /** Selected workspace-status ids; absent/empty means every status is shown. */
+  filterWorkspaceStatuses?: string[]
   collapsedGroups: string[]
   uiZoomLevel: number
   editorFontZoomLevel: number

--- a/src/shared/workspace-status-filter-sanitize.test.ts
+++ b/src/shared/workspace-status-filter-sanitize.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_WORKSPACE_STATUSES, sanitizeFilterWorkspaceStatuses } from './workspace-statuses'
+import type { WorkspaceStatusDefinition } from './worktree/types'
+
+const STATUSES: readonly WorkspaceStatusDefinition[] = DEFAULT_WORKSPACE_STATUSES
+
+describe('sanitizeFilterWorkspaceStatuses', () => {
+  it('keeps ids that still exist in the catalog', () => {
+    expect(sanitizeFilterWorkspaceStatuses(['todo', 'completed'], STATUSES)).toEqual([
+      'todo',
+      'completed'
+    ])
+  })
+
+  it('drops ids for statuses the catalog no longer defines', () => {
+    // The restart case: a custom status was deleted while a filter named it.
+    // Without this, the sidebar comes back empty with no visible cause.
+    expect(sanitizeFilterWorkspaceStatuses(['deleted-custom', 'todo'], STATUSES)).toEqual(['todo'])
+  })
+
+  it('collapses a selection naming every status back to "all"', () => {
+    expect(
+      sanitizeFilterWorkspaceStatuses(
+        STATUSES.map((status) => status.id),
+        STATUSES
+      )
+    ).toEqual([])
+  })
+
+  it('collapses to "all" when every selected id was pruned', () => {
+    expect(sanitizeFilterWorkspaceStatuses(['gone-a', 'gone-b'], STATUSES)).toEqual([])
+  })
+
+  it('keeps the surviving id when stale ids alone reach the catalog size', () => {
+    // Why this case: counting stale ids toward the "everything is selected"
+    // check would collapse a real one-status filter back to "all" — the filter
+    // would silently stop applying after an unrelated status was deleted.
+    expect(
+      sanitizeFilterWorkspaceStatuses(['todo', 'gone-a', 'gone-b', 'gone-c'], STATUSES)
+    ).toEqual(['todo'])
+  })
+
+  it('reorders into catalog order so the label and persisted value stay stable', () => {
+    expect(sanitizeFilterWorkspaceStatuses(['completed', 'todo'], STATUSES)).toEqual([
+      'todo',
+      'completed'
+    ])
+  })
+
+  it('de-duplicates repeated ids', () => {
+    expect(sanitizeFilterWorkspaceStatuses(['todo', 'todo'], STATUSES)).toEqual(['todo'])
+  })
+
+  it('treats non-array persisted payloads as no filter', () => {
+    expect(sanitizeFilterWorkspaceStatuses(undefined, STATUSES)).toEqual([])
+    expect(sanitizeFilterWorkspaceStatuses('todo', STATUSES)).toEqual([])
+    expect(sanitizeFilterWorkspaceStatuses([1, null, {}], STATUSES)).toEqual([])
+  })
+
+  it('returns the same array identity when nothing changed', () => {
+    // Why: this runs on every catalog edit; a fresh array would wake the
+    // debounced persisted-UI writer for a no-op normalization.
+    const already = ['todo', 'completed']
+    expect(sanitizeFilterWorkspaceStatuses(already, STATUSES)).toBe(already)
+
+    const empty: string[] = []
+    expect(sanitizeFilterWorkspaceStatuses(empty, STATUSES)).toBe(empty)
+  })
+
+  it('returns a new array when the selection actually changed', () => {
+    const stale = ['completed', 'gone']
+    expect(sanitizeFilterWorkspaceStatuses(stale, STATUSES)).not.toBe(stale)
+  })
+})

--- a/src/shared/workspace-statuses.ts
+++ b/src/shared/workspace-statuses.ts
@@ -268,6 +268,42 @@ export function getWorkspaceStatus(
     : getDefaultWorkspaceStatusId(statuses)
 }
 
+/**
+ * Drop selected filter ids that no longer exist in the catalog, and collapse a
+ * full selection back to "all".
+ *
+ * Why collapse: a selection naming every status filters nothing but still reads
+ * as an active filter in the badge and Clear Filters. Why prune: a filter for a
+ * since-deleted custom status would otherwise match no workspace and empty the
+ * sidebar with no visible cause.
+ *
+ * Returns the same array identity when nothing changed so the debounced
+ * persisted-UI writer isn't woken by a no-op normalization.
+ */
+export function sanitizeFilterWorkspaceStatuses(
+  value: unknown,
+  statuses: readonly WorkspaceStatusDefinition[]
+): WorkspaceStatus[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+  const seen = new Set<WorkspaceStatus>()
+  for (const entry of value) {
+    if (typeof entry === 'string' && isWorkspaceStatusId(entry, statuses)) {
+      seen.add(entry)
+    }
+  }
+  if (seen.size === 0 || seen.size === statuses.length) {
+    return value.length === 0 ? (value as WorkspaceStatus[]) : []
+  }
+  // Why catalog order, not selection order: the menu, the label ("N statuses")
+  // and the persisted value then stay stable across toggles.
+  const sanitized = statuses.filter((status) => seen.has(status.id)).map((status) => status.id)
+  return sanitized.length === value.length && sanitized.every((id, i) => id === value[i])
+    ? (value as WorkspaceStatus[])
+    : sanitized
+}
+
 export function getWorkspaceStatusGroupKey(status: WorkspaceStatus): string {
   return `${WORKSPACE_STATUS_GROUP_PREFIX}${encodeURIComponent(status)}`
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​473 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​473 |
| Prod | 17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​386 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​372 |

<!-- /orca-pr-loc -->

## ELI5

The sidebar can already **group** workspaces by card status (Todo / In progress / In review / Done), but it can't **filter** by it. This adds a "Status" row to the sidebar options menu (the sliders icon) with a checkbox per status. Tick nothing and you see everything, exactly as today. Tick "Done" and you see only your finished workspaces.

## What Changed

**The filter**

- New `Status` row in the sidebar options menu, under `Show`, next to `Hosts` and `Projects`. Same `DropdownMenuSub` shape as those two — label left, current value right ("All statuses" / the status name / "N statuses"), checkboxes in the nested panel.
- Positive multi-select: an **empty selection means "show everything"**. This matches the workspace-status filter already shipped on the Agent Dashboard in #11042 (`agent-board-filtering.ts`), which uses exactly `filters.workspaceStatuses.length === 0 || filters.workspaceStatuses.includes(id)`.
- The predicate lives in the shared `computeVisibleWorktreeIds` pipeline, so it applies in **every** grouping mode (Project / Status / PR / None), to the Workspace Board, and to the Cmd+1–9 numbering — those cannot diverge from the rendered card order because they read the same function.
- New `filterWorkspaceStatuses` UI state, persisted through the existing debounced `window.api.ui.set` writer and the `ClientUiWorkspaceFilterFields` allowlist. Counted by the filter badge and reset by Clear Filters.

**The traps this closes**

- **Stale ids can't empty your sidebar.** `sanitizeFilterWorkspaceStatuses` validates the selection against the live status catalog on hydrate *and* on every catalog edit. Delete a custom status you were filtering by and the filter drops that id instead of silently matching nothing.
- **"Select all" isn't a filter.** Selecting every status narrows nothing, so it collapses back to the empty selection rather than showing a filter badge that does nothing.
- **You can't trap yourself in the menu.** Deselecting the last checked status returns to "All statuses" instead of emptying the list from inside the control that created the problem.
- **Reveal still works.** Activating or revealing a workspace whose status is filtered out clears the filter, matching the existing repo-filter rule in `activateAndRevealWorktree`.

**One refactor, forced by a lint gate**

`visible-worktrees.ts` crossed the 300-line `max-lines` cap. Per AGENTS.md a disable or a baseline bump is not allowed, so `SidebarFilterState` / `sidebarHasActiveFilters` / `ClearFilterActions` / `computeClearFilterActions` moved into `sidebar-filter-state.ts`. That is the same split #13971 proposed, and the repo had already named the concept — `sidebar-filter-state.test.ts` existed before this PR. Four importers, no behavior change.

## Why

#13996 asks for this directly, and calls out the inconsistency: the Workspace Board and the Agent Dashboard both filter by `workspaceStatus`; the sidebar, which shares the model, does not.

**Why this supersedes the two open attempts**

| | #13971 (jihoonl) | #13999 (PannenetsF) | this PR |
|---|---|---|---|
| Model | **Inverted** — `hiddenWorkspaceStatusIds` | Positive — `filterWorkspaceStatuses` | Positive |
| Matches #13996's spec ("empty = show all") | ✗ | ✓ | ✓ |
| Matches shipped #11042 dashboard filter | ✗ | ✓ | ✓ |
| Prunes deleted statuses on catalog edit | ✗ | ✓ | ✓ |
| Validates persisted selection on hydrate | partial | ✓ | ✓ |
| Clears filter when revealing a hidden workspace | ✗ | ✓ | ✓ |
| Collapses a full selection back to "all" | n/a | ✗ | ✓ |
| Keeps the active workspace listed when its own status is filtered out | ✓ | ✗ | ✓ (adopted) |
| Applies the predicate inside the jump palette | ✓ | ✗ | ✗ **deliberate** |
| Merges into current `main` | ✗ 8 files conflict | ✗ 6 files conflict | ✓ clean |

#13999 had the right model and I have adopted its shape wholesale — positive selection, the pipeline predicate, catalog sanitization, and the reveal escape hatch are all its design. #13971 contributed the `sidebar-filter-state.ts` split and the active-workspace pin, both of which this PR also adopts. What is new here is the "select all collapses to none" rule (both PRs leave a full selection reading as an active filter that filters nothing), the deselect-the-last guard as a *collapse* rather than #13971's *disabled checkbox*, catalog-ordered persistence so the label is stable, and a rebase onto the post-#14465 / post-#14486 sidebar.

**The two places this PR deliberately differs from #13971, spelled out so nobody has to diff to find out whether they were intentional:**

- **The active-workspace pin is kept** (`use-visible-worktrees.ts`). "Move to Status" sits on the workspace row itself, so restatusing the workspace you are working in would otherwise delete its row while its panes stay open, with nothing on screen saying why. Status is the only filter dimension a user can flip from the row, so no other filter can be turned against the row that turned it — which is why the pin is gated on a status filter being active rather than applied unconditionally. Regression test: `worktree-list/listing/active-workspace-survives-status-filter.test.ts`.
- **The jump palette is NOT filtered**, where #13971 filtered it. This is the deliberate one. If the palette hid workspaces off the selected statuses, a filtered-out workspace would be unreachable by name and the "clear the filter on reveal" escape hatch in `activateAndRevealWorktree` could never fire — the recovery path would be gated behind the very filter it exists to recover from. Leaving the palette unfiltered keeps hidden workspaces findable, and jumping to one clears the filter.

**Performance (STA-3354)**

STA-3354 (P0) is about tab-agent status resolution scanning the whole global agent-status map per tab per render. **This filter does not touch that path.** It is worth stating plainly because the two things are both called "status" and they are not the same:

- `WorktreeStatus` (`src/renderer/src/lib/worktree-status.ts:14`, `active | working | permission | done | inactive`) is the **agent-activity dot**, derived from live PTYs and the agent-status map via `resolveWorktreeStatus`.
- `WorkspaceStatus` (`src/shared/worktree/types.ts:51`) is the **kanban card status** the user drags between board columns. It is a plain string field on the worktree.

#13996 and #11042 are both about the second one. So the added cost is one `Set.has(getWorkspaceStatus(w, statuses))` per worktree, inside `computeVisibleWorktreeIds`, which already runs once per filter/sort snapshot — not per row, not per render, and with no read of `agentStatusByPaneKey`. Both call sites also subscribe to the status catalog **only while a filter is active**, so users who never filter by status pay nothing and don't re-run the pipeline on status renames.

**Manual order (STA-3921 / #13847)**

No interaction. `computeVisibleWorktreeIds` takes the already-computed `sortedIds` and only *removes* entries, then re-sorts by that pre-existing order index. Filtering never derives or writes an order, so it cannot compound the manual-order jumping in #13847 — exactly like the existing repo and host filters.

## Linked Issue

Fixes #13996

Supersedes #13971 and #13999 (same feature, two authors; both now conflict with `main`).

Related but deliberately **not** bundled: #13938 (project name on grouped cards) and #9708 (folder workspaces under Status/PR grouping).

## Refactor collision assessment (#14443 / #14486)

Requested separately from the filter. Every claim below is from a `git merge-tree` probe, not from the GitHub mergeable flag — which was stale for #14486 throughout.

> **Update (2026-08-16) — the assessment's recommendation was borne out.** It was written against `origin/main` at `9bb8836bb6`, when #14486 was still open and GitHub was mislabelling it `CONFLICTING`. **#14486 merged on 2026-08-15T20:40:10Z**, and this PR has since been rebased onto the resulting layout. The analysis is kept below as written, with the claims that events have settled marked in place and the probe numbers re-run against current `main` (`96b03bab4f`). **#14443 is still open, and is now more obsolete than when this was written, not less.**

**#14443 is obsolete and should be closed, not merged.**

`refactor(sidebar): extract WorktreeList into focused modules` extracts a ~4800-line monolithic `WorktreeList.tsx` into ~40 flat `sidebar/use-worktree-*.ts` modules. That monolith no longer exists. **#14465** (nwparker, merged 2026-08-14T06:35:41Z, 81 files) already landed that extraction as a `sidebar/worktree-list/` module — 70 files — followed by #14467 for the quality gates. `main`'s `WorktreeList.tsx` is now 344 lines.

- #14443's head does **not** contain #14465's merge commit (`08027d0d2376`). It was last pushed 34 seconds before #14465 merged.
- #14443 conflicts with `main` in 3 files, including `WorktreeList.tsx` — the file whose old contents its entire diff is premised on. *(Re-probed 2026-08-16 against `96b03bab4f`: now **4** conflicts — `WorktreeList.tsx`, `project-group-header-dom.test.ts`, `worktree-keyboard-cycle.test.ts`, plus a modify/delete on `worktree-list-groups.test.ts` that `main` has since removed. Drifting further, as predicted.)*
- The author reached the same conclusion: #14486's own commit message reads "Follow-up to #14465 / #14467. **Keep the landed extract** and reorganize."

**#14443 and #14486 do conflict with each other, and cannot be ordered.** A direct probe reports 12 conflicting files including `WorktreeList.tsx`. But ordering is the wrong question — they are not two steps, they are two competing extractions of the same code at different bases. #14486's head **does** contain #14465. It is #14443's rebased successor. **#14486 supersedes #14443.**

**#14486 did not conflict with `main`, and did not conflict with this PR.** *(Settled: it merged on 2026-08-15T20:40:10Z. The `git merge-tree` probe was right and the GitHub flag was wrong.)*

- `main` + #14486 → **clean**. (GitHub still labelled it CONFLICTING at the time; that reflected the older head `715b46a`. The head `b91ad74` merged cleanly — and did merge.)
- It is a directory reorg: `worktree-list/` flat files into `drag/`, `headers/`, `reveal/`, `rows/`, `scroll/`, `viewport/`. Layout only.
- It shares exactly **one** file with this PR — `worktree-list/use-visible-sidebar-worktrees.ts` — which #14486 modifies in place (import retargeting) rather than moving. Both merge orders are clean:
  - `main` → #14486 → this PR: **clean**
  - `main` → this PR → #14486: **clean**

  > **Correction (2026-08-16).** The "modifies in place rather than moving" half of that bullet was wrong. #14486 *moved* both files this PR touches in that directory: `use-visible-sidebar-worktrees.ts` → `listing/use-visible-worktrees.ts`, and `use-sidebar-worktree-filters.ts` → `listing/use-filters.ts`. The *conclusion* held — rename detection carried both hunks across and the rebase landed clean — but the mechanism was a rename, not an in-place edit, and the shared-file count was two rather than one.

**#14486 does conflict with both superseded filter PRs** — 22 files with #13999, 25 with #13971 — but that is not #14486's doing. Those two already conflict with plain `main` (5 and 7 files) because they predate #14465. The refactor is not what blocks them. *(Re-probed 2026-08-16 against `96b03bab4f`, now that #14486 has landed: #13971 conflicts in **8** files, #13999 in **6**. Both drifted further, and neither was blocked by the refactor as such.)*

**Recommended order for a maintainer**

1. ~~Merge **#14486** whenever convenient. It is clean against `main` today and every day it waits it drifts against a very active directory.~~ **Done — merged 2026-08-15T20:40:10Z.**
2. Merge **this PR** in either order relative to #14486 — both directions are clean. *(Now moot in the good way: this PR has been rebased onto post-#14486 `main`, and `git merge-tree --write-tree origin/main HEAD` returns clean with zero `CONFLICT` lines.)*
3. **Close #14443** as superseded by the merged #14465 and by the merged #14486, with thanks — the author already redirected their own work. **Still open, and still the recommendation.**
4. **Close #13971 and #13999** as superseded by this PR, crediting #13999 for the model and #13971 for the module split. **Still open, and still the recommendation.**

The real churn risk is not the filter PRs colliding with the refactor. It is that #14486 is a 119-file move sitting on the busiest directory in the app, and it is clean *right now*. Merge it first and everything else rebases trivially. *(That is what happened: #14486 went in first, and this PR's rebase across it was mechanical — three conflicts, all import-path or code-that-moved-house, no behavior change.)*

## Visual Proof

**None captured — this change is visually unverified, and I am not claiming otherwise.**

Orca's sanctioned UI-validation skill is reserved for explicit human invocation, so I could not run it. The alternative — standing up my own isolated Electron dev instance — was not safe to attempt here: this machine currently has 7 live Orca processes and 26 Electron processes belonging to the user's real workspace and to other concurrent sessions, this worktree has no prebuilt dev bundle, and a dev instance launched alongside those has a track record of adopting sibling worktrees and clobbering dev identity mid-session. Risking the user's live workspace for a screenshot was the wrong trade, so I stopped.

The logic is covered by tests (see Testing); **the rendered menu is not.** A reviewer should confirm the visual result. Two-minute manual check:

1. Open the sidebar options menu (the sliders icon in the sidebar header).
2. Under **Show**, there is now a **Status** row between **Projects** and the separator, reading "All statuses".
3. Open it — one checkbox per workspace status, each with its status icon, plus an "All statuses" row on top.
4. Tick **Done**. The sidebar narrows to Done workspaces; the trigger row reads "Done"; the sliders icon grows its filter-count badge.
5. Tick every status. The row returns to "All statuses" and the badge clears — selecting everything is not a filter.
6. Tick a status no workspace has. The list empties and shows the standard "No workspaces found" state with a working **Clear Filters** button.

What I would specifically ask a reviewer to eyeball, since tests cannot: the status icons rendering at `size-3.5` next to their labels, and the trigger row's value text truncating correctly for a long custom status name.

## Testing

Scoped checks only (full-suite runs are avoided in this worktree).

- **New tests** — 3 files, 30 assertions:
  - `visible-worktrees-status-filter.test.ts` — the pipeline predicate: empty = all, single status, multi-status union, unset `workspaceStatus` resolving to the catalog default, **the empty-result state** (a status no workspace holds → zero visible, together with the assertion that `sidebarHasActiveFilters` is true so Clear Filters stays reachable), fail-open when the catalog is missing, stale ids ignored, and intersection with other filters.
  - `workspace-status-filter-sanitize.test.ts` — pruning, collapse-to-all, catalog ordering, dedupe, non-array payloads, array-identity stability.
  - `SidebarWorkspaceStatusFilterSection.test.ts` — toggle and label logic.
- **Non-vacuity proven by mutation**, not assumed:
  - Neutralizing the pipeline predicate → **6 of 8** pipeline tests fail (the 2 that pass are the intentional no-op guards).
  - Removing the toggle's collapse branch → **2** tests fail.
  - Removing the sanitizer's catalog guard → initially **0** failed. That exposed a genuine hole in my own coverage, so I added `keeps the surviving id when stale ids alone reach the catalog size`, which fails under that mutation. The guard is now load-bearing and proven so.
- **Regression sweep**: `src/renderer/src/components/sidebar`, `src/renderer/src/store/slices`, `src/shared/workspace-status*` → **409 files, 4793 tests, all pass** (covers the `sidebar-filter-state.ts` extraction).

### Re-verified after the post-#14486 rebase (2026-08-16)

Rebased onto `96b03bab4f`. Three conflicts, all resolved without behavior change — see the collision-assessment update above for why they were structural rather than semantic.

- **No test was lost.** The five test files this PR adds or touches carried **69 tests before the rebase and 69 after**, all passing. File count and diffstat are unchanged at 20 files / 755 insertions.
- **Regression sweep, re-run on the rebased tree**: `components/sidebar` + `app-shell` + `shared/workspace-status*` → **252 files, 2225 tests, all pass**; `store/slices` → **262 files, 2612 tests, all pass**. (An initial combined run showed timeouts in `agent-status-live-map-leak.test.ts`; that file passes in isolation and in the split runs, the timing-out test differed between runs, and this PR touches nothing in the agent-status eviction path — machine load, not a regression.)
- **Typecheck**: `tsconfig.node.json`, `tsconfig.tc.web.json`, `tsconfig.tc.cli.json` all exit 0 on the rebased tree.
- **Gates re-run**: `oxfmt --check` clean; `oxlint --deny-warnings` clean on changed files — *and confirmed live* by injecting a `debugger` statement and watching it fail, since a silent clean run is otherwise indistinguishable from a dead gate. Native + type-aware code-quality audits exit 0 over `src config tests mobile`. react-doctor (both the config run and the changed-lines gate) clean. Max-lines ratchet OK, no new bypasses. All three localization gates pass.
- **The `max-lines` extraction still earns its keep.** `main` had grown `visible-worktrees.ts` to 448 lines; with the extraction plus this feature it is **394** — a net reduction, with no `max-lines` disable anywhere.
- **The STA-3354 perf property survives the resolution**, which was the thing most at risk in a rebase across a reorg. The predicate still builds `new Set(filterWorkspaceStatuses)` **once per pipeline run**, outside the `.filter` callback, costing one `Set.has(getWorkspaceStatus(w, statuses))` per worktree inside the existing `useMemo` — not per row, not per render. Neither call site reads `agentStatusByPaneKey`, and both still subscribe to the status catalog only while a filter is active.

One incidental fix the rebase forced: `main` moved the debounced persisted-UI writer out of `App.tsx` into `app-shell/use-persisted-ui-writer.ts` and reshaped it around a `useShallow` selector. This PR's three `App.tsx` lines were re-homed there rather than recreated at the old path, and a code comment in `ui.ts` that named `App.tsx` was corrected to name the hook.
- **Typecheck**: all three projects pass — `tsconfig.node.json`, `tsconfig.tc.web.json`, `tsconfig.tc.cli.json`. Verified the node gate is live by injecting a deliberate type error and confirming it was caught.
- **Lint / gates**: `oxlint`, `oxfmt`, react-doctor (changed), type-aware + native code-quality audits (changed), max-lines ratchet, reliability gates, all three localization gates — all pass. No `max-lines` disable added; the cap was resolved by extraction.

Platforms: logic-level change with no platform-dependent code — no `metaKey`/path/shell handling touched. Under SSH the filter is pure renderer state over already-loaded worktree fields, so it adds no round-trips.

- [ ] I manually tested these changes locally — see Visual Proof: not done, and not claimed
- [x] Automated tests added/updated, or explained why not below

## Review

- **Security** — no new IPC surface; one optional `z.array(z.string())` field added to the existing `ClientUiWorkspaceFilterFields` allowlist.
- **Cross-platform** — no platform-conditional code; no shortcuts, paths, or accelerators touched.
- **Remote SSH** — renderer-only filtering over data already in the store; no extra round-trips, no new loading states.
- **Mobile** — untouched. `mobile/` has its own workspace-status grouping and is not part of this change.
- **Backwards compatibility** — `filterWorkspaceStatuses` is optional in `PersistedUI` and defaults to `[]`, which is exactly today's behavior. An older client reading a newer profile ignores the field; a newer client reading an older profile sanitizes `undefined` to `[]`. No wire opcode, no capability negotiation needed.
- **Performance** — see the STA-3354 note above. One `Set` lookup per worktree per pipeline run; the status catalog is subscribed to only while a filter is active.

## Author

- X / Twitter: @BrennanKB5


