### PR TITLE
fix(agents): surface Cline panes in worktree agent rows via a declared identity frame (STA-3906)

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -202,6 +202,62 @@ describe('buildTitleDerivedAgentRows', () => {
     }
   })
 
+  // Why: cline 3.0.55 writes OSC 0 `Cline` and posts no hooks, so the title path is the
+  // only thing that can put the pane in the sidebar at all (STA-3906 / #13823).
+  it('adds an idle row for a registry-declared agent that only writes its own name', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { title: 'Cline' })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: { 'tab-1': { 1: 'Cline' } },
+      ptyIdsByTabId: { 'tab-1': ['pty-cline'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(rows.map((row) => [row.agentType, row.state, row.entry.lastAssistantMessage])).toEqual([
+      ['cline', 'idle', 'Idle']
+    ])
+    expect(rows[0]?.paneKey).toBe(makePaneKey('tab-1', LEAF_ID_1))
+  })
+
+  it('does not invent a Cline row from Claude task text that mentions cline', () => {
+    const unowned = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1')],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: { 'tab-1': { 1: '⠋ use cline for the sidebar fix' } },
+      ptyIdsByTabId: { 'tab-1': ['pty-claude-task'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+    expect(unowned).toHaveLength(0)
+
+    const owned = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { launchAgent: 'claude' })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: { 'tab-1': { 1: '⠋ use cline for the sidebar fix' } },
+      ptyIdsByTabId: { 'tab-1': ['pty-claude-task'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+    expect(owned.map((row) => row.agentType)).toEqual(['claude'])
+  })
+
+  it('keeps a cline-named worktree path out of the sidebar', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { title: '~/orca/workspaces/cline-scratch' })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: { 'tab-1': { 1: '~/orca/workspaces/cline-scratch' } },
+      ptyIdsByTabId: { 'tab-1': ['pty-shell'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+    expect(rows).toHaveLength(0)
+  })
+
   it('attributes a spinner-only title to the launched agent when the title has no identity', () => {
     const launchAgent: TuiAgent = 'codex'
     const rows = buildWorktreeAgentRows({

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -21,6 +21,7 @@ import {
 } from '../../../../shared/agent-title-owner'
 import { resolvePaneAgentOwner } from '../../../../shared/pane-agent-owner'
 import { isClaudeIdentityFrameTitle } from '../../../../shared/terminal-title-agent-type'
+import { ALL_TUI_AGENTS, TUI_AGENT_DISPLAY_NAMES } from '../../../../shared/tui-agent-display-names'
 
 const EMPTY_RUNTIME_TITLES: Record<string, Record<number, string>> = {}
 const EMPTY_LIVE_PTY_IDS: Record<string, string[]> = {}
@@ -43,6 +44,12 @@ const TITLE_AGENT_LABEL_TO_TYPE: Record<string, AgentType> = {
   Pi: 'pi',
   OMP: 'omp'
 }
+
+// Why: labels that already equal an agent's canonical display name need no second
+// table — registry-declared agents (agent-identity-frame.ts) resolve straight through.
+const DISPLAY_NAME_TO_AGENT_TYPE: Record<string, AgentType> = Object.fromEntries(
+  ALL_TUI_AGENTS.map((agent) => [TUI_AGENT_DISPLAY_NAMES[agent], agent as AgentType])
+)
 
 const CLAUDE_AGENT_TOKEN_RE = /(?<![\w./\\-])claude(?![\w./\\-])/i
 
@@ -201,7 +208,8 @@ export function resolveTitleDerivedAgentType(
   label: string,
   ownerAgentType?: AgentType | null
 ): AgentType | null {
-  const agentType = TITLE_AGENT_LABEL_TO_TYPE[label] ?? 'unknown'
+  const agentType =
+    TITLE_AGENT_LABEL_TO_TYPE[label] ?? DISPLAY_NAME_TO_AGENT_TYPE[label] ?? 'unknown'
   if (agentType !== 'claude') {
     return agentType
   }

--- a/src/shared/agent-identity-frame.test.ts
+++ b/src/shared/agent-identity-frame.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AGENT_IDENTITY_FRAMES,
+  buildAgentIdentityFrameRe,
+  isAgentIdentityFrameTitleFor,
+  resolveAgentIdentityFrameType
+} from './agent-identity-frame'
+import { getAgentLabel } from './agent-title-identity'
+import { detectAgentStatusFromTitle } from './agent-title-status'
+import {
+  isClaudeIdentityFrameTitle,
+  resolveExplicitTerminalTitleAgentType,
+  resolveTerminalTitleAgentType
+} from './terminal-title-agent-type'
+
+describe('agent identity frames', () => {
+  it('claims a title that is only the agent name, decorated or multiplexer-wrapped', () => {
+    for (const title of ['Cline', 'cline', 'cline.cmd', 'cline.exe', '⠋ Cline', 'zsh | Cline']) {
+      expect(resolveAgentIdentityFrameType(title)).toBe('cline')
+      expect(isAgentIdentityFrameTitleFor(title, 'cline')).toBe(true)
+    }
+  })
+
+  it('rejects the name inside task text, a path, or a hyphenated compound', () => {
+    for (const title of [
+      '⠋ use cline for the sidebar fix',
+      'port the cline prompt',
+      '~/cline-scratch',
+      'cline-rules',
+      'src/cline/index.ts',
+      'clinent'
+    ]) {
+      expect(resolveAgentIdentityFrameType(title)).not.toBe('cline')
+      expect(isAgentIdentityFrameTitleFor(title, 'cline')).toBe(false)
+    }
+  })
+
+  it('accepts at most one status word, never free-form trailing text', () => {
+    expect(isAgentIdentityFrameTitleFor('Cline ready', 'cline')).toBe(true)
+    expect(isAgentIdentityFrameTitleFor('Cline - action required', 'cline')).toBe(true)
+    expect(isAgentIdentityFrameTitleFor('Cline working on the parser', 'cline')).toBe(false)
+    expect(isAgentIdentityFrameTitleFor('Cline ready idle', 'cline')).toBe(false)
+  })
+
+  it('is not declared for agents whose names are too common to anchor on', () => {
+    // Why: `amp`/`pi`/`cn` would claim ordinary shell titles; the registry stays observed-only.
+    expect(AGENT_IDENTITY_FRAMES.amp).toBeUndefined()
+    expect(resolveAgentIdentityFrameType('amp')).toBeNull()
+    expect(resolveAgentIdentityFrameType('crush')).toBeNull()
+  })
+
+  // Why: this is the whole point of the registry — a new runtime is data, not five call sites.
+  it('builds the same frame shape for any declared name', () => {
+    const re = buildAgentIdentityFrameRe({ names: ['widgetcli'], executableSuffix: true })
+    expect(re.test('widgetcli')).toBe(true)
+    expect(re.test('widgetcli.exe')).toBe(true)
+    expect(re.test('widgetcli - action required')).toBe(true)
+    expect(re.test('use widgetcli here')).toBe(false)
+  })
+})
+
+describe('Cline title visibility (STA-3906 / #13823)', () => {
+  // Observed against cline 3.0.55: the CLI emits OSC 0 `Cline` and never varies it.
+  it('resolves the live Cline title to identity, label, and an idle status', () => {
+    expect(getAgentLabel('Cline')).toBe('Cline')
+    expect(resolveTerminalTitleAgentType('Cline')).toBe('cline')
+    expect(resolveExplicitTerminalTitleAgentType('Cline')).toBe('cline')
+    expect(detectAgentStatusFromTitle('Cline')).toBe('idle')
+  })
+
+  it('maps decorated Cline frames to status without inventing status from mentions', () => {
+    expect(detectAgentStatusFromTitle('Cline ready')).toBe('idle')
+    expect(detectAgentStatusFromTitle('Cline working')).toBe('working')
+    expect(detectAgentStatusFromTitle('Cline - action required')).toBe('permission')
+    expect(detectAgentStatusFromTitle('⠋ Cline')).toBe('working')
+    for (const title of ['port the cline prompt', '~/cline-scratch', 'cline-rules']) {
+      expect(detectAgentStatusFromTitle(title)).toBeNull()
+    }
+  })
+
+  it('keeps Claude task text that mentions cline as Claude', () => {
+    expect(getAgentLabel('⠋ use cline for the sidebar fix')).toBe('Claude Code')
+    expect(resolveTerminalTitleAgentType('⠋ use cline for the sidebar fix')).toBe('claude')
+    // Why: the spinner still proves activity; the mention must not rebrand the pane.
+    expect(detectAgentStatusFromTitle('⠋ use cline for the sidebar fix')).toBe('working')
+  })
+})
+
+// Why: the Claude frame moved onto the shared builder — pin the behavior it had before.
+describe('isClaudeIdentityFrameTitle after the shared-builder move', () => {
+  it('accepts Claude frames and rejects Claude mentions', () => {
+    for (const title of [
+      'Claude',
+      'claude code',
+      'Claude Code',
+      '✳ Claude Code',
+      'Claude ready',
+      'Claude Code - action required',
+      'zsh | ⠋ Claude Code'
+    ]) {
+      expect(isClaudeIdentityFrameTitle(title)).toBe(true)
+    }
+    for (const title of [
+      '⠋ ask claude about the parser',
+      'claude-scratch',
+      '~/claude/worktrees',
+      'Claude Code review the diff'
+    ]) {
+      expect(isClaudeIdentityFrameTitle(title)).toBe(false)
+    }
+  })
+})

--- a/src/shared/agent-identity-frame.ts
+++ b/src/shared/agent-identity-frame.ts
@@ -1,0 +1,92 @@
+/**
+ * One shape for "this title PRESENTS agent X", shared by every consumer that
+ * turns an OSC title into agent identity.
+ *
+ * Why a registry and not another per-agent predicate: an identity frame is the
+ * agent's own name plus, at most, one status word. That shape was already
+ * hand-copied per agent (Claude here, Pi/OMP in pi-compatible-synthetic-title,
+ * Cursor's closed literal set in agent-title-core), so every new runtime meant a
+ * new regex threaded through five call sites. Declaring the names instead keeps
+ * the next runtime a one-row change.
+ *
+ * Why frames and not name tokens: a name inside free-form task text is a
+ * mention, not identity, and must never take a pane away from its owner
+ * (#8940). Anchoring the whole title is what separates the two.
+ */
+import { stripLeadingAgentTitleDecorationOrEmpty } from './agent-title-decoration'
+import { getWrapperTitleSegments } from './terminal-title-wrapper-segments'
+import type { TuiAgent } from './tui-agent'
+
+/** The status words agents append to their own name — Orca's synthetic titles
+ *  use the same vocabulary (synthetic-agent-title.ts), so a frame must accept both. */
+const IDENTITY_STATUS_WORDS = ['ready', 'idle', 'done', 'working', 'thinking', 'running'] as const
+
+// Why: Windows titles can surface the launcher process name (`cline.cmd`).
+const EXECUTABLE_SUFFIX = String.raw`(?:\.(?:exe|cmd|bat|ps1))?`
+
+export type AgentIdentityFrameSpec = {
+  /** Lowercase names the agent presents itself under, longest first. */
+  names: readonly string[]
+  /** Accept a Windows launcher extension after the name. */
+  executableSuffix?: boolean
+}
+
+export function buildAgentIdentityFrameRe(spec: AgentIdentityFrameSpec): RegExp {
+  const names = spec.names.map((name) => name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')
+  const suffix = spec.executableSuffix ? EXECUTABLE_SUFFIX : ''
+  return new RegExp(
+    `^(?:${names})${suffix}(?:\\s+(?:${IDENTITY_STATUS_WORDS.join('|')}))?(?:\\s*-\\s*action required)?$`
+  )
+}
+
+/**
+ * Agents identified by the title they write about themselves. Only add a runtime
+ * here once its CLI is observed emitting the title — an unobserved name widens
+ * the false-positive surface for every ordinary shell title.
+ */
+export const AGENT_IDENTITY_FRAMES: Partial<Record<TuiAgent, AgentIdentityFrameSpec>> = {
+  claude: { names: ['claude code', 'claude'] },
+  // Verified against cline 3.0.55: it emits OSC 0 `Cline` and never varies it,
+  // so Orca sees identity but no status transitions (STA-3906).
+  cline: { names: ['cline'], executableSuffix: true }
+}
+
+const IDENTITY_FRAME_RES = new Map<TuiAgent, RegExp>(
+  Object.entries(AGENT_IDENTITY_FRAMES).map(([agent, spec]) => [
+    agent as TuiAgent,
+    buildAgentIdentityFrameRe(spec)
+  ])
+)
+
+/**
+ * Whether `title` presents `agent`, once multiplexer prefixes and leading status
+ * decoration are stripped.
+ *
+ * Why segments: a multiplexer prefix (`zsh | ⠋ Claude Code`) would otherwise read
+ * as task text and cost a genuine agent pane its identity.
+ */
+export function isAgentIdentityFrameTitleFor(
+  title: string | null | undefined,
+  agent: TuiAgent
+): boolean {
+  const re = IDENTITY_FRAME_RES.get(agent)
+  if (!re || typeof title !== 'string') {
+    return false
+  }
+  return getWrapperTitleSegments(title).some((segment) =>
+    re.test(stripLeadingAgentTitleDecorationOrEmpty(segment).trim().toLowerCase())
+  )
+}
+
+/** The agent a title presents, or null when the title is task text, a path, or a bare shell title. */
+export function resolveAgentIdentityFrameType(title: string | null | undefined): TuiAgent | null {
+  if (typeof title !== 'string') {
+    return null
+  }
+  for (const agent of IDENTITY_FRAME_RES.keys()) {
+    if (isAgentIdentityFrameTitleFor(title, agent)) {
+      return agent
+    }
+  }
+  return null
+}

--- a/src/shared/agent-title-identity.ts
+++ b/src/shared/agent-title-identity.ts
@@ -10,8 +10,10 @@ import {
   isPiAgentTitle,
   titleHasAgentName
 } from './agent-title-core'
+import { resolveAgentIdentityFrameType } from './agent-identity-frame'
 import { isOpenCodeNativeTitle } from './opencode-terminal-title'
 import { getPiCompatibleSyntheticAgentLabel } from './pi-compatible-synthetic-title'
+import { TUI_AGENT_DISPLAY_NAMES } from './tui-agent-display-names'
 
 /**
  * Returns true when the terminal title matches Claude Code's title conventions.
@@ -32,9 +34,15 @@ export function isClaudeAgent(title: string): boolean {
     return true
   }
   if (containsAgentSpinnerGlyph(title)) {
-    // Why: named non-Claude agents carry braille spinners too. Gate Cursor by its
-    // identity title, not the token, so a Claude title mentioning a cursor stays Claude.
-    return !isCursorAgentTitle(title) && !lower.includes('openclaude')
+    // Why: named non-Claude agents carry braille spinners too. Gate them by their
+    // identity frame, not a name token, so Claude task text that merely mentions
+    // one (`⠋ use cline for the fix`) stays Claude.
+    const frameAgent = resolveAgentIdentityFrameType(title)
+    return (
+      (frameAgent === null || frameAgent === 'claude') &&
+      !isCursorAgentTitle(title) &&
+      !lower.includes('openclaude')
+    )
   }
 
   const trimmedTitle = title.trimStart()
@@ -101,6 +109,12 @@ export function getAgentLabel(title: string): string | null {
   }
   if (titleHasAgentName(title, 'aider')) {
     return 'Aider'
+  }
+  // Why: registry-declared agents identify themselves by frame only, so this must
+  // run before Claude's generic braille heuristic but after the token matches above.
+  const frameAgent = resolveAgentIdentityFrameType(title)
+  if (frameAgent && frameAgent !== 'claude') {
+    return TUI_AGENT_DISPLAY_NAMES[frameAgent]
   }
   // Why: `cursor` is ordinary editor vocabulary, not identity. Match Cursor's closed
   // title set (mirrors @cursor routing), before `isClaudeAgent` claims the braille frame.

--- a/src/shared/agent-title-status.ts
+++ b/src/shared/agent-title-status.ts
@@ -1,3 +1,4 @@
+import { resolveAgentIdentityFrameType } from './agent-identity-frame'
 import {
   AGY_AGENT_NAME_RE,
   BRAILLE_SPINNER_RE,
@@ -196,7 +197,16 @@ export function detectAgentStatusFromTitle(title: string): AgentStatus | null {
   const hasHermesAgentName = HERMES_AGENT_NAME_RE.test(title)
   const hasAgyAgentName = AGY_AGENT_NAME_RE.test(title)
   const hasLegacyAgentName = containsLegacyAgentName(title)
-  if (!hasLegacyAgentName && !hasDroidAgentName && !hasHermesAgentName && !hasAgyAgentName) {
+  // Why: registry-declared agents are deliberately absent from AGENT_NAMES — their
+  // names are too common to token-match — so their whole-title frame is the evidence.
+  const hasIdentityFrame = resolveAgentIdentityFrameType(title) !== null
+  if (
+    !hasLegacyAgentName &&
+    !hasDroidAgentName &&
+    !hasHermesAgentName &&
+    !hasAgyAgentName &&
+    !hasIdentityFrame
+  ) {
     return null
   }
   if (containsAny(title, ['action required', 'permission', 'waiting'])) {

--- a/src/shared/terminal-title-agent-type.ts
+++ b/src/shared/terminal-title-agent-type.ts
@@ -4,14 +4,14 @@ import {
   HERMES_AGENT_NAME_RE,
   titleHasAgentName
 } from './agent-name-token-match'
+import { isAgentIdentityFrameTitleFor, resolveAgentIdentityFrameType } from './agent-identity-frame'
 import { containsAgentSpinnerGlyph, isCursorAgentTitle } from './agent-title-core'
-import { stripLeadingAgentTitleDecorationOrEmpty } from './agent-title-decoration'
 import { isOpenCodeNativeTitle } from './opencode-terminal-title'
-import { getWrapperTitleSegments } from './terminal-title-wrapper-segments'
 import {
   getPiCompatibleSyntheticAgentLabel,
   isLegacyPiCompatibleTitle
 } from './pi-compatible-synthetic-title'
+import { TUI_AGENT_DISPLAY_NAMES, ALL_TUI_AGENTS } from './tui-agent-display-names'
 import type { TuiAgent } from './tui-agent'
 
 export const CLAUDE_IDLE = '\u2733' // ✳ (eight-spoked asterisk — Claude Code idle prefix)
@@ -97,9 +97,15 @@ export function isClaudeAgent(title: string): boolean {
     return true
   }
   if (containsAgentSpinnerGlyph(title)) {
-    // Why: named non-Claude agents carry braille spinners too. Gate Cursor by its
-    // identity title, not the token, so a Claude title mentioning a cursor stays Claude.
-    return !isCursorAgentTitle(title) && !lower.includes('openclaude')
+    // Why: named non-Claude agents carry braille spinners too. Gate them by their
+    // identity frame, not a name token, so Claude task text that merely mentions
+    // one (`⠋ use cline for the fix`) stays Claude.
+    const frameAgent = resolveAgentIdentityFrameType(title)
+    return (
+      (frameAgent === null || frameAgent === 'claude') &&
+      !isCursorAgentTitle(title) &&
+      !lower.includes('openclaude')
+    )
   }
   // Why: permission/action-required Claude titles can omit the usual prefixes.
   // Token-match so cwd/worktree titles like "claude-scratch" do not become
@@ -184,6 +190,12 @@ export function getAgentLabel(title: string): string | null {
   if (titleHasAgentName(title, 'aider')) {
     return 'Aider'
   }
+  // Why: registry-declared agents identify themselves by frame only, so this must
+  // run before Claude's generic braille heuristic but after the token matches above.
+  const frameAgent = resolveAgentIdentityFrameType(title)
+  if (frameAgent && frameAgent !== 'claude') {
+    return TUI_AGENT_DISPLAY_NAMES[frameAgent]
+  }
   // Why: `cursor` is ordinary editor vocabulary, not identity. Match Cursor's closed
   // title set (mirrors @cursor routing), before `isClaudeAgent` claims the braille frame.
   if (isCursorAgentTitle(title)) {
@@ -229,6 +241,12 @@ const TITLE_LABEL_TO_AGENT: Partial<Record<string, TuiAgent>> = {
   OMP: 'omp'
 }
 
+// Why: labels that already equal an agent's canonical display name need no second
+// table — registry-declared agents (agent-identity-frame.ts) resolve straight through.
+const DISPLAY_NAME_TO_AGENT = new Map<string, TuiAgent>(
+  ALL_TUI_AGENTS.map((agent) => [TUI_AGENT_DISPLAY_NAMES[agent], agent])
+)
+
 function hasGenericClaudeStatusPrefix(title: string): boolean {
   return (
     containsAgentSpinnerGlyph(title) ||
@@ -239,10 +257,6 @@ function hasGenericClaudeStatusPrefix(title: string): boolean {
   )
 }
 
-// Claude's own name plus, at most, one of its status words — never free-form task text.
-const CLAUDE_IDENTITY_FRAME_RE =
-  /^claude(?: code)?(?:\s+(?:ready|idle|done|working|thinking|running))?(?:\s*-\s*action required)?$/
-
 /**
  * Whether a title PRESENTS Claude rather than merely mentioning it, once its leading
  * status decoration is stripped. A "claude" token inside free-form task text is a mention,
@@ -250,13 +264,7 @@ const CLAUDE_IDENTITY_FRAME_RE =
  * keep using `resolveExplicitTerminalTitleAgentType`, whose token match is looser.
  */
 export function isClaudeIdentityFrameTitle(title: string): boolean {
-  // Why segments: a multiplexer prefix (`zsh | ⠋ Claude Code`) would otherwise read as task
-  // text and cost a genuine Claude pane its identity.
-  return getWrapperTitleSegments(title).some((segment) =>
-    CLAUDE_IDENTITY_FRAME_RE.test(
-      stripLeadingAgentTitleDecorationOrEmpty(segment).trim().toLowerCase()
-    )
-  )
+  return isAgentIdentityFrameTitleFor(title, 'claude')
 }
 
 function isGenericClaudeStatusClaim(title: string, titleAgent: TuiAgent | null): boolean {
@@ -269,7 +277,10 @@ function isGenericClaudeStatusClaim(title: string, titleAgent: TuiAgent | null):
 
 export function resolveTerminalTitleAgentType(title: string): TuiAgent | null {
   const label = getAgentLabel(title)
-  return label ? (TITLE_LABEL_TO_AGENT[label] ?? null) : null
+  if (!label) {
+    return null
+  }
+  return TITLE_LABEL_TO_AGENT[label] ?? DISPLAY_NAME_TO_AGENT.get(label) ?? null
 }
 
 /**


### PR DESCRIPTION
## ELI5

Run `cline` in an Orca terminal and the worktree sidebar shows nothing — no agent row, no state dot, as if the pane were an empty shell. Cline does write a title saying who it is; Orca just had no rule that recognised it. This adds that rule, and puts it in one shared place so the next runtime is one line of data instead of a new regex threaded through five files.

## What Changed

**New:** `src/shared/agent-identity-frame.ts` — one registry + one matcher for "this title PRESENTS agent X" (the agent's own name, optionally decorated with a spinner, optionally wrapped by a multiplexer, plus at most one status word or `- action required`).

- `claude` moves onto it (its `CLAUDE_IDENTITY_FRAME_RE` was already exactly this shape — deleted, behavior pinned by test).
- `cline` is declared on it. That is the whole Cline change.

**Wired through the four consumers that decide whether a pane is an agent:**

| File | Change |
| --- | --- |
| `agent-title-status.ts` | `detectAgentStatusFromTitle` accepts a declared identity frame as evidence, alongside the existing name-token matchers |
| `agent-title-identity.ts` / `terminal-title-agent-type.ts` | `getAgentLabel` returns the declared agent's display name; `isClaudeAgent`'s spinner branch excludes other agents' frames |
| `worktree-title-derived-agent-rows.ts` | label → `AgentType` falls back to canonical display names, so a declared agent needs no third table |

Net `+121/−22` across 5 files, 2 new.

## Why

`cline` 3.0.55 emits `OSC 0 ; Cline BEL` and nothing else — no hooks, no status transitions. I verified this by installing the real CLI and capturing its raw PTY stream:

```
--- OSC sequences (8) ---
OSC 10 => "?"          OSC 11 => "?"        OSC 99 => "i=…:p=?;"
OSC 1337 => "Capabilities"                  OSC 66 => "w=1; "
OSC 66 => "s=2; "      OSC 4 => "0;?"       OSC 0 => "Cline"
```

With no hook row, the pane falls to `buildTitleDerivedAgentRows`, which needs **both** a status and a label. Pre-fix, `Cline` produced neither: `cline` is deliberately absent from `AGENT_NAMES` (that list is token-matched, and its own comment explains why it is "intentionally narrower than the full set of launchable agents"). So `detectAgentStatusFromTitle('Cline') === null`, `getAgentLabel('Cline') === null`, and `buildTitleDerivedAgentRow` returned `null` — the pane is invisible.

Note what this proves about the framing in STA-2144: **`cline` was already in the `TuiAgent` union and in `TUI_AGENT_CONFIG`, and was still invisible.** The closed set that hides a runtime is not the launch allowlist — it is the *title-detection vocabulary*: `AGENT_NAMES`, plus one bespoke predicate per agent, plus two label→type tables. Adding a runtime to `TuiAgent` does nothing for visibility.

Why a registry rather than a sixth predicate: the identity-frame shape was already hand-copied four times — Claude's `CLAUDE_IDENTITY_FRAME_RE`, the Pi/OMP regex in `pi-compatible-synthetic-title.ts`, Cursor's literal set in `agent-title-core.ts`, and the generic `isIdentityStatusTitle` in `agent-row-conversation-name.ts`. Each copy meant a new regex plus edits at every call site. This collapses the shape to one place; Pi/OMP and Cursor can migrate later (they carry extra synthetic-spinner behavior, so they are deliberately not in this PR).

## Is the long-term fix (a) more allowlist entries, or (b) generic discovery?

**(b) — but only for *declared* identity, never for *inferred* identity. Title inference cannot be made generic, and the code says so.**

Justification from the code:

1. **The type system is already open.** `AgentType = WellKnownAgentType | (string & {})` (`agent-status-types.ts:43`). An arbitrary agent id already renders.
2. **A generic in-band path already exists and is not agent-gated.** `agent-status-osc.ts` parses `ESC ] 9999 ;` on every PTY before xterm, for any process. Any agent that emits it surfaces today with zero code change. That is the (b) mechanism, already shipped — what is missing is that no third-party CLI knows to emit it.
3. **Title inference cannot be opened up.** `AGENT_NAMES`' own comment: short names like `amp` would classify `"timestamp ready"` as agent activity. A blanket reverse index over all 35 `TUI_AGENT_DISPLAY_NAMES` entries would let `amp`, `pi`, `cn`, `crush`, `goose` claim ordinary shell and cwd titles. The registry in this PR is therefore observed-only by design, and `agent-identity-frame.test.ts` pins that (`AGENT_IDENTITY_FRAMES.amp` must stay undefined).
4. **The allowlist demonstrably rots.** `aider` sits in `WellKnownAgentType` with no hook endpoint, no normalizer, and no hook service — an entry that does nothing. `cline` sat in `TuiAgent` while its panes stayed invisible.

So the shape that actually closes the class is: **identity must be a declared fact, not a parse.** Three declaration channels, in descending order of how much they solve:

- **User-declared agent definitions.** A settings-level "custom agent" record (`id`, display name, launch command, identity title) that flows into the same registry this PR introduces. Adding a runtime becomes a user action, not a release. This is the real fix for #7797 too, since a user who declares the agent no longer depends on Orca guessing through a multiplexer's title. Rough cost: a settings schema + store slice + migration, the registry merge (already the seam this PR creates), and settings UI — a few hundred lines, one focused PR.
- **Agent-declared status.** Publish `OSC 9999` as a documented contract so a CLI opts into full status without Orca knowing it exists. Zero Orca code per runtime; cost is advocacy, not engineering.
- **This PR's registry.** The bridge for CLIs that do neither: one declarative row per observed runtime, instead of a regex spread over five modules.

Continuing with (a) is defensible only as the residue after those exist. I did not attempt the user-declared definition here — it is not small, and bundling it would bury a P0.

**Scope this PR does not cover, deliberately:** #13840 (Cline in the Agents / AI Vault panel) is a different layer. AI Vault sources are transcript-file walkers (`remote-session-scanner-sources.ts`), and cline stores sessions in SQLite (`~/.cline/data/db/sessions.db`), not JSONL — so it needs a new source *kind* that also works over SSH, where Orca reads files rather than opening databases. That is its own PR.

## Linked Issue

Fixes #13823

Supersedes #13959 (@OrcaWin) — same root cause, same verified premise, and its tests informed these. Superseded rather than merged because it adds a fifth hand-copied identity regex instead of removing the duplication, and its status vocabulary (`Cline ready`/`working`/`- action required`) was asserted without the CLI being observed. This PR keeps that vocabulary — it is the repo-wide synthetic-title convention (`synthetic-agent-title.ts`), so it is right for forward-compat — but says plainly in code that cline's live title is static.

Related, not fixed here: #13840 (AI Vault, see above), STA-2144 (the class), #7797 (multiplexers).

## Visual Proof

Same worktree, same live PTY, same store input (`runtimePaneTitlesByTabId = { <tab>: { 1: "Cline" } }`, tab title `Cline`) — captured on two separate launches of an isolated dev instance from this worktree, one on the parent commit and one on this commit. Not an HMR flip.

The title was produced by a real PTY emitting the exact bytes captured from `cline` 3.0.55: `1b 5d 30 3b 43 6c 69 6e 65 07` (`ESC ] 0 ; C l i n e BEL`).

**Before** — the pane is live and the tab is labelled `Cline`, but the worktree card has no agent row at all:

![before-sidebar.png](https://github.com/user-attachments/assets/d2b13261-89a1-4c0e-b47f-fe75b5ec63e8)

**After** — `Cline - Idle` with the Cline glyph and a live timestamp:

![after-sidebar.png](https://github.com/user-attachments/assets/ce5da403-43b5-4f16-8624-1d9c4b5c5b28)

## Testing

Automated, and proven non-vacuous by running the new tests against pre-fix code (fix stashed):

```
FAIL  Cline title visibility (STA-3906 / #13823) > resolves the live Cline title …
  expect(getAgentLabel('Cline')).toBe('Cline')   →  expected null to be 'Cline'
FAIL  Cline title visibility (STA-3906 / #13823) > maps decorated Cline frames …
  expect(detectAgentStatusFromTitle('Cline ready')).toBe('idle')  →  expected null to be 'idle'
Tests  2 failed | 7 passed (9)
```

With the fix: 9/9 pass. New coverage:

- `src/shared/agent-identity-frame.test.ts` — frame accepts `Cline` / `cline.cmd` / `⠋ Cline` / `zsh | Cline`; rejects `⠋ use cline for the sidebar fix`, `~/cline-scratch`, `cline-rules`, `src/cline/index.ts`, `clinent`; rejects free-form trailing text (`Cline working on the parser`); asserts `amp` stays undeclared; pins `isClaudeIdentityFrameTitle` behavior across the shared-builder move.
- `worktree-title-derived-agent-rows.test.ts` — the actual ticket surface: a live pane titled `Cline` produces exactly one `['cline', 'idle', 'Idle']` row on the right pane key; Claude task text mentioning cline yields no row unowned and a `claude` row when owned; a `~/orca/workspaces/cline-scratch` shell title yields no row.

Suites run: `src/shared` 4682 passed / 19 skipped · `src/renderer` 23167 passed / 4 skipped · `src/main` 21499 passed, with 10 pre-existing failures in `src/main/ipc/pty.test.ts` (ZDOTDIR/shell-ready) that reproduce identically on a clean checkout of this branch's base — unrelated to this change.

Also clean: `oxfmt`, `oxlint`, `oxlint --config config/oxlint-code-quality-native-plugins.json` (`--deny-warnings`), `oxlint --type-aware --config config/oxlint-code-quality-type-aware.json` (`--deny-warnings`), react-doctor changed-lines. Full `pnpm typecheck` deliberately not run locally (OOM risk on this machine); the changed shared modules typecheck standalone under `--strict`, and CI covers the rest.

Platforms: logic is platform-independent and lives in `src/shared`. The frame accepts `.exe/.cmd/.bat/.ps1` because Windows titles can surface the launcher name, and `cline` ships as a `.cmd` shim there. Not exercised on a Windows host. Remote/SSH is unaffected — this path consumes the OSC title Orca already forwards, and adds no RPC field, stream opcode, or host-published content.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

- **Security** — no new I/O, no process spawn, no network. Regex is anchored, bounded, and built from a compile-time constant list.
- **Cross-platform** — shared module, no path or platform assumptions; Windows launcher suffixes handled.
- **Remote SSH** — no wire change. Titles already cross the relay; this only reinterprets one locally.
- **Mobile** — the same shared detection feeds mobile agent labels, so a Cline pane now labels correctly there too. No payload change.
- **Backwards compatibility** — `DISPLAY_NAME_TO_AGENT` is a fallback behind the existing label tables and is inert for every label `getAgentLabel` returns today. Claude's frame regex was replaced by a generated one of identical shape, pinned by test.
- **Performance** — two anchored regex tests per title update, on strings capped at 200 chars.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @BrennanKB5
