### PR TITLE
fix(agent-status): keep the turn identity a disconnect clear removed (STA-3524)

### DIFF
--- a/src/main/agent-hooks/reconnect-clear-replay-turn-identity.test.ts
+++ b/src/main/agent-hooks/reconnect-clear-replay-turn-identity.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AgentHookServer } from './server'
+import { makePaneKey } from '../../shared/stable-pane-id'
+
+vi.mock('../telemetry/client', () => ({ track: vi.fn() }))
+vi.mock('../telemetry/cohort-classifier', () => ({ getCohortAtEmit: vi.fn(() => ({})) }))
+
+const LEAF = '11111111-1111-4111-8111-111111111111'
+const PANE = makePaneKey('tab-1', LEAF)
+const CONNECTION = 'ssh-host-1'
+const T0 = 1_700_000_000_000
+const PROMPT = 'ship the release notes'
+
+function ingest(
+  server: AgentHookServer,
+  options: {
+    state: 'working' | 'done'
+    hookEventName: string
+    isReplay?: boolean
+    connectionId?: string
+    prompt?: string
+  }
+): void {
+  server.ingestRemote(
+    {
+      paneKey: PANE,
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      source: 'claude',
+      hookEventName: options.hookEventName,
+      ...(options.isReplay ? { isReplay: true } : {}),
+      payload: { state: options.state, prompt: options.prompt ?? PROMPT, agentType: 'claude' }
+    },
+    options.connectionId ?? CONNECTION
+  )
+}
+
+function paneRow(server: AgentHookServer): {
+  state: string
+  receivedAt: number
+  startedAt: number
+} {
+  const row = server.getStatusSnapshot()[0]
+  if (!row) {
+    throw new Error('expected a cached status row')
+  }
+  return { state: row.state, receivedAt: row.receivedAt, startedAt: row.stateStartedAt }
+}
+
+/** Completion-notification dedupe keys on `state:agentType:stateStartedAt`
+ *  (agent-completion-coordinator.ts). Mirror that key so these assertions are about the
+ *  thing the renderer actually compares, not an incidental field. */
+function turnIdentity(server: AgentHookServer): string {
+  const row = server.getStatusSnapshot()[0]
+  if (!row) {
+    throw new Error('expected a cached status row')
+  }
+  return [row.state, row.agentType ?? '', String(row.stateStartedAt)].join(':')
+}
+
+function completeATurn(server: AgentHookServer): void {
+  ingest(server, { state: 'working', hookEventName: 'UserPromptSubmit' })
+  vi.setSystemTime(T0 + 5_000)
+  ingest(server, { state: 'done', hookEventName: 'Stop' })
+}
+
+describe('reconnect clear + replay keeps one completion turn identity (STA-3524)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(T0)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('reclaims the cleared turn identity when the reconnect replays that same turn', () => {
+    const server = new AgentHookServer()
+    completeATurn(server)
+    const beforeDisconnect = paneRow(server)
+    const notifiedIdentity = turnIdentity(server)
+
+    // A dropped SSH connection clears every row it owned; reconnect replays the host cache.
+    vi.setSystemTime(T0 + 60_000)
+    server.clearStatusEntriesForConnection(CONNECTION)
+    expect(server.getStatusSnapshot()).toEqual([])
+
+    vi.setSystemTime(T0 + 61_000)
+    ingest(server, { state: 'done', hookEventName: 'Stop', isReplay: true })
+
+    expect(turnIdentity(server)).toBe(notifiedIdentity)
+    expect(paneRow(server).startedAt).toBe(beforeDisconnect.startedAt)
+    // receivedAt must still advance past the clear watermark or the renderer drops the row.
+    expect(paneRow(server).receivedAt).toBeGreaterThan(beforeDisconnect.receivedAt)
+  })
+
+  it('mints a new turn identity for a completion that landed while disconnected', () => {
+    const server = new AgentHookServer()
+    ingest(server, { state: 'working', hookEventName: 'UserPromptSubmit' })
+    const workingIdentity = turnIdentity(server)
+
+    // The turn ended on the host while the relay was down, so this `done` is news.
+    vi.setSystemTime(T0 + 60_000)
+    server.clearStatusEntriesForConnection(CONNECTION)
+    vi.setSystemTime(T0 + 61_000)
+    ingest(server, { state: 'done', hookEventName: 'Stop', isReplay: true })
+
+    expect(turnIdentity(server)).not.toBe(workingIdentity)
+    expect(paneRow(server).startedAt).toBe(T0 + 61_000)
+  })
+
+  it('mints a new turn identity when the replay carries a different prompt', () => {
+    const server = new AgentHookServer()
+    completeATurn(server)
+    const firstTurnStartedAt = paneRow(server).startedAt
+
+    vi.setSystemTime(T0 + 60_000)
+    server.clearStatusEntriesForConnection(CONNECTION)
+    vi.setSystemTime(T0 + 61_000)
+    ingest(server, {
+      state: 'done',
+      hookEventName: 'Stop',
+      isReplay: true,
+      prompt: 'a different task the host finished meanwhile'
+    })
+
+    expect(paneRow(server).startedAt).toBe(T0 + 61_000)
+    expect(paneRow(server).startedAt).not.toBe(firstTurnStartedAt)
+  })
+
+  it('does not let another host reclaim the cleared turn', () => {
+    const server = new AgentHookServer()
+    completeATurn(server)
+
+    vi.setSystemTime(T0 + 60_000)
+    server.clearStatusEntriesForConnection(CONNECTION)
+    vi.setSystemTime(T0 + 61_000)
+    ingest(server, {
+      state: 'done',
+      hookEventName: 'Stop',
+      isReplay: true,
+      connectionId: 'ssh-host-2'
+    })
+
+    expect(paneRow(server).startedAt).toBe(T0 + 61_000)
+  })
+
+  it('does not reclaim the cleared turn for a live (non-replay) event', () => {
+    const server = new AgentHookServer()
+    completeATurn(server)
+    const firstTurnStartedAt = paneRow(server).startedAt
+
+    vi.setSystemTime(T0 + 60_000)
+    server.clearStatusEntriesForConnection(CONNECTION)
+    vi.setSystemTime(T0 + 61_000)
+    ingest(server, { state: 'done', hookEventName: 'Stop' })
+
+    expect(paneRow(server).startedAt).toBe(T0 + 61_000)
+    expect(paneRow(server).startedAt).not.toBe(firstTurnStartedAt)
+  })
+
+  it('does not bleed the cleared turn into a genuinely new turn after the clear', () => {
+    const server = new AgentHookServer()
+    completeATurn(server)
+    const firstTurnStartedAt = paneRow(server).startedAt
+
+    vi.setSystemTime(T0 + 60_000)
+    server.clearStatusEntriesForConnection(CONNECTION)
+
+    // A live prompt lands first; the stale timing is spent and must not reach the next done.
+    vi.setSystemTime(T0 + 61_000)
+    ingest(server, { state: 'working', hookEventName: 'UserPromptSubmit' })
+    vi.setSystemTime(T0 + 62_000)
+    ingest(server, { state: 'done', hookEventName: 'Stop' })
+
+    expect(paneRow(server).startedAt).toBe(T0 + 62_000)
+    expect(paneRow(server).startedAt).not.toBe(firstTurnStartedAt)
+  })
+
+  it('does not reclaim a turn across a real pane teardown', () => {
+    const server = new AgentHookServer()
+    completeATurn(server)
+    const firstTurnStartedAt = paneRow(server).startedAt
+
+    vi.setSystemTime(T0 + 60_000)
+    server.clearStatusEntriesForConnection(CONNECTION)
+    server.clearPaneState(PANE)
+
+    vi.setSystemTime(T0 + 61_000)
+    ingest(server, { state: 'done', hookEventName: 'Stop', isReplay: true })
+
+    expect(paneRow(server).startedAt).toBe(T0 + 61_000)
+    expect(paneRow(server).startedAt).not.toBe(firstTurnStartedAt)
+  })
+})

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -190,6 +190,32 @@ type AgentPromptSentDedupeEntry = {
   promptInteractionKey?: string
 }
 
+/** Turn identity of a row a transient connection clear deleted, kept only until the
+ *  pane's next status so a reconnect replay of that same turn can reclaim it. */
+type ClearedStatusTiming = {
+  connectionId: string
+  state: ParsedAgentStatusPayload['state']
+  agentType: ParsedAgentStatusPayload['agentType']
+  prompt: string
+  stateStartedAt: number
+}
+
+/** True when a replay re-delivers the exact turn a disconnect clear removed. A replay
+ *  carrying anything else is news this client missed and must keep live timing. */
+function replayReclaimsClearedTurn(
+  cleared: ClearedStatusTiming | undefined,
+  payload: AgentHookEventPayload
+): cleared is ClearedStatusTiming {
+  return (
+    cleared !== undefined &&
+    payload.isReplay === true &&
+    cleared.connectionId === payload.connectionId &&
+    cleared.state === payload.payload.state &&
+    cleared.agentType === payload.payload.agentType &&
+    cleared.prompt === payload.payload.prompt
+  )
+}
+
 function agentTypeToPromptSentAgentKind(agentType: AgentType | undefined): AgentKind {
   const normalized = agentType?.trim().toLowerCase()
   if (!normalized || normalized === 'unknown') {
@@ -634,6 +660,9 @@ export class AgentHookServer {
   private closedAgentStatusTabIds = new Set<string>()
   private closedAgentStatusPaneKeys = new Set<string>()
   private connectionTimestampWatermarkById = new Map<string, number>()
+  // Why: a transient disconnect clear deletes the row the reconnect replay is about to
+  // re-deliver; keep its turn identity so the replay is recognized as the same turn (STA-3524).
+  private clearedStatusTimingByPaneKey = new Map<string, ClearedStatusTiming>()
   // Why: skip disk writes when the JSON exactly matches the last write; guards against re-firing trailing timers when nothing changed.
   private lastWrittenJson: string | null = null
 
@@ -1054,12 +1083,23 @@ export class AgentHookServer {
         previousPromptInteractionKey: previous.promptInteractionKey,
         incomingPromptInteractionKey: payload.promptInteractionKey
       })
+    // Why: the pane's next status supersedes the clear either way — reclaimed below or
+    // outdated by a live event — so the tombstone is one-shot.
+    const cleared = this.clearedStatusTimingByPaneKey.get(payload.paneKey)
+    this.clearedStatusTimingByPaneKey.delete(payload.paneKey)
+    // Why: a disconnect clear removed `previous`, so a reconnect replay of that same turn
+    // would otherwise mint a new stateStartedAt — re-firing the task-complete notification
+    // the user already got, since completion dedupe keys on it (STA-3524).
+    const reclaimedStateStartedAt =
+      !previous && replayReclaimsClearedTurn(cleared, payload) ? cleared.stateStartedAt : undefined
     const stateStartedAt =
       previous && previous.payload.state === payload.payload.state && !commandCodeNewTurn
         ? previous.stateStartedAt
-        : now
+        : (reclaimedStateStartedAt ?? now)
     return {
       ...payload,
+      // Why: receivedAt must stay live — it has to sort after the clear watermark or the
+      // renderer drops the replayed row as a resurrected pre-disconnect status.
       receivedAt: now,
       stateStartedAt
     }
@@ -2241,6 +2281,7 @@ export class AgentHookServer {
     this.closedAgentStatusTabIds.clear()
     this.closedAgentStatusPaneKeys.clear()
     this.connectionTimestampWatermarkById.clear()
+    this.clearedStatusTimingByPaneKey.clear()
     this.legacyPaneKeyAliases.clear()
     clearAllListenerCaches(this.state)
     this.notifyStatusChangeListeners()
@@ -2289,6 +2330,13 @@ export class AgentHookServer {
       const deleted = this.deleteStatusEntry(paneKey, { preserveAuthority: true })
       if (deleted) {
         statusChanged = true
+        this.clearedStatusTimingByPaneKey.set(paneKey, {
+          connectionId: normalizedConnectionId,
+          state: deleted.payload.state,
+          agentType: deleted.payload.agentType,
+          prompt: deleted.payload.prompt,
+          stateStartedAt: deleted.stateStartedAt
+        })
         if (deleted.payload.agentType === 'codex') {
           // Why: a replacement remote process may reuse the pane; don't merge it with the lost connection's children.
           this.state.codexSubagentRosterByPaneKey.delete(paneKey)
@@ -2334,6 +2382,9 @@ export class AgentHookServer {
     if (!options?.preserveAuthority) {
       this.hydratedLaunchTokenHashByPaneKey.delete(resolvedPaneKey)
       this.persistedAuthorityCommitmentsByPaneKey.delete(resolvedPaneKey)
+      // Why: only a transient disconnect expects a replay to reclaim the turn; real
+      // teardown must not leave a tombstone a reused pane could match against.
+      this.clearedStatusTimingByPaneKey.delete(resolvedPaneKey)
     }
     this.clearAssistantMessageRetry(resolvedPaneKey)
     this.clearCodexSubagentPoll(resolvedPaneKey)
@@ -2414,6 +2465,7 @@ export class AgentHookServer {
       this.runtimeObservedStatusPaneKeys.delete(paneKey)
       this.currentAuthorityObservations.delete(paneKey)
       this.promptSentDedupeByPaneKey.delete(paneKey)
+      this.clearedStatusTimingByPaneKey.delete(paneKey)
     }
     if (aliasChanged) {
       this.notifyPaneKeyAliasPersistenceListener()
@@ -2434,6 +2486,7 @@ export class AgentHookServer {
     clearPaneCacheState(this.state, resolvedPaneKey)
     this.currentAuthorityObservations.delete(resolvedPaneKey)
     this.promptSentDedupeByPaneKey.delete(resolvedPaneKey)
+    this.clearedStatusTimingByPaneKey.delete(resolvedPaneKey)
     let clearedAlias = false
     for (const [legacyPaneKey, stablePaneKey] of this.legacyPaneKeyAliases) {
       if (stablePaneKey.stablePaneKey === resolvedPaneKey) {
@@ -2443,6 +2496,7 @@ export class AgentHookServer {
         clearPaneCacheState(this.state, legacyPaneKey)
         this.currentAuthorityObservations.delete(legacyPaneKey)
         this.promptSentDedupeByPaneKey.delete(legacyPaneKey)
+        this.clearedStatusTimingByPaneKey.delete(legacyPaneKey)
         clearedAlias = true
       }
     }

--- a/src/renderer/src/components/terminal-pane/agent-completion-reconnect-replay.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-reconnect-replay.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  createAgentCompletionCoordinator,
+  resetAgentCompletionCoordinatorIdentitiesForTest
+} from './agent-completion-coordinator'
+import type { AgentCompletionStatusSnapshot } from './agent-completion-coordinator-types'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
+
+const PANE = makePaneKey('tab-1', '11111111-1111-4111-8111-111111111111')
+const T0 = 1_700_000_000_000
+const PROMPT = 'ship the release notes'
+
+function row(state: 'working' | 'done', stateStartedAt: number): AgentCompletionStatusSnapshot {
+  return { state, prompt: PROMPT, agentType: 'claude', stateStartedAt }
+}
+
+function trackCompletions(): {
+  observe: (snapshot: AgentCompletionStatusSnapshot) => void
+  count: () => number
+  dispose: () => void
+} {
+  const completions: string[] = []
+  const coordinator = createAgentCompletionCoordinator({
+    paneKey: PANE,
+    getPtyId: () => 'pty-1',
+    getSettings: () => null,
+    inspectProcess: async () => ({ foregroundProcess: null, hasChildProcesses: false }),
+    dispatchCompletion: (title) => {
+      completions.push(title)
+    },
+    isLive: () => true
+  })
+  return {
+    observe: (snapshot) => coordinator.observeHookStatus(snapshot),
+    count: () => completions.length,
+    dispose: () => coordinator.dispose()
+  }
+}
+
+/** The renderer's only defence against a repeated `done` is the turn identity
+ *  `state:agentType:stateStartedAt`. These cases pin what a reconnect replay must and must
+ *  not carry for that defence to hold — the contract `reconnect-clear-replay-turn-identity.test.ts`
+ *  enforces on the main-process side (STA-3524). */
+describe('reconnect replay and the completion turn identity', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(T0)
+    resetAgentCompletionCoordinatorIdentitiesForTest()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    resetAgentCompletionCoordinatorIdentitiesForTest()
+  })
+
+  it('re-fires the notification when a replayed done arrives with a re-minted stateStartedAt', () => {
+    const notifications = trackCompletions()
+    notifications.observe(row('working', T0))
+    vi.setSystemTime(T0 + 5_000)
+    notifications.observe(row('done', T0 + 5_000))
+    vi.advanceTimersByTime(5_000)
+    expect(notifications.count()).toBe(1)
+
+    // What a clear + replay produced before the fix: the same finished turn, restamped.
+    vi.setSystemTime(T0 + 61_000)
+    notifications.observe(row('done', T0 + 61_000))
+    vi.advanceTimersByTime(5_000)
+
+    expect(notifications.count()).toBe(2)
+    notifications.dispose()
+  })
+
+  it('stays silent when the replayed done keeps the turn identity it was notified under', () => {
+    const notifications = trackCompletions()
+    notifications.observe(row('working', T0))
+    vi.setSystemTime(T0 + 5_000)
+    notifications.observe(row('done', T0 + 5_000))
+    vi.advanceTimersByTime(5_000)
+    expect(notifications.count()).toBe(1)
+
+    vi.setSystemTime(T0 + 61_000)
+    notifications.observe(row('done', T0 + 5_000))
+    vi.advanceTimersByTime(5_000)
+
+    expect(notifications.count()).toBe(1)
+    notifications.dispose()
+  })
+
+  it('stays silent across repeated reconnect cycles replaying the same turn', () => {
+    const notifications = trackCompletions()
+    notifications.observe(row('working', T0))
+    vi.setSystemTime(T0 + 5_000)
+    notifications.observe(row('done', T0 + 5_000))
+    vi.advanceTimersByTime(5_000)
+
+    // The reported symptom is a flap: dozens of replays in a few minutes.
+    for (let cycle = 1; cycle <= 12; cycle += 1) {
+      vi.setSystemTime(T0 + 60_000 + cycle * 10_000)
+      notifications.observe(row('done', T0 + 5_000))
+      vi.advanceTimersByTime(5_000)
+    }
+
+    expect(notifications.count()).toBe(1)
+    notifications.dispose()
+  })
+
+  it('still notifies a completion first seen on the replay', () => {
+    const notifications = trackCompletions()
+    notifications.observe(row('working', T0))
+    expect(notifications.count()).toBe(0)
+
+    // The turn ended while the client was disconnected, so this done is new to the pane.
+    vi.setSystemTime(T0 + 61_000)
+    notifications.observe(row('done', T0 + 61_000))
+    vi.advanceTimersByTime(5_000)
+
+    expect(notifications.count()).toBe(1)
+    notifications.dispose()
+  })
+
+  it('notifies again for a real next turn after the replayed one', () => {
+    const notifications = trackCompletions()
+    notifications.observe(row('working', T0))
+    vi.setSystemTime(T0 + 5_000)
+    notifications.observe(row('done', T0 + 5_000))
+    vi.setSystemTime(T0 + 61_000)
+    notifications.observe(row('done', T0 + 5_000))
+    vi.advanceTimersByTime(5_000)
+    expect(notifications.count()).toBe(1)
+
+    vi.setSystemTime(T0 + 70_000)
+    notifications.observe(row('working', T0 + 70_000))
+    vi.setSystemTime(T0 + 80_000)
+    notifications.observe(row('done', T0 + 80_000))
+    vi.advanceTimersByTime(5_000)
+
+    expect(notifications.count()).toBe(2)
+    notifications.dispose()
+  })
+})


### PR DESCRIPTION
## ELI5

When Orca loses an SSH connection it throws away everything it knew about the agents on that host. On reconnect the host re-sends ("replays") what it had. Orca had no memory of the turn it just threw away, so a job that finished an hour ago looked like it had *just* finished — and Orca announced it again. Every reconnect, another "Claude finished" notification. During a flapping connection, dozens in a few minutes.

This PR makes Orca remember the identity of the turn it cleared, just long enough for the replay to arrive, so it recognizes the re-sent status as the same turn instead of a new one.

## What Changed

`src/main/agent-hooks/server.ts`:

- `clearStatusEntriesForConnection` now stashes the turn identity of each row it deletes — `connectionId`, `state`, `agentType`, `prompt`, `stateStartedAt`.
- `attachStatusTiming` consults that stash when there is no cached `previous` row. If the incoming event is a replay from the same connection carrying the same state / agentType / prompt, it reclaims the original `stateStartedAt`. Anything else keeps live timing.
- The stash is one-shot: read-and-delete on the pane's next status, so a live event supersedes it. It is also dropped by both real teardown fan-outs (`deleteStatusEntry` without `preserveAuthority`, `dropStatusEntriesByTabPrefix`, `clearPaneState`), alongside the existing `promptSentDedupeByPaneKey` per-pane cache it now mirrors.

`receivedAt` is deliberately **not** restored — it must keep advancing past the disconnect's clear watermark, or the renderer's `transientClearWatermark` guard drops the replayed row as a resurrected pre-disconnect status.

No wire change, no IPC change, no renderer change.

## Why

The renderer already has the right dedupe. `agent-completion-coordinator.ts` keys completion notifications on a turn identity:

```ts
function hookCompletionIdentity(payload) {
  return [payload.state, payload.agentType ?? '', String(Math.trunc(payload.stateStartedAt))].join(':')
}
```

and checks it twice — once against the live coordinator's `lastCompletionIdentity`, once against the module-scoped `lastCompletionIdentityByPaneKey` that outlives a coordinator remount. A repeated `done` for the same turn is supposed to be silent.

The defect is that the **key gets re-minted**, not that the dedupe is missing:

1. `ssh-relay-session.ts:1612` — `connection_lost` teardown calls `agentHookServer.clearStatusEntriesForConnection(targetId)`, which `deleteStatusEntry`s every row that connection owned.
2. Reconnect calls `agent_hook.requestReplay`; the host re-forwards its cache with `isReplay: true`.
3. `applyNormalizedStatus` → `attachStatusTiming` finds no `previous` (step 1 deleted it), so it falls to `stateStartedAt = now`.
4. `done:claude:<old>` becomes `done:claude:<now>`. Both dedupe checks miss. `dispatchCompletion` fires.

So the fix belongs where the identity is minted, not at a new bypass downstream.

### Why not "skip notifications for replayed statuses"

That is what the two PRs below do — plumb `isReplay` into `AgentStatusIpcPayload` and add `data.isReplay !== true` to the notification guard in `useIpcEvents.ts:3281`. It suppresses the reported symptom, but that guard fences off the whole of `observeAgentHookCompletionForNotification`, not just the duplicate:

- **Attention is lost too.** The same call drives `dispatchAttention` for `waiting` / permission states. A replay is exactly how a client re-learns that an agent is blocked on the user after a flap; skipping observation means no "Needs You" — the inverse failure tracked as #14426.
- **`dispatchHookLifecycle` is skipped**, which the notifications module explicitly wants to keep running independent of notification preferences ("accepted hooks must still release pane-owned cursor/cache effects after the quiet window").
- **Coordinator turn state desyncs.** A skipped replayed `working` leaves `workingStatusObserved` false and never clears `paneKeysRequiringFreshWorking`, which can silently swallow the *next* real completion.
- It leaves the re-minted `stateStartedAt` in place, so every other consumer of it stays wrong: `WorktreeCardAgents.tsx:98` and `useActivityUnreadCount.ts:71` (`ackAt < entry.stateStartedAt`) re-mark the row unread on each reconnect; `dashboard-agent-status-patch.ts:49` re-stamps `finishedAt`; `web-session-tabs-sync.ts:1211` lets a replayed `done` outrank a newer client `working`; `isMirroredCommandCodeTurnBump` reads it as a new Command Code turn.

Restoring the identity fixes all of those at once and reuses the dedupe that already exists.

### Relationship to #14610 (STA-4144)

Complementary, non-overlapping, and this PR closes the gap #14610 documented as out of scope.

- #14610 handles the reconnect paths that **do not clear first** (WSL relay, host-side relay restart). There `previous` still exists, so `stateStartedAt` was already preserved and the notification never re-fired; its bug was `receivedAt` being re-armed. It preserves `receivedAt` for a same-state replay.
- This PR handles the path that **does clear first** (SSH `connection_lost`). There `previous` is gone, so `stateStartedAt` is re-minted — the notification bug. #14610's PR body names this exact case under "Known remaining gap (not fixed here)".

They touch neighbouring lines of the same two functions but different branches: #14610 acts when `previous` exists, this acts when it does not. #14610 argued the gap needed "a new optional wire field"; a client-side tombstone closes it with no wire change. Either can merge first; whichever lands second will need a trivial textual rebase in `attachStatusTiming`/`applyNormalizedStatus`, no logic conflict.

Re-verified against both PRs as they stand today rather than asserted from memory: #14610 is still `OPEN` and `CONFLICTING` / `DIRTY` against `main`, and touches `src/main/agent-hooks/server.ts` (+10/−1) plus one new test. Its hunk sits in `applyNormalizedStatus` at ~line 1276, passing `replayPreservedReceivedAt ?? now` into `attachStatusTiming`; this PR's nearest hunk ends inside `attachStatusTiming` at ~line 1102 — about 174 lines apart, no textual overlap. The branches are mutually exclusive: #14610 requires `previous` to exist, this PR's reclaim requires `!previous`, in which case `previous?.receivedAt` is `undefined` and `receivedAt` stays live. Either can merge first.

### Supersedes

- **#12998** (@innocarpe) — `isReplay` through the IPC payload + renderer notification skip. Also adds `isReplay` to `toAgentStatusIpcPayload`, which leaks the flag into `getStatusSnapshot()` and the persisted last-status cache, so a pane whose last row happened to arrive as a replay stays marked replayed indefinitely.
- **#12750** (@robertnisipeanu) — same renderer skip, narrower plumbing (the `isReplay` field is not on `AgentStatusIpcPayload` today, which is the observation the issue was filed on).

Both correctly identified where the notification fires. This PR fixes why the row looked new instead of gating the observation.

## Linked Issue

Fixes #12747

Linear **STA-3524**.

## Visual Proof

No UI change, and the user-visible difference is the *absence* of a duplicate OS notification — which a single screenshot cannot show. So the proof is a **count across repeated relay drops against a live SSH host**, run in both directions.

### Live rig

Throwaway `ubuntu:22.04` Docker container as the SSH target (linux-arm64, key-only root login, node 22.14.0, `build-essential` + `python3` — required or node-pty will not compile on the host and remote PTYs never come up — a real git repo at `/work/demo-project`, and `claude` 2.1.233 on `PATH` so Orca's remote hook detector fires). The client was this worktree running as an isolated Electron dev instance (own `ORCA_DEV_USER_DATA_PATH`, own CDP port, `getIdentity()` re-verified before every interaction batch, `repos: []` on first attach confirming a genuinely fresh profile), connected through the real `ssh.connect` path. Orca installed its real managed hook on the remote — `/root/.orca/agent-hooks/claude-hook.sh` plus `SessionStart` / `UserPromptSubmit` / `Stop` entries in `/root/.claude/settings.json`.

The relay drop is the exact `connection_lost` path this PR is about: kill only the relay's `--connect` bridge inside the container by resolved numeric PID, leaving the detached relay daemon (which owns the cache that gets replayed) alive. That gives mux transport close → `teardownProviders('connection_lost')` → `clearStatusEntriesForConnection` → auto-reconnect → `agent_hook.requestReplay` → host re-forwards with `isReplay: true`.

### Result

**Before the fix** (`src/main/agent-hooks/server.ts` reverted to its pre-PR state; the running main bundle verified to contain zero occurrences of `clearedStatusTimingByPaneKey`):

```
1 real completion         → 1 notification
12 relay-drop cycles      → 12 more, exactly one per reconnect
TOTAL = 13
```

`stateStartedAt` was re-minted on every replay — `1786947531919 → 1786947619673 → … → 1786947736801` — which is precisely the re-minted identity this PR describes.

**After the fix** (same rig, same container, single pane, fresh profile):

```
1 real completion         → 1 notification
12 relay-drop cycles      → 0
TOTAL = 1
```

Every cycle asserted (a) the client answered CDP before and after and (b) the remote relay logged a fresh `Socket client accepted`, so no cycle is vacuous — the relay logged 13 accepts total (1 initial + 12 reconnects). This mirrors the 12-cycle unit test at the real wire.

### `receivedAt` still advances

Final row after the 12 drops:

```
stateStartedAt: 1786950695833   ← unchanged across all 12 replays
receivedAt:     1786950857498   ← +161,665 ms, past every disconnect clear watermark
```

Identity reclaimed, `receivedAt` deliberately not restored. Visible in the UI too: the sidebar agent row still reads `3m` old instead of resetting to "just now" on each reconnect.

### Two honest caveats

**The agent binary was substituted.** The container has `claude` installed but no credentials. So the turn was driven by invoking **Orca's own installed managed hook script** from inside the real remote pane with a real Claude `UserPromptSubmit` then `Stop` payload on stdin — the same call the agent process makes. Everything downstream of that script is production code: hook script → relay hook server on `127.0.0.1:$ORCA_AGENT_HOOK_PORT` → `agent.hook` notification over the relay → `SshRelaySession.ingestRemote` → `applyNormalizedStatus` / `attachStatusTiming` → renderer completion coordinator → `notifications:dispatch`. The pane's genuinely injected env confirms the wiring (`ORCA_AGENT_HOOK_PORT` / `_TOKEN` / `_ENV` / `_VERSION`, `ORCA_PANE_KEY`, `ORCA_TAB_ID`, `ORCA_WORKTREE_ID`, `ORCA_TERMINAL_HANDLE`). Only the process that would have invoked the hook was simulated.

**That substitution was subsequently shown to be immaterial.** `UserPromptSubmit` / `Stop` payloads were captured from a real authenticated Claude 2.1.233 — the same version the container had — and differentiated against the payloads this rig actually injected, both arms driven through production `normalizeHookPayload` (the relay's own `/hook/claude` call) and the real `AgentHookServer` clear/replay, with the prompt text held identical so the arms differed only in payload shape:

- The three fields `replayReclaimsClearedTurn` compares — `state`, `prompt`, `agentType` — are byte-identical.
- The two that differ, `lastAssistantMessage` and `providerSession`, appear in neither the tombstone predicate nor the completion identity `state:agentType:stateStartedAt`.
- The real binary's `Stop` carries **no `prompt` field at all**. `resolvePrompt` recovers it from the per-pane `lastPromptByPaneKey` cache seeded by `UserPromptSubmit`, so the `done` row still carries the true prompt — asserted as equal to the actual text on both arms, not merely equal to each other, since empty-on-both would satisfy the predicate vacuously.
- Driving the **real** payload through 12 replay cycles reproduces both arms offline: **13** distinct completion identities without `isReplay` (`stateStartedAt` re-minted to equal `receivedAt`, advance 0 ms) and **1** with (advance 715,999 ms) — the same 13-vs-1 and the same shape as the live +161,665 ms.

This differential is **offline and single-process**: it does not cross the relay wire and it is not the `notifications:dispatch` measurement. It does not replace the live run above, and it is not a claim that the binary was un-substituted — it establishes that the payloads the live run injected were not a fiction.

**Why the substitution was not simply removed.** Re-running with a genuinely authenticated Claude was attempted and is blocked on this machine: every `claude` here authenticates through `ANTHROPIC_AUTH_TOKEN` + `ANTHROPIC_BASE_URL` set in the `env` block of `~/.claude/settings.json`, so the OAuth file credentials rot unused — `~/.claude/.credentials.json` has both its access and refresh tokens past expiry, and it answers `401 OAuth access token has been revoked`. Confirmed from inside a throwaway container with both credential files copied in and no `ANTHROPIC_*` in its environment: `Failed to authenticate: OAuth session expired and could not be refreshed`. Worth knowing before rebuilding this rig.

**Counting happens at the `notifications:dispatch` IPC handler, not at the OS banner.** macOS refuses banners for an isolated dev bundle — the authorization read returns `denied`, so `deliverNativeNotification()` is never reached in *either* arm. `notifications:dispatch` is the call that becomes the banner; the only gates past it are the 5 s per-worktree cooldown, focus suppression (disabled for the run), and authorization — all worktree-global and identical in both arms, and the cycles were spaced well beyond the cooldown. So the 13-vs-1 comparison is unaffected.

### One result that looks like a miss and is not

An earlier post-fix arm carried a stale pane over from a previous app run and produced **one** extra notification on that pane's first replay. That is the intended `a completion first seen on the replay still notifies` path (cases 2 and 4 below), not a leaked duplicate: at cold start the pane was not live yet so observation was skipped, and the first live replay was the coordinator's first sight of that turn. Its `stateStartedAt` was **not** re-minted (`1786947736801` preserved), and the remaining 11 cycles were silent. The 12/12 figures quoted above come from a clean single-pane profile so the number is unambiguous.

## Testing

**New — `src/main/agent-hooks/reconnect-clear-replay-turn-identity.test.ts`** (7 cases). Drives the real `AgentHookServer` through `ingestRemote` / `clearStatusEntriesForConnection` and asserts on the real `getStatusSnapshot()` row, using the same `state:agentType:stateStartedAt` key the renderer dedupes on.

Red/green oracle — with the fix reverted (`git stash push -- src/main/agent-hooks/server.ts`):

```
AssertionError: expected 'done:claude:1700000061000' to be 'done:claude:1700000005000'
Tests  1 failed | 6 passed (7)
```

The other six pass without the fix — they are guards on behavior that must NOT change:

1. replay reclaims the cleared turn identity; `receivedAt` still advances **(fails without the fix)**
2. a `done` first seen on the replay mints a new identity — the missed-completion path still notifies
3. a replay with a different prompt does not reclaim
4. a replay from a different host does not reclaim
5. a live (non-replay) event does not reclaim
6. a live turn after the clear does not inherit the stale timing
7. a real pane teardown drops the tombstone

**New — `src/renderer/src/components/terminal-pane/agent-completion-reconnect-replay.test.ts`** (5 cases). Drives the real `createAgentCompletionCoordinator` and counts `dispatchCompletion` calls, pinning why the identity matters:

- a re-minted `stateStartedAt` fires a **second** notification (the pre-fix behavior, asserted explicitly)
- a preserved one stays silent
- 12 consecutive replay cycles still yield exactly 1 notification (the reported flap)
- a completion first seen on the replay still notifies
- a genuinely new turn afterwards still notifies

Both guard directions verified load-bearing by deleting the `connectionId` comparison from the predicate and confirming case 4 fails.

Scoped checks (full typecheck skipped per instruction — OOM risk):

- `vitest src/main/agent-hooks/ src/relay/agent-hook-server.test.ts src/main/ssh/ssh-relay-session-agent-hooks.integration.test.ts` → **42 files, 644 passed**, 4 skipped
- `vitest src/renderer/src/components/terminal-pane/agent-completion* src/renderer/src/hooks/agent-hook-completion-notifications.test.ts src/renderer/src/hooks/useIpcEvents.test.ts src/renderer/src/runtime/web-session-tabs-sync*` → **11 files, 359 passed**
- `tsc --noEmit -p config/tsconfig.node.json --composite false` → clean
- `tsc --noEmit -p config/tsconfig.web.json --composite false` → clean
- `check-changed-code-quality.mjs -- origin/main` → 0 findings across 3 changed files (all three scans)
- `oxlint` + `oxfmt --check` on changed files → clean

Platforms: no platform branch. The path it fixes is the SSH relay reconnect, covered by the integration suites above **and** exercised live — macOS client → Linux SSH remote — under Visual Proof.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

- **Security** — none. No new input, no trust-boundary change; the retained fields are already-normalized values from a row this process cached.
- **Cross-platform** — no platform branch; shared ingest path.
- **Remote SSH** — this *is* the remote path, and it was exercised live against a Linux SSH host through the real relay (see Visual Proof). No wire change and no new field on either side, so mixed client/host versions are unaffected: the fix is entirely client-side over `isReplay`, which already crosses the wire.
- **Mobile / paired clients** — read the same rows. A replayed `done` now carries its true `stateStartedAt`, so it stops re-marking rows unread (`useActivityUnreadCount.ts:71`) and stops outranking newer client state in `web-session-tabs-sync.ts`.
- **Backwards compatibility** — no persisted-format change. The tombstone is in-memory only and never serialized to `last-status.json`.
- **Performance** — one map read/delete per ingested event; at most one entry per pane, dropped on the pane's next status or its teardown.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] Scoped lint / typecheck / tests pass locally (full typecheck skipped per instruction — OOM risk)

## Author

- X / Twitter: @BrennanKB5


