### PR TITLE
fix(runtime): rank tui-idle evidence instead of inferring idle from silence

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -16370,6 +16370,263 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  // Why: `syncWindowGraph` rebuilds `this.leaves` with fresh objects on every renderer
+  // publish, so the record a tui-idle waiter closed over stops advancing the moment the
+  // graph next syncs. The fallback poll must re-read the live record or it re-checks a
+  // dead snapshot forever and the wait burns its whole timeout (#6011).
+  it('polls the live leaf record after a graph resync replaces it', async () => {
+    vi.useFakeTimers()
+    try {
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess: async () => null
+      })
+      // A working spinner title: not explicit-idle, so the waiter registers and polls.
+      syncSinglePty(runtime, 'pty-1', { tabTitle: 'Claude Code', paneTitle: '◐ Claude Code' })
+      const [terminal] = (await runtime.listTerminals()).terminals
+
+      const waitPromise = runtime.waitForTerminal(terminal.handle, {
+        condition: 'tui-idle',
+        timeoutMs: 60_000
+      })
+      let settled = false
+      void waitPromise.then(
+        () => {
+          settled = true
+        },
+        () => {
+          settled = true
+        }
+      )
+      await vi.advanceTimersByTimeAsync(1_000)
+      expect(settled).toBe(false)
+
+      // The renderer republishes the pane at its idle title. This is a graph-only
+      // update — no PTY bytes — so the transition resolver never runs and the
+      // fallback poll is the only path that can satisfy the waiter.
+      syncSinglePty(runtime, 'pty-1', { tabTitle: 'Claude Code', paneTitle: '✳ Claude Code' })
+
+      await vi.advanceTimersByTimeAsync(5_000)
+
+      await expect(waitPromise).resolves.toMatchObject({
+        handle: terminal.handle,
+        condition: 'tui-idle',
+        satisfied: true
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // Why: this is the orchestration worker-readiness shape. `startWorker` waits tui-idle on a
+  // freshly launched agent, so the pre-registration fast path can never satisfy it — it always
+  // registers. Codex announces readiness in its BODY banner, not an OSC title, so no title
+  // transition fires and the fallback poll is the only path to resolution.
+  it('resolves a leaf tui-idle waiter from a ready prompt that lands after a resync', async () => {
+    vi.useFakeTimers()
+    try {
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess: async () => null
+      })
+      syncSinglePty(runtime, 'pty-1', { tabTitle: 'worker-task-1', paneTitle: 'Codex YOLO' })
+      const [terminal] = (await runtime.listTerminals()).terminals
+
+      const waitPromise = runtime.waitForTerminal(terminal.handle, {
+        condition: 'tui-idle',
+        timeoutMs: 60_000
+      })
+      let settled = false
+      void waitPromise.then(
+        () => {
+          settled = true
+        },
+        () => {
+          settled = true
+        }
+      )
+      await vi.advanceTimersByTimeAsync(1_000)
+      expect(settled).toBe(false)
+
+      // Any renderer publish during the cold start — creating the worker pane is itself one.
+      syncSinglePty(runtime, 'pty-1', { tabTitle: 'worker-task-1', paneTitle: 'Codex YOLO' })
+
+      runtime.onPtyData(
+        'pty-1',
+        [
+          ' >_ OpenAI Codex (v0.131.0)\n',
+          ' model:       gpt-5.5 high   /model to change\n',
+          ' directory:   ~/orca/workspaces/orca/cli-debug\n'
+        ].join(''),
+        Date.now()
+      )
+      await vi.advanceTimersByTimeAsync(5_000)
+
+      await expect(waitPromise).resolves.toMatchObject({
+        handle: terminal.handle,
+        condition: 'tui-idle',
+        satisfied: true
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // Why: PTY records are mutated in place today, but `dropDisconnectedPtyRecord` +
+  // re-registration mints a fresh object under the same id (restore, reconnect, prune).
+  // The PTY poll closes over the same kind of reference as the leaf poll, so it is fixed
+  // symmetrically rather than left to rot until that path is hit in production.
+  it('polls the live pty record after it is replaced under the same id', async () => {
+    vi.useFakeTimers()
+    try {
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess: async () => null
+      })
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+      runtime.onPtyData('pty-bg', 'booting\n', Date.now())
+
+      const waitPromise = runtime.waitForTerminal(handle, {
+        condition: 'tui-idle',
+        timeoutMs: 60_000
+      })
+      let settled = false
+      void waitPromise.then(
+        () => {
+          settled = true
+        },
+        () => {
+          settled = true
+        }
+      )
+      await vi.advanceTimersByTimeAsync(1_000)
+      expect(settled).toBe(false)
+
+      const internals = runtime as unknown as {
+        ptysById: Map<string, Record<string, unknown>>
+      }
+      const captured = internals.ptysById.get('pty-bg')
+      expect(captured).toBeDefined()
+      // Stand in for drop + re-register: same id, new object, ready prompt in its body.
+      const readyPrompt = [
+        ' >_ OpenAI Codex (v0.131.0)',
+        ' model:       gpt-5.5 high   /model to change',
+        ' directory:   ~/orca/workspaces/orca/cli-debug'
+      ].join('\n')
+      internals.ptysById.set('pty-bg', {
+        ...(captured as Record<string, unknown>),
+        preview: readyPrompt,
+        tailBuffer: readyPrompt.split('\n'),
+        tailPartialLine: ''
+      })
+
+      await vi.advanceTimersByTimeAsync(5_000)
+
+      await expect(waitPromise).resolves.toMatchObject({
+        handle,
+        condition: 'tui-idle',
+        satisfied: true
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // Why: the transition itself is only a title sample. A name-only title classifies as
+  // 'idle' by default, so resolving on the transition alone is how a mid-turn Claude `✳`
+  // frame reported a finished turn. The first-party stream still says working — re-rank
+  // the transition instead of trusting it.
+  it('does not resolve a leaf tui-idle waiter on a title transition the stream vetoes', async () => {
+    vi.useFakeTimers()
+    try {
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess: async () => null
+      })
+      syncSinglePty(runtime, 'pty-1', { tabTitle: 'Claude Code', paneTitle: null })
+      runtime.onPtyData(
+        'pty-1',
+        '\x1b]9999;{"state":"working","agentType":"claude"}\x07\x1b]0;◐ Claude Code\x07thinking\n',
+        Date.now()
+      )
+      const [terminal] = (await runtime.listTerminals()).terminals
+
+      const waitPromise = runtime.waitForTerminal(terminal.handle, {
+        condition: 'tui-idle',
+        timeoutMs: 60_000
+      })
+      let settled = false
+      void waitPromise.then(
+        () => {
+          settled = true
+        },
+        () => {
+          settled = true
+        }
+      )
+      await vi.advanceTimersByTimeAsync(500)
+
+      // A name-only title: detectAgentStatusFromTitle DEFAULTS this to 'idle', which fires
+      // the transition resolver while the agent is demonstrably still working.
+      runtime.onPtyData('pty-1', '\x1b]0;Claude Code\x07', Date.now())
+      await vi.advanceTimersByTimeAsync(500)
+
+      expect(settled).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not resolve a pty tui-idle waiter on a title transition the stream vetoes', async () => {
+    vi.useFakeTimers()
+    try {
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess: async () => null
+      })
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+      runtime.onPtyData(
+        'pty-bg',
+        '\x1b]9999;{"state":"working","agentType":"claude"}\x07\x1b]0;◐ Claude Code\x07thinking\n',
+        Date.now()
+      )
+
+      const waitPromise = runtime.waitForTerminal(handle, {
+        condition: 'tui-idle',
+        timeoutMs: 60_000
+      })
+      let settled = false
+      void waitPromise.then(
+        () => {
+          settled = true
+        },
+        () => {
+          settled = true
+        }
+      )
+      await vi.advanceTimersByTimeAsync(500)
+
+      runtime.onPtyData('pty-bg', '\x1b]0;Claude Code\x07', Date.now())
+      await vi.advanceTimersByTimeAsync(500)
+
+      expect(settled).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('resolves tui-idle from a Codex ready prompt preview', async () => {
     const runtime = new OrcaRuntimeService(store)
     runtime.setPtyController({

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -16158,6 +16158,218 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  // Why: `Codex` is a name-only title, which detectAgentStatusFromTitle DEFAULTS to
+  // 'idle' — agents render their spinner and `esc to interrupt` in the terminal body,
+  // not the OSC title. The agent's own OSC 9999 stream is saying `working` the whole
+  // time, so tui-idle must not report a finished turn (#6011).
+  it('does not report tui-idle while the agent status stream still reports working', async () => {
+    vi.useFakeTimers()
+    try {
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess: async () => null
+      })
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+      runtime.onPtyData(
+        'pty-bg',
+        '\x1b]9999;{"state":"working","agentType":"codex"}\x07\x1b]0;Codex\x07thinking\n',
+        Date.now()
+      )
+
+      const waitPromise = runtime.waitForTerminal(handle, {
+        condition: 'tui-idle',
+        timeoutMs: 30_000
+      })
+      let settled = false
+      void waitPromise.then(
+        () => {
+          settled = true
+        },
+        () => {
+          settled = true
+        }
+      )
+
+      // Well past TUI_IDLE_QUIESCENCE_MS: silence alone would have satisfied the
+      // wait here, which is exactly the inference this change removes.
+      await vi.advanceTimersByTimeAsync(10_000)
+      expect(settled).toBe(false)
+
+      runtime.onPtyData(
+        'pty-bg',
+        '\x1b]9999;{"state":"done","agentType":"codex"}\x07done\n',
+        Date.now()
+      )
+      await vi.advanceTimersByTimeAsync(6_000)
+
+      await expect(waitPromise).resolves.toMatchObject({
+        handle,
+        condition: 'tui-idle',
+        satisfied: true,
+        status: 'running'
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // Why: agents that publish no OSC 9999 status at all (the tier-3 path) get only the
+  // sustained-quiescence guard. Streaming output is proof of work regardless of title.
+  it('does not report tui-idle while a name-only agent title keeps streaming output', async () => {
+    vi.useFakeTimers()
+    try {
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess: async () => null
+      })
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+      runtime.onPtyData('pty-bg', '\x1b]0;Codex\x07working 1\n', Date.now())
+
+      const waitPromise = runtime.waitForTerminal(handle, {
+        condition: 'tui-idle',
+        timeoutMs: 60_000
+      })
+      let settled = false
+      void waitPromise.then(
+        () => {
+          settled = true
+        },
+        () => {
+          settled = true
+        }
+      )
+
+      for (let i = 2; i <= 6; i++) {
+        runtime.onPtyData('pty-bg', `working ${i}\n`, Date.now())
+        await vi.advanceTimersByTimeAsync(2_000)
+      }
+      expect(settled).toBe(false)
+
+      await vi.advanceTimersByTimeAsync(5_000)
+      await expect(waitPromise).resolves.toMatchObject({
+        handle,
+        condition: 'tui-idle',
+        satisfied: true,
+        status: 'running'
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // Why: a fresh `working` must never outrank the composer actually being on screen —
+  // otherwise an agent that misses its completion hook would strand every later wait
+  // for the whole staleness window.
+  it('resolves tui-idle from a ready prompt even while a working status is retained', async () => {
+    vi.useFakeTimers()
+    try {
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess: async () => null
+      })
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+      runtime.onPtyData(
+        'pty-bg',
+        '\x1b]9999;{"state":"working","agentType":"codex"}\x07',
+        Date.now()
+      )
+      runtime.onPtyData(
+        'pty-bg',
+        [
+          ' >_ OpenAI Codex (v0.131.0)\n',
+          ' model:       gpt-5.5 high   /model to change\n',
+          ' directory:   ~/orca/workspaces/orca/cli-debug\n'
+        ].join(''),
+        Date.now()
+      )
+
+      await expect(
+        runtime.waitForTerminal(handle, { condition: 'tui-idle', timeoutMs: 1_000 })
+      ).resolves.toMatchObject({
+        handle,
+        condition: 'tui-idle',
+        satisfied: true,
+        status: 'running'
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // Why: a cold-starting agent is quiet by definition, so "non-shell process, quiet for
+  // 3s" is indistinguishable from "agent at its prompt". Resolving here is what let a
+  // dispatch inject write into a TUI that had not attached its reader yet (#9976).
+  it('does not report tui-idle from quiet foreground alone for a launched agent', async () => {
+    vi.useFakeTimers()
+    try {
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess: async () => 'claude'
+      })
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+        launchAgent: 'claude'
+      })
+      // Boot noise with no OSC title and no status payload: nothing has reported
+      // readiness, so nothing may conclude it.
+      runtime.onPtyData('pty-bg', 'starting up\n', Date.now())
+
+      const waitPromise = runtime.waitForTerminal(handle, {
+        condition: 'tui-idle',
+        timeoutMs: 20_000
+      })
+      const timeoutAssertion = expect(waitPromise).rejects.toThrow('timeout')
+
+      await vi.advanceTimersByTimeAsync(25_000)
+      await timeoutAssertion
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // Why: the cold-start guard is keyed on Orca having launched a KNOWN agent. An ad-hoc
+  // TUI Orca knows nothing about still has only the quiescence fallback; don't break it.
+  it('still reports tui-idle from quiet foreground for an unlaunched non-shell TUI', async () => {
+    vi.useFakeTimers()
+    try {
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess: async () => 'claude'
+      })
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+      runtime.onPtyData('pty-bg', 'starting up\n', Date.now())
+
+      const waitPromise = runtime.waitForTerminal(handle, {
+        condition: 'tui-idle',
+        timeoutMs: 20_000
+      })
+      await vi.advanceTimersByTimeAsync(6_000)
+
+      await expect(waitPromise).resolves.toMatchObject({
+        handle,
+        condition: 'tui-idle',
+        satisfied: true,
+        status: 'running'
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('resolves tui-idle from a Codex ready prompt preview', async () => {
     const runtime = new OrcaRuntimeService(store)
     runtime.setPtyController({

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -16420,6 +16420,98 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  // Why: a daemon respawn or cold restore reuses the PTY id. The previous process's turn
+  // state must not survive into its replacement, or the veto blocks tui-idle forever for a
+  // process that never reported anything.
+  it('drops the retained working veto when the provider generation resets', async () => {
+    vi.useFakeTimers()
+    try {
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess: async () => 'claude'
+      })
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+      runtime.onPtyData(
+        'pty-bg',
+        '\x1b]9999;{"state":"working","agentType":"claude"}\x07mid turn\n',
+        Date.now()
+      )
+
+      // Initialize the provider domain, then replace it — the respawn shape.
+      runtime.synchronizePtyOutputSequenceFromProvider(
+        'pty-bg',
+        { value: 0, generation: 'continued' },
+        0
+      )
+      runtime.synchronizePtyOutputSequenceFromProvider(
+        'pty-bg',
+        { value: 0, generation: 'reset' },
+        Number.MAX_SAFE_INTEGER
+      )
+
+      const waitPromise = runtime.waitForTerminal(handle, {
+        condition: 'tui-idle',
+        timeoutMs: 20_000
+      })
+      await vi.advanceTimersByTimeAsync(6_000)
+
+      await expect(waitPromise).resolves.toMatchObject({
+        handle,
+        condition: 'tui-idle',
+        satisfied: true
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // Why: the quiet-foreground branch is pure absence-of-evidence — a non-shell process that
+  // has not written for a while. The agent's own stream saying `working` outranks it, so the
+  // veto has to guard that branch too, not just the title-derived one.
+  it('does not report tui-idle from quiet foreground while the stream reports working', async () => {
+    vi.useFakeTimers()
+    try {
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess: async () => 'claude'
+      })
+      // No startupAgent: `quietForegroundProcessProvesTuiIdle` allows this branch, and the
+      // sibling test above shows it resolves here without a status stream.
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+      // OSC 9999 only — no OSC 0 title, so lastAgentStatus stays null and the branch is live.
+      runtime.onPtyData(
+        'pty-bg',
+        '\x1b]9999;{"state":"working","agentType":"claude"}\x07starting up\n',
+        Date.now()
+      )
+
+      const waitPromise = runtime.waitForTerminal(handle, {
+        condition: 'tui-idle',
+        timeoutMs: 20_000
+      })
+      let settled = false
+      void waitPromise.then(
+        () => {
+          settled = true
+        },
+        () => {
+          settled = true
+        }
+      )
+      await vi.advanceTimersByTimeAsync(6_000)
+
+      expect(settled).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   // Why: this is the orchestration worker-readiness shape. `startWorker` waits tui-idle on a
   // freshly launched agent, so the pre-registration fast path can never satisfy it — it always
   // registers. Codex announces readiness in its BODY banner, not an OSC title, so no title

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -16512,6 +16512,49 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  // Why: the leaf poll carries its own copy of the quiet-foreground guard, and only the PTY
+  // copy was pinned — deleting the leaf one left all 1176 tests green. A visible tab is the
+  // shape `orca terminal create` produces, so this is the branch real dispatches take.
+  it('does not report tui-idle from quiet foreground on a leaf while the stream reports working', async () => {
+    vi.useFakeTimers()
+    try {
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess: async () => 'claude'
+      })
+      // No OSC 0 title, so leaf.lastAgentStatus stays null and the foreground branch is live.
+      syncSinglePty(runtime, 'pty-1', { tabTitle: 'Codex', paneTitle: null })
+      runtime.onPtyData(
+        'pty-1',
+        '\x1b]9999;{"state":"working","agentType":"claude"}\x07starting up\n',
+        Date.now()
+      )
+      const [terminal] = (await runtime.listTerminals()).terminals
+
+      const waitPromise = runtime.waitForTerminal(terminal.handle, {
+        condition: 'tui-idle',
+        timeoutMs: 20_000
+      })
+      let settled = false
+      void waitPromise.then(
+        () => {
+          settled = true
+        },
+        () => {
+          settled = true
+        }
+      )
+      // Well past TUI_IDLE_QUIESCENCE_MS: a quiet non-shell foreground would resolve here.
+      await vi.advanceTimersByTimeAsync(6_000)
+
+      expect(settled).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   // Why: this is the orchestration worker-readiness shape. `startWorker` waits tui-idle on a
   // freshly launched agent, so the pre-registration fast path can never satisfy it — it always
   // registers. Codex announces readiness in its BODY banner, not an OSC title, so no title

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -16568,69 +16568,6 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
-  // Why: PTY records are mutated in place today, but `dropDisconnectedPtyRecord` +
-  // re-registration mints a fresh object under the same id (restore, reconnect, prune).
-  // The PTY poll closes over the same kind of reference as the leaf poll, so it is fixed
-  // symmetrically rather than left to rot until that path is hit in production.
-  it('polls the live pty record after it is replaced under the same id', async () => {
-    vi.useFakeTimers()
-    try {
-      const runtime = new OrcaRuntimeService(store)
-      runtime.setPtyController({
-        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
-        write: () => true,
-        kill: () => true,
-        getForegroundProcess: async () => null
-      })
-      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
-      runtime.onPtyData('pty-bg', 'booting\n', Date.now())
-
-      const waitPromise = runtime.waitForTerminal(handle, {
-        condition: 'tui-idle',
-        timeoutMs: 60_000
-      })
-      let settled = false
-      void waitPromise.then(
-        () => {
-          settled = true
-        },
-        () => {
-          settled = true
-        }
-      )
-      await vi.advanceTimersByTimeAsync(1_000)
-      expect(settled).toBe(false)
-
-      const internals = runtime as unknown as {
-        ptysById: Map<string, Record<string, unknown>>
-      }
-      const captured = internals.ptysById.get('pty-bg')
-      expect(captured).toBeDefined()
-      // Stand in for drop + re-register: same id, new object, ready prompt in its body.
-      const readyPrompt = [
-        ' >_ OpenAI Codex (v0.131.0)',
-        ' model:       gpt-5.5 high   /model to change',
-        ' directory:   ~/orca/workspaces/orca/cli-debug'
-      ].join('\n')
-      internals.ptysById.set('pty-bg', {
-        ...(captured as Record<string, unknown>),
-        preview: readyPrompt,
-        tailBuffer: readyPrompt.split('\n'),
-        tailPartialLine: ''
-      })
-
-      await vi.advanceTimersByTimeAsync(5_000)
-
-      await expect(waitPromise).resolves.toMatchObject({
-        handle,
-        condition: 'tui-idle',
-        satisfied: true
-      })
-    } finally {
-      vi.useRealTimers()
-    }
-  })
-
   // Why: the transition itself is only a title sample. A name-only title classifies as
   // 'idle' by default, so resolving on the transition alone is how a mid-turn Claude `✳`
   // frame reported a finished turn. The first-party stream still says working — re-rank

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -34661,6 +34661,22 @@ export class OrcaRuntimeService {
     return this.hasSustainedTitleIdle(pty)
   }
 
+  /** Re-read the leaf the waiter registered against. `syncWindowGraph` rebuilds
+   *  `this.leaves` with fresh objects on every renderer publish, so a record captured in a
+   *  poll closure stops advancing almost immediately — its title and status freeze at their
+   *  registration values and the waiter becomes unsatisfiable. Falls back to the captured
+   *  record so a closed pane still reaches its own timeout rather than throwing. */
+  private getLiveLeafRecord(captured: RuntimeLeafRecord): RuntimeLeafRecord {
+    return this.leaves.get(this.getLeafKey(captured.tabId, captured.leafId)) ?? captured
+  }
+
+  /** Same re-read for PTY records. These are mutated in place today, but a drop and
+   *  re-register under the same id (restore, reconnect, disconnected-record prune) mints a
+   *  new object, which would strand this poll the same way. */
+  private getLivePtyRecord(captured: RuntimePtyWorktreeRecord): RuntimePtyWorktreeRecord {
+    return this.ptysById.get(captured.ptyId) ?? captured
+  }
+
   private isLeafTuiIdleSatisfied(leaf: RuntimeLeafRecord, waitText: string): boolean {
     const title = leaf.paneTitle ?? this.tabs.get(leaf.tabId)?.title
     if (
@@ -34741,7 +34757,10 @@ export class OrcaRuntimeService {
   }
 
   // Why: the primary OSC-title signal can't fire for daemon-hosted terminals (no PTY data through the runtime), so this fallback polls the renderer-synced tab title + foreground-process quiescence; self-cancels when the OSC path fires.
-  private startTuiIdleFallbackPoll(waiter: TerminalWaiter, leaf: RuntimeLeafRecord): void {
+  private startTuiIdleFallbackPoll(
+    waiter: TerminalWaiter,
+    registeredLeaf: RuntimeLeafRecord
+  ): void {
     let foregroundPollInFlight = false
     waiter.pollInterval = setInterval(async () => {
       if (!waiter.pollInterval) {
@@ -34749,6 +34768,7 @@ export class OrcaRuntimeService {
       }
       let startedForegroundPoll = false
       try {
+        const leaf = this.getLiveLeafRecord(registeredLeaf)
         const leafWaitText = buildTerminalWaitText(
           leaf.tailBuffer,
           leaf.tailPartialLine,
@@ -34810,7 +34830,10 @@ export class OrcaRuntimeService {
     }, TUI_IDLE_POLL_INTERVAL_MS)
   }
 
-  private startPtyTuiIdleFallbackPoll(waiter: TerminalWaiter, pty: RuntimePtyWorktreeRecord): void {
+  private startPtyTuiIdleFallbackPoll(
+    waiter: TerminalWaiter,
+    registeredPty: RuntimePtyWorktreeRecord
+  ): void {
     let foregroundPollInFlight = false
     waiter.pollInterval = setInterval(async () => {
       if (!waiter.pollInterval) {
@@ -34818,6 +34841,7 @@ export class OrcaRuntimeService {
       }
       let startedForegroundPoll = false
       try {
+        const pty = this.getLivePtyRecord(registeredPty)
         const ptyWaitText = buildTerminalWaitText(pty.tailBuffer, pty.tailPartialLine, pty.preview)
         const blockedReason = detectTerminalWaitBlockedReason(ptyWaitText)
         if (blockedReason) {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -53,7 +53,8 @@ import {
   type AgentStatusIpcPayload,
   type ParsedAgentStatusPayload,
   type AgentStatusOrchestrationContext,
-  type AgentStatusEntry
+  type AgentStatusEntry,
+  type AgentStatusState
 } from '../../shared/agent-status-types'
 import { indexAgentStatusRowsByPaneKey } from '../agent-hooks/agent-status-pane-index'
 import type { AgentHookAuthorityAttestation } from '../agent-hooks/server'
@@ -1471,6 +1472,10 @@ type RuntimePtyWorktreeRecord = {
   lastAgentStatusStartedAtEpochMs: number | null
   // A later semantic title interval cannot inherit rich fields from an earlier task.
   lastAgentStatusRichInvalidatedAtEpochMs: number | null
+  /** Latest first-party state from the agent's own OSC 9999 status stream — what the
+   *  agent SAYS it is doing, as opposed to `lastAgentStatus`, which is what we infer
+   *  from its OSC title. Optional like `tailWaitState`: absent until a payload lands. */
+  lastExplicitAgentStatus?: { state: AgentStatusState; updatedAt: number } | null
   lastOscTitle: string | null
   lastOscTitleAt: number | null
   // Why a second stamp: `lastOscTitleAt` is a title-observation sequence number,
@@ -11753,6 +11758,8 @@ export class OrcaRuntimeService {
       pty.lastAgentStatusObservedLive = false
       pty.lastAgentStatusStartedAtEpochMs = null
       pty.lastAgentStatusRichInvalidatedAtEpochMs = Date.now()
+      // Why: the prior process's turn state must not veto tui-idle for its replacement.
+      pty.lastExplicitAgentStatus = null
       pty.managementTitle = null
       pty.managementTitleAt = null
       pty.waitBlockedAt = null
@@ -11884,6 +11891,16 @@ export class OrcaRuntimeService {
     >()
     const pty = this.ptysById.get(ptyId)
     const connectionId = pty?.connectionId ?? null
+    if (pty) {
+      // Why: the retained snapshots below are keyed by paneKey, which a background
+      // CLI-created PTY may never have. `terminal wait --for tui-idle` still needs
+      // the agent's own state, so keep it on the PTY record where the ptyId is the
+      // only identity the wait path is guaranteed to hold.
+      const latest = chunk.payloads.at(-1)
+      if (latest) {
+        pty.lastExplicitAgentStatus = { state: latest.state, updatedAt: Date.now() }
+      }
+    }
     for (const leaf of this.getLeavesForPty(ptyId)) {
       const paneKey = this.makeRuntimePaneKey(leaf)
       targets.set(paneKey, {
@@ -19119,14 +19136,7 @@ export class OrcaRuntimeService {
       if (condition === 'tui-idle' && ptyBlockedReason) {
         return buildPtyTerminalWaitBlockedResult(handle, condition, pty.pty, ptyBlockedReason)
       }
-      if (condition === 'tui-idle' && pty.pty.lastAgentStatus === 'idle') {
-        return buildPtyTerminalWaitResult(handle, condition, pty.pty)
-      }
-      if (
-        condition === 'tui-idle' &&
-        (this.getAdoptedPtyExplicitIdleStatus(pty.pty) === 'idle' ||
-          isKnownReadyPromptPreview(ptyWaitText))
-      ) {
+      if (condition === 'tui-idle' && this.isPtyTuiIdleSatisfied(pty.pty, ptyWaitText)) {
         return buildPtyTerminalWaitResult(handle, condition, pty.pty)
       }
       return await new Promise<RuntimeTerminalWait>((resolve, reject) => {
@@ -19179,12 +19189,7 @@ export class OrcaRuntimeService {
               waiter,
               buildPtyTerminalWaitBlockedResult(handle, condition, live.pty, blockedReason)
             )
-          } else if (live.pty.lastAgentStatus === 'idle') {
-            this.resolveWaiter(waiter, buildPtyTerminalWaitResult(handle, condition, live.pty))
-          } else if (
-            this.getAdoptedPtyExplicitIdleStatus(live.pty) === 'idle' ||
-            isKnownReadyPromptPreview(livePtyWaitText)
-          ) {
+          } else if (this.isPtyTuiIdleSatisfied(live.pty, livePtyWaitText)) {
             this.resolveWaiter(waiter, buildPtyTerminalWaitResult(handle, condition, live.pty))
           } else {
             this.startPtyTuiIdleFallbackPoll(waiter, live.pty)
@@ -19204,22 +19209,13 @@ export class OrcaRuntimeService {
       return buildTerminalWaitBlockedResult(handle, condition, leaf, leafBlockedReason)
     }
 
-    // Why: if the agent already transitioned to idle (or permission) before the
-    // waiter was registered, resolve immediately. This uses the same OSC title
-    // detection that powers the renderer's "Task complete" notifications.
+    // Why: if the agent already reached idle before the waiter was registered,
+    // resolve immediately. This uses the same OSC title detection that powers the
+    // renderer's "Task complete" notifications.
     // Why: only 'idle' satisfies tui-idle, not 'permission'. Permission means the
     // agent is blocked on user approval, not finished with its task.
-    if (condition === 'tui-idle' && leaf.lastAgentStatus === 'idle') {
+    if (condition === 'tui-idle' && this.isLeafTuiIdleSatisfied(leaf, leafWaitText)) {
       return buildTerminalWaitResult(handle, condition, leaf)
-    }
-    if (condition === 'tui-idle') {
-      const fastPathTitle = leaf.paneTitle ?? this.tabs.get(leaf.tabId)?.title
-      if (
-        (fastPathTitle && detectExplicitIdleStatusFromTitle(fastPathTitle) === 'idle') ||
-        isKnownReadyPromptPreview(leafWaitText)
-      ) {
-        return buildTerminalWaitResult(handle, condition, leaf)
-      }
     }
 
     return await new Promise<RuntimeTerminalWait>((resolve, reject) => {
@@ -19281,7 +19277,7 @@ export class OrcaRuntimeService {
               waiter,
               buildTerminalWaitBlockedResult(handle, condition, live.leaf, blockedReason)
             )
-          } else if (live.leaf.lastAgentStatus === 'idle') {
+          } else if (this.isLeafTuiIdleSatisfied(live.leaf, liveLeafWaitText)) {
             // Why: don't clear lastAgentStatus here. It's a factual record of the
             // last detected OSC state, not a one-shot signal. Clearing it causes
             // subsequent tui-idle waiters to hang even though the agent is idle —
@@ -19291,15 +19287,7 @@ export class OrcaRuntimeService {
             // Why: renderer-synced previews can show a known ready prompt even
             // while the last OSC title is still "working"; keep polling the
             // preview/title until the waiter resolves or hits its timeout.
-            const fastPathTitle = live.leaf.paneTitle ?? this.tabs.get(live.leaf.tabId)?.title
-            if (
-              (fastPathTitle && detectExplicitIdleStatusFromTitle(fastPathTitle) === 'idle') ||
-              isKnownReadyPromptPreview(liveLeafWaitText)
-            ) {
-              this.resolveWaiter(waiter, buildTerminalWaitResult(handle, condition, live.leaf))
-            } else {
-              this.startTuiIdleFallbackPoll(waiter, live.leaf)
-            }
+            this.startTuiIdleFallbackPoll(waiter, live.leaf)
           }
         }
       } catch (error) {
@@ -34608,6 +34596,85 @@ export class OrcaRuntimeService {
     }
   }
 
+  // ─── tui-idle evidence ranking ──────────────────────────────────────────────
+  // Why the ranking exists: a thinking TUI and a finished TUI are both silent, so
+  // the absence of a working marker can never prove completion. Every satisfaction
+  // site below sorts its evidence into three tiers and only the top two can resolve:
+  //
+  //   1. POSITIVE  — the agent (or its rendered composer) states it is ready:
+  //                  an explicit idle OSC title, or a known ready-prompt body.
+  //   2. FIRST-PARTY VETO — a fresh OSC 9999 status saying working/blocked/waiting.
+  //                  This is the agent's own account of itself; it outranks anything
+  //                  we infer from titles or bytes, and it is the same freshness rule
+  //                  `getTerminalAgentStatus` already applies, so the two APIs agree.
+  //   3. ABSENCE   — a name-only agent title (which `detectAgentStatusFromTitle`
+  //                  DEFAULTS to 'idle'), or a quiet non-shell foreground process.
+  //                  Usable only as a last resort, and only once sustained.
+
+  /** The agent's own status stream says this turn is still open. */
+  private hasFreshWorkingAgentStatusForPty(ptyId: string | null | undefined): boolean {
+    if (!ptyId) {
+      return false
+    }
+    const explicit = this.ptysById.get(ptyId)?.lastExplicitAgentStatus
+    return isFreshNonDoneAgentStatus(explicit ?? undefined)
+  }
+
+  /** Tier 3: a title-derived 'idle' is the classifier's fallthrough for a name-only
+   *  agent title, so on its own it means "no working marker seen", not "finished".
+   *  Agents render their spinner and `esc to interrupt` in the terminal BODY, so a
+   *  busy Codex/Devin/aider is routinely titled idle — that is #6011. Demand the
+   *  stream also go quiet before acting on it. Handles with no PTY output of their
+   *  own (adopted/daemon) have nothing to debounce, so their title still stands. */
+  private hasSustainedTitleIdle(target: {
+    lastAgentStatus: AgentStatus | null
+    lastOutputAt: number | null
+  }): boolean {
+    if (target.lastAgentStatus !== 'idle') {
+      return false
+    }
+    if (target.lastOutputAt === null) {
+      return true
+    }
+    return Date.now() - target.lastOutputAt >= TUI_IDLE_QUIESCENCE_MS
+  }
+
+  /** Tier 3, cold start: Orca launched a known agent on this PTY, so a quiet
+   *  non-shell foreground process is an agent still booting, not one at its prompt.
+   *  Resolving here is what let `dispatch --inject` write into a TUI that had not
+   *  yet attached its reader and silently lose the prompt (#9976). Readiness for a
+   *  launched agent must come from tier 1/2 evidence instead. */
+  private quietForegroundProcessProvesTuiIdle(ptyId: string | null | undefined): boolean {
+    return !(ptyId && this.ptysById.get(ptyId)?.launchAgent)
+  }
+
+  private isPtyTuiIdleSatisfied(pty: RuntimePtyWorktreeRecord, waitText: string): boolean {
+    if (
+      this.getAdoptedPtyExplicitIdleStatus(pty) === 'idle' ||
+      isKnownReadyPromptPreview(waitText)
+    ) {
+      return true
+    }
+    if (this.hasFreshWorkingAgentStatusForPty(pty.ptyId)) {
+      return false
+    }
+    return this.hasSustainedTitleIdle(pty)
+  }
+
+  private isLeafTuiIdleSatisfied(leaf: RuntimeLeafRecord, waitText: string): boolean {
+    const title = leaf.paneTitle ?? this.tabs.get(leaf.tabId)?.title
+    if (
+      (title && detectExplicitIdleStatusFromTitle(title) === 'idle') ||
+      isKnownReadyPromptPreview(waitText)
+    ) {
+      return true
+    }
+    if (this.hasFreshWorkingAgentStatusForPty(leaf.ptyId)) {
+      return false
+    }
+    return this.hasSustainedTitleIdle(leaf)
+  }
+
   private resolveTuiIdleWaiters(leaf: RuntimeLeafRecord): void {
     const leafKey = this.getLeafKey(leaf.tabId, leaf.leafId)
     const candidateHandle =
@@ -34624,8 +34691,12 @@ export class OrcaRuntimeService {
     if (!waiters || waiters.size === 0) {
       return
     }
+    const waitText = buildTerminalWaitText(leaf.tailBuffer, leaf.tailPartialLine, leaf.preview)
     for (const waiter of [...waiters]) {
-      if (waiter.condition === 'tui-idle') {
+      // Why: the transition itself is only a title sample. Re-rank it — an idle
+      // title arriving mid-work is tier-3 evidence, and the fallback poll picks
+      // the waiter up once it becomes sustained or the agent reports done.
+      if (waiter.condition === 'tui-idle' && this.isLeafTuiIdleSatisfied(leaf, waitText)) {
         this.resolveWaiter(waiter, buildTerminalWaitResult(handle, 'tui-idle', leaf))
       }
     }
@@ -34659,8 +34730,11 @@ export class OrcaRuntimeService {
     if (!waiters || waiters.size === 0) {
       return
     }
+    const waitText = buildTerminalWaitText(pty.tailBuffer, pty.tailPartialLine, pty.preview)
     for (const waiter of [...waiters]) {
-      if (waiter.condition === 'tui-idle') {
+      // Why: same re-ranking as resolveTuiIdleWaiters — a title transition is not
+      // on its own proof the turn ended.
+      if (waiter.condition === 'tui-idle' && this.isPtyTuiIdleSatisfied(pty, waitText)) {
         this.resolveWaiter(waiter, buildPtyTerminalWaitResult(handle, 'tui-idle', pty))
       }
     }
@@ -34675,27 +34749,6 @@ export class OrcaRuntimeService {
       }
       let startedForegroundPoll = false
       try {
-        if (leaf.lastAgentStatus === 'idle') {
-          if (waiter.pollInterval) {
-            clearInterval(waiter.pollInterval)
-            waiter.pollInterval = null
-          }
-          this.resolveWaiter(waiter, buildTerminalWaitResult(waiter.handle, 'tui-idle', leaf))
-          return
-        }
-        // Why: the renderer-synced title is the only path where OSC titles are visible for daemon-hosted terminals.
-        const pollTitle = leaf.paneTitle ?? this.tabs.get(leaf.tabId)?.title
-        if (pollTitle) {
-          const titleStatus = detectExplicitIdleStatusFromTitle(pollTitle)
-          if (titleStatus === 'idle') {
-            if (waiter.pollInterval) {
-              clearInterval(waiter.pollInterval)
-              waiter.pollInterval = null
-            }
-            this.resolveWaiter(waiter, buildTerminalWaitResult(waiter.handle, 'tui-idle', leaf))
-            return
-          }
-        }
         const leafWaitText = buildTerminalWaitText(
           leaf.tailBuffer,
           leaf.tailPartialLine,
@@ -34713,7 +34766,10 @@ export class OrcaRuntimeService {
           )
           return
         }
-        if (isKnownReadyPromptPreview(leafWaitText)) {
+        // Why: the renderer-synced title is the only path where OSC titles are
+        // visible for daemon-hosted terminals; it is ranked with the rest inside
+        // isLeafTuiIdleSatisfied.
+        if (this.isLeafTuiIdleSatisfied(leaf, leafWaitText)) {
           if (waiter.pollInterval) {
             clearInterval(waiter.pollInterval)
             waiter.pollInterval = null
@@ -34725,6 +34781,8 @@ export class OrcaRuntimeService {
         if (
           leaf.lastAgentStatus === null &&
           leaf.ptyId &&
+          this.quietForegroundProcessProvesTuiIdle(leaf.ptyId) &&
+          !this.hasFreshWorkingAgentStatusForPty(leaf.ptyId) &&
           this.ptyController &&
           !foregroundPollInFlight
         ) {
@@ -34760,14 +34818,6 @@ export class OrcaRuntimeService {
       }
       let startedForegroundPoll = false
       try {
-        if (pty.lastAgentStatus === 'idle') {
-          if (waiter.pollInterval) {
-            clearInterval(waiter.pollInterval)
-            waiter.pollInterval = null
-          }
-          this.resolveWaiter(waiter, buildPtyTerminalWaitResult(waiter.handle, 'tui-idle', pty))
-          return
-        }
         const ptyWaitText = buildTerminalWaitText(pty.tailBuffer, pty.tailPartialLine, pty.preview)
         const blockedReason = detectTerminalWaitBlockedReason(ptyWaitText)
         if (blockedReason) {
@@ -34782,10 +34832,7 @@ export class OrcaRuntimeService {
           return
         }
         // Why: adopted background PTY handles use their live xterm title as the same readiness signal as leaf handles.
-        if (
-          this.getAdoptedPtyExplicitIdleStatus(pty) === 'idle' ||
-          isKnownReadyPromptPreview(ptyWaitText)
-        ) {
+        if (this.isPtyTuiIdleSatisfied(pty, ptyWaitText)) {
           if (waiter.pollInterval) {
             clearInterval(waiter.pollInterval)
             waiter.pollInterval = null
@@ -34793,7 +34840,13 @@ export class OrcaRuntimeService {
           this.resolveWaiter(waiter, buildPtyTerminalWaitResult(waiter.handle, 'tui-idle', pty))
           return
         }
-        if (pty.lastAgentStatus === null && this.ptyController && !foregroundPollInFlight) {
+        if (
+          pty.lastAgentStatus === null &&
+          this.quietForegroundProcessProvesTuiIdle(pty.ptyId) &&
+          !this.hasFreshWorkingAgentStatusForPty(pty.ptyId) &&
+          this.ptyController &&
+          !foregroundPollInFlight
+        ) {
           foregroundPollInFlight = true
           startedForegroundPoll = true
           const fg = await this.ptyController.getForegroundProcess(pty.ptyId)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -34670,9 +34670,11 @@ export class OrcaRuntimeService {
     return this.leaves.get(this.getLeafKey(captured.tabId, captured.leafId)) ?? captured
   }
 
-  /** Same re-read for PTY records. These are mutated in place today, but a drop and
-   *  re-register under the same id (restore, reconnect, disconnected-record prune) mints a
-   *  new object, which would strand this poll the same way. */
+  /** Same re-read for PTY records, and a no-op today by construction: `ptysById` has one
+   *  `set` site guarded by `if (!pty)`, so records are create-once and mutated in place, and
+   *  the only path that mints a fresh object under the same id — `dropDisconnectedPtyRecord`
+   *  — rejects the handle's waiters on its way through. Kept so the two polls cannot drift:
+   *  a second `set` site would otherwise reintroduce the leaf hang here, silently. */
   private getLivePtyRecord(captured: RuntimePtyWorktreeRecord): RuntimePtyWorktreeRecord {
     return this.ptysById.get(captured.ptyId) ?? captured
   }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -34670,11 +34670,17 @@ export class OrcaRuntimeService {
     return this.leaves.get(this.getLeafKey(captured.tabId, captured.leafId)) ?? captured
   }
 
-  /** Same re-read for PTY records, and a no-op today by construction: `ptysById` has one
-   *  `set` site guarded by `if (!pty)`, so records are create-once and mutated in place, and
-   *  the only path that mints a fresh object under the same id — `dropDisconnectedPtyRecord`
-   *  — rejects the handle's waiters on its way through. Kept so the two polls cannot drift:
-   *  a second `set` site would otherwise reintroduce the leaf hang here, silently. */
+  /** Same re-read for PTY records, inert today — deliberately kept so the two polls cannot
+   *  drift apart. Two things make it inert, and this guard goes live the moment either
+   *  changes:
+   *    1. `ptysById` has one `set` site (`recordPtyWorktree`), guarded by `if (!pty)`, so
+   *       records are create-once and mutated in place rather than swapped. A second `set`
+   *       site would make PTY captures go stale exactly like leaf ones.
+   *    2. The only path that mints a fresh record under an existing id,
+   *       `dropDisconnectedPtyRecord`, calls `invalidatePtyIncarnationHandle` →
+   *       `rejectWaitersForHandle(handle, 'terminal_handle_stale')`. Every waiter on that
+   *       handle is rejected before any replacement record could be observed. Moving that
+   *       rejection off the drop path would let a waiter outlive its record. */
   private getLivePtyRecord(captured: RuntimePtyWorktreeRecord): RuntimePtyWorktreeRecord {
     return this.ptysById.get(captured.ptyId) ?? captured
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​541 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​541 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​162 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​77 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​85 |

<!-- /orca-pr-loc -->

## ELI5

Orca has a command that means "tell me when the agent is done": `orca terminal wait --for tui-idle`. Orchestration and automation use it to decide a worker finished so the next step can start.

Today it answers **"done!" instantly while the agent is still working.** The way it decided was, roughly, *"I don't currently see proof it's busy, so it must be finished."* That's the bug in one sentence — **a thinking agent and a finished agent look identical if all you're measuring is quiet.**

This PR changes the question from "is it quiet?" to "**who actually said it was done, and how good is that evidence?**" Orca already receives a real "I'm working / I'm done" report from the agents themselves — it just wasn't being read here. Now it is.

## What Changed

`waitForTerminal(..., 'tui-idle')` now ranks its evidence at every satisfaction site instead of accepting the first idle-looking sample:

1. **Positive** — an explicit idle OSC title, or a known ready-prompt body (the composer is literally on screen). Resolves immediately, exactly as before.
2. **First-party veto** — a *fresh* structured status from the agent's own stream saying `working` / `blocked` / `waiting`. This outranks anything Orca infers from titles or bytes.
3. **Absence** — a name-only agent title, or a quiet non-shell foreground process. Last resort only, and only once sustained.

Concretely:

- Added `RuntimePtyWorktreeRecord.lastExplicitAgentStatus`, stamped from the OSC 9999 payloads that `onPtyData` already parses. It lives on the PTY record rather than the existing paneKey-keyed snapshot map because a background CLI-created PTY may never have a paneKey, and the ptyId is the only identity the wait path is guaranteed to hold. Cleared on provider-generation reset so a dead process's turn can't veto its replacement.
- The eight scattered `lastAgentStatus === 'idle'` / title / preview checks collapse into two evaluators, `isPtyTuiIdleSatisfied` and `isLeafTuiIdleSatisfied`, used by the sync fast paths, the in-promise registration checks, both fallback polls, and both working→idle transition resolvers. Net −75 lines of duplicated branching.
- A title-derived `idle` now requires `TUI_IDLE_QUIESCENCE_MS` of quiet before it counts (the constant already existed but was only reachable from the foreground-process branch).
- The quiet-foreground fallback no longer fires when Orca launched a known agent on that PTY (`pty.launchAgent`).

Two incidental consistency fixes fell out: the leaf fallback poll now checks blocked-prompt state *before* idle evidence (every other site already did, so the poll could disagree with its own fast path), and the transition resolvers re-rank rather than resolving on the raw transition.

## Why

### The KEY QUESTION: is "sustained quiescence" the right fix?

**No — not as the primary fix.** Silence is not a signal. A TUI that is thinking emits nothing; a TUI that is idle also emits nothing. A longer window only buys the agent more time to be slow before we mislabel it; it converts a fast false positive into a slower false positive and taxes every honest wait to do it. The four open PRs are all variations on tuning that window or pattern-matching a specific agent's HUD chrome.

**The correct fix is (c): consume the structured agent-status signal that already exists.** The evidence is in this repo, not in theory:

- `src/shared/agent-status-types.ts:250` — the file's own header: *"status comes from hooks (Claude, Codex, etc.) — **never inferred from terminal titles**."* A canonical `working|blocked|waiting|done` enum is defined at `:16`.
- `src/shared/agent-status-osc.ts` — a stateful OSC 9999 parser that runs on **every PTY chunk**, at `orca-runtime.ts:9830`, before any title handling.
- `getTerminalAgentStatus()` (`orca-runtime.ts:17001`) **already** resolves that structured status via `getFreshExplicitAgentStatusForHandle()` and gives it authority over title heuristics.
- `waitForTerminal()` — the same class, the same handle — had **zero** references to it. It read only `lastAgentStatus`, which `applyTrackedPtyTitle()` (`:10589`) assigns from `detectAgentStatusFromTitle(rawTitle)` and nothing else.

So the two APIs were self-inconsistent by construction: `terminal agent-status` could report `working` from a hook at the same instant `terminal wait --for tui-idle` reported satisfied from a name-only title. That is the defect, and it's the same family as #14610 (re-armed staleness from a replayed signal) and #14626 (a gate that only spoke one provider's vocabulary): **lifecycle inferred from the wrong signal.**

Making both APIs read the same status under the same freshness rule is the fix. Reusing the existing `isFreshNonDoneAgentStatus` predicate rather than inventing a new window is deliberate — if a status is fresh enough for `terminal agent-status` to report `working`, it is fresh enough for `tui-idle` to refuse to claim idle.

### Why (a) survives as tier 3, and (b) is not needed

Quiescence is kept **only** for agents that publish no structured status at all, layered under a positive content signal (a recognized agent title) — a confirmation guard on a match, not "N ms of nothing ⇒ done." Screen-snapshot semantics (#14561) would improve tier 1's content inspection, but it is still inference over bytes; it doesn't change that tier 2 should outrank it. I did survey how comparable tools solve this before choosing; the ordering here matches the direction that work has converged on, including the specific rule that a live first-party lifecycle report suppresses screen-derived detection.

### Why the veto does not strand waits

A stuck `working` (agent misses its completion hook) cannot hang a wait indefinitely, because **tier 1 outranks the veto**: an explicit idle title or a visible ready prompt still resolves immediately. That carve-out is pinned by a test. Where no evidence at all exists, the wait times out — which is the honest answer, and the right failure mode: a timeout is loud, a false `satisfied: true` silently drops dispatched work (#9976).

### Superseded PRs

- **#6012** (revofusion) and **#6555** (nwparker) — a true duplicate pair, identical titles, both "require sustained quiescence." Superseded: this keeps their quiescence guard but demotes it to a last-resort tier under the authoritative signal they didn't consult. #6555's push-on-idle message-delivery change is intentionally **not** carried over — that is separate behavior and belongs in its own PR.
- **#9915** (OnlyYu1996) and **#9929** (innocarpe) — the second duplicate pair, matching Grok background-task HUD chrome (`Tasks 1`, `watching · 1 command`) with regexes. Superseded in approach: a per-agent screen-chrome regex is the tier-1 inference layer, and #9929's own body concedes it false-positives on any text containing those strings. If Grok publishes structured status during background tasks, tier 2 covers it with no patterns at all. **I am not claiming #9905 is fixed** — it is marked `cannot_repro` and I have no evidence about Grok's OSC 9999 behavior during background work. That needs a live measurement, not a regex.
- **#10020** (innocarpe) — the launchAgent cold-start guard. Its insight is correct and is carried over here, because it is the same principle (absence of a status is not a status), and the two fixes are not separable: fixing only the veto leaves cold start broken, and fixing only cold start leaves #6011 broken.

**Not bundled:** **#8113** (nwparker, perf — skipping full wait scans for ordinary PTY output). It is a pure hot-path optimization with its own benchmark and should land or not land on its own merits.

## Root cause, limits, and what this does not fix

### The actual root cause of #6011

`detectAgentStatusFromTitle` falls through to `'idle'` for **any** title carrying a known
agent name with no spinner and no working keyword (`src/shared/agent-title-status.ts:224` is
a bare `return 'idle'`). So a single frame of the plain task title classifies as idle — no
special glyph required. Claude Code's transient `✳` frame (`CLAUDE_IDLE` at
`agent-title-core.ts:14`) is one instance of this, not the whole of it.

Every satisfaction site that trusted the title therefore reported a finished turn from a
classifier fall-through. A pre-fix measurement resolved at t=7.1s **through the transition
resolver**, which only fires on a transition *to* idle — direct evidence that an
idle-classifying title genuinely arrives mid-turn.

That is why four previous PRs kept reaching for longer quiescence windows: they were treating
a classifier fall-through as a timing problem. No window fixes it, because the title is
wrong rather than early. Ranking removes the misread instead.

### Tier 2 only helps agents that publish OSC 9999

The claim "a longer window trades one failure for the other, ranking should not" holds for
Claude and Codex, which publish first-party status. For an agent that emits no OSC 9999 at
all, there is no veto to apply and the ranking collapses to exactly a plain quiescence
window at `TUI_IDLE_QUIESCENCE_MS` (3s) — the same mechanism the superseded PRs proposed,
just gated behind a positive title match. grok is in that group today. This change does not
make those agents more correct; it makes them no worse, and it makes the agents that do
publish status strictly correct.

### The grok HUD case works for an incidental reason

grok's background-task HUD animates `◎/○/◉` continuously, so `lastOutputAt` keeps moving and
quiet never reaches 3s — which is why tier 3 does not fire during background work. That is
luck, not design. If that HUD ever stops repainting for more than 3s while a task is still
running, tier 3 reports idle, which is the same fragility #9929 conceded, minus the regex.
A durable fix for grok needs structured status from grok itself, not a longer window here.

### The PTY poll does not share the defect

The leaf poll and the PTY poll close over the same kind of reference, so the fix was applied
to both. Forcing the real cycle then disproved the premise for the PTY side, and the negative
result is worth recording:

- `this.ptysById` has exactly one `set` site (`orca-runtime.ts:30068`), guarded by
  `if (!pty)`. Records are create-once and mutated in place — never swapped.
- The only path that mints a fresh object under an existing id is
  `dropDisconnectedPtyRecord` (`:30509`), and it calls `invalidatePtyIncarnationHandle`,
  which **rejects that handle's waiters** (`terminal_handle_stale`) on its way through.

So no PTY waiter can survive long enough to observe a replaced record. A test that appeared to
cover this passed its mutation check only because the fixture reached into `ptysById` and
manufactured a state production cannot reach; it has been removed rather than left as false
coverage.

**The general rule, because this is easy to get wrong:** "fails without the fix" is necessary
but not sufficient for a poll test. The state it pins also has to be one production can reach.
A fixture that reaches into internal state to manufacture an impossible condition passes its
mutation check and still proves nothing. Check reachability, not just redness.

`getLivePtyRecord` stays as an inert guard — one `Map.get` per 2s tick — so the two parallel
polls cannot drift apart: one that re-resolves beside one that does not is the shape a future
refactor trips over. Its comment names the two mechanisms that keep it inert (the single
`if (!pty)`-guarded `set` site, and `rejectWaitersForHandle` on the drop path) so whoever
changes either knows precisely what they have made live.

`this.leaves`, by contrast, is rebuilt wholesale by `syncWindowGraph`
(`nextLeaves.set(leafKey, {...leaf})` at `:5728`, swapped at `:5827`). That asymmetry is the
entire bug: the leaf capture dies within milliseconds, the PTY capture stays live.

### Timing budget

`TUI_IDLE_POLL_INTERVAL_MS` is 2s and `TUI_IDLE_QUIESCENCE_MS` is 3s, so the worst case from
readiness to resolution is one quiescence window plus one tick — about 5s, against the 60s
`orchestration.workerStart` allows. Tier 1 and tier 2 evidence resolve on the next tick
without waiting out the window at all.

### Severity: did this break orchestration dispatch?

Yes, for a specific and common shape. `startWorker`
(`src/main/runtime/rpc/methods/orchestration-workers.ts:197`) gates `agent_readiness` on
`waitForTerminal(..., 'tui-idle')` against a **freshly launched** agent, so the
pre-registration fast path can never be satisfied — it always registers a waiter and falls
through to the fallback poll. On a desktop app with a renderer attached, that handle is
leaf-backed, and every renderer publish replaced the record the poll had closed over
(creating the worker pane is itself such a publish).

Whether a given wait survived depended on how its agent announces readiness:

- **Rescued** — agents whose readiness arrives as an explicit idle OSC title. The transition
  resolver re-reads the leaf live, so it resolved them despite the dead poll record.
- **Stranded** — agents whose readiness is only visible in the terminal **body**. Codex is
  the clear case: `findCodexReadyPromptIndex` matches its banner, and `Codex YOLO` is
  explicitly *not* treated as a readiness title. No title transition fires, so the poll was
  the only path, and it was checking a frozen snapshot. Those dispatches failed
  `agent_readiness` with `Agent did not become ready (timeout)`.

That shape is pinned by a test (`resolves a leaf tui-idle waiter from a ready prompt that
lands after a resync`), which hangs for its full timeout with the live-record read reverted.

Headless (`orca serve`, no renderer) was unaffected: with no graph publishes the handle
stays PTY-backed and those records are mutated in place.

## Linked Issue

Fixes #6011

Related: #9976, #9905 / STA-2331, #14561

## Visual Proof

`N/A` — this is a main-process CLI/RPC behavior change in `waitForTerminal`; it renders nothing and touches no renderer code, so there is no before/after surface to capture.

## Testing

Nine tests in `src/main/runtime/orca-runtime.test.ts` — the original five, plus four added
after a mutation matrix showed **four of the eight production hunks were undetectable** by
the suite as it stood, including both transition-resolver re-rankings.

**Every test below was mutation-checked**: its own hunk was reverted in isolation and the
test was re-run. All of them fail without their hunk.

| Hunk | Test | With hunk reverted |
| --- | --- | --- |
| live leaf record in the fallback poll | polls the live leaf record after a graph resync replaces it | hangs to timeout |
| live leaf record (worker-readiness shape) | resolves a leaf tui-idle waiter from a ready prompt that lands after a resync | hangs to timeout |
| `resolveTuiIdleWaiters` re-ranking | does not resolve a leaf tui-idle waiter on a title transition the stream vetoes | `expected true to be false` |
| `resolvePtyTuiIdleWaiters` re-ranking | does not resolve a pty tui-idle waiter on a title transition the stream vetoes | `expected true to be false` |
| veto guard on quiet-foreground | does not report tui-idle from quiet foreground while the stream reports working | `expected true to be false` |
| clear retained status on generation reset | drops the retained working veto when the provider generation resets | hangs to timeout |
| veto (original) | does not report tui-idle while the agent status stream still reports working | fails |
| sustained quiescence (original) | does not report tui-idle while a name-only agent title keeps streaming output | fails |
| launchAgent cold-start guard (original) | does not report tui-idle from quiet foreground alone for a launched agent | fails |

Two originals are regression guards that pass both ways by design, and are labelled as such:
`resolves tui-idle from a ready prompt even while a working status is retained` (tier 1
outranks the veto) and `still reports tui-idle from quiet foreground for an unlaunched
non-shell TUI`.

**Checking this branch out locally:** the rebase brings in `@xterm/addon-serialize`, which is
in `package.json` but was not present in an older worktree's `node_modules`. Run
`pnpm install --frozen-lockfile` first or the runtime suite fails to collect with
`Cannot find package '@xterm/addon-serialize'`. CI installs fresh, so it only bites humans.

Rebased onto `origin/main` (142 commits) and re-run on the materialized tree, not merged
speculatively — `orca-runtime.ts` had drifted enough that a clean `merge-tree` was not
sufficient evidence on its own.

- `vitest run src/main/runtime/orca-runtime.test.ts` → **1174 passed**, 1 skipped
- `tsc --noEmit -p config/tsconfig.node.json --composite false` → clean
- `oxlint` + `oxfmt --check` on both changed files → clean
- `check-changed-code-quality.mjs` → 0 new findings (native, type-aware, React Doctor)

Platforms: macOS.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

**Honest gap:** I did not re-run the live agent repro. The original hang was reproduced live
4/5 times on fresh panes before this fix, and the mechanism is now reproduced deterministically
at the unit level against the real `OrcaRuntimeService` — real `syncWindowGraph` publishes,
real `onPtyData` byte sequences — with every assertion mutation-checked. A live confirmation
run would still be worth doing before merge.

## AI Disclosure

<!-- DO NOT FILL IN IF YOU ARE STABLYAI TEAM MEMBER (INTERNAL CONTRIBUTOR), IGNORE SECTION: -->

## Review

- **Security** — no new IPC surface, command execution, path handling, or network access. Only already-parsed in-band status and existing PTY records are read.
- **Cross-platform** — no platform branches, paths, shell commands, or accelerators touched. `isShellProcess` / `getForegroundProcess` behavior is unchanged; only whether its result is *trusted* changed.
- **Remote SSH** — no wire change. `lastExplicitAgentStatus` is main-process-local state derived from bytes the host already parses; nothing new crosses the RPC boundary, no new stream opcode, no new RPC param. Per `docs/reference/remote-wire-compatibility.md` this is not a mixed-version concern.
- **Mobile** — untouched. The retained paneKey-keyed snapshots that feed mobile `worktree.ps` are written exactly as before; the new field is additive and read only by the wait path.
- **Backwards compatibility** — `tui-idle` gets *stricter*, so a wait that used to lie now either resolves later or times out. Callers already pass `--timeout-ms`. The three paths that resolved immediately before (explicit idle title, ready prompt, adopted/daemon handles with no PTY stream of their own) still resolve immediately.
- **Performance** — the veto is a `Map.get` plus two comparisons. `buildTerminalWaitText` in the two transition resolvers runs only when that handle actually has waiters (guarded by an existing early return) and only on a transition *to* idle, so it is off the per-chunk hot path.

## What this PR's own mistakes taught

Two checks written for this PR could not have observed what they claimed to. A
`vitest -t "tui-idle"` filter silently skipped the two tests whose names lacked that
substring and reported them green. A latency rig stopped sampling the moment the wait
resolved, so a mid-turn resolve was invisible to it by construction. Both produced
confident, right-looking, wrong answers — more dangerous than an obviously wrong one.
A third test pinned a state production cannot reach: `dropDisconnectedPtyRecord`
rejects a handle's waiters on the way through, so no PTY waiter survives to observe a
replaced record, and the test was removed rather than kept as false assurance.

Two rules came out of that, and they are more durable than this fix:

> a test must pin a state production can actually reach; and a measurement must be able
> to observe its own failure case.

## Root cause, measured rather than assumed

Driving a real `claude` through a pty and timestamping every OSC title frame shows the
classifier fall-through is not a rare transient. In one 4.8s turn, `✳ Claude Code` — an
idle-*classifying* title — was emitted ten times, interleaved with spinner frames at
roughly 100ms cadence, the first **30ms after submit**. `CLAUDE_IDLE = '✳'`
(`agent-title-core.ts:14`) makes `detectAgentStatusFromTitle` return `idle` for those,
and separately the function *falls through* to `'idle'` for any title carrying a known
agent name with no spinner (`agent-title-status.ts:199-224`) — so the glyph is not even
required. That is why four previous PRs reached for longer timers: they were treating a
classifier fall-through as a timing problem.

Scope honestly stated: this clustering at turn *opening* is well-supported for ~5s turns
and **not established for long ones**. A 1s-sampled trace of a longer turn showed an
idle-classifying title about 4.5s before output ceased, which is evidence against
generalising it.

## A known gap this PR does not close

Tier 2 reads `lastExplicitAgentStatus`, which is written only from the OSC 9999 stream.
None of the bundled hooks in `~/.orca/agent-hooks/` emit OSC 9999 — all twelve POST to
the hook server keyed by `ORCA_PANE_KEY` — so for Claude and Codex the veto is inert and
the ranking runs on tiers 1 and 3 alone. Pointing the veto at the paneKey-keyed map was
built and measured: the veto then fires (18/22 samples, up from none), but it makes
observable behaviour *worse*, because tier 1 outranks the veto by design and its title
branch has no quiescence gate, so resolution simply moves to tier 1 and fires mid-turn.
That change is deliberately **not** included here — it is a real fix to a real defect
that should not ship alone, recorded so it is not rediscovered as new.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
      Scoped equivalents run locally and listed above; full `typecheck` / `build` left to CI by instruction (OOM risk).

## Author

- X / Twitter: @BrennanKB5




