### PR TITLE
fix(agent-map): reveal agents through worktree-activation so slept agents wake

### DIFF
--- a/src/main/ipc/dashboard-payload-validation.test.ts
+++ b/src/main/ipc/dashboard-payload-validation.test.ts
@@ -534,7 +534,8 @@ describe('dashboard payload validation', () => {
         worktreeId: 'worktree-1',
         executionHostId: 'runtime:env-1',
         tabId: 'tab-1',
-        leafId: null
+        leafId: null,
+        paneKey: 'tab-1:leaf-1'
       })
     ).toBe(true)
     expect(
@@ -548,6 +549,15 @@ describe('dashboard payload validation', () => {
     ).toBe(false)
     expect(
       isDashboardRevealAgentArgs({ repoId: 'repo-1', worktreeId: 'worktree-1', tabId: '' })
+    ).toBe(false)
+    expect(
+      isDashboardRevealAgentArgs({
+        repoId: 'repo-1',
+        worktreeId: 'worktree-1',
+        tabId: 'tab-1',
+        leafId: null,
+        paneKey: ''
+      })
     ).toBe(false)
   })
 })

--- a/src/main/ipc/dashboard-payload-validation.ts
+++ b/src/main/ipc/dashboard-payload-validation.ts
@@ -78,7 +78,8 @@ export function isDashboardRevealAgentArgs(value: unknown): value is DashboardRe
       (isBoundedString(args.executionHostId, MAX_ID_LENGTH) &&
         normalizeExecutionHostId(args.executionHostId) !== null)) &&
     isBoundedString(args.tabId, MAX_ID_LENGTH) &&
-    (args.leafId === null || isBoundedString(args.leafId, MAX_ID_LENGTH))
+    (args.leafId === null || isBoundedString(args.leafId, MAX_ID_LENGTH)) &&
+    (args.paneKey === undefined || isBoundedString(args.paneKey, MAX_ID_LENGTH))
   )
 }
 

--- a/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.test.tsx
@@ -134,7 +134,8 @@ describe('AgentTerminalDialog', () => {
       worktreeId: 'w1',
       executionHostId: 'runtime:env-1',
       tabId: 'tab1',
-      leafId: 'leaf1'
+      leafId: 'leaf1',
+      paneKey: 'tab1:leaf1'
     })
   })
 

--- a/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.tsx
@@ -45,7 +45,8 @@ function AgentTerminalFrame({
       worktreeId: card.worktreeId,
       executionHostId: card.executionHostId,
       tabId: card.tabId,
-      leafId: card.leafId
+      leafId: card.leafId,
+      paneKey: card.paneKey
     })
     onOpenChange(false)
   }

--- a/src/renderer/src/components/dashboard/AgentDashboardDrawer.test.tsx
+++ b/src/renderer/src/components/dashboard/AgentDashboardDrawer.test.tsx
@@ -8,11 +8,16 @@ const mocks = vi.hoisted(() => ({
   useLiveDashboardSnapshot: vi.fn(() => ({ generatedAt: 1, cards: [] })),
   blockingOverlay: false,
   boardProps: null as Record<string, unknown> | null,
-  activateTabAndFocusPane: vi.fn()
+  activateTabAndFocusPane: vi.fn(),
+  activateAndRevealWorkspace: vi.fn(() => ({ primaryTabId: 'tab-1' }))
 }))
 
 vi.mock('@/lib/activate-tab-and-focus-pane', () => ({
   activateTabAndFocusPane: mocks.activateTabAndFocusPane
+}))
+
+vi.mock('@/lib/worktree-activation', () => ({
+  activateAndRevealWorkspace: mocks.activateAndRevealWorkspace
 }))
 
 vi.mock('./useLiveDashboardSnapshot', () => ({
@@ -104,10 +109,17 @@ describe('AgentDashboardDrawer', () => {
     expect(useAppStore.getState().agentDashboardDrawerOpen).toBe(false)
   })
 
-  it('reveals a colliding worktree on the card execution host', () => {
+  // Why: a raw setActiveWorktree skips resumeSleepingAgentSessionsForWorktree, so
+  // revealing a slept agent from the board landed on a dead pane.
+  it('reveals a colliding worktree through workspace activation on the card execution host', () => {
     const setActiveWorktree = vi.spyOn(useAppStore.getState(), 'setActiveWorktree')
     render(<AgentDashboardDrawer statusBarVisible />)
-    act(() => useAppStore.setState({ agentDashboardDrawerOpen: true }))
+    act(() =>
+      useAppStore.setState({
+        agentDashboardDrawerOpen: true,
+        tabsByWorktree: { 'shared-worktree': [{ id: 'tab-1' }] } as never
+      })
+    )
     const onRevealAgent = mocks.boardProps?.onRevealAgent
     expect(onRevealAgent).toBeTypeOf('function')
 
@@ -129,7 +141,10 @@ describe('AgentDashboardDrawer', () => {
       })
     })
 
-    expect(setActiveWorktree).toHaveBeenCalledWith('shared-worktree', 'runtime:env-1')
+    expect(mocks.activateAndRevealWorkspace).toHaveBeenCalledWith('shared-worktree', {
+      executionHostId: 'runtime:env-1'
+    })
+    expect(setActiveWorktree).not.toHaveBeenCalled()
     expect(mocks.activateTabAndFocusPane).toHaveBeenCalledWith('tab-1', 'leaf-1', {
       flashFocusedPane: true
     })

--- a/src/renderer/src/components/dashboard/AgentDashboardDrawer.tsx
+++ b/src/renderer/src/components/dashboard/AgentDashboardDrawer.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useAppStore } from '@/store'
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
-import { activateTabAndFocusPane } from '@/lib/activate-tab-and-focus-pane'
+import { revealAgentPane } from '@/lib/reveal-agent-pane'
 import { AgentKanbanBoard } from '../dashboard-popout/AgentKanbanBoard'
 import type { AgentRevealArgs } from '../dashboard-popout/AgentTerminalDialog'
 import {
@@ -48,8 +48,7 @@ function AgentDashboardDrawerBody({
   }, [])
   const handleRevealAgent = useCallback(
     (args: AgentRevealArgs) => {
-      useAppStore.getState().setActiveWorktree(args.worktreeId, args.executionHostId)
-      activateTabAndFocusPane(args.tabId, args.leafId, { flashFocusedPane: true })
+      revealAgentPane(args, { flashFocusedPane: true })
       onClose()
     },
     [onClose]

--- a/src/renderer/src/components/dashboard/useDashboardPopoutBridge.test.tsx
+++ b/src/renderer/src/components/dashboard/useDashboardPopoutBridge.test.tsx
@@ -7,6 +7,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
   acknowledgeAgents: vi.fn(),
   setActiveWorktree: vi.fn(),
+  activateAndRevealWorkspace: vi.fn(() => ({ primaryTabId: 'tab-1' })),
+  activateTabAndFocusPane: vi.fn(),
+  tabsByWorktree: { 'shared-worktree': [{ id: 'tab-1' }] } as Record<string, { id: string }[]>,
   subscribeStore: vi.fn((_listener: (state: unknown, previousState: unknown) => void) => vi.fn()),
   onRevealAgent: vi.fn(),
   onAckAgent: vi.fn(),
@@ -27,14 +30,19 @@ vi.mock('@/store', () => ({
   useAppStore: {
     getState: () => ({
       acknowledgeAgents: mocks.acknowledgeAgents,
-      setActiveWorktree: mocks.setActiveWorktree
+      setActiveWorktree: mocks.setActiveWorktree,
+      tabsByWorktree: mocks.tabsByWorktree
     }),
     subscribe: mocks.subscribeStore
   }
 }))
 
 vi.mock('@/lib/activate-tab-and-focus-pane', () => ({
-  activateTabAndFocusPane: vi.fn()
+  activateTabAndFocusPane: mocks.activateTabAndFocusPane
+}))
+
+vi.mock('@/lib/worktree-activation', () => ({
+  activateAndRevealWorkspace: mocks.activateAndRevealWorkspace
 }))
 
 vi.mock('./build-dashboard-snapshot', () => ({
@@ -157,7 +165,9 @@ describe('useDashboardPopoutBridge', () => {
     expect(mocks.buildDashboardSnapshot).toHaveBeenCalledTimes(1)
   })
 
-  it('reveals the agent on its exact execution host', async () => {
+  // Why: a raw setActiveWorktree skips resumeSleepingAgentSessionsForWorktree, so
+  // revealing a slept agent from the pop-out board/map landed on a dead pane.
+  it('reveals the agent through workspace activation on its exact execution host', async () => {
     await act(async () => root.render(<Harness enabled />))
 
     await act(async () =>
@@ -170,7 +180,13 @@ describe('useDashboardPopoutBridge', () => {
       })
     )
 
-    expect(mocks.setActiveWorktree).toHaveBeenCalledWith('shared-worktree', 'runtime:env-1')
+    expect(mocks.activateAndRevealWorkspace).toHaveBeenCalledWith('shared-worktree', {
+      executionHostId: 'runtime:env-1'
+    })
+    expect(mocks.setActiveWorktree).not.toHaveBeenCalled()
+    expect(mocks.activateTabAndFocusPane).toHaveBeenCalledWith('tab-1', 'leaf-1', {
+      flashFocusedPane: true
+    })
   })
 
   it('ignores unrelated store writes while retaining every snapshot input', () => {

--- a/src/renderer/src/components/dashboard/useDashboardPopoutBridge.ts
+++ b/src/renderer/src/components/dashboard/useDashboardPopoutBridge.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import { useAppStore, type AppState } from '@/store'
-import { activateTabAndFocusPane } from '@/lib/activate-tab-and-focus-pane'
+import { revealAgentPane } from '@/lib/reveal-agent-pane'
 import { runSleepWorktree } from '../sidebar/sleep-worktree-flow'
 import type { RepoIcon } from '../../../../shared/repo-icon'
 import { buildDashboardSnapshot, type DashboardSnapshotState } from './build-dashboard-snapshot'
@@ -131,8 +131,7 @@ export function useDashboardPopoutBridge(enabled: boolean): void {
       return
     }
     return window.api.dashboard.onRevealAgent((args) => {
-      useAppStore.getState().setActiveWorktree(args.worktreeId, args.executionHostId)
-      activateTabAndFocusPane(args.tabId, args.leafId, { flashFocusedPane: true })
+      revealAgentPane(args, { flashFocusedPane: true })
     })
   }, [enabled])
 

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.activation.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.activation.test.tsx
@@ -92,7 +92,7 @@ function buildMockStoreState(): Record<string, unknown> {
 }
 
 const activationMocks = vi.hoisted(() => ({
-  activateAndRevealWorktree: vi.fn(),
+  activateAndRevealWorkspace: vi.fn(),
   activateTabAndFocusPane: vi.fn()
 }))
 
@@ -110,7 +110,7 @@ vi.mock('@/store', () => ({
 }))
 
 vi.mock('@/lib/worktree-activation', () => ({
-  activateAndRevealWorktree: activationMocks.activateAndRevealWorktree
+  activateAndRevealWorkspace: activationMocks.activateAndRevealWorkspace
 }))
 
 vi.mock('@/lib/activate-tab-and-focus-pane', () => ({
@@ -149,7 +149,11 @@ vi.mock('./focused-agent-row-highlight', () => ({
 describe('WorktreeCardAgents activation', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    activationMocks.activateAndRevealWorktree.mockImplementation(() => undefined)
+    // Why: revealAgentPane skips pane focus when activation refuses, so the
+    // default must be the truthy success shape the real dispatcher returns.
+    activationMocks.activateAndRevealWorkspace.mockImplementation(() => ({
+      primaryTabId: 'tab-1'
+    }))
     activationMocks.activateTabAndFocusPane.mockImplementation(() => undefined)
     mockAgents = []
     mockAgentActivityDisplayMode = undefined
@@ -176,8 +180,9 @@ describe('WorktreeCardAgents activation', () => {
     mockAgentStatusByPaneKey = { [paneKey]: { worktreeId: 'wt-1' } }
     // Why: activation must use the post-reveal store snapshot, matching tab
     // hydration that arrives while a background worker is being opened.
-    activationMocks.activateAndRevealWorktree.mockImplementation(() => {
+    activationMocks.activateAndRevealWorkspace.mockImplementation(() => {
       mockTabsByWorktree = { 'wt-1': [{ id: tabId }] }
+      return { primaryTabId: tabId }
     })
     const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
 
@@ -185,7 +190,7 @@ describe('WorktreeCardAgents activation', () => {
     expect(capturedRowActivations).toHaveLength(1)
     capturedRowActivations[0].onActivate(tabId, paneKey)
 
-    expect(activationMocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-1')
+    expect(activationMocks.activateAndRevealWorkspace).toHaveBeenCalledWith('wt-1', {})
     expect(activationMocks.activateTabAndFocusPane).toHaveBeenCalledWith(tabId, LEAF_A, {
       ackPaneKeyOnSuccess: paneKey,
       flashFocusedPane: true,
@@ -224,7 +229,7 @@ describe('WorktreeCardAgents activation', () => {
     expect(capturedRowActivations).toHaveLength(1)
     capturedRowActivations[0].onActivate(tabId, paneKey)
 
-    expect(activationMocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-1')
+    expect(activationMocks.activateAndRevealWorkspace).toHaveBeenCalledWith('wt-1', {})
     expect(activationMocks.activateTabAndFocusPane).toHaveBeenCalledWith(tabId, LEAF_A, {
       ackPaneKeyOnSuccess: paneKey,
       flashFocusedPane: true,
@@ -254,7 +259,7 @@ describe('WorktreeCardAgents activation', () => {
     expect(capturedRowActivations).toHaveLength(1)
     capturedRowActivations[0].onActivate(tabId, paneKey)
 
-    expect(activationMocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-1')
+    expect(activationMocks.activateAndRevealWorkspace).toHaveBeenCalledWith('wt-1', {})
     expect(activationMocks.activateTabAndFocusPane).not.toHaveBeenCalled()
     expect(staleAgentRowMocks.dismissStaleAgentRowByKey).not.toHaveBeenCalled()
   })
@@ -276,9 +281,10 @@ describe('WorktreeCardAgents activation', () => {
     mockAgentStatusByPaneKey = { [paneKey]: { worktreeId: 'wt-1' } }
     // Why: activation may create/select a different terminal before the
     // automation worker hydrates; the row must only pane-focus its exact tab.
-    activationMocks.activateAndRevealWorktree.mockImplementation(() => {
+    activationMocks.activateAndRevealWorkspace.mockImplementation(() => {
       mockTabsByWorktree = { 'wt-1': [{ id: fallbackTabId }] }
       mockSetActiveTab(fallbackTabId)
+      return { primaryTabId: fallbackTabId }
     })
     const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
 
@@ -286,7 +292,7 @@ describe('WorktreeCardAgents activation', () => {
     expect(capturedRowActivations).toHaveLength(1)
     capturedRowActivations[0].onActivate(tabId, paneKey)
 
-    expect(activationMocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-1')
+    expect(activationMocks.activateAndRevealWorkspace).toHaveBeenCalledWith('wt-1', {})
     expect(mockActiveTabId).toBe(fallbackTabId)
     expect(activationMocks.activateTabAndFocusPane).not.toHaveBeenCalled()
     expect(staleAgentRowMocks.dismissStaleAgentRowByKey).not.toHaveBeenCalled()
@@ -312,7 +318,7 @@ describe('WorktreeCardAgents activation', () => {
       expect(capturedRowActivations).toHaveLength(1)
       capturedRowActivations[0].onActivate('worker-tab', paneKey)
 
-      expect(activationMocks.activateAndRevealWorktree).not.toHaveBeenCalled()
+      expect(activationMocks.activateAndRevealWorkspace).not.toHaveBeenCalled()
       expect(activationMocks.activateTabAndFocusPane).not.toHaveBeenCalled()
       expect(staleAgentRowMocks.dismissStaleAgentRowByKey).toHaveBeenCalledWith(paneKey)
     } finally {
@@ -339,7 +345,7 @@ describe('WorktreeCardAgents activation', () => {
     expect(capturedRowActivations).toHaveLength(1)
     capturedRowActivations[0].onActivate('worker-tab', paneKey)
 
-    expect(activationMocks.activateAndRevealWorktree).not.toHaveBeenCalled()
+    expect(activationMocks.activateAndRevealWorkspace).not.toHaveBeenCalled()
     expect(activationMocks.activateTabAndFocusPane).not.toHaveBeenCalled()
     expect(staleAgentRowMocks.dismissStaleAgentRowByKey).toHaveBeenCalledWith(paneKey)
     warnSpy.mockRestore()
@@ -365,7 +371,7 @@ describe('WorktreeCardAgents activation', () => {
     expect(capturedRowActivations).toHaveLength(1)
     capturedRowActivations[0].onActivate(tabId, paneKey)
 
-    expect(activationMocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-1')
+    expect(activationMocks.activateAndRevealWorkspace).toHaveBeenCalledWith('wt-1', {})
     expect(activationMocks.activateTabAndFocusPane).not.toHaveBeenCalled()
     expect(staleAgentRowMocks.dismissStaleAgentRowByKey).toHaveBeenCalledWith(paneKey)
   })
@@ -386,8 +392,9 @@ describe('WorktreeCardAgents activation', () => {
     mockAgentStatusByPaneKey = { [paneKey]: { worktreeId: 'wt-1' } }
     // Why: compact rows share the same activation contract as full rows, so
     // this keeps the test pinned to reveal-time tab hydration.
-    activationMocks.activateAndRevealWorktree.mockImplementation(() => {
+    activationMocks.activateAndRevealWorkspace.mockImplementation(() => {
       mockTabsByWorktree = { 'wt-1': [{ id: tabId }] }
+      return { primaryTabId: tabId }
     })
     const host = document.createElement('div')
     document.body.append(host)
@@ -404,7 +411,7 @@ describe('WorktreeCardAgents activation', () => {
       row?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
 
-    expect(activationMocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-1')
+    expect(activationMocks.activateAndRevealWorkspace).toHaveBeenCalledWith('wt-1', {})
     expect(activationMocks.activateTabAndFocusPane).toHaveBeenCalledWith(tabId, LEAF_A, {
       ackPaneKeyOnSuccess: paneKey,
       flashFocusedPane: true,

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
@@ -1,8 +1,7 @@
 import React, { useCallback, useLayoutEffect, useMemo, useRef } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '@/store'
-import { activateAndRevealWorktree } from '@/lib/worktree-activation'
-import { activateTabAndFocusPane } from '@/lib/activate-tab-and-focus-pane'
+import { revealAgentPane } from '@/lib/reveal-agent-pane'
 import DashboardAgentRow from '@/components/dashboard/DashboardAgentRow'
 import { useNow } from '@/components/dashboard/useNow'
 import { deriveRunningAgentSendTargets } from '@/lib/running-agent-targets'
@@ -164,23 +163,24 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
         dismissStaleAgentRowByKey(paneKey)
         return
       }
-      // Why: design-doc rule — every user-initiated worktree switch must route through activateAndRevealWorktree (cross-repo activation + nav history).
-      activateAndRevealWorktree(worktreeId)
-      const tabs = useAppStore.getState().tabsByWorktree[worktreeId] ?? []
-      if (tabs.some((t) => t.id === tabId)) {
-        activateTabAndFocusPane(tabId, parsed.leafId, {
+      // Why: design-doc rule — every user-initiated worktree switch must route through
+      // worktree-activation (cross-repo activation + nav history + slept-agent wake).
+      revealAgentPane(
+        { worktreeId, tabId, leafId: parsed.leafId },
+        {
           ackPaneKeyOnSuccess: paneKey,
           flashFocusedPane: true,
-          scrollToBottomIfOutputSinceLastView: true
-        })
-      } else {
-        const liveEntry = useAppStore.getState().agentStatusByPaneKey[paneKey]
-        if (liveEntry?.worktreeId === worktreeId) {
-          // Why: orchestration worker status can be worktree-attributed before the renderer knows its tab; keep the live row instead of dismissing as stale.
-          return
+          scrollToBottomIfOutputSinceLastView: true,
+          onTargetUnavailable: () => {
+            const liveEntry = useAppStore.getState().agentStatusByPaneKey[paneKey]
+            if (liveEntry?.worktreeId === worktreeId) {
+              // Why: orchestration worker status can be worktree-attributed before the renderer knows its tab; keep the live row instead of dismissing as stale.
+              return
+            }
+            dismissStaleAgentRowByKey(paneKey)
+          }
         }
-        dismissStaleAgentRowByKey(paneKey)
-      }
+      )
     },
     [worktreeId]
   )

--- a/src/renderer/src/lib/resume-sleeping-agent-session-host-scope.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session-host-scope.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-resume'
+import { folderWorkspaceKey } from '../../../shared/workspace-scope'
+import { useAppStore } from '@/store'
+import { resumeSleepingAgentSessionsForWorktree } from './resume-sleeping-agent-session'
+
+const initialState = useAppStore.getState()
+
+afterEach(() => {
+  useAppStore.setState(initialState, true)
+})
+
+function makeRecord(
+  paneKey: string,
+  worktreeId: string,
+  overrides: Partial<SleepingAgentSessionRecord> = {}
+): SleepingAgentSessionRecord {
+  return {
+    paneKey,
+    tabId: paneKey,
+    worktreeId,
+    agent: 'claude',
+    providerSession: { key: 'session_id', id: `session-${paneKey}` },
+    prompt: 'continue',
+    state: 'working',
+    capturedAt: 1,
+    updatedAt: 1,
+    origin: 'quit',
+    ...overrides
+  }
+}
+
+describe('sleeping agent execution host scope', () => {
+  it('launches and clears only the selected host when workspace ids collide', () => {
+    const local = makeRecord('local-pane', 'same-worktree', { executionHostId: 'local' })
+    const ssh = makeRecord('ssh-pane', 'same-worktree', {
+      connectionId: 'ssh-1',
+      executionHostId: 'ssh:ssh-1'
+    })
+    const runtime = makeRecord('runtime-pane', 'same-worktree', {
+      executionHostId: 'runtime:env-1',
+      state: 'done'
+    })
+    useAppStore.setState({
+      tabsByWorktree: { 'same-worktree': [] },
+      sleepingAgentSessionsByPaneKey: {
+        [local.paneKey]: local,
+        [ssh.paneKey]: ssh,
+        [runtime.paneKey]: runtime
+      }
+    } as never)
+
+    expect(
+      resumeSleepingAgentSessionsForWorktree('same-worktree', { executionHostId: 'local' })
+    ).toBe(1)
+
+    const state = useAppStore.getState()
+    expect(state.sleepingAgentSessionsByPaneKey[local.paneKey]).toBeUndefined()
+    expect(state.sleepingAgentSessionsByPaneKey[ssh.paneKey]).toBe(ssh)
+    expect(state.sleepingAgentSessionsByPaneKey[runtime.paneKey]).toBe(runtime)
+  })
+
+  it('keeps same-key folder records from another host untouched', () => {
+    const workspaceId = folderWorkspaceKey('same-folder')
+    const local = makeRecord('local-folder-pane', workspaceId, { executionHostId: 'local' })
+    const runtime = makeRecord('runtime-folder-pane', workspaceId, {
+      executionHostId: 'runtime:env-1'
+    })
+    useAppStore.setState({
+      tabsByWorktree: { [workspaceId]: [] },
+      sleepingAgentSessionsByPaneKey: {
+        [local.paneKey]: local,
+        [runtime.paneKey]: runtime
+      }
+    } as never)
+
+    expect(resumeSleepingAgentSessionsForWorktree(workspaceId, { executionHostId: 'local' })).toBe(
+      1
+    )
+    expect(useAppStore.getState().sleepingAgentSessionsByPaneKey[runtime.paneKey]).toBe(runtime)
+  })
+
+  it('matches legacy SSH provenance but preserves ambiguous legacy records', () => {
+    const ssh = makeRecord('ssh-pane', 'same-worktree', { connectionId: 'ssh target' })
+    const ambiguous = makeRecord('legacy-pane', 'same-worktree')
+    useAppStore.setState({
+      tabsByWorktree: { 'same-worktree': [] },
+      sleepingAgentSessionsByPaneKey: {
+        [ssh.paneKey]: ssh,
+        [ambiguous.paneKey]: ambiguous
+      }
+    } as never)
+
+    expect(
+      resumeSleepingAgentSessionsForWorktree('same-worktree', {
+        executionHostId: 'ssh:ssh%20target'
+      })
+    ).toBe(1)
+    expect(useAppStore.getState().sleepingAgentSessionsByPaneKey[ambiguous.paneKey]).toBe(ambiguous)
+  })
+
+  it('ignores foreign-host legacy claims when checking preserved pane ownership', () => {
+    const local = makeRecord('tab-1:0', 'same-worktree', {
+      tabId: 'tab-1',
+      executionHostId: 'local'
+    })
+    const runtime = makeRecord('tab-1:1', 'same-worktree', {
+      tabId: 'tab-1',
+      executionHostId: 'runtime:env-1'
+    })
+    useAppStore.setState({
+      activeWorktreeId: 'same-worktree',
+      tabsByWorktree: {
+        'same-worktree': [
+          {
+            id: 'tab-1',
+            ptyId: 'wake-hint',
+            worktreeId: 'same-worktree',
+            title: 'shell',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1
+          }
+        ]
+      },
+      sleepingAgentSessionsByPaneKey: {
+        [local.paneKey]: local,
+        [runtime.paneKey]: runtime
+      }
+    } as never)
+
+    expect(
+      resumeSleepingAgentSessionsForWorktree('same-worktree', { executionHostId: 'local' })
+    ).toBe(0)
+    expect(useAppStore.getState().sleepingAgentSessionsByPaneKey[local.paneKey]).toBe(local)
+    expect(useAppStore.getState().sleepingAgentSessionsByPaneKey[runtime.paneKey]).toBe(runtime)
+  })
+
+  it('includes passive same-host records in legacy pane ownership ambiguity', () => {
+    const active = makeRecord('tab-1:0', 'same-worktree', {
+      tabId: 'tab-1',
+      executionHostId: 'local'
+    })
+    const passive = makeRecord('tab-1:1', 'same-worktree', {
+      tabId: 'tab-1',
+      executionHostId: 'local',
+      state: 'done',
+      origin: 'worktree-sleep',
+      providerSession: { key: 'session_id', id: 'passive-session' }
+    })
+    useAppStore.setState({
+      activeWorktreeId: 'same-worktree',
+      tabsByWorktree: {
+        'same-worktree': [
+          {
+            id: 'tab-1',
+            ptyId: 'wake-hint',
+            worktreeId: 'same-worktree',
+            title: 'shell',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1
+          }
+        ]
+      },
+      sleepingAgentSessionsByPaneKey: {
+        [active.paneKey]: active,
+        [passive.paneKey]: passive
+      }
+    } as never)
+
+    expect(
+      resumeSleepingAgentSessionsForWorktree('same-worktree', { executionHostId: 'local' })
+    ).toBe(1)
+    expect(useAppStore.getState().sleepingAgentSessionsByPaneKey[active.paneKey]).toBeUndefined()
+  })
+
+  it('excludes invalid same-host records from legacy pane ownership ambiguity', () => {
+    const active = makeRecord('tab-1:0', 'same-worktree', {
+      tabId: 'tab-1',
+      executionHostId: 'local'
+    })
+    const invalid = makeRecord('tab-1:1', 'same-worktree', {
+      tabId: 'tab-1',
+      executionHostId: 'local',
+      state: 'done',
+      origin: undefined,
+      providerSession: { key: 'session_id', id: 'invalid-session' },
+      capturedAt: 2,
+      updatedAt: 2
+    })
+    useAppStore.setState({
+      activeWorktreeId: 'same-worktree',
+      tabsByWorktree: {
+        'same-worktree': [
+          {
+            id: 'tab-1',
+            ptyId: 'wake-hint',
+            worktreeId: 'same-worktree',
+            title: 'shell',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1
+          }
+        ]
+      },
+      sleepingAgentSessionsByPaneKey: {
+        [active.paneKey]: active,
+        [invalid.paneKey]: invalid
+      }
+    } as never)
+
+    expect(
+      resumeSleepingAgentSessionsForWorktree('same-worktree', { executionHostId: 'local' })
+    ).toBe(0)
+    expect(useAppStore.getState().sleepingAgentSessionsByPaneKey[active.paneKey]).toBe(active)
+    expect(useAppStore.getState().sleepingAgentSessionsByPaneKey[invalid.paneKey]).toBeUndefined()
+  })
+})

--- a/src/renderer/src/lib/resume-sleeping-agent-session-selected-completion.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session-selected-completion.test.ts
@@ -59,6 +59,7 @@ describe('selected completed agent resume', () => {
     } as never)
 
     const launched = resumeSleepingAgentSessionsForWorktree('wt-1', {
+      executionHostId: 'local',
       resumeCompletedPaneKey: selected.paneKey
     })
 

--- a/src/renderer/src/lib/resume-sleeping-agent-session-selected-completion.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session-selected-completion.test.ts
@@ -97,6 +97,36 @@ describe('selected completed agent resume', () => {
     expect(useAppStore.getState().sleepingAgentSessionsByPaneKey[record.paneKey]).toBe(record)
   })
 
+  it('does not force a second session while selected-pane hibernation is still killing its PTY', () => {
+    const record = makeCompletedRecord({
+      paneKey: makePaneKey('tab-1', LEAF_ID),
+      tabId: 'tab-1'
+    })
+    useAppStore.setState({
+      activeWorktreeId: 'wt-1',
+      tabsByWorktree: { 'wt-1': [makeTerminalTab('tab-1')] },
+      ptyIdsByTabId: { 'tab-1': ['pty-1'] },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: LEAF_ID },
+          activeLeafId: LEAF_ID,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [LEAF_ID]: 'pty-1' }
+        }
+      },
+      sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
+    } as never)
+
+    const launched = resumeSleepingAgentSessionsForWorktree('wt-1', {
+      resumeCompletedPaneKey: record.paneKey,
+      forceFreshSelectedCompletion: true
+    })
+
+    expect(launched).toBe(0)
+    expect(useAppStore.getState().tabsByWorktree['wt-1']).toHaveLength(1)
+    expect(useAppStore.getState().sleepingAgentSessionsByPaneKey[record.paneKey]).toBe(record)
+  })
+
   it('does not duplicate a selected provider session that is already active', () => {
     const record = makeCompletedRecord()
     useAppStore.setState({

--- a/src/renderer/src/lib/resume-sleeping-agent-session-selected-completion.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session-selected-completion.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-resume'
+import { makePaneKey } from '../../../shared/stable-pane-id'
+import { useAppStore } from '@/store'
+import { resumeSleepingAgentSessionsForWorktree } from './resume-sleeping-agent-session'
+
+const initialAppStoreState = useAppStore.getState()
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+
+afterEach(() => {
+  useAppStore.setState(initialAppStoreState, true)
+})
+
+function makeCompletedRecord(
+  overrides: Partial<SleepingAgentSessionRecord> = {}
+): SleepingAgentSessionRecord {
+  return {
+    paneKey: makePaneKey('closed-tab', LEAF_ID),
+    tabId: 'closed-tab',
+    worktreeId: 'wt-1',
+    agent: 'claude',
+    providerSession: { key: 'session_id', id: 'sess-1' },
+    prompt: 'finish the task',
+    state: 'done',
+    origin: 'worktree-sleep',
+    capturedAt: 1,
+    updatedAt: 1,
+    ...overrides
+  }
+}
+
+function makeTerminalTab(id: string): Record<string, unknown> {
+  return {
+    id,
+    ptyId: null,
+    worktreeId: 'wt-1',
+    title: 'shell',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1
+  }
+}
+
+describe('selected completed agent resume', () => {
+  it('resumes the exact completed record when its pane is gone', () => {
+    const selected = makeCompletedRecord()
+    const other = makeCompletedRecord({
+      paneKey: makePaneKey('other-closed-tab', LEAF_ID),
+      tabId: 'other-closed-tab',
+      providerSession: { key: 'session_id', id: 'sess-2' }
+    })
+    useAppStore.setState({
+      tabsByWorktree: { 'wt-1': [] },
+      sleepingAgentSessionsByPaneKey: {
+        [selected.paneKey]: selected,
+        [other.paneKey]: other
+      }
+    } as never)
+
+    const launched = resumeSleepingAgentSessionsForWorktree('wt-1', {
+      resumeCompletedPaneKey: selected.paneKey
+    })
+
+    const state = useAppStore.getState()
+    expect(launched).toBe(1)
+    expect(state.tabsByWorktree['wt-1']).toHaveLength(1)
+    expect(state.tabsByWorktree['wt-1']?.[0]?.launchAgent).toBe('claude')
+    expect(state.sleepingAgentSessionsByPaneKey[selected.paneKey]).toBeUndefined()
+  })
+
+  it('leaves a preserved selected pane for in-place cold restore', () => {
+    const record = makeCompletedRecord({
+      paneKey: makePaneKey('tab-1', LEAF_ID),
+      tabId: 'tab-1'
+    })
+    useAppStore.setState({
+      activeWorktreeId: 'wt-1',
+      tabsByWorktree: { 'wt-1': [makeTerminalTab('tab-1')] },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: LEAF_ID },
+          activeLeafId: LEAF_ID,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [LEAF_ID]: 'pty-1' }
+        }
+      },
+      sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
+    } as never)
+
+    const launched = resumeSleepingAgentSessionsForWorktree('wt-1', {
+      resumeCompletedPaneKey: record.paneKey
+    })
+
+    expect(launched).toBe(0)
+    expect(useAppStore.getState().tabsByWorktree['wt-1']).toHaveLength(1)
+    expect(useAppStore.getState().sleepingAgentSessionsByPaneKey[record.paneKey]).toBe(record)
+  })
+
+  it('does not duplicate a selected provider session that is already active', () => {
+    const record = makeCompletedRecord()
+    useAppStore.setState({
+      tabsByWorktree: { 'wt-1': [makeTerminalTab('live-tab')] },
+      agentStatusByPaneKey: {
+        'live-tab:leaf-1': {
+          paneKey: 'live-tab:leaf-1',
+          tabId: 'live-tab',
+          worktreeId: 'wt-1',
+          agentType: 'claude',
+          state: 'working',
+          providerSession: record.providerSession
+        }
+      },
+      sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
+    } as never)
+
+    const launched = resumeSleepingAgentSessionsForWorktree('wt-1', {
+      resumeCompletedPaneKey: record.paneKey
+    })
+
+    expect(launched).toBe(0)
+    expect(useAppStore.getState().tabsByWorktree['wt-1']).toHaveLength(1)
+    expect(useAppStore.getState().sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()
+  })
+})

--- a/src/renderer/src/lib/resume-sleeping-agent-session.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session.ts
@@ -4,6 +4,7 @@ import {
   type SleepingAgentSessionRecord
 } from '../../../shared/agent-session-resume'
 import { AGENT_STATUS_STALE_AFTER_MS } from '../../../shared/agent-status-types'
+import { toSshExecutionHostId } from '../../../shared/execution-host'
 import {
   getProviderSessionClaimKey,
   isPassiveCompletedHibernationEvidence,
@@ -33,7 +34,10 @@ function clearPassiveCompletedRecordsForClaimKey(
   }
 }
 
-function getCurrentPaneOwnedClaimKeys(records: readonly SleepingAgentSessionRecord[]): Set<string> {
+function getCurrentPaneOwnedClaimKeys(
+  records: readonly SleepingAgentSessionRecord[],
+  ownershipRecords: readonly SleepingAgentSessionRecord[]
+): Set<string> {
   const state = useAppStore.getState()
   const keys = new Set<string>()
   for (const record of records) {
@@ -44,7 +48,7 @@ function getCurrentPaneOwnedClaimKeys(records: readonly SleepingAgentSessionReco
     ) {
       continue
     }
-    if (recordPaneIsOwnedByPreservedPane(record, state)) {
+    if (recordPaneIsOwnedByPreservedPane(record, state, ownershipRecords)) {
       keys.add(getProviderSessionClaimKey(record))
     }
   }
@@ -83,7 +87,7 @@ function getPreservedPassiveClaimOwner(
         state.sleepingAgentSessionsByPaneKey[candidate.paneKey] === candidate &&
         isPassiveCompletedHibernationEvidence(candidate) &&
         getProviderSessionClaimKey(candidate) === claimKey &&
-        recordPaneIsOwnedByPreservedPane(candidate, state)
+        recordPaneIsOwnedByPreservedPane(candidate, state, records)
     ) ?? null
   )
 }
@@ -161,13 +165,32 @@ function isInvalidWorktreeActivationRecord(record: SleepingAgentSessionRecord): 
   )
 }
 
+function recordMatchesExecutionHost(
+  record: SleepingAgentSessionRecord,
+  options: ResumeSleepingAgentSessionsOptions | undefined
+): boolean {
+  const executionHostId = options?.executionHostId
+  if (!executionHostId) {
+    return true
+  }
+  if (record.executionHostId) {
+    return record.executionHostId === executionHostId
+  }
+  if (record.connectionId?.trim()) {
+    return toSshExecutionHostId(record.connectionId) === executionHostId
+  }
+  return options?.resumeCompletedPaneKey === record.paneKey
+}
+
 export function resumeSleepingAgentSessionsForWorktree(
   worktreeId: string,
   options?: ResumeSleepingAgentSessionsOptions
 ): number {
   const state = useAppStore.getState()
   const worktreeRecords = Object.values(state.sleepingAgentSessionsByPaneKey)
-    .filter((record) => record.worktreeId === worktreeId)
+    .filter(
+      (record) => record.worktreeId === worktreeId && recordMatchesExecutionHost(record, options)
+    )
     .sort((a, b) => a.capturedAt - b.capturedAt || a.updatedAt - b.updatedAt)
   const validWorktreeRecords = worktreeRecords.filter(
     (record) => !isInvalidWorktreeActivationRecord(record)
@@ -199,7 +222,7 @@ export function resumeSleepingAgentSessionsForWorktree(
       state.clearSleepingAgentSession(record.paneKey)
       continue
     }
-    const isPaneOwned = recordPaneIsOwnedByPreservedPane(record, currentState)
+    const isPaneOwned = recordPaneIsOwnedByPreservedPane(record, currentState, validWorktreeRecords)
     if (isPassiveCompletedHibernationEvidence(record)) {
       const explicitlySelected = options?.resumeCompletedPaneKey === record.paneKey
       // Why: completed-agent hibernation stays passive unless the user opened
@@ -244,7 +267,10 @@ export function resumeSleepingAgentSessionsForWorktree(
       state.clearSleepingAgentSession(record.paneKey)
       continue
     }
-    const paneOwnedClaimKeys = getCurrentPaneOwnedClaimKeys(activeWorktreeRecords)
+    const paneOwnedClaimKeys = getCurrentPaneOwnedClaimKeys(
+      activeWorktreeRecords,
+      validWorktreeRecords
+    )
     if (paneOwnedClaimKeys.has(claimKey)) {
       if (!isPaneOwned) {
         state.clearSleepingAgentSession(record.paneKey)

--- a/src/renderer/src/lib/resume-sleeping-agent-session.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session.ts
@@ -68,6 +68,25 @@ function getNewestActiveRecordsByClaimKey(
   return newestRecords
 }
 
+function getPreservedPassiveClaimOwner(
+  record: SleepingAgentSessionRecord,
+  records: readonly SleepingAgentSessionRecord[],
+  state: ReturnType<typeof useAppStore.getState>,
+  excludedPaneKey?: string
+): SleepingAgentSessionRecord | null {
+  const claimKey = getProviderSessionClaimKey(record)
+  return (
+    records.find(
+      (candidate) =>
+        candidate.paneKey !== excludedPaneKey &&
+        state.sleepingAgentSessionsByPaneKey[candidate.paneKey] === candidate &&
+        isPassiveCompletedHibernationEvidence(candidate) &&
+        getProviderSessionClaimKey(candidate) === claimKey &&
+        recordPaneIsOwnedByPreservedPane(candidate, state)
+    ) ?? null
+  )
+}
+
 function getAgentStatusTabId(entry: {
   paneKey: string
   tabId?: string | undefined
@@ -181,10 +200,38 @@ export function resumeSleepingAgentSessionsForWorktree(
     }
     const isPaneOwned = recordPaneIsOwnedByPreservedPane(record, currentState)
     if (isPassiveCompletedHibernationEvidence(record)) {
-      // Why: completed-agent hibernation is passive history; activation should
-      // only keep displayable evidence, never start new work from it.
-      if (!isPaneOwned || activeClaimKeys.has(claimKey)) {
+      const explicitlySelected = options?.resumeCompletedPaneKey === record.paneKey
+      // Why: completed-agent hibernation stays passive unless the user opened
+      // this exact card; broad workspace activation must not restart history.
+      if (!explicitlySelected) {
+        if (!isPaneOwned || activeClaimKeys.has(claimKey)) {
+          state.clearSleepingAgentSession(record.paneKey)
+        }
+        continue
+      }
+      if (
+        activeClaimKeys.has(claimKey) ||
+        activeOrQueuedResumeClaimsProviderSession(record, currentState, isPaneOwned)
+      ) {
         state.clearSleepingAgentSession(record.paneKey)
+        continue
+      }
+      const preservedOwner = getPreservedPassiveClaimOwner(
+        record,
+        validWorktreeRecords,
+        currentState,
+        options?.forceFreshSelectedCompletion ? record.paneKey : undefined
+      )
+      if (preservedOwner) {
+        if (preservedOwner !== record) {
+          state.clearSleepingAgentSession(record.paneKey)
+        }
+        continue
+      }
+      if (launchSleepingAgentSession(record, options)) {
+        launched += 1
+        freshlyLaunchedClaimKeys.add(claimKey)
+        clearPassiveCompletedRecordsForClaimKey(worktreeRecords, claimKey, record.paneKey)
       }
       continue
     }

--- a/src/renderer/src/lib/resume-sleeping-agent-session.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session.ts
@@ -7,6 +7,7 @@ import { AGENT_STATUS_STALE_AFTER_MS } from '../../../shared/agent-status-types'
 import {
   getProviderSessionClaimKey,
   isPassiveCompletedHibernationEvidence,
+  recordPaneHasLivePty,
   recordPaneIsOwnedByPreservedPane
 } from './sleeping-agent-pane-ownership'
 import {
@@ -220,7 +221,9 @@ export function resumeSleepingAgentSessionsForWorktree(
         record,
         validWorktreeRecords,
         currentState,
-        options?.forceFreshSelectedCompletion ? record.paneKey : undefined
+        options?.forceFreshSelectedCompletion && !recordPaneHasLivePty(record, currentState)
+          ? record.paneKey
+          : undefined
       )
       if (preservedOwner) {
         if (preservedOwner !== record) {

--- a/src/renderer/src/lib/reveal-agent-pane.test.ts
+++ b/src/renderer/src/lib/reveal-agent-pane.test.ts
@@ -53,6 +53,28 @@ describe('revealAgentPane', () => {
     })
   })
 
+  it('requests only the selected retained card and focuses its replacement tab', () => {
+    mocks.activateAndRevealWorkspace.mockReturnValue({
+      primaryTabId: 'shell-tab',
+      resumedAgentTabId: 'resumed-tab'
+    })
+    mocks.tabsByWorktree = { 'wt-1': [{ id: 'shell-tab' }, { id: 'resumed-tab' }] }
+
+    expect(
+      revealAgentPane({
+        worktreeId: 'wt-1',
+        tabId: 'closed-tab',
+        leafId: 'closed-leaf',
+        paneKey: 'closed-tab:closed-leaf'
+      })
+    ).toBe(true)
+
+    expect(mocks.activateAndRevealWorkspace).toHaveBeenCalledWith('wt-1', {
+      resumeCompletedPaneKey: 'closed-tab:closed-leaf'
+    })
+    expect(mocks.activateTabAndFocusPane).toHaveBeenCalledWith('resumed-tab', null, {})
+  })
+
   // Dashboard/agent-map cards carry `folder:<id>` in worktreeId; the dispatcher
   // inside activateAndRevealWorkspace is what routes those to the folder path.
   it('passes a folder workspace key straight through to the dispatcher', () => {

--- a/src/renderer/src/lib/reveal-agent-pane.test.ts
+++ b/src/renderer/src/lib/reveal-agent-pane.test.ts
@@ -1,0 +1,123 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  activateAndRevealWorkspace: vi.fn(() => ({ primaryTabId: 'tab-1' }) as unknown),
+  activateTabAndFocusPane: vi.fn(),
+  tabsByWorktree: {} as Record<string, { id: string }[]>
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: () => ({ tabsByWorktree: mocks.tabsByWorktree })
+  }
+}))
+
+vi.mock('@/lib/worktree-activation', () => ({
+  activateAndRevealWorkspace: mocks.activateAndRevealWorkspace
+}))
+
+vi.mock('@/lib/activate-tab-and-focus-pane', () => ({
+  activateTabAndFocusPane: mocks.activateTabAndFocusPane
+}))
+
+import { revealAgentPane } from './reveal-agent-pane'
+
+describe('revealAgentPane', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.activateAndRevealWorkspace.mockReturnValue({ primaryTabId: 'tab-1' })
+    mocks.tabsByWorktree = { 'wt-1': [{ id: 'tab-1' }], 'folder:folder-1': [{ id: 'tab-2' }] }
+  })
+
+  // The whole point of the helper: activateAndRevealWorkspace is what runs
+  // resumeSleepingAgentSessionsForWorktree, so a slept agent wakes on the way in.
+  it('activates through worktree-activation rather than the raw store setter', () => {
+    expect(revealAgentPane({ worktreeId: 'wt-1', tabId: 'tab-1', leafId: 'leaf-1' })).toBe(true)
+
+    expect(mocks.activateAndRevealWorkspace).toHaveBeenCalledWith('wt-1', {})
+    expect(mocks.activateTabAndFocusPane).toHaveBeenCalledWith('tab-1', 'leaf-1', {})
+  })
+
+  it('forwards the execution host so a colliding worktree id resolves', () => {
+    revealAgentPane({
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      leafId: 'leaf-1',
+      executionHostId: 'runtime:env-1'
+    })
+
+    expect(mocks.activateAndRevealWorkspace).toHaveBeenCalledWith('wt-1', {
+      executionHostId: 'runtime:env-1'
+    })
+  })
+
+  // Dashboard/agent-map cards carry `folder:<id>` in worktreeId; the dispatcher
+  // inside activateAndRevealWorkspace is what routes those to the folder path.
+  it('passes a folder workspace key straight through to the dispatcher', () => {
+    expect(revealAgentPane({ worktreeId: 'folder:folder-1', tabId: 'tab-2', leafId: null })).toBe(
+      true
+    )
+
+    expect(mocks.activateAndRevealWorkspace).toHaveBeenCalledWith('folder:folder-1', {})
+    expect(mocks.activateTabAndFocusPane).toHaveBeenCalledWith('tab-2', null, {})
+  })
+
+  it('still activates the tab when the card carries no leaf', () => {
+    revealAgentPane({ worktreeId: 'wt-1', tabId: 'tab-1', leafId: null })
+
+    expect(mocks.activateTabAndFocusPane).toHaveBeenCalledWith('tab-1', null, {})
+  })
+
+  it('forwards the ack, flash and scroll options', () => {
+    revealAgentPane(
+      { worktreeId: 'wt-1', tabId: 'tab-1', leafId: 'leaf-1' },
+      {
+        ackPaneKeyOnSuccess: 'pane-1',
+        flashFocusedPane: true,
+        scrollToBottomIfOutputSinceLastView: true
+      }
+    )
+
+    expect(mocks.activateTabAndFocusPane).toHaveBeenCalledWith('tab-1', 'leaf-1', {
+      ackPaneKeyOnSuccess: 'pane-1',
+      flashFocusedPane: true,
+      scrollToBottomIfOutputSinceLastView: true
+    })
+  })
+
+  // Waking a slept agent can append a fresh `--resume` tab instead of reviving the
+  // husk; focusing the dead id would yank the user off the tab the wake just opened.
+  it('does not focus a tab that the wake replaced', () => {
+    const onTargetUnavailable = vi.fn()
+
+    expect(
+      revealAgentPane(
+        { worktreeId: 'wt-1', tabId: 'husk-tab', leafId: 'leaf-1' },
+        { onTargetUnavailable }
+      )
+    ).toBe(false)
+
+    expect(mocks.activateAndRevealWorkspace).toHaveBeenCalledTimes(1)
+    expect(mocks.activateTabAndFocusPane).not.toHaveBeenCalled()
+    expect(onTargetUnavailable).toHaveBeenCalledTimes(1)
+  })
+
+  // A folder workspace whose path is missing/unmounted toasts and returns false;
+  // the sidebar leans on this to drop the stale agent row.
+  it('reports unavailable when activation itself refuses', () => {
+    mocks.activateAndRevealWorkspace.mockReturnValue(false)
+    const onTargetUnavailable = vi.fn()
+
+    expect(
+      revealAgentPane(
+        { worktreeId: 'wt-1', tabId: 'tab-1', leafId: 'leaf-1' },
+        { onTargetUnavailable }
+      )
+    ).toBe(false)
+
+    expect(mocks.activateTabAndFocusPane).not.toHaveBeenCalled()
+    expect(onTargetUnavailable).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/lib/reveal-agent-pane.ts
+++ b/src/renderer/src/lib/reveal-agent-pane.ts
@@ -1,0 +1,63 @@
+import { useAppStore } from '@/store'
+import { activateTabAndFocusPane } from '@/lib/activate-tab-and-focus-pane'
+import { activateAndRevealWorkspace } from '@/lib/worktree-activation'
+import type { ExecutionHostId } from '../../../shared/execution-host'
+
+export type RevealAgentPaneTarget = {
+  /** Plain worktree id or a `folder:` workspace key — both dispatch correctly. */
+  worktreeId: string
+  tabId: string
+  leafId: string | null
+  executionHostId?: ExecutionHostId
+}
+
+export type RevealAgentPaneOptions = {
+  ackPaneKeyOnSuccess?: string
+  flashFocusedPane?: boolean
+  scrollToBottomIfOutputSinceLastView?: boolean
+  /** Runs when the pane could not be focused — the workspace refused to
+   *  activate, or it activated but the target tab is gone. */
+  onTargetUnavailable?: () => void
+}
+
+/**
+ * Focuses one agent's pane from a surface that lists agents across workspaces
+ * (sidebar rows, the dashboard board, the agent map).
+ *
+ * Why this exists: activation must go through worktree-activation, not a raw
+ * setActiveWorktree. That is where resumeSleepingAgentSessionsForWorktree runs,
+ * so it is the difference between a slept agent waking on the way in and the
+ * caller landing on a dead pane.
+ *
+ * Returns true when the pane was focused.
+ */
+export function revealAgentPane(
+  target: RevealAgentPaneTarget,
+  options?: RevealAgentPaneOptions
+): boolean {
+  const activated = activateAndRevealWorkspace(
+    target.worktreeId,
+    target.executionHostId ? { executionHostId: target.executionHostId } : {}
+  )
+  if (!activated) {
+    options?.onTargetUnavailable?.()
+    return false
+  }
+  // Why: read tabs AFTER activation — waking a slept agent can add its `--resume`
+  // tab, and a husk tab can be replaced rather than revived.
+  const tabs = useAppStore.getState().tabsByWorktree[target.worktreeId] ?? []
+  if (!tabs.some((tab) => tab.id === target.tabId)) {
+    // Why: the wake already focused the replacement tab; re-activating the dead
+    // id would yank the user back to a tab that no longer renders.
+    options?.onTargetUnavailable?.()
+    return false
+  }
+  activateTabAndFocusPane(target.tabId, target.leafId, {
+    ...(options?.ackPaneKeyOnSuccess ? { ackPaneKeyOnSuccess: options.ackPaneKeyOnSuccess } : {}),
+    ...(options?.flashFocusedPane ? { flashFocusedPane: true } : {}),
+    ...(options?.scrollToBottomIfOutputSinceLastView
+      ? { scrollToBottomIfOutputSinceLastView: true }
+      : {})
+  })
+  return true
+}

--- a/src/renderer/src/lib/reveal-agent-pane.ts
+++ b/src/renderer/src/lib/reveal-agent-pane.ts
@@ -8,6 +8,8 @@ export type RevealAgentPaneTarget = {
   worktreeId: string
   tabId: string
   leafId: string | null
+  /** Exact retained card to resume when its completed pane no longer exists. */
+  paneKey?: string
   executionHostId?: ExecutionHostId
 }
 
@@ -35,10 +37,10 @@ export function revealAgentPane(
   target: RevealAgentPaneTarget,
   options?: RevealAgentPaneOptions
 ): boolean {
-  const activated = activateAndRevealWorkspace(
-    target.worktreeId,
-    target.executionHostId ? { executionHostId: target.executionHostId } : {}
-  )
+  const activated = activateAndRevealWorkspace(target.worktreeId, {
+    ...(target.executionHostId ? { executionHostId: target.executionHostId } : {}),
+    ...(target.paneKey ? { resumeCompletedPaneKey: target.paneKey } : {})
+  })
   if (!activated) {
     options?.onTargetUnavailable?.()
     return false
@@ -46,13 +48,15 @@ export function revealAgentPane(
   // Why: read tabs AFTER activation — waking a slept agent can add its `--resume`
   // tab, and a husk tab can be replaced rather than revived.
   const tabs = useAppStore.getState().tabsByWorktree[target.worktreeId] ?? []
-  if (!tabs.some((tab) => tab.id === target.tabId)) {
+  const targetTabExists = tabs.some((tab) => tab.id === target.tabId)
+  const focusTabId = activated.resumedAgentTabId ?? (targetTabExists ? target.tabId : undefined)
+  if (!focusTabId || !tabs.some((tab) => tab.id === focusTabId)) {
     // Why: the wake already focused the replacement tab; re-activating the dead
     // id would yank the user back to a tab that no longer renders.
     options?.onTargetUnavailable?.()
     return false
   }
-  activateTabAndFocusPane(target.tabId, target.leafId, {
+  activateTabAndFocusPane(focusTabId, activated.resumedAgentTabId ? null : target.leafId, {
     ...(options?.ackPaneKeyOnSuccess ? { ackPaneKeyOnSuccess: options.ackPaneKeyOnSuccess } : {}),
     ...(options?.flashFocusedPane ? { flashFocusedPane: true } : {}),
     ...(options?.scrollToBottomIfOutputSinceLastView

--- a/src/renderer/src/lib/sleeping-agent-pane-ownership.ts
+++ b/src/renderer/src/lib/sleeping-agent-pane-ownership.ts
@@ -30,12 +30,12 @@ function getLegacyPaneTabId(record: SleepingAgentSessionRecord): string | null {
 }
 
 function getLegacyProviderSessionKeysForTab(
-  state: AppStoreState,
+  records: Iterable<SleepingAgentSessionRecord>,
   worktreeId: string,
   tabId: string
 ): Set<string> {
   const keys = new Set<string>()
-  for (const record of Object.values(state.sleepingAgentSessionsByPaneKey)) {
+  for (const record of records) {
     if (record.worktreeId === worktreeId && getLegacyPaneTabId(record) === tabId) {
       keys.add(getProviderSessionClaimKey(record))
     }
@@ -141,7 +141,10 @@ function paneWillConnectOnActivation(
 
 export function recordPaneIsOwnedByPreservedPane(
   record: SleepingAgentSessionRecord,
-  state: AppStoreState
+  state: AppStoreState,
+  scopedRecords: Iterable<SleepingAgentSessionRecord> = Object.values(
+    state.sleepingAgentSessionsByPaneKey
+  )
 ): boolean {
   const worktreeTabs = state.tabsByWorktree[record.worktreeId] ?? []
   const stable = parsePaneKey(record.paneKey)
@@ -180,7 +183,7 @@ export function recordPaneIsOwnedByPreservedPane(
     return false
   }
   const tab = worktreeTabs.find((candidate) => candidate.id === tabId) ?? null
-  const providerKeys = getLegacyProviderSessionKeysForTab(state, record.worktreeId, tabId)
+  const providerKeys = getLegacyProviderSessionKeysForTab(scopedRecords, record.worktreeId, tabId)
   // Why: legacy numeric pane keys lack leaf identity, so only a preserved
   // tab-level wake hint plus a single provider session is strong enough to
   // claim pane recovery without risking the wrong split-pane session.

--- a/src/renderer/src/lib/sleeping-agent-pane-ownership.ts
+++ b/src/renderer/src/lib/sleeping-agent-pane-ownership.ts
@@ -105,6 +105,23 @@ function stablePaneHasLivePty(
   return layout?.root?.type === 'leaf' && layout.root.leafId === leafId
 }
 
+export function recordPaneHasLivePty(
+  record: SleepingAgentSessionRecord,
+  state: AppStoreState
+): boolean {
+  const stable = parsePaneKey(record.paneKey)
+  if (!stable || (record.tabId && record.tabId !== stable.tabId)) {
+    return false
+  }
+  const tabId = record.tabId ?? stable.tabId
+  return stablePaneHasLivePty(
+    tabId,
+    stable.leafId,
+    state.ptyIdsByTabId,
+    state.terminalLayoutsByTabId[tabId]
+  )
+}
+
 function paneWillConnectOnActivation(
   worktreeId: string,
   tabId: string,
@@ -142,14 +159,7 @@ export function recordPaneIsOwnedByPreservedPane(
     }
     // Why: a pane with a live PTY owns its running session regardless of which
     // pane reconnects on activation; forking it would duplicate the session.
-    if (
-      stablePaneHasLivePty(
-        tabId,
-        stable.leafId,
-        state.ptyIdsByTabId,
-        state.terminalLayoutsByTabId[tabId]
-      )
-    ) {
+    if (recordPaneHasLivePty(record, state)) {
       return true
     }
     // Why: active sessions rely on pane-level cold restore. A preserved leaf

--- a/src/renderer/src/lib/sleeping-agent-session-launch-host-collision.test.ts
+++ b/src/renderer/src/lib/sleeping-agent-session-launch-host-collision.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-resume'
+
+const mocks = vi.hoisted(() => ({
+  getKnownWorktreeById: vi.fn(),
+  getLocalProjectExecutionRuntimeContext: vi.fn(),
+  resolveAgentResumeLaunchTarget: vi.fn(() => ({ platform: 'linux', shell: undefined })),
+  queueTabStartupCommand: vi.fn(),
+  createTab: vi.fn(() => ({ id: 'resumed-tab' })),
+  state: {} as Record<string, unknown>
+}))
+
+vi.mock('@/store', () => ({ useAppStore: { getState: () => mocks.state } }))
+vi.mock('@/lib/tui-agent-startup', () => ({
+  buildAgentResumeStartupPlan: () => ({ launchCommand: "claude '--resume' 'session-1'" })
+}))
+vi.mock('@/lib/telemetry', () => ({ tuiAgentToAgentKind: () => 'claude' }))
+vi.mock('@/components/tab-bar/reconcile-order', () => ({ reconcileTabOrder: () => [] }))
+vi.mock('@/lib/agent-resume-launch-target', () => ({
+  resolveAgentResumeLaunchTarget: mocks.resolveAgentResumeLaunchTarget
+}))
+vi.mock('@/lib/worktree-runtime-owner', () => ({
+  getExecutionHostIdForWorktree: () => 'local'
+}))
+vi.mock('@/lib/local-preflight-context', () => ({
+  getLocalProjectExecutionRuntimeContext: mocks.getLocalProjectExecutionRuntimeContext
+}))
+vi.mock('../../../shared/tui-agent-launch-defaults', () => ({
+  resolveTuiAgentLaunchArgs: () => '',
+  resolveTuiAgentLaunchEnv: () => ({})
+}))
+vi.mock('@/i18n/i18n', () => ({ translate: (_key: string, fallback: string) => fallback }))
+
+const { launchSleepingAgentSession } = await import('./sleeping-agent-session-launch')
+
+const record: SleepingAgentSessionRecord = {
+  paneKey: 'closed-tab:leaf-1',
+  tabId: 'closed-tab',
+  worktreeId: 'colliding-worktree',
+  agent: 'claude',
+  providerSession: { key: 'session_id', id: 'session-1' },
+  prompt: 'finish',
+  state: 'done',
+  origin: 'worktree-sleep',
+  capturedAt: 1,
+  updatedAt: 1,
+  connectionId: 'remote-connection'
+}
+
+describe('sleeping agent resume host collision', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.getKnownWorktreeById.mockReturnValue({
+      id: record.worktreeId,
+      repoId: 'repo-1',
+      path: '/remote/worktree'
+    })
+    mocks.state = {
+      getKnownWorktreeById: mocks.getKnownWorktreeById,
+      repos: [
+        { id: 'repo-1', path: 'C:\\local', executionHostId: 'local' },
+        {
+          id: 'repo-1',
+          path: '/remote',
+          connectionId: 'remote-connection',
+          executionHostId: 'ssh:remote-connection'
+        }
+      ],
+      settings: { agentCmdOverrides: {} },
+      tabsByWorktree: { [record.worktreeId]: [] },
+      openFiles: [],
+      browserTabsByWorktree: {},
+      tabBarOrderByWorktree: {},
+      createTab: mocks.createTab,
+      queueTabStartupCommand: mocks.queueTabStartupCommand,
+      claimAutomaticAgentResume: vi.fn(),
+      clearSleepingAgentSession: vi.fn(),
+      setActiveTabType: vi.fn(),
+      setTabBarOrder: vi.fn()
+    }
+  })
+
+  it('does not let a colliding local WSL project override an SSH resume target', () => {
+    expect(launchSleepingAgentSession(record, { executionHostId: 'ssh:remote-connection' })).toBe(
+      true
+    )
+
+    expect(mocks.getKnownWorktreeById).toHaveBeenCalledWith(
+      record.worktreeId,
+      'ssh:remote-connection'
+    )
+    expect(mocks.getLocalProjectExecutionRuntimeContext).not.toHaveBeenCalled()
+    expect(mocks.resolveAgentResumeLaunchTarget).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectRuntime: undefined,
+        connectionId: 'remote-connection',
+        executionHostId: 'ssh:remote-connection',
+        worktreePath: '/remote/worktree'
+      })
+    )
+  })
+})

--- a/src/renderer/src/lib/sleeping-agent-session-launch.ts
+++ b/src/renderer/src/lib/sleeping-agent-session-launch.ts
@@ -14,10 +14,19 @@ import {
   resolveTuiAgentLaunchEnv
 } from '../../../shared/tui-agent-launch-defaults'
 import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-resume'
+import { getRepoExecutionHostId, type ExecutionHostId } from '../../../shared/execution-host'
 import { translate } from '@/i18n/i18n'
 
 export type ResumeSleepingAgentSessionsOptions = {
   suppressNavigation?: boolean
+  /** Exact completed pane the user explicitly asked to reopen. Generic
+   *  workspace activation keeps completed hibernation evidence passive. */
+  resumeCompletedPaneKey?: string
+  /** Folder panes do not cold-restore on activation; replace only the selected
+   *  completion before its preserved pane can claim the provider session. */
+  forceFreshSelectedCompletion?: boolean
+  /** Pins resume launch resolution when workspace ids collide across hosts. */
+  executionHostId?: ExecutionHostId
   /** Provider-session claim keys already woken in place by mounted panes
    *  (WAKE_HIBERNATED_AGENTS_WORKTREE_EVENT). Their sleeping records are
    *  cleared only after the in-place spawn succeeds, so the generic resume
@@ -26,17 +35,33 @@ export type ResumeSleepingAgentSessionsOptions = {
   /** Called with the tab id of each freshly launched resume tab, so
    *  navigation-suppressed callers can background-mount exactly those tabs. */
   onSessionLaunched?: (tabId: string) => void
+  /** Reports only the explicitly selected completed record's replacement. */
+  onSelectedCompletedSessionLaunched?: (tabId: string) => void
 }
 
-function getResumeLaunchTarget(worktreeId: string): AgentResumeLaunchTarget {
+function getResumeLaunchTarget(
+  record: SleepingAgentSessionRecord,
+  executionHostId?: ExecutionHostId
+): AgentResumeLaunchTarget {
   const state = useAppStore.getState()
-  const worktree = state.getKnownWorktreeById(worktreeId)
-  const repo = worktree ? state.repos.find((entry) => entry.id === worktree.repoId) : null
+  const worktreeId = record.worktreeId
+  const worktree = state.getKnownWorktreeById(worktreeId, executionHostId)
+  const resolvedExecutionHostId =
+    executionHostId ?? getExecutionHostIdForWorktree(state, worktreeId)
+  const repo = worktree
+    ? (state.repos.find(
+        (entry) =>
+          entry.id === worktree.repoId && getRepoExecutionHostId(entry) === resolvedExecutionHostId
+      ) ?? null)
+    : null
   // The resume tab is created without a shell override, so the global Windows shell wins.
   return resolveAgentResumeLaunchTarget({
-    projectRuntime: getLocalProjectExecutionRuntimeContext(state, worktreeId),
-    connectionId: repo?.connectionId,
-    executionHostId: getExecutionHostIdForWorktree(state, worktreeId),
+    projectRuntime:
+      resolvedExecutionHostId === 'local'
+        ? getLocalProjectExecutionRuntimeContext(state, worktreeId)
+        : undefined,
+    connectionId: repo?.connectionId ?? record.connectionId,
+    executionHostId: resolvedExecutionHostId,
     worktreePath: worktree?.path,
     terminalWindowsShell: state.settings?.terminalWindowsShell
   })
@@ -68,7 +93,7 @@ export function launchSleepingAgentSession(
 ): boolean {
   const state = useAppStore.getState()
   const launchConfig = record.launchConfig
-  const resumeTarget = getResumeLaunchTarget(record.worktreeId)
+  const resumeTarget = getResumeLaunchTarget(record, options?.executionHostId)
   const startupPlan = buildAgentResumeStartupPlan({
     agent: record.agent,
     providerSession: record.providerSession,
@@ -130,5 +155,8 @@ export function launchSleepingAgentSession(
   }
   appendTabToWorktreeOrder(record.worktreeId, tab.id)
   options?.onSessionLaunched?.(tab.id)
+  if (options?.resumeCompletedPaneKey === record.paneKey) {
+    options.onSelectedCompletedSessionLaunched?.(tab.id)
+  }
   return true
 }

--- a/src/renderer/src/lib/workspace-activation-path-gate.test.ts
+++ b/src/renderer/src/lib/workspace-activation-path-gate.test.ts
@@ -5,6 +5,8 @@ import type { ProjectGroup } from '../../../shared/project-group-types'
 import type { FolderWorkspacePathStatusReason } from '../../../shared/folder-workspace-path-status'
 import { folderWorkspaceKey } from '../../../shared/workspace-scope'
 import { resolveWindowShortcutAction } from '../../../shared/window-shortcut-policy'
+import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-resume'
+import { makePaneKey } from '../../../shared/stable-pane-id'
 
 // Why: drives the real activation module against a real store, so a regression in
 // the workspace dispatch or in the path-status guard itself both surface here.
@@ -63,7 +65,9 @@ async function seedFolderWorkspace(
     activeWorktreeId: null,
     activeWorkspaceKey: null,
     activeView: 'terminal',
-    folderWorkspacePathStatuses: {}
+    folderWorkspacePathStatuses: {},
+    sleepingAgentSessionsByPaneKey: {},
+    tabsByWorktree: {}
   })
   mocks.getPathStatus.mockResolvedValue({ path: folderWorkspace.folderPath, ...status })
   // Why the real fetch: it writes the cache under the exact key + request snapshot
@@ -94,6 +98,32 @@ describe('Cmd/Ctrl+1-9 folder-workspace path gate (#10716)', () => {
     expect(mocks.toastError).toHaveBeenCalledTimes(1)
   })
 
+  it('keeps a selected completion retryable when folder activation is blocked', async () => {
+    await seedFolderWorkspace({ exists: false, reason: 'missing' })
+    const worktreeId = folderWorkspaceKey(folderWorkspace.id)
+    const record = {
+      paneKey: makePaneKey('completed-tab', '11111111-1111-4111-8111-111111111111'),
+      tabId: 'completed-tab',
+      worktreeId,
+      agent: 'claude',
+      providerSession: { key: 'session_id', id: 'completed-session' },
+      prompt: 'completed task',
+      state: 'done',
+      origin: 'worktree-sleep',
+      capturedAt: 1,
+      updatedAt: 1
+    } satisfies SleepingAgentSessionRecord
+    store.setState({ sleepingAgentSessionsByPaneKey: { [record.paneKey]: record } })
+
+    const result = activateAndRevealWorkspace(worktreeId, {
+      resumeCompletedPaneKey: record.paneKey
+    })
+
+    expect(result).toBe(false)
+    expect(store.getState().sleepingAgentSessionsByPaneKey[record.paneKey]).toBe(record)
+    expect(store.getState().tabsByWorktree[worktreeId]).toBeUndefined()
+  })
+
   it('blocks the number shortcut when the SSH connection owning the folder is ambiguous', async () => {
     await seedFolderWorkspace({ exists: false, reason: 'ambiguous-connection' })
 
@@ -110,6 +140,124 @@ describe('Cmd/Ctrl+1-9 folder-workspace path gate (#10716)', () => {
 
     expect(store.getState().activeWorkspaceKey).toBe(folderWorkspaceKey(folderWorkspace.id))
     expect(mocks.toastError).not.toHaveBeenCalled()
+  })
+
+  it('attributes a mixed wake to the explicitly selected completed folder agent', async () => {
+    await seedFolderWorkspace({ exists: true })
+    const worktreeId = folderWorkspaceKey(folderWorkspace.id)
+    const completed = {
+      paneKey: makePaneKey('completed-tab', '11111111-1111-4111-8111-111111111111'),
+      tabId: 'completed-tab',
+      worktreeId,
+      agent: 'claude',
+      providerSession: { key: 'session_id', id: 'completed-session' },
+      prompt: 'completed task',
+      state: 'done',
+      origin: 'worktree-sleep',
+      capturedAt: 1,
+      updatedAt: 1
+    } satisfies SleepingAgentSessionRecord
+    const active = {
+      ...completed,
+      paneKey: makePaneKey('active-tab', '22222222-2222-4222-8222-222222222222'),
+      tabId: 'active-tab',
+      providerSession: { key: 'session_id', id: 'active-session' },
+      prompt: 'active task',
+      state: 'working',
+      capturedAt: 2,
+      updatedAt: 2
+    } satisfies SleepingAgentSessionRecord
+    store.setState({
+      sleepingAgentSessionsByPaneKey: {
+        [completed.paneKey]: completed,
+        [active.paneKey]: active
+      }
+    })
+
+    const result = activateAndRevealWorkspace(worktreeId, {
+      resumeCompletedPaneKey: completed.paneKey
+    })
+
+    expect(result).not.toBe(false)
+    if (!result) {
+      throw new Error('folder workspace activation unexpectedly failed')
+    }
+    const state = store.getState()
+    expect(state.tabsByWorktree[worktreeId]).toHaveLength(2)
+    const resumedAgentTabId = result.resumedAgentTabId
+    if (!resumedAgentTabId) {
+      throw new Error('selected completed agent did not receive a replacement tab')
+    }
+    expect(state.pendingStartupByTabId[resumedAgentTabId]?.resumeProviderSession).toEqual(
+      completed.providerSession
+    )
+    const otherTabId = state.tabsByWorktree[worktreeId]?.find(
+      (tab) => tab.id !== resumedAgentTabId
+    )?.id
+    if (!otherTabId) {
+      throw new Error('active sleeping agent did not receive a resume tab')
+    }
+    expect(state.pendingStartupByTabId[otherTabId]?.resumeProviderSession).toEqual(
+      active.providerSession
+    )
+  })
+
+  it('fresh-resumes the selected folder agent when its preserved pane cannot cold-restore', async () => {
+    await seedFolderWorkspace({ exists: true })
+    const worktreeId = folderWorkspaceKey(folderWorkspace.id)
+    const leafId = '11111111-1111-4111-8111-111111111111'
+    const record = {
+      paneKey: makePaneKey('completed-tab', leafId),
+      tabId: 'completed-tab',
+      worktreeId,
+      agent: 'claude',
+      providerSession: { key: 'session_id', id: 'completed-session' },
+      prompt: 'completed task',
+      state: 'done',
+      origin: 'worktree-sleep',
+      capturedAt: 1,
+      updatedAt: 1
+    } satisfies SleepingAgentSessionRecord
+    store.setState({
+      tabsByWorktree: {
+        [worktreeId]: [
+          {
+            id: 'completed-tab',
+            ptyId: null,
+            worktreeId,
+            title: 'Claude',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        'completed-tab': {
+          root: { type: 'leaf', leafId },
+          activeLeafId: leafId,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [leafId]: 'dead-pty' }
+        }
+      },
+      sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
+    })
+
+    const result = activateAndRevealWorkspace(worktreeId, {
+      resumeCompletedPaneKey: record.paneKey
+    })
+
+    if (!result || !result.resumedAgentTabId) {
+      throw new Error('selected folder agent did not receive a replacement tab')
+    }
+    expect(store.getState().tabsByWorktree[worktreeId]?.map((tab) => tab.id)).toEqual([
+      result.resumedAgentTabId
+    ])
+    expect(
+      store.getState().pendingStartupByTabId[result.resumedAgentTabId]?.resumeProviderSession
+    ).toEqual(record.providerSession)
+    expect(store.getState().sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()
   })
 
   // Why per AGENTS.md: the gate must hold on Windows/Linux Ctrl too, not just Cmd.

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -741,12 +741,15 @@ function queueSetupAndIssueCommands(
  * order must dispatch here — the folder branch is what enforces the path-status
  * gate that blocks a missing/unmounted/disconnected-SSH folder (#10716).
  */
-export function activateAndRevealWorkspace(workspaceId: string): ActivateAndRevealResult | false {
+export function activateAndRevealWorkspace(
+  workspaceId: string,
+  opts?: { executionHostId?: ExecutionHostId }
+): ActivateAndRevealResult | false {
   const workspaceScope = parseWorkspaceKey(workspaceId)
   if (workspaceScope?.type === 'folder') {
-    return activateAndRevealFolderWorkspace(workspaceScope.folderWorkspaceId)
+    return activateAndRevealFolderWorkspace(workspaceScope.folderWorkspaceId, opts)
   }
-  return activateAndRevealWorktree(workspaceId)
+  return activateAndRevealWorktree(workspaceId, opts)
 }
 
 // Why: break the import cycle — nav-history slice (under @/store) can't import activation directly, so register the activator here.

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -185,6 +185,32 @@ export type ActivateAndRevealResult = {
   /** Id of the primary terminal tab seeded with `opts.startup`, or null. Prefer this over
    *  `activeTabIdByWorktree`, which may point at another tab if setup/issue scripts opened their own. */
   primaryTabId: string | null
+  /** Fresh tab created for an explicitly selected completed agent. */
+  resumedAgentTabId?: string
+}
+
+type WorkspaceAgentResumeOptions = {
+  executionHostId?: ExecutionHostId
+  resumeCompletedPaneKey?: string
+}
+
+function resumeAgentsForWorkspace(
+  workspaceId: string,
+  opts?: WorkspaceAgentResumeOptions,
+  forceFreshSelectedCompletion = false
+): string | null {
+  let resumedTabId: string | null = null
+  resumeSleepingAgentSessionsForWorktree(workspaceId, {
+    ...(opts?.executionHostId ? { executionHostId: opts.executionHostId } : {}),
+    ...(opts?.resumeCompletedPaneKey
+      ? { resumeCompletedPaneKey: opts.resumeCompletedPaneKey }
+      : {}),
+    ...(forceFreshSelectedCompletion ? { forceFreshSelectedCompletion: true } : {}),
+    onSelectedCompletedSessionLaunched: (tabId) => {
+      resumedTabId = tabId
+    }
+  })
+  return resumedTabId
 }
 
 function ensureFolderWorkspaceInitialTerminal(
@@ -211,6 +237,7 @@ export function activateAndRevealFolderWorkspace(
     startup?: WorktreeStartupPayload
     runtimeEnvironmentId?: string | null
     executionHostId?: ExecutionHostId
+    resumeCompletedPaneKey?: string
   }
 ): ActivateAndRevealResult | false {
   const state = useAppStore.getState()
@@ -260,8 +287,12 @@ export function activateAndRevealFolderWorkspace(
   if (!state.isNavigatingHistory) {
     state.recordWorktreeVisit(workspaceKey)
   }
-  resumeSleepingAgentSessionsForWorktree(workspaceKey)
-  const primaryTabId = ensureFolderWorkspaceInitialTerminal(folderWorkspace, opts?.startup)
+  const resumedTabId = resumeAgentsForWorkspace(
+    workspaceKey,
+    opts,
+    Boolean(opts?.resumeCompletedPaneKey)
+  )
+  const ensuredTabId = ensureFolderWorkspaceInitialTerminal(folderWorkspace, opts?.startup)
 
   if (opts?.sidebarRevealBehavior) {
     state.revealWorktreeInSidebar(workspaceKey, { behavior: opts.sidebarRevealBehavior })
@@ -269,7 +300,10 @@ export function activateAndRevealFolderWorkspace(
     state.revealWorktreeInSidebar(workspaceKey)
   }
 
-  return { primaryTabId }
+  return {
+    primaryTabId: ensuredTabId,
+    ...(resumedTabId ? { resumedAgentTabId: resumedTabId } : {})
+  }
 }
 
 export function activateAndRevealWorktree(
@@ -284,6 +318,7 @@ export function activateAndRevealWorktree(
     notifyHostRuntime?: boolean
     revealInSidebar?: boolean
     executionHostId?: ExecutionHostId
+    resumeCompletedPaneKey?: string
     backendStartupTerminalSpawned?: boolean
   }
 ): ActivateAndRevealResult | false {
@@ -336,7 +371,7 @@ export function activateAndRevealWorktree(
   }
 
   // Why: sleeping destroys the local PTY but preserves the provider session id, so waking should restore those CLI sessions automatically.
-  resumeSleepingAgentSessionsForWorktree(worktreeId)
+  const resumedTabId = resumeAgentsForWorkspace(worktreeId, opts)
 
   // 4. Ensure a focusable surface exists for externally-created worktrees
   const primaryTabId = ensureWorktreeHasInitialTerminal(
@@ -382,7 +417,10 @@ export function activateAndRevealWorktree(
     ensureWebRuntimeWorktreeTerminalAfterWake(worktreeId)
   }
 
-  return { primaryTabId }
+  return {
+    primaryTabId,
+    ...(resumedTabId ? { resumedAgentTabId: resumedTabId } : {})
+  }
 }
 
 export function ensureWebRuntimeWorktreeTerminalAfterWake(worktreeId: string): void {
@@ -743,7 +781,7 @@ function queueSetupAndIssueCommands(
  */
 export function activateAndRevealWorkspace(
   workspaceId: string,
-  opts?: { executionHostId?: ExecutionHostId }
+  opts?: WorkspaceAgentResumeOptions
 ): ActivateAndRevealResult | false {
   const workspaceScope = parseWorkspaceKey(workspaceId)
   if (workspaceScope?.type === 'folder') {

--- a/src/renderer/src/store/slices/agent-status-provider-session.test.ts
+++ b/src/renderer/src/store/slices/agent-status-provider-session.test.ts
@@ -16,6 +16,61 @@ function makePiCompatibleProviderSession(agent: 'pi' | 'omp' | 'prime-agent') {
 }
 
 describe('recordAgentProviderSession', () => {
+  it('refreshes host provenance without downgrading a confirmed quit capture', () => {
+    const store = createTestStore()
+    const providerSession = { key: 'session_id' as const, id: 'claude-session-1' }
+    store.setState({
+      tabsByWorktree: {
+        'wt-1': [makeTab({ id: 'tab-1', worktreeId: 'wt-1' })]
+      }
+    } as Partial<AppState>)
+
+    store
+      .getState()
+      .setAgentStatus(
+        'tab-1:leaf-1',
+        { state: 'working', prompt: 'continue', agentType: 'claude' },
+        'Claude',
+        { updatedAt: 10, stateStartedAt: 10 },
+        { tabId: 'tab-1', worktreeId: 'wt-1', connectionId: 'ssh-1' },
+        { providerSession }
+      )
+    expect(store.getState().sleepingAgentSessionsByPaneKey['tab-1:leaf-1']?.executionHostId).toBe(
+      'ssh:ssh-1'
+    )
+
+    store
+      .getState()
+      .setAgentStatus(
+        'tab-1:leaf-1',
+        { state: 'working', prompt: 'continue', agentType: 'claude' },
+        'Claude',
+        { updatedAt: 20, stateStartedAt: 10 },
+        { tabId: 'tab-1', worktreeId: 'wt-1', connectionId: null },
+        { providerSession }
+      )
+    const localRecord = store.getState().sleepingAgentSessionsByPaneKey['tab-1:leaf-1']!
+    expect(localRecord.executionHostId).toBe('local')
+
+    store.setState({
+      sleepingAgentSessionsByPaneKey: {
+        'tab-1:leaf-1': {
+          ...localRecord,
+          connectionId: undefined,
+          executionHostId: undefined,
+          origin: 'quit'
+        }
+      }
+    } as Partial<AppState>)
+    store.getState().captureAllSleepingAgentSessions('periodic')
+
+    expect(store.getState().sleepingAgentSessionsByPaneKey['tab-1:leaf-1']).toMatchObject({
+      connectionId: null,
+      executionHostId: 'local',
+      origin: 'quit'
+    })
+  })
+
   it('preserves the root session while a child permission hook moves Codex to waiting', () => {
     const store = createTestStore()
     const providerSession = { key: 'session_id' as const, id: 'root-session' }
@@ -207,6 +262,7 @@ describe('recordAgentProviderSession', () => {
       agent: 'pi',
       providerSession,
       launchConfig,
+      executionHostId: 'local',
       origin: 'live'
     })
 

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -30,9 +30,11 @@ import { agentEntryCompletionAt } from '../../../../shared/agent-completion-time
 import type { TerminalPaneLayoutNode, TerminalTab } from '../../../../shared/terminal-tab-types'
 import {
   getRepoExecutionHostId,
-  getWorktreeExecutionHostId
+  getWorktreeExecutionHostId,
+  toSshExecutionHostId
 } from '../../../../shared/execution-host'
 import { isExplicitAgentStatusFresh } from '@/lib/agent-status'
+import { getExecutionHostIdForWorktree } from '@/lib/worktree-runtime-owner'
 import {
   getAgentRowGeneratedTitleText,
   getOrcaDispatchTaskId,
@@ -598,6 +600,9 @@ function sleepingRecordFromEntry(args: {
     return null
   }
   const tab = args.tab ?? findTabForAgentEntry(args.state, args.worktreeId, args.entry)
+  const executionHostId = args.entry.connectionId?.trim()
+    ? toSshExecutionHostId(args.entry.connectionId)
+    : getExecutionHostIdForWorktree(args.state, args.worktreeId)
   return {
     paneKey: args.entry.paneKey,
     ...(tab ? { tabId: tab.id } : {}),
@@ -608,6 +613,8 @@ function sleepingRecordFromEntry(args: {
     state: args.entry.state,
     capturedAt: args.capturedAt,
     updatedAt: args.entry.updatedAt,
+    ...(args.entry.connectionId !== undefined ? { connectionId: args.entry.connectionId } : {}),
+    executionHostId,
     ...((args.entry.terminalTitle ?? tab?.title)
       ? { terminalTitle: (args.entry.terminalTitle ?? tab?.title)! }
       : {}),
@@ -878,6 +885,8 @@ function sleepingRecordsEquivalentIgnoringCaptureTime(
     existing.terminalTitle === next.terminalTitle &&
     existing.lastAssistantMessage === next.lastAssistantMessage &&
     existing.interrupted === next.interrupted &&
+    existing.connectionId === next.connectionId &&
+    existing.executionHostId === next.executionHostId &&
     existing.origin === next.origin &&
     launchConfigsEqual(existing.launchConfig, next.launchConfig)
   )
@@ -895,6 +904,8 @@ function recoveryRecordMatches(
     existing.agent === next.agent &&
     existing.worktreeId === next.worktreeId &&
     existing.tabId === next.tabId &&
+    existing.connectionId === next.connectionId &&
+    existing.executionHostId === next.executionHostId &&
     agentProviderSessionsEqual(existing.agent, existing.providerSession, next.providerSession) &&
     launchConfigsEqual(existing.launchConfig, next.launchConfig)
   )
@@ -907,6 +918,20 @@ function recoveryRecordTargetsSameSession(
   if (!existing) {
     return false
   }
+  return (
+    existing.agent === next.agent &&
+    existing.worktreeId === next.worktreeId &&
+    existing.tabId === next.tabId &&
+    existing.connectionId === next.connectionId &&
+    existing.executionHostId === next.executionHostId &&
+    agentProviderSessionsEqual(existing.agent, existing.providerSession, next.providerSession)
+  )
+}
+
+function recoveryRecordHasSameProviderSession(
+  existing: SleepingAgentSessionRecord,
+  next: SleepingAgentSessionRecord
+): boolean {
   return (
     existing.agent === next.agent &&
     existing.worktreeId === next.worktreeId &&
@@ -1827,6 +1852,13 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         const launchConfig =
           (registryMatches ? registryEntry?.launchConfig : undefined) ??
           (existingRecordMatchesProviderSession ? existingRecord.launchConfig : undefined)
+        const connectionId =
+          routing?.connectionId !== undefined ? routing.connectionId : existingRecord?.connectionId
+        const executionHostId = connectionId?.trim()
+          ? toSshExecutionHostId(connectionId)
+          : routing?.connectionId === undefined && existingRecord?.executionHostId
+            ? existingRecord.executionHostId
+            : getExecutionHostIdForWorktree(s, worktreeId)
         const record: SleepingAgentSessionRecord = {
           paneKey,
           ...(tabId ? { tabId } : {}),
@@ -1838,16 +1870,13 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
           state: 'working',
           capturedAt: updatedAt,
           updatedAt,
+          executionHostId,
           ...(existingStatus?.terminalTitle
             ? { terminalTitle: existingStatus.terminalTitle }
             : existingRecord?.terminalTitle
               ? { terminalTitle: existingRecord.terminalTitle }
               : {}),
-          ...(routing?.connectionId !== undefined
-            ? { connectionId: routing.connectionId }
-            : existingRecord?.connectionId !== undefined
-              ? { connectionId: existingRecord.connectionId }
-              : {}),
+          ...(connectionId !== undefined ? { connectionId } : {}),
           ...(launchConfig ? { launchConfig: copyLaunchConfig(launchConfig) } : {}),
           ...(existingRecordMatchesProviderSession &&
           existingRecord.automaticResumeBlockedBy === 'legacy-orchestration-worker'
@@ -2129,7 +2158,9 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
             ? { connectionId: routing.connectionId }
             : existing?.connectionId !== undefined
               ? { connectionId: existing.connectionId }
-              : {}),
+              : existingSleepingRecord?.connectionId !== undefined
+                ? { connectionId: existingSleepingRecord.connectionId }
+                : {}),
           tabId: statusTabId,
           terminalTitle: effectiveTitle,
           stateHistory: history,
@@ -3104,8 +3135,18 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
             mode === 'periodic' &&
             existing?.origin === 'quit' &&
             record &&
-            recoveryRecordTargetsSameSession(existing, record)
+            recoveryRecordHasSameProviderSession(existing, record)
           ) {
+            if (!recoveryRecordTargetsSameSession(existing, record)) {
+              next[entry.paneKey] = {
+                ...existing,
+                ...(record.connectionId !== undefined
+                  ? { connectionId: record.connectionId }
+                  : { connectionId: undefined }),
+                executionHostId: record.executionHostId
+              }
+              changed = true
+            }
             continue
           }
           if (record && !sleepingRecordsEquivalentIgnoringCaptureTime(existing, record)) {

--- a/src/shared/agent-session-resume.ts
+++ b/src/shared/agent-session-resume.ts
@@ -1,5 +1,6 @@
 import type { AgentHookSource } from './agent-hook-relay'
 import type { AgentStatusState } from './agent-status-types'
+import type { ExecutionHostId } from './execution-host'
 import type { TuiAgent } from './tui-agent'
 
 export const RESUMABLE_TUI_AGENTS = [
@@ -54,6 +55,7 @@ export type SleepingAgentSessionRecord = {
   lastAssistantMessage?: string
   interrupted?: boolean
   connectionId?: string | null
+  executionHostId?: ExecutionHostId
   launchConfig?: SleepingAgentLaunchConfig
   /** How the record was captured. Worktree-sleep records (legacy records have
    *  no origin) are consumed by worktree activation, which opens a fresh tab.

--- a/src/shared/dashboard-snapshot.ts
+++ b/src/shared/dashboard-snapshot.ts
@@ -212,6 +212,8 @@ export type DashboardRevealAgentArgs = {
   executionHostId?: ExecutionHostId
   tabId: string
   leafId: string | null
+  /** Optional for mixed-version pop-outs; identifies retained resume evidence. */
+  paneKey?: string
 }
 
 export type DashboardSpawnAgentArgs = {

--- a/src/shared/workspace-session-schema.sleeping-agent.test.ts
+++ b/src/shared/workspace-session-schema.sleeping-agent.test.ts
@@ -359,6 +359,37 @@ describe('parseWorkspaceSession sleeping agents', () => {
     }
   })
 
+  it('preserves sleeping agent execution host provenance across hydration', () => {
+    const result = parseWorkspaceSession({
+      activeRepoId: null,
+      activeWorktreeId: null,
+      activeTabId: null,
+      tabsByWorktree: {},
+      terminalLayoutsByTabId: {},
+      sleepingAgentSessionsByPaneKey: {
+        'tab1:pane-1': {
+          paneKey: 'tab1:pane-1',
+          tabId: 'tab1',
+          worktreeId: 'wt',
+          agent: 'claude',
+          providerSession: { key: 'session_id', id: 'claude-session' },
+          prompt: 'continue',
+          state: 'working',
+          capturedAt: 10,
+          updatedAt: 10,
+          executionHostId: 'runtime:env-1'
+        }
+      }
+    })
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value.sleepingAgentSessionsByPaneKey?.['tab1:pane-1']?.executionHostId).toBe(
+        'runtime:env-1'
+      )
+    }
+  })
+
   it('preserves interrupted sleeping agent records across hydration', () => {
     const result = parseWorkspaceSession({
       activeRepoId: null,

--- a/src/shared/workspace-session-sleeping-agents.ts
+++ b/src/shared/workspace-session-sleeping-agents.ts
@@ -5,6 +5,8 @@ import {
   RESUMABLE_TUI_AGENTS
 } from './agent-session-resume'
 import { isValidTerminalTabId } from './terminal-tab-id'
+import { normalizeExecutionHostId } from './execution-host'
+import type { ExecutionHostId } from './execution-host'
 import { salvagingRecord } from './zod-salvage'
 
 const terminalTabIdSchema = z
@@ -77,6 +79,15 @@ const sleepingAgentLaunchConfigBaseSchema = z.object({
     .optional()
 })
 
+const executionHostIdSchema = z.preprocess(
+  (raw) => (typeof raw === 'string' ? (normalizeExecutionHostId(raw) ?? undefined) : undefined),
+  z
+    .custom<ExecutionHostId>(
+      (value) => typeof value === 'string' && normalizeExecutionHostId(value) === value
+    )
+    .optional()
+)
+
 export const sleepingAgentLaunchConfigSchema = z.preprocess((raw) => {
   const parsed = sleepingAgentLaunchConfigBaseSchema.safeParse(raw)
   return parsed.success ? parsed.data : undefined
@@ -97,6 +108,7 @@ const sleepingAgentSessionRecordSchema = z
     lastAssistantMessage: z.string().optional(),
     interrupted: z.boolean().optional(),
     connectionId: z.string().nullable().optional(),
+    executionHostId: executionHostIdSchema,
     launchConfig: sleepingAgentLaunchConfigSchema.optional(),
     origin: z.enum(['worktree-sleep', 'quit', 'live']).optional(),
     automaticResumeBlockedBy: z.enum(['legacy-orchestration-worker']).optional(),


### PR DESCRIPTION
## ELI5

The Agent Map could show a finished Claude/Codex card as **Idle** with “No live terminal — this agent’s pane has closed,” but **Open worktree** only navigated to the workspace. It did not recreate the selected agent’s terminal. This change carries the selected pane identity through reveal and resumes that one retained session while leaving ordinary workspace activation passive.

## What Changed

- Route Agent Map, dashboard, and sidebar agent reveals through one `revealAgentPane` path.
- Add the optional selected `paneKey` to the dashboard reveal payload and validate it at the IPC boundary.
- Resume only the explicitly selected retained completed session; generic workspace activation still does not restart completed history.
- Focus the replacement resume tab when the original pane no longer exists.
- Persist optional execution-host provenance on sleeping records and scope records before validation, ownership, clearing, dedupe, or launch.
- Preserve folder-workspace, execution-host, SSH fallback, non-local WSL resolution, and legacy-record behavior.
- Deduplicate against live PTYs, queued startups, provider-session claims, and an old PTY still shutting down.

## Why

The original dashboard handlers called the raw active-worktree setter. That skipped the activation/resume flow, and a `folder:<id>` workspace key was a silent no-op. Routing through workspace activation fixed navigation, but the reported retained completed card was deliberately passive history and still would not wake. The final behavior uses the user’s explicit card selection as the narrow authorization to resume only that session.

Host provenance is required because local, SSH, runtime, and folder workspaces can have identical IDs. Without it, selecting one host could resume or clear another host’s sleeping record.

## Scope

This stays focused on explicit agent reveal and host-safe sleeping-session recovery. It does not make worktree switching restart completed agents, add background polling, change remote wire formats, or touch mobile behavior.

## Linked Issue

No filed issue; this came from a direct report with a screenshot of the Agent Map panel stuck on “No live terminal — this agent’s pane has closed.”

## Visual Proof

Captured in an isolated Electron profile through Playwright CDP at `da1caf1b78afc4c076d1fd5f4987ceb3d396fb6e`. Final head `4ac77094dde72b0d2e2a4f1a4afeb0b1e02420fa` adds host provenance/scoping without changing the rendered UI.

### Git worktree retained completion

Before — acknowledged retained Claude card, **Idle**, no live terminal:

![Agent Map retained Idle card](https://github.com/user-attachments/assets/541c99eb-9379-44b8-9bea-e46b31af5b4c)

After — focused replacement `claude · resume` terminal:

![Replacement Claude resume terminal](https://github.com/user-attachments/assets/288289a6-da72-4e37-8b56-d59a90558b31)

### Folder-workspace retained completion

Before:

![Folder workspace retained Idle card](https://github.com/user-attachments/assets/3b2299ab-2b5c-42b3-9276-eac876c7059c)

After:

![Folder workspace replacement terminal](https://github.com/user-attachments/assets/bb15a2f2-ef71-438b-a73a-b3667e017001)

Full UI backing-state evidence: https://github.com/stablyai/orca/pull/14646#issuecomment-5300011349

## Testing

- Earlier full-suite review run: 52,366 tests across 4,878 files.
- Final-head host/resume/capture suite: 136/136 tests.
- Post-commit host-collision suite: 6/6 tests.
- `pnpm typecheck`
- standard and type-aware lint; full lint pipeline
- max-lines ratchet, reliability, and diff checks
- Same-model review loop: `CLEAN`.
- Closing readiness checklist: `CLEAN`, no P0/P1/P2 findings.
- Live Electron QA for git worktree and folder workspace: selected sleeping record consumed, exact provider-session claim attached to the new tab, and exactly one live PTY with no duplicate wake.

One combined agent-status performance test timed out under concurrent validation load; that exact test passed independently in 13.12 seconds.

## Review Notes

- **Security:** renderer navigation/session selection only; no new network, dependency, or shell-input surface.
- **Performance:** user-click-only bounded lookups; no polling, listeners, timers, subprocesses, or growing caches.
- **Cross-platform:** no platform-specific path, shortcut, shell, or native behavior added.
- **SSH/remote:** execution-host identity is persisted and enforced locally; no RPC or wire-format change.
- **Mobile/backwards compatibility:** `executionHostId` and `paneKey` are optional; legacy records are salvaged conservatively and no mobile-facing contract changed.

## Checklist

- [x] Focused on the reported agent-reveal failure
- [x] Meaningful regression tests added
- [x] Before/after Electron proof attached
- [x] Correctness, concurrency, performance, security, remote, host-collision, and folder-workspace behavior reviewed
- [x] Tests, lint, typecheck, and release gates pass locally

## Author

- X / Twitter: @BrennanKB5
