### PR TITLE
fix(agents): surface Qwen Code panes via a declared identity frame (STA-2840)

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -258,6 +258,61 @@ describe('buildTitleDerivedAgentRows', () => {
     expect(rows).toHaveLength(0)
   })
 
+  // Why: qwen-code 0.21.12 posts no hooks and titles itself `Qwen - <cwd>` (80-char
+  // padded), so the title path is the only thing that can list the pane (STA-2840 / #11148).
+  it('adds rows for Qwen panes titled with the cwd suffix the CLI actually writes', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { title: 'Qwen - orca' })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        'tab-1': {
+          1: 'Qwen - orca'.padEnd(80, ' '),
+          2: '\u25D0\uFE0E Qwen - orca'.padEnd(80, ' ')
+        }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-left', 'pty-right'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSplitLayout() },
+      now: 2000
+    })
+
+    expect(rows.map((row) => [row.agentType, row.state])).toEqual([
+      ['qwen-code', 'idle'],
+      ['qwen-code', 'working']
+    ])
+  })
+
+  // Why: `\u2733` is Claude's idle glyph but Qwen's await-confirmation glyph; the pane
+  // must surface as Qwen needing input, not as an idle Claude row.
+  it('surfaces a confirming Qwen pane as qwen-code awaiting permission', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { title: 'Qwen - orca' })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: { 'tab-1': { 1: '\u2733\uFE0E Qwen - orca'.padEnd(80, ' ') } },
+      ptyIdsByTabId: { 'tab-1': ['pty-qwen'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(rows.map((row) => [row.agentType, row.state])).toEqual([['qwen-code', 'waiting']])
+    expect(rows[0]?.paneKey).toBe(makePaneKey('tab-1', LEAF_ID_1))
+  })
+
+  it('keeps a qwen-named worktree path out of the sidebar', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { title: '~/orca/workspaces/qwen-scratch' })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: { 'tab-1': { 1: '~/orca/workspaces/qwen-scratch' } },
+      ptyIdsByTabId: { 'tab-1': ['pty-shell'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(rows).toHaveLength(0)
+  })
+
   it('attributes a spinner-only title to the launched agent when the title has no identity', () => {
     const launchAgent: TuiAgent = 'codex'
     const rows = buildWorktreeAgentRows({

--- a/src/shared/agent-identity-frame.test.ts
+++ b/src/shared/agent-identity-frame.test.ts
@@ -6,7 +6,10 @@ import {
   resolveAgentIdentityFrameType
 } from './agent-identity-frame'
 import { getAgentLabel } from './agent-title-identity'
-import { detectAgentStatusFromTitle } from './agent-title-status'
+import {
+  detectAgentStatusFromTitle,
+  isQuarterCircleSpinnerOnlyAgentTitle
+} from './agent-title-status'
 import {
   isClaudeIdentityFrameTitle,
   resolveExplicitTerminalTitleAgentType,
@@ -178,6 +181,14 @@ describe('Qwen Code title visibility (STA-2840 / #11148)', () => {
     )
     // Why: qwen falls back to its own name when the cwd basename is empty.
     expect(resolveAgentIdentityFrameType('Qwen - qwen')).toBe('qwen-code')
+  })
+
+  // Why: `◐` proves activity, not identity — but a title that also carries the agent's own
+  // name is not spinner-only, and Qwen must agree with Claude here (STA-4028 / #13925).
+  it('does not read a named Qwen frame as spinner-only evidence', () => {
+    expect(isQuarterCircleSpinnerOnlyAgentTitle(RESPONDING)).toBe(false)
+    expect(isQuarterCircleSpinnerOnlyAgentTitle('◐ Claude Code')).toBe(false)
+    expect(isQuarterCircleSpinnerOnlyAgentTitle('◐ building')).toBe(true)
   })
 
   // Why: the registry is shared — prove the neighbours it already carried still hold.

--- a/src/shared/agent-identity-frame.test.ts
+++ b/src/shared/agent-identity-frame.test.ts
@@ -169,6 +169,17 @@ describe('Qwen Code title visibility (STA-2840 / #11148)', () => {
     expect(isAgentIdentityFrameTitleFor('Qwen-orca', 'qwen-code')).toBe(false)
   })
 
+  // Why: inside a multiplexer Qwen writes OSC 2 only and skips the padding, and a long
+  // cwd is truncated at 80 chars mid-name — both must still resolve to the same agent.
+  it('resolves the unpadded multiplexer form and an 80-char-truncated cwd', () => {
+    expect(resolveAgentIdentityFrameType('zsh | Qwen - orca')).toBe('qwen-code')
+    expect(resolveAgentIdentityFrameType(`Qwen - ${'a'.repeat(200)}`.slice(0, 80))).toBe(
+      'qwen-code'
+    )
+    // Why: qwen falls back to its own name when the cwd basename is empty.
+    expect(resolveAgentIdentityFrameType('Qwen - qwen')).toBe('qwen-code')
+  })
+
   // Why: the registry is shared — prove the neighbours it already carried still hold.
   it('leaves the agents already in the registry unchanged', () => {
     expect(resolveAgentIdentityFrameType('Cline')).toBe('cline')

--- a/src/shared/agent-identity-frame.test.ts
+++ b/src/shared/agent-identity-frame.test.ts
@@ -110,3 +110,73 @@ describe('isClaudeIdentityFrameTitle after the shared-builder move', () => {
     }
   })
 })
+
+// Observed against qwen-code 0.21.12 under a pty: OSC 0 is `Qwen - <cwd basename>`
+// padded to 80 chars, prefixed with `◐︎` while responding and `✳︎` while awaiting
+// confirmation. Every literal below is a real captured payload (STA-2840 / #11148).
+describe('Qwen Code title visibility (STA-2840 / #11148)', () => {
+  const pad = (title: string): string => title.padEnd(80, ' ')
+  const IDLE = pad('Qwen - scratchdir')
+  const RESPONDING = pad('◐︎ Qwen - scratchdir')
+  const CONFIRMING = pad('✳︎ Qwen - scratchdir')
+
+  it('claims the name-plus-cwd frame the CLI actually writes, padding included', () => {
+    for (const title of [IDLE, RESPONDING, CONFIRMING]) {
+      expect(resolveAgentIdentityFrameType(title)).toBe('qwen-code')
+    }
+    expect(getAgentLabel(IDLE)).toBe('Qwen Code')
+    expect(resolveTerminalTitleAgentType(IDLE)).toBe('qwen-code')
+  })
+
+  // Why: this is the whole bug — a responding pane was resolving to Claude because
+  // `◐` is a quarter-circle spinner and nothing else claimed the title first.
+  it('stops a responding Qwen pane from being attributed to Claude', () => {
+    expect(getAgentLabel(RESPONDING)).toBe('Qwen Code')
+    expect(resolveTerminalTitleAgentType(RESPONDING)).toBe('qwen-code')
+    expect(isClaudeIdentityFrameTitle(RESPONDING)).toBe(false)
+  })
+
+  it('maps the declared glyphs to status, including the ✳ that means idle for Claude', () => {
+    expect(detectAgentStatusFromTitle(IDLE)).toBe('idle')
+    expect(detectAgentStatusFromTitle(RESPONDING)).toBe('working')
+    expect(detectAgentStatusFromTitle(CONFIRMING)).toBe('permission')
+    // Why: the same glyph must keep meaning idle for the agent that declares no glyphs.
+    expect(detectAgentStatusFromTitle('✳ Claude Code')).toBe('idle')
+  })
+
+  it('rejects the name in task text, a path, or a hyphenated compound', () => {
+    for (const title of [
+      'qwen-code-fixtures ready',
+      '~/qwen/working',
+      'src/qwen/index.ts',
+      'port the qwen prompt'
+    ]) {
+      expect(resolveAgentIdentityFrameType(title)).toBeNull()
+      expect(detectAgentStatusFromTitle(title)).toBeNull()
+    }
+  })
+
+  it('keeps Claude task text that mentions qwen as Claude', () => {
+    expect(getAgentLabel('⠋ ask qwen about the parser')).toBe('Claude Code')
+    expect(resolveTerminalTitleAgentType('⠋ ask qwen about the parser')).toBe('claude')
+  })
+
+  // Why: the context suffix must not swallow arbitrary trailing prose.
+  it('accepts only a separated context tail, never free-form trailing text', () => {
+    expect(isAgentIdentityFrameTitleFor('Qwen - orca', 'qwen-code')).toBe(true)
+    expect(isAgentIdentityFrameTitleFor('Qwen', 'qwen-code')).toBe(true)
+    expect(isAgentIdentityFrameTitleFor('Qwen fix the parser', 'qwen-code')).toBe(false)
+    expect(isAgentIdentityFrameTitleFor('Qwen-orca', 'qwen-code')).toBe(false)
+  })
+
+  // Why: the registry is shared — prove the neighbours it already carried still hold.
+  it('leaves the agents already in the registry unchanged', () => {
+    expect(resolveAgentIdentityFrameType('Cline')).toBe('cline')
+    expect(detectAgentStatusFromTitle('Cline')).toBe('idle')
+    expect(resolveAgentIdentityFrameType('Claude Code')).toBe('claude')
+    expect(isClaudeIdentityFrameTitle('zsh | ⠋ Claude Code')).toBe(true)
+    // Why: a context suffix is opt-in; cline must not start accepting `Cline - foo`.
+    expect(isAgentIdentityFrameTitleFor('Cline - the parser', 'cline')).toBe(false)
+    expect(AGENT_IDENTITY_FRAMES.amp).toBeUndefined()
+  })
+})

--- a/src/shared/agent-identity-frame.ts
+++ b/src/shared/agent-identity-frame.ts
@@ -14,6 +14,7 @@
  * (#8940). Anchoring the whole title is what separates the two.
  */
 import { stripLeadingAgentTitleDecorationOrEmpty } from './agent-title-decoration'
+import type { AgentStatus } from './agent-title-core'
 import { getWrapperTitleSegments } from './terminal-title-wrapper-segments'
 import type { TuiAgent } from './tui-agent'
 
@@ -24,18 +25,32 @@ const IDENTITY_STATUS_WORDS = ['ready', 'idle', 'done', 'working', 'thinking', '
 // Why: Windows titles can surface the launcher process name (`cline.cmd`).
 const EXECUTABLE_SUFFIX = String.raw`(?:\.(?:exe|cmd|bat|ps1))?`
 
+// Why: some CLIs append their working directory to their own name (`Qwen - orca`).
+// The separator must carry whitespace on both sides so a hyphenated compound
+// (`qwen-code-fixtures`) stays a path, not an identity.
+const CONTEXT_SUFFIX = String.raw`(?:\s+-\s+\S.*)?`
+
 export type AgentIdentityFrameSpec = {
   /** Lowercase names the agent presents itself under, longest first. */
   names: readonly string[]
   /** Accept a Windows launcher extension after the name. */
   executableSuffix?: boolean
+  /** Accept free-form context the agent appends after ` - ` (its cwd, typically). */
+  contextSuffix?: boolean
+  /**
+   * Leading glyphs the agent writes to mean a status of its own. Declared per agent
+   * because the same glyph differs across CLIs — `✳` is Claude's idle marker but
+   * Qwen's await-confirmation marker.
+   */
+  statusGlyphs?: Readonly<Record<string, AgentStatus>>
 }
 
 export function buildAgentIdentityFrameRe(spec: AgentIdentityFrameSpec): RegExp {
   const names = spec.names.map((name) => name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')
   const suffix = spec.executableSuffix ? EXECUTABLE_SUFFIX : ''
+  const context = spec.contextSuffix ? CONTEXT_SUFFIX : ''
   return new RegExp(
-    `^(?:${names})${suffix}(?:\\s+(?:${IDENTITY_STATUS_WORDS.join('|')}))?(?:\\s*-\\s*action required)?$`
+    `^(?:${names})${suffix}(?:\\s+(?:${IDENTITY_STATUS_WORDS.join('|')}))?(?:\\s*-\\s*action required)?${context}$`
   )
 }
 
@@ -48,7 +63,15 @@ export const AGENT_IDENTITY_FRAMES: Partial<Record<TuiAgent, AgentIdentityFrameS
   claude: { names: ['claude code', 'claude'] },
   // Verified against cline 3.0.55: it emits OSC 0 `Cline` and never varies it,
   // so Orca sees identity but no status transitions (STA-3906).
-  cline: { names: ['cline'], executableSuffix: true }
+  cline: { names: ['cline'], executableSuffix: true },
+  // Verified against qwen-code 0.21.12: OSC 0 is `Qwen - <cwd basename>`, padded to
+  // 80 chars, re-emitted on each turn with a leading `◐` while responding and `✳`
+  // while awaiting confirmation (STA-2840 / #11148).
+  'qwen-code': {
+    names: ['qwen'],
+    contextSuffix: true,
+    statusGlyphs: { '◐': 'working', '✳': 'permission' }
+  }
 }
 
 const IDENTITY_FRAME_RES = new Map<TuiAgent, RegExp>(
@@ -76,6 +99,34 @@ export function isAgentIdentityFrameTitleFor(
   return getWrapperTitleSegments(title).some((segment) =>
     re.test(stripLeadingAgentTitleDecorationOrEmpty(segment).trim().toLowerCase())
   )
+}
+
+/**
+ * The status a registry-declared agent claims through its own leading glyph, or null
+ * when the agent declares none. Gated on the identity frame so a glyph inside somebody
+ * else's task text can never mint a status.
+ */
+export function resolveAgentIdentityFrameStatus(
+  title: string | null | undefined
+): AgentStatus | null {
+  if (typeof title !== 'string') {
+    return null
+  }
+  for (const [agent, spec] of Object.entries(AGENT_IDENTITY_FRAMES)) {
+    const glyphs = spec?.statusGlyphs
+    if (!glyphs || !isAgentIdentityFrameTitleFor(title, agent as TuiAgent)) {
+      continue
+    }
+    for (const segment of getWrapperTitleSegments(title)) {
+      const leading = segment.trimStart()
+      for (const [glyph, status] of Object.entries(glyphs)) {
+        if (leading.startsWith(glyph)) {
+          return status
+        }
+      }
+    }
+  }
+  return null
 }
 
 /** The agent a title presents, or null when the title is task text, a path, or a bare shell title. */

--- a/src/shared/agent-title-decoration.ts
+++ b/src/shared/agent-title-decoration.ts
@@ -3,9 +3,14 @@
 // and Claude's '. '/'* ' working/idle prefixes. Once the tab bar shows the
 // provider icon, this leading glyph reads as a redundant second icon, so strip
 // it from the displayed title. Scoped to titles we already know belong to an agent.
+//
+// Why the trailing selector: Qwen Code writes its glyphs text-presentation-qualified
+// (`◐` + U+FE0E). Left behind, that invisible character stays glued to the front of
+// the title and stops the name matching its identity frame - so absorb it per glyph
+// rather than inside the class, where it would read as a combining sequence.
 const LEADING_AGENT_TITLE_DECORATION_RE =
   // eslint-disable-next-line no-control-regex -- intentional unicode status-glyph ranges
-  /^(?:[✳✦⏲◇✋⠀-⣿◐-◓]+|[.*]\s)\s*/
+  /^(?:(?:[✳✦⏲◇✋⠀-⣿◐-◓][\uFE0E\uFE0F]?)+|[.*]\s)\s*/
 
 export function stripLeadingAgentTitleDecorationOrEmpty(title: string): string {
   return title.replace(LEADING_AGENT_TITLE_DECORATION_RE, '').trimStart()

--- a/src/shared/agent-title-decoration.ts
+++ b/src/shared/agent-title-decoration.ts
@@ -7,10 +7,12 @@
 // Why the trailing selector: Qwen Code writes its glyphs text-presentation-qualified
 // (`◐` + U+FE0E). Left behind, that invisible character stays glued to the front of
 // the title and stops the name matching its identity frame - so absorb it per glyph
-// rather than inside the class, where it would read as a combining sequence.
+// rather than inside the class, where it would read as a combining sequence. The lone
+// selector branch catches what callers leave behind when they strip a spinner themselves
+// (isQuarterCircleSpinnerOnlyAgentTitle), which would otherwise orphan it at the front.
 const LEADING_AGENT_TITLE_DECORATION_RE =
   // eslint-disable-next-line no-control-regex -- intentional unicode status-glyph ranges
-  /^(?:(?:[✳✦⏲◇✋⠀-⣿◐-◓][\uFE0E\uFE0F]?)+|[.*]\s)\s*/
+  /^(?:(?:[✳✦⏲◇✋⠀-⣿◐-◓][\uFE0E\uFE0F]?)+|[\uFE0E\uFE0F]+|[.*]\s)\s*/
 
 export function stripLeadingAgentTitleDecorationOrEmpty(title: string): string {
   return title.replace(LEADING_AGENT_TITLE_DECORATION_RE, '').trimStart()

--- a/src/shared/agent-title-status.ts
+++ b/src/shared/agent-title-status.ts
@@ -1,4 +1,7 @@
-import { resolveAgentIdentityFrameType } from './agent-identity-frame'
+import {
+  resolveAgentIdentityFrameStatus,
+  resolveAgentIdentityFrameType
+} from './agent-identity-frame'
 import {
   AGY_AGENT_NAME_RE,
   BRAILLE_SPINNER_RE,
@@ -182,6 +185,13 @@ export function detectAgentStatusFromTitle(title: string): AgentStatus | null {
   const piCompatibleSyntheticAgentStatus = getPiCompatibleSyntheticAgentStatus(title)
   if (piCompatibleSyntheticAgentStatus) {
     return piCompatibleSyntheticAgentStatus
+  }
+
+  // Why: an agent that declares its own status glyphs outranks the shared vocabulary
+  // below — Qwen's await-confirmation `✳` is the same glyph Claude uses for idle.
+  const identityFrameStatus = resolveAgentIdentityFrameStatus(title)
+  if (identityFrameStatus) {
+    return identityFrameStatus
   }
 
   if (title.startsWith(`${CLAUDE_IDLE} `) || title === CLAUDE_IDLE) {


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked on #14634** (`base = brennanb2025/runtime-visibility-cline-13823`), because this
> registers into the identity-frame registry that #14634 introduces and which is not yet on `main`.
> **Retarget this PR to `main` before merging it** — a stacked PR merged into an already-merged
> parent branch reports `MERGED` with green checks while delivering nothing to `main`.
> The diff below is this PR's own commit only.

## ELI5

Qwen Code was running fine in a terminal but never showed up in the workspace agent
list. Orca decides "which agent is this pane?" by reading the terminal title, and
nobody had ever checked what title Qwen actually writes. It writes `Qwen - <folder>`.
Orca was looking for the word `Qwen` on its own, so an idle Qwen pane matched nothing —
and a *busy* Qwen pane got mistaken for Claude, because Qwen's "thinking" glyph `◐` is
one Orca already treats as a generic spinner.

## What Changed

Registers `qwen-code` in the identity-frame registry from #14634 instead of adding a
sixth hand-copied predicate. Two new **declared** options carry the ways Qwen differs
from Cline:

- `contextSuffix` — accept the cwd the CLI appends after ` - `. The separator requires
  whitespace on both sides, so `qwen-code-fixtures` stays a path, not an identity.
- `statusGlyphs` — a per-agent glyph→status map, because the same glyph does not mean
  the same thing across CLIs: `✳` is **idle** for Claude but **await-confirmation** for Qwen.

Also absorbs the variation selector Qwen writes after its glyphs (`◐` + U+FE0E) in the
leading-decoration strip — one optional selector per glyph, plus a lone-selector branch.
Without the first, the leftover invisible character stopped the name matching its frame.
Without the second, `isQuarterCircleSpinnerOnlyAgentTitle` (which strips the spinner itself
and re-tests the remainder) orphaned the selector and classified a *named* Qwen pane as
spinner-only evidence, which `◐ Claude Code` is not. Pinned by test.

## Why

**Observed, not assumed.** Ground truth captured from the real `qwen-code@0.21.12`
binary under a `pty.fork` (the issue reports 0.21.0):

```
OSC 0 => "Qwen - scratchdir" + spaces, padded to 80 chars
```

and from `packages/cli/src/ui/utils/windowTitle.ts` in the shipped bundle:
`Qwen - ${folderName}`, with `titleStatusPrefix()` prepending `◐` while responding
and `✳` while awaiting confirmation.

Measured behaviour on `main` before this change:

| Real title | label | agent type | verdict |
| --- | --- | --- | --- |
| `Qwen - scratchdir` | `null` | `null` | invisible |
| `◐︎ Qwen - scratchdir` | **`Claude Code`** | **`claude`** | **mislabelled as Claude** |
| `✳︎ Qwen - scratchdir` | `null` | `null` | invisible |

The mislabel is the more serious half and neither open PR noticed it.

**Supersedes #11186** — it maps the literal label `Qwen Code` and adds `qwen` to
`AGENT_NAMES`. The CLI never emits `Qwen Code`, so that table entry is dead on arrival;
its `Qwen Code` / `⠋ Qwen Code` / `qwen ready` test titles are invented. The part that
would have worked is the `AGENT_NAMES` token match — which is exactly what that module's
own comment warns against, and which places the check *before* `isClaudeAgent`, so a
Claude pane titled `⠋ ask qwen about the parser` gets rebranded Qwen (#8940).

**Overlaps — but does not supersede — #12555.** That PR is sound and I want to correct the
record on it: qwen-code really does ship hooks (`settings.json` → `hooks.UserPromptSubmit`,
`PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `Stop`), so its managed-hook service is
built on a real mechanism, and its `isQwenNativeTitle` independently identified the same
`qwen` / `qwen - <dir>` frame this PR registers.

The two are complementary: hooks give authoritative status once Orca has installed them,
this gives identity and status for every pane that has not. Where they genuinely differ is
that #12555 states the Qwen title "never varies by state" and keeps `qwen` out of the status
path for that reason — the capture above shows it *does* vary (`◐` responding, `✳` awaiting
confirmation), which is what makes title-only status possible here. If #12555 lands, its
`isQwenNativeTitle` / `QWEN_AGENT_NAME_RE` / `isQwenBrailleSyntheticTitle` trio should collapse
into this one registry row; its `QWEN_AGENT_NAME_RE` token match is the piece worth dropping,
since a bare `qwen` token can still be a mention.

## Linked Issue

Fixes #11148

## Visual Proof

N/A — this adds no UI. The sidebar row component is untouched; the change only alters
which agent an existing row is attributed to, and that attribution is asserted directly
in `worktree-title-derived-agent-rows.test.ts` against the exact captured OSC payload.

The behavioural evidence is the pty capture from the real binary rather than a screenshot:

```
$ python3 capture.py          # pty.fork around qwen-code@0.21.12
CHILD_PID=17396
OSC b'11;?'
OSC b'0;Qwen - scratchdir                                                               '
OSC b'2;Qwen - scratchdir                                                               '
```

An end-to-end screenshot would additionally need Qwen credentials for a live turn, which
this machine does not have.

## Testing

`pnpm vitest run --config config/vitest.config.ts src/shared/ src/renderer/src/components/sidebar/`
→ **6986 passed**. `typecheck:node` and `typecheck:web` both clean; `oxlint` clean
(gate confirmed live by injecting a violation, since a clean oxlint run prints nothing).

Every title literal in the new tests is a real captured payload, padding included.

**Proven non-vacuous**: with the test files kept and only the three source files reverted
to the #14634 base, 6 of the 9 new tests fail. The 3 that pass are the negative guards
(mention/path/hyphen rejection, and the neighbouring-agent regression check) — those must
hold both before and after, and would be the vacuous ones if they flipped.

Platforms: logic is pure title parsing, shared by main and renderer — no platform-specific
paths. Windows launcher suffixes and multiplexer-wrapped titles are covered by the existing
registry tests. Qwen's own multiplexer branch emits OSC 2 only (no OSC 0) and drops the
padding; the frame trims, so both forms resolve identically.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

- **Security** — no new input trusted; the frame is anchored and narrower than a token match.
- **Cross-platform** — no platform branches; `executableSuffix` stays opt-in and off for Qwen
  (it installs as `qwen`, and process recognition already handles `qwen.cmd`).
- **Remote SSH / folder workspaces** — title-derived rows only; no filesystem or git assumptions.
- **Backwards compatibility** — no wire change. `statusGlyphs` and `contextSuffix` are opt-in,
  so `claude` and `cline` build byte-identical regexes; a test pins that `Cline - the parser`
  is still rejected and that `AGENT_IDENTITY_FRAMES.amp` stays undefined.
- **Performance** — one extra anchored regex per declared agent per title resolve.

### Known limitation (deliberately not fixed here)

Once a Qwen session has a name, `formatSessionWindowTitle` replaces the base entirely, so the
title becomes `<status glyph><session name>` with no `Qwen` in it. Orca cannot identify those
panes from the title, and no anchored frame can. Closing that needs the runtime-status file or
a user-declarable agent identity, which is the `#7797` direction — out of scope for this fix.

## Author

- X / Twitter: @BrennanKB5
