### PR TITLE
feat(browser): report client page inventory

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -2604,6 +2604,7 @@
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/browser-host-page-retirement.test.ts src/main/runtime/browser-host-page-placement-replacement.test.ts src/main/runtime/browser-host-page-placement.test.ts src/main/runtime/browser-host-lease-registry.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/browser-host-page-reconciliation-plan.test.ts",
+        "pnpm exec vitest run --config config/vitest.config.ts src/shared/browser-client-host-protocol.test.ts src/main/browser/browser-client-host-attach-request.test.ts src/main/browser/browser-client-page-command-executor.test.ts src/main/browser/browser-client-page-command-integration.test.ts src/main/browser/browser-client-page-inventory.test.ts src/main/browser/paired-runtime-browser-client-host-composition.test.ts src/main/browser/paired-runtime-browser-client-host.test.ts src/main/browser/paired-runtime-browser-host-lease.test.ts src/main/runtime/browser-host-lease-registry.test.ts src/main/runtime/rpc/methods/browser-client-host.test.ts src/main/runtime/browser-host-page-reconciliation-plan.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/shared/browser-network-capabilities.test.ts src/shared/browser-network-tunnel-protocol.test.ts src/main/browser/browser-network-tunnel-session.test.ts src/main/browser/remote-browser-socks-server.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/main/browser/browser-network-tunnel-client.test.ts src/main/browser/paired-runtime-browser-network-route.test.ts src/main/runtime/runtime-binary-message-router.test.ts src/main/runtime/rpc/methods/browser-network-tunnel.test.ts src/main/runtime/browser-network-tunnel-paired-runtime.integration.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/main/browser/browser-network-tunnel-outbound-memory-budget.test.ts src/main/browser/browser-network-tunnel-client-memory-budget.test.ts src/main/browser/browser-network-tunnel-session-aggregate-memory.test.ts src/shared/ws-outbound-backpressure-queue.test.ts src/shared/remote-runtime-client.test.ts",
@@ -2637,7 +2638,10 @@
         "src/main/browser/paired-runtime-browser-client-host-composition.test.ts",
         "src/main/browser/paired-runtime-browser-client-host-registry.test.ts",
         "src/main/browser/paired-runtime-browser-client-host-runtime.test.ts",
+        "src/main/browser/browser-client-host-attach-request.test.ts",
         "src/main/browser/browser-client-page-command-executor.test.ts",
+        "src/main/browser/browser-client-page-command-integration.test.ts",
+        "src/main/browser/browser-client-page-inventory.test.ts",
         "src/main/browser/browser-session-startup.test.ts",
         "src/main/ipc/runtime-environments.test.ts",
         "src/main/browser/browser-client-host-command-dispatcher.test.ts",
@@ -2697,7 +2701,7 @@
           "assertions": [
             "exact current pages retain without navigation while runtime-missing pages restore and client orphans close",
             "profile, execution-host, authority, generation, and outcome-unknown mismatches require a close-before-restore barrier",
-            "old-epoch reclaim requires one exact persisted previous authority, an epoch transition, and the same browser-host client identity while allowing counters to restart under the new epoch",
+            "old-epoch reclaim requires one exact persisted previous authority, authenticated paired-device provenance, an epoch transition, and the same browser-host client identity while allowing counters to restart under the new epoch",
             "duplicate and over-capacity inventories fail atomically before returning a partial plan",
             "invalid identities, generations, URLs, states, limits, duplicate inventories, and over-capacity inventories fail atomically while valid records and action lists are immutable"
           ]
@@ -2713,7 +2717,10 @@
             "lease replacement invalidates every grant from the old host generation",
             "late page cleanup cannot remove a replacement client generation or server placement",
             "retired page placement leaves no tombstone and a reused ID receives a higher global generation",
-            "page placement generations are monotonic and stale lease authority is rejected"
+            "page placement generations are monotonic and stale lease authority is rejected",
+            "incomplete, unsupported-version, duplicate, over-budget, and foreign-client inventories fail before lease replacement",
+            "a previous-runtime inventory remains eligible for exact persisted-authority restart reconciliation",
+            "the exact authenticated lease retains an immutable inventory snapshot"
           ]
         },
         {
@@ -2727,6 +2734,8 @@
           "file": "src/shared/browser-client-host-protocol.test.ts",
           "assertions": [
             "page-command v1 negotiation is optional and independent of the legacy ready/revoked stream",
+            "page-inventory v1 is optional, independently echoed, authority-bound, duplicate-free, capped at 256 pages and 768 KiB, and stripped by old attach and ready decoders",
+            "inventory-only identities are capped after JSON escaping so 256 worst-case valid page records remain within budget without narrowing legacy fields",
             "create and navigate commands bind bounded IDs and sequences to exact runtime, epoch, host, and page generations",
             "unknown versions, command kinds, invalid generations, and oversized identities fail before delivery",
             "command-result acknowledgements require an explicit boolean accepted field"
@@ -2737,6 +2746,7 @@
           "assertions": [
             "a client requests commands only with a delivery handler and accepts them only after an exact v1 echo",
             "an old host that omits the echo cannot deliver a command",
+            "one complete inventory snapshot is sampled before attach, a missing echo stays unsupported, and an unsolicited echo closes the lease",
             "stale authority commands close the exact lease before handler delivery",
             "completed and failed results submit exact command authority on the established subscription",
             "missing result transport, handler failure, server rejection, and malformed or wrong-runtime acknowledgement close the lease",
@@ -2760,11 +2770,42 @@
           "file": "src/main/browser/paired-runtime-browser-client-host-composition.test.ts",
           "assertions": [
             "exact route authority activates before the first page command",
+            "host attach samples the executor's exact page inventory once",
             "page retirement settles dispatcher ownership before guest cleanup and ledger forget",
             "shutdown closes control transport before executor pages and every retained route",
             "non-settling handlers remove network reach immediately and defer page cleanup until exact late settlement",
             "deferred executor cleanup failures remain fenced and emit an observable composition error",
             "cleanly absent failed creates are forgotten while unresolved cleanup remains fenced"
+          ]
+        },
+        {
+          "file": "src/main/browser/browser-client-host-attach-request.test.ts",
+          "assertions": [
+            "an unencodable optional inventory is omitted without changing legacy page-command negotiation"
+          ]
+        },
+        {
+          "file": "src/main/browser/browser-client-page-command-executor.test.ts",
+          "assertions": [
+            "in-flight create, ambiguous cleanup, and stale renderer authority snapshot as outcome unknown",
+            "a destroyed exact guest snapshots as outcome unknown before executor retirement",
+            "create-to-active transition emits one exact page record without duplicate identity",
+            "successful normalized navigation updates the immutable current URL snapshot unless normalization exceeds the URL field bound",
+            "legacy-valid command identities remain executable even when optional inventory cannot encode them",
+            "executor capacity cannot exceed the shared 256-page attach limit"
+          ]
+        },
+        {
+          "file": "src/main/browser/browser-client-page-command-integration.test.ts",
+          "assertions": [
+            "spontaneous exact guest destruction revokes active inventory before explicit page retirement"
+          ]
+        },
+        {
+          "file": "src/main/browser/browser-client-page-inventory.test.ts",
+          "assertions": [
+            "optional URLs compact by deterministic codepoint order without dropping required page identity",
+            "an unencodable complete snapshot declines inventory negotiation instead of dropping a page"
           ]
         },
         {
@@ -2830,6 +2871,7 @@
             "the control method stays out of production registration",
             "only a negotiated authenticated paired-runtime connection receives a server-owned epoch and generation",
             "page-command v1 is echoed only to an explicit v1 attach while legacy event shapes remain unchanged",
+            "page-inventory v1 is echoed only after a complete authenticated inventory is retained on the exact lease",
             "only the exact negotiated connection, paired device, and live page placement can settle a server-owned command",
             "an unnegotiated runtime connection cannot submit command results",
             "exact duplicate results are idempotent while conflicts and stale or retired placement fail closed",
@@ -3025,6 +3067,15 @@
         }
       ],
       "evidenceRuns": [
+        {
+          "date": "2026-08-14",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/shared/browser-client-host-protocol.test.ts src/main/browser/browser-client-host-attach-request.test.ts src/main/browser/browser-client-page-command-executor.test.ts src/main/browser/browser-client-page-command-integration.test.ts src/main/browser/browser-client-page-inventory.test.ts src/main/browser/paired-runtime-browser-client-host-composition.test.ts src/main/browser/paired-runtime-browser-client-host.test.ts src/main/browser/paired-runtime-browser-host-lease.test.ts src/main/runtime/browser-host-lease-registry.test.ts src/main/runtime/rpc/methods/browser-client-host.test.ts src/main/runtime/browser-host-page-reconciliation-plan.test.ts",
+          "result": "passed",
+          "durationSeconds": 7.3,
+          "summary": "Eleven files passed 145 exact inventory negotiation, 256-page and 768 KiB atomic bounds, worst-case JSON-escaped inventory identities, deterministic optional-URL compaction, legacy-command preservation when inventory is unencodable, legacy strip, immutable authenticated lease snapshot, strict v1/duplicate/foreign-client rejection, paired-device-bound previous-runtime restart admission, missing and unsolicited echo, create-to-active deduplication, renderer/guest-stale outcome-unknown classification, normalized URL bounds, composition sampling, RPC retention, and reconciliation tests."
+        },
         {
           "date": "2026-08-14",
           "runner": "local",

--- a/docs/sta-4150-client-hosted-browser-progress.md
+++ b/docs/sta-4150-client-hosted-browser-progress.md
@@ -36,10 +36,10 @@ Old clients and callers that omit placement must retain current server-hosted be
 - Stage 0 compatibility hardening: PR
   [#14402](https://github.com/stablyai/orca/pull/14402) is merged. It is not the long-term
   architecture and is not part of this draft stack.
-- Latest published stack tip: `sta-4150-browser-client-page-reconciliation`, draft PR
-  [#14617](https://github.com/stablyai/orca/pull/14617), stacked on composition PR
-  [#14613](https://github.com/stablyai/orca/pull/14613); CI is rerunning after the import-side-effect
-  fix and latest-main rebase.
+- Latest published stack tip: `sta-4150-browser-client-page-inventory`, draft PR
+  [#14648](https://github.com/stablyai/orca/pull/14648), stacked on reconciliation PR
+  [#14617](https://github.com/stablyai/orca/pull/14617); CI is running after the
+  `origin/main@a3b472d050` rebase.
 - PR #14566: final lifecycle/correctness/security review clean; all 43 required CI checks pass.
 - Published bridge branch: `sta-4150-browser-client-page-mount-bridge` locally rebased to
   `830cb95c25`, draft PR [#14578](https://github.com/stablyai/orca/pull/14578), stacked on #14566;
@@ -89,6 +89,7 @@ ownership.
 | [#14596](https://github.com/stablyai/orca/pull/14596) | Renderer registry | Bounded document-owned blank guest retention and lifecycle                |
 | [#14613](https://github.com/stablyai/orca/pull/14613) | Host composition  | Environment-scoped host, executor, renderer, and route composition        |
 | [#14617](https://github.com/stablyai/orca/pull/14617) | Reconciliation    | Bounded retain, reclaim, restore, and close semantics                     |
+| [#14648](https://github.com/stablyai/orca/pull/14648) | Page inventory    | Optional authenticated complete client-page snapshot                      |
 
 ## Current stage: exact renderer bridge
 
@@ -299,35 +300,88 @@ Current evidence:
 - This stage pins semantics only. Authenticated inventory transport, runtime integration,
   executor inventory, pending-close resolution, and real reconnect/restart journeys remain.
 
+## Published stage: authenticated hosted-page inventory (#14648)
+
+Branch `sta-4150-browser-client-page-inventory` is stacked on #14617 as draft PR
+[#14648](https://github.com/stablyai/orca/pull/14648). It carries one optional, complete page
+snapshot on the existing authenticated browser-host attach. It does not execute the reconciliation
+plan, advertise a runtime capability, activate client placement, or change current browser
+behavior.
+
+Implemented:
+
+- Independent `pageInventoryProtocolVersion: 1` negotiation on attach, ready, and exact lease
+  authority. Missing server echo remains unsupported/unknown; an unsolicited echo fails closed.
+- A frozen inventory record with exact runtime, epoch, client, host/page generations, browser
+  profile, execution-host key, `active` or `outcomeUnknown` state, and optional normalized URL.
+- Atomic limits of 256 unique page IDs, 384 JSON-encoded bytes per inventory-only identity, and 768
+  KiB total, below the remote subscription's 1 MiB retained parameter ceiling and the 8 MiB
+  encrypted WebSocket frame ceiling. Existing wire identities keep their old 256-character bound.
+  Optional URLs are omitted in deterministic codepoint order when needed; page identity is never
+  truncated or dropped. If a legacy-valid identity cannot fit the optional inventory encoding, the
+  client keeps executing page commands and declines inventory negotiation for that attach.
+- Attach-level and runtime-registry rejection for incomplete negotiation, duplicate pages, foreign
+  client authority, invalid records, and oversized snapshots. A previous runtime authority remains
+  available for exact persisted-authority restart reconciliation, which additionally requires the
+  inventory lease's authenticated paired-device identity to match persisted provenance. Old attach
+  and ready decoders strip the optional fields.
+- Executor snapshots classify in-flight creation, retirement, ambiguous cleanup, stale renderer,
+  and destroyed guest authority as `outcomeUnknown`; an exact current retained guest is `active`.
+  Create-to-active transitions cannot emit a duplicate page ID, successful normalized navigation
+  updates the frozen URL snapshot, and percent-expanded URLs that exceed the field bound are omitted.
+- Composition samples the executor exactly once before attach, and the runtime stores a separate
+  immutable snapshot on the exact authenticated lease.
+
+Deterministic evidence:
+
+- Baseline: 5 files failed 7 expected assertions because the inventory contracts and accessors did
+  not exist.
+- Focused inventory/reconciliation gate: 11 files / 145 tests passed.
+- Broader authenticated lease/tunnel gate: 16 files / 188 tests passed.
+- Real old/new terminal wire compatibility: 5/5 journeys passed.
+- Full node/CLI/web typecheck, lint and native/type-aware audits, the 86-gate reliability manifest,
+  changed-code quality, max-lines ratchet, formatting, diff checks, CLI build, Electron build, and
+  paired-web projection passed on `origin/main@a3b472d050`.
+- Two fresh read-only reviews found no P0/P1 or must-fix item. Their notes preserve intentional
+  restart acceptance, bounded ambiguous-cleanup tombstones, atomic inventory opt-out, and the
+  one-shot snapshot as an activation blocker rather than weakening those fences.
+
+Architectural limitation: the current executor still belongs to one lease composition. Initial
+attach therefore normally reports an empty inventory, and transport loss closes the executor and
+its pages. Reconnect recovery cannot become live until a later stage preserves or transfers
+executor/page lifetime across the bounded grace period and feeds the stored inventory plus runtime
+intent into the already-pinned reconciliation planner. Treating a missing or unavailable snapshot
+as empty remains forbidden.
+
 ## Acceptance matrix
 
-| Requirement                                                        | State                     | Evidence or blocker                                                                                               |
-| ------------------------------------------------------------------ | ------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| Negotiated client-host and tunnel contracts                        | Partial                   | Schemas/RPC methods exist; runtime capabilities are intentionally not advertised                                  |
-| Runtime placement, leases, authority epochs, host/page generations | Partial                   | Deterministic registries exist; normal browser creation does not call them                                        |
-| Main browser-host registry                                         | Partial                   | Environment-scoped lease/executor/route composition exists but has no production caller                           |
-| Renderer-owned retained webview registry and surface               | Partial                   | Local exact-tuple preload/registry stage passes deterministic and Electron proof; no BrowserPane adoption exists  |
-| Route/profile-scoped partition before first request                | Partial                   | Deterministic policy ordering passes; real Electron worker/popup/speculation proof is missing                     |
-| SOCKS5 tunnel with remote DNS and bounded flow control             | Partial                   | Native and SSH route foundations exist; WSL and production route retention are incomplete                         |
-| Agent/CLI routing by placement                                     | Missing                   | Only create/navigate command foundations exist; public browser methods still use current server behavior          |
-| Inventory/reconciliation after ambiguous outcomes and restart      | Missing                   | Failed/ambiguous creates intentionally consume bounded capacity until authenticated reconciliation exists         |
-| Independent bounded control/tunnel/mirror/binary channels          | Partial                   | Control and tunnel are separate/bounded; mirror and large-result paths are incomplete                             |
-| Mixed client/server compatibility                                  | Partial                   | Optional/capability-gated contracts and cross-version tests exist; activated rolling-upgrade behavior is unproven |
-| Local pointer/keyboard/chrome with no runtime round trip           | Missing                   | Requires the renderer surface and interaction-owner fencing                                                       |
-| No screencast for client placement                                 | Missing                   | No live client placement exists yet                                                                               |
-| Remote localhost/private DNS/subresources/workers/WebSockets       | Unproven                  | Requires real Electron CDP plus traffic/DNS evidence                                                              |
-| Tunnel loss fails closed with no desktop fallback                  | Partial                   | State-machine route fencing exists; live Electron/network-service proof is missing                                |
-| Browserless runtime can serve client-hosted pages                  | Unproven                  | Needs a real paired browserless runtime journey                                                                   |
-| Server/offscreen placement remains stable                          | Preserved so far          | Entire draft stack is inert; activation and rollback tests remain                                                 |
-| Headed paired-Electron terminal-link journey                       | Missing                   | Must prove page load, stable PTY/multiplex identity, and no reconnect UI                                          |
-| macOS/Linux/Windows, SSH/WSL, worktree/folder, multi-client        | Mostly missing live proof | Deterministic platform-neutral contracts exist; physical and paired topology matrix remains                       |
+| Requirement                                                        | State                     | Evidence or blocker                                                                                                 |
+| ------------------------------------------------------------------ | ------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Negotiated client-host and tunnel contracts                        | Partial                   | Schemas/RPC methods exist; runtime capabilities are intentionally not advertised                                    |
+| Runtime placement, leases, authority epochs, host/page generations | Partial                   | Deterministic registries exist; normal browser creation does not call them                                          |
+| Main browser-host registry                                         | Partial                   | Environment-scoped lease/executor/route composition exists but has no production caller                             |
+| Renderer-owned retained webview registry and surface               | Partial                   | Local exact-tuple preload/registry stage passes deterministic and Electron proof; no BrowserPane adoption exists    |
+| Route/profile-scoped partition before first request                | Partial                   | Deterministic policy ordering passes; real Electron worker/popup/speculation proof is missing                       |
+| SOCKS5 tunnel with remote DNS and bounded flow control             | Partial                   | Native and SSH route foundations exist; WSL and production route retention are incomplete                           |
+| Agent/CLI routing by placement                                     | Missing                   | Only create/navigate command foundations exist; public browser methods still use current server behavior            |
+| Inventory/reconciliation after ambiguous outcomes and restart      | Partial                   | Planner and authenticated bounded inventory snapshot exist; executor lifetime, plan execution, and reconnect remain |
+| Independent bounded control/tunnel/mirror/binary channels          | Partial                   | Control and tunnel are separate/bounded; mirror and large-result paths are incomplete                               |
+| Mixed client/server compatibility                                  | Partial                   | Optional/capability-gated contracts and cross-version tests exist; activated rolling-upgrade behavior is unproven   |
+| Local pointer/keyboard/chrome with no runtime round trip           | Missing                   | Requires the renderer surface and interaction-owner fencing                                                         |
+| No screencast for client placement                                 | Missing                   | No live client placement exists yet                                                                                 |
+| Remote localhost/private DNS/subresources/workers/WebSockets       | Unproven                  | Requires real Electron CDP plus traffic/DNS evidence                                                                |
+| Tunnel loss fails closed with no desktop fallback                  | Partial                   | State-machine route fencing exists; live Electron/network-service proof is missing                                  |
+| Browserless runtime can serve client-hosted pages                  | Unproven                  | Needs a real paired browserless runtime journey                                                                     |
+| Server/offscreen placement remains stable                          | Preserved so far          | Entire draft stack is inert; activation and rollback tests remain                                                   |
+| Headed paired-Electron terminal-link journey                       | Missing                   | Must prove page load, stable PTY/multiplex identity, and no reconnect UI                                            |
+| macOS/Linux/Windows, SSH/WSL, worktree/folder, multi-client        | Mostly missing live proof | Deterministic platform-neutral contracts exist; physical and paired topology matrix remains                         |
 
 ## Remaining implementation order
 
 1. Monitor #14596, #14613, and #14617 CI and fix any actionable failure without merging or
    marking them ready.
-2. Finish authenticated inventory transport and compose the pinned reclaim/restore/close plan
-   before recovering ambiguous slots or routes.
+2. Preserve executor/page lifetime through reconnect grace and compose authenticated inventory
+   with the pinned reclaim/restore/close plan before recovering ambiguous slots or routes.
 3. Add optional placement to logical session-tab publication and renderer state. Follow
    `docs/reference/remote-wire-compatibility.md`; old callers and clients remain server-hosted.
 4. Route create and every existing browser command by explicit placement. Never silently fall
@@ -394,7 +448,7 @@ topology, versions, and explicit gaps at every later checkpoint.
 - Pushed the STA-4150 staged branches listed in the draft-stack table.
 - Opened and maintained their linked draft PRs; none were merged or marked ready.
 - Attached draft PRs and posted one concise checkpoint per stage on STA-4150.
-- Latest public checkpoint: attached/commented draft PR #14617; CI is rerunning.
+- Latest public checkpoint: attached/commented draft PR #14648; CI is running.
 - Updated the Orca worktree comment/status at context, reproduction, fix, validation, and review
   checkpoints.
 - Pushed the renderer-bridge branch, opened draft PR #14578 on #14566, attached it to STA-4150,
@@ -412,6 +466,10 @@ topology, versions, and explicit gaps at every later checkpoint.
 - Rebased all 27 branches onto `origin/main@500b72d8ef` and force-pushed them with lease checks.
   Range-diff preserved the first 24 stages; the bridge date was already upstream, and the
   composition delta is the intentional lazy Electron IPC fix.
+- Rebased all 28 stack branches onto `origin/main@a3b472d050`, confirmed all 29 patches identical
+  by `git range-diff`, and force-pushed them with lease checks.
+- Pushed the authenticated inventory stage, opened draft PR #14648 on #14617, attached it to
+  STA-4150, and posted one concise checkpoint. The ticket remains In Progress.
 - No PR was merged or marked ready.
 
 ## Completion rule

--- a/src/main/browser/browser-client-host-attach-request.test.ts
+++ b/src/main/browser/browser-client-host-attach-request.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { PairingOffer } from '../../shared/pairing'
+import { createBrowserClientHostAttachRequest } from './browser-client-host-attach-request'
+
+const pairing = {
+  v: 2,
+  endpoint: 'ws://127.0.0.1:6768',
+  deviceToken: 'device-token',
+  publicKeyB64: 'public-key',
+  pairedDeviceId: 'device-a',
+  scope: 'runtime'
+} as PairingOffer
+
+describe('browser client host attach request', () => {
+  it('omits unencodable inventory without changing legacy page-command negotiation', () => {
+    const onPageCommand = vi.fn(() => ({ status: 'completed' as const }))
+    const attach = createBrowserClientHostAttachRequest({
+      pairing,
+      authorityRuntimeId: 'runtime-a',
+      browserHostClientId: 'host-a',
+      hostCapabilities: ['webview'],
+      pageCommandProtocolVersion: 1,
+      onPageCommand,
+      pageInventoryProtocolVersion: 1,
+      getPageInventory: () => [
+        {
+          authorityRuntimeId: 'runtime-old',
+          authorityEpoch: 'epoch-old',
+          browserHostClientId: 'host-a',
+          browserHostGeneration: 2,
+          browserPageId: 'page-a',
+          pageHostGeneration: 3,
+          browserProfileId: '\0'.repeat(256),
+          executionHostKey: 'native:runtime-old:1',
+          state: 'active'
+        }
+      ]
+    })
+
+    expect(attach.pageCommandProtocolVersion).toBe(1)
+    expect(attach.pageInventoryProtocolVersion).toBeUndefined()
+    expect(attach.params).toMatchObject({ pageCommandProtocolVersion: 1 })
+    expect(attach.params).not.toHaveProperty('pageInventoryProtocolVersion')
+    expect(attach.params).not.toHaveProperty('pageInventory')
+  })
+})

--- a/src/main/browser/browser-client-host-attach-request.ts
+++ b/src/main/browser/browser-client-host-attach-request.ts
@@ -1,0 +1,41 @@
+import { BrowserClientHostAttachParams } from '../../shared/browser-client-host-protocol'
+import { prepareBrowserClientPageInventoryForAttach } from './browser-client-page-inventory'
+import type { PairedRuntimeBrowserHostLeaseOptions } from './paired-runtime-browser-host-lease-options'
+
+export function assertBrowserClientHostAttachOptions(
+  options: PairedRuntimeBrowserHostLeaseOptions
+): void {
+  if (
+    (options.pageInventoryProtocolVersion === undefined) !==
+    (options.getPageInventory === undefined)
+  ) {
+    throw new Error('Browser host page inventory negotiation is incomplete')
+  }
+}
+
+export function createBrowserClientHostAttachRequest(
+  options: PairedRuntimeBrowserHostLeaseOptions
+) {
+  const pageCommandProtocolVersion = options.onPageCommand
+    ? options.pageCommandProtocolVersion
+    : undefined
+  const pageInventory = options.getPageInventory
+    ? prepareBrowserClientPageInventoryForAttach(options.getPageInventory())
+    : undefined
+  const pageInventoryProtocolVersion = pageInventory
+    ? options.pageInventoryProtocolVersion
+    : undefined
+  const params = BrowserClientHostAttachParams.parse({
+    authorityRuntimeId: options.authorityRuntimeId,
+    browserHostClientId: options.browserHostClientId,
+    hostCapabilities: [...options.hostCapabilities],
+    ...(pageCommandProtocolVersion ? { pageCommandProtocolVersion } : {}),
+    ...(pageInventoryProtocolVersion
+      ? {
+          pageInventoryProtocolVersion,
+          pageInventory
+        }
+      : {})
+  })
+  return { pageCommandProtocolVersion, pageInventoryProtocolVersion, params }
+}

--- a/src/main/browser/browser-client-host-command-authority.ts
+++ b/src/main/browser/browser-client-host-command-authority.ts
@@ -33,6 +33,7 @@ export function sameBrowserClientHostLeaseAuthority(
     left.authorityEpoch === right.authorityEpoch &&
     left.browserHostClientId === right.browserHostClientId &&
     left.browserHostGeneration === right.browserHostGeneration &&
-    left.pageCommandProtocolVersion === right.pageCommandProtocolVersion
+    left.pageCommandProtocolVersion === right.pageCommandProtocolVersion &&
+    left.pageInventoryProtocolVersion === right.pageInventoryProtocolVersion
   )
 }

--- a/src/main/browser/browser-client-page-command-admission.ts
+++ b/src/main/browser/browser-client-page-command-admission.ts
@@ -1,0 +1,33 @@
+import type { BrowserClientHostCommandEvent } from '../../shared/browser-client-host-protocol'
+import type {
+  BrowserClientPageRenderer,
+  BrowserClientPageRendererIdentity
+} from './browser-client-page-cleanup'
+import { BrowserClientPageCommandError } from './browser-client-page-command-failure'
+
+export function browserClientPageIdentity(
+  page: Pick<BrowserClientHostCommandEvent, 'browserPageId' | 'pageHostGeneration'>,
+  partition: string
+): BrowserClientPageRendererIdentity {
+  return {
+    partition,
+    browserPageId: page.browserPageId,
+    pageHostGeneration: page.pageHostGeneration
+  }
+}
+
+export function assertCurrentBrowserClientPageRenderer(renderer: BrowserClientPageRenderer): void {
+  if (
+    !Number.isInteger(renderer.rendererWebContentsId) ||
+    renderer.rendererWebContentsId <= 0 ||
+    !renderer.isCurrent()
+  ) {
+    throw new BrowserClientPageCommandError('browser_client_page_renderer_stale')
+  }
+}
+
+export function assertBrowserClientPageCommandNotAborted(signal: AbortSignal): void {
+  if (signal.aborted) {
+    throw new BrowserClientPageCommandError('browser_client_page_command_aborted')
+  }
+}

--- a/src/main/browser/browser-client-page-command-executor.test.ts
+++ b/src/main/browser/browser-client-page-command-executor.test.ts
@@ -37,12 +37,14 @@ function createCommand(
 
 function createLifecycleClaim(
   registration: BrowserRoutePageGuestIdentity,
-  whenDestroyed: Promise<void> = Promise.resolve()
+  whenDestroyed: Promise<void> = Promise.resolve(),
+  isCurrent = () => true
 ): BrowserRouteGuestLifecycleClaim {
   return {
     registration: { ...registration },
     guestAuthority: Symbol('guest-authority'),
-    whenDestroyed
+    whenDestroyed,
+    isCurrent
   }
 }
 
@@ -190,6 +192,111 @@ describe('BrowserClientPageCommandExecutor', () => {
       lifecycleClaim,
       'https://example.internal/path'
     )
+    expect(executor.snapshotPageInventory()).toEqual([
+      {
+        authorityRuntimeId: 'runtime-a',
+        authorityEpoch: 'epoch-a',
+        browserHostClientId: 'client-a',
+        browserHostGeneration: 3,
+        browserPageId: 'page-a',
+        pageHostGeneration: 7,
+        browserProfileId: 'profile-a',
+        executionHostKey: 'execution-host-a',
+        state: 'active',
+        currentUrl: 'https://example.internal/path'
+      }
+    ])
+  })
+
+  it('keeps legacy-valid command identities when inventory cannot encode them', async () => {
+    const { executor } = createHarness()
+    const browserProfileId = '\0'.repeat(256)
+
+    await expect(
+      executor.handle(
+        createCommand('createPage', {
+          command: { type: 'createPage', browserProfileId, executionHostKey: 'execution-host-a' }
+        }),
+        new AbortController().signal
+      )
+    ).resolves.toEqual({ status: 'completed' })
+    expect(executor.snapshotPageInventory()).toEqual([
+      expect.objectContaining({ browserProfileId, state: 'active' })
+    ])
+  })
+
+  it('omits a normalized URL that expands beyond the inventory field bound', async () => {
+    const { dependencies, executor } = createHarness()
+    await executor.handle(createCommand('createPage'), new AbortController().signal)
+    const requestedUrl = `https://example.internal/${'é'.repeat(4_000)}`
+
+    await expect(
+      executor.handle(
+        createCommand('navigate', { command: { type: 'navigate', url: requestedUrl } }),
+        new AbortController().signal
+      )
+    ).resolves.toEqual({ status: 'completed' })
+
+    expect(dependencies.routeWebContents.navigateGuest).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.stringMatching(/^https:\/\/example\.internal\/%C3%A9%C3%A9/)
+    )
+    expect(executor.snapshotPageInventory()[0]).not.toHaveProperty('currentUrl')
+  })
+
+  it('snapshots in-flight and unresolved pages as outcome unknown', async () => {
+    const { dependencies, executor, route } = createHarness()
+    let resolveRoute = (_route: typeof route): void => {}
+    dependencies.retainNetworkRoute.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveRoute = resolve
+        })
+    )
+    const creating = executor.handle(createCommand('createPage'), new AbortController().signal)
+    await Promise.resolve()
+
+    const inFlight = executor.snapshotPageInventory()
+    expect(inFlight).toEqual([
+      expect.objectContaining({ browserPageId: 'page-a', state: 'outcomeUnknown' })
+    ])
+    expect(Object.isFrozen(inFlight)).toBe(true)
+    expect(Object.isFrozen(inFlight[0])).toBe(true)
+
+    resolveRoute(route)
+    await expect(creating).resolves.toEqual({ status: 'completed' })
+    expect(executor.snapshotPageInventory()).toEqual([
+      expect.objectContaining({ browserPageId: 'page-a', state: 'active' })
+    ])
+  })
+
+  it('never duplicates a page during its create-to-active transition', async () => {
+    const { dependencies, executor, order } = createHarness()
+    let transitionSnapshot: ReturnType<typeof executor.snapshotPageInventory> = []
+    dependencies.routeWebContents.grantNavigation.mockImplementationOnce(() => {
+      order.push('grant-navigation')
+      queueMicrotask(() => {
+        transitionSnapshot = executor.snapshotPageInventory()
+      })
+      return true
+    })
+
+    await executor.handle(createCommand('createPage'), new AbortController().signal)
+
+    expect(transitionSnapshot).toEqual([
+      expect.objectContaining({ browserPageId: 'page-a', state: 'active' })
+    ])
+  })
+
+  it('never reports a page as active after its renderer authority is replaced', async () => {
+    const { executor, setRendererCurrent } = createHarness()
+    await executor.handle(createCommand('createPage'), new AbortController().signal)
+
+    setRendererCurrent(false)
+
+    expect(executor.snapshotPageInventory()).toEqual([
+      expect.objectContaining({ browserPageId: 'page-a', state: 'outcomeUnknown' })
+    ])
   })
 
   it('rejects stale generations and local-file navigation without touching Chromium', async () => {
@@ -293,6 +400,9 @@ describe('BrowserClientPageCommandExecutor', () => {
     expect(order.slice(-2)).toEqual(['mount-page', 'retire-renderer-page'])
     expect(routeSession.release).not.toHaveBeenCalled()
     expect(route.release).not.toHaveBeenCalled()
+    expect(executor.snapshotPageInventory()).toEqual([
+      expect.objectContaining({ browserPageId: 'page-a', state: 'outcomeUnknown' })
+    ])
     await expect(
       executor.handle(
         createCommand('createPage', { pageHostGeneration: 8 }),
@@ -380,6 +490,9 @@ describe('BrowserClientPageCommandExecutor', () => {
     await Promise.resolve()
     await Promise.resolve()
     expect(order.slice(-2)).toEqual(['retire-guest', 'retire-renderer-page'])
+    expect(executor.snapshotPageInventory()).toEqual([
+      expect.objectContaining({ browserPageId: 'page-a', state: 'outcomeUnknown' })
+    ])
     acknowledgeDestroyed()
     await expect(retiring).resolves.toBe(true)
     expect(order.slice(-4)).toEqual([
@@ -488,6 +601,10 @@ describe('BrowserClientPageCommandExecutor', () => {
     ).resolves.toEqual({ status: 'failed', errorCode: 'browser_client_page_capacity' })
     resolveRoute(route)
     await expect(first).resolves.toEqual({ status: 'completed' })
+  })
+
+  it('rejects a page limit above the attach inventory maximum', () => {
+    expect(() => createHarness({ maxPages: 257 })).toThrow('browser_client_page_limit_invalid')
   })
 
   it('does not retain a page when close races its in-flight creation', async () => {

--- a/src/main/browser/browser-client-page-command-executor.ts
+++ b/src/main/browser/browser-client-page-command-executor.ts
@@ -1,14 +1,20 @@
-import type {
-  BrowserClientHostCommandEvent,
-  BrowserClientHostCommandResult
+import {
+  BROWSER_CLIENT_HOST_PAGE_INVENTORY_MAX_PAGES,
+  type BrowserClientHostedPageInventory,
+  type BrowserClientHostCommandEvent,
+  type BrowserClientHostCommandResult
 } from '../../shared/browser-client-host-protocol'
 import { normalizeBrowserNavigationUrl } from '../../shared/browser-url'
 import {
   cleanupBrowserClientPage,
   type BrowserClientPageNetworkRoute as RetainedNetworkRoute,
-  type BrowserClientPageRenderer,
-  type BrowserClientPageRendererIdentity as RendererPageIdentity
+  type BrowserClientPageRenderer
 } from './browser-client-page-cleanup'
+import {
+  assertBrowserClientPageCommandNotAborted,
+  assertCurrentBrowserClientPageRenderer,
+  browserClientPageIdentity
+} from './browser-client-page-command-admission'
 import type {
   BrowserRouteGuestLifecycleClaim,
   BrowserRoutePageGuestIdentity
@@ -21,6 +27,11 @@ import {
   BrowserClientPageCommandError,
   isBrowserClientPageCleanupFailure
 } from './browser-client-page-command-failure'
+import {
+  createBrowserClientPageInventory,
+  snapshotBrowserClientPageInventoryList,
+  updateBrowserClientPageInventoryCurrentUrl
+} from './browser-client-page-inventory'
 
 type BrowserClientPageCommandExecutorDependencies = {
   orcaProfileId: string
@@ -41,6 +52,7 @@ type BrowserClientPageCommandExecutorDependencies = {
 
 type RetainedPage = {
   generation: number
+  inventory: BrowserClientHostedPageInventory
   registration: BrowserRoutePageGuestIdentity
   lifecycleClaim: BrowserRouteGuestLifecycleClaim
   renderer: BrowserClientPageRenderer
@@ -52,14 +64,18 @@ type RetainedPage = {
 export class BrowserClientPageCommandExecutor {
   private readonly maxPages: number
   private readonly pages = new Map<string, RetainedPage>()
-  private readonly creatingPageIds = new Set<string>()
-  private readonly failedPages = new Map<string, number>()
+  private readonly creatingPages = new Map<string, BrowserClientHostedPageInventory>()
+  private readonly failedPages = new Map<string, BrowserClientHostedPageInventory>()
   private closePromise: Promise<void> | null = null
   private closed = false
 
   constructor(private readonly dependencies: BrowserClientPageCommandExecutorDependencies) {
-    this.maxPages = dependencies.maxPages ?? 256
-    if (!Number.isInteger(this.maxPages) || this.maxPages < 1) {
+    this.maxPages = dependencies.maxPages ?? BROWSER_CLIENT_HOST_PAGE_INVENTORY_MAX_PAGES
+    if (
+      !Number.isInteger(this.maxPages) ||
+      this.maxPages < 1 ||
+      this.maxPages > BROWSER_CLIENT_HOST_PAGE_INVENTORY_MAX_PAGES
+    ) {
       throw new Error('browser_client_page_limit_invalid')
     }
   }
@@ -86,7 +102,15 @@ export class BrowserClientPageCommandExecutor {
   }
 
   hasUnresolvedPage(browserPageId: string, pageHostGeneration: number): boolean {
-    return this.failedPages.get(browserPageId) === pageHostGeneration
+    return this.failedPages.get(browserPageId)?.pageHostGeneration === pageHostGeneration
+  }
+
+  snapshotPageInventory(): readonly BrowserClientHostedPageInventory[] {
+    return snapshotBrowserClientPageInventoryList(
+      this.creatingPages,
+      this.pages.values(),
+      this.failedPages
+    )
   }
 
   close(): Promise<void> {
@@ -116,24 +140,25 @@ export class BrowserClientPageCommandExecutor {
     }
     if (
       this.pages.has(event.browserPageId) ||
-      this.creatingPageIds.has(event.browserPageId) ||
+      this.creatingPages.has(event.browserPageId) ||
       this.failedPages.has(event.browserPageId)
     ) {
       throw new BrowserClientPageCommandError('browser_client_page_generation_conflict')
     }
-    if (this.pages.size + this.creatingPageIds.size + this.failedPages.size >= this.maxPages) {
+    if (this.pages.size + this.creatingPages.size + this.failedPages.size >= this.maxPages) {
       throw new BrowserClientPageCommandError('browser_client_page_capacity')
     }
-    this.creatingPageIds.add(event.browserPageId)
+    const unknownInventory = createBrowserClientPageInventory(event, 'outcomeUnknown')
+    this.creatingPages.set(event.browserPageId, unknownInventory)
     try {
       await this.createReservedPage(event, signal)
     } catch (error) {
       if (isBrowserClientPageCleanupFailure(error)) {
-        this.failedPages.set(event.browserPageId, event.pageHostGeneration)
+        this.failedPages.set(event.browserPageId, unknownInventory)
       }
       throw error
     } finally {
-      this.creatingPageIds.delete(event.browserPageId)
+      this.creatingPages.delete(event.browserPageId)
     }
   }
 
@@ -144,7 +169,7 @@ export class BrowserClientPageCommandExecutor {
     if (event.command.type !== 'createPage') {
       throw new BrowserClientPageCommandError('browser_client_page_command_invalid')
     }
-    assertNotAborted(signal)
+    assertBrowserClientPageCommandNotAborted(signal)
     let route: RetainedNetworkRoute | null = null
     let routeSession: BrowserRouteSessionHandle | null = null
     let renderer: BrowserClientPageRenderer | null = null
@@ -156,9 +181,9 @@ export class BrowserClientPageCommandExecutor {
       if (route.key !== event.command.executionHostKey) {
         throw new BrowserClientPageCommandError('browser_client_page_execution_host_stale')
       }
-      assertNotAborted(signal)
+      assertBrowserClientPageCommandNotAborted(signal)
       renderer = this.dependencies.selectRenderer()
-      assertCurrentRenderer(renderer)
+      assertCurrentBrowserClientPageRenderer(renderer)
       routeSession = await this.dependencies.routeSessions.preparePage({
         identity: {
           orcaProfileId: this.dependencies.orcaProfileId,
@@ -171,9 +196,9 @@ export class BrowserClientPageCommandExecutor {
         rendererWebContentsId: renderer.rendererWebContentsId,
         proxyEndpoint: route.proxyEndpoint
       })
-      assertNotAborted(signal)
-      assertCurrentRenderer(renderer)
-      const page = pageIdentity(event, routeSession.partition)
+      assertBrowserClientPageCommandNotAborted(signal)
+      assertCurrentBrowserClientPageRenderer(renderer)
+      const page = browserClientPageIdentity(event, routeSession.partition)
       mountAttempted = true
       const mounted = await renderer.mountPage(page, signal)
       registration = {
@@ -185,8 +210,8 @@ export class BrowserClientPageCommandExecutor {
       if (!lifecycleClaim) {
         throw new BrowserClientPageCommandError('browser_client_page_guest_observation_failed')
       }
-      assertNotAborted(signal)
-      assertCurrentRenderer(renderer)
+      assertBrowserClientPageCommandNotAborted(signal)
+      assertCurrentBrowserClientPageRenderer(renderer)
       if (!this.dependencies.routeWebContents.registerGuest(registration)) {
         throw new BrowserClientPageCommandError('browser_client_page_guest_registration_failed')
       }
@@ -198,6 +223,7 @@ export class BrowserClientPageCommandExecutor {
       }
       this.pages.set(event.browserPageId, {
         generation: event.pageHostGeneration,
+        inventory: createBrowserClientPageInventory(event, 'active'),
         registration,
         lifecycleClaim,
         renderer,
@@ -211,7 +237,9 @@ export class BrowserClientPageCommandExecutor {
           guestMayExist: mountAttempted,
           lifecycleClaim,
           renderer,
-          rendererPage: routeSession ? pageIdentity(event, routeSession.partition) : null,
+          rendererPage: routeSession
+            ? browserClientPageIdentity(event, routeSession.partition)
+            : null,
           route,
           routeSession
         })
@@ -232,8 +260,8 @@ export class BrowserClientPageCommandExecutor {
     if (!page || page.generation !== event.pageHostGeneration || page.retiring) {
       throw new BrowserClientPageCommandError('browser_client_page_generation_stale')
     }
-    assertNotAborted(signal)
-    assertCurrentRenderer(page.renderer)
+    assertBrowserClientPageCommandNotAborted(signal)
+    assertCurrentBrowserClientPageRenderer(page.renderer)
     const normalized = normalizeBrowserNavigationUrl(event.command.url)
     if (!normalized || normalized.startsWith('file:')) {
       throw new BrowserClientPageCommandError('browser_client_page_navigation_invalid')
@@ -245,6 +273,7 @@ export class BrowserClientPageCommandExecutor {
     if (!navigated) {
       throw new BrowserClientPageCommandError('browser_client_page_navigation_failed')
     }
+    page.inventory = updateBrowserClientPageInventoryCurrentUrl(page.inventory, normalized)
   }
 
   private async cleanupPage(page: RetainedPage): Promise<void> {
@@ -252,7 +281,7 @@ export class BrowserClientPageCommandExecutor {
       guestMayExist: true,
       lifecycleClaim: page.lifecycleClaim,
       renderer: page.renderer,
-      rendererPage: pageIdentity(page.registration, page.registration.partition),
+      rendererPage: browserClientPageIdentity(page.registration, page.registration.partition),
       route: page.route,
       routeSession: page.routeSession
     })
@@ -260,7 +289,7 @@ export class BrowserClientPageCommandExecutor {
 
   private async closePages(): Promise<void> {
     const failures: unknown[] = [
-      ...(this.creatingPageIds.size > 0
+      ...(this.creatingPages.size > 0
         ? [new Error('browser_client_page_creation_still_running')]
         : []),
       ...(this.failedPages.size > 0 ? [new Error('browser_client_page_cleanup_unresolved')] : [])
@@ -279,32 +308,5 @@ export class BrowserClientPageCommandExecutor {
     if (failures.length > 0) {
       throw new AggregateError(failures, 'Browser client page executor cleanup failed')
     }
-  }
-}
-
-function pageIdentity(
-  page: Pick<BrowserClientHostCommandEvent, 'browserPageId' | 'pageHostGeneration'>,
-  partition: string
-): RendererPageIdentity {
-  return {
-    partition,
-    browserPageId: page.browserPageId,
-    pageHostGeneration: page.pageHostGeneration
-  }
-}
-
-function assertCurrentRenderer(renderer: BrowserClientPageRenderer): void {
-  if (
-    !Number.isInteger(renderer.rendererWebContentsId) ||
-    renderer.rendererWebContentsId <= 0 ||
-    !renderer.isCurrent()
-  ) {
-    throw new BrowserClientPageCommandError('browser_client_page_renderer_stale')
-  }
-}
-
-function assertNotAborted(signal: AbortSignal): void {
-  if (signal.aborted) {
-    throw new BrowserClientPageCommandError('browser_client_page_command_aborted')
   }
 }

--- a/src/main/browser/browser-client-page-command-integration.test.ts
+++ b/src/main/browser/browser-client-page-command-integration.test.ts
@@ -71,6 +71,9 @@ describe('BrowserClientPageCommandExecutor integration', () => {
     expect(guest.url()).toBe('https://example.internal/path')
 
     guest.destroy()
+    expect(executor.snapshotPageInventory()).toEqual([
+      expect.objectContaining({ browserPageId: 'page-a', state: 'outcomeUnknown' })
+    ])
     await expect(executor.retirePage('page-a', 7)).resolves.toBe(true)
     expect(guest.webContents.close).not.toHaveBeenCalled()
     expect(rendererRetire).toHaveBeenCalledOnce()

--- a/src/main/browser/browser-client-page-inventory.test.ts
+++ b/src/main/browser/browser-client-page-inventory.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import type { BrowserClientHostedPageInventory } from '../../shared/browser-client-host-protocol'
+import { prepareBrowserClientPageInventoryForAttach } from './browser-client-page-inventory'
+
+describe('browser client page inventory', () => {
+  it('uses codepoint order to break equal URL-compaction ties across input order', () => {
+    const pageIds = [
+      'ä-page',
+      'z-page',
+      ...Array.from({ length: 254 }, (_, index) => `page-${index.toString().padStart(3, '0')}`)
+    ]
+    const inventory = pageIds.map(inventoryPage)
+    const forward = prepareBrowserClientPageInventoryForAttach(inventory)
+    const reversed = prepareBrowserClientPageInventoryForAttach(inventory.toReversed())
+    if (!forward || !reversed) {
+      throw new Error('expected encodable inventory')
+    }
+    const omitted = omittedPageIds(forward)
+    const expected = [...pageIds].sort(compareCodepoints).slice(0, omitted.length)
+
+    expect(omitted.length).toBeGreaterThan(0)
+    expect(omitted).toEqual(expected)
+    expect(omittedPageIds(reversed)).toEqual(expected)
+  })
+
+  it('declines the optional snapshot instead of dropping an unencodable page', () => {
+    expect(
+      prepareBrowserClientPageInventoryForAttach([
+        inventoryPage('page-a'),
+        { ...inventoryPage('page-b'), browserProfileId: '\0'.repeat(256) }
+      ])
+    ).toBeUndefined()
+  })
+})
+
+function inventoryPage(browserPageId: string): BrowserClientHostedPageInventory {
+  return {
+    authorityRuntimeId: 'runtime-a',
+    authorityEpoch: 'epoch-old',
+    browserHostClientId: 'host-a',
+    browserHostGeneration: 2,
+    browserPageId,
+    pageHostGeneration: 3,
+    browserProfileId: 'profile-a',
+    executionHostKey: 'native:runtime-a:1',
+    state: 'active',
+    currentUrl: `https://remote.internal/${'x'.repeat(4096)}`
+  }
+}
+
+function omittedPageIds(pages: readonly BrowserClientHostedPageInventory[]): string[] {
+  return pages
+    .filter((page) => page.currentUrl === undefined)
+    .map((page) => page.browserPageId)
+    .sort(compareCodepoints)
+}
+
+function compareCodepoints(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0
+}

--- a/src/main/browser/browser-client-page-inventory.ts
+++ b/src/main/browser/browser-client-page-inventory.ts
@@ -1,0 +1,173 @@
+import {
+  BROWSER_CLIENT_HOST_PAGE_INVENTORY_MAX_BYTES,
+  BROWSER_CLIENT_HOST_PAGE_INVENTORY_MAX_PAGES,
+  BROWSER_CLIENT_HOST_PAGE_INVENTORY_URL_MAX_LENGTH,
+  BrowserClientHostedPageInventoryList,
+  browserClientHostedPageInventoryByteLength,
+  type BrowserClientHostedPageInventory,
+  type BrowserClientHostCommandEvent
+} from '../../shared/browser-client-host-protocol'
+import type { BrowserClientPageRenderer } from './browser-client-page-cleanup'
+import { BrowserClientPageCommandError } from './browser-client-page-command-failure'
+import type { BrowserRouteGuestLifecycleClaim } from './browser-route-page-authority'
+
+export function createBrowserClientPageInventory(
+  event: BrowserClientHostCommandEvent,
+  state: BrowserClientHostedPageInventory['state']
+): BrowserClientHostedPageInventory {
+  if (event.command.type !== 'createPage') {
+    throw new BrowserClientPageCommandError('browser_client_page_command_invalid')
+  }
+  return Object.freeze({
+    authorityRuntimeId: event.authorityRuntimeId,
+    authorityEpoch: event.authorityEpoch,
+    browserHostClientId: event.browserHostClientId,
+    browserHostGeneration: event.browserHostGeneration,
+    browserPageId: event.browserPageId,
+    pageHostGeneration: event.pageHostGeneration,
+    browserProfileId: event.command.browserProfileId,
+    executionHostKey: event.command.executionHostKey,
+    state
+  })
+}
+
+export function snapshotBrowserClientPageInventory(
+  inventory: BrowserClientHostedPageInventory,
+  renderer: BrowserClientPageRenderer,
+  lifecycleClaim: BrowserRouteGuestLifecycleClaim,
+  forceOutcomeUnknown = false
+): BrowserClientHostedPageInventory {
+  return Object.freeze({
+    ...inventory,
+    state:
+      !forceOutcomeUnknown &&
+      browserClientPageRendererIsCurrent(renderer) &&
+      browserRouteGuestLifecycleClaimIsCurrent(lifecycleClaim)
+        ? 'active'
+        : 'outcomeUnknown'
+  })
+}
+
+export function snapshotBrowserClientPageInventoryList(
+  creatingPages: ReadonlyMap<string, BrowserClientHostedPageInventory>,
+  retainedPages: Iterable<{
+    inventory: BrowserClientHostedPageInventory
+    lifecycleClaim: BrowserRouteGuestLifecycleClaim
+    renderer: BrowserClientPageRenderer
+    retiring: Promise<void> | null
+  }>,
+  failedPages: ReadonlyMap<string, BrowserClientHostedPageInventory>
+): readonly BrowserClientHostedPageInventory[] {
+  const inventoryByPageId = new Map(creatingPages)
+  for (const page of retainedPages) {
+    inventoryByPageId.set(
+      page.inventory.browserPageId,
+      snapshotBrowserClientPageInventory(
+        page.inventory,
+        page.renderer,
+        page.lifecycleClaim,
+        page.retiring !== null
+      )
+    )
+  }
+  for (const page of failedPages.values()) {
+    inventoryByPageId.set(page.browserPageId, page)
+  }
+  return Object.freeze(
+    [...inventoryByPageId.values()].sort((left, right) =>
+      left.browserPageId < right.browserPageId
+        ? -1
+        : left.browserPageId > right.browserPageId
+          ? 1
+          : 0
+    )
+  )
+}
+
+export function prepareBrowserClientPageInventoryForAttach(
+  pages: readonly BrowserClientHostedPageInventory[]
+): readonly BrowserClientHostedPageInventory[] | undefined {
+  if (pages.length > BROWSER_CLIENT_HOST_PAGE_INVENTORY_MAX_PAGES) {
+    return undefined
+  }
+  const inventory: BrowserClientHostedPageInventory[] = []
+  for (const page of pages) {
+    const parsed = BrowserClientHostedPageInventoryList.element.safeParse(page)
+    if (!parsed.success) {
+      return undefined
+    }
+    inventory.push(parsed.data)
+  }
+  let inventoryBytes = browserClientHostedPageInventoryByteLength(inventory)
+  const optionalUrls = inventory
+    .flatMap((page, index) => {
+      if (page.currentUrl === undefined) {
+        return []
+      }
+      const withoutUrl = omitBrowserClientPageInventoryUrl(page)
+      return [
+        {
+          browserPageId: page.browserPageId,
+          index,
+          savings:
+            browserClientHostedPageInventoryByteLength([page]) -
+            browserClientHostedPageInventoryByteLength([withoutUrl]),
+          withoutUrl
+        }
+      ]
+    })
+    .sort(
+      (left, right) =>
+        right.savings - left.savings ||
+        compareBrowserPageIds(left.browserPageId, right.browserPageId)
+    )
+  for (const candidate of optionalUrls) {
+    if (inventoryBytes <= BROWSER_CLIENT_HOST_PAGE_INVENTORY_MAX_BYTES) {
+      break
+    }
+    inventory[candidate.index] = candidate.withoutUrl
+    inventoryBytes -= candidate.savings
+  }
+  const prepared = BrowserClientHostedPageInventoryList.safeParse(inventory)
+  return prepared.success ? prepared.data : undefined
+}
+
+export function updateBrowserClientPageInventoryCurrentUrl(
+  inventory: BrowserClientHostedPageInventory,
+  currentUrl: string
+): BrowserClientHostedPageInventory {
+  if (currentUrl.length > BROWSER_CLIENT_HOST_PAGE_INVENTORY_URL_MAX_LENGTH) {
+    return Object.freeze(omitBrowserClientPageInventoryUrl(inventory))
+  }
+  return Object.freeze({ ...inventory, currentUrl })
+}
+
+function omitBrowserClientPageInventoryUrl(
+  inventory: BrowserClientHostedPageInventory
+): BrowserClientHostedPageInventory {
+  const withoutUrl = { ...inventory }
+  delete withoutUrl.currentUrl
+  return withoutUrl
+}
+
+function browserClientPageRendererIsCurrent(renderer: BrowserClientPageRenderer): boolean {
+  try {
+    return renderer.isCurrent()
+  } catch {
+    return false
+  }
+}
+
+function browserRouteGuestLifecycleClaimIsCurrent(
+  lifecycleClaim: BrowserRouteGuestLifecycleClaim
+): boolean {
+  try {
+    return lifecycleClaim.isCurrent()
+  } catch {
+    return false
+  }
+}
+
+function compareBrowserPageIds(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0
+}

--- a/src/main/browser/browser-route-guest-lifecycle-claim.ts
+++ b/src/main/browser/browser-route-guest-lifecycle-claim.ts
@@ -24,6 +24,7 @@ export function claimBrowserRouteGuestLifecycle(
   return Object.freeze({
     registration: Object.freeze({ ...registration }),
     guestAuthority: state.guestAuthority,
-    whenDestroyed: state.whenDestroyed
+    whenDestroyed: state.whenDestroyed,
+    isCurrent: () => !state.retirementRequested && registrationMatches()
   })
 }

--- a/src/main/browser/browser-route-page-authority.ts
+++ b/src/main/browser/browser-route-page-authority.ts
@@ -21,6 +21,7 @@ export type BrowserRouteGuestLifecycleClaim = Readonly<{
   registration: BrowserRoutePageGuestIdentity
   guestAuthority: symbol
   whenDestroyed: Promise<void>
+  isCurrent: () => boolean
 }>
 
 export type BrowserRoutePageAuthority = BrowserRoutePageOwnerIdentity &

--- a/src/main/browser/paired-runtime-browser-client-host-composition.test.ts
+++ b/src/main/browser/paired-runtime-browser-client-host-composition.test.ts
@@ -24,6 +24,16 @@ describe('PairedRuntimeBrowserClientHostComposition', () => {
     expect(rig.order).toEqual(['activate-routes', 'handle-command'])
   })
 
+  it('provides the exact executor inventory to the host attach', () => {
+    const rig = createRig()
+    rig.createComposition()
+
+    expect(rig.hostOptions.getPageInventory?.()).toEqual([
+      expect.objectContaining({ browserPageId: 'page-a', state: 'active' })
+    ])
+    expect(rig.executor.snapshotPageInventory).toHaveBeenCalledOnce()
+  })
+
   it('settles dispatcher retirement before destroying and forgetting the page', async () => {
     const rig = createRig()
     const composition = rig.createComposition()
@@ -127,6 +137,19 @@ function createRig(options: { executorCloseError?: Error; hostSettled?: boolean 
       return true
     }),
     hasUnresolvedPage: vi.fn(() => false),
+    snapshotPageInventory: vi.fn(() => [
+      {
+        authorityRuntimeId: 'runtime-a',
+        authorityEpoch: 'epoch-a',
+        browserHostClientId: 'client-a',
+        browserHostGeneration: 4,
+        browserPageId: 'page-a',
+        pageHostGeneration: 7,
+        browserProfileId: 'profile-a',
+        executionHostKey: 'execution-host-a',
+        state: 'active' as const
+      }
+    ]),
     close: vi.fn(async () => {
       order.push('close-executor')
       if (options.executorCloseError) {
@@ -135,6 +158,7 @@ function createRig(options: { executorCloseError?: Error; hostSettled?: boolean 
     })
   }
   let hostOptions: {
+    getPageInventory?: () => readonly unknown[]
     onAuthority?: (next: BrowserClientHostLeaseAuthority) => void
     handler?: (
       event: BrowserClientHostCommandEvent,

--- a/src/main/browser/paired-runtime-browser-client-host-composition.ts
+++ b/src/main/browser/paired-runtime-browser-client-host-composition.ts
@@ -1,4 +1,5 @@
 import type {
+  BrowserClientHostedPageInventory,
   BrowserClientHostCommandEvent,
   BrowserClientHostCommandResult,
   BrowserClientHostLeaseAuthority
@@ -17,6 +18,7 @@ type ComposedPageExecutor = {
   ): Promise<BrowserClientHostCommandResult>
   retirePage(browserPageId: string, pageHostGeneration: number): Promise<boolean>
   hasUnresolvedPage(browserPageId: string, pageHostGeneration: number): boolean
+  snapshotPageInventory(): readonly BrowserClientHostedPageInventory[]
   close(): Promise<void>
 }
 
@@ -42,6 +44,7 @@ type PairedRuntimeBrowserClientHostCompositionOptions = {
       signal: AbortSignal
     ): Promise<BrowserClientHostCommandResult>
     onAuthority(authority: BrowserClientHostLeaseAuthority): void
+    getPageInventory(): readonly BrowserClientHostedPageInventory[]
     onError(error: Error): void
   }): ComposedClientHost
   onError?: (error: Error) => void
@@ -63,6 +66,7 @@ export class PairedRuntimeBrowserClientHostComposition {
     })
     this.host = options.createHost({
       handler: (event, signal) => this.executor.handle(event, signal),
+      getPageInventory: () => this.executor.snapshotPageInventory(),
       onAuthority: (authority) => this.activateRoutes(authority),
       onError: (error) => this.handleHostError(error)
     })

--- a/src/main/browser/paired-runtime-browser-client-host-runtime.ts
+++ b/src/main/browser/paired-runtime-browser-client-host-runtime.ts
@@ -43,13 +43,14 @@ const browserClientHosts =
             routeSessions: browserRouteSessionRegistry,
             routeWebContents: browserRouteWebContentsRegistry
           }),
-        createHost: ({ handler, onAuthority, onError }) =>
+        createHost: ({ handler, getPageInventory, onAuthority, onError }) =>
           new PairedRuntimeBrowserClientHost({
             pairing: input.pairing,
             authorityRuntimeId: input.authorityRuntimeId,
             browserHostClientId,
             hostCapabilities: ['webview'],
             handler,
+            getPageInventory,
             onAuthority,
             onError
           }),

--- a/src/main/browser/paired-runtime-browser-client-host.test.ts
+++ b/src/main/browser/paired-runtime-browser-client-host.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { PairingOffer } from '../../shared/pairing'
 import type {
+  BrowserClientHostedPageInventory,
   BrowserClientHostCommandEvent,
   BrowserClientHostCommandResult
 } from '../../shared/browser-client-host-protocol'
@@ -36,6 +37,27 @@ afterEach(() => {
 })
 
 describe('PairedRuntimeBrowserClientHost', () => {
+  it('forwards a complete inventory provider to the lease attach', async () => {
+    const { callbacks } = subscribeHost()
+    const getPageInventory = vi.fn(() => [] as readonly BrowserClientHostedPageInventory[])
+    const host = createHost(() => ({ status: 'completed' }), undefined, undefined, getPageInventory)
+    const starting = host.start()
+    await vi.waitFor(() => expect(callbacks.current).toBeDefined())
+
+    expect(getPageInventory).toHaveBeenCalledOnce()
+    expect(subscribeRemoteRuntimeRequestMock).toHaveBeenCalledWith(
+      pairing,
+      'browser.clientHost.attach',
+      expect.objectContaining({ pageInventoryProtocolVersion: 1, pageInventory: [] }),
+      15_000,
+      expect.any(Object),
+      expect.any(Object)
+    )
+    callbacks.current!.onResponse(readyResponse())
+    await starting
+    await host.close()
+  })
+
   it('constructs command authority before the first command can arrive', async () => {
     const { callbacks, sendRequest } = subscribeHost()
     const handler = vi.fn((_command: BrowserClientHostCommandEvent, _signal: AbortSignal) => ({
@@ -271,7 +293,8 @@ function createHost(
     signal: AbortSignal
   ) => BrowserClientHostCommandResult | Promise<BrowserClientHostCommandResult>,
   onError?: (error: Error) => void,
-  dispatcher?: { joinTimeoutMs?: number }
+  dispatcher?: { joinTimeoutMs?: number },
+  getPageInventory?: () => readonly BrowserClientHostedPageInventory[]
 ): PairedRuntimeBrowserClientHost {
   return new PairedRuntimeBrowserClientHost({
     pairing,
@@ -279,6 +302,7 @@ function createHost(
     browserHostClientId: 'host-a',
     hostCapabilities: ['webview'],
     handler,
+    getPageInventory,
     onError,
     dispatcher
   })

--- a/src/main/browser/paired-runtime-browser-client-host.ts
+++ b/src/main/browser/paired-runtime-browser-client-host.ts
@@ -1,4 +1,5 @@
 import type {
+  BrowserClientHostedPageInventory,
   BrowserClientHostCommandEvent,
   BrowserClientHostCommandResult,
   BrowserClientHostLeaseAuthority
@@ -17,6 +18,7 @@ export type PairedRuntimeBrowserClientHostOptions = {
   browserHostClientId: string
   hostCapabilities: readonly string[]
   handler: CommandHandler
+  getPageInventory?: () => readonly BrowserClientHostedPageInventory[]
   dispatcher?: DispatcherLimits
   timeoutMs?: number
   subscription?: RemoteRuntimeSubscriptionOptions
@@ -40,6 +42,12 @@ export class PairedRuntimeBrowserClientHost {
       browserHostClientId: options.browserHostClientId,
       hostCapabilities: options.hostCapabilities,
       pageCommandProtocolVersion: 1,
+      ...(options.getPageInventory
+        ? {
+            pageInventoryProtocolVersion: 1,
+            getPageInventory: options.getPageInventory
+          }
+        : {}),
       onAuthority: (authority) => this.activateDispatcher(authority),
       onPageCommand: (command) => this.dispatch(command),
       timeoutMs: options.timeoutMs,

--- a/src/main/browser/paired-runtime-browser-host-lease-options.ts
+++ b/src/main/browser/paired-runtime-browser-host-lease-options.ts
@@ -1,4 +1,5 @@
 import type {
+  BrowserClientHostedPageInventory,
   BrowserClientHostCommandEvent,
   BrowserClientHostCommandResult,
   BrowserClientHostLeaseAuthority
@@ -12,6 +13,8 @@ export type PairedRuntimeBrowserHostLeaseOptions = {
   browserHostClientId: string
   hostCapabilities: readonly string[]
   pageCommandProtocolVersion?: 1
+  pageInventoryProtocolVersion?: 1
+  getPageInventory?: () => readonly BrowserClientHostedPageInventory[]
   onPageCommand?: (
     command: BrowserClientHostCommandEvent
   ) => BrowserClientHostCommandResult | Promise<BrowserClientHostCommandResult>

--- a/src/main/browser/paired-runtime-browser-host-lease.test.ts
+++ b/src/main/browser/paired-runtime-browser-host-lease.test.ts
@@ -1,8 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { PairingOffer } from '../../shared/pairing'
 import type {
+  BrowserClientHostedPageInventory,
   BrowserClientHostCommandEvent,
   BrowserClientHostCommandResult
+} from '../../shared/browser-client-host-protocol'
+import {
+  BROWSER_CLIENT_HOST_PAGE_INVENTORY_MAX_BYTES,
+  browserClientHostedPageInventoryByteLength
 } from '../../shared/browser-client-host-protocol'
 import { BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY } from '../../shared/protocol-version'
 import type {
@@ -38,7 +43,9 @@ describe('PairedRuntimeBrowserHostLease', () => {
   it.each([
     [{ maxConcurrentCommandResults: 17 }, 'limit is invalid'],
     [{ maxUnsettledCommandResults: 257 }, 'limit is invalid'],
-    [{ maxConcurrentCommandResults: 2, maxUnsettledCommandResults: 1 }, 'limits are inconsistent']
+    [{ maxConcurrentCommandResults: 2, maxUnsettledCommandResults: 1 }, 'limits are inconsistent'],
+    [{ getPageInventory: () => [] }, 'inventory negotiation is incomplete'],
+    [{ pageInventoryProtocolVersion: 1 as const }, 'inventory negotiation is incomplete']
   ])('rejects unsafe command-result limits', (limits, expectedMessage) => {
     expect(() => createLease(limits)).toThrow(expectedMessage)
   })
@@ -134,6 +141,96 @@ describe('PairedRuntimeBrowserHostLease', () => {
       15_000
     )
     expect(close).not.toHaveBeenCalled()
+    await lease.close()
+  })
+
+  it('sends one complete inventory snapshot and activates it only after the echo', async () => {
+    const { callbacks } = await subscribeLease()
+    const page = inventoryPage()
+    const getPageInventory = vi.fn(() => [page])
+    const lease = createLease({
+      pageInventoryProtocolVersion: 1,
+      getPageInventory
+    })
+    const starting = lease.start()
+    await vi.waitFor(() => expect(callbacks.current).toBeDefined())
+
+    expect(getPageInventory).toHaveBeenCalledOnce()
+    expect(subscribeRemoteRuntimeRequestMock).toHaveBeenCalledWith(
+      pairing,
+      'browser.clientHost.attach',
+      expect.objectContaining({
+        pageInventoryProtocolVersion: 1,
+        pageInventory: [page]
+      }),
+      15_000,
+      expect.any(Object),
+      expect.any(Object)
+    )
+    callbacks.current!.onResponse(readyResponse({ pageInventoryProtocolVersion: 1 }))
+
+    await expect(starting).resolves.toMatchObject({ pageInventoryProtocolVersion: 1 })
+    await lease.close()
+  })
+
+  it('omits optional URLs deterministically to keep every page identity within budget', async () => {
+    const { callbacks } = await subscribeLease()
+    const inventory = Array.from({ length: 256 }, (_, index) => ({
+      ...inventoryPage(),
+      browserPageId: `page-${index.toString().padStart(3, '0')}`,
+      currentUrl: `https://remote.internal/${index}/${'x'.repeat(4096)}`
+    }))
+    const lease = createLease({
+      pageInventoryProtocolVersion: 1,
+      getPageInventory: () => inventory
+    })
+    const starting = lease.start()
+    await vi.waitFor(() => expect(callbacks.current).toBeDefined())
+    const attach = subscribeRemoteRuntimeRequestMock.mock.calls[0]?.[2] as {
+      pageInventory: BrowserClientHostedPageInventory[]
+    }
+
+    expect(attach.pageInventory).toHaveLength(256)
+    expect(browserClientHostedPageInventoryByteLength(attach.pageInventory)).toBeLessThanOrEqual(
+      BROWSER_CLIENT_HOST_PAGE_INVENTORY_MAX_BYTES
+    )
+    expect(attach.pageInventory.some((page) => page.currentUrl === undefined)).toBe(true)
+    expect(new Set(attach.pageInventory.map((page) => page.browserPageId)).size).toBe(256)
+    callbacks.current!.onResponse(readyResponse({ pageInventoryProtocolVersion: 1 }))
+    await starting
+    await lease.close()
+  })
+
+  it('treats a missing inventory echo as unsupported rather than accepted empty state', async () => {
+    const { callbacks } = await subscribeLease()
+    const lease = createLease({
+      pageInventoryProtocolVersion: 1,
+      getPageInventory: () => []
+    })
+    const starting = lease.start()
+    await vi.waitFor(() => expect(callbacks.current).toBeDefined())
+    callbacks.current!.onResponse(readyResponse())
+
+    await expect(starting).resolves.not.toHaveProperty('pageInventoryProtocolVersion')
+    expect(subscribeRemoteRuntimeRequestMock).toHaveBeenCalledWith(
+      pairing,
+      'browser.clientHost.attach',
+      expect.objectContaining({ pageInventoryProtocolVersion: 1, pageInventory: [] }),
+      15_000,
+      expect.any(Object),
+      expect.any(Object)
+    )
+    await lease.close()
+  })
+
+  it('rejects an unsolicited inventory echo', async () => {
+    const { callbacks } = await subscribeLease()
+    const lease = createLease()
+    const starting = lease.start()
+    await vi.waitFor(() => expect(callbacks.current).toBeDefined())
+    callbacks.current!.onResponse(readyResponse({ pageInventoryProtocolVersion: 1 }))
+
+    await expect(starting).rejects.toThrow('Invalid browser host lease response')
     await lease.close()
   })
 
@@ -643,6 +740,7 @@ async function subscribeLease(options?: { sendRequest?: ReturnType<typeof vi.fn>
 
 function createLease(
   overrides: {
+    getPageInventory?: () => readonly BrowserClientHostedPageInventory[]
     maxConcurrentCommandResults?: number
     maxUnsettledCommandResults?: number
     onError?: (error: Error) => void
@@ -650,6 +748,7 @@ function createLease(
       command: BrowserClientHostCommandEvent
     ) => BrowserClientHostCommandResult | Promise<BrowserClientHostCommandResult>
     pageCommandProtocolVersion?: 1
+    pageInventoryProtocolVersion?: 1
   } = {}
 ): PairedRuntimeBrowserHostLease {
   return new PairedRuntimeBrowserHostLease({
@@ -661,7 +760,24 @@ function createLease(
   })
 }
 
-function readyResponse(overrides: { pageCommandProtocolVersion?: 1 } = {}) {
+function inventoryPage(): BrowserClientHostedPageInventory {
+  return {
+    authorityRuntimeId: 'runtime-a',
+    authorityEpoch: 'epoch-old',
+    browserHostClientId: 'host-a',
+    browserHostGeneration: 2,
+    browserPageId: 'page-a',
+    pageHostGeneration: 3,
+    browserProfileId: 'profile-a',
+    executionHostKey: 'native:runtime-a:1',
+    state: 'active',
+    currentUrl: 'https://remote.internal/'
+  }
+}
+
+function readyResponse(
+  overrides: { pageCommandProtocolVersion?: 1; pageInventoryProtocolVersion?: 1 } = {}
+) {
   return {
     id: 'browser-host',
     ok: true as const,

--- a/src/main/browser/paired-runtime-browser-host-lease.ts
+++ b/src/main/browser/paired-runtime-browser-host-lease.ts
@@ -12,6 +12,10 @@ import {
   type RemoteRuntimeSubscription
 } from '../../shared/remote-runtime-client'
 import { RemoteRuntimeClientError } from '../../shared/remote-runtime-client-error'
+import {
+  assertBrowserClientHostAttachOptions,
+  createBrowserClientHostAttachRequest
+} from './browser-client-host-attach-request'
 import { sameBrowserClientHostLeaseAuthority } from './browser-client-host-command-authority'
 import {
   BrowserHostCommandResultSettler,
@@ -29,6 +33,7 @@ export class PairedRuntimeBrowserHostLease {
   private closed = false
 
   constructor(private readonly options: PairedRuntimeBrowserHostLeaseOptions) {
+    assertBrowserClientHostAttachOptions(options)
     this.commandResultSettler = new BrowserHostCommandResultSettler({
       maxConcurrent: options.maxConcurrentCommandResults,
       maxUnsettled: options.maxUnsettledCommandResults,
@@ -66,16 +71,12 @@ export class PairedRuntimeBrowserHostLease {
     void ready.catch(() => undefined)
     let readyTimeout: ReturnType<typeof setTimeout> | null = null
     try {
-      const pageCommandProtocolVersion = this.requestedPageCommandProtocolVersion()
+      const { pageCommandProtocolVersion, pageInventoryProtocolVersion, params } =
+        createBrowserClientHostAttachRequest(this.options)
       const subscription = await subscribeRemoteRuntimeRequest(
         this.options.pairing,
         'browser.clientHost.attach',
-        {
-          authorityRuntimeId: this.options.authorityRuntimeId,
-          browserHostClientId: this.options.browserHostClientId,
-          hostCapabilities: [...this.options.hostCapabilities],
-          ...(pageCommandProtocolVersion ? { pageCommandProtocolVersion } : {})
-        },
+        params,
         timeoutMs,
         {
           onResponse: (response) => {
@@ -117,6 +118,13 @@ export class PairedRuntimeBrowserHostLease {
               this.fail(new Error('Invalid browser host lease response'), rejectReady)
               return
             }
+            if (
+              parsed.data.pageInventoryProtocolVersion !== undefined &&
+              parsed.data.pageInventoryProtocolVersion !== pageInventoryProtocolVersion
+            ) {
+              this.fail(new Error('Invalid browser host lease response'), rejectReady)
+              return
+            }
             if (parsed.data.pageCommandProtocolVersion && !this.subscription?.sendRequest) {
               this.fail(new Error('Browser host command result transport unavailable'), rejectReady)
               return
@@ -128,6 +136,9 @@ export class PairedRuntimeBrowserHostLease {
               browserHostGeneration: parsed.data.browserHostGeneration,
               ...(parsed.data.pageCommandProtocolVersion
                 ? { pageCommandProtocolVersion: parsed.data.pageCommandProtocolVersion }
+                : {}),
+              ...(parsed.data.pageInventoryProtocolVersion
+                ? { pageInventoryProtocolVersion: parsed.data.pageInventoryProtocolVersion }
                 : {})
             })
             if (this.authority) {
@@ -194,10 +205,6 @@ export class PairedRuntimeBrowserHostLease {
     void closing.catch((closeError) =>
       this.reportError(closeError instanceof Error ? closeError : new Error(String(closeError)))
     )
-  }
-
-  private requestedPageCommandProtocolVersion(): 1 | undefined {
-    return this.options.onPageCommand ? this.options.pageCommandProtocolVersion : undefined
   }
 
   private handlePageCommand(

--- a/src/main/runtime/browser-host-lease-fencing.ts
+++ b/src/main/runtime/browser-host-lease-fencing.ts
@@ -1,0 +1,34 @@
+import type { BrowserHostLeaseState, BrowserHostRouteState } from './browser-host-lease-records'
+import type { BrowserHostFenceReason } from './browser-host-lease-fence'
+
+export function fenceBrowserHostLease(
+  state: BrowserHostLeaseState,
+  reason: BrowserHostFenceReason,
+  leasesByClientId: Map<string, BrowserHostLeaseState>,
+  fenceRoute: (route: BrowserHostRouteState, reason: BrowserHostFenceReason) => void
+): void {
+  if (leasesByClientId.get(state.lease.browserHostClientId)?.token !== state.token) {
+    return
+  }
+  leasesByClientId.delete(state.lease.browserHostClientId)
+  for (const route of state.routes) {
+    fenceRoute(route, reason === 'replaced' ? 'lease_replaced' : 'lease_released')
+  }
+  state.executionHostGrants.clear()
+  state.commandLedger?.close()
+  state.fence.resolve(reason)
+}
+
+export function fenceBrowserHostRoute(
+  state: BrowserHostRouteState,
+  reason: BrowserHostFenceReason,
+  routesByKey: Map<string, BrowserHostRouteState>
+): void {
+  state.releaseGrantLink?.()
+  state.releaseGrantLink = undefined
+  state.lease.routes.delete(state)
+  if (routesByKey.get(state.key)?.token === state.token) {
+    routesByKey.delete(state.key)
+  }
+  state.fence.resolve(reason)
+}

--- a/src/main/runtime/browser-host-lease-records.ts
+++ b/src/main/runtime/browser-host-lease-records.ts
@@ -1,3 +1,4 @@
+import type { BrowserClientHostedPageInventory } from '../../shared/browser-client-host-protocol'
 import type { BrowserExecutionHostGrantRegistry } from './browser-execution-host-grant-registry'
 import type { BrowserHostCommandLedger } from './browser-host-command-ledger'
 import type { BrowserHostFence, BrowserHostFenceReason } from './browser-host-lease-fence'
@@ -15,6 +16,8 @@ export type BrowserHostLease = Readonly<{
   pairedDeviceId: string
   hostCapabilities: readonly string[]
   pageCommandProtocolVersion?: 1
+  pageInventoryProtocolVersion?: 1
+  pageInventory?: readonly BrowserClientHostedPageInventory[]
 }>
 
 export type BrowserHostLeaseIdentity = Pick<

--- a/src/main/runtime/browser-host-lease-registry.test.ts
+++ b/src/main/runtime/browser-host-lease-registry.test.ts
@@ -5,6 +5,67 @@ const registry = (): BrowserHostLeaseRegistry =>
   new BrowserHostLeaseRegistry({ authorityRuntimeId: 'runtime-a', authorityEpoch: 'epoch-a' })
 
 describe('BrowserHostLeaseRegistry', () => {
+  it('rejects incomplete, duplicate, and foreign-client inventory before replacing a lease', () => {
+    const leases = registry()
+    const attach = (overrides: Record<string, unknown>) =>
+      leases.attach({
+        browserHostClientId: 'host-a',
+        connectionId: 'connection-a',
+        pairedDeviceId: 'device-a',
+        hostCapabilities: ['webview'],
+        ...overrides
+      })
+    const page = inventoryPage()
+
+    expect(() => attach({ pageInventoryProtocolVersion: 1 })).toThrow(
+      'browser_host_page_inventory_negotiation_incomplete'
+    )
+    expect(() =>
+      attach({ pageInventoryProtocolVersion: 2 as never, pageInventory: [page] })
+    ).toThrow('browser_host_page_inventory_protocol_unsupported')
+    expect(() => attach({ pageInventory: [page] })).toThrow(
+      'browser_host_page_inventory_negotiation_incomplete'
+    )
+    expect(() => attach({ pageInventoryProtocolVersion: 1, pageInventory: [page, page] })).toThrow(
+      'Duplicate browser page inventory identity'
+    )
+    expect(() =>
+      attach({
+        pageInventoryProtocolVersion: 1,
+        pageInventory: [{ ...page, browserHostClientId: 'host-b' }]
+      })
+    ).toThrow('browser_host_page_inventory_authority_mismatch')
+    expect(
+      attach({
+        pageInventoryProtocolVersion: 1,
+        pageInventory: [{ ...page, authorityRuntimeId: 'runtime-old' }]
+      }).lease.pageInventory
+    ).toEqual([expect.objectContaining({ authorityRuntimeId: 'runtime-old' })])
+  })
+
+  it('retains an immutable inventory snapshot on the authenticated lease', () => {
+    const leases = registry()
+    const page = inventoryPage()
+    const pageInventory = [page]
+    const lease = leases.attach({
+      browserHostClientId: 'host-a',
+      connectionId: 'connection-a',
+      pairedDeviceId: 'device-a',
+      hostCapabilities: ['webview'],
+      pageInventoryProtocolVersion: 1,
+      pageInventory
+    }).lease
+
+    page.currentUrl = 'https://mutated.invalid/'
+    pageInventory.length = 0
+
+    expect(lease.pageInventory).toEqual([
+      expect.objectContaining({ browserPageId: 'page-a', currentUrl: 'https://remote.internal/' })
+    ])
+    expect(Object.isFrozen(lease.pageInventory)).toBe(true)
+    expect(Object.isFrozen(lease.pageInventory?.[0])).toBe(true)
+  })
+
   it('selects only an exact host when more than one lease is live', () => {
     const leases = registry()
     leases.attach({
@@ -346,3 +407,18 @@ describe('BrowserHostLeaseRegistry', () => {
     ).toThrow('browser_tunnel_execution_host_not_granted')
   })
 })
+
+function inventoryPage() {
+  return {
+    authorityRuntimeId: 'runtime-a',
+    authorityEpoch: 'epoch-old',
+    browserHostClientId: 'host-a',
+    browserHostGeneration: 2,
+    browserPageId: 'page-a',
+    pageHostGeneration: 3,
+    browserProfileId: 'profile-a',
+    executionHostKey: 'native:runtime-a:1',
+    state: 'active' as const,
+    currentUrl: 'https://remote.internal/'
+  }
+}

--- a/src/main/runtime/browser-host-lease-registry.ts
+++ b/src/main/runtime/browser-host-lease-registry.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto'
 import type {
+  BrowserClientHostedPageInventory,
   BrowserClientHostCommandEvent,
   BrowserClientHostCommandResult
 } from '../../shared/browser-client-host-protocol'
@@ -27,10 +28,12 @@ import {
   type RuntimeBrowserPlacement
 } from './browser-host-page-placement'
 import { createBrowserHostFence, type BrowserHostFenceReason } from './browser-host-lease-fence'
+import { fenceBrowserHostLease, fenceBrowserHostRoute } from './browser-host-lease-fencing'
 import {
   BROWSER_HOST_WEBVIEW_CAPABILITY,
   selectBrowserHostLease
 } from './browser-host-capability-selection'
+import { snapshotBrowserHostPageInventory } from './browser-host-page-inventory-snapshot'
 
 export class BrowserHostLeaseRegistry {
   readonly authorityRuntimeId: string
@@ -55,7 +58,10 @@ export class BrowserHostLeaseRegistry {
     pairedDeviceId: string
     hostCapabilities: readonly string[]
     pageCommandProtocolVersion?: 1
+    pageInventoryProtocolVersion?: 1
+    pageInventory?: readonly BrowserClientHostedPageInventory[]
   }): BrowserHostLeaseHandle {
+    const pageInventory = snapshotBrowserHostPageInventory(input)
     const existing = this.leasesByClientId.get(input.browserHostClientId)
     if (existing) {
       if (existing.lease.pairedDeviceId !== input.pairedDeviceId) {
@@ -77,7 +83,13 @@ export class BrowserHostLeaseRegistry {
         connectionId: input.connectionId,
         pairedDeviceId: input.pairedDeviceId,
         hostCapabilities: Object.freeze([...input.hostCapabilities]),
-        ...(input.pageCommandProtocolVersion ? { pageCommandProtocolVersion: 1 as const } : {})
+        ...(input.pageCommandProtocolVersion ? { pageCommandProtocolVersion: 1 as const } : {}),
+        ...(pageInventory
+          ? {
+              pageInventoryProtocolVersion: 1 as const,
+              pageInventory
+            }
+          : {})
       }),
       fence: createBrowserHostFence(),
       routes: new Set(),
@@ -285,26 +297,13 @@ export class BrowserHostLeaseRegistry {
   }
 
   private fenceLease(state: BrowserHostLeaseState, reason: BrowserHostFenceReason): void {
-    if (this.leasesByClientId.get(state.lease.browserHostClientId)?.token !== state.token) {
-      return
-    }
-    this.leasesByClientId.delete(state.lease.browserHostClientId)
-    for (const route of state.routes) {
-      this.fenceRoute(route, reason === 'replaced' ? 'lease_replaced' : 'lease_released')
-    }
-    state.executionHostGrants.clear()
-    state.commandLedger?.close()
-    state.fence.resolve(reason)
+    fenceBrowserHostLease(state, reason, this.leasesByClientId, (route, routeReason) =>
+      this.fenceRoute(route, routeReason)
+    )
   }
 
   private fenceRoute(state: BrowserHostRouteState, reason: BrowserHostFenceReason): void {
-    state.releaseGrantLink?.()
-    state.releaseGrantLink = undefined
-    state.lease.routes.delete(state)
-    if (this.routesByKey.get(state.key)?.token === state.token) {
-      this.routesByKey.delete(state.key)
-    }
-    state.fence.resolve(reason)
+    fenceBrowserHostRoute(state, reason, this.routesByKey)
   }
 }
 

--- a/src/main/runtime/browser-host-page-inventory-snapshot.ts
+++ b/src/main/runtime/browser-host-page-inventory-snapshot.ts
@@ -1,0 +1,28 @@
+import {
+  BrowserClientHostedPageInventoryList,
+  type BrowserClientHostedPageInventory
+} from '../../shared/browser-client-host-protocol'
+
+export function snapshotBrowserHostPageInventory(input: {
+  browserHostClientId: string
+  pageInventoryProtocolVersion?: 1
+  pageInventory?: readonly BrowserClientHostedPageInventory[]
+}): readonly BrowserClientHostedPageInventory[] | undefined {
+  if ((input.pageInventoryProtocolVersion === undefined) !== (input.pageInventory === undefined)) {
+    throw new Error('browser_host_page_inventory_negotiation_incomplete')
+  }
+  if (input.pageInventoryProtocolVersion === undefined || !input.pageInventory) {
+    return undefined
+  }
+  if (input.pageInventoryProtocolVersion !== 1) {
+    throw new Error('browser_host_page_inventory_protocol_unsupported')
+  }
+  const inventory = BrowserClientHostedPageInventoryList.parse(input.pageInventory)
+  for (const page of inventory) {
+    if (page.browserHostClientId !== input.browserHostClientId) {
+      throw new Error('browser_host_page_inventory_authority_mismatch')
+    }
+    Object.freeze(page)
+  }
+  return Object.freeze(inventory)
+}

--- a/src/main/runtime/browser-host-page-reconciliation-plan.test.ts
+++ b/src/main/runtime/browser-host-page-reconciliation-plan.test.ts
@@ -5,6 +5,8 @@ import {
   type BrowserHostRuntimePageIntent
 } from './browser-host-page-reconciliation-plan'
 
+const inventorySource = { inventoryPairedDeviceId: 'device-a' }
+
 const currentIntent = (overrides: Partial<BrowserHostRuntimePageIntent> = {}) => ({
   authorityRuntimeId: 'runtime-new',
   authorityEpoch: 'epoch-new',
@@ -24,12 +26,24 @@ const currentPage = (overrides: Partial<BrowserClientHostedPageInventory> = {}) 
   ...overrides
 })
 
+function inventoryPageAuthority(
+  previous: NonNullable<BrowserHostRuntimePageIntent['reclaimFrom']>
+) {
+  return {
+    authorityRuntimeId: previous.authorityRuntimeId,
+    authorityEpoch: previous.authorityEpoch,
+    browserHostClientId: previous.browserHostClientId,
+    browserHostGeneration: previous.browserHostGeneration,
+    pageHostGeneration: previous.pageHostGeneration
+  }
+}
+
 describe('browser host page reconciliation plan', () => {
   it('retains an exact current page without navigation or restoration', () => {
     const intent = currentIntent()
     const page = currentPage()
 
-    const plan = planBrowserHostPageReconciliation([intent], [page])
+    const plan = planBrowserHostPageReconciliation([intent], [page], inventorySource)
 
     expect(plan).toEqual({
       retain: [{ intent, page }],
@@ -43,7 +57,7 @@ describe('browser host page reconciliation plan', () => {
   it('restores runtime pages missing from authoritative client inventory', () => {
     const intent = currentIntent()
 
-    expect(planBrowserHostPageReconciliation([intent], [])).toEqual({
+    expect(planBrowserHostPageReconciliation([intent], [], inventorySource)).toEqual({
       retain: [],
       reclaim: [],
       close: [],
@@ -55,7 +69,7 @@ describe('browser host page reconciliation plan', () => {
   it('closes client orphans that have no runtime intent', () => {
     const page = currentPage()
 
-    expect(planBrowserHostPageReconciliation([], [page])).toEqual({
+    expect(planBrowserHostPageReconciliation([], [page], inventorySource)).toEqual({
       retain: [],
       reclaim: [],
       close: [page],
@@ -74,7 +88,7 @@ describe('browser host page reconciliation plan', () => {
     const intent = currentIntent()
     const page = currentPage(mismatch)
 
-    expect(planBrowserHostPageReconciliation([intent], [page])).toEqual({
+    expect(planBrowserHostPageReconciliation([intent], [page], inventorySource)).toEqual({
       retain: [],
       reclaim: [],
       close: [],
@@ -89,12 +103,13 @@ describe('browser host page reconciliation plan', () => {
       authorityEpoch: 'epoch-old',
       browserHostClientId: 'client-a',
       browserHostGeneration: 4,
-      pageHostGeneration: 7
+      pageHostGeneration: 7,
+      pairedDeviceId: 'device-a'
     }
     const intent = currentIntent({ reclaimFrom: previous })
-    const page = currentPage({ ...previous })
+    const page = currentPage(inventoryPageAuthority(previous))
 
-    expect(planBrowserHostPageReconciliation([intent], [page])).toEqual({
+    expect(planBrowserHostPageReconciliation([intent], [page], inventorySource)).toEqual({
       retain: [],
       reclaim: [{ intent, page }],
       close: [],
@@ -115,6 +130,7 @@ describe('browser host page reconciliation plan', () => {
       browserHostClientId: 'client-a',
       browserHostGeneration: 4,
       pageHostGeneration: 7,
+      pairedDeviceId: 'device-a',
       ...previousOverride
     }
     const intent = currentIntent(previousOverride === undefined ? {} : { reclaimFrom: previous })
@@ -125,7 +141,7 @@ describe('browser host page reconciliation plan', () => {
       pageHostGeneration: 7
     })
 
-    expect(planBrowserHostPageReconciliation([intent], [page])).toMatchObject({
+    expect(planBrowserHostPageReconciliation([intent], [page], inventorySource)).toMatchObject({
       retain: [],
       reclaim: [],
       close: [],
@@ -140,14 +156,15 @@ describe('browser host page reconciliation plan', () => {
       authorityEpoch: 'epoch-old',
       browserHostClientId: 'client-a',
       browserHostGeneration: 4,
-      pageHostGeneration: 7
+      pageHostGeneration: 7,
+      pairedDeviceId: 'device-a'
     }
     const intent = currentIntent({ browserHostClientId: 'client-b', reclaimFrom: previous })
-    const page = currentPage({ ...previous })
+    const page = currentPage(inventoryPageAuthority(previous))
 
-    expect(planBrowserHostPageReconciliation([intent], [page]).closeThenRestore).toEqual([
-      { intent, page }
-    ])
+    expect(
+      planBrowserHostPageReconciliation([intent], [page], inventorySource).closeThenRestore
+    ).toEqual([{ intent, page }])
   })
 
   it('rejects reclaim within one authority epoch even when previous identity is exact', () => {
@@ -156,18 +173,19 @@ describe('browser host page reconciliation plan', () => {
       authorityEpoch: 'epoch-new',
       browserHostClientId: 'client-a',
       browserHostGeneration: 9,
-      pageHostGeneration: 12
+      pageHostGeneration: 12,
+      pairedDeviceId: 'device-a'
     }
     const intent = currentIntent({
       browserHostGeneration: 8,
       pageHostGeneration: 11,
       reclaimFrom: previous
     })
-    const page = currentPage({ ...previous })
+    const page = currentPage(inventoryPageAuthority(previous))
 
-    expect(planBrowserHostPageReconciliation([intent], [page]).closeThenRestore).toEqual([
-      { intent, page }
-    ])
+    expect(
+      planBrowserHostPageReconciliation([intent], [page], inventorySource).closeThenRestore
+    ).toEqual([{ intent, page }])
   })
 
   it('permits generation counters to restart under a new authority epoch', () => {
@@ -176,16 +194,38 @@ describe('browser host page reconciliation plan', () => {
       authorityEpoch: 'epoch-old',
       browserHostClientId: 'client-a',
       browserHostGeneration: 9,
-      pageHostGeneration: 12
+      pageHostGeneration: 12,
+      pairedDeviceId: 'device-a'
     }
     const intent = currentIntent({
       browserHostGeneration: 1,
       pageHostGeneration: 1,
       reclaimFrom: previous
     })
-    const page = currentPage({ ...previous })
+    const page = currentPage(inventoryPageAuthority(previous))
 
-    expect(planBrowserHostPageReconciliation([intent], [page]).reclaim).toEqual([{ intent, page }])
+    expect(planBrowserHostPageReconciliation([intent], [page], inventorySource).reclaim).toEqual([
+      { intent, page }
+    ])
+  })
+
+  it('rejects restart reclaim from a different authenticated paired device', () => {
+    const previous = {
+      authorityRuntimeId: 'runtime-old',
+      authorityEpoch: 'epoch-old',
+      browserHostClientId: 'client-a',
+      browserHostGeneration: 4,
+      pageHostGeneration: 7,
+      pairedDeviceId: 'device-a'
+    }
+    const intent = currentIntent({ reclaimFrom: previous })
+    const page = currentPage(inventoryPageAuthority(previous))
+
+    expect(
+      planBrowserHostPageReconciliation([intent], [page], {
+        inventoryPairedDeviceId: 'device-b'
+      }).closeThenRestore
+    ).toEqual([{ intent, page }])
   })
 
   it('never retains or reclaims an outcome-unknown page', () => {
@@ -195,12 +235,13 @@ describe('browser host page reconciliation plan', () => {
         authorityEpoch: 'epoch-new',
         browserHostClientId: 'client-a',
         browserHostGeneration: 9,
-        pageHostGeneration: 12
+        pageHostGeneration: 12,
+        pairedDeviceId: 'device-a'
       }
     })
     const page = currentPage({ state: 'outcomeUnknown' })
 
-    expect(planBrowserHostPageReconciliation([intent], [page])).toEqual({
+    expect(planBrowserHostPageReconciliation([intent], [page], inventorySource)).toEqual({
       retain: [],
       reclaim: [],
       close: [],
@@ -213,7 +254,7 @@ describe('browser host page reconciliation plan', () => {
     ['runtime intent', [currentIntent(), currentIntent()], []],
     ['client inventory', [], [currentPage(), currentPage()]]
   ])('rejects duplicate page IDs in %s', (_label, intents, pages) => {
-    expect(() => planBrowserHostPageReconciliation(intents, pages)).toThrow(
+    expect(() => planBrowserHostPageReconciliation(intents, pages, inventorySource)).toThrow(
       'browser_host_page_reconciliation_duplicate'
     )
   })
@@ -223,7 +264,7 @@ describe('browser host page reconciliation plan', () => {
       planBrowserHostPageReconciliation(
         [currentIntent(), currentIntent({ browserPageId: 'page-b' })],
         [],
-        { maxPages: 1 }
+        { ...inventorySource, maxPages: 1 }
       )
     ).toThrow('browser_host_page_reconciliation_capacity')
   })
@@ -234,32 +275,41 @@ describe('browser host page reconciliation plan', () => {
     ['zero generation', currentIntent({ pageHostGeneration: 0 }), 'generation'],
     ['oversized generation', currentIntent({ pageHostGeneration: 0x1_0000_0000 }), 'generation']
   ])('rejects %s', (_label, intent, errorKind) => {
-    expect(() => planBrowserHostPageReconciliation([intent], [])).toThrow(
+    expect(() => planBrowserHostPageReconciliation([intent], [], inventorySource)).toThrow(
       `browser_host_page_reconciliation_${errorKind}_invalid`
     )
   })
 
   it('rejects oversized URLs and unknown client page states', () => {
     expect(() =>
-      planBrowserHostPageReconciliation([], [currentPage({ currentUrl: 'u'.repeat(8193) })])
+      planBrowserHostPageReconciliation(
+        [],
+        [currentPage({ currentUrl: 'u'.repeat(8193) })],
+        inventorySource
+      )
     ).toThrow('browser_host_page_reconciliation_url_invalid')
     const invalidState = { ...currentPage(), state: 'other' }
     expect(() =>
       planBrowserHostPageReconciliation(
         [],
-        [invalidState as unknown as BrowserClientHostedPageInventory]
+        [invalidState as unknown as BrowserClientHostedPageInventory],
+        inventorySource
       )
     ).toThrow('browser_host_page_reconciliation_state_invalid')
   })
 
   it.each([0, 257])('rejects invalid max page limit %s', (maxPages) => {
-    expect(() => planBrowserHostPageReconciliation([], [], { maxPages })).toThrow(
-      'browser_host_page_reconciliation_limit_invalid'
-    )
+    expect(() =>
+      planBrowserHostPageReconciliation([], [], { ...inventorySource, maxPages })
+    ).toThrow('browser_host_page_reconciliation_limit_invalid')
   })
 
   it('returns immutable records and action lists', () => {
-    const plan = planBrowserHostPageReconciliation([currentIntent()], [currentPage()])
+    const plan = planBrowserHostPageReconciliation(
+      [currentIntent()],
+      [currentPage()],
+      inventorySource
+    )
 
     expect(Object.isFrozen(plan)).toBe(true)
     expect(Object.isFrozen(plan.retain)).toBe(true)

--- a/src/main/runtime/browser-host-page-reconciliation-plan.ts
+++ b/src/main/runtime/browser-host-page-reconciliation-plan.ts
@@ -1,3 +1,5 @@
+import type { BrowserClientHostedPageInventory } from '../../shared/browser-client-host-protocol'
+
 const DEFAULT_MAX_PAGES = 256
 const MAX_GENERATION = 0xffff_ffff
 const MAX_IDENTITY_LENGTH = 256
@@ -16,17 +18,10 @@ export type BrowserHostRuntimePageIntent = BrowserHostPageAuthority &
     browserPageId: string
     browserProfileId: string
     executionHostKey: string
-    reclaimFrom?: BrowserHostPageAuthority
+    reclaimFrom?: BrowserHostPageAuthority & Readonly<{ pairedDeviceId: string }>
   }>
 
-export type BrowserClientHostedPageInventory = BrowserHostPageAuthority &
-  Readonly<{
-    browserPageId: string
-    browserProfileId: string
-    executionHostKey: string
-    state: 'active' | 'outcomeUnknown'
-    currentUrl?: string
-  }>
+export type { BrowserClientHostedPageInventory } from '../../shared/browser-client-host-protocol'
 
 type PagePair = Readonly<{
   intent: BrowserHostRuntimePageIntent
@@ -44,8 +39,9 @@ export type BrowserHostPageReconciliationPlan = Readonly<{
 export function planBrowserHostPageReconciliation(
   intentInput: readonly BrowserHostRuntimePageIntent[],
   pageInput: readonly BrowserClientHostedPageInventory[],
-  options: { maxPages?: number } = {}
+  options: { inventoryPairedDeviceId: string; maxPages?: number }
 ): BrowserHostPageReconciliationPlan {
+  assertIdentity(options.inventoryPairedDeviceId)
   const maxPages = options.maxPages ?? DEFAULT_MAX_PAGES
   assertCapacity(maxPages, intentInput.length, pageInput.length)
   const intents = freezeUniqueRecords(intentInput, freezeIntent)
@@ -69,7 +65,7 @@ export function planBrowserHostPageReconciliation(
       retain.push(Object.freeze({ intent, page }))
       continue
     }
-    if (page.state === 'active' && canReclaimPage(intent, page)) {
+    if (page.state === 'active' && canReclaimPage(intent, page, options.inventoryPairedDeviceId)) {
       reclaim.push(Object.freeze({ intent, page }))
       continue
     }
@@ -103,10 +99,12 @@ function sameCurrentPage(
 
 function canReclaimPage(
   intent: BrowserHostRuntimePageIntent,
-  page: BrowserClientHostedPageInventory
+  page: BrowserClientHostedPageInventory,
+  inventoryPairedDeviceId: string
 ): boolean {
   return Boolean(
     intent.reclaimFrom &&
+    intent.reclaimFrom.pairedDeviceId === inventoryPairedDeviceId &&
     intent.authorityEpoch !== intent.reclaimFrom.authorityEpoch &&
     sameAuthority(intent.reclaimFrom, page) &&
     intent.browserHostClientId === intent.reclaimFrom.browserHostClientId &&
@@ -144,6 +142,7 @@ function freezeIntent(intent: BrowserHostRuntimePageIntent): BrowserHostRuntimeP
   assertPageRecord(intent)
   if (intent.reclaimFrom) {
     assertAuthority(intent.reclaimFrom)
+    assertIdentity(intent.reclaimFrom.pairedDeviceId)
   }
   return Object.freeze({
     ...intent,

--- a/src/main/runtime/rpc/methods/browser-client-host.test.ts
+++ b/src/main/runtime/rpc/methods/browser-client-host.test.ts
@@ -6,7 +6,11 @@ import { RpcDispatcher } from '../dispatcher'
 import { BROWSER_CLIENT_HOST_METHODS } from './browser-client-host'
 import { ALL_RPC_METHODS } from './index'
 
-function request(browserHostClientId = 'host-a', pageCommandProtocolVersion?: 1) {
+function request(
+  browserHostClientId = 'host-a',
+  pageCommandProtocolVersion?: 1,
+  pageInventoryProtocolVersion?: 1
+) {
   return {
     id: `browser-host:${browserHostClientId}`,
     authToken: 'bound-by-websocket',
@@ -15,7 +19,10 @@ function request(browserHostClientId = 'host-a', pageCommandProtocolVersion?: 1)
       authorityRuntimeId: 'runtime-a',
       browserHostClientId,
       hostCapabilities: ['webview'],
-      ...(pageCommandProtocolVersion ? { pageCommandProtocolVersion } : {})
+      ...(pageCommandProtocolVersion ? { pageCommandProtocolVersion } : {}),
+      ...(pageInventoryProtocolVersion
+        ? { pageInventoryProtocolVersion, pageInventory: [inventoryPage()] }
+        : {})
     }
   }
 }
@@ -130,6 +137,36 @@ describe('browser.clientHost.attach RPC', () => {
     cleanups.get('browser-client-host:host-a')?.()
     await dispatch
     expect(JSON.parse(replies[1]!).result).not.toHaveProperty('pageCommandProtocolVersion')
+  })
+
+  it('echoes and retains only an explicitly negotiated complete page inventory', async () => {
+    const cleanups = new Map<string, () => void>()
+    const hostRuntime = runtime(cleanups)
+    const dispatcher = new RpcDispatcher({
+      runtime: hostRuntime,
+      methods: BROWSER_CLIENT_HOST_METHODS
+    })
+    const replies: string[] = []
+    const dispatch = dispatcher.dispatchStreaming(
+      request('host-a', undefined, 1),
+      (reply) => replies.push(reply),
+      {
+        connectionId: 'connection-a',
+        clientKind: 'runtime',
+        pairedDeviceId: 'device-a',
+        clientCapabilities: [BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY]
+      }
+    )
+
+    await vi.waitFor(() => expect(replies).toHaveLength(1))
+    expect(JSON.parse(replies[0]!).result).toMatchObject({ pageInventoryProtocolVersion: 1 })
+    expect(getBrowserHostLeaseRegistry(hostRuntime).select('host-a')).toMatchObject({
+      pageInventoryProtocolVersion: 1,
+      pageInventory: [inventoryPage()]
+    })
+
+    cleanups.get('browser-client-host:host-a')?.()
+    await dispatch
   })
 
   it('publishes one server-owned command and fences result authority', async () => {
@@ -412,5 +449,20 @@ function unownedCommandResult(authorityRuntimeId: string) {
     commandSequence: 1,
     commandId: 'command-a',
     result: { status: 'completed' }
+  }
+}
+
+function inventoryPage() {
+  return {
+    authorityRuntimeId: 'runtime-a',
+    authorityEpoch: 'epoch-old',
+    browserHostClientId: 'host-a',
+    browserHostGeneration: 2,
+    browserPageId: 'page-a',
+    pageHostGeneration: 3,
+    browserProfileId: 'profile-a',
+    executionHostKey: 'native:runtime-a:1',
+    state: 'active' as const,
+    currentUrl: 'https://remote.internal/'
   }
 }

--- a/src/main/runtime/rpc/methods/browser-client-host.ts
+++ b/src/main/runtime/rpc/methods/browser-client-host.ts
@@ -31,7 +31,9 @@ export const BROWSER_CLIENT_HOST_METHODS: RpcAnyMethod[] = [
         connectionId,
         pairedDeviceId,
         hostCapabilities: params.hostCapabilities,
-        pageCommandProtocolVersion: params.pageCommandProtocolVersion
+        pageCommandProtocolVersion: params.pageCommandProtocolVersion,
+        pageInventoryProtocolVersion: params.pageInventoryProtocolVersion,
+        pageInventory: params.pageInventory
       })
       let releaseCommandDelivery = (): void => {}
       let cleaned = false
@@ -68,6 +70,9 @@ export const BROWSER_CLIENT_HOST_METHODS: RpcAnyMethod[] = [
           browserHostGeneration: handle.lease.browserHostGeneration,
           ...(params.pageCommandProtocolVersion
             ? { pageCommandProtocolVersion: params.pageCommandProtocolVersion }
+            : {}),
+          ...(params.pageInventoryProtocolVersion
+            ? { pageInventoryProtocolVersion: params.pageInventoryProtocolVersion }
             : {})
         })
         const reason = await handle.whenFenced

--- a/src/shared/browser-client-host-protocol.test.ts
+++ b/src/shared/browser-client-host-protocol.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { REMOTE_RUNTIME_MAX_SUBSCRIPTION_PARAM_BYTES } from './remote-runtime-memory-limits'
 import {
+  BROWSER_CLIENT_HOST_PAGE_INVENTORY_MAX_BYTES,
+  BROWSER_CLIENT_HOST_PAGE_INVENTORY_IDENTITY_MAX_JSON_BYTES,
+  BROWSER_CLIENT_HOST_PAGE_INVENTORY_PROTOCOL_VERSION,
   BrowserClientHostAttachParams,
   BrowserClientHostCommandEvent,
   BrowserClientHostCommandResultAck,
@@ -57,6 +62,184 @@ describe('browser client-host control protocol', () => {
         hostCapabilities: ['webview']
       })
     ).not.toHaveProperty('pageCommandProtocolVersion')
+  })
+
+  it('negotiates a complete bounded page inventory independently of commands', () => {
+    const page = {
+      authorityRuntimeId: 'runtime-a',
+      authorityEpoch: 'epoch-old',
+      browserHostClientId: 'host-a',
+      browserHostGeneration: 2,
+      browserPageId: 'page-a',
+      pageHostGeneration: 3,
+      browserProfileId: 'profile-a',
+      executionHostKey: 'native:runtime-a:1',
+      state: 'active' as const,
+      currentUrl: 'https://remote.internal/'
+    }
+    const attach = BrowserClientHostAttachParams.parse({
+      authorityRuntimeId: 'runtime-a',
+      browserHostClientId: 'host-a',
+      hostCapabilities: ['webview'],
+      pageInventoryProtocolVersion: BROWSER_CLIENT_HOST_PAGE_INVENTORY_PROTOCOL_VERSION,
+      pageInventory: [page]
+    })
+
+    expect(attach).toMatchObject({ pageInventoryProtocolVersion: 1, pageInventory: [page] })
+    expect(
+      BrowserClientHostReady.parse({
+        type: 'ready',
+        authorityEpoch: 'epoch-a',
+        browserHostGeneration: 4,
+        pageInventoryProtocolVersion: 1
+      })
+    ).toMatchObject({ pageInventoryProtocolVersion: 1 })
+    expect(() =>
+      BrowserClientHostAttachParams.parse({
+        authorityRuntimeId: 'runtime-a',
+        browserHostClientId: 'host-a',
+        hostCapabilities: ['webview'],
+        pageInventoryProtocolVersion: 1
+      })
+    ).toThrow()
+    expect(() =>
+      BrowserClientHostAttachParams.parse({
+        authorityRuntimeId: 'runtime-a',
+        browserHostClientId: 'host-a',
+        hostCapabilities: ['webview'],
+        pageInventory: [page]
+      })
+    ).toThrow()
+    expect(() =>
+      BrowserClientHostAttachParams.parse({
+        authorityRuntimeId: 'runtime-a',
+        browserHostClientId: 'host-a',
+        hostCapabilities: ['webview'],
+        pageInventoryProtocolVersion: 1,
+        pageInventory: [page, page]
+      })
+    ).toThrow()
+    expect(() =>
+      BrowserClientHostAttachParams.parse({
+        authorityRuntimeId: 'runtime-a',
+        browserHostClientId: 'host-a',
+        hostCapabilities: ['webview'],
+        pageInventoryProtocolVersion: 1,
+        pageInventory: Array.from({ length: 257 }, (_, index) => ({
+          ...page,
+          browserPageId: `page-${index}`
+        }))
+      })
+    ).toThrow()
+    expect(() =>
+      BrowserClientHostAttachParams.parse({
+        authorityRuntimeId: 'runtime-a',
+        browserHostClientId: 'host-a',
+        hostCapabilities: ['webview'],
+        pageInventoryProtocolVersion: 1,
+        pageInventory: Array.from({ length: 256 }, (_, index) => ({
+          ...page,
+          browserPageId: `page-${index}`,
+          currentUrl: `https://remote.internal/${'x'.repeat(4096)}`
+        }))
+      })
+    ).toThrow('Browser page inventory exceeds its byte budget')
+    expect(BROWSER_CLIENT_HOST_PAGE_INVENTORY_MAX_BYTES).toBeLessThan(
+      REMOTE_RUNTIME_MAX_SUBSCRIPTION_PARAM_BYTES
+    )
+    expect(() =>
+      BrowserClientHostAttachParams.parse({
+        authorityRuntimeId: 'runtime-a',
+        browserHostClientId: 'host-a',
+        hostCapabilities: ['webview'],
+        pageInventoryProtocolVersion: 1,
+        pageInventory: [{ ...page, browserHostClientId: 'host-b' }]
+      })
+    ).toThrow('Browser page inventory authority does not match the attaching host')
+  })
+
+  it('bounds inventory identities after JSON escaping without narrowing legacy identities', () => {
+    const authorityRuntimeId = maxInventoryIdentity('runtime-')
+    const browserHostClientId = maxInventoryIdentity('host-')
+    const pageInventory = Array.from({ length: 256 }, (_, index) => ({
+      authorityRuntimeId,
+      authorityEpoch: maxInventoryIdentity('epoch-'),
+      browserHostClientId,
+      browserHostGeneration: 2,
+      browserPageId: maxInventoryIdentity(`page-${index.toString().padStart(3, '0')}-`),
+      pageHostGeneration: 3,
+      browserProfileId: maxInventoryIdentity('profile-'),
+      executionHostKey: maxInventoryIdentity('execution-'),
+      state: 'active' as const
+    }))
+    const firstPage = pageInventory.at(0)
+    if (!firstPage) {
+      throw new Error('expected inventory page')
+    }
+
+    expect(
+      BrowserClientHostAttachParams.parse({
+        authorityRuntimeId: 'runtime-new',
+        browserHostClientId,
+        hostCapabilities: ['webview'],
+        pageInventoryProtocolVersion: 1,
+        pageInventory
+      }).pageInventory
+    ).toHaveLength(256)
+    expect(
+      BrowserClientHostAttachParams.parse({
+        authorityRuntimeId: 'é'.repeat(256),
+        browserHostClientId: 'host-a',
+        hostCapabilities: ['webview']
+      })
+    ).toMatchObject({ authorityRuntimeId: 'é'.repeat(256) })
+    expect(() =>
+      BrowserClientHostAttachParams.parse({
+        authorityRuntimeId: 'runtime-new',
+        browserHostClientId,
+        hostCapabilities: ['webview'],
+        pageInventoryProtocolVersion: 1,
+        pageInventory: [
+          {
+            ...firstPage,
+            browserProfileId: `${maxInventoryIdentity('profile-')}x`
+          }
+        ]
+      })
+    ).toThrow('Browser page inventory identity exceeds its JSON byte budget')
+  })
+
+  it('keeps old attach and ready decoders compatible with optional inventory fields', () => {
+    const legacyAttach = z.object({
+      authorityRuntimeId: z.string(),
+      browserHostClientId: z.string(),
+      hostCapabilities: z.array(z.string()),
+      pageCommandProtocolVersion: z.literal(1).optional()
+    })
+    const legacyReady = z.object({
+      type: z.literal('ready'),
+      authorityEpoch: z.string(),
+      browserHostGeneration: z.number(),
+      pageCommandProtocolVersion: z.literal(1).optional()
+    })
+
+    expect(
+      legacyAttach.parse({
+        authorityRuntimeId: 'runtime-a',
+        browserHostClientId: 'host-a',
+        hostCapabilities: ['webview'],
+        pageInventoryProtocolVersion: 1,
+        pageInventory: []
+      })
+    ).not.toHaveProperty('pageInventory')
+    expect(
+      legacyReady.parse({
+        type: 'ready',
+        authorityEpoch: 'epoch-a',
+        browserHostGeneration: 2,
+        pageInventoryProtocolVersion: 1
+      })
+    ).not.toHaveProperty('pageInventoryProtocolVersion')
   })
 
   it('binds create-page commands and results to exact bounded authority', () => {
@@ -227,3 +410,23 @@ describe('browser client-host control protocol', () => {
     })
   })
 })
+
+function maxInventoryIdentity(prefix: string): string {
+  let value = prefix
+  while (
+    value.length < 256 &&
+    jsonByteLength(`${value}\0`) <= BROWSER_CLIENT_HOST_PAGE_INVENTORY_IDENTITY_MAX_JSON_BYTES
+  ) {
+    value += '\0'
+  }
+  while (
+    jsonByteLength(`${value}x`) <= BROWSER_CLIENT_HOST_PAGE_INVENTORY_IDENTITY_MAX_JSON_BYTES
+  ) {
+    value += 'x'
+  }
+  return value
+}
+
+function jsonByteLength(value: unknown): number {
+  return new TextEncoder().encode(JSON.stringify(value)).byteLength
+}

--- a/src/shared/browser-client-host-protocol.ts
+++ b/src/shared/browser-client-host-protocol.ts
@@ -2,31 +2,22 @@ import { z } from 'zod'
 
 const Generation = z.number().int().min(1).max(0xffff_ffff)
 const Identity = z.string().min(1).max(256)
+export const BROWSER_CLIENT_HOST_PAGE_INVENTORY_IDENTITY_MAX_JSON_BYTES = 384
+const PageInventoryIdentity = Identity.refine(
+  (value) =>
+    browserClientHostJsonByteLength(value) <=
+    BROWSER_CLIENT_HOST_PAGE_INVENTORY_IDENTITY_MAX_JSON_BYTES,
+  'Browser page inventory identity exceeds its JSON byte budget'
+)
 const CommandSequence = z.number().int().min(1).max(Number.MAX_SAFE_INTEGER)
+export const BROWSER_CLIENT_HOST_PAGE_INVENTORY_MAX_PAGES = 256
+export const BROWSER_CLIENT_HOST_PAGE_INVENTORY_MAX_BYTES = 768 * 1024
+export const BROWSER_CLIENT_HOST_PAGE_INVENTORY_URL_MAX_LENGTH = 8192
 
 export const BROWSER_CLIENT_HOST_PAGE_COMMAND_PROTOCOL_VERSION = 1 as const
 const PageCommandProtocolVersion = z.literal(BROWSER_CLIENT_HOST_PAGE_COMMAND_PROTOCOL_VERSION)
-
-export const BrowserClientHostAttachParams = z.object({
-  authorityRuntimeId: Identity,
-  browserHostClientId: Identity,
-  hostCapabilities: z.array(z.string().min(1).max(128)).max(32),
-  pageCommandProtocolVersion: PageCommandProtocolVersion.optional()
-})
-
-export const BrowserClientHostReady = z.object({
-  type: z.literal('ready'),
-  authorityEpoch: Identity,
-  browserHostGeneration: Generation,
-  pageCommandProtocolVersion: PageCommandProtocolVersion.optional()
-})
-
-const BrowserClientHostRevoked = z.object({
-  type: z.literal('revoked'),
-  authorityEpoch: Identity,
-  browserHostGeneration: Generation,
-  reason: z.enum(['replaced', 'released'])
-})
+export const BROWSER_CLIENT_HOST_PAGE_INVENTORY_PROTOCOL_VERSION = 1 as const
+const PageInventoryProtocolVersion = z.literal(BROWSER_CLIENT_HOST_PAGE_INVENTORY_PROTOCOL_VERSION)
 
 export const BrowserHostLeaseAuthority = z.object({
   authorityRuntimeId: Identity,
@@ -37,8 +28,105 @@ export const BrowserHostLeaseAuthority = z.object({
 
 export type BrowserHostLeaseAuthority = z.infer<typeof BrowserHostLeaseAuthority>
 
+export const BrowserClientHostedPageInventory = z.object({
+  authorityRuntimeId: PageInventoryIdentity,
+  authorityEpoch: PageInventoryIdentity,
+  browserHostClientId: PageInventoryIdentity,
+  browserHostGeneration: Generation,
+  browserPageId: PageInventoryIdentity,
+  pageHostGeneration: Generation,
+  browserProfileId: PageInventoryIdentity,
+  executionHostKey: PageInventoryIdentity,
+  state: z.enum(['active', 'outcomeUnknown']),
+  currentUrl: z.string().max(BROWSER_CLIENT_HOST_PAGE_INVENTORY_URL_MAX_LENGTH).optional()
+})
+
+export type BrowserClientHostedPageInventory = z.infer<typeof BrowserClientHostedPageInventory>
+
+export const BrowserClientHostedPageInventoryList = z
+  .array(BrowserClientHostedPageInventory)
+  .max(BROWSER_CLIENT_HOST_PAGE_INVENTORY_MAX_PAGES)
+  .superRefine((pages, context) => {
+    const pageIds = new Set<string>()
+    for (const [index, page] of pages.entries()) {
+      if (pageIds.has(page.browserPageId)) {
+        context.addIssue({
+          code: 'custom',
+          message: 'Duplicate browser page inventory identity',
+          path: [index, 'browserPageId']
+        })
+      }
+      pageIds.add(page.browserPageId)
+    }
+    if (
+      browserClientHostedPageInventoryByteLength(pages) >
+      BROWSER_CLIENT_HOST_PAGE_INVENTORY_MAX_BYTES
+    ) {
+      context.addIssue({
+        code: 'custom',
+        message: 'Browser page inventory exceeds its byte budget'
+      })
+    }
+  })
+
+export function browserClientHostedPageInventoryByteLength(
+  pages: readonly BrowserClientHostedPageInventory[]
+): number {
+  return browserClientHostJsonByteLength(pages)
+}
+
+function browserClientHostJsonByteLength(value: unknown): number {
+  return new TextEncoder().encode(JSON.stringify(value)).byteLength
+}
+
+export const BrowserClientHostAttachParams = z
+  .object({
+    authorityRuntimeId: Identity,
+    browserHostClientId: Identity,
+    hostCapabilities: z.array(z.string().min(1).max(128)).max(32),
+    pageCommandProtocolVersion: PageCommandProtocolVersion.optional(),
+    pageInventoryProtocolVersion: PageInventoryProtocolVersion.optional(),
+    pageInventory: BrowserClientHostedPageInventoryList.optional()
+  })
+  .superRefine((params, context) => {
+    if (
+      (params.pageInventoryProtocolVersion === undefined) !==
+      (params.pageInventory === undefined)
+    ) {
+      context.addIssue({
+        code: 'custom',
+        message: 'Browser page inventory negotiation is incomplete'
+      })
+    }
+    for (const [index, page] of (params.pageInventory ?? []).entries()) {
+      if (page.browserHostClientId !== params.browserHostClientId) {
+        context.addIssue({
+          code: 'custom',
+          message: 'Browser page inventory authority does not match the attaching host',
+          path: ['pageInventory', index]
+        })
+      }
+    }
+  })
+
+export const BrowserClientHostReady = z.object({
+  type: z.literal('ready'),
+  authorityEpoch: Identity,
+  browserHostGeneration: Generation,
+  pageCommandProtocolVersion: PageCommandProtocolVersion.optional(),
+  pageInventoryProtocolVersion: PageInventoryProtocolVersion.optional()
+})
+
+const BrowserClientHostRevoked = z.object({
+  type: z.literal('revoked'),
+  authorityEpoch: Identity,
+  browserHostGeneration: Generation,
+  reason: z.enum(['replaced', 'released'])
+})
+
 export const BrowserClientHostLeaseAuthority = BrowserHostLeaseAuthority.extend({
-  pageCommandProtocolVersion: PageCommandProtocolVersion.optional()
+  pageCommandProtocolVersion: PageCommandProtocolVersion.optional(),
+  pageInventoryProtocolVersion: PageInventoryProtocolVersion.optional()
 })
 
 export type BrowserClientHostLeaseAuthority = z.infer<typeof BrowserClientHostLeaseAuthority>


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​810 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​39 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​771 |
| Prod | 21 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​683 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​143 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​540 |

<!-- /orca-pr-loc -->

# Summary

- Add an optional, complete hosted-page inventory to the existing authenticated browser-host attach.
- Negotiate inventory v1 independently from page commands, with atomic 256-page / 768 KiB bounds and exact paired-device restart provenance.
- Snapshot executor lifecycle states conservatively: only an exact current guest is active; in-flight, retiring, stale, destroyed, and ambiguous pages are outcomeUnknown.

This is a production-inert STA-4150 stage. It does not advertise client hosting, activate client placement, execute reconciliation, or change server/offscreen browser behavior.

# Compatibility

- Old hosts and clients strip the optional fields.
- Missing inventory/version remains unsupported/unknown; an authenticated empty array is distinct.
- Unencodable optional inventory omits both fields while legacy page-command execution remains unchanged.
- Previous-runtime IDs are retained only as evidence for the separately pinned, paired-device-bound restart reconciliation plan.

# Validation

- 11 focused files / 145 tests
- 16 authenticated lease/tunnel files / 188 tests
- Cross-version terminal wire: 5/5
- Full Node/CLI/web typecheck and lint/audits
- CLI, Electron, and paired-web builds
- Two fresh read-only lifecycle/security/wire reviews: no P0/P1 or must-fix finding

# Next stage

Preserve or transfer executor/page lifetime through reconnect grace, then feed the authenticated snapshot and runtime intent into the existing reconciliation planner. Missing inventory must never be treated as empty.

Linear: STA-4150
