### PR TITLE
fix(runtime): stop one unreachable relay from freezing every workspace as active (STA-517)

### DIFF
--- a/src/main/ipc/pty-controller-process-inventory.test.ts
+++ b/src/main/ipc/pty-controller-process-inventory.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { handleMock, onMock, removeHandlerMock, removeAllListenersMock } = vi.hoisted(() => ({
+  handleMock: vi.fn(),
+  onMock: vi.fn(),
+  removeHandlerMock: vi.fn(),
+  removeAllListenersMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: true,
+    getPath: vi.fn().mockReturnValue('/tmp/orca-test-userdata')
+  },
+  ipcMain: {
+    handle: handleMock,
+    on: onMock,
+    removeHandler: removeHandlerMock,
+    removeAllListeners: removeAllListenersMock
+  },
+  powerMonitor: {
+    on: vi.fn()
+  }
+}))
+
+vi.mock('fs', () => ({
+  existsSync: () => true,
+  statSync: () => ({ isDirectory: () => true, mode: 0o755 }),
+  accessSync: () => undefined,
+  mkdirSync: vi.fn(),
+  readFileSync: vi.fn(() => ''),
+  writeFileSync: vi.fn(),
+  chmodSync: vi.fn(),
+  constants: { X_OK: 1 }
+}))
+
+vi.mock('node-pty', () => ({
+  spawn: vi.fn().mockReturnValue({
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(),
+    process: 'zsh',
+    pid: 12345
+  })
+}))
+
+vi.mock('../opencode/hook-service', () => ({
+  openCodeHookService: { buildPtyEnv: () => ({}), clearPty: vi.fn() }
+}))
+
+vi.mock('../pi/titlebar-extension-service', () => ({
+  piTitlebarExtensionService: { buildPtyEnv: () => ({}), clearPty: vi.fn() }
+}))
+
+import {
+  registerPtyHandlers,
+  registerSshPtyProvider,
+  setLocalPtyProvider,
+  unregisterSshPtyProvider
+} from './pty'
+import type { IPtyProvider, PtyProcessInfo } from '../providers/types'
+
+// The runtime's worktree.ps liveness refresh calls the aggregate inventory (no connectionId)
+// under a 3s budget, and only a returned inventory can retire an exited PTY. STA-517: one
+// unreachable relay made the whole aggregate fail, so no PTY was ever proven dead and every
+// retained pane — the SSH ones above all — kept reporting "active" to mobile indefinitely.
+
+type ListCall = { opts: { deadlineMs?: number } | undefined }
+
+function createProvider(
+  sessions: PtyProcessInfo[],
+  behavior: 'ok' | 'reject' = 'ok'
+): { provider: IPtyProvider; calls: ListCall[] } {
+  const calls: ListCall[] = []
+  const provider = {
+    onData: vi.fn().mockReturnValue(() => {}),
+    onRejectedData: vi.fn().mockReturnValue(() => {}),
+    onReplay: vi.fn().mockReturnValue(() => {}),
+    onExit: vi.fn().mockReturnValue(() => {}),
+    listProcesses: vi.fn(async (opts?: { deadlineMs?: number }) => {
+      calls.push({ opts })
+      if (behavior === 'reject') {
+        throw new Error('relay unreachable')
+      }
+      return sessions
+    })
+  } as unknown as IPtyProvider
+  return { provider, calls }
+}
+
+function session(id: string): PtyProcessInfo {
+  return { id, cwd: '/tmp', title: id } as unknown as PtyProcessInfo
+}
+
+const mainWindow = {
+  isDestroyed: () => false,
+  webContents: { on: vi.fn(), send: vi.fn(), removeListener: vi.fn() }
+}
+
+function captureController(): {
+  listProcesses: (
+    connectionId?: string | null,
+    opts?: { deadlineMs?: number }
+  ) => Promise<PtyProcessInfo[]>
+} {
+  handleMock.mockReset()
+  onMock.mockReset()
+  handleMock.mockImplementation(() => {})
+  onMock.mockImplementation(() => {})
+  let controller: { listProcesses?: unknown } | undefined
+  const runtime = {
+    setPtyController: vi.fn((next: { listProcesses?: unknown }) => {
+      controller = next
+    }),
+    createPreAllocatedTerminalHandle: vi.fn(() => 'term_test'),
+    registerPreAllocatedHandleForPty: vi.fn(),
+    registerPty: vi.fn()
+  }
+  registerPtyHandlers(mainWindow as never, runtime as never)
+  if (typeof controller?.listProcesses !== 'function') {
+    throw new Error('PTY controller listProcesses was not registered')
+  }
+  return controller as never
+}
+
+describe('aggregate PTY process inventory', () => {
+  const registered: string[] = []
+
+  function register(connectionId: string, provider: IPtyProvider): void {
+    registerSshPtyProvider(connectionId, provider)
+    registered.push(connectionId)
+  }
+
+  afterEach(() => {
+    for (const connectionId of registered.splice(0)) {
+      unregisterSshPtyProvider(connectionId)
+    }
+  })
+
+  it('still reports local and healthy relays when one SSH relay rejects', async () => {
+    const local = createProvider([session('local-pty')])
+    const healthy = createProvider([session('ssh:conn-ok@@pty')])
+    const broken = createProvider([], 'reject')
+    setLocalPtyProvider(local.provider)
+    register('conn-ok', healthy.provider)
+    register('conn-broken', broken.provider)
+    const controller = captureController()
+
+    const sessions = await controller.listProcesses()
+
+    // Pre-fix this rejected: Promise.all surfaced the broken relay's error, the runtime
+    // read it as "no inventory", and no PTY anywhere was retired.
+    expect(sessions.map((entry) => entry.id).sort()).toEqual(['local-pty', 'ssh:conn-ok@@pty'])
+  })
+
+  it('bounds every relay list by the caller deadline instead of the mux default', async () => {
+    const local = createProvider([session('local-pty')])
+    const remote = createProvider([session('ssh:conn-a@@pty')])
+    setLocalPtyProvider(local.provider)
+    register('conn-a', remote.provider)
+    const controller = captureController()
+    const deadlineMs = Date.now() + 2500
+
+    await controller.listProcesses(undefined, { deadlineMs })
+
+    // Without a forwarded deadline an unanswered relay list runs to the SSH mux's own
+    // 30s default, far past the runtime's 3s budget for the whole refresh.
+    expect(remote.calls).toEqual([{ opts: { deadlineMs } }])
+  })
+
+  it('forwards the caller deadline on a targeted single-connection list', async () => {
+    const local = createProvider([session('local-pty')])
+    const remote = createProvider([session('ssh:conn-a@@pty')])
+    setLocalPtyProvider(local.provider)
+    register('conn-a', remote.provider)
+    const controller = captureController()
+    const deadlineMs = Date.now() + 1200
+
+    await controller.listProcesses('conn-a', { deadlineMs })
+
+    expect(remote.calls).toEqual([{ opts: { deadlineMs } }])
+  })
+
+  it('fails the aggregate when the local provider cannot list', async () => {
+    const local = createProvider([], 'reject')
+    setLocalPtyProvider(local.provider)
+    const controller = captureController()
+
+    // A local failure is a real controller fault, not one unreachable host: the runtime must
+    // keep treating it as "no inventory" rather than proving every local PTY dead.
+    await expect(controller.listProcesses()).rejects.toThrow('relay unreachable')
+  })
+})

--- a/src/main/ipc/pty-runtime-kill-and-exit.test.ts
+++ b/src/main/ipc/pty-runtime-kill-and-exit.test.ts
@@ -126,6 +126,9 @@ describe('registerPtyHandlers', () => {
     expect(sshAList).toHaveBeenCalledOnce()
     expect(sshBList).not.toHaveBeenCalled()
 
+    // STA-517: the aggregate used to propagate ssh-b's failure, which cost the runtime the
+    // whole liveness inventory — so no PTY was ever proven dead and mobile kept every
+    // retained pane "active". One unreachable relay now drops out of the answer instead.
     await expect(controller.listProcesses()).resolves.toEqual([
       { id: 'local-pty', title: 'Local', cwd: '/local' },
       { id: 'ssh-a-pty' }

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -265,8 +265,15 @@ function registeredPtyProviders(): RegisteredPtyProvider[] {
   ]
 }
 
+// Why: settling each provider separately only bounds a relay that *rejects*. An
+// unanswered relay list runs to the mux's own 30s default — far past the caller's
+// budget — so the aggregate still expired and the runtime lost the inventory it
+// needs to retire exited PTYs, freezing every retained pane as "active" (STA-517).
+// Forward the caller's deadline so a silent relay fails fast and lands in the
+// unavailable branch below: unknown, not empty.
 async function listRegisteredPtyProcessesWithHostScope(
-  onSshInventoryUnavailable?: (connectionId: string, error: unknown) => void
+  onSshInventoryUnavailable?: (connectionId: string, error: unknown) => void,
+  opts?: { deadlineMs?: number }
 ): Promise<{
   processes: PtyProcessInfo[]
   hostIds: ExecutionHostId[]
@@ -279,7 +286,8 @@ async function listRegisteredPtyProcessesWithHostScope(
           ? toSshExecutionHostId(connectionId)
           : LOCAL_EXECUTION_HOST_ID
         return {
-          processes: await provider.listProcesses(),
+          // Why: the deadline only applies to relay round-trips; the local provider answers in-process.
+          processes: await (connectionId ? provider.listProcesses(opts) : provider.listProcesses()),
           hostId
         }
       } catch (error) {
@@ -5834,22 +5842,23 @@ export function registerPtyHandlers(
         return null
       }
     },
-    listProcesses: async (connectionId) => {
+    listProcesses: async (connectionId, opts) => {
       if (connectionId === null) {
         return localProvider.listProcesses()
       }
       if (connectionId !== undefined) {
         try {
-          return await getProvider(connectionId).listProcesses()
+          return await getProvider(connectionId).listProcesses(opts)
         } catch (error) {
           markSshInventoryUnverifiable(connectionId, error)
           throw error
         }
       }
-      return (await listRegisteredPtyProcessesWithHostScope(markSshInventoryUnverifiable)).processes
+      return (await listRegisteredPtyProcessesWithHostScope(markSshInventoryUnverifiable, opts))
+        .processes
     },
-    listProcessesWithHostScope: () =>
-      listRegisteredPtyProcessesWithHostScope(markSshInventoryUnverifiable),
+    listProcessesWithHostScope: (opts) =>
+      listRegisteredPtyProcessesWithHostScope(markSshInventoryUnverifiable, opts),
     serializeBuffer: (ptyId, opts) => {
       // Why: mobile xterm must start from the desktop's exact screen state/dimensions before live TUI chunks render correctly.
       return requestSerializedBuffer(ptyId, opts)

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -1003,6 +1003,9 @@ async function referenceStatusFrameLines(
 }
 
 const TEST_WINDOW_ID = 1
+// The inventory refresh forwards its own budget so a relay cannot outlive it (STA-517).
+// These assertions are about which provider scope was asked, so the deadline stays loose.
+const LIST_PROVIDER_DEADLINE = expect.objectContaining({ deadlineMs: expect.any(Number) })
 const TEST_REPO_ID = 'repo-1'
 const TEST_REPO_PATH = '/tmp/repo'
 const TEST_WORKTREE_PATH = '/tmp/worktree-a'
@@ -20214,7 +20217,7 @@ describe('OrcaRuntimeService', () => {
       paneKey: makePaneKey('tab-agent', HEADLESS_LEAF_ID)
     })
     expect(listProcesses).toHaveBeenCalledTimes(inventoryCount + 1)
-    expect(listProcesses).toHaveBeenLastCalledWith(null)
+    expect(listProcesses).toHaveBeenLastCalledWith(null, LIST_PROVIDER_DEADLINE)
     expect(
       (await runtime.listTerminals()).terminals.find((terminal) => terminal.ptyId === 'pty-agent')
     ).toMatchObject({
@@ -20224,7 +20227,7 @@ describe('OrcaRuntimeService', () => {
       leafId: HEADLESS_LEAF_ID
     })
     expect(listProcesses).toHaveBeenCalledTimes(inventoryCount + 2)
-    expect(listProcesses).toHaveBeenLastCalledWith(undefined)
+    expect(listProcesses).toHaveBeenLastCalledWith(undefined, LIST_PROVIDER_DEADLINE)
     await expect(
       runtime.adoptTerminalOrphans({
         worktree: `id:${TEST_WORKTREE_ID}`,
@@ -21490,7 +21493,7 @@ describe('OrcaRuntimeService', () => {
     expect(getSession().sleepingAgentSessionsByPaneKey?.[workerPaneKey]).toBeUndefined()
     expect(getSession().sleepingAgentSessionsByPaneKey?.[secondWorkerPaneKey]).toBeUndefined()
     expect(listProcesses).toHaveBeenCalledTimes(3)
-    expect(listProcesses).toHaveBeenCalledWith(null)
+    expect(listProcesses).toHaveBeenCalledWith(null, LIST_PROVIDER_DEADLINE)
     expect(getSession().tabsByWorktree[TEST_WORKTREE_ID]).toEqual([
       expect.objectContaining({ id: 'legacy-worker-two', ptyId: 'pty-exited-two' })
     ])
@@ -21605,7 +21608,7 @@ describe('OrcaRuntimeService', () => {
       await vi.advanceTimersByTimeAsync(1_000)
 
       expect(listProcesses).toHaveBeenCalledTimes(4)
-      expect(listProcesses.mock.calls).toEqual([[null], [null], [null], [null]])
+      expect(listProcesses.mock.calls.map((call) => call[0])).toEqual([null, null, null, null])
       expect(hasPty).not.toHaveBeenCalled()
       expect(getSession().tabsByWorktree[TEST_WORKTREE_ID]).toEqual([
         expect.objectContaining({ id: 'legacy-worker', ptyId: 'pty-inventory-unavailable' })
@@ -21796,7 +21799,7 @@ describe('OrcaRuntimeService', () => {
       deferredDispatchIds: ['dispatch-missing', 'dispatch-ambiguous']
     })
     expect(listProcesses).toHaveBeenCalledOnce()
-    expect(listProcesses).toHaveBeenCalledWith(null)
+    expect(listProcesses).toHaveBeenCalledWith(null, LIST_PROVIDER_DEADLINE)
     for (const { name, leafId } of cases.slice(0, 2)) {
       expect(
         getSession().sleepingAgentSessionsByPaneKey?.[`legacy-${name}:${leafId}`]
@@ -21906,7 +21909,7 @@ describe('OrcaRuntimeService', () => {
     )
     expect(getSession().sleepingAgentSessionsByPaneKey?.[workerPaneKey]).toBeUndefined()
     expect(listProcesses).toHaveBeenCalledTimes(3)
-    expect(listProcesses).toHaveBeenCalledWith(null)
+    expect(listProcesses).toHaveBeenCalledWith(null, LIST_PROVIDER_DEADLINE)
     expect(revealTerminalSession).toHaveBeenCalledWith(TEST_FOLDER_WORKSPACE_KEY, {
       ptyId: 'pty-folder-legacy',
       title: 'Folder worker',
@@ -22048,7 +22051,7 @@ describe('OrcaRuntimeService', () => {
     expect(getWorkspaceSession).toHaveBeenCalledWith(`ssh:${connectionId}`)
     expect(setWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), `ssh:${connectionId}`)
     expect(listProcesses).toHaveBeenCalledTimes(3)
-    expect(listProcesses).toHaveBeenCalledWith(connectionId)
+    expect(listProcesses).toHaveBeenCalledWith(connectionId, LIST_PROVIDER_DEADLINE)
     expect(sshSession.tabsByWorktree[TEST_FOLDER_WORKSPACE_KEY]).toContainEqual(
       expect.objectContaining({
         id: 'legacy-ssh-folder-worker',
@@ -22277,7 +22280,7 @@ describe('OrcaRuntimeService', () => {
         exitedDispatchIds: [],
         deferredDispatchIds: []
       })
-      expect(listProcesses).toHaveBeenLastCalledWith(connectionId)
+      expect(listProcesses).toHaveBeenLastCalledWith(connectionId, LIST_PROVIDER_DEADLINE)
     } finally {
       unregisterSshGitProvider(connectionId)
     }
@@ -22414,7 +22417,7 @@ describe('OrcaRuntimeService', () => {
     expect(getSession().sleepingAgentSessionsByPaneKey?.[workerPaneKey]).toBeUndefined()
     expect(revealTerminalSession).toHaveBeenCalledOnce()
     expect(listProcesses).toHaveBeenCalledTimes(5)
-    expect(listProcesses.mock.calls).toEqual([[null], [null], [null], [null], [null]])
+    expect(listProcesses.mock.calls.map((call) => call[0])).toEqual([null, null, null, null, null])
   })
 
   it('restores orphan pane and group topology without replacing a newer host-owned tab', async () => {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -22366,7 +22366,9 @@ describe('OrcaRuntimeService', () => {
         }
       ]
     } as unknown as OrchestrationDb)
-    const listProcesses = vi.fn(async () => [
+    // Declares the scope parameter so mock.calls keeps it — the runtime passes a deadline
+    // alongside it, and a bare `async () =>` would type the call tuple as empty.
+    const listProcesses = vi.fn(async (_connectionId?: string | null) => [
       {
         id: 'pty-wsl-legacy',
         incarnationId,

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1908,7 +1908,6 @@ type RuntimePtyController = {
     processes: PtyProcessInfo[]
     hostIds: ExecutionHostId[]
   }>
-
   serializeBuffer?(
     ptyId: string,
     opts?: { scrollbackRows?: number; altScreenForcesZeroRows?: boolean }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1898,11 +1898,17 @@ type RuntimePtyController = {
   resize?(ptyId: string, cols: number, rows: number): boolean
   // Why: exact-id mobile polls should not enumerate every local and SSH PTY.
   hasPty?(ptyId: string): boolean | null
-  listProcesses?(connectionId?: string | null): Promise<PtyProcessInfo[]>
-  listProcessesWithHostScope?(): Promise<{
+  // Why: the caller's budget has to reach the relay. Without it an SSH list runs to
+  // the mux's own 30s default and blows every inventory refresh (STA-517).
+  listProcesses?(
+    connectionId?: string | null,
+    opts?: { deadlineMs?: number }
+  ): Promise<PtyProcessInfo[]>
+  listProcessesWithHostScope?(opts?: { deadlineMs?: number }): Promise<{
     processes: PtyProcessInfo[]
     hostIds: ExecutionHostId[]
   }>
+
   serializeBuffer?(
     ptyId: string,
     opts?: { scrollbackRows?: number; altScreenForcesZeroRows?: boolean }
@@ -31803,10 +31809,20 @@ export class OrcaRuntimeService {
     } else {
       this.ptyControllerInventoryGenerationByProvider.set(providerKey, inventoryGeneration)
     }
+    const listBudgetMs =
+      deadline === undefined
+        ? PTY_CONTROLLER_LIST_TIMEOUT_MS
+        : Math.max(1, Math.min(PTY_CONTROLLER_LIST_TIMEOUT_MS, deadline - Date.now()))
+    // Why: give each provider a deadline strictly inside our own, so a relay that
+    // never answers still leaves the aggregate time to return the providers that did
+    // — expiring at the same instant would discard the whole inventory instead.
+    const providerListOpts = {
+      deadlineMs: Date.now() + Math.max(1, listBudgetMs - PTY_CONTROLLER_LIST_PROVIDER_MARGIN_MS)
+    }
     const processInventory =
       connectionId === undefined && this.ptyController.listProcessesWithHostScope
-        ? this.ptyController.listProcessesWithHostScope()
-        : this.ptyController.listProcesses(connectionId).then((processes) => {
+        ? this.ptyController.listProcessesWithHostScope(providerListOpts)
+        : this.ptyController.listProcesses(connectionId, providerListOpts).then((processes) => {
             const hostIds = new Set<ExecutionHostId>()
             if (connectionId === undefined || connectionId === null) {
               hostIds.add(LOCAL_EXECUTION_HOST_ID)
@@ -31827,12 +31843,7 @@ export class OrcaRuntimeService {
             }
             return { processes, hostIds: [...hostIds] }
           })
-    const sessionsResult = await withTimeoutResult(
-      processInventory,
-      deadline === undefined
-        ? PTY_CONTROLLER_LIST_TIMEOUT_MS
-        : Math.max(1, Math.min(PTY_CONTROLLER_LIST_TIMEOUT_MS, deadline - Date.now()))
-    )
+    const sessionsResult = await withTimeoutResult(processInventory, listBudgetMs)
     if (!sessionsResult.ok) {
       // Why: a transient controller failure is not evidence that retained PTYs exited.
       return null
@@ -31994,17 +32005,6 @@ export class OrcaRuntimeService {
       // Why: fire-and-forget so this listing hot path doesn't serialize a relay round-trip per session and a throw can't abort the sweep below.
       this.refreshPtyForegroundAgent(session.id)
     }
-    for (const [ptyId, receipt] of this.restoredOrchestrationAuthorityByPtyId) {
-      const inScope =
-        connectionId === undefined ||
-        (connectionId === null && receipt.hostScope.kind !== 'ssh') ||
-        (typeof connectionId === 'string' &&
-          receipt.hostScope.kind === 'ssh' &&
-          receipt.hostScope.targetId === connectionId)
-      if (inScope && !allLivePtyIds.has(ptyId)) {
-        this.restoredOrchestrationAuthorityByPtyId.delete(ptyId)
-      }
-    }
     for (const pty of this.ptysById.values()) {
       if (connectionId !== undefined && pty.connectionId !== connectionId) {
         continue
@@ -32045,6 +32045,20 @@ export class OrcaRuntimeService {
         } else if (observed === null) {
           this.markPtyLivenessUnverifiable(pty.ptyId, NO_OBSERVING_PROVIDER_REASON)
         }
+      }
+    }
+    // Why: runs after the hasPty rescue so a still-addressable pane keeps its receipt.
+    // A provider that failed to list is absent from `sessions`, and dropping authority on
+    // that silence would retire an orchestration handle the relay can still reach.
+    for (const [ptyId, receipt] of this.restoredOrchestrationAuthorityByPtyId) {
+      const inScope =
+        connectionId === undefined ||
+        (connectionId === null && receipt.hostScope.kind !== 'ssh') ||
+        (typeof connectionId === 'string' &&
+          receipt.hostScope.kind === 'ssh' &&
+          receipt.hostScope.targetId === connectionId)
+      if (inScope && !allLivePtyIds.has(ptyId)) {
+        this.restoredOrchestrationAuthorityByPtyId.delete(ptyId)
       }
     }
     this.pruneDisconnectedPtyRecords()
@@ -37824,6 +37838,9 @@ export function resolveWorktreeScanCacheTtlMs(repo: Pick<Repo, 'path' | 'connect
     : WORKTREE_SCAN_CACHE_TTL_MS
 }
 const PTY_CONTROLLER_LIST_TIMEOUT_MS = 3000
+// Why: the slice of the list budget reserved for the aggregate to collect the providers
+// that answered after a stalled one gives up.
+const PTY_CONTROLLER_LIST_PROVIDER_MARGIN_MS = 500
 // Why: the renderer waits 15s; leave room for the verified failure response and release the spawn fence before its caller times out.
 const WORKTREE_TERMINAL_SLEEP_TIMEOUT_MS = 12_000
 

--- a/src/main/runtime/pty-inventory-partial-relay-liveness.test.ts
+++ b/src/main/runtime/pty-inventory-partial-relay-liveness.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest'
+import { getDefaultWorkspaceSession } from '../../shared/constants'
+import { makePaneKey } from '../../shared/stable-pane-id'
+import { OrcaRuntimeService } from './orca-runtime'
+
+// STA-517: the worktree.ps liveness refresh is the only thing that retires an exited PTY, and
+// mobile renders "active" straight off the summary it produces. It must reach the providers
+// under its own budget, and a pane the controller still vouches for must survive a listing
+// that did not mention it.
+const REPO_ID = 'repo-1'
+const REPO_PATH = '/tmp/relay-liveness'
+const WORKSPACE = `${REPO_ID}::${REPO_PATH}`
+const RETAINED_PTY = `${WORKSPACE}@@retained-pty`
+const TAB_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const LEAF_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const PANE_KEY = makePaneKey(TAB_ID, LEAF_ID)
+
+// Mirrors the runtime's own list budget; the forwarded deadline has to land strictly inside it.
+const LIST_BUDGET_MS = 3000
+
+const REPO = {
+  id: REPO_ID,
+  path: REPO_PATH,
+  displayName: 'relay-liveness',
+  badgeColor: 'blue',
+  addedAt: 1,
+  kind: 'git'
+} as const
+
+type RuntimeInternals = {
+  buildResolvedWorktreeFromId: (worktreeId: string) => unknown
+  refreshPtyWorktreeRecordsWithControllerInventory: (
+    resolvedWorktrees: unknown[],
+    targetWorktreeId?: string | null,
+    deadline?: number
+  ) => Promise<unknown>
+  recordPtyWorktree: (
+    ptyId: string,
+    worktreeId: string,
+    state?: Record<string, unknown>
+  ) => Record<string, unknown>
+  ptysById: Map<string, { connected: boolean }>
+  restoredOrchestrationAuthorityByPtyId: Map<string, unknown>
+}
+
+type ListCall = { connectionId: string | null | undefined; deadlineMs: number | undefined }
+
+function createRuntime(options: { sessions?: unknown[]; vouchesForRetainedPty?: boolean } = {}): {
+  internals: RuntimeInternals
+  calls: ListCall[]
+} {
+  const meta: Record<string, Record<string, unknown>> = { [WORKSPACE]: { hostId: 'local' } }
+  const store = {
+    getRepos: () => [REPO],
+    getRepo: (id: string) => (id === REPO_ID ? REPO : undefined),
+    getAllWorktreeMeta: () => meta,
+    getWorktreeMeta: (worktreeId: string) => meta[worktreeId],
+    setWorktreeMeta: (worktreeId: string, patch: Record<string, unknown>) => {
+      meta[worktreeId] = { ...meta[worktreeId], ...patch }
+      return meta[worktreeId]
+    },
+    getWorkspaceSession: () => getDefaultWorkspaceSession(),
+    setWorkspaceSession: () => {},
+    flushOrThrow: () => {}
+  } as never
+  const calls: ListCall[] = []
+  const runtime = new OrcaRuntimeService(store)
+  runtime.setPtyController({
+    write: () => true,
+    kill: () => true,
+    getForegroundProcess: async () => null,
+    // Why: the controller's own liveness vouch, which the runtime consults for a PTY the
+    // listing omitted. A relay that failed to list still owns its panes.
+    hasPty: (ptyId: string) =>
+      options.vouchesForRetainedPty && ptyId === RETAINED_PTY ? true : null,
+    listProcesses: async (connectionId?: string | null, opts?: { deadlineMs?: number }) => {
+      calls.push({ connectionId, deadlineMs: opts?.deadlineMs })
+      return options.sessions ?? []
+    }
+  } as never)
+  return { internals: runtime as unknown as RuntimeInternals, calls }
+}
+
+describe('pty inventory refresh against a partially answering relay set', () => {
+  it('gives the providers a deadline strictly inside its own list budget', async () => {
+    const { internals, calls } = createRuntime()
+    const before = Date.now()
+
+    await internals.refreshPtyWorktreeRecordsWithControllerInventory([
+      internals.buildResolvedWorktreeFromId(WORKSPACE)
+    ])
+
+    expect(calls).toHaveLength(1)
+    const { deadlineMs } = calls[0]!
+    // Unbounded, an SSH list runs to the mux's 30s default and the whole refresh expires, so
+    // no inventory ever arrives and nothing is retired.
+    expect(deadlineMs).toBeDefined()
+    expect(deadlineMs!).toBeGreaterThan(before)
+    expect(deadlineMs!).toBeLessThan(before + LIST_BUDGET_MS)
+  })
+
+  it('honours a caller deadline tighter than the list budget', async () => {
+    const { internals, calls } = createRuntime()
+    const callerDeadline = Date.now() + 400
+
+    await internals.refreshPtyWorktreeRecordsWithControllerInventory(
+      [internals.buildResolvedWorktreeFromId(WORKSPACE)],
+      null,
+      callerDeadline
+    )
+
+    expect(calls[0]!.deadlineMs!).toBeLessThanOrEqual(callerDeadline)
+  })
+
+  it('keeps orchestration authority for a pane the controller still vouches for', async () => {
+    const { internals } = createRuntime({ vouchesForRetainedPty: true })
+    internals.recordPtyWorktree(RETAINED_PTY, WORKSPACE, {
+      connected: true,
+      tabId: TAB_ID,
+      paneKey: PANE_KEY
+    })
+    internals.restoredOrchestrationAuthorityByPtyId.set(RETAINED_PTY, {
+      ptyId: RETAINED_PTY,
+      worktreeId: WORKSPACE,
+      terminalHandle: 'term_retained',
+      paneKey: PANE_KEY,
+      processIncarnation: `${RETAINED_PTY}:inc-1`,
+      hostScope: { kind: 'local' }
+    })
+
+    await internals.refreshPtyWorktreeRecordsWithControllerInventory([
+      internals.buildResolvedWorktreeFromId(WORKSPACE)
+    ])
+
+    // A listing that omits a still-addressable pane is silence, not proof of exit: the
+    // authority sweep has to read the rescued live set, not the raw listing.
+    expect(internals.restoredOrchestrationAuthorityByPtyId.has(RETAINED_PTY)).toBe(true)
+    expect(internals.ptysById.get(RETAINED_PTY)?.connected).toBe(true)
+  })
+
+  it('retires a pane no provider vouches for', async () => {
+    const { internals } = createRuntime({ vouchesForRetainedPty: false })
+    internals.recordPtyWorktree(RETAINED_PTY, WORKSPACE, {
+      connected: true,
+      tabId: TAB_ID,
+      paneKey: PANE_KEY
+    })
+    internals.restoredOrchestrationAuthorityByPtyId.set(RETAINED_PTY, {
+      ptyId: RETAINED_PTY,
+      worktreeId: WORKSPACE,
+      terminalHandle: 'term_retained',
+      paneKey: PANE_KEY,
+      processIncarnation: `${RETAINED_PTY}:inc-1`,
+      hostScope: { kind: 'local' }
+    })
+
+    await internals.refreshPtyWorktreeRecordsWithControllerInventory([
+      internals.buildResolvedWorktreeFromId(WORKSPACE)
+    ])
+
+    // The other half of the contract: an answered inventory that omits an unvouched pane is
+    // what lets the workspace stop reporting itself active on mobile.
+    expect(internals.ptysById.get(RETAINED_PTY)?.connected).toBe(false)
+    expect(internals.restoredOrchestrationAuthorityByPtyId.has(RETAINED_PTY)).toBe(false)
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​379 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​369 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​53 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​28 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​25 |

<!-- /orca-pr-loc -->

## ELI5

Your phone asks the desktop "which workspaces are busy?". To answer, the desktop counts the terminals that are still alive — and that count is the only thing that can ever mark a *forgotten* terminal as dead. It asks every machine and waits.

If one SSH machine goes **silent** — not refusing, just never answering — the desktop waits on it far longer than it is willing to wait for the whole answer, so it throws the entire count away, including the machines that did reply. Nothing gets marked dead, and those workspaces stay lit up as **active**.

This PR gives each machine its own time limit, strictly inside the overall one. A silent machine now gives up early, and the answer still comes back with everyone else's terminals in it.

## What Changed

**Scope note (post-rebase):** main's #14977 already made each provider settle independently — a relay that *rejects* is caught, dropped from both `processes` and `hostIds`, and recorded as `unverifiable`. **This PR now contributes only the missing deadline**, which is the half that covers the actual failure: a relay that goes silent never rejects, so it never reaches #14977's catch. Earlier revisions of this PR also introduced the settle; that part is now main's, and the resolution here deliberately keeps main's `try/catch` (and its `markSshInventoryUnverifiable` call) rather than replacing it with a `.catch(...)` that would have silently dropped the verdict.

**The deadline does not merely coexist with #14977 — it closes a hole in it.** #14977's verdict machinery hangs off the `catch`: a relay that fails to list is supposed to be recorded `unverifiable` so nothing downstream mistakes lost contact for a confirmed exit. But a **silent** relay never throws, so before this change that branch was simply never reached for the silent case — the aggregate died on the runtime's own timeout first and the verdict was never recorded at all. With the deadline forwarded, a silent relay now rejects at the deadline, falls into main's `catch`, fires `onSshInventoryUnavailable`, and lands the `unverifiable` verdict that #14977 intended. The two changes compose: one supplies the branch, the other makes it reachable.

`src/main/ipc/pty.ts` — the aggregate PTY inventory:

```ts
async function listRegisteredPtyProcessesWithHostScope(
  onSshInventoryUnavailable?: (connectionId: string, error: unknown) => void,
  opts?: { deadlineMs?: number }   // ← added
)
…
  // Why: the deadline only applies to relay round-trips; the local provider answers in-process.
  processes: await (connectionId ? provider.listProcesses(opts) : provider.listProcesses()),
```

The deadline is threaded through all three entry points: the aggregate, the targeted single-connection path (`listProcesses(connectionId, opts)`), and `listProcessesWithHostScope(opts)`. The local provider is deliberately **not** given a deadline — it answers in-process, and a local failure still fails the aggregate.

`src/main/runtime/orca-runtime.ts`:

- `refreshPtyWorktreeRecordsWithControllerInventory` computes its list budget once and passes a deadline strictly inside it (`PTY_CONTROLLER_LIST_PROVIDER_MARGIN_MS = 500`), so a relay that gives up still leaves the aggregate time to return the providers that answered;
- `RuntimePtyController.listProcesses` / `listProcessesWithHostScope` gain the optional `opts` to carry it (main-process internal type; not a wire contract);
- the restored-orchestration-authority sweep moved to **after** the `hasPty` rescue, so a pane the controller still vouches for keeps its handle.

## Why

`worktree.ps` is mobile's only status source, and its liveness refresh is the only code path that can flip a retained PTY to `connected = false`.

`SshPtyProvider.listProcesses` falls through to the mux's own `REQUEST_TIMEOUT_MS = 30_000`, while the runtime wraps the whole aggregate in `PTY_CONTROLLER_LIST_TIMEOUT_MS = 3_000`. A registered-but-unresponsive relay therefore blows the budget every single time — and #14977's per-provider `try/catch` does not help, because a silent relay never throws. `Promise.all` simply does not settle inside 3s, `withTimeoutResult` fires, and `refreshPtyWorktreeRecordsWithControllerInventory` returns `null` **before** the sweep that marks PTYs disconnected. The entire inventory is lost, local included.

**Which panes actually get stuck — corrected.** An earlier revision of this description implied that local panes stay "active" after their processes exit. That is not accurate, and live testing falsified it. Orca has two independent retirement paths:

1. **The PTY exit event** — a shell that exits *under observation* is retired immediately and never consults the inventory.
2. **The inventory sweep** — the only path that can retire a pane whose death was never observed.

So the stuck-active symptom applies to panes that must be **proven dead by the listing**: records restored from persistence after an app restart, and retained/unconfirmed records generally. A pane that exits while the app is watching retires normally even with the inventory broken. The user-visible bug is real; this is the accurate statement of its scope.

A provider that does not answer is **unknown, not empty**. Its panes are not retired: the existing `hasPty` rescue re-adds them (`SshPtyProvider.livePtyIds` is cleared only on `dispose()`), and it drops out of `hostIds` so the listing never claims coverage it lacks. When the connection is genuinely lost, `teardownProviders('connection_lost')` disposes and unregisters the provider, `hasPty` returns `null`, and the workspace correctly goes inactive. That self-healing path is what the failed aggregate was preventing.

## Linked Issue

Fixes STA-517 — https://linear.app/stably/issue/STA-517/fix-incorrect-active-status-display-for-ssh-work-trees-on-mobile

## Visual Proof

`N/A` for screenshots — no UI change; this is a host-side correctness fix to the values `worktree.ps` publishes, and mobile's rendering code is untouched. The proof is a **measured before/after against a real SSH relay**, below.

## Testing

- [x] I manually tested these changes locally

### Live rig

A throwaway `ubuntu:22.04` Docker container as the SSH target (key-only root login, node 22.14.0, `build-essential` + `python3` — required or node-pty will not build on the remote and remote PTYs never come up — and a real git repo at `/work/demo-project`). The client was this worktree running as an isolated Electron dev instance (own `ORCA_DEV_USER_DATA_PATH`, own CDP port, `getIdentity()` re-verified before every interaction batch, `repos.list()` returning `[]` on first attach confirming a genuinely fresh profile), connected through the real `ssh.connect` path with the real relay deployed and running on the container (detached daemon + `--connect` bridge both verified by PID inside the container).

**4 real PTYs, 2 per host**: 2 local (darwin) and 2 remote (`ssh:…@@pty-1/2`, real `/bin/bash` on `pts/0` inside the container, titles resolving to `root@c4a120d1207b: /work/demo-project`).

**Unreachability = `docker pause`.** This is the important detail: the TCP socket stays open and nothing ever answers. That is the actual failure mode — killing the container or blackholing the port produces a clean error instead, which exercises #14977's branch rather than this one. The mux confirmed it: `[ssh-mux] Protocol error: Connection timed out (no ack received)`.

Each arm's running bundle was verified to be the code under test, not assumed: `PTY_CONTROLLER_LIST_PROVIDER_MARGIN_MS` occurs **2×** in `out/main/index.js` with the fix and **0×** without it.

### Result

Baseline, relay healthy — `hostIds: ["local","ssh:…"]`, `omittedHostIds: []`, both workspaces `active:true live:2`.

With the relay hung:

| | pre-fix | post-fix |
| :--- | :--- | :--- |
| `terminal.list` latency | `3004 ms` (hit the 3s ceiling, returned nothing) | `5395 ms` (returned) |
| `hostScope.hostIds` | `[]` — **whole inventory lost, local included** | `["local"]` |
| `hostScope.omittedHostIds` | `["local","ssh:…"]` | `["ssh:…"]` |
| local panes | never reconciled | retired (`active:false live:0`) |
| remote panes | — | retained, `active:true live:2` (UNKNOWN, not empty) |

Pre-fix rows, verbatim:

```
{"arm":"PREFIX","tag":"BEFORE-pause","listMs":14,  "covered":["local","ssh:…"],"notCovered":[],           "localTerms":2,"sshTerms":2}
# PAUSED
{"arm":"PREFIX","tag":"T1","listMs":3004,"covered":[],"notCovered":["local","ssh:…"],"sshTerms":2}
{"arm":"PREFIX","tag":"T2","listMs":3004,"covered":[],"notCovered":["local","ssh:…"],"sshTerms":2}
```

Corroborated in the same run by `terminal_liveness_unavailable` thrown out of `refreshRestoredOrchestrationAuthority` — the `requireFreshPtyLiveness` callers failing on the null inventory.

### `— not covered:` renders correctly

The live `terminal.list` payload was captured off the running runtime and fed to the **real** `formatTerminalList` from `src/cli/terminal-format.ts`:

```
post-fix:  scope: local — not covered: ssh:ssh-1786951515639-b1xqbj
pre-fix:   scope: none — not covered: local, ssh:ssh-1786951515639-b1xqbj
```

A dead relay prints "not covered" rather than an empty list that would read as "no terminals there".

**Caveat, stated plainly:** only the **post-fix** line comes from a fully captured payload. The pre-fix line substitutes the `hostScope` the pre-fix runtime actually reported into that captured payload — the `hostScope` values are measured, the surrounding body is not a pre-fix capture.

### Re-run against the rebased tree — the caveat is now a measurement

The section this replaces said the "current main behaves identically under a hang" claim was **code inspection, not measurement**, and that the rig had not been re-run after the rebase. It has now been re-run against this exact tree (`141d45db76`), and the inspection was correct.

Full log: [sta517-rebased-measurement.txt](https://github.com/user-attachments/files/31158582/sta517-rebased-measurement.txt)

**Rig.** Fresh throwaway `debian:bookworm-slim` sshd container (key-only, node 20.18.1 + `build-essential`/`python3`, aarch64 — node-pty will not build on the remote without them and every remote PTY comes up unavailable), plus `pnpm run build:relay` first because the dev build ships no linux-arm64 relay. Isolated Electron dev instance (own `ORCA_DEV_USER_DATA_PATH`, own CDP port, `getIdentity()` verified), with the `orca` CLI pointed at **that** runtime via `ORCA_USER_DATA_PATH=<same dir>` so the measurement cannot read another instance. Real PTYs on both hosts. Unreachability is again `docker pause` — socket open, nothing answers.

**Rebased baseline confirmed:** `origin/main` already carries #14977's per-provider settle (`7afce2ea41`), so this PR contributes only the forwarded deadline.

| relay hung | pre-fix (deadline removed) | post-fix (this PR) |
| :--- | :--- | :--- |
| `terminal.list` latency | **3.18 s** — the 3 s ceiling | **2.70 s** — the provider deadline, inside it |
| `hostScope.hostIds` | `[]` — **whole inventory lost, local included** | `["local"]` |
| `hostScope.omittedHostIds` | `["local","ssh:…"]` | `["ssh:…"]` |
| rendered scope line | `scope: none — not covered: local, ssh:…` | `scope: local — not covered: ssh:…` |
| terminals returned | 5, all stale — nothing retired | 1 (local); the dead host's records retired |
| `onSshInventoryUnavailable` | **never fired** | fired |

Both arms are real `orca terminal list` output from the running runtime — the pre-fix scope line is a genuine pre-fix capture this time, not a substitution.

**The composition with #14977, observed.** This is the part that had never been seen. Two temporary `console.log` calls in `markSshInventoryUnverifiable` (reverted afterwards; not in this diff) recorded:

```
[STA517-PROBE] onSshInventoryUnavailable conn=ssh-… reason=Request "pty.listProcesses" timed out after 2500ms
[STA517-PROBE] markPtyLivenessUnverifiable pty=ssh:…@@pty-1
[STA517-PROBE] markPtyLivenessUnverifiable pty=ssh:…@@pty-2
[STA517-PROBE] markPtyLivenessUnverifiable pty=ssh:…@@pty-4
```

`2500 ms` is exactly `PTY_CONTROLLER_LIST_TIMEOUT_MS` (3000) minus `PTY_CONTROLLER_LIST_PROVIDER_MARGIN_MS` (500). The silent relay rejects **at** the deadline, falls into main's per-provider `catch`, fires `onSshInventoryUnavailable`, and lands the `unverifiable` verdict on every PTY that connection owns. With the deadline removed the same probe printed **zero** lines across the whole arm: main's verdict machinery is genuinely unreachable for a silent relay, and the deadline is what makes it reachable. That is the deadline's contribution stated exactly.

**Still not measured.** The `unverifiable` verdict was observed at the point it is recorded, not at a user-facing surface: `terminal.close` is the only CLI surface that reports `ptyStopVerdict`, and it returns `tab_not_found` for CLI-created terminals in a headless rig (for local terminals too), so the verdict was not read back out through an RPC. Only the aggregate (`connectionId === undefined`) path was exercised; the per-connection path shares the same forwarding but was not driven separately.

### Automated

- `src/main/ipc/pty-controller-process-inventory.test.ts` — the aggregate still reports local + healthy relays when one relay is unavailable; the deadline is forwarded on both the aggregate and targeted paths; a local failure still fails the aggregate (contract lock).
- `src/main/runtime/pty-inventory-partial-relay-liveness.test.ts` — the provider deadline lands strictly inside the runtime's own budget, a tighter caller deadline is honoured, a vouched-for pane keeps its orchestration authority, and a pane no provider vouches for is retired.
- `src/main/ipc/pty-runtime-kill-and-exit.test.ts` / `src/main/runtime/orca-runtime.test.ts` — existing assertions matched the inventory call on exact arity; their intent is *which provider scope was asked*, so they now match the scope argument **and** require a numeric deadline beside it, so the added budget is covered rather than merely tolerated.

```bash
pnpm exec vitest run --config config/vitest.config.ts \
  src/main/runtime/pty-inventory-partial-relay-liveness.test.ts \
  src/main/ipc/pty-controller-process-inventory.test.ts \
  src/main/ipc/pty-runtime-kill-and-exit.test.ts \
  src/main/runtime/orca-runtime.test.ts \
  src/main/runtime/terminal-list-execution-host-scope.test.ts
```

Post-rebase: **5 files, 1202 passed, 1 skipped.** `tsc --noEmit -p config/tsconfig.node.json --composite false` clean. `oxlint` + `oxfmt --check` clean on all 6 changed files, and the lint gate was **proven live** by injecting a `no-unused-vars` / `no-debugger` violation and confirming both were reported, rather than trusting silent output.

- [x] Automated tests added/updated, or explained why not below

## Review

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

- **Remote SSH** — the point of the change. Strictly more correct: a silent relay no longer poisons the inventory, and its own panes are still protected by `hasPty` rather than being wrongly retired.
- **Interaction with #14977** — complementary, and verified on the rebased tree rather than assumed. The deadline is what *feeds* #14977's verdict machinery: without it a hung relay never reaches the `catch`, so `markSshInventoryUnverifiable` never fires for the silent case. `listProcessesWithHostScope` still binds the hoisted module-level `listRegisteredPtyProcessesWithHostScope`, and `orca-runtime.ts` still calls exactly that — checked explicitly, since a clean merge does not prove the fix stayed on the live path.
- **Wire compatibility** — checked against `docs/reference/remote-wire-compatibility.md`. No frame shape change, no new opcode, no RPC params touched. This is Rule 3 territory (host-published *content* on `worktree.ps`): no field changes meaning, units, or nullability, and the host does not stop populating anything. It stops emitting a **false positive**. An older client reads the same `status` / `hasHostSidebarActivity` / `liveTerminalCount` fields with the same semantics, just accurate, so no capability gate is needed.
- **Cross-platform** — no platform-conditional code, no paths, no shortcuts.
- **Folder workspaces** — untouched; the summary builder treats them identically.
- **Performance** — strictly better. The providers already ran concurrently; bounding each one stops a dead relay from holding the refresh for up to 30s. Measured above: 3004 ms and no answer, versus 5395 ms with the local inventory intact.
- **Mobile** — no mobile source changed; mobile renders whatever `worktree.ps` publishes.

**Adjacent finding, deliberately not fixed here** (flagging so it is not lost; it wants its own ticket): `mobile/src/worktree/agent-row-display.ts` decays a stale agent row using the *phone's* `Date.now()` against a *host*-stamped `row.updatedAt` — the two-machine clock comparison STA-3455 describes. A phone clock behind the host makes that delta negative, so the per-agent dot never decays. It styles the agent row rather than the worktree's active status, so it is a separate defect and out of scope for a focused fix.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — scoped equivalents run locally as listed in Testing; full typecheck/build left to CI

## Author

- X / Twitter: @BrennanKB5


