### PR TITLE
fix(sidebar): keep owned agent panes visible when their title carries no agent frame (#14464)

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -110,6 +110,123 @@ describe('buildTitleDerivedAgentRows', () => {
     ])
   })
 
+  // Why: Codex titles its panes with the worktree name, so a live Codex pane's title carries
+  // neither an agent name nor a status frame. Titles below were captured from
+  // `orca terminal list --json` on Windows 11 and cross-referenced to each tab's persisted
+  // launchAgent. Before #14464 every one of these panes produced no row at all, so a restored
+  // Codex tab disappeared from the sidebar and Agent Dashboard while its PTY stayed connected.
+  describe('owned panes whose title carries no agent frame (#14464)', () => {
+    for (const title of [
+      'gh-13695',
+      'issue-13626-complete',
+      'pr-13977-best-review',
+      'gh-13752-current-main...',
+      'Terminal 1'
+    ]) {
+      it(`keeps a live Codex pane titled ${JSON.stringify(title)} as an idle Codex row`, () => {
+        const rows = buildWorktreeAgentRows({
+          tabs: [makeTab('tab-1', { title, defaultTitle: 'Terminal 1', launchAgent: 'codex' })],
+          entries: [],
+          retained: [],
+          ptyIdsByTabId: { 'tab-1': ['pty-codex'] },
+          terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+          now: 2000
+        })
+
+        expect(rows.map((row) => [row.agentType, row.state, row.entry.prompt])).toEqual([
+          ['codex', 'idle', 'Codex']
+        ])
+        expect(rows.map((row) => row.paneKey)).toEqual([makePaneKey('tab-1', LEAF_ID_1)])
+      })
+    }
+
+    // Why: node-pty reports the foreground process as the console title on Windows, so a
+    // full-path shell title is positive evidence the agent exited and left its shell behind.
+    // That must not be resurrected as an agent row just because launchAgent outlived it.
+    for (const shellTitle of [
+      'C:\\Program Files\\WindowsApps\\Microsoft.PowerShell_7.6.4.0_x64__8wekyb3d8bbwe\\pwsh.exe',
+      'C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+      'bash',
+      'pwsh.exe'
+    ]) {
+      it(`drops a pane whose title is the shell ${JSON.stringify(shellTitle)}`, () => {
+        const rows = buildWorktreeAgentRows({
+          tabs: [
+            makeTab('tab-1', {
+              title: shellTitle,
+              defaultTitle: 'Terminal 1',
+              launchAgent: 'codex'
+            })
+          ],
+          entries: [],
+          retained: [],
+          ptyIdsByTabId: { 'tab-1': ['pty-codex'] },
+          terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+          now: 2000
+        })
+
+        expect(rows).toEqual([])
+      })
+    }
+
+    it('still drops an unowned pane whose title carries no agent frame', () => {
+      const rows = buildWorktreeAgentRows({
+        tabs: [makeTab('tab-1', { title: 'gh-13695', defaultTitle: 'Terminal 1' })],
+        entries: [],
+        retained: [],
+        ptyIdsByTabId: { 'tab-1': ['pty-shell'] },
+        terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+        now: 2000
+      })
+
+      expect(rows).toEqual([])
+    })
+
+    it('still drops an owned pane with no live PTY', () => {
+      const rows = buildWorktreeAgentRows({
+        tabs: [makeTab('tab-1', { title: 'gh-13695', launchAgent: 'codex' })],
+        entries: [],
+        retained: [],
+        ptyIdsByTabId: {},
+        terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+        now: 2000
+      })
+
+      expect(rows).toEqual([])
+    })
+
+    // Why: launchAgent is tab-scoped, so inside a split it is not pane ownership — letting it
+    // seed rows there would brand a sibling pane with the other pane's agent.
+    it('does not brand split panes from the tab-scoped launch agent', () => {
+      const rows = buildWorktreeAgentRows({
+        tabs: [makeTab('tab-1', { title: 'gh-13695', launchAgent: 'codex' })],
+        entries: [],
+        retained: [],
+        runtimePaneTitlesByTabId: { 'tab-1': { 1: 'gh-13695', 2: 'gh-13695' } },
+        ptyIdsByTabId: { 'tab-1': ['pty-left', 'pty-right'] },
+        terminalLayoutsByTabId: { 'tab-1': makeSplitLayout() },
+        now: 2000
+      })
+
+      expect(rows).toEqual([])
+    })
+
+    // Why: the owner is a fallback, never an override — a title that names a live agent still
+    // decides identity and activity.
+    it('lets an agent-naming title win over the launch owner', () => {
+      const rows = buildWorktreeAgentRows({
+        tabs: [makeTab('tab-1', { title: '\u280b Codex', launchAgent: 'codex' })],
+        entries: [],
+        retained: [],
+        ptyIdsByTabId: { 'tab-1': ['pty-codex'] },
+        terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+        now: 2000
+      })
+
+      expect(rows.map((row) => [row.agentType, row.state])).toEqual([['codex', 'working']])
+    })
+  })
+
   it('does not add title-derived rows for panes without a live PTY', () => {
     const rows = buildWorktreeAgentRows({
       tabs: [makeTab('tab-1')],

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -1,6 +1,7 @@
 import type { DashboardAgentRow } from '@/components/dashboard/useDashboardData'
 import { formatAgentTypeLabel, isClaudeManagementTitle } from '@/lib/agent-status'
 import { isCursorAgentTitle } from '../../../../shared/agent-title-core'
+import { isShellProcess } from '../../../../shared/shell-process-detection'
 import { classifyTitleActivity, resolveTitleActivityLabel } from '@/lib/pane-agent-evidence'
 import { tabHasLivePty } from '@/lib/tab-has-live-pty'
 import type {
@@ -138,6 +139,14 @@ function buildTitleDerivedAgentRow(args: {
   // is a separate, stricter question — it decides identity, so it uses ownerAgentType below.
   const title = normalizeCompatibleAgentTitleForOwner(args.title, args.tab.launchAgent)
   const isClaudeAgentsTitle = isClaudeManagementTitle(title)
+  // Why: an owned pane whose title carries no agent frame is still that owner's session
+  // (Codex titles its panes with the worktree name, so a live Codex pane reads as
+  // "gh-13695"). Same concession as Cursor below, widened from one literal to any known
+  // owner: without it the pane's only row source is its title, so a restored agent tab
+  // vanishes from the sidebar/dashboard while its PTY stays connected (#14464).
+  // A shell title is positive evidence the agent left, so it must not resurrect a row.
+  const ownerIdentifiesPane =
+    args.ownerAgentType !== null && args.ownerAgentType !== 'unknown' && !isShellProcess(title)
   // Why: `claude agents` is a live Claude Code Agent Teams surface, but the
   // shared detector keeps it neutral so runtime liveness probes do not treat
   // the management/list screen as active work.
@@ -146,8 +155,12 @@ function buildTitleDerivedAgentRow(args: {
   // reads idle instead of vanishing (#10258).
   const status = isClaudeAgentsTitle
     ? 'idle'
-    : (classifyTitleActivity(title) ?? (isCursorAgentTitle(title) ? 'idle' : null))
-  const label = isClaudeAgentsTitle ? 'Claude Code' : resolveTitleActivityLabel(title)
+    : (classifyTitleActivity(title) ??
+      (isCursorAgentTitle(title) || ownerIdentifiesPane ? 'idle' : null))
+  const label = isClaudeAgentsTitle
+    ? 'Claude Code'
+    : (resolveTitleActivityLabel(title) ??
+      (ownerIdentifiesPane ? formatAgentTypeLabel(args.ownerAgentType) : null))
   if (!status || !label) {
     return null
   }


### PR DESCRIPTION
## ELI5

Orca decides "is this terminal an agent?" mostly by reading the terminal's title. Codex doesn't put its name in the title on Windows — it names the pane after the worktree (`gh-13695`), so Orca didn't recognise it. As soon as there was no live hook status to fall back on (right after a restart or an update), those Codex tabs simply disappeared from the sidebar and the Agent Dashboard, even though the process was still running fine. This makes Orca also trust what it already knows: which agent was launched in that pane.

## What Changed

`buildTitleDerivedAgentRow` gains an owner fallback. When the pane's title yields no agent activity, but the pane has a **known owner** (`launchAgent`) and a **live PTY**, the row is emitted as an idle row for that owner instead of being dropped.

Guards kept deliberately tight — all covered by tests:

- **Shell titles still win.** A title that is a shell process is positive evidence the agent exited and left its shell behind, so it must not resurrect a row. Uses the existing shared `isShellProcess`, which already handles Windows full-path titles (`C:\...\pwsh.exe`) and blank titles.
- **Unowned panes are unchanged** — no `launchAgent`, no row. This path still never manufactures a row from a plain shell.
- **Dead PTYs are unchanged** — the pre-existing `tabHasLivePty` gate is untouched.
- **Splits are unchanged.** `launchAgent` is tab-scoped, so `resolveTitleDerivedPaneOwner` only returns an owner for a single-leaf layout; a split pane cannot brand its sibling.
- **The owner is a fallback, never an override.** A title that names a live agent still decides identity and activity.

No platform branching: this is a correctness fix in shared agent-identity logic, and the guards above mean macOS/Linux behaviour only changes in the same case that was broken there too.

## Why

A live agent pane with no hook status has exactly one row source: its terminal title. The gate was:

```ts
const status = classifyTitleActivity(title) ?? (isCursorAgentTitle(title) ? 'idle' : null)
const label  = resolveTitleActivityLabel(title)
if (!status || !label) return null   // <- pane dropped
```

`ownerAgentType` was already computed and passed into this function, but sat *behind* that gate and was unreachable. So a pane whose owner Orca knew for certain was still discarded.

That matters because Codex's pane title on Windows carries neither an agent name nor a status glyph. Captured live on this box with `orca terminal list --json`, then cross-referenced to each tab's persisted `launchAgent`: **all 12 live Codex panes** had titles like `gh-13695`, `issue-13626-complete`, `pr-13977-best-review`, or the neutral `Terminal 1` — every one failing the gate. Grok and Claude panes on the same box carried agent-identifying titles (`... - grok`, `claude`) and were unaffected. That 1:1 correlation is what the new tests pin.

Consequence: whenever hook status is absent for a Codex pane — precisely the state after an app restart or update, before the next hook ping — the pane has *no* row source at all and drops out of `buildWorktreeAgentRows`, which feeds both the sidebar (`useWorktreeAgentRows`) and the Agent Dashboard (`build-dashboard-snapshot`). The PTY stays connected and writable the whole time, which is the reported symptom.

This is the same concession already made for Cursor's deliberately status-less native title (#10258, `isCursorAgentTitle(title) ? 'idle' : null`) — "it still identifies a live pane, so the row reads idle instead of vanishing". This widens it from one hard-coded literal to any known owner.

## Linked Issue

Fixes #14464

Also expected to address STA-4054 (Codex agents not recognized as agents in Orca or the Agent Dashboard on Windows), which is the same root cause observed without a restart.

## Visual Proof

`N/A` — could not capture. The Orca build on this Windows host is the packaged release with no `--remote-debugging-port`, so CDP inspection was unavailable, and relaunching it to attach a debugger would have destroyed 33 live PTYs belonging to other in-flight sessions on this box. The behaviour is instead pinned by unit tests asserting the exact row output (`agentType`, `state`, `prompt`, `paneKey`) for the real captured titles.

## Testing

Windows 11 Pro (10.0.26200), `win32 x64`, platform confirmed at runtime.

Evidence gathering:

1. `orca terminal list --json` on the live host to capture real pane titles.
2. Cross-referenced each `tabId` against `%APPDATA%\orca\profiles\local-default\orca-data.json` to read its persisted `launchAgent`.
3. Confirmed every worktree-name-titled live pane was `launchAgent: "codex"`, and that Grok/Claude panes carried agent-identifying titles.

Automated:

- 10 new tests in `worktree-title-derived-agent-rows.test.ts` — 5 positive (real captured Codex titles) and 5 negative guards (shell titles, unowned pane, dead PTY, split layout, agent-naming title wins).
- **Verified the new tests fail without the fix**: stashing only the source change gives `5 failed | 25 passed`; the 5 negative guards pass either way, as they should.
- `src/renderer/src/components/sidebar` + `src/renderer/src/components/dashboard`: **294 files, 2646 tests passed**.
- Agent-status consumers (`src/renderer/src/runtime`, `use-tab-agent*`, `worktree-status-spinner-launch-agent`, `agent-row-primary-text`): **81 files, 857 tests passed**.
- `oxlint` on both changed files: clean.

Not run / known-failing for unrelated reasons:

- Full `pnpm typecheck` was **deliberately not run** (OOM risk on this host, per task constraint). Types touched are narrow: `formatAgentTypeLabel(AgentType | null | undefined)` and `isShellProcess(string)`.
- `oxfmt --check` flags the changed files, but flags untouched files in the same directory identically — the known Windows CRLF false positive, not introduced here. No formatting was rewritten, to avoid polluting the diff with line-ending churn.
- `check:code-quality:changed` fails with `EINVAL spawnSync pnpm.cmd` on Windows — a pre-existing harness issue; ran `oxlint` directly instead.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

- **Cross-platform**: no platform branching added. `isShellProcess` already normalises Windows full-path/`.exe` titles and POSIX basenames.
- **Remote SSH**: unchanged. This function is title/owner-only and does no probing; the remote-specific handling lives in the callers.
- **Performance**: one extra `isShellProcess` string check per title-derived pane, only on the path that previously returned `null`.
- **Backwards compatibility**: purely additive to row construction — no persisted state, no wire format, no schema touched.

## AI Disclosure

Claude Opus 4.5 (Claude Code), on a Windows host.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — scoped equivalents run locally and green; full typecheck left to CI per the OOM constraint above

## Author

- X / Twitter: @BrennanKB5
