### PR TITLE
feat(terminal): opt-in setting to terminate sessions on quit

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3276,8 +3276,13 @@ app.on('will-quit', (e) => {
     : Promise.resolve()
   // Why: allSettled (not all) keeps fail-open — a daemon-disconnect rejection still quits instead of hanging.
   // Why: telemetry flush folds in before app.quit() (bounded 2s); catch defensively so a flush failure can't cancel the quit chain.
-  // Why: normal quits keep the detached daemon for warm reattach, but a dead dev parent leaves the temp/dev profile ownerless.
-  const daemonTeardown = isDevParentShutdownRequested() ? shutdownDaemon() : disconnectDaemon()
+  // Why: normal quits keep the detached daemon for warm reattach, but a dead dev parent leaves the
+  // temp/dev profile ownerless — and terminateSessionsOnQuit is the user's opt-in for quit meaning
+  // every session stops instead of surviving for reattach (#7783).
+  const daemonTeardown =
+    isDevParentShutdownRequested() || store?.getSettings().terminateSessionsOnQuit === true
+      ? shutdownDaemon()
+      : disconnectDaemon()
   // Why: a wedged transport (half-open post-sleep socket) can leave one
   // member unsettled forever and block app.quit() until Force Quit (#9447).
   // Why stats/state join here: their writes are durable but not worth hanging the app for.

--- a/src/renderer/src/components/settings/ManageSessionsSection.test.tsx
+++ b/src/renderer/src/components/settings/ManageSessionsSection.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment happy-dom
+
+import '@testing-library/jest-dom/vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getDefaultSettings } from '../../../../shared/constants'
+
+const mocks = vi.hoisted(() => ({
+  listSessions: vi.fn(),
+  setPending: vi.fn()
+}))
+
+vi.mock('@/i18n/i18n', () => ({
+  i18n: { language: 'en' },
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      settingsSearchQuery: '',
+      tabsByWorktree: {},
+      ptyIdsByTabId: {},
+      setActiveView: vi.fn(),
+      closeSettingsPage: vi.fn()
+    })
+}))
+
+vi.mock('../shared/useDaemonActions', () => ({
+  useDaemonActions: () => ({ isBusy: false, busyKind: null, setPending: mocks.setPending }),
+  DaemonActionDialog: () => null
+}))
+
+vi.mock('./TerminalTccAttributionNotice', () => ({
+  MANAGE_SESSIONS_SECTION_ID: 'manage-sessions',
+  TerminalTccAttributionNotice: () => null
+}))
+
+vi.mock('./ManageSessionsTable', () => ({
+  ManageSessionsTable: () => null
+}))
+
+vi.mock('./ManageSessionKillDialog', () => ({
+  ManageSessionKillDialog: () => null
+}))
+
+vi.mock('../status-bar/daemon-session-inventory-invalidation', () => ({
+  notifyDaemonSessionInventoryInvalidated: vi.fn()
+}))
+
+import { ManageSessionsSection } from './ManageSessionsSection'
+
+describe('ManageSessionsSection terminate-on-quit toggle', () => {
+  beforeEach(() => {
+    mocks.listSessions.mockResolvedValue({ sessions: [] })
+    vi.stubGlobal(
+      'window',
+      Object.assign(window, {
+        api: { pty: { management: { listSessions: mocks.listSessions } } }
+      })
+    )
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+  })
+
+  it('defaults off so quit keeps sessions warm for reattach', () => {
+    render(<ManageSessionsSection settings={getDefaultSettings('/tmp')} updateSettings={vi.fn()} />)
+
+    const toggle = screen.getByRole('switch', { name: 'Terminate sessions when quitting Orca' })
+    expect(toggle).toHaveAttribute('aria-checked', 'false')
+  })
+
+  it('opts in and out through updateSettings', async () => {
+    const user = userEvent.setup()
+    const updateSettings = vi.fn()
+    const { rerender } = render(
+      <ManageSessionsSection
+        settings={getDefaultSettings('/tmp')}
+        updateSettings={updateSettings}
+      />
+    )
+
+    await user.click(screen.getByRole('switch', { name: 'Terminate sessions when quitting Orca' }))
+    expect(updateSettings).toHaveBeenCalledWith({ terminateSessionsOnQuit: true })
+
+    rerender(
+      <ManageSessionsSection
+        settings={{ ...getDefaultSettings('/tmp'), terminateSessionsOnQuit: true }}
+        updateSettings={updateSettings}
+      />
+    )
+    const toggle = screen.getByRole('switch', { name: 'Terminate sessions when quitting Orca' })
+    expect(toggle).toHaveAttribute('aria-checked', 'true')
+    await user.click(toggle)
+    expect(updateSettings).toHaveBeenLastCalledWith({ terminateSessionsOnQuit: false })
+  })
+})

--- a/src/renderer/src/components/settings/ManageSessionsSection.tsx
+++ b/src/renderer/src/components/settings/ManageSessionsSection.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import type { PtyManagementSession } from '../../../../preload/api-types'
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
 import { SearchableSetting } from './SearchableSetting'
+import { SettingsSwitchRow } from './SettingsFormControls'
 import { getManageSessionsSearchEntries } from './terminal-search'
 import { useAppStore } from '../../store'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
@@ -18,7 +20,15 @@ import { translate } from '@/i18n/i18n'
 
 type ConfirmKind = 'killOne'
 
-export function ManageSessionsSection(): React.JSX.Element {
+type ManageSessionsSectionProps = {
+  settings: GlobalSettings
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+}
+
+export function ManageSessionsSection({
+  settings,
+  updateSettings
+}: ManageSessionsSectionProps): React.JSX.Element {
   const [sessions, setSessions] = useState<PtyManagementSession[]>([])
   const [isRefreshing, setIsRefreshing] = useState(true)
   const [hasLoadedOnce, setHasLoadedOnce] = useState(false)
@@ -231,6 +241,23 @@ export function ManageSessionsSection(): React.JSX.Element {
           onRestartDaemon={() => daemonActions.setPending('restart')}
           onNavigate={handleNavigate}
           onRequestKill={setPendingKillSession}
+        />
+      </SearchableSetting>
+
+      <SearchableSetting
+        title={getManageSessionsSearchEntries()[1].title}
+        description={getManageSessionsSearchEntries()[1].description}
+        keywords={getManageSessionsSearchEntries()[1].keywords}
+      >
+        <SettingsSwitchRow
+          label={getManageSessionsSearchEntries()[1].title}
+          description={getManageSessionsSearchEntries()[1].description}
+          checked={settings.terminateSessionsOnQuit === true}
+          onChange={() =>
+            updateSettings({
+              terminateSessionsOnQuit: !(settings.terminateSessionsOnQuit === true)
+            })
+          }
         />
       </SearchableSetting>
 

--- a/src/renderer/src/components/settings/TerminalPane.tsx
+++ b/src/renderer/src/components/settings/TerminalPane.tsx
@@ -94,7 +94,11 @@ export function TerminalPane({
       />
     ) : null,
     matchesSettingsSearch(searchQuery, getManageSessionsSearchEntries()) ? (
-      <ManageSessionsSection key="manage-sessions" />
+      <ManageSessionsSection
+        key="manage-sessions"
+        settings={settings}
+        updateSettings={updateSettings}
+      />
     ) : null,
     matchesSettingsSearch(searchQuery, getTerminalAdvancedSearchEntries()) ||
     (showWindowsPowerShellImplementation &&

--- a/src/renderer/src/components/settings/terminal-window-setup-search.ts
+++ b/src/renderer/src/components/settings/terminal-window-setup-search.ts
@@ -28,6 +28,36 @@ export const getManageSessionsSearchEntries = createLocalizedCatalog(() => [
       ...translateSearchKeyword('auto.components.settings.terminal.search.88561b3499', 'frozen'),
       ...translateSearchKeyword('auto.components.settings.terminal.search.d4daf4f612', 'unfreeze')
     ]
+  },
+  {
+    title: translate(
+      'auto.components.settings.terminal.search.terminateOnQuitTitle',
+      'Terminate sessions when quitting Orca'
+    ),
+    description: translate(
+      'auto.components.settings.terminal.search.terminateOnQuitDescription',
+      'Kill every terminal and agent session on quit instead of keeping them running in the background for reattach.'
+    ),
+    keywords: [
+      ...translateSearchKeyword(
+        'auto.components.settings.terminal.search.terminateKeyword',
+        'terminate'
+      ),
+      ...translateSearchKeyword('auto.components.settings.terminal.search.quitKeyword', 'quit'),
+      ...translateSearchKeyword('auto.components.settings.terminal.search.exitKeyword', 'exit'),
+      ...translateSearchKeyword(
+        'auto.components.settings.terminal.search.backgroundKeyword',
+        'background'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.terminal.search.persistKeyword',
+        'persist'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.terminal.search.restoreKeyword',
+        'restore'
+      )
+    ]
   }
 ])
 

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -9497,7 +9497,9 @@
               "title": "Theme Mode",
               "keyword_target": "target",
               "keyword_editing": "editing"
-            }
+            },
+            "terminateOnQuitTitle": "Terminate sessions when quitting Orca",
+            "terminateOnQuitDescription": "Kill every terminal and agent session on quit instead of keeping them running in the background for reattach."
           },
           "windows": {
             "search": {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -321,6 +321,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     claudeAgentTeamsDefaultDisabledMigrated: true,
     skipDeleteWorktreeConfirm: false,
     skipCloseTerminalWithRunningProcessConfirm: false,
+    terminateSessionsOnQuit: false,
     skipDeleteAutomationConfirm: false,
     skipDeleteArtifactConfirm: false,
     skipCodexRateLimitResetConfirm: false,

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -312,6 +312,10 @@ export type GlobalSettings = {
   skipDeleteWorktreeConfirm: boolean
   /** Why: closing a terminal with child processes kills foreground work; keep this skip separate from other confirmations. */
   skipCloseTerminalWithRunningProcessConfirm: boolean
+  /** Why: the daemon outlives quit so sessions reattach warm on relaunch, but that leaves agents
+   *  running headless after the app closes (#7783); this opt-in makes quit kill the daemon and
+   *  every session with it. Optional so pre-existing profiles keep the warm-reattach default. */
+  terminateSessionsOnQuit?: boolean
   /** Why: deleting an automation also deletes its run history; keep this skip separate from worktree deletion. */
   skipDeleteAutomationConfirm: boolean
   /** Why: deleting an artifact breaks a public link others may already hold; keep this skip separate from local deletions. */


### PR DESCRIPTION
## ELI5

Today, quitting Orca doesn't stop your terminals — a background daemon keeps every session (including running coding agents) alive so they can reattach warm on relaunch. That's great until you *want* quit to mean stop: agents keep burning tokens headless, and tabs you thought were gone resurrect on the next launch. This PR adds an off-by-default toggle: "Terminate sessions when quitting Orca."

## What Changed

- New `GlobalSettings` field `terminateSessionsOnQuit` (optional, defaults off — existing behavior is unchanged unless the user opts in).
- The quit teardown in `src/main/index.ts` routes through the existing `shutdownDaemon()` when the setting is on — the same full-cleanup path dev-parent shutdowns already use — instead of `disconnectDaemon()`. No new daemon protocol messages, so mixed client/daemon versions are unaffected.
- A toggle in Settings → Terminal → Manage Sessions, indexed for settings search (quit, terminate, background, persist, restore).

## Why

The daemon deliberately outliving quit is the right default for warm reattach, but some users need the opposite guarantee: when the app closes, everything stops. Without it, `claude`/agent sessions keep running invisibly after quit (#7783), and closed sessions reappear on relaunch. Reusing `shutdownDaemon()` keeps the change minimal and rides a teardown path that already runs daily in dev.

## Linked Issue

Fixes #7783
Related: #7806, #9195

## Visual Proof

Before — Manage Sessions ends after the sessions table:

![before](https://raw.githubusercontent.com/kayd-1337/orca/pr-assets-terminate-on-quit/before-manage-sessions.png)

After — new toggle, off by default:

![after-off](https://raw.githubusercontent.com/kayd-1337/orca/pr-assets-terminate-on-quit/after-manage-sessions-off.png)

After — toggled on:

![after-on](https://raw.githubusercontent.com/kayd-1337/orca/pr-assets-terminate-on-quit/after-manage-sessions-on.png)

## Testing

- `pnpm typecheck` — clean.
- `pnpm exec vitest run src/renderer/src/components/settings/` (151 files / 1,024 tests) and `src/shared/` (456 files / 4,700 tests) — all pass.
- Added `ManageSessionsSection.test.tsx`: asserts the toggle defaults off and round-trips `updateSettings({ terminateSessionsOnQuit })` in both directions.
- Localization: `verify:localization-catalog` and `verify:localization-extraction` — clean (2 new keys synced to en.json).
- Manually verified on macOS via `pnpm dev`: toggle renders in Settings → Terminal → Manage Sessions, flips state, and is found by settings search. The main-process branch itself reuses `shutdownDaemon()`, which dev-parent shutdowns exercise on every dev quit; I did not run a packaged production build.
- Platforms tested: macOS. The change has no platform-specific code paths (settings field + teardown selection + renderer toggle).

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Implemented with Claude Code (Claude Fable 5), directed and reviewed by the human author. All checks above were run locally, not assumed.

## Review

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

- No wire/protocol changes; old daemons and new clients (and vice versa) behave as before unless the user opts in.
- SSH/remote sessions are untouched — the setting only selects between the two existing local-daemon teardown functions at quit.
- Setting is optional in the schema, so persisted profiles from older versions load unchanged.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (typecheck, targeted tests, localization + max-lines gates run locally; CI to cover the full matrix and build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
