### PR TITLE
fix(sidebar): keep agent rows ordered by their session start once state history wraps

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-agent-row-fallback-tab.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-row-fallback-tab.ts
@@ -1,9 +1,10 @@
+import { agentEntrySessionStartedAt } from '../../../../shared/agent-session-start-time'
 import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
 import { parsePaneKey } from '../../../../shared/stable-pane-id'
 import type { TerminalTab } from '../../../../shared/terminal-tab-types'
 
 export function effectiveWorktreeAgentRowStartedAt(entry: AgentStatusEntry): number {
-  return entry.stateHistory[0]?.startedAt ?? entry.stateStartedAt
+  return agentEntrySessionStartedAt(entry)
 }
 
 export function tabFromWorktreeAttributedStatusEntry(

--- a/src/renderer/src/components/sidebar/worktree-agent-row-order.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-row-order.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AGENT_STATE_HISTORY_MAX,
+  type AgentStateHistoryEntry,
+  type AgentStatusEntry
+} from '../../../../shared/agent-status-types'
+import type { TerminalTab } from '../../../../shared/terminal-tab-types'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
+import { buildWorktreeAgentRows } from './worktree-agent-rows'
+
+const BUSY_LEAF_ID = '11111111-1111-4111-8111-111111111111'
+const QUIET_LEAF_ID = '22222222-2222-4222-8222-222222222222'
+const BUSY_PANE_KEY = makePaneKey('tab-busy', BUSY_LEAF_ID)
+const QUIET_PANE_KEY = makePaneKey('tab-quiet', QUIET_LEAF_ID)
+
+const NOW = 900_000
+
+function makeTab(id: string, sortOrder: number): TerminalTab {
+  return {
+    id,
+    worktreeId: 'wt-1',
+    ptyId: null,
+    title: 'Claude',
+    customTitle: null,
+    color: null,
+    sortOrder,
+    createdAt: 0
+  }
+}
+
+/** A history window that has already wrapped: the session's real first states were trimmed away. */
+function wrappedHistory(oldestRetainedAt: number): AgentStateHistoryEntry[] {
+  return Array.from({ length: AGENT_STATE_HISTORY_MAX }, (_, index) => ({
+    state: index % 2 === 0 ? ('working' as const) : ('done' as const),
+    prompt: `turn ${index}`,
+    startedAt: oldestRetainedAt + index * 1000
+  }))
+}
+
+function makeEntry(paneKey: string, overrides: Partial<AgentStatusEntry>): AgentStatusEntry {
+  return {
+    paneKey,
+    state: 'working',
+    prompt: 'keep going',
+    agentType: 'claude',
+    stateStartedAt: NOW - 1000,
+    updatedAt: NOW - 1000,
+    stateHistory: [],
+    ...overrides
+  }
+}
+
+describe('worktree agent row order across new activity', () => {
+  // Why: the busy agent started FIRST, so it must stay first. Its stateHistory has wrapped the
+  // AGENT_STATE_HISTORY_MAX cap, so stateHistory[0] no longer marks the session start — reading
+  // it directly would rank the row by its most recent turns and jump it past the quiet agent.
+  it('keeps the older session ahead once its history window has wrapped', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-busy', 0), makeTab('tab-quiet', 1)],
+      entries: [
+        makeEntry(BUSY_PANE_KEY, {
+          firstStateStartedAt: 1000,
+          stateHistory: wrappedHistory(500_000)
+        }),
+        makeEntry(QUIET_PANE_KEY, { firstStateStartedAt: 2000, stateStartedAt: 2000 })
+      ],
+      retained: [],
+      now: NOW
+    })
+
+    expect(rows.map((row) => row.paneKey)).toEqual([BUSY_PANE_KEY, QUIET_PANE_KEY])
+    expect(rows[0].startedAt).toBe(1000)
+  })
+
+  it('does not re-sort the busy row when its next turn slides the history window', () => {
+    const buildRows = (oldestRetainedAt: number): string[] =>
+      buildWorktreeAgentRows({
+        tabs: [makeTab('tab-busy', 0), makeTab('tab-quiet', 1)],
+        entries: [
+          makeEntry(BUSY_PANE_KEY, {
+            firstStateStartedAt: 1000,
+            stateHistory: wrappedHistory(oldestRetainedAt)
+          }),
+          makeEntry(QUIET_PANE_KEY, { firstStateStartedAt: 2000, stateStartedAt: 2000 })
+        ],
+        retained: [],
+        now: NOW
+      }).map((row) => row.paneKey)
+
+    const before = buildRows(500_000)
+    // One more turn: the oldest retained history row is dropped, so stateHistory[0] advances.
+    const after = buildRows(502_000)
+
+    expect(after).toEqual(before)
+    expect(after).toEqual([BUSY_PANE_KEY, QUIET_PANE_KEY])
+  })
+
+  // Why: entries rehydrated from disk (or synthesized by main) carry no latched origin; they must
+  // still order by their oldest known state rather than collapsing to the current status clock.
+  it('falls back to the oldest retained history row when no origin was latched', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-busy', 0), makeTab('tab-quiet', 1)],
+      entries: [
+        makeEntry(BUSY_PANE_KEY, { stateHistory: wrappedHistory(1000) }),
+        makeEntry(QUIET_PANE_KEY, { stateStartedAt: 2000 })
+      ],
+      retained: [],
+      now: NOW
+    })
+
+    expect(rows.map((row) => row.paneKey)).toEqual([BUSY_PANE_KEY, QUIET_PANE_KEY])
+    expect(rows[0].startedAt).toBe(1000)
+  })
+})

--- a/src/renderer/src/store/slices/agent-status-session-start-latch.test.ts
+++ b/src/renderer/src/store/slices/agent-status-session-start-latch.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import { AGENT_STATE_HISTORY_MAX } from '../../../../shared/agent-status-types'
+import { agentEntrySessionStartedAt } from '../../../../shared/agent-session-start-time'
+import { createTestStore } from './store-test-helpers'
+
+const PANE_KEY = 'tab-1:leaf-1'
+const SESSION_START = 10_000
+
+function runTurns(store: ReturnType<typeof createTestStore>, turns: number): void {
+  for (let turn = 0; turn < turns; turn++) {
+    const at = SESSION_START + (turn + 1) * 1000
+    store
+      .getState()
+      .setAgentStatus(
+        PANE_KEY,
+        { state: 'working', prompt: `turn ${turn}`, agentType: 'claude' },
+        'Claude',
+        { updatedAt: at, stateStartedAt: at }
+      )
+    store
+      .getState()
+      .setAgentStatus(
+        PANE_KEY,
+        { state: 'done', prompt: `turn ${turn}`, agentType: 'claude' },
+        'Claude',
+        { updatedAt: at + 500, stateStartedAt: at + 500 }
+      )
+  }
+}
+
+describe('agent status session-start latch', () => {
+  it('latches the first reported state as the session start', () => {
+    const store = createTestStore()
+    store
+      .getState()
+      .setAgentStatus(
+        PANE_KEY,
+        { state: 'working', prompt: 'first prompt', agentType: 'claude' },
+        'Claude',
+        { updatedAt: SESSION_START, stateStartedAt: SESSION_START }
+      )
+
+    expect(store.getState().agentStatusByPaneKey[PANE_KEY]?.firstStateStartedAt).toBe(SESSION_START)
+  })
+
+  // Why: stateHistory is a rolling window that trims oldest-first, so past the cap its first row
+  // is a recent turn. Without a latched origin the sidebar's row clock would follow activity.
+  it('holds the session start once stateHistory has wrapped its cap', () => {
+    const store = createTestStore()
+    store
+      .getState()
+      .setAgentStatus(
+        PANE_KEY,
+        { state: 'working', prompt: 'first prompt', agentType: 'claude' },
+        'Claude',
+        { updatedAt: SESSION_START, stateStartedAt: SESSION_START }
+      )
+    // Two transitions per turn, so this comfortably overruns AGENT_STATE_HISTORY_MAX.
+    runTurns(store, AGENT_STATE_HISTORY_MAX)
+
+    const entry = store.getState().agentStatusByPaneKey[PANE_KEY]
+    expect(entry).toBeDefined()
+    expect(entry!.stateHistory).toHaveLength(AGENT_STATE_HISTORY_MAX)
+    // The window really did slide: the oldest retained row is no longer the session start.
+    expect(entry!.stateHistory[0]!.startedAt).toBeGreaterThan(SESSION_START)
+    expect(entry!.firstStateStartedAt).toBe(SESSION_START)
+    expect(agentEntrySessionStartedAt(entry!)).toBe(SESSION_START)
+  })
+
+  it('starts a fresh session clock after the pane status is dropped', () => {
+    const store = createTestStore()
+    store
+      .getState()
+      .setAgentStatus(
+        PANE_KEY,
+        { state: 'working', prompt: 'first prompt', agentType: 'claude' },
+        'Claude',
+        { updatedAt: SESSION_START, stateStartedAt: SESSION_START }
+      )
+    store.getState().dropAgentStatus(PANE_KEY)
+    store
+      .getState()
+      .setAgentStatus(
+        PANE_KEY,
+        { state: 'working', prompt: 'new session', agentType: 'claude' },
+        'Claude',
+        { updatedAt: 900_000, stateStartedAt: 900_000 }
+      )
+
+    expect(store.getState().agentStatusByPaneKey[PANE_KEY]?.firstStateStartedAt).toBe(900_000)
+  })
+})

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -27,6 +27,7 @@ import {
 } from '../../../../shared/agent-status-identity'
 import { isCommandCodeNewTurnWhileWorking } from '../../../../shared/command-code-turn-boundary'
 import { agentEntryCompletionAt } from '../../../../shared/agent-completion-time'
+import { agentEntrySessionStartedAt } from '../../../../shared/agent-session-start-time'
 import type { TerminalPaneLayoutNode, TerminalTab } from '../../../../shared/terminal-tab-types'
 import {
   getRepoExecutionHostId,
@@ -550,7 +551,7 @@ function retainedAgentEntryFromLive(
     worktreeId,
     tab,
     agentType,
-    startedAt: entry.stateHistory[0]?.startedAt ?? entry.stateStartedAt
+    startedAt: agentEntrySessionStartedAt(entry)
   }
 }
 
@@ -2133,6 +2134,14 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
           tabId: statusTabId,
           terminalTitle: effectiveTitle,
           stateHistory: history,
+          // Why: `history` trims oldest-first at the cap, so latch the session's first state
+          // once — otherwise the sidebar's row clock advances with every turn past the cap and
+          // busy agents re-sort themselves. Falls back for entries that predate the field.
+          firstStateStartedAt:
+            existing?.firstStateStartedAt ??
+            existing?.stateHistory[0]?.startedAt ??
+            existing?.stateStartedAt ??
+            stateStartedAt,
           toolName: payload.toolName,
           toolInput: payload.toolInput,
           // Why: full untruncated AskUserQuestion JSON so mobile/web can render the live prompt

--- a/src/shared/agent-session-start-time.ts
+++ b/src/shared/agent-session-start-time.ts
@@ -1,0 +1,30 @@
+import type { AgentStatusEntry } from './agent-status-types'
+
+/** The subset of a hook entry a session start is derived from. */
+export type AgentSessionStartSource = Pick<
+  AgentStatusEntry,
+  'firstStateStartedAt' | 'stateStartedAt' | 'stateHistory'
+>
+
+function finiteOrNull(value: number | undefined): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+/**
+ * When this pane's agent session first reported a state — the stable identity clock the
+ * sidebar orders agent rows by.
+ *
+ * Why not `stateHistory[0].startedAt` alone: `stateHistory` is a rolling window capped at
+ * `AGENT_STATE_HISTORY_MAX` that trims oldest-first, so once a session passes the cap its
+ * first *retained* row advances on every transition. Reading it directly turns a stable
+ * identity clock into an activity clock, and the row re-sorts on each new turn.
+ * `firstStateStartedAt` is latched at session start and never moves; history remains the
+ * fallback for entries that predate it (rehydrated from disk, derived rows).
+ */
+export function agentEntrySessionStartedAt(entry: AgentSessionStartSource): number {
+  return (
+    finiteOrNull(entry.firstStateStartedAt) ??
+    finiteOrNull(entry.stateHistory[0]?.startedAt) ??
+    entry.stateStartedAt
+  )
+}

--- a/src/shared/agent-status-types.ts
+++ b/src/shared/agent-status-types.ts
@@ -117,6 +117,11 @@ export type AgentStatusEntry = {
   terminalTitle?: string
   /** Rolling log of previous states, capped at AGENT_STATE_HISTORY_MAX. */
   stateHistory: AgentStateHistoryEntry[]
+  /** Timestamp (ms) of this session's FIRST reported state, latched once and never moved.
+   *  Why: `stateHistory` trims oldest-first at the cap, so `stateHistory[0]` stops being the
+   *  session origin after ~20 transitions; row order keyed off it would follow activity.
+   *  Read it via `agentEntrySessionStartedAt`, which still falls back to history. */
+  firstStateStartedAt?: number
   /** Name of the tool the agent is currently using (e.g. "Edit", "Bash"). */
   toolName?: string
   /** Short preview of the tool input (e.g. file path, command). */


### PR DESCRIPTION
## ELI5

Each agent row in the sidebar is ordered by "when this agent session started". That start time was read off the agent's state-transition log — but that log is a rolling window that only keeps the last 20 entries. Once a busy agent runs past 20 transitions, the oldest entries are dropped, so "when it started" quietly becomes "roughly when it did its recent work" — and it moves in the list every time it does something. This pins the real start time so a busy agent stops re-sorting itself.

## What Changed

- `AgentStatusEntry` gains an optional `firstStateStartedAt`: the timestamp of the session's **first** reported state, latched once when the entry is created and never moved afterwards.
- New `src/shared/agent-session-start-time.ts` exports `agentEntrySessionStartedAt(entry)` — one definition of the row's identity clock: the latched origin, falling back to `stateHistory[0].startedAt` and then `stateStartedAt` for entries that predate the field (rehydrated from disk, or synthesized by main with an empty history).
- The two readers of that clock now go through it:
  - `effectiveWorktreeAgentRowStartedAt` (sidebar agent-row sort key, `worktree-agent-row-order.ts` primary term)
  - `retainedAgentEntryFromLive` in the agent-status slice (retained-row `startedAt`, also the first term of `shouldReplaceRetainedWithLive`)

## Why

`compareWorktreeAgentRows` (`worktree-agent-row-order.ts:17`) sorts sidebar agent rows by `startedAt` **first**, and only then by the user's tab order (`tab.sortOrder`, `tab.createdAt`). `startedAt` was resolved as:

```ts
entry.stateHistory[0]?.startedAt ?? entry.stateStartedAt
```

`stateHistory` is documented as a *"rolling log of previous states, capped at AGENT_STATE_HISTORY_MAX"* (20), and the trim in `agent-status.ts` drops the **oldest** rows:

```ts
if (history.length > AGENT_STATE_HISTORY_MAX) {
  history = history.slice(history.length - AGENT_STATE_HISTORY_MAX)
}
```

A turn pushes two transitions (`working` → `done`), so after roughly ten turns the window wraps. From that point `stateHistory[0].startedAt` advances on **every** subsequent transition: the sort key that was supposed to be a stable session identity becomes an activity timestamp, and the row slides past agents that have not yet hit the cap. Because `startedAt` is the primary term, that movement overrides the tab order the user arranged — the row order changes as a side effect of the agent receiving new output. `worktree-agent-row-fallback-tab.ts` already stated the intended contract in a comment — *"missing-tab rows must keep their original clock through real state transitions; current stateStartedAt is a status timestamp, not tab order"* — the history trim silently broke it.

Latching the origin is the standard fix for this shape (a stable list key must not be derived from a bounded, evicting buffer): the ordering key is stored once at session start, the eviction policy of the activity log is free to change, and nothing has to re-derive status per row per render — the field is read straight off the entry, so this does **not** add work to the hot path flagged by STA-3354.

**Why not just keep the oldest history row instead:** `stateHistory` is consumed by the activity feed, unread counts and hibernation guards, which all read it as *recent* transitions. Pinning an ancient orphan row in it would render a stale activity block. The origin belongs next to the entry, not inside the rolling log.

## Linked Issue

Fixes #13847 (STA-3921) — *Agents list: manual order jumps when an agent receives new activity.*

This is the agent-row half of that report: the list re-orders itself on activity, undoing the arrangement the user set. See **Relationship to open PRs** below for the workspace-row half.

## Visual Proof

`N/A` — reproducing this on a running instance requires a single agent to accumulate more than `AGENT_STATE_HISTORY_MAX` (20) real state transitions alongside a second, quieter agent; I could not drive that on an isolated dev instance within this change, so I proved the ordering with tests that fail against pre-fix code instead (below) rather than attach a staged capture that would not show the real mechanism.

## Testing

- [x] Automated tests added/updated
- [ ] I manually tested these changes locally

New tests:

- `src/renderer/src/components/sidebar/worktree-agent-row-order.test.ts` — builds two agent rows through `buildWorktreeAgentRows`, one whose history window has wrapped. Asserts the older session stays first, and that sliding the window one more turn does not change the rendered order. Also covers the legacy fallback (no latched origin).
- `src/renderer/src/store/slices/agent-status-session-start-latch.test.ts` — drives `setAgentStatus` through more than `AGENT_STATE_HISTORY_MAX` transitions and asserts `stateHistory[0].startedAt` really does advance while `firstStateStartedAt` holds; plus a fresh latch after `dropAgentStatus`.

**Proven non-vacuous:** reverting both halves of the fix (the resolver back to `stateHistory[0]?.startedAt ?? stateStartedAt`, and removing the latch) fails 5 of the 6 new assertions. The sixth is the legacy-fallback guard, which is expected to pass either way.

Scoped checks run in this worktree:

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/agent-status src/renderer/src/components/sidebar/useWorktreeAgentRows.test.ts src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts src/renderer/src/components/sidebar/smart-sort.test.ts src/renderer/src/runtime/paired-reconnect-sidebar-agent-count.test.ts` → 18 files, 250 tests pass
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/dashboard src/renderer/src/components/activity src/renderer/src/lib/agent-hibernation-input-guard` → 70 files, 532 tests pass
- `pnpm exec tsc --noEmit -p config/tsconfig.tc.web.json` → clean
- `oxlint` + `oxfmt` clean on the changed files (verified the lint gate is live by injecting a violation and seeing it reported)

Full typecheck was deliberately not run locally (OOM risk on this machine); CI covers it.

## Relationship to open PRs

I reviewed the two open PRs in this area before writing anything. **This PR supersedes neither** — it fixes a different mechanism and touches no file either of them touches.

- **#14284** (`fix(sidebar): keep manual worktree order stable across agent activity`, also linked to #13847) targets the **workspace-row** list: it stops `buildSparseManualOrderUpdates` leaving unmoved rows on the `manualOrder ?? sortOrder` fallback. Worth flagging for its reviewer, not for me to change: `sortOrder` is only re-persisted while `sortBy === 'smart'` (`use-sidebar-worktree-sort-order.ts:198-204`), so in Manual mode agent activity cannot move a row through that fallback on its own — the fallback only bites after a round trip through Smart mode, or for rows that were filtered out at drag time (which that PR does not backfill either, since it ranks over the *visible* group). It is a real hardening of the mixed-scale comparator; whether it fixes the reported symptom depends on which sort mode the reporter was in, which is still unanswered on the issue. Independently of this PR, **#14284 currently conflicts with `main` in `WorktreeList.tsx`** (`git merge-tree origin/main <14284 head>` → 1 conflict) and needs a rebase.
- **#14126** (`fix(sidebar): stop sibling session rows indenting when a lineage expands`, #14084) is a pure layout change in `WorktreeCardAgents.tsx`. Unrelated file set; no overlap with this PR.

**Merge check against the in-flight reorg:** `git merge-tree --write-tree HEAD b91ad74` (#14486, the 119-file `worktree-list` reorganisation) → **exit 0, no conflicts**. Same for #14126 and #13776. Run locally rather than read off GitHub's `mergeable` flag, which was reported stale for #14486.

## AI Disclosure

Developed with Claude (Anthropic). Root cause, mechanism and tests reviewed by the author.

## Review

- **Cross-platform:** renderer/shared only; no paths, shell commands, shortcuts, or Electron platform branches.
- **Backwards compatibility:** `firstStateStartedAt` is optional and additive. Entries that lack it — persisted `last-status.json` rehydrations, rows synthesized in `orca-runtime.ts` with an empty history, title-derived and subagent child rows — resolve exactly as they do today through the unchanged fallback chain.
- **Remote wire:** no wire change. The field is latched renderer-side where the trim happens; the mobile agent-status projection (`sync-runtime-graph.ts`) is a change-detection hash and is intentionally left alone, so old and new hosts exchange the same payload. An older host simply sends no origin and the fallback applies.
- **SSH / folder workspaces:** the ordering path is identical for both; nothing here reads a git worktree or a host.
- **Performance:** one extra number per live status entry, read directly off the entry. No per-row status-map scan is introduced — relevant given STA-3354.
- **Security:** no auth, transport, IPC contract, or command execution touched.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] Scoped `lint` / `typecheck:web` / in-scope `test` pass locally; CI covers the full suite

## Author

- X / Twitter: @BrennanKB5
