### PR TITLE
fix(macos): stop reporting every app update as severed TCC attribution

### DIFF
--- a/src/main/daemon/daemon-health.ts
+++ b/src/main/daemon/daemon-health.ts
@@ -671,6 +671,11 @@ async function readVerifiedDaemonPid(
   return parsedPid
 }
 
+let cachedDaemonBundleStaleness: {
+  key: string
+  pending: Promise<boolean | null>
+} | null = null
+
 export async function isDaemonStaleForCurrentBundle(
   runtimeDir: string,
   socketPath: string,
@@ -678,19 +683,56 @@ export async function isDaemonStaleForCurrentBundle(
   currentAppVersion: string,
   protocolVersion = PROTOCOL_VERSION
 ): Promise<boolean> {
-  const parsedPid = await readVerifiedDaemonPid(runtimeDir, socketPath, tokenPath, protocolVersion)
-  if (!parsedPid) {
-    return false
+  let cacheKey: string | null = null
+  try {
+    cacheKey = JSON.stringify([
+      runtimeDir,
+      socketPath,
+      tokenPath,
+      currentAppVersion,
+      protocolVersion,
+      readFileSync(getDaemonPidPath(runtimeDir, protocolVersion), 'utf8')
+    ])
+  } catch {
+    // Retry the verified read below so a transient PID-file race does not become sticky.
   }
 
-  if (parsedPid.appVersion !== null) {
-    return parsedPid.appVersion !== currentAppVersion
+  if (cacheKey && cachedDaemonBundleStaleness?.key === cacheKey) {
+    return (await cachedDaemonBundleStaleness.pending) ?? false
   }
 
-  // Why: older packaged daemons do not carry a reliable build-generation
-  // marker. Replacing them once prevents archive-preserved mtimes from
-  // reusing stale native modules across the first metadata-aware upgrade.
-  return true
+  const pending = (async (): Promise<boolean | null> => {
+    const parsedPid = await readVerifiedDaemonPid(
+      runtimeDir,
+      socketPath,
+      tokenPath,
+      protocolVersion
+    )
+    if (!parsedPid) {
+      return null
+    }
+
+    if (parsedPid.appVersion !== null) {
+      return parsedPid.appVersion !== currentAppVersion
+    }
+
+    // Why: older packaged daemons do not carry a reliable build-generation
+    // marker. Replacing them once prevents archive-preserved mtimes from
+    // reusing stale native modules across the first metadata-aware upgrade.
+    return true
+  })()
+  if (cacheKey) {
+    cachedDaemonBundleStaleness = { key: cacheKey, pending }
+  }
+  const stale = await pending
+  if (
+    stale === null &&
+    cachedDaemonBundleStaleness?.key === cacheKey &&
+    cachedDaemonBundleStaleness.pending === pending
+  ) {
+    cachedDaemonBundleStaleness = null
+  }
+  return stale ?? false
 }
 
 // 'severed': macOS can no longer resolve the daemon's TCC responsible process, so

--- a/src/main/daemon/daemon-health.ts
+++ b/src/main/daemon/daemon-health.ts
@@ -707,7 +707,6 @@ function getMacDaemonTccAttributionCacheKey(
   runtimeDir: string,
   socketPath: string,
   tokenPath: string,
-  packagedAppVersion: string | null,
   protocolVersion: number
 ): string | null {
   try {
@@ -717,14 +716,7 @@ function getMacDaemonTccAttributionCacheKey(
       return null
     }
     const spawnerExists = parsedPid.spawnerExecPath ? existsSync(parsedPid.spawnerExecPath) : null
-    return JSON.stringify([
-      socketPath,
-      tokenPath,
-      packagedAppVersion,
-      protocolVersion,
-      pidRecord,
-      spawnerExists
-    ])
+    return JSON.stringify([socketPath, tokenPath, protocolVersion, pidRecord, spawnerExists])
   } catch {
     return null
   }
@@ -732,16 +724,13 @@ function getMacDaemonTccAttributionCacheKey(
 
 /**
  * macOS pins a process's TCC "responsible process" to the binary that forked it,
- * by file reference. The detached daemon outlives that app instance, and once the
- * spawning binary is deleted (every packaged update replaces the bundle) tccd
- * can't resolve the grant subject — `osascript`/System Events from every terminal
- * hosted by that daemon is silently denied (-25211) no matter what the user grants.
+ * by file reference. If that binary path disappears while the daemon survives, tccd
+ * cannot resolve the grant subject for the daemon's terminals (STA-3491).
  */
 export async function getMacDaemonTccAttributionHealth(
   runtimeDir: string,
   socketPath: string,
   tokenPath: string,
-  packagedAppVersion: string | null,
   protocolVersion = PROTOCOL_VERSION
 ): Promise<MacDaemonTccAttributionHealth> {
   if (process.platform !== 'darwin') {
@@ -751,7 +740,6 @@ export async function getMacDaemonTccAttributionHealth(
     runtimeDir,
     socketPath,
     tokenPath,
-    packagedAppVersion,
     protocolVersion
   )
   if (cacheKey && cachedMacDaemonTccAttributionHealth?.key === cacheKey) {
@@ -767,11 +755,6 @@ export async function getMacDaemonTccAttributionHealth(
     )
     if (!parsedPid) {
       return 'unknown'
-    }
-    // Packaged updates can replace the bundle at the same path; missing version
-    // metadata also identifies a daemon from before the current packaged generation.
-    if (packagedAppVersion !== null && parsedPid.appVersion !== packagedAppVersion) {
-      return 'severed'
     }
     if (parsedPid.spawnerExecPath) {
       return existsSync(parsedPid.spawnerExecPath) ? 'intact' : 'severed'

--- a/src/main/daemon/daemon-init.test.ts
+++ b/src/main/daemon/daemon-init.test.ts
@@ -237,7 +237,10 @@ type MockAdapter = {
     socketPath: string
     tokenPath: string
     historyPath?: string
-    respawn?: (reason: 'daemon_died' | 'unhealthy_resolver') => Promise<void>
+    packagedAppVersion?: string | null
+    respawn?: (
+      reason: 'daemon_died' | 'unhealthy_resolver' | 'stale_bundle' | 'severed_tcc_attribution'
+    ) => Promise<void>
     protocolVersion?: number
   }
   getActiveSessionIds: ReturnType<typeof vi.fn>
@@ -570,9 +573,19 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
       setLocalPtyProviderMock.mock.invocationCallOrder[0]
     )
     expect(adoptionLeaseReleases[0]).toHaveBeenCalledOnce()
+    expect(adapterInstances[0].options.packagedAppVersion).toBeNull()
     expect(adapterInstances[0].establishLifecycleLease.mock.invocationCallOrder[0]).toBeLessThan(
       adoptionLeaseReleases[0].mock.invocationCallOrder[0]
     )
+  })
+
+  it('passes the packaged app version to runtime stale-bundle retirement', async () => {
+    const mod = await importFresh()
+    isPackagedMock.mockReturnValue(true)
+
+    await mod.initDaemonPtyProvider()
+
+    expect(adapterInstances[0].options.packagedAppVersion).toBe('1.2.3')
   })
 
   it('uses daemon-owned idle retirement when a fresh launch fails permanent adoption', async () => {
@@ -1984,46 +1997,48 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
 
   // STA-2376 regression: dropping the adapter's last authenticated client is enough to make an idle
   // daemon self-retire, so by the time the launcher runs there is nothing to kill and its own
-  // confirmed-kill gate reports nothing. The attributed reason is what keeps the runtime resolver
-  // replacement on the wire — and keeps it off the failed_health_check bucket it would otherwise land in.
-  it('reports the runtime resolver replacement even after the daemon self-retired', async () => {
-    const mod = await importFresh()
-    await mod.initDaemonPtyProvider()
-    const adapterOptions = adapterInstances[0].options
-    trackDaemonReplacedMock.mockClear()
+  // confirmed-kill gate reports nothing. The attributed reason keeps the replacement on the wire.
+  it.each(['unhealthy_resolver', 'stale_bundle'] as const)(
+    'reports the %s replacement even after the daemon self-retired',
+    async (reason) => {
+      const mod = await importFresh()
+      await mod.initDaemonPtyProvider()
+      const adapterOptions = adapterInstances[0].options
+      trackDaemonReplacedMock.mockClear()
 
-    // The daemon is gone before the launcher looks: nothing answers, nothing left to kill.
-    checkDaemonHealthMock.mockResolvedValue('unreachable')
-    killStaleDaemonMock
-      .mockResolvedValueOnce({ killed: false, liveOwnerSurvived: false })
-      .mockResolvedValueOnce({ killed: false, liveOwnerSurvived: false })
-    forkMock.mockImplementationOnce(() => {
-      throw new Error('stop after replacement decision')
-    })
-    const launcher = spawnerInstances[0].launcher as (
-      socketPath: string,
-      tokenPath: string
-    ) => Promise<{ shutdown(): Promise<void> }>
+      // The daemon is gone before the launcher looks: nothing answers, nothing left to kill.
+      checkDaemonHealthMock.mockResolvedValue('unreachable')
+      killStaleDaemonMock
+        .mockResolvedValueOnce({ killed: false, liveOwnerSurvived: false })
+        .mockResolvedValueOnce({ killed: false, liveOwnerSurvived: false })
+      forkMock.mockImplementationOnce(() => {
+        throw new Error('stop after replacement decision')
+      })
+      const launcher = spawnerInstances[0].launcher as (
+        socketPath: string,
+        tokenPath: string
+      ) => Promise<{ shutdown(): Promise<void> }>
 
-    await adapterOptions.respawn?.('unhealthy_resolver')
-    expect(trackDaemonReplacedMock).not.toHaveBeenCalled()
+      await adapterOptions.respawn?.(reason)
+      expect(trackDaemonReplacedMock).not.toHaveBeenCalled()
 
-    await expect(launcher('/fake/socket', '/fake/token')).rejects.toThrow(
-      'stop after replacement decision'
-    )
-    expect(trackDaemonReplacedMock).toHaveBeenCalledTimes(1)
-    expect(trackDaemonReplacedMock).toHaveBeenCalledWith('unhealthy_resolver', 0)
+      await expect(launcher('/fake/socket', '/fake/token')).rejects.toThrow(
+        'stop after replacement decision'
+      )
+      expect(trackDaemonReplacedMock).toHaveBeenCalledTimes(1)
+      expect(trackDaemonReplacedMock).toHaveBeenCalledWith(reason, 0)
 
-    // One-shot: a later unrelated launch must not inherit the attribution.
-    trackDaemonReplacedMock.mockClear()
-    forkMock.mockImplementationOnce(() => {
-      throw new Error('stop after replacement decision')
-    })
-    await expect(launcher('/fake/socket', '/fake/token')).rejects.toThrow(
-      'stop after replacement decision'
-    )
-    expect(trackDaemonReplacedMock).not.toHaveBeenCalled()
-  })
+      // One-shot: a later unrelated launch must not inherit the attribution.
+      trackDaemonReplacedMock.mockClear()
+      forkMock.mockImplementationOnce(() => {
+        throw new Error('stop after replacement decision')
+      })
+      await expect(launcher('/fake/socket', '/fake/token')).rejects.toThrow(
+        'stop after replacement decision'
+      )
+      expect(trackDaemonReplacedMock).not.toHaveBeenCalled()
+    }
+  )
 
   // STA-2376: the attribution covers the case the confirmed-kill gate cannot see; it must not
   // overwrite a reason this launch proved against the daemon it actually removed. Otherwise a

--- a/src/main/daemon/daemon-init.test.ts
+++ b/src/main/daemon/daemon-init.test.ts
@@ -3464,6 +3464,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     // STA-2376: stale-bundle replacement, emitted exactly once.
     expect(trackDaemonReplacedMock).toHaveBeenCalledTimes(1)
     expect(trackDaemonReplacedMock).toHaveBeenCalledWith('stale_bundle', 0)
+    expect(getMacDaemonTccAttributionHealthMock).not.toHaveBeenCalled()
   })
 
   it('preserves a packaged daemon that predates the current app bundle when it owns live sessions', async () => {

--- a/src/main/daemon/daemon-init.test.ts
+++ b/src/main/daemon/daemon-init.test.ts
@@ -585,7 +585,9 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
 
     await mod.initDaemonPtyProvider()
 
-    expect(adapterInstances[0].options.packagedAppVersion).toBe('1.2.3')
+    expect(adapterInstances[0].options.packagedAppVersion).toBe(
+      process.platform === 'darwin' ? '1.2.3' : null
+    )
   })
 
   it('uses daemon-owned idle retirement when a fresh launch fails permanent adoption', async () => {

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -552,8 +552,7 @@ function createOutOfProcessLauncher(
             const attributionHealth = await getMacDaemonTccAttributionHealth(
               runtimeDir,
               socketPath,
-              tokenPath,
-              app.isPackaged ? app.getVersion() : null
+              tokenPath
             )
             if (attributionHealth === 'severed') {
               // Why: replacing with live sessions would kill them; Settings → Developer
@@ -950,8 +949,7 @@ export async function initDaemonPtyProvider(
       tokenPath: info.tokenPath,
       pidPath: getDaemonPidPath(runtimeDir),
       profileScope: runtimeDir,
-      runtimeDir,
-      packagedAppVersion: app.isPackaged ? app.getVersion() : null
+      runtimeDir
     })
     releaseDaemonAdoptionLease(newSpawner.getHandle())
     await abortedStartupAdapter.disconnectOnly()
@@ -964,7 +962,6 @@ export async function initDaemonPtyProvider(
     pidPath: getDaemonPidPath(runtimeDir),
     profileScope: runtimeDir,
     runtimeDir,
-    packagedAppVersion: app.isPackaged ? app.getVersion() : null,
     historyPath: getHistoryDir(),
     // Why: on daemon death, ensureConnected() detects the dead socket and calls this to fork a replacement before retrying.
     respawn: async (reason: DaemonRespawnReason) => {
@@ -1079,8 +1076,7 @@ export async function getCurrentDaemonMacTccAttributionHealth(): Promise<MacDaem
   return getMacDaemonTccAttributionHealth(
     runtimeDir,
     getDaemonSocketPath(runtimeDir),
-    getDaemonTokenPath(runtimeDir),
-    app.isPackaged ? app.getVersion() : null
+    getDaemonTokenPath(runtimeDir)
   )
 }
 
@@ -1201,7 +1197,6 @@ async function runRestartDaemon(): Promise<RestartDaemonResult> {
     pidPath: getDaemonPidPath(runtimeDir),
     profileScope: runtimeDir,
     runtimeDir,
-    packagedAppVersion: app.isPackaged ? app.getVersion() : null,
     historyPath: getHistoryDir(),
     respawn: async (reason: DaemonRespawnReason) => {
       // Why: attribute rather than emit — the launcher below is the one that completes the
@@ -1421,7 +1416,6 @@ export async function createLegacyDaemonAdapters(
         pidPath: getDaemonPidPath(runtimeDir, protocolVersion),
         profileScope: runtimeDir,
         runtimeDir,
-        packagedAppVersion: app.isPackaged ? app.getVersion() : null,
         protocolVersion,
         historyPath
       })

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -962,6 +962,7 @@ export async function initDaemonPtyProvider(
     pidPath: getDaemonPidPath(runtimeDir),
     profileScope: runtimeDir,
     runtimeDir,
+    packagedAppVersion: app.isPackaged ? app.getVersion() : null,
     historyPath: getHistoryDir(),
     // Why: on daemon death, ensureConnected() detects the dead socket and calls this to fork a replacement before retrying.
     respawn: async (reason: DaemonRespawnReason) => {
@@ -976,7 +977,7 @@ export async function initDaemonPtyProvider(
         if (!restartInFlight) {
           trackDaemonRetired('died_respawn')
         }
-      } else if (reason === 'unhealthy_resolver' || reason === 'severed_tcc_attribution') {
+      } else {
         // Must reach the launcher below without an await in between; see the consume site.
         attributedReplaceReason = reason
       }
@@ -1197,6 +1198,7 @@ async function runRestartDaemon(): Promise<RestartDaemonResult> {
     pidPath: getDaemonPidPath(runtimeDir),
     profileScope: runtimeDir,
     runtimeDir,
+    packagedAppVersion: app.isPackaged ? app.getVersion() : null,
     historyPath: getHistoryDir(),
     respawn: async (reason: DaemonRespawnReason) => {
       // Why: attribute rather than emit — the launcher below is the one that completes the
@@ -1210,7 +1212,7 @@ async function runRestartDaemon(): Promise<RestartDaemonResult> {
         if (!restartInFlight) {
           trackDaemonRetired('died_respawn')
         }
-      } else if (reason === 'unhealthy_resolver' || reason === 'severed_tcc_attribution') {
+      } else {
         // Must reach the launcher below without an await in between; see the consume site.
         attributedReplaceReason = reason
       }

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -962,7 +962,7 @@ export async function initDaemonPtyProvider(
     pidPath: getDaemonPidPath(runtimeDir),
     profileScope: runtimeDir,
     runtimeDir,
-    packagedAppVersion: app.isPackaged ? app.getVersion() : null,
+    packagedAppVersion: process.platform === 'darwin' && app.isPackaged ? app.getVersion() : null,
     historyPath: getHistoryDir(),
     // Why: on daemon death, ensureConnected() detects the dead socket and calls this to fork a replacement before retrying.
     respawn: async (reason: DaemonRespawnReason) => {
@@ -1198,7 +1198,7 @@ async function runRestartDaemon(): Promise<RestartDaemonResult> {
     pidPath: getDaemonPidPath(runtimeDir),
     profileScope: runtimeDir,
     runtimeDir,
-    packagedAppVersion: app.isPackaged ? app.getVersion() : null,
+    packagedAppVersion: process.platform === 'darwin' && app.isPackaged ? app.getVersion() : null,
     historyPath: getHistoryDir(),
     respawn: async (reason: DaemonRespawnReason) => {
       // Why: attribute rather than emit — the launcher below is the one that completes the

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -4115,7 +4115,6 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
         socketPath,
         tokenPath,
         runtimeDir: dir,
-        packagedAppVersion: '1.4.178',
         respawn: respawnFn
       })
       // One live session in this adapter — the zero-session gate must fail closed.
@@ -4128,7 +4127,6 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
         dir,
         socketPath,
         tokenPath,
-        '1.4.178',
         respawnAdapter.protocolVersion
       )
       expect(respawnFn).not.toHaveBeenCalled()
@@ -4143,7 +4141,6 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
         socketPath,
         tokenPath,
         runtimeDir: dir,
-        packagedAppVersion: '1.4.178',
         respawn: respawnFn
       })
       const internals = respawnAdapter as unknown as {
@@ -4182,7 +4179,6 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
         socketPath,
         tokenPath,
         runtimeDir: dir,
-        packagedAppVersion: '1.4.178',
         respawn: respawnFn
       })
       getMacDaemonTccAttributionHealthMock.mockResolvedValueOnce('severed')
@@ -4193,7 +4189,6 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
         dir,
         socketPath,
         tokenPath,
-        '1.4.178',
         respawnAdapter.protocolVersion
       )
       expect(respawnFn).toHaveBeenCalledTimes(1)

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -24,16 +24,19 @@ import { getDaemonSocketPath, serializeDaemonPidFile } from './daemon-spawner'
 import { PtyWriteUnavailableError } from '../providers/pty-write-unavailable-error'
 import { TERMINAL_HISTORY_INLINE_SEED_CODE_UNITS } from './terminal-history-seed-chunks'
 
-const { getMacDaemonSystemResolverHealthMock, getMacDaemonTccAttributionHealthMock } = vi.hoisted(
-  () => ({
-    getMacDaemonSystemResolverHealthMock: vi.fn(
-      async (): Promise<'unknown' | 'unhealthy'> => 'unknown'
-    ),
-    getMacDaemonTccAttributionHealthMock: vi.fn(
-      async (): Promise<'intact' | 'severed' | 'unknown'> => 'unknown'
-    )
-  })
-)
+const {
+  getMacDaemonSystemResolverHealthMock,
+  getMacDaemonTccAttributionHealthMock,
+  isDaemonStaleForCurrentBundleMock
+} = vi.hoisted(() => ({
+  getMacDaemonSystemResolverHealthMock: vi.fn(
+    async (): Promise<'unknown' | 'unhealthy'> => 'unknown'
+  ),
+  getMacDaemonTccAttributionHealthMock: vi.fn(
+    async (): Promise<'intact' | 'severed' | 'unknown'> => 'unknown'
+  ),
+  isDaemonStaleForCurrentBundleMock: vi.fn(async () => false)
+}))
 
 const itOnPosix = process.platform === 'win32' ? it.skip : it
 
@@ -42,7 +45,8 @@ vi.mock('./daemon-health', async (importOriginal) => {
   return {
     ...actual,
     getMacDaemonSystemResolverHealth: getMacDaemonSystemResolverHealthMock,
-    getMacDaemonTccAttributionHealth: getMacDaemonTccAttributionHealthMock
+    getMacDaemonTccAttributionHealth: getMacDaemonTccAttributionHealthMock,
+    isDaemonStaleForCurrentBundle: isDaemonStaleForCurrentBundleMock
   }
 })
 
@@ -147,6 +151,8 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
     getMacDaemonSystemResolverHealthMock.mockResolvedValue('unknown')
     getMacDaemonTccAttributionHealthMock.mockReset()
     getMacDaemonTccAttributionHealthMock.mockResolvedValue('unknown')
+    isDaemonStaleForCurrentBundleMock.mockReset()
+    isDaemonStaleForCurrentBundleMock.mockResolvedValue(false)
   })
 
   it('reports whether its daemon protocol can participate in agent claims', () => {
@@ -4107,6 +4113,96 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       expect(respawnFn).not.toHaveBeenCalled()
 
       respawnAdapter.dispose()
+    })
+
+    it('preserves a stale packaged daemon that still owns live sessions before a new spawn', async () => {
+      const respawnFn = vi.fn()
+      const respawnAdapter = new DaemonPtyAdapter({
+        socketPath,
+        tokenPath,
+        runtimeDir: dir,
+        packagedAppVersion: '1.4.178',
+        respawn: respawnFn
+      })
+      await respawnAdapter.spawn({ cols: 80, rows: 24, isNewSession: true })
+      isDaemonStaleForCurrentBundleMock.mockResolvedValueOnce(true)
+
+      const next = await respawnAdapter.spawn({ cols: 80, rows: 24, isNewSession: true })
+
+      expect(isDaemonStaleForCurrentBundleMock).toHaveBeenCalledWith(
+        dir,
+        socketPath,
+        tokenPath,
+        '1.4.178',
+        respawnAdapter.protocolVersion
+      )
+      expect(respawnFn).not.toHaveBeenCalled()
+      expect(next.id).toBeDefined()
+
+      respawnAdapter.dispose()
+    })
+
+    it('preserves a stale packaged daemon when its live session inventory is unavailable', async () => {
+      const respawnFn = vi.fn()
+      const respawnAdapter = new DaemonPtyAdapter({
+        socketPath,
+        tokenPath,
+        runtimeDir: dir,
+        packagedAppVersion: '1.4.178',
+        respawn: respawnFn
+      })
+      const internals = respawnAdapter as unknown as {
+        client: { request: (type: string, payload?: unknown) => Promise<unknown> }
+      }
+      const originalRequest = internals.client.request.bind(internals.client)
+      vi.spyOn(internals.client, 'request').mockImplementation((type, payload) => {
+        if (type === 'listSessions') {
+          return Promise.reject(new Error('inventory unavailable'))
+        }
+        return originalRequest(type, payload)
+      })
+      isDaemonStaleForCurrentBundleMock.mockResolvedValueOnce(true)
+
+      const next = await respawnAdapter.spawn({ cols: 80, rows: 24, isNewSession: true })
+
+      expect(respawnFn).not.toHaveBeenCalled()
+      expect(next.id).toBeDefined()
+
+      respawnAdapter.dispose()
+    })
+
+    it('coalesces stale-bundle retirement before concurrent fresh sessions', async () => {
+      let respawnServer: DaemonServer | undefined
+      const respawnFn = vi.fn(async () => {
+        await server.shutdown()
+        rmSync(socketPath, { force: true })
+        respawnServer = new DaemonServer({
+          socketPath,
+          tokenPath,
+          spawnSubprocess: () => createMockSubprocess()
+        })
+        await respawnServer.start()
+      })
+      const respawnAdapter = new DaemonPtyAdapter({
+        socketPath,
+        tokenPath,
+        runtimeDir: dir,
+        packagedAppVersion: '1.4.178',
+        respawn: respawnFn
+      })
+      isDaemonStaleForCurrentBundleMock.mockResolvedValue(true)
+
+      const replacements = await Promise.all([
+        respawnAdapter.spawn({ cols: 80, rows: 24, isNewSession: true }),
+        respawnAdapter.spawn({ cols: 80, rows: 24, isNewSession: true })
+      ])
+
+      expect(respawnFn).toHaveBeenCalledTimes(1)
+      expect(respawnFn).toHaveBeenCalledWith('stale_bundle')
+      expect(replacements.every((replacement) => replacement.id)).toBe(true)
+
+      respawnAdapter.dispose()
+      await respawnServer?.shutdown()
     })
 
     it('preserves a severed-TCC daemon that still owns live sessions before a new spawn', async () => {

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -7,6 +7,7 @@ import { DAEMON_ENDPOINT_LOST_MESSAGE } from './daemon-endpoint-ownership'
 import {
   getMacDaemonSystemResolverHealth,
   getMacDaemonTccAttributionHealth,
+  isDaemonStaleForCurrentBundle,
   parseDaemonPidFile,
   type ParsedDaemonPid
 } from './daemon-health'
@@ -141,11 +142,17 @@ export type DaemonPtyAdapterOptions = {
   historyPath?: string
   /** Runtime profile directory used to verify daemon TCC attribution. */
   runtimeDir?: string
-  /** Forks a fresh daemon after endpoint death or a confirmed resolver-health replacement. */
+  /** Current packaged version, or null for unpackaged builds. */
+  packagedAppVersion?: string | null
+  /** Forks a fresh daemon after endpoint death or a confirmed health replacement. */
   respawn?: (reason: DaemonRespawnReason) => Promise<void | (() => void)>
 }
 
-export type DaemonRespawnReason = 'daemon_died' | 'unhealthy_resolver' | 'severed_tcc_attribution'
+export type DaemonRespawnReason =
+  | 'daemon_died'
+  | 'unhealthy_resolver'
+  | 'stale_bundle'
+  | 'severed_tcc_attribution'
 
 export type DaemonIdentityChangeEvent = {
   previous: DaemonEndpointIdentity
@@ -234,10 +241,12 @@ export class DaemonPtyAdapter implements IPtyProvider {
   private historyReader: HistoryReader | null
   private respawnFn: DaemonPtyAdapterOptions['respawn'] | null
   private runtimeDir: string | null
+  private packagedAppVersion: string | null
   private pendingRespawnAdoptionRelease: (() => void) | null = null
   private respawnAdoptionClosed = false
   // Why: concurrent spawn() calls hitting a dead daemon would each fork their own; this promise coalesces respawns so only the first forks and the rest await it.
   private respawnPromise: Promise<void> | null = null
+  private staleBundleReplacementPromise: Promise<void> | null = null
   private writeRecoveryPromise: Promise<void> | null = null
   private writeRecoveryAttempted = false
   private dataListeners: ((payload: {
@@ -355,6 +364,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     this.historyReader = opts.historyPath ? new HistoryReader(opts.historyPath) : null
     this.respawnFn = opts.respawn ?? null
     this.runtimeDir = opts.runtimeDir ?? opts.profileScope ?? null
+    this.packagedAppVersion = opts.packagedAppVersion ?? null
     this.supportsCheckpoints = this.protocolVersion >= 4
     this.supportsIncrementalCheckpoints = this.protocolVersion >= 13
     this.supportsProducerFlowControl = this.protocolVersion >= 19
@@ -526,6 +536,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
 
     if (opts.isNewSession) {
       await this.replaceUnhealthyMacResolverDaemonBeforeNewPty()
+      await this.replaceStaleBundleDaemonBeforeNewPty()
       await this.replaceSeveredMacTccDaemonBeforeNewPty()
     }
 
@@ -2658,6 +2669,60 @@ export class DaemonPtyAdapter implements IPtyProvider {
       this.respawnPromise = this.doRespawn(
         '[daemon] macOS system resolver unavailable - respawning daemon',
         'unhealthy_resolver'
+      ).finally(() => {
+        this.respawnPromise = null
+      })
+    }
+    await this.respawnPromise
+  }
+
+  /** Replace a stale packaged daemon only after its live sessions drain. */
+  private async replaceStaleBundleDaemonBeforeNewPty(): Promise<void> {
+    if (!this.respawnFn || !this.runtimeDir || !this.packagedAppVersion) {
+      return
+    }
+    if (!this.staleBundleReplacementPromise) {
+      this.staleBundleReplacementPromise = this.replaceStaleBundleDaemonOnce(
+        this.runtimeDir,
+        this.packagedAppVersion
+      ).finally(() => {
+        this.staleBundleReplacementPromise = null
+      })
+    }
+    await this.staleBundleReplacementPromise
+  }
+
+  private async replaceStaleBundleDaemonOnce(
+    runtimeDir: string,
+    packagedAppVersion: string
+  ): Promise<void> {
+    const stale = await isDaemonStaleForCurrentBundle(
+      runtimeDir,
+      this.socketPath,
+      this.tokenPath,
+      packagedAppVersion,
+      this.protocolVersion
+    )
+    if (!stale) {
+      return
+    }
+
+    const daemonLiveSessionCount = await this.getDaemonLiveSessionCount()
+    const liveSessionCount = Math.max(this.activeSessionIds.size, daemonLiveSessionCount ?? 0)
+    if (daemonLiveSessionCount === null || liveSessionCount > 0) {
+      console.warn(
+        daemonLiveSessionCount === null
+          ? '[daemon] Packaged daemon is stale - preserving it because live session state could not be verified'
+          : `[daemon] Packaged daemon is stale - preserving it because it owns ${liveSessionCount} live session${liveSessionCount === 1 ? '' : 's'}`
+      )
+      return
+    }
+
+    this.fanoutSyntheticExits(-1)
+    if (!this.respawnPromise) {
+      this.respawnPromise = this.doRespawn(
+        '[daemon] Packaged daemon is stale - respawning from the current app bundle',
+        'stale_bundle'
       ).finally(() => {
         this.respawnPromise = null
       })

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -141,8 +141,6 @@ export type DaemonPtyAdapterOptions = {
   historyPath?: string
   /** Runtime profile directory used to verify daemon TCC attribution. */
   runtimeDir?: string
-  /** Current packaged version, or null for unpackaged builds. */
-  packagedAppVersion?: string | null
   /** Forks a fresh daemon after endpoint death or a confirmed resolver-health replacement. */
   respawn?: (reason: DaemonRespawnReason) => Promise<void | (() => void)>
 }
@@ -236,7 +234,6 @@ export class DaemonPtyAdapter implements IPtyProvider {
   private historyReader: HistoryReader | null
   private respawnFn: DaemonPtyAdapterOptions['respawn'] | null
   private runtimeDir: string | null
-  private packagedAppVersion: string | null
   private pendingRespawnAdoptionRelease: (() => void) | null = null
   private respawnAdoptionClosed = false
   // Why: concurrent spawn() calls hitting a dead daemon would each fork their own; this promise coalesces respawns so only the first forks and the rest await it.
@@ -358,7 +355,6 @@ export class DaemonPtyAdapter implements IPtyProvider {
     this.historyReader = opts.historyPath ? new HistoryReader(opts.historyPath) : null
     this.respawnFn = opts.respawn ?? null
     this.runtimeDir = opts.runtimeDir ?? opts.profileScope ?? null
-    this.packagedAppVersion = opts.packagedAppVersion === undefined ? null : opts.packagedAppVersion
     this.supportsCheckpoints = this.protocolVersion >= 4
     this.supportsIncrementalCheckpoints = this.protocolVersion >= 13
     this.supportsProducerFlowControl = this.protocolVersion >= 19
@@ -2680,7 +2676,6 @@ export class DaemonPtyAdapter implements IPtyProvider {
       this.runtimeDir,
       this.socketPath,
       this.tokenPath,
-      this.packagedAppVersion,
       this.protocolVersion
     )
     if (health !== 'severed') {

--- a/src/main/daemon/daemon-tcc-attribution-main-thread.test.ts
+++ b/src/main/daemon/daemon-tcc-attribution-main-thread.test.ts
@@ -43,7 +43,8 @@ vi.mock('node:fs', async (importOriginal) => {
 })
 
 const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')
-const { getMacDaemonTccAttributionHealth } = await import('./daemon-health')
+const { getMacDaemonTccAttributionHealth, isDaemonStaleForCurrentBundle } =
+  await import('./daemon-health')
 
 describe('macOS daemon TCC attribution main-thread cost', () => {
   let dir: string
@@ -89,6 +90,43 @@ describe('macOS daemon TCC attribution main-thread cost', () => {
       })
     )
   }
+
+  it('deduplicates bundle-staleness identity inspection and invalidates by generation', async () => {
+    writePidRecord('1.2.2')
+
+    await expect(
+      Promise.all([
+        isDaemonStaleForCurrentBundle(dir, socketPath, tokenPath, '1.2.3'),
+        isDaemonStaleForCurrentBundle(dir, socketPath, tokenPath, '1.2.3')
+      ])
+    ).resolves.toEqual([true, true])
+    await expect(isDaemonStaleForCurrentBundle(dir, socketPath, tokenPath, '1.2.3')).resolves.toBe(
+      true
+    )
+    expect(execFileMock).toHaveBeenCalledTimes(1)
+
+    writePidRecord('1.2.3')
+    await expect(isDaemonStaleForCurrentBundle(dir, socketPath, tokenPath, '1.2.3')).resolves.toBe(
+      false
+    )
+    expect(execFileMock).toHaveBeenCalledTimes(2)
+    expect(execFileSyncMock).not.toHaveBeenCalled()
+  })
+
+  it('retries an indeterminate bundle-staleness identity inspection', async () => {
+    writePidRecord('1.2.2')
+    psError.value = new Error('ps unavailable')
+    await expect(isDaemonStaleForCurrentBundle(dir, socketPath, tokenPath, '1.2.3')).resolves.toBe(
+      false
+    )
+
+    psError.value = null
+    await expect(isDaemonStaleForCurrentBundle(dir, socketPath, tokenPath, '1.2.3')).resolves.toBe(
+      true
+    )
+    expect(execFileMock).toHaveBeenCalledTimes(2)
+    expect(execFileSyncMock).not.toHaveBeenCalled()
+  })
 
   it('deduplicates identity inspection by daemon generation without a synchronous spawn', async () => {
     writePidRecord('1.2.2')

--- a/src/main/daemon/daemon-tcc-attribution-main-thread.test.ts
+++ b/src/main/daemon/daemon-tcc-attribution-main-thread.test.ts
@@ -77,7 +77,7 @@ describe('macOS daemon TCC attribution main-thread cost', () => {
     }
   })
 
-  function writePidRecord(appVersion?: string): void {
+  function writePidRecord(appVersion?: string, includeSpawner = true): void {
     writeFileSync(
       join(dir, `daemon-v${PROTOCOL_VERSION}.pid`),
       JSON.stringify({
@@ -85,7 +85,7 @@ describe('macOS daemon TCC attribution main-thread cost', () => {
         startedAtMs: PS_STARTED_AT_MS,
         launchNonce: 'launch-a',
         ...(appVersion === undefined ? {} : { appVersion }),
-        spawnerExecPath
+        ...(includeSpawner ? { spawnerExecPath } : {})
       })
     )
   }
@@ -95,13 +95,13 @@ describe('macOS daemon TCC attribution main-thread cost', () => {
 
     await expect(
       Promise.all([
-        getMacDaemonTccAttributionHealth(dir, socketPath, tokenPath, '1.2.3'),
-        getMacDaemonTccAttributionHealth(dir, socketPath, tokenPath, '1.2.3')
+        getMacDaemonTccAttributionHealth(dir, socketPath, tokenPath),
+        getMacDaemonTccAttributionHealth(dir, socketPath, tokenPath)
       ])
-    ).resolves.toEqual(['severed', 'severed'])
-    await expect(
-      getMacDaemonTccAttributionHealth(dir, socketPath, tokenPath, '1.2.3')
-    ).resolves.toBe('severed')
+    ).resolves.toEqual(['intact', 'intact'])
+    await expect(getMacDaemonTccAttributionHealth(dir, socketPath, tokenPath)).resolves.toBe(
+      'intact'
+    )
 
     expect(execFileSyncMock).not.toHaveBeenCalled()
     expect(execFileMock).toHaveBeenCalledTimes(1)
@@ -113,40 +113,40 @@ describe('macOS daemon TCC attribution main-thread cost', () => {
     )
 
     writePidRecord('1.2.3')
-    await expect(
-      getMacDaemonTccAttributionHealth(dir, socketPath, tokenPath, '1.2.3')
-    ).resolves.toBe('intact')
+    await expect(getMacDaemonTccAttributionHealth(dir, socketPath, tokenPath)).resolves.toBe(
+      'intact'
+    )
     expect(execFileMock).toHaveBeenCalledTimes(2)
 
     rmSync(spawnerExecPath)
-    await expect(
-      getMacDaemonTccAttributionHealth(dir, socketPath, tokenPath, '1.2.3')
-    ).resolves.toBe('severed')
+    await expect(getMacDaemonTccAttributionHealth(dir, socketPath, tokenPath)).resolves.toBe(
+      'severed'
+    )
     expect(execFileMock).toHaveBeenCalledTimes(3)
   })
 
   it('retries an indeterminate identity inspection', async () => {
     writePidRecord('1.2.2')
     psError.value = new Error('ps unavailable')
-    await expect(
-      getMacDaemonTccAttributionHealth(dir, socketPath, tokenPath, '1.2.3')
-    ).resolves.toBe('unknown')
+    await expect(getMacDaemonTccAttributionHealth(dir, socketPath, tokenPath)).resolves.toBe(
+      'unknown'
+    )
 
     psError.value = null
-    await expect(
-      getMacDaemonTccAttributionHealth(dir, socketPath, tokenPath, '1.2.3')
-    ).resolves.toBe('severed')
+    await expect(getMacDaemonTccAttributionHealth(dir, socketPath, tokenPath)).resolves.toBe(
+      'intact'
+    )
 
     expect(execFileSyncMock).not.toHaveBeenCalled()
     expect(execFileMock).toHaveBeenCalledTimes(2)
   })
 
-  it('treats a packaged legacy pid record as a previous app generation', async () => {
-    writePidRecord()
+  it('fails open for a legacy pid record without app-version metadata', async () => {
+    writePidRecord(undefined, false)
 
-    await expect(
-      getMacDaemonTccAttributionHealth(dir, socketPath, tokenPath, '1.2.3')
-    ).resolves.toBe('severed')
+    await expect(getMacDaemonTccAttributionHealth(dir, socketPath, tokenPath)).resolves.toBe(
+      'unknown'
+    )
 
     expect(execFileMock).toHaveBeenCalledTimes(1)
     expect(execFileSyncMock).not.toHaveBeenCalled()

--- a/src/main/daemon/daemon-tcc-attribution.test.ts
+++ b/src/main/daemon/daemon-tcc-attribution.test.ts
@@ -100,9 +100,7 @@ describe('macOS daemon TCC attribution health', () => {
     }
     await withDaemonLikeProcess(async (writePidFile) => {
       writePidFile({ spawnerExecPath: join(dir, 'deleted-bundle', 'Orca') })
-      expect(await getMacDaemonTccAttributionHealth(dir, socketPath, tokenPath, '1.2.3')).toBe(
-        'severed'
-      )
+      expect(await getMacDaemonTccAttributionHealth(dir, socketPath, tokenPath)).toBe('severed')
     })
   })
 
@@ -114,13 +112,11 @@ describe('macOS daemon TCC attribution health', () => {
       const spawnerPath = join(dir, 'Orca')
       writeFileSync(spawnerPath, '', 'utf8')
       writePidFile({ spawnerExecPath: spawnerPath, appVersion: '1.2.3' })
-      expect(await getMacDaemonTccAttributionHealth(dir, socketPath, tokenPath, '1.2.3')).toBe(
-        'intact'
-      )
+      expect(await getMacDaemonTccAttributionHealth(dir, socketPath, tokenPath)).toBe('intact')
     })
   })
 
-  it('reports severed after a packaged update reuses the spawning binary path', async () => {
+  it('reports intact after an app-version change when the spawning binary path still exists', async () => {
     if (process.platform !== 'darwin') {
       return
     }
@@ -128,34 +124,21 @@ describe('macOS daemon TCC attribution health', () => {
       const spawnerPath = join(dir, 'Orca')
       writeFileSync(spawnerPath, '', 'utf8')
       writePidFile({ spawnerExecPath: spawnerPath, appVersion: '1.2.2' })
-      expect(await getMacDaemonTccAttributionHealth(dir, socketPath, tokenPath, '1.2.3')).toBe(
-        'severed'
-      )
+      expect(await getMacDaemonTccAttributionHealth(dir, socketPath, tokenPath)).toBe('intact')
     })
   })
 
-  it('flags missing or changed app-version metadata only for packaged builds', async () => {
+  it('fails open without a recorded spawning binary', async () => {
     if (process.platform !== 'darwin') {
       return
     }
     await withDaemonLikeProcess(async (writePidFile) => {
       writePidFile({})
-      expect(await getMacDaemonTccAttributionHealth(dir, socketPath, tokenPath, '1.2.3')).toBe(
-        'severed'
-      )
+      expect(await getMacDaemonTccAttributionHealth(dir, socketPath, tokenPath)).toBe('unknown')
       writePidFile({ appVersion: '1.2.2' })
-      // Updater replaced the bundle since this daemon was forked → attribution is gone.
-      expect(await getMacDaemonTccAttributionHealth(dir, socketPath, tokenPath, '1.2.3')).toBe(
-        'severed'
-      )
+      expect(await getMacDaemonTccAttributionHealth(dir, socketPath, tokenPath)).toBe('unknown')
       writePidFile({ appVersion: '1.2.3' })
-      expect(await getMacDaemonTccAttributionHealth(dir, socketPath, tokenPath, '1.2.3')).toBe(
-        'unknown'
-      )
-      // Dev builds pass null — no version heuristic, fail open.
-      expect(await getMacDaemonTccAttributionHealth(dir, socketPath, tokenPath, null)).toBe(
-        'unknown'
-      )
+      expect(await getMacDaemonTccAttributionHealth(dir, socketPath, tokenPath)).toBe('unknown')
     })
   })
 
@@ -163,17 +146,13 @@ describe('macOS daemon TCC attribution health', () => {
     if (process.platform !== 'darwin') {
       return
     }
-    expect(await getMacDaemonTccAttributionHealth(dir, socketPath, tokenPath, '1.2.3')).toBe(
-      'unknown'
-    )
+    expect(await getMacDaemonTccAttributionHealth(dir, socketPath, tokenPath)).toBe('unknown')
   })
 
   it('reports unknown off macOS', async () => {
     if (process.platform === 'darwin') {
       return
     }
-    expect(await getMacDaemonTccAttributionHealth(dir, socketPath, tokenPath, '1.2.3')).toBe(
-      'unknown'
-    )
+    expect(await getMacDaemonTccAttributionHealth(dir, socketPath, tokenPath)).toBe('unknown')
   })
 })


### PR DESCRIPTION
## ELI5

After every app update, Orca told you your macOS permissions had stopped reaching your terminals — and offered to fix it by killing every terminal you had open. That warning was wrong. Nothing was broken. This removes the bad check.

## What Changed

Removed the app-version comparison from `getMacDaemonTccAttributionHealth()` in `src/main/daemon/daemon-health.ts`:

```ts
// removed
if (packagedAppVersion !== null && parsedPid.appVersion !== packagedAppVersion) {
  return 'severed'
}
```

Severed attribution is now reported only by the pre-existing spawner-path check from #12848. The now-unused `packagedAppVersion` parameter is dropped from the function, its cache key, `DaemonPtyAdapterOptions`, and all five call sites.

## Why

The removed line returned `'severed'` whenever the running daemon's recorded `appVersion` differed from the installed app version. Every routine update changes that string, so it fired on **every** update.

It has two consumers, and both misfired:

1. `useMacTccAttributionSeveredNotice.ts` — an infinite toast telling the user to restart the daemon, which closes every running Orca terminal.
2. `daemon-init.ts:552-566` — automatic daemon replacement under reason `severed_tcc_attribution` when live sessions hit zero.

**The premise behind it is false.** The doc comment claimed that "once the spawning binary is deleted (every packaged update replaces the bundle) tccd can't resolve the grant subject." Squirrel/ShipIt replaces the bundle *at the same path*, and tccd tracks the responsible binary by file reference plus code identity — it survives unlink, move, and same-path replacement by an identically-signed bundle.

This was measured, not reasoned about, on a machine sitting in exactly the state the check calls broken — two daemons predating a ShipIt swap, both version-mismatched, spawning bundle fully unlinked (`lsof +L` `NLINK=0`, `stat` ENOENT), spawning process dead. Both of #12848's stated severance preconditions genuinely held. From a shell proven by `ps -o ppid=` to descend from daemon pid 4301:

| Grant | Probe (read-only, sends no input) | Result |
|---|---|---|
| Automation / AppleEvents | `tell application "System Events" to count processes` | `82`, exit 0 |
| Accessibility (the exact -25211 symptom) | `get name of first window of process "Finder"` | `Desktop`, exit 0 |
| Screen Recording | `CGPreflightScreenCaptureAccess()` | `true` |

Errors were not being swallowed — a deliberately invalid query returned `-1719`, exit 1. `TCC.db` contains no AppleEvents grant for `osascript`, `sh`, `zsh`, `login`, `Terminal`, or `iTerm`, so `com.stablyai.orca` is the only object that could have authorized those calls. Attribution was intact.

**Nothing is lost operationally.** In `daemon-init.ts` the attribution check sits in the `else` of `identity === 'mismatch' || stalePackagedBundle`, where `stalePackagedBundle` is the *same* `appVersion !== app.getVersion()` comparison. Version-mismatched daemons are already replaced at zero live sessions under reason `'stale_bundle'`, so on the adoption path the removed line was unreachable. All it added was the false warning.

### Known behavioural delta

`DaemonPtyAdapter.replaceSeveredMacTccDaemonBeforeNewPty()` gates only on `'severed'` and has no `stale_bundle` equivalent, so a version-mismatched daemon is no longer proactively replaced before a new PTY on that path. That is a code-freshness concern rather than a TCC one, and it was only ever happening as a side effect of a check that was wrong about permissions. Left out deliberately to keep this narrow — worth re-expressing as an explicit staleness check if that proactive replacement is actually wanted.

## Linked Issue

No issue — this is a regression found in dogfooding, introduced by #13992 (`e1ee1b3ef3`, 2026-08-13) and never released. Related: #12848 (STA-3491), whose `existsSync` check this PR keeps.

For the record, #13992 validated the toast by hand-editing a live daemon's pid record to `1.4.177` "to simulate an update boundary" and confirming the toast appeared. No TCC behaviour was measured at any point, and the version compare exists to make that simulation trigger. #12848's severance mechanism was likewise a deduction — "the same resolution *necessarily* fails once that recorded binary is deleted" — asserted, never observed, in a PR that states the reporter's environment "is not reproducible here."

## Visual Proof

N/A — the observable change is the *absence* of a toast that should never have appeared. There is no new UI. The before/after is the warning in the screenshot below no longer firing after a routine update; the functional evidence is the probe table above.

Before: after any update, the "macOS permissions may not reach Orca terminals" toast appears with `duration: Infinity` and offers to close all running terminals.
After: it appears only when the spawning binary path is genuinely gone.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

291 tests pass across the five touched suites on macOS:

```
daemon-tcc-attribution.test.ts, daemon-tcc-attribution-main-thread.test.ts,
daemon-health.test.ts                                    44 passed
daemon-init.test.ts, daemon-pty-adapter.test.ts         247 passed
```

New/updated coverage in `daemon-tcc-attribution.test.ts`:

- `reports intact after an app-version change when the spawning binary path still exists` — the regression test for this bug
- `reports severed when the recorded spawning binary no longer exists` — STA-3491 preserved
- `fails open without a recorded spawning binary` / `when no verifiable pid record exists` — legacy pid files still return `unknown`, so no replacement is triggered
- `reports unknown off macOS`

Plus a `daemon-init.test.ts` case proving version-mismatch replacement is billed to `stale_bundle` and not to the TCC reason.

Platforms: macOS only — the function returns `'unknown'` off darwin and is unreachable elsewhere. No SSH, remote-wire, mobile, or Windows/Linux surface is touched.

## Review

- **Security:** none — removes a check, adds no new capability, touches no permission grant.
- **Cross-platform:** macOS-only code path, already gated by `process.platform !== 'darwin'`.
- **Remote SSH / mobile:** untouched.
- **Backwards compatibility:** `packagedAppVersion` was internal to the main process; no wire format, IPC payload, or persisted schema changes. The `pty.management.macTccAttribution` IPC still returns the same `{ health }` shape.
- **Performance:** strictly less work — one fewer comparison and a smaller cache key.

## Follow-up worth filing separately

The user `TCC.db` on the machine used for this investigation carries explicit **deny** records for `com.stablyai.orca` — `kTCCServiceSystemPolicyAppBundles` auth=0, `kTCCServiceFileProviderDomain` auth=0, `kTCCServiceAppleEvents → com.openai.sky.CUAService` auth=0. A denied TCC record suppresses all future prompts and produces exactly "permanently denied regardless of the grants on Orca.app," which is a more parsimonious explanation for the original STA-3491 `-25211` report than responsible-process severance — and one fixed by clearing the record with `tccutil`, not by replacing the daemon. Worth investigating before building more machinery on the severance theory.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @BrennanKB5
