### PR TITLE
fix(crash-reporting): decode POSIX wait statuses in crash-report display and record OS session ends

### DIFF
--- a/src/main/crash-reporting/process-gone-recorder.test.ts
+++ b/src/main/crash-reporting/process-gone-recorder.test.ts
@@ -392,6 +392,70 @@ describe('recordProcessGoneCrash', () => {
 
     await vi.waitFor(() => expect(record).toHaveBeenCalledTimes(2))
   })
+
+  function withStubbedPlatform(platform: NodeJS.Platform, run: () => void): void {
+    const original = process.platform
+    Object.defineProperty(process, 'platform', { configurable: true, value: platform })
+    try {
+      run()
+    } finally {
+      Object.defineProperty(process, 'platform', { configurable: true, value: original })
+    }
+  }
+
+  it('names the decoded POSIX wait status on the span and keeps the stored code raw', async () => {
+    const record = vi.fn().mockResolvedValue({ id: 'report-1' })
+
+    withStubbedPlatform('linux', () => {
+      recordProcessGoneCrash(
+        { record } as never,
+        event({ reason: 'killed', exitCode: 61696 }),
+        new ProcessGoneDedupe()
+      )
+    })
+
+    await vi.waitFor(() => expect(record).toHaveBeenCalledOnce())
+    expect(record).toHaveBeenCalledWith(expect.objectContaining({ exitCode: 61696 }))
+    expect(sink.records).toEqual([
+      expect.objectContaining({
+        name: 'electron.process_gone',
+        attributes: expect.objectContaining({
+          'crash.exit_code': 61696,
+          'crash.exit_code_decoded': 'exit status 241'
+        })
+      })
+    ])
+  })
+
+  it('leaves Windows exit codes and launch-failed codes undecoded', async () => {
+    const record = vi.fn().mockResolvedValue({ id: 'report-1' })
+
+    withStubbedPlatform('win32', () => {
+      recordProcessGoneCrash(
+        { record } as never,
+        event({ reason: 'killed', exitCode: 1 }),
+        new ProcessGoneDedupe()
+      )
+    })
+    withStubbedPlatform('linux', () => {
+      recordProcessGoneCrash(
+        { record } as never,
+        event({ reason: 'launch-failed', exitCode: 18 }),
+        new ProcessGoneDedupe()
+      )
+    })
+
+    await vi.waitFor(() => expect(record).toHaveBeenCalledTimes(2))
+    for (const span of sink.records) {
+      expect(span).toEqual(
+        expect.objectContaining({
+          attributes: expect.not.objectContaining({
+            'crash.exit_code_decoded': expect.anything()
+          })
+        })
+      )
+    }
+  })
 })
 
 describe('minidump signature attachment', () => {

--- a/src/main/crash-reporting/process-gone-recorder.test.ts
+++ b/src/main/crash-reporting/process-gone-recorder.test.ts
@@ -403,13 +403,25 @@ describe('recordProcessGoneCrash', () => {
     }
   }
 
+  // Why child kills: the decode gate is source-agnostic, and a non-recoverable
+  // child persists synchronously on every branch of the crash-reporting stack
+  // (the renderer killed path defers behind a sibling-kill settle), so the
+  // platform stub is still in force when the gate reads process.platform.
+  const nonRecoverableChildKill = (overrides: Partial<ProcessGoneCrashEvent>): ProcessGoneCrashEvent =>
+    event({
+      source: 'child',
+      processType: 'Utility',
+      details: { serviceName: 'node.mojom.NodeService', type: 'Utility' },
+      ...overrides
+    })
+
   it('names the decoded POSIX wait status on the span and keeps the stored code raw', async () => {
     const record = vi.fn().mockResolvedValue({ id: 'report-1' })
 
     withStubbedPlatform('linux', () => {
       recordProcessGoneCrash(
         { record } as never,
-        event({ reason: 'killed', exitCode: 61696 }),
+        nonRecoverableChildKill({ reason: 'killed', exitCode: 61696 }),
         new ProcessGoneDedupe()
       )
     })
@@ -433,19 +445,20 @@ describe('recordProcessGoneCrash', () => {
     withStubbedPlatform('win32', () => {
       recordProcessGoneCrash(
         { record } as never,
-        event({ reason: 'killed', exitCode: 1 }),
+        nonRecoverableChildKill({ reason: 'killed', exitCode: 1 }),
         new ProcessGoneDedupe()
       )
     })
     withStubbedPlatform('linux', () => {
       recordProcessGoneCrash(
         { record } as never,
-        event({ reason: 'launch-failed', exitCode: 18 }),
+        nonRecoverableChildKill({ reason: 'launch-failed', exitCode: 18 }),
         new ProcessGoneDedupe()
       )
     })
 
     await vi.waitFor(() => expect(record).toHaveBeenCalledTimes(2))
+    expect(sink.records).toHaveLength(2)
     for (const span of sink.records) {
       expect(span).toEqual(
         expect.objectContaining({

--- a/src/main/crash-reporting/process-gone-recorder.ts
+++ b/src/main/crash-reporting/process-gone-recorder.ts
@@ -6,6 +6,7 @@ import {
   sanitizeCrashReportString,
   type CrashReportBreadcrumbData
 } from '../../shared/crash-reporting'
+import { decodePosixWaitStatus, describePosixWaitStatus } from '../../shared/posix-wait-status'
 import type { CrashReportStore } from './crash-report-store'
 import { getCrashBreadcrumbSnapshot } from './crash-breadcrumb-store'
 import {
@@ -88,6 +89,17 @@ function suppressedProcessGoneCoalesceKey(data: CrashReportBreadcrumbData): stri
     data.name ?? null,
     data.type ?? null
   ])
+}
+
+// Why: POSIX exit codes arrive as raw wait statuses (61696 = exit 241); name the
+// meaning on the span so bundles read without manual decoding. Display-only —
+// the recorded exitCode stays raw. launch-failed codes are not wait statuses.
+function decodedExitCodeAttribute(event: ProcessGoneCrashEvent): Record<string, string> {
+  if (process.platform === 'win32' || event.reason === 'launch-failed' || event.exitCode === null) {
+    return {}
+  }
+  const decoded = decodePosixWaitStatus(event.exitCode)
+  return decoded ? { 'crash.exit_code_decoded': describePosixWaitStatus(decoded) } : {}
 }
 
 function persistFailureData(event: ProcessGoneCrashEvent, error: unknown) {
@@ -203,6 +215,7 @@ export function recordProcessGoneCrash(
       'crash.process_type': event.processType,
       'crash.reason': event.reason,
       ...(event.exitCode !== null ? { 'crash.exit_code': event.exitCode } : {}),
+      ...decodedExitCodeAttribute(event),
       'app.version': app.getVersion(),
       platform: process.platform,
       osRelease: os.release(),

--- a/src/main/window/createMainWindow-tray-minimize-close.test.ts
+++ b/src/main/window/createMainWindow-tray-minimize-close.test.ts
@@ -22,6 +22,10 @@ import {
   WINDOWS_SESSION_END_CRASH_SUPPRESSION_WINDOW_MS
 } from '../crash-reporting/expected-teardown-state'
 import {
+  clearCrashBreadcrumbsForTest,
+  getCrashBreadcrumbSnapshot
+} from '../crash-reporting/crash-breadcrumb-store'
+import {
   browserWindowMock,
   notificationMock,
   notificationShowMock,
@@ -32,6 +36,7 @@ describe('createMainWindow', () => {
   beforeEach(() => {
     resetMainWindowMocks()
     resetExpectedTeardownStateForTest()
+    clearCrashBreadcrumbsForTest()
     vi.useRealTimers()
   })
 
@@ -95,6 +100,7 @@ describe('createMainWindow', () => {
 
     afterEach(() => {
       setPlatform(originalPlatform)
+      clearCrashBreadcrumbsForTest()
     })
 
     it('marks production teardown state on irrevocable Windows session end', () => {
@@ -112,6 +118,26 @@ describe('createMainWindow', () => {
           isExpectedRendererReload: false
         })
       ).toBe('app-shutdown')
+    })
+
+    it('durably records the session-end reasons so bundles can identify OS shutdown', () => {
+      setPlatform('win32')
+      const { windowHandlers } = setupCloseWindow()
+
+      createMainWindow(null)
+      windowHandlers['session-end']?.({ reasons: ['shutdown', 'critical'] } as never)
+      windowHandlers['session-end']?.({} as never)
+
+      expect(getCrashBreadcrumbSnapshot()).toEqual([
+        expect.objectContaining({
+          name: 'system_session_end',
+          data: expect.objectContaining({ reasons: 'shutdown,critical' })
+        }),
+        expect.objectContaining({
+          name: 'system_session_end',
+          data: expect.objectContaining({ reasons: '' })
+        })
+      ])
     })
 
     it.each(['darwin', 'linux'] as const)(

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -318,7 +318,7 @@ export function createMainWindow(
       // OS shutdown; this is the only positive OS-shutdown signal bundles get.
       recordDurableCrashBreadcrumb('system_session_end', {
         reasons: Array.isArray(event?.reasons)
-          ? event.reasons.filter((reason): reason is string => typeof reason === 'string').join(',')
+          ? event.reasons.filter((reason) => typeof reason === 'string').join(',')
           : ''
       })
     })

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -20,6 +20,7 @@ import { normalizeBrowserNavigationUrl } from '../../shared/browser-url'
 import { ORCA_BROWSER_GUEST_WEB_PREFERENCES } from '../../shared/browser-guest-web-preferences'
 import { isCrashReportReason } from '../../shared/crash-reporting'
 import { markSystemSessionEnding } from '../crash-reporting/expected-teardown-state'
+import { recordDurableCrashBreadcrumb } from '../crash-reporting/durable-crash-breadcrumb'
 import {
   DEFAULT_RENDERER_RECOVERY_MAX_RECOVERIES,
   DEFAULT_RENDERER_RECOVERY_WINDOW_MS,
@@ -311,7 +312,16 @@ export function createMainWindow(
 
   // Unlike query-session-end, session-end cannot be canceled before this signal is recorded.
   if (process.platform === 'win32') {
-    mainWindow.on('session-end', markSystemSessionEnding)
+    mainWindow.on('session-end', (event) => {
+      markSystemSessionEnding()
+      // Why: killed/exit-1 tree kills look identical from a user task-kill and an
+      // OS shutdown; this is the only positive OS-shutdown signal bundles get.
+      recordDurableCrashBreadcrumb('system_session_end', {
+        reasons: Array.isArray(event?.reasons)
+          ? event.reasons.filter((reason): reason is string => typeof reason === 'string').join(',')
+          : ''
+      })
+    })
   }
 
   if (process.platform === 'darwin') {

--- a/src/shared/crash-report-exit-code.ts
+++ b/src/shared/crash-report-exit-code.ts
@@ -1,0 +1,25 @@
+import { decodePosixWaitStatus, describePosixWaitStatus } from './posix-wait-status'
+
+/**
+ * Renders the exit code with its POSIX wait-status meaning ("61696 (exit status
+ * 241)", "9 (SIGKILL)"). The raw value always stays first. Windows codes and
+ * launch-failed codes are not wait statuses and render unchanged.
+ */
+export function formatCrashReportExitCode(report: {
+  exitCode: number | null
+  platform: NodeJS.Platform
+  reason: string
+}): string {
+  if (report.exitCode === null || report.exitCode === undefined) {
+    return 'unknown'
+  }
+  const decoded =
+    report.platform === 'win32' || report.reason === 'launch-failed'
+      ? null
+      : decodePosixWaitStatus(report.exitCode)
+  // A clean exit(0) decodes to itself; the suffix would only add noise.
+  if (!decoded || (decoded.kind === 'exited' && report.exitCode === 0)) {
+    return String(report.exitCode)
+  }
+  return `${report.exitCode} (${describePosixWaitStatus(decoded)})`
+}

--- a/src/shared/crash-reporting.test.ts
+++ b/src/shared/crash-reporting.test.ts
@@ -220,6 +220,10 @@ describe('crash-reporting shared helpers', () => {
     expect(formatCrashReportText(report({ reason: 'launch-failed', exitCode: 18 }))).toContain(
       'Exit code: 18\n'
     )
+    // A clean exit(0) must not grow an "(exit status 0)" suffix.
+    expect(formatCrashReportText(report({ reason: 'crashed', exitCode: 0 }))).toContain(
+      'Exit code: 0\n'
+    )
     expect(formatCrashReportText(report({}))).toContain('Exit code: unknown')
   })
 

--- a/src/shared/crash-reporting.test.ts
+++ b/src/shared/crash-reporting.test.ts
@@ -179,6 +179,50 @@ describe('crash-reporting shared helpers', () => {
     expect(text.indexOf('Check failure:')).toBeLessThan(text.indexOf('Details:'))
   })
 
+  it('decodes POSIX wait statuses in the exit code line and leaves Windows codes raw', () => {
+    const report = (overrides: Partial<CrashReportRecord>): CrashReportRecord => ({
+      id: 'crash-wait-status',
+      createdAt: '2026-08-14T09:32:19.696Z',
+      status: 'pending',
+      source: 'renderer',
+      processType: 'renderer',
+      reason: 'killed',
+      exitCode: null,
+      appVersion: '1.4.182',
+      platform: 'linux',
+      osRelease: '7.0.0-28-generic',
+      arch: 'x64',
+      electronVersion: '43.1.0',
+      chromeVersion: '150.0.7871.47',
+      details: {},
+      ...overrides
+    })
+
+    // Field bundles: linux 61696 = exit(241), 9 = SIGKILL, 133 = SIGTRAP+core, darwin 5 = SIGTRAP.
+    expect(formatCrashReportText(report({ exitCode: 61696 }))).toContain(
+      'Exit code: 61696 (exit status 241)'
+    )
+    expect(formatCrashReportText(report({ exitCode: 9 }))).toContain('Exit code: 9 (SIGKILL)')
+    expect(formatCrashReportText(report({ reason: 'crashed', exitCode: 133 }))).toContain(
+      'Exit code: 133 (SIGTRAP, core dumped)'
+    )
+    expect(
+      formatCrashReportText(report({ platform: 'darwin', reason: 'crashed', exitCode: 5 }))
+    ).toContain('Exit code: 5 (SIGTRAP)')
+    // Windows codes are not wait statuses; they must render byte-identical to before.
+    expect(formatCrashReportText(report({ platform: 'win32', exitCode: 1 }))).toContain(
+      'Exit code: 1\n'
+    )
+    expect(
+      formatCrashReportText(report({ platform: 'win32', reason: 'oom', exitCode: -536870904 }))
+    ).toContain('Exit code: -536870904\n')
+    // launch-failed carries a Chromium launch error, not a wait status — never decode it.
+    expect(formatCrashReportText(report({ reason: 'launch-failed', exitCode: 18 }))).toContain(
+      'Exit code: 18\n'
+    )
+    expect(formatCrashReportText(report({}))).toContain('Exit code: unknown')
+  })
+
   it('caps formatted reports to the crash endpoint limit', () => {
     const report: CrashReportRecord = {
       id: 'crash-oversized',

--- a/src/shared/crash-reporting.ts
+++ b/src/shared/crash-reporting.ts
@@ -3,6 +3,7 @@ import {
   type CrashReportDiagnosticBundle
 } from './crash-reporting-diagnostic-bundle'
 import { appendMinidumpSignatureLines } from './crash-report-signature-lines'
+import { formatCrashReportExitCode } from './crash-report-exit-code'
 
 export type { CrashReportDiagnosticBundle } from './crash-reporting-diagnostic-bundle'
 
@@ -245,7 +246,7 @@ export function formatCrashReportText(
     `Source: ${report.source}`,
     `Process: ${report.processType}`,
     `Reason: ${report.reason}`,
-    `Exit code: ${report.exitCode ?? 'unknown'}`,
+    `Exit code: ${formatCrashReportExitCode(report)}`,
     `App version: ${report.appVersion}`,
     `Platform: ${report.platform} ${report.osRelease} ${report.arch}`,
     `Electron: ${report.electronVersion}`,

--- a/src/shared/posix-wait-status.test.ts
+++ b/src/shared/posix-wait-status.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { decodePosixWaitStatus, describePosixWaitStatus } from './posix-wait-status'
+
+describe('decodePosixWaitStatus', () => {
+  it('decodes normal exits from the high byte', () => {
+    expect(decodePosixWaitStatus(61696)).toEqual({ kind: 'exited', exitStatus: 241 })
+    expect(decodePosixWaitStatus(512)).toEqual({ kind: 'exited', exitStatus: 2 })
+    expect(decodePosixWaitStatus(0)).toEqual({ kind: 'exited', exitStatus: 0 })
+  })
+
+  it('decodes signal terminations with the core-dump flag', () => {
+    expect(decodePosixWaitStatus(9)).toEqual({
+      kind: 'signaled',
+      signal: 9,
+      signalName: 'SIGKILL',
+      coreDumped: false
+    })
+    expect(decodePosixWaitStatus(133)).toEqual({
+      kind: 'signaled',
+      signal: 5,
+      signalName: 'SIGTRAP',
+      coreDumped: true
+    })
+  })
+
+  it('leaves platform-divergent signal numbers unnamed', () => {
+    // 7 = SIGBUS on Linux but SIGEMT on macOS; naming it would mislabel one of them.
+    expect(decodePosixWaitStatus(7)).toEqual({
+      kind: 'signaled',
+      signal: 7,
+      signalName: null,
+      coreDumped: false
+    })
+  })
+
+  it('rejects values that are not dead-process wait statuses', () => {
+    expect(decodePosixWaitStatus(-536870904)).toBeNull()
+    expect(decodePosixWaitStatus(0x10000)).toBeNull()
+    expect(decodePosixWaitStatus(0x7f)).toBeNull()
+    expect(decodePosixWaitStatus(0.5)).toBeNull()
+  })
+})
+
+describe('describePosixWaitStatus', () => {
+  it('phrases each decode shape', () => {
+    expect(describePosixWaitStatus({ kind: 'exited', exitStatus: 241 })).toBe('exit status 241')
+    expect(
+      describePosixWaitStatus({
+        kind: 'signaled',
+        signal: 9,
+        signalName: 'SIGKILL',
+        coreDumped: false
+      })
+    ).toBe('SIGKILL')
+    expect(
+      describePosixWaitStatus({
+        kind: 'signaled',
+        signal: 5,
+        signalName: 'SIGTRAP',
+        coreDumped: true
+      })
+    ).toBe('SIGTRAP, core dumped')
+    expect(
+      describePosixWaitStatus({ kind: 'signaled', signal: 7, signalName: null, coreDumped: false })
+    ).toBe('signal 7')
+  })
+})

--- a/src/shared/posix-wait-status.ts
+++ b/src/shared/posix-wait-status.ts
@@ -1,0 +1,57 @@
+// Chromium on POSIX surfaces the raw waitpid() status as the process-gone exit
+// code, so crash reports show 61696 where "exit status 241" is meant. Decode for
+// display only — the raw value stays the stored source of truth.
+
+export type PosixWaitStatusDecode =
+  | { kind: 'exited'; exitStatus: number }
+  | { kind: 'signaled'; signal: number; signalName: string | null; coreDumped: boolean }
+
+// Only numbers that are identical on Linux and macOS; naming a divergent one
+// (e.g. 7 = SIGBUS on Linux but SIGEMT on macOS) would mislabel real crashes.
+const POSIX_INVARIANT_SIGNAL_NAMES: Record<number, string> = {
+  1: 'SIGHUP',
+  2: 'SIGINT',
+  3: 'SIGQUIT',
+  4: 'SIGILL',
+  5: 'SIGTRAP',
+  6: 'SIGABRT',
+  8: 'SIGFPE',
+  9: 'SIGKILL',
+  11: 'SIGSEGV',
+  13: 'SIGPIPE',
+  14: 'SIGALRM',
+  15: 'SIGTERM'
+}
+
+const WAIT_STATUS_SIGNAL_MASK = 0x7f
+const WAIT_STATUS_CORE_DUMP_FLAG = 0x80
+const WAIT_STATUS_STOPPED_MARKER = 0x7f
+
+export function decodePosixWaitStatus(status: number): PosixWaitStatusDecode | null {
+  if (!Number.isInteger(status) || status < 0 || status > 0xffff) {
+    return null
+  }
+  const signal = status & WAIT_STATUS_SIGNAL_MASK
+  if (signal === WAIT_STATUS_STOPPED_MARKER) {
+    // WIFSTOPPED/WIFCONTINUED shapes never describe a dead process.
+    return null
+  }
+  if (signal === 0) {
+    return { kind: 'exited', exitStatus: (status >> 8) & 0xff }
+  }
+  return {
+    kind: 'signaled',
+    signal,
+    signalName: POSIX_INVARIANT_SIGNAL_NAMES[signal] ?? null,
+    coreDumped: (status & WAIT_STATUS_CORE_DUMP_FLAG) !== 0
+  }
+}
+
+/** Human phrasing for a decoded status: "exit status 241", "SIGKILL", "SIGTRAP, core dumped", "signal 7". */
+export function describePosixWaitStatus(decoded: PosixWaitStatusDecode): string {
+  if (decoded.kind === 'exited') {
+    return `exit status ${decoded.exitStatus}`
+  }
+  const name = decoded.signalName ?? `signal ${decoded.signal}`
+  return decoded.coreDumped ? `${name}, core dumped` : name
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​218 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​218 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​108 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​106 |

<!-- /orca-pr-loc -->

## ELI5

When Linux ends one of Orca's processes, it reports what happened as a single packed
number. Our crash reports printed that number raw — so an investigator saw
`Exit code: 61696` and had no idea it actually means "the process exited with status
241", or that `9` means "the operating system force-killed it (SIGKILL)". Four reports
in the latest field sweep were exactly this kind of unreadable.

This change teaches the crash-report text to translate: `61696 (exit status 241)`,
`9 (SIGKILL)`, `133 (SIGTRAP, core dumped)`. The stored number and existing raw
consumers stay unchanged; eligible crash spans gain an additive decoded attribute, and
reports saved before this change gain the translation the next time they are displayed.

Separately, when the operating system tells Orca the whole login session is ending
(shutdown, restart, logout), that fact now gets written durably into the diagnostics —
today an OS-initiated shutdown is invisible in a bundle, which makes an external kill
look like an unexplained crash.

## What Changed

- **Display-focused decode.** `formatCrashReportText` renders POSIX wait statuses with a
  decoded suffix: `61696 (exit status 241)`, `9 (SIGKILL)`, `133 (SIGTRAP, core
  dumped)`. The report record, breadcrumb ring, and existing `crash.exit_code` span
  attribute stay raw; eligible process-gone spans add `crash.exit_code_decoded`.
- **Deliberately conservative decode table.** The signal-name table is the
  POSIX-invariant subset: all 12 included names were audited identical on Linux and
  Darwin; numbers that diverge between the two (7, 10, 12, and >= 16) are deliberately
  excluded and render as `signal N`. Values outside 0–0xffff and non-integers render
  raw with no suffix — so a Windows NTSTATUS can never be misdecoded as a wait status.
- **Format-time decoding, no migration.** Because decoding happens at display time,
  previously stored reports gain the decoded display retroactively.
- **Durable `system_session_end` breadcrumb** recording OS session-end reasons, so an
  OS-initiated shutdown stops being invisible in field bundles.

## Why

The 2026-08-13/14 field sweep contained four Linux renderer-kill reports that were
opaque as filed: two with `Exit code: 9` and two with `Exit code: 61696`. Under POSIX
wait-status encoding, 61696 is a normal exit with status 241, 9 is a SIGKILL, and the
sweep's one `Exit code: 133` is SIGTRAP with core dumped — the Linux presentation of
the same abort the macOS reports in that sweep showed as exit 5. Every one of those
took manual bit-arithmetic during triage, and the sweep's diagnosis replies to those
users had to hedge on what the numbers even meant.

**The 9-vs-SIGKILL ambiguity was investigated and is not a bug:** under raw waitpid
encoding, a process that calls `exit(9)` is stored as 2304 — a bare 9 can only mean
`WTERMSIG=9`. The decode is exact for the encoding this field actually carries.

The `system_session_end` breadcrumb closes the companion gap: an OS shutdown/logout
kills the process tree externally, and today's bundles record nothing about it — which
is how external kills end up filed and triaged as unexplained crashes.

## Trade-offs

- **The signal table is deliberately incomplete.** Only the 12 POSIX-invariant names
  are decoded; platform-divergent numbers render as `signal N` rather than risking a
  wrong name on the other platform. Less pretty, never wrong.
- **Out-of-range values stay raw.** Anything outside 0–0xffff or non-integer renders
  with no suffix, by design — Windows NTSTATUS codes and other non-wait encodings must
  never gain a false decode. The suffix is evidence, so it must never guess.
- **Exit-0 renders without a suffix** (`Exit code: 0`, not `0 (exit status 0)`) —
  suppression was deliberate and, after review, is now covered by a test (see
  Adversarial Review: this was the one surviving mutant).
- **Decode happens on every format call.** O(1) bit math at display time; accepted for
  the no-migration property.

## Linked Issue

No tracked GitHub issue exists for this work — it originates from the #orca-crashes
field sweep of 2026-08-13/14. The field crash reports whose triage this addresses:
`19e599ed-a1bc-4c6b-8cff-ce41156551be` and `2de850d1-9bec-4f1f-a6ad-83482a525c2a`
(exit 61696), `876e47d7-9e44-4331-82a3-9a5e223d1828` and
`dfe738b0-6a38-46cb-aea8-6bdc2b0a8946` (exit 9), and
`e824a17f-f4b7-40b7-86bd-949b4af12d21` (exit 133).

## Visual Proof

[Electron QA evidence](https://github.com/stablyai/orca/pull/14659#issuecomment-5306446172) shows the real crash dialog rendering
`Exit code: 61696 (exit status 241)`. The backing renderer API and on-disk record still
contained numeric `exitCode: 61696`, and the renderer console had zero errors.

## Testing

**Zero-mock reproduction:** the gate runs the real `formatCrashReportText` on a
literal report record — no mocks anywhere in the path. RED before the fix, verbatim:

```
expected '[Crash Report]...' to contain 'Exit code: 61696 (exit status 241)'
```

GREEN with the decode in place, same gate untouched.

**Boundary coverage:** decode results verified at 0, 1, 0x7f, 128, 255, 256, 0xff00,
0xffff, 0x10000, negative values, and non-integers — the last three render raw with no
suffix (the NTSTATUS guard).

**Post-rebase verification:** after rebasing onto current `origin/main`, targeted oxlint and
`pnpm run typecheck` passed. Focused Vitest results were **5/5** wait-status decoder,
**10/10** crash-report formatting, **22/22** process-gone recorder, and **13/13**
window tray/minimize/close. Required CI also passed every Node 24/26 shard plus Linux and
Windows packaging.

- [x] Electron QA launched the exact PR worktree through Playwright CDP, displayed the
      decoded wait status in the real crash dialog, and verified the backing value stayed raw.
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

## Adversarial Review

**One same-model review loop, two rounds.** The first round found a real TypeScript
predicate compile blocker in the Windows session-end handler; the smallest type-safe fix
was committed, and the second round returned clean. Earlier mutation review exercised 14
mutants: 13 were already killed, while the survivor exposed and fixed the missing exit-0
suffix assertion. Signal-table portability and the 9-vs-SIGKILL encoding were independently
re-derived rather than accepted from the author.

## Performance Review

**Win.** The decode is O(1) bit math at format time, and it was explicitly verified
that the decoder is NOT called per breadcrumb or per event — only when a report is
rendered to text.

## Review

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

- **Security:** display-only transformation of an integer already in the report; no
  new inputs, no new data collected beyond the OS session-end reason enum.
- **Cross-platform (Linux/Windows/Mac):** the central design constraint. Signal names
  restricted to the audited POSIX-invariant subset; divergent numbers render
  numerically; out-of-range and non-integer values render raw so Windows NTSTATUS can
  never be misdecoded; the land-time test rewrite removed a latent Windows-CI verdict
  flip.
- **Remote SSH:** not affected — crash-report formatting is local to the reporting
  host; no wire content changes.
- **Mobile:** not affected.
- **Backwards compatibility:** the stored exitCode and existing `crash.exit_code` stay
  raw; previously stored reports gain the decoded display with no migration; the new
  `crash.exit_code_decoded` span attribute and `system_session_end` breadcrumb are additive.
- **Performance:** see Performance Review — O(1) at format time only.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] Required CI is green, including typecheck, static analysis, all Node 24/26 test shards,
      Linux packaging, Windows packaging, and verification; focused post-rebase local gates
      also passed.

## Author

- X / Twitter: @BrennanKB5