### PR TITLE
feat(terminal): breadcrumb the worktree parking pass verdicts and manager census

### DIFF
--- a/src/main/ipc/crash-reporting-renderer-breadcrumbs.test.ts
+++ b/src/main/ipc/crash-reporting-renderer-breadcrumbs.test.ts
@@ -255,6 +255,21 @@ describe('renderer breadcrumb IPC routing', () => {
     }
   })
 
+  it('coalesces parking passes by name so the store can retain the latest sample', () => {
+    emitRendererBreadcrumb({
+      name: 'terminal_parking_pass',
+      data: { managers: 49, panes: 60, sampledAtMs: 123 }
+    })
+
+    expect(recordCrashBreadcrumbMock).not.toHaveBeenCalled()
+    expect(recordCoalescedCrashBreadcrumbMock).toHaveBeenCalledWith({
+      name: 'terminal_parking_pass',
+      data: { managers: 49, panes: 60, sampledAtMs: 123 },
+      coalesceKey: 'terminal_parking_pass',
+      minIntervalMs: 30_000
+    })
+  })
+
   // Why: `burst` means damping engaged a commit short of React #185 while
   // `window` is slow benign churn. A shared key would drop the near-crash
   // signal into the slow-churn slot.

--- a/src/main/ipc/crash-reporting-renderer-breadcrumbs.ts
+++ b/src/main/ipc/crash-reporting-renderer-breadcrumbs.ts
@@ -48,12 +48,14 @@ function recordRendererBreadcrumbTrace(
 // suppressed count instead.
 const DUPLICATE_TAB_OWNER_BREADCRUMB = 'terminal_tab_id_owned_by_multiple_worktrees'
 const PARK_VERDICT_CHURN_BREADCRUMB = 'terminal_park_verdict_churn'
+const PARKING_PASS_BREADCRUMB = 'terminal_parking_pass'
 const COALESCED_RENDERER_BREADCRUMB_NAMES = new Set([
   'renderer_error',
   'renderer_unhandled_rejection',
   'terminal_safe_fit_retry_exhausted',
   DUPLICATE_TAB_OWNER_BREADCRUMB,
   PARK_VERDICT_CHURN_BREADCRUMB,
+  PARKING_PASS_BREADCRUMB,
   TERMINAL_WEBGL_DIAGNOSTIC_BREADCRUMB
 ])
 const RENDERER_BREADCRUMB_COALESCE_MS = 30_000
@@ -66,7 +68,12 @@ const RENDERER_BREADCRUMB_COALESCE_MS = 30_000
 // mounted pane within ~60ms. Windows crash F0BKR84AHEH lost 26-90% of its
 // 30-entry ring to two such bursts. `suppressedSinceLast` keeps the pane count
 // — the only signal these carry — in one slot.
-const NAME_ONLY_COALESCED_BREADCRUMB_NAMES = new Set(['terminal_safe_fit_retry_exhausted'])
+// Parking passes are one process-wide latest-state stream; per-payload keys
+// would defeat the store's newest-payload folding and retained slot.
+const NAME_ONLY_COALESCED_BREADCRUMB_NAMES = new Set([
+  'terminal_safe_fit_retry_exhausted',
+  PARKING_PASS_BREADCRUMB
+])
 
 function rendererBreadcrumbCoalesceKey(
   name: string,

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -125,7 +125,10 @@ import {
   type TerminalWorktreeRetentionCandidate
 } from './terminal-pane/terminal-hidden-worktree-retention'
 import { recordRendererCrashBreadcrumb } from '@/lib/crash-breadcrumb-recorder'
-import { recordTerminalWorktreeParkingPass } from './terminal-pane/terminal-worktree-parking-telemetry'
+import {
+  queueTerminalWorktreeParkingPass,
+  resetTerminalWorktreeParkingPassTelemetry
+} from './terminal-pane/terminal-worktree-parking-telemetry'
 import { captureForceParkedWorktreeBuffers } from './terminal-pane/force-park-buffer-capture'
 import { warnTerminalLifecycleAnomaly } from './terminal-pane/terminal-lifecycle-diagnostics'
 import {
@@ -908,6 +911,7 @@ function Terminal(): React.JSX.Element | null {
         window.clearTimeout(timer)
       }
       timers.clear()
+      resetTerminalWorktreeParkingPassTelemetry()
     }
   }, [])
 
@@ -1067,12 +1071,12 @@ function Terminal(): React.JSX.Element | null {
       forceParked: forceParkedWorktreeIds.has(candidate.worktreeId)
     }))
     recordTerminalWorktreeParkingDebugVerdicts(parkingPassVerdicts)
-    // Why breadcrumbed: without the per-pass verdicts a field bundle cannot
-    // separate a resetting hiddenSince clock from a decision-time veto — the
-    // exact ambiguity that stalled the mounted-manager investigations.
-    recordTerminalWorktreeParkingPass({
+    // Defer the census until React commits this pass's pane unmounts.
+    queueTerminalWorktreeParkingPass({
       verdicts: parkingPassVerdicts,
       ordinaryParkedCount: nextParkedTerminalWorktreeIds.size,
+      parkingEnabled: terminalParkingEnabled,
+      retentionBudgetEnabled: terminalRetentionBudgetEnabled,
       nowMs
     })
     const capturedForceParked = forceParkedCaptureDoneRef.current

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -125,6 +125,7 @@ import {
   type TerminalWorktreeRetentionCandidate
 } from './terminal-pane/terminal-hidden-worktree-retention'
 import { recordRendererCrashBreadcrumb } from '@/lib/crash-breadcrumb-recorder'
+import { recordTerminalWorktreeParkingPass } from './terminal-pane/terminal-worktree-parking-telemetry'
 import { captureForceParkedWorktreeBuffers } from './terminal-pane/force-park-buffer-capture'
 import { warnTerminalLifecycleAnomaly } from './terminal-pane/terminal-lifecycle-diagnostics'
 import {
@@ -1060,13 +1061,20 @@ function Terminal(): React.JSX.Element | null {
       nowMs,
       ...overrides
     })
-    recordTerminalWorktreeParkingDebugVerdicts(
-      retentionBudgetCandidates.map((candidate) => ({
-        ...candidate,
-        parkCooldownUntilMs: candidate.parkCooldownUntilMs ?? null,
-        forceParked: forceParkedWorktreeIds.has(candidate.worktreeId)
-      }))
-    )
+    const parkingPassVerdicts = retentionBudgetCandidates.map((candidate) => ({
+      ...candidate,
+      parkCooldownUntilMs: candidate.parkCooldownUntilMs ?? null,
+      forceParked: forceParkedWorktreeIds.has(candidate.worktreeId)
+    }))
+    recordTerminalWorktreeParkingDebugVerdicts(parkingPassVerdicts)
+    // Why breadcrumbed: without the per-pass verdicts a field bundle cannot
+    // separate a resetting hiddenSince clock from a decision-time veto — the
+    // exact ambiguity that stalled the mounted-manager investigations.
+    recordTerminalWorktreeParkingPass({
+      verdicts: parkingPassVerdicts,
+      ordinaryParkedCount: nextParkedTerminalWorktreeIds.size,
+      nowMs
+    })
     const capturedForceParked = forceParkedCaptureDoneRef.current
     for (const id of Array.from(capturedForceParked)) {
       if (!forceParkedWorktreeIds.has(id)) {

--- a/src/renderer/src/components/terminal-pane/terminal-worktree-parking-telemetry.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-worktree-parking-telemetry.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { TerminalWorktreeParkingDebugVerdict } from './terminal-parking-e2e-overrides'
+
+const harness = vi.hoisted(() => ({
+  census: { managers: 0, panes: 0 },
+  crumbs: [] as { name: string; data?: Record<string, unknown> }[]
+}))
+
+vi.mock('@/lib/crash-breadcrumb-recorder', () => ({
+  recordRendererCrashBreadcrumb: (name: string, data?: Record<string, unknown>) => {
+    harness.crumbs.push({ name, ...(data ? { data } : {}) })
+  }
+}))
+
+vi.mock('@/lib/pane-manager/pane-manager-registry', () => ({
+  getLivePaneCensus: () => harness.census
+}))
+
+import {
+  recordTerminalWorktreeParkingPass,
+  resetTerminalWorktreeParkingPassTelemetry,
+  summarizeTerminalWorktreeParkingPass
+} from './terminal-worktree-parking-telemetry'
+
+function verdict(
+  overrides: Partial<TerminalWorktreeParkingDebugVerdict> & { worktreeId: string }
+): TerminalWorktreeParkingDebugVerdict {
+  return {
+    forceParked: false,
+    hasActivityTerminalPortal: false,
+    hasPendingSpawnWork: false,
+    hiddenSinceMs: null,
+    isVisible: false,
+    ordinaryParkingCovers: false,
+    parkCooldownUntilMs: null,
+    shouldMeasureHiddenWorktree: false,
+    ...overrides
+  }
+}
+
+describe('worktree parking pass telemetry', () => {
+  beforeEach(() => {
+    resetTerminalWorktreeParkingPassTelemetry()
+    harness.census = { managers: 49, panes: 60 }
+    harness.crumbs.length = 0
+  })
+
+  it('summarizes deadline cohorts and vetoes so clock resets and vetoes separate', () => {
+    const nowMs = 100 * 60_000
+    // Clock-reset shape: hidden but always younger than the 30s park delay.
+    const clockReset = summarizeTerminalWorktreeParkingPass({
+      verdicts: [
+        verdict({ worktreeId: 'a', hiddenSinceMs: nowMs - 10_000 }),
+        verdict({ worktreeId: 'b', hiddenSinceMs: nowMs - 25_000 })
+      ],
+      census: harness.census,
+      ordinaryParkedCount: 0,
+      nowMs
+    })
+    expect(clockReset.hiddenTracked).toBe(2)
+    expect(clockReset.hiddenPastParkDelay).toBe(0)
+    expect(clockReset.oldestHiddenAgeMs).toBe(25_000)
+
+    // Veto shape: long-hidden but blocked at decision time.
+    const vetoed = summarizeTerminalWorktreeParkingPass({
+      verdicts: [
+        verdict({
+          worktreeId: 'a',
+          hiddenSinceMs: nowMs - 20 * 60_000,
+          hasPendingSpawnWork: true
+        }),
+        verdict({
+          worktreeId: 'b',
+          hiddenSinceMs: nowMs - 6 * 60_000,
+          parkCooldownUntilMs: nowMs + 1_000
+        })
+      ],
+      census: harness.census,
+      ordinaryParkedCount: 0,
+      nowMs
+    })
+    expect(vetoed.hiddenPastParkDelay).toBe(2)
+    expect(vetoed.hiddenPastHotRetain).toBe(2)
+    expect(vetoed.hiddenPastRetentionTtl).toBe(1)
+    expect(vetoed.pendingSpawnWork).toBe(1)
+    expect(vetoed.cooldown).toBe(1)
+    expect(vetoed.managers).toBe(49)
+  })
+
+  it('emits once per verdict shift with interval damping, not per pass', () => {
+    const base = [verdict({ worktreeId: 'a', hiddenSinceMs: 0 })]
+    recordTerminalWorktreeParkingPass({ verdicts: base, ordinaryParkedCount: 0, nowMs: 60_000 })
+    expect(harness.crumbs).toHaveLength(1)
+    expect(harness.crumbs[0]?.name).toBe('terminal_parking_pass')
+    expect(harness.crumbs[0]?.data?.hiddenPastParkDelay).toBe(1)
+
+    // Same cohorts, older age: no re-emit (ages are not part of the key).
+    recordTerminalWorktreeParkingPass({ verdicts: base, ordinaryParkedCount: 0, nowMs: 70_000 })
+    expect(harness.crumbs).toHaveLength(1)
+
+    // A genuine shift inside the damping window stays pending.
+    const shifted = [verdict({ worktreeId: 'a', hiddenSinceMs: 0, hasPendingSpawnWork: true })]
+    recordTerminalWorktreeParkingPass({ verdicts: shifted, ordinaryParkedCount: 0, nowMs: 80_000 })
+    expect(harness.crumbs).toHaveLength(1)
+
+    // The pending shift fires once the window opens.
+    recordTerminalWorktreeParkingPass({ verdicts: shifted, ordinaryParkedCount: 0, nowMs: 95_000 })
+    expect(harness.crumbs).toHaveLength(2)
+    expect(harness.crumbs[1]?.data?.pendingSpawnWork).toBe(1)
+  })
+
+  it('records the manager census with every emission', () => {
+    harness.census = { managers: 7, panes: 9 }
+    recordTerminalWorktreeParkingPass({ verdicts: [], ordinaryParkedCount: 0, nowMs: 60_000 })
+    expect(harness.crumbs[0]?.data?.managers).toBe(7)
+    expect(harness.crumbs[0]?.data?.panes).toBe(9)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-worktree-parking-telemetry.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-worktree-parking-telemetry.test.ts
@@ -131,7 +131,7 @@ describe('worktree parking pass telemetry', () => {
     expect(summary.pastParkDelayPendingSpawnWork).toBe(0)
   })
 
-  it('queues every pass for main-process coalescing', () => {
+  it('queues changed passes for main-process coalescing', () => {
     const base = [verdict({ worktreeId: 'a', hiddenSinceMs: 0 })]
     queueTerminalWorktreeParkingPass({
       verdicts: base,
@@ -156,6 +156,42 @@ describe('worktree parking pass telemetry', () => {
     vi.runOnlyPendingTimers()
     expect(harness.crumbs).toHaveLength(2)
     expect(harness.crumbs[1]?.data?.pastParkDelayPendingSpawnWork).toBe(1)
+  })
+
+  it('suppresses unchanged summaries after the coalescing interval', () => {
+    const base = [verdict({ worktreeId: 'a', hiddenSinceMs: 0 })]
+    queueTerminalWorktreeParkingPass({
+      verdicts: base,
+      ordinaryParkedCount: 0,
+      parkingEnabled: true,
+      retentionBudgetEnabled: true,
+      nowMs: 60_000
+    })
+    vi.runOnlyPendingTimers()
+
+    vi.advanceTimersByTime(31_000)
+    queueTerminalWorktreeParkingPass({
+      verdicts: base,
+      ordinaryParkedCount: 0,
+      parkingEnabled: true,
+      retentionBudgetEnabled: true,
+      nowMs: 91_000
+    })
+    vi.runOnlyPendingTimers()
+    expect(harness.crumbs).toHaveLength(1)
+
+    harness.census = { managers: 7, panes: 9 }
+    queueTerminalWorktreeParkingPass({
+      verdicts: base,
+      ordinaryParkedCount: 0,
+      parkingEnabled: true,
+      retentionBudgetEnabled: true,
+      nowMs: 122_000
+    })
+    vi.runOnlyPendingTimers()
+    expect(harness.crumbs).toHaveLength(2)
+    expect(harness.crumbs[1]?.data?.managers).toBe(7)
+    expect(harness.crumbs[1]?.data?.panes).toBe(9)
   })
 
   it('samples the manager census after the queued pass', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-worktree-parking-telemetry.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-worktree-parking-telemetry.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { TerminalWorktreeParkingDebugVerdict } from './terminal-parking-e2e-overrides'
 
 const harness = vi.hoisted(() => ({
@@ -17,7 +17,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', () => ({
 }))
 
 import {
-  recordTerminalWorktreeParkingPass,
+  queueTerminalWorktreeParkingPass,
   resetTerminalWorktreeParkingPassTelemetry,
   summarizeTerminalWorktreeParkingPass
 } from './terminal-worktree-parking-telemetry'
@@ -40,9 +40,15 @@ function verdict(
 
 describe('worktree parking pass telemetry', () => {
   beforeEach(() => {
+    vi.useFakeTimers()
     resetTerminalWorktreeParkingPassTelemetry()
     harness.census = { managers: 49, panes: 60 }
     harness.crumbs.length = 0
+  })
+
+  afterEach(() => {
+    resetTerminalWorktreeParkingPassTelemetry()
+    vi.useRealTimers()
   })
 
   it('summarizes deadline cohorts and vetoes so clock resets and vetoes separate', () => {
@@ -55,6 +61,8 @@ describe('worktree parking pass telemetry', () => {
       ],
       census: harness.census,
       ordinaryParkedCount: 0,
+      parkingEnabled: true,
+      retentionBudgetEnabled: true,
       nowMs
     })
     expect(clockReset.hiddenTracked).toBe(2)
@@ -73,46 +81,111 @@ describe('worktree parking pass telemetry', () => {
           worktreeId: 'b',
           hiddenSinceMs: nowMs - 6 * 60_000,
           parkCooldownUntilMs: nowMs + 1_000
+        }),
+        verdict({
+          worktreeId: 'young',
+          hiddenSinceMs: nowMs - 10_000,
+          hasPendingSpawnWork: true
         })
       ],
       census: harness.census,
       ordinaryParkedCount: 0,
+      parkingEnabled: true,
+      retentionBudgetEnabled: false,
       nowMs
     })
     expect(vetoed.hiddenPastParkDelay).toBe(2)
     expect(vetoed.hiddenPastHotRetain).toBe(2)
     expect(vetoed.hiddenPastRetentionTtl).toBe(1)
-    expect(vetoed.pendingSpawnWork).toBe(1)
-    expect(vetoed.cooldown).toBe(1)
+    expect(vetoed.pastParkDelayPendingSpawnWork).toBe(1)
+    expect(vetoed.pastParkDelayCooldown).toBe(1)
     expect(vetoed.managers).toBe(49)
+    expect(vetoed.parkingEnabled).toBe(true)
+    expect(vetoed.retentionBudgetEnabled).toBe(false)
   })
 
-  it('emits once per verdict shift with interval damping, not per pass', () => {
+  it('keeps veto counts inside the aged cohort', () => {
+    const nowMs = 20 * 60_000
+    const summary = summarizeTerminalWorktreeParkingPass({
+      verdicts: [
+        verdict({
+          worktreeId: 'aged-covered',
+          hiddenSinceMs: 0,
+          ordinaryParkingCovers: true
+        }),
+        verdict({
+          worktreeId: 'young-pending',
+          hiddenSinceMs: nowMs - 10_000,
+          hasPendingSpawnWork: true
+        })
+      ],
+      census: harness.census,
+      ordinaryParkedCount: 0,
+      parkingEnabled: true,
+      retentionBudgetEnabled: true,
+      nowMs
+    })
+
+    expect(summary.hiddenPastParkDelay).toBe(1)
+    expect(summary.pastParkDelayOrdinaryParkingCovers).toBe(1)
+    expect(summary.pastParkDelayPendingSpawnWork).toBe(0)
+  })
+
+  it('queues every pass for main-process coalescing', () => {
     const base = [verdict({ worktreeId: 'a', hiddenSinceMs: 0 })]
-    recordTerminalWorktreeParkingPass({ verdicts: base, ordinaryParkedCount: 0, nowMs: 60_000 })
+    queueTerminalWorktreeParkingPass({
+      verdicts: base,
+      ordinaryParkedCount: 0,
+      parkingEnabled: true,
+      retentionBudgetEnabled: true,
+      nowMs: 60_000
+    })
+    vi.runOnlyPendingTimers()
     expect(harness.crumbs).toHaveLength(1)
     expect(harness.crumbs[0]?.name).toBe('terminal_parking_pass')
     expect(harness.crumbs[0]?.data?.hiddenPastParkDelay).toBe(1)
 
-    // Same cohorts, older age: no re-emit (ages are not part of the key).
-    recordTerminalWorktreeParkingPass({ verdicts: base, ordinaryParkedCount: 0, nowMs: 70_000 })
-    expect(harness.crumbs).toHaveLength(1)
-
-    // A genuine shift inside the damping window stays pending.
     const shifted = [verdict({ worktreeId: 'a', hiddenSinceMs: 0, hasPendingSpawnWork: true })]
-    recordTerminalWorktreeParkingPass({ verdicts: shifted, ordinaryParkedCount: 0, nowMs: 80_000 })
-    expect(harness.crumbs).toHaveLength(1)
-
-    // The pending shift fires once the window opens.
-    recordTerminalWorktreeParkingPass({ verdicts: shifted, ordinaryParkedCount: 0, nowMs: 95_000 })
+    queueTerminalWorktreeParkingPass({
+      verdicts: shifted,
+      ordinaryParkedCount: 0,
+      parkingEnabled: true,
+      retentionBudgetEnabled: true,
+      nowMs: 61_000
+    })
+    vi.runOnlyPendingTimers()
     expect(harness.crumbs).toHaveLength(2)
-    expect(harness.crumbs[1]?.data?.pendingSpawnWork).toBe(1)
+    expect(harness.crumbs[1]?.data?.pastParkDelayPendingSpawnWork).toBe(1)
   })
 
-  it('records the manager census with every emission', () => {
+  it('samples the manager census after the queued pass', () => {
+    queueTerminalWorktreeParkingPass({
+      verdicts: [],
+      ordinaryParkedCount: 0,
+      parkingEnabled: true,
+      retentionBudgetEnabled: true,
+      nowMs: 60_000
+    })
     harness.census = { managers: 7, panes: 9 }
-    recordTerminalWorktreeParkingPass({ verdicts: [], ordinaryParkedCount: 0, nowMs: 60_000 })
+    expect(harness.crumbs).toHaveLength(0)
+
+    vi.runOnlyPendingTimers()
     expect(harness.crumbs[0]?.data?.managers).toBe(7)
     expect(harness.crumbs[0]?.data?.panes).toBe(9)
+  })
+
+  it('cancels a queued sample when the terminal surface unmounts', () => {
+    queueTerminalWorktreeParkingPass({
+      verdicts: [],
+      ordinaryParkedCount: 0,
+      parkingEnabled: true,
+      retentionBudgetEnabled: true,
+      nowMs: 60_000
+    })
+
+    resetTerminalWorktreeParkingPassTelemetry()
+    vi.runOnlyPendingTimers()
+
+    expect(harness.crumbs).toHaveLength(0)
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-worktree-parking-telemetry.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-worktree-parking-telemetry.ts
@@ -1,0 +1,148 @@
+/**
+ * Production telemetry for the worktree parking pass.
+ *
+ * Why: the pass already computes a per-worktree verdict every run and throws
+ * it away outside e2e, so a field bundle cannot say WHY hidden worktrees never
+ * park — a hiddenSince clock that keeps resetting is indistinguishable from a
+ * decision-time veto (pending spawn work, cooldown, coverage). One bounded,
+ * change-damped breadcrumb per meaningful shift answers that, alongside the
+ * live manager census the same bundles used to infer from crumb multiplicity.
+ */
+import { recordRendererCrashBreadcrumb } from '@/lib/crash-breadcrumb-recorder'
+import { getLivePaneCensus } from '@/lib/pane-manager/pane-manager-registry'
+import { TERMINAL_HIDDEN_WORKTREE_RETENTION_TTL_MS } from './terminal-hidden-worktree-retention'
+import {
+  TERMINAL_WORKTREE_COLD_PARK_DELAY_MS,
+  TERMINAL_WORKTREE_HOT_RETAIN_MS
+} from './terminal-hidden-view-parking'
+import type { TerminalWorktreeParkingDebugVerdict } from './terminal-parking-e2e-overrides'
+
+export const TERMINAL_PARKING_PASS_BREADCRUMB = 'terminal_parking_pass'
+const MIN_EMIT_INTERVAL_MS = 30_000
+
+export type TerminalWorktreeParkingPassSummary = {
+  managers: number
+  panes: number
+  worktrees: number
+  hiddenTracked: number
+  /** Hidden ages crossing the policy deadlines — the clock-reset discriminator:
+   *  a resetting hiddenSince keeps all three at zero forever. */
+  hiddenPastParkDelay: number
+  hiddenPastHotRetain: number
+  hiddenPastRetentionTtl: number
+  oldestHiddenAgeMs: number
+  visible: number
+  measuring: number
+  portal: number
+  ordinaryParkingCovers: number
+  pendingSpawnWork: number
+  cooldown: number
+  ordinaryParked: number
+  forceParked: number
+}
+
+export function summarizeTerminalWorktreeParkingPass(args: {
+  verdicts: readonly TerminalWorktreeParkingDebugVerdict[]
+  census: { managers: number; panes: number }
+  ordinaryParkedCount: number
+  nowMs: number
+}): TerminalWorktreeParkingPassSummary {
+  const summary: TerminalWorktreeParkingPassSummary = {
+    managers: args.census.managers,
+    panes: args.census.panes,
+    worktrees: args.verdicts.length,
+    hiddenTracked: 0,
+    hiddenPastParkDelay: 0,
+    hiddenPastHotRetain: 0,
+    hiddenPastRetentionTtl: 0,
+    oldestHiddenAgeMs: 0,
+    visible: 0,
+    measuring: 0,
+    portal: 0,
+    ordinaryParkingCovers: 0,
+    pendingSpawnWork: 0,
+    cooldown: 0,
+    ordinaryParked: args.ordinaryParkedCount,
+    forceParked: 0
+  }
+  for (const verdict of args.verdicts) {
+    if (verdict.isVisible) {
+      summary.visible += 1
+    }
+    if (verdict.shouldMeasureHiddenWorktree) {
+      summary.measuring += 1
+    }
+    if (verdict.hasActivityTerminalPortal) {
+      summary.portal += 1
+    }
+    if (verdict.ordinaryParkingCovers) {
+      summary.ordinaryParkingCovers += 1
+    }
+    if (verdict.hasPendingSpawnWork) {
+      summary.pendingSpawnWork += 1
+    }
+    if (verdict.parkCooldownUntilMs != null && args.nowMs < verdict.parkCooldownUntilMs) {
+      summary.cooldown += 1
+    }
+    if (verdict.forceParked) {
+      summary.forceParked += 1
+    }
+    if (verdict.hiddenSinceMs === null || verdict.isVisible) {
+      continue
+    }
+    summary.hiddenTracked += 1
+    const ageMs = Math.max(0, args.nowMs - verdict.hiddenSinceMs)
+    summary.oldestHiddenAgeMs = Math.max(summary.oldestHiddenAgeMs, ageMs)
+    if (ageMs >= TERMINAL_WORKTREE_COLD_PARK_DELAY_MS) {
+      summary.hiddenPastParkDelay += 1
+    }
+    if (ageMs >= TERMINAL_WORKTREE_HOT_RETAIN_MS) {
+      summary.hiddenPastHotRetain += 1
+    }
+    if (ageMs >= TERMINAL_HIDDEN_WORKTREE_RETENTION_TTL_MS) {
+      summary.hiddenPastRetentionTtl += 1
+    }
+  }
+  return summary
+}
+
+// Why key over counts, not ages: the deadline-cohort counts are the signal and
+// change rarely; a raw age in the key would re-emit every pass forever.
+function summaryChangeKey(summary: TerminalWorktreeParkingPassSummary): string {
+  const { oldestHiddenAgeMs: _oldestHiddenAgeMs, ...keyed } = summary
+  return JSON.stringify(keyed)
+}
+
+let lastSummaryKey: string | null = null
+let lastEmitAtMs = 0
+
+export function resetTerminalWorktreeParkingPassTelemetry(): void {
+  lastSummaryKey = null
+  lastEmitAtMs = 0
+}
+
+/** Records one parking pass; emits a breadcrumb only on a damped verdict shift. */
+export function recordTerminalWorktreeParkingPass(args: {
+  verdicts: readonly TerminalWorktreeParkingDebugVerdict[]
+  ordinaryParkedCount: number
+  nowMs: number
+}): void {
+  const summary = summarizeTerminalWorktreeParkingPass({
+    verdicts: args.verdicts,
+    census: getLivePaneCensus(),
+    ordinaryParkedCount: args.ordinaryParkedCount,
+    nowMs: args.nowMs
+  })
+  const key = summaryChangeKey(summary)
+  if (key === lastSummaryKey) {
+    return
+  }
+  // Why keep the last key on damped returns: the shift stays pending and
+  // re-fires once the window opens instead of being lost.
+  if (lastSummaryKey !== null && args.nowMs - lastEmitAtMs < MIN_EMIT_INTERVAL_MS) {
+    return
+  }
+  lastSummaryKey = key
+  lastEmitAtMs = args.nowMs
+  recordRendererCrashBreadcrumb(TERMINAL_PARKING_PASS_BREADCRUMB, { ...summary })
+}

--- a/src/renderer/src/components/terminal-pane/terminal-worktree-parking-telemetry.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-worktree-parking-telemetry.ts
@@ -5,8 +5,8 @@
  * it away outside e2e, so a field bundle cannot say WHY hidden worktrees never
  * park — a hiddenSince clock that keeps resetting is indistinguishable from a
  * decision-time veto (pending spawn work, cooldown, coverage). One bounded,
- * change-damped breadcrumb per meaningful shift answers that, alongside the
- * live manager census the same bundles used to infer from crumb multiplicity.
+ * coalesced latest-state breadcrumb answers that, alongside the post-commit
+ * manager census the same bundles used to infer from crumb multiplicity.
  */
 import { recordRendererCrashBreadcrumb } from '@/lib/crash-breadcrumb-recorder'
 import { getLivePaneCensus } from '@/lib/pane-manager/pane-manager-registry'
@@ -18,11 +18,13 @@ import {
 import type { TerminalWorktreeParkingDebugVerdict } from './terminal-parking-e2e-overrides'
 
 export const TERMINAL_PARKING_PASS_BREADCRUMB = 'terminal_parking_pass'
-const MIN_EMIT_INTERVAL_MS = 30_000
 
 export type TerminalWorktreeParkingPassSummary = {
   managers: number
   panes: number
+  sampledAtMs: number
+  parkingEnabled: boolean
+  retentionBudgetEnabled: boolean
   worktrees: number
   hiddenTracked: number
   /** Hidden ages crossing the policy deadlines — the clock-reset discriminator:
@@ -32,11 +34,11 @@ export type TerminalWorktreeParkingPassSummary = {
   hiddenPastRetentionTtl: number
   oldestHiddenAgeMs: number
   visible: number
-  measuring: number
+  pastParkDelayMeasuring: number
   portal: number
-  ordinaryParkingCovers: number
-  pendingSpawnWork: number
-  cooldown: number
+  pastParkDelayOrdinaryParkingCovers: number
+  pastParkDelayPendingSpawnWork: number
+  pastParkDelayCooldown: number
   ordinaryParked: number
   forceParked: number
 }
@@ -45,11 +47,16 @@ export function summarizeTerminalWorktreeParkingPass(args: {
   verdicts: readonly TerminalWorktreeParkingDebugVerdict[]
   census: { managers: number; panes: number }
   ordinaryParkedCount: number
+  parkingEnabled: boolean
+  retentionBudgetEnabled: boolean
   nowMs: number
 }): TerminalWorktreeParkingPassSummary {
   const summary: TerminalWorktreeParkingPassSummary = {
     managers: args.census.managers,
     panes: args.census.panes,
+    sampledAtMs: args.nowMs,
+    parkingEnabled: args.parkingEnabled,
+    retentionBudgetEnabled: args.retentionBudgetEnabled,
     worktrees: args.verdicts.length,
     hiddenTracked: 0,
     hiddenPastParkDelay: 0,
@@ -57,11 +64,11 @@ export function summarizeTerminalWorktreeParkingPass(args: {
     hiddenPastRetentionTtl: 0,
     oldestHiddenAgeMs: 0,
     visible: 0,
-    measuring: 0,
+    pastParkDelayMeasuring: 0,
     portal: 0,
-    ordinaryParkingCovers: 0,
-    pendingSpawnWork: 0,
-    cooldown: 0,
+    pastParkDelayOrdinaryParkingCovers: 0,
+    pastParkDelayPendingSpawnWork: 0,
+    pastParkDelayCooldown: 0,
     ordinaryParked: args.ordinaryParkedCount,
     forceParked: 0
   }
@@ -69,20 +76,8 @@ export function summarizeTerminalWorktreeParkingPass(args: {
     if (verdict.isVisible) {
       summary.visible += 1
     }
-    if (verdict.shouldMeasureHiddenWorktree) {
-      summary.measuring += 1
-    }
     if (verdict.hasActivityTerminalPortal) {
       summary.portal += 1
-    }
-    if (verdict.ordinaryParkingCovers) {
-      summary.ordinaryParkingCovers += 1
-    }
-    if (verdict.hasPendingSpawnWork) {
-      summary.pendingSpawnWork += 1
-    }
-    if (verdict.parkCooldownUntilMs != null && args.nowMs < verdict.parkCooldownUntilMs) {
-      summary.cooldown += 1
     }
     if (verdict.forceParked) {
       summary.forceParked += 1
@@ -95,6 +90,18 @@ export function summarizeTerminalWorktreeParkingPass(args: {
     summary.oldestHiddenAgeMs = Math.max(summary.oldestHiddenAgeMs, ageMs)
     if (ageMs >= TERMINAL_WORKTREE_COLD_PARK_DELAY_MS) {
       summary.hiddenPastParkDelay += 1
+      if (verdict.shouldMeasureHiddenWorktree) {
+        summary.pastParkDelayMeasuring += 1
+      }
+      if (verdict.ordinaryParkingCovers) {
+        summary.pastParkDelayOrdinaryParkingCovers += 1
+      }
+      if (verdict.hasPendingSpawnWork) {
+        summary.pastParkDelayPendingSpawnWork += 1
+      }
+      if (verdict.parkCooldownUntilMs != null && args.nowMs < verdict.parkCooldownUntilMs) {
+        summary.pastParkDelayCooldown += 1
+      }
     }
     if (ageMs >= TERMINAL_WORKTREE_HOT_RETAIN_MS) {
       summary.hiddenPastHotRetain += 1
@@ -106,43 +113,46 @@ export function summarizeTerminalWorktreeParkingPass(args: {
   return summary
 }
 
-// Why key over counts, not ages: the deadline-cohort counts are the signal and
-// change rarely; a raw age in the key would re-emit every pass forever.
-function summaryChangeKey(summary: TerminalWorktreeParkingPassSummary): string {
-  const { oldestHiddenAgeMs: _oldestHiddenAgeMs, ...keyed } = summary
-  return JSON.stringify(keyed)
-}
-
-let lastSummaryKey: string | null = null
-let lastEmitAtMs = 0
+let queuedSummary: TerminalWorktreeParkingPassSummary | null = null
+let flushTimer: ReturnType<typeof setTimeout> | null = null
 
 export function resetTerminalWorktreeParkingPassTelemetry(): void {
-  lastSummaryKey = null
-  lastEmitAtMs = 0
+  queuedSummary = null
+  if (flushTimer !== null) {
+    clearTimeout(flushTimer)
+    flushTimer = null
+  }
 }
 
-/** Records one parking pass; emits a breadcrumb only on a damped verdict shift. */
-export function recordTerminalWorktreeParkingPass(args: {
+/** Queues the latest pass so its census observes the resulting pane unmounts. */
+export function queueTerminalWorktreeParkingPass(args: {
   verdicts: readonly TerminalWorktreeParkingDebugVerdict[]
   ordinaryParkedCount: number
+  parkingEnabled: boolean
+  retentionBudgetEnabled: boolean
   nowMs: number
 }): void {
-  const summary = summarizeTerminalWorktreeParkingPass({
+  queuedSummary = summarizeTerminalWorktreeParkingPass({
     verdicts: args.verdicts,
-    census: getLivePaneCensus(),
+    census: { managers: 0, panes: 0 },
     ordinaryParkedCount: args.ordinaryParkedCount,
+    parkingEnabled: args.parkingEnabled,
+    retentionBudgetEnabled: args.retentionBudgetEnabled,
     nowMs: args.nowMs
   })
-  const key = summaryChangeKey(summary)
-  if (key === lastSummaryKey) {
+  if (flushTimer !== null) {
     return
   }
-  // Why keep the last key on damped returns: the shift stays pending and
-  // re-fires once the window opens instead of being lost.
-  if (lastSummaryKey !== null && args.nowMs - lastEmitAtMs < MIN_EMIT_INTERVAL_MS) {
-    return
-  }
-  lastSummaryKey = key
-  lastEmitAtMs = args.nowMs
-  recordRendererCrashBreadcrumb(TERMINAL_PARKING_PASS_BREADCRUMB, { ...summary })
+  flushTimer = setTimeout(() => {
+    flushTimer = null
+    const summary = queuedSummary
+    queuedSummary = null
+    if (!summary) {
+      return
+    }
+    recordRendererCrashBreadcrumb(TERMINAL_PARKING_PASS_BREADCRUMB, {
+      ...summary,
+      ...getLivePaneCensus()
+    })
+  }, 0)
 }

--- a/src/renderer/src/components/terminal-pane/terminal-worktree-parking-telemetry.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-worktree-parking-telemetry.ts
@@ -115,9 +115,19 @@ export function summarizeTerminalWorktreeParkingPass(args: {
 
 let queuedSummary: TerminalWorktreeParkingPassSummary | null = null
 let flushTimer: ReturnType<typeof setTimeout> | null = null
+let lastEmittedSummaryKey: string | null = null
+
+function parkingPassSummaryKey(summary: TerminalWorktreeParkingPassSummary): string {
+  const stableSummary: Partial<TerminalWorktreeParkingPassSummary> = { ...summary }
+  // Elapsed time alone must not turn an unchanged parking shape into ring churn.
+  delete stableSummary.sampledAtMs
+  delete stableSummary.oldestHiddenAgeMs
+  return JSON.stringify(stableSummary)
+}
 
 export function resetTerminalWorktreeParkingPassTelemetry(): void {
   queuedSummary = null
+  lastEmittedSummaryKey = null
   if (flushTimer !== null) {
     clearTimeout(flushTimer)
     flushTimer = null
@@ -150,9 +160,15 @@ export function queueTerminalWorktreeParkingPass(args: {
     if (!summary) {
       return
     }
-    recordRendererCrashBreadcrumb(TERMINAL_PARKING_PASS_BREADCRUMB, {
+    const sampledSummary = {
       ...summary,
       ...getLivePaneCensus()
-    })
+    }
+    const summaryKey = parkingPassSummaryKey(sampledSummary)
+    if (summaryKey === lastEmittedSummaryKey) {
+      return
+    }
+    lastEmittedSummaryKey = summaryKey
+    recordRendererCrashBreadcrumb(TERMINAL_PARKING_PASS_BREADCRUMB, sampledSummary)
   }, 0)
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​242 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​242 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​201 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​193 |

<!-- /orca-pr-loc -->

## ELI5

Orca already decides on every terminal parking pass whether hidden worktrees are old enough to unload and which rule, if any, vetoes that decision. Production currently throws that explanation away, so a crash bundle with many live terminal managers cannot distinguish a clock that keeps resetting from an aged worktree that is repeatedly vetoed.

This PR records one compact latest-state census: hidden-worktree age cohorts, veto counts for the cohort already past the parking delay, the global parking/retention gates, ordinary/forced parking outcomes, and the post-commit live manager/pane counts. It changes no parking verdict or mount behavior.

## What Changed

- Summarize the parking verdict array without worktree IDs or filesystem paths.
- Queue the census until after React commits the parking pass, then sample the live pane registry.
- Send every pass through the existing renderer breadcrumb IPC path as `terminal_parking_pass`.
- Coalesce that process-wide stream by name for 30 seconds so bursts update the latest payload and suppression count without filling the breadcrumb ring.
- Cancel queued renderer work when the Terminal surface unmounts.

This branch intentionally does not change `crash-breadcrumb-store` retention policy.

## Why

This is instrumentation, not a crash fix. The next field bundle can distinguish:

1. A resetting clock: `hiddenTracked` remains high while the 30-second, 5-minute, and 15-minute cohorts remain near zero.
2. A decision-time veto: worktrees reach the aged cohort while pending spawn work, cooldown, measuring, coverage, or a global gate explains why they stay mounted.

The payload contains aggregate counts only; worktree IDs are excluded because they embed paths.

## Durability

The retained-slot policy landed independently in #14867 and is now part of `main`. This PR uses that existing durability behavior but does not change its budget or retention rules.

The telemetry remains logically independent: emission and coalescing produce valid census data, while the already-landed store policy determines how long it survives unrelated ring pressure.

## Trade-offs

- It observes; it does not fix the resetting clock or a sticky veto.
- Aggregates distinguish the two failure shapes but do not identify a specific worktree.
- Each event-driven parking pass adds one summary fold, one coalesced zero-delay post-commit task, and one compact IPC payload; there is no polling.
- Name-scoped coalescing keeps only the latest payload during a burst; the existing retained slot protects that census from later unrelated breadcrumbs.

## Visual Proof

N/A — this adds crash-reporting instrumentation and changes no rendered UI or interaction.

## Testing

All #14660 targeted tests pass after rebasing onto current `origin/main` (7 files, 95/95 tests):

| Suite | Result |
| --- | ---: |
| `terminal-worktree-parking-telemetry.test.ts` | 6/6 |
| `crash-reporting-renderer-breadcrumbs.test.ts` | 19/19 |
| `active-terminal-repair-loop.react185.test.tsx` | 11/11 |
| `use-terminal-tab-cold-parking.test.ts` | 11/11 |
| `terminal-cold-park-verdict-loop.test.tsx` | 2/2 |
| `force-park-buffer-capture.test.ts` | 3/3 |
| `terminal-hidden-view-parking.test.ts` | 43/43 |

Current `origin/main` includes the independently landed retention and coalescing changes; the counts above are from this rebased PR head.

## Compatibility and Scope

- Cross-platform: shared renderer/main logic; no platform-specific paths or shortcuts.
- SSH and folder workspaces: aggregate observation follows the existing parking pass and assumes neither local execution nor a Git worktree.
- Remote wire compatibility: no new RPC params, stream opcodes, or persisted schema.
- Security/privacy: no worktree IDs, paths, tokens, or per-worktree rows.
- Mobile: not affected; this is the desktop terminal parking path.

## Linked Issue

No tracked GitHub issue exists for this work. It comes from the 2026-08-13/14 crash-field sweep and instruments the open question behind a renderer-memory investigation.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Visual proof is N/A because there is no UI change
- [x] Targeted tests pass locally
- [x] Cross-platform, SSH/remote, privacy, and compatibility impact considered
- [ ] Full lint, typecheck, test, and build are left to CI

## Author

- X / Twitter: @BrennanKB5


