### PR TITLE
fix(crash-reporting): stop post-mortem process metrics crowning a survivor as the crasher

### DIFF
--- a/src/main/crash-reporting/gone-time-system-memory.ts
+++ b/src/main/crash-reporting/gone-time-system-memory.ts
@@ -1,0 +1,71 @@
+import type { CrashReportDetailValue } from '../../shared/crash-reporting'
+
+// ─── System memory at gone time ─────────────────────────────────────
+// Why: the system outlives the crashed process, so this IS sampleable at
+// process-gone — it separates "renderer grew huge" from "machine out of
+// memory/commit", which the per-process buckets alone cannot.
+// Platform honesty: swap* exist on Windows/Linux only. On macOS `free` is
+// near-meaningless (file cache and compression keep it low on healthy
+// machines); fileBacked/purgeable are the only reclaimability proxy this API
+// gives there, and none of these fields answers "was the machine under
+// pressure" on macOS — that needs a signal Electron does not expose.
+
+type CrashReportDetails = Record<string, CrashReportDetailValue>
+
+export function memoryKBFieldMB(value: unknown): number | undefined {
+  const kb = typeof value === 'number' && Number.isFinite(value) ? value : undefined
+  return kb === undefined ? undefined : Math.round(Math.max(0, kb) / 1024)
+}
+
+type SystemMemoryInfoLike = {
+  total?: unknown
+  free?: unknown
+  swapTotal?: unknown
+  swapFree?: unknown
+  fileBacked?: unknown
+  purgeable?: unknown
+}
+
+type SystemMemoryInfoReader = () => SystemMemoryInfoLike | null
+
+function readElectronSystemMemoryInfo(): SystemMemoryInfoLike | null {
+  const read = (process as NodeJS.Process & { getSystemMemoryInfo?: () => SystemMemoryInfoLike })
+    .getSystemMemoryInfo
+  if (typeof read !== 'function') {
+    return null
+  }
+  try {
+    return read.call(process)
+  } catch {
+    return null
+  }
+}
+
+let systemMemoryInfoReader: SystemMemoryInfoReader = readElectronSystemMemoryInfo
+
+export function setSystemMemoryInfoReaderForTest(reader: SystemMemoryInfoReader | null): void {
+  systemMemoryInfoReader = reader ?? readElectronSystemMemoryInfo
+}
+
+export function getSystemMemoryAtGoneDetails(): CrashReportDetails {
+  const info = systemMemoryInfoReader()
+  if (!info) {
+    return {}
+  }
+  const details: CrashReportDetails = {}
+  const fields: readonly [keyof SystemMemoryInfoLike, string][] = [
+    ['total', 'systemMemoryTotalMB'],
+    ['free', 'systemMemoryFreeMB'],
+    ['swapTotal', 'systemMemorySwapTotalMB'],
+    ['swapFree', 'systemMemorySwapFreeMB'],
+    ['fileBacked', 'systemMemoryFileBackedMB'],
+    ['purgeable', 'systemMemoryPurgeableMB']
+  ]
+  for (const [field, key] of fields) {
+    const mb = memoryKBFieldMB(info[field])
+    if (mb !== undefined) {
+      details[key] = mb
+    }
+  }
+  return details
+}

--- a/src/main/crash-reporting/gone-time-system-memory.ts
+++ b/src/main/crash-reporting/gone-time-system-memory.ts
@@ -4,6 +4,8 @@ import type { CrashReportDetailValue } from '../../shared/crash-reporting'
 // Why: the system outlives the crashed process, so this IS sampleable at
 // process-gone — it separates "renderer grew huge" from "machine out of
 // memory/commit", which the per-process buckets alone cannot.
+// Timing honesty: this reads AFTER the crashed process's memory returned to
+// the OS, so free/swapFree can look healthier than they were at kill time.
 // Platform honesty: swap* exist on Windows/Linux only. On macOS `free` is
 // near-meaningless (file cache and compression keep it low on healthy
 // machines); fileBacked/purgeable are the only reclaimability proxy this API

--- a/src/main/crash-reporting/process-gone-diagnostics.test.ts
+++ b/src/main/crash-reporting/process-gone-diagnostics.test.ts
@@ -123,7 +123,7 @@ describe('process gone diagnostics', () => {
     })
   })
 
-  it('refreshes the pre-gone sample on the interval and starts only once', () => {
+  it('samples at start, refreshes on the interval, and starts only once', () => {
     vi.useFakeTimers()
     vi.setSystemTime(0)
     appMetricsMock.mockReturnValue([
@@ -132,10 +132,18 @@ describe('process gone diagnostics', () => {
     startPreGoneProcessMetricsSampling(1_000)
     startPreGoneProcessMetricsSampling(1_000)
 
+    // A crash inside the first interval already has a sample to draw from.
+    expect(buildProcessGoneCrashDetails({}, 'renderer')).toMatchObject({
+      processMetricsPreGoneRendererWorkingSetMB: 100
+    })
+
+    appMetricsMock.mockClear()
     appMetricsMock.mockReturnValue([
       { pid: 30, type: 'Tab', memory: { workingSetSize: 1024 * 900 } }
     ])
     vi.advanceTimersByTime(1_000)
+    // Exactly one sweep: the second start() must not have armed a second timer.
+    expect(appMetricsMock).toHaveBeenCalledTimes(1)
     appMetricsMock.mockReturnValue([{ pid: 1, type: 'Browser', memory: { workingSetSize: 0 } }])
 
     expect(buildProcessGoneCrashDetails({}, 'renderer')).toMatchObject({
@@ -144,12 +152,40 @@ describe('process gone diagnostics', () => {
     })
   })
 
+  it('keeps the previous pre-gone sample when a sweep fails', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(2_000_000)
+    appMetricsMock.mockReturnValue([
+      { pid: 60, type: 'Tab', memory: { workingSetSize: 1024 * 1200 } }
+    ])
+    samplePreGoneProcessMetrics()
+
+    vi.setSystemTime(2_000_000 + 5_000)
+    appMetricsMock.mockImplementationOnce(() => {
+      throw new Error('metrics unavailable')
+    })
+    samplePreGoneProcessMetrics()
+    appMetricsMock.mockReturnValue([{ pid: 1, type: 'Browser', memory: { workingSetSize: 0 } }])
+
+    // Sample and its timestamp both survive the failed sweep.
+    expect(buildProcessGoneCrashDetails({}, 'renderer')).toMatchObject({
+      processMetricsPreGoneRendererWorkingSetMB: 1200,
+      processMetricsPreGoneSampleAgeMs: 5_000
+    })
+  })
+
   it('reports the renderer lifetime peak and private bytes when the metrics carry them', () => {
     const details = collectProcessGoneMetricDetails([
       {
+        // Larger peak/private than any renderer: proves the fields are
+        // renderer-only aggregates, not app-wide maxima.
         pid: 10,
         type: 'Browser',
-        memory: { workingSetSize: 1024 * 200, peakWorkingSetSize: 1024 * 900 }
+        memory: {
+          workingSetSize: 1024 * 200,
+          peakWorkingSetSize: 1024 * 9000,
+          privateBytes: 1024 * 8000
+        }
       },
       {
         pid: 11,

--- a/src/main/crash-reporting/process-gone-diagnostics.test.ts
+++ b/src/main/crash-reporting/process-gone-diagnostics.test.ts
@@ -5,13 +5,14 @@ import {
   collectProcessGoneMetricDetails,
   resetPreGoneProcessMetricsSamplingForTest,
   samplePreGoneProcessMetrics,
+  setSystemMemoryInfoReaderForTest,
   startPreGoneProcessMetricsSampling
 } from './process-gone-diagnostics'
 
 type MetricFixture = {
   pid: number
   type: string
-  memory: { workingSetSize: number }
+  memory: { workingSetSize: number; peakWorkingSetSize?: number; privateBytes?: number }
 }
 
 const { appMetricsMock } = vi.hoisted(() => ({
@@ -27,6 +28,7 @@ vi.mock('electron', () => ({
 describe('process gone diagnostics', () => {
   beforeEach(() => {
     resetPreGoneProcessMetricsSamplingForTest()
+    setSystemMemoryInfoReaderForTest(null)
   })
 
   afterEach(() => {
@@ -140,6 +142,74 @@ describe('process gone diagnostics', () => {
       processMetricsPreGoneSampleAgeMs: 0,
       processMetricsPreGoneRendererWorkingSetMB: 900
     })
+  })
+
+  it('reports the renderer lifetime peak and private bytes when the metrics carry them', () => {
+    const details = collectProcessGoneMetricDetails([
+      {
+        pid: 10,
+        type: 'Browser',
+        memory: { workingSetSize: 1024 * 200, peakWorkingSetSize: 1024 * 900 }
+      },
+      {
+        pid: 11,
+        type: 'Tab',
+        memory: {
+          workingSetSize: 1024 * 800,
+          peakWorkingSetSize: 1024 * 4100,
+          privateBytes: 1024 * 3900
+        }
+      },
+      {
+        pid: 12,
+        type: 'Tab',
+        memory: { workingSetSize: 1024 * 300, peakWorkingSetSize: 1024 * 350 }
+      }
+    ])
+
+    // Max across renderers, never the Browser's; a spike between interval
+    // samples survives in the lifetime peak.
+    expect(details.processMetricsRendererPeakWorkingSetMB).toBe(4100)
+    expect(details.processMetricsRendererPrivateMB).toBe(3900)
+  })
+
+  it('carries the renderer peak through the pre-gone sample after a between-sample spike', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(500_000)
+    appMetricsMock.mockReturnValue([
+      {
+        pid: 40,
+        type: 'Tab',
+        memory: { workingSetSize: 1024 * 800, peakWorkingSetSize: 1024 * 4100 }
+      }
+    ])
+    samplePreGoneProcessMetrics()
+    appMetricsMock.mockReturnValue([{ pid: 1, type: 'Browser', memory: { workingSetSize: 0 } }])
+
+    expect(buildProcessGoneCrashDetails({}, 'renderer')).toMatchObject({
+      processMetricsPreGoneRendererWorkingSetMB: 800,
+      processMetricsPreGoneRendererPeakWorkingSetMB: 4100
+    })
+  })
+
+  it('samples system memory at gone time but never into the pre-gone snapshot', () => {
+    appMetricsMock.mockReturnValue([{ pid: 1, type: 'Browser', memory: { workingSetSize: 0 } }])
+    samplePreGoneProcessMetrics()
+    setSystemMemoryInfoReaderForTest(() => ({
+      total: 1024 * 16_384,
+      free: 1024 * 210,
+      swapTotal: 1024 * 8_192,
+      swapFree: 1024 * 40
+    }))
+
+    const details = buildProcessGoneCrashDetails({}, 'renderer')
+    expect(details).toMatchObject({
+      systemMemoryTotalMB: 16_384,
+      systemMemoryFreeMB: 210,
+      systemMemorySwapTotalMB: 8_192,
+      systemMemorySwapFreeMB: 40
+    })
+    expect(details.processMetricsPreGoneSystemMemoryTotalMB).toBeUndefined()
   })
 
   it('leaves records unflagged when the crashed bucket is still populated', () => {

--- a/src/main/crash-reporting/process-gone-diagnostics.test.ts
+++ b/src/main/crash-reporting/process-gone-diagnostics.test.ts
@@ -10,6 +10,7 @@ import { setSystemMemoryInfoReaderForTest } from './gone-time-system-memory'
 
 type MetricFixture = {
   pid?: number
+  creationTime?: number
   type: string
   memory: { workingSetSize: number; peakWorkingSetSize?: number; privateBytes?: number }
 }
@@ -101,7 +102,7 @@ describe('process gone diagnostics', () => {
     })
   })
 
-  it('carries the dead renderer working set from the last pre-gone sample', () => {
+  it('mirrors the last whole-process sample before process gone', () => {
     vi.useFakeTimers()
     vi.setSystemTime(1_000_000)
     appMetricsMock.mockReturnValue([
@@ -122,8 +123,10 @@ describe('process gone diagnostics', () => {
       processMetricsRendererCount: 0,
       processMetricsRendererWorkingSetMB: 0,
       processMetricsCrashedProcessAbsent: true,
-      // The crasher's last known size survives via the pre-gone sample.
+      // A single-renderer snapshot happens to equal that renderer's values,
+      // but the contract remains snapshot-wide rather than per-crasher.
       processMetricsPreGoneSampleAgeMs: 42_000,
+      processMetricsPreGoneCrashedProcessAttributionAmbiguous: true,
       processMetricsPreGoneRendererCount: 1,
       processMetricsPreGoneRendererWorkingSetMB: 4380,
       processMetricsPreGoneLargestPid: 15385,
@@ -282,45 +285,98 @@ describe('process gone diagnostics', () => {
     expect(details.processMetricsPreGoneRendererPrivateMB).toBe(2900)
   })
 
-  it('proves crasher absence when a webview guest keeps the renderer bucket alive', () => {
-    // The case that motivated the PR: webviewTag guests / the dashboard popout
-    // leave surviving renderers, so the bucket count never hits zero for a
-    // main-window crash — a sampled renderer pid missing from the live set is
-    // the proof instead.
+  it('keeps the pre-gone snapshot honest when a larger renderer survives', () => {
     vi.useFakeTimers()
     vi.setSystemTime(1_000_000)
-    // Guest enumerated BEFORE the crasher: Largest must carry the crasher's
-    // individual working set, never the renderer bucket's running sum.
     appMetricsMock.mockReturnValue([
       { pid: 100, type: 'Browser', memory: { workingSetSize: 1024 * 431 } },
-      { pid: 102, type: 'Tab', memory: { workingSetSize: 1024 * 300 } },
-      { pid: 101, type: 'Tab', memory: { workingSetSize: 1024 * 4380 } }
+      {
+        pid: 101,
+        type: 'Tab',
+        memory: {
+          workingSetSize: 1024 * 300,
+          peakWorkingSetSize: 1024 * 500,
+          privateBytes: 1024 * 250
+        }
+      },
+      {
+        pid: 102,
+        type: 'Tab',
+        memory: {
+          workingSetSize: 1024 * 4380,
+          peakWorkingSetSize: 1024 * 5000,
+          privateBytes: 1024 * 4000
+        }
+      }
     ])
     samplePreGoneProcessMetrics()
 
     appMetricsMock.mockReturnValue([
       { pid: 100, type: 'Browser', memory: { workingSetSize: 1024 * 431 } },
-      { pid: 102, type: 'Tab', memory: { workingSetSize: 1024 * 300 } }
+      {
+        pid: 102,
+        type: 'Tab',
+        memory: {
+          workingSetSize: 1024 * 4380,
+          peakWorkingSetSize: 1024 * 5000,
+          privateBytes: 1024 * 4000
+        }
+      }
     ])
 
     const details = buildProcessGoneCrashDetails({}, 'renderer')
     expect(details).toMatchObject({
       processMetricsRendererCount: 1,
       processMetricsCrashedProcessAbsent: true,
-      // The live bucket carries the surviving guest only; the crasher's size
-      // reaches the record through the PreGone mirrors: the bucket total sums
-      // crasher + guest, while Largest names the crasher's own size.
-      processMetricsRendererWorkingSetMB: 300,
+      processMetricsRendererWorkingSetMB: 4380,
       processMetricsPreGoneRendererWorkingSetMB: 4680,
-      processMetricsPreGoneLargestPid: 101,
+      processMetricsPreGoneLargestPid: 102,
       processMetricsPreGoneLargestType: 'Tab',
-      processMetricsPreGoneLargestWorkingSetMB: 4380
+      processMetricsPreGoneLargestWorkingSetMB: 4380,
+      processMetricsPreGoneRendererPeakWorkingSetMB: 5000,
+      processMetricsPreGoneRendererPrivateMB: 4000,
+      processMetricsPreGoneCrashedProcessAttributionAmbiguous: true
     })
   })
 
+  it('uses creation time to distinguish a same-pid same-bucket replacement', () => {
+    appMetricsMock.mockReturnValue([
+      {
+        pid: 101,
+        creationTime: 1_000,
+        type: 'Tab',
+        memory: { workingSetSize: 1024 * 400 }
+      }
+    ])
+    samplePreGoneProcessMetrics()
+
+    appMetricsMock.mockReturnValue([
+      {
+        pid: 101,
+        creationTime: 1_000,
+        type: 'Tab',
+        memory: { workingSetSize: 1024 * 400 }
+      }
+    ])
+    expect(
+      buildProcessGoneCrashDetails({}, 'renderer').processMetricsCrashedProcessAbsent
+    ).toBeUndefined()
+
+    appMetricsMock.mockReturnValue([
+      {
+        pid: 101,
+        creationTime: 2_000,
+        type: 'Tab',
+        memory: { workingSetSize: 1024 * 400 }
+      }
+    ])
+    expect(buildProcessGoneCrashDetails({}, 'renderer').processMetricsCrashedProcessAbsent).toBe(
+      true
+    )
+  })
+
   it('proves absence when the OS recycles the sampled renderer pid into another bucket', () => {
-    // Pid reuse: the crasher's pid comes back as a NEW utility process inside
-    // the sweep window. A bare live-pid set would read the crasher as alive.
+    // A bare pid set would mistake the replacement Utility for the sampled Tab.
     appMetricsMock.mockReturnValue([
       { pid: 100, type: 'Browser', memory: { workingSetSize: 1024 * 400 } },
       { pid: 101, type: 'Tab', memory: { workingSetSize: 1024 * 4380 } },
@@ -424,7 +480,7 @@ describe('process gone diagnostics', () => {
     ])
     samplePreGoneProcessMetrics()
 
-    // First death: record #1 carries the true pre-death size.
+    // Record #1 carries the snapshot that still included the first renderer.
     appMetricsMock.mockReturnValue([
       { pid: 200, type: 'Browser', memory: { workingSetSize: 1024 * 400 } }
     ])
@@ -511,6 +567,7 @@ describe('process gone diagnostics', () => {
         processMetricsCount: 999,
         systemMemoryFreeMB: 999_999,
         processMetricsPreGoneRendererWorkingSetMB: 999_999,
+        processMetricsPreGoneCrashedProcessAttributionAmbiguous: false,
         processMetricsCrashedProcessAbsent: false
       },
       'renderer'
@@ -518,6 +575,7 @@ describe('process gone diagnostics', () => {
     expect(details.processMetricsCount).toBe(1)
     expect(details.systemMemoryFreeMB).toBe(500)
     expect(details.processMetricsPreGoneRendererWorkingSetMB).toBe(100)
+    expect(details.processMetricsPreGoneCrashedProcessAttributionAmbiguous).toBe(true)
     expect(details.processMetricsCrashedProcessAbsent).toBe(true)
   })
 

--- a/src/main/crash-reporting/process-gone-diagnostics.test.ts
+++ b/src/main/crash-reporting/process-gone-diagnostics.test.ts
@@ -1,8 +1,11 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   buildProcessGoneCrashDetails,
   buildSuppressedProcessGoneBreadcrumbData,
-  collectProcessGoneMetricDetails
+  collectProcessGoneMetricDetails,
+  resetPreGoneProcessMetricsSamplingForTest,
+  samplePreGoneProcessMetrics,
+  startPreGoneProcessMetricsSampling
 } from './process-gone-diagnostics'
 
 type MetricFixture = {
@@ -22,6 +25,14 @@ vi.mock('electron', () => ({
 }))
 
 describe('process gone diagnostics', () => {
+  beforeEach(() => {
+    resetPreGoneProcessMetricsSamplingForTest()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('summarizes Electron process memory by crash-report-friendly buckets', () => {
     const details = collectProcessGoneMetricDetails([
       { pid: 10, type: 'Browser', memory: { workingSetSize: 1024 * 200 } },
@@ -50,13 +61,105 @@ describe('process gone diagnostics', () => {
     })
   })
 
+  it('flags a renderer-gone record whose live metrics carry only survivors', () => {
+    // Field repro (report caf677f2): render-process-gone fires after the OS
+    // process exits, so getAppMetrics() enumerates survivors only.
+    appMetricsMock.mockReturnValue([
+      { pid: 15384, type: 'Browser', memory: { workingSetSize: 1024 * 431 } },
+      { pid: 15390, type: 'GPU', memory: { workingSetSize: 1024 * 150 } },
+      { pid: 15391, type: 'Utility', memory: { workingSetSize: 1024 * 146 } }
+    ])
+
+    expect(buildProcessGoneCrashDetails({ processType: 'renderer' }, 'renderer')).toEqual({
+      processType: 'renderer',
+      processMetricsCount: 3,
+      processMetricsBrowserCount: 1,
+      processMetricsBrowserWorkingSetMB: 431,
+      processMetricsRendererCount: 0,
+      processMetricsRendererWorkingSetMB: 0,
+      processMetricsGpuCount: 1,
+      processMetricsGpuWorkingSetMB: 150,
+      processMetricsUtilityCount: 1,
+      processMetricsUtilityWorkingSetMB: 146,
+      processMetricsOtherCount: 0,
+      processMetricsOtherWorkingSetMB: 0,
+      processMetricsLargestPid: 15384,
+      processMetricsLargestType: 'Browser',
+      processMetricsLargestWorkingSetMB: 431,
+      processMetricsCrashedProcessAbsent: true
+    })
+  })
+
+  it('carries the dead renderer working set from the last pre-gone sample', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000_000)
+    appMetricsMock.mockReturnValue([
+      { pid: 15384, type: 'Browser', memory: { workingSetSize: 1024 * 431 } },
+      { pid: 15385, type: 'Tab', memory: { workingSetSize: 1024 * 4380 } },
+      { pid: 15390, type: 'GPU', memory: { workingSetSize: 1024 * 150 } }
+    ])
+    samplePreGoneProcessMetrics()
+
+    vi.setSystemTime(1_000_000 + 42_000)
+    appMetricsMock.mockReturnValue([
+      { pid: 15384, type: 'Browser', memory: { workingSetSize: 1024 * 431 } },
+      { pid: 15390, type: 'GPU', memory: { workingSetSize: 1024 * 150 } }
+    ])
+
+    expect(buildProcessGoneCrashDetails({ processType: 'renderer' }, 'renderer')).toMatchObject({
+      // Live buckets stay survivors-only, and say so.
+      processMetricsRendererCount: 0,
+      processMetricsRendererWorkingSetMB: 0,
+      processMetricsCrashedProcessAbsent: true,
+      // The crasher's last known size survives via the pre-gone sample.
+      processMetricsPreGoneSampleAgeMs: 42_000,
+      processMetricsPreGoneRendererCount: 1,
+      processMetricsPreGoneRendererWorkingSetMB: 4380,
+      processMetricsPreGoneLargestPid: 15385,
+      processMetricsPreGoneLargestType: 'Tab',
+      processMetricsPreGoneLargestWorkingSetMB: 4380
+    })
+  })
+
+  it('refreshes the pre-gone sample on the interval and starts only once', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    appMetricsMock.mockReturnValue([
+      { pid: 30, type: 'Tab', memory: { workingSetSize: 1024 * 100 } }
+    ])
+    startPreGoneProcessMetricsSampling(1_000)
+    startPreGoneProcessMetricsSampling(1_000)
+
+    appMetricsMock.mockReturnValue([
+      { pid: 30, type: 'Tab', memory: { workingSetSize: 1024 * 900 } }
+    ])
+    vi.advanceTimersByTime(1_000)
+    appMetricsMock.mockReturnValue([{ pid: 1, type: 'Browser', memory: { workingSetSize: 0 } }])
+
+    expect(buildProcessGoneCrashDetails({}, 'renderer')).toMatchObject({
+      processMetricsPreGoneSampleAgeMs: 0,
+      processMetricsPreGoneRendererWorkingSetMB: 900
+    })
+  })
+
+  it('leaves records unflagged when the crashed bucket is still populated', () => {
+    appMetricsMock.mockReturnValue([
+      { pid: 21, type: 'Browser', memory: { workingSetSize: 1024 * 100 } },
+      { pid: 22, type: 'Tab', memory: { workingSetSize: 1024 * 400 } }
+    ])
+
+    const details = buildProcessGoneCrashDetails({ processType: 'renderer' }, 'renderer')
+    expect(details.processMetricsCrashedProcessAbsent).toBeUndefined()
+    expect(details.processMetricsRendererWorkingSetMB).toBe(400)
+  })
+
   it('adds process metrics to persisted crash details', () => {
     appMetricsMock.mockReturnValue([
       { pid: 21, type: 'Browser', memory: { workingSetSize: 1024 * 100 } },
       { pid: 22, type: 'Tab', memory: { workingSetSize: 1024 * 400 } }
     ])
 
-    expect(buildProcessGoneCrashDetails({ processType: 'renderer' })).toMatchObject({
+    expect(buildProcessGoneCrashDetails({ processType: 'renderer' }, 'renderer')).toMatchObject({
       processType: 'renderer',
       processMetricsCount: 2,
       processMetricsRendererWorkingSetMB: 400,

--- a/src/main/crash-reporting/process-gone-diagnostics.test.ts
+++ b/src/main/crash-reporting/process-gone-diagnostics.test.ts
@@ -289,10 +289,12 @@ describe('process gone diagnostics', () => {
     // the proof instead.
     vi.useFakeTimers()
     vi.setSystemTime(1_000_000)
+    // Guest enumerated BEFORE the crasher: Largest must carry the crasher's
+    // individual working set, never the renderer bucket's running sum.
     appMetricsMock.mockReturnValue([
       { pid: 100, type: 'Browser', memory: { workingSetSize: 1024 * 431 } },
-      { pid: 101, type: 'Tab', memory: { workingSetSize: 1024 * 4380 } },
-      { pid: 102, type: 'Tab', memory: { workingSetSize: 1024 * 300 } }
+      { pid: 102, type: 'Tab', memory: { workingSetSize: 1024 * 300 } },
+      { pid: 101, type: 'Tab', memory: { workingSetSize: 1024 * 4380 } }
     ])
     samplePreGoneProcessMetrics()
 
@@ -306,9 +308,13 @@ describe('process gone diagnostics', () => {
       processMetricsRendererCount: 1,
       processMetricsCrashedProcessAbsent: true,
       // The live bucket carries the surviving guest only; the crasher's size
-      // reaches the record through the PreGone mirrors.
+      // reaches the record through the PreGone mirrors: the bucket total sums
+      // crasher + guest, while Largest names the crasher's own size.
       processMetricsRendererWorkingSetMB: 300,
-      processMetricsPreGoneRendererWorkingSetMB: 4680
+      processMetricsPreGoneRendererWorkingSetMB: 4680,
+      processMetricsPreGoneLargestPid: 101,
+      processMetricsPreGoneLargestType: 'Tab',
+      processMetricsPreGoneLargestWorkingSetMB: 4380
     })
   })
 

--- a/src/main/crash-reporting/process-gone-diagnostics.test.ts
+++ b/src/main/crash-reporting/process-gone-diagnostics.test.ts
@@ -282,9 +282,11 @@ describe('process gone diagnostics', () => {
     expect(details.processMetricsPreGoneRendererPrivateMB).toBe(2900)
   })
 
-  it('proves crasher absence by vanished pid when a webview guest keeps the renderer bucket alive', () => {
-    // The common case: webviewTag guests / the dashboard popout leave surviving
-    // renderers, so the bucket count never hits zero for a main-window crash.
+  it('proves crasher absence when a webview guest keeps the renderer bucket alive', () => {
+    // The case that motivated the PR: webviewTag guests / the dashboard popout
+    // leave surviving renderers, so the bucket count never hits zero for a
+    // main-window crash — a sampled renderer pid missing from the live set is
+    // the proof instead.
     vi.useFakeTimers()
     vi.setSystemTime(1_000_000)
     appMetricsMock.mockReturnValue([
@@ -303,30 +305,14 @@ describe('process gone diagnostics', () => {
     expect(details).toMatchObject({
       processMetricsRendererCount: 1,
       processMetricsCrashedProcessAbsent: true,
-      processMetricsVanishedCount: 1,
-      processMetricsVanishedWorkingSetMB: 4380,
-      processMetricsVanishedPid: 101
+      // The live bucket carries the surviving guest only; the crasher's size
+      // reaches the record through the PreGone mirrors.
+      processMetricsRendererWorkingSetMB: 300,
+      processMetricsPreGoneRendererWorkingSetMB: 4680
     })
   })
 
-  it('sums multiple vanished same-bucket processes and drops the ambiguous pid', () => {
-    appMetricsMock.mockReturnValue([
-      { pid: 100, type: 'Browser', memory: { workingSetSize: 1024 * 400 } },
-      { pid: 101, type: 'Tab', memory: { workingSetSize: 1024 * 2000 } },
-      { pid: 102, type: 'Tab', memory: { workingSetSize: 1024 * 500 } }
-    ])
-    samplePreGoneProcessMetrics()
-    appMetricsMock.mockReturnValue([
-      { pid: 100, type: 'Browser', memory: { workingSetSize: 1024 * 400 } }
-    ])
-
-    const details = buildProcessGoneCrashDetails({}, 'renderer')
-    expect(details.processMetricsVanishedCount).toBe(2)
-    expect(details.processMetricsVanishedWorkingSetMB).toBe(2500)
-    expect(details.processMetricsVanishedPid).toBeUndefined()
-  })
-
-  it('counts a sampled renderer pid as vanished when the OS recycles it into another bucket', () => {
+  it('proves absence when the OS recycles the sampled renderer pid into another bucket', () => {
     // Pid reuse: the crasher's pid comes back as a NEW utility process inside
     // the sweep window. A bare live-pid set would read the crasher as alive.
     appMetricsMock.mockReturnValue([
@@ -342,204 +328,35 @@ describe('process gone diagnostics', () => {
     ])
 
     expect(buildProcessGoneCrashDetails({}, 'renderer')).toMatchObject({
-      processMetricsCrashedProcessAbsent: true,
-      processMetricsVanishedCount: 1,
-      processMetricsVanishedWorkingSetMB: 4380,
-      processMetricsVanishedPid: 101
+      processMetricsCrashedProcessAbsent: true
     })
   })
 
-  it('bounds an ambiguous vanished sum with the largest single vanished process', () => {
-    // Max in the MIDDLE: first-wins and last-wins aggregations both fail here.
-    appMetricsMock.mockReturnValue([
-      { pid: 101, type: 'Tab', memory: { workingSetSize: 1024 * 500 } },
-      { pid: 102, type: 'Tab', memory: { workingSetSize: 1024 * 2000 } },
-      { pid: 103, type: 'Tab', memory: { workingSetSize: 1024 * 800 } }
-    ])
-    samplePreGoneProcessMetrics()
-    appMetricsMock.mockReturnValue([
-      { pid: 100, type: 'Browser', memory: { workingSetSize: 1024 * 400 } }
-    ])
-
-    const details = buildProcessGoneCrashDetails({}, 'renderer')
-    expect(details.processMetricsVanishedWorkingSetMB).toBe(3300)
-    expect(details.processMetricsVanishedLargestWorkingSetMB).toBe(2000)
-  })
-
-  it('never re-attributes an already-reported vanished pid to a later crash', () => {
-    // Crash loop, no sweep in between: record #2 is for the RESPAWNED renderer
-    // (never sampled) — it must not inherit the first crasher's pid and size.
+  it('keeps reporting absence for every record of a crash loop', () => {
+    // Stateless proof: record #2 (the respawn dying before any sweep) makes
+    // the same true claim as record #1 — the crashed process is not in the
+    // live enumeration. No consume-once bookkeeping is involved.
     appMetricsMock.mockReturnValue([
       { pid: 200, type: 'Browser', memory: { workingSetSize: 1024 * 400 } },
-      { pid: 201, type: 'Tab', memory: { workingSetSize: 1024 * 5000 } }
-    ])
-    samplePreGoneProcessMetrics()
-    appMetricsMock.mockReturnValue([
-      { pid: 200, type: 'Browser', memory: { workingSetSize: 1024 * 400 } }
-    ])
-
-    const first = buildProcessGoneCrashDetails({}, 'renderer')
-    expect(first.processMetricsVanishedPid).toBe(201)
-    expect(first.processMetricsVanishedAlreadyReportedCount).toBeUndefined()
-
-    const second = buildProcessGoneCrashDetails({}, 'renderer')
-    expect(second.processMetricsVanishedCount).toBeUndefined()
-    expect(second.processMetricsVanishedPid).toBeUndefined()
-    // Absence still proven by the empty live renderer bucket.
-    expect(second.processMetricsCrashedProcessAbsent).toBe(true)
-    // Suppressed attribution is not "nothing vanished": the record says a
-    // prior report consumed the pid, so its PreGone mirrors are that era's.
-    expect(second.processMetricsVanishedAlreadyReportedCount).toBe(1)
-  })
-
-  it('marks a later vanished pid ambiguous once an earlier crash consumed part of the era', () => {
-    // Two sampled renderers; crash #1 consumes 201 and leaves an unsampled
-    // respawn. When 202 then vanishes before any sweep, the respawn is at
-    // least as plausible a crasher as 202 — the confident-looking pid must
-    // carry the same ambiguity flag as the blind era.
-    appMetricsMock.mockReturnValue([
       { pid: 201, type: 'Tab', memory: { workingSetSize: 1024 * 5000 } },
       { pid: 202, type: 'Tab', memory: { workingSetSize: 1024 * 300 } }
     ])
     samplePreGoneProcessMetrics()
+    // Guest 202 survives both crashes, so the bucket count never hits zero.
     appMetricsMock.mockReturnValue([
+      { pid: 200, type: 'Browser', memory: { workingSetSize: 1024 * 400 } },
       { pid: 202, type: 'Tab', memory: { workingSetSize: 1024 * 300 } }
     ])
 
-    const first = buildProcessGoneCrashDetails({}, 'renderer')
-    expect(first.processMetricsVanishedPid).toBe(201)
-    expect(first.processMetricsVanishedAmbiguousWithEarlierCrash).toBeUndefined()
-
-    appMetricsMock.mockReturnValue([])
-    const second = buildProcessGoneCrashDetails({}, 'renderer')
-    expect(second.processMetricsVanishedPid).toBe(202)
-    expect(second.processMetricsVanishedAlreadyReportedCount).toBe(1)
-    expect(second.processMetricsVanishedAmbiguousWithEarlierCrash).toBe(true)
+    expect(buildProcessGoneCrashDetails({}, 'renderer').processMetricsCrashedProcessAbsent).toBe(
+      true
+    )
+    expect(buildProcessGoneCrashDetails({}, 'renderer').processMetricsCrashedProcessAbsent).toBe(
+      true
+    )
   })
 
-  it('keeps consumed attribution suppressed across a failed sweep', () => {
-    // A failed sweep keeps the old sample, so it must keep the old
-    // attribution state too — clearing here would resurrect the crash-loop
-    // misattribution the consume-once set exists to prevent.
-    appMetricsMock.mockReturnValue([
-      { pid: 201, type: 'Tab', memory: { workingSetSize: 1024 * 5000 } }
-    ])
-    samplePreGoneProcessMetrics()
-    appMetricsMock.mockReturnValue([])
-    expect(buildProcessGoneCrashDetails({}, 'renderer')).toMatchObject({
-      processMetricsVanishedPid: 201
-    })
-
-    appMetricsMock.mockImplementationOnce(() => {
-      throw new Error('metrics unavailable')
-    })
-    samplePreGoneProcessMetrics()
-    appMetricsMock.mockReturnValue([])
-
-    const second = buildProcessGoneCrashDetails({}, 'renderer')
-    expect(second.processMetricsVanishedPid).toBeUndefined()
-    expect(second.processMetricsVanishedAlreadyReportedCount).toBe(1)
-  })
-
-  it('marks vanished attribution ambiguous after a metrics-blind crash in the same era', () => {
-    // Consume-once only consumes when the gone-time read succeeds: a crash
-    // recorded blind (getAppMetrics threw) leaves its pid unconsumed, so a
-    // later record's Vanished numbers may describe THAT crash — say so.
-    appMetricsMock.mockReturnValue([
-      { pid: 201, type: 'Tab', memory: { workingSetSize: 1024 * 5000 } }
-    ])
-    samplePreGoneProcessMetrics()
-    appMetricsMock.mockImplementationOnce(() => {
-      throw new Error('metrics unavailable')
-    })
-    expect(buildProcessGoneCrashDetails({}, 'renderer').processMetricsError).toBe('Error')
-
-    appMetricsMock.mockReturnValue([])
-    const second = buildProcessGoneCrashDetails({}, 'renderer')
-    expect(second.processMetricsVanishedPid).toBe(201)
-    expect(second.processMetricsVanishedAmbiguousWithEarlierCrash).toBe(true)
-
-    // A fresh sweep starts a clean era: attribution is confident again.
-    appMetricsMock.mockReturnValue([
-      { pid: 301, type: 'Tab', memory: { workingSetSize: 1024 * 800 } }
-    ])
-    samplePreGoneProcessMetrics()
-    appMetricsMock.mockReturnValue([])
-    const third = buildProcessGoneCrashDetails({}, 'renderer')
-    expect(third.processMetricsVanishedPid).toBe(301)
-    expect(third.processMetricsVanishedAmbiguousWithEarlierCrash).toBeUndefined()
-  })
-
-  it('scopes the blind-crash ambiguity to the crashed bucket', () => {
-    // A blind Utility crash says nothing about renderer attribution.
-    appMetricsMock.mockReturnValue([
-      { pid: 201, type: 'Tab', memory: { workingSetSize: 1024 * 5000 } },
-      { pid: 210, type: 'Utility', memory: { workingSetSize: 1024 * 80 } }
-    ])
-    samplePreGoneProcessMetrics()
-    appMetricsMock.mockImplementationOnce(() => {
-      throw new Error('metrics unavailable')
-    })
-    buildProcessGoneCrashDetails({}, 'Utility')
-
-    appMetricsMock.mockReturnValue([
-      { pid: 210, type: 'Utility', memory: { workingSetSize: 1024 * 80 } }
-    ])
-    const details = buildProcessGoneCrashDetails({}, 'renderer')
-    expect(details.processMetricsVanishedPid).toBe(201)
-    expect(details.processMetricsVanishedAmbiguousWithEarlierCrash).toBeUndefined()
-  })
-
-  it('consumes an ambiguous vanished pair so a later record never repeats its sum', () => {
-    appMetricsMock.mockReturnValue([
-      { pid: 101, type: 'Tab', memory: { workingSetSize: 1024 * 2000 } },
-      { pid: 102, type: 'Tab', memory: { workingSetSize: 1024 * 500 } }
-    ])
-    samplePreGoneProcessMetrics()
-    appMetricsMock.mockReturnValue([])
-
-    expect(buildProcessGoneCrashDetails({}, 'renderer')).toMatchObject({
-      processMetricsVanishedCount: 2,
-      processMetricsVanishedWorkingSetMB: 2500
-    })
-
-    // The ambiguous pair was reported once (count + sum + largest); a second
-    // record repeating those numbers would double-report the same exits.
-    const second = buildProcessGoneCrashDetails({}, 'renderer')
-    expect(second.processMetricsVanishedCount).toBeUndefined()
-    expect(second.processMetricsVanishedWorkingSetMB).toBeUndefined()
-    expect(second.processMetricsVanishedLargestWorkingSetMB).toBeUndefined()
-    expect(second.processMetricsVanishedAlreadyReportedCount).toBe(2)
-  })
-
-  it('re-arms vanished attribution when a fresh sweep samples the pid alive again', () => {
-    // Attribution belongs to the sample it came from: once a new sweep sees
-    // the pid alive (respawn or recycle), a later disappearance is reportable.
-    appMetricsMock.mockReturnValue([
-      { pid: 201, type: 'Tab', memory: { workingSetSize: 1024 * 1000 } }
-    ])
-    samplePreGoneProcessMetrics()
-    appMetricsMock.mockReturnValue([])
-    expect(buildProcessGoneCrashDetails({}, 'renderer')).toMatchObject({
-      processMetricsVanishedPid: 201
-    })
-
-    appMetricsMock.mockReturnValue([
-      { pid: 201, type: 'Tab', memory: { workingSetSize: 1024 * 1500 } }
-    ])
-    samplePreGoneProcessMetrics()
-    appMetricsMock.mockReturnValue([])
-
-    const details = buildProcessGoneCrashDetails({}, 'renderer')
-    expect(details).toMatchObject({
-      processMetricsVanishedPid: 201,
-      processMetricsVanishedWorkingSetMB: 1500
-    })
-    // Fresh sweep = fresh era: no stale "already reported" residue.
-    expect(details.processMetricsVanishedAlreadyReportedCount).toBeUndefined()
-  })
-
-  it('claims neither absence nor vanished pids when gone-time metrics are unreadable', () => {
+  it('claims no absence when gone-time metrics are unreadable', () => {
     appMetricsMock.mockReturnValue([
       { pid: 300, type: 'Tab', memory: { workingSetSize: 1024 * 900 } }
     ])
@@ -550,14 +367,13 @@ describe('process gone diagnostics', () => {
 
     const details = buildProcessGoneCrashDetails({}, 'renderer')
     expect(details.processMetricsError).toBe('Error')
-    // Unreadable metrics prove nothing: no absence flag, no vanished claims.
+    // Unreadable metrics prove nothing: no absence flag.
     expect(details.processMetricsCrashedProcessAbsent).toBeUndefined()
-    expect(details.processMetricsVanishedCount).toBeUndefined()
     // The cached pre-gone sample still reaches the record.
     expect(details.processMetricsPreGoneRendererWorkingSetMB).toBe(900)
   })
 
-  it('never counts a sampled pid-less metric as vanished', () => {
+  it('never lets a sampled pid-less metric prove absence', () => {
     appMetricsMock.mockReturnValue([
       { type: 'Tab', memory: { workingSetSize: 1024 * 50 } },
       { pid: 400, type: 'Tab', memory: { workingSetSize: 1024 * 100 } }
@@ -567,29 +383,26 @@ describe('process gone diagnostics', () => {
       { pid: 400, type: 'Tab', memory: { workingSetSize: 1024 * 100 } }
     ])
 
-    const details = buildProcessGoneCrashDetails({}, 'renderer')
-    expect(details.processMetricsVanishedCount).toBeUndefined()
-    expect(details.processMetricsCrashedProcessAbsent).toBeUndefined()
+    expect(
+      buildProcessGoneCrashDetails({}, 'renderer').processMetricsCrashedProcessAbsent
+    ).toBeUndefined()
   })
 
-  it('ignores vanished processes outside the crashed bucket', () => {
+  it('ignores an out-of-bucket vanish when the crashed bucket is intact', () => {
     appMetricsMock.mockReturnValue([
       { pid: 100, type: 'Tab', memory: { workingSetSize: 1024 * 600 } },
       { pid: 110, type: 'Utility', memory: { workingSetSize: 1024 * 80 } }
     ])
     samplePreGoneProcessMetrics()
     // The Utility vanished, but the crash under report is a renderer whose
-    // process is still enumerable — no absence claim, no Vanished fields.
+    // process is still enumerable — no absence claim.
     appMetricsMock.mockReturnValue([
       { pid: 100, type: 'Tab', memory: { workingSetSize: 1024 * 600 } }
     ])
 
-    const details = buildProcessGoneCrashDetails({}, 'renderer')
-    expect(details.processMetricsCrashedProcessAbsent).toBeUndefined()
-    expect(details.processMetricsVanishedCount).toBeUndefined()
-    expect(details.processMetricsVanishedWorkingSetMB).toBeUndefined()
-    // Out-of-bucket and still-alive exclusions are not "already reported".
-    expect(details.processMetricsVanishedAlreadyReportedCount).toBeUndefined()
+    expect(
+      buildProcessGoneCrashDetails({}, 'renderer').processMetricsCrashedProcessAbsent
+    ).toBeUndefined()
   })
 
   it('degrades honestly in a crash loop when the sweep lands between death and respawn', () => {
@@ -611,7 +424,7 @@ describe('process gone diagnostics', () => {
     ])
     expect(buildProcessGoneCrashDetails({}, 'renderer')).toMatchObject({
       processMetricsPreGoneRendererWorkingSetMB: 5000,
-      processMetricsVanishedPid: 201
+      processMetricsCrashedProcessAbsent: true
     })
 
     // Sweep lands while the renderer is dead, overwriting the sample.

--- a/src/main/crash-reporting/process-gone-diagnostics.test.ts
+++ b/src/main/crash-reporting/process-gone-diagnostics.test.ts
@@ -62,6 +62,16 @@ describe('process gone diagnostics', () => {
     })
   })
 
+  it('keeps the first-enumerated process as Largest on an exact working-set tie', () => {
+    // Pins the > tie-break: >= would silently crown the last-enumerated tie.
+    const details = collectProcessGoneMetricDetails([
+      { pid: 10, type: 'Tab', memory: { workingSetSize: 1024 * 500 } },
+      { pid: 11, type: 'GPU', memory: { workingSetSize: 1024 * 500 } }
+    ])
+    expect(details.processMetricsLargestPid).toBe(10)
+    expect(details.processMetricsLargestType).toBe('Tab')
+  })
+
   it('flags a renderer-gone record whose live metrics carry only survivors', () => {
     // Field repro (report caf677f2): render-process-gone fires after the OS
     // process exits, so getAppMetrics() enumerates survivors only.
@@ -380,6 +390,31 @@ describe('process gone diagnostics', () => {
     // Suppressed attribution is not "nothing vanished": the record says a
     // prior report consumed the pid, so its PreGone mirrors are that era's.
     expect(second.processMetricsVanishedAlreadyReportedCount).toBe(1)
+  })
+
+  it('marks a later vanished pid ambiguous once an earlier crash consumed part of the era', () => {
+    // Two sampled renderers; crash #1 consumes 201 and leaves an unsampled
+    // respawn. When 202 then vanishes before any sweep, the respawn is at
+    // least as plausible a crasher as 202 — the confident-looking pid must
+    // carry the same ambiguity flag as the blind era.
+    appMetricsMock.mockReturnValue([
+      { pid: 201, type: 'Tab', memory: { workingSetSize: 1024 * 5000 } },
+      { pid: 202, type: 'Tab', memory: { workingSetSize: 1024 * 300 } }
+    ])
+    samplePreGoneProcessMetrics()
+    appMetricsMock.mockReturnValue([
+      { pid: 202, type: 'Tab', memory: { workingSetSize: 1024 * 300 } }
+    ])
+
+    const first = buildProcessGoneCrashDetails({}, 'renderer')
+    expect(first.processMetricsVanishedPid).toBe(201)
+    expect(first.processMetricsVanishedAmbiguousWithEarlierCrash).toBeUndefined()
+
+    appMetricsMock.mockReturnValue([])
+    const second = buildProcessGoneCrashDetails({}, 'renderer')
+    expect(second.processMetricsVanishedPid).toBe(202)
+    expect(second.processMetricsVanishedAlreadyReportedCount).toBe(1)
+    expect(second.processMetricsVanishedAmbiguousWithEarlierCrash).toBe(true)
   })
 
   it('keeps consumed attribution suppressed across a failed sweep', () => {

--- a/src/main/crash-reporting/process-gone-diagnostics.test.ts
+++ b/src/main/crash-reporting/process-gone-diagnostics.test.ts
@@ -10,7 +10,7 @@ import {
 import { setSystemMemoryInfoReaderForTest } from './gone-time-system-memory'
 
 type MetricFixture = {
-  pid: number
+  pid?: number
   type: string
   memory: { workingSetSize: number; peakWorkingSetSize?: number; privateBytes?: number }
 }
@@ -317,6 +317,126 @@ describe('process gone diagnostics', () => {
     expect(details.processMetricsVanishedPid).toBeUndefined()
   })
 
+  it('counts a sampled renderer pid as vanished when the OS recycles it into another bucket', () => {
+    // Pid reuse: the crasher's pid comes back as a NEW utility process inside
+    // the sweep window. A bare live-pid set would read the crasher as alive.
+    appMetricsMock.mockReturnValue([
+      { pid: 100, type: 'Browser', memory: { workingSetSize: 1024 * 400 } },
+      { pid: 101, type: 'Tab', memory: { workingSetSize: 1024 * 4380 } },
+      { pid: 102, type: 'Tab', memory: { workingSetSize: 1024 * 300 } }
+    ])
+    samplePreGoneProcessMetrics()
+    appMetricsMock.mockReturnValue([
+      { pid: 100, type: 'Browser', memory: { workingSetSize: 1024 * 400 } },
+      { pid: 101, type: 'Utility', memory: { workingSetSize: 1024 * 40 } },
+      { pid: 102, type: 'Tab', memory: { workingSetSize: 1024 * 300 } }
+    ])
+
+    expect(buildProcessGoneCrashDetails({}, 'renderer')).toMatchObject({
+      processMetricsCrashedProcessAbsent: true,
+      processMetricsVanishedCount: 1,
+      processMetricsVanishedWorkingSetMB: 4380,
+      processMetricsVanishedPid: 101
+    })
+  })
+
+  it('bounds an ambiguous vanished sum with the largest single vanished process', () => {
+    // Max in the MIDDLE: first-wins and last-wins aggregations both fail here.
+    appMetricsMock.mockReturnValue([
+      { pid: 101, type: 'Tab', memory: { workingSetSize: 1024 * 500 } },
+      { pid: 102, type: 'Tab', memory: { workingSetSize: 1024 * 2000 } },
+      { pid: 103, type: 'Tab', memory: { workingSetSize: 1024 * 800 } }
+    ])
+    samplePreGoneProcessMetrics()
+    appMetricsMock.mockReturnValue([
+      { pid: 100, type: 'Browser', memory: { workingSetSize: 1024 * 400 } }
+    ])
+
+    const details = buildProcessGoneCrashDetails({}, 'renderer')
+    expect(details.processMetricsVanishedWorkingSetMB).toBe(3300)
+    expect(details.processMetricsVanishedLargestWorkingSetMB).toBe(2000)
+  })
+
+  it('never re-attributes an already-reported vanished pid to a later crash', () => {
+    // Crash loop, no sweep in between: record #2 is for the RESPAWNED renderer
+    // (never sampled) — it must not inherit the first crasher's pid and size.
+    appMetricsMock.mockReturnValue([
+      { pid: 200, type: 'Browser', memory: { workingSetSize: 1024 * 400 } },
+      { pid: 201, type: 'Tab', memory: { workingSetSize: 1024 * 5000 } }
+    ])
+    samplePreGoneProcessMetrics()
+    appMetricsMock.mockReturnValue([
+      { pid: 200, type: 'Browser', memory: { workingSetSize: 1024 * 400 } }
+    ])
+
+    expect(buildProcessGoneCrashDetails({}, 'renderer')).toMatchObject({
+      processMetricsVanishedPid: 201
+    })
+
+    const second = buildProcessGoneCrashDetails({}, 'renderer')
+    expect(second.processMetricsVanishedCount).toBeUndefined()
+    expect(second.processMetricsVanishedPid).toBeUndefined()
+    // Absence still proven by the empty live renderer bucket.
+    expect(second.processMetricsCrashedProcessAbsent).toBe(true)
+  })
+
+  it('re-arms vanished attribution when a fresh sweep samples the pid alive again', () => {
+    // Attribution belongs to the sample it came from: once a new sweep sees
+    // the pid alive (respawn or recycle), a later disappearance is reportable.
+    appMetricsMock.mockReturnValue([
+      { pid: 201, type: 'Tab', memory: { workingSetSize: 1024 * 1000 } }
+    ])
+    samplePreGoneProcessMetrics()
+    appMetricsMock.mockReturnValue([])
+    expect(buildProcessGoneCrashDetails({}, 'renderer')).toMatchObject({
+      processMetricsVanishedPid: 201
+    })
+
+    appMetricsMock.mockReturnValue([
+      { pid: 201, type: 'Tab', memory: { workingSetSize: 1024 * 1500 } }
+    ])
+    samplePreGoneProcessMetrics()
+    appMetricsMock.mockReturnValue([])
+
+    expect(buildProcessGoneCrashDetails({}, 'renderer')).toMatchObject({
+      processMetricsVanishedPid: 201,
+      processMetricsVanishedWorkingSetMB: 1500
+    })
+  })
+
+  it('claims neither absence nor vanished pids when gone-time metrics are unreadable', () => {
+    appMetricsMock.mockReturnValue([
+      { pid: 300, type: 'Tab', memory: { workingSetSize: 1024 * 900 } }
+    ])
+    samplePreGoneProcessMetrics()
+    appMetricsMock.mockImplementationOnce(() => {
+      throw new Error('metrics unavailable')
+    })
+
+    const details = buildProcessGoneCrashDetails({}, 'renderer')
+    expect(details.processMetricsError).toBe('Error')
+    // Unreadable metrics prove nothing: no absence flag, no vanished claims.
+    expect(details.processMetricsCrashedProcessAbsent).toBeUndefined()
+    expect(details.processMetricsVanishedCount).toBeUndefined()
+    // The cached pre-gone sample still reaches the record.
+    expect(details.processMetricsPreGoneRendererWorkingSetMB).toBe(900)
+  })
+
+  it('never counts a sampled pid-less metric as vanished', () => {
+    appMetricsMock.mockReturnValue([
+      { type: 'Tab', memory: { workingSetSize: 1024 * 50 } },
+      { pid: 400, type: 'Tab', memory: { workingSetSize: 1024 * 100 } }
+    ])
+    samplePreGoneProcessMetrics()
+    appMetricsMock.mockReturnValue([
+      { pid: 400, type: 'Tab', memory: { workingSetSize: 1024 * 100 } }
+    ])
+
+    const details = buildProcessGoneCrashDetails({}, 'renderer')
+    expect(details.processMetricsVanishedCount).toBeUndefined()
+    expect(details.processMetricsCrashedProcessAbsent).toBeUndefined()
+  })
+
   it('ignores vanished processes outside the crashed bucket', () => {
     appMetricsMock.mockReturnValue([
       { pid: 100, type: 'Tab', memory: { workingSetSize: 1024 * 600 } },
@@ -379,6 +499,31 @@ describe('process gone diagnostics', () => {
     expect(details.processMetricsRendererWorkingSetMB).toBe(100)
   })
 
+  it('clamps a garbage negative renderer peak to zero', () => {
+    const details = collectProcessGoneMetricDetails([
+      {
+        pid: 10,
+        type: 'Tab',
+        memory: { workingSetSize: 1024 * 10, peakWorkingSetSize: -1024 * 90 }
+      }
+    ])
+    expect(details.processMetricsRendererPeakWorkingSetMB).toBe(0)
+  })
+
+  it('clamps garbage negative system memory to zero', () => {
+    setSystemMemoryInfoReaderForTest(() => ({ free: -1024 * 10, total: 1024 * 16_384 }))
+    const details = buildProcessGoneCrashDetails({}, 'renderer')
+    expect(details.systemMemoryFreeMB).toBe(0)
+    expect(details.systemMemoryTotalMB).toBe(16_384)
+  })
+
+  it('rounds working sets to the nearest MB', () => {
+    const details = collectProcessGoneMetricDetails([
+      { pid: 10, type: 'Tab', memory: { workingSetSize: 1024 * 200 + 700 } }
+    ])
+    expect(details.processMetricsRendererWorkingSetMB).toBe(201)
+  })
+
   it('clamps the pre-gone sample age when the clock moves backwards', () => {
     vi.useFakeTimers()
     vi.setSystemTime(100_000)
@@ -393,12 +538,31 @@ describe('process gone diagnostics', () => {
     })
   })
 
-  it('lets live metrics win over a colliding key in the incoming details', () => {
+  it('lets every metrics-owned key family win over colliding incoming details', () => {
+    // Precedence must hold per family — live buckets, system memory, PreGone
+    // mirrors, and the absence flag are all written after the incoming spread.
+    appMetricsMock.mockReturnValue([
+      { pid: 30, type: 'Tab', memory: { workingSetSize: 1024 * 100 } }
+    ])
+    samplePreGoneProcessMetrics()
     appMetricsMock.mockReturnValue([
       { pid: 21, type: 'Browser', memory: { workingSetSize: 1024 * 100 } }
     ])
-    const details = buildProcessGoneCrashDetails({ processMetricsCount: 999 }, 'renderer')
+    setSystemMemoryInfoReaderForTest(() => ({ free: 1024 * 500 }))
+
+    const details = buildProcessGoneCrashDetails(
+      {
+        processMetricsCount: 999,
+        systemMemoryFreeMB: 999_999,
+        processMetricsPreGoneRendererWorkingSetMB: 999_999,
+        processMetricsCrashedProcessAbsent: false
+      },
+      'renderer'
+    )
     expect(details.processMetricsCount).toBe(1)
+    expect(details.systemMemoryFreeMB).toBe(500)
+    expect(details.processMetricsPreGoneRendererWorkingSetMB).toBe(100)
+    expect(details.processMetricsCrashedProcessAbsent).toBe(true)
   })
 
   it("arms an unref'd interval so sampling never holds the event loop open", () => {

--- a/src/main/crash-reporting/process-gone-diagnostics.test.ts
+++ b/src/main/crash-reporting/process-gone-diagnostics.test.ts
@@ -5,9 +5,9 @@ import {
   collectProcessGoneMetricDetails,
   resetPreGoneProcessMetricsSamplingForTest,
   samplePreGoneProcessMetrics,
-  setSystemMemoryInfoReaderForTest,
   startPreGoneProcessMetricsSampling
 } from './process-gone-diagnostics'
+import { setSystemMemoryInfoReaderForTest } from './gone-time-system-memory'
 
 type MetricFixture = {
   pid: number
@@ -187,8 +187,19 @@ describe('process gone diagnostics', () => {
           privateBytes: 1024 * 8000
         }
       },
+      // Max peak/private sit on the MIDDLE renderer: first-wins and last-wins
+      // aggregation bugs both fail here, only a true max passes.
       {
         pid: 11,
+        type: 'Tab',
+        memory: {
+          workingSetSize: 1024 * 300,
+          peakWorkingSetSize: 1024 * 350,
+          privateBytes: 1024 * 280
+        }
+      },
+      {
+        pid: 12,
         type: 'Tab',
         memory: {
           workingSetSize: 1024 * 800,
@@ -197,9 +208,13 @@ describe('process gone diagnostics', () => {
         }
       },
       {
-        pid: 12,
+        pid: 13,
         type: 'Tab',
-        memory: { workingSetSize: 1024 * 300, peakWorkingSetSize: 1024 * 350 }
+        memory: {
+          workingSetSize: 1024 * 400,
+          peakWorkingSetSize: 1024 * 900,
+          privateBytes: 1024 * 700
+        }
       }
     ])
 
@@ -256,6 +271,146 @@ describe('process gone diagnostics', () => {
     expect(details.processMetricsRendererPrivateMB).toBeUndefined()
     expect(details.processMetricsPreGoneRendererPeakWorkingSetMB).toBe(3300)
     expect(details.processMetricsPreGoneRendererPrivateMB).toBe(2900)
+  })
+
+  it('proves crasher absence by vanished pid when a webview guest keeps the renderer bucket alive', () => {
+    // The common case: webviewTag guests / the dashboard popout leave surviving
+    // renderers, so the bucket count never hits zero for a main-window crash.
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000_000)
+    appMetricsMock.mockReturnValue([
+      { pid: 100, type: 'Browser', memory: { workingSetSize: 1024 * 431 } },
+      { pid: 101, type: 'Tab', memory: { workingSetSize: 1024 * 4380 } },
+      { pid: 102, type: 'Tab', memory: { workingSetSize: 1024 * 300 } }
+    ])
+    samplePreGoneProcessMetrics()
+
+    appMetricsMock.mockReturnValue([
+      { pid: 100, type: 'Browser', memory: { workingSetSize: 1024 * 431 } },
+      { pid: 102, type: 'Tab', memory: { workingSetSize: 1024 * 300 } }
+    ])
+
+    const details = buildProcessGoneCrashDetails({}, 'renderer')
+    expect(details).toMatchObject({
+      processMetricsRendererCount: 1,
+      processMetricsCrashedProcessAbsent: true,
+      processMetricsVanishedCount: 1,
+      processMetricsVanishedWorkingSetMB: 4380,
+      processMetricsVanishedPid: 101
+    })
+  })
+
+  it('sums multiple vanished same-bucket processes and drops the ambiguous pid', () => {
+    appMetricsMock.mockReturnValue([
+      { pid: 100, type: 'Browser', memory: { workingSetSize: 1024 * 400 } },
+      { pid: 101, type: 'Tab', memory: { workingSetSize: 1024 * 2000 } },
+      { pid: 102, type: 'Tab', memory: { workingSetSize: 1024 * 500 } }
+    ])
+    samplePreGoneProcessMetrics()
+    appMetricsMock.mockReturnValue([
+      { pid: 100, type: 'Browser', memory: { workingSetSize: 1024 * 400 } }
+    ])
+
+    const details = buildProcessGoneCrashDetails({}, 'renderer')
+    expect(details.processMetricsVanishedCount).toBe(2)
+    expect(details.processMetricsVanishedWorkingSetMB).toBe(2500)
+    expect(details.processMetricsVanishedPid).toBeUndefined()
+  })
+
+  it('ignores vanished processes outside the crashed bucket', () => {
+    appMetricsMock.mockReturnValue([
+      { pid: 100, type: 'Tab', memory: { workingSetSize: 1024 * 600 } },
+      { pid: 110, type: 'Utility', memory: { workingSetSize: 1024 * 80 } }
+    ])
+    samplePreGoneProcessMetrics()
+    // The Utility vanished, but the crash under report is a renderer whose
+    // process is still enumerable — no absence claim, no Vanished fields.
+    appMetricsMock.mockReturnValue([
+      { pid: 100, type: 'Tab', memory: { workingSetSize: 1024 * 600 } }
+    ])
+
+    const details = buildProcessGoneCrashDetails({}, 'renderer')
+    expect(details.processMetricsCrashedProcessAbsent).toBeUndefined()
+    expect(details.processMetricsVanishedCount).toBeUndefined()
+    expect(details.processMetricsVanishedWorkingSetMB).toBeUndefined()
+  })
+
+  it('degrades honestly in a crash loop when the sweep lands between death and respawn', () => {
+    // Crash-loop reality check: if a sweep fires while the renderer is dead,
+    // the next crash record cannot recover the first crasher's size — but it
+    // must say so (zero PreGone renderer fields), never report a stale value
+    // as if it were the second crasher's.
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    appMetricsMock.mockReturnValue([
+      { pid: 200, type: 'Browser', memory: { workingSetSize: 1024 * 400 } },
+      { pid: 201, type: 'Tab', memory: { workingSetSize: 1024 * 5000 } }
+    ])
+    samplePreGoneProcessMetrics()
+
+    // First death: record #1 carries the true pre-death size.
+    appMetricsMock.mockReturnValue([
+      { pid: 200, type: 'Browser', memory: { workingSetSize: 1024 * 400 } }
+    ])
+    expect(buildProcessGoneCrashDetails({}, 'renderer')).toMatchObject({
+      processMetricsPreGoneRendererWorkingSetMB: 5000,
+      processMetricsVanishedPid: 201
+    })
+
+    // Sweep lands while the renderer is dead, overwriting the sample.
+    vi.setSystemTime(60_000)
+    samplePreGoneProcessMetrics()
+
+    // Second death (respawned pid 202 crashes before any further sweep).
+    vi.setSystemTime(62_000)
+    expect(buildProcessGoneCrashDetails({}, 'renderer')).toMatchObject({
+      processMetricsCrashedProcessAbsent: true,
+      processMetricsPreGoneRendererCount: 0,
+      processMetricsPreGoneRendererWorkingSetMB: 0,
+      processMetricsPreGoneSampleAgeMs: 2_000
+    })
+  })
+
+  it('clamps a garbage negative working set to zero', () => {
+    const details = collectProcessGoneMetricDetails([
+      { pid: 10, type: 'Tab', memory: { workingSetSize: -1024 * 50 } },
+      { pid: 11, type: 'Tab', memory: { workingSetSize: 1024 * 100 } }
+    ])
+    expect(details.processMetricsRendererWorkingSetMB).toBe(100)
+  })
+
+  it('clamps the pre-gone sample age when the clock moves backwards', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(100_000)
+    appMetricsMock.mockReturnValue([
+      { pid: 10, type: 'Tab', memory: { workingSetSize: 1024 * 100 } }
+    ])
+    samplePreGoneProcessMetrics()
+    vi.setSystemTime(95_000)
+
+    expect(buildProcessGoneCrashDetails({}, 'renderer')).toMatchObject({
+      processMetricsPreGoneSampleAgeMs: 0
+    })
+  })
+
+  it('lets live metrics win over a colliding key in the incoming details', () => {
+    appMetricsMock.mockReturnValue([
+      { pid: 21, type: 'Browser', memory: { workingSetSize: 1024 * 100 } }
+    ])
+    const details = buildProcessGoneCrashDetails({ processMetricsCount: 999 }, 'renderer')
+    expect(details.processMetricsCount).toBe(1)
+  })
+
+  it("arms an unref'd interval so sampling never holds the event loop open", () => {
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval')
+    try {
+      startPreGoneProcessMetricsSampling(60_000)
+      const timer = setIntervalSpy.mock.results[0]?.value as NodeJS.Timeout
+      expect(timer.hasRef()).toBe(false)
+    } finally {
+      setIntervalSpy.mockRestore()
+      resetPreGoneProcessMetricsSamplingForTest()
+    }
   })
 
   it('reports macOS-shaped system memory and omits the fields macOS lacks', () => {

--- a/src/main/crash-reporting/process-gone-diagnostics.test.ts
+++ b/src/main/crash-reporting/process-gone-diagnostics.test.ts
@@ -192,6 +192,57 @@ describe('process gone diagnostics', () => {
     })
   })
 
+  it('keeps plain-prefix peak/private live-only while PreGone carries the cached values', () => {
+    // Era invariant: plain prefix = sampled at gone time (survivors), PreGone
+    // prefix = cached pre-death sample. Neither may leak into the other.
+    appMetricsMock.mockReturnValue([
+      {
+        pid: 50,
+        type: 'Tab',
+        memory: {
+          workingSetSize: 1024 * 3000,
+          peakWorkingSetSize: 1024 * 3300,
+          privateBytes: 1024 * 2900
+        }
+      }
+    ])
+    samplePreGoneProcessMetrics()
+    appMetricsMock.mockReturnValue([
+      {
+        pid: 51,
+        type: 'Tab',
+        memory: { workingSetSize: 1024 * 90, peakWorkingSetSize: 1024 * 120 }
+      }
+    ])
+
+    const details = buildProcessGoneCrashDetails({}, 'renderer')
+    expect(details.processMetricsRendererPeakWorkingSetMB).toBe(120)
+    expect(details.processMetricsRendererPrivateMB).toBeUndefined()
+    expect(details.processMetricsPreGoneRendererPeakWorkingSetMB).toBe(3300)
+    expect(details.processMetricsPreGoneRendererPrivateMB).toBe(2900)
+  })
+
+  it('reports macOS-shaped system memory and omits the fields macOS lacks', () => {
+    // macOS getSystemMemoryInfo() has no swap fields; fileBacked/purgeable are
+    // its only reclaimability proxy. Verified on Electron 43.1.0.
+    setSystemMemoryInfoReaderForTest(() => ({
+      total: 1024 * 65_536,
+      free: 1024 * 59,
+      fileBacked: 1024 * 21_000,
+      purgeable: 1024 * 1_800
+    }))
+
+    const details = buildProcessGoneCrashDetails({}, 'renderer')
+    expect(details).toMatchObject({
+      systemMemoryTotalMB: 65_536,
+      systemMemoryFreeMB: 59,
+      systemMemoryFileBackedMB: 21_000,
+      systemMemoryPurgeableMB: 1_800
+    })
+    expect(details.systemMemorySwapTotalMB).toBeUndefined()
+    expect(details.systemMemorySwapFreeMB).toBeUndefined()
+  })
+
   it('samples system memory at gone time but never into the pre-gone snapshot', () => {
     appMetricsMock.mockReturnValue([{ pid: 1, type: 'Browser', memory: { workingSetSize: 0 } }])
     samplePreGoneProcessMetrics()

--- a/src/main/crash-reporting/process-gone-diagnostics.test.ts
+++ b/src/main/crash-reporting/process-gone-diagnostics.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   buildProcessGoneCrashDetails,
-  buildSuppressedProcessGoneBreadcrumbData,
   collectProcessGoneMetricDetails,
   resetPreGoneProcessMetricsSamplingForTest,
   samplePreGoneProcessMetrics,
@@ -369,15 +368,113 @@ describe('process gone diagnostics', () => {
       { pid: 200, type: 'Browser', memory: { workingSetSize: 1024 * 400 } }
     ])
 
-    expect(buildProcessGoneCrashDetails({}, 'renderer')).toMatchObject({
-      processMetricsVanishedPid: 201
-    })
+    const first = buildProcessGoneCrashDetails({}, 'renderer')
+    expect(first.processMetricsVanishedPid).toBe(201)
+    expect(first.processMetricsVanishedAlreadyReportedCount).toBeUndefined()
 
     const second = buildProcessGoneCrashDetails({}, 'renderer')
     expect(second.processMetricsVanishedCount).toBeUndefined()
     expect(second.processMetricsVanishedPid).toBeUndefined()
     // Absence still proven by the empty live renderer bucket.
     expect(second.processMetricsCrashedProcessAbsent).toBe(true)
+    // Suppressed attribution is not "nothing vanished": the record says a
+    // prior report consumed the pid, so its PreGone mirrors are that era's.
+    expect(second.processMetricsVanishedAlreadyReportedCount).toBe(1)
+  })
+
+  it('keeps consumed attribution suppressed across a failed sweep', () => {
+    // A failed sweep keeps the old sample, so it must keep the old
+    // attribution state too — clearing here would resurrect the crash-loop
+    // misattribution the consume-once set exists to prevent.
+    appMetricsMock.mockReturnValue([
+      { pid: 201, type: 'Tab', memory: { workingSetSize: 1024 * 5000 } }
+    ])
+    samplePreGoneProcessMetrics()
+    appMetricsMock.mockReturnValue([])
+    expect(buildProcessGoneCrashDetails({}, 'renderer')).toMatchObject({
+      processMetricsVanishedPid: 201
+    })
+
+    appMetricsMock.mockImplementationOnce(() => {
+      throw new Error('metrics unavailable')
+    })
+    samplePreGoneProcessMetrics()
+    appMetricsMock.mockReturnValue([])
+
+    const second = buildProcessGoneCrashDetails({}, 'renderer')
+    expect(second.processMetricsVanishedPid).toBeUndefined()
+    expect(second.processMetricsVanishedAlreadyReportedCount).toBe(1)
+  })
+
+  it('marks vanished attribution ambiguous after a metrics-blind crash in the same era', () => {
+    // Consume-once only consumes when the gone-time read succeeds: a crash
+    // recorded blind (getAppMetrics threw) leaves its pid unconsumed, so a
+    // later record's Vanished numbers may describe THAT crash — say so.
+    appMetricsMock.mockReturnValue([
+      { pid: 201, type: 'Tab', memory: { workingSetSize: 1024 * 5000 } }
+    ])
+    samplePreGoneProcessMetrics()
+    appMetricsMock.mockImplementationOnce(() => {
+      throw new Error('metrics unavailable')
+    })
+    expect(buildProcessGoneCrashDetails({}, 'renderer').processMetricsError).toBe('Error')
+
+    appMetricsMock.mockReturnValue([])
+    const second = buildProcessGoneCrashDetails({}, 'renderer')
+    expect(second.processMetricsVanishedPid).toBe(201)
+    expect(second.processMetricsVanishedAmbiguousWithEarlierCrash).toBe(true)
+
+    // A fresh sweep starts a clean era: attribution is confident again.
+    appMetricsMock.mockReturnValue([
+      { pid: 301, type: 'Tab', memory: { workingSetSize: 1024 * 800 } }
+    ])
+    samplePreGoneProcessMetrics()
+    appMetricsMock.mockReturnValue([])
+    const third = buildProcessGoneCrashDetails({}, 'renderer')
+    expect(third.processMetricsVanishedPid).toBe(301)
+    expect(third.processMetricsVanishedAmbiguousWithEarlierCrash).toBeUndefined()
+  })
+
+  it('scopes the blind-crash ambiguity to the crashed bucket', () => {
+    // A blind Utility crash says nothing about renderer attribution.
+    appMetricsMock.mockReturnValue([
+      { pid: 201, type: 'Tab', memory: { workingSetSize: 1024 * 5000 } },
+      { pid: 210, type: 'Utility', memory: { workingSetSize: 1024 * 80 } }
+    ])
+    samplePreGoneProcessMetrics()
+    appMetricsMock.mockImplementationOnce(() => {
+      throw new Error('metrics unavailable')
+    })
+    buildProcessGoneCrashDetails({}, 'Utility')
+
+    appMetricsMock.mockReturnValue([
+      { pid: 210, type: 'Utility', memory: { workingSetSize: 1024 * 80 } }
+    ])
+    const details = buildProcessGoneCrashDetails({}, 'renderer')
+    expect(details.processMetricsVanishedPid).toBe(201)
+    expect(details.processMetricsVanishedAmbiguousWithEarlierCrash).toBeUndefined()
+  })
+
+  it('consumes an ambiguous vanished pair so a later record never repeats its sum', () => {
+    appMetricsMock.mockReturnValue([
+      { pid: 101, type: 'Tab', memory: { workingSetSize: 1024 * 2000 } },
+      { pid: 102, type: 'Tab', memory: { workingSetSize: 1024 * 500 } }
+    ])
+    samplePreGoneProcessMetrics()
+    appMetricsMock.mockReturnValue([])
+
+    expect(buildProcessGoneCrashDetails({}, 'renderer')).toMatchObject({
+      processMetricsVanishedCount: 2,
+      processMetricsVanishedWorkingSetMB: 2500
+    })
+
+    // The ambiguous pair was reported once (count + sum + largest); a second
+    // record repeating those numbers would double-report the same exits.
+    const second = buildProcessGoneCrashDetails({}, 'renderer')
+    expect(second.processMetricsVanishedCount).toBeUndefined()
+    expect(second.processMetricsVanishedWorkingSetMB).toBeUndefined()
+    expect(second.processMetricsVanishedLargestWorkingSetMB).toBeUndefined()
+    expect(second.processMetricsVanishedAlreadyReportedCount).toBe(2)
   })
 
   it('re-arms vanished attribution when a fresh sweep samples the pid alive again', () => {
@@ -398,10 +495,13 @@ describe('process gone diagnostics', () => {
     samplePreGoneProcessMetrics()
     appMetricsMock.mockReturnValue([])
 
-    expect(buildProcessGoneCrashDetails({}, 'renderer')).toMatchObject({
+    const details = buildProcessGoneCrashDetails({}, 'renderer')
+    expect(details).toMatchObject({
       processMetricsVanishedPid: 201,
       processMetricsVanishedWorkingSetMB: 1500
     })
+    // Fresh sweep = fresh era: no stale "already reported" residue.
+    expect(details.processMetricsVanishedAlreadyReportedCount).toBeUndefined()
   })
 
   it('claims neither absence nor vanished pids when gone-time metrics are unreadable', () => {
@@ -453,6 +553,8 @@ describe('process gone diagnostics', () => {
     expect(details.processMetricsCrashedProcessAbsent).toBeUndefined()
     expect(details.processMetricsVanishedCount).toBeUndefined()
     expect(details.processMetricsVanishedWorkingSetMB).toBeUndefined()
+    // Out-of-bucket and still-alive exclusions are not "already reported".
+    expect(details.processMetricsVanishedAlreadyReportedCount).toBeUndefined()
   })
 
   it('degrades honestly in a crash loop when the sweep lands between death and respawn', () => {
@@ -640,31 +742,6 @@ describe('process gone diagnostics', () => {
       processMetricsCount: 2,
       processMetricsRendererWorkingSetMB: 400,
       processMetricsLargestPid: 22
-    })
-  })
-
-  it('preserves child process identity on suppressed breadcrumbs', () => {
-    expect(
-      buildSuppressedProcessGoneBreadcrumbData({
-        source: 'child',
-        processType: 'Utility',
-        reason: 'killed',
-        exitCode: 1,
-        expectedTeardown: 'app-shutdown',
-        details: {
-          name: 'Network Service',
-          serviceName: 'network.mojom.NetworkService',
-          nested: { ignored: true }
-        }
-      })
-    ).toEqual({
-      source: 'child',
-      processType: 'Utility',
-      reason: 'killed',
-      exitCode: 1,
-      expectedTeardown: 'app-shutdown',
-      name: 'Network Service',
-      serviceName: 'network.mojom.NetworkService'
     })
   })
 })

--- a/src/main/crash-reporting/process-gone-diagnostics.ts
+++ b/src/main/crash-reporting/process-gone-diagnostics.ts
@@ -7,6 +7,7 @@ import { getSystemMemoryAtGoneDetails, memoryKBFieldMB } from './gone-time-syste
 
 type ProcessMetricLike = {
   pid?: unknown
+  creationTime?: unknown
   type?: unknown
   memory?: {
     workingSetSize?: unknown
@@ -126,43 +127,47 @@ export function collectProcessGoneMetricDetails(metrics: ProcessMetricLike[]): C
 
 type LiveProcessGoneMetrics = {
   details: CrashReportDetails
-  // null = metrics unreadable, so pid-level absence cannot be proven.
-  // Bucket per pid, not a bare pid set: a recycled pid living on as a
-  // different process type must still read as a vanished sampled process.
-  pidBuckets: Map<number, ProcessMetricBucketName> | null
+  identitiesByPid: Map<number, ProcessMetricIdentity> | null
+}
+
+type ProcessMetricIdentity = {
+  bucket: ProcessMetricBucketName
+  creationTime?: number
+}
+
+function processMetricIdentity(metric: ProcessMetricLike): ProcessMetricIdentity {
+  return {
+    bucket: metricTypeBucket(metric.type),
+    creationTime: safeFiniteNumber(metric.creationTime)
+  }
 }
 
 function getLiveProcessGoneMetrics(): LiveProcessGoneMetrics {
   try {
     const metrics = app.getAppMetrics()
-    const pidBuckets = new Map<number, ProcessMetricBucketName>()
+    const identitiesByPid = new Map<number, ProcessMetricIdentity>()
     for (const metric of metrics) {
       const pid = safeFiniteNumber(metric.pid)
       if (pid !== undefined) {
-        pidBuckets.set(pid, metricTypeBucket(metric.type))
+        identitiesByPid.set(pid, processMetricIdentity(metric))
       }
     }
-    return { details: collectProcessGoneMetricDetails(metrics), pidBuckets }
+    return { details: collectProcessGoneMetricDetails(metrics), identitiesByPid }
   } catch (error) {
     const errorName = error instanceof Error ? error.name : typeof error
-    return { details: { processMetricsError: errorName }, pidBuckets: null }
+    return { details: { processMetricsError: errorName }, identitiesByPid: null }
   }
 }
 
 // ─── Pre-gone metric sampling ───────────────────────────────────────
-// Why: process-gone fires after the crashed process left Chromium's registry,
-// so gone-time getAppMetrics() only sees survivors — field reports carried
-// processMetricsRendererCount=0 for every renderer death. A periodic sample
-// keeps the last pre-death working sets so the crasher's size survives it.
-// Staleness honesty: PreGone values are sample-time, not death-time — a
-// process that grew in the up-to-60s before death is understated, bounded
-// only by PreGoneSampleAgeMs and the lifetime peak fields.
+// Why: process-gone metrics see survivors only, so retain a recent whole-app
+// snapshot for comparison without pretending it identifies the crasher.
 
 export const PROCESS_METRICS_PRE_GONE_SAMPLE_INTERVAL_MS = 60_000
 
 type PreGoneSampledProcess = {
   pid: number
-  bucket: ProcessMetricBucketName
+  identity: ProcessMetricIdentity
 }
 
 type PreGoneProcessMetricsSample = {
@@ -181,7 +186,7 @@ function sampledProcessIdentities(metrics: ProcessMetricLike[]): PreGoneSampledP
     if (pid === undefined) {
       continue
     }
-    processes.push({ pid, bucket: metricTypeBucket(metric.type) })
+    processes.push({ pid, identity: processMetricIdentity(metric) })
   }
   return processes
 }
@@ -225,13 +230,33 @@ function preGoneSampleDetails(
   nowMs: number
 ): CrashReportDetails {
   const details: CrashReportDetails = {
-    processMetricsPreGoneSampleAgeMs: Math.max(0, nowMs - sample.sampledAtMs)
+    processMetricsPreGoneSampleAgeMs: Math.max(0, nowMs - sample.sampledAtMs),
+    // Why: Electron's gone events omit pid, so no snapshot row is attributable
+    // to the crasher even when only one same-type process was sampled.
+    processMetricsPreGoneCrashedProcessAttributionAmbiguous: true
   }
   for (const [key, value] of Object.entries(sample.details)) {
     details[`${PROCESS_METRICS_KEY_PREFIX}PreGone${key.slice(PROCESS_METRICS_KEY_PREFIX.length)}`] =
       value
   }
   return details
+}
+
+function sampledProcessIsGone(
+  sampled: PreGoneSampledProcess,
+  liveIdentitiesByPid: Map<number, ProcessMetricIdentity>
+): boolean {
+  const live = liveIdentitiesByPid.get(sampled.pid)
+  if (!live || live.bucket !== sampled.identity.bucket) {
+    return true
+  }
+  const sampledCreationTime = sampled.identity.creationTime
+  const liveCreationTime = live.creationTime
+  return (
+    sampledCreationTime !== undefined &&
+    liveCreationTime !== undefined &&
+    sampledCreationTime !== liveCreationTime
+  )
 }
 
 export function buildProcessGoneCrashDetails(
@@ -241,7 +266,8 @@ export function buildProcessGoneCrashDetails(
   const sanitizedDetails = sanitizeCrashReportDetails(details)
   // Why: low-JS-heap renderer kills can still be native/process memory pressure.
   // Capture Electron process buckets at process-gone time before recovery reloads.
-  const { details: liveMetricDetails, pidBuckets: livePidBuckets } = getLiveProcessGoneMetrics()
+  const { details: liveMetricDetails, identitiesByPid: liveIdentitiesByPid } =
+    getLiveProcessGoneMetrics()
   const crashDetails: CrashReportDetails = {
     ...sanitizedDetails,
     ...liveMetricDetails,
@@ -249,24 +275,19 @@ export function buildProcessGoneCrashDetails(
   }
   // Why: with the crasher gone, Largest names a survivor — flag that so the
   // live buckets are read as "everyone else", not as the crashed process.
-  // Same-bucket survivors are the norm (webview guests, the dashboard popout,
-  // origin-bar views), so a zero bucket count alone under-detects: a sampled
-  // same-bucket pid missing from the live set — including one the OS recycled
-  // into a different bucket — also proves absence. The proof is stateless and
-  // holds for every record of a crash loop. False negatives remain when the
-  // crasher was younger than the last sweep, or when its pid was recycled
-  // into a NEW same-bucket process inside the sweep window; a legitimately
-  // closed sampled process can still trip the flag if the crasher's own row
-  // somehow survives in the live enumeration.
+  // Same-bucket survivors are common, so use Electron's (pid, creationTime)
+  // identity to distinguish a missing sampled process from a recycled pid.
   const crashedBucket = metricTypeBucket(crashedProcessType)
   const crashedBucketCountKey = `${PROCESS_METRICS_KEY_PREFIX}${titleCaseBucket(crashedBucket)}Count`
-  const sampledSameBucketPidVanished = Boolean(
-    livePidBuckets &&
+  const sampledSameBucketProcessVanished = Boolean(
+    liveIdentitiesByPid &&
     preGoneSample?.processes.some(
-      (p) => p.bucket === crashedBucket && livePidBuckets.get(p.pid) !== p.bucket
+      (process) =>
+        process.identity.bucket === crashedBucket &&
+        sampledProcessIsGone(process, liveIdentitiesByPid)
     )
   )
-  if (liveMetricDetails[crashedBucketCountKey] === 0 || sampledSameBucketPidVanished) {
+  if (liveMetricDetails[crashedBucketCountKey] === 0 || sampledSameBucketProcessVanished) {
     crashDetails.processMetricsCrashedProcessAbsent = true
   }
   if (preGoneSample) {

--- a/src/main/crash-reporting/process-gone-diagnostics.ts
+++ b/src/main/crash-reporting/process-gone-diagnostics.ts
@@ -129,23 +129,25 @@ export function collectProcessGoneMetricDetails(metrics: ProcessMetricLike[]): C
 type LiveProcessGoneMetrics = {
   details: CrashReportDetails
   // null = metrics unreadable, so pid-level absence cannot be proven.
-  pids: Set<number> | null
+  // Bucket per pid, not a bare pid set: a recycled pid living on as a
+  // different process type must still read as a vanished sampled process.
+  pidBuckets: Map<number, ProcessMetricBucketName> | null
 }
 
 function getLiveProcessGoneMetrics(): LiveProcessGoneMetrics {
   try {
     const metrics = app.getAppMetrics()
-    const pids = new Set<number>()
+    const pidBuckets = new Map<number, ProcessMetricBucketName>()
     for (const metric of metrics) {
       const pid = safeFiniteNumber(metric.pid)
       if (pid !== undefined) {
-        pids.add(pid)
+        pidBuckets.set(pid, metricTypeBucket(metric.type))
       }
     }
-    return { details: collectProcessGoneMetricDetails(metrics), pids }
+    return { details: collectProcessGoneMetricDetails(metrics), pidBuckets }
   } catch (error) {
     const errorName = error instanceof Error ? error.name : typeof error
-    return { details: { processMetricsError: errorName }, pids: null }
+    return { details: { processMetricsError: errorName }, pidBuckets: null }
   }
 }
 
@@ -171,6 +173,10 @@ type PreGoneProcessMetricsSample = {
 
 let preGoneSample: PreGoneProcessMetricsSample | null = null
 let preGoneSampleTimer: ReturnType<typeof setInterval> | null = null
+// Why: a pid reported as Vanished once must not be re-attributed to a later
+// crash — a crash-looped respawn dying before the next sweep would otherwise
+// confidently inherit the previous crasher's pid and working set.
+const attributedVanishedPids = new Set<number>()
 
 function sampledProcessIdentities(metrics: ProcessMetricLike[]): PreGoneSampledProcess[] {
   const processes: PreGoneSampledProcess[] = []
@@ -196,6 +202,8 @@ export function samplePreGoneProcessMetrics(nowMs: number = Date.now()): void {
       processes: sampledProcessIdentities(metrics),
       sampledAtMs: nowMs
     }
+    // Fresh identities: attribution state belongs to the sample it came from.
+    attributedVanishedPids.clear()
   } catch {
     // Why: a failed sweep must not erase the previous good sample.
   }
@@ -218,6 +226,7 @@ export function resetPreGoneProcessMetricsSamplingForTest(): void {
   }
   preGoneSampleTimer = null
   preGoneSample = null
+  attributedVanishedPids.clear()
 }
 
 const PROCESS_METRICS_KEY_PREFIX = 'processMetrics'
@@ -243,7 +252,7 @@ export function buildProcessGoneCrashDetails(
   const sanitizedDetails = sanitizeCrashReportDetails(details)
   // Why: low-JS-heap renderer kills can still be native/process memory pressure.
   // Capture Electron process buckets at process-gone time before recovery reloads.
-  const { details: liveMetricDetails, pids: livePids } = getLiveProcessGoneMetrics()
+  const { details: liveMetricDetails, pidBuckets: livePidBuckets } = getLiveProcessGoneMetrics()
   const crashDetails: CrashReportDetails = {
     ...sanitizedDetails,
     ...liveMetricDetails,
@@ -260,8 +269,13 @@ export function buildProcessGoneCrashDetails(
   const crashedBucket = metricTypeBucket(crashedProcessType)
   const crashedBucketCountKey = `${PROCESS_METRICS_KEY_PREFIX}${titleCaseBucket(crashedBucket)}Count`
   const vanished =
-    livePids && preGoneSample
-      ? preGoneSample.processes.filter((p) => p.bucket === crashedBucket && !livePids.has(p.pid))
+    livePidBuckets && preGoneSample
+      ? preGoneSample.processes.filter(
+          (p) =>
+            p.bucket === crashedBucket &&
+            !attributedVanishedPids.has(p.pid) &&
+            livePidBuckets.get(p.pid) !== p.bucket
+        )
       : []
   if (liveMetricDetails[crashedBucketCountKey] === 0 || vanished.length > 0) {
     crashDetails.processMetricsCrashedProcessAbsent = true
@@ -274,6 +288,16 @@ export function buildProcessGoneCrashDetails(
     )
     if (vanished.length === 1) {
       crashDetails.processMetricsVanishedPid = vanished[0].pid
+    } else {
+      // Why: the sum spans unrelated exits (a closed pane plus the crasher);
+      // Largest bounds what any single vanished process held.
+      crashDetails.processMetricsVanishedLargestWorkingSetMB = vanished.reduce(
+        (max, p) => Math.max(max, p.workingSetMB),
+        0
+      )
+    }
+    for (const p of vanished) {
+      attributedVanishedPids.add(p.pid)
     }
   }
   if (preGoneSample) {

--- a/src/main/crash-reporting/process-gone-diagnostics.ts
+++ b/src/main/crash-reporting/process-gone-diagnostics.ts
@@ -110,14 +110,90 @@ function getProcessGoneMetricDetails(): CrashReportDetails {
   }
 }
 
-export function buildProcessGoneCrashDetails(details: Record<string, unknown>): CrashReportDetails {
+// ─── Pre-gone metric sampling ───────────────────────────────────────
+// Why: process-gone fires after the crashed process left Chromium's registry,
+// so gone-time getAppMetrics() only sees survivors — field reports carried
+// processMetricsRendererCount=0 for every renderer death. A periodic sample
+// keeps the last pre-death working sets so the crasher's size survives it.
+
+export const PROCESS_METRICS_PRE_GONE_SAMPLE_INTERVAL_MS = 60_000
+
+type PreGoneProcessMetricsSample = {
+  details: CrashReportDetails
+  sampledAtMs: number
+}
+
+let preGoneSample: PreGoneProcessMetricsSample | null = null
+let preGoneSampleTimer: ReturnType<typeof setInterval> | null = null
+
+export function samplePreGoneProcessMetrics(nowMs: number = Date.now()): void {
+  try {
+    preGoneSample = {
+      details: collectProcessGoneMetricDetails(app.getAppMetrics()),
+      sampledAtMs: nowMs
+    }
+  } catch {
+    // Why: a failed sweep must not erase the previous good sample.
+  }
+}
+
+export function startPreGoneProcessMetricsSampling(
+  intervalMs: number = PROCESS_METRICS_PRE_GONE_SAMPLE_INTERVAL_MS
+): void {
+  if (preGoneSampleTimer) {
+    return
+  }
+  samplePreGoneProcessMetrics()
+  preGoneSampleTimer = setInterval(() => samplePreGoneProcessMetrics(), intervalMs)
+  preGoneSampleTimer.unref?.()
+}
+
+export function resetPreGoneProcessMetricsSamplingForTest(): void {
+  if (preGoneSampleTimer) {
+    clearInterval(preGoneSampleTimer)
+  }
+  preGoneSampleTimer = null
+  preGoneSample = null
+}
+
+const PROCESS_METRICS_KEY_PREFIX = 'processMetrics'
+
+function preGoneSampleDetails(
+  sample: PreGoneProcessMetricsSample,
+  nowMs: number
+): CrashReportDetails {
+  const details: CrashReportDetails = {
+    processMetricsPreGoneSampleAgeMs: Math.max(0, nowMs - sample.sampledAtMs)
+  }
+  for (const [key, value] of Object.entries(sample.details)) {
+    details[`${PROCESS_METRICS_KEY_PREFIX}PreGone${key.slice(PROCESS_METRICS_KEY_PREFIX.length)}`] =
+      value
+  }
+  return details
+}
+
+export function buildProcessGoneCrashDetails(
+  details: Record<string, unknown>,
+  crashedProcessType: string
+): CrashReportDetails {
   const sanitizedDetails = sanitizeCrashReportDetails(details)
   // Why: low-JS-heap renderer kills can still be native/process memory pressure.
   // Capture Electron process buckets at process-gone time before recovery reloads.
-  return {
+  const liveMetricDetails = getProcessGoneMetricDetails()
+  const crashDetails: CrashReportDetails = {
     ...sanitizedDetails,
-    ...getProcessGoneMetricDetails()
+    ...liveMetricDetails
   }
+  // Why: with the crasher gone, Largest names a survivor — flag that so the
+  // live buckets are read as "everyone else", not as the crashed process.
+  const crashedBucketCountKey = `${PROCESS_METRICS_KEY_PREFIX}${titleCaseBucket(metricTypeBucket(crashedProcessType))}Count`
+  if (liveMetricDetails[crashedBucketCountKey] === 0) {
+    crashDetails.processMetricsCrashedProcessAbsent = true
+  }
+  if (preGoneSample) {
+    Object.assign(crashDetails, preGoneSampleDetails(preGoneSample, Date.now()))
+  }
+  return crashDetails
 }
 
 export function buildSuppressedProcessGoneBreadcrumbData({

--- a/src/main/crash-reporting/process-gone-diagnostics.ts
+++ b/src/main/crash-reporting/process-gone-diagnostics.ts
@@ -255,14 +255,16 @@ export function buildProcessGoneCrashDetails(
   // into a different bucket — also proves absence. The proof is stateless and
   // holds for every record of a crash loop. False negatives remain when the
   // crasher was younger than the last sweep, or when its pid was recycled
-  // into a NEW same-bucket process inside the sweep window.
+  // into a NEW same-bucket process inside the sweep window; a legitimately
+  // closed sampled process can still trip the flag if the crasher's own row
+  // somehow survives in the live enumeration.
   const crashedBucket = metricTypeBucket(crashedProcessType)
   const crashedBucketCountKey = `${PROCESS_METRICS_KEY_PREFIX}${titleCaseBucket(crashedBucket)}Count`
   const sampledSameBucketPidVanished = Boolean(
     livePidBuckets &&
-      preGoneSample?.processes.some(
-        (p) => p.bucket === crashedBucket && livePidBuckets.get(p.pid) !== p.bucket
-      )
+    preGoneSample?.processes.some(
+      (p) => p.bucket === crashedBucket && livePidBuckets.get(p.pid) !== p.bucket
+    )
   )
   if (liveMetricDetails[crashedBucketCountKey] === 0 || sampledSameBucketPidVanished) {
     crashDetails.processMetricsCrashedProcessAbsent = true

--- a/src/main/crash-reporting/process-gone-diagnostics.ts
+++ b/src/main/crash-reporting/process-gone-diagnostics.ts
@@ -313,9 +313,10 @@ export function buildProcessGoneCrashDetails(
         0
       )
     }
-    if (metricsBlindCrashBuckets.has(crashedBucket)) {
-      // Why: an earlier same-bucket crash in this era was recorded blind, so
-      // these Vanished numbers may belong to it rather than to this crash.
+    if (metricsBlindCrashBuckets.has(crashedBucket) || vanishedAlreadyReported > 0) {
+      // Why: an earlier same-bucket crash this era either consumed nothing (a
+      // blind record) or consumed pids and left an unsampled respawn — either
+      // way these Vanished numbers may describe a different process's exit.
       crashDetails.processMetricsVanishedAmbiguousWithEarlierCrash = true
     }
     for (const p of vanished) {

--- a/src/main/crash-reporting/process-gone-diagnostics.ts
+++ b/src/main/crash-reporting/process-gone-diagnostics.ts
@@ -143,12 +143,19 @@ function getProcessGoneMetricDetails(): CrashReportDetails {
 // Why: the system outlives the crashed process, so this IS sampleable at
 // process-gone — it separates "renderer grew huge" from "machine out of
 // memory/commit", which the per-process buckets alone cannot.
+// Platform honesty: swap* exist on Windows/Linux only. On macOS `free` is
+// near-meaningless (file cache and compression keep it low on healthy
+// machines); fileBacked/purgeable are the only reclaimability proxy this API
+// gives there, and none of these fields answers "was the machine under
+// pressure" on macOS — that needs a signal Electron does not expose.
 
 type SystemMemoryInfoLike = {
   total?: unknown
   free?: unknown
   swapTotal?: unknown
   swapFree?: unknown
+  fileBacked?: unknown
+  purgeable?: unknown
 }
 
 type SystemMemoryInfoReader = () => SystemMemoryInfoLike | null
@@ -182,7 +189,9 @@ function getSystemMemoryAtGoneDetails(): CrashReportDetails {
     ['total', 'systemMemoryTotalMB'],
     ['free', 'systemMemoryFreeMB'],
     ['swapTotal', 'systemMemorySwapTotalMB'],
-    ['swapFree', 'systemMemorySwapFreeMB']
+    ['swapFree', 'systemMemorySwapFreeMB'],
+    ['fileBacked', 'systemMemoryFileBackedMB'],
+    ['purgeable', 'systemMemoryPurgeableMB']
   ]
   for (const [field, key] of fields) {
     const mb = memoryKBFieldMB(info[field])

--- a/src/main/crash-reporting/process-gone-diagnostics.ts
+++ b/src/main/crash-reporting/process-gone-diagnostics.ts
@@ -154,13 +154,15 @@ function getLiveProcessGoneMetrics(): LiveProcessGoneMetrics {
 // so gone-time getAppMetrics() only sees survivors — field reports carried
 // processMetricsRendererCount=0 for every renderer death. A periodic sample
 // keeps the last pre-death working sets so the crasher's size survives it.
+// Staleness honesty: PreGone values are sample-time, not death-time — a
+// process that grew in the up-to-60s before death is understated, bounded
+// only by PreGoneSampleAgeMs and the lifetime peak fields.
 
 export const PROCESS_METRICS_PRE_GONE_SAMPLE_INTERVAL_MS = 60_000
 
 type PreGoneSampledProcess = {
   pid: number
   bucket: ProcessMetricBucketName
-  workingSetMB: number
 }
 
 type PreGoneProcessMetricsSample = {
@@ -171,17 +173,6 @@ type PreGoneProcessMetricsSample = {
 
 let preGoneSample: PreGoneProcessMetricsSample | null = null
 let preGoneSampleTimer: ReturnType<typeof setInterval> | null = null
-// Why: a pid reported as Vanished once must not be re-attributed to a later
-// crash — a crash-looped respawn dying before the next sweep would otherwise
-// confidently inherit the previous crasher's pid and working set.
-// Bounded: only pids of the current sample are ever added, and a successful
-// sweep clears it, so it never outgrows one sample's process list.
-const attributedVanishedPids = new Set<number>()
-// Why: a crash recorded while gone-time metrics were unreadable consumed
-// nothing — a later record's Vanished numbers drawn from the same sample era
-// may describe THAT crash, not their own. Track the blind buckets so the
-// later record says so instead of attributing confidently.
-const metricsBlindCrashBuckets = new Set<ProcessMetricBucketName>()
 
 function sampledProcessIdentities(metrics: ProcessMetricLike[]): PreGoneSampledProcess[] {
   const processes: PreGoneSampledProcess[] = []
@@ -190,11 +181,7 @@ function sampledProcessIdentities(metrics: ProcessMetricLike[]): PreGoneSampledP
     if (pid === undefined) {
       continue
     }
-    processes.push({
-      pid,
-      bucket: metricTypeBucket(metric.type),
-      workingSetMB: workingSetMB(metric)
-    })
+    processes.push({ pid, bucket: metricTypeBucket(metric.type) })
   }
   return processes
 }
@@ -207,9 +194,6 @@ export function samplePreGoneProcessMetrics(nowMs: number = Date.now()): void {
       processes: sampledProcessIdentities(metrics),
       sampledAtMs: nowMs
     }
-    // Fresh identities: attribution state belongs to the sample it came from.
-    attributedVanishedPids.clear()
-    metricsBlindCrashBuckets.clear()
   } catch {
     // Why: a failed sweep must not erase the previous good sample.
   }
@@ -232,8 +216,6 @@ export function resetPreGoneProcessMetricsSamplingForTest(): void {
   }
   preGoneSampleTimer = null
   preGoneSample = null
-  attributedVanishedPids.clear()
-  metricsBlindCrashBuckets.clear()
 }
 
 const PROCESS_METRICS_KEY_PREFIX = 'processMetrics'
@@ -268,66 +250,22 @@ export function buildProcessGoneCrashDetails(
   // Why: with the crasher gone, Largest names a survivor — flag that so the
   // live buckets are read as "everyone else", not as the crashed process.
   // Same-bucket survivors are the norm (webview guests, the dashboard popout,
-  // origin-bar views), so a zero bucket count alone under-detects: also treat
-  // a sampled same-bucket pid that vanished from the live set as proof. That
-  // still misses a crasher younger than the last sweep, and Vanished can
-  // include a legitimately-closed same-bucket process — Pid is only emitted
-  // when the vanished process is unambiguous among SAMPLED processes; it can
-  // still name a legitimately-closed one when the true crasher was younger
-  // than the last sweep.
+  // origin-bar views), so a zero bucket count alone under-detects: a sampled
+  // same-bucket pid missing from the live set — including one the OS recycled
+  // into a different bucket — also proves absence. The proof is stateless and
+  // holds for every record of a crash loop. False negatives remain when the
+  // crasher was younger than the last sweep, or when its pid was recycled
+  // into a NEW same-bucket process inside the sweep window.
   const crashedBucket = metricTypeBucket(crashedProcessType)
   const crashedBucketCountKey = `${PROCESS_METRICS_KEY_PREFIX}${titleCaseBucket(crashedBucket)}Count`
-  if (!livePidBuckets) {
-    metricsBlindCrashBuckets.add(crashedBucket)
-  }
-  let vanishedAlreadyReported = 0
-  const vanished =
-    livePidBuckets && preGoneSample
-      ? preGoneSample.processes.filter((p) => {
-          if (p.bucket !== crashedBucket || livePidBuckets.get(p.pid) === p.bucket) {
-            return false
-          }
-          if (attributedVanishedPids.has(p.pid)) {
-            vanishedAlreadyReported += 1
-            return false
-          }
-          return true
-        })
-      : []
-  if (liveMetricDetails[crashedBucketCountKey] === 0 || vanished.length > 0) {
-    crashDetails.processMetricsCrashedProcessAbsent = true
-  }
-  if (vanished.length > 0) {
-    crashDetails.processMetricsVanishedCount = vanished.length
-    crashDetails.processMetricsVanishedWorkingSetMB = vanished.reduce(
-      (sum, p) => sum + p.workingSetMB,
-      0
-    )
-    if (vanished.length === 1) {
-      crashDetails.processMetricsVanishedPid = vanished[0].pid
-    } else {
-      // Why: the sum spans unrelated exits (a closed pane plus the crasher);
-      // Largest bounds what any single vanished process held.
-      crashDetails.processMetricsVanishedLargestWorkingSetMB = vanished.reduce(
-        (max, p) => Math.max(max, p.workingSetMB),
-        0
+  const sampledSameBucketPidVanished = Boolean(
+    livePidBuckets &&
+      preGoneSample?.processes.some(
+        (p) => p.bucket === crashedBucket && livePidBuckets.get(p.pid) !== p.bucket
       )
-    }
-    if (metricsBlindCrashBuckets.has(crashedBucket) || vanishedAlreadyReported > 0) {
-      // Why: an earlier same-bucket crash this era either consumed nothing (a
-      // blind record) or consumed pids and left an unsampled respawn — either
-      // way these Vanished numbers may describe a different process's exit.
-      crashDetails.processMetricsVanishedAmbiguousWithEarlierCrash = true
-    }
-    for (const p of vanished) {
-      attributedVanishedPids.add(p.pid)
-    }
-  }
-  if (vanishedAlreadyReported > 0) {
-    // Why: consumed attribution must not read as "nothing vanished" — this
-    // says an earlier record already reported these pids, so the PreGone
-    // mirrors below describe that earlier crasher's era, not this one's.
-    crashDetails.processMetricsVanishedAlreadyReportedCount = vanishedAlreadyReported
+  )
+  if (liveMetricDetails[crashedBucketCountKey] === 0 || sampledSameBucketPidVanished) {
+    crashDetails.processMetricsCrashedProcessAbsent = true
   }
   if (preGoneSample) {
     Object.assign(crashDetails, preGoneSampleDetails(preGoneSample, Date.now()))

--- a/src/main/crash-reporting/process-gone-diagnostics.ts
+++ b/src/main/crash-reporting/process-gone-diagnostics.ts
@@ -279,6 +279,8 @@ export function buildProcessGoneCrashDetails(
   }
   // Why: with the crasher gone, Largest names a survivor — flag that so the
   // live buckets are read as "everyone else", not as the crashed process.
+  // Bucket-level only: a surviving same-type process (second window, another
+  // utility) keeps the flag off even though the crasher is still absent.
   const crashedBucketCountKey = `${PROCESS_METRICS_KEY_PREFIX}${titleCaseBucket(metricTypeBucket(crashedProcessType))}Count`
   if (liveMetricDetails[crashedBucketCountKey] === 0) {
     crashDetails.processMetricsCrashedProcessAbsent = true

--- a/src/main/crash-reporting/process-gone-diagnostics.ts
+++ b/src/main/crash-reporting/process-gone-diagnostics.ts
@@ -5,6 +5,7 @@ import {
   type CrashReportDetailValue
 } from '../../shared/crash-reporting'
 import type { ExpectedTeardownScope } from './process-gone-classification'
+import { getSystemMemoryAtGoneDetails, memoryKBFieldMB } from './gone-time-system-memory'
 
 type ProcessMetricLike = {
   pid?: unknown
@@ -54,11 +55,6 @@ function metricTypeBucket(type: unknown): ProcessMetricBucketName {
 function workingSetMB(metric: ProcessMetricLike): number {
   const workingSetKB = safeFiniteNumber(metric.memory?.workingSetSize) ?? 0
   return Math.round(Math.max(0, workingSetKB) / 1024)
-}
-
-function memoryKBFieldMB(value: unknown): number | undefined {
-  const kb = safeFiniteNumber(value)
-  return kb === undefined ? undefined : Math.round(Math.max(0, kb) / 1024)
 }
 
 function emptyBuckets(): Record<ProcessMetricBucketName, ProcessMetricBucket> {
@@ -130,76 +126,27 @@ export function collectProcessGoneMetricDetails(metrics: ProcessMetricLike[]): C
   return details
 }
 
-function getProcessGoneMetricDetails(): CrashReportDetails {
+type LiveProcessGoneMetrics = {
+  details: CrashReportDetails
+  // null = metrics unreadable, so pid-level absence cannot be proven.
+  pids: Set<number> | null
+}
+
+function getLiveProcessGoneMetrics(): LiveProcessGoneMetrics {
   try {
-    return collectProcessGoneMetricDetails(app.getAppMetrics())
+    const metrics = app.getAppMetrics()
+    const pids = new Set<number>()
+    for (const metric of metrics) {
+      const pid = safeFiniteNumber(metric.pid)
+      if (pid !== undefined) {
+        pids.add(pid)
+      }
+    }
+    return { details: collectProcessGoneMetricDetails(metrics), pids }
   } catch (error) {
     const errorName = error instanceof Error ? error.name : typeof error
-    return { processMetricsError: errorName }
+    return { details: { processMetricsError: errorName }, pids: null }
   }
-}
-
-// ─── System memory at gone time ─────────────────────────────────────
-// Why: the system outlives the crashed process, so this IS sampleable at
-// process-gone — it separates "renderer grew huge" from "machine out of
-// memory/commit", which the per-process buckets alone cannot.
-// Platform honesty: swap* exist on Windows/Linux only. On macOS `free` is
-// near-meaningless (file cache and compression keep it low on healthy
-// machines); fileBacked/purgeable are the only reclaimability proxy this API
-// gives there, and none of these fields answers "was the machine under
-// pressure" on macOS — that needs a signal Electron does not expose.
-
-type SystemMemoryInfoLike = {
-  total?: unknown
-  free?: unknown
-  swapTotal?: unknown
-  swapFree?: unknown
-  fileBacked?: unknown
-  purgeable?: unknown
-}
-
-type SystemMemoryInfoReader = () => SystemMemoryInfoLike | null
-
-function readElectronSystemMemoryInfo(): SystemMemoryInfoLike | null {
-  const read = (process as NodeJS.Process & { getSystemMemoryInfo?: () => SystemMemoryInfoLike })
-    .getSystemMemoryInfo
-  if (typeof read !== 'function') {
-    return null
-  }
-  try {
-    return read.call(process)
-  } catch {
-    return null
-  }
-}
-
-let systemMemoryInfoReader: SystemMemoryInfoReader = readElectronSystemMemoryInfo
-
-export function setSystemMemoryInfoReaderForTest(reader: SystemMemoryInfoReader | null): void {
-  systemMemoryInfoReader = reader ?? readElectronSystemMemoryInfo
-}
-
-function getSystemMemoryAtGoneDetails(): CrashReportDetails {
-  const info = systemMemoryInfoReader()
-  if (!info) {
-    return {}
-  }
-  const details: CrashReportDetails = {}
-  const fields: readonly [keyof SystemMemoryInfoLike, string][] = [
-    ['total', 'systemMemoryTotalMB'],
-    ['free', 'systemMemoryFreeMB'],
-    ['swapTotal', 'systemMemorySwapTotalMB'],
-    ['swapFree', 'systemMemorySwapFreeMB'],
-    ['fileBacked', 'systemMemoryFileBackedMB'],
-    ['purgeable', 'systemMemoryPurgeableMB']
-  ]
-  for (const [field, key] of fields) {
-    const mb = memoryKBFieldMB(info[field])
-    if (mb !== undefined) {
-      details[key] = mb
-    }
-  }
-  return details
 }
 
 // ─── Pre-gone metric sampling ───────────────────────────────────────
@@ -210,18 +157,43 @@ function getSystemMemoryAtGoneDetails(): CrashReportDetails {
 
 export const PROCESS_METRICS_PRE_GONE_SAMPLE_INTERVAL_MS = 60_000
 
+type PreGoneSampledProcess = {
+  pid: number
+  bucket: ProcessMetricBucketName
+  workingSetMB: number
+}
+
 type PreGoneProcessMetricsSample = {
   details: CrashReportDetails
+  processes: PreGoneSampledProcess[]
   sampledAtMs: number
 }
 
 let preGoneSample: PreGoneProcessMetricsSample | null = null
 let preGoneSampleTimer: ReturnType<typeof setInterval> | null = null
 
+function sampledProcessIdentities(metrics: ProcessMetricLike[]): PreGoneSampledProcess[] {
+  const processes: PreGoneSampledProcess[] = []
+  for (const metric of metrics) {
+    const pid = safeFiniteNumber(metric.pid)
+    if (pid === undefined) {
+      continue
+    }
+    processes.push({
+      pid,
+      bucket: metricTypeBucket(metric.type),
+      workingSetMB: workingSetMB(metric)
+    })
+  }
+  return processes
+}
+
 export function samplePreGoneProcessMetrics(nowMs: number = Date.now()): void {
   try {
+    const metrics = app.getAppMetrics()
     preGoneSample = {
-      details: collectProcessGoneMetricDetails(app.getAppMetrics()),
+      details: collectProcessGoneMetricDetails(metrics),
+      processes: sampledProcessIdentities(metrics),
       sampledAtMs: nowMs
     }
   } catch {
@@ -271,7 +243,7 @@ export function buildProcessGoneCrashDetails(
   const sanitizedDetails = sanitizeCrashReportDetails(details)
   // Why: low-JS-heap renderer kills can still be native/process memory pressure.
   // Capture Electron process buckets at process-gone time before recovery reloads.
-  const liveMetricDetails = getProcessGoneMetricDetails()
+  const { details: liveMetricDetails, pids: livePids } = getLiveProcessGoneMetrics()
   const crashDetails: CrashReportDetails = {
     ...sanitizedDetails,
     ...liveMetricDetails,
@@ -279,11 +251,30 @@ export function buildProcessGoneCrashDetails(
   }
   // Why: with the crasher gone, Largest names a survivor — flag that so the
   // live buckets are read as "everyone else", not as the crashed process.
-  // Bucket-level only: a surviving same-type process (second window, another
-  // utility) keeps the flag off even though the crasher is still absent.
-  const crashedBucketCountKey = `${PROCESS_METRICS_KEY_PREFIX}${titleCaseBucket(metricTypeBucket(crashedProcessType))}Count`
-  if (liveMetricDetails[crashedBucketCountKey] === 0) {
+  // Same-bucket survivors are the norm (webview guests, the dashboard popout,
+  // origin-bar views), so a zero bucket count alone under-detects: also treat
+  // a sampled same-bucket pid that vanished from the live set as proof. That
+  // still misses a crasher younger than the last sweep, and Vanished can
+  // include a legitimately-closed same-bucket process — Pid is only emitted
+  // when the vanished process is unambiguous.
+  const crashedBucket = metricTypeBucket(crashedProcessType)
+  const crashedBucketCountKey = `${PROCESS_METRICS_KEY_PREFIX}${titleCaseBucket(crashedBucket)}Count`
+  const vanished =
+    livePids && preGoneSample
+      ? preGoneSample.processes.filter((p) => p.bucket === crashedBucket && !livePids.has(p.pid))
+      : []
+  if (liveMetricDetails[crashedBucketCountKey] === 0 || vanished.length > 0) {
     crashDetails.processMetricsCrashedProcessAbsent = true
+  }
+  if (vanished.length > 0) {
+    crashDetails.processMetricsVanishedCount = vanished.length
+    crashDetails.processMetricsVanishedWorkingSetMB = vanished.reduce(
+      (sum, p) => sum + p.workingSetMB,
+      0
+    )
+    if (vanished.length === 1) {
+      crashDetails.processMetricsVanishedPid = vanished[0].pid
+    }
   }
   if (preGoneSample) {
     Object.assign(crashDetails, preGoneSampleDetails(preGoneSample, Date.now()))

--- a/src/main/crash-reporting/process-gone-diagnostics.ts
+++ b/src/main/crash-reporting/process-gone-diagnostics.ts
@@ -11,6 +11,8 @@ type ProcessMetricLike = {
   type?: unknown
   memory?: {
     workingSetSize?: unknown
+    peakWorkingSetSize?: unknown
+    privateBytes?: unknown
   } | null
 }
 type CrashReportDetails = Record<string, CrashReportDetailValue>
@@ -54,6 +56,11 @@ function workingSetMB(metric: ProcessMetricLike): number {
   return Math.round(Math.max(0, workingSetKB) / 1024)
 }
 
+function memoryKBFieldMB(value: unknown): number | undefined {
+  const kb = safeFiniteNumber(value)
+  return kb === undefined ? undefined : Math.round(Math.max(0, kb) / 1024)
+}
+
 function emptyBuckets(): Record<ProcessMetricBucketName, ProcessMetricBucket> {
   return {
     browser: { count: 0, workingSetMB: 0 },
@@ -71,12 +78,28 @@ function titleCaseBucket(bucket: ProcessMetricBucketName): string {
 export function collectProcessGoneMetricDetails(metrics: ProcessMetricLike[]): CrashReportDetails {
   const buckets = emptyBuckets()
   let largest: { pid: number; type: string; workingSetMB: number } | null = null
+  // Why peak/private only for renderers: a spike between interval samples still
+  // shows in the lifetime peak, and private-vs-shared separates real commit
+  // from mapped memory — both matter for OOM triage, not for other buckets.
+  let rendererPeakWorkingSetMB: number | null = null
+  let rendererPrivateMB: number | null = null
 
   for (const metric of metrics) {
-    const bucket = buckets[metricTypeBucket(metric.type)]
+    const bucketName = metricTypeBucket(metric.type)
+    const bucket = buckets[bucketName]
     const metricWorkingSetMB = workingSetMB(metric)
     bucket.count += 1
     bucket.workingSetMB += metricWorkingSetMB
+    if (bucketName === 'renderer') {
+      const peakMB = memoryKBFieldMB(metric.memory?.peakWorkingSetSize)
+      if (peakMB !== undefined) {
+        rendererPeakWorkingSetMB = Math.max(rendererPeakWorkingSetMB ?? 0, peakMB)
+      }
+      const privateMB = memoryKBFieldMB(metric.memory?.privateBytes)
+      if (privateMB !== undefined) {
+        rendererPrivateMB = Math.max(rendererPrivateMB ?? 0, privateMB)
+      }
+    }
     const pid = safeFiniteNumber(metric.pid) ?? 0
     if (!largest || metricWorkingSetMB > largest.workingSetMB) {
       largest = {
@@ -93,6 +116,12 @@ export function collectProcessGoneMetricDetails(metrics: ProcessMetricLike[]): C
     details[`processMetrics${label}Count`] = buckets[bucketName].count
     details[`processMetrics${label}WorkingSetMB`] = buckets[bucketName].workingSetMB
   }
+  if (rendererPeakWorkingSetMB !== null) {
+    details.processMetricsRendererPeakWorkingSetMB = rendererPeakWorkingSetMB
+  }
+  if (rendererPrivateMB !== null) {
+    details.processMetricsRendererPrivateMB = rendererPrivateMB
+  }
   if (largest) {
     details.processMetricsLargestPid = largest.pid
     details.processMetricsLargestType = largest.type
@@ -108,6 +137,60 @@ function getProcessGoneMetricDetails(): CrashReportDetails {
     const errorName = error instanceof Error ? error.name : typeof error
     return { processMetricsError: errorName }
   }
+}
+
+// ─── System memory at gone time ─────────────────────────────────────
+// Why: the system outlives the crashed process, so this IS sampleable at
+// process-gone — it separates "renderer grew huge" from "machine out of
+// memory/commit", which the per-process buckets alone cannot.
+
+type SystemMemoryInfoLike = {
+  total?: unknown
+  free?: unknown
+  swapTotal?: unknown
+  swapFree?: unknown
+}
+
+type SystemMemoryInfoReader = () => SystemMemoryInfoLike | null
+
+function readElectronSystemMemoryInfo(): SystemMemoryInfoLike | null {
+  const read = (process as NodeJS.Process & { getSystemMemoryInfo?: () => SystemMemoryInfoLike })
+    .getSystemMemoryInfo
+  if (typeof read !== 'function') {
+    return null
+  }
+  try {
+    return read.call(process)
+  } catch {
+    return null
+  }
+}
+
+let systemMemoryInfoReader: SystemMemoryInfoReader = readElectronSystemMemoryInfo
+
+export function setSystemMemoryInfoReaderForTest(reader: SystemMemoryInfoReader | null): void {
+  systemMemoryInfoReader = reader ?? readElectronSystemMemoryInfo
+}
+
+function getSystemMemoryAtGoneDetails(): CrashReportDetails {
+  const info = systemMemoryInfoReader()
+  if (!info) {
+    return {}
+  }
+  const details: CrashReportDetails = {}
+  const fields: readonly [keyof SystemMemoryInfoLike, string][] = [
+    ['total', 'systemMemoryTotalMB'],
+    ['free', 'systemMemoryFreeMB'],
+    ['swapTotal', 'systemMemorySwapTotalMB'],
+    ['swapFree', 'systemMemorySwapFreeMB']
+  ]
+  for (const [field, key] of fields) {
+    const mb = memoryKBFieldMB(info[field])
+    if (mb !== undefined) {
+      details[key] = mb
+    }
+  }
+  return details
 }
 
 // ─── Pre-gone metric sampling ───────────────────────────────────────
@@ -182,7 +265,8 @@ export function buildProcessGoneCrashDetails(
   const liveMetricDetails = getProcessGoneMetricDetails()
   const crashDetails: CrashReportDetails = {
     ...sanitizedDetails,
-    ...liveMetricDetails
+    ...liveMetricDetails,
+    ...getSystemMemoryAtGoneDetails()
   }
   // Why: with the crasher gone, Largest names a survivor — flag that so the
   // live buckets are read as "everyone else", not as the crashed process.

--- a/src/main/crash-reporting/process-gone-diagnostics.ts
+++ b/src/main/crash-reporting/process-gone-diagnostics.ts
@@ -1,10 +1,8 @@
 import { app } from 'electron'
 import {
   sanitizeCrashReportDetails,
-  type CrashReportBreadcrumbData,
   type CrashReportDetailValue
 } from '../../shared/crash-reporting'
-import type { ExpectedTeardownScope } from './process-gone-classification'
 import { getSystemMemoryAtGoneDetails, memoryKBFieldMB } from './gone-time-system-memory'
 
 type ProcessMetricLike = {
@@ -176,7 +174,14 @@ let preGoneSampleTimer: ReturnType<typeof setInterval> | null = null
 // Why: a pid reported as Vanished once must not be re-attributed to a later
 // crash — a crash-looped respawn dying before the next sweep would otherwise
 // confidently inherit the previous crasher's pid and working set.
+// Bounded: only pids of the current sample are ever added, and a successful
+// sweep clears it, so it never outgrows one sample's process list.
 const attributedVanishedPids = new Set<number>()
+// Why: a crash recorded while gone-time metrics were unreadable consumed
+// nothing — a later record's Vanished numbers drawn from the same sample era
+// may describe THAT crash, not their own. Track the blind buckets so the
+// later record says so instead of attributing confidently.
+const metricsBlindCrashBuckets = new Set<ProcessMetricBucketName>()
 
 function sampledProcessIdentities(metrics: ProcessMetricLike[]): PreGoneSampledProcess[] {
   const processes: PreGoneSampledProcess[] = []
@@ -204,6 +209,7 @@ export function samplePreGoneProcessMetrics(nowMs: number = Date.now()): void {
     }
     // Fresh identities: attribution state belongs to the sample it came from.
     attributedVanishedPids.clear()
+    metricsBlindCrashBuckets.clear()
   } catch {
     // Why: a failed sweep must not erase the previous good sample.
   }
@@ -227,6 +233,7 @@ export function resetPreGoneProcessMetricsSamplingForTest(): void {
   preGoneSampleTimer = null
   preGoneSample = null
   attributedVanishedPids.clear()
+  metricsBlindCrashBuckets.clear()
 }
 
 const PROCESS_METRICS_KEY_PREFIX = 'processMetrics'
@@ -265,17 +272,27 @@ export function buildProcessGoneCrashDetails(
   // a sampled same-bucket pid that vanished from the live set as proof. That
   // still misses a crasher younger than the last sweep, and Vanished can
   // include a legitimately-closed same-bucket process — Pid is only emitted
-  // when the vanished process is unambiguous.
+  // when the vanished process is unambiguous among SAMPLED processes; it can
+  // still name a legitimately-closed one when the true crasher was younger
+  // than the last sweep.
   const crashedBucket = metricTypeBucket(crashedProcessType)
   const crashedBucketCountKey = `${PROCESS_METRICS_KEY_PREFIX}${titleCaseBucket(crashedBucket)}Count`
+  if (!livePidBuckets) {
+    metricsBlindCrashBuckets.add(crashedBucket)
+  }
+  let vanishedAlreadyReported = 0
   const vanished =
     livePidBuckets && preGoneSample
-      ? preGoneSample.processes.filter(
-          (p) =>
-            p.bucket === crashedBucket &&
-            !attributedVanishedPids.has(p.pid) &&
-            livePidBuckets.get(p.pid) !== p.bucket
-        )
+      ? preGoneSample.processes.filter((p) => {
+          if (p.bucket !== crashedBucket || livePidBuckets.get(p.pid) === p.bucket) {
+            return false
+          }
+          if (attributedVanishedPids.has(p.pid)) {
+            vanishedAlreadyReported += 1
+            return false
+          }
+          return true
+        })
       : []
   if (liveMetricDetails[crashedBucketCountKey] === 0 || vanished.length > 0) {
     crashDetails.processMetricsCrashedProcessAbsent = true
@@ -296,49 +313,23 @@ export function buildProcessGoneCrashDetails(
         0
       )
     }
+    if (metricsBlindCrashBuckets.has(crashedBucket)) {
+      // Why: an earlier same-bucket crash in this era was recorded blind, so
+      // these Vanished numbers may belong to it rather than to this crash.
+      crashDetails.processMetricsVanishedAmbiguousWithEarlierCrash = true
+    }
     for (const p of vanished) {
       attributedVanishedPids.add(p.pid)
     }
+  }
+  if (vanishedAlreadyReported > 0) {
+    // Why: consumed attribution must not read as "nothing vanished" — this
+    // says an earlier record already reported these pids, so the PreGone
+    // mirrors below describe that earlier crasher's era, not this one's.
+    crashDetails.processMetricsVanishedAlreadyReportedCount = vanishedAlreadyReported
   }
   if (preGoneSample) {
     Object.assign(crashDetails, preGoneSampleDetails(preGoneSample, Date.now()))
   }
   return crashDetails
-}
-
-export function buildSuppressedProcessGoneBreadcrumbData({
-  source,
-  processType,
-  reason,
-  exitCode,
-  expectedTeardown,
-  details
-}: {
-  source: 'renderer' | 'child'
-  processType: string
-  reason: string
-  exitCode: number | null
-  expectedTeardown: ExpectedTeardownScope
-  details: Record<string, unknown>
-}): CrashReportBreadcrumbData {
-  const breadcrumb: CrashReportBreadcrumbData = {
-    source,
-    processType,
-    reason,
-    exitCode,
-    expectedTeardown
-  }
-  const name = safeString(details.name)
-  if (name) {
-    breadcrumb.name = name
-  }
-  const serviceName = safeString(details.serviceName)
-  if (serviceName) {
-    breadcrumb.serviceName = serviceName
-  }
-  const type = safeString(details.type)
-  if (type) {
-    breadcrumb.type = type
-  }
-  return breadcrumb
 }

--- a/src/main/crash-reporting/process-gone-recorder.test.ts
+++ b/src/main/crash-reporting/process-gone-recorder.test.ts
@@ -1,9 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+const { appMetricsMock } = vi.hoisted(() => ({
+  appMetricsMock: vi.fn((): unknown[] => [])
+}))
+
 vi.mock('electron', () => ({
   app: {
     getVersion: () => '1.2.3-test',
-    getAppMetrics: () => []
+    getAppMetrics: appMetricsMock
   }
 }))
 
@@ -242,6 +246,35 @@ describe('recordProcessGoneCrash', () => {
       'network.mojom.NetworkService',
       'audio.mojom.AudioService'
     ])
+  })
+
+  it('derives the crashed-process-absent flag from the crashed process type', async () => {
+    // Binds event.processType through to the diagnostics bucket check: a live
+    // Utility survivor clears the flag for a Utility crash but not a renderer one.
+    appMetricsMock.mockReturnValue([
+      { pid: 77, type: 'Utility', memory: { workingSetSize: 1024 * 50 } }
+    ])
+
+    const rendererRecord = vi.fn().mockResolvedValue({ id: 'report-r' })
+    recordProcessGoneCrash({ record: rendererRecord } as never, event(), new ProcessGoneDedupe())
+    await vi.waitFor(() => expect(rendererRecord).toHaveBeenCalledOnce())
+    expect(rendererRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: expect.objectContaining({ processMetricsCrashedProcessAbsent: true })
+      })
+    )
+
+    const utilityRecord = vi.fn().mockResolvedValue({ id: 'report-u' })
+    recordProcessGoneCrash(
+      { record: utilityRecord } as never,
+      event({ source: 'child', processType: 'Utility', details: { type: 'Utility' } }),
+      new ProcessGoneDedupe()
+    )
+    await vi.waitFor(() => expect(utilityRecord).toHaveBeenCalledOnce())
+    const utilityDetails = (utilityRecord.mock.calls[0][0] as { details: Record<string, unknown> })
+      .details
+    expect(utilityDetails.processMetricsUtilityCount).toBe(1)
+    expect(utilityDetails.processMetricsCrashedProcessAbsent).toBeUndefined()
   })
 
   it('persists a report and flushes the process-gone trace before recovery', async () => {

--- a/src/main/crash-reporting/process-gone-recorder.ts
+++ b/src/main/crash-reporting/process-gone-recorder.ts
@@ -17,10 +17,8 @@ import {
   type ExpectedTeardownScope,
   type ProcessGoneSource
 } from './process-gone-classification'
-import {
-  buildProcessGoneCrashDetails,
-  buildSuppressedProcessGoneBreadcrumbData
-} from './process-gone-diagnostics'
+import { buildProcessGoneCrashDetails } from './process-gone-diagnostics'
+import { buildSuppressedProcessGoneBreadcrumbData } from './suppressed-process-gone-breadcrumb'
 import {
   getProcessGoneDedupeKey,
   processGoneDedupe,

--- a/src/main/crash-reporting/process-gone-recorder.ts
+++ b/src/main/crash-reporting/process-gone-recorder.ts
@@ -192,10 +192,13 @@ export function recordProcessGoneCrash(
     return
   }
   const mainProcessLifecycle = getMainProcessLifecycleIdentity()
-  const crashDetails = buildProcessGoneCrashDetails({
-    ...event.details,
-    ...mainProcessLifecycle
-  })
+  const crashDetails = buildProcessGoneCrashDetails(
+    {
+      ...event.details,
+      ...mainProcessLifecycle
+    },
+    event.processType
+  )
   const breadcrumbs = getCrashBreadcrumbSnapshot()
   const span = startSpan('electron.process_gone', {
     attributes: {

--- a/src/main/crash-reporting/suppressed-process-gone-breadcrumb.test.ts
+++ b/src/main/crash-reporting/suppressed-process-gone-breadcrumb.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { buildSuppressedProcessGoneBreadcrumbData } from './suppressed-process-gone-breadcrumb'
+
+describe('buildSuppressedProcessGoneBreadcrumbData', () => {
+  it('preserves child process identity on suppressed breadcrumbs', () => {
+    expect(
+      buildSuppressedProcessGoneBreadcrumbData({
+        source: 'child',
+        processType: 'Utility',
+        reason: 'killed',
+        exitCode: 1,
+        expectedTeardown: 'app-shutdown',
+        details: {
+          name: 'Network Service',
+          serviceName: 'network.mojom.NetworkService',
+          nested: { ignored: true }
+        }
+      })
+    ).toEqual({
+      source: 'child',
+      processType: 'Utility',
+      reason: 'killed',
+      exitCode: 1,
+      expectedTeardown: 'app-shutdown',
+      name: 'Network Service',
+      serviceName: 'network.mojom.NetworkService'
+    })
+  })
+
+  it('drops empty and non-string identity fields', () => {
+    expect(
+      buildSuppressedProcessGoneBreadcrumbData({
+        source: 'renderer',
+        processType: 'renderer',
+        reason: 'crashed',
+        exitCode: null,
+        expectedTeardown: 'none',
+        details: { name: '', serviceName: 42, type: undefined }
+      })
+    ).toEqual({
+      source: 'renderer',
+      processType: 'renderer',
+      reason: 'crashed',
+      exitCode: null,
+      expectedTeardown: 'none'
+    })
+  })
+})

--- a/src/main/crash-reporting/suppressed-process-gone-breadcrumb.test.ts
+++ b/src/main/crash-reporting/suppressed-process-gone-breadcrumb.test.ts
@@ -13,6 +13,8 @@ describe('buildSuppressedProcessGoneBreadcrumbData', () => {
         details: {
           name: 'Network Service',
           serviceName: 'network.mojom.NetworkService',
+          // Distinct from processType: proves type comes from details.type.
+          type: 'GPU',
           nested: { ignored: true }
         }
       })
@@ -23,7 +25,8 @@ describe('buildSuppressedProcessGoneBreadcrumbData', () => {
       exitCode: 1,
       expectedTeardown: 'app-shutdown',
       name: 'Network Service',
-      serviceName: 'network.mojom.NetworkService'
+      serviceName: 'network.mojom.NetworkService',
+      type: 'GPU'
     })
   })
 

--- a/src/main/crash-reporting/suppressed-process-gone-breadcrumb.ts
+++ b/src/main/crash-reporting/suppressed-process-gone-breadcrumb.ts
@@ -1,0 +1,43 @@
+import type { CrashReportBreadcrumbData } from '../../shared/crash-reporting'
+import type { ExpectedTeardownScope } from './process-gone-classification'
+
+function safeString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+export function buildSuppressedProcessGoneBreadcrumbData({
+  source,
+  processType,
+  reason,
+  exitCode,
+  expectedTeardown,
+  details
+}: {
+  source: 'renderer' | 'child'
+  processType: string
+  reason: string
+  exitCode: number | null
+  expectedTeardown: ExpectedTeardownScope
+  details: Record<string, unknown>
+}): CrashReportBreadcrumbData {
+  const breadcrumb: CrashReportBreadcrumbData = {
+    source,
+    processType,
+    reason,
+    exitCode,
+    expectedTeardown
+  }
+  const name = safeString(details.name)
+  if (name) {
+    breadcrumb.name = name
+  }
+  const serviceName = safeString(details.serviceName)
+  if (serviceName) {
+    breadcrumb.serviceName = serviceName
+  }
+  const type = safeString(details.type)
+  if (type) {
+    breadcrumb.type = type
+  }
+  return breadcrumb
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2850,8 +2850,8 @@ void app.whenReady().then(async () => {
       removeManagedAgentHooks()
     }
   }
-  // Why: process-gone metrics only see survivors; keep a fresh pre-death sample
-  // so a crashed process's last working set reaches its crash report.
+  // Why: process-gone metrics only see survivors; retain a recent whole-app
+  // snapshot for comparison in crash reports.
   startPreGoneProcessMetricsSampling()
   app.on('child-process-gone', (_event, details) => {
     recordProcessGoneCrash('child', details.type, details.reason, details.exitCode ?? null, {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -318,6 +318,7 @@ import {
 } from './crash-reporting/process-gone-classification'
 import { recordProcessGoneCrash as recordProcessGoneCrashEvent } from './crash-reporting/process-gone-recorder'
 import { startCrashpadCapture } from './crash-reporting/crashpad-capture'
+import { startPreGoneProcessMetricsSampling } from './crash-reporting/process-gone-diagnostics'
 import { resolveExpectedTeardownScope } from './crash-reporting/expected-teardown-state'
 import {
   advanceSyntheticTitleSpinnerEntries,
@@ -2849,6 +2850,9 @@ void app.whenReady().then(async () => {
       removeManagedAgentHooks()
     }
   }
+  // Why: process-gone metrics only see survivors; keep a fresh pre-death sample
+  // so a crashed process's last working set reaches its crash report.
+  startPreGoneProcessMetricsSampling()
   app.on('child-process-gone', (_event, details) => {
     recordProcessGoneCrash('child', details.type, details.reason, details.exitCode ?? null, {
       name: details.name,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​684 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​32 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​652 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​315 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​55 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​260 |

<!-- /orca-pr-loc -->

## ELI5

When an Orca process crashes, Electron reports the event after that process has already left its process list. The existing crash record therefore describes surviving processes only, which can make a survivor look like the process relevant to the crash.

This PR keeps a recent, whole-app process snapshot and writes it beside the post-gone snapshot. It deliberately does **not** guess which cached row was the crasher: Electron's gone events do not include a PID, so every cached snapshot carries an explicit attribution-ambiguity flag.

## What Changed

- Starts one unref'd 60-second main-process sampler, with an immediate first sample.
- Emits the cached whole-app snapshot under `processMetricsPreGone*`, plus `processMetricsPreGoneSampleAgeMs`.
- Emits `processMetricsPreGoneCrashedProcessAttributionAmbiguous: true` whenever a cached snapshot is present.
- Keeps existing plain `processMetrics*` fields as the post-gone, survivors-only snapshot.
- Uses Electron's documented `(pid, creationTime)` process identity when checking whether a sampled process from the crashed bucket disappeared, including same-PID/same-bucket reuse.
- Adds renderer-wide peak working-set and private-byte maxima when Electron supplies them.
- Adds system-memory fields sampled while building the gone record.

## Exact Telemetry Semantics

- `processMetricsLargest*` is the largest process in the post-gone snapshot and may be a survivor.
- `processMetricsPreGoneLargest*` is the largest process in the entire cached snapshot and may also be a survivor.
- `processMetricsPreGoneRendererWorkingSetMB` is the sum across all cached renderer/Tab processes.
- `processMetricsPreGoneRendererPeakWorkingSetMB` and `...PrivateMB` are maxima across all cached renderer/Tab processes.
- No `PreGone*` field identifies the crashed process. `processMetricsPreGoneCrashedProcessAttributionAmbiguous: true` is the machine-readable boundary.
- `processMetricsCrashedProcessAbsent` is a stateless absence signal: the gone-time bucket is empty, or a sampled same-bucket `(pid, creationTime)` identity is no longer present. Missing creation time degrades conservatively rather than claiming same-bucket PID replacement.
- `systemMemory*` is sampled after Electron reports the process gone. Released memory can make free/swap-free look healthier than it was when the process exited; these fields are not crash-instant measurements.

## Why

Field reports consistently showed renderer-gone records with the dead renderer missing from `app.getAppMetrics()`. A periodic snapshot restores useful before/after context, but a multi-renderer counterexample sets the contract boundary: a 300 MB renderer can die while a surviving 4.38 GB Tab owns cached Largest, peak, and private fields, and the renderer total is their 4.68 GB sum.

There is no more precise stateless implementation available from Electron's event payload. Per-crasher attribution would require new correlation/state machinery and would still be ambiguous across unrelated closes, crash loops, and processes born between samples, so this PR keeps the snapshot honest instead.

## Trade-offs

- With successful sweeps, the cached snapshot is normally up to 60 seconds old. Failed sweeps retain the last good sample, so it can be older; `SampleAgeMs` reports the actual staleness.
- A process born and gone inside one interval may never appear in the cache.
- A sweep during the blind period after death can replace the cache with a survivor-only snapshot; that zero/empty shape is preserved rather than attributed to a later crash.
- Crash-loop records can reuse one cached era, but the ambiguity marker prevents interpreting it as a later crasher's metrics.
- On macOS, Electron exposes total/free/file-backed/purgeable memory but no swap fields, and post-release free memory cannot confirm memory pressure. Windows/Linux swap fields are emitted when supplied.

## Performance Review

The sampler adds one `app.getAppMetrics()` call at startup and once per 60 seconds. Work and retention are O(current Electron process count), the cache replaces one bounded snapshot rather than accumulating history, failed sweeps retain the last good sample, and the timer is unref'd. The existing real-Electron measurement for this branch was roughly 100 microseconds per process (about 3-6 ms for a heavy process tree), or approximately 0.005-0.01% duty at this interval.

## Safety and Compatibility Review

- **Security:** numeric process/system metrics only; `creationTime` is used internally and is not emitted. No new input, IPC, filesystem, or network surface.
- **macOS / Windows / Linux:** `creationTime` is part of Electron's cross-platform `ProcessMetric` contract; optional platform memory fields are omitted rather than zero-filled.
- **SSH / folder workspaces / mobile:** unaffected; collection belongs to the local Electron main process and assumes neither a git worktree nor a remote host.
- **Wire / provider compatibility:** no RPC, stream, Git, or provider contract changes.
- **Backwards compatibility:** additive fields only; existing plain-prefix field meanings are unchanged.
- **Startup:** sampling begins after `app.whenReady()` and before process-gone listeners are installed; duplicate starts are guarded and the interval cannot keep shutdown alive.

## Testing

- `process-gone-diagnostics.test.ts`: 28 passed, including the larger-surviving-Tab counterexample, ambiguity field, same-PID/same-bucket `creationTime` reuse, blind-era/crash-loop behavior, platform-shaped system memory, startup sampling, failed sweeps, and unref cleanup.
- `process-gone-recorder.test.ts`: 21 passed.
- `suppressed-process-gone-breadcrumb.test.ts`: 2 passed.
- `pnpm run typecheck:node`: passed.
- Targeted `oxlint`, `oxfmt --check`, `git diff --check`, and the max-lines ratchet: passed.

## Live Electron QA

Grok QA launched the exact review head `c05398e77647e2bae215721fe33f8cf7e53dfcef` from this worktree, verified `window.api.app.getIdentity()`, and triggered a real renderer crash via CDP `Page.crash`. The recovered crash dialog and persisted `crash-reports.json` showed `processMetricsCrashedProcessAbsent: true`, `processMetricsPreGoneCrashedProcessAttributionAmbiguous: true`, a surviving Browser as post-gone Largest, and macOS total/free/file-backed/purgeable fields with swap omitted. A final validation after rebasing onto current main ran the exact head `9bd2d59e584a0d5685675905aebd039836c963f8`: all focused tests and node typecheck passed, and a fresh-profile real renderer crash after the sampling tick persisted the renderer in the pre-gone snapshot while the post-gone Largest remained the surviving Browser. A crash before the first post-startup tick also reproduced the documented born-and-gone interval blind spot.

![Healthy PR worktree](https://github.com/user-attachments/assets/4a35da89-e13d-4e71-b601-fb8aa3aa711e)

![Recovered crash dialog](https://github.com/user-attachments/assets/a8a095ae-4f89-4aa3-96c8-003b106ae596)

![Post-gone survivor metrics](https://github.com/user-attachments/assets/0b21d5c0-acfa-4d53-8bc6-0c8629d4adcf)

![Pre-gone ambiguity and snapshot metrics](https://github.com/user-attachments/assets/b262f176-5b44-4b3d-ae52-b24c0a28bddd)

Windows/Linux swap fields were not live-tested; source guards and shaped platform tests cover field availability, with the final CI matrix still running.

## Linked Issue

No tracked GitHub issue; this came from the 2026-08-13/14 `#orca-crashes` field sweep.

## AI Disclosure

AI assisted with implementation, adversarial review, and focused test construction.

## Checklist

- [x] Focused change with exact telemetry semantics documented
- [x] Automated regression tests added
- [x] Security, performance, cross-platform, SSH/folder, mobile, and compatibility impact reviewed
- [x] Live Electron crash telemetry proof attached
- [ ] Full suite/build not run locally; focused tests and node typecheck passed, with remaining coverage left to CI

## Author

- X / Twitter: @BrennanKB5