### PR TITLE
fix(mobile-native-chat): retire pending bubbles glued into one transcript row (mobile half of #14262)

### DIFF
--- a/mobile/src/session/mobile-native-chat-pending-echo.ts
+++ b/mobile/src/session/mobile-native-chat-pending-echo.ts
@@ -2,6 +2,8 @@ export type MobileNativeChatPendingMessage = {
   id: string
   text: string
   expectedOccurrence: number
+  /** Whether the transcript snapshot captured before this send was authoritative. */
+  glueBaselineTrusted: boolean
   /** Local preview URIs carried by the send for its optimistic echo. */
   images?: string[]
   baselineTailMessageId: string | null
@@ -13,6 +15,7 @@ export type MobileNativeChatSendOrigin = {
   normalizedText: string
   baselineOccurrences: number
   baselineTailMessageId: string | null
+  glueBaselineTrusted: boolean
 }
 
 type PendingByKey = Record<string, MobileNativeChatPendingMessage[]>
@@ -56,6 +59,7 @@ export function appendMobileNativeChatPending(
             ? expectedImageEchoOrdinal
             : origin.baselineOccurrences + earlierOutstanding + 1,
         baselineTailMessageId: origin.baselineTailMessageId,
+        glueBaselineTrusted: origin.glueBaselineTrusted,
         ...(images?.length ? { images } : {})
       }
     ]

--- a/mobile/src/session/mobile-native-chat-pending-retirement.test.ts
+++ b/mobile/src/session/mobile-native-chat-pending-retirement.test.ts
@@ -27,9 +27,10 @@ function pendingSend(
   id: string,
   text: string,
   tail: string | null,
-  expectedOccurrence = 1
+  expectedOccurrence = 1,
+  glueBaselineTrusted = true
 ): MobileNativeChatPendingMessage {
-  return { id, text, expectedOccurrence, baselineTailMessageId: tail }
+  return { id, text, expectedOccurrence, baselineTailMessageId: tail, glueBaselineTrusted }
 }
 
 function retiredIds(
@@ -173,6 +174,15 @@ describe('selectGluedPendingIds', () => {
     const messages = [userTurn('m1', 'one two', 5000)]
     const pending = [pendingSend('p1', 'one', null), pendingSend('p2', 'two', null)]
     expect(retiredIds(messages, pending)).toEqual(['p1', 'p2'])
+  })
+
+  it('does not trust history loaded after sends captured against a placeholder transcript', () => {
+    const messages = [userTurn('m1', 'one two', 1000)]
+    const pending = [
+      pendingSend('p1', 'one', null, 1, false),
+      pendingSend('p2', 'two', null, 1, false)
+    ]
+    expect(retiredIds(messages, pending)).toEqual([])
   })
 
   it('skips a caption-less image echo instead of gluing it', () => {

--- a/mobile/src/session/mobile-native-chat-pending-retirement.test.ts
+++ b/mobile/src/session/mobile-native-chat-pending-retirement.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
 import type { MobileNativeChatPendingMessage } from './mobile-native-chat-pending-echo'
 import {
@@ -189,6 +189,28 @@ describe('selectGluedPendingIds', () => {
     const messages = [assistantTurn('m1', 'ready', 1000), userTurn('m2', 'one two', 5000)]
     expect(retiredIds(messages, [pendingSend('p1', 'one', 'm1')])).toEqual([])
   })
+
+  it('inspects each pending segment at most once per transcript turn', () => {
+    const pendingCount = 96
+    const turnCount = 12
+    const text = `${'a '.repeat(pendingCount)}x`
+    const messages = [
+      assistantTurn('tail', 'ready', 1000),
+      ...Array.from({ length: turnCount }, (_, index) => userTurn(`m${index}`, text, 2000 + index))
+    ]
+    const pending = Array.from({ length: pendingCount }, (_, index) =>
+      pendingSend(`p${index}`, 'a', 'tail', index + 1)
+    )
+    const startsWith = vi.spyOn(String.prototype, 'startsWith')
+    let segmentChecks = 0
+    try {
+      expect(retiredIds(messages, pending)).toEqual([])
+      segmentChecks = startsWith.mock.calls.length
+    } finally {
+      startsWith.mockRestore()
+    }
+    expect(segmentChecks).toBeLessThanOrEqual(turnCount * pendingCount)
+  })
 })
 
 describe('retireLandedMobileNativeChatPending', () => {
@@ -212,6 +234,22 @@ describe('retireLandedMobileNativeChatPending', () => {
     expect(
       retireLandedMobileNativeChatPending(messages, pending, NO_IMAGE_ECHOES).map((item) => item.id)
     ).toEqual(['p1', 'p2'])
+  })
+
+  it('does not glue former neighbors across an exact-landed send', () => {
+    const messages = [
+      assistantTurn('m0', 'ready', 1000),
+      userTurn('m1', 'middle', 2000),
+      userTurn('m2', 'one two', 3000)
+    ]
+    const pending = [
+      pendingSend('p1', 'one', 'm0'),
+      pendingSend('p2', 'middle', 'm0'),
+      pendingSend('p3', 'two', 'm0')
+    ]
+    expect(
+      retireLandedMobileNativeChatPending(messages, pending, NO_IMAGE_ECHOES).map((item) => item.id)
+    ).toEqual(['p1', 'p3'])
   })
 
   it('keeps image echoes until their preview is rebound', () => {

--- a/mobile/src/session/mobile-native-chat-pending-retirement.test.ts
+++ b/mobile/src/session/mobile-native-chat-pending-retirement.test.ts
@@ -185,6 +185,18 @@ describe('selectGluedPendingIds', () => {
     expect(retiredIds(messages, pending)).toEqual(['p2', 'p3'])
   })
 
+  it('keeps a captioned image echo and its neighbors until the preview is rebound', () => {
+    const messages = [assistantTurn('m1', 'ready', 1000), userTurn('m2', 'one two', 5000)]
+    const pending = [
+      { ...pendingSend('p1', 'one', 'm1'), images: ['file:///a.png'] },
+      pendingSend('p2', 'two', 'm1')
+    ]
+    expect(retiredIds(messages, pending)).toEqual([])
+    expect(
+      retireLandedMobileNativeChatPending(messages, pending, NO_IMAGE_ECHOES).map((item) => item.id)
+    ).toEqual(['p1', 'p2'])
+  })
+
   it('does nothing for a single pending send', () => {
     const messages = [assistantTurn('m1', 'ready', 1000), userTurn('m2', 'one two', 5000)]
     expect(retiredIds(messages, [pendingSend('p1', 'one', 'm1')])).toEqual([])

--- a/mobile/src/session/mobile-native-chat-pending-retirement.test.ts
+++ b/mobile/src/session/mobile-native-chat-pending-retirement.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from 'vitest'
+import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
+import type { MobileNativeChatPendingMessage } from './mobile-native-chat-pending-echo'
+import {
+  retireLandedMobileNativeChatPending,
+  selectGluedPendingIds
+} from './mobile-native-chat-pending-retirement'
+
+const NO_IMAGE_ECHOES: ReadonlySet<string> = new Set()
+
+function userTurn(id: string, text: string, timestamp: number): NativeChatMessage {
+  return { id, role: 'user', blocks: [{ type: 'text', text }], timestamp, source: 'transcript' }
+}
+
+function assistantTurn(id: string, text: string, timestamp: number): NativeChatMessage {
+  return {
+    id,
+    role: 'assistant',
+    blocks: [{ type: 'text', text }],
+    timestamp,
+    source: 'transcript'
+  }
+}
+
+/** A send captured with `tail` as the last transcript message it could see. */
+function pendingSend(
+  id: string,
+  text: string,
+  tail: string | null,
+  expectedOccurrence = 1
+): MobileNativeChatPendingMessage {
+  return { id, text, expectedOccurrence, baselineTailMessageId: tail }
+}
+
+function retiredIds(
+  messages: readonly NativeChatMessage[],
+  pending: readonly MobileNativeChatPendingMessage[]
+): string[] {
+  return [...selectGluedPendingIds(messages, pending)].sort()
+}
+
+describe('selectGluedPendingIds', () => {
+  it('retires both bubbles when two rapid sends collapse into one user row', () => {
+    const messages = [
+      assistantTurn('m1', 'ready', 1000),
+      userTurn('m2', 'run the tests again', 5000)
+    ]
+    const pending = [pendingSend('p1', 'run the tests', 'm1'), pendingSend('p2', 'again', 'm1')]
+    expect(retiredIds(messages, pending)).toEqual(['p1', 'p2'])
+  })
+
+  it('retires a glued row that concatenated with no separator at all', () => {
+    const messages = [
+      assistantTurn('m1', 'ready', 1000),
+      userTurn('m2', 'run the testsagain', 5000)
+    ]
+    const pending = [pendingSend('p1', 'run the tests', 'm1'), pendingSend('p2', 'again', 'm1')]
+    expect(retiredIds(messages, pending)).toEqual(['p1', 'p2'])
+  })
+
+  it('retires three collapsed prompts in one row', () => {
+    const messages = [assistantTurn('m1', 'ready', 1000), userTurn('m2', 'one two three', 5000)]
+    const pending = [
+      pendingSend('p1', 'one', 'm1'),
+      pendingSend('p2', 'two', 'm1'),
+      pendingSend('p3', 'three', 'm1')
+    ]
+    expect(retiredIds(messages, pending)).toEqual(['p1', 'p2', 'p3'])
+  })
+
+  it('matches across tab, newline and repeated-space separators', () => {
+    const messages = [
+      assistantTurn('m1', 'ready', 1000),
+      userTurn('m2', 'run the tests\t\n  again', 5000)
+    ]
+    const pending = [
+      pendingSend('p1', ' run the tests\n', 'm1'),
+      pendingSend('p2', '\tagain ', 'm1')
+    ]
+    expect(retiredIds(messages, pending)).toEqual(['p1', 'p2'])
+  })
+
+  it('matches prompts that themselves contain the separator', () => {
+    const messages = [
+      assistantTurn('m1', 'ready', 1000),
+      userTurn('m2', 'fix the bug and run the tests', 5000)
+    ]
+    const pending = [
+      pendingSend('p1', 'fix the bug', 'm1'),
+      pendingSend('p2', 'and run the tests', 'm1')
+    ]
+    expect(retiredIds(messages, pending)).toEqual(['p1', 'p2'])
+  })
+
+  it('matches when one pending is a strict prefix of the next', () => {
+    const messages = [assistantTurn('m1', 'ready', 1000), userTurn('m2', 'run run the tests', 5000)]
+    const pending = [pendingSend('p1', 'run', 'm1'), pendingSend('p2', 'run the tests', 'm1')]
+    expect(retiredIds(messages, pending)).toEqual(['p1', 'p2'])
+  })
+
+  it('matches identical prompts sent twice and three times', () => {
+    const twice = [assistantTurn('m1', 'ready', 1000), userTurn('m2', 'hi hi', 5000)]
+    expect(
+      retiredIds(twice, [pendingSend('p1', 'hi', 'm1', 1), pendingSend('p2', 'hi', 'm1', 2)])
+    ).toEqual(['p1', 'p2'])
+
+    const thrice = [assistantTurn('m1', 'ready', 1000), userTurn('m2', 'hi hi hi', 5000)]
+    expect(
+      retiredIds(thrice, [
+        pendingSend('p1', 'hi', 'm1', 1),
+        pendingSend('p2', 'hi', 'm1', 2),
+        pendingSend('p3', 'hi', 'm1', 3)
+      ])
+    ).toEqual(['p1', 'p2', 'p3'])
+  })
+
+  it('retires two separate glued rows against their own runs', () => {
+    const messages = [
+      assistantTurn('m1', 'ready', 1000),
+      userTurn('m2', 'one two', 5000),
+      userTurn('m3', 'three four', 6000)
+    ]
+    const pending = [
+      pendingSend('p1', 'one', 'm1'),
+      pendingSend('p2', 'two', 'm1'),
+      pendingSend('p3', 'three', 'm2'),
+      pendingSend('p4', 'four', 'm2')
+    ]
+    expect(retiredIds(messages, pending)).toEqual(['p1', 'p2', 'p3', 'p4'])
+  })
+
+  // FP1: the concatenation already exists in history, older than the sends.
+  it('never lets a transcript row that predates the sends retire them', () => {
+    const messages = [
+      userTurn('m1', 'run the tests again', 1),
+      assistantTurn('m2', 'done', 2),
+      assistantTurn('m3', 'anything else?', 3)
+    ]
+    const pending = [pendingSend('p1', 'run the tests', 'm3'), pendingSend('p2', 'again', 'm3')]
+    expect(retiredIds(messages, pending)).toEqual([])
+  })
+
+  // FP2: an old turn reads like the concatenation of two much later sends.
+  it('never lets an older turn retire sends captured after it', () => {
+    const messages = [userTurn('m1', 'fix the bug', 1000), assistantTurn('m2', 'fixed', 1100)]
+    const pending = [pendingSend('p1', 'fix the', 'm2'), pendingSend('p2', 'bug', 'm2')]
+    expect(retiredIds(messages, pending)).toEqual([])
+  })
+
+  it('rejects a row the pending run only prefixes', () => {
+    const messages = [
+      assistantTurn('m1', 'ready', 1000),
+      userTurn('m2', 'run the tests again with coverage', 5000)
+    ]
+    const pending = [pendingSend('p1', 'run the tests', 'm1'), pendingSend('p2', 'again', 'm1')]
+    expect(retiredIds(messages, pending)).toEqual([])
+  })
+
+  it('rejects a run that only partly spells the row', () => {
+    const messages = [assistantTurn('m1', 'ready', 1000), userTurn('m2', 'run the tests', 5000)]
+    const pending = [pendingSend('p1', 'run the tests', 'm1'), pendingSend('p2', 'again', 'm1')]
+    // A lone exact match is an ordinary landing, not glue.
+    expect(retiredIds(messages, pending)).toEqual([])
+  })
+
+  it('rejects glue when a send in the run cannot resolve its own tail', () => {
+    const messages = [assistantTurn('m1', 'ready', 1000), userTurn('m2', 'one two', 5000)]
+    const pending = [pendingSend('p1', 'one', 'm1'), pendingSend('p2', 'two', 'paginated-away')]
+    expect(retiredIds(messages, pending)).toEqual([])
+  })
+
+  it('treats a null tail as "transcript was empty", so any row can glue', () => {
+    const messages = [userTurn('m1', 'one two', 5000)]
+    const pending = [pendingSend('p1', 'one', null), pendingSend('p2', 'two', null)]
+    expect(retiredIds(messages, pending)).toEqual(['p1', 'p2'])
+  })
+
+  it('skips a caption-less image echo instead of gluing it', () => {
+    const messages = [assistantTurn('m1', 'ready', 1000), userTurn('m2', 'one two', 5000)]
+    const pending = [
+      pendingSend('p1', '', 'm1'),
+      pendingSend('p2', 'one', 'm1'),
+      pendingSend('p3', 'two', 'm1')
+    ]
+    expect(retiredIds(messages, pending)).toEqual(['p2', 'p3'])
+  })
+
+  it('does nothing for a single pending send', () => {
+    const messages = [assistantTurn('m1', 'ready', 1000), userTurn('m2', 'one two', 5000)]
+    expect(retiredIds(messages, [pendingSend('p1', 'one', 'm1')])).toEqual([])
+  })
+})
+
+describe('retireLandedMobileNativeChatPending', () => {
+  it('retires exact landings by ordinal and glued rows in the same pass', () => {
+    const messages = [
+      assistantTurn('m1', 'ready', 1000),
+      userTurn('m2', 'standalone', 4000),
+      userTurn('m3', 'run the tests again', 5000)
+    ]
+    const pending = [
+      pendingSend('p0', 'standalone', 'm1'),
+      pendingSend('p1', 'run the tests', 'm2'),
+      pendingSend('p2', 'again', 'm2')
+    ]
+    expect(retireLandedMobileNativeChatPending(messages, pending, NO_IMAGE_ECHOES)).toEqual([])
+  })
+
+  it('keeps sends whose glue candidate predates them', () => {
+    const messages = [userTurn('m1', 'fix the bug', 1000), assistantTurn('m2', 'fixed', 1100)]
+    const pending = [pendingSend('p1', 'fix the', 'm2'), pendingSend('p2', 'bug', 'm2')]
+    expect(
+      retireLandedMobileNativeChatPending(messages, pending, NO_IMAGE_ECHOES).map((item) => item.id)
+    ).toEqual(['p1', 'p2'])
+  })
+
+  it('keeps image echoes until their preview is rebound', () => {
+    const messages = [assistantTurn('m1', 'ready', 1000)]
+    const pending = [{ ...pendingSend('p1', 'photo', 'm1'), images: ['file:///a.png'] }]
+    expect(
+      retireLandedMobileNativeChatPending(messages, pending, NO_IMAGE_ECHOES).map((item) => item.id)
+    ).toEqual(['p1'])
+    expect(retireLandedMobileNativeChatPending(messages, pending, new Set(['p1']))).toEqual([])
+  })
+})

--- a/mobile/src/session/mobile-native-chat-pending-retirement.ts
+++ b/mobile/src/session/mobile-native-chat-pending-retirement.ts
@@ -1,0 +1,134 @@
+import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
+import {
+  countImageSourceTurnsAfter,
+  normalizeReconcileText,
+  normalizedUserText
+} from './mobile-native-chat-draft-reconcile'
+import type { MobileNativeChatPendingMessage } from './mobile-native-chat-pending-echo'
+
+const SPACE = ' '
+
+/** A normalized user turn plus its transcript position, which bounds glue. */
+type UserTurn = { index: number; text: string }
+
+/**
+ * Ids retired by a single transcript turn that glued several rapid sends into
+ * one row (the host writes a send's body and its Enter ~500ms apart, so a second
+ * body can land on the same TUI input line before the first submits).
+ *
+ * Bounded to turns strictly AFTER each send's captured tail. Without that bound
+ * an older turn that happens to read like the concatenation retires a newer
+ * send, and a message the user really queued silently never renders.
+ */
+export function selectGluedPendingIds(
+  messages: readonly NativeChatMessage[],
+  pending: readonly MobileNativeChatPendingMessage[]
+): ReadonlySet<string> {
+  const retired = new Set<string>()
+  if (pending.length < 2) {
+    return retired
+  }
+  const messageIndexById = new Map<string, number>()
+  const turns: UserTurn[] = []
+  for (const [index, message] of messages.entries()) {
+    messageIndexById.set(message.id, index)
+    const text = normalizedUserText(message)
+    if (text) {
+      turns.push({ index, text })
+    }
+  }
+  // Image echoes carry no caption to concatenate; an unresolvable tail leaves the
+  // send unbounded. Either way the item can only end a run, never join one.
+  const segments = pending.map((item) => normalizeReconcileText(item.text))
+  const tails = pending.map((item) =>
+    item.baselineTailMessageId === null
+      ? -1
+      : (messageIndexById.get(item.baselineTailMessageId) ?? null)
+  )
+
+  let cursor = 0
+  for (const turn of turns) {
+    if (cursor >= pending.length - 1) {
+      break
+    }
+    for (let start = cursor; start < pending.length - 1; start++) {
+      const matched = matchGluedRun(turn, segments, tails, start)
+      if (matched === 0) {
+        continue
+      }
+      for (let index = start; index < start + matched; index++) {
+        retired.add(pending[index]!.id)
+      }
+      cursor = start + matched
+      break
+    }
+  }
+  return retired
+}
+
+/**
+ * Length of the pending run starting at `start` that exactly spells out `turn`,
+ * or 0 when there is none. Greedy is provably equivalent to backtracking here:
+ * both sides are whitespace-normalized, so a segment can never begin with the
+ * optional single-space separator and consuming it is forced.
+ */
+function matchGluedRun(
+  turn: UserTurn,
+  segments: readonly string[],
+  tails: readonly (number | null)[],
+  start: number
+): number {
+  let at = 0
+  let matched = 0
+  for (let index = start; index < segments.length; index++) {
+    const segment = segments[index]!
+    const tail = tails[index]
+    if (segment === '' || tail === null || turn.index <= tail) {
+      return 0
+    }
+    if (at > 0 && turn.text[at] === SPACE) {
+      at += 1
+    }
+    if (!turn.text.startsWith(segment, at)) {
+      return 0
+    }
+    at += segment.length
+    matched += 1
+    if (at === turn.text.length) {
+      // A lone exact match is an ordinary landing, which the count pass owns.
+      return matched > 1 ? matched : 0
+    }
+  }
+  return 0
+}
+
+/** Pending echoes that survive this transcript: exact-text landings retire by
+ *  ordinal, and whatever is left gets one bounded pass for a glued row. */
+export function retireLandedMobileNativeChatPending(
+  messages: readonly NativeChatMessage[],
+  current: readonly MobileNativeChatPendingMessage[],
+  landedImagePendingIds: ReadonlySet<string>
+): MobileNativeChatPendingMessage[] {
+  const landedCounts = new Map<string, number>()
+  for (const message of messages) {
+    const text = normalizedUserText(message)
+    if (text) {
+      landedCounts.set(text, (landedCounts.get(text) ?? 0) + 1)
+    }
+  }
+  // Image-only source-turn counts stay stable across reruns and ignore paginated history.
+  const survivors = current.filter((item) => {
+    if (landedImagePendingIds.has(item.id)) {
+      return false
+    }
+    // Keep image echoes until their local preview reaches the authoritative message.
+    if (item.images?.length) {
+      return true
+    }
+    return item.text.trim() === ''
+      ? countImageSourceTurnsAfter(messages, item.baselineTailMessageId) < item.expectedOccurrence
+      : (landedCounts.get(normalizeReconcileText(item.text)) ?? 0) < item.expectedOccurrence
+  })
+  const glued = selectGluedPendingIds(messages, survivors)
+  return glued.size === 0 ? survivors : survivors.filter((item) => !glued.has(item.id))
+}

--- a/mobile/src/session/mobile-native-chat-pending-retirement.ts
+++ b/mobile/src/session/mobile-native-chat-pending-retirement.ts
@@ -37,7 +37,9 @@ export function selectGluedPendingIds(
       item.baselineTailMessageId === null
         ? -1
         : (messageIndexById.get(item.baselineTailMessageId) ?? null)
-    return excludedPendingIds.has(item.id) || text === '' || tail === null ? null : { text, tail }
+    return excludedPendingIds.has(item.id) || item.images?.length || text === '' || tail === null
+      ? null
+      : { text, tail }
   })
 
   // Barriers preserve original adjacency after exact landings retire.

--- a/mobile/src/session/mobile-native-chat-pending-retirement.ts
+++ b/mobile/src/session/mobile-native-chat-pending-retirement.ts
@@ -37,7 +37,11 @@ export function selectGluedPendingIds(
       item.baselineTailMessageId === null
         ? -1
         : (messageIndexById.get(item.baselineTailMessageId) ?? null)
-    return excludedPendingIds.has(item.id) || item.images?.length || text === '' || tail === null
+    return excludedPendingIds.has(item.id) ||
+      !item.glueBaselineTrusted ||
+      item.images?.length ||
+      text === '' ||
+      tail === null
       ? null
       : { text, tail }
   })

--- a/mobile/src/session/mobile-native-chat-pending-retirement.ts
+++ b/mobile/src/session/mobile-native-chat-pending-retirement.ts
@@ -7,22 +7,16 @@ import {
 import type { MobileNativeChatPendingMessage } from './mobile-native-chat-pending-echo'
 
 const SPACE = ' '
+const NO_PENDING_IDS: ReadonlySet<string> = new Set()
 
-/** A normalized user turn plus its transcript position, which bounds glue. */
 type UserTurn = { index: number; text: string }
+type GlueSegment = { text: string; tail: number } | null
 
-/**
- * Ids retired by a single transcript turn that glued several rapid sends into
- * one row (the host writes a send's body and its Enter ~500ms apart, so a second
- * body can land on the same TUI input line before the first submits).
- *
- * Bounded to turns strictly AFTER each send's captured tail. Without that bound
- * an older turn that happens to read like the concatenation retires a newer
- * send, and a message the user really queued silently never renders.
- */
+/** Pending ids represented by post-send transcript rows that glued adjacent sends. */
 export function selectGluedPendingIds(
   messages: readonly NativeChatMessage[],
-  pending: readonly MobileNativeChatPendingMessage[]
+  pending: readonly MobileNativeChatPendingMessage[],
+  excludedPendingIds: ReadonlySet<string> = NO_PENDING_IDS
 ): ReadonlySet<string> {
   const retired = new Set<string>()
   if (pending.length < 2) {
@@ -37,62 +31,65 @@ export function selectGluedPendingIds(
       turns.push({ index, text })
     }
   }
-  // Image echoes carry no caption to concatenate; an unresolvable tail leaves the
-  // send unbounded. Either way the item can only end a run, never join one.
-  const segments = pending.map((item) => normalizeReconcileText(item.text))
-  const tails = pending.map((item) =>
-    item.baselineTailMessageId === null
-      ? -1
-      : (messageIndexById.get(item.baselineTailMessageId) ?? null)
-  )
+  const segments: GlueSegment[] = pending.map((item) => {
+    const text = normalizeReconcileText(item.text)
+    const tail =
+      item.baselineTailMessageId === null
+        ? -1
+        : (messageIndexById.get(item.baselineTailMessageId) ?? null)
+    return excludedPendingIds.has(item.id) || text === '' || tail === null ? null : { text, tail }
+  })
 
-  let cursor = 0
-  for (const turn of turns) {
-    if (cursor >= pending.length - 1) {
-      break
+  // Barriers preserve original adjacency after exact landings retire.
+  let runStart = 0
+  while (runStart < pending.length) {
+    while (runStart < pending.length && segments[runStart] === null) {
+      runStart += 1
     }
-    for (let start = cursor; start < pending.length - 1; start++) {
-      const matched = matchGluedRun(turn, segments, tails, start)
+    let runEnd = runStart
+    while (runEnd < pending.length && segments[runEnd] !== null) {
+      runEnd += 1
+    }
+    let cursor = runStart
+    for (const turn of turns) {
+      if (cursor >= runEnd - 1) {
+        break
+      }
+      const matched = matchGluedRun(turn, segments, cursor, runEnd)
       if (matched === 0) {
         continue
       }
-      for (let index = start; index < start + matched; index++) {
+      for (let index = cursor; index < cursor + matched; index++) {
         retired.add(pending[index]!.id)
       }
-      cursor = start + matched
-      break
+      cursor += matched
     }
+    runStart = runEnd + 1
   }
   return retired
 }
 
-/**
- * Length of the pending run starting at `start` that exactly spells out `turn`,
- * or 0 when there is none. Greedy is provably equivalent to backtracking here:
- * both sides are whitespace-normalized, so a segment can never begin with the
- * optional single-space separator and consuming it is forced.
- */
+/** Length of the exact glued run at `start`, or zero. */
 function matchGluedRun(
   turn: UserTurn,
-  segments: readonly string[],
-  tails: readonly (number | null)[],
-  start: number
+  segments: readonly GlueSegment[],
+  start: number,
+  end: number
 ): number {
   let at = 0
   let matched = 0
-  for (let index = start; index < segments.length; index++) {
+  for (let index = start; index < end; index++) {
     const segment = segments[index]!
-    const tail = tails[index]
-    if (segment === '' || tail === null || turn.index <= tail) {
+    if (turn.index <= segment.tail) {
       return 0
     }
     if (at > 0 && turn.text[at] === SPACE) {
       at += 1
     }
-    if (!turn.text.startsWith(segment, at)) {
+    if (!turn.text.startsWith(segment.text, at)) {
       return 0
     }
-    at += segment.length
+    at += segment.text.length
     matched += 1
     if (at === turn.text.length) {
       // A lone exact match is an ordinary landing, which the count pass owns.
@@ -102,8 +99,7 @@ function matchGluedRun(
   return 0
 }
 
-/** Pending echoes that survive this transcript: exact-text landings retire by
- *  ordinal, and whatever is left gets one bounded pass for a glued row. */
+/** Retires exact and glued transcript landings while preserving pending order. */
 export function retireLandedMobileNativeChatPending(
   messages: readonly NativeChatMessage[],
   current: readonly MobileNativeChatPendingMessage[],
@@ -116,19 +112,27 @@ export function retireLandedMobileNativeChatPending(
       landedCounts.set(text, (landedCounts.get(text) ?? 0) + 1)
     }
   }
-  // Image-only source-turn counts stay stable across reruns and ignore paginated history.
-  const survivors = current.filter((item) => {
+  const landedPendingIds = new Set<string>()
+  for (const item of current) {
     if (landedImagePendingIds.has(item.id)) {
-      return false
+      landedPendingIds.add(item.id)
+      continue
     }
     // Keep image echoes until their local preview reaches the authoritative message.
     if (item.images?.length) {
-      return true
+      continue
     }
-    return item.text.trim() === ''
-      ? countImageSourceTurnsAfter(messages, item.baselineTailMessageId) < item.expectedOccurrence
-      : (landedCounts.get(normalizeReconcileText(item.text)) ?? 0) < item.expectedOccurrence
-  })
-  const glued = selectGluedPendingIds(messages, survivors)
-  return glued.size === 0 ? survivors : survivors.filter((item) => !glued.has(item.id))
+    const landed =
+      item.text.trim() === ''
+        ? countImageSourceTurnsAfter(messages, item.baselineTailMessageId) >=
+          item.expectedOccurrence
+        : (landedCounts.get(normalizeReconcileText(item.text)) ?? 0) >= item.expectedOccurrence
+    if (landed) {
+      landedPendingIds.add(item.id)
+    }
+  }
+  const glued = selectGluedPendingIds(messages, current, landedPendingIds)
+  return landedPendingIds.size === 0 && glued.size === 0
+    ? [...current]
+    : current.filter((item) => !landedPendingIds.has(item.id) && !glued.has(item.id))
 }

--- a/mobile/src/session/use-mobile-native-chat-controller.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-controller.test.ts
@@ -96,7 +96,8 @@ const ORIGIN = {
   pendingKey: 'h\0w\0tab-1\0session-1',
   normalizedText: 'look',
   baselineOccurrences: 0,
-  baselineTailMessageId: null
+  baselineTailMessageId: null,
+  glueBaselineTrusted: true
 }
 
 describe('useMobileNativeChatController handleNativeChatSend', () => {

--- a/mobile/src/session/use-mobile-native-chat-drafts-glued-pending.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-drafts-glued-pending.test.ts
@@ -50,25 +50,32 @@ describe('useMobileNativeChatDrafts glued pending sends', () => {
     state = null
   })
 
-  function Harness({ messages }: { messages: NativeChatMessage[] }): null {
+  function Harness({
+    messages,
+    transcriptLoading = false
+  }: {
+    messages: NativeChatMessage[]
+    transcriptLoading?: boolean
+  }): null {
     state = useMobileNativeChatDrafts({
       hostId: 'host',
       worktreeId: 'worktree',
       tabId: 'tab',
       sessionId: 'session',
-      messages
+      messages,
+      transcriptLoading
     })
     return null
   }
 
-  async function mount(messages: NativeChatMessage[]): Promise<void> {
+  async function mount(messages: NativeChatMessage[], transcriptLoading = false): Promise<void> {
     await act(async () => {
-      renderer = create(createElement(Harness, { messages }))
+      renderer = create(createElement(Harness, { messages, transcriptLoading }))
     })
   }
 
-  async function update(messages: NativeChatMessage[]): Promise<void> {
-    await act(async () => renderer?.update(createElement(Harness, { messages })))
+  async function update(messages: NativeChatMessage[], transcriptLoading = false): Promise<void> {
+    await act(async () => renderer?.update(createElement(Harness, { messages, transcriptLoading })))
   }
 
   /** Two composer sends fired before either transcript echo lands. */
@@ -121,6 +128,16 @@ describe('useMobileNativeChatDrafts glued pending sends', () => {
     await update([...history])
     expect(state?.pending.map((item) => item.text)).toEqual(['fix the', 'bug'])
     expect(renderedPendingTexts(history, state)).toEqual(['fix the', 'bug'])
+  })
+
+  it('keeps both bubbles when history loads after their baseline was captured', async () => {
+    await mount([], true)
+    rapidSend('run the tests', 'again')
+
+    const loadedHistory = [userTurn('m1', 'run the tests again', 1000)]
+    await update(loadedHistory)
+    expect(state?.pending.map((item) => item.text)).toEqual(['run the tests', 'again'])
+    expect(renderedPendingTexts(loadedHistory, state)).toEqual(['run the tests', 'again'])
   })
 
   it('still retires each bubble on its own when the sends do not glue', async () => {

--- a/mobile/src/session/use-mobile-native-chat-drafts-glued-pending.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-drafts-glued-pending.test.ts
@@ -1,11 +1,15 @@
 import { createElement } from 'react'
-import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { act, create } from 'react-test-renderer'
 import { afterEach, describe, expect, it } from 'vitest'
 import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
 import { buildMobileNativeChatTransientData } from './mobile-native-chat-render-data'
 import { useMobileNativeChatDrafts } from './use-mobile-native-chat-drafts'
 
 type DraftState = ReturnType<typeof useMobileNativeChatDrafts>
+type TestRenderer = {
+  unmount(): void
+  update(element: ReturnType<typeof createElement>): void
+}
 
 function userTurn(id: string, text: string, timestamp: number): NativeChatMessage {
   return { id, role: 'user', blocks: [{ type: 'text', text }], timestamp, source: 'transcript' }
@@ -37,7 +41,7 @@ function renderedPendingTexts(
 }
 
 describe('useMobileNativeChatDrafts glued pending sends', () => {
-  let renderer: ReactTestRenderer | null = null
+  let renderer: TestRenderer | null = null
   let state: DraftState | null = null
 
   afterEach(() => {

--- a/mobile/src/session/use-mobile-native-chat-drafts-glued-pending.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-drafts-glued-pending.test.ts
@@ -1,0 +1,146 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
+import { buildMobileNativeChatTransientData } from './mobile-native-chat-render-data'
+import { useMobileNativeChatDrafts } from './use-mobile-native-chat-drafts'
+
+type DraftState = ReturnType<typeof useMobileNativeChatDrafts>
+
+function userTurn(id: string, text: string, timestamp: number): NativeChatMessage {
+  return { id, role: 'user', blocks: [{ type: 'text', text }], timestamp, source: 'transcript' }
+}
+
+function assistantTurn(id: string, text: string, timestamp: number): NativeChatMessage {
+  return {
+    id,
+    role: 'assistant',
+    blocks: [{ type: 'text', text }],
+    timestamp,
+    source: 'transcript'
+  }
+}
+
+/** Texts of the optimistic bubbles the chat list actually renders. */
+function renderedPendingTexts(
+  messages: NativeChatMessage[],
+  state: DraftState | null
+): (string | undefined)[] {
+  const { data } = buildMobileNativeChatTransientData({
+    folded: messages,
+    streaming: null,
+    pending: state?.pending ?? []
+  })
+  return data
+    .filter((message) => !messages.some((existing) => existing.id === message.id))
+    .map((message) => message.blocks.find((block) => block.type === 'text')?.text)
+}
+
+describe('useMobileNativeChatDrafts glued pending sends', () => {
+  let renderer: ReactTestRenderer | null = null
+  let state: DraftState | null = null
+
+  afterEach(() => {
+    act(() => renderer?.unmount())
+    renderer = null
+    state = null
+  })
+
+  function Harness({ messages }: { messages: NativeChatMessage[] }): null {
+    state = useMobileNativeChatDrafts({
+      hostId: 'host',
+      worktreeId: 'worktree',
+      tabId: 'tab',
+      sessionId: 'session',
+      messages
+    })
+    return null
+  }
+
+  async function mount(messages: NativeChatMessage[]): Promise<void> {
+    await act(async () => {
+      renderer = create(createElement(Harness, { messages }))
+    })
+  }
+
+  async function update(messages: NativeChatMessage[]): Promise<void> {
+    await act(async () => renderer?.update(createElement(Harness, { messages })))
+  }
+
+  /** Two composer sends fired before either transcript echo lands. */
+  function rapidSend(first: string, second: string): void {
+    act(() => {
+      const originFirst = state?.captureSendOrigin(first)
+      if (originFirst) {
+        state?.acceptSend(originFirst, first)
+      }
+      const originSecond = state?.captureSendOrigin(second)
+      if (originSecond) {
+        state?.acceptSend(originSecond, second)
+      }
+    })
+  }
+
+  it('retires both bubbles when the rapid sends land as one glued user row', async () => {
+    const history = [assistantTurn('m1', 'ready', 1000)]
+    await mount(history)
+    rapidSend('run the tests', 'again')
+    expect(state?.pending.map((item) => item.text)).toEqual(['run the tests', 'again'])
+
+    const glued = [...history, userTurn('m2', 'run the tests again', 5000)]
+    await update(glued)
+    expect(state?.pending).toEqual([])
+    expect(renderedPendingTexts(glued, state)).toEqual([])
+  })
+
+  // FP1: the concatenation already sits in history, older than the sends.
+  it('keeps and renders both bubbles when the matching row predates the sends', async () => {
+    const history = [
+      userTurn('m1', 'run the tests again', 1000),
+      assistantTurn('m2', 'done', 2000),
+      assistantTurn('m3', 'anything else?', 3000)
+    ]
+    await mount(history)
+    rapidSend('run the tests', 'again')
+
+    await update([...history])
+    expect(state?.pending.map((item) => item.text)).toEqual(['run the tests', 'again'])
+    expect(renderedPendingTexts(history, state)).toEqual(['run the tests', 'again'])
+  })
+
+  // FP2: an older turn reads like the concatenation of two much later sends.
+  it('keeps and renders both bubbles when an older turn spells them out', async () => {
+    const history = [userTurn('m1', 'fix the bug', 1000), assistantTurn('m2', 'fixed', 1100)]
+    await mount(history)
+    rapidSend('fix the', 'bug')
+
+    await update([...history])
+    expect(state?.pending.map((item) => item.text)).toEqual(['fix the', 'bug'])
+    expect(renderedPendingTexts(history, state)).toEqual(['fix the', 'bug'])
+  })
+
+  it('still retires each bubble on its own when the sends do not glue', async () => {
+    const history = [assistantTurn('m1', 'ready', 1000)]
+    await mount(history)
+    rapidSend('run the tests', 'again')
+
+    const separate = [
+      ...history,
+      userTurn('m2', 'run the tests', 5000),
+      userTurn('m3', 'again', 5100)
+    ]
+    await update(separate)
+    expect(state?.pending).toEqual([])
+  })
+
+  it('keeps the second bubble when only the first send has echoed', async () => {
+    const history = [assistantTurn('m1', 'ready', 1000)]
+    await mount(history)
+    rapidSend('run the tests', 'again')
+
+    const partial = [...history, userTurn('m2', 'run the tests', 5000)]
+    await update(partial)
+    expect(state?.pending.map((item) => item.text)).toEqual(['again'])
+    expect(renderedPendingTexts(partial, state)).toEqual(['again'])
+  })
+})

--- a/mobile/src/session/use-mobile-native-chat-drafts.ts
+++ b/mobile/src/session/use-mobile-native-chat-drafts.ts
@@ -137,10 +137,11 @@ export function useMobileNativeChatDrafts(args: {
         pendingKey,
         normalizedText,
         baselineOccurrences: countUserTextOccurrences(messagesRef.current, normalizedText),
-        baselineTailMessageId: messagesRef.current.at(-1)?.id ?? null
+        baselineTailMessageId: messagesRef.current.at(-1)?.id ?? null,
+        glueBaselineTrusted: !transcriptLoading
       }
     },
-    [draftKey, pendingKey]
+    [draftKey, pendingKey, transcriptLoading]
   )
 
   // Why: over relay the send RPC can take seconds (or lose only its ack), and a

--- a/mobile/src/session/use-mobile-native-chat-drafts.ts
+++ b/mobile/src/session/use-mobile-native-chat-drafts.ts
@@ -1,16 +1,15 @@
 import { useCallback, useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react'
 import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
 import {
-  countImageSourceTurnsAfter,
   countUserTextOccurrences,
   findLandedImagePreviewEchoes,
   findLandedUnconfirmedSends,
   mergeLandedImagePreviewEchoes,
   migrateImagePreviewMessageIds,
   normalizeReconcileText,
-  normalizedUserText,
   type UnconfirmedSend
 } from './mobile-native-chat-draft-reconcile'
+import { retireLandedMobileNativeChatPending } from './mobile-native-chat-pending-retirement'
 import {
   appendMobileNativeChatPending,
   combineMobileNativeChatPending,
@@ -291,27 +290,7 @@ export function useMobileNativeChatDrafts(args: {
     }
     setPendingBySession((previous) => {
       const current = previous[pendingKey] ?? []
-      const landedCounts = new Map<string, number>()
-      for (const message of messages) {
-        const text = normalizedUserText(message)
-        if (text) {
-          landedCounts.set(text, (landedCounts.get(text) ?? 0) + 1)
-        }
-      }
-      // Image-only source-turn counts stay stable across reruns and ignore paginated history.
-      const next = current.filter((item) => {
-        if (landedImagePendingIds.has(item.id)) {
-          return false
-        }
-        // Keep image echoes until their local preview reaches the authoritative message.
-        if (item.images?.length) {
-          return true
-        }
-        return item.text.trim() === ''
-          ? countImageSourceTurnsAfter(messages, item.baselineTailMessageId) <
-              item.expectedOccurrence
-          : (landedCounts.get(normalizeReconcileText(item.text)) ?? 0) < item.expectedOccurrence
-      })
+      const next = retireLandedMobileNativeChatPending(messages, current, landedImagePendingIds)
       if (next.length === current.length) {
         return previous
       }

--- a/mobile/src/session/use-mobile-native-chat-message-send.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-message-send.test.ts
@@ -36,6 +36,7 @@ describe('useMobileNativeChatMessageSend', () => {
   let renderer: ReactTestRenderer | null = null
   let api: Send | null = null
   const acceptSend = vi.fn()
+  const captureSendOrigin = vi.fn(() => ({ draftKey: 'k', pendingKey: 'p' }) as never)
   const holdUnconfirmedSend = vi.fn()
   const onCommandSend = vi.fn()
   const commandSendRef = { current: onCommandSend }
@@ -55,7 +56,7 @@ describe('useMobileNativeChatMessageSend', () => {
         deviceTokenRef: { current: 'device' },
         agentRef,
         commandSendRef,
-        captureSendOrigin: () => ({ draftKey: 'k', pendingKey: 'p' }) as never,
+        captureSendOrigin,
         readSeededLaunchDraftSeed,
         clearDraftForSend: () => {},
         restoreRejectedDraft: () => {},
@@ -71,10 +72,12 @@ describe('useMobileNativeChatMessageSend', () => {
   }
 
   const sentArgs = (): {
+    text?: string
     clearInputFirst?: boolean
     resolvedLaunchDraft?: { text: string; createdAt: number }
   } =>
     sendWithOutcome.mock.calls[0]![0] as {
+      text?: string
       clearInputFirst?: boolean
       resolvedLaunchDraft?: { text: string; createdAt: number }
     }
@@ -89,6 +92,7 @@ describe('useMobileNativeChatMessageSend', () => {
     typeCommandWithOutcome.mockReset()
     typeCommandWithOutcome.mockResolvedValue('accepted')
     acceptSend.mockReset()
+    captureSendOrigin.mockClear()
     holdUnconfirmedSend.mockReset()
     onCommandSend.mockReset()
     commandSendRef.current = onCommandSend
@@ -380,5 +384,33 @@ describe('useMobileNativeChatMessageSend', () => {
     // The answer released its own hold on the way out.
     expect(acquireMobileNativeChatTerminalWrite('term')).toBe(true)
     releaseMobileNativeChatTerminalWrite('term')
+  })
+
+  // The host writes these bytes verbatim, so whitespace the match key drops must
+  // not reach the agent's input line and glue the next rapid send onto it (#14262).
+  it('writes the same trimmed body it reconciles against', async () => {
+    mount(() => null)
+    await act(async () => {
+      await api!.send('  run the tests \n')
+    })
+    expect(sentArgs().text).toBe('run the tests')
+    expect(captureSendOrigin).toHaveBeenCalledWith('run the tests')
+    expect(acceptSend.mock.calls[0]![1]).toBe('run the tests')
+  })
+
+  it('trims the body on a question answer too', async () => {
+    mount(() => null)
+    await act(async () => {
+      await api!.answerQuestion('\n 1 ')
+    })
+    expect(sentArgs().text).toBe('1')
+  })
+
+  it('keeps interior newlines of a multi-line prompt', async () => {
+    mount(() => null)
+    await act(async () => {
+      await api!.send('\nfirst line\nsecond line\n')
+    })
+    expect(sentArgs().text).toBe('first line\nsecond line')
   })
 })

--- a/mobile/src/session/use-mobile-native-chat-message-send.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-message-send.test.ts
@@ -388,28 +388,40 @@ describe('useMobileNativeChatMessageSend', () => {
 
   // The host writes these bytes verbatim, so whitespace the match key drops must
   // not reach the agent's input line and glue the next rapid send onto it (#14262).
-  it('writes the same trimmed body it reconciles against', async () => {
+  it('trims trailing whitespace without changing leading prompt content', async () => {
     mount(() => null)
     await act(async () => {
       await api!.send('  run the tests \n')
     })
-    expect(sentArgs().text).toBe('run the tests')
-    expect(captureSendOrigin).toHaveBeenCalledWith('run the tests')
-    expect(acceptSend.mock.calls[0]![1]).toBe('run the tests')
+    expect(sentArgs().text).toBe('  run the tests')
+    expect(captureSendOrigin).toHaveBeenCalledWith('  run the tests')
+    expect(acceptSend.mock.calls[0]![1]).toBe('  run the tests')
   })
 
-  it('trims the body on a question answer too', async () => {
+  it('trims trailing whitespace on a question answer too', async () => {
     mount(() => null)
     await act(async () => {
       await api!.answerQuestion('\n 1 ')
     })
-    expect(sentArgs().text).toBe('1')
+    expect(sentArgs().text).toBe('\n 1')
+  })
+
+  it('keeps a leading-whitespace slash draft as prose', async () => {
+    mount(() => null, 'codex')
+    await act(async () => {
+      await api!.send(' /delete ')
+    })
+    expect(sentArgs().text).toBe(' /delete')
+    expect(sendWithOutcome).toHaveBeenCalledOnce()
+    expect(typeCommandWithOutcome).not.toHaveBeenCalled()
+    expect(acceptSend).toHaveBeenCalledWith(expect.anything(), ' /delete', undefined)
+    expect(onCommandSend).not.toHaveBeenCalled()
   })
 
   it('keeps interior newlines of a multi-line prompt', async () => {
     mount(() => null)
     await act(async () => {
-      await api!.send('\nfirst line\nsecond line\n')
+      await api!.send('first line\nsecond line\n')
     })
     expect(sentArgs().text).toBe('first line\nsecond line')
   })

--- a/mobile/src/session/use-mobile-native-chat-message-send.ts
+++ b/mobile/src/session/use-mobile-native-chat-message-send.ts
@@ -85,12 +85,18 @@ export function useMobileNativeChatMessageSend(args: {
 
   const sendMessage = useCallback(
     async (
-      text: string,
+      rawText: string,
       images: string[] | undefined,
       syncComposer: boolean,
       recordControlSend: boolean,
       sharedDeadline?: number
     ): Promise<MobileNativeChatSendOutcome> => {
+      // Why: the host writes these bytes verbatim, so surrounding whitespace lands
+      // on the agent's TUI input line while every reconciliation key is
+      // normalized. A rapid follow-up send then glues onto that residue and the
+      // submitted turn matches neither pending key. Trim once here so the wire
+      // text and the match key describe the same message for every send path.
+      const text = rawText.trim()
       const handle = handleRef.current
       const origin = captureSendOrigin(text)
       const agent = agentRef.current
@@ -216,7 +222,7 @@ export function useMobileNativeChatMessageSend(args: {
       } else if (recordControlSend) {
         // The session-option catalog can recognize controls omitted from the
         // autocomplete catalog (for example Claude `/model` and `/fast`).
-        recordCommand(text.trim())
+        recordCommand(text)
       }
       return 'accepted'
     },

--- a/mobile/src/session/use-mobile-native-chat-message-send.ts
+++ b/mobile/src/session/use-mobile-native-chat-message-send.ts
@@ -91,12 +91,8 @@ export function useMobileNativeChatMessageSend(args: {
       recordControlSend: boolean,
       sharedDeadline?: number
     ): Promise<MobileNativeChatSendOutcome> => {
-      // Why: the host writes these bytes verbatim, so surrounding whitespace lands
-      // on the agent's TUI input line while every reconciliation key is
-      // normalized. A rapid follow-up send then glues onto that residue and the
-      // submitted turn matches neither pending key. Trim once here so the wire
-      // text and the match key describe the same message for every send path.
-      const text = rawText.trim()
+      // The host writes trailing whitespace verbatim, where it can glue the next send.
+      const text = rawText.trimEnd()
       const handle = handleRef.current
       const origin = captureSendOrigin(text)
       const agent = agentRef.current


### PR DESCRIPTION
## ELI5

On mobile, two fast chat sends can appear in the transcript as one user row, such as `run the tests` plus `again` becoming `run the tests again`. Mobile previously waited for two separate rows, so both optimistic “queued” bubbles could remain below later replies forever. This change recognizes a safely bounded glued row and retires only the pending sends it proves the row represents.

## What Changed

**Mobile only.** This is the mobile half of #14262; the desktop/renderer implementation is handled separately.

1. **Normalize trailing whitespace at the message-send seam** (`use-mobile-native-chat-message-send.ts`). `sendMessage` applies `trimEnd()` before capture, classification, transport, and optimistic-echo creation. Leading whitespace and interior newlines remain unchanged, so leading-space prose is not converted into a slash command. This covers composer, question-answer, and image-message callers routed through `sendMessage`; the separate Codex `dispatchCommand` path is unchanged.

2. **Bounded glue matching** (new `mobile-native-chat-pending-retirement.ts`). One transcript user turn retires a run of at least two consecutive text-only pending sends only when it exactly spells their normalized concatenation, with an optional single-space boundary. Every candidate row must be strictly after every matched send’s captured transcript tail, and the baseline transcript snapshot must have finished loading before the send.

3. **Preserve original adjacency and image-preview state.** Exact landings, image echoes, empty text, unresolved tails, and baselines captured against a loading placeholder transcript are barriers. Matching advances only the leading unresolved candidate in each barrier-separated run. It never searches past an unresolved earlier text send and never drops an image echo before its phone-local preview is rebound to an authoritative row.

4. **Keep retirement rules together.** The existing count/ordinal exact-match behavior moved into the same module, and hook-level regressions exercise the rendered pending list through the real draft hook and render-data builder.

The glue pass performs at most `O(transcript rows × pending entries)` segment inspections. It adds no timers, polling, RPCs, persisted state, or retained resources.

## Why

Pending bubbles previously retired only when the transcript contained their exact normalized text at the expected occurrence. If two sends landed as one user row, neither exact key appeared and both bubbles remained cached.

The host writes a send body and its Enter as separate PTY writes with a 500 ms beat between them. Rapid successive sends can still be observed by the TUI as one input row even though the mobile composer awaits each send call. Trimming trailing whitespace removes the separator controlled by the client, while glue reconciliation handles coalesced rows that still reach the transcript.

The transcript-tail bound is essential: an older row that merely looks like a new pair of sends must never retire real pending messages. Tests cover an already-existing glued-looking row, a historical row that spells two later sends, and history arriving after a send was captured against a loading placeholder transcript.

No timeout fallback was added. A slow transcript echo is valid over relay or SSH, and silently removing the only local evidence of a send could prompt a duplicate resend.

## Linked Issue

Refs #14262 for the mobile client. `src/renderer` is untouched.

## Visual Proof

Native mobile QA screenshots are attached in [the evidence comment](https://github.com/stablyai/orca/pull/14665#issuecomment-5300427704). On an iPhone 17 Pro simulator running iOS 26.5, two sequential send pairs settled without stale pending bubbles. The exact sub-500 ms glue race could not be reproduced because `orca emulator` required 4.85 seconds between sends; deterministic tests cover that race and its false-positive bounds.

```text
BEFORE                                  AFTER
[assistant] ready                       [assistant] ready
[user] run the tests again              [user] run the tests again
[assistant] newest reply                [assistant] newest reply
[user] run the tests   ← stale
[user] again           ← stale
```

## Testing

Run from `mobile/` unless noted:

```bash
pnpm exec vitest run --config vitest.config.ts src/session/mobile-native-chat-pending-retirement.test.ts \
  src/session/use-mobile-native-chat-drafts-glued-pending.test.ts \
  src/session/use-mobile-native-chat-drafts.test.ts \
  src/session/use-mobile-native-chat-message-send.test.ts
pnpm exec vitest run --config vitest.config.ts src/session
pnpm exec oxlint --config .oxlintrc.json src/session/mobile-native-chat-pending-retirement.ts \
  src/session/mobile-native-chat-pending-retirement.test.ts
pnpm exec oxfmt --check src/session/mobile-native-chat-pending-retirement.ts \
  src/session/mobile-native-chat-pending-retirement.test.ts
PATH=/opt/homebrew/opt/node@24/bin:$PATH node config/scripts/check-changed-code-quality.mjs -- origin/main
```

Results at reviewed HEAD:

- Targeted suites: **4 files / 82 tests passed**.
- Mobile session suites: **129 files / 1,151 tests passed**.
- Focused Oxlint, Oxfmt, and `git diff --check`: clean.
- Node 24 code quality, type-aware quality, and React Doctor: **0 findings across 8 changed files**.

Not rerun after the final review adjustment: the whole mobile suite. Not run locally per the brief: full `tsc` / `tsc -b`.

- [x] Manual native mobile QA — ordinary retirement verified; exact glue race blocked by emulator action latency
- [x] Automated regressions added

## Review

- **Security / supply chain** — no dependencies, new IO, network sinks, secrets, shell execution, or persisted state.
- **Backward compatibility / data loss** — exact ordinal retirement keeps its prior semantics. Glue matching requires full-row consumption and at least two adjacent text sends; barriers prevent retirement across exact landings, unresolved image previews, or history that was not loaded when the send baseline was captured.
- **Performance / resources** — deterministic coverage bounds segment inspections to `rows × pending`; all Maps, arrays, and Sets are invocation-local.
- **Cross-platform / remote** — pure Expo client string logic with no platform, path, provider, local-host, SSH, relay, or wire-protocol branch.
- **Scope** — eight files under `mobile/src/session/`; no desktop renderer implementation.

## Checklist

- [x] Focused mobile-only fix
- [x] Root cause and false-positive bounds documented
- [x] Automated correctness and performance regressions
- [x] Cross-platform, remote, folder-workspace, and wire impact reviewed
- [x] Native screenshots attached; exact race limitation disclosed

## AI Disclosure

Authored and reviewed with AI assistance.

## Author

- X / Twitter: @BrennanKB5


