### PR TITLE
fix(crash-reporting): preserve coalesced repeat accounting

### DIFF
--- a/src/main/crash-reporting/crash-breadcrumb-store-orphan-cleanup.test.ts
+++ b/src/main/crash-reporting/crash-breadcrumb-store-orphan-cleanup.test.ts
@@ -102,6 +102,24 @@ describe('orphaned coalesced breadcrumb cleanup', () => {
     expectSuppressedBurstPreserved()
   })
 
+  it('preserves data-less repeats through orphan cleanup', () => {
+    for (let index = 0; index < 3; index += 1) {
+      recordCoalescedCrashBreadcrumb({
+        name: ORPHAN_KEY,
+        coalesceKey: ORPHAN_KEY,
+        minIntervalMs: COALESCE_WINDOW_MS
+      })
+    }
+    orphanFromRing()
+
+    expireWithUnrelatedKey()
+
+    const recovered = getCrashBreadcrumbSnapshot().find(
+      (breadcrumb) => breadcrumb.name === ORPHAN_KEY
+    )
+    expect(recovered?.data).toEqual({ suppressedSinceLast: 2 })
+  })
+
   it('preserves snapshot-budget-orphaned repeats through unrelated expiry cleanup', () => {
     recordSuppressedBurst()
     orphanFromSnapshotBudget()

--- a/src/main/crash-reporting/crash-breadcrumb-store-orphan-cleanup.test.ts
+++ b/src/main/crash-reporting/crash-breadcrumb-store-orphan-cleanup.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearCrashBreadcrumbsForTest,
+  getCrashBreadcrumbSnapshot,
+  recordCoalescedCrashBreadcrumb,
+  recordCrashBreadcrumb
+} from './crash-breadcrumb-store'
+
+const COALESCE_WINDOW_MS = 30_000
+const MAX_COALESCE_KEYS = 128
+const ORPHAN_KEY = 'terminal_safe_fit_retry_exhausted'
+
+function recordOrphanCandidate(livePanes: number): void {
+  recordCoalescedCrashBreadcrumb({
+    name: ORPHAN_KEY,
+    data: { livePanes },
+    coalesceKey: ORPHAN_KEY,
+    minIntervalMs: COALESCE_WINDOW_MS
+  })
+}
+
+function resumeOrphanCandidate(livePanes: number): { suppressedSinceLast: number } | undefined {
+  return recordCoalescedCrashBreadcrumb({
+    name: ORPHAN_KEY,
+    data: { livePanes },
+    coalesceKey: ORPHAN_KEY,
+    minIntervalMs: COALESCE_WINDOW_MS
+  })
+}
+
+function recordSuppressedBurst(): void {
+  recordOrphanCandidate(1)
+  recordOrphanCandidate(2)
+  recordOrphanCandidate(3)
+}
+
+function orphanFromRing(): void {
+  for (let index = 0; index < 30; index += 1) {
+    recordCrashBreadcrumb(`renderer_error_${index}`, { index })
+  }
+  getCrashBreadcrumbSnapshot()
+}
+
+function orphanFromSnapshotBudget(): void {
+  for (let index = 0; index < 4; index += 1) {
+    recordCrashBreadcrumb('renderer_memory_highwater', {
+      rendererSurface: `surface-${index}`,
+      thresholdPct: 80
+    })
+  }
+  for (let index = 0; index < 29; index += 1) {
+    recordCrashBreadcrumb(`renderer_error_${index}`, { index })
+  }
+  getCrashBreadcrumbSnapshot()
+}
+
+function expireWithUnrelatedKey(): void {
+  vi.advanceTimersByTime(COALESCE_WINDOW_MS + 1)
+  recordCoalescedCrashBreadcrumb({
+    name: 'agent_state_changed',
+    data: { agentType: 'claude', state: 'working' },
+    coalesceKey: 'agent:claude:working',
+    minIntervalMs: COALESCE_WINDOW_MS
+  })
+}
+
+function evictWithUnrelatedKeys(): void {
+  for (let index = 0; index < MAX_COALESCE_KEYS; index += 1) {
+    recordCoalescedCrashBreadcrumb({
+      name: 'renderer_error',
+      data: { message: `error-${index}` },
+      coalesceKey: `renderer_error:error-${index}`,
+      minIntervalMs: COALESCE_WINDOW_MS
+    })
+  }
+}
+
+function expectSuppressedBurstPreserved(): void {
+  const recovered = getCrashBreadcrumbSnapshot().find(
+    (breadcrumb) => breadcrumb.name === ORPHAN_KEY && breadcrumb.data?.suppressedSinceLast === 2
+  )
+  expect(recovered?.data).toEqual({ livePanes: 3, suppressedSinceLast: 2 })
+}
+
+describe('orphaned coalesced breadcrumb cleanup', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-22T12:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    clearCrashBreadcrumbsForTest()
+    vi.useRealTimers()
+  })
+
+  it('preserves ring-orphaned repeats through unrelated expiry cleanup', () => {
+    recordSuppressedBurst()
+    orphanFromRing()
+
+    expireWithUnrelatedKey()
+
+    expectSuppressedBurstPreserved()
+  })
+
+  it('preserves snapshot-budget-orphaned repeats through unrelated expiry cleanup', () => {
+    recordSuppressedBurst()
+    orphanFromSnapshotBudget()
+
+    expireWithUnrelatedKey()
+
+    expectSuppressedBurstPreserved()
+  })
+
+  it('preserves ring-orphaned repeats through LRU cleanup', () => {
+    recordSuppressedBurst()
+    orphanFromRing()
+
+    evictWithUnrelatedKeys()
+
+    expectSuppressedBurstPreserved()
+  })
+
+  it('preserves snapshot-budget-orphaned repeats through LRU cleanup', () => {
+    recordSuppressedBurst()
+    orphanFromSnapshotBudget()
+
+    evictWithUnrelatedKeys()
+
+    expectSuppressedBurstPreserved()
+  })
+
+  it('materializes only repeats not already claimed by an earlier snapshot', () => {
+    recordOrphanCandidate(1)
+    recordOrphanCandidate(2)
+    const firstSnapshot = getCrashBreadcrumbSnapshot()
+    recordOrphanCandidate(3)
+    recordOrphanCandidate(4)
+    orphanFromRing()
+
+    expireWithUnrelatedKey()
+
+    expect(firstSnapshot[0]?.data).toEqual({ livePanes: 2, suppressedSinceLast: 1 })
+    const recovered = getCrashBreadcrumbSnapshot().find(
+      (breadcrumb) => breadcrumb.name === ORPHAN_KEY
+    )
+    expect(recovered?.data).toEqual({ livePanes: 4, suppressedSinceLast: 2 })
+    expect(resumeOrphanCandidate(5)).toEqual({ suppressedSinceLast: 0 })
+  })
+})

--- a/src/main/crash-reporting/crash-breadcrumb-store.test.ts
+++ b/src/main/crash-reporting/crash-breadcrumb-store.test.ts
@@ -125,6 +125,45 @@ describe('crash breadcrumb store', () => {
     vi.useRealTimers()
   })
 
+  it('expires the coalescing window after a backward wall-clock step', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-20T12:00:00.000Z'))
+    const hit = (): { suppressedSinceLast: number } | undefined =>
+      recordCoalescedCrashBreadcrumb({
+        name: 'agent_state_changed',
+        coalesceKey: 'agent:claude:working',
+        minIntervalMs: 30_000
+      })
+
+    hit()
+    vi.advanceTimersByTime(10_000)
+    expect(hit()).toBeUndefined()
+    vi.setSystemTime(new Date('2025-05-20T12:00:00.000Z'))
+    vi.advanceTimersByTime(20_000)
+
+    expect(hit()).toEqual({ suppressedSinceLast: 1 })
+    expect(getCrashBreadcrumbSnapshot()).toHaveLength(2)
+  })
+
+  it('does not collapse the coalescing window after a forward wall-clock step', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-20T12:00:00.000Z'))
+    const hit = (): { suppressedSinceLast: number } | undefined =>
+      recordCoalescedCrashBreadcrumb({
+        name: 'agent_state_changed',
+        coalesceKey: 'agent:claude:working',
+        minIntervalMs: 30_000
+      })
+
+    hit()
+    vi.advanceTimersByTime(10_000)
+    vi.setSystemTime(new Date('2027-05-20T12:00:00.000Z'))
+
+    expect(hit()).toBeUndefined()
+    vi.advanceTimersByTime(20_000)
+    expect(hit()).toEqual({ suppressedSinceLast: 1 })
+  })
+
   it('folds data-less repeats into the emitted breadcrumb', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-05-20T12:00:00.000Z'))

--- a/src/main/crash-reporting/crash-breadcrumb-store.test.ts
+++ b/src/main/crash-reporting/crash-breadcrumb-store.test.ts
@@ -125,6 +125,24 @@ describe('crash breadcrumb store', () => {
     vi.useRealTimers()
   })
 
+  it('folds data-less repeats into the emitted breadcrumb', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-20T12:00:00.000Z'))
+
+    recordCoalescedCrashBreadcrumb({
+      name: 'terminal_safe_fit_retry_exhausted',
+      coalesceKey: 'terminal_safe_fit_retry_exhausted',
+      minIntervalMs: 30_000
+    })
+    recordCoalescedCrashBreadcrumb({
+      name: 'terminal_safe_fit_retry_exhausted',
+      coalesceKey: 'terminal_safe_fit_retry_exhausted',
+      minIntervalMs: 30_000
+    })
+
+    expect(getCrashBreadcrumbSnapshot()[0]?.data).toEqual({ suppressedSinceLast: 1 })
+  })
+
   // Windows crash F0BKR84AHEH: two `terminal_safe_fit_retry_exhausted` bursts
   // (34 crumbs in 76ms, 34 in 56ms) flushed the pre-crash trail out of a
   // 30-entry ring. Every hidden pane is display:none, so it measures 0x0, fails
@@ -450,9 +468,9 @@ describe('crash breadcrumb store', () => {
       expect(resumed).toEqual({ suppressedSinceLast: 2 })
     })
 
-    // Two crash reports filed inside one window fold twice into the same crumb;
-    // the claim is a running total, and the next window starts from zero debt.
-    it('keeps a second fold in the same window a running total, claimed exactly once', () => {
+    // Two crash reports filed inside one window are immutable cumulative views;
+    // the next window must still start from zero unresolved debt.
+    it('keeps immutable snapshots cumulative without re-claiming resolved debt', () => {
       vi.useFakeTimers()
       vi.setSystemTime(new Date('2026-07-22T12:00:00.000Z'))
       const hit = (livePanes: number): { suppressedSinceLast: number } | undefined =>
@@ -467,12 +485,13 @@ describe('crash breadcrumb store', () => {
       vi.advanceTimersByTime(10)
       hit(2)
       hit(3)
-      getCrashBreadcrumbSnapshot()
+      const firstSnapshot = getCrashBreadcrumbSnapshot()
       vi.advanceTimersByTime(10)
       hit(4)
       const secondFold = getCrashBreadcrumbSnapshot().find(
         (entry) => entry.name === 'terminal_safe_fit_retry_exhausted'
       )
+      expect(firstSnapshot[0]?.data).toEqual({ livePanes: 3, suppressedSinceLast: 2 })
       expect(secondFold?.data).toEqual({ livePanes: 4, suppressedSinceLast: 3 })
 
       vi.advanceTimersByTime(31_000)

--- a/src/main/crash-reporting/crash-breadcrumb-store.test.ts
+++ b/src/main/crash-reporting/crash-breadcrumb-store.test.ts
@@ -315,6 +315,180 @@ describe('crash breadcrumb store', () => {
       expect(bursts[1].data).toEqual({ livePanes: 3, suppressedSinceLast: 1 })
     })
 
+    // A crash report filed mid-window snapshots the ring, which folds the
+    // suppressed repeats into the emitted crumb. Re-claiming those repeats on
+    // the next emit would report one burst twice across two crumbs.
+    it('does not re-claim repeats a snapshot already folded into the crumb', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-07-22T12:00:00.000Z'))
+      const hit = (livePanes: number): { suppressedSinceLast: number } | undefined =>
+        recordCoalescedCrashBreadcrumb({
+          name: 'terminal_safe_fit_retry_exhausted',
+          data: { livePanes },
+          coalesceKey: 'terminal_safe_fit_retry_exhausted',
+          minIntervalMs: 30_000
+        })
+
+      hit(1)
+      vi.advanceTimersByTime(10)
+      hit(2)
+      getCrashBreadcrumbSnapshot()
+      vi.advanceTimersByTime(31_000)
+      const resumed = hit(3)
+
+      expect(resumed).toEqual({ suppressedSinceLast: 0 })
+      const bursts = getCrashBreadcrumbSnapshot().filter(
+        (entry) => entry.name === 'terminal_safe_fit_retry_exhausted'
+      )
+      expect(bursts[0].data).toEqual({ livePanes: 2, suppressedSinceLast: 1 })
+      expect(bursts[1].data).toEqual({ livePanes: 3 })
+
+      // The re-emitted crumb was born claiming nothing, so a fold onto it must
+      // claim only the new repeat — not the one the first crumb already owns.
+      vi.advanceTimersByTime(10)
+      hit(4)
+      const resolved = getCrashBreadcrumbSnapshot().filter(
+        (entry) => entry.name === 'terminal_safe_fit_retry_exhausted'
+      )
+      expect(resolved[1].data).toEqual({ livePanes: 4, suppressedSinceLast: 1 })
+    })
+
+    // A re-emitted crumb is born already claiming the previous window's count;
+    // a later fold must add to that claim, not overwrite it away.
+    it('keeps the carried count when a fold resolves onto a re-emitted crumb', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-07-22T12:00:00.000Z'))
+      const hit = (livePanes: number): void => {
+        recordCoalescedCrashBreadcrumb({
+          name: 'terminal_safe_fit_retry_exhausted',
+          data: { livePanes },
+          coalesceKey: 'terminal_safe_fit_retry_exhausted',
+          minIntervalMs: 30_000
+        })
+      }
+
+      hit(1)
+      vi.advanceTimersByTime(10)
+      hit(2)
+      vi.advanceTimersByTime(31_000)
+      hit(3)
+      vi.advanceTimersByTime(10)
+      hit(4)
+
+      const bursts = getCrashBreadcrumbSnapshot().filter(
+        (entry) => entry.name === 'terminal_safe_fit_retry_exhausted'
+      )
+      expect(bursts[1].data).toEqual({ livePanes: 4, suppressedSinceLast: 2 })
+    })
+
+    // A crash storm records other breadcrumbs too; if they push the burst crumb
+    // out of the 30-entry ring mid-window, a snapshot's fold lands in evidence
+    // no snapshot can see. Marking those repeats resolved anyway would let the
+    // next emit claim nothing and the burst vanish from the record entirely.
+    it('re-claims repeats on the next emit when the burst crumb was evicted from the ring', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-07-22T12:00:00.000Z'))
+      const hit = (livePanes: number): { suppressedSinceLast: number } | undefined =>
+        recordCoalescedCrashBreadcrumb({
+          name: 'terminal_safe_fit_retry_exhausted',
+          data: { livePanes },
+          coalesceKey: 'terminal_safe_fit_retry_exhausted',
+          minIntervalMs: 30_000
+        })
+
+      hit(1)
+      vi.advanceTimersByTime(10)
+      hit(2)
+      hit(3)
+      for (let index = 0; index < 30; index += 1) {
+        recordCrashBreadcrumb(`renderer_error_${index}`, { index })
+      }
+      getCrashBreadcrumbSnapshot()
+      vi.advanceTimersByTime(31_000)
+      const resumed = hit(4)
+
+      expect(resumed).toEqual({ suppressedSinceLast: 2 })
+      const burst = getCrashBreadcrumbSnapshot().find(
+        (entry) => entry.name === 'terminal_safe_fit_retry_exhausted'
+      )
+      expect(burst?.data).toEqual({ livePanes: 4, suppressedSinceLast: 2 })
+    })
+
+    // Retained high-water profiles occupy snapshot slots, so the oldest ring
+    // entries past that budget are invisible to every future snapshot even
+    // though they are still in the array; folding there loses the burst too.
+    it('re-claims repeats when retained profiles push the burst crumb past the snapshot budget', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-07-22T12:00:00.000Z'))
+      const hit = (livePanes: number): { suppressedSinceLast: number } | undefined =>
+        recordCoalescedCrashBreadcrumb({
+          name: 'terminal_safe_fit_retry_exhausted',
+          data: { livePanes },
+          coalesceKey: 'terminal_safe_fit_retry_exhausted',
+          minIntervalMs: 30_000
+        })
+
+      hit(1)
+      vi.advanceTimersByTime(10)
+      hit(2)
+      hit(3)
+      for (let index = 0; index < 4; index += 1) {
+        recordCrashBreadcrumb('renderer_memory_highwater', {
+          rendererSurface: `surface-${index}`,
+          thresholdPct: 80
+        })
+      }
+      // Ring stays at 30 (burst crumb still at index 0) but only the newest 26
+      // ring entries fit a snapshot alongside the 4 retained profiles.
+      for (let index = 0; index < 29; index += 1) {
+        recordCrashBreadcrumb(`renderer_error_${index}`, { index })
+      }
+      getCrashBreadcrumbSnapshot()
+      vi.advanceTimersByTime(31_000)
+      const resumed = hit(4)
+
+      expect(resumed).toEqual({ suppressedSinceLast: 2 })
+    })
+
+    // Two crash reports filed inside one window fold twice into the same crumb;
+    // the claim is a running total, and the next window starts from zero debt.
+    it('keeps a second fold in the same window a running total, claimed exactly once', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-07-22T12:00:00.000Z'))
+      const hit = (livePanes: number): { suppressedSinceLast: number } | undefined =>
+        recordCoalescedCrashBreadcrumb({
+          name: 'terminal_safe_fit_retry_exhausted',
+          data: { livePanes },
+          coalesceKey: 'terminal_safe_fit_retry_exhausted',
+          minIntervalMs: 30_000
+        })
+
+      hit(1)
+      vi.advanceTimersByTime(10)
+      hit(2)
+      hit(3)
+      getCrashBreadcrumbSnapshot()
+      vi.advanceTimersByTime(10)
+      hit(4)
+      const secondFold = getCrashBreadcrumbSnapshot().find(
+        (entry) => entry.name === 'terminal_safe_fit_retry_exhausted'
+      )
+      expect(secondFold?.data).toEqual({ livePanes: 4, suppressedSinceLast: 3 })
+
+      vi.advanceTimersByTime(31_000)
+      const resumed = hit(5)
+      expect(resumed).toEqual({ suppressedSinceLast: 0 })
+
+      // A fold onto the fresh crumb must claim only its own window's repeat —
+      // over-resolving in the first window would push this claim negative.
+      vi.advanceTimersByTime(10)
+      hit(6)
+      const resolved = getCrashBreadcrumbSnapshot().filter(
+        (entry) => entry.name === 'terminal_safe_fit_retry_exhausted'
+      )
+      expect(resolved[1].data).toEqual({ livePanes: 6, suppressedSinceLast: 1 })
+    })
+
     // A key that ages out loses its only handle on the ring entry it owns, so
     // the newest suppressed payload must be folded in before the entry is
     // dropped from the map.

--- a/src/main/crash-reporting/crash-breadcrumb-store.ts
+++ b/src/main/crash-reporting/crash-breadcrumb-store.ts
@@ -16,6 +16,11 @@ const MAX_COALESCE_KEYS = 128
 type CoalescedBreadcrumbState = {
   recordedAt: number
   suppressed: number
+  /** Count the crumb was emitted claiming (the previous window's repeats). */
+  carried: number
+  /** Of `suppressed`, how many a resolve already folded into the crumb, so a
+   *  later emit never claims the same repeats a snapshot attributed. */
+  resolved: number
   /** Ring entry this key owns, refreshed in place while suppressing. */
   emitted?: CrashReportBreadcrumb
   /** Newest suppressed payload, sanitized only if a snapshot actually asks for it. */
@@ -123,7 +128,16 @@ export function recordCoalescedCrashBreadcrumb({
     }
   }
   coalescedBreadcrumbs.delete(coalesceKey)
-  const state: CoalescedBreadcrumbState = { recordedAt: now, suppressed: 0 }
+  // Claim only repeats no resolve has already folded into the previous crumb —
+  // a snapshot mid-window attributes them there, and forensic totals must not
+  // count one burst twice.
+  const suppressedSinceLast = previous ? previous.suppressed - previous.resolved : 0
+  const state: CoalescedBreadcrumbState = {
+    recordedAt: now,
+    suppressed: 0,
+    carried: suppressedSinceLast,
+    resolved: 0
+  }
   coalescedBreadcrumbs.set(coalesceKey, state)
   while (coalescedBreadcrumbs.size > MAX_COALESCE_KEYS) {
     const oldest = coalescedBreadcrumbs.entries().next()
@@ -133,7 +147,6 @@ export function recordCoalescedCrashBreadcrumb({
     resolvePendingCoalescedBreadcrumb(oldest.value[1])
     coalescedBreadcrumbs.delete(oldest.value[0])
   }
-  const suppressedSinceLast = previous?.suppressed ?? 0
   state.emitted = recordCrashBreadcrumb(
     name,
     suppressedSinceLast > 0 ? { ...data, suppressedSinceLast } : data
@@ -141,15 +154,47 @@ export function recordCoalescedCrashBreadcrumb({
   return { suppressedSinceLast }
 }
 
+/** Whether any future snapshot can still include this crumb. The ring only
+ *  appends and the retained map only grows toward its cap, so an entry pushed
+ *  past the snapshot budget is invisible forever, not just for now. */
+function isCoalescedCrumbStillInEvidence(crumb: CrashReportBreadcrumb): boolean {
+  const visibleFrom = breadcrumbs.length - (MAX_BREADCRUMBS - retainedBreadcrumbs.size)
+  const index = breadcrumbs.indexOf(crumb)
+  if (index !== -1 && index >= visibleFrom) {
+    return true
+  }
+  for (const retained of retainedBreadcrumbs.values()) {
+    if (retained === crumb) {
+      return true
+    }
+  }
+  return false
+}
+
 /** Fold a key's newest suppressed payload into the ring entry it owns. */
 function resolvePendingCoalescedBreadcrumb(state: CoalescedBreadcrumbState): void {
   if (!state.pending || !state.emitted) {
     return
   }
+  // Eviction can orphan the crumb mid-window; folding into it would mark the
+  // repeats resolved into evidence no snapshot can see, and the next emit would
+  // then claim nothing — the burst vanishes from the record entirely. Drop the
+  // handle (keeping `resolved` for folds that landed while it was live) so the
+  // next emit claims the unclaimed repeats instead.
+  if (!isCoalescedCrumbStillInEvidence(state.emitted)) {
+    state.emitted = undefined
+    state.pending = undefined
+    return
+  }
+  // The crumb's claim is a running total: what it was born claiming plus every
+  // repeat folded since. Dropping `carried` would erase the previous window's
+  // count from the record; omitting `resolved` bookkeeping would let the next
+  // emit claim these repeats a second time.
   state.emitted.data = sanitizeCrashReportDetails({
     ...state.pending,
-    suppressedSinceLast: state.suppressed
+    suppressedSinceLast: state.carried + state.suppressed
   })
+  state.resolved = state.suppressed
   state.pending = undefined
 }
 

--- a/src/main/crash-reporting/crash-breadcrumb-store.ts
+++ b/src/main/crash-reporting/crash-breadcrumb-store.ts
@@ -14,6 +14,8 @@ const MAX_RETAINED_BREADCRUMBS = 4
 const MAX_COALESCE_KEYS = 128
 
 type CoalescedBreadcrumbState = {
+  /** Name needed to materialize unresolved repeats if the owned crumb is orphaned. */
+  name: string
   recordedAt: number
   suppressed: number
   /** Count the crumb was emitted claiming (the previous window's repeats). */
@@ -99,9 +101,7 @@ export function recordCoalescedCrashBreadcrumb({
     // this coalescing was built to prevent. Sanitizing here would put that cost
     // on every suppressed hit of a 1459/min crash loop; the snapshot resolves it
     // once instead, on the rare path that actually reads breadcrumbs.
-    if (previous.emitted) {
-      previous.pending = data
-    }
+    previous.pending = data
     // Re-anchor recency without touching recordedAt: a suppressed key is the
     // hottest key in the map, but only the emit path below moves position, so
     // a continuously-suppressed key would keep its original slot and be first
@@ -122,7 +122,7 @@ export function recordCoalescedCrashBreadcrumb({
       // `suppressedSinceLast`, so folding the same events into its old slot
       // too would report one burst twice.
       if (key !== coalesceKey) {
-        resolvePendingCoalescedBreadcrumb(entry)
+        preservePendingCoalescedBreadcrumb(entry)
       }
       coalescedBreadcrumbs.delete(key)
     }
@@ -133,6 +133,7 @@ export function recordCoalescedCrashBreadcrumb({
   // count one burst twice.
   const suppressedSinceLast = previous ? previous.suppressed - previous.resolved : 0
   const state: CoalescedBreadcrumbState = {
+    name,
     recordedAt: now,
     suppressed: 0,
     carried: suppressedSinceLast,
@@ -144,7 +145,7 @@ export function recordCoalescedCrashBreadcrumb({
     if (oldest.done) {
       break
     }
-    resolvePendingCoalescedBreadcrumb(oldest.value[1])
+    preservePendingCoalescedBreadcrumb(oldest.value[1])
     coalescedBreadcrumbs.delete(oldest.value[0])
   }
   state.emitted = recordCrashBreadcrumb(
@@ -179,11 +180,10 @@ function resolvePendingCoalescedBreadcrumb(state: CoalescedBreadcrumbState): voi
   // Eviction can orphan the crumb mid-window; folding into it would mark the
   // repeats resolved into evidence no snapshot can see, and the next emit would
   // then claim nothing — the burst vanishes from the record entirely. Drop the
-  // handle (keeping `resolved` for folds that landed while it was live) so the
-  // next emit claims the unclaimed repeats instead.
+  // handle (keeping `resolved` for folds that landed while it was live) so a
+  // later emit or bounded cleanup can materialize the unclaimed repeats.
   if (!isCoalescedCrumbStillInEvidence(state.emitted)) {
     state.emitted = undefined
-    state.pending = undefined
     return
   }
   // The crumb's claim is a running total: what it was born claiming plus every
@@ -193,6 +193,22 @@ function resolvePendingCoalescedBreadcrumb(state: CoalescedBreadcrumbState): voi
   state.emitted.data = sanitizeCrashReportDetails({
     ...state.pending,
     suppressedSinceLast: state.carried + state.suppressed
+  })
+  state.resolved = state.suppressed
+  state.pending = undefined
+}
+
+/** Resolve into the owned crumb, or emit the unclaimed repeats before bounded
+ *  cleanup drops an orphan's last accounting state. */
+function preservePendingCoalescedBreadcrumb(state: CoalescedBreadcrumbState): void {
+  resolvePendingCoalescedBreadcrumb(state)
+  const unresolved = state.suppressed - state.resolved
+  if (state.emitted || unresolved <= 0) {
+    return
+  }
+  recordCrashBreadcrumb(state.name, {
+    ...state.pending,
+    suppressedSinceLast: unresolved
   })
   state.resolved = state.suppressed
   state.pending = undefined

--- a/src/main/crash-reporting/crash-breadcrumb-store.ts
+++ b/src/main/crash-reporting/crash-breadcrumb-store.ts
@@ -13,10 +13,13 @@ const MAX_RETAINED_BREADCRUMBS = 4
 // Bound the coalesce map the same way ProcessGoneDedupe bounds its key map.
 const MAX_COALESCE_KEYS = 128
 
+// Why: wall-clock corrections must not stretch or collapse suppression windows.
+const monotonicNow = (): number => performance.now()
+
 type CoalescedBreadcrumbState = {
   /** Name needed to materialize unresolved repeats if the owned crumb is orphaned. */
   name: string
-  recordedAt: number
+  windowStartedAtMs: number
   suppressed: number
   /** Count the crumb was emitted claiming (the previous window's repeats). */
   carried: number
@@ -89,9 +92,9 @@ export function recordCoalescedCrashBreadcrumb({
   coalesceKey: string
   minIntervalMs: number
 }): { suppressedSinceLast: number } | undefined {
-  const now = Date.now()
+  const now = monotonicNow()
   const previous = coalescedBreadcrumbs.get(coalesceKey)
-  if (previous && now - previous.recordedAt < minIntervalMs) {
+  if (previous && now - previous.windowStartedAtMs < minIntervalMs) {
     previous.suppressed += 1
     // Stash the newest payload for the entry this key already owns: the burst
     // still costs exactly one ring slot, but the retained crumb ends up
@@ -102,11 +105,7 @@ export function recordCoalescedCrashBreadcrumb({
     // on every suppressed hit of a 1459/min crash loop; the snapshot resolves it
     // once instead, on the rare path that actually reads breadcrumbs.
     previous.pending = data
-    // Re-anchor recency without touching recordedAt: a suppressed key is the
-    // hottest key in the map, but only the emit path below moves position, so
-    // a continuously-suppressed key would keep its original slot and be first
-    // out under high-cardinality churn. recordedAt stays put so the suppression
-    // window still expires on schedule instead of renewing on every hit.
+    // A hot key stays LRU-recent without renewing its fixed suppression window.
     coalescedBreadcrumbs.delete(coalesceKey)
     coalescedBreadcrumbs.set(coalesceKey, previous)
     return undefined
@@ -117,7 +116,7 @@ export function recordCoalescedCrashBreadcrumb({
   // recency so only genuinely idle keys are evicted. Resolve first: an expiring
   // key is about to lose its only handle on the ring entry it owns.
   for (const [key, entry] of coalescedBreadcrumbs) {
-    if (now - entry.recordedAt >= minIntervalMs) {
+    if (now - entry.windowStartedAtMs >= minIntervalMs) {
       // Why the key check: this key is about to emit a fresh crumb carrying
       // `suppressedSinceLast`, so folding the same events into its old slot
       // too would report one burst twice.
@@ -134,7 +133,7 @@ export function recordCoalescedCrashBreadcrumb({
   const suppressedSinceLast = previous ? previous.suppressed - previous.resolved : 0
   const state: CoalescedBreadcrumbState = {
     name,
-    recordedAt: now,
+    windowStartedAtMs: now,
     suppressed: 0,
     carried: suppressedSinceLast,
     resolved: 0

--- a/src/main/crash-reporting/crash-breadcrumb-store.ts
+++ b/src/main/crash-reporting/crash-breadcrumb-store.ts
@@ -174,7 +174,8 @@ function isCoalescedCrumbStillInEvidence(crumb: CrashReportBreadcrumb): boolean 
 
 /** Fold a key's newest suppressed payload into the ring entry it owns. */
 function resolvePendingCoalescedBreadcrumb(state: CoalescedBreadcrumbState): void {
-  if (!state.pending || !state.emitted) {
+  // `data` is optional, so the count—not pending payload presence—marks unresolved work.
+  if (!state.emitted || state.suppressed <= state.resolved) {
     return
   }
   // Eviction can orphan the crumb mid-window; folding into it would mark the

--- a/src/main/crash-reporting/process-gone-recorder.test.ts
+++ b/src/main/crash-reporting/process-gone-recorder.test.ts
@@ -55,6 +55,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  vi.useRealTimers()
   vi.restoreAllMocks()
   _resetTracerForTests()
   clearCrashBreadcrumbsForTest()
@@ -161,6 +162,7 @@ describe('recordProcessGoneCrash', () => {
   })
 
   it('reports how many repeats a coalesced suppression stands for', () => {
+    vi.useFakeTimers()
     const dedupe = new ProcessGoneDedupe()
     const utilityCrash = event({
       source: 'child',
@@ -168,13 +170,11 @@ describe('recordProcessGoneCrash', () => {
       reason: 'crashed',
       details: { serviceName: 'network.mojom.NetworkService' }
     })
-    const nowSpy = vi.spyOn(Date, 'now')
 
-    nowSpy.mockReturnValue(0)
     for (let i = 0; i < 700; i++) {
       recordProcessGoneCrash({ record: vi.fn() } as never, utilityCrash, dedupe)
     }
-    nowSpy.mockReturnValue(30_000)
+    vi.advanceTimersByTime(30_000)
     recordProcessGoneCrash({ record: vi.fn() } as never, utilityCrash, dedupe)
 
     expect(getCrashBreadcrumbSnapshot()).toEqual([


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​402 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​399 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​79 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​18 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​61 |

<!-- /orca-pr-loc -->

## ELI5

When the same crash-related event fires rapidly, Orca doesn't write every occurrence —
it writes one entry plus a "repeated N times" count. Those counts are evidence: crash
investigations lean on them to tell one burst from two.

The bookkeeping had two bugs. If a crash report happened to be filed in the middle of a
burst, the report took a snapshot that included the pending repeats — and then the
normal path counted the same repeats AGAIN into the next entry, so one burst read as
two. Separately, when repeats were folded onto an entry that had itself been re-emitted
with a count, the fold overwrote the count the entry was born carrying — deleting a
window's worth of repeats from the record.

The first fix introduced a third bug worse than either: during a crash storm busy enough
to push the target entry out of the ring, the fold landed on a dead object and marked the
repeats resolved, so the burst vanished from every artifact. The reachability guard
stopped that zero-count regression, but review found one more escape hatch: TTL or LRU
cleanup could delete the deliberately unresolved state before the key emitted again.
The cleanup repair materializes only that unclaimed debt into the bounded ring before
cleanup drops the state.
Loop 2 closed the same cleanup hole for data-less breadcrumbs, where "no payload"
had been mistaken for "no pending repeat."

A cross-lane review then found that the 30-second suppression window used the wall clock.
A backward correction could stretch suppression indefinitely, while a forward correction
could collapse it early. The window now measures monotonic elapsed time; forensic ISO
timestamps remain wall-clock metadata.

## What Changed

Four commits, four files (+481/−21), all in the durable breadcrumb store and its focused
tests — the path every coalesced breadcrumb producer routes through:

- **Double-claim closed:** repeats resolved into a report snapshot are marked claimed,
  so the emit path no longer re-counts them into the next crumb.
- **Mirror erasure closed:** a fold resolving onto a re-emitted crumb adds to the count
  that crumb was born carrying instead of overwriting it.
- **Zero-evidence orphan closed:** folds check ring membership plus the retained-slot
  snapshot budget before resolving. Unreachable repeats remain unclaimed for the next
  emit; if unrelated TTL or LRU cleanup arrives first, it materializes only the unclaimed
  repeats into a fresh bounded-ring crumb before deleting the state.
- **Data-less orphan closed:** omitted optional payloads now resolve from the suppression
  count, so cleanup cannot mistake missing data for missing debt.
- **Clock-robust window:** suppression and TTL cleanup use monotonic elapsed time, so
  forward or backward system-clock corrections cannot shorten or extend the 30-second window.

## Why

The durable breadcrumb store's repeat counts are forensic evidence — the crash sweep's
analyses read them as ground truth for how often something fired. The original defects
either inflated a burst into two or erased a window's repeats. The initial orphan guard
still allowed the same erasure when unrelated cleanup deleted the unresolved state; the
new cleanup handoff closes that final path without retaining unbounded tombstones.

## Trade-offs

All three stated plainly:

1. **Semantic change — trace spans report only repeat debt not already folded into an
   earlier snapshot, and orphan-cleanup materialization emits no span.** Report snapshots
   are cumulative immutable views, while emitted breadcrumbs are mirrored into spans;
   spans plus snapshots, or multiple snapshots, overlap by design and must not be summed
   as disjoint counts. Span-only rate analytics can miss snapshot-owned counts.
2. **Unfixed residual at `ipc/crash-reporting.ts:185`:** if the renderer-error
   `store.record` rejects, the already-folded snapshot dies with it and those counts can
   no longer resurface via emit re-claim. This is disk-failure-only; a transactional
   unwind would couple the store to report-persistence outcomes across modules, judged
   disproportionate to the failure mode.
3. **Blast radius — five producers route through this store** (`agent_state_changed` in
   index.ts, pr-refresh-validation-backoff, pr-refresh-coordinator, IPC renderer
   breadcrumbs, durable-crash-breadcrumb). Three ignore the return value. Two mirror
   real emits into trace spans; rare orphan-cleanup materialization remains breadcrumb
   evidence and does not add a forced trace flush.

## Linked Issue

No tracked GitHub issue exists for this work — it originates from the #orca-crashes
field sweep of 2026-08-13/14. The defects were found while reviewing the sibling
external-kill-correlation branch (whose durable audit breadcrumbs depend on these counts
being exact) and split out on that reviewer's recommendation.

PR #14667 intentionally remains store-free and depends on this PR landing first. It is
blocked on this monotonic-window guarantee because its durable defer-time breadcrumbs route
through this store.

## Visual Proof

No rendered interaction change. Grok's Electron/CDP launch smoke is attached in
https://github.com/stablyai/orca/pull/14666#issuecomment-5300863071; unit-level accounting
evidence is the acceptance signal for this main-process-only change.

## Testing

- **Post-rebase branch HEAD, one single-file Vitest invocation at a time:** 102/102 across
  13 focused files: store 21, orphan cleanup 6, bounded-map leak 3, six upstream-split PR
  refresh coordinator shards 35, PR validation backoff 3, IPC renderer breadcrumbs 18,
  durable breadcrumbs 3, and process-gone recorder 13.
- **Clock mutation:** replacing only the monotonic source with `Date.now()` yields
  `2 failed | 19 passed`: backward correction suppresses the required emit and forward
  correction emits early. Restoring `performance.now()` yields `21 passed`.
- **The cleanup blocker is pinned as a four-case matrix:** TTL expiry and LRU eviction
  after both full ring eviction and retained-slot snapshot-budget orphaning.
- **Partial claims are pinned:** cleanup materializes only repeats not
  already folded into an earlier snapshot, and a later key emit starts with zero debt.
- `tsc --noEmit -p config/tsconfig.node.json`, targeted `oxlint`, targeted `oxfmt --check`,
  and `git diff --check` pass after rebasing onto current `origin/main`.
- The earlier 38-mutant battery predates the cleanup fix and is not claimed as validation
  for the new path; the focused regressions above replace the previously documented LRU
  survivor assumption that this review disproved.

- [ ] I manually tested these changes locally — *not applicable to a main-process-only
      accounting fix; no live crash storm was induced.*
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

## Adversarial Review

Earlier review loops on the sibling work found the original double-claim and the first
fix's zero-evidence orphan, which led to splitting this store change into its own PR.
Adversarial review loop 1 on this PR then reproduced the remaining TTL/LRU state-deletion
blocker, added the four cleanup/orphan regressions plus a partial-claim debt-transfer case,
and drove the bounded materialization fix that now ships.
Adversarial review loop 2 then caught the optional-data contract hole in that cleanup
path, added data-less fold/orphan regressions, and clarified that immutable report
snapshots and their mirrored trace spans overlap by design.
Adversarial review loop 3 was reopened by a cross-lane clock finding, drove the monotonic
window plus backward/forward regressions and producer test-seam correction, and returned
CLEAN on the final diff.

## Review

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH,
Mobile, general backwards compatibility, performance

- **Security:** no new inputs or surface; pending producer data still passes through the
  existing sanitizer before entering evidence.
- **Cross-platform (Linux/Windows/Mac):** `performance.now()` provides per-process
  monotonic elapsed time on every target; no platform-conditional path is added.
- **Remote SSH and folder workspaces:** producers can originate from either context, but
  accounting remains local main-process state with no path, Git, or wire-format change.
- **Mobile:** not affected.
- **Backwards compatibility:** crumb shapes and fields are unchanged; only repeat
  attribution changes. Span-only rate analytics retain trade-off (1).
- **Performance:** the state map remains capped at 128, the ring at 30, and the retained
  map at 4. Each call replaces one wall-clock read with one monotonic-clock read; steady
  suppression still allocates nothing new, and only rare orphan cleanup performs one
  sanitized ring write before deleting the state.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover;
      local preferred) — *focused lint/format, node typecheck, and tests pass locally;
      full commands were not run and are left to CI.*

## Author

- X / Twitter: @BrennanKB5

