### PR TITLE
test(crash-reporting): keep ambiguous whole-tree kills reportable

### DIFF
--- a/src/main/crash-reporting/process-gone-killed-one-ordering.test.ts
+++ b/src/main/crash-reporting/process-gone-killed-one-ordering.test.ts
@@ -17,6 +17,9 @@ import {
 import { ProcessGoneDedupe } from './process-gone-dedupe'
 import { recordProcessGoneCrash, type ProcessGoneCrashEvent } from './process-gone-recorder'
 
+const noMinidump = async () => null
+const attachDetails = async () => null
+
 function event(overrides: Partial<ProcessGoneCrashEvent> = {}): ProcessGoneCrashEvent {
   return {
     source: 'renderer',
@@ -82,9 +85,32 @@ describe('recordProcessGoneCrash killed/1 ordering', () => {
 
     recordProcessGoneCrash({ record } as never, gpuKill, dedupe)
     recordProcessGoneCrash({ record } as never, networkServiceKill, dedupe)
-    recordProcessGoneCrash({ record } as never, rendererKill, dedupe)
+    recordProcessGoneCrash(
+      { record, attachDetails } as never,
+      rendererKill,
+      dedupe,
+      noMinidump
+    )
 
     expect(record).toHaveBeenCalledOnce()
+    // Timing proximity is evidence, not authority to discard an ambiguous report.
+    expect(record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        breadcrumbs: expect.arrayContaining([
+          expect.objectContaining({
+            name: 'process_gone_suppressed',
+            data: expect.objectContaining({ source: 'child', processType: 'GPU' })
+          }),
+          expect.objectContaining({
+            name: 'process_gone_suppressed',
+            data: expect.objectContaining({
+              source: 'child',
+              serviceName: 'network.mojom.NetworkService'
+            })
+          })
+        ])
+      })
+    )
   })
 
   it('suppresses the fleet sequence only after independent session-end intent', () => {

--- a/src/main/crash-reporting/process-gone-recorder.test.ts
+++ b/src/main/crash-reporting/process-gone-recorder.test.ts
@@ -436,10 +436,9 @@ describe('recordProcessGoneCrash', () => {
     }
   }
 
-  // Why child kills: the decode gate is source-agnostic, and a non-recoverable
-  // child persists synchronously on every branch of the crash-reporting stack
-  // (the renderer killed path defers behind a sibling-kill settle), so the
-  // platform stub is still in force when the gate reads process.platform.
+  // Why child kills: the decode gate is source-agnostic and reads
+  // process.platform synchronously at record time, so the platform stub is
+  // still in force when it runs.
   const nonRecoverableChildKill = (overrides: Partial<ProcessGoneCrashEvent>): ProcessGoneCrashEvent =>
     event({
       source: 'child',


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​30 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​25 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## ELI5

When the renderer and Chromium helper processes exit near the same time, that timing is useful evidence but not proof that one whole-process-tree kill caused every exit. Orca should keep filing an otherwise-unexpected renderer exit and carry the nearby helper-exit breadcrumbs in the report so postmortem analysis can make the correlation without losing evidence.

## What Changed

- No production behavior changes.
- Strengthens the existing killed/1 ordering regression to require immediate renderer-report persistence even after matching GPU and Network Service exits.
- Requires both child-exit breadcrumbs to be present in the persisted renderer report.
- Keeps suppression limited to authoritative teardown intent already owned by Orca.

## Why

Electron provides no deterministic causal identity or ordering guarantee across `child-process-gone` and `render-process-gone`. A timing gate could permanently suppress a genuine renderer report after an unrelated matching child exit; emitting the ambiguous report with its existing breadcrumbs preserves evidence and follows the safer failure mode.

This replaces the earlier sibling-window implementation on this branch. The 250ms settle, 2s lookback, sibling-count classification, and deferred-report breadcrumb have all been removed.

## Linked Issue

No tracked GitHub issue exists for this work; it originated from crash-report postmortem analysis.

## Visual Proof

`N/A` — no UI or interaction change.

## Testing

- `process-gone-killed-one-ordering.test.ts`: **5/5 passed** on current `origin/main`.
- [ ] Manually tested — not applicable; this is a test-only policy regression.
- [x] Automated test updated.

## AI Disclosure

AI assistance was used for implementation and review.

## Review

- **Security:** no production or input-surface change.
- **Cross-platform:** pins platform-neutral Electron process-gone semantics without exit-code heuristics.
- **Remote SSH / folder workspaces / mobile:** unaffected.
- **Backwards compatibility:** no runtime or wire change.
- **Performance:** no production cost.

## Checklist

- [x] Small and focused.
- [x] Change and rationale documented.
- [x] Visual proof marked N/A.
- [x] Self-reviewed for correctness, security, and performance.
- [x] Cross-platform and remote impact considered.
- [ ] Full lint, test, typecheck, and build left to CI; the focused file passed locally.

## Author

- X / Twitter: @BrennanKB5


## Completion verification

- Rebased onto current `origin/main`, which includes #14666 and #14662; all 19 `src/main/crash-reporting/` test files passed individually (**201/201 tests**) with file parallelism disabled.
- The #14666 coalescing window and TTL cleanup now use monotonic elapsed time; wall-clock ISO timestamps remain evidence metadata. Its backward and forward clock-step regressions cover both failure directions.
- Windows low-spec packaged-kill QA remains unavailable because the saved environment returned no runtime state. No destructive process control was substituted on the shared host, and this PR does not claim a packaged-kill reproduction.
