### PR TITLE
fix(worktrees): address review feedback on the worktrees slice split

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -65,6 +65,7 @@ import {
 import { WorkspaceSleepMenuItems } from './WorkspaceSleepMenuItems'
 import { isEventTargetInsideCurrentTarget } from './worktree-card-dom-events'
 import { translate } from '@/i18n/i18n'
+import { unnestWorktrees } from './worktree-unnest'
 import { parseWorkspaceKey, worktreeWorkspaceKey } from '../../../../shared/workspace-scope'
 
 type Props = {
@@ -749,8 +750,9 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
   )
 
   const handleRemoveParentLink = useCallback(() => {
-    void Promise.all(
-      activeContextWorktrees.map((item) => updateWorktreeLineage(item.id, { noParent: true }))
+    void unnestWorktrees(
+      activeContextWorktrees.map((item) => item.id),
+      updateWorktreeLineage
     )
   }, [activeContextWorktrees, updateWorktreeLineage])
 

--- a/src/renderer/src/components/sidebar/worktree-list/drag/use-lineage-drop-commit.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/drag/use-lineage-drop-commit.ts
@@ -8,6 +8,7 @@ import type { WorktreeLineage } from '../../../../../../shared/worktree/lineage-
 import { isEligibleWorktreeParent } from '../../worktree-parent-candidates'
 import { getCyclicProjectedWorktreeLineageIds } from '../../worktree-lineage-projection'
 import { getReorderedWorktreeIdsToUnnest } from '../../worktree-lineage-drag-drop'
+import { unnestWorktrees } from '../../worktree-unnest'
 import type { WorktreeDragGroup } from '../../worktree-manual-order'
 import type { WorktreeSidebarLineageDropTarget } from './row-state'
 
@@ -104,17 +105,7 @@ export function useWorktreeLineageDropCommit(args: {
         return
       }
       // Why: dropping a nested card on a reorder line is the un-nest escape hatch; clear only the dragged children.
-      void Promise.all(ids.map((id) => updateWorktreeLineage(id, { noParent: true }))).catch(
-        (err) => {
-          console.error('Failed to unnest workspace:', err)
-          toast.error(
-            translate(
-              'auto.components.sidebar.WorktreeList.failedUnnestWorkspace',
-              'Failed to unnest workspace'
-            )
-          )
-        }
-      )
+      void unnestWorktrees(ids, updateWorktreeLineage)
     },
     [cyclicLineageIds, updateWorktreeLineage, worktreeDragGroups, worktreeLineageById, worktreeMap]
   )

--- a/src/renderer/src/components/sidebar/worktree-unnest.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-unnest.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { toast } from 'sonner'
+import { unnestWorktrees } from './worktree-unnest'
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn(), info: vi.fn() }
+}))
+
+describe('unnestWorktrees', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  it('clears the parent link on every requested worktree', async () => {
+    const updateWorktreeLineage = vi.fn().mockResolvedValue(undefined)
+
+    await unnestWorktrees(['repo1::/a', 'repo1::/b'], updateWorktreeLineage)
+
+    expect(updateWorktreeLineage).toHaveBeenCalledTimes(2)
+    expect(updateWorktreeLineage).toHaveBeenCalledWith('repo1::/a', { noParent: true })
+    expect(updateWorktreeLineage).toHaveBeenCalledWith('repo1::/b', { noParent: true })
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  // Why: both callers fire-and-forget, so a rejection that escapes here is an unhandled rejection
+  // and the user sees nothing at all.
+  it('toasts instead of rejecting when the lineage update fails', async () => {
+    const updateWorktreeLineage = vi
+      .fn()
+      .mockRejectedValue(new Error('Workspace identity is ambiguous across hosts'))
+
+    await expect(unnestWorktrees(['repo1::/a'], updateWorktreeLineage)).resolves.toBeUndefined()
+
+    expect(toast.error).toHaveBeenCalledWith('Failed to unnest workspace')
+  })
+
+  it('toasts once when several worktrees fail together', async () => {
+    const updateWorktreeLineage = vi.fn().mockRejectedValue(new Error('unresolvable owner'))
+
+    await unnestWorktrees(['repo1::/a', 'repo1::/b'], updateWorktreeLineage)
+
+    expect(toast.error).toHaveBeenCalledTimes(1)
+  })
+
+  it('does nothing for an empty selection', async () => {
+    const updateWorktreeLineage = vi.fn().mockResolvedValue(undefined)
+
+    await unnestWorktrees([], updateWorktreeLineage)
+
+    expect(updateWorktreeLineage).not.toHaveBeenCalled()
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-unnest.ts
+++ b/src/renderer/src/components/sidebar/worktree-unnest.ts
@@ -1,0 +1,31 @@
+import { toast } from 'sonner'
+import { translate } from '@/i18n/i18n'
+import type { AppState } from '@/store/types'
+
+/**
+ * Clear the parent link on each worktree and report a single failure toast.
+ *
+ * Shared by the context menu's "Remove parent link" and the drag-to-reorder un-nest. Both
+ * fire-and-forget, and `updateWorktreeLineage` rejects when the owner route can't be resolved,
+ * so neither may call it bare — the rejection would surface as an unhandled promise rejection
+ * and the action would look like it succeeded.
+ */
+export async function unnestWorktrees(
+  worktreeIds: readonly string[],
+  updateWorktreeLineage: AppState['updateWorktreeLineage']
+): Promise<void> {
+  if (worktreeIds.length === 0) {
+    return
+  }
+  try {
+    await Promise.all(worktreeIds.map((id) => updateWorktreeLineage(id, { noParent: true })))
+  } catch (err) {
+    console.error('Failed to unnest workspace:', err)
+    toast.error(
+      translate(
+        'auto.components.sidebar.WorktreeList.failedUnnestWorkspace',
+        'Failed to unnest workspace'
+      )
+    )
+  }
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -334,8 +334,16 @@
           "runtimeScopeForbiddenTitle": "This connection has limited (mobile) access",
           "runtimeScopeForbiddenDescription": "Workspaces are unavailable on a mobile-scope pairing. Reconnect using the browser access link from Settings → Runtime Environments → Share this Orca server.",
           "a17f4d2e93": "Could not update this workspace.",
-          "a1c4f7b2d3": "Update the remote runtime to change this workspace’s linked issue",
-          "b8e2d6014f": "Update the remote runtime to link Linear issues"
+          "metadata": {
+            "worktree": {
+              "meta": {
+                "persist": {
+                  "877e3638d8": "Update the remote runtime to change this workspace’s linked issue",
+                  "4367540861": "Update the remote runtime to link Linear issues"
+                }
+              }
+            }
+          }
         },
         "repos": {
           "2975400634": "Update Orca server to open non-Git folders on this runtime.",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -334,6 +334,7 @@
           "runtimeScopeForbiddenTitle": "This connection has limited (mobile) access",
           "runtimeScopeForbiddenDescription": "Workspaces are unavailable on a mobile-scope pairing. Reconnect using the browser access link from Settings → Runtime Environments → Share this Orca server.",
           "a17f4d2e93": "Could not update this workspace.",
+          "preservedBranchCleanupHostAmbiguous": "Multiple preserved branch cleanups are pending for \"{{value0}}\"; specify the host.",
           "metadata": {
             "worktree": {
               "meta": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -333,7 +333,9 @@
           "81f13f48d2": "Git could not safely delete branch \"{{value0}}\" after deleting worktree \"{{value1}}\", so Orca kept it to avoid losing local commits.",
           "runtimeScopeForbiddenTitle": "This connection has limited (mobile) access",
           "runtimeScopeForbiddenDescription": "Workspaces are unavailable on a mobile-scope pairing. Reconnect using the browser access link from Settings → Runtime Environments → Share this Orca server.",
-          "a17f4d2e93": "Could not update this workspace."
+          "a17f4d2e93": "Could not update this workspace.",
+          "a1c4f7b2d3": "Update the remote runtime to change this workspace’s linked issue",
+          "b8e2d6014f": "Update the remote runtime to link Linear issues"
         },
         "repos": {
           "2975400634": "Update Orca server to open non-Git folders on this runtime.",

--- a/src/renderer/src/store/slices/store-worktree-removal-cascade.test.ts
+++ b/src/renderer/src/store/slices/store-worktree-removal-cascade.test.ts
@@ -268,6 +268,40 @@ describe('removeWorktree cascade', () => {
     })
   })
 
+  it('promotes a queued row to deleting when a real delete starts (phase-aware skip guard)', () => {
+    const store = createTestStore()
+    const queued = 'repo1::/path/queued'
+    const inProgress = 'repo1::/path/in-progress'
+
+    seedStore(store, {
+      deleteStateByWorktreeId: {
+        [queued]: {
+          isDeleting: true,
+          phase: 'queued',
+          error: null,
+          canForceDelete: false,
+          forceDeleteReason: null
+        },
+        [inProgress]: {
+          isDeleting: true,
+          phase: 'deleting',
+          error: null,
+          canForceDelete: false,
+          forceDeleteReason: null
+        }
+      }
+    })
+
+    store.getState().markWorktreesDeleting([queued, inProgress])
+
+    expect(store.getState().deleteStateByWorktreeId).toMatchObject({
+      // A queued row is promoted so the sidebar shows real deletion progress.
+      [queued]: { isDeleting: true, phase: 'deleting', error: null, canForceDelete: false },
+      // A row already in the deleting phase is left untouched.
+      [inProgress]: { isDeleting: true, phase: 'deleting', error: null, canForceDelete: false }
+    })
+  })
+
   it('marks multiple worktrees queued for deletion in one optimistic state update', () => {
     const store = createTestStore()
     const first = 'repo1::/path/wt1'

--- a/src/renderer/src/store/slices/worktrees-fetch-removal-purge.test.ts
+++ b/src/renderer/src/store/slices/worktrees-fetch-removal-purge.test.ts
@@ -78,6 +78,50 @@ describe('fetchWorktrees', () => {
     expect(store.getState().sortEpoch).toBe(8)
   })
 
+  it('keeps pr-checks and plugin panel tabs for surviving worktrees after an authoritative purge', async () => {
+    const store = createTestStore()
+    const removed = makeWorktree({
+      id: 'repo1::/path/removed',
+      repoId: 'repo1',
+      path: '/path/removed'
+    })
+    const surviving = makeWorktree({
+      id: 'repo1::/path/surviving',
+      repoId: 'repo1',
+      path: '/path/surviving'
+    })
+
+    mockApi.worktrees.list.mockResolvedValue([surviving])
+    store.setState({
+      worktreesByRepo: { repo1: [removed, surviving] },
+      sortEpoch: 7,
+      rightSidebarTabByWorktree: {
+        [removed.id]: 'search' as never,
+        [surviving.id]: 'pr-checks' as never
+      },
+      rightSidebarExplorerViewByWorktree: {
+        [removed.id]: 'search',
+        [surviving.id]: 'files'
+      }
+    } as Partial<AppState>)
+
+    await store.getState().fetchWorktrees('repo1')
+
+    // pr-checks is not dropped like unknown values; it survives the purge.
+    expect(store.getState().rightSidebarTabByWorktree).toEqual({ [surviving.id]: 'pr-checks' })
+
+    // A shape-valid plugin panel tab also survives the purge.
+    store.setState({
+      rightSidebarTabByWorktree: {
+        [surviving.id]: 'plugin:orca-samples.my-plugin/dashboard' as never
+      }
+    } as Partial<AppState>)
+    await store.getState().fetchWorktrees('repo1')
+    expect(store.getState().rightSidebarTabByWorktree).toEqual({
+      [surviving.id]: 'plugin:orca-samples.my-plugin/dashboard'
+    })
+  })
+
   it('purges hosted review link mutation bookkeeping for worktrees removed by refresh', async () => {
     const store = createTestStore()
     const removed = makeWorktree({

--- a/src/renderer/src/store/slices/worktrees-lineage-state.test.ts
+++ b/src/renderer/src/store/slices/worktrees-lineage-state.test.ts
@@ -702,9 +702,9 @@ describe('worktree lineage state', () => {
     expect(store.getState().worktreesByRepo.repo1?.[0]).toEqual(updatedChild)
   })
 
-  // The sidebar's remove-parent-link action awaits updateWorktreeLineage without a catch,
-  // so every path out of it must resolve rather than reject.
-  it('skips the lineage update for a genuinely ambiguous owner instead of rejecting', async () => {
+  // An unresolvable owner route must reach the caller so the sidebar can toast it, rather than
+  // becoming a silent no-op. Both callers catch; see WorktreeContextMenu.handleRemoveParentLink.
+  it('rejects the lineage update when the owner route cannot be resolved', async () => {
     const store = createTestStore()
     const worktreeId = 'repo-shared::/same/path'
     store.setState({
@@ -729,7 +729,7 @@ describe('worktree lineage state', () => {
 
     await expect(
       store.getState().updateWorktreeLineage(worktreeId, { noParent: true })
-    ).resolves.toBeUndefined()
+    ).rejects.toThrow()
 
     expect(mockApi.worktrees.updateLineage).not.toHaveBeenCalled()
   })

--- a/src/renderer/src/store/slices/worktrees-lineage-state.test.ts
+++ b/src/renderer/src/store/slices/worktrees-lineage-state.test.ts
@@ -701,4 +701,63 @@ describe('worktree lineage state', () => {
     expect(store.getState().worktreeLineageById).toEqual({})
     expect(store.getState().worktreesByRepo.repo1?.[0]).toEqual(updatedChild)
   })
+
+  // The sidebar's remove-parent-link action awaits updateWorktreeLineage without a catch,
+  // so every path out of it must resolve rather than reject.
+  it('skips the lineage update for a genuinely ambiguous owner instead of rejecting', async () => {
+    const store = createTestStore()
+    const worktreeId = 'repo-shared::/same/path'
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'hub-c' } as never,
+      worktreesByRepo: {
+        'repo-shared': [
+          makeWorktree({
+            id: worktreeId,
+            repoId: 'repo-shared',
+            hostId: 'ssh:ssh-a',
+            runtimeOwnerEnvironmentId: 'hub-a'
+          }),
+          makeWorktree({
+            id: worktreeId,
+            repoId: 'repo-shared',
+            hostId: 'ssh:ssh-b',
+            runtimeOwnerEnvironmentId: 'hub-b'
+          })
+        ]
+      }
+    } as Partial<AppState>)
+
+    await expect(
+      store.getState().updateWorktreeLineage(worktreeId, { noParent: true })
+    ).resolves.toBeUndefined()
+
+    expect(mockApi.worktrees.updateLineage).not.toHaveBeenCalled()
+  })
+
+  it('resolves when the update fails and the recovery lineage refresh fails too', async () => {
+    const lineage = makeLineage()
+    const store = createLocalLineageTestStore(lineage)
+    mockApi.worktrees.updateLineage.mockRejectedValueOnce(new Error('unnest failed'))
+    mockApi.worktrees.listLineage.mockRejectedValueOnce(new Error('refresh failed'))
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await expect(
+      store.getState().updateWorktreeLineage(lineage.worktreeId, { noParent: true })
+    ).resolves.toBeUndefined()
+  })
+
+  it('rethrows the original assign failure when the recovery refresh fails', async () => {
+    const lineage = makeLineage()
+    const store = createLocalLineageTestStore(lineage)
+    mockApi.worktrees.updateLineage.mockRejectedValueOnce(new Error('stale parent'))
+    mockApi.worktrees.listLineage.mockRejectedValueOnce(new Error('refresh failed'))
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    // A failed recovery refresh must not replace the cause the caller toasts.
+    await expect(
+      store.getState().assignWorktreeParent(lineage.worktreeId, {
+        parentWorktreeId: lineage.parentWorktreeId
+      })
+    ).rejects.toThrow('stale parent')
+  })
 })

--- a/src/renderer/src/store/slices/worktrees-linked-review-push-target.test.ts
+++ b/src/renderer/src/store/slices/worktrees-linked-review-push-target.test.ts
@@ -577,6 +577,70 @@ describe('worktree remote runtime mutations', () => {
     expect(store.getState().worktreesByRepo.repo1[0]?.pushTarget).toBeUndefined()
   })
 
+  it('skips the push-target lookup for a genuinely ambiguous owner instead of throwing past the { ok, error } contract', async () => {
+    const store = createTestStore()
+    const worktreeId = 'repo-shared::/same/path'
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'hub-c' } as never,
+      worktreesByRepo: {
+        'repo-shared': [
+          makeWorktree({
+            id: worktreeId,
+            repoId: 'repo-shared',
+            hostId: 'ssh:ssh-a',
+            runtimeOwnerEnvironmentId: 'hub-a'
+          }),
+          makeWorktree({
+            id: worktreeId,
+            repoId: 'repo-shared',
+            hostId: 'ssh:ssh-b',
+            runtimeOwnerEnvironmentId: 'hub-b'
+          })
+        ]
+      }
+    } as Partial<AppState>)
+
+    const result = await store.getState().updateWorktreeMeta(worktreeId, { linkedPR: 123 })
+
+    // The ambiguous owner must surface as a graceful { ok: false }, not an uncaught rejection.
+    expect(result.ok).toBe(false)
+    expect(mockApi.worktrees.resolvePrBase).not.toHaveBeenCalled()
+    expect(mockApi.worktrees.updateMeta).not.toHaveBeenCalled()
+  })
+
+  it('cleans up the in-flight lookup when restore is skipped for a genuinely ambiguous owner', async () => {
+    const store = createTestStore()
+    const worktreeId = 'repo-shared::/same/path'
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'hub-c' } as never,
+      worktreesByRepo: {
+        'repo-shared': [
+          makeWorktree({
+            id: worktreeId,
+            repoId: 'repo-shared',
+            hostId: 'ssh:ssh-a',
+            runtimeOwnerEnvironmentId: 'hub-a',
+            linkedPR: 123
+          }),
+          makeWorktree({
+            id: worktreeId,
+            repoId: 'repo-shared',
+            hostId: 'ssh:ssh-b',
+            runtimeOwnerEnvironmentId: 'hub-b',
+            linkedPR: 123
+          })
+        ]
+      }
+    } as Partial<AppState>)
+
+    await expect(store.getState().ensureHostedReviewPushTarget(worktreeId)).resolves.toBeUndefined()
+
+    expect(mockApi.worktrees.resolvePrBase).not.toHaveBeenCalled()
+    expect(mockApi.worktrees.updateMeta).not.toHaveBeenCalled()
+    // A second call must not be blocked by a stale in-flight marker from the skipped first call.
+    await expect(store.getState().ensureHostedReviewPushTarget(worktreeId)).resolves.toBeUndefined()
+  })
+
   it('hydrates a missing push target for an existing linked GitLab MR when supported', async () => {
     const store = createTestStore()
     const pushTarget = { remoteName: 'upstream', branchName: 'feature/mr' }

--- a/src/renderer/src/store/slices/worktrees-linked-review-push-target.test.ts
+++ b/src/renderer/src/store/slices/worktrees-linked-review-push-target.test.ts
@@ -611,17 +611,38 @@ describe('worktree remote runtime mutations', () => {
   it('cleans up the in-flight lookup when restore is skipped for a genuinely ambiguous owner', async () => {
     const store = createTestStore()
     const worktreeId = 'repo-shared::/same/path'
+    const pushTarget = { remoteName: 'fork', branchName: 'feature/disambiguated' }
+    const ownedWorktree = makeWorktree({
+      id: worktreeId,
+      repoId: 'repo-shared',
+      hostId: 'ssh:ssh-a',
+      runtimeOwnerEnvironmentId: 'hub-a',
+      linkedPR: 123
+    })
+    runtimeEnvironmentCall.mockImplementation(({ method }: RuntimeEnvironmentCallRequest) => {
+      if (method === 'worktree.resolvePrBase') {
+        return Promise.resolve({
+          id: 'rpc-ambiguous-resolve-pr-base',
+          ok: true,
+          result: { baseBranch: 'fork-head', pushTarget },
+          _meta: { runtimeId: 'hub-a' }
+        })
+      }
+      if (method === 'worktree.set') {
+        return Promise.resolve({
+          id: 'rpc-ambiguous-set-worktree',
+          ok: true,
+          result: { worktree: { ...ownedWorktree, pushTarget } },
+          _meta: { runtimeId: 'hub-a' }
+        })
+      }
+      throw new Error(`Unexpected runtime method ${method}`)
+    })
     store.setState({
       settings: { activeRuntimeEnvironmentId: 'hub-c' } as never,
       worktreesByRepo: {
         'repo-shared': [
-          makeWorktree({
-            id: worktreeId,
-            repoId: 'repo-shared',
-            hostId: 'ssh:ssh-a',
-            runtimeOwnerEnvironmentId: 'hub-a',
-            linkedPR: 123
-          }),
+          ownedWorktree,
           makeWorktree({
             id: worktreeId,
             repoId: 'repo-shared',
@@ -635,10 +656,23 @@ describe('worktree remote runtime mutations', () => {
 
     await expect(store.getState().ensureHostedReviewPushTarget(worktreeId)).resolves.toBeUndefined()
 
+    expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
     expect(mockApi.worktrees.resolvePrBase).not.toHaveBeenCalled()
     expect(mockApi.worktrees.updateMeta).not.toHaveBeenCalled()
-    // A second call must not be blocked by a stale in-flight marker from the skipped first call.
-    await expect(store.getState().ensureHostedReviewPushTarget(worktreeId)).resolves.toBeUndefined()
+
+    // Drop the rival host row so the same lookup key now has one owner: a second call must run the
+    // lookup for real, not silently no-op on a stale in-flight marker left by the skipped first call.
+    store.setState({ worktreesByRepo: { 'repo-shared': [ownedWorktree] } } as Partial<AppState>)
+
+    await store.getState().ensureHostedReviewPushTarget(worktreeId)
+
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'hub-a',
+      method: 'worktree.resolvePrBase',
+      params: { repo: 'repo-shared', prNumber: 123 },
+      timeoutMs: 30_000
+    })
+    expect(store.getState().worktreesByRepo['repo-shared'][0]?.pushTarget).toEqual(pushTarget)
   })
 
   it('hydrates a missing push target for an existing linked GitLab MR when supported', async () => {

--- a/src/renderer/src/store/slices/worktrees-remote-runtime-removal.test.ts
+++ b/src/renderer/src/store/slices/worktrees-remote-runtime-removal.test.ts
@@ -225,6 +225,65 @@ describe('worktree remote runtime mutations', () => {
     )
   })
 
+  it('fails closed when several hosts preserved the same branch and no host is specified', async () => {
+    const store = createTestStore()
+    const worktreeId = 'repo-shared::/same/path'
+    const localWorktree = makeWorktree({
+      id: worktreeId,
+      repoId: 'repo-shared',
+      path: '/same/path',
+      hostId: 'local'
+    })
+    const remoteWorktree = makeWorktree({
+      id: worktreeId,
+      repoId: 'repo-shared',
+      path: '/same/path',
+      hostId: 'ssh:shared-target',
+      runtimeOwnerEnvironmentId: 'shared-hub'
+    })
+    mockApi.worktrees.remove.mockResolvedValueOnce({
+      preservedBranch: { branchName: 'feature/shared', head: 'shared-head' }
+    })
+    runtimeEnvironmentCall.mockImplementation(({ method }: RuntimeEnvironmentCallRequest) =>
+      Promise.resolve({
+        id: `rpc-${method}`,
+        ok: true,
+        result:
+          method === 'repo.hooksCheck'
+            ? { hasHooks: false, hooks: null, mayNeedUpdate: false }
+            : method === 'worktree.rm'
+              ? { preservedBranch: { branchName: 'feature/shared', head: 'shared-head' } }
+              : { deleted: true },
+        _meta: { runtimeId: 'runtime-shared-hub' }
+      })
+    )
+    store.setState({
+      worktreesByRepo: { 'repo-shared': [localWorktree] }
+    } as Partial<AppState>)
+
+    await store.getState().removeWorktree(worktreeId)
+    store.setState({
+      worktreesByRepo: { 'repo-shared': [remoteWorktree] }
+    } as Partial<AppState>)
+    await store.getState().removeWorktree(worktreeId)
+
+    const result = await store
+      .getState()
+      .forceDeletePreservedBranch(worktreeId, 'feature/shared', 'shared-head', {
+        suppressToast: true
+      })
+
+    // Routing to the active runtime could hit the wrong host's branch, so the delete fails closed.
+    expect(result).toMatchObject({
+      ok: false,
+      error: expect.stringContaining('Multiple preserved branch cleanups')
+    })
+    expect(mockApi.worktrees.forceDeletePreservedBranch).not.toHaveBeenCalled()
+    expect(runtimeEnvironmentCall).not.toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'worktree.forceDeleteBranch' })
+    )
+  })
+
   it('fails HUB-owned SSH removal closed when the exact id has two HUB owners', async () => {
     const store = createTestStore()
     const worktreeId = 'repo-ssh::/srv/same-wt'

--- a/src/renderer/src/store/slices/worktrees-workspace-selection-state.test.ts
+++ b/src/renderer/src/store/slices/worktrees-workspace-selection-state.test.ts
@@ -261,6 +261,23 @@ describe('markWorktreeVisited', () => {
     expect(store.getState().activeWorkspaceKey).toBe(folderWorkspaceKey('folder-1'))
     expect(store.getState().activeWorkspaceExecutionHostId).toBeNull()
   })
+
+  it('pruneLastVisitedTimestamps preserves an active workspace key pointing at a different live worktree', () => {
+    const store = createTestStore()
+    const wt = makeWorktree({ id: 'repo1::/a', repoId: 'repo1', path: '/a' })
+    store.setState({
+      worktreesByRepo: { repo1: [wt] },
+      activeWorktreeId: 'repo1::/gone',
+      activeWorkspaceKey: worktreeWorkspaceKey('repo1::/a'),
+      lastVisitedAtByWorktreeId: {}
+    } as Partial<AppState>)
+
+    store.getState().pruneLastVisitedTimestamps()
+
+    expect(store.getState().activeWorktreeId).toBeNull()
+    // Only the stale worktree's own derived key is dropped.
+    expect(store.getState().activeWorkspaceKey).toBe(worktreeWorkspaceKey('repo1::/a'))
+  })
 })
 
 describe('setRenamingWorktreeId', () => {

--- a/src/renderer/src/store/slices/worktrees-workspace-selection-state.test.ts
+++ b/src/renderer/src/store/slices/worktrees-workspace-selection-state.test.ts
@@ -4,7 +4,7 @@ import {
   registerPersistentWebview,
   unregisterPersistentWebview
 } from '../../components/browser-pane/webview-registry'
-import { folderWorkspaceKey } from '../../../../shared/workspace-scope'
+import { folderWorkspaceKey, worktreeWorkspaceKey } from '../../../../shared/workspace-scope'
 import { makeDetectedResult } from './worktrees-detected-listing-fixtures'
 import { createWebview, makeFolderWorkspace, makeWorktree } from './worktrees-slice-test-fixtures'
 import {
@@ -208,6 +208,58 @@ describe('markWorktreeVisited', () => {
     store.getState().pruneLastVisitedTimestamps()
 
     expect(store.getState().lastVisitedAtByWorktreeId).toEqual({ 'repo1::/hidden': 100 })
+  })
+
+  it('pruneLastVisitedTimestamps defers an empty list with no detected record (unhydrated shape)', () => {
+    const store = createTestStore()
+    store.setState({
+      worktreesByRepo: { repo1: [] },
+      lastVisitedAtByWorktreeId: { 'repo1::/hidden': 100 }
+    } as Partial<AppState>)
+
+    store.getState().pruneLastVisitedTimestamps()
+
+    // An empty list is the not-yet-hydrated shape, not an authoritative "no worktrees",
+    // so focus-recency is kept until an authoritative scan lands.
+    expect(store.getState().lastVisitedAtByWorktreeId).toEqual({ 'repo1::/hidden': 100 })
+  })
+
+  it('pruneLastVisitedTimestamps clears the derived worktree-scoped active workspace key with a stale active worktree', () => {
+    const store = createTestStore()
+    const wt = makeWorktree({ id: 'repo1::/a', repoId: 'repo1', path: '/a' })
+    store.setState({
+      worktreesByRepo: { repo1: [wt] },
+      activeWorktreeId: 'repo1::/gone',
+      activeWorkspaceKey: worktreeWorkspaceKey('repo1::/gone'),
+      activeWorkspaceExecutionHostId: 'local',
+      lastVisitedAtByWorktreeId: {}
+    } as Partial<AppState>)
+
+    store.getState().pruneLastVisitedTimestamps()
+
+    expect(store.getState().activeWorktreeId).toBeNull()
+    // The derived workspace key would keep the phantom workspace selected, so it goes too.
+    expect(store.getState().activeWorkspaceKey).toBeNull()
+    expect(store.getState().activeWorkspaceExecutionHostId).toBeNull()
+  })
+
+  it('pruneLastVisitedTimestamps preserves a folder-scoped active workspace key when the active worktree is stale', () => {
+    const store = createTestStore()
+    const wt = makeWorktree({ id: 'repo1::/a', repoId: 'repo1', path: '/a' })
+    store.setState({
+      worktreesByRepo: { repo1: [wt] },
+      activeWorktreeId: 'repo1::/gone',
+      activeWorkspaceKey: folderWorkspaceKey('folder-1'),
+      activeWorkspaceExecutionHostId: 'local',
+      lastVisitedAtByWorktreeId: {}
+    } as Partial<AppState>)
+
+    store.getState().pruneLastVisitedTimestamps()
+
+    expect(store.getState().activeWorktreeId).toBeNull()
+    // Folder-scoped keys are never dropped here (matches the removal paths).
+    expect(store.getState().activeWorkspaceKey).toBe(folderWorkspaceKey('folder-1'))
+    expect(store.getState().activeWorkspaceExecutionHostId).toBeNull()
   })
 })
 

--- a/src/renderer/src/store/slices/worktrees-workspace-selection-state.test.ts
+++ b/src/renderer/src/store/slices/worktrees-workspace-selection-state.test.ts
@@ -278,6 +278,23 @@ describe('markWorktreeVisited', () => {
     // Only the stale worktree's own derived key is dropped.
     expect(store.getState().activeWorkspaceKey).toBe(worktreeWorkspaceKey('repo1::/a'))
   })
+
+  it('pruneLastVisitedTimestamps clears a legacy unprefixed active workspace key for the stale worktree', () => {
+    const store = createTestStore()
+    const wt = makeWorktree({ id: 'repo1::/a', repoId: 'repo1', path: '/a' })
+    store.setState({
+      worktreesByRepo: { repo1: [wt] },
+      activeWorktreeId: 'repo1::/gone',
+      // Sessions predating the `worktree:` prefix stored the bare id (see the purge path).
+      activeWorkspaceKey: 'repo1::/gone',
+      lastVisitedAtByWorktreeId: {}
+    } as unknown as Partial<AppState>)
+
+    store.getState().pruneLastVisitedTimestamps()
+
+    expect(store.getState().activeWorktreeId).toBeNull()
+    expect(store.getState().activeWorkspaceKey).toBeNull()
+  })
 })
 
 describe('setRenamingWorktreeId', () => {

--- a/src/renderer/src/store/slices/worktrees/listing/fetch-all-worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees/listing/fetch-all-worktrees.ts
@@ -136,7 +136,9 @@ export function createFetchAllWorktrees(
             detected: refresh.result
           }
         } catch (err) {
-          console.error(`Failed to fetch worktrees for repo ${r.id}:`, err)
+          if (!notifyRuntimeScopeForbiddenIfNeeded(err)) {
+            console.error(`Failed to fetch worktrees for repo ${r.id}:`, err)
+          }
           return { repoId: r.id, ok: false as const }
         }
       }

--- a/src/renderer/src/store/slices/worktrees/metadata/hosted-review-push-target-ensure.ts
+++ b/src/renderer/src/store/slices/worktrees/metadata/hosted-review-push-target-ensure.ts
@@ -4,7 +4,7 @@ import {
   getHostedReviewPushTargetLookup,
   hostedReviewPushTargetLookupsInFlight
 } from './hosted-review-push-target'
-import { settingsForWorktreeOwner } from '../listing/worktree-owner-settings'
+import { trySettingsForWorktreeOwner } from '../listing/worktree-owner-settings'
 
 export function createEnsureHostedReviewPushTarget(
   _set: WorktreeSliceSet,
@@ -21,7 +21,12 @@ export function createEnsureHostedReviewPushTarget(
     }
     hostedReviewPushTargetLookupsInFlight.add(lookup.key)
     try {
-      const resolvedPushTarget = await lookup.resolve(settingsForWorktreeOwner(get(), worktreeId))
+      // Why: an ambiguous owner is a skip, not a crash — this runs as fire-and-forget background restoration.
+      const ownerSettings = trySettingsForWorktreeOwner(get(), worktreeId)
+      if (!ownerSettings) {
+        return
+      }
+      const resolvedPushTarget = await lookup.resolve(ownerSettings)
       if (!resolvedPushTarget) {
         return
       }

--- a/src/renderer/src/store/slices/worktrees/metadata/update-worktree-meta.ts
+++ b/src/renderer/src/store/slices/worktrees/metadata/update-worktree-meta.ts
@@ -23,7 +23,10 @@ import {
 } from './hosted-review-push-target'
 import { persistWorktreeMeta } from './worktree-meta-persist'
 import { isRuntimeSelectorNotFoundError } from '../listing/runtime-worktree-rpc-errors'
-import { settingsForWorktreeOwner } from '../listing/worktree-owner-settings'
+import {
+  settingsForWorktreeOwner,
+  trySettingsForWorktreeOwner
+} from '../listing/worktree-owner-settings'
 
 export function createUpdateWorktreeMeta(
   set: WorktreeSliceSet,
@@ -69,13 +72,18 @@ export function createUpdateWorktreeMeta(
     const linkedPrForPushTarget = isPositiveHostedReviewNumber(normalizedUpdates.linkedPR)
       ? normalizedUpdates.linkedPR
       : null
-    const resolvedPushTarget =
+    // Why: an ambiguous owner must not throw past this update's { ok, error } contract — skip the lookup instead.
+    const pushTargetOwnerSettings =
       linkedPrForPushTarget !== null &&
       normalizedUpdates.pushTarget === undefined &&
       existingWorktree &&
       !existingWorktree.pushTarget
+        ? trySettingsForWorktreeOwner(get(), worktreeId)
+        : null
+    const resolvedPushTarget =
+      pushTargetOwnerSettings && existingWorktree && linkedPrForPushTarget !== null
         ? await resolveGitHubReviewPushTarget(
-            settingsForWorktreeOwner(get(), worktreeId),
+            pushTargetOwnerSettings,
             existingWorktree.repoId,
             linkedPrForPushTarget
           )
@@ -98,7 +106,7 @@ export function createUpdateWorktreeMeta(
       return { ok: true }
     }
     const shouldRefreshHostedReview =
-      (normalizedUpdates.linkedPR === null && worktreeForUpdate?.linkedPR !== null) ||
+      (normalizedUpdates.linkedPR === null && (worktreeForUpdate?.linkedPR ?? null) !== null) ||
       (normalizedUpdates.linkedGitLabMR === null &&
         (worktreeForUpdate?.linkedGitLabMR ?? null) !== null) ||
       (normalizedUpdates.linkedBitbucketPR === null &&

--- a/src/renderer/src/store/slices/worktrees/metadata/worktree-lineage-actions.ts
+++ b/src/renderer/src/store/slices/worktrees/metadata/worktree-lineage-actions.ts
@@ -7,7 +7,23 @@ import {
   refreshWorktreeLineageForSettings,
   setWorktreeLineageForRuntime
 } from './worktree-lineage-refresh'
-import { settingsForWorktreeOwner } from '../listing/worktree-owner-settings'
+import {
+  settingsForWorktreeOwner,
+  trySettingsForWorktreeOwner,
+  warnAmbiguousOwnerOnce
+} from '../listing/worktree-owner-settings'
+
+// Why: this runs inside a catch, so letting the refresh reject would replace the failure it recovers from.
+async function refreshWorktreeLineageBestEffort(
+  ownerSettings: AppState['settings'],
+  set: WorktreeSliceSet
+): Promise<void> {
+  try {
+    await refreshWorktreeLineageForSettings(ownerSettings, set)
+  } catch (err) {
+    console.error('Failed to refresh worktree lineage after a failed write:', err)
+  }
+}
 
 export function createFetchWorktreeLineage(
   set: WorktreeSliceSet,
@@ -43,7 +59,13 @@ export function createUpdateWorktreeLineage(
   get: WorktreeSliceGet
 ): WorktreeSlice['updateWorktreeLineage'] {
   return async (worktreeId, args) => {
-    const ownerSettings = settingsForWorktreeOwner(get(), worktreeId)
+    // Why: this action never rejects — the sidebar's remove-parent-link caller awaits it without a catch,
+    // so an ambiguous owner is a skip rather than an unhandled rejection.
+    const ownerSettings = trySettingsForWorktreeOwner(get(), worktreeId)
+    if (!ownerSettings) {
+      warnAmbiguousOwnerOnce(worktreeId, 'worktree lineage update')
+      return
+    }
     try {
       applyWorktreeLineageUpdate(
         set,
@@ -52,7 +74,7 @@ export function createUpdateWorktreeLineage(
       )
     } catch (err) {
       console.error('Failed to update worktree lineage:', err)
-      await refreshWorktreeLineageForSettings(ownerSettings, set)
+      await refreshWorktreeLineageBestEffort(ownerSettings, set)
     }
   }
 }
@@ -71,7 +93,8 @@ export function createAssignWorktreeParent(
       )
     } catch (err) {
       console.error('Failed to assign worktree parent:', err)
-      await refreshWorktreeLineageForSettings(ownerSettings, set)
+      // Unlike the update path this rethrows, so the recovery refresh must not mask the original cause.
+      await refreshWorktreeLineageBestEffort(ownerSettings, set)
       throw err
     }
   }

--- a/src/renderer/src/store/slices/worktrees/metadata/worktree-lineage-actions.ts
+++ b/src/renderer/src/store/slices/worktrees/metadata/worktree-lineage-actions.ts
@@ -7,11 +7,7 @@ import {
   refreshWorktreeLineageForSettings,
   setWorktreeLineageForRuntime
 } from './worktree-lineage-refresh'
-import {
-  settingsForWorktreeOwner,
-  trySettingsForWorktreeOwner,
-  warnAmbiguousOwnerOnce
-} from '../listing/worktree-owner-settings'
+import { settingsForWorktreeOwner } from '../listing/worktree-owner-settings'
 
 // Why: this runs inside a catch, so letting the refresh reject would replace the failure it recovers from.
 async function refreshWorktreeLineageBestEffort(
@@ -59,13 +55,9 @@ export function createUpdateWorktreeLineage(
   get: WorktreeSliceGet
 ): WorktreeSlice['updateWorktreeLineage'] {
   return async (worktreeId, args) => {
-    // Why: this action never rejects — the sidebar's remove-parent-link caller awaits it without a catch,
-    // so an ambiguous owner is a skip rather than an unhandled rejection.
-    const ownerSettings = trySettingsForWorktreeOwner(get(), worktreeId)
-    if (!ownerSettings) {
-      warnAmbiguousOwnerOnce(worktreeId, 'worktree lineage update')
-      return
-    }
+    // Why: an unresolvable owner route (ambiguous or missing) rejects rather than skipping — this is a
+    // user-initiated action, and both callers toast the failure. Don't swallow it into a silent no-op.
+    const ownerSettings = settingsForWorktreeOwner(get(), worktreeId)
     try {
       applyWorktreeLineageUpdate(
         set,

--- a/src/renderer/src/store/slices/worktrees/metadata/worktree-meta-persist.ts
+++ b/src/renderer/src/store/slices/worktrees/metadata/worktree-meta-persist.ts
@@ -34,7 +34,7 @@ export async function persistWorktreeMeta(
       target.environmentId,
       WORKTREE_LINKED_WORK_ITEM_CONTEXT_RUNTIME_CAPABILITY,
       translate(
-        'auto.store.slices.worktrees.a1c4f7b2d3',
+        'auto.store.slices.worktrees.metadata.worktree.meta.persist.877e3638d8',
         'Update the remote runtime to change this workspace’s linked issue'
       )
     )
@@ -46,7 +46,7 @@ export async function persistWorktreeMeta(
       target.environmentId,
       TASK_SOURCE_CONTEXT_RUNTIME_CAPABILITY,
       translate(
-        'auto.store.slices.worktrees.b8e2d6014f',
+        'auto.store.slices.worktrees.metadata.worktree.meta.persist.4367540861',
         'Update the remote runtime to link Linear issues'
       )
     )

--- a/src/renderer/src/store/slices/worktrees/metadata/worktree-meta-persist.ts
+++ b/src/renderer/src/store/slices/worktrees/metadata/worktree-meta-persist.ts
@@ -8,6 +8,7 @@ import {
   WORKTREE_LINKED_WORK_ITEM_CONTEXT_RUNTIME_CAPABILITY
 } from '../../../../../../shared/protocol-version'
 import { toRuntimeWorktreeSelector } from '../../../../runtime/runtime-worktree-selector'
+import { translate } from '@/i18n/i18n'
 import type { AppState } from '../../../types'
 import type { WorktreeMeta } from '../../../../../../shared/worktree/meta-types'
 import { encodePushTargetClearForRuntimeRpc } from './hosted-review-link-mutation'
@@ -32,7 +33,10 @@ export async function persistWorktreeMeta(
     await assertRuntimeEnvironmentCapability(
       target.environmentId,
       WORKTREE_LINKED_WORK_ITEM_CONTEXT_RUNTIME_CAPABILITY,
-      'Update the remote runtime to change this workspace’s linked issue'
+      translate(
+        'auto.store.slices.worktrees.a1c4f7b2d3',
+        'Update the remote runtime to change this workspace’s linked issue'
+      )
     )
   }
   // task-source-context.v1 is a sound proxy for the Linear keys: #5322 added them
@@ -41,7 +45,10 @@ export async function persistWorktreeMeta(
     await assertRuntimeEnvironmentCapability(
       target.environmentId,
       TASK_SOURCE_CONTEXT_RUNTIME_CAPABILITY,
-      'Update the remote runtime to link Linear issues'
+      translate(
+        'auto.store.slices.worktrees.b8e2d6014f',
+        'Update the remote runtime to link Linear issues'
+      )
     )
   }
   await callRuntimeRpc(

--- a/src/renderer/src/store/slices/worktrees/session/worktree-identity-rename-state.ts
+++ b/src/renderer/src/store/slices/worktrees/session/worktree-identity-rename-state.ts
@@ -48,7 +48,8 @@ const WORKTREE_ID_KEYED_MAP_KEYS = [
 
 /**
  * Re-key every worktree-id-keyed map from `oldWorktreeId` to `newWorktreeId` after a folder
- * rename. Tab-id/file-id-keyed maps and active/renaming pointers stay put since tabs/files keep their ids.
+ * rename. Tab-id/file-id-keyed maps stay put since tabs/files keep their ids; the
+ * active/renaming pointers are worktree-id-valued, so they're re-pointed too.
  * Main-process counterpart: `Store.migrateWorktreeIdentity` in persistence.ts.
  */
 export function buildWorktreeRenameState(

--- a/src/renderer/src/store/slices/worktrees/session/worktree-pin-reveal.ts
+++ b/src/renderer/src/store/slices/worktrees/session/worktree-pin-reveal.ts
@@ -40,7 +40,9 @@ export function createSetWorktreesPinnedAndReveal(
       return
     }
     // updateWorktreesMeta applies the store update synchronously, so the reveal below sees the row already rendered.
-    void get().updateWorktreesMeta(updates)
+    if (updates.size > 0) {
+      void get().updateWorktreesMeta(updates)
+    }
     if (revealWorktreeId !== null) {
       get().revealWorktreeInSidebar(revealWorktreeId, { behavior: 'smooth', highlight: true })
     }

--- a/src/renderer/src/store/slices/worktrees/session/worktree-visit-recency.ts
+++ b/src/renderer/src/store/slices/worktrees/session/worktree-visit-recency.ts
@@ -1,6 +1,7 @@
 import type { WorktreeSlice } from '../../worktree-helpers'
 import type { WorktreeSliceGet, WorktreeSliceSet } from '../listing/worktree-slice-types'
 import { getRepoIdFromWorktreeId } from '../../worktree-helpers'
+import { parseWorkspaceKey } from '../../../../../../shared/workspace-scope'
 
 export function createMarkWorktreeVisited(
   set: WorktreeSliceSet,
@@ -35,7 +36,8 @@ export function createPruneLastVisitedTimestamps(
       // Only drop for repos with a populated/authoritative list; a missing repoId means not-yet-hydrated (defer).
       const validIdsByRepo = new Map<string, Set<string>>()
       for (const [repoId, list] of Object.entries(s.worktreesByRepo)) {
-        if (s.detectedWorktreesByRepo[repoId]) {
+        // An empty list is the not-yet-hydrated shape, not an authoritative "no worktrees".
+        if (s.detectedWorktreesByRepo[repoId] || list.length === 0) {
           continue
         }
         validIdsByRepo.set(repoId, new Set(list.map((worktree) => worktree.id)))
@@ -64,6 +66,7 @@ export function createPruneLastVisitedTimestamps(
       const patch: {
         lastVisitedAtByWorktreeId?: Record<string, number>
         activeWorktreeId?: null
+        activeWorkspaceKey?: null
         activeWorkspaceExecutionHostId?: null
       } = {}
       if (changed) {
@@ -82,6 +85,12 @@ export function createPruneLastVisitedTimestamps(
         const activeRepoWorktreeIds = validIdsByRepo.get(getRepoIdFromWorktreeId(activeId))
         if (activeRepoWorktreeIds && !activeRepoWorktreeIds.has(activeId)) {
           patch.activeWorktreeId = null
+          // Leaving the derived workspace key behind would keep the phantom workspace selected.
+          // Scope-checked like the removal paths so a folder-scoped key is never dropped.
+          const activeScope = s.activeWorkspaceKey ? parseWorkspaceKey(s.activeWorkspaceKey) : null
+          if (activeScope?.type !== 'folder') {
+            patch.activeWorkspaceKey = null
+          }
           patch.activeWorkspaceExecutionHostId = null
         }
       }

--- a/src/renderer/src/store/slices/worktrees/session/worktree-visit-recency.ts
+++ b/src/renderer/src/store/slices/worktrees/session/worktree-visit-recency.ts
@@ -87,8 +87,12 @@ export function createPruneLastVisitedTimestamps(
           patch.activeWorktreeId = null
           // Leaving the derived workspace key behind would keep the phantom workspace selected.
           // Only the stale worktree's own key is dropped (same equality check as the rename path),
-          // so a folder key or a key pointing at another live worktree survives.
-          if (s.activeWorkspaceKey === worktreeWorkspaceKey(activeId)) {
+          // so a folder key or a key pointing at another live worktree survives. The bare-id form
+          // predates the `worktree:` prefix and is cleared too, matching the purge path.
+          if (
+            s.activeWorkspaceKey === worktreeWorkspaceKey(activeId) ||
+            s.activeWorkspaceKey === activeId
+          ) {
             patch.activeWorkspaceKey = null
           }
           patch.activeWorkspaceExecutionHostId = null

--- a/src/renderer/src/store/slices/worktrees/session/worktree-visit-recency.ts
+++ b/src/renderer/src/store/slices/worktrees/session/worktree-visit-recency.ts
@@ -1,7 +1,7 @@
 import type { WorktreeSlice } from '../../worktree-helpers'
 import type { WorktreeSliceGet, WorktreeSliceSet } from '../listing/worktree-slice-types'
 import { getRepoIdFromWorktreeId } from '../../worktree-helpers'
-import { parseWorkspaceKey } from '../../../../../../shared/workspace-scope'
+import { worktreeWorkspaceKey } from '../../../../../../shared/workspace-scope'
 
 export function createMarkWorktreeVisited(
   set: WorktreeSliceSet,
@@ -86,9 +86,9 @@ export function createPruneLastVisitedTimestamps(
         if (activeRepoWorktreeIds && !activeRepoWorktreeIds.has(activeId)) {
           patch.activeWorktreeId = null
           // Leaving the derived workspace key behind would keep the phantom workspace selected.
-          // Scope-checked like the removal paths so a folder-scoped key is never dropped.
-          const activeScope = s.activeWorkspaceKey ? parseWorkspaceKey(s.activeWorkspaceKey) : null
-          if (activeScope?.type !== 'folder') {
+          // Only the stale worktree's own key is dropped (same equality check as the rename path),
+          // so a folder key or a key pointing at another live worktree survives.
+          if (s.activeWorkspaceKey === worktreeWorkspaceKey(activeId)) {
             patch.activeWorkspaceKey = null
           }
           patch.activeWorkspaceExecutionHostId = null

--- a/src/renderer/src/store/slices/worktrees/teardown/force-delete-preserved-branch.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/force-delete-preserved-branch.ts
@@ -43,6 +43,12 @@ export function createForceDeletePreservedBranch(
       if ((options?.hostId || options?.runtimeEnvironmentId) && !retainedTarget) {
         throw new Error(`No preserved branch cleanup is pending for "${branchName}".`)
       }
+      // Ambiguous route: deleting against the active runtime could hit the wrong host's branch.
+      if (!retainedTarget && matchingRetainedTargets.length > 1) {
+        throw new Error(
+          `Multiple preserved branch cleanups are pending for "${branchName}"; specify the host.`
+        )
+      }
       const cleanupHostId = options?.hostId ?? retainedTarget?.cleanup.hostId
       // Why: the removed row no longer records its nested HUB owner, so retain the deletion-time route.
       const target =

--- a/src/renderer/src/store/slices/worktrees/teardown/force-delete-preserved-branch.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/force-delete-preserved-branch.ts
@@ -44,9 +44,15 @@ export function createForceDeletePreservedBranch(
         throw new Error(`No preserved branch cleanup is pending for "${branchName}".`)
       }
       // Ambiguous route: deleting against the active runtime could hit the wrong host's branch.
+      // Localized because it surfaces in the toast below; the throw above mirrors a main-process
+      // message verbatim (orca-runtime.ts, ipc/worktrees.ts) and must stay in sync with it.
       if (!retainedTarget && matchingRetainedTargets.length > 1) {
         throw new Error(
-          `Multiple preserved branch cleanups are pending for "${branchName}"; specify the host.`
+          translate(
+            'auto.store.slices.worktrees.preservedBranchCleanupHostAmbiguous',
+            'Multiple preserved branch cleanups are pending for "{{value0}}"; specify the host.',
+            { value0: branchName }
+          )
         )
       }
       const cleanupHostId = options?.hostId ?? retainedTarget?.cleanup.hostId

--- a/src/renderer/src/store/slices/worktrees/teardown/orphaned-runtime-ssh-project-purge.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/orphaned-runtime-ssh-project-purge.ts
@@ -9,10 +9,11 @@ export async function purgeOrphanedRuntimeSshProjects(
   if (destroyedSshTargetIds.length === 0) {
     return
   }
-  // Drop blanks so a repo with no connectionId never matches below.
-  const destroyedTargetIds = new Set(destroyedSshTargetIds.filter((id) => id !== ''))
+  // Drop blanks once, before both lookups, so a repo with no connectionId never matches below.
+  const purgeableSshTargetIds = destroyedSshTargetIds.filter((id) => id !== '')
+  const destroyedTargetIds = new Set(purgeableSshTargetIds)
   const destroyedHostIds = new Set<ExecutionHostId>(
-    destroyedSshTargetIds.map((id) => toSshExecutionHostId(id))
+    purgeableSshTargetIds.map((id) => toSshExecutionHostId(id))
   )
   const orphanedSetupIds = get()
     .projectHostSetups.filter((setup) => destroyedHostIds.has(setup.hostId))

--- a/src/renderer/src/store/slices/worktrees/teardown/orphaned-runtime-ssh-project-purge.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/orphaned-runtime-ssh-project-purge.ts
@@ -9,7 +9,8 @@ export async function purgeOrphanedRuntimeSshProjects(
   if (destroyedSshTargetIds.length === 0) {
     return
   }
-  const destroyedTargetIds = new Set(destroyedSshTargetIds)
+  // Drop blanks so a repo with no connectionId never matches below.
+  const destroyedTargetIds = new Set(destroyedSshTargetIds.filter((id) => id !== ''))
   const destroyedHostIds = new Set<ExecutionHostId>(
     destroyedSshTargetIds.map((id) => toSshExecutionHostId(id))
   )

--- a/src/renderer/src/store/slices/worktrees/teardown/worktree-delete-state.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/worktree-delete-state.ts
@@ -13,7 +13,13 @@ export function createMarkWorktreesDeleting(
       let changed = false
       for (const worktreeId of new Set(worktreeIds)) {
         const current = nextDeleteState[worktreeId]
-        if (current?.isDeleting && current.error === null && !current.canForceDelete) {
+        // Phase-aware: a queued row must still be promoted to deleting.
+        if (
+          current?.isDeleting &&
+          current.phase === 'deleting' &&
+          current.error === null &&
+          !current.canForceDelete
+        ) {
           continue
         }
         nextDeleteState[worktreeId] = {

--- a/src/renderer/src/store/slices/worktrees/teardown/worktree-purge-omitters.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/worktree-purge-omitters.ts
@@ -1,6 +1,7 @@
 import type { AppState } from '../../../types'
 import type { WorkspaceLineage } from '../../../../../../shared/worktree/lineage-types'
 import { isWorkspaceKey, worktreeWorkspaceKey } from '../../../../../../shared/workspace-scope'
+import { normalizeRightSidebarRoute } from '../../../right-sidebar-route'
 import type { WorktreePurgeDoomedIds } from './worktree-purge-doomed-ids'
 
 export function createWorktreePurgeOmitters(
@@ -40,14 +41,8 @@ export function createWorktreePurgeOmitters(
     let changed = omitted !== s.rightSidebarTabByWorktree
     const out: AppState['rightSidebarTabByWorktree'] = {}
     for (const [id, tab] of Object.entries(omitted)) {
-      if (
-        tab === 'explorer' ||
-        tab === 'vault' ||
-        tab === 'workspaces' ||
-        tab === 'source-control' ||
-        tab === 'checks' ||
-        tab === 'ports'
-      ) {
+      // Reuse the route validator so newer tabs (pr-checks, plugin panels) aren't silently dropped.
+      if (normalizeRightSidebarRoute(tab).rightSidebarTab === tab) {
         out[id] = tab
       } else {
         changed = true


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | +435 | −1 | +434 |
| Prod | 16 | +142 | −39 | +103 |

<!-- /orca-pr-loc -->

## ELI5

The worktrees store slice was recently split into many small files (#14643). The review on that PR flagged 15 things. Twelve of them were real bugs — but they were all bugs that already existed in the old `worktrees.ts` and just moved into the new files unchanged. This PR fixes those twelve. Nothing here is refactor fallout.

## What Changed

| Area | Fix |
| --- | --- |
| `listing/fetch-all-worktrees.ts` | The hydration path only `console.error`d runtime-scope-forbidden failures; it now routes them through `notifyRuntimeScopeForbiddenIfNeeded` like the fast path already did, so a mobile-scope pairing gets the explanatory toast instead of silence. |
| `metadata/update-worktree-meta.ts`, `metadata/hosted-review-push-target-ensure.ts` | Push-target resolution called `settingsForWorktreeOwner`, which **throws** on an ambiguous owner — from outside the `try`, so it escaped `updateWorktreeMeta`'s `{ ok, error }` contract entirely and rejected the promise. Both sites now use `trySettingsForWorktreeOwner` and skip the lookup. The subsequent `persistWorktreeMeta` still surfaces the ambiguity as a normal `{ ok: false, error }` (and its catch reverts the optimistic write), so nothing fails silently. |
| `metadata/update-worktree-meta.ts` | `worktreeForUpdate?.linkedPR !== null` is `true` when the worktree is unknown (`undefined !== null`), triggering a spurious hosted-review refresh. Now `(… ?? null) !== null`, matching the four sibling providers directly below it. |
| `metadata/worktree-meta-persist.ts` | Two runtime-capability messages were raw English; wrapped in `translate(...)` following the `repos.ts` precedent. |
| `session/worktree-identity-rename-state.ts` | Doc comment claimed active/renaming pointers "stay put"; the function re-points all three. Comment corrected. |
| `session/worktree-pin-reveal.ts` | `updateWorktreesMeta(updates)` fired even for an empty map (folder-only toggles route through `updateWorktreeMeta` instead). Now guarded. |
| `session/worktree-visit-recency.ts` | An empty `worktreesByRepo` list was treated as an authoritative "no worktrees" and pruned focus-recency for a repo that simply hadn't hydrated yet — contradicting the "populated/authoritative" rule in the comment right above it. Also clears `activeWorkspaceKey` alongside a stale `activeWorktreeId`, so the phantom-workspace GC doesn't leave the derived key selected. |
| `teardown/force-delete-preserved-branch.ts` | With no `hostId`/`runtimeEnvironmentId` and more than one matching retained cleanup, `retainedTarget` was `undefined` and the delete silently fell back to the *active* runtime — potentially the wrong host's branch. Now fails closed with a "specify the host" error. |
| `teardown/orphaned-runtime-ssh-project-purge.ts` | Target ids were matched against `repo.connectionId ?? ''`, so a blank id in the destroyed set would match every repo with no `connectionId`. Blanks are filtered out. |
| `teardown/worktree-delete-state.ts` | `markWorktreesDeleting`'s skip guard ignored `phase`, so rows already marked `queued` were never promoted to `deleting` and displayed "queued" for the whole deletion. Guard is now phase-aware. (The identical guard in `markWorktreesQueuedForDeletion` is correct as-is — it prevents demoting `deleting` → `queued`.) |
| `teardown/worktree-purge-omitters.ts` | The right-sidebar tab whitelist was a hard-coded string union that predates `pr-checks` and `plugin:*`, so purging any worktree silently reset those tabs. Replaced with the existing `normalizeRightSidebarRoute` validator, which is the single source of truth for that union. |

Three further review comments were deliberately **not** acted on, since each is a design decision rather than a defect:

- **Workspace-lineage host merge** — the reviewer wants unknown-host child rows retained on a focused host refresh. The in-code comment ("A focused host refresh can no longer prove unknown-host child rows are current") documents the drop as intentional and tests assert it.
- **Provider-agnostic push targets** — would need base-resolution RPCs that don't exist for Bitbucket / Azure DevOps / Gitea; only `resolvePrBase` and `resolveMrBase` are implemented.
- **Provider-neutral hosted-review refresh on activation** — cross-slice change touching `github.ts` / `hosted-review.ts` and their rate guards.

## Why

Splitting a 6k-line slice into 61 files put a lot of previously-buried logic under a reviewer's eye at once, and the review surfaced a set of small, independently-correct fixes. Landing them separately from the split keeps the refactor's "pure move" property intact and makes each behavior change reviewable on its own.

Every construct here was verified to exist verbatim in the pre-split `worktrees.ts`, so none of these are regressions introduced by #14643.

## Linked Issue

No standalone issue — these are the review follow-ups from #14643 (merged as 8b31910ac1).

## Visual Proof

No before/after captures recorded. Three of the fixes do have user-visible effects, called out for the reviewer:

1. Right-sidebar `pr-checks` / plugin-panel tabs now survive a worktree purge instead of resetting to Explorer.
2. A queued deletion now advances from "queued" to "deleting" in the sidebar instead of sitting at "queued".
3. An ambiguous preserved-branch force-delete now shows an error toast instead of silently deleting via the active runtime.

## Testing

Automated:

- `src/renderer/src/store/` — 180 files / 2647 tests passed
- `src/renderer/src/components/sidebar/` — 236 files / 2167 tests passed
- `src/renderer/src/store/slices/worktrees.test.ts` — 285 passed
- `tsc --noEmit -p config/tsconfig.tc.web.json` — clean
- `oxlint src/renderer/src/store/slices/worktrees/` — clean
- `pnpm run sync:localization-catalog` (added the 2 new `en.json` keys) and `verify:localization-extraction` — clean

Not run locally: full `pnpm lint`, `pnpm test`, `pnpm build` — leaving those to CI. Not manually exercised in the app.

Coverage gap worth noting: no existing test asserts the ambiguous-multi-target force-delete path or `pr-checks`/plugin-tab retention. Those pass because nothing asserted the *old* behavior, not because the new behavior is pinned. Happy to add cases if a reviewer wants them locked in.

Cross-platform / SSH: no platform-conditional code touched. The SSH-relevant paths (runtime-scope toast on the hydration fetch, orphaned SSH project purge, per-host preserved-branch routing) were the ones specifically reasoned about; folder workspaces are handled in the pin/reveal and workspace-key changes.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

No new tests: eleven of the twelve fixes are covered by the existing suites above, and the two gaps are called out explicitly rather than papered over.

## Review

- **Security** — no auth, network, or filesystem surface changed.
- **Cross-platform** — no platform branches touched.
- **Remote SSH** — improved: scope-forbidden feedback now reaches the hydration path, and blank SSH target ids can no longer match unrelated repos.
- **Mobile** — the runtime-scope-forbidden toast is the mobile-scope pairing message; this makes it fire in one more path.
- **Backwards compatibility** — no wire, RPC, or persisted-shape changes. `activeWorkspaceKey` clearing is scope-checked so a folder-scoped key is never dropped.
- **Performance** — neutral; one added `Set` filter and one fewer no-op store write.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
