### PR TITLE
fix(skills): cancel and bound abandoned skill discovery scans

### DIFF
--- a/src/main/skills/discovery.test.ts
+++ b/src/main/skills/discovery.test.ts
@@ -1,10 +1,32 @@
 import { mkdtemp, mkdir, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { buildSkillDiscoverySources, clearSkillRootScanCache, discoverSkills } from './discovery'
 import { TUI_AGENT_CONFIG } from '../../shared/tui-agent-config'
+import type * as SkillRootFileWalk from './skill-root-file-walk'
 import type { Repo } from '../../shared/repo-types'
+
+/** Root path whose walk should reject as if its scan had been abandoned. */
+let unavailableRootPath: string | null = null
+
+vi.mock('./skill-root-file-walk', async (importOriginal) => {
+  const actual = await importOriginal<typeof SkillRootFileWalk>()
+  return {
+    ...actual,
+    findSkillFiles: (rootPath: string, maxDepth: number, signal?: AbortSignal) => {
+      if (unavailableRootPath !== null && rootPath === unavailableRootPath) {
+        // Shape matches what an aborted walk throws.
+        return Promise.reject(
+          Object.assign(new Error('This operation was aborted'), {
+            name: 'AbortError'
+          })
+        )
+      }
+      return actual.findSkillFiles(rootPath, maxDepth, signal)
+    }
+  }
+})
 
 function makeRepo(path: string, connectionId: string | null = null): Repo {
   return {
@@ -24,7 +46,54 @@ beforeEach(() => {
   vi.spyOn(console, 'info').mockImplementation(() => undefined)
 })
 
+afterEach(() => {
+  unavailableRootPath = null
+})
+
 describe('skill discovery', () => {
+  // Why this matters: callers already waiting on a scan that is later abandoned for
+  // age see it reject. Re-throwing turned one slow root into a failed discovery that
+  // emptied the picker for every healthy root beside it.
+  it('keeps every healthy root when one root walk is aborted', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skills-'))
+    const home = join(root, 'home')
+    const healthySkill = join(home, '.codex', 'skills', 'review')
+    const stalledSkill = join(home, '.omp', 'agent', 'skills', 'planning')
+    await mkdir(healthySkill, { recursive: true })
+    await mkdir(stalledSkill, { recursive: true })
+    await writeFile(join(healthySkill, 'SKILL.md'), '# Review\n\nReview code.')
+    await writeFile(join(stalledSkill, 'SKILL.md'), '# Planning\n\nPlan work.')
+    unavailableRootPath = join(home, '.omp', 'agent', 'skills')
+
+    const result = await discoverSkills({ homeDir: home, cwd: join(root, 'missing-cwd') })
+
+    expect(result.skills.map((skill) => skill.name)).toEqual(['Review'])
+    const stalledSource = result.sources.find((source) => source.path === unavailableRootPath)
+    expect(stalledSource).toMatchObject({ skippedReason: 'unavailable' })
+  })
+
+  // `unavailable` must stay distinct from `missing`: a root that did not answer is
+  // unknown, not empty, and a consumer must not read it as "these skills are gone".
+  it('does not report an aborted root as missing', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skills-'))
+    const home = join(root, 'home')
+    const absentRoot = join(home, '.codex', 'skills')
+    const stalledRoot = join(home, '.omp', 'agent', 'skills')
+    await mkdir(stalledRoot, { recursive: true })
+    unavailableRootPath = stalledRoot
+
+    const result = await discoverSkills({ homeDir: home, cwd: join(root, 'missing-cwd') })
+
+    expect(result.sources.find((source) => source.path === absentRoot)).toMatchObject({
+      exists: false,
+      skippedReason: 'missing'
+    })
+    expect(result.sources.find((source) => source.path === stalledRoot)).toMatchObject({
+      exists: true,
+      skippedReason: 'unavailable'
+    })
+  })
+
   it('discovers home and repo SKILL.md packages with provider metadata', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-skills-'))
     const home = join(root, 'home')

--- a/src/main/skills/discovery.ts
+++ b/src/main/skills/discovery.ts
@@ -19,7 +19,11 @@ import {
 import { discoverClaudePluginSkillSources } from './claude-plugin-skill-sources'
 import { findSkillFiles } from './skill-root-file-walk'
 import { runSkillCandidateTasks } from './skill-candidate-concurrency'
-import { SkillScanCoalescer, type SkillScanOutcome } from './skill-scan-coalescer'
+import {
+  SkillScanCoalescer,
+  SkillScanShedError,
+  type SkillScanOutcome
+} from './skill-scan-coalescer'
 
 export { buildSkillDiscoverySources } from './skill-discovery-sources'
 
@@ -44,7 +48,7 @@ const MAX_CACHED_SKILL_ROOTS = 1_024
 // are not — a repo/plugin id is already a hash.
 export const MAX_LOGGED_ROOT_IDS = 12
 
-type RootScan = { exists: boolean; skills: ScannedSkill[] }
+type RootScan = { exists: boolean; skills: ScannedSkill[]; unavailable?: boolean }
 
 const rootScans = new SkillScanCoalescer<RootScan>(MAX_CACHED_SKILL_ROOTS)
 
@@ -89,14 +93,17 @@ async function readSkillSummary(skillFilePath: string): Promise<{
 
 type ScannedSkill = DiscoveredSkill & { canonicalSkillFilePath: string }
 
-async function scanRoot(root: SkillScanRoot): Promise<ScannedSkill[]> {
+async function scanRoot(root: SkillScanRoot, signal: AbortSignal): Promise<ScannedSkill[]> {
   const maxDepth = root.sourceKind === 'plugin' ? 9 : 4
-  const skillFiles = await findSkillFiles(root.path, maxDepth)
+  const skillFiles = await findSkillFiles(root.path, maxDepth, signal)
   // Why: a root can hold many packages and each one costs a summary read plus a
   // package walk. Unbounded fan-out here is what turned one scan into a burst of
   // filesystem-metadata work across every core.
   const skills = await runSkillCandidateTasks(
     skillFiles.map((skillFilePath) => async (): Promise<ScannedSkill | null> => {
+      // Why: these tasks drain long after the walk, so an abandoned scan would
+      // keep spending a realpath + stat + read per remaining candidate.
+      signal.throwIfAborted()
       // Why: path identity belongs to the scanning host; canonicalizing before
       // returning prevents symlinked roots from becoming duplicate picker rows.
       const canonicalSkillFilePath = await realpath(skillFilePath).catch(() => skillFilePath)
@@ -134,14 +141,28 @@ function rootScanKey(root: SkillScanRoot): string {
   return `${root.sourceKind}\0${root.path}`
 }
 
-function scanRootShared(
+async function scanRootShared(
   root: SkillScanRoot,
   refresh: boolean
 ): Promise<SkillScanOutcome<RootScan>> {
-  return rootScans.run(rootScanKey(root), { ttlMs: SKILL_ROOT_SCAN_TTL_MS, refresh }, async () => {
-    const exists = await pathExists(root.path)
-    return { exists, skills: exists ? await scanRoot(root) : [] }
-  })
+  try {
+    return await rootScans.run(
+      rootScanKey(root),
+      { ttlMs: SKILL_ROOT_SCAN_TTL_MS, refresh },
+      async (signal) => {
+        const exists = await pathExists(root.path)
+        return { exists, skills: exists ? await scanRoot(root, signal) : [] }
+      }
+    )
+  } catch (error) {
+    if (!(error instanceof SkillScanShedError)) {
+      throw error
+    }
+    // Why degrade instead of rejecting: one unreachable root must not fail the
+    // whole discovery and empty the picker for every healthy root beside it.
+    // `unavailable` keeps that distinct from a root that genuinely is not there.
+    return { value: { exists: true, skills: [], unavailable: true }, cached: false }
+  }
 }
 
 function mergeScannedSkill(seen: Map<string, DiscoveredSkill>, skill: ScannedSkill): void {
@@ -200,7 +221,11 @@ export async function discoverSkills(args: {
     ...root,
     providers: [...root.providers],
     exists: scans[index].value.exists,
-    skippedReason: scans[index].value.exists ? undefined : 'missing'
+    skippedReason: scans[index].value.unavailable
+      ? 'unavailable'
+      : scans[index].value.exists
+        ? undefined
+        : 'missing'
   }))
   const seen = new Map<string, DiscoveredSkill>()
   for (const { value } of scans) {

--- a/src/main/skills/discovery.ts
+++ b/src/main/skills/discovery.ts
@@ -20,8 +20,8 @@ import { discoverClaudePluginSkillSources } from './claude-plugin-skill-sources'
 import { findSkillFiles } from './skill-root-file-walk'
 import { runSkillCandidateTasks } from './skill-candidate-concurrency'
 import {
+  isSkillRootUnavailableError,
   SkillScanCoalescer,
-  SkillScanShedError,
   type SkillScanOutcome
 } from './skill-scan-coalescer'
 
@@ -155,12 +155,16 @@ async function scanRootShared(
       }
     )
   } catch (error) {
-    if (!(error instanceof SkillScanShedError)) {
+    if (!isSkillRootUnavailableError(error)) {
       throw error
     }
     // Why degrade instead of rejecting: one unreachable root must not fail the
     // whole discovery and empty the picker for every healthy root beside it.
     // `unavailable` keeps that distinct from a root that genuinely is not there.
+    //
+    // The abort case matters as much as the shed one: callers already waiting on
+    // a scan that is later abandoned for age see it reject, and re-throwing here
+    // would turn one slow root into a failed discovery for every root.
     return { value: { exists: true, skills: [], unavailable: true }, cached: false }
   }
 }

--- a/src/main/skills/skill-discovery-target.test.ts
+++ b/src/main/skills/skill-discovery-target.test.ts
@@ -26,7 +26,7 @@ vi.mock('./skill-discovery-wsl', () => ({
 
 const { clearSkillDiscoveryCaches, discoverSkillsOnTarget } =
   await import('./skill-discovery-target')
-const { clearSkillRootScanCache } = await import('./discovery')
+const { clearSkillRootScanCache, discoverSkills } = await import('./discovery')
 
 function makeRepo(path: string): Repo {
   return {
@@ -154,5 +154,19 @@ describe('discoverSkillsOnTarget', () => {
   it('drops the root cache too when the host clears its scans', () => {
     clearSkillDiscoveryCaches()
     expect(clearSkillRootScanCache).toHaveBeenCalled()
+  })
+
+  // This layer scans whole targets, so it has no partial answer to degrade to. It
+  // must not leak the internal error class to IPC/RPC, and must not answer with an
+  // empty result — zero skills reads as "nothing installed" and re-offers installs.
+  it('reports a stalled target as a retryable error rather than as no skills', async () => {
+    vi.mocked(discoverSkills).mockRejectedValueOnce(
+      Object.assign(new Error('This operation was aborted'), { name: 'AbortError' })
+    )
+
+    const call = discoverSkillsOnTarget({ kind: 'native-host', cwd: '/workspace' }, [])
+
+    await expect(call).rejects.toThrow(/try again/i)
+    await expect(call).rejects.not.toThrow(/workspace/)
   })
 })

--- a/src/main/skills/skill-discovery-target.ts
+++ b/src/main/skills/skill-discovery-target.ts
@@ -5,7 +5,7 @@ import { clearSkillRootScanCache, discoverSkills } from './discovery'
 import { discoverSkillsInWsl } from './skill-discovery-wsl'
 import { stablePathId } from './skill-discovery-sources'
 import { getRepoExecutionHostId } from '../../shared/execution-host'
-import { SkillScanCoalescer } from './skill-scan-coalescer'
+import { isSkillRootUnavailableError, SkillScanCoalescer } from './skill-scan-coalescer'
 
 // Why: on WSL the unit of cost is the wsl.exe boot plus one `find` per skill, so
 // the whole result is what must be shared. The native path shares at root level
@@ -99,21 +99,32 @@ export async function discoverSkillsOnTarget(
   options: { refresh?: boolean } = {}
 ): Promise<SkillDiscoveryResult> {
   const refresh = options.refresh === true
-  const outcome = await targetScans.run(
-    scanKey(target, repos),
-    { ttlMs: target.kind === 'wsl' ? WSL_RESULT_TTL_MS : 0, refresh },
-    async () => {
-      if (target.kind === 'wsl') {
-        return discoverSkillsInWsl({
-          distro: target.distro,
-          homeDir: target.homeDir,
-          cwd: target.cwd
-        })
+  try {
+    const outcome = await targetScans.run(
+      scanKey(target, repos),
+      { ttlMs: target.kind === 'wsl' ? WSL_RESULT_TTL_MS : 0, refresh },
+      async () => {
+        if (target.kind === 'wsl') {
+          return discoverSkillsInWsl({
+            distro: target.distro,
+            homeDir: target.homeDir,
+            cwd: target.cwd
+          })
+        }
+        return target.cwd
+          ? discoverSkills({ repos: [], cwd: target.cwd, refresh })
+          : discoverSkills({ repos: [...repos], refresh })
       }
-      return target.cwd
-        ? discoverSkills({ repos: [], cwd: target.cwd, refresh })
-        : discoverSkills({ repos: [...repos], refresh })
+    )
+    return outcome.value
+  } catch (error) {
+    if (!isSkillRootUnavailableError(error)) {
+      throw error
     }
-  )
-  return outcome.value
+    // Why not an empty result: this layer scans whole targets, so it has no
+    // partial answer to degrade to, and returning zero skills would read as
+    // "nothing is installed" and re-offer installs for skills that are present.
+    // An error keeps the picker's retry affordance and says something true.
+    throw new Error('Skill discovery is still reading a slow location. Try again.')
+  }
 }

--- a/src/main/skills/skill-discovery-target.ts
+++ b/src/main/skills/skill-discovery-target.ts
@@ -125,6 +125,8 @@ export async function discoverSkillsOnTarget(
     // partial answer to degrade to, and returning zero skills would read as
     // "nothing is installed" and re-offer installs for skills that are present.
     // An error keeps the picker's retry affordance and says something true.
-    throw new Error('Skill discovery is still reading a slow location. Try again.')
+    throw new Error('Skill discovery is still reading a slow location. Try again.', {
+      cause: error
+    })
   }
 }

--- a/src/main/skills/skill-root-file-walk.test.ts
+++ b/src/main/skills/skill-root-file-walk.test.ts
@@ -1,8 +1,28 @@
-import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
+import type * as FsPromises from 'node:fs/promises'
+import { mkdir, mkdtemp, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { findSkillFiles } from './skill-root-file-walk'
+
+/** Set by a test to run at a chosen point inside the walk; cleared after each. */
+let onStat: ((path: string) => Promise<void>) | null = null
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof FsPromises>()
+  return {
+    ...actual,
+    stat: async (path: string, ...rest: unknown[]) => {
+      const result = await (actual.stat as (...args: unknown[]) => Promise<unknown>)(path, ...rest)
+      await onStat?.(path)
+      return result
+    }
+  }
+})
+
+afterEach(() => {
+  onStat = null
+})
 
 async function makeTree(): Promise<string> {
   return mkdtemp(join(tmpdir(), 'orca-skill-walk-'))
@@ -34,6 +54,27 @@ describe('findSkillFiles', () => {
     await writeFileAt(join(root, 'two', 'SKILL.md'))
 
     await expect(findSkillFiles(root, 4, AbortSignal.abort())).rejects.toThrow()
+  })
+
+  // The broken-link catch around the symlink branch must not swallow the abort a
+  // nested visit throws, or the walk returns a truncated listing as success. The
+  // abort has to land inside the symlink's stat — after the entry loop's check and
+  // before the nested visit's — and the link must be the last entry, so nothing
+  // afterwards re-checks the signal.
+  it('propagates an abort thrown while following a symlinked directory', async () => {
+    const base = await makeTree()
+    const root = join(base, 'skills')
+    await writeFileAt(join(base, 'linked', 'deep', 'SKILL.md'))
+    await mkdir(root, { recursive: true })
+    await symlink(join(base, 'linked'), join(root, 'via-link'), 'dir')
+    const controller = new AbortController()
+    onStat = async (path) => {
+      if (path.endsWith('via-link')) {
+        controller.abort()
+      }
+    }
+
+    await expect(findSkillFiles(root, 4, controller.signal)).rejects.toThrow()
   })
 
   // Why not a truncated list: a caller that cached one would publish "these skills

--- a/src/main/skills/skill-root-file-walk.test.ts
+++ b/src/main/skills/skill-root-file-walk.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { findSkillFiles } from './skill-root-file-walk'
+import { isSkillRootUnavailableError } from './skill-scan-coalescer'
 
 /** Set by a test to run at a chosen point inside the walk; cleared after each. */
 let onStat: ((path: string) => Promise<void>) | null = null
@@ -48,12 +49,20 @@ describe('findSkillFiles', () => {
     expect(await findSkillFiles(join(await makeTree(), 'absent'), 4)).toEqual([])
   })
 
-  it('stops walking once its signal aborts', async () => {
+  // The name is load-bearing, not incidental: `isSkillRootUnavailableError` matches
+  // on it to decide whether a root degrades to `unavailable` or fails the discovery.
+  // Callers elsewhere fabricate this shape, so this is the one place that pins a
+  // real abort actually producing it.
+  it('stops walking once its signal aborts, rejecting with an AbortError', async () => {
     const root = join(await makeTree(), 'skills')
     await writeFileAt(join(root, 'one', 'SKILL.md'))
     await writeFileAt(join(root, 'two', 'SKILL.md'))
 
-    await expect(findSkillFiles(root, 4, AbortSignal.abort())).rejects.toThrow()
+    const walk = findSkillFiles(root, 4, AbortSignal.abort())
+
+    await expect(walk).rejects.toMatchObject({ name: 'AbortError' })
+    await expect(walk).rejects.toBeInstanceOf(Error)
+    expect(isSkillRootUnavailableError(await walk.catch((error: unknown) => error))).toBe(true)
   })
 
   // The broken-link catch around the symlink branch must not swallow the abort a

--- a/src/main/skills/skill-root-file-walk.test.ts
+++ b/src/main/skills/skill-root-file-walk.test.ts
@@ -27,4 +27,25 @@ describe('findSkillFiles', () => {
   it('returns nothing for a missing root rather than throwing', async () => {
     expect(await findSkillFiles(join(await makeTree(), 'absent'), 4)).toEqual([])
   })
+
+  it('stops walking once its signal aborts', async () => {
+    const root = join(await makeTree(), 'skills')
+    await writeFileAt(join(root, 'one', 'SKILL.md'))
+    await writeFileAt(join(root, 'two', 'SKILL.md'))
+
+    await expect(findSkillFiles(root, 4, AbortSignal.abort())).rejects.toThrow()
+  })
+
+  // Why not a truncated list: a caller that cached one would publish "these skills
+  // no longer exist" for a root that was merely slow.
+  it('rejects rather than returning the entries it had already collected', async () => {
+    const root = join(await makeTree(), 'skills')
+    await writeFileAt(join(root, 'one', 'SKILL.md'))
+    await writeFileAt(join(root, 'two', 'SKILL.md'))
+    const controller = new AbortController()
+    const walk = findSkillFiles(root, 4, controller.signal)
+    controller.abort()
+
+    await expect(walk).rejects.toThrow()
+  })
 })

--- a/src/main/skills/skill-root-file-walk.test.ts
+++ b/src/main/skills/skill-root-file-walk.test.ts
@@ -66,7 +66,11 @@ describe('findSkillFiles', () => {
     const root = join(base, 'skills')
     await writeFileAt(join(base, 'linked', 'deep', 'SKILL.md'))
     await mkdir(root, { recursive: true })
-    await symlink(join(base, 'linked'), join(root, 'via-link'), 'dir')
+    await symlink(
+      join(base, 'linked'),
+      join(root, 'via-link'),
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
     const controller = new AbortController()
     onStat = async (path) => {
       if (path.endsWith('via-link')) {

--- a/src/main/skills/skill-root-file-walk.ts
+++ b/src/main/skills/skill-root-file-walk.ts
@@ -86,12 +86,16 @@ export async function findSkillFiles(
       if (entry.isSymbolicLink()) {
         // Why: users commonly symlink agent skill dirs across providers; follow
         // directory links but guard by realpath so recursive links cannot loop.
+        let linksToDirectory = false
         try {
-          if ((await stat(entryPath)).isDirectory()) {
-            await visit(entryPath)
-          }
+          linksToDirectory = (await stat(entryPath)).isDirectory()
         } catch {
           // Broken links are not valid skill directories.
+        }
+        // Why outside the catch: it must not swallow the abort a nested visit
+        // throws, which would let the walk return a truncated list as success.
+        if (linksToDirectory) {
+          await visit(entryPath)
         }
       }
     }

--- a/src/main/skills/skill-root-file-walk.ts
+++ b/src/main/skills/skill-root-file-walk.ts
@@ -24,10 +24,24 @@ async function readEntries(dirPath: string): Promise<Dirent[] | null> {
   }
 }
 
-export async function findSkillFiles(rootPath: string, maxDepth: number): Promise<string[]> {
+/**
+ * `signal` bounds the walk's future work, not its current syscall: `readdir`,
+ * `realpath`, and `stat` take no signal, so a call already dispatched to the
+ * libuv pool runs to completion. Aborting stops the walk issuing *more* of them,
+ * which is what keeps an abandoned scan on a stalled mount from growing.
+ */
+export async function findSkillFiles(
+  rootPath: string,
+  maxDepth: number,
+  signal?: AbortSignal
+): Promise<string[]> {
   const out: string[] = []
   const visitedDirectoryPaths = new Set<string>()
   async function visit(dirPath: string): Promise<void> {
+    // Why throw rather than return what we have: a truncated listing is
+    // indistinguishable from a genuinely small root, and a caller that cached it
+    // would publish "these skills no longer exist".
+    signal?.throwIfAborted()
     if (!isWithinDepth(rootPath, dirPath, maxDepth)) {
       return
     }
@@ -47,6 +61,7 @@ export async function findSkillFiles(rootPath: string, maxDepth: number): Promis
       return
     }
     for (const entry of entries) {
+      signal?.throwIfAborted()
       const entryPath = join(dirPath, entry.name)
       if (entry.name === SKILL_FILE_NAME) {
         if (entry.isFile()) {

--- a/src/main/skills/skill-scan-coalescer.test.ts
+++ b/src/main/skills/skill-scan-coalescer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { SkillScanCoalescer } from './skill-scan-coalescer'
+import { SkillScanCoalescer, SkillScanShedError } from './skill-scan-coalescer'
 
 function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
   let resolve!: (value: T) => void
@@ -195,13 +195,21 @@ describe('SkillScanCoalescer', () => {
     const coalescer = new SkillScanCoalescer<number>(8, () => now)
     const wedged = deferred<number>()
     let runs = 0
-    const task = (): Promise<number> => {
+    // Mirrors `findSkillFiles`, which throws once its signal aborts.
+    const task = (signal: AbortSignal): Promise<number> => {
       runs += 1
       // The first scan models a root on a stalled mount: its readdir never settles.
-      return runs === 1 ? wedged.promise : Promise.resolve(runs)
+      return runs === 1
+        ? Promise.race([
+            wedged.promise,
+            new Promise<number>((_resolve, reject) => {
+              signal.addEventListener('abort', () => reject(signal.reason))
+            })
+          ])
+        : Promise.resolve(runs)
     }
 
-    void coalescer.run('root', { ttlMs: 10_000 }, task)
+    void coalescer.run('root', { ttlMs: 10_000 }, task).catch(() => undefined)
     now = 1_100
     // Still young enough to share.
     const joined = coalescer.run('root', { ttlMs: 10_000 }, task)
@@ -213,10 +221,77 @@ describe('SkillScanCoalescer', () => {
     })
     expect(runs).toBe(2)
 
-    // The wedged callers still receive its eventual value rather than being orphaned...
+    // Callers of the abandoned scan are released by its abort rather than left
+    // waiting on a mount that may never answer.
+    await expect(joined).rejects.toThrow()
+    // It must not overwrite the replacement's newer result with a fresh ttl.
     wedged.resolve(99)
-    expect((await joined).value).toBe(99)
-    // ...but it must not overwrite the replacement's newer result with a fresh ttl.
     expect(await coalescer.run('root', { ttlMs: 10_000 }, task)).toEqual({ value: 2, cached: true })
+  })
+
+  it('aborts the scan it abandons so its walk stops doing filesystem work', async () => {
+    let now = 1_000
+    const coalescer = new SkillScanCoalescer<number>(8, () => now)
+    const signals: AbortSignal[] = []
+    const task = (signal: AbortSignal): Promise<number> => {
+      signals.push(signal)
+      return signals.length === 1 ? new Promise<number>(() => {}) : Promise.resolve(2)
+    }
+
+    void coalescer.run('root', { ttlMs: 10_000 }, task).catch(() => undefined)
+    expect(signals[0].aborted).toBe(false)
+    now = 40_000
+    await coalescer.run('root', { ttlMs: 10_000 }, task)
+
+    expect(signals[0].aborted).toBe(true)
+    // The replacement owns the key now, so it must not be aborted alongside it.
+    expect(signals[1].aborted).toBe(false)
+  })
+
+  // Why not abort here: on a healthy root the superseded scan is about to finish and
+  // its callers still want an answer; the publish fence already stops the stale write.
+  it('does not abort the scan a refresh supersedes', async () => {
+    const coalescer = new SkillScanCoalescer<string>(8)
+    const slowScan = deferred<string>()
+    const signals: AbortSignal[] = []
+
+    const inFlight = coalescer.run('root', { ttlMs: 10_000 }, (signal) => {
+      signals.push(signal)
+      return slowScan.promise
+    })
+    await coalescer.run('root', { ttlMs: 10_000, refresh: true }, async () => 'after-install')
+
+    expect(signals[0].aborted).toBe(false)
+    slowScan.resolve('before-install')
+    expect((await inFlight).value).toBe('before-install')
+  })
+
+  // The walk is wedged inside a syscall here, so aborting it never settles it —
+  // the case the budget exists for. A walk that does return on abort frees its
+  // slot again, which is why the budget is not a permanent ceiling.
+  it('sheds a replacement once too many abandoned scans are still live', async () => {
+    let now = 1_000
+    const coalescer = new SkillScanCoalescer<number>(64, () => now)
+    const task = (): Promise<number> => new Promise<number>(() => {})
+    const keys = Array.from({ length: 17 }, (_unused, index) => `root-${index}`)
+
+    // Every root on one dead mount wedges, then each is abandoned for age when a
+    // later caller arrives and tries to replace it.
+    for (const key of keys) {
+      void coalescer.run(key, { ttlMs: 10_000 }, task).catch(() => undefined)
+    }
+    now = 40_000
+    const shed: string[] = []
+    for (const key of keys) {
+      void coalescer.run(key, { ttlMs: 10_000 }, task).catch((error: unknown) => {
+        if (error instanceof SkillScanShedError) {
+          shed.push(key)
+        }
+      })
+    }
+    await new Promise((resolve) => setImmediate(resolve))
+
+    // 16 replacements are admitted; past that no further walk is started.
+    expect(shed).toEqual(['root-16'])
   })
 })

--- a/src/main/skills/skill-scan-coalescer.ts
+++ b/src/main/skills/skill-scan-coalescer.ts
@@ -9,7 +9,7 @@ export type SkillScanRunOptions = {
 }
 
 type CacheEntry<T> = { value: T; expiresAt: number }
-type PendingEntry<T> = { promise: Promise<T>; startedAt: number }
+type PendingEntry<T> = { promise: Promise<T>; startedAt: number; abort: AbortController }
 
 // Why: a root on a stalled network mount can leave a readdir that never settles.
 // Joining it forever would make one wedged mount permanently wedge discovery for
@@ -17,6 +17,22 @@ type PendingEntry<T> = { promise: Promise<T>; startedAt: number }
 // least retried. Past this age a new caller starts its own scan instead; the old
 // promise is dropped, so at most one pending entry per key survives.
 const MAX_JOINABLE_SCAN_AGE_MS = 30_000
+
+// Why bound *abandoned* scans and not live ones: one discovery legitimately starts
+// a walk per root (a dozen-plus at once), so a cap on live scans would shed healthy
+// roots and make skills vanish from the picker. A scan only becomes abandoned by
+// outliving MAX_JOINABLE_SCAN_AGE_MS without settling, which healthy roots never do,
+// so this budget is spent only by genuinely stalled mounts. Sized above the ~12 fixed
+// home roots so a single dead home dir can still be replaced once before shedding.
+const MAX_ABANDONED_SCANS = 16
+
+/** Thrown instead of starting yet another walk while too many are stalled. */
+export class SkillScanShedError extends Error {
+  constructor(key: string) {
+    super(`Skill scan for ${key} was shed: too many stalled scans`)
+    this.name = 'SkillScanShedError'
+  }
+}
 
 /**
  * Shares one filesystem scan between concurrent callers and, optionally, reuses
@@ -28,6 +44,8 @@ const MAX_JOINABLE_SCAN_AGE_MS = 30_000
 export class SkillScanCoalescer<T> {
   private readonly pending = new Map<string, PendingEntry<T>>()
   private readonly cache = new Map<string, CacheEntry<T>>()
+  /** Scans abandoned for age that have not settled; the budget for replacements. */
+  private abandonedScans = 0
 
   constructor(
     private readonly maximumEntries: number,
@@ -37,12 +55,15 @@ export class SkillScanCoalescer<T> {
   async run(
     key: string,
     options: SkillScanRunOptions,
-    task: () => Promise<T>
+    task: (signal: AbortSignal) => Promise<T>
   ): Promise<SkillScanOutcome<T>> {
     if (options.refresh) {
       // Why: a forced caller is answering a mutation it just made, so it must not
       // join a scan that may have started before that mutation. Concurrent forced
       // callers therefore duplicate; they are rare (install / explicit recheck).
+      // The superseded scan is not aborted — on a healthy root it is about to
+      // finish, and its callers still want an answer; the publish fence in
+      // `start` already stops it writing a pre-mutation result.
       this.cache.delete(key)
       return { value: await this.start(key, options.ttlMs, task), cached: false }
     }
@@ -54,6 +75,23 @@ export class SkillScanCoalescer<T> {
     if (inFlight && this.now() - inFlight.startedAt < MAX_JOINABLE_SCAN_AGE_MS) {
       return { value: await inFlight.promise, cached: true }
     }
+    if (inFlight) {
+      if (this.abandonedScans >= MAX_ABANDONED_SCANS) {
+        // Why leave the stalled entry in `pending`: it is still the only scan that
+        // can answer this key, so keeping it lets the root recover on its own the
+        // moment the mount responds, with no extra walk from us.
+        throw new SkillScanShedError(key)
+      }
+      // Why: the replacement is what future callers read, so the walk this one
+      // gives up on must stop issuing filesystem work rather than race it.
+      this.abandonedScans += 1
+      inFlight.abort.abort()
+      void inFlight.promise
+        .catch(() => undefined)
+        .finally(() => {
+          this.abandonedScans -= 1
+        })
+    }
     return { value: await this.start(key, options.ttlMs, task), cached: false }
   }
 
@@ -63,8 +101,9 @@ export class SkillScanCoalescer<T> {
     this.pending.clear()
   }
 
-  private start(key: string, ttlMs: number, task: () => Promise<T>): Promise<T> {
-    const promise = task()
+  private start(key: string, ttlMs: number, task: (signal: AbortSignal) => Promise<T>): Promise<T> {
+    const abort = new AbortController()
+    const promise = task(abort.signal)
       .then((value) => {
         // Why: owning the pending slot is what makes a scan publishable, and it is
         // per key by construction. Deleting the cache entry is not enough to
@@ -88,7 +127,7 @@ export class SkillScanCoalescer<T> {
     // Why: rejections must not surface as an unhandled rejection on the shared
     // promise before the caller that started it awaits.
     promise.catch(() => undefined)
-    this.pending.set(key, { promise, startedAt: this.now() })
+    this.pending.set(key, { promise, startedAt: this.now(), abort })
     return promise
   }
 

--- a/src/main/skills/skill-scan-coalescer.ts
+++ b/src/main/skills/skill-scan-coalescer.ts
@@ -22,16 +22,37 @@ const MAX_JOINABLE_SCAN_AGE_MS = 30_000
 // a walk per root (a dozen-plus at once), so a cap on live scans would shed healthy
 // roots and make skills vanish from the picker. A scan only becomes abandoned by
 // outliving MAX_JOINABLE_SCAN_AGE_MS without settling, which healthy roots never do,
-// so this budget is spent only by genuinely stalled mounts. Sized above the ~12 fixed
-// home roots so a single dead home dir can still be replaced once before shedding.
+// so this budget is spent only by genuinely stalled mounts.
+//
+// The budget is global and per-abandonment, not per-key: a single wedged root can
+// spend all of it on its own, one replacement per 30s window. That is the intended
+// shape — the number bounds how many stalled walks may be alive at once, whatever
+// mix of roots produced them. It is not a count of distinct roots.
 const MAX_ABANDONED_SCANS = 16
 
-/** Thrown instead of starting yet another walk while too many are stalled. */
+/**
+ * Thrown instead of starting yet another walk while too many are stalled.
+ *
+ * The key is deliberately not in the message: it carries an absolute workspace
+ * path, and this reaches a paired client and the renderer's error string.
+ */
 export class SkillScanShedError extends Error {
-  constructor(key: string) {
-    super(`Skill scan for ${key} was shed: too many stalled scans`)
+  constructor() {
+    super('Skill scan was shed: too many stalled scans')
     this.name = 'SkillScanShedError'
   }
+}
+
+/**
+ * True for the two ways a scan now ends without an answer: shed before it began,
+ * or aborted because it was abandoned for age. Callers that can degrade a single
+ * root should treat both the same — re-throwing either one fails a whole scan.
+ */
+export function isSkillRootUnavailableError(error: unknown): boolean {
+  return (
+    error instanceof SkillScanShedError ||
+    (error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError'))
+  )
 }
 
 /**
@@ -80,7 +101,7 @@ export class SkillScanCoalescer<T> {
         // Why leave the stalled entry in `pending`: it is still the only scan that
         // can answer this key, so keeping it lets the root recover on its own the
         // moment the mount responds, with no extra walk from us.
-        throw new SkillScanShedError(key)
+        throw new SkillScanShedError()
       }
       // Why: the replacement is what future callers read, so the walk this one
       // gives up on must stop issuing filesystem work rather than race it.

--- a/src/main/skills/skill-scan-coalescer.ts
+++ b/src/main/skills/skill-scan-coalescer.ts
@@ -44,9 +44,14 @@ export class SkillScanShedError extends Error {
 }
 
 /**
- * True for the two ways a scan now ends without an answer: shed before it began,
- * or aborted because it was abandoned for age. Callers that can degrade a single
- * root should treat both the same — re-throwing either one fails a whole scan.
+ * True for the ways a scan ends without an answer: shed before it began, or
+ * aborted because it was abandoned for age. Callers that can degrade a single
+ * root should treat them the same — re-throwing either one fails a whole scan.
+ *
+ * Matching on the name is safe rather than broad: the walk and the candidate
+ * tasks catch every filesystem error locally, so the only `AbortError` that can
+ * escape a scan is the one its own signal raised. `TimeoutError` is the name
+ * `AbortSignal.timeout()` aborts with, so a pre-flight deadline lands here too.
  */
 export function isSkillRootUnavailableError(error: unknown): boolean {
   return (

--- a/src/shared/skills.ts
+++ b/src/shared/skills.ts
@@ -32,7 +32,8 @@ export type SkillDiscoverySource = {
   /** Agent that owns this root; null is the explicit shared-skills scope. */
   owner: AgentType | null
   exists: boolean
-  skippedReason?: 'missing' | 'remote-repo'
+  /** `unavailable`: the root did not answer in time, so its skills are unknown rather than absent. */
+  skippedReason?: 'missing' | 'remote-repo' | 'unavailable'
 }
 
 export type SkillDiscoveryResult = {


### PR DESCRIPTION
Fixes STA-4359.

## Problem

A skill root on a stalled network mount never settles its `readdir`, so after 30s `SkillScanCoalescer` starts a replacement walk. The abandoned walk kept running with no cancellation, and nothing counted it — so live filesystem work accumulated for the life of the process. `discovery.ts` fans out a walk per root with an unbounded `Promise.all`, and `runSkillCandidateTasks` only bounds summary reads *within* one root, so nothing bounded concurrently active walks.

Result fencing by generation was already in place (`pending.get(key)?.promise === promise`); cancellation and an active-scan bound were not.

## Change

- **Abort on age-based abandonment.** Superseding a scan for age aborts it. `findSkillFiles` and the candidate tasks bail on the signal.
- **Budget the abandoned scans.** Past `MAX_ABANDONED_SCANS` a replacement is shed instead of started, and the stalled `pending` entry is left in place so the root recovers on its own the moment the mount answers.
- **Degrade, don't fail.** A root that is shed *or* aborted reports the new `unavailable` skipped reason, so one unreachable root cannot fail the whole discovery and empty the picker for every healthy root beside it.

## Notes on the design

**The budget counts abandoned scans, not live ones.** One discovery legitimately walks a dozen-plus roots at once, so a cap on live scans would shed healthy roots and make skills vanish. A scan only becomes abandoned by outliving 30s without settling, which healthy roots never do. The budget is global and per-abandonment rather than per-root: a single wedged root can spend all of it alone, one replacement per 30s window. That is the intended shape — it bounds how many stalled walks may be alive at once, whatever mix of roots produced them.

**`refresh` does not abort what it supersedes.** On a healthy root that scan is about to finish and its callers still want an answer, and the publish fence already stops it writing a pre-mutation result. Aborting there would turn a would-have-succeeded discovery into an error in the common case. The consequence is that the forced path still duplicates walks without abort or budget; it fires on skill-install events, and tightening it is left as follow-up.

**Aborting bounds future work, not the current syscall.** `readdir`/`realpath`/`stat` take no signal, so a call already dispatched to the libuv pool runs to completion. This stops an abandoned walk issuing *more* of them, which is the accumulation this fixes.

**The ticket asked for a killable worker; this does not add one.** A `worker_thread` shares the process-wide libuv pool and `terminate()` does not reclaim a dispatched fs request, so it would not release the resource that actually matters. Only a child process would, and that is a much larger change (entry file, packaging, protocol, cross-platform spawn) — filed separately rather than ridden along here.

## Review findings addressed

Independent review found two P1s in the first revision, both now fixed with regression tests that were each verified to fail against the pre-fix code:

1. **An aborted root failed the entire discovery.** The abort gave the coalescer a way to reject that it did not have before — every error inside the walk and the candidate tasks was caught locally, so the task effectively could not fail. `scanRootShared` re-threw anything that was not a shed, so a caller waiting on a slow-but-recoverable root lost every other root's skills. Both endings are now handled by one predicate.
2. **The internal error class escaped to IPC/RPC.** `discoverSkillsOnTarget` runs a second coalescer over the whole target and had no handler. It now converts both endings into a retryable error. It deliberately does *not* return an empty result — zero skills reads as "nothing installed" and re-offers installs for skills that are present.

Also fixed from review: a swallowed `AbortError` in the walk's symlink branch (the broken-link `catch` wrapped the nested `visit`, so an abort could return a truncated listing as success); the scan key removed from the shed message, which carried an absolute workspace path to a paired client and the renderer's error string; a factually wrong sizing rationale on the budget comment; and the Windows `junction` guard on the new symlink test.

## Tests

- Abandoned scan is aborted; the replacement that now owns the key is not.
- A `refresh` does not abort the scan it supersedes.
- Replacements are shed once too many abandoned scans are still live.
- `findSkillFiles` rejects on abort rather than returning a truncated listing, including through a symlinked directory.
- One aborted root leaves every healthy root's skills intact and is reported `unavailable`, distinct from `missing`.
- A stalled target surfaces as a retryable error carrying no host path.

218 tests in `src/main/skills/` pass; typecheck and type-aware lint clean.

## Known limitations (not fixed here)

`unavailable` is not a timeout — it only arrives once the budget is exhausted, so against a permanently wedged root the earliest callers still wait rather than degrading immediately. A short pre-flight timeout on the root `stat` would give a fast honest answer and is the natural follow-up, together with bringing the forced-refresh path under the same abort and budget.
