### PR TITLE
fix(workspaces): gate the Jira palette match on the issue's tenant

### DIFF
--- a/src/renderer/src/lib/worktree-palette-task-url-match.test.ts
+++ b/src/renderer/src/lib/worktree-palette-task-url-match.test.ts
@@ -622,6 +622,90 @@ describe('matchWorktreePaletteTaskUrl', () => {
       })
     ).toBeNull()
   })
+
+  it('matches a Jira issue URL on its own tenant', () => {
+    const intent = parseCmdJTaskSourceUrl('https://acme.atlassian.net/browse/PROJ-123')
+
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree({
+          linkedWorkItem: {
+            provider: 'jira',
+            type: 'issue',
+            number: 0,
+            title: 'Tenant scoped',
+            jiraIdentifier: 'PROJ-123',
+            url: 'https://acme.atlassian.net/browse/PROJ-123'
+          }
+        }),
+        intent: intent!
+      })
+    ).toMatchObject({ supportingText: { text: 'PROJ-123' } })
+  })
+
+  // Why: Jira issue keys are per-project, so the same PROJ-123 exists on every
+  // tenant that has a PROJ project.
+  it('rejects a Jira issue URL from a different tenant with the same issue key', () => {
+    const intent = parseCmdJTaskSourceUrl('https://acme.atlassian.net/browse/PROJ-123')
+
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree({
+          linkedWorkItem: {
+            provider: 'jira',
+            type: 'issue',
+            number: 0,
+            title: 'Other tenant',
+            jiraIdentifier: 'PROJ-123',
+            url: 'https://other.atlassian.net/browse/PROJ-123'
+          }
+        }),
+        intent: intent!
+      })
+    ).toBeNull()
+  })
+
+  // Same host, different site path: Jira Server installs are commonly path-scoped.
+  it('rejects a Jira issue URL from a different site path on the same host', () => {
+    const intent = parseCmdJTaskSourceUrl('https://jira.acme.test/one/browse/PROJ-123')
+
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree({
+          linkedWorkItem: {
+            provider: 'jira',
+            type: 'issue',
+            number: 0,
+            title: 'Other site',
+            jiraIdentifier: 'PROJ-123',
+            url: 'https://jira.acme.test/two/browse/PROJ-123'
+          }
+        }),
+        intent: intent!
+      })
+    ).toBeNull()
+  })
+
+  // The identifier is the only evidence when no URL was stored, so it still matches.
+  it('falls back to the Jira identifier when the linked item has no url', () => {
+    const intent = parseCmdJTaskSourceUrl('https://acme.atlassian.net/browse/PROJ-123')
+
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree({
+          linkedWorkItem: {
+            provider: 'jira',
+            type: 'issue',
+            number: 0,
+            title: 'No url',
+            jiraIdentifier: 'PROJ-123',
+            url: ''
+          }
+        }),
+        intent: intent!
+      })
+    ).toMatchObject({ supportingText: { text: 'PROJ-123' } })
+  })
 })
 
 describe('getCmdJTaskUrlCreatePreview', () => {

--- a/src/renderer/src/lib/worktree-palette-task-url-match.test.ts
+++ b/src/renderer/src/lib/worktree-palette-task-url-match.test.ts
@@ -686,8 +686,10 @@ describe('matchWorktreePaletteTaskUrl', () => {
     ).toBeNull()
   })
 
-  // The identifier is the only evidence when no URL was stored, so it still matches.
-  it('falls back to the Jira identifier when the linked item has no url', () => {
+  // The reachable fallback: `normalizeWorkspaceLinkedItem` drops any item with a
+  // blank url, so the only way to have no tenant evidence is a url that is present
+  // but is not a Jira browse link. The identifier is then all there is.
+  it('falls back to the Jira identifier when the stored url is not a Jira link', () => {
     const intent = parseCmdJTaskSourceUrl('https://acme.atlassian.net/browse/PROJ-123')
 
     expect(
@@ -697,9 +699,32 @@ describe('matchWorktreePaletteTaskUrl', () => {
             provider: 'jira',
             type: 'issue',
             number: 0,
-            title: 'No url',
+            title: 'Linked elsewhere',
             jiraIdentifier: 'PROJ-123',
-            url: ''
+            url: 'https://github.com/stablyai/orca/issues/14198'
+          }
+        }),
+        intent: intent!
+      })
+    ).toMatchObject({ supportingText: { text: 'PROJ-123' } })
+  })
+
+  // Jira appends a tracking query on copy, and the matcher is pathname-only.
+  it('matches a pasted Jira url carrying a tracking query string', () => {
+    const intent = parseCmdJTaskSourceUrl(
+      'https://acme.atlassian.net/browse/PROJ-123?atlOrigin=eyJpIjoiZm9vIn0'
+    )
+
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree({
+          linkedWorkItem: {
+            provider: 'jira',
+            type: 'issue',
+            number: 0,
+            title: 'Tenant scoped',
+            jiraIdentifier: 'PROJ-123',
+            url: 'https://acme.atlassian.net/browse/PROJ-123'
           }
         }),
         intent: intent!

--- a/src/renderer/src/lib/worktree-palette-task-url-match.ts
+++ b/src/renderer/src/lib/worktree-palette-task-url-match.ts
@@ -275,18 +275,21 @@ function worktreeMatchesLinearUrl(worktree: Worktree, intent: LinearIssueUrlInte
 }
 
 function worktreeMatchesJiraUrl(worktree: Worktree, parsed: ParsedJiraIssueUrl): boolean {
-  if (worktree.linkedWorkItem?.jiraIdentifier?.toUpperCase() === parsed.issueKey) {
-    return true
-  }
   const linkedUrl = worktree.linkedWorkItem?.url
     ? parseJiraIssueUrl(worktree.linkedWorkItem.url)
     : null
-  return (
-    linkedUrl !== null &&
-    linkedUrl.issueKey === parsed.issueKey &&
-    linkedUrl.origin === parsed.origin &&
-    linkedUrl.sitePath === parsed.sitePath
-  )
+  // Why url first: issue keys are per-project, not per-tenant, so two Jira sites
+  // routinely both have a PROJ-123. The stored URL is the only tenant evidence
+  // here, so where it exists it decides — matching on the bare identifier would
+  // jump to another tenant's worktree.
+  if (linkedUrl) {
+    return (
+      linkedUrl.issueKey === parsed.issueKey &&
+      linkedUrl.origin === parsed.origin &&
+      linkedUrl.sitePath === parsed.sitePath
+    )
+  }
+  return worktree.linkedWorkItem?.jiraIdentifier?.toUpperCase() === parsed.issueKey
 }
 
 export function matchWorktreePaletteTaskUrl(args: {


### PR DESCRIPTION
Addresses the Jira half of STA-4362.

## Problem

Pasting a Jira issue URL into the worktree palette matched any worktree whose linked item carried the same `jiraIdentifier`, with no comparison of the site it came from:

```ts
if (worktree.linkedWorkItem?.jiraIdentifier?.toUpperCase() === parsed.issueKey) {
  return true
}
```

Jira issue keys are per-project, not per-tenant, so every tenant with a `PROJ` project has a `PROJ-123`. Pasting `https://acme.atlassian.net/browse/PROJ-123` could jump to a worktree tracking `https://other.atlassian.net/browse/PROJ-123`. The URL fallback three lines below already compared `origin` and `sitePath` — the identifier short-circuit ran first and skipped it.

## Change

The stored linked URL is the only tenant evidence available at match time, so where it exists it now decides. The bare identifier still matches when no URL was stored, since it is then the only evidence there is.

This mirrors the check `isWorkspaceLinkedItemSourceContextMatch` already makes on the same fields.

## Tests

4 added; the two cross-tenant ones were verified to fail without the fix.

- Matches on its own tenant.
- Rejects a different tenant with the same issue key.
- Rejects a different site path on the same host (path-scoped Jira Server installs).
- Still falls back to the identifier when the linked item has no URL.

## Not included: the GitLab half

The ticket also asked to "decline GitLab exact match when project identity is unresolved" and "do not convert an upstream mismatch into a number-only accept". Both would regress deliberate, tested behavior:

- Declining on unresolved identity contradicts #10527 ("keep repos with a pending remote-identity probe in the picker") and breaks the test at `worktree-palette-task-url-match.test.ts:509`.
- Rejecting on an upstream mismatch breaks the fork test at `:526` and its character-for-character identical GitHub twin at `:291`, which the ticket does not flag.

The underlying hole is real — with `origin=gitlab.com/me/orca` and `upstream=gitlab.com/acme/orca`, pasting a stranger's `gitlab.com/bob/orca/-/merge_requests/42` is accepted — but it is not fixable in the matcher. `deriveGitRemoteIdentity` ranks `upstream` above `origin` and keeps only one remote, so the key that would refute the match was already discarded. Closing it needs new identity data (the sibling remote keys) plumbed through the shared type, the persistence sanitizer whitelist, and the enrichment write gate. Filed as a follow-up rather than widened into this PR.