### PR TITLE
fix(repos): forget remote-identity deadlines for removed repo locations

### DIFF
--- a/src/main/repo-git-remote-identity-enrichment.test.ts
+++ b/src/main/repo-git-remote-identity-enrichment.test.ts
@@ -329,6 +329,60 @@ describe('enrichMissingRepoGitRemoteIdentities', () => {
     expect(probeGitRemoteIdentity).not.toHaveBeenCalled()
   })
 
+  it('forgets a removed repo location so its deadline cannot outlive the repo', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    vi.mocked(probeGitRemoteIdentity).mockResolvedValue(resolvedProbe)
+    const repo = makeRepo({ gitRemoteIdentity: remoteIdentity })
+    const live: Repo[] = [repo]
+    const store: RepoIdentityStore = {
+      getRepos: () => live,
+      getRepo: (id) => live.find((candidate) => candidate.id === id),
+      updateRepo: () => null
+    }
+
+    // Seeds the startup-delay deadline for this location.
+    await sweep(store)
+    live.length = 0
+    await sweep(store)
+    live.push(repo)
+    // Past the seeded deadline: a retained entry would make this location due at once.
+    vi.setSystemTime(1_000 + REFRESH_STARTUP_DELAY_MS + 1)
+    await sweep(store)
+
+    expect(probeGitRemoteIdentity).not.toHaveBeenCalled()
+  })
+
+  it('keeps a surviving repo backoff when a sibling repo is removed', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    vi.mocked(probeGitRemoteIdentity).mockResolvedValue(resolvedProbe)
+    const kept = makeRepo({ gitRemoteIdentity: remoteIdentity })
+    const removed = makeRepo({
+      id: 'repo-2',
+      path: '/workspace/other-app',
+      gitRemoteIdentity: remoteIdentity
+    })
+    const live: Repo[] = [kept, removed]
+    const store: RepoIdentityStore = {
+      getRepos: () => live,
+      getRepo: (id) => live.find((candidate) => candidate.id === id),
+      updateRepo: () => null
+    }
+
+    await sweep(store)
+    vi.setSystemTime(1_000 + REFRESH_STARTUP_DELAY_MS + 1)
+    await sweep(store)
+    expect(probeGitRemoteIdentity).toHaveBeenCalledTimes(2)
+
+    live.splice(1, 1)
+    await sweep(store)
+
+    // The kept repo is still inside its 6h refresh window, so pruning its sibling
+    // must not make it due again.
+    expect(probeGitRemoteIdentity).toHaveBeenCalledTimes(2)
+  })
+
   it('does not write stale identity data after the repo path changes', async () => {
     const probe = deferred<GitRemoteIdentityProbe>()
     vi.mocked(probeGitRemoteIdentity).mockReturnValue(probe.promise)

--- a/src/main/repo-git-remote-identity-enrichment.ts
+++ b/src/main/repo-git-remote-identity-enrichment.ts
@@ -126,9 +126,10 @@ function isIdentityRefreshDue(repo: Repo, now: number): boolean {
 function pruneRetryDeadlines(liveRepos: Repo[]): void {
   const liveKeys = new Set(liveRepos.map(getRepoLocationKey))
   for (const locationKey of probeRetryAfterByLocation.keys()) {
-    // Why: an in-flight probe re-adds its own key on settle, so skipping those
-    // keeps a probe that outlived one sweep from losing its backoff.
-    if (!liveKeys.has(locationKey) && !inFlightProbesByLocation.has(locationKey)) {
+    // A probe still running for a dropped repo needs no exemption: it re-adds its
+    // own deadline on settle, and only live repos are ever candidates, so nothing
+    // reads this entry in between.
+    if (!liveKeys.has(locationKey)) {
       probeRetryAfterByLocation.delete(locationKey)
     }
   }
@@ -138,8 +139,8 @@ function selectEnrichmentCandidates(store: RepoIdentityStore): Repo[] {
   const now = Date.now()
   const repos = store.getRepos().filter((repo) => repo.kind !== 'folder')
   // Why here: this is the one place that already enumerates every live repo, and
-  // `getRepos()` reads a fully-hydrated in-memory array, so a repo is never
-  // transiently absent mid-sweep and cannot lose its startup delay or backoff.
+  // `getRepos()` builds its list synchronously from in-memory state, so a repo is
+  // never transiently absent mid-sweep and cannot lose its startup delay or backoff.
   pruneRetryDeadlines(repos)
   // Why: the settled `null` marker stays a candidate on purpose — a repo that
   // gains a remote later must still resolve. Do not tighten this to

--- a/src/main/repo-git-remote-identity-enrichment.ts
+++ b/src/main/repo-git-remote-identity-enrichment.ts
@@ -119,9 +119,28 @@ function isIdentityRefreshDue(repo: Repo, now: number): boolean {
   return dueAt <= now
 }
 
+/**
+ * Drop deadlines for locations no longer backed by a repo, so removed repos and
+ * retired SSH hosts do not accumulate for the life of the process.
+ */
+function pruneRetryDeadlines(liveRepos: Repo[]): void {
+  const liveKeys = new Set(liveRepos.map(getRepoLocationKey))
+  for (const locationKey of probeRetryAfterByLocation.keys()) {
+    // Why: an in-flight probe re-adds its own key on settle, so skipping those
+    // keeps a probe that outlived one sweep from losing its backoff.
+    if (!liveKeys.has(locationKey) && !inFlightProbesByLocation.has(locationKey)) {
+      probeRetryAfterByLocation.delete(locationKey)
+    }
+  }
+}
+
 function selectEnrichmentCandidates(store: RepoIdentityStore): Repo[] {
   const now = Date.now()
   const repos = store.getRepos().filter((repo) => repo.kind !== 'folder')
+  // Why here: this is the one place that already enumerates every live repo, and
+  // `getRepos()` reads a fully-hydrated in-memory array, so a repo is never
+  // transiently absent mid-sweep and cannot lose its startup delay or backoff.
+  pruneRetryDeadlines(repos)
   // Why: the settled `null` marker stays a candidate on purpose — a repo that
   // gains a remote later must still resolve. Do not tighten this to
   // `=== undefined`; the retry TTL already bounds the cost and `writeIdentity`


### PR DESCRIPTION
Fixes STA-4350.

## Problem

`probeRetryAfterByLocation` is keyed by `connectionId\0path` and written on both resolved and unresolved probes, but never pruned — only the test reset cleared it. A removed repo, a retired SSH host, or a repo whose `path`/`connectionId` changed kept its deadline for the life of the process.

`isIdentityRefreshDue` also *seeds* an entry for every resolved repo the first time it is seen, so the map grew with repository and host churn even with no probe activity at all.

The sharper statement of the defect: the map is not merely unpruned, it is **process-global**, while the repo list it describes belongs to a `Store` instance. Nothing tied its lifetime to the thing it was caching decisions about.

## Change

The candidate sweep already enumerates every live repo, so it now reconciles the deadline map against those location keys — no new plumbing, O(n) on a list that was already being walked, and no exported signature changes.

Two things that make this safe:

- **No re-probe storm.** `getRepos()` is a synchronous map over an already-in-memory array, and `this.state` is assigned exactly once, in the `Store` constructor — there is no in-place reload that could transiently shrink the list. A repo therefore cannot be absent from `getRepos()` mid-sweep and lose its 5-minute startup delay or its 6h backoff to a prune-then-reseed. (Both of those deadlines are *suppressors* in any case: dropping one costs another quiet interval, it never forces a probe.)
- **A probe still running for a dropped repo needs no exemption.** It re-adds its own deadline when it settles, and only live repos are ever candidates, so nothing reads that entry in between. An earlier revision of this PR carried such an exemption; review showed it was a no-op whose comment named the very reason it was unnecessary, and that it would let a probe which never settles pin its deadline forever. It has been removed.

The prune must stay per-sweep rather than being hoisted to a one-shot at startup — that is what collects the orphan left behind when a repo is removed while its probe is still running.

## Why reconcile rather than a bounded cache

The repo has a tested LRU (`BoundedMap`, `src/shared/bounded-map.ts`) and it is the wrong tool here. `get()` mutates recency, and capacity eviction can drop a *live* repo's deadline — which for an unresolved repo means an immediate extra `git remote -v`, reintroducing exactly the spurious-probe cost the TTL constants at the top of this file exist to prevent. A fixed cap also has nothing principled to be set to: the legitimate working set is "however many repos the user has", which is precisely what reconciling against live keys expresses and what any `maxEntries` would have to guess.

## Severity

Honest assessment: this is hygiene, not a memory problem. Entries cost roughly 100-150 bytes (Map slot plus key string plus load factor), and cardinality is bounded by the repo store — keys are minted only from `getRepos()`, and the only writer to that array is `Store.addRepo` via user-initiated add/clone/create flows. No discovery loop auto-registers repos, and worktrees are not `Repo` records, so worktree churn contributes zero keys. Steady state is the live repo count (5-30 KB); orphans over a desktop process lifetime are realistically under 15 KB.

So this is P3/P4 rather than P2, and it is worth shipping mainly because the fix is six lines and the rest of this file reasons carefully about lifetimes — this was the one loose end.

## Tests

- A removed repo's deadline is forgotten, so the location is not immediately due when the repo comes back.
- A surviving repo keeps its backoff when a sibling repo is removed (guards against over-pruning).

All 18 tests in the file pass.


## Known adjacent gap (pre-existing, not fixed here)

`probeGitRemoteIdentity` runs `git remote -v` with no timeout (`src/main/git/runner.ts:1082` only forwards a caller-supplied one). If that hangs on a wedged mount or SSH transport, its `inFlightProbesByLocation` entry never clears. That map self-clears on settle and is unaffected by this change, so it is out of scope — but a probe timeout would be a reasonable follow-up.
