### PR TITLE
fix: keep remote visibility hydration off local startup path

### DIFF
--- a/src/renderer/src/app-shell/use-app-startup-hydration.ts
+++ b/src/renderer/src/app-shell/use-app-startup-hydration.ts
@@ -58,6 +58,8 @@ function useStartupActions() {
       fetchWorktreeLineage: s.fetchWorktreeLineage,
       fetchOrcaProfiles: s.fetchOrcaProfiles,
       fetchSettings: s.fetchSettings,
+      awaitOwnerWorktreeVisibilityDefaultsHydration:
+        s.awaitOwnerWorktreeVisibilityDefaultsHydration,
       fetchKeybindings: s.fetchKeybindings,
       initGitHubCache: s.initGitHubCache,
       hydrateWorkspaceSession: s.hydrateWorkspaceSession,
@@ -109,8 +111,10 @@ export function useAppStartupHydration(onOnboardingLoaded: (state: OnboardingSta
       try {
         // Why: nothing in the hydration chain reads profile state synchronously, so don't let it add a serial IPC round-trip before fetchSettings.
         void actions.fetchOrcaProfiles()
-        // Why: repo/worktree hydration routes through settings.activeRuntimeEnvironmentId; load settings first so a persisted remote runtime doesn't hydrate stale local state.
-        await timeRendererStartupStep('fetch-settings', () => actions.fetchSettings())
+        // Why: publish local settings before persisted UI/catalog work; a saved remote owner's defaults can spend the full connect timeout.
+        await timeRendererStartupStep('fetch-settings', () =>
+          actions.fetchSettings({ deferOwnerWorktreeVisibilityDefaults: true })
+        )
         // Why: hidden-at-launch PTYs can query OSC 10/11 before any pane mounts; publish view attributes as soon as settings exist so main's silent-until-push responder has data.
         publishTerminalViewAttributesAtAppStart(
           useAppStore.getState().settings,
@@ -283,6 +287,10 @@ export function useAppStartupHydration(onOnboardingLoaded: (state: OnboardingSta
           void (async () => {
             try {
               try {
+                // Why: remote rows must not render under a fallback visibility while their owner default is still loading.
+                await timeRendererStartupStep('owner-visibility-defaults', () =>
+                  actions.awaitOwnerWorktreeVisibilityDefaultsHydration()
+                )
                 await timeRendererStartupStep('remote-catalog-refresh', async () => {
                   await actions.fetchReposForAllHosts()
                   await actions.fetchProjectGroupsForAllHosts()

--- a/src/renderer/src/app-startup-routing.test.ts
+++ b/src/renderer/src/app-startup-routing.test.ts
@@ -30,7 +30,9 @@ describe('renderer startup runtime routing', () => {
       const relativeIndex = startupBlock.indexOf(needle)
       return relativeIndex === -1 ? -1 : startupBlockStart + relativeIndex
     }
-    const settingsIndex = indexInStartupBlock('actions.fetchSettings()')
+    const settingsIndex = indexInStartupBlock(
+      'actions.fetchSettings({ deferOwnerWorktreeVisibilityDefaults: true })'
+    )
     const uiGetIndex = indexInStartupBlock("timeRendererStartupStep('ui-get'")
     const hydrateUiIndex = indexInStartupBlock("timeRendererStartupSyncStep('hydrate-persisted-ui'")
     const localReposIndex = indexInStartupBlock(
@@ -96,6 +98,14 @@ describe('renderer startup runtime routing', () => {
     expect(fullWorktreesIndex).toBeGreaterThan(
       source.indexOf("logRendererStartupDiagnostic('startup-hydration-done'")
     )
+    const ownerDefaultsIndex = source.indexOf(
+      'actions.awaitOwnerWorktreeVisibilityDefaultsHydration()'
+    )
+    const remoteCatalogIndex = source.indexOf("timeRendererStartupStep('remote-catalog-refresh'")
+    expect(ownerDefaultsIndex).toBeGreaterThan(
+      source.indexOf("logRendererStartupDiagnostic('startup-hydration-done'")
+    )
+    expect(ownerDefaultsIndex).toBeLessThan(remoteCatalogIndex)
     // Why: the deferred full scan must be followed by a re-prune so deleted-worktree visit
     // timestamps for non-session repos are dropped once every repo is authoritative.
     expect(

--- a/src/renderer/src/store/slices/settings-owner-hydration-publication.ts
+++ b/src/renderer/src/store/slices/settings-owner-hydration-publication.ts
@@ -8,9 +8,95 @@ export type SettingsStateSetter = Parameters<StateCreator<AppState, [], []>>[0]
 type SettingsStateGetter = Parameters<StateCreator<AppState, [], []>>[1]
 const completedOwnerVisibilityDefaultsHydration = Promise.resolve()
 const ownerVisibilityDefaultsHydrationByStore = new WeakMap<SettingsStateGetter, Promise<void>>()
+let settingsPublicationGeneration = 0
+let ownerSettingsHydrationGeneration = 0
+
+function mergeOwnerDefaultsIntoCurrentSettings(
+  current: GlobalSettings | null,
+  hydrated: GlobalSettings
+): GlobalSettings {
+  if (!current) {
+    return hydrated
+  }
+  const { worktreeVisibilityDefaults } = hydrated
+  const { worktreeVisibilityDefaults: _currentDefaults, ...currentWithoutDefaults } = current
+  return worktreeVisibilityDefaults
+    ? { ...current, worktreeVisibilityDefaults }
+    : (currentWithoutDefaults as GlobalSettings)
+}
 
 export type FetchSettingsOptions = {
   deferOwnerWorktreeVisibilityDefaults?: boolean
+}
+
+export function createSettingsPublicationFence(invalidateOwnerHydration = false): () => boolean {
+  const generation = ++settingsPublicationGeneration
+  if (invalidateOwnerHydration) {
+    ownerSettingsHydrationGeneration += 1
+  }
+  return () => generation === settingsPublicationGeneration
+}
+
+export function createOwnerSettingsHydrationFence(): () => boolean {
+  const generation = ++ownerSettingsHydrationGeneration
+  return () => generation === ownerSettingsHydrationGeneration
+}
+
+export function registerPendingOwnerWorktreeVisibilityDefaultsHydration(
+  get: SettingsStateGetter
+): (restorePrevious?: boolean) => void {
+  const previousHydration = ownerVisibilityDefaultsHydrationByStore.get(get)
+  let settle!: () => void
+  const hydration = new Promise<void>((resolve) => (settle = resolve))
+  ownerVisibilityDefaultsHydrationByStore.set(get, hydration)
+  return (restorePrevious = false) => {
+    // Why: a fenced local read never reached the point where it superseded the prior owner hydration.
+    if (
+      restorePrevious &&
+      previousHydration &&
+      ownerVisibilityDefaultsHydrationByStore.get(get) === hydration
+    ) {
+      ownerVisibilityDefaultsHydrationByStore.set(get, previousHydration)
+    }
+    settle()
+  }
+}
+
+export async function fetchSettingsWithOwnerHydration(args: {
+  options?: FetchSettingsOptions
+  set: SettingsStateSetter
+  get: SettingsStateGetter
+}): Promise<void> {
+  const shouldPublishSettings = createSettingsPublicationFence()
+  const settleOwnerHydration = registerPendingOwnerWorktreeVisibilityDefaultsHydration(args.get)
+  let ownerHydrationStarted = false
+  try {
+    const localSettings = (await window.api.settings.get()) as GlobalSettings
+    if (!shouldPublishSettings()) {
+      return
+    }
+    const ownerVisibilityDefaultsHydration = startOwnerWorktreeVisibilityDefaultsHydration({
+      settings: localSettings,
+      deferPublication: args.options?.deferOwnerWorktreeVisibilityDefaults === true,
+      shouldPublish: createOwnerSettingsHydrationFence(),
+      set: args.set,
+      get: args.get
+    })
+    ownerHydrationStarted = true
+    void ownerVisibilityDefaultsHydration.then(
+      () => settleOwnerHydration(),
+      () => settleOwnerHydration()
+    )
+    if (!args.options?.deferOwnerWorktreeVisibilityDefaults) {
+      await ownerVisibilityDefaultsHydration
+    }
+  } catch (err) {
+    console.error('Failed to fetch settings:', err)
+  } finally {
+    if (!ownerHydrationStarted) {
+      settleOwnerHydration(true)
+    }
+  }
 }
 
 export function startOwnerWorktreeVisibilityDefaultsHydration(args: {
@@ -31,6 +117,7 @@ export function startOwnerWorktreeVisibilityDefaultsHydration(args: {
         : state.worktreeVisibilityDefaultsByHost
     }))
   }
+  const settingsAtHydrationStart = args.get().settings
   const hydration = hydrateOwnerWorktreeVisibilityDefaults(
     args.settings,
     args.get().worktreeVisibilityDefaultsByHost
@@ -40,7 +127,10 @@ export function startOwnerWorktreeVisibilityDefaultsHydration(args: {
         return
       }
       args.set((state) => ({
-        settings: hydrated.settings,
+        settings:
+          state.settings === settingsAtHydrationStart
+            ? hydrated.settings
+            : mergeOwnerDefaultsIntoCurrentSettings(state.settings, hydrated.settings),
         worktreeVisibilityDefaultsByHost: {
           ...state.worktreeVisibilityDefaultsByHost,
           ...hydrated.defaultsByHost
@@ -52,14 +142,24 @@ export function startOwnerWorktreeVisibilityDefaultsHydration(args: {
       }))
     })
     .catch((err) => console.error('Failed to fetch settings:', err))
-  ownerVisibilityDefaultsHydrationByStore.set(args.get, hydration)
   return hydration
 }
 
 export function awaitOwnerWorktreeVisibilityDefaultsHydration(
   get: SettingsStateGetter
 ): Promise<void> {
-  return (
-    ownerVisibilityDefaultsHydrationByStore.get(get) ?? completedOwnerVisibilityDefaultsHydration
-  )
+  return (async () => {
+    let hydration =
+      ownerVisibilityDefaultsHydrationByStore.get(get) ?? completedOwnerVisibilityDefaultsHydration
+    while (true) {
+      await hydration
+      const latest =
+        ownerVisibilityDefaultsHydrationByStore.get(get) ??
+        completedOwnerVisibilityDefaultsHydration
+      if (latest === hydration) {
+        return
+      }
+      hydration = latest
+    }
+  })()
 }

--- a/src/renderer/src/store/slices/settings-owner-hydration-publication.ts
+++ b/src/renderer/src/store/slices/settings-owner-hydration-publication.ts
@@ -1,0 +1,65 @@
+import type { StateCreator } from 'zustand'
+import type { AppState } from '../types'
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import { LOCAL_EXECUTION_HOST_ID } from '../../../../shared/execution-host'
+import { hydrateOwnerWorktreeVisibilityDefaults } from './worktree-visibility-owner-settings'
+
+export type SettingsStateSetter = Parameters<StateCreator<AppState, [], []>>[0]
+type SettingsStateGetter = Parameters<StateCreator<AppState, [], []>>[1]
+const completedOwnerVisibilityDefaultsHydration = Promise.resolve()
+const ownerVisibilityDefaultsHydrationByStore = new WeakMap<SettingsStateGetter, Promise<void>>()
+
+export type FetchSettingsOptions = {
+  deferOwnerWorktreeVisibilityDefaults?: boolean
+}
+
+export function startOwnerWorktreeVisibilityDefaultsHydration(args: {
+  settings: GlobalSettings
+  deferPublication: boolean
+  shouldPublish: () => boolean
+  set: SettingsStateSetter
+  get: SettingsStateGetter
+}): Promise<void> {
+  if (args.deferPublication) {
+    args.set((state) => ({
+      settings: args.settings,
+      worktreeVisibilityDefaultsByHost: args.settings.worktreeVisibilityDefaults
+        ? {
+            ...state.worktreeVisibilityDefaultsByHost,
+            [LOCAL_EXECUTION_HOST_ID]: args.settings.worktreeVisibilityDefaults
+          }
+        : state.worktreeVisibilityDefaultsByHost
+    }))
+  }
+  const hydration = hydrateOwnerWorktreeVisibilityDefaults(
+    args.settings,
+    args.get().worktreeVisibilityDefaultsByHost
+  )
+    .then((hydrated) => {
+      if (!args.shouldPublish()) {
+        return
+      }
+      args.set((state) => ({
+        settings: hydrated.settings,
+        worktreeVisibilityDefaultsByHost: {
+          ...state.worktreeVisibilityDefaultsByHost,
+          ...hydrated.defaultsByHost
+        },
+        worktreeVisibilityDefaultsSupportedRuntimeEnvironmentId:
+          hydrated.supportedRuntimeEnvironmentId,
+        worktreeVisibilitySourceDefaultsSupportedRuntimeEnvironmentId:
+          hydrated.sourceDefaultsSupportedRuntimeEnvironmentId
+      }))
+    })
+    .catch((err) => console.error('Failed to fetch settings:', err))
+  ownerVisibilityDefaultsHydrationByStore.set(args.get, hydration)
+  return hydration
+}
+
+export function awaitOwnerWorktreeVisibilityDefaultsHydration(
+  get: SettingsStateGetter
+): Promise<void> {
+  return (
+    ownerVisibilityDefaultsHydrationByStore.get(get) ?? completedOwnerVisibilityDefaultsHydration
+  )
+}

--- a/src/renderer/src/store/slices/settings-owner-hydration-write-fence.test.ts
+++ b/src/renderer/src/store/slices/settings-owner-hydration-write-fence.test.ts
@@ -104,5 +104,111 @@ it('publishes startup settings before remote owner hydration and local catalog w
   await startup
   await store.getState().awaitOwnerWorktreeVisibilityDefaultsHydration()
   expect(store.getState().settings?.pluginSystemEnabled).toBe(true)
-  expect(store.getState().worktreeVisibilityDefaultsByHost['runtime:env-1']).toBeUndefined()
+  expect(store.getState().worktreeVisibilityDefaultsByHost['runtime:env-1']).toEqual({
+    external: 'hide'
+  })
+})
+
+it('waits for a replacement owner hydration before publishing remote rows', async () => {
+  markRuntimeEnvironmentCompatible('env-replacement')
+  let resolveFirstOwnerRead!: (value: unknown) => void
+  let resolveSecondOwnerRead!: (value: unknown) => void
+  let resolveReplacementSettingsRead!: (value: GlobalSettings) => void
+  const firstOwnerRead = new Promise((resolve) => (resolveFirstOwnerRead = resolve))
+  const secondOwnerRead = new Promise((resolve) => (resolveSecondOwnerRead = resolve))
+  const replacementSettingsRead = new Promise<GlobalSettings>(
+    (resolve) => (resolveReplacementSettingsRead = resolve)
+  )
+  let settingsCallCount = 0
+  const runtimeCall = vi.fn(({ method }: { method: string }) => {
+    if (method !== 'settings.get') {
+      return Promise.reject(new Error('status unavailable'))
+    }
+    settingsCallCount += 1
+    return settingsCallCount === 1 ? firstOwnerRead : secondOwnerRead
+  })
+  vi.stubGlobal('window', {
+    api: {
+      settings: {
+        get: vi
+          .fn()
+          .mockResolvedValueOnce({ activeRuntimeEnvironmentId: 'env-replacement' })
+          .mockReturnValueOnce(replacementSettingsRead)
+      },
+      runtimeEnvironments: {
+        call: runtimeCall,
+        list: vi.fn().mockResolvedValue([])
+      }
+    }
+  })
+  const store = createTestStore()
+  await store.getState().fetchSettings({ deferOwnerWorktreeVisibilityDefaults: true })
+  const ownerHydration = store.getState().awaitOwnerWorktreeVisibilityDefaultsHydration()
+  let ownerHydrationSettled = false
+  void ownerHydration.then(() => (ownerHydrationSettled = true))
+  const replacementFetch = store.getState().fetchSettings()
+  await vi.waitFor(() => expect(window.api.settings.get).toHaveBeenCalledTimes(2))
+
+  resolveFirstOwnerRead({
+    ok: true,
+    result: { settings: { worktreeVisibilityDefaults: { external: 'show' } } },
+    _meta: { runtimeId: 'runtime-first' }
+  })
+  await Promise.resolve()
+  await Promise.resolve()
+  expect(ownerHydrationSettled).toBe(false)
+
+  resolveReplacementSettingsRead({
+    activeRuntimeEnvironmentId: 'env-replacement'
+  } as GlobalSettings)
+  await vi.waitFor(() => expect(settingsCallCount).toBe(2))
+  resolveSecondOwnerRead({
+    ok: true,
+    result: { settings: { worktreeVisibilityDefaults: { external: 'hide' } } },
+    _meta: { runtimeId: 'runtime-second' }
+  })
+  await Promise.all([ownerHydration, replacementFetch])
+  expect(store.getState().worktreeVisibilityDefaultsByHost['runtime:env-replacement']).toEqual({
+    external: 'hide'
+  })
+})
+
+it('preserves owner defaults when an unrelated settings write settles after hydration', async () => {
+  markRuntimeEnvironmentCompatible('env-write-race')
+  let resolveOwnerRead!: (value: unknown) => void
+  let resolveSettingsWrite!: (value: GlobalSettings) => void
+  const ownerRead = new Promise((resolve) => (resolveOwnerRead = resolve))
+  const settingsWrite = new Promise<GlobalSettings>((resolve) => (resolveSettingsWrite = resolve))
+  vi.stubGlobal('window', {
+    api: {
+      settings: {
+        get: vi.fn().mockResolvedValue({ activeRuntimeEnvironmentId: 'env-write-race' }),
+        set: vi.fn().mockReturnValue(settingsWrite)
+      },
+      runtimeEnvironments: {
+        call: vi.fn().mockReturnValue(ownerRead),
+        list: vi.fn().mockResolvedValue([])
+      }
+    }
+  })
+  const store = createTestStore()
+  await store.getState().fetchSettings({ deferOwnerWorktreeVisibilityDefaults: true })
+  const update = store.getState().updateSettingsOrThrow({ pluginSystemEnabled: true })
+
+  resolveOwnerRead({
+    ok: true,
+    result: { settings: { worktreeVisibilityDefaults: { external: 'hide' } } },
+    _meta: { runtimeId: 'runtime-write-race' }
+  })
+  await store.getState().awaitOwnerWorktreeVisibilityDefaultsHydration()
+  resolveSettingsWrite({
+    activeRuntimeEnvironmentId: 'env-write-race',
+    pluginSystemEnabled: true
+  } as GlobalSettings)
+  await update
+
+  expect(store.getState().settings).toMatchObject({
+    pluginSystemEnabled: true,
+    worktreeVisibilityDefaults: { external: 'hide' }
+  })
 })

--- a/src/renderer/src/store/slices/settings-owner-hydration-write-fence.test.ts
+++ b/src/renderer/src/store/slices/settings-owner-hydration-write-fence.test.ts
@@ -35,7 +35,8 @@ it('preserves host defaults added while owner hydration is in flight', async () 
         get: vi.fn().mockResolvedValue({ activeRuntimeEnvironmentId: 'env-1' })
       },
       runtimeEnvironments: {
-        call: vi.fn().mockReturnValue(ownerRead)
+        call: vi.fn().mockReturnValue(ownerRead),
+        list: vi.fn().mockResolvedValue([])
       }
     }
   })
@@ -57,4 +58,51 @@ it('preserves host defaults added while owner hydration is in flight', async () 
     'runtime:env-1': { external: 'hide' },
     'runtime:env-2': { external: 'show' }
   })
+})
+
+it('publishes startup settings before remote owner hydration and local catalog work', async () => {
+  markRuntimeEnvironmentCompatible('env-1')
+  let resolveOwnerRead!: (value: unknown) => void
+  const ownerRead = new Promise((resolve) => (resolveOwnerRead = resolve))
+  vi.stubGlobal('window', {
+    api: {
+      settings: {
+        get: vi.fn().mockResolvedValue({
+          activeRuntimeEnvironmentId: 'env-1',
+          worktreeVisibilityDefaults: { external: 'show' }
+        }),
+        set: vi.fn().mockResolvedValue({
+          activeRuntimeEnvironmentId: 'env-1',
+          pluginSystemEnabled: true,
+          worktreeVisibilityDefaults: { external: 'show' }
+        })
+      },
+      runtimeEnvironments: {
+        call: vi.fn().mockReturnValue(ownerRead),
+        list: vi.fn().mockResolvedValue([])
+      }
+    }
+  })
+  const store = createTestStore()
+  let localCatalogStarted = false
+  const startup = (async () => {
+    await store.getState().fetchSettings({ deferOwnerWorktreeVisibilityDefaults: true })
+    localCatalogStarted = true
+  })()
+  await vi.waitFor(() => expect(window.api.runtimeEnvironments.call).toHaveBeenCalled())
+
+  expect(store.getState().settings?.activeRuntimeEnvironmentId).toBe('env-1')
+  expect(store.getState().worktreeVisibilityDefaultsByHost.local).toEqual({ external: 'show' })
+  expect(localCatalogStarted).toBe(true)
+
+  await store.getState().updateSettingsOrThrow({ pluginSystemEnabled: true })
+  resolveOwnerRead({
+    ok: true,
+    result: { settings: { worktreeVisibilityDefaults: { external: 'hide' } } },
+    _meta: { runtimeId: 'runtime-1' }
+  })
+  await startup
+  await store.getState().awaitOwnerWorktreeVisibilityDefaultsHydration()
+  expect(store.getState().settings?.pluginSystemEnabled).toBe(true)
+  expect(store.getState().worktreeVisibilityDefaultsByHost['runtime:env-1']).toBeUndefined()
 })

--- a/src/renderer/src/store/slices/settings-owner-hydration-write-fence.test.ts
+++ b/src/renderer/src/store/slices/settings-owner-hydration-write-fence.test.ts
@@ -109,6 +109,41 @@ it('publishes startup settings before remote owner hydration and local catalog w
   })
 })
 
+it('preserves deferred owner hydration across a no-op runtime selection', async () => {
+  markRuntimeEnvironmentCompatible('env-no-op')
+  let resolveOwnerRead!: (value: unknown) => void
+  const ownerRead = new Promise((resolve) => (resolveOwnerRead = resolve))
+  vi.stubGlobal('window', {
+    api: {
+      settings: {
+        get: vi.fn().mockResolvedValue({ activeRuntimeEnvironmentId: 'env-no-op' }),
+        setActiveRuntimeEnvironmentPreference: vi.fn()
+      },
+      runtimeEnvironments: {
+        call: vi.fn().mockReturnValue(ownerRead),
+        list: vi.fn().mockResolvedValue([])
+      }
+    }
+  })
+  const store = createTestStore()
+  await store.getState().fetchSettings({ deferOwnerWorktreeVisibilityDefaults: true })
+
+  await expect(store.getState().setActiveRuntimeEnvironmentPreference(' env-no-op ')).resolves.toBe(
+    true
+  )
+  resolveOwnerRead({
+    ok: true,
+    result: { settings: { worktreeVisibilityDefaults: { external: 'show' } } },
+    _meta: { runtimeId: 'runtime-no-op' }
+  })
+  await store.getState().awaitOwnerWorktreeVisibilityDefaultsHydration()
+
+  expect(window.api.settings.setActiveRuntimeEnvironmentPreference).not.toHaveBeenCalled()
+  expect(store.getState().worktreeVisibilityDefaultsByHost['runtime:env-no-op']).toEqual({
+    external: 'show'
+  })
+})
+
 it('waits for a replacement owner hydration before publishing remote rows', async () => {
   markRuntimeEnvironmentCompatible('env-replacement')
   let resolveFirstOwnerRead!: (value: unknown) => void

--- a/src/renderer/src/store/slices/settings.ts
+++ b/src/renderer/src/store/slices/settings.ts
@@ -52,8 +52,6 @@ type LegacyTerminalScrollbackSettingsUpdate = Partial<GlobalSettings> & {
   terminalScrollbackBytes?: unknown
 }
 
-let ownerSettingsHydrationGeneration = 0
-
 function normalizeRuntimeEnvironmentId(value: string | null | undefined): string | null {
   const trimmed = value?.trim()
   return trimmed ? trimmed : null
@@ -187,26 +185,7 @@ export const createSettingsSlice: StateCreator<AppState, [], [], SettingsSlice> 
   ...createSettingsSearchState((state) => set(state)),
 
   fetchSettings: async (options) => {
-    const generation = ++ownerSettingsHydrationGeneration
-    try {
-      const localSettings = (await window.api.settings.get()) as GlobalSettings
-      if (generation !== ownerSettingsHydrationGeneration) {
-        return
-      }
-      const ownerVisibilityDefaultsHydration =
-        ownerHydration.startOwnerWorktreeVisibilityDefaultsHydration({
-          settings: localSettings,
-          deferPublication: options?.deferOwnerWorktreeVisibilityDefaults === true,
-          shouldPublish: () => generation === ownerSettingsHydrationGeneration,
-          set,
-          get
-        })
-      if (!options?.deferOwnerWorktreeVisibilityDefaults) {
-        await ownerVisibilityDefaultsHydration
-      }
-    } catch (err) {
-      console.error('Failed to fetch settings:', err)
-    }
+    await ownerHydration.fetchSettingsWithOwnerHydration({ options, set, get })
     const { runtimeEnvironmentCatalogHydrated, runtimeEnvironments, runtimeStatusByEnvironmentId } =
       get()
     // Why: settings refreshes are frequent, but only incomplete host coverage needs
@@ -225,7 +204,9 @@ export const createSettingsSlice: StateCreator<AppState, [], [], SettingsSlice> 
     ownerHydration.awaitOwnerWorktreeVisibilityDefaultsHydration(get),
 
   updateSettings: async (updates) => {
-    const generation = ++ownerSettingsHydrationGeneration
+    const shouldPublish = ownerHydration.createSettingsPublicationFence(
+      'activeRuntimeEnvironmentId' in updates || 'worktreeVisibilityDefaults' in updates
+    )
     const visibilityOwnerHostId = getSettingsFocusedExecutionHostId(get().settings)
     try {
       await persistSettingsUpdates(
@@ -234,7 +215,7 @@ export const createSettingsSlice: StateCreator<AppState, [], [], SettingsSlice> 
         get().settings,
         get().worktreeVisibilityDefaultsSupportedRuntimeEnvironmentId,
         get().worktreeVisibilitySourceDefaultsSupportedRuntimeEnvironmentId,
-        () => generation === ownerSettingsHydrationGeneration
+        shouldPublish
       )
       if ('worktreeVisibilityDefaults' in updates) {
         await get().fetchAllWorktrees({ visibilityOwnerHostId })
@@ -245,7 +226,9 @@ export const createSettingsSlice: StateCreator<AppState, [], [], SettingsSlice> 
   },
 
   updateSettingsOrThrow: async (updates) => {
-    const generation = ++ownerSettingsHydrationGeneration
+    const shouldPublish = ownerHydration.createSettingsPublicationFence(
+      'activeRuntimeEnvironmentId' in updates || 'worktreeVisibilityDefaults' in updates
+    )
     const visibilityOwnerHostId = getSettingsFocusedExecutionHostId(get().settings)
     await persistSettingsUpdates(
       set,
@@ -253,7 +236,7 @@ export const createSettingsSlice: StateCreator<AppState, [], [], SettingsSlice> 
       get().settings,
       get().worktreeVisibilityDefaultsSupportedRuntimeEnvironmentId,
       get().worktreeVisibilitySourceDefaultsSupportedRuntimeEnvironmentId,
-      () => generation === ownerSettingsHydrationGeneration
+      shouldPublish
     )
     if ('worktreeVisibilityDefaults' in updates) {
       await get().fetchAllWorktrees({ visibilityOwnerHostId })
@@ -261,7 +244,7 @@ export const createSettingsSlice: StateCreator<AppState, [], [], SettingsSlice> 
   },
 
   setActiveRuntimeEnvironmentPreference: async (environmentId) => {
-    const generation = ++ownerSettingsHydrationGeneration
+    const shouldPublish = ownerHydration.createSettingsPublicationFence(true)
     const nextId = normalizeRuntimeEnvironmentId(environmentId)
     const previousId = normalizeRuntimeEnvironmentId(get().settings?.activeRuntimeEnvironmentId)
     if (previousId === nextId) {
@@ -270,7 +253,7 @@ export const createSettingsSlice: StateCreator<AppState, [], [], SettingsSlice> 
     try {
       clearRuntimeCompatibilityCache(nextId)
       await verifyRuntimeEnvironmentReachable(nextId)
-      if (generation !== ownerSettingsHydrationGeneration) {
+      if (!shouldPublish()) {
         return true
       }
       const nextSettings = await window.api.settings.setActiveRuntimeEnvironmentPreference({
@@ -286,7 +269,7 @@ export const createSettingsSlice: StateCreator<AppState, [], [], SettingsSlice> 
           focusedSettings,
           get().worktreeVisibilityDefaultsByHost
         )
-        if (generation !== ownerSettingsHydrationGeneration) {
+        if (!shouldPublish()) {
           return true
         }
         set((state) => ({

--- a/src/renderer/src/store/slices/settings.ts
+++ b/src/renderer/src/store/slices/settings.ts
@@ -244,12 +244,12 @@ export const createSettingsSlice: StateCreator<AppState, [], [], SettingsSlice> 
   },
 
   setActiveRuntimeEnvironmentPreference: async (environmentId) => {
-    const shouldPublish = ownerHydration.createSettingsPublicationFence(true)
     const nextId = normalizeRuntimeEnvironmentId(environmentId)
     const previousId = normalizeRuntimeEnvironmentId(get().settings?.activeRuntimeEnvironmentId)
     if (previousId === nextId) {
       return true
     }
+    const shouldPublish = ownerHydration.createSettingsPublicationFence(true)
     try {
       clearRuntimeCompatibilityCache(nextId)
       await verifyRuntimeEnvironmentReachable(nextId)

--- a/src/renderer/src/store/slices/settings.ts
+++ b/src/renderer/src/store/slices/settings.ts
@@ -32,6 +32,7 @@ import {
   hydrateOwnerWorktreeVisibilityDefaults,
   type WorktreeVisibilityDefaultsByHost
 } from './worktree-visibility-owner-settings'
+import * as ownerHydration from './settings-owner-hydration-publication'
 import { persistVisibilityAwareSettings } from './worktree-visibility-settings-write'
 import { getSettingsFocusedExecutionHostId } from '../../../../shared/execution-host'
 
@@ -40,7 +41,8 @@ export type SettingsSlice = SettingsSearchState & {
   worktreeVisibilityDefaultsByHost: WorktreeVisibilityDefaultsByHost
   worktreeVisibilityDefaultsSupportedRuntimeEnvironmentId: string | null
   worktreeVisibilitySourceDefaultsSupportedRuntimeEnvironmentId: string | null
-  fetchSettings: () => Promise<void>
+  fetchSettings: (options?: ownerHydration.FetchSettingsOptions) => Promise<void>
+  awaitOwnerWorktreeVisibilityDefaultsHydration: () => Promise<void>
   updateSettings: (updates: Partial<GlobalSettings>) => Promise<void>
   updateSettingsOrThrow: (updates: Partial<GlobalSettings>) => Promise<void>
   setActiveRuntimeEnvironmentPreference: (environmentId: string | null) => Promise<boolean>
@@ -50,7 +52,6 @@ type LegacyTerminalScrollbackSettingsUpdate = Partial<GlobalSettings> & {
   terminalScrollbackBytes?: unknown
 }
 
-type SettingsStateSetter = Parameters<StateCreator<AppState, [], [], SettingsSlice>>[0]
 let ownerSettingsHydrationGeneration = 0
 
 function normalizeRuntimeEnvironmentId(value: string | null | undefined): string | null {
@@ -134,7 +135,7 @@ function normalizeSettingsUpdates(
 }
 
 async function persistSettingsUpdates(
-  set: SettingsStateSetter,
+  set: ownerHydration.SettingsStateSetter,
   updates: Partial<GlobalSettings>,
   currentSettings: GlobalSettings | null,
   supportedRuntimeEnvironmentId: string | null,
@@ -185,27 +186,24 @@ export const createSettingsSlice: StateCreator<AppState, [], [], SettingsSlice> 
   worktreeVisibilitySourceDefaultsSupportedRuntimeEnvironmentId: null,
   ...createSettingsSearchState((state) => set(state)),
 
-  fetchSettings: async () => {
+  fetchSettings: async (options) => {
     const generation = ++ownerSettingsHydrationGeneration
     try {
-      const hydrated = await hydrateOwnerWorktreeVisibilityDefaults(
-        (await window.api.settings.get()) as GlobalSettings,
-        get().worktreeVisibilityDefaultsByHost
-      )
+      const localSettings = (await window.api.settings.get()) as GlobalSettings
       if (generation !== ownerSettingsHydrationGeneration) {
         return
       }
-      set((state) => ({
-        settings: hydrated.settings,
-        worktreeVisibilityDefaultsByHost: {
-          ...state.worktreeVisibilityDefaultsByHost,
-          ...hydrated.defaultsByHost
-        },
-        worktreeVisibilityDefaultsSupportedRuntimeEnvironmentId:
-          hydrated.supportedRuntimeEnvironmentId,
-        worktreeVisibilitySourceDefaultsSupportedRuntimeEnvironmentId:
-          hydrated.sourceDefaultsSupportedRuntimeEnvironmentId
-      }))
+      const ownerVisibilityDefaultsHydration =
+        ownerHydration.startOwnerWorktreeVisibilityDefaultsHydration({
+          settings: localSettings,
+          deferPublication: options?.deferOwnerWorktreeVisibilityDefaults === true,
+          shouldPublish: () => generation === ownerSettingsHydrationGeneration,
+          set,
+          get
+        })
+      if (!options?.deferOwnerWorktreeVisibilityDefaults) {
+        await ownerVisibilityDefaultsHydration
+      }
     } catch (err) {
       console.error('Failed to fetch settings:', err)
     }
@@ -222,6 +220,9 @@ export const createSettingsSlice: StateCreator<AppState, [], [], SettingsSlice> 
       void get().hydrateRuntimeEnvironmentStatuses()
     }
   },
+
+  awaitOwnerWorktreeVisibilityDefaultsHydration: () =>
+    ownerHydration.awaitOwnerWorktreeVisibilityDefaultsHydration(get),
 
   updateSettings: async (updates) => {
     const generation = ++ownerSettingsHydrationGeneration

--- a/src/renderer/src/store/slices/worktree-visibility-settings-write.ts
+++ b/src/renderer/src/store/slices/worktree-visibility-settings-write.ts
@@ -111,7 +111,12 @@ export async function persistVisibilityAwareSettings(args: {
       const defaults =
         state.worktreeVisibilityDefaultsByHost[toRuntimeExecutionHostId(target.environmentId)] ??
         currentSettings?.worktreeVisibilityDefaults
-      if (target.environmentId === supportedRuntimeEnvironmentId && defaults) {
+      if (
+        target.environmentId ===
+          (state.worktreeVisibilityDefaultsSupportedRuntimeEnvironmentId ??
+            supportedRuntimeEnvironmentId) &&
+        defaults
+      ) {
         return { ...persisted, worktreeVisibilityDefaults: defaults }
       }
       const { worktreeVisibilityDefaults: _unsupported, ...settingsWithoutDefaults } = persisted


### PR DESCRIPTION
## ELI5

Orca now shows locally persisted settings and starts the local project catalog without waiting for a slow or offline selected remote server to answer a visibility-default request.

## What Changed

- Publish local settings before remote owner visibility-default hydration during startup.
- Continue owner hydration in the background and wait for it only before the deferred remote catalog refresh, keeping remote rows steady while their defaults load.
- Preserve the existing generation/write fence so a user setting change wins over stale deferred hydration.
- Add ordering coverage proving local startup continues while the remote request is unresolved.

## Why

A persisted remote runtime could consume the connect plus RPC timeout budget before local settings, persisted UI, and the local repository catalog became usable. This follows the existing startup pattern that keeps remote catalog work off the first-paint path.

## Linked Issue

[STA-4384](https://linear.app/stably/issue/STA-4384/p1continuous-remote-visibility-default-hydration-blocks-local-first)

## Visual Proof

macOS Electron CDP QA captured the usable local workbench during an unresolved remote stall; timing, backing-state evidence, and the uncropped screenshot are attached in [this PR comment](https://github.com/stablyai/orca/pull/14674#issuecomment-5300629146).

## Testing

- [x] 68 focused Vitest tests across settings hydration, write fencing, runtime visibility defaults, runtime switching, stale-host purging, and startup ordering
- [x] `pnpm typecheck:web`
- [x] focused `oxlint`
- [x] max-lines ratchet
- [x] macOS Electron CDP QA via Playwright CDP against an intentionally stalled saved remote runtime

Independent baseline reproduction confirmed the stall and also found that paired web performs two serial remote `settings.get` calls. This focused desktop startup fix does not change the web preload path; paired web remains an unexercised residual path for follow-up.

## Review

No wire format, persistence schema, Git command, path, shortcut, mobile, or provider behavior changes. Remote rows remain gated behind owner-default hydration, while local and folder workspaces continue through the local startup path.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Visual proof attached; a before/after pair is N/A because this is a startup-timing stall, with the regression and fix compared through startup instrumentation
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] Full CI is green, including static analysis, typecheck, packaging, verification, and all test shards; focused checks pass locally

## Author

- X / Twitter: @BrennanKB5
