### PR TITLE
fix(agents): surface Trae CLI panes in worktree agent rows via a declared identity frame (#11643)

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -245,6 +245,83 @@ describe('buildTitleDerivedAgentRows', () => {
     expect(owned.map((row) => row.agentType)).toEqual(['claude'])
   })
 
+  // Why: #11643's repro shows a live TRAE CN pane whose title is the bare launcher name
+  // `traecli`. Trae posts no hooks, so the title path is the only thing that can put the
+  // pane on the worktree card at all (STA-3048).
+  it('adds idle rows for live Trae panes titled with the launcher name', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { title: 'traecli' })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: { 'tab-1': { 1: 'traecli', 2: 'traecli.cmd' } },
+      ptyIdsByTabId: { 'tab-1': ['pty-posix', 'pty-windows'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSplitLayout() },
+      now: 2000
+    })
+
+    expect(rows.map((row) => [row.agentType, row.state, row.entry.lastAssistantMessage])).toEqual([
+      ['trae', 'idle', 'Idle'],
+      ['trae', 'idle', 'Idle']
+    ])
+    expect(rows[0]?.paneKey).toBe(makePaneKey('tab-1', LEAF_ID_1))
+  })
+
+  // Why: the issue's last acceptance criterion — closing the session must clear the row.
+  it('drops the Trae row once the tab has no live pty', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { title: 'traecli' })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: { 'tab-1': { 1: 'traecli' } },
+      ptyIdsByTabId: {},
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(rows).toHaveLength(0)
+  })
+
+  it('does not invent a Trae row from Claude task text that mentions traecli', () => {
+    const unowned = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1')],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: { 'tab-1': { 1: '⠋ fix the traecli mapping' } },
+      ptyIdsByTabId: { 'tab-1': ['pty-claude-task'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+    expect(unowned).toHaveLength(0)
+
+    const owned = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { launchAgent: 'claude' })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: { 'tab-1': { 1: '⠋ fix the traecli mapping' } },
+      ptyIdsByTabId: { 'tab-1': ['pty-claude-task'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+    expect(owned.map((row) => row.agentType)).toEqual(['claude'])
+  })
+
+  // Why: `trae-cli` is the unrelated open-source bytedance/trae-agent binary, and a
+  // traecli-named worktree path is an ordinary shell title.
+  it('keeps trae-cli and traecli-named paths out of the sidebar', () => {
+    for (const title of ['trae-cli', '~/orca/workspaces/traecli-scratch']) {
+      const rows = buildWorktreeAgentRows({
+        tabs: [makeTab('tab-1', { title })],
+        entries: [],
+        retained: [],
+        runtimePaneTitlesByTabId: { 'tab-1': { 1: title } },
+        ptyIdsByTabId: { 'tab-1': ['pty-shell'] },
+        terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+        now: 2000
+      })
+      expect(rows).toHaveLength(0)
+    }
+  })
+
   it('keeps a cline-named worktree path out of the sidebar', () => {
     const rows = buildWorktreeAgentRows({
       tabs: [makeTab('tab-1', { title: '~/orca/workspaces/cline-scratch' })],

--- a/src/shared/agent-identity-frame.test.ts
+++ b/src/shared/agent-identity-frame.test.ts
@@ -5,7 +5,7 @@ import {
   isAgentIdentityFrameTitleFor,
   resolveAgentIdentityFrameType
 } from './agent-identity-frame'
-import { getAgentLabel } from './agent-title-identity'
+import { getAgentLabel, isClaudeAgent } from './agent-title-identity'
 import { detectAgentStatusFromTitle } from './agent-title-status'
 import {
   isClaudeIdentityFrameTitle,
@@ -108,5 +108,82 @@ describe('isClaudeIdentityFrameTitle after the shared-builder move', () => {
     ]) {
       expect(isClaudeIdentityFrameTitle(title)).toBe(false)
     }
+  })
+})
+
+// The only Trae title Orca has on record is the one in #11643's repro: a live TRAE CN
+// session whose pane title is the bare launcher name `traecli`, undecorated, while the
+// session is interactive and already answering. TRAE CN's installer is region locked
+// (trae.cn 403s "denied by region block" from outside CN), so nothing beyond that frame
+// is observed — hence no glyph or context vocabulary is declared for it.
+describe('Trae CLI title visibility (STA-3048 / #11643)', () => {
+  it('resolves the launcher-name title to identity, label, and an idle status', () => {
+    expect(resolveAgentIdentityFrameType('traecli')).toBe('trae')
+    expect(getAgentLabel('traecli')).toBe('Trae')
+    expect(resolveTerminalTitleAgentType('traecli')).toBe('trae')
+    expect(resolveExplicitTerminalTitleAgentType('traecli')).toBe('trae')
+    expect(detectAgentStatusFromTitle('traecli')).toBe('idle')
+  })
+
+  // Why: TRAE CN ships a `.cmd` launcher on Windows, so the pane title there surfaces
+  // the extension rather than the bare name.
+  it('accepts the Windows launcher forms and the multiplexer-wrapped form', () => {
+    for (const title of ['traecli.exe', 'traecli.cmd', 'zsh | traecli']) {
+      expect(resolveAgentIdentityFrameType(title)).toBe('trae')
+      expect(detectAgentStatusFromTitle(title)).toBe('idle')
+    }
+  })
+
+  // Why: the unrelated open-source bytedance/trae-agent installs a `trae-cli` binary and
+  // `trae` is an ordinary word — TUI_AGENT_CONFIG.trae detects on `traecli` for exactly
+  // this reason, and the frame must not be looser than the launcher it mirrors.
+  it('rejects the bare word, the unrelated trae-agent binary, paths, and task text', () => {
+    for (const title of [
+      'trae',
+      'trae-cli',
+      'trae-agent',
+      '~/traecli/working',
+      'src/traecli/index.ts',
+      'traecli-scratch',
+      'port the traecli prompt'
+    ]) {
+      expect(resolveAgentIdentityFrameType(title)).toBeNull()
+      expect(detectAgentStatusFromTitle(title)).toBeNull()
+      expect(getAgentLabel(title)).not.toBe('Trae')
+    }
+  })
+
+  // Why: a decorated `traecli` frame resolved to Claude Code before the registry row, so
+  // a Trae pane could reach Claude-only behavior (the prompt-cache timer and the parked
+  // byte watcher both branch on isClaudeAgent).
+  it('stops a decorated traecli title from being attributed to Claude', () => {
+    expect(getAgentLabel('⠋ traecli')).toBe('Trae')
+    expect(resolveTerminalTitleAgentType('⠋ traecli')).toBe('trae')
+    expect(isClaudeAgent('⠋ traecli')).toBe(false)
+    expect(isClaudeIdentityFrameTitle('⠋ traecli')).toBe(false)
+  })
+
+  it('keeps Claude task text that mentions traecli as Claude', () => {
+    expect(getAgentLabel('⠋ fix the traecli mapping')).toBe('Claude Code')
+    expect(resolveTerminalTitleAgentType('⠋ fix the traecli mapping')).toBe('claude')
+    expect(isClaudeAgent('⠋ fix the traecli mapping')).toBe(true)
+  })
+
+  it('never lets the frame swallow trailing prose or a context tail', () => {
+    expect(isAgentIdentityFrameTitleFor('traecli fix the parser', 'trae')).toBe(false)
+    // Why: Trae has never been seen appending a cwd, so its frame stays anchored on the
+    // name alone — a trailing tail is somebody's shell title, not Trae identity.
+    expect(isAgentIdentityFrameTitleFor('traecli - orca', 'trae')).toBe(false)
+  })
+
+  // Why: the registry is shared — prove the neighbours it already carried still hold.
+  it('leaves the agents already in the registry unchanged', () => {
+    expect(resolveAgentIdentityFrameType('Cline')).toBe('cline')
+    expect(detectAgentStatusFromTitle('Cline')).toBe('idle')
+    expect(getAgentLabel('Cline')).toBe('Cline')
+    expect(resolveAgentIdentityFrameType('Claude Code')).toBe('claude')
+    expect(isClaudeIdentityFrameTitle('zsh | ⠋ Claude Code')).toBe(true)
+    expect(getAgentLabel('⠋ use cline for the sidebar fix')).toBe('Claude Code')
+    expect(AGENT_IDENTITY_FRAMES.amp).toBeUndefined()
   })
 })

--- a/src/shared/agent-identity-frame.ts
+++ b/src/shared/agent-identity-frame.ts
@@ -48,7 +48,13 @@ export const AGENT_IDENTITY_FRAMES: Partial<Record<TuiAgent, AgentIdentityFrameS
   claude: { names: ['claude code', 'claude'] },
   // Verified against cline 3.0.55: it emits OSC 0 `Cline` and never varies it,
   // so Orca sees identity but no status transitions (STA-3906).
-  cline: { names: ['cline'], executableSuffix: true }
+  cline: { names: ['cline'], executableSuffix: true },
+  // Observed in the #11643 repro: a live TRAE CN session's pane title is the bare
+  // launcher name `traecli` — the same string Orca launches and expects as the
+  // process (TUI_AGENT_CONFIG.trae) — with no decoration and no state transitions.
+  // No glyph or context vocabulary is declared because trae.cn's installer is region
+  // locked, so nothing beyond that one frame has been observed (STA-3048).
+  trae: { names: ['traecli'], executableSuffix: true }
 }
 
 const IDENTITY_FRAME_RES = new Map<TuiAgent, RegExp>(


### PR DESCRIPTION
## ELI5

Orca could launch Trae CLI but never showed it in the left sidebar, because Orca only lists a
pane as an agent if it recognises the pane's *title*. Trae's title (`traecli`) was not in the
vocabulary. This adds one row to the identity-frame registry #14634 introduced, and Trae shows up.

## What Changed

One row in `AGENT_IDENTITY_FRAMES` (`src/shared/agent-identity-frame.ts`):

```ts
trae: { names: ['traecli'], executableSuffix: true }
```

Everything else is tests. No new predicate, no new table entry, no change to any call site.

## Why

`trae` was already in `TuiAgent`, `TUI_AGENT_CONFIG`, `agent-catalog`, `agent-kind`,
`agent-status-types` and telemetry — and the pane was still invisible. The closed set is the
**title vocabulary**, exactly as #14634 (Cline) and #14647 (Qwen) each established. This is the
third runtime to confirm it, and the first one that needed *nothing but data*.

**Measured on the base branch, before this commit:**

| pane title | `getAgentLabel` | `resolveTerminalTitleAgentType` | `detectAgentStatusFromTitle` |
| --- | --- | --- | --- |
| `traecli` | `null` | `null` | `null` — invisible |
| `traecli.exe` | `null` | `null` | `null` — invisible |
| `⠋ traecli` | **`Claude Code`** | **`claude`** | `working` — **mislabelled** |

After: `Trae` / `trae` / `idle` (and `working` for the decorated form), with `isClaudeAgent`
returning `false` so a Trae pane no longer reaches Claude-only behaviour (the prompt-cache timer
and the parked-terminal byte watcher both branch on it).

### Where the title evidence comes from

**TRAE CN's CLI could not be installed on this machine** — `trae.cn`'s installer answers
`HTTP 403 … denied by region block` outside CN, so I could not run it and observe its title
transitions first-hand. Rather than invent titles, the frame is declared from what is actually on
record:

- **#11643's own repro screenshot**: a live, already-answering Trae session whose pane title is
  the bare launcher name `traecli` — undecorated, lowercase, no status text.
- **`TUI_AGENT_CONFIG.trae`**: `launchCmd`/`detectCmd`/`expectedProcess` are all `traecli`, and its
  comment records *why* (`trae` is an ordinary word and the unrelated open-source
  `bytedance/trae-agent` installs a **`trae-cli`** binary).

So the frame declares **no `statusGlyphs` and no `contextSuffix`** — neither has been observed, and
an unobserved one only widens the false-positive surface. If someone with CN access later captures
real Trae status glyphs, they are two more declared fields, not another predicate.

## Linked Issue

Fixes #11643 (STA-3048).

## Visual Proof

Same live pane in both shots (pane title `traecli`, single pty), toggled only by the one-row
registry entry via HMR on an isolated dev instance:

**BEFORE** — worktree card has no Agents group at all:

![trae-sidebar-BEFORE.png](https://github.com/user-attachments/assets/f5c73e7d-b799-4c38-a844-720c05ffd66f)

**AFTER** — `Trae` icon, `traecli - Idle`, `now`:

![trae-sidebar-AFTER.png](https://github.com/user-attachments/assets/c732cf82-1036-4b9e-abdf-618f285cc20b)

Accessibility tree of the AFTER row:

```
treeitem "Idle traecli - Idle now" [level=1]
  generic "Idle"
  generic "Trae"          <- agent icon/label
  generic: "traecli" + "- Idle"
  generic: "now"
```

Honest caveat on the pane: since the real CLI is region-blocked here, the pane is a stub that emits
**the one thing that matters** — `OSC 0 ; traecli BEL` from a live pty — which is exactly the byte
sequence in the issue screenshot. Nothing about Trae's *behaviour* is simulated or asserted.

## Testing

- `pnpm exec vitest run --config config/vitest.config.ts src/shared/agent-identity-frame.test.ts
  src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
  src/shared/agent-detection.test.ts src/shared/terminal-title-agent-type.test.ts` — 126 passed.
- Broader sweep: `src/renderer/src/components/sidebar/`, `src/renderer/src/components/tab-bar/`,
  `src/renderer/src/lib/agent-status.test.ts` — 2665 passed. Two files timed out at 30s under that
  282-file parallel run (`WorktreeCard.compact-ports-hover-independence`, `BrowserTab`); both pass
  in isolation **with** this change, so they are load flakes, not regressions.
- `pnpm exec oxlint` + `oxfmt --check` on the three changed files: clean.
  `node config/scripts/check-changed-code-quality.mjs`: 0 new findings (code quality, type-aware,
  React Doctor).
- Scoped `tsc --noEmit --ignoreConfig --strict` over the changed shared files: clean. Full
  `pnpm typecheck` deliberately not run locally (OOM risk on this host) — CI covers it.

**Tests proven non-vacuous, both directions:**
- Revert the one registry row → **4 tests fail** (`resolves the launcher-name title…`, `accepts the
  Windows launcher forms…`, `stops a decorated traecli title from being attributed to Claude`,
  `adds idle rows for live Trae panes titled with the launcher name`).
- Widen the row to `names: ['traecli', 'trae']` → the guard test `rejects the bare word, the
  unrelated trae-agent binary, paths, and task text` fails.
- Lint gate proven live by injecting `debugger` (oxlint flagged it); typecheck gate proven live by
  injecting a bad field type (TS2322).

Registry regression coverage for a **different** agent is included, since the file is shared: Cline
and Claude frames, labels and statuses are re-asserted in
`leaves the agents already in the registry unchanged`.

Platforms: macOS only. The Windows launcher forms (`traecli.exe` / `traecli.cmd`) are covered by
unit test, not by a Windows run. No SSH, IPC, filesystem, credential or wire-format surface is
touched — this is pure string classification in `src/shared`.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

**Base branch.** This is stacked on `brennanb2025/runtime-visibility-cline-13823` (#14634) because
`agent-identity-frame.ts` is not on `main` yet. **Retarget to `main` before merging** — a stacked PR
merged into an already-merged parent reports MERGED while delivering nothing.

**Supersedes #11851** (@rodboev, "fix(sidebar): show Trae agent status in worktrees"). That PR found
the right title and found a real bug (`⠋ traecli` reaching `isClaudeAgent`), and full credit for
both — but its shape is the one #14634 exists to stop, and it has one measured hazard:

1. **It is the fifth hand-copy of the identity-frame shape.** It adds a bespoke
   `TRAE_CLI_TITLE_RE` + `isTraeCliTitle` and threads it through six call sites
   (`agent-name-token-match`, `agent-title-core`, `agent-title-identity`,
   `terminal-title-agent-type` ×2, `worktree-title-derived-agent-rows`), +135/−4 across 8 files.
   The registry does the same job in one row, and the `isClaudeAgent` guard it hand-wired comes for
   free — #14634 already routes that branch through `resolveAgentIdentityFrameType`.
2. **It adds `traecli` to `AGENT_NAMES`, whose own comment warns against exactly that.** Measured
   with that line applied: `detectAgentStatusFromTitle` starts minting a status from free-form text
   that merely *mentions* the name — `"rewrite the traecli docs, working on it"` → `working`,
   `"traecli notes ready"` → `idle`, `"traecli is broken - action required"` → `permission`. Its own
   anchored regex already does the identity work, so the `AGENT_NAMES` entry is unnecessary risk.
   (This widens the status vocabulary; the sidebar row path is separately gated by `getAgentLabel`.)
3. **`⠋ traecli` is not an observed title.** It is asserted as Trae's "working" form in that PR's
   tests. It costs nothing to accept it — this PR does too, via the shared decoration strip — but it
   should not be presented as something the CLI emits, and the test here does not.

**Not superseded** (different concerns, both still valid): #11278 (@innocarpe, Trae resume /
`traecli --resume`) and #13515 (@mosh-box, AI-vault Trae session history).

**Runtimes still invisible after this** — none of them belong in this PR:
- **#12898 / STA-3589 — Antigravity**: no `PreToolUse` hook installed, so no live tool-in-progress
  status. Open PR #12993. Hook-installation gap, not a title gap.
- **#13626 — Kilo Code**: needs OpenCode-family hooks + status plugin. Open PR #13990.
- **#9834 / STA-2305 — Kimi Code on Windows**: Orca installs a POSIX `/bin/sh` hook while Kimi runs
  under `cmd.exe`. A hook-shell mismatch — genuinely a different defect class, and it must **not** be
  forced into this registry.

Cross-platform: the frame accepts `.exe/.cmd/.bat/.ps1` after the name for the Windows launcher.
SSH/remote and folder-vs-worktree workspaces are unaffected — the row builder already gates on a
live pty, and this changes only how a title string is classified.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots attached
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] Focused lint/tests/typecheck pass locally; full `pnpm typecheck`/`build` left to CI

## Author

- X / Twitter: @BrennanKB5
