### PR TITLE
fix(terminal): keep unresolved snapshot-capability verdicts re-askable

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -117,11 +117,14 @@ import {
 } from './terminal-pane/terminal-hidden-view-parking'
 import {
   TERMINAL_HIDDEN_WORKTREE_RETENTION_TTL_MS,
+  countEvictionExemptTabRoutes,
+  formatEvictionExemptRouteCounts,
   hasPendingRetentionSpawnWork,
   selectForceParkEvictableTabIds,
   selectRetentionForceParkedTerminalWorktrees,
   type TerminalWorktreeRetentionCandidate
 } from './terminal-pane/terminal-hidden-worktree-retention'
+import { recordRendererCrashBreadcrumb } from '@/lib/crash-breadcrumb-recorder'
 import { captureForceParkedWorktreeBuffers } from './terminal-pane/force-park-buffer-capture'
 import { warnTerminalLifecycleAnomaly } from './terminal-pane/terminal-lifecycle-diagnostics'
 import {
@@ -1096,10 +1099,19 @@ function Terminal(): React.JSX.Element | null {
         // Why logged: an all-exempt force-park frees no heap at all (daemon
         // fail-open makes every local pty exempt), so the budget only holds
         // while this stays rare — make the degenerate case observable.
+        // Why routed + breadcrumbed: only per-route counts in a field bundle
+        // can say whether fail-open ids or unresolved snapshot capability
+        // dominates the degenerate case.
         if (evictableTabIds.length === 0 && forceParkedTabs.length > 0) {
+          const exemptRouteCounts = countEvictionExemptTabRoutes(forceParkedTabs, worktreeId)
           warnTerminalLifecycleAnomaly('retention force-park freed no panes', {
             worktreeId,
-            reason: `exemptTabs=${forceParkedTabs.length}`
+            reason: `exemptTabs=${forceParkedTabs.length} ${formatEvictionExemptRouteCounts(exemptRouteCounts)}`
+          })
+          recordRendererCrashBreadcrumb('terminal_force_park_freed_no_panes', {
+            worktreeId,
+            exemptTabs: forceParkedTabs.length,
+            ...exemptRouteCounts
           })
         }
         // Why conditional: a tab whose pane was mid-remount registered no

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -423,7 +423,9 @@ function Terminal(): React.JSX.Element | null {
         : [],
     [renderedActiveWorktreeId, tabsByWorktree]
   )
-  useTerminalProviderSnapshotCapability(workspaceSessionReady && hydrationSucceeded)
+  const terminalProviderSnapshotCapabilityRevision = useTerminalProviderSnapshotCapability(
+    workspaceSessionReady && hydrationSucceeded
+  )
 
   // Why: TabBar portals into the titlebar (target created by App.tsx) so tabs share the "Orca" title row.
   const titlebarTabsTarget = document.getElementById('titlebar-tabs')
@@ -1109,7 +1111,6 @@ function Terminal(): React.JSX.Element | null {
             reason: `exemptTabs=${forceParkedTabs.length} ${formatEvictionExemptRouteCounts(exemptRouteCounts)}`
           })
           recordRendererCrashBreadcrumb('terminal_force_park_freed_no_panes', {
-            worktreeId,
             exemptTabs: forceParkedTabs.length,
             ...exemptRouteCounts
           })
@@ -1180,6 +1181,7 @@ function Terminal(): React.JSX.Element | null {
     tabsByWorktree,
     terminalParkingEnabled,
     terminalParkingRevision,
+    terminalProviderSnapshotCapabilityRevision,
     terminalRetentionBudgetEnabled,
     terminalSshParkingEnabled,
     workspaceSurfaces

--- a/src/renderer/src/components/terminal-pane/terminal-cold-park-exempt-flip.react185.test.tsx
+++ b/src/renderer/src/components/terminal-pane/terminal-cold-park-exempt-flip.react185.test.tsx
@@ -271,7 +271,6 @@ describe('force-park exemption flips under capability changes', () => {
       const allPtyIds = TAB_IDS.map(ptyIdFor)
       for (let flip = 0; flip < 6; flip += 1) {
         const syncCallsBefore = harness.syncCalls
-        // eslint-disable-next-line no-await-in-loop -- flips are sequential by design
         await act(async () => {
           if (flip % 2 === 0) {
             // Daemon answered: every pty has an authoritative snapshot.

--- a/src/renderer/src/components/terminal-pane/terminal-cold-park-exempt-flip.react185.test.tsx
+++ b/src/renderer/src/components/terminal-pane/terminal-cold-park-exempt-flip.react185.test.tsx
@@ -1,0 +1,303 @@
+/**
+ * Guard for the capability re-settlement fix: eviction-exemption flips are a
+ * pin-unreachable input to the rendered park verdict (same family as the
+ * activation-deferred clause behind the terminal.workbench React #185
+ * cluster). Capability verdicts may therefore only change between commits —
+ * asynchronously, off daemon answers — never as a function of the pane
+ * mount/unmount lifecycle. This harness force-parks a worktree, lets pane
+ * mounts write layouts/titles (the mount-lifecycle writes that feed the
+ * exemption's OTHER inputs), and flips the capability verdict between commits
+ * repeatedly: every flip must settle without approaching React's nested
+ * update limit.
+ */
+/** @vitest-environment happy-dom */
+import { act, StrictMode } from 'react'
+import type * as ReactModule from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Tab, TabGroup } from '../../../../shared/tab-types'
+import type { TerminalTab } from '../../../../shared/terminal-tab-types'
+import type * as ParkedTabWatchersModule from './terminal-parked-tab-watchers'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const harness = vi.hoisted(() => ({
+  worktreeId: 'wt-exempt-flip',
+  syncCalls: 0,
+  slotRenders: 0,
+  slotMounts: 0,
+  observedParkedCounts: new Set<number>(),
+  watcherEntries: new Set<string>()
+}))
+
+vi.mock('../../store', async () => {
+  const { create } = await import('zustand')
+  const useAppStore = create(() => ({
+    activeGroupIdByWorktree: {} as Record<string, string | undefined>,
+    groupsByWorktree: {} as Record<string, TabGroup[]>,
+    pendingStartupByTabId: {} as Record<string, unknown>,
+    ptyIdsByTabId: {} as Record<string, string[]>,
+    runtimeStatusByEnvironmentId: new Map<string, unknown>(),
+    runtimePaneTitlesByTabId: {} as Record<string, Record<number, string>>,
+    settings: {} as Record<string, unknown>,
+    sleepingAgentSessionsByPaneKey: {} as Record<string, unknown>,
+    tabsByWorktree: {} as Record<string, TerminalTab[]>,
+    terminalLayoutsByTabId: {} as Record<string, unknown>,
+    unifiedTabsByWorktree: {} as Record<string, Tab[]>,
+    consumeSuppressedPtyExit: () => false,
+    focusGroup: () => {},
+    reconcileWorktreeTabModel: () => ({ renderableTabCount: 2 }),
+    setActiveWorktree: () => {}
+  }))
+  return { useAppStore }
+})
+
+vi.mock('../native-chat/use-native-chat-toggle-shortcut', () => ({
+  useNativeChatToggleShortcut: () => {}
+}))
+
+vi.mock('./terminal-parking-e2e-overrides', () => ({
+  getTerminalParkingPolicyOverrides: () => ({})
+}))
+
+vi.mock('@/lib/crash-breadcrumb-recorder', () => ({
+  recordRendererCrashBreadcrumb: () => {}
+}))
+
+// Why mount writes: a revealing pane publishes its title and registers its
+// layout leaf — the mount-lifecycle writes that feed the exemption's layout
+// key. The capability verdict itself must stay untouched by these.
+vi.mock('./TerminalOverlaySlot', async () => {
+  const { useEffect } = await vi.importActual<typeof ReactModule>('react')
+  const { useAppStore } = await import('../../store')
+  type SlotStoreState = {
+    tabsByWorktree: Record<string, TerminalTab[]>
+    terminalLayoutsByTabId: Record<string, unknown>
+  }
+  return {
+    TerminalOverlaySlot: ({ terminalTabId }: { terminalTabId: string }) => {
+      harness.slotRenders += 1
+      useEffect(() => {
+        harness.slotMounts += 1
+        if (harness.slotMounts > 400) {
+          throw new Error('harness runaway: slot remount storm exceeded 400 mounts')
+        }
+        ;(
+          useAppStore as unknown as {
+            setState: (update: (state: SlotStoreState) => Partial<SlotStoreState>) => void
+          }
+        ).setState((state) => ({
+          tabsByWorktree: {
+            ...state.tabsByWorktree,
+            [harness.worktreeId]: state.tabsByWorktree[harness.worktreeId].map((tab) =>
+              tab.id === terminalTabId ? { ...tab, title: `mounted-${harness.slotMounts}` } : tab
+            )
+          },
+          terminalLayoutsByTabId: { ...state.terminalLayoutsByTabId }
+        }))
+      }, [terminalTabId])
+      return null
+    }
+  }
+})
+
+vi.mock('./terminal-parked-tab-watchers', async () => {
+  const actual = await vi.importActual<typeof ParkedTabWatchersModule>(
+    './terminal-parked-tab-watchers'
+  )
+  return {
+    ...actual,
+    syncParkedTerminalTabWatchers: (args: {
+      tabs: readonly { id: string }[]
+      parkedTabIds: ReadonlySet<string>
+    }) => {
+      harness.syncCalls += 1
+      if (harness.syncCalls > 400) {
+        throw new Error('harness runaway: watcher sync exceeded 400 reconciliations')
+      }
+      harness.observedParkedCounts.add(args.parkedTabIds.size)
+      for (const tabId of Array.from(harness.watcherEntries)) {
+        if (!args.parkedTabIds.has(tabId)) {
+          harness.watcherEntries.delete(tabId)
+        }
+      }
+      for (const tab of args.tabs) {
+        if (args.parkedTabIds.has(tab.id)) {
+          harness.watcherEntries.add(tab.id)
+        }
+      }
+    },
+    disposeParkedTerminalWatchersForWorktree: () => {
+      harness.watcherEntries.clear()
+    }
+  }
+})
+
+import { useAppStore } from '../../store'
+import TerminalPaneOverlayLayer from './TerminalPaneOverlayLayer'
+import {
+  clearTerminalProviderSnapshotCapabilities,
+  synchronizeTerminalProviderSnapshotCapabilities
+} from '../terminal/terminal-provider-snapshot-capability'
+
+const TAB_IDS = ['tab-a', 'tab-b'] as const
+const GROUP_ID = 'group-a'
+const LEAF_IDS: Record<string, string> = {
+  'tab-a': '11111111-2222-4333-8444-55555555555a',
+  'tab-b': '11111111-2222-4333-8444-55555555555b'
+}
+
+const harnessStore = useAppStore as unknown as {
+  setState: (partial: Record<string, unknown>) => void
+  getState: () => { tabsByWorktree: Record<string, TerminalTab[]> }
+}
+
+function ptyIdFor(tabId: string): string {
+  return `${harness.worktreeId}@@session-${tabId}`
+}
+
+function terminalTab(id: string): TerminalTab {
+  return {
+    id,
+    worktreeId: harness.worktreeId,
+    ptyId: ptyIdFor(id),
+    title: id,
+    generation: 0
+  } as TerminalTab
+}
+
+function unifiedTerminalTab(id: string): Tab {
+  return {
+    id: `unified-${id}`,
+    entityId: id,
+    worktreeId: harness.worktreeId,
+    groupId: GROUP_ID,
+    contentType: 'terminal',
+    label: id,
+    customLabel: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0
+  }
+}
+
+// Why the store touch: capability answers land in module state, which the
+// exemption memo cannot subscribe to; the next store change reveals them —
+// modeled here as the routine title churn every live session produces.
+function touchStoreTitles(marker: string): void {
+  harnessStore.setState({
+    tabsByWorktree: {
+      [harness.worktreeId]: harnessStore
+        .getState()
+        .tabsByWorktree[harness.worktreeId].map((tab) => ({
+          ...tab,
+          title: `${tab.id}-${marker}`
+        }))
+    }
+  })
+}
+
+describe('force-park exemption flips under capability changes', () => {
+  let container: HTMLDivElement
+  let root: Root | undefined
+
+  beforeEach(() => {
+    clearTerminalProviderSnapshotCapabilities()
+    harness.syncCalls = 0
+    harness.slotRenders = 0
+    harness.slotMounts = 0
+    harness.observedParkedCounts.clear()
+    harness.watcherEntries.clear()
+    harnessStore.setState({
+      activeGroupIdByWorktree: { [harness.worktreeId]: GROUP_ID },
+      groupsByWorktree: {
+        [harness.worktreeId]: [
+          {
+            id: GROUP_ID,
+            worktreeId: harness.worktreeId,
+            activeTabId: `unified-${TAB_IDS[0]}`,
+            tabOrder: TAB_IDS.map((id) => `unified-${id}`),
+            recentTabIds: [`unified-${TAB_IDS[0]}`]
+          }
+        ]
+      },
+      tabsByWorktree: { [harness.worktreeId]: TAB_IDS.map(terminalTab) },
+      unifiedTabsByWorktree: { [harness.worktreeId]: TAB_IDS.map(unifiedTerminalTab) },
+      terminalLayoutsByTabId: Object.fromEntries(
+        TAB_IDS.map((id) => [
+          id,
+          {
+            root: { type: 'leaf', leafId: LEAF_IDS[id] },
+            activeLeafId: LEAF_IDS[id],
+            ptyIdsByLeafId: { [LEAF_IDS[id]]: ptyIdFor(id) }
+          }
+        ])
+      )
+    })
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    try {
+      act(() => root?.unmount())
+    } catch {
+      // A failed commit leaves no mounted tree to clean up.
+    }
+    root = undefined
+    container.remove()
+    clearTerminalProviderSnapshotCapabilities()
+  })
+
+  it('settles every capability flip without approaching the update-depth limit', async () => {
+    root = createRoot(container)
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    let thrown: unknown = null
+    try {
+      act(() => {
+        root!.render(
+          <StrictMode>
+            <TerminalPaneOverlayLayer
+              worktreeId={harness.worktreeId}
+              worktreePath="exempt-flip"
+              isWorktreeActive={false}
+              coldParkTerminalPanes={true}
+              isForceParked={true}
+            />
+          </StrictMode>
+        )
+      })
+
+      const allPtyIds = TAB_IDS.map(ptyIdFor)
+      for (let flip = 0; flip < 6; flip += 1) {
+        const syncCallsBefore = harness.syncCalls
+        // eslint-disable-next-line no-await-in-loop -- flips are sequential by design
+        await act(async () => {
+          if (flip % 2 === 0) {
+            // Daemon answered: every pty has an authoritative snapshot.
+            await synchronizeTerminalProviderSnapshotCapabilities(
+              [...allPtyIds],
+              async (ids) => ids.map((id) => ({ id, authoritative: true })),
+              1_000 + flip
+            )
+          } else {
+            // Daemon restart: verdicts reset to unknown (exempt again).
+            clearTerminalProviderSnapshotCapabilities()
+          }
+          touchStoreTitles(`flip-${flip}`)
+        })
+        expect(harness.syncCalls - syncCallsBefore).toBeLessThan(20)
+      }
+    } catch (error) {
+      thrown = error
+    }
+    consoleError.mockRestore()
+
+    expect(thrown).toBeNull()
+    // Non-vacuous: the flips genuinely moved the rendered verdict both ways —
+    // all-exempt (0 parked) and all-evictable (2 parked) were both committed.
+    expect(harness.observedParkedCounts.has(0)).toBe(true)
+    expect(harness.observedParkedCounts.has(TAB_IDS.length)).toBe(true)
+    expect(harness.slotMounts).toBeGreaterThan(0)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-hidden-worktree-retention.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-hidden-worktree-retention.ts
@@ -1,9 +1,9 @@
 import { isRemoteRuntimePtyId } from '@/runtime/runtime-terminal-inspection'
+import { PTY_SESSION_ID_SEPARATOR } from '../../../../shared/pty-session-id-format'
 import { parseAppSshPtyId } from '../../../../shared/ssh-pty-id'
 import { terminalProviderHasAuthoritativeSnapshot } from '../terminal/terminal-provider-snapshot-capability'
 import {
   TERMINAL_WORKTREE_COLD_PARK_DELAY_MS,
-  isSnapshotBackedTerminalPty,
   selectIdsBeyondHotRetain,
   type ColdParkRetainCandidate,
   type TerminalColdParkPolicyOverrides
@@ -52,13 +52,69 @@ export function isEvictionExemptTerminalPty(
   ptyId: string | null | undefined,
   worktreeId: string
 ): boolean {
+  return classifyEvictionExemptTerminalPty(ptyId, worktreeId) !== null
+}
+
+export type EvictionExemptTerminalPtyRoute = 'fail-open' | 'foreign-worktree' | 'capability-unknown'
+
+// Why routes: an all-exempt force-park frees nothing, and only per-route
+// counts in the field can say whether daemon fail-open ids or unresolved
+// snapshot capability dominates that degenerate case.
+export function classifyEvictionExemptTerminalPty(
+  ptyId: string | null | undefined,
+  worktreeId: string
+): EvictionExemptTerminalPtyRoute | null {
   if (!ptyId || isRemoteRuntimePtyId(ptyId) || parseAppSshPtyId(ptyId)) {
-    return false
+    return null
   }
-  return (
-    !isSnapshotBackedTerminalPty(ptyId, worktreeId) ||
-    !terminalProviderHasAuthoritativeSnapshot(ptyId)
-  )
+  const separatorIdx = ptyId.lastIndexOf(PTY_SESSION_ID_SEPARATOR)
+  if (separatorIdx === -1) {
+    return 'fail-open'
+  }
+  if (ptyId.slice(0, separatorIdx) !== worktreeId) {
+    return 'foreign-worktree'
+  }
+  return terminalProviderHasAuthoritativeSnapshot(ptyId) ? null : 'capability-unknown'
+}
+
+export type EvictionExemptRouteCounts = {
+  failOpen: number
+  foreignWorktree: number
+  capabilityUnknown: number
+  /** Tab-level pty classifies clean, so the exemption came from a split pane's pty. */
+  splitPane: number
+}
+
+export function countEvictionExemptTabRoutes(
+  tabs: readonly Pick<TerminalTab, 'ptyId'>[],
+  worktreeId: string
+): EvictionExemptRouteCounts {
+  const counts: EvictionExemptRouteCounts = {
+    failOpen: 0,
+    foreignWorktree: 0,
+    capabilityUnknown: 0,
+    splitPane: 0
+  }
+  for (const tab of tabs) {
+    switch (classifyEvictionExemptTerminalPty(tab.ptyId, worktreeId)) {
+      case 'fail-open':
+        counts.failOpen += 1
+        break
+      case 'foreign-worktree':
+        counts.foreignWorktree += 1
+        break
+      case 'capability-unknown':
+        counts.capabilityUnknown += 1
+        break
+      default:
+        counts.splitPane += 1
+    }
+  }
+  return counts
+}
+
+export function formatEvictionExemptRouteCounts(counts: EvictionExemptRouteCounts): string {
+  return `routes=fail-open:${counts.failOpen},foreign:${counts.foreignWorktree},capability:${counts.capabilityUnknown},split-pane:${counts.splitPane}`
 }
 
 export type TerminalWorktreeRetentionCandidate = {

--- a/src/renderer/src/components/terminal-pane/terminal-hidden-worktree-retention.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-hidden-worktree-retention.ts
@@ -106,8 +106,9 @@ export function countEvictionExemptTabRoutes(
       case 'capability-unknown':
         counts.capabilityUnknown += 1
         break
-      default:
+      case null:
         counts.splitPane += 1
+        break
     }
   }
   return counts

--- a/src/renderer/src/components/terminal-pane/terminal-retention-exempt-growth.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-retention-exempt-growth.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Gate: the hidden-worktree retention budget must bound mounted tabs once the
+ * daemon recovers.
+ *
+ * Models the field shape: a capability outage settles every local pty
+ * unknown, the daemon then recovers, and the session keeps accumulating
+ * hidden worktrees. If the settled verdicts are permanent, every tab stays
+ * eviction-exempt, force-park frees nothing, and retained mounted tabs grow
+ * linearly with visited worktrees — unbounded mounts by design.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { PTY_SESSION_ID_SEPARATOR } from '../../../../shared/pty-session-id-format'
+import {
+  TERMINAL_HIDDEN_WORKTREE_RETENTION_LIMIT,
+  isEvictionExemptTerminalPty,
+  selectForceParkEvictableTabIds,
+  selectRetentionForceParkedTerminalWorktrees
+} from './terminal-hidden-worktree-retention'
+import {
+  clearTerminalProviderSnapshotCapabilities,
+  synchronizeTerminalProviderSnapshotCapabilities
+} from '../terminal/terminal-provider-snapshot-capability'
+
+const WORKTREE_COUNT = 8
+const TABS_PER_WORKTREE = 2
+
+type GrowthTab = { id: string; ptyId: string }
+
+function worktreeId(index: number): string {
+  return `wt-growth-${index}`
+}
+
+function worktreeTabs(index: number): GrowthTab[] {
+  return Array.from({ length: TABS_PER_WORKTREE }, (_, tabIndex) => ({
+    id: `tab-${index}-${tabIndex}`,
+    ptyId: `${worktreeId(index)}${PTY_SESSION_ID_SEPARATOR}session-${tabIndex}`
+  }))
+}
+
+function allPtyIds(): string[] {
+  const ids: string[] = []
+  for (let index = 0; index < WORKTREE_COUNT; index += 1) {
+    for (const tab of worktreeTabs(index)) {
+      ids.push(tab.ptyId)
+    }
+  }
+  return ids
+}
+
+async function settleCapabilityOutage(startMs: number): Promise<number> {
+  const failingResolver = vi.fn(async () => {
+    throw new Error('daemon unavailable')
+  })
+  const livePtyIds = allPtyIds()
+  let nowMs = startMs
+  for (let attempt = 0; attempt < 12; attempt += 1) {
+    const retryDelayMs = await synchronizeTerminalProviderSnapshotCapabilities(
+      livePtyIds,
+      failingResolver,
+      nowMs
+    )
+    if (retryDelayMs === null) {
+      break
+    }
+    nowMs += retryDelayMs + 1
+  }
+  return nowMs
+}
+
+describe('hidden-worktree retention with recovered capability', () => {
+  beforeEach(() => clearTerminalProviderSnapshotCapabilities())
+
+  it('bounds retained mounted tabs at the retention limit as hidden worktrees grow', async () => {
+    const settledAtMs = await settleCapabilityOutage(1_000)
+
+    // Daemon recovered well before the retention deadlines fire.
+    const healthyResolver = vi.fn(async (ids: string[]) =>
+      ids.map((id) => ({ id, authoritative: true }))
+    )
+    const recoveredAtMs = settledAtMs + 10 * 60_000
+    await synchronizeTerminalProviderSnapshotCapabilities(
+      allPtyIds(),
+      healthyResolver,
+      recoveredAtMs
+    )
+    await synchronizeTerminalProviderSnapshotCapabilities(
+      allPtyIds(),
+      healthyResolver,
+      recoveredAtMs + 10 * 60_000
+    )
+
+    // Every worktree hidden for 20+ minutes: all are past the 15-minute TTL.
+    const nowMs = recoveredAtMs + 30 * 60_000
+    const hiddenSinceMs = nowMs - 20 * 60_000
+    const forceParked = selectRetentionForceParkedTerminalWorktrees({
+      worktrees: Array.from({ length: WORKTREE_COUNT }, (_, index) => ({
+        worktreeId: worktreeId(index),
+        hiddenSinceMs,
+        isVisible: false,
+        shouldMeasureHiddenWorktree: false,
+        hasActivityTerminalPortal: false,
+        ordinaryParkingCovers: false,
+        hasPendingSpawnWork: false
+      })),
+      parkingEnabled: true,
+      retentionBudgetEnabled: true,
+      nowMs
+    })
+    expect(forceParked.size).toBe(WORKTREE_COUNT)
+
+    let retainedMountedTabs = 0
+    for (let index = 0; index < WORKTREE_COUNT; index += 1) {
+      const tabs = worktreeTabs(index)
+      if (!forceParked.has(worktreeId(index))) {
+        retainedMountedTabs += tabs.length
+        continue
+      }
+      const evictable = new Set(
+        selectForceParkEvictableTabIds(tabs, (tab) =>
+          isEvictionExemptTerminalPty(tab.ptyId, worktreeId(index))
+        )
+      )
+      retainedMountedTabs += tabs.length - evictable.size
+    }
+
+    // The invariant a bounded system must hold; permanent settle-false keeps
+    // every tab exempt and retained grows linearly with visited worktrees.
+    expect(retainedMountedTabs).toBeLessThanOrEqual(
+      TERMINAL_HIDDEN_WORKTREE_RETENTION_LIMIT * TABS_PER_WORKTREE
+    )
+  })
+})

--- a/src/renderer/src/components/terminal/terminal-provider-snapshot-capability-resettlement.test.ts
+++ b/src/renderer/src/components/terminal/terminal-provider-snapshot-capability-resettlement.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Gate for the capability re-settlement fix.
+ *
+ * A daemon that cannot answer within the retry budget must not convert its
+ * ptys into permanently eviction-exempt tabs: once a healthy resolver exists,
+ * capability synchronization must consult it again and the exemption must
+ * clear. During the outage, unknown must stay exempt (pane stays mounted).
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { PTY_SESSION_ID_SEPARATOR } from '../../../../shared/pty-session-id-format'
+import {
+  classifyEvictionExemptTerminalPty,
+  isEvictionExemptTerminalPty
+} from '../terminal-pane/terminal-hidden-worktree-retention'
+import {
+  clearTerminalProviderSnapshotCapabilities,
+  synchronizeTerminalProviderSnapshotCapabilities,
+  terminalProviderHasAuthoritativeSnapshot
+} from './terminal-provider-snapshot-capability'
+
+const WORKTREE_ID = 'wt-resettlement'
+const PTY_ID = `${WORKTREE_ID}${PTY_SESSION_ID_SEPARATOR}session-1`
+
+/** Drives synchronize past each retry deadline until the budget is exhausted. */
+async function exhaustRetryBudget(
+  resolver: (ids: string[]) => Promise<{ id: string; authoritative: boolean | null }[]>,
+  startMs: number
+): Promise<number> {
+  const livePtyIds = [PTY_ID]
+  let nowMs = startMs
+  // 8 attempts across the 1/2/4/8/16/30/30s ladder, plus slack iterations.
+  for (let attempt = 0; attempt < 12; attempt += 1) {
+    const retryDelayMs = await synchronizeTerminalProviderSnapshotCapabilities(
+      livePtyIds,
+      resolver,
+      nowMs
+    )
+    if (retryDelayMs === null) {
+      break
+    }
+    nowMs += retryDelayMs + 1
+  }
+  return nowMs
+}
+
+describe('terminal provider snapshot capability re-settlement', () => {
+  beforeEach(() => clearTerminalProviderSnapshotCapabilities())
+
+  it('keeps an unknown-capability pty exempt during the outage (safety)', async () => {
+    const failingResolver = vi.fn(async () => {
+      throw new Error('daemon unavailable')
+    })
+    await synchronizeTerminalProviderSnapshotCapabilities([PTY_ID], failingResolver, 1_000)
+
+    expect(failingResolver).toHaveBeenCalled()
+    expect(terminalProviderHasAuthoritativeSnapshot(PTY_ID)).toBe(false)
+    expect(isEvictionExemptTerminalPty(PTY_ID, WORKTREE_ID)).toBe(true)
+  })
+
+  it('re-consults a recovered resolver after the retry budget and clears the exemption', async () => {
+    const failingResolver = vi.fn(async () => {
+      throw new Error('daemon unavailable')
+    })
+    const settledAtMs = await exhaustRetryBudget(failingResolver, 1_000)
+    // The outage itself must leave the pty exempt.
+    expect(isEvictionExemptTerminalPty(PTY_ID, WORKTREE_ID)).toBe(true)
+
+    const healthyResolver = vi.fn(async (ids: string[]) =>
+      ids.map((id) => ({ id, authoritative: true }))
+    )
+    // Daemon recovered; give the slow re-ask cadence generous room (a fresh
+    // pty-set identity models the session's ordinary tab churn too).
+    const recoveredAtMs = settledAtMs + 10 * 60_000
+    await synchronizeTerminalProviderSnapshotCapabilities([PTY_ID], healthyResolver, recoveredAtMs)
+    const secondPassMs = recoveredAtMs + 10 * 60_000
+    await synchronizeTerminalProviderSnapshotCapabilities([PTY_ID], healthyResolver, secondPassMs)
+
+    expect(healthyResolver).toHaveBeenCalled()
+    expect(terminalProviderHasAuthoritativeSnapshot(PTY_ID)).toBe(true)
+    expect(isEvictionExemptTerminalPty(PTY_ID, WORKTREE_ID)).toBe(false)
+  })
+
+  it('classifies exemption routes in parity with the predicate', async () => {
+    const failOpenId = 'no-separator-daemon-fail-open'
+    const foreignId = `other-worktree${PTY_SESSION_ID_SEPARATOR}session-9`
+    const sshId = 'ssh:host@@pty-1'
+
+    expect(classifyEvictionExemptTerminalPty(failOpenId, WORKTREE_ID)).toBe('fail-open')
+    expect(classifyEvictionExemptTerminalPty(foreignId, WORKTREE_ID)).toBe('foreign-worktree')
+    expect(classifyEvictionExemptTerminalPty(PTY_ID, WORKTREE_ID)).toBe('capability-unknown')
+    expect(classifyEvictionExemptTerminalPty(sshId, WORKTREE_ID)).toBeNull()
+    expect(classifyEvictionExemptTerminalPty(null, WORKTREE_ID)).toBeNull()
+
+    const healthyResolver = vi.fn(async (ids: string[]) =>
+      ids.map((id) => ({ id, authoritative: true }))
+    )
+    await synchronizeTerminalProviderSnapshotCapabilities([PTY_ID], healthyResolver, 1_000)
+    expect(classifyEvictionExemptTerminalPty(PTY_ID, WORKTREE_ID)).toBeNull()
+
+    for (const id of [failOpenId, foreignId, sshId, PTY_ID, null]) {
+      expect(isEvictionExemptTerminalPty(id, WORKTREE_ID)).toBe(
+        classifyEvictionExemptTerminalPty(id, WORKTREE_ID) !== null
+      )
+    }
+  })
+})

--- a/src/renderer/src/components/terminal/terminal-provider-snapshot-capability-resettlement.test.ts
+++ b/src/renderer/src/components/terminal/terminal-provider-snapshot-capability-resettlement.test.ts
@@ -10,6 +10,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { PTY_SESSION_ID_SEPARATOR } from '../../../../shared/pty-session-id-format'
 import {
   classifyEvictionExemptTerminalPty,
+  countEvictionExemptTabRoutes,
+  formatEvictionExemptRouteCounts,
   isEvictionExemptTerminalPty
 } from '../terminal-pane/terminal-hidden-worktree-retention'
 import {
@@ -102,5 +104,29 @@ describe('terminal provider snapshot capability re-settlement', () => {
         classifyEvictionExemptTerminalPty(id, WORKTREE_ID) !== null
       )
     }
+  })
+
+  // Why: these counts land in the force-park breadcrumb, so a mis-bucketed
+  // route would misdirect the field triage the breadcrumb exists for.
+  it('buckets route counts per classification for the force-park breadcrumb', () => {
+    const counts = countEvictionExemptTabRoutes(
+      [
+        { ptyId: 'no-separator-daemon-fail-open' },
+        { ptyId: `other-worktree${PTY_SESSION_ID_SEPARATOR}session-9` },
+        { ptyId: PTY_ID },
+        { ptyId: null }
+      ],
+      WORKTREE_ID
+    )
+
+    expect(counts).toEqual({
+      failOpen: 1,
+      foreignWorktree: 1,
+      capabilityUnknown: 1,
+      splitPane: 1
+    })
+    expect(formatEvictionExemptRouteCounts(counts)).toBe(
+      'routes=fail-open:1,foreign:1,capability:1,split-pane:1'
+    )
   })
 })

--- a/src/renderer/src/components/terminal/terminal-provider-snapshot-capability.test.ts
+++ b/src/renderer/src/components/terminal/terminal-provider-snapshot-capability.test.ts
@@ -165,14 +165,16 @@ describe('terminal provider snapshot capabilities', () => {
     expect(terminalProviderHasAuthoritativeSnapshot('current-pty')).toBe(true)
   })
 
-  it('stops polling for a PTY whose route never resolves', async () => {
-    // Bounded retries prevent lifelong capability polling for vanished routes.
+  it('decays polling to a slow cadence for a PTY whose route never resolves', async () => {
+    // Why not a permanent settle: the eviction-exemption path inherits the
+    // verdict for life, so an unresolvable route stays exempt but re-askable.
     const resolve = vi.fn(async () => [{ id: 'gone-pty', authoritative: null }])
     const backoffSchedule = [1_000, 2_000, 4_000, 8_000, 16_000, 30_000, 30_000]
 
     let nowMs = 1_000
     await synchronizeTerminalProviderSnapshotCapabilities(['gone-pty'], resolve, nowMs)
     for (const delayMs of backoffSchedule) {
+      // Just before the deadline: no extra consult.
       await synchronizeTerminalProviderSnapshotCapabilities(
         ['gone-pty'],
         resolve,
@@ -181,22 +183,26 @@ describe('terminal provider snapshot capabilities', () => {
       nowMs += delayMs
       await synchronizeTerminalProviderSnapshotCapabilities(['gone-pty'], resolve, nowMs)
     }
-    const settledCallCount = resolve.mock.calls.length
+    const ladderCallCount = resolve.mock.calls.length
+    expect(ladderCallCount).toBe(backoffSchedule.length + 1)
 
-    for (let index = 1; index <= 1_000; index += 1) {
+    // Inside the slow window: still no consult.
+    await synchronizeTerminalProviderSnapshotCapabilities(['gone-pty'], resolve, nowMs + 60_000)
+    expect(resolve).toHaveBeenCalledTimes(ladderCallCount)
+
+    // Bounded slow cadence: one consult per elapsed slow window, not per call.
+    for (let index = 1; index <= 12; index += 1) {
       await synchronizeTerminalProviderSnapshotCapabilities(
         ['gone-pty'],
         resolve,
-        nowMs + index * 60_000
+        nowMs + index * 5 * 60_000
       )
     }
-
-    expect(settledCallCount).toBe(backoffSchedule.length + 1)
-    expect(resolve).toHaveBeenCalledTimes(settledCallCount)
+    expect(resolve.mock.calls.length).toBe(ladderCallCount + 12)
     expect(terminalProviderHasAuthoritativeSnapshot('gone-pty')).toBe(false)
   })
 
-  it('stops rescheduling once an unresolvable PTY has settled', async () => {
+  it('keeps rescheduling at the slow cadence once an unresolvable PTY has decayed', async () => {
     const resolve = vi.fn(async () => [{ id: 'gone-pty', authoritative: null }])
 
     let nowMs = 1_000
@@ -210,7 +216,9 @@ describe('terminal provider snapshot capabilities', () => {
       )
     }
 
-    expect(retryDelayMs).toBeNull()
+    // Why non-null: the slow re-ask keeps one timer alive so a recovered
+    // daemon is consulted again without any event wiring.
+    expect(retryDelayMs).toBe(5 * 60_000)
   })
 
   it('re-probes an unknown PTY from scratch after it closes and a new one appears', async () => {

--- a/src/renderer/src/components/terminal/terminal-provider-snapshot-capability.test.ts
+++ b/src/renderer/src/components/terminal/terminal-provider-snapshot-capability.test.ts
@@ -250,13 +250,43 @@ describe('terminal provider snapshot capabilities', () => {
     expect(retryDelayMs).toBe(5 * 60_000)
   })
 
+  // Why same-reference: the hook's chain re-fires with the SAME memoized id
+  // array, so the unchanged-set early-out must yield to a due unknown retry —
+  // an unconditional same-identity bail would kill the chain after one backoff.
+  it('re-consults a due unknown on an identical live-set identity', async () => {
+    const livePtyIds = ['pty-1']
+    const resolve = vi
+      .fn()
+      .mockResolvedValueOnce([{ id: 'pty-1', authoritative: null }])
+      .mockResolvedValueOnce([{ id: 'pty-1', authoritative: true }])
+
+    await synchronizeTerminalProviderSnapshotCapabilities(livePtyIds, resolve, 1_000)
+    const retryDelayMs = await synchronizeTerminalProviderSnapshotCapabilities(
+      livePtyIds,
+      resolve,
+      2_000
+    )
+
+    expect(resolve).toHaveBeenCalledTimes(2)
+    expect(retryDelayMs).toBeNull()
+    expect(terminalProviderHasAuthoritativeSnapshot('pty-1')).toBe(true)
+  })
+
   it('re-probes an unknown PTY from scratch after it closes and a new one appears', async () => {
     const resolve = vi.fn(async () => [{ id: 'gone-pty', authoritative: null }])
 
     await synchronizeTerminalProviderSnapshotCapabilities(['gone-pty'], resolve, 1_000)
-    await synchronizeTerminalProviderSnapshotCapabilities([], resolve, 2_000)
+    // Why null: pruning the closed pty's retry state must also stop the timer
+    // chain — a leaked entry would keep a phantom re-ask timer for the session.
+    await expect(
+      synchronizeTerminalProviderSnapshotCapabilities([], resolve, 2_000)
+    ).resolves.toBeNull()
     await synchronizeTerminalProviderSnapshotCapabilities(['gone-pty'], resolve, 2_001)
-
     expect(resolve).toHaveBeenCalledTimes(2)
+
+    // Why a third consult: the reappeared id restarts the 1s ladder — leaked
+    // attempts would resume the decayed cadence for a brand-new pty.
+    await synchronizeTerminalProviderSnapshotCapabilities(['gone-pty'], resolve, 3_001)
+    expect(resolve).toHaveBeenCalledTimes(3)
   })
 })

--- a/src/renderer/src/components/terminal/terminal-provider-snapshot-capability.test.ts
+++ b/src/renderer/src/components/terminal/terminal-provider-snapshot-capability.test.ts
@@ -165,6 +165,35 @@ describe('terminal provider snapshot capabilities', () => {
     expect(terminalProviderHasAuthoritativeSnapshot('current-pty')).toBe(true)
   })
 
+  // Why 0, not null: null ends the caller's timer chain, but a superseding
+  // startup refresh ignores its own return value — if it leaves unknowns
+  // behind, the cancelled chain is the only re-ask scheduler left alive.
+  it('asks a superseded pass to re-check instead of ending its timer chain', async () => {
+    let resolveStale!: (value: { id: string; authoritative: boolean | null }[]) => void
+    const stale = new Promise<{ id: string; authoritative: boolean | null }[]>((resolve) => {
+      resolveStale = resolve
+    })
+    const first = synchronizeTerminalProviderSnapshotCapabilities(['pty-1'], () => stale, 1_000)
+    await synchronizeTerminalProviderSnapshotCapabilities(['pty-1', 'pty-2'], async () => [], 1_000)
+
+    resolveStale([{ id: 'pty-1', authoritative: true }])
+
+    await expect(first).resolves.toBe(0)
+  })
+
+  it('asks a superseded pass whose resolver rejected to re-check as well', async () => {
+    let rejectStale!: (reason: Error) => void
+    const stale = new Promise<{ id: string; authoritative: boolean | null }[]>((_, reject) => {
+      rejectStale = reject
+    })
+    const first = synchronizeTerminalProviderSnapshotCapabilities(['pty-1'], () => stale, 1_000)
+    await synchronizeTerminalProviderSnapshotCapabilities(['pty-1', 'pty-2'], async () => [], 1_000)
+
+    rejectStale(new Error('daemon unavailable'))
+
+    await expect(first).resolves.toBe(0)
+  })
+
   it('decays polling to a slow cadence for a PTY whose route never resolves', async () => {
     // Why not a permanent settle: the eviction-exemption path inherits the
     // verdict for life, so an unresolvable route stays exempt but re-askable.

--- a/src/renderer/src/components/terminal/terminal-provider-snapshot-capability.ts
+++ b/src/renderer/src/components/terminal/terminal-provider-snapshot-capability.ts
@@ -152,7 +152,11 @@ export async function synchronizeTerminalProviderSnapshotCapabilities(
       resolved = await resolveSnapshotCapabilityBatch(resolve, batch)
     } catch {
       if (generation !== synchronizationGeneration) {
-        return null
+        // Why 0, not null: null ends a caller's timer chain, but the winning
+        // pass may leave unknowns behind with nobody scheduled to re-ask (the
+        // startup refresh ignores its return value). Re-checking immediately
+        // is cheap — the early-outs above collapse it when nothing is pending.
+        return 0
       }
       // Why: unknown capability must keep the pane mounted. Do not cache the
       // failure as supported; back off before retrying daemon startup.
@@ -162,7 +166,9 @@ export async function synchronizeTerminalProviderSnapshotCapabilities(
       continue
     }
     if (generation !== synchronizationGeneration) {
-      return null
+      // Why 0: see the catch above — a superseded pass must keep its caller's
+      // timer chain alive, or the 5-minute re-ask dies with it.
+      return 0
     }
     if (!resolved) {
       for (const id of missing.slice(offset)) {

--- a/src/renderer/src/components/terminal/terminal-provider-snapshot-capability.ts
+++ b/src/renderer/src/components/terminal/terminal-provider-snapshot-capability.ts
@@ -15,8 +15,13 @@ const unknownCapabilityRetryAtByPtyId = new Map<string, number>()
 const unknownCapabilityAttemptsByPtyId = new Map<string, number>()
 const UNKNOWN_CAPABILITY_RETRY_MS = 1_000
 const UNKNOWN_CAPABILITY_MAX_RETRY_MS = 30_000
-/** 1/2/4/8/16/30/30 s — ~91 s of daemon-startup grace, then settle conservatively. */
+/** 1/2/4/8/16/30/30 s — ~91 s of daemon-startup grace, then a slow re-ask. */
 const UNKNOWN_CAPABILITY_MAX_ATTEMPTS = 8
+// Why re-askable: a permanent settle turned a slow daemon start into
+// session-long eviction exemption for every local pty — force-park could free
+// nothing until app restart. Unknown stays exempt (pane stays mounted), but a
+// recovered daemon is consulted again within one slow cycle.
+const SETTLED_UNKNOWN_REASK_MS = 5 * 60_000
 const CAPABILITY_RESOLUTION_TIMEOUT_MS = 1_000
 let lastSynchronizedLivePtyIds: readonly string[] | null = null
 let earliestUnknownCapabilityRetryAtMs = Number.POSITIVE_INFINITY
@@ -54,20 +59,23 @@ function refreshEarliestUnknownCapabilityRetry(): void {
   }
 }
 
-// Unknown routes settle eager after bounded retries to avoid lifelong capability polling.
+// Unknown routes decay to a slow cadence after the startup ladder — never a
+// permanent verdict, which the eviction-exemption path would inherit for life.
 function backOffUnknownCapability(ptyId: string, nowMs: number): void {
-  const attempts = (unknownCapabilityAttemptsByPtyId.get(ptyId) ?? 0) + 1
-  if (attempts >= UNKNOWN_CAPABILITY_MAX_ATTEMPTS) {
-    authoritativeSnapshotByPtyId.set(ptyId, false)
-    unknownCapabilityAttemptsByPtyId.delete(ptyId)
-    unknownCapabilityRetryAtByPtyId.delete(ptyId)
-    return
-  }
+  const attempts = Math.min(
+    (unknownCapabilityAttemptsByPtyId.get(ptyId) ?? 0) + 1,
+    UNKNOWN_CAPABILITY_MAX_ATTEMPTS
+  )
   unknownCapabilityAttemptsByPtyId.set(ptyId, attempts)
   unknownCapabilityRetryAtByPtyId.set(
     ptyId,
     nowMs +
-      Math.min(UNKNOWN_CAPABILITY_RETRY_MS * 2 ** (attempts - 1), UNKNOWN_CAPABILITY_MAX_RETRY_MS)
+      (attempts >= UNKNOWN_CAPABILITY_MAX_ATTEMPTS
+        ? SETTLED_UNKNOWN_REASK_MS
+        : Math.min(
+            UNKNOWN_CAPABILITY_RETRY_MS * 2 ** (attempts - 1),
+            UNKNOWN_CAPABILITY_MAX_RETRY_MS
+          ))
   )
 }
 

--- a/src/renderer/src/components/terminal/terminal-provider-snapshot-capability.ts
+++ b/src/renderer/src/components/terminal/terminal-provider-snapshot-capability.ts
@@ -26,6 +26,24 @@ const CAPABILITY_RESOLUTION_TIMEOUT_MS = 1_000
 let lastSynchronizedLivePtyIds: readonly string[] | null = null
 let earliestUnknownCapabilityRetryAtMs = Number.POSITIVE_INFINITY
 let synchronizationGeneration = 0
+let capabilityRevision = 0
+const capabilityRevisionListeners = new Set<() => void>()
+
+function publishCapabilityChange(): void {
+  capabilityRevision += 1
+  for (const listener of capabilityRevisionListeners) {
+    listener()
+  }
+}
+
+export function subscribeTerminalProviderSnapshotCapability(listener: () => void): () => void {
+  capabilityRevisionListeners.add(listener)
+  return () => capabilityRevisionListeners.delete(listener)
+}
+
+export function getTerminalProviderSnapshotCapabilityRevision(): number {
+  return capabilityRevision
+}
 
 export function collectTerminalProviderSnapshotPtyIds(
   state: SnapshotCapabilityBindingState
@@ -120,8 +138,10 @@ export async function synchronizeTerminalProviderSnapshotCapabilities(
   const generation = ++synchronizationGeneration
   lastSynchronizedLivePtyIds = livePtyIds
   const live = new Set(livePtyIds.filter((id) => id.length > 0))
+  let capabilityChanged = false
   for (const cachedId of authoritativeSnapshotByPtyId.keys()) {
     if (!live.has(cachedId)) {
+      capabilityChanged ||= authoritativeSnapshotByPtyId.get(cachedId) === true
       authoritativeSnapshotByPtyId.delete(cachedId)
     }
   }
@@ -143,6 +163,9 @@ export async function synchronizeTerminalProviderSnapshotCapabilities(
       backOffUnknownCapability(id, nowMs)
     }
     refreshEarliestUnknownCapabilityRetry()
+    if (capabilityChanged) {
+      publishCapabilityChange()
+    }
     return unknownCapabilityRetryDelayMs(nowMs)
   }
   for (let offset = 0; offset < missing.length; offset += 512) {
@@ -156,6 +179,9 @@ export async function synchronizeTerminalProviderSnapshotCapabilities(
         // pass may leave unknowns behind with nobody scheduled to re-ask (the
         // startup refresh ignores its return value). Re-checking immediately
         // is cheap — the early-outs above collapse it when nothing is pending.
+        if (capabilityChanged) {
+          publishCapabilityChange()
+        }
         return 0
       }
       // Why: unknown capability must keep the pane mounted. Do not cache the
@@ -168,6 +194,9 @@ export async function synchronizeTerminalProviderSnapshotCapabilities(
     if (generation !== synchronizationGeneration) {
       // Why 0: see the catch above — a superseded pass must keep its caller's
       // timer chain alive, or the 5-minute re-ask dies with it.
+      if (capabilityChanged) {
+        publishCapabilityChange()
+      }
       return 0
     }
     if (!resolved) {
@@ -180,6 +209,8 @@ export async function synchronizeTerminalProviderSnapshotCapabilities(
     for (const id of batch) {
       const authoritative = resolvedById.get(id)
       if (typeof authoritative === 'boolean') {
+        capabilityChanged ||=
+          (authoritativeSnapshotByPtyId.get(id) === true) !== (authoritative === true)
         authoritativeSnapshotByPtyId.set(id, authoritative)
         unknownCapabilityRetryAtByPtyId.delete(id)
         unknownCapabilityAttemptsByPtyId.delete(id)
@@ -189,6 +220,9 @@ export async function synchronizeTerminalProviderSnapshotCapabilities(
     }
   }
   refreshEarliestUnknownCapabilityRetry()
+  if (capabilityChanged) {
+    publishCapabilityChange()
+  }
   return unknownCapabilityRetryDelayMs(observedAtMs === undefined ? Date.now() : nowMs)
 }
 
@@ -197,12 +231,17 @@ export async function refreshTerminalProviderSnapshotCapabilities(
   resolveCapabilities?: SnapshotCapabilityResolver
 ): Promise<number | null> {
   lastSynchronizedLivePtyIds = null
+  let capabilityChanged = false
   for (const id of livePtyIds) {
+    capabilityChanged ||= authoritativeSnapshotByPtyId.get(id) === true
     authoritativeSnapshotByPtyId.delete(id)
     unknownCapabilityRetryAtByPtyId.delete(id)
     unknownCapabilityAttemptsByPtyId.delete(id)
   }
   refreshEarliestUnknownCapabilityRetry()
+  if (capabilityChanged) {
+    publishCapabilityChange()
+  }
   return synchronizeTerminalProviderSnapshotCapabilities(livePtyIds, resolveCapabilities)
 }
 
@@ -229,10 +268,16 @@ export function terminalProviderHasAuthoritativeSnapshot(ptyId: string): boolean
 }
 
 export function clearTerminalProviderSnapshotCapabilities(): void {
+  const capabilityChanged = [...authoritativeSnapshotByPtyId.values()].some(
+    (authoritative) => authoritative
+  )
   authoritativeSnapshotByPtyId.clear()
   unknownCapabilityRetryAtByPtyId.clear()
   unknownCapabilityAttemptsByPtyId.clear()
   lastSynchronizedLivePtyIds = null
   earliestUnknownCapabilityRetryAtMs = Number.POSITIVE_INFINITY
   synchronizationGeneration += 1
+  if (capabilityChanged) {
+    publishCapabilityChange()
+  }
 }

--- a/src/renderer/src/components/terminal/use-terminal-provider-snapshot-capability.test.tsx
+++ b/src/renderer/src/components/terminal/use-terminal-provider-snapshot-capability.test.tsx
@@ -34,6 +34,10 @@ describe('useTerminalProviderSnapshotCapability', () => {
   beforeEach(() => {
     clearTerminalProviderSnapshotCapabilities()
     resolveCapabilities.mockReset()
+    storeState.tabsByWorktree = {
+      'repo::worktree': [{ id: 'tab-1', ptyId: 'ssh:target@@pty-1' }]
+    }
+    storeState.ptyIdsByTabId = { 'tab-1': ['ssh:target@@pty-1'] }
     ;(window as unknown as { api: unknown }).api = {
       pty: { getAuthoritativeBufferSnapshotCapabilities: resolveCapabilities }
     }
@@ -91,6 +95,42 @@ describe('useTerminalProviderSnapshotCapability', () => {
 
     await waitFor(() =>
       expect(resolveCapabilities).toHaveBeenLastCalledWith(['ssh:target@@new-split'])
+    )
+    hook.unmount()
+  })
+
+  // Why per-map: every dep of the collect-key memo is individually
+  // load-bearing, and exhaustive-deps is only a warn in this repo — a dropped
+  // dep silently freezes the key for exactly that map's changes.
+  it('re-collects when each remaining collected store map changes', async () => {
+    resolveCapabilities.mockImplementation(async (ids: string[]) =>
+      ids.map((id) => ({ id, authoritative: true }))
+    )
+    const hook = renderHook(() => useTerminalProviderSnapshotCapability(true))
+    await waitFor(() => expect(resolveCapabilities).toHaveBeenCalledOnce())
+
+    storeState.pendingReconnectPtyIdByTabId = { 'tab-9': 'ssh:target@@reconnect' }
+    hook.rerender()
+    await waitFor(() =>
+      expect(resolveCapabilities).toHaveBeenLastCalledWith(['ssh:target@@reconnect'])
+    )
+
+    storeState.tabsByWorktree = {
+      'repo::worktree': [
+        ...storeState.tabsByWorktree['repo::worktree'],
+        { id: 'tab-2', ptyId: 'ssh:target@@tab-2' }
+      ]
+    }
+    hook.rerender()
+    await waitFor(() => expect(resolveCapabilities).toHaveBeenLastCalledWith(['ssh:target@@tab-2']))
+
+    storeState.ptyIdsByTabId = {
+      ...storeState.ptyIdsByTabId,
+      'tab-2': ['ssh:target@@tab-2-split']
+    }
+    hook.rerender()
+    await waitFor(() =>
+      expect(resolveCapabilities).toHaveBeenLastCalledWith(['ssh:target@@tab-2-split'])
     )
     hook.unmount()
   })

--- a/src/renderer/src/components/terminal/use-terminal-provider-snapshot-capability.test.tsx
+++ b/src/renderer/src/components/terminal/use-terminal-provider-snapshot-capability.test.tsx
@@ -154,13 +154,14 @@ describe('useTerminalProviderSnapshotCapability', () => {
   it('prefetches restored PTYs after render before activation is enabled', async () => {
     resolveCapabilities.mockResolvedValue([{ id: 'ssh:target@@pty-1', authoritative: false }])
 
-    renderHook(() => {
+    const hook = renderHook(() => {
       useTerminalProviderSnapshotCapability(false)
       expect(resolveCapabilities).not.toHaveBeenCalled()
     })
 
     await waitFor(() => expect(resolveCapabilities).toHaveBeenCalledOnce())
     expect(resolveCapabilities).toHaveBeenCalledWith(['ssh:target@@pty-1'])
+    hook.unmount()
   })
 
   it('does not poll again after a provider returns a definitive result', async () => {

--- a/src/renderer/src/components/terminal/use-terminal-provider-snapshot-capability.test.tsx
+++ b/src/renderer/src/components/terminal/use-terminal-provider-snapshot-capability.test.tsx
@@ -157,6 +157,25 @@ describe('useTerminalProviderSnapshotCapability', () => {
     hook.unmount()
   })
 
+  // Why: the timer chain is the sole recovery vehicle for unknown verdicts,
+  // and its refire reuses the same memoized id array — this pins the backoff
+  // return, the rescheduled timer, and the same-identity re-ask end to end.
+  it('polls an unknown pty again on the retry timer without any id churn', async () => {
+    vi.useFakeTimers()
+    resolveCapabilities
+      .mockResolvedValueOnce([{ id: 'ssh:target@@pty-1', authoritative: null }])
+      .mockResolvedValueOnce([{ id: 'ssh:target@@pty-1', authoritative: true }])
+    const hook = renderHook(() => useTerminalProviderSnapshotCapability(true))
+    await vi.advanceTimersByTimeAsync(0)
+    expect(resolveCapabilities).toHaveBeenCalledOnce()
+
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    expect(resolveCapabilities).toHaveBeenCalledTimes(2)
+    expect(terminalProviderHasAuthoritativeSnapshot('ssh:target@@pty-1')).toBe(true)
+    hook.unmount()
+  })
+
   it('cancels an unknown-capability retry when the hook unmounts', async () => {
     vi.useFakeTimers()
     resolveCapabilities.mockResolvedValue([{ id: 'ssh:target@@pty-1', authoritative: null }])

--- a/src/renderer/src/components/terminal/use-terminal-provider-snapshot-capability.test.tsx
+++ b/src/renderer/src/components/terminal/use-terminal-provider-snapshot-capability.test.tsx
@@ -1,4 +1,6 @@
 // @vitest-environment happy-dom
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
 import {
@@ -99,6 +101,20 @@ describe('useTerminalProviderSnapshotCapability', () => {
     hook.unmount()
   })
 
+  it('preserves newline-bearing folder-workspace pty ids in the memo key', async () => {
+    const newlinePtyId = 'repo::folder\nname@@pty-1'
+    storeState.tabsByWorktree = {
+      'repo::folder\nname': [{ id: 'tab-1', ptyId: newlinePtyId }]
+    }
+    storeState.ptyIdsByTabId = { 'tab-1': [newlinePtyId] }
+    resolveCapabilities.mockResolvedValue([{ id: newlinePtyId, authoritative: true }])
+
+    const hook = renderHook(() => useTerminalProviderSnapshotCapability(true))
+
+    await waitFor(() => expect(resolveCapabilities).toHaveBeenCalledWith([newlinePtyId]))
+    hook.unmount()
+  })
+
   // Why per-map: every dep of the collect-key memo is individually
   // load-bearing, and exhaustive-deps is only a warn in this repo — a dropped
   // dep silently freezes the key for exactly that map's changes.
@@ -166,6 +182,7 @@ describe('useTerminalProviderSnapshotCapability', () => {
       .mockResolvedValueOnce([{ id: 'ssh:target@@pty-1', authoritative: null }])
       .mockResolvedValueOnce([{ id: 'ssh:target@@pty-1', authoritative: true }])
     const hook = renderHook(() => useTerminalProviderSnapshotCapability(true))
+    const initialRevision = hook.result.current
     await vi.advanceTimersByTimeAsync(0)
     expect(resolveCapabilities).toHaveBeenCalledOnce()
 
@@ -173,7 +190,21 @@ describe('useTerminalProviderSnapshotCapability', () => {
 
     expect(resolveCapabilities).toHaveBeenCalledTimes(2)
     expect(terminalProviderHasAuthoritativeSnapshot('ssh:target@@pty-1')).toBe(true)
+    expect(hook.result.current).toBeGreaterThan(initialRevision)
     hook.unmount()
+  })
+
+  // Why source-pinned: the hook test cannot prove the quiet Terminal parking effect consumes the external revision.
+  it('invalidates the Terminal parking pass when a capability verdict changes', () => {
+    const terminalSource = readFileSync(join(__dirname, '../Terminal.tsx'), 'utf8')
+    const parkingEffectStart = terminalSource.indexOf('// Worktree cold-park policy:')
+    const parkingEffectEnd = terminalSource.indexOf('// Why here: downloads', parkingEffectStart)
+
+    expect(parkingEffectStart).toBeGreaterThan(-1)
+    expect(parkingEffectEnd).toBeGreaterThan(parkingEffectStart)
+    expect(terminalSource.slice(parkingEffectStart, parkingEffectEnd)).toContain(
+      'terminalProviderSnapshotCapabilityRevision'
+    )
   })
 
   it('cancels an unknown-capability retry when the hook unmounts', async () => {

--- a/src/renderer/src/components/terminal/use-terminal-provider-snapshot-capability.test.tsx
+++ b/src/renderer/src/components/terminal/use-terminal-provider-snapshot-capability.test.tsx
@@ -1,9 +1,21 @@
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
-import { clearTerminalProviderSnapshotCapabilities } from './terminal-provider-snapshot-capability'
+import {
+  clearTerminalProviderSnapshotCapabilities,
+  collectTerminalProviderSnapshotPtyIds,
+  synchronizeTerminalProviderSnapshotCapabilities,
+  terminalProviderHasAuthoritativeSnapshot
+} from './terminal-provider-snapshot-capability'
 
-const storeState = {
+type HookStoreState = {
+  tabsByWorktree: Record<string, { id: string; ptyId: string | null }[]>
+  ptyIdsByTabId: Record<string, string[]>
+  pendingReconnectPtyIdByTabId?: Record<string, string>
+  terminalLayoutsByTabId?: Record<string, { ptyIdsByLeafId?: Record<string, string> }>
+}
+
+const storeState: HookStoreState = {
   tabsByWorktree: {
     'repo::worktree': [{ id: 'tab-1', ptyId: 'ssh:target@@pty-1' }]
   },
@@ -30,6 +42,36 @@ describe('useTerminalProviderSnapshotCapability', () => {
   afterEach(() => {
     vi.useRealTimers()
     delete (window as unknown as { api?: unknown }).api
+    delete storeState.pendingReconnectPtyIdByTabId
+    delete storeState.terminalLayoutsByTabId
+  })
+
+  // Why: synchronization PRUNES cached verdicts outside its collected set, so
+  // the ongoing collector must gather the same fields startup does
+  // (pending-reconnect and split-leaf layout ptys) or their startup answers
+  // decay back into exempt-by-default unknown.
+  it('keeps startup verdicts for split-leaf and pending-reconnect ptys alive', async () => {
+    storeState.pendingReconnectPtyIdByTabId = { 'tab-2': 'ssh:target@@restored' }
+    storeState.terminalLayoutsByTabId = {
+      'tab-1': { ptyIdsByLeafId: { leaf: 'ssh:target@@split' } }
+    }
+    const startupResolver = vi.fn(async (ids: string[]) =>
+      ids.map((id) => ({ id, authoritative: true }))
+    )
+    await synchronizeTerminalProviderSnapshotCapabilities(
+      collectTerminalProviderSnapshotPtyIds(storeState),
+      startupResolver
+    )
+    expect(terminalProviderHasAuthoritativeSnapshot('ssh:target@@split')).toBe(true)
+    resolveCapabilities.mockResolvedValue([])
+
+    const hook = renderHook(() => useTerminalProviderSnapshotCapability(true))
+    await Promise.resolve()
+
+    for (const ptyId of ['ssh:target@@pty-1', 'ssh:target@@split', 'ssh:target@@restored']) {
+      expect(terminalProviderHasAuthoritativeSnapshot(ptyId)).toBe(true)
+    }
+    hook.unmount()
   })
 
   it('prefetches restored PTYs after render before activation is enabled', async () => {

--- a/src/renderer/src/components/terminal/use-terminal-provider-snapshot-capability.test.tsx
+++ b/src/renderer/src/components/terminal/use-terminal-provider-snapshot-capability.test.tsx
@@ -74,6 +74,27 @@ describe('useTerminalProviderSnapshotCapability', () => {
     hook.unmount()
   })
 
+  // Why: the collect key is memoized on the four store maps; a missing memo
+  // dep would freeze the key and silently drop new split-leaf ptys from the
+  // sync — a stale-collector correctness bug, not a perf one.
+  it('re-collects when a split leaf pty appears in the layouts map', async () => {
+    resolveCapabilities.mockImplementation(async (ids: string[]) =>
+      ids.map((id) => ({ id, authoritative: true }))
+    )
+    const hook = renderHook(() => useTerminalProviderSnapshotCapability(true))
+    await waitFor(() => expect(resolveCapabilities).toHaveBeenCalledOnce())
+
+    storeState.terminalLayoutsByTabId = {
+      'tab-1': { ptyIdsByLeafId: { leaf: 'ssh:target@@new-split' } }
+    }
+    hook.rerender()
+
+    await waitFor(() =>
+      expect(resolveCapabilities).toHaveBeenLastCalledWith(['ssh:target@@new-split'])
+    )
+    hook.unmount()
+  })
+
   it('prefetches restored PTYs after render before activation is enabled', async () => {
     resolveCapabilities.mockResolvedValue([{ id: 'ssh:target@@pty-1', authoritative: false }])
 

--- a/src/renderer/src/components/terminal/use-terminal-provider-snapshot-capability.ts
+++ b/src/renderer/src/components/terminal/use-terminal-provider-snapshot-capability.ts
@@ -1,11 +1,13 @@
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useSyncExternalStore } from 'react'
 import { useAppStore } from '@/store'
 import {
   collectTerminalProviderSnapshotPtyIds,
+  getTerminalProviderSnapshotCapabilityRevision,
+  subscribeTerminalProviderSnapshotCapability,
   startTerminalProviderSnapshotCapabilitySynchronization
 } from './terminal-provider-snapshot-capability'
 
-export function useTerminalProviderSnapshotCapability(enabled: boolean): void {
+export function useTerminalProviderSnapshotCapability(enabled: boolean): number {
   const tabsByWorktree = useAppStore((state) => state.tabsByWorktree)
   const ptyIdsByTabId = useAppStore((state) => state.ptyIdsByTabId)
   const pendingReconnectPtyIdByTabId = useAppStore((state) => state.pendingReconnectPtyIdByTabId)
@@ -20,19 +22,21 @@ export function useTerminalProviderSnapshotCapability(enabled: boolean): void {
   // and only a change to one of the four collected maps can alter the id set.
   const boundPtyIdsKey = useMemo(
     () =>
-      collectTerminalProviderSnapshotPtyIds({
-        tabsByWorktree,
-        ptyIdsByTabId,
-        pendingReconnectPtyIdByTabId,
-        terminalLayoutsByTabId
-      })
-        .sort()
-        .join('\n'),
+      JSON.stringify(
+        collectTerminalProviderSnapshotPtyIds({
+          tabsByWorktree,
+          ptyIdsByTabId,
+          pendingReconnectPtyIdByTabId,
+          terminalLayoutsByTabId
+        }).sort()
+      ),
     [tabsByWorktree, ptyIdsByTabId, pendingReconnectPtyIdByTabId, terminalLayoutsByTabId]
   )
-  const boundPtyIds = useMemo(
-    () => (boundPtyIdsKey.length === 0 ? [] : boundPtyIdsKey.split('\n')),
-    [boundPtyIdsKey]
+  const boundPtyIds = useMemo(() => JSON.parse(boundPtyIdsKey) as string[], [boundPtyIdsKey])
+  const capabilityRevision = useSyncExternalStore(
+    subscribeTerminalProviderSnapshotCapability,
+    getTerminalProviderSnapshotCapabilityRevision,
+    getTerminalProviderSnapshotCapabilityRevision
   )
 
   useEffect(() => {
@@ -42,4 +46,6 @@ export function useTerminalProviderSnapshotCapability(enabled: boolean): void {
     }
     return startTerminalProviderSnapshotCapabilitySynchronization(boundPtyIds)
   }, [boundPtyIds, enabled])
+
+  return capabilityRevision
 }

--- a/src/renderer/src/components/terminal/use-terminal-provider-snapshot-capability.ts
+++ b/src/renderer/src/components/terminal/use-terminal-provider-snapshot-capability.ts
@@ -16,14 +16,20 @@ export function useTerminalProviderSnapshotCapability(enabled: boolean): void {
   // pending-reconnect ptys back into the exempt-by-default unknown state.
   // Why keyed: layouts change without changing the pty set (active-leaf churn);
   // the synchronization loop must restart only on genuine id-set changes.
-  const boundPtyIdsKey = collectTerminalProviderSnapshotPtyIds({
-    tabsByWorktree,
-    ptyIdsByTabId,
-    pendingReconnectPtyIdByTabId,
-    terminalLayoutsByTabId
-  })
-    .sort()
-    .join('\n')
+  // Why memoized on the map identities: this runs at Terminal's render cadence,
+  // and only a change to one of the four collected maps can alter the id set.
+  const boundPtyIdsKey = useMemo(
+    () =>
+      collectTerminalProviderSnapshotPtyIds({
+        tabsByWorktree,
+        ptyIdsByTabId,
+        pendingReconnectPtyIdByTabId,
+        terminalLayoutsByTabId
+      })
+        .sort()
+        .join('\n'),
+    [tabsByWorktree, ptyIdsByTabId, pendingReconnectPtyIdByTabId, terminalLayoutsByTabId]
+  )
   const boundPtyIds = useMemo(
     () => (boundPtyIdsKey.length === 0 ? [] : boundPtyIdsKey.split('\n')),
     [boundPtyIdsKey]

--- a/src/renderer/src/components/terminal/use-terminal-provider-snapshot-capability.ts
+++ b/src/renderer/src/components/terminal/use-terminal-provider-snapshot-capability.ts
@@ -8,9 +8,25 @@ import {
 export function useTerminalProviderSnapshotCapability(enabled: boolean): void {
   const tabsByWorktree = useAppStore((state) => state.tabsByWorktree)
   const ptyIdsByTabId = useAppStore((state) => state.ptyIdsByTabId)
+  const pendingReconnectPtyIdByTabId = useAppStore((state) => state.pendingReconnectPtyIdByTabId)
+  const terminalLayoutsByTabId = useAppStore((state) => state.terminalLayoutsByTabId)
+  // Why the full field set: synchronization PRUNES cached verdicts outside the
+  // collected ids, so a collector narrower than startup's (App.tsx refresh
+  // passes full state) would evict valid answers for split-leaf and
+  // pending-reconnect ptys back into the exempt-by-default unknown state.
+  // Why keyed: layouts change without changing the pty set (active-leaf churn);
+  // the synchronization loop must restart only on genuine id-set changes.
+  const boundPtyIdsKey = collectTerminalProviderSnapshotPtyIds({
+    tabsByWorktree,
+    ptyIdsByTabId,
+    pendingReconnectPtyIdByTabId,
+    terminalLayoutsByTabId
+  })
+    .sort()
+    .join('\n')
   const boundPtyIds = useMemo(
-    () => collectTerminalProviderSnapshotPtyIds({ tabsByWorktree, ptyIdsByTabId }),
-    [ptyIdsByTabId, tabsByWorktree]
+    () => (boundPtyIdsKey.length === 0 ? [] : boundPtyIdsKey.split('\n')),
+    [boundPtyIdsKey]
   )
 
   useEffect(() => {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​801 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​787 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​183 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​25 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​158 |

<!-- /orca-pr-loc -->

## ELI5

Orca saves memory by unloading terminal views that have been hidden for a while. It may only unload a pane when the terminal process can be reattached **and** a replay source will survive the unmount; otherwise the user loses scrollback and the shell can be orphaned.

When Orca could not determine that replay capability, it correctly kept the pane mounted—but after about 91 seconds of failed probes it stopped asking forever. One slow daemon startup could therefore make every local terminal permanently ineligible for eviction for the rest of the app session. This change keeps the conservative safety behavior and re-asks every five minutes, allowing a recovered daemon to make those panes safely evictable.

## What changed

1. The `1/2/4/8/16/30/30s` unknown-capability ladder now decays to a bounded five-minute re-ask instead of synthesizing a permanent `false` verdict. Unknown remains eviction-exempt throughout.
2. Superseded probe generations keep their caller's timer chain alive, and closed PTYs are pruned from retry state.
3. The ongoing collector now covers tabs, pane-layout leaves, and pending reconnects just like startup refresh. Its sorted PTY-set key is memoized and JSON-encoded, so ordinary layout churn does not restart the loop and newline-bearing folder/workspace IDs cannot collide.
4. Capability changes publish a small external-store revision consumed by the terminal parking effect. A quiet hidden worktree therefore re-evaluates parking when the daemon recovers; recovery is not dependent on unrelated React/store churn.
5. The existing all-exempt force-park diagnostic now reports counts by route (`fail-open`, `foreign-worktree`, `capability-unknown`, `split-pane`) in a counts-only crash breadcrumb. No worktree IDs or filesystem paths enter the breadcrumb.

The broader `terminal_parking_pass` instrumentation was split into #14660 and is intentionally not part of this focused fix.

## Why

**This fixes a real latent defect, not a defect observed firing in the crash sweep.** The retained field snapshot from the separately investigated leak showed the exemption system idle, and this change does not explain that leak or the renderer OOM cluster. The defect here is reproduced by focused unit/React gates.

The safety invariant remains: no pane may unmount unless both process reattachment and surviving replay are known. A failed, timed-out, missing, or `null` capability answer never becomes permission to evict.

## Honest limitation

A stale cached authoritative `true` remains unchanged from `main`. If a provider later loses replay without invalidating that cached result, it remains the pre-existing route by which a pane could be unmounted without restorable scrollback. The five-minute re-ask applies only to unresolved answers and does **not** narrow that stale-true window; provider-generation/liveness invalidation is a separate follow-up.

## Scope and compatibility

- Renderer-only policy and state propagation; no RPC, stream opcode, daemon payload, or other remote-wire change.
- Shared desktop path works for native, SSH, and folder workspaces; no platform-specific path or shortcut behavior.
- Resolver-free/degraded surfaces perform at most one bounded unresolved batch per five-minute window and never gain permission to evict.
- Steady-state healthy sessions resolve once and leave the retry set. The only continuing work is the bounded slow re-ask for unresolved PTYs.
- Mobile is unaffected.

## Testing

Focused post-rebase verification:

| Gate | Result |
| --- | ---: |
| `terminal-provider-snapshot-capability.test.ts` | 16 passed |
| `terminal-provider-snapshot-capability-resettlement.test.ts` | 4 passed |
| `use-terminal-provider-snapshot-capability.test.tsx` | 9 passed |
| `terminal-retention-exempt-growth.test.ts` | 1 passed |
| `terminal-cold-park-exempt-flip.react185.test.tsx` | 1 passed |

The gates cover the full retry ladder and slow re-ask, same-array-identity timer refires, superseded generations, closed-PTY pruning, collector parity for split leaves and reconnects, newline-bearing PTY IDs, React invalidation, retention bounds after recovery, and repeated park-verdict flips without a React #185 loop. Targeted standard and type-aware lint also pass.

CI on the previous pushed head passed typecheck, package (macOS and Windows), cross-version wire compatibility, Git compatibility, shell contracts, and all 32 test shards. The sole static-analysis failure was an unused test suppression, removed in the next commit; final CI will rerun on the rebased head.

## Adversarial review

Eight loops were run to clean:

- Loop 1 found the split-leaf collector case and route classification unpinned, plus render-path collection work outside memoization; fixed and tested.
- Loop 2 found incomplete memo dependencies and a generation-cancelled pass that could kill the degraded-startup timer chain; fixed and tested.
- Loop 3 found the central same-identity re-ask mutation unpinned and a closed-PTY retry-state leak; fixed with non-vacuous gates.
- Loop 4 independently re-applied the mutations and returned clean.
- Merge-gate loop 5 found the missing React invalidation, newline-delimited key collision, non-exhaustive route switch, path-bearing diagnostic payload, and overstated stale-true claim; fixed and tested.
- Merge-gate loop 6 re-derived the final behavior and returned clean after seven focused files / 94 tests.
- Final-readiness loop 7 found a test-isolation leak: the prefetch `renderHook` stayed mounted, so a later capability publication logged a real assertion error even while Vitest reported green; fixed by explicitly unmounting the hook.
- Final-readiness loop 8 re-audited pushed head `b6cca5a26c` and returned clean with no P0/P1/P2 findings.

Open-source precedent review supports the design: detach/unmount is safe only with process persistence plus replay, unknown capability stays mounted, and recovery is retried or event-driven instead of converting transient uncertainty into a durable verdict. The bounded re-ask and explicit React invalidation are conventional, focused mechanisms.

## Visual proof

Electron QA ran through Playwright CDP on a dedicated dev instance at reviewed head `cf11b9aeba` (the final rebase adds only the lint-suppression cleanup and new base commits). The parking delay was reduced to 2 seconds for exerciseability; capability and replay behavior were production paths.

- [Visible marker before park](https://github.com/user-attachments/assets/24f80f9c-b29c-4b6b-80c1-8330d056e0a4)
- [Target parked before the daemon process restart](https://github.com/user-attachments/assets/9817cecf-cba7-42b1-93db-228c47db9ba8)
- [Revealed after restart, marker visibly preserved in scrollback](https://github.com/user-attachments/assets/b41dad0a-aa5a-4342-9bdf-d0ca35358b2b)
- [Full QA report and screenshots](https://github.com/stablyai/orca/pull/14676#issuecomment-5300877084)

The passing rendered flow was park → terminate only the dedicated profile's daemon process → daemon recovery → reveal; the marker survived and was visible after scrolling to the top. Orca's explicit `pty.management.restart()` is intentionally destructive: it synthesized session exits and retired the parked tab, so reveal was impossible and that API cannot serve as session-preserving proof.

Live visual proof of “unknown capability stays mounted” remains blocked: the context-bridged capability IPC is immutable, and the dedicated daemon auto-respawned quickly enough that new PTYs resolved authoritative before force-park. This gap is stated rather than replaced with store inspection; the safety direction is covered by the focused unit/React gates.

## Follow-ups

- Invalidate cached authoritative results on provider-generation/liveness changes, using the remote-wire compatibility process if a new daemon lifecycle signal is required.
- Continue the separate field-OOM investigation; this PR does not claim to identify its retainer.
- Broader parking-decision instrumentation remains in #14660.

## Checklist

- [x] Focused fix with regression coverage
- [x] Security/privacy, performance, cross-platform, SSH/remote, folder-workspace, and wire-compatibility reviewed
- [x] Automated tests added/updated
- [x] Final rebased focused verification and Electron evidence complete, with the live unknown-capability visual gap documented above
- [ ] Final rebased CI complete

## Author

- X / Twitter: @BrennanKB5
