### PR TITLE
preserve agent badges when searching for tabs

### DIFF
--- a/src/renderer/src/components/WorktreeJumpPalette.recent-tabs.test.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.recent-tabs.test.tsx
@@ -889,6 +889,25 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
     expect(activateWorkspaceTabPaletteResult).not.toHaveBeenCalled()
   })
 
+  it('keeps the agent badge on an Open Tabs row a query surfaced', async () => {
+    await renderPalette(
+      makeRecentTabState({
+        agentStatusByPaneKey: {
+          [makePaneKey('term-alpha', LEAF_ID)]: makeAgentEntry('term-alpha', 'working', Date.now())
+        }
+      })
+    )
+
+    await act(async () => {
+      setCommandQuery?.('Alpha')
+    })
+    await flushEffects()
+
+    // Why: searching for a tab is exactly when its status matters — the pip must survive the query.
+    expect(getTabRowIds()).toContain('tab-alpha')
+    expect(testContainer.querySelector('[title="Working"]')).not.toBeNull()
+  })
+
   it('keeps create-worktree below the matches it would otherwise outrank', async () => {
     await renderPalette(makeRecentTabState())
 

--- a/src/renderer/src/components/WorktreeJumpPalette.recent-tabs.test.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.recent-tabs.test.tsx
@@ -898,14 +898,24 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
       })
     )
 
+    // Why not optional-call: a skipped setter would leave the empty-query Recent section standing
+    // and the assertions below would pass without the query path ever running.
+    const applyQuery = setCommandQuery
+    if (!applyQuery) {
+      throw new Error('CommandInput never installed a query setter')
+    }
     await act(async () => {
-      setCommandQuery?.('Alpha')
+      applyQuery('Alpha')
     })
     await flushEffects()
 
     // Why: searching for a tab is exactly when its status matters — the pip must survive the query.
     expect(getTabRowIds()).toContain('tab-alpha')
-    expect(testContainer.querySelector('[title="Working"]')).not.toBeNull()
+    expect(getTabRowIds()).not.toContain('tab-beta')
+    const alphaRow = testContainer.querySelector<HTMLElement>(
+      '[data-command-item="workspace-tab:tab-alpha"]'
+    )
+    expect(alphaRow?.querySelector('[title="Working"]')).not.toBeNull()
   })
 
   it('keeps create-worktree below the matches it would otherwise outrank', async () => {

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -3255,9 +3255,9 @@ function WorktreeJumpPaletteContent({
                 )
                 const WorkspaceTabIcon =
                   result.contentType === 'terminal' ? SquareTerminal : FileText
-                // Why null on a typed query: live corner pips belong to the frozen recent section —
-                // Open Tabs search results stay content-icon only (no agent status overlay).
-                const recentRow = hasQuery ? null : (recentTabRowById.get(entry.id) ?? null)
+                // Why regardless of query: a searched-for tab is exactly when you need to know it's
+                // still working — the map covers every open tab, not just the recent section.
+                const recentRow = recentTabRowById.get(entry.id) ?? null
 
                 return (
                   <CommandItem


### PR DESCRIPTION
## Problem

Agent status badges (e.g., "Working") were hidden when searching for tabs, even though users need this information when actively locating a tab.

## Solution

Always preserve agent status information in tab search results instead of only showing it in the recent section.

## ELI5

Agent status badges show if a tab is actively running. Previously these disappeared when you searched for a tab—now they stay visible.

## What Changed

- Modified `WorktreeJumpPalette.tsx` to always include agent status data when rendering Open Tabs search results
- Added test case verifying agent badges appear on tabs surfaced by search queries

## Why

A searched-for tab is exactly when you need to know its status. The agent status map covers every open tab, not just the recent section.

## Linked Issue

Fixes #

## Visual Proof

N/A - Badge data flow fix; no new UI elements or visual changes.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below
  - Added test: "keeps the agent badge on an Open Tabs row a query surfaced"

## Review

- Cross-platform, SSH/remote: No platform-specific changes
- Performance: Uses existing data structures
- Backwards compatibility: Non-breaking

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [ ] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)