### PR TITLE
fix(sidebar): stop the agent row's tool step from flickering on every hook (#11075)

### DIFF
--- a/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
@@ -13,6 +13,7 @@ import type { DashboardAgentRow as DashboardAgentRowData } from './useDashboardD
 import { getAgentRowPrimaryText } from '@/lib/agent-row-primary-text'
 import { useAgentRowConversationName } from './use-agent-row-conversation-name'
 import { lastEnteredDoneAt } from './agent-finished-timestamp'
+import { useSettledAgentToolStep } from '@/hooks/use-settled-agent-tool-step'
 
 // Why: narrow the dashboard's rollup states to shared dot states, defaulting unknowns to 'idle' so a row never crashes.
 function asDotState(state: AgentStatusState | 'idle'): AgentDotState {
@@ -146,8 +147,11 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
   const model = agent.entry.model?.trim() ?? ''
   // Why: gate tool fields on 'working' — a stale tool line on a done row reads as still-running.
   const isWorking = agent.state === 'working'
-  const toolName = isWorking ? (agent.entry.toolName?.trim() ?? '') : ''
-  const toolInput = isWorking ? (agent.entry.toolInput?.trim() ?? '') : ''
+  // Why: hooks rewrite the pair several times a second; hold it for a readable dwell (#11075).
+  const { toolName, toolInput } = useSettledAgentToolStep(
+    isWorking ? (agent.entry.toolName?.trim() ?? '') : '',
+    isWorking ? (agent.entry.toolInput?.trim() ?? '') : ''
+  )
   const lastAssistantMessage = agent.entry.lastAssistantMessage?.trim() ?? ''
   const isInterrupted = agent.entry.interrupted === true
   const lineage = agent.lineage

--- a/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tool-step-flicker.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tool-step-flicker.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DashboardAgentRow as DashboardAgentRowData } from '@/components/dashboard/useDashboardData'
+import { AGENT_TOOL_STEP_DWELL_MS } from '@/hooks/use-settled-agent-tool-step'
+import { CompactAgentRow } from './worktree-card-compact-agent-row'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+const PANE_KEY = 'tab-1:leaf-1'
+
+function cursorAgentRow(toolName: string, toolInput: string): DashboardAgentRowData {
+  return {
+    paneKey: PANE_KEY,
+    tab: { id: 'tab-1', worktreeId: 'wt-1' },
+    agentType: 'cursor',
+    rowSource: 'live',
+    state: 'working',
+    startedAt: 1000,
+    entry: {
+      prompt: 'Refactor the intake flow',
+      state: 'working',
+      paneKey: PANE_KEY,
+      updatedAt: 1000,
+      stateStartedAt: 1000,
+      stateHistory: [],
+      agentType: 'cursor',
+      toolName,
+      toolInput
+    }
+  } as unknown as DashboardAgentRowData
+}
+
+let container: HTMLDivElement
+let root: Root
+
+function renderRow(agent: DashboardAgentRowData): void {
+  act(() => {
+    root.render(
+      <CompactAgentRow agent={agent} now={2000} onActivate={vi.fn()} cacheTimerActive={false} />
+    )
+  })
+}
+
+function rowText(): string {
+  return container.querySelector('.compact-agent-row')?.textContent?.trim() ?? ''
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+  vi.useRealTimers()
+})
+
+describe('compact sidebar agent row tool-step flicker (#11075)', () => {
+  it('does not repaint the row on every hook while a cursor turn runs', () => {
+    renderRow(cursorAgentRow('Read', 'src/a.ts'))
+    const settled = rowText()
+    expect(settled).toContain('Read: src/a.ts')
+
+    // A cursor turn emits pre/post tool hooks several times a second. Every one
+    // of these rewrote the row's single truncated line before the fix.
+    const burst: [string, string][] = [
+      ['Grep', 'TODO'],
+      ['Edit', 'src/b.ts'],
+      ['Bash', 'pnpm test'],
+      ['Read', 'src/c.ts']
+    ]
+    for (const [toolName, toolInput] of burst) {
+      act(() => {
+        vi.advanceTimersByTime(60)
+      })
+      renderRow(cursorAgentRow(toolName, toolInput))
+      expect(rowText()).toBe(settled)
+    }
+
+    act(() => {
+      vi.advanceTimersByTime(AGENT_TOOL_STEP_DWELL_MS)
+    })
+    // The newest step lands; 'Grep: TODO', 'Edit: src/b.ts', and 'Bash: pnpm test'
+    // were never painted at all.
+    expect(rowText()).toContain('Read: src/c.ts')
+  })
+
+  it('keeps the prompt visible the whole time', () => {
+    renderRow(cursorAgentRow('Read', 'src/a.ts'))
+    for (const [toolName, toolInput] of [
+      ['Grep', 'TODO'],
+      ['Edit', 'src/b.ts']
+    ] as [string, string][]) {
+      act(() => {
+        vi.advanceTimersByTime(60)
+      })
+      renderRow(cursorAgentRow(toolName, toolInput))
+      expect(rowText()).toContain('Refactor the intake flow')
+    }
+  })
+
+  it('settles on the newest tool step once the burst stops', () => {
+    renderRow(cursorAgentRow('Read', 'src/a.ts'))
+    act(() => {
+      vi.advanceTimersByTime(40)
+    })
+    renderRow(cursorAgentRow('Bash', 'pnpm build'))
+    act(() => {
+      vi.advanceTimersByTime(AGENT_TOOL_STEP_DWELL_MS)
+    })
+
+    expect(rowText()).toContain('Bash: pnpm build')
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
@@ -10,6 +10,7 @@ import { translate } from '@/i18n/i18n'
 import { getAgentRowPrimaryText } from '@/lib/agent-row-primary-text'
 import { useAgentRowConversationName } from '@/components/dashboard/use-agent-row-conversation-name'
 import { lastEnteredDoneAt } from '@/components/dashboard/agent-finished-timestamp'
+import { useSettledAgentToolStep, type AgentToolStep } from '@/hooks/use-settled-agent-tool-step'
 import CacheTimer, { usePromptCacheCountdownForPane } from './CacheTimer'
 
 function formatShortTimeAgo(ts: number, now: number): string {
@@ -36,19 +37,15 @@ function getCompactAgentPrimary(
   return prompt || agentStateLabel(getAgentDotState(agent))
 }
 
-function getCompactAgentSecondary(agent: DashboardAgentRowData): string {
+function getCompactAgentSecondary(agent: DashboardAgentRowData, toolStep: AgentToolStep): string {
   if (agent.entry.interrupted === true) {
     return 'Interrupted by user'
   }
-  if (agent.state === 'working') {
-    const toolName = agent.entry.toolName?.trim() ?? ''
-    const toolInput = agent.entry.toolInput?.trim() ?? ''
-    if (toolName && toolInput) {
-      return `${toolName}: ${toolInput}`
-    }
-    if (toolName) {
-      return toolName
-    }
+  if (toolStep.toolName && toolStep.toolInput) {
+    return `${toolStep.toolName}: ${toolStep.toolInput}`
+  }
+  if (toolStep.toolName) {
+    return toolStep.toolName
   }
   const lastAssistantMessage = agent.entry.lastAssistantMessage?.trim()
   if (lastAssistantMessage) {
@@ -123,7 +120,15 @@ export const CompactAgentRow = React.memo(function CompactAgentRow({
   const conversationName = useAgentRowConversationName(agent)
   const primary = getCompactAgentPrimary(agent, conversationName)
   const isLineageChild = agent.lineage?.depth === 1
-  const secondary = getCompactAgentSecondary(agent)
+  // Why: gate on 'working' — a stale tool step on a done row reads as still-running.
+  const isWorking = agent.state === 'working'
+  // Why: the tool step shares this row's one truncated line with the prompt, so a
+  // per-hook rewrite reads as the identity itself flickering (#11075).
+  const toolStep = useSettledAgentToolStep(
+    isWorking ? (agent.entry.toolName?.trim() ?? '') : '',
+    isWorking ? (agent.entry.toolInput?.trim() ?? '') : ''
+  )
+  const secondary = getCompactAgentSecondary(agent, toolStep)
   const model = agent.entry.model?.trim() ?? ''
   const shortTime = getCompactAgentTime(agent, now)
   const cacheTimer = usePromptCacheCountdownForPane(agent.paneKey, cacheTimerActive)

--- a/src/renderer/src/hooks/use-settled-agent-tool-step.test.ts
+++ b/src/renderer/src/hooks/use-settled-agent-tool-step.test.ts
@@ -1,0 +1,189 @@
+// @vitest-environment happy-dom
+
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AGENT_TOOL_STEP_DWELL_MS, useSettledAgentToolStep } from './use-settled-agent-tool-step'
+
+type StepProps = { name: string; input: string }
+
+function renderStep(initialProps: StepProps) {
+  return renderHook(({ name, input }: StepProps) => useSettledAgentToolStep(name, input), {
+    initialProps
+  })
+}
+
+function passDwell(): void {
+  act(() => {
+    vi.advanceTimersByTime(AGENT_TOOL_STEP_DWELL_MS)
+  })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('useSettledAgentToolStep', () => {
+  it('shows the mounted step without waiting for a dwell', () => {
+    const { result } = renderStep({ name: 'Read', input: 'src/main.ts' })
+
+    expect(result.current).toEqual({ toolName: 'Read', toolInput: 'src/main.ts' })
+  })
+
+  it('holds the mounted step for one dwell before the first rewrite lands', () => {
+    const { result, rerender } = renderStep({ name: '', input: '' })
+
+    act(() => {
+      rerender({ name: 'Read', input: 'src/main.ts' })
+    })
+    expect(result.current).toEqual({ toolName: '', toolInput: '' })
+
+    passDwell()
+    expect(result.current).toEqual({ toolName: 'Read', toolInput: 'src/main.ts' })
+  })
+
+  it('coalesces a burst of hook rewrites to the newest step', () => {
+    const { result, rerender } = renderStep({ name: 'Read', input: 'a.ts' })
+    passDwell()
+
+    act(() => {
+      rerender({ name: 'Read', input: 'b.ts' })
+    })
+    expect(result.current).toEqual({ toolName: 'Read', toolInput: 'b.ts' })
+
+    for (const [name, input] of [
+      ['Grep', 'TODO'],
+      ['Edit', 'c.ts'],
+      ['Bash', 'pnpm test']
+    ] as [string, string][]) {
+      act(() => {
+        vi.advanceTimersByTime(80)
+        rerender({ name, input })
+      })
+      // Three rewrites inside the dwell paint nothing.
+      expect(result.current).toEqual({ toolName: 'Read', toolInput: 'b.ts' })
+    }
+
+    passDwell()
+    // Only the newest lands — the two intermediates are never painted.
+    expect(result.current).toEqual({ toolName: 'Bash', toolInput: 'pnpm test' })
+  })
+
+  it('always lands the final step once the burst stops', () => {
+    const { result, rerender } = renderStep({ name: 'Read', input: 'a.ts' })
+    passDwell()
+
+    act(() => {
+      rerender({ name: 'Read', input: 'b.ts' })
+    })
+    act(() => {
+      vi.advanceTimersByTime(50)
+      rerender({ name: 'Bash', input: 'pnpm build' })
+    })
+    passDwell()
+
+    expect(result.current).toEqual({ toolName: 'Bash', toolInput: 'pnpm build' })
+  })
+
+  it('never pairs one step name with another step input', () => {
+    const seen: string[] = []
+    const { rerender } = renderHook(
+      ({ name, input }: StepProps) => {
+        const step = useSettledAgentToolStep(name, input)
+        seen.push(`${step.toolName}|${step.toolInput}`)
+        return step
+      },
+      { initialProps: { name: 'Read', input: 'a.ts' } }
+    )
+    passDwell()
+
+    act(() => {
+      rerender({ name: 'Bash', input: 'pnpm test' })
+    })
+    act(() => {
+      vi.advanceTimersByTime(40)
+      rerender({ name: 'Grep', input: 'needle' })
+    })
+    passDwell()
+
+    const validPairs = new Set(['Read|a.ts', 'Bash|pnpm test', 'Grep|needle'])
+    expect(seen.every((pair) => validPairs.has(pair))).toBe(true)
+  })
+
+  it('coalesces a transient clear away when a new step arrives inside the dwell', () => {
+    // Why: cursor postToolUseFailure clears the pair for one event; painting that
+    // blank frame is what swings the row between unrelated text (#11075).
+    const { result, rerender } = renderStep({ name: 'Read', input: 'a.ts' })
+    passDwell()
+
+    act(() => {
+      rerender({ name: 'Bash', input: 'pnpm test' })
+    })
+    act(() => {
+      vi.advanceTimersByTime(30)
+      rerender({ name: '', input: '' })
+    })
+    act(() => {
+      vi.advanceTimersByTime(30)
+      rerender({ name: 'Edit', input: 'fix.ts' })
+    })
+    expect(result.current).toEqual({ toolName: 'Bash', toolInput: 'pnpm test' })
+
+    passDwell()
+    expect(result.current).toEqual({ toolName: 'Edit', toolInput: 'fix.ts' })
+  })
+
+  it('lands a clear that outlives the dwell so a finished row drops its tool step', () => {
+    const { result, rerender } = renderStep({ name: 'Read', input: 'a.ts' })
+    passDwell()
+
+    act(() => {
+      rerender({ name: 'Bash', input: 'pnpm test' })
+    })
+    act(() => {
+      vi.advanceTimersByTime(30)
+      rerender({ name: '', input: '' })
+    })
+    passDwell()
+
+    expect(result.current).toEqual({ toolName: '', toolInput: '' })
+  })
+
+  it('keeps repainting on schedule instead of restarting the dwell on every rewrite', () => {
+    const { result, rerender } = renderStep({ name: 'Read', input: 'a.ts' })
+    passDwell()
+
+    // A hook every 50ms for well over one dwell must still land a fresh step.
+    for (let elapsed = 0; elapsed <= AGENT_TOOL_STEP_DWELL_MS * 2; elapsed += 50) {
+      act(() => {
+        vi.advanceTimersByTime(50)
+        rerender({ name: 'Bash', input: `step-${elapsed}` })
+      })
+    }
+
+    expect(result.current.toolName).toBe('Bash')
+    expect(result.current.toolInput).toMatch(/^step-\d+$/)
+  })
+
+  it('clears its pending dwell on unmount', () => {
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout')
+    const { rerender, unmount } = renderStep({ name: 'Read', input: 'a.ts' })
+    passDwell()
+
+    act(() => {
+      rerender({ name: 'Bash', input: 'pnpm test' })
+    })
+    act(() => {
+      vi.advanceTimersByTime(20)
+      rerender({ name: 'Grep', input: 'needle' })
+    })
+    unmount()
+
+    expect(clearTimeoutSpy).toHaveBeenCalled()
+    expect(() => vi.advanceTimersByTime(AGENT_TOOL_STEP_DWELL_MS)).not.toThrow()
+    clearTimeoutSpy.mockRestore()
+  })
+})

--- a/src/renderer/src/hooks/use-settled-agent-tool-step.ts
+++ b/src/renderer/src/hooks/use-settled-agent-tool-step.ts
@@ -1,0 +1,56 @@
+import { useEffect, useRef, useState } from 'react'
+
+export type AgentToolStep = {
+  toolName: string
+  toolInput: string
+}
+
+/**
+ * Minimum time a tool step stays on screen before the next one may replace it.
+ * STYLEGUIDE.md: feedback that lives under ~100ms "reads as a glitch"; agents
+ * emit several hooks per second, so the row needs a readable floor.
+ */
+export const AGENT_TOOL_STEP_DWELL_MS = 800
+
+/**
+ * Holds an agent's `toolName`/`toolInput` pair steady for a minimum dwell so the
+ * row reads instead of flickering (#11075). Steps arriving inside the dwell are
+ * coalesced to the newest one, so the pair is always atomic and the last value
+ * always lands. Hook events themselves are untouched — this is display only, and
+ * every other consumer still sees each event.
+ */
+export function useSettledAgentToolStep(
+  toolName: string,
+  toolInput: string,
+  dwellMs: number = AGENT_TOOL_STEP_DWELL_MS
+): AgentToolStep {
+  const [settled, setSettled] = useState<AgentToolStep>(() => ({ toolName, toolInput }))
+  const paintedAtRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    // Why: mount already painted a step, so its dwell starts here — otherwise the
+    // first rewrite after mount lands instantly and the row still flickers once.
+    paintedAtRef.current ??= Date.now()
+    if (toolName === settled.toolName && toolInput === settled.toolInput) {
+      return
+    }
+    const paint = (): void => {
+      paintedAtRef.current = Date.now()
+      setSettled({ toolName, toolInput })
+    }
+    // Why: an ABSOLUTE deadline off the last paint. Rescheduling on the next hook
+    // therefore re-aims at the same instant instead of restarting the dwell, which
+    // is what lets this effect own its own cleanup without starving the row.
+    const remainingMs = paintedAtRef.current + dwellMs - Date.now()
+    if (remainingMs <= 0) {
+      paint()
+      return
+    }
+    const timer = setTimeout(paint, remainingMs)
+    return () => {
+      clearTimeout(timer)
+    }
+  }, [toolName, toolInput, dwellMs, settled])
+
+  return settled
+}


### PR DESCRIPTION
## ELI5

While a Cursor agent works, it tells Orca what it's doing several times a second — "reading this file", "running that command". The sidebar row printed every single one of those onto the same line as the workspace's name. The name never actually changed, but the line it lived on was being rewritten ~8 times a second, so the whole row read as flickering. Now a step stays put long enough to read before the next one replaces it. Nothing is dropped — the row just stops repainting faster than a human can follow.

## What Changed

- New `useSettledAgentToolStep(toolName, toolInput)` (`src/renderer/src/hooks/use-settled-agent-tool-step.ts`): holds an agent's tool-step pair for a minimum **800ms dwell**, coalescing anything that arrives inside the window down to the newest value.
- The compact sidebar agent row (`worktree-card-compact-agent-row.tsx`) and its sibling `DashboardAgentRow` now read their `toolName`/`toolInput` through it.
- New suites: `use-settled-agent-tool-step.test.ts` (9) and `worktree-card-compact-agent-row.tool-step-flicker.test.tsx` (3).

Three properties matter and are each covered by a test:

1. **Nothing is dropped.** This is display-only. Hook events, the status store, notifications, and every other consumer still see all of them.
2. **The pair is atomic.** `toolName` and `toolInput` settle together, so the row can never show one step's name beside another step's input.
3. **The last value always lands.** The dwell is a floor on how fast the row repaints, never a filter — when the burst stops, the newest step is painted.

The dwell is scheduled off an **absolute deadline** (`lastPaintedAt + 800ms`), not a restarting timer. That's what lets the effect own its own `clearTimeout` cleanup — rescheduling on the next hook re-aims at the same instant instead of pushing the deadline out, so a continuously-churning row still repaints on schedule rather than being starved. (Sequential per-hook `setTimeout` bookkeeping was the first draft; React Doctor's `effect-needs-cleanup` correctly rejected it, and the absolute-deadline form is both cleaner and leak-free.)

## Why

#11075 reports the Cursor tab **and** sidebar title flickering. Those are two different surfaces with different code paths, so I checked both:

**The tab is already fixed on `main`.** The alternation the reporter saw was Orca's synthetic `⠋ Cursor Agent` spinner fighting `cursor-agent`'s bare `Cursor Agent` native OSC title, which it re-emits on every redraw. Frame-to-frame spinner churn was already collapsed by `isDecorativeAgentTitleFrameChange` (#5294, June 12 — *before* this issue was filed), but that guard deliberately does **not** collapse the spinner ↔ bare-literal pair, because the bare literal detects as `null` status and so has a different decorative signature. I verified that directly:

```
isDecorativeAgentTitleFrameChange('⠋ Cursor Agent', '⠙ Cursor Agent') === true
isDecorativeAgentTitleFrameChange('⠋ Cursor Agent', 'Cursor Agent')  === false
```

That second pair was the tab flicker, and it was closed on **Aug 9** by `shouldSuppressCursorNativeTitle` (#12466), which now suppresses the native re-emission at both `pty-transport.ts:133` and `:458` once a Cursor-owned title holds the pane. #11075 was filed July 28 against v1.4.158, so the tab half of this report is genuinely fixed — incidentally, by a PR for a different issue. **No tab-path change is needed and none is in this PR.**

> Correcting one detail from #14626, which reached the same conclusion by a slightly different route: it said the decorative-collapse machinery post-dates #11075. It predates it (#5294). The guard that actually fixed the tab is the *native-title suppression* from #12466, which does post-date the issue.

**The sidebar is the live defect,** and it is the one the reporter themselves isolated in the issue body ("the compact row is `primary - secondary` and secondary is live `tool: input`"). `getCompactAgentSecondary` recomputed `toolName: toolInput` on every status update and concatenated it onto the row's single `truncate`d line, immediately after the prompt. A Cursor turn emits `preToolUse` / `postToolUse` / `beforeShellExecution` / `beforeMCPExecution` continuously, so that line was rewritten several times a second.

It's worse than a fast ticker, because the secondary is a **priority ladder over three unrelated sources** — tool step, then `lastAssistantMessage`, then the agent-type label. `extractCursorToolFields` clears the tool pair outright on `postToolUseFailure` (`clearActiveToolFieldsUpdate()`, `agent-hook-listener.ts:1810`) *and* sets `lastAssistantMessage` to the error text on the same event. So a single failed tool made the line jump from `Bash: pnpm test` to a raw error string and back to a tool on the next hook — three unrelated content categories inside ~300ms. The dwell coalesces that transient away entirely, since it never outlives the window.

**Why stabilise the display rather than the events:** the events are correct and other consumers need them, so the fix belongs at the paint. STYLEGUIDE.md's in-flight-feedback table puts the perceptual floor at ~100ms ("anything visible reads as a glitch"); 800ms gives a tool step time to actually be read.

**Why `DashboardAgentRow` too, given the report only names the sidebar:** STYLEGUIDE.md UX rule 2 — it is the direct sibling (same data, same domain, adjacent surfaces), it renders the identical volatile pair, and it also feeds an expandable `<pre>` that a user opens specifically *to read* the tool input. Stabilising one and not the other would leave a seam. It's the same one-line change at both call sites.

### Superseded / related

- **Supersedes #11127** (@Fazalkadivar21). Same issue, and it correctly identified the compact-row secondary — but its three changes are each a regression:
  1. `resolveTerminalTabTitle` / `resolveUnifiedTabLabel` are rewritten so that when `tabAutoGenerateTitle` is on, **the `fallback` argument is dropped entirely** and the function returns `''` if there's no generated title. Its own added test asserts `.toBe('')`. That is a blank tab, and the PR body acknowledges it. It also changes titles for *every* agent, not just Cursor.
  2. It deletes `useAgentRowConversationName` from the compact row, so sidebar rows lose the conversation/generated tab name — an unrelated shipped feature.
  3. It removes the tool secondary outright rather than stabilising it, losing the live activity signal instead of making it readable.
  
  Its `terminals.ts` guard is also now redundant with `shouldSuppressCursorNativeTitle`, which landed after that branch was cut.
- Complements **#14626** (#12686, Cursor panes stuck `Working`), which deliberately left this cluster out after testing the flicker hypothesis. This PR starts from its findings and reaches the sidebar-row conclusion it pointed at. No file overlap.

## Linked Issue

Fixes #11075

## Visual Proof

Same component, same synthetic hook stream (a new tool step every 130ms, as Cursor emits), same 7-second window. Top is `main`, bottom is this PR.

https://github.com/user-attachments/assets/5965051b-81ce-4a97-8091-6cd0eca13f82

Sampling the rendered row text every 60ms over that window gives a hard count of distinct painted strings:

| | distinct repaints in 7s |
| --- | --- |
| `main` | **54** |
| this PR | **10** |

The capture harness mounted the real shipping `CompactAgentRow` against the real `main.css` tokens in Chromium and recorded both runs identically, reverting only the two source files in between. It was deleted before commit and is not part of the diff.

## Testing

`src/renderer/src/hooks/use-settled-agent-tool-step.test.ts` — 9 tests:

- Mounted step paints with no dwell; the first rewrite after mount waits one dwell.
- A burst of four rewrites inside one dwell paints **nothing**, then only the newest lands — the intermediates are never painted.
- The final step always lands once the burst stops.
- The pair never desyncs: every string the hook ever returns is a real `(name, input)` pair.
- A transient clear (the `postToolUseFailure` case) is coalesced away when a new step arrives inside the dwell, but a clear that outlives the dwell **does** land, so a finished row drops its tool step.
- A hook every 50ms for 2× the dwell still repaints on schedule — the absolute deadline is not restarted.
- The pending dwell is cleared on unmount.

`src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tool-step-flicker.test.tsx` — 3 tests, rendering the real row into a real DOM and asserting its `textContent` is byte-identical across a hook burst, that the prompt stays visible throughout, and that the newest step lands afterward.

**Proven non-vacuous.** Keeping both test files and reverting only the two source files (`git stash push -- <sources>`), the row suite goes **1 failed / 2 passed**, failing exactly on the churn assertion:

```
AssertionError: expected 'Refactor the intake flow - Grep: TODO…'
                to be      'Refactor the intake flow - Read: src/…'
```

With the fix applied it is 3 passed. The 2 that pass pre-fix are the controls the fix must not change (the prompt stays visible; the newest step eventually lands — both already true on `main`).

Scoped checks run locally (full `pnpm typecheck` skipped deliberately — OOM risk on this box; the node project is the one this diff touches):

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/hooks/use-settled-agent-tool-step.test.ts src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tool-step-flicker.test.tsx` — 12 passed
- [x] `… src/renderer/src/components/dashboard/ src/renderer/src/components/sidebar/WorktreeCardAgents*.test.tsx` — 25 files, 188 passed
- [x] `tsc --noEmit -p config/tsconfig.node.json --composite false` — clean
- [x] `pnpm run check:code-quality:changed` — oxlint, `--type-aware`, and React Doctor all 0 new findings across 5 changed files. The gate is demonstrably live: it failed this branch once on `react-doctor(effect-needs-cleanup)` and drove the absolute-deadline restructure described above.
- [x] `oxfmt --write` on the changed files

Six `WorktreeCard.*` suites (PR display, compact hover, lineage, pinned repo icon, hosted review refresh) time out when the full 250-file sidebar+dashboard run is executed in one parallel batch. All six pass when run on their own, none of them touch agent rows, and the set that times out varies between runs — load-dependent flake, not this change.

Platforms actually exercised: macOS. The issue is labelled `os:linux`; nothing here is platform-specific (see Review).

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

- **Performance:** deliberately O(1) per render — the hook is one `useState`, one `useRef`, and two string compares, with no map or store scans. This matters because STA-3354 already flags tab-agent status resolution as scanning the global status map per tab per render; nothing here adds to that. It does not add renders either: the rows still re-render on every hook (their props change regardless), the dwell only governs what is *painted*. It removes work if anything, by cutting DOM text mutations ~5×. At most one live timer per churning row, cleared on unmount.
- **Correctness:** the dwell is a floor on repaint rate, never a filter. Every value eventually lands; the pair is atomic; `interrupted` is still checked ahead of the tool step so an interrupt surfaces immediately rather than waiting behind a dwell.
- **Security:** none. Display-only, no new inputs, IPC, paths, or process execution. Tool strings were already rendered by both rows and are still capped upstream by `deriveToolInputPreview`.
- **Cross-platform:** no paths, shells, accelerators, shortcut labels, or platform branches — pure renderer state and string comparison. Identical on macOS, Linux, and Windows. The report is `os:linux`; the mechanism is the hook cadence, which is platform-independent, and I could not reproduce on Linux hardware from here.
- **Remote / SSH:** no wire change, no new RPC params, stream frames, or published content. Status still arrives exactly as before; only the renderer's paint cadence changed. If anything this helps under SSH, where bursts arrive batchier.
- **Mobile:** unaffected — neither row ships to mobile.
- **Backwards compatibility:** no persisted state, no settings, no schema. Reverting the two call sites restores the previous behavior exactly.
- **Accessibility:** the row's `title` attribute is built from the same settled strings, so the tooltip and the visible text never disagree.

## Author

- X / Twitter: @BrennanKB5
