### PR TITLE
fix(browser): align anti-detection identity signals

### DIFF
--- a/src/main/browser/anti-detection.test.ts
+++ b/src/main/browser/anti-detection.test.ts
@@ -2,6 +2,7 @@ import { runInNewContext } from 'node:vm'
 import { describe, expect, it } from 'vitest'
 
 import { ANTI_DETECTION_SCRIPT } from './anti-detection'
+import { googleAuthUserAgent } from './browser-google-auth-ua'
 
 type PermissionQueryResult = {
   state: string
@@ -14,8 +15,16 @@ type AntiDetectionContext = {
     requestPermission: (callback?: (permission: string) => void) => Promise<string>
   }
   navigator: {
+    userAgent: string
     permissions: {
       query: (descriptor: { name: string }) => Promise<PermissionQueryResult>
+    }
+  }
+  window: {
+    chrome?: {
+      runtime?: unknown
+      csi?: () => unknown
+      loadTimes?: () => unknown
     }
   }
 }
@@ -23,6 +32,7 @@ type AntiDetectionContext = {
 function createContext(args: {
   nativeNotificationPermission: string
   requestedNotificationPermission: string
+  userAgent?: string
 }): AntiDetectionContext & Record<string, unknown> {
   class Permissions {
     query(): Promise<PermissionQueryResult> {
@@ -50,6 +60,9 @@ function createContext(args: {
     performance: { now: () => 0 },
     window: {},
     navigator: {
+      userAgent:
+        args.userAgent ??
+        'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36',
       plugins: [],
       languages: [],
       permissions: new Permissions()
@@ -60,6 +73,48 @@ function createContext(args: {
 }
 
 describe('ANTI_DETECTION_SCRIPT', () => {
+  it('does not expose Chrome globals under a Firefox identity', () => {
+    const context = createContext({
+      nativeNotificationPermission: 'denied',
+      requestedNotificationPermission: 'denied',
+      userAgent: googleAuthUserAgent()
+    })
+
+    runInNewContext(ANTI_DETECTION_SCRIPT, context)
+
+    expect(context.window.chrome).toBeUndefined()
+  })
+
+  it('keeps Chrome API stubs aligned with an ordinary Chrome page', () => {
+    const context = createContext({
+      nativeNotificationPermission: 'denied',
+      requestedNotificationPermission: 'denied'
+    })
+
+    runInNewContext(ANTI_DETECTION_SCRIPT, context)
+
+    expect(context.window.chrome?.runtime).toBeUndefined()
+    expect(context.window.chrome?.csi).toBeTypeOf('function')
+    expect(context.window.chrome?.loadTimes).toBeTypeOf('function')
+  })
+
+  it.each(['geolocation', 'idle-detection', 'midi', 'storage-access'])(
+    'preserves the native denied state for %s',
+    async (name) => {
+      const context = createContext({
+        nativeNotificationPermission: 'denied',
+        requestedNotificationPermission: 'denied'
+      })
+
+      runInNewContext(ANTI_DETECTION_SCRIPT, context)
+
+      await expect(context.navigator.permissions.query({ name })).resolves.toEqual({
+        state: 'denied',
+        onchange: null
+      })
+    }
+  )
+
   it('reports notification permission as granted after a site permission request succeeds', async () => {
     const context = createContext({
       nativeNotificationPermission: 'denied',

--- a/src/main/browser/anti-detection.test.ts
+++ b/src/main/browser/anti-detection.test.ts
@@ -58,7 +58,8 @@ function createContext(args: {
     Promise,
     Set,
     performance: { now: () => 0 },
-    window: {},
+    // Electron 43 exposes this native object before the anti-detection script runs.
+    window: { chrome: {} },
     navigator: {
       userAgent:
         args.userAgent ??
@@ -83,6 +84,7 @@ describe('ANTI_DETECTION_SCRIPT', () => {
     runInNewContext(ANTI_DETECTION_SCRIPT, context)
 
     expect(context.window.chrome).toBeUndefined()
+    expect('chrome' in context.window).toBe(false)
   })
 
   it('keeps Chrome API stubs aligned with an ordinary Chrome page', () => {

--- a/src/main/browser/anti-detection.ts
+++ b/src/main/browser/anti-detection.ts
@@ -16,44 +16,43 @@ export const ANTI_DETECTION_SCRIPT = `(function() {
       ]
     });
   }
-  // Why: Electron webviews may not have the window.chrome object that real
-  // Chrome exposes. Turnstile checks for its presence. The csi() and
-  // loadTimes() stubs satisfy deeper probes that check for these Chrome-
-  // specific APIs beyond just chrome.runtime.
-  if (!window.chrome) {
-    window.chrome = {};
-  }
-  if (!window.chrome.runtime) {
-    window.chrome.runtime = {};
-  }
-  if (!window.chrome.csi) {
-    window.chrome.csi = function() {
-      return {
-        startE: Date.now(),
-        onloadT: Date.now(),
-        pageT: performance.now(),
-        tran: 15
+  // Why: auth hosts present Firefox, where exposing Chrome-only globals is a direct identity mismatch.
+  if (!navigator.userAgent.includes('Firefox/')) {
+    // Why: Electron webviews may not have the window.chrome object that real
+    // Chrome exposes. Turnstile checks for its presence. The csi() and
+    // loadTimes() stubs satisfy deeper probes of Chrome-specific APIs.
+    if (!window.chrome) {
+      window.chrome = {};
+    }
+    if (!window.chrome.csi) {
+      window.chrome.csi = function() {
+        return {
+          startE: Date.now(),
+          onloadT: Date.now(),
+          pageT: performance.now(),
+          tran: 15
+        };
       };
-    };
-  }
-  if (!window.chrome.loadTimes) {
-    window.chrome.loadTimes = function() {
-      return {
-        commitLoadTime: Date.now() / 1000,
-        connectionInfo: 'h2',
-        finishDocumentLoadTime: Date.now() / 1000,
-        finishLoadTime: Date.now() / 1000,
-        firstPaintAfterLoadTime: 0,
-        firstPaintTime: Date.now() / 1000,
-        navigationType: 'Other',
-        npnNegotiatedProtocol: 'h2',
-        requestTime: Date.now() / 1000 - 0.16,
-        startLoadTime: Date.now() / 1000 - 0.3,
-        wasAlternateProtocolAvailable: false,
-        wasFetchedViaSpdy: true,
-        wasNpnNegotiated: true
+    }
+    if (!window.chrome.loadTimes) {
+      window.chrome.loadTimes = function() {
+        return {
+          commitLoadTime: Date.now() / 1000,
+          connectionInfo: 'h2',
+          finishDocumentLoadTime: Date.now() / 1000,
+          finishLoadTime: Date.now() / 1000,
+          firstPaintAfterLoadTime: 0,
+          firstPaintTime: Date.now() / 1000,
+          navigationType: 'Other',
+          npnNegotiatedProtocol: 'h2',
+          requestTime: Date.now() / 1000 - 0.16,
+          startLoadTime: Date.now() / 1000 - 0.3,
+          wasAlternateProtocolAvailable: false,
+          wasFetchedViaSpdy: true,
+          wasNpnNegotiated: true
+        };
       };
-    };
+    }
   }
   // Why: Electron's Permission API defaults to 'denied' for most permissions,
   // but real Chrome returns 'prompt' for ungranted permissions. Returning
@@ -77,8 +76,7 @@ export const ANTI_DETECTION_SCRIPT = `(function() {
     }
   } catch {}
   const promptPerms = new Set([
-    'geolocation', 'camera', 'microphone',
-    'midi', 'idle-detection', 'storage-access'
+    'camera', 'microphone'
   ]);
   const origQuery = Permissions.prototype.query;
   Permissions.prototype.query = function(desc) {

--- a/src/main/browser/anti-detection.ts
+++ b/src/main/browser/anti-detection.ts
@@ -16,8 +16,15 @@ export const ANTI_DETECTION_SCRIPT = `(function() {
       ]
     });
   }
-  // Why: auth hosts present Firefox, where exposing Chrome-only globals is a direct identity mismatch.
-  if (!navigator.userAgent.includes('Firefox/')) {
+  // Why: auth hosts present Firefox, where Electron's native window.chrome is an identity mismatch.
+  if (navigator.userAgent.includes('Firefox/')) {
+    try {
+      delete window.chrome;
+      if ('chrome' in window) {
+        window.chrome = undefined;
+      }
+    } catch {}
+  } else {
     // Why: Electron webviews may not have the window.chrome object that real
     // Chrome exposes. Turnstile checks for its presence. The csi() and
     // loadTimes() stubs satisfy deeper probes of Chrome-specific APIs.


### PR DESCRIPTION
## ELI5

We were telling Google's sign-in page "I'm Firefox" while handing it Chrome-only APIs, and telling sites a permission would prompt when we were going to silently deny it. Both now tell one story.

## What Changed

**1. Chrome-only globals are no longer shipped under the Firefox auth UA.** `window.chrome`, `chrome.csi()` and `chrome.loadTimes()` are gated behind `!navigator.userAgent.includes('Firefox/')`. The guards were previously **existence** checks, never UA checks, while we present a Firefox UA on `accounts.google.com` / `accounts.youtube.com`.

**2. The `chrome.runtime = {}` stub is removed.** Real Chrome reports `chrome.runtime === undefined` on an ordinary page — measured. The stub added to look *more* like Chrome made us look *less* like it.

**3. `promptPerms` narrowed to `camera` / `microphone`.** Those two genuinely resolve through macOS TCC, so `'prompt'` is honest. `geolocation`, `midi`, `idle-detection` and `storage-access` are hard-denied by `browser-session-permission-policy.ts`, so reporting `'prompt'` sent sites down a "the user will be asked" branch that ended in a silent denial.

## Why

Measured against real Chrome 151, same Mac and page:

| probe | real Chrome | Orca (before) |
| --- | --- | --- |
| `window.chrome.runtime` | `undefined` | `object` |

GH #12852 reports "Email signing fails at the anti bot verification" in the in-app browser. An identity that contradicts itself across layers is exactly what those checks key on.

The permission **policy** is deliberately unchanged — whether to grant `storage-access` is a separate product decision, and this PR only stops misreporting the current policy.

## Linked Issue

Fixes #14681

## Visual Proof

N/A — no visual surface; the change is observable only via JS APIs presented to pages. Live before/after measurements are in Testing.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Extended the existing `runInNewContext` harness. **Verified non-vacuous:** reverting the production change turns **6 of 8** tests red (Chrome globals under a Firefox identity, stub alignment with an ordinary Chrome page, and the four preserved denied states).

Gates: 643 browser tests pass · `pnpm typecheck` clean · `oxlint` clean · `oxfmt --check` clean.

**Not verified:** a live Cloudflare Turnstile challenge end to end. The public demo uses an always-passes dummy sitekey, so it proves nothing. Since these stubs exist for Turnstile (#885), that gap is called out rather than glossed.

## Review

Security: only removes/gates signals presented to pages; it cannot widen what a site sees. Cross-platform: pure JS in the injected script, no platform branches. No IPC, path, or shell changes.

## Checklist

- [x] Scope kept tight — permission policy untouched
- [x] No `max-lines` disable or baseline bump
