### PR TITLE
fix(agent-launch): preserve cold Codex startup drafts

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines -- Why: runtime behavior is stateful and cross-cutting, so these tests stay in one file to preserve the end-to-end invariants around handles, waits, and graph sync. */
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, onTestFinished, vi } from 'vitest'
 import type * as GitUsernameModule from '../git/git-username'
 import { performance } from 'node:perf_hooks'
 import { EventEmitter } from 'node:events'
@@ -44208,6 +44208,10 @@ describe('OrcaRuntimeService', () => {
   })
 
   it('uses desktop task agent selection and bracketed-pastes startup drafts for local worktrees', async () => {
+    vi.useFakeTimers()
+    onTestFinished(() => {
+      vi.useRealTimers()
+    })
     detectInstalledAgentsWithShellPathHydrationMock.mockResolvedValue(['claude'])
     const metaById: Record<string, WorktreeMeta> = {}
     const runtimeStore = {
@@ -44280,10 +44284,82 @@ describe('OrcaRuntimeService', () => {
     )
     expect(metaById[result.worktree.id]).toMatchObject({ createdWithAgent: 'codex' })
 
-    runtime.onPtyData('pty-startup-draft', '\x1b[?2004h›', Date.now())
-    await vi.waitFor(() => {
-      expect(write).toHaveBeenCalledWith('pty-startup-draft', `\x1b[200~${draftUrl}\x1b[201~`)
+    runtime.onPtyData('pty-startup-draft', '\x1b[?2004h', Date.now())
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(write).not.toHaveBeenCalled()
+
+    runtime.onPtyData('pty-startup-draft', '›', Date.now())
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(write).toHaveBeenCalledWith('pty-startup-draft', `\x1b[200~${draftUrl}\x1b[201~`)
+  })
+
+  it('keeps the 8s main-runtime startup readiness budget for non-Codex agents', async () => {
+    vi.useFakeTimers()
+    onTestFinished(() => {
+      vi.useRealTimers()
     })
+    const runtimeStore = {
+      ...store,
+      getSettings: () => ({
+        ...store.getSettings(),
+        defaultTuiAgent: 'opencode' as const,
+        agentCmdOverrides: {}
+      })
+    }
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    const spawn = vi.fn().mockResolvedValue({ id: 'pty-opencode-draft-timeout' })
+    const write = vi.fn().mockReturnValue(true)
+    runtime.setPtyController({
+      spawn,
+      write,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    runtime.setNotifier({
+      worktreesChanged: vi.fn(),
+      reposChanged: vi.fn(),
+      activateWorktree: vi.fn(),
+      createTerminal: vi.fn(),
+      revealTerminalSession: vi.fn().mockResolvedValue({ tabId: 'tab-opencode-draft-timeout' }),
+      splitTerminal: vi.fn(),
+      renameTerminal: vi.fn(),
+      focusTerminal: vi.fn(),
+      closeTerminal: vi.fn(),
+      sleepWorktree: vi.fn(),
+      terminalFitOverrideChanged: vi.fn(),
+      terminalDriverChanged: vi.fn()
+    })
+    runtime.attachWindow(1)
+
+    computeWorktreePathMock.mockReturnValue('/tmp/workspaces/runtime-opencode-draft-timeout')
+    ensurePathWithinWorkspaceMock.mockReturnValue('/tmp/workspaces/runtime-opencode-draft-timeout')
+    vi.mocked(listWorktrees).mockResolvedValue([
+      {
+        path: '/tmp/workspaces/runtime-opencode-draft-timeout',
+        head: 'def',
+        branch: 'runtime-opencode-draft-timeout',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    await runtime.createManagedWorktree({
+      repoSelector: 'id:repo-1',
+      name: 'runtime-opencode-draft-timeout',
+      startupDraft: 'https://github.com/stablyai/orca/issues/456'
+    })
+
+    await vi.advanceTimersByTimeAsync(7999)
+    expect(write).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1)
+    runtime.onPtyData('pty-opencode-draft-timeout', '\x1b[?2004h\x1b[?25h', Date.now())
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(write).not.toHaveBeenCalled()
   })
 
   it('rejects explicit startup commands for disabled selected agents', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -479,6 +479,7 @@ import {
   isTuiAgent,
   TUI_AGENT_CONFIG
 } from '../../shared/tui-agent-config'
+import { resolveDraftPasteReadyTimeoutMs } from '../../shared/draft-paste-ready-timeout'
 import { createDraftPasteReadyScanner } from '../../shared/draft-paste-ready-scanner'
 import { detectInstalledAgentsWithShellPathHydration, detectRemoteAgents } from '../ipc/preflight'
 import {
@@ -1863,7 +1864,6 @@ const FOREGROUND_AGENT_WRAPPER_RETRY_TIMEOUT_MS = 6_500
 const BRACKETED_PASTE_BEGIN = '\x1b[200~'
 const BRACKETED_PASTE_END = '\x1b[201~'
 const BRACKETED_PASTE_QUIET_MS = 1500
-const DRAFT_PASTE_READY_TIMEOUT_MS = 8000
 const AGENT_PROMPT_RENDER_TIMEOUT_MS = 8000
 const AGENT_PROMPT_RENDER_QUIET_MS = 1500
 // Why: Claude and Codex emit show-cursor while rendering pasted composer content.
@@ -22197,7 +22197,7 @@ export class OrcaRuntimeService {
       if (replay) {
         observeData(replay)
       }
-      hardTimer = setTimeout(() => finish(null), DRAFT_PASTE_READY_TIMEOUT_MS)
+      hardTimer = setTimeout(() => finish(null), resolveDraftPasteReadyTimeoutMs(agent))
     })
   }
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -6544,13 +6544,14 @@ describe('connectPanePty', () => {
     expect(transport.sendInput).not.toHaveBeenCalledWith("claude 'say test'\r")
   })
 
-  it('arms draft observation after a provider-owned SSH startup succeeds', async () => {
+  it('keeps the 8s fallback after a provider-owned non-Codex startup succeeds', async () => {
+    vi.useFakeTimers()
     const { connectPanePty } = await import('./pty-connection')
     const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
-    const transport = createMockTransport('pty-codex')
+    const transport = createMockTransport('pty-droid')
     transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
       capturedDataCallback.current = callbacks.onData ?? null
-      return 'pty-ssh-codex'
+      return 'pty-ssh-droid'
     })
     transportFactoryQueue.push(transport)
     mockStoreState = {
@@ -6559,31 +6560,36 @@ describe('connectPanePty', () => {
       repos: [{ id: 'repo1', connectionId: 'ssh-conn-1' }],
       sshConnectionStates: new Map([['ssh-conn-1', { status: 'connected' }]])
     }
-    const prompt = 'https://linear.app/stably/issue/STA-4067'
+    vi.mocked(window.api.pty.getForegroundProcess).mockResolvedValue('droid')
+    const prompt = 'Review the linked work item'
 
     connectPanePty(
       createPane(1) as never,
       createManager(1) as never,
       createDeps({
         startup: {
-          command: 'codex',
-          launchAgent: 'codex',
+          command: 'droid',
+          launchAgent: 'droid',
           launchConfig: { agentArgs: '', agentEnv: {} },
           launchToken: 'launch-token-ssh',
           draftPrompt: prompt
         }
       }) as never
     )
+    await vi.advanceTimersByTimeAsync(20)
     await flushAsyncTicks()
-    capturedDataCallback.current?.('\x1b[?2004h\x1b[2K› ')
+    await vi.advanceTimersByTimeAsync(7900)
+    expect(transport.sendInputAccepted).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(100)
     await flushAsyncTicks()
 
     expect(createdTransportOptions[0]?.commandDelivery).toBe('provider')
-    expect(transport.sendInput).not.toHaveBeenCalledWith('codex\r')
+    expect(transport.sendInput).not.toHaveBeenCalledWith('droid\r')
     expect(transport.sendInputAccepted).toHaveBeenCalledWith(`\x1b[200~${prompt}\x1b[201~`)
   })
 
-  it('orders a startup draft behind existing user input when Codex renders its composer', async () => {
+  it('waits past 8s for a cold Codex composer and preserves input ordering', async () => {
+    vi.useFakeTimers()
     const { connectPanePty } = await import('./pty-connection')
 
     const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
@@ -6611,8 +6617,10 @@ describe('connectPanePty', () => {
         draftPrompt: 'https://github.com/stablyai/orca/issues/42'
       }
     })
+    vi.mocked(window.api.pty.getForegroundProcess).mockResolvedValue('codex')
 
     connectPanePty(pane as never, manager as never, deps as never)
+    await vi.advanceTimersByTimeAsync(VISIBLE_PTY_SETTLE_MS)
     await flushAsyncTicks()
     expect(capturedDataCallback.current).not.toBeNull()
 
@@ -6628,6 +6636,8 @@ describe('connectPanePty', () => {
       }
     ).mock.calls[0]?.[0]('USER_DRAFT')
     ;(mockStoreState.recordTerminalInput as ReturnType<typeof vi.fn>).mockClear()
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(transport.sendInputAccepted).not.toHaveBeenCalled()
     capturedDataCallback.current?.('\x1b[?2004h\x1b[2K› ')
     await flushAsyncTicks()
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -313,6 +313,7 @@ import {
 import type { TuiAgent } from '../../../../shared/tui-agent'
 import type { SetupSplitDirection } from '../../../../shared/worktree/launch-types'
 import { isTuiAgent, TUI_AGENT_CONFIG } from '../../../../shared/tui-agent-config'
+import { resolveDraftPasteReadyTimeoutMs } from '../../../../shared/draft-paste-ready-timeout'
 import { createDraftPasteReadyScanner } from '../../../../shared/draft-paste-ready-scanner'
 import { sendAgentDraftPasteContent } from '@/lib/agent-draft-paste-content'
 import { writeTerminalPastePtyInput } from './terminal-pty-paste-writer'
@@ -351,7 +352,6 @@ const STARTUP_DRAFT_PASTE_QUIET_MS = 1500
 // contain private repo/user names; the terminal itself shows where it opened.
 export const STARTUP_CWD_FALLBACK_NOTICE =
   '\r\n[Orca opened this terminal at the workspace root because its saved start folder no longer exists.]\r\n'
-const STARTUP_DRAFT_PASTE_TIMEOUT_MS = 8000
 const HIDDEN_OUTPUT_RESTORE_PENDING_CHARS = 512 * 1024
 const HIDDEN_OUTPUT_RESTORE_DEFERRED_RETRY_MS = 50
 const HIDDEN_OUTPUT_RESTORE_DEFERRED_RETRY_MAX = 3
@@ -4937,7 +4937,7 @@ export function connectPanePty(
       startupDraftHardTimer = setTimeout(() => {
         startupDraftHardTimer = null
         void deliverStartupDraftIfAgentOwnsPty()
-      }, STARTUP_DRAFT_PASTE_TIMEOUT_MS)
+      }, resolveDraftPasteReadyTimeoutMs(startupDraftAgent))
     }
     const armStartupDraftQuietTimer = (): void => {
       if (!startupDraftReadyScanner || startupDraftPasteSettled) {

--- a/src/renderer/src/lib/agent-paste-draft-readiness-budget.test.ts
+++ b/src/renderer/src/lib/agent-paste-draft-readiness-budget.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { pasteDraftToAgentPtyWhenReady } from './agent-paste-draft'
+
+const testState = vi.hoisted(() => ({
+  waitForReady: vi.fn(),
+  inspectProcess: vi.fn(),
+  sendInput: vi.fn()
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: () => ({ settings: {}, tabsByWorktree: {} })
+  }
+}))
+
+vi.mock('./agent-draft-readiness', () => ({
+  waitForAgentDraftInputReady: testState.waitForReady
+}))
+
+vi.mock('@/runtime/runtime-terminal-inspection', () => ({
+  inspectRuntimeTerminalProcess: testState.inspectProcess,
+  sendRuntimePtyInputVerified: testState.sendInput
+}))
+
+describe('pty-bound agent draft readiness budget', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.stubGlobal('window', {
+      setTimeout: globalThis.setTimeout,
+      clearTimeout: globalThis.clearTimeout
+    })
+    testState.waitForReady.mockReset()
+    testState.waitForReady.mockImplementation(
+      (_ptyId: string, timeoutMs: number) =>
+        new Promise<boolean>((resolve) => {
+          setTimeout(() => resolve(timeoutMs >= 10_000), Math.min(timeoutMs, 10_000))
+        })
+    )
+    testState.inspectProcess.mockReset()
+    testState.inspectProcess.mockResolvedValue({
+      foregroundProcess: 'bash',
+      hasChildProcesses: false
+    })
+    testState.sendInput.mockReset()
+    testState.sendInput.mockResolvedValue(true)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('delivers when a cold Codex composer becomes ready after 8s', async () => {
+    const promise = pasteDraftToAgentPtyWhenReady({
+      tabId: 'tab-1',
+      ptyId: 'pty-1',
+      content: 'draft',
+      agent: 'codex',
+      forcePaste: true
+    })
+
+    await vi.advanceTimersByTimeAsync(10_000)
+
+    await expect(promise).resolves.toBe(true)
+    expect(testState.waitForReady).toHaveBeenCalledWith(
+      'pty-1',
+      20_000,
+      'codex-composer-prompt',
+      {}
+    )
+    expect(testState.sendInput).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the 8s readiness deadline for non-Codex agents', async () => {
+    const onTimeout = vi.fn()
+    const promise = pasteDraftToAgentPtyWhenReady({
+      tabId: 'tab-1',
+      ptyId: 'pty-1',
+      content: 'draft',
+      agent: 'opencode',
+      forcePaste: true,
+      onTimeout
+    })
+
+    await vi.advanceTimersByTimeAsync(9000)
+
+    await expect(promise).resolves.toBe(false)
+    expect(testState.waitForReady).toHaveBeenCalledWith(
+      'pty-1',
+      8000,
+      'render-cursor-after-bracketed-paste',
+      {}
+    )
+    expect(onTimeout).toHaveBeenCalledTimes(1)
+    expect(testState.sendInput).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/lib/agent-paste-draft.ts
+++ b/src/renderer/src/lib/agent-paste-draft.ts
@@ -1,6 +1,7 @@
 import type { GlobalSettings } from '../../../shared/global-settings-types'
 import type { TuiAgent } from '../../../shared/tui-agent'
 import { TUI_AGENT_CONFIG } from '../../../shared/tui-agent-config'
+import { resolveDraftPasteReadyTimeoutMs } from '../../../shared/draft-paste-ready-timeout'
 import { useAppStore } from '@/store'
 import {
   inspectRuntimeTerminalProcess,
@@ -45,8 +46,6 @@ export function sanitizeBracketedPasteContent(content: string): string {
 // composer budget on top would only delay that verdict. Keeping them distinct
 // also stops one slow step from spending the other's budget (STA-3367).
 const PTY_SPAWN_TIMEOUT_MS = 8000
-const READINESS_TIMEOUT_MS = 8000
-const CODEX_COMPOSER_READY_TIMEOUT_MS = 20000
 
 export function getSettingsForAgentTabRuntimeOwner(
   tabId: string
@@ -103,8 +102,7 @@ export async function pasteDraftWhenAgentReady(args: {
 
   const readySignal = agentConfig?.draftPasteReadySignal ?? 'render-quiet-after-bracketed-paste'
   const settings = getSettingsForAgentTabRuntimeOwner(tabId)
-  const readinessTimeoutMs =
-    timeoutMs ?? (agent === 'codex' ? CODEX_COMPOSER_READY_TIMEOUT_MS : READINESS_TIMEOUT_MS)
+  const readinessTimeoutMs = resolveDraftPasteReadyTimeoutMs(agent, timeoutMs)
   const readiness = await waitForAgentDraftInputReadyOnTab({
     tabId,
     spawnTimeoutMs: PTY_SPAWN_TIMEOUT_MS,
@@ -159,7 +157,7 @@ export async function pasteDraftToAgentPtyWhenReady(args: {
 
   const settings = getSettingsForAgentTabRuntimeOwner(tabId)
   const readySignal = agentConfig?.draftPasteReadySignal ?? 'render-quiet-after-bracketed-paste'
-  const budget = timeoutMs ?? READINESS_TIMEOUT_MS
+  const budget = resolveDraftPasteReadyTimeoutMs(agent, timeoutMs)
   const ready = await waitForAgentDraftInputReady(ptyId, budget, readySignal, settings)
   if (!ready) {
     const fallbackReady = agentConfig

--- a/src/shared/draft-paste-ready-timeout.ts
+++ b/src/shared/draft-paste-ready-timeout.ts
@@ -1,0 +1,12 @@
+import type { TuiAgent } from './tui-agent'
+import { TUI_AGENT_CONFIG } from './tui-agent-config'
+
+const DEFAULT_DRAFT_PASTE_READY_TIMEOUT_MS = 8000
+
+export function resolveDraftPasteReadyTimeoutMs(agent?: TuiAgent, overrideMs?: number): number {
+  return (
+    overrideMs ??
+    (agent ? TUI_AGENT_CONFIG[agent].draftPasteReadyTimeoutMs : undefined) ??
+    DEFAULT_DRAFT_PASTE_READY_TIMEOUT_MS
+  )
+}

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -38,8 +38,10 @@ export type TuiAgentConfig = {
   draftPromptEnvVar?: string
   /** Pre-write a trust artifact so the agent's first-launch "trust this folder?" menu doesn't consume the bracketed paste (see agent-trust-presets.ts). */
   preflightTrust?: 'cursor' | 'copilot' | 'codex'
-  /** Renderer-specific signal that the composer is ready for paste, stronger than the default quiet-render window. */
+  /** Agent-specific signal that the composer is ready for paste, stronger than the default quiet-render window. */
   draftPasteReadySignal?: DraftPasteReadySignal
+  /** Hard deadline for the agent's composer readiness signal. */
+  draftPasteReadyTimeoutMs?: number
   /** Windows Shift+Enter encoding override; omitted agents keep the legacy Esc+CR path. */
   windowsShiftEnterEncoding?: 'csi-u'
   /** Paste newlines for TUIs that read Windows console input records instead of VT paste frames. */
@@ -87,7 +89,8 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
     promptInjectionMode: 'argv',
     windowsInputRecordPasteNewline: 'alt-enter',
     preflightTrust: 'codex',
-    draftPasteReadySignal: 'codex-composer-prompt'
+    draftPasteReadySignal: 'codex-composer-prompt',
+    draftPasteReadyTimeoutMs: 20_000
   },
   autohand: {
     detectCmd: 'autohand',


### PR DESCRIPTION
## ELI5

Cold Codex sessions can take longer than eight seconds to show a safe composer. Workspace startup drafts now wait for the same Codex-specific readiness window as ordinary tab drafts, so the first prompt is not pasted early or dropped.

## What Changed

- Added one shared agent-keyed draft readiness timeout resolver.
- Configured Codex for 20 seconds while retaining the 8-second default for every other agent.
- Applied the resolver to renderer known-PTY startup delivery and main-runtime startup delivery.
- Added regressions for readiness at 10 seconds and the non-Codex 8-second deadline.

## Why

Workspace-startup draft owners drifted from the ordinary Codex tab path and retained the generic 8-second deadline. Co-locating the override with Codex readiness configuration gives both runtime owners one source of truth without crossing main/renderer boundaries.

## Linked Issue

Fixes [STA-4385](https://linear.app/stably/issue/STA-4385/p1continuous-cold-codex-workspace-startup-drafts-still-use-8s)

## Visual Proof

Electron QA at exact pushed HEAD `3beb584bdc0c7e5a65a8fd90b6aae0208d3db68b` (Fork Agent Session flow, uncropped full-window screenshot — editable Codex composer draft `[Pasted Content 10646 chars]`, no submit):

![pr14688-fork-draft-proof.png](https://github.com/user-attachments/assets/6d4face7-dcbe-42c4-b261-75b361616962)

Full QA comment with backing state and residual gap: [https://github.com/stablyai/orca/pull/14688#issuecomment-5300849679](https://github.com/stablyai/orca/pull/14688#issuecomment-5300849679)

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Passed locally:
- Renderer draft tests: 40 tests
- Main-runtime focused startup tests: 2 tests
- TypeScript typecheck
- Touched-file oxlint with warnings denied
- Max-lines ratchet

## AI Disclosure

## Review

Reviewed for security, cross-platform support, remote/SSH behavior, mobile compatibility, backward compatibility, and performance. The change is in-memory configuration only and adds no wire or persisted-state contract.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or N/A with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] pnpm lint, pnpm typecheck, pnpm test, and pnpm build pass (or CI will cover; local preferred)

## Author

- X / Twitter: @BrennanKB5

