### PR TITLE
Add shortcuts to navigate active worktrees

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-keyboard-cycle.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-keyboard-cycle.test.ts
@@ -2,7 +2,11 @@ import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import type { HostSectionRow } from './host-section-rows'
-import { getCyclableWorktreeIds, resolveCycledWorktreeId } from './worktree-keyboard-cycle'
+import {
+  getActiveCyclableWorktreeIds,
+  getCyclableWorktreeIds,
+  resolveCycledWorktreeId
+} from './worktree-keyboard-cycle'
 
 describe('resolveCycledWorktreeId', () => {
   const worktreeIds = ['a', 'b', 'c']
@@ -127,6 +131,27 @@ describe('getCyclableWorktreeIds', () => {
 
     expect(getCyclableWorktreeIds(rows, 'single-location')).toEqual(['visible-after-host'])
   })
+
+  it('keeps only worktrees with a live terminal, browser, or agent', () => {
+    const rows: HostSectionRow[] = [
+      worktree('terminal'),
+      worktree('browser'),
+      worktree('agent'),
+      worktree('sleeping')
+    ]
+
+    expect(
+      getActiveCyclableWorktreeIds(rows, 'single-location', {
+        tabsByWorktree: {
+          terminal: [{ id: 'terminal-tab' }],
+          agent: [{ id: 'agent-tab' }]
+        },
+        ptyIdsByTabId: { 'terminal-tab': ['pty-1'] },
+        browserTabsByWorktree: { browser: [{ id: 'browser-tab' }] },
+        worktreeIdsWithLiveAgent: new Set(['agent'])
+      })
+    ).toEqual(['terminal', 'browser', 'agent'])
+  })
 })
 
 describe('WorktreeList keyboard cycling', () => {
@@ -145,6 +170,7 @@ describe('WorktreeList keyboard cycling', () => {
     // Why: a second buildRows call drifts from the rendered layout (host sections,
     // pinned placement); cycling must read the same rows the viewport renders.
     expect(navigateWorktree).toContain('getCyclableWorktreeIds(rows, pinnedDisplayPolicy)')
+    expect(navigateWorktree).toContain('getActiveCyclableWorktreeIds(rows, pinnedDisplayPolicy')
     expect(navigateWorktree).toContain('resolveCycledWorktreeId')
     expect(navigateWorktree).not.toContain('buildRows(')
   })

--- a/src/renderer/src/components/sidebar/worktree-keyboard-cycle.ts
+++ b/src/renderer/src/components/sidebar/worktree-keyboard-cycle.ts
@@ -1,6 +1,14 @@
 import type { HostSectionRow } from './host-section-rows'
+import { hasActiveWorkspaceActivity } from '@/lib/worktree-activity-state'
 import type { PinnedWorktreeDisplayPolicy, WorktreeRow } from './worktree-list-groups'
 import { getPreferredWorktreeRows } from './worktree-sidebar-row-preference'
+
+type ActiveWorktreeInputs = {
+  tabsByWorktree: Record<string, readonly { id: string }[]>
+  ptyIdsByTabId: Record<string, string[]>
+  browserTabsByWorktree: Record<string, readonly { id: string }[]>
+  worktreeIdsWithLiveAgent: ReadonlySet<string>
+}
 
 /** Worktree ids in sidebar order, taken from the rows the sidebar actually
  *  rendered, so collapsed groups and collapsed host sections drop out on their own. */
@@ -21,6 +29,23 @@ export function getCyclableWorktreeIds(
     ids.push(row.worktree.id)
   }
   return ids
+}
+
+/** Worktree ids in sidebar order that still have a live session or agent. */
+export function getActiveCyclableWorktreeIds(
+  rows: readonly HostSectionRow[],
+  pinnedDisplayPolicy: PinnedWorktreeDisplayPolicy,
+  activity: ActiveWorktreeInputs
+): string[] {
+  return getCyclableWorktreeIds(rows, pinnedDisplayPolicy).filter((worktreeId) =>
+    hasActiveWorkspaceActivity(
+      worktreeId,
+      activity.tabsByWorktree,
+      activity.ptyIdsByTabId,
+      activity.browserTabsByWorktree,
+      activity.worktreeIdsWithLiveAgent
+    )
+  )
 }
 
 /** Pick the worktree that `worktree.navigateUp` / `worktree.navigateDown` moves

--- a/src/renderer/src/components/sidebar/worktree-list/use-worktree-list-keyboard-navigation.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/use-worktree-list-keyboard-navigation.ts
@@ -3,12 +3,17 @@ import type React from 'react'
 import type { Virtualizer } from '@tanstack/react-virtual'
 import { useAppStore } from '@/store'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
+import { getWorktreeIdsWithLiveAgent } from '@/lib/worktree-activity-state'
 import { getShortcutPlatform } from '@/lib/shortcut-platform'
 import { keybindingMatchesAction } from '../../../../../shared/keybindings'
 import type { HostSectionRow } from '../host-section-rows'
 import type { PinnedWorktreeDisplayPolicy } from '../worktree-list-groups'
 import type { RenderRow } from '../worktree-list-virtual-rows'
-import { getCyclableWorktreeIds, resolveCycledWorktreeId } from '../worktree-keyboard-cycle'
+import {
+  getActiveCyclableWorktreeIds,
+  getCyclableWorktreeIds,
+  resolveCycledWorktreeId
+} from '../worktree-keyboard-cycle'
 import { findPreferredRenderRowIndexForWorktree } from './render-row-worktree-lookup'
 import { isEditableTarget } from './sidebar-editable-target'
 
@@ -33,14 +38,31 @@ export function useWorktreeListKeyboardNavigation(args: {
     markDirectScrollInput
   } = args
   const keybindings = useAppStore((s) => s.keybindings)
+  const tabsByWorktree = useAppStore((s) => s.tabsByWorktree)
+  const ptyIdsByTabId = useAppStore((s) => s.ptyIdsByTabId)
+  const browserTabsByWorktree = useAppStore((s) => s.browserTabsByWorktree)
+  const agentStatusEpoch = useAppStore((s) => s.agentStatusEpoch)
 
   const navigateWorktree = useCallback(
-    (direction: 'up' | 'down') => {
+    (direction: 'up' | 'down', activeOnly = false) => {
       // Why: cycle over the rows the sidebar actually rendered — collapsing a group
       // means "not now", and a rebuilt near-copy would drift from what is on screen
       // (host sections, pinned placement, folder workspaces).
+      void agentStatusEpoch
+      const worktreeIds = activeOnly
+        ? getActiveCyclableWorktreeIds(rows, pinnedDisplayPolicy, {
+            tabsByWorktree,
+            ptyIdsByTabId,
+            browserTabsByWorktree,
+            worktreeIdsWithLiveAgent: getWorktreeIdsWithLiveAgent(
+              useAppStore.getState().agentStatusByPaneKey,
+              tabsByWorktree,
+              Date.now()
+            )
+          })
+        : getCyclableWorktreeIds(rows, pinnedDisplayPolicy)
       const nextWorktreeId = resolveCycledWorktreeId({
-        worktreeIds: getCyclableWorktreeIds(rows, pinnedDisplayPolicy),
+        worktreeIds,
         activeWorktreeId,
         direction
       })
@@ -60,7 +82,17 @@ export function useWorktreeListKeyboardNavigation(args: {
         virtualizer.scrollToIndex(rowIndex, { align: 'auto' })
       }
     },
-    [rows, renderRows, activeWorktreeId, virtualizer, pinnedDisplayPolicy]
+    [
+      rows,
+      renderRows,
+      activeWorktreeId,
+      virtualizer,
+      pinnedDisplayPolicy,
+      tabsByWorktree,
+      ptyIdsByTabId,
+      browserTabsByWorktree,
+      agentStatusEpoch
+    ]
   )
 
   useEffect(() => {
@@ -76,14 +108,18 @@ export function useWorktreeListKeyboardNavigation(args: {
         return
       }
 
-      const direction = keybindingMatchesAction('worktree.navigateUp', e, platform, keybindings)
-        ? 'up'
+      const navigation = keybindingMatchesAction('worktree.navigateUp', e, platform, keybindings)
+        ? { direction: 'up' as const, activeOnly: false }
         : keybindingMatchesAction('worktree.navigateDown', e, platform, keybindings)
-          ? 'down'
-          : null
-      if (direction) {
+          ? { direction: 'down' as const, activeOnly: false }
+          : keybindingMatchesAction('worktree.navigateActiveUp', e, platform, keybindings)
+            ? { direction: 'up' as const, activeOnly: true }
+            : keybindingMatchesAction('worktree.navigateActiveDown', e, platform, keybindings)
+              ? { direction: 'down' as const, activeOnly: true }
+              : null
+      if (navigation) {
         markDirectScrollInput()
-        navigateWorktree(direction)
+        navigateWorktree(navigation.direction, navigation.activeOnly)
         e.preventDefault()
       }
     }

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -31,6 +31,8 @@ export type KeybindingActionId =
   | 'worktree.palette'
   | 'worktree.navigateUp'
   | 'worktree.navigateDown'
+  | 'worktree.navigateActiveUp'
+  | 'worktree.navigateActiveDown'
   | 'app.settings'
   | 'app.forceReload'
   | 'workspace.create'
@@ -254,6 +256,22 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     scope: 'global',
     searchKeywords: ['shortcut', 'global', 'worktree', 'next', 'down'],
     defaultBindings: platformBindings(['Mod+Shift+ArrowDown'])
+  },
+  {
+    id: 'worktree.navigateActiveUp',
+    title: 'Previous active worktree',
+    group: 'Global',
+    scope: 'global',
+    searchKeywords: ['shortcut', 'global', 'worktree', 'previous', 'active', 'running'],
+    defaultBindings: platformBindings(['Mod+Alt+Shift+ArrowUp'])
+  },
+  {
+    id: 'worktree.navigateActiveDown',
+    title: 'Next active worktree',
+    group: 'Global',
+    scope: 'global',
+    searchKeywords: ['shortcut', 'global', 'worktree', 'next', 'active', 'running'],
+    defaultBindings: platformBindings(['Mod+Alt+Shift+ArrowDown'])
   },
   {
     id: 'workspace.create',


### PR DESCRIPTION
## ELI5

This adds two shortcuts that move between worktrees that are still active, so sleeping worktrees do not interrupt keyboard navigation.

## What Changed

- Added Previous active worktree and Next active worktree actions with default `Mod+Alt+Shift+ArrowUp` and `Mod+Alt+Shift+ArrowDown` bindings.
- Reused the existing active-workspace predicate: live terminal, browser, or agent worktrees remain navigable.
- Preserved sidebar order, pinned placement, collapsed sections, and existing all-worktree navigation.

## Why

When many worktrees are asleep, cycling through every visible worktree requires unnecessary keypresses. The new actions provide a direct path through worktrees with a live session or running agent.

## Linked Issue

Fixes #14673

## Visual Proof

N/A — this adds keyboard-only behavior and no visual component. The Electron validation skill was not available in this environment; behavior is covered by unit tests.

## Testing

- [x] `pnpm lint` on Node 24.19.0
- [x] `pnpm typecheck` on Node 24.19.0
- [x] Targeted Vitest suite: 84 tests passed
- [x] `pnpm build` on Node 24.19.0
- [ ] Manual Electron validation (Electron skill unavailable in this environment)

## AI Disclosure

Codex (GPT-5) assisted with implementation and review.

## Review

- Security: no new IPC, filesystem, network, or credential paths.
- Cross-platform: uses the existing `Mod` shortcut abstraction, which maps to Command on macOS and Control on Linux/Windows.
- Remote/SSH/local: reuses the established activity predicate, including live-agent handling during SSH reconnects.
- Agents/integrations: provider-neutral; no agent-specific protocol or integration change.
- Performance: activity filtering happens only on explicit shortcut handling and preserves the rendered sidebar order.
- UI quality: no new visual surface; existing focus, scroll, and activation paths are reused.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No visual component was added
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform and SSH/remote behavior considered
- [x] Lint, typecheck, targeted tests, and build passed

## Author

- X / Twitter: Not provided