### PR TITLE
fix(browser): isolate late retired tunnel frames

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -2937,6 +2937,7 @@
           "assertions": [
             "destination writes replenish client credit only after settlement",
             "stale generations and reused stream IDs cannot replace the current destination",
+            "late frames for retired or reserved stream IDs leave concurrent destinations alive while never-reserved IDs fail closed",
             "pending opens and admitted open rate remain bounded and recover only after exact release or window expiry",
             "both traffic directions share an 8 MiB application-retention ledger with exact settlement, retirement, stale-callback, and reentrant-close release",
             "unsettled client-to-destination writes retain at most 256 chunks per stream independently of byte credit"
@@ -2957,6 +2958,7 @@
             "pending tiny frames stay chunk-bounded and data drains before remote close retirement",
             "late local settlement after remote close sends no stale credit and leaves the tunnel usable",
             "stale generations cannot open a stream and route close destroys every source",
+            "late frames for retired stream IDs leave concurrent sources alive while never-allocated IDs fail closed",
             "stream IDs never repeat within one tunnel generation after the bounded ledger exhausts"
           ]
         },

--- a/docs/sta-4150-client-hosted-browser-progress.md
+++ b/docs/sta-4150-client-hosted-browser-progress.md
@@ -36,13 +36,15 @@ Old clients and callers that omit placement must retain current server-hosted be
 - Stage 0 compatibility hardening: PR
   [#14402](https://github.com/stablyai/orca/pull/14402) is merged. It is not the long-term
   architecture and is not part of this draft stack.
-- Latest published stack tip: `sta-4150-browser-client-host-reconnect-grace`, draft PR
-  [#14691](https://github.com/stablyai/orca/pull/14691), stacked on inventory PR
-  [#14648](https://github.com/stablyai/orca/pull/14648). The stack is rebased onto
-  `origin/main@e570cade3c`.
+- Latest published stack tip: `sta-4150-browser-tunnel-retired-frame-isolation`, draft PR
+  [#14694](https://github.com/stablyai/orca/pull/14694), stacked on reconnect PR
+  [#14691](https://github.com/stablyai/orca/pull/14691). The stack is rebased onto
+  `origin/main@3908978ba4`.
 - The reconnect stage preserves exact client-host authority and page/executor lifetime through a
   negotiated, bounded same-client reconnect grace. Its pre-ledger, pre-replay-fix tip was
   `1093072a0b`; the reviewed fix was first committed at `5374c561a6` before this final ledger amend.
+- Published retired-frame stage `sta-4150-browser-tunnel-retired-frame-isolation` prevents one late
+  frame for a retired stream from destroying healthy concurrent tunnel streams.
 - PR #14566: final lifecycle/correctness/security review clean; all 43 required CI checks pass.
 - Published bridge branch: `sta-4150-browser-client-page-mount-bridge` locally rebased to
   `830cb95c25`, draft PR [#14578](https://github.com/stablyai/orca/pull/14578), stacked on #14566;
@@ -94,6 +96,7 @@ ownership.
 | [#14617](https://github.com/stablyai/orca/pull/14617) | Reconciliation    | Bounded retain, reclaim, restore, and close semantics                     |
 | [#14648](https://github.com/stablyai/orca/pull/14648) | Page inventory    | Optional authenticated complete client-page snapshot                      |
 | [#14691](https://github.com/stablyai/orca/pull/14691) | Reconnect grace   | Negotiated same-client authority and page lifetime preservation           |
+| [#14694](https://github.com/stablyai/orca/pull/14694) | Tunnel isolation  | Late retired-stream frames cannot collapse healthy concurrent streams     |
 
 ## Current stage: exact renderer bridge
 
@@ -416,6 +419,41 @@ Deterministic evidence:
 - Live headed/headless/browserless reconnect, Electron containment, SSH/WSL, and physical
   cross-platform proof remain activation blockers; this deterministic stage makes no such claim.
 
+## Published stage: retired tunnel-frame isolation (#14694)
+
+The browser-tunnel protocol already allocates stream IDs monotonically and never reuses an ID
+within one tunnel generation. The client retains its next allocated ID, and the execution-host
+session retains a bounded set of every reserved ID. That is enough to distinguish an in-flight
+frame for a retired or permanently burned stream identity from a frame for a never-reserved
+identity without a new field or opcode.
+
+Implemented:
+
+- Both tunnel ends ignore a valid non-Open frame only when its current generation proves that exact
+  stream ID previously existed and is now retired.
+- A never-allocated client ID, never-reserved execution-host ID, malformed frame, stale generation,
+  or explicit Open reuse keeps the existing fail-closed behavior. Rejected execution-host opens
+  burn their reserved ID before admission and may therefore ignore later frames without targeting
+  another stream.
+- Ping/Pong handling moved into one concrete heartbeat module so the session remains within its
+  300-line module budget without a suppression or limit bump.
+
+Deterministic evidence:
+
+- Baseline was 2/2 red: retire stream 1, keep stream 2 active, deliver late Data for stream 1, and
+  observe both client and execution-host session destroy stream 2.
+- The same oracle is green on the candidate: stream 2 carries a marker after the late frame, while
+  a never-allocated ID still closes the route and a reused Open still fails closed.
+- Focused client/session: 2 files / 28 tests passed. Full browser-network/control gate: 16 files /
+  198 tests passed. Full Node/CLI/web typecheck, lint and native/type-aware audits, the 87-gate
+  manifest, max-lines ratchet, localization checks, formatting, diff checks, and changed-code
+  quality across 180 files pass.
+- A fresh read-only review found no P0/P1 or required fix across all opcodes, generation rollover,
+  mixed versions, resource bounds, and malicious-peer behavior. It prompted the precise
+  reserved-versus-never-reserved wording above.
+- No payload, opcode, capability, field, limit, or publication changes. New/new peers avoid the
+  teardown race; an older peer may retain its conservative whole-tunnel close until upgraded.
+
 ## Acceptance matrix
 
 | Requirement                                                        | State                     | Evidence or blocker                                                                                               |
@@ -441,10 +479,10 @@ Deterministic evidence:
 
 ## Remaining implementation order
 
-1. Monitor #14691 CI without merging or marking it ready.
-2. Make late per-stream frames local to that stream, make long-poll admission fair/recoverable
-   across paired devices, retire placements when fencing a lease, and enforce main-owned webview
-   navigation grants before activating any client-host capability.
+1. Monitor #14691 and #14694 CI without merging or marking either ready.
+2. Make long-poll admission fair/recoverable across paired devices, retire placements when
+   fencing a lease, and enforce main-owned webview navigation grants before activating any
+   client-host capability.
 3. Execute the pinned reclaim/restore/close reconciliation plan against authenticated runtime
    intent and the preserved reconnect inventory before recovering ambiguous slots or routes.
 4. Add optional placement to logical session-tab publication and renderer state. Follow
@@ -523,6 +561,15 @@ Published reconnect-grace stage (#14691):
   durability contract changes. The optional JSON field is stripped by old peers and required only
   after exact echo on a reconnect attempt.
 
+Published retired-frame isolation stage (#14694):
+
+- Baseline/candidate oracle: 2 failed / 26 passed before the fix, 28/28 passed after it.
+- Full affected browser-network/control gate: 16 files / 198 tests passed.
+- Full Node/CLI/web typecheck, lint/audits, 87-gate manifest, max-lines, localization, formatting,
+  diff checks, and changed-code quality pass.
+- The full 31-patch stack rebased conflict-free onto `origin/main@3908978ba4`; `git range-diff`
+  marked every patch identical before this ledger amend.
+
 Do not promote narrow deterministic evidence into a live-topology claim. Record exact commands,
 topology, versions, and explicit gaps at every later checkpoint.
 
@@ -562,6 +609,13 @@ topology, versions, and explicit gaps at every later checkpoint.
   [#14691](https://github.com/stablyai/orca/pull/14691) on #14648. No PR was merged or marked ready.
 - Attached #14691 to STA-4150 and posted one concise reconnect-stage checkpoint. The ticket remains
   In Progress.
+- Rebased all 31 patches onto `origin/main@3908978ba4`, confirmed every patch identical by
+  `git range-diff`, and atomically force-pushed all 29 prior public branches with exact remote-OID
+  leases while creating the retired-frame branch with a must-not-exist lease.
+- Opened draft PR [#14694](https://github.com/stablyai/orca/pull/14694) on #14691. No PR was merged
+  or marked ready.
+- GitHub attached #14694 to STA-4150 automatically; posted exactly one retired-frame checkpoint
+  comment and kept the ticket In Progress.
 - No PR was merged or marked ready.
 
 ## Completion rule

--- a/src/main/browser/browser-network-tunnel-client.test.ts
+++ b/src/main/browser/browser-network-tunnel-client.test.ts
@@ -181,6 +181,34 @@ describe('BrowserNetworkTunnelClient', () => {
     client.close()
   })
 
+  it('ignores a retired stream frame but rejects a never-allocated stream ID', async () => {
+    const client = new BrowserNetworkTunnelClient({
+      tunnelGeneration: 7,
+      sendBinary: () => true
+    })
+    const firstOpening = client.open({ host: 'first.internal', port: 443 })
+    client.handleBinary(frame(BrowserNetworkTunnelOpcode.Opened))
+    const first = await firstOpening
+    first.on('error', () => {})
+    const firstClosed = once(first, 'close')
+    first.destroy()
+    await firstClosed
+
+    const secondOpening = client.open({ host: 'second.internal', port: 443 })
+    client.handleBinary(frame(BrowserNetworkTunnelOpcode.Opened, new Uint8Array(), 7, 2))
+    const second = await secondOpening
+    second.on('error', () => {})
+
+    client.handleBinary(frame(BrowserNetworkTunnelOpcode.Data, new Uint8Array([1]), 7, 1))
+
+    expect(second.destroyed).toBe(false)
+    const received = once(second, 'data')
+    client.handleBinary(frame(BrowserNetworkTunnelOpcode.Data, new Uint8Array([2]), 7, 2))
+    await expect(received).resolves.toEqual([Buffer.from([2])])
+    client.handleBinary(frame(BrowserNetworkTunnelOpcode.Data, new Uint8Array([3]), 7, 3))
+    expect(second.destroyed).toBe(true)
+  })
+
   it('never reuses stream IDs within one generation after its bounded ledger exhausts', async () => {
     const sent: Uint8Array<ArrayBufferLike>[] = []
     const client = new BrowserNetworkTunnelClient({

--- a/src/main/browser/browser-network-tunnel-client.ts
+++ b/src/main/browser/browser-network-tunnel-client.ts
@@ -7,6 +7,7 @@ import {
   type BrowserNetworkTunnelOpen
 } from '../../shared/browser-network-tunnel-protocol'
 import { BrowserNetworkTunnelFrameSender } from './browser-network-tunnel-frame-sender'
+import { handleBrowserNetworkTunnelHeartbeat } from './browser-network-tunnel-heartbeat'
 import type { BrowserNetworkTunnelOutboundMemoryLease } from './browser-network-tunnel-outbound-memory-budget'
 import {
   BROWSER_NETWORK_TUNNEL_INITIAL_WINDOW_BYTES,
@@ -122,15 +123,14 @@ export class BrowserNetworkTunnelClient {
     if (frame.tunnelGeneration !== this.tunnelGeneration) {
       return
     }
-    if (frame.opcode === BrowserNetworkTunnelOpcode.Ping) {
-      this.frameSender.send(BrowserNetworkTunnelOpcode.Pong, frame.streamId, frame.payload)
-      return
-    }
-    if (frame.opcode === BrowserNetworkTunnelOpcode.Pong) {
+    if (handleBrowserNetworkTunnelHeartbeat(frame, this.frameSender)) {
       return
     }
     const stream = this.streams.get(frame.streamId)
     if (!stream) {
+      if (frame.streamId < this.nextStreamId) {
+        return
+      }
       this.close(new Error('Browser tunnel received a frame for an unknown stream'))
       return
     }

--- a/src/main/browser/browser-network-tunnel-heartbeat.ts
+++ b/src/main/browser/browser-network-tunnel-heartbeat.ts
@@ -1,0 +1,16 @@
+import {
+  BrowserNetworkTunnelOpcode,
+  type BrowserNetworkTunnelFrame
+} from '../../shared/browser-network-tunnel-protocol'
+import type { BrowserNetworkTunnelFrameSender } from './browser-network-tunnel-frame-sender'
+
+export function handleBrowserNetworkTunnelHeartbeat(
+  frame: BrowserNetworkTunnelFrame,
+  sender: Pick<BrowserNetworkTunnelFrameSender, 'send'>
+): boolean {
+  if (frame.opcode === BrowserNetworkTunnelOpcode.Ping) {
+    sender.send(BrowserNetworkTunnelOpcode.Pong, frame.streamId, frame.payload)
+    return true
+  }
+  return frame.opcode === BrowserNetworkTunnelOpcode.Pong
+}

--- a/src/main/browser/browser-network-tunnel-session.test.ts
+++ b/src/main/browser/browser-network-tunnel-session.test.ts
@@ -229,7 +229,7 @@ describe('BrowserNetworkTunnelSession', () => {
     expect(error ? new TextDecoder().decode(error.payload) : '').toBe('stream_id_reused')
   })
 
-  it('rejects current-generation frames for unknown and retired stream IDs', () => {
+  it('rejects current-generation frames for never-reserved and reused stream IDs', () => {
     const socket = new FakeSocket()
     const sent: Uint8Array<ArrayBufferLike>[] = []
     const connect = vi.fn(() => socket)
@@ -270,6 +270,38 @@ describe('BrowserNetworkTunnelSession', () => {
     )
     unknownSession.handleBinary(frame(BrowserNetworkTunnelOpcode.Data, new Uint8Array([1]), 4))
     expect(otherSocket.destroyed).toBe(true)
+  })
+
+  it('keeps concurrent streams alive when late data arrives for a retired stream', () => {
+    const firstSocket = new FakeSocket()
+    const secondSocket = new FakeSocket()
+    const connect = vi.fn().mockReturnValueOnce(firstSocket).mockReturnValueOnce(secondSocket)
+    const session = new BrowserNetworkTunnelSession({
+      tunnelGeneration: 7,
+      connect,
+      sendBinary: () => true
+    })
+    const open = (streamId: number): void =>
+      session.handleBinary(
+        frame(
+          BrowserNetworkTunnelOpcode.Open,
+          encodeBrowserNetworkTunnelOpen({ host: 'localhost', port: 80 }),
+          streamId
+        )
+      )
+
+    open(1)
+    open(2)
+    firstSocket.emit('connect')
+    secondSocket.emit('connect')
+    session.handleBinary(frame(BrowserNetworkTunnelOpcode.Close, new Uint8Array(), 1))
+    session.handleBinary(frame(BrowserNetworkTunnelOpcode.Data, new Uint8Array([1]), 1))
+
+    expect(firstSocket.destroyed).toBe(true)
+    expect(secondSocket.destroyed).toBe(false)
+    session.handleBinary(frame(BrowserNetworkTunnelOpcode.Data, new Uint8Array([2]), 2))
+    expect(secondSocket.writes).toEqual([new Uint8Array([2])])
+    session.close()
   })
 
   it('accepts unused out-of-order stream IDs without permitting reuse', () => {

--- a/src/main/browser/browser-network-tunnel-session.ts
+++ b/src/main/browser/browser-network-tunnel-session.ts
@@ -13,6 +13,7 @@ import {
   writeBrowserNetworkDestination
 } from './browser-network-tunnel-destination-flow'
 import { BrowserNetworkTunnelFrameSender } from './browser-network-tunnel-frame-sender'
+import { handleBrowserNetworkTunnelHeartbeat } from './browser-network-tunnel-heartbeat'
 import { createBrowserNetworkTunnelResourceBudget } from './browser-network-tunnel-resource-budget'
 import {
   BROWSER_NETWORK_TUNNEL_INITIAL_WINDOW_BYTES,
@@ -81,11 +82,7 @@ export class BrowserNetworkTunnelSession {
   }
 
   private handleFrame(frame: BrowserNetworkTunnelFrame): void {
-    if (frame.opcode === BrowserNetworkTunnelOpcode.Ping) {
-      this.frameSender.send(BrowserNetworkTunnelOpcode.Pong, frame.streamId, frame.payload)
-      return
-    }
-    if (frame.opcode === BrowserNetworkTunnelOpcode.Pong) {
+    if (handleBrowserNetworkTunnelHeartbeat(frame, this.frameSender)) {
       return
     }
     if (frame.opcode === BrowserNetworkTunnelOpcode.Open) {
@@ -94,6 +91,9 @@ export class BrowserNetworkTunnelSession {
     }
     const stream = this.streams.get(frame.streamId)
     if (!stream) {
+      if (this.openedStreamIds.has(frame.streamId)) {
+        return
+      }
       this.close()
       return
     }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​61 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​60 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​90 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​18 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​72 |

<!-- /orca-pr-loc -->

## Summary

- ignore valid in-flight non-Open frames only for stream IDs proven retired or permanently reserved in the current tunnel generation
- keep never-allocated IDs, explicit Open reuse, malformed frames, and stale generations fail-closed
- extract shared tunnel heartbeat handling to preserve the session module size budget

This is a production-inert activation-hardening stage for [STA-4150](https://linear.app/stably/issue/STA-4150/refactor-remote-browser-to-client-hosted-electron-webviews), stacked on #14691. It changes no field, opcode, capability, payload, publication, placement, or limit.

## Causal evidence

Baseline: after retiring stream 1 while stream 2 remained live, one in-flight Data frame for stream 1 destroyed the entire tunnel and stream 2. The byte-identical oracle was 2 failed / 26 passed before the fix and 28 / 28 after it; never-allocated IDs and reused Open frames still close the route.

## Validation

- 16 browser-network/control files / 198 tests
- full Node, CLI, and web typecheck
- full lint, native and type-aware audits, 87 reliability gates, max-lines, localization, and changed-code quality
- formatting and git diff checks
- 31-patch post-rebase range-diff unchanged on origin/main@3908978ba4

## Compatibility and risk

New/new peers isolate the late retired frame. Mixed-version pairs remain safe but an older endpoint keeps the conservative whole-tunnel teardown until upgraded. The feature remains unadvertised and server-hosted behavior is unchanged.