### PR TITLE
feat(agent-sessions): preserve project-linked session history

### DIFF
--- a/mobile/src/agent-history/agent-history-resume-target.test.ts
+++ b/mobile/src/agent-history/agent-history-resume-target.test.ts
@@ -179,6 +179,36 @@ describe('mobile AI Vault resume target guards', () => {
     })
   })
 
+  it('never resumes a deleted-worktree session in an unrelated active project', () => {
+    const target = resolveMobileAiVaultSessionResumeTarget({
+      session: session({
+        cwd: '/Users/ada/removed/task',
+        project: {
+          id: 'project-orca',
+          repoId: 'orca-repo',
+          displayName: 'Orca',
+          originalWorktreeId: 'removed-wt',
+          originalWorktreePath: '/Users/ada/removed/task',
+          workspaceAvailability: 'missing'
+        }
+      }),
+      activeWorktreeId: 'hq-wt',
+      worktrees: [
+        worktree({
+          worktreeId: 'hq-wt',
+          repoId: 'hq-repo',
+          projectId: 'project-hq',
+          path: '/Users/ada/hq'
+        })
+      ],
+      repos
+    })
+    expect(target).toEqual({
+      status: 'blocked',
+      message: 'Open a worktree for Orca before resuming this session.'
+    })
+  })
+
   it('falls back to the active route worktree when the session worktree is archived', () => {
     const target = resolveMobileAiVaultSessionResumeTarget({
       session: session({ cwd: '/Users/ada/repo/archive/src' }),

--- a/mobile/src/agent-history/agent-history-resume-target.ts
+++ b/mobile/src/agent-history/agent-history-resume-target.ts
@@ -12,7 +12,6 @@ import {
   canResumeInMobileSessionWorktree,
   resolveMobileAgentHistorySessionWorktree
 } from './agent-history-session-worktree'
-
 export type MobileAiVaultResumeTargetStatus = 'local' | 'ssh' | 'runtime' | 'unknown'
 
 export type MobileAiVaultResumeRepo = {
@@ -24,6 +23,7 @@ export type MobileAiVaultResumeRepo = {
 }
 
 type MobileAiVaultResumeWorktree = Pick<Worktree, 'repoId' | 'worktreeId'> & {
+  projectId?: string
   path?: string | null
   workspaceKind?: Worktree['workspaceKind']
   hostId?: ExecutionHostId | null
@@ -130,12 +130,26 @@ export function resolveMobileAiVaultSessionResumeTarget(args: {
   const sessionWorktreeId = canResumeInMobileSessionWorktree(sessionWorktree)
     ? sessionWorktree?.worktreeId
     : null
+  const projectWorktreeIds = args.session.project
+    ? new Set(
+        args.worktrees
+          .filter(
+            (worktree) =>
+              worktree.projectId === args.session.project!.id ||
+              worktree.repoId === args.session.project!.repoId
+          )
+          .map((worktree) => worktree.worktreeId)
+      )
+    : null
   const candidateWorktreeIds = [
     sessionWorktreeId,
     args.activeWorktreeId && args.activeWorktreeId !== sessionWorktreeId
       ? args.activeWorktreeId
       : null
-  ].filter((candidate): candidate is string => Boolean(candidate))
+  ].filter(
+    (candidate): candidate is string =>
+      Boolean(candidate) && (!projectWorktreeIds || projectWorktreeIds.has(candidate!))
+  )
 
   for (const candidateWorktreeId of candidateWorktreeIds) {
     const targetStatus = getMobileAiVaultResumeWorktreeTargetStatus({
@@ -168,7 +182,13 @@ export function resolveMobileAiVaultSessionResumeTarget(args: {
     folderWorkspaces: args.folderWorkspaces,
     projectGroups: args.projectGroups
   })
-  return { status: 'blocked', message: mobileAiVaultResumeTargetBlockMessage(blockedStatus) }
+  return {
+    status: 'blocked',
+    message:
+      args.session.project && candidateWorktreeIds.length === 0
+        ? `Open a worktree for ${args.session.project.displayName} before resuming this session.`
+        : mobileAiVaultResumeTargetBlockMessage(blockedStatus)
+  }
 }
 
 function getMobileAiVaultResumeFolderTargetStatus(args: {

--- a/mobile/src/agent-history/agent-history-sections.ts
+++ b/mobile/src/agent-history/agent-history-sections.ts
@@ -1,7 +1,4 @@
-import {
-  filterAiVaultSessions,
-  groupAiVaultSessions
-} from '../../../src/shared/ai-vault-session-filters'
+import { filterAiVaultSessions } from '../../../src/shared/ai-vault-session-filters'
 import { AI_VAULT_AGENTS } from '../../../src/shared/ai-vault-types'
 import type { AiVaultScope, AiVaultSession } from '../../../src/shared/ai-vault-types'
 import {
@@ -20,7 +17,7 @@ export type MobileAgentHistorySection = {
 // Why: the host treats scopePaths as a WIDENING union (it adds in-scope sessions
 // beyond the recency cap, never restricts), so the Workspace/Project tabs must
 // narrow on the client like the desktop panel does. Mobile has no project-key
-// metadata, so both scoped tabs narrow by cwd path-prefix: Workspace = the active
+// metadata for legacy transcripts, so those scoped tabs narrow by cwd path-prefix: Workspace = the active
 // worktree path, Project = the active worktree + same-repo siblings (the same set
 // deriveMobileAiVaultScopePaths produces). 'all' applies no path narrowing.
 // hideEmptySessions matches the desktop default.
@@ -48,9 +45,16 @@ export function buildMobileAgentHistorySections(
     hideEmptySessions: true
   })
 
-  const groups = groupAiVaultSessions(filtered, 'folder')
-  return groups.map((group) => ({
-    key: group.key,
+  const groups = new Map<string, { label: string; sessions: AiVaultSession[] }>()
+  for (const session of filtered) {
+    const key = session.project ? `project:${session.project.id}` : `folder:${session.cwd ?? ''}`
+    const label = session.project?.displayName ?? session.cwd ?? 'Unknown folder'
+    const group = groups.get(key) ?? { label, sessions: [] }
+    group.sessions.push(session)
+    groups.set(key, group)
+  }
+  return [...groups.entries()].map(([key, group]) => ({
+    key,
     label: group.label,
     data: group.sessions.map((session) =>
       buildMobileAgentHistoryCard(session, options.activeWorktreePath, options.now)

--- a/mobile/src/agent-history/agent-history-session-card.test.ts
+++ b/mobile/src/agent-history/agent-history-session-card.test.ts
@@ -92,6 +92,37 @@ describe('isSessionInActiveWorktree', () => {
 })
 
 describe('buildMobileAgentHistorySections', () => {
+  it('groups attributed sessions by durable project name instead of worktree folder', () => {
+    const project = {
+      id: 'project-orca',
+      repoId: 'repo-orca',
+      displayName: 'Orca',
+      originalWorktreeId: 'worktree-old',
+      originalWorktreePath: '/Users/ada/worktrees/orca/task-old',
+      workspaceAvailability: 'missing' as const
+    }
+    const sections = buildMobileAgentHistorySections(
+      [
+        session({
+          id: 'codex:one',
+          agent: 'codex',
+          cwd: '/Users/ada/worktrees/orca/task-one',
+          project
+        }),
+        session({
+          id: 'codex:two',
+          agent: 'codex',
+          cwd: '/Users/ada/worktrees/orca/task-two',
+          project
+        })
+      ],
+      { query: '', scope: 'all', scopeFilterPaths: [], activeWorktreePath: null, now: NOW }
+    )
+    expect(sections).toHaveLength(1)
+    expect(sections[0]).toMatchObject({ key: 'project:project-orca', label: 'Orca' })
+    expect(sections[0].data.map((card) => card.id)).toEqual(['codex:one', 'codex:two'])
+  })
+
   it('hides empty sessions by default and groups remaining by folder', () => {
     const sections = buildMobileAgentHistorySections(
       [

--- a/mobile/src/worktree/workspace-list-types.ts
+++ b/mobile/src/worktree/workspace-list-types.ts
@@ -6,6 +6,7 @@ export type Worktree = {
   workspaceKind?: 'git' | 'folder-workspace'
   worktreeId: string
   repoId: string
+  projectId?: string
   hostId?: ExecutionHostId
   terminalPlatform?: NodeJS.Platform
   repo: string

--- a/src/cli/handler-group-manifest.ts
+++ b/src/cli/handler-group-manifest.ts
@@ -13,6 +13,16 @@ export type HandlerGroup = {
 // real exports by handler-group-manifest.test.ts, so drift fails CI, not dispatch.
 export const HANDLER_GROUPS: readonly HandlerGroup[] = [
   {
+    name: 'agent-session',
+    keys: [
+      'agent session start',
+      'agent session list',
+      'agent session resume',
+      'agent session stop'
+    ],
+    load: async () => (await import('./handlers/agent-session.js')).AGENT_SESSION_HANDLERS
+  },
+  {
     name: 'core',
     keys: ['claude-teams', 'open', 'serve', 'status'],
     load: async () => (await import('./handlers/core.js')).CORE_HANDLERS

--- a/src/cli/handlers/agent-session.test.ts
+++ b/src/cli/handlers/agent-session.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../format', () => ({ printResult: vi.fn() }))
+
+import { printResult } from '../format'
+import { AGENT_SESSION_HANDLERS } from './agent-session'
+
+const call = vi.fn()
+
+beforeEach(() => {
+  call.mockReset()
+  vi.mocked(printResult).mockReset()
+})
+
+describe('agent session CLI handlers', () => {
+  it('resolves a worktree selector before filtering session history', async () => {
+    call
+      .mockResolvedValueOnce({
+        result: {
+          sessions: [
+            {
+              id: 'codex:session-1',
+              agent: 'codex',
+              title: 'Keep this conversation',
+              project: {
+                id: 'orca',
+                displayName: 'Orca',
+                originalWorktreeId: 'repo::/workspace/task',
+                originalWorktreePath: '/workspace/task'
+              }
+            }
+          ]
+        }
+      })
+      .mockResolvedValueOnce({
+        result: { worktree: { id: 'repo::/workspace/task', path: '/workspace/task' } }
+      })
+
+    await AGENT_SESSION_HANDLERS['agent session list']({
+      flags: new Map([['worktree', 'path:/workspace/task']]),
+      client: { call },
+      cwd: '/workspace/task',
+      json: false
+    } as never)
+
+    expect(call).toHaveBeenNthCalledWith(2, 'worktree.show', {
+      worktree: 'path:/workspace/task'
+    })
+    const output = vi.mocked(printResult).mock.calls[0]?.[0] as {
+      result: { sessions: { id: string }[] }
+    }
+    expect(output.result.sessions).toEqual([expect.objectContaining({ id: 'codex:session-1' })])
+  })
+
+  it('reports a successful terminal close as stopped', async () => {
+    call.mockResolvedValue({
+      result: { handle: 'term_1', tabId: 'tab-1', ptyKilled: true }
+    })
+
+    await AGENT_SESSION_HANDLERS['agent session stop']({
+      flags: new Map([['session', 'codex:session-1']]),
+      client: { call },
+      cwd: '/workspace/task',
+      json: false
+    } as never)
+
+    const formatter = vi.mocked(printResult).mock.calls[0]?.[2] as
+      | ((value: { handle: string; tabId: string; ptyKilled: boolean }) => string)
+      | undefined
+    expect(formatter?.({ handle: 'term_1', tabId: 'tab-1', ptyKilled: false })).toBe(
+      'term_1\tstopped'
+    )
+  })
+})

--- a/src/cli/handlers/agent-session.ts
+++ b/src/cli/handlers/agent-session.ts
@@ -1,0 +1,125 @@
+import { randomBytes } from 'node:crypto'
+import type { AiVaultListResult, AiVaultSession } from '../../shared/ai-vault-types'
+import type {
+  RuntimeCreateAgentSessionResult,
+  RuntimeEnsureAgentSessionResult
+} from '../../shared/agent-session-host-authority'
+import type { RuntimeTerminalClose, RuntimeWorktreeRecord } from '../../shared/runtime-types'
+import type { TuiAgent } from '../../shared/tui-agent'
+import { isTuiAgent } from '../../shared/tui-agent-config'
+import type { CommandHandler } from '../dispatch'
+import { printResult } from '../format'
+import {
+  getOptionalPositiveIntegerFlag,
+  getOptionalStringFlag,
+  getRequiredStringFlag
+} from '../flags'
+import { RuntimeClientError } from '../runtime-client'
+import { getOptionalWorktreeSelector, resolveCurrentWorktreeSelector } from '../selectors'
+
+function formatSession(session: AiVaultSession): string {
+  const project = session.project?.displayName ?? 'Unassigned'
+  const state = session.liveTerminalHandle ? 'live' : 'history'
+  return `${session.id}\t${state}\t${session.agent}\t${project}\t${session.title}`
+}
+
+async function selectedWorktree(
+  flags: Map<string, string | boolean>,
+  cwd: string,
+  client: Parameters<CommandHandler>[0]['client']
+): Promise<string> {
+  const explicit = await getOptionalWorktreeSelector(flags, 'worktree', cwd, client)
+  if (explicit) {
+    return explicit
+  }
+  if (client.isRemote) {
+    throw new RuntimeClientError(
+      'invalid_argument',
+      'Remote agent sessions require an explicit --worktree selector.'
+    )
+  }
+  return resolveCurrentWorktreeSelector(cwd, client)
+}
+
+async function selectedAgent(
+  flags: Map<string, string | boolean>,
+  client: Parameters<CommandHandler>[0]['client']
+): Promise<TuiAgent> {
+  const explicit = getOptionalStringFlag(flags, 'agent')
+  const settings = explicit
+    ? null
+    : await client.call<{
+        settings: { defaultTuiAgent?: string | null; disabledTuiAgents?: string[] }
+      }>('settings.get')
+  const agent = explicit ?? settings?.result.settings.defaultTuiAgent
+  if (!agent || !isTuiAgent(agent)) {
+    throw new RuntimeClientError(
+      'invalid_argument',
+      'No usable agent was selected. Configure Orca defaultTuiAgent or pass --agent.'
+    )
+  }
+  if (settings?.result.settings.disabledTuiAgents?.includes(agent)) {
+    throw new RuntimeClientError('invalid_argument', `The default agent "${agent}" is disabled.`)
+  }
+  return agent
+}
+
+export const AGENT_SESSION_HANDLERS: Record<string, CommandHandler> = {
+  'agent session start': async ({ flags, client, cwd, json }) => {
+    const result = await client.call<RuntimeCreateAgentSessionResult>(
+      'terminal.createAgentSession',
+      {
+        clientOperationId: `${Date.now()}-${randomBytes(16).toString('hex')}`,
+        worktree: await selectedWorktree(flags, cwd, client),
+        agent: await selectedAgent(flags, client),
+        prompt: getOptionalStringFlag(flags, 'prompt'),
+        presentation: flags.get('focus') === true ? 'focused' : 'background',
+        viewMode: 'chat'
+      }
+    )
+    printResult(result, json, (value) => value.terminal.handle)
+  },
+  'agent session list': async ({ flags, client, cwd, json }) => {
+    const state = getOptionalStringFlag(flags, 'state') ?? 'all'
+    if (!['live', 'history', 'all'].includes(state)) {
+      throw new RuntimeClientError('invalid_argument', '--state must be live, history, or all')
+    }
+    const response = await client.call<AiVaultListResult>('agentSession.list', {
+      limit: getOptionalPositiveIntegerFlag(flags, 'limit')
+    })
+    const project = getOptionalStringFlag(flags, 'project')
+    const worktreeSelector = await getOptionalWorktreeSelector(flags, 'worktree', cwd, client)
+    const worktree = worktreeSelector
+      ? (
+          await client.call<{ worktree: RuntimeWorktreeRecord }>('worktree.show', {
+            worktree: worktreeSelector
+          })
+        ).result.worktree
+      : null
+    const sessions = response.result.sessions.filter(
+      (session) =>
+        (!project || session.project?.id === project || session.project?.displayName === project) &&
+        (!worktree ||
+          session.project?.originalWorktreeId === worktree.id ||
+          session.project?.originalWorktreePath === worktree.path) &&
+        (state === 'all' || (state === 'live') === Boolean(session.liveTerminalHandle))
+    )
+    printResult({ ...response, result: { ...response.result, sessions } }, json, (value) =>
+      value.sessions.map(formatSession).join('\n')
+    )
+  },
+  'agent session resume': async ({ flags, client, cwd, json }) => {
+    const result = await client.call<RuntimeEnsureAgentSessionResult>('agentSession.resume', {
+      sessionId: getRequiredStringFlag(flags, 'session'),
+      worktree: await selectedWorktree(flags, cwd, client),
+      presentation: flags.get('focus') === true ? 'focused' : 'background'
+    })
+    printResult(result, json, (value) => value.terminal.handle)
+  },
+  'agent session stop': async ({ flags, client, json }) => {
+    const result = await client.call<RuntimeTerminalClose>('agentSession.stop', {
+      sessionId: getRequiredStringFlag(flags, 'session')
+    })
+    printResult(result, json, (value) => `${value.handle}\tstopped`)
+  }
+}

--- a/src/cli/specs/agent-session.ts
+++ b/src/cli/specs/agent-session.ts
@@ -1,0 +1,31 @@
+import type { CommandSpec } from '../args'
+import { GLOBAL_FLAGS } from '../args'
+
+export const AGENT_SESSION_COMMAND_SPECS: CommandSpec[] = [
+  {
+    path: ['agent', 'session', 'start'],
+    summary: 'Start an agent session in an existing worktree',
+    usage:
+      'orca agent session start [--worktree <selector>] [--agent <id>] [--prompt <text>] [--focus] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'worktree', 'agent', 'prompt', 'focus']
+  },
+  {
+    path: ['agent', 'session', 'list'],
+    summary: 'List agent sessions with their project and worktree association',
+    usage:
+      'orca agent session list [--project <id>] [--worktree <selector>] [--state live|history|all] [--limit <n>] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'project', 'worktree', 'state', 'limit']
+  },
+  {
+    path: ['agent', 'session', 'resume'],
+    summary: 'Resume an agent session in a worktree from the same project',
+    usage: 'orca agent session resume --session <id> [--worktree <selector>] [--focus] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'session', 'worktree', 'focus']
+  },
+  {
+    path: ['agent', 'session', 'stop'],
+    summary: 'Stop a live agent session without deleting its history',
+    usage: 'orca agent session stop --session <id> [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'session']
+  }
+]

--- a/src/cli/specs/index.ts
+++ b/src/cli/specs/index.ts
@@ -17,9 +17,11 @@ import { LINEAR_COMMAND_SPECS } from './linear'
 import { VM_COMMAND_SPECS } from './vm'
 import { SKILL_COMMAND_SPECS } from './skills'
 import { ARTIFACT_COMMAND_SPECS } from './artifacts'
+import { AGENT_SESSION_COMMAND_SPECS } from './agent-session'
 
 export const COMMAND_SPECS: CommandSpec[] = [
   ...CORE_COMMAND_SPECS,
+  ...AGENT_SESSION_COMMAND_SPECS,
   ...ARTIFACT_COMMAND_SPECS,
   ...ACCOUNT_COMMAND_SPECS,
   ...PROJECT_COMMAND_SPECS,

--- a/src/main/ai-vault/session-project-association-store.test.ts
+++ b/src/main/ai-vault/session-project-association-store.test.ts
@@ -1,0 +1,103 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { AiVaultListResult, AiVaultSession } from '../../shared/ai-vault-types'
+import type { AgentStatusIpcPayload } from '../../shared/agent-status-types'
+import type { Project } from '../../shared/project-types'
+import type { Worktree } from '../../shared/worktree/types'
+import { AgentSessionProjectAssociationStore } from './session-project-association-store'
+
+const temporaryDirectories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true })))
+})
+
+function session(): AiVaultSession {
+  return {
+    id: 'codex:session-1',
+    executionHostId: 'local',
+    agent: 'codex',
+    sessionId: 'session-1',
+    title: 'Keep this conversation',
+    cwd: '/workspace/worktrees/orca/task-one',
+    branch: null,
+    model: null,
+    filePath: '/profile/codex/session-1.jsonl',
+    codexHome: null,
+    createdAt: null,
+    updatedAt: null,
+    modifiedAt: '2026-08-15T00:00:00.000Z',
+    messageCount: 2,
+    totalTokens: 10,
+    previewMessages: [{ role: 'user', text: 'hello', timestamp: null }],
+    queuedMessageCount: 0,
+    subagentTranscriptCount: 0,
+    resumeCommand: '',
+    subagent: null
+  }
+}
+
+function result(): AiVaultListResult {
+  return { sessions: [session()], issues: [], scannedAt: '2026-08-15T00:00:00.000Z' }
+}
+
+describe('AgentSessionProjectAssociationStore', () => {
+  it('keeps project attribution after the original worktree disappears', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-session-project-'))
+    temporaryDirectories.push(root)
+    const filePath = join(root, 'associations.json')
+    const project = {
+      id: 'project-orca',
+      displayName: 'Orca',
+      badgeColor: '#000000',
+      sourceRepoIds: ['repo-orca'],
+      createdAt: 1,
+      updatedAt: 1
+    } satisfies Project
+    const worktree = {
+      id: 'repo-orca::/workspace/worktrees/orca/task-one',
+      repoId: 'repo-orca',
+      projectId: project.id,
+      path: '/workspace/worktrees/orca/task-one',
+      isArchived: false
+    } as Worktree
+    const hook = {
+      agentType: 'codex',
+      worktreeId: worktree.id,
+      terminalHandle: 'term_live',
+      providerSession: { key: 'session_id', id: 'session-1' }
+    } as AgentStatusIpcPayload
+
+    const store = new AgentSessionProjectAssociationStore(filePath)
+    await store.capture({
+      agent: 'codex',
+      providerSession: hook.providerSession!,
+      project,
+      worktree
+    })
+    const first = await store.enrich({
+      result: result(),
+      projects: [project],
+      worktrees: [worktree],
+      hookSessions: [hook]
+    })
+    expect(first.sessions[0]).toMatchObject({
+      liveTerminalHandle: 'term_live',
+      project: { id: project.id, displayName: 'Orca', workspaceAvailability: 'active' }
+    })
+
+    const restored = await new AgentSessionProjectAssociationStore(filePath).enrich({
+      result: result(),
+      projects: [project],
+      worktrees: [],
+      hookSessions: []
+    })
+    expect(restored.sessions[0].project).toMatchObject({
+      id: project.id,
+      originalWorktreeId: worktree.id,
+      workspaceAvailability: 'missing'
+    })
+  })
+})

--- a/src/main/ai-vault/session-project-association-store.ts
+++ b/src/main/ai-vault/session-project-association-store.ts
@@ -1,0 +1,223 @@
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import type { AgentStatusIpcPayload } from '../../shared/agent-status-types'
+import type { AiVaultListResult, AiVaultSession } from '../../shared/ai-vault-types'
+import type { AgentProviderSessionMetadata } from '../../shared/agent-session-resume'
+import { createNormalizedPathInsideOrEqualMatcher } from '../../shared/cross-platform-path'
+import type { Project } from '../../shared/project-types'
+import type { Worktree } from '../../shared/worktree/types'
+
+type StoredAssociation = {
+  agent: string
+  providerSession: AgentProviderSessionMetadata
+  projectId: string
+  repoId: string
+  worktreeId: string
+  worktreePath: string
+  boundAt: number
+  lastSeenAt: number
+}
+
+type StoredFile = {
+  version: 1
+  associations: Record<string, StoredAssociation>
+}
+
+type AssociationWorktree = Pick<Worktree, 'id' | 'repoId' | 'projectId' | 'path'>
+
+function providerSessionFor(session: AiVaultSession): AgentProviderSessionMetadata {
+  if (session.providerSession) {
+    return session.providerSession
+  }
+  return {
+    key: session.agent === 'antigravity' ? 'conversation_id' : 'session_id',
+    id: session.sessionId,
+    ...(session.agent === 'pi' || session.agent === 'prime-agent'
+      ? { transcriptPath: session.filePath }
+      : {})
+  }
+}
+
+function associationKey(agent: string, providerSession: AgentProviderSessionMetadata): string {
+  return `${agent}\0${providerSession.key}\0${providerSession.id}`
+}
+
+function projectForWorktree(worktree: Worktree, projects: readonly Project[]): Project | null {
+  if (worktree.projectId) {
+    return projects.find((project) => project.id === worktree.projectId) ?? null
+  }
+  return projects.find((project) => project.sourceRepoIds.includes(worktree.repoId)) ?? null
+}
+
+function matchingWorktree(
+  session: AiVaultSession,
+  worktrees: readonly Worktree[]
+): Worktree | null {
+  if (!session.cwd) {
+    return null
+  }
+  return (
+    worktrees
+      .filter((worktree) => createNormalizedPathInsideOrEqualMatcher(worktree.path)(session.cwd!))
+      .sort((left, right) => right.path.length - left.path.length)[0] ?? null
+  )
+}
+
+export class AgentSessionProjectAssociationStore {
+  private loadPromise: Promise<void> | null = null
+  private associations = new Map<string, StoredAssociation>()
+  private writeQueue: Promise<void> = Promise.resolve()
+
+  constructor(private readonly filePath: string) {}
+
+  private load(): Promise<void> {
+    this.loadPromise ??= this.loadFromDisk()
+    return this.loadPromise
+  }
+
+  private async loadFromDisk(): Promise<void> {
+    try {
+      const parsed = JSON.parse(await readFile(this.filePath, 'utf8')) as Partial<StoredFile>
+      if (parsed.version !== 1 || !parsed.associations) {
+        return
+      }
+      for (const [key, value] of Object.entries(parsed.associations)) {
+        if (value?.projectId && value.providerSession?.id) {
+          this.associations.set(key, value)
+        }
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        console.warn('[agent-session] project association load failed', error)
+      }
+    }
+  }
+
+  private record(
+    agent: string,
+    providerSession: AgentProviderSessionMetadata,
+    worktree: AssociationWorktree,
+    project: Project,
+    now: number
+  ): boolean {
+    const key = associationKey(agent, providerSession)
+    const previous = this.associations.get(key)
+    const next: StoredAssociation = {
+      agent,
+      providerSession,
+      projectId: project.id,
+      repoId: worktree.repoId,
+      worktreeId: worktree.id,
+      worktreePath: worktree.path,
+      boundAt: previous?.boundAt ?? now,
+      lastSeenAt: previous?.lastSeenAt ?? now
+    }
+    if (previous && JSON.stringify(previous) === JSON.stringify(next)) {
+      return false
+    }
+    this.associations.set(key, next)
+    return true
+  }
+
+  private async persist(): Promise<void> {
+    const snapshot: StoredFile = {
+      version: 1,
+      associations: Object.fromEntries(this.associations)
+    }
+    this.writeQueue = this.writeQueue.then(async () => {
+      await mkdir(dirname(this.filePath), { recursive: true })
+      const temporary = `${this.filePath}.${process.pid}.tmp`
+      await writeFile(temporary, `${JSON.stringify(snapshot, null, 2)}\n`, 'utf8')
+      await rename(temporary, this.filePath)
+    })
+    await this.writeQueue
+  }
+
+  async capture(args: {
+    agent: string
+    providerSession: AgentProviderSessionMetadata
+    worktree: AssociationWorktree
+    project: Project
+  }): Promise<void> {
+    await this.load()
+    if (this.record(args.agent, args.providerSession, args.worktree, args.project, Date.now())) {
+      await this.persist()
+    }
+  }
+
+  async enrich(args: {
+    result: AiVaultListResult
+    projects: readonly Project[]
+    worktrees: readonly Worktree[]
+    hookSessions: readonly AgentStatusIpcPayload[]
+  }): Promise<AiVaultListResult> {
+    await this.load()
+    const now = Date.now()
+    let changed = false
+
+    for (const hook of args.hookSessions) {
+      if (!hook.agentType || !hook.providerSession || !hook.worktreeId) {
+        continue
+      }
+      const worktree = args.worktrees.find((candidate) => candidate.id === hook.worktreeId)
+      if (!worktree) {
+        continue
+      }
+      const project = projectForWorktree(worktree, args.projects)
+      if (!project) {
+        continue
+      }
+      changed = this.record(hook.agentType, hook.providerSession, worktree, project, now) || changed
+    }
+
+    const sessions: AiVaultSession[] = args.result.sessions.map((session): AiVaultSession => {
+      const providerSession = providerSessionFor(session)
+      const liveHook = args.hookSessions.find(
+        (hook) =>
+          hook.agentType === session.agent &&
+          hook.providerSession?.key === providerSession.key &&
+          hook.providerSession.id === providerSession.id
+      )
+      let association = this.associations.get(associationKey(session.agent, providerSession))
+      if (!association) {
+        const worktree = matchingWorktree(session, args.worktrees)
+        const project = worktree ? projectForWorktree(worktree, args.projects) : null
+        if (worktree && project) {
+          changed = this.record(session.agent, providerSession, worktree, project, now) || changed
+          association = this.associations.get(associationKey(session.agent, providerSession))
+        }
+      }
+      if (!association) {
+        return { ...session, providerSession }
+      }
+      const project = args.projects.find((candidate) => candidate.id === association.projectId)
+      const originalWorktree = args.worktrees.find(
+        (candidate) =>
+          candidate.id === association!.worktreeId ||
+          candidate.priorWorktreeIds?.includes(association!.worktreeId)
+      )
+      return {
+        ...session,
+        providerSession,
+        ...(liveHook?.terminalHandle ? { liveTerminalHandle: liveHook.terminalHandle } : {}),
+        project: {
+          id: association.projectId,
+          repoId: association.repoId,
+          displayName: project?.displayName ?? association.projectId,
+          originalWorktreeId: association.worktreeId,
+          originalWorktreePath: association.worktreePath,
+          workspaceAvailability: originalWorktree
+            ? originalWorktree.isArchived
+              ? 'archived'
+              : 'active'
+            : 'missing'
+        }
+      }
+    })
+
+    if (changed) {
+      await this.persist()
+    }
+    return { ...args.result, sessions }
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2306,6 +2306,11 @@ void app.whenReady().then(async () => {
   // would keep the pane's last projection until an unrelated PTY touch came along.
   const hookStatusChangedSessionTabs = createHookStatusSessionTabsInvalidator()
   const unsubscribeHookStatusSessionTabs = agentHookServer.subscribeEnrichedStatus((enriched) => {
+    runtime?.captureAgentSessionProjectAssociation({
+      worktreeId: enriched.worktreeId,
+      agentType: enriched.payload.agentType,
+      providerSession: enriched.providerSession
+    })
     if (hookStatusChangedSessionTabs(enriched)) {
       runtime?.touchMobileSessionTabsForPane(enriched.paneKey, enriched.worktreeId ?? null)
     }
@@ -2558,6 +2563,9 @@ void app.whenReady().then(async () => {
     orchestrationEnvironmentTransport
   })
   runtime = runtimeService
+  for (const status of agentHookServer.getStatusSnapshot()) {
+    runtimeService.captureAgentSessionProjectAssociation(status)
+  }
   runtimeService.prepareLegacyWorkerTerminalRecovery()
   publishProviderSessionChanges(agentHookServer.getProviderSessionIdentities())
   browserManager.setBrowserGuestStateChangedListener((worktreeId) => {

--- a/src/main/runtime/orca-runtime-agent-session-operation.test.ts
+++ b/src/main/runtime/orca-runtime-agent-session-operation.test.ts
@@ -290,3 +290,51 @@ describe('agent-session create operation ledger', () => {
     expect(createTerminal).toHaveBeenCalledOnce()
   })
 })
+
+describe('AI Vault session resume', () => {
+  it('passes the scanned OMP session file through the provider adapter', async () => {
+    const runtime = createRuntime()
+    vi.spyOn(runtime, 'listAiVaultSessions').mockResolvedValue({
+      sessions: [
+        {
+          id: 'omp:session-1',
+          agent: 'omp',
+          sessionId: 'session-1',
+          providerSession: { key: 'session_id', id: 'session-1' },
+          filePath: '/profile/omp/project/session-1.jsonl',
+          project: { id: 'orca' }
+        }
+      ],
+      issues: [],
+      scannedAt: '2026-08-15T00:00:00.000Z'
+    } as never)
+    vi.spyOn(runtime, 'listProjects').mockReturnValue([
+      { id: 'orca', sourceRepoIds: ['repo-orca'] }
+    ] as never)
+    const internals = runtime as unknown as {
+      resolveWorktreeSelector: ReturnType<typeof vi.fn>
+    }
+    internals.resolveWorktreeSelector = vi.fn(async () => ({
+      id: 'repo-orca::/workspace/orca/task',
+      repoId: 'repo-orca',
+      projectId: 'orca',
+      isArchived: false
+    }))
+    const ensure = vi
+      .spyOn(runtime, 'ensureAgentSession')
+      .mockResolvedValue({ disposition: 'adopted' } as never)
+
+    await runtime.resumeAiVaultSession({
+      sessionId: 'omp:session-1',
+      worktree: 'id:repo-orca::/workspace/orca/task'
+    })
+
+    expect(ensure).toHaveBeenCalledWith({
+      kind: 'explicit',
+      worktree: 'id:repo-orca::/workspace/orca/task',
+      agent: 'omp',
+      providerSession: { key: 'session_id', id: 'session-1' },
+      ompResumeFilePath: '/profile/omp/project/session-1.jsonl'
+    })
+  })
+})

--- a/src/main/runtime/orca-runtime-agent-session-project-association.test.ts
+++ b/src/main/runtime/orca-runtime-agent-session-project-association.test.ts
@@ -1,0 +1,47 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { OrcaRuntimeService } from './orca-runtime'
+
+vi.mock('electron', () => ({
+  BrowserWindow: { fromId: vi.fn(() => null) },
+  webContents: { fromId: vi.fn(() => null) },
+  ipcMain: { on: vi.fn(), removeListener: vi.fn() },
+  app: { getPath: vi.fn(() => '/tmp') }
+}))
+
+const temporaryDirectories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true })))
+})
+
+describe('runtime agent session project association', () => {
+  it('persists a provider hook association before any history list scan', async () => {
+    const profile = await mkdtemp(join(tmpdir(), 'orca-runtime-session-project-'))
+    temporaryDirectories.push(profile)
+    const worktreeId = 'repo-orca::/workspace/worktrees/orca/task-one'
+    const runtime = new OrcaRuntimeService({
+      getProfileStorageDirectory: () => profile,
+      getWorktreeMeta: () => ({ projectId: 'orca' }),
+      getProjects: () => [{ id: 'orca', displayName: 'Orca', sourceRepoIds: ['repo-orca'] }]
+    } as never)
+
+    runtime.captureAgentSessionProjectAssociation({
+      worktreeId,
+      agentType: 'codex',
+      providerSession: { key: 'session_id', id: 'session-1' }
+    })
+
+    const filePath = join(profile, 'agent-session-project-associations.json')
+    await vi.waitFor(async () => {
+      const stored = JSON.parse(await readFile(filePath, 'utf8')) as {
+        associations: Record<string, { projectId: string; worktreeId: string }>
+      }
+      expect(Object.values(stored.associations)).toEqual([
+        expect.objectContaining({ projectId: 'orca', worktreeId })
+      ])
+    })
+  })
+})

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -115,6 +115,7 @@ import { GIT_FETCH_SKIP_AUTO_MAINTENANCE_CONFIG_ARGS } from '../../shared/git-fe
 import { createHash, randomUUID } from 'node:crypto'
 import { homedir } from 'node:os'
 import { isAbsolute, join, resolve } from 'node:path'
+import { AgentSessionProjectAssociationStore } from '../ai-vault/session-project-association-store'
 import { mkdir, readFile, readdir, rm, stat } from 'node:fs/promises'
 import { resolveWorktreeCreateBase } from '../worktree-create-base'
 import { resolveWorktreeAddBaseRef } from '../../shared/worktree/base-ref'
@@ -292,9 +293,10 @@ import {
 } from '../../shared/execution-host'
 import { preservedBranchCleanupScopeKey } from '../../shared/preserved-branch-cleanup'
 import { getRegisteredSshState } from '../ipc/ssh'
-import type {
-  AgentProviderSessionMetadata,
-  SleepingAgentLaunchConfig
+import {
+  isResumableTuiAgent,
+  type AgentProviderSessionMetadata,
+  type SleepingAgentLaunchConfig
 } from '../../shared/agent-session-resume'
 import type { ExactWorkerProviderSession } from '../../shared/orchestration-worker-output'
 import type { RuntimeClientEvent } from '../../shared/runtime-client-events'
@@ -1145,6 +1147,7 @@ export type CodexRateLimitResetRpcResult = {
 )
 
 type RuntimeStore = {
+  getProfileStorageDirectory?: Store['getProfileStorageDirectory']
   getRepos: Store['getRepos']
   getRepo: Store['getRepo']
   addRepo: Store['addRepo']
@@ -2750,6 +2753,7 @@ export class OrcaRuntimeService {
   private readonly runtimeId = randomUUID()
   private readonly startedAt = Date.now()
   private readonly store: RuntimeStore | null
+  private readonly agentSessionProjectAssociations: AgentSessionProjectAssociationStore | null
   private managedHookReconciliationGeneration = 0
   private managedHookReconciliationTail: Promise<void> = Promise.resolve()
   private readonly orchestrationEnvironmentTransport: OrchestrationEnvironmentTransport | null
@@ -3453,6 +3457,11 @@ export class OrcaRuntimeService {
     }
   ) {
     this.store = store
+    this.agentSessionProjectAssociations = store?.getProfileStorageDirectory
+      ? new AgentSessionProjectAssociationStore(
+          join(store.getProfileStorageDirectory(), 'agent-session-project-associations.json')
+        )
+      : null
     // Why: per-device tab selections must survive host restarts, or every phone snaps back to the first tab on return.
     const persistedClientTabSelections = store?.getMobileClientTabSelections?.()
     if (persistedClientTabSelections) {
@@ -5098,8 +5107,61 @@ export class OrcaRuntimeService {
   // Why: scans the transcript-owning host's disk (correct by construction over
   // RPC — a remote/SSH host scans its own disk). Delegates to the one shared
   // cache so the desktop panel and the mobile screen never double-scan.
-  listAiVaultSessions(args?: AiVaultListArgs): Promise<AiVaultListResult> {
-    return listAiVaultSessions(args)
+  async listAiVaultSessions(args?: AiVaultListArgs): Promise<AiVaultListResult> {
+    const result = await listAiVaultSessions(args)
+    if (!this.agentSessionProjectAssociations || !this.store) {
+      return result
+    }
+    return this.agentSessionProjectAssociations.enrich({
+      result,
+      projects: this.listProjects(),
+      worktrees: [...(await this.getResolvedWorktreeMap()).values()],
+      hookSessions: this.getAgentProviderSessionSnapshotFn?.() ?? []
+    })
+  }
+
+  async resumeAiVaultSession(args: {
+    sessionId: string
+    worktree: string
+    presentation?: RuntimeTerminalPresentation
+  }): Promise<RuntimeEnsureAgentSessionResult> {
+    const result = await this.listAiVaultSessions({ unlimited: true, force: true })
+    const session = result.sessions.find((candidate) => candidate.id === args.sessionId)
+    if (!session?.providerSession || !session.project) {
+      throw new Error('agent_session_not_found')
+    }
+    if (!isResumableTuiAgent(session.agent)) {
+      throw new Error('agent_session_not_resumable')
+    }
+    const worktree = await this.resolveWorktreeSelector(args.worktree)
+    const targetProject = this.listProjects().find(
+      (project) =>
+        project.id === worktree.projectId || project.sourceRepoIds.includes(worktree.repoId)
+    )
+    if (targetProject?.id !== session.project.id || worktree.isArchived) {
+      throw new Error('agent_session_project_mismatch')
+    }
+    return this.ensureAgentSession({
+      kind: 'explicit',
+      worktree: `id:${worktree.id}`,
+      agent: session.agent,
+      providerSession: session.providerSession,
+      ...(session.agent === 'omp' ? { ompResumeFilePath: session.filePath } : {}),
+      ...(args.presentation ? { presentation: args.presentation } : {})
+    })
+  }
+
+  async stopAiVaultSession(sessionId: string): Promise<RuntimeTerminalClose> {
+    const session = (
+      await this.listAiVaultSessions({ unlimited: true, force: true })
+    ).sessions.find((candidate) => candidate.id === sessionId)
+    if (!session) {
+      throw new Error('agent_session_not_found')
+    }
+    if (!session.liveTerminalHandle) {
+      throw new Error('agent_session_not_live')
+    }
+    return this.closeTerminal(session.liveTerminalHandle)
   }
 
   resolveAiVaultSessionTitles(
@@ -10920,6 +10982,48 @@ export class OrcaRuntimeService {
       }
     }
     return retainedChanged
+  }
+
+  captureAgentSessionProjectAssociation(
+    payload: Pick<AgentStatusIpcPayload, 'worktreeId' | 'agentType' | 'providerSession'>
+  ): void {
+    const worktreeId = payload.worktreeId
+    if (
+      !worktreeId ||
+      !payload.agentType ||
+      !payload.providerSession ||
+      !this.agentSessionProjectAssociations ||
+      !this.store
+    ) {
+      return
+    }
+    const parsed = splitWorktreeIdForFilesystem(worktreeId)
+    if (!parsed) {
+      return
+    }
+    const meta = this.store.getWorktreeMeta(worktreeId)
+    const projects = this.listProjects()
+    const project =
+      (meta?.projectId
+        ? projects.find((candidate) => candidate.id === meta.projectId)
+        : undefined) ??
+      projects.find((candidate) => candidate.sourceRepoIds.includes(parsed.repoId))
+    if (!project) {
+      return
+    }
+    void this.agentSessionProjectAssociations
+      .capture({
+        agent: payload.agentType,
+        providerSession: payload.providerSession,
+        worktree: {
+          id: worktreeId,
+          repoId: parsed.repoId,
+          path: parsed.worktreePath,
+          ...(meta?.projectId ? { projectId: meta.projectId } : {})
+        },
+        project
+      })
+      .catch((error) => console.warn('[agent-session] project association capture failed', error))
   }
 
   private retainAgentRowSnapshot(
@@ -18069,6 +18173,7 @@ export class OrcaRuntimeService {
         workspaceKind: 'git',
         worktreeId: worktree.id,
         repoId: worktree.repoId,
+        ...(worktree.projectId ? { projectId: worktree.projectId } : {}),
         ...((worktree.hostId ?? meta?.hostId) ? { hostId: worktree.hostId ?? meta?.hostId } : {}),
         terminalPlatform,
         repo: repo?.displayName ?? worktree.repoId,

--- a/src/main/runtime/rpc/methods/agent-session.test.ts
+++ b/src/main/runtime/rpc/methods/agent-session.test.ts
@@ -35,11 +35,47 @@ function runtimeStub() {
   return {
     getRuntimeId: () => 'runtime-1',
     ensureAgentSession: vi.fn().mockResolvedValue(terminalResult()),
-    createAgentSession: vi.fn().mockResolvedValue(terminalResult())
+    createAgentSession: vi.fn().mockResolvedValue(terminalResult()),
+    listAiVaultSessions: vi.fn().mockResolvedValue({ sessions: [], issues: [], scannedAt: 'now' }),
+    resumeAiVaultSession: vi.fn().mockResolvedValue(terminalResult('adopted')),
+    stopAiVaultSession: vi
+      .fn()
+      .mockResolvedValue({ handle: 'term_1', tabId: 'tab-1', ptyKilled: true })
   }
 }
 
 describe('agent session RPC methods', () => {
+  it('exposes list, project-safe resume, and stop through the common session namespace', async () => {
+    const runtime = runtimeStub()
+    const dispatcher = new RpcDispatcher({
+      runtime: runtime as unknown as OrcaRuntimeService,
+      methods: AGENT_SESSION_METHODS
+    })
+    expect(await dispatcher.dispatch(request('agentSession.list', { limit: 50 }))).toMatchObject({
+      ok: true,
+      result: { sessions: [] }
+    })
+    expect(
+      await dispatcher.dispatch(
+        request('agentSession.resume', {
+          sessionId: 'codex:session-1',
+          worktree: 'id:repo::/workspace/task',
+          presentation: 'focused'
+        })
+      )
+    ).toMatchObject({ ok: true, result: { disposition: 'adopted' } })
+    expect(
+      await dispatcher.dispatch(request('agentSession.stop', { sessionId: 'codex:session-1' }))
+    ).toMatchObject({ ok: true, result: { ptyKilled: true } })
+    expect(runtime.listAiVaultSessions).toHaveBeenCalledWith({ limit: 50 })
+    expect(runtime.resumeAiVaultSession).toHaveBeenCalledWith({
+      sessionId: 'codex:session-1',
+      worktree: 'id:repo::/workspace/task',
+      presentation: 'focused'
+    })
+    expect(runtime.stopAiVaultSession).toHaveBeenCalledWith('codex:session-1')
+  })
+
   it('dispatches an explicit structured resume without an authoritative command', async () => {
     const runtime = runtimeStub()
     const dispatcher = new RpcDispatcher({

--- a/src/main/runtime/rpc/methods/agent-session.ts
+++ b/src/main/runtime/rpc/methods/agent-session.ts
@@ -111,6 +111,8 @@ const ProviderSession = z
   })
   .strict()
 
+const HistorySessionId = StrictNonEmptyString(4096, 'Invalid session ID')
+
 const AutomaticEnsure = z
   .object({
     kind: z.literal('automatic'),
@@ -201,6 +203,12 @@ type AgentSessionRuntime = OrcaRuntimeService & {
     request: RuntimeCreateAgentSessionRequest,
     caller?: RuntimeAgentSessionRpcCaller
   ): Promise<RuntimeCreateAgentSessionResult>
+  resumeAiVaultSession(args: {
+    sessionId: string
+    worktree: string
+    presentation?: 'background' | 'focused'
+  }): Promise<RuntimeEnsureAgentSessionResult>
+  stopAiVaultSession(sessionId: string): Promise<unknown>
 }
 
 function callerContext(
@@ -234,6 +242,32 @@ function assertOperationTimestampWithinFutureSkew(clientOperationId: string): vo
 }
 
 export const AGENT_SESSION_METHODS: RpcAnyMethod[] = [
+  defineMethod({
+    name: 'agentSession.list',
+    params: z.object({ limit: z.number().int().positive().max(10_000).optional() }).strict(),
+    handler: (params, { runtime }) =>
+      (runtime as AgentSessionRuntime).listAiVaultSessions({ limit: params.limit ?? 1000 })
+  }),
+  defineMethod({
+    name: 'agentSession.resume',
+    params: z
+      .object({
+        sessionId: HistorySessionId,
+        worktree: WorktreeSelector,
+        presentation: Presentation.optional()
+      })
+      .strict(),
+    handler: (params, { runtime, clientKind }) =>
+      (runtime as AgentSessionRuntime).resumeAiVaultSession(
+        withExecutionHostAgentPresentation(params, clientKind)
+      )
+  }),
+  defineMethod({
+    name: 'agentSession.stop',
+    params: z.object({ sessionId: HistorySessionId }).strict(),
+    handler: (params, { runtime }) =>
+      (runtime as AgentSessionRuntime).stopAiVaultSession(params.sessionId)
+  }),
   defineMethod({
     name: 'terminal.ensureAgentSession',
     params: EnsureAgentSessionParams,

--- a/src/shared/ai-vault-types.ts
+++ b/src/shared/ai-vault-types.ts
@@ -1,5 +1,6 @@
 import type { TuiAgent } from './tui-agent'
 import type { ExecutionHostId, ExecutionHostScope } from './execution-host'
+import type { AgentProviderSessionMetadata } from './agent-session-resume'
 
 export const AI_VAULT_AGENTS = [
   'claude',
@@ -86,6 +87,16 @@ export type AiVaultSession = {
   executionHostPlatform?: NodeJS.Platform | null
   agent: AiVaultAgent
   sessionId: string
+  providerSession?: AgentProviderSessionMetadata
+  project?: {
+    id: string
+    repoId: string
+    displayName: string
+    originalWorktreeId: string
+    originalWorktreePath: string
+    workspaceAvailability: 'active' | 'archived' | 'missing'
+  }
+  liveTerminalHandle?: string
   title: string
   cwd: string | null
   branch: string | null

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -767,6 +767,7 @@ export type RuntimeWorktreePsSummary = {
   workspaceKind?: 'git' | 'folder-workspace'
   worktreeId: string
   repoId: string
+  projectId?: string
   hostId?: Worktree['hostId']
   terminalPlatform?: NodeJS.Platform
   repo: string


### PR DESCRIPTION
## Summary
- add provider-neutral agent session start, list, resume, and stop CLI commands
- persist session-to-project associations so history survives worktree cleanup
- group and resume project sessions safely in mobile

## Validation
- 43 targeted root tests passed
- 30 mobile tests passed
- node, CLI, web, and mobile typechecks passed
- max-lines and pre-commit lint/format checks passed