### PR TITLE
feat(file-explorer): add F2 rename keybinding via the shortcut registry

### DIFF
--- a/src/renderer/src/components/right-sidebar/file-explorer-row-context-menu.tsx
+++ b/src/renderer/src/components/right-sidebar/file-explorer-row-context-menu.tsx
@@ -113,6 +113,7 @@ export function FileExplorerRowContextMenu({
   const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
   const copyPathShortcutLabel = useShortcutLabel('fileExplorer.copyPath')
   const copyRelativePathShortcutLabel = useShortcutLabel('fileExplorer.copyRelativePath')
+  const renameShortcutLabel = useShortcutLabel('fileExplorer.rename')
   const findInFolderShortcutLabel = useShortcutLabel('sidebar.search.toggle')
   const showRemoteDownloadAction = shouldShowRemoteDownloadAction(
     node,
@@ -296,11 +297,9 @@ export function FileExplorerRowContextMenu({
       <ContextMenuItem onSelect={() => onStartRename(node)}>
         <Pencil />
         {translate('auto.components.right.sidebar.FileExplorerRow.fc747429bf', 'Rename')}
-        <ContextMenuShortcut>
-          {isMac
-            ? '↩'
-            : translate('auto.components.right.sidebar.FileExplorerRow.a06551beee', 'Enter')}
-        </ContextMenuShortcut>
+        {renameShortcutLabel !== 'Unassigned' ? (
+          <ContextMenuShortcut>{renameShortcutLabel}</ContextMenuShortcut>
+        ) : null}
       </ContextMenuItem>
       <ContextMenuItem variant="destructive" onSelect={onRequestDelete}>
         <Trash2 />

--- a/src/renderer/src/components/right-sidebar/useFileExplorerKeys.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerKeys.ts
@@ -221,7 +221,13 @@ export function useFileExplorerKeys(opts: {
           (focused !== null ? rowProjectionRef.current.getRowAtIndex(focused) : null) ??
           selectedNodeRef.current
         if (node) {
-          if (e.key === 'Enter' && !e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey) {
+          const wantsRename = keybindingMatchesAction(
+            'fileExplorer.rename',
+            e,
+            platform,
+            keybindings
+          )
+          if (wantsRename) {
             e.preventDefault()
             startRenameRef.current(node)
             return

--- a/src/shared/keybindings-default-bindings.test.ts
+++ b/src/shared/keybindings-default-bindings.test.ts
@@ -437,4 +437,74 @@ describe('keybindings', () => {
       })
     ).toBe(true)
   })
+
+  it('matches the default file explorer rename shortcut', () => {
+    expect(getEffectiveKeybindingsForAction('fileExplorer.rename', 'darwin')).toEqual([
+      'Enter',
+      'F2'
+    ])
+    expect(getEffectiveKeybindingsForAction('fileExplorer.rename', 'linux')).toEqual([
+      'F2',
+      'Enter'
+    ])
+    expect(getEffectiveKeybindingsForAction('fileExplorer.rename', 'win32')).toEqual([
+      'F2',
+      'Enter'
+    ])
+    expect(
+      keybindingMatchesAction(
+        'fileExplorer.rename',
+        { key: 'F2', code: 'F2', control: false, meta: false, alt: false, shift: false },
+        'win32'
+      )
+    ).toBe(true)
+    expect(
+      keybindingMatchesAction(
+        'fileExplorer.rename',
+        { key: 'Enter', code: 'Enter', control: false, meta: false, alt: false, shift: false },
+        'darwin'
+      )
+    ).toBe(true)
+    expect(
+      keybindingMatchesAction(
+        'fileExplorer.rename',
+        { key: 'Enter', code: 'Enter', control: false, meta: false, alt: false, shift: true },
+        'linux'
+      )
+    ).toBe(false)
+
+    const remapped = { 'fileExplorer.rename': ['Enter'] }
+    expect(getEffectiveKeybindingsForAction('fileExplorer.rename', 'win32', remapped)).toEqual([
+      'Enter'
+    ])
+    expect(
+      keybindingMatchesAction(
+        'fileExplorer.rename',
+        { key: 'F2', code: 'F2', control: false, meta: false, alt: false, shift: false },
+        'win32',
+        remapped
+      )
+    ).toBe(false)
+    expect(
+      keybindingMatchesAction(
+        'fileExplorer.rename',
+        { key: 'Enter', code: 'Enter', control: false, meta: false, alt: false, shift: false },
+        'win32',
+        remapped
+      )
+    ).toBe(true)
+    expect(
+      getEffectiveKeybindingsForAction('fileExplorer.rename', 'win32', {
+        'fileExplorer.rename': []
+      })
+    ).toEqual([])
+    expect(
+      keybindingMatchesAction(
+        'fileExplorer.rename',
+        { key: 'F2', code: 'F2', control: false, meta: false, alt: false, shift: false },
+        'win32',
+        { 'fileExplorer.rename': [] }
+      )
+    ).toBe(false)
+  })
 })

--- a/src/shared/keybindings/definitions-core-3.ts
+++ b/src/shared/keybindings/definitions-core-3.ts
@@ -177,6 +177,21 @@ export const KEYBINDING_DEFINITION_CORE_3: readonly KeybindingDefinition[] = [
     defaultBindings: platformBindings(['Mod+Alt+Shift+C'])
   },
   {
+    id: 'fileExplorer.rename',
+    title: 'Rename file',
+    group: 'File Explorer',
+    scope: 'fileExplorer',
+    searchKeywords: ['shortcut', 'file explorer', 'rename', 'f2'],
+    // Why: F2 mirrors VS Code/JetBrains on Windows/Linux; Enter stays bound everywhere
+    // to keep the long-standing Enter-to-rename behavior.
+    defaultBindings: {
+      darwin: ['Enter', 'F2'],
+      linux: ['F2', 'Enter'],
+      win32: ['F2', 'Enter']
+    },
+    allowBareKeybindings: true
+  },
+  {
     id: 'fileExplorer.delete',
     title: 'Delete file',
     group: 'File Explorer',

--- a/src/shared/keybindings/types.ts
+++ b/src/shared/keybindings/types.ts
@@ -97,6 +97,7 @@ export type KeybindingActionId =
   | 'fileExplorer.redo'
   | 'fileExplorer.copyPath'
   | 'fileExplorer.copyRelativePath'
+  | 'fileExplorer.rename'
   | 'fileExplorer.delete'
   | 'settings.search'
   | 'terminal.copySelection'

--- a/tests/e2e/file-explorer-rename-keybinding.spec.ts
+++ b/tests/e2e/file-explorer-rename-keybinding.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from './helpers/orca-app'
+import { openFileExplorer } from './helpers/file-explorer'
+import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+
+test('F2 starts inline rename on the selected explorer row', async ({ orcaPage }) => {
+  await waitForSessionReady(orcaPage)
+  await waitForActiveWorktree(orcaPage)
+  await openFileExplorer(orcaPage)
+
+  const explorer = orcaPage.locator('[data-orca-explorer-shell]')
+  await expect(explorer).toBeVisible({ timeout: 15_000 })
+  const row = explorer
+    .locator('[data-file-explorer-row]')
+    .filter({ hasText: /^README\.md$/ })
+    .first()
+  await expect(row).toBeVisible({ timeout: 10_000 })
+
+  await row.click()
+  await orcaPage.keyboard.press('F2')
+
+  // The inline rename input renders inside a virtualized row wrapper; the
+  // explorer's Find-files filter input sits outside them.
+  const inlineInput = explorer.locator('[data-index] input')
+  await expect(inlineInput).toBeVisible({ timeout: 5_000 })
+  await expect(inlineInput).toHaveValue('README.md')
+
+  // Escape cancels without touching the file
+  await inlineInput.press('Escape')
+  await expect(inlineInput).toHaveCount(0)
+  await expect(row).toBeVisible()
+})


### PR DESCRIPTION
## ELI5

You can now press **F2** (or Enter, as before) to rename the selected file or folder in the File Explorer — the same key every other editor uses. The shortcut also shows up in Settings → Shortcuts, so you can remap it to whatever you like.

## What Changed

- Added a `fileExplorer.rename` action to the central keybinding registry (`src/shared/keybindings.ts`) with platform defaults following editor conventions: `F2` + `Enter` on Windows/Linux, `Enter` + `F2` on macOS. `Enter` stays bound on every platform, so the long-standing Enter-to-rename behavior is preserved exactly.
- Replaced the hardcoded `e.key === 'Enter'` branch in `useFileExplorerKeys.ts` with `keybindingMatchesAction('fileExplorer.rename', …)`, mirroring the existing `fileExplorer.delete` branch right below it.
- The context-menu **Rename** item now renders its shortcut hint from the effective binding (like Copy Path / Delete already do) instead of a hardcoded `Enter` / `↩` label, so user remaps are reflected.
- Tests: registry defaults + matching unit tests (`keybindings-default-bindings.test.ts`), and an e2e spec (`file-explorer-rename-keybinding.spec.ts`) that presses F2 on a selected row, asserts the inline rename input opens prefilled, and that Escape cancels cleanly.

## Why

Rename is a high-frequency operation, and F2 is muscle memory from VS Code, JetBrains, Zed, and the OS file managers on Windows/Linux. Orca's only pointer path (double-click on the filename) is also the reason single clicks on the name hotspot wait 500 ms (#12800), so a keyboard path matters. The existing Enter branch was invisible: not in the registry, not shown in Settings, not remappable — this moves it into the registry rather than adding a second hardcoded key.

## Linked Issue

Fixes #14693

## Visual Proof

| | Before | After |
|---|---|---|
| Context menu hint | ![before context menu](https://raw.githubusercontent.com/jsk4581/orca/assets/f2-rename-14693/before-1-context-menu.png) | ![after context menu](https://raw.githubusercontent.com/jsk4581/orca/assets/f2-rename-14693/after-1-context-menu.png) |
| F2 on a selected row | ![before f2](https://raw.githubusercontent.com/jsk4581/orca/assets/f2-rename-14693/before-2-f2-pressed.png) | ![after f2](https://raw.githubusercontent.com/jsk4581/orca/assets/f2-rename-14693/after-2-f2-pressed.png) |
| Settings → Shortcuts | ![before settings](https://raw.githubusercontent.com/jsk4581/orca/assets/f2-rename-14693/before-3-settings-shortcuts.png) | ![after settings](https://raw.githubusercontent.com/jsk4581/orca/assets/f2-rename-14693/after-3-settings-shortcuts.png) |

Before: F2 does nothing; the context-menu hint is a hardcoded `Enter`; no rename row in Settings.
After: F2 opens the inline rename input with the basename preselected; the hint reads `F2, Enter` (platform-ordered); a remappable **Rename file** row appears under Settings → Shortcuts → File Explorer.

## Testing

- `pnpm lint`, `pnpm typecheck` pass; `pnpm build` passes.
- `vitest` on `src/shared/keybindings-default-bindings.test.ts`, `useFileExplorerKeys.test.ts`, `file-explorer-inline-rename-flow.test.tsx`: all pass (registry tests live in `keybindings-default-bindings.test.ts` after the #14728 test-file split).
- New e2e spec passes headless on Linux: `SKIP_BUILD=1 npx playwright test tests/e2e/file-explorer-rename-keybinding.spec.ts --project=electron-headless`.
- Full `pnpm test`: 6 failures in `src/main/**` (persistence retention, automations retention, hook-service endpoint, ai-vault sqlite bounds ×2, runtime-files preview) — all reproduce identically on a clean `upstream/main` checkout on this machine and are unrelated to this diff (renderer + shared registry only).
- Manually tested on Linux (headless Electron): F2 rename open/cancel/commit, Enter still works, context menu hint, Settings row + remap UI.
- Not manually tested on macOS/Windows hardware; the change is registry data + an existing matcher path that `fileExplorer.delete` already exercises on all platforms.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Implemented with Claude (Anthropic), driven and reviewed by a human contributor. All checks were run locally; test design and the registry approach follow the existing `fileExplorer.delete` precedent.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Review

AI code review summary (Claude):

- **Cross-platform**: no `metaKey`/`ctrlKey` hardcoding added; per-platform defaults live in the registry (`darwin`/`linux`/`win32`) and matching goes through the existing `keybindingMatchesAction` engine. F2 and Enter are already valid safe bare-key tokens (`isSafeBareKey`), gated by `allowBareKeybindings` exactly like `fileExplorer.delete`. No Electron menu accelerators touched.
- **SSH / remote / folder workspaces**: the shortcut only triggers the same `startRename` → inline input → `renameFileOnDisk` path the context menu and double-click already use, including its `operationOwner` (local vs runtime) routing — no new filesystem or wire behavior.
- **Agents / integrations**: no agent-, provider-, or integration-specific behavior involved.
- **Performance**: one additional registry match per keydown inside the explorer scope (same cost profile as the adjacent delete check); no hot-path or startup impact.
- **UI quality**: context-menu hint and Settings row both derive from the registry, so remaps stay consistent; bare keys only fire when focus is inside the explorer shell (existing `focusInExplorer` guard), so the editor/terminal never lose F2 or Enter.
- **Security**: no new IPC, paths, or privileges.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

