### PR TITLE
fix(antigravity): install a PreToolUse status hook without deciding tool permissions

### DIFF
--- a/config/tsconfig.cli.json
+++ b/config/tsconfig.cli.json
@@ -13,6 +13,7 @@
     "../src/main/agent-hooks/managed-agent-hook-controls.ts",
     "../src/main/agent-hooks/managed-agent-hook-registry.ts",
     "../src/main/agent-hooks/managed-hook-script-refresh.ts",
+    "../src/main/agent-hooks/posix-hook-command.ts",
     "../src/main/agent-hooks/runtime-home-hook-command.ts",
     "../src/main/amp/agent-status-plugin-source.ts",
     "../src/main/amp/hook-service.ts",

--- a/src/main/agent-hooks/installer-utils.test.ts
+++ b/src/main/agent-hooks/installer-utils.test.ts
@@ -492,6 +492,37 @@ describe('wrapPosixHookCommand', () => {
     }
   )
 
+  it('emits a fallback response before draining when the caller supplies one', () => {
+    const cmd = wrapPosixHookCommand('/does/not/exist.sh', {}, { fallbackStdout: '{"a":"b"}' })
+    expect(cmd).toBe(
+      `if [ -f '/does/not/exist.sh' ] && [ -r '/does/not/exist.sh' ] && [ -x '/does/not/exist.sh' ]; then /bin/sh '/does/not/exist.sh'; else printf '%s\\n' '{"a":"b"}'; ${POSIX_HOOK_STDIN_DRAIN_COMMAND}; fi`
+    )
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'writes the fallback response and still drains a large stdin payload',
+    () => {
+      const cmd = wrapPosixHookCommand('/does/not/exist.sh', {}, { fallbackStdout: '{"a":"b"}' })
+      const result = spawnSync('/bin/sh', ['-c', cmd], {
+        input: Buffer.alloc(1_000_000, 'x'),
+        encoding: 'utf8'
+      })
+      expect(result.status).toBe(0)
+      expect(result.stdout).toBe('{"a":"b"}\n')
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'runs the script instead of the fallback when the script is present',
+    () => {
+      const scriptPath = join(tmpDir, 'present-hook.sh')
+      writeFileSync(scriptPath, "#!/bin/sh\nprintf 'from-script\\n'\n", { mode: 0o755 })
+      const cmd = wrapPosixHookCommand(scriptPath, {}, { fallbackStdout: '{"a":"b"}' })
+      const result = spawnSync('/bin/sh', ['-c', cmd], { encoding: 'utf8' })
+      expect(result.stdout).toBe('from-script\n')
+    }
+  )
+
   it.skipIf(process.platform === 'win32')(
     'drains stdin when a directory occupies the managed script path',
     () => {

--- a/src/main/agent-hooks/installer-utils.ts
+++ b/src/main/agent-hooks/installer-utils.ts
@@ -13,7 +13,6 @@ import { dirname, join } from 'node:path'
 import { randomUUID } from 'node:crypto'
 import type { AgentHookSource } from '../../shared/agent-hook-relay'
 import { grantDirAcl, isPermissionError } from '../win32-utils'
-import { POSIX_HOOK_STDIN_DRAIN_COMMAND } from './hook-stdin-contract'
 import { resolveHooksJsonWritePath } from './hook-config-write-path'
 import { writeRollingFileBackup } from '../rolling-file-backup'
 
@@ -105,20 +104,7 @@ export function getSharedManagedScriptPath(scriptFileName: string): string {
   return join(homedir(), '.orca', 'agent-hooks', scriptFileName)
 }
 
-function quotePosixShellString(value: string): string {
-  return `'${value.replaceAll("'", "'\\''")}'`
-}
-
-// Why: guard for a readable executable so a stale entry at a missing script becomes a silent no-op, not an exit-127 failure on every tool call.
-export function wrapPosixHookCommand(scriptPath: string, env: Record<string, string> = {}): string {
-  // Why: single-quote escape so $, `, ", \ in scriptPath stay literal — avoids shell injection from an arbitrary path.
-  const quoted = quotePosixShellString(scriptPath)
-  const envPrefix = Object.entries(env)
-    .map(([key, value]) => `${key}='${value.replaceAll("'", "'\\''")}'`)
-    .join(' ')
-  const invocation = envPrefix ? `${envPrefix} /bin/sh ${quoted}` : `/bin/sh ${quoted}`
-  return `if [ -f ${quoted} ] && [ -r ${quoted} ] && [ -x ${quoted} ]; then ${invocation}; else ${POSIX_HOOK_STDIN_DRAIN_COMMAND}; fi`
-}
+export { wrapPosixHookCommand } from './posix-hook-command'
 
 function quotePowerShellString(value: string): string {
   return `'${value.replaceAll("'", "''")}'`

--- a/src/main/agent-hooks/posix-hook-command.ts
+++ b/src/main/agent-hooks/posix-hook-command.ts
@@ -1,0 +1,25 @@
+import { POSIX_HOOK_STDIN_DRAIN_COMMAND } from './hook-stdin-contract'
+
+function quotePosixShellString(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`
+}
+
+// Why: guard for a readable executable so a stale entry at a missing script becomes a silent no-op, not an exit-127 failure on every tool call.
+export function wrapPosixHookCommand(
+  scriptPath: string,
+  env: Record<string, string> = {},
+  // Why: silence is a hard deny on gate events (Antigravity PreToolUse, #2426); those callers need the guard to still answer.
+  options: { fallbackStdout?: string } = {}
+): string {
+  // Why: single-quote escape so $, `, ", \ in scriptPath stay literal — avoids shell injection from an arbitrary path.
+  const quoted = quotePosixShellString(scriptPath)
+  const envPrefix = Object.entries(env)
+    .map(([key, value]) => `${key}='${value.replaceAll("'", "'\\''")}'`)
+    .join(' ')
+  const invocation = envPrefix ? `${envPrefix} /bin/sh ${quoted}` : `/bin/sh ${quoted}`
+  const fallback =
+    options.fallbackStdout === undefined
+      ? POSIX_HOOK_STDIN_DRAIN_COMMAND
+      : `printf '%s\\n' ${quotePosixShellString(options.fallbackStdout)}; ${POSIX_HOOK_STDIN_DRAIN_COMMAND}`
+  return `if [ -f ${quoted} ] && [ -r ${quoted} ] && [ -x ${quoted} ]; then ${invocation}; else ${fallback}; fi`
+}

--- a/src/main/agent-hooks/remote-hook-service-installers.test.ts
+++ b/src/main/agent-hooks/remote-hook-service-installers.test.ts
@@ -343,14 +343,20 @@ describe('remote hook service installers', () => {
       expect(command).toContain('/home/dev/.orca/agent-hooks/antigravity-hook.sh')
       expect(command).toContain(`ORCA_ANTIGRAVITY_EVENT='${eventName}'`)
     }
-    expect(antigravityConfig['orca-status'].PreToolUse).toBeUndefined()
-    for (const eventName of ['PostToolUse']) {
+    for (const eventName of ['PreToolUse', 'PostToolUse']) {
       const definition = antigravityConfig['orca-status'][eventName]?.[0]
       const command = definition?.hooks?.[0]?.command
       expect(definition?.matcher).toBe('*')
       expect(command).toContain('/home/dev/.orca/agent-hooks/antigravity-hook.sh')
       expect(command).toContain(`ORCA_ANTIGRAVITY_EVENT='${eventName}'`)
     }
+    // Why: #2426 was an SSH report — a remote host missing the script must still answer the gate, not deny every tool.
+    expect(antigravityConfig['orca-status'].PreToolUse[0].hooks?.[0]?.command).toContain(
+      `printf '%s\\n' '{"decision":"ask"}'`
+    )
+    expect(antigravityConfig['orca-status'].PostToolUse[0].hooks?.[0]?.command).not.toContain(
+      '{"decision"'
+    )
 
     const ampPlugin = amp.fs.files.get('/home/dev/.config/amp/plugins/orca-agent-status.ts')
     expect(ampPlugin).toContain('/hook/amp')
@@ -527,7 +533,7 @@ describe('remote hook service installers', () => {
     }
   })
 
-  it('removes stale remote Antigravity PreToolUse hooks while installing SSH hooks', async () => {
+  it('replaces stale remote Antigravity PreToolUse hooks while installing SSH hooks', async () => {
     const { sftp, fs } = createFakeSftp()
     fs.files.set(
       '/home/dev/.gemini/config/hooks.json',
@@ -568,7 +574,12 @@ describe('remote hook service installers', () => {
     const config = JSON.parse(fs.files.get('/home/dev/.gemini/config/hooks.json')!) as {
       'orca-status': Record<string, { hooks?: { command: string }[] }[]>
     }
-    expect(config['orca-status'].PreToolUse).toBeUndefined()
+    const preToolCommands = config['orca-status'].PreToolUse.flatMap((definition) =>
+      (definition.hooks ?? []).map((hook) => hook.command)
+    )
+    expect(preToolCommands).toHaveLength(1)
+    expect(preToolCommands[0]).toContain('/home/dev/.orca/agent-hooks/antigravity-hook.sh')
+    expect(preToolCommands).not.toContain('/tmp/old/agent-hooks/antigravity-hook.sh')
     const postToolCommands = config['orca-status'].PostToolUse.flatMap((definition) =>
       (definition.hooks ?? []).map((hook) => hook.command)
     )

--- a/src/main/antigravity/hook-events.ts
+++ b/src/main/antigravity/hook-events.ts
@@ -12,14 +12,22 @@ export const ANTIGRAVITY_EVENTS = [
     windowsWrapperFileName: 'antigravity-post-invocation.cmd'
   },
   { eventName: 'Stop', schema: 'direct', windowsWrapperFileName: 'antigravity-stop.cmd' },
-  // Why: Antigravity requires PreToolUse hooks to make permission decisions.
-  // Orca's hook is observational, so installing there can block user tools.
+  // PreToolUse is the only pre-tool signal Antigravity emits; without it panes show a bare "Working" spinner (#12898).
+  {
+    eventName: 'PreToolUse',
+    schema: 'tool',
+    windowsWrapperFileName: 'antigravity-pre-tool-use.cmd'
+  },
   {
     eventName: 'PostToolUse',
     schema: 'tool',
     windowsWrapperFileName: 'antigravity-post-tool-use.cmd'
   }
 ] as const
+
+// Why: Antigravity requires a decision on PreToolUse and reads silence as deny (#2426). Of the documented values
+// only "ask" defers to the user's permission config — "allow" would auto-approve every tool call Orca observes.
+export const ANTIGRAVITY_PRE_TOOL_USE_DECISION = '{"decision":"ask"}'
 
 export type AntigravityEvent = (typeof ANTIGRAVITY_EVENTS)[number]
 

--- a/src/main/antigravity/hook-script.ts
+++ b/src/main/antigravity/hook-script.ts
@@ -4,6 +4,7 @@ import {
   buildWindowsHookStdinDrainEpilogue,
   WINDOWS_HOOK_STDIN_DRAIN_COMMAND
 } from '../agent-hooks/hook-stdin-contract'
+import { ANTIGRAVITY_PRE_TOOL_USE_DECISION } from './hook-events'
 
 export function getManagedScript(target: 'local' | 'posix' = 'local'): string {
   if (target === 'local' && process.platform === 'win32') {
@@ -12,6 +13,8 @@ export function getManagedScript(target: 'local' | 'posix' = 'local'): string {
       'setlocal',
       'if /I "%ORCA_ANTIGRAVITY_EVENT%"=="Stop" (',
       '  echo {"decision":""}',
+      ') else if /I "%ORCA_ANTIGRAVITY_EVENT%"=="PreToolUse" (',
+      `  echo ${ANTIGRAVITY_PRE_TOOL_USE_DECISION}`,
       ') else (',
       '  echo {}',
       ')',
@@ -30,10 +33,12 @@ export function getManagedScript(target: 'local' | 'posix' = 'local'): string {
     '  Stop)',
     '    printf \'{"decision":""}\\n\'',
     '    ;;',
+    '  PreToolUse)',
+    `    printf '${ANTIGRAVITY_PRE_TOOL_USE_DECISION}\\n'`,
+    '    ;;',
     '  *)',
     // Why: Antigravity accepts an empty JSON object for passive status hooks;
-    // returning allow/ask/deny from PreToolUse would change the user's tool
-    // permission policy.
+    // only the PreToolUse gate rejects it, and that branch answers above.
     '    printf "{}\\n"',
     '    ;;',
     'esac',
@@ -79,6 +84,8 @@ export function getWindowsWrapperScript(eventName: string): string {
     ')',
     'if /I "%ORCA_ANTIGRAVITY_EVENT%"=="Stop" (',
     '  echo {"decision":""}',
+    ') else if /I "%ORCA_ANTIGRAVITY_EVENT%"=="PreToolUse" (',
+    `  echo ${ANTIGRAVITY_PRE_TOOL_USE_DECISION}`,
     ') else (',
     '  echo {}',
     ')',

--- a/src/main/antigravity/hook-service.test.ts
+++ b/src/main/antigravity/hook-service.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { spawnSync } from 'node:child_process'
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
@@ -25,6 +26,11 @@ const ANTIGRAVITY_PRE_INVOCATION_COMMAND =
   process.platform === 'win32' ? 'antigravity-pre-invocation.cmd' : 'antigravity-hook.sh'
 const ANTIGRAVITY_POST_TOOL_USE_COMMAND =
   process.platform === 'win32' ? 'antigravity-post-tool-use.cmd' : 'antigravity-hook.sh'
+const ANTIGRAVITY_PRE_TOOL_USE_COMMAND =
+  process.platform === 'win32' ? 'antigravity-pre-tool-use.cmd' : 'antigravity-hook.sh'
+// Why: the gate decision Orca is allowed to emit — "allow" would auto-approve every observed tool call.
+const PRE_TOOL_USE_DECISION = '{"decision":"ask"}'
+const POLICY_OVERRIDING_DECISIONS = ['allow', 'deny', 'force_ask', 'deny_unless_prior_grant']
 
 function withPlatform<T>(platform: NodeJS.Platform, run: () => T): T {
   const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
@@ -67,9 +73,12 @@ describe('AntigravityHookService', () => {
       >
     }
     expect(Object.keys(config['orca-status']).sort()).toEqual(
-      ['PostInvocation', 'PostToolUse', 'PreInvocation', 'Stop'].sort()
+      ['PostInvocation', 'PostToolUse', 'PreInvocation', 'PreToolUse', 'Stop'].sort()
     )
-    expect(config['orca-status'].PreToolUse).toBeUndefined()
+    expect(config['orca-status'].PreToolUse[0].matcher).toBe('*')
+    expect(config['orca-status'].PreToolUse[0].hooks?.[0]?.command).toContain(
+      ANTIGRAVITY_PRE_TOOL_USE_COMMAND
+    )
     expect(config['orca-status'].PostToolUse[0].matcher).toBe('*')
     expect(config['orca-status'].PreInvocation[0].command).toContain(
       ANTIGRAVITY_PRE_INVOCATION_COMMAND
@@ -105,9 +114,85 @@ describe('AntigravityHookService', () => {
       expect(script).not.toContain('--data-urlencode "payload=${payload}"')
     }
     expect(script).toContain('{"decision":""}')
+    expect(script).toContain(PRE_TOOL_USE_DECISION)
+    for (const decision of POLICY_OVERRIDING_DECISIONS) {
+      expect(script).not.toContain(`{"decision":"${decision}"}`)
+    }
   })
 
-  it('installs Windows event wrappers without nested cmd quoting and removes stale PreToolUse hooks', () => {
+  it.skipIf(process.platform === 'win32')(
+    'answers the PreToolUse gate with ask so the hook never decides tool permissions',
+    () => {
+      new AntigravityHookService().install()
+
+      const result = spawnSync(
+        '/bin/sh',
+        [join(homeDir, '.orca', 'agent-hooks', 'antigravity-hook.sh')],
+        {
+          env: {
+            ...process.env,
+            ORCA_ANTIGRAVITY_EVENT: 'PreToolUse',
+            ORCA_AGENT_HOOK_ENDPOINT: '',
+            ORCA_AGENT_HOOK_PORT: '',
+            ORCA_AGENT_HOOK_TOKEN: '',
+            ORCA_PANE_KEY: ''
+          },
+          input: '{"toolCall":{"name":"run_command","args":{"CommandLine":"ls"}}}',
+          encoding: 'utf8'
+        }
+      )
+
+      expect(result.status).toBe(0)
+      // Why: Antigravity reads silence/`{}` on PreToolUse as a deny (#2426), so the exact payload is the contract.
+      expect(result.stdout).toBe(`${PRE_TOOL_USE_DECISION}\n`)
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'keeps answering the PreToolUse gate when the managed script is missing',
+    () => {
+      new AntigravityHookService().install()
+      rmSync(join(homeDir, '.orca', 'agent-hooks'), { recursive: true, force: true })
+
+      const config = JSON.parse(
+        readFileSync(join(homeDir, '.gemini', 'config', 'hooks.json'), 'utf8')
+      ) as { 'orca-status': Record<string, { hooks?: { command: string }[] }[]> }
+      const command = config['orca-status'].PreToolUse[0].hooks?.[0]?.command
+
+      const result = spawnSync('/bin/sh', ['-c', command!], {
+        input: '{"toolCall":{"name":"run_command"}}',
+        encoding: 'utf8'
+      })
+
+      // Why: hooks.json lives in ~/.gemini and outlives ~/.orca, so a swept script must not deny every tool call.
+      expect(result.status).toBe(0)
+      expect(result.stdout).toBe(`${PRE_TOOL_USE_DECISION}\n`)
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'leaves non-gate Antigravity events silent when the managed script is missing',
+    () => {
+      new AntigravityHookService().install()
+      rmSync(join(homeDir, '.orca', 'agent-hooks'), { recursive: true, force: true })
+
+      const config = JSON.parse(
+        readFileSync(join(homeDir, '.gemini', 'config', 'hooks.json'), 'utf8')
+      ) as {
+        'orca-status': Record<string, { command?: string; hooks?: { command: string }[] }[]>
+      }
+      const postToolUse = config['orca-status'].PostToolUse[0].hooks?.[0]?.command
+      const preInvocation = config['orca-status'].PreInvocation[0].command
+
+      for (const command of [postToolUse, preInvocation]) {
+        const result = spawnSync('/bin/sh', ['-c', command!], { input: '{}', encoding: 'utf8' })
+        expect(result.status).toBe(0)
+        expect(result.stdout).toBe('')
+      }
+    }
+  )
+
+  it('installs Windows event wrappers without nested cmd quoting and replaces stale PreToolUse hooks', () => {
     withPlatform('win32', () => {
       const configPath = join(homeDir, '.gemini', 'config', 'hooks.json')
       const staleScriptPath = join(
@@ -155,18 +240,20 @@ describe('AntigravityHookService', () => {
           { matcher?: string; command?: string; hooks?: { command: string }[] }[]
         >
       }
-      expect(config['orca-status'].PreToolUse).toBeUndefined()
+      expect(config['orca-status'].PreToolUse).toHaveLength(1)
 
       const expectedWrappers = {
         PreInvocation: 'antigravity-pre-invocation.cmd',
         PostInvocation: 'antigravity-post-invocation.cmd',
         Stop: 'antigravity-stop.cmd',
+        PreToolUse: 'antigravity-pre-tool-use.cmd',
         PostToolUse: 'antigravity-post-tool-use.cmd'
       }
       for (const [eventName, wrapperFileName] of Object.entries(expectedWrappers)) {
         const definition = config['orca-status'][eventName][0]
-        const command =
-          eventName === 'PostToolUse' ? definition.hooks?.[0]?.command : definition.command
+        const command = ['PreToolUse', 'PostToolUse'].includes(eventName)
+          ? definition.hooks?.[0]?.command
+          : definition.command
         expect(createManagedCommandMatcher(wrapperFileName)(command)).toBe(true)
         expect(command).not.toContain('cmd /d /s /c')
         expect(command).not.toContain('ORCA_ANTIGRAVITY_EVENT')
@@ -174,6 +261,13 @@ describe('AntigravityHookService', () => {
         const wrapper = readFileSync(join(homeDir, '.orca', 'agent-hooks', wrapperFileName), 'utf8')
         expect(wrapper).toContain(`set "ORCA_ANTIGRAVITY_EVENT=${eventName}"`)
         expect(wrapper).toContain('call "%ORCA_ANTIGRAVITY_CORE%"')
+        // Why: the wrapper is the stdin owner when the core script is gone, so it must answer the gate itself.
+        if (eventName === 'PreToolUse') {
+          expect(wrapper).toContain(`echo ${PRE_TOOL_USE_DECISION}`)
+        }
+        for (const decision of POLICY_OVERRIDING_DECISIONS) {
+          expect(wrapper).not.toContain(`{"decision":"${decision}"}`)
+        }
       }
 
       const script = readFileSync(
@@ -254,7 +348,15 @@ describe('AntigravityHookService', () => {
       'orca-status': Record<string, { command?: string; hooks?: { command: string }[] }[]>
     }
     expect(config['orca-status'].OldEvent).toBeUndefined()
-    expect(config['orca-status'].PreToolUse).toBeUndefined()
+    // Why: the pre-a480e6b7 PreToolUse entry pointed at a script with no gate branch; it must be replaced, not kept.
+    const preToolCommands = config['orca-status'].PreToolUse.flatMap((definition) =>
+      (definition.hooks ?? []).map((hook) => hook.command)
+    )
+    expect(preToolCommands).toHaveLength(1)
+    expect(preToolCommands[0]).toContain(
+      join(homeDir, '.orca', 'agent-hooks', ANTIGRAVITY_PRE_TOOL_USE_COMMAND)
+    )
+    expect(preToolCommands[0]).not.toContain('/tmp/old/agent-hooks/antigravity-hook.sh')
     const commands = config['orca-status'].PostToolUse.flatMap((definition) =>
       (definition.hooks ?? []).map((hook) => hook.command)
     )

--- a/src/main/antigravity/hook-service.ts
+++ b/src/main/antigravity/hook-service.ts
@@ -17,7 +17,11 @@ import {
   writeManagedScriptRemote
 } from '../agent-hooks/installer-utils-remote'
 import { refreshManagedScriptIfPresent } from '../agent-hooks/managed-hook-script-refresh'
-import { ANTIGRAVITY_EVENTS, type AntigravityEvent } from './hook-events'
+import {
+  ANTIGRAVITY_EVENTS,
+  ANTIGRAVITY_PRE_TOOL_USE_DECISION,
+  type AntigravityEvent
+} from './hook-events'
 import { getManagedScript, getWindowsWrapperScript } from './hook-script'
 import {
   buildInstalledConfig,
@@ -46,11 +50,20 @@ function getWindowsWrapperScriptPath(event: AntigravityEvent): string {
   return getSharedManagedScriptPath(event.windowsWrapperFileName)
 }
 
+function getPosixManagedCommand(scriptPath: string, event: AntigravityEvent): string {
+  return wrapPosixHookCommand(
+    scriptPath,
+    { ORCA_ANTIGRAVITY_EVENT: event.eventName },
+    // Why: a missing managed script must not brick tools; the guard answers PreToolUse itself instead of staying silent.
+    event.eventName === 'PreToolUse' ? { fallbackStdout: ANTIGRAVITY_PRE_TOOL_USE_DECISION } : {}
+  )
+}
+
 function getManagedCommand(scriptPath: string, event: AntigravityEvent): string {
   if (process.platform === 'win32') {
     return wrapWindowsCmdHookCommand(getWindowsWrapperScriptPath(event))
   }
-  return wrapPosixHookCommand(scriptPath, { ORCA_ANTIGRAVITY_EVENT: event.eventName })
+  return getPosixManagedCommand(scriptPath, event)
 }
 
 export class AntigravityHookService {
@@ -174,8 +187,7 @@ export class AntigravityHookService {
 
       buildInstalledConfig(
         config,
-        (event) =>
-          wrapPosixHookCommand(remoteScriptPath, { ORCA_ANTIGRAVITY_EVENT: event.eventName }),
+        (event) => getPosixManagedCommand(remoteScriptPath, event),
         createAntigravityManagedCommandMatcher()
       )
       await writeManagedScriptRemote(sftp, remoteScriptPath, getManagedScript('posix'))


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​155 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​144 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​62 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​23 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​39 |

<!-- /orca-pr-loc -->

## ELI5

Every agent Orca supports shows you *which tool it's running right now* — "Working — Read(src/app.ts)". Antigravity just shows a spinner, because Orca never installed the hook that reports tool starts. This installs it, while making sure Orca doesn't accidentally become the thing that approves your tool calls.

## What Changed

- Install the `PreToolUse` status hook for Antigravity (local, Windows wrappers, and SSH remote), which is the only pre-tool signal Antigravity emits.
- Answer that hook with `{"decision":"ask"}` — the one documented decision that defers to the user's own permission config.
- Make the hooks.json missing-script guard emit the gate response too, so a swept `~/.orca` can't deny every tool call.
- Extract `wrapPosixHookCommand` into `posix-hook-command.ts` (the `options` parameter pushed `installer-utils.ts` past `max-lines`; per AGENTS.md a disable is not an option).

## Why

Antigravity is the only supported agent with no "a tool just started" signal (see the table in #12898). The consumer side is already fully implemented and already tested — `extractAntigravityToolFields` and `normalizeAntigravityEvent` parse `PreToolUse`, including the `waiting` state for `ask_question` / `ask_permission`. It was simply never fed one. This is an installer-side gap only.

**Why not the identity-frame registry.** The recent runtime work (#14634 Cline, #14647 Qwen, #14675 Trae) migrated runtimes onto the declared identity registry, because those runtimes were invisible to *title-detection vocabulary*. Antigravity is not an identity problem — it already has a dedicated `/hook/antigravity` route and its own normalizer at `agent-hook-listener.ts:3251`. Its defect is a missing hook *event kind*. The registry is the right tool for identity and the wrong tool here.

### Why `ask` and not `allow`

`PreToolUse` was installed when Antigravity support landed (`8afdbea2`), then removed the next day in `a480e6b7` / #2501 because the observational `{}` response violates Antigravity's schema and is read as a **deny** — #2426, "Tool call denied by jsonhook__orca-status_PreToolUse_0_0. Can not do any toolcall." That removal was correct given the constraint. The question is which valid response replaces `{}`.

Per [Google's hooks docs](https://antigravity.google/docs/hooks), `decision` is **required** on `PreToolUse` and has five documented values:

| Value | Documented meaning |
|---|---|
| `allow` | "Automatically allows the tool execution." |
| `deny` | "Hard blocks execution immediately." |
| **`ask`** | **"Prompts the user, but respects 'Always Allow' settings."** |
| `force_ask` | "Always prompts the user, ignoring cached permissions." |
| `deny_unless_prior_grant` | "Denies execution unless the resource was previously approved in a prior user grant." |

`ask` is the only value that hands the decision back to the user's configuration: it consults stored grants rather than forcing a prompt (that's `force_ask`) and rather than granting one (that's `allow`). `allow` would mean Orca silently auto-approves every tool call it observes — on every platform and on SSH hosts — as a side effect of a *status* feature. [Antigravity's permissions engine](https://antigravity.google/docs/cli/permissions) defaults unconfigured `command` / `mcp` / `execute_url` / non-workspace file actions to Ask, so `allow` would suppress exactly the prompts a default install relies on.

The decision value is orthogonal to the status feature: the hook script posts to `/hook/antigravity` regardless of what it echoes. `allow` buys nothing for the sidebar and only loosens the gate, so there is no tradeoff to make here.

### Fail-safe when the script is missing

`wrapPosixHookCommand`'s guard existed so "a stale entry at a missing script becomes a silent no-op." Silence is a no-op for `PostToolUse` / `PreInvocation` / `Stop` — but on the `PreToolUse` gate it is the #2426 deny. This matters because `~/.gemini/config/hooks.json` lives outside Orca and outlives `~/.orca`: an Orca uninstall, a re-provisioned SSH home, or dotfile sync leaves the entry pointing at nothing. The guard now emits `{"decision":"ask"}` for gate events, so the worst case is "no status," never "no tools." Non-gate events keep the byte-identical old guard, and this is covered both ways by tests.

## Linked Issue

Fixes #12898 (STA-3589)

## Superseded / related PRs

- **Supersedes #12993** (@innocarpe, "fix(antigravity): allow PreToolUse status hooks). Same correct diagnosis and largely the same installer structure — credit for identifying that only the installer was missing and for the Windows wrapper plumbing. Superseded for two reasons:
  1. It returns `{"decision":"allow"}`. That auto-approves every tool call Orca observes. The PR replaces the comment that warned about this ("returning allow/ask/deny from PreToolUse would change the user's tool permission policy") with "PreToolUse is the only passive status hook with a required allow response" — which is not accurate: `allow` is not the only valid response, and it is specifically the one that overrides the user's policy. `ask` is documented as respecting it.
  2. It leaves the missing-script guard silent, so it can reintroduce #2426 on any host where hooks.json outlives the managed script.
- Not superseded: #2501 / `a480e6b7` was the correct fix for the constraint as it stood, and this PR keeps its stale-entry cleanup behavior intact.

## Visual Proof

N/A — I could not produce a genuine before/after. The Antigravity CLI is not installed on this machine and is not distributed on npm (`@google/antigravity-cli`, `@google/antigravity`, `@antigravity/cli` all 404), so I could not A/B the sidebar or empirically confirm the runtime's handling of each `decision` value. The behavior claims above come from Google's published hook and permissions docs, quoted verbatim, plus the existing repo history (#2426 → `a480e6b7`). #12898's author reports an empirical A/B confirming the sidebar goes live the moment a `PreToolUse` hook is added and stays static without one.

Reviewer with `agy` installed: the one thing worth confirming on real hardware is that `{"decision":"ask"}` does not introduce a prompt for a tool the user has already allowed. If it does, that is a strong signal the feature needs an explicit opt-in rather than a different decision value — `allow` is not the fallback.

## Testing

`pnpm exec vitest run --config config/vitest.config.ts src/main/antigravity src/main/agent-hooks/installer-utils.test.ts src/main/agent-hooks/remote-hook-service-installers.test.ts src/shared/agent-hook-listener.test.ts` — 220 passed, 3 skipped (pre-existing win32-only skips).

Regression sweep over every other agent that shares `wrapPosixHookCommand` (devin, droid, copilot, gemini, cursor, codex, grok, command-code, kimi): 14 files, 93 passed.

`pnpm exec tsc -p config/tsconfig.node.json --noEmit` — clean. `oxlint` and `oxfmt` on changed files — clean.

**Non-vacuity proof.** Reverted `hook-service.ts` and `installer-utils.ts` to `main` while keeping the new tests: 9 of them fail, including both executable-behavior tests. Restored, all green.

New tests actually execute the generated shell rather than string-matching it:
- runs the installed `antigravity-hook.sh` with `ORCA_ANTIGRAVITY_EVENT=PreToolUse` and asserts stdout is exactly `{"decision":"ask"}\n`, exit 0;
- deletes `~/.orca/agent-hooks`, then runs the *hooks.json command string* and asserts it still answers `{"decision":"ask"}` (the #2426 belt);
- asserts non-gate events stay silent under the same conditions, so the guard change is scoped;
- asserts a present script wins over the fallback, so the fallback can't shadow a real hook;
- asserts no script or wrapper ever contains `allow` / `deny` / `force_ask` / `deny_unless_prior_grant`.

Platforms: exercised on macOS. Windows and SSH paths are covered by unit tests (Windows wrappers via the `withPlatform('win32')` harness; SSH via the fake-SFTP remote installer suite, including the new assertion that the remote `PreToolUse` command carries the fallback). Not exercised against a live `agy` binary — see Visual Proof.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

- **Security:** this is the central concern and the reason for `ask` over `allow`. Orca must not widen a user's tool-permission policy as a side effect of a status feature. `ask` defers; `allow` grants. The fallback path also emits `ask`, so Orca never grants even when its own script is gone.
- **Cross-platform:** POSIX core script, Windows core `.cmd`, and the Windows per-event wrapper all gained the same branch. One asymmetry, stated plainly: on Windows the hooks.json command is the bare wrapper path (required by #8430 — Antigravity spawns it as argv[0], so it can't be an `if exist` launcher), which means a *missing wrapper* can't be answered inline the way POSIX can. The wrapper answers the gate when the shared core is missing; nothing can answer when the wrapper itself is gone.
- **Remote SSH:** #2426 was an SSH report. `installRemote` now goes through the same command builder as local, so the fallback is present remotely too, asserted in `remote-hook-service-installers.test.ts`.
- **Backwards compatibility:** `wrapPosixHookCommand`'s new third parameter is optional and the emitted string is byte-identical for all 11 existing callers (asserted). Existing installs report `partial` until reinstall, which is the same migration path `a480e6b7` used in the opposite direction. Stale pre-`a480e6b7` `PreToolUse` entries are replaced, not appended.
- **Mobile / performance:** no change. The hook posts on the same path as `PostToolUse`, and the decision is printed before any network work.

## What remains open

- The `ask` semantics are documented, not empirically confirmed on a live `agy` — see Visual Proof.
- Antigravity's behavior when multiple `PreToolUse` hooks return different decisions is undocumented. Orca now always returns the non-deciding value, so it can never be the hook that loosens a user's own gate, but the precedence itself is unverified.
- #13626 / STA-1095 (Kilo status + resume) is the other half of this cluster and is **not** in this PR. It is a different mechanism and belongs in its own change; open PR #13990 covers the resume slice.

## Author

- X / Twitter: @BrennanKB5
