### PR TITLE
fix(sidebar): attribute each split pane's runtime title to its own leaf (STA-3264)

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -382,3 +382,114 @@ describe('buildTitleDerivedAgentRows', () => {
     expect(rows).toHaveLength(0)
   })
 })
+
+// Why: `runtimePaneTitlesByTabId` mixes two disjoint id spaces — live PaneManager
+// ids (>= 1) and the `-(leafIndex + 1)` slots a parked tab mints — so attributing a
+// title by its position in the numerically sorted slot list puts one split pane's
+// lifecycle on its sibling's row (STA-3264).
+describe('split-pane runtime title attribution', () => {
+  const LEAF_ID_3 = '99999999-9999-4999-8999-999999999999'
+
+  function makeNestedSplitLayout(): TerminalLayoutSnapshot {
+    // Split once (leaf 1 | leaf 2), then split the FIRST pane again (leaf 3).
+    // Layout traversal order is [1, 3, 2]; pane-creation order is [1, 2, 3].
+    return {
+      root: {
+        type: 'split',
+        direction: 'vertical',
+        first: {
+          type: 'split',
+          direction: 'vertical',
+          first: { type: 'leaf', leafId: LEAF_ID_1 },
+          second: { type: 'leaf', leafId: LEAF_ID_3 }
+        },
+        second: { type: 'leaf', leafId: LEAF_ID_2 }
+      },
+      activeLeafId: LEAF_ID_1,
+      expandedLeafId: null
+    }
+  }
+
+  function rowsFor(
+    paneTitles: Record<string, string>,
+    layout: TerminalLayoutSnapshot,
+    ptyIds: string[]
+  ) {
+    return buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { title: '⠋ Codex' })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: { 'tab-1': paneTitles },
+      ptyIdsByTabId: { 'tab-1': ptyIds },
+      terminalLayoutsByTabId: { 'tab-1': layout },
+      now: 2000
+    })
+  }
+
+  it('keeps a finished split pane out of Running while its sibling keeps working', () => {
+    // A parked split tab reports its panes through synthetic slots numbered off the
+    // in-order leaf list: -1 is the first leaf, -2 the second.
+    const rows = rowsFor({ '-1': 'Codex', '-2': '⠋ Codex' }, makeSplitLayout(), ['pty-a', 'pty-b'])
+
+    expect(rows.map((row) => [row.paneKey, row.state, row.entry.lastAssistantMessage])).toEqual([
+      [makePaneKey('tab-1', LEAF_ID_1), 'idle', 'Idle'],
+      [makePaneKey('tab-1', LEAF_ID_2), 'working', 'Running']
+    ])
+  })
+
+  it('lets a revealed tab’s live slots outrank the parked slots it left behind', () => {
+    // Revealing a parked tab mounts live slots without clearing the parked ones, so
+    // both id spaces describe the same two leaves at once. The live pair is current:
+    // leaf 1 has finished, leaf 2 is still working.
+    const rows = rowsFor(
+      { '-1': '⠋ Codex', '-2': '⠋ Codex', 1: 'Codex', 2: '⠋ Codex' },
+      makeSplitLayout(),
+      ['pty-a', 'pty-b']
+    )
+
+    expect(rows.map((row) => [row.paneKey, row.state])).toEqual([
+      [makePaneKey('tab-1', LEAF_ID_1), 'idle'],
+      [makePaneKey('tab-1', LEAF_ID_2), 'working']
+    ])
+  })
+
+  it('does not let sibling panes inherit each other’s agent or state', () => {
+    const rows = rowsFor(
+      { 1: 'Antigravity', 2: '⠋ Codex', 3: '⠋ Gemini CLI' },
+      makeNestedSplitLayout(),
+      ['pty-a', 'pty-b', 'pty-c']
+    )
+
+    expect(
+      rows
+        .map((row) => [row.paneKey, row.agentType, row.state])
+        .sort((a, b) => (a[0] < b[0] ? -1 : 1))
+    ).toEqual([
+      [makePaneKey('tab-1', LEAF_ID_1), 'antigravity', 'idle'],
+      [makePaneKey('tab-1', LEAF_ID_2), 'codex', 'working'],
+      [makePaneKey('tab-1', LEAF_ID_3), 'gemini', 'working']
+    ])
+  })
+
+  it('does not recycle a closed split pane’s row onto a surviving sibling', () => {
+    // Panes 1|2|3 were open; closing pane 1 promotes the surviving pair and clears
+    // only that pane's slot, leaving the survivors' live ids sparse (2, 3).
+    const survivingLayout: TerminalLayoutSnapshot = {
+      root: {
+        type: 'split',
+        direction: 'vertical',
+        first: { type: 'leaf', leafId: LEAF_ID_2 },
+        second: { type: 'leaf', leafId: LEAF_ID_3 }
+      },
+      activeLeafId: LEAF_ID_2,
+      expandedLeafId: null
+    }
+    const rows = rowsFor({ 2: '⠋ Codex', 3: 'Gemini CLI' }, survivingLayout, ['pty-b', 'pty-c'])
+
+    expect(rows.map((row) => [row.paneKey, row.agentType, row.state])).toEqual([
+      [makePaneKey('tab-1', LEAF_ID_2), 'codex', 'working'],
+      [makePaneKey('tab-1', LEAF_ID_3), 'gemini', 'idle']
+    ])
+    expect(rows.some((row) => row.paneKey === makePaneKey('tab-1', LEAF_ID_1))).toBe(false)
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -9,6 +9,8 @@ import type {
   AgentStatusState,
   AgentType
 } from '../../../../shared/agent-status-types'
+import { FIRST_PANE_ID } from '../../../../shared/pane-key'
+import { resolveRuntimePaneTitleLeafIdFromRoot } from '@/lib/runtime-pane-title-leaf-id'
 import { isTerminalLeafId, makePaneKey } from '../../../../shared/stable-pane-id'
 import type {
   TerminalLayoutSnapshot,
@@ -68,14 +70,26 @@ export function buildTitleDerivedAgentRows(args: {
     const paneTitles = runtimePaneTitlesByTabId[tab.id]
     const paneTitleEntries =
       paneTitles && Object.keys(paneTitles).length > 0
-        ? Object.entries(paneTitles).sort(([a], [b]) => Number(a) - Number(b))
+        ? Object.entries(paneTitles).sort(compareRuntimePaneTitleSlots)
         : []
 
     if (paneTitleEntries.length > 0) {
+      // Why: hoisted per tab — the leaf lists are layout-derived, not pane-derived.
+      const leafIds = collectLeafIds(layout?.root ?? null)
+      const liveSlotIds = paneTitleEntries
+        .map(([paneId]) => Number(paneId))
+        .filter((paneId) => paneId >= FIRST_PANE_ID)
+      // Why: pane ids only encode creation order while they are the dense sequence a
+      // fresh mount or replay allocates; an in-session pane close leaves them sparse.
+      const liveSlotsAreDense =
+        liveSlotIds.length === leafIds.length &&
+        liveSlotIds.every((paneId, index) => paneId === FIRST_PANE_ID + index)
       for (const [paneId, title] of paneTitleEntries) {
         const leafId = resolveLeafIdForTitleFallback({
           layout,
-          paneTitleEntries,
+          leafIds,
+          liveSlotIds,
+          liveSlotsAreDense,
           paneId: Number(paneId),
           title
         })
@@ -266,12 +280,56 @@ function titleStatusToRowState(
   return 'idle'
 }
 
+/**
+ * Orders runtime pane-title slots so live PaneManager ids claim their leaf before
+ * the synthetic slots a parked tab minted for the same leaf. Revealing a parked tab
+ * mounts new live slots without clearing the parked ones, so both id spaces coexist
+ * and the stale parked title must never win the row.
+ */
+function compareRuntimePaneTitleSlots([a]: [string, string], [b]: [string, string]): number {
+  const paneIdA = Number(a)
+  const paneIdB = Number(b)
+  const isLiveA = paneIdA >= FIRST_PANE_ID
+  if (isLiveA !== paneIdB >= FIRST_PANE_ID) {
+    return isLiveA ? -1 : 1
+  }
+  return paneIdA - paneIdB
+}
+
+/**
+ * Resolves the layout leaf that owns a runtime pane title.
+ *
+ * `runtimePaneTitlesByTabId` mixes two disjoint id spaces: live PaneManager ids
+ * (`>= FIRST_PANE_ID`, allocated in pane-creation order) and the `-(leafIndex + 1)`
+ * slots parked tabs mint in `fallbackParkedPaneCandidates`. Neither space is ordered
+ * like the layout's in-order leaf traversal, so attributing a title by its position
+ * in the slot list lands one pane's status on a sibling's row.
+ */
 function resolveLeafIdForTitleFallback(args: {
   layout: TerminalLayoutSnapshot | undefined
-  paneTitleEntries: [string, string][]
+  leafIds: string[]
+  liveSlotIds: number[]
+  liveSlotsAreDense: boolean
   paneId: number
   title: string
 }): string | null {
+  if (args.leafIds.length === 1) {
+    return args.leafIds[0]
+  }
+  if (args.paneId < FIRST_PANE_ID) {
+    // Parked slots are defined off the in-order leaf list, so invert that definition.
+    return args.leafIds[-args.paneId - 1] ?? null
+  }
+  if (args.liveSlotsAreDense) {
+    const creationOrderLeafId = resolveRuntimePaneTitleLeafIdFromRoot(
+      args.layout?.root,
+      String(args.paneId)
+    )
+    if (creationOrderLeafId) {
+      return creationOrderLeafId
+    }
+  }
+
   const matchingTitleLeafIds = Object.entries(args.layout?.titlesByLeafId ?? {})
     .filter(([, title]) => title === args.title)
     .map(([leafId]) => leafId)
@@ -279,13 +337,10 @@ function resolveLeafIdForTitleFallback(args: {
     return matchingTitleLeafIds[0]
   }
 
-  const leafIds = collectLeafIds(args.layout?.root ?? null)
-  if (leafIds.length === 1) {
-    return leafIds[0]
-  }
-
-  const paneIndex = args.paneTitleEntries.findIndex(([paneId]) => Number(paneId) === args.paneId)
-  return paneIndex !== -1 ? (leafIds[paneIndex] ?? null) : null
+  // Why: in-session pane closes leave the survivors' ids sparse, which creation order
+  // cannot resolve. Index within the LIVE slots only — never across both id spaces.
+  const paneIndex = args.liveSlotIds.indexOf(args.paneId)
+  return paneIndex !== -1 ? (args.leafIds[paneIndex] ?? null) : null
 }
 
 function collectLeafIds(node: TerminalPaneLayoutNode | null): string[] {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​111 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​111 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​65 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​55 |

<!-- /orca-pr-loc -->

## ELI5

Two agents in one split terminal tab each get their own sidebar row. Orca works out which row a pane's status belongs to by looking at the pane's terminal title — but it matched titles to panes **by position in a list**, and that list is not in pane order. So one pane's status could land on its sibling's row: you finish one agent and the sidebar keeps both rows spinning "Running", while the pane that actually finished is the one still showing work.

This makes each pane title resolve to *its own* pane by identity instead of by position.

## What Changed

`buildTitleDerivedAgentRows` resolves each runtime pane title to the layout leaf that actually owns it.

`runtimePaneTitlesByTabId[tabId]` is keyed by runtime pane id, and it holds **two disjoint id spaces**:

| Slot | Written by | Numbering |
| --- | --- | --- |
| `>= 1` | live `PaneManager` (`this.nextPaneId++`) | pane-**creation** order |
| `-(leafIndex + 1)` | `fallbackParkedPaneCandidates` for parked (unmounted) tabs | in-**order** leaf index, negated |

Neither space is ordered like the layout tree's in-order leaf traversal, and the two can be present at the same time. The old resolver sorted every slot numerically and used the slot's **index** into `collectLeafIds(root)`, which crosses both spaces.

The new resolution, per slot:

1. **Single-leaf tab** → the only leaf. (Unchanged, just moved to the front so it outranks the title match below.)
2. **Parked slot (`< 1`)** → `leafIds[-paneId - 1]`, the exact inverse of how `fallbackParkedPaneCandidates` mints it.
3. **Live slot, ids dense from `FIRST_PANE_ID`** → `resolveRuntimePaneTitleLeafIdFromRoot`, the repo's existing creation-order resolver already used by `worktree-status.ts`, `smart-attention.ts`, `worktree-agent-rows.ts`, and `ai-vault-original-pane.ts`. This PR does not add a resolver; it stops the sidebar from being the one place that hand-rolls its own.
4. **Unique `titlesByLeafId` match** → unchanged, but **demoted below** id-based resolution. It compares a live OSC title against a *user-assigned* pane name, so it must not take a leaf away from the pane whose id names it.
5. **Live slot, sparse ids** → index within the **live** slots only, never across both spaces. This is the old behavior, preserved for the case creation order genuinely cannot answer.

Slots are also ordered live-before-parked, so when a revealed tab carries both, the live slot claims the leaf and `seenPaneKeys` drops the stale parked duplicate rather than the other way round.

**Deliberately gated on density (step 3).** Pane ids only encode creation order while they are the dense sequence a fresh mount or replay allocates. An in-session pane close leaves survivors sparse (`{2, 3}`), where creation order would answer confidently and wrongly. Sparse falls to step 5, which is exactly today's behavior — so no in-session-close case regresses.

## Why

The literal string `Running` reaches a sidebar agent row through exactly one line in the renderer — `worktree-title-derived-agent-rows.ts` — so STA-3264's "both rows Running" is specifically about **title-derived** rows, the path hookless agents (Pi, Codex over SSH, Cursor Agent) depend on. Everything upstream of it is already pane-scoped: `agentStatusByPaneKey`, `selectLiveAgentStatusEntriesForWorktree`, and the explicit-entry loop in `buildWorktreeAgentRows` all key on `tabId:leafId`. The tab-scoped error is in the last step — deciding which leaf a pane title belongs to.

I drove `buildWorktreeAgentRows` directly to confirm the mechanism rather than reason about it. Real output, same builder the sidebar renders from, before the fix:

**Parked split tab.** Leaf 1 finished (idle title in slot `-1`), leaf 2 still working (slot `-2`). Sorting ascending gives `[-2, -1]`, which is the reverse of the leaf list the slots were numbered against:

```
before:  leaf-1  working  "Running"      <- the pane that FINISHED
         leaf-2  idle     "Idle"         <- the pane still WORKING
after:   leaf-1  idle     "Idle"
         leaf-2  working  "Running"
```

**Revealed parked tab — this is the reported symptom.** `disposeParkedTabWatchers` tears down watchers without clearing their title slots, so mounting adds live slots `{1, 2}` alongside the parked `{-1, -2}`. Four slots, two leaves: indices 0 and 1 are the two stale parked spinner titles, and the live idle title of the pane that finished is pushed to index 2 and dropped entirely.

```
before:  leaf-1  working  "Running"      <- stale parked title
         leaf-2  working  "Running"      <- stale parked title
         (the finished pane's live idle title is discarded)
after:   leaf-1  idle     "Idle"
         leaf-2  working  "Running"
```

**Three panes, left pane split again.** Tree traversal is `[1, 3, 2]`; creation order is `[1, 2, 3]`. Panes 2 and 3 take each other's title, so sibling panes inherit each other's agent identity *and* state:

```
before:  leaf-1 antigravity idle | leaf-3 codex working | leaf-2 gemini working
after:   leaf-1 antigravity idle | leaf-2 codex working | leaf-3 gemini working
```

That last case is why the fix is identity-based rather than another positional tweak: no ordering of a positional index can be right, because pane ids and tree position are independent facts.

### Which of the four cluster tickets this is — and is not

Three distinct root causes sit behind the four tickets. They are not one bug.

| Ticket | Root cause | Status |
| --- | --- | --- |
| **STA-3264** / #12228 — split-pane agents jointly Running | Runtime pane title → leaf attribution (this PR) | **Fixed here** |
| **STA-2811** / #11069 — split rows share one name that flips on click | `getAgentRowConversationName` reads `tab.title`, which carries only the focused pane's title | **Still open.** Addressed by #11070 (@pythonstrup) — see below |
| **STA-2926** / #11372 — title-derived row recycles after a split pane closes | A *different branch* of the same function: once the closed pane's title slot is cleared, the tab falls through to the `tab.title` fallback and re-synthesizes a row from the tab's stale spinner title | **Still open**, untouched here |
| STA-2637 — detaching a completed split pane split one session into two rows | — | Already Done |

**No PR is superseded.** There is no open or closed PR against STA-3264 (searched `12228 in:body` and `STA-3264 in:body`, both empty), and #11372 is an issue, not a PR.

**#11070 (@pythonstrup) is complementary, not competing, and is *not* superseded.** It suppresses the tab's live title as a *conversation name* source for split rows; this PR fixes which *pane* a title's *lifecycle state* is attributed to. STA-3264 puts the name half explicitly out of scope ("conversation names and lifecycle states are separate projections and should not be coupled"), and STA-2811 is listed under STA-3264's Out of Scope. The two changes touch disjoint files — #11070 edits `agent-row-conversation-name` / `use-agent-row-conversation-name` / `build-dashboard-snapshot`; this edits `worktree-title-derived-agent-rows` — and land independently. Worth noting they compose in the right direction: #11070's fallback for a split row is the pane's own prompt keyed by `paneKey`, which is only correct once that `paneKey` is the right pane, which is what this PR establishes.

**Not the subagent-clobbers-parent class** (STA-2112/2035, STA-2243). Nothing here reads or writes `orchestration.parentPaneKey`, and no row's preview or completion state is derived from another row. The change is confined to choosing a leaf id for one pane's own title.

### Prior art this builds on

- **#14615** (STA-2069) binds *hook-reported* status to the pane its session was spawned into. That is the authoritative-status anchor, and it already covers hook-carrying agents in splits — its own test suite pins two split panes keeping separate rows and prompts. It does not reach title-derived rows, which have no session to bind: their only pane coordinate is the runtime title slot this PR resolves. The two are the hook half and the hookless half of the same contract.
- **#14650** established that `launchAgent` is tab-scoped, so `resolveTitleDerivedPaneOwner` returns an owner only for a single-leaf layout — a split pane cannot brand its sibling. That guard is untouched and still holds: this PR changes *which leaf* a title maps to, never whether a split pane may claim tab-scoped ownership.
- **#14682** stabilised the compact row secondary. `worktree-card-compact-agent-row.tsx` is not touched.

## Linked Issue

Fixes #12228 (STA-3264)

Does **not** fix #11069 (STA-2811) or #11372 (STA-2926) — see the table above.

## Visual Proof

**Captured on a live app.** See the [full validation comment](https://github.com/stablyai/orca/pull/14702#issuecomment-5321232331) for the rig and the SSH leg.

Three panes in one tab (split once, then split the **first** pane, so traversal order `[1,3,2]` diverges from creation order `[1,2,3]`), each running a hookless process emitting a real OSC 0 agent title. Before/after is a one-line diff on a **single live instance**: the production hunk is reverted in place, Vite HMR reloads it, and the same panes are re-measured — each sample asserts which source version is actually served.

| pane (visible banner) | leaf | pre-fix row says | post-fix row says |
| --- | --- | --- | --- |
| PANE A — Antigravity, idle | `59d0919d` | antigravity / idle | antigravity / idle |
| PANE B — **Codex, working** | `2522ba8a` | **gemini / idle** | codex / working |
| PANE C — **Gemini, idle** | `2d238208` | **codex / working** | gemini / idle |

With focus on PANE A, clicking the row showing the Codex spinner lands on **PANE C** (the idle Gemini pane) pre-fix, and on **PANE B** (the pane actually running) post-fix.

![before](https://github.com/user-attachments/assets/4581a842-35e4-41c7-af13-9ada49c3197a)
![after](https://github.com/user-attachments/assets/7c3b1f96-d339-48f7-9eda-b740d05eea87)

**Read the images with this caveat.** A runtime title carries the agent name *and* its lifecycle state together, so mis-attribution moves both — the rendered multiset of (name, state) pairs is identical either way, and what changes is which **pane** each row is bound to. The shots therefore differ in row **order** and per-row **icon**, not in the name text. Also, all three rows render the same *name* there because of STA-2811 / #11069, which this PR does not fix; per-row identity is correct in the accessible summary (`Antigravity idle; Gemini idle; Codex working`).

**Not captured: the parked/revealed path.** I parked a split tab for real (pane manager gone, parked watchers owning it) but never observed a negative title slot — `resolveParkedTerminalPaneCandidates` prefers `capturedPanesByTabId`, so a tab that has mounted once keeps reusing its **positive** ids while parked. The `{-1,-2,1,2}` state behind the "both rows Running" block under **Why** remains **unverified on a live app** (that block is still constructed-state output).

## Testing

- [x] I manually tested these changes locally — **on a live dev app**, local and over a real SSH host, with a HMR-based one-line before/after (see Visual Proof and the validation comment). The constructed-store runs below are retained as the unit-level oracle.
- [x] Automated tests added/updated

**New tests** — `src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts`, new `split-pane runtime title attribution` block. They assert externally visible projection only (paneKey, agentType, lifecycle state, row count), per STA-3264's testing decisions:

1. *keeps a finished split pane out of Running while its sibling keeps working* — parked split tab, mixed lifecycle.
2. *lets a revealed tab's live slots outrank the parked slots it left behind* — both id spaces present; asserts two rows, correct states, no duplicates.
3. *does not let sibling panes inherit each other's agent or state* — three panes, left pane re-split; three different agents so a crossed mapping cannot pass by coincidence.
4. *does not recycle a closed split pane's row onto a surviving sibling* — survivors' ids sparse after a close; asserts each survivor keeps its own leaf and no row exists for the closed leaf.

**Red/green oracle.** Reverting **only** `worktree-title-derived-agent-rows.ts` and keeping the tests: **3 failed | 18 passed**. Tests 1–3 fail; test 4 passes both ways and is stated as a guard on the sparse-id path this PR deliberately preserves, not as evidence of a fix. Restored: 21/21.

**Regression scope.**

- `src/renderer/src/components/sidebar` + `src/renderer/src/components/dashboard`: the two suites that own the changed behavior (`worktree-title-derived-agent-rows`, `useWorktreeAgentRows`, `WorktreeCardAgents`) pass 79/79. Running the full pair of directories surfaces failures in heavy `WorktreeCard.*` render tests, all timeouts at the 20s/60s marks and all pre-existing: `WorktreeCard.pr-display.test.tsx` fails **2** tests on the pre-fix source and **1** with the change applied, i.e. it is a timing flake in both directions and not caused here. Nothing in the agent-row path fails.
- Every other consumer of the shared resolver — `paired-reconnect-sidebar-agent-count`, `runtime-pane-title-leaf-id`, `worktree-status`, `smart-attention`: **84 passed**.
- `check:code-quality:changed`: 0 new findings across 2 changed files, on all three gates (code quality, type-aware, React Doctor). No `max-lines` suppression added.
- Full `pnpm typecheck` **deliberately not run** (OOM risk on this host). The type-aware gate above covers the changed files. Types touched are narrow: one internal function's argument object and two imports.

**Rebase.** Rebased onto `origin/main` (`c4e188a25f`) from 146 commits behind; no conflicts, `merge-tree --write-tree` clean, red/green oracle re-run after the rebase (3 failed reverted → 21/21 restored). Confirmed `worktree-title-derived-agent-rows.ts` is byte-identical between the branch base and current main and that `WorktreeCardAgents.tsx → useWorktreeAgentRows → buildWorktreeAgentRows → buildTitleDerivedAgentRows` is still the live render chain.

**SSH.** Exercised for real against a throwaway `ubuntu:22.04` SSH target with a real relay (`remotePlatform: linux`): three hookless agents in one remote split tab reproduce the same swap pre-fix and are correct post-fix.

**Known limit, verified live and worth restating.** The in-session-close case is not merely untested, it is a **surviving mis-attribution of the same class**: split → close pane 2 → split again leaves live ids sparse (`{1,3,4}`), `liveSlotsAreDense` is false, and **with this PR applied** PANE D (OpenCode, working) still reports `gemini/idle` while PANE C (Gemini, idle) reports `opencode/working`. `worktree-status.ts` calls `resolveRuntimePaneTitleLeafIdFromRoot` directly with no density gate and is likewise untouched.

**Merge-collision check.** `git merge-tree --write-tree` against the head SHA of each in-flight PR that touches this area — **#14486** (the 119-file worktree-list reorg), **#14682**, **#14654** — all three merge with no conflict. I did not stop at the flag: I materialized the **#14486** merge into a scratch worktree and ran the agent-row suites on the merged tree — **79 passed**, so the merged result is green, not merely mergeable. (GitHub's `mergeable` field was independently verified stale during this sweep; I did not rely on it.)

**Platforms.** Written and run on macOS. Nothing platform-dependent is introduced: no shortcuts, modifier keys, shortcut labels, path construction, shell invocation, or Electron platform APIs. The change is integer/string id resolution over an in-memory layout tree. I did not exercise Windows, Linux, or a live SSH host.

## Review

- **Security.** No new surface. No command execution, path handling, auth, secrets, IPC channel, dependency, persisted state, or schema change. The only inputs are ids the renderer already owns.
- **Cross-platform.** No branching on `process.platform` or `navigator.userAgent`; nothing OS-specific to diverge.
- **Remote SSH.** This is the path that matters most for SSH: hookless agents over SSH (Codex #8711, OpenCode #8940) surface *only* decorated titles, so their rows are title-derived and were the most exposed to mis-attribution. No probing, no Git commands, no local-only assumptions — identical for local, remote-runtime, and SSH panes, and for folder workspaces as well as git worktrees (nothing reads git state).
- **Mobile / remote wire.** No wire change: no RPC params, no stream opcodes, and nothing new published to a paired client. This is renderer-local row derivation.
- **Backwards compatibility.** Nothing persisted, no migration, no downgrade hazard. The single-leaf and sparse-live-id paths keep their existing behavior byte for byte.
- **Performance** (STA-3354, Urgent P0 — tab-agent status resolution already scans the global status map per tab per render; rows must not multiply that). **This reduces per-render work.** It touches no status-map scan and adds no store subscription. Per tab with *n* leaves and *k* title slots, the old code ran `collectLeafIds` (O(n)) **and** an `Object.entries(titlesByLeafId)` scan **per slot** — O(k·n). The new code hoists the leaf list to **once per tab** and resolves each slot in O(n) worst case, with the `titlesByLeafId` scan now only reached when id-based resolution fails, which for a normally-mounted tab is never. Net: strictly fewer scans than today, one added O(k) pass to compute `liveSlotIds`, and no change to row count — so nothing downstream multiplies either.

## AI Disclosure

Claude Opus 5 (Claude Code), on macOS.

## Checklist

- [x] This PR is small and focused — 1 source file, 1 test file
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — scoped equivalents run locally and green; full typecheck left to CI per the OOM constraint above

## Author

- X / Twitter: @BrennanKB5

