### PR TITLE
fix(sidebar): stop workspace delete from waking a sleeping sibling

### DIFF
--- a/src/renderer/src/components/sidebar/active-worktree-focus-after-delete.test.ts
+++ b/src/renderer/src/components/sidebar/active-worktree-focus-after-delete.test.ts
@@ -185,7 +185,7 @@ describe('prepareActiveWorktreeFocusAfterDelete', () => {
     simulateDelete('wt-del', true)
     commit()
 
-    expect(activateAndRevealWorktree).toHaveBeenCalledWith('wt-awake')
+    expect(activateAndRevealWorktree).toHaveBeenCalledWith('wt-awake', { revealInSidebar: false })
   })
 
   it('keeps a sibling whose agent is live across a PTY gap eligible', () => {
@@ -210,7 +210,7 @@ describe('prepareActiveWorktreeFocusAfterDelete', () => {
     simulateDelete('wt-del', true)
     commit()
 
-    expect(activateAndRevealWorktree).toHaveBeenCalledWith('wt-agent')
+    expect(activateAndRevealWorktree).toHaveBeenCalledWith('wt-agent', { revealInSidebar: false })
   })
 
   it('stays within the deleted worktree project instead of jumping to another project', () => {

--- a/src/renderer/src/components/sidebar/active-worktree-focus-after-delete.test.ts
+++ b/src/renderer/src/components/sidebar/active-worktree-focus-after-delete.test.ts
@@ -155,8 +155,7 @@ describe('prepareActiveWorktreeFocusAfterDelete', () => {
   })
 
   it('leaves focus empty rather than waking a sleeping sibling', () => {
-    // Activating a slept workspace respawns its PTYs and resumes its agent sessions,
-    // so a delete must never pick one as the successor. #10205
+    // The reported flow: every survivor slept, so the delete revived one. #10205
     seed([
       { id: 'main', isMainWorktree: true, asleep: true },
       { id: 'wt-slept', asleep: true },

--- a/src/renderer/src/components/sidebar/active-worktree-focus-after-delete.test.ts
+++ b/src/renderer/src/components/sidebar/active-worktree-focus-after-delete.test.ts
@@ -17,7 +17,14 @@ const mocks = vi.hoisted(() => {
     repos: [] as SeedRepo[],
     lastVisitedAtByWorktreeId: {} as Record<string, number>,
     deleteStateByWorktreeId: {} as Record<string, { isDeleting?: boolean }>,
-    worktreeMap: new Map<string, SeedWorktree>()
+    worktreeMap: new Map<string, SeedWorktree>(),
+    tabsByWorktree: {} as Record<string, { id: string }[]>,
+    ptyIdsByTabId: {} as Record<string, string[]>,
+    browserTabsByWorktree: {} as Record<string, { id: string }[]>,
+    agentStatusByPaneKey: {} as Record<
+      string,
+      { paneKey: string; worktreeId?: string; state: string; updatedAt: number }
+    >
   }
   return { state }
 })
@@ -41,7 +48,14 @@ import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { prepareActiveWorktreeFocusAfterDelete } from './active-worktree-focus-after-delete'
 
 function seed(
-  worktrees: { id: string; repoId?: string; isMainWorktree?: boolean; hostId?: string }[]
+  worktrees: {
+    id: string
+    repoId?: string
+    isMainWorktree?: boolean
+    hostId?: string
+    /** Slept workspaces keep their tab records but hold no live PTY. */
+    asleep?: boolean
+  }[]
 ): void {
   const normalized: SeedWorktree[] = worktrees.map((worktree) => ({
     id: worktree.id,
@@ -57,6 +71,15 @@ function seed(
   mocks.state.worktreesByRepo = byRepo
   // A repo per referenced repoId so getRepoMapFromState resolves (host info comes via worktree.hostId).
   mocks.state.repos = [...new Set(normalized.map((w) => w.repoId))].map((id) => ({ id }))
+  mocks.state.tabsByWorktree = {}
+  mocks.state.ptyIdsByTabId = {}
+  for (const worktree of worktrees) {
+    const tabId = `${worktree.id}-tab`
+    mocks.state.tabsByWorktree[worktree.id] = [{ id: tabId }]
+    if (worktree.asleep !== true) {
+      mocks.state.ptyIdsByTabId[tabId] = [`${tabId}-pty`]
+    }
+  }
 }
 
 // Why: mirror the store reducer — once a delete resolves, the removed worktree
@@ -85,6 +108,10 @@ describe('prepareActiveWorktreeFocusAfterDelete', () => {
     mocks.state.lastVisitedAtByWorktreeId = {}
     mocks.state.deleteStateByWorktreeId = {}
     mocks.state.worktreeMap = new Map()
+    mocks.state.tabsByWorktree = {}
+    mocks.state.ptyIdsByTabId = {}
+    mocks.state.browserTabsByWorktree = {}
+    mocks.state.agentStatusByPaneKey = {}
     vi.mocked(activateAndRevealWorktree).mockClear()
   })
 
@@ -125,6 +152,66 @@ describe('prepareActiveWorktreeFocusAfterDelete', () => {
     commit()
 
     expect(activateAndRevealWorktree).not.toHaveBeenCalled()
+  })
+
+  it('leaves focus empty rather than waking a sleeping sibling', () => {
+    // Activating a slept workspace respawns its PTYs and resumes its agent sessions,
+    // so a delete must never pick one as the successor. #10205
+    seed([
+      { id: 'main', isMainWorktree: true, asleep: true },
+      { id: 'wt-slept', asleep: true },
+      { id: 'wt-del' }
+    ])
+    mocks.state.activeWorktreeId = 'wt-del'
+    mocks.state.lastVisitedAtByWorktreeId = { 'wt-slept': 300 }
+
+    const commit = prepareActiveWorktreeFocusAfterDelete('wt-del')
+    simulateDelete('wt-del', true)
+    commit()
+
+    expect(activateAndRevealWorktree).not.toHaveBeenCalled()
+  })
+
+  it('prefers an awake sibling over a more-recently-visited sleeping one', () => {
+    seed([
+      { id: 'main', isMainWorktree: true },
+      { id: 'wt-awake' },
+      { id: 'wt-slept', asleep: true },
+      { id: 'wt-del' }
+    ])
+    mocks.state.activeWorktreeId = 'wt-del'
+    mocks.state.lastVisitedAtByWorktreeId = { 'wt-awake': 100, 'wt-slept': 300 }
+
+    const commit = prepareActiveWorktreeFocusAfterDelete('wt-del')
+    simulateDelete('wt-del', true)
+    commit()
+
+    expect(activateAndRevealWorktree).toHaveBeenCalledWith('wt-awake')
+  })
+
+  it('keeps a sibling whose agent is live across a PTY gap eligible', () => {
+    // Why: an SSH reconnect drops the live PTY while the agent keeps running (#7197);
+    // that workspace is awake, so focusing it wakes nothing.
+    seed([
+      { id: 'main', isMainWorktree: true, asleep: true },
+      { id: 'wt-agent', asleep: true },
+      { id: 'wt-del' }
+    ])
+    mocks.state.activeWorktreeId = 'wt-del'
+    mocks.state.agentStatusByPaneKey = {
+      pane1: {
+        paneKey: 'pane1',
+        worktreeId: 'wt-agent',
+        state: 'working',
+        updatedAt: Date.now()
+      }
+    }
+
+    const commit = prepareActiveWorktreeFocusAfterDelete('wt-del')
+    simulateDelete('wt-del', true)
+    commit()
+
+    expect(activateAndRevealWorktree).toHaveBeenCalledWith('wt-agent')
   })
 
   it('stays within the deleted worktree project instead of jumping to another project', () => {

--- a/src/renderer/src/components/sidebar/active-worktree-focus-after-delete.ts
+++ b/src/renderer/src/components/sidebar/active-worktree-focus-after-delete.ts
@@ -1,6 +1,7 @@
 import { useAppStore } from '@/store'
 import { getRepoMapFromState, getWorktreeMapFromState } from '@/store/selectors'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
+import { getWorktreeIdsWithLiveAgent, isInactiveWorkspace } from '@/lib/worktree-activity-state'
 import { isRuntimeOwnedSshTargetId, parseExecutionHostId } from '../../../../shared/execution-host'
 import type { Repo } from '../../../../shared/repo-types'
 import type { Worktree } from '../../../../shared/worktree/types'
@@ -39,6 +40,12 @@ function isHostedOnRuntimeOwnedSshTarget(
 // so a delete behaves like closing a tab — prefer another non-base/primary
 // workspace of the same project (most-recently-visited first), and fall back to
 // the project's base/primary workspace when no other workspace remains.
+//
+// Only already-awake siblings qualify: activating a slept workspace respawns its
+// PTYs and resumes its agent sessions, so an unattended delete would otherwise
+// revive a session the user deliberately put to sleep. When every survivor is
+// asleep the selection stays empty, exactly as it does after sleeping the
+// focused workspace. #10205
 function pickNextWorktreeIdAfterDelete(
   state: AppStoreState,
   repoId: string,
@@ -46,12 +53,24 @@ function pickNextWorktreeIdAfterDelete(
 ): string | null {
   const deleteState = state.deleteStateByWorktreeId
   const repoById = getRepoMapFromState(state)
+  const worktreeIdsWithLiveAgent = getWorktreeIdsWithLiveAgent(
+    state.agentStatusByPaneKey,
+    state.tabsByWorktree,
+    Date.now()
+  )
   const siblings = (state.worktreesByRepo[repoId] ?? []).filter(
     (worktree) =>
       worktree.id !== deletedWorktreeId &&
       !getDeleteStateForWorktreeHost(worktree, deleteState)?.isDeleting &&
       // Skip siblings hosted on the now-destroyed runtime-owned SSH target (see helper).
-      !isHostedOnRuntimeOwnedSshTarget(worktree, repoById)
+      !isHostedOnRuntimeOwnedSshTarget(worktree, repoById) &&
+      !isInactiveWorkspace(
+        worktree.id,
+        state.tabsByWorktree,
+        state.ptyIdsByTabId,
+        state.browserTabsByWorktree,
+        worktreeIdsWithLiveAgent
+      )
   )
   const others = siblings.filter((worktree) => !worktree.isMainWorktree)
   if (others.length > 0) {

--- a/src/renderer/src/components/sidebar/active-worktree-focus-after-delete.ts
+++ b/src/renderer/src/components/sidebar/active-worktree-focus-after-delete.ts
@@ -41,11 +41,9 @@ function isHostedOnRuntimeOwnedSshTarget(
 // workspace of the same project (most-recently-visited first), and fall back to
 // the project's base/primary workspace when no other workspace remains.
 //
-// Only already-awake siblings qualify: activating a slept workspace respawns its
-// PTYs and resumes its agent sessions, so an unattended delete would otherwise
-// revive a session the user deliberately put to sleep. When every survivor is
-// asleep the selection stays empty, exactly as it does after sleeping the
-// focused workspace. #10205
+// Only awake siblings qualify: activating a slept workspace respawns its PTYs and
+// resumes its agent sessions. With none awake the selection stays empty, the same
+// state sleeping the focused workspace leaves behind. #10205
 function pickNextWorktreeIdAfterDelete(
   state: AppStoreState,
   repoId: string,


### PR DESCRIPTION
## ELI5

When you delete the workspace you're looking at, Orca moves you to another workspace in the same project so you don't end up staring at nothing. It just wasn't checking whether that other workspace was asleep. So if you'd put everything else to sleep, deleting your last awake workspace would drag a sleeping one back to life — new terminal, agent session resumed, none of it asked for. Now Orca only hands focus to a workspace that's already awake, and if they're all asleep it leaves the selection empty instead of waking one.

## What Changed

`pickNextWorktreeIdAfterDelete` in `src/renderer/src/components/sidebar/active-worktree-focus-after-delete.ts` already excluded siblings that were mid-delete or hosted on a torn-down runtime-owned SSH target. It now also excludes siblings that are asleep, via the existing `isInactiveWorkspace` helper.

That helper is the same predicate the sidebar uses to decide whether a workspace renders as sleeping, so the focus logic and the sleeping indicator can't disagree. A workspace counts as awake if it has a live PTY, a browser tab, **or** a live agent — the last one matters because an SSH reconnect drops the PTY while the agent keeps running (#7197), and treating that as asleep would skip a workspace that's genuinely alive.

When no sibling qualifies, the function returns `null` and focus stays empty. That is not a new UI state: sleeping the focused workspace already leaves `activeWorktreeId` null via `setActiveWorktree(null)` in `sleep-worktree-flow.ts`.

## Why

Steps to reproduce on `main`:

1. Create two or more worktrees in a project.
2. Sleep all of them except one.
3. In the remaining awake worktree, right-click → Delete.
4. A sleeping worktree wakes up and opens a terminal.

`runWorktreeDeleteWithToast` calls `prepareActiveWorktreeFocusAfterDelete`, whose committer runs `activateAndRevealWorktree(nextWorktreeId)` on the chosen successor. That call does two things to a slept workspace:

- `resumeSleepingAgentSessionsForWorktree` (`worktree-activation.ts:339`) relaunches the persisted CLI agent sessions
- `ensureWorktreeHasInitialTerminal` (`worktree-activation.ts:342`) brings the tab back and reconnects its PTY

The picked workspace looks arbitrary to the user because the ranking is `lastVisitedAtByWorktreeId` (most-recently-focused first), and sleeping a workspace does not restamp that value.

Only awake siblings can be safely activated, because activating an awake one is a no-op with respect to process lifecycle — that's the invariant this restores.

## Linked Issue

Refs #10205

Not `Fixes` — #10205 is an umbrella report for "sleeping workspaces revive without user activation" and lists two other triggers (sleeping the focused workspace cascades into another wake; answering an agent question). Those are separate code paths and are untouched here, so this PR should not close it. The delete path is a third trigger that was not in that report, and unlike the other two it reproduces deterministically.

Happy to split a dedicated issue out for this trigger if maintainers prefer one PR ↔ one issue.

## Visual Proof

No before/after capture attached. The change has no static visual difference — the observable delta is a terminal that no longer spontaneously appears, which a screenshot pair can't show honestly. The behavioral difference is covered by the repro steps above and by the tests below.

Before: after step 3, a sleeping worktree becomes selected and its terminal spawns.
After: after step 3, the terminal view is left with nothing selected and every slept worktree stays slept.

## Testing

`src/renderer/src/components/sidebar/active-worktree-focus-after-delete.test.ts` — three tests added, written before the fix and confirmed red against it:

| Test | Before fix |
|---|---|
| `leaves focus empty rather than waking a sleeping sibling` | ❌ activated `wt-slept` (the reported bug) |
| `prefers an awake sibling over a more-recently-visited sleeping one` | ❌ activated `wt-slept` |
| `keeps a sibling whose agent is live across a PTY gap eligible` | guard for the #7197 carve-out |

The third test is a regression guard rather than a red-first test, so I verified it earns its place by mutation: replacing the live-agent set with an empty one makes it fail while the other 14 stay green.

The file's `seed()` helper previously modeled no tabs or PTYs at all, which left every seeded worktree "asleep" under the new predicate. It now seeds a live PTY by default and takes an explicit `asleep: true`. Each pre-existing test keeps its original assertion and subject (MRU ordering, base-worktree fallback, SSH exclusion, focus-stealing guards).

Verification run locally on macOS:

- `pnpm lint` — pass
- `pnpm typecheck` (node + cli + web) — pass
- `pnpm test` — 51,647 passed. Four failures, all unrelated to this change: `src/relay/agent-exec-handler.test.ts` (2) fails identically on a clean `main` with this branch stashed; `src/main/updater.test.ts` and `src/main/runtime/rpc/terminal-output-frame-chunks-equivalence.test.ts` are load-induced timing assertions that pass in isolation.
- Targeted: the sidebar + status-bar suites (2,401 tests) cover five of the six modules that import this one.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

**The manual box is deliberately unchecked.** This was verified through unit tests that encode the reported flow, not by driving the built app. A reviewer running the four repro steps above would be the missing confirmation.

## AI Disclosure

Written with Claude Code (Claude Opus 5). Root cause, fix, and tests were reviewed by the author.

## Review

**Security** — no new I/O, IPC, process spawning, or user input handling. The change only removes candidates from an in-memory selection list, so it can never broaden what gets activated.

**Cross-platform** — pure renderer state logic, no paths, shell strings, keyboard modifiers, or platform branches. Identical on macOS, Linux, and Windows.

**Remote / SSH** — the live-agent term keeps SSH workspaces eligible while a reconnect leaves their PTY gap, which is why `isInactiveWorkspace` was chosen over the narrower `hasSleepableWorkspaceActivity`. The pre-existing runtime-owned-SSH-target exclusion is untouched and still runs first.

**Folder workspaces** — unaffected. This path keys off `worktreesByRepo[repoId]`, and `prepareActiveWorktreeFocusAfterDelete` already resolves `repoId` to `null` for a folder workspace, so it never reaches the picker.

**Backwards compatibility** — no persisted state, schema, or wire format touched. Nothing crosses the client/host boundary.

**Performance** — adds one `getWorktreeIdsWithLiveAgent` pass per delete commit, over the agent-status map. It runs once per delete, not per render; the sidebar already computes the same set every render.

**Failure mode** — if a client's `ptyIdsByTabId` under-reports liveness for a genuinely awake workspace, the result is a skipped auto-focus, not a spurious wake. The change can only ever activate fewer workspaces than before, never more.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test` pass locally (`pnpm build` not run; no build-surface change)
