### PR TITLE
fix(sidebar): name each split-pane agent row from its own pane title (STA-2811)

### DIFF
--- a/src/renderer/src/components/dashboard/agent-row-pane-live-title.test.ts
+++ b/src/renderer/src/components/dashboard/agent-row-pane-live-title.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import type { TerminalLayoutSnapshot } from '../../../../shared/terminal-tab-types'
+import { resolveAgentRowPaneLiveTitle } from './agent-row-pane-live-title'
+
+const LEAF_A = '11111111-1111-4111-8111-111111111111'
+const LEAF_B = '22222222-2222-4222-8222-222222222222'
+const LEAF_C = '33333333-3333-4333-8333-333333333333'
+
+const SPLIT: TerminalLayoutSnapshot = {
+  root: {
+    type: 'split',
+    direction: 'horizontal',
+    first: { type: 'leaf', leafId: LEAF_A },
+    second: { type: 'leaf', leafId: LEAF_B }
+  },
+  activeLeafId: LEAF_A,
+  expandedLeafId: null
+}
+
+describe('resolveAgentRowPaneLiveTitle', () => {
+  it('returns undefined for a single-pane tab, where the tab title is the pane title', () => {
+    const single: TerminalLayoutSnapshot = {
+      root: { type: 'leaf', leafId: LEAF_A },
+      activeLeafId: LEAF_A,
+      expandedLeafId: null
+    }
+    expect(resolveAgentRowPaneLiveTitle(single, { 1: '✳ Redis cache' }, LEAF_A)).toBeUndefined()
+    expect(resolveAgentRowPaneLiveTitle(undefined, { 1: '✳ Redis cache' }, LEAF_A)).toBeUndefined()
+  })
+
+  it('gives each leaf of a split its own runtime pane title', () => {
+    const titles = { 1: '✳ Linear work log', 2: '✳ Redis cache strategy' }
+    expect(resolveAgentRowPaneLiveTitle(SPLIT, titles, LEAF_A)).toBe('✳ Linear work log')
+    expect(resolveAgentRowPaneLiveTitle(SPLIT, titles, LEAF_B)).toBe('✳ Redis cache strategy')
+  })
+
+  it('returns null rather than a sibling title when the pane has no slot', () => {
+    expect(resolveAgentRowPaneLiveTitle(SPLIT, { 1: '✳ Linear work log' }, LEAF_B)).toBeNull()
+    expect(resolveAgentRowPaneLiveTitle(SPLIT, undefined, LEAF_A)).toBeNull()
+    // A leaf that is not in this layout must never inherit a pane title.
+    expect(resolveAgentRowPaneLiveTitle(SPLIT, { 1: 'a', 2: 'b' }, LEAF_C)).toBeNull()
+    // An unparseable paneKey yields no leaf id, which must suppress, not guess.
+    expect(resolveAgentRowPaneLiveTitle(SPLIT, { 1: 'a', 2: 'b' }, undefined)).toBeNull()
+  })
+
+  it('walks replay creation order, not tree order, for a nested split', () => {
+    // Left pane split again: tree order is [A, C, B], creation order is [A, B, C].
+    const nested: TerminalLayoutSnapshot = {
+      root: {
+        type: 'split',
+        direction: 'horizontal',
+        first: {
+          type: 'split',
+          direction: 'vertical',
+          first: { type: 'leaf', leafId: LEAF_A },
+          second: { type: 'leaf', leafId: LEAF_C }
+        },
+        second: { type: 'leaf', leafId: LEAF_B }
+      },
+      activeLeafId: LEAF_A,
+      expandedLeafId: null
+    }
+    const titles = { 1: 'first', 2: 'second', 3: 'third' }
+    expect(resolveAgentRowPaneLiveTitle(nested, titles, LEAF_A)).toBe('first')
+    expect(resolveAgentRowPaneLiveTitle(nested, titles, LEAF_B)).toBe('second')
+    expect(resolveAgentRowPaneLiveTitle(nested, titles, LEAF_C)).toBe('third')
+  })
+})

--- a/src/renderer/src/components/dashboard/agent-row-pane-live-title.ts
+++ b/src/renderer/src/components/dashboard/agent-row-pane-live-title.ts
@@ -1,0 +1,29 @@
+import { resolveRuntimePaneTitleForLeaf } from '@/lib/runtime-pane-title-leaf-id'
+import type { TerminalLayoutSnapshot } from '../../../../shared/terminal-tab-types'
+
+/**
+ * The live terminal title of the pane an agent row belongs to, for tabs holding
+ * more than one pane.
+ *
+ * `undefined` means the tab holds a single pane, so its tab title already IS
+ * that pane's title and the caller should keep using it. `null` means the tab
+ * is split but this pane's own title could not be attributed, so no live title
+ * belongs to the row — showing the tab title there would show a sibling's.
+ *
+ * Cost: a single-pane tab pays one property read and returns, so the common tab
+ * shape is unchanged. A split tab walks only its own pane-title slots against
+ * its own layout tree; no global map is scanned.
+ */
+export function resolveAgentRowPaneLiveTitle(
+  layout: TerminalLayoutSnapshot | undefined,
+  paneTitles: Record<number, string> | undefined,
+  leafId: string | null | undefined
+): string | null | undefined {
+  if (layout?.root?.type !== 'split') {
+    return undefined
+  }
+  if (!leafId) {
+    return null
+  }
+  return resolveRuntimePaneTitleForLeaf(layout, paneTitles, leafId)
+}

--- a/src/renderer/src/components/dashboard/build-dashboard-snapshot.test.ts
+++ b/src/renderer/src/components/dashboard/build-dashboard-snapshot.test.ts
@@ -48,6 +48,7 @@ const LEAF_ID = '11111111-1111-4111-8111-111111111111'
 const CHILD_LEAF_ID = '33333333-3333-4333-8333-333333333333'
 const GRANDCHILD_LEAF_ID = '44444444-4444-4444-8444-444444444444'
 const GONE_LEAF_ID = '22222222-2222-4222-8222-222222222222'
+const SPLIT_SIBLING_LEAF_ID = '55555555-5555-4555-8555-555555555555'
 const PANE_KEY = makePaneKey(TAB_ID, LEAF_ID)
 const CHILD_PANE_KEY = makePaneKey(TAB_ID, CHILD_LEAF_ID)
 const GRANDCHILD_PANE_KEY = makePaneKey(TAB_ID, GRANDCHILD_LEAF_ID)
@@ -334,6 +335,46 @@ describe('buildDashboardSnapshot', () => {
       NOW
     )
     expect(unnamed.cards[0].conversationName).toBeUndefined()
+  })
+
+  // STA-2811: both panes of a split tab carried the focused pane's title.
+  it('names each pane of a split tab from its own title', () => {
+    const siblingPaneKey = makePaneKey(TAB_ID, SPLIT_SIBLING_LEAF_ID)
+    const snapshot = buildDashboardSnapshot(
+      baseState({
+        agentStatusByPaneKey: {
+          [PANE_KEY]: entry({}),
+          [siblingPaneKey]: entry({ paneKey: siblingPaneKey })
+        },
+        // The tab title is whichever pane has focus, so it must not name both.
+        tabsByWorktree: { w1: [{ ...tab(), title: '\u2733 Linear work log' }] },
+        terminalLayoutsByTabId: {
+          [TAB_ID]: {
+            root: {
+              type: 'split',
+              direction: 'horizontal',
+              first: { type: 'leaf', leafId: LEAF_ID },
+              second: { type: 'leaf', leafId: SPLIT_SIBLING_LEAF_ID }
+            },
+            activeLeafId: LEAF_ID,
+            expandedLeafId: null,
+            ptyIdsByLeafId: { [LEAF_ID]: 'pty1', [SPLIT_SIBLING_LEAF_ID]: 'pty2' }
+          }
+        },
+        ptyIdsByTabId: { [TAB_ID]: ['pty1', 'pty2'] },
+        // Pane ids are replay-creation-ordered: 1 -> first leaf, 2 -> second.
+        runtimePaneTitlesByTabId: {
+          [TAB_ID]: { 1: '\u2733 Linear work log', 2: '\u2733 Redis cache strategy' }
+        }
+      }),
+      NOW
+    )
+
+    const nameByPaneKey = new Map(
+      snapshot.cards.map((card) => [card.paneKey, card.conversationName])
+    )
+    expect(nameByPaneKey.get(PANE_KEY)).toBe('Linear work log')
+    expect(nameByPaneKey.get(siblingPaneKey)).toBe('Redis cache strategy')
   })
 
   // Why: `orca terminal rename --title` is unbounded, and the main-process

--- a/src/renderer/src/components/dashboard/build-dashboard-snapshot.ts
+++ b/src/renderer/src/components/dashboard/build-dashboard-snapshot.ts
@@ -4,7 +4,6 @@ import {
   dashboardCardDisplayState,
   type DashboardCard,
   type DashboardCardDotState,
-  type DashboardCardSubagent,
   type DashboardSnapshot,
   type DashboardWorkspace
 } from '../../../../shared/dashboard-snapshot'
@@ -56,6 +55,7 @@ import {
 } from './dashboard-worktree-launch-options'
 import { buildDashboardSnapshotFilterOptions } from './dashboard-snapshot-filter-options'
 import { dashboardBucketForDotState } from './dashboard-card-bucket'
+import { groupSubagentsByParentPaneKey } from './dashboard-subagent-cards'
 
 /** The store slices the snapshot builder reads. Kept as a Pick so unit tests
  *  can pass a partial store without constructing the whole AppState. */
@@ -141,13 +141,14 @@ export function buildDashboardSnapshot(
           ]
         : liveEntries
     const terminalLayoutsByTabId = selectTerminalLayoutsForWorktree(state, worktreeId)
+    const paneTitlesByTabId = selectRuntimePaneTitlesForWorktree(state, worktreeId)
 
     const rows = applyAgentRowLineage(
       buildWorktreeAgentRows({
         tabs: state.tabsByWorktree[worktreeId] ?? [],
         entries,
         retained: selectRetainedAgentEntriesForWorktree(state, worktreeId),
-        runtimePaneTitlesByTabId: selectRuntimePaneTitlesForWorktree(state, worktreeId),
+        runtimePaneTitlesByTabId: paneTitlesByTabId,
         ptyIdsByTabId: selectLivePtyIdsForWorktree(state, worktreeId),
         terminalLayoutsByTabId,
         runtimeAgentOrchestrationByPaneKey:
@@ -158,33 +159,8 @@ export function buildDashboardSnapshot(
       })
     )
     const subagentsByParentPaneKey = includeCardDetails
-      ? new Map<string, DashboardCardSubagent[]>()
+      ? groupSubagentsByParentPaneKey(rows)
       : undefined
-    if (subagentsByParentPaneKey) {
-      for (const row of rows) {
-        if (row.rowSource !== 'subagent') {
-          continue
-        }
-        const parentPaneKey = row.entry.orchestration?.parentPaneKey
-        if (!parentPaneKey) {
-          continue
-        }
-        const subagent: DashboardCardSubagent = {
-          id: row.paneKey,
-          name:
-            nonEmpty(row.entry.orchestration?.displayName) ??
-            nonEmpty(row.entry.prompt) ??
-            row.agentType,
-          dotState: row.state
-        }
-        const existing = subagentsByParentPaneKey.get(parentPaneKey)
-        if (existing) {
-          existing.push(subagent)
-        } else {
-          subagentsByParentPaneKey.set(parentPaneKey, [subagent])
-        }
-      }
-    }
     const context = includeCardDetails
       ? resolveDashboardCardContext(state, repo, worktree)
       : undefined
@@ -303,7 +279,14 @@ export function buildDashboardSnapshot(
         // board and the sidebar bold/mute the same agents at the same time.
         unseen,
         askSummary: bucket === 'attention' ? (row.entry.interactivePrompt ?? undefined) : undefined,
-        conversationName: boundedLabelOrUndefined(rowConversationName(row, generatedTitlesEnabled)),
+        conversationName: boundedLabelOrUndefined(
+          rowConversationName(
+            row,
+            generatedTitlesEnabled,
+            terminalLayoutsByTabId[row.tab.id],
+            paneTitlesByTabId[row.tab.id]
+          )
+        ),
         ...(terminalInput ? { terminalInput } : {})
       })
     }

--- a/src/renderer/src/components/dashboard/dashboard-card-labels.ts
+++ b/src/renderer/src/components/dashboard/dashboard-card-labels.ts
@@ -1,6 +1,8 @@
 import { getAgentRowConversationName } from '../../../../shared/agent-row-conversation-name'
 import { DASHBOARD_MAX_LABEL_LENGTH } from '../../../../shared/dashboard-snapshot'
 import { parsePaneKey } from '../../../../shared/stable-pane-id'
+import type { TerminalLayoutSnapshot } from '../../../../shared/terminal-tab-types'
+import { resolveAgentRowPaneLiveTitle } from './agent-row-pane-live-title'
 import type { DashboardAgentRow } from './useDashboardData'
 
 export function rowTask(row: DashboardAgentRow): string {
@@ -28,7 +30,9 @@ export function boundedLabelOrUndefined(value: string | undefined): string | und
  *  same agent with the same name. */
 export function rowConversationName(
   row: DashboardAgentRow,
-  generatedTitlesEnabled: boolean
+  generatedTitlesEnabled: boolean,
+  layout: TerminalLayoutSnapshot | undefined,
+  paneTitles: Record<number, string> | undefined
 ): string | undefined {
   const parentPaneKey = row.entry.orchestration?.parentPaneKey
   // Why: a child row rendered on its parent's tab does not own that tab's name.
@@ -39,5 +43,13 @@ export function rowConversationName(
   ) {
     return undefined
   }
-  return getAgentRowConversationName(row.tab, row.agentType, generatedTitlesEnabled) ?? undefined
+  const paneLiveTitle = resolveAgentRowPaneLiveTitle(
+    layout,
+    paneTitles,
+    parsePaneKey(row.paneKey)?.leafId
+  )
+  return (
+    getAgentRowConversationName(row.tab, row.agentType, generatedTitlesEnabled, paneLiveTitle) ??
+    undefined
+  )
 }

--- a/src/renderer/src/components/dashboard/dashboard-subagent-cards.ts
+++ b/src/renderer/src/components/dashboard/dashboard-subagent-cards.ts
@@ -1,0 +1,35 @@
+import type { DashboardCardSubagent } from '../../../../shared/dashboard-snapshot'
+import { nonEmpty } from './dashboard-card-labels'
+import type { DashboardAgentRow } from './useDashboardData'
+
+/** Subagent child rows, grouped under the parent pane whose session spawned
+ *  them — they have no pane of their own, so the board nests them on the card. */
+export function groupSubagentsByParentPaneKey(
+  rows: readonly DashboardAgentRow[]
+): Map<string, DashboardCardSubagent[]> {
+  const byParentPaneKey = new Map<string, DashboardCardSubagent[]>()
+  for (const row of rows) {
+    if (row.rowSource !== 'subagent') {
+      continue
+    }
+    const parentPaneKey = row.entry.orchestration?.parentPaneKey
+    if (!parentPaneKey) {
+      continue
+    }
+    const subagent: DashboardCardSubagent = {
+      id: row.paneKey,
+      name:
+        nonEmpty(row.entry.orchestration?.displayName) ??
+        nonEmpty(row.entry.prompt) ??
+        row.agentType,
+      dotState: row.state
+    }
+    const existing = byParentPaneKey.get(parentPaneKey)
+    if (existing) {
+      existing.push(subagent)
+    } else {
+      byParentPaneKey.set(parentPaneKey, [subagent])
+    }
+  }
+  return byParentPaneKey
+}

--- a/src/renderer/src/components/dashboard/use-agent-row-conversation-name.test.ts
+++ b/src/renderer/src/components/dashboard/use-agent-row-conversation-name.test.ts
@@ -7,14 +7,21 @@ const storeState = vi.hoisted(() => ({
   current: { settings: {}, tabsByWorktree: {} } as {
     settings: Record<string, unknown>
     tabsByWorktree: Record<string, unknown[]>
+    terminalLayoutsByTabId?: Record<string, unknown>
+    runtimePaneTitlesByTabId?: Record<string, unknown>
   }
 }))
 
 // Why: the mocked selector makes the hook a pure function, so tests can call it
-// directly without mounting a component.
+// directly without mounting a component. The pane maps default to empty so each
+// test declares only the ones it exercises.
 vi.mock('@/store', () => ({
   useAppStore: (selector: (state: AppState) => unknown) =>
-    selector(storeState.current as unknown as AppState)
+    selector({
+      terminalLayoutsByTabId: {},
+      runtimePaneTitlesByTabId: {},
+      ...storeState.current
+    } as unknown as AppState)
 }))
 
 function makeAgent(overrides: Partial<DashboardAgentRow> = {}): DashboardAgentRow {
@@ -139,6 +146,110 @@ describe('useAgentRowConversationName', () => {
       }
     }
     expect(useAgentRowConversationName(makeAgent())).toBe('Renamed later')
+  })
+
+  // STA-2811 / #11069: both panes of a split tab showed one name that flipped to
+  // whichever pane was clicked last, because tab.title tracks only the focused pane.
+  describe('split panes', () => {
+    const LEAF_A = '11111111-1111-4111-8111-111111111111'
+    const LEAF_B = '22222222-2222-4222-8222-222222222222'
+    const SPLIT_LAYOUT = {
+      root: {
+        type: 'split',
+        direction: 'horizontal',
+        first: { type: 'leaf', leafId: LEAF_A },
+        second: { type: 'leaf', leafId: LEAF_B }
+      },
+      activeLeafId: LEAF_A,
+      expandedLeafId: null
+    }
+
+    // Why: pty-connection syncs the FOCUSED pane's title onto the tab, so the tab
+    // snapshot every row carries names one pane and mislabels the other.
+    function splitRow(leafId: string, focusedPaneTitle: string): DashboardAgentRow {
+      return makeAgent({
+        paneKey: `tab-1:${leafId}`,
+        tab: { id: 'tab-1', worktreeId: 'wt-1', customTitle: null, title: focusedPaneTitle }
+      } as Partial<DashboardAgentRow>)
+    }
+
+    function setSplitStore(focusedPaneTitle: string, customTitle: string | null = null): void {
+      storeState.current = {
+        settings: {},
+        tabsByWorktree: {
+          'wt-1': [{ id: 'tab-1', worktreeId: 'wt-1', customTitle, title: focusedPaneTitle }]
+        },
+        terminalLayoutsByTabId: { 'tab-1': SPLIT_LAYOUT },
+        // Pane ids are replay-creation-ordered: 1 -> LEAF_A, 2 -> LEAF_B.
+        runtimePaneTitlesByTabId: {
+          'tab-1': { 1: '\u2733 Linear work log', 2: '\u2733 Redis cache strategy' }
+        }
+      }
+    }
+
+    it('gives each pane in one tab its own name', () => {
+      setSplitStore('\u2733 Linear work log')
+      expect(useAgentRowConversationName(splitRow(LEAF_A, '\u2733 Linear work log'))).toBe(
+        'Linear work log'
+      )
+      expect(useAgentRowConversationName(splitRow(LEAF_B, '\u2733 Linear work log'))).toBe(
+        'Redis cache strategy'
+      )
+    })
+
+    it('does not rename the sibling row when the other pane is clicked', () => {
+      // Clicking pane B re-syncs the tab title to B's; both rows must be unmoved.
+      setSplitStore('\u2733 Redis cache strategy')
+      expect(useAgentRowConversationName(splitRow(LEAF_A, '\u2733 Redis cache strategy'))).toBe(
+        'Linear work log'
+      )
+      expect(useAgentRowConversationName(splitRow(LEAF_B, '\u2733 Redis cache strategy'))).toBe(
+        'Redis cache strategy'
+      )
+    })
+
+    it('lends no name to a split pane with no live title of its own', () => {
+      // Why: the tab title here is the SIBLING's, so the row keeps its own label.
+      storeState.current = {
+        settings: {},
+        tabsByWorktree: {
+          'wt-1': [
+            { id: 'tab-1', worktreeId: 'wt-1', customTitle: null, title: '\u2733 Linear work log' }
+          ]
+        },
+        terminalLayoutsByTabId: { 'tab-1': SPLIT_LAYOUT },
+        runtimePaneTitlesByTabId: { 'tab-1': { 1: '\u2733 Linear work log' } }
+      }
+      expect(useAgentRowConversationName(splitRow(LEAF_B, '\u2733 Linear work log'))).toBeNull()
+    })
+
+    it('still lends a tab-owned name to every pane', () => {
+      setSplitStore('\u2733 Linear work log', 'Patient sync spike')
+      expect(useAgentRowConversationName(splitRow(LEAF_A, '\u2733 Linear work log'))).toBe(
+        'Patient sync spike'
+      )
+      expect(useAgentRowConversationName(splitRow(LEAF_B, '\u2733 Linear work log'))).toBe(
+        'Patient sync spike'
+      )
+    })
+
+    it('leaves a single-leaf tab on its tab title', () => {
+      storeState.current = {
+        settings: {},
+        tabsByWorktree: {
+          'wt-1': [
+            { id: 'tab-1', worktreeId: 'wt-1', customTitle: null, title: '\u2733 Redis cache' }
+          ]
+        },
+        terminalLayoutsByTabId: {
+          'tab-1': { root: { type: 'leaf', leafId: LEAF_A }, activeLeafId: LEAF_A }
+        },
+        runtimePaneTitlesByTabId: {}
+      }
+      expect(useAgentRowConversationName(splitRow(LEAF_A, '\u2733 Redis cache'))).toBe(
+        'Redis cache'
+      )
+    })
   })
 
   it('honors the generated-titles setting for generated names', () => {

--- a/src/renderer/src/components/dashboard/use-agent-row-conversation-name.ts
+++ b/src/renderer/src/components/dashboard/use-agent-row-conversation-name.ts
@@ -1,5 +1,6 @@
 import { getAgentRowConversationName } from '../../../../shared/agent-row-conversation-name'
 import { parsePaneKey } from '../../../../shared/stable-pane-id'
+import { resolveAgentRowPaneLiveTitle } from './agent-row-pane-live-title'
 import { useAppStore } from '@/store'
 import type { AppState } from '@/store/types'
 import type { DashboardAgentRow } from './useDashboardData'
@@ -39,10 +40,30 @@ export function useAgentRowConversationName(agent: DashboardAgentRow): string | 
       ? undefined
       : getIndexedTab(s.tabsByWorktree[agent.tab.worktreeId], agent.tab.id)
   )
+  // Why: parsed per render rather than inside the selector, which runs on every
+  // store update and must stay allocation-free.
+  const ownLeafId = cannotOwnTabName ? null : parsePaneKey(agent.paneKey)?.leafId
+  // Why: in a split tab the tab title belongs to whichever pane has focus, so
+  // this row reads its OWN pane's title. Returns a primitive, so a row
+  // re-renders only when its own pane's title changes.
+  const paneLiveTitle = useAppStore((s) =>
+    cannotOwnTabName
+      ? undefined
+      : resolveAgentRowPaneLiveTitle(
+          s.terminalLayoutsByTabId?.[agent.tab.id],
+          s.runtimePaneTitlesByTabId?.[agent.tab.id],
+          ownLeafId
+        )
+  )
   // Why: synthetic and same-tab child rows do not own the parent tab's name.
   if (cannotOwnTabName) {
     return null
   }
   // Why: retained row snapshots need a fallback after their live tab disappears.
-  return getAgentRowConversationName(liveTab ?? agent.tab, agent.agentType, generatedTitlesEnabled)
+  return getAgentRowConversationName(
+    liveTab ?? agent.tab,
+    agent.agentType,
+    generatedTitlesEnabled,
+    paneLiveTitle
+  )
 }

--- a/src/shared/agent-row-conversation-name.test.ts
+++ b/src/shared/agent-row-conversation-name.test.ts
@@ -37,6 +37,34 @@ describe('getAgentRowConversationName', () => {
     expect(getAgentRowConversationName(tab, 'claude', false)).toBe('Investigate replay bug')
   })
 
+  it('names a split pane from its own live title, not the tab title', () => {
+    // Why: the tab title is the FOCUSED pane's, so the sibling must not read it.
+    const tab = makeTab({ title: '\u2733 Linear work log' })
+    expect(getAgentRowConversationName(tab, 'claude', false, '\u2733 Redis cache strategy')).toBe(
+      'Redis cache strategy'
+    )
+    // OpenCode's semantic title is a live title too, so it follows the pane.
+    expect(
+      getAgentRowConversationName(tab, 'opencode', false, 'OC | build the release pipeline')
+    ).toBe('OC | build the release pipeline')
+    // No resolvable pane title: no live title at all, never the sibling's.
+    expect(getAgentRowConversationName(tab, 'claude', false, null)).toBeNull()
+    // A single-pane tab passes undefined and is untouched.
+    expect(getAgentRowConversationName(tab, 'claude', false)).toBe('Linear work log')
+  })
+
+  it('keeps tab-owned names above the pane title', () => {
+    // Why: the user gave these to the whole tab, and none of them flip on focus.
+    const custom = makeTab({ customTitle: 'Patient sync spike' })
+    expect(getAgentRowConversationName(custom, 'claude', false, 'Redis cache strategy')).toBe(
+      'Patient sync spike'
+    )
+    const quick = makeTab({ quickCommandLabel: 'Run tests' })
+    expect(getAgentRowConversationName(quick, 'claude', false, null)).toBe('Run tests')
+    const generated = makeTab({ generatedTitle: 'Fix intake flow' })
+    expect(getAgentRowConversationName(generated, 'claude', true, null)).toBe('Fix intake flow')
+  })
+
   it('strips leading status decoration from agent-set titles', () => {
     expect(
       getAgentRowConversationName(makeTab({ title: '✳ Fix patient intake flow' }), 'claude', false)

--- a/src/shared/agent-row-conversation-name.ts
+++ b/src/shared/agent-row-conversation-name.ts
@@ -113,7 +113,13 @@ function conversationNameFromLiveTitle(
 export function getAgentRowConversationName(
   tab: ConversationNameTab,
   agentType: AgentType | null | undefined,
-  generatedTitlesEnabled: boolean
+  generatedTitlesEnabled: boolean,
+  // Why: `tab.title` carries only the FOCUSED pane's title, so in a split tab it
+  // names one pane and mislabels its siblings. Callers on a multi-pane tab pass
+  // this row's own pane title, or `null` when none resolves; `undefined` (a
+  // single-pane tab) keeps the tab title. Tab-owned names above are unaffected:
+  // the user gave those to the whole tab and they do not flip on focus.
+  paneLiveTitle?: string | null
 ): string | null {
   const customTitle = tab.customTitle?.trim()
   if (customTitle) {
@@ -123,7 +129,8 @@ export function getAgentRowConversationName(
   if (quickCommandLabel) {
     return quickCommandLabel
   }
-  const liveTitle = tab.title?.trim() ?? ''
+  const liveTitle =
+    paneLiveTitle === undefined ? (tab.title?.trim() ?? '') : (paneLiveTitle?.trim() ?? '')
   if (isMeaningfulOpenCodeTerminalTitle(liveTitle)) {
     return liveTitle
   }


### PR DESCRIPTION
## ELI5

Split a terminal tab in two, run an agent in each pane, and the sidebar shows two rows — but both rows carried the **same** name, and that name changed to whichever pane you clicked last. The name came from the *tab's* title, and a tab only ever holds the **focused** pane's title.

Each row now reads its **own** pane's title.

## What Changed

`getAgentRowConversationName` gains an optional `paneLiveTitle`. Its `undefined` default is today's behavior, so a single-pane tab is untouched.

Both callers — the sidebar/dashboard hook `useAgentRowConversationName` and its pop-out-board mirror `rowConversationName` — now resolve it through one shared helper:

```ts
// agent-row-pane-live-title.ts
if (layout?.root?.type !== 'split') return undefined      // tab title IS the pane title
if (!leafId) return null
return resolveRuntimePaneTitleForLeaf(layout, paneTitles, leafId)
```

Three outcomes, and the middle one is the point:

| Tab shape | `paneLiveTitle` | Row shows |
| --- | --- | --- |
| one pane | `undefined` | the tab title — **unchanged** |
| split, this pane's title resolves | that pane's title | **its own name** |
| split, no title for this leaf | `null` | no live title, so the row keeps its own per-pane label — never a sibling's name |

**Tab-owned names still apply to every row in the tab.** `customTitle`, `quickCommandLabel` and `generatedTitle` short-circuit above `liveTitle`; the user gave those to the whole tab and none of them flip on focus. Only the live title is pane-specific by nature, and only it is redirected. Pinned by a test.

`resolveRuntimePaneTitleForLeaf` is the repo's existing leaf-keyed live-title resolver (`runtime-pane-title-leaf-id.ts`, since #7043), already used by `running-agent-targets.ts`, `notes-send-agent-targets.ts` and `active-agent-note-target.ts`. This PR adds no resolver; it stops the naming path from being the one place that reads a tab-scoped title for a pane-scoped row.

### Incidental: one extraction

`build-dashboard-snapshot.ts` sat at **exactly** the 300-line `max-lines` cap, so any addition trips lint and `max-lines` disables are forbidden. The self-contained subagent-grouping loop moved verbatim to `dashboard-subagent-cards.ts` (`groupSubagentsByParentPaneKey`). No behavior change; the file's existing tests cover it.

## Why

PR #14702 (STA-3264, the jointly-Running sibling of this bug) located this one precisely and deliberately left it open rather than bundling:

> `getAgentRowConversationName` reads `tab.title`, which carries only the FOCUSED pane title.

That is the whole mechanism, and it is a **different** root cause from what #14702 fixed. #14702 corrected runtime-pane-title → leaf *attribution* inside `buildTitleDerivedAgentRows`. This is the *naming* path: everything upstream of it is already pane-scoped (`agentStatusByPaneKey`, `selectLiveAgentStatusEntriesForWorktree`, and the row `paneKey` itself are all `tabId:leafId`), and then the last step reaches for a tab-scoped field.

`pty-connection.ts` keeps `tab.title` on the focused pane on purpose — so two agents in a split don't make the tab title flicker — and `use-terminal-pane-lifecycle.ts` re-syncs it on every focus change. That is exactly the "flips to whichever pane was clicked last" in the title of #11069.

Introduced by #9989, whose design note reads *"row identity consistently follows tab identity"*. Split panes are the case where one tab holds several independent sessions.

### Supersedes #11070 (@pythonstrup)

**#11070's diagnosis is correct and this PR keeps it**, including the call that tab-owned names must survive in a split. It is superseded on the remedy, not the analysis.

#11070 suppresses the live title in a split (`tabHasSplitPanes ? '' : tab.title`) and lets every split row fall back to its per-pane label. That stops the flip, but it also states as a known limit:

> Orca has no per-pane live title the sidebar can read: the only live per-pane map (`runtimePaneTitlesByTabId`) is keyed by ephemeral numeric pane ids, while rows are keyed by `tabId:leafId`. Giving split rows real titles means adding a leaf-keyed live-title channel.

**That channel already exists.** `resolveRuntimePaneTitleForLeaf(layout, paneTitles, leafId)` bridges exactly those two id spaces and has since #7043. So the infrastructure #11070 deferred to a follow-up is a one-line call, and its second known limit — *"hook-less split agents now fall back to their agent label... both read as duplicates"* — does not have to ship. Under #11070 two Codex panes in a split both read `Codex`; here they read their own titles.

`null` (no title resolvable for this leaf) reproduces #11070's behavior exactly, so its safe case is this PR's fallback, not its ceiling.

### Constraints from the surrounding cluster, checked

- **#14650's split guard is untouched.** `resolveTitleDerivedPaneOwner` returns an owner only for a single-leaf layout — because `launchAgent` is tab-scoped and a split pane must not brand its sibling. This PR does not touch `worktree-title-derived-agent-rows.ts` or any owner resolution.
- **STA-3354 (per-render global status-map scans) is not multiplied.** The added selector returns a **string primitive**, so it cannot churn on identity and does not subscribe rows to title frames. Its cost per store update is:
  - **single-pane tab (the common shape): one property read** (`layout?.root?.type`) and return. No map scan, no allocation, no tree walk.
  - **split tab:** iterate that tab's own pane-title slots (2–3), each resolving against that tab's own layout tree (O(leaves)) — ~4 node visits for a two-way split.

  It never touches the global status map, so it adds nothing to the scan STA-3354 is about. `parsePaneKey` runs once per render (not per store update), matching the `parsePaneKey(parentPaneKey)` already in the hook. The pop-out builder reuses the worktree-scoped maps already in scope and hoists one selector call that was previously made inline.

## Linked Issue

Fixes #11069

Supersedes #11070.

Not superseded, all distinct root causes in the same cluster: #14702 (STA-3264, pane-title → leaf attribution), #14650 (#14464, owner fallback for title-less panes), #14615 (STA-2069, hook status → spawn pane).

## Visual Proof

Captured live on one Orca dev instance (isolated `ORCA_DEV_USER_DATA_PATH`, CDP + Playwright). **Before** and **after** are the *same running pane*: the fix was reverted in place, Vite HMR flipped the live sidebar, then it was restored — so nothing here is a rebuild or a different session.

Two Claude panes in one split tab: the left pane's title is `✳ Linear work log`, the right pane's is `✳ Redis cache strategy`.

**BEFORE — focus on the left pane.** Both rows read the left pane's name:

![before-focus-a.png](https://github.com/user-attachments/assets/d2adf82d-08f1-4482-aacb-cb18de61adea)

**BEFORE — click the right pane.** Both rows rename together. This is the reported symptom:

![before-focus-b.png](https://github.com/user-attachments/assets/39b8d68c-ff76-4677-9baf-293c918f41cd)

**AFTER — same panes.** Each row carries its own name:

![after.png](https://github.com/user-attachments/assets/6fa6c40e-a0ac-4395-b67e-b6bbeae7eef6)

**AFTER — click the right pane.** Nothing renames; the rows are unmoved:

![after-focus-b.png](https://github.com/user-attachments/assets/a8ceac8d-f46c-4571-9693-cb6e171e0ff3)

No layout, spacing, color, typography, or component change — `docs/STYLEGUIDE.md` is not engaged. The only difference is which text an already-existing row resolves.

## Testing

Scoped checks only — a full `pnpm typecheck` OOMs on this host, so it was run against a project narrowed to the touched modules and their transitive graph (clean; it caught one real error in a new fixture, a missing `expandedLeafId`, which is fixed).

- [x] `oxlint` on every changed file — clean. The gate is proven live, not silent: it **rejected** the first version of this change with `max-lines` on `build-dashboard-snapshot.ts`, which is what forced the extraction above.
- [x] `oxlint --config config/oxlint-react-doctor.json` (pre-commit) — clean, and it does see the new `useAppStore` selector.
- [x] Scoped `tsc --noEmit` over the touched modules + their consumers (`worktree-card-compact-agent-row.tsx`, `DashboardAgentRow.tsx`) — clean.
- [x] `vitest`: dashboard + dashboard-popout + sidebar + shared resolver — **297 files / 2661 tests pass**.
- [x] Added tests, each proven non-vacuous by reverting the fix (see below).
- [x] Manual: reproduced and verified live on an isolated macOS dev instance via CDP — see Visual Proof.

**Tests added — and proven to fail without the fix.** The fix was reverted in place (`liveTitle` back to `tab.title`) and the suite re-run; these four failed and then passed again on restore:

| Test | File |
| --- | --- |
| names a split pane from its own live title, not the tab title | `src/shared/agent-row-conversation-name.test.ts` |
| gives each pane in one tab its own name | `use-agent-row-conversation-name.test.ts` |
| does not rename the sibling row when the other pane is clicked | `use-agent-row-conversation-name.test.ts` |
| lends no name to a split pane with no live title of its own | `use-agent-row-conversation-name.test.ts` |

The board half is pinned separately: dropping the `paneLiveTitle` argument in `dashboard-card-labels.ts` fails `names each pane of a split tab from its own title` in `build-dashboard-snapshot.test.ts` — so the sidebar and the pop-out board cannot silently drift apart.

Tests that must keep passing under that revert, and do — they pin *unchanged* behavior: `leaves a single-leaf tab on its tab title`, `still lends a tab-owned name to every pane`, `keeps tab-owned names above the pane title`.

`agent-row-pane-live-title.test.ts` additionally covers a nested split, where replay creation order `[A, B, C]` differs from tree order `[A, C, B]` — the case where any positional shortcut would silently hand a pane its sibling's title.

**Merge compatibility — verified by materializing and running, not by GitHub's flags** (which were stale elsewhere in this sweep):

| Against | `git merge-tree` | Merged tree tested |
| --- | --- | --- |
| #14682 (compact-row secondary dwell) | clean | ✅ 24 files / 188 tests pass |
| #14702 (pane-title → leaf attribution) | clean | ✅ 258 files / 2327 tests pass |
| #14654 (agent-row ordering) | clean | no file overlap |
| #14486 (119-file sidebar reorg) | clean | no file overlap; does not move any file touched here |
| #11070 | conflicts (expected — superseded) | — |

Platforms: macOS (this host). The change is a string and a tree walk — no shortcuts, accelerators, modifier keys, path construction, shell invocation, or Electron platform APIs — so there is nothing platform-dependent to diverge.

## Review

- **Security** — no new string reaches the UI; one existing source is *redirected to a narrower one*. No command execution, path handling, auth, secrets, IPC channel, dependency, persisted state, or schema change.
- **Cross-platform** — no platform branching (see above). The resolver's existing Windows/UNC path-rejection cases pass unchanged.
- **Remote SSH / folder workspaces** — the layout root and the runtime pane-title map are identical on local, remote-server and SSH hosts, and for folder workspaces as well as git worktrees. No Git commands, no local-only assumptions. Hook-less agents over SSH — the ones that depend on title-derived rows — are the biggest beneficiaries, since their split rows previously read as duplicates.
- **Remote wire compatibility** — none engaged. Nothing crosses the client/host wire: no RPC params, no stream opcodes. The pop-out board snapshot's `conversationName` field is unchanged in shape and bound (`boundedLabelOrUndefined` still applies); only which per-pane string fills it changes, and it was already an optional field.
- **Mobile** — `mobile/` does not import this resolver (grepped).
- **Backwards compatibility** — the new parameter is optional and defaults to today's behavior, so any future caller is correct by default. `root: null` (a snapshot taken mid-teardown) reads as not-split and reverts to the status quo — degraded to today's behavior, never a new wrong name.
- **Performance** — stated with numbers under "Constraints from the surrounding cluster" above.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots attached (same live pane, HMR before/after)
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] Scoped lint / typecheck / tests pass locally; full `typecheck` and `build` left to CI (OOM on this host)

## Author

- X / Twitter: @BrennanKB5
