### PR TITLE
fix(sidebar): retire the unpublished-title fallback that minted an agent row and both dots (STA-2926)

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeCard.test.ts
@@ -44,16 +44,21 @@ describe('getWorktreeStatus', () => {
     // populated live-pty map so this assertion exercises the live-tab branch.
     // Titles are real classifiable shapes: getWorktreeStatus reads the shared
     // classifier through pane-agent-evidence, which this file does not mock.
+    // Why (STA-2926): the dot reads runtime pane titles, so publish each title on a pane rather
+    // than relying on the tab title, which no longer feeds the heuristic on its own.
     const livePtyIds = { 'tab-1': ['pty-1'] }
     expect(
       getWorktreeStatus(
         [makeTerminalTab('Claude - action required')],
         [{ id: 'browser-1' }],
-        livePtyIds
+        livePtyIds,
+        { 'tab-1': { 0: 'Claude - action required' } }
       )
     ).toBe('permission')
     expect(
-      getWorktreeStatus([makeTerminalTab('mimo working')], [{ id: 'browser-1' }], livePtyIds)
+      getWorktreeStatus([makeTerminalTab('mimo working')], [{ id: 'browser-1' }], livePtyIds, {
+        'tab-1': { 0: 'mimo working' }
+      })
     ).toBe('working')
   })
 })

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -7,6 +7,7 @@ import { buildWorktreeAgentRows } from './worktree-agent-rows'
 
 const LEAF_ID_1 = '77777777-7777-4777-8777-777777777777'
 const LEAF_ID_2 = '88888888-8888-4888-8888-888888888888'
+const LEAF_ID_3 = '99999999-9999-4999-8999-999999999999'
 
 function makeTab(id: string, overrides: Partial<TerminalTab> = {}): TerminalTab {
   return {
@@ -380,5 +381,82 @@ describe('buildTitleDerivedAgentRows', () => {
     })
 
     expect(rows).toHaveLength(0)
+  })
+})
+
+// STA-2926 / #11372. Closing a split pane clears that pane's runtime title slot, but nothing
+// clears `tab.title` — `resolveTabTitleAfterPaneClose` asks for a reset and
+// `getFallbackTabTitle` hands the current (stale) title straight back whenever the tab has no
+// customTitle/quickCommandLabel/defaultTitle. The tab title is a tab-scoped mirror of the
+// focused pane, so it carries no pane provenance and must never mint a pane row.
+describe('buildTitleDerivedAgentRows — closed split pane', () => {
+  it('does not recycle a closed pane row onto the sibling or a replacement session', () => {
+    // The agent pane closed; `survivingLeafId` is the leaf the sidebar would attribute the
+    // orphaned tab title to — the promoted sibling, or a pane opened after the close.
+    for (const survivingLeafId of [LEAF_ID_1, LEAF_ID_3]) {
+      const rows = buildWorktreeAgentRows({
+        tabs: [makeTab('tab-1', { title: '✳ Claude Code' })],
+        entries: [],
+        retained: [],
+        // Emptied by clearRuntimePaneTitle on the closed pane's PTY exit.
+        runtimePaneTitlesByTabId: {},
+        ptyIdsByTabId: { 'tab-1': ['pty-survivor'] },
+        terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(survivingLeafId) },
+        now: 2000
+      })
+
+      expect(rows).toHaveLength(0)
+    }
+  })
+
+  // Pre-fix these minted codex/working, codex/idle and gemini/idle respectively — the last one
+  // an agent the tab never launched, taken purely from the dead pane's leftover title.
+  it('does not synthesize a row from a stale spinner or identity tab title', () => {
+    for (const title of ['⠋ Codex', '✳ refactor the resolver', '⏸ Gemini CLI']) {
+      const rows = buildWorktreeAgentRows({
+        tabs: [makeTab('tab-1', { title, launchAgent: 'codex' })],
+        entries: [],
+        retained: [],
+        runtimePaneTitlesByTabId: {},
+        ptyIdsByTabId: { 'tab-1': ['pty-survivor'] },
+        terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+        now: 2000
+      })
+
+      expect(rows).toHaveLength(0)
+    }
+  })
+
+  it('keeps the surviving pane on its own identity rather than the closed pane title', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { title: '✳ Claude Code' })],
+      entries: [],
+      retained: [],
+      // The survivor publishes; the closed pane's slot is gone.
+      runtimePaneTitlesByTabId: { 'tab-1': { 2: '⠋ Codex' } },
+      ptyIdsByTabId: { 'tab-1': ['pty-survivor'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_2) },
+      now: 2000
+    })
+
+    expect(rows.map((row) => [row.paneKey, row.agentType, row.state])).toEqual([
+      [makePaneKey('tab-1', LEAF_ID_2), 'codex', 'working']
+    ])
+  })
+
+  it('still rows a live pane that publishes its own runtime title', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { title: '⠋ Codex', launchAgent: 'codex' })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: { 'tab-1': { 1: '⠋ Codex' } },
+      ptyIdsByTabId: { 'tab-1': ['pty-codex'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(rows.map((row) => [row.paneKey, row.agentType, row.state])).toEqual([
+      [makePaneKey('tab-1', LEAF_ID_1), 'codex', 'working']
+    ])
   })
 })

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -71,58 +71,45 @@ export function buildTitleDerivedAgentRows(args: {
         ? Object.entries(paneTitles).sort(([a], [b]) => Number(a) - Number(b))
         : []
 
-    if (paneTitleEntries.length > 0) {
-      for (const [paneId, title] of paneTitleEntries) {
-        const leafId = resolveLeafIdForTitleFallback({
-          layout,
-          paneTitleEntries,
-          paneId: Number(paneId),
-          title
-        })
-        if (!leafId) {
-          continue
-        }
-        const row = buildTitleDerivedAgentRow({
-          tab,
-          leafId,
-          title,
-          ownerAgentType: resolveTitleDerivedPaneOwner(tab, layout, leafId),
-          now: args.now,
-          runtimeAgentOrchestrationByPaneKey: args.runtimeAgentOrchestrationByPaneKey
-        })
-        if (!row || args.seenPaneKeys.has(row.paneKey)) {
-          continue
-        }
-        rows.push(row)
-        args.seenPaneKeys.add(row.paneKey)
+    // Why (STA-2926, #11372): runtimePaneTitles is the only pane-scoped title channel — it is
+    // written per OSC frame and cleared the moment a pane's PTY exits or its pane closes. A tab
+    // with none of them has no pane publishing a title, so there is nothing here to row. The
+    // former `tab.title` fallback recycled a dead pane's row onto whichever leaf survived: the
+    // tab title is a tab-scoped mirror of the *focused* pane and carries no pane provenance, so
+    // once its pane closed it could not be attributed to any leaf — it was evidence of nothing.
+    // Symmetrical with #14650's `isShellProcess` guard, which refuses to resurrect a row from a
+    // title that is positive evidence the agent exited.
+    for (const [paneId, title] of paneTitleEntries) {
+      const leafId = resolveLeafIdForTitleFallback({
+        layout,
+        paneTitleEntries,
+        paneId: Number(paneId),
+        title
+      })
+      if (!leafId) {
+        continue
       }
-      continue
+      const row = buildTitleDerivedAgentRow({
+        tab,
+        leafId,
+        title,
+        ownerAgentType: resolveTitleDerivedPaneOwner(tab, layout, leafId),
+        now: args.now,
+        runtimeAgentOrchestrationByPaneKey: args.runtimeAgentOrchestrationByPaneKey
+      })
+      if (!row || args.seenPaneKeys.has(row.paneKey)) {
+        continue
+      }
+      rows.push(row)
+      args.seenPaneKeys.add(row.paneKey)
     }
-
-    const leafId = layout?.activeLeafId ?? collectLeafIds(layout?.root ?? null)[0]
-    if (!leafId) {
-      continue
-    }
-    const row = buildTitleDerivedAgentRow({
-      tab,
-      leafId,
-      title: tab.title,
-      ownerAgentType: resolveTitleDerivedPaneOwner(tab, layout, leafId),
-      now: args.now,
-      runtimeAgentOrchestrationByPaneKey: args.runtimeAgentOrchestrationByPaneKey
-    })
-    if (!row || args.seenPaneKeys.has(row.paneKey)) {
-      continue
-    }
-    rows.push(row)
-    args.seenPaneKeys.add(row.paneKey)
   }
 
   return rows
 }
 
 /**
- * Constructs a dashboard agent row from a terminal tab's title fallback,
+ * Constructs a dashboard agent row from one pane's live runtime title,
  * normalising Pi-compatible agent names to their owner.
  */
 function buildTitleDerivedAgentRow(args: {

--- a/src/renderer/src/components/tab-bar/terminal-tab-activity-status.test.ts
+++ b/src/renderer/src/components/tab-bar/terminal-tab-activity-status.test.ts
@@ -106,6 +106,9 @@ describe('resolveTerminalTabActivityStatus', () => {
       resolveTerminalTabActivityStatus({
         tab: { id: TAB_ID, title: 'Codex working' },
         agentStatusByPaneKey: { [stale.paneKey]: stale },
+        // Why (STA-2926): the title has to be live on a pane — a tab title alone no longer
+        // reaches the heuristic, so publishing it is what makes this a "live" title.
+        runtimePaneTitlesByTabId: { [TAB_ID]: { 1: 'Codex working' } },
         ptyIdsByTabId: LIVE_PTY
       })
     ).toBe('working')
@@ -117,6 +120,7 @@ describe('resolveTerminalTabActivityStatus', () => {
       resolveTerminalTabActivityStatus({
         tab: { id: TAB_ID, title: 'Codex working' },
         agentStatusByPaneKey: { [restored.paneKey]: restored },
+        runtimePaneTitlesByTabId: { [TAB_ID]: { 1: 'Codex working' } },
         ptyIdsByTabId: LIVE_PTY
       })
     ).toBe('active')
@@ -207,6 +211,9 @@ describe('resolveTerminalTabActivityStatus', () => {
     expect(
       resolveTerminalTabActivityStatus({
         tab: { id: TAB_ID, title: 'zsh' },
+        // Published so the shell title actually reaches the classifier rather than stopping at
+        // the no-pane-titles guard (STA-2926).
+        runtimePaneTitlesByTabId: { [TAB_ID]: { 1: 'zsh' } },
         ptyIdsByTabId: LIVE_PTY
       })
     ).toBe('active')

--- a/src/renderer/src/components/tab-bar/terminal-tab-spinner-launch-agent.test.ts
+++ b/src/renderer/src/components/tab-bar/terminal-tab-spinner-launch-agent.test.ts
@@ -14,13 +14,14 @@ describe('#9040 terminal tab dot attributes spinner titles to the launched agent
     resetTerminalTabActivityFlagsCacheForTest()
   })
 
-  it('reports working for a Claude spinner title on a live tab', () => {
+  it('reports working for a Claude spinner pane title on a live tab', () => {
     const status = resolveTerminalTabActivityStatus({
       tab: {
         id: 'tab-1',
-        title: '⠋ implementing the feature',
+        title: 'bash',
         launchAgent: 'claude'
       } satisfies Partial<TerminalTab> as TerminalTab,
+      runtimePaneTitlesByTabId: { 'tab-1': { 0: '⠋ implementing the feature' } },
       ptyIdsByTabId: { 'tab-1': ['pty-0'] }
     })
 
@@ -28,21 +29,40 @@ describe('#9040 terminal tab dot attributes spinner titles to the launched agent
   })
 
   // Control: the named-provider path this must stay at parity with.
-  it('reports working for a named-provider title', () => {
+  it('reports working for a named-provider pane title', () => {
     const status = resolveTerminalTabActivityStatus({
-      tab: { id: 'tab-1', title: 'claude [working]' } as TerminalTab,
+      tab: { id: 'tab-1', title: 'bash' } as TerminalTab,
+      runtimePaneTitlesByTabId: { 'tab-1': { 0: 'claude [working]' } },
       ptyIdsByTabId: { 'tab-1': ['pty-0'] }
     })
 
     expect(status).toBe('working')
   })
 
-  it('stays out of working for a spinner title with no launch identity', () => {
+  it('stays out of working for a spinner pane title with no launch identity', () => {
     const status = resolveTerminalTabActivityStatus({
-      tab: { id: 'tab-1', title: '⠐ Review branch for regressions' } as TerminalTab,
+      tab: { id: 'tab-1', title: 'bash' } as TerminalTab,
+      runtimePaneTitlesByTabId: { 'tab-1': { 0: '⠐ Review branch for regressions' } },
       ptyIdsByTabId: { 'tab-1': ['pty-0'] }
     })
 
     expect(status).not.toBe('working')
+  })
+
+  // Why (STA-2926): the tab-bar dot resolves through the same heuristic as the sidebar, so it
+  // inherits the same rule — a title left on the tab after its pane stopped publishing is a
+  // stale leftover with no pane to attribute it to, and must not light the dot.
+  it('does not report working for an agent title no pane is publishing', () => {
+    for (const tab of [
+      { id: 'tab-1', title: '⠋ implementing the feature', launchAgent: 'claude' },
+      { id: 'tab-1', title: 'claude [working]' }
+    ] satisfies Partial<TerminalTab>[]) {
+      const status = resolveTerminalTabActivityStatus({
+        tab: tab as TerminalTab,
+        ptyIdsByTabId: { 'tab-1': ['pty-0'] }
+      })
+
+      expect(status).toBe('active')
+    }
   })
 })

--- a/src/renderer/src/lib/worktree-status-spinner-launch-agent.test.ts
+++ b/src/renderer/src/lib/worktree-status-spinner-launch-agent.test.ts
@@ -30,20 +30,10 @@ function rowCount(tab: Partial<TerminalTab>, paneTitles?: Record<number, string>
 
 // Why: #9040 — Claude's thinking title is a braille spinner plus task text with no
 // provider token, so the dot's attribution gate rejected it and the worktree resolved
-// to 'active', which renders the same emerald dot as 'done'. The sidebar row builder
-// already falls back to the tab's launch identity for spinner titles (#9647); the dot
-// must agree.
+// to 'active', which renders the same emerald dot as 'done'. The sidebar row builder falls
+// back to the pane's launch identity for spinner titles (#9647); the dot must agree. Both
+// halves now read the same pane-scoped channel — see the STA-2926 cases below.
 describe('#9040 worktree dot attributes spinner titles to the launched agent', () => {
-  it('spins for a Claude spinner title when the tab was launched as claude', () => {
-    const status = getWorktreeStatus(
-      [{ id: 'tab-1', title: '⠋ implementing the feature', launchAgent: 'claude' }],
-      [],
-      livePtyMap('tab-1')
-    )
-
-    expect(status).toBe('working')
-  })
-
   it('spins for a spinner-only pane title when the tab was launched as claude', () => {
     const status = getWorktreeStatus(
       [{ id: 'tab-1', title: 'bash', launchAgent: 'claude' }],
@@ -55,11 +45,12 @@ describe('#9040 worktree dot attributes spinner titles to the launched agent', (
     expect(status).toBe('working')
   })
 
-  // Why: pins the #9647 gate — spinner attribution needs a launch identity, so a
-  // spinner in a tab no agent was launched in cannot spin the dot.
-  it('stays active for a spinner title with no launch identity', () => {
+  // Why (STA-2926): a spinner surviving only on `tab.title` is the leftover of a pane that
+  // already closed — no pane is publishing it. It must not spin the dot, because the row
+  // builder will not mint a row from it and the dot may never spin over zero rows.
+  it('does not spin for a Claude spinner tab title no pane is publishing', () => {
     const status = getWorktreeStatus(
-      [{ id: 'tab-1', title: '⠐ Review branch for regressions' }],
+      [{ id: 'tab-1', title: '⠋ implementing the feature', launchAgent: 'claude' }],
       [],
       livePtyMap('tab-1')
     )
@@ -67,11 +58,23 @@ describe('#9040 worktree dot attributes spinner titles to the launched agent', (
     expect(status).toBe('active')
   })
 
-  it('does not manufacture activity from a non-spinner title with a launch identity', () => {
+  // Why: pins the #9647 gate — spinner attribution needs a launch identity, so a
+  // spinner in a tab no agent was launched in cannot spin the dot. Published on a pane so the
+  // assertion exercises that gate rather than stopping at the no-pane-titles guard above.
+  it('stays active for a spinner pane title with no launch identity', () => {
+    const status = getWorktreeStatus([{ id: 'tab-1', title: 'bash' }], [], livePtyMap('tab-1'), {
+      'tab-1': { 0: '⠐ Review branch for regressions' }
+    })
+
+    expect(status).toBe('active')
+  })
+
+  it('does not manufacture activity from a non-spinner pane title with a launch identity', () => {
     const status = getWorktreeStatus(
       [{ id: 'tab-1', title: 'bash', launchAgent: 'claude' }],
       [],
-      livePtyMap('tab-1')
+      livePtyMap('tab-1'),
+      { 'tab-1': { 0: 'bash' } }
     )
 
     expect(status).toBe('active')
@@ -86,19 +89,18 @@ describe('#9040 worktree dot attributes spinner titles to the launched agent', (
 // deliberate choice rather than drifting silently.
 describe('#9040 spinner attribution trade-off is bounded', () => {
   it('over-reports a non-agent spinner in a tab an agent was launched in', () => {
-    const tab = {
-      id: 'tab-1',
-      title: '⠋ Progress: resolved 42',
-      launchAgent: 'claude'
-    } satisfies Partial<TerminalTab>
+    const tab = { id: 'tab-1', title: 'bash', launchAgent: 'claude' } satisfies Partial<TerminalTab>
+    // The spinner is published by a live pane; a tab-title-only spinner no longer reaches the
+    // heuristic at all (STA-2926), so the trade-off is pinned where it is still real.
+    const paneTitles = { 'tab-1': { 0: '⠋ Progress: resolved 42' } }
 
-    expect(getWorktreeStatus([tab], [], livePtyMap('tab-1'))).toBe('working')
-    // Bound 1: the same title cannot spin a tab with no launch identity.
-    expect(getWorktreeStatus([{ id: 'tab-1', title: tab.title }], [], livePtyMap('tab-1'))).toBe(
-      'active'
-    )
+    expect(getWorktreeStatus([tab], [], livePtyMap('tab-1'), paneTitles)).toBe('working')
+    // Bound 1: the same pane title cannot spin a tab with no launch identity.
+    expect(
+      getWorktreeStatus([{ id: 'tab-1', title: 'bash' }], [], livePtyMap('tab-1'), paneTitles)
+    ).toBe('active')
     // Bound 2: a dead PTY drops out regardless of launch identity.
-    expect(getWorktreeStatus([tab], [], {})).toBe('inactive')
+    expect(getWorktreeStatus([tab], [], {}, paneTitles)).toBe('inactive')
   })
 })
 
@@ -109,28 +111,54 @@ describe('#9040 spinner attribution matches named-provider dot/row agreement', (
   it('produces a sidebar row alongside the dot, like a named provider does', () => {
     const spinnerTab = {
       id: 'tab-1',
-      title: '⠋ implementing the feature',
+      title: 'bash',
       launchAgent: 'claude'
     } satisfies Partial<TerminalTab>
-    const namedTab = { id: 'tab-1', title: 'claude [working]' }
-
-    expect(getWorktreeStatus([spinnerTab], [], livePtyMap('tab-1'))).toBe('working')
-    expect(rowCount(spinnerTab)).toBe(1)
-    // Control: the pre-existing named-provider path resolves to the same pair.
-    expect(getWorktreeStatus([namedTab], [], livePtyMap('tab-1'))).toBe('working')
-    expect(rowCount(namedTab)).toBe(1)
-  })
-
-  it('agrees for a spinner pane title too', () => {
-    const tab = { id: 'tab-1', title: 'bash', launchAgent: 'claude' } satisfies Partial<TerminalTab>
-    const paneTitles = { 'tab-1': { 0: '⠙ refactoring the parser' } }
+    const spinnerPaneTitles = { 0: '⠋ implementing the feature' }
+    const namedTab = { id: 'tab-1', title: 'bash' }
+    const namedPaneTitles = { 0: 'claude [working]' }
     const layouts = { 'tab-1': singleLeafLayout() }
 
     expect(
-      getWorktreeStatus([tab], [], livePtyMap('tab-1'), paneTitles, {
-        terminalLayoutsByTabId: layouts
-      })
+      getWorktreeStatus(
+        [spinnerTab],
+        [],
+        livePtyMap('tab-1'),
+        { 'tab-1': spinnerPaneTitles },
+        {
+          terminalLayoutsByTabId: layouts
+        }
+      )
     ).toBe('working')
-    expect(rowCount(tab, paneTitles['tab-1'])).toBe(1)
+    expect(rowCount(spinnerTab, spinnerPaneTitles)).toBe(1)
+    // Control: the pre-existing named-provider path resolves to the same pair.
+    expect(
+      getWorktreeStatus(
+        [namedTab],
+        [],
+        livePtyMap('tab-1'),
+        { 'tab-1': namedPaneTitles },
+        {
+          terminalLayoutsByTabId: layouts
+        }
+      )
+    ).toBe('working')
+    expect(rowCount(namedTab, namedPaneTitles)).toBe(1)
+  })
+
+  // Why (STA-2926): the agreement is load-bearing in the negative direction too. Once no pane
+  // publishes a title, the closed pane's leftover tab title must move neither half. Previously
+  // it moved both — minting a recycled row on the surviving leaf — and a half-applied fix that
+  // removed only the row would have stranded a dot spinning "working" over zero agents.
+  it('moves neither the dot nor a row when no pane publishes a title', () => {
+    const tabs = [
+      { id: 'tab-1', title: '⠋ implementing the feature', launchAgent: 'claude' },
+      { id: 'tab-1', title: 'claude [working]' }
+    ] satisfies Partial<TerminalTab>[]
+
+    for (const tab of tabs) {
+      expect(getWorktreeStatus([tab], [], livePtyMap('tab-1'))).toBe('active')
+      expect(rowCount(tab)).toBe(0)
+    }
   })
 })

--- a/src/renderer/src/lib/worktree-status.test.ts
+++ b/src/renderer/src/lib/worktree-status.test.ts
@@ -34,7 +34,10 @@ describe('getWorktreeStatus', () => {
         { id: 'tab-2', title: 'claude [permission]' }
       ],
       [{ id: 'browser-1' }],
-      livePtyMap('tab-1', 'tab-2')
+      livePtyMap('tab-1', 'tab-2'),
+      // Why: the status must come from panes that are actually publishing — a tab title alone no
+      // longer feeds the dot (STA-2926).
+      { 'tab-1': { 0: 'claude [working]' }, 'tab-2': { 0: 'claude [permission]' } }
     )
 
     expect(status).toBe('permission')
@@ -129,14 +132,28 @@ describe('getWorktreeStatus', () => {
     expect(status).toBe('active')
   })
 
-  it('still spins on an agent-attributable braille-spinner title', () => {
+  it('still spins on an agent-attributable braille-spinner pane title', () => {
     const status = getWorktreeStatus(
       [{ id: 'tab-1', title: '⠹ codex fix flaky test' }],
+      [],
+      livePtyMap('tab-1'),
+      { 'tab-1': { 0: '⠹ codex fix flaky test' } }
+    )
+
+    expect(status).toBe('working')
+  })
+
+  // Why (STA-2926): once every pane's title slot is cleared, `tab.title` is a provenance-free
+  // leftover of a pane that is gone. It used to keep the dot spinning over zero sidebar rows;
+  // the row builder refuses to mint a row from it, so the dot must refuse to spin on it too.
+  it('does not spin on an agent title no pane is publishing', () => {
+    const status = getWorktreeStatus(
+      [{ id: 'tab-1', title: 'claude [working]' }],
       [],
       livePtyMap('tab-1')
     )
 
-    expect(status).toBe('working')
+    expect(status).toBe('active')
   })
 })
 
@@ -259,6 +276,7 @@ describe('resolveWorktreeStatus', () => {
       tabs: [{ id: 'tab-1', title: 'claude [working]' }],
       browserTabs: [],
       ptyIdsByTabId: livePtyMap('tab-1'),
+      runtimePaneTitlesByTabId: { 'tab-1': { 0: 'claude [working]' } },
       hasPermission: false,
       hasLiveWorking: false,
       hasLiveDone: true,
@@ -352,6 +370,7 @@ describe('resolveWorktreeStatus', () => {
       tabs: [{ id: 'tab-1', title: 'claude [permission]' }],
       browserTabs: [],
       ptyIdsByTabId: livePtyMap('tab-1'),
+      runtimePaneTitlesByTabId: { 'tab-1': { 0: 'claude [permission]' } },
       hasPermission: false,
       hasLiveWorking: false,
       hasLiveDone: true,

--- a/src/renderer/src/lib/worktree-status.ts
+++ b/src/renderer/src/lib/worktree-status.ts
@@ -63,39 +63,38 @@ function tabHasStatus(
 ): boolean {
   const agentStatusPaneIds = options.agentStatusPaneIdsByTabId?.[tab.id]
   const paneTitles = runtimePaneTitlesByTabId[tab.id]
-  if (paneTitles && Object.keys(paneTitles).length > 0) {
-    const tabLayoutRoot =
-      options.terminalLayoutRootsByTabId?.[tab.id] ?? options.terminalLayoutsByTabId?.[tab.id]?.root
-    const paneTitleEntries = Object.entries(paneTitles)
-    for (const [runtimePaneId, title] of paneTitleEntries) {
-      const leafId = resolveRuntimePaneTitleLeafIdFromRoot(tabLayoutRoot, runtimePaneId)
-      // Why: runtime titles can precede layout hydration (SSH/replay); with one title and one agent row, prefer that row over a stale spinner.
-      const hasSingleUnmappedAgentStatusPane =
-        leafId === null && agentStatusPaneIds?.size === 1 && paneTitleEntries.length === 1
-      if (
-        agentStatusPaneIds?.has(runtimePaneId) ||
-        (leafId !== null && agentStatusPaneIds?.has(leafId)) ||
-        hasSingleUnmappedAgentStatusPane
-      ) {
-        continue
-      }
-      if (
-        classifyTitleActivity(title) === status &&
-        titleStatusIsAgentAttributable(title, tab.launchAgent)
-      ) {
-        return true
-      }
+  // Why (STA-2926, #11372): runtime pane titles are the only pane-scoped title channel, and
+  // clearRuntimePaneTitle drops a pane's slot the moment its PTY exits. A tab with no slots left
+  // has nothing publishing a title, so `tab.title` — a provenance-free mirror of the last focused
+  // pane — is a stale leftover rather than evidence of live work. The row builder refuses to mint
+  // a row from that same title, and the dot must agree with the row (#9040) instead of spinning
+  // "working" over zero agents.
+  if (!paneTitles || Object.keys(paneTitles).length === 0) {
+    return false
+  }
+  const tabLayoutRoot =
+    options.terminalLayoutRootsByTabId?.[tab.id] ?? options.terminalLayoutsByTabId?.[tab.id]?.root
+  const paneTitleEntries = Object.entries(paneTitles)
+  for (const [runtimePaneId, title] of paneTitleEntries) {
+    const leafId = resolveRuntimePaneTitleLeafIdFromRoot(tabLayoutRoot, runtimePaneId)
+    // Why: runtime titles can precede layout hydration (SSH/replay); with one title and one agent row, prefer that row over a stale spinner.
+    const hasSingleUnmappedAgentStatusPane =
+      leafId === null && agentStatusPaneIds?.size === 1 && paneTitleEntries.length === 1
+    if (
+      agentStatusPaneIds?.has(runtimePaneId) ||
+      (leafId !== null && agentStatusPaneIds?.has(leafId)) ||
+      hasSingleUnmappedAgentStatusPane
+    ) {
+      continue
     }
-    return false
+    if (
+      classifyTitleActivity(title) === status &&
+      titleStatusIsAgentAttributable(title, tab.launchAgent)
+    ) {
+      return true
+    }
   }
-  // Why: a tab title can't identify its pane; once an agent row owns one, prefer the row over a completed pane's stale "working" title.
-  if (agentStatusPaneIds && agentStatusPaneIds.size > 0) {
-    return false
-  }
-  return (
-    classifyTitleActivity(tab.title) === status &&
-    titleStatusIsAgentAttributable(tab.title, tab.launchAgent)
-  )
+  return false
 }
 
 // Why: require agent attribution so a bare never-cleared spinner title can't spin the dot "0 agents" forever with no matching sidebar row.
@@ -104,8 +103,8 @@ function titleStatusIsAgentAttributable(title: string, launchAgent?: TuiAgent | 
     return true
   }
   // Why: a spinner proves activity but not identity (Claude's thinking title has no provider
-  // token, #9040); the tab's launch identity supplies it, mirroring the row builder's spinner
-  // fallback (#9647) so the dot and the sidebar row agree.
+  // token, #9040); the tab's launch identity supplies it, mirroring the row builder's own
+  // pane-title owner fallback (#9647) so the dot and the sidebar row agree.
   return containsAgentSpinnerGlyph(title) && Boolean(launchAgent)
 }
 


### PR DESCRIPTION
## What this actually is — read this first

**This is not a live user-facing fix, and the original framing of it was wrong.** Live validation established that the symptom STA-2926 describes — closing a split pane and having its agent row re-point at the survivor — **no longer reproduces on current `main`**, in either arm. `resolveTabTitleAfterPaneClose` (`terminal-pane-close-identity.ts:12`, from **#8569**) already resets a tab to its stable fallback on pane close, with a comment describing exactly this case. App restart doesn't preserve it either.

**What this PR does is retire a branch that is wrong whenever it is entered, and stop the dot from outliving the row.** The removed fallback minted an agent row *and* both dots from a `tab.title` that **no pane was publishing** — verified live:

| shape | before | after |
| --- | --- | --- |
| `tab.title` only, `runtimePaneTitles = {}` | rows **1**, worktree dot **working**, tab dot **working** | rows **0**, both dots `active` |
| same title published *on a pane* | rows 1, working, working | unchanged |

**Why the dot half is in here too, and why it is not optional.** Removing only the row fallback would have left the dot still reading stale `tab.title` — producing a dot spinning "working" forever over **zero agent rows**, which is #9040. CI caught that, and the pre-fix half of that state was observed directly during validation. The two halves are one change; shipping the row half alone reintroduces a fixed bug.

**Verified not to under-report:** a plain shell with no agent, including a surviving split pane, gives rows 0 / both dots `active` in both arms. A live agent in a split or unsplit pane still gets its row and dots — the pane branch is untouched.

**One path is untested:** `web-session-tabs-sync` publishes host-synced tab titles and could still deliver an agent-shaped `tab.title` with empty runtime pane titles. That is the one place the precondition might still arise, and it was not exercised.

## Original framing, kept for the record

The `before:` table further down comes from executing the pre-fix row builder against **constructed store states**, not from a running app. It shows what the branch does when entered — which is real — but should not be read as a captured live repro of the ticket.

## What Changed

One branch removed from `buildTitleDerivedAgentRows`: the `tab.title` fallback that ran when a tab had no runtime pane titles at all.

```ts
// removed
const leafId = layout?.activeLeafId ?? collectLeafIds(layout?.root ?? null)[0]
const row = buildTitleDerivedAgentRow({ tab, leafId, title: tab.title, ... })
```

The matching branch is removed from the worktree dot in `worktree-status.ts` — which the tab-bar dot also resolves through — see **Scope expanded beyond the ticket** below for why that is in this PR.

A title-derived row is now minted only from `runtimePaneTitlesByTabId[tabId]` — the pane-scoped title channel. Everything else in the file is untouched: identity resolution, the Claude token guard, the owner fallback, the Cursor/`claude agents` carve-outs, the leaf resolver.

## Scope expanded beyond the ticket

**This PR now also changes the worktree card DOT, not just the sidebar row. That was not in STA-2926's scope.**

**And the tab-bar dot with it.** `resolveTerminalTabActivityStatus` (`terminal-tab-activity-status.ts:151`) delegates straight to `resolveWorktreeStatus` — *"Reuse the WorktreeCard status vocabulary and resolver so the tab's live states resolve identically to the sidebar."* One resolver, so the dot rule lands on both surfaces at once. That is the correct outcome (the tab-bar dot had the same "spinning over zero rows" hole), but it is a second surface changed, so it is stated here rather than left to the diff. It cost three more rewritten tests and one new one, listed below.

It was done because the alternative was shipping a regression, and CI caught it. `worktree-status-spinner-launch-agent.test.ts` > *#9040 spinner attribution matches named-provider dot/row agreement* failed on the row-only change — and it is **not** a stale expectation. #9040 and STA-2926 feed **structurally identical inputs** (single-leaf layout, `runtimePaneTitles = {}`, one live PTY, an agent-identifying `tab.title`) and demand opposite outputs. Every candidate discriminator was checked — `launchAgent` present/absent, spinner vs. named identity, PTY count, leaf count, `layout.titlesByLeafId` — and both suites cover both sides of each. No narrowing guard can separate them.

Why the two halves cannot be allowed to disagree is written into the source. `worktree-status.ts:106-109` says its spinner fallback exists specifically to mirror *"the row builder's spinner fallback (#9647) so the dot and the sidebar row agree"* — the exact fallback the row half removes. Removing one side and keeping the other is not minimal scope; it is a half-applied change that breaks the agreement that comment describes, leaving the dot spinning `working` over **zero** sidebar rows. That is precisely the "0 agents" symptom #9040 was filed to fix.

So the dot gets the same rule: with no pane publishing a title, there is nothing to attribute.

**#9040's real feature survives — this fixes it rather than reverting it.** Spinner attribution runs through the pane-title branch, which is untouched: *spins for a spinner-only pane title when the tab was launched as claude* passes unchanged before and after. What is removed is only the tab-title variant, reachable only once a pane has stopped publishing.

### Named-provider tab titles: intended, not collateral

The row half also stops minting rows from **named-provider** tab titles (`claude [working]`), not only stale spinners. **This is intended, and the guard is deliberately not narrowed.**

The defect is attribution, not title content. `tab.title` carries no pane provenance at all; the removed branch assigned it to `layout.activeLeafId ?? firstLeaf` — a *guess* at which leaf owned it. That guess is exactly as unfounded for `claude [working]` as for `⠋ implementing the feature`: the title's specificity changes what the row would **say**, not which pane it belongs to. The PR's own test shows the named case is a live bug — `✳ Claude Code` recycled onto both a promoted sibling and a replacement session.

Named providers lose nothing while they are alive. `onTitleChange` writes `setRuntimePaneTitle` for **every** pane (pane 0 of an unsplit tab included) and only *then* mirrors the focused pane into `tab.title`, so a live agent always occupies a pane slot and is rowed by the pane branch. Empty slots plus an agent-shaped `tab.title` is, by construction, the cleared/stale state. The rewritten control assertion pins this: `claude [working]` published on a pane still produces both a spinning dot and exactly one row.

### The 12 rewritten tests

Each keeps its original assertion; the status source moves from `tab.title` to the pane-title channel that actually feeds the heuristic in production. None was weakened to pass.

`worktree-status.test.ts`

1. *prioritizes permission over other live activity states* — assertion unchanged (`permission` beats `working` + browser presence); the two titles are now published on panes.
2. *still spins on an agent-attributable braille-spinner **pane** title* — renamed; same `working` assertion, via the pane channel.
3. *lets heuristic working beat hasLiveDone (newer in-progress signal wins)* — assertion unchanged; added `runtimePaneTitlesByTabId`.
4. *honors heuristic permission over hasLiveDone (priority: permission > done)* — assertion unchanged; added `runtimePaneTitlesByTabId`.
5. **new** — *does not spin on an agent title no pane is publishing* — pins the new contract directly.

`WorktreeCard.test.ts`

6. *keeps terminal agent states higher priority than browser presence* — both assertions unchanged (`permission` and `working` each beat browser presence); titles published on panes.

`worktree-status-spinner-launch-agent.test.ts` (#9040)

7. *spins for a Claude spinner title when the tab was launched as claude* → replaced by *does not spin for a Claude spinner tab title no pane is publishing*, asserting the new contract. Its positive twin (*spins for a spinner-only **pane** title…*) already existed and still passes, so #9040's feature keeps direct coverage.
8. *over-reports a non-agent spinner in a tab an agent was launched in* — the documented #9647 trade-off, re-pinned on the pane channel where it is still real; both bounds intact.
9. *produces a sidebar row alongside the dot, like a named provider does* — the invariant test, now asserting dot/row agreement through the pane channel for **both** the spinner and the named provider.
10. **new** — *moves neither the dot nor a row when no pane publishes a title* — the same invariant in the negative direction, for both title shapes.

Two further tests in that file — *stays active for a spinner title with no launch identity* and *does not manufacture activity from a non-spinner title with a launch identity* — still **passed** after the change, but only because everything without pane titles now returns `active`. They had gone **vacuous**, asserting nothing about the #9647 gate they exist to pin, so they were moved to the pane channel as well. They are not counted among the failures.

`terminal-tab-spinner-launch-agent.test.ts` (#9040, tab-bar dot)

11. *reports working for a Claude spinner **pane** title on a live tab* — renamed; same `working` assertion, via the pane channel.
12. *reports working for a named-provider **pane** title* — the parity control, same assertion, via the pane channel.
13. **new** — *does not report working for an agent title no pane is publishing* — the negative contract on the tab-bar surface, for both the spinner and the named provider.

*stays out of working for a spinner pane title with no launch identity* was also moved to the pane channel for the same vacuity reason as the two sidebar cases above.

`terminal-tab-activity-status.test.ts`

14. *falls back to a live working title when hook status is stale* — assertion unchanged (`working` beats a >30m-stale `done` hook); the title is now published on a pane, which is what "live" means after this change.
15. *does not revive an unconfirmed restored row from its preserved title* — assertion unchanged (`active`); still load-bearing, since without the `restoredUnconfirmed` suppression the published pane title would classify as `working`.
16. *reports a live shell with no agent as active (no activity glyph)* — assertion unchanged; `zsh` published on a pane so it reaches the classifier instead of stopping at the new no-pane-titles guard.

**Nothing was deleted.** Every case above kept its original assertion; none was weakened into vacuity, so no test lost its reason to exist.

**Mutation-proved, not assumed.** Three independent mutations, each run against the rebased tree:

| Mutation | Result |
| --- | --- |
| Restore the old `tab.title` fallback in `worktree-status.ts` | **2 failed \| 36 passed** — *does not spin on an agent title no pane is publishing* and its tab-bar twin *does not report working for an agent title no pane is publishing* |
| Neutralize the #9040 spinner gate (`titleStatusIsAgentAttributable` → `false`) | **4 failed \| 7 passed** — including *spins for a spinner-only pane title when the tab was launched as claude* and *reports working for a Claude spinner pane title on a live tab* |
| Revert the row-builder fix | STA-2926's own two tests **and** the two-way invariant test go red |

The second mutation is the direct evidence for **#9040's feature surviving on both dots**: those cases are only green because the spinner→launch-identity attribution still runs, through the pane-title branch this PR does not touch. Option B fixes #9040 rather than reverting it.

## Why

**Two title channels, only one of which knows about panes.**

| | `runtimePaneTitlesByTabId[tabId][paneId]` | `tab.title` |
| --- | --- | --- |
| Scope | one pane | the tab |
| Written | every OSC frame, per pane (`onTitleChange`) | only by the **focused** pane ("otherwise two agents in split panes cause rapid title flickering") |
| Cleared when its pane dies | **yes** — `clearRuntimePaneTitle` on PTY exit (`pty-connection.ts`), on pane close (`use-terminal-pane-lifecycle.ts`), and on parked-pane exit (`shouldDeferParkedPtyExitTabClose`) | **no** |

So the removed branch ran *precisely* when every pane's live title had been cleared, and the string it read was, by construction, produced by a pane that is no longer publishing. It then attributed that string to `layout.activeLeafId` — the pane that survived the close. That is the recycle.

**The intended reset already exists and silently no-ops.** `onPaneClosed` does try to fix this at the source:

```ts
updateTabTitle(tabId, resolveTabTitleAfterPaneClose(paneTitles, newActivePane.id))
// "an empty update resets the tab to its stable fallback instead of
//  leaving the closed pane's agent title attached to an untitled survivor"
```

but `applyTerminalTabTitleUpdates` resolves the empty string through `getFallbackTabTitle`, whose last resort is **`tab.title` itself**:

```ts
tab.customTitle?.trim() || tab.quickCommandLabel?.trim() || tab.defaultTitle?.trim() || tab.title || 'Terminal 1'
```

A tab with no custom title, no quick-command label and no `defaultTitle` (`defaultTitle` is only ever stamped from a `Terminal N` title, so a tab that never wore one has none) gets its stale title handed straight back, `currentTab.title === nextTitle`, no update. The reset is a no-op exactly when it is needed.

**`tab.title` is unfixable in place.** There is no signal in this function that separates "this tab title belongs to the survivor" from "it belongs to the pane that just closed" — the tab title carries no pane provenance at all. So the only correct action is to stop minting a *pane* row from it.

### Symmetry with the sweep's other two identity fixes

- **#14650** established that a title which is a shell process is *positive evidence the agent exited*, so it must not resurrect a row. An unbacked `tab.title` is the inverse case: positive evidence of **nothing** about the pane it would be attributed to. Same treatment — do not synthesize the row. #14650 lands the owner (`launchAgent`) fallback inside `buildTitleDerivedAgentRow`, which is still reached from the pane-scoped branch a live pane always uses, so the two compose: this PR removes a row source that could only ever be wrong, and #14650 keeps a live owned pane visible on the branch that is right.
- **#14615** (STA-2069) binds hook status to the pane its session was spawned into. Same invariant on the hookless half: a row is a claim about a *pane*, so its evidence must be pane-scoped.
- The repo already holds this principle one layer down, for the sibling field: `shouldClearLaunchAgentForClosedPane` — *"Closing that PTY must not transfer its bootstrap identity to a surviving shell sibling."* A closed pane's **title** must not transfer either.

### Relationship to #14702 (same file)

#14702 fixed the *other* branch of this function — which leaf a live pane title resolves to (STA-3264) — and explicitly left this one open:

> **STA-2926** / #11372 — a *different branch* of the same function: once the closed pane's title slot is cleared, the tab falls through to the `tab.title` fallback and re-synthesizes a row from the tab's stale spinner title. **Still open**, untouched here.

This is that branch. The two are independent and land in either order — see the merge note under **Testing**. Nothing in #14702's leaf-resolution work is re-done here.

Not #11069 / STA-2811 (split rows sharing one conversation *name*) — that is `getAgentRowConversationName`, a different file, addressed by #11070.

**No PR is superseded.** #11372 is an issue, not a PR; `11372 in:body` and `STA-2926 in:body` both return nothing open.

## Linked Issue

Fixes #11372 (STA-2926)

## Visual Proof

Now captured live. An isolated Orca dev instance running this branch (own `ORCA_DEV_USER_DATA_PATH`, own CDP port, `getIdentity()` verified per arm, never the instance the user is running), with a real `claude` session in a real split pane. Arms differ only by `git checkout origin/main --` on the two production files, with a **full relaunch per arm** — `electron-vite dev` does not rebuild the main process, so HMR would have measured the same build twice.

Full log: [sta2926-live-validation.txt](https://github.com/user-attachments/files/31159231/sta2926-live-validation.txt) · ![postfix-live.png](https://github.com/user-attachments/assets/5ff8bea8-1372-42fa-943f-4a29460f3e0a)

All three changed surfaces were read from the live renderer store on every sample — `buildWorktreeAgentRows` (rows), `resolveWorktreeStatus` (worktree-card dot), `resolveTerminalTabActivityStatus` (tab-bar dot).

**The removed branch, when reached.** Same tab, same title, `launchAgent: 'claude'`, one live PTY, single-leaf layout; the only difference is whether a pane is publishing:

| shape | pre-fix | post-fix |
| :--- | :--- | :--- |
| `tab.title` only, `runtimePaneTitles = {}` | rows=**1**, worktree dot=**working**, tab dot=**working** | rows=**0**, both dots **`active`** |
| same title published **on a pane** | rows=1, working, working | rows=1, working, working — **unchanged** |

So the branch really did mint a row *and* both dots from a title no pane was publishing, and after the fix all three go silent **together**. That is the dot/row agreement the scope expansion exists to preserve: **no state was found in which a dot spins `working` over zero rows.**

**Live scenarios**, all run in both arms:

- **Agent live and focused, plain-shell sibling** — rows=1 (claude), both dots agree. No under-report.
- **Braille spinner published on a pane, `launchAgent: 'claude'`** — rows=1 `working`, both dots `working`. Identical in both arms; the untouched pane branch is unaffected.
- **Plain shell with no agent, including a surviving split pane** — rows=0, both dots `active`. Removing the fallback does not under-report a pane that has no agent.

### Reachability — stated plainly, because it cuts against the ticket's story

I could **not** reach the removed branch through ordinary user actions on this tree:

- **Closing the split pane** (the exact repro) ends identically in both arms: `runtimePaneTitles → {}`, `tab.title → "Terminal N"`, rows=0, both dots `active`. No recycled row **in either arm**. The cause is already on `origin/main`: `resolveTabTitleAfterPaneClose` (`terminal-pane-close-identity.ts:12`, from #8569) resets the tab to its stable fallback rather than *"leaving the closed pane's agent title attached to an untitled survivor."*
- **Restarting the app** does not preserve the shape either — `tab.title` reverts to its `defaultTitle`, and the panes republish. Sampled every 2s for 40s across the boot window in both arms: rows and both dots agreed at every sample.

So on current `main` the branch this PR deletes looks **dead for the paths the ticket describes**. That makes the change safe — a dead-branch removal that also restores dot/row symmetry — but it means the recycle itself was not live-reproducible here, and the `before:` outputs below come from executing the pre-fix builder against constructed states rather than from a running app.

**Not exhausted:** the remote/SSH path. `web-session-tabs-sync` publishes host-synced tab titles, which could still deliver an agent-shaped `tab.title` with empty runtime pane titles; that was not tested.

The constructed-state outputs previously quoted here remain accurate for what the pre-fix builder does when the branch *is* reached — real assertion output from the pre-fix source, and now corroborated by the live pre-fix arm above:

```
before:  tab-1:LEAF_ID_1   claude   working   "Running"   <- pane that never ran Claude
after:   (no row)

title "⠋ Codex"                 before: codex  working    after: (no row)
title "✳ refactor the resolver" before: codex  idle       after: (no row)
title "⏸ Gemini CLI"            before: gemini idle       after: (no row)   <- agent the tab never launched
```

## Testing

- [x] I manually tested these changes locally — live in an isolated dev instance with a real `claude` session, both arms, all three surfaces; see Visual Proof. Constructed store states were used additionally, to reach the branch that ordinary actions no longer reach.
- [x] Automated tests added/updated

**New tests** — `worktree-title-derived-agent-rows.test.ts`, new `closed split pane` block, asserting externally visible projection only (`paneKey`, `agentType`, `state`):

1. *does not recycle a closed pane row onto the sibling or a replacement session* — survivor is the promoted sibling, and separately a pane opened after the close; both expect zero rows.
2. *does not synthesize a row from a stale spinner or identity tab title* — the three titles above, including the wrong-agent case.
3. *keeps the surviving pane on its own identity rather than the closed pane title* — survivor publishes `⠋ Codex` while `tab.title` still says `✳ Claude Code`; the row must be Codex on the survivor's leaf.
4. *still rows a live pane that publishes its own runtime title* — the visibility guard.

**Red/green oracle.** Reverting **only** `worktree-title-derived-agent-rows.ts` and keeping the tests: **2 failed | 19 passed**. Tests 1 and 2 fail; 3 and 4 pass both ways and are stated as guards on the pane-scoped path this PR preserves, not as evidence of the fix. Restored: **21/21**. Each of the three titles in test 2 was additionally verified to recycle pre-fix *individually* (a loop stops at its first failure), which is where the `before:` table above comes from.

**Is the removed branch load-bearing?** Checked before writing anything: with the fallback neutralized outright, `src/renderer/src/components/sidebar` + `src/renderer/src/components/dashboard` ran **295 files / 2640 tests, all passing** — no existing test depended on it. Both consumers of `buildWorktreeAgentRows` (`useWorktreeAgentRows`, `build-dashboard-snapshot`) are inside that scope.

**Regression scope** (re-run on the rebased tree).

- `sidebar` + `lib/worktree-status*` + `tab-bar` + `dashboard`: **358 files / 3068 tests passed.**
- `oxlint` and React Doctor across all 8 changed files: **clean.** Proved the gate was live rather than silently dead by appending a `debugger`/loose-equality probe to `worktree-status.ts` — it reported `eslint(no-debugger)` — then reverting. No `max-lines` suppression added. `oxfmt --check` clean on all 8.
- Full `pnpm typecheck` **deliberately not run** (OOM risk on this host, per the sweep constraint). The only type surface touched is the deletion of one call site plus test-fixture fields.

### CI red → green, cause by cause

| Check | Cause | State |
| --- | --- | --- |
| `tests node 24/26 · 2/16` — `terminal-tab-spinner-launch-agent.test.ts`, 2 failures | Real. The tab-bar dot shares `resolveWorktreeStatus`, so the dot fix reached it and two `tab.title`-fed cases went red. | **Fixed** — moved to the pane channel, assertions unchanged; new negative case added. |
| `tests node 24/26 · 8/16` — `terminal-tab-activity-status.test.ts`, 1 failure | Same cause: *falls back to a live working title when hook status is stale* fed its title through `tab.title`. | **Fixed** — same treatment. |
| `verify` | Aggregate only; its inputs were `TEST: failure`, everything else `success`. | **Fixed** by the above. |
| `test vs non-test LoC` | **Not a ratio failure.** `.github/workflows/pr-test-loc.yml` fetches `.github/scripts/pr-test-loc-{table,summary}.mjs` from `pull/14708/head`; the branch predated those scripts, so `gh api` returned `404` and `base64 --decode` failed. The job has no threshold at all — `pr-test-loc-summary.mjs` only counts and PATCHes this body. | **Fixed by rebasing** onto `main` (82 commits), which brings the scripts onto the head ref. No code change could have fixed it. |

**Rebase safety.** `git merge-tree --write-tree origin/main HEAD` was clean before rebasing, and `git log HEAD..origin/main -- <the 8 files>` was **empty** — `main` had not touched any file in this PR, so the rebase is mechanical. All three commits replayed without conflict; the full scoped suite above was re-run afterwards, and all three mutation proofs were re-run on the rebased tree.

**Merge-collision check — run locally with `git merge-tree --write-tree`, not read off GitHub's `mergeable` flag** (independently verified stale during this sweep). Against each in-flight PR's head SHA:

| PR | Result |
| --- | --- |
| #14486 (119-file sidebar reorg) | clean |
| #14654, #14682, #14650, #14615 | clean |
| **#14702** | **conflicts** — same function, same test file |

I did not stop at the flags:

- **#14486** materialized into a merged tree and the suites **run**: sidebar + dashboard **295 files / 2644 tests passed**. Mergeable *and* green.
- **#14702** conflict materialized and resolved to confirm it is mechanical, not semantic. The resolution is: keep #14702's hoisted `leafIds` / `liveSlotIds` / `liveSlotsAreDense` and its `resolveLeafIdForTitleFallback` signature, drop the `if (paneTitleEntries.length > 0) { … }` wrapper and the `tab.title` block below it, keep both test blocks and delete #14702's now-duplicate inner `LEAF_ID_3`. The merged tree runs **25/25** in this file and **295 files / 2648 tests** across sidebar + dashboard. Whichever of the two lands second takes that resolution; neither PR needs the other, and this one is based on `main`, not stacked.

**Platforms.** Written and run on macOS. Nothing platform-dependent is introduced or removed: no shortcuts, modifier keys, shortcut labels, path construction, shell invocation or Electron platform APIs. Windows, Linux and a live SSH host were not exercised.

## AI Disclosure

Claude Opus 5 (Claude Code), on macOS.

## Review

- **Security.** No new surface. No command execution, path handling, auth, secrets, IPC channel, dependency, persisted state or schema change. Strictly a removal in renderer-local row derivation.
- **Cross-platform.** No `process.platform` / `navigator.userAgent` branching added or removed; nothing OS-specific to diverge.
- **Remote SSH.** This is the path SSH cares about most — hookless agents over SSH (Codex #8711, OpenCode #8940) surface only decorated titles, so their rows are title-derived. Their live titles arrive through `setRuntimePaneTitle` exactly like local panes, so the surviving branch covers them unchanged; what is removed is a source that could only ever fire once a pane had *stopped* publishing. No probing, no Git commands, no local-only assumptions. Identical for folder workspaces and git worktrees — nothing reads git state.
- **Mobile / remote wire.** No wire change: no RPC params, no stream opcodes, nothing new published to a paired client.
- **Backwards compatibility.** Nothing persisted, no migration, no downgrade hazard.
- **Behavior removed, stated plainly.** A tab with a live PTY, an agent-shaped `tab.title`, and *zero* runtime pane titles no longer gets a row. Beyond the closed-pane case that is only reachable in the window between a pane's spawn and its first OSC title frame, where the correct display is "no pane evidence yet" rather than a persisted string. If that window ever wants a row, #14650's owner fallback is the right mechanism for it — durable, pane-scoped for a single-leaf tab, and gated on a live PTY — not a title with no provenance.
- **Performance** (STA-3354, Urgent P0 — rows must not multiply per-render status-map work). **Strictly less work.** One branch deleted; no status-map scan, no store subscription, no new selector, no added pass over anything. Row count can only shrink, so nothing downstream multiplies.

## Checklist

- [x] This PR is small and focused — 2 source files, 6 test files (see **Scope expanded beyond the ticket**)
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — scoped equivalents run locally and green; full typecheck left to CI per the OOM constraint above

## Author

- X / Twitter: @BrennanKB5




