### PR TITLE
fix(codex): hold the fabricated permission BEL for the Codex quiet window

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -340,6 +340,12 @@ import {
 import { LocalPtyProvider } from './providers/local-pty-provider'
 import { KeybindingService } from './keybindings/keybinding-service'
 import { applyElectronProxySettings } from './network/proxy-settings'
+import {
+  SYNTHETIC_PERMISSION_BELL,
+  buildSyntheticTerminalTitleFrame,
+  shouldDeferSyntheticPermissionBell
+} from '../shared/codex-attention-quiet-window'
+import { SyntheticPermissionBellDeferral } from './synthetic-permission-bell-deferral'
 import { preserveAgentAuthBeforeRestart } from './agent-auth-restart-preservation'
 import { CliInstaller } from './cli/cli-installer'
 import { installLinuxBareOrcaDispatcher } from './cli/linux-bare-orca-dispatcher'
@@ -1504,6 +1510,7 @@ function openMainWindow(options: { revealOnDidFinishLoad?: boolean } = {}): Brow
     setMigrationUnsupportedPtyListener(null)
     // Why: stop the spinner timer here — it would fire into destroyed webContents, and per-pane teardown may never run for restored-but-untorn panes.
     stopAllSyntheticTitleSpinners()
+    syntheticPermissionBellDeferral.cancelAll()
   })
   mainWindow = window
   window.on('show', resumeSyntheticTitleSpinnerTimer)
@@ -1583,6 +1590,17 @@ function openMainWindow(options: { revealOnDidFinishLoad?: boolean } = {}): Brow
         getDashboardPopoutWindow()?.webContents.send('agentStatus:set', statusEvent)
       }
       recordAgentStateCrashBreadcrumb(payload.agentType ?? 'unknown', payload.state)
+      // Why: a pause that resolved itself must drop its deferred BEL even when this event
+      // suppresses the synthetic title entirely (#13600).
+      if (
+        !shouldDeferSyntheticPermissionBell({
+          agentType: payload.agentType,
+          state: payload.state,
+          toolName: payload.toolName
+        })
+      ) {
+        syntheticPermissionBellDeferral.cancel(paneKey)
+      }
       // Why: native OSC titles miss some idle/permission frames, so inject hook-derived ones to keep the renderer title tracker in sync.
       const profile = getSyntheticAgentTitleProfile(payload.agentType)
       if (
@@ -1590,13 +1608,17 @@ function openMainWindow(options: { revealOnDidFinishLoad?: boolean } = {}): Brow
         shouldDriveSyntheticAgentTitleFromHook(payload.agentType, payload.state) &&
         !suppressSyntheticCodexAutoApprovalTitle
       ) {
-        driveSyntheticTitleFromHook(paneKey, payload.state, profile)
+        driveSyntheticTitleFromHook(paneKey, payload, profile)
       }
     }
   )
   agentHookServer.setPaneStatusClearListener((clear) => {
     if (mainWindow?.isDestroyed()) {
       return
+    }
+    // Why: the pane's status is gone, so its held-back permission BEL has nothing left to announce.
+    if ('paneKey' in clear) {
+      syntheticPermissionBellDeferral.cancel(clear.paneKey)
     }
     mainWindow?.webContents.send('agentStatus:clear', clear)
     getDashboardPopoutWindow()?.webContents.send('agentStatus:clear', clear)
@@ -1812,6 +1834,7 @@ const syntheticTitleSpinnerByPaneKey = new Map<
   SyntheticTitleSpinnerEntry<SyntheticAgentTitleProfile>
 >()
 let syntheticTitleSpinnerTimer: ReturnType<typeof setInterval> | null = null
+const syntheticPermissionBellDeferral = new SyntheticPermissionBellDeferral()
 
 type ServeOptions = {
   json: boolean
@@ -2051,9 +2074,10 @@ function resumeSyntheticTitleSpinnerTimer(): void {
 
 function driveSyntheticTitleFromHook(
   paneKey: string,
-  state: AgentStatusState,
+  status: { agentType?: string | null; state: AgentStatusState; toolName?: string },
   profile: SyntheticAgentTitleProfile
 ): void {
+  const { agentType, state, toolName } = status
   const ptyId = getPtyIdForPaneKey(paneKey)
   if (!ptyId) {
     return
@@ -2077,9 +2101,25 @@ function driveSyntheticTitleFromHook(
   stopSyntheticTitleSpinner(paneKey)
   const needsUserInput = state === 'blocked' || state === 'waiting'
   const label = needsUserInput ? profile.permissionLabel : profile.idleLabel
-  sendSyntheticTitle(ptyId, `\x1b]0;${label}\x07${needsUserInput ? '\x07' : ''}`, {
-    force: true
+  // Why: this fabricated BEL is Orca's own attention signal, so it must clear the same Codex
+  // quiet window the renderer applies to the OS notification — ringing it inline let an
+  // "Approve for me" pause raise "Attention requested" before the auto-reviewer replied (#13600).
+  const { frame, deferBell } = buildSyntheticTerminalTitleFrame({
+    agentType,
+    state,
+    toolName,
+    label
   })
+  sendSyntheticTitle(ptyId, frame, { force: true })
+  if (deferBell) {
+    syntheticPermissionBellDeferral.defer(paneKey, () => {
+      // Why: re-resolve the PTY — the pane can be torn down or re-bound inside the quiet window.
+      const livePtyId = getPtyIdForPaneKey(paneKey)
+      if (livePtyId) {
+        sendSyntheticTitle(livePtyId, SYNTHETIC_PERMISSION_BELL, { force: true })
+      }
+    })
+  }
 }
 
 function shouldSuppressCodexAutoApprovalSyntheticTitleFromHook(args: {

--- a/src/main/synthetic-permission-bell-deferral.test.ts
+++ b/src/main/synthetic-permission-bell-deferral.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { SyntheticPermissionBellDeferral } from './synthetic-permission-bell-deferral'
+import { CODEX_ATTENTION_QUIET_MS } from '../shared/codex-attention-quiet-window'
+
+const PANE = 'tab-1:leaf-a'
+const OTHER_PANE = 'tab-1:leaf-b'
+
+describe('SyntheticPermissionBellDeferral', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('rings a pause the agent never resolves, one quiet window later', () => {
+    const deferral = new SyntheticPermissionBellDeferral()
+    const emit = vi.fn()
+
+    deferral.defer(PANE, emit)
+    vi.advanceTimersByTime(CODEX_ATTENTION_QUIET_MS - 1)
+    expect(emit).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1)
+    expect(emit).toHaveBeenCalledTimes(1)
+    expect(deferral.hasPending(PANE)).toBe(false)
+  })
+
+  it('drops the BEL when the pause resolves inside the window (#13600)', () => {
+    const deferral = new SyntheticPermissionBellDeferral()
+    const emit = vi.fn()
+
+    deferral.defer(PANE, emit)
+    vi.advanceTimersByTime(CODEX_ATTENTION_QUIET_MS - 1)
+    expect(deferral.cancel(PANE)).toBe(true)
+
+    vi.advanceTimersByTime(CODEX_ATTENTION_QUIET_MS * 4)
+    expect(emit).not.toHaveBeenCalled()
+  })
+
+  it('cancels only the named pane', () => {
+    const deferral = new SyntheticPermissionBellDeferral()
+    const resolved = vi.fn()
+    const stillWaiting = vi.fn()
+
+    deferral.defer(PANE, resolved)
+    deferral.defer(OTHER_PANE, stillWaiting)
+    deferral.cancel(PANE)
+    vi.advanceTimersByTime(CODEX_ATTENTION_QUIET_MS)
+
+    expect(resolved).not.toHaveBeenCalled()
+    expect(stillWaiting).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-arming a pane replaces its pending BEL instead of queueing a second ring', () => {
+    const deferral = new SyntheticPermissionBellDeferral()
+    const first = vi.fn()
+    const second = vi.fn()
+
+    deferral.defer(PANE, first)
+    vi.advanceTimersByTime(CODEX_ATTENTION_QUIET_MS - 1)
+    deferral.defer(PANE, second)
+    vi.advanceTimersByTime(CODEX_ATTENTION_QUIET_MS)
+
+    expect(first).not.toHaveBeenCalled()
+    expect(second).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports nothing to cancel for an unarmed pane', () => {
+    const deferral = new SyntheticPermissionBellDeferral()
+
+    expect(deferral.cancel(PANE)).toBe(false)
+    expect(deferral.hasPending(PANE)).toBe(false)
+  })
+
+  it('cancelAll drops every pending BEL at window teardown', () => {
+    const deferral = new SyntheticPermissionBellDeferral()
+    const first = vi.fn()
+    const second = vi.fn()
+
+    deferral.defer(PANE, first)
+    deferral.defer(OTHER_PANE, second)
+    deferral.cancelAll()
+    vi.advanceTimersByTime(CODEX_ATTENTION_QUIET_MS * 4)
+
+    expect(first).not.toHaveBeenCalled()
+    expect(second).not.toHaveBeenCalled()
+    expect(deferral.hasPending(OTHER_PANE)).toBe(false)
+  })
+
+  it('honors an injected window for callers that need a different cadence', () => {
+    const deferral = new SyntheticPermissionBellDeferral(50)
+    const emit = vi.fn()
+
+    deferral.defer(PANE, emit)
+    vi.advanceTimersByTime(50)
+
+    expect(emit).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/synthetic-permission-bell-deferral.ts
+++ b/src/main/synthetic-permission-bell-deferral.ts
@@ -1,0 +1,48 @@
+import { CODEX_ATTENTION_QUIET_MS } from '../shared/codex-attention-quiet-window'
+
+/**
+ * Holds back the BEL that main fabricates for a Codex permission pause until the quiet window
+ * elapses, so an "Approve for me" pause Codex resolves itself never rings the terminal bell
+ * (#13600). The OSC title still lands immediately — only the attention signal waits.
+ *
+ * Cancellation is the whole point: any later non-permission state for the pane drops the pending
+ * BEL, and a re-armed pause replaces its predecessor rather than queueing a second ring.
+ */
+export class SyntheticPermissionBellDeferral {
+  private readonly timers = new Map<string, ReturnType<typeof setTimeout>>()
+
+  constructor(private readonly quietMs: number = CODEX_ATTENTION_QUIET_MS) {}
+
+  /** Arm (or re-arm) the deferred BEL for `paneKey`; `emit` runs only if the window elapses uncancelled. */
+  defer(paneKey: string, emit: () => void): void {
+    this.cancel(paneKey)
+    const timer = setTimeout(() => {
+      this.timers.delete(paneKey)
+      emit()
+    }, this.quietMs)
+    // Why: a pending decorative bell must never hold the app open at quit.
+    timer.unref?.()
+    this.timers.set(paneKey, timer)
+  }
+
+  cancel(paneKey: string): boolean {
+    const timer = this.timers.get(paneKey)
+    if (timer === undefined) {
+      return false
+    }
+    clearTimeout(timer)
+    this.timers.delete(paneKey)
+    return true
+  }
+
+  cancelAll(): void {
+    for (const timer of this.timers.values()) {
+      clearTimeout(timer)
+    }
+    this.timers.clear()
+  }
+
+  hasPending(paneKey: string): boolean {
+    return this.timers.has(paneKey)
+  }
+}

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
@@ -17,6 +17,7 @@ import type {
 } from './agent-completion-coordinator-types'
 import type { RuntimeTerminalProcessInspection } from '@/runtime/runtime-terminal-inspection'
 import { isPiCompatibleAgentType } from '../../../../shared/pi-agent-kind'
+import { CODEX_ATTENTION_QUIET_MS } from '../../../../shared/codex-attention-quiet-window'
 import {
   titleHasExplicitAgentIdentity,
   titleIsInconclusiveNativeDroidTitle
@@ -49,8 +50,6 @@ const PENDING_TITLE_TTL_MS = Math.max(2_000, INSPECTION_TIMEOUT_MS + 500)
 const PENDING_TITLE_MAX_TTL_MS = Math.max(30_000, PENDING_TITLE_TTL_MS)
 const COMPLETION_REPLAY_GUARD_MS = 1_000
 const HOOK_DONE_QUIET_MS = 1_500
-// Why: under "Approve for me" Codex resumes almost immediately, so debounce the OS attention notification so a self-resolving pause raises no false banner (#8387).
-const CODEX_ATTENTION_QUIET_MS = 1_500
 
 const POLL_TIER_INTERVAL_MS: Record<PollCadenceTier, number> = {
   active: ACTIVE_POLL_INTERVAL_MS,

--- a/src/shared/codex-attention-quiet-window.test.ts
+++ b/src/shared/codex-attention-quiet-window.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CODEX_ATTENTION_QUIET_MS,
+  SYNTHETIC_PERMISSION_BELL,
+  buildSyntheticTerminalTitleFrame,
+  shouldDeferSyntheticPermissionBell
+} from './codex-attention-quiet-window'
+import { createTerminalTitleTracker } from './terminal-output-side-effects'
+import { getSyntheticAgentTitleProfile } from './synthetic-agent-title'
+
+const CODEX_PERMISSION_LABEL = getSyntheticAgentTitleProfile('codex')?.permissionLabel ?? ''
+const CODEX_IDLE_LABEL = getSyntheticAgentTitleProfile('codex')?.idleLabel ?? ''
+
+/** Count the bells a fabricated frame would ring through the real per-PTY tracker. */
+function bellsFromSyntheticFrames(frames: readonly string[]): number {
+  let bells = 0
+  const tracker = createTerminalTitleTracker({ onBell: () => (bells += 1) })
+  try {
+    for (const frame of frames) {
+      tracker.applySyntheticTitleFrame(frame)
+    }
+  } finally {
+    tracker.dispose()
+  }
+  return bells
+}
+
+describe('shouldDeferSyntheticPermissionBell', () => {
+  it('defers only Codex permission pauses', () => {
+    expect(shouldDeferSyntheticPermissionBell({ agentType: 'codex', state: 'waiting' })).toBe(true)
+    expect(shouldDeferSyntheticPermissionBell({ agentType: 'codex', state: 'blocked' })).toBe(true)
+    expect(shouldDeferSyntheticPermissionBell({ agentType: 'codex', state: 'done' })).toBe(false)
+    expect(shouldDeferSyntheticPermissionBell({ agentType: 'codex', state: 'working' })).toBe(false)
+  })
+
+  it('leaves every other runtime ringing immediately', () => {
+    for (const agentType of ['claude', 'cursor', 'opencode', 'pi', null, undefined]) {
+      expect(shouldDeferSyntheticPermissionBell({ agentType, state: 'waiting' })).toBe(false)
+    }
+  })
+
+  it('never defers a question put to the user — no auto-reviewer answers those', () => {
+    for (const toolName of ['request_user_input', 'AskUserQuestion', 'requestUserInput']) {
+      expect(
+        shouldDeferSyntheticPermissionBell({ agentType: 'codex', state: 'waiting', toolName })
+      ).toBe(false)
+    }
+  })
+
+  it('still defers an ordinary Codex approval pause carrying a tool name', () => {
+    expect(
+      shouldDeferSyntheticPermissionBell({
+        agentType: 'codex',
+        state: 'waiting',
+        toolName: 'exec_command'
+      })
+    ).toBe(true)
+  })
+})
+
+describe('buildSyntheticTerminalTitleFrame', () => {
+  it('holds the attention BEL out of a Codex permission frame while keeping the title', () => {
+    const { frame, deferBell } = buildSyntheticTerminalTitleFrame({
+      agentType: 'codex',
+      state: 'waiting',
+      label: CODEX_PERMISSION_LABEL
+    })
+
+    expect(deferBell).toBe(true)
+    expect(frame).toBe(`\x1b]0;${CODEX_PERMISSION_LABEL}\x07`)
+    // The lone \x07 left in the frame is the OSC terminator, not a bell.
+    expect(bellsFromSyntheticFrames([frame])).toBe(0)
+  })
+
+  it('still rings a non-Codex permission frame inline', () => {
+    const claudePermissionLabel = 'Claude - action required'
+    const { frame, deferBell } = buildSyntheticTerminalTitleFrame({
+      agentType: 'claude',
+      state: 'blocked',
+      label: claudePermissionLabel
+    })
+
+    expect(deferBell).toBe(false)
+    expect(frame).toBe(`\x1b]0;${claudePermissionLabel}\x07\x07`)
+    expect(bellsFromSyntheticFrames([frame])).toBe(1)
+  })
+
+  it('rings a Codex request_user_input pause inline, without the quiet window', () => {
+    const { frame, deferBell } = buildSyntheticTerminalTitleFrame({
+      agentType: 'codex',
+      state: 'waiting',
+      toolName: 'request_user_input',
+      label: CODEX_PERMISSION_LABEL
+    })
+
+    expect(deferBell).toBe(false)
+    expect(bellsFromSyntheticFrames([frame])).toBe(1)
+  })
+
+  it('never rings a terminal idle frame', () => {
+    const { frame, deferBell } = buildSyntheticTerminalTitleFrame({
+      agentType: 'codex',
+      state: 'done',
+      label: CODEX_IDLE_LABEL
+    })
+
+    expect(deferBell).toBe(false)
+    expect(frame).toBe(`\x1b]0;${CODEX_IDLE_LABEL}\x07`)
+    expect(bellsFromSyntheticFrames([frame])).toBe(0)
+  })
+
+  it('rings once when the deferred BEL is released for a real pause', () => {
+    // Guards the over-suppression failure mode: a Codex pause the user must answer still
+    // reaches onBell — just after the quiet window instead of inside it.
+    const { frame } = buildSyntheticTerminalTitleFrame({
+      agentType: 'codex',
+      state: 'waiting',
+      label: CODEX_PERMISSION_LABEL
+    })
+
+    expect(bellsFromSyntheticFrames([frame, SYNTHETIC_PERMISSION_BELL])).toBe(1)
+  })
+
+  it('pins the pre-fix frame as the one that rang inline (#13600 regression anchor)', () => {
+    // The shipped 1.4.179 frame; asserting it still rings proves the new frame's silence is
+    // the fix, not a tracker that stopped seeing fabricated bells.
+    expect(bellsFromSyntheticFrames([`\x1b]0;${CODEX_PERMISSION_LABEL}\x07\x07`])).toBe(1)
+  })
+})
+
+describe('CODEX_ATTENTION_QUIET_MS', () => {
+  it('is the single window both attention paths wait out', () => {
+    expect(CODEX_ATTENTION_QUIET_MS).toBe(1_500)
+  })
+})

--- a/src/shared/codex-attention-quiet-window.ts
+++ b/src/shared/codex-attention-quiet-window.ts
@@ -1,0 +1,48 @@
+import { isAskUserQuestionTool } from './agent-question-answered-intent'
+import type { AgentStatusState } from './agent-status-types'
+
+/**
+ * Why: under Codex "Approve for me" the auto-reviewer resolves the permission pause itself,
+ * so every Codex attention signal waits out one quiet window and is dropped if work resumes
+ * inside it (#8387/#8519). Shared so the renderer's OS notification and main's fabricated
+ * permission BEL cannot drift apart again (#13600).
+ */
+export const CODEX_ATTENTION_QUIET_MS = 1_500
+
+/** The standalone BEL main fabricates to light up a permission pause. */
+export const SYNTHETIC_PERMISSION_BELL = '\x07'
+
+/**
+ * Codex-only: no other runtime self-approves its own permission pause, so their permission BEL
+ * still rings immediately — matching the renderer's Codex-scoped attention debounce.
+ *
+ * `request_user_input` also normalizes to `waiting`, but no auto-reviewer ever answers a question
+ * put to the user, so it keeps ringing inline rather than paying the quiet window.
+ */
+export function shouldDeferSyntheticPermissionBell(args: {
+  agentType: string | null | undefined
+  state: AgentStatusState
+  toolName?: string | undefined
+}): boolean {
+  return (
+    args.agentType === 'codex' &&
+    (args.state === 'waiting' || args.state === 'blocked') &&
+    !isAskUserQuestionTool(args.toolName)
+  )
+}
+
+/**
+ * Terminal-state (non-working) synthetic title frame. The OSC title always lands now so the
+ * visible "action required" status is never delayed; only the attention BEL can be held back.
+ */
+export function buildSyntheticTerminalTitleFrame(args: {
+  agentType: string | null | undefined
+  state: AgentStatusState
+  toolName?: string | undefined
+  label: string
+}): { frame: string; deferBell: boolean } {
+  const needsUserInput = args.state === 'blocked' || args.state === 'waiting'
+  const deferBell = shouldDeferSyntheticPermissionBell(args)
+  const inlineBell = needsUserInput && !deferBell ? SYNTHETIC_PERMISSION_BELL : ''
+  return { frame: `\x1b]0;${args.label}\x07${inlineBell}`, deferBell }
+}


### PR DESCRIPTION
## ELI5

When Codex pauses to ask permission, Orca fakes a terminal "ding" so the pane lights up. Under **"Approve for me"** Codex answers its own question a moment later — but the ding had already fired, so you got a false *Attention requested* notification. This PR makes the ding wait a moment and cancel itself if Codex resolves the pause. The visible "Codex - action required" label still appears instantly.

## What Changed

- `src/shared/codex-attention-quiet-window.ts` (new) — owns `CODEX_ATTENTION_QUIET_MS` (moved out of the renderer coordinator, value unchanged at 1500ms), plus `shouldDeferSyntheticPermissionBell` and `buildSyntheticTerminalTitleFrame`.
- `src/main/synthetic-permission-bell-deferral.ts` (new) — per-pane timer map that arms, re-arms, cancels, and bulk-cancels the held-back BEL.
- `src/main/index.ts` — `driveSyntheticTitleFromHook` now emits the OSC title **without** the trailing BEL for a Codex permission pause and defers the BEL instead. Any later non-permission hook state, a pane status clear, or window teardown cancels it.
- `src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts` — imports the shared constant instead of defining a second copy.

No wire fields, no new env vars, no installer/relay/WSL/SSH changes.

## Why

#8519 added a 1.5s quiet window for Codex attention — but only on the renderer's `dispatchAttention` path (the rich *"… - Codex needs input"* notification).

Orca raises attention for the same hook event a **second** way. `src/main/index.ts` fabricates a synthetic title frame per hook state, and for `waiting`/`blocked` it appends a standalone BEL:

```ts
sendSyntheticTitle(ptyId, `\x1b]0;${label}\x07${needsUserInput ? '\x07' : ''}`, { force: true })
```

That frame goes to `runtime.ingestSyntheticTitleFrame` → `applySyntheticTitleFrame` → `onBell` in `pty-connection.ts`, which marks the worktree/tab unread and, after only `AGENT_TASK_COMPLETE_NOTIFICATION_GRACE_MS` (250ms), dispatches `{ source: 'terminal-bell' }`. That notification renders as **`Bell in <worktree>` / `<repo> · Attention requested`** — exactly the notification in the issue screenshot.

So the reporter's observation is explained without the auto-review needing to exceed 1.5 seconds: **the 1.5s window never covered this path at all.** The reporter said as much ("This reproduction does not prove that the auto-review itself took more than exactly 1.5 seconds"); this is the missing half.

The fix makes Orca's own fabricated attention signal honor the decision #8519 already made, and puts both paths on one shared constant so they cannot drift apart again.

**Scope discipline.** Only the BEL Orca *fabricates* is deferred. A real BEL emitted by Codex's own output is untouched — `onBell` documents that suppressing real PTY bells is a transport-layer guess, and that stays true.

**Not over-suppressing.** Codex `request_user_input` also normalizes to `waiting`, but no auto-reviewer ever answers a question put to the user, so it is exempt and rings inline. Non-Codex runtimes are untouched. And a Codex pause that is *not* resolved still rings — 1.5s later, not never.

### Superseded / related PRs

**Supersedes #11046** (`fix(codex): suppress auto-review-owned permission attention`, @GoodFarming). Its diagnosis of the symptom is right, but the remedy does not fix the reported repro:

1. Its authority function ignores the wire stamp outright — `resolveAuthoritativeCodexApprovalReviewer` contains a literal `void args.wireReviewer` and returns `resolveCodexApprovalReviewer(args.agentArgs)`. Reviewer ownership therefore comes **only** from Orca launch args matching `approvals_reviewer=auto_review`.
2. In #13600 the user selects **"Approve for me" inside the Codex TUI**, not via an Orca launch arg. Reviewer resolves to `unknown`, suppression never engages, and the bell still fires.
3. Because the wire value is voided for the decision, the ~1000 lines plumbing `ORCA_CODEX_APPROVAL_REVIEWER` through installer-utils, the managed hook script, `pty-subprocess`, WSL interop (`WSLENV`), the SSH relay, the relay hook server, hydrate persistence, and a new `codexApprovalReviewer` IPC/wire field carry no effect on the fix — and the hook version bump `1 → 2` is wire surface taken on for it.
4. It never touches the BEL emission; it only re-gates `driveSyntheticTitleFromHook` behind the same launch-arg proof.

Also related to #8387 / #8519 (the timer this restores parity with) and #13991 (closed as a duplicate of #11046).

**#10947 / PR #11174 is independent — not bundled.** #10947 is about *where Codex status hooks get installed* (real `~/.codex/hooks.json` vs managed `CODEX_HOME`) and shares no code with the attention path; this PR touches none of the five files #11174 touches. Verified rather than assumed, per the precedent set in #14611.

**Not a naming coincidence (per #14626).** This gate keys on the normalized `agentType === 'codex'` plus normalized `state`, never on a hook event name, so it does not depend on Codex and Claude happening to share event vocabulary.

## Linked Issue

Fixes #13600

## Visual Proof

`N/A` — and stated plainly rather than implied: **this was not verified on Windows.** #13600 is `os:Windows` + WSL, and the Windows host available to this session is unreachable (`remote_runtime_unavailable`). The change is derived from the code path and covered by automated tests that drive the real `createTerminalTitleTracker` bell detector; no live Windows/WSL repro was performed and none is claimed.

Nothing here is platform-dependent — no `process.platform` branch is added or changed, and the deferral runs identically on macOS, Linux, and Windows. The affected notification is OS-level, so there is no rendered UI surface to screenshot.

## Testing

```
npx vitest run --config config/vitest.config.ts \
  src/shared/codex-attention-quiet-window.test.ts \
  src/main/synthetic-permission-bell-deferral.test.ts \
  src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts \
  src/renderer/src/components/terminal-pane/terminal-title-tracker-parity.test.ts \
  src/renderer/src/components/terminal-pane/terminal-side-effect-facts-handler.test.ts \
  src/renderer/src/components/terminal-pane/parked-terminal-byte-watcher.test.ts \
  src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts \
  src/renderer/src/components/terminal-pane/codex-auto-approval-notification-suppression.test.ts \
  src/renderer/src/hooks/agent-hook-completion-notifications.test.ts \
  src/shared/terminal-output-side-effects.test.ts
# 10 files, 261 tests passed
```

Coverage on the two assertions that matter:

| Assertion | Test |
| --- | --- |
| An auto-reviewable Codex `PermissionRequest` raises **no** bell | `holds the attention BEL out of a Codex permission frame while keeping the title` — frame fed to the real tracker yields 0 bells |
| A genuine pause **still** raises attention | `rings once when the deferred BEL is released for a real pause` — 1 bell |
| A Codex question to the user is **never** delayed | `rings a Codex request_user_input pause inline, without the quiet window` — 1 bell, `deferBell === false` |
| Other runtimes unchanged | `still rings a non-Codex permission frame inline` — 1 bell |
| Resolved pause drops the bell | `drops the BEL when the pause resolves inside the window (#13600)` |
| Regression anchor | `pins the pre-fix frame as the one that rang inline` — the shipped 1.4.179 frame still rings, so the new frame's silence is the fix and not a tracker that stopped seeing fabricated bells |

**Non-vacuity proven by mutation against pre-fix behavior:**
- Reverting the builder to the shipped inline BEL (`needsUserInput ? BELL : ''`) → **2 tests fail**.
- Neutralizing `SyntheticPermissionBellDeferral.cancel` to a no-op → **3 tests fail**.
- Injecting an `any` into the new shared module → oxlint errors, confirming the lint gate is live on these paths rather than silently clean.

Scoped checks (no full typecheck — OOM risk):
- `npx tsc --noEmit` over the two new modules and a probe asserting the `ParsedAgentStatusPayload` → `driveSyntheticTitleFromHook` / `shouldDeferSyntheticPermissionBell` / `buildSyntheticTerminalTitleFrame` call sites: exit 0.
- `npx oxlint` on all new/changed files: clean; pre-commit `oxlint` + react-doctor + `oxfmt` passed.

Platforms actually exercised: **macOS** (unit tests). **Windows / WSL: not exercised** — see Visual Proof. SSH: no transport code touched.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Claude Opus 5 via Claude Code.

## Review

- **Security** — no new wire field, IPC field, env var, or hook-script surface; nothing crosses a trust boundary. Compare #11046, which adds a `codexApprovalReviewer` wire field and bumps the hook version.
- **Cross-platform** — no `process.platform` branch added or changed; deferral behaves identically on macOS, Linux, and Windows.
- **Remote SSH** — no relay, transport, or hook-installer code touched. Synthetic frames are fabricated in main and never entered the PTY byte stream.
- **Remote wire compatibility** — no RPC param, stream opcode, or published-content change; a mixed-version client/host pair is unaffected.
- **Mobile** — the terminal-bell notification path is desktop-only; no mobile surface touched.
- **Backwards compatibility** — `CODEX_ATTENTION_QUIET_MS` moved modules with its value unchanged; every non-Codex path and every non-permission state emits byte-identical frames.
- **Performance** — one `setTimeout` per Codex permission pause, `unref`'d so it cannot hold the app open at quit, replaced on re-arm and cleared on resume/status-clear/teardown.

**Known residual (stated, not hidden):** if a Codex auto-review round trip exceeds the quiet window, both attention paths still fire. That is now a single shared constant instead of two divergent behaviors, but tuning it needs a live Windows/WSL repro this session could not obtain, so it is deliberately left at the value #8519 chose.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — scoped lint/tests/typecheck run locally as listed above; full typecheck deliberately skipped (OOM risk), CI covers it

## Author

- X / Twitter: @BrennanKB5
