### PR TITLE
fix(remote): keep the host's last assistant message on client-owned agent rows (#12906)

### DIFF
--- a/src/renderer/src/runtime/remote-agent-row-last-assistant-message.test.ts
+++ b/src/renderer/src/runtime/remote-agent-row-last-assistant-message.test.ts
@@ -1,0 +1,422 @@
+/**
+ * #12906 / STA-3596: on a paired (remote) runtime the sidebar agent row renders
+ * its identity line and its status subtitle, but the last-assistant-message line
+ * below is permanently blank. Local panes show it.
+ *
+ * Causal boundary: buildMirroredAgentStatusPatch in web-session-tabs-sync.ts.
+ * A remote pane has TWO writers for one store key — this renderer's OSC byte
+ * pipeline (pty-connection claims every pane with a runtimeEnvironmentId) and
+ * the mirrored host `session.tabs` snapshot. When the client owns the key the
+ * merge keeps the client's entry wholesale and copies only paneKey/worktreeId/
+ * tabId/providerSession off the host frame. `lastAssistantMessage` is hook-only
+ * content the byte pipeline can never see (setAgentStatus writes
+ * `payload.lastAssistantMessage` straight through, so each OSC write also blanks
+ * it), so the host's text is discarded on every republication.
+ *
+ * Everything runs through the real seams: the real host-snapshot mirror, the
+ * real store, the real sidebar row builder. The oracle is the field both row
+ * renderers read — DashboardAgentRowMessage and the compact row's secondary
+ * line consume `entry.lastAssistantMessage` and nothing else.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RuntimeMobileSessionTabsResult } from '../../../shared/runtime-types'
+import { makePaneKey } from '../../../shared/stable-pane-id'
+import { toWebTerminalSurfaceTabId } from '../../../shared/terminal-surface-id'
+import { getDefaultSettings } from '../../../shared/constants'
+import type { AppState } from '../store/types'
+import { createTestStore, makeWorktree, seedStore } from '../store/slices/store-test-helpers'
+import {
+  markRendererOwnedAgentStatusWrite,
+  registerRendererOwnedAgentStatusPane,
+  resetRendererOwnedAgentStatusPanesForTests
+} from '../components/terminal-pane/renderer-owned-agent-status-registry'
+import {
+  applyFreshWebSessionTabsSnapshot,
+  resetWebSessionTabsSnapshotFreshnessForTests
+} from './web-session-tabs-sync'
+import { buildWorktreeAgentRows } from '../components/sidebar/worktree-agent-rows'
+import {
+  selectLiveAgentStatusEntriesForWorktree,
+  selectRetainedAgentEntriesForWorktree
+} from '../components/sidebar/worktree-agent-row-selectors'
+import {
+  selectLivePtyIdsForWorktree,
+  selectRuntimePaneTitlesForWorktree
+} from '../components/sidebar/worktree-card-status-inputs'
+
+// Why: web-session-tabs-sync imports the app-level store singleton; this
+// harness drives a createTestStore instance instead, like its sibling suites.
+vi.mock('../store', () => ({
+  useAppStore: {
+    setState: vi.fn(),
+    getState: vi.fn(() => ({})),
+    subscribe: vi.fn(() => () => {})
+  }
+}))
+
+const WT = 'repo1::/path/wt1'
+const ENV = 'remote-env-1'
+const HOST_EPOCH = 'host-epoch-1'
+const T0 = 1_700_000_000_000
+
+/** The pane this renderer streams and therefore claims (pty-connection claims
+ *  every pane whose transport has a runtimeEnvironmentId). */
+const OWNED = {
+  hostTabId: 'host-tab-1',
+  leafId: '11111111-1111-4111-8111-111111111111'
+} as const
+/** A pane mirrored from the same host that this renderer never wrote status for,
+ *  so the host stays authoritative for it. */
+const CEDED = {
+  hostTabId: 'host-tab-2',
+  leafId: '22222222-2222-4222-8222-222222222222'
+} as const
+
+const HOST_MESSAGE = '좌→우 가로 파이프라인으로 다시 그렸습니다'
+
+type PaneRef = { hostTabId: string; leafId: string }
+
+function mirrorTabId(pane: PaneRef): string {
+  return toWebTerminalSurfaceTabId(pane.hostTabId)
+}
+
+function mirrorPaneKey(pane: PaneRef): string {
+  return makePaneKey(mirrorTabId(pane), pane.leafId)
+}
+
+type HostPaneStatus = {
+  state: 'working' | 'done'
+  /** Omitted entirely for the old-host skew case. */
+  lastAssistantMessage?: string
+  stateStartedAt: number
+}
+
+function makeHostSnapshot(args: {
+  snapshotVersion: number
+  hostNow: number
+  statusByHostTabId: Record<string, HostPaneStatus>
+}): RuntimeMobileSessionTabsResult {
+  const panes: PaneRef[] = [OWNED, CEDED]
+  return {
+    worktree: WT,
+    publicationEpoch: HOST_EPOCH,
+    snapshotVersion: args.snapshotVersion,
+    activeGroupId: 'host-group-1',
+    activeTabId: `${OWNED.hostTabId}::${OWNED.leafId}`,
+    activeTabType: 'terminal',
+    tabs: panes.map((pane, index) => {
+      const status = args.statusByHostTabId[pane.hostTabId]
+      return {
+        type: 'terminal' as const,
+        id: `${pane.hostTabId}::${pane.leafId}`,
+        title: 'Claude Code',
+        parentTabId: pane.hostTabId,
+        leafId: pane.leafId,
+        isActive: index === 0,
+        launchAgent: 'claude' as const,
+        status: 'ready' as const,
+        terminal: `terminal-${index + 1}`,
+        ...(status
+          ? {
+              agentStatus: {
+                state: status.state,
+                prompt: '',
+                updatedAt: args.hostNow,
+                stateStartedAt: status.stateStartedAt,
+                agentType: 'claude' as const,
+                paneKey: makePaneKey(pane.hostTabId, pane.leafId),
+                tabId: pane.hostTabId,
+                worktreeId: WT,
+                stateHistory: [],
+                ...(status.lastAssistantMessage !== undefined
+                  ? { lastAssistantMessage: status.lastAssistantMessage }
+                  : {})
+              }
+            }
+          : {})
+      }
+    })
+  }
+}
+
+type TestStore = ReturnType<typeof createTestStore>
+
+/** Mirrors applyWebSessionTabsStorePatch: build the patch from live state, then
+ *  set it. Returns false when the mirror produced no change — pre-fix, a
+ *  republication onto a client-owned pane is exactly that no-op. */
+function applyHostSnapshot(
+  store: TestStore,
+  snapshot: RuntimeMobileSessionTabsResult,
+  now: number
+): boolean {
+  vi.setSystemTime(now)
+  const state = store.getState()
+  const patch = applyFreshWebSessionTabsSnapshot(state, snapshot, ENV, now)
+  store.setState(patch as Partial<AppState>)
+  return patch !== state
+}
+
+/**
+ * Byte-identical replay of what pty-connection does for a remote pane: claim the
+ * key at transport creation, then prove the claim with a byte-derived write. The
+ * OSC pipeline sees a title and a state — never a Stop event — so the payload it
+ * writes carries no lastAssistantMessage.
+ */
+function replayClientByteStatus(
+  store: TestStore,
+  pane: PaneRef,
+  state: 'working' | 'done',
+  clientNow: number
+): void {
+  vi.setSystemTime(clientNow)
+  const paneKey = mirrorPaneKey(pane)
+  registerRendererOwnedAgentStatusPane(paneKey, ENV)
+  markRendererOwnedAgentStatusWrite(paneKey)
+  store
+    .getState()
+    .setAgentStatus(paneKey, { state, prompt: '', agentType: 'claude' }, 'Claude Code', undefined, {
+      tabId: mirrorTabId(pane),
+      worktreeId: WT
+    })
+}
+
+function seedPairedClientStore(): TestStore {
+  const store = createTestStore()
+  seedStore(store, {
+    settings: { ...getDefaultSettings('/tmp'), tabAutoGenerateTitle: true },
+    worktreesByRepo: { repo1: [makeWorktree({ id: WT, repoId: 'repo1', path: '/path/wt1' })] },
+    activeWorktreeId: WT
+  } as Partial<AppState>)
+  return store
+}
+
+/** The value both agent-row renderers read, keyed by pane. Byte-identical to
+ *  useWorktreeAgentRows' inputs, minus React. */
+function observeRowMessages(store: TestStore, now: number): Record<string, string | undefined> {
+  const state = store.getState()
+  const tabs = state.tabsByWorktree[WT] ?? []
+  const rows = buildWorktreeAgentRows({
+    tabs,
+    entries: selectLiveAgentStatusEntriesForWorktree(state, WT),
+    retained: selectRetainedAgentEntriesForWorktree(state, WT),
+    runtimePaneTitlesByTabId: selectRuntimePaneTitlesForWorktree(state, WT),
+    ptyIdsByTabId: selectLivePtyIdsForWorktree(state, WT),
+    terminalLayoutsByTabId: Object.fromEntries(
+      tabs.map((tab) => [tab.id, state.terminalLayoutsByTabId[tab.id]])
+    ),
+    now
+  })
+  const byPaneKey: Record<string, string | undefined> = {}
+  for (const row of rows) {
+    if (row.rowSource !== 'subagent') {
+      byPaneKey[row.paneKey] = row.entry.lastAssistantMessage
+    }
+  }
+  return byPaneKey
+}
+
+describe('#12906: remote agent rows keep the host-published last assistant message', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(T0)
+    resetWebSessionTabsSnapshotFreshnessForTests()
+    resetRendererOwnedAgentStatusPanesForTests()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    resetRendererOwnedAgentStatusPanesForTests()
+  })
+
+  it('shows the message on a pane this renderer owns from the byte stream', () => {
+    const store = seedPairedClientStore()
+    // The agent finished its turn: the host hook has the completion text, and
+    // this renderer's OSC pipeline independently saw the pane go idle.
+    const mirrored = applyHostSnapshot(
+      store,
+      makeHostSnapshot({
+        snapshotVersion: 1,
+        hostNow: T0 - 1_000,
+        statusByHostTabId: {
+          [OWNED.hostTabId]: {
+            state: 'done',
+            lastAssistantMessage: HOST_MESSAGE,
+            stateStartedAt: T0 - 2_000
+          }
+        }
+      }),
+      T0
+    )
+    expect(mirrored, 'harness must reach the mirror, not stop at the freshness gate').toBe(true)
+    replayClientByteStatus(store, OWNED, 'done', T0)
+    // Republication is where the loss happens: the client now owns the key.
+    applyHostSnapshot(
+      store,
+      makeHostSnapshot({
+        snapshotVersion: 2,
+        hostNow: T0 + 1_000,
+        statusByHostTabId: {
+          [OWNED.hostTabId]: {
+            state: 'done',
+            lastAssistantMessage: HOST_MESSAGE,
+            stateStartedAt: T0 - 2_000
+          }
+        }
+      }),
+      T0 + 2_000
+    )
+
+    const messages = observeRowMessages(store, T0 + 2_000)
+    expect(messages, JSON.stringify(messages, null, 2)).toMatchObject({
+      [mirrorPaneKey(OWNED)]: HOST_MESSAGE
+    })
+  })
+
+  it('control: a pane this renderer never wrote status for already showed it', () => {
+    const store = seedPairedClientStore()
+    applyHostSnapshot(
+      store,
+      makeHostSnapshot({
+        snapshotVersion: 1,
+        hostNow: T0 - 1_000,
+        statusByHostTabId: {
+          [CEDED.hostTabId]: {
+            state: 'done',
+            lastAssistantMessage: HOST_MESSAGE,
+            stateStartedAt: T0 - 2_000
+          }
+        }
+      }),
+      T0
+    )
+
+    // Pins the causal boundary to the ownership fence, not the mirror as a whole.
+    expect(observeRowMessages(store, T0)[mirrorPaneKey(CEDED)]).toBe(HOST_MESSAGE)
+  })
+
+  it('never invents a message the host did not publish (old host / new client)', () => {
+    const store = seedPairedClientStore()
+    applyHostSnapshot(
+      store,
+      makeHostSnapshot({
+        snapshotVersion: 1,
+        hostNow: T0 - 1_000,
+        statusByHostTabId: {
+          [OWNED.hostTabId]: { state: 'done', stateStartedAt: T0 - 2_000 }
+        }
+      }),
+      T0
+    )
+    replayClientByteStatus(store, OWNED, 'done', T0)
+    applyHostSnapshot(
+      store,
+      makeHostSnapshot({
+        snapshotVersion: 2,
+        hostNow: T0 + 1_000,
+        statusByHostTabId: {
+          [OWNED.hostTabId]: { state: 'done', stateStartedAt: T0 - 2_000 }
+        }
+      }),
+      T0 + 2_000
+    )
+
+    const messages = observeRowMessages(store, T0 + 2_000)
+    // Guard against a vacuous pass: the row must exist for its blank message to mean anything.
+    expect(Object.keys(messages)).toContain(mirrorPaneKey(OWNED))
+    expect(messages[mirrorPaneKey(OWNED)]).toBeUndefined()
+  })
+
+  it('keeps a mirrored message when a later host frame omits the field (old host / new client)', () => {
+    const store = seedPairedClientStore()
+    applyHostSnapshot(
+      store,
+      makeHostSnapshot({
+        snapshotVersion: 1,
+        hostNow: T0 - 1_000,
+        statusByHostTabId: {
+          [OWNED.hostTabId]: { state: 'done', stateStartedAt: T0 - 2_000 }
+        }
+      }),
+      T0
+    )
+    replayClientByteStatus(store, OWNED, 'done', T0)
+    applyHostSnapshot(
+      store,
+      makeHostSnapshot({
+        snapshotVersion: 2,
+        hostNow: T0 + 1_000,
+        statusByHostTabId: {
+          [OWNED.hostTabId]: {
+            state: 'done',
+            lastAssistantMessage: HOST_MESSAGE,
+            stateStartedAt: T0 - 2_000
+          }
+        }
+      }),
+      T0 + 2_000
+    )
+    expect(
+      observeRowMessages(store, T0 + 2_000)[mirrorPaneKey(OWNED)],
+      'precondition: the fenced pane adopted the host message'
+    ).toBe(HOST_MESSAGE)
+
+    // A host that predates #9914's fix drops lastAssistantMessage when it demotes
+    // a stale status under a neutral title. That must not blank the mirrored line.
+    applyHostSnapshot(
+      store,
+      makeHostSnapshot({
+        snapshotVersion: 3,
+        hostNow: T0 + 3_000,
+        statusByHostTabId: {
+          [OWNED.hostTabId]: { state: 'done', stateStartedAt: T0 - 2_000 }
+        }
+      }),
+      T0 + 4_000
+    )
+
+    expect(observeRowMessages(store, T0 + 4_000)[mirrorPaneKey(OWNED)]).toBe(HOST_MESSAGE)
+  })
+
+  it('does not paste last turn’s message under a turn the client already restarted', () => {
+    const store = seedPairedClientStore()
+    applyHostSnapshot(
+      store,
+      makeHostSnapshot({
+        snapshotVersion: 1,
+        hostNow: T0 - 10_000,
+        statusByHostTabId: {
+          [OWNED.hostTabId]: {
+            state: 'done',
+            lastAssistantMessage: HOST_MESSAGE,
+            stateStartedAt: T0 - 20_000
+          }
+        }
+      }),
+      T0 - 9_000
+    )
+    // A new prompt starts: the byte pipeline sees the spinner before the host's
+    // hook catches up, so its `done` frame is now the previous turn's evidence.
+    replayClientByteStatus(store, OWNED, 'working', T0)
+    applyHostSnapshot(
+      store,
+      makeHostSnapshot({
+        snapshotVersion: 2,
+        hostNow: T0 + 1_000,
+        statusByHostTabId: {
+          [OWNED.hostTabId]: {
+            state: 'done',
+            lastAssistantMessage: HOST_MESSAGE,
+            stateStartedAt: T0 - 20_000
+          }
+        }
+      }),
+      T0 + 2_000
+    )
+
+    // Local parity: setAgentStatus writes payload.lastAssistantMessage straight
+    // through, so a local pane starting a new turn shows no completion text.
+    const messages = observeRowMessages(store, T0 + 2_000)
+    expect(Object.keys(messages)).toContain(mirrorPaneKey(OWNED))
+    expect(messages[mirrorPaneKey(OWNED)]).toBeUndefined()
+  })
+})

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -1229,17 +1229,12 @@ function buildMirroredAgentStatusPatch(
             providerSession:
               existing.providerSession ??
               (hostIdentityPredatesCurrentTurn ? undefined : entry.providerSession),
-            // Why: hook-only content, same class as providerSession — the byte
-            // pipeline never sees a Stop event, and setAgentStatus writes
-            // `payload.lastAssistantMessage` straight through, so each OSC write
-            // blanks it. Keeping the client entry wholesale left remote agent rows
-            // with a permanently empty message line (#12906). Only the host frame
-            // can add one, so falling back to `existing` retains what an earlier
-            // frame already delivered instead of blanking on a host that stopped
-            // publishing it.
-            lastAssistantMessage: hostIdentityPredatesCurrentTurn
-              ? existing.lastAssistantMessage
-              : (entry.lastAssistantMessage ?? existing.lastAssistantMessage)
+            // Why: hook-only content the byte pipeline can never see, and every OSC
+            // write blanks it, so a fenced pane's message line stayed empty forever
+            // (#12906). Host-first unlike providerSession: only the host can mint one.
+            lastAssistantMessage:
+              (hostIdentityPredatesCurrentTurn ? undefined : entry.lastAssistantMessage) ??
+              existing.lastAssistantMessage
           }
         : entry
     nextByPaneKey.set(entry.paneKey, nextEntry)

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -1228,7 +1228,18 @@ function buildMirroredAgentStatusPatch(
             tabId: entry.tabId,
             providerSession:
               existing.providerSession ??
-              (hostIdentityPredatesCurrentTurn ? undefined : entry.providerSession)
+              (hostIdentityPredatesCurrentTurn ? undefined : entry.providerSession),
+            // Why: hook-only content, same class as providerSession — the byte
+            // pipeline never sees a Stop event, and setAgentStatus writes
+            // `payload.lastAssistantMessage` straight through, so each OSC write
+            // blanks it. Keeping the client entry wholesale left remote agent rows
+            // with a permanently empty message line (#12906). Only the host frame
+            // can add one, so falling back to `existing` retains what an earlier
+            // frame already delivered instead of blanking on a host that stopped
+            // publishing it.
+            lastAssistantMessage: hostIdentityPredatesCurrentTurn
+              ? existing.lastAssistantMessage
+              : (entry.lastAssistantMessage ?? existing.lastAssistantMessage)
           }
         : entry
     nextByPaneKey.set(entry.paneKey, nextEntry)


### PR DESCRIPTION
## ELI5

When your laptop is paired to a remote Orca runtime, every agent pane has **two** things writing its status into one slot: the remote host (which reads the real agent hooks and knows what the agent last said) and your own laptop (which watches the terminal bytes and can only tell "spinner on / spinner off").

To stop the two from fighting, we let the laptop win for panes it is actively streaming. But the "laptop wins" rule threw away the *whole* host row — including the one thing the laptop can never know: the agent's last message. So the remote agent row showed the agent's name and its status, and the message line underneath stayed blank forever.

This keeps that one field from the host, exactly the way we already keep the host's session id.

## What Changed

`buildMirroredAgentStatusPatch` (`src/renderer/src/runtime/web-session-tabs-sync.ts`) now carries `lastAssistantMessage` from the host frame onto a client-owned entry, alongside the `providerSession` it already carried:

```ts
lastAssistantMessage:
  (hostIdentityPredatesCurrentTurn ? undefined : entry.lastAssistantMessage) ??
  existing.lastAssistantMessage
```

- `hostIdentityPredatesCurrentTurn` is the predicate this line already computes for `providerSession`; reusing it keeps local parity (a pane that has started a new turn shows no completion text, because `setAgentStatus` writes `payload.lastAssistantMessage` straight through and a `working` payload carries none).
- The `?? existing` fallback means a host that *stops* publishing the field cannot blank a line it already delivered. Host-first, unlike the `providerSession` line above it, because only the host can ever mint one.

**Receive-side only. No wire change, no new field, no new opcode, no capability, nothing new published.** 6 added lines in one file, plus a new test file.

## Why

### Where the message is lost: (c), not (a) or (b)

The message is **published by the host, received by the client, and then discarded by the client's own status-arbitration merge.**

A remote pane has two writers for one `agentStatusByPaneKey` key:

| Writer | Path | Carries `lastAssistantMessage`? |
|---|---|---|
| Host | `session.tabs` snapshot → `remapHostAgentStatus` | **Yes** — it reads the real hook rows |
| This renderer | `pty-connection.ts` OSC pipeline (`shouldOwnAgentStatusInRenderer = runtimeEnvironmentId !== null`, i.e. *every* remote pane) | **No** — bytes never carry a `Stop` event |

`renderer-owned-agent-status-registry.ts` fences the host out of a pane the client both claimed and wrote, so the mirror keeps the client entry wholesale and copies only `paneKey` / `worktreeId` / `tabId` / `providerSession` off the host frame. Two things then compound:

1. `setAgentStatus` writes `lastAssistantMessage: payload.lastAssistantMessage` with **no merge**, so every byte-derived OSC write blanks whatever the host had delivered.
2. The fence prevents the next host republication from putting it back.

Net: on a remote pane, the field is destroyed and can never be restored. `terminalTitle`/`agentType`/`state` survive because the client *does* produce those — which is exactly the reported shape: **identity and status render, the message line never does.**

Both row renderers read that field and nothing else — `DashboardAgentRowMessage` renders its blank spacer when `lastAssistantMessage` is falsy, and `getCompactAgentSecondary` falls through to the agent-type label.

That also explains why the reporter's `orca worktree ps --json` on the node shows a populated `agents[].lastAssistantMessage`: `worktree ps` is a different projection that never passes through this merge.

### The #14621 pattern, again: a surface claiming authority it does not have

`isClientAuthoritativeAgentStatusPane` grants the client authority over the **whole** status
row on the strength of "claimed at transport creation and wrote once" — regardless of whether
the client can produce the field being arbitrated. That is the same shape as #14621's hook
diagnostic reporting `installed` for a host where nothing was: an authority claim wider than
the evidence behind it. `providerSession` was already recognised as an exception; every other
host-only field was silently swept up with it.

The narrow fix is to carve out the field the ticket names. The general shape — the fence still
discards `interrupted`, `toolName`/`toolInput`, `model`, `subagents`, `orchestration` for the
same reason — is left for whoever has a ticket that needs one of those, rather than widened
speculatively here.

Checked for the #14649 shape too (one bad element voiding a whole aggregate): the mirror loops
per surface and per pane key with no `Promise.all` and no all-or-nothing collection, so a single
pane cannot void the batch.

### Why the fix is on the client

The hard rule is *don't make the client infer content it was not sent*. This does the opposite — the client **was** sent the text and is throwing it away. Nothing is inferred, synthesized, or reconstructed: if the host frame carries no message and none was ever mirrored, the line stays blank (covered by a test).

### Relationship to #9930 — complementary, NOT superseded

**No PRs are superseded by this one.**

[#9930](https://github.com/stablyai/orca/pull/9930) (@innocarpe) fixes a **host-side** drop: `listMobileSessionTabs` demotes a stale `working` status under a neutral live title and omits `lastAssistantMessage` from the demoted projection. That is a real, separate loss on the publication side and it should still land.

This PR fixes the **client-side** drop that happens *after* a host frame carrying the message arrives. #12906 filed separately from #9914 precisely because it suspected a different cause — it is. Neither fix subsumes the other:

- #9930 alone: the host publishes the message in the demoted case, and this client still discards it for any pane it streams.
- This alone: panes whose host status is demoted under a neutral shell title still publish no message to adopt.

### Remote wire compatibility

Assessed against all three rules in `docs/reference/remote-wire-compatibility.md`:

- **Rule 1 (new optional field)** — N/A. `lastAssistantMessage` has always been on `AgentStatusEntry` and has always been published on the terminal surface; this only stops the receiver discarding it.
- **Rule 2 (new opcode)** — N/A. No opcode, no framing change, no handshake change.
- **Rule 3 (changed host projection)** — N/A. **The host publishes nothing new.** The only change is which fields the client keeps when it merges a frame it already receives, so no old client sees anything different and no capability gate is warranted.

Both skew directions are covered by tests anyway:

- **Old host / new client** — an old host that never carries the field must not make the client fabricate one, and must not blank a message an earlier frame already delivered. Two dedicated tests.
- **New host / old client** — unchanged by construction: this PR sends nothing, so an old client sees byte-identical frames. The unchanged path is pinned by the `control:` test (a pane the client never wrote status for takes the host entry verbatim, exactly as before).

`tests/e2e/cross-version-wire/cross-version-terminal-wire.unit.test.ts` runs green.

### On STA-3455 (agent status has no explicit owner)

This adds **no new cross-machine clock comparison.** The two that exist on this line (`existing.updatedAt > entry.updatedAt`, and `hostIdentityPredatesCurrentTurn`'s `stateStartedAt` compare) are untouched; the new field reuses the second one's already-computed result rather than introducing a third.

## Linked Issue

Fixes #12906

Related (not fixed here): #9914 — the host-side half, addressed by #9930.

## Visual Proof

The change is data plumbing with no layout, styling, or component change; the rendered difference is the existing `DashboardAgentRowMessage` slot going from its blank spacer to the agent's text. Reproducing it on screen needs a live paired remote runtime with an agent mid-turn, which this environment has no sanctioned host for.

Behavioural before/after is pinned instead by a test that runs the **real** seams end to end — the real `applyFreshWebSessionTabsSnapshot` mirror, the real store, the real `buildWorktreeAgentRows` — and asserts on the exact field both row renderers read:

**Before (working tree at `ab9d1a29a9`, new test file only):**

```
 × shows the message on a pane this renderer owns from the byte stream
 × keeps a mirrored message when a later host frame omits the field (old host / new client)
   Tests  2 failed | 3 passed (5)

  {
-   "web-terminal-host-tab-1:11111111-...": "좌→우 가로 파이프라인으로 다시 그렸습니다",
+   "web-terminal-host-tab-1:11111111-...": undefined,
  }
```

**After:**

```
   Tests  5 passed (5)
```

The 3 tests that pass in both directions are the non-regression half: the host-authoritative control path and the two "never fabricate a message" invariants are unchanged by the fix.

The render half of the chain — `entry.lastAssistantMessage` ⇒ the visible secondary line — is already pinned by the repo's own suite and needs no new coverage:

```
src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx:240
  expect(markup).toContain('<span class="text-muted-foreground/65"> - Inspecting changes</span>')
```

So this PR restores the field, and that test proves the field is the line.

## Testing

New: `src/renderer/src/runtime/remote-agent-row-last-assistant-message.test.ts` (5 cases). It replays byte-for-byte what `pty-connection` does for a remote pane — claim the key at transport creation, prove the claim with a byte-derived write — then drives real host snapshots through the real mirror.

| Case | Asserts | Pre-fix |
|---|---|---|
| owned pane keeps the host message | the fenced pane's row shows the host text after republication | **fails** |
| control: pane the client never wrote | host-authoritative path unchanged | passes |
| never invents a message (old host / new client) | host frame with no field ⇒ row stays blank, row still exists | passes |
| keeps a mirrored message when a later host frame omits it (old host / new client) | an old host's demoted frame cannot blank an already-mirrored line | **fails** |
| does not paste last turn's message under a restarted turn | local parity: a new turn shows no completion text | passes |

Every case guards against a vacuous pass — the blank-line assertions also assert the row exists.

```bash
pnpm exec vitest run --config config/vitest.config.ts \
  src/renderer/src/runtime/remote-agent-row-last-assistant-message.test.ts        # 5 passed

# neighbours on the same merge path
pnpm exec vitest run --config config/vitest.config.ts \
  src/renderer/src/runtime/web-session-tabs-sync.test.ts \
  src/renderer/src/runtime/web-session-tabs-sync-remote-status-title-flap.test.ts \
  src/renderer/src/runtime/web-session-tabs-sync-mirror-identity.test.ts \
  src/renderer/src/runtime/paired-reconnect-sidebar-agent-count.test.ts           # 107 passed

pnpm exec vitest run --config config/vitest.config.ts \
  src/renderer/src/runtime/web-session-tabs-sync-visibility-collision.test.tsx \
  src/renderer/src/runtime/web-session-tabs-sync-window-visibility.test.tsx \
  src/renderer/src/runtime/remote-runtime-session-tabs-inflight.test.ts \
  src/renderer/src/store/slices/agent-status                                      # 194 passed

pnpm exec vitest run --config config/vitest.config.ts \
  src/renderer/src/components/sidebar/useWorktreeAgentRows.test.ts \
  src/renderer/src/components/sidebar/worktree-agent-row-selectors.test.ts        # 40 passed

pnpm exec vitest run --config config/vitest.config.ts \
  src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx \
  src/renderer/src/components/dashboard/DashboardAgentRow                          # 45 passed

pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/runtime     # 783 passed (78 files)

# wire-compatibility enforcement, both skew directions
pnpm exec vitest run --config config/vitest.config.ts \
  tests/e2e/cross-version-wire/cross-version-terminal-wire.unit.test.ts           # 5 passed

node config/scripts/check-changed-code-quality.mjs
# code quality: 0 new finding(s) across 2 changed file(s).
# type-aware code quality: 0 new finding(s) across 2 changed file(s).
# React Doctor: 0 new finding(s) across 2 changed file(s).

npx oxfmt --check <changed files>   # All matched files use the correct format.
```

Platforms: the changed code is renderer-side TypeScript with no OS-dependent branch. The path it fixes is by definition the remote/paired one (macOS client ↔ Linux `orca serve` in the report); local panes never reach this merge.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

- **Security** — no new IPC, RPC, or trust boundary; the string already crosses this exact channel and is already capped at `AGENT_STATUS_ASSISTANT_MESSAGE_MAX_LENGTH` (8 KB) upstream.
- **Cross-platform** — renderer TypeScript, no platform branch.
- **Remote SSH / pairing** — this *is* the remote path; local status flow is untouched.
- **Mobile** — mobile mirrors through the same function and gets the same fix.
- **Backwards compatibility** — receive-side only; see the Rule 1/2/3 assessment above.
- **Performance** — one nullish coalesce on an object already being built per changed pane. `agentStatusEntryEqual` already compares `lastAssistantMessage`, so no extra republication churn; a message-only change is deliberately not sort- or aggregate-relevant, so it does not bump `agentStatusEpoch`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
  - Scoped suites above run locally and pass. Full `pnpm typecheck` deliberately not run locally (OOM risk in this environment); the changed-code type-aware gate is green over both changed files and CI covers the rest.

## Out of scope

- **The host-side half** — leaving `lastAssistantMessage` on the demoted projection in `listMobileSessionTabs` is #9930's change, not duplicated here.
- **STA-3521** (remote agent rows cannot open their tabs when several remote agents share a project). Not the same root cause — that is activation, not content — so it is deliberately not bundled. Handing over the lead this investigation turned up, unreproduced but code-verified:

  Activating a remote terminal tab requires **two** things, and the reference implementation is the workspace tab palette (`workspace-tab-palette-activation.ts:105-113`):

  ```ts
  if (isWebRuntimeSessionActive(runtimeEnvironmentId)) {
    void activateWebRuntimeSessionTab({ worktreeId, tabId: entityId, environmentId })  // host RPC
  }
  state.setActiveTab(result.entityId)                                                  // local store
  ```

  The RPC is what records the focus intent (`recordWebSessionFocusIntent`) and sends `intent: 'user'` — commented in `web-runtime-session.ts:1157` as "the gesture that is supposed to wake a slept pane".

  `activateTabAndFocusPane` — the sidebar agent row's path — does **only** the local half. `setActiveTab` → `activateTab` (`store/slices/tabs.ts:1037`) never reaches `web-runtime-session`, so the host is never told and no focus intent is recorded. The other three activation entry points (`Terminal.tsx`, `useTabGroupWorkspaceModel.ts`, `tab-number-shortcuts.ts`) all do call the RPC; `activateTabAndFocusPane`'s five callers — sidebar agent rows, Manage Sessions, the Activity page, terminal-handle links, and the dashboard popout bridge — do not.

  That asymmetry fits the report's shape, including why multiplicity matters: with one agent the host's active tab already *is* the target, so a local-only flip is indistinguishable from a correct activation; with several it is not, and the target pane is never asked to wake.

  Ruled out along the way, so nobody re-walks it: the paired mirror subscribes via `session.tabs.subscribeAll`, so non-active worktrees **do** get their tabs mirrored — a missing-tab theory is not the gap. The one other silent no-op is `handleActivateAgentTab` (`WorktreeCardAgents.tsx:176-181`), reachable only by rows from `buildWorktreeAgentRows`' worktree-attributed fallback (`worktree-agent-rows.ts:271-296`); worth instrumenting second.
- Wiring consumers to #14706's `observation` provenance facet.

## Author

- X / Twitter: @BrennanKB5
