### PR TITLE
fix(agents): surface Kilo panes and their turn state from Kilo's native title (#6909)

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -368,6 +368,35 @@ describe('buildTitleDerivedAgentRows', () => {
     expect(rowsFor('zsh', 'opencode')).toHaveLength(0)
   })
 
+  it('surfaces Kilo panes from its native title, carrying its declared indicator', () => {
+    // Titles as `@kilocode/cli` 7.4.22 emits them: bare base on the home screen,
+    // `${glyph} Kilo CLI | ${session}` in a session. Pre-fix every one of these
+    // produced no label and no status, so the pane had no row at all.
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1'), makeTab('tab-2'), makeTab('tab-3')],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        'tab-1': { 1: 'Kilo CLI' },
+        'tab-2': { 1: '◔ Kilo CLI | fix the flaky pty test' },
+        'tab-3': { 1: '⚠ Kilo CLI | fix the flaky pty test' }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-1'], 'tab-2': ['pty-2'], 'tab-3': ['pty-3'] },
+      terminalLayoutsByTabId: {
+        'tab-1': makeSingleLayout(LEAF_ID_1),
+        'tab-2': makeSingleLayout(LEAF_ID_1),
+        'tab-3': makeSingleLayout(LEAF_ID_1)
+      },
+      now: 2000
+    })
+
+    expect(rows.map((row) => [row.agentType, row.state, row.entry.lastAssistantMessage])).toEqual([
+      ['kilo', 'idle', 'Idle'],
+      ['kilo', 'working', 'Running'],
+      ['kilo', 'waiting', 'Needs input']
+    ])
+  })
+
   it('does not brand a split pane with the tab-scoped launch agent', () => {
     const rows = buildWorktreeAgentRows({
       tabs: [makeTab('tab-1', { launchAgent: 'opencode' })],

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -36,6 +36,7 @@ const TITLE_AGENT_LABEL_TO_TYPE: Record<string, AgentType> = {
   Devin: 'devin',
   Antigravity: 'antigravity',
   OpenCode: 'opencode',
+  Kilocode: 'kilo',
   Aider: 'aider',
   Cursor: 'cursor',
   Droid: 'droid',

--- a/src/shared/agent-title-identity.ts
+++ b/src/shared/agent-title-identity.ts
@@ -10,6 +10,7 @@ import {
   isPiAgentTitle,
   titleHasAgentName
 } from './agent-title-core'
+import { isKiloNativeTitle } from './kilo-terminal-title'
 import { isOpenCodeNativeTitle } from './opencode-terminal-title'
 import { getPiCompatibleSyntheticAgentLabel } from './pi-compatible-synthetic-title'
 
@@ -18,7 +19,12 @@ import { getPiCompatibleSyntheticAgentLabel } from './pi-compatible-synthetic-ti
  * Used to scope prompt-cache-timer behavior to Claude sessions only.
  */
 export function isClaudeAgent(title: string): boolean {
-  if (!title || isClaudeManagementTitle(title) || isOpenCodeNativeTitle(title)) {
+  if (
+    !title ||
+    isClaudeManagementTitle(title) ||
+    isOpenCodeNativeTitle(title) ||
+    isKiloNativeTitle(title)
+  ) {
     return false
   }
   const lower = title.toLowerCase()
@@ -51,6 +57,11 @@ export function getAgentLabel(title: string): string | null {
   // include status glyphs from other agents without changing OpenCode identity.
   if (isOpenCodeNativeTitle(title)) {
     return 'OpenCode'
+  }
+  // Why: same reasoning for Kilo's native frame — its session text is free-form
+  // and may carry another agent's name or spinner.
+  if (isKiloNativeTitle(title)) {
+    return 'Kilocode'
   }
   // Why: Claude task titles can mention another CLI; the prefix is the identity
   // signal, not arbitrary task text.

--- a/src/shared/agent-title-status.ts
+++ b/src/shared/agent-title-status.ts
@@ -24,6 +24,7 @@ import {
   isPiTerminalTitle
 } from './agent-title-core'
 import type { AgentStatus } from './agent-title-core'
+import { detectKiloTitleStatus } from './kilo-terminal-title'
 import { isOpenCodeNativeTitle } from './opencode-terminal-title'
 import { getPiCompatibleSyntheticAgentStatus } from './pi-compatible-synthetic-title'
 import { isGrokRotatingWorkingTitle } from './terminal-title-agent-type'
@@ -164,6 +165,15 @@ export function detectAgentStatusFromTitle(title: string): AgentStatus | null {
 
   if (isOpenCodeNativeTitle(title)) {
     return containsAgentSpinnerGlyph(title) ? 'working' : 'idle'
+  }
+
+  // Why: Kilo declares its own turn state in the title glyph, so read that
+  // rather than the generic spinner heuristic — a Kilo frame whose session text
+  // carries an unrelated spinner would otherwise report `working` while Kilo is
+  // actually waiting on a permission prompt.
+  const kiloStatus = detectKiloTitleStatus(title)
+  if (kiloStatus) {
+    return kiloStatus
   }
 
   if (title.includes(GEMINI_PERMISSION)) {

--- a/src/shared/agent-type-label.ts
+++ b/src/shared/agent-type-label.ts
@@ -12,6 +12,7 @@ const WELL_KNOWN_LABELS: Record<string, string> = {
   copilot: 'GitHub Copilot',
   opencode: 'OpenCode',
   'mimo-code': 'MiMo Code',
+  kilo: 'Kilocode',
   cursor: 'Cursor',
   aider: 'Aider',
   pi: 'Pi',

--- a/src/shared/kilo-terminal-title.test.ts
+++ b/src/shared/kilo-terminal-title.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+import {
+  detectKiloTitleStatus,
+  isKiloNativeTitle,
+  parseKiloTitleIndicator
+} from './kilo-terminal-title'
+import { detectAgentStatusFromTitle } from './agent-title-status'
+import { getAgentLabel as getIdentityAgentLabel, isClaudeAgent } from './agent-title-identity'
+import {
+  getAgentLabel,
+  isClaudeAgent as isClaudeAgentFromTitleType,
+  resolveTerminalTitleAgentType
+} from './terminal-title-agent-type'
+import { isOpenCodeNativeTitle } from './opencode-terminal-title'
+
+// Titles below are the shapes `@kilocode/cli` 7.4.22 actually emits: the bare
+// base `Kilo CLI` on the home screen (captured from its raw OSC 0 stream) and
+// `${glyph} Kilo CLI | ${session title}` in a session, with the glyph drawn from
+// Kilo's `unicode` (◔ ⚠ ✓) or `emojis` (💭 🔶 ✅) `title_icon` tables.
+const HOME = 'Kilo CLI'
+const SESSION = 'Kilo CLI | fix the flaky pty test'
+const WORKING = '◔ Kilo CLI | fix the flaky pty test'
+const ATTENTION = '⚠ Kilo CLI | fix the flaky pty test'
+const FINISHED = '✓ Kilo CLI | fix the flaky pty test'
+
+describe('parseKiloTitleIndicator', () => {
+  it('reads every indicator Kilo can emit, in both of its glyph tables', () => {
+    expect(parseKiloTitleIndicator(HOME)).toBe('none')
+    expect(parseKiloTitleIndicator(SESSION)).toBe('none')
+    expect(parseKiloTitleIndicator(WORKING)).toBe('working')
+    expect(parseKiloTitleIndicator(ATTENTION)).toBe('attention')
+    expect(parseKiloTitleIndicator(FINISHED)).toBe('finished')
+    expect(parseKiloTitleIndicator('💭 Kilo CLI | ship it')).toBe('working')
+    expect(parseKiloTitleIndicator('🔶 Kilo CLI | ship it')).toBe('attention')
+    expect(parseKiloTitleIndicator('✅ Kilo CLI | ship it')).toBe('finished')
+    // Fonts and terminals may round-trip ⚠ with a variation selector.
+    expect(parseKiloTitleIndicator('⚠️ Kilo CLI | ship it')).toBe('attention')
+  })
+
+  it('accepts a multiplexer or SSH wrapper prefix, and tolerates padding', () => {
+    expect(parseKiloTitleIndicator('tmux | Kilo CLI | ses_123')).toBe('none')
+    expect(parseKiloTitleIndicator('ssh build-host | ◔ Kilo CLI | ses_123')).toBe('working')
+    expect(parseKiloTitleIndicator('user@host: ~/code | Kilo CLI')).toBe('none')
+    expect(parseKiloTitleIndicator('  Kilo CLI  ')).toBe('none')
+    expect(parseKiloTitleIndicator('Kilo CLI |\tses_123')).toBe('none')
+    // Kilo's own non-session route still frames the base marker.
+    expect(parseKiloTitleIndicator('Kilo CLI | KiloClaw')).toBe('none')
+  })
+
+  it('rejects prose that merely mentions the CLI, and non-Kilo titles', () => {
+    // Kilo's own docs/pager text — a trailing word is not Kilo's ` | ` tail.
+    expect(isKiloNativeTitle('Kilo CLI Configuration Reference')).toBe(false)
+    expect(isKiloNativeTitle('installing Kilo CLI')).toBe(false)
+    expect(isKiloNativeTitle('kilo cli | ses_123')).toBe(false) // case-sensitive marker
+    expect(isKiloNativeTitle('Kilo CLI |')).toBe(false) // empty session tail
+    expect(isKiloNativeTitle('Kilo CLI|ses_123')).toBe(false) // no spaces around the pipe
+    expect(isKiloNativeTitle('kilo')).toBe(false)
+    expect(isKiloNativeTitle('OC | ses_123')).toBe(false)
+    expect(isKiloNativeTitle('')).toBe(false)
+    expect(isKiloNativeTitle(undefined)).toBe(false)
+    // A glyph-led segment belongs to whoever emitted it; it is not a wrapper.
+    expect(isKiloNativeTitle('◔ build step | Kilo CLI')).toBe(false)
+  })
+})
+
+describe('detectKiloTitleStatus', () => {
+  it('maps Kilo indicators onto Orca title status', () => {
+    expect(detectKiloTitleStatus(WORKING)).toBe('working')
+    // attention covers permission / question / suggestion / network / plan approval.
+    expect(detectKiloTitleStatus(ATTENTION)).toBe('permission')
+    expect(detectKiloTitleStatus(FINISHED)).toBe('idle')
+    expect(detectKiloTitleStatus(HOME)).toBe('idle')
+    expect(detectKiloTitleStatus('a plain shell')).toBeNull()
+  })
+})
+
+describe('Kilo panes in the title-detection vocabulary', () => {
+  it('gives every Kilo frame an identity, a type and a status', () => {
+    for (const title of [HOME, SESSION, WORKING, ATTENTION, FINISHED]) {
+      expect(getAgentLabel(title)).toBe('Kilocode')
+      expect(getIdentityAgentLabel(title)).toBe('Kilocode')
+      expect(resolveTerminalTitleAgentType(title)).toBe('kilo')
+    }
+    expect(detectAgentStatusFromTitle(HOME)).toBe('idle')
+    expect(detectAgentStatusFromTitle(WORKING)).toBe('working')
+    expect(detectAgentStatusFromTitle(ATTENTION)).toBe('permission')
+    expect(detectAgentStatusFromTitle(FINISHED)).toBe('idle')
+  })
+
+  it('keeps a Kilo pane out of Claude-only behavior even when its session text carries a spinner', () => {
+    // Why: `⠋` inside free-form session text is the task's, not Claude's. Both
+    // isClaudeAgent copies gate Claude's prompt-cache timer and parked-terminal
+    // byte watcher, so both must reject the frame.
+    const spinnerInTask = '⚠ Kilo CLI | ⠋ run the flaky suite'
+    expect(isClaudeAgent(spinnerInTask)).toBe(false)
+    expect(isClaudeAgentFromTitleType(spinnerInTask)).toBe(false)
+    expect(getAgentLabel(spinnerInTask)).toBe('Kilocode')
+    // The declared indicator wins over the borrowed spinner: Kilo needs input.
+    expect(detectAgentStatusFromTitle(spinnerInTask)).toBe('permission')
+  })
+
+  it('leaves the other native-title families untouched', () => {
+    // Why: Kilo is an OpenCode fork sharing this title shape; adding it must not
+    // move OpenCode, MiMo Code or Claude panes.
+    expect(isKiloNativeTitle('OC | ses_123')).toBe(false)
+    expect(isOpenCodeNativeTitle('Kilo CLI | ses_123')).toBe(false)
+    expect(getAgentLabel('OC | ses_123')).toBe('OpenCode')
+    expect(detectAgentStatusFromTitle('⠋ OC | ses_123')).toBe('working')
+    expect(detectAgentStatusFromTitle('OC | ses_123')).toBe('idle')
+    expect(getAgentLabel('✳ Fix the auth bug')).toBe('Claude Code')
+    expect(detectAgentStatusFromTitle('✳ Fix the auth bug')).toBe('idle')
+    expect(isClaudeAgent('✳ Fix the auth bug')).toBe(true)
+    expect(isClaudeAgentFromTitleType('✳ Fix the auth bug')).toBe(true)
+    expect(getAgentLabel('⠋ Codex')).toBe('Codex')
+    expect(resolveTerminalTitleAgentType('MiMo Code')).toBe('mimo-code')
+  })
+})

--- a/src/shared/kilo-terminal-title.ts
+++ b/src/shared/kilo-terminal-title.ts
@@ -1,0 +1,85 @@
+import type { AgentStatus } from './agent-title-core'
+
+/**
+ * Kilo CLI writes a native terminal title that already carries its identity AND
+ * its turn state, so Orca reads both from one declared grammar instead of
+ * inferring either from decoration.
+ *
+ * Measured on `@kilocode/cli` 7.4.22 (raw `OSC 0` capture plus the shipped
+ * title builder): the home screen emits the bare base `Kilo CLI`; inside a
+ * session it emits `${glyph} Kilo CLI | ${session title}` where the session
+ * title is truncated by Kilo to 40 characters. The glyph set is chosen by
+ * Kilo's `title_icon` config — `unicode`, `emojis`, or `none`, and `none`
+ * renders no glyph at all, so an undecorated frame must stay valid evidence.
+ *
+ * Deliberately provider-owned rather than a branch inside OpenCode's matcher:
+ * Kilo is an OpenCode fork and shares this title *shape*, but its base marker,
+ * glyph tables and indicator precedence are its own, and OpenCode panes must
+ * not shift behavior when Kilo's vocabulary grows.
+ */
+export type KiloTitleIndicator = 'working' | 'attention' | 'finished' | 'none'
+
+// Kilo's `title_icon` tables: `unicode` first, then `emojis`. Kept per-indicator
+// so a title reports what Kilo meant, not merely that it was decorated.
+const KILO_WORKING_GLYPHS = ['◔', '\u{1f4ad}'] // ◔ 💭
+const KILO_ATTENTION_GLYPHS = ['⚠', '\u{1f536}'] // ⚠ 🔶
+const KILO_FINISHED_GLYPHS = ['✓', '✅'] // ✓ ✅
+const KILO_GLYPHS = [...KILO_WORKING_GLYPHS, ...KILO_ATTENTION_GLYPHS, ...KILO_FINISHED_GLYPHS]
+
+const KILO_GLYPH_CLASS = `[${KILO_GLYPHS.join('')}]`
+
+// Why: wrappers may prepend an SSH/tmux label, and Kilo may prepend one status
+// glyph. A glyph-led segment from another agent must not be read as a wrapper.
+// The tail is either nothing (home screen) or Kilo's ` | <session title>`;
+// anything else — `Kilo CLI Configuration Reference` in a pager, say — is prose
+// that merely mentions the CLI and must not mint an agent row.
+const KILO_NATIVE_TITLE_RE = new RegExp(
+  `^\\s*(?:(?!${KILO_GLYPH_CLASS})[^|]+? \\| )?(${KILO_GLYPH_CLASS})?\\ufe0f?\\s*Kilo CLI(?: \\|[ \\t]+\\S.*)?\\s*$`,
+  'u'
+)
+
+/** Kilo's own indicator for a native title, or `null` when the title is not Kilo's. */
+export function parseKiloTitleIndicator(
+  title: string | null | undefined
+): KiloTitleIndicator | null {
+  if (!title) {
+    return null
+  }
+  const match = KILO_NATIVE_TITLE_RE.exec(title)
+  if (!match) {
+    return null
+  }
+  const glyph = match[1]
+  if (!glyph) {
+    return 'none'
+  }
+  if (KILO_WORKING_GLYPHS.includes(glyph)) {
+    return 'working'
+  }
+  if (KILO_ATTENTION_GLYPHS.includes(glyph)) {
+    return 'attention'
+  }
+  return 'finished'
+}
+
+export function isKiloNativeTitle(title: string | null | undefined): boolean {
+  return parseKiloTitleIndicator(title) !== null
+}
+
+/**
+ * Kilo's indicator mapped onto Orca's title status.
+ *
+ * `attention` is Kilo's single "needs the human" indicator — it covers a pending
+ * permission, question, suggestion, network prompt or plan approval (and a session
+ * that went offline), so it reads as `permission` rather than as work in flight.
+ */
+export function detectKiloTitleStatus(title: string | null | undefined): AgentStatus | null {
+  const indicator = parseKiloTitleIndicator(title)
+  if (!indicator) {
+    return null
+  }
+  if (indicator === 'working') {
+    return 'working'
+  }
+  return indicator === 'attention' ? 'permission' : 'idle'
+}

--- a/src/shared/terminal-title-agent-type.ts
+++ b/src/shared/terminal-title-agent-type.ts
@@ -6,6 +6,7 @@ import {
 } from './agent-name-token-match'
 import { containsAgentSpinnerGlyph, isCursorAgentTitle } from './agent-title-core'
 import { stripLeadingAgentTitleDecorationOrEmpty } from './agent-title-decoration'
+import { isKiloNativeTitle } from './kilo-terminal-title'
 import { isOpenCodeNativeTitle } from './opencode-terminal-title'
 import { getWrapperTitleSegments } from './terminal-title-wrapper-segments'
 import {
@@ -79,7 +80,12 @@ export function isPiAgentTitle(title: string): boolean {
  * agents have different (or no) caching semantics.
  */
 export function isClaudeAgent(title: string): boolean {
-  if (!title || isClaudeManagementTitle(title) || isOpenCodeNativeTitle(title)) {
+  if (
+    !title ||
+    isClaudeManagementTitle(title) ||
+    isOpenCodeNativeTitle(title) ||
+    isKiloNativeTitle(title)
+  ) {
     return false
   }
   const lower = title.toLowerCase()
@@ -127,6 +133,11 @@ export function getAgentLabel(title: string): string | null {
   // include status glyphs from other agents without changing OpenCode identity.
   if (isOpenCodeNativeTitle(title)) {
     return 'OpenCode'
+  }
+  // Why: same reasoning for Kilo's native frame — its session text is free-form
+  // and may carry another agent's name or spinner.
+  if (isKiloNativeTitle(title)) {
+    return 'Kilocode'
   }
   // Why: Claude Code title text is often the task title. If that task mentions
   // another CLI, the Claude-specific prefix is the identity signal, not the words.
@@ -220,6 +231,7 @@ const TITLE_LABEL_TO_AGENT: Partial<Record<string, TuiAgent>> = {
   Devin: 'devin',
   Antigravity: 'antigravity',
   OpenCode: 'opencode',
+  Kilocode: 'kilo',
   'MiMo Code': 'mimo-code',
   Aider: 'aider',
   Cursor: 'cursor',


### PR DESCRIPTION
## ELI5

Run Kilo in an Orca terminal and the worktree sidebar shows nothing — no agent row, no state dot, as
if the pane were an empty shell. Kilo *does* write a title saying who it is and what it is doing;
Orca simply had no rule that recognised it. This adds that rule, reading Kilo's own status glyph
instead of guessing from decoration, so a Kilo pane shows up as **Running / Needs input / Idle**.

## What Changed

**New:** `src/shared/kilo-terminal-title.ts` — one module that parses Kilo's own title grammar and
reports the indicator Kilo *meant*, not merely that the title was decorated.

Wired at the same points its sibling `opencode-terminal-title.ts` is already consumed:

| File | Change |
| --- | --- |
| `agent-title-status.ts` | `detectAgentStatusFromTitle` reads Kilo's declared indicator |
| `terminal-title-agent-type.ts` | `getAgentLabel` → `Kilocode`; `TITLE_LABEL_TO_AGENT` → `kilo`; `isClaudeAgent` excludes Kilo's frame |
| `agent-title-identity.ts` | the parallel `getAgentLabel` / `isClaudeAgent` copies, kept in step |
| `worktree-title-derived-agent-rows.ts` | label → `AgentType` so the row gets Kilo's icon, not `unknown` |
| `agent-type-label.ts` | `kilo` → `Kilocode` (it fell through to the raw lowercase id) |

Net `+268/−2` across 8 files, 2 new. No change to any shared *function's* behaviour for another
runtime — each edit is a Kilo-guarded early return placed beside the existing OpenCode one.

## Why

### The title grammar, measured — not guessed

`@kilocode/cli` **7.4.22** installed to a scratch prefix and driven under a PTY. Its raw `OSC 0` is:

```
OSC 10 => "?"       OSC 11 => "?"      OSC 99 => "i=opentui-notifications:p=?;"
OSC 1337 => "Capabilities"             OSC 66 => "w=1; "
OSC 66 => "s=2; "   OSC 4 => "0;?"     OSC 0 => "Kilo CLI"      OSC 12 => "#fafaf9"
```

and its shipped title builder (gated by `KILO_DISABLE_TERMINAL_TITLE`) is:

```
format({base,title,indicator,icon}) -> icon ? `${icon} ${base} | ${title}` : `${base} | ${title}`
base = "Kilo CLI"   separator = " | "   session title truncated by Kilo to 40 chars
ICONS   none:    (no glyph for any indicator)
        unicode: working ◔   attention ⚠   finished ✓
        emojis:  working 💭  attention 🔶  finished ✅
```

So Kilo is **richer than a bare identity frame** — it already publishes its turn state. `attention`
is its single "needs the human" indicator: a pending permission, question, suggestion, network
prompt or plan approval (also a session that went offline). That maps onto `permission`, and
`working` / `finished` map onto `working` / `idle`.

Kilo is an OpenCode fork — its own log line ends `… opencode`, and this title module is the same one
behind Orca's existing `OC | …` matcher, with a different `base`. That is why the fix is a **sibling
module** rather than a branch inside OpenCode's: the shape is shared, the vocabulary is not, and an
OpenCode pane must not shift when Kilo's glyph table grows.

### Measured on the base branch, before this commit

| pane title | `getAgentLabel` | `resolveTerminalTitleAgentType` | `detectAgentStatusFromTitle` |
| --- | --- | --- | --- |
| `Kilo CLI` | `null` | `null` | `null` — invisible |
| `Kilo CLI \| fix the flaky test` | `null` | `null` | `null` — invisible |
| `◔ Kilo CLI \| fix the flaky test` | `null` | `null` | `null` — invisible |
| `⚠ Kilo CLI \| fix the flaky test` | `null` | `null` | `null` — invisible |
| `✓ Kilo CLI \| fix the flaky test` | `null` | `null` | `null` — invisible |

After: `Kilocode` / `kilo` / `idle`–`working`–`permission` respectively.

Note what this proves about the framing in #6909: **`kilo` was already in `TuiAgent`,
`TUI_AGENT_CONFIG`, `agent-catalog`, `agent-kind`, `tui-agent-display-names`, `tui-agent-selection`
and the sidebar's iconable-agent table — and the pane was still invisible.** The closed set that
hides a runtime is the *title-detection vocabulary*, not the launch allowlist.

Two details that made this fail silently rather than loudly:

- Kilo's working glyph is `◔` **U+25D4**, exactly one code point past Orca's
  `QUARTER_CIRCLE_SPINNER_RE = /[◐-◓]/`, so no existing spinner rule fired.
- `kilo` is deliberately **not** in `AGENT_NAMES` — that list is token-matched and its own comment
  explains why it stays narrower than the launchable set. Nothing here widens it.

### A second, quieter defect this fixes

Pre-fix, `isClaudeAgent('⚠ Kilo CLI | ⠋ run the flaky suite')` returned **`true`**: a braille spinner
inside Kilo's free-form session text hit Claude's generic spinner branch. Both `isClaudeAgent` copies
gate Claude-only behaviour (the prompt-cache timer and the parked-terminal byte watcher), so a Kilo
pane could reach them. Both now reject Kilo's frame, and the status comes from `⚠` — `permission`,
not the borrowed spinner's `working`.

## Scope

**This is the sidebar/status half of #13626 and #6909.** The other half — cold restore returning a
plain terminal instead of a Kilo session — is a session-resume problem, and #13990 (OrcaWin) is the
open PR for it; the two are complementary and neither supersedes the other. I re-verified #13990's
load-bearing external facts against the real CLI and they hold (see Testing). The third symptom in
#13626, the right-sidebar tab-switch redraw break, is untouched and stays open.

**No PRs are superseded by this one.**

Deliberately out of scope: Kilo's row *conversation name* still comes from the raw live title, so it
carries the leading glyph and re-renders on each transition. Its sibling OpenCode behaves identically
today, and changing it would move tab-title resolution for both — a separate change, not a Kilo bug.

## Linked Issue

Refs #13626 (STA-1095) and #6909.

Deliberately non-closing: #6909 also asks for Agent Session History / "Filter by Agent" coverage,
which needs the provider session id that #13990 captures. #13626's cold-restore and redraw symptoms
are likewise not claimed here.

## Visual Proof

Same live instance, same three ptys, same pane titles in both shots — toggled only by neutralising
`parseKiloTitleIndicator` and letting vite HMR flip the renderer in place, so the two states differ in
**exactly one line of code**. Pane 1 is the **real `@kilocode/cli` 7.4.22 binary** running in an Orca
pane (its own `OSC 0` → `Kilo CLI`); panes 2 and 3 emit Kilo's `◔` working and `⚠` attention frames
byte-for-byte.

**BEFORE** — the worktree card has no Agents group at all:

![card-before.png](https://github.com/user-attachments/assets/23435348-9335-4079-8840-3a507762bd11)

**AFTER** — `3 agents`, three Kilo rows with Kilo's icon and three distinct states:

![card-after.png](https://github.com/user-attachments/assets/6f808040-6014-4bea-8123-f8a00b937416)

The accessibility label on the summary is the fix stated plainly:

| | summary `aria-label` |
| --- | --- |
| before | `Agents` |
| after | `Expand 3 agents: 1 waiting, 1 working, 1 idle. Kilocode idle; Kilocode working; Kilocode waiting` |

<details><summary>Full window, both states (tab bar shows the three live Kilo panes and their icons)</summary>

**BEFORE**

![full-before.png](https://github.com/user-attachments/assets/032aac73-1145-4c73-afc6-17f8097fdd49)

**AFTER**

![full-after2.png](https://github.com/user-attachments/assets/cc3830e3-a736-4a13-b549-7c314c575599)

</details>

## Testing

Automated — new `src/shared/kilo-terminal-title.test.ts` (7 tests) plus a sidebar row case in
`worktree-title-derived-agent-rows.test.ts`. **Both proven non-vacuous**: with the wiring reverted and
only the new module present, `gives every Kilo frame an identity, a type and a status` fails with
`expected null to be 'Kilocode'`, `keeps a Kilo pane out of Claude-only behavior…` fails with
`expected true to be false`, and the sidebar row case fails outright (no row is produced).

Non-regression for every runtime sharing a function this touches — OpenCode, MiMo Code, Claude,
Codex, Pi/OMP, Cursor, Grok, Droid:

```
vitest: kilo-terminal-title, worktree-title-derived-agent-rows, terminal-title-agent-type,
        agent-detection, opencode-terminal-title, repro-8478-opencode-native-title-icon,
        repro-13889-claude-quarter-circle-busy-title, agent-title-decoration,
        agent-row-conversation-name, tab-title-resolution, pane-agent-evidence, agent-status,
        WorktreeCard, quarter-circle-title-send-authorization, launch-agent-session-continuation,
        pty-connection, orca-runtime, ActivityPrototypePage, tabs   →  2113 passed, 1 skipped
tsc -p config/tsconfig.tc.web.json --noEmit   → clean
tsc -p config/tsconfig.node.json  --noEmit    → clean
oxlint (incl. react-doctor config) + oxfmt --check on changed files → clean
```

Manual — installed the real `@kilocode/cli` 7.4.22 to a scratch prefix and captured its PTY stream and
title builder; every title asserted in tests is a shape the binary actually produces. Also
re-verified, against that same binary, the external facts #13990 depends on: `-s, --session <id>` and
`-c, --continue` exist; `KILO_CONFIG_DIR` is real and **additive** (Kilo reads both `~/.config/kilo`
and `$KILO_CONFIG_DIR`); and **both** `plugins/` and `plugin/` under the config dir are auto-loaded.

Platforms: title parsing is pure and platform-independent; the frame tolerates the SSH/tmux wrapper
prefix (`ssh build-host | ◔ Kilo CLI | …`) that remote panes prepend, covered by tests. No path,
shell, process or IPC surface is touched, so there is nothing platform- or remote-specific to break;
verified on macOS.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

- **Security** — no new input trust boundary; a terminal title was already untrusted display text and
  still only selects a label/status.
- **Cross-platform** — pure string matching, no path/shell/process assumptions. The frame accepts the
  wrapper prefix Windows/SSH panes prepend.
- **Remote SSH** — no wire, RPC or stream change; `detectAgentStatusFromTitle` runs on titles Orca
  already receives, so a new client against an old host and the reverse both behave the same.
- **Mobile** — `agent-type-label.ts` is shared with mobile, where `kilo` previously rendered as the
  raw lowercase id; it now reads `Kilocode`.
- **Backwards compatibility** — additive only. Every pre-existing title keeps its label, type and
  status, pinned by the suites above.
- **Performance** — one pre-compiled regex, tested only after the existing OpenCode check and only
  for titles that reach the status detector.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @BrennanKB5
