### PR TITLE
fix(deps): bump transitive nanoid to 3.3.18 (GHSA-2v37-7h3g-55p8)

### DIFF
--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -5606,8 +5606,8 @@ packages:
   multitars@1.0.0:
     resolution: {integrity: sha512-H/J4fMLedtudftaYMOg7ajzLYgT3/rwbWVJbqr/iUgB8DQztn38ys5HOqI1CzSxx8QhXXwOOnnBvd4v3jG5+Mg==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -9906,7 +9906,7 @@ snapshots:
       '@react-navigation/routers': 7.5.3
       escape-string-regexp: 4.0.0
       fast-deep-equal: 3.1.3
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       query-string: 7.1.3
       react: 19.2.6
       react-is: 19.2.6
@@ -9942,14 +9942,14 @@ snapshots:
       '@react-navigation/core': 7.17.2(react@19.2.6)
       escape-string-regexp: 4.0.0
       fast-deep-equal: 3.1.3
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       react: 19.2.6
       react-native: 0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6)
       use-latest-callback: 0.2.6(react@19.2.6)
 
   '@react-navigation/routers@7.5.3':
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
 
   '@rolldown/binding-android-arm64@1.1.3':
     optional: true
@@ -12166,7 +12166,7 @@ snapshots:
       expo-symbols: 55.0.8(expo-font@55.0.8)(expo@55.0.27)(react-native@0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       fast-deep-equal: 3.1.3
       invariant: 2.2.4
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       query-string: 7.1.3
       react: 19.2.6
       react-fast-compare: 3.2.2
@@ -13866,7 +13866,7 @@ snapshots:
 
   multitars@1.0.0: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -14162,7 +14162,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
Clears the one fixable open [Dependabot alert](https://github.com/stablyai/orca/security/dependabot), without adding a `pnpm` override.

## What changed

`nanoid` 3.3.17 → 3.3.18 in `mobile/pnpm-lock.yaml` ([GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8), high — a custom generator can loop indefinitely when `size` is zero).

It's a purely transitive dep, reached via `postcss`, `@react-navigation/{core,native,routers}`, and `expo-router`. Every one of those ranges on `^3.3.x`, so 3.3.18 already satisfies them — the lockfile entry just needed refreshing. **No override required.**

The diff is deliberately limited to the 8 nanoid lines. A plain `pnpm update nanoid -r` also re-resolved unrelated floating dev deps (`@types/node` 26.1.2→26.2.0, `terser` 5.49.1→5.50.0); that churn was reverted to keep this reviewable as a security-only change.

## The two `image-size` alerts are not fixable, and are intentionally left open

[GHSA-w3rx-r6r6-pgpr](https://github.com/advisories/GHSA-w3rx-r6r6-pgpr) (ICNS parser) and [GHSA-5p2g-fcmc-qvqq](https://github.com/advisories/GHSA-5p2g-fcmc-qvqq) (JXL/HEIF parsers) — both infinite-loop DoS in `image-size`.

There is no upgrade path today:

- Both advisories cover `<= 2.0.2` with **no patched version published**. The latest release on npm *is* 2.0.2, so every existing version is vulnerable.
- `image-size` arrives via `metro`, and every metro release through the current latest (0.87.0) still pins `image-size: ^1.0.2`.

An override couldn't help here — it would only repoint at another vulnerable version, and `image-size` 2.x is ESM-only with a changed API, so it would break metro's bundler. These stay open until upstream ships a fix; the exposure is a build-time bundler parsing image assets, not runtime app code.

## Verification

Run in `mobile/`:

- `pnpm install --frozen-lockfile` — succeeds, so the lockfile is self-consistent and integrity hashes check out; resolves `nanoid@3.3.18`.
- `pnpm typecheck` — clean.
- `pnpm test` — 450/450 files, 3554 passed, 3 skipped.

(An initial run failed on missing `*.generated` files — an artifact of my installing with `--ignore-scripts`, not of this change. Re-ran after the `postinstall` engine builds; those files are gitignored and stay out of the diff.)