### PR TITLE
Remove worktree deletion success toasts

### DIFF
--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-background-removal.test.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-background-removal.test.ts
@@ -98,7 +98,7 @@ describe('startWorkspaceCleanupBackgroundRemoval', () => {
       removedCount: 1,
       failedCount: 0
     })
-    expect(toast.success).toHaveBeenCalled()
+    expect(toast.success).not.toHaveBeenCalled()
     expect(onResult).toHaveBeenCalledWith({ removedIds: [candidate.worktreeId], failures: [] })
   })
 
@@ -572,7 +572,7 @@ describe('startWorkspaceCleanupBackgroundRemoval', () => {
       removedIds: [parent.worktreeId],
       failures: []
     })
-    expect(toast.success).toHaveBeenLastCalledWith('Removed workspaces: 1')
+    expect(toast.success).not.toHaveBeenCalled()
   })
 
   it('hardens a provisional parent skip after the child late-fails post-batch', async () => {
@@ -829,7 +829,7 @@ describe('startWorkspaceCleanupBackgroundRemoval', () => {
     })
     await settleBackgroundRemoval()
 
-    expect(toast.success).toHaveBeenCalledWith('Removed workspaces: 1')
+    expect(toast.success).not.toHaveBeenCalled()
     expect(toast.error).not.toHaveBeenCalledWith(
       'Workspace cleanup failed',
       expect.objectContaining({ description: 'callback failed' })

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-removal-toasts.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-removal-toasts.ts
@@ -12,14 +12,6 @@ export function showWorkspaceCleanupRemovalResultToasts(
 ): void {
   if (result.preservedBranches && result.preservedBranches.length > 0) {
     showPreservedBranchBatchToast(result.removedIds.length, result.preservedBranches)
-  } else if (result.removedIds.length > 0) {
-    toast.success(
-      translate(
-        'auto.components.workspace.cleanup.backgroundRemoval.removed',
-        'Removed workspaces: {{value0}}',
-        { value0: result.removedIds.length }
-      )
-    )
   }
   const definitiveFailures = pendingSettlementFailures
     ? result.failures.filter((failure) => !pendingSettlementFailures.has(failure))


### PR DESCRIPTION
## Summary
- remove success notifications after workspace cleanup deletions
- retain failure, in-progress, and preserved-branch notifications
- cover ordinary and late-settlement deletion results

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/workspace-cleanup/workspace-cleanup-background-removal.test.ts src/renderer/src/components/workspace-cleanup/workspace-cleanup-background-removal-late-settlement.test.ts src/renderer/src/components/workspace-cleanup/workspace-cleanup-background-removal-snapshot-batch.test.ts
- pnpm run typecheck:web
- pnpm run verify:localization-extraction
- pnpm run verify:localization-catalog