### PR TITLE
Fix Windows horizontal computer-use scroll

### DIFF
--- a/config/scripts/computer-use-windows-horizontal-scroll.test.mjs
+++ b/config/scripts/computer-use-windows-horizontal-scroll.test.mjs
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const projectDir = resolve(import.meta.dirname, '../..')
+
+function source(path) {
+  return readFileSync(join(projectDir, path), 'utf8')
+}
+
+function sourceBetween(contents, startMarker, endMarker) {
+  const start = contents.indexOf(startMarker)
+  const end = contents.indexOf(endMarker, start + startMarker.length)
+  if (start === -1 || end === -1) {
+    throw new Error(`Missing source boundary: ${startMarker} → ${endMarker}`)
+  }
+  return contents.slice(start, end)
+}
+
+describe('Windows computer-use horizontal scroll', () => {
+  it('routes left and right through the horizontal wheel with native signs', () => {
+    const windows = source('native/computer-use-windows/runtime.ps1')
+    const mouseEvents = sourceBetween(windows, '$MouseEvents = @{', 'function Write-OrcaJson')
+    const scroll = sourceBetween(windows, '        "scroll" {', '        "drag" {')
+    const left = sourceBetween(
+      scroll,
+      '} elseif ($Operation.direction -eq "left") {',
+      '} elseif ($Operation.direction -eq "right") {'
+    )
+    const right = sourceBetween(
+      scroll,
+      '} elseif ($Operation.direction -eq "right") {',
+      '} elseif ($Operation.direction -ne "up") {'
+    )
+
+    expect(mouseEvents).toContain('HorizontalWheel = 0x01000')
+    expect(scroll).toContain('$mouseEvent = $MouseEvents.Wheel')
+    expect(left).toContain('$mouseEvent = $MouseEvents.HorizontalWheel')
+    expect(left).toContain('$delta = -1 * $delta')
+    expect(right).toContain('$mouseEvent = $MouseEvents.HorizontalWheel')
+    expect(right).not.toContain('$delta = -1 * $delta')
+    expect(scroll).toContain(
+      '[OrcaDesktopWin32]::mouse_event($mouseEvent, 0, 0, $delta, [UIntPtr]::Zero)'
+    )
+    expect(scroll).not.toContain('mouse_event($MouseEvents.Wheel')
+    expect(scroll).toContain('throw "unsupported scroll direction: $($Operation.direction)"')
+  })
+})

--- a/native/computer-use-windows/runtime.ps1
+++ b/native/computer-use-windows/runtime.ps1
@@ -179,6 +179,7 @@ $MouseEvents = @{
     MiddleDown = 0x0020
     MiddleUp = 0x0040
     Wheel = 0x0800
+    HorizontalWheel = 0x01000
 }
 
 function Write-OrcaJson($Payload) {
@@ -1235,16 +1236,22 @@ function Invoke-OrcaOperation($Operation) {
         }
         "scroll" {
             $delta = 120 * [int][Math]::Ceiling((Get-OrcaPositiveNumber $Operation.pages "pages"))
-            if ($Operation.direction -eq "down" -or $Operation.direction -eq "right") {
+            $mouseEvent = $MouseEvents.Wheel
+            if ($Operation.direction -eq "down") {
                 $delta = -1 * $delta
-            } elseif ($Operation.direction -ne "up" -and $Operation.direction -ne "left") {
+            } elseif ($Operation.direction -eq "left") {
+                $mouseEvent = $MouseEvents.HorizontalWheel
+                $delta = -1 * $delta
+            } elseif ($Operation.direction -eq "right") {
+                $mouseEvent = $MouseEvents.HorizontalWheel
+            } elseif ($Operation.direction -ne "up") {
                 throw "unsupported scroll direction: $($Operation.direction)"
             }
             $point = Get-OrcaElementScreenPoint $element
             if ($null -eq $point) { $point = Get-OrcaScreenPoint $Operation $windowFrame }
             [void][OrcaDesktopWin32]::SetForegroundWindow($handle)
             [void][OrcaDesktopWin32]::SetCursorPos([int]$point.x, [int]$point.y)
-            [OrcaDesktopWin32]::mouse_event($MouseEvents.Wheel, 0, 0, $delta, [UIntPtr]::Zero)
+            [OrcaDesktopWin32]::mouse_event($mouseEvent, 0, 0, $delta, [UIntPtr]::Zero)
             $action = [pscustomobject]@{ path = "synthetic"; actionName = "scroll"; fallbackReason = $null }
         }
         "drag" {


### PR DESCRIPTION
## ELI5

Windows heard `left` and `right` scroll requests but sent them through the up/down mouse wheel. This change sends those requests through Windows' horizontal wheel instead.

## What Changed

- Added the Windows `MOUSEEVENTF_HWHEEL` (`0x01000`) synthetic mouse-event flag.
- Kept `up`/`down` on the existing vertical wheel path and routed `left`/`right` through the horizontal wheel.
- Added a focused source guardrail for the constant, routing, horizontal signs, synthetic dispatch, and unsupported-direction error.
- Left `WM_MOUSEHWHEEL` out because this path does not post window messages. `ConvertTo-OrcaWheelParam` is likewise not used: it packs a delta into `wParam` for `PostMessage`, while this path passes signed `dwData` directly to `mouse_event`.

## Why

Windows previously reported successful synthetic horizontal scrolling while actually moving the vertical wheel. Per Microsoft's [`MOUSEINPUT` documentation](https://learn.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-mouseinput), `MOUSEEVENTF_HWHEEL` uses a positive value for right and a negative value for left, so Windows now sends `right` as positive and `left` as negative.

That native sign convention is the inverse of Core Graphics' encoding in Orca (`wheel2` positive for left and negative for right), but the caller-facing meaning is the same: `left` moves left and `right` moves right. It also matches Linux's caller semantics through AT-SPI buttons 6 and 7.

## Linked Issue

None. Found during a computer-use mouse and scroll surface audit.

## Visual Proof

N/A — this is native synthetic-input routing with no rendered UI, and the macOS host cannot execute the Windows runtime.

## Testing

- [ ] I manually tested these changes locally — Windows runtime testing was not possible on this macOS host.
- [x] Automated tests added/updated.

Passed:

- `pnpm lint`
- `pnpm typecheck`
- `pnpm verify:computer-native`
- `pnpm vitest run --config config/vitest.config.ts config/scripts/computer-use-windows-horizontal-scroll.test.mjs` (1 test)

`pnpm verify:computer-native` ran the macOS provider tests, Linux syntax and renderer checks, native argument guardrails, and macOS helper bundle/signature check. It skipped the Windows PowerShell parse check because `pwsh` is unavailable, as well as Windows handshake/snapshot tests and Linux provider imports on this host.

The source guardrail was mutation-verified against the real runtime. Replacing both horizontal routes with `$MouseEvents.Wheel` failed with `AssertionError: expected ... to contain '$mouseEvent = $MouseEvents.HorizontalWheel'`; restoring the implementation returned the runtime SHA-1 to `a650f3184b951942d287c02288a91e110672fcc9`, left only the intended two paths in `git status --porcelain`, and the test passed again.

## AI Disclosure

N/A — internal contributor.

## Review

The change is Windows-only and does not alter schemas, remote wire behavior, macOS/Linux input, SSH/folder-workspace behavior, mobile, security boundaries, or Git/provider behavior. The dispatch remains a constant-time synthetic input call with the existing unsupported-direction failure intact.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] Required scoped gates pass; the full `pnpm test` and `pnpm build` were intentionally not run per task scope

## Author

- X / Twitter: @BrennanKB5
