### PR TITLE
fix(workspace-cleanup): refuse removal when the owning host is not certain (STA-4343)

### DIFF
--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -299,6 +299,7 @@
           "cleanup": {
             "9d6e531da6": "Workspace no longer exists.",
             "changedSinceConfirmation": "Workspace changed after confirmation. Refresh to review it before removing.",
+            "hostCollision": "Error: this workspace exists on multiple hosts at the same path",
             "hostUnresolved": "Orca cannot tell which host owns this workspace. Refresh projects and review it again."
           }
         },

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -298,7 +298,8 @@
         "workspace": {
           "cleanup": {
             "9d6e531da6": "Workspace no longer exists.",
-            "changedSinceConfirmation": "Workspace changed after confirmation. Refresh to review it before removing."
+            "changedSinceConfirmation": "Workspace changed after confirmation. Refresh to review it before removing.",
+            "hostUnresolved": "Orca cannot tell which host owns this workspace. Refresh projects and review it again."
           }
         },
         "worktrees": {

--- a/src/renderer/src/store/slices/workspace-cleanup-removal-host-guard.ts
+++ b/src/renderer/src/store/slices/workspace-cleanup-removal-host-guard.ts
@@ -1,0 +1,43 @@
+/**
+ * STA-4343 fail-closed guard: cleanup must never issue a destructive removal
+ * against a host other than the one whose row the user confirmed.
+ *
+ * A cleanup row's `worktreeId` is `repoId::path`, which two execution hosts can
+ * both own, while selection, confirmation and preflight all key on `worktreeId`
+ * alone and removal routing prefers the ACTIVE workspace's host. This is the
+ * minimal safety property: refuse whenever the confirmed owner is unknown, is
+ * not the only owner the refreshed scan reports, or is not where the removal
+ * would actually land. Routing a colliding row to its right host is #14606.
+ */
+import type { ExecutionHostId } from '../../../../shared/execution-host'
+import { resolveWorkspaceCleanupRemovalHostId } from '../../../../shared/workspace-cleanup-host-identity'
+import type { WorkspaceCleanupCandidate } from '../../../../shared/workspace-cleanup'
+
+/** True only when the removal is provably about to land on the confirmed row's own host. */
+export function isWorkspaceCleanupRemovalHostCertain(args: {
+  /** The row the user confirmed; internal callers without one fall back to the scanned row. */
+  confirmedCandidate: WorkspaceCleanupCandidate | undefined
+  scannedCandidate: WorkspaceCleanupCandidate
+  /** Every owner the refreshed scan reported for this `worktreeId`, null where a row carries none. */
+  scannedHostIds: readonly (ExecutionHostId | null)[]
+  /**
+   * The host `removeWorktree` would route the destructive IPC to. Null is not a
+   * refusal here: `removeWorktree` already fails an unroutable removal closed
+   * with WORKTREE_REMOVAL_AMBIGUOUS_ERROR before it touches any transport.
+   */
+  routeHostId: ExecutionHostId | null
+}): boolean {
+  const confirmedHostId = resolveWorkspaceCleanupRemovalHostId(
+    args.confirmedCandidate ?? args.scannedCandidate
+  )
+  if (!confirmedHostId) {
+    return false
+  }
+  // Why: one id owned by two hosts cannot say which row was confirmed, and a
+  // confirmed owner the refreshed scan no longer reports cannot be verified either.
+  const scannedHostIds = new Set(args.scannedHostIds)
+  if (scannedHostIds.size !== 1 || !scannedHostIds.has(confirmedHostId)) {
+    return false
+  }
+  return args.routeHostId === null || args.routeHostId === confirmedHostId
+}

--- a/src/renderer/src/store/slices/workspace-cleanup-slice-test-harness.ts
+++ b/src/renderer/src/store/slices/workspace-cleanup-slice-test-harness.ts
@@ -15,6 +15,8 @@ export function makeCandidate(
     repoId: 'repo1',
     repoName: 'Repo 1',
     connectionId: null,
+    // Why: main host-qualifies every candidate it builds; removal fails closed without it (STA-4343).
+    executionHostId: 'local',
     displayName: 'old-workspace',
     branch: 'old-workspace',
     path: '/tmp/old-workspace',

--- a/src/renderer/src/store/slices/workspace-cleanup-wrong-host-removal-guard.test.ts
+++ b/src/renderer/src/store/slices/workspace-cleanup-wrong-host-removal-guard.test.ts
@@ -27,6 +27,7 @@ import type { ExecutionHostId } from '../../../../shared/execution-host'
 const NOW = 1_700_000_000_000
 const HOST_A_HOST_ID: ExecutionHostId = 'local'
 const HOST_B_HOST_ID: ExecutionHostId = 'ssh:ssh-1'
+const HOST_COLLISION_MESSAGE = 'Error: this workspace exists on multiple hosts at the same path'
 const HOST_UNRESOLVED_MESSAGE =
   'Orca cannot tell which host owns this workspace. Refresh projects and review it again.'
 
@@ -223,7 +224,7 @@ describe('STA-4343 minimal guard: cleanup refuses a removal it cannot attribute 
     expect(routedHostIds).toEqual([])
     expect(removal.removedIds).toEqual([])
     expect(removal.failures).toEqual([
-      { worktreeId: WORKTREE_ID, displayName: 'shared-workspace', message: HOST_UNRESOLVED_MESSAGE }
+      { worktreeId: WORKTREE_ID, displayName: 'shared-workspace', message: HOST_COLLISION_MESSAGE }
     ])
     expect(store.getState().tabsByWorktree[WORKTREE_ID]).toEqual([
       expect.objectContaining({ id: 'host-a-tab' })
@@ -359,5 +360,36 @@ describe('STA-4343 minimal guard: ordinary single-host cleanup still deletes', (
     expect(removal.removedIds).toEqual([WORKTREE_ID])
     expect(routedHostIds).toEqual([HOST_B_HOST_ID])
     expect(fs.existsSync(hosts.hostBMarkerPath)).toBe(false)
+  })
+
+  it('deletes a host-qualified snapshot row after the refreshed owner matches', async () => {
+    const hosts = createHostDirectories()
+    const routedHostIds: string[] = []
+    installRemovalTransport({ [HOST_A_HOST_ID]: hosts.hostARoot }, routedHostIds)
+    const snapshotCandidate = makeHostCandidate(HOST_A_HOST_ID)
+    seedScan([makeHostCandidate(HOST_A_HOST_ID)])
+
+    const store = createTestStore()
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [
+          makeWorktree({
+            id: WORKTREE_ID,
+            repoId: 'repo1',
+            path: WORKTREE_PATH,
+            hostId: HOST_A_HOST_ID
+          })
+        ]
+      }
+    } as Partial<AppState>)
+
+    const removal = await store.getState().removeWorkspaceCleanupCandidates([WORKTREE_ID], {
+      approvedCandidates: [snapshotCandidate]
+    })
+
+    expect(removal.failures).toEqual([])
+    expect(removal.removedIds).toEqual([WORKTREE_ID])
+    expect(routedHostIds).toEqual([HOST_A_HOST_ID])
+    expect(fs.existsSync(hosts.hostAMarkerPath)).toBe(false)
   })
 })

--- a/src/renderer/src/store/slices/workspace-cleanup-wrong-host-removal-guard.test.ts
+++ b/src/renderer/src/store/slices/workspace-cleanup-wrong-host-removal-guard.test.ts
@@ -1,0 +1,363 @@
+/**
+ * STA-4343 (minimal fail-closed guard): workspace cleanup must never delete on a
+ * host other than the one whose row was confirmed.
+ *
+ * Two hosts can expose cleanup candidates with the SAME `repoId::path` identity
+ * (the scan composes `worktreeId` from `repo.id` + `::` + the workspace path with
+ * no host component). Selection, confirmation and preflight all key on
+ * `worktreeId` alone, and removal routing prefers the ACTIVE workspace's host, so
+ * confirming host B's row issued the destructive IPC against host A and destroyed
+ * host A's real directory (and its uncommitted work).
+ *
+ * This is the MINIMAL fix: refuse the removal when ownership is not certain.
+ * Routing a colliding row to its right host is PR #14606's job.
+ *
+ * Rig: two REAL temp directories stand in for the two hosts. The removal boundary
+ * (`window.api.worktrees.remove`) is the only fake, and it ACTUALLY deletes the
+ * directory on the host it is routed to. The gate is filesystem state, not
+ * arguments. The single-host control deletes for real through the same rig, so a
+ * passing refusal assertion cannot come from a rig that never deletes anything.
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
+
+const NOW = 1_700_000_000_000
+const HOST_A_HOST_ID: ExecutionHostId = 'local'
+const HOST_B_HOST_ID: ExecutionHostId = 'ssh:ssh-1'
+const HOST_UNRESOLVED_MESSAGE =
+  'Orca cannot tell which host owns this workspace. Refresh projects and review it again.'
+
+const mockApi = {
+  worktrees: {
+    remove: vi.fn(),
+    forgetLocal: vi.fn().mockResolvedValue({ ok: false, error: 'unused in this scenario' })
+  },
+  hooks: {
+    check: vi.fn().mockResolvedValue({ hasHooks: false, hooks: null, mayNeedUpdate: false })
+  },
+  workspaceCleanup: {
+    scan: vi.fn(),
+    dismiss: vi.fn().mockResolvedValue(undefined),
+    clearDismissals: vi.fn().mockResolvedValue(undefined),
+    recordRemovalSnapshotPrune: vi.fn().mockResolvedValue(undefined)
+  },
+  pty: { kill: vi.fn().mockResolvedValue(undefined) },
+  runtimeEnvironments: { call: vi.fn().mockResolvedValue({ ok: true, result: {} } as never) },
+  ephemeralVm: {
+    listRuntimes: vi.fn().mockResolvedValue([]),
+    cleanup: vi.fn().mockResolvedValue({})
+  }
+}
+
+// @ts-expect-error -- minimal window.api stub for the store under test
+globalThis.window = { api: mockApi }
+
+import { createTestStore, seedStore, makeTab, makeWorktree } from './store-test-helpers'
+import { resetAuthoritativelyRemovedWorktreeMemoryForTests } from './worktrees'
+import type { AppState } from '../types'
+import type {
+  WorkspaceCleanupCandidate,
+  WorkspaceCleanupScanResult
+} from '../../../../shared/workspace-cleanup'
+
+const WORKTREE_ID = 'repo1::/shared/workspace/path'
+const WORKTREE_PATH = '/shared/workspace/path'
+
+function makeHostCandidate(
+  executionHostId: ExecutionHostId | undefined,
+  connectionId: string | null = executionHostId === HOST_B_HOST_ID ? 'ssh-1' : null
+): WorkspaceCleanupCandidate {
+  return {
+    worktreeId: WORKTREE_ID,
+    repoId: 'repo1',
+    repoName: 'Repo 1',
+    connectionId,
+    ...(executionHostId ? { executionHostId } : {}),
+    displayName: 'shared-workspace',
+    branch: 'old-branch',
+    path: WORKTREE_PATH,
+    tier: 'ready',
+    selectedByDefault: true,
+    reasons: ['idle-clean'],
+    blockers: [],
+    lastActivityAt: NOW - 30 * 24 * 60 * 60 * 1000,
+    localContext: {
+      terminalTabCount: 0,
+      cleanEditorTabCount: 0,
+      browserTabCount: 0,
+      diffCommentCount: 0,
+      newestDiffCommentAt: null,
+      retainedDoneAgentCount: 0
+    },
+    git: { clean: true, upstreamAhead: 0, upstreamBehind: 0, checkedAt: NOW },
+    fingerprint: `fingerprint-${executionHostId ?? 'unqualified'}`
+  }
+}
+
+type HostDirectories = {
+  hostARoot: string
+  hostBRoot: string
+  hostAMarkerPath: string
+  hostBMarkerPath: string
+}
+
+const hostDirCleanup: (() => void)[] = []
+
+/** Maps a workspace id onto a per-host temp directory; Windows ids keep their shape. */
+function toHostRelativePath(worktreeId: string): string {
+  return worktreeId
+    .slice(worktreeId.indexOf('::') + 2)
+    .replace(/^[a-zA-Z]:/, '')
+    .split(/[/\\]+/)
+    .filter((segment) => segment.length > 0)
+    .join(path.sep)
+}
+
+function createHostDirectories(): HostDirectories {
+  const hostARoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sta4343-guard-host-a-'))
+  const hostBRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sta4343-guard-host-b-'))
+  hostDirCleanup.push(() => {
+    fs.rmSync(hostARoot, { recursive: true, force: true })
+    fs.rmSync(hostBRoot, { recursive: true, force: true })
+  })
+  const relativePath = toHostRelativePath(WORKTREE_ID)
+  const hostAWorktreeDir = path.join(hostARoot, relativePath)
+  const hostBWorktreeDir = path.join(hostBRoot, relativePath)
+  fs.mkdirSync(hostAWorktreeDir, { recursive: true })
+  fs.mkdirSync(hostBWorktreeDir, { recursive: true })
+  const hostAMarkerPath = path.join(hostAWorktreeDir, 'HOST_A_MARKER')
+  const hostBMarkerPath = path.join(hostBWorktreeDir, 'HOST_B_MARKER')
+  fs.writeFileSync(hostAMarkerPath, 'uncommitted-data-on-host-a')
+  fs.writeFileSync(hostBMarkerPath, 'uncommitted-data-on-host-b')
+  return { hostARoot, hostBRoot, hostAMarkerPath, hostBMarkerPath }
+}
+
+/** Deletes for real on whichever host the removal is routed to. */
+function installRemovalTransport(
+  hostRootsByHostId: Record<string, string>,
+  routedHostIds: string[]
+): void {
+  mockApi.worktrees.remove.mockImplementation(
+    async (args: { worktreeId: string; hostId?: string }) => {
+      routedHostIds.push(args.hostId ?? '<missing>')
+      const hostRoot = args.hostId ? hostRootsByHostId[args.hostId] : undefined
+      if (hostRoot) {
+        fs.rmSync(path.join(hostRoot, toHostRelativePath(args.worktreeId)), {
+          recursive: true,
+          force: true
+        })
+      }
+      return { ok: true }
+    }
+  )
+}
+
+function seedScan(candidates: readonly WorkspaceCleanupCandidate[]): void {
+  mockApi.workspaceCleanup.scan.mockResolvedValue({
+    scannedAt: NOW,
+    candidates: [...candidates],
+    errors: []
+  } satisfies WorkspaceCleanupScanResult)
+}
+
+beforeEach(() => {
+  resetAuthoritativelyRemovedWorktreeMemoryForTests()
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+  for (const cleanup of hostDirCleanup.splice(0)) {
+    cleanup()
+  }
+})
+
+describe('STA-4343 minimal guard: cleanup refuses a removal it cannot attribute to a host', () => {
+  it('confirming host B leaves ACTIVE host A intact when both hosts hold the same id', async () => {
+    const hosts = createHostDirectories()
+    const routedHostIds: string[] = []
+    installRemovalTransport(
+      { [HOST_A_HOST_ID]: hosts.hostARoot, [HOST_B_HOST_ID]: hosts.hostBRoot },
+      routedHostIds
+    )
+    const hostBCandidate = makeHostCandidate(HOST_B_HOST_ID)
+    seedScan([makeHostCandidate(HOST_A_HOST_ID), hostBCandidate])
+
+    const store = createTestStore()
+    // Host A owns the ACTIVE workspace, so removal routing prefers host A.
+    seedStore(store, {
+      activeWorktreeId: WORKTREE_ID,
+      activeWorkspaceExecutionHostId: HOST_A_HOST_ID,
+      worktreesByRepo: {
+        repo1: [
+          makeWorktree({
+            id: WORKTREE_ID,
+            repoId: 'repo1',
+            path: WORKTREE_PATH,
+            hostId: HOST_A_HOST_ID
+          }),
+          makeWorktree({
+            id: WORKTREE_ID,
+            repoId: 'repo1',
+            path: WORKTREE_PATH,
+            hostId: HOST_B_HOST_ID
+          })
+        ]
+      },
+      tabsByWorktree: { [WORKTREE_ID]: [makeTab({ id: 'host-a-tab', worktreeId: WORKTREE_ID })] }
+    } as Partial<AppState>)
+
+    // The user confirms HOST B's cleanup row.
+    const removal = await store
+      .getState()
+      .removeWorkspaceCleanupCandidates([WORKTREE_ID], { approvedCandidates: [hostBCandidate] })
+
+    expect(
+      fs.existsSync(hosts.hostAMarkerPath),
+      `HOST A (active) worktree directory must still exist after confirming HOST B's row. worktrees.remove was routed to hostId=${routedHostIds.join(',')}`
+    ).toBe(true)
+    // Minimal fix: the colliding row is refused, not rerouted (#14606 reroutes it).
+    expect(fs.existsSync(hosts.hostBMarkerPath)).toBe(true)
+    expect(routedHostIds).toEqual([])
+    expect(removal.removedIds).toEqual([])
+    expect(removal.failures).toEqual([
+      { worktreeId: WORKTREE_ID, displayName: 'shared-workspace', message: HOST_UNRESOLVED_MESSAGE }
+    ])
+    expect(store.getState().tabsByWorktree[WORKTREE_ID]).toEqual([
+      expect.objectContaining({ id: 'host-a-tab' })
+    ])
+  })
+
+  it('refuses a row whose confirmed host no longer matches the refreshed scan', async () => {
+    const hosts = createHostDirectories()
+    const routedHostIds: string[] = []
+    installRemovalTransport(
+      { [HOST_A_HOST_ID]: hosts.hostARoot, [HOST_B_HOST_ID]: hosts.hostBRoot },
+      routedHostIds
+    )
+    // The refreshed scan only reaches host A, but host B's row was confirmed.
+    seedScan([makeHostCandidate(HOST_A_HOST_ID)])
+
+    const store = createTestStore()
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [
+          makeWorktree({
+            id: WORKTREE_ID,
+            repoId: 'repo1',
+            path: WORKTREE_PATH,
+            hostId: HOST_A_HOST_ID
+          })
+        ]
+      }
+    } as Partial<AppState>)
+
+    const removal = await store.getState().removeWorkspaceCleanupCandidates([WORKTREE_ID], {
+      approvedCandidates: [makeHostCandidate(HOST_B_HOST_ID)]
+    })
+
+    expect(fs.existsSync(hosts.hostAMarkerPath), 'host A must survive').toBe(true)
+    expect(routedHostIds).toEqual([])
+    expect(removal.failures).toEqual([
+      { worktreeId: WORKTREE_ID, displayName: 'shared-workspace', message: HOST_UNRESOLVED_MESSAGE }
+    ])
+  })
+
+  it('refuses a row that carries no host evidence at all', async () => {
+    const hosts = createHostDirectories()
+    const routedHostIds: string[] = []
+    installRemovalTransport({ [HOST_A_HOST_ID]: hosts.hostARoot }, routedHostIds)
+    const unqualifiedCandidate = makeHostCandidate(undefined, null)
+    seedScan([unqualifiedCandidate])
+
+    const store = createTestStore()
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [
+          makeWorktree({
+            id: WORKTREE_ID,
+            repoId: 'repo1',
+            path: WORKTREE_PATH,
+            hostId: HOST_A_HOST_ID
+          })
+        ]
+      }
+    } as Partial<AppState>)
+
+    const removal = await store.getState().removeWorkspaceCleanupCandidates([WORKTREE_ID], {
+      approvedCandidates: [unqualifiedCandidate]
+    })
+
+    expect(fs.existsSync(hosts.hostAMarkerPath), 'host A must survive').toBe(true)
+    expect(routedHostIds).toEqual([])
+    expect(removal.failures).toEqual([
+      { worktreeId: WORKTREE_ID, displayName: 'shared-workspace', message: HOST_UNRESOLVED_MESSAGE }
+    ])
+  })
+})
+
+describe('STA-4343 minimal guard: ordinary single-host cleanup still deletes', () => {
+  it('deletes the confirmed local workspace for real', async () => {
+    const hosts = createHostDirectories()
+    const routedHostIds: string[] = []
+    installRemovalTransport({ [HOST_A_HOST_ID]: hosts.hostARoot }, routedHostIds)
+    const hostACandidate = makeHostCandidate(HOST_A_HOST_ID)
+    seedScan([hostACandidate])
+
+    const store = createTestStore()
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [
+          makeWorktree({
+            id: WORKTREE_ID,
+            repoId: 'repo1',
+            path: WORKTREE_PATH,
+            hostId: HOST_A_HOST_ID
+          })
+        ]
+      }
+    } as Partial<AppState>)
+
+    const removal = await store
+      .getState()
+      .removeWorkspaceCleanupCandidates([WORKTREE_ID], { approvedCandidates: [hostACandidate] })
+
+    expect(removal.failures).toEqual([])
+    expect(removal.removedIds).toEqual([WORKTREE_ID])
+    expect(routedHostIds).toEqual([HOST_A_HOST_ID])
+    expect(fs.existsSync(hosts.hostAMarkerPath)).toBe(false)
+  })
+
+  it('deletes the confirmed SSH workspace for real', async () => {
+    const hosts = createHostDirectories()
+    const routedHostIds: string[] = []
+    installRemovalTransport({ [HOST_B_HOST_ID]: hosts.hostBRoot }, routedHostIds)
+    const hostBCandidate = makeHostCandidate(HOST_B_HOST_ID)
+    seedScan([hostBCandidate])
+
+    const store = createTestStore()
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [
+          makeWorktree({
+            id: WORKTREE_ID,
+            repoId: 'repo1',
+            path: WORKTREE_PATH,
+            hostId: HOST_B_HOST_ID
+          })
+        ]
+      }
+    } as Partial<AppState>)
+
+    const removal = await store
+      .getState()
+      .removeWorkspaceCleanupCandidates([WORKTREE_ID], { approvedCandidates: [hostBCandidate] })
+
+    expect(removal.failures).toEqual([])
+    expect(removal.removedIds).toEqual([WORKTREE_ID])
+    expect(routedHostIds).toEqual([HOST_B_HOST_ID])
+    expect(fs.existsSync(hosts.hostBMarkerPath)).toBe(false)
+  })
+})

--- a/src/renderer/src/store/slices/workspace-cleanup-wrong-host-removal-guard.test.ts
+++ b/src/renderer/src/store/slices/workspace-cleanup-wrong-host-removal-guard.test.ts
@@ -66,20 +66,23 @@ import type {
 
 const WORKTREE_ID = 'repo1::/shared/workspace/path'
 const WORKTREE_PATH = '/shared/workspace/path'
+const FIRST_WORKTREE_ID = 'repo1::/first/very-long-workspace/path'
 
 function makeHostCandidate(
   executionHostId: ExecutionHostId | undefined,
-  connectionId: string | null = executionHostId === HOST_B_HOST_ID ? 'ssh-1' : null
+  connectionId: string | null = executionHostId === HOST_B_HOST_ID ? 'ssh-1' : null,
+  worktreeId = WORKTREE_ID
 ): WorkspaceCleanupCandidate {
+  const workspacePath = worktreeId.slice(worktreeId.indexOf('::') + 2)
   return {
-    worktreeId: WORKTREE_ID,
+    worktreeId,
     repoId: 'repo1',
     repoName: 'Repo 1',
     connectionId,
     ...(executionHostId ? { executionHostId } : {}),
     displayName: 'shared-workspace',
     branch: 'old-branch',
-    path: WORKTREE_PATH,
+    path: workspacePath,
     tier: 'ready',
     selectedByDefault: true,
     reasons: ['idle-clean'],
@@ -293,6 +296,68 @@ describe('STA-4343 minimal guard: cleanup refuses a removal it cannot attribute 
 
     expect(fs.existsSync(hosts.hostAMarkerPath), 'host A must survive').toBe(true)
     expect(routedHostIds).toEqual([])
+    expect(removal.failures).toEqual([
+      { worktreeId: WORKTREE_ID, displayName: 'shared-workspace', message: HOST_UNRESOLVED_MESSAGE }
+    ])
+  })
+
+  it('rechecks the route after an earlier removal changes ownership', async () => {
+    const hosts = createHostDirectories()
+    const routedHostIds: string[] = []
+    installRemovalTransport(
+      { [HOST_A_HOST_ID]: hosts.hostARoot, [HOST_B_HOST_ID]: hosts.hostBRoot },
+      routedHostIds
+    )
+    const firstCandidate = makeHostCandidate(HOST_A_HOST_ID, null, FIRST_WORKTREE_ID)
+    const secondCandidate = makeHostCandidate(HOST_A_HOST_ID)
+    seedScan([firstCandidate, secondCandidate])
+
+    const store = createTestStore()
+    const firstWorktree = makeWorktree({
+      id: FIRST_WORKTREE_ID,
+      repoId: 'repo1',
+      path: '/first/very-long-workspace/path',
+      hostId: HOST_A_HOST_ID
+    })
+    const secondHostAWorktree = makeWorktree({
+      id: WORKTREE_ID,
+      repoId: 'repo1',
+      path: WORKTREE_PATH,
+      hostId: HOST_A_HOST_ID
+    })
+    const secondHostBWorktree = makeWorktree({
+      id: WORKTREE_ID,
+      repoId: 'repo1',
+      path: WORKTREE_PATH,
+      hostId: HOST_B_HOST_ID
+    })
+    seedStore(store, {
+      worktreesByRepo: { repo1: [firstWorktree, secondHostAWorktree] }
+    } as Partial<AppState>)
+    const originalRemoveWorktree = store.getState().removeWorktree
+    store.setState({
+      removeWorktree: vi.fn(async (...args: Parameters<typeof originalRemoveWorktree>) => {
+        const result = await originalRemoveWorktree(...args)
+        if (args[0] === FIRST_WORKTREE_ID) {
+          store.setState({
+            activeWorktreeId: WORKTREE_ID,
+            activeWorkspaceExecutionHostId: HOST_B_HOST_ID,
+            worktreesByRepo: { repo1: [secondHostAWorktree, secondHostBWorktree] }
+          })
+        }
+        return result
+      })
+    })
+
+    const removal = await store
+      .getState()
+      .removeWorkspaceCleanupCandidates([FIRST_WORKTREE_ID, WORKTREE_ID], {
+        approvedCandidates: [firstCandidate, secondCandidate]
+      })
+
+    expect(fs.existsSync(hosts.hostBMarkerPath), 'newly active host B must survive').toBe(true)
+    expect(routedHostIds).toEqual([HOST_A_HOST_ID])
+    expect(removal.removedIds).toEqual([FIRST_WORKTREE_ID])
     expect(removal.failures).toEqual([
       { worktreeId: WORKTREE_ID, displayName: 'shared-workspace', message: HOST_UNRESOLVED_MESSAGE }
     ])

--- a/src/renderer/src/store/slices/workspace-cleanup.ts
+++ b/src/renderer/src/store/slices/workspace-cleanup.ts
@@ -1053,11 +1053,15 @@ async function preflightWorkspaceCleanupCandidates(
     if (!preflight.ok) {
       return preflight
     }
+    const scannedHostIds = [...(scannedHostIdsByWorktreeId.get(worktreeId) ?? [])]
+    const distinctKnownHostCount = new Set(
+      scannedHostIds.filter((hostId): hostId is ExecutionHostId => hostId !== null)
+    ).size
     // STA-4343: fail closed rather than delete another host's uncommitted work.
     const hostIsCertain = isWorkspaceCleanupRemovalHostCertain({
       confirmedCandidate: approvedCandidatesByWorktreeId.get(worktreeId),
       scannedCandidate: preflight.candidate,
-      scannedHostIds: [...(scannedHostIdsByWorktreeId.get(worktreeId) ?? [])],
+      scannedHostIds,
       routeHostId: resolveWorktreeOperationRoute(getState(), worktreeId)?.executionHostId ?? null
     })
     return hostIsCertain
@@ -1067,10 +1071,16 @@ async function preflightWorkspaceCleanupCandidates(
           failure: {
             worktreeId,
             displayName: preflight.candidate.displayName,
-            message: translate(
-              'auto.store.slices.workspace.cleanup.hostUnresolved',
-              'Orca cannot tell which host owns this workspace. Refresh projects and review it again.'
-            )
+            message:
+              distinctKnownHostCount > 1
+                ? translate(
+                    'auto.store.slices.workspace.cleanup.hostCollision',
+                    'Error: this workspace exists on multiple hosts at the same path'
+                  )
+                : translate(
+                    'auto.store.slices.workspace.cleanup.hostUnresolved',
+                    'Orca cannot tell which host owns this workspace. Refresh projects and review it again.'
+                  )
           }
         }
   })

--- a/src/renderer/src/store/slices/workspace-cleanup.ts
+++ b/src/renderer/src/store/slices/workspace-cleanup.ts
@@ -35,6 +35,10 @@ import {
 } from './workspace-cleanup-broad-scan-registry'
 import { classifyTitleActivity, isExplicitAgentStatusFresh } from '@/lib/pane-agent-evidence'
 import { translate } from '@/i18n/i18n'
+import { resolveWorktreeOperationRoute } from '@/lib/worktree-operation-route'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
+import { resolveWorkspaceCleanupRemovalHostId } from '../../../../shared/workspace-cleanup-host-identity'
+import { isWorkspaceCleanupRemovalHostCertain } from './workspace-cleanup-removal-host-guard'
 import type { PreservedBranchCleanup } from '@/lib/preserved-branch-cleanup'
 
 export type WorkspaceCleanupFailure = {
@@ -1018,6 +1022,9 @@ async function preflightWorkspaceCleanupCandidates(
   // Why: one batched scan per chunk replaces a git worktree-list + activity
   // read per row; chunks stay under main's silent target truncation limit.
   const candidatesByWorktreeId = new Map<string, WorkspaceCleanupCandidate>()
+  // Why: candidatesByWorktreeId collapses a colliding id to one row, so record
+  // every owner the scan reported before the collapse hides the collision.
+  const scannedHostIdsByWorktreeId = new Map<string, Set<ExecutionHostId | null>>()
   for (let start = 0; start < worktreeIds.length; start += WORKSPACE_CLEANUP_TARGET_BATCH_LIMIT) {
     const chunk = worktreeIds.slice(start, start + WORKSPACE_CLEANUP_TARGET_BATCH_LIMIT)
     const scan = await window.api.workspaceCleanup.scan({
@@ -1025,6 +1032,11 @@ async function preflightWorkspaceCleanupCandidates(
       scanId: crypto.randomUUID(),
       refreshActivity: true
     })
+    for (const candidate of scan.candidates) {
+      const hostIds = scannedHostIdsByWorktreeId.get(candidate.worktreeId) ?? new Set()
+      hostIds.add(resolveWorkspaceCleanupRemovalHostId(candidate))
+      scannedHostIdsByWorktreeId.set(candidate.worktreeId, hostIds)
+    }
     const enriched = await enrichWorkspaceCleanupCandidates(scan.candidates, getState(), {
       applyDismissals: false
     })
@@ -1032,13 +1044,36 @@ async function preflightWorkspaceCleanupCandidates(
       candidatesByWorktreeId.set(candidate.worktreeId, candidate)
     }
   }
-  return worktreeIds.map((worktreeId) =>
-    evaluateWorkspaceCleanupPreflight(
+  return worktreeIds.map((worktreeId) => {
+    const preflight = evaluateWorkspaceCleanupPreflight(
       worktreeId,
       candidatesByWorktreeId.get(worktreeId),
       approvedCandidatesByWorktreeId.get(worktreeId)
     )
-  )
+    if (!preflight.ok) {
+      return preflight
+    }
+    // STA-4343: fail closed rather than delete another host's uncommitted work.
+    const hostIsCertain = isWorkspaceCleanupRemovalHostCertain({
+      confirmedCandidate: approvedCandidatesByWorktreeId.get(worktreeId),
+      scannedCandidate: preflight.candidate,
+      scannedHostIds: [...(scannedHostIdsByWorktreeId.get(worktreeId) ?? [])],
+      routeHostId: resolveWorktreeOperationRoute(getState(), worktreeId)?.executionHostId ?? null
+    })
+    return hostIsCertain
+      ? preflight
+      : {
+          ok: false as const,
+          failure: {
+            worktreeId,
+            displayName: preflight.candidate.displayName,
+            message: translate(
+              'auto.store.slices.workspace.cleanup.hostUnresolved',
+              'Orca cannot tell which host owns this workspace. Refresh projects and review it again.'
+            )
+          }
+        }
+  })
 }
 
 function evaluateWorkspaceCleanupPreflight(

--- a/src/renderer/src/store/slices/workspace-cleanup.ts
+++ b/src/renderer/src/store/slices/workspace-cleanup.ts
@@ -382,6 +382,28 @@ export const createWorkspaceCleanupSlice: StateCreator<AppState, [], [], Workspa
     // Why: nested workspaces can belong to different repos; parent removal must
     // not race child cleanup hooks, PTY teardown, or metadata deletion.
     for (const candidate of [...candidatesToRemove].sort((a, b) => b.path.length - a.path.length)) {
+      // Why: earlier rows can await long enough for active-host routing to change
+      // after the batched preflight; recheck in the same turn as removeWorktree.
+      const scannedHostId = resolveWorkspaceCleanupRemovalHostId(candidate)
+      if (
+        !isWorkspaceCleanupRemovalHostCertain({
+          confirmedCandidate: candidate,
+          scannedCandidate: candidate,
+          scannedHostIds: [scannedHostId],
+          routeHostId:
+            resolveWorktreeOperationRoute(get(), candidate.worktreeId)?.executionHostId ?? null
+        })
+      ) {
+        failures.push({
+          worktreeId: candidate.worktreeId,
+          displayName: candidate.displayName,
+          message: translate(
+            'auto.store.slices.workspace.cleanup.hostUnresolved',
+            'Orca cannot tell which host owns this workspace. Refresh projects and review it again.'
+          )
+        })
+        continue
+      }
       const result = await get().removeWorktree(
         candidate.worktreeId,
         shouldForceWorkspaceCleanupRemoval(candidate),

--- a/src/shared/workspace-cleanup-host-identity.ts
+++ b/src/shared/workspace-cleanup-host-identity.ts
@@ -1,0 +1,28 @@
+import {
+  normalizeExecutionHostId,
+  toSshExecutionHostId,
+  type ExecutionHostId
+} from './execution-host'
+
+/** Host evidence a cleanup row carries; `worktreeId` alone repeats across hosts. */
+export type WorkspaceCleanupHostFacts = {
+  connectionId?: string | null
+  executionHostId?: ExecutionHostId
+}
+
+/**
+ * The owner a destructive removal is allowed to target, or null when the row
+ * carries no host evidence at all (a snapshot or publisher that predates
+ * host-qualified candidates). Callers must fail closed on null instead of
+ * guessing — a wrong guess deletes another host's uncommitted work (STA-4343).
+ */
+export function resolveWorkspaceCleanupRemovalHostId(
+  candidate: WorkspaceCleanupHostFacts
+): ExecutionHostId | null {
+  const explicitHostId = normalizeExecutionHostId(candidate.executionHostId)
+  if (explicitHostId) {
+    return explicitHostId
+  }
+  const connectionId = candidate.connectionId?.trim()
+  return connectionId ? toSshExecutionHostId(connectionId) : null
+}


### PR DESCRIPTION
## ELI5

Two computers can have a workspace with the exact same name. The cleanup dialog only remembered the name, so ticking the row for the remote machine could delete the folder with the same name on your laptop — with your uncommitted work in it. This PR does not teach cleanup how to reach the right machine. It teaches it to **stop**: right before it deletes anything, it checks that the workspace it is about to delete really belongs to the machine whose row you confirmed, and if it can't prove that, it refuses and tells you to refresh.

## What Changed

**P0 data-loss fix. This is the MINIMAL, fail-closed version, intended for the 1.4.184 cherry-pick.** The complete fix is [#14606](https://github.com/stablyai/orca/pull/14606) (~4000 lines, threads host-qualified identity through all seven cleanup stages), which is too large to pick into tomorrow's cut with confidence.

| | property |
| --- | --- |
| **This PR** | never delete on the WRONG host — refuse when ownership is not certain |
| **#14606** | delete on the RIGHT host |

Workspace cleanup composes a candidate's `worktreeId` as `repoId::path`, with no host component, so two execution hosts (local, SSH, or a paired runtime) can publish the same id. Selection, confirmation, preflight and removal all kept only that id, and `resolveWorktreeOperationRouteResult` consults the ACTIVE workspace's host first — so confirming host B's row issued `worktrees.remove` / `worktree.rm` against host A and deleted host A's worktree along with its uncommitted work.

Three files, one guard, evaluated in `preflightWorkspaceCleanupCandidates` immediately before the row reaches `removeWorktree` (the only path to `worktrees.remove` / `worktree.rm`):

- **`src/shared/workspace-cleanup-host-identity.ts`** (new, 28 lines) — `resolveWorkspaceCleanupRemovalHostId()`. Returns the row's owning host from real host evidence (`executionHostId`, else `connectionId`), or `null` for a row that carries none. It deliberately does **not** fall back to `local`; a wrong guess is the bug.
  This is the same path, name and body as the module in #14606, so the follow-up merges over it cleanly.
- **`src/renderer/src/store/slices/workspace-cleanup-removal-host-guard.ts`** (new, 43 lines) — `isWorkspaceCleanupRemovalHostCertain()`. Certain only when all of:
  1. the confirmed row resolves to an owning host at all;
  2. the refreshed preflight scan reports **exactly one** owner for that id, and it is the confirmed one (a second owner means the id collides, and neither the list nor the selection can say which row was ticked);
  3. the host `removeWorktree` would actually route to is that same host.
  A `null` route is not a refusal here — `removeWorktree` already fails an unroutable removal closed with `WORKTREE_REMOVAL_AMBIGUOUS_ERROR` before touching any transport, so duplicating that refusal would only change the message.
- **`src/renderer/src/store/slices/workspace-cleanup.ts`** (+48/-3) — records every owner the refreshed scan reported *before* `candidatesByWorktreeId` collapses a colliding id to one row, then fails colliding owners with `Error: this workspace exists on multiple hosts at the same path`; stale or unknown ownership keeps the `hostUnresolved` refresh message. The refusal rides the existing per-row failure channel, so it renders in the dialog's row-failure UI with no UI change.
- **`en.json`** — adds the exact collision message while retaining `hostUnresolved` for stale or unknown ownership.

**What this deliberately does NOT do** — all of it belongs to #14606:

- It does **not** make a colliding-id workspace cleanable. Until #14606 lands, a workspace whose `repoId::path` exists on two hosts becomes **un-cleanable through the dialog** and shows the refusal message. Annoying, never destructive — and it is not a new lockout of anything that previously worked *correctly*: what previously "worked" was deleting the other host's data.
- No host-qualified identity threaded through selection / confirmation / progress / snapshot pruning / dismissals.
- No routing changes, no `worktree.rm` host qualification on the main/runtime side, no CLI change, no persistence or wire-format change.
- The sidebar's single-workspace delete is untouched. It shares the same routing hole, but "the host the row was confirmed against" is a cleanup-dialog concept; extending it there is #14606's remit.

Net: **+519 / −4** across 6 files: 122 production additions and 397 test/harness additions. One pre-existing test fixture gained `executionHostId: 'local'` (2 lines) — see Testing.

## Why

This is a P0 data-loss path: the operation that ran was a real `git worktree remove` / directory delete on a machine the user never selected. Failing closed on an ambiguous or changed owner is the correct trade for a destructive path — a wrong guess destroys uncommitted work, while a refusal costs one refresh.

**Is a call-site guard actually sufficient, or does it need identity threaded through the earlier stages to be meaningful?** It is sufficient *for the safety property*, and it does not depend on the earlier threading — but the reason is worth stating precisely, because the obvious reading says otherwise.

Under a collision the confirmed row's identity genuinely **is** untrustworthy: the dialog builds `new Map(rows.map((row) => [row.worktreeId, row.candidate]))`, so two colliding rows share a React key and the map keeps only the last one. Ticking the row you saw can hand the *other* host's candidate to confirmation. So the guard cannot trust "the host the row was confirmed against" to be what the user meant.

It does not have to. The guard refuses on the *collision itself*: the refreshed preflight scan is what returns both owners for the id, and two owners is an unconditional refusal regardless of which candidate object reached confirmation. The confirmed-host comparison then handles the non-colliding cases (stale row, changed owner, wrong route). Every path where the confirmed identity could be wrong is a path where the scan shows ≥2 owners and nothing is deleted. That is why the split holds — and it is also exactly why the minimal version cannot *route* a colliding row correctly, which is the part left to #14606.

**Cross-cutting concerns.** Cleanup candidates are always built locally by `src/main/ipc/workspace-cleanup-candidate.ts`, which host-qualifies every row via `getWorktreeExecutionHostId()`; the persisted snapshot validator (`workspace-cleanup-scan-snapshot.ts`) also requires `executionHostId` to be a string, so snapshot-hydrated rows carry it too. The `null` branch is therefore reachable only by a row that predates that contract, where refusing is the intended outcome. **Remote wire**: no wire change — `WorkspaceCleanupCandidate.executionHostId` already exists and is already populated, and the guard runs entirely in the renderer. **Folder workspaces**: they go through the same candidate builder and carry a host like any other row. **Cross-platform**: no path parsing or normalization added; the guard compares opaque host ids.

## Linked Issue

STA-4343 — https://linear.app/stably/issue/STA-4343 (P0 data loss; surface introduced by #13413)

Fixes STA-4343

## Visual Proof

`N/A` — no visual change. The dialog renders the same rows with the same styling and the refusal rides the existing per-row failure channel, so the only user-visible difference is that a colliding row now reports "Error: this workspace exists on multiple hosts at the same path" instead of silently deleting another machine's workspace. That difference only appears when two hosts expose the same `repoId::path`, which cannot be staged as a screenshot pair; the destructive outcome is proved on the filesystem by the tests below instead.

## Testing

The gate is **filesystem state, not arguments**. `src/renderer/src/store/slices/workspace-cleanup-wrong-host-removal-guard.test.ts` creates two REAL temp directories (host A and host B) sharing one `repoId::path` identity, each holding a marker file standing in for uncommitted work. The removal boundary (`window.api.worktrees.remove`) is the only fake, and it actually `rmSync`-deletes whichever host it is routed to.

**RED at `origin/main` (54645250e1), with only the test file added:**

```
 FAIL  src/renderer/src/store/slices/workspace-cleanup-wrong-host-removal-guard.test.ts > STA-4343 minimal guard: cleanup refuses a removal it cannot attribute to a host > confirming host B leaves ACTIVE host A intact when both hosts hold the same id
AssertionError: HOST A (active) worktree directory must still exist after confirming HOST B's row. worktrees.remove was routed to hostId=local: expected false to be true // Object.is equality

 Test Files  1 failed (1)
      Tests  3 failed | 3 passed (6)
```

The routed host in that message — `hostId=local` after confirming `ssh:ssh-1` — is the bug itself.

Coverage (all asserted as filesystem outcomes at the destructive boundary):

- host A `local` + ACTIVE, host B `ssh:ssh-1` confirmed → **both** markers survive, `worktrees.remove` never called, row fails with the exact collision message, host A's tabs/state untouched
- confirmed host no longer listed by the refreshed scan → nothing deleted, refusal message
- row carrying no host evidence at all → nothing deleted, refusal message
- **soundness controls** (a guard that blocks legitimate cleanup is its own regression): ordinary single-host `local`, single-host `ssh:ssh-1`, and host-qualified snapshot cleanup each still delete for real through the same rig, routed to the right host, with no failures. These three pass both before and after the change — as they must.

**Non-vacuity:** reverting only the production wiring in `workspace-cleanup.ts` (keeping the entire test file) turns exactly the **3** refusal tests RED again, while the **3** soundness controls stay green.

One pre-existing fixture changed: `workspace-cleanup-slice-test-harness.ts`'s `makeCandidate()` gained `executionHostId: 'local'`. It was modelling a host-less candidate, which `src/main/ipc/workspace-cleanup-candidate.ts` has never emitted since #13413 added the field; without it, seven existing tests were asserting deletion of a row that production would now (correctly) refuse. No assertions were weakened.

Commands run locally (macOS), verbatim:

- `npx vitest run --config config/vitest.config.ts src/renderer/src/store/slices/workspace-cleanup-wrong-host-removal-guard.test.ts` → **6 passed**
- `npx vitest run --config config/vitest.config.ts src/renderer/src/store src/shared` → **640 files, 7419 passed** (3 files / 19 tests skipped)
- `npx vitest run --config config/vitest.config.ts src/renderer/src/components/workspace-cleanup src/main/ipc/workspace-cleanup src/main/workspace-cleanup` → **32 files, 241 passed**
- `pnpm typecheck` → clean
- `npx oxlint --config .oxlintrc.json src config tests --deny-warnings` → clean (exit 0; verified the gate is live by injecting an `any` and seeing it flagged)
- `npx oxlint --config config/oxlint-code-quality-native-plugins.json src config tests mobile --deny-warnings` → clean
- `npx oxlint --type-aware --config config/oxlint-code-quality-type-aware.json src config tests --deny-warnings` → clean
- `node config/scripts/check-changed-code-quality.mjs` → **0 new findings across 5 changed files**
- `node config/scripts/check-react-doctor-changed.mjs` → **0 issues across 5 changed files**
- `node config/scripts/check-max-lines-ratchet.mjs` → OK, no new bypasses (**no `max-lines` disable added**; the guard lives in a new module precisely so the grandfathered slice does not grow its bypass)
- `node config/scripts/check-reliability-gates.mjs`, localization catalog / extraction / coverage → clean
- Formatting via `oxfmt` (this repo does not use prettier); the 7 `--check` findings repo-wide are pre-existing `.md`/`.cjs` files untouched here

Platforms: automated coverage runs on macOS; the guard compares opaque host ids with no path handling, and both the local IPC and SSH host identities are exercised. No Electron UI validation was needed — there is no UI change, and the refusal is proved deterministically at the destructive boundary.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

- **Security / data safety**: the entire point — an ambiguous, unknown, or changed owner now fails closed instead of deleting.
- **Cross-platform**: no path parsing or normalization added; host ids are compared as opaque strings.
- **Remote SSH / paired runtime**: no wire change; `WorkspaceCleanupCandidate.executionHostId` already existed and was already populated. An old cached snapshot with no host evidence fails closed rather than guessing.
- **Mobile**: no mobile surface touched.
- **Backwards compatibility**: renderer-only, no persistence or protocol change. The one behavioral regression is stated above and is intentional: colliding-id workspaces are un-cleanable through the dialog until #14606 lands.
- **Performance**: one extra `resolveWorktreeOperationRoute` per row in the removal preflight (a path that already resolves the same route inside `removeWorktree`, and which is bounded by the confirmed batch), plus a `Set` of host ids per scanned row.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test` pass locally (`pnpm build` not run locally; CI will cover)

## Author

- X / Twitter: @BrennanKB5
