### PR TITLE
feat(shortcuts): warn when macOS Mission Control captures digit chords

### DIFF
--- a/src/main/ipc/app.ts
+++ b/src/main/ipc/app.ts
@@ -22,6 +22,7 @@ import {
   resolveFloatingTerminalCwd
 } from './floating-workspace-directory'
 import { isMarkdownDocumentName, markdownDocumentFromFilePath } from './markdown-documents'
+import { registerMacSymbolicHotkeysProbeHandler } from './macos-symbolic-hotkeys-probe'
 import { registerRendererShutdownCheckpointHandler } from './renderer-shutdown-checkpoint'
 
 const KEYBOARD_INPUT_SOURCE_TIMEOUT_MS = 500
@@ -301,6 +302,8 @@ export function registerAppHandlers(store: Store, options: RegisterAppHandlersOp
       app.quit()
     }, 150)
   })
+
+  registerMacSymbolicHotkeysProbeHandler(readCommandStdout)
 
   ipcMain.handle('app:setUnreadDockBadgeCount', (_event, count: number) => {
     setUnreadDockBadgeCount(Number.isFinite(count) ? count : 0)

--- a/src/main/ipc/macos-symbolic-hotkeys-probe.ts
+++ b/src/main/ipc/macos-symbolic-hotkeys-probe.ts
@@ -1,10 +1,10 @@
 import { ipcMain } from 'electron'
 import {
-  capturedDigitChordsFromSymbolicHotkeysJson,
-  type MacCapturedDigitChord
+  capturedDigitRowChordsFromSymbolicHotkeysJson,
+  type MacCapturedDigitRowChord
 } from '../../shared/macos-symbolic-hotkeys'
 
-// Why: symbolichotkeys is plain dict/int/bool, so unlike HIToolbox a whole-domain json convert is safe.
+// Export live preferences; the plist may be stale.
 const MAC_SYMBOLIC_HOTKEYS_JSON_COMMAND = [
   '/usr/bin/defaults export com.apple.symbolichotkeys -',
   '/usr/bin/plutil -convert json -o - -'
@@ -16,23 +16,24 @@ type ReadCommandStdout = (
   timeoutMessage: string
 ) => Promise<string>
 
-// Why: Mission Control's Spaces chords (Ctrl+digit by default) are consumed by WindowServer
-// before app delivery, so the renderer can only detect the conflict, never observe the press.
+// Mission Control intercepts these chords before renderer delivery.
 export function registerMacSymbolicHotkeysProbeHandler(readCommandStdout: ReadCommandStdout): void {
-  ipcMain.handle('app:getMacCapturedDigitChords', async (): Promise<MacCapturedDigitChord[]> => {
-    if (process.platform !== 'darwin') {
-      return []
+  ipcMain.handle(
+    'app:getMacCapturedDigitRowChords',
+    async (): Promise<MacCapturedDigitRowChord[]> => {
+      if (process.platform !== 'darwin') {
+        return []
+      }
+      try {
+        const stdout = await readCommandStdout(
+          '/bin/sh',
+          ['-c', MAC_SYMBOLIC_HOTKEYS_JSON_COMMAND],
+          'Symbolic hotkeys probe timed out'
+        )
+        return capturedDigitRowChordsFromSymbolicHotkeysJson(JSON.parse(stdout))
+      } catch {
+        return []
+      }
     }
-    try {
-      const stdout = await readCommandStdout(
-        '/bin/sh',
-        ['-c', MAC_SYMBOLIC_HOTKEYS_JSON_COMMAND],
-        'Symbolic hotkeys probe timed out'
-      )
-      return capturedDigitChordsFromSymbolicHotkeysJson(JSON.parse(stdout))
-    } catch {
-      // Why: no signal (missing domain, sandbox, timeout) must never surface a false warning.
-      return []
-    }
-  })
+  )
 }

--- a/src/main/ipc/macos-symbolic-hotkeys-probe.ts
+++ b/src/main/ipc/macos-symbolic-hotkeys-probe.ts
@@ -1,0 +1,38 @@
+import { ipcMain } from 'electron'
+import {
+  capturedDigitChordsFromSymbolicHotkeysJson,
+  type MacCapturedDigitChord
+} from '../../shared/macos-symbolic-hotkeys'
+
+// Why: symbolichotkeys is plain dict/int/bool, so unlike HIToolbox a whole-domain json convert is safe.
+const MAC_SYMBOLIC_HOTKEYS_JSON_COMMAND = [
+  '/usr/bin/defaults export com.apple.symbolichotkeys -',
+  '/usr/bin/plutil -convert json -o - -'
+].join(' | ')
+
+type ReadCommandStdout = (
+  command: string,
+  args: string[],
+  timeoutMessage: string
+) => Promise<string>
+
+// Why: Mission Control's Spaces chords (Ctrl+digit by default) are consumed by WindowServer
+// before app delivery, so the renderer can only detect the conflict, never observe the press.
+export function registerMacSymbolicHotkeysProbeHandler(readCommandStdout: ReadCommandStdout): void {
+  ipcMain.handle('app:getMacCapturedDigitChords', async (): Promise<MacCapturedDigitChord[]> => {
+    if (process.platform !== 'darwin') {
+      return []
+    }
+    try {
+      const stdout = await readCommandStdout(
+        '/bin/sh',
+        ['-c', MAC_SYMBOLIC_HOTKEYS_JSON_COMMAND],
+        'Symbolic hotkeys probe timed out'
+      )
+      return capturedDigitChordsFromSymbolicHotkeysJson(JSON.parse(stdout))
+    } catch {
+      // Why: no signal (missing domain, sandbox, timeout) must never surface a false warning.
+      return []
+    }
+  })
+}

--- a/src/preload/api/app-api.ts
+++ b/src/preload/api/app-api.ts
@@ -5,7 +5,7 @@ import type {
   WriteTerminalRenderDesyncEvidenceArgs,
   WriteTerminalRenderDesyncEvidenceResult
 } from '../../shared/terminal-render-desync-evidence'
-import type { MacCapturedDigitChord } from '../../shared/macos-symbolic-hotkeys'
+import type { MacCapturedDigitRowChord } from '../../shared/macos-symbolic-hotkeys'
 import type { MarkdownDocument } from '../../shared/filesystem-entry-types'
 import type { PersistedUIState } from '../../shared/persisted-ui-state-types'
 import type { FloatingTerminalCwdRequest } from '../../shared/ui-chrome-types'
@@ -44,9 +44,8 @@ export type AppApi = {
    *  Distinguishes CJK IMEs and Option-layer-composing layouts that look like US QWERTY (issue #1205).
    *  Returns null on non-Darwin or when the defaults read fails. */
   getKeyboardInputSourceId: () => Promise<string | null>
-  /** macOS Mission Control digit chords (Switch to Desktop 1-9) the OS consumes before
-   *  app delivery, for shortcut-conflict warnings. Empty on non-Darwin or probe failure. */
-  getMacCapturedDigitChords: () => Promise<MacCapturedDigitChord[]>
+  /** Physical Mission Control chords before layout resolution. */
+  getMacCapturedDigitRowChords: () => Promise<MacCapturedDigitRowChord[]>
   /** Updates the macOS Dock unread badge. No-op on Windows/Linux. */
   setUnreadDockBadgeCount: (count: number) => Promise<void>
   /** Resolves the launch directory for global Floating Terminal tabs. */

--- a/src/preload/api/app-api.ts
+++ b/src/preload/api/app-api.ts
@@ -5,6 +5,7 @@ import type {
   WriteTerminalRenderDesyncEvidenceArgs,
   WriteTerminalRenderDesyncEvidenceResult
 } from '../../shared/terminal-render-desync-evidence'
+import type { MacCapturedDigitChord } from '../../shared/macos-symbolic-hotkeys'
 import type { MarkdownDocument } from '../../shared/filesystem-entry-types'
 import type { PersistedUIState } from '../../shared/persisted-ui-state-types'
 import type { FloatingTerminalCwdRequest } from '../../shared/ui-chrome-types'
@@ -43,6 +44,9 @@ export type AppApi = {
    *  Distinguishes CJK IMEs and Option-layer-composing layouts that look like US QWERTY (issue #1205).
    *  Returns null on non-Darwin or when the defaults read fails. */
   getKeyboardInputSourceId: () => Promise<string | null>
+  /** macOS Mission Control digit chords (Switch to Desktop 1-9) the OS consumes before
+   *  app delivery, for shortcut-conflict warnings. Empty on non-Darwin or probe failure. */
+  getMacCapturedDigitChords: () => Promise<MacCapturedDigitChord[]>
   /** Updates the macOS Dock unread badge. No-op on Windows/Linux. */
   setUnreadDockBadgeCount: (count: number) => Promise<void>
   /** Resolves the launch directory for global Floating Terminal tabs. */

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4,6 +4,7 @@ import { electronAPI } from '@electron-toolkit/preload'
 import { preloadE2EConfig } from './e2e-config'
 import { glApi } from './gitlab'
 import type { AppIdentity } from '../shared/app-identity'
+import type { MacCapturedDigitChord } from '../shared/macos-symbolic-hotkeys'
 import type { ComputerAwakeStatus } from '../shared/computer-awake-mode'
 import type {
   DashboardRevealAgentArgs,
@@ -534,6 +535,8 @@ const api = {
     // Why: macOS input mode (or layout ID) so keyboard workarounds can tell CJK/compose layouts from US QWERTY (issue #1205); null on non-Darwin or read failure.
     getKeyboardInputSourceId: (): Promise<string | null> =>
       ipcRenderer.invoke('app:getKeyboardInputSourceId'),
+    getMacCapturedDigitChords: (): Promise<MacCapturedDigitChord[]> =>
+      ipcRenderer.invoke('app:getMacCapturedDigitChords'),
     setUnreadDockBadgeCount: (count: number): Promise<void> =>
       ipcRenderer.invoke('app:setUnreadDockBadgeCount', count),
     getFloatingTerminalCwd: (args?: FloatingTerminalCwdRequest): Promise<string> =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4,7 +4,7 @@ import { electronAPI } from '@electron-toolkit/preload'
 import { preloadE2EConfig } from './e2e-config'
 import { glApi } from './gitlab'
 import type { AppIdentity } from '../shared/app-identity'
-import type { MacCapturedDigitChord } from '../shared/macos-symbolic-hotkeys'
+import type { MacCapturedDigitRowChord } from '../shared/macos-symbolic-hotkeys'
 import type { ComputerAwakeStatus } from '../shared/computer-awake-mode'
 import type {
   DashboardRevealAgentArgs,
@@ -535,8 +535,8 @@ const api = {
     // Why: macOS input mode (or layout ID) so keyboard workarounds can tell CJK/compose layouts from US QWERTY (issue #1205); null on non-Darwin or read failure.
     getKeyboardInputSourceId: (): Promise<string | null> =>
       ipcRenderer.invoke('app:getKeyboardInputSourceId'),
-    getMacCapturedDigitChords: (): Promise<MacCapturedDigitChord[]> =>
-      ipcRenderer.invoke('app:getMacCapturedDigitChords'),
+    getMacCapturedDigitRowChords: (): Promise<MacCapturedDigitRowChord[]> =>
+      ipcRenderer.invoke('app:getMacCapturedDigitRowChords'),
     setUnreadDockBadgeCount: (count: number): Promise<void> =>
       ipcRenderer.invoke('app:setUnreadDockBadgeCount', count),
     getFloatingTerminalCwd: (args?: FloatingTerminalCwdRequest): Promise<string> =>

--- a/src/renderer/src/components/settings/ShortcutCommandBlock.test.tsx
+++ b/src/renderer/src/components/settings/ShortcutCommandBlock.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getKeybindingDefinition } from '../../../../shared/keybindings'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { ShortcutCommandBlock } from './ShortcutCommandBlock'
+
+afterEach(cleanup)
+
+describe('ShortcutCommandBlock', () => {
+  it('wraps persistent conflict remediation instead of truncating it', () => {
+    const warning = 'Blocked by Mission Control. Remap here or change it in System Settings.'
+    const item = getKeybindingDefinition('tab.selectByIndex')
+    expect(item).not.toBeNull()
+
+    render(
+      <TooltipProvider>
+        <ShortcutCommandBlock
+          item={item!}
+          groupTitle="Tab Navigation"
+          platform="darwin"
+          effective={['Ctrl+1']}
+          modified={false}
+          warnings={[warning]}
+          previousBindings={[]}
+          recordingBindingIndex={null}
+          onStartRecordingAt={vi.fn()}
+          onAppendBinding={vi.fn()}
+          onCancelRecording={vi.fn()}
+          onCapture={vi.fn()}
+          onClearError={vi.fn()}
+          onRemoveBindingAt={vi.fn()}
+          onResetAction={vi.fn()}
+          onDisableAction={vi.fn()}
+          onEnableAction={vi.fn()}
+        />
+      </TooltipProvider>
+    )
+
+    const helper = screen.getByText(warning)
+    expect(helper.classList.contains('whitespace-normal')).toBe(true)
+    expect(helper.classList.contains('truncate')).toBe(false)
+  })
+})

--- a/src/renderer/src/components/settings/ShortcutCommandBlock.tsx
+++ b/src/renderer/src/components/settings/ShortcutCommandBlock.tsx
@@ -309,7 +309,7 @@ export function ShortcutCommandBlock({
       {helperMessage ? (
         <span
           className={cn(
-            'block truncate px-2 text-[11px] leading-4',
+            'block whitespace-normal px-2 text-[11px] leading-4',
             helperTone === 'error' ? 'text-destructive' : 'text-muted-foreground'
           )}
           aria-live="polite"

--- a/src/renderer/src/components/settings/ShortcutsPane.tsx
+++ b/src/renderer/src/components/settings/ShortcutsPane.tsx
@@ -11,6 +11,7 @@ import {
   type KeybindingDefinition,
   type KeybindingInput
 } from '../../../../shared/keybindings'
+import type { MacCapturedDigitChord } from '../../../../shared/macos-symbolic-hotkeys'
 import { EMPTY_DISABLED_TUI_AGENTS } from './shortcut-groups'
 import { useAppStore } from '../../store'
 import { KeybindingsFileActions } from './KeybindingsFileActions'
@@ -81,12 +82,27 @@ export function ShortcutsPane(): React.JSX.Element {
   )
   const [shortcutQuery, setShortcutQuery] = useState('')
   const [shortcutFilter, setShortcutFilter] = useState<ShortcutFilter>('all')
+  const [macCapturedDigitChords, setMacCapturedDigitChords] = useState<
+    readonly MacCapturedDigitChord[]
+  >([])
 
   // Why: suspend global dispatch so a captured chord reaches the editor.
   useEffect(() => {
     window.api.ui.setShortcutRecorderFocused(recordingActionId !== null)
     return () => window.api.ui.setShortcutRecorderFocused(false)
   }, [recordingActionId])
+
+  // Why: Mission Control chords are consumed before app delivery, so the only detection is a state probe on pane mount.
+  useEffect(() => {
+    if (!isMac) {
+      return
+    }
+    void window.api.app.getMacCapturedDigitChords().then((chords) => {
+      if (mountedRef.current && chords.length > 0) {
+        setMacCapturedDigitChords(chords)
+      }
+    })
+  }, [mountedRef])
 
   const { groups, definitions, definitionsByAction, ignoredConflictActionIds, conflictByAction } =
     useMemo(
@@ -95,9 +111,10 @@ export function ShortcutsPane(): React.JSX.Element {
           disabledTuiAgents,
           pluginCommands,
           keybindings,
-          platform
+          platform,
+          macCapturedDigitChords
         }),
-      [disabledTuiAgents, keybindings, pluginCommands]
+      [disabledTuiAgents, keybindings, macCapturedDigitChords, pluginCommands]
     )
   const definitionForAction = (actionId: KeybindingActionId): KeybindingDefinition | null =>
     definitionsByAction.get(actionId) ?? getKeybindingDefinition(actionId)

--- a/src/renderer/src/components/settings/ShortcutsPane.tsx
+++ b/src/renderer/src/components/settings/ShortcutsPane.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { useShallow } from 'zustand/react/shallow'
 import {
   findKeybindingConflictsForDefinitions,
@@ -11,7 +12,6 @@ import {
   type KeybindingDefinition,
   type KeybindingInput
 } from '../../../../shared/keybindings'
-import type { MacCapturedDigitChord } from '../../../../shared/macos-symbolic-hotkeys'
 import { EMPTY_DISABLED_TUI_AGENTS } from './shortcut-groups'
 import { useAppStore } from '../../store'
 import { KeybindingsFileActions } from './KeybindingsFileActions'
@@ -39,6 +39,7 @@ import { useEditablePluginCommands } from '@/store/plugin-panels'
 import { buildShortcutDefinitionCatalog } from './shortcut-definition-catalog'
 import { getClientCreationActionPolicy } from '@/lib/client-creation-action-policy'
 import { buildShortcutRowVisibility } from './shortcut-row-visibility'
+import { useMacCapturedDigitChords } from './use-mac-captured-digit-chords'
 
 const isMac = navigator.userAgent.includes('Mac')
 const platform: NodeJS.Platform = isMac
@@ -48,6 +49,7 @@ const platform: NodeJS.Platform = isMac
     : 'linux'
 
 export function ShortcutsPane(): React.JSX.Element {
+  useTranslation()
   const searchQuery = useAppStore((state) => state.settingsSearchQuery)
   const terminalShortcutPolicy = useAppStore(
     (state) => state.settings?.terminalShortcutPolicy ?? 'orca-first'
@@ -82,27 +84,17 @@ export function ShortcutsPane(): React.JSX.Element {
   )
   const [shortcutQuery, setShortcutQuery] = useState('')
   const [shortcutFilter, setShortcutFilter] = useState<ShortcutFilter>('all')
-  const [macCapturedDigitChords, setMacCapturedDigitChords] = useState<
-    readonly MacCapturedDigitChord[]
-  >([])
+  const macCapturedDigitChords = useMacCapturedDigitChords({ enabled: isMac })
+  const missionControlConflictMessage = translate(
+    'auto.components.settings.shortcutDefinitionCatalog.missionControlConflict',
+    'Blocked by Mission Control. Remap here or change it in System Settings.'
+  )
 
   // Why: suspend global dispatch so a captured chord reaches the editor.
   useEffect(() => {
     window.api.ui.setShortcutRecorderFocused(recordingActionId !== null)
     return () => window.api.ui.setShortcutRecorderFocused(false)
   }, [recordingActionId])
-
-  // Why: Mission Control chords are consumed before app delivery, so the only detection is a state probe on pane mount.
-  useEffect(() => {
-    if (!isMac) {
-      return
-    }
-    void window.api.app.getMacCapturedDigitChords().then((chords) => {
-      if (mountedRef.current && chords.length > 0) {
-        setMacCapturedDigitChords(chords)
-      }
-    })
-  }, [mountedRef])
 
   const { groups, definitions, definitionsByAction, ignoredConflictActionIds, conflictByAction } =
     useMemo(
@@ -112,9 +104,16 @@ export function ShortcutsPane(): React.JSX.Element {
           pluginCommands,
           keybindings,
           platform,
-          macCapturedDigitChords
+          macCapturedDigitChords,
+          missionControlConflictMessage
         }),
-      [disabledTuiAgents, keybindings, macCapturedDigitChords, pluginCommands]
+      [
+        disabledTuiAgents,
+        keybindings,
+        macCapturedDigitChords,
+        missionControlConflictMessage,
+        pluginCommands
+      ]
     )
   const definitionForAction = (actionId: KeybindingActionId): KeybindingDefinition | null =>
     definitionsByAction.get(actionId) ?? getKeybindingDefinition(actionId)

--- a/src/renderer/src/components/settings/shortcut-definition-catalog.test.ts
+++ b/src/renderer/src/components/settings/shortcut-definition-catalog.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import type { MacCapturedDigitChord } from '../../../../shared/macos-symbolic-hotkeys'
+import { i18n, translate } from '@/i18n/i18n'
+import { PSEUDO_LOCALIZATION_LOCALE } from '@/i18n/pseudo-localization'
+import { buildShortcutDefinitionCatalog } from './shortcut-definition-catalog'
+
+function chord(digit: number): MacCapturedDigitChord {
+  return { digit, meta: false, control: true, alt: false, shift: false }
+}
+
+function warningFor(chords: readonly MacCapturedDigitChord[]): string | undefined {
+  return buildShortcutDefinitionCatalog({
+    disabledTuiAgents: [],
+    pluginCommands: [],
+    keybindings: {},
+    platform: 'darwin',
+    macCapturedDigitChords: chords,
+    missionControlConflictMessage: translate(
+      'auto.components.settings.shortcutDefinitionCatalog.missionControlConflict',
+      'Blocked by Mission Control. Remap here or change it in System Settings.'
+    )
+  }).conflictByAction.get('tab.selectByIndex')?.[0]
+}
+
+afterEach(async () => {
+  await i18n.changeLanguage('en')
+})
+
+describe('Mission Control shortcut warnings', () => {
+  it('uses concise count-independent remediation copy', () => {
+    expect(warningFor([chord(1), chord(2), chord(3), chord(4), chord(5), chord(6)])).toBe(
+      'Blocked by Mission Control. Remap here or change it in System Settings.'
+    )
+  })
+
+  it('passes through pseudo-localization', async () => {
+    await i18n.changeLanguage(PSEUDO_LOCALIZATION_LOCALE)
+
+    expect(warningFor([chord(1)])).toBe(
+      '[Blocked by Mission Control. Remap here or change it in System Settings.]'
+    )
+  })
+
+  it.each([
+    ['es', 'Bloqueado por Mission Control. Reasigna aquí o cámbialo en Ajustes del Sistema.'],
+    [
+      'ja',
+      'Mission Control によってブロックされています。ここで再割り当てするか、システム設定で変更してください。'
+    ],
+    [
+      'ko',
+      'Mission Control에 의해 차단되었습니다. 여기에서 다시 매핑하거나 시스템 설정에서 변경하세요.'
+    ],
+    ['zh', '已被调度中心拦截。在此重新映射，或在系统设置中更改。']
+  ])('uses the shipped %s translation', async (locale, expected) => {
+    await i18n.changeLanguage(locale)
+
+    expect(warningFor([chord(1)])).toBe(expected)
+  })
+})

--- a/src/renderer/src/components/settings/shortcut-definition-catalog.ts
+++ b/src/renderer/src/components/settings/shortcut-definition-catalog.ts
@@ -28,6 +28,7 @@ export function buildShortcutDefinitionCatalog(options: {
   keybindings: KeybindingOverrides
   platform: NodeJS.Platform
   macCapturedDigitChords?: readonly MacCapturedDigitChord[]
+  missionControlConflictMessage: string
 }): ShortcutDefinitionCatalog {
   const pluginDefinitions = buildPluginCommandKeybindingDefinitions(options.pluginCommands)
   const groups = groupDefinitions(options.disabledTuiAgents, pluginDefinitions)
@@ -57,7 +58,6 @@ export function buildShortcutDefinitionCatalog(options: {
       ])
     }
   }
-  // Why: Mission Control chords never reach the app, so this is the only place the user can learn why the binding is dead.
   const systemConflicts = findMacSystemHotkeyConflicts(
     definitions,
     options.platform,
@@ -70,7 +70,7 @@ export function buildShortcutDefinitionCatalog(options: {
     }
     conflictByAction.set(conflict.actionId, [
       ...(conflictByAction.get(conflict.actionId) ?? []),
-      `${formatKeybindingList(conflict.capturedBindings, options.platform)} is captured by macOS Mission Control (Switch to Desktop) before it reaches Orca. Disable it in System Settings → Keyboard → Keyboard Shortcuts → Mission Control, or remap this shortcut.`
+      options.missionControlConflictMessage
     ])
   }
   return {

--- a/src/renderer/src/components/settings/shortcut-definition-catalog.ts
+++ b/src/renderer/src/components/settings/shortcut-definition-catalog.ts
@@ -5,6 +5,10 @@ import {
   type KeybindingDefinition,
   type KeybindingOverrides
 } from '../../../../shared/keybindings'
+import {
+  findMacSystemHotkeyConflicts,
+  type MacCapturedDigitChord
+} from '../../../../shared/macos-symbolic-hotkeys'
 import type { TuiAgent } from '../../../../shared/tui-agent'
 import type { ActivePluginCommand } from '@/store/plugin-panels'
 import { buildPluginCommandKeybindingDefinitions } from '@/lib/plugin-command-keybindings'
@@ -23,6 +27,7 @@ export function buildShortcutDefinitionCatalog(options: {
   pluginCommands: readonly ActivePluginCommand[]
   keybindings: KeybindingOverrides
   platform: NodeJS.Platform
+  macCapturedDigitChords?: readonly MacCapturedDigitChord[]
 }): ShortcutDefinitionCatalog {
   const pluginDefinitions = buildPluginCommandKeybindingDefinitions(options.pluginCommands)
   const groups = groupDefinitions(options.disabledTuiAgents, pluginDefinitions)
@@ -51,6 +56,22 @@ export function buildShortcutDefinitionCatalog(options: {
         `${formatKeybindingList([conflict.binding], options.platform)} conflicts with ${labels}.`
       ])
     }
+  }
+  // Why: Mission Control chords never reach the app, so this is the only place the user can learn why the binding is dead.
+  const systemConflicts = findMacSystemHotkeyConflicts(
+    definitions,
+    options.platform,
+    options.keybindings,
+    options.macCapturedDigitChords ?? []
+  )
+  for (const conflict of systemConflicts) {
+    if (ignoredConflictActionIds.includes(conflict.actionId)) {
+      continue
+    }
+    conflictByAction.set(conflict.actionId, [
+      ...(conflictByAction.get(conflict.actionId) ?? []),
+      `${formatKeybindingList(conflict.capturedBindings, options.platform)} is captured by macOS Mission Control (Switch to Desktop) before it reaches Orca. Disable it in System Settings → Keyboard → Keyboard Shortcuts → Mission Control, or remap this shortcut.`
+    ])
   }
   return {
     groups,

--- a/src/renderer/src/components/settings/shortcut-groups.test.ts
+++ b/src/renderer/src/components/settings/shortcut-groups.test.ts
@@ -44,7 +44,8 @@ describe('shortcut groups', () => {
       disabledTuiAgents: [],
       pluginCommands: [command],
       keybindings: {},
-      platform: 'darwin'
+      platform: 'darwin',
+      missionControlConflictMessage: 'Blocked by Mission Control.'
     })
 
     expect(catalog.conflictByAction.get('plugin:orca-samples.tasks/open')).toEqual([

--- a/src/renderer/src/components/settings/use-mac-captured-digit-chords.test.ts
+++ b/src/renderer/src/components/settings/use-mac-captured-digit-chords.test.ts
@@ -1,0 +1,152 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type {
+  MacCapturedDigitRowChord,
+  MacDigitRowCode
+} from '../../../../shared/macos-symbolic-hotkeys'
+import type { LayoutMapLike } from '@/lib/keyboard-layout/detect-option-as-alt'
+import { useMacCapturedDigitChords } from './use-mac-captured-digit-chords'
+
+const PHYSICAL_CTRL_ONE: MacCapturedDigitRowChord = {
+  code: 'Digit1',
+  meta: false,
+  control: true,
+  alt: false,
+  shift: false
+}
+
+function layoutMap(entries: [MacDigitRowCode, string][]): LayoutMapLike {
+  return new Map<string, string>(entries)
+}
+
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+} {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((next) => {
+    resolve = next
+  })
+  return { promise, resolve }
+}
+
+afterEach(cleanup)
+
+describe('useMacCapturedDigitChords', () => {
+  it('reads immediately and clears the warning after a focus refresh', async () => {
+    const readSystemChords = vi
+      .fn()
+      .mockResolvedValueOnce([PHYSICAL_CTRL_ONE])
+      .mockResolvedValueOnce([])
+    const readLayoutMap = vi.fn().mockResolvedValue(layoutMap([['Digit1', '1']]))
+    const hook = renderHook(() =>
+      useMacCapturedDigitChords({ enabled: true, readSystemChords, readLayoutMap })
+    )
+
+    await waitFor(() => expect(hook.result.current).toHaveLength(1))
+    act(() => window.dispatchEvent(new Event('focus')))
+    await waitFor(() => expect(hook.result.current).toEqual([]))
+
+    expect(readSystemChords).toHaveBeenCalledTimes(2)
+    expect(readLayoutMap).toHaveBeenCalledTimes(2)
+  })
+
+  it('stays silent when the active layout does not produce a digit', async () => {
+    const readSystemChords = async (): Promise<MacCapturedDigitRowChord[]> => [PHYSICAL_CTRL_ONE]
+    const readLayoutMap = async (): Promise<LayoutMapLike> => layoutMap([['Digit1', '&']])
+    const hook = renderHook(() =>
+      useMacCapturedDigitChords({
+        enabled: true,
+        readSystemChords,
+        readLayoutMap
+      })
+    )
+
+    await waitFor(() => expect(hook.result.current).toEqual([]))
+  })
+
+  it('clears a prior result when the system probe rejects', async () => {
+    const readSystemChords = vi
+      .fn()
+      .mockResolvedValueOnce([PHYSICAL_CTRL_ONE])
+      .mockRejectedValueOnce(new Error('unavailable'))
+    const readLayoutMap = async (): Promise<LayoutMapLike> => layoutMap([['Digit1', '1']])
+    const hook = renderHook(() =>
+      useMacCapturedDigitChords({
+        enabled: true,
+        readSystemChords,
+        readLayoutMap
+      })
+    )
+
+    await waitFor(() => expect(hook.result.current).toHaveLength(1))
+    act(() => window.dispatchEvent(new Event('focus')))
+    await waitFor(() => expect(hook.result.current).toEqual([]))
+  })
+
+  it('clears a prior result when the layout-map probe rejects', async () => {
+    const readSystemChords = vi.fn().mockResolvedValue([PHYSICAL_CTRL_ONE])
+    const readLayoutMap = vi
+      .fn()
+      .mockResolvedValueOnce(layoutMap([['Digit1', '1']]))
+      .mockRejectedValueOnce(new Error('layout unavailable'))
+    const hook = renderHook(() =>
+      useMacCapturedDigitChords({ enabled: true, readSystemChords, readLayoutMap })
+    )
+
+    await waitFor(() => expect(hook.result.current).toHaveLength(1))
+    act(() => window.dispatchEvent(new Event('focus')))
+    await waitFor(() => expect(hook.result.current).toEqual([]))
+  })
+
+  it('coalesces focus events into one trailing refresh', async () => {
+    const older = deferred<MacCapturedDigitRowChord[]>()
+    const newer = deferred<MacCapturedDigitRowChord[]>()
+    const readSystemChords = vi
+      .fn()
+      .mockResolvedValueOnce([PHYSICAL_CTRL_ONE])
+      .mockReturnValueOnce(older.promise)
+      .mockReturnValueOnce(newer.promise)
+    const readLayoutMap = async (): Promise<LayoutMapLike> => layoutMap([['Digit1', '1']])
+    const hook = renderHook(() =>
+      useMacCapturedDigitChords({
+        enabled: true,
+        readSystemChords,
+        readLayoutMap
+      })
+    )
+
+    await waitFor(() => expect(hook.result.current).toHaveLength(1))
+    act(() => {
+      window.dispatchEvent(new Event('focus'))
+      window.dispatchEvent(new Event('focus'))
+      window.dispatchEvent(new Event('focus'))
+    })
+    expect(readSystemChords).toHaveBeenCalledTimes(2)
+    await act(async () => older.resolve([]))
+    await waitFor(() => expect(readSystemChords).toHaveBeenCalledTimes(3))
+    expect(hook.result.current).toHaveLength(1)
+    await act(async () => newer.resolve([]))
+    expect(hook.result.current).toEqual([])
+  })
+
+  it('removes the focus listener when unmounted', async () => {
+    const readSystemChords = vi.fn().mockResolvedValue([PHYSICAL_CTRL_ONE])
+    const readLayoutMap = async (): Promise<LayoutMapLike> => layoutMap([['Digit1', '1']])
+    const hook = renderHook(() =>
+      useMacCapturedDigitChords({
+        enabled: true,
+        readSystemChords,
+        readLayoutMap
+      })
+    )
+    await waitFor(() => expect(readSystemChords).toHaveBeenCalledOnce())
+
+    hook.unmount()
+    window.dispatchEvent(new Event('focus'))
+
+    expect(readSystemChords).toHaveBeenCalledOnce()
+  })
+})

--- a/src/renderer/src/components/settings/use-mac-captured-digit-chords.ts
+++ b/src/renderer/src/components/settings/use-mac-captured-digit-chords.ts
@@ -1,0 +1,97 @@
+import { useEffect, useState } from 'react'
+import {
+  resolveCapturedDigitChordsForLayout,
+  type MacCapturedDigitChord,
+  type MacCapturedDigitRowChord
+} from '../../../../shared/macos-symbolic-hotkeys'
+import type { LayoutMapLike } from '@/lib/keyboard-layout/detect-option-as-alt'
+import { normalizeLayoutBaseCharacter } from '@/lib/keyboard-layout/layout-base-character'
+
+type SystemChordReader = (win: Window) => Promise<MacCapturedDigitRowChord[]>
+type LayoutMapReader = (win: Window) => Promise<LayoutMapLike | null>
+
+type UseMacCapturedDigitChordsOptions = {
+  enabled: boolean
+  win?: Window
+  readSystemChords?: SystemChordReader
+  readLayoutMap?: LayoutMapReader
+}
+
+const EMPTY_CHORDS: readonly MacCapturedDigitChord[] = []
+
+function defaultSystemChordReader(win: Window): Promise<MacCapturedDigitRowChord[]> {
+  return win.api.app.getMacCapturedDigitRowChords()
+}
+
+async function defaultLayoutMapReader(win: Window): Promise<LayoutMapLike | null> {
+  const navigatorWithKeyboard = win.navigator as Navigator & {
+    keyboard?: { getLayoutMap: () => Promise<LayoutMapLike> }
+  }
+  return navigatorWithKeyboard.keyboard?.getLayoutMap() ?? null
+}
+
+async function readCapturedDigitChords(
+  win: Window,
+  readSystemChords: SystemChordReader,
+  readLayoutMap: LayoutMapReader
+): Promise<readonly MacCapturedDigitChord[]> {
+  try {
+    const [physicalChords, layoutMap] = await Promise.all([
+      readSystemChords(win),
+      readLayoutMap(win)
+    ])
+    if (!layoutMap) {
+      return EMPTY_CHORDS
+    }
+    return resolveCapturedDigitChordsForLayout(physicalChords, (code) =>
+      normalizeLayoutBaseCharacter(layoutMap.get(code))
+    )
+  } catch {
+    return EMPTY_CHORDS
+  }
+}
+
+export function useMacCapturedDigitChords({
+  enabled,
+  win = window,
+  readSystemChords = defaultSystemChordReader,
+  readLayoutMap = defaultLayoutMapReader
+}: UseMacCapturedDigitChordsOptions): readonly MacCapturedDigitChord[] {
+  const [chords, setChords] = useState<readonly MacCapturedDigitChord[]>(EMPTY_CHORDS)
+
+  // Probe OS-owned chords that never reach the renderer.
+  useEffect(() => {
+    if (!enabled) {
+      return
+    }
+    let disposed = false
+    let probing = false
+    let refreshPending = false
+    const refresh = async (): Promise<void> => {
+      if (probing) {
+        refreshPending = true
+        return
+      }
+      probing = true
+      do {
+        refreshPending = false
+        const next = await readCapturedDigitChords(win, readSystemChords, readLayoutMap)
+        if (!disposed && !refreshPending) {
+          setChords(next)
+        }
+      } while (!disposed && refreshPending)
+      probing = false
+    }
+    const onFocus = (): void => {
+      void refresh()
+    }
+    win.addEventListener('focus', onFocus)
+    void refresh()
+    return () => {
+      disposed = true
+      win.removeEventListener('focus', onFocus)
+    }
+  }, [enabled, readLayoutMap, readSystemChords, win])
+
+  return chords
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -10733,6 +10733,9 @@
           "cancel": "Keep cleaning",
           "stopping": "Stopping…",
           "confirm": "Stop cleanup"
+        },
+        "shortcutDefinitionCatalog": {
+          "missionControlConflict": "Blocked by Mission Control. Remap here or change it in System Settings."
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -8785,6 +8785,9 @@
             }
           }
         },
+        "shortcutDefinitionCatalog": {
+          "missionControlConflict": "Bloqueado por Mission Control. Reasigna aquí o cámbialo en Ajustes del Sistema."
+        },
         "shortcuts": {
           "search": {
             "ca6a0c2df7": "atajo",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -8807,6 +8807,9 @@
             }
           }
         },
+        "shortcutDefinitionCatalog": {
+          "missionControlConflict": "Mission Control によってブロックされています。ここで再割り当てするか、システム設定で変更してください。"
+        },
         "shortcuts": {
           "search": {
             "ca6a0c2df7": "ショートカット",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -8770,6 +8770,9 @@
             }
           }
         },
+        "shortcutDefinitionCatalog": {
+          "missionControlConflict": "Mission Control에 의해 차단되었습니다. 여기에서 다시 매핑하거나 시스템 설정에서 변경하세요."
+        },
         "shortcuts": {
           "search": {
             "ca6a0c2df7": "단축키",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -8782,6 +8782,9 @@
             }
           }
         },
+        "shortcutDefinitionCatalog": {
+          "missionControlConflict": "已被调度中心拦截。在此重新映射，或在系统设置中更改。"
+        },
         "shortcuts": {
           "search": {
             "ca6a0c2df7": "捷径",

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -582,8 +582,8 @@ function createWebPreloadApi(): Partial<PreloadApi> {
       recoverLegacyWorkerTerminalsForRendererStartup: () => Promise.resolve(),
       startupDiagnostic: () => Promise.resolve(),
       getKeyboardInputSourceId: () => Promise.resolve(null),
-      // Why: the web client cannot probe the local machine's Spaces shortcuts — stay silent.
-      getMacCapturedDigitChords: () => Promise.resolve([]),
+      // The web client cannot inspect local Mission Control shortcuts.
+      getMacCapturedDigitRowChords: () => Promise.resolve([]),
       setUnreadDockBadgeCount: () => Promise.resolve(),
       getFloatingTerminalCwd: () => Promise.resolve(''),
       getFloatingMarkdownDirectory: () => Promise.resolve(''),

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -582,6 +582,8 @@ function createWebPreloadApi(): Partial<PreloadApi> {
       recoverLegacyWorkerTerminalsForRendererStartup: () => Promise.resolve(),
       startupDiagnostic: () => Promise.resolve(),
       getKeyboardInputSourceId: () => Promise.resolve(null),
+      // Why: the web client cannot probe the local machine's Spaces shortcuts — stay silent.
+      getMacCapturedDigitChords: () => Promise.resolve([]),
       setUnreadDockBadgeCount: () => Promise.resolve(),
       getFloatingTerminalCwd: () => Promise.resolve(''),
       getFloatingMarkdownDirectory: () => Promise.resolve(''),

--- a/src/shared/macos-symbolic-hotkeys.test.ts
+++ b/src/shared/macos-symbolic-hotkeys.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import { KEYBINDING_DEFINITIONS } from './keybindings'
+import {
+  capturedDigitChordsFromSymbolicHotkeysJson,
+  findMacSystemHotkeyConflicts,
+  type MacCapturedDigitChord
+} from './macos-symbolic-hotkeys'
+
+const CONTROL_MASK = 0x40000
+const OPTION_MASK = 0x80000
+const SHIFT_MASK = 0x20000
+
+function hotkeyEntry(keycode: number, mask: number, enabled = true): unknown {
+  return { enabled, value: { type: 'standard', parameters: [65535, keycode, mask] } }
+}
+
+function chord(
+  digit: number,
+  overrides: Partial<MacCapturedDigitChord> = {}
+): MacCapturedDigitChord {
+  return { digit, meta: false, control: true, alt: false, shift: false, ...overrides }
+}
+
+describe('capturedDigitChordsFromSymbolicHotkeysJson', () => {
+  it('parses enabled Switch to Desktop entries and skips disabled ones', () => {
+    const chords = capturedDigitChordsFromSymbolicHotkeysJson({
+      AppleSymbolicHotKeys: {
+        '118': hotkeyEntry(18, CONTROL_MASK),
+        '119': hotkeyEntry(19, CONTROL_MASK),
+        '120': hotkeyEntry(20, CONTROL_MASK, false)
+      }
+    })
+    expect(chords).toEqual([chord(1), chord(2)])
+  })
+
+  it('decodes option and shift modifier masks', () => {
+    const chords = capturedDigitChordsFromSymbolicHotkeysJson({
+      AppleSymbolicHotKeys: { '118': hotkeyEntry(18, CONTROL_MASK | OPTION_MASK | SHIFT_MASK) }
+    })
+    expect(chords).toEqual([chord(1, { alt: true, shift: true })])
+  })
+
+  it('skips unrecognized keycodes and malformed entries', () => {
+    const chords = capturedDigitChordsFromSymbolicHotkeysJson({
+      AppleSymbolicHotKeys: {
+        // Why: a rebound non-digit chord (keycode 49 = Space) must not be misread as a digit.
+        '118': hotkeyEntry(49, CONTROL_MASK),
+        '119': { enabled: true },
+        '120': { enabled: true, value: { parameters: 'bogus' } }
+      }
+    })
+    expect(chords).toEqual([])
+  })
+
+  it('returns empty for missing or non-object domains', () => {
+    expect(capturedDigitChordsFromSymbolicHotkeysJson(null)).toEqual([])
+    expect(capturedDigitChordsFromSymbolicHotkeysJson({})).toEqual([])
+    expect(capturedDigitChordsFromSymbolicHotkeysJson({ AppleSymbolicHotKeys: 'bogus' })).toEqual(
+      []
+    )
+  })
+})
+
+describe('findMacSystemHotkeyConflicts', () => {
+  it('flags the default darwin tab range against captured Ctrl+digits, not the Cmd workspace range', () => {
+    const conflicts = findMacSystemHotkeyConflicts(KEYBINDING_DEFINITIONS, 'darwin', undefined, [
+      chord(1),
+      chord(2)
+    ])
+    expect(conflicts).toEqual([
+      { actionId: 'tab.selectByIndex', binding: 'Ctrl+1', capturedBindings: ['Ctrl+1', 'Ctrl+2'] }
+    ])
+  })
+
+  it('covers every digit of the 1-9 range from the stored representative', () => {
+    const conflicts = findMacSystemHotkeyConflicts(KEYBINDING_DEFINITIONS, 'darwin', undefined, [
+      chord(7)
+    ])
+    expect(conflicts).toEqual([
+      { actionId: 'tab.selectByIndex', binding: 'Ctrl+1', capturedBindings: ['Ctrl+7'] }
+    ])
+  })
+
+  it('clears the conflict when the user remaps away from the captured modifiers', () => {
+    const conflicts = findMacSystemHotkeyConflicts(
+      KEYBINDING_DEFINITIONS,
+      'darwin',
+      { 'tab.selectByIndex': ['Ctrl+Cmd+1'] },
+      [chord(1), chord(2)]
+    )
+    expect(conflicts).toEqual([])
+  })
+
+  it('flags a remapped workspace range when Spaces chords use the same modifiers', () => {
+    const conflicts = findMacSystemHotkeyConflicts(
+      KEYBINDING_DEFINITIONS,
+      'darwin',
+      { 'tab.selectByIndex': [], 'workspace.selectByIndex': ['Ctrl+1'] },
+      [chord(3)]
+    )
+    expect(conflicts).toEqual([
+      { actionId: 'workspace.selectByIndex', binding: 'Ctrl+1', capturedBindings: ['Ctrl+3'] }
+    ])
+  })
+
+  it('returns empty without captured chords', () => {
+    expect(findMacSystemHotkeyConflicts(KEYBINDING_DEFINITIONS, 'darwin', undefined, [])).toEqual(
+      []
+    )
+  })
+})

--- a/src/shared/macos-symbolic-hotkeys.test.ts
+++ b/src/shared/macos-symbolic-hotkeys.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import { KEYBINDING_DEFINITIONS } from './keybindings'
 import {
-  capturedDigitChordsFromSymbolicHotkeysJson,
+  capturedDigitRowChordsFromSymbolicHotkeysJson,
   findMacSystemHotkeyConflicts,
-  type MacCapturedDigitChord
+  resolveCapturedDigitChordsForLayout,
+  type MacCapturedDigitChord,
+  type MacCapturedDigitRowChord,
+  type MacDigitRowCode
 } from './macos-symbolic-hotkeys'
 
 const CONTROL_MASK = 0x40000
@@ -21,43 +24,87 @@ function chord(
   return { digit, meta: false, control: true, alt: false, shift: false, ...overrides }
 }
 
-describe('capturedDigitChordsFromSymbolicHotkeysJson', () => {
+describe('capturedDigitRowChordsFromSymbolicHotkeysJson', () => {
   it('parses enabled Switch to Desktop entries and skips disabled ones', () => {
-    const chords = capturedDigitChordsFromSymbolicHotkeysJson({
+    const chords = capturedDigitRowChordsFromSymbolicHotkeysJson({
       AppleSymbolicHotKeys: {
         '118': hotkeyEntry(18, CONTROL_MASK),
         '119': hotkeyEntry(19, CONTROL_MASK),
         '120': hotkeyEntry(20, CONTROL_MASK, false)
       }
     })
-    expect(chords).toEqual([chord(1), chord(2)])
+    expect(chords).toEqual([physicalChord('Digit1'), physicalChord('Digit2')])
   })
 
   it('decodes option and shift modifier masks', () => {
-    const chords = capturedDigitChordsFromSymbolicHotkeysJson({
+    const chords = capturedDigitRowChordsFromSymbolicHotkeysJson({
       AppleSymbolicHotKeys: { '118': hotkeyEntry(18, CONTROL_MASK | OPTION_MASK | SHIFT_MASK) }
     })
-    expect(chords).toEqual([chord(1, { alt: true, shift: true })])
+    expect(chords).toEqual([physicalChord('Digit1', { alt: true, shift: true })])
   })
 
-  it('skips unrecognized keycodes and malformed entries', () => {
-    const chords = capturedDigitChordsFromSymbolicHotkeysJson({
+  it('skips non-standard, unrecognized, and malformed entries', () => {
+    const chords = capturedDigitRowChordsFromSymbolicHotkeysJson({
       AppleSymbolicHotKeys: {
-        // Why: a rebound non-digit chord (keycode 49 = Space) must not be misread as a digit.
         '118': hotkeyEntry(49, CONTROL_MASK),
         '119': { enabled: true },
-        '120': { enabled: true, value: { parameters: 'bogus' } }
+        '120': { enabled: true, value: { parameters: 'bogus' } },
+        '121': {
+          enabled: true,
+          value: { type: 'symbolic', parameters: [65535, 18, CONTROL_MASK] }
+        },
+        '122': {
+          enabled: true,
+          value: { type: 'standard', parameters: [65535, 18, Number.NaN] }
+        },
+        '123': {
+          enabled: true,
+          value: { type: 'standard', parameters: [65535, 18, CONTROL_MASK, 1] }
+        }
       }
     })
     expect(chords).toEqual([])
   })
 
+  it('skips chords with modifier bits the matcher cannot represent', () => {
+    const chords = capturedDigitRowChordsFromSymbolicHotkeysJson({
+      AppleSymbolicHotKeys: { '118': hotkeyEntry(18, CONTROL_MASK | 0x800000) }
+    })
+    expect(chords).toEqual([])
+  })
+
   it('returns empty for missing or non-object domains', () => {
-    expect(capturedDigitChordsFromSymbolicHotkeysJson(null)).toEqual([])
-    expect(capturedDigitChordsFromSymbolicHotkeysJson({})).toEqual([])
-    expect(capturedDigitChordsFromSymbolicHotkeysJson({ AppleSymbolicHotKeys: 'bogus' })).toEqual(
-      []
-    )
+    expect(capturedDigitRowChordsFromSymbolicHotkeysJson(null)).toEqual([])
+    expect(capturedDigitRowChordsFromSymbolicHotkeysJson({})).toEqual([])
+    expect(
+      capturedDigitRowChordsFromSymbolicHotkeysJson({ AppleSymbolicHotKeys: 'bogus' })
+    ).toEqual([])
+  })
+})
+
+function physicalChord(
+  code: MacDigitRowCode,
+  overrides: Partial<MacCapturedDigitRowChord> = {}
+): MacCapturedDigitRowChord {
+  return { code, meta: false, control: true, alt: false, shift: false, ...overrides }
+}
+
+describe('resolveCapturedDigitChordsForLayout', () => {
+  it('resolves physical keys through a digit-producing layout', () => {
+    const values = new Map<MacDigitRowCode, string>([
+      ['Digit1', '1'],
+      ['Digit2', '2']
+    ])
+    expect(
+      resolveCapturedDigitChordsForLayout(
+        [physicalChord('Digit1'), physicalChord('Digit2')],
+        (code) => values.get(code)
+      )
+    ).toEqual([chord(1), chord(2)])
+  })
+
+  it('does not equate AZERTY digit-row positions with logical digits', () => {
+    expect(resolveCapturedDigitChordsForLayout([physicalChord('Digit1')], () => '&')).toEqual([])
   })
 })
 

--- a/src/shared/macos-symbolic-hotkeys.ts
+++ b/src/shared/macos-symbolic-hotkeys.ts
@@ -7,72 +7,102 @@ import {
   type KeybindingOverrides
 } from './keybindings'
 
-/** A Mission Control "Switch to Desktop" chord WindowServer consumes before app delivery. */
-export type MacCapturedDigitChord = {
-  digit: number
+export type MacDigitRowCode =
+  | 'Digit1'
+  | 'Digit2'
+  | 'Digit3'
+  | 'Digit4'
+  | 'Digit5'
+  | 'Digit6'
+  | 'Digit7'
+  | 'Digit8'
+  | 'Digit9'
+
+type MacCapturedChordModifiers = {
   meta: boolean
   control: boolean
   alt: boolean
   shift: boolean
 }
 
+export type MacCapturedDigitRowChord = MacCapturedChordModifiers & {
+  code: MacDigitRowCode
+}
+
+export type MacCapturedDigitChord = MacCapturedChordModifiers & {
+  digit: number
+}
+
 export type MacSystemHotkeyConflict = {
   actionId: KeybindingActionId
-  /** Orca's effective binding that can never fire. */
   binding: string
-  /** Canonical chords the OS consumes, e.g. ['Ctrl+1', 'Ctrl+2']. */
   capturedBindings: string[]
 }
 
-// Symbolic hotkeys 118-126 = Switch to Desktop 1-9; entries appear once the user adds Spaces.
+// Symbolic hotkeys 118-126 switch to desktops 1-9.
 const SWITCH_TO_DESKTOP_HOTKEY_IDS = Array.from({ length: 9 }, (_, index) => 118 + index)
-// kVK_ANSI digit-row virtual keycodes (not contiguous: 5↔6 and 7-9 are shuffled).
-const DIGIT_BY_KEYCODE = new Map([
-  [18, 1],
-  [19, 2],
-  [20, 3],
-  [21, 4],
-  [23, 5],
-  [22, 6],
-  [26, 7],
-  [28, 8],
-  [25, 9]
+// kVK_ANSI digit-row keycodes are physical positions, not logical digits.
+const DIGIT_ROW_CODE_BY_KEYCODE = new Map<number, MacDigitRowCode>([
+  [18, 'Digit1'],
+  [19, 'Digit2'],
+  [20, 'Digit3'],
+  [21, 'Digit4'],
+  [23, 'Digit5'],
+  [22, 'Digit6'],
+  [26, 'Digit7'],
+  [28, 'Digit8'],
+  [25, 'Digit9']
 ])
-// NX device-independent modifier masks used in the parameters array.
+// NX device-independent masks from the parameters array.
 const SHIFT_MASK = 0x20000
 const CONTROL_MASK = 0x40000
 const OPTION_MASK = 0x80000
 const COMMAND_MASK = 0x100000
+const SUPPORTED_MODIFIER_MASK = SHIFT_MASK | CONTROL_MASK | OPTION_MASK | COMMAND_MASK
 
 function asRecord(value: unknown): Record<string, unknown> | null {
   return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : null
 }
 
-/** Parses `defaults export com.apple.symbolichotkeys | plutil -convert json` output into the
- *  digit chords Mission Control consumes. Anything unrecognized is skipped, never guessed. */
-export function capturedDigitChordsFromSymbolicHotkeysJson(json: unknown): MacCapturedDigitChord[] {
+function isSupportedParameter(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) >= 0 && (value as number) <= 0xffffffff
+}
+
+export function capturedDigitRowChordsFromSymbolicHotkeysJson(
+  json: unknown
+): MacCapturedDigitRowChord[] {
   const hotkeys = asRecord(asRecord(json)?.AppleSymbolicHotKeys)
   if (!hotkeys) {
     return []
   }
-  const chords: MacCapturedDigitChord[] = []
+  const chords: MacCapturedDigitRowChord[] = []
   for (const id of SWITCH_TO_DESKTOP_HOTKEY_IDS) {
     const entry = asRecord(hotkeys[String(id)])
-    if (!entry?.enabled) {
+    if (entry?.enabled !== true) {
       continue
     }
-    const parameters = asRecord(entry.value)?.parameters
-    if (!Array.isArray(parameters)) {
+    const value = asRecord(entry.value)
+    const parameters = value?.parameters
+    if (value?.type !== 'standard' || !Array.isArray(parameters) || parameters.length !== 3) {
       continue
     }
+    const character = parameters[0]
     const keycode = parameters[1]
     const mask = parameters[2]
-    const digit = typeof keycode === 'number' ? DIGIT_BY_KEYCODE.get(keycode) : undefined
-    if (digit === undefined || typeof mask !== 'number') {
+    if (
+      !isSupportedParameter(character) ||
+      !isSupportedParameter(keycode) ||
+      !isSupportedParameter(mask) ||
+      (mask & ~SUPPORTED_MODIFIER_MASK) !== 0
+    ) {
+      continue
+    }
+    const code = DIGIT_ROW_CODE_BY_KEYCODE.get(keycode)
+    if (!code) {
       continue
     }
     chords.push({
-      digit,
+      code,
       meta: (mask & COMMAND_MASK) !== 0,
       control: (mask & CONTROL_MASK) !== 0,
       alt: (mask & OPTION_MASK) !== 0,
@@ -80,6 +110,23 @@ export function capturedDigitChordsFromSymbolicHotkeysJson(json: unknown): MacCa
     })
   }
   return chords
+}
+
+type LayoutBaseCharacterReader = (code: MacDigitRowCode) => string | undefined
+
+export function resolveCapturedDigitChordsForLayout(
+  chords: readonly MacCapturedDigitRowChord[],
+  readBaseCharacter: LayoutBaseCharacterReader
+): MacCapturedDigitChord[] {
+  const resolved: MacCapturedDigitChord[] = []
+  for (const { code, ...modifiers } of chords) {
+    const character = readBaseCharacter(code)
+    if (!character || !DIGIT_KEY_PATTERN.test(character)) {
+      continue
+    }
+    resolved.push({ digit: Number(character), ...modifiers })
+  }
+  return resolved
 }
 
 function chordToBinding(chord: MacCapturedDigitChord): string {
@@ -102,7 +149,7 @@ function chordToBinding(chord: MacCapturedDigitChord): string {
 
 const DIGIT_KEY_PATTERN = /^[1-9]$/
 
-// A digit-index row's stored chord is a 1-9 representative; expand so every captured digit is checked.
+// Expand a digit-index representative across its full 1-9 range.
 function candidateBindings(actionId: KeybindingActionId, binding: string): string[] {
   if (!isDigitIndexActionId(actionId)) {
     return [binding]
@@ -116,8 +163,7 @@ function candidateBindings(actionId: KeybindingActionId, binding: string): strin
   )
 }
 
-/** Finds Orca bindings the OS consumes before delivery — they can never fire, so an
- *  in-app handler fix is impossible and the conflict must be surfaced to the user. */
+/** Finds Orca bindings intercepted by Mission Control. */
 export function findMacSystemHotkeyConflicts(
   definitions: readonly KeybindingDefinition[],
   platform: NodeJS.Platform,

--- a/src/shared/macos-symbolic-hotkeys.ts
+++ b/src/shared/macos-symbolic-hotkeys.ts
@@ -1,0 +1,149 @@
+import {
+  getEffectiveKeybindingsForDefinition,
+  getKeybindingConflictIdentity,
+  isDigitIndexActionId,
+  type KeybindingActionId,
+  type KeybindingDefinition,
+  type KeybindingOverrides
+} from './keybindings'
+
+/** A Mission Control "Switch to Desktop" chord WindowServer consumes before app delivery. */
+export type MacCapturedDigitChord = {
+  digit: number
+  meta: boolean
+  control: boolean
+  alt: boolean
+  shift: boolean
+}
+
+export type MacSystemHotkeyConflict = {
+  actionId: KeybindingActionId
+  /** Orca's effective binding that can never fire. */
+  binding: string
+  /** Canonical chords the OS consumes, e.g. ['Ctrl+1', 'Ctrl+2']. */
+  capturedBindings: string[]
+}
+
+// Symbolic hotkeys 118-126 = Switch to Desktop 1-9; entries appear once the user adds Spaces.
+const SWITCH_TO_DESKTOP_HOTKEY_IDS = Array.from({ length: 9 }, (_, index) => 118 + index)
+// kVK_ANSI digit-row virtual keycodes (not contiguous: 5↔6 and 7-9 are shuffled).
+const DIGIT_BY_KEYCODE = new Map([
+  [18, 1],
+  [19, 2],
+  [20, 3],
+  [21, 4],
+  [23, 5],
+  [22, 6],
+  [26, 7],
+  [28, 8],
+  [25, 9]
+])
+// NX device-independent modifier masks used in the parameters array.
+const SHIFT_MASK = 0x20000
+const CONTROL_MASK = 0x40000
+const OPTION_MASK = 0x80000
+const COMMAND_MASK = 0x100000
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : null
+}
+
+/** Parses `defaults export com.apple.symbolichotkeys | plutil -convert json` output into the
+ *  digit chords Mission Control consumes. Anything unrecognized is skipped, never guessed. */
+export function capturedDigitChordsFromSymbolicHotkeysJson(json: unknown): MacCapturedDigitChord[] {
+  const hotkeys = asRecord(asRecord(json)?.AppleSymbolicHotKeys)
+  if (!hotkeys) {
+    return []
+  }
+  const chords: MacCapturedDigitChord[] = []
+  for (const id of SWITCH_TO_DESKTOP_HOTKEY_IDS) {
+    const entry = asRecord(hotkeys[String(id)])
+    if (!entry?.enabled) {
+      continue
+    }
+    const parameters = asRecord(entry.value)?.parameters
+    if (!Array.isArray(parameters)) {
+      continue
+    }
+    const keycode = parameters[1]
+    const mask = parameters[2]
+    const digit = typeof keycode === 'number' ? DIGIT_BY_KEYCODE.get(keycode) : undefined
+    if (digit === undefined || typeof mask !== 'number') {
+      continue
+    }
+    chords.push({
+      digit,
+      meta: (mask & COMMAND_MASK) !== 0,
+      control: (mask & CONTROL_MASK) !== 0,
+      alt: (mask & OPTION_MASK) !== 0,
+      shift: (mask & SHIFT_MASK) !== 0
+    })
+  }
+  return chords
+}
+
+function chordToBinding(chord: MacCapturedDigitChord): string {
+  const parts: string[] = []
+  if (chord.meta) {
+    parts.push('Cmd')
+  }
+  if (chord.control) {
+    parts.push('Ctrl')
+  }
+  if (chord.alt) {
+    parts.push('Alt')
+  }
+  if (chord.shift) {
+    parts.push('Shift')
+  }
+  parts.push(String(chord.digit))
+  return parts.join('+')
+}
+
+const DIGIT_KEY_PATTERN = /^[1-9]$/
+
+// A digit-index row's stored chord is a 1-9 representative; expand so every captured digit is checked.
+function candidateBindings(actionId: KeybindingActionId, binding: string): string[] {
+  if (!isDigitIndexActionId(actionId)) {
+    return [binding]
+  }
+  const parts = binding.split('+')
+  if (!DIGIT_KEY_PATTERN.test(parts.at(-1) ?? '')) {
+    return [binding]
+  }
+  return Array.from({ length: 9 }, (_, index) =>
+    [...parts.slice(0, -1), String(index + 1)].join('+')
+  )
+}
+
+/** Finds Orca bindings the OS consumes before delivery — they can never fire, so an
+ *  in-app handler fix is impossible and the conflict must be surfaced to the user. */
+export function findMacSystemHotkeyConflicts(
+  definitions: readonly KeybindingDefinition[],
+  platform: NodeJS.Platform,
+  overrides: KeybindingOverrides | undefined,
+  capturedChords: readonly MacCapturedDigitChord[]
+): MacSystemHotkeyConflict[] {
+  if (capturedChords.length === 0) {
+    return []
+  }
+  const capturedByIdentity = new Map<string, string>()
+  for (const chord of capturedChords) {
+    const captured = chordToBinding(chord)
+    capturedByIdentity.set(getKeybindingConflictIdentity(captured, platform), captured)
+  }
+  const conflicts: MacSystemHotkeyConflict[] = []
+  for (const definition of definitions) {
+    for (const binding of getEffectiveKeybindingsForDefinition(definition, platform, overrides)) {
+      const capturedBindings = candidateBindings(definition.id, binding)
+        .map((candidate) =>
+          capturedByIdentity.get(getKeybindingConflictIdentity(candidate, platform))
+        )
+        .filter((captured): captured is string => captured !== undefined)
+      if (capturedBindings.length > 0) {
+        conflicts.push({ actionId: definition.id, binding, capturedBindings })
+      }
+    }
+  }
+  return conflicts
+}


### PR DESCRIPTION
## Summary

On macOS, an enabled “Switch to Desktop 1–9” symbolic shortcut can consume a digit chord before Orca receives it. Settings → Shortcuts now warns only when Orca confirms that the local system owns the same effective chord.

This PR does not change shortcut defaults.

## Product decision and scope

Orca introduced the macOS `Ctrl+1–9` tab default on May 30 in #3193 and made it remappable on June 19 in #5789. The linked issue #14733 was filed nine minutes after this PR’s first implementation commit, so it is useful reproduction evidence—not independent proof of a longstanding regression.

Changing the default now would require a migration and a broader redesign of Orca’s separate tab and workspace digit ranges. This PR keeps the current defaults and makes verified OS conflicts visible; a default migration can be evaluated separately.

Fixes #14733.

## What changed

- Reads live local macOS symbolic-hotkey preferences through a Darwin-only main-process probe with a 500 ms process-group timeout.
- Validates the exact known preference shape, physical digit-row keycodes, supported modifier bits, and bounded numeric values. Unknown or malformed data fails silent.
- Resolves physical keys through a fresh active keyboard-layout map. It does not guess a US layout or reuse stale layout data.
- Probes immediately and again when the window regains focus, so following the remediation in System Settings updates the warning without remounting Settings.
- Serializes refreshes, coalesces focus bursts to one trailing probe, rejects stale results, clears failed reads, and removes the listener on cleanup.
- Routes the warning through the existing conflict UI, including the Conflicts filter/count. Helper text wraps instead of truncating.
- Ships concise warning copy in English, Spanish, Japanese, Korean, and Chinese.
- Probes the local Electron client for desktop SSH workspaces because that Mac receives the keystroke. Paired web stays silent locally. No remote-wire contract changes.

## Visual proof

Conflict detected from the local macOS preference and active layout; the full remediation is visible and Conflicts is 1:

![Conflict detected](https://github.com/user-attachments/assets/60bced9f-0728-4f0a-bc00-93a9a4ee1b5f)

After the preference is cleared and Orca regains focus, the warning disappears without remounting and Conflicts returns to 0:

![Cleared after focus refresh](https://github.com/user-attachments/assets/af8692ef-0181-405a-8ed6-e6db32478d92)

A 600 px viewport check also confirmed the helper wraps to two lines without clipping.

## Verification

- Full local suite: 5,636 test files passed, 22 skipped; 52,833 tests passed, 123 skipped.
- Final rebased head: 37 focused tests passed across parsing, IPC wiring, layout resolution, focus refresh/coalescing, localization, and helper rendering.
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- Localization catalog, extraction, and coverage gates
- Max-lines ratchet and `git diff --check`
- Three independent readiness passes: correctness/security, performance/UI lifecycle, and compatibility/packaging; no P0/P1/P2 findings remain.
- Electron CDP validation attached to the intended worktree and checked both the rendered state and backing IPC/state. Six enabled desktop-switch chords produced one range conflict; clearing them and refocusing cleared the rendered warning.

## Compatibility and failure behavior

- Windows/Linux return before any macOS command.
- Desktop SSH correctly uses the local client’s Mission Control state.
- Paired web returns no warning and does not query the paired host.
- Missing APIs, rejected layout-map reads, malformed preferences, subprocess failures, and timeouts all return no warning.
- No persisted-state, mobile, RPC, relay, Git-provider, dependency, native-module, or remote-wire changes.

## Checklist

- [x] Manually tested in the rendered Electron app
- [x] Automated regression coverage added
- [x] Cross-platform, SSH, paired-web, localization, lifecycle, and failure paths reviewed
- [x] Full tests, lint, typecheck, build, and localization gates pass

## AI disclosure

AI-assisted implementation and review. The maintainer directed the product decision, reviewed the diff, and verified the automated and rendered evidence.
