### PR TITLE
Fix macOS updater relaunch races across profiles

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -112,6 +112,7 @@ import {
 import { configureRemoteServerUpdater } from './runtime/remote-server-updater'
 import type { UpdateCheckOptions } from '../shared/update-status-types'
 import { recordUpdaterLifecycle } from './updater-lifecycle-diagnostics'
+import { shouldDeferMacLaunchForUpdate } from './macos-update-install-handoff'
 import {
   installServeSupervisorDisconnectQuit,
   notifyServeSupervisorReady
@@ -646,6 +647,17 @@ const devAgentHookEndpointNamespace = devInstanceIdentity.isDev
 installUncaughtPipeErrorGuard()
 // Why (issue #9441): without this, one rejected background promise during startup restore kills main silently (exit 1, no crash report).
 installUnhandledRejectionLogging()
+if (
+  shouldDeferMacLaunchForUpdate({
+    appDataPath: app.getPath('appData'),
+    appVersion: app.getVersion(),
+    executablePath: process.execPath,
+    isPackaged: app.isPackaged
+  })
+) {
+  console.info('[updater] Deferring old-version launch while ShipIt applies the update')
+  app.exit(0)
+}
 // Why: expose the app version via process.env so main and the forked daemon can set TERM_PROGRAM_VERSION without importing electron.
 process.env.ORCA_APP_VERSION = app.getVersion()
 configureRemoteServerUpdater({
@@ -3320,6 +3332,7 @@ app.on('window-all-closed', () => {
     shouldQuitWhenAllWindowsClosed({
       platform: process.platform,
       isQuitting,
+      isQuittingForUpdate: isQuittingForUpdate(),
       isServeMode
     })
   ) {

--- a/src/main/macos-update-install-handoff.test.ts
+++ b/src/main/macos-update-install-handoff.test.ts
@@ -1,0 +1,298 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  MAC_UPDATE_INSTALL_HANDOFF_MAX_AGE_MS,
+  MAC_UPDATE_INSTALL_SHIPIT_APPEARANCE_MS,
+  armMacUpdateInstallHandoff,
+  clearMacUpdateInstallHandoff,
+  findConflictingMacAppPids,
+  getMacUpdateInstallHandoffPath,
+  isMatchingBundleShipItRunning,
+  parseSameExecutablePids,
+  shouldDeferMacLaunchForUpdate
+} from './macos-update-install-handoff'
+
+const APP_EXECUTABLE = '/Applications/Orca.app/Contents/MacOS/Orca'
+const APP_BUNDLE = '/Applications/Orca.app'
+const SHIPIT = '/Applications/Orca.app/Contents/Frameworks/Squirrel.framework/Resources/ShipIt'
+const SOURCE_RC = '1.4.160-rc.3'
+const TARGET_ADHOC = '1.4.160-adhoc.20260815140533'
+
+const tempDirectories: string[] = []
+
+function createAppData(): string {
+  const directory = mkdtempSync(join(tmpdir(), 'orca-update-handoff-'))
+  tempDirectories.push(directory)
+  return directory
+}
+
+function arm(appDataPath: string, now = 1_000_000) {
+  return armMacUpdateInstallHandoff({
+    appDataPath,
+    executablePath: APP_EXECUTABLE,
+    isPackaged: true,
+    platform: 'darwin',
+    sourceVersion: SOURCE_RC,
+    targetVersion: TARGET_ADHOC,
+    now
+  })!
+}
+
+afterEach(() => {
+  for (const directory of tempDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+describe('macOS update process detection', () => {
+  it('finds only other main processes using the exact installed executable', () => {
+    const output = [
+      `  100 ${APP_EXECUTABLE}`,
+      `  200 ${APP_EXECUTABLE}`,
+      '  300 /Applications/Orca.app/Contents/Frameworks/Orca Helper.app/Contents/MacOS/Orca Helper',
+      '  400 /Applications/Orca Copy.app/Contents/MacOS/Orca'
+    ].join('\n')
+
+    expect(parseSameExecutablePids(output, APP_EXECUTABLE, 100)).toEqual([200])
+  })
+
+  it('keeps executable paths containing spaces intact', () => {
+    const executable = '/Users/test/My Apps/Orca.app/Contents/MacOS/Orca'
+    expect(
+      parseSameExecutablePids(`  42 ${executable}\n  43 ${executable} Helper`, executable, 1)
+    ).toEqual([42])
+  })
+
+  it('is macOS-only and fails stop when the macOS process table is unavailable', async () => {
+    await expect(
+      findConflictingMacAppPids({
+        platform: 'linux',
+        readProcessList: async () => `  42 ${APP_EXECUTABLE}`
+      })
+    ).resolves.toEqual([])
+    await expect(
+      findConflictingMacAppPids({
+        platform: 'darwin',
+        readProcessList: async () => {
+          throw new Error('ps unavailable')
+        }
+      })
+    ).resolves.toBeNull()
+  })
+
+  it('matches only this bundle’s ShipIt executable at argv zero', () => {
+    expect(isMatchingBundleShipItRunning(APP_BUNDLE, `${SHIPIT} com.stablyai.orca.ShipIt`)).toBe(
+      true
+    )
+    expect(isMatchingBundleShipItRunning(APP_BUNDLE, `/bin/zsh -c echo ${SHIPIT}`)).toBe(false)
+    expect(
+      isMatchingBundleShipItRunning(
+        APP_BUNDLE,
+        '/Applications/Other.app/Contents/Frameworks/Squirrel.framework/Resources/ShipIt'
+      )
+    ).toBe(false)
+  })
+})
+
+describe('macOS update install handoff', () => {
+  it('writes profile-independent source and exact target build identity durably', () => {
+    const appDataPath = createAppData()
+    arm(appDataPath)
+
+    const marker = JSON.parse(readFileSync(getMacUpdateInstallHandoffPath(appDataPath), 'utf8'))
+    expect(marker).toMatchObject({
+      schemaVersion: 1,
+      sourceVersion: SOURCE_RC,
+      targetVersion: TARGET_ADHOC,
+      targetBundlePath: APP_BUNDLE
+    })
+  })
+
+  it('blocks the source build during the ShipIt appearance window', () => {
+    const appDataPath = createAppData()
+    const now = 1_000_000
+    arm(appDataPath, now)
+
+    expect(
+      shouldDeferMacLaunchForUpdate({
+        appDataPath,
+        appVersion: SOURCE_RC,
+        executablePath: APP_EXECUTABLE,
+        isPackaged: true,
+        platform: 'darwin',
+        now: now + MAC_UPDATE_INSTALL_SHIPIT_APPEARANCE_MS,
+        readProcessList: () => {
+          throw new Error('must not probe during appearance grace')
+        }
+      })
+    ).toBe(true)
+  })
+
+  it('blocks while this bundle’s ShipIt runs and releases after it exits', () => {
+    const appDataPath = createAppData()
+    const now = 1_000_000
+    arm(appDataPath, now)
+    const options = {
+      appDataPath,
+      appVersion: SOURCE_RC,
+      executablePath: APP_EXECUTABLE,
+      isPackaged: true,
+      platform: 'darwin' as const,
+      now: now + MAC_UPDATE_INSTALL_SHIPIT_APPEARANCE_MS + 1
+    }
+
+    expect(
+      shouldDeferMacLaunchForUpdate({
+        ...options,
+        readProcessList: () => `${SHIPIT} com.stablyai.orca.ShipIt`
+      })
+    ).toBe(true)
+    expect(
+      shouldDeferMacLaunchForUpdate({ ...options, readProcessList: () => '/bin/launchd' })
+    ).toBe(false)
+    expect(existsSync(getMacUpdateInstallHandoffPath(appDataPath))).toBe(false)
+  })
+
+  it('keeps blocking if ShipIt state cannot be inspected after the appearance window', () => {
+    const appDataPath = createAppData()
+    const now = 1_000_000
+    arm(appDataPath, now)
+
+    expect(
+      shouldDeferMacLaunchForUpdate({
+        appDataPath,
+        appVersion: SOURCE_RC,
+        executablePath: APP_EXECUTABLE,
+        isPackaged: true,
+        platform: 'darwin',
+        now: now + MAC_UPDATE_INSTALL_SHIPIT_APPEARANCE_MS + 1,
+        readProcessList: () => {
+          throw new Error('ps unavailable')
+        }
+      })
+    ).toBe(true)
+  })
+
+  it('expires a stale handoff instead of trapping the source build indefinitely', () => {
+    const appDataPath = createAppData()
+    const now = 1_000_000
+    arm(appDataPath, now)
+
+    expect(
+      shouldDeferMacLaunchForUpdate({
+        appDataPath,
+        appVersion: SOURCE_RC,
+        executablePath: APP_EXECUTABLE,
+        isPackaged: true,
+        platform: 'darwin',
+        now: now + MAC_UPDATE_INSTALL_HANDOFF_MAX_AGE_MS + 1,
+        readProcessList: () => `${SHIPIT} com.stablyai.orca.ShipIt`
+      })
+    ).toBe(false)
+    expect(existsSync(getMacUpdateInstallHandoffPath(appDataPath))).toBe(false)
+  })
+
+  it('does not gate a different app bundle or consume the target bundle’s handoff', () => {
+    const appDataPath = createAppData()
+    arm(appDataPath)
+
+    expect(
+      shouldDeferMacLaunchForUpdate({
+        appDataPath,
+        appVersion: SOURCE_RC,
+        executablePath: '/Applications/Orca Copy.app/Contents/MacOS/Orca',
+        isPackaged: true,
+        platform: 'darwin',
+        now: 1_000_001
+      })
+    ).toBe(false)
+    expect(existsSync(getMacUpdateInstallHandoffPath(appDataPath))).toBe(true)
+  })
+
+  it('lets the exact ad hoc target through even though it sorts below the RC source', () => {
+    const appDataPath = createAppData()
+    arm(appDataPath)
+
+    expect(
+      shouldDeferMacLaunchForUpdate({
+        appDataPath,
+        appVersion: TARGET_ADHOC,
+        executablePath: APP_EXECUTABLE,
+        isPackaged: true,
+        platform: 'darwin',
+        now: 1_000_001,
+        readProcessList: () => `${SHIPIT} com.stablyai.orca.ShipIt`
+      })
+    ).toBe(false)
+    expect(existsSync(getMacUpdateInstallHandoffPath(appDataPath))).toBe(false)
+  })
+
+  it('blocks any unexpected bundle version until the exact target wins or ShipIt exits', () => {
+    const appDataPath = createAppData()
+    const now = 1_000_000
+    arm(appDataPath, now)
+    const options = {
+      appDataPath,
+      appVersion: '1.4.161',
+      executablePath: APP_EXECUTABLE,
+      isPackaged: true,
+      platform: 'darwin' as const
+    }
+
+    expect(shouldDeferMacLaunchForUpdate({ ...options, now: now + 1 })).toBe(true)
+    expect(
+      shouldDeferMacLaunchForUpdate({
+        ...options,
+        now: now + MAC_UPDATE_INSTALL_SHIPIT_APPEARANCE_MS + 1,
+        readProcessList: () => '/bin/launchd'
+      })
+    ).toBe(false)
+    expect(existsSync(getMacUpdateInstallHandoffPath(appDataPath))).toBe(false)
+  })
+
+  it('does not let an older source handle clear a newer attempt', () => {
+    const appDataPath = createAppData()
+    const first = arm(appDataPath, 1_000_000)
+    const second = arm(appDataPath, 1_000_001)
+
+    clearMacUpdateInstallHandoff(first)
+    expect(existsSync(second.filePath)).toBe(true)
+    clearMacUpdateInstallHandoff(second)
+    expect(existsSync(second.filePath)).toBe(false)
+  })
+
+  it('fails stop when the durable handoff cannot be written', () => {
+    const appDataPath = createAppData()
+    writeFileSync(join(appDataPath, 'com.stablyai.orca'), 'not a directory')
+
+    expect(() => arm(appDataPath)).toThrow()
+  })
+
+  it('does nothing for unpackaged and non-macOS launches without inspecting processes', () => {
+    const appDataPath = createAppData()
+    expect(
+      armMacUpdateInstallHandoff({
+        appDataPath,
+        executablePath: APP_EXECUTABLE,
+        isPackaged: true,
+        platform: 'linux',
+        sourceVersion: SOURCE_RC,
+        targetVersion: TARGET_ADHOC
+      })
+    ).toBeNull()
+    expect(
+      shouldDeferMacLaunchForUpdate({
+        appDataPath,
+        appVersion: SOURCE_RC,
+        executablePath: APP_EXECUTABLE,
+        isPackaged: false,
+        platform: 'darwin',
+        readProcessList: () => {
+          throw new Error('must not inspect processes')
+        }
+      })
+    ).toBe(false)
+  })
+})

--- a/src/main/macos-update-install-handoff.ts
+++ b/src/main/macos-update-install-handoff.ts
@@ -1,0 +1,264 @@
+import { randomUUID } from 'node:crypto'
+import { execFile, execFileSync } from 'node:child_process'
+import { existsSync, lstatSync, readFileSync, rmSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { isValidAppVersion } from '../shared/app-version'
+import { writeDurableSecureJsonFile } from '../shared/secure-file'
+
+export const MAC_UPDATE_INSTALL_HANDOFF_SCHEMA_VERSION = 1
+export const MAC_UPDATE_INSTALL_HANDOFF_MAX_AGE_MS = 30 * 60_000
+export const MAC_UPDATE_INSTALL_SHIPIT_APPEARANCE_MS = 30_000
+
+const HANDOFF_DIRECTORY = 'com.stablyai.orca'
+const HANDOFF_FILENAME = 'update-install-handoff-v1.json'
+const HANDOFF_MAX_BYTES = 32 * 1024
+const PROCESS_LIST_TIMEOUT_MS = 2_000
+const PROCESS_LIST_MAX_BYTES = 16 * 1024 * 1024
+
+export type MacUpdateInstallHandoff = {
+  schemaVersion: 1
+  attemptId: string
+  sourceVersion: string
+  targetVersion: string
+  targetBundlePath: string
+  createdAtMs: number
+}
+
+export type MacUpdateInstallHandoffHandle = Pick<MacUpdateInstallHandoff, 'attemptId'> & {
+  filePath: string
+}
+
+type HandoffReadResult =
+  | { kind: 'missing' }
+  | { kind: 'invalid' }
+  | { kind: 'valid'; handoff: MacUpdateInstallHandoff }
+
+export function getMacUpdateInstallHandoffPath(appDataPath: string): string {
+  return join(appDataPath, HANDOFF_DIRECTORY, HANDOFF_FILENAME)
+}
+
+export function resolveMacAppBundlePath(executablePath: string): string {
+  const bundlePath = resolve(executablePath, '..', '..', '..')
+  if (!bundlePath.toLowerCase().endsWith('.app')) {
+    throw new Error('The updater executable is not inside a macOS app bundle')
+  }
+  return bundlePath
+}
+
+export function armMacUpdateInstallHandoff(options: {
+  appDataPath: string
+  executablePath: string
+  isPackaged: boolean
+  platform?: NodeJS.Platform
+  sourceVersion: string
+  targetVersion: string
+  now?: number
+}): MacUpdateInstallHandoffHandle | null {
+  if ((options.platform ?? process.platform) !== 'darwin' || !options.isPackaged) {
+    return null
+  }
+  if (!isValidAppVersion(options.sourceVersion) || !isValidAppVersion(options.targetVersion)) {
+    throw new Error('The macOS update handoff requires valid source and target versions')
+  }
+  const filePath = getMacUpdateInstallHandoffPath(options.appDataPath)
+  const handoff: MacUpdateInstallHandoff = {
+    schemaVersion: MAC_UPDATE_INSTALL_HANDOFF_SCHEMA_VERSION,
+    attemptId: randomUUID(),
+    sourceVersion: options.sourceVersion,
+    targetVersion: options.targetVersion,
+    targetBundlePath: resolveMacAppBundlePath(options.executablePath),
+    createdAtMs: options.now ?? Date.now()
+  }
+  writeDurableSecureJsonFile(filePath, handoff)
+  return { attemptId: handoff.attemptId, filePath }
+}
+
+export function clearMacUpdateInstallHandoff(handle: MacUpdateInstallHandoffHandle | null): void {
+  if (!handle) {
+    return
+  }
+  const current = readHandoff(handle.filePath)
+  if (current.kind === 'valid' && current.handoff.attemptId !== handle.attemptId) {
+    return
+  }
+  removeHandoff(handle.filePath)
+}
+
+export function parseSameExecutablePids(
+  processList: string,
+  executablePath: string,
+  currentPid: number
+): number[] {
+  const pids: number[] = []
+  for (const line of processList.split('\n')) {
+    const match = /^\s*(\d+)\s+(.+?)\s*$/.exec(line)
+    if (!match) {
+      continue
+    }
+    const pid = Number(match[1])
+    if (pid !== currentPid && match[2] === executablePath) {
+      pids.push(pid)
+    }
+  }
+  return pids
+}
+
+export async function findConflictingMacAppPids(
+  options: {
+    platform?: NodeJS.Platform
+    executablePath?: string
+    currentPid?: number
+    readProcessList?: () => Promise<string>
+  } = {}
+): Promise<number[] | null> {
+  if ((options.platform ?? process.platform) !== 'darwin') {
+    return []
+  }
+  try {
+    const processList = await (options.readProcessList ?? readCurrentUserProcessList)()
+    return parseSameExecutablePids(
+      processList,
+      options.executablePath ?? process.execPath,
+      options.currentPid ?? process.pid
+    )
+  } catch {
+    return null
+  }
+}
+
+export function isMatchingBundleShipItRunning(
+  targetBundlePath: string,
+  processCommandList: string
+): boolean {
+  const shipItPath = join(
+    targetBundlePath,
+    'Contents',
+    'Frameworks',
+    'Squirrel.framework',
+    'Resources',
+    'ShipIt'
+  )
+  return processCommandList.split('\n').some((line) => {
+    const command = line.trimStart()
+    return command === shipItPath || command.startsWith(`${shipItPath} `)
+  })
+}
+
+export function shouldDeferMacLaunchForUpdate(options: {
+  appDataPath: string
+  appVersion: string
+  executablePath: string
+  isPackaged: boolean
+  platform?: NodeJS.Platform
+  now?: number
+  readProcessList?: () => string
+}): boolean {
+  if ((options.platform ?? process.platform) !== 'darwin' || !options.isPackaged) {
+    return false
+  }
+  const filePath = getMacUpdateInstallHandoffPath(options.appDataPath)
+  const current = readHandoff(filePath)
+  if (current.kind !== 'valid') {
+    return false
+  }
+  const handoff = current.handoff
+  const currentBundlePath = resolveMacAppBundlePath(options.executablePath)
+  if (!macPathsEqual(handoff.targetBundlePath, currentBundlePath)) {
+    return false
+  }
+  if (options.appVersion === handoff.targetVersion) {
+    removeHandoff(filePath)
+    return false
+  }
+  // Exact equality is required: an RC source can intentionally install a semver-lower ad hoc target.
+  const ageMs = (options.now ?? Date.now()) - handoff.createdAtMs
+  if (ageMs < 0 || ageMs > MAC_UPDATE_INSTALL_HANDOFF_MAX_AGE_MS) {
+    removeHandoff(filePath)
+    return false
+  }
+  if (ageMs <= MAC_UPDATE_INSTALL_SHIPIT_APPEARANCE_MS) {
+    return true
+  }
+
+  try {
+    const processList = (options.readProcessList ?? readAllProcessCommands)()
+    if (isMatchingBundleShipItRunning(handoff.targetBundlePath, processList)) {
+      return true
+    }
+  } catch {
+    return true
+  }
+  removeHandoff(filePath)
+  return false
+}
+
+function readHandoff(filePath: string): HandoffReadResult {
+  try {
+    if (!existsSync(filePath)) {
+      return { kind: 'missing' }
+    }
+    const stats = lstatSync(filePath)
+    if (!stats.isFile() || stats.isSymbolicLink() || stats.size > HANDOFF_MAX_BYTES) {
+      return { kind: 'invalid' }
+    }
+    const value = JSON.parse(readFileSync(filePath, 'utf8')) as Partial<MacUpdateInstallHandoff>
+    if (
+      value.schemaVersion !== MAC_UPDATE_INSTALL_HANDOFF_SCHEMA_VERSION ||
+      typeof value.attemptId !== 'string' ||
+      !isValidAppVersion(value.sourceVersion ?? '') ||
+      !isValidAppVersion(value.targetVersion ?? '') ||
+      typeof value.targetBundlePath !== 'string' ||
+      !value.targetBundlePath.startsWith('/') ||
+      !value.targetBundlePath.toLowerCase().endsWith('.app') ||
+      !Number.isSafeInteger(value.createdAtMs) ||
+      (value.createdAtMs ?? 0) <= 0
+    ) {
+      return { kind: 'invalid' }
+    }
+    return { kind: 'valid', handoff: value as MacUpdateInstallHandoff }
+  } catch {
+    return { kind: 'invalid' }
+  }
+}
+
+function removeHandoff(filePath: string): void {
+  try {
+    rmSync(filePath, { force: true })
+  } catch {
+    // A stale handoff self-expires; cleanup must never prevent startup.
+  }
+}
+
+function readCurrentUserProcessList(): Promise<string> {
+  return new Promise((resolveProcessList, reject) => {
+    execFile(
+      '/bin/ps',
+      ['-xww', '-o', 'pid=,comm='],
+      { encoding: 'utf8', timeout: PROCESS_LIST_TIMEOUT_MS, maxBuffer: PROCESS_LIST_MAX_BYTES },
+      (error, stdout) => {
+        if (error) {
+          reject(error)
+        } else {
+          resolveProcessList(stdout)
+        }
+      }
+    )
+  })
+}
+
+function readAllProcessCommands(): string {
+  return execFileSync('/bin/ps', ['-ww', '-axo', 'command='], {
+    encoding: 'utf8',
+    timeout: PROCESS_LIST_TIMEOUT_MS,
+    maxBuffer: PROCESS_LIST_MAX_BYTES
+  })
+}
+
+function macPathsEqual(left: string, right: string): boolean {
+  const normalize = (value: string): string =>
+    resolve(value)
+      .replace(/^\/System\/Volumes\/Data(?=\/)/i, '')
+      .normalize('NFC')
+      .toLocaleLowerCase('en-US')
+  return normalize(left) === normalize(right)
+}

--- a/src/main/startup/desktop-startup-ordering.test.ts
+++ b/src/main/startup/desktop-startup-ordering.test.ts
@@ -3,6 +3,24 @@ import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 describe('startup ordering', () => {
+  it('gates a racing old-version launch before profile locking or persistence', () => {
+    const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
+    const updateGate = source.indexOf(
+      'shouldDeferMacLaunchForUpdate({',
+      source.indexOf('installUnhandledRejectionLogging()')
+    )
+    const pathSetup = source.indexOf('patchPackagedProcessPath()', updateGate)
+    const profileConfiguration = source.indexOf('configureDevUserDataPath(is.dev)', updateGate)
+    const singleInstanceLock = source.indexOf('acquireSingleInstanceLock(app', updateGate)
+    const persistence = source.indexOf('initDataPath()', updateGate)
+
+    expect(updateGate).toBeGreaterThanOrEqual(0)
+    expect(pathSetup).toBeGreaterThan(updateGate)
+    expect(profileConfiguration).toBeGreaterThan(updateGate)
+    expect(singleInstanceLock).toBeGreaterThan(updateGate)
+    expect(persistence).toBeGreaterThan(singleInstanceLock)
+  })
+
   it('passes the startup barrier into PTY handlers without blocking window creation', () => {
     const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
     const attachStart = source.indexOf('attachMainWindowServices(')

--- a/src/main/startup/window-all-closed-quit-policy.test.ts
+++ b/src/main/startup/window-all-closed-quit-policy.test.ts
@@ -42,6 +42,17 @@ describe('shouldQuitWhenAllWindowsClosed', () => {
     ).toBe(true)
   })
 
+  it('continues the native update quit before Electron emits before-quit', () => {
+    expect(
+      shouldQuitWhenAllWindowsClosed({
+        platform: 'darwin',
+        isQuitting: false,
+        isQuittingForUpdate: true,
+        isServeMode: false
+      })
+    ).toBe(true)
+  })
+
   it('continues a committed quit after a serve owner was promoted to desktop', () => {
     expect(
       shouldQuitWhenAllWindowsClosed({

--- a/src/main/startup/window-all-closed-quit-policy.ts
+++ b/src/main/startup/window-all-closed-quit-policy.ts
@@ -1,10 +1,12 @@
 export function shouldQuitWhenAllWindowsClosed(options: {
   platform: NodeJS.Platform
   isQuitting: boolean
+  isQuittingForUpdate?: boolean
   isServeMode: boolean
 }): boolean {
-  if (options.isServeMode && !options.isQuitting) {
+  const quitCommitted = options.isQuitting || options.isQuittingForUpdate === true
+  if (options.isServeMode && !quitCommitted) {
     return false
   }
-  return options.platform !== 'darwin' || options.isQuitting
+  return options.platform !== 'darwin' || quitCommitted
 }

--- a/src/main/updater-fallback.ts
+++ b/src/main/updater-fallback.ts
@@ -51,6 +51,7 @@ export function statusesEqual(left: UpdateStatus, right: UpdateStatus): boolean 
         left.message === right.message &&
         left.userInitiated === right.userInitiated &&
         left.activeNudgeId === right.activeNudgeId &&
+        left.installRetryable === right.installRetryable &&
         // Why: clearing recovery must reach the renderer even when the message is unchanged, or dead actions stay enabled.
         left.recovery?.kind === right.recovery?.kind &&
         left.recovery?.packageType === right.recovery?.packageType &&

--- a/src/main/updater-linux-package-recovery-actions.test.ts
+++ b/src/main/updater-linux-package-recovery-actions.test.ts
@@ -11,6 +11,9 @@ const {
   resolveLinuxPackageInstallInstructionsMock,
   revalidateLinuxPackageForInstallMock,
   revealLinuxPackageMock,
+  armMacUpdateInstallHandoffMock,
+  clearMacUpdateInstallHandoffMock,
+  findConflictingMacAppPidsMock,
   resetHandlers
 } = vi.hoisted(() => {
   const updaterHandlers = new Map<string, ((...args: unknown[]) => void)[]>()
@@ -37,7 +40,13 @@ const {
     }
   }
   return {
-    appMock: { isPackaged: true, getVersion: vi.fn(() => '1.0.51'), on: vi.fn(), quit: vi.fn() },
+    appMock: {
+      isPackaged: true,
+      getVersion: vi.fn(() => '1.0.51'),
+      getPath: vi.fn(() => 'orca-test-app-data'),
+      on: vi.fn(),
+      quit: vi.fn()
+    },
     autoUpdaterMock,
     clearTrackedLinuxPackageArtifactMock: vi.fn(),
     getTrackedLinuxPackageArtifactMock: vi.fn(),
@@ -45,6 +54,9 @@ const {
     resolveLinuxPackageInstallInstructionsMock: vi.fn(),
     revalidateLinuxPackageForInstallMock: vi.fn(),
     revealLinuxPackageMock: vi.fn(),
+    armMacUpdateInstallHandoffMock: vi.fn(),
+    clearMacUpdateInstallHandoffMock: vi.fn(),
+    findConflictingMacAppPidsMock: vi.fn(),
     resetHandlers: () => updaterHandlers.clear()
   }
 })
@@ -76,6 +88,11 @@ vi.mock('./update-install-exit-watchdog', () => ({
 }))
 vi.mock('./updater-lifecycle-diagnostics', () => ({
   recordUpdaterLifecycle: recordUpdaterLifecycleMock
+}))
+vi.mock('./macos-update-install-handoff', () => ({
+  armMacUpdateInstallHandoff: armMacUpdateInstallHandoffMock,
+  clearMacUpdateInstallHandoff: clearMacUpdateInstallHandoffMock,
+  findConflictingMacAppPids: findConflictingMacAppPidsMock
 }))
 vi.mock('./linux-update-package-type', () => ({ getLinuxRootPackageType: () => 'deb' }))
 vi.mock('./linux-package-update-recovery', () => ({
@@ -118,6 +135,9 @@ describe('linux package recovery actions', () => {
       .mockResolvedValue({ ok: true, command: "sudo apt install -- '<pkg>'", packageFileName: 'p' })
     revalidateLinuxPackageForInstallMock.mockReset().mockResolvedValue({ ok: true })
     revealLinuxPackageMock.mockReset().mockResolvedValue({ ok: true })
+    armMacUpdateInstallHandoffMock.mockReset().mockReturnValue(null)
+    clearMacUpdateInstallHandoffMock.mockReset()
+    findConflictingMacAppPidsMock.mockReset().mockResolvedValue([])
   })
 
   const startUpdater = async (): Promise<{

--- a/src/main/updater.fallback.test.ts
+++ b/src/main/updater.fallback.test.ts
@@ -86,6 +86,12 @@ describe('statusesEqual', () => {
     ).toBe(false)
     expect(statusesEqual(withRecovery, { ...withRecovery })).toBe(true)
   })
+
+  it('does not dedupe an install-retryable error against an ordinary error', () => {
+    expect(statusesEqual(withoutRecovery, { ...withoutRecovery, installRetryable: true })).toBe(
+      false
+    )
+  })
 })
 
 describe('isReleaseAssetsPublishingFailure', () => {

--- a/src/main/updater.headless-serve-install.test.ts
+++ b/src/main/updater.headless-serve-install.test.ts
@@ -8,6 +8,9 @@ const {
   recordUpdaterLifecycleMock,
   requestServeUpdateHandoffMock,
   failServeUpdateHandoffMock,
+  armMacUpdateInstallHandoffMock,
+  clearMacUpdateInstallHandoffMock,
+  findConflictingMacAppPidsMock,
   resetHandlers
 } = vi.hoisted(() => {
   const appHandlers = new Map<string, ((...args: unknown[]) => void)[]>()
@@ -26,6 +29,7 @@ const {
   const appMock = {
     isPackaged: true,
     getVersion: vi.fn(() => '1.0.51'),
+    getPath: vi.fn(() => 'orca-test-app-data'),
     on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
       appHandlers.set(event, [...(appHandlers.get(event) ?? []), handler])
       return appMock
@@ -58,6 +62,9 @@ const {
     recordUpdaterLifecycleMock: vi.fn(),
     requestServeUpdateHandoffMock: vi.fn(() => true),
     failServeUpdateHandoffMock: vi.fn(),
+    armMacUpdateInstallHandoffMock: vi.fn(),
+    clearMacUpdateInstallHandoffMock: vi.fn(),
+    findConflictingMacAppPidsMock: vi.fn(),
     resetHandlers: () => {
       appHandlers.clear()
       updaterHandlers.clear()
@@ -103,6 +110,11 @@ vi.mock('./serve-update-handoff', () => ({
   hasServeUpdateSupervisor: vi.fn(() => true),
   requestServeUpdateHandoff: requestServeUpdateHandoffMock
 }))
+vi.mock('./macos-update-install-handoff', () => ({
+  armMacUpdateInstallHandoff: armMacUpdateInstallHandoffMock,
+  clearMacUpdateInstallHandoff: clearMacUpdateInstallHandoffMock,
+  findConflictingMacAppPids: findConflictingMacAppPidsMock
+}))
 
 describe('headless serve update install handoff', () => {
   beforeEach(() => {
@@ -122,6 +134,9 @@ describe('headless serve update install handoff', () => {
     recordUpdaterLifecycleMock.mockReset()
     requestServeUpdateHandoffMock.mockReset().mockReturnValue(true)
     failServeUpdateHandoffMock.mockReset()
+    armMacUpdateInstallHandoffMock.mockReset().mockReturnValue(null)
+    clearMacUpdateInstallHandoffMock.mockReset()
+    findConflictingMacAppPidsMock.mockReset().mockResolvedValue([])
     resetHandlers()
   })
 

--- a/src/main/updater.install-failure-cause.test.ts
+++ b/src/main/updater.install-failure-cause.test.ts
@@ -10,7 +10,10 @@ const {
   autoUpdaterMock,
   isMock,
   killAllPtyMock,
-  recordUpdaterLifecycleMock
+  recordUpdaterLifecycleMock,
+  armMacUpdateInstallHandoffMock,
+  clearMacUpdateInstallHandoffMock,
+  findConflictingMacAppPidsMock
 } = vi.hoisted(() => {
   const appEventHandlers = new Map<string, ((...args: unknown[]) => void)[]>()
   const eventHandlers = new Map<string, ((...args: unknown[]) => void)[]>()
@@ -71,7 +74,10 @@ const {
     autoUpdaterMock,
     isMock: { dev: false },
     killAllPtyMock: vi.fn(),
-    recordUpdaterLifecycleMock: vi.fn()
+    recordUpdaterLifecycleMock: vi.fn(),
+    armMacUpdateInstallHandoffMock: vi.fn(),
+    clearMacUpdateInstallHandoffMock: vi.fn(),
+    findConflictingMacAppPidsMock: vi.fn()
   }
 })
 
@@ -99,6 +105,11 @@ vi.mock('./updater-nudge', () => ({
 }))
 vi.mock('./updater-lifecycle-diagnostics', () => ({
   recordUpdaterLifecycle: recordUpdaterLifecycleMock
+}))
+vi.mock('./macos-update-install-handoff', () => ({
+  armMacUpdateInstallHandoff: armMacUpdateInstallHandoffMock,
+  clearMacUpdateInstallHandoff: clearMacUpdateInstallHandoffMock,
+  findConflictingMacAppPids: findConflictingMacAppPidsMock
 }))
 
 // The real electron-updater DebUpdater failure text when elevation is impossible.
@@ -179,6 +190,9 @@ describe('quitAndInstall failure carries the updater cause', () => {
     isMock.dev = false
     killAllPtyMock.mockReset()
     recordUpdaterLifecycleMock.mockReset()
+    armMacUpdateInstallHandoffMock.mockReset().mockReturnValue(null)
+    clearMacUpdateInstallHandoffMock.mockReset()
+    findConflictingMacAppPidsMock.mockReset().mockResolvedValue([])
     Object.defineProperty(process, 'platform', {
       value: 'linux',
       configurable: true

--- a/src/main/updater.mac-install.test.ts
+++ b/src/main/updater.mac-install.test.ts
@@ -7,7 +7,10 @@ const {
   autoUpdaterMock,
   shellMock,
   isMock,
-  killAllPtyMock
+  killAllPtyMock,
+  armMacUpdateInstallHandoffMock,
+  clearMacUpdateInstallHandoffMock,
+  findConflictingMacAppPidsMock
 } = vi.hoisted(() => {
   const appEventHandlers = new Map<string, ((...args: unknown[]) => void)[]>()
   const eventHandlers = new Map<string, ((...args: unknown[]) => void)[]>()
@@ -64,6 +67,7 @@ const {
     appMock: {
       isPackaged: true,
       getVersion: vi.fn(() => '1.0.51'),
+      getPath: vi.fn(() => 'orca-test-app-data'),
       on: appOn,
       emit: appEmit,
       quit: vi.fn()
@@ -79,7 +83,10 @@ const {
       openExternal: vi.fn()
     },
     isMock: { dev: false },
-    killAllPtyMock: vi.fn()
+    killAllPtyMock: vi.fn(),
+    armMacUpdateInstallHandoffMock: vi.fn(),
+    clearMacUpdateInstallHandoffMock: vi.fn(),
+    findConflictingMacAppPidsMock: vi.fn()
   }
 })
 
@@ -108,6 +115,12 @@ vi.mock('./ipc/pty', () => ({
   killAllPty: killAllPtyMock
 }))
 
+vi.mock('./macos-update-install-handoff', () => ({
+  armMacUpdateInstallHandoff: armMacUpdateInstallHandoffMock,
+  clearMacUpdateInstallHandoff: clearMacUpdateInstallHandoffMock,
+  findConflictingMacAppPids: findConflictingMacAppPidsMock
+}))
+
 vi.mock('./updater-changelog', () => ({
   fetchChangelog: vi.fn().mockResolvedValue(null)
 }))
@@ -127,10 +140,14 @@ describe('updater mac install handoff', () => {
     shellMock.openExternal.mockReset()
     appMock.getVersion.mockReset()
     appMock.getVersion.mockReturnValue('1.0.51')
+    appMock.getPath.mockReset().mockReturnValue('orca-test-app-data')
     appMock.quit.mockReset()
     appMock.isPackaged = true
     isMock.dev = false
     killAllPtyMock.mockReset()
+    armMacUpdateInstallHandoffMock.mockReset().mockReturnValue(null)
+    clearMacUpdateInstallHandoffMock.mockReset()
+    findConflictingMacAppPidsMock.mockReset().mockResolvedValue([])
     vi.unstubAllGlobals()
     vi.useRealTimers()
   })

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -128,6 +128,7 @@ const {
     appMock: {
       isPackaged: true,
       getVersion: vi.fn(() => '1.0.51'),
+      getPath: vi.fn(() => 'orca-test-app-data'),
       on: appOn,
       emit: appEmit,
       quit: vi.fn()
@@ -218,6 +219,22 @@ vi.mock('./update-install-exit-watchdog', () => ({
   disarmUpdateInstallExitWatchdog: disarmExitWatchdogMock
 }))
 
+const {
+  armMacUpdateInstallHandoffMock,
+  clearMacUpdateInstallHandoffMock,
+  findConflictingMacAppPidsMock
+} = vi.hoisted(() => ({
+  armMacUpdateInstallHandoffMock: vi.fn(),
+  clearMacUpdateInstallHandoffMock: vi.fn(),
+  findConflictingMacAppPidsMock: vi.fn()
+}))
+
+vi.mock('./macos-update-install-handoff', () => ({
+  armMacUpdateInstallHandoff: armMacUpdateInstallHandoffMock,
+  clearMacUpdateInstallHandoff: clearMacUpdateInstallHandoffMock,
+  findConflictingMacAppPids: findConflictingMacAppPidsMock
+}))
+
 const { fetchNewerReleaseTagsMock } = vi.hoisted(() => ({
   fetchNewerReleaseTagsMock: vi.fn()
 }))
@@ -261,12 +278,16 @@ describe('updater', () => {
     browserWindowMock.getAllWindows.mockReturnValue([])
     appMock.getVersion.mockReset()
     appMock.getVersion.mockReturnValue('1.0.51')
+    appMock.getPath.mockReset().mockReturnValue('orca-test-app-data')
     appMock.quit.mockReset()
     appMock.isPackaged = true
     isMock.dev = false
     killAllPtyMock.mockReset()
     armExitWatchdogMock.mockReset()
     disarmExitWatchdogMock.mockReset()
+    armMacUpdateInstallHandoffMock.mockReset().mockReturnValue(null)
+    clearMacUpdateInstallHandoffMock.mockReset()
+    findConflictingMacAppPidsMock.mockReset().mockResolvedValue([])
     powerMonitorOnMock.mockReset()
     getLinuxRootPackageTypeMock.mockReset().mockReturnValue(null)
     recordUpdaterLifecycleMock.mockReset()
@@ -1760,6 +1781,120 @@ describe('updater', () => {
     expect(onBeforeQuit.mock.invocationCallOrder[0]).toBeLessThan(
       killAllPtyMock.mock.invocationCallOrder[0]
     )
+  })
+
+  it('blocks a doomed macOS install until another app instance exits', async () => {
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    vi.useFakeTimers()
+    const handoff = { attemptId: 'attempt-1', filePath: 'handoff.json' }
+    armMacUpdateInstallHandoffMock.mockReturnValue(handoff)
+    findConflictingMacAppPidsMock.mockResolvedValueOnce([777]).mockResolvedValueOnce([])
+    const send = vi.fn()
+    const onBeforeQuit = vi.fn()
+    const { setupAutoUpdater, quitAndInstall, isQuittingForUpdate } = await import('./updater')
+
+    setupAutoUpdater({ webContents: { send } } as never, { onBeforeQuit })
+    autoUpdaterMock.emit('checking-for-update')
+    autoUpdaterMock.emit('update-available', { version: '1.0.61' })
+    await vi.advanceTimersByTimeAsync(0)
+    autoUpdaterMock.emit('update-downloaded', { version: '1.0.61' })
+    const nativeDownloadedHandler = nativeUpdaterMock.on.mock.calls.find(
+      ([eventName]) => eventName === 'update-downloaded'
+    )?.[1] as (() => void) | undefined
+    nativeDownloadedHandler?.()
+    quitAndInstall()
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled()
+    expect(onBeforeQuit).not.toHaveBeenCalled()
+    expect(killAllPtyMock).not.toHaveBeenCalled()
+    expect(clearMacUpdateInstallHandoffMock).toHaveBeenCalledWith(handoff)
+    expect(isQuittingForUpdate()).toBe(false)
+    expect(send).toHaveBeenCalledWith('updater:status', {
+      state: 'error',
+      message: 'Close the other Orca process (PID 777) and try Restart to Update again.',
+      installRetryable: true
+    })
+
+    quitAndInstall()
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1)
+    expect(onBeforeQuit).toHaveBeenCalledTimes(1)
+    platformSpy.mockRestore()
+  })
+
+  it('keeps the staged macOS update retryable when the process check fails', async () => {
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    vi.useFakeTimers()
+    armMacUpdateInstallHandoffMock.mockReturnValue({
+      attemptId: 'attempt-1',
+      filePath: 'handoff.json'
+    })
+    findConflictingMacAppPidsMock.mockResolvedValue(null)
+    const send = vi.fn()
+    const { setupAutoUpdater, quitAndInstall } = await import('./updater')
+
+    setupAutoUpdater({ webContents: { send } } as never)
+    autoUpdaterMock.emit('checking-for-update')
+    autoUpdaterMock.emit('update-available', { version: '1.0.61' })
+    await vi.advanceTimersByTimeAsync(0)
+    autoUpdaterMock.emit('update-downloaded', { version: '1.0.61' })
+    const nativeDownloadedHandler = nativeUpdaterMock.on.mock.calls.find(
+      ([eventName]) => eventName === 'update-downloaded'
+    )?.[1] as (() => void) | undefined
+    nativeDownloadedHandler?.()
+    quitAndInstall()
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled()
+    expect(send).toHaveBeenCalledWith('updater:status', {
+      state: 'error',
+      message: 'Could not verify that Orca is ready to update. Try Restart to Update again.',
+      installRetryable: true
+    })
+    platformSpy.mockRestore()
+  })
+
+  it('arms the cross-profile launch handoff before cleanup or native install', async () => {
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    vi.useFakeTimers()
+    armMacUpdateInstallHandoffMock.mockReturnValue({
+      attemptId: 'attempt-1',
+      filePath: 'handoff.json'
+    })
+    const onBeforeQuit = vi.fn()
+    const { setupAutoUpdater, quitAndInstall } = await import('./updater')
+
+    setupAutoUpdater({ webContents: { send: vi.fn() } } as never, { onBeforeQuit })
+    autoUpdaterMock.emit('checking-for-update')
+    autoUpdaterMock.emit('update-available', { version: '1.0.61' })
+    await vi.advanceTimersByTimeAsync(0)
+    autoUpdaterMock.emit('update-downloaded', { version: '1.0.61' })
+    const nativeDownloadedHandler = nativeUpdaterMock.on.mock.calls.find(
+      ([eventName]) => eventName === 'update-downloaded'
+    )?.[1] as (() => void) | undefined
+    nativeDownloadedHandler?.()
+    quitAndInstall()
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(armMacUpdateInstallHandoffMock).toHaveBeenCalledWith({
+      appDataPath: 'orca-test-app-data',
+      executablePath: process.execPath,
+      isPackaged: true,
+      sourceVersion: '1.0.51',
+      targetVersion: '1.0.61'
+    })
+    expect(armMacUpdateInstallHandoffMock.mock.invocationCallOrder[0]).toBeLessThan(
+      findConflictingMacAppPidsMock.mock.invocationCallOrder[0]
+    )
+    expect(findConflictingMacAppPidsMock.mock.invocationCallOrder[0]).toBeLessThan(
+      onBeforeQuit.mock.invocationCallOrder[0]
+    )
+    expect(onBeforeQuit.mock.invocationCallOrder[0]).toBeLessThan(
+      autoUpdaterMock.quitAndInstall.mock.invocationCallOrder[0]
+    )
+    platformSpy.mockRestore()
   })
 
   it('ignores duplicate quitAndInstall requests while the shared delay is pending', async () => {

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -34,6 +34,12 @@ import {
 } from './update-install-exit-watchdog'
 import { registerAutoUpdaterHandlers } from './updater-events'
 import { recordUpdaterLifecycle } from './updater-lifecycle-diagnostics'
+import {
+  armMacUpdateInstallHandoff,
+  clearMacUpdateInstallHandoff,
+  findConflictingMacAppPids,
+  type MacUpdateInstallHandoffHandle
+} from './macos-update-install-handoff'
 import { getLinuxRootPackageType } from './linux-update-package-type'
 import {
   beginLinuxPackageInstallDiagnosticCapture,
@@ -191,6 +197,7 @@ let pinnedBuildSelectionInProgress = false
 // deliberate downgrade, so newer-only gates must yield to it too.
 let isPinnedBuildActive = false
 let getReleaseChannelOverride: (() => ReleaseChannel | null) | null = null
+let macUpdateInstallHandoff: MacUpdateInstallHandoffHandle | null = null
 
 function getAutoUpdater(): ElectronAutoUpdater {
   if (!autoUpdater) {
@@ -745,6 +752,49 @@ async function performQuitAndInstall(): Promise<void> {
         version: pendingVersion || null,
         macInstallerReady: process.platform === 'darwin' ? isMacInstallerReady() : true
       })
+      macUpdateInstallHandoff =
+        process.platform === 'darwin' && app.isPackaged
+          ? armMacUpdateInstallHandoff({
+              appDataPath: app.getPath('appData'),
+              executablePath: process.execPath,
+              isPackaged: true,
+              sourceVersion: app.getVersion(),
+              targetVersion: pendingVersion
+            })
+          : null
+      if (macUpdateInstallHandoff) {
+        const conflictingPids = await findConflictingMacAppPids()
+        if (conflictingPids === null) {
+          recordUpdaterLifecycle(
+            'quit_and_install_process_check_failed',
+            { version: pendingVersion || null },
+            { level: 'warn', message: 'Could not inspect other Orca app processes' }
+          )
+          resetQuitForUpdateState()
+          sendInstallFailureStatus({
+            state: 'error',
+            message: 'Could not verify that Orca is ready to update. Try Restart to Update again.',
+            installRetryable: true
+          })
+          span.fail('Could not inspect other Orca app processes')
+          return
+        }
+        if (conflictingPids.length > 0) {
+          recordUpdaterLifecycle(
+            'quit_and_install_blocked_by_other_instances',
+            { conflictingProcessCount: conflictingPids.length, version: pendingVersion || null },
+            { level: 'warn', message: 'Another Orca app process would block ShipIt' }
+          )
+          resetQuitForUpdateState()
+          sendInstallFailureStatus({
+            state: 'error',
+            message: `Close the other Orca process${conflictingPids.length === 1 ? '' : 'es'} (PID ${conflictingPids.join(', ')}) and try Restart to Update again.`,
+            installRetryable: true
+          })
+          span.fail('Another Orca app process would block the macOS installer')
+          return
+        }
+      }
       span.addEvent('pre_quit_cleanup_start')
       await runBeforeUpdateQuitCleanup()
       span.addEvent('pre_quit_cleanup_done')
@@ -807,7 +857,10 @@ async function performQuitAndInstall(): Promise<void> {
       // Why: DebUpdater/RpmUpdater install through spawnSync, so a normal return already means the
       // package is installed. Commit here or a throw in the cleanup below is reported as an install
       // failure — offering a recovery card, and stale stderr, for an update that actually succeeded.
-      if (getLinuxRootPackageType() !== null) {
+      if (
+        getLinuxRootPackageType() !== null ||
+        (process.platform === 'darwin' && isMacInstallerReady())
+      ) {
         updateInstallCommitted = true
         armUpdateInstallExitWatchdog()
       }
@@ -822,8 +875,8 @@ async function performQuitAndInstall(): Promise<void> {
         windowCount: BrowserWindow.getAllWindows().length
       })
 
-      // Why: committed installs keep quittingForUpdate so dock activate can't reopen the old process; macOS without Squirrel stays uncommitted so late native errors can still recover.
-      if (!updateInstallCommitted && (process.platform !== 'darwin' || isMacInstallerReady())) {
+      // Why: committed installs keep quittingForUpdate so dock activate can't reopen the old process; macOS commits immediately after its native handoff above.
+      if (!updateInstallCommitted && process.platform !== 'darwin') {
         updateInstallCommitted = true
         // Why: past commit the installer waits for this process to exit; a wedged async shutdown would strand the user with no app and no update (#4438).
         armUpdateInstallExitWatchdog()
@@ -874,6 +927,8 @@ async function performQuitAndInstall(): Promise<void> {
 }
 
 function resetQuitForUpdateState(): void {
+  clearMacUpdateInstallHandoff(macUpdateInstallHandoff)
+  macUpdateInstallHandoff = null
   quitAndInstallInProgress = false
   quittingForUpdate = false
   updateInstallCommitted = false

--- a/src/renderer/src/components/UpdateCard.error-card.test.tsx
+++ b/src/renderer/src/components/UpdateCard.error-card.test.tsx
@@ -273,6 +273,22 @@ describe('UpdateCard Linux package-install recovery', () => {
     expect(download).toHaveBeenCalledTimes(1)
   })
 
+  it('retries a blocked native install without downloading the staged build again', () => {
+    renderAfterAvailableStatus()
+
+    act(() =>
+      useAppStore.getState().setUpdateStatus({
+        state: 'error',
+        message: 'Close the other Orca process and try Restart to Update again.',
+        installRetryable: true
+      })
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Try Again' }))
+    expect(quitAndInstall).toHaveBeenCalledTimes(1)
+    expect(download).not.toHaveBeenCalled()
+  })
+
   it('shows the appended install cause behind the generic card details', () => {
     const message =
       'Could not start the update installer. Orca remains open. (Command failed: pkexec must be setuid root)'

--- a/src/renderer/src/components/UpdateCard.tsx
+++ b/src/renderer/src/components/UpdateCard.tsx
@@ -390,8 +390,10 @@ export function UpdateCard() {
                   // Why: check-time failures are often transient, so offer a Re-check instead of forcing manual download.
                   primaryAction: cachedVersion
                     ? {
-                        label: translate('auto.components.UpdateCard.48565a32bc', 'Retry Download'),
-                        onClick: handleUpdate
+                        label: status.installRetryable
+                          ? translate('auto.components.UpdateCard.2c2d3e03ca', 'Try Again')
+                          : translate('auto.components.UpdateCard.48565a32bc', 'Retry Download'),
+                        onClick: status.installRetryable ? handleInstallRetry : handleUpdate
                       }
                     : {
                         label: translate('auto.components.UpdateCard.6b0085010d', 'Re-check'),

--- a/src/shared/update-status-types.ts
+++ b/src/shared/update-status-types.ts
@@ -79,6 +79,7 @@ export type UpdateStatus = (
       message: string
       userInitiated?: boolean
       activeNudgeId?: string
+      installRetryable?: boolean
       recovery?: LinuxPackageInstallRecovery
     }
 ) & { source?: UpdateSource }


### PR DESCRIPTION
## Summary

- persist a profile-independent, durable macOS install handoff before invoking Squirrel
- reject installs that ShipIt cannot complete because another Orca main process is already running
- stop racing old-version launches before profile selection, single-instance locking, or persistence, while admitting only the exact downloaded target build
- keep the native macOS quit moving through `window-all-closed`, arm the existing exit watchdog immediately after native handoff, and make preflight failures retry the staged install without redownloading it

## Root cause

This is a macOS process-lifecycle and cross-profile multi-instance race, not an ad hoc packaging or update-channel failure.

Orca's normal single-instance lock is scoped by `userData`, so an installed `/Applications/Orca.app` launched with a temporary profile can coexist with the user's instance. Squirrel.Mac/ShipIt requires every main process for the target bundle to stay gone while it replaces the app. A second launch during that silent install window causes ShipIt's `App Still Running Error`, leaves the old bundle installed, and makes the next open appear to have rolled back to the prior RC.

Current main already waits for Squirrel readiness, collapses duplicate installs, guards Dock activation, pins update feeds, and has an old-main exit watchdog. It did not have a cross-profile launch fence or preflight for an already-running second main process. It also treated `window-all-closed` as an ordinary macOS close until `before-quit`, even though Electron's native updater closes windows first.

Updater history independently contains the same incident evidence and direction in commits `91aba932be` and `17870106a4` / #9094. This implementation strengthens that earlier unmerged approach with a profile-independent, fail-stop, atomic marker carrying source version, exact target version, target bundle path, attempt ownership, and bounded expiry.

## Channel and security invariants

- RC to ad hoc can intentionally be a SemVer downgrade, so success is `runningVersion === targetVersion`, never `runningVersion >= targetVersion`.
- The existing ad hoc repo/feed selection, `allowDowngrade`, signing, hardened runtime, notarization, and updater signature checks are unchanged.
- The marker uses the existing durable secure-file writer, is scoped to the exact app bundle, and expires after a bounded interval.
- macOS process inspection is current-user scoped, has a two-second timeout and bounded output, and never kills another process.
- Windows and Linux skip the marker and process scan. Existing Linux package recovery and supervised headless-server behavior remain covered.
- `installRetryable` is an optional field on the existing JSON status payload. Older peers ignore it; newer clients fall back safely when older servers omit it.

## Validation

- 322 updater-adjacent tests across 20 files, including macOS handoff/readiness, preflight conflicts, racing launches, exact RC-to-ad-hoc target admission, expiry, quit policy, supervised serve, Linux recovery, release-channel selection, mac channel packaging config, and renderer retry behavior
- `pnpm run typecheck`
- focused `oxlint` plus commit-hook `oxlint` and React Doctor
- `pnpm run check:max-lines-ratchet`
- `pnpm run verify:localization-extraction`
- `pnpm run verify:localization-coverage`
- `git diff --check`
- exact BSD `ps` probe arguments validated on macOS without acting on any process

All reproduction and validation used unit fixtures, temporary directories, injected process tables, and source-level checks. No browser or Computer Use was used; no running Orca process was quit/restarted/relaunched or otherwise controlled; and the installed production app was not touched.

This PR is intentionally not merged.
