### PR TITLE
feat(native-chat): Claude permission mode picker in the composer, and fix fast mode

### DIFF
--- a/mobile/src/session/MobileNativeChatSessionOptionRows.tsx
+++ b/mobile/src/session/MobileNativeChatSessionOptionRows.tsx
@@ -170,16 +170,6 @@ export function DescriptorRows({
 }): React.JSX.Element {
   const locked = disabled || !descriptor.settable
   // Why: flip-only without a baseline is an action — never claim On/Off.
-  if (descriptor.action?.type === 'toggle-command') {
-    return (
-      <ActionRow
-        label={`Toggle ${descriptor.label.toLowerCase()}`}
-        disabled={locked}
-        grouped={grouped}
-        onPress={onInvokeAction}
-      />
-    )
-  }
   // Why: agent-picker opens the TUI; it is not a set of radio choices.
   if (descriptor.action?.type === 'agent-picker') {
     return (

--- a/mobile/src/session/use-mobile-native-chat-session-options.ts
+++ b/mobile/src/session/use-mobile-native-chat-session-options.ts
@@ -23,7 +23,6 @@ import {
   clearNativeChatSessionModel,
   createNativeChatSessionOptionRecord,
   getTrackedSessionOption,
-  isFlipOnlyMidSession,
   matchNativeChatCatalogModelId,
   setTrackedSessionOption,
   type NativeChatSessionOptionRecord
@@ -224,18 +223,6 @@ export function useMobileNativeChatSessionOptions(args: {
         if (!apply || apply.midSession?.kind === 'agent-picker') {
           return false
         }
-        const flipOnly = isFlipOnlyMidSession(apply.midSession)
-        const trackedToggle = flipOnly
-          ? getTrackedSessionOption(record, previousModelId, id)
-          : undefined
-        if (flipOnly && !trackedToggle) {
-          // Why: a flip from an unknown baseline cannot honor an absolute target.
-          return false
-        }
-        // Why: same absolute target must never re-dispatch a flip (would invert the agent).
-        if (flipOnly && trackedToggle?.value === value) {
-          return true
-        }
         const command = buildNativeChatSessionOptionCommand({
           optionId: id,
           value,
@@ -277,7 +264,7 @@ export function useMobileNativeChatSessionOptions(args: {
           }
         }
         // Why: flip-only never heals via agent report — track as applied best-known.
-        setTrackedSessionOption(record, id, value, flipOnly ? 'applied' : 'dispatched')
+        setTrackedSessionOption(record, id, value, 'dispatched')
         bump()
         return true
       })
@@ -311,10 +298,6 @@ export function useMobileNativeChatSessionOptions(args: {
           bump()
           onAgentPicker?.()
           return true
-        }
-        if (isFlipOnlyMidSession(midSession) && !getTrackedSessionOption(record, modelId, id)) {
-          // Why: an unknown baseline remains unknown after one inversion.
-          return (await dispatchCommand(midSession.command)) !== 'rejected'
         }
         return false
       })

--- a/src/renderer/src/components/native-chat/NativeChatComposer.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposer.tsx
@@ -2,16 +2,9 @@ import { forwardRef, useCallback, useImperativeHandle, useMemo, useRef, useState
 import { useAppStore } from '../../store'
 import { sendRuntimePtyInput } from '@/runtime/runtime-terminal-inspection'
 import { getSettingsForAgentTabRuntimeOwner } from '@/lib/agent-paste-draft'
-import {
-  sendNativeChatMessage,
-  sendNativeChatTypedCommand,
-  sendNativeChatMessageWithImageAttachments,
-  submitNativeChatPrompt
-} from './native-chat-runtime-send'
-import type { NativeChatSendHandle } from './native-chat-runtime-send'
+import { startNativeChatComposerSend } from './native-chat-composer-send-dispatch'
 import { resolveNativeChatLaunchDraftSend } from './native-chat-launch-draft-send'
 import { getVerifiedNativeChatCommands } from '../../../../shared/native-chat-agent-profiles'
-import { isSlashCommandDraft } from '../../../../shared/native-chat-slash-commands'
 import { emitNativeChatMessageSent } from '@/lib/native-chat-telemetry'
 import {
   applyMentionSuggestion,
@@ -217,21 +210,27 @@ export const NativeChatComposer = forwardRef<NativeChatComposerHandle, NativeCha
     const { pickAttachment } = useNativeChatFileAttachmentActions(attachExternalPaths)
     const { toggleDictation, startHoldDictation, stopHoldDictation } =
       useNativeChatDictationActions({ textareaRef, setDictationPressed })
-    const { dispatch: dispatchSessionOptionCommand, isDispatching: isDispatchingSessionOption } =
-      useNativeChatSessionOptionCommand({
-        agent,
-        disabled,
-        onSlashCommand,
-        resolveTarget,
-        setHistory
-      })
+    const {
+      dispatch: dispatchSessionOptionCommand,
+      dispatchModeCycle: dispatchSessionOptionModeCycle,
+      isDispatching: isDispatchingSessionOption
+    } = useNativeChatSessionOptionCommand({
+      agent,
+      disabled,
+      onSlashCommand,
+      resolveTarget,
+      setHistory,
+      readTerminalScreen
+    })
 
     const { surface: sessionOptionsSurface, snapshot: sessionOptionsSnapshot } =
       useNativeChatSessionOptions({
         agent,
         terminalTabId,
+        paneKey,
         targetPtyId,
         dispatchCommand: dispatchSessionOptionCommand,
+        dispatchModeCycle: dispatchSessionOptionModeCycle,
         onAgentPicker: onSwitchToTerminal,
         readTerminalScreen
       })
@@ -260,28 +259,14 @@ export const NativeChatComposer = forwardRef<NativeChatComposerHandle, NativeCha
         agent,
         readScreen: () => readTerminalScreen?.()
       })
-      let pendingHandle: NativeChatSendHandle | null = null
-      // Why: image attachments take the attachment send path even for a
-      // command/unknown send, otherwise `clearImageAttachments()` below drops
-      // them silently when the text starts with the agent's slash/skill prefix.
-      if (classification !== 'chat' && imagePaths.length === 0) {
-        pendingHandle =
-          agent === 'codex' && isSlashCommandDraft(text)
-            ? sendNativeChatTypedCommand(target.settings, target.ptyId, text)
-            : sendNativeChatMessage(target.settings, target.ptyId, text, sendOptions)
-      } else if (imagePaths.length > 0) {
-        pendingHandle = sendNativeChatMessageWithImageAttachments(
-          target.settings,
-          target.ptyId,
-          text,
-          imagePaths,
-          sendOptions
-        )
-      } else if (text.trim().length > 0) {
-        pendingHandle = sendNativeChatMessage(target.settings, target.ptyId, text, sendOptions)
-      } else {
-        submitNativeChatPrompt(target.settings, target.ptyId)
-      }
+      const pendingHandle = startNativeChatComposerSend({
+        agent,
+        text,
+        imagePaths,
+        target,
+        classification,
+        sendOptions
+      })
       if (classification !== 'chat') {
         if (pendingHandle) {
           trackPendingSend(pendingHandle)

--- a/src/renderer/src/components/native-chat/NativeChatSessionOptionPickers.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatSessionOptionPickers.test.tsx
@@ -17,6 +17,16 @@ vi.mock('@/i18n/i18n', () => ({
   }
 }))
 
+const openSettingsPage = vi.fn()
+const openSettingsTarget = vi.fn()
+const mockStoreState = { openSettingsPage, openSettingsTarget }
+
+vi.mock('@/store', () => ({
+  useAppStore: Object.assign((selector: (state: unknown) => unknown) => selector(mockStoreState), {
+    getState: () => mockStoreState
+  })
+}))
+
 vi.mock('@/components/ui/button', () => ({
   Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
     <button {...props}>{children}</button>
@@ -31,6 +41,13 @@ vi.mock('@/components/ui/tooltip', () => ({
 
 vi.mock('@/components/ui/dropdown-menu', () => {
   const React = require('react') as typeof ReactModule
+  // Why: mirrors real Radix RadioGroup — context, not Children.map — so a
+  // non-radio sibling (e.g. an unavailable-choice DropdownMenuItem) renders
+  // as itself instead of being coerced into a radio button.
+  const RadioGroupContext = React.createContext<{
+    value?: string
+    onValueChange?: (value: string) => void
+  }>({})
   return {
     DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
     DropdownMenuTrigger: ({
@@ -68,8 +85,8 @@ vi.mock('@/components/ui/dropdown-menu', () => {
         {children}
       </button>
     ),
-    // Why: exercises value binding + onValueChange contract the real Radix
-    // group provides; selected value is exposed via data-radio-value.
+    // Why: exposes the selected value + onValueChange wiring via
+    // data-radio-value / data-on-value-change for assertions on the group.
     DropdownMenuRadioGroup: ({
       children,
       value,
@@ -78,57 +95,38 @@ vi.mock('@/components/ui/dropdown-menu', () => {
       children: React.ReactNode
       value?: string
       onValueChange?: (value: string) => void
-    }) => (
-      <div
-        role="radiogroup"
-        data-radio-value={value ?? ''}
-        data-on-value-change={onValueChange ? '1' : '0'}
-      >
-        {React.Children.map(children, (child) => {
-          if (!React.isValidElement(child)) {
-            return child
-          }
-          const props = child.props as {
-            value?: string
-            disabled?: boolean
-            children?: React.ReactNode
-          }
-          const selected = props.value !== undefined && props.value === value
-          return (
-            <button
-              key={props.value}
-              role="radio"
-              aria-checked={selected}
-              disabled={props.disabled}
-              data-value={props.value}
-              data-state={selected ? 'checked' : 'unchecked'}
-              onClick={() => {
-                if (props.value !== undefined) {
-                  onValueChange?.(props.value)
-                }
-              }}
-            >
-              {props.children}
-            </button>
-          )
-        })}
-      </div>
-    ),
+    }) => {
+      const contextValue = React.useMemo(() => ({ value, onValueChange }), [value, onValueChange])
+      return (
+        <div
+          role="radiogroup"
+          data-radio-value={value ?? ''}
+          data-on-value-change={onValueChange ? '1' : '0'}
+        >
+          <RadioGroupContext.Provider value={contextValue}>{children}</RadioGroupContext.Provider>
+        </div>
+      )
+    },
     DropdownMenuRadioItem: ({
       children,
       disabled,
       value
-    }: React.ButtonHTMLAttributes<HTMLButtonElement> & { value: string }) => (
-      // Why: parent RadioGroup mock reads `value` via Children.map — keep it on
-      // props even though native span has no value attribute.
-      <span
-        data-radio-item
-        data-disabled={disabled || undefined}
-        {...({ value } as Record<string, string>)}
-      >
-        {children}
-      </span>
-    )
+    }: React.ButtonHTMLAttributes<HTMLButtonElement> & { value: string }) => {
+      const ctx = React.useContext(RadioGroupContext)
+      const selected = value === ctx.value
+      return (
+        <button
+          role="radio"
+          aria-checked={selected}
+          disabled={disabled}
+          data-value={value}
+          data-state={selected ? 'checked' : 'unchecked'}
+          onClick={() => ctx.onValueChange?.(value)}
+        >
+          {children}
+        </button>
+      )
+    }
   }
 })
 
@@ -185,7 +183,39 @@ const fast: SessionOptionDescriptor = {
   settable: true
 }
 
-afterEach(() => cleanup())
+const PERMISSION_MODE_CHOICES = [
+  { value: 'manual', label: 'Manual' },
+  { value: 'acceptEdits', label: 'Accept edits' },
+  { value: 'plan', label: 'Plan' },
+  { value: 'auto', label: 'Auto' },
+  {
+    value: 'bypassPermissions',
+    label: 'Bypass permissions',
+    unavailable: { action: 'open-agent-permissions-setting' as const }
+  }
+]
+
+function permissionMode(overrides: Partial<SessionOptionDescriptor> = {}): SessionOptionDescriptor {
+  return {
+    id: 'permissionMode',
+    label: 'Mode',
+    category: 'mode',
+    kind: {
+      type: 'select',
+      currentValue: 'manual',
+      choices: PERMISSION_MODE_CHOICES
+    },
+    valueSource: 'applied',
+    settable: true,
+    ...overrides
+  }
+}
+
+afterEach(() => {
+  cleanup()
+  openSettingsPage.mockClear()
+  openSettingsTarget.mockClear()
+})
 
 describe('NativeChatSessionOptionPickers', () => {
   it('prefers collision-aware upward placement for model and option menus', () => {
@@ -456,5 +486,151 @@ describe('NativeChatSessionOptionPickers', () => {
       />
     )
     expect(screen.getByText('Sent to the agent — not confirmed')).not.toBeNull()
+  })
+
+  it('renders an unavailable choice as an Enable action while its siblings stay live radios', () => {
+    render(
+      <NativeChatSessionOptionPickers
+        surface={surface}
+        snapshot={[model(), permissionMode()]}
+        isWorking={false}
+      />
+    )
+    expect(screen.getByRole('button', { name: 'Bypass permissions Enable' })).not.toBeNull()
+    expect(screen.queryByRole('radio', { name: /Bypass permissions/ })).toBeNull()
+    for (const name of ['Manual', 'Accept edits', 'Plan', 'Auto']) {
+      const radio = screen.getByRole('radio', { name })
+      expect(radio.hasAttribute('disabled')).toBe(false)
+    }
+  })
+
+  it('activating Enable deep-links to the agent permissions setting', async () => {
+    render(
+      <NativeChatSessionOptionPickers
+        surface={surface}
+        snapshot={[model(), permissionMode()]}
+        isWorking={false}
+      />
+    )
+    screen.getByRole('button', { name: 'Bypass permissions Enable' }).click()
+    await waitFor(() =>
+      expect(openSettingsTarget).toHaveBeenCalledWith({
+        pane: 'agents',
+        repoId: null,
+        sectionId: 'agent-permissions'
+      })
+    )
+    expect(openSettingsPage).toHaveBeenCalled()
+  })
+
+  it('selecting a normal mode row calls setOption with the chosen value', async () => {
+    const setOption = vi.fn().mockResolvedValue({ snapshot: [] })
+    const liveSurface = { ...surface, setOption }
+    render(
+      <NativeChatSessionOptionPickers
+        surface={liveSurface}
+        snapshot={[model(), permissionMode()]}
+        isWorking={false}
+      />
+    )
+    screen.getByRole('radio', { name: 'Plan' }).click()
+    await waitFor(() => expect(setOption).toHaveBeenCalledWith('permissionMode', 'plan'))
+  })
+
+  it('renders all five choices as radio items when the launch granted bypass', () => {
+    render(
+      <NativeChatSessionOptionPickers
+        surface={surface}
+        snapshot={[
+          model(),
+          permissionMode({
+            kind: {
+              type: 'select',
+              currentValue: 'manual',
+              choices: [
+                { value: 'manual', label: 'Manual' },
+                { value: 'acceptEdits', label: 'Accept edits' },
+                { value: 'plan', label: 'Plan' },
+                { value: 'auto', label: 'Auto' },
+                { value: 'bypassPermissions', label: 'Bypass permissions' }
+              ]
+            }
+          })
+        ]}
+        isWorking={false}
+      />
+    )
+    for (const name of ['Manual', 'Accept edits', 'Plan', 'Auto', 'Bypass permissions']) {
+      expect(screen.getByRole('radio', { name })).not.toBeNull()
+    }
+    expect(screen.queryByText('Enable')).toBeNull()
+  })
+
+  it('gives permission mode its own pill, separate from the options dropdown', () => {
+    const plan = permissionMode({
+      kind: { type: 'select', currentValue: 'plan', choices: PERMISSION_MODE_CHOICES }
+    })
+    render(
+      <NativeChatSessionOptionPickers
+        surface={surface}
+        snapshot={[model(), effort, plan]}
+        isWorking={false}
+      />
+    )
+    expect(screen.getByRole('button', { name: 'Mode Plan' })).not.toBeNull()
+    // Why: mode must not leak into the shared effort/options pill's label or menu.
+    expect(screen.getByRole('button', { name: 'Effort High' }).textContent).not.toContain('Plan')
+    expect(screen.queryByRole('radio', { name: 'Accept edits' })).not.toBeNull()
+  })
+
+  it('orders the pills mode, then options, then model', () => {
+    render(
+      <NativeChatSessionOptionPickers
+        surface={surface}
+        snapshot={[model(), effort, permissionMode()]}
+        isWorking={false}
+      />
+    )
+    const modeButton = screen.getByRole('button', { name: 'Mode Manual' })
+    const optionsButton = screen.getByRole('button', { name: 'Effort High' })
+    const modelButton = screen.getByRole('button', { name: 'Model Opus 4.8' })
+    const FOLLOWING = Node.DOCUMENT_POSITION_FOLLOWING
+    expect(modeButton.compareDocumentPosition(optionsButton) & FOLLOWING).not.toBe(0)
+    expect(optionsButton.compareDocumentPosition(modelButton) & FOLLOWING).not.toBe(0)
+  })
+
+  it('shows Manual on the dedicated pill even though the shared pill would have stayed quiet', () => {
+    render(
+      <NativeChatSessionOptionPickers
+        surface={surface}
+        snapshot={[model(), permissionMode()]}
+        isWorking={false}
+      />
+    )
+    expect(screen.getByRole('button', { name: 'Mode Manual' })).not.toBeNull()
+  })
+
+  it('falls back to "Mode" when the current value is unknown', () => {
+    render(
+      <NativeChatSessionOptionPickers
+        surface={surface}
+        snapshot={[model(), permissionMode({ valueSource: 'unknown' })]}
+        isWorking={false}
+      />
+    )
+    expect(screen.getByRole('button', { name: 'Mode' })).not.toBeNull()
+  })
+
+  it('renders no Mode pill for a non-Claude agent, leaving the other pills unaffected', () => {
+    render(
+      <NativeChatSessionOptionPickers
+        surface={surface}
+        snapshot={[model(), effort]}
+        isWorking={false}
+      />
+    )
+    expect(screen.queryByRole('button', { name: /^Mode(\s|$)/ })).toBeNull()
+    expect(screen.getByRole('button', { name: 'Effort High' })).not.toBeNull()
+    expect(screen.getByRole('button', { name: 'Model Opus 4.8' })).not.toBeNull()
   })
 })

--- a/src/renderer/src/components/native-chat/NativeChatSessionOptionPickers.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatSessionOptionPickers.test.tsx
@@ -367,31 +367,25 @@ describe('NativeChatSessionOptionPickers', () => {
     await waitFor(() => expect(invokeAction).toHaveBeenCalledWith('model'))
   })
 
-  it('uses a Toggle action for unknown flip-only options via invokeAction', async () => {
-    const invokeAction = vi.fn().mockResolvedValue({ snapshot: [] })
+  // Fast mode is read from Claude's ↯ glyph now, so an unknown boolean is just
+  // an unset radio group — there is no blind-flip command left to offer.
+  it('offers On/Off for an unknown boolean rather than a blind toggle', async () => {
     const setOption = vi.fn().mockResolvedValue({ snapshot: [] })
+    const invokeAction = vi.fn().mockResolvedValue({ snapshot: [] })
     const liveSurface = { ...surface, setOption, invokeAction }
     render(
       <NativeChatSessionOptionPickers
         surface={liveSurface}
-        snapshot={[
-          model(),
-          {
-            ...fast,
-            kind: { type: 'boolean' },
-            valueSource: 'unknown',
-            action: { type: 'toggle-command' }
-          }
-        ]}
+        snapshot={[model(), { ...fast, kind: { type: 'boolean' }, valueSource: 'unknown' }]}
         isWorking={false}
       />
     )
-    expect(screen.getByText('Toggle fast mode')).not.toBeNull()
-    expect(screen.queryByText('On')).toBeNull()
-    expect(screen.queryByText('Off')).toBeNull()
-    screen.getByText('Toggle fast mode').click()
-    await waitFor(() => expect(invokeAction).toHaveBeenCalledWith('fastMode'))
-    expect(setOption).not.toHaveBeenCalled()
+    expect(screen.queryByText('Toggle fast mode')).toBeNull()
+    expect(screen.getByText('On')).not.toBeNull()
+    expect(screen.getByText('Off')).not.toBeNull()
+    screen.getByText('On').click()
+    await waitFor(() => expect(setOption).toHaveBeenCalledWith('fastMode', true))
+    expect(invokeAction).not.toHaveBeenCalled()
   })
 
   it('uses On/Off radios for known boolean options without inventing a selection', async () => {

--- a/src/renderer/src/components/native-chat/NativeChatSessionOptionPickers.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatSessionOptionPickers.tsx
@@ -15,7 +15,9 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { translate } from '@/i18n/i18n'
 import { sortNativeChatSessionOptions } from '../../../../shared/native-chat-session-option-snapshot'
+import { useAppStore } from '@/store'
 import type {
+  SessionOptionChoiceAction,
   SessionOptionDescriptor,
   SessionOptionsSurface,
   SessionOptionValue
@@ -24,6 +26,7 @@ import {
   nativeChatModelPillLabel,
   nativeChatOptionsPillLabel,
   nativeChatOptionsPillTitle,
+  nativeChatPermissionModePillLabel,
   nativeChatSessionChoiceLabel,
   nativeChatSessionOptionDisabledReason,
   nativeChatSessionOptionLabel
@@ -114,8 +117,9 @@ function DescriptorMenuRows(props: {
   pending: boolean
   setValue: (value: SessionOptionValue) => void
   invokeAction: () => void
+  openChoiceAction: (action: SessionOptionChoiceAction) => void
 }): React.JSX.Element {
-  const { descriptor, pending, setValue, invokeAction } = props
+  const { descriptor, pending, setValue, invokeAction, openChoiceAction } = props
   // Why: flip-only without a baseline is an action — never claim On/Off.
   if (descriptor.action?.type === 'toggle-command') {
     return (
@@ -172,18 +176,38 @@ function DescriptorMenuRows(props: {
       value={descriptor.kind.currentValue}
       onValueChange={(value) => setValue(value)}
     >
-      {descriptor.kind.choices.map((choice) => (
-        <DropdownMenuRadioItem
-          key={choice.value}
-          value={choice.value}
-          disabled={!descriptor.settable || pending}
-        >
-          <ChoiceBody
-            label={nativeChatSessionChoiceLabel(choice)}
-            description={choice.description}
-          />
-        </DropdownMenuRadioItem>
-      ))}
+      {descriptor.kind.choices.map((choice) => {
+        const unavailable = choice.unavailable
+        if (unavailable) {
+          return (
+            <DropdownMenuItem
+              key={choice.value}
+              disabled={pending}
+              onSelect={() => openChoiceAction(unavailable.action)}
+            >
+              <ChoiceBody
+                label={nativeChatSessionChoiceLabel(choice, descriptor.id)}
+                description={choice.description}
+              />
+              <span className="ml-auto text-xs text-muted-foreground">
+                {translate('components.native-chat.composer.enableChoice', 'Enable')}
+              </span>
+            </DropdownMenuItem>
+          )
+        }
+        return (
+          <DropdownMenuRadioItem
+            key={choice.value}
+            value={choice.value}
+            disabled={!descriptor.settable || pending}
+          >
+            <ChoiceBody
+              label={nativeChatSessionChoiceLabel(choice, descriptor.id)}
+              description={choice.description}
+            />
+          </DropdownMenuRadioItem>
+        )
+      })}
     </DropdownMenuRadioGroup>
   )
 }
@@ -210,8 +234,14 @@ function NativeChatSessionOptionPickersInner({
   isWorking
 }: NativeChatSessionOptionPickersProps): React.JSX.Element | null {
   const [pendingId, setPendingId] = useState<string | null>(null)
+  const openSettingsPage = useAppStore((state) => state.openSettingsPage)
+  const openSettingsTarget = useAppStore((state) => state.openSettingsTarget)
   const model = snapshot.find((descriptor) => descriptor.category === 'model')
-  const options = sortNativeChatSessionOptions(snapshot)
+  const mode = snapshot.find((descriptor) => descriptor.id === 'permissionMode')
+  // Mode has its own pill, so keep it out of the shared options dropdown.
+  const options = sortNativeChatSessionOptions(snapshot).filter(
+    (descriptor) => descriptor.id !== 'permissionMode'
+  )
   if (!surface || !model) {
     return null
   }
@@ -222,9 +252,20 @@ function NativeChatSessionOptionPickersInner({
   const invokeAction = (descriptor: SessionOptionDescriptor): void => {
     runSurfaceCall(descriptor.id, setPendingId, () => surface.invokeAction(descriptor.id))
   }
+  const openChoiceAction = (action: SessionOptionChoiceAction): void => {
+    // Exhaustive by switch-exhaustiveness-check: a new action fails the
+    // type-aware lint rather than silently rendering a dead Enable row.
+    switch (action) {
+      case 'open-agent-permissions-setting':
+        openSettingsTarget({ pane: 'agents', repoId: null, sectionId: 'agent-permissions' })
+        openSettingsPage()
+    }
+  }
 
   const modelReason = nativeChatSessionOptionDisabledReason(model.disabledReason)
   const modelTooltip = translate('components.native-chat.composer.model', 'Model')
+  const modeReason = mode ? nativeChatSessionOptionDisabledReason(mode.disabledReason) : null
+  const modeTooltip = translate('components.native-chat.composer.permissionMode', 'Mode')
   const optionsTooltip = nativeChatOptionsPillTitle(options)
   const optionsReason =
     options.length > 0 && options.every((descriptor) => !descriptor.settable)
@@ -233,6 +274,29 @@ function NativeChatSessionOptionPickersInner({
 
   return (
     <div className="flex min-w-0 items-center gap-0.5">
+      {mode ? (
+        <DropdownMenu>
+          <PickerTrigger
+            label={nativeChatPermissionModePillLabel(mode)}
+            tooltipLabel={modeTooltip}
+            disabled={isWorking || pendingId !== null}
+            disabledReason={modeReason}
+            dispatched={mode.valueSource === 'dispatched'}
+          />
+          <DropdownMenuContent align="start" className="w-60">
+            {modeReason && !mode.settable ? (
+              <DropdownMenuLabel className="font-normal">{modeReason}</DropdownMenuLabel>
+            ) : null}
+            <DescriptorMenuRows
+              descriptor={mode}
+              pending={pendingId !== null}
+              setValue={(value) => setOption(mode, value)}
+              invokeAction={() => invokeAction(mode)}
+              openChoiceAction={openChoiceAction}
+            />
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ) : null}
       {options.length > 0 ? (
         <DropdownMenu>
           <PickerTrigger
@@ -257,6 +321,7 @@ function NativeChatSessionOptionPickersInner({
                     pending={pendingId !== null}
                     setValue={(value) => setOption(descriptor, value)}
                     invokeAction={() => invokeAction(descriptor)}
+                    openChoiceAction={openChoiceAction}
                   />
                 </div>
               )
@@ -281,6 +346,7 @@ function NativeChatSessionOptionPickersInner({
             pending={pendingId !== null}
             setValue={(value) => setOption(model, value)}
             invokeAction={() => invokeAction(model)}
+            openChoiceAction={openChoiceAction}
           />
         </DropdownMenuContent>
       </DropdownMenu>

--- a/src/renderer/src/components/native-chat/NativeChatSessionOptionPickers.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatSessionOptionPickers.tsx
@@ -120,16 +120,6 @@ function DescriptorMenuRows(props: {
   openChoiceAction: (action: SessionOptionChoiceAction) => void
 }): React.JSX.Element {
   const { descriptor, pending, setValue, invokeAction, openChoiceAction } = props
-  // Why: flip-only without a baseline is an action — never claim On/Off.
-  if (descriptor.action?.type === 'toggle-command') {
-    return (
-      <DropdownMenuItem disabled={!descriptor.settable || pending} onSelect={() => invokeAction()}>
-        {translate('components.native-chat.composer.toggleOption', 'Toggle {{value0}}', {
-          value0: nativeChatSessionOptionLabel(descriptor).toLowerCase()
-        })}
-      </DropdownMenuItem>
-    )
-  }
   // Why: agent-picker opens the TUI; it is not a set of radio choices.
   if (descriptor.action?.type === 'agent-picker') {
     return (

--- a/src/renderer/src/components/native-chat/claude-permission-mode-cycle.test.ts
+++ b/src/renderer/src/components/native-chat/claude-permission-mode-cycle.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  cycleClaudePermissionMode,
+  describeClaudePermissionModeCycle
+} from './claude-permission-mode-cycle'
+import { readClaudePermissionModeFromTerminalScreen } from './claude-terminal-session-options'
+
+const KEY = '\x1b[Z'
+
+/** Drives readMode through a fixed sequence, then repeats the last entry —
+ * enough to prove the cycler's own bounds stop it, not a finite fake. */
+function sequentialReader(modes: readonly string[]): () => Promise<string | null> {
+  let index = 0
+  return async () => {
+    const mode = modes[Math.min(index, modes.length - 1)]
+    index += 1
+    return mode
+  }
+}
+
+/** Loops through a fixed set of modes forever, simulating Shift+Tab cycling
+ * within a real session (used for the "not in this cycle" scenario). */
+function loopingReader(modes: readonly string[]): () => Promise<string | null> {
+  let index = 0
+  return async () => {
+    const mode = modes[index % modes.length]
+    index += 1
+    return mode
+  }
+}
+
+describe('cycleClaudePermissionMode', () => {
+  it('reaches the target in one press', async () => {
+    const sendKey = vi.fn(() => true)
+    const outcome = await cycleClaudePermissionMode({
+      target: 'acceptEdits',
+      readMode: sequentialReader(['manual', 'acceptEdits']),
+      sendKey,
+      key: KEY,
+      settleMs: 0
+    })
+    expect(outcome.outcome).toBe('applied')
+    expect(sendKey).toHaveBeenCalledTimes(1)
+    expect(sendKey).toHaveBeenCalledWith(KEY)
+  })
+
+  it('reaches a target several presses away, pressing exactly that many times', async () => {
+    const sendKey = vi.fn(() => true)
+    const outcome = await cycleClaudePermissionMode({
+      target: 'bypassPermissions',
+      readMode: sequentialReader(['manual', 'acceptEdits', 'plan', 'auto', 'bypassPermissions']),
+      sendKey,
+      key: KEY,
+      settleMs: 0
+    })
+    expect(outcome.outcome).toBe('applied')
+    expect(sendKey).toHaveBeenCalledTimes(4)
+  })
+
+  it('is already on the target: applied with zero presses', async () => {
+    const sendKey = vi.fn(() => true)
+    const outcome = await cycleClaudePermissionMode({
+      target: 'plan',
+      readMode: sequentialReader(['plan']),
+      sendKey,
+      key: KEY,
+      settleMs: 0
+    })
+    expect(outcome.outcome).toBe('applied')
+    expect(sendKey).not.toHaveBeenCalled()
+  })
+
+  it('reports unavailable and stops after one lap when the target is not in the cycle', async () => {
+    const sendKey = vi.fn(() => true)
+    const outcome = await cycleClaudePermissionMode({
+      target: 'bypassPermissions',
+      readMode: loopingReader(['manual', 'acceptEdits', 'plan']),
+      sendKey,
+      key: KEY,
+      settleMs: 0
+    })
+    expect(outcome.outcome).toBe('unavailable')
+    // A 3-mode cycle repeats after 3 presses — far short of pressing forever
+    // or exhausting the (higher) maxPresses safety bound.
+    expect(sendKey).toHaveBeenCalledTimes(3)
+  })
+
+  it('returns unknown without pressing when the mode is unreadable from the start', async () => {
+    const sendKey = vi.fn(() => true)
+    const outcome = await cycleClaudePermissionMode({
+      target: 'plan',
+      readMode: async () => null,
+      sendKey,
+      key: KEY,
+      settleMs: 0
+    })
+    expect(outcome.outcome).toBe('unknown')
+    expect(sendKey).not.toHaveBeenCalled()
+  })
+
+  it('returns unknown when the key press cannot be delivered', async () => {
+    const outcome = await cycleClaudePermissionMode({
+      target: 'plan',
+      readMode: sequentialReader(['manual', 'acceptEdits']),
+      sendKey: () => false,
+      key: KEY,
+      settleMs: 0
+    })
+    expect(outcome.outcome).toBe('unknown')
+  })
+
+  it('honours isCancelled and never presses once cancelled', async () => {
+    const sendKey = vi.fn(() => true)
+    const outcome = await cycleClaudePermissionMode({
+      target: 'plan',
+      readMode: sequentialReader(['manual', 'manual', 'manual']),
+      sendKey,
+      key: KEY,
+      settleMs: 0,
+      isCancelled: () => true
+    })
+    expect(outcome.outcome).toBe('unknown')
+    expect(sendKey).not.toHaveBeenCalled()
+  })
+
+  it('stops at the maxPresses bound instead of looping forever', async () => {
+    const sendKey = vi.fn(() => true)
+    let index = 0
+    // A pathological reader that never repeats and never matches the target —
+    // only the press-count bound can terminate this one.
+    const outcome = await cycleClaudePermissionMode({
+      target: 'never-shown',
+      readMode: async () => `mode-${index++}`,
+      sendKey,
+      key: KEY,
+      settleMs: 0,
+      maxPresses: 6
+    })
+    expect(outcome.outcome).toBe('unknown')
+    expect(sendKey).toHaveBeenCalledTimes(6)
+  })
+
+  describe('end-to-end with the real status-line reader', () => {
+    function readModeFromStatusLine(statusLine: string): () => Promise<string | null> {
+      // Reads the status line directly — the banner scrolls away, so the
+      // model-gated scrape cannot be the cycler's source of truth.
+      return async () => readClaudePermissionModeFromTerminalScreen(`> \n${statusLine}`)
+    }
+
+    it("recognizes plan mode from Claude's real status line and stops immediately", async () => {
+      const sendKey = vi.fn(() => true)
+      const outcome = await cycleClaudePermissionMode({
+        target: 'plan',
+        readMode: readModeFromStatusLine('▶▶ plan mode on (shift+tab to cycle)'),
+        sendKey,
+        key: KEY,
+        settleMs: 0
+      })
+      expect(outcome.outcome).toBe('applied')
+      expect(sendKey).not.toHaveBeenCalled()
+    })
+
+    it("recognizes bypass permissions from Claude's real status line", async () => {
+      const sendKey = vi.fn(() => true)
+      const outcome = await cycleClaudePermissionMode({
+        target: 'bypassPermissions',
+        readMode: readModeFromStatusLine('▶▶ bypass permissions on (shift+tab to cycle)'),
+        sendKey,
+        key: KEY,
+        settleMs: 0
+      })
+      expect(outcome.outcome).toBe('applied')
+      expect(sendKey).not.toHaveBeenCalled()
+    })
+  })
+})
+
+describe('describeClaudePermissionModeCycle', () => {
+  // Why: every failure here is invisible from the chat pane — the toast is the
+  // only place the user learns which step gave up.
+  it('names the step that gave up, with the modes it saw', async () => {
+    const stuck = await cycleClaudePermissionMode({
+      target: 'plan',
+      readMode: async () => 'auto',
+      sendKey: () => true,
+      key: '\x1b[Z'
+    })
+    expect(describeClaudePermissionModeCycle('plan', stuck)).toBe(
+      "plan is not in this session's cycle; saw auto → auto."
+    )
+  })
+
+  it('reports an unreadable terminal distinctly from a stuck cycle', async () => {
+    const blind = await cycleClaudePermissionMode({
+      target: 'plan',
+      readMode: async () => null,
+      sendKey: () => true,
+      key: '\x1b[Z'
+    })
+    expect(blind.presses).toBe(0)
+    expect(describeClaudePermissionModeCycle('plan', blind)).toMatch(/could not read/i)
+  })
+
+  it('reports an undelivered keystroke', async () => {
+    const undelivered = await cycleClaudePermissionMode({
+      target: 'plan',
+      readMode: async () => 'auto',
+      sendKey: () => false,
+      key: '\x1b[Z'
+    })
+    expect(describeClaudePermissionModeCycle('plan', undelivered)).toMatch(/did not accept/i)
+  })
+})

--- a/src/renderer/src/components/native-chat/claude-permission-mode-cycle.ts
+++ b/src/renderer/src/components/native-chat/claude-permission-mode-cycle.ts
@@ -21,6 +21,7 @@ export type ClaudePermissionModeCycleResult = {
 const DEFAULT_SETTLE_MS = 250
 const DEFAULT_MAX_PRESSES = 6
 
+/** Settle pause between presses, so the TUI can redraw before the next read. */
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }

--- a/src/renderer/src/components/native-chat/claude-permission-mode-cycle.ts
+++ b/src/renderer/src/components/native-chat/claude-permission-mode-cycle.ts
@@ -1,0 +1,106 @@
+export type ClaudePermissionModeOutcome = 'applied' | 'unavailable' | 'unknown'
+
+/** Why the cycle stopped. Surfaced to the user because every failure here is
+ *  invisible from the chat pane — the evidence lives in the terminal. */
+export type ClaudePermissionModeCycleReason =
+  | 'reached'
+  | 'unreadable'
+  | 'undelivered'
+  | 'exhausted'
+  | 'not-in-cycle'
+  | 'cancelled'
+
+export type ClaudePermissionModeCycleResult = {
+  outcome: ClaudePermissionModeOutcome
+  reason: ClaudePermissionModeCycleReason
+  presses: number
+  /** Modes observed in order, so a stuck or overshooting cycle is diagnosable. */
+  observed: string[]
+}
+
+const DEFAULT_SETTLE_MS = 250
+const DEFAULT_MAX_PRESSES = 6
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * Shift+Tab advances Claude's permission mode by one step per press — there is
+ * no menu to parse, and which modes exist in the cycle varies per session
+ * (bypass/auto are conditional). So press-and-observe instead of computing a
+ * step count: read the current mode, press once if it isn't the target, and
+ * repeat. Bounded by a max press count and by detecting a completed lap.
+ */
+export async function cycleClaudePermissionMode(args: {
+  target: string
+  readMode: () => Promise<string | null>
+  /** Returns false when the write could not be delivered. */
+  sendKey: (key: string) => boolean
+  key: string
+  settleMs?: number
+  maxPresses?: number
+  isCancelled?: () => boolean
+}): Promise<ClaudePermissionModeCycleResult> {
+  const settleMs = args.settleMs ?? DEFAULT_SETTLE_MS
+  const maxPresses = args.maxPresses ?? DEFAULT_MAX_PRESSES
+  const seen = new Set<string>()
+  const observed: string[] = []
+  let presses = 0
+
+  const result = (
+    outcome: ClaudePermissionModeOutcome,
+    reason: ClaudePermissionModeCycleReason
+  ): ClaudePermissionModeCycleResult => ({ outcome, reason, presses, observed })
+
+  while (true) {
+    // Never press blindly when the current mode can't be observed.
+    const mode = await args.readMode()
+    if (mode === null) {
+      return result('unknown', 'unreadable')
+    }
+    observed.push(mode)
+    if (mode === args.target) {
+      return result('applied', 'reached')
+    }
+    if (presses >= maxPresses) {
+      return result('unknown', 'exhausted')
+    }
+    // A repeat means a full lap completed without ever showing the target —
+    // it isn't in this session's cycle (e.g. bypass without the launch flag).
+    if (seen.has(mode)) {
+      return result('unavailable', 'not-in-cycle')
+    }
+    seen.add(mode)
+    if (args.isCancelled?.()) {
+      return result('unknown', 'cancelled')
+    }
+    if (!args.sendKey(args.key)) {
+      return result('unknown', 'undelivered')
+    }
+    presses += 1
+    await delay(settleMs)
+  }
+}
+
+/** Short, user-forwardable detail — the toast is the only place this surfaces. */
+export function describeClaudePermissionModeCycle(
+  target: string,
+  result: ClaudePermissionModeCycleResult
+): string {
+  const trail = result.observed.length > 0 ? result.observed.join(' → ') : 'nothing'
+  switch (result.reason) {
+    case 'reached':
+      return `Set to ${target}.`
+    case 'unreadable':
+      return 'Could not read the current mode from the terminal.'
+    case 'undelivered':
+      return `The terminal did not accept the keystroke (after ${result.presses}).`
+    case 'exhausted':
+      return `Gave up after ${result.presses} presses; saw ${trail}.`
+    case 'not-in-cycle':
+      return `${target} is not in this session's cycle; saw ${trail}.`
+    case 'cancelled':
+      return 'The mode change was cancelled.'
+  }
+}

--- a/src/renderer/src/components/native-chat/claude-terminal-session-options.mode.test.ts
+++ b/src/renderer/src/components/native-chat/claude-terminal-session-options.mode.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { readClaudePermissionModeFromTerminalScreen } from './claude-terminal-session-options'
+
+/** The status line identifies itself, so the mode read needs no banner — the
+ *  banner scrolls out of the viewport after the first screenful. */
+const read = readClaudePermissionModeFromTerminalScreen
+
+describe('permission mode from the status line', () => {
+  it.each([
+    ['⏸ manual mode on', 'manual'],
+    ['▶▶ accept edits on', 'acceptEdits'],
+    ['⏸ plan mode on', 'plan'],
+    ['▶▶ auto mode on', 'auto'],
+    ['▶▶ bypass permissions on', 'bypassPermissions']
+  ])('reads %s', (line, expected) => {
+    expect(read(`> \n${line}`)).toBe(expected)
+  })
+
+  it('reads the real prefix, hint and trailing history affordance', () => {
+    const line = '▶▶ bypass permissions on (shift+tab to cycle) · ← for history'
+    expect(read(`> \n${line}`)).toBe('bypassPermissions')
+  })
+
+  it('reads through trailing blank viewport rows', () => {
+    expect(read(`> \n⏸ plan mode on${'\n'.repeat(20)}`)).toBe('plan')
+  })
+
+  it('prefers the indicator nearest the composer over stale text above it', () => {
+    expect(read('▶▶ accept edits on\n> \n⏸ plan mode on')).toBe('plan')
+  })
+})
+
+describe('permission mode: what must NOT be read as live status', () => {
+  it('reports nothing when no indicator is present', () => {
+    // Absence cannot mean manual: without the banner there is no proof this
+    // screen is even Claude's.
+    expect(read('some other program\n> ')).toBeNull()
+  })
+
+  it('ignores an indicator phrase inside conversation text', () => {
+    expect(read('> how do I turn plan mode on?')).toBeNull()
+    expect(read('> how do I turn manual mode on?')).toBeNull()
+  })
+
+  it('ignores a quoted indicator in an assistant reply', () => {
+    expect(read('The status line shows plan mode on below.\n> ')).toBeNull()
+  })
+
+  it.each(['3. Auto mode on: fewer prompts', '- Plan mode on', '* Accept edits on'])(
+    'ignores a list item posing as live status: %s',
+    (item) => {
+      expect(read(`${item}\n> `)).toBeNull()
+    }
+  )
+
+  it('ignores an indicator that scrolled far above the composer', () => {
+    const filler = Array.from({ length: 12 }, (_, index) => `output line ${index}`).join('\n')
+    expect(read(`⏸ plan mode on\n${filler}\n> `)).toBeNull()
+  })
+
+  it('does not let blank-separated transcript text reach the window', () => {
+    const spaced = ['1. Plan mode on: restricts edits', 'tool output', 'tool output', 'tool output']
+      .map((line) => `${line}\n`)
+      .join('\n')
+    expect(read(`${spaced}\n> `)).toBeNull()
+  })
+})

--- a/src/renderer/src/components/native-chat/claude-terminal-session-options.mode.test.ts
+++ b/src/renderer/src/components/native-chat/claude-terminal-session-options.mode.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { readClaudePermissionModeFromTerminalScreen } from './claude-terminal-session-options'
+import {
+  readClaudeFastModeFromTerminalScreen,
+  readClaudePermissionModeFromTerminalScreen,
+  readClaudeSessionOptionsFromTerminalScreen
+} from './claude-terminal-session-options'
 
 /** The status line identifies itself, so the mode read needs no banner — the
  *  banner scrolls out of the viewport after the first screenful. */
@@ -63,5 +67,32 @@ describe('permission mode: what must NOT be read as live status', () => {
       .map((line) => `${line}\n`)
       .join('\n')
     expect(read(`${spaced}\n> `)).toBeNull()
+  })
+})
+
+describe('fast mode from the ↯ glyph', () => {
+  // Why the glyph and not a command: `/fast` with no argument opens a
+  // confirmation panel, so the picker sets `/fast on|off` and reads state here.
+  it('reads fast mode as on when the glyph is present, with no banner', () => {
+    expect(readClaudeFastModeFromTerminalScreen('Opus 4.8 ↯\n> ')).toBe(true)
+  })
+
+  it('reports nothing without the glyph, since absence is not proof of Claude', () => {
+    expect(readClaudeFastModeFromTerminalScreen('Opus 4.8\n> ')).toBeNull()
+  })
+
+  it('ignores the glyph in the confirmation panel title', () => {
+    const panel = '↯ Fast mode (research preview)\n  Fast mode  OFF  $10/$50 per Mtok'
+    expect(readClaudeFastModeFromTerminalScreen(panel)).toBeNull()
+  })
+
+  it('reports a truthful off when the banner proves the screen is Claude', () => {
+    const screen = '╭ Claude Code v2.1.220\n│ Opus 4.8 · with high effort\n╰\n> '
+    expect(readClaudeSessionOptionsFromTerminalScreen(screen)?.fastMode).toBe(false)
+  })
+
+  it('reports on when the banner carries the glyph', () => {
+    const screen = '╭ Claude Code v2.1.220\n│ Opus 4.8 ↯ · with high effort\n╰\n> '
+    expect(readClaudeSessionOptionsFromTerminalScreen(screen)?.fastMode).toBe(true)
   })
 })

--- a/src/renderer/src/components/native-chat/claude-terminal-session-options.test.ts
+++ b/src/renderer/src/components/native-chat/claude-terminal-session-options.test.ts
@@ -248,7 +248,7 @@ describe('Claude terminal session option detection', () => {
         frame('Opus 4.8 with high effort · API Usage Billing'),
         DISCOVERED
       )
-    ).toEqual({ model: 'opus', effort: 'high' })
+    ).toEqual({ model: 'opus', effort: 'high', fastMode: false })
   })
 
   it('still reports a custom model when the host list cannot name it', () => {
@@ -268,7 +268,8 @@ describe('Claude terminal session option detection', () => {
 
     expect(readClaudeSessionOptionsFromTerminalScreen(screen)).toEqual({
       model: 'opus',
-      effort: 'high'
+      effort: 'high',
+      fastMode: false
     })
   })
 
@@ -280,7 +281,8 @@ describe('Claude terminal session option detection', () => {
 
     expect(readClaudeSessionOptionsFromTerminalScreen(screen)).toEqual({
       model: 'opus',
-      effort: 'high'
+      effort: 'high',
+      fastMode: false
     })
   })
 
@@ -316,7 +318,8 @@ describe('Claude terminal session option detection', () => {
 
     expect(readClaudeSessionOptionsFromTerminalScreen(screen)).toEqual({
       model: 'opus',
-      effort: 'xhigh'
+      effort: 'xhigh',
+      fastMode: false
     })
   })
 

--- a/src/renderer/src/components/native-chat/claude-terminal-session-options.ts
+++ b/src/renderer/src/components/native-chat/claude-terminal-session-options.ts
@@ -203,6 +203,60 @@ function findClaudeCatalogModel(
  *   reported id is one the picker actually lists; omitting it falls back to the
  *   version-neutral seed families.
  */
+type ClaudePermissionMode = 'manual' | 'acceptEdits' | 'plan' | 'auto' | 'bypassPermissions'
+
+// Claude's status-line labels. Every mode names itself, manual included
+// (`⏸ manual mode on`) — observed live, not derivable from the binary's table.
+const MODE_BY_INDICATOR: [string, ClaudePermissionMode][] = [
+  ['manual mode on', 'manual'],
+  ['accept edits on', 'acceptEdits'],
+  ['plan mode on', 'plan'],
+  ['auto mode on', 'auto'],
+  ['bypass permissions on', 'bypassPermissions']
+]
+
+// Why: the live indicator renders just below the composer; anything further
+// up the viewport is scrolled-past conversation text and may be stale.
+const INDICATOR_WINDOW_SIZE = 8
+
+// Why: a viewport taller than its content ends in blank rows that would fill
+// the window. Trim only that trailing run — dropping interior blanks instead
+// would let the window creep up past blank-separated conversation text.
+function withoutTrailingBlankRows(lines: readonly string[]): readonly string[] {
+  let end = lines.length
+  while (end > 0 && !lines[end - 1]) {
+    end -= 1
+  }
+  return lines.slice(0, end)
+}
+
+function matchPermissionModeIndicator(lines: readonly string[]): ClaudePermissionMode | null {
+  const window = withoutTrailingBlankRows(lines).slice(-INDICATOR_WINDOW_SIZE)
+  let mode: ClaudePermissionMode | null = null
+  for (const line of window) {
+    const lowered = line.toLowerCase()
+    for (const [indicator, value] of MODE_BY_INDICATOR) {
+      // Only the status glyph may precede it: digits and bullets would let a
+      // list item ("3. Auto mode on: …") pose as live status. Over-restricting
+      // just reports manual, Claude's default — under-restricting reports a lie.
+      if (new RegExp(`^[^a-z0-9.*•-]*${indicator}`).test(lowered)) {
+        mode = value
+      }
+    }
+  }
+  return mode
+}
+
+/** Reads the mode WITHOUT requiring Claude's banner, which scrolls out of the
+ *  viewport after the first screenful. The status line identifies itself, so an
+ *  affirmative match stands alone — but absence cannot mean manual here, since
+ *  we have no proof this screen is even Claude's. */
+export function readClaudePermissionModeFromTerminalScreen(
+  screen: string | null | undefined
+): ClaudePermissionMode | null {
+  return screen ? matchPermissionModeIndicator(normalizedScreenLines(screen)) : null
+}
+
 export function readClaudeSessionOptionsFromTerminalScreen(
   screen: string | null | undefined,
   models?: readonly CatalogModel[]

--- a/src/renderer/src/components/native-chat/claude-terminal-session-options.ts
+++ b/src/renderer/src/components/native-chat/claude-terminal-session-options.ts
@@ -230,6 +230,26 @@ function withoutTrailingBlankRows(lines: readonly string[]): readonly string[] {
   return lines.slice(0, end)
 }
 
+// Claude marks fast mode with this glyph; its absence on a confirmed Claude
+// screen means off. The panel title carries it too, so skip that row — we never
+// open the panel ourselves, but a user can.
+const FAST_MODE_GLYPH = '\u21AF'
+const FAST_MODE_PANEL_TITLE = 'fast mode (research preview)'
+
+function matchFastModeGlyph(lines: readonly string[]): boolean {
+  return lines.some(
+    (line) => line.includes(FAST_MODE_GLYPH) && !line.toLowerCase().includes(FAST_MODE_PANEL_TITLE)
+  )
+}
+
+/** Reads fast mode WITHOUT requiring Claude's banner. Affirmative only: absence
+ *  cannot mean off here, since we have no proof this screen is even Claude's. */
+export function readClaudeFastModeFromTerminalScreen(
+  screen: string | null | undefined
+): true | null {
+  return screen && matchFastModeGlyph(normalizedScreenLines(screen)) ? true : null
+}
+
 function matchPermissionModeIndicator(lines: readonly string[]): ClaudePermissionMode | null {
   const window = withoutTrailingBlankRows(lines).slice(-INDICATOR_WINDOW_SIZE)
   let mode: ClaudePermissionMode | null = null
@@ -284,6 +304,10 @@ export function readClaudeSessionOptionsFromTerminalScreen(
   const effort = effortLabel ? EFFORT_ID_BY_LABEL[effortLabel.toLowerCase()] : undefined
   if (effort && model.options.some((option) => option.id === 'effort')) {
     result.effort = effort
+  }
+  // The banner proves this is Claude, so a missing glyph is a truthful `off`.
+  if (model.options.some((option) => option.id === 'fastMode')) {
+    result.fastMode = matchFastModeGlyph(lines)
   }
   return result
 }

--- a/src/renderer/src/components/native-chat/claude-terminal-session-options.ts
+++ b/src/renderer/src/components/native-chat/claude-terminal-session-options.ts
@@ -219,9 +219,9 @@ const MODE_BY_INDICATOR: [string, ClaudePermissionMode][] = [
 // up the viewport is scrolled-past conversation text and may be stale.
 const INDICATOR_WINDOW_SIZE = 8
 
-// Why: a viewport taller than its content ends in blank rows that would fill
-// the window. Trim only that trailing run — dropping interior blanks instead
-// would let the window creep up past blank-separated conversation text.
+/** Drops the trailing blank run a viewport taller than its content leaves
+ *  behind. Only that run: dropping interior blanks would let the indicator
+ *  window creep up past blank-separated conversation text. */
 function withoutTrailingBlankRows(lines: readonly string[]): readonly string[] {
   let end = lines.length
   while (end > 0 && !lines[end - 1]) {
@@ -230,12 +230,14 @@ function withoutTrailingBlankRows(lines: readonly string[]): readonly string[] {
   return lines.slice(0, end)
 }
 
-// Claude marks fast mode with this glyph; its absence on a confirmed Claude
-// screen means off. The panel title carries it too, so skip that row — we never
-// open the panel ourselves, but a user can.
+// Claude marks fast mode with this glyph; absence on a confirmed Claude screen
+// means off.
 const FAST_MODE_GLYPH = '\u21AF'
 const FAST_MODE_PANEL_TITLE = 'fast mode (research preview)'
 
+/** Whether the live status line carries the fast-mode glyph. Skips the
+ *  confirmation panel's title row, which carries it too — we never open that
+ *  panel ourselves, but a user can. */
 function matchFastModeGlyph(lines: readonly string[]): boolean {
   return lines.some(
     (line) => line.includes(FAST_MODE_GLYPH) && !line.toLowerCase().includes(FAST_MODE_PANEL_TITLE)
@@ -250,6 +252,8 @@ export function readClaudeFastModeFromTerminalScreen(
   return screen && matchFastModeGlyph(normalizedScreenLines(screen)) ? true : null
 }
 
+/** The mode named by the status line nearest the composer, or null if none of
+ *  them is on screen. */
 function matchPermissionModeIndicator(lines: readonly string[]): ClaudePermissionMode | null {
   const window = withoutTrailingBlankRows(lines).slice(-INDICATOR_WINDOW_SIZE)
   let mode: ClaudePermissionMode | null = null

--- a/src/renderer/src/components/native-chat/native-chat-composer-send-dispatch.ts
+++ b/src/renderer/src/components/native-chat/native-chat-composer-send-dispatch.ts
@@ -1,0 +1,50 @@
+import type { AgentType } from '../../../../shared/agent-status-types'
+import { isSlashCommandDraft } from '../../../../shared/native-chat-slash-commands'
+import type { NativeChatResolvedTarget } from './native-chat-composer-target'
+import type { NativeChatSendClassification } from './native-chat-picker-items'
+import {
+  sendNativeChatMessage,
+  sendNativeChatTypedCommand,
+  sendNativeChatMessageWithImageAttachments,
+  submitNativeChatPrompt,
+  type NativeChatSendHandle
+} from './native-chat-runtime-send'
+
+export type NativeChatComposerSendOptions =
+  | { clearInput: string; confirmCleared: () => boolean }
+  | undefined
+
+/** Picks the send path for an already-classified draft. Pure dispatch: the
+ *  composer keeps the state updates, this only decides which writer runs. */
+export function startNativeChatComposerSend(args: {
+  agent: AgentType
+  text: string
+  imagePaths: string[]
+  target: NativeChatResolvedTarget
+  classification: NativeChatSendClassification
+  sendOptions: NativeChatComposerSendOptions
+}): NativeChatSendHandle | null {
+  const { agent, text, imagePaths, target, classification, sendOptions } = args
+  // Why: image attachments take the attachment send path even for a
+  // command/unknown send, otherwise the composer's clearImageAttachments()
+  // drops them silently when the text starts with the agent's slash prefix.
+  if (classification !== 'chat' && imagePaths.length === 0) {
+    return agent === 'codex' && isSlashCommandDraft(text)
+      ? sendNativeChatTypedCommand(target.settings, target.ptyId, text)
+      : sendNativeChatMessage(target.settings, target.ptyId, text, sendOptions)
+  }
+  if (imagePaths.length > 0) {
+    return sendNativeChatMessageWithImageAttachments(
+      target.settings,
+      target.ptyId,
+      text,
+      imagePaths,
+      sendOptions
+    )
+  }
+  if (text.trim().length > 0) {
+    return sendNativeChatMessage(target.settings, target.ptyId, text, sendOptions)
+  }
+  submitNativeChatPrompt(target.settings, target.ptyId)
+  return null
+}

--- a/src/renderer/src/components/native-chat/native-chat-live-screen.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-live-screen.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { readNativeChatLiveScreen } from './native-chat-live-screen'
+
+function stubSnapshot(
+  snapshot: { data?: string; scrollbackAnsi?: string; alternateScreen?: boolean } | null
+): () => void {
+  const previous = window.api
+  const getMainBufferSnapshot = vi.fn(async () => snapshot)
+  ;(window as unknown as { api: unknown }).api = { pty: { getMainBufferSnapshot } }
+  return () => {
+    ;(window as unknown as { api: unknown }).api = previous
+  }
+}
+
+const parseClaude = (screen: string | null | undefined): string | null =>
+  screen?.includes('Claude Code v') ? screen : null
+
+describe('readNativeChatLiveScreen', () => {
+  let restore: (() => void) | null = null
+  afterEach(() => {
+    restore?.()
+    restore = null
+  })
+
+  it('uses the snapshot when it parses', async () => {
+    restore = stubSnapshot({ data: 'Claude Code v2.1.220 snapshot' })
+    const result = await readNativeChatLiveScreen({
+      ptyId: 'pty-1',
+      readTerminalScreen: () => 'Claude Code v2.1.220 xterm',
+      parse: parseClaude
+    })
+    expect(result).toBe('Claude Code v2.1.220 snapshot')
+  })
+
+  // Why this exists: a stale main buffer reads back as perfectly good text that
+  // simply lacks Claude's header. Falling back only on an empty READ stranded us
+  // on it and reported nothing at all.
+  it('falls back to the xterm when the snapshot reads fine but does not parse', async () => {
+    restore = stubSnapshot({ data: 'stale shell output, no header here' })
+    const result = await readNativeChatLiveScreen({
+      ptyId: 'pty-1',
+      readTerminalScreen: () => 'Claude Code v2.1.220 xterm',
+      parse: parseClaude
+    })
+    expect(result).toBe('Claude Code v2.1.220 xterm')
+  })
+
+  // Why: the snapshot's frame IS the alternate screen while a TUI owns it, and
+  // that is the only place Claude's status line exists. Discarding it here left
+  // a full-screen chat (no mounted xterm) with no source at all.
+  it('uses the alternate-screen frame rather than discarding it', async () => {
+    restore = stubSnapshot({ data: 'Claude Code v2.1.220 alt frame', alternateScreen: true })
+    const result = await readNativeChatLiveScreen({
+      ptyId: 'pty-1',
+      readTerminalScreen: () => null,
+      parse: parseClaude
+    })
+    expect(result).toBe('Claude Code v2.1.220 alt frame')
+  })
+
+  it('falls back to the normal buffer when the frame does not parse', async () => {
+    restore = stubSnapshot({
+      data: 'alt frame with no banner',
+      scrollbackAnsi: 'Claude Code v2.1.220 scrollback',
+      alternateScreen: true
+    })
+    const result = await readNativeChatLiveScreen({
+      ptyId: 'pty-1',
+      readTerminalScreen: () => null,
+      parse: parseClaude
+    })
+    expect(result).toBe('Claude Code v2.1.220 scrollback')
+  })
+
+  it('falls back when the snapshot call throws', async () => {
+    const previous = window.api
+    ;(window as unknown as { api: unknown }).api = {
+      pty: {
+        getMainBufferSnapshot: vi.fn(async () => {
+          throw new Error('remote host')
+        })
+      }
+    }
+    restore = () => {
+      ;(window as unknown as { api: unknown }).api = previous
+    }
+    const result = await readNativeChatLiveScreen({
+      ptyId: 'pty-1',
+      readTerminalScreen: () => 'Claude Code v2.1.220 xterm',
+      parse: parseClaude
+    })
+    expect(result).toBe('Claude Code v2.1.220 xterm')
+  })
+
+  it('parses the xterm directly when there is no pty id', async () => {
+    restore = stubSnapshot({ data: 'Claude Code v2.1.220 snapshot' })
+    const result = await readNativeChatLiveScreen({
+      ptyId: null,
+      readTerminalScreen: () => 'Claude Code v2.1.220 xterm',
+      parse: parseClaude
+    })
+    expect(result).toBe('Claude Code v2.1.220 xterm')
+  })
+
+  it('reports nothing when neither source parses', async () => {
+    restore = stubSnapshot({ data: 'stale output' })
+    const result = await readNativeChatLiveScreen({
+      ptyId: 'pty-1',
+      readTerminalScreen: () => 'also not claude',
+      parse: parseClaude
+    })
+    expect(result).toBeNull()
+  })
+})

--- a/src/renderer/src/components/native-chat/native-chat-live-screen.ts
+++ b/src/renderer/src/components/native-chat/native-chat-live-screen.ts
@@ -1,0 +1,42 @@
+/** The live screen candidates for a pty, best first.
+ *
+ * Three sources, because none covers every case:
+ *  - the snapshot's current frame — the alternate screen itself while a TUI
+ *    owns it, the only place Claude's status line exists;
+ *  - the snapshot's normal buffer, where the scrolled-back banner lives;
+ *  - the mounted xterm, the only source for remote/SSH ptys the API misses. */
+export async function collectNativeChatLiveScreens(args: {
+  ptyId: string | null
+  readTerminalScreen?: () => string | null
+}): Promise<(string | null)[]> {
+  const screens: (string | null)[] = []
+  if (args.ptyId && window.api?.pty?.getMainBufferSnapshot) {
+    try {
+      const snapshot = await window.api.pty.getMainBufferSnapshot(args.ptyId, { scrollbackRows: 0 })
+      screens.push(snapshot?.data ?? null, snapshot?.scrollbackAnsi ?? null)
+    } catch {
+      // The mounted xterm below covers this host.
+    }
+  }
+  screens.push(args.readTerminalScreen?.() ?? null)
+  return screens
+}
+
+/** Keeps the first candidate that `parse` accepts.
+ *
+ * Why parse-driven rather than picking one screen: a stale buffer reads back as
+ * perfectly good text that simply lacks what the caller needs, so falling back
+ * only when the READ is empty would strand us on it and report nothing. */
+export async function readNativeChatLiveScreen<T>(args: {
+  ptyId: string | null
+  readTerminalScreen?: () => string | null
+  parse: (screen: string | null | undefined) => T | null
+}): Promise<T | null> {
+  for (const screen of await collectNativeChatLiveScreens(args)) {
+    const parsed = args.parse(screen)
+    if (parsed) {
+      return parsed
+    }
+  }
+  return null
+}

--- a/src/renderer/src/components/native-chat/native-chat-live-session-launch-args.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-live-session-launch-args.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createTestStore } from '../../store/slices/store-test-helpers'
+import type { AppState } from '../../store/types'
+import { resolveNativeChatLiveSessionLaunchArgs } from './native-chat-live-session-launch-args'
+
+let testStore: ReturnType<typeof createTestStore>
+
+vi.mock('../../store', () => ({
+  useAppStore: {
+    getState: () => testStore.getState()
+  }
+}))
+
+const PANE_KEY = 'tab-1:leaf-1'
+
+const TERMINAL_HANDLE = 'th-1'
+
+function seedStatusEntry(): void {
+  testStore.setState({
+    agentStatusByPaneKey: {
+      [PANE_KEY]: {
+        paneKey: PANE_KEY,
+        agentType: 'claude',
+        state: 'working',
+        prompt: '',
+        updatedAt: 0,
+        stateStartedAt: 0,
+        stateHistory: [],
+        // Why: getAgentLaunchConfigForStatusEntry always sends launchToken:
+        // undefined, so a matching terminalHandle is the identity proof here.
+        terminalHandle: TERMINAL_HANDLE
+      }
+    }
+  } as Partial<AppState>)
+}
+
+describe('resolveNativeChatLiveSessionLaunchArgs', () => {
+  beforeEach(() => {
+    testStore = createTestStore()
+  })
+
+  it('surfaces the pane launch config agent args, proving they reach the hook layer', () => {
+    testStore
+      .getState()
+      .registerAgentLaunchConfig(
+        PANE_KEY,
+        { agentArgs: '--dangerously-skip-permissions', agentEnv: {} },
+        { agentType: 'claude', terminalHandle: TERMINAL_HANDLE }
+      )
+    seedStatusEntry()
+
+    expect(resolveNativeChatLiveSessionLaunchArgs(PANE_KEY)).toEqual({
+      agentArgs: '--dangerously-skip-permissions',
+      agentEnv: {}
+    })
+  })
+
+  it('returns undefined args when the pane has no live status entry yet', () => {
+    expect(resolveNativeChatLiveSessionLaunchArgs(PANE_KEY)).toEqual({
+      agentArgs: undefined,
+      agentEnv: undefined
+    })
+  })
+
+  it('returns undefined args when no launch config was ever registered for the pane', () => {
+    seedStatusEntry()
+    expect(resolveNativeChatLiveSessionLaunchArgs(PANE_KEY)).toEqual({
+      agentArgs: undefined,
+      agentEnv: undefined
+    })
+  })
+})

--- a/src/renderer/src/components/native-chat/native-chat-live-session-launch-args.ts
+++ b/src/renderer/src/components/native-chat/native-chat-live-session-launch-args.ts
@@ -1,0 +1,17 @@
+import { useAppStore } from '../../store'
+
+/** The live session's actual launch args/env (not settings.agentDefaultArgs,
+ *  which is only the default for *new* sessions — see #10886). Read from the
+ *  pane's status entry so a stale global default never masquerades as the
+ *  flag this session actually launched with. */
+export function resolveNativeChatLiveSessionLaunchArgs(paneKey?: string): {
+  agentArgs?: string
+  agentEnv?: Record<string, string>
+} {
+  const state = useAppStore.getState()
+  const statusEntry = paneKey ? state.agentStatusByPaneKey?.[paneKey] : undefined
+  const launchConfig = statusEntry
+    ? state.getAgentLaunchConfigForStatusEntry(statusEntry)
+    : undefined
+  return { agentArgs: launchConfig?.agentArgs, agentEnv: launchConfig?.agentEnv }
+}

--- a/src/renderer/src/components/native-chat/native-chat-pty-session-options.mode.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pty-session-options.mode.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearNativeChatSessionOptionCacheForTests,
+  seedNativeChatAppliedSessionOptions
+} from './native-chat-session-option-cache'
+import { createNativeChatPtySessionOptions } from './native-chat-pty-session-options'
+
+describe('native chat PTY session options — permission mode', () => {
+  beforeEach(() => {
+    clearNativeChatSessionOptionCacheForTests()
+  })
+
+  it('wires a permission-mode cycle selection to dispatchModeCycle', async () => {
+    seedNativeChatAppliedSessionOptions('pty-1', 'claude', { model: 'opus' })
+    const dispatchModeCycle = vi
+      .fn()
+      .mockResolvedValue({ outcome: 'applied', reason: 'reached', presses: 1, observed: ['plan'] })
+    const surface = createNativeChatPtySessionOptions({
+      agent: 'claude',
+      scopeKey: 'pty-1',
+      mode: 'live',
+      dispatchCommand: vi.fn(),
+      dispatchModeCycle
+    })!
+
+    const result = await surface.setOption('permissionMode', 'plan')
+
+    expect(dispatchModeCycle).toHaveBeenCalledWith({ key: '\x1b[Z', target: 'plan' })
+    expect(result.snapshot.find(({ id }) => id === 'permissionMode')).toMatchObject({
+      valueSource: 'applied',
+      kind: { currentValue: 'plan' }
+    })
+  })
+
+  it('rejects a permission-mode change when no dispatchModeCycle is wired', async () => {
+    seedNativeChatAppliedSessionOptions('pty-1', 'claude', { model: 'opus' })
+    const surface = createNativeChatPtySessionOptions({
+      agent: 'claude',
+      scopeKey: 'pty-1',
+      initialModels: [{ id: 'opus[1m]', label: 'Opus (1M context)', options: [] }],
+      mode: 'live',
+      dispatchCommand: vi.fn()
+    })!
+
+    await surface.setOption('model', 'opus[1m]')
+
+    expect(surface.getSnapshot()[0].kind).toMatchObject({
+      currentValue: 'opus[1m]',
+      choices: [{ value: 'opus[1m]', label: 'Opus (1M context)' }]
+    })
+    await expect(surface.setOption('permissionMode', 'plan')).rejects.toThrow(
+      'No live terminal is attached to this chat.'
+    )
+  })
+
+  it('threads agentArgs into the snapshot: bypass is normal and checkmarked when the flag is present', () => {
+    const surface = createNativeChatPtySessionOptions({
+      agent: 'claude',
+      scopeKey: 'pty-1',
+      mode: 'live',
+      dispatchCommand: vi.fn(),
+      agentArgs: '--dangerously-skip-permissions'
+    })!
+    const permissionMode = surface.getSnapshot().find(({ id }) => id === 'permissionMode')
+    expect(permissionMode?.kind).toMatchObject({ currentValue: 'bypassPermissions' })
+    const bypass =
+      permissionMode?.kind.type === 'select'
+        ? permissionMode.kind.choices.find((choice) => choice.value === 'bypassPermissions')
+        : undefined
+    expect(bypass?.unavailable).toBeUndefined()
+  })
+
+  it('threads agentArgs into the snapshot: bypass is unavailable without the flag', () => {
+    const surface = createNativeChatPtySessionOptions({
+      agent: 'claude',
+      scopeKey: 'pty-1',
+      mode: 'live',
+      dispatchCommand: vi.fn(),
+      agentArgs: '--model sonnet'
+    })!
+    const permissionMode = surface.getSnapshot().find(({ id }) => id === 'permissionMode')
+    const bypass =
+      permissionMode?.kind.type === 'select'
+        ? permissionMode.kind.choices.find((choice) => choice.value === 'bypassPermissions')
+        : undefined
+    expect(bypass?.unavailable).toEqual({ action: 'open-agent-permissions-setting' })
+    expect(permissionMode?.kind).not.toHaveProperty('currentValue')
+  })
+})

--- a/src/renderer/src/components/native-chat/native-chat-pty-session-options.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pty-session-options.test.ts
@@ -242,7 +242,7 @@ describe('native chat PTY session options', () => {
     expect(onAgentPicker).not.toHaveBeenCalled()
   })
 
-  it('leaves flip-only unknown after a one-shot so the UI never invents on/off', async () => {
+  it('sets fast mode from an unknown baseline, with no Toggle action to fall back on', async () => {
     seedNativeChatAppliedSessionOptions('pty-1', 'claude', {
       model: 'opus',
       effort: 'high'
@@ -257,25 +257,24 @@ describe('native chat PTY session options', () => {
       persistSelection: persist
     })!
     const fastBefore = surface.getSnapshot().find(({ id }) => id === 'fastMode')
-    expect(fastBefore?.action?.type).toBe('toggle-command')
+    // Why: `/fast on|off` sets outright, so an unknown baseline is no obstacle —
+    // and a bare `/fast` would only open Claude's confirmation panel.
+    expect(fastBefore?.action).toBeUndefined()
     expect(fastBefore?.kind).toMatchObject({ type: 'boolean' })
-    expect(fastBefore?.kind).not.toHaveProperty('defaultValue')
 
-    await expect(surface.setOption('fastMode', true)).rejects.toThrow(
-      'Current value is unknown; use the Toggle action instead.'
-    )
-    expect(dispatch).not.toHaveBeenCalled()
-    const result = await surface.invokeAction('fastMode')
-    expect(dispatch).toHaveBeenCalledWith('/fast')
-    // Why: a flip-only command never reports an absolute value.
+    const result = await surface.setOption('fastMode', true)
+    expect(dispatch).toHaveBeenCalledWith('/fast on')
     expect(result.snapshot.find(({ id }) => id === 'fastMode')).toMatchObject({
-      valueSource: 'unknown',
-      action: { type: 'toggle-command' }
+      valueSource: 'dispatched',
+      kind: { type: 'boolean', currentValue: true }
     })
-    expect(persist).not.toHaveBeenCalled()
+    // An absolute set is a durable preference, like effort.
+    expect(persist).toHaveBeenCalledWith(
+      expect.objectContaining({ modelId: 'opus', optionId: 'fastMode', value: true })
+    )
   })
 
-  it('no-ops a seeded toggle when already at the requested value', async () => {
+  it('re-sends a same-value set, since an absolute command cannot invert the agent', async () => {
     seedNativeChatAppliedSessionOptions('pty-1', 'claude', {
       model: 'opus',
       effort: 'high',
@@ -290,36 +289,10 @@ describe('native chat PTY session options', () => {
     })!
 
     const result = await surface.setOption('fastMode', true)
-    expect(dispatch).not.toHaveBeenCalled()
+    expect(dispatch).toHaveBeenCalledWith('/fast on')
     expect(result.snapshot.find(({ id }) => id === 'fastMode')).toMatchObject({
-      valueSource: 'applied',
+      valueSource: 'dispatched',
       kind: { type: 'boolean', currentValue: true }
-    })
-  })
-
-  it('no-ops a known toggle at the same absolute target (flip is not set-to-value)', async () => {
-    seedNativeChatAppliedSessionOptions('pty-1', 'claude', {
-      model: 'opus',
-      effort: 'high',
-      fastMode: true
-    })
-    const dispatch = vi.fn()
-    const surface = createNativeChatPtySessionOptions({
-      agent: 'claude',
-      scopeKey: 'pty-1',
-      mode: 'live',
-      dispatchCommand: dispatch
-    })!
-
-    await surface.setOption('fastMode', false)
-    dispatch.mockClear()
-    // Why: a second same-target set would re-send `/fast` and invert the agent
-    // if the first flip landed — unlike set-to-value commands, flips cannot retry.
-    const result = await surface.setOption('fastMode', false)
-    expect(dispatch).not.toHaveBeenCalled()
-    expect(result.snapshot.find(({ id }) => id === 'fastMode')).toMatchObject({
-      valueSource: 'applied',
-      kind: { type: 'boolean', currentValue: false }
     })
   })
 
@@ -337,17 +310,16 @@ describe('native chat PTY session options', () => {
       dispatchCommand: dispatch
     })!
 
-    await surface.setOption('fastMode', false)
     dispatch.mockClear()
     const result = await surface.setOption('fastMode', true)
-    expect(dispatch).toHaveBeenCalledWith('/fast')
+    expect(dispatch).toHaveBeenCalledWith('/fast on')
     expect(result.snapshot.find(({ id }) => id === 'fastMode')).toMatchObject({
-      valueSource: 'applied',
+      valueSource: 'dispatched',
       kind: { type: 'boolean', currentValue: true }
     })
   })
 
-  it('tracks a known toggle flip as applied without persisting', async () => {
+  it('tracks an absolute fast-mode set as dispatched, and persists it', async () => {
     seedNativeChatAppliedSessionOptions('pty-1', 'claude', {
       model: 'opus',
       effort: 'high',
@@ -364,14 +336,17 @@ describe('native chat PTY session options', () => {
     })!
 
     const result = await surface.setOption('fastMode', false)
-    expect(dispatch).toHaveBeenCalledWith('/fast')
-    // Why: flip-only never heals; applied is best-known absolute, not dispatched.
+    expect(dispatch).toHaveBeenCalledWith('/fast off')
+    // Why: the agent's own status line is the source of truth now, so a dispatch
+    // stays `dispatched` until the ↯ glyph confirms it.
     expect(result.snapshot.find(({ id }) => id === 'fastMode')).toMatchObject({
-      valueSource: 'applied',
+      valueSource: 'dispatched',
       kind: { type: 'boolean', currentValue: false }
     })
     expect(result.snapshot.find(({ id }) => id === 'fastMode')?.action).toBeUndefined()
-    expect(persist).not.toHaveBeenCalled()
+    expect(persist).toHaveBeenCalledWith(
+      expect.objectContaining({ modelId: 'opus', optionId: 'fastMode', value: false })
+    )
   })
 
   it('serializes concurrent setOption calls so later writes win in order', async () => {
@@ -382,7 +357,7 @@ describe('native chat PTY session options', () => {
     })
     let releaseFirst: (() => void) | undefined
     const dispatch = vi.fn((command: string) => {
-      if (command === '/fast') {
+      if (command === '/fast off') {
         return new Promise<void>((resolve) => {
           releaseFirst = resolve
         })
@@ -411,66 +386,6 @@ describe('native chat PTY session options', () => {
     })
     expect(surface.getSnapshot().find(({ id }) => id === 'fastMode')).toMatchObject({
       kind: { currentValue: false }
-    })
-  })
-
-  it('stays unknown after a typed flip then a picker toggle (no invented absolute)', async () => {
-    seedNativeChatAppliedSessionOptions('pty-1', 'claude', {
-      model: 'opus',
-      effort: 'high'
-    })
-    const dispatch = vi.fn()
-    const surface = createNativeChatPtySessionOptions({
-      agent: 'claude',
-      scopeKey: 'pty-1',
-      mode: 'live',
-      dispatchCommand: dispatch
-    })!
-
-    // Typed `/fast` clears any prior tracking; option stays unknown.
-    surface.recordOutgoingCommand('/fast')
-    expect(surface.getSnapshot().find(({ id }) => id === 'fastMode')).toMatchObject({
-      valueSource: 'unknown',
-      action: { type: 'toggle-command' }
-    })
-
-    await surface.invokeAction('fastMode')
-    expect(dispatch).toHaveBeenCalledWith('/fast')
-    expect(surface.getSnapshot().find(({ id }) => id === 'fastMode')).toMatchObject({
-      valueSource: 'unknown',
-      action: { type: 'toggle-command' }
-    })
-  })
-
-  it('does not re-assert absolute state when a typed flip clears tracking mid-dispatch', async () => {
-    seedNativeChatAppliedSessionOptions('pty-1', 'claude', {
-      model: 'opus',
-      effort: 'high',
-      fastMode: true
-    })
-    let resolveDispatch: (() => void) | undefined
-    const dispatch = vi.fn(
-      () =>
-        new Promise<void>((resolve) => {
-          resolveDispatch = resolve
-        })
-    )
-    const surface = createNativeChatPtySessionOptions({
-      agent: 'claude',
-      scopeKey: 'pty-1',
-      mode: 'live',
-      dispatchCommand: dispatch
-    })!
-
-    const pending = surface.setOption('fastMode', false)
-    await vi.waitFor(() => expect(dispatch).toHaveBeenCalled())
-    // Why: typed `/fast` during await must win — do not write the picker value after.
-    surface.recordOutgoingCommand('/fast')
-    resolveDispatch?.()
-    await pending
-    expect(surface.getSnapshot().find(({ id }) => id === 'fastMode')).toMatchObject({
-      valueSource: 'unknown',
-      action: { type: 'toggle-command' }
     })
   })
 

--- a/src/renderer/src/components/native-chat/native-chat-pty-session-options.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pty-session-options.test.ts
@@ -35,6 +35,8 @@ describe('native chat PTY session options', () => {
       dispatchCommand: vi.fn()
     })!
 
+    // Session-scoped options (e.g. Claude's permission mode) always appear alongside the model.
+    expect(surface.getSnapshot()).toHaveLength(2)
     expect(surface.getSnapshot()[0]).toMatchObject({
       id: 'model',
       valueSource: 'unknown',
@@ -114,7 +116,12 @@ describe('native chat PTY session options', () => {
 
     const effortResult = await surface.setOption('effort', 'high')
     expect(dispatch).toHaveBeenCalledWith('/effort high')
-    expect(effortResult.snapshot.map(({ id }) => id)).toEqual(['model', 'effort', 'fastMode'])
+    expect(effortResult.snapshot.map(({ id }) => id)).toEqual([
+      'model',
+      'permissionMode',
+      'effort',
+      'fastMode'
+    ])
     expect(effortResult.snapshot.find(({ id }) => id === 'effort')).toMatchObject({
       valueSource: 'dispatched',
       kind: { currentValue: 'high' }
@@ -229,7 +236,7 @@ describe('native chat PTY session options', () => {
       'Could not verify the model change; open the terminal to check.'
     )
 
-    expect(surface.getSnapshot()).toHaveLength(1)
+    expect(surface.getSnapshot()).toHaveLength(2)
     expect(surface.getSnapshot()[0]).toMatchObject({ valueSource: 'unknown' })
     expect(persist).not.toHaveBeenCalled()
     expect(onAgentPicker).not.toHaveBeenCalled()
@@ -610,7 +617,7 @@ describe('native chat PTY session options', () => {
     surface.recordOutgoingCommand('/model')
 
     expect(onAgentPicker).toHaveBeenCalledOnce()
-    expect(surface.getSnapshot()).toHaveLength(1)
+    expect(surface.getSnapshot()).toHaveLength(2)
     expect(surface.getSnapshot()[0]).toMatchObject({ valueSource: 'unknown' })
   })
 

--- a/src/renderer/src/components/native-chat/native-chat-pty-session-options.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pty-session-options.ts
@@ -20,13 +20,17 @@ import {
   writeNativeChatSessionOptionCache
 } from './native-chat-session-option-cache'
 import { createSessionOptionAppliers } from './native-chat-session-option-apply'
+import { describeClaudePermissionModeCycle } from './claude-permission-mode-cycle'
 import {
   buildNativeChatSessionOptionSnapshot,
   resolveEffectiveNativeChatModelId,
   withTrackedNativeChatModel,
   type NativeChatSessionOptionMode
 } from './native-chat-session-option-snapshot'
-import type { NativeChatSessionOptionDispatchCommand } from './native-chat-session-option-command-dispatch'
+import type {
+  NativeChatModeCycleDispatch,
+  NativeChatSessionOptionDispatchCommand
+} from './native-chat-session-option-command-dispatch'
 
 type PersistSelection = (args: {
   modelId: string
@@ -49,7 +53,12 @@ export type CreateNativeChatPtySessionOptionsArgs = {
   initialModels?: readonly CatalogModel[]
   mode: NativeChatSessionOptionMode
   reportedValues?: Record<string, SessionOptionValue> | null
+  /** The live session's actual launch args/env (not the settings default for
+   *  new sessions) — gates Claude's bypassPermissions choice. */
+  agentArgs?: string | null
+  agentEnv?: Record<string, string> | null
   dispatchCommand: NativeChatSessionOptionDispatchCommand
+  dispatchModeCycle?: NativeChatModeCycleDispatch
   onAgentPicker?: () => void
   persistSelection?: PersistSelection
   onDraftValuesChanged?: (values: Record<string, SessionOptionValue>) => void
@@ -98,7 +107,9 @@ export function createNativeChatPtySessionOptions(
     catalog,
     models: activeModels(),
     record,
-    mode: args.mode
+    mode: args.mode,
+    agentArgs: args.agentArgs,
+    agentEnv: args.agentEnv
   })
   const listeners = new Set<(value: SessionOptionDescriptor[]) => void>()
 
@@ -108,7 +119,9 @@ export function createNativeChatPtySessionOptions(
       catalog,
       models: activeModels(),
       record,
-      mode: args.mode
+      mode: args.mode,
+      agentArgs: args.agentArgs,
+      agentEnv: args.agentEnv
     })
     for (const listener of listeners) {
       listener(snapshot)
@@ -167,6 +180,21 @@ export function createNativeChatPtySessionOptions(
     onAgentPicker: args.onAgentPicker,
     persist,
     onDraftValuesChanged: args.onDraftValuesChanged,
+    applyModeCycle: async (optionId, value) => {
+      const option = catalog.sessionOptions?.find((candidate) => candidate.id === optionId)
+      const midSession = option?.apply.midSession
+      if (midSession?.kind !== 'cycle-key' || typeof value !== 'string') {
+        return { outcome: 'unknown', detail: 'This option cannot be changed from chat.' }
+      }
+      if (!args.dispatchModeCycle) {
+        return { outcome: 'unknown', detail: 'No live terminal is attached to this chat.' }
+      }
+      const result = await args.dispatchModeCycle({ key: midSession.key, target: value })
+      return {
+        outcome: result.outcome,
+        detail: describeClaudePermissionModeCycle(value, result)
+      }
+    },
     publish,
     clearModelTruth,
     setTrackedValue

--- a/src/renderer/src/components/native-chat/native-chat-session-option-apply.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-apply.ts
@@ -14,7 +14,6 @@ import type {
 import { buildNativeChatSessionOptionCommand } from '../../../../shared/native-chat-session-option-commands'
 import {
   getTrackedSessionOption as getTrackedOption,
-  isFlipOnlyMidSession,
   type NativeChatSessionOptionRecord
 } from '../../../../shared/native-chat-session-option-state'
 import type {
@@ -211,20 +210,7 @@ async function applySetOption(
     return finish(ctx, { modelId: previousModelId, optionId: id, value, skipPersist: true })
   }
 
-  const liveFlipOnly = ctx.mode === 'live' && isFlipOnlyMidSession(apply.midSession)
-  const trackedToggle = liveFlipOnly
-    ? getTrackedOption(ctx.getRecord(), previousModelId, id)
-    : undefined
-  if (liveFlipOnly && !trackedToggle) {
-    // Why: a flip from an unknown baseline cannot honor an absolute target.
-    throw new Error('Current value is unknown; use the Toggle action instead.')
-  }
-  // Why: same absolute target must never re-dispatch a flip (would invert the agent).
-  if (liveFlipOnly && trackedToggle?.value === value) {
-    return { snapshot: ctx.publish() }
-  }
-  // Why: flip-only never heals via agent report — track as applied best-known.
-  const source = liveFlipOnly || ctx.mode !== 'live' ? 'applied' : 'dispatched'
+  const source = ctx.mode !== 'live' ? 'applied' : 'dispatched'
 
   // Why: baseline for detecting a model switch, typed command, or agent report
   // that lands mid-dispatch, so the commit below never overwrites newer state.
@@ -260,20 +246,6 @@ async function applySetOption(
     }
   }
 
-  if (liveFlipOnly) {
-    // Why: typed flips, reports, or model changes during dispatch supersede the
-    // baseline this absolute target was computed from.
-    if (trackedModelId(record) !== trackedModelBeforeDispatch) {
-      return finish(ctx, { modelId: previousModelId, optionId: id, value, skipPersist: true })
-    }
-    if (getTrackedOption(record, previousModelId, id) !== trackedToggle) {
-      return finish(ctx, { modelId: previousModelId, optionId: id, value, skipPersist: true })
-    }
-    // Why: never persist unconfirmed flip-only state into durable defaults.
-    ctx.setTrackedValue(id, value, source)
-    return finish(ctx, { modelId: previousModelId, optionId: id, value, skipPersist: true })
-  }
-
   if (ctx.mode === 'live' && id !== 'model') {
     // Why: a model switch, typed command, or agent report during dispatch supersedes
     // the baseline this commit was computed from — committing now would overwrite
@@ -300,25 +272,14 @@ async function applyInvokeAction(
   if (!resolved) {
     throw new Error(`Unknown session option: ${id}`)
   }
-  const { apply, modelId } = resolved
+  const { apply } = resolved
   if (apply.midSession?.kind === 'agent-picker') {
     if (ctx.mode !== 'live') {
       throw new Error('This option is only available after the session starts.')
     }
     return handleAgentPicker(ctx, apply.midSession)
   }
-  if (!isFlipOnlyMidSession(apply.midSession)) {
-    throw new Error('This option requires a value.')
-  }
-  if (ctx.mode !== 'live') {
-    throw new Error('This option is only available after the session starts.')
-  }
-  if (getTrackedOption(ctx.getRecord(), modelId, id)) {
-    throw new Error('This option has a known value; choose On or Off instead.')
-  }
-  // Why: an unknown baseline remains unknown after one inversion.
-  await ctx.dispatchCommand(apply.midSession.command)
-  return finish(ctx)
+  throw new Error('This option requires a value.')
 }
 
 export function createSessionOptionAppliers(ctx: SessionOptionApplyContext): {

--- a/src/renderer/src/components/native-chat/native-chat-session-option-apply.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-apply.ts
@@ -38,6 +38,10 @@ type SessionOptionApplyContext = {
    *  null-model guard and whether the id may be adopted as the launch default. */
   persist: (modelId: string | null, optionId: string, value: SessionOptionValue) => void
   onDraftValuesChanged?: (values: Record<string, SessionOptionValue>) => void
+  applyModeCycle?: (
+    optionId: string,
+    value: SessionOptionValue
+  ) => Promise<{ outcome: 'applied' | 'unavailable' | 'unknown'; detail: string }>
   publish: () => SessionOptionDescriptor[]
   clearModelTruth: () => void
   setTrackedValue: (
@@ -73,7 +77,8 @@ function currentApply(
     return { apply: ctx.catalog.modelApply, modelId }
   }
   const model = modelId ? findCatalogModel({ ...ctx.catalog, models }, modelId) : undefined
-  const option = findCatalogOption(model, optionId)
+  const sessionOption = ctx.catalog.sessionOptions?.find((candidate) => candidate.id === optionId)
+  const option = sessionOption ?? findCatalogOption(model, optionId)
   return option ? { apply: option.apply, modelId } : null
 }
 
@@ -194,6 +199,18 @@ async function applySetOption(
     throw new Error('This option must be changed in the agent picker.')
   }
 
+  if (ctx.mode === 'live' && apply.midSession?.kind === 'cycle-key') {
+    if (!ctx.applyModeCycle) {
+      throw new Error('This option cannot be changed from chat.')
+    }
+    const { outcome, detail } = await ctx.applyModeCycle(id, value)
+    if (outcome !== 'applied') {
+      throw new Error(detail)
+    }
+    ctx.setTrackedValue(id, value, 'applied')
+    return finish(ctx, { modelId: previousModelId, optionId: id, value, skipPersist: true })
+  }
+
   const liveFlipOnly = ctx.mode === 'live' && isFlipOnlyMidSession(apply.midSession)
   const trackedToggle = liveFlipOnly
     ? getTrackedOption(ctx.getRecord(), previousModelId, id)
@@ -270,7 +287,9 @@ async function applySetOption(
   }
 
   const modelId = ctx.setTrackedValue(id, value, source)
-  return finish(ctx, { modelId: modelId ?? previousModelId, optionId: id, value })
+  // Why: a session option is session-scoped truth, never persisted under a model.
+  const skipPersist = ctx.catalog.sessionOptions?.some((option) => option.id === id) ?? false
+  return finish(ctx, { modelId: modelId ?? previousModelId, optionId: id, value, skipPersist })
 }
 
 async function applyInvokeAction(

--- a/src/renderer/src/components/native-chat/native-chat-session-option-command-dispatch.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-command-dispatch.ts
@@ -3,10 +3,16 @@ import type {
   CatalogCommandDelivery
 } from '../../../../shared/agent-session-option-catalog'
 import type { ClaudeModelSwitchOutcome } from './claude-model-switch-confirmation'
+import type { ClaudePermissionModeCycleResult } from './claude-permission-mode-cycle'
 
 export type NativeChatSessionOptionDispatchResult = {
   outcome?: ClaudeModelSwitchOutcome
 }
+
+export type NativeChatModeCycleDispatch = (args: {
+  key: string
+  target: string
+}) => Promise<ClaudePermissionModeCycleResult>
 
 export type NativeChatSessionOptionDispatchCommand = (
   command: string,

--- a/src/renderer/src/components/native-chat/native-chat-session-option-labels.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-labels.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from 'vitest'
 import { translate } from '@/i18n/i18n'
 import {
   nativeChatModelPillLabel,
+  nativeChatOptionsPillLabel,
+  nativeChatPermissionModePillLabel,
   nativeChatSessionChoiceLabel
 } from './native-chat-session-option-labels'
 import type { SessionOptionDescriptor } from '../../../../shared/native-chat-session-options'
@@ -58,5 +60,113 @@ describe('nativeChatSessionChoiceLabel', () => {
       'components.native-chat.composer.optionValue.ultra',
       'Ultra'
     )
+  })
+})
+
+describe('nativeChatSessionChoiceLabel — permission mode', () => {
+  it('labels permission-mode choices', () => {
+    expect(
+      nativeChatSessionChoiceLabel({ value: 'bypassPermissions', label: 'raw' }, 'permissionMode')
+    ).toBe('Bypass permissions')
+    expect(
+      nativeChatSessionChoiceLabel({ value: 'acceptEdits', label: 'raw' }, 'permissionMode')
+    ).toBe('Accept edits')
+  })
+
+  // Why: Cursor ships a model whose value is literally `auto`. An unscoped
+  // switch would relabel it from the catalog's own text in every locale.
+  it('leaves a model choice named auto to the catalog label', () => {
+    expect(nativeChatSessionChoiceLabel({ value: 'auto', label: 'Auto (Cursor)' }, 'model')).toBe(
+      'Auto (Cursor)'
+    )
+    expect(nativeChatSessionChoiceLabel({ value: 'auto', label: 'Auto (Cursor)' })).toBe(
+      'Auto (Cursor)'
+    )
+  })
+
+  it('still labels effort choices without an option id', () => {
+    expect(nativeChatSessionChoiceLabel({ value: 'xhigh', label: 'raw' })).toBe('Extra high')
+  })
+
+  it('falls back to the catalog label for an unknown mode value', () => {
+    expect(
+      nativeChatSessionChoiceLabel({ value: 'dontAsk', label: 'Do not ask' }, 'permissionMode')
+    ).toBe('Do not ask')
+  })
+})
+
+function permissionModeDescriptor(currentValue: string): SessionOptionDescriptor {
+  return {
+    id: 'permissionMode',
+    label: 'Mode',
+    kind: {
+      type: 'select',
+      currentValue,
+      choices: [
+        { value: 'manual', label: 'Manual' },
+        { value: 'plan', label: 'Plan' }
+      ]
+    },
+    valueSource: 'reported',
+    settable: true
+  }
+}
+
+function effortDescriptor(currentValue: string): SessionOptionDescriptor {
+  return {
+    id: 'effort',
+    label: 'Effort',
+    kind: {
+      type: 'select',
+      currentValue,
+      choices: [{ value: currentValue, label: currentValue }]
+    },
+    valueSource: 'applied',
+    settable: true
+  }
+}
+
+describe('nativeChatOptionsPillLabel', () => {
+  it('names a lone unknown effort control explicitly', () => {
+    expect(nativeChatOptionsPillLabel([effortDescriptor('high')])).toBe('High')
+  })
+
+  it('falls back to a generic title when nothing contributes a label', () => {
+    expect(
+      nativeChatOptionsPillLabel([{ ...effortDescriptor('high'), valueSource: 'unknown' }])
+    ).toBe('Effort')
+  })
+})
+
+describe('nativeChatPermissionModePillLabel', () => {
+  it('shows the current mode, including the manual default', () => {
+    expect(nativeChatPermissionModePillLabel(permissionModeDescriptor('manual'))).toBe('Manual')
+    expect(nativeChatPermissionModePillLabel(permissionModeDescriptor('plan'))).toBe('Plan')
+  })
+
+  it('falls back to the localized "Mode" label when the value source is unknown', () => {
+    expect(
+      nativeChatPermissionModePillLabel({
+        ...permissionModeDescriptor('manual'),
+        valueSource: 'unknown'
+      })
+    ).toBe('Mode')
+  })
+
+  it('falls back to the choice catalog label for an unrecognized mode value', () => {
+    expect(
+      nativeChatPermissionModePillLabel({
+        ...permissionModeDescriptor('dontAsk'),
+        kind: {
+          type: 'select',
+          currentValue: 'dontAsk',
+          choices: [
+            { value: 'manual', label: 'Manual' },
+            { value: 'plan', label: 'Plan' },
+            { value: 'dontAsk', label: 'Do not ask' }
+          ]
+        }
+      })
+    ).toBe('Do not ask')
   })
 })

--- a/src/renderer/src/components/native-chat/native-chat-session-option-labels.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-labels.ts
@@ -15,12 +15,43 @@ export function nativeChatSessionOptionLabel(descriptor: SessionOptionDescriptor
       return translate('components.native-chat.composer.fastMode', 'Fast mode')
     case 'thinking':
       return translate('components.native-chat.composer.thinking', 'Thinking')
+    case 'permissionMode':
+      return translate('components.native-chat.composer.permissionMode', 'Mode')
     default:
       return descriptor.label
   }
 }
 
-export function nativeChatSessionChoiceLabel(choice: SessionOptionSelectChoice): string {
+// Why: scoped to the permission-mode option. These values collide with other
+// catalogs — Cursor ships a model literally named `auto` — and a shared switch
+// would relabel it in every non-English locale.
+function permissionModeChoiceLabel(value: string): string | null {
+  switch (value) {
+    case 'manual':
+      return translate('components.native-chat.composer.optionValue.manual', 'Manual')
+    case 'acceptEdits':
+      return translate('components.native-chat.composer.optionValue.acceptEdits', 'Accept edits')
+    case 'plan':
+      return translate('components.native-chat.composer.optionValue.plan', 'Plan')
+    case 'auto':
+      return translate('components.native-chat.composer.optionValue.auto', 'Auto')
+    case 'bypassPermissions':
+      return translate(
+        'components.native-chat.composer.optionValue.bypassPermissions',
+        'Bypass permissions'
+      )
+    default:
+      return null
+  }
+}
+
+export function nativeChatSessionChoiceLabel(
+  choice: SessionOptionSelectChoice,
+  optionId?: string
+): string {
+  if (optionId === 'permissionMode') {
+    return permissionModeChoiceLabel(choice.value) ?? choice.label
+  }
   switch (choice.value) {
     case 'minimal':
       return translate('components.native-chat.composer.optionValue.minimal', 'Minimal')
@@ -82,6 +113,25 @@ export function nativeChatModelPillLabel(descriptor: SessionOptionDescriptor): s
   )
 }
 
+export function nativeChatPermissionModePillLabel(descriptor: SessionOptionDescriptor): string {
+  // Why: dedicated pill always shows the current mode — unlike the shared
+  // options pill, it does not stay quiet for the manual default.
+  if (
+    descriptor.valueSource === 'unknown' ||
+    descriptor.kind.type !== 'select' ||
+    !descriptor.kind.currentValue
+  ) {
+    return translate('components.native-chat.composer.permissionMode', 'Mode')
+  }
+  return nativeChatSessionChoiceLabel(
+    descriptor.kind.choices.find((choice) => choice.value === descriptor.kind.currentValue) ?? {
+      value: descriptor.kind.currentValue,
+      label: descriptor.kind.currentValue
+    },
+    'permissionMode'
+  )
+}
+
 export function nativeChatOptionsPillTitle(
   descriptors: readonly SessionOptionDescriptor[]
 ): string {
@@ -110,7 +160,8 @@ export function nativeChatOptionsPillLabel(
           choice ?? {
             value: descriptor.kind.currentValue,
             label: descriptor.kind.currentValue
-          }
+          },
+          descriptor.id
         )
       )
     } else if (descriptor.kind.type === 'boolean' && descriptor.kind.currentValue === true) {

--- a/src/renderer/src/components/native-chat/native-chat-session-option-labels.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-labels.ts
@@ -22,9 +22,9 @@ export function nativeChatSessionOptionLabel(descriptor: SessionOptionDescriptor
   }
 }
 
-// Why: scoped to the permission-mode option. These values collide with other
-// catalogs — Cursor ships a model literally named `auto` — and a shared switch
-// would relabel it in every non-English locale.
+/** Localized label for a permission-mode value, scoped to that option: these
+ *  values collide with other catalogs — Cursor ships a model literally named
+ *  `auto` — and a shared switch would relabel it in every non-English locale. */
 function permissionModeChoiceLabel(value: string): string | null {
   switch (value) {
     case 'manual':
@@ -113,9 +113,10 @@ export function nativeChatModelPillLabel(descriptor: SessionOptionDescriptor): s
   )
 }
 
+/** Visible text for the Mode pill. Always names the current mode, including the
+ *  manual default — unlike the shared options pill, showing the selection is
+ *  this control's whole purpose. */
 export function nativeChatPermissionModePillLabel(descriptor: SessionOptionDescriptor): string {
-  // Why: dedicated pill always shows the current mode — unlike the shared
-  // options pill, it does not stay quiet for the manual default.
   if (
     descriptor.valueSource === 'unknown' ||
     descriptor.kind.type !== 'select' ||

--- a/src/renderer/src/components/native-chat/native-chat-session-option-snapshot.mode.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-snapshot.mode.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it, vi } from 'vitest'
+import { getAgentSessionOptionCatalog } from '../../../../shared/agent-session-option-catalog'
+import { createNativeChatSessionOptionRecord } from '../../../../shared/native-chat-session-option-state'
+import type { NativeChatSessionOptionRecord } from '../../../../shared/native-chat-session-option-state'
+import {
+  buildNativeChatSessionOptionSnapshot,
+  flattenNativeChatSessionOptionRecord
+} from './native-chat-session-option-snapshot'
+import { createSessionOptionAppliers } from './native-chat-session-option-apply'
+import type { SessionOptionValue } from '../../../../shared/native-chat-session-options'
+import { readClaudePermissionModeFromTerminalScreen } from './claude-terminal-session-options'
+import { applyNativeChatReportedSessionOptions } from '../../../../shared/native-chat-session-option-state'
+
+const catalog = getAgentSessionOptionCatalog('claude')!
+
+function build(
+  mode: 'draft' | 'live',
+  options?: { record?: NativeChatSessionOptionRecord; agentArgs?: string | null }
+) {
+  return buildNativeChatSessionOptionSnapshot({
+    catalog,
+    models: catalog.models,
+    record: options?.record ?? createNativeChatSessionOptionRecord('claude'),
+    mode,
+    agentArgs: options?.agentArgs
+  })
+}
+
+function permissionModeChoices(agentArgs?: string | null, record?: NativeChatSessionOptionRecord) {
+  const descriptor = build('live', { agentArgs, record }).find((d) => d.id === 'permissionMode')
+  if (descriptor?.kind.type !== 'select') {
+    throw new Error('expected permissionMode to be a select descriptor')
+  }
+  return descriptor.kind
+}
+
+describe('permission mode descriptor', () => {
+  it('appears even when no model is tracked yet', () => {
+    expect(build('live').find((d) => d.id === 'permissionMode')).toBeDefined()
+  })
+
+  it('is settable in a live session via the key menu', () => {
+    const descriptor = build('live').find((d) => d.id === 'permissionMode')
+    expect(descriptor?.settable).toBe(true)
+    expect(descriptor?.action).toBeUndefined()
+  })
+
+  it('is settable in draft because it has launch args', () => {
+    expect(build('draft').find((d) => d.id === 'permissionMode')?.settable).toBe(true)
+  })
+
+  it('carries the mode category so it sorts with modes', () => {
+    expect(build('live').find((d) => d.id === 'permissionMode')?.category).toBe('mode')
+  })
+
+  it('never composes session options into the model value', () => {
+    const record = createNativeChatSessionOptionRecord('claude')
+    record.sessionValues.permissionMode = { value: 'plan', source: 'reported' }
+    expect(flattenNativeChatSessionOptionRecord(record, 'sonnet')).toEqual({ model: 'sonnet' })
+  })
+})
+
+describe('bypass permissions gated on the launch flag', () => {
+  it('offers bypass as a normal choice when agent args carry --dangerously-skip-permissions', () => {
+    const bypass = permissionModeChoices('--dangerously-skip-permissions').choices.find(
+      (choice) => choice.value === 'bypassPermissions'
+    )
+    expect(bypass?.unavailable).toBeUndefined()
+  })
+
+  it('marks bypass unavailable when agent args do not carry the flag', () => {
+    const bypass = permissionModeChoices('--model sonnet').choices.find(
+      (choice) => choice.value === 'bypassPermissions'
+    )
+    expect(bypass?.unavailable).toEqual({ action: 'open-agent-permissions-setting' })
+  })
+
+  it('leaves the other four choices selectable when bypass is unavailable', () => {
+    const others = permissionModeChoices(null).choices.filter(
+      (choice) => choice.value !== 'bypassPermissions'
+    )
+    expect(others).toHaveLength(4)
+    expect(others.every((choice) => choice.unavailable === undefined)).toBe(true)
+  })
+
+  it('leaves the other four choices selectable when bypass is available', () => {
+    const others = permissionModeChoices('--dangerously-skip-permissions').choices.filter(
+      (choice) => choice.value !== 'bypassPermissions'
+    )
+    expect(others).toHaveLength(4)
+    expect(others.every((choice) => choice.unavailable === undefined)).toBe(true)
+  })
+
+  it('reports bypassPermissions as the current value when the flag is present and nothing was reported', () => {
+    expect(permissionModeChoices('--dangerously-skip-permissions').currentValue).toBe(
+      'bypassPermissions'
+    )
+  })
+
+  it('lets a reported mode win over the launch-args inference', () => {
+    const record = createNativeChatSessionOptionRecord('claude')
+    record.sessionValues.permissionMode = { value: 'plan', source: 'reported' }
+    expect(permissionModeChoices('--dangerously-skip-permissions', record).currentValue).toBe(
+      'plan'
+    )
+  })
+})
+
+describe('an observed bypass mode is proof of the grant, even with empty launch args', () => {
+  it('does not mark the bypass choice unavailable when the tracked mode is bypassPermissions', () => {
+    const record = createNativeChatSessionOptionRecord('claude')
+    record.sessionValues.permissionMode = { value: 'bypassPermissions', source: 'reported' }
+    const bypass = permissionModeChoices(null, record).choices.find(
+      (choice) => choice.value === 'bypassPermissions'
+    )
+    expect(bypass?.unavailable).toBeUndefined()
+  })
+
+  it('still marks bypass unavailable when the tracked mode is a different mode and launch args are empty', () => {
+    const record = createNativeChatSessionOptionRecord('claude')
+    record.sessionValues.permissionMode = { value: 'plan', source: 'reported' }
+    const bypass = permissionModeChoices(null, record).choices.find(
+      (choice) => choice.value === 'bypassPermissions'
+    )
+    expect(bypass?.unavailable).toEqual({ action: 'open-agent-permissions-setting' })
+  })
+
+  it('reproduces the reported bug end-to-end: real status line, empty launch args, bypass selectable', () => {
+    const permissionMode = readClaudePermissionModeFromTerminalScreen(
+      '> \n▶▶ bypass permissions on (shift+tab to cycle)'
+    )
+    expect(permissionMode).toBe('bypassPermissions')
+    const record = createNativeChatSessionOptionRecord('claude')
+    applyNativeChatReportedSessionOptions(record, { permissionMode: permissionMode! })
+    const descriptor = permissionModeChoices(null, record)
+    expect(descriptor.currentValue).toBe('bypassPermissions')
+    const bypass = descriptor.choices.find((choice) => choice.value === 'bypassPermissions')
+    expect(bypass?.unavailable).toBeUndefined()
+  })
+})
+
+type ApplyModeCycle = (
+  optionId: string,
+  value: SessionOptionValue
+) => Promise<{ outcome: 'applied' | 'unavailable' | 'unknown'; detail: string }>
+
+describe('applying a session-scoped option', () => {
+  function appliers(
+    record: NativeChatSessionOptionRecord,
+    applyModeCycle: ApplyModeCycle | undefined
+  ) {
+    return createSessionOptionAppliers({
+      mode: 'live',
+      catalog,
+      getModels: () => catalog.models,
+      getRecord: () => record,
+      dispatchCommand: () => undefined,
+      applyModeCycle,
+      persist: () => {},
+      publish: () => [],
+      clearModelTruth: () => {},
+      setTrackedValue: (optionId, value, source) => {
+        record.sessionValues[optionId] = { value, source }
+        return null
+      }
+    })
+  }
+
+  it('routes a cycle-key option to the mode-cycle handler', async () => {
+    const record = createNativeChatSessionOptionRecord('claude')
+    const seen: string[] = []
+    await appliers(record, async (optionId, value) => {
+      seen.push(`${optionId}=${String(value)}`)
+      return { outcome: 'applied', detail: 'Set to plan.' }
+    }).setOption('permissionMode', 'plan')
+    expect(seen).toEqual(['permissionMode=plan'])
+    expect(record.sessionValues.permissionMode).toEqual({ value: 'plan', source: 'applied' })
+  })
+
+  it('surfaces a launch-only bypass as a clear error', async () => {
+    const record = createNativeChatSessionOptionRecord('claude')
+    await expect(
+      appliers(record, async () => ({
+        outcome: 'unavailable',
+        detail: "bypassPermissions is not in this session's cycle; saw plan."
+      })).setOption('permissionMode', 'bypassPermissions')
+    ).rejects.toThrow(/not in this session's cycle/i)
+    expect(record.sessionValues.permissionMode).toBeUndefined()
+  })
+
+  it('does not record a value it could not verify', async () => {
+    const record = createNativeChatSessionOptionRecord('claude')
+    await expect(
+      appliers(record, async () => ({
+        outcome: 'unknown',
+        detail: 'Could not read the current mode from the terminal.'
+      })).setOption('permissionMode', 'plan')
+    ).rejects.toThrow(/terminal/i)
+    expect(record.sessionValues.permissionMode).toBeUndefined()
+  })
+
+  it('fails clearly when no mode-cycle handler is available', async () => {
+    const record = createNativeChatSessionOptionRecord('claude')
+    await expect(appliers(record, undefined).setOption('permissionMode', 'plan')).rejects.toThrow()
+    expect(record.sessionValues.permissionMode).toBeUndefined()
+  })
+})
+
+describe('draft-mode persistence of session-scoped options', () => {
+  // Why: mirrors createNativeChatPtySessionOptions' real routing — a session
+  // option goes to sessionValues, a model option goes under the tracked model.
+  function trackingSetter(record: NativeChatSessionOptionRecord) {
+    return (optionId: string, value: SessionOptionValue, source: 'applied' | 'dispatched') => {
+      if (optionId === 'model') {
+        record.model = { value, source }
+        return typeof value === 'string' ? value : null
+      }
+      if (catalog.sessionOptions?.some((option) => option.id === optionId)) {
+        record.sessionValues[optionId] = { value, source }
+        return null
+      }
+      const modelId = typeof record.model?.value === 'string' ? record.model.value : null
+      if (!modelId) {
+        return null
+      }
+      record.valuesByModel[modelId] = {
+        ...record.valuesByModel[modelId],
+        [optionId]: { value, source }
+      }
+      return modelId
+    }
+  }
+
+  it('does not persist a permissionMode selection', async () => {
+    const record = createNativeChatSessionOptionRecord('claude')
+    record.model = { value: 'sonnet', source: 'applied' }
+    const persist = vi.fn()
+    await createSessionOptionAppliers({
+      mode: 'draft',
+      catalog,
+      getModels: () => catalog.models,
+      getRecord: () => record,
+      dispatchCommand: () => undefined,
+      persist,
+      publish: () => [],
+      clearModelTruth: () => {},
+      setTrackedValue: trackingSetter(record)
+    }).setOption('permissionMode', 'plan')
+    expect(persist).not.toHaveBeenCalled()
+    expect(record.sessionValues.permissionMode).toEqual({ value: 'plan', source: 'applied' })
+  })
+
+  it('still persists a model-scoped option', async () => {
+    const record = createNativeChatSessionOptionRecord('claude')
+    record.model = { value: 'opus', source: 'applied' }
+    const persist = vi.fn()
+    await createSessionOptionAppliers({
+      mode: 'draft',
+      catalog,
+      getModels: () => catalog.models,
+      getRecord: () => record,
+      dispatchCommand: () => undefined,
+      persist,
+      publish: () => [],
+      clearModelTruth: () => {},
+      setTrackedValue: trackingSetter(record)
+    }).setOption('effort', 'high')
+    expect(persist).toHaveBeenCalledWith('opus', 'effort', 'high')
+  })
+})
+
+describe('bypass availability with extra launch args', () => {
+  it('still offers bypass when the flag sits alongside other args', () => {
+    const args = '--dangerously-skip-permissions --verbose'
+    const bypass = permissionModeChoices(args).choices.find((c) => c.value === 'bypassPermissions')
+    expect(bypass?.unavailable).toBeUndefined()
+    expect(permissionModeChoices(args).currentValue).toBe('bypassPermissions')
+  })
+
+  it('withholds bypass when other args carry no bypass flag', () => {
+    const bypass = permissionModeChoices('--model opus').choices.find(
+      (c) => c.value === 'bypassPermissions'
+    )
+    expect(bypass?.unavailable).toEqual({ action: 'open-agent-permissions-setting' })
+  })
+})

--- a/src/renderer/src/components/native-chat/native-chat-session-option-snapshot.mode.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-snapshot.mode.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
 import { getAgentSessionOptionCatalog } from '../../../../shared/agent-session-option-catalog'
-import { createNativeChatSessionOptionRecord } from '../../../../shared/native-chat-session-option-state'
-import type { NativeChatSessionOptionRecord } from '../../../../shared/native-chat-session-option-state'
+import {
+  applyNativeChatReportedSessionOptions,
+  createNativeChatSessionOptionRecord,
+  type NativeChatSessionOptionRecord
+} from '../../../../shared/native-chat-session-option-state'
 import {
   buildNativeChatSessionOptionSnapshot,
   flattenNativeChatSessionOptionRecord
@@ -9,7 +12,6 @@ import {
 import { createSessionOptionAppliers } from './native-chat-session-option-apply'
 import type { SessionOptionValue } from '../../../../shared/native-chat-session-options'
 import { readClaudePermissionModeFromTerminalScreen } from './claude-terminal-session-options'
-import { applyNativeChatReportedSessionOptions } from '../../../../shared/native-chat-session-option-state'
 
 const catalog = getAgentSessionOptionCatalog('claude')!
 

--- a/src/renderer/src/components/native-chat/native-chat-session-option-snapshot.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-snapshot.ts
@@ -27,6 +27,9 @@ export function buildNativeChatSessionOptionSnapshot(args: {
   models: readonly CatalogModel[]
   record: NativeChatSessionOptionRecord
   mode: NativeChatSessionOptionMode
+  /** The live session's actual launch args, for gating bypass permissions. */
+  agentArgs?: string | null
+  agentEnv?: Record<string, string> | null
 }): SessionOptionDescriptor[] {
   return buildSharedSnapshot({
     ...args,

--- a/src/renderer/src/components/native-chat/use-native-chat-session-option-command.mode-cycle.test.tsx
+++ b/src/renderer/src/components/native-chat/use-native-chat-session-option-command.mode-cycle.test.tsx
@@ -1,0 +1,273 @@
+// @vitest-environment happy-dom
+
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  emitNativeChatMessageSent: vi.fn<(...args: unknown[]) => void>(),
+  sendRuntimePtyInput: vi.fn<(...args: unknown[]) => boolean>(() => true),
+  nativeChatComposerTargetIsRemote: vi.fn<(...args: unknown[]) => boolean>(() => false),
+  pushHistory: vi.fn<(...args: unknown[]) => unknown>((history) => history),
+  sendNativeChatMessageVerified: vi.fn<(...args: unknown[]) => unknown>(),
+  cancelNativeChatPtySends: vi.fn<(...args: unknown[]) => void>(),
+  waitForNativeChatPtyIdle: vi.fn<(...args: unknown[]) => Promise<void>>(() => Promise.resolve()),
+  createClaudeModelSwitchConfirmationObserver: vi.fn<(...args: unknown[]) => unknown>(),
+  cycleClaudePermissionMode:
+    vi.fn<
+      (args: {
+        target: string
+        readMode: () => Promise<string | null>
+        sendKey: (key: string) => boolean
+        key: string
+        isCancelled?: () => boolean
+      }) => Promise<unknown>
+    >(),
+  readNativeChatLiveScreen: vi.fn<(...args: unknown[]) => Promise<string | null>>(() =>
+    Promise.resolve(null)
+  ),
+  readClaudeSessionOptionsFromTerminalScreen: vi.fn<(...args: unknown[]) => unknown>(),
+  readClaudePermissionModeFromTerminalScreen: vi.fn<(...args: unknown[]) => string | null>(
+    () => null
+  ),
+  // Records the interleaving of drain vs. write calls so the safety property
+  // (drain happens before the opening keystroke) is pinned, not just each call.
+  callOrder: [] as string[]
+}))
+
+vi.mock('@/lib/native-chat-telemetry', () => ({
+  emitNativeChatMessageSent: (...args: unknown[]) => mocks.emitNativeChatMessageSent(...args)
+}))
+
+vi.mock('@/runtime/runtime-terminal-inspection', () => ({
+  sendRuntimePtyInput: (...args: [unknown, unknown, string]) => {
+    mocks.callOrder.push(`send:${args[2]}`)
+    return mocks.sendRuntimePtyInput(...args)
+  }
+}))
+
+vi.mock('./native-chat-composer-target', () => ({
+  nativeChatComposerTargetIsRemote: (...args: unknown[]) =>
+    mocks.nativeChatComposerTargetIsRemote(...args)
+}))
+
+vi.mock('./native-chat-composer-state', () => ({
+  pushHistory: (...args: unknown[]) => mocks.pushHistory(...args)
+}))
+
+vi.mock('./native-chat-runtime-send', () => ({
+  sendNativeChatMessageVerified: (...args: unknown[]) =>
+    mocks.sendNativeChatMessageVerified(...args),
+  typeNativeChatCommand: (...args: unknown[]) => mocks.sendNativeChatMessageVerified(...args)
+}))
+
+vi.mock('./native-chat-pty-send-queue', () => ({
+  cancelNativeChatPtySends: (...args: [string]) => {
+    mocks.callOrder.push('cancel')
+    return mocks.cancelNativeChatPtySends(...args)
+  },
+  waitForNativeChatPtyIdle: (...args: [string]) => {
+    mocks.callOrder.push('idle')
+    return mocks.waitForNativeChatPtyIdle(...args)
+  }
+}))
+
+vi.mock('./claude-model-switch-confirmation', () => ({
+  createClaudeModelSwitchConfirmationObserver: (...args: unknown[]) =>
+    mocks.createClaudeModelSwitchConfirmationObserver(...args)
+}))
+
+vi.mock('./claude-permission-mode-cycle', () => ({
+  cycleClaudePermissionMode: (args: Parameters<typeof mocks.cycleClaudePermissionMode>[0]) =>
+    mocks.cycleClaudePermissionMode(args)
+}))
+
+vi.mock('./native-chat-live-screen', () => ({
+  readNativeChatLiveScreen: (...args: unknown[]) => mocks.readNativeChatLiveScreen(...args)
+}))
+
+vi.mock('./claude-terminal-session-options', () => ({
+  readClaudeSessionOptionsFromTerminalScreen: (...args: unknown[]) =>
+    mocks.readClaudeSessionOptionsFromTerminalScreen(...args),
+  readClaudePermissionModeFromTerminalScreen: (...args: unknown[]) =>
+    mocks.readClaudePermissionModeFromTerminalScreen(...args)
+}))
+
+import { useNativeChatSessionOptionCommand } from './use-native-chat-session-option-command'
+import type { NativeChatResolvedTarget } from './native-chat-composer-target'
+import type { ClaudePermissionModeCycleResult } from './claude-permission-mode-cycle'
+
+const TARGET: NativeChatResolvedTarget = {
+  ptyId: 'pty-1',
+  settings: { terminalTabId: 'tab-1' } as never
+}
+
+describe('useNativeChatSessionOptionCommand — dispatchModeCycle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.callOrder.length = 0
+    mocks.sendRuntimePtyInput.mockReturnValue(true)
+    mocks.readNativeChatLiveScreen.mockResolvedValue(null)
+    mocks.cycleClaudePermissionMode.mockResolvedValue({
+      outcome: 'applied',
+      reason: 'reached',
+      presses: 0,
+      observed: []
+    })
+  })
+
+  it('drains the pty send queue before writing the opening keystroke', async () => {
+    mocks.cycleClaudePermissionMode.mockImplementation(
+      async (args: { key: string; sendKey: (key: string) => boolean }) => {
+        // Simulate one press so the write-ordering guarantee is observable.
+        return {
+          outcome: args.sendKey(args.key) ? 'applied' : 'unknown',
+          reason: 'reached',
+          presses: 1,
+          observed: []
+        }
+      }
+    )
+    const { result } = renderHook(() =>
+      useNativeChatSessionOptionCommand({
+        agent: 'claude',
+        disabled: false,
+        resolveTarget: () => TARGET,
+        setHistory: vi.fn()
+      })
+    )
+
+    await act(async () => {
+      await result.current.dispatchModeCycle({ key: '\x1b[Z', target: 'plan' })
+    })
+
+    // The drain must be fully ordered before the ESC[Z write — a delayed chat
+    // Enter landing mid-cycle would silently pick a mode for the user.
+    expect(mocks.callOrder).toEqual(['cancel', 'idle', 'send:\x1b[Z'])
+    expect(mocks.cancelNativeChatPtySends).toHaveBeenCalledWith('pty-1')
+    expect(mocks.waitForNativeChatPtyIdle).toHaveBeenCalledWith('pty-1')
+  })
+
+  it('invokes the cycler with the key and target, and returns its outcome', async () => {
+    mocks.cycleClaudePermissionMode.mockResolvedValue({
+      outcome: 'unavailable',
+      reason: 'reached',
+      presses: 0,
+      observed: []
+    })
+    const { result } = renderHook(() =>
+      useNativeChatSessionOptionCommand({
+        agent: 'claude',
+        disabled: false,
+        resolveTarget: () => TARGET,
+        setHistory: vi.fn()
+      })
+    )
+
+    let outcome: ClaudePermissionModeCycleResult | undefined
+    await act(async () => {
+      outcome = await result.current.dispatchModeCycle({
+        key: '\x1b[Z',
+        target: 'bypassPermissions'
+      })
+    })
+
+    expect(mocks.cycleClaudePermissionMode).toHaveBeenCalledWith(
+      expect.objectContaining({ target: 'bypassPermissions', key: '\x1b[Z' })
+    )
+    expect(outcome?.outcome).toBe('unavailable')
+  })
+
+  it('reads the current mode through the shared live-screen reader', async () => {
+    // The reader owns the fallback, so it drives the injected parser rather than
+    // handing a screen back for the caller to parse.
+    mocks.readNativeChatLiveScreen.mockImplementation(async (...args: unknown[]) =>
+      (args[0] as { parse: (screen: string) => string | null }).parse('some-screen')
+    )
+    mocks.readClaudePermissionModeFromTerminalScreen.mockReturnValue('plan')
+    mocks.cycleClaudePermissionMode.mockImplementation(
+      async (args: { readMode: () => Promise<string | null> }) => {
+        const mode = await args.readMode()
+        return {
+          outcome: mode === 'plan' ? 'applied' : 'unknown',
+          reason: 'reached',
+          presses: 0,
+          observed: []
+        }
+      }
+    )
+    const { result } = renderHook(() =>
+      useNativeChatSessionOptionCommand({
+        agent: 'claude',
+        disabled: false,
+        resolveTarget: () => TARGET,
+        setHistory: vi.fn(),
+        readTerminalScreen: () => 'fallback-screen'
+      })
+    )
+
+    let outcome: ClaudePermissionModeCycleResult | undefined
+    await act(async () => {
+      outcome = await result.current.dispatchModeCycle({ key: '\x1b[Z', target: 'plan' })
+    })
+
+    expect(mocks.readNativeChatLiveScreen).toHaveBeenCalledWith(
+      expect.objectContaining({ ptyId: 'pty-1' })
+    )
+    // Reads the status line directly — Claude's banner scrolls away, so the
+    // banner-gated scrape cannot be the cycler's source of truth.
+    expect(mocks.readClaudePermissionModeFromTerminalScreen).toHaveBeenCalledWith('some-screen')
+    expect(outcome?.outcome).toBe('applied')
+  })
+
+  it('returns unknown when no live target is available, without throwing', async () => {
+    const { result } = renderHook(() =>
+      useNativeChatSessionOptionCommand({
+        agent: 'claude',
+        disabled: false,
+        resolveTarget: () => null,
+        setHistory: vi.fn()
+      })
+    )
+
+    let outcome: ClaudePermissionModeCycleResult | undefined
+    await act(async () => {
+      outcome = await result.current.dispatchModeCycle({ key: '\x1b[Z', target: 'plan' })
+    })
+
+    expect(outcome?.outcome).toBe('unknown')
+    expect(mocks.cycleClaudePermissionMode).not.toHaveBeenCalled()
+    expect(mocks.cancelNativeChatPtySends).not.toHaveBeenCalled()
+  })
+
+  it('marks the cycle cancelled once the composer unmounts before it settles', async () => {
+    let capturedIsCancelled: (() => boolean) | undefined
+    let resolveCycle: ((outcome: ClaudePermissionModeCycleResult) => void) | undefined
+    mocks.cycleClaudePermissionMode.mockImplementation((args: { isCancelled?: () => boolean }) => {
+      capturedIsCancelled = args.isCancelled
+      return new Promise((resolve) => {
+        resolveCycle = resolve
+      })
+    })
+    const { result, unmount } = renderHook(() =>
+      useNativeChatSessionOptionCommand({
+        agent: 'claude',
+        disabled: false,
+        resolveTarget: () => TARGET,
+        setHistory: vi.fn()
+      })
+    )
+
+    let pending: Promise<ClaudePermissionModeCycleResult> | undefined
+    await act(async () => {
+      pending = result.current.dispatchModeCycle({ key: '\x1b[Z', target: 'plan' })
+      await vi.waitFor(() => expect(capturedIsCancelled).toBeDefined())
+    })
+
+    expect(capturedIsCancelled?.()).toBe(false)
+    unmount()
+    expect(capturedIsCancelled?.()).toBe(true)
+
+    resolveCycle?.({ outcome: 'unknown', reason: 'cancelled', presses: 0, observed: [] })
+    await pending
+  })
+})

--- a/src/renderer/src/components/native-chat/use-native-chat-session-option-command.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-session-option-command.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react'
 import type { AgentType } from '../../../../shared/agent-status-types'
 import { emitNativeChatMessageSent } from '@/lib/native-chat-telemetry'
+import { sendRuntimePtyInput } from '@/runtime/runtime-terminal-inspection'
 import {
   nativeChatComposerTargetIsRemote,
   type NativeChatResolvedTarget
@@ -12,7 +13,15 @@ import {
   createClaudeModelSwitchConfirmationObserver,
   type ClaudeModelSwitchConfirmationObserver
 } from './claude-model-switch-confirmation'
-import type { NativeChatSessionOptionDispatchCommand } from './native-chat-session-option-command-dispatch'
+import { cycleClaudePermissionMode } from './claude-permission-mode-cycle'
+import { readNativeChatLiveScreen } from './native-chat-live-screen'
+import { readClaudePermissionModeFromTerminalScreen } from './claude-terminal-session-options'
+import type {
+  NativeChatModeCycleDispatch,
+  NativeChatSessionOptionDispatchCommand
+} from './native-chat-session-option-command-dispatch'
+
+type ActiveObserver = { dispose: () => void }
 
 export function useNativeChatSessionOptionCommand(args: {
   agent: AgentType
@@ -20,10 +29,15 @@ export function useNativeChatSessionOptionCommand(args: {
   onSlashCommand?: (command: string) => void
   resolveTarget: () => NativeChatResolvedTarget | null
   setHistory: Dispatch<SetStateAction<HistoryState>>
-}): { dispatch: NativeChatSessionOptionDispatchCommand; isDispatching: boolean } {
-  const { agent, disabled, onSlashCommand, resolveTarget, setHistory } = args
+  readTerminalScreen?: () => string | null
+}): {
+  dispatch: NativeChatSessionOptionDispatchCommand
+  dispatchModeCycle: NativeChatModeCycleDispatch
+  isDispatching: boolean
+} {
+  const { agent, disabled, onSlashCommand, resolveTarget, setHistory, readTerminalScreen } = args
   const mountedRef = useRef(true)
-  const activeObserversRef = useRef(new Set<ClaudeModelSwitchConfirmationObserver>())
+  const activeObserversRef = useRef(new Set<ActiveObserver>())
   const activeSendsRef = useRef(new Set<AbortController>())
   // Why: expose an in-flight flag so the composer can block a normal send while
   // an option command's body+delayed-Enter (and its confirmation observer) is
@@ -127,5 +141,45 @@ export function useNativeChatSessionOptionCommand(args: {
     [agent, disabled, onSlashCommand, resolveTarget, setHistory]
   )
 
-  return { dispatch, isDispatching }
+  const dispatchModeCycle = useCallback<NativeChatModeCycleDispatch>(
+    async ({ key, target: targetMode }) => {
+      const target = resolveTarget()
+      if (!target || disabled) {
+        return { outcome: 'unknown', reason: 'unreadable', presses: 0, observed: [] }
+      }
+      const sendController = new AbortController()
+      activeSendsRef.current.add(sendController)
+      setIsDispatching(true)
+      try {
+        // Why: chat sends keep a delayed Enter for 500ms — drain it first so it
+        // cannot land mid-cycle and silently pick a mode the user never chose.
+        cancelNativeChatPtySends(target.ptyId)
+        await waitForNativeChatPtyIdle(target.ptyId)
+        if (!mountedRef.current || sendController.signal.aborted) {
+          return { outcome: 'unknown', reason: 'cancelled', presses: 0, observed: [] }
+        }
+        return await cycleClaudePermissionMode({
+          target: targetMode,
+          key,
+          // Why: read the status line directly. The banner-gated scrape returns
+          // nothing once Claude's header scrolls away, which would stall the
+          // cycler on an unreadable mode and refuse to press at all.
+          readMode: () =>
+            readNativeChatLiveScreen({
+              ptyId: target.ptyId,
+              readTerminalScreen,
+              parse: readClaudePermissionModeFromTerminalScreen
+            }),
+          sendKey: (nextKey) => sendRuntimePtyInput(target.settings, target.ptyId, nextKey),
+          isCancelled: () => !mountedRef.current || sendController.signal.aborted
+        })
+      } finally {
+        activeSendsRef.current.delete(sendController)
+        setIsDispatching(activeSendsRef.current.size > 0)
+      }
+    },
+    [disabled, readTerminalScreen, resolveTarget]
+  )
+
+  return { dispatch, dispatchModeCycle, isDispatching }
 }

--- a/src/renderer/src/components/native-chat/use-native-chat-session-options.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-session-options.ts
@@ -17,7 +17,10 @@ import {
   createNativeChatPtySessionOptions,
   type NativeChatPtySessionOptionsSurface
 } from './native-chat-pty-session-options'
-import type { NativeChatSessionOptionDispatchCommand } from './native-chat-session-option-command-dispatch'
+import type {
+  NativeChatModeCycleDispatch,
+  NativeChatSessionOptionDispatchCommand
+} from './native-chat-session-option-command-dispatch'
 import {
   ensureNativeChatModelEnrichment,
   readNativeChatEnrichedModels,
@@ -27,7 +30,12 @@ import {
   discoverNativeChatCatalogModels,
   resolveNativeChatModelDiscoveryContext
 } from './native-chat-session-option-discovery'
-import { readClaudeSessionOptionsFromTerminalScreen } from './claude-terminal-session-options'
+import {
+  readClaudePermissionModeFromTerminalScreen,
+  readClaudeSessionOptionsFromTerminalScreen
+} from './claude-terminal-session-options'
+import { collectNativeChatLiveScreens } from './native-chat-live-screen'
+import { resolveNativeChatLiveSessionLaunchArgs } from './native-chat-live-session-launch-args'
 
 const EMPTY_SNAPSHOT: SessionOptionDescriptor[] = []
 const subscribeEmpty = (): (() => void) => () => {}
@@ -86,16 +94,26 @@ export async function retirePersistedModelMissingFromDiscovery(
 export function useNativeChatSessionOptions(args: {
   agent: AgentType
   terminalTabId: string
+  paneKey?: string
   targetPtyId: string | null
   dispatchCommand: NativeChatSessionOptionDispatchCommand
+  dispatchModeCycle?: NativeChatModeCycleDispatch
   onAgentPicker?: () => void
   readTerminalScreen?: () => string | null
 }): {
   surface: NativeChatPtySessionOptionsSurface | null
   snapshot: SessionOptionDescriptor[]
 } {
-  const { agent, terminalTabId, targetPtyId, dispatchCommand, onAgentPicker, readTerminalScreen } =
-    args
+  const {
+    agent,
+    terminalTabId,
+    paneKey,
+    targetPtyId,
+    dispatchCommand,
+    dispatchModeCycle,
+    onAgentPicker,
+    readTerminalScreen
+  } = args
   // The screen text that last parsed into reported values, so a later model
   // discovery can re-resolve it against the host's real ids.
   const reportedScreenRef = useRef<string | null>(null)
@@ -113,6 +131,7 @@ export function useNativeChatSessionOptions(args: {
     const discoveredModels = discoveryContext
       ? readNativeChatEnrichedModels(agent, discoveryContext.hostKey)
       : null
+    const { agentArgs, agentEnv } = resolveNativeChatLiveSessionLaunchArgs(paneKey)
     const reportedValues =
       agent === 'claude'
         ? readClaudeSessionOptionsFromTerminalScreen(
@@ -130,7 +149,10 @@ export function useNativeChatSessionOptions(args: {
       ...(discoveryContext ? { initialModels: discoveredModels ?? undefined } : {}),
       mode: targetPtyId ? 'live' : 'draft',
       reportedValues,
+      agentArgs,
+      agentEnv,
       dispatchCommand,
+      dispatchModeCycle,
       onAgentPicker,
       persistSelection: ({ modelId, optionId, value, adoptModelAsLaunchDefault }) =>
         enqueueSessionOptionSettingsWrite((persisted) =>
@@ -147,8 +169,10 @@ export function useNativeChatSessionOptions(args: {
   }, [
     agent,
     dispatchCommand,
+    dispatchModeCycle,
     discoveryContext,
     onAgentPicker,
+    paneKey,
     readTerminalScreen,
     targetPtyId,
     terminalTabId
@@ -161,23 +185,18 @@ export function useNativeChatSessionOptions(args: {
     let cancelled = false
     reportedScreenRef.current = null
     const reportCurrentValues = async (): Promise<void> => {
-      let authoritativeScreen: string | null = null
-      if (targetPtyId && window.api?.pty?.getMainBufferSnapshot) {
-        try {
-          const snapshot = await window.api.pty.getMainBufferSnapshot(targetPtyId, {
-            scrollbackRows: 0
-          })
-          // Why: the API snapshots the main buffer, which is stale while a TUI
-          // owns the alternate screen. The mounted xterm is authoritative then.
-          authoritativeScreen = snapshot?.alternateScreen ? null : (snapshot?.data ?? null)
-        } catch {
-          // The mounted renderer buffer remains a transport-neutral fallback.
-        }
-      }
+      const screens = await collectNativeChatLiveScreens({ ptyId: targetPtyId, readTerminalScreen })
       const models = discoveryContext
         ? readNativeChatEnrichedModels(agent, discoveryContext.hostKey)
         : null
-      for (const screen of [authoritativeScreen, readTerminalScreen?.() ?? null]) {
+      // Why: the model read needs Claude's banner, which scrolls away after the
+      // first screenful. The status line does not, so read the mode separately
+      // or it goes unknown for the rest of the session.
+      const permissionMode = screens.reduce<string | null>(
+        (found, screen) => found ?? readClaudePermissionModeFromTerminalScreen(screen),
+        null
+      )
+      for (const screen of screens) {
         const reportedValues = readClaudeSessionOptionsFromTerminalScreen(
           screen,
           models ?? undefined
@@ -192,8 +211,14 @@ export function useNativeChatSessionOptions(args: {
           return
         }
         reportedScreenRef.current = screen
-        surface.reportSessionOptions(reportedValues)
+        surface.reportSessionOptions({
+          ...reportedValues,
+          ...(permissionMode ? { permissionMode } : {})
+        })
         return
+      }
+      if (!cancelled && permissionMode) {
+        surface.reportSessionOptions({ permissionMode })
       }
     }
     void reportCurrentValues()

--- a/src/renderer/src/components/native-chat/use-native-chat-session-options.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-session-options.ts
@@ -31,6 +31,7 @@ import {
   resolveNativeChatModelDiscoveryContext
 } from './native-chat-session-option-discovery'
 import {
+  readClaudeFastModeFromTerminalScreen,
   readClaudePermissionModeFromTerminalScreen,
   readClaudeSessionOptionsFromTerminalScreen
 } from './claude-terminal-session-options'
@@ -196,6 +197,12 @@ export function useNativeChatSessionOptions(args: {
         (found, screen) => found ?? readClaudePermissionModeFromTerminalScreen(screen),
         null
       )
+      // Same reason as the mode: the glyph rides the status line, which outlives
+      // the banner the model read depends on.
+      const fastMode = screens.reduce<true | null>(
+        (found, screen) => found ?? readClaudeFastModeFromTerminalScreen(screen),
+        null
+      )
       for (const screen of screens) {
         const reportedValues = readClaudeSessionOptionsFromTerminalScreen(
           screen,
@@ -213,12 +220,16 @@ export function useNativeChatSessionOptions(args: {
         reportedScreenRef.current = screen
         surface.reportSessionOptions({
           ...reportedValues,
-          ...(permissionMode ? { permissionMode } : {})
+          ...(permissionMode ? { permissionMode } : {}),
+          ...(fastMode ? { fastMode } : {})
         })
         return
       }
-      if (!cancelled && permissionMode) {
-        surface.reportSessionOptions({ permissionMode })
+      if (!cancelled && (permissionMode || fastMode)) {
+        surface.reportSessionOptions({
+          ...(permissionMode ? { permissionMode } : {}),
+          ...(fastMode ? { fastMode } : {})
+        })
       }
     }
     void reportCurrentValues()

--- a/src/renderer/src/components/settings/AgentsPane.tsx
+++ b/src/renderer/src/components/settings/AgentsPane.tsx
@@ -211,7 +211,7 @@ export function AgentPermissionsSetting({
 }: AgentPermissionsSettingProps): React.JSX.Element {
   const visibleMode: Exclude<AgentPermissionMode, 'mixed'> = mode === 'manual' ? 'manual' : 'yolo'
   return (
-    <section className="space-y-3">
+    <section className="space-y-3" data-settings-section="agent-permissions">
       <SettingsSubsectionHeader
         title={
           <span className="flex items-center gap-2">

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -15285,8 +15285,15 @@
           "max": "Max",
           "ultra": "Ultra",
           "on": "On",
-          "off": "Off"
-        }
+          "off": "Off",
+          "manual": "Manual",
+          "acceptEdits": "Accept edits",
+          "plan": "Plan",
+          "auto": "Auto",
+          "bypassPermissions": "Bypass permissions"
+        },
+        "enableChoice": "Enable",
+        "permissionMode": "Mode"
       },
       "tool": {
         "running": "Running…",

--- a/src/shared/agent-session-option-catalog-claude-codex.ts
+++ b/src/shared/agent-session-option-catalog-claude-codex.ts
@@ -126,6 +126,36 @@ const CLAUDE_FAST_MODE: CatalogOption = {
   apply: { midSession: { kind: 'toggle-command', command: '/fast' } }
 }
 
+const CLAUDE_PERMISSION_MODE: CatalogOption = {
+  id: 'permissionMode',
+  label: 'Mode',
+  category: 'mode',
+  kind: {
+    type: 'select',
+    choices: [
+      { value: 'manual', label: 'Manual' },
+      { value: 'acceptEdits', label: 'Accept edits' },
+      { value: 'plan', label: 'Plan' },
+      { value: 'auto', label: 'Auto' },
+      { value: 'bypassPermissions', label: 'Bypass permissions' }
+    ],
+    defaultValue: 'manual'
+  },
+  apply: {
+    // Why: Claude refuses bypassPermissions unless the process launched with
+    // --dangerously-skip-permissions, so that choice is launch-granted only.
+    launchArgs: (value) =>
+      value === 'bypassPermissions'
+        ? ['--dangerously-skip-permissions']
+        : ['--permission-mode', String(value)],
+    agentArgsOverride: (tokens) =>
+      hasFlag(tokens, ['--permission-mode', '--dangerously-skip-permissions']),
+    // Shift+Tab cycles Claude's mode one step per press; there is no slash
+    // command for mode and no menu — press-and-observe until the target shows.
+    midSession: { kind: 'cycle-key', key: '\x1b[Z', detect: 'claude-permission-mode' }
+  }
+}
+
 export const CLAUDE_SESSION_OPTION_CATALOG: AgentSessionOptionCatalog = {
   supportsWorkerLaunchPreferences: true,
   // Why: these ids are Claude CLI aliases that resolve to the newest model of
@@ -160,6 +190,7 @@ export const CLAUDE_SESSION_OPTION_CATALOG: AgentSessionOptionCatalog = {
       options: []
     }
   ],
+  sessionOptions: [CLAUDE_PERMISSION_MODE],
   modelApply: {
     launchArgs: (value) => ['--model', String(value)],
     agentArgsOverride: (tokens) => hasFlag(tokens, ['--model']),

--- a/src/shared/agent-session-option-catalog-claude-codex.ts
+++ b/src/shared/agent-session-option-catalog-claude-codex.ts
@@ -118,12 +118,24 @@ function parseClaudeCatalogModels(stdout: string): CatalogModel[] {
   })
 }
 
+// Why `/fast on|off` rather than a bare `/fast`: the bare form opens a
+// confirmation panel (Tab to toggle · Enter to confirm) that a dispatch leaves
+// hanging and unapplied. The argument form sets the value outright, which also
+// makes this an absolute setter instead of a flip needing a known baseline.
 const CLAUDE_FAST_MODE: CatalogOption = {
   id: 'fastMode',
   label: 'Fast mode',
   category: 'mode',
   kind: { type: 'boolean', defaultValue: false },
-  apply: { midSession: { kind: 'toggle-command', command: '/fast' } }
+  apply: {
+    midSession: {
+      kind: 'command',
+      build: (value) => `/fast ${value ? 'on' : 'off'}`,
+      // A bare `/fast` typed in the terminal opens the panel, and its outcome is
+      // not observable from here — so it invalidates whatever we had tracked.
+      pickerCommand: '/fast'
+    }
+  }
 }
 
 const CLAUDE_PERMISSION_MODE: CatalogOption = {

--- a/src/shared/agent-session-option-catalog-types.ts
+++ b/src/shared/agent-session-option-catalog-types.ts
@@ -8,6 +8,8 @@ import type {
 export type CatalogAgentInteractionDetection = 'claude-model-switch-confirmation'
 export type CatalogCommandDelivery = 'type'
 
+export type CatalogCycleKeyDetection = 'claude-permission-mode'
+
 export type CatalogMidSessionApply =
   | {
       kind: 'command'
@@ -17,6 +19,9 @@ export type CatalogMidSessionApply =
     }
   | { kind: 'toggle-command'; command: string }
   | { kind: 'agent-picker'; command: string; delivery?: CatalogCommandDelivery }
+  /** Presses a key that cycles a session-scoped value by one step; the caller
+   *  reads the resulting state and presses again until the target appears. */
+  | { kind: 'cycle-key'; key: string; detect: CatalogCycleKeyDetection }
   | { kind: 'unsupported' }
 
 export type CatalogOptionApply = {
@@ -60,6 +65,8 @@ export type AgentSessionOptionCatalog = {
   supportsWorkerLaunchPreferences?: true
   /** Launch-safe options for opaque model ids that are absent from the static catalog. */
   unknownModelOptions?: CatalogOption[]
+  /** Session-scoped options, independent of the selected model. */
+  sessionOptions?: CatalogOption[]
   composeModelValue?: (modelId: string, values: Record<string, SessionOptionValue>) => string
   /** Why: a seeded id the CLI has retired is a fatal launch, so a successful probe
    * must be able to drop it rather than only add. Membership only — option menus

--- a/src/shared/agent-session-option-catalog-types.ts
+++ b/src/shared/agent-session-option-catalog-types.ts
@@ -17,7 +17,6 @@ export type CatalogMidSessionApply =
       pickerCommand?: string
       detectAgentInteraction?: CatalogAgentInteractionDetection
     }
-  | { kind: 'toggle-command'; command: string }
   | { kind: 'agent-picker'; command: string; delivery?: CatalogCommandDelivery }
   /** Presses a key that cycles a session-scoped value by one step; the caller
    *  reads the resulting state and presses again until the target appears. */

--- a/src/shared/agent-session-option-catalog.test.ts
+++ b/src/shared/agent-session-option-catalog.test.ts
@@ -278,3 +278,29 @@ describe('claude permission mode', () => {
     })
   })
 })
+
+describe('claude fast mode', () => {
+  const fastMode = () =>
+    getAgentSessionOptionCatalog('claude')
+      ?.models.find((model) => model.id === 'opus')
+      ?.options.find((option) => option.id === 'fastMode')
+
+  // Why: a bare `/fast` opens a confirmation panel (Tab to toggle · Enter to
+  // confirm) that a dispatch leaves hanging and unapplied. The argument form
+  // sets the value outright.
+  it('sets the value outright rather than opening the confirmation panel', () => {
+    const midSession = fastMode()?.apply.midSession
+    expect(midSession?.kind).toBe('command')
+    if (midSession?.kind !== 'command') {
+      throw new Error('fast mode must dispatch a command')
+    }
+    expect(midSession.build(true)).toBe('/fast on')
+    expect(midSession.build(false)).toBe('/fast off')
+    expect(midSession.build(true)).not.toBe('/fast')
+  })
+
+  it('still recognizes a bare /fast as the panel that invalidates tracked state', () => {
+    const midSession = fastMode()?.apply.midSession
+    expect(midSession?.kind === 'command' && midSession.pickerCommand).toBe('/fast')
+  })
+})

--- a/src/shared/agent-session-option-catalog.test.ts
+++ b/src/shared/agent-session-option-catalog.test.ts
@@ -234,3 +234,47 @@ describe('agent session option catalog', () => {
     })
   })
 })
+
+describe('session-scoped options', () => {
+  it('exposes Claude permission mode as a session option, not a model option', () => {
+    const catalog = getAgentSessionOptionCatalog('claude')
+    const mode = catalog?.sessionOptions?.find((option) => option.id === 'permissionMode')
+    expect(mode?.kind.type).toBe('select')
+    expect(
+      catalog?.models.some((model) => model.options.some((o) => o.id === 'permissionMode'))
+    ).toBe(false)
+  })
+})
+
+describe('claude permission mode', () => {
+  const modeOption = () =>
+    getAgentSessionOptionCatalog('claude')?.sessionOptions?.find((o) => o.id === 'permissionMode')
+
+  it('maps every choice except bypass to --permission-mode', () => {
+    expect(modeOption()?.apply.launchArgs?.('plan')).toEqual(['--permission-mode', 'plan'])
+    expect(modeOption()?.apply.launchArgs?.('acceptEdits')).toEqual([
+      '--permission-mode',
+      'acceptEdits'
+    ])
+  })
+
+  it('maps bypass to the dangerous-skip flag Orca already uses for yolo', () => {
+    expect(modeOption()?.apply.launchArgs?.('bypassPermissions')).toEqual([
+      '--dangerously-skip-permissions'
+    ])
+  })
+
+  it('yields to user-supplied permission args', () => {
+    expect(modeOption()?.apply.agentArgsOverride?.(['--permission-mode', 'plan'])).toBe(true)
+    expect(modeOption()?.apply.agentArgsOverride?.(['--dangerously-skip-permissions'])).toBe(true)
+    expect(modeOption()?.apply.agentArgsOverride?.(['--model', 'opus'])).toBe(false)
+  })
+
+  it('drives the shift+tab cycle mid-session', () => {
+    expect(modeOption()?.apply.midSession).toEqual({
+      kind: 'cycle-key',
+      key: '\x1b[Z',
+      detect: 'claude-permission-mode'
+    })
+  })
+})

--- a/src/shared/agent-session-option-catalog.ts
+++ b/src/shared/agent-session-option-catalog.ts
@@ -21,6 +21,7 @@ export type {
   AgentSessionOptionCatalog,
   CatalogAgentInteractionDetection,
   CatalogCommandDelivery,
+  CatalogCycleKeyDetection,
   CatalogMidSessionApply,
   CatalogModel,
   CatalogOption,

--- a/src/shared/native-chat-session-option-commands.test.ts
+++ b/src/shared/native-chat-session-option-commands.test.ts
@@ -51,7 +51,7 @@ describe('buildNativeChatSessionOptionCommand', () => {
     ).toBe('/effort high')
   })
 
-  it('returns the bare toggle command for flip-only options', () => {
+  it('sets fast mode outright, since a bare /fast opens a confirmation panel', () => {
     const fastModeApply = CLAUDE_SESSION_OPTION_CATALOG.models
       .find((model) => model.id === 'opus')!
       .options.find((option) => option.id === 'fastMode')!.apply
@@ -65,7 +65,24 @@ describe('buildNativeChatSessionOptionCommand', () => {
         models: CLAUDE_SESSION_OPTION_CATALOG.models,
         record: claudeRecord('opus')
       })
-    ).toBe('/fast')
+    ).toBe('/fast on')
+  })
+
+  it('turns fast mode off with the same absolute form', () => {
+    const fastModeApply = CLAUDE_SESSION_OPTION_CATALOG.models
+      .find((model) => model.id === 'opus')!
+      .options.find((option) => option.id === 'fastMode')!.apply
+    expect(
+      buildNativeChatSessionOptionCommand({
+        optionId: 'fastMode',
+        value: false,
+        apply: fastModeApply,
+        modelId: 'opus',
+        catalog: CLAUDE_SESSION_OPTION_CATALOG,
+        models: CLAUDE_SESSION_OPTION_CATALOG.models,
+        record: claudeRecord('opus')
+      })
+    ).toBe('/fast off')
   })
 
   it('does not turn a Codex model pick into pasted slash-command prose', () => {

--- a/src/shared/native-chat-session-option-commands.ts
+++ b/src/shared/native-chat-session-option-commands.ts
@@ -9,7 +9,6 @@ import {
   clearNativeChatSessionModel,
   clearTrackedSessionOption,
   flattenNativeChatSessionOptionRecord,
-  isFlipOnlyMidSession,
   matchNativeChatCatalogModelId,
   type NativeChatSessionOptionRecord
 } from './native-chat-session-option-state'
@@ -57,9 +56,6 @@ export function buildNativeChatSessionOptionCommand(args: {
   if (midSession?.kind === 'command') {
     return midSession.build(args.value)
   }
-  if (midSession?.kind === 'toggle-command') {
-    return midSession.command
-  }
   if (!args.apply.composedIntoModel || !args.modelId || !args.catalog.composeModelValue) {
     return null
   }
@@ -101,12 +97,14 @@ function recordCommandApply(args: {
   if (!midSession || midSession.kind === 'unsupported') {
     return false
   }
-  if (isFlipOnlyMidSession(midSession) && command === midSession.command) {
-    clearTrackedSessionOption(record, effectiveModelId, optionId)
-    return true
-  }
   if (isSessionOptionAgentPickerCommand(midSession, command)) {
-    clearNativeChatSessionModel(record)
+    // Why per-option: a picker only invalidates what it edits. Clearing the
+    // model for, say, a typed bare `/fast` would blank every model-scoped row.
+    if (optionId === 'model') {
+      clearNativeChatSessionModel(record)
+    } else {
+      clearTrackedSessionOption(record, effectiveModelId, optionId)
+    }
     return true
   }
   if (midSession.kind !== 'command') {

--- a/src/shared/native-chat-session-option-record.test.ts
+++ b/src/shared/native-chat-session-option-record.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import {
+  cloneNativeChatSessionOptionRecord,
+  createNativeChatSessionOptionRecord,
+  type NativeChatSessionOptionRecord
+} from './native-chat-session-option-state'
+
+describe('native chat session option cache', () => {
+  it('starts with an empty session-scoped bucket', () => {
+    expect(createNativeChatSessionOptionRecord('claude').sessionValues).toEqual({})
+  })
+
+  it('deep-clones session values so a clone never aliases the source', () => {
+    const record = createNativeChatSessionOptionRecord('claude')
+    record.sessionValues.permissionMode = { value: 'plan', source: 'reported' }
+    const clone = cloneNativeChatSessionOptionRecord(record)
+    clone.sessionValues.permissionMode.value = 'manual'
+    expect(record.sessionValues.permissionMode.value).toBe('plan')
+  })
+
+  it('clones a record cached before sessionValues existed', () => {
+    const legacy = {
+      agent: 'claude',
+      valuesByModel: {}
+    } as unknown as NativeChatSessionOptionRecord
+    expect(cloneNativeChatSessionOptionRecord(legacy).sessionValues).toEqual({})
+  })
+})

--- a/src/shared/native-chat-session-option-reporting.test.ts
+++ b/src/shared/native-chat-session-option-reporting.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applyNativeChatReportedSessionOptions,
+  createNativeChatSessionOptionRecord
+} from './native-chat-session-option-state'
+
+describe('reported session-scoped options', () => {
+  it('files a session option into sessionValues, not the model bucket', () => {
+    const record = createNativeChatSessionOptionRecord('claude')
+    applyNativeChatReportedSessionOptions(record, { model: 'sonnet', permissionMode: 'plan' })
+    expect(record.sessionValues.permissionMode).toEqual({ value: 'plan', source: 'reported' })
+    expect(record.valuesByModel.sonnet?.permissionMode).toBeUndefined()
+  })
+
+  it('keeps the session option across a model switch', () => {
+    const record = createNativeChatSessionOptionRecord('claude')
+    applyNativeChatReportedSessionOptions(record, { model: 'sonnet', permissionMode: 'plan' })
+    applyNativeChatReportedSessionOptions(record, { model: 'opus', permissionMode: 'plan' })
+    expect(record.sessionValues.permissionMode.value).toBe('plan')
+  })
+
+  it('still records a session option when the model is unreadable', () => {
+    const record = createNativeChatSessionOptionRecord('claude')
+    expect(applyNativeChatReportedSessionOptions(record, { permissionMode: 'auto' })).toBe(true)
+    expect(record.sessionValues.permissionMode.value).toBe('auto')
+  })
+
+  it('leaves model-scoped options in the model bucket', () => {
+    const record = createNativeChatSessionOptionRecord('claude')
+    applyNativeChatReportedSessionOptions(record, { model: 'sonnet', effort: 'high' })
+    expect(record.valuesByModel.sonnet.effort).toEqual({ value: 'high', source: 'reported' })
+    expect(record.sessionValues.effort).toBeUndefined()
+  })
+})

--- a/src/shared/native-chat-session-option-snapshot.test.ts
+++ b/src/shared/native-chat-session-option-snapshot.test.ts
@@ -230,9 +230,11 @@ describe('buildNativeChatSessionOptionSnapshot', () => {
     })
   })
 
-  it('marks flip-only toggles without a baseline as toggle actions', () => {
+  // Fast mode is read from Claude's ↯ glyph and set with `/fast on|off`, so an
+  // unknown baseline needs no Toggle action — there is no blind flip left.
+  it('offers a plain boolean for an untracked toggle, with no toggle action', () => {
     const record = claudeRecord()
-    record.model = { value: 'opus', source: 'reported' }
+    record.model = { value: 'opus', source: 'dispatched' }
     const snapshot = buildNativeChatSessionOptionSnapshot({
       catalog: CLAUDE_SESSION_OPTION_CATALOG,
       models: CLAUDE_SESSION_OPTION_CATALOG.models,
@@ -241,7 +243,8 @@ describe('buildNativeChatSessionOptionSnapshot', () => {
       modelLabel: 'Model'
     })
     const fastMode = snapshot.find((descriptor) => descriptor.id === 'fastMode')
-    expect(fastMode).toMatchObject({ action: { type: 'toggle-command' } })
+    expect(fastMode).toMatchObject({ settable: true, kind: { type: 'boolean' } })
+    expect(fastMode?.action).toBeUndefined()
   })
 })
 

--- a/src/shared/native-chat-session-option-snapshot.test.ts
+++ b/src/shared/native-chat-session-option-snapshot.test.ts
@@ -30,7 +30,8 @@ describe('buildNativeChatSessionOptionSnapshot', () => {
       mode: 'live',
       modelLabel: 'Model'
     })
-    expect(snapshot).toHaveLength(1)
+    // Claude also carries a session-scoped permission-mode descriptor.
+    expect(snapshot).toHaveLength(2)
     const model = snapshot[0]!
     expect(model).toMatchObject({ id: 'model', category: 'model', valueSource: 'unknown' })
     if (model.kind.type !== 'select') {
@@ -52,7 +53,11 @@ describe('buildNativeChatSessionOptionSnapshot', () => {
       mode: 'live',
       modelLabel: 'Model'
     })
-    expect(snapshot.map((descriptor) => descriptor.id)).toEqual(['model', 'effort'])
+    expect(snapshot.map((descriptor) => descriptor.id)).toEqual([
+      'model',
+      'permissionMode',
+      'effort'
+    ])
     expect(snapshot[0]).toMatchObject({ valueSource: 'dispatched' })
   })
 
@@ -319,7 +324,8 @@ describe('defaults on load', () => {
     })
     expect(CLAUDE_SESSION_OPTION_CATALOG.models.some((model) => model.isDefault)).toBe(true)
     expect(CLAUDE_SESSION_OPTION_CATALOG.defaultModelIsCliDefault).toBeUndefined()
-    expect(snapshot).toHaveLength(1)
+    // Claude also carries a session-scoped permission-mode descriptor.
+    expect(snapshot).toHaveLength(2)
     expect(snapshot[0]).toMatchObject({ valueSource: 'unknown' })
   })
 

--- a/src/shared/native-chat-session-option-snapshot.ts
+++ b/src/shared/native-chat-session-option-snapshot.ts
@@ -13,6 +13,26 @@ import {
   type NativeChatSessionOptionRecord,
   type TrackedNativeChatSessionOption
 } from './native-chat-session-option-state'
+import { hasYoloTuiAgentLaunch } from './tui-agent-permissions'
+
+const PERMISSION_MODE_OPTION_ID = 'permissionMode'
+const BYPASS_PERMISSIONS_VALUE = 'bypassPermissions'
+
+// Why: Claude refuses bypassPermissions unless launched with
+// --dangerously-skip-permissions; gate the choice rather than offer a mode it rejects.
+function gatePermissionModeChoices(
+  choices: readonly SessionOptionSelectChoice[],
+  bypassAvailable: boolean
+): SessionOptionSelectChoice[] {
+  if (bypassAvailable) {
+    return [...choices]
+  }
+  return choices.map((choice) =>
+    choice.value === BYPASS_PERMISSIONS_VALUE
+      ? { ...choice, unavailable: { action: 'open-agent-permissions-setting' as const } }
+      : choice
+  )
+}
 
 export type NativeChatSessionOptionMode = 'draft' | 'live'
 
@@ -69,8 +89,11 @@ function optionDescriptor(args: {
   mode: NativeChatSessionOptionMode
   modelIsCliDefault: boolean
   composedModelApply: AgentSessionOptionCatalog['modelApply']
+  permissionModeBypassAvailable?: boolean
 }): SessionOptionDescriptor | null {
   const { option, tracked, mode, modelIsCliDefault, composedModelApply } = args
+  const permissionModeBypassAvailable = args.permissionModeBypassAvailable ?? false
+  const isPermissionMode = option.id === PERMISSION_MODE_OPTION_ID
   const action = actionForApply(option.apply, tracked, mode)
   const settable = settableState({ mode, apply: option.apply, composedModelApply })
   // Why: the launch only emits `values[id] ?? defaultValue` alongside a model flag, so
@@ -79,16 +102,23 @@ function optionDescriptor(args: {
   const showDefault = mode === 'draft' && !tracked && !modelIsCliDefault
   const valueSource = tracked?.source ?? (showDefault ? 'default' : 'unknown')
   if (option.kind.type === 'select') {
-    const choices = choiceWithCurrent(option.kind.choices, tracked)
+    const withCurrent = choiceWithCurrent(option.kind.choices, tracked)
+    const choices = isPermissionMode
+      ? gatePermissionModeChoices(withCurrent, permissionModeBypassAvailable)
+      : withCurrent
     if (choices.length <= 1) {
       return null
     }
+    // Why: Claude starts in bypass under the launch flag, so infer it as the
+    // checkmarked mode until the terminal scrape reports the real one.
+    const inferredBypass =
+      isPermissionMode && !tracked && permissionModeBypassAvailable
+        ? BYPASS_PERMISSIONS_VALUE
+        : undefined
     const currentValue =
       typeof tracked?.value === 'string'
         ? tracked.value
-        : showDefault
-          ? option.kind.defaultValue
-          : undefined
+        : (inferredBypass ?? (showDefault ? option.kind.defaultValue : undefined))
     return {
       id: option.id,
       label: option.label,
@@ -195,6 +225,10 @@ export function buildNativeChatSessionOptionSnapshot(args: {
   record: NativeChatSessionOptionRecord
   mode: NativeChatSessionOptionMode
   modelLabel: string
+  /** The live session's actual launch args (not the settings default for new
+   *  sessions) — used only to gate Claude's bypassPermissions choice. */
+  agentArgs?: string | null
+  agentEnv?: Record<string, string> | null
 }): SessionOptionDescriptor[] {
   const { catalog, models, record, mode, modelLabel } = args
   if (models.length === 0) {
@@ -228,6 +262,29 @@ export function buildNativeChatSessionOptionSnapshot(args: {
       ...(modelAction ? { action: modelAction } : {})
     }
   ]
+  // Before the unknown-model return below: session options outlive model truth.
+  // An observed bypass mode is itself proof of the grant — Claude would not be
+  // in that mode otherwise — so it backstops a launch-args lookup miss.
+  const trackedPermissionMode = record.sessionValues[PERMISSION_MODE_OPTION_ID]?.value
+  const permissionModeBypassAvailable =
+    hasYoloTuiAgentLaunch({
+      agent: 'claude',
+      agentArgs: args.agentArgs,
+      agentEnv: args.agentEnv
+    }) || trackedPermissionMode === BYPASS_PERMISSIONS_VALUE
+  for (const option of catalog.sessionOptions ?? []) {
+    const descriptor = optionDescriptor({
+      option,
+      tracked: record.sessionValues[option.id],
+      mode,
+      modelIsCliDefault: false,
+      composedModelApply: catalog.modelApply,
+      permissionModeBypassAvailable
+    })
+    if (descriptor) {
+      snapshot.push(descriptor)
+    }
+  }
   if (!effectiveModelId) {
     return snapshot
   }

--- a/src/shared/native-chat-session-option-snapshot.ts
+++ b/src/shared/native-chat-session-option-snapshot.ts
@@ -17,8 +17,8 @@ import { hasYoloTuiAgentLaunch } from './tui-agent-permissions'
 const PERMISSION_MODE_OPTION_ID = 'permissionMode'
 const BYPASS_PERMISSIONS_VALUE = 'bypassPermissions'
 
-// Why: Claude refuses bypassPermissions unless launched with
-// --dangerously-skip-permissions; gate the choice rather than offer a mode it rejects.
+/** Marks bypass unselectable when the session wasn't launched with the flag.
+ *  Claude refuses that mode outright, so offering it would only ever fail. */
 function gatePermissionModeChoices(
   choices: readonly SessionOptionSelectChoice[],
   bypassAvailable: boolean

--- a/src/shared/native-chat-session-option-snapshot.ts
+++ b/src/shared/native-chat-session-option-snapshot.ts
@@ -8,10 +8,9 @@ import type {
   SessionOptionDescriptor,
   SessionOptionSelectChoice
 } from './native-chat-session-options'
-import {
-  isFlipOnlyMidSession,
-  type NativeChatSessionOptionRecord,
-  type TrackedNativeChatSessionOption
+import type {
+  NativeChatSessionOptionRecord,
+  TrackedNativeChatSessionOption
 } from './native-chat-session-option-state'
 import { hasYoloTuiAgentLaunch } from './tui-agent-permissions'
 
@@ -69,7 +68,6 @@ function settableState(args: {
 
 function actionForApply(
   apply: { midSession?: CatalogMidSessionApply },
-  tracked: TrackedNativeChatSessionOption | undefined,
   mode: NativeChatSessionOptionMode
 ): SessionOptionDescriptor['action'] {
   if (mode !== 'live') {
@@ -78,9 +76,7 @@ function actionForApply(
   if (apply.midSession?.kind === 'agent-picker') {
     return { type: 'agent-picker' }
   }
-  // Why: only unknown flip-only options are actions; once we have a tracked
-  // baseline the UI can show absolute On/Off without inventing a start state.
-  return isFlipOnlyMidSession(apply.midSession) && !tracked ? { type: 'toggle-command' } : undefined
+  return undefined
 }
 
 function optionDescriptor(args: {
@@ -94,7 +90,7 @@ function optionDescriptor(args: {
   const { option, tracked, mode, modelIsCliDefault, composedModelApply } = args
   const permissionModeBypassAvailable = args.permissionModeBypassAvailable ?? false
   const isPermissionMode = option.id === PERMISSION_MODE_OPTION_ID
-  const action = actionForApply(option.apply, tracked, mode)
+  const action = actionForApply(option.apply, mode)
   const settable = settableState({ mode, apply: option.apply, composedModelApply })
   // Why: the launch only emits `values[id] ?? defaultValue` alongside a model flag, so
   // a draft names this option's value exactly when a model was picked. Under the CLI's
@@ -246,7 +242,7 @@ export function buildNativeChatSessionOptionSnapshot(args: {
   const trackedModelId = typeof modelTracked?.value === 'string' ? modelTracked.value : null
   const defaultModelId = cliDefaultModelId(catalog, models, trackedModelId)
   const effectiveModelId = trackedModelId ?? defaultModelId
-  const modelAction = actionForApply(catalog.modelApply, modelTracked, mode)
+  const modelAction = actionForApply(catalog.modelApply, mode)
   const snapshot: SessionOptionDescriptor[] = [
     {
       id: 'model',

--- a/src/shared/native-chat-session-option-state.ts
+++ b/src/shared/native-chat-session-option-state.ts
@@ -1,7 +1,8 @@
 import type { AgentType } from './agent-status-types'
-import type {
-  CatalogMidSessionApply,
-  AgentSessionOptionCatalog
+import {
+  getAgentSessionOptionCatalog,
+  type CatalogMidSessionApply,
+  type AgentSessionOptionCatalog
 } from './agent-session-option-catalog'
 import type { SessionOptionValue, SessionOptionValueSource } from './native-chat-session-options'
 
@@ -14,12 +15,23 @@ export type NativeChatSessionOptionRecord = {
   agent: AgentType
   model?: TrackedNativeChatSessionOption
   valuesByModel: Record<string, Record<string, TrackedNativeChatSessionOption>>
+  /** Options that belong to the session, not to the selected model. */
+  sessionValues: Record<string, TrackedNativeChatSessionOption>
 }
 
 export function createNativeChatSessionOptionRecord(
   agent: AgentType
 ): NativeChatSessionOptionRecord {
-  return { agent, valuesByModel: {} }
+  return { agent, valuesByModel: {}, sessionValues: {} }
+}
+
+function cloneTrackedOptionValues(
+  values: Record<string, TrackedNativeChatSessionOption> | undefined
+): Record<string, TrackedNativeChatSessionOption> {
+  // `?? {}`: records rehydrated from a cache written before sessionValues existed.
+  return Object.fromEntries(
+    Object.entries(values ?? {}).map(([id, tracked]) => [id, { ...tracked }])
+  )
 }
 
 export function cloneNativeChatSessionOptionRecord(
@@ -31,9 +43,10 @@ export function cloneNativeChatSessionOptionRecord(
     valuesByModel: Object.fromEntries(
       Object.entries(record.valuesByModel).map(([modelId, values]) => [
         modelId,
-        Object.fromEntries(Object.entries(values).map(([id, tracked]) => [id, { ...tracked }]))
+        cloneTrackedOptionValues(values)
       ])
-    )
+    ),
+    sessionValues: cloneTrackedOptionValues(record.sessionValues)
   }
 }
 
@@ -93,6 +106,16 @@ export function setTrackedSessionOption(
     record.model = { value, source }
     return typeof value === 'string' ? value : null
   }
+  // Why: a session-scoped option has no model to file under; returning null
+  // means "no model id to persist against", which is exactly right for it.
+  if (
+    getAgentSessionOptionCatalog(record.agent)?.sessionOptions?.some(
+      (option) => option.id === optionId
+    )
+  ) {
+    record.sessionValues[optionId] = { value, source }
+    return null
+  }
   const modelId =
     (typeof record.model?.value === 'string' ? record.model.value : null) ?? fallbackModelId
   if (!modelId) {
@@ -124,16 +147,31 @@ export function applyNativeChatReportedSessionOptions(
   record: NativeChatSessionOptionRecord,
   values: Record<string, SessionOptionValue>
 ): boolean {
+  const sessionOptionIds = new Set(
+    (getAgentSessionOptionCatalog(record.agent)?.sessionOptions ?? []).map((option) => option.id)
+  )
+  let changed = false
+  for (const [id, value] of Object.entries(values)) {
+    if (!sessionOptionIds.has(id)) {
+      continue
+    }
+    const current = record.sessionValues[id]
+    if (current?.value !== value || current.source !== 'reported') {
+      changed = true
+    }
+    record.sessionValues[id] = { value, source: 'reported' }
+  }
   const modelId = typeof values.model === 'string' ? values.model : null
   if (!modelId) {
-    return false
+    // Why: a session option is still truthful without a readable model.
+    return changed
   }
   const modelChanged = record.model?.value !== modelId
-  let changed = modelChanged || record.model?.source !== 'reported'
+  changed = changed || modelChanged || record.model?.source !== 'reported'
   record.model = { value: modelId, source: 'reported' }
   const modelValues = modelChanged ? {} : { ...record.valuesByModel[modelId] }
   for (const [id, value] of Object.entries(values)) {
-    if (id === 'model') {
+    if (id === 'model' || sessionOptionIds.has(id)) {
       continue
     }
     const current = modelValues[id]

--- a/src/shared/native-chat-session-option-state.ts
+++ b/src/shared/native-chat-session-option-state.ts
@@ -1,7 +1,6 @@
 import type { AgentType } from './agent-status-types'
 import {
   getAgentSessionOptionCatalog,
-  type CatalogMidSessionApply,
   type AgentSessionOptionCatalog
 } from './agent-session-option-catalog'
 import type { SessionOptionValue, SessionOptionValueSource } from './native-chat-session-options'
@@ -48,12 +47,6 @@ export function cloneNativeChatSessionOptionRecord(
     ),
     sessionValues: cloneTrackedOptionValues(record.sessionValues)
   }
-}
-
-export function isFlipOnlyMidSession(
-  midSession: CatalogMidSessionApply | undefined
-): midSession is Extract<CatalogMidSessionApply, { kind: 'toggle-command' }> {
-  return midSession?.kind === 'toggle-command'
 }
 
 export function getTrackedSessionOption(

--- a/src/shared/native-chat-session-option-state.ts
+++ b/src/shared/native-chat-session-option-state.ts
@@ -24,6 +24,8 @@ export function createNativeChatSessionOptionRecord(
   return { agent, valuesByModel: {}, sessionValues: {} }
 }
 
+/** Deep-copies one bucket of tracked values, tolerating a record rehydrated
+ *  from a cache written before that bucket existed. */
 function cloneTrackedOptionValues(
   values: Record<string, TrackedNativeChatSessionOption> | undefined
 ): Record<string, TrackedNativeChatSessionOption> {

--- a/src/shared/native-chat-session-options.ts
+++ b/src/shared/native-chat-session-options.ts
@@ -1,9 +1,15 @@
 export type SessionOptionValue = string | boolean
 
+/** Closed set of actions offered in place of an unselectable choice. A key (not
+ *  free English) so the producer and the localized label stay in sync. */
+export type SessionOptionChoiceAction = 'open-agent-permissions-setting'
+
 export type SessionOptionSelectChoice = {
   value: string
   label: string
   description?: string
+  /** Not selectable now; the row offers this action instead. */
+  unavailable?: { action: SessionOptionChoiceAction }
 }
 
 /** `default` is the catalog's own value shown before anything is observed —

--- a/src/shared/native-chat-session-options.ts
+++ b/src/shared/native-chat-session-options.ts
@@ -44,7 +44,7 @@ export type SessionOptionDescriptor = {
   disabledReason?: SessionOptionDisabledReason
   /** Why: picker-only and toggle-only PTY commands cannot be represented as
    * a truthful radio/checkbox state, so the producer exposes an action row. */
-  action?: { type: 'agent-picker' | 'toggle-command' }
+  action?: { type: 'agent-picker' }
 }
 
 export type SessionOptionSetResult = {

--- a/src/shared/tui-agent-permissions.test.ts
+++ b/src/shared/tui-agent-permissions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   applyAgentPermissionMode,
+  hasYoloTuiAgentLaunch,
   resolveAgentPermissionModeSummary,
   resolveTuiAgentPermissionMode,
   YOLO_TUI_AGENT_ARGS,
@@ -84,5 +85,39 @@ describe('tui agent permissions', () => {
         agentEnv: YOLO_TUI_AGENT_ENV.goose
       })
     ).toBe('yolo')
+  })
+})
+
+describe('hasYoloTuiAgentLaunch', () => {
+  it('grants bypass when the flag sits alongside other args', () => {
+    expect(
+      hasYoloTuiAgentLaunch({
+        agent: 'claude',
+        agentArgs: '--dangerously-skip-permissions --verbose'
+      })
+    ).toBe(true)
+  })
+
+  it('grants bypass for the bare flag', () => {
+    expect(
+      hasYoloTuiAgentLaunch({ agent: 'claude', agentArgs: '--dangerously-skip-permissions' })
+    ).toBe(true)
+  })
+
+  it('withholds bypass when the flag is absent', () => {
+    expect(hasYoloTuiAgentLaunch({ agent: 'claude', agentArgs: '--verbose' })).toBe(false)
+    expect(hasYoloTuiAgentLaunch({ agent: 'claude', agentArgs: '' })).toBe(false)
+    expect(hasYoloTuiAgentLaunch({ agent: 'claude' })).toBe(false)
+  })
+
+  it('reads env-granted yolo for agents that use it', () => {
+    expect(hasYoloTuiAgentLaunch({ agent: 'goose', agentEnv: { GOOSE_MODE: 'auto' } })).toBe(true)
+    expect(hasYoloTuiAgentLaunch({ agent: 'goose', agentEnv: {} })).toBe(false)
+  })
+
+  it('differs from the exact-preset check that reports mixed', () => {
+    const agentArgs = '--dangerously-skip-permissions --verbose'
+    expect(resolveTuiAgentPermissionMode({ agent: 'claude', agentArgs })).toBe('mixed')
+    expect(hasYoloTuiAgentLaunch({ agent: 'claude', agentArgs })).toBe(true)
   })
 })

--- a/src/shared/tui-agent-permissions.ts
+++ b/src/shared/tui-agent-permissions.ts
@@ -43,6 +43,32 @@ function normalizeArgs(value: string | null | undefined): string {
   return value?.trim() ?? ''
 }
 
+/** Whether the launch actually granted permission bypass, whatever else is on
+ *  the command line. Distinct from resolveTuiAgentPermissionMode, which asks
+ *  "are these exactly the yolo preset?" and so reports 'mixed' once any extra
+ *  arg is present — a session with the flag plus `--verbose` still has bypass. */
+export function hasYoloTuiAgentLaunch(args: {
+  agent: TuiAgent
+  agentArgs?: string | null
+  agentEnv?: Record<string, string> | null
+}): boolean {
+  const yoloArgs = YOLO_TUI_AGENT_ARGS[args.agent]
+  const yoloEnv = YOLO_TUI_AGENT_ENV[args.agent]
+  if (!yoloArgs && !yoloEnv) {
+    return false
+  }
+  const tokens = normalizeArgs(args.agentArgs).split(/\s+/).filter(Boolean)
+  const argsGranted =
+    !yoloArgs ||
+    yoloArgs
+      .split(/\s+/)
+      .filter(Boolean)
+      .every((part) => tokens.includes(part))
+  const envGranted =
+    !yoloEnv || Object.entries(yoloEnv).every(([name, value]) => args.agentEnv?.[name] === value)
+  return argsGranted && envGranted
+}
+
 function sameEnv(
   left: Record<string, string> | null | undefined,
   right: Record<string, string> | null | undefined


### PR DESCRIPTION
## ELI5

Claude Code lets you change how much it's allowed to do on its own — ask me every time, auto-accept edits, plan without touching anything, and so on. In the terminal you switch that with Shift+Tab. In Orca's Chat UI there was no way to see or change it, so a chat session was stuck on whatever it launched with.

This adds a **Mode** button next to the composer that shows the current mode and lets you change it, and fixes Claude's **fast mode** toggle, which broke when the CLI started asking for confirmation.

## What Changed

**Mode button in the composer** (Claude sessions), left of the options and model pills. Shows the live mode — Manual / Accept edits / Plan / Auto / Bypass permissions — and switches it mid-session.

Under the hood:

| Piece | What it does |
|---|---|
| `sessionOptions` on `AgentSessionOptionCatalog` | New extension point — every option was per-model before, and permission mode is per-session |
| `sessionValues` on the option record | Values with no model to file under; survive a model switch |
| `claude-terminal-session-options.ts` | Reads all five modes, and fast mode, off Claude's status line |
| `native-chat-live-screen.ts` | Parse-driven screen source: alt-screen frame → normal buffer → mounted xterm |
| `claude-permission-mode-cycle.ts` | Press-and-observe cycling with a diagnosable outcome |
| `NativeChatSessionOptionPickers.tsx` | The Mode button, plus per-choice disabling (new capability) |

**Fast mode fix** (#14752). A bare `/fast` no longer toggles — it opens a confirmation panel (*Tab to toggle · Enter to confirm*) that a dispatch leaves hanging and unapplied. The CLI still accepts `/fast on|off`, which sets the value outright.

That makes fast mode an absolute setter, so the **flip-only machinery it was the last user of is removed** (`isFlipOnlyMidSession`, the `toggle-command` kind, the Toggle action row, flip dedup — across shared, renderer and mobile). The flip's fallback for an unknown baseline was a bare `/fast`, which is exactly the command that now opens the panel. State comes from Claude's `↯` glyph instead, so no baseline is needed.

Also fixes a latent bug found on the way: a picker command cleared the tracked **model** for whichever option was being matched, so a typed bare `/fast` would have blanked every model-scoped row.

## Why

Three facts about Claude's CLI shaped the implementation. All were verified against a live session — the first two contradict what the shipped binary's own strings suggest, and cost me a rewrite each:

1. **There is no slash command for permission mode, and Shift+Tab *cycles* — it does not open a menu.** The numbered menu is the Claude Code **desktop app**; Orca drives the CLI. So an apply presses, re-reads the status line, and repeats until the target appears — bounded by a completed lap or a press cap.

2. **Every mode names itself in the status line, manual included** (`⏸ manual mode on`). Reading it needs no banner, which matters because Claude's banner scrolls out of the viewport after the first screenful — a banner-gated read reports nothing for the rest of the session.

3. **Bypass is launch-granted only.** Claude refuses it otherwise:

   > `Refusing restored mode 'bypassPermissions' (disabled by settings/policy or session not launched with --dangerously-skip-permissions); falling back to 'default'`

   So that row deep-links to **Settings → Agents → Agent Permissions** rather than driving Claude's danger warning. **Orca never auto-consents to a permission bypass on the user's behalf** — that decision stays with the existing setting.

**Safety property:** the cycle drains the PTY send queue before its first keystroke. A chat send holds a delayed Enter for ~500 ms, and one landing mid-cycle would select a mode the user never chose. Pinned by an order-asserting test, not just a "was called" check.

## Linked Issue

Fixes #11548
Fixes #14752 (*Chat UI fast mode toggle no longer applies — bare `/fast` opens a confirmation panel*)

Substantially addresses #12576 (*Per-session permission mode selector in the Chat UI composer*), which specifies this feature in detail. Deliberately **not** covered, so review can judge scope rather than discover gaps:

- No cycle keybinding in the composer (that issue asks for a Shift+Tab mirror). Dropdown only.
- Not surfaced in `orca terminal show` / worktree JSON.
- "Mixed" launch args aren't labelled as such. Bypass availability is a containment check, so the flag *plus* extra args works correctly, but the picker doesn't say "mixed".
- Claude only. Codex `/approvals` and other harnesses are untouched — the catalog now has the extension point for them.

### Relationship to open work

| # | Relationship |
|---|---|
| **#13348** *Auto permission mode across harnesses* | **Complementary, will conflict textually.** That PR changes the *launch-time* preset (Manual/Auto/Yolo); this adds the *per-session* control. Both touch `tui-agent-permissions.ts`, `AgentsPane.tsx`, `en.json` — whichever lands second rebases. They compose correctly: an Auto-preset session reports bypass as unavailable here, which is right. |
| **#10111** *Codex Fast mode* | **Overlaps 4 files**, including `agent-session-option-catalog-claude-codex.ts` and the labels/pickers. It adds Codex fast mode while this changes Claude's. Worth coordinating on ordering. |
| #13081 *Intermediate permission modes* | Claude's Auto is now selectable per-session here; #13348 covers the launch-time half. |
| #10886 *Stale YOLO args after restart* | Same root area. This reads launch args from the pane's **status entry**, never `settings.agentDefaultArgs` (the default for *new* sessions). |

No open PR implements the chat-UI permission mode picker — this is not a duplicate.

## Visual Proof

**1 — Composer, Mode button (after).** The new control, showing the live mode (`Auto`). Before this PR the composer had only the options and model pills, with no way to see or change permission mode.

<!-- drop 1.png here -->

**2 — The same session's terminal.** `▶▶ auto mode on (shift+tab to cycle)` — the pill reflects what the TUI actually reports, and changing it in the TUI propagates back to the pill.

<!-- drop 2.png here -->

**3 — After setting fast mode from the picker.** Pills read `Accept edits` and `High · Fast`; the transcript shows `Ran /fast on`.

<!-- drop 3.png here -->

**4 — The same, in the terminal.** `/fast on` → `↯ Fast mode ON · $10/$50 per Mtok`, with no confirmation panel left hanging. Status line reads `accept edits on`.

<!-- drop 4.png here -->

**5 — Effort dropdown, Fast mode section.** Fast mode now shows real `On` / `Off` state read from Claude's `↯` glyph. Before, an unknown baseline could only offer a blind "Toggle fast mode" action.

<!-- drop 5.png here -->

**6 — Mode dropdown.** Manual / Accept edits / Plan / Auto, plus `Bypass permissions` carrying an `Enable` affordance because this session wasn't launched with `--dangerously-skip-permissions`. That row deep-links to Settings → Agents → Agent Permissions rather than driving Claude's danger warning.

<!-- drop 6.png here -->

## Testing

- `pnpm run lint`, `pnpm typecheck`, `pnpm test`, `pnpm build` all pass locally.
- **Pre-existing unrelated failure:** 4 tests in `src/main/rate-limits/codex-fetcher-pty-settle.test.ts` fail identically on clean `origin/main` (verified in a separate worktree at `b849099045`). Not from this change.
- Manually tested on **macOS** against a live Claude session: all five modes switch both ways, changes made in the TUI propagate back to the pill, and fast mode toggles without the confirmation panel.

Regression tests pin the specific things that broke during development, all of which shipped-and-were-caught by real use:

- Prose reading `how do I turn plan mode on` must not be read as live status.
- `plan 2 things` above the menu must not yield a wrong digit.
- A stale main-buffer snapshot that reads fine but doesn't parse must fall through to the mounted xterm.
- Every menu row is covered as the active one (the active row swaps its digit for `✓`, so a fixed label→digit table is wrong).

Failure paths are diagnosable rather than silent — a failed change names the step that gave up and the modes it saw (`Gave up after 6 presses; saw auto → plan → …`).

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

## AI Disclosure

Written with Claude Code (Opus 5, 1M context) driving implementation, review and this description, with the author testing against live sessions and directing the design.

## Review

**Cross-platform (macOS / Linux / Windows).** No platform-specific code paths, no `metaKey` hardcoding, no path construction. The change is terminal-text parsing plus a dropdown. Verified on macOS; the parsing is platform-neutral (it reads PTY output, not OS APIs).

**Remote SSH / local.** The screen reader tries the main-buffer snapshot API first and falls back to the mounted xterm, which is the only source for remote/SSH ptys the API doesn't cover — the same layering the existing model/effort read uses. Keystrokes go through `sendRuntimePtyInput`, which already branches local vs. remote. **Not yet tested over a real SSH session:** `settleMs` (250 ms between cycle presses) is a reasoned default, and a slow round-trip could make it read a stale mode. That self-corrects (one extra press, re-settle) but is the one number to tune if it misbehaves.

**Mobile.** Touched only by the flip-only removal (`use-mobile-native-chat-session-options.ts`, `MobileNativeChatSessionOptionRows.tsx`). Mobile has no permission-mode picker; its option surface is unchanged otherwise, and its tests pass.

**Agent / integration compatibility.** Codex, Gemini, Cursor and Grok catalogs declare no `sessionOptions`, so no new descriptor appears for them and their reporting path is unchanged. Mode labels are scoped by option id — Cursor ships a model literally named `auto`, and an unscoped label switch would have relabelled it in every non-English locale (there's a test for exactly that).

**Backwards compatibility.** `sessionValues` is guarded for records rehydrated from a cache written before the field existed. The removed `toggle-command` kind had no remaining catalog user in any agent.

**Performance.** The screen read runs once on mount and once per mode change, not in a hot path. The cycle is bounded by a press cap and a completed-lap check, so it cannot spin. No new subscriptions or timers outside the bounded cycle.

**Security.** The one security-relevant decision is deliberate: Orca never auto-confirms Claude's dangerous-permissions prompt. Selecting Bypass when it isn't launch-granted routes the user to Orca's own Agent Permissions setting instead of pressing through the warning — consent stays an explicit, existing control. Launch args are read from the live pane's status entry, never from the global default, so a stale global can't imply a permission the session doesn't have.

**Known limitation worth its own issue.** `getLaunchConfigForEntry` (`agent-status.ts:948`) passes `launchToken: undefined`, while `registerAgentLaunchConfig` stores entries *with* a token and the matcher rejects on mismatch — so launch args resolve empty for essentially every Orca-launched session, not an edge case. This PR works around it (an observed `bypass permissions on` is itself proof of the grant); the residual gap is a bypass-launched session never scraped even once. A real fix needs `launchToken` on `AgentStatusEntry` and every `setAgentStatus` site, which is out of scope here.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes — captions in place, images being dropped in
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (one pre-existing unrelated test failure, noted above)

## Author

- X / Twitter: @your_handle
