### PR TITLE
fix(terminal): stop the hidden-output restore re-arming itself after dispose

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection-post-dispose-restore-termination.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-post-dispose-restore-termination.test.ts
@@ -1,0 +1,154 @@
+import type * as React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushAsyncTicks } from './pty-connection-test-async'
+import {
+  createMockTransport,
+  createPane,
+  captureCallbackTerminalWrites,
+  createManager
+} from './pty-connection-test-pane-fixtures'
+import type { ConnectCallbacks, MockTransport } from './pty-connection-test-pane-fixtures'
+import { buildPaneConnectionDeps } from './pty-connection-test-deps'
+import { createInitialStoreState } from './pty-connection-test-store-fixtures'
+import type { StoreState } from './pty-connection-test-store-state'
+import {
+  installTerminalTestGlobals,
+  restoreTerminalTestGlobals
+} from './pty-connection-test-environment'
+
+const { scheduleRuntimeGraphSync, shouldSeedCacheTimerOnInitialTitle, toastInfo } = vi.hoisted(
+  () => ({
+    scheduleRuntimeGraphSync: vi.fn(),
+    shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
+    toastInfo: vi.fn()
+  })
+)
+
+let mockStoreState: StoreState
+let transportFactoryQueue: MockTransport[] = []
+let storeSubscribers: ((state: StoreState) => void)[] = []
+
+vi.mock('@/runtime/sync-runtime-graph', () => ({ scheduleRuntimeGraphSync }))
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: () => mockStoreState,
+    subscribe: (listener: (state: StoreState) => void) => {
+      storeSubscribers.push(listener)
+      return () => {
+        storeSubscribers = storeSubscribers.filter((candidate) => candidate !== listener)
+      }
+    }
+  }
+}))
+
+vi.mock('@/lib/agent-status', async (importOriginal) => {
+  const { buildAgentStatusModuleMock } = await import('./pty-connection-test-environment')
+  return buildAgentStatusModuleMock(await importOriginal<Record<string, unknown>>())
+})
+
+vi.mock('./cache-timer-seeding', () => ({ shouldSeedCacheTimerOnInitialTitle }))
+
+vi.mock('sonner', () => ({ toast: { info: toastInfo } }))
+
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof React>()
+  return {
+    ...actual,
+    useCallback: <T extends (...args: unknown[]) => unknown>(fn: T): T => fn
+  }
+})
+
+vi.mock('./pty-transport', () => ({
+  createIpcPtyTransport: vi.fn(() => {
+    const nextTransport = transportFactoryQueue.shift()
+    if (!nextTransport) {
+      throw new Error('No mock transport queued')
+    }
+    return nextTransport
+  })
+}))
+
+describe('connectPanePty', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    transportFactoryQueue = []
+    storeSubscribers = []
+    mockStoreState = createInitialStoreState(() => mockStoreState)
+    installTerminalTestGlobals()
+  })
+
+  afterEach(async () => {
+    await restoreTerminalTestGlobals()
+  })
+
+  // Why this exists: the hidden-output restore task used to re-arm itself from its
+  // own `.finally`. After dispose the task body exits immediately, so the handler
+  // re-ran instantly and re-armed again — an unbounded self-feeding promise chain
+  // that consumed ~4GB in ~12s. It only stayed invisible because the pre-split
+  // 25k-line suite happened to run a later test that tore the loop down.
+  it('stops re-arming the hidden output restore once the pane binding is disposed', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-id')
+    const capturedDataCallback: {
+      current: ((data: string, meta?: { seq?: number; rawLength?: number }) => void) | null
+    } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'pty-id'
+    })
+    transportFactoryQueue.push(transport)
+
+    const getMainBufferSnapshot = window.api.pty.getMainBufferSnapshot as unknown as ReturnType<
+      typeof vi.fn
+    >
+    const hidden = 'x'.repeat(2 * 1024 * 1024 + 1)
+    const live = 'visible-after\r\n'
+    getMainBufferSnapshot.mockResolvedValue({
+      data: 'snapshot-state\r\n',
+      cols: 100,
+      rows: 30,
+      seq: hidden.length + live.length
+    })
+
+    const pane = createPane(1)
+    captureCallbackTerminalWrites(pane)
+
+    // Why a counting getter: the restore task's `.finally` reads isVisibleRef.current
+    // on every re-arm, so read count is a direct, deterministic measure of how many
+    // times the chain cycled — no timing or memory heuristics needed.
+    let visibilityReads = 0
+    let visible = false
+    const isVisibleRef = {
+      get current() {
+        visibilityReads += 1
+        return visible
+      },
+      set current(next: boolean) {
+        visible = next
+      }
+    }
+    const deps = buildPaneConnectionDeps(() => mockStoreState, { isVisibleRef })
+
+    const disposable = connectPanePty(pane as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks(6)
+
+    // Arm the restore: hidden bytes land while the pane is hidden, then it is revealed.
+    capturedDataCallback.current?.(hidden, { seq: hidden.length, rawLength: hidden.length })
+    visible = true
+    capturedDataCallback.current?.(live, {
+      seq: hidden.length + live.length,
+      rawLength: live.length
+    })
+    await flushAsyncTicks(20)
+
+    disposable.dispose()
+    const readsAtDispose = visibilityReads
+    await flushAsyncTicks(200)
+
+    // A terminated chain settles in a handful of turns; the self-feeding loop grew
+    // once per microtask turn and would blow past this by orders of magnitude.
+    expect(visibilityReads - readsAtDispose).toBeLessThan(50)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -7659,6 +7659,12 @@ export function connectPanePty(
         if (hiddenOutputRestoreInFlight === trackedHiddenOutputRestore) {
           hiddenOutputRestoreInFlight = null
         }
+        // Why: after dispose the task body exits immediately, so re-arming here
+        // resolves instantly and re-enters this handler — an unbounded promise
+        // chain that eats the heap. The pane is gone; there is nothing to restore.
+        if (disposed) {
+          return
+        }
         if (hiddenOutputRestorePendingChunks.length > 0 || hiddenOutputRestorePendingOverflow) {
           hiddenOutputRestoreNeeded = true
           armHiddenOutputRestoreForegroundDeadline()


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | +154 | 0 | +154 |
| Prod | 1 | +6 | 0 | +6 |

<!-- /orca-pr-loc -->

## The bug

`requestHiddenOutputRestoreIfNeeded` tracks its in-flight task with a `.finally` handler that re-arms the restore:

```js
trackedHiddenOutputRestore = hiddenOutputRestoreTask.finally(() => {
  …
  requestHiddenOutputRestoreIfNeeded()   // re-arms the same chain
})
```

The task body is `while (!disposed) { … }`. Once the pane is disposed it exits **immediately**, so the promise settles at once, the `.finally` runs, re-arms, and the new task exits immediately too. That is an unbounded self-feeding promise chain: it consumed **~4GB in ~12s** and starved the microtask queue.

The pane is gone at that point and there is nothing to restore, so the handler now returns early when `disposed`.

## Why it never surfaced before

The pre-split `pty-connection.test.ts` was 25,841 lines, and a test that ran *later* in the file happened to tear the loop down. Splitting it into focused suites left the arming tests at the end of a file, which turned this into a reproducible OOM — that is how it was found.

## Test

`pty-connection-post-dispose-restore-termination.test.ts` drives the restore into its armed state, disposes the pane, and counts how many times the chain re-reads `isVisibleRef.current` (the `.finally` reads it on every re-arm, so it is a direct, deterministic measure — no timing or memory heuristics).

Confirmed red before the fix:

```
AssertionError: expected 196 to be less than 50
FATAL ERROR: … JavaScript heap out of memory
```

and green after.

## Verification

- Full suite: **52,813 passing, 0 failures**
- `pnpm typecheck`: exit 0
- All 580 `pty-connection` suites pass

## Note

This also removes the ordering constraint flagged in #14728: the split files kept the arming tests upstream of the test that neutralized the loop. With the source fixed, that ordering is no longer load-bearing. I left the current arrangement alone rather than churn the files in the same PR.