### PR TITLE
test(daemon): stop mutating process-global cwd in the daemon cwd-repair tests

### DIFF
--- a/src/main/daemon/pty-subprocess-test-harness.ts
+++ b/src/main/daemon/pty-subprocess-test-harness.ts
@@ -15,6 +15,32 @@ const ORCA_SHELL_WRAPPER_ENV = [
 ] as const
 export const POWERLEVEL10K_WIZARD_DISABLE_ENV = 'POWERLEVEL9K_DISABLE_CONFIGURATION_WIZARD'
 
+/**
+ * Makes the daemon look like it is sitting in a deleted cwd, without moving the
+ * test process there.
+ *
+ * Why: `process.cwd()` and `process.chdir()` are process-global. The previous
+ * version of these tests really did chdir into a temp dir and delete it, so every
+ * other test file sharing the worker saw a missing cwd for that window — an
+ * intermittent failure that got likelier once this suite was split across files.
+ * Stubbing keeps the cwd-repair assertion exact and the process untouched.
+ */
+export function stubMissingDaemonCwd(): {
+  chdirSpy: Mock<(directory: string) => void>
+  restoreCwdStubs: () => void
+} {
+  const missingDaemonCwd = join(tmpdir(), 'orca-daemon-cwd-that-does-not-exist')
+  const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(missingDaemonCwd)
+  const chdirSpy = vi.spyOn(process, 'chdir').mockImplementation(() => {})
+  return {
+    chdirSpy: chdirSpy as unknown as Mock<(directory: string) => void>,
+    restoreCwdStubs: () => {
+      cwdSpy.mockRestore()
+      chdirSpy.mockRestore()
+    }
+  }
+}
+
 /** Annotated so declaration emit never has to name @vitest/spy internals. */
 export type MockPtyProcess = {
   pid: number

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -1,6 +1,6 @@
 // Spawn setup: node-pty launch options, Unix shell resolution and daemon cwd repair.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { mkdtempSync, realpathSync, rmSync } from 'node:fs'
+import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type * as LocalPtyUtils from '../providers/local-pty-utils'
@@ -80,6 +80,7 @@ import { PREVIOUS_DAEMON_PROTOCOL_VERSIONS, PROTOCOL_VERSION } from './types'
 import {
   mockPtyProcess,
   POWERLEVEL10K_WIZARD_DISABLE_ENV,
+  stubMissingDaemonCwd,
   useDaemonPtySubprocessEnv
 } from './pty-subprocess-test-harness'
 
@@ -332,25 +333,22 @@ describe('createPtySubprocess', () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
-    const originalCwd = process.cwd()
-    const deletedDaemonCwd = mkdtempSync(join(tmpdir(), 'orca-deleted-daemon-cwd-'))
+    const terminalCwd = process.cwd()
     Object.defineProperty(process, 'platform', { value: 'darwin' })
+    const { restoreCwdStubs, chdirSpy } = stubMissingDaemonCwd()
 
     try {
-      process.chdir(deletedDaemonCwd)
-      rmSync(deletedDaemonCwd, { recursive: true, force: true })
-
       createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
-        cwd: originalCwd,
+        cwd: terminalCwd,
         env: { SHELL: '/bin/bash' }
       })
 
-      expect(process.cwd()).toBe(realpathSync(ptyEnv.userDataPath))
+      expect(chdirSpy).toHaveBeenCalledWith(ptyEnv.userDataPath)
     } finally {
-      process.chdir(originalCwd)
+      restoreCwdStubs()
       if (platform) {
         Object.defineProperty(process, 'platform', platform)
       }
@@ -361,7 +359,7 @@ describe('createPtySubprocess', () => {
     expect(spawnMock).toHaveBeenCalledWith(
       '/bin/bash',
       expect.any(Array),
-      expect.objectContaining({ cwd: originalCwd })
+      expect.objectContaining({ cwd: terminalCwd })
     )
   })
 
@@ -369,25 +367,22 @@ describe('createPtySubprocess', () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
-    const originalCwd = process.cwd()
-    const deletedDaemonCwd = mkdtempSync(join(tmpdir(), 'orca-deleted-daemon-cwd-'))
+    const terminalCwd = process.cwd()
     Object.defineProperty(process, 'platform', { value: 'linux' })
+    const { restoreCwdStubs, chdirSpy } = stubMissingDaemonCwd()
 
     try {
-      process.chdir(deletedDaemonCwd)
-      rmSync(deletedDaemonCwd, { recursive: true, force: true })
-
       createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
-        cwd: originalCwd,
+        cwd: terminalCwd,
         env: { SHELL: '/bin/bash' }
       })
 
-      expect(process.cwd()).toBe(realpathSync(ptyEnv.userDataPath))
+      expect(chdirSpy).toHaveBeenCalledWith(ptyEnv.userDataPath)
     } finally {
-      process.chdir(originalCwd)
+      restoreCwdStubs()
       if (platform) {
         Object.defineProperty(process, 'platform', platform)
       }
@@ -396,7 +391,7 @@ describe('createPtySubprocess', () => {
     expect(spawnMock).toHaveBeenCalledWith(
       '/bin/bash',
       expect.any(Array),
-      expect.objectContaining({ cwd: originalCwd })
+      expect.objectContaining({ cwd: terminalCwd })
     )
   })
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | +14 | −19 | −5 |
| Prod | 1 | +26 | 0 | +26 |

<!-- /orca-pr-loc -->

## The problem

The two daemon cwd-repair tests really did move the test process:

```js
process.chdir(deletedDaemonCwd)
rmSync(deletedDaemonCwd, { recursive: true, force: true })
…
expect(process.cwd()).toBe(realpathSync(ptyEnv.userDataPath))
```

`process.cwd()` and `process.chdir()` are **process-global**, so for that window every other test file sharing the worker process saw a deleted working directory.

That was already a latent hazard. Splitting `pty-subprocess.test.ts` into ten files (#14728) made the window overlap far more concurrent work, and these two started failing intermittently in full-suite runs while passing in isolation — they failed in two separate full runs, one the macOS variant and one the Linux variant.

## The fix

Stub the boundary instead of moving the process: report a non-existent daemon cwd from `process.cwd()`, and spy on `process.chdir()` to capture the repair target.

The assertion gets **stricter**, not weaker. It previously observed where the process happened to land; it now names the directory `repairDaemonCwd()` actually selected:

```js
expect(chdirSpy).toHaveBeenCalledWith(ptyEnv.userDataPath)
```

The shared helper lives in `pty-subprocess-test-harness.ts` next to the other daemon env lifecycle helpers.

## Verification

- `pty-subprocess` family: **131 passing across 4 consecutive runs**
- Full suite: 52,813 passing, 0 failures — both cwd-repair tests green, having failed in prior full runs
- No test in the repo mutates process-global cwd any more (`grep` for `process.chdir` outside the spy returns nothing)

## Note

The product behavior is unchanged — `repairDaemonCwd()` still calls `process.chdir()` for real; only the tests stop doing so.