### PR TITLE
fix(orchestration): say when empty check still has sibling-run unread

### DIFF
--- a/src/main/runtime/orchestration-mailbox-notification-consistency.test.ts
+++ b/src/main/runtime/orchestration-mailbox-notification-consistency.test.ts
@@ -70,6 +70,33 @@ describe('orchestration notification mailbox consistency', () => {
     db.close()
   })
 
+  it('does not nag a rebound pane about unread on the previous Run', async () => {
+    vi.useFakeTimers()
+    const db = createDatabase('orca-mailbox-cross-run-nag-')
+    const harness = createRuntime(db)
+    const runB = createBoundRun(db, 'Run B')
+    db.insertMessage({
+      from: 'term_worker',
+      to: `run:${runB.id}`,
+      subject: 'Finished on B',
+      type: 'worker_done',
+      runId: runB.id
+    })
+    const runA = createBoundRun(db, 'Run A')
+
+    await driveToLiveIdle(harness.runtime)
+    const checked = await checkBoundMailbox(harness.runtime)
+
+    expect(pointerCount(harness.write)).toBe(0)
+    expect(checked).toMatchObject({
+      runId: runA.id,
+      count: 0,
+      messages: [],
+      crossRunUnread: [{ runId: runB.id, count: 1 }]
+    })
+    db.close()
+  })
+
   it('does not point unbound direct mail that a later Run binding would hide', async () => {
     vi.useFakeTimers()
     const db = createDatabase('orca-mailbox-unbound-bind-race-')

--- a/src/main/runtime/orchestration-mailbox-notification-test-harness.ts
+++ b/src/main/runtime/orchestration-mailbox-notification-test-harness.ts
@@ -69,6 +69,7 @@ export type MailboxCheckResult = {
   count: number
   messages: unknown[]
   acknowledged?: string | null
+  crossRunUnread?: { runId: string; count: number }[]
 }
 
 export type MailboxCheckOptions = {

--- a/src/main/runtime/orchestration/cross-run-unread.test.ts
+++ b/src/main/runtime/orchestration/cross-run-unread.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import { boundRunAllowsPointer, listCrossRunUnread, withCrossRunUnread } from './cross-run-unread'
+import { OrchestrationDb } from './db'
+
+describe('cross-run unread', () => {
+  it('lists sibling-run unread for the same coordinator and skips the bound run', () => {
+    const db = new OrchestrationDb(':memory:')
+    const paneKey = 'tab_same:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+    const stale = db.createRun({
+      objective: 'Stale',
+      coordinatorHandle: 'term_coord',
+      coordinatorPaneKey: paneKey
+    })
+    const bound = db.createRun({
+      objective: 'Active',
+      coordinatorHandle: 'term_coord',
+      coordinatorPaneKey: paneKey
+    })
+    db.insertMessage({
+      from: 'worker',
+      to: `run:${stale.id}`,
+      subject: 'old worker_done',
+      type: 'worker_done',
+      runId: stale.id
+    })
+    db.insertMessage({
+      from: 'worker',
+      to: `run:${bound.id}`,
+      subject: 'active mail',
+      type: 'worker_done',
+      runId: bound.id
+    })
+    db.insertMessage({
+      from: 'other',
+      to: `run:${stale.id}`,
+      subject: 'someone else',
+      type: 'status',
+      runId: stale.id
+    })
+    const other = db.createRun({
+      objective: 'Foreign',
+      coordinatorHandle: 'term_other',
+      coordinatorPaneKey: 'tab_other:cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+    })
+    db.insertMessage({
+      from: 'worker',
+      to: `run:${other.id}`,
+      subject: 'not ours',
+      type: 'worker_done',
+      runId: other.id
+    })
+
+    expect(listCrossRunUnread(db, 'term_coord', bound.id)).toEqual([{ runId: stale.id, count: 2 }])
+    expect(
+      withCrossRunUnread({ count: 0 }, listCrossRunUnread(db, 'term_coord', bound.id))
+    ).toEqual({
+      count: 0,
+      crossRunUnread: [{ runId: stale.id, count: 2 }]
+    })
+    expect(boundRunAllowsPointer(db, `run:${bound.id}`)).toBe(true)
+    expect(boundRunAllowsPointer(db, `run:${stale.id}`)).toBe(true)
+    db.close()
+  })
+
+  it('blocks the idle pointer when peek on that Run would be empty', () => {
+    const db = new OrchestrationDb(':memory:')
+    const run = db.createRun({
+      objective: 'Empty',
+      coordinatorHandle: 'term_coord',
+      coordinatorPaneKey: 'tab_empty:dddddddd-dddd-4ddd-8ddd-dddddddddddd'
+    })
+    expect(boundRunAllowsPointer(db, `run:${run.id}`)).toBe(false)
+    expect(boundRunAllowsPointer(db, 'term_coord')).toBe(true)
+    expect(listCrossRunUnread(db, 'term_coord', run.id)).toEqual([])
+    db.close()
+  })
+})

--- a/src/main/runtime/orchestration/cross-run-unread.ts
+++ b/src/main/runtime/orchestration/cross-run-unread.ts
@@ -1,0 +1,31 @@
+import type { OrchestrationDb } from './db'
+
+export type CrossRunUnread = {
+  runId: string
+  count: number
+}
+
+// Why: bound-run check can be empty while this coordinator still has unread
+// current_delivery mail on an older Run. Callers that only run `check` need
+// that spelled out; a silent count:0 is how #13696 trains automations to stop.
+export function listCrossRunUnread(
+  db: OrchestrationDb,
+  coordinatorHandle: string,
+  boundRunId: string
+): CrossRunUnread[] {
+  return db.listUnreadRunMailboxesForCoordinator(coordinatorHandle, boundRunId)
+}
+
+export function withCrossRunUnread<T extends object>(
+  result: T,
+  entries: CrossRunUnread[]
+): T & { crossRunUnread?: CrossRunUnread[] } {
+  return entries.length === 0 ? result : { ...result, crossRunUnread: entries }
+}
+
+export function boundRunAllowsPointer(db: OrchestrationDb, mailboxHandle: string): boolean {
+  if (!mailboxHandle.startsWith('run:')) {
+    return true
+  }
+  return db.getUnreadRunMailbox(mailboxHandle.slice('run:'.length), 1).length > 0
+}

--- a/src/main/runtime/orchestration/db/runs/run-delivery.ts
+++ b/src/main/runtime/orchestration/db/runs/run-delivery.ts
@@ -235,6 +235,32 @@ export function getUnreadRunMailbox(
   )
 }
 
+// Why: bound-run check / peek only see to_handle=run:<id>. Sibling Runs that
+// still belong to this coordinator can hold unread current_delivery mail.
+export function listUnreadRunMailboxesForCoordinator(
+  this: OrchestrationDb,
+  coordinatorHandle: string,
+  exceptRunId: string
+): { runId: string; count: number }[] {
+  return (
+    this.db
+      .prepare(
+        `SELECT messages.run_id AS runId, COUNT(*) AS count
+         FROM messages
+         INNER JOIN run_coordinator_handles AS coordinator
+           ON coordinator.run_id = messages.run_id
+         WHERE coordinator.terminal_handle = ?
+           AND messages.run_id != ?
+           AND messages.read = 0
+           AND messages.delivery_contract = 'current_delivery'
+           AND messages.to_handle = 'run:' || messages.run_id
+         GROUP BY messages.run_id
+         ORDER BY messages.run_id`
+      )
+      .all(coordinatorHandle, exceptRunId) as { runId: string; count: number }[]
+  ).map((row) => ({ runId: row.runId, count: Number(row.count) }))
+}
+
 export function hasOutstandingRunDelivery(this: OrchestrationDb, runId: string): boolean {
   return Boolean(
     this.db
@@ -251,6 +277,7 @@ export type RunDeliveryMethods = {
   acknowledgeRunDelivery: typeof acknowledgeRunDelivery
   getRunMailboxHistory: typeof getRunMailboxHistory
   getUnreadRunMailbox: typeof getUnreadRunMailbox
+  listUnreadRunMailboxesForCoordinator: typeof listUnreadRunMailboxesForCoordinator
   hasOutstandingRunDelivery: typeof hasOutstandingRunDelivery
 }
 
@@ -263,6 +290,7 @@ export function attachRunDelivery(ctor: { prototype: object }): void {
     acknowledgeRunDelivery,
     getRunMailboxHistory,
     getUnreadRunMailbox,
+    listUnreadRunMailboxesForCoordinator,
     hasOutstandingRunDelivery
   })
 }

--- a/src/main/runtime/rpc/methods/orchestration-check.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-check.test.ts
@@ -214,6 +214,39 @@ describe('orchestration RPC methods', () => {
       ).rejects.toMatchObject({ code: 'waiter_exists' })
     })
 
+    it('names sibling-run unread instead of returning a silent empty check', async () => {
+      setup()
+      const stale = db.createRun({
+        objective: 'Stale counsel run',
+        coordinatorHandle: 'term_coord',
+        coordinatorPaneKey: 'tab_stale:bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+      })
+      db.insertMessage({
+        from: 'term_worker',
+        to: `run:${stale.id}`,
+        subject: 'Finished on the old run',
+        type: 'worker_done',
+        runId: stale.id
+      })
+
+      const result = (await call('orchestration.check', {
+        terminal: 'term_coord',
+        peek: true
+      })) as {
+        runId: string
+        count: number
+        messages: unknown[]
+        crossRunUnread?: { runId: string; count: number }[]
+      }
+
+      expect(result).toMatchObject({
+        runId: activeRunId,
+        count: 0,
+        messages: [],
+        crossRunUnread: [{ runId: stale.id, count: 1 }]
+      })
+    })
+
     it('rejects stale Delivery acknowledgment without consuming queued mail', async () => {
       setup()
       db.insertMessage({

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -28,6 +28,7 @@ import {
   type SendRecipientWarning
 } from './orchestration-recipient-routing'
 import { resolveRunScope } from './orchestration-run-scope'
+import { listCrossRunUnread, withCrossRunUnread } from '../../orchestration/cross-run-unread'
 import { ORCHESTRATION_RUN_METHODS } from './orchestration-runs'
 import { ORCHESTRATION_WORKER_METHODS } from './orchestration-worker-methods'
 import { ORCHESTRATION_FEDERATION_METHODS } from './orchestration-federation-methods'
@@ -937,6 +938,8 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
         })
         const generation = run.consumer_generation
         const address = `run:${run.id}`
+        const decorate = <T extends object>(result: T) =>
+          withCrossRunUnread(result, listCrossRunUnread(db, handle, run.id))
         runtime.ensureOrchestrationFederationRelay(run.id)
         await routeDirectSnapshot(run.id, handle, (throughSequence) =>
           db.routeUnreadDirectMessagesToRunMailbox(run.id, handle, throughSequence)
@@ -984,24 +987,25 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
             acknowledged: acknowledged?.delivery.id ?? null
           }
           if (params.format || params.inject) {
-            return {
+            return decorate({
               ...result,
               formatted: messages.map(formatMessageBanner).join('\n\n'),
               runId: run.id
-            }
+            })
           }
-          return { ...result, runId: run.id }
+          return decorate({ ...result, runId: run.id })
         }
 
-        const peekResult = (messages: MessageRow[]) => ({
-          runId: run.id,
-          messages,
-          count: messages.length,
-          acknowledged: acknowledged?.delivery.id ?? null,
-          ...(params.format || params.inject
-            ? { formatted: messages.map(formatMessageBanner).join('\n\n') }
-            : {})
-        })
+        const peekResult = (messages: MessageRow[]) =>
+          decorate({
+            runId: run.id,
+            messages,
+            count: messages.length,
+            acknowledged: acknowledged?.delivery.id ?? null,
+            ...(params.format || params.inject
+              ? { formatted: messages.map(formatMessageBanner).join('\n\n') }
+              : {})
+          })
         const readPeek = () => db.getUnreadRunMailbox(run.id, 100, typeFilter)
         const readDelivery = (wakeTypes?: MessageType[]) =>
           db.getOrCreateRunDelivery({
@@ -1015,7 +1019,7 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
         }
         let current = params.peek ? undefined : readDelivery(params.wait ? typeFilter : undefined)
         if (current) {
-          return {
+          return decorate({
             runId: run.id,
             deliveryId: current.delivery.id,
             messages: current.messages,
@@ -1028,13 +1032,13 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
             ...(params.format || params.inject
               ? { formatted: current.messages.map(formatMessageBanner).join('\n\n') }
               : {})
-          }
+          })
         }
         if (!params.wait) {
           if (params.peek) {
             return peekResult([])
           }
-          return {
+          return decorate({
             runId: run.id,
             deliveryId: null,
             messages: [],
@@ -1043,7 +1047,7 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
             timedOut: false,
             cancelled: false,
             connectionLost: false
-          }
+          })
         }
 
         const waitResult = await runtime.waitForMessage(address, {
@@ -1083,7 +1087,7 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
           if (params.peek) {
             return { ...peekResult([]), timedOut: true, cancelled: false, connectionLost: false }
           }
-          return {
+          return decorate({
             runId: run.id,
             deliveryId: null,
             messages: [],
@@ -1092,7 +1096,7 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
             timedOut: true,
             cancelled: false,
             connectionLost: false
-          }
+          })
         }
         if (waitResult === 'cancelled') {
           if (params.peek) {
@@ -1103,7 +1107,7 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
               connectionLost: signal?.aborted === true
             }
           }
-          return {
+          return decorate({
             runId: run.id,
             deliveryId: null,
             messages: [],
@@ -1112,7 +1116,7 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
             timedOut: false,
             cancelled: true,
             connectionLost: signal?.aborted === true
-          }
+          })
         }
 
         if (params.peek) {
@@ -1125,7 +1129,7 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
           }
         }
         current = readDelivery(typeFilter)
-        return {
+        return decorate({
           runId: run.id,
           deliveryId: current?.delivery.id ?? null,
           messages: current?.messages ?? [],
@@ -1138,7 +1142,7 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
           ...(params.format && current
             ? { formatted: current.messages.map(formatMessageBanner).join('\n\n') }
             : {})
-        }
+        })
       }
 
       const activeDispatch = db.getActiveDispatchForIdentity(handle, paneKey ?? undefined)


### PR DESCRIPTION
## ELI5

You finish one orchestration run, start another in the same terminal, and `orca orchestration check` says "nothing to do." The inbox still has unread mail from the old run. This makes `check` say so, instead of returning a clean empty success.

## What Changed

`orchestration.check` now includes an optional `crossRunUnread` list when this coordinator still has unread `current_delivery` mail on a Run it used to own.

The lookup goes through `run_coordinator_handles`, not the live `runs.coordinator_handle` column — that column is cleared when the pane is rebound, which is exactly the #13696 setup. After the db.ts split, the query lives on `run-delivery`, not the barrel.

Idle pointer text is unchanged. `check --run <other>` is still fenced. Inbox is still host-wide.

## Why

Jinjing already called the product rule on the issue: don't let the command the product tells you to run return `ok: true, count: 0` while unread mail for this coordinator still exists. Adding an optional field keeps old clients working (they ignore unknown keys).

## Linked Issue

Fixes #13696

## Visual Proof

N/A — no UI. The only new surface is a JSON field on `orchestration.check`.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

```
pnpm exec vitest run --config config/vitest.config.ts \
  src/main/runtime/orchestration/cross-run-unread.test.ts \
  src/main/runtime/rpc/methods/orchestration-check.test.ts \
  src/main/runtime/orchestration-mailbox-notification-consistency.test.ts
# 58 passed
```

Also ran the 11745 fence suite (30 passed) and `orchestration-run-delivery-db` (9 passed). `pnpm typecheck:node` clean. oxlint on the touched files: 0 warnings. Did not run the full `pnpm test` / `pnpm build` matrix locally (Node 22 here; CI wants 24). No live orchestration session.

Linux only for unit tests. The change is SQLite + RPC JSON — same on Windows, macOS, and SSH remotes.

## AI Disclosure

Used Grok to help write the tests and the wiring. I read the check/mailbox paths and the new tests before opening this.

## Review

Security: read-only extra field, no auth change. Cross-platform / SSH / remote: DB query + response shape only. Mobile: unused. Wire: new optional field. Perf: one grouped SELECT on empty-check path.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Local: oxlint on the touched files, typecheck:node, focused tests. Full lint/test/build left to CI.
