### PR TITLE
fix(ci): unbreak static analysis on main (restrict-template-expressions)

### DIFF
--- a/config/scripts/pr-test-loc-summary.test.mjs
+++ b/config/scripts/pr-test-loc-summary.test.mjs
@@ -85,7 +85,7 @@ describe('PR test LoC summary', () => {
       fetchImpl: async (url) => {
         const page = pages[url]
         if (page == null) {
-          throw new Error(`unexpected url ${url}`)
+          throw new Error(`unexpected url ${String(url)}`)
         }
         return {
           ok: true,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | +1 | −1 | 0 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## Summary

`main` is currently failing the **static analysis** job, so every open PR inherits the failure.

#14738 (`ci: post test vs non-test LoC on pull requests`) added `config/scripts/pr-test-loc-summary.test.mjs`, which interpolates an untyped `fetchImpl` url into a template literal:

```
config/scripts/pr-test-loc-summary.test.mjs:88:45: warning typescript(restrict-template-expressions): Invalid type used in template literal expression.
```

`pnpm run audit:code-quality:type-aware` treats that as fatal (exit 1), and it runs as the *Enforce type-aware code-quality baseline* step of the static analysis job in `.github/workflows/pr.yml`.

Wrapping the value in `String(...)` clears it.

## Verification

- `pnpm run audit:code-quality:type-aware` — exit 1 on a clean `origin/main` checkout, exit 0 with this change
- `config/scripts/pr-test-loc-summary.test.mjs` — 8 tests pass
- `oxlint config/scripts/` — 0 warnings, 0 errors

## Trade-offs

None. One-line change in a test helper's error path; no runtime or CI behavior change beyond unblocking the gate.