### PR TITLE
feat(browser): bound page reconciliation execution

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -2589,6 +2589,7 @@
         "server-owned page-command issue and result ledger",
         "same-socket paired-runtime control requests",
         "paired desktop browser-host lifecycle composition",
+        "bounded client-page reconciliation execution",
         "dedicated paired-runtime E2EE tunnel subscription"
       ],
       "platforms": ["macos", "linux", "windows"],
@@ -2604,7 +2605,7 @@
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/browser-host-page-retirement.test.ts src/main/runtime/browser-host-page-placement-replacement.test.ts src/main/runtime/browser-host-page-placement.test.ts src/main/runtime/browser-host-lease-registry.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/browser-host-lease-placement-retirement.test.ts src/main/runtime/browser-host-page-retirement.test.ts src/main/runtime/browser-host-page-placement-replacement.test.ts src/main/runtime/browser-host-page-placement.test.ts src/main/runtime/browser-host-lease-registry.test.ts",
-        "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/browser-host-page-reconciliation-plan.test.ts",
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/browser-host-page-reconciliation-plan.test.ts src/main/runtime/browser-host-page-reconciliation-executor.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/shared/browser-client-host-protocol.test.ts src/main/browser/browser-client-host-attach-request.test.ts src/main/browser/browser-client-page-command-executor.test.ts src/main/browser/browser-client-page-command-integration.test.ts src/main/browser/browser-client-page-inventory.test.ts src/main/browser/paired-runtime-browser-client-host-composition.test.ts src/main/browser/paired-runtime-browser-client-host.test.ts src/main/browser/paired-runtime-browser-host-lease.test.ts src/main/runtime/browser-host-lease-registry.test.ts src/main/runtime/rpc/methods/browser-client-host.test.ts src/main/runtime/browser-host-page-reconciliation-plan.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/shared/browser-network-capabilities.test.ts src/shared/browser-network-tunnel-protocol.test.ts src/main/browser/browser-network-tunnel-session.test.ts src/main/browser/remote-browser-socks-server.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/main/browser/browser-network-tunnel-client.test.ts src/main/browser/paired-runtime-browser-network-route.test.ts src/main/runtime/runtime-binary-message-router.test.ts src/main/runtime/rpc/methods/browser-network-tunnel.test.ts src/main/runtime/browser-network-tunnel-paired-runtime.integration.test.ts",
@@ -2634,6 +2635,7 @@
         "src/main/runtime/browser-host-page-placement-replacement.test.ts",
         "src/main/runtime/browser-host-page-placement.test.ts",
         "src/main/runtime/browser-host-page-reconciliation-plan.test.ts",
+        "src/main/runtime/browser-host-page-reconciliation-executor.test.ts",
         "src/main/runtime/browser-host-command-ledger.test.ts",
         "src/main/runtime/browser-host-command-ledger-capacity.test.ts",
         "src/main/runtime/browser-host-lease-registry.test.ts",

--- a/docs/sta-4150-client-hosted-browser-progress.md
+++ b/docs/sta-4150-client-hosted-browser-progress.md
@@ -532,7 +532,7 @@ Validation and review:
 | Route/profile-scoped partition before first request                | Partial                   | Deterministic policy ordering passes; real Electron worker/popup/speculation proof is missing                     |
 | SOCKS5 tunnel with remote DNS and bounded flow control             | Partial                   | Native and SSH route foundations exist; WSL and production route retention are incomplete                         |
 | Agent/CLI routing by placement                                     | Missing                   | Only create/navigate command foundations exist; public browser methods still use current server behavior          |
-| Inventory/reconciliation after ambiguous outcomes and restart      | Partial                   | Planner, authenticated inventory, and reconnect lifetime exist; plan execution and restart recovery remain        |
+| Inventory/reconciliation after ambiguous outcomes and restart      | Partial                   | Planner, authenticated inventory, and bounded executor exist; concrete adapters and restart recovery remain       |
 | Independent bounded control/tunnel/mirror/binary channels          | Partial                   | Control and tunnel are separate/bounded; mirror and large-result paths are incomplete                             |
 | Mixed client/server compatibility                                  | Partial                   | Optional/capability-gated contracts and cross-version tests exist; activated rolling-upgrade behavior is unproven |
 | Local pointer/keyboard/chrome with no runtime round trip           | Missing                   | Requires the renderer surface and interaction-owner fencing                                                       |
@@ -548,8 +548,8 @@ Validation and review:
 
 1. Monitor #14754 CI without merging or marking it ready; the current-main type-aware warning is
    upstream and must not be folded into this browser stage.
-2. Execute the pinned reclaim/restore/close reconciliation plan against authenticated runtime
-   intent and the preserved reconnect inventory before recovering ambiguous slots or routes.
+2. Bind the bounded reconciliation executor to authenticated runtime intent and preserved reconnect
+   inventory with exact generation-fenced reclaim, close, and restore adapters.
 3. Add optional placement to logical session-tab publication and renderer state. Follow
    `docs/reference/remote-wire-compatibility.md`; old callers and clients remain server-hosted.
 4. Route create and every existing browser command by explicit placement. Never silently fall
@@ -691,6 +691,31 @@ Published terminal navigation-authority stage (#14754):
   folder/worktree behavior, UI, or server-hosted browser behavior changes. The stage remains
   production-inert and needs live activation/topology evidence later.
 
+Published reconciliation-execution stage (#14756):
+
+- Baseline: the deterministic executor oracle failed because no module executed the immutable
+  reconciliation plan; the planner could describe retain/reclaim/close/restore work but had no
+  proof barrier, timeout, cancellation, or bounded scheduler.
+- Candidate: reclaim and close actions run with configurable concurrency capped at 16 and an
+  action deadline capped at 60 seconds. Every independent phase-one action is attempted, while any
+  rejection, timeout, or abort blocks all restores and requires a fresh authenticated plan.
+- Close-then-restore pages cannot restore until their exact close and every other phase-one action
+  settle positively. Action callbacks receive an abort signal, late rejections remain handled, and
+  no mutation is retried automatically.
+- Focused planner/executor coverage passes 2 files / 45 tests. The affected placement, lease,
+  reconnect, command, route, and RPC package passes 18 files / 212 tests; mixed-version terminal
+  wire passes 5/5; the 87-gate reliability manifest includes the executor.
+- Node/CLI/web typecheck, changed-code quality, max-lines, localization, skill-manifest, formatting,
+  and diff checks pass. Full lint reaches only the known upstream-main type-aware warning at
+  `config/scripts/pr-test-loc-summary.test.mjs:88`; the native audit and all later subchecks pass.
+- Fresh lifecycle, resource, security, mobile-compatibility, and cross-platform review found no
+  actionable issue. Work is bounded to at most 256 planner actions and 16 active callbacks, timers
+  and parent-abort listeners are cleaned on success/failure/timeout, and no path, shell, dependency,
+  network, persisted-state, exchanged-field, capability, publication, UI, or placement behavior is
+  changed. Concrete adapters must fence late mutation by exact authority generation before use.
+- Draft PR [#14756](https://github.com/stablyai/orca/pull/14756) stacks on #14754 and remains draft.
+  GitHub auto-attached it to STA-4150; the ticket remains In Progress.
+
 Do not promote narrow deterministic evidence into a live-topology claim. Record exact commands,
 topology, versions, and explicit gaps at every later checkpoint.
 
@@ -760,6 +785,11 @@ topology, versions, and explicit gaps at every later checkpoint.
   changed, and no PR was merged or marked ready.
 - GitHub auto-attached #14754 to STA-4150. Posted exactly one navigation-fence checkpoint comment
   (`6ea865bf-8003-435a-8600-9ec11fd21577`) and kept the ticket In Progress.
+- Pushed `sta-4150-browser-page-reconciliation-execution` with a must-not-exist lease and opened
+  draft PR [#14756](https://github.com/stablyai/orca/pull/14756) on #14754. No prior stack branch
+  changed, and no PR was merged or marked ready.
+- GitHub auto-attached #14756 to STA-4150. Posted exactly one reconciliation-executor checkpoint
+  comment (`3957ea40-a9e2-4b25-9197-2f972166f47b`) and kept the ticket In Progress.
 - No PR was merged or marked ready.
 
 ## Completion rule

--- a/src/main/runtime/browser-host-page-reconciliation-executor.test.ts
+++ b/src/main/runtime/browser-host-page-reconciliation-executor.test.ts
@@ -1,0 +1,365 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  executeBrowserHostPageReconciliation,
+  type BrowserHostPageReconciliationActions
+} from './browser-host-page-reconciliation-executor'
+import {
+  planBrowserHostPageReconciliation,
+  type BrowserClientHostedPageInventory,
+  type BrowserHostRuntimePageIntent
+} from './browser-host-page-reconciliation-plan'
+
+const inventorySource = { inventoryPairedDeviceId: 'device-a' }
+
+const intent = (
+  browserPageId: string,
+  overrides: Partial<BrowserHostRuntimePageIntent> = {}
+): BrowserHostRuntimePageIntent => ({
+  authorityRuntimeId: 'runtime-new',
+  authorityEpoch: 'epoch-new',
+  browserHostClientId: 'client-a',
+  browserHostGeneration: 9,
+  browserPageId,
+  pageHostGeneration: Number(browserPageId.replace(/\D/g, '')) + 10,
+  browserProfileId: 'profile-a',
+  executionHostKey: 'native:runtime-new:3',
+  ...overrides
+})
+
+const page = (
+  browserPageId: string,
+  overrides: Partial<BrowserClientHostedPageInventory> = {}
+): BrowserClientHostedPageInventory => ({
+  ...intent(browserPageId),
+  state: 'active',
+  ...overrides
+})
+
+const priorPageAuthority = (
+  previous: NonNullable<BrowserHostRuntimePageIntent['reclaimFrom']>
+): Partial<BrowserClientHostedPageInventory> => ({
+  authorityRuntimeId: previous.authorityRuntimeId,
+  authorityEpoch: previous.authorityEpoch,
+  browserHostClientId: previous.browserHostClientId,
+  browserHostGeneration: previous.browserHostGeneration,
+  pageHostGeneration: previous.pageHostGeneration
+})
+
+function reconciliationPlan() {
+  const previous = {
+    authorityRuntimeId: 'runtime-old',
+    authorityEpoch: 'epoch-old',
+    browserHostClientId: 'client-a',
+    browserHostGeneration: 4,
+    pageHostGeneration: 12,
+    pairedDeviceId: 'device-a'
+  }
+  return planBrowserHostPageReconciliation(
+    [
+      intent('page-1'),
+      intent('page-2', { reclaimFrom: previous }),
+      intent('page-4'),
+      intent('page-5')
+    ],
+    [
+      page('page-1'),
+      page('page-2', priorPageAuthority(previous)),
+      page('page-3'),
+      page('page-5', { browserProfileId: 'profile-stale' })
+    ],
+    inventorySource
+  )
+}
+
+function actionSpies(): BrowserHostPageReconciliationActions & {
+  order: string[]
+  phaseOneSettled: () => number
+} {
+  const order: string[] = []
+  let settled = 0
+  return {
+    order,
+    phaseOneSettled: () => settled,
+    reclaimPage: vi.fn(async ({ intent: next }) => {
+      order.push(`reclaim:${next.browserPageId}`)
+      settled += 1
+    }),
+    closePage: vi.fn(async (target) => {
+      order.push(`close:${target.browserPageId}`)
+      settled += 1
+    }),
+    restorePage: vi.fn(async (target) => {
+      order.push(`restore:${target.browserPageId}`)
+    })
+  }
+}
+
+describe('browser host page reconciliation executor', () => {
+  afterEach(() => vi.useRealTimers())
+
+  it('proves every reclaim and close before restoring any page', async () => {
+    const plan = reconciliationPlan()
+    const actions = actionSpies()
+    actions.restorePage = vi.fn(async (target) => {
+      expect(actions.phaseOneSettled()).toBe(3)
+      actions.order.push(`restore:${target.browserPageId}`)
+    })
+
+    await expect(
+      executeBrowserHostPageReconciliation(plan, actions, { maxConcurrency: 2 })
+    ).resolves.toEqual({ retained: 1, reclaimed: 1, closed: 2, restored: 2 })
+
+    expect(actions.order.slice(-2).sort()).toEqual(['restore:page-4', 'restore:page-5'])
+  })
+
+  it('attempts every safe phase-one action and blocks every restore after one failure', async () => {
+    const plan = reconciliationPlan()
+    const actions = actionSpies()
+    actions.closePage = vi.fn(async (target) => {
+      actions.order.push(`close:${target.browserPageId}`)
+      if (target.browserPageId === 'page-3') {
+        throw new Error('close outcome unknown')
+      }
+    })
+
+    await expect(
+      executeBrowserHostPageReconciliation(plan, actions, { maxConcurrency: 2 })
+    ).rejects.toMatchObject({
+      message: 'Browser host page reconciliation reclaim/close phase failed',
+      errors: [expect.objectContaining({ message: 'close page-3 failed' })]
+    })
+
+    expect(actions.reclaimPage).toHaveBeenCalledOnce()
+    expect(actions.closePage).toHaveBeenCalledTimes(2)
+    expect(actions.restorePage).not.toHaveBeenCalled()
+  })
+
+  it('bounds action fanout and restores independent pages after the barrier', async () => {
+    const plan = planBrowserHostPageReconciliation(
+      Array.from({ length: 8 }, (_, index) => intent(`page-${index + 10}`)),
+      [],
+      inventorySource
+    )
+    let active = 0
+    let peak = 0
+    let release = (): void => {}
+    const released = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const actions: BrowserHostPageReconciliationActions = {
+      reclaimPage: vi.fn(async () => {}),
+      closePage: vi.fn(async () => {}),
+      restorePage: vi.fn(async () => {
+        active += 1
+        peak = Math.max(peak, active)
+        await released
+        active -= 1
+      })
+    }
+
+    const executing = executeBrowserHostPageReconciliation(plan, actions, { maxConcurrency: 2 })
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(actions.restorePage).toHaveBeenCalledTimes(2)
+    release()
+    await executing
+
+    expect(peak).toBe(2)
+    expect(actions.restorePage).toHaveBeenCalledTimes(8)
+  })
+
+  it('stops scheduling on abort and never crosses the restore barrier', async () => {
+    const plan = reconciliationPlan()
+    const controller = new AbortController()
+    const actions = actionSpies()
+    actions.reclaimPage = vi.fn(async (_pair, signal) => {
+      controller.abort(new Error('authority replaced'))
+      expect(signal.aborted).toBe(true)
+    })
+
+    await expect(
+      executeBrowserHostPageReconciliation(plan, actions, {
+        maxConcurrency: 1,
+        signal: controller.signal
+      })
+    ).rejects.toThrow('Browser host page reconciliation reclaim/close phase failed')
+
+    expect(actions.reclaimPage).toHaveBeenCalledOnce()
+    expect(actions.closePage).not.toHaveBeenCalled()
+    expect(actions.restorePage).not.toHaveBeenCalled()
+  })
+
+  it('starts no action when the parent is already aborted', async () => {
+    const controller = new AbortController()
+    controller.abort(new Error('authority already replaced'))
+    const actions = actionSpies()
+
+    await expect(
+      executeBrowserHostPageReconciliation(reconciliationPlan(), actions, {
+        signal: controller.signal
+      })
+    ).rejects.toThrow('Browser host page reconciliation reclaim/close phase failed')
+
+    expect(actions.reclaimPage).not.toHaveBeenCalled()
+    expect(actions.closePage).not.toHaveBeenCalled()
+    expect(actions.restorePage).not.toHaveBeenCalled()
+  })
+
+  it('reports a synchronous action failure and continues safe phase-one actions', async () => {
+    const actions = actionSpies()
+    actions.reclaimPage = vi.fn(() => {
+      throw new Error('synchronous reclaim rejection')
+    })
+
+    await expect(
+      executeBrowserHostPageReconciliation(reconciliationPlan(), actions, { maxConcurrency: 1 })
+    ).rejects.toMatchObject({
+      errors: [expect.objectContaining({ message: 'reclaim page-2 failed' })]
+    })
+
+    expect(actions.closePage).toHaveBeenCalledTimes(2)
+    expect(actions.restorePage).not.toHaveBeenCalled()
+  })
+
+  it('times out an unsettled close without releasing the restore barrier', async () => {
+    vi.useFakeTimers()
+    const plan = reconciliationPlan()
+    const actions = actionSpies()
+    let actionSignal: AbortSignal | undefined
+    actions.reclaimPage = vi.fn((_pair, signal) => {
+      actionSignal = signal
+      return new Promise<void>(() => {})
+    })
+
+    const executing = executeBrowserHostPageReconciliation(plan, actions, {
+      maxConcurrency: 1,
+      actionTimeoutMs: 25
+    })
+    const rejected = executing.catch((error: unknown) => error)
+    await vi.advanceTimersByTimeAsync(25)
+
+    await expect(rejected).resolves.toMatchObject({
+      message: 'Browser host page reconciliation reclaim/close phase failed'
+    })
+    expect(actionSignal?.aborted).toBe(true)
+    expect(actions.restorePage).not.toHaveBeenCalled()
+  })
+
+  it('cleans the action timer and parent abort listener after settlement', async () => {
+    vi.useFakeTimers()
+    const controller = new AbortController()
+    const addListener = vi.spyOn(controller.signal, 'addEventListener')
+    const removeListener = vi.spyOn(controller.signal, 'removeEventListener')
+
+    await executeBrowserHostPageReconciliation(
+      planBrowserHostPageReconciliation([], [], inventorySource),
+      actionSpies(),
+      { signal: controller.signal }
+    )
+    expect(vi.getTimerCount()).toBe(0)
+    expect(addListener).not.toHaveBeenCalled()
+    expect(removeListener).not.toHaveBeenCalled()
+
+    await executeBrowserHostPageReconciliation(
+      planBrowserHostPageReconciliation([intent('page-30')], [], inventorySource),
+      actionSpies(),
+      { signal: controller.signal }
+    )
+    expect(vi.getTimerCount()).toBe(0)
+    expect(addListener).toHaveBeenCalledTimes(1)
+    expect(removeListener).toHaveBeenCalledTimes(1)
+
+    const failingActions = actionSpies()
+    failingActions.restorePage = vi.fn(async () => {
+      throw new Error('restore failed')
+    })
+    await expect(
+      executeBrowserHostPageReconciliation(
+        planBrowserHostPageReconciliation([intent('page-32')], [], inventorySource),
+        failingActions,
+        { signal: controller.signal }
+      )
+    ).rejects.toThrow('Browser host page reconciliation restore phase failed')
+    expect(vi.getTimerCount()).toBe(0)
+    expect(addListener).toHaveBeenCalledTimes(2)
+    expect(removeListener).toHaveBeenCalledTimes(2)
+  })
+
+  it('handles a late action rejection after timeout', async () => {
+    vi.useFakeTimers()
+    let rejectAction = (_error: Error): void => {}
+    const lateAction = new Promise<void>((_resolve, reject) => {
+      rejectAction = reject
+    })
+    const actions = actionSpies()
+    actions.restorePage = vi.fn(() => lateAction)
+    const executing = executeBrowserHostPageReconciliation(
+      planBrowserHostPageReconciliation([intent('page-31')], [], inventorySource),
+      actions,
+      { actionTimeoutMs: 25 }
+    )
+    const rejected = executing.catch((error: unknown) => error)
+    await vi.advanceTimersByTimeAsync(25)
+    await rejected
+
+    rejectAction(new Error('late action rejection'))
+    await Promise.resolve()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('never restores a close-then-restore page after its exact close fails', async () => {
+    const actions = actionSpies()
+    actions.closePage = vi.fn(async (target) => {
+      if (target.browserPageId === 'page-5') {
+        throw new Error('exact close outcome unknown')
+      }
+    })
+
+    await expect(
+      executeBrowserHostPageReconciliation(reconciliationPlan(), actions)
+    ).rejects.toMatchObject({
+      errors: [expect.objectContaining({ message: 'close page-5 failed' })]
+    })
+    expect(actions.restorePage).not.toHaveBeenCalled()
+  })
+
+  it('attempts every independent restore and reports exact failed actions', async () => {
+    const plan = planBrowserHostPageReconciliation(
+      [intent('page-20'), intent('page-21')],
+      [],
+      inventorySource
+    )
+    const actions = actionSpies()
+    actions.restorePage = vi.fn(async (target) => {
+      if (target.browserPageId === 'page-20') {
+        throw new Error('restore rejected')
+      }
+    })
+
+    await expect(executeBrowserHostPageReconciliation(plan, actions)).rejects.toMatchObject({
+      message: 'Browser host page reconciliation restore phase failed',
+      errors: [expect.objectContaining({ message: 'restore page-20 failed' })]
+    })
+    expect(actions.restorePage).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns an immutable settlement count', async () => {
+    const result = await executeBrowserHostPageReconciliation(reconciliationPlan(), actionSpies())
+
+    expect(result).toEqual({ retained: 1, reclaimed: 1, closed: 2, restored: 2 })
+    expect(Object.isFrozen(result)).toBe(true)
+  })
+
+  it.each([
+    [{ maxConcurrency: 0 }, 'concurrency'],
+    [{ maxConcurrency: 17 }, 'concurrency'],
+    [{ actionTimeoutMs: 0 }, 'timeout'],
+    [{ actionTimeoutMs: 60_001 }, 'timeout']
+  ])('rejects invalid execution limits %#', async (options, errorKind) => {
+    const actions = actionSpies()
+    await expect(
+      executeBrowserHostPageReconciliation(reconciliationPlan(), actions, options)
+    ).rejects.toThrow(`browser_host_page_reconciliation_${errorKind}_invalid`)
+    expect(actions.reclaimPage).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/runtime/browser-host-page-reconciliation-executor.ts
+++ b/src/main/runtime/browser-host-page-reconciliation-executor.ts
@@ -1,0 +1,219 @@
+import type { BrowserClientHostedPageInventory } from '../../shared/browser-client-host-protocol'
+import type {
+  BrowserHostPageReconciliationPlan,
+  BrowserHostRuntimePageIntent
+} from './browser-host-page-reconciliation-plan'
+
+const DEFAULT_MAX_CONCURRENCY = 4
+const MAX_CONCURRENCY = 16
+const DEFAULT_ACTION_TIMEOUT_MS = 15_000
+const MAX_ACTION_TIMEOUT_MS = 60_000
+
+type ReconciliationPair = BrowserHostPageReconciliationPlan['reclaim'][number]
+
+export type BrowserHostPageReconciliationActions = {
+  reclaimPage(pair: ReconciliationPair, signal: AbortSignal): void | Promise<void>
+  closePage(page: BrowserClientHostedPageInventory, signal: AbortSignal): void | Promise<void>
+  restorePage(intent: BrowserHostRuntimePageIntent, signal: AbortSignal): void | Promise<void>
+}
+
+export type BrowserHostPageReconciliationResult = Readonly<{
+  retained: number
+  reclaimed: number
+  closed: number
+  restored: number
+}>
+
+type ReconciliationAction = Readonly<{
+  kind: 'reclaim' | 'close' | 'restore'
+  browserPageId: string
+  run(signal: AbortSignal): void | Promise<void>
+}>
+
+export async function executeBrowserHostPageReconciliation(
+  plan: BrowserHostPageReconciliationPlan,
+  actions: BrowserHostPageReconciliationActions,
+  options: {
+    maxConcurrency?: number
+    actionTimeoutMs?: number
+    signal?: AbortSignal
+  } = {}
+): Promise<BrowserHostPageReconciliationResult> {
+  const maxConcurrency = boundedInteger(
+    options.maxConcurrency,
+    DEFAULT_MAX_CONCURRENCY,
+    MAX_CONCURRENCY,
+    'concurrency'
+  )
+  const actionTimeoutMs = boundedInteger(
+    options.actionTimeoutMs,
+    DEFAULT_ACTION_TIMEOUT_MS,
+    MAX_ACTION_TIMEOUT_MS,
+    'timeout'
+  )
+  const reclaimAndClose = createReclaimAndCloseActions(plan, actions)
+  await executePhase(
+    reclaimAndClose,
+    maxConcurrency,
+    actionTimeoutMs,
+    options.signal,
+    'reclaim/close'
+  )
+  // Ambiguous authority or destruction outcomes require a fresh plan, never an in-place restore.
+  const restore = createRestoreActions(plan, actions)
+  await executePhase(restore, maxConcurrency, actionTimeoutMs, options.signal, 'restore')
+  return Object.freeze({
+    retained: plan.retain.length,
+    reclaimed: plan.reclaim.length,
+    closed: plan.close.length + plan.closeThenRestore.length,
+    restored: plan.restore.length + plan.closeThenRestore.length
+  })
+}
+
+function createReclaimAndCloseActions(
+  plan: BrowserHostPageReconciliationPlan,
+  actions: BrowserHostPageReconciliationActions
+): readonly ReconciliationAction[] {
+  return [
+    ...plan.reclaim.map((pair) =>
+      reconciliationAction('reclaim', pair.intent.browserPageId, (signal) =>
+        actions.reclaimPage(pair, signal)
+      )
+    ),
+    ...plan.close.map((page) =>
+      reconciliationAction('close', page.browserPageId, (signal) => actions.closePage(page, signal))
+    ),
+    ...plan.closeThenRestore.map(({ page }) =>
+      reconciliationAction('close', page.browserPageId, (signal) => actions.closePage(page, signal))
+    )
+  ]
+}
+
+function createRestoreActions(
+  plan: BrowserHostPageReconciliationPlan,
+  actions: BrowserHostPageReconciliationActions
+): readonly ReconciliationAction[] {
+  return [
+    ...plan.restore.map((intent) =>
+      reconciliationAction('restore', intent.browserPageId, (signal) =>
+        actions.restorePage(intent, signal)
+      )
+    ),
+    ...plan.closeThenRestore.map(({ intent }) =>
+      reconciliationAction('restore', intent.browserPageId, (signal) =>
+        actions.restorePage(intent, signal)
+      )
+    )
+  ]
+}
+
+function reconciliationAction(
+  kind: ReconciliationAction['kind'],
+  browserPageId: string,
+  run: ReconciliationAction['run']
+): ReconciliationAction {
+  return Object.freeze({ kind, browserPageId, run })
+}
+
+async function executePhase(
+  actions: readonly ReconciliationAction[],
+  maxConcurrency: number,
+  actionTimeoutMs: number,
+  signal: AbortSignal | undefined,
+  phase: 'reclaim/close' | 'restore'
+): Promise<void> {
+  const failures: (Error | undefined)[] = []
+  let nextIndex = 0
+  const worker = async (): Promise<void> => {
+    while (!signal?.aborted) {
+      const index = nextIndex
+      nextIndex += 1
+      const action = actions[index]
+      if (!action) {
+        return
+      }
+      try {
+        await runReconciliationAction(action, actionTimeoutMs, signal)
+      } catch (error) {
+        failures[index] = new Error(`${action.kind} ${action.browserPageId} failed`, {
+          cause: error
+        })
+      }
+    }
+  }
+  const workers = Math.min(maxConcurrency, actions.length)
+  await Promise.all(Array.from({ length: workers }, worker))
+  if (signal?.aborted) {
+    failures.push(reconciliationAbortError(signal))
+  }
+  const exactFailures = failures.filter((failure): failure is Error => Boolean(failure))
+  if (exactFailures.length > 0) {
+    throw new AggregateError(
+      exactFailures,
+      `Browser host page reconciliation ${phase} phase failed`
+    )
+  }
+}
+
+async function runReconciliationAction(
+  action: ReconciliationAction,
+  timeoutMs: number,
+  parentSignal: AbortSignal | undefined
+): Promise<void> {
+  if (parentSignal?.aborted) {
+    throw reconciliationAbortError(parentSignal)
+  }
+  const controller = new AbortController()
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  let removeParentAbort = (): void => {}
+  const timeoutPromise = new Promise<never>((_resolve, reject) => {
+    timeout = setTimeout(() => {
+      const error = new Error('browser_host_page_reconciliation_action_timeout')
+      reject(error)
+      controller.abort(error)
+    }, timeoutMs)
+  })
+  const parentAbortPromise = new Promise<never>((_resolve, reject) => {
+    if (!parentSignal) {
+      return
+    }
+    const abort = (): void => {
+      const error = reconciliationAbortError(parentSignal)
+      reject(error)
+      controller.abort(error)
+    }
+    parentSignal.addEventListener('abort', abort, { once: true })
+    removeParentAbort = () => parentSignal.removeEventListener('abort', abort)
+  })
+  let actionResult: void | Promise<void>
+  try {
+    actionResult = action.run(controller.signal)
+  } catch (error) {
+    actionResult = Promise.reject(error)
+  }
+  try {
+    await Promise.race([Promise.resolve(actionResult), timeoutPromise, parentAbortPromise])
+  } finally {
+    if (timeout !== undefined) {
+      clearTimeout(timeout)
+    }
+    removeParentAbort()
+  }
+}
+
+function reconciliationAbortError(signal: AbortSignal): Error {
+  return new Error('browser_host_page_reconciliation_aborted', { cause: signal.reason })
+}
+
+function boundedInteger(
+  value: number | undefined,
+  fallback: number,
+  maximum: number,
+  errorKind: 'concurrency' | 'timeout'
+): number {
+  const resolved = value ?? fallback
+  if (!Number.isInteger(resolved) || resolved < 1 || resolved > maximum) {
+    throw new Error(`browser_host_page_reconciliation_${errorKind}_invalid`)
+  }
+  return resolved
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​365 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​365 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​255 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​251 |

<!-- /orca-pr-loc -->

## Summary

- execute immutable client-page reconciliation plans with a global reclaim/close proof barrier before any restore
- bound action fanout and per-action deadlines, propagate parent cancellation, and never retry ambiguous mutations
- attempt independent safe work while reporting exact failed action identities
- register the executor in the existing browser route reliability gate

## Causal evidence

The #14754 tip has a deterministic planner but no executor: the new executor oracle is red because the production module does not exist. The candidate makes every reclaim and close settle positively before restore work can start; any rejection, timeout, or abort blocks all restores and requires a fresh authenticated plan.

## Validation

- focused planner/executor: 2 files / 45 tests
- affected placement, lease, reconnect, command, route, and RPC package: 18 files / 212 tests
- mixed-version terminal wire: 5 / 5
- Node, CLI, and web typecheck
- changed-code quality: zero findings
- 87 reliability gates, max-lines ratchet, localization, skill manifests, formatting, and diff checks
- full lint reaches only the pre-existing origin/main type-aware warning at config/scripts/pr-test-loc-summary.test.mjs:88; native audit and all later lint subchecks pass

## Compatibility and scope

No exchanged field, opcode, capability, payload, publication, placement default, persisted state, SSH/WSL adapter, workspace shape, UI, dependency, or server/offscreen behavior changes. The executor is callback-driven and has no production caller yet, so old clients and current browser placement remain unchanged.

Timeout cancellation is cooperative. Concrete adapters must also fence every late callback by exact authority and generation before this executor is activated.

Linear: [STA-4150](https://linear.app/stably/issue/STA-4150/refactor-remote-browser-to-client-hosted-electron-webviews)

Stacked on #14754. Draft only; do not merge or mark ready.
