### PR TITLE
fix(ci): stringify the fetch URL in the PR test-LoC summary test

### DIFF
--- a/config/scripts/pr-test-loc-summary.test.mjs
+++ b/config/scripts/pr-test-loc-summary.test.mjs
@@ -83,9 +83,12 @@ describe('PR test LoC summary', () => {
       pullNumber: 9,
       token: 'test-token',
       fetchImpl: async (url) => {
-        const page = pages[url]
+        // Why String(): fetchImpl defaults to global fetch, so `url` is typed
+        // RequestInfo | URL. Only the string form is a usable lookup key here.
+        const requestedUrl = String(url)
+        const page = pages[requestedUrl]
         if (page == null) {
-          throw new Error(`unexpected url ${url}`)
+          throw new Error(`unexpected url ${requestedUrl}`)
         }
         return {
           ok: true,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | +5 | −2 | +3 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## Why

`audit:code-quality:type-aware` currently fails on `main`, which fails the **static analysis** job on every PR opened against it (seen on #14749 and #14750):

```
config/scripts/pr-test-loc-summary.test.mjs:88:45: Invalid type used in template literal expression.
```

`listPullFiles` defaults `fetchImpl` to the global `fetch`, so the test double's `url` parameter is typed `RequestInfo | URL`. That union includes `Request`, which has no meaningful string form, so interpolating it into a template literal trips `typescript(restrict-template-expressions)`.

This landed green in #14738 but fails on `main` now, so it needs an explicit fix rather than a re-run.

## Change

Take the string form once and use it for both the page lookup and the error message. Behavior is identical — the keys were always strings.

## Verification

- `pnpm run audit:code-quality:type-aware`: exit 0
- `config/scripts/pr-test-loc-summary.test.mjs`: 8 tests passing

Unblocks #14749 and #14750.