### PR TITLE
feat(browser): negotiate page reconciliation commands

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -2590,13 +2590,14 @@
         "same-socket paired-runtime control requests",
         "paired desktop browser-host lifecycle composition",
         "bounded client-page reconciliation execution",
+        "capability-gated client-page reconciliation commands",
         "dedicated paired-runtime E2EE tunnel subscription"
       ],
       "platforms": ["macos", "linux", "windows"],
       "providers": ["local", "remote-runtime", "ssh", "wsl"],
       "coveredPlatforms": ["macos"],
       "coveredProviders": ["remote-runtime", "ssh"],
-      "coverageNotes": "Deterministic protocol, registry, injected-socket, and loopback-listener tests cover strict framing, remote-DNS targets, exact destination-write and source-consumption credit, at most 16 pending opens, 128 admitted opens per 10-second monotonic window, an 8 MiB per-route application-buffer ledger, shared 32 MiB browser-host and 128 MiB process ledgers across application copies, encrypted client queues, and native WebSocket bufferedAmount, bounded byte/claim/socket-source counts, a four-frame queued-drain quantum, authority epochs, exact host selection, one host per authenticated connection, four hosts per paired device, eight global browser-host polls with four per authenticated paired device, a shared ask/host ceiling that retains one quarter for waits, bounded initial and reconnect runtime_busy recovery, long-poll metering and disconnect abort, monotonic host/page/route generations without page tombstones, two-phase exact page retirement with cancellation, connection-owned cleanup, exact client revocation, stale and replaced fences, retired stream IDs, half-close and close ordering, SOCKS CONNECT, bind/close races, listener wildcard normalization, unsupported commands, unavailable routes, and raw/terminal binary-handler isolation. Page commands use a separately echoed v1 attach negotiation, exact authority/host/page generations, bounded command IDs and sequences, and bounded create/navigate payloads; legacy attaches still receive only the unchanged ready/revoked event shapes. An inert client dispatcher additionally proves per-page FIFO execution, exact payload-matched duplicate replay, frozen command/result snapshots, a global retired-generation floor, transactional admission, bounded pages/active commands/queues/per-page and global result cache/concurrency, create dependency failure, cancellation, deduplicated retirement joining, and bounded close without late-result overwrite. The server ledger owns issue order and immutable command/result snapshots, bounds outstanding commands, pages, and per-page/global replay caches, validates the shared wire payload before admission, requires live delivery and exact placement, authenticates results to the negotiated connection and paired lease, rejects gaps and conflicting replay, and fences outstanding outcomes at exact retirement. Negotiated command results reuse the authenticated attach socket through bounded nested JSON requests; exact ID routing, reverse-order replies, unknown and duplicate IDs, timeout teardown, serialization failure, aggregate queue accounting, acknowledgement validation, and the unchanged non-v1 path are deterministic. A stable local listener rejects CONNECT while offline or reconnecting, retains its address across replacement, requires a strictly increasing tunnel generation, ignores late superseded callbacks, propagates tunnel protocol failure to the route owner, and recycles exhausted stream IDs only after generation replacement. Reconnect uses the unchanged native v1 attach payload and capability pair; SSH descriptors alone add an execution-host capability and require a runtime-minted grant bound to the exact browser-host lease. Exact SSH provider epoch and connection generation fence ssh2 forwardOut and one non-interactive standalone system-SSH dynamic forward per route. Unit tests preserve domain-form SOCKS requests, sanitize remote errors, bound stderr, cancel startup, release timed-out and synchronously failed sockets, and release routes once. An ephemeral Docker sshd resolves a container-only domain and returns a unique HTTP marker through both ssh2 and the actual system-OpenSSH dynamic-forward adapter without touching the user's SSH files; authority loss fences the ssh2 route. The execution runtime charges route application bytes to the same per-host/process policy; its existing E2EE owner separately caps native outbound buffers process-wide. Explicitly injected browser-host and paired-runtime methods lease one exact host, prove attach, command delivery, and result settlement share one exact connection identity, then carry SOCKS and HTTP bytes over a dedicated E2EE socket to the fenced execution-host revision and prove route close destroys the destination socket. The production-inert desktop adapter now composes one exact host per environment pairing revision with the page executor, current renderer selector, route Session/WebContents registries, and one reference-counted route per canonical execution-host key. Negotiated same-client control reconnect retains exact authority, placements, grants, dispatcher dedupe, executor guests, and listener addresses; it fences tunnels immediately, blocks route admission, reattaches command delivery only after ready, and replays unsettled commands without repeating completed mutations. Terminal release, replacement, legacy disconnect, and reconnect-grace expiry make only the exact host generation's client placements non-cancellable retirement-pending while retaining capacity until exact cleanup; reconnect grace preserves them. Environment replacement and app shutdown still serialize transport closure before page cleanup and force-close every remaining route. The starter has no production caller, and host/tunnel capabilities remain unadvertised. Node stream-internal high-water bytes, strict cross-route scheduling, WSL, and physical cross-platform evidence remain uncovered.",
+      "coverageNotes": "Deterministic protocol, registry, injected-socket, and loopback-listener tests cover strict framing, remote-DNS targets, exact destination-write and source-consumption credit, at most 16 pending opens, 128 admitted opens per 10-second monotonic window, an 8 MiB per-route application-buffer ledger, shared 32 MiB browser-host and 128 MiB process ledgers across application copies, encrypted client queues, and native WebSocket bufferedAmount, bounded byte/claim/socket-source counts, a four-frame queued-drain quantum, authority epochs, exact host selection, one host per authenticated connection, four hosts per paired device, eight global browser-host polls with four per authenticated paired device, a shared ask/host ceiling that retains one quarter for waits, bounded initial and reconnect runtime_busy recovery, long-poll metering and disconnect abort, monotonic host/page/route generations without page tombstones, two-phase exact page retirement with cancellation, connection-owned cleanup, exact client revocation, stale and replaced fences, retired stream IDs, half-close and close ordering, SOCKS CONNECT, bind/close races, listener wildcard normalization, unsupported commands, unavailable routes, and raw/terminal binary-handler isolation. Page commands use a separately echoed v1 attach negotiation, exact authority/host/page generations, bounded command IDs and sequences, and bounded create/navigate payloads; legacy attaches still receive only the unchanged ready/revoked event shapes. A second optional reconciliation subprotocol gates bounded reclaim, close, and restore payloads behind exact attach/ready echo, complete inventory, command negotiation, reconnect authority, and command-result authority; the production client does not advertise it. An inert client dispatcher additionally proves per-page FIFO execution, exact payload-matched duplicate replay, frozen command/result snapshots, a global retired-generation floor, transactional admission, bounded pages/active commands/queues/per-page and global result cache/concurrency, create dependency failure, cancellation, deduplicated retirement joining, and bounded close without late-result overwrite. The server ledger owns issue order and immutable command/result snapshots, bounds outstanding commands, pages, and per-page/global replay caches, validates the shared wire payload before admission, requires live delivery and exact placement, authenticates results to the negotiated connection and paired lease, rejects gaps and conflicting replay, and fences outstanding outcomes at exact retirement. Negotiated command results reuse the authenticated attach socket through bounded nested JSON requests; exact ID routing, reverse-order replies, unknown and duplicate IDs, timeout teardown, serialization failure, aggregate queue accounting, acknowledgement validation, and the unchanged non-v1 path are deterministic. A stable local listener rejects CONNECT while offline or reconnecting, retains its address across replacement, requires a strictly increasing tunnel generation, ignores late superseded callbacks, propagates tunnel protocol failure to the route owner, and recycles exhausted stream IDs only after generation replacement. Reconnect uses the unchanged native v1 attach payload and capability pair; SSH descriptors alone add an execution-host capability and require a runtime-minted grant bound to the exact browser-host lease. Exact SSH provider epoch and connection generation fence ssh2 forwardOut and one non-interactive standalone system-SSH dynamic forward per route. Unit tests preserve domain-form SOCKS requests, sanitize remote errors, bound stderr, cancel startup, release timed-out and synchronously failed sockets, and release routes once. An ephemeral Docker sshd resolves a container-only domain and returns a unique HTTP marker through both ssh2 and the actual system-OpenSSH dynamic-forward adapter without touching the user's SSH files; authority loss fences the ssh2 route. The execution runtime charges route application bytes to the same per-host/process policy; its existing E2EE owner separately caps native outbound buffers process-wide. Explicitly injected browser-host and paired-runtime methods lease one exact host, prove attach, command delivery, and result settlement share one exact connection identity, then carry SOCKS and HTTP bytes over a dedicated E2EE socket to the fenced execution-host revision and prove route close destroys the destination socket. The production-inert desktop adapter now composes one exact host per environment pairing revision with the page executor, current renderer selector, route Session/WebContents registries, and one reference-counted route per canonical execution-host key. Negotiated same-client control reconnect retains exact authority, placements, grants, dispatcher dedupe, executor guests, and listener addresses; it fences tunnels immediately, blocks route admission, reattaches command delivery only after ready, and replays unsettled commands without repeating completed mutations. Terminal release, replacement, legacy disconnect, and reconnect-grace expiry make only the exact host generation's client placements non-cancellable retirement-pending while retaining capacity until exact cleanup; reconnect grace preserves them. Environment replacement and app shutdown still serialize transport closure before page cleanup and force-close every remaining route. The starter has no production caller, and host/tunnel capabilities remain unadvertised. Node stream-internal high-water bytes, strict cross-route scheduling, WSL, and physical cross-platform evidence remain uncovered.",
       "motivatingLinks": [
         "https://linear.app/stably/issue/STA-4150/refactor-remote-browser-to-client-hosted-electron-webviews"
       ],
@@ -2606,6 +2607,7 @@
         "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/browser-host-page-retirement.test.ts src/main/runtime/browser-host-page-placement-replacement.test.ts src/main/runtime/browser-host-page-placement.test.ts src/main/runtime/browser-host-lease-registry.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/browser-host-lease-placement-retirement.test.ts src/main/runtime/browser-host-page-retirement.test.ts src/main/runtime/browser-host-page-placement-replacement.test.ts src/main/runtime/browser-host-page-placement.test.ts src/main/runtime/browser-host-lease-registry.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/browser-host-page-reconciliation-plan.test.ts src/main/runtime/browser-host-page-reconciliation-executor.test.ts",
+        "pnpm exec vitest run --config config/vitest.config.ts src/shared/browser-client-host-reconciliation-protocol.test.ts src/main/browser/paired-runtime-browser-host-reconciliation-negotiation.test.ts src/main/runtime/rpc/methods/browser-client-host-reconciliation.test.ts src/main/runtime/browser-host-lease-registry.test.ts src/main/browser/paired-runtime-browser-client-host.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/shared/browser-client-host-protocol.test.ts src/main/browser/browser-client-host-attach-request.test.ts src/main/browser/browser-client-page-command-executor.test.ts src/main/browser/browser-client-page-command-integration.test.ts src/main/browser/browser-client-page-inventory.test.ts src/main/browser/paired-runtime-browser-client-host-composition.test.ts src/main/browser/paired-runtime-browser-client-host.test.ts src/main/browser/paired-runtime-browser-host-lease.test.ts src/main/runtime/browser-host-lease-registry.test.ts src/main/runtime/rpc/methods/browser-client-host.test.ts src/main/runtime/browser-host-page-reconciliation-plan.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/shared/browser-network-capabilities.test.ts src/shared/browser-network-tunnel-protocol.test.ts src/main/browser/browser-network-tunnel-session.test.ts src/main/browser/remote-browser-socks-server.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/main/browser/browser-network-tunnel-client.test.ts src/main/browser/paired-runtime-browser-network-route.test.ts src/main/runtime/runtime-binary-message-router.test.ts src/main/runtime/rpc/methods/browser-network-tunnel.test.ts src/main/runtime/browser-network-tunnel-paired-runtime.integration.test.ts",
@@ -2629,6 +2631,7 @@
       "testFiles": [
         "src/shared/browser-network-capabilities.test.ts",
         "src/shared/browser-client-host-protocol.test.ts",
+        "src/shared/browser-client-host-reconciliation-protocol.test.ts",
         "src/shared/browser-network-tunnel-protocol.test.ts",
         "src/main/runtime/browser-host-lease-placement-retirement.test.ts",
         "src/main/runtime/browser-host-page-retirement.test.ts",
@@ -2641,8 +2644,10 @@
         "src/main/runtime/browser-host-lease-registry.test.ts",
         "src/main/runtime/runtime-rpc-browser-host-admission.test.ts",
         "src/main/runtime/rpc/methods/browser-client-host.test.ts",
+        "src/main/runtime/rpc/methods/browser-client-host-reconciliation.test.ts",
         "src/main/browser/paired-runtime-browser-host-lease.test.ts",
         "src/main/browser/paired-runtime-browser-host-lease-reconnect.test.ts",
+        "src/main/browser/paired-runtime-browser-host-reconciliation-negotiation.test.ts",
         "src/main/browser/browser-host-lease-reconnect-delay.test.ts",
         "src/main/browser/paired-runtime-browser-client-host.test.ts",
         "src/main/browser/paired-runtime-browser-client-host-reconnect.test.ts",
@@ -2745,7 +2750,10 @@
             "page placement generations are monotonic and stale lease authority is rejected",
             "incomplete, unsupported-version, duplicate, over-budget, and foreign-client inventories fail before lease replacement",
             "a previous-runtime inventory remains eligible for exact persisted-authority restart reconciliation",
-            "the exact authenticated lease retains an immutable inventory snapshot"
+            "the exact authenticated lease retains an immutable inventory snapshot",
+            "reconciliation requires command and complete-inventory negotiation",
+            "reconnect cannot change reconciliation negotiation in place",
+            "legacy command leases reject reconciliation variants before delivery"
           ]
         },
         {
@@ -2767,6 +2775,15 @@
             "create and navigate commands bind bounded IDs and sequences to exact runtime, epoch, host, and page generations",
             "unknown versions, command kinds, invalid generations, and oversized identities fail before delivery",
             "command-result acknowledgements require an explicit boolean accepted field"
+          ]
+        },
+        {
+          "file": "src/shared/browser-client-host-reconciliation-protocol.test.ts",
+          "assertions": [
+            "old attach and ready decoders strip the optional reconciliation version",
+            "reclaim, close, and restore commands require exact reconciliation negotiation",
+            "reclaim and close bind the previous page to exact authority while restore inputs remain bounded",
+            "legacy create and navigate command payloads remain unchanged"
           ]
         },
         {
@@ -2795,6 +2812,15 @@
             "malformed and unsolicited reconnect echoes fail closed",
             "outstanding command replay reuses exact active result admissions without double-charging settlement capacity",
             "an unencodable reconnect inventory cannot silently replace exact authority or fall back to legacy"
+          ]
+        },
+        {
+          "file": "src/main/browser/paired-runtime-browser-host-reconciliation-negotiation.test.ts",
+          "assertions": [
+            "the optional reconciliation request is retained only after exact ready echo",
+            "an older host can omit the echo without enabling reconciliation",
+            "unsolicited and dependency-inconsistent echoes fail closed",
+            "exact reconnect rejects reconciliation downgrade"
           ]
         },
         {
@@ -2947,6 +2973,13 @@
             "exact duplicate results are idempotent while conflicts and stale or retired placement fail closed",
             "a second browser-host identity on one authenticated connection is rejected",
             "legacy cleanup emits exact revocation while negotiated cleanup enters bounded unavailable grace"
+          ]
+        },
+        {
+          "file": "src/main/runtime/rpc/methods/browser-client-host-reconciliation.test.ts",
+          "assertions": [
+            "the authenticated server echoes and retains reconciliation only when explicitly requested",
+            "command result settlement requires the exact negotiated reconciliation authority"
           ]
         },
         {

--- a/docs/sta-4150-client-hosted-browser-progress.md
+++ b/docs/sta-4150-client-hosted-browser-progress.md
@@ -716,6 +716,38 @@ Published reconciliation-execution stage (#14756):
 - Draft PR [#14756](https://github.com/stablyai/orca/pull/14756) stacks on #14754 and remains draft.
   GitHub auto-attached it to STA-4150; the ticket remains In Progress.
 
+Published reconciliation-command-contract stage (#14759):
+
+- Baseline: the shared command-schema oracle failed 3 of 5 assertions because reclaim, close, and
+  restore variants plus their negotiation did not exist. Client attach failed to retain the
+  optional version, and the authenticated server neither retained nor echoed it.
+- Candidate: a separate optional `pageReconciliationProtocolVersion: 1` is valid only beside page
+  commands and complete page inventory. The server retains and echoes it only after an explicit
+  authenticated request; the client enables it only after an exact ready echo and rejects
+  unsolicited, dependency-inconsistent, or in-place reconnect changes.
+- Reclaim and close payloads bind an exact prior authority; restore carries bounded profile,
+  execution-host, and optional URL inputs. Legacy create/navigate payloads are unchanged. Central
+  server admission rejects every reconciliation variant before delivery to a legacy v1 command
+  lease, and command-result settlement requires the exact negotiated reconciliation authority.
+- Old attach and ready decoders strip the optional field. An old server can omit the echo and the
+  new client safely disables reconciliation. The current production `PairedRuntimeBrowserClientHost`
+  composition deliberately does not advertise the new subprotocol, so no new command, placement,
+  publication, or page mutation is active yet.
+- Focused protocol/client/server coverage passes 6 files / 58 tests; the broader host lease,
+  reconnect, command, reconciliation, and RPC surface passes 21 files / 219 tests; mixed-version
+  terminal wire passes 5/5. On `origin/main@931cb037c5`, Node/CLI/web typecheck, full lint and
+  audits, changed-code quality, the 87-gate reliability manifest, max-lines, skill manifests,
+  localization, formatting, and diff checks pass.
+- All 36 stack patches rebased conflict-free from `origin/main@5b7f44278a` to
+  `origin/main@931cb037c5`; `git range-diff` marks every patch identical. The only intervening main
+  change fixes the previously known unrelated type-aware warning and overlaps no STA-4150 file.
+- Fresh security/resource/mobile/cross-platform review found no actionable issue. The stage adds no
+  dependency, network sink, path/shell behavior, timer, retry loop, cache, persisted state, mobile
+  route/framing, UI, SSH/WSL branch, or server/offscreen behavior. Concrete reclaim/close/restore
+  adapters and their exact page-authority rekeying remain the next stage.
+- Draft PR [#14759](https://github.com/stablyai/orca/pull/14759) stacks on #14756 and remains draft.
+  GitHub auto-attached it to STA-4150; the ticket remains In Progress.
+
 Do not promote narrow deterministic evidence into a live-topology claim. Record exact commands,
 topology, versions, and explicit gaps at every later checkpoint.
 
@@ -790,6 +822,17 @@ topology, versions, and explicit gaps at every later checkpoint.
   changed, and no PR was merged or marked ready.
 - GitHub auto-attached #14756 to STA-4150. Posted exactly one reconciliation-executor checkpoint
   comment (`3957ea40-a9e2-4b25-9197-2f972166f47b`) and kept the ticket In Progress.
+- Updated the Orca worktree comment after validating the reconciliation-command-contract candidate.
+- Locally rebased all 36 STA-4150 patches onto `origin/main@931cb037c5` and confirmed every patch
+  identical by `git range-diff`. Safety pointer `sta-4150-safety-pre-931c-rebase-20260815` retains
+  the pre-rebase series. No rewritten branch or new stage branch has been pushed at this checkpoint.
+- Atomically force-pushed all 34 existing public stack branches with exact remote-OID leases and
+  created `sta-4150-browser-reconciliation-command-contracts` with a must-not-exist lease. The
+  first local count assertion expected 35 published branches and failed before invoking `git push`;
+  the corrected 34-branch transaction updated all refs together.
+- Opened draft PR [#14759](https://github.com/stablyai/orca/pull/14759) on #14756. GitHub
+  auto-attached it to STA-4150; posted exactly one reconciliation-contract checkpoint comment
+  (`b775afbd-fb75-42bf-bee3-8d8ca0877b33`) and kept the ticket In Progress.
 - No PR was merged or marked ready.
 
 ## Completion rule

--- a/src/main/browser/browser-client-host-attach-request.ts
+++ b/src/main/browser/browser-client-host-attach-request.ts
@@ -17,6 +17,15 @@ export function assertBrowserClientHostAttachOptions(
   ) {
     throw new Error('Browser host reconnect requires page inventory negotiation')
   }
+  if (
+    options.pageReconciliationProtocolVersion !== undefined &&
+    (options.pageCommandProtocolVersion !== 1 ||
+      options.onPageCommand === undefined ||
+      options.pageInventoryProtocolVersion !== 1 ||
+      options.getPageInventory === undefined)
+  ) {
+    throw new Error('Browser page reconciliation requires command and inventory negotiation')
+  }
 }
 
 export function createBrowserClientHostAttachRequest(
@@ -34,6 +43,10 @@ export function createBrowserClientHostAttachRequest(
   const leaseReconnectProtocolVersion = pageInventoryProtocolVersion
     ? options.leaseReconnectProtocolVersion
     : undefined
+  const pageReconciliationProtocolVersion =
+    pageCommandProtocolVersion && pageInventoryProtocolVersion
+      ? options.pageReconciliationProtocolVersion
+      : undefined
   const params = BrowserClientHostAttachParams.parse({
     authorityRuntimeId: options.authorityRuntimeId,
     browserHostClientId: options.browserHostClientId,
@@ -45,12 +58,14 @@ export function createBrowserClientHostAttachRequest(
           pageInventory
         }
       : {}),
-    ...(leaseReconnectProtocolVersion ? { leaseReconnectProtocolVersion } : {})
+    ...(leaseReconnectProtocolVersion ? { leaseReconnectProtocolVersion } : {}),
+    ...(pageReconciliationProtocolVersion ? { pageReconciliationProtocolVersion } : {})
   })
   return {
     pageCommandProtocolVersion,
     pageInventoryProtocolVersion,
     leaseReconnectProtocolVersion,
+    pageReconciliationProtocolVersion,
     params
   }
 }

--- a/src/main/browser/browser-client-host-command-authority.ts
+++ b/src/main/browser/browser-client-host-command-authority.ts
@@ -9,6 +9,7 @@ export function assertBrowserClientHostCommandAuthority(
 ): void {
   if (
     command.pageCommandProtocolVersion !== authority.pageCommandProtocolVersion ||
+    command.pageReconciliationProtocolVersion !== authority.pageReconciliationProtocolVersion ||
     command.authorityRuntimeId !== authority.authorityRuntimeId ||
     command.authorityEpoch !== authority.authorityEpoch ||
     command.browserHostClientId !== authority.browserHostClientId ||
@@ -35,6 +36,7 @@ export function sameBrowserClientHostLeaseAuthority(
     left.browserHostGeneration === right.browserHostGeneration &&
     left.pageCommandProtocolVersion === right.pageCommandProtocolVersion &&
     left.pageInventoryProtocolVersion === right.pageInventoryProtocolVersion &&
-    left.leaseReconnectProtocolVersion === right.leaseReconnectProtocolVersion
+    left.leaseReconnectProtocolVersion === right.leaseReconnectProtocolVersion &&
+    left.pageReconciliationProtocolVersion === right.pageReconciliationProtocolVersion
   )
 }

--- a/src/main/browser/browser-host-command-result-submission.ts
+++ b/src/main/browser/browser-host-command-result-submission.ts
@@ -18,6 +18,9 @@ export async function submitBrowserHostCommandResult(
     'browser.clientHost.commandResult',
     {
       pageCommandProtocolVersion: command.pageCommandProtocolVersion,
+      ...(command.pageReconciliationProtocolVersion
+        ? { pageReconciliationProtocolVersion: command.pageReconciliationProtocolVersion }
+        : {}),
       authorityRuntimeId: command.authorityRuntimeId,
       authorityEpoch: command.authorityEpoch,
       browserHostClientId: command.browserHostClientId,

--- a/src/main/browser/paired-runtime-browser-client-host.test.ts
+++ b/src/main/browser/paired-runtime-browser-client-host.test.ts
@@ -57,6 +57,9 @@ describe('PairedRuntimeBrowserClientHost', () => {
       expect.any(Object),
       expect.any(Object)
     )
+    expect(subscribeRemoteRuntimeRequestMock.mock.calls[0]?.[2]).not.toHaveProperty(
+      'pageReconciliationProtocolVersion'
+    )
     callbacks.current!.onResponse(readyResponse())
     await starting
     await host.close()

--- a/src/main/browser/paired-runtime-browser-host-lease-connection.ts
+++ b/src/main/browser/paired-runtime-browser-host-lease-connection.ts
@@ -191,7 +191,13 @@ export class PairedRuntimeBrowserHostLeaseConnection {
         ready.leaseReconnectProtocolVersion,
         request.leaseReconnectProtocolVersion
       ) ||
+      !matchesOptionalProtocol(
+        ready.pageReconciliationProtocolVersion,
+        request.pageReconciliationProtocolVersion
+      ) ||
       (ready.leaseReconnectProtocolVersion === 1 && ready.pageInventoryProtocolVersion !== 1) ||
+      (ready.pageReconciliationProtocolVersion === 1 &&
+        (ready.pageCommandProtocolVersion !== 1 || ready.pageInventoryProtocolVersion !== 1)) ||
       (this.options.reconnect && ready.leaseReconnectProtocolVersion !== 1)
     ) {
       this.fail(new Error('Invalid browser host lease response'))
@@ -261,6 +267,9 @@ function browserHostLeaseAuthority(
       : {}),
     ...(ready.leaseReconnectProtocolVersion
       ? { leaseReconnectProtocolVersion: ready.leaseReconnectProtocolVersion }
+      : {}),
+    ...(ready.pageReconciliationProtocolVersion
+      ? { pageReconciliationProtocolVersion: ready.pageReconciliationProtocolVersion }
       : {})
   })
 }

--- a/src/main/browser/paired-runtime-browser-host-lease-options.ts
+++ b/src/main/browser/paired-runtime-browser-host-lease-options.ts
@@ -14,6 +14,7 @@ export type PairedRuntimeBrowserHostLeaseOptions = {
   hostCapabilities: readonly string[]
   pageCommandProtocolVersion?: 1
   pageInventoryProtocolVersion?: 1
+  pageReconciliationProtocolVersion?: 1
   leaseReconnectProtocolVersion?: 1
   getPageInventory?: () => readonly BrowserClientHostedPageInventory[]
   onPageCommand?: (

--- a/src/main/browser/paired-runtime-browser-host-lease.ts
+++ b/src/main/browser/paired-runtime-browser-host-lease.ts
@@ -212,7 +212,8 @@ export class PairedRuntimeBrowserHostLease {
     if (
       !authority?.pageCommandProtocolVersion ||
       !this.options.onPageCommand ||
-      command.pageCommandProtocolVersion !== authority.pageCommandProtocolVersion
+      command.pageCommandProtocolVersion !== authority.pageCommandProtocolVersion ||
+      command.pageReconciliationProtocolVersion !== authority.pageReconciliationProtocolVersion
     ) {
       this.failTerminal(new Error('Unnegotiated browser host page command'))
       return

--- a/src/main/browser/paired-runtime-browser-host-reconciliation-negotiation.test.ts
+++ b/src/main/browser/paired-runtime-browser-host-reconciliation-negotiation.test.ts
@@ -1,0 +1,198 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { PairingOffer } from '../../shared/pairing'
+import type {
+  RemoteRuntimeSubscription,
+  RemoteRuntimeSubscriptionCallbacks
+} from '../../shared/remote-runtime-client'
+import { RemoteRuntimeClientError } from '../../shared/remote-runtime-client-error'
+
+const { subscribeRemoteRuntimeRequestMock } = vi.hoisted(() => ({
+  subscribeRemoteRuntimeRequestMock: vi.fn()
+}))
+
+vi.mock('../../shared/remote-runtime-client', () => ({
+  subscribeRemoteRuntimeRequest: subscribeRemoteRuntimeRequestMock
+}))
+
+import { PairedRuntimeBrowserHostLease } from './paired-runtime-browser-host-lease'
+import type { PairedRuntimeBrowserHostLeaseOptions } from './paired-runtime-browser-host-lease-options'
+
+const pairing = {
+  v: 2,
+  endpoint: 'ws://127.0.0.1:6768',
+  deviceToken: 'device-token',
+  publicKeyB64: 'public-key',
+  pairedDeviceId: 'device-a',
+  scope: 'runtime'
+} as PairingOffer
+
+afterEach(() => {
+  subscribeRemoteRuntimeRequestMock.mockReset()
+})
+
+describe('paired runtime browser-host reconciliation negotiation', () => {
+  it('requests and retains an exact echoed reconciliation protocol', async () => {
+    const callbacks: { current?: RemoteRuntimeSubscriptionCallbacks } = {}
+    const close = vi.fn()
+    subscribeRemoteRuntimeRequestMock.mockImplementationOnce(
+      async (...args: unknown[]): Promise<RemoteRuntimeSubscription> => {
+        callbacks.current = args[4] as RemoteRuntimeSubscriptionCallbacks
+        return {
+          requestId: 'browser-host',
+          close,
+          sendBinary: () => false,
+          sendRequest: vi.fn()
+        }
+      }
+    )
+    const lease = createLease()
+    const starting = lease.start()
+    await vi.waitFor(() => expect(callbacks.current).toBeDefined())
+
+    expect(subscribeRemoteRuntimeRequestMock.mock.calls[0]?.[2]).toMatchObject({
+      pageCommandProtocolVersion: 1,
+      pageInventoryProtocolVersion: 1,
+      pageInventory: [],
+      pageReconciliationProtocolVersion: 1
+    })
+    callbacks.current!.onResponse(readyResponse({ pageReconciliationProtocolVersion: 1 }))
+    await expect(starting).resolves.toMatchObject({ pageReconciliationProtocolVersion: 1 })
+    await lease.close()
+    expect(close).toHaveBeenCalledOnce()
+  })
+
+  it('falls back without enabling reconciliation when an older host omits the echo', async () => {
+    const callbacks: { current?: RemoteRuntimeSubscriptionCallbacks } = {}
+    subscribeRemoteRuntimeRequestMock.mockImplementationOnce(
+      async (...args: unknown[]): Promise<RemoteRuntimeSubscription> => {
+        callbacks.current = args[4] as RemoteRuntimeSubscriptionCallbacks
+        return {
+          requestId: 'browser-host',
+          close: vi.fn(),
+          sendBinary: () => false,
+          sendRequest: vi.fn()
+        }
+      }
+    )
+    const lease = createLease()
+    const starting = lease.start()
+    await vi.waitFor(() => expect(callbacks.current).toBeDefined())
+    callbacks.current!.onResponse(readyResponse())
+
+    await expect(starting).resolves.not.toHaveProperty('pageReconciliationProtocolVersion')
+    await lease.close()
+  })
+
+  it('rejects an unsolicited or dependency-inconsistent reconciliation echo', async () => {
+    const callbacks: { current?: RemoteRuntimeSubscriptionCallbacks } = {}
+    subscribeRemoteRuntimeRequestMock.mockImplementation(
+      async (...args: unknown[]): Promise<RemoteRuntimeSubscription> => {
+        callbacks.current = args[4] as RemoteRuntimeSubscriptionCallbacks
+        return {
+          requestId: 'browser-host',
+          close: vi.fn(),
+          sendBinary: () => false,
+          sendRequest: vi.fn()
+        }
+      }
+    )
+    const unsolicited = createLease({ pageReconciliationProtocolVersion: undefined })
+    const unsolicitedStart = unsolicited.start()
+    await vi.waitFor(() => expect(callbacks.current).toBeDefined())
+    callbacks.current!.onResponse(readyResponse({ pageReconciliationProtocolVersion: 1 }))
+    await expect(unsolicitedStart).rejects.toThrow('Invalid browser host lease response')
+
+    subscribeRemoteRuntimeRequestMock.mockReset()
+    callbacks.current = undefined
+    subscribeRemoteRuntimeRequestMock.mockImplementation(
+      async (...args: unknown[]): Promise<RemoteRuntimeSubscription> => {
+        callbacks.current = args[4] as RemoteRuntimeSubscriptionCallbacks
+        return {
+          requestId: 'browser-host',
+          close: vi.fn(),
+          sendBinary: () => false,
+          sendRequest: vi.fn()
+        }
+      }
+    )
+    const inconsistent = createLease()
+    const inconsistentStart = inconsistent.start()
+    await vi.waitFor(() => expect(callbacks.current).toBeDefined())
+    callbacks.current!.onResponse({
+      ...readyResponse({ pageReconciliationProtocolVersion: 1 }),
+      result: {
+        ...readyResponse({ pageReconciliationProtocolVersion: 1 }).result,
+        pageInventoryProtocolVersion: undefined
+      }
+    })
+    await expect(inconsistentStart).rejects.toThrow('Invalid browser host lease response')
+  })
+
+  it('rejects reconciliation downgrade during exact reconnect', async () => {
+    const callbacks: RemoteRuntimeSubscriptionCallbacks[] = []
+    const onError = vi.fn()
+    subscribeRemoteRuntimeRequestMock.mockImplementation(
+      async (...args: unknown[]): Promise<RemoteRuntimeSubscription> => {
+        callbacks.push(args[4] as RemoteRuntimeSubscriptionCallbacks)
+        return {
+          requestId: `browser-host-${callbacks.length}`,
+          close: vi.fn(),
+          sendBinary: () => false,
+          sendRequest: vi.fn()
+        }
+      }
+    )
+    const lease = createLease({ reconnectRetryDelayMs: 1, onError })
+    const starting = lease.start()
+    await vi.waitFor(() => expect(callbacks).toHaveLength(1))
+    callbacks[0]!.onResponse(readyResponse({ pageReconciliationProtocolVersion: 1 }))
+    await starting
+
+    callbacks[0]!.onError(
+      new RemoteRuntimeClientError('remote_runtime_unavailable', 'transport closed')
+    )
+    await vi.waitFor(() => expect(callbacks).toHaveLength(2))
+    callbacks[1]!.onResponse(readyResponse())
+    await vi.waitFor(() => expect(onError).toHaveBeenCalledOnce())
+
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Browser host lease authority changed in place' })
+    )
+    await lease.close()
+  })
+})
+
+function createLease(
+  overrides: Partial<PairedRuntimeBrowserHostLeaseOptions> = {}
+): PairedRuntimeBrowserHostLease {
+  return new PairedRuntimeBrowserHostLease({
+    pairing,
+    authorityRuntimeId: 'runtime-a',
+    browserHostClientId: 'host-a',
+    hostCapabilities: ['webview'],
+    pageCommandProtocolVersion: 1,
+    pageInventoryProtocolVersion: 1,
+    pageReconciliationProtocolVersion: 1,
+    leaseReconnectProtocolVersion: 1,
+    getPageInventory: () => [],
+    onPageCommand: async () => ({ status: 'completed' }),
+    ...overrides
+  })
+}
+
+function readyResponse(overrides: { pageReconciliationProtocolVersion?: 1 } = {}) {
+  return {
+    id: 'browser-host',
+    ok: true as const,
+    result: {
+      type: 'ready' as const,
+      authorityEpoch: 'epoch-a',
+      browserHostGeneration: 4,
+      pageCommandProtocolVersion: 1 as const,
+      pageInventoryProtocolVersion: 1 as const,
+      leaseReconnectProtocolVersion: 1 as const,
+      ...overrides
+    },
+    _meta: { runtimeId: 'runtime-a' }
+  }
+}

--- a/src/main/runtime/browser-host-command-ledger.ts
+++ b/src/main/runtime/browser-host-command-ledger.ts
@@ -240,6 +240,8 @@ export class BrowserHostCommandLedger {
   private assertAuthority(params: BrowserHostCommandResultParams): void {
     if (
       params.pageCommandProtocolVersion !== this.authority.pageCommandProtocolVersion ||
+      params.pageReconciliationProtocolVersion !==
+        this.authority.pageReconciliationProtocolVersion ||
       params.authorityRuntimeId !== this.authority.authorityRuntimeId ||
       params.authorityEpoch !== this.authority.authorityEpoch ||
       params.browserHostClientId !== this.authority.browserHostClientId ||

--- a/src/main/runtime/browser-host-lease-attachment.ts
+++ b/src/main/runtime/browser-host-lease-attachment.ts
@@ -12,6 +12,7 @@ export type BrowserHostLeaseAttachInput = {
   pageCommandProtocolVersion?: 1
   pageInventoryProtocolVersion?: 1
   pageInventory?: readonly BrowserClientHostedPageInventory[]
+  pageReconciliationProtocolVersion?: 1
   leaseReconnectProtocolVersion?: 1
 }
 
@@ -24,6 +25,18 @@ export function assertBrowserHostReconnectNegotiation(input: BrowserHostLeaseAtt
   }
   if (input.leaseReconnectProtocolVersion === 1 && input.pageInventoryProtocolVersion !== 1) {
     throw new Error('browser_host_reconnect_inventory_required')
+  }
+  if (
+    input.pageReconciliationProtocolVersion !== undefined &&
+    input.pageReconciliationProtocolVersion !== 1
+  ) {
+    throw new Error('browser_host_reconciliation_protocol_unsupported')
+  }
+  if (
+    input.pageReconciliationProtocolVersion === 1 &&
+    (input.pageCommandProtocolVersion !== 1 || input.pageInventoryProtocolVersion !== 1)
+  ) {
+    throw new Error('browser_host_reconciliation_protocol_dependencies_required')
   }
 }
 
@@ -54,7 +67,10 @@ export function createBrowserHostLeaseState(options: {
             pageInventory: options.pageInventory
           }
         : {}),
-      ...(input.leaseReconnectProtocolVersion ? { leaseReconnectProtocolVersion: 1 as const } : {})
+      ...(input.leaseReconnectProtocolVersion ? { leaseReconnectProtocolVersion: 1 as const } : {}),
+      ...(input.pageReconciliationProtocolVersion
+        ? { pageReconciliationProtocolVersion: 1 as const }
+        : {})
     }),
     status: 'active',
     fence: createBrowserHostFence(),
@@ -68,7 +84,10 @@ export function createBrowserHostLeaseState(options: {
         authorityEpoch: state.lease.authorityEpoch,
         browserHostClientId: state.lease.browserHostClientId,
         browserHostGeneration: state.lease.browserHostGeneration,
-        pageCommandProtocolVersion: 1
+        pageCommandProtocolVersion: 1,
+        ...(state.lease.pageReconciliationProtocolVersion
+          ? { pageReconciliationProtocolVersion: 1 as const }
+          : {})
       }
     })
   }

--- a/src/main/runtime/browser-host-lease-reconnect.ts
+++ b/src/main/runtime/browser-host-lease-reconnect.ts
@@ -11,6 +11,7 @@ type BrowserHostReconnectAttach = {
   connectionId: string
   hostCapabilities: readonly string[]
   pageCommandProtocolVersion?: 1
+  pageReconciliationProtocolVersion?: 1
   leaseReconnectProtocolVersion?: 1
 }
 
@@ -49,6 +50,7 @@ export class BrowserHostLeaseReconnectController {
       state.lease.leaseReconnectProtocolVersion !== 1 ||
       input.leaseReconnectProtocolVersion !== 1 ||
       state.lease.pageCommandProtocolVersion !== input.pageCommandProtocolVersion ||
+      state.lease.pageReconciliationProtocolVersion !== input.pageReconciliationProtocolVersion ||
       !sameCapabilities(state.lease.hostCapabilities, input.hostCapabilities)
     ) {
       return undefined

--- a/src/main/runtime/browser-host-lease-records.ts
+++ b/src/main/runtime/browser-host-lease-records.ts
@@ -17,6 +17,7 @@ export type BrowserHostLease = Readonly<{
   hostCapabilities: readonly string[]
   pageCommandProtocolVersion?: 1
   pageInventoryProtocolVersion?: 1
+  pageReconciliationProtocolVersion?: 1
   leaseReconnectProtocolVersion?: 1
   pageInventory?: readonly BrowserClientHostedPageInventory[]
 }>

--- a/src/main/runtime/browser-host-lease-registry.test.ts
+++ b/src/main/runtime/browser-host-lease-registry.test.ts
@@ -13,6 +13,31 @@ afterEach(() => {
 })
 
 describe('BrowserHostLeaseRegistry', () => {
+  it('requires reconciliation dependencies before retaining the negotiated lease', () => {
+    const leases = registry()
+    const attach = (overrides: Record<string, unknown>) =>
+      leases.attach({
+        browserHostClientId: 'host-a',
+        connectionId: 'connection-a',
+        pairedDeviceId: 'device-a',
+        hostCapabilities: ['webview'],
+        pageReconciliationProtocolVersion: 1,
+        ...overrides
+      })
+
+    expect(() => attach({})).toThrow('browser_host_reconciliation_protocol_dependencies_required')
+    expect(() => attach({ pageCommandProtocolVersion: 1 })).toThrow(
+      'browser_host_reconciliation_protocol_dependencies_required'
+    )
+    expect(
+      attach({
+        pageCommandProtocolVersion: 1,
+        pageInventoryProtocolVersion: 1,
+        pageInventory: []
+      }).lease
+    ).toMatchObject({ pageReconciliationProtocolVersion: 1 })
+  })
+
   it('rejects incomplete, duplicate, and foreign-client inventory before replacing a lease', () => {
     const leases = registry()
     const attach = (overrides: Record<string, unknown>) =>
@@ -127,6 +152,86 @@ describe('BrowserHostLeaseRegistry', () => {
     expect(leases.select('host-a')).toEqual(replacement.lease)
     first.disconnect()
     expect(leases.select('host-a')).toEqual(replacement.lease)
+  })
+
+  it('replaces instead of restoring a lease when reconciliation negotiation changes', async () => {
+    const leases = registry()
+    const first = leases.attach({
+      browserHostClientId: 'host-a',
+      connectionId: 'connection-a',
+      pairedDeviceId: 'device-a',
+      hostCapabilities: ['webview'],
+      pageCommandProtocolVersion: 1,
+      pageInventoryProtocolVersion: 1,
+      pageInventory: [],
+      pageReconciliationProtocolVersion: 1,
+      leaseReconnectProtocolVersion: 1
+    })
+    first.disconnect()
+
+    const replacement = leases.attach({
+      browserHostClientId: 'host-a',
+      connectionId: 'connection-b',
+      pairedDeviceId: 'device-a',
+      hostCapabilities: ['webview'],
+      pageCommandProtocolVersion: 1,
+      pageInventoryProtocolVersion: 1,
+      pageInventory: [],
+      leaseReconnectProtocolVersion: 1
+    })
+
+    expect(replacement.lease.browserHostGeneration).toBe(first.lease.browserHostGeneration + 1)
+    expect(replacement.lease).not.toHaveProperty('pageReconciliationProtocolVersion')
+    await expect(first.whenFenced).resolves.toBe('replaced')
+  })
+
+  it('never emits reconciliation commands to a legacy page-command lease', () => {
+    const leases = registry()
+    const host = leases.attach({
+      browserHostClientId: 'host-a',
+      connectionId: 'connection-a',
+      pairedDeviceId: 'device-a',
+      hostCapabilities: ['webview'],
+      pageCommandProtocolVersion: 1
+    })
+    const identity = {
+      authorityEpoch: host.lease.authorityEpoch,
+      browserHostClientId: host.lease.browserHostClientId,
+      browserHostGeneration: host.lease.browserHostGeneration,
+      pairedDeviceId: host.lease.pairedDeviceId
+    }
+    const delivery = vi.fn()
+    leases.attachCommandDelivery(identity, delivery)
+    const placement = leases.placeClientPage('page-a', 'host-a')
+    if (placement.kind !== 'client') {
+      throw new Error('expected client placement')
+    }
+    const authority = {
+      authorityRuntimeId: host.lease.authorityRuntimeId,
+      authorityEpoch: host.lease.authorityEpoch,
+      browserPageId: 'page-a',
+      browserHostClientId: host.lease.browserHostClientId,
+      browserHostGeneration: host.lease.browserHostGeneration,
+      pageHostGeneration: placement.pageHostGeneration
+    }
+
+    expect(() =>
+      leases.issueClientPageCommand(authority, {
+        type: 'restorePage',
+        browserProfileId: 'default',
+        executionHostKey: 'host-key-a'
+      })
+    ).toThrow('browser_host_reconciliation_protocol_required')
+    expect(delivery).not.toHaveBeenCalled()
+
+    leases.grantExecutionHost(identity, 'host-key-a')
+    const legacy = leases.issueClientPageCommand(authority, {
+      type: 'createPage',
+      browserProfileId: 'default',
+      executionHostKey: 'host-key-a'
+    })
+    expect(legacy.event).not.toHaveProperty('pageReconciliationProtocolVersion')
+    expect(delivery).toHaveBeenCalledWith(legacy.event)
   })
 
   it('restores exact authority when reattach arrives before old connection cleanup', async () => {

--- a/src/main/runtime/browser-host-lease-registry.ts
+++ b/src/main/runtime/browser-host-lease-registry.ts
@@ -17,6 +17,7 @@ import {
 } from './browser-host-lease-records'
 import { retireClientPageCommandLedger } from './browser-host-command-retirement'
 import { BrowserHostGenerationCounter } from './browser-host-generation-counter'
+import { assertBrowserHostPageCommandAdmission } from './browser-host-page-command-admission'
 import {
   BrowserHostPagePlacementRegistry,
   type BrowserClientPageAuthority,
@@ -209,9 +210,9 @@ export class BrowserHostLeaseRegistry {
     ) {
       throw new Error('browser_host_command_protocol_required')
     }
-    if (command.type === 'createPage') {
-      state.executionHostGrants.require(command.executionHostKey)
-    }
+    assertBrowserHostPageCommandAdmission(state.lease, command, (executionHostKey) =>
+      state.executionHostGrants.require(executionHostKey)
+    )
     return ledger.issue({
       browserPageId: authority.browserPageId,
       pageHostGeneration: authority.pageHostGeneration,

--- a/src/main/runtime/browser-host-page-command-admission.ts
+++ b/src/main/runtime/browser-host-page-command-admission.ts
@@ -1,0 +1,23 @@
+import type { BrowserClientHostCommandEvent } from '../../shared/browser-client-host-protocol'
+import type { BrowserHostLease } from './browser-host-lease-records'
+
+export function assertBrowserHostPageCommandAdmission(
+  lease: BrowserHostLease,
+  command: BrowserClientHostCommandEvent['command'],
+  requireExecutionHost: (executionHostKey: string) => void
+): void {
+  if (
+    command.type !== 'createPage' &&
+    command.type !== 'navigate' &&
+    lease.pageReconciliationProtocolVersion !== 1
+  ) {
+    throw new Error('browser_host_reconciliation_protocol_required')
+  }
+  if (
+    command.type === 'createPage' ||
+    command.type === 'reclaimPage' ||
+    command.type === 'restorePage'
+  ) {
+    requireExecutionHost(command.executionHostKey)
+  }
+}

--- a/src/main/runtime/rpc/methods/browser-client-host-reconciliation.test.ts
+++ b/src/main/runtime/rpc/methods/browser-client-host-reconciliation.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi } from 'vitest'
+import { BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY } from '../../../../shared/protocol-version'
+import { getBrowserHostLeaseRegistry } from '../../browser-host-lease-registry'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import { RpcDispatcher } from '../dispatcher'
+import { BROWSER_CLIENT_HOST_METHODS } from './browser-client-host'
+
+describe('browser.clientHost reconciliation negotiation', () => {
+  it('echoes and retains reconciliation only for an explicit authenticated request', async () => {
+    const cleanups = new Map<string, () => void>()
+    const hostRuntime = runtime(cleanups)
+    const dispatcher = new RpcDispatcher({
+      runtime: hostRuntime,
+      methods: BROWSER_CLIENT_HOST_METHODS
+    })
+    const replies: string[] = []
+    const dispatch = dispatcher.dispatchStreaming(
+      {
+        id: 'browser-host:host-a',
+        authToken: 'bound-by-websocket',
+        method: 'browser.clientHost.attach',
+        params: {
+          authorityRuntimeId: 'runtime-a',
+          browserHostClientId: 'host-a',
+          hostCapabilities: ['webview'],
+          pageCommandProtocolVersion: 1,
+          pageInventoryProtocolVersion: 1,
+          pageInventory: [],
+          pageReconciliationProtocolVersion: 1
+        }
+      },
+      (reply) => replies.push(reply),
+      {
+        connectionId: 'connection-a',
+        clientKind: 'runtime',
+        pairedDeviceId: 'device-a',
+        clientCapabilities: [BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY]
+      }
+    )
+
+    await vi.waitFor(() => expect(replies).toHaveLength(1))
+    expect(JSON.parse(replies[0]!).result).toMatchObject({
+      pageCommandProtocolVersion: 1,
+      pageInventoryProtocolVersion: 1,
+      pageReconciliationProtocolVersion: 1
+    })
+    expect(getBrowserHostLeaseRegistry(hostRuntime).select('host-a')).toMatchObject({
+      pageReconciliationProtocolVersion: 1
+    })
+
+    cleanups.get('browser-client-host:host-a')?.()
+    await dispatch
+  })
+
+  it('requires exact reconciliation authority on command results', async () => {
+    const cleanups = new Map<string, () => void>()
+    const hostRuntime = runtime(cleanups)
+    const dispatcher = new RpcDispatcher({
+      runtime: hostRuntime,
+      methods: BROWSER_CLIENT_HOST_METHODS
+    })
+    const replies: string[] = []
+    const dispatch = dispatcher.dispatchStreaming(
+      attachRequest(),
+      (reply) => replies.push(reply),
+      caller()
+    )
+    await vi.waitFor(() => expect(replies).toHaveLength(1))
+    const registry = getBrowserHostLeaseRegistry(hostRuntime)
+    const lease = registry.select('host-a')
+    const placement = registry.placeClientPage('page-a', 'host-a')
+    if (placement.kind !== 'client') {
+      throw new Error('expected client placement')
+    }
+    const identity = {
+      authorityEpoch: lease.authorityEpoch,
+      browserHostClientId: lease.browserHostClientId,
+      browserHostGeneration: lease.browserHostGeneration,
+      pairedDeviceId: lease.pairedDeviceId
+    }
+    registry.grantExecutionHost(identity, 'host-key-a')
+    const issued = registry.issueClientPageCommand(
+      {
+        authorityRuntimeId: lease.authorityRuntimeId,
+        authorityEpoch: lease.authorityEpoch,
+        browserPageId: 'page-a',
+        browserHostClientId: lease.browserHostClientId,
+        browserHostGeneration: lease.browserHostGeneration,
+        pageHostGeneration: placement.pageHostGeneration
+      },
+      {
+        type: 'createPage',
+        browserProfileId: 'default',
+        executionHostKey: 'host-key-a'
+      }
+    )
+    await vi.waitFor(() => expect(replies).toHaveLength(2))
+    expect(issued.event).toMatchObject({ pageReconciliationProtocolVersion: 1 })
+    const { pageReconciliationProtocolVersion: _omitted, ...legacyAuthority } = issued.event
+
+    await expect(
+      commandResult(dispatcher, { ...legacyAuthority, result: { status: 'completed' } })
+    ).resolves.toMatchObject({
+      ok: false,
+      error: { message: 'browser_host_command_result_authority_stale' }
+    })
+    await expect(
+      commandResult(dispatcher, { ...issued.event, result: { status: 'completed' } })
+    ).resolves.toMatchObject({ ok: true, result: { accepted: true } })
+    await expect(issued.result).resolves.toEqual({ status: 'completed' })
+
+    cleanups.get('browser-client-host:host-a')?.()
+    await dispatch
+  })
+})
+
+function attachRequest() {
+  return {
+    id: 'browser-host:host-a',
+    authToken: 'bound-by-websocket',
+    method: 'browser.clientHost.attach',
+    params: {
+      authorityRuntimeId: 'runtime-a',
+      browserHostClientId: 'host-a',
+      hostCapabilities: ['webview'],
+      pageCommandProtocolVersion: 1,
+      pageInventoryProtocolVersion: 1,
+      pageInventory: [],
+      pageReconciliationProtocolVersion: 1
+    }
+  }
+}
+
+function caller() {
+  return {
+    connectionId: 'connection-a',
+    clientKind: 'runtime' as const,
+    pairedDeviceId: 'device-a',
+    clientCapabilities: [BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY]
+  }
+}
+
+async function commandResult(dispatcher: RpcDispatcher, params: Record<string, unknown>) {
+  const replies: string[] = []
+  await dispatcher.dispatchStreaming(
+    {
+      id: 'command-result-a',
+      authToken: 'bound-by-websocket',
+      method: 'browser.clientHost.commandResult',
+      params
+    },
+    (reply) => replies.push(reply),
+    caller()
+  )
+  return JSON.parse(replies[0]!)
+}
+
+function runtime(cleanups: Map<string, () => void>): OrcaRuntimeService {
+  return {
+    getRuntimeId: () => 'runtime-a',
+    getStartedAt: () => 1,
+    registerSubscriptionCleanup: (id: string, cleanup: () => void) => cleanups.set(id, cleanup)
+  } as unknown as OrcaRuntimeService
+}

--- a/src/main/runtime/rpc/methods/browser-client-host.ts
+++ b/src/main/runtime/rpc/methods/browser-client-host.ts
@@ -34,6 +34,7 @@ export const BROWSER_CLIENT_HOST_METHODS: RpcAnyMethod[] = [
         pageCommandProtocolVersion: params.pageCommandProtocolVersion,
         pageInventoryProtocolVersion: params.pageInventoryProtocolVersion,
         pageInventory: params.pageInventory,
+        pageReconciliationProtocolVersion: params.pageReconciliationProtocolVersion,
         leaseReconnectProtocolVersion: params.leaseReconnectProtocolVersion
       })
       let releaseCommandDelivery = (): void => {}
@@ -71,6 +72,9 @@ export const BROWSER_CLIENT_HOST_METHODS: RpcAnyMethod[] = [
             : {}),
           ...(params.leaseReconnectProtocolVersion
             ? { leaseReconnectProtocolVersion: params.leaseReconnectProtocolVersion }
+            : {}),
+          ...(params.pageReconciliationProtocolVersion
+            ? { pageReconciliationProtocolVersion: params.pageReconciliationProtocolVersion }
             : {})
         })
         if (params.pageCommandProtocolVersion) {

--- a/src/shared/browser-client-host-protocol.ts
+++ b/src/shared/browser-client-host-protocol.ts
@@ -22,6 +22,10 @@ export const BROWSER_CLIENT_HOST_LEASE_RECONNECT_PROTOCOL_VERSION = 1 as const
 const LeaseReconnectProtocolVersion = z.literal(
   BROWSER_CLIENT_HOST_LEASE_RECONNECT_PROTOCOL_VERSION
 )
+export const BROWSER_CLIENT_HOST_PAGE_RECONCILIATION_PROTOCOL_VERSION = 1 as const
+const PageReconciliationProtocolVersion = z.literal(
+  BROWSER_CLIENT_HOST_PAGE_RECONCILIATION_PROTOCOL_VERSION
+)
 
 export const BrowserHostLeaseAuthority = z.object({
   authorityRuntimeId: Identity,
@@ -31,6 +35,10 @@ export const BrowserHostLeaseAuthority = z.object({
 })
 
 export type BrowserHostLeaseAuthority = z.infer<typeof BrowserHostLeaseAuthority>
+
+const BrowserClientHostedPageAuthority = BrowserHostLeaseAuthority.extend({
+  pageHostGeneration: Generation
+})
 
 export const BrowserClientHostedPageInventory = z.object({
   authorityRuntimeId: PageInventoryIdentity,
@@ -91,7 +99,8 @@ export const BrowserClientHostAttachParams = z
     pageCommandProtocolVersion: PageCommandProtocolVersion.optional(),
     pageInventoryProtocolVersion: PageInventoryProtocolVersion.optional(),
     pageInventory: BrowserClientHostedPageInventoryList.optional(),
-    leaseReconnectProtocolVersion: LeaseReconnectProtocolVersion.optional()
+    leaseReconnectProtocolVersion: LeaseReconnectProtocolVersion.optional(),
+    pageReconciliationProtocolVersion: PageReconciliationProtocolVersion.optional()
   })
   .superRefine((params, context) => {
     if (
@@ -112,6 +121,15 @@ export const BrowserClientHostAttachParams = z
         message: 'Browser host reconnect requires page inventory negotiation'
       })
     }
+    if (
+      params.pageReconciliationProtocolVersion !== undefined &&
+      (params.pageCommandProtocolVersion !== 1 || params.pageInventoryProtocolVersion !== 1)
+    ) {
+      context.addIssue({
+        code: 'custom',
+        message: 'Browser page reconciliation requires command and inventory negotiation'
+      })
+    }
     for (const [index, page] of (params.pageInventory ?? []).entries()) {
       if (page.browserHostClientId !== params.browserHostClientId) {
         context.addIssue({
@@ -129,7 +147,8 @@ export const BrowserClientHostReady = z.object({
   browserHostGeneration: Generation,
   pageCommandProtocolVersion: PageCommandProtocolVersion.optional(),
   pageInventoryProtocolVersion: PageInventoryProtocolVersion.optional(),
-  leaseReconnectProtocolVersion: LeaseReconnectProtocolVersion.optional()
+  leaseReconnectProtocolVersion: LeaseReconnectProtocolVersion.optional(),
+  pageReconciliationProtocolVersion: PageReconciliationProtocolVersion.optional()
 })
 
 const BrowserClientHostRevoked = z.object({
@@ -142,7 +161,8 @@ const BrowserClientHostRevoked = z.object({
 export const BrowserClientHostLeaseAuthority = BrowserHostLeaseAuthority.extend({
   pageCommandProtocolVersion: PageCommandProtocolVersion.optional(),
   pageInventoryProtocolVersion: PageInventoryProtocolVersion.optional(),
-  leaseReconnectProtocolVersion: LeaseReconnectProtocolVersion.optional()
+  leaseReconnectProtocolVersion: LeaseReconnectProtocolVersion.optional(),
+  pageReconciliationProtocolVersion: PageReconciliationProtocolVersion.optional()
 })
 
 export type BrowserClientHostLeaseAuthority = z.infer<typeof BrowserClientHostLeaseAuthority>
@@ -186,14 +206,67 @@ const BrowserClientHostNavigateCommand = z.object({
   url: z.string().min(1).max(8192)
 })
 
+const BrowserClientHostReclaimPageCommand = z.object({
+  type: z.literal('reclaimPage'),
+  previousAuthority: BrowserClientHostedPageAuthority,
+  browserProfileId: Identity,
+  executionHostKey: Identity
+})
+
+const BrowserClientHostClosePageCommand = z.object({
+  type: z.literal('closePage'),
+  targetAuthority: BrowserClientHostedPageAuthority
+})
+
+const BrowserClientHostRestorePageCommand = z.object({
+  type: z.literal('restorePage'),
+  browserProfileId: Identity,
+  executionHostKey: Identity,
+  url: z.string().min(1).max(8192).optional()
+})
+
 export const BrowserClientHostPageCommand = z.discriminatedUnion('type', [
   BrowserClientHostCreatePageCommand,
-  BrowserClientHostNavigateCommand
+  BrowserClientHostNavigateCommand,
+  BrowserClientHostReclaimPageCommand,
+  BrowserClientHostClosePageCommand,
+  BrowserClientHostRestorePageCommand
 ])
 
 export const BrowserClientHostCommandEvent = BrowserClientPageCommandAuthority.extend({
   type: z.literal('command'),
   command: BrowserClientHostPageCommand
+}).superRefine((event, context) => {
+  if (event.command.type === 'createPage' || event.command.type === 'navigate') {
+    return
+  }
+  if (event.pageReconciliationProtocolVersion !== 1) {
+    context.addIssue({
+      code: 'custom',
+      message: 'Browser page reconciliation command was not negotiated'
+    })
+  }
+  const previousAuthority =
+    event.command.type === 'reclaimPage'
+      ? event.command.previousAuthority
+      : event.command.type === 'closePage'
+        ? event.command.targetAuthority
+        : null
+  if (previousAuthority && previousAuthority.browserHostClientId !== event.browserHostClientId) {
+    context.addIssue({
+      code: 'custom',
+      message: 'Browser page reconciliation client authority does not match'
+    })
+  }
+  if (
+    event.command.type === 'reclaimPage' &&
+    event.command.previousAuthority.authorityEpoch === event.authorityEpoch
+  ) {
+    context.addIssue({
+      code: 'custom',
+      message: 'Browser page reclaim requires an older authority epoch'
+    })
+  }
 })
 
 export type BrowserClientHostCommandEvent = z.infer<typeof BrowserClientHostCommandEvent>
@@ -216,7 +289,7 @@ export const BrowserClientHostLeaseEvent = z.discriminatedUnion('type', [
   BrowserClientHostRevoked
 ])
 
-export const BrowserClientHostEvent = z.discriminatedUnion('type', [
+export const BrowserClientHostEvent = z.union([
   BrowserClientHostReady,
   BrowserClientHostRevoked,
   BrowserClientHostCommandEvent

--- a/src/shared/browser-client-host-reconciliation-protocol.test.ts
+++ b/src/shared/browser-client-host-reconciliation-protocol.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import {
+  BROWSER_CLIENT_HOST_PAGE_RECONCILIATION_PROTOCOL_VERSION,
+  BrowserClientHostAttachParams,
+  BrowserClientHostCommandEvent,
+  BrowserClientHostReady
+} from './browser-client-host-protocol'
+
+const inventoryPage = {
+  authorityRuntimeId: 'runtime-old',
+  authorityEpoch: 'epoch-old',
+  browserHostClientId: 'host-a',
+  browserHostGeneration: 2,
+  browserPageId: 'page-a',
+  pageHostGeneration: 3,
+  browserProfileId: 'profile-a',
+  executionHostKey: 'native:runtime-a:1',
+  state: 'active' as const
+}
+
+const command = (reconciliationCommand: object) => ({
+  type: 'command' as const,
+  authorityRuntimeId: 'runtime-a',
+  authorityEpoch: 'epoch-new',
+  browserHostClientId: 'host-a',
+  browserHostGeneration: 4,
+  pageCommandProtocolVersion: 1 as const,
+  pageReconciliationProtocolVersion: 1 as const,
+  browserPageId: 'page-a',
+  pageHostGeneration: 5,
+  commandSequence: 6,
+  commandId: 'command-a',
+  command: reconciliationCommand
+})
+
+describe('browser client-host reconciliation protocol', () => {
+  it('negotiates reconciliation only beside commands and complete inventory', () => {
+    expect(
+      BrowserClientHostAttachParams.parse({
+        authorityRuntimeId: 'runtime-a',
+        browserHostClientId: 'host-a',
+        hostCapabilities: ['webview'],
+        pageCommandProtocolVersion: 1,
+        pageInventoryProtocolVersion: 1,
+        pageInventory: [inventoryPage],
+        pageReconciliationProtocolVersion: BROWSER_CLIENT_HOST_PAGE_RECONCILIATION_PROTOCOL_VERSION
+      })
+    ).toMatchObject({ pageReconciliationProtocolVersion: 1 })
+    expect(
+      BrowserClientHostReady.parse({
+        type: 'ready',
+        authorityEpoch: 'epoch-new',
+        browserHostGeneration: 4,
+        pageCommandProtocolVersion: 1,
+        pageInventoryProtocolVersion: 1,
+        pageReconciliationProtocolVersion: 1
+      })
+    ).toMatchObject({ pageReconciliationProtocolVersion: 1 })
+
+    for (const incomplete of [
+      { pageCommandProtocolVersion: 1 },
+      { pageInventoryProtocolVersion: 1, pageInventory: [inventoryPage] }
+    ]) {
+      expect(() =>
+        BrowserClientHostAttachParams.parse({
+          authorityRuntimeId: 'runtime-a',
+          browserHostClientId: 'host-a',
+          hostCapabilities: ['webview'],
+          pageReconciliationProtocolVersion: 1,
+          ...incomplete
+        })
+      ).toThrow('Browser page reconciliation requires command and inventory negotiation')
+    }
+  })
+
+  it('keeps optional negotiation fields invisible to old attach and ready decoders', () => {
+    const legacyAttach = z.object({
+      authorityRuntimeId: z.string(),
+      browserHostClientId: z.string(),
+      hostCapabilities: z.array(z.string()),
+      pageCommandProtocolVersion: z.literal(1).optional()
+    })
+    const legacyReady = z.object({
+      type: z.literal('ready'),
+      authorityEpoch: z.string(),
+      browserHostGeneration: z.number(),
+      pageCommandProtocolVersion: z.literal(1).optional()
+    })
+
+    expect(
+      legacyAttach.parse({
+        authorityRuntimeId: 'runtime-a',
+        browserHostClientId: 'host-a',
+        hostCapabilities: ['webview'],
+        pageCommandProtocolVersion: 1,
+        pageInventoryProtocolVersion: 1,
+        pageInventory: [],
+        pageReconciliationProtocolVersion: 1
+      })
+    ).not.toHaveProperty('pageReconciliationProtocolVersion')
+    expect(
+      legacyReady.parse({
+        type: 'ready',
+        authorityEpoch: 'epoch-new',
+        browserHostGeneration: 4,
+        pageCommandProtocolVersion: 1,
+        pageInventoryProtocolVersion: 1,
+        pageReconciliationProtocolVersion: 1
+      })
+    ).not.toHaveProperty('pageReconciliationProtocolVersion')
+  })
+
+  it('decodes exact reclaim, close, and restore commands only after negotiation', () => {
+    const previousAuthority = {
+      authorityRuntimeId: 'runtime-a',
+      authorityEpoch: 'epoch-old',
+      browserHostClientId: 'host-a',
+      browserHostGeneration: 2,
+      pageHostGeneration: 3
+    }
+    const reconciliationCommands = [
+      {
+        type: 'reclaimPage',
+        previousAuthority,
+        browserProfileId: 'profile-a',
+        executionHostKey: 'native:runtime-a:1'
+      },
+      { type: 'closePage', targetAuthority: previousAuthority },
+      {
+        type: 'restorePage',
+        browserProfileId: 'profile-a',
+        executionHostKey: 'native:runtime-a:1',
+        url: 'https://remote.internal/'
+      }
+    ]
+
+    for (const reconciliationCommand of reconciliationCommands) {
+      expect(BrowserClientHostCommandEvent.parse(command(reconciliationCommand))).toMatchObject({
+        pageReconciliationProtocolVersion: 1,
+        command: reconciliationCommand
+      })
+      const unnegotiated = command(reconciliationCommand)
+      delete (unnegotiated as { pageReconciliationProtocolVersion?: number })
+        .pageReconciliationProtocolVersion
+      expect(() => BrowserClientHostCommandEvent.parse(unnegotiated)).toThrow(
+        'Browser page reconciliation command was not negotiated'
+      )
+    }
+  })
+
+  it('rejects stale reclaim authority and malformed restore inputs', () => {
+    expect(() =>
+      BrowserClientHostCommandEvent.parse(
+        command({
+          type: 'reclaimPage',
+          previousAuthority: {
+            authorityRuntimeId: 'runtime-a',
+            authorityEpoch: 'epoch-new',
+            browserHostClientId: 'host-a',
+            browserHostGeneration: 2,
+            pageHostGeneration: 3
+          },
+          browserProfileId: 'profile-a',
+          executionHostKey: 'native:runtime-a:1'
+        })
+      )
+    ).toThrow('Browser page reclaim requires an older authority epoch')
+    expect(() =>
+      BrowserClientHostCommandEvent.parse(
+        command({
+          type: 'restorePage',
+          browserProfileId: '',
+          executionHostKey: 'native:runtime-a:1'
+        })
+      )
+    ).toThrow()
+  })
+
+  it('leaves legacy create and navigate commands unchanged', () => {
+    const legacyCommand = {
+      ...command({
+        type: 'createPage',
+        browserProfileId: 'profile-a',
+        executionHostKey: 'native:runtime-a:1'
+      })
+    }
+    delete (legacyCommand as { pageReconciliationProtocolVersion?: number })
+      .pageReconciliationProtocolVersion
+
+    expect(BrowserClientHostCommandEvent.parse(legacyCommand)).toEqual(legacyCommand)
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​663 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​663 |
| Prod | 16 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​247 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​15 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​232 |

<!-- /orca-pr-loc -->

## ELI5

After a client or runtime restart, Orca needs to tell the Electron desktop to keep, close, or rebuild exact browser pages. This PR adds a separate handshake key for those recovery instructions: unless both sides explicitly agree to the key, the server is unable to send them.

## What Changed

- Add optional page-reconciliation v1 negotiation to browser-host attach, ready, lease, reconnect, and command-result authority.
- Add bounded reclaimPage, closePage, and restorePage command contracts with exact prior page authority.
- Reject unsolicited/inconsistent echoes, reconnect negotiation changes, stale result authority, and reconciliation commands on legacy page-command leases.
- Keep the production PairedRuntimeBrowserClientHost composition from advertising the new subprotocol; this stage activates no page mutation or placement behavior.
- Register the mixed-version and fail-closed contracts in the existing browser-network reliability gate.

## Why

The current page-command v1 stream knows only createPage and navigate. Sending new recovery variants through that unnegotiated stream would break old decoders. A separate exact attach/ready echo lets old servers strip the optional field, lets new clients safely fall back when the echo is absent, and prevents new servers from publishing new command content to old clients.

## Linked Issue

[STA-4150](https://linear.app/stably/issue/STA-4150/refactor-remote-browser-to-client-hosted-electron-webviews)

## Visual Proof

N/A — this is a production-inert shared/main-process protocol contract with no UI or activated browser behavior.

## Testing

- 6 focused files / 58 tests
- 21 affected host lease, reconnect, command, reconciliation, and RPC files / 219 tests
- mixed-version terminal wire: 5/5
- pnpm typecheck
- pnpm lint
- pnpm check:code-quality:changed
- reliability manifest (87 gates), max-lines, formatting, localization, and skill manifests
- all 36 stack patches rebased onto origin/main@931cb037c5 and byte-equivalent by git range-diff before the ledger-only rebase record

Platforms reviewed: macOS local test host; pure TypeScript contracts have no path, shell, native-module, UI, or platform branch. Windows/Linux packaging and SSH/WSL live topology remain later activation gates.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

## Review

No actionable security, cross-platform, SSH/remote, mobile, backwards-compatibility, performance, or resource issue found. Old peers strip or omit the optional field; new command variants require exact negotiation; current production composition does not advertise them. No dependency, persisted state, network sink, retry loop, timer, cache, server/offscreen placement, or mobile-facing contract changed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or N/A with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] pnpm lint, pnpm typecheck, affected tests, and local gates pass; CI covers full test/build

## Author

- X / Twitter: @your_handle
