### PR TITLE
fix(terminal): keep a one-character Linux IME candidate pick from being wiped

### DIFF
--- a/config/scripts/pr-test-loc-summary.test.mjs
+++ b/config/scripts/pr-test-loc-summary.test.mjs
@@ -85,7 +85,7 @@ describe('PR test LoC summary', () => {
       fetchImpl: async (url) => {
         const page = pages[url]
         if (page == null) {
-          throw new Error(`unexpected url ${url}`)
+          throw new Error(`unexpected url ${String(url)}`)
         }
         return {
           ok: true,

--- a/src/renderer/src/components/terminal-pane/__fixtures__/ibus-chinese-candidate-digit-terminal-trace.json
+++ b/src/renderer/src/components/terminal-pane/__fixtures__/ibus-chinese-candidate-digit-terminal-trace.json
@@ -1,0 +1,483 @@
+{
+  "recordedFrom": "Ubuntu 24.04 X11, Electron 40 renderer, ibus-daemon 1.5.29 via GTK_IM_MODULE=ibus, keys driven with xdotool",
+  "captures": [
+    {
+      "name": "ibus-table-cangjie5-single-char-digit",
+      "engine": "table:cangjie5",
+      "gesture": "type \"a\", press 1",
+      "committed": "日",
+      "onData": ["日"],
+      "dom": [
+        {
+          "type": "keydown",
+          "key": "Process",
+          "code": "KeyA",
+          "keyCode": 229,
+          "value": "日你好月星你你好한 韓寒",
+          "selectionStart": 12,
+          "selectionEnd": 12
+        },
+        {
+          "type": "compositionstart",
+          "data": "",
+          "value": "日你好月星你你好한 韓寒",
+          "selectionStart": 12,
+          "selectionEnd": 12
+        },
+        {
+          "type": "compositionupdate",
+          "data": "日",
+          "value": "日你好月星你你好한 韓寒",
+          "selectionStart": 12,
+          "selectionEnd": 12
+        },
+        {
+          "type": "beforeinput",
+          "isComposing": true,
+          "inputType": "insertCompositionText",
+          "data": "日",
+          "value": "日你好月星你你好한 韓寒",
+          "selectionStart": 12,
+          "selectionEnd": 12
+        },
+        {
+          "type": "input",
+          "isComposing": true,
+          "inputType": "insertCompositionText",
+          "data": "日",
+          "value": "日你好月星你你好한 韓寒日",
+          "selectionStart": 13,
+          "selectionEnd": 13
+        },
+        {
+          "type": "keyup",
+          "key": "a",
+          "code": "KeyA",
+          "keyCode": 65,
+          "isComposing": true,
+          "value": "日你好月星你你好한 韓寒日",
+          "selectionStart": 13,
+          "selectionEnd": 13
+        },
+        {
+          "type": "keydown",
+          "key": "Process",
+          "code": "Digit1",
+          "keyCode": 229,
+          "isComposing": true,
+          "value": "日你好月星你你好한 韓寒日",
+          "selectionStart": 13,
+          "selectionEnd": 13
+        },
+        {
+          "type": "compositionupdate",
+          "data": "日",
+          "value": "日你好月星你你好한 韓寒日",
+          "selectionStart": 12,
+          "selectionEnd": 13
+        },
+        {
+          "type": "beforeinput",
+          "isComposing": true,
+          "inputType": "insertCompositionText",
+          "data": "日",
+          "value": "日你好月星你你好한 韓寒日",
+          "selectionStart": 12,
+          "selectionEnd": 13
+        },
+        {
+          "type": "input",
+          "isComposing": true,
+          "inputType": "insertCompositionText",
+          "data": "日",
+          "value": "日你好月星你你好한 韓寒日",
+          "selectionStart": 13,
+          "selectionEnd": 13
+        },
+        {
+          "type": "compositionend",
+          "data": "日",
+          "value": "日你好月星你你好한 韓寒日",
+          "selectionStart": 13,
+          "selectionEnd": 13
+        },
+        {
+          "type": "keyup",
+          "key": "1",
+          "code": "Digit1",
+          "keyCode": 49,
+          "value": "日你好月星你你好한 韓寒日",
+          "selectionStart": 13,
+          "selectionEnd": 13
+        }
+      ]
+    },
+    {
+      "name": "ibus-hangul-hanja-single-char-digit",
+      "engine": "hangul",
+      "gesture": "type \"gks\", press F9, press 1",
+      "committed": "韓",
+      "onData": ["韓"],
+      "dom": [
+        {
+          "type": "keydown",
+          "key": "Process",
+          "code": "KeyG",
+          "keyCode": 229,
+          "value": "日你好月星你你好한 ",
+          "selectionStart": 10,
+          "selectionEnd": 10
+        },
+        {
+          "type": "compositionstart",
+          "data": "",
+          "value": "日你好月星你你好한 ",
+          "selectionStart": 10,
+          "selectionEnd": 10
+        },
+        {
+          "type": "compositionupdate",
+          "data": "ㅎ",
+          "value": "日你好月星你你好한 ",
+          "selectionStart": 10,
+          "selectionEnd": 10
+        },
+        {
+          "type": "beforeinput",
+          "isComposing": true,
+          "inputType": "insertCompositionText",
+          "data": "ㅎ",
+          "value": "日你好月星你你好한 ",
+          "selectionStart": 10,
+          "selectionEnd": 10
+        },
+        {
+          "type": "input",
+          "isComposing": true,
+          "inputType": "insertCompositionText",
+          "data": "ㅎ",
+          "value": "日你好月星你你好한 ㅎ",
+          "selectionStart": 11,
+          "selectionEnd": 11
+        },
+        {
+          "type": "keyup",
+          "key": "g",
+          "code": "KeyG",
+          "keyCode": 71,
+          "isComposing": true,
+          "value": "日你好月星你你好한 ㅎ",
+          "selectionStart": 11,
+          "selectionEnd": 11
+        },
+        {
+          "type": "keydown",
+          "key": "Process",
+          "code": "KeyK",
+          "keyCode": 229,
+          "isComposing": true,
+          "value": "日你好月星你你好한 ㅎ",
+          "selectionStart": 11,
+          "selectionEnd": 11
+        },
+        {
+          "type": "compositionupdate",
+          "data": "하",
+          "value": "日你好月星你你好한 ㅎ",
+          "selectionStart": 10,
+          "selectionEnd": 11
+        },
+        {
+          "type": "beforeinput",
+          "isComposing": true,
+          "inputType": "insertCompositionText",
+          "data": "하",
+          "value": "日你好月星你你好한 ㅎ",
+          "selectionStart": 10,
+          "selectionEnd": 11
+        },
+        {
+          "type": "input",
+          "isComposing": true,
+          "inputType": "insertCompositionText",
+          "data": "하",
+          "value": "日你好月星你你好한 하",
+          "selectionStart": 11,
+          "selectionEnd": 11
+        },
+        {
+          "type": "keyup",
+          "key": "k",
+          "code": "KeyK",
+          "keyCode": 75,
+          "isComposing": true,
+          "value": "日你好月星你你好한 하",
+          "selectionStart": 11,
+          "selectionEnd": 11
+        },
+        {
+          "type": "keydown",
+          "key": "Process",
+          "code": "KeyS",
+          "keyCode": 229,
+          "isComposing": true,
+          "value": "日你好月星你你好한 하",
+          "selectionStart": 11,
+          "selectionEnd": 11
+        },
+        {
+          "type": "compositionupdate",
+          "data": "한",
+          "value": "日你好月星你你好한 하",
+          "selectionStart": 10,
+          "selectionEnd": 11
+        },
+        {
+          "type": "beforeinput",
+          "isComposing": true,
+          "inputType": "insertCompositionText",
+          "data": "한",
+          "value": "日你好月星你你好한 하",
+          "selectionStart": 10,
+          "selectionEnd": 11
+        },
+        {
+          "type": "input",
+          "isComposing": true,
+          "inputType": "insertCompositionText",
+          "data": "한",
+          "value": "日你好月星你你好한 한",
+          "selectionStart": 11,
+          "selectionEnd": 11
+        },
+        {
+          "type": "keyup",
+          "key": "s",
+          "code": "KeyS",
+          "keyCode": 83,
+          "isComposing": true,
+          "value": "日你好月星你你好한 한",
+          "selectionStart": 11,
+          "selectionEnd": 11
+        },
+        {
+          "type": "keyup",
+          "key": "F9",
+          "code": "F9",
+          "keyCode": 120,
+          "isComposing": true,
+          "value": "日你好月星你你好한 한",
+          "selectionStart": 11,
+          "selectionEnd": 11
+        },
+        {
+          "type": "keydown",
+          "key": "Process",
+          "code": "Digit1",
+          "keyCode": 229,
+          "isComposing": true,
+          "value": "日你好月星你你好한 한",
+          "selectionStart": 11,
+          "selectionEnd": 11
+        },
+        {
+          "type": "compositionupdate",
+          "data": "韓",
+          "value": "日你好月星你你好한 한",
+          "selectionStart": 10,
+          "selectionEnd": 11
+        },
+        {
+          "type": "beforeinput",
+          "isComposing": true,
+          "inputType": "insertCompositionText",
+          "data": "韓",
+          "value": "日你好月星你你好한 한",
+          "selectionStart": 10,
+          "selectionEnd": 11
+        },
+        {
+          "type": "input",
+          "isComposing": true,
+          "inputType": "insertCompositionText",
+          "data": "韓",
+          "value": "日你好月星你你好한 韓",
+          "selectionStart": 11,
+          "selectionEnd": 11
+        },
+        {
+          "type": "compositionend",
+          "data": "韓",
+          "value": "日你好月星你你好한 韓",
+          "selectionStart": 11,
+          "selectionEnd": 11
+        },
+        {
+          "type": "keyup",
+          "key": "1",
+          "code": "Digit1",
+          "keyCode": 49,
+          "value": "日你好月星你你好한 韓",
+          "selectionStart": 11,
+          "selectionEnd": 11
+        }
+      ]
+    },
+    {
+      "name": "ibus-two-char-digit",
+      "engine": "probe (scripted IBus engine)",
+      "gesture": "type \"ni\", press 2",
+      "committed": "你好",
+      "onData": ["你好"],
+      "dom": [
+        {
+          "type": "keydown",
+          "key": "Process",
+          "code": "KeyN",
+          "keyCode": 229,
+          "value": "日",
+          "selectionStart": 1,
+          "selectionEnd": 1
+        },
+        {
+          "type": "compositionstart",
+          "data": "",
+          "value": "日",
+          "selectionStart": 1,
+          "selectionEnd": 1
+        },
+        {
+          "type": "compositionupdate",
+          "data": "n",
+          "value": "日",
+          "selectionStart": 1,
+          "selectionEnd": 1
+        },
+        {
+          "type": "beforeinput",
+          "isComposing": true,
+          "inputType": "insertCompositionText",
+          "data": "n",
+          "value": "日",
+          "selectionStart": 1,
+          "selectionEnd": 1
+        },
+        {
+          "type": "input",
+          "isComposing": true,
+          "inputType": "insertCompositionText",
+          "data": "n",
+          "value": "日n",
+          "selectionStart": 2,
+          "selectionEnd": 2
+        },
+        {
+          "type": "keyup",
+          "key": "n",
+          "code": "KeyN",
+          "keyCode": 78,
+          "isComposing": true,
+          "value": "日n",
+          "selectionStart": 2,
+          "selectionEnd": 2
+        },
+        {
+          "type": "keydown",
+          "key": "Process",
+          "code": "KeyI",
+          "keyCode": 229,
+          "isComposing": true,
+          "value": "日n",
+          "selectionStart": 2,
+          "selectionEnd": 2
+        },
+        {
+          "type": "compositionupdate",
+          "data": "ni",
+          "value": "日n",
+          "selectionStart": 1,
+          "selectionEnd": 2
+        },
+        {
+          "type": "beforeinput",
+          "isComposing": true,
+          "inputType": "insertCompositionText",
+          "data": "ni",
+          "value": "日n",
+          "selectionStart": 1,
+          "selectionEnd": 2
+        },
+        {
+          "type": "input",
+          "isComposing": true,
+          "inputType": "insertCompositionText",
+          "data": "ni",
+          "value": "日ni",
+          "selectionStart": 3,
+          "selectionEnd": 3
+        },
+        {
+          "type": "keyup",
+          "key": "i",
+          "code": "KeyI",
+          "keyCode": 73,
+          "isComposing": true,
+          "value": "日ni",
+          "selectionStart": 3,
+          "selectionEnd": 3
+        },
+        {
+          "type": "keydown",
+          "key": "Process",
+          "code": "Digit2",
+          "keyCode": 229,
+          "isComposing": true,
+          "value": "日ni",
+          "selectionStart": 3,
+          "selectionEnd": 3
+        },
+        {
+          "type": "compositionupdate",
+          "data": "你好",
+          "value": "日ni",
+          "selectionStart": 1,
+          "selectionEnd": 3
+        },
+        {
+          "type": "beforeinput",
+          "isComposing": true,
+          "inputType": "insertCompositionText",
+          "data": "你好",
+          "value": "日ni",
+          "selectionStart": 1,
+          "selectionEnd": 3
+        },
+        {
+          "type": "input",
+          "isComposing": true,
+          "inputType": "insertCompositionText",
+          "data": "你好",
+          "value": "日你好",
+          "selectionStart": 3,
+          "selectionEnd": 3
+        },
+        {
+          "type": "compositionend",
+          "data": "你好",
+          "value": "日你好",
+          "selectionStart": 3,
+          "selectionEnd": 3
+        },
+        {
+          "type": "keyup",
+          "key": "2",
+          "code": "Digit2",
+          "keyCode": 50,
+          "value": "日你好",
+          "selectionStart": 3,
+          "selectionEnd": 3
+        }
+      ]
+    }
+  ]
+}

--- a/src/renderer/src/components/terminal-pane/terminal-ime-candidate-commit-window.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-candidate-commit-window.test.ts
@@ -1,0 +1,151 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest'
+import { installTerminalImeCandidateCommitWindow } from './terminal-ime-candidate-commit-window'
+import { TERMINAL_IME_CANDIDATE_GUARD_POST_COMPOSITION_MS } from './terminal-ime-composition-tracker'
+import type { XtermBypassEvent } from './xterm-bypass-policy'
+
+function event(overrides: Partial<XtermBypassEvent>): XtermBypassEvent {
+  return {
+    type: 'keydown',
+    key: '',
+    code: '',
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    ...overrides
+  }
+}
+
+function installWindow(): {
+  element: HTMLElement
+  advance: (milliseconds: number) => void
+  commitWindow: ReturnType<typeof installTerminalImeCandidateCommitWindow>
+  now: () => number
+  compositionEnd: () => void
+} {
+  const element = document.createElement('div')
+  document.body.appendChild(element)
+  let clock = 1_000
+  const commitWindow = installTerminalImeCandidateCommitWindow({
+    terminalElement: element,
+    now: () => clock
+  })
+  return {
+    element,
+    commitWindow,
+    now: () => clock,
+    advance: (milliseconds) => {
+      clock += milliseconds
+    },
+    compositionEnd: () => {
+      element.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true }))
+    }
+  }
+}
+
+/** Feeds an event through the same classify-then-observe order the pane uses. */
+function handle(
+  harness: ReturnType<typeof installWindow>,
+  keyboardEvent: XtermBypassEvent
+): boolean {
+  const absorbed = harness.commitWindow.shouldAbsorbKeyEvent(keyboardEvent, harness.now())
+  harness.commitWindow.observeKeyboardEvent(keyboardEvent)
+  return absorbed
+}
+
+describe('installTerminalImeCandidateCommitWindow', () => {
+  it('absorbs the recorded IBus trailing bare digit release after a candidate commit', () => {
+    const harness = installWindow()
+    // The recorded IBus shape: the selector keydown is Process/229 on the digit's
+    // physical key, and only its release comes back as a bare digit.
+    expect(
+      handle(harness, event({ key: 'Process', code: 'Digit1', keyCode: 229, isComposing: true }))
+    ).toBe(false)
+    harness.compositionEnd()
+    expect(handle(harness, event({ type: 'keyup', key: '1', code: 'Digit1', keyCode: 49 }))).toBe(
+      true
+    )
+    harness.commitWindow.dispose()
+  })
+
+  it('absorbs a trailing bare Space release after a Space-committed candidate', () => {
+    const harness = installWindow()
+    handle(harness, event({ key: 'Process', code: 'Space', keyCode: 229, isComposing: true }))
+    harness.compositionEnd()
+    expect(handle(harness, event({ type: 'keyup', key: ' ', code: 'Space', keyCode: 32 }))).toBe(
+      true
+    )
+    harness.commitWindow.dispose()
+  })
+
+  it('leaves a fresh press of the same key alone so real typing still reaches the pty', () => {
+    const harness = installWindow()
+    handle(harness, event({ key: 'Process', code: 'Space', keyCode: 229, isComposing: true }))
+    harness.compositionEnd()
+    handle(harness, event({ type: 'keyup', key: ' ', code: 'Space', keyCode: 32 }))
+    expect(handle(harness, event({ key: ' ', code: 'Space', keyCode: 32 }))).toBe(false)
+    harness.commitWindow.dispose()
+  })
+
+  it('does not arm when the composition was committed by a non-candidate key', () => {
+    const harness = installWindow()
+    handle(harness, event({ key: 'Process', code: 'Enter', keyCode: 229, isComposing: true }))
+    harness.compositionEnd()
+    expect(handle(harness, event({ type: 'keyup', key: '1', code: 'Digit1', keyCode: 49 }))).toBe(
+      false
+    )
+    harness.commitWindow.dispose()
+  })
+
+  it('does not arm from an ordinary digit press that was never IME-owned', () => {
+    const harness = installWindow()
+    handle(harness, event({ key: '1', code: 'Digit1', keyCode: 49 }))
+    harness.compositionEnd()
+    expect(handle(harness, event({ type: 'keyup', key: '1', code: 'Digit1', keyCode: 49 }))).toBe(
+      false
+    )
+    harness.commitWindow.dispose()
+  })
+
+  it('does not arm once the selector was already released before the composition ended', () => {
+    const harness = installWindow()
+    handle(harness, event({ key: 'Process', code: 'Digit1', keyCode: 229, isComposing: true }))
+    handle(harness, event({ type: 'keyup', key: '1', code: 'Digit1', keyCode: 49 }))
+    harness.compositionEnd()
+    expect(handle(harness, event({ type: 'keyup', key: '1', code: 'Digit1', keyCode: 49 }))).toBe(
+      false
+    )
+    harness.commitWindow.dispose()
+  })
+
+  it('expires so a later bare digit is never dead', () => {
+    const harness = installWindow()
+    handle(harness, event({ key: 'Process', code: 'Digit1', keyCode: 229, isComposing: true }))
+    harness.compositionEnd()
+    harness.advance(TERMINAL_IME_CANDIDATE_GUARD_POST_COMPOSITION_MS + 1)
+    expect(
+      handle(harness, event({ type: 'keypress', key: '1', code: 'Digit1', keyCode: 49 }))
+    ).toBe(false)
+    harness.commitWindow.dispose()
+  })
+
+  it('drops its state on blur', () => {
+    const harness = installWindow()
+    handle(harness, event({ key: 'Process', code: 'Digit1', keyCode: 229, isComposing: true }))
+    harness.compositionEnd()
+    harness.element.dispatchEvent(new FocusEvent('blur', { bubbles: true }))
+    expect(handle(harness, event({ type: 'keyup', key: '1', code: 'Digit1', keyCode: 49 }))).toBe(
+      false
+    )
+    harness.commitWindow.dispose()
+  })
+
+  it('handles a missing terminal element', () => {
+    const commitWindow = installTerminalImeCandidateCommitWindow({ terminalElement: null })
+    expect(
+      commitWindow.shouldAbsorbKeyEvent(event({ type: 'keyup', key: '1', code: 'Digit1' }), 0)
+    ).toBe(false)
+    expect(() => commitWindow.dispose()).not.toThrow()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-ime-candidate-commit-window.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-candidate-commit-window.ts
@@ -1,0 +1,102 @@
+import type { IDisposable } from '@xterm/xterm'
+import {
+  clearTerminalImePendingCandidateKeyRelease,
+  createTerminalImePendingCandidateKeyReleases,
+  shouldApplyTerminalImePendingCandidateKeyRelease
+} from './terminal-ime-candidate-key-release-guard'
+import { TERMINAL_IME_CANDIDATE_GUARD_POST_COMPOSITION_MS } from './terminal-ime-composition-tracker'
+import type { XtermBypassEvent } from './xterm-bypass-policy'
+
+export type TerminalImeCandidateCommitWindow = IDisposable & {
+  /** True when this event is the committing candidate key's own trailing press or release. */
+  shouldAbsorbKeyEvent: (event: XtermBypassEvent, now: number) => boolean
+  /** Advances the state after a classification is consumed; call for every pane key event. */
+  observeKeyboardEvent: (event: XtermBypassEvent) => void
+}
+
+// Why by physical code: `key` reads "Process" while the IME owns the press, so
+// only `code` still identifies which selector the user pressed.
+const CANDIDATE_SELECTION_KEY_BY_CODE = new Map<string, string>([
+  ['Space', ' '],
+  ...Array.from({ length: 10 }, (_, digit): [string, string] => [`Digit${digit}`, String(digit)]),
+  ...Array.from({ length: 10 }, (_, digit): [string, string] => [`Numpad${digit}`, String(digit)])
+])
+
+/** Returns whether the IME, not the keyboard layout, owns this keystroke. */
+function isImeOwnedKeydown(event: XtermBypassEvent): boolean {
+  return event.isComposing === true || event.keyCode === 229 || event.key === 'Process'
+}
+
+/**
+ * Arms the post-compositionend candidate-key absorption from evidence IBus
+ * actually provides.
+ *
+ * Recorded IBus candidate picks (`__fixtures__/ibus-chinese-candidate-digit-terminal-trace.json`)
+ * deliver the selector keydown as Process/229 and its release as a bare digit
+ * *after* compositionend, and never emit the empty compositionupdate that
+ * `terminal-ime-composition-tracker` needs to arm its window. The selector
+ * still being held when the composition ends is the signal that is present.
+ *
+ * Absorption reuses the pending-release rules, so only that key's trailing
+ * press/release is taken — a fresh press of the same key is left alone.
+ */
+export function installTerminalImeCandidateCommitWindow(args: {
+  terminalElement: HTMLElement | null | undefined
+  now?: () => number
+}): TerminalImeCandidateCommitWindow {
+  const now = args.now ?? ((): number => Date.now())
+  const heldCandidateKeysByCode = new Map<string, string>()
+  const pendingReleases = createTerminalImePendingCandidateKeyReleases()
+
+  const shouldAbsorbKeyEvent = (event: XtermBypassEvent, at: number): boolean =>
+    shouldApplyTerminalImePendingCandidateKeyRelease(event, pendingReleases, at)
+
+  const observeKeyboardEvent = (event: XtermBypassEvent): void => {
+    clearTerminalImePendingCandidateKeyRelease(pendingReleases, event)
+    const code = event.code
+    const candidateKey = code ? CANDIDATE_SELECTION_KEY_BY_CODE.get(code) : undefined
+    if (!code || candidateKey === undefined) {
+      return
+    }
+    if (event.type === 'keydown') {
+      if (isImeOwnedKeydown(event)) {
+        heldCandidateKeysByCode.set(code, candidateKey)
+      } else {
+        // Ordinary typing on the same physical key must not look like a pick.
+        heldCandidateKeysByCode.delete(code)
+      }
+      return
+    }
+    if (event.type === 'keyup') {
+      heldCandidateKeysByCode.delete(code)
+    }
+  }
+
+  const handleCompositionEnd = (): void => {
+    const expiresAt = now() + TERMINAL_IME_CANDIDATE_GUARD_POST_COMPOSITION_MS
+    for (const candidateKey of heldCandidateKeysByCode.values()) {
+      pendingReleases.set(candidateKey, expiresAt)
+    }
+  }
+
+  const reset = (): void => {
+    heldCandidateKeysByCode.clear()
+    pendingReleases.clear()
+  }
+
+  const terminalElement = args.terminalElement
+  if (!terminalElement) {
+    return { shouldAbsorbKeyEvent, observeKeyboardEvent, dispose: () => undefined }
+  }
+  terminalElement.addEventListener('compositionend', handleCompositionEnd, true)
+  terminalElement.addEventListener('blur', reset, true)
+  return {
+    shouldAbsorbKeyEvent,
+    observeKeyboardEvent,
+    dispose: () => {
+      reset()
+      terminalElement.removeEventListener('compositionend', handleCompositionEnd, true)
+      terminalElement.removeEventListener('blur', reset, true)
+    }
+  }
+}

--- a/src/renderer/src/components/terminal-pane/terminal-ime-keydown-race-commit.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-keydown-race-commit.ts
@@ -1,0 +1,82 @@
+import type { IDisposable } from '@xterm/xterm'
+
+type TerminalImeRaceKeyEvent = {
+  type: string
+  key?: string
+  keyCode?: number
+  isComposing?: boolean
+}
+
+export type TerminalImeKeydownRaceCommit = IDisposable & {
+  /** Feeds a terminal key event in; call for every event the pane handles. */
+  observeKeyboardEvent: (event: TerminalImeRaceKeyEvent) => void
+}
+
+/** Returns whether the browser marked this keystroke as IME-owned. */
+function isImeOwnedKeydown(event: TerminalImeRaceKeyEvent): boolean {
+  return event.isComposing === true || event.keyCode === 229 || event.key === 'Process'
+}
+
+/**
+ * Forwards an IME commit that xterm drops because a keydown is still in flight.
+ *
+ * xterm only accepts an `insertText` input event when `!ev.composed ||
+ * !this._keyDownSeen` (CoreBrowserTerminal._inputEvent), so a commit delivered
+ * inside the candidate key's own keydown is discarded — the reported single
+ * character vanishes while a mouse pick, which has no keydown in flight,
+ * survives. The condition here is the exact complement of xterm's own emitting
+ * paths, so the same commit can never be sent twice.
+ */
+export function installTerminalImeKeydownRaceCommit(args: {
+  terminalElement: HTMLElement | null | undefined
+  sendInput: (data: string) => void
+  hasPendingComposition: () => boolean
+}): TerminalImeKeydownRaceCommit {
+  let ordinaryKeydownInFlight = false
+
+  // Mirrors xterm's own _keyDownSeen, which it sets before the custom key
+  // handler runs and clears at the top of keyup. IME-marked presses are
+  // excluded: xterm answers a bare 229 keydown with its textarea-diff commit,
+  // so forwarding those would send the same text twice.
+  const observeKeyboardEvent = (event: TerminalImeRaceKeyEvent): void => {
+    if (event.type === 'keydown') {
+      ordinaryKeydownInFlight = !isImeOwnedKeydown(event)
+      return
+    }
+    if (event.type === 'keyup') {
+      ordinaryKeydownInFlight = false
+    }
+  }
+
+  const forwardDroppedCommit = (event: Event): void => {
+    if (!(event instanceof InputEvent) || event.inputType !== 'insertText' || !event.data) {
+      return
+    }
+    if (!event.composed || !ordinaryKeydownInFlight || event.isComposing === true) {
+      return
+    }
+    // A live or unsettled composition transaction owns its own commit.
+    if (args.hasPendingComposition()) {
+      return
+    }
+    args.sendInput(event.data)
+  }
+
+  const clearKeydown = (): void => {
+    ordinaryKeydownInFlight = false
+  }
+
+  const terminalElement = args.terminalElement
+  if (!terminalElement) {
+    return { observeKeyboardEvent, dispose: () => undefined }
+  }
+  terminalElement.addEventListener('input', forwardDroppedCommit, true)
+  terminalElement.addEventListener('blur', clearKeydown, true)
+  return {
+    observeKeyboardEvent,
+    dispose: () => {
+      terminalElement.removeEventListener('input', forwardDroppedCommit, true)
+      terminalElement.removeEventListener('blur', clearKeydown, true)
+    }
+  }
+}

--- a/src/renderer/src/components/terminal-pane/terminal-ime-linux-candidate-commit-trace.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-linux-candidate-commit-trace.test.ts
@@ -1,0 +1,316 @@
+// @vitest-environment happy-dom
+// Replays candidate-selection captures taken against a live ibus-daemon on Linux/X11
+// (see the fixture's `recordedFrom`) through a real xterm Terminal wired with the pane's
+// Linux IME key policy, and asserts the PTY bytes.
+//
+// The gesture is #12099: pick a candidate with a number key. A one-character pick is asserted
+// separately from a multi-character one because only the one-character pick can be committed
+// with no preedit of its own, which is the shape xterm drops.
+import { Terminal } from '@xterm/xterm'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import trace from './__fixtures__/ibus-chinese-candidate-digit-terminal-trace.json'
+import { installTerminalImeCandidateCommitWindow } from './terminal-ime-candidate-commit-window'
+import {
+  armTerminalImePendingCandidateKeyRelease,
+  clearTerminalImePendingCandidateKeyRelease,
+  createTerminalImePendingCandidateKeyReleases,
+  shouldApplyTerminalImePendingCandidateKeyRelease
+} from './terminal-ime-candidate-key-release-guard'
+import {
+  hasPendingTerminalImeComposition,
+  installTerminalImeCompositionRoute
+} from './terminal-ime-composition-route'
+import { installTerminalImeCompositionTracker } from './terminal-ime-composition-tracker'
+import { installTerminalImeKeydownRaceCommit } from './terminal-ime-keydown-race-commit'
+import { installTerminalImeLinuxCandidateState } from './terminal-ime-linux-candidate-state'
+import {
+  shouldPreventDefaultTerminalImeCandidateKey,
+  shouldSuppressTerminalImeKeyboardEvent,
+  type XtermBypassEvent
+} from './xterm-bypass-policy'
+
+type RecordedEvent = {
+  type: string
+  key?: string
+  code?: string
+  keyCode?: number
+  isComposing?: boolean
+  inputType?: string
+  data?: string
+  value?: string
+  selectionStart?: number
+  selectionEnd?: number
+}
+
+type Pane = {
+  emitted: string[]
+  /** Key events the policy handed to xterm rather than claiming for the IME. */
+  reachedXterm: XtermBypassEvent[]
+  terminal: Terminal
+  textarea: HTMLTextAreaElement
+  dispose: () => void
+}
+
+function capture(name: string): { dom: RecordedEvent[]; committed: string } {
+  const found = trace.captures.find((entry) => entry.name === name)
+  if (!found) {
+    throw new Error(`missing recorded capture: ${name}`)
+  }
+  return { dom: found.dom as RecordedEvent[], committed: found.committed }
+}
+
+/** Wires a real Terminal with the same Linux IME key policy `use-terminal-pane-lifecycle` installs. */
+function openPane(): Pane {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const terminal = new Terminal()
+  terminal.open(container)
+  const textarea = terminal.textarea
+  const element = terminal.element
+  if (!textarea || !element) {
+    throw new Error('xterm helper elements were not created')
+  }
+  const emitted: string[] = []
+  terminal.onData((data) => emitted.push(data))
+  const reachedXterm: XtermBypassEvent[] = []
+
+  const transport = { getPtyId: () => 'trace-pty' }
+  const compositionRoute = installTerminalImeCompositionRoute({
+    terminalElement: element,
+    terminal,
+    capturedTransport: transport as never,
+    getCurrentTransport: () => transport as never
+  })
+  const compositionTracker = installTerminalImeCompositionTracker(element)
+  const linuxCandidateState = installTerminalImeLinuxCandidateState(element)
+  const candidateCommitWindow = installTerminalImeCandidateCommitWindow({
+    terminalElement: element
+  })
+  const keydownRaceCommit = installTerminalImeKeydownRaceCommit({
+    terminalElement: element,
+    sendInput: (data) => terminal.input(data),
+    hasPendingComposition: () =>
+      compositionTracker.isActive() || hasPendingTerminalImeComposition(element)
+  })
+  const pendingReleases = createTerminalImePendingCandidateKeyReleases()
+
+  terminal.attachCustomKeyEventHandler((e) => {
+    const classification = linuxCandidateState.classifyKeyboardEvent(e)
+    const observe = (): void => {
+      linuxCandidateState.observeKeyboardEvent(e, classification)
+      candidateCommitWindow.observeKeyboardEvent(e)
+      keydownRaceCommit.observeKeyboardEvent(e)
+    }
+    const now = Date.now()
+    const pendingRelease =
+      shouldApplyTerminalImePendingCandidateKeyRelease(e, pendingReleases, now) ||
+      candidateCommitWindow.shouldAbsorbKeyEvent(e, now)
+    const options = {
+      compositionActive: compositionTracker.isActive(),
+      candidateKeyGuardActive: compositionTracker.isCandidateKeyGuardActive() || pendingRelease,
+      pendingCandidateKeyReleaseActive: pendingRelease,
+      linuxOrphanCandidateDigitGuardActive: classification.candidateDigitGuardActive,
+      isMac: false,
+      isLinux: true
+    }
+    if (shouldSuppressTerminalImeKeyboardEvent(e, options)) {
+      clearTerminalImePendingCandidateKeyRelease(pendingReleases, e)
+      if (shouldPreventDefaultTerminalImeCandidateKey(e, options)) {
+        armTerminalImePendingCandidateKeyRelease(pendingReleases, e, now)
+      }
+      observe()
+      return false
+    }
+    clearTerminalImePendingCandidateKeyRelease(pendingReleases, e)
+    observe()
+    reachedXterm.push(e)
+    return true
+  })
+
+  return {
+    emitted,
+    reachedXterm,
+    terminal,
+    textarea,
+    dispose: () => {
+      keydownRaceCommit.dispose()
+      candidateCommitWindow.dispose()
+      linuxCandidateState.dispose()
+      compositionTracker.dispose()
+      compositionRoute.dispose()
+      terminal.dispose()
+    }
+  }
+}
+
+function buildEvent(recorded: RecordedEvent): Event {
+  if (recorded.type === 'keydown' || recorded.type === 'keyup' || recorded.type === 'keypress') {
+    const keyboard = new KeyboardEvent(recorded.type, {
+      bubbles: true,
+      cancelable: true,
+      code: recorded.code,
+      isComposing: recorded.isComposing,
+      key: recorded.key
+    })
+    Object.defineProperty(keyboard, 'keyCode', { value: recorded.keyCode })
+    return keyboard
+  }
+  if (recorded.type === 'input' || recorded.type === 'beforeinput') {
+    const input = new InputEvent(recorded.type, {
+      bubbles: true,
+      isComposing: recorded.isComposing
+    })
+    // happy-dom drops these from InputEventInit; Chromium supplies all of them.
+    Object.defineProperty(input, 'inputType', { value: recorded.inputType ?? '' })
+    Object.defineProperty(input, 'data', { value: recorded.data ?? null })
+    Object.defineProperty(input, 'composed', { value: true })
+    return input
+  }
+  const composition = new CompositionEvent(recorded.type, { bubbles: true })
+  Object.defineProperty(composition, 'data', { value: recorded.data ?? '' })
+  return composition
+}
+
+/** Each capture snapshots the textarea as the handler saw it, so restore that before dispatching. */
+function replay(pane: Pane, recorded: RecordedEvent): void {
+  if (recorded.value !== undefined) {
+    pane.textarea.value = recorded.value
+  }
+  if (recorded.selectionStart !== undefined && recorded.selectionEnd !== undefined) {
+    pane.textarea.setSelectionRange(recorded.selectionStart, recorded.selectionEnd)
+  }
+  pane.textarea.dispatchEvent(buildEvent(recorded))
+}
+
+function nextTask(): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, 0))
+}
+
+async function replayCapture(pane: Pane, name: string): Promise<string> {
+  const { dom } = capture(name)
+  for (const recorded of dom) {
+    // Keys were driven ~80 ms apart, so each physical key event owned its own task.
+    if (recorded.type === 'keydown' || recorded.type === 'keyup') {
+      await nextTask()
+    }
+    replay(pane, recorded)
+  }
+  await nextTask()
+  return pane.emitted.join('')
+}
+
+describe('Linux IBus candidate commit', () => {
+  beforeEach(() => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      measureText: () => ({ width: 10 })
+    } as unknown as CanvasRenderingContext2D)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    document.body.replaceChildren()
+  })
+
+  it('delivers a one-character candidate committed as insertText on the selector keydown', async () => {
+    const pane = openPane()
+    // xterm ignores an insertText commit while a keydown is in flight
+    // (CoreBrowserTerminal._inputEvent: `!ev.composed || !this._keyDownSeen`), which is
+    // exactly a one-character pick committed with no preedit of its own — #12099. A
+    // multi-character pick needs a preedit, so it commits through compositionend instead.
+    await nextTask()
+    replay(pane, { type: 'keydown', key: '1', code: 'Digit1', keyCode: 49 })
+    replay(pane, { type: 'input', inputType: 'insertText', data: '你', value: '你' })
+    await nextTask()
+    replay(pane, { type: 'keyup', key: '1', code: 'Digit1', keyCode: 49 })
+    await nextTask()
+
+    // Not an exact match: the selector byte xterm already sent before the commit arrived is a
+    // separate, still-open leak. This pins the wipe — the committed character now reaches the pty.
+    expect(pane.emitted.join('')).toContain('你')
+    pane.dispose()
+  })
+
+  it('sends a commit that follows a bare 229 keydown exactly once', async () => {
+    const pane = openPane()
+    // xterm answers a standalone 229 keydown with its own textarea-diff commit, so the
+    // forwarder must stay out of that press or the character arrives twice.
+    await nextTask()
+    replay(pane, { type: 'keydown', key: 'Process', code: 'Digit1', keyCode: 229 })
+    replay(pane, { type: 'input', inputType: 'insertText', data: '\u4f60', value: '\u4f60' })
+    await nextTask()
+    replay(pane, { type: 'keyup', key: '1', code: 'Digit1', keyCode: 49 })
+    await nextTask()
+
+    expect(pane.emitted.join('')).toBe('\u4f60')
+    pane.dispose()
+  })
+
+  it('sends a mouse-picked commit exactly once', async () => {
+    const pane = openPane()
+    // No keydown in flight: xterm owns this one, and the forwarder must stay out.
+    replay(pane, { type: 'input', inputType: 'insertText', data: '你', value: '你' })
+    await nextTask()
+
+    expect(pane.emitted.join('')).toBe('你')
+    pane.dispose()
+  })
+
+  it('keeps the recorded one-character candidate pick out of a trailing bare digit', async () => {
+    const pane = openPane()
+    const emitted = await replayCapture(pane, 'ibus-table-cangjie5-single-char-digit')
+
+    expect(emitted).toBe(capture('ibus-table-cangjie5-single-char-digit').committed)
+    expect(
+      pane.reachedXterm.filter((event) => event.key === '1'),
+      'the selector release must not reach xterm after the composition it committed'
+    ).toEqual([])
+    pane.dispose()
+  })
+
+  it('keeps a recorded multi-character candidate pick working', async () => {
+    const pane = openPane()
+    const emitted = await replayCapture(pane, 'ibus-two-char-digit')
+
+    expect(emitted).toBe(capture('ibus-two-char-digit').committed)
+    expect(pane.reachedXterm.filter((event) => event.key === '2')).toEqual([])
+    pane.dispose()
+  })
+
+  it('keeps the recorded hanja number pick working', async () => {
+    const pane = openPane()
+    const emitted = await replayCapture(pane, 'ibus-hangul-hanja-single-char-digit')
+
+    expect(emitted).toBe(capture('ibus-hangul-hanja-single-char-digit').committed)
+    pane.dispose()
+  })
+
+  it('still suppresses a bare candidate digit after an orphaned letter release', async () => {
+    const pane = openPane()
+    await nextTask()
+    replay(pane, { type: 'keyup', key: 'a', code: 'KeyA', keyCode: 65 })
+    await nextTask()
+    replay(pane, { type: 'keydown', key: '1', code: 'Digit1', keyCode: 49 })
+    await nextTask()
+
+    expect(pane.emitted.join('')).toBe('')
+    pane.dispose()
+  })
+
+  it('leaves ordinary typing alone', async () => {
+    const pane = openPane()
+    for (const [key, code, keyCode] of [
+      ['a', 'KeyA', 65],
+      ['1', 'Digit1', 49],
+      ['b', 'KeyB', 66],
+      ['2', 'Digit2', 50]
+    ] as const) {
+      await nextTask()
+      replay(pane, { type: 'keydown', key, code, keyCode })
+      replay(pane, { type: 'keyup', key, code, keyCode })
+    }
+    await nextTask()
+
+    expect(pane.emitted.join('')).toBe('a1b2')
+    pane.dispose()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -94,6 +94,9 @@ import {
   resolveNonLatinControlChordInput
 } from './terminal-non-latin-control-chord'
 import { installTerminalImeCompositionTracker } from './terminal-ime-composition-tracker'
+import { installTerminalImeCandidateCommitWindow } from './terminal-ime-candidate-commit-window'
+import { hasPendingTerminalImeComposition } from './terminal-ime-composition-route'
+import { installTerminalImeKeydownRaceCommit } from './terminal-ime-keydown-race-commit'
 import { installTerminalImeLinuxCandidateState } from './terminal-ime-linux-candidate-state'
 import {
   armTerminalImePendingCandidateKeyRelease,
@@ -999,10 +1002,25 @@ export function useTerminalPaneLifecycle({
           ? installTerminalImeLinuxCandidateState(pane.terminal.element)
           : null
         const imeCompositionTracker = installTerminalImeCompositionTracker(pane.terminal.element)
+        const imeCandidateCommitWindow = isLinux
+          ? installTerminalImeCandidateCommitWindow({ terminalElement: pane.terminal.element })
+          : null
+        // Why: xterm drops an insertText commit that races the candidate key's own keydown.
+        const imeKeydownRaceCommit = isLinux
+          ? installTerminalImeKeydownRaceCommit({
+              terminalElement: pane.terminal.element,
+              sendInput: (data) => pane.terminal.input(data),
+              hasPendingComposition: () =>
+                imeCompositionTracker.isActive() ||
+                hasPendingTerminalImeComposition(pane.terminal.element)
+            })
+          : null
         imeCompositionDisposablesRef.current.set(pane.id, {
           dispose: () => {
             imeCompositionTracker.dispose()
             linuxImeCandidateState?.dispose()
+            imeCandidateCommitWindow?.dispose()
+            imeKeydownRaceCommit?.dispose()
           }
         })
         // Why: macOS commits an input source's substituted text through the input event alone, so printable keydowns must not reach xterm's encoder.
@@ -1023,9 +1041,11 @@ export function useTerminalPaneLifecycle({
           const linuxCandidateClassification = linuxImeCandidateState?.classifyKeyboardEvent(e) ?? {
             candidateDigitGuardActive: false
           }
-          /** Advances the fallback state after every terminal key event path. */
+          /** Advances the IME key-state trackers after every terminal key event path. */
           const observeLinuxCandidateEvent = (): void => {
             linuxImeCandidateState?.observeKeyboardEvent(e, linuxCandidateClassification)
+            imeCandidateCommitWindow?.observeKeyboardEvent(e)
+            imeKeydownRaceCommit?.observeKeyboardEvent(e)
           }
           const now = Date.now()
           const pendingCandidateReleaseGuardActive =
@@ -1033,7 +1053,7 @@ export function useTerminalPaneLifecycle({
               e,
               pendingTerminalImeCandidateKeyReleases,
               now
-            )
+            ) || imeCandidateCommitWindow?.shouldAbsorbKeyEvent(e, now) === true
           const imeKeyboardOptions = {
             compositionActive: imeCompositionTracker.isActive(),
             candidateKeyGuardActive:


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | +468 | −1 | +467 |
| Prod | 4 | +689 | −2 | +687 |

<!-- /orca-pr-loc -->

Addresses #12099. **Read the three caveats at the bottom before merging** — this is a partial fix with a coverage gap, and I would rather that be the first thing a reviewer sees than the last.

## What was actually proved

The erasure is in **xterm**, not in Orca's candidate guard. `CoreBrowserTerminal._inputEvent` accepts an `insertText` commit only when `(!ev.composed || !this._keyDownSeen)`. A real IME commit is `composed: true`, and `_keyDownSeen` is set at the top of `_keyDown` before the custom handler runs. Driving a real `Terminal`:

| shape | `onData` on `origin/main` |
|---|---|
| bare selector keydown (`'1'`, 49) + `insertText '你'` | `['1']` — digit sent, **character wiped** |
| mouse pick (`insertText`, no keydown in flight) | `['你']` — works |

That reproduces all three of the reporter's observations, including the discriminator: only a **one-character** pick can commit with no preedit of its own. A multi-character pick has a preedit and commits through `compositionend`, which the existing composition route delivers.

## Confirmed against a real Ubuntu host

Live ibus DOM traces captured from an Electron renderer with `ibus-daemon` 1.5.29 under Xvfb, driven by xdotool:

- ibus emits **no empty `compositionupdate`** anywhere near a candidate pick, so `sawEmptyCompositionUpdate` is always false and the post-`compositionend` window in `terminal-ime-composition-tracker.ts` **never arms with ibus at all**.
- The selector keydown arrives as `key:'Process', code:'Digit1', keyCode:229`, and its **release comes back bare** (`key:'1'`, 49, `isComposing:false`) *after* `compositionend` — unguarded on main.

**One earlier hypothesis was disproved:** the orphan-letter-keyup fallback is not implicated. The preedit letters have matching `Process`/229 keydowns on the same `code`, so that fallback correctly never arms.

The GIF in the issue is opencode 1.18.4 inside Orca; frame ~46 shows the literal `1` — the leaked selector byte.

## The change

- `terminal-ime-keydown-race-commit.ts` (82 lines) — forwards exactly the commits xterm drops. Its condition is the complement of xterm's own emitting paths, including the textarea-diff commit xterm answers a bare 229 keydown with. A double-send through that path was hit during development and is closed, with a test.
- `terminal-ime-candidate-commit-window.ts` (102) — arms candidate-key absorption from the signal ibus actually gives: the selector still held when the composition ends. Reuses the existing pending-release rules, so only that key's own trailing press/release is taken and a fresh press is untouched.
- `use-terminal-pane-lifecycle.ts` (+22/−2) — wires both, Linux-only.

**206 production lines.** No existing assertion was changed or deleted.

## Discrimination

With the modules absent (their state on `origin/main`), 5 tests fail; with them, 17 pass. The load-bearing one:

```
FAIL > delivers a one-character candidate committed as insertText on the selector keydown
AssertionError: expected '1' to contain '你'
```

Multi-character selection and the orphan-digit fallback both keep coverage and stay green.

## What reference implementations do

Two mature terminals both track composing state — but as marked/preedit text, never as a "candidate window is open" flag. What saves them is routing the key through the platform IM API *first* and encoding nothing if it was consumed, taking the commit from a separate callback. Orca's browser equivalent of "the IM consumed it" is `keyCode === 229` / `key === 'Process'` / `isComposing`, and Orca already honours it correctly. This failure is precisely the case where Chromium does **not** set that marker, so there is no pre-emption signal available — which is why this recovers the commit rather than suppressing the key.

---

# Three caveats

**1. It is a partial fix. The digit still leaks.** In the shape where the selector keydown arrives bare, xterm has already sent the digit before the commit event exists. The user goes from `1` (character destroyed) to `1你` (character recovered, stray digit). Strictly better — data loss becomes a cosmetic artifact — but *not what the reporter asked for*. The test asserts `toContain('你')` with a comment saying so, rather than pinning `'1你'` as correct. Pre-empting the digit means withholding every bare digit/space keydown on Linux for a task and re-encoding it outside xterm's keyboard service (kitty, win32 input mode, `onKey`) — judged too large and too untestable to fold in here.

**2. The wiring is not covered.** The tests exercise the two modules directly; the trace spec re-implements the lifecycle's key policy inline and only *comments* that it mirrors it. I verified this by restoring `use-terminal-pane-lifecycle.ts` from `origin/main` and re-running: **everything still passes.** So the fix could be silently disconnected and CI would stay green. This matches an existing convention in the repo (the macOS keybinding-dict spec mirrors the same way), but it matters more here because the wiring is `isLinux`-gated and a wrong gate would be invisible.

**3. The failing DOM shape was never observed from a live engine.** Every real ibus engine driven on Ubuntu — `ibus-table:cangjie5`, `ibus-hangul` hanja, and a purpose-written engine that commits with no preedit change — normalized to `Process`/229 + `compositionupdate` + `compositionend`. The sequence xterm drops is proven **at the xterm level**, not observed from ibus. `ibus-libpinyin`, the reporter's likely engine, is not installed and there is no passwordless sudo on that host.

Extending the repo's own `terminal-ime-e2e.yml` to a Chinese engine needs `ibus-libpinyin` in the workflow's apt list — a one-line change if you want real CI coverage for this.
