### PR TITLE
fix(orchestration): teach dispatched workers the status message for progress

### DIFF
--- a/src/main/runtime/orchestration/__snapshots__/preamble.test.ts.snap
+++ b/src/main/runtime/orchestration/__snapshots__/preamble.test.ts.snap
@@ -23,12 +23,28 @@ Slack, GitHub comments, or any other channel to reach a human during the run.
   # Never encode failure only in prose and never silently exit.
   # Include BOTH taskId and dispatchId in the payload so a late completion
   # from a failed retry cannot complete the current dispatch.
+  #
+  # RULE: worker_done is terminal, not a progress report. It settles the task
+  # and revokes your dispatch capability the moment it lands, so a mid-run
+  # update sent this way ends your run and makes every later worker_done and
+  # heartbeat fail. For an interim update use --type status below.
   orca orchestration send --from term_WORKER \\
     --type worker_done --subject "<short status>" \\
     --body "<3-sentence summary: what you did, what you found, what's left>" \\
     --task-id task_SNAP --dispatch-id ctx_SNAP --outcome succeeded \\
     --files-modified "path/a,path/b" \\
     --report-path "<optional: path to the full artifact>"
+
+  # Report mid-run progress without ending the task.
+  #
+  # RULE: status is the only content-bearing message that settles nothing, so
+  # every "phase one is done, starting phase two" update belongs here. Reach
+  # for it whenever you have something to say and the task is not finished;
+  # heartbeat carries no body, and worker_done would end the run.
+  orca orchestration send --from term_WORKER \\
+    --type status --subject "<short progress headline>" \\
+    --body "<what just finished, what you are starting next>" \\
+    --task-id task_SNAP --dispatch-id ctx_SNAP
 
   # BEHAVIOR RULE: send a heartbeat every 5 minutes
   # while actively working on the task. The coordinator uses this to

--- a/src/main/runtime/orchestration/__snapshots__/preamble.test.ts.snap
+++ b/src/main/runtime/orchestration/__snapshots__/preamble.test.ts.snap
@@ -29,7 +29,7 @@ Slack, GitHub comments, or any other channel to reach a human during the run.
   # update sent this way ends your run and makes every later worker_done and
   # heartbeat fail. For an interim update use --type status below.
   orca orchestration send --from term_WORKER \\
-    --type worker_done --subject "<short status>" \\
+    --type worker_done --subject "<short completion headline>" \\
     --body "<3-sentence summary: what you did, what you found, what's left>" \\
     --task-id task_SNAP --dispatch-id ctx_SNAP --outcome succeeded \\
     --files-modified "path/a,path/b" \\
@@ -37,10 +37,13 @@ Slack, GitHub comments, or any other channel to reach a human during the run.
 
   # Report mid-run progress without ending the task.
   #
-  # RULE: status is the only content-bearing message that settles nothing, so
-  # every "phase one is done, starting phase two" update belongs here. Reach
-  # for it whenever you have something to say and the task is not finished;
-  # heartbeat carries no body, and worker_done would end the run.
+  # RULE: use status for "phase one is done, starting phase two" progress —
+  # you are neither finished nor blocked, and heartbeat carries no body to
+  # say it in. Put the headline in --subject: the coordinator loop logs the
+  # subject and leaves the body for whoever opens the message.
+  #
+  # It does not replace the commands below: ask when you need an answer,
+  # escalation when you are blocked, worker_done only when the task is over.
   orca orchestration send --from term_WORKER \\
     --type status --subject "<short progress headline>" \\
     --body "<what just finished, what you are starting next>" \\

--- a/src/main/runtime/orchestration/preamble.test.ts
+++ b/src/main/runtime/orchestration/preamble.test.ts
@@ -77,6 +77,31 @@ describe('buildDispatchPreamble', () => {
     }
   )
 
+  it('offers status as the content-bearing way to report mid-run progress', () => {
+    const result = buildDispatchPreamble(baseParams())
+    // Why: status is the only worker message that carries a body without
+    // settling anything. Without it in the preamble the sole content-bearing
+    // command a worker has been taught is worker_done, so a progress update
+    // becomes a completion and revokes the dispatch capability.
+    expect(result).toContain('--type status')
+    expect(result).toMatch(/--subject "<short progress headline>"/)
+    expect(result).toContain('--body "<what just finished, what you are starting next>"')
+    // Attribution matches the other lifecycle-adjacent commands so the
+    // coordinator can place the update on the right dispatch, not just the task.
+    expect(result).toMatch(/--type status[\s\S]*--task-id task_abc123 --dispatch-id ctx_def456/)
+    expect(result).toMatch(/orchestration send --from term_worker/)
+  })
+
+  it('warns that worker_done is terminal and revokes the dispatch capability', () => {
+    const result = buildDispatchPreamble(baseParams())
+    // Why: naming the consequence is what separates the two commands. A worker
+    // told only "send it exactly once" still reads worker_done as the reporting
+    // verb; a worker told it revokes the capability does not reach for it midway.
+    expect(result).toMatch(/worker_done is terminal, not a progress report/)
+    expect(result).toMatch(/revokes your dispatch capability/)
+    expect(result).toMatch(/use --type status/)
+  })
+
   it('includes heartbeat CLI block with taskId and dispatchId and 5-minute cadence', () => {
     const result = buildDispatchPreamble(baseParams())
     expect(result).toContain('--type heartbeat')
@@ -123,7 +148,10 @@ describe('buildDispatchPreamble', () => {
       dispatchCapability: 'dcap_test_secret'
     })
 
-    expect(result.match(/--dispatch-capability dcap_test_secret/g)).toHaveLength(4)
+    // worker_done, status, heartbeat, ask, escalation. Only the first and the
+    // heartbeat are capability-gated at the runtime, but every worker-originated
+    // command carries the flag so one omission cannot become the odd one out.
+    expect(result.match(/--dispatch-capability dcap_test_secret/g)).toHaveLength(5)
     expect(result).not.toContain('"dispatchCapability"')
   })
 

--- a/src/main/runtime/orchestration/preamble.test.ts
+++ b/src/main/runtime/orchestration/preamble.test.ts
@@ -162,10 +162,24 @@ describe('buildDispatchPreamble', () => {
       dispatchCapability: 'dcap_test_secret'
     })
 
-    // worker_done, status, heartbeat, ask, escalation. The runtime verifies the
-    // capability for worker_done and heartbeat on the send path and for ask on
-    // its own; status and escalation are not verified. Every worker-originated
-    // command still carries the flag so one omission cannot become the odd one out.
+    // Why per command, not a count: a bare total passes when one command loses
+    // the flag and another gains it twice, which is exactly the shape a bad edit
+    // takes. The runtime verifies the capability for worker_done and heartbeat
+    // on the send path and for ask on its own; status and escalation are not
+    // verified, but every worker-originated command carries it so one omission
+    // cannot become the odd one out. `[^#]*` keeps each match inside its block.
+    const sendCarriesCapability = (type: string) =>
+      new RegExp(
+        `orchestration send --from term_worker --dispatch-capability dcap_test_secret[^#]*--type ${type}\\b`
+      )
+
+    for (const type of ['worker_done', 'status', 'heartbeat', 'escalation']) {
+      expect(result).toMatch(sendCarriesCapability(type))
+    }
+    expect(result).toMatch(
+      /orchestration ask --from term_worker --dispatch-capability dcap_test_secret[^#]*--question/
+    )
+    // Total guard so a sixth carrier cannot appear unasserted.
     expect(result.match(/--dispatch-capability dcap_test_secret/g)).toHaveLength(5)
     expect(result).not.toContain('"dispatchCapability"')
   })

--- a/src/main/runtime/orchestration/preamble.test.ts
+++ b/src/main/runtime/orchestration/preamble.test.ts
@@ -86,9 +86,10 @@ describe('buildDispatchPreamble', () => {
     expect(result).toContain('--type status')
     expect(result).toMatch(/--subject "<short progress headline>"/)
     expect(result).toContain('--body "<what just finished, what you are starting next>"')
-    // Attribution matches the other lifecycle-adjacent commands so the
-    // coordinator can place the update on the right dispatch, not just the task.
-    expect(result).toMatch(/--type status[\s\S]*--task-id task_abc123 --dispatch-id ctx_def456/)
+    // Why: the IDs must be on the status command itself, not merely somewhere
+    // in the preamble, so the match is anchored inside one command block —
+    // `[^#]*` cannot cross the comment header that starts the next one.
+    expect(result).toMatch(/--type status[^#]*--task-id task_abc123 --dispatch-id ctx_def456/)
     expect(result).toMatch(/orchestration send --from term_worker/)
   })
 
@@ -100,6 +101,19 @@ describe('buildDispatchPreamble', () => {
     expect(result).toMatch(/worker_done is terminal, not a progress report/)
     expect(result).toMatch(/revokes your dispatch capability/)
     expect(result).toMatch(/use --type status/)
+    // Why: the terminal command must not describe its own subject as a status
+    // line while status sits next to it as the non-terminal option.
+    expect(result).not.toContain('--type worker_done --subject "<short status>"')
+  })
+
+  it('keeps status from displacing ask and escalation', () => {
+    const result = buildDispatchPreamble(baseParams())
+    // Why: "use it whenever you have something to say" would pull blockers and
+    // questions into a message the coordinator only logs by subject. The status
+    // rule has to name its neighbours to stay in its lane.
+    expect(result).toMatch(/ask when you need an answer/)
+    expect(result).toMatch(/escalation when you are blocked/)
+    expect(result).toMatch(/Put the headline in --subject/)
   })
 
   it('includes heartbeat CLI block with taskId and dispatchId and 5-minute cadence', () => {
@@ -148,9 +162,10 @@ describe('buildDispatchPreamble', () => {
       dispatchCapability: 'dcap_test_secret'
     })
 
-    // worker_done, status, heartbeat, ask, escalation. Only the first and the
-    // heartbeat are capability-gated at the runtime, but every worker-originated
-    // command carries the flag so one omission cannot become the odd one out.
+    // worker_done, status, heartbeat, ask, escalation. The runtime verifies the
+    // capability for worker_done and heartbeat on the send path and for ask on
+    // its own; status and escalation are not verified. Every worker-originated
+    // command still carries the flag so one omission cannot become the odd one out.
     expect(result.match(/--dispatch-capability dcap_test_secret/g)).toHaveLength(5)
     expect(result).not.toContain('"dispatchCapability"')
   })

--- a/src/main/runtime/orchestration/preamble.test.ts
+++ b/src/main/runtime/orchestration/preamble.test.ts
@@ -110,10 +110,16 @@ describe('buildDispatchPreamble', () => {
     const result = buildDispatchPreamble(baseParams())
     // Why: "use it whenever you have something to say" would pull blockers and
     // questions into a message the coordinator only logs by subject. The status
-    // rule has to name its neighbours to stay in its lane.
-    expect(result).toMatch(/ask when you need an answer/)
-    expect(result).toMatch(/escalation when you are blocked/)
-    expect(result).toMatch(/Put the headline in --subject/)
+    // rule has to name its neighbours to stay in its lane — inside its own
+    // block, so a phrase surviving elsewhere in the preamble cannot satisfy it.
+    const start = result.indexOf('# Report mid-run progress')
+    const end = result.indexOf('# BEHAVIOR RULE: send a heartbeat')
+    expect(start).toBeGreaterThan(-1)
+    expect(end).toBeGreaterThan(start)
+    const statusBlock = result.slice(start, end)
+    expect(statusBlock).toMatch(/ask when you need an answer/)
+    expect(statusBlock).toMatch(/escalation when you are blocked/)
+    expect(statusBlock).toMatch(/Put the headline in --subject/)
   })
 
   it('includes heartbeat CLI block with taskId and dispatchId and 5-minute cadence', () => {

--- a/src/main/runtime/orchestration/preamble.test.ts
+++ b/src/main/runtime/orchestration/preamble.test.ts
@@ -79,10 +79,8 @@ describe('buildDispatchPreamble', () => {
 
   it('offers status as the content-bearing way to report mid-run progress', () => {
     const result = buildDispatchPreamble(baseParams())
-    // Why: status is the only worker message that carries a body without
-    // settling anything. Without it in the preamble the sole content-bearing
-    // command a worker has been taught is worker_done, so a progress update
-    // becomes a completion and revokes the dispatch capability.
+    // Why: without status in the preamble, a worker reporting progress reaches
+    // for worker_done, which settles the task and revokes the capability.
     expect(result).toContain('--type status')
     expect(result).toMatch(/--subject "<short progress headline>"/)
     expect(result).toContain('--body "<what just finished, what you are starting next>"')

--- a/src/main/runtime/orchestration/preamble.ts
+++ b/src/main/runtime/orchestration/preamble.ts
@@ -85,7 +85,7 @@ Slack, GitHub comments, or any other channel to reach a human during the run.
   # update sent this way ends your run and makes every later worker_done and
   # heartbeat fail. For an interim update use --type status below.
   ${cli} orchestration send --from ${params.workerHandle}${capabilityFlag} \\
-    --type worker_done --subject "<short status>" \\
+    --type worker_done --subject "<short completion headline>" \\
     --body "<3-sentence summary: what you did, what you found, what's left>" \\
     --task-id ${params.taskId} --dispatch-id ${params.dispatchId} --outcome succeeded \\
     --files-modified "path/a,path/b" \\
@@ -93,10 +93,13 @@ Slack, GitHub comments, or any other channel to reach a human during the run.
 
   # Report mid-run progress without ending the task.
   #
-  # RULE: status is the only content-bearing message that settles nothing, so
-  # every "phase one is done, starting phase two" update belongs here. Reach
-  # for it whenever you have something to say and the task is not finished;
-  # heartbeat carries no body, and worker_done would end the run.
+  # RULE: use status for "phase one is done, starting phase two" progress —
+  # you are neither finished nor blocked, and heartbeat carries no body to
+  # say it in. Put the headline in --subject: the coordinator loop logs the
+  # subject and leaves the body for whoever opens the message.
+  #
+  # It does not replace the commands below: ask when you need an answer,
+  # escalation when you are blocked, worker_done only when the task is over.
   ${cli} orchestration send --from ${params.workerHandle}${capabilityFlag} \\
     --type status --subject "<short progress headline>" \\
     --body "<what just finished, what you are starting next>" \\

--- a/src/main/runtime/orchestration/preamble.ts
+++ b/src/main/runtime/orchestration/preamble.ts
@@ -79,12 +79,28 @@ Slack, GitHub comments, or any other channel to reach a human during the run.
   # Never encode failure only in prose and never silently exit.
   # Include BOTH taskId and dispatchId in the payload so a late completion
   # from a failed retry cannot complete the current dispatch.
+  #
+  # RULE: worker_done is terminal, not a progress report. It settles the task
+  # and revokes your dispatch capability the moment it lands, so a mid-run
+  # update sent this way ends your run and makes every later worker_done and
+  # heartbeat fail. For an interim update use --type status below.
   ${cli} orchestration send --from ${params.workerHandle}${capabilityFlag} \\
     --type worker_done --subject "<short status>" \\
     --body "<3-sentence summary: what you did, what you found, what's left>" \\
     --task-id ${params.taskId} --dispatch-id ${params.dispatchId} --outcome succeeded \\
     --files-modified "path/a,path/b" \\
     --report-path "<optional: path to the full artifact>"
+
+  # Report mid-run progress without ending the task.
+  #
+  # RULE: status is the only content-bearing message that settles nothing, so
+  # every "phase one is done, starting phase two" update belongs here. Reach
+  # for it whenever you have something to say and the task is not finished;
+  # heartbeat carries no body, and worker_done would end the run.
+  ${cli} orchestration send --from ${params.workerHandle}${capabilityFlag} \\
+    --type status --subject "<short progress headline>" \\
+    --body "<what just finished, what you are starting next>" \\
+    --task-id ${params.taskId} --dispatch-id ${params.dispatchId}
 
   # BEHAVIOR RULE: send a heartbeat every ${HEARTBEAT_INTERVAL_MIN} minutes
   # while actively working on the task. The coordinator uses this to

--- a/src/main/runtime/rpc/methods/orchestration-send.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-send.test.ts
@@ -880,6 +880,45 @@ describe('orchestration RPC methods', () => {
       expect(db.getActiveDispatchForTerminal('term_worker')).toBeDefined()
     })
 
+    it('leaves the dispatch live for a worker status update so the later worker_done still settles', async () => {
+      setup()
+      const task = db.createTask({ spec: 'multi-phase work' })
+      const dispatch = db.createDispatchContext(task.id, 'term_worker')
+      vi.spyOn(runtime, 'deliverPendingMessagesForHandle').mockImplementation(() => {})
+
+      // Why: this is the exact shape the dispatch preamble teaches for mid-run
+      // progress. If status ever gained a settling path, the preamble would be
+      // steering workers into the completion-and-revoke failure it exists to
+      // prevent, and only a test at this layer would catch it.
+      await call('orchestration.send', {
+        from: 'term_worker',
+        to: 'term_coord',
+        subject: 'phase one done',
+        body: 'finished the survey, starting the diagnosis',
+        type: 'status',
+        payload: JSON.stringify({ taskId: task.id, dispatchId: dispatch.id })
+      })
+
+      expect(db.getTask(task.id)?.status).toBe('dispatched')
+      expect(db.getDispatchContextById(dispatch.id)?.status).toBe('dispatched')
+      expect(db.getDispatchContextById(dispatch.id)?.capability_revoked_at).toBeNull()
+
+      await call('orchestration.send', {
+        from: 'term_worker',
+        to: 'term_coord',
+        subject: 'work complete',
+        type: 'worker_done',
+        payload: JSON.stringify({
+          taskId: task.id,
+          dispatchId: dispatch.id,
+          outcome: 'succeeded'
+        })
+      })
+
+      expect(db.getTask(task.id)?.status).toBe('completed')
+      expect(db.getDispatchContextById(dispatch.id)?.status).toBe('completed')
+    })
+
     it('does not release dispatch lock for non-lifecycle sends', async () => {
       setup()
       const task = db.createTask({ spec: 'in-flight work' })

--- a/src/main/runtime/rpc/methods/orchestration-send.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-send.test.ts
@@ -917,6 +917,9 @@ describe('orchestration RPC methods', () => {
 
       expect(db.getTask(task.id)?.status).toBe('completed')
       expect(db.getDispatchContextById(dispatch.id)?.status).toBe('completed')
+      // Why: completion without revocation would leave the settled dispatch's
+      // capability live — the exact hole the status/worker_done split guards.
+      expect(db.getDispatchContextById(dispatch.id)?.capability_revoked_at).not.toBeNull()
     })
 
     it('does not release dispatch lock for non-lifecycle sends', async () => {


### PR DESCRIPTION
## ELI5

When Orca dispatches a worker, it injects a preamble listing the commands that worker may use to talk back. For a worker that is midway through a task and wants to say "phase one is done, starting phase two", none of those commands fit. `heartbeat`'s subject is hardcoded to `"alive"`, so it carries no content. `ask` blocks waiting for an answer. `escalation` announces a blocker. What is left is `worker_done` — and that one ends the run.

`status` is already exactly the right type: content-bearing, non-blocking, settles nothing. It simply was never in the preamble, so workers never learned it. This adds it.

## Why the wrong choice is expensive

`worker_done` is not merely recorded. `settleWorkerReport` completes the task and stamps `capability_revoked_at` in the same `UPDATE`:

```sql
SET status = ?, completed_at = datetime('now'),
    last_failure = CASE WHEN ? = 'failed' THEN ? ELSE last_failure END,
    capability_revoked_at = COALESCE(capability_revoked_at, datetime('now'))
```

Nothing upstream of that update inspects whether the work finished — the guards check task/dispatch status, identity, and staleness only, so an authenticated active worker sending a valid `--outcome` is indistinguishable from a genuine completion. `--outcome` does not help either: `succeeded` and `failed` are both terminal, there is no non-settling value.

Afterwards `verifyDispatchCapability` sees the revocation and the worker's real completion is rejected with `Dispatch ctx_… capability is revoked`. In the report that prompted this, the worker read the rejection as a hard stop and quit before committing or pushing.

So the expected behaviour #14311 asks for — "a worker's own message should never terminate a task the coordinator didn't complete" — cannot be recovered at the settle path, because by then the information needed to tell the two apart is gone. It has to be prevented where the worker picks the message.

## What changed

**1. A `status` block, immediately after `worker_done`** — the contrast only teaches if the two are adjacent:

```
  # Report mid-run progress without ending the task.
  #
  # RULE: use status for "phase one is done, starting phase two" progress —
  # you are neither finished nor blocked, and heartbeat carries no body to
  # say it in. Put the headline in --subject: the coordinator loop logs the
  # subject and leaves the body for whoever opens the message.
  #
  # It does not replace the commands below: ask when you need an answer,
  # escalation when you are blocked, worker_done only when the task is over.
```

The `--subject` instruction is deliberate: `coordinator.ts:250` logs a status message by subject and never surfaces the body, so guidance that put the substance in `--body` would be quietly useless in the normal loop.

**2. The consequence named on `worker_done`.** The existing rule says to send it exactly once, which gives a worker the cardinality but never the cost of going early:

```
  # RULE: worker_done is terminal, not a progress report. It settles the task
  # and revokes your dispatch capability the moment it lands, so a mid-run
  # update sent this way ends your run and makes every later worker_done and
  # heartbeat fail. For an interim update use --type status below.
```

**3. `worker_done`'s subject placeholder** was `"<short status>"`, which named the terminal command after the non-terminal one now sitting beside it. It is `"<short completion headline>"`.

## Scope

Preamble text and tests. No runtime, schema, message-type, or CLI-surface change — `status` already routes and already settles nothing, and `--task-id`/`--dispatch-id` are generic `send` flags rather than type-restricted ones.

I deliberately left the heavier options in #14311 alone: a new `progress` message type (SQLite CHECK migration, federation report parser, version skew against older remote runtimes), a final/settle discriminator on `worker_done` (an older worker omitting the marker strands its task in `dispatched`), and two-phase coordinator-acknowledged completion (delays the dependent-task promotion that currently fires on settle). Each is a state-machine decision deserving its own evidence, and none is needed for the reported case. Happy to take one further if you would rather fix this at the protocol level.

## Testing

- `preamble.test.ts`: three new cases — the `status` block with its dispatch attribution, the terminal-and-revokes warning on `worker_done`, and a guard that the status rule keeps naming `ask` and `escalation` so it cannot drift into "use it for everything". All fail without this change.
- `orchestration.test.ts`: a new RPC-layer case that sends the exact status command the preamble teaches, asserts task and dispatch stay `dispatched` with `capability_revoked_at` still null, then sends `worker_done` and asserts it still settles. The preamble's promise is that status is safe mid-run; this is the test that fails if that stops being true.
- Full `src/main/runtime/orchestration/` + `orchestration.test.ts` + `src/cli/handlers/orchestration.test.ts`: 541/541.
- `tsc -p config/tsconfig.node.json` clean, `oxlint` clean on all three files.
- The snapshot diff is the blocks above and the subject placeholder, nothing else.
- `agent-generated-tab-title.test.ts` fails to import `@/i18n/i18n` under the default vitest project. It fails identically on unmodified `main`, so it is a project-config resolution issue, not from this change.

## One thing to review deliberately

`status` carries `--dispatch-capability` like every other worker-originated command in the preamble. Strictly it does not need it: the runtime verifies the capability for `worker_done` and `heartbeat` on the send path (`orchestration.ts:594`) and for `ask` on its own (`orchestration.ts:1438`), while `status` and `escalation` are not verified. I kept the flag for consistency, since `escalation` is in the same position and already carries it. If you would rather the preamble carry the flag only where the runtime enforces it, that is an easy change — but it is a change to `escalation` as well, not just this line.

The assertion guarding that used to be a bare count, and adding a fifth carrier put more weight on it than a count can hold: a total cannot tell "every command has the flag" from "one lost it and another gained a second one". It now matches each of the five commands inside its own block, keeping the total only as a guard against an unasserted sixth carrier. I confirmed the difference by mutation rather than assuming it — removing the flag from `status` while duplicating it on `worker_done` keeps the total at five and passes the old assertion, and fails the new ones.
