### PR TITLE
feat(browser): apply client page reconciliation

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -2609,6 +2609,7 @@
         "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/browser-host-page-reconciliation-plan.test.ts src/main/runtime/browser-host-page-reconciliation-executor.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/shared/browser-client-host-reconciliation-protocol.test.ts src/main/browser/paired-runtime-browser-host-reconciliation-negotiation.test.ts src/main/runtime/rpc/methods/browser-client-host-reconciliation.test.ts src/main/runtime/browser-host-lease-registry.test.ts src/main/browser/paired-runtime-browser-client-host.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/shared/browser-client-host-protocol.test.ts src/main/browser/browser-client-host-attach-request.test.ts src/main/browser/browser-client-page-command-executor.test.ts src/main/browser/browser-client-page-command-integration.test.ts src/main/browser/browser-client-page-inventory.test.ts src/main/browser/paired-runtime-browser-client-host-composition.test.ts src/main/browser/paired-runtime-browser-client-host.test.ts src/main/browser/paired-runtime-browser-host-lease.test.ts src/main/runtime/browser-host-lease-registry.test.ts src/main/runtime/rpc/methods/browser-client-host.test.ts src/main/runtime/browser-host-page-reconciliation-plan.test.ts",
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/browser/browser-client-host-reconciliation-command-order.test.ts src/main/browser/browser-client-page-reconciliation-adapters.test.ts src/main/browser/browser-route-prepared-page-rekey.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/shared/browser-network-capabilities.test.ts src/shared/browser-network-tunnel-protocol.test.ts src/main/browser/browser-network-tunnel-session.test.ts src/main/browser/remote-browser-socks-server.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/main/browser/browser-network-tunnel-client.test.ts src/main/browser/paired-runtime-browser-network-route.test.ts src/main/runtime/runtime-binary-message-router.test.ts src/main/runtime/rpc/methods/browser-network-tunnel.test.ts src/main/runtime/browser-network-tunnel-paired-runtime.integration.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/main/browser/browser-network-tunnel-outbound-memory-budget.test.ts src/main/browser/browser-network-tunnel-client-memory-budget.test.ts src/main/browser/browser-network-tunnel-session-aggregate-memory.test.ts src/shared/ws-outbound-backpressure-queue.test.ts src/shared/remote-runtime-client.test.ts",
@@ -2656,9 +2657,12 @@
         "src/main/browser/paired-runtime-browser-client-host-registry.test.ts",
         "src/main/browser/paired-runtime-browser-client-host-runtime.test.ts",
         "src/main/browser/browser-client-host-attach-request.test.ts",
+        "src/main/browser/browser-client-host-reconciliation-command-order.test.ts",
         "src/main/browser/browser-client-page-command-executor.test.ts",
         "src/main/browser/browser-client-page-command-integration.test.ts",
+        "src/main/browser/browser-client-page-reconciliation-adapters.test.ts",
         "src/main/browser/browser-client-page-inventory.test.ts",
+        "src/main/browser/browser-route-prepared-page-rekey.test.ts",
         "src/main/browser/browser-session-startup.test.ts",
         "src/main/ipc/runtime-environments-subscription-teardown.test.ts",
         "src/main/browser/browser-client-host-command-dispatcher.test.ts",
@@ -2871,6 +2875,15 @@
           ]
         },
         {
+          "file": "src/main/browser/browser-client-host-reconciliation-command-order.test.ts",
+          "assertions": [
+            "reclaim, restore, and close are valid first commands only after exact reconciliation negotiation",
+            "reclaim and restore failure cancels later navigation without running it",
+            "nested prior authority is immutable and exact duplicate matching rejects mutation on both ledgers",
+            "successful close is terminal while failed close releases the fence and successful reclaim can continue with navigation"
+          ]
+        },
+        {
           "file": "src/main/browser/browser-client-page-command-executor.test.ts",
           "assertions": [
             "in-flight create, ambiguous cleanup, and stale renderer authority snapshot as outcome unknown",
@@ -2879,8 +2892,25 @@
             "successful normalized navigation updates the immutable current URL snapshot unless normalization exceeds the URL field bound",
             "legacy-valid command identities remain executable even when optional inventory cannot encode them",
             "executor capacity cannot exceed the shared 256-page attach limit",
+            "failed retirement leaves immutable outcome-unknown inventory without a retryable live-page handle",
             "terminal navigation fencing revokes retained grants once and blocks late in-flight creation without inferring destruction",
             "revocation failure remains observable while exact guest, renderer, Session, and route cleanup still run"
+          ]
+        },
+        {
+          "file": "src/main/browser/browser-client-page-reconciliation-adapters.test.ts",
+          "assertions": [
+            "reclaim moves one exact retained guest to a new authority without remounting",
+            "restore creates fresh authority and destroys it when initial navigation cannot be proven",
+            "close targets only exact prior authority",
+            "renderer failure or abort after main rekey retires both possible exact renderer identities, preserves unrelated pages, destroys the guest, and reports outcome unknown"
+          ]
+        },
+        {
+          "file": "src/main/browser/browser-route-prepared-page-rekey.test.ts",
+          "assertions": [
+            "prepared authority rekeys without changing its opaque capability token",
+            "stale, occupied, cross-page, and cross-renderer targets fail without mutation"
           ]
         },
         {
@@ -3386,7 +3416,7 @@
         "The system-SSH adapter opens another no-auth loopback SOCKS listener outside tunnel accounting; its release-and-bind port can be claimed by a sibling process, and readiness proves only that some TCP listener answered.",
         "Standalone system-SSH cleanup is exact, but targets that require an already-authenticated ControlMaster, passphrase, PIN, or keyboard-interactive prompt can fail non-interactive route startup.",
         "Execution-host grant keys are not independently capped or ref-counted; activation requires one server-owned page or partition lifetime and bounded per-lease grant admission.",
-        "Same-authority command replay is deterministic, but applying the authenticated inventory reconciliation plan after runtime restart remains unimplemented.",
+        "Same-authority replay and concrete client reclaim, restore, and close application are deterministic, but server placement reconciliation still lacks dedicated authenticated command issuance and proof-driven placement rekey after runtime restart.",
         "SSH2 and system OpenSSH have isolated Docker evidence, but WSL, browserless serve, Electron proxy policy, UDP denial, and desktop DNS/socket capture are not exercised."
       ],
       "demotionRule": "Keep experimental or demote if a self-asserted or ambiguous host can receive a route, an SSH descriptor bypasses capability, lease-bound grant, or provider-authority checks, late cleanup can remove a replacement, a route can resolve names on the desktop, exceed a byte or stream bound, replenish credit before destination settlement, accept a stale or non-increasing generation, reuse a stream ID within one generation, lose or bypass its fail-closed listener during reconnect, expose the SOCKS listener off-loopback, accept BIND/UDP, or fall back when the selected route is unavailable."
@@ -3538,15 +3568,18 @@
       "oracle": "Prepare a page for one renderer and require authority lookup and registration by a sibling renderer to fail; reject owner replacement while the generation is active or retiring, then lose the owning renderer before guest registration and require only its prepared pages to retire. Pause partition setup, lose the owner, and require its waiter to fail without authority; add a live sibling waiter to the same pending setup and require only that waiter to admit; exceed the configured waiter cap and require immediate refusal. Make policy cleanup throw in the first of two owned partitions and require the sweep to retire both without restoring admission. Through the inert executor, retain one exact route, prepare its partition, mount blank on one current renderer, register and grant the exact guest in order, then load only its normalized HTTP(S) URL. Queue renderer requests before subscription, replace one subscriber, overflow both request and page budgets, race attachment with retirement, delay guest identity until DOM readiness, lose the guest renderer, and require exact bounded settlement without reparenting or cross-partition collision. Under real Electron, require the main bridge to accept only the actual main-frame reply, match the positive renderer WebContents ID to did-attach-webview, destroy it on retirement, and reject and remove a denied unprepared guest. Reject a mismatched route, stale renderer or page generation, and file URL without touching Chromium. Abort or fail registration after mount and require exact guest, renderer, Session, and route cleanup in that order; make renderer cleanup reject but require destruction before later release, and keep the generation fenced from replacement. Make guest retirement fail or mount outcome ambiguous and require every safe cleanup while Session and route remain retained. Destroy a guest spontaneously before command cleanup, reuse its WebContents identity, and require the old opaque claim not to retire the replacement while the replacement claim still can. Attach a blank route guest and require nonblank navigation plus every popup to be denied. Reject a wrong renderer, wrong page generation, nonblank initial document, wrong WebContents type, destroyed guest, and excess attachment; delay or fail its close and require navigation and popups to remain denied. Register the exact prepared tuple and prove navigation remains denied until a second grant; then allow repeated HTTP(S) navigation while continuing to deny file navigation and popups. Release logical page authority with delayed guest close; require immediate navigation revocation, one exact close, no partition admission, no policy cleanup, and same-tuple preparation refusal until destroyed acknowledgement. Make destroyed inspection throw and require retirement plus navigation to remain fail-closed until the explicit destroyed event. Acknowledge destruction, require one policy cleanup, reprepare the tuple, replay stale acknowledgement, and prove the replacement remains admitted. Make retirement startup throw and require policy plus capacity to remain fail-closed. Retire two pages sharing one partition and require cleanup only after both exact acknowledgements. Emit guest render-process-gone and destroyed, and emit owning-renderer process loss through the main-window boundary; require exact logical retirement, close, and grant revocation while unrelated renderer guests and prepared pages survive. Reject retirement for the wrong opaque authority. Reprepare after ordinary release, require a new opaque authority, deny the stale guest, and admit an exact replacement. Destroy a registered guest under real destroyed state, verify best-effort listener release, replay stale cleanup, and prove its replacement remains grantable. Mutate caller input after registration and prove main-owned authority is unchanged. Attach a normal browser Session and require no route-registry mutation.",
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/main/browser/browser-client-page-command-executor.test.ts src/main/browser/browser-client-page-command-integration.test.ts src/main/browser/browser-client-page-renderer-bridge.test.ts src/main/browser/browser-client-page-renderer-lifecycle.electron.test.ts src/main/browser/browser-client-page-renderer-runtime.test.ts src/main/browser/browser-route-session-registry.test.ts src/main/browser/browser-route-webcontents-registry.test.ts src/preload/browser-client-page-renderer-requests.test.ts src/renderer/src/components/browser-pane/browser-client-page-retained-registry.test.ts src/renderer/src/components/browser-pane/browser-client-page-renderer-installation.test.ts src/main/window/createMainWindow.test.ts src/main/window/renderer-document-navigation.test.ts",
-        "pnpm exec vitest run --config config/vitest.config.ts src/main/browser/browser-client-page-command-executor.test.ts src/main/browser/browser-client-page-command-integration.test.ts src/main/browser/browser-client-page-renderer-bridge.test.ts src/main/browser/browser-client-page-renderer-runtime.test.ts src/main/browser/browser-route-session-registry.test.ts src/main/browser/browser-route-webcontents-registry.test.ts src/main/window/createMainWindow.test.ts src/main/window/renderer-document-navigation.test.ts"
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/browser/browser-client-page-command-executor.test.ts src/main/browser/browser-client-page-command-integration.test.ts src/main/browser/browser-client-page-renderer-bridge.test.ts src/main/browser/browser-client-page-renderer-runtime.test.ts src/main/browser/browser-route-session-registry.test.ts src/main/browser/browser-route-webcontents-registry.test.ts src/main/window/createMainWindow.test.ts src/main/window/renderer-document-navigation.test.ts",
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/browser/browser-client-page-reconciliation-adapters.test.ts src/main/browser/browser-route-prepared-page-rekey.test.ts"
       ],
       "testFiles": [
         "src/main/browser/browser-client-page-command-executor.test.ts",
         "src/main/browser/browser-client-page-command-integration.test.ts",
+        "src/main/browser/browser-client-page-reconciliation-adapters.test.ts",
         "src/main/browser/browser-client-page-renderer-bridge.test.ts",
         "src/main/browser/browser-client-page-renderer-lifecycle.electron.test.ts",
         "src/main/browser/browser-client-page-renderer-runtime.test.ts",
         "src/main/browser/browser-route-session-registry.test.ts",
+        "src/main/browser/browser-route-prepared-page-rekey.test.ts",
         "src/main/browser/browser-route-webcontents-registry.test.ts",
         "src/preload/browser-client-page-renderer-requests.test.ts",
         "src/renderer/src/components/browser-pane/browser-client-page-retained-registry.test.ts",
@@ -3568,7 +3601,14 @@
         {
           "file": "src/main/browser/browser-client-page-command-integration.test.ts",
           "assertions": [
-            "real route Session and WebContents registries compose create, navigate, destroyed acknowledgement, policy cleanup, and route release"
+            "a fresh new-authority dispatcher reclaims an old-authority executor page while real route Session and WebContents registries preserve exact cleanup"
+          ]
+        },
+        {
+          "file": "src/main/browser/browser-client-page-reconciliation-adapters.test.ts",
+          "assertions": [
+            "exact reclaim preserves the guest while rekeying renderer, Session, lifecycle claim, and navigation authority",
+            "rekey uncertainty retires both possible renderer identities and failed restore navigation destroys the affected guest before releasing retained resources"
           ]
         },
         {
@@ -3617,6 +3657,13 @@
             "prepared authority is bound to one renderer and owner loss retires unregistered pages",
             "page release removes logical authority and tuple reuse receives a new opaque token",
             "route policy stays installed and tuple reuse stays blocked until delayed exact-guest destruction settles"
+          ]
+        },
+        {
+          "file": "src/main/browser/browser-route-prepared-page-rekey.test.ts",
+          "assertions": [
+            "prepared authority moves only across an exact same-page same-renderer generation change",
+            "rekey preserves the opaque authority and leaves stale or conflicting input unchanged"
           ]
         },
         {

--- a/docs/sta-4150-client-hosted-browser-progress.md
+++ b/docs/sta-4150-client-hosted-browser-progress.md
@@ -36,11 +36,11 @@ Old clients and callers that omit placement must retain current server-hosted be
 - Stage 0 compatibility hardening: PR
   [#14402](https://github.com/stablyai/orca/pull/14402) is merged. It is not the long-term
   architecture and is not part of this draft stack.
-- Latest published stack tip: `sta-4150-browser-navigation-grant-lease-fencing`, draft PR
-  [#14754](https://github.com/stablyai/orca/pull/14754), stacked on lease-retirement PR
-  [#14753](https://github.com/stablyai/orca/pull/14753).
-- All 32 patches through the published admission stage are rebased onto
-  `origin/main@5b7f44278a`; range-diff marked every patch identical before the exact-lease push.
+- Latest published stack tip: `sta-4150-browser-page-reconciliation-adapters`, draft PR
+  [#14763](https://github.com/stablyai/orca/pull/14763), stacked on reconciliation-command PR
+  [#14759](https://github.com/stablyai/orca/pull/14759).
+- All 37 published patches are cascade-rebased onto `origin/main@c4e397bcdc`. Range-diff marked
+  every patch identical; the two intervening main commits touch no STA-4150 file.
 - Published lease-fence placement-retirement stage: draft PR
   [#14753](https://github.com/stablyai/orca/pull/14753). It makes exact terminal host-generation
   placement retirement non-cancellable without inferring destruction or releasing capacity.
@@ -114,8 +114,11 @@ ownership.
 | [#14747](https://github.com/stablyai/orca/pull/14747) | Admission fairness | Per-device host capacity, wait reservation, and bounded pressure recovery |
 | [#14753](https://github.com/stablyai/orca/pull/14753) | Lease retirement   | Terminal exact-host fencing makes placements non-cancellable pending      |
 | [#14754](https://github.com/stablyai/orca/pull/14754) | Navigation fence   | Terminal authority loss suspends routes and revokes exact guest grants    |
+| [#14756](https://github.com/stablyai/orca/pull/14756) | Plan execution     | Bounded two-phase reconciliation action execution                         |
+| [#14759](https://github.com/stablyai/orca/pull/14759) | Command contracts  | Negotiated reclaim, restore, and close command contracts                  |
+| [#14763](https://github.com/stablyai/orca/pull/14763) | Client adapters    | Exact retained-page reclaim, restore, close, and fail-closed cleanup      |
 
-## Current stage: exact renderer bridge
+## Published stage: exact renderer bridge (#14578)
 
 Baseline #14566 was deterministically red because the renderer bridge and local IPC contract did
 not exist.
@@ -532,7 +535,7 @@ Validation and review:
 | Route/profile-scoped partition before first request                | Partial                   | Deterministic policy ordering passes; real Electron worker/popup/speculation proof is missing                     |
 | SOCKS5 tunnel with remote DNS and bounded flow control             | Partial                   | Native and SSH route foundations exist; WSL and production route retention are incomplete                         |
 | Agent/CLI routing by placement                                     | Missing                   | Only create/navigate command foundations exist; public browser methods still use current server behavior          |
-| Inventory/reconciliation after ambiguous outcomes and restart      | Partial                   | Planner, authenticated inventory, and bounded executor exist; concrete adapters and restart recovery remain       |
+| Inventory/reconciliation after ambiguous outcomes and restart      | Partial                   | Concrete client adapters exist; server action issuance, proof-driven placement rekey, and restart recovery remain |
 | Independent bounded control/tunnel/mirror/binary channels          | Partial                   | Control and tunnel are separate/bounded; mirror and large-result paths are incomplete                             |
 | Mixed client/server compatibility                                  | Partial                   | Optional/capability-gated contracts and cross-version tests exist; activated rolling-upgrade behavior is unproven |
 | Local pointer/keyboard/chrome with no runtime round trip           | Missing                   | Requires the renderer surface and interaction-owner fencing                                                       |
@@ -546,20 +549,22 @@ Validation and review:
 
 ## Remaining implementation order
 
-1. Monitor #14754 CI without merging or marking it ready; the current-main type-aware warning is
-   upstream and must not be folded into this browser stage.
-2. Bind the bounded reconciliation executor to authenticated runtime intent and preserved reconnect
-   inventory with exact generation-fenced reclaim, close, and restore adapters.
-3. Add optional placement to logical session-tab publication and renderer state. Follow
+1. Monitor #14763 CI without merging or marking it ready; production advertisement stays disabled.
+2. Add a dedicated authenticated server action-issuance path that binds one immutable plan to its
+   exact lease and client inventory. Preserve the client executor across the authority transition;
+   a transport or composition restart must not destroy the retained guest before reclaim.
+3. Rekey server placement only after the exact client command result proves reclaim or restore;
+   keep outcome-unknown inventory fenced and rerun a fresh plan after any phase-one failure.
+4. Add optional placement to logical session-tab publication and renderer state. Follow
    `docs/reference/remote-wire-compatibility.md`; old callers and clients remain server-hosted.
-4. Route create and every existing browser command by explicit placement. Never silently fall
+5. Route create and every existing browser command by explicit placement. Never silently fall
    back or migrate a live page.
-5. Add local browser chrome and interaction-owner fencing for client placement.
-6. Add mobile mirroring and dedicated large-result channels without coupling them to control or
+6. Add local browser chrome and interaction-owner fencing for client placement.
+7. Add mobile mirroring and dedicated large-result channels without coupling them to control or
    terminal multiplexing.
-7. Run real Electron containment and traffic proof, then headed/headless/browserless paired
+8. Run real Electron containment and traffic proof, then headed/headless/browserless paired
    journeys and the physical platform/provider matrix.
-8. Enable client placement only behind a kill switch for newly created eligible desktop pages;
+9. Enable client placement only behind a kill switch for newly created eligible desktop pages;
    retain explicit server placement and rollback that does not move existing pages.
 
 ## Compatibility costs and risks
@@ -748,6 +753,39 @@ Published reconciliation-command-contract stage (#14759):
 - Draft PR [#14759](https://github.com/stablyai/orca/pull/14759) stacks on #14756 and remains draft.
   GitHub auto-attached it to STA-4150; the ticket remains In Progress.
 
+Published reconciliation-adapter stage (#14763):
+
+- Baseline: the client had negotiated command shapes but no concrete reclaim, restore, or close
+  adapter. The focused adapter suites failed because their modules and exact rekey operations did
+  not exist.
+- Candidate: reclaim rekeys the same guest across renderer retention, prepared Session authority,
+  WebContents lifecycle claims, and navigation authority without remounting. Restore creates a new
+  blank guest and applies optional initial navigation only after exact authority admission. Close
+  retires only an exact prior authority.
+- Revert oracles prove three review fixes: uncertain renderer rekey must retire both the old and new
+  exact renderer identities; failed cleanup must leave immutable `outcomeUnknown` inventory without
+  a retryable live-page handle; and a failed close must release its terminal command fence.
+- A fresh new-authority dispatcher successfully reclaims an old-authority executor page. A proposed
+  same-dispatcher create-to-reclaim test was rejected because reclaim is required to cross authority
+  epochs, while a dispatcher is bound to one immutable lease authority.
+- Focused changed surface: 19 files / 233 tests. Paired runtime/server: 13 files / 179 tests.
+  Isolated Electron lifecycle: 1/1. Cross-version terminal wire: 5/5. Node/CLI/web typecheck, full
+  lint and native/type-aware audits, 87 reliability gates, max-lines, skill/localization checks,
+  formatting, diff checks, and changed-code quality pass with zero findings.
+- One Electron invocation run concurrently with typecheck and the wire journey observed Chromium's
+  transient empty initial URL; the required standalone rerun passed 1/1. Keep this real-Electron
+  file isolated from broad parallel suites.
+- Fresh security, lifecycle, and portability reviews found and drove the cleanup fixes above. The
+  remaining activation blocker is architectural: a terminal authority change currently tears down
+  the composition/executor that owns the retained page. Server reconciliation must preserve that
+  client state, issue actions through a dedicated authenticated path, and rekey placement only after
+  client proof.
+- Production advertisement remains disabled. Old clients, server/offscreen placement, browserless
+  hosts, SSH/WSL routes, folder workspaces, git worktrees, and existing browser behavior are
+  unchanged by this stage.
+- Draft PR [#14763](https://github.com/stablyai/orca/pull/14763) stacks on #14759 and remains
+  draft. GitHub auto-attached it to STA-4150; the ticket remains In Progress.
+
 Do not promote narrow deterministic evidence into a live-topology claim. Record exact commands,
 topology, versions, and explicit gaps at every later checkpoint.
 
@@ -756,7 +794,7 @@ topology, versions, and explicit gaps at every later checkpoint.
 - Pushed the STA-4150 staged branches listed in the draft-stack table.
 - Opened and maintained their linked draft PRs; none were merged or marked ready.
 - Attached draft PRs and posted one concise checkpoint per stage on STA-4150.
-- Latest public checkpoint: GitHub auto-attached draft PR #14754 and one Linear checkpoint was
+- Latest public checkpoint: GitHub auto-attached draft PR #14763 and one Linear checkpoint was
   posted; CI is running.
 - Updated the Orca worktree comment/status at context, reproduction, fix, validation, and review
   checkpoints.
@@ -833,6 +871,17 @@ topology, versions, and explicit gaps at every later checkpoint.
 - Opened draft PR [#14759](https://github.com/stablyai/orca/pull/14759) on #14756. GitHub
   auto-attached it to STA-4150; posted exactly one reconciliation-contract checkpoint comment
   (`b775afbd-fb75-42bf-bee3-8d8ca0877b33`) and kept the ticket In Progress.
+- Locally cascade-rebased all 36 published patches plus the reconciliation-adapter patch onto
+  `origin/main@c4e397bcdc`; range-diff marked all 37 patches identical. Safety pointer
+  `sta-4150-safety-pre-c4e-rebase-20260815` retains the prior series. No rewritten branch or new
+  stage branch has been pushed at this checkpoint.
+- The first atomic-push command constructed invalid zsh refspecs and failed before any remote
+  update. The corrected transaction atomically force-pushed all 35 existing public stack branches
+  with exact remote-OID leases and created `sta-4150-browser-page-reconciliation-adapters` with a
+  must-not-exist lease.
+- Opened draft PR [#14763](https://github.com/stablyai/orca/pull/14763) on #14759. GitHub
+  auto-attached it to STA-4150; posted exactly one reconciliation-adapter checkpoint comment
+  (`de3e18d0-c24d-433b-ad67-3943c68d4129`) and kept the ticket In Progress.
 - No PR was merged or marked ready.
 
 ## Completion rule

--- a/src/main/browser/browser-client-host-command-dispatcher.ts
+++ b/src/main/browser/browser-client-host-command-dispatcher.ts
@@ -12,6 +12,9 @@ import { joinBrowserClientHostCommands } from './browser-client-host-command-joi
 import {
   assertNewPageCommand,
   findExistingCommand,
+  isBrowserClientPageBootstrapCommand,
+  recordBrowserClientPageCommandResult,
+  recordNewPageCommand,
   removeScheduledCommandPage,
   selectCommandPage
 } from './browser-client-host-command-page'
@@ -96,6 +99,7 @@ export class BrowserClientHostCommandDispatcher {
     }
     const previousPage = this.pages.get(acceptedCommand.browserPageId)
     admission.commit()
+    recordNewPageCommand(page, acceptedCommand)
     if (previousPage && previousPage !== page) {
       this.resultCache.releasePage(previousPage)
     }
@@ -182,6 +186,7 @@ export class BrowserClientHostCommandDispatcher {
     if (
       this.closed ||
       page.retiring ||
+      page.retired ||
       page.queue[0]?.status !== 'queued' ||
       this.readyPageIds.has(page.browserPageId)
     ) {
@@ -245,16 +250,13 @@ export class BrowserClientHostCommandDispatcher {
     this.runningHandlers -= 1
     if (record.status === 'running') {
       resolveCommandRecord(record, result)
-      if (record.event.command.type === 'createPage') {
-        page.created = result.status === 'completed'
-        page.createFailed = !page.created
-      }
+      recordBrowserClientPageCommandResult(page, record.event.command, result)
     }
     record.status = 'settled'
     record.controller = undefined
     record.handlerPromise = undefined
     this.removeActiveRecord(page, record)
-    if (record.event.command.type === 'createPage' && !page.created) {
+    if (isBrowserClientPageBootstrapCommand(record.event.command) && !page.created) {
       this.cancelPage(page, 'browser_host_command_dependency_failed')
     }
     if (page.retiring && page.queue.length === 0) {

--- a/src/main/browser/browser-client-host-command-page.ts
+++ b/src/main/browser/browser-client-host-command-page.ts
@@ -1,4 +1,7 @@
-import type { BrowserClientHostCommandEvent } from '../../shared/browser-client-host-protocol'
+import type {
+  BrowserClientHostCommandEvent,
+  BrowserClientHostCommandResult
+} from '../../shared/browser-client-host-protocol'
 import {
   createPageState,
   type CommandRecord,
@@ -94,6 +97,23 @@ function commandsMatch(
       first.command.executionHostKey === second.command.executionHostKey
     )
   }
+  if (first.command.type === 'restorePage' && second.command.type === 'restorePage') {
+    return (
+      first.command.browserProfileId === second.command.browserProfileId &&
+      first.command.executionHostKey === second.command.executionHostKey &&
+      first.command.url === second.command.url
+    )
+  }
+  if (first.command.type === 'reclaimPage' && second.command.type === 'reclaimPage') {
+    return (
+      first.command.browserProfileId === second.command.browserProfileId &&
+      first.command.executionHostKey === second.command.executionHostKey &&
+      sameCommandAuthority(first.command.previousAuthority, second.command.previousAuthority)
+    )
+  }
+  if (first.command.type === 'closePage' && second.command.type === 'closePage') {
+    return sameCommandAuthority(first.command.targetAuthority, second.command.targetAuthority)
+  }
   return false
 }
 
@@ -101,14 +121,63 @@ export function assertNewPageCommand(
   page: PageState,
   command: BrowserClientHostCommandEvent
 ): void {
-  if (page.nextSequence === 1 && command.command.type !== 'createPage') {
+  if (page.nextSequence === 1 && command.command.type === 'navigate') {
     throw new Error('browser_host_command_create_required')
   }
-  if (page.nextSequence > 1 && command.command.type === 'createPage') {
-    throw new Error('browser_host_command_create_repeated')
+  if (page.nextSequence > 1) {
+    if (page.terminalCommandIssued) {
+      throw new Error('browser_host_command_page_terminal')
+    }
+    if (
+      command.command.type === 'createPage' ||
+      command.command.type === 'reclaimPage' ||
+      command.command.type === 'restorePage'
+    ) {
+      throw new Error(
+        command.command.type === 'createPage'
+          ? 'browser_host_command_create_repeated'
+          : 'browser_host_command_bootstrap_repeated'
+      )
+    }
   }
   if (page.createFailed) {
     throw new Error('browser_host_command_dependency_failed')
+  }
+}
+
+export function recordNewPageCommand(
+  page: PageState,
+  command: BrowserClientHostCommandEvent
+): void {
+  if (command.command.type === 'closePage') {
+    page.terminalCommandIssued = true
+  }
+}
+
+export function isBrowserClientPageBootstrapCommand(
+  command: BrowserClientHostCommandEvent['command']
+): boolean {
+  return (
+    command.type === 'createPage' ||
+    command.type === 'reclaimPage' ||
+    command.type === 'restorePage'
+  )
+}
+
+export function recordBrowserClientPageCommandResult(
+  page: PageState,
+  command: BrowserClientHostCommandEvent['command'],
+  result: BrowserClientHostCommandResult
+): void {
+  if (isBrowserClientPageBootstrapCommand(command)) {
+    page.created = result.status === 'completed'
+    page.createFailed = !page.created
+  }
+  if (command.type === 'closePage' && result.status === 'completed') {
+    page.retired = true
+  }
+  if (command.type === 'closePage' && result.status === 'failed') {
+    page.terminalCommandIssued = false
   }
 }
 
@@ -123,4 +192,29 @@ export function removeScheduledCommandPage(
       readyPages.splice(index, 1)
     }
   }
+}
+
+function sameCommandAuthority(
+  left: {
+    authorityRuntimeId: string
+    authorityEpoch: string
+    browserHostClientId: string
+    browserHostGeneration: number
+    pageHostGeneration: number
+  },
+  right: {
+    authorityRuntimeId: string
+    authorityEpoch: string
+    browserHostClientId: string
+    browserHostGeneration: number
+    pageHostGeneration: number
+  }
+): boolean {
+  return (
+    left.authorityRuntimeId === right.authorityRuntimeId &&
+    left.authorityEpoch === right.authorityEpoch &&
+    left.browserHostClientId === right.browserHostClientId &&
+    left.browserHostGeneration === right.browserHostGeneration &&
+    left.pageHostGeneration === right.pageHostGeneration
+  )
 }

--- a/src/main/browser/browser-client-host-command-state.ts
+++ b/src/main/browser/browser-client-host-command-state.ts
@@ -35,6 +35,7 @@ export type PageState = {
   createFailed: boolean
   retiring: boolean
   retired: boolean
+  terminalCommandIssued: boolean
   retirementPromise?: Promise<boolean>
   queue: CommandRecord[]
   records: Map<number, CommandRecord>
@@ -99,7 +100,7 @@ export function createCommandRecord(event: BrowserClientHostCommandEvent): Comma
 export function snapshotCommandEvent(
   event: BrowserClientHostCommandEvent
 ): BrowserClientHostCommandEvent {
-  const command = Object.freeze({ ...event.command })
+  const command = snapshotPageCommand(event.command)
   return Object.freeze({ ...event, command })
 }
 
@@ -112,11 +113,30 @@ export function createPageState(browserPageId: string, generation: number): Page
     createFailed: false,
     retiring: false,
     retired: false,
+    terminalCommandIssued: false,
     queue: [],
     records: new Map(),
     sequencesByCommandId: new Map(),
     settledSequences: []
   }
+}
+
+function snapshotPageCommand(
+  command: BrowserClientHostCommandEvent['command']
+): BrowserClientHostCommandEvent['command'] {
+  if (command.type === 'reclaimPage') {
+    return Object.freeze({
+      ...command,
+      previousAuthority: Object.freeze({ ...command.previousAuthority })
+    })
+  }
+  if (command.type === 'closePage') {
+    return Object.freeze({
+      ...command,
+      targetAuthority: Object.freeze({ ...command.targetAuthority })
+    })
+  }
+  return Object.freeze({ ...command })
 }
 
 export function failedCommandResult(errorCode: string): BrowserClientHostCommandResult {

--- a/src/main/browser/browser-client-host-reconciliation-command-order.test.ts
+++ b/src/main/browser/browser-client-host-reconciliation-command-order.test.ts
@@ -1,0 +1,277 @@
+import type {
+  BrowserClientHostCommandEvent,
+  BrowserClientHostLeaseAuthority
+} from '../../shared/browser-client-host-protocol'
+import { describe, expect, it, vi } from 'vitest'
+import { BrowserHostCommandLedger } from '../runtime/browser-host-command-ledger'
+import { BrowserClientHostCommandDispatcher } from './browser-client-host-command-dispatcher'
+
+const authority: BrowserClientHostLeaseAuthority & {
+  pageCommandProtocolVersion: 1
+  pageReconciliationProtocolVersion: 1
+} = {
+  authorityRuntimeId: 'runtime-a',
+  authorityEpoch: 'epoch-new',
+  browserHostClientId: 'host-a',
+  browserHostGeneration: 3,
+  pageCommandProtocolVersion: 1,
+  pageReconciliationProtocolVersion: 1
+}
+
+const previousAuthority = {
+  authorityRuntimeId: 'runtime-a',
+  authorityEpoch: 'epoch-old',
+  browserHostClientId: 'host-a',
+  browserHostGeneration: 2,
+  pageHostGeneration: 7
+}
+
+function event(
+  command: BrowserClientHostCommandEvent['command'],
+  overrides: Partial<BrowserClientHostCommandEvent> = {}
+): BrowserClientHostCommandEvent {
+  return {
+    type: 'command',
+    ...authority,
+    browserPageId: 'page-a',
+    pageHostGeneration: command.type === 'closePage' ? 7 : 8,
+    commandSequence: 1,
+    commandId: `${command.type}-a`,
+    command,
+    ...overrides
+  }
+}
+
+describe('browser reconciliation command ordering', () => {
+  it.each([
+    {
+      type: 'reclaimPage' as const,
+      previousAuthority,
+      browserProfileId: 'profile-a',
+      executionHostKey: 'host-key-a'
+    },
+    {
+      type: 'restorePage' as const,
+      browserProfileId: 'profile-a',
+      executionHostKey: 'host-key-a'
+    },
+    { type: 'closePage' as const, targetAuthority: previousAuthority }
+  ])('admits $type as an authenticated first client-dispatch command', async (command) => {
+    const handler = vi.fn().mockResolvedValue({ status: 'completed' })
+    const dispatcher = new BrowserClientHostCommandDispatcher({ authority, handler })
+
+    await expect(dispatcher.dispatch(event(command))).resolves.toEqual({ status: 'completed' })
+    expect(handler).toHaveBeenCalledOnce()
+  })
+
+  it('deduplicates exact reclaim bootstrap and rejects changed prior authority', async () => {
+    const handler = vi.fn().mockResolvedValue({ status: 'completed' })
+    const dispatcher = new BrowserClientHostCommandDispatcher({ authority, handler })
+    const reclaim = event({
+      type: 'reclaimPage',
+      previousAuthority,
+      browserProfileId: 'profile-a',
+      executionHostKey: 'host-key-a'
+    })
+
+    const first = dispatcher.dispatch(reclaim)
+    const duplicate = dispatcher.dispatch(reclaim)
+    await expect(first).resolves.toEqual({ status: 'completed' })
+    await expect(duplicate).resolves.toEqual({ status: 'completed' })
+    expect(handler).toHaveBeenCalledOnce()
+    expect(() =>
+      dispatcher.dispatch({
+        ...reclaim,
+        command: {
+          ...reclaim.command,
+          previousAuthority: { ...previousAuthority, authorityEpoch: 'different' }
+        }
+      } as BrowserClientHostCommandEvent)
+    ).toThrow('browser_host_command_sequence_conflict')
+  })
+
+  it('snapshots nested reconciliation authority on both sides of dispatch', async () => {
+    const handler = vi.fn().mockResolvedValue({ status: 'completed' })
+    const dispatcher = new BrowserClientHostCommandDispatcher({ authority, handler })
+    const clientAuthority = { ...previousAuthority }
+    const clientEvent = event({
+      type: 'reclaimPage',
+      previousAuthority: clientAuthority,
+      browserProfileId: 'profile-a',
+      executionHostKey: 'host-key-a'
+    })
+
+    const dispatched = dispatcher.dispatch(clientEvent)
+    clientAuthority.authorityEpoch = 'mutated-client'
+    await dispatched
+    const accepted = handler.mock.calls[0]?.[0] as BrowserClientHostCommandEvent
+    expect(accepted.command).toMatchObject({
+      previousAuthority: expect.objectContaining({ authorityEpoch: 'epoch-old' })
+    })
+    expect(
+      Object.isFrozen(accepted.command.type === 'reclaimPage' && accepted.command.previousAuthority)
+    ).toBe(true)
+
+    const delivery = vi.fn()
+    const ledger = new BrowserHostCommandLedger({ authority })
+    ledger.attach(delivery)
+    const serverAuthority = { ...previousAuthority }
+    ledger.issue({
+      browserPageId: 'page-b',
+      pageHostGeneration: 8,
+      command: {
+        type: 'reclaimPage',
+        previousAuthority: serverAuthority,
+        browserProfileId: 'profile-a',
+        executionHostKey: 'host-key-a'
+      }
+    })
+    serverAuthority.authorityEpoch = 'mutated-server'
+    const emitted = delivery.mock.calls[0]?.[0] as BrowserClientHostCommandEvent
+    expect(emitted.command).toMatchObject({
+      previousAuthority: expect.objectContaining({ authorityEpoch: 'epoch-old' })
+    })
+    expect(
+      Object.isFrozen(emitted.command.type === 'reclaimPage' && emitted.command.previousAuthority)
+    ).toBe(true)
+  })
+
+  it.each(['reclaimPage', 'restorePage'] as const)(
+    'cancels navigation when %s bootstrap fails',
+    async (type) => {
+      const handler = vi
+        .fn()
+        .mockResolvedValueOnce({ status: 'failed', errorCode: 'bootstrap_failed' })
+      const dispatcher = new BrowserClientHostCommandDispatcher({ authority, handler })
+      const bootstrap =
+        type === 'reclaimPage'
+          ? {
+              type,
+              previousAuthority,
+              browserProfileId: 'profile-a',
+              executionHostKey: 'host-key-a'
+            }
+          : {
+              type,
+              browserProfileId: 'profile-a',
+              executionHostKey: 'host-key-a'
+            }
+      const first = dispatcher.dispatch(event(bootstrap))
+      const navigate = dispatcher.dispatch(
+        event(
+          { type: 'navigate', url: 'https://remote.internal/' },
+          { commandSequence: 2, commandId: `${type}-navigate` }
+        )
+      )
+
+      await expect(first).resolves.toEqual({
+        status: 'failed',
+        errorCode: 'bootstrap_failed'
+      })
+      await expect(navigate).resolves.toEqual({
+        status: 'failed',
+        errorCode: 'browser_host_command_dependency_failed'
+      })
+      expect(handler).toHaveBeenCalledOnce()
+    }
+  )
+
+  it('makes an exact close terminal while allowing navigate after reclaim', async () => {
+    const dispatcher = new BrowserClientHostCommandDispatcher({
+      authority,
+      handler: vi.fn().mockResolvedValue({ status: 'completed' })
+    })
+    await dispatcher.dispatch(
+      event({
+        type: 'reclaimPage',
+        previousAuthority,
+        browserProfileId: 'profile-a',
+        executionHostKey: 'host-key-a'
+      })
+    )
+    await expect(
+      dispatcher.dispatch(
+        event(
+          { type: 'navigate', url: 'https://remote.internal/' },
+          { commandSequence: 2, commandId: 'navigate-a' }
+        )
+      )
+    ).resolves.toEqual({ status: 'completed' })
+
+    const closing = new BrowserClientHostCommandDispatcher({
+      authority,
+      handler: vi.fn().mockResolvedValue({ status: 'completed' })
+    })
+    await closing.dispatch(event({ type: 'closePage', targetAuthority: previousAuthority }))
+    expect(() =>
+      closing.dispatch(
+        event(
+          { type: 'navigate', url: 'https://remote.internal/' },
+          { commandSequence: 2, commandId: 'navigate-after-close', pageHostGeneration: 7 }
+        )
+      )
+    ).toThrow('browser_host_page_generation_stale')
+  })
+
+  it('allows the same generation to continue after a failed close', async () => {
+    const handler = vi
+      .fn()
+      .mockResolvedValueOnce({ status: 'failed', errorCode: 'authority_stale' })
+      .mockResolvedValueOnce({ status: 'completed' })
+    const dispatcher = new BrowserClientHostCommandDispatcher({ authority, handler })
+
+    await expect(
+      dispatcher.dispatch(event({ type: 'closePage', targetAuthority: previousAuthority }))
+    ).resolves.toEqual({ status: 'failed', errorCode: 'authority_stale' })
+    await expect(
+      dispatcher.dispatch(
+        event(
+          { type: 'navigate', url: 'https://remote.internal/' },
+          { commandSequence: 2, commandId: 'navigate-after-failed-close', pageHostGeneration: 7 }
+        )
+      )
+    ).resolves.toEqual({ status: 'completed' })
+  })
+
+  it('issues reconciliation bootstrap commands from the server ledger without create', () => {
+    const delivery = vi.fn()
+    const ledger = new BrowserHostCommandLedger({ authority })
+    ledger.attach(delivery)
+
+    const reclaim = ledger.issue({
+      browserPageId: 'page-a',
+      pageHostGeneration: 8,
+      command: {
+        type: 'reclaimPage',
+        previousAuthority,
+        browserProfileId: 'profile-a',
+        executionHostKey: 'host-key-a'
+      }
+    })
+    const navigate = ledger.issue({
+      browserPageId: 'page-a',
+      pageHostGeneration: 8,
+      command: { type: 'navigate', url: 'https://remote.internal/' }
+    })
+    const close = ledger.issue({
+      browserPageId: 'page-b',
+      pageHostGeneration: 9,
+      command: {
+        type: 'closePage',
+        targetAuthority: { ...previousAuthority, pageHostGeneration: 9 }
+      }
+    })
+
+    expect(reclaim.event.commandSequence).toBe(1)
+    expect(navigate.event.commandSequence).toBe(2)
+    expect(close.event.commandSequence).toBe(1)
+    expect(delivery).toHaveBeenCalledTimes(3)
+    expect(() =>
+      ledger.issue({
+        browserPageId: 'page-b',
+        pageHostGeneration: 9,
+        command: { type: 'navigate', url: 'https://after-close.invalid/' }
+      })
+    ).toThrow('browser_host_command_page_terminal')
+  })
+})

--- a/src/main/browser/browser-client-page-cleanup.ts
+++ b/src/main/browser/browser-client-page-cleanup.ts
@@ -23,6 +23,11 @@ export type BrowserClientPageRenderer = {
     page: BrowserClientPageRendererIdentity,
     signal: AbortSignal
   ): Promise<{ webContentsId: number }>
+  rekeyPage?(
+    previous: BrowserClientPageRendererIdentity,
+    next: BrowserClientPageRendererIdentity,
+    signal: AbortSignal
+  ): Promise<void>
   retirePage(page: BrowserClientPageRendererIdentity): void | Promise<void>
 }
 
@@ -32,7 +37,7 @@ export async function cleanupBrowserClientPage(
     guestMayExist: boolean
     lifecycleClaim: BrowserRouteGuestLifecycleClaim | null
     renderer: BrowserClientPageRenderer | null
-    rendererPage: BrowserClientPageRendererIdentity | null
+    rendererPages: readonly BrowserClientPageRendererIdentity[]
     routeSession: BrowserRouteSessionHandle | null
     route: BrowserClientPageNetworkRoute | null
   }
@@ -53,9 +58,10 @@ export async function cleanupBrowserClientPage(
     }
   }
   const renderer = target.renderer
-  const rendererPage = target.rendererPage
-  if (renderer && rendererPage) {
-    await collectCleanupFailure(() => renderer.retirePage(rendererPage), failures)
+  if (renderer) {
+    for (const rendererPage of target.rendererPages) {
+      await collectCleanupFailure(() => renderer.retirePage(rendererPage), failures)
+    }
   }
   if (guestDestruction) {
     guestDestroyed = await collectCleanupFailure(() => guestDestruction, failures)

--- a/src/main/browser/browser-client-page-command-executor.test.ts
+++ b/src/main/browser/browser-client-page-command-executor.test.ts
@@ -507,7 +507,7 @@ describe('BrowserClientPageCommandExecutor', () => {
     ])
   })
 
-  it('attempts every cleanup and keeps a failed retirement fenced', async () => {
+  it('moves a failed retirement into immutable outcome-unknown inventory', async () => {
     const { executor, order, renderer } = createHarness()
     await executor.handle(createCommand('createPage'), new AbortController().signal)
     renderer.retirePage.mockImplementationOnce(async () => {
@@ -524,7 +524,14 @@ describe('BrowserClientPageCommandExecutor', () => {
       'release-session',
       'release-route'
     ])
-    expect(executor.hasPage('page-a', 7)).toBe(true)
+    expect(executor.hasPage('page-a', 7)).toBe(false)
+    expect(executor.hasUnresolvedPage('page-a', 7)).toBe(true)
+    const inventory = executor.snapshotPageInventory()
+    expect(inventory).toEqual([
+      expect.objectContaining({ browserPageId: 'page-a', state: 'outcomeUnknown' })
+    ])
+    expect(Object.isFrozen(inventory[0])).toBe(true)
+    await expect(executor.retirePage('page-a', 7)).resolves.toBe(false)
     await expect(
       executor.handle(
         createCommand('createPage', { pageHostGeneration: 8 }),

--- a/src/main/browser/browser-client-page-command-executor.ts
+++ b/src/main/browser/browser-client-page-command-executor.ts
@@ -8,25 +8,23 @@ import { normalizeBrowserNavigationUrl } from '../../shared/browser-url'
 import {
   cleanupBrowserClientPage,
   type BrowserClientPageNetworkRoute as RetainedNetworkRoute,
-  type BrowserClientPageRenderer
+  type BrowserClientPageRenderer,
+  type BrowserClientPageRendererIdentity
 } from './browser-client-page-cleanup'
+import { createReservedBrowserClientPage } from './browser-client-page-creation'
 import {
   assertBrowserClientPageCommandNotAborted,
   assertCurrentBrowserClientPageRenderer,
   browserClientPageIdentity
 } from './browser-client-page-command-admission'
-import type {
-  BrowserRouteGuestLifecycleClaim,
-  BrowserRoutePageGuestIdentity
-} from './browser-route-page-authority'
 import type { BrowserRouteSessionRegistry } from './browser-route-session-registry'
-import type { BrowserRouteSessionHandle } from './browser-route-session-state'
 import {
   browserClientPageCommandFailureCode,
   BrowserClientPageCommandError,
   isBrowserClientPageCleanupFailure
 } from './browser-client-page-command-failure'
 import { BrowserClientPageNavigationFence } from './browser-client-page-navigation-fence'
+import { executeBrowserClientPageReconciliationCommand } from './browser-client-page-reconciliation'
 import type {
   BrowserClientPageLifecycleRegistry,
   BrowserClientRetainedPage
@@ -75,12 +73,37 @@ export class BrowserClientPageCommandExecutor {
       return { status: 'failed', errorCode: 'browser_client_page_executor_closed' }
     }
     try {
-      await (event.command.type === 'createPage'
-        ? this.createPage(event, signal)
-        : this.navigate(event, signal))
+      await this.executeCommand(event, signal)
       return { status: 'completed' }
     } catch (error) {
       return { status: 'failed', errorCode: browserClientPageCommandFailureCode(error, signal) }
+    }
+  }
+
+  private executeCommand(event: BrowserClientHostCommandEvent, signal: AbortSignal): Promise<void> {
+    switch (event.command.type) {
+      case 'createPage':
+        return this.createPage(event, signal)
+      case 'navigate':
+        return this.navigate(event, signal)
+      case 'reclaimPage':
+      case 'closePage':
+      case 'restorePage':
+        return executeBrowserClientPageReconciliationCommand(
+          {
+            pages: this.pages,
+            failedPages: this.failedPages,
+            routeWebContents: this.dependencies.routeWebContents,
+            assertAvailable: () => this.navigationFence.assertAvailable(this.closed),
+            createPage: (command, commandSignal) => this.createPage(command, commandSignal),
+            navigate: (command, commandSignal) => this.navigate(command, commandSignal),
+            retirePage: (browserPageId, generation) => this.retirePage(browserPageId, generation),
+            cleanupPage: (page, previousRendererPage) =>
+              this.cleanupPage(page, previousRendererPage)
+          },
+          event,
+          signal
+        )
     }
   }
 
@@ -121,7 +144,18 @@ export class BrowserClientPageCommandExecutor {
       return false
     }
     page.retiring ??= this.cleanupPage(page)
-    await page.retiring
+    try {
+      await page.retiring
+    } catch (error) {
+      if (this.pages.get(browserPageId) === page) {
+        this.pages.delete(browserPageId)
+      }
+      this.failedPages.set(
+        browserPageId,
+        Object.freeze({ ...page.inventory, state: 'outcomeUnknown' })
+      )
+      throw error
+    }
     if (this.pages.get(browserPageId) === page) {
       this.pages.delete(browserPageId)
     }
@@ -163,93 +197,13 @@ export class BrowserClientPageCommandExecutor {
     event: BrowserClientHostCommandEvent,
     signal: AbortSignal
   ): Promise<void> {
-    if (event.command.type !== 'createPage') {
-      throw new BrowserClientPageCommandError('browser_client_page_command_invalid')
-    }
-    assertBrowserClientPageCommandNotAborted(signal)
-    let route: RetainedNetworkRoute | null = null
-    let routeSession: BrowserRouteSessionHandle | null = null
-    let renderer: BrowserClientPageRenderer | null = null
-    let registration: BrowserRoutePageGuestIdentity | null = null
-    let lifecycleClaim: BrowserRouteGuestLifecycleClaim | null = null
-    let mountAttempted = false
-    try {
-      route = await this.dependencies.retainNetworkRoute(event.command.executionHostKey, signal)
-      if (route.key !== event.command.executionHostKey) {
-        throw new BrowserClientPageCommandError('browser_client_page_execution_host_stale')
-      }
-      assertBrowserClientPageCommandNotAborted(signal)
-      this.navigationFence.assertAvailable(this.closed)
-      renderer = this.dependencies.selectRenderer()
-      assertCurrentBrowserClientPageRenderer(renderer)
-      routeSession = await this.dependencies.routeSessions.preparePage({
-        identity: {
-          orcaProfileId: this.dependencies.orcaProfileId,
-          browserProfileId: event.command.browserProfileId,
-          authorityConnectionIdentity: this.dependencies.authorityConnectionIdentity,
-          executionHostIdentity: route.executionHostIdentity
-        },
-        browserPageId: event.browserPageId,
-        pageHostGeneration: event.pageHostGeneration,
-        rendererWebContentsId: renderer.rendererWebContentsId,
-        proxyEndpoint: route.proxyEndpoint
-      })
-      assertBrowserClientPageCommandNotAborted(signal)
-      this.navigationFence.assertAvailable(this.closed)
-      assertCurrentBrowserClientPageRenderer(renderer)
-      const page = browserClientPageIdentity(event, routeSession.partition)
-      mountAttempted = true
-      const mounted = await renderer.mountPage(page, signal)
-      registration = {
-        ...page,
-        rendererWebContentsId: renderer.rendererWebContentsId,
-        webContentsId: mounted.webContentsId
-      }
-      lifecycleClaim = this.dependencies.routeWebContents.claimGuestLifecycle(registration)
-      if (!lifecycleClaim) {
-        throw new BrowserClientPageCommandError('browser_client_page_guest_observation_failed')
-      }
-      assertBrowserClientPageCommandNotAborted(signal)
-      this.navigationFence.assertAvailable(this.closed)
-      assertCurrentBrowserClientPageRenderer(renderer)
-      if (!this.dependencies.routeWebContents.registerGuest(registration)) {
-        throw new BrowserClientPageCommandError('browser_client_page_guest_registration_failed')
-      }
-      if (!this.dependencies.routeWebContents.grantNavigation(registration)) {
-        throw new BrowserClientPageCommandError('browser_client_page_navigation_grant_failed')
-      }
-      if (this.closed || this.navigationFence.isFenced) {
-        throw new BrowserClientPageCommandError('browser_client_page_executor_closed')
-      }
-      this.pages.set(event.browserPageId, {
-        generation: event.pageHostGeneration,
-        inventory: createBrowserClientPageInventory(event, 'active'),
-        registration,
-        lifecycleClaim,
-        renderer,
-        route,
-        routeSession,
-        retiring: null
-      })
-    } catch (error) {
-      try {
-        await cleanupBrowserClientPage(this.dependencies.routeWebContents, {
-          guestMayExist: mountAttempted,
-          lifecycleClaim,
-          renderer,
-          rendererPage: routeSession
-            ? browserClientPageIdentity(event, routeSession.partition)
-            : null,
-          route,
-          routeSession
-        })
-      } catch (cleanupError) {
-        throw new BrowserClientPageCommandError('browser_client_page_cleanup_failed', {
-          cause: new AggregateError([error, cleanupError], 'Browser client page creation failed')
-        })
-      }
-      throw error
-    }
+    await createReservedBrowserClientPage(
+      this.dependencies,
+      event,
+      signal,
+      () => this.navigationFence.assertAvailable(this.closed),
+      (page) => this.pages.set(event.browserPageId, page)
+    )
   }
 
   private async navigate(event: BrowserClientHostCommandEvent, signal: AbortSignal): Promise<void> {
@@ -257,7 +211,12 @@ export class BrowserClientPageCommandExecutor {
       throw new BrowserClientPageCommandError('browser_client_page_command_invalid')
     }
     const page = this.pages.get(event.browserPageId)
-    if (!page || page.generation !== event.pageHostGeneration || page.retiring) {
+    if (
+      !page ||
+      page.generation !== event.pageHostGeneration ||
+      page.retiring ||
+      page.reconciling
+    ) {
       throw new BrowserClientPageCommandError('browser_client_page_generation_stale')
     }
     assertBrowserClientPageCommandNotAborted(signal)
@@ -276,12 +235,21 @@ export class BrowserClientPageCommandExecutor {
     page.inventory = updateBrowserClientPageInventoryCurrentUrl(page.inventory, normalized)
   }
 
-  private async cleanupPage(page: BrowserClientRetainedPage): Promise<void> {
+  private async cleanupPage(
+    page: BrowserClientRetainedPage,
+    previousRendererPage?: BrowserClientPageRendererIdentity
+  ): Promise<void> {
+    const currentRendererPage = browserClientPageIdentity(
+      page.registration,
+      page.registration.partition
+    )
     return cleanupBrowserClientPage(this.dependencies.routeWebContents, {
       guestMayExist: true,
       lifecycleClaim: page.lifecycleClaim,
       renderer: page.renderer,
-      rendererPage: browserClientPageIdentity(page.registration, page.registration.partition),
+      rendererPages: previousRendererPage
+        ? [currentRendererPage, previousRendererPage]
+        : [currentRendererPage],
       route: page.route,
       routeSession: page.routeSession
     })

--- a/src/main/browser/browser-client-page-command-integration.test.ts
+++ b/src/main/browser/browser-client-page-command-integration.test.ts
@@ -1,6 +1,7 @@
 import type { Session, WebContents } from 'electron'
 import { describe, expect, it, vi } from 'vitest'
 import type { BrowserClientHostCommandEvent } from '../../shared/browser-client-host-protocol'
+import { BrowserClientHostCommandDispatcher } from './browser-client-host-command-dispatcher'
 import { BrowserClientPageCommandExecutor } from './browser-client-page-command-executor'
 import { BrowserRouteSessionRegistry } from './browser-route-session-registry'
 import { BrowserRouteWebContentsRegistry } from './browser-route-webcontents-registry'
@@ -29,15 +30,19 @@ describe('BrowserClientPageCommandExecutor integration', () => {
     webContentsRegistry = new BrowserRouteWebContentsRegistry({
       getPartitionForSession: (session) => sessionRegistry.getPartitionForSession(session),
       getPreparedPageAuthority: (page) => sessionRegistry.getPreparedPageAuthority(page),
+      rekeyPreparedPage: (previous, next) => sessionRegistry.rekeyPreparedPage(previous, next),
       retirePreparedPage: (page) => sessionRegistry.retirePreparedPage(page),
       retirePreparedPagesOwnedByRenderer: (rendererWebContentsId) =>
         sessionRegistry.retirePreparedPagesOwnedByRenderer(rendererWebContentsId)
     })
+    const rekeyGuestLifecycle = vi.spyOn(webContentsRegistry, 'rekeyGuestLifecycle')
+    const grantReconciledNavigation = vi.spyOn(webContentsRegistry, 'grantReconciledNavigation')
     const guest = createGuest(routeSession as unknown as Session)
     const routeRelease = vi.fn()
     const rendererRetire = vi.fn(async () => {
       guest.destroy()
     })
+    const rendererRekey = vi.fn(async () => {})
     const executor = new BrowserClientPageCommandExecutor({
       orcaProfileId: 'orca-profile-a',
       authorityConnectionIdentity: 'authority-record-a',
@@ -54,6 +59,7 @@ describe('BrowserClientPageCommandExecutor integration', () => {
           expect(webContentsRegistry?.attachGuest(guest.webContents)).toBe(true)
           return { webContentsId: 41 }
         },
+        rekeyPage: rendererRekey,
         retirePage: rendererRetire
       }),
       routeSessions: sessionRegistry,
@@ -70,11 +76,32 @@ describe('BrowserClientPageCommandExecutor integration', () => {
     })
     expect(guest.url()).toBe('https://example.internal/path')
 
+    const reclaim = createCommand('reclaimPage')
+    const dispatcher = new BrowserClientHostCommandDispatcher({
+      authority: reclaim,
+      handler: (event, commandSignal) => executor.handle(event, commandSignal)
+    })
+    const reclaimed = await dispatcher.dispatch(reclaim)
+    expect(rekeyGuestLifecycle).toHaveReturnedWith(expect.any(Object))
+    expect(grantReconciledNavigation).toHaveReturnedWith(true)
+    expect(reclaimed).toEqual({ status: 'completed' })
+    expect(rendererRekey).toHaveBeenCalledOnce()
+    expect(executor.hasPage('page-a', 7)).toBe(false)
+    expect(executor.hasPage('page-a', 8)).toBe(true)
+    expect(executor.snapshotPageInventory()).toEqual([
+      expect.objectContaining({
+        authorityEpoch: 'epoch-new',
+        pageHostGeneration: 8,
+        currentUrl: 'https://example.internal/path',
+        state: 'active'
+      })
+    ])
+
     guest.destroy()
     expect(executor.snapshotPageInventory()).toEqual([
       expect.objectContaining({ browserPageId: 'page-a', state: 'outcomeUnknown' })
     ])
-    await expect(executor.retirePage('page-a', 7)).resolves.toBe(true)
+    await expect(executor.retirePage('page-a', 8)).resolves.toBe(true)
     expect(guest.webContents.close).not.toHaveBeenCalled()
     expect(rendererRetire).toHaveBeenCalledOnce()
     expect(routeRelease).toHaveBeenCalledOnce()
@@ -83,17 +110,27 @@ describe('BrowserClientPageCommandExecutor integration', () => {
   })
 })
 
-function createCommand(type: 'createPage' | 'navigate'): BrowserClientHostCommandEvent {
-  return {
-    type: 'command',
+function createCommand(
+  type: 'createPage' | 'navigate' | 'reclaimPage'
+): BrowserClientHostCommandEvent {
+  const previousAuthority = {
     authorityRuntimeId: 'runtime-a',
     authorityEpoch: 'epoch-a',
     browserHostClientId: 'client-a',
     browserHostGeneration: 3,
+    pageHostGeneration: 7
+  }
+  return {
+    type: 'command',
+    authorityRuntimeId: 'runtime-a',
+    authorityEpoch: type === 'reclaimPage' ? 'epoch-new' : 'epoch-a',
+    browserHostClientId: 'client-a',
+    browserHostGeneration: type === 'reclaimPage' ? 4 : 3,
     pageCommandProtocolVersion: 1,
+    pageReconciliationProtocolVersion: 1,
     browserPageId: 'page-a',
-    pageHostGeneration: 7,
-    commandSequence: type === 'createPage' ? 1 : 2,
+    pageHostGeneration: type === 'reclaimPage' ? 8 : 7,
+    commandSequence: type === 'createPage' || type === 'reclaimPage' ? 1 : 2,
     commandId: `${type}-a`,
     command:
       type === 'createPage'
@@ -102,7 +139,14 @@ function createCommand(type: 'createPage' | 'navigate'): BrowserClientHostComman
             browserProfileId: 'profile-a',
             executionHostKey: 'execution-host-a'
           }
-        : { type: 'navigate', url: 'example.internal/path' }
+        : type === 'navigate'
+          ? { type: 'navigate', url: 'example.internal/path' }
+          : {
+              type: 'reclaimPage',
+              previousAuthority,
+              browserProfileId: 'profile-a',
+              executionHostKey: 'execution-host-a'
+            }
   }
 }
 

--- a/src/main/browser/browser-client-page-creation.ts
+++ b/src/main/browser/browser-client-page-creation.ts
@@ -1,0 +1,129 @@
+import type { BrowserClientHostCommandEvent } from '../../shared/browser-client-host-protocol'
+import {
+  cleanupBrowserClientPage,
+  type BrowserClientPageNetworkRoute as RetainedNetworkRoute,
+  type BrowserClientPageRenderer
+} from './browser-client-page-cleanup'
+import {
+  assertBrowserClientPageCommandNotAborted,
+  assertCurrentBrowserClientPageRenderer,
+  browserClientPageIdentity
+} from './browser-client-page-command-admission'
+import { BrowserClientPageCommandError } from './browser-client-page-command-failure'
+import { createBrowserClientPageInventory } from './browser-client-page-inventory'
+import type {
+  BrowserClientPageLifecycleRegistry,
+  BrowserClientRetainedPage
+} from './browser-client-page-retained-state'
+import type {
+  BrowserRouteGuestLifecycleClaim,
+  BrowserRoutePageGuestIdentity
+} from './browser-route-page-authority'
+import type { BrowserRouteSessionRegistry } from './browser-route-session-registry'
+import type { BrowserRouteSessionHandle } from './browser-route-session-state'
+
+type BrowserClientPageCreationDependencies = {
+  orcaProfileId: string
+  authorityConnectionIdentity: string
+  retainNetworkRoute(executionHostKey: string, signal: AbortSignal): Promise<RetainedNetworkRoute>
+  selectRenderer(): BrowserClientPageRenderer
+  routeSessions: Pick<BrowserRouteSessionRegistry, 'preparePage'>
+  routeWebContents: BrowserClientPageLifecycleRegistry
+}
+
+export async function createReservedBrowserClientPage(
+  dependencies: BrowserClientPageCreationDependencies,
+  event: BrowserClientHostCommandEvent,
+  signal: AbortSignal,
+  assertAvailable: () => void,
+  commit: (page: BrowserClientRetainedPage) => void
+): Promise<BrowserClientRetainedPage> {
+  if (event.command.type !== 'createPage') {
+    throw new BrowserClientPageCommandError('browser_client_page_command_invalid')
+  }
+  assertBrowserClientPageCommandNotAborted(signal)
+  let route: RetainedNetworkRoute | null = null
+  let routeSession: BrowserRouteSessionHandle | null = null
+  let renderer: BrowserClientPageRenderer | null = null
+  let registration: BrowserRoutePageGuestIdentity | null = null
+  let lifecycleClaim: BrowserRouteGuestLifecycleClaim | null = null
+  let mountAttempted = false
+  try {
+    route = await dependencies.retainNetworkRoute(event.command.executionHostKey, signal)
+    if (route.key !== event.command.executionHostKey) {
+      throw new BrowserClientPageCommandError('browser_client_page_execution_host_stale')
+    }
+    assertBrowserClientPageCommandNotAborted(signal)
+    assertAvailable()
+    renderer = dependencies.selectRenderer()
+    assertCurrentBrowserClientPageRenderer(renderer)
+    routeSession = await dependencies.routeSessions.preparePage({
+      identity: {
+        orcaProfileId: dependencies.orcaProfileId,
+        browserProfileId: event.command.browserProfileId,
+        authorityConnectionIdentity: dependencies.authorityConnectionIdentity,
+        executionHostIdentity: route.executionHostIdentity
+      },
+      browserPageId: event.browserPageId,
+      pageHostGeneration: event.pageHostGeneration,
+      rendererWebContentsId: renderer.rendererWebContentsId,
+      proxyEndpoint: route.proxyEndpoint
+    })
+    assertBrowserClientPageCommandNotAborted(signal)
+    assertAvailable()
+    assertCurrentBrowserClientPageRenderer(renderer)
+    const page = browserClientPageIdentity(event, routeSession.partition)
+    mountAttempted = true
+    const mounted = await renderer.mountPage(page, signal)
+    registration = {
+      ...page,
+      rendererWebContentsId: renderer.rendererWebContentsId,
+      webContentsId: mounted.webContentsId
+    }
+    lifecycleClaim = dependencies.routeWebContents.claimGuestLifecycle(registration)
+    if (!lifecycleClaim) {
+      throw new BrowserClientPageCommandError('browser_client_page_guest_observation_failed')
+    }
+    assertBrowserClientPageCommandNotAborted(signal)
+    assertAvailable()
+    assertCurrentBrowserClientPageRenderer(renderer)
+    if (!dependencies.routeWebContents.registerGuest(registration)) {
+      throw new BrowserClientPageCommandError('browser_client_page_guest_registration_failed')
+    }
+    if (!dependencies.routeWebContents.grantNavigation(registration)) {
+      throw new BrowserClientPageCommandError('browser_client_page_navigation_grant_failed')
+    }
+    assertAvailable()
+    const retainedPage = {
+      generation: event.pageHostGeneration,
+      inventory: createBrowserClientPageInventory(event, 'active'),
+      registration,
+      lifecycleClaim,
+      renderer,
+      route,
+      routeSession,
+      retiring: null,
+      reconciling: false
+    }
+    commit(retainedPage)
+    return retainedPage
+  } catch (error) {
+    try {
+      await cleanupBrowserClientPage(dependencies.routeWebContents, {
+        guestMayExist: mountAttempted,
+        lifecycleClaim,
+        renderer,
+        rendererPages: routeSession
+          ? [browserClientPageIdentity(event, routeSession.partition)]
+          : [],
+        route,
+        routeSession
+      })
+    } catch (cleanupError) {
+      throw new BrowserClientPageCommandError('browser_client_page_cleanup_failed', {
+        cause: new AggregateError([error, cleanupError], 'Browser client page creation failed')
+      })
+    }
+    throw error
+  }
+}

--- a/src/main/browser/browser-client-page-inventory.ts
+++ b/src/main/browser/browser-client-page-inventory.ts
@@ -55,6 +55,7 @@ export function snapshotBrowserClientPageInventoryList(
     lifecycleClaim: BrowserRouteGuestLifecycleClaim
     renderer: BrowserClientPageRenderer
     retiring: Promise<void> | null
+    reconciling: boolean
   }>,
   failedPages: ReadonlyMap<string, BrowserClientHostedPageInventory>
 ): readonly BrowserClientHostedPageInventory[] {
@@ -66,7 +67,7 @@ export function snapshotBrowserClientPageInventoryList(
         page.inventory,
         page.renderer,
         page.lifecycleClaim,
-        page.retiring !== null
+        page.retiring !== null || page.reconciling
       )
     )
   }

--- a/src/main/browser/browser-client-page-reconciliation-adapters.test.ts
+++ b/src/main/browser/browser-client-page-reconciliation-adapters.test.ts
@@ -1,0 +1,288 @@
+import type { BrowserClientHostCommandEvent } from '../../shared/browser-client-host-protocol'
+import { describe, expect, it, vi } from 'vitest'
+import { BrowserClientPageCommandExecutor } from './browser-client-page-command-executor'
+import type {
+  BrowserRouteGuestLifecycleClaim,
+  BrowserRoutePageGuestIdentity
+} from './browser-route-page-authority'
+
+const partition = `persist:orca-browser-v1-${'a'.repeat(64)}`
+
+function command(
+  type: BrowserClientHostCommandEvent['command']['type'],
+  overrides: Partial<BrowserClientHostCommandEvent> = {}
+): BrowserClientHostCommandEvent {
+  const authority =
+    type === 'createPage'
+      ? {
+          authorityRuntimeId: 'runtime-a',
+          authorityEpoch: 'epoch-old',
+          browserHostGeneration: 2,
+          pageHostGeneration: 7
+        }
+      : {
+          authorityRuntimeId: 'runtime-a',
+          authorityEpoch: 'epoch-new',
+          browserHostGeneration: 3,
+          pageHostGeneration: type === 'closePage' ? 7 : 8
+        }
+  const previousAuthority = {
+    authorityRuntimeId: 'runtime-a',
+    authorityEpoch: 'epoch-old',
+    browserHostClientId: 'client-a',
+    browserHostGeneration: 2,
+    pageHostGeneration: 7
+  }
+  const commands = {
+    createPage: {
+      type: 'createPage' as const,
+      browserProfileId: 'profile-a',
+      executionHostKey: 'execution-host-a'
+    },
+    navigate: { type: 'navigate' as const, url: 'https://remote.internal/' },
+    reclaimPage: {
+      type: 'reclaimPage' as const,
+      previousAuthority,
+      browserProfileId: 'profile-a',
+      executionHostKey: 'execution-host-a'
+    },
+    closePage: { type: 'closePage' as const, targetAuthority: previousAuthority },
+    restorePage: {
+      type: 'restorePage' as const,
+      browserProfileId: 'profile-a',
+      executionHostKey: 'execution-host-a',
+      url: 'https://restored.internal/'
+    }
+  }
+  return {
+    type: 'command',
+    pageCommandProtocolVersion: 1,
+    pageReconciliationProtocolVersion: 1,
+    browserHostClientId: 'client-a',
+    browserPageId: 'page-a',
+    commandSequence: 1,
+    commandId: `${type}-a`,
+    ...authority,
+    command: commands[type],
+    ...overrides
+  } as BrowserClientHostCommandEvent
+}
+
+function lifecycleClaim(
+  registration: BrowserRoutePageGuestIdentity
+): BrowserRouteGuestLifecycleClaim {
+  return {
+    registration: { ...registration },
+    guestAuthority: Symbol('guest-authority'),
+    whenDestroyed: Promise.resolve(),
+    isCurrent: () => true
+  }
+}
+
+function createHarness() {
+  const route = {
+    key: 'execution-host-a',
+    executionHostIdentity: 'execution-host-record-a',
+    proxyEndpoint: { host: '127.0.0.1' as const, port: 43123 },
+    release: vi.fn()
+  }
+  const routeSession = { partition, release: vi.fn() }
+  const renderer = {
+    rendererWebContentsId: 11,
+    isCurrent: vi.fn(() => true),
+    mountPage: vi.fn(async () => ({ webContentsId: 41 })),
+    rekeyPage: vi.fn(async () => {}),
+    retirePage: vi.fn()
+  }
+  const routeWebContents = {
+    claimGuestLifecycle: vi.fn((registration: BrowserRoutePageGuestIdentity) =>
+      lifecycleClaim(registration)
+    ),
+    registerGuest: vi.fn(() => true),
+    grantNavigation: vi.fn(() => true),
+    grantReconciledNavigation: vi.fn(() => true),
+    revokeNavigation: vi.fn(() => true),
+    navigateGuest: vi.fn(async () => true),
+    beginGuestRetirement: vi.fn(() => Promise.resolve()),
+    rekeyGuestLifecycle: vi.fn(
+      (_claim: BrowserRouteGuestLifecycleClaim, registration: BrowserRoutePageGuestIdentity) => ({
+        lifecycleClaim: lifecycleClaim(registration),
+        routeSession: { partition, release: vi.fn() }
+      })
+    )
+  }
+  const dependencies = {
+    orcaProfileId: 'orca-profile-a',
+    authorityConnectionIdentity: 'authority-record-a',
+    retainNetworkRoute: vi.fn(async () => route),
+    selectRenderer: vi.fn(() => renderer),
+    routeSessions: { preparePage: vi.fn(async () => routeSession) },
+    routeWebContents
+  }
+  return {
+    dependencies,
+    executor: new BrowserClientPageCommandExecutor(dependencies),
+    renderer,
+    routeWebContents
+  }
+}
+
+describe('browser client page reconciliation adapters', () => {
+  it('reclaims one retained guest by rekeying every exact authority without remounting', async () => {
+    const { executor, renderer, routeWebContents } = createHarness()
+    await expect(
+      executor.handle(command('createPage'), new AbortController().signal)
+    ).resolves.toEqual({
+      status: 'completed'
+    })
+
+    await expect(
+      executor.handle(command('reclaimPage'), new AbortController().signal)
+    ).resolves.toEqual({
+      status: 'completed'
+    })
+
+    expect(renderer.mountPage).toHaveBeenCalledOnce()
+    expect(renderer.rekeyPage).toHaveBeenCalledWith(
+      { partition, browserPageId: 'page-a', pageHostGeneration: 7 },
+      { partition, browserPageId: 'page-a', pageHostGeneration: 8 },
+      expect.any(AbortSignal)
+    )
+    expect(routeWebContents.rekeyGuestLifecycle).toHaveBeenCalledOnce()
+    expect(executor.snapshotPageInventory()).toEqual([
+      expect.objectContaining({
+        authorityEpoch: 'epoch-new',
+        browserHostGeneration: 3,
+        pageHostGeneration: 8,
+        state: 'active'
+      })
+    ])
+  })
+
+  it('closes only the exact stale authority and leaves mismatches untouched', async () => {
+    const { executor, renderer } = createHarness()
+    await executor.handle(command('createPage'), new AbortController().signal)
+
+    await expect(
+      executor.handle(
+        command('closePage', {
+          command: {
+            type: 'closePage',
+            targetAuthority: {
+              authorityRuntimeId: 'runtime-a',
+              authorityEpoch: 'different',
+              browserHostClientId: 'client-a',
+              browserHostGeneration: 2,
+              pageHostGeneration: 7
+            }
+          }
+        }),
+        new AbortController().signal
+      )
+    ).resolves.toEqual({
+      status: 'failed',
+      errorCode: 'browser_client_page_reconciliation_authority_stale'
+    })
+    expect(executor.hasPage('page-a', 7)).toBe(true)
+
+    await expect(
+      executor.handle(command('closePage'), new AbortController().signal)
+    ).resolves.toEqual({
+      status: 'completed'
+    })
+    expect(renderer.retirePage).toHaveBeenCalledOnce()
+    expect(executor.snapshotPageInventory()).toEqual([])
+  })
+
+  it('restores a missing page and its URL only after fresh exact creation', async () => {
+    const { executor, renderer, routeWebContents } = createHarness()
+
+    await expect(
+      executor.handle(command('restorePage'), new AbortController().signal)
+    ).resolves.toEqual({
+      status: 'completed'
+    })
+
+    expect(renderer.mountPage).toHaveBeenCalledOnce()
+    expect(routeWebContents.navigateGuest).toHaveBeenCalledWith(
+      expect.any(Object),
+      'https://restored.internal/'
+    )
+    expect(executor.snapshotPageInventory()).toEqual([
+      expect.objectContaining({
+        authorityEpoch: 'epoch-new',
+        browserHostGeneration: 3,
+        pageHostGeneration: 8,
+        currentUrl: 'https://restored.internal/',
+        state: 'active'
+      })
+    ])
+  })
+
+  it('destroys a rekeyed guest instead of restoring authority after renderer failure', async () => {
+    const { executor, renderer, routeWebContents } = createHarness()
+    await executor.handle(command('createPage'), new AbortController().signal)
+    const retainedRendererPages = new Set(['page-a:7', 'page-b:4'])
+    renderer.rekeyPage.mockRejectedValueOnce(new Error('renderer outcome unknown'))
+    renderer.retirePage.mockImplementation(async (page) => {
+      retainedRendererPages.delete(`${page.browserPageId}:${page.pageHostGeneration}`)
+    })
+
+    await expect(
+      executor.handle(command('reclaimPage'), new AbortController().signal)
+    ).resolves.toEqual({
+      status: 'failed',
+      errorCode: 'browser_client_page_command_failed'
+    })
+
+    expect(routeWebContents.revokeNavigation).toHaveBeenCalledOnce()
+    expect(routeWebContents.grantNavigation).toHaveBeenCalledOnce()
+    expect(routeWebContents.beginGuestRetirement).toHaveBeenCalledOnce()
+    expect(renderer.retirePage).toHaveBeenNthCalledWith(1, {
+      partition,
+      browserPageId: 'page-a',
+      pageHostGeneration: 8
+    })
+    expect(renderer.retirePage).toHaveBeenNthCalledWith(2, {
+      partition,
+      browserPageId: 'page-a',
+      pageHostGeneration: 7
+    })
+    expect(retainedRendererPages).toEqual(new Set(['page-b:4']))
+    expect(executor.snapshotPageInventory()).toEqual([])
+  })
+
+  it('removes a fresh restore when its initial navigation cannot be proven', async () => {
+    const { executor, renderer, routeWebContents } = createHarness()
+    routeWebContents.navigateGuest.mockResolvedValueOnce(false)
+
+    await expect(
+      executor.handle(command('restorePage'), new AbortController().signal)
+    ).resolves.toEqual({
+      status: 'failed',
+      errorCode: 'browser_client_page_navigation_failed'
+    })
+
+    expect(renderer.retirePage).toHaveBeenCalledOnce()
+    expect(routeWebContents.beginGuestRetirement).toHaveBeenCalledOnce()
+    expect(executor.snapshotPageInventory()).toEqual([])
+  })
+
+  it('destroys a guest rekeyed after abort instead of granting late navigation', async () => {
+    const { executor, renderer, routeWebContents } = createHarness()
+    await executor.handle(command('createPage'), new AbortController().signal)
+    const controller = new AbortController()
+    renderer.rekeyPage.mockImplementationOnce(async () => {
+      controller.abort(new Error('authority replaced'))
+    })
+
+    await expect(executor.handle(command('reclaimPage'), controller.signal)).resolves.toEqual({
+      status: 'failed',
+      errorCode: 'browser_client_page_command_aborted'
+    })
+
+    expect(routeWebContents.grantReconciledNavigation).not.toHaveBeenCalled()
+    expect(routeWebContents.beginGuestRetirement).toHaveBeenCalledOnce()
+    expect(executor.snapshotPageInventory()).toEqual([])
+  })
+})

--- a/src/main/browser/browser-client-page-reconciliation.ts
+++ b/src/main/browser/browser-client-page-reconciliation.ts
@@ -1,0 +1,257 @@
+import type {
+  BrowserClientHostedPageInventory,
+  BrowserClientHostCommandEvent
+} from '../../shared/browser-client-host-protocol'
+import {
+  assertBrowserClientPageCommandNotAborted,
+  assertCurrentBrowserClientPageRenderer,
+  browserClientPageIdentity
+} from './browser-client-page-command-admission'
+import { BrowserClientPageCommandError } from './browser-client-page-command-failure'
+import {
+  createBrowserClientPageInventory,
+  updateBrowserClientPageInventoryCurrentUrl
+} from './browser-client-page-inventory'
+import type {
+  BrowserClientPageLifecycleRegistry,
+  BrowserClientRetainedPage
+} from './browser-client-page-retained-state'
+import type { BrowserClientPageRendererIdentity } from './browser-client-page-cleanup'
+
+type BrowserClientPageReconciliationContext = {
+  pages: Map<string, BrowserClientRetainedPage>
+  failedPages: Map<string, BrowserClientHostedPageInventory>
+  routeWebContents: BrowserClientPageLifecycleRegistry
+  assertAvailable: () => void
+  createPage: (event: BrowserClientHostCommandEvent, signal: AbortSignal) => Promise<void>
+  navigate: (event: BrowserClientHostCommandEvent, signal: AbortSignal) => Promise<void>
+  retirePage: (browserPageId: string, pageHostGeneration: number) => Promise<boolean>
+  cleanupPage: (
+    page: BrowserClientRetainedPage,
+    previousRendererPage?: BrowserClientPageRendererIdentity
+  ) => Promise<void>
+}
+
+export function executeBrowserClientPageReconciliationCommand(
+  context: BrowserClientPageReconciliationContext,
+  event: BrowserClientHostCommandEvent,
+  signal: AbortSignal
+): Promise<void> {
+  switch (event.command.type) {
+    case 'reclaimPage':
+      return reclaimPage(context, event, signal)
+    case 'closePage':
+      return closeReconciledPage(context, event, signal)
+    case 'restorePage':
+      return restorePage(context, event, signal)
+    case 'createPage':
+    case 'navigate':
+      throw new BrowserClientPageCommandError('browser_client_page_command_invalid')
+  }
+}
+
+async function reclaimPage(
+  context: BrowserClientPageReconciliationContext,
+  event: BrowserClientHostCommandEvent,
+  signal: AbortSignal
+): Promise<void> {
+  if (event.command.type !== 'reclaimPage') {
+    throw new BrowserClientPageCommandError('browser_client_page_command_invalid')
+  }
+  const page = context.pages.get(event.browserPageId)
+  if (
+    !page ||
+    page.retiring ||
+    page.reconciling ||
+    !sameBrowserClientPageAuthority(page.inventory, event.command.previousAuthority) ||
+    page.inventory.browserProfileId !== event.command.browserProfileId ||
+    page.inventory.executionHostKey !== event.command.executionHostKey
+  ) {
+    throw new BrowserClientPageCommandError('browser_client_page_reconciliation_authority_stale')
+  }
+  assertBrowserClientPageCommandNotAborted(signal)
+  assertCurrentBrowserClientPageRenderer(page.renderer)
+  context.assertAvailable()
+  page.reconciling = true
+  if (!context.routeWebContents.revokeNavigation(page.lifecycleClaim)) {
+    page.reconciling = false
+    throw new BrowserClientPageCommandError('browser_client_page_reconciliation_authority_stale')
+  }
+  const previousRendererPage = browserClientPageIdentity(
+    page.registration,
+    page.registration.partition
+  )
+  const nextRegistration = { ...page.registration, pageHostGeneration: event.pageHostGeneration }
+  const nextRendererPage = browserClientPageIdentity(nextRegistration, nextRegistration.partition)
+  const rekeyGuestLifecycle = context.routeWebContents.rekeyGuestLifecycle
+  const grantReconciledNavigation = context.routeWebContents.grantReconciledNavigation
+  const rekeyRendererPage = page.renderer.rekeyPage
+  if (!rekeyGuestLifecycle || !grantReconciledNavigation || !rekeyRendererPage) {
+    page.reconciling = false
+    if (
+      !grantReconciledNavigation ||
+      !grantReconciledNavigation.call(context.routeWebContents, page.lifecycleClaim)
+    ) {
+      await failClosedRekeyedPage(
+        context,
+        page,
+        new BrowserClientPageCommandError('browser_client_page_reconciliation_unsupported')
+      )
+    }
+    throw new BrowserClientPageCommandError('browser_client_page_reconciliation_unsupported')
+  }
+  const rekeyed = rekeyGuestLifecycle.call(
+    context.routeWebContents,
+    page.lifecycleClaim,
+    nextRegistration
+  )
+  if (!rekeyed) {
+    page.reconciling = false
+    if (!grantReconciledNavigation.call(context.routeWebContents, page.lifecycleClaim)) {
+      await failClosedRekeyedPage(
+        context,
+        page,
+        new BrowserClientPageCommandError('browser_client_page_reconciliation_authority_stale')
+      )
+    }
+    throw new BrowserClientPageCommandError('browser_client_page_reconciliation_authority_stale')
+  }
+  page.generation = event.pageHostGeneration
+  page.registration = nextRegistration
+  page.lifecycleClaim = rekeyed.lifecycleClaim
+  page.routeSession = rekeyed.routeSession
+  page.inventory = createReconciliationInventory(event, 'outcomeUnknown', page.inventory.currentUrl)
+  try {
+    await rekeyRendererPage.call(page.renderer, previousRendererPage, nextRendererPage, signal)
+    assertBrowserClientPageCommandNotAborted(signal)
+    context.assertAvailable()
+    assertCurrentBrowserClientPageRenderer(page.renderer)
+    if (!grantReconciledNavigation.call(context.routeWebContents, rekeyed.lifecycleClaim)) {
+      throw new BrowserClientPageCommandError('browser_client_page_reconciliation_authority_stale')
+    }
+    page.inventory = createReconciliationInventory(event, 'active', page.inventory.currentUrl)
+    page.reconciling = false
+  } catch (error) {
+    await failClosedRekeyedPage(context, page, error, previousRendererPage)
+  }
+}
+
+async function closeReconciledPage(
+  context: BrowserClientPageReconciliationContext,
+  event: BrowserClientHostCommandEvent,
+  signal: AbortSignal
+): Promise<void> {
+  if (event.command.type !== 'closePage') {
+    throw new BrowserClientPageCommandError('browser_client_page_command_invalid')
+  }
+  const page = context.pages.get(event.browserPageId)
+  if (
+    !page ||
+    page.retiring ||
+    page.reconciling ||
+    event.pageHostGeneration !== event.command.targetAuthority.pageHostGeneration ||
+    !sameBrowserClientPageAuthority(page.inventory, event.command.targetAuthority)
+  ) {
+    throw new BrowserClientPageCommandError('browser_client_page_reconciliation_authority_stale')
+  }
+  assertBrowserClientPageCommandNotAborted(signal)
+  if (!(await context.retirePage(event.browserPageId, page.generation))) {
+    throw new BrowserClientPageCommandError('browser_client_page_reconciliation_authority_stale')
+  }
+}
+
+async function restorePage(
+  context: BrowserClientPageReconciliationContext,
+  event: BrowserClientHostCommandEvent,
+  signal: AbortSignal
+): Promise<void> {
+  if (event.command.type !== 'restorePage') {
+    throw new BrowserClientPageCommandError('browser_client_page_command_invalid')
+  }
+  await context.createPage(reconciliationCreateEvent(event), signal)
+  if (!event.command.url) {
+    return
+  }
+  try {
+    await context.navigate(
+      { ...event, command: { type: 'navigate', url: event.command.url } },
+      signal
+    )
+  } catch (error) {
+    try {
+      await context.retirePage(event.browserPageId, event.pageHostGeneration)
+    } catch (cleanupError) {
+      throw new BrowserClientPageCommandError('browser_client_page_cleanup_failed', {
+        cause: new AggregateError([error, cleanupError], 'Browser page restore failed')
+      })
+    }
+    throw error
+  }
+}
+
+async function failClosedRekeyedPage(
+  context: BrowserClientPageReconciliationContext,
+  page: BrowserClientRetainedPage,
+  error: unknown,
+  previousRendererPage?: BrowserClientPageRendererIdentity
+): Promise<never> {
+  page.reconciling = false
+  page.retiring ??= context.cleanupPage(page, previousRendererPage)
+  try {
+    await page.retiring
+    if (context.pages.get(page.inventory.browserPageId) === page) {
+      context.pages.delete(page.inventory.browserPageId)
+    }
+  } catch (cleanupError) {
+    context.pages.delete(page.inventory.browserPageId)
+    context.failedPages.set(page.inventory.browserPageId, page.inventory)
+    throw new BrowserClientPageCommandError('browser_client_page_cleanup_failed', {
+      cause: new AggregateError([error, cleanupError], 'Browser page reclaim failed')
+    })
+  }
+  throw error
+}
+
+function sameBrowserClientPageAuthority(
+  inventory: BrowserClientHostedPageInventory,
+  authority: {
+    authorityRuntimeId: string
+    authorityEpoch: string
+    browserHostClientId: string
+    browserHostGeneration: number
+    pageHostGeneration: number
+  }
+): boolean {
+  return (
+    inventory.authorityRuntimeId === authority.authorityRuntimeId &&
+    inventory.authorityEpoch === authority.authorityEpoch &&
+    inventory.browserHostClientId === authority.browserHostClientId &&
+    inventory.browserHostGeneration === authority.browserHostGeneration &&
+    inventory.pageHostGeneration === authority.pageHostGeneration
+  )
+}
+
+function reconciliationCreateEvent(
+  event: BrowserClientHostCommandEvent
+): BrowserClientHostCommandEvent {
+  if (event.command.type !== 'reclaimPage' && event.command.type !== 'restorePage') {
+    throw new BrowserClientPageCommandError('browser_client_page_command_invalid')
+  }
+  return {
+    ...event,
+    command: {
+      type: 'createPage',
+      browserProfileId: event.command.browserProfileId,
+      executionHostKey: event.command.executionHostKey
+    }
+  }
+}
+
+function createReconciliationInventory(
+  event: BrowserClientHostCommandEvent,
+  state: BrowserClientHostedPageInventory['state'],
+  currentUrl?: string
+): BrowserClientHostedPageInventory {
+  const inventory = createBrowserClientPageInventory(reconciliationCreateEvent(event), state)
+  return currentUrl ? updateBrowserClientPageInventoryCurrentUrl(inventory, currentUrl) : inventory
+}

--- a/src/main/browser/browser-client-page-renderer-bridge.test.ts
+++ b/src/main/browser/browser-client-page-renderer-bridge.test.ts
@@ -9,6 +9,50 @@ import {
 } from './browser-client-page-renderer-bridge-test-rig'
 
 describe('BrowserClientPageRendererBridgeRegistry', () => {
+  it('rekeys only after an exact current-document echo', async () => {
+    const harness = createHarness()
+    const renderer = harness.registry.attachRenderer(harness.endpoint)
+    const next = { ...page, pageHostGeneration: 8 }
+    const rekeyed = renderer.rekeyPage!(page, next, new AbortController().signal)
+    const request = sentRequest(harness.endpoint)
+
+    expect(request).toMatchObject({ type: 'rekeyPage', page, nextPage: next })
+    harness.reply(harness.endpoint, {
+      type: 'rekeyed',
+      requestId: request.requestId,
+      page: request.page,
+      nextPage: next
+    })
+    await expect(rekeyed).resolves.toBeUndefined()
+  })
+
+  it('accepts exact rekey failure and rejects a changed next-page echo', async () => {
+    const harness = createHarness()
+    const renderer = harness.registry.attachRenderer(harness.endpoint)
+    const next = { ...page, pageHostGeneration: 8 }
+    const failed = renderer.rekeyPage!(page, next, new AbortController().signal)
+    let request = sentRequest(harness.endpoint)
+
+    harness.reply(harness.endpoint, {
+      type: 'failed',
+      operation: 'rekeyPage',
+      requestId: request.requestId,
+      page: request.page,
+      errorCode: 'browser_client_page_renderer_rekey_stale'
+    })
+    await expect(failed).rejects.toThrow('browser_client_page_renderer_rekey_stale')
+
+    const mismatched = renderer.rekeyPage!(page, next, new AbortController().signal)
+    request = sentRequest(harness.endpoint)
+    harness.reply(harness.endpoint, {
+      type: 'rekeyed',
+      requestId: request.requestId,
+      page: request.page,
+      nextPage: { ...next, pageHostGeneration: 9 }
+    })
+    await expect(mismatched).rejects.toThrow('browser_client_page_renderer_reply_invalid')
+  })
+
   it('mounts only through the exact current main-frame document and carries no target URL', async () => {
     const harness = createHarness()
     const renderer = harness.registry.attachRenderer(harness.endpoint)
@@ -184,6 +228,42 @@ describe('BrowserClientPageRendererBridgeRegistry', () => {
       const replacement = renderer.mountPage(page, new AbortController().signal)
       completeMount(harness)
       await expect(replacement).resolves.toEqual({ webContentsId: 91 })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('ignores a late rekey reply after timeout and admits an exact replacement', async () => {
+    vi.useFakeTimers()
+    try {
+      const harness = createHarness({ maxPending: 1, timeoutMs: 25 })
+      const renderer = harness.registry.attachRenderer(harness.endpoint)
+      const next = { ...page, pageHostGeneration: 8 }
+      const timedOut = renderer.rekeyPage!(page, next, new AbortController().signal)
+      const staleRequest = sentRequest(harness.endpoint)
+      const timedOutExpectation = expect(timedOut).rejects.toThrow(
+        'browser_client_page_renderer_request_timeout'
+      )
+
+      await vi.advanceTimersByTimeAsync(25)
+      await timedOutExpectation
+      harness.reply(harness.endpoint, {
+        type: 'rekeyed',
+        requestId: staleRequest.requestId,
+        page: staleRequest.page,
+        nextPage: next
+      })
+
+      const replacement = renderer.rekeyPage!(page, next, new AbortController().signal)
+      const currentRequest = sentRequest(harness.endpoint)
+      expect(currentRequest.requestId).not.toBe(staleRequest.requestId)
+      harness.reply(harness.endpoint, {
+        type: 'rekeyed',
+        requestId: currentRequest.requestId,
+        page: currentRequest.page,
+        nextPage: next
+      })
+      await expect(replacement).resolves.toBeUndefined()
     } finally {
       vi.useRealTimers()
     }

--- a/src/main/browser/browser-client-page-renderer-bridge.ts
+++ b/src/main/browser/browser-client-page-renderer-bridge.ts
@@ -49,6 +49,12 @@ type PendingRequest = {
   reject: (error: Error) => void
 }
 
+type RendererRequestInput = RendererRequest extends infer Request
+  ? Request extends { requestId: string }
+    ? Omit<Request, 'requestId'>
+    : never
+  : never
+
 export class BrowserClientPageRendererBridgeRegistry {
   private readonly maxPending: number
   private readonly timeoutMs: number
@@ -95,6 +101,11 @@ export class BrowserClientPageRendererBridgeRegistry {
       isCurrent: () => this.isCurrent(state),
       mountPage: (page: RendererPageIdentity, signal: AbortSignal) =>
         this.mountPage(state, page, signal),
+      rekeyPage: (
+        previous: RendererPageIdentity,
+        next: RendererPageIdentity,
+        signal: AbortSignal
+      ) => this.rekeyPage(state, previous, next, signal),
       retirePage: (page: RendererPageIdentity) => this.retirePage(state, page)
     })
     state.bridge = bridge
@@ -159,9 +170,25 @@ export class BrowserClientPageRendererBridgeRegistry {
     }
   }
 
+  private async rekeyPage(
+    state: RendererState,
+    previousCandidate: RendererPageIdentity,
+    nextCandidate: RendererPageIdentity,
+    signal: AbortSignal
+  ): Promise<void> {
+    const page = BrowserClientPageRendererIdentity.parse(previousCandidate)
+    const nextPage = BrowserClientPageRendererIdentity.parse(nextCandidate)
+    const reply = await this.request(state, { type: 'rekeyPage', page, nextPage }, signal)
+    if (reply.type !== 'rekeyed') {
+      throw new Error(
+        reply.type === 'failed' ? reply.errorCode : 'browser_client_page_rekey_failed'
+      )
+    }
+  }
+
   private request(
     state: RendererState,
-    input: Omit<RendererRequest, 'requestId'>,
+    input: RendererRequestInput,
     signal: AbortSignal | null
   ): Promise<RendererReply> {
     if (!this.isCurrent(state)) {

--- a/src/main/browser/browser-client-page-renderer-reply-admission.ts
+++ b/src/main/browser/browser-client-page-renderer-reply-admission.ts
@@ -45,12 +45,19 @@ export function rendererReplyMatchesRequest(
   reply: RendererReply,
   request: RendererRequest
 ): boolean {
-  const expectedType = request.type === 'mountPage' ? 'mounted' : 'retired'
+  const expectedType =
+    request.type === 'mountPage' ? 'mounted' : request.type === 'retirePage' ? 'retired' : 'rekeyed'
   return Boolean(
     (reply.type === expectedType ||
       (reply.type === 'failed' && reply.operation === request.type)) &&
     reply.page.partition === request.page.partition &&
     reply.page.browserPageId === request.page.browserPageId &&
-    reply.page.pageHostGeneration === request.page.pageHostGeneration
+    reply.page.pageHostGeneration === request.page.pageHostGeneration &&
+    (request.type !== 'rekeyPage' ||
+      reply.type === 'failed' ||
+      (reply.type === 'rekeyed' &&
+        reply.nextPage.partition === request.nextPage.partition &&
+        reply.nextPage.browserPageId === request.nextPage.browserPageId &&
+        reply.nextPage.pageHostGeneration === request.nextPage.pageHostGeneration))
   )
 }

--- a/src/main/browser/browser-client-page-retained-state.ts
+++ b/src/main/browser/browser-client-page-retained-state.ts
@@ -18,7 +18,9 @@ export type BrowserClientPageLifecycleRegistry = Pick<
   | 'revokeNavigation'
   | 'navigateGuest'
   | 'beginGuestRetirement'
->
+> &
+  Partial<Pick<BrowserRouteWebContentsRegistry, 'rekeyGuestLifecycle'>> &
+  Partial<Pick<BrowserRouteWebContentsRegistry, 'grantReconciledNavigation'>>
 
 export type BrowserClientRetainedPage = {
   generation: number
@@ -29,4 +31,5 @@ export type BrowserClientRetainedPage = {
   route: BrowserClientPageNetworkRoute
   routeSession: BrowserRouteSessionHandle
   retiring: Promise<void> | null
+  reconciling: boolean
 }

--- a/src/main/browser/browser-route-prepared-page-ledger.ts
+++ b/src/main/browser/browser-route-prepared-page-ledger.ts
@@ -57,6 +57,31 @@ export class BrowserRoutePreparedPageLedger {
     return page
   }
 
+  rekey(
+    previous: BrowserRoutePageAuthority,
+    next: BrowserRoutePageOwnerIdentity
+  ): BrowserRoutePageAuthority | null {
+    if (
+      !this.isExactActivePage(previous) ||
+      !isValidBrowserRoutePageOwnerIdentity(next) ||
+      next.partition !== this.partition ||
+      next.browserPageId !== previous.browserPageId ||
+      next.rendererWebContentsId !== previous.rendererWebContentsId ||
+      next.pageHostGeneration === previous.pageHostGeneration
+    ) {
+      return null
+    }
+    const previousKey = pageKey(previous)
+    const nextKey = pageKey(next)
+    if (this.active.has(nextKey) || this.retiring.has(nextKey)) {
+      return null
+    }
+    const rekeyed = { ...next, pageAuthority: previous.pageAuthority }
+    this.active.delete(previousKey)
+    this.active.set(nextKey, rekeyed)
+    return rekeyed
+  }
+
   beginRetirement(page: BrowserRoutePageAuthority): boolean {
     if (!this.isExactActivePage(page)) {
       return false

--- a/src/main/browser/browser-route-prepared-page-rekey.test.ts
+++ b/src/main/browser/browser-route-prepared-page-rekey.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { BrowserRoutePreparedPageLedger } from './browser-route-prepared-page-ledger'
+
+const partition = 'persist:route-a'
+
+describe('BrowserRoutePreparedPageLedger rekey', () => {
+  it('moves one exact active authority without changing its capability token', () => {
+    const ledger = new BrowserRoutePreparedPageLedger(partition, 4)
+    const previous = ledger.link('page-a', 7, 11)
+    const nextOwner = {
+      partition,
+      browserPageId: 'page-a',
+      pageHostGeneration: 8,
+      rendererWebContentsId: 11
+    }
+
+    const next = ledger.rekey(previous, nextOwner)
+
+    expect(next).toMatchObject(nextOwner)
+    expect(next?.pageAuthority).toBe(previous.pageAuthority)
+    expect(ledger.getAuthority(previous)).toBeNull()
+    expect(ledger.getAuthority(nextOwner)).toBe(previous.pageAuthority)
+  })
+
+  it('rejects stale, cross-page, cross-renderer, and occupied targets without mutation', () => {
+    const ledger = new BrowserRoutePreparedPageLedger(partition, 4)
+    const previous = ledger.link('page-a', 7, 11)
+    ledger.link('page-a', 8, 11)
+
+    expect(
+      ledger.rekey(previous, {
+        partition,
+        browserPageId: 'page-a',
+        pageHostGeneration: 8,
+        rendererWebContentsId: 11
+      })
+    ).toBeNull()
+    expect(
+      ledger.rekey(previous, {
+        partition,
+        browserPageId: 'page-b',
+        pageHostGeneration: 9,
+        rendererWebContentsId: 11
+      })
+    ).toBeNull()
+    expect(
+      ledger.rekey(previous, {
+        partition,
+        browserPageId: 'page-a',
+        pageHostGeneration: 9,
+        rendererWebContentsId: 12
+      })
+    ).toBeNull()
+    expect(ledger.getAuthority(previous)).toBe(previous.pageAuthority)
+  })
+})

--- a/src/main/browser/browser-route-session-registry.test.ts
+++ b/src/main/browser/browser-route-session-registry.test.ts
@@ -121,6 +121,35 @@ function deferred(): { promise: Promise<void>; resolve: () => void } {
 }
 
 describe('BrowserRouteSessionRegistry', () => {
+  it('rekeys one prepared authority and makes the old release handle inert', async () => {
+    const { dependencies, registry } = createHarness()
+    const previousHandle = await prepare(registry)
+    const previousOwner = {
+      partition: previousHandle.partition,
+      browserPageId: 'page-a',
+      pageHostGeneration: 1,
+      rendererWebContentsId: 11
+    }
+    const pageAuthority = registry.getPreparedPageAuthority(previousOwner)
+    expect(pageAuthority).not.toBeNull()
+    const nextOwner = { ...previousOwner, pageHostGeneration: 2 }
+
+    const rekeyed = registry.rekeyPreparedPage(
+      { ...previousOwner, pageAuthority: pageAuthority! },
+      nextOwner
+    )
+
+    expect(rekeyed?.page).toMatchObject(nextOwner)
+    expect(rekeyed?.page.pageAuthority).toBe(pageAuthority)
+    expect(registry.getPreparedPageAuthority(previousOwner)).toBeNull()
+    expect(registry.getPreparedPageAuthority(nextOwner)).toBe(pageAuthority)
+    previousHandle.release()
+    expect(registry.getPreparedPageAuthority(nextOwner)).toBe(pageAuthority)
+    rekeyed?.routeSession.release()
+    expect(registry.getPreparedPageAuthority(nextOwner)).toBeNull()
+    expect(dependencies.clearPolicies).toHaveBeenCalledOnce()
+  })
+
   it('applies and verifies the exact fail-closed proxy before allowlisting', async () => {
     const { dependencies, order, registry, session } = createHarness()
 

--- a/src/main/browser/browser-route-session-registry.ts
+++ b/src/main/browser/browser-route-session-registry.ts
@@ -3,10 +3,9 @@ import {
   type BrowserRoutePartitionIdentity,
   type DerivedBrowserRoutePartition
 } from './browser-route-identity'
-import {
-  isValidBrowserRoutePageOwnerIdentity,
-  type BrowserRoutePageAuthority,
-  type BrowserRoutePageOwnerIdentity
+import type {
+  BrowserRoutePageAuthority,
+  BrowserRoutePageOwnerIdentity
 } from './browser-route-page-authority'
 import {
   assertBrowserRoutePreparedPageOwner,
@@ -24,8 +23,15 @@ import {
   type BrowserRouteProxyEndpoint as ProxyEndpoint
 } from './browser-route-session-policy'
 import type { BrowserRouteSessionRegistryDependencies } from './browser-route-session-registry-contract'
+import {
+  getBrowserRoutePreparedPageAuthority,
+  rekeyBrowserRouteSessionPage
+} from './browser-route-session-rekey'
+import { retireBrowserRouteSessionRendererPages } from './browser-route-session-renderer-retirement'
+import { retireBrowserRouteSessionPage } from './browser-route-session-retirement'
 import type {
   BrowserRouteSessionHandle,
+  BrowserRouteSessionRekey,
   PendingBrowserRoutePartition as PendingPartition,
   PreparedBrowserRoutePartition as PreparedPartition
 } from './browser-route-session-state'
@@ -64,40 +70,34 @@ export class BrowserRouteSessionRegistry {
   }
 
   getPreparedPageAuthority(input: BrowserRoutePageOwnerIdentity): symbol | null {
-    const state = this.live.get(input.partition)
-    if (!state || !isValidBrowserRoutePageOwnerIdentity(input)) {
-      return null
-    }
-    return state.pages.getAuthority(input)
+    return getBrowserRoutePreparedPageAuthority(this.live, input)
+  }
+
+  rekeyPreparedPage(
+    previous: BrowserRoutePageAuthority,
+    next: BrowserRoutePageOwnerIdentity
+  ): BrowserRouteSessionRekey | null {
+    return rekeyBrowserRouteSessionPage(
+      this.live,
+      previous,
+      next,
+      this.retirePreparedPage.bind(this)
+    )
   }
 
   retirePreparedPage(input: BrowserRoutePageAuthority): boolean {
-    const state = this.live.get(input.partition)
-    if (!state || !state.pages.beginRetirement(input)) {
-      return false
-    }
-    this.settlePageRetirement(state, input)
-    return true
+    return retireBrowserRouteSessionPage(this.live, input, (state, page) =>
+      this.settlePageRetirement(state, page)
+    )
   }
 
   retirePreparedPagesOwnedByRenderer(rendererWebContentsId: number): number {
-    if (!Number.isInteger(rendererWebContentsId) || rendererWebContentsId <= 0) {
-      return 0
-    }
-    this.rendererPrepareFences.retire(rendererWebContentsId)
-    const retirements: { state: PreparedPartition; pages: BrowserRoutePageAuthority[] }[] = []
-    for (const state of Array.from(this.live.values())) {
-      const pages = state.pages.beginRendererRetirements(rendererWebContentsId)
-      retirements.push({ state, pages })
-    }
-    let retiredCount = 0
-    for (const { state, pages } of retirements) {
-      retiredCount += pages.length
-      for (const page of pages) {
-        this.settlePageRetirement(state, page)
-      }
-    }
-    return retiredCount
+    return retireBrowserRouteSessionRendererPages({
+      rendererWebContentsId,
+      rendererPrepareFences: this.rendererPrepareFences,
+      live: this.live,
+      settle: (state, page) => this.settlePageRetirement(state, page)
+    })
   }
 
   async preparePage(input: {

--- a/src/main/browser/browser-route-session-rekey.ts
+++ b/src/main/browser/browser-route-session-rekey.ts
@@ -1,0 +1,38 @@
+import type {
+  BrowserRoutePageAuthority,
+  BrowserRoutePageOwnerIdentity
+} from './browser-route-page-authority'
+import type {
+  BrowserRouteSessionRekey,
+  PreparedBrowserRoutePartition
+} from './browser-route-session-state'
+
+export function getBrowserRoutePreparedPageAuthority(
+  live: ReadonlyMap<string, PreparedBrowserRoutePartition>,
+  input: BrowserRoutePageOwnerIdentity
+): symbol | null {
+  return live.get(input.partition)?.pages.getAuthority(input) ?? null
+}
+
+export function rekeyBrowserRouteSessionPage(
+  live: ReadonlyMap<string, PreparedBrowserRoutePartition>,
+  previous: BrowserRoutePageAuthority,
+  next: BrowserRoutePageOwnerIdentity,
+  retirePreparedPage: (page: BrowserRoutePageAuthority) => boolean
+): BrowserRouteSessionRekey | null {
+  const state = live.get(previous.partition)
+  if (!state || next.partition !== previous.partition) {
+    return null
+  }
+  const page = state.pages.rekey(previous, next)
+  if (!page) {
+    return null
+  }
+  return {
+    page,
+    routeSession: {
+      partition: state.partition,
+      release: () => void retirePreparedPage(page)
+    }
+  }
+}

--- a/src/main/browser/browser-route-session-renderer-retirement.ts
+++ b/src/main/browser/browser-route-session-renderer-retirement.ts
@@ -1,0 +1,27 @@
+import type { BrowserRoutePageAuthority } from './browser-route-page-authority'
+import type { BrowserRouteRendererPrepareFenceRegistry } from './browser-route-renderer-prepare-fence'
+import type { PreparedBrowserRoutePartition } from './browser-route-session-state'
+
+export function retireBrowserRouteSessionRendererPages(input: {
+  rendererWebContentsId: number
+  rendererPrepareFences: BrowserRouteRendererPrepareFenceRegistry
+  live: ReadonlyMap<string, PreparedBrowserRoutePartition>
+  settle: (state: PreparedBrowserRoutePartition, page: BrowserRoutePageAuthority) => void
+}): number {
+  if (!Number.isInteger(input.rendererWebContentsId) || input.rendererWebContentsId <= 0) {
+    return 0
+  }
+  input.rendererPrepareFences.retire(input.rendererWebContentsId)
+  const retirements = [...input.live.values()].map((state) => ({
+    state,
+    pages: state.pages.beginRendererRetirements(input.rendererWebContentsId)
+  }))
+  let retiredCount = 0
+  for (const { state, pages } of retirements) {
+    retiredCount += pages.length
+    for (const page of pages) {
+      input.settle(state, page)
+    }
+  }
+  return retiredCount
+}

--- a/src/main/browser/browser-route-session-retirement.ts
+++ b/src/main/browser/browser-route-session-retirement.ts
@@ -1,0 +1,15 @@
+import type { BrowserRoutePageAuthority } from './browser-route-page-authority'
+import type { PreparedBrowserRoutePartition } from './browser-route-session-state'
+
+export function retireBrowserRouteSessionPage(
+  live: ReadonlyMap<string, PreparedBrowserRoutePartition>,
+  input: BrowserRoutePageAuthority,
+  settle: (state: PreparedBrowserRoutePartition, page: BrowserRoutePageAuthority) => void
+): boolean {
+  const state = live.get(input.partition)
+  if (!state || !state.pages.beginRetirement(input)) {
+    return false
+  }
+  settle(state, input)
+  return true
+}

--- a/src/main/browser/browser-route-session-runtime.ts
+++ b/src/main/browser/browser-route-session-runtime.ts
@@ -41,6 +41,8 @@ export const browserRouteWebContentsRegistry = new BrowserRouteWebContentsRegist
   getPartitionForSession: (routeSession) =>
     browserRouteSessionRegistry.getPartitionForSession(routeSession),
   getPreparedPageAuthority: (page) => browserRouteSessionRegistry.getPreparedPageAuthority(page),
+  rekeyPreparedPage: (previous, next) =>
+    browserRouteSessionRegistry.rekeyPreparedPage(previous, next),
   retirePreparedPage: (page) => browserRouteSessionRegistry.retirePreparedPage(page),
   retirePreparedPagesOwnedByRenderer: (rendererWebContentsId) =>
     browserRouteSessionRegistry.retirePreparedPagesOwnedByRenderer(rendererWebContentsId)

--- a/src/main/browser/browser-route-session-state.ts
+++ b/src/main/browser/browser-route-session-state.ts
@@ -1,4 +1,5 @@
 import type { BrowserRoutePreparedPageLedger } from './browser-route-prepared-page-ledger'
+import type { BrowserRoutePageAuthority } from './browser-route-page-authority'
 import type {
   BrowserRouteElectronSession,
   BrowserRouteProxyEndpoint
@@ -7,6 +8,11 @@ import type {
 export type BrowserRouteSessionHandle = Readonly<{
   partition: string
   release: () => void
+}>
+
+export type BrowserRouteSessionRekey = Readonly<{
+  page: BrowserRoutePageAuthority
+  routeSession: BrowserRouteSessionHandle
 }>
 
 export type PreparedBrowserRoutePartition = {

--- a/src/main/browser/browser-route-webcontents-registration.ts
+++ b/src/main/browser/browser-route-webcontents-registration.ts
@@ -1,0 +1,49 @@
+import {
+  browserRoutePageKey,
+  type BrowserRoutePageGuestIdentity as GuestIdentity,
+  type BrowserRoutePageOwnerIdentity
+} from './browser-route-page-authority'
+import { isBlankRouteGuest, isValidRoutePageRegistration } from './browser-route-guest-guard'
+import type { BrowserRouteGuestState as GuestState } from './browser-route-webcontents-state'
+
+export function registerBrowserRouteGuest(input: {
+  registration: GuestIdentity
+  state: GuestState | undefined
+  guestsByPage: Map<string, GuestState>
+  getPreparedPageAuthority: (page: BrowserRoutePageOwnerIdentity) => symbol | null
+  registrationMatchesGuest: (state: GuestState, registration: GuestIdentity) => boolean
+  hasLivePageAuthority: (state: GuestState) => boolean
+}): boolean {
+  const { registration, state } = input
+  if (
+    !isValidRoutePageRegistration(registration) ||
+    !state ||
+    state.retirementRequested ||
+    !isBlankRouteGuest(state.guest) ||
+    !input.registrationMatchesGuest(state, registration)
+  ) {
+    return false
+  }
+  const pageAuthority = input.getPreparedPageAuthority(registration)
+  if (pageAuthority === null) {
+    return false
+  }
+  const pageKey = browserRoutePageKey(registration)
+  const existingPage = input.guestsByPage.get(pageKey)
+  if (existingPage && existingPage !== state && input.hasLivePageAuthority(existingPage)) {
+    return false
+  }
+  if (state.registration) {
+    return (
+      browserRoutePageKey(state.registration) === pageKey && state.pageAuthority === pageAuthority
+    )
+  }
+  if (existingPage && existingPage !== state) {
+    existingPage.registration = null
+    existingPage.pageAuthority = null
+  }
+  state.registration = { ...registration }
+  state.pageAuthority = pageAuthority
+  input.guestsByPage.set(pageKey, state)
+  return true
+}

--- a/src/main/browser/browser-route-webcontents-registry.test.ts
+++ b/src/main/browser/browser-route-webcontents-registry.test.ts
@@ -15,7 +15,25 @@ function createHarness(options: { maxGuests?: number } = {}) {
   const routeSession = { marker: 'route-session' } as unknown as Session
   let prepared = true
   let pageAuthority = Symbol('page-authority')
+  let pageHostGeneration = page.pageHostGeneration
   const retirePreparedPagesOwnedByRenderer = vi.fn(() => 0)
+  const rekeyPreparedPage = vi.fn((previous, next) => {
+    if (
+      !prepared ||
+      previous.pageAuthority !== pageAuthority ||
+      previous.pageHostGeneration !== pageHostGeneration ||
+      next.partition !== partition ||
+      next.browserPageId !== page.browserPageId ||
+      next.rendererWebContentsId !== page.rendererWebContentsId
+    ) {
+      return null
+    }
+    pageHostGeneration = next.pageHostGeneration
+    return {
+      page: { ...next, pageAuthority },
+      routeSession: { partition, release: vi.fn() }
+    }
+  })
   let registry: BrowserRouteWebContentsRegistry
   registry = new BrowserRouteWebContentsRegistry({
     getPartitionForSession: (session) => (session === routeSession ? partition : null),
@@ -23,7 +41,7 @@ function createHarness(options: { maxGuests?: number } = {}) {
       prepared &&
       input.partition === partition &&
       input.browserPageId === page.browserPageId &&
-      input.pageHostGeneration === page.pageHostGeneration &&
+      input.pageHostGeneration === pageHostGeneration &&
       input.rendererWebContentsId === page.rendererWebContentsId
         ? pageAuthority
         : null,
@@ -35,12 +53,14 @@ function createHarness(options: { maxGuests?: number } = {}) {
       registry.retirePageAuthority({ ...input, onRetired: vi.fn() })
       return true
     },
+    rekeyPreparedPage,
     retirePreparedPagesOwnedByRenderer,
     maxGuests: options.maxGuests
   })
   return {
     getPageAuthority: () => pageAuthority,
     registry,
+    rekeyPreparedPage,
     retirePreparedPagesOwnedByRenderer,
     routeSession,
     setPrepared: (value: boolean) => {
@@ -128,6 +148,34 @@ function requireLifecycleClaim(registry: BrowserRouteWebContentsRegistry, regist
 }
 
 describe('BrowserRouteWebContentsRegistry', () => {
+  it('atomically rekeys the prepared page, guest index, lifecycle claim, and navigation grant', async () => {
+    const { registry, rekeyPreparedPage, routeSession } = createHarness()
+    const guest = createGuest({ session: routeSession })
+    expect(registry.attachGuest(guest.guest)).toBe(true)
+    expect(registry.registerGuest(page)).toBe(true)
+    const previousClaim = requireLifecycleClaim(registry)
+    expect(registry.grantNavigation(page)).toBe(true)
+    await expect(
+      registry.navigateGuest(previousClaim, 'https://before-rekey.internal/')
+    ).resolves.toBe(true)
+    expect(registry.revokeNavigation(previousClaim)).toBe(true)
+    const next = { ...page, pageHostGeneration: 8 }
+
+    const rekeyed = registry.rekeyGuestLifecycle(previousClaim, next)
+
+    expect(rekeyed?.lifecycleClaim.registration).toEqual(next)
+    expect(rekeyPreparedPage).toHaveBeenCalledOnce()
+    expect(previousClaim.isCurrent()).toBe(false)
+    expect(rekeyed?.lifecycleClaim.isCurrent()).toBe(true)
+    expect(registry.grantReconciledNavigation(rekeyed!.lifecycleClaim)).toBe(true)
+    await expect(registry.navigateGuest(previousClaim, 'https://stale.invalid/')).resolves.toBe(
+      false
+    )
+    await expect(
+      registry.navigateGuest(rekeyed!.lifecycleClaim, 'https://remote.internal/')
+    ).resolves.toBe(true)
+  })
+
   it('holds navigation and popups until exact registration and an explicit grant', () => {
     const { registry, routeSession } = createHarness()
     const guest = createGuest({ session: routeSession })

--- a/src/main/browser/browser-route-webcontents-registry.ts
+++ b/src/main/browser/browser-route-webcontents-registry.ts
@@ -13,7 +13,6 @@ import {
   isRouteGuestDestroyed,
   isRouteGuestOwnedByRenderer,
   isValidBlankRouteGuest,
-  isValidRoutePageRegistration,
   isValidRoutePageRetirement
 } from './browser-route-guest-guard'
 import { claimBrowserRouteGuestLifecycle } from './browser-route-guest-lifecycle-claim'
@@ -30,10 +29,21 @@ import {
   navigateBrowserRouteGuest
 } from './browser-route-guest-lifecycle'
 import type { BrowserRouteGuestState as GuestState } from './browser-route-webcontents-state'
+import type { BrowserRouteSessionRekey } from './browser-route-session-state'
+import {
+  grantReconciledBrowserRouteGuestNavigation,
+  rekeyBrowserRouteGuest,
+  type BrowserRouteGuestLifecycleRekey
+} from './browser-route-webcontents-rekey'
+import { registerBrowserRouteGuest } from './browser-route-webcontents-registration'
 
 type BrowserRouteWebContentsRegistryDependencies = {
   getPartitionForSession(session: Session): string | null
   getPreparedPageAuthority(input: BrowserRoutePageOwnerIdentity): symbol | null
+  rekeyPreparedPage?(
+    previous: BrowserRoutePageAuthority,
+    next: BrowserRoutePageOwnerIdentity
+  ): BrowserRouteSessionRekey | null
   retirePreparedPage(input: BrowserRoutePageAuthority): boolean
   retirePreparedPagesOwnedByRenderer(rendererWebContentsId: number): number
   maxGuests?: number
@@ -89,47 +99,43 @@ export class BrowserRouteWebContentsRegistry {
   }
 
   registerGuest(registration: GuestIdentity): boolean {
-    if (!isValidRoutePageRegistration(registration)) {
-      return false
-    }
-    const state = this.guests.get(registration.webContentsId)
-    if (
-      !state ||
-      state.retirementRequested ||
-      !isBlankRouteGuest(state.guest) ||
-      !this.registrationMatchesGuest(state, registration)
-    ) {
-      return false
-    }
-    const pageAuthority = this.dependencies.getPreparedPageAuthority(registration)
-    if (pageAuthority === null) {
-      return false
-    }
-    const pageKey = browserRoutePageKey(registration)
-    const existingPage = this.guestsByPage.get(pageKey)
-    if (existingPage && existingPage !== state && this.hasLivePageAuthority(existingPage)) {
-      return false
-    }
-    if (state.registration) {
-      return (
-        browserRoutePageKey(state.registration) === pageKey && state.pageAuthority === pageAuthority
-      )
-    }
-    if (existingPage && existingPage !== state) {
-      existingPage.registration = null
-      existingPage.pageAuthority = null
-    }
-    state.registration = { ...registration }
-    state.pageAuthority = pageAuthority
-    this.guestsByPage.set(pageKey, state)
-    return true
+    return registerBrowserRouteGuest({
+      registration,
+      state: this.guests.get(registration.webContentsId),
+      guestsByPage: this.guestsByPage,
+      getPreparedPageAuthority: (page) => this.dependencies.getPreparedPageAuthority(page),
+      registrationMatchesGuest: (state, page) => this.registrationMatchesGuest(state, page),
+      hasLivePageAuthority: (state) => this.hasLivePageAuthority(state)
+    })
   }
 
   claimGuestLifecycle(registration: GuestIdentity): BrowserRouteGuestLifecycleClaim | null {
     const state = this.guests.get(registration.webContentsId)
     return claimBrowserRouteGuestLifecycle(registration, state, () =>
-      Boolean(state && this.registrationMatchesGuest(state, registration))
+      Boolean(
+        state &&
+        (!state.registration ||
+          (browserRoutePageKey(state.registration) === browserRoutePageKey(registration) &&
+            this.hasLivePageAuthority(state))) &&
+        this.registrationMatchesGuest(state, registration)
+      )
     )
+  }
+
+  rekeyGuestLifecycle(
+    claim: BrowserRouteGuestLifecycleClaim,
+    next: GuestIdentity
+  ): BrowserRouteGuestLifecycleRekey | null {
+    return rekeyBrowserRouteGuest({
+      claim,
+      next,
+      state: this.guests.get(claim.registration.webContentsId),
+      guestsByPage: this.guestsByPage,
+      dependencies: this.dependencies,
+      registrationMatchesGuest: (state, registration) =>
+        this.registrationMatchesGuest(state, registration),
+      claimGuestLifecycle: (registration) => this.claimGuestLifecycle(registration)
+    })
   }
 
   grantNavigation(registration: GuestIdentity): boolean {
@@ -144,6 +150,16 @@ export class BrowserRouteWebContentsRegistry {
           this.registrationMatchesGuest(state, registration)
         ),
       hasLivePageAuthority: () => Boolean(state && this.hasLivePageAuthority(state))
+    })
+  }
+
+  grantReconciledNavigation(claim: BrowserRouteGuestLifecycleClaim): boolean {
+    return grantReconciledBrowserRouteGuestNavigation({
+      claim,
+      state: this.guests.get(claim.registration.webContentsId),
+      registrationMatchesGuest: (state, registration) =>
+        this.registrationMatchesGuest(state, registration),
+      hasLivePageAuthority: (state) => this.hasLivePageAuthority(state)
     })
   }
 

--- a/src/main/browser/browser-route-webcontents-rekey.ts
+++ b/src/main/browser/browser-route-webcontents-rekey.ts
@@ -1,0 +1,111 @@
+import {
+  browserRoutePageKey,
+  type BrowserRouteGuestLifecycleClaim,
+  type BrowserRoutePageAuthority,
+  type BrowserRoutePageGuestIdentity as GuestIdentity,
+  type BrowserRoutePageOwnerIdentity
+} from './browser-route-page-authority'
+import { isValidRoutePageRegistration } from './browser-route-guest-guard'
+import type {
+  BrowserRouteSessionHandle,
+  BrowserRouteSessionRekey
+} from './browser-route-session-state'
+import type { BrowserRouteGuestState as GuestState } from './browser-route-webcontents-state'
+
+type BrowserRouteGuestRekeyDependencies = {
+  rekeyPreparedPage?(
+    previous: BrowserRoutePageAuthority,
+    next: BrowserRoutePageOwnerIdentity
+  ): BrowserRouteSessionRekey | null
+}
+
+export type BrowserRouteGuestLifecycleRekey = {
+  lifecycleClaim: BrowserRouteGuestLifecycleClaim
+  routeSession: BrowserRouteSessionHandle
+}
+
+export function rekeyBrowserRouteGuest(input: {
+  claim: BrowserRouteGuestLifecycleClaim
+  next: GuestIdentity
+  state: GuestState | undefined
+  guestsByPage: Map<string, GuestState>
+  dependencies: BrowserRouteGuestRekeyDependencies
+  registrationMatchesGuest: (state: GuestState, registration: GuestIdentity) => boolean
+  claimGuestLifecycle: (registration: GuestIdentity) => BrowserRouteGuestLifecycleClaim | null
+}): BrowserRouteGuestLifecycleRekey | null {
+  const { claim, next, state } = input
+  const previous = claim.registration
+  if (
+    !state?.registration ||
+    state.guestAuthority !== claim.guestAuthority ||
+    state.retirementRequested ||
+    state.navigationGranted ||
+    state.pageAuthority === null ||
+    !isValidRoutePageRegistration(next) ||
+    next.partition !== previous.partition ||
+    next.browserPageId !== previous.browserPageId ||
+    next.rendererWebContentsId !== previous.rendererWebContentsId ||
+    next.webContentsId !== previous.webContentsId ||
+    next.pageHostGeneration === previous.pageHostGeneration ||
+    browserRoutePageKey(state.registration) !== browserRoutePageKey(previous) ||
+    !input.registrationMatchesGuest(state, previous)
+  ) {
+    return null
+  }
+  const nextKey = browserRoutePageKey(next)
+  const conflicting = input.guestsByPage.get(nextKey)
+  const rekeyPreparedPage = input.dependencies.rekeyPreparedPage
+  if ((conflicting && conflicting !== state) || !rekeyPreparedPage) {
+    return null
+  }
+  const previousAuthority = { ...previous, pageAuthority: state.pageAuthority }
+  const rekeyed = rekeyPreparedPage(previousAuthority, next)
+  if (
+    !rekeyed ||
+    rekeyed.page.pageAuthority !== state.pageAuthority ||
+    rekeyed.routeSession.partition !== next.partition ||
+    browserRoutePageKey(rekeyed.page) !== nextKey ||
+    rekeyed.page.rendererWebContentsId !== next.rendererWebContentsId
+  ) {
+    if (rekeyed) {
+      rekeyPreparedPage(rekeyed.page, previous)
+    }
+    return null
+  }
+  const previousKey = browserRoutePageKey(previous)
+  input.guestsByPage.delete(previousKey)
+  state.registration = { ...next }
+  state.pageAuthority = rekeyed.page.pageAuthority
+  input.guestsByPage.set(nextKey, state)
+  const lifecycleClaim = input.claimGuestLifecycle(next)
+  if (!lifecycleClaim) {
+    input.guestsByPage.delete(nextKey)
+    state.registration = { ...previous }
+    state.pageAuthority = previousAuthority.pageAuthority
+    input.guestsByPage.set(previousKey, state)
+    rekeyPreparedPage(rekeyed.page, previous)
+    return null
+  }
+  return { lifecycleClaim, routeSession: rekeyed.routeSession }
+}
+
+export function grantReconciledBrowserRouteGuestNavigation(input: {
+  claim: BrowserRouteGuestLifecycleClaim
+  state: GuestState | undefined
+  registrationMatchesGuest: (state: GuestState, registration: GuestIdentity) => boolean
+  hasLivePageAuthority: (state: GuestState) => boolean
+}): boolean {
+  const { claim, state } = input
+  const registration = claim.registration
+  if (
+    !state?.registration ||
+    state.guestAuthority !== claim.guestAuthority ||
+    browserRoutePageKey(state.registration) !== browserRoutePageKey(registration) ||
+    !input.registrationMatchesGuest(state, registration) ||
+    !input.hasLivePageAuthority(state)
+  ) {
+    return false
+  }
+  state.navigationGranted = true
+  return true
+}

--- a/src/main/runtime/browser-host-command-ledger.ts
+++ b/src/main/runtime/browser-host-command-ledger.ts
@@ -19,6 +19,8 @@ import {
   type BrowserHostCommandRecord,
   type BrowserHostCommandResultParams,
   positiveBrowserHostCommandLimit,
+  recordBrowserHostCommandOrder,
+  snapshotBrowserHostPageCommand,
   sameBrowserHostCommandResult
 } from './browser-host-command-state'
 import { replayOutstandingBrowserHostCommands } from './browser-host-command-replay'
@@ -108,6 +110,7 @@ export class BrowserHostCommandLedger {
     }
     assertBrowserHostCommandOrder(page, command)
     admission.commit()
+    recordBrowserHostCommandOrder(page, command)
     const commandSequence = page.nextIssueSequence
     const event = Object.freeze({
       type: 'command' as const,
@@ -117,7 +120,7 @@ export class BrowserHostCommandLedger {
       pageHostGeneration: input.pageHostGeneration,
       commandSequence,
       commandId: this.createCommandId(commandSequence),
-      command: Object.freeze(command)
+      command: snapshotBrowserHostPageCommand(command)
     })
     const record = createBrowserHostCommandRecord(event)
     page.records.set(commandSequence, record)
@@ -224,7 +227,8 @@ export class BrowserHostCommandLedger {
       nextSettlementSequence: 1,
       records: new Map(),
       outstanding: 0,
-      settledSequences: []
+      settledSequences: [],
+      terminalCommandIssued: false
     }
     return {
       page,

--- a/src/main/runtime/browser-host-command-state.ts
+++ b/src/main/runtime/browser-host-command-state.ts
@@ -38,18 +38,59 @@ export type BrowserHostCommandPageState = {
   records: Map<number, BrowserHostCommandRecord>
   outstanding: number
   settledSequences: number[]
+  terminalCommandIssued: boolean
 }
 
 export function assertBrowserHostCommandOrder(
   page: BrowserHostCommandPageState,
   command: BrowserClientHostCommandEvent['command']
 ): void {
-  if (page.nextIssueSequence === 1 && command.type !== 'createPage') {
+  if (page.nextIssueSequence === 1 && command.type === 'navigate') {
     throw new Error('browser_host_command_create_required')
   }
-  if (page.nextIssueSequence > 1 && command.type === 'createPage') {
-    throw new Error('browser_host_command_create_repeated')
+  if (page.nextIssueSequence > 1) {
+    if (page.terminalCommandIssued) {
+      throw new Error('browser_host_command_page_terminal')
+    }
+    if (
+      command.type === 'createPage' ||
+      command.type === 'reclaimPage' ||
+      command.type === 'restorePage'
+    ) {
+      throw new Error(
+        command.type === 'createPage'
+          ? 'browser_host_command_create_repeated'
+          : 'browser_host_command_bootstrap_repeated'
+      )
+    }
   }
+}
+
+export function recordBrowserHostCommandOrder(
+  page: BrowserHostCommandPageState,
+  command: BrowserClientHostCommandEvent['command']
+): void {
+  if (command.type === 'closePage') {
+    page.terminalCommandIssued = true
+  }
+}
+
+export function snapshotBrowserHostPageCommand(
+  command: BrowserClientHostCommandEvent['command']
+): BrowserClientHostCommandEvent['command'] {
+  if (command.type === 'reclaimPage') {
+    return Object.freeze({
+      ...command,
+      previousAuthority: Object.freeze({ ...command.previousAuthority })
+    })
+  }
+  if (command.type === 'closePage') {
+    return Object.freeze({
+      ...command,
+      targetAuthority: Object.freeze({ ...command.targetAuthority })
+    })
+  }
+  return Object.freeze({ ...command })
 }
 
 export type BrowserHostCommandLedgerOptions = {

--- a/src/preload/browser-client-page-renderer-requests.test.ts
+++ b/src/preload/browser-client-page-renderer-requests.test.ts
@@ -43,7 +43,7 @@ const PAGE = {
 
 function request(
   requestId: string,
-  type: BrowserClientPageRendererRequest['type'] = 'mountPage'
+  type: Exclude<BrowserClientPageRendererRequest['type'], 'rekeyPage'> = 'mountPage'
 ): BrowserClientPageRendererRequest {
   return { requestId, type, page: PAGE }
 }
@@ -58,6 +58,32 @@ afterEach(() => {
 })
 
 describe('browser client page renderer preload requests', () => {
+  it('echoes the exact immutable rekey target through the current subscriber', async () => {
+    const ipc = new FakeIpc()
+    const requests = createBrowserClientPageRendererRequests({ ipc, isTopFrame: () => true })
+    const nextPage = { ...PAGE, pageHostGeneration: 8 }
+    const callback = vi.fn(() => ({ type: 'rekeyed' as const }))
+    requests.subscribe(callback)
+
+    ipc.emit({ requestId: 'rekey-a', type: 'rekeyPage', page: PAGE, nextPage })
+    nextPage.pageHostGeneration = 9
+    await flush()
+
+    expect(callback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'rekeyPage',
+        page: PAGE,
+        nextPage: { ...PAGE, pageHostGeneration: 8 }
+      })
+    )
+    expect(ipc.sent[0]?.reply).toEqual({
+      type: 'rekeyed',
+      requestId: 'rekey-a',
+      page: PAGE,
+      nextPage: { ...PAGE, pageHostGeneration: 8 }
+    })
+  })
+
   it('queues before subscription and dispatches in arrival order', async () => {
     const ipc = new FakeIpc()
     const requests = createBrowserClientPageRendererRequests({ ipc, isTopFrame: () => true })

--- a/src/preload/browser-client-page-renderer-requests.ts
+++ b/src/preload/browser-client-page-renderer-requests.ts
@@ -229,6 +229,7 @@ class BrowserClientPageRendererRequests {
   }
 
   private sendReply(request: RendererRequest, outcome: RendererOutcome): void {
+    const nextPage = request.type === 'rekeyPage' ? { nextPage: request.nextPage } : {}
     const reply = BrowserClientPageRendererReply.safeParse(
       outcome.type === 'failed'
         ? {
@@ -237,7 +238,7 @@ class BrowserClientPageRendererRequests {
             page: request.page,
             operation: request.type
           }
-        : { ...outcome, requestId: request.requestId, page: request.page }
+        : { ...outcome, requestId: request.requestId, page: request.page, ...nextPage }
     )
     if (!reply.success) {
       return
@@ -257,13 +258,18 @@ function readTopFrame(isTopFrame: () => boolean): boolean {
 }
 
 function freezeRequest(request: RendererRequest): RendererRequest {
-  return Object.freeze({ ...request, page: Object.freeze({ ...request.page }) })
+  return Object.freeze({
+    ...request,
+    page: Object.freeze({ ...request.page }),
+    ...(request.type === 'rekeyPage' ? { nextPage: Object.freeze({ ...request.nextPage }) } : {})
+  })
 }
 
 function outcomeMatchesRequest(outcome: RendererOutcome, request: RendererRequest): boolean {
   return (
     outcome.type === 'failed' ||
     (request.type === 'mountPage' && outcome.type === 'mounted') ||
-    (request.type === 'retirePage' && outcome.type === 'retired')
+    (request.type === 'retirePage' && outcome.type === 'retired') ||
+    (request.type === 'rekeyPage' && outcome.type === 'rekeyed')
   )
 }

--- a/src/renderer/src/components/browser-pane/browser-client-page-renderer-installation.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-client-page-renderer-installation.test.ts
@@ -33,7 +33,7 @@ describe('browser client page renderer installation', () => {
     expect(subscribe).not.toHaveBeenCalled()
   })
 
-  it('routes mount and idempotent retirement through one subscriber', async () => {
+  it('routes mount, rekey, and idempotent retirement through one subscriber', async () => {
     let callback: RequestCallback | null = null
     const unsubscribe = vi.fn()
     const subscribe = vi.fn((next: typeof callback) => {
@@ -50,6 +50,7 @@ describe('browser client page renderer installation', () => {
         partitionCount: 1
       })),
       mountPage: vi.fn(async () => ({ webContentsId: 41 })),
+      rekeyPage: vi.fn(),
       retirePage: vi.fn()
     }
     const installation = installBrowserClientPageRenderer({ registry, subscribe })!
@@ -57,10 +58,15 @@ describe('browser client page renderer installation', () => {
     await expect(
       Promise.resolve(callback!({ requestId: 'mount-a', type: 'mountPage', page: PAGE }))
     ).resolves.toEqual({ type: 'mounted', webContentsId: 41 })
+    const nextPage = { ...PAGE, pageHostGeneration: 8 }
+    await expect(
+      Promise.resolve(callback!({ requestId: 'rekey-a', type: 'rekeyPage', page: PAGE, nextPage }))
+    ).resolves.toEqual({ type: 'rekeyed' })
     await expect(
       Promise.resolve(callback!({ requestId: 'retire-a', type: 'retirePage', page: PAGE }))
     ).resolves.toEqual({ type: 'retired' })
     expect(registry.mountPage).toHaveBeenCalledWith(PAGE)
+    expect(registry.rekeyPage).toHaveBeenCalledWith(PAGE, nextPage)
     expect(registry.retirePage).toHaveBeenCalledWith(PAGE)
     expect(installation.getMemoryProfile().retainedPageCount).toBe(1)
 
@@ -78,6 +84,7 @@ describe('browser client page renderer installation', () => {
       mountPage: vi.fn(async () => {
         throw new Error('browser_client_page_renderer_attach_timeout')
       }),
+      rekeyPage: vi.fn(),
       retirePage: vi.fn(() => {
         throw new Error('sensitive renderer detail')
       })

--- a/src/renderer/src/components/browser-pane/browser-client-page-renderer-installation.ts
+++ b/src/renderer/src/components/browser-pane/browser-client-page-renderer-installation.ts
@@ -11,6 +11,10 @@ type RendererPageRegistry = {
   dispose(): void
   getMemoryProfile(): BrowserClientPageRendererMemoryProfile
   mountPage(page: BrowserClientPageRendererRequest['page']): Promise<{ webContentsId: number }>
+  rekeyPage(
+    previous: BrowserClientPageRendererRequest['page'],
+    next: BrowserClientPageRendererRequest['page']
+  ): void
   retirePage(page: BrowserClientPageRendererRequest['page']): void
 }
 
@@ -72,6 +76,10 @@ async function handleRequest(
     if (request.type === 'mountPage') {
       const mounted = await registry.mountPage(request.page)
       return { type: 'mounted', webContentsId: mounted.webContentsId }
+    }
+    if (request.type === 'rekeyPage') {
+      registry.rekeyPage(request.page, request.nextPage)
+      return { type: 'rekeyed' }
     }
     registry.retirePage(request.page)
     return { type: 'retired' }

--- a/src/renderer/src/components/browser-pane/browser-client-page-retained-registry.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-client-page-retained-registry.test.ts
@@ -57,6 +57,22 @@ afterEach(() => {
 })
 
 describe('browser client page retained registry', () => {
+  it('rekeys an attached guest without remounting or changing its WebContents', async () => {
+    const { registry, webviews } = createRig()
+    const mounting = registry.mountPage(PAGE)
+    attach(webviews[0]!)
+    await expect(mounting).resolves.toEqual({ webContentsId: 41 })
+    const next = { ...PAGE, pageHostGeneration: 8 }
+
+    registry.rekeyPage(PAGE, next)
+
+    await expect(registry.mountPage(next)).resolves.toEqual({ webContentsId: 41 })
+    expect(webviews).toHaveLength(1)
+    expect(() => registry.rekeyPage(PAGE, { ...next, pageHostGeneration: 9 })).toThrow(
+      'browser_client_page_renderer_rekey_stale'
+    )
+  })
+
   it('mounts only about:blank in a stable document-level host', async () => {
     const { registry, webviews } = createRig()
     const mounted = registry.mountPage(PAGE)

--- a/src/renderer/src/components/browser-pane/browser-client-page-retained-registry.ts
+++ b/src/renderer/src/components/browser-pane/browser-client-page-retained-registry.ts
@@ -10,30 +10,12 @@ import {
   readBrowserClientPageAttachedGuestId
 } from './browser-client-page-retained-elements'
 import { browserClientPageRetainedKey } from './browser-client-page-retained-key'
+import { rekeyBrowserClientRetainedPage } from './browser-client-page-retained-rekey'
+import type { BrowserClientRetainedRendererPage as RetainedPage } from './browser-client-page-retained-state'
 
 const DEFAULT_MAX_PAGES = 256
 const DEFAULT_MAX_PAGES_PER_PARTITION = 64
 const DEFAULT_ATTACH_TIMEOUT_MS = 5_000
-
-type RetainedPageStatus = 'attaching' | 'attached' | 'retiring'
-
-type RetainedPage = {
-  key: string
-  identity: RendererPageIdentity
-  host: HTMLDivElement
-  webview: Electron.WebviewTag
-  status: RetainedPageStatus
-  webContentsId: number | null
-  attachmentObserved: boolean
-  mount: Promise<{ webContentsId: number }>
-  resolveMount: (value: { webContentsId: number }) => void
-  rejectMount: (error: Error) => void
-  attachTimer: ReturnType<typeof setTimeout>
-  onAttached: EventListener
-  onReady: EventListener
-  onDestroyed: EventListener
-  onRendererGone: EventListener
-}
 
 export type BrowserClientPageRendererMemoryProfile = {
   retainedPageCount: number
@@ -134,6 +116,12 @@ export class BrowserClientPageRetainedRegistry {
     ) {
       this.releasePage(page)
     }
+  }
+
+  rekeyPage(previousCandidate: RendererPageIdentity, nextCandidate: RendererPageIdentity): void {
+    rekeyBrowserClientRetainedPage(this.pages, previousCandidate, nextCandidate, (page) =>
+      this.fenceRendererLoss(page)
+    )
   }
 
   getMemoryProfile(): BrowserClientPageRendererMemoryProfile {

--- a/src/renderer/src/components/browser-pane/browser-client-page-retained-rekey.ts
+++ b/src/renderer/src/components/browser-pane/browser-client-page-retained-rekey.ts
@@ -1,0 +1,43 @@
+import {
+  BrowserClientPageRendererIdentity,
+  type BrowserClientPageRendererIdentity as RendererPageIdentity
+} from '../../../../shared/browser-client-page-renderer-protocol'
+import { readBrowserClientPageAttachedGuestId } from './browser-client-page-retained-elements'
+import { browserClientPageRetainedKey } from './browser-client-page-retained-key'
+import type { BrowserClientRetainedRendererPage } from './browser-client-page-retained-state'
+
+export function rekeyBrowserClientRetainedPage(
+  pages: Map<string, BrowserClientRetainedRendererPage>,
+  previousCandidate: RendererPageIdentity,
+  nextCandidate: RendererPageIdentity,
+  fenceRendererLoss: (page: BrowserClientRetainedRendererPage) => void
+): void {
+  const previous = BrowserClientPageRendererIdentity.safeParse(previousCandidate)
+  const next = BrowserClientPageRendererIdentity.safeParse(nextCandidate)
+  if (
+    !previous.success ||
+    !next.success ||
+    previous.data.partition !== next.data.partition ||
+    previous.data.browserPageId !== next.data.browserPageId ||
+    previous.data.pageHostGeneration === next.data.pageHostGeneration
+  ) {
+    throw new Error('browser_client_page_renderer_rekey_invalid')
+  }
+  const previousKey = browserClientPageRetainedKey(previous.data)
+  const nextKey = browserClientPageRetainedKey(next.data)
+  const page = pages.get(previousKey)
+  if (!page || page.status !== 'attached') {
+    throw new Error('browser_client_page_renderer_rekey_stale')
+  }
+  if (pages.has(nextKey)) {
+    throw new Error('browser_client_page_renderer_rekey_conflict')
+  }
+  if (readBrowserClientPageAttachedGuestId(page.webview) !== page.webContentsId) {
+    fenceRendererLoss(page)
+    throw new Error('browser_client_page_renderer_process_gone')
+  }
+  pages.delete(previousKey)
+  page.key = nextKey
+  page.identity = next.data
+  pages.set(nextKey, page)
+}

--- a/src/renderer/src/components/browser-pane/browser-client-page-retained-state.ts
+++ b/src/renderer/src/components/browser-pane/browser-client-page-retained-state.ts
@@ -1,0 +1,19 @@
+import type { BrowserClientPageRendererIdentity } from '../../../../shared/browser-client-page-renderer-protocol'
+
+export type BrowserClientRetainedRendererPage = {
+  key: string
+  identity: BrowserClientPageRendererIdentity
+  host: HTMLDivElement
+  webview: Electron.WebviewTag
+  status: 'attaching' | 'attached' | 'retiring'
+  webContentsId: number | null
+  attachmentObserved: boolean
+  mount: Promise<{ webContentsId: number }>
+  resolveMount: (value: { webContentsId: number }) => void
+  rejectMount: (error: Error) => void
+  attachTimer: ReturnType<typeof setTimeout>
+  onAttached: EventListener
+  onReady: EventListener
+  onDestroyed: EventListener
+  onRendererGone: EventListener
+}

--- a/src/shared/browser-client-page-renderer-protocol.ts
+++ b/src/shared/browser-client-page-renderer-protocol.ts
@@ -23,13 +23,18 @@ const RendererRequestBase = z.object({
 
 export const BrowserClientPageRendererRequest = z.discriminatedUnion('type', [
   RendererRequestBase.extend({ type: z.literal('mountPage') }),
-  RendererRequestBase.extend({ type: z.literal('retirePage') })
+  RendererRequestBase.extend({ type: z.literal('retirePage') }),
+  RendererRequestBase.extend({
+    type: z.literal('rekeyPage'),
+    nextPage: BrowserClientPageRendererIdentity
+  })
 ])
 export type BrowserClientPageRendererRequest = z.infer<typeof BrowserClientPageRendererRequest>
 
 export const BrowserClientPageRendererOutcome = z.discriminatedUnion('type', [
   z.object({ type: z.literal('mounted'), webContentsId: WebContentsId }),
   z.object({ type: z.literal('retired') }),
+  z.object({ type: z.literal('rekeyed') }),
   z.object({ type: z.literal('failed'), errorCode: Identity })
 ])
 export type BrowserClientPageRendererOutcome = z.infer<typeof BrowserClientPageRendererOutcome>
@@ -43,8 +48,12 @@ export const BrowserClientPageRendererReply = z.discriminatedUnion('type', [
   }),
   RendererReplyBase.extend({ type: z.literal('retired') }),
   RendererReplyBase.extend({
+    type: z.literal('rekeyed'),
+    nextPage: BrowserClientPageRendererIdentity
+  }),
+  RendererReplyBase.extend({
     type: z.literal('failed'),
-    operation: z.enum(['mountPage', 'retirePage']),
+    operation: z.enum(['mountPage', 'retirePage', 'rekeyPage']),
     errorCode: Identity
   })
 ])


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​890 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​878 |
| Prod | 31 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1255 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​238 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1017 |

<!-- /orca-pr-loc -->

## Summary

- execute negotiated `reclaimPage`, `restorePage`, and `closePage` commands in the client-hosted Electron page executor
- rekey one retained guest across renderer retention, prepared Session authority, WebContents lifecycle claims, and navigation authority without remounting
- fail closed on uncertain rekey or cleanup, including both possible renderer identities and immutable `outcomeUnknown` inventory
- keep reconciliation advertisement and all production client placement disabled

This draft is stacked on #14759 and is one production-inert stage of [STA-4150](https://linear.app/stably/issue/STA-4150/refactor-remote-browser-to-client-hosted-electron-webviews).

## Causal evidence

- reverting dual-identity cleanup makes the adapter oracle fail because the previous retained renderer key survives
- reverting failed-retirement inventory transfer leaves a rejected cleanup promise in the live-page map
- reverting failed-close fence release bricks later same-generation commands
- a fresh new-authority dispatcher successfully reclaims an old-authority executor page; same-dispatcher create-to-reclaim is intentionally not supported because reclaim requires an authority-epoch transition

## Validation

- changed surface: 19 files / 233 tests
- paired runtime/server: 13 files / 179 tests
- isolated real-Electron lifecycle: 1/1
- cross-version terminal wire: 5/5
- Node/CLI/web typecheck
- full lint, native and type-aware audits, 87 reliability gates, max-lines, skill and localization checks
- changed-code quality: zero findings
- formatting and `git diff --check`

## Compatibility and remaining blocker

No new remote field or opcode is introduced in this stage. Reconciliation remains behind the optional, already-negotiated subprotocol and is not advertised by production. Old clients, server/offscreen placement, browserless hosts, SSH/WSL routes, folder workspaces, git worktrees, and current browser behavior remain unchanged.

Do not enable production advertisement from this PR. Server orchestration still needs a dedicated authenticated action-issuance path, preservation of the client executor across authority transition, and proof-driven placement rekey after the client result. Restore remains behind the global phase-one barrier.
