### PR TITLE
fix(orchestration): tell a settled worker what happened instead of that it is revoked

### DIFF
--- a/src/main/runtime/orchestration/db/dispatch-context/dispatch-capability.ts
+++ b/src/main/runtime/orchestration/db/dispatch-context/dispatch-capability.ts
@@ -6,11 +6,8 @@ import { isEquivalentPaneKey } from '../pane-key-match'
 import { exposeUtcTimestamp } from '../utc-timestamp'
 import type { OrchestrationDb } from '../orchestration-db'
 
-// Why: "capability is revoked" describes the mechanism, not the cause, and an
-// agent worker reads it as its authorization dying — the reported failure is a
-// worker that quits with finished work uncommitted rather than one that reports
-// again. State only what the row proves: whether this dispatch was settled or
-// released, when, and the one channel that still works. Never guess why.
+// Why: state only what the row proves — what settled the dispatch and when —
+// and name escalation as the one channel this capability does not gate.
 function describeRevokedDispatch(dispatch: DispatchContextRow): string {
   return [
     describeRevocationCause(dispatch),
@@ -22,11 +19,8 @@ function describeRevokedDispatch(dispatch: DispatchContextRow): string {
   ].join('\n')
 }
 
-// Why every branch reads a stored column: a revoked row does not record who
-// revoked it, so any sentence about stopping, releasing, or reporting early
-// would be inference. `status` distinguishes the terminal cases, `last_failure`
-// carries the real cause behind a `failed` row ('stopped', 'abandoned'), and a
-// still-open status means the capability went before the dispatch settled.
+// Why: a revoked row does not record who revoked it, so every branch states
+// only stored columns and never infers the actor.
 function describeRevocationCause(dispatch: DispatchContextRow): string {
   const at = exposeUtcTimestamp(dispatch.completed_at ?? dispatch.capability_revoked_at)
   const when = at ? ` at ${at}` : ''
@@ -110,10 +104,7 @@ export function verifyDispatchCapability(
   ) {
     return { valid: false, reason: 'The Dispatch process incarnation changed.' }
   }
-  // Why revocation is checked last: only a caller that has proven it is this
-  // dispatch's own worker gets told what happened to it. A caller that failed
-  // identity now learns nothing about the dispatch's state, and the recovery
-  // advice below is only ever addressed to someone who can act on it.
+  // Why last: a caller must pass identity before it learns any dispatch state.
   if (dispatch.capability_revoked_at) {
     return { valid: false, reason: describeRevokedDispatch(dispatch) }
   }

--- a/src/main/runtime/orchestration/db/dispatch-context/dispatch-capability.ts
+++ b/src/main/runtime/orchestration/db/dispatch-context/dispatch-capability.ts
@@ -12,17 +12,32 @@ import type { OrchestrationDb } from '../orchestration-db'
 // again. State only what the row proves: whether this dispatch was settled or
 // released, when, and the one channel that still works. Never guess why.
 function describeRevokedDispatch(dispatch: DispatchContextRow): string {
-  const settled = dispatch.status === 'completed' || dispatch.status === 'failed'
-  const at = exposeUtcTimestamp(dispatch.completed_at ?? dispatch.capability_revoked_at)
-  const cause = settled
-    ? `Dispatch ${dispatch.id} was already settled as ${dispatch.status}${at ? ` at ${at}` : ''}, which revoked its lifecycle capability.`
-    : `Dispatch ${dispatch.id} was released${at ? ` at ${at}` : ''}, which revoked its lifecycle capability.`
   return [
-    cause,
+    describeRevocationCause(dispatch),
     'This is final for worker_done and heartbeat: resending them cannot change it.',
-    'If the task is not actually finished, say so with --type escalation, which does not need this capability.',
+    // Why not "escalation will reach the coordinator": that depends on topology
+    // this function cannot see. The gate's scope is a fact; delivery is not.
+    'This capability gates only worker_done and heartbeat, so if the task is not actually finished, report that with --type escalation.',
     'Do not exit with uncommitted work.'
   ].join('\n')
+}
+
+// Why every branch reads a stored column: a revoked row does not record who
+// revoked it, so any sentence about stopping, releasing, or reporting early
+// would be inference. `status` distinguishes the terminal cases, `last_failure`
+// carries the real cause behind a `failed` row ('stopped', 'abandoned'), and a
+// still-open status means the capability went before the dispatch settled.
+function describeRevocationCause(dispatch: DispatchContextRow): string {
+  const at = exposeUtcTimestamp(dispatch.completed_at ?? dispatch.capability_revoked_at)
+  const when = at ? ` at ${at}` : ''
+  if (dispatch.status === 'circuit_broken') {
+    return `Dispatch ${dispatch.id} circuit-broke after ${dispatch.failure_count} failures${when}, which revoked its lifecycle capability.`
+  }
+  if (dispatch.status === 'completed' || dispatch.status === 'failed') {
+    const cause = dispatch.last_failure ? ` (${dispatch.last_failure})` : ''
+    return `Dispatch ${dispatch.id} was settled as ${dispatch.status}${cause}${when}, which revoked its lifecycle capability.`
+  }
+  return `Dispatch ${dispatch.id} had its lifecycle capability revoked${when} while still ${dispatch.status}.`
 }
 
 export function mintDispatchCapability(

--- a/src/main/runtime/orchestration/db/dispatch-context/dispatch-capability.ts
+++ b/src/main/runtime/orchestration/db/dispatch-context/dispatch-capability.ts
@@ -1,8 +1,29 @@
 import { randomBytes, timingSafeEqual } from 'node:crypto'
 import { OrchestrationError } from '../../orchestration-error'
+import type { DispatchContextRow } from '../../types'
 import { hashDispatchCapability } from '../dispatch-capability-hash'
 import { isEquivalentPaneKey } from '../pane-key-match'
+import { exposeUtcTimestamp } from '../utc-timestamp'
 import type { OrchestrationDb } from '../orchestration-db'
+
+// Why: "capability is revoked" describes the mechanism, not the cause, and an
+// agent worker reads it as its authorization dying — the reported failure is a
+// worker that quits with finished work uncommitted rather than one that reports
+// again. State only what the row proves: whether this dispatch was settled or
+// released, when, and the one channel that still works. Never guess why.
+function describeRevokedDispatch(dispatch: DispatchContextRow): string {
+  const settled = dispatch.status === 'completed' || dispatch.status === 'failed'
+  const at = exposeUtcTimestamp(dispatch.completed_at ?? dispatch.capability_revoked_at)
+  const cause = settled
+    ? `Dispatch ${dispatch.id} was already settled as ${dispatch.status}${at ? ` at ${at}` : ''}, which revoked its lifecycle capability.`
+    : `Dispatch ${dispatch.id} was released${at ? ` at ${at}` : ''}, which revoked its lifecycle capability.`
+  return [
+    cause,
+    'This is final for worker_done and heartbeat: resending them cannot change it.',
+    'If the task is not actually finished, say so with --type escalation, which does not need this capability.',
+    'Do not exit with uncommitted work.'
+  ].join('\n')
+}
 
 export function mintDispatchCapability(
   this: OrchestrationDb,
@@ -52,9 +73,6 @@ export function verifyDispatchCapability(
   if (!dispatch.capability_hash) {
     return { valid: false, reason: `Dispatch ${params.dispatchId} has no lifecycle capability.` }
   }
-  if (dispatch.capability_revoked_at) {
-    return { valid: false, reason: `Dispatch ${params.dispatchId} capability is revoked.` }
-  }
   if (!params.capability) {
     return { valid: false, reason: 'The Dispatch capability is missing.' }
   }
@@ -76,6 +94,13 @@ export function verifyDispatchCapability(
     dispatch.process_incarnation !== params.processIncarnation
   ) {
     return { valid: false, reason: 'The Dispatch process incarnation changed.' }
+  }
+  // Why revocation is checked last: only a caller that has proven it is this
+  // dispatch's own worker gets told what happened to it. A caller that failed
+  // identity now learns nothing about the dispatch's state, and the recovery
+  // advice below is only ever addressed to someone who can act on it.
+  if (dispatch.capability_revoked_at) {
+    return { valid: false, reason: describeRevokedDispatch(dispatch) }
   }
   return { valid: true }
 }

--- a/src/main/runtime/orchestration/revoked-dispatch-reason.test.ts
+++ b/src/main/runtime/orchestration/revoked-dispatch-reason.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, afterEach } from 'vitest'
+import type Database from '../../sqlite/sync-database'
+import { OrchestrationDb } from './db'
+
+// The rejection a worker reads when its dispatch capability is gone. An agent
+// acts on this text literally, so each branch must report a stored column
+// rather than infer a story about who revoked it.
+describe('OrchestrationDb', () => {
+  let db: OrchestrationDb | undefined
+
+  afterEach(() => {
+    db?.close()
+  })
+
+  function createDb(): OrchestrationDb {
+    db = new OrchestrationDb(':memory:')
+    return db
+  }
+
+describe('revoked dispatch rejection reason', () => {
+  // Why direct SQL: these are terminal and interrupted states a settled
+  // dispatch cannot be walked into from the public API in one test, and the
+  // point of the helper is that it reads the row rather than inferring.
+  function revoke(
+    d: OrchestrationDb,
+    id: string,
+    columns: Partial<{
+      status: string
+      last_failure: string
+      failure_count: number
+      completed_at: string
+    }>
+  ): void {
+    const sqlite = (d as unknown as { db: Database.Database }).db
+    const entries = Object.entries({ ...columns, capability_revoked_at: '2026-01-02 03:04:05' })
+    sqlite
+      .prepare(
+        `UPDATE dispatch_contexts SET ${entries.map(([c]) => `${c} = ?`).join(', ')} WHERE id = ?`
+      )
+      .run(...entries.map(([, v]) => v), id)
+  }
+
+  function reasonFor(
+    columns: Partial<{
+      status: string
+      last_failure: string
+      failure_count: number
+      completed_at: string
+    }>
+  ): string {
+    const d = createDb()
+    const task = d.createTask({ spec: 'work' })
+    const dispatch = d.createDispatchContext(task.id, 'term_worker', 'tab:leaf')
+    const capability = d.mintDispatchCapability({
+      dispatchId: dispatch.id,
+      paneKey: 'tab:leaf',
+      processIncarnation: 'inc_1'
+    })
+    revoke(d, dispatch.id, columns)
+    const result = d.verifyDispatchCapability({
+      dispatchId: dispatch.id,
+      capability,
+      paneKey: 'tab:leaf',
+      processIncarnation: 'inc_1'
+    })
+    expect(result.valid).toBe(false)
+    return (result as { valid: false; reason: string }).reason
+  }
+
+  it('names a completed settlement and its time', () => {
+    const reason = reasonFor({ status: 'completed', completed_at: '2026-01-02 03:04:05' })
+    expect(reason).toContain('was settled as completed')
+    expect(reason).toContain('2026-01-02')
+  })
+
+  it('carries the recorded cause behind a failed settlement', () => {
+    // Why: worker-stop and context-only release both write status 'failed'
+    // and keep the real cause in last_failure. Reporting only 'failed' would
+    // hide the one column that says what actually happened.
+    const reason = reasonFor({ status: 'failed', last_failure: 'stopped' })
+    expect(reason).toContain('was settled as failed (stopped)')
+  })
+
+  it('names a circuit break rather than calling it a release', () => {
+    // Why: circuit_broken is terminal. Any branch that only knows completed
+    // and failed misfiles it as something the worker could retry past.
+    const reason = reasonFor({ status: 'circuit_broken', failure_count: 3 })
+    expect(reason).toContain('circuit-broke after 3 failures')
+    expect(reason).not.toContain('settled as')
+  })
+
+  it('does not claim a settlement when the capability went first', () => {
+    // Why: a stop request revokes the capability while the dispatch is still
+    // open, so saying it was settled or released would be a guess.
+    const reason = reasonFor({ status: 'dispatched' })
+    expect(reason).toContain('revoked')
+    expect(reason).toContain('while still dispatched')
+    expect(reason).not.toContain('settled')
+  })
+
+  it('states the gate scope without promising escalation delivery', () => {
+    // Why: whether an escalation reaches a coordinator depends on topology
+    // this function cannot see; the gate covering only worker_done and
+    // heartbeat is a fact it can state.
+    const reason = reasonFor({ status: 'completed' })
+    expect(reason).toContain('gates only worker_done and heartbeat')
+    expect(reason).toContain('--type escalation')
+    expect(reason).toContain('Do not exit with uncommitted work')
+  })
+})
+})

--- a/src/main/runtime/rpc/methods/orchestration-send.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-send.test.ts
@@ -501,6 +501,42 @@ describe('orchestration RPC methods', () => {
       expect(foreign.lifecycle.reason).toBe('The Dispatch capability is invalid.')
       expect(foreign.lifecycle.reason).not.toContain('settled')
       expect(foreign.lifecycle.reason).not.toContain('escalation')
+
+      // Why: identity has three legs — token, pane, process incarnation — and
+      // revocation must stay behind all of them. A caller holding the real
+      // token from the wrong pane or a restarted process learns which check it
+      // failed and still nothing about settlement.
+      ctx = { runtime, orchestrationCapability: capability }
+      vi.mocked(runtime.getTerminalPaneKey).mockImplementation((handle) =>
+        handle === 'term_worker' ? 'tab_other:leaf_other' : coordinatorPaneKey
+      )
+      const wrongPane = (await call('orchestration.send', {
+        from: 'term_worker',
+        subject: 'Done',
+        type: 'worker_done',
+        payload
+      })) as { lifecycle: { code: string; reason: string } }
+      expect(wrongPane.lifecycle.code).toBe('dispatch_capability_invalid')
+      expect(wrongPane.lifecycle.reason).toBe('The caller is not the Dispatch pane.')
+      expect(wrongPane.lifecycle.reason).not.toContain('settled')
+      expect(wrongPane.lifecycle.reason).not.toContain('escalation')
+
+      vi.mocked(runtime.getTerminalPaneKey).mockImplementation((handle) =>
+        handle === 'term_worker' ? 'tab_worker:leaf_worker' : coordinatorPaneKey
+      )
+      vi.mocked(runtime.getTerminalProcessIncarnation).mockReturnValue(
+        'runtime_test:term_worker:2'
+      )
+      const wrongProcess = (await call('orchestration.send', {
+        from: 'term_worker',
+        subject: 'Done',
+        type: 'worker_done',
+        payload
+      })) as { lifecycle: { code: string; reason: string } }
+      expect(wrongProcess.lifecycle.code).toBe('dispatch_capability_invalid')
+      expect(wrongProcess.lifecycle.reason).toBe('The Dispatch process incarnation changed.')
+      expect(wrongProcess.lifecycle.reason).not.toContain('settled')
+      expect(wrongProcess.lifecycle.reason).not.toContain('escalation')
     })
 
     it('does not wake waiters for a heartbeat suppressed at send time', async () => {

--- a/src/main/runtime/rpc/methods/orchestration-send.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-send.test.ts
@@ -455,7 +455,7 @@ describe('orchestration RPC methods', () => {
       // reason must say what happened and what still works. A bare "capability
       // is revoked" reads to an agent as its authorization dying, and the
       // reported failure is a worker that exits with work uncommitted.
-      expect(revoked.lifecycle.reason).toContain('already settled as completed')
+      expect(revoked.lifecycle.reason).toContain('was settled as completed')
       expect(revoked.lifecycle.reason).toContain('--type escalation')
       expect(revoked.lifecycle.reason).toContain('Do not exit with uncommitted work')
     })

--- a/src/main/runtime/rpc/methods/orchestration-send.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-send.test.ts
@@ -451,10 +451,7 @@ describe('orchestration RPC methods', () => {
         payload
       })) as { lifecycle: { code: string; reason: string } }
       expect(revoked.lifecycle.code).toBe('dispatch_capability_invalid')
-      // Why: the worker that hits this has proven it owns the dispatch, so the
-      // reason must say what happened and what still works. A bare "capability
-      // is revoked" reads to an agent as its authorization dying, and the
-      // reported failure is a worker that exits with work uncommitted.
+      // Why: the proven dispatch owner is told what settled it and what still works.
       expect(revoked.lifecycle.reason).toContain('was settled as completed')
       expect(revoked.lifecycle.reason).toContain('--type escalation')
       expect(revoked.lifecycle.reason).toContain('Do not exit with uncommitted work')
@@ -487,9 +484,7 @@ describe('orchestration RPC methods', () => {
       })
       expect(db.getDispatchContextById(dispatch.id)?.capability_revoked_at).toBeTruthy()
 
-      // Why: revocation is verified after identity, so a caller holding the
-      // wrong token learns that its token is wrong and nothing about whether
-      // the dispatch settled, when, or with what outcome.
+      // Why: an invalid token must not disclose whether or how the dispatch settled.
       ctx = { runtime, orchestrationCapability: 'dcap_wrong' }
       const foreign = (await call('orchestration.send', {
         from: 'term_worker',
@@ -502,10 +497,7 @@ describe('orchestration RPC methods', () => {
       expect(foreign.lifecycle.reason).not.toContain('settled')
       expect(foreign.lifecycle.reason).not.toContain('escalation')
 
-      // Why: identity has three legs — token, pane, process incarnation — and
-      // revocation must stay behind all of them. A caller holding the real
-      // token from the wrong pane or a restarted process learns which check it
-      // failed and still nothing about settlement.
+      // Why: pane and process identity failures must equally disclose nothing about settlement.
       ctx = { runtime, orchestrationCapability: capability }
       vi.mocked(runtime.getTerminalPaneKey).mockImplementation((handle) =>
         handle === 'term_worker' ? 'tab_other:leaf_other' : coordinatorPaneKey

--- a/src/main/runtime/rpc/methods/orchestration-send.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-send.test.ts
@@ -449,8 +449,58 @@ describe('orchestration RPC methods', () => {
         subject: 'Done again',
         type: 'worker_done',
         payload
-      })) as { lifecycle: { code: string } }
+      })) as { lifecycle: { code: string; reason: string } }
       expect(revoked.lifecycle.code).toBe('dispatch_capability_invalid')
+      // Why: the worker that hits this has proven it owns the dispatch, so the
+      // reason must say what happened and what still works. A bare "capability
+      // is revoked" reads to an agent as its authorization dying, and the
+      // reported failure is a worker that exits with work uncommitted.
+      expect(revoked.lifecycle.reason).toContain('already settled as completed')
+      expect(revoked.lifecycle.reason).toContain('--type escalation')
+      expect(revoked.lifecycle.reason).toContain('Do not exit with uncommitted work')
+    })
+
+    it('does not disclose settlement state to a caller that fails identity', async () => {
+      setup()
+      const task = db.createTask({ spec: 'capability work' })
+      const dispatch = db.createDispatchContext(task.id, 'term_worker', 'tab_worker:leaf_worker')
+      const capability = db.mintDispatchCapability({
+        dispatchId: dispatch.id,
+        paneKey: 'tab_worker:leaf_worker',
+        processIncarnation: 'runtime_test:term_worker:1'
+      })
+      vi.spyOn(runtime, 'getTerminalPaneKey').mockImplementation((handle) =>
+        handle === 'term_worker' ? 'tab_worker:leaf_worker' : coordinatorPaneKey
+      )
+      const payload = JSON.stringify({
+        taskId: task.id,
+        dispatchId: dispatch.id,
+        outcome: 'succeeded'
+      })
+
+      ctx = { runtime, orchestrationCapability: capability }
+      await call('orchestration.send', {
+        from: 'term_worker',
+        subject: 'Done',
+        type: 'worker_done',
+        payload
+      })
+      expect(db.getDispatchContextById(dispatch.id)?.capability_revoked_at).toBeTruthy()
+
+      // Why: revocation is verified after identity, so a caller holding the
+      // wrong token learns that its token is wrong and nothing about whether
+      // the dispatch settled, when, or with what outcome.
+      ctx = { runtime, orchestrationCapability: 'dcap_wrong' }
+      const foreign = (await call('orchestration.send', {
+        from: 'term_worker',
+        subject: 'Done',
+        type: 'worker_done',
+        payload
+      })) as { lifecycle: { code: string; reason: string } }
+      expect(foreign.lifecycle.code).toBe('dispatch_capability_invalid')
+      expect(foreign.lifecycle.reason).toBe('The Dispatch capability is invalid.')
+      expect(foreign.lifecycle.reason).not.toContain('settled')
+      expect(foreign.lifecycle.reason).not.toContain('escalation')
     })
 
     it('does not wake waiters for a heartbeat suppressed at send time', async () => {


### PR DESCRIPTION
## ELI5

When a worker's dispatch has been settled, its next `worker_done` or `heartbeat` comes back as:

```
Dispatch ctx_… capability is revoked.
```

That sentence names a mechanism. It does not say what settled the dispatch, when, whether resending would help, or whether anything can still be said. An agent reading it concludes its authorization is gone and stops — which in the report behind #14311 meant exiting with finished work uncommitted. The task row was recoverable; the work was not.

This changes what that worker is told. It does not change what is accepted.

## What it says now

```
Dispatch ctx_… was settled as completed at 2026-08-15T10:34:59Z, which revoked its lifecycle capability.
This is final for worker_done and heartbeat: resending them cannot change it.
This capability gates only worker_done and heartbeat, so if the task is not actually finished, report that with --type escalation.
Do not exit with uncommitted work.
```

Every branch of the first line reads a stored column rather than inferring one:

| Row | What it says |
|---|---|
| `status` completed / failed | settled as that status, plus `last_failure` when set — `worker-stop` and context-only release both write `failed` and keep the real cause (`stopped`, `abandoned`) there |
| `status` circuit_broken | circuit-broke after `failure_count` failures — terminal, and not the same event as a settlement |
| still `pending` / `dispatched` | the capability was revoked while the dispatch was still open, which is what a stop *request* does before anything settles |

There is deliberately no guess about *why*. A revoked row does not record who revoked it, so "you probably reported completion too early" would be speculation — and speculation presented as fact is what makes the current message harmful.

The last line is scoped for the same reason. It states the gate's coverage, which is a fact (`orchestration.ts:594` gates `worker_done` and `heartbeat`; `ask` is gated separately at `orchestration.ts:1438`), and stops short of promising that an escalation reaches a coordinator — that depends on topology this function cannot see.

## Why the check moved

`verifyDispatchCapability` tested revocation third, before the capability hash, the pane, and the process incarnation. That ordering has two consequences worth separating:

**It made the better message impossible.** At that point the caller has not proven it is this dispatch's worker, so nothing specific can be said to it safely.

**It leaked state.** A caller holding the wrong token learned that the dispatch existed and had been revoked. Now it learns only that its token is wrong.

Revocation is now the last check. Every branch still returns `valid: false` exactly where it did, so no message is accepted that was not accepted before — the change is strictly in which of several already-failing paths a caller lands on, and what it reads.

## Scope

`verifyDispatchCapability` and one new module-level helper. No schema change, no state-machine change, no change to what settles or when.

This is independent of #14762, which is preamble text and no runtime change at all. They address the same report from opposite ends: #14762 makes the mistake less likely, this one makes it less expensive. Either can land without the other.

## Testing

- The existing `requires the minted capability, exact pane, and process incarnation` case already drove a second `worker_done` through a settled dispatch and asserted only the rejection code. It now also asserts the reason names the settlement, points at `escalation`, and says not to exit with uncommitted work.
- A new case settles a dispatch, then sends with a wrong capability, and asserts the reason is exactly `The Dispatch capability is invalid.` with no settlement details in it.
- `revoked-dispatch-reason.test.ts` covers the state table directly: completed, failed carrying `last_failure`, `circuit_broken`, revoked-while-still-dispatched, and the gate-scope wording. Kept out of `db.test.ts`, which is already at its max-lines budget.
- Every one of these was verified by reverting rather than assumed. All five state-table cases fail against the earlier two-status version of the helper, three of them because it answered "released" for a state that was nothing of the kind; the two RPC cases fail against unmodified `main`.
- `src/main/runtime/orchestration/` + `src/main/runtime/rpc/methods/` + `src/cli/handlers/orchestration.test.ts`: 1209/1209. `check-max-lines-ratchet` clean.
- `tsc -p config/tsconfig.node.json` clean, `oxlint` clean on both files.
- No existing test asserted the old string, so nothing was updated to accommodate this.

## The general shape, if it is useful

This is the second place in one session where a misleading error caused an agent worker to abandon finished work. The other is #12528: the CLI discards the `EPERM` from a sandboxed connect and reports `Orca is not running`, and the worker believed it. Different subsystems, same ending.

Error text written for a human who will retry and investigate behaves differently when the reader is an agent that acts on it literally. Both cases fix the same way — stop asserting what is not known, state the fact that is.
