### PR TITLE
fix(native-chat): show Codex compaction markers

### DIFF
--- a/src/main/native-chat/transcript-line-decoders-codex.ts
+++ b/src/main/native-chat/transcript-line-decoders-codex.ts
@@ -14,6 +14,8 @@ import {
 import { claudeContentBlocks, toolResultOutput } from './transcript-record-blocks'
 import { CODEX_EVENT_TURN_ABORTED } from './transcript-turn-markers'
 
+const CODEX_CONTEXT_COMPACTED_STATUS_TEXT = 'Context compacted'
+
 export function decodeCodexTranscriptLine(
   line: string,
   fallbackId: string
@@ -150,6 +152,15 @@ function codexCompletedTurnItem(
     return null
   }
   const id = extractString(item.id) ?? fallbackId
+  if (item.type === 'ContextCompaction') {
+    return {
+      id,
+      role: 'system',
+      blocks: [{ type: 'text', text: CODEX_CONTEXT_COMPACTED_STATUS_TEXT }],
+      timestamp,
+      source: 'transcript'
+    }
+  }
   const blocks = codexTurnItemBlocks(item.content)
   if (blocks.length === 0) {
     return null

--- a/src/main/native-chat/transcript-reader-codex-history-mode.test.ts
+++ b/src/main/native-chat/transcript-reader-codex-history-mode.test.ts
@@ -133,6 +133,7 @@ describe('Codex transcript history modes', () => {
         },
         '2026-08-09T10:00:01.000Z'
       ),
+      completedItem({ type: 'ContextCompaction', id: 'compaction-1' }, '2026-08-09T10:00:01.500Z'),
       {
         type: 'response_item',
         payload: {
@@ -172,13 +173,19 @@ describe('Codex transcript history modes', () => {
           ]
         },
         {
+          id: 'compaction-1',
+          role: 'system',
+          timestamp: Date.parse('2026-08-09T10:00:01.500Z'),
+          blocks: [{ type: 'text', text: 'Context compacted' }]
+        },
+        {
           id: 'assistant-1',
           role: 'assistant',
           blocks: [{ type: 'text', text: 'Visible response' }]
         }
       ]
     })
-    expect('messages' in result && result.messages).toHaveLength(2)
+    expect('messages' in result && result.messages).toHaveLength(3)
     expect(tail).toMatchObject({ messages: 'messages' in result ? result.messages : [] })
   })
 


### PR DESCRIPTION
## ELI5

When Codex automatically compresses an older conversation to free context space, Native Chat should show where that happened instead of silently jumping to a smaller context.

## What Changed

- Decode completed Codex `ContextCompaction` items as a system message that says `Context compacted`.
- Preserve the provider item id, transcript position, and timestamp.
- Add paginated transcript coverage that verifies the marker appears between the surrounding user and assistant messages.
- Verify full transcript and live tail reads return the same marker without duplication.

## Why

Codex emits compaction as a completed lifecycle item with no `content` array. The decoder previously converted content before checking the item type, so the empty block list caused an early `null` return and silently removed the event.

Handling `ContextCompaction` before content decoding matches the Codex TUI wording and keeps the existing message decoder behavior unchanged for user and assistant items.

## Linked Issue

Fixes #14188

## Visual Proof

N/A — the change is a transcript decoder mapping. A deterministic paginated Codex fixture verifies the exact visible text, ordering, id, timestamp, and parity between full transcript and live tail reads without requiring a token-intensive live auto-compaction run.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Verified locally on macOS:

- native-chat test suite: 257 tests passed
- focused decoder and history-mode suites: 6 tests passed
- `pnpm run typecheck:node`
- focused oxlint and oxfmt checks
- `git diff --check`

Repository CI will cover the clean full lint, test, and build matrix.

## AI Disclosure

OpenAI Codex GPT-5 was used to reproduce the issue against current main, implement the decoder mapping, add regression coverage, and review the focused diff. I reviewed the final behavior and test assertions before submission.

## Review

- Security: no external input, authentication, permission, or command execution behavior changed.
- Cross-platform: pure transcript decoding with no OS-specific path.
- Remote SSH: local and remote Codex rollouts use the same decoder path.
- Mobile: full transcript and live tail consumers receive the same existing system-message shape.
- Backwards compatibility: user and assistant completed-item decoding is unchanged.
- Performance: one constant-time item type check before existing content decoding.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or N/A with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @erishforG
