### PR TITLE
fix(i18n): localize caffeinate controls in Chinese

### DIFF
--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -3509,6 +3509,18 @@
               }
             }
           },
+          "CaffeinateStatusSegment": {
+            "on": "始终开启",
+            "auto": "智能体",
+            "off": "关闭",
+            "active": "生效中",
+            "inactive": "未生效",
+            "ariaLabel": "防止休眠，{{status}}",
+            "title": "防止休眠",
+            "onDescription": "始终保持电脑唤醒",
+            "autoDescription": "智能体工作时保持唤醒",
+            "offDescription": "允许系统正常休眠"
+          },
           "SkillUpdateStatusSegment": {
             "runningLabel": "Updating skills",
             "runningOne": "Updating {{value0}}…",


### PR DESCRIPTION
## ELI5

Display the Caffeinate status-bar controls in Chinese when Orca is using the Chinese locale.

## What Changed

- Added Chinese labels for the On, Agent, and Off Caffeinate modes.
- Added Chinese active and inactive status text.
- Added Chinese menu descriptions, title, and accessibility label.

## Why

The Caffeinate component already uses localization keys, but those keys were missing from the Chinese catalog. As a result, Chinese users saw the English fallback strings.

Adding the existing keys to `zh.json` fixes the fallback without changing component behavior.

## Linked Issue

N/A — follow-up localization for #13480.

## Visual Proof

N/A — this PR only supplies missing Chinese catalog entries and does not change layout or interaction behavior.

## Testing

- `pnpm run verify:localization-catalog`
- `pnpm run verify:localization-extraction`
- `pnpm run verify:localization-coverage`
- `pnpm exec oxfmt --check src/renderer/src/i18n/locales/zh.json`
- `git diff --check`

No automated test was added because the change only adds translations to the existing localization catalog.

- [ ] I manually tested these changes locally
- [ ] Automated tests added/updated, or explained why not below

## AI Disclosure

OpenAI Codex (GPT-5) was used to inspect the localization path and prepare the translation.

## Review

No security, cross-platform, remote SSH, mobile, compatibility, or performance behavior is changed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: N/A
