### PR TITLE
fix(macos): disable ApplePressAndHold so held keys repeat

### DIFF
--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -335,6 +335,10 @@ module.exports = {
     entitlements: 'resources/build/entitlements.mac.plist',
     entitlementsInherit: 'resources/build/entitlements.mac.plist',
     extendInfo: {
+      // Why: macOS defaults press-and-hold to the accent picker, which
+      // swallows key repeat in the terminal (vim hjkl). Ship false so packaged
+      // Orca does not need a manual defaults write (#14746).
+      ApplePressAndHoldEnabled: false,
       NSAppleEventsUsageDescription:
         'Orca allows terminal-launched developer tools to automate local apps when you request it.',
       NSBluetoothAlwaysUsageDescription:

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -133,6 +133,7 @@ import {
   installUncaughtPipeErrorGuard,
   installUnhandledRejectionLogging
 } from './startup/main-process-error-guards'
+import { disableApplePressAndHold } from './startup/macos-press-and-hold'
 import { enableRendererHeapHeadroom } from './startup/renderer-heap-headroom'
 import { argvRequestsServeMode, normalizeServeModeArgv } from './startup/serve-mode-argv'
 import { ensureVirtualDisplayForHeadlessServe } from './startup/ensure-virtual-display'
@@ -850,6 +851,7 @@ if (hasSingleInstanceLock) {
     ...getMainProcessLifecycleIdentity()
   })
   disableUnsupportedChromiumFeatures()
+  disableApplePressAndHold()
   configureElectronNetworkCompatibility()
   enableRendererHeapHeadroom()
   maybeApplyGpuFallbackForThisLaunch()

--- a/src/main/startup/macos-press-and-hold.test.ts
+++ b/src/main/startup/macos-press-and-hold.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { setUserDefault } = vi.hoisted(() => ({
+  setUserDefault: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  systemPreferences: {
+    setUserDefault
+  }
+}))
+
+import { APPLE_PRESS_AND_HOLD_ENABLED_KEY, disableApplePressAndHold } from './macos-press-and-hold'
+
+const require = createRequire(import.meta.url)
+const electronBuilderConfig = require('../../../config/electron-builder.config.cjs') as {
+  appId: string
+  mac: { extendInfo: { ApplePressAndHoldEnabled?: unknown } }
+}
+
+describe('disableApplePressAndHold', () => {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+  function setPlatform(platform: NodeJS.Platform): void {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: platform
+    })
+  }
+
+  afterEach(() => {
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform)
+    }
+    setUserDefault.mockReset()
+  })
+
+  it('writes ApplePressAndHoldEnabled false on macOS so held keys repeat', () => {
+    setPlatform('darwin')
+    disableApplePressAndHold()
+    expect(setUserDefault).toHaveBeenCalledWith(APPLE_PRESS_AND_HOLD_ENABLED_KEY, 'boolean', false)
+  })
+
+  it('does not touch user defaults on other platforms', () => {
+    setPlatform('linux')
+    disableApplePressAndHold()
+    expect(setUserDefault).not.toHaveBeenCalled()
+  })
+
+  it('ships the same override in the packaged macOS Info.plist', () => {
+    expect(electronBuilderConfig.appId).toBe('com.stablyai.orca')
+    expect(electronBuilderConfig.mac.extendInfo.ApplePressAndHoldEnabled).toBe(false)
+  })
+
+  it('is invoked from main-process startup before windows exist', () => {
+    const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
+    expect(source).toContain('disableApplePressAndHold()')
+    const callIndex = source.indexOf('disableApplePressAndHold()')
+    const windowIndex = source.indexOf('openMainWindow()')
+    expect(callIndex).toBeGreaterThanOrEqual(0)
+    expect(windowIndex).toBeGreaterThan(callIndex)
+  })
+})

--- a/src/main/startup/macos-press-and-hold.ts
+++ b/src/main/startup/macos-press-and-hold.ts
@@ -1,0 +1,13 @@
+import { systemPreferences } from 'electron'
+
+export const APPLE_PRESS_AND_HOLD_ENABLED_KEY = 'ApplePressAndHoldEnabled'
+
+export function disableApplePressAndHold(): void {
+  if (process.platform !== 'darwin') {
+    return
+  }
+  // Why: Chromium reads this from NSUserDefaults, not Info.plist. Writing the
+  // app-domain default is the shipped equivalent of
+  // `defaults write com.stablyai.orca ApplePressAndHoldEnabled -bool false` (#14746).
+  systemPreferences.setUserDefault(APPLE_PRESS_AND_HOLD_ENABLED_KEY, 'boolean', false)
+}


### PR DESCRIPTION
## Description
Held keys in the macOS terminal now repeat instead of opening the accent picker.
Ship `ApplePressAndHoldEnabled=false` for the Orca bundle and write the same default at startup.

## Focused fix
- In scope: disable press-and-hold for `com.stablyai.orca`.
- Out of scope: other keyboard shortcuts or IME behavior.

## Preserves
- Existing keybindings and input methods are unchanged.

## Evidence
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/main/startup/macos-press-and-hold.test.ts`
- 4 passed. Tests fail if the plist key or startup write is missing.

Fixes #14746
