### PR TITLE
fix(cli): report real exitCode from terminal wait --for exit

### DIFF
--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -498,6 +498,15 @@ describe('orca root help', () => {
     expect(terminalHelp).toContain(
       'orca terminal create --worktree active --command "codex" --json'
     )
+    expect(terminalHelp).toContain('prefix --command with exec')
+    expect(callMock).not.toHaveBeenCalled()
+
+    logSpy.mockClear()
+    await main(['terminal', 'wait', '--help'], '/tmp/repo')
+
+    expect(String(logSpy.mock.calls[0][0])).toContain(
+      'Prefix terminal create --command with exec so the command replaces the shell'
+    )
     expect(callMock).not.toHaveBeenCalled()
   })
 })

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -221,7 +221,10 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
     summary: 'Wait for a terminal condition',
     usage:
       'orca terminal wait [--terminal <handle>] --for exit|tui-idle [--timeout-ms <ms>] [--json]',
-    allowedFlags: [...GLOBAL_FLAGS, 'terminal', 'for', 'timeout-ms']
+    allowedFlags: [...GLOBAL_FLAGS, 'terminal', 'for', 'timeout-ms'],
+    notes: [
+      "--for exit tracks the pane process, not a foreground command that returns to the shell. Prefix terminal create --command with exec so the command replaces the shell and its exitCode is reported (e.g. exec zsh -c 'exit 42')."
+    ]
   },
   {
     path: ['terminal', 'stop'],
@@ -237,7 +240,8 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
     allowedFlags: [...GLOBAL_FLAGS, 'worktree', 'command', 'title', 'focus'],
     notes: [
       'Creates a visible terminal tab without switching focus when possible; falls back to a background handle if the UI cannot adopt it. Pass --focus to switch to it.',
-      'Use this, not worktree create, for a fresh agent in the current checkout.'
+      'Use this, not worktree create, for a fresh agent in the current checkout.',
+      "To use terminal wait --for exit, prefix --command with exec so the command replaces the pane shell (e.g. exec zsh -c 'exit 42')."
     ],
     examples: [
       'orca terminal create --json',

--- a/src/main/ipc/pty-login-shell-startup-commands.test.ts
+++ b/src/main/ipc/pty-login-shell-startup-commands.test.ts
@@ -86,7 +86,7 @@ describe('registerPtyHandlers', () => {
         '--norc',
         '-p',
         '-c',
-        'export SHELL="$1"; shift; exec -l -- "$@"',
+        'export SHELL="$1"; shift; command -- "$@"; code=$?; printf "\\033]777;orca-pane-exit:%s\\007" "$code"; exit "$code"',
         'orca-tcc-login',
         '/bin/zsh',
         '/bin/zsh',

--- a/src/main/providers/macos-tcc-login-shell.test.ts
+++ b/src/main/providers/macos-tcc-login-shell.test.ts
@@ -25,6 +25,7 @@ vi.mock('./macos-login-session-pty-probe', async (importOriginal) => ({
 }))
 
 import {
+  MACOS_TCC_SHELL_TRAMPOLINE,
   prepareMacosTccLoginShell,
   probeMacosLoginSessionAlive,
   resetMacosLoginShellPreflightForTests,
@@ -86,7 +87,7 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
         '--norc',
         '-p',
         '-c',
-        'export SHELL="$1"; shift; exec -l -- "$@"',
+        'export SHELL="$1"; shift; command -- "$@"; code=$?; printf "\\033]777;orca-pane-exit:%s\\007" "$code"; exit "$code"',
         'orca-tcc-login',
         '/bin/zsh',
         '/bin/zsh',
@@ -362,7 +363,7 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
         '--norc',
         '-p',
         '-c',
-        'export SHELL="$1"; shift; exec -- "$@"',
+        'export SHELL="$1"; shift; command -- "$@"; code=$?; printf "\\033]777;orca-pane-exit:%s\\007" "$code"; exit "$code"',
         'orca-tcc-login',
         '/bin/bash',
         '/bin/bash',
@@ -387,7 +388,7 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
         '--norc',
         '-p',
         '-c',
-        'export SHELL="$1"; shift; exec -l -- "$@"',
+        'export SHELL="$1"; shift; command -- "$@"; code=$?; printf "\\033]777;orca-pane-exit:%s\\007" "$code"; exit "$code"',
         'orca-tcc-login',
         '/opt/homebrew/bin/fish',
         '/bin/zsh',
@@ -409,7 +410,7 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
         '--norc',
         '-p',
         '-c',
-        'export SHELL="$1"; shift; exec -l -- "$@"',
+        'export SHELL="$1"; shift; command -- "$@"; code=$?; printf "\\033]777;orca-pane-exit:%s\\007" "$code"; exit "$code"',
         'orca-tcc-login',
         '/bin/zsh',
         '/bin/zsh',
@@ -437,7 +438,7 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
         '--norc',
         '-p',
         '-c',
-        'export SHELL="$1"; shift; exec -l -- "$@"',
+        'export SHELL="$1"; shift; command -- "$@"; code=$?; printf "\\033]777;orca-pane-exit:%s\\007" "$code"; exit "$code"',
         'orca-tcc-login',
         '/Applications/Custom Shell/bin/fish=debug',
         '/Applications/Custom Shell/bin/fish=debug',
@@ -447,13 +448,37 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
     })
   })
 
-  it('terminates exec option parsing before a dash-prefixed shell name', async () => {
+  it('terminates command option parsing before a dash-prefixed shell name', async () => {
     setPlatform('darwin')
     await prepareMacosTccLoginShell()
     const wrapped = wrapShellSpawnForMacosTccAttribution('-custom-shell', ['-l'])
 
-    expect(wrapped.args).toContain('export SHELL="$1"; shift; exec -l -- "$@"')
+    expect(wrapped.args).toContain(
+      'export SHELL="$1"; shift; command -- "$@"; code=$?; printf "\\033]777;orca-pane-exit:%s\\007" "$code"; exit "$code"'
+    )
     expect(wrapped.args.slice(-2)).toEqual(['-custom-shell', '-l'])
+  })
+
+  itOnPosixHost('reports a non-zero inner command status through the pane-exit OSC', () => {
+    const result = spawnSync(
+      '/bin/bash',
+      [
+        '--noprofile',
+        '--norc',
+        '-p',
+        '-c',
+        MACOS_TCC_SHELL_TRAMPOLINE,
+        'orca-tcc-login',
+        '/bin/sh',
+        '/bin/sh',
+        '-c',
+        'exit 42'
+      ],
+      { encoding: 'utf8' }
+    )
+
+    expect(result.status).toBe(42)
+    expect(result.stdout).toContain('\x1b]777;orca-pane-exit:42\x07')
   })
 
   itOnPosixHost('ignores inherited BASH_ENV before evaluating the trampoline', () => {

--- a/src/main/providers/macos-tcc-login-shell.ts
+++ b/src/main/providers/macos-tcc-login-shell.ts
@@ -1,7 +1,6 @@
 import { execFile } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { userInfo } from 'node:os'
-import { basename } from 'node:path'
 import {
   classifyLoginPreflightError,
   runMacosLoginSessionPtyProbe,
@@ -13,8 +12,12 @@ export type { LoginPreflightOutcome } from './macos-login-session-pty-probe'
 const MACOS_LOGIN_PATH = '/usr/bin/login'
 const MACOS_BASH_PATH = '/bin/bash'
 const MACOS_PRINTF_PATH = '/usr/bin/printf'
-const LOGIN_SHELL_TRAMPOLINE = 'export SHELL="$1"; shift; exec -l -- "$@"'
-const DIRECT_SHELL_TRAMPOLINE = 'export SHELL="$1"; shift; exec -- "$@"'
+// Why: login(1) always exits 0, so exec would drop the inner command status
+// that `terminal wait --for exit` reports. Stay the parent, emit the child's
+// code via OSC, then exit with that same code. `command --` keeps a
+// dash-prefixed shell path from being parsed as a builtin flag.
+export const MACOS_TCC_SHELL_TRAMPOLINE =
+  'export SHELL="$1"; shift; command -- "$@"; code=$?; printf "\\033]777;orca-pane-exit:%s\\007" "$code"; exit "$code"'
 const LOGIN_PREFLIGHT_TIMEOUT_MS = 500
 // Why: the death-watch probe runs off the spawn path, so it can afford a bound
 // that outlasts a PAM stack answering slowly rather than misreading it as a hang.
@@ -311,9 +314,10 @@ export async function probeMacosLoginSessionAlive(
  * CLIs like `op` otherwise re-prompt every launch because tccd attributes the grant
  * to Orca and never persists it (#6996, #8985).
  *
- * A clean bash trampoline restores SHELL after login(1) overwrites it, then replaces
- * itself with the configured shell. Values stay positional so custom paths and
- * arguments are never interpreted as shell source.
+ * A clean bash trampoline restores SHELL after login(1) overwrites it, then runs
+ * the configured shell as a child so the inner exit code can be reported. Values
+ * stay positional so custom paths and arguments are never interpreted as shell
+ * source.
  *
  * No-op off macOS, when already wrapped, when disabled via {@link DISABLE_ENV_VAR},
  * or when the login(1) PAM preflight rejects this process's user.
@@ -349,12 +353,6 @@ export function wrapShellSpawnForMacosTccAttribution(
   }
 
   const shellEnvValue = env?.SHELL || file
-  // Why: Bash ignores --rcfile when argv[0] marks it as a login shell; Orca's
-  // rcfile already reproduces login startup and must remain the active wrapper.
-  const trampoline =
-    basename(file).toLowerCase() === 'bash' && args.includes('--rcfile')
-      ? DIRECT_SHELL_TRAMPOLINE
-      : LOGIN_SHELL_TRAMPOLINE
 
   // Why: -p blocks login(1)-preserved BASH_ENV and imported functions before the fixed trampoline runs.
   return {
@@ -367,7 +365,7 @@ export function wrapShellSpawnForMacosTccAttribution(
       '--norc',
       '-p',
       '-c',
-      trampoline,
+      MACOS_TCC_SHELL_TRAMPOLINE,
       'orca-tcc-login',
       shellEnvValue,
       file,

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -15733,6 +15733,31 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
+  it('does not treat a malformed pane-exit marker as a command status', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, { tabs: [], leaves: [] })
+    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+
+    const waiting = runtime.waitForTerminal(handle, { condition: 'exit', timeoutMs: 1000 })
+    runtime.onPtyData('pty-bg', '\x1b]777;orca-pane-exit:42junk\x07', 100)
+    runtime.onPtyExit('pty-bg', 0)
+
+    await expect(waiting).resolves.toMatchObject({
+      handle,
+      condition: 'exit',
+      satisfied: true,
+      status: 'exited',
+      exitCode: 0
+    })
+  })
+
   it('observes setup command completion without waiting for its interactive shell to exit', async () => {
     const runtime = new OrcaRuntimeService(store)
     runtime.setPtyController({

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -15708,6 +15708,31 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
+  it('reports the trampoline pane-exit status when login(1) exits 0', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, { tabs: [], leaves: [] })
+    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+
+    const waiting = runtime.waitForTerminal(handle, { condition: 'exit', timeoutMs: 1000 })
+    runtime.onPtyData('pty-bg', '\x1b]777;orca-pane-exit:42\x07', 100)
+    runtime.onPtyExit('pty-bg', 0)
+
+    await expect(waiting).resolves.toMatchObject({
+      handle,
+      condition: 'exit',
+      satisfied: true,
+      status: 'exited',
+      exitCode: 42
+    })
+  })
+
   it('observes setup command completion without waiting for its interactive shell to exit', async () => {
     const runtime = new OrcaRuntimeService(store)
     runtime.setPtyController({

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -9919,6 +9919,13 @@ export class OrcaRuntimeService {
       this.paneExitScanStateByPtyId.set(ptyId, createPaneExitScanState()).get(ptyId)
     if (paneExitScan) {
       const scanned = scanPaneExitMarker(paneExitScan, data)
+      if (scanned.output.length !== data.length) {
+        // Why: stripped marker bytes must not keep the longer rawLength/sourceRanges.
+        sourceRanges = undefined
+        if (!transformed) {
+          sequenceChars = scanned.output.length
+        }
+      }
       data = scanned.output
       if (scanned.exitCode !== null) {
         this.lastReportedPaneExitCodeByPtyId.set(ptyId, scanned.exitCode)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -17,6 +17,12 @@ import { sortDirEntries } from '../../shared/file-name-sort'
 import { isServerDriveListRequest, listWindowsDrives } from './windows-drive-listing'
 import { extractLastOsc7Uri, extractOscScanTail } from '../daemon/osc7-uri-extraction'
 import { parseFileUriPathParts } from '../daemon/osc7-file-uri'
+import {
+  createPaneExitScanState,
+  resolvePaneProcessExitCode,
+  scanPaneExitMarker,
+  type PaneExitScanState
+} from '../shell-pane-exit-scanner'
 import type { AgentStatus } from '../../shared/agent-detection'
 import type { TerminalOscLinkRange } from '../../shared/terminal-osc-link-ranges'
 import type { TerminalOscColorQueryReplyColors } from '../../shared/terminal-osc-color-reply'
@@ -2912,6 +2918,9 @@ export class OrcaRuntimeService {
   private detachedPreAllocatedLeaves = new Map<string, RuntimeLeafRecord>()
   private graphSyncCallbacks: (() => void)[] = []
   private waitersByHandle = new Map<string, Set<TerminalWaiter>>()
+  // Why: macOS login(1) exits 0; the TCC trampoline publishes the inner status here.
+  private lastReportedPaneExitCodeByPtyId = new Map<string, number>()
+  private paneExitScanStateByPtyId = new Map<string, PaneExitScanState>()
   private ptyController: RuntimePtyController | null = null
   private notifier: RuntimeNotifier | null = null
   private clientEventListeners = new Set<(event: RuntimeClientEvent) => void>()
@@ -9662,10 +9671,14 @@ export class OrcaRuntimeService {
       }
       pty.connected = true
       pty.disconnectedAt = null
+      pty.lastExitCode = null
     }
+    this.lastReportedPaneExitCodeByPtyId.delete(ptyId)
+    this.paneExitScanStateByPtyId.delete(ptyId)
     for (const leaf of this.getLeavesForPty(ptyId)) {
       leaf.connected = true
       leaf.writable = this.graphStatus === 'ready'
+      leaf.lastExitCode = null
       this.adoptPreAllocatedHandle(leaf)
     }
   }
@@ -9901,6 +9914,16 @@ export class OrcaRuntimeService {
     captureModelReceipt?: (completion: Promise<void>) => void,
     sourceRanges?: readonly TerminalOutputSourceRange[]
   ): number {
+    const paneExitScan =
+      this.paneExitScanStateByPtyId.get(ptyId) ??
+      this.paneExitScanStateByPtyId.set(ptyId, createPaneExitScanState()).get(ptyId)
+    if (paneExitScan) {
+      const scanned = scanPaneExitMarker(paneExitScan, data)
+      data = scanned.output
+      if (scanned.exitCode !== null) {
+        this.lastReportedPaneExitCodeByPtyId.set(ptyId, scanned.exitCode)
+      }
+    }
     const outputSequence = (this.ptyOutputSequenceById.get(ptyId) ?? 0) + sequenceChars
     this.ptyOutputSequenceById.set(ptyId, outputSequence)
     this.providerModeTrackersByPtyId.get(ptyId)?.scan(data)
@@ -14028,12 +14051,18 @@ export class OrcaRuntimeService {
     this.remoteDesktopViewerRevisions.delete(ptyId)
     this.disposeHeadlessTerminal(ptyId)
     this.agentDetector?.onExit(ptyId)
+    const resolvedExitCode = resolvePaneProcessExitCode(
+      exitCode,
+      this.lastReportedPaneExitCodeByPtyId.get(ptyId) ?? null
+    )
+    this.lastReportedPaneExitCodeByPtyId.delete(ptyId)
+    this.paneExitScanStateByPtyId.delete(ptyId)
     if (pty) {
       pty.connected = false
       pty.runtimeSessionOwned = false
       this.setPairedRendererSessionOwnership(pty.ptyId, false)
       pty.disconnectedAt = Date.now()
-      pty.lastExitCode = exitCode
+      pty.lastExitCode = resolvedExitCode
       // Why: the exited process's live frames say nothing about a replacement.
       // A same-id respawn makes the leaf writable again before any new title,
       // so leaving this true would let push delivery type into the new process
@@ -14055,11 +14084,11 @@ export class OrcaRuntimeService {
       this.detachedPreAllocatedLeaves.delete(ptyId)
       leaf.connected = false
       leaf.writable = false
-      leaf.lastExitCode = exitCode
+      leaf.lastExitCode = resolvedExitCode
       leaf.lastAgentStatusObservedLive = false
       this.resolveExitWaiters(leaf)
       if (!preservesAbnormalSshSurface) {
-        this.failActiveDispatchOnExit(leaf, exitCode)
+        this.failActiveDispatchOnExit(leaf, resolvedExitCode)
       }
     }
     this.pruneDisconnectedPtyRecords()

--- a/src/main/shell-pane-exit-scanner.test.ts
+++ b/src/main/shell-pane-exit-scanner.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createPaneExitScanState,
+  PANE_EXIT_MARKER_PREFIX,
+  resolvePaneProcessExitCode,
+  scanPaneExitMarker
+} from './shell-pane-exit-scanner'
+
+describe('resolvePaneProcessExitCode', () => {
+  it('does not report exit 42 as 0 when the trampoline published 42', () => {
+    expect(resolvePaneProcessExitCode(0, 42)).toBe(42)
+  })
+
+  it('keeps a direct non-zero process status', () => {
+    expect(resolvePaneProcessExitCode(42, null)).toBe(42)
+  })
+
+  it('keeps an abnormal negative process status over a reported code', () => {
+    expect(resolvePaneProcessExitCode(-1, 42)).toBe(-1)
+  })
+
+  it('reports 0 when neither source has a non-zero status', () => {
+    expect(resolvePaneProcessExitCode(0, null)).toBe(0)
+    expect(resolvePaneProcessExitCode(0, 0)).toBe(0)
+  })
+})
+
+describe('scanPaneExitMarker', () => {
+  it('extracts the last complete pane-exit marker and strips it from output', () => {
+    const state = createPaneExitScanState()
+    expect(scanPaneExitMarker(state, `before${PANE_EXIT_MARKER_PREFIX}7\x07after`)).toEqual({
+      output: 'beforeafter',
+      exitCode: 7
+    })
+    expect(
+      scanPaneExitMarker(state, `${PANE_EXIT_MARKER_PREFIX}1\x07${PANE_EXIT_MARKER_PREFIX}42\x07`)
+    ).toEqual({
+      output: '',
+      exitCode: 42
+    })
+  })
+
+  it('reassembles a marker split across PTY chunks', () => {
+    const state = createPaneExitScanState()
+    expect(scanPaneExitMarker(state, `pre${PANE_EXIT_MARKER_PREFIX}4`)).toEqual({
+      output: 'pre',
+      exitCode: null
+    })
+    expect(scanPaneExitMarker(state, '2\x07post')).toEqual({
+      output: 'post',
+      exitCode: 42
+    })
+  })
+})

--- a/src/main/shell-pane-exit-scanner.test.ts
+++ b/src/main/shell-pane-exit-scanner.test.ts
@@ -51,4 +51,13 @@ describe('scanPaneExitMarker', () => {
       exitCode: 42
     })
   })
+
+  it('does not treat a numeric prefix as a pane-exit status', () => {
+    const state = createPaneExitScanState()
+    expect(scanPaneExitMarker(state, `${PANE_EXIT_MARKER_PREFIX}42junk\x07keep`)).toEqual({
+      output: 'keep',
+      exitCode: null
+    })
+    expect(resolvePaneProcessExitCode(0, null)).toBe(0)
+  })
 })

--- a/src/main/shell-pane-exit-scanner.ts
+++ b/src/main/shell-pane-exit-scanner.ts
@@ -1,0 +1,82 @@
+/**
+ * Chunk-boundary-safe OSC 777 orca-pane-exit scanner.
+ *
+ * Why: macOS login(1) always exits 0, so the TCC trampoline reports the inner
+ * pane process status through this marker for `terminal wait --for exit`.
+ */
+
+export const PANE_EXIT_MARKER_PREFIX = '\x1b]777;orca-pane-exit:'
+
+export type PaneExitScanState = {
+  carry: string
+}
+
+export type PaneExitScanResult = {
+  output: string
+  exitCode: number | null
+}
+
+const MAX_PANE_EXIT_CARRY_LENGTH = PANE_EXIT_MARKER_PREFIX.length + 20
+
+export function createPaneExitScanState(): PaneExitScanState {
+  return { carry: '' }
+}
+
+export function resolvePaneProcessExitCode(
+  processExitCode: number,
+  reportedPaneExitCode: number | null
+): number {
+  // Why: login(1) exits 0 after a successful session even when the inner
+  // exec'd command exited non-zero. Prefer the trampoline-reported code.
+  if (processExitCode === 0 && reportedPaneExitCode !== null) {
+    return reportedPaneExitCode
+  }
+  return processExitCode
+}
+
+export function scanPaneExitMarker(state: PaneExitScanState, data: string): PaneExitScanResult {
+  let combined = state.carry + data
+  state.carry = ''
+  let output = ''
+  let exitCode: number | null = null
+
+  while (combined.length > 0) {
+    const start = combined.indexOf(PANE_EXIT_MARKER_PREFIX[0] as string)
+    if (start === -1) {
+      output += combined
+      break
+    }
+    output += combined.slice(0, start)
+    const candidate = combined.slice(start)
+    if (candidate.length < PANE_EXIT_MARKER_PREFIX.length) {
+      if (PANE_EXIT_MARKER_PREFIX.startsWith(candidate)) {
+        state.carry = candidate
+        break
+      }
+      output += candidate[0]
+      combined = candidate.slice(1)
+      continue
+    }
+    if (!candidate.startsWith(PANE_EXIT_MARKER_PREFIX)) {
+      output += candidate[0]
+      combined = candidate.slice(1)
+      continue
+    }
+    const suffix = candidate.slice(PANE_EXIT_MARKER_PREFIX.length)
+    const terminator = suffix.indexOf('\x07')
+    if (terminator === -1) {
+      state.carry =
+        candidate.length > MAX_PANE_EXIT_CARRY_LENGTH
+          ? candidate.slice(candidate.length - MAX_PANE_EXIT_CARRY_LENGTH)
+          : candidate
+      break
+    }
+    const parsed = Number.parseInt(suffix.slice(0, terminator), 10)
+    if (Number.isSafeInteger(parsed)) {
+      exitCode = parsed
+    }
+    combined = suffix.slice(terminator + 1)
+  }
+
+  return { output, exitCode }
+}

--- a/src/main/shell-pane-exit-scanner.ts
+++ b/src/main/shell-pane-exit-scanner.ts
@@ -71,9 +71,13 @@ export function scanPaneExitMarker(state: PaneExitScanState, data: string): Pane
           : candidate
       break
     }
-    const parsed = Number.parseInt(suffix.slice(0, terminator), 10)
-    if (Number.isSafeInteger(parsed)) {
-      exitCode = parsed
+    const payload = suffix.slice(0, terminator)
+    // Why: parseInt("42junk") is 42; only a complete integer is a pane status.
+    if (/^-?\d+$/.test(payload)) {
+      const parsed = Number.parseInt(payload, 10)
+      if (Number.isSafeInteger(parsed)) {
+        exitCode = parsed
+      }
     }
     combined = suffix.slice(terminator + 1)
   }


### PR DESCRIPTION
## Description
`orca terminal wait --for exit` now reports the command's real exit code instead of always `0`.
Help text notes that `--command` needs `exec` so wait tracks the pane process.

## Focused fix
- In scope: plumb the real pane exit code; document the exec requirement.
- Out of scope: changing when `--for exit` fires for a non-exec shell.

## Preserves
- Non-exec `--command` panes still wait on the shell process, not the child.

## Evidence
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/main/shell-pane-exit-scanner.test.ts src/main/providers/macos-tcc-login-shell.test.ts src/cli/index.test.ts`
- Scanner resolves `resolvePaneProcessExitCode(0, 42) === 42`.

Fixes #14739
