### PR TITLE
fix(settings): use Workspace Directory for Create project default path

### DIFF
--- a/src/main/ipc/repos-create.test.ts
+++ b/src/main/ipc/repos-create.test.ts
@@ -33,7 +33,8 @@ const {
     addRepo: vi.fn(),
     removeProject: vi.fn(),
     getRepo: vi.fn(),
-    updateRepo: vi.fn()
+    updateRepo: vi.fn(),
+    getSettings: vi.fn().mockReturnValue({})
   },
   mkdirMock: vi.fn(),
   accessMock: vi.fn(),
@@ -132,6 +133,7 @@ describe('repos:create', () => {
     removeHandlerMock.mockReset()
     mockStore.getRepos.mockReset().mockReturnValue([])
     mockStore.addRepo.mockReset()
+    mockStore.getSettings.mockReset().mockReturnValue({})
     mockWindow.webContents.send.mockReset()
     invalidateAuthorizedRootsCacheMock.mockReset()
     prepareLocalWorktreeRootForRepoMock.mockReset().mockResolvedValue(undefined)
@@ -153,6 +155,21 @@ describe('repos:create', () => {
 
   it('registers the home-backed create-project default handler', async () => {
     expect(handlers.has('repos:getDefaultCreateProjectParent')).toBe(true)
+    await expect(callDefaultCreateProjectParent()).resolves.toBe(defaultProjectParent)
+  })
+
+  it('uses the configured workspace directory as the create-project default parent', async () => {
+    mockStore.getSettings.mockReturnValue({ workspaceDir: 'J:\\PROJECTS' })
+    await expect(callDefaultCreateProjectParent()).resolves.toBe('J:\\PROJECTS')
+  })
+
+  it('falls back to the home projects directory when workspace directory is unset', async () => {
+    mockStore.getSettings.mockReturnValue({ workspaceDir: '' })
+    await expect(callDefaultCreateProjectParent()).resolves.toBe(defaultProjectParent)
+  })
+
+  it('falls back to the home projects directory when workspace directory is whitespace', async () => {
+    mockStore.getSettings.mockReturnValue({ workspaceDir: '   ' })
     await expect(callDefaultCreateProjectParent()).resolves.toBe(defaultProjectParent)
   })
 

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -1106,7 +1106,12 @@ async function isGitAvailable(): Promise<boolean> {
   }
 }
 
-function getDefaultCreateProjectParent(): string {
+function getDefaultCreateProjectParent(store: Store): string {
+  const workspaceDir = store.getSettings().workspaceDir?.trim()
+  // Why: Settings → Workspace Directory is the user-facing root; keep ~/orca/projects only when that setting is empty.
+  if (workspaceDir) {
+    return workspaceDir
+  }
   return join(homedir(), 'orca', 'projects')
 }
 
@@ -1482,7 +1487,7 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
   )
 
   ipcMain.handle('repos:isGitAvailable', () => isGitAvailable())
-  ipcMain.handle('repos:getDefaultCreateProjectParent', () => getDefaultCreateProjectParent())
+  ipcMain.handle('repos:getDefaultCreateProjectParent', () => getDefaultCreateProjectParent(store))
 
   ipcMain.handle('projectGroups:list', () => store.getProjectGroups())
 

--- a/src/renderer/src/components/sidebar/create-project-defaults.test.ts
+++ b/src/renderer/src/components/sidebar/create-project-defaults.test.ts
@@ -81,6 +81,18 @@ describe('create project defaults', () => {
     ).toBe('~/orca/projects')
     expect(
       formatCreateProjectParentSummary({
+        parent: 'J:\\PROJECTS',
+        defaultParent: 'J:\\PROJECTS'
+      })
+    ).toBe('J:\\PROJECTS')
+    expect(
+      formatCreateProjectParentSummary({
+        parent: '/Users/alice/orca/workspaces',
+        defaultParent: '/Users/alice/orca/workspaces'
+      })
+    ).toBe('/Users/alice/orca/workspaces')
+    expect(
+      formatCreateProjectParentSummary({
         parent: '',
         defaultParent: '',
         runtimeEnvironmentId: 'env-1'

--- a/src/renderer/src/components/sidebar/create-project-defaults.ts
+++ b/src/renderer/src/components/sidebar/create-project-defaults.ts
@@ -4,6 +4,10 @@ function pathSeparatorFor(pathValue: string): '/' | '\\' {
   return pathValue.includes('\\') ? '\\' : '/'
 }
 
+function isClassicHomeCreateProjectParent(pathValue: string): boolean {
+  return /(?:^|[\\/])orca[\\/]projects$/.test(pathValue)
+}
+
 function trimTrailingSeparators(pathValue: string): string {
   const trimmed = pathValue.replace(/[\\/]+$/, '')
   if (trimmed === '' && pathValue.startsWith('/')) {
@@ -81,7 +85,13 @@ export function formatCreateProjectParentSummary({
   if (!trimmedParent) {
     return runtimeEnvironmentId || isRemoteHost ? missingServerLocationLabel : missingLocationLabel
   }
-  if (defaultParent && trimmedParent === defaultParent && !runtimeEnvironmentId && !isRemoteHost) {
+  if (
+    defaultParent &&
+    trimmedParent === defaultParent &&
+    !runtimeEnvironmentId &&
+    !isRemoteHost &&
+    isClassicHomeCreateProjectParent(trimmedParent)
+  ) {
     return '~/orca/projects'
   }
   return trimmedParent

--- a/src/renderer/src/components/sidebar/useCreateProjectDefaults.test.ts
+++ b/src/renderer/src/components/sidebar/useCreateProjectDefaults.test.ts
@@ -104,15 +104,16 @@ describe('useCreateProjectDefaults', () => {
     expect(mocks.callRuntimeRpc).not.toHaveBeenCalled()
   })
 
-  it('auto-fills the local home default regardless of workspace directory settings', async () => {
+  it('auto-fills the parent returned by the local default-parent API', async () => {
+    mocks.getDefaultCreateProjectParent.mockResolvedValue('J:\\PROJECTS')
     mocks.isGitAvailable.mockResolvedValue(true)
 
     const { setCreateParent } = useHarness()
     await flushAsync()
 
     expect(mocks.getDefaultCreateProjectParent).toHaveBeenCalled()
-    expect(setCreateParent).toHaveBeenCalledWith('/Users/alice/orca/projects')
-    expect(mocks.stateValues[DEFAULT_PARENT_STATE]).toBe('/Users/alice/orca/projects')
+    expect(setCreateParent).toHaveBeenCalledWith('J:\\PROJECTS')
+    expect(mocks.stateValues[DEFAULT_PARENT_STATE]).toBe('J:\\PROJECTS')
   })
 
   it('keeps the local default marker after the auto-filled parent rerenders the hook', async () => {


### PR DESCRIPTION
## Description
Create new project now defaults Location to Settings → Workspace Directory.
The old `~/orca/projects` path remains only when that setting is unset.

## Focused fix
- In scope: default parent for Create project.
- Out of scope: worktree-create paths that already honor the setting.

## Preserves
- Unset/blank setting still uses `join(homedir(), "orca", "projects")`.

## Evidence
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/repos-create.test.ts src/renderer/src/components/sidebar/create-project-defaults.test.ts`

Fixes #14767
