### PR TITLE
docs: warn that bare brew cask orca is Plotly, not Orca ADE

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,9 @@ _Or via a package manager:_
 
 ```bash
 # macOS (Homebrew)
+# Always use the fully-qualified token. Bare `orca` is Plotly's deprecated cask, not Orca ADE.
 brew install --cask stablyai/orca/orca
+brew upgrade --cask stablyai/orca/orca
 
 # Arch Linux (AUR) — or stably-orca-git to build from source
 yay -S stably-orca-bin

--- a/docs/readme/README.es.md
+++ b/docs/readme/README.es.md
@@ -216,7 +216,9 @@ _O mediante un gestor de paquetes:_
 
 ```bash
 # macOS (Homebrew)
+# Always use the fully-qualified token. Bare `orca` is Plotly's deprecated cask, not Orca ADE.
 brew install --cask stablyai/orca/orca
+brew upgrade --cask stablyai/orca/orca
 
 # Arch Linux (AUR) — or stably-orca-git to build from source
 yay -S stably-orca-bin

--- a/docs/readme/README.es.md
+++ b/docs/readme/README.es.md
@@ -216,7 +216,7 @@ _O mediante un gestor de paquetes:_
 
 ```bash
 # macOS (Homebrew)
-# Always use the fully-qualified token. Bare `orca` is Plotly's deprecated cask, not Orca ADE.
+# Usa siempre el token completo. El `orca` suelto es el cask obsoleto de Plotly, no Orca ADE.
 brew install --cask stablyai/orca/orca
 brew upgrade --cask stablyai/orca/orca
 

--- a/docs/readme/README.fr.md
+++ b/docs/readme/README.fr.md
@@ -224,7 +224,7 @@ _Ou via un gestionnaire de paquets :_
 
 ```bash
 # macOS (Homebrew)
-# Always use the fully-qualified token. Bare `orca` is Plotly's deprecated cask, not Orca ADE.
+# Utilisez toujours le jeton pleinement qualifie. Le `orca` nu est le cask deprecie de Plotly, pas Orca ADE.
 brew install --cask stablyai/orca/orca
 brew upgrade --cask stablyai/orca/orca
 

--- a/docs/readme/README.fr.md
+++ b/docs/readme/README.fr.md
@@ -224,7 +224,9 @@ _Ou via un gestionnaire de paquets :_
 
 ```bash
 # macOS (Homebrew)
+# Always use the fully-qualified token. Bare `orca` is Plotly's deprecated cask, not Orca ADE.
 brew install --cask stablyai/orca/orca
+brew upgrade --cask stablyai/orca/orca
 
 # Arch Linux (AUR) — ou stably-orca-git pour compiler depuis les sources
 yay -S stably-orca-bin

--- a/docs/readme/README.ja.md
+++ b/docs/readme/README.ja.md
@@ -216,7 +216,7 @@ _パッケージマネージャーからもインストールできます:_
 
 ```bash
 # macOS (Homebrew)
-# Always use the fully-qualified token. Bare `orca` is Plotly's deprecated cask, not Orca ADE.
+# 必ず完全修飾トークンを使ってください。裸の `orca` は非推奨の Plotly cask であり、Orca ADE ではありません。
 brew install --cask stablyai/orca/orca
 brew upgrade --cask stablyai/orca/orca
 

--- a/docs/readme/README.ja.md
+++ b/docs/readme/README.ja.md
@@ -216,7 +216,9 @@ _パッケージマネージャーからもインストールできます:_
 
 ```bash
 # macOS (Homebrew)
+# Always use the fully-qualified token. Bare `orca` is Plotly's deprecated cask, not Orca ADE.
 brew install --cask stablyai/orca/orca
+brew upgrade --cask stablyai/orca/orca
 
 # Arch Linux (AUR) — or stably-orca-git to build from source
 yay -S stably-orca-bin

--- a/docs/readme/README.ko.md
+++ b/docs/readme/README.ko.md
@@ -219,7 +219,9 @@ _또는 패키지 매니저로 설치:_
 
 ```bash
 # macOS (Homebrew)
+# Always use the fully-qualified token. Bare `orca` is Plotly's deprecated cask, not Orca ADE.
 brew install --cask stablyai/orca/orca
+brew upgrade --cask stablyai/orca/orca
 
 # Arch Linux (AUR) — or stably-orca-git to build from source
 yay -S stably-orca-bin

--- a/docs/readme/README.ko.md
+++ b/docs/readme/README.ko.md
@@ -219,7 +219,7 @@ _또는 패키지 매니저로 설치:_
 
 ```bash
 # macOS (Homebrew)
-# Always use the fully-qualified token. Bare `orca` is Plotly's deprecated cask, not Orca ADE.
+# 항상 전체 토큰을 쓰세요. 그냥 `orca` 는 지원 종료된 Plotly cask 이고 Orca ADE 가 아닙니다.
 brew install --cask stablyai/orca/orca
 brew upgrade --cask stablyai/orca/orca
 

--- a/docs/readme/README.pt.md
+++ b/docs/readme/README.pt.md
@@ -219,7 +219,9 @@ _Ou por um gerenciador de pacotes:_
 
 ```bash
 # macOS (Homebrew)
+# Always use the fully-qualified token. Bare `orca` is Plotly's deprecated cask, not Orca ADE.
 brew install --cask stablyai/orca/orca
+brew upgrade --cask stablyai/orca/orca
 
 # Arch Linux (AUR) — ou stably-orca-git para compilar a partir do código-fonte
 yay -S stably-orca-bin

--- a/docs/readme/README.pt.md
+++ b/docs/readme/README.pt.md
@@ -219,7 +219,7 @@ _Ou por um gerenciador de pacotes:_
 
 ```bash
 # macOS (Homebrew)
-# Always use the fully-qualified token. Bare `orca` is Plotly's deprecated cask, not Orca ADE.
+# Use sempre o token totalmente qualificado. O `orca` sem prefixo e o cask descontinuado do Plotly, nao o Orca ADE.
 brew install --cask stablyai/orca/orca
 brew upgrade --cask stablyai/orca/orca
 

--- a/docs/readme/README.zh-CN.md
+++ b/docs/readme/README.zh-CN.md
@@ -216,7 +216,7 @@ _也可以通过包管理器安装：_
 
 ```bash
 # macOS (Homebrew)
-# Always use the fully-qualified token. Bare `orca` is Plotly's deprecated cask, not Orca ADE.
+# 请始终使用完整 token。单独的 `orca` 是已弃用的 Plotly cask，不是 Orca ADE。
 brew install --cask stablyai/orca/orca
 brew upgrade --cask stablyai/orca/orca
 

--- a/docs/readme/README.zh-CN.md
+++ b/docs/readme/README.zh-CN.md
@@ -216,7 +216,9 @@ _也可以通过包管理器安装：_
 
 ```bash
 # macOS (Homebrew)
+# Always use the fully-qualified token. Bare `orca` is Plotly's deprecated cask, not Orca ADE.
 brew install --cask stablyai/orca/orca
+brew upgrade --cask stablyai/orca/orca
 
 # Arch Linux (AUR) — or stably-orca-git to build from source
 yay -S stably-orca-bin


### PR DESCRIPTION
## Description
Install docs now tell users to use the fully qualified Homebrew token `stablyai/orca/orca`.
Bare `brew upgrade --cask orca` installs deprecated Plotly Orca.

## Focused fix
- In scope: README and localized README install blocks.
- Out of scope: renaming the Homebrew tap.

## Preserves
- Install commands still install Orca ADE when the qualified token is used.

## Evidence
- Docs-only. No tap or product-code change.

Fixes #14591
