### PR TITLE
fix(tasks): remember last GitHub Start vs Open-in-browser choice

### DIFF
--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -142,6 +142,7 @@ import {
 } from '../shared/constants'
 import { parseWorkspaceSessionSalvaging } from '../shared/workspace-session-salvage'
 import { normalizeUsagePercentageDisplay } from '../shared/usage-percentage-display'
+import { normalizeGitHubTaskPrimaryAction } from '../shared/github-task-primary-action'
 import { normalizeStatusBarUsageMode } from '../shared/status-bar-usage-mode'
 import {
   normalizeCustomWorktreeVisibilitySources,
@@ -6277,6 +6278,9 @@ export class Store {
       featureTipsSeenIds: normalizeFeatureTipIds(this.state.ui?.featureTipsSeenIds),
       contextualToursSeenIds: normalizeContextualTourIds(this.state.ui?.contextualToursSeenIds),
       featureInteractions: normalizeFeatureInteractions(this.state.ui?.featureInteractions),
+      githubTaskPrimaryAction: normalizeGitHubTaskPrimaryAction(
+        this.state.ui?.githubTaskPrimaryAction
+      ),
       activeView: this.activeViewPreference.get()
     }
   }

--- a/src/main/runtime/rpc/methods/client-ui-schemas.ts
+++ b/src/main/runtime/rpc/methods/client-ui-schemas.ts
@@ -284,6 +284,7 @@ const UiUpdateFields = z
     sidekickId: z.string().optional(),
     customSidekicks: UnknownRecordArray.optional(),
     sidekickSize: z.number().finite().optional(),
+    githubTaskPrimaryAction: z.enum(['start', 'open-in-browser']).optional(),
     taskResumeState: TaskResumeState.optional(),
     workspaceCleanup: WorkspaceCleanup.optional(),
     featureTipsSeenIds: FeatureTipIds.optional(),

--- a/src/main/runtime/rpc/methods/client-ui.test.ts
+++ b/src/main/runtime/rpc/methods/client-ui.test.ts
@@ -594,7 +594,8 @@ describe('client UI RPC methods', () => {
     ['browserImportHintHidden', { browserImportHintHidden: true }],
     ['mobileEmulatorTabIntroDismissed', { mobileEmulatorTabIntroDismissed: true }],
     ['mobileEmulatorAgentSetupDismissed', { mobileEmulatorAgentSetupDismissed: true }],
-    ['alwaysShowDefaultBranchWorkspace', { alwaysShowDefaultBranchWorkspace: false }]
+    ['alwaysShowDefaultBranchWorkspace', { alwaysShowDefaultBranchWorkspace: false }],
+    ['githubTaskPrimaryAction', { githubTaskPrimaryAction: 'open-in-browser' }]
   ])('accepts %s, which the renderer persists through ui.set', async (_label, payload) => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -15,7 +15,6 @@ import {
   CircleDot,
   Clock3,
   Copy,
-  EllipsisVertical,
   ExternalLink,
   Eye,
   Files,
@@ -49,6 +48,7 @@ import {
   parseExecutionHostId,
   getRepoExecutionHostId
 } from '../../../shared/execution-host'
+import { resolveGitHubTaskSplitActions } from '../../../shared/github-task-primary-action'
 import { Button } from '@/components/ui/button'
 import { ButtonGroup } from '@/components/ui/button-group'
 import { Input } from '@/components/ui/input'
@@ -2992,6 +2992,9 @@ export default function TaskPage(): React.JSX.Element {
   const persistedUIReady = useAppStore((s) => s.persistedUIReady)
   const taskResumeState = useAppStore((s) => s.taskResumeState)
   const setTaskResumeState = useAppStore((s) => s.setTaskResumeState)
+  const githubTaskPrimaryAction = useAppStore((s) => s.githubTaskPrimaryAction)
+  const setGitHubTaskPrimaryAction = useAppStore((s) => s.setGitHubTaskPrimaryAction)
+  const githubTaskSplitActions = resolveGitHubTaskSplitActions(githubTaskPrimaryAction)
   const pageData = useAppStore((s) => s.taskPageData)
   const openTaskPage = useAppStore((s) => s.openTaskPage)
   const closeTaskPage = useAppStore((s) => s.closeTaskPage)
@@ -10476,144 +10479,146 @@ export default function TaskPage(): React.JSX.Element {
                           </Tooltip>
 
                           <div className="flex items-center justify-start gap-1 lg:justify-end">
-                            {item.type === 'pr' ? (
-                              <DropdownMenu modal={false}>
-                                <ButtonGroup>
+                            <DropdownMenu modal={false}>
+                              <ButtonGroup>
+                                <Button
+                                  type="button"
+                                  // Why: Open/Resume an existing workspace — solid primary reads stronger than outline Start (new workspace).
+                                  variant={attachedWorkspace ? 'default' : 'outline'}
+                                  size="xs"
+                                  data-contextual-tour-target="tasks-start-workspace"
+                                  onClick={(event) => {
+                                    event.stopPropagation()
+                                    if (githubTaskSplitActions.primary === 'open-in-browser') {
+                                      setGitHubTaskPrimaryAction('open-in-browser')
+                                      window.api.shell.openUrl(item.url)
+                                      return
+                                    }
+                                    setGitHubTaskPrimaryAction('start')
+                                    handleOpenOrUseGitHubWorkItem(item)
+                                  }}
+                                  className={cn(
+                                    'min-w-[72px] gap-1 font-semibold',
+                                    attachedWorkspace ? 'shadow-xs' : 'bg-background/80'
+                                  )}
+                                  aria-label={
+                                    githubTaskSplitActions.primary === 'open-in-browser'
+                                      ? translate(
+                                          'auto.components.TaskPage.c1d1600362',
+                                          'Open in browser'
+                                        )
+                                      : item.type === 'pr'
+                                        ? attachedWorkspace
+                                          ? translate(
+                                              'auto.components.TaskPage.67d881244c',
+                                              'Resume workspace attached to PR'
+                                            )
+                                          : translate(
+                                              'auto.components.TaskPage.e4b29c5bcf',
+                                              'Start workspace from PR'
+                                            )
+                                        : attachedWorkspace
+                                          ? translate(
+                                              'auto.components.TaskPage.2193a99ec1',
+                                              'Open workspace attached to issue'
+                                            )
+                                          : translate(
+                                              'auto.components.TaskPage.e104fa3d3d',
+                                              'Start workspace from issue'
+                                            )
+                                  }
+                                >
+                                  {githubTaskSplitActions.primary === 'open-in-browser' ? (
+                                    <>
+                                      {translate(
+                                        'auto.components.TaskPage.c1d1600362',
+                                        'Open in browser'
+                                      )}
+                                      <ExternalLink className="size-3" />
+                                    </>
+                                  ) : (
+                                    <>
+                                      {item.type === 'pr'
+                                        ? attachedWorkspace
+                                          ? translate(
+                                              'auto.components.TaskPage.7753652524',
+                                              'Resume'
+                                            )
+                                          : translate(
+                                              'auto.components.TaskPage.7d08e8be0f',
+                                              'Start'
+                                            )
+                                        : attachedWorkspace
+                                          ? translate('auto.components.TaskPage.606a85c774', 'Open')
+                                          : translate(
+                                              'auto.components.TaskPage.7d08e8be0f',
+                                              'Start'
+                                            )}
+                                      <ArrowRight className="size-3" />
+                                    </>
+                                  )}
+                                </Button>
+                                <DropdownMenuTrigger asChild>
                                   <Button
                                     type="button"
                                     variant={attachedWorkspace ? 'default' : 'outline'}
-                                    size="xs"
-                                    data-contextual-tour-target="tasks-start-workspace"
-                                    onClick={(event) => {
-                                      event.stopPropagation()
-                                      handleOpenOrUseGitHubWorkItem(item)
-                                    }}
+                                    size="icon-xs"
+                                    onClick={(event) => event.stopPropagation()}
                                     className={cn(
-                                      'min-w-[72px] gap-1 font-semibold',
                                       attachedWorkspace ? 'shadow-xs' : 'bg-background/80'
                                     )}
                                     aria-label={
-                                      attachedWorkspace
+                                      item.type === 'pr'
                                         ? translate(
-                                            'auto.components.TaskPage.67d881244c',
-                                            'Resume workspace attached to PR'
+                                            'auto.components.TaskPage.7deb9e59a5',
+                                            'More PR actions'
                                           )
                                         : translate(
-                                            'auto.components.TaskPage.e4b29c5bcf',
-                                            'Start workspace from PR'
+                                            'auto.components.TaskPage.66ae7330f6',
+                                            'More actions'
                                           )
                                     }
                                   >
-                                    {attachedWorkspace
-                                      ? translate('auto.components.TaskPage.7753652524', 'Resume')
-                                      : translate('auto.components.TaskPage.7d08e8be0f', 'Start')}
-                                    <ArrowRight className="size-3" />
+                                    <ChevronDown className="size-3" />
                                   </Button>
-                                  <DropdownMenuTrigger asChild>
-                                    <Button
-                                      type="button"
-                                      variant={attachedWorkspace ? 'default' : 'outline'}
-                                      size="icon-xs"
-                                      onClick={(event) => event.stopPropagation()}
-                                      className={cn(
-                                        attachedWorkspace ? 'shadow-xs' : 'bg-background/80'
-                                      )}
-                                      aria-label={translate(
-                                        'auto.components.TaskPage.7deb9e59a5',
-                                        'More PR actions'
-                                      )}
-                                    >
-                                      <ChevronDown className="size-3" />
-                                    </Button>
-                                  </DropdownMenuTrigger>
-                                </ButtonGroup>
-                                <DropdownMenuContent
-                                  align="end"
-                                  onClick={(event) => event.stopPropagation()}
-                                >
-                                  {attachedWorkspace ? (
-                                    <DropdownMenuItem onSelect={() => handleUseWorkItem(item)}>
-                                      <Plus className="size-4" />
-                                      {translate(
-                                        'auto.components.TaskPage.b6329379ca',
-                                        'Start new workspace'
-                                      )}
-                                    </DropdownMenuItem>
-                                  ) : null}
-                                  <DropdownMenuItem
-                                    onSelect={() => window.api.shell.openUrl(item.url)}
-                                  >
-                                    <ExternalLink className="size-4" />
-                                    {translate(
-                                      'auto.components.TaskPage.c1d1600362',
-                                      'Open in browser'
-                                    )}
-                                  </DropdownMenuItem>
-                                </DropdownMenuContent>
-                              </DropdownMenu>
-                            ) : (
-                              <Button
-                                type="button"
-                                // Why: Open resumes an existing workspace — solid primary reads stronger than outline Start (new workspace).
-                                variant={attachedWorkspace ? 'default' : 'outline'}
-                                size="xs"
-                                data-contextual-tour-target="tasks-start-workspace"
-                                onClick={(event) => {
-                                  event.stopPropagation()
-                                  handleOpenOrUseGitHubWorkItem(item)
-                                }}
-                                className={cn(
-                                  'min-w-[72px] gap-1 font-semibold',
-                                  attachedWorkspace ? 'shadow-xs' : 'bg-background/80'
-                                )}
-                                aria-label={
-                                  attachedWorkspace
-                                    ? translate(
-                                        'auto.components.TaskPage.2193a99ec1',
-                                        'Open workspace attached to issue'
-                                      )
-                                    : translate(
-                                        'auto.components.TaskPage.e104fa3d3d',
-                                        'Start workspace from issue'
-                                      )
-                                }
-                              >
-                                {attachedWorkspace
-                                  ? translate('auto.components.TaskPage.606a85c774', 'Open')
-                                  : translate('auto.components.TaskPage.7d08e8be0f', 'Start')}
-                                <ArrowRight className="size-3" />
-                              </Button>
-                            )}
-                            {item.type !== 'pr' ? (
-                              <DropdownMenu modal={false}>
-                                <DropdownMenuTrigger asChild>
-                                  <button
-                                    type="button"
-                                    onClick={(e) => e.stopPropagation()}
-                                    className="rounded-lg p-1.5 text-muted-foreground transition hover:bg-muted/60 hover:text-foreground"
-                                    aria-label={translate(
-                                      'auto.components.TaskPage.66ae7330f6',
-                                      'More actions'
-                                    )}
-                                  >
-                                    <EllipsisVertical className="size-4" />
-                                  </button>
                                 </DropdownMenuTrigger>
-                                <DropdownMenuContent
-                                  align="end"
-                                  onClick={(e) => e.stopPropagation()}
-                                >
-                                  {attachedWorkspace ? (
-                                    <DropdownMenuItem onSelect={() => handleUseWorkItem(item)}>
-                                      <Plus className="size-4" />
-                                      {translate(
-                                        'auto.components.TaskPage.b6329379ca',
-                                        'Start new workspace'
-                                      )}
-                                    </DropdownMenuItem>
-                                  ) : null}
+                              </ButtonGroup>
+                              <DropdownMenuContent
+                                align="end"
+                                onClick={(event) => event.stopPropagation()}
+                              >
+                                {githubTaskSplitActions.menu.includes('start') ? (
                                   <DropdownMenuItem
-                                    onSelect={() => window.api.shell.openUrl(item.url)}
+                                    onSelect={() => {
+                                      setGitHubTaskPrimaryAction('start')
+                                      handleOpenOrUseGitHubWorkItem(item)
+                                    }}
+                                  >
+                                    <ArrowRight className="size-4" />
+                                    {item.type === 'pr'
+                                      ? attachedWorkspace
+                                        ? translate('auto.components.TaskPage.7753652524', 'Resume')
+                                        : translate('auto.components.TaskPage.7d08e8be0f', 'Start')
+                                      : attachedWorkspace
+                                        ? translate('auto.components.TaskPage.606a85c774', 'Open')
+                                        : translate('auto.components.TaskPage.7d08e8be0f', 'Start')}
+                                  </DropdownMenuItem>
+                                ) : null}
+                                {attachedWorkspace ? (
+                                  <DropdownMenuItem onSelect={() => handleUseWorkItem(item)}>
+                                    <Plus className="size-4" />
+                                    {translate(
+                                      'auto.components.TaskPage.b6329379ca',
+                                      'Start new workspace'
+                                    )}
+                                  </DropdownMenuItem>
+                                ) : null}
+                                {githubTaskSplitActions.menu.includes('open-in-browser') ? (
+                                  <DropdownMenuItem
+                                    onSelect={() => {
+                                      setGitHubTaskPrimaryAction('open-in-browser')
+                                      window.api.shell.openUrl(item.url)
+                                    }}
                                   >
                                     <ExternalLink className="size-4" />
                                     {translate(
@@ -10621,9 +10626,9 @@ export default function TaskPage(): React.JSX.Element {
                                       'Open in browser'
                                     )}
                                   </DropdownMenuItem>
-                                </DropdownMenuContent>
-                              </DropdownMenu>
-                            ) : null}
+                                ) : null}
+                              </DropdownMenuContent>
+                            </DropdownMenu>
                           </div>
                         </div>
                       )

--- a/src/renderer/src/components/task-page-github-primary-action-boundary.test.ts
+++ b/src/renderer/src/components/task-page-github-primary-action-boundary.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const TASK_PAGE_SOURCE = readFileSync(join(__dirname, 'TaskPage.tsx'), 'utf8')
+
+describe('TaskPage GitHub primary action persistence', () => {
+  it('remembers the last Start vs Open-in-browser choice as the next primary action', () => {
+    expect(TASK_PAGE_SOURCE).toContain('resolveGitHubTaskSplitActions(githubTaskPrimaryAction)')
+    expect(TASK_PAGE_SOURCE).toContain("setGitHubTaskPrimaryAction('open-in-browser')")
+    expect(TASK_PAGE_SOURCE).toContain("setGitHubTaskPrimaryAction('start')")
+    expect(TASK_PAGE_SOURCE).toContain("githubTaskSplitActions.primary === 'open-in-browser'")
+    expect(TASK_PAGE_SOURCE).toContain("githubTaskSplitActions.menu.includes('start')")
+    expect(TASK_PAGE_SOURCE).toContain('handleOpenOrUseGitHubWorkItem(item)')
+    expect(TASK_PAGE_SOURCE).toContain('window.api.shell.openUrl(item.url)')
+  })
+})

--- a/src/renderer/src/components/task-page-workspace-composer-boundary.test.ts
+++ b/src/renderer/src/components/task-page-workspace-composer-boundary.test.ts
@@ -108,7 +108,7 @@ describe('TaskPage workspace creation source boundaries', () => {
   it('uses the shared composer handler from GitHub detail and start-new actions', () => {
     expect(TASK_PAGE_SOURCE.match(/onUse=\{\(item\) => \{/g)).toHaveLength(2)
     expect(TASK_PAGE_SOURCE.match(/onSelect=\{\(\) => handleUseWorkItem\(item\)\}/g)).toHaveLength(
-      2
+      1
     )
   })
 

--- a/src/renderer/src/store/slices/ui-hydration-workspace-preferences.test.ts
+++ b/src/renderer/src/store/slices/ui-hydration-workspace-preferences.test.ts
@@ -592,6 +592,43 @@ describe('createUISlice hydratePersistedUI', () => {
     }
   })
 
+  it('defaults GitHub task primary action to Start and hydrates the last choice', () => {
+    const store = createUIStore()
+
+    expect(store.getState().githubTaskPrimaryAction).toBe('start')
+
+    store.getState().hydratePersistedUI(
+      makePersistedUI({
+        githubTaskPrimaryAction: 'open-in-browser'
+      })
+    )
+    expect(store.getState().githubTaskPrimaryAction).toBe('open-in-browser')
+
+    store.getState().hydratePersistedUI(
+      makePersistedUI({
+        githubTaskPrimaryAction: 'resume' as never
+      })
+    )
+    expect(store.getState().githubTaskPrimaryAction).toBe('start')
+  })
+
+  it('persists GitHub task primary action changes and skips no-ops', () => {
+    const setUI = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('window', { api: { ui: { set: setUI } } })
+    const store = createUIStore()
+
+    store.getState().setGitHubTaskPrimaryAction('open-in-browser')
+    expect(store.getState().githubTaskPrimaryAction).toBe('open-in-browser')
+    expect(setUI).toHaveBeenCalledWith({ githubTaskPrimaryAction: 'open-in-browser' })
+
+    store.getState().setGitHubTaskPrimaryAction('open-in-browser')
+    expect(setUI).toHaveBeenCalledTimes(1)
+
+    store.getState().setGitHubTaskPrimaryAction('start')
+    expect(store.getState().githubTaskPrimaryAction).toBe('start')
+    expect(setUI).toHaveBeenCalledWith({ githubTaskPrimaryAction: 'start' })
+  })
+
   it('merges and persists partial task resume updates', () => {
     const setUI = vi.fn().mockResolvedValue(undefined)
     vi.stubGlobal('window', { api: { ui: { set: setUI } } })

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -34,6 +34,11 @@ import {
   applyManualRepoOrder,
   normalizeManualRepoOrder
 } from '../../../../shared/manual-repo-order'
+import {
+  DEFAULT_GITHUB_TASK_PRIMARY_ACTION,
+  normalizeGitHubTaskPrimaryAction,
+  type GitHubTaskPrimaryAction
+} from '../../../../shared/github-task-primary-action'
 import { isTopLevelView } from '../../../../shared/top-level-view'
 import { isReleaseChannel, type ReleaseChannel } from '../../../../shared/release-channel'
 import type { UsagePercentageDisplay } from '../../../../shared/usage-percentage-display'
@@ -683,6 +688,8 @@ export type UISlice = {
   }
   taskResumeState: TaskResumeState | undefined
   setTaskResumeState: (updates: Partial<TaskResumeState>) => void
+  githubTaskPrimaryAction: GitHubTaskPrimaryAction
+  setGitHubTaskPrimaryAction: (action: GitHubTaskPrimaryAction) => void
   taskListPosition: { contextKey: string; page: number; scrollTop: number } | null
   setTaskListPosition: (position: UISlice['taskListPosition']) => void
   githubTaskDrawerWorkItem: GitHubWorkItem | null
@@ -1244,6 +1251,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
   setActiveView: (view) => set({ activeView: view }),
   taskPageData: {},
   taskResumeState: undefined,
+  githubTaskPrimaryAction: DEFAULT_GITHUB_TASK_PRIMARY_ACTION,
   taskListPosition: null,
   githubTaskDrawerWorkItem: null,
   newWorkspaceDraft: null,
@@ -1398,6 +1406,15 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
       const next = { ...s.taskResumeState, ...updates }
       window.api.ui.set({ taskResumeState: next }).catch(console.error)
       return { taskResumeState: next }
+    }),
+  setGitHubTaskPrimaryAction: (action) =>
+    set((s) => {
+      const next = normalizeGitHubTaskPrimaryAction(action)
+      if (s.githubTaskPrimaryAction === next) {
+        return s
+      }
+      window.api.ui.set({ githubTaskPrimaryAction: next }).catch(console.error)
+      return { githubTaskPrimaryAction: next }
     }),
   setTaskListPosition: (taskListPosition) => set({ taskListPosition }),
   setGithubTaskDrawerWorkItem: (item) => set({ githubTaskDrawerWorkItem: item }),
@@ -2528,6 +2545,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
         browserDefaultSearchEngine: ui.browserDefaultSearchEngine ?? null,
         browserDefaultZoomLevel: normalizeBrowserPageZoomLevel(ui.browserDefaultZoomLevel),
         browserKagiSessionLink: normalizeKagiSessionLink(ui.browserKagiSessionLink ?? ''),
+        githubTaskPrimaryAction: normalizeGitHubTaskPrimaryAction(ui.githubTaskPrimaryAction),
         taskResumeState: sanitizeTaskResumeState(ui.taskResumeState),
         featureTipsSeenIds: normalizeFeatureTipIds(ui.featureTipsSeenIds),
         featureInteractions: normalizeFeatureInteractions(ui.featureInteractions),

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -31,6 +31,7 @@ import { DEFAULT_SETUP_AGENT_STARTUP_POLICY } from './setup-agent-startup-policy
 import { DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT } from './terminal-scrollback-policy'
 import { DEFAULT_USAGE_PERCENTAGE_DISPLAY } from './usage-percentage-display'
 import { DEFAULT_STATUS_BAR_USAGE_MODE } from './status-bar-usage-mode'
+import { DEFAULT_GITHUB_TASK_PRIMARY_ACTION } from './github-task-primary-action'
 
 export { DEFAULT_STATUS_BAR_ITEMS } from './status-bar-defaults'
 export {
@@ -524,7 +525,8 @@ export function getDefaultUIState(): PersistedUIState {
     featureTipsSeenIds: [],
     featureInteractions: {},
     contextualToursSeenIds: [],
-    browserDefaultZoomLevel: DEFAULT_BROWSER_PAGE_ZOOM_LEVEL
+    browserDefaultZoomLevel: DEFAULT_BROWSER_PAGE_ZOOM_LEVEL,
+    githubTaskPrimaryAction: DEFAULT_GITHUB_TASK_PRIMARY_ACTION
   }
 }
 

--- a/src/shared/github-task-primary-action.test.ts
+++ b/src/shared/github-task-primary-action.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_GITHUB_TASK_PRIMARY_ACTION,
+  isGitHubTaskPrimaryAction,
+  normalizeGitHubTaskPrimaryAction,
+  resolveGitHubTaskSplitActions
+} from './github-task-primary-action'
+
+describe('normalizeGitHubTaskPrimaryAction', () => {
+  it('defaults new users and unknown values to Start', () => {
+    expect(normalizeGitHubTaskPrimaryAction(undefined)).toBe(DEFAULT_GITHUB_TASK_PRIMARY_ACTION)
+    expect(normalizeGitHubTaskPrimaryAction(null)).toBe('start')
+    expect(normalizeGitHubTaskPrimaryAction('resume')).toBe('start')
+    expect(normalizeGitHubTaskPrimaryAction('')).toBe('start')
+  })
+
+  it('keeps an explicit Open-in-browser choice', () => {
+    expect(normalizeGitHubTaskPrimaryAction('open-in-browser')).toBe('open-in-browser')
+  })
+
+  it('keeps an explicit Start choice', () => {
+    expect(normalizeGitHubTaskPrimaryAction('start')).toBe('start')
+  })
+})
+
+describe('isGitHubTaskPrimaryAction', () => {
+  it('accepts only the persisted Start vs Open-in-browser pair', () => {
+    expect(isGitHubTaskPrimaryAction('start')).toBe(true)
+    expect(isGitHubTaskPrimaryAction('open-in-browser')).toBe(true)
+    expect(isGitHubTaskPrimaryAction('resume')).toBe(false)
+  })
+})
+
+describe('resolveGitHubTaskSplitActions', () => {
+  it('presents Start as the primary action for new users', () => {
+    expect(resolveGitHubTaskSplitActions(undefined)).toEqual({
+      primary: 'start',
+      menu: ['open-in-browser']
+    })
+  })
+
+  it('promotes Open in browser after that choice is remembered', () => {
+    expect(resolveGitHubTaskSplitActions('open-in-browser')).toEqual({
+      primary: 'open-in-browser',
+      menu: ['start']
+    })
+  })
+
+  it('keeps Start available after remembering Open in browser', () => {
+    const resolved = resolveGitHubTaskSplitActions('open-in-browser')
+    expect(resolved.menu).toContain('start')
+    expect(resolved.primary).not.toBe('start')
+  })
+})

--- a/src/shared/github-task-primary-action.ts
+++ b/src/shared/github-task-primary-action.ts
@@ -1,0 +1,24 @@
+export const GITHUB_TASK_PRIMARY_ACTIONS = ['start', 'open-in-browser'] as const
+
+export type GitHubTaskPrimaryAction = (typeof GITHUB_TASK_PRIMARY_ACTIONS)[number]
+
+export const DEFAULT_GITHUB_TASK_PRIMARY_ACTION: GitHubTaskPrimaryAction = 'start'
+
+export function isGitHubTaskPrimaryAction(value: unknown): value is GitHubTaskPrimaryAction {
+  return value === 'start' || value === 'open-in-browser'
+}
+
+export function normalizeGitHubTaskPrimaryAction(value: unknown): GitHubTaskPrimaryAction {
+  return value === 'open-in-browser' ? 'open-in-browser' : DEFAULT_GITHUB_TASK_PRIMARY_ACTION
+}
+
+export function resolveGitHubTaskSplitActions(preferred: unknown): {
+  primary: GitHubTaskPrimaryAction
+  menu: GitHubTaskPrimaryAction[]
+} {
+  const primary = normalizeGitHubTaskPrimaryAction(preferred)
+  return {
+    primary,
+    menu: [primary === 'open-in-browser' ? 'start' : 'open-in-browser']
+  }
+}

--- a/src/shared/persisted-ui-state-types.ts
+++ b/src/shared/persisted-ui-state-types.ts
@@ -21,6 +21,7 @@ import type {
   WorkspaceHostScope,
   WorktreeCardProperty
 } from './ui-chrome-types'
+import type { GitHubTaskPrimaryAction } from './github-task-primary-action'
 import type { WorkspaceStatusDefinition } from './worktree/types'
 
 export type PersistedUIState = {
@@ -190,6 +191,8 @@ export type PersistedUIState = {
   sidekickId?: string
   customSidekicks?: CustomPet[]
   sidekickSize?: number
+  /** Last Tasks → GitHub split-button choice; absent means Start for new users. */
+  githubTaskPrimaryAction?: GitHubTaskPrimaryAction
   /** Page-position state for Tasks: only transient tabs/searches (source/repo/team/project selections use their own settings paths). */
   taskResumeState?: TaskResumeState
   workspaceCleanup?: WorkspaceCleanupUIState


### PR DESCRIPTION
## Description
Tasks → GitHub remembers the last Start vs Open in browser choice and shows it as the primary action next time.

## Focused fix
- In scope: persist one UI preference. Default remains Start.
- Out of scope: changing how Start or Open in browser works.

## Preserves
- New users still see Start first. Both actions remain available.

## Evidence
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/shared/github-task-primary-action.test.ts src/renderer/src/components/task-page-github-primary-action-boundary.test.ts`

Fixes #14480
