### PR TITLE
feat(dashboard): remember Worktree View as the default Dashboard view

### DIFF
--- a/src/main/window/dashboard-popout-window.test.ts
+++ b/src/main/window/dashboard-popout-window.test.ts
@@ -143,8 +143,12 @@ import {
 
 type FakeWindow = InstanceType<typeof BrowserWindowMock>
 
-function makeStore(ui: Record<string, unknown> = {}): {
+function makeStore(
+  ui: Record<string, unknown> = {},
+  settings: Record<string, unknown> = {}
+): {
   getUI: () => Record<string, unknown>
+  getSettings: () => Record<string, unknown>
   updateUI: ReturnType<typeof vi.fn>
   onUIChanged: ReturnType<typeof vi.fn>
   emitUIChanged: (next: Record<string, unknown>) => void
@@ -154,6 +158,7 @@ function makeStore(ui: Record<string, unknown> = {}): {
   const uiChangeUnsubscribe = vi.fn()
   return {
     getUI: () => ui,
+    getSettings: () => settings,
     updateUI: vi.fn(),
     onUIChanged: vi.fn((listener: (next: Record<string, unknown>) => void) => {
       listeners.push(listener)
@@ -233,6 +238,23 @@ describe('createOrFocusDashboardPopout', () => {
 
   it('opens on the current dashboard view by default', () => {
     createOrFocusDashboardPopout(makeStore() as never)
+
+    expect(instances[0].loadFile.mock.calls[0][1]).toEqual({ search: 'view=board' })
+  })
+
+  it('opens the worktree map when that persisted default is on', () => {
+    createOrFocusDashboardPopout(
+      makeStore({}, { experimentalAgentDashboardDefaultWorktreeView: true }) as never
+    )
+
+    expect(instances[0].loadFile.mock.calls[0][1]).toEqual({ search: 'view=map' })
+  })
+
+  it('keeps an explicit popout view over the persisted worktree-view default', () => {
+    createOrFocusDashboardPopout(
+      makeStore({}, { experimentalAgentDashboardDefaultWorktreeView: true }) as never,
+      'board'
+    )
 
     expect(instances[0].loadFile.mock.calls[0][1]).toEqual({ search: 'view=board' })
   })

--- a/src/main/window/dashboard-popout-window.ts
+++ b/src/main/window/dashboard-popout-window.ts
@@ -5,6 +5,7 @@ import type { Store } from '../persistence'
 import { rectHasVisibleAreaOnAnyDisplay } from './window-bounds-validation'
 import { sendToTrustedUIRenderer } from '../ipc/ui'
 import { installPrivilegedWindowNavigationPolicy } from './privileged-window-navigation'
+import { resolveAgentDashboardInitialView } from '../../shared/agent-dashboard-default-view'
 import { stepUIZoomLevel, type UIZoomDirection } from '../../shared/ui-zoom-level'
 import { nativeZoomCommandMatchesKeybindings } from '../../shared/window-shortcut-policy'
 import {
@@ -18,7 +19,6 @@ const MIN_WIDTH = 480
 const MIN_HEIGHT = 360
 const DEFAULT_WIDTH = 960
 const DEFAULT_HEIGHT = 720
-const DEFAULT_VIEW = 'board'
 const DASHBOARD_POPOUT_PARTITION = 'orca-dashboard-popout'
 
 // Why: singleton — the dashboard is a companion surface, so a second "Pop Out"
@@ -152,7 +152,11 @@ export function createOrFocusDashboardPopout(
     return dashboardPopoutWindow
   }
 
-  const initialView = view ?? DEFAULT_VIEW
+  const initialView =
+    view ??
+    resolveAgentDashboardInitialView({
+      defaultWorktreeView: store?.getSettings().experimentalAgentDashboardDefaultWorktreeView
+    })
 
   const savedBounds = resolveRestoredBounds(store)
 

--- a/src/renderer/src/components/dashboard-popout/AgentKanbanBoard.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanBoard.tsx
@@ -8,6 +8,7 @@ import {
   type DashboardSnapshot,
   type DashboardSpawnAgentArgs
 } from '../../../../shared/dashboard-snapshot'
+import type { AgentDashboardView } from '../../../../shared/agent-dashboard-default-view'
 import type { RepoIcon } from '../../../../shared/repo-icon'
 import { cn } from '@/lib/utils'
 import { TooltipProvider } from '@/components/ui/tooltip'
@@ -25,7 +26,7 @@ import { translate } from '@/i18n/i18n'
 import { Button } from '@/components/ui/button'
 import { lazyWithRetry } from '@/lib/lazy-with-retry'
 
-export type AgentDashboardView = 'map' | 'board'
+export type { AgentDashboardView }
 
 const AgentDashboardMapView = lazyWithRetry(
   () =>

--- a/src/renderer/src/components/dashboard-popout/DashboardPopoutRoot.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/DashboardPopoutRoot.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAppStore } from '@/store'
+
+const mocks = vi.hoisted(() => ({
+  boardProps: null as Record<string, unknown> | null
+}))
+
+vi.mock('./useDashboardSnapshot', () => ({
+  useDashboardSnapshot: () => ({ generatedAt: 1, cards: [] })
+}))
+
+vi.mock('./AgentKanbanBoard', () => ({
+  AgentKanbanBoard: (props: Record<string, unknown>) => {
+    mocks.boardProps = props
+    return null
+  }
+}))
+
+import { DashboardPopoutRoot } from './DashboardPopoutRoot'
+
+const initialState = useAppStore.getInitialState()
+
+beforeEach(() => {
+  mocks.boardProps = null
+  useAppStore.setState(initialState, true)
+  ;(window as unknown as { api: { dashboard: { onViewRequested: typeof vi.fn } } }).api = {
+    dashboard: { onViewRequested: vi.fn(() => vi.fn()) }
+  }
+})
+
+afterEach(() => {
+  cleanup()
+  useAppStore.setState(initialState, true)
+})
+
+describe('DashboardPopoutRoot', () => {
+  it('paints the status board when the worktree-view setting is unset', () => {
+    render(<DashboardPopoutRoot view={null} />)
+    expect(mocks.boardProps?.initialView).toBe('board')
+  })
+
+  it('paints the worktree map when the persisted default is on', () => {
+    useAppStore.setState({
+      settings: { experimentalAgentDashboardDefaultWorktreeView: true } as never
+    })
+    render(<DashboardPopoutRoot view={null} />)
+    expect(mocks.boardProps?.initialView).toBe('map')
+  })
+
+  it('keeps an explicit requested view over the persisted default', () => {
+    useAppStore.setState({
+      settings: { experimentalAgentDashboardDefaultWorktreeView: true } as never
+    })
+    render(<DashboardPopoutRoot view="board" />)
+    expect(mocks.boardProps?.initialView).toBe('board')
+  })
+
+  it('does not apply the setting after a later per-session view request', () => {
+    const listeners: ((view: 'board' | 'map') => void)[] = []
+    ;(window as unknown as { api: { dashboard: { onViewRequested: typeof vi.fn } } }).api = {
+      dashboard: {
+        onViewRequested: vi.fn((listener: (view: 'board' | 'map') => void) => {
+          listeners.push(listener)
+          return vi.fn()
+        })
+      }
+    }
+    useAppStore.setState({
+      settings: { experimentalAgentDashboardDefaultWorktreeView: true } as never
+    })
+    render(<DashboardPopoutRoot view={null} />)
+    expect(mocks.boardProps?.initialView).toBe('map')
+
+    act(() => {
+      listeners[0]?.('board')
+    })
+    expect(mocks.boardProps?.initialView).toBe('board')
+  })
+})

--- a/src/renderer/src/components/dashboard-popout/DashboardPopoutRoot.tsx
+++ b/src/renderer/src/components/dashboard-popout/DashboardPopoutRoot.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useState } from 'react'
-import { AgentKanbanBoard, type AgentDashboardView } from './AgentKanbanBoard'
+import {
+  resolveAgentDashboardInitialView,
+  type AgentDashboardView
+} from '../../../../shared/agent-dashboard-default-view'
+import { useAppStore } from '@/store'
+import { AgentKanbanBoard } from './AgentKanbanBoard'
 import { useDashboardSnapshot } from './useDashboardSnapshot'
 
 type DashboardPopoutRootProps = {
@@ -14,7 +19,11 @@ type DashboardPopoutRootProps = {
 export function DashboardPopoutRoot(_props: DashboardPopoutRootProps): React.JSX.Element {
   const snapshot = useDashboardSnapshot()
   const [view, setView] = useState<AgentDashboardView>(() =>
-    _props.view === 'map' || _props.view === 'rings' ? 'map' : 'board'
+    resolveAgentDashboardInitialView({
+      defaultWorktreeView:
+        useAppStore.getState().settings?.experimentalAgentDashboardDefaultWorktreeView,
+      requestedView: _props.view
+    })
   )
   useEffect(() => window.api.dashboard.onViewRequested(setView), [])
   return <AgentKanbanBoard key={view} snapshot={snapshot} initialView={view} />

--- a/src/renderer/src/components/dashboard/AgentDashboardDrawer.test.tsx
+++ b/src/renderer/src/components/dashboard/AgentDashboardDrawer.test.tsx
@@ -85,6 +85,16 @@ describe('AgentDashboardDrawer', () => {
     expect(useAppStore.getState().agentDashboardDrawerOpen).toBe(false)
   })
 
+  it('opens the worktree map when that persisted default is on', () => {
+    useAppStore.setState({
+      settings: { experimentalAgentDashboardDefaultWorktreeView: true } as never
+    })
+    render(<AgentDashboardDrawer statusBarVisible />)
+
+    act(() => useAppStore.setState({ agentDashboardDrawerOpen: true }))
+    expect(mocks.boardProps?.initialView).toBe('map')
+  })
+
   it('hands map rendering to the dedicated popout', () => {
     const openPopout = vi.mocked(window.api.dashboard.openPopout)
     render(<AgentDashboardDrawer statusBarVisible />)

--- a/src/renderer/src/components/dashboard/AgentDashboardDrawer.tsx
+++ b/src/renderer/src/components/dashboard/AgentDashboardDrawer.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { useAppStore } from '@/store'
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
 import { activateTabAndFocusPane } from '@/lib/activate-tab-and-focus-pane'
+import { resolveAgentDashboardInitialView } from '../../../../shared/agent-dashboard-default-view'
 import { AgentKanbanBoard } from '../dashboard-popout/AgentKanbanBoard'
 import type { AgentRevealArgs } from '../dashboard-popout/AgentTerminalDialog'
 import {
@@ -40,6 +41,10 @@ function AgentDashboardDrawerBody({
   onMenuOpenChange: (open: boolean) => void
 }): React.JSX.Element {
   const snapshot = useLiveDashboardSnapshot()
+  const defaultWorktreeView = useAppStore(
+    (s) => s.settings?.experimentalAgentDashboardDefaultWorktreeView === true
+  )
+  const initialView = resolveAgentDashboardInitialView({ defaultWorktreeView })
 
   // In-window ack/reveal act on the local store directly — the pop-out's IPC
   // relay is gated to the pop-out renderer and would reject calls from here.
@@ -70,7 +75,7 @@ function AgentDashboardDrawerBody({
   return (
     <AgentKanbanBoard
       snapshot={snapshot}
-      initialView="board"
+      initialView={initialView}
       // Why: bg-transparent lets the sheet's worktree-sidebar surface through
       // so the board reads as the same companion panel as the workspace board.
       containerClassName="h-full w-full bg-transparent"

--- a/src/renderer/src/components/dashboard/AgentDashboardSettingsMenu.test.tsx
+++ b/src/renderer/src/components/dashboard/AgentDashboardSettingsMenu.test.tsx
@@ -4,22 +4,21 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const updateSettings = vi.fn()
+const settings = {
+  experimentalAgentDashboardMode: 'in-window' as const,
+  experimentalAgentDashboardShowIdle: false,
+  experimentalAgentDashboardDefaultWorktreeView: false
+}
 
 vi.mock('@/store', () => ({
   useAppStore: (
     selector: (state: {
-      settings: {
-        experimentalAgentDashboardMode: 'in-window'
-        experimentalAgentDashboardShowIdle: boolean
-      }
+      settings: typeof settings
       updateSettings: typeof updateSettings
     }) => unknown
   ) =>
     selector({
-      settings: {
-        experimentalAgentDashboardMode: 'in-window',
-        experimentalAgentDashboardShowIdle: false
-      },
+      settings,
       updateSettings
     })
 }))
@@ -67,5 +66,25 @@ describe('AgentDashboardSettingsMenu', () => {
     act(() => toggle?.click())
 
     expect(updateSettings).toHaveBeenCalledWith({ experimentalAgentDashboardShowIdle: true })
+  })
+
+  it('owns the default worktree-view setting', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    act(() => {
+      root?.render(<AgentDashboardSettingsMenu onSwitchToPopout={vi.fn()} onOpenChange={vi.fn()} />)
+    })
+
+    const toggle = container.querySelector<HTMLButtonElement>(
+      'button[role="switch"][aria-label="Open in Worktree View by default"]'
+    )
+    expect(toggle).not.toBeNull()
+
+    act(() => toggle?.click())
+
+    expect(updateSettings).toHaveBeenCalledWith({
+      experimentalAgentDashboardDefaultWorktreeView: true
+    })
   })
 })

--- a/src/renderer/src/components/dashboard/AgentDashboardSettingsMenu.tsx
+++ b/src/renderer/src/components/dashboard/AgentDashboardSettingsMenu.tsx
@@ -30,6 +30,9 @@ export function AgentDashboardSettingsMenu({
 }: AgentDashboardSettingsMenuProps): React.JSX.Element {
   const mode = useAppStore((s) => s.settings?.experimentalAgentDashboardMode ?? 'in-window')
   const showIdle = useAppStore((s) => s.settings?.experimentalAgentDashboardShowIdle === true)
+  const defaultWorktreeView = useAppStore(
+    (s) => s.settings?.experimentalAgentDashboardDefaultWorktreeView === true
+  )
   const updateSettings = useAppStore((s) => s.updateSettings)
 
   const handleModeChange = (next: AgentDashboardMode): void => {
@@ -104,6 +107,35 @@ export function AgentDashboardSettingsMenu({
                 )
               }
             ]}
+          />
+        </div>
+        <DropdownMenuSeparator />
+        <div className="flex items-start justify-between gap-3 rounded-md px-1.5 py-1.5">
+          <span className="min-w-0 space-y-0.5">
+            <span className="block text-[12px] font-medium leading-4 text-foreground">
+              {translate(
+                'dashboardPopout.settings.defaultWorktreeView',
+                'Open in Worktree View by default'
+              )}
+            </span>
+            <span className="block text-[11px] leading-4 text-muted-foreground">
+              {translate(
+                'dashboardPopout.settings.defaultWorktreeViewCopy',
+                'Open Agent Map when the dashboard starts. The status board stays the default when this is off.'
+              )}
+            </span>
+          </span>
+          <SettingsSwitch
+            checked={defaultWorktreeView}
+            onChange={() => {
+              void updateSettings({
+                experimentalAgentDashboardDefaultWorktreeView: !defaultWorktreeView
+              })
+            }}
+            ariaLabel={translate(
+              'dashboardPopout.settings.defaultWorktreeView',
+              'Open in Worktree View by default'
+            )}
           />
         </div>
         <DropdownMenuSeparator />

--- a/src/renderer/src/components/settings/ExperimentalPane.test.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.test.tsx
@@ -173,6 +173,7 @@ describe('ExperimentalPane', () => {
     )
 
     expect(markup).not.toContain('Show idle agents')
+    expect(markup).not.toContain('Open in Worktree View by default')
   })
 
   it('renders Cloud VM as an off-by-default experimental subsection', () => {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -15669,6 +15669,8 @@
     "total": "{{count}} total",
     "close": "Close dashboard",
     "settings": {
+      "defaultWorktreeView": "Open in Worktree View by default",
+      "defaultWorktreeViewCopy": "Open Agent Map when the dashboard starts. The status board stays the default when this is off.",
       "showIdle": "Show idle agents",
       "showIdleCopy": "Include agents that have gone quiet for 30 minutes without reporting completion. Hidden by default."
     },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -14577,6 +14577,8 @@
     },
     "settingsLabel": "Configuración del Panel de agentes",
     "settings": {
+      "defaultWorktreeView": "Abrir en vista de worktree de forma predeterminada",
+      "defaultWorktreeViewCopy": "Muestra el mapa de agentes al abrir el panel. Si está desactivado, se mantiene el tablero de estado.",
       "showIdle": "Mostrar agentes inactivos",
       "showIdleCopy": "Incluye agentes que han permanecido inactivos durante 30 minutos sin informar que finalizaron. Ocultos de forma predeterminada."
     }

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -14577,6 +14577,8 @@
     },
     "settingsLabel": "Agent ダッシュボード設定",
     "settings": {
+      "defaultWorktreeView": "デフォルトで Worktree View を開く",
+      "defaultWorktreeViewCopy": "ダッシュボード起動時にステータスボードではなく Agent Map を表示します。オフのときは従来の既定値のままです。",
       "showIdle": "アイドル状態の Agent を表示",
       "showIdleCopy": "完了を報告せずに30分間停止している Agent を含めます。デフォルトでは非表示です。"
     }

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -14588,6 +14588,8 @@
     },
     "settingsLabel": "에이전트 대시보드 설정",
     "settings": {
+      "defaultWorktreeView": "워크트리 뷰를 기본으로 열기",
+      "defaultWorktreeViewCopy": "대시보드를 열 때 상태 보드 대신 Agent Map을 표시합니다. 끄면 기존 기본값이 유지됩니다.",
       "showIdle": "유휴 에이전트 표시",
       "showIdleCopy": "완료를 보고하지 않은 채 30분 동안 조용한 에이전트를 포함합니다. 기본적으로 숨겨집니다."
     }

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -14597,6 +14597,8 @@
     },
     "settingsLabel": "智能体仪表盘设置",
     "settings": {
+      "defaultWorktreeView": "默认在工作树视图中打开",
+      "defaultWorktreeViewCopy": "打开仪表盘时显示 Agent Map。关闭后仍使用原来的状态看板。",
       "showIdle": "显示空闲智能体",
       "showIdleCopy": "包括已安静 30 分钟且未报告完成的智能体。默认隐藏。"
     }

--- a/src/shared/agent-dashboard-default-view.test.ts
+++ b/src/shared/agent-dashboard-default-view.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { resolveAgentDashboardInitialView } from './agent-dashboard-default-view'
+
+describe('resolveAgentDashboardInitialView', () => {
+  it('keeps the status board when the worktree-view setting is off or unset', () => {
+    expect(resolveAgentDashboardInitialView({})).toBe('board')
+    expect(resolveAgentDashboardInitialView({ defaultWorktreeView: false })).toBe('board')
+    expect(resolveAgentDashboardInitialView({ defaultWorktreeView: null })).toBe('board')
+    expect(resolveAgentDashboardInitialView({ requestedView: null })).toBe('board')
+    expect(resolveAgentDashboardInitialView({ requestedView: '' })).toBe('board')
+    expect(resolveAgentDashboardInitialView({ requestedView: 'unknown' })).toBe('board')
+  })
+
+  it('opens the worktree map when the setting is on and no override is set', () => {
+    expect(resolveAgentDashboardInitialView({ defaultWorktreeView: true })).toBe('map')
+  })
+
+  it('lets an explicit per-session view override the persisted default', () => {
+    expect(
+      resolveAgentDashboardInitialView({
+        defaultWorktreeView: true,
+        requestedView: 'board'
+      })
+    ).toBe('board')
+    expect(
+      resolveAgentDashboardInitialView({
+        defaultWorktreeView: true,
+        requestedView: 'kanban'
+      })
+    ).toBe('board')
+    expect(
+      resolveAgentDashboardInitialView({
+        defaultWorktreeView: false,
+        requestedView: 'map'
+      })
+    ).toBe('map')
+    expect(
+      resolveAgentDashboardInitialView({
+        defaultWorktreeView: false,
+        requestedView: 'rings'
+      })
+    ).toBe('map')
+  })
+})

--- a/src/shared/agent-dashboard-default-view.ts
+++ b/src/shared/agent-dashboard-default-view.ts
@@ -1,0 +1,16 @@
+export type AgentDashboardView = 'map' | 'board'
+
+/** Explicit pop-out/query overrides beat the persisted default. */
+export function resolveAgentDashboardInitialView(args: {
+  defaultWorktreeView?: boolean | null
+  requestedView?: string | null
+}): AgentDashboardView {
+  const requested = args.requestedView
+  if (requested === 'map' || requested === 'rings') {
+    return 'map'
+  }
+  if (requested === 'board' || requested === 'kanban') {
+    return 'board'
+  }
+  return args.defaultWorktreeView === true ? 'map' : 'board'
+}

--- a/src/shared/constants.test.ts
+++ b/src/shared/constants.test.ts
@@ -114,6 +114,7 @@ describe('getDefaultSettings', () => {
   it('keeps the agent dashboard popout disabled by default', () => {
     expect(getDefaultSettings('/tmp').experimentalAgentDashboardPopout).toBeUndefined()
     expect(getDefaultSettings('/tmp').experimentalAgentDashboardShowIdle).toBeUndefined()
+    expect(getDefaultSettings('/tmp').experimentalAgentDashboardDefaultWorktreeView).toBeUndefined()
   })
 
   it('routes fresh Codex profiles through the real-home rollout by default', () => {})

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -411,6 +411,8 @@ export type GlobalSettings = {
   experimentalAgentDashboardMode?: AgentDashboardMode
   /** Includes stale quiet agents as a fourth Agent Dashboard column. */
   experimentalAgentDashboardShowIdle?: boolean
+  /** Opens the Agent Dashboard on the worktree map. Unset/false keeps the status board. */
+  experimentalAgentDashboardDefaultWorktreeView?: boolean
   /** One-shot migration guard for defaulting the Agents view off; later explicit opt-ins persist normally. */
   experimentalActivityDefaultedOffForAllUsers?: boolean
   /** Experimental: persistent terminal-pane attention ring for bell + agent-completion events. Opt-in while tuning signal/noise. */


### PR DESCRIPTION
## Description
Dashboard can remember Worktree View as the default view across restarts.
Unset/off keeps the current board.

## Focused fix
- In scope: one persisted default. Explicit `view=` / session override still wins.
- Out of scope: Dashboard redesign.

## Preserves
- Existing users without the setting keep the current default.

## Evidence
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/shared/agent-dashboard-default-view.test.ts src/renderer/src/components/dashboard/AgentDashboardDrawer.test.tsx`

Fixes #14429
