### PR TITLE
feat(explorer): paste copied files into a File Explorer folder

### DIFF
--- a/src/main/window/clipboard-dashboard-popout-access.test.ts
+++ b/src/main/window/clipboard-dashboard-popout-access.test.ts
@@ -112,6 +112,9 @@ describe('dashboard popout clipboard access', () => {
         connectionId: 'ssh-secret'
       })
     ).toThrow('Unauthorized clipboard IPC sender')
+    expect(() => handlers.get('clipboard:readFile')?.(popoutEvent)).toThrow(
+      'Unauthorized clipboard IPC sender'
+    )
     expect(() =>
       handlers.get('clipboard:writeImage')?.(popoutEvent, 'data:image/png;base64,AAAA')
     ).toThrow('Unauthorized clipboard IPC sender')

--- a/src/main/window/clipboard-file-read.test.ts
+++ b/src/main/window/clipboard-file-read.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from 'vitest'
+import { readFilesFromClipboard, type ClipboardFileReadDeps } from './clipboard-file-read'
+
+function makeDeps(overrides: Partial<ClipboardFileReadDeps> = {}): ClipboardFileReadDeps {
+  return {
+    platform: 'darwin',
+    desktop: undefined,
+    readBuffer: vi.fn(() => Buffer.alloc(0)),
+    runCommand: vi.fn(async () => ''),
+    ...overrides
+  }
+}
+
+describe('readFilesFromClipboard', () => {
+  it('returns no files when the clipboard has no file payload', async () => {
+    expect(await readFilesFromClipboard(makeDeps())).toEqual({ ok: true, filePaths: [] })
+  })
+
+  it('reads a public.file-url buffer on macOS', async () => {
+    const result = await readFilesFromClipboard(
+      makeDeps({
+        platform: 'darwin',
+        readBuffer: (format) =>
+          format === 'public.file-url'
+            ? Buffer.from('file:///repo/a%20b.png\0', 'utf8')
+            : Buffer.alloc(0)
+      })
+    )
+    expect(result).toEqual({ ok: true, filePaths: ['/repo/a b.png'] })
+  })
+
+  it('ignores non-file clipboard text on macOS', async () => {
+    const result = await readFilesFromClipboard(
+      makeDeps({
+        platform: 'darwin',
+        readBuffer: (format) =>
+          format === 'public.file-url' ? Buffer.from('just some text', 'utf8') : Buffer.alloc(0)
+      })
+    )
+    expect(result).toEqual({ ok: true, filePaths: [] })
+  })
+
+  it('reads FileNameW paths on Windows', async () => {
+    const result = await readFilesFromClipboard(
+      makeDeps({
+        platform: 'win32',
+        readBuffer: (format) =>
+          format === 'FileNameW' ? Buffer.from('C:\\repo\\notes.txt\0', 'utf16le') : Buffer.alloc(0)
+      })
+    )
+    expect(result).toEqual({ ok: true, filePaths: ['C:\\repo\\notes.txt'] })
+  })
+
+  it('reads the GNOME copied-files payload on non-KDE desktops', async () => {
+    const runCommand = vi.fn(async (command: string, args: string[]) => {
+      if (command === 'wl-paste' && args.includes('x-special/gnome-copied-files')) {
+        return 'copy\nfile:///repo/a.png'
+      }
+      throw new Error('missing format')
+    })
+    expect(
+      await readFilesFromClipboard(makeDeps({ platform: 'linux', desktop: 'GNOME', runCommand }))
+    ).toEqual({ ok: true, filePaths: ['/repo/a.png'] })
+  })
+
+  it('reads the KDE text/uri-list payload first on a KDE desktop', async () => {
+    const runCommand = vi.fn(async (command: string, args: string[]) => {
+      if (command === 'wl-paste' && args.includes('text/uri-list')) {
+        return 'file:///repo/a%20b.png\r\n'
+      }
+      throw new Error('missing format')
+    })
+    expect(
+      await readFilesFromClipboard(makeDeps({ platform: 'linux', desktop: 'KDE', runCommand }))
+    ).toEqual({ ok: true, filePaths: ['/repo/a b.png'] })
+  })
+
+  it('prefers an Electron buffer over spawning a Linux clipboard tool', async () => {
+    const runCommand = vi.fn(async () => {
+      throw new Error('should not run')
+    })
+    expect(
+      await readFilesFromClipboard(
+        makeDeps({
+          platform: 'linux',
+          desktop: 'GNOME',
+          readBuffer: (format) =>
+            format === 'x-special/gnome-copied-files'
+              ? Buffer.from('copy\nfile:///repo/from-electron.ts', 'utf8')
+              : Buffer.alloc(0),
+          runCommand
+        })
+      )
+    ).toEqual({ ok: true, filePaths: ['/repo/from-electron.ts'] })
+    expect(runCommand).not.toHaveBeenCalled()
+  })
+
+  it('returns no files when every Linux clipboard tool is unavailable', async () => {
+    const runCommand = vi.fn(async () => {
+      throw new Error('command not found')
+    })
+    expect(await readFilesFromClipboard(makeDeps({ platform: 'linux', runCommand }))).toEqual({
+      ok: true,
+      filePaths: []
+    })
+  })
+
+  it('does not treat a clipboard read throw as a hard failure', async () => {
+    expect(
+      await readFilesFromClipboard(
+        makeDeps({
+          readBuffer: () => {
+            throw new Error('clipboard unavailable')
+          }
+        })
+      )
+    ).toEqual({ ok: true, filePaths: [] })
+  })
+})

--- a/src/main/window/clipboard-file-read.test.ts
+++ b/src/main/window/clipboard-file-read.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
-import { readFilesFromClipboard, type ClipboardFileReadDeps } from './clipboard-file-read'
+import {
+  CLIPBOARD_FILE_LIST_MAX_BYTES,
+  readFilesFromClipboard,
+  runClipboardCommandCapture,
+  type ClipboardFileReadDeps
+} from './clipboard-file-read'
 
 function makeDeps(overrides: Partial<ClipboardFileReadDeps> = {}): ClipboardFileReadDeps {
   return {
@@ -116,4 +121,21 @@ describe('readFilesFromClipboard', () => {
       )
     ).toEqual({ ok: true, filePaths: [] })
   })
+})
+
+describe('runClipboardCommandCapture', () => {
+  it('rejects after the byte cap instead of buffering the whole payload', async () => {
+    await expect(
+      runClipboardCommandCapture(process.execPath, [
+        '-e',
+        `process.stdout.write('x'.repeat(${CLIPBOARD_FILE_LIST_MAX_BYTES + 1}))`
+      ])
+    ).rejects.toThrow(/exceeded/)
+  })
+
+  it('rejects when the command exceeds the timeout', async () => {
+    await expect(
+      runClipboardCommandCapture(process.execPath, ['-e', 'setTimeout(() => {}, 10_000)'])
+    ).rejects.toThrow(/timed out/)
+  }, 8_000)
 })

--- a/src/main/window/clipboard-file-read.ts
+++ b/src/main/window/clipboard-file-read.ts
@@ -1,3 +1,4 @@
+import { spawn } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 
 export type ClipboardFileReadResult = { ok: true; filePaths: string[] }
@@ -10,7 +11,52 @@ export type ClipboardFileReadDeps = {
   runCommand: (command: string, args: string[]) => Promise<string>
 }
 
-const CLIPBOARD_FILE_LIST_MAX_BYTES = 64 * 1024
+export const CLIPBOARD_FILE_LIST_MAX_BYTES = 64 * 1024
+export const CLIPBOARD_FILE_READ_TIMEOUT_MS = 2_000
+
+export function runClipboardCommandCapture(command: string, args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'ignore'] })
+    const chunks: Buffer[] = []
+    let received = 0
+    let settled = false
+
+    const finish = (error?: Error, value?: string): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timer)
+      if (!child.killed) {
+        child.kill('SIGKILL')
+      }
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve(value ?? '')
+    }
+
+    const timer = setTimeout(() => {
+      finish(new Error(`${command} timed out`))
+    }, CLIPBOARD_FILE_READ_TIMEOUT_MS)
+
+    child.stdout?.on('data', (chunk: Buffer) => {
+      received += chunk.length
+      if (received > CLIPBOARD_FILE_LIST_MAX_BYTES) {
+        finish(new Error(`${command} exceeded ${CLIPBOARD_FILE_LIST_MAX_BYTES} bytes`))
+        return
+      }
+      chunks.push(chunk)
+    })
+    child.on('error', (error) => finish(error))
+    child.on('exit', (code) =>
+      code === 0
+        ? finish(undefined, Buffer.concat(chunks).toString('utf8'))
+        : finish(new Error(`${command} exited with ${code}`))
+    )
+  })
+}
 
 export async function readFilesFromClipboard(
   deps: ClipboardFileReadDeps

--- a/src/main/window/clipboard-file-read.ts
+++ b/src/main/window/clipboard-file-read.ts
@@ -1,0 +1,179 @@
+import { fileURLToPath } from 'node:url'
+
+export type ClipboardFileReadResult = { ok: true; filePaths: string[] }
+
+// Injected so the platform branching is unit-testable without the real OS clipboard.
+export type ClipboardFileReadDeps = {
+  platform: NodeJS.Platform
+  desktop?: string
+  readBuffer: (format: string) => Buffer
+  runCommand: (command: string, args: string[]) => Promise<string>
+}
+
+const CLIPBOARD_FILE_LIST_MAX_BYTES = 64 * 1024
+
+export async function readFilesFromClipboard(
+  deps: ClipboardFileReadDeps
+): Promise<ClipboardFileReadResult> {
+  try {
+    if (deps.platform === 'darwin') {
+      return { ok: true, filePaths: readMacClipboardFiles(deps) }
+    }
+    if (deps.platform === 'win32') {
+      return { ok: true, filePaths: readWindowsClipboardFiles(deps) }
+    }
+    return { ok: true, filePaths: await readLinuxClipboardFiles(deps) }
+  } catch {
+    return { ok: true, filePaths: [] }
+  }
+}
+
+function readMacClipboardFiles(deps: ClipboardFileReadDeps): string[] {
+  return parseFileUrls(readClipboardText(deps, 'public.file-url'))
+}
+
+function readWindowsClipboardFiles(deps: ClipboardFileReadDeps): string[] {
+  return decodeFileNameWList(safeReadBuffer(deps, 'FileNameW'))
+}
+
+async function readLinuxClipboardFiles(deps: ClipboardFileReadDeps): Promise<string[]> {
+  const mimeTypes = /kde/i.test(deps.desktop ?? '')
+    ? (['text/uri-list', 'x-special/gnome-copied-files'] as const)
+    : (['x-special/gnome-copied-files', 'text/uri-list'] as const)
+
+  for (const mime of mimeTypes) {
+    const fromElectron = parseLinuxClipboardPayload(readClipboardText(deps, mime), mime)
+    if (fromElectron.length > 0) {
+      return fromElectron
+    }
+    for (const [command, args] of [
+      ['wl-paste', ['--type', mime, '--no-newline']],
+      ['xclip', ['-selection', 'clipboard', '-t', mime, '-o']]
+    ] as const) {
+      try {
+        const paths = parseLinuxClipboardPayload(await deps.runCommand(command, [...args]), mime)
+        if (paths.length > 0) {
+          return paths
+        }
+      } catch {
+        // try the next tool
+      }
+    }
+  }
+  return []
+}
+
+function parseLinuxClipboardPayload(payload: string, mime: string): string[] {
+  const text = payload.replace(/\0+$/u, '')
+  if (!text.trim()) {
+    return []
+  }
+  if (mime === 'x-special/gnome-copied-files') {
+    const lines = text.split(/\r?\n/u)
+    // Why: the first line is the copy/cut verb; explorer paste always copies.
+    return parseFileUrls(lines.slice(1).join('\n'))
+  }
+  return parseFileUrls(text)
+}
+
+function parseFileUrls(payload: string): string[] {
+  const paths: string[] = []
+  for (const rawLine of payload.split(/\r?\n/u)) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith('#')) {
+      continue
+    }
+    const filePath = decodeClipboardFileReference(line)
+    if (filePath && !paths.includes(filePath)) {
+      paths.push(filePath)
+    }
+  }
+  return paths
+}
+
+function decodeClipboardFileReference(value: string): string | null {
+  if (value.startsWith('file:')) {
+    try {
+      return usableClipboardPath(fileURLToPath(value))
+    } catch {
+      return null
+    }
+  }
+  return usableClipboardPath(value)
+}
+
+function decodeFileNameWList(value: Buffer): string[] {
+  if (
+    value.byteLength < 2 ||
+    value.byteLength > CLIPBOARD_FILE_LIST_MAX_BYTES ||
+    value.byteLength % 2 !== 0
+  ) {
+    return []
+  }
+  const paths: string[] = []
+  let offset = 0
+  while (offset + 2 <= value.byteLength) {
+    let end = offset
+    while (end + 2 <= value.byteLength && value.readUInt16LE(end) !== 0) {
+      end += 2
+    }
+    if (end === offset) {
+      break
+    }
+    const filePath = usableClipboardPath(value.subarray(offset, end).toString('utf16le'))
+    if (filePath && !paths.includes(filePath)) {
+      paths.push(filePath)
+    }
+    offset = end + 2
+  }
+  return paths
+}
+
+function usableClipboardPath(filePath: string): string | null {
+  if (!filePath || filePath.includes('\0')) {
+    return null
+  }
+  if (filePath.startsWith('/') || isFullyQualifiedWindowsPath(filePath)) {
+    return filePath
+  }
+  return null
+}
+
+function isFullyQualifiedWindowsPath(filePath: string): boolean {
+  if (/^[A-Za-z]:[\\/]/.test(filePath)) {
+    return true
+  }
+  if (/^\\\\\?\\[A-Za-z]:\\/.test(filePath)) {
+    return true
+  }
+  const extendedUnc = /^\\\\\?\\UNC\\[^\\/]+\\([^\\/]+)(?:\\|$)/i.exec(filePath)
+  if (extendedUnc) {
+    return isOrdinaryUncShare(extendedUnc[1])
+  }
+  const unc = /^[/\\]{2}(?![?.][/\\])[^/\\]+[/\\]([^/\\]+)(?:[/\\]|$)/.exec(filePath)
+  return isOrdinaryUncShare(unc?.[1])
+}
+
+function isOrdinaryUncShare(share: string | undefined): boolean {
+  return typeof share === 'string' && share.toLowerCase() !== 'pipe'
+}
+
+function readClipboardText(deps: ClipboardFileReadDeps, format: string): string {
+  return stripTrailingNulls(safeReadBuffer(deps, format).toString('utf8'))
+}
+
+function safeReadBuffer(deps: ClipboardFileReadDeps, format: string): Buffer {
+  try {
+    const value = deps.readBuffer(format)
+    if (!Buffer.isBuffer(value) || value.byteLength > CLIPBOARD_FILE_LIST_MAX_BYTES) {
+      return Buffer.alloc(0)
+    }
+    return value
+  } catch {
+    return Buffer.alloc(0)
+  }
+}
+
+function stripTrailingNulls(value: string): string {
+  return value.replace(/\0+$/u, '')
+}

--- a/src/main/window/clipboard-ipc-file-read.test.ts
+++ b/src/main/window/clipboard-ipc-file-read.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { handlers, clipboardReadBuffer } = vi.hoisted(() => ({
+  handlers: new Map<string, (...args: unknown[]) => unknown>(),
+  clipboardReadBuffer: vi.fn(() => Buffer.alloc(0))
+}))
+
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn(() => '/tmp') },
+  clipboard: {
+    readText: vi.fn(() => ''),
+    readBuffer: clipboardReadBuffer,
+    writeText: vi.fn(),
+    readImage: vi.fn(),
+    writeImage: vi.fn(),
+    writeBuffer: vi.fn()
+  },
+  ipcMain: {
+    removeHandler: (channel: string) => handlers.delete(channel),
+    handle: (channel: string, handler: (...args: unknown[]) => unknown) =>
+      handlers.set(channel, handler)
+  },
+  nativeImage: { createFromBuffer: vi.fn() }
+}))
+
+vi.mock('./dashboard-popout-window', () => ({ isDashboardPopoutRenderer: () => false }))
+vi.mock('./clipboard-remote-file-copy', () => ({
+  cleanupExpiredRemoteClipboardFiles: vi.fn(async () => undefined),
+  scheduleLegacyRemoteClipboardFileCleanup: vi.fn(),
+  writeRemoteFileToClipboard: vi.fn()
+}))
+
+import {
+  registerClipboardHandlers,
+  setTrustedClipboardRendererWebContentsId
+} from './clipboard-ipc-handlers'
+
+function makeClipboardEvent(senderOverrides: Record<string, unknown> = {}): {
+  sender: Record<string, unknown>
+} {
+  return {
+    sender: {
+      id: 17,
+      getType: () => 'window',
+      getURL: () => 'file:///orca/index.html',
+      isDestroyed: () => false,
+      ...senderOverrides
+    }
+  }
+}
+
+describe('clipboard:readFile IPC', () => {
+  beforeEach(() => {
+    handlers.clear()
+    clipboardReadBuffer.mockReset()
+    clipboardReadBuffer.mockReturnValue(Buffer.alloc(0))
+    setTrustedClipboardRendererWebContentsId(null)
+    registerClipboardHandlers({} as never)
+  })
+
+  it('reads a file from the OS clipboard', async () => {
+    clipboardReadBuffer.mockImplementation((format: string) => {
+      if (format === 'public.file-url') {
+        return Buffer.from('file:///tmp/copied-file.txt', 'utf8')
+      }
+      if (format === 'FileNameW') {
+        return Buffer.from('C:\\tmp\\copied-file.txt\0', 'utf16le')
+      }
+      if (format === 'x-special/gnome-copied-files') {
+        return Buffer.from('copy\nfile:///tmp/copied-file.txt', 'utf8')
+      }
+      if (format === 'text/uri-list') {
+        return Buffer.from('file:///tmp/copied-file.txt\r\n', 'utf8')
+      }
+      return Buffer.alloc(0)
+    })
+
+    await expect(handlers.get('clipboard:readFile')?.(makeClipboardEvent())).resolves.toEqual({
+      ok: true,
+      filePaths:
+        process.platform === 'win32' ? ['C:\\tmp\\copied-file.txt'] : ['/tmp/copied-file.txt']
+    })
+  })
+
+  it('returns no files when the OS clipboard has no file payload', async () => {
+    await expect(handlers.get('clipboard:readFile')?.(makeClipboardEvent())).resolves.toEqual({
+      ok: true,
+      filePaths: []
+    })
+  })
+
+  it('rejects clipboard file reads from untrusted renderers', () => {
+    setTrustedClipboardRendererWebContentsId(17)
+    registerClipboardHandlers({} as never)
+
+    expect(() => handlers.get('clipboard:readFile')?.(makeClipboardEvent({ id: 42 }))).toThrow(
+      'Unauthorized clipboard IPC sender'
+    )
+    expect(clipboardReadBuffer).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/window/clipboard-ipc-handlers.test.ts
+++ b/src/main/window/clipboard-ipc-handlers.test.ts
@@ -546,6 +546,7 @@ describe('registerClipboardHandlers', () => {
     expect(removeHandlerMock).toHaveBeenCalledWith('clipboard:writeSelectionText')
     expect(removeHandlerMock).toHaveBeenCalledWith('clipboard:writeImage')
     expect(removeHandlerMock).toHaveBeenCalledWith('clipboard:writeFile')
+    expect(removeHandlerMock).toHaveBeenCalledWith('clipboard:readFile')
     expect(removeHandlerMock).toHaveBeenCalledWith('clipboard:saveImageAsTempFile')
   })
 

--- a/src/main/window/clipboard-ipc-handlers.ts
+++ b/src/main/window/clipboard-ipc-handlers.ts
@@ -30,6 +30,11 @@ import {
   type ClipboardFileResult
 } from './clipboard-file-copy'
 import {
+  readFilesFromClipboard,
+  type ClipboardFileReadDeps,
+  type ClipboardFileReadResult
+} from './clipboard-file-read'
+import {
   cleanupExpiredRemoteClipboardFiles,
   scheduleLegacyRemoteClipboardFileCleanup,
   writeRemoteFileToClipboard
@@ -83,6 +88,7 @@ export function registerClipboardHandlers(store: Store): void {
   ipcMain.removeHandler('clipboard:writeSelectionText')
   ipcMain.removeHandler('clipboard:writeImage')
   ipcMain.removeHandler('clipboard:writeFile')
+  ipcMain.removeHandler('clipboard:readFile')
   ipcMain.removeHandler('clipboard:saveImageAsTempFile')
 
   void cleanupExpiredRemoteClipboardFiles()
@@ -159,6 +165,10 @@ export function registerClipboardHandlers(store: Store): void {
       return writeFileToClipboard(request.filePath, deps)
     }
   )
+  ipcMain.handle('clipboard:readFile', (event): Promise<ClipboardFileReadResult> => {
+    assertTrustedClipboardSender(event)
+    return readFilesFromClipboard(makeClipboardFileReadDeps())
+  })
   ipcMain.handle('clipboard:writeText', async (event, text: string) => {
     assertTrustedClipboardTextSender(event)
     return clipboard.writeText(await assertClipboardTextWriteWithinLimitWithYield(text))
@@ -240,6 +250,31 @@ function makeClipboardFileDeps(
     writeBuffer: (format, buffer) => clipboard.writeBuffer(format, buffer),
     runCommand
   }
+}
+
+function makeClipboardFileReadDeps(): ClipboardFileReadDeps {
+  return {
+    platform: process.platform,
+    desktop: process.env.XDG_CURRENT_DESKTOP,
+    readBuffer: (format) => clipboard.readBuffer(format),
+    runCommand: runCommandCapture
+  }
+}
+
+function runCommandCapture(command: string, args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'ignore'] })
+    const chunks: Buffer[] = []
+    child.stdout?.on('data', (chunk: Buffer) => {
+      chunks.push(chunk)
+    })
+    child.on('error', reject)
+    child.on('exit', (code) =>
+      code === 0
+        ? resolve(Buffer.concat(chunks).toString('utf8'))
+        : reject(new Error(`${command} exited with ${code}`))
+    )
+  })
 }
 
 function assertTrustedClipboardSender(event: IpcMainInvokeEvent): void {

--- a/src/main/window/clipboard-ipc-handlers.ts
+++ b/src/main/window/clipboard-ipc-handlers.ts
@@ -31,6 +31,7 @@ import {
 } from './clipboard-file-copy'
 import {
   readFilesFromClipboard,
+  runClipboardCommandCapture,
   type ClipboardFileReadDeps,
   type ClipboardFileReadResult
 } from './clipboard-file-read'
@@ -257,24 +258,8 @@ function makeClipboardFileReadDeps(): ClipboardFileReadDeps {
     platform: process.platform,
     desktop: process.env.XDG_CURRENT_DESKTOP,
     readBuffer: (format) => clipboard.readBuffer(format),
-    runCommand: runCommandCapture
+    runCommand: runClipboardCommandCapture
   }
-}
-
-function runCommandCapture(command: string, args: string[]): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'ignore'] })
-    const chunks: Buffer[] = []
-    child.stdout?.on('data', (chunk: Buffer) => {
-      chunks.push(chunk)
-    })
-    child.on('error', reject)
-    child.on('exit', (code) =>
-      code === 0
-        ? resolve(Buffer.concat(chunks).toString('utf8'))
-        : reject(new Error(`${command} exited with ${code}`))
-    )
-  })
 }
 
 function assertTrustedClipboardSender(event: IpcMainInvokeEvent): void {

--- a/src/preload/api/ui-window-api.ts
+++ b/src/preload/api/ui-window-api.ts
@@ -26,6 +26,7 @@ export type UiWindowApi = {
         }
       | string
   ) => Promise<{ ok: boolean; reason?: string }>
+  readClipboardFile: () => Promise<{ ok: boolean; filePaths: string[]; reason?: string }>
   onFileDrop: (callback: (data: NativeFileDropPayload) => void) => () => void
   getZoomLevel: () => number
   setZoomLevel: (level: number) => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4161,6 +4161,8 @@ const api = {
           }
         | string
     ): Promise<{ ok: boolean; reason?: string }> => ipcRenderer.invoke('clipboard:writeFile', args),
+    readClipboardFile: (): Promise<{ ok: boolean; filePaths: string[]; reason?: string }> =>
+      ipcRenderer.invoke('clipboard:readFile'),
     onFileDrop: (callback: (data: NativeFileDropPayload) => void): (() => void) =>
       subscribeNativeFileDrop(callback),
     getZoomLevel: (): number => webFrame.getZoomLevel(),

--- a/src/renderer/src/components/right-sidebar/FileExplorer.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.tsx
@@ -40,6 +40,7 @@ import { useFileExplorerKeys } from './useFileExplorerKeys'
 import { useFileDuplicate } from './useFileDuplicate'
 import { useFileExplorerDragDrop } from './useFileExplorerDragDrop'
 import { useFileExplorerImport } from './useFileExplorerImport'
+import { useFileExplorerPaste } from './useFileExplorerPaste'
 import { useFileExplorerManualRefresh } from './useFileExplorerManualRefresh'
 import { useFileExplorerTree } from './useFileExplorerTree'
 import { decideExpandedDirLoad } from './file-explorer-stale-dir-cache'
@@ -415,6 +416,13 @@ function FileExplorerFiles(): React.JSX.Element {
     setSelectedPath: setSingleSelectedPath,
     operationOwner: rootCache?.operationOwner
   })
+  const pasteClipboardFiles = useFileExplorerPaste({
+    worktreePath: visibleFilesWorktreePath,
+    activeWorktreeId,
+    refreshDir,
+    setSelectedPath: setSingleSelectedPath,
+    operationOwner: rootCache?.operationOwner
+  })
 
   const totalCount = visibleRowCount + (inlineInputIndex >= 0 ? 1 : 0)
 
@@ -553,7 +561,9 @@ function FileExplorerFiles(): React.JSX.Element {
     requestDelete,
     requestDeleteAll,
     scrollToIndex,
-    activeWorktreeId
+    activeWorktreeId,
+    worktreePath: visibleFilesWorktreePath,
+    onPasteFiles: pasteClipboardFiles
   })
 
   // Why: context-menu Delete should respect the multi-selection — if the
@@ -787,6 +797,7 @@ function FileExplorerFiles(): React.JSX.Element {
                 onViewFile={handleClick}
                 onContextMenuSelect={preserveSelectionForContextMenu}
                 onCopyPaths={copyPathsForNode}
+                onPasteFiles={pasteClipboardFiles}
                 onStartNew={startNew}
                 onStartRename={handleStartRename}
                 onDuplicate={handleDuplicate}
@@ -836,6 +847,7 @@ function FileExplorerFiles(): React.JSX.Element {
         point={bgMenuPoint}
         worktreePath={worktreePath}
         onStartNew={startNew}
+        onPasteFiles={pasteClipboardFiles}
       />
     </>
   )

--- a/src/renderer/src/components/right-sidebar/FileExplorerBackgroundMenu.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerBackgroundMenu.tsx
@@ -1,13 +1,17 @@
 import React, { useEffect } from 'react'
-import { FilePlus, FolderPlus } from 'lucide-react'
+import { ClipboardPaste, FilePlus, FolderPlus } from 'lucide-react'
 import { CLOSE_ALL_CONTEXT_MENUS_EVENT } from '@/components/tab-bar/SortableTab'
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
+import { useShortcutLabel } from '@/hooks/useShortcutLabel'
 import { translate } from '@/i18n/i18n'
+import { shouldShowPasteFileAction } from './file-explorer-clipboard-paste'
 
 function stopRightButtonMenuSelection(event: React.PointerEvent): void {
   if (event.button !== 2) {
@@ -24,14 +28,17 @@ export function FileExplorerBackgroundMenu({
   onOpenChange,
   point,
   worktreePath,
-  onStartNew
+  onStartNew,
+  onPasteFiles
 }: {
   open: boolean
   onOpenChange: (open: boolean) => void
   point: { x: number; y: number }
   worktreePath: string
   onStartNew: (type: 'file' | 'folder', dir: string, depth: number) => void
+  onPasteFiles?: (destinationDir: string) => void
 }): React.JSX.Element {
+  const pasteShortcutLabel = useShortcutLabel('fileExplorer.paste')
   useEffect(() => {
     const close = (): void => onOpenChange(false)
     window.addEventListener(CLOSE_ALL_CONTEXT_MENUS_EVENT, close)
@@ -69,6 +76,18 @@ export function FileExplorerBackgroundMenu({
             'New Folder'
           )}
         </DropdownMenuItem>
+        {shouldShowPasteFileAction() && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={() => onPasteFiles?.(worktreePath)}>
+              <ClipboardPaste />
+              {translate('auto.components.right.sidebar.FileExplorerBackgroundMenu.paste', 'Paste')}
+              {pasteShortcutLabel !== 'Unassigned' ? (
+                <DropdownMenuShortcut>{pasteShortcutLabel}</DropdownMenuShortcut>
+              ) : null}
+            </DropdownMenuItem>
+          </>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/src/renderer/src/components/right-sidebar/FileExplorerRow.actions.test.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerRow.actions.test.tsx
@@ -9,6 +9,7 @@ import {
   shouldShowRemoteDownloadAction,
   shouldShowViewFileAction
 } from './FileExplorerRow'
+import { shouldShowPasteFileAction } from './file-explorer-clipboard-paste'
 import { directoryNode, fileNode } from './file-explorer-tree-node-test-fixtures'
 import type * as RuntimeFileClient from '@/runtime/runtime-file-client'
 
@@ -125,6 +126,17 @@ describe('FileExplorerRow collapse folder action', () => {
       ;(globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ = true
 
       expect(shouldShowCopyFileAction(fileNode, null, 1)).toBe(false)
+    } finally {
+      ;(globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ = previous
+    }
+  })
+
+  it('shows paste on desktop File Explorer rows and hides it on the web client', () => {
+    const previous = (globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__
+    try {
+      expect(shouldShowPasteFileAction()).toBe(true)
+      ;(globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ = true
+      expect(shouldShowPasteFileAction()).toBe(false)
     } finally {
       ;(globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ = previous
     }

--- a/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
@@ -4,6 +4,7 @@ import { basename } from '@/lib/path'
 import {
   ChevronRight,
   CircleSlash,
+  ClipboardPaste,
   Copy,
   Download,
   ExternalLink,
@@ -47,6 +48,7 @@ import type { GitFileStatus } from '../../../../shared/git-status-types'
 import { STATUS_LABELS } from './status-display'
 import { RENAME_HOTSPOT_ATTR } from './file-explorer-dir-toggle-timing'
 import type { TreeNode } from './file-explorer-types'
+import { shouldShowPasteFileAction } from './file-explorer-clipboard-paste'
 import { useFileExplorerRowDrag } from './useFileExplorerRowDrag'
 import { isLocalPathOpenBlocked, showLocalPathOpenBlockedToast } from '@/lib/local-path-open-guard'
 import { translate } from '@/i18n/i18n'
@@ -277,6 +279,7 @@ type FileExplorerRowProps = {
   onViewFile: () => void
   onContextMenuSelect: () => void
   onCopyPaths: (pathKind: 'absolute' | 'relative') => void
+  onPasteFiles?: (destinationDir: string) => void
   onStartNew: (type: 'file' | 'folder', dir: string, depth: number) => void
   onStartRename: (node: TreeNode) => void
   onDuplicate: (node: TreeNode) => void
@@ -466,6 +469,7 @@ export function FileExplorerRow({
   onViewFile,
   onContextMenuSelect,
   onCopyPaths,
+  onPasteFiles,
   onStartNew,
   onStartRename,
   onDuplicate,
@@ -486,6 +490,7 @@ export function FileExplorerRow({
   const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
   const copyPathShortcutLabel = useShortcutLabel('fileExplorer.copyPath')
   const copyRelativePathShortcutLabel = useShortcutLabel('fileExplorer.copyRelativePath')
+  const pasteShortcutLabel = useShortcutLabel('fileExplorer.paste')
   const findInFolderShortcutLabel = useShortcutLabel('sidebar.search.toggle')
   const FileIcon = getFileTypeIcon(node.relativePath || node.name)
   const rowDropDir = node.isDirectory ? node.path : targetDir
@@ -496,6 +501,7 @@ export function FileExplorerRow({
     supportsFolderDownload
   )
   const showCopyFileAction = shouldShowCopyFileAction(node, connectionId, selectionSize)
+  const showPasteFileAction = shouldShowPasteFileAction()
   const { setRowDragNode, handleDragOver, handleDragEnter, handleDragLeave, handleDrop } =
     useFileExplorerRowDrag({
       rowDropDir,
@@ -710,6 +716,15 @@ export function FileExplorerRow({
           <ContextMenuItem onSelect={handleCopyFile}>
             <Copy />
             {translate('auto.components.right.sidebar.FileExplorerRow.98a79948b3', 'Copy')}
+          </ContextMenuItem>
+        )}
+        {showPasteFileAction && (
+          <ContextMenuItem onSelect={() => onPasteFiles?.(rowDropDir)}>
+            <ClipboardPaste />
+            {translate('auto.components.right.sidebar.FileExplorerRow.paste', 'Paste')}
+            {pasteShortcutLabel !== 'Unassigned' ? (
+              <ContextMenuShortcut>{pasteShortcutLabel}</ContextMenuShortcut>
+            ) : null}
           </ContextMenuItem>
         )}
         <ContextMenuItem onSelect={() => onCopyPaths('absolute')}>

--- a/src/renderer/src/components/right-sidebar/FileExplorerVirtualRows.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerVirtualRows.tsx
@@ -35,6 +35,7 @@ type FileExplorerVirtualRowsProps = {
   onViewFile: (node: TreeNode) => void
   onContextMenuSelect: (node: TreeNode) => void
   onCopyPaths: (node: TreeNode, pathKind: 'absolute' | 'relative') => void
+  onPasteFiles?: (destinationDir: string) => void
   onStartNew: (type: 'file' | 'folder', parentPath: string, depth: number) => void
   onStartRename: (node: TreeNode) => void
   onDuplicate: (node: TreeNode) => void
@@ -82,6 +83,7 @@ export function FileExplorerVirtualRows(props: FileExplorerVirtualRowsProps): Re
     onViewFile,
     onContextMenuSelect,
     onCopyPaths,
+    onPasteFiles,
     onStartNew,
     onStartRename,
     onDuplicate,
@@ -191,6 +193,7 @@ export function FileExplorerVirtualRows(props: FileExplorerVirtualRowsProps): Re
               onViewFile={() => onViewFile(n)}
               onContextMenuSelect={() => onContextMenuSelect(n)}
               onCopyPaths={(pathKind) => onCopyPaths(n, pathKind)}
+              onPasteFiles={onPasteFiles}
               onStartNew={onStartNew}
               onStartRename={onStartRename}
               onDuplicate={onDuplicate}

--- a/src/renderer/src/components/right-sidebar/file-explorer-clipboard-paste.test.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-clipboard-paste.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  pasteClipboardFilesIntoExplorerFolder,
+  resolveFileExplorerPasteDestination,
+  shouldShowPasteFileAction
+} from './file-explorer-clipboard-paste'
+import type * as RuntimeFileClient from '@/runtime/runtime-file-client'
+
+const { importExternalPathsToRuntimeMock, toastErrorMock } = vi.hoisted(() => ({
+  importExternalPathsToRuntimeMock: vi.fn(),
+  toastErrorMock: vi.fn()
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: toastErrorMock, success: vi.fn() }
+}))
+
+vi.mock('@/runtime/runtime-file-client', async (importOriginal) => {
+  const actual = await importOriginal<typeof RuntimeFileClient>()
+  return {
+    ...actual,
+    importExternalPathsToRuntime: importExternalPathsToRuntimeMock
+  }
+})
+
+vi.mock('./file-explorer-operation-owner', () => ({
+  captureFileExplorerOperationGuard: () => ({
+    assertCurrent: () => undefined,
+    route: {
+      settings: { activeRuntimeEnvironmentId: null },
+      connectionId: undefined,
+      expectedExecutionHostId: 'local'
+    }
+  })
+}))
+
+describe('file explorer clipboard paste', () => {
+  beforeEach(() => {
+    toastErrorMock.mockReset()
+    importExternalPathsToRuntimeMock.mockReset()
+    delete (globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__
+  })
+
+  it('pastes a clipboard file into the selected folder and refreshes it', async () => {
+    const readClipboardFile = vi.fn().mockResolvedValue({
+      ok: true,
+      filePaths: ['/other-project/SomeFile.ts']
+    })
+    const refreshDir = vi.fn().mockResolvedValue(undefined)
+    const setSelectedPath = vi.fn()
+    importExternalPathsToRuntimeMock.mockResolvedValue({
+      results: [
+        {
+          sourcePath: '/other-project/SomeFile.ts',
+          status: 'imported',
+          destPath: '/repo/src/SomeFile.ts',
+          kind: 'file',
+          renamed: false
+        }
+      ]
+    })
+    ;(
+      globalThis as unknown as {
+        window: { api: { ui: { readClipboardFile: typeof readClipboardFile } } }
+      }
+    ).window = { api: { ui: { readClipboardFile } } }
+
+    await pasteClipboardFilesIntoExplorerFolder({
+      destinationDir: '/repo/src',
+      worktreeId: 'wt-1',
+      worktreePath: '/repo',
+      refreshDir,
+      setSelectedPath
+    })
+
+    expect(importExternalPathsToRuntimeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        worktreeId: 'wt-1',
+        worktreePath: '/repo'
+      }),
+      ['/other-project/SomeFile.ts'],
+      '/repo/src',
+      expect.objectContaining({ assertCurrent: expect.any(Function) })
+    )
+    expect(refreshDir).toHaveBeenCalledWith('/repo/src')
+    expect(setSelectedPath).toHaveBeenCalledWith('/repo/src/SomeFile.ts')
+    expect(toastErrorMock).not.toHaveBeenCalled()
+  })
+
+  it('is a no-op when the OS clipboard has no files', async () => {
+    const readClipboardFile = vi.fn().mockResolvedValue({ ok: true, filePaths: [] })
+    const refreshDir = vi.fn()
+    ;(
+      globalThis as unknown as {
+        window: { api: { ui: { readClipboardFile: typeof readClipboardFile } } }
+      }
+    ).window = { api: { ui: { readClipboardFile } } }
+
+    await pasteClipboardFilesIntoExplorerFolder({
+      destinationDir: '/repo/src',
+      worktreeId: 'wt-1',
+      worktreePath: '/repo',
+      refreshDir
+    })
+
+    expect(importExternalPathsToRuntimeMock).not.toHaveBeenCalled()
+    expect(refreshDir).not.toHaveBeenCalled()
+    expect(toastErrorMock).not.toHaveBeenCalled()
+  })
+
+  it('is a no-op when clipboard file read fails', async () => {
+    const readClipboardFile = vi.fn().mockRejectedValue(new Error('clipboard unavailable'))
+    const refreshDir = vi.fn()
+    ;(
+      globalThis as unknown as {
+        window: { api: { ui: { readClipboardFile: typeof readClipboardFile } } }
+      }
+    ).window = { api: { ui: { readClipboardFile } } }
+
+    await pasteClipboardFilesIntoExplorerFolder({
+      destinationDir: '/repo/src',
+      worktreeId: 'wt-1',
+      worktreePath: '/repo',
+      refreshDir
+    })
+
+    expect(importExternalPathsToRuntimeMock).not.toHaveBeenCalled()
+    expect(refreshDir).not.toHaveBeenCalled()
+    expect(toastErrorMock).not.toHaveBeenCalled()
+  })
+
+  it('pastes into a file row parent and into the project root when nothing is selected', () => {
+    expect(
+      resolveFileExplorerPasteDestination(
+        { path: '/repo/src/index.ts', isDirectory: false },
+        '/repo'
+      )
+    ).toBe('/repo/src')
+    expect(
+      resolveFileExplorerPasteDestination({ path: '/repo/src', isDirectory: true }, '/repo')
+    ).toBe('/repo/src')
+    expect(resolveFileExplorerPasteDestination(null, '/repo')).toBe('/repo')
+    expect(resolveFileExplorerPasteDestination(null, null)).toBeNull()
+  })
+
+  it('hides paste on the web client', () => {
+    expect(shouldShowPasteFileAction()).toBe(true)
+    ;(globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ = true
+    expect(shouldShowPasteFileAction()).toBe(false)
+  })
+})

--- a/src/renderer/src/components/right-sidebar/file-explorer-clipboard-paste.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-clipboard-paste.ts
@@ -1,0 +1,99 @@
+import { toast } from 'sonner'
+import { extractIpcErrorMessage } from '@/lib/ipc-error'
+import { dirname } from '@/lib/path'
+import { translate } from '@/i18n/i18n'
+import { importExternalPathsToRuntime } from '@/runtime/runtime-file-client'
+import type { FileExplorerOperationOwner } from './file-explorer-types'
+import { captureFileExplorerOperationGuard } from './file-explorer-operation-owner'
+
+export function shouldShowPasteFileAction(): boolean {
+  return (globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ !== true
+}
+
+export function resolveFileExplorerPasteDestination(
+  selectedNode: { path: string; isDirectory: boolean } | null,
+  worktreePath: string | null
+): string | null {
+  if (!worktreePath) {
+    return null
+  }
+  if (!selectedNode) {
+    return worktreePath
+  }
+  return selectedNode.isDirectory ? selectedNode.path : dirname(selectedNode.path)
+}
+
+export async function pasteClipboardFilesIntoExplorerFolder(args: {
+  destinationDir: string
+  worktreeId: string | null
+  worktreePath: string | null
+  operationOwner?: FileExplorerOperationOwner
+  refreshDir: (dirPath: string) => Promise<void>
+  setSelectedPath?: (path: string | null) => void
+}): Promise<void> {
+  if (!args.worktreeId || !args.worktreePath) {
+    return
+  }
+
+  let filePaths: string[]
+  try {
+    const clipboard = await window.api.ui.readClipboardFile()
+    filePaths = clipboard.ok ? clipboard.filePaths : []
+  } catch {
+    return
+  }
+  if (filePaths.length === 0) {
+    return
+  }
+
+  try {
+    const operationGuard = captureFileExplorerOperationGuard(args.worktreeId, args.operationOwner)
+    operationGuard.assertCurrent()
+    const { results } = await importExternalPathsToRuntime(
+      {
+        settings: operationGuard.route.settings,
+        worktreeId: args.worktreeId,
+        worktreePath: args.worktreePath,
+        connectionId: operationGuard.route.connectionId,
+        expectedExecutionHostId: operationGuard.route.expectedExecutionHostId,
+        expectedSshTargetId: operationGuard.route.expectedSshTargetId,
+        expectedSshConnectionGeneration: operationGuard.route.expectedSshConnectionGeneration
+      },
+      filePaths,
+      args.destinationDir,
+      { assertCurrent: operationGuard.assertCurrent }
+    )
+
+    await args.refreshDir(args.destinationDir)
+
+    const imported = results.filter((result) => result.status === 'imported')
+    const skipped = results.filter((result) => result.status === 'skipped')
+    const failed = results.filter((result) => result.status === 'failed')
+
+    if (imported.length > 0) {
+      args.setSelectedPath?.(imported[0].destPath)
+    }
+
+    if (failed.length > 0) {
+      const noun = failed.length === 1 ? 'file' : 'files'
+      toast.error(
+        translate(
+          'auto.components.right.sidebar.fileExplorerClipboardPaste.failed',
+          'Failed to paste {{value0}} {{value1}}.',
+          { value0: failed.length, value1: noun }
+        )
+      )
+    } else if (skipped.length > 0 && imported.length === 0) {
+      const noun = skipped.length === 1 ? 'file' : 'files'
+      toast.error(
+        translate(
+          'auto.components.right.sidebar.fileExplorerClipboardPaste.skipped',
+          'Skipped {{value0}} {{value1}}.',
+          { value0: skipped.length, value1: noun }
+        )
+      )
+    }
+  } catch (error) {
+    toast.error(extractIpcErrorMessage(error, 'Failed to paste files.'))
+  }
+}

--- a/src/renderer/src/components/right-sidebar/file-explorer-runtime-owner-boundary.test.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-runtime-owner-boundary.test.ts
@@ -12,6 +12,7 @@ describe('right sidebar file/git runtime ownership boundaries', () => {
   it.each([
     'src/renderer/src/components/right-sidebar/useFileExplorerTree.ts',
     'src/renderer/src/components/right-sidebar/useFileExplorerImport.ts',
+    'src/renderer/src/components/right-sidebar/file-explorer-clipboard-paste.ts',
     'src/renderer/src/components/right-sidebar/useFileExplorerInlineInput.ts',
     'src/renderer/src/components/right-sidebar/useFileExplorerDragDrop.ts',
     'src/renderer/src/components/right-sidebar/useFileDuplicate.ts',

--- a/src/renderer/src/components/right-sidebar/useFileExplorerKeys.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerKeys.ts
@@ -7,6 +7,7 @@ import type { InlineInput } from './FileExplorerRow'
 import type { TreeNode } from './file-explorer-types'
 import type { FileExplorerRowProjection } from './file-explorer-row-projection'
 import { formatFileExplorerPathsForClipboard } from './file-explorer-selection'
+import { resolveFileExplorerPasteDestination } from './file-explorer-clipboard-paste'
 import {
   fileExplorerHasRedo,
   fileExplorerHasUndo,
@@ -51,6 +52,8 @@ export function useFileExplorerKeys(opts: {
   requestDeleteAll: (nodes: TreeNode[]) => void
   scrollToIndex: (index: number) => void
   activeWorktreeId: string | null
+  worktreePath: string | null
+  onPasteFiles: (destinationDir: string) => void
 }): void {
   const rightSidebarOpen = useAppStore((s) => s.rightSidebarOpen)
   const rightSidebarTab = useAppStore((s) => s.rightSidebarTab)
@@ -85,6 +88,10 @@ export function useFileExplorerKeys(opts: {
   scrollToIndexRef.current = opts.scrollToIndex
   const activeWorktreeIdRef = useRef(opts.activeWorktreeId)
   activeWorktreeIdRef.current = opts.activeWorktreeId
+  const worktreePathRef = useRef(opts.worktreePath)
+  worktreePathRef.current = opts.worktreePath
+  const onPasteFilesRef = useRef(opts.onPasteFiles)
+  onPasteFilesRef.current = opts.onPasteFiles
 
   useEffect(() => {
     // Find the row index whose button is currently focused. Each virtualized
@@ -246,6 +253,21 @@ export function useFileExplorerKeys(opts: {
       if (!focusInExplorer()) {
         return
       }
+      const wantsPaste = keybindingMatchesAction('fileExplorer.paste', e, platform, keybindings)
+      if (wantsPaste) {
+        const focused = findFocusedIndex()
+        const node =
+          (focused !== null ? rowProjectionRef.current.getRowAtIndex(focused) : null) ??
+          selectedNodeRef.current
+        const destinationDir = resolveFileExplorerPasteDestination(node, worktreePathRef.current)
+        if (!destinationDir) {
+          return
+        }
+        e.preventDefault()
+        onPasteFilesRef.current(destinationDir)
+        return
+      }
+
       const wantsCopyRelativePath = keybindingMatchesAction(
         'fileExplorer.copyRelativePath',
         e,

--- a/src/renderer/src/components/right-sidebar/useFileExplorerKeys.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerKeys.ts
@@ -7,7 +7,10 @@ import type { InlineInput } from './FileExplorerRow'
 import type { TreeNode } from './file-explorer-types'
 import type { FileExplorerRowProjection } from './file-explorer-row-projection'
 import { formatFileExplorerPathsForClipboard } from './file-explorer-selection'
-import { resolveFileExplorerPasteDestination } from './file-explorer-clipboard-paste'
+import {
+  resolveFileExplorerPasteDestination,
+  shouldShowPasteFileAction
+} from './file-explorer-clipboard-paste'
 import {
   fileExplorerHasRedo,
   fileExplorerHasUndo,
@@ -254,7 +257,7 @@ export function useFileExplorerKeys(opts: {
         return
       }
       const wantsPaste = keybindingMatchesAction('fileExplorer.paste', e, platform, keybindings)
-      if (wantsPaste) {
+      if (wantsPaste && shouldShowPasteFileAction()) {
         const focused = findFocusedIndex()
         const node =
           (focused !== null ? rowProjectionRef.current.getRowAtIndex(focused) : null) ??

--- a/src/renderer/src/components/right-sidebar/useFileExplorerPaste.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerPaste.ts
@@ -1,0 +1,41 @@
+import { useCallback, useRef } from 'react'
+import type { FileExplorerOperationOwner } from './file-explorer-types'
+import { pasteClipboardFilesIntoExplorerFolder } from './file-explorer-clipboard-paste'
+
+type UseFileExplorerPasteParams = {
+  worktreePath: string | null
+  activeWorktreeId: string | null
+  refreshDir: (dirPath: string) => Promise<void>
+  setSelectedPath: (path: string | null) => void
+  operationOwner?: FileExplorerOperationOwner
+}
+
+export function useFileExplorerPaste({
+  worktreePath,
+  activeWorktreeId,
+  refreshDir,
+  setSelectedPath,
+  operationOwner
+}: UseFileExplorerPasteParams): (destinationDir: string) => void {
+  const worktreePathRef = useRef(worktreePath)
+  worktreePathRef.current = worktreePath
+  const activeWorktreeIdRef = useRef(activeWorktreeId)
+  activeWorktreeIdRef.current = activeWorktreeId
+  const refreshDirRef = useRef(refreshDir)
+  refreshDirRef.current = refreshDir
+  const setSelectedPathRef = useRef(setSelectedPath)
+  setSelectedPathRef.current = setSelectedPath
+  const operationOwnerRef = useRef(operationOwner)
+  operationOwnerRef.current = operationOwner
+
+  return useCallback((destinationDir: string) => {
+    void pasteClipboardFilesIntoExplorerFolder({
+      destinationDir,
+      worktreeId: activeWorktreeIdRef.current,
+      worktreePath: worktreePathRef.current,
+      operationOwner: operationOwnerRef.current,
+      refreshDir: refreshDirRef.current,
+      setSelectedPath: setSelectedPathRef.current
+    })
+  }, [])
+}

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2803,6 +2803,7 @@ function createWebUiApi(): NonNullable<Partial<PreloadApi>['ui']> {
       Promise.reject(new Error('Selection clipboard is unavailable in the web client')),
     writeClipboardImage: () => Promise.resolve(),
     writeClipboardFile: () => Promise.resolve({ ok: false, reason: 'unsupported-platform' }),
+    readClipboardFile: () => Promise.resolve({ ok: true, filePaths: [] }),
     performNativePaste: () => {
       document.execCommand?.('paste')
     },

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -98,6 +98,7 @@ export type KeybindingActionId =
   | 'fileExplorer.redo'
   | 'fileExplorer.copyPath'
   | 'fileExplorer.copyRelativePath'
+  | 'fileExplorer.paste'
   | 'fileExplorer.delete'
   | 'settings.search'
   | 'terminal.copySelection'
@@ -922,6 +923,14 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     scope: 'fileExplorer',
     searchKeywords: ['shortcut', 'file explorer', 'copy', 'relative', 'path'],
     defaultBindings: platformBindings(['Mod+Alt+Shift+C'])
+  },
+  {
+    id: 'fileExplorer.paste',
+    title: 'Paste file',
+    group: 'File Explorer',
+    scope: 'fileExplorer',
+    searchKeywords: ['shortcut', 'file explorer', 'paste', 'clipboard', 'file'],
+    defaultBindings: platformBindings(['Mod+V'])
   },
   {
     id: 'fileExplorer.delete',


### PR DESCRIPTION
## Description
File Explorer can paste OS-copied files into a folder from the context menu or Cmd/Ctrl+V, including across projects.

## Focused fix
- In scope: Paste of clipboard files into the target folder.
- Out of scope: changing Copy.

## Preserves
- Copy still writes the OS file clipboard. Empty clipboard is a no-op.

## Evidence
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/main/window/clipboard-file-read.test.ts src/renderer/src/components/right-sidebar/file-explorer-clipboard-paste.test.ts`

Fixes #14530
