### PR TITLE
fix(mobile): send Native Chat on hardware Enter

### DIFF
--- a/mobile/src/session/MobileNativeChatComposer.test.ts
+++ b/mobile/src/session/MobileNativeChatComposer.test.ts
@@ -77,6 +77,95 @@ describe('MobileNativeChatComposer', () => {
     ) as { props: { onPress: () => Promise<void> } }
   }
 
+  function composerInput(): {
+    props: {
+      multiline?: boolean
+      onChangeText?: (text: string) => void
+      onKeyPress?: (event: {
+        nativeEvent: { key: string; shiftKey?: boolean; isComposing?: boolean }
+      }) => void
+    }
+  } {
+    if (!renderer) {
+      throw new Error('Composer was not rendered')
+    }
+    return renderer.root.find((node) => node.type === 'TextInput') as {
+      props: {
+        multiline?: boolean
+        onChangeText?: (text: string) => void
+        onKeyPress?: (event: {
+          nativeEvent: { key: string; shiftKey?: boolean; isComposing?: boolean }
+        }) => void
+      }
+    }
+  }
+
+  it('sends on hardware Enter through the existing handleSend path', async () => {
+    const onChangeText = vi.fn()
+    const onSend = vi.fn().mockResolvedValue(true)
+    await render(onSend, onChangeText)
+
+    expect(composerInput().props.multiline).toBe(true)
+    await act(async () => composerInput().props.onKeyPress?.({ nativeEvent: { key: 'Enter' } }))
+
+    expect(onSend).toHaveBeenCalledWith(' hello')
+    expect(onChangeText).not.toHaveBeenCalled()
+  })
+
+  it('keeps Shift+Enter as a newline instead of sending', async () => {
+    const onChangeText = vi.fn()
+    const onSend = vi.fn().mockResolvedValue(true)
+    await render(onSend, onChangeText)
+
+    await act(async () =>
+      composerInput().props.onKeyPress?.({ nativeEvent: { key: 'Enter', shiftKey: true } })
+    )
+    await act(async () => composerInput().props.onChangeText?.(' hello \n'))
+
+    expect(onSend).not.toHaveBeenCalled()
+    expect(onChangeText).toHaveBeenCalledWith(' hello \n')
+  })
+
+  it('does not send while IME composition is confirming', async () => {
+    const onSend = vi.fn().mockResolvedValue(true)
+    await render(onSend, vi.fn())
+
+    await act(async () =>
+      composerInput().props.onKeyPress?.({ nativeEvent: { key: 'Enter', isComposing: true } })
+    )
+
+    expect(onSend).not.toHaveBeenCalled()
+  })
+
+  it('does not send hardware Enter when the composer cannot send', async () => {
+    const onSend = vi.fn().mockResolvedValue(true)
+    await act(async () => {
+      renderer = create(
+        createElement(MobileNativeChatComposer, {
+          value: '   ',
+          onChangeText: vi.fn(),
+          onSend
+        })
+      )
+    })
+
+    await act(async () => composerInput().props.onKeyPress?.({ nativeEvent: { key: 'Enter' } }))
+
+    expect(onSend).not.toHaveBeenCalled()
+  })
+
+  it('swallows the newline multiline TextInput inserts after a hardware submit', async () => {
+    const onChangeText = vi.fn()
+    const onSend = vi.fn().mockResolvedValue(true)
+    await render(onSend, onChangeText)
+
+    await act(async () => composerInput().props.onKeyPress?.({ nativeEvent: { key: 'Enter' } }))
+    await act(async () => composerInput().props.onChangeText?.(' hello \n'))
+
+    expect(onSend).toHaveBeenCalledWith(' hello')
+    expect(onChangeText).not.toHaveBeenCalled()
+  })
+
   it('reports an accepted send without owning route-scoped draft cleanup', async () => {
     const onChangeText = vi.fn()
     const onSend = vi.fn().mockResolvedValue(true)

--- a/mobile/src/session/MobileNativeChatComposer.test.ts
+++ b/mobile/src/session/MobileNativeChatComposer.test.ts
@@ -96,6 +96,9 @@ describe('MobileNativeChatComposer', () => {
         onKeyPress?: (event: {
           nativeEvent: { key: string; shiftKey?: boolean; isComposing?: boolean }
         }) => void
+        onSelectionChange?: (event: {
+          nativeEvent: { selection: { start: number; end: number } }
+        }) => void
       }
     }
   }
@@ -163,6 +166,31 @@ describe('MobileNativeChatComposer', () => {
     await act(async () => composerInput().props.onChangeText?.(' hello \n'))
 
     expect(onSend).toHaveBeenCalledWith(' hello')
+    expect(onChangeText).not.toHaveBeenCalled()
+  })
+
+  it('swallows a mid-caret newline inserted after hardware submit', async () => {
+    const onChangeText = vi.fn()
+    const onSend = vi.fn().mockResolvedValue(true)
+    await act(async () => {
+      renderer = create(
+        createElement(MobileNativeChatComposer, {
+          value: 'hello',
+          onChangeText,
+          onSend
+        })
+      )
+    })
+
+    await act(async () =>
+      composerInput().props.onSelectionChange?.({
+        nativeEvent: { selection: { start: 2, end: 2 } }
+      })
+    )
+    await act(async () => composerInput().props.onKeyPress?.({ nativeEvent: { key: 'Enter' } }))
+    await act(async () => composerInput().props.onChangeText?.('he\nllo'))
+
+    expect(onSend).toHaveBeenCalledWith('hello')
     expect(onChangeText).not.toHaveBeenCalled()
   })
 

--- a/mobile/src/session/MobileNativeChatComposer.tsx
+++ b/mobile/src/session/MobileNativeChatComposer.tsx
@@ -87,6 +87,9 @@ export function MobileNativeChatComposer({
     null
   )
   const sendingRef = useRef(false)
+  // Multiline Return still inserts `\n` after onKeyPress; drop that one change
+  // so a send that already cleared the draft cannot bounce it back.
+  const suppressSubmitNewlineRef = useRef(false)
   const [sending, setSending] = useState(false)
   const trimmed = value.trim()
   const sessionOptionDispatching = sessionOptions?.controller.pendingId != null
@@ -127,6 +130,11 @@ export function MobileNativeChatComposer({
   }, [onNeedFiles, trigger?.kind, trigger?.query])
 
   const handleChange = (next: string): void => {
+    if (suppressSubmitNewlineRef.current && next === `${value}\n`) {
+      suppressSubmitNewlineRef.current = false
+      return
+    }
+    suppressSubmitNewlineRef.current = false
     onChangeText(next)
   }
 
@@ -159,6 +167,19 @@ export function MobileNativeChatComposer({
       sendingRef.current = false
       setSending(false)
     }
+  }
+
+  const handleKeyPress = (event: {
+    nativeEvent: { key: string; shiftKey?: boolean; isComposing?: boolean }
+  }): void => {
+    const { key, shiftKey, isComposing } = event.nativeEvent
+    // Why: IME Enter confirms composition; submitting would send a partial draft.
+    if (key !== 'Enter' || shiftKey || isComposing || !canSend) {
+      return
+    }
+    // Why: hardware Enter sends like desktop; Shift+Enter stays a newline (#14744).
+    suppressSubmitNewlineRef.current = true
+    void handleSend()
   }
 
   return (
@@ -201,6 +222,7 @@ export function MobileNativeChatComposer({
             style={styles.input}
             value={value}
             onChangeText={handleChange}
+            onKeyPress={handleKeyPress}
             // Controlled only transiently right after an autocomplete insert.
             selection={pendingSelection ?? undefined}
             onSelectionChange={(e) => {

--- a/mobile/src/session/MobileNativeChatComposer.tsx
+++ b/mobile/src/session/MobileNativeChatComposer.tsx
@@ -87,9 +87,10 @@ export function MobileNativeChatComposer({
     null
   )
   const sendingRef = useRef(false)
+  const selectionRef = useRef<{ start: number; end: number } | null>(null)
   // Multiline Return still inserts `\n` after onKeyPress; drop that one change
   // so a send that already cleared the draft cannot bounce it back.
-  const suppressSubmitNewlineRef = useRef(false)
+  const suppressSubmitNewlineRef = useRef<{ start: number; end: number } | null>(null)
   const [sending, setSending] = useState(false)
   const trimmed = value.trim()
   const sessionOptionDispatching = sessionOptions?.controller.pendingId != null
@@ -130,11 +131,15 @@ export function MobileNativeChatComposer({
   }, [onNeedFiles, trigger?.kind, trigger?.query])
 
   const handleChange = (next: string): void => {
-    if (suppressSubmitNewlineRef.current && next === `${value}\n`) {
-      suppressSubmitNewlineRef.current = false
-      return
+    const pending = suppressSubmitNewlineRef.current
+    if (pending) {
+      suppressSubmitNewlineRef.current = null
+      // Why: mid-caret Enter inserts at the selection, not at value + '\n'.
+      const expected = `${value.slice(0, pending.start)}\n${value.slice(pending.end)}`
+      if (next === expected) {
+        return
+      }
     }
-    suppressSubmitNewlineRef.current = false
     onChangeText(next)
   }
 
@@ -162,6 +167,7 @@ export function MobileNativeChatComposer({
       const accepted = await onSend(value.trimEnd())
       if (accepted) {
         setCursor(0)
+        selectionRef.current = { start: 0, end: 0 }
       }
     } finally {
       sendingRef.current = false
@@ -178,7 +184,8 @@ export function MobileNativeChatComposer({
       return
     }
     // Why: hardware Enter sends like desktop; Shift+Enter stays a newline (#14744).
-    suppressSubmitNewlineRef.current = true
+    suppressSubmitNewlineRef.current = pendingSelection ??
+      selectionRef.current ?? { start: value.length, end: value.length }
     void handleSend()
   }
 
@@ -226,7 +233,9 @@ export function MobileNativeChatComposer({
             // Controlled only transiently right after an autocomplete insert.
             selection={pendingSelection ?? undefined}
             onSelectionChange={(e) => {
-              setCursor(e.nativeEvent.selection.end)
+              const { start, end } = e.nativeEvent.selection
+              setCursor(end)
+              selectionRef.current = { start, end }
               setPendingSelection(null)
             }}
             placeholder={placeholder}


### PR DESCRIPTION
## Description
Hardware Enter/Return in mobile Native Chat now sends the message.
Shift+Enter still inserts a newline.

## Focused fix
- In scope: hardware Enter → existing `handleSend()`.
- Out of scope: removing multiline.

## Preserves
- Soft-keyboard multiline and IME composition are unchanged.

## Evidence
- Test: `cd mobile && pnpm exec vitest run src/session/MobileNativeChatComposer.test.ts`
- 18 passed.

Fixes #14744
