### PR TITLE
fix(editor): apply terminal line height to Monaco

### DIFF
--- a/src/renderer/src/components/editor/MonacoEditor.line-height.test.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.line-height.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment happy-dom
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const editorProps = vi.hoisted(() => ({ current: null as Record<string, unknown> | null }))
+const storeState = vi.hoisted(() => ({
+  current: {
+    theme: 'dark',
+    terminalFontSize: 13,
+    terminalFontFamily: 'monospace'
+  } as Record<string, unknown>
+}))
+
+vi.mock('@monaco-editor/react', () => ({
+  default: (props: Record<string, unknown>) => {
+    editorProps.current = props
+    return null
+  },
+  loader: { config: vi.fn() }
+}))
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      settings: storeState.current,
+      editorFontZoomLevel: 0,
+      setPendingEditorReveal: vi.fn(),
+      setEditorCursorLine: vi.fn(),
+      addDiffComment: vi.fn(),
+      deleteDiffComment: vi.fn(),
+      updateDiffComment: vi.fn(),
+      scrollToDiffCommentId: null,
+      setScrollToDiffCommentId: vi.fn(),
+      worktreeDiffComments: {}
+    })
+}))
+vi.mock('../diff-comments/useDiffCommentDecorator', () => ({
+  useDiffCommentDecorator: vi.fn()
+}))
+vi.mock('./useContextualCopySetup', () => ({
+  useContextualCopySetup: () => ({ setupCopy: vi.fn(), toastNode: null })
+}))
+
+import MonacoEditor from './MonacoEditor'
+
+function renderEditor(): Record<string, unknown> | undefined {
+  render(
+    <MonacoEditor
+      fileId="file"
+      filePath="/repo/file.py"
+      viewStateKey="pane:file"
+      relativePath="file.py"
+      content="print('hi')"
+      language="python"
+      onContentChange={vi.fn()}
+      onSave={vi.fn()}
+      readOnly
+    />
+  )
+  return editorProps.current?.options as Record<string, unknown> | undefined
+}
+
+afterEach(() => {
+  cleanup()
+  editorProps.current = null
+})
+
+describe('MonacoEditor line height', () => {
+  it('keeps the documented default of 1 when terminal Line Height is unset', () => {
+    storeState.current = {
+      theme: 'dark',
+      terminalFontSize: 13,
+      terminalFontFamily: 'monospace'
+    }
+    const options = renderEditor()
+    expect(options?.lineHeight).toBe(13)
+  })
+
+  it('derives constructed lineHeight from the terminal Line Height setting', () => {
+    storeState.current = {
+      theme: 'dark',
+      terminalFontSize: 13,
+      terminalFontFamily: 'monospace',
+      terminalLineHeight: 1.35
+    }
+    const options = renderEditor()
+    expect(options?.lineHeight).toBe(17.55)
+  })
+})

--- a/src/renderer/src/components/editor/MonacoEditor.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.tsx
@@ -9,7 +9,11 @@ import type { MarkdownDocument } from '../../../../shared/filesystem-entry-types
 import { useAppStore } from '@/store'
 import { scrollTopCache, cursorPositionCache, setWithLRU } from '@/lib/scroll-cache'
 import '@/lib/monaco-setup'
-import { computeEditorFontSize, resolveEditorFontFamily } from '@/lib/editor-font-zoom'
+import {
+  computeEditorFontSize,
+  computeEditorLineHeight,
+  resolveEditorFontFamily
+} from '@/lib/editor-font-zoom'
 import { registerFileSearchSelectedTextProvider } from '@/lib/file-search-selection'
 
 import { useContextualCopySetup } from './useContextualCopySetup'
@@ -157,18 +161,19 @@ export default function MonacoEditor({
     settings?.terminalFontSize ?? 13,
     editorFontZoomLevel
   )
+  const editorLineHeight = computeEditorLineHeight(editorFontSize, settings?.terminalLineHeight)
   const editorFontFamily = resolveEditorFontFamily(settings)
   const editorWordWrap = settings?.editorWordWrap
   const estimatedAutoHeight = useMemo(() => {
     if (!autoHeight) {
       return null
     }
-    return getMonacoAutoHeightForContent(content, Math.ceil(editorFontSize * 1.45))
-  }, [autoHeight, content, editorFontSize])
+    return getMonacoAutoHeightForContent(content, Math.ceil(editorLineHeight))
+  }, [autoHeight, content, editorLineHeight])
   const renderedEditorHeight = autoHeight
     ? (autoHeightContentHeight ?? estimatedAutoHeight ?? 80)
     : null
-  const autoHeightLineHeight = Math.ceil(editorFontSize * 1.45)
+  const autoHeightLineHeight = Math.ceil(editorLineHeight)
   const autoHeightUsesInternalScroll =
     autoHeight && isMonacoAutoHeightCapped(renderedEditorHeight, autoHeightLineHeight)
   // Why: @monaco-editor/react skips its value→model sync on the first post-remount render, so retained models need an explicit sync or they show stale text.
@@ -732,9 +737,10 @@ export default function MonacoEditor({
     editorRef.current.updateOptions({
       fontSize: editorFontSize,
       fontFamily: editorFontFamily,
+      lineHeight: editorLineHeight,
       ...buildFileEditorWordWrapOptions(editorWordWrap)
     })
-  }, [editorFontFamily, editorFontSize, editorWordWrap])
+  }, [editorFontFamily, editorFontSize, editorLineHeight, editorWordWrap])
 
   useEffect(() => {
     markdownDocLinkDecorationsRef.current?.refresh()
@@ -850,6 +856,7 @@ export default function MonacoEditor({
           ...buildFileEditorWordWrapOptions(editorWordWrap),
           fontSize: editorFontSize,
           fontFamily: editorFontFamily,
+          lineHeight: editorLineHeight,
           lineNumbers: 'on',
           renderLineHighlight: 'line',
           automaticLayout: true,

--- a/src/renderer/src/lib/editor-font-zoom.test.ts
+++ b/src/renderer/src/lib/editor-font-zoom.test.ts
@@ -3,9 +3,11 @@ import { describe, expect, it } from 'vitest'
 import {
   computeDiffEditorFontSize,
   computeEditorFontSize,
+  computeEditorLineHeight,
   resolveEditorFontFamily,
   resolveEditorFontFamilyOrInherit
 } from './editor-font-zoom'
+import { MIN_TERMINAL_LINE_HEIGHT } from '../../../shared/terminal-line-height-settings'
 
 describe('editor font zoom', () => {
   it('keeps diff editors smaller than regular editor surfaces', () => {
@@ -16,6 +18,25 @@ describe('editor font zoom', () => {
   it('keeps diff editor font size within the editor safety bounds', () => {
     expect(computeDiffEditorFontSize(10, -6)).toBe(8)
     expect(computeDiffEditorFontSize(24, 18)).toBe(32)
+  })
+})
+
+describe('computeEditorLineHeight', () => {
+  it('keeps the documented default of 1 when terminal Line Height is unset', () => {
+    expect(computeEditorLineHeight(13)).toBe(13 * MIN_TERMINAL_LINE_HEIGHT)
+    expect(computeEditorLineHeight(13, undefined)).toBe(13)
+    expect(computeEditorLineHeight(13, Number.NaN)).toBe(13)
+  })
+
+  it('derives Monaco px lineHeight from the terminal Line Height setting', () => {
+    expect(computeEditorLineHeight(13, 1)).toBe(13)
+    expect(computeEditorLineHeight(13, 1.35)).toBe(17.55)
+    expect(computeEditorLineHeight(15, 1.2)).toBe(18)
+  })
+
+  it('clamps inherited terminal Line Height to the same 1–3 bounds as the terminal', () => {
+    expect(computeEditorLineHeight(13, 0.85)).toBe(13)
+    expect(computeEditorLineHeight(13, 4)).toBe(39)
   })
 })
 

--- a/src/renderer/src/lib/editor-font-zoom.ts
+++ b/src/renderer/src/lib/editor-font-zoom.ts
@@ -1,3 +1,5 @@
+import { normalizeTerminalLineHeight } from '../../../shared/terminal-line-height-settings'
+
 const EDITOR_FONT_ZOOM_MIN = -6
 const EDITOR_FONT_ZOOM_MAX = 18
 const EDITOR_FONT_ZOOM_STEP = 1
@@ -29,6 +31,16 @@ export function computeDiffEditorFontSize(baseFontSize: number, zoomLevel: numbe
   // Why: diff editors have denser gutters and inline decorations, so matching
   // terminal font size makes review views feel oversized relative to app chrome.
   return computeEditorFontSize(baseFontSize - 0.5, zoomLevel)
+}
+
+/**
+ * Monaco `lineHeight` in px. Inherits terminal Line Height.
+ * Unset / invalid values keep the documented default of 1 (`MIN_TERMINAL_LINE_HEIGHT`).
+ * Why: omitting this option leaves Monaco on GOLDEN_LINE_HEIGHT_RATIO (1.5 on
+ * macOS), so the file view cannot match a terminal at Line Height 1.
+ */
+export function computeEditorLineHeight(fontSize: number, terminalLineHeight?: number): number {
+  return fontSize * normalizeTerminalLineHeight(terminalLineHeight)
 }
 
 export type EditorFontFamilySettings = {


### PR DESCRIPTION
## Description
The file editor now passes Monaco `lineHeight` from the terminal Line Height setting so file view can match terminal spacing.

## Focused fix
- In scope: one Monaco option derived from the existing setting.
- Out of scope: restyling the editor.

## Preserves
- Unset/invalid line height keeps the documented default (1× font size).

## Evidence
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/editor-font-zoom.test.ts src/renderer/src/components/editor/MonacoEditor.line-height.test.tsx`

Fixes #14257
