### PR TITLE
fix(terminal): do not inherit nice -8 into integrated PTYs

### DIFF
--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -10,12 +10,14 @@ const {
   isPwshAvailableMock,
   validateWorkingDirectoryMock,
   resolveUnixShellPathMock,
-  resolveAgentForegroundProcessMock
+  resolveAgentForegroundProcessMock,
+  resetLinuxPtyChildPriorityMock
 } = vi.hoisted(() => ({
   spawnMock: vi.fn(),
   isPwshAvailableMock: vi.fn(),
   resolveUnixShellPathMock: vi.fn((shellPath: string) => shellPath),
   resolveAgentForegroundProcessMock: vi.fn(),
+  resetLinuxPtyChildPriorityMock: vi.fn(),
   validateWorkingDirectoryMock: vi.fn((cwd: string) => {
     if (cwd.includes('definitely-missing')) {
       throw new Error(
@@ -27,6 +29,10 @@ const {
 
 vi.mock('node-pty', () => ({
   spawn: spawnMock
+}))
+
+vi.mock('../pty/linux-pty-child-priority', () => ({
+  resetLinuxPtyChildPriority: resetLinuxPtyChildPriorityMock
 }))
 
 vi.mock('../pwsh', () => ({
@@ -99,6 +105,7 @@ describe('createPtySubprocess', () => {
   it('spawns node-pty with correct options', () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
+    resetLinuxPtyChildPriorityMock.mockClear()
     const onMacosTccSpawnStrategy = vi.fn()
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { value: 'linux' })
@@ -129,6 +136,41 @@ describe('createPtySubprocess', () => {
       })
     )
     expect(onMacosTccSpawnStrategy).toHaveBeenCalledWith('direct')
+    expect(resetLinuxPtyChildPriorityMock).toHaveBeenCalledWith(proc.pid)
+  })
+
+  it('does not rewrite Linux spawn file/args when resetting child niceness', () => {
+    const proc = mockPtyProcess(4242)
+    spawnMock.mockReturnValue(proc)
+    resetLinuxPtyChildPriorityMock.mockClear()
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })
+
+    try {
+      createPtySubprocess({
+        sessionId: 'test',
+        cols: 80,
+        rows: 24,
+        cwd: '/home/user',
+        env: { SHELL: '/bin/bash' }
+      })
+    } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      '/bin/bash',
+      expect.any(Array),
+      expect.objectContaining({
+        cols: 80,
+        rows: 24,
+        cwd: '/home/user'
+      })
+    )
+    expect(spawnMock.mock.calls[0]?.[0]).not.toBe('nice')
+    expect(resetLinuxPtyChildPriorityMock).toHaveBeenCalledWith(4242)
   })
 
   it('does not report a spawn strategy when node-pty fails before launch', () => {

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -18,6 +18,7 @@ import {
   validateWorkingDirectory
 } from '../providers/local-pty-utils'
 import { wrapShellSpawnForMacosTccAttribution } from '../providers/macos-tcc-login-shell'
+import { resetLinuxPtyChildPriority } from '../pty/linux-pty-child-priority'
 import { signalPosixPtyForegroundGroup } from '../pty/posix-pty-foreground-group'
 import { readPtsName } from '../pty/node-pty-pts-name'
 import {
@@ -579,6 +580,7 @@ function spawnDaemonPtyWithWindowsFallback(args: {
       // Why: legacy system ConPTY can corrupt full-width TUI rows in scrollback; bundled ConPTY has the wrap-marker behavior xterm expects.
       ...(process.platform === 'win32' ? { useConptyDll: true } : {})
     })
+    resetLinuxPtyChildPriority(proc.pid)
     args.onMacosTccSpawnStrategy?.(wrapped.file === shellPath ? 'direct' : 'wrapped')
     return proc
   }

--- a/src/main/providers/local-pty-utils.test.ts
+++ b/src/main/providers/local-pty-utils.test.ts
@@ -2,14 +2,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as fs from 'node:fs'
 import type { Stats } from 'node:fs'
 
-const { existsSyncMock, statSyncMock, accessSyncMock, wslUncDirectoryExistsMock, wrapSpawnMock } =
-  vi.hoisted(() => ({
-    existsSyncMock: vi.fn(),
-    statSyncMock: vi.fn(),
-    accessSyncMock: vi.fn(),
-    wslUncDirectoryExistsMock: vi.fn(),
-    wrapSpawnMock: vi.fn()
-  }))
+const {
+  existsSyncMock,
+  statSyncMock,
+  accessSyncMock,
+  wslUncDirectoryExistsMock,
+  wrapSpawnMock,
+  resetLinuxPtyChildPriorityMock
+} = vi.hoisted(() => ({
+  existsSyncMock: vi.fn(),
+  statSyncMock: vi.fn(),
+  accessSyncMock: vi.fn(),
+  wslUncDirectoryExistsMock: vi.fn(),
+  wrapSpawnMock: vi.fn(),
+  resetLinuxPtyChildPriorityMock: vi.fn()
+}))
 
 vi.mock('fs', async (importOriginal) => {
   const actual = await importOriginal<typeof fs>()
@@ -31,6 +38,10 @@ vi.mock('../wsl', () => ({
 
 vi.mock('./macos-tcc-login-shell', () => ({
   wrapShellSpawnForMacosTccAttribution: wrapSpawnMock
+}))
+
+vi.mock('../pty/linux-pty-child-priority', () => ({
+  resetLinuxPtyChildPriority: resetLinuxPtyChildPriorityMock
 }))
 
 import {
@@ -236,5 +247,111 @@ describe('spawnShellWithFallback macOS TCC login wrapping', () => {
       expect.objectContaining({ cwd: '/work' })
     )
     expect(result.shellPath).toBe('/bin/bash')
+  })
+})
+
+describe('spawnShellWithFallback Linux PTY child priority', () => {
+  let origPlatform: PropertyDescriptor | undefined
+
+  beforeEach(() => {
+    origPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })
+    existsSyncMock.mockReturnValue(true)
+    statSyncMock.mockReturnValue(dirStats(true))
+    accessSyncMock.mockReturnValue(undefined)
+    wrapSpawnMock.mockImplementation((file: string, args: string[]) => ({ file, args }))
+    resetLinuxPtyChildPriorityMock.mockReset()
+  })
+
+  afterEach(() => {
+    if (origPlatform) {
+      Object.defineProperty(process, 'platform', origPlatform)
+    }
+    vi.restoreAllMocks()
+  })
+
+  it('resets the spawned child pid and leaves spawn file/args unchanged', () => {
+    const ptySpawn = vi.fn().mockReturnValue({ pid: 4242 })
+
+    const result = spawnShellWithFallback({
+      shellPath: '/bin/zsh',
+      shellArgs: ['-l'],
+      cols: 80,
+      rows: 24,
+      cwd: '/work',
+      env: {},
+      ptySpawn: ptySpawn as never
+    })
+
+    expect(ptySpawn).toHaveBeenCalledWith(
+      '/bin/zsh',
+      ['-l'],
+      expect.objectContaining({ cwd: '/work', cols: 80, rows: 24 })
+    )
+    expect(resetLinuxPtyChildPriorityMock).toHaveBeenCalledTimes(1)
+    expect(resetLinuxPtyChildPriorityMock).toHaveBeenCalledWith(4242)
+    expect(result.shellPath).toBe('/bin/zsh')
+  })
+
+  it('resets fallback-shell children too', () => {
+    const ptySpawn = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        throw new Error('primary boom')
+      })
+      .mockReturnValue({ pid: 77 })
+
+    spawnShellWithFallback({
+      shellPath: '/bin/zsh',
+      shellArgs: ['-l'],
+      cols: 80,
+      rows: 24,
+      cwd: '/work',
+      env: {},
+      ptySpawn: ptySpawn as never
+    })
+
+    expect(resetLinuxPtyChildPriorityMock).toHaveBeenCalledTimes(1)
+    expect(resetLinuxPtyChildPriorityMock).toHaveBeenCalledWith(77)
+  })
+})
+
+describe('spawnShellWithFallback non-Linux PTY child priority', () => {
+  let origPlatform: PropertyDescriptor | undefined
+
+  afterEach(() => {
+    if (origPlatform) {
+      Object.defineProperty(process, 'platform', origPlatform)
+    }
+    vi.restoreAllMocks()
+  })
+
+  it('still invokes the reset helper so the platform no-op stays at the wrapper', () => {
+    origPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'darwin' })
+    existsSyncMock.mockReturnValue(true)
+    statSyncMock.mockReturnValue(dirStats(true))
+    accessSyncMock.mockReturnValue(undefined)
+    wrapSpawnMock.mockImplementation((file: string, args: string[]) => ({ file, args }))
+    resetLinuxPtyChildPriorityMock.mockReset()
+    const ptySpawn = vi.fn().mockReturnValue({ pid: 9 })
+
+    spawnShellWithFallback({
+      shellPath: '/bin/zsh',
+      shellArgs: ['-l'],
+      cols: 80,
+      rows: 24,
+      cwd: '/work',
+      env: {},
+      ptySpawn: ptySpawn as never
+    })
+
+    // Why: spawn options stay the shell; the wrapper no-ops off Linux.
+    expect(ptySpawn).toHaveBeenCalledWith(
+      '/bin/zsh',
+      ['-l'],
+      expect.objectContaining({ cwd: '/work' })
+    )
+    expect(resetLinuxPtyChildPriorityMock).toHaveBeenCalledWith(9)
   })
 })

--- a/src/main/providers/local-pty-utils.ts
+++ b/src/main/providers/local-pty-utils.ts
@@ -3,6 +3,7 @@ import { existsSync, accessSync, statSync, chmodSync, constants as fsConstants }
 import { release } from 'node:os'
 import type * as pty from 'node-pty'
 import { isWslUncPath } from '../../shared/wsl-paths'
+import { resetLinuxPtyChildPriority } from '../pty/linux-pty-child-priority'
 import { wslUncDirectoryExists } from '../wsl'
 import { wrapShellSpawnForMacosTccAttribution } from './macos-tcc-login-shell'
 
@@ -224,6 +225,7 @@ function spawnWindowsFallbackChain(
         env,
         ...windowsConptyDllOptions()
       })
+      resetLinuxPtyChildPriority(proc.pid)
       console.warn(
         `[pty] Primary shell "${params.shellPath}" failed (${primaryError}), fell back to "${attempt.shellPath}"`
       )
@@ -265,15 +267,17 @@ export function spawnShellWithFallback(params: ShellSpawnParams): ShellSpawnResu
   if (!primaryError) {
     try {
       const wrapped = wrapShellSpawnForMacosTccAttribution(shellPath, shellArgs, env)
+      const proc = ptySpawn(wrapped.file, wrapped.args, {
+        name: termName,
+        cols,
+        rows,
+        cwd,
+        env,
+        ...windowsConptyDllOptions()
+      })
+      resetLinuxPtyChildPriority(proc.pid)
       return {
-        process: ptySpawn(wrapped.file, wrapped.args, {
-          name: termName,
-          cols,
-          rows,
-          cwd,
-          env,
-          ...windowsConptyDllOptions()
-        }),
+        process: proc,
         shellPath
       }
     } catch (err) {
@@ -312,6 +316,7 @@ export function spawnShellWithFallback(params: ShellSpawnParams): ShellSpawnResu
           cwd,
           env
         })
+        resetLinuxPtyChildPriority(proc.pid)
         console.warn(
           `[pty] Primary shell "${shellPath}" failed (${primaryError ?? 'unknown error'}), fell back to "${fallback}"`
         )

--- a/src/main/pty/linux-pty-child-priority.test.ts
+++ b/src/main/pty/linux-pty-child-priority.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { constants } from 'node:os'
+import type * as Os from 'node:os'
+
+const setPriorityMock = vi.hoisted(() => vi.fn())
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof Os>()
+  return {
+    ...actual,
+    setPriority: setPriorityMock
+  }
+})
+
+import { resetLinuxPtyChildPriority } from './linux-pty-child-priority'
+
+function setPlatform(platform: NodeJS.Platform): () => void {
+  const original = Object.getOwnPropertyDescriptor(process, 'platform')
+  Object.defineProperty(process, 'platform', { configurable: true, value: platform })
+  return () => {
+    if (original) {
+      Object.defineProperty(process, 'platform', original)
+    }
+  }
+}
+
+describe('resetLinuxPtyChildPriority', () => {
+  let restorePlatform: (() => void) | null = null
+
+  afterEach(() => {
+    restorePlatform?.()
+    restorePlatform = null
+    setPriorityMock.mockReset()
+  })
+
+  it('sets the child to PRIORITY_NORMAL on Linux without touching this process', () => {
+    restorePlatform = setPlatform('linux')
+
+    expect(resetLinuxPtyChildPriority(4242)).toBe(true)
+    expect(setPriorityMock).toHaveBeenCalledTimes(1)
+    expect(setPriorityMock).toHaveBeenCalledWith(4242, constants.priority.PRIORITY_NORMAL)
+    expect(setPriorityMock.mock.calls[0]?.[0]).not.toBe(process.pid)
+  })
+
+  it('leaves darwin and win32 children on the inherited priority', () => {
+    for (const platform of ['darwin', 'win32'] as const) {
+      restorePlatform?.()
+      restorePlatform = setPlatform(platform)
+      setPriorityMock.mockClear()
+
+      expect(resetLinuxPtyChildPriority(4242)).toBe(false)
+      expect(setPriorityMock).not.toHaveBeenCalled()
+    }
+  })
+
+  it('ignores missing or invalid child pids', () => {
+    restorePlatform = setPlatform('linux')
+
+    expect(resetLinuxPtyChildPriority(undefined)).toBe(false)
+    expect(resetLinuxPtyChildPriority(0)).toBe(false)
+    expect(resetLinuxPtyChildPriority(-1)).toBe(false)
+    expect(setPriorityMock).not.toHaveBeenCalled()
+  })
+
+  it('swallows setPriority failures so spawn still succeeds', () => {
+    restorePlatform = setPlatform('linux')
+    setPriorityMock.mockImplementation(() => {
+      throw new Error('EPERM')
+    })
+
+    expect(resetLinuxPtyChildPriority(4242)).toBe(false)
+  })
+})

--- a/src/main/pty/linux-pty-child-priority.ts
+++ b/src/main/pty/linux-pty-child-priority.ts
@@ -1,0 +1,24 @@
+import { constants, setPriority } from 'node:os'
+
+/**
+ * Reset an integrated PTY child's niceness to 0 on Linux.
+ *
+ * Why: Electron/Chromium runs the main process at nice -8. node-pty children
+ * inherit that and so do Gradle/clang++ trees started from the terminal,
+ * which can starve the desktop compositor (#14639). Only the child is
+ * changed — never this process.
+ */
+export function resetLinuxPtyChildPriority(pid: number | undefined): boolean {
+  if (process.platform !== 'linux') {
+    return false
+  }
+  if (pid === undefined || !Number.isSafeInteger(pid) || pid <= 0) {
+    return false
+  }
+  try {
+    setPriority(pid, constants.priority.PRIORITY_NORMAL)
+    return true
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## Description
Linux integrated terminals no longer inherit Electron's nice -8.
Child PTY PIDs are reset to `PRIORITY_NORMAL` after spawn.

## Focused fix
- In scope: Linux PTY child niceness only.
- Out of scope: changing main-process priority.

## Preserves
- macOS/Windows spawn is unchanged. Main process stays at its current nice.

## Evidence
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/main/pty/linux-pty-child-priority.test.ts src/main/providers/local-pty-utils.test.ts`

Fixes #14639
