### PR TITLE
fix(terminal): refresh desktop TUI after mobile-fit ends

### DIFF
--- a/src/renderer/src/components/terminal-pane/desktop-fit-fallback.test.ts
+++ b/src/renderer/src/components/terminal-pane/desktop-fit-fallback.test.ts
@@ -1,19 +1,26 @@
 import { describe, expect, it, vi } from 'vitest'
-import { applyDesktopFitFallbackAfterReplay } from './desktop-fit-fallback'
+import {
+  applyDesktopFitFallbackAfterReplay,
+  fitAndRefreshDesktopPane,
+  refreshDesktopPaneContents
+} from './desktop-fit-fallback'
 import {
   beginTerminalScrollIntentBufferRebuild,
   endTerminalScrollIntentBufferRebuild
 } from '@/lib/pane-manager/terminal-scroll-intent-rebuild'
 
-function createPane() {
+function createPane(
+  options: { rows?: number; proposed?: { cols: number; rows: number } | null } = {}
+) {
   const terminal = {
     cols: 49,
-    rows: 20,
+    rows: options.rows ?? 20,
     buffer: { active: { type: 'normal', viewportY: 0, baseY: 0 } },
     resize: vi.fn((cols: number, rows: number) => {
       terminal.cols = cols
       terminal.rows = rows
-    })
+    }),
+    refresh: vi.fn()
   }
   return {
     terminal,
@@ -22,7 +29,7 @@ function createPane() {
       getBoundingClientRect: () => ({ width: 800, height: 600 })
     },
     fitAddon: {
-      proposeDimensions: vi.fn(() => null),
+      proposeDimensions: vi.fn(() => (options.proposed === undefined ? null : options.proposed)),
       fit: vi.fn()
     }
   }
@@ -44,6 +51,7 @@ describe('desktop fit fallback', () => {
     endTerminalScrollIntentBufferRebuild(pane.terminal)
     await Promise.resolve()
     expect(pane.terminal.resize).toHaveBeenCalledWith(120, 40)
+    expect(pane.terminal.refresh).toHaveBeenCalledWith(0, 39)
   })
 
   it('drops deferred dimensions when the pane binding becomes stale', async () => {
@@ -62,5 +70,67 @@ describe('desktop fit fallback', () => {
     endTerminalScrollIntentBufferRebuild(pane.terminal)
     await Promise.resolve()
     expect(pane.terminal.resize).not.toHaveBeenCalled()
+    expect(pane.terminal.refresh).not.toHaveBeenCalled()
+  })
+
+  it('refreshes the canvas after a stuck-grid fallback resize', async () => {
+    const pane = createPane({ proposed: null })
+    applyDesktopFitFallbackAfterReplay(pane as never, {
+      cols: 120,
+      rows: 40,
+      priorCols: 49,
+      priorRows: 20
+    })
+
+    expect(pane.terminal.resize).toHaveBeenCalledWith(120, 40)
+    expect(pane.terminal.refresh).toHaveBeenCalledWith(0, 39)
+  })
+})
+
+describe('fitAndRefreshDesktopPane', () => {
+  it('fits and refreshes after mobile-fit ends, not only resize bookkeeping', () => {
+    const pane = createPane({ proposed: { cols: 120, rows: 40 } })
+
+    fitAndRefreshDesktopPane(pane as never)
+
+    expect(pane.fitAddon.fit).toHaveBeenCalledTimes(1)
+    expect(pane.terminal.refresh).toHaveBeenCalledWith(0, 19)
+    expect(pane.terminal.resize).not.toHaveBeenCalled()
+  })
+
+  it('still refreshes when fit is a no-op because the grid already matches', () => {
+    const pane = createPane({ proposed: { cols: 49, rows: 20 } })
+
+    fitAndRefreshDesktopPane(pane as never)
+
+    expect(pane.fitAddon.fit).not.toHaveBeenCalled()
+    expect(pane.terminal.refresh).toHaveBeenCalledWith(0, 19)
+  })
+
+  it('skips refresh when the terminal has no rows', () => {
+    const pane = createPane({ rows: 0, proposed: { cols: 120, rows: 40 } })
+
+    refreshDesktopPaneContents(pane as never)
+
+    expect(pane.terminal.refresh).not.toHaveBeenCalled()
+  })
+
+  it('forces a paused renderer through instead of a swallowed refresh', () => {
+    const refreshRows = vi.fn()
+    const pane = createPane()
+    Object.assign(pane.terminal, {
+      _core: {
+        _renderService: {
+          _isPaused: true,
+          _needsFullRefresh: true,
+          refreshRows
+        }
+      }
+    })
+
+    refreshDesktopPaneContents(pane as never)
+
+    expect(refreshRows).toHaveBeenCalledWith(0, 19, true)
+    expect(pane.terminal.refresh).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/terminal-pane/desktop-fit-fallback.ts
+++ b/src/renderer/src/components/terminal-pane/desktop-fit-fallback.ts
@@ -1,5 +1,6 @@
 import type { ManagedPane } from '@/lib/pane-manager/pane-manager-types'
 import { safeFit } from '@/lib/pane-manager/pane-fit'
+import { forceRepaintThroughRenderPause } from '@/lib/pane-manager/terminal-render-pause-release'
 import { deferTerminalGeometryMutationDuringRebuild } from '@/lib/pane-manager/terminal-scroll-intent-rebuild'
 
 type DesktopFitFallbackDimensions = {
@@ -8,6 +9,23 @@ type DesktopFitFallbackDimensions = {
   priorCols?: number | null
   priorRows?: number | null
   shouldApply?: () => boolean
+}
+
+// Why: mobile-fit restore can return cols×rows while xterm's WebGL/paused
+// renderer keeps the phone-sized canvas until a scroll. Present the live
+// buffer after geometry lands; do not change the hold policy.
+export function refreshDesktopPaneContents(pane: Pick<ManagedPane, 'terminal'>): void {
+  if (pane.terminal.rows <= 0) {
+    return
+  }
+  if (!forceRepaintThroughRenderPause(pane.terminal)) {
+    pane.terminal.refresh(0, pane.terminal.rows - 1)
+  }
+}
+
+export function fitAndRefreshDesktopPane(pane: ManagedPane): void {
+  safeFit(pane)
+  refreshDesktopPaneContents(pane)
 }
 
 export function applyDesktopFitFallbackAfterReplay(
@@ -27,6 +45,7 @@ export function applyDesktopFitFallbackAfterReplay(
     if (stuckAtPriorGrid && dimensions.cols > 0 && dimensions.rows > 0) {
       pane.terminal.resize(dimensions.cols, dimensions.rows)
     }
+    refreshDesktopPaneContents(pane)
   }
   // Why: the server dimensions are only a fallback; source-dimension replay
   // must parse and restore its viewport before this can reflow xterm.

--- a/src/renderer/src/components/terminal-pane/use-mobile-overlay-ticks-desktop-fit.test.tsx
+++ b/src/renderer/src/components/terminal-pane/use-mobile-overlay-ticks-desktop-fit.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, render } from '@testing-library/react'
+import { hydrateOverrides, setFitOverride } from '@/lib/pane-manager/mobile-fit-overrides'
+import type { PaneManager } from '@/lib/pane-manager/pane-manager'
+import type { PtyTransport } from './pty-transport'
+import { useMobileOverlayTicks } from './use-mobile-overlay-ticks'
+
+type TestPane = {
+  id: number
+  terminal: {
+    cols: number
+    rows: number
+    refresh: ReturnType<typeof vi.fn>
+    resize: ReturnType<typeof vi.fn>
+  }
+  container: {
+    dataset: Record<string, string>
+    getBoundingClientRect: () => { width: number; height: number }
+  }
+  fitAddon: {
+    fit: ReturnType<typeof vi.fn>
+    proposeDimensions: ReturnType<typeof vi.fn>
+  }
+}
+
+function createPane(): TestPane {
+  const terminal = {
+    cols: 49,
+    rows: 20,
+    refresh: vi.fn(),
+    resize: vi.fn((cols: number, rows: number) => {
+      terminal.cols = cols
+      terminal.rows = rows
+    })
+  }
+  return {
+    id: 1,
+    terminal,
+    container: {
+      dataset: { ptyId: 'pty-1' },
+      getBoundingClientRect: () => ({ width: 800, height: 600 })
+    },
+    fitAddon: {
+      fit: vi.fn(),
+      proposeDimensions: vi.fn(() => ({ cols: 120, rows: 40 }))
+    }
+  }
+}
+
+function HookHost({
+  managerRef,
+  paneTransportsRef
+}: {
+  managerRef: { current: PaneManager | null }
+  paneTransportsRef: { current: ReadonlyMap<number, Pick<PtyTransport, 'getPtyId'>> }
+}): null {
+  useMobileOverlayTicks({ managerRef, paneTransportsRef })
+  return null
+}
+
+describe('useMobileOverlayTicks desktop-fit restore', () => {
+  let rafQueue: FrameRequestCallback[]
+
+  function flushAnimationFrames(): void {
+    const queued = rafQueue
+    rafQueue = []
+    act(() => {
+      for (const callback of queued) {
+        callback(16)
+      }
+    })
+  }
+
+  beforeEach(() => {
+    rafQueue = []
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      rafQueue.push(callback)
+      return rafQueue.length
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+  })
+
+  afterEach(() => {
+    cleanup()
+    hydrateOverrides([])
+    vi.unstubAllGlobals()
+  })
+
+  function mountForPane(pane: TestPane): void {
+    const managerRef = {
+      current: { getPanes: () => [pane] } as unknown as PaneManager
+    }
+    const paneTransportsRef = {
+      current: new Map([[1, { getPtyId: () => 'pty-1' }]])
+    }
+    render(<HookHost managerRef={managerRef} paneTransportsRef={paneTransportsRef} />)
+  }
+
+  it('refits and refreshes when mobile-fit is released, not only resize bookkeeping', () => {
+    const pane = createPane()
+    mountForPane(pane)
+
+    act(() => {
+      setFitOverride('pty-1', 'mobile-fit', 49, 20)
+    })
+    flushAnimationFrames()
+    expect(pane.fitAddon.fit).not.toHaveBeenCalled()
+    expect(pane.terminal.refresh).not.toHaveBeenCalled()
+
+    act(() => {
+      setFitOverride('pty-1', 'desktop-fit', 120, 40)
+    })
+    flushAnimationFrames()
+
+    expect(pane.fitAddon.fit).toHaveBeenCalledTimes(1)
+    expect(pane.terminal.refresh).toHaveBeenCalledWith(0, 19)
+  })
+
+  it('does not refresh while applying a mobile-fit hold', () => {
+    const pane = createPane()
+    pane.terminal.cols = 120
+    pane.terminal.rows = 40
+    mountForPane(pane)
+
+    act(() => {
+      setFitOverride('pty-1', 'mobile-fit', 49, 20)
+    })
+    flushAnimationFrames()
+
+    expect(pane.terminal.resize).toHaveBeenCalledWith(49, 20)
+    expect(pane.terminal.refresh).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/use-mobile-overlay-ticks.ts
+++ b/src/renderer/src/components/terminal-pane/use-mobile-overlay-ticks.ts
@@ -3,7 +3,10 @@ import { onDriverChange } from '@/lib/pane-manager/mobile-driver-state'
 import { onOverrideChange } from '@/lib/pane-manager/mobile-fit-overrides'
 import type { ManagedPane, PaneManager } from '@/lib/pane-manager/pane-manager'
 import { safeFit } from '@/lib/pane-manager/pane-tree-ops'
-import { applyDesktopFitFallbackAfterReplay } from './desktop-fit-fallback'
+import {
+  applyDesktopFitFallbackAfterReplay,
+  fitAndRefreshDesktopPane
+} from './desktop-fit-fallback'
 import { getOverrideAffectedPanes, getPanesNeedingOverrideFit } from './override-affected-panes'
 import type { PtyTransport } from './pty-transport'
 
@@ -100,9 +103,10 @@ export function useMobileOverlayTicks({ managerRef, paneTransportsRef }: MobileO
       }
       if (event.mode === 'desktop-fit') {
         // Why: fitAddon.fit() measures the DOM, so run under rAF after layout settles; the timeout is a safety net if fit silently threw.
+        // Why: size restore alone leaves TUI pixels stale until scroll — refresh after fit.
         const fitAffectedPanes = (): void => {
           for (const pane of getAffectedPanes()) {
-            safeFit(pane)
+            fitAndRefreshDesktopPane(pane)
           }
         }
         scheduleFitFrame(fitAffectedPanes)


### PR DESCRIPTION
## Description
After a mobile session ends, the desktop TUI now fit+refreshes instead of only restoring geometry.

## Focused fix
- In scope: refresh/repaint when mobile-fit lifts.
- Out of scope: changing mobile-fit hold policy.

## Preserves
- mobile-fit hold and restore-target bookkeeping are unchanged.

## Evidence
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/desktop-fit-fallback.test.ts src/renderer/src/components/terminal-pane/use-mobile-overlay-ticks-desktop-fit.test.tsx`

Fixes #14321
