### PR TITLE
fix(wsl): deliver the probed path to the guest shell

### DIFF
--- a/src/main/wsl.test.ts
+++ b/src/main/wsl.test.ts
@@ -813,18 +813,48 @@ describe('wslUncDirectoryExists', () => {
     expect(result).toBe(true)
     expect(execFileSyncMock).toHaveBeenCalledWith(
       'wsl.exe',
-      [
-        '-d',
-        'Ubuntu',
-        '--',
-        'sh',
-        '-c',
-        expect.stringContaining('__ORCA_DIRECTORY_EXISTS__'),
-        'sh',
-        '/home/jin/repo'
-      ],
+      ['-d', 'Ubuntu', '--', 'sh', '-c', expect.stringContaining('__ORCA_DIRECTORY_EXISTS__')],
       expect.objectContaining({ timeout: 5000 })
     )
+  })
+
+  it('inlines the path in the probe script instead of passing it positionally', () => {
+    // Why: a positional `$1` is consumed by the login shell before the guest sh runs.
+    execFileSyncMock.mockReturnValue('__ORCA_DIRECTORY_EXISTS__')
+    withPlatform('win32', () => wslUncDirectoryExists('\\\\wsl.localhost\\Ubuntu\\home\\jin\\repo'))
+    const [, args] = execFileSyncMock.mock.calls[0] as [string, string[]]
+    expect(args).toHaveLength(6)
+    expect(args[5]).toContain("'/home/jin/repo'")
+    expect(args[5]).not.toContain('$1')
+  })
+
+  it('escapes single quotes in the probed path', () => {
+    execFileSyncMock.mockReturnValue('__ORCA_DIRECTORY_EXISTS__')
+    withPlatform('win32', () =>
+      wslUncDirectoryExists("\\\\wsl.localhost\\Ubuntu\\home\\jin\\it's here")
+    )
+    const [, args] = execFileSyncMock.mock.calls[0] as [string, string[]]
+    expect(args[5]).toContain("'/home/jin/it'\\''s here'")
+  })
+
+  it('escapes a dollar sign in the probed path for the wsl.exe argv layer', () => {
+    // Why: an unescaped `$` is expanded before the guest shell sees the quotes.
+    execFileSyncMock.mockReturnValue('__ORCA_DIRECTORY_EXISTS__')
+    withPlatform('win32', () =>
+      wslUncDirectoryExists('\\\\wsl.localhost\\Ubuntu\\home\\jin\\cost$dir')
+    )
+    const [, args] = execFileSyncMock.mock.calls[0] as [string, string[]]
+    expect(args[5]).toContain("'/home/jin/cost\\$dir'")
+  })
+
+  it('refuses to spawn for a backticked path and answers null', () => {
+    // Why: null sends the caller to existsSync rather than rejecting a live path.
+    execFileSyncMock.mockReturnValue('__ORCA_DIRECTORY_EXISTS__')
+    const result = withPlatform('win32', () =>
+      wslUncDirectoryExists('\\\\wsl.localhost\\Ubuntu\\home\\jin\\a`id`b')
+    )
+    expect(result).toBeNull()
+    expect(execFileSyncMock).not.toHaveBeenCalled()
   })
 
   it('returns false when the guest reports the directory missing', () => {
@@ -873,16 +903,7 @@ describe('wslUncDirectoryExistsAsync', () => {
     ).resolves.toBe(true)
     expect(execFileMock).toHaveBeenCalledWith(
       'wsl.exe',
-      [
-        '-d',
-        'Ubuntu',
-        '--',
-        'sh',
-        '-c',
-        expect.stringContaining('__ORCA_DIRECTORY_EXISTS__'),
-        'sh',
-        '/home/jin/repo'
-      ],
+      ['-d', 'Ubuntu', '--', 'sh', '-c', expect.stringContaining("'/home/jin/repo'")],
       expect.objectContaining({ timeout: 5000 }),
       expect.any(Function)
     )
@@ -905,6 +926,19 @@ describe('wslUncDirectoryExistsAsync', () => {
         wslUncDirectoryExistsAsync('\\\\wsl.localhost\\Ubuntu\\home\\jin\\repo')
       ).resolves.toBeNull()
     })
+  })
+
+  it('refuses to spawn asynchronously for a backticked path', async () => {
+    execFileMock.mockImplementation((_command, _args, _options, callback) =>
+      callback(null, '__ORCA_DIRECTORY_EXISTS__')
+    )
+
+    await expect(
+      withPlatformAsync('win32', () =>
+        wslUncDirectoryExistsAsync('\\\\wsl.localhost\\Ubuntu\\home\\jin\\a`id`b')
+      )
+    ).resolves.toBeNull()
+    expect(execFileMock).not.toHaveBeenCalled()
   })
 
   it('returns null without spawning for paths outside WSL or off Windows', async () => {

--- a/src/main/wsl.ts
+++ b/src/main/wsl.ts
@@ -1,4 +1,5 @@
 import { execFile, execFileSync } from 'node:child_process'
+import { escapeWslShCommandForWindows, quotePosixShell } from '../shared/wsl-login-shell-command'
 import { parseWslUncPath, toWindowsWslPath } from '../shared/wsl-paths'
 import { filterUserWslDistros, parseWslDistros } from './wsl-distro-list-output'
 import { wslDistroListRetryDelayMs } from './wsl-distro-retry'
@@ -24,6 +25,8 @@ export type WslPathInfo = {
 const WSL_DIRECTORY_EXISTS_MARKER = '__ORCA_DIRECTORY_EXISTS__'
 const WSL_DIRECTORY_MISSING_MARKER = '__ORCA_DIRECTORY_MISSING__'
 
+// Why: wsl.exe routes this through the distro's login shell, which expands the
+// script text before the requested `sh` sees it, so a positional `$1` arrives empty.
 function getWslDirectoryProbeArgs(info: WslPathInfo): string[] {
   return [
     '-d',
@@ -31,10 +34,16 @@ function getWslDirectoryProbeArgs(info: WslPathInfo): string[] {
     '--',
     'sh',
     '-c',
-    `if [ -d "$1" ]; then printf ${WSL_DIRECTORY_EXISTS_MARKER}; else printf ${WSL_DIRECTORY_MISSING_MARKER}; fi`,
-    'sh',
-    info.linuxPath
+    escapeWslShCommandForWindows(
+      `if [ -d ${quotePosixShell(info.linuxPath)} ]; then printf ${WSL_DIRECTORY_EXISTS_MARKER}; else printf ${WSL_DIRECTORY_MISSING_MARKER}; fi`
+    )
   ]
+}
+
+// Why: that same login shell command-substitutes a backtick under every payload
+// shape, so the path has to be refused rather than quoted.
+function isProbeSafeLinuxPath(linuxPath: string): boolean {
+  return !linuxPath.includes('`')
 }
 
 function parseWslDirectoryProbeOutput(stdout: unknown): boolean | null {
@@ -86,7 +95,7 @@ export function wslUncDirectoryExists(uncPath: string): boolean | null {
     return null
   }
   const info = parseWslUncPath(uncPath)
-  if (!info) {
+  if (!info || !isProbeSafeLinuxPath(info.linuxPath)) {
     return null
   }
   try {
@@ -106,7 +115,7 @@ export function wslUncDirectoryExistsAsync(uncPath: string): Promise<boolean | n
     return Promise.resolve(null)
   }
   const info = parseWslUncPath(uncPath)
-  if (!info) {
+  if (!info || !isProbeSafeLinuxPath(info.linuxPath)) {
     return Promise.resolve(null)
   }
   return new Promise((resolve) => {


### PR DESCRIPTION
## ELI5

Orca asks WSL "does this folder exist?" by handing the path to a small shell script. Another shell sits in between and eats the path before the script sees it, so the answer is always "no" and Orca refuses to open a terminal in any WSL folder. This writes the path into the script instead, so the shell in between has nothing to eat.

## What Changed

`src/main/wsl.ts` — `getWslDirectoryProbeArgs` inlines the probed path into the script instead of passing it positionally, using `quotePosixShell` and `escapeWslShCommandForWindows`, both already exported from `src/shared/wsl-login-shell-command.ts`.

It also refuses to probe a path containing a backtick, returning `null` before spawning, because a paired backtick is command-substituted rather than merely failing (see below). That hardens this probe only — the other nine call sites of `escapeWslShCommandForWindows` are untouched.

`src/main/wsl.test.ts` — both argv assertions pinned the broken shape, so both are updated; five tests added.

Net **+68 / −25** across 2 files: 14 production lines, 54 test lines. One call site, no new file, no wire or schema change.

**On backticked paths.** A directory name can legally contain a backtick, and `parseWslUncPath` keeps it — it only normalizes backslashes. Measured with a `touch` canary on Windows, a paired backtick in the path executes as command substitution under every payload shape, not just this one:

| probe form | canary |
| --- | --- |
| positional (current `main`) | fired |
| inlined (this PR, before the guard) | fired |
| `test -d` (pre-#13420) | fired |

So it is pre-existing rather than introduced here, but this PR is changing that function, so the guard closes it here rather than leaving it open. `null` is what the callers already treat as "ask the filesystem instead". Before #13420 that shape answered `false`, which threw, so this is an improvement on both.

Feeding `escapeWslShCommandForWindows` a path containing `\\` or `\$` also mis-escapes, because its `command[index - 1] !== '\\'` guard reads a backslash in path data as one it already applied. Not reachable from here: `parseWslUncPath` normalizes with `path.replace(/\\/g, '/')`, so a `linuxPath` arriving at this probe cannot contain a backslash at all.

## Why

The path goes to an inner `sh -c` as a positional argument, but wsl.exe routes the post-`--` command line through the distro's default login shell first, and that shell expands unescaped `$` in the script text before the requested `sh` runs. Stock Ubuntu distro, from a Windows scheduled task so no WSL interop parent is in the chain:

```
sh -c 'echo d1=[$1] argc=$#'      sh /tmp  =>  d1=[]     argc=0
sh -c 'echo d1=[\$1] argc=\$#'    sh /tmp  =>  d1=[/tmp] argc=1
```

Escaped, the guest `sh` receives `$1`. Unescaped, the outer shell consumed it, so `[ -d "" ]` is false and **every WSL UNC directory that exists probes as missing**. That answer is `false`, not `null`, and `false` is the one value `validateWorkingDirectory` acts on:

```ts
if (existsInDistro === false) throwMissingWorkingDirectory(cwd)  // throws here
if (existsInDistro === true) return
if (!existsSync(cwd)) throwMissingWorkingDirectory(cwd)          // never reached
```

So the fallback never runs, and any spawn reaching this probe with an explicit WSL UNC cwd fails with `DaemonProtocolError: Working directory "…" does not exist` — while `stat`, `access`, `realpath` and `existsSync` all succeed on that same path in the same process in under 10ms. Consumers are `local-pty-utils.ts:135` (sync) and `pty.ts:6077,6084` (async).

Introduced by `bdd763188` (#13420), which replaced `test -d` with the marker protocol plus `sh -c` and a positional path. The three-state result is worth keeping; only the argument passing is broken — a spawn failure still returns `null` correctly, it is the answered case that is wrong. Escaping the script but keeping the positional path is not enough either: the path element crosses the same hop, scoring 6/9 against 7/9 for inlining, and its `$HOME` row passes only by accident.

## Linked Issue

No pre-existing issue. Regression of #6331 (fixed by #6536), but that one is closed and had a different cause — UNC paths not handled at all, rather than the login-shell hop eating the script text — so reopening it would mislead a later bisect. Happy to file a tracking issue if you would prefer one.

## Visual Proof

`N/A` — no UI or interaction change; a shell-argument fix in the terminal daemon's directory probe.

## Testing

Against a real WSL distro from a clean Windows process:

| path | before | after | expected |
| --- | --- | --- | --- |
| `/home/<user>/enor_agi/misc` | `false` | `true` | `true` |
| ``/tmp/orca probe/quo'te`` | `false` | `true` | `true` |
| `/tmp/orca probe/中文 目錄` | `false` | `true` | `true` |
| `/tmp/orca probe/dollar$dir` | `false` | `true` | `true` |
| ``/tmp/orca probe/back`tick`` | `null` | `null` | `true` |
| `/home/<user>/__definitely_not_here__` | `false` | `false` | `false` |

Five of the nine cases tested change from wrong to right and two were already correct. The backtick row still answers `null`, now because the guard declines to spawn rather than because the probe errored. A nonexistent distro still exits `4294967295` and maps to `null`, so the three-state contract holds. Patching the shipped `codex-home-wsl-env` chunk in an installed 1.4.183 and restarting the terminal daemon also clears the error in the app.

**The tests discriminate.** Source change reverted with the tests kept: `7 failed | 44 passed` — both updated argv assertions, the three inlining tests and the two guard tests. Both applied: `51 passed (51)`. They assert on mocked `execFileSync` argv, so they pin the shape but cannot prove it survives a real `wsl.exe` — the table above covers that, and the integration tests that could are gated behind `canRunWslSh()` and skip on CI.

Platforms: **Windows 11 26200, WSL2 Ubuntu**. Not tested on macOS, Linux or SSH — the changed branch is `process.platform === 'win32'` only. Gates: `oxfmt --check` and `oxlint` clean, native code-quality gate passes, max-lines ratchet reports no new bypasses. Not run locally: `pnpm typecheck`, `pnpm build`.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Investigated and written with Claude Opus 5, reviewed read-only by OpenAI Codex (gpt-5.6) and a second Claude instance. Every measurement quoted here was executed, not predicted.

## Review

Windows-only branch; other platforms return `null` before reaching it. A backticked path now spawns nothing at all. No new process spawn or input path, no wire or schema change. The `true` / `false` / `null` contract is unchanged — only the unconditional `false` becomes correct.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
