### PR TITLE
fix(source-control): drop unsupported Kimi recipe flags

### DIFF
--- a/src/shared/commit-message-agent-spec.test.ts
+++ b/src/shared/commit-message-agent-spec.test.ts
@@ -64,8 +64,10 @@ describe('COMMIT_MESSAGE_AGENT_SPECS', () => {
     const promptIndex = args.indexOf('--prompt')
     expect(promptIndex).toBeGreaterThanOrEqual(0)
     expect(args[promptIndex + 1]).toBe('Name a branch for adding login')
-    expect(args).toContain('--quiet')
-    expect(args).toContain('--thinking')
+    // Why: kimi-code 0.36–0.40 reject --quiet/--thinking/--no-thinking as unknown options (#14771).
+    expect(args).not.toContain('--quiet')
+    expect(args).not.toContain('--thinking')
+    expect(args).not.toContain('--no-thinking')
     expect(args).toEqual(expect.arrayContaining(['--model', 'kimi-code/kimi-for-coding']))
   })
 
@@ -76,15 +78,19 @@ describe('COMMIT_MESSAGE_AGENT_SPECS', () => {
     ])
   })
 
-  it('maps Kimi thinking off and omission to distinct argv', () => {
+  it('does not advertise unsupported Kimi thinking controls', () => {
     const spec = COMMIT_MESSAGE_AGENT_SPECS.kimi!
-    const offArgs = spec.buildArgs({ prompt: 'PROMPT', model: 'default', thinkingLevel: 'off' })
-    const defaultArgs = spec.buildArgs({ prompt: 'PROMPT', model: 'default' })
+    const model = spec.models.find((candidate) => candidate.id === 'kimi-code/kimi-for-coding')
 
-    expect(offArgs).toContain('--no-thinking')
-    expect(offArgs).not.toContain('--thinking')
-    expect(defaultArgs).not.toContain('--thinking')
-    expect(defaultArgs).not.toContain('--no-thinking')
+    expect(model).toBeDefined()
+    expect(model?.thinkingLevels).toBeUndefined()
+    expect(model?.defaultThinkingLevel).toBeUndefined()
+    for (const thinkingLevel of ['on', 'off'] as const) {
+      const args = spec.buildArgs({ prompt: 'PROMPT', model: 'default', thinkingLevel })
+      expect(args).not.toContain('--thinking')
+      expect(args).not.toContain('--no-thinking')
+      expect(args).not.toContain('--quiet')
+    }
   })
 
   it('omits Kimi --model for the config default and an empty model', () => {

--- a/src/shared/commit-message-agent-specs-secondary.ts
+++ b/src/shared/commit-message-agent-specs-secondary.ts
@@ -82,16 +82,11 @@ export function buildSecondaryCommitMessageAgentSpecs({
       // Why: kimi-code accepts the generation prompt only via --prompt/-p (Claude's
       // --print is rejected). Deliver on argv so --prompt receives the text (#11669).
       promptDelivery: 'argv',
-      buildArgs: ({ prompt, model, thinkingLevel }) => [
+      // Why: kimi-code 0.36–0.40 reject --quiet/--thinking/--no-thinking (#14771).
+      buildArgs: ({ prompt, model }) => [
         '--prompt',
         prompt,
-        '--quiet',
-        ...(model && model !== 'default' ? ['--model', model] : []),
-        ...(thinkingLevel === 'on'
-          ? ['--thinking']
-          : thinkingLevel === 'off'
-            ? ['--no-thinking']
-            : [])
+        ...(model && model !== 'default' ? ['--model', model] : [])
       ],
       modelSource: 'static',
       models: [
@@ -100,12 +95,7 @@ export function buildSecondaryCommitMessageAgentSpecs({
           // Why: Kimi resolves its managed model by provider/model; bare model
           // names are rejected by the CLI with "LLM not set".
           id: 'kimi-code/kimi-for-coding',
-          label: 'Kimi K2.6',
-          thinkingLevels: [
-            { id: 'on', label: 'On' },
-            { id: 'off', label: 'Off' }
-          ],
-          defaultThinkingLevel: 'on'
+          label: 'Kimi K2.6'
         }
       ],
       defaultModelId: 'default'


### PR DESCRIPTION
## ELI5

Source Control AI was launching Kimi with flags current Kimi Code does not understand, so the recipe died with `unknown option` before reading the prompt. This keeps only the flags Kimi actually accepts.

## What Changed

- Rebased onto current `main` after the commit-message spec split (`commit-message-agent-specs-secondary.ts`).
- Removed `--quiet`, `--thinking`, and `--no-thinking` from the Kimi recipe.
- Removed Kimi thinking-level metadata so the UI cannot regenerate those flags.
- Kept `--prompt` delivery and optional `--model`.

## Why

Issue #14771: Kimi Code 0.36.1 (and locally reproduced 0.40.1) rejects `--quiet`. The same CLI also rejects `--thinking` / `--no-thinking` (`unknown option`). Those flags were reintroduced on `main` when the spec was split; they still crash the recipe.

**Test red-line (declared):** existing assertions that required `--quiet` and Kimi thinking argv were replaced because they encoded flags the current CLI rejects. The function under fix is not mocked.

## Linked Issue

Fixes #14771

## Visual Proof

N/A — subprocess argv only; no UI or interaction change besides hiding a thinking picker that generated rejected flags.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- Live CLI: `kimi` 0.40.1 (`/Users/bing/.kimi-code/bin/kimi`). `kimi -p x --quiet`, `--thinking`, and `--no-thinking` each print `error: unknown option` and do not run the prompt.
- RED: focused spec tests failed on current `main` at `not.toContain(--quiet)` and `thinkingLevels` still defined.
- GREEN: `./node_modules/.bin/vitest run --config config/vitest.config.ts src/shared/commit-message-agent-spec.test.ts src/shared/commit-message-plan.test.ts src/shared/commit-message-generation.test.ts` — 3 files, 74 passed.
- `pnpm typecheck:node` passed.
- oxlint + oxfmt on the two changed files passed.
- `git diff --check` clean.
- Not run: full `pnpm test`, `pnpm lint`, `pnpm build`, Windows/SSH hosts. Shared argv only.

Final head: `8f1812cf0ee8573ee7706218900e30b31fd0a3b6`

## AI Disclosure

OpenAI Codex / Grok 4.6 used for rebase onto current main, TDD, verification, and PR body. Independent second-model review of this SHA: UNVERIFIED (not a security/auth change; one attempt may follow).

## Review

- Security: no new input, permissions, network, or trust-boundary behavior.
- Cross-platform: shared argv construction only.
- SSH / folder workspace / git provider: unchanged.
- Agent compatibility: Kimi recipe only.
- Backwards compatibility: supported `--prompt` / optional `--model` retained; rejected flags removed.
- Performance / mobile: N/A.

## Overlap

- This is an update to existing #14790, not a new PR.
- #14838 also mentions #14771 but bundles four other issues; this PR stays the single-concern Kimi argv fix.
- #18138 touches the same spec files for Antigravity, not Kimi. Independent increment.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Focused tests + `typecheck:node` passed locally; full matrix left to CI.

## Author

- X / Twitter: N/A
