### PR TITLE
fix(agent-hooks): strip Kimi hook-result envelopes

### DIFF
--- a/src/shared/agent-hook-listener-claude-compatible-vendors.test.ts
+++ b/src/shared/agent-hook-listener-claude-compatible-vendors.test.ts
@@ -116,6 +116,60 @@ describe('shared agent-hook-listener', () => {
     expect(stopped?.providerSession).toMatchObject({ key: 'session_id', id: 'session_abc' })
   })
 
+  it('strips leading Kimi UserPromptSubmit hook results from prompt blocks', () => {
+    const submitted = normalizeAndAccept(state, 'kimi', {
+      hook_event_name: 'UserPromptSubmit',
+      prompt: [
+        {
+          type: 'text',
+          text: '<hook_result hook_event="UserPromptSubmit">\n{}\n</hook_result>'
+        },
+        {
+          type: 'text',
+          text: '<hook_result hook_event="UserPromptSubmit">\nmetadata\n</hook_result>'
+        },
+        { type: 'text', text: 'Fix the CI configuration' }
+      ]
+    })
+
+    expect(submitted?.payload.prompt).toBe('Fix the CI configuration')
+    expect(submitted?.hasExplicitPrompt).toBe(true)
+  })
+
+  it('ignores a Kimi prompt containing only UserPromptSubmit hook results', () => {
+    normalizeAndAccept(state, 'kimi', {
+      hook_event_name: 'UserPromptSubmit',
+      prompt: [{ type: 'text', text: 'Fix the CI configuration' }]
+    })
+    const hookResult = normalizeAndAccept(state, 'kimi', {
+      hook_event_name: 'UserPromptSubmit',
+      prompt: [
+        {
+          type: 'text',
+          text: '<hook_result hook_event="UserPromptSubmit">\n{}\n</hook_result>'
+        }
+      ]
+    })
+    const tool = normalizeAndAccept(state, 'kimi', {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Bash',
+      tool_input: { command: 'pnpm test' }
+    })
+
+    expect(hookResult).toBeNull()
+    expect(tool?.payload.prompt).toBe('Fix the CI configuration')
+  })
+
+  it('preserves Kimi user text that only mentions hook-result markup', () => {
+    const prompt = 'Explain why <hook_result hook_event="UserPromptSubmit"> appears here'
+    const submitted = normalizeAndAccept(state, 'kimi', {
+      hook_event_name: 'UserPromptSubmit',
+      prompt: [{ type: 'text', text: prompt }]
+    })
+
+    expect(submitted?.payload.prompt).toBe(prompt)
+  })
+
   // Why: Kimi shares Claude-compatible compact/harness hooks; cover the same sticky-working
   // guards so a Kimi-only regression cannot slip past the Claude-only tests (issue #11352).
   it('ignores harness-injected UserPromptSubmit for Kimi', () => {

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -11,7 +11,10 @@ import { readFirstString } from './agent-hook-listener/interactive-tool'
 import type { AgentHookEventPayload } from './agent-hook-listener/listener-event'
 import { normalizeClaudePromptId } from './agent-hook-listener/listener-limits'
 import type { HookListenerState } from './agent-hook-listener/listener-state'
-import { extractPromptText } from './agent-hook-listener/prompt-fields'
+import {
+  extractPromptText,
+  stripLeadingKimiUserPromptHookResults
+} from './agent-hook-listener/prompt-fields'
 import { normalizeProviderEvent } from './agent-hook-listener/provider-dispatch'
 import { hasExplicitUserPrompt } from './agent-hook-listener/provider-event-routing'
 import { hasExplicitAmpPrompt } from './agent-hook-listener/providers/amp-events'
@@ -100,7 +103,10 @@ export function normalizeHookPayload(
   }
 
   const extractedPrompt = extractPromptText(hookPayloadRecord)
-  const promptText = extractedPrompt.text
+  const promptText =
+    source === 'kimi' && eventName === 'UserPromptSubmit'
+      ? stripLeadingKimiUserPromptHookResults(extractedPrompt.text)
+      : extractedPrompt.text
   const dispatched = normalizeProviderEvent({
     state,
     source,

--- a/src/shared/agent-hook-listener/prompt-fields.ts
+++ b/src/shared/agent-hook-listener/prompt-fields.ts
@@ -74,6 +74,20 @@ export function extractPromptText(hookPayload: Record<string, unknown>): Extract
   return { text: '', source: null }
 }
 
+const KIMI_USER_PROMPT_HOOK_RESULT_ENVELOPE =
+  /^<hook_result hook_event="UserPromptSubmit">[\s\S]*?<\/hook_result>\s*/
+
+export function stripLeadingKimiUserPromptHookResults(promptText: string): string {
+  let text = promptText
+  let stripped: string
+  do {
+    stripped = text
+    text = text.replace(KIMI_USER_PROMPT_HOOK_RESULT_ENVELOPE, '')
+  } while (text !== stripped)
+  // Why: Kimi appends hook results as user-role envelopes; prompt-derived UI should see only the typed suffix.
+  return text.trim()
+}
+
 export function stripGrokUserQueryWrapper(promptText: string): string {
   const opener = '<user_query>'
   if (!promptText.startsWith(opener)) {

--- a/src/shared/agent-hook-listener/provider-dispatch.ts
+++ b/src/shared/agent-hook-listener/provider-dispatch.ts
@@ -146,7 +146,10 @@ export function normalizeProviderEvent(input: {
       payload = normalizeDevinEvent(state, eventName, promptText, paneKey, hookPayload)
       break
     case 'kimi':
-      payload = normalizeKimiEvent(state, eventName, promptText, paneKey, hookPayload)
+      payload =
+        eventName === 'UserPromptSubmit' && extractedPrompt.text && !promptText
+          ? null
+          : normalizeKimiEvent(state, eventName, promptText, paneKey, hookPayload)
       break
   }
 


### PR DESCRIPTION
Kimi UserPromptSubmit hook-result envelopes no longer become user prompt text. Strip only complete leading Kimi envelopes, preserve the typed suffix and ordinary inline mentions, and ignore envelope-only events so they cannot replace the last real prompt. Other providers and event kinds retain their existing behavior. The port follows current main's split prompt-fields/provider-dispatch modules. Fixes #14789.

Validation: Cursor's 9 focused vendor tests passed; Codex independently ran all 201 shared hook-listener tests across 16 files. Node non-composite typecheck and changed-file lint/format passed. No live Kimi session was exercised.

Full repository suite/build and default composite typechecks were not run for this candidate. Known baseline TS2883 is not treated as passing; only the explicit non-composite checks above are claimed.

Cursor reviewed the final candidate; Codex independently reviewed the diff and raw checks. Reviewed commit: `68fd42e68b15f58fd74daf633cd7c03d052e5995`; rebased onto `bba68b1bddf1276c8bd27ad4ca41efcbd4260321`.
