### PR TITLE
fix(runtime): keep unmounted renderer browser tabs

### DIFF
--- a/src/main/runtime/orca-runtime-close-structured-agent-session-tab.ts
+++ b/src/main/runtime/orca-runtime-close-structured-agent-session-tab.ts
@@ -8,7 +8,6 @@ import type {
   RuntimeMobileSessionTerminalTab
 } from '../../shared/runtime-types'
 import type { RuntimePtyWorktreeRecord } from './runtime-terminal-state-records'
-import { getMobileSessionSnapshotTabIdentityKeys } from './mobile-session-tab-merge'
 import type { BrowserSessionTabSelectionOptions } from './browser-tab-create-publication'
 import { getRuntimeBrowserPageRegistry } from './runtime-browser-page-registry'
 import { applyBrowserSessionTabSelection } from './browser-session-tab-selection-snapshot'
@@ -127,18 +126,7 @@ export class OrcaRuntimeWithCloseStructuredAgentSessionTab extends OrcaRuntimeWi
     if (!this.offscreenBrowserBackend || !tab.browserPageId) {
       return false
     }
-    if (this.isHeadlessBuiltMobileSessionPublicationBase(snapshot.publicationEpoch)) {
-      return true
-    }
-    const accepted = this.acceptedRendererMobileSnapshotByWorktree.get(snapshot.worktree)
-    return (
-      snapshot.publicationEpoch.includes(':headless-merge:') &&
-      accepted !== undefined &&
-      !getMobileSessionSnapshotTabIdentityKeys(tab).some((id) =>
-        accepted.rendererTabIdentityKeys.has(id)
-      ) &&
-      this.getLiveBrowserTabsByPageId(snapshot.worktree).has(tab.browserPageId)
-    )
+    return this.isHeadlessOwnedMobileBrowserTab(snapshot, tab)
   }
 
   // Public so runtime-side page release (lease fencing) can prune a tab whose page is gone.
@@ -162,7 +150,11 @@ export class OrcaRuntimeWithCloseStructuredAgentSessionTab extends OrcaRuntimeWi
     const active = nextTabs.find((candidate) => candidate.isActive) ?? nextTabs[0] ?? null
     const nextSnapshot: RuntimeMobileSessionTabsSnapshot = {
       ...snapshot,
-      publicationEpoch: `headless:${Date.now().toString(36)}`,
+      publicationEpoch: this.getMobileSessionPublicationEpochAfterHeadlessBrowserChange(
+        snapshot,
+        nextTabs,
+        'headless'
+      ),
       snapshotVersion: snapshot.snapshotVersion + 1,
       activeTabId: active?.id ?? null,
       activeTabType: active?.type ?? null,

--- a/src/main/runtime/orca-runtime-merge-preserved-headless-mobile-session-tabs.ts
+++ b/src/main/runtime/orca-runtime-merge-preserved-headless-mobile-session-tabs.ts
@@ -173,9 +173,16 @@ export class OrcaRuntimeWithMergePreservedHeadlessMobileSessionTabs extends Orca
     const terminalTabs = tabs.filter(
       (tab): tab is RuntimeMobileSessionTerminalTab => tab.type === 'terminal'
     )
+    // Why: renderer-detach prune must rebase remaining runtime rows onto a
+    // headless-built epoch or they stay classified as renderer-owned.
+    const publicationBase = this.isHeadlessBuiltMobileSessionPublicationBase(
+      existing.publicationEpoch
+    )
+      ? existing
+      : { ...existing, publicationEpoch: `headless-hydrated:${Date.now().toString(36)}` }
     return {
       ...existing,
-      publicationEpoch: this.getMergedMobileSessionPublicationEpoch(existing, tabs),
+      publicationEpoch: this.getMergedMobileSessionPublicationEpoch(publicationBase, tabs),
       // Why: mint a fresh version or clients' same-epoch gate drops the prune frame.
       snapshotVersion: existing.snapshotVersion + 1,
       activeGroupId: existing.activeGroupId ?? getHeadlessMobileSessionGroupId(existing.worktree),

--- a/src/main/runtime/orca-runtime-persist-headless-terminal-title.ts
+++ b/src/main/runtime/orca-runtime-persist-headless-terminal-title.ts
@@ -106,7 +106,7 @@ export class OrcaRuntimeWithPersistHeadlessTerminalTitle extends OrcaRuntimeWith
         const liveTab = tab.browserPageId
           ? liveBrowserTabsByPageId.get(tab.browserPageId)
           : undefined
-        if (!liveTab) {
+        if (!liveTab && !this.isRendererOwnedMobileBrowserTab(snapshot, tab)) {
           continue
         }
         ids.add(tab.id)

--- a/src/main/runtime/orca-runtime-prune-mobile-session-tab-group-layout.ts
+++ b/src/main/runtime/orca-runtime-prune-mobile-session-tab-group-layout.ts
@@ -91,6 +91,8 @@ export class OrcaRuntimeWithPruneMobileSessionTabGroupLayout extends OrcaRuntime
       leaves: this.leaves,
       ptysById: this.ptysById,
       getLiveBrowserTabs: (worktreeId) => this.getLiveBrowserTabsByPageId(worktreeId),
+      isRendererOwnedMobileBrowserTab: (snapshot, tab) =>
+        this.isRendererOwnedMobileBrowserTab(snapshot, tab),
       getProviderSessionRows: (paneKey) => this.getAgentProviderSessionRowsForPaneFn?.(paneKey),
       getProviderSessionSnapshot: () => this.getAgentProviderSessionSnapshotFn?.() ?? [],
       getLeafKey: (tabId, leafId) => this.getLeafKey(tabId, leafId),

--- a/src/main/runtime/orca-runtime-reconcile-headless-mobile-session-browser-tabs.ts
+++ b/src/main/runtime/orca-runtime-reconcile-headless-mobile-session-browser-tabs.ts
@@ -28,6 +28,14 @@ export class OrcaRuntimeWithReconcileHeadlessMobileSessionBrowserTabs extends Or
     const existingBrowserTabs = existing.tabs.filter(
       (tab): tab is RuntimeMobileSessionBrowserTab => tab.type === 'browser'
     )
+    if (this.offscreenBrowserBackend) {
+      this.reconcileOffscreenOwnedMobileSessionBrowserTabs(
+        worktreeId,
+        existing,
+        existingBrowserTabs
+      )
+      return
+    }
     const publishedBrowserTabs = this.buildHeadlessMobileSessionBrowserTabs(worktreeId)
     // An attached renderer owns its browser rows; the client-page registry cannot retire them.
     const rendererBrowserTabs =
@@ -70,6 +78,65 @@ export class OrcaRuntimeWithReconcileHeadlessMobileSessionBrowserTabs extends Or
       : (nextTabs.find((tab) => tab.isActive) ?? nextTabs[0] ?? null)
     this.storeMobileSessionSnapshot(worktreeId, {
       ...existing,
+      snapshotVersion: existing.snapshotVersion + 1,
+      ...(activeStillPresent
+        ? {}
+        : { activeTabId: active?.id ?? null, activeTabType: active?.type ?? null }),
+      tabGroups,
+      tabs: nextTabs
+    })
+  }
+
+  // Why: offscreen live pages replace only headless-owned rows; unmounted renderer tabs stay.
+  protected reconcileOffscreenOwnedMobileSessionBrowserTabs(
+    worktreeId: string,
+    existing: RuntimeMobileSessionTabsSnapshot,
+    existingBrowserTabs: RuntimeMobileSessionBrowserTab[]
+  ): void {
+    const existingHeadlessBrowserTabs = existingBrowserTabs.filter(
+      (tab) => !this.isRendererOwnedMobileBrowserTab(existing, tab)
+    )
+    const rendererBrowserPageIds = new Set(
+      existingBrowserTabs
+        .filter((tab) => this.isRendererOwnedMobileBrowserTab(existing, tab))
+        .map((tab) => tab.browserPageId)
+        .filter((pageId): pageId is string => Boolean(pageId))
+    )
+    const liveBrowserTabs = this.buildHeadlessMobileSessionBrowserTabs(worktreeId).filter(
+      (tab) => !rendererBrowserPageIds.has(tab.browserPageId ?? '')
+    )
+    const liveIds = liveBrowserTabs.map((tab) => tab.id)
+    const existingHeadlessBrowserIds = new Set(
+      existingHeadlessBrowserTabs.flatMap((tab) => [tab.id, tab.browserWorkspaceId])
+    )
+    if (headlessBrowserTabsUnchanged(liveBrowserTabs, existingHeadlessBrowserTabs)) {
+      return
+    }
+    const retainedTabs = existing.tabs.filter(
+      (tab) => tab.type !== 'browser' || !existingHeadlessBrowserIds.has(tab.id)
+    )
+    const nextTabs: RuntimeMobileSessionSnapshotTab[] = [...retainedTabs, ...liveBrowserTabs]
+    const liveIdSet = new Set(liveIds)
+    const tabGroups = appendBrowserTabOrder(
+      (existing.tabGroups ?? []).map((group) => ({
+        ...group,
+        tabOrder: group.tabOrder.filter(
+          (id) => liveIdSet.has(id) || !existingHeadlessBrowserIds.has(id)
+        )
+      })),
+      liveIds
+    )
+    const activeStillPresent = nextTabs.some((tab) => tab.id === existing.activeTabId)
+    const active = activeStillPresent
+      ? null
+      : (nextTabs.find((tab) => tab.isActive) ?? nextTabs[0] ?? null)
+    this.storeMobileSessionSnapshot(worktreeId, {
+      ...existing,
+      publicationEpoch: this.getMobileSessionPublicationEpochAfterHeadlessBrowserChange(
+        existing,
+        nextTabs,
+        'headless-hydrated'
+      ),
       snapshotVersion: existing.snapshotVersion + 1,
       ...(activeStillPresent
         ? {}

--- a/src/main/runtime/orca-runtime-reconcile-headless-mobile-session-browser-tabs.ts
+++ b/src/main/runtime/orca-runtime-reconcile-headless-mobile-session-browser-tabs.ts
@@ -93,6 +93,14 @@ export class OrcaRuntimeWithReconcileHeadlessMobileSessionBrowserTabs extends Or
     existing: RuntimeMobileSessionTabsSnapshot,
     existingBrowserTabs: RuntimeMobileSessionBrowserTab[]
   ): void {
+    // Why: without an accepted renderer revision, ownership is unknown — do not
+    // promote live offscreen pages into a renderer-base snapshot.
+    const headlessBuilt = this.isHeadlessBuiltMobileSessionPublicationBase(
+      existing.publicationEpoch
+    )
+    if (!headlessBuilt && !this.getAcceptedRendererIdentityKeysForMobileSessionSnapshot(existing)) {
+      return
+    }
     const existingHeadlessBrowserTabs = existingBrowserTabs.filter(
       (tab) => !this.isRendererOwnedMobileBrowserTab(existing, tab)
     )

--- a/src/main/runtime/orca-runtime-stored-mobile-snapshot-has-stale-preserved-tab.ts
+++ b/src/main/runtime/orca-runtime-stored-mobile-snapshot-has-stale-preserved-tab.ts
@@ -67,12 +67,12 @@ export class OrcaRuntimeWithStoredMobileSnapshotHasStalePreservedTab extends Orc
       if (!this.offscreenBrowserBackend) {
         return false
       }
-      // Why: in a renderer-based merged snapshot the browser entries can also
-      // be renderer-owned, so only pages the offscreen bridge still lists are
-      // runtime-owned and preservable; a pure renderer epoch preserves none.
+      // Why: current merges keep the renderer publisher epoch unchanged, so
+      // runtime-owned pages are those absent from the accepted identity set.
+      // `:headless-merge:` remains a legacy marker when that pair is gone.
       return (
         this.isHeadlessBuiltMobileSessionPublicationBase(snapshot.publicationEpoch) ||
-        (snapshot.publicationEpoch.includes(':headless-merge:') &&
+        (this.isRuntimeOwnedBrowserOnRendererPublication(snapshot, tab) &&
           typeof tab.browserPageId === 'string' &&
           this.getLiveBrowserTabsByPageId(snapshot.worktree).has(tab.browserPageId))
       )
@@ -121,6 +121,23 @@ export class OrcaRuntimeWithStoredMobileSnapshotHasStalePreservedTab extends Orc
     return accepted?.publicationEpoch === baseEpoch ? accepted.rendererTabIdentityKeys : null
   }
 
+  // Why: current getMerged keeps the renderer publisher epoch; accepted
+  // identity is the owner split. Legacy `:headless-merge:` still names a
+  // mixed snapshot when that pair is missing.
+  protected isRuntimeOwnedBrowserOnRendererPublication(
+    snapshot: RuntimeMobileSessionTabsSnapshot,
+    tab: RuntimeMobileSessionBrowserTab
+  ): boolean {
+    const rendererTabIdentityKeys =
+      this.getAcceptedRendererIdentityKeysForMobileSessionSnapshot(snapshot)
+    if (rendererTabIdentityKeys) {
+      return !getMobileSessionSnapshotTabIdentityKeys(tab).some((id) =>
+        rendererTabIdentityKeys.has(id)
+      )
+    }
+    return snapshot.publicationEpoch.includes(':headless-merge:')
+  }
+
   protected isHeadlessOwnedMobileBrowserTab(
     snapshot: RuntimeMobileSessionTabsSnapshot,
     tab: RuntimeMobileSessionBrowserTab
@@ -128,17 +145,14 @@ export class OrcaRuntimeWithStoredMobileSnapshotHasStalePreservedTab extends Orc
     if (this.isHeadlessBuiltMobileSessionPublicationBase(snapshot.publicationEpoch)) {
       return true
     }
-    if (!snapshot.publicationEpoch.includes(':headless-merge:')) {
-      return false
-    }
     const rendererTabIdentityKeys =
       this.getAcceptedRendererIdentityKeysForMobileSessionSnapshot(snapshot)
-    if (!rendererTabIdentityKeys) {
-      return false
+    if (rendererTabIdentityKeys) {
+      return !getMobileSessionSnapshotTabIdentityKeys(tab).some((id) =>
+        rendererTabIdentityKeys.has(id)
+      )
     }
-    return !getMobileSessionSnapshotTabIdentityKeys(tab).some((id) =>
-      rendererTabIdentityKeys.has(id)
-    )
+    return false
   }
 
   protected isRendererOwnedMobileBrowserTab(

--- a/src/main/runtime/orca-runtime-stored-mobile-snapshot-has-stale-preserved-tab.ts
+++ b/src/main/runtime/orca-runtime-stored-mobile-snapshot-has-stale-preserved-tab.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck -- mechanically split from OrcaRuntimeService; behavior is covered by AST equivalence and characterization tests.
 import { OrcaRuntimeWithMergePreservedHeadlessMobileSessionTabs } from './orca-runtime-merge-preserved-headless-mobile-session-tabs'
 import type {
+  RuntimeMobileSessionBrowserTab,
   RuntimeMobileSessionSnapshotTab,
   RuntimeMobileSessionTabsRemovedResult,
   RuntimeMobileSessionTabsSnapshot
@@ -110,6 +111,70 @@ export class OrcaRuntimeWithStoredMobileSnapshotHasStalePreservedTab extends Orc
   protected isHeadlessBuiltMobileSessionPublicationBase(publicationEpoch: string): boolean {
     const base = publicationEpoch.split(':headless-merge:')[0]
     return base.startsWith('headless:') || base.startsWith('headless-hydrated:')
+  }
+
+  protected getAcceptedRendererIdentityKeysForMobileSessionSnapshot(
+    snapshot: RuntimeMobileSessionTabsSnapshot
+  ): ReadonlySet<string> | null {
+    const baseEpoch = snapshot.publicationEpoch.split(':headless-merge:')[0]
+    const accepted = this.acceptedRendererMobileSnapshotByWorktree.get(snapshot.worktree)
+    return accepted?.publicationEpoch === baseEpoch ? accepted.rendererTabIdentityKeys : null
+  }
+
+  protected isHeadlessOwnedMobileBrowserTab(
+    snapshot: RuntimeMobileSessionTabsSnapshot,
+    tab: RuntimeMobileSessionBrowserTab
+  ): boolean {
+    if (this.isHeadlessBuiltMobileSessionPublicationBase(snapshot.publicationEpoch)) {
+      return true
+    }
+    if (!snapshot.publicationEpoch.includes(':headless-merge:')) {
+      return false
+    }
+    const rendererTabIdentityKeys =
+      this.getAcceptedRendererIdentityKeysForMobileSessionSnapshot(snapshot)
+    if (!rendererTabIdentityKeys) {
+      return false
+    }
+    return !getMobileSessionSnapshotTabIdentityKeys(tab).some((id) =>
+      rendererTabIdentityKeys.has(id)
+    )
+  }
+
+  protected isRendererOwnedMobileBrowserTab(
+    snapshot: RuntimeMobileSessionTabsSnapshot,
+    tab: RuntimeMobileSessionBrowserTab
+  ): boolean {
+    if (tab.placement?.kind === 'client') {
+      return false
+    }
+    return !this.isHeadlessOwnedMobileBrowserTab(snapshot, tab)
+  }
+
+  protected getMobileSessionPublicationEpochAfterHeadlessBrowserChange(
+    snapshot: RuntimeMobileSessionTabsSnapshot,
+    nextTabs: readonly RuntimeMobileSessionSnapshotTab[],
+    headlessEpochPrefix: 'headless' | 'headless-hydrated'
+  ): string {
+    if (this.isHeadlessBuiltMobileSessionPublicationBase(snapshot.publicationEpoch)) {
+      return `${headlessEpochPrefix}:${Date.now().toString(36)}`
+    }
+    const rendererTabIdentityKeys =
+      this.getAcceptedRendererIdentityKeysForMobileSessionSnapshot(snapshot)
+    if (!rendererTabIdentityKeys) {
+      return snapshot.publicationEpoch
+    }
+    const preservedTabs = nextTabs.filter(
+      (tab) =>
+        !getMobileSessionSnapshotTabIdentityKeys(tab).some((id) => rendererTabIdentityKeys.has(id))
+    )
+    const baseEpoch = snapshot.publicationEpoch.split(':headless-merge:')[0]
+    return preservedTabs.length === 0
+      ? baseEpoch
+      : this.getMergedMobileSessionPublicationEpoch(
+          { ...snapshot, publicationEpoch: baseEpoch },
+          preservedTabs
+        )
   }
 
   protected getMergedMobileSessionPublicationEpoch(

--- a/src/main/runtime/orca-runtime-tests/terminal-handles-and-agent-status-part-03.spec.ts
+++ b/src/main/runtime/orca-runtime-tests/terminal-handles-and-agent-status-part-03.spec.ts
@@ -552,7 +552,7 @@ describe('OrcaRuntimeService', () => {
     ])
   })
 
-  it('omits stale browser session tabs that no longer have live webContents', async () => {
+  it('keeps renderer browser tabs without live webContents but filters stale headless tabs', async () => {
     const runtime = new OrcaRuntimeService(store)
     const tabList = vi.fn(() => ({
       tabs: [
@@ -573,7 +573,7 @@ describe('OrcaRuntimeService', () => {
       mobileSessionTabs: [
         {
           worktree: TEST_WORKTREE_ID,
-          publicationEpoch: 'epoch-1',
+          publicationEpoch: 'renderer-epoch-1',
           snapshotVersion: 1,
           activeGroupId: 'group-1',
           activeTabId: 'browser-unified-stale',
@@ -614,6 +614,39 @@ describe('OrcaRuntimeService', () => {
     expect(result.tabs).toEqual([
       expect.objectContaining({
         type: 'browser',
+        id: 'browser-unified-stale',
+        browserPageId: 'browser-page-stale',
+        url: 'about:blank',
+        title: 'Dead Browser',
+        isActive: true
+      }),
+      expect.objectContaining({
+        type: 'browser',
+        id: 'browser-unified-live',
+        browserPageId: 'browser-page-live',
+        url: 'https://live.example/',
+        title: 'Live Browser',
+        isActive: false
+      })
+    ])
+    expect(result.activeTabId).toBe('browser-unified-stale')
+    expect(result.activeTabType).toBe('browser')
+
+    const rendererSnapshot = runtime['mobileSessionTabsByWorktree'].get(TEST_WORKTREE_ID)!
+    expect([...runtime['collectPublicMobileSessionTabIds'](rendererSnapshot)]).toEqual([
+      'browser-unified-stale',
+      'browser-workspace-stale',
+      'browser-unified-live',
+      'browser-workspace-live'
+    ])
+
+    const headlessSnapshot = { ...rendererSnapshot, publicationEpoch: 'headless:epoch-1' }
+    runtime['mobileSessionTabsByWorktree'].set(TEST_WORKTREE_ID, headlessSnapshot)
+    const headlessResult = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+
+    expect(headlessResult.tabs).toEqual([
+      expect.objectContaining({
+        type: 'browser',
         id: 'browser-unified-live',
         browserPageId: 'browser-page-live',
         url: 'https://live.example/',
@@ -621,7 +654,9 @@ describe('OrcaRuntimeService', () => {
         isActive: true
       })
     ])
-    expect(result.activeTabId).toBe('browser-unified-live')
-    expect(result.activeTabType).toBe('browser')
+    expect([...runtime['collectPublicMobileSessionTabIds'](headlessSnapshot)]).toEqual([
+      'browser-unified-live',
+      'browser-workspace-live'
+    ])
   })
 })

--- a/src/main/runtime/renderer-browser-accepted-epoch-review.test.ts
+++ b/src/main/runtime/renderer-browser-accepted-epoch-review.test.ts
@@ -1,0 +1,34 @@
+import { expect, it, vi } from 'vitest'
+import { OrcaRuntimeService } from './orca-runtime-test-mocks.spec'
+import { TEST_WORKTREE_ID, store } from './orca-runtime-test-fixtures.spec'
+import type { RuntimeMobileSessionTabsSnapshot } from '../../shared/runtime-types'
+
+it('does not publish unknown-owner offscreen rows into an unaccepted renderer epoch', () => {
+  const runtime = new OrcaRuntimeService(store)
+  runtime.setOffscreenBrowserBackend({ closeTab: vi.fn() } as never)
+  runtime.setAgentBrowserBridge({
+    tabList: () => ({
+      tabs: [
+        {
+          browserPageId: 'offscreen-new',
+          title: 'Headless',
+          url: 'https://example.com/',
+          active: false
+        }
+      ]
+    })
+  } as never)
+  const snapshot: RuntimeMobileSessionTabsSnapshot = {
+    worktree: TEST_WORKTREE_ID,
+    publicationEpoch: 'renderer-unaccepted',
+    snapshotVersion: 1,
+    activeGroupId: null,
+    activeTabId: null,
+    activeTabType: null,
+    tabs: []
+  }
+  runtime['mobileSessionTabsByWorktree'].set(TEST_WORKTREE_ID, snapshot)
+  runtime['acceptedRendererMobileSnapshotByWorktree'].delete(TEST_WORKTREE_ID)
+  runtime['reconcileHeadlessMobileSessionBrowserTabs'](TEST_WORKTREE_ID, snapshot)
+  expect(runtime['mobileSessionTabsByWorktree'].get(TEST_WORKTREE_ID)).toEqual(snapshot)
+})

--- a/src/main/runtime/renderer-browser-accepted-epoch-review.test.ts
+++ b/src/main/runtime/renderer-browser-accepted-epoch-review.test.ts
@@ -32,3 +32,46 @@ it('does not publish unknown-owner offscreen rows into an unaccepted renderer ep
   runtime['reconcileHeadlessMobileSessionBrowserTabs'](TEST_WORKTREE_ID, snapshot)
   expect(runtime['mobileSessionTabsByWorktree'].get(TEST_WORKTREE_ID)).toEqual(snapshot)
 })
+
+it('classifies headless rows added under the current unchanged renderer epoch', () => {
+  const runtime = new OrcaRuntimeService(store)
+  const tab = {
+    type: 'browser' as const,
+    id: 'offscreen-new',
+    browserWorkspaceId: 'offscreen-new',
+    browserPageId: 'offscreen-new',
+    title: 'Headless',
+    url: 'https://example.com/',
+    loading: false,
+    canGoBack: false,
+    canGoForward: false,
+    isActive: false
+  }
+  const snapshot: RuntimeMobileSessionTabsSnapshot = {
+    worktree: TEST_WORKTREE_ID,
+    publicationEpoch: 'renderer-accepted',
+    snapshotVersion: 1,
+    activeGroupId: null,
+    activeTabId: null,
+    activeTabType: null,
+    tabs: []
+  }
+  runtime['acceptedRendererMobileSnapshotByWorktree'].set(TEST_WORKTREE_ID, {
+    publicationEpoch: snapshot.publicationEpoch,
+    rendererVersion: 1,
+    rendererTabCount: 0,
+    rendererTabIdentityKeys: new Set<string>()
+  })
+  const epoch = runtime['getMobileSessionPublicationEpochAfterHeadlessBrowserChange'](
+    snapshot,
+    [tab],
+    'headless-hydrated'
+  )
+  expect(epoch).toBe(snapshot.publicationEpoch)
+  expect(
+    runtime['isHeadlessOwnedMobileBrowserTab'](
+      { ...snapshot, publicationEpoch: epoch, tabs: [tab] },
+      tab
+    )
+  ).toBe(true)
+})

--- a/src/main/runtime/renderer-browser-ownership.test.ts
+++ b/src/main/runtime/renderer-browser-ownership.test.ts
@@ -112,4 +112,45 @@ it('preserves renderer browser ownership across headless reconciliation and clos
   await runtime.closeMobileSessionTab(`id:${TEST_WORKTREE_ID}`, 'headless-page-1')
   expect(closeSessionTab).not.toHaveBeenCalled()
   expect(closeTab).toHaveBeenCalledWith('headless-page-1')
+
+  const afterHeadlessClose = runtime['mobileSessionTabsByWorktree'].get(TEST_WORKTREE_ID)!
+  expect(afterHeadlessClose.publicationEpoch).toBe('epoch-1')
+  expect((await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)).tabs).toEqual([
+    expect.objectContaining({ id: 'browser-unified-1' })
+  ])
+
+  closeSessionTab.mockClear()
+  closeTab.mockClear()
+  await runtime.closeMobileSessionTab(`id:${TEST_WORKTREE_ID}`, 'browser-workspace-1')
+  expect(closeSessionTab).toHaveBeenCalledWith('browser-unified-1', TEST_WORKTREE_ID)
+  expect(closeTab).not.toHaveBeenCalled()
+
+  runtime.setAgentBrowserBridge({
+    tabList: vi.fn(() => ({
+      tabs: [
+        {
+          browserPageId: 'headless-page-1',
+          title: 'Headless Browser',
+          url: 'https://headless.example/'
+        }
+      ]
+    }))
+  } as never)
+  const detachedSnapshot = runtime['buildPreservedHeadlessMobileSessionSnapshot']({
+    ...afterHeadlessClose,
+    publicationEpoch: 'epoch-1:headless-merge:runtime-page',
+    tabs: [...afterHeadlessClose.tabs, headlessTab]
+  })!
+  runtime['acceptedRendererMobileSnapshotByWorktree'].delete(TEST_WORKTREE_ID)
+  runtime['mobileSessionTabsByWorktree'].set(TEST_WORKTREE_ID, detachedSnapshot)
+  expect(detachedSnapshot.publicationEpoch).toMatch(/^headless-hydrated:/)
+
+  const preservedAgain = runtime['buildPreservedHeadlessMobileSessionSnapshot'](detachedSnapshot)
+  expect(preservedAgain?.publicationEpoch).toBe(detachedSnapshot.publicationEpoch)
+
+  closeSessionTab.mockClear()
+  closeTab.mockClear()
+  await runtime.closeMobileSessionTab(`id:${TEST_WORKTREE_ID}`, 'headless-page-1')
+  expect(closeSessionTab).not.toHaveBeenCalled()
+  expect(closeTab).toHaveBeenCalledWith('headless-page-1')
 })

--- a/src/main/runtime/renderer-browser-ownership.test.ts
+++ b/src/main/runtime/renderer-browser-ownership.test.ts
@@ -1,0 +1,115 @@
+import { expect, it, vi } from 'vitest'
+import { OrcaRuntimeService } from './orca-runtime-test-mocks.spec'
+import { TEST_WORKTREE_ID, store } from './orca-runtime-test-fixtures.spec'
+import type {
+  RuntimeMobileSessionSnapshotTab,
+  RuntimeMobileSessionTabsSnapshot
+} from '../../shared/runtime-types'
+
+it('preserves renderer browser ownership across headless reconciliation and close', async () => {
+  const closeSessionTab = vi.fn()
+  const closeTab = vi.fn().mockResolvedValue(undefined)
+  const runtime = new OrcaRuntimeService(store)
+  runtime.setOffscreenBrowserBackend({ closeTab } as never)
+  const forgetTabs = vi.spyOn(runtime['clientSessionTabSelections'], 'forgetTabs')
+  runtime.setNotifier({
+    worktreesChanged: vi.fn(),
+    reposChanged: vi.fn(),
+    activateWorktree: vi.fn(),
+    createTerminal: vi.fn(),
+    revealTerminalSession: vi.fn(),
+    splitTerminal: vi.fn(),
+    renameTerminal: vi.fn(),
+    focusTerminal: vi.fn(),
+    closeTerminal: vi.fn(),
+    closeSessionTab,
+    sleepWorktree: vi.fn(),
+    terminalFitOverrideChanged: vi.fn(),
+    terminalDriverChanged: vi.fn()
+  })
+  runtime.attachWindow(1)
+  runtime.syncWindowGraph(1, {
+    tabs: [],
+    leaves: [],
+    mobileSessionTabs: [
+      {
+        worktree: TEST_WORKTREE_ID,
+        publicationEpoch: 'epoch-1',
+        snapshotVersion: 1,
+        activeGroupId: 'group-1',
+        activeTabId: 'browser-unified-1',
+        activeTabType: 'browser',
+        tabs: [
+          {
+            type: 'browser',
+            id: 'browser-unified-1',
+            title: 'Browser',
+            browserWorkspaceId: 'browser-workspace-1',
+            browserPageId: 'browser-page-1',
+            url: 'https://example.com/',
+            loading: false,
+            canGoBack: false,
+            canGoForward: false,
+            isActive: true
+          }
+        ]
+      }
+    ]
+  })
+
+  await runtime.closeMobileSessionTab(`id:${TEST_WORKTREE_ID}`, 'browser-workspace-1')
+  expect(closeSessionTab).toHaveBeenCalledWith('browser-unified-1', TEST_WORKTREE_ID)
+  expect(forgetTabs).toHaveBeenCalledWith(TEST_WORKTREE_ID, ['browser-unified-1'])
+  expect(closeTab).not.toHaveBeenCalled()
+
+  const rendererSnapshot = runtime['mobileSessionTabsByWorktree'].get(TEST_WORKTREE_ID)!
+  const headlessTab = {
+    type: 'browser',
+    id: 'headless-page-1',
+    title: 'Headless Browser',
+    browserWorkspaceId: 'headless-page-1',
+    browserPageId: 'headless-page-1',
+    url: 'https://headless.example/',
+    loading: false,
+    canGoBack: false,
+    canGoForward: false,
+    isActive: false
+  } satisfies RuntimeMobileSessionSnapshotTab
+  const mergedSnapshot: RuntimeMobileSessionTabsSnapshot = {
+    ...rendererSnapshot,
+    publicationEpoch: 'epoch-1:headless-merge:runtime-page',
+    tabs: [...rendererSnapshot.tabs, headlessTab]
+  }
+  runtime['acceptedRendererMobileSnapshotByWorktree'].set(TEST_WORKTREE_ID, {
+    publicationEpoch: 'epoch-1',
+    rendererVersion: 1,
+    rendererTabCount: rendererSnapshot.tabs.length,
+    rendererTabIdentityKeys: new Set(
+      rendererSnapshot.tabs.flatMap((tab) => [
+        tab.id,
+        tab.type === 'browser' ? tab.browserWorkspaceId : tab.id
+      ])
+    )
+  })
+  runtime['mobileSessionTabsByWorktree'].set(TEST_WORKTREE_ID, mergedSnapshot)
+
+  expect((await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)).tabs).toEqual([
+    expect.objectContaining({ id: 'browser-unified-1' })
+  ])
+
+  runtime.notifyMobileSessionTabsChanged(TEST_WORKTREE_ID)
+  const reconciled = runtime['mobileSessionTabsByWorktree'].get(TEST_WORKTREE_ID)!
+  expect(reconciled.publicationEpoch).toBe('epoch-1')
+  expect(reconciled.tabs).toEqual([expect.objectContaining({ id: 'browser-unified-1' })])
+
+  runtime['mobileSessionTabsByWorktree'].set(TEST_WORKTREE_ID, mergedSnapshot)
+  closeSessionTab.mockClear()
+  await runtime.closeMobileSessionTab(`id:${TEST_WORKTREE_ID}`, 'browser-workspace-1')
+  expect(closeSessionTab).toHaveBeenCalledWith('browser-unified-1', TEST_WORKTREE_ID)
+  expect(closeTab).not.toHaveBeenCalled()
+
+  closeSessionTab.mockClear()
+  await runtime.closeMobileSessionTab(`id:${TEST_WORKTREE_ID}`, 'headless-page-1')
+  expect(closeSessionTab).not.toHaveBeenCalled()
+  expect(closeTab).toHaveBeenCalledWith('headless-page-1')
+})

--- a/src/main/runtime/renderer-browser-ownership.test.ts
+++ b/src/main/runtime/renderer-browser-ownership.test.ts
@@ -77,7 +77,8 @@ it('preserves renderer browser ownership across headless reconciliation and clos
   } satisfies RuntimeMobileSessionSnapshotTab
   const mergedSnapshot: RuntimeMobileSessionTabsSnapshot = {
     ...rendererSnapshot,
-    publicationEpoch: 'epoch-1:headless-merge:runtime-page',
+    // Why: current getMerged keeps the renderer publisher epoch unchanged.
+    publicationEpoch: rendererSnapshot.publicationEpoch,
     tabs: [...rendererSnapshot.tabs, headlessTab]
   }
   runtime['acceptedRendererMobileSnapshotByWorktree'].set(TEST_WORKTREE_ID, {
@@ -138,7 +139,7 @@ it('preserves renderer browser ownership across headless reconciliation and clos
   } as never)
   const detachedSnapshot = runtime['buildPreservedHeadlessMobileSessionSnapshot']({
     ...afterHeadlessClose,
-    publicationEpoch: 'epoch-1:headless-merge:runtime-page',
+    publicationEpoch: afterHeadlessClose.publicationEpoch,
     tabs: [...afterHeadlessClose.tabs, headlessTab]
   })!
   runtime['acceptedRendererMobileSnapshotByWorktree'].delete(TEST_WORKTREE_ID)
@@ -153,4 +154,45 @@ it('preserves renderer browser ownership across headless reconciliation and clos
   await runtime.closeMobileSessionTab(`id:${TEST_WORKTREE_ID}`, 'headless-page-1')
   expect(closeSessionTab).not.toHaveBeenCalled()
   expect(closeTab).toHaveBeenCalledWith('headless-page-1')
+})
+
+it('still preserves live offscreen pages from a legacy merge-suffix snapshot', () => {
+  const runtime = new OrcaRuntimeService(store)
+  runtime.setOffscreenBrowserBackend({ closeTab: vi.fn() } as never)
+  runtime.setAgentBrowserBridge({
+    tabList: () => ({
+      tabs: [
+        {
+          browserPageId: 'headless-page-1',
+          title: 'Headless Browser',
+          url: 'https://headless.example/'
+        }
+      ]
+    })
+  } as never)
+  const headlessTab = {
+    type: 'browser' as const,
+    id: 'headless-page-1',
+    title: 'Headless Browser',
+    browserWorkspaceId: 'headless-page-1',
+    browserPageId: 'headless-page-1',
+    url: 'https://headless.example/',
+    loading: false,
+    canGoBack: false,
+    canGoForward: false,
+    isActive: false
+  }
+  const snapshot: RuntimeMobileSessionTabsSnapshot = {
+    worktree: TEST_WORKTREE_ID,
+    publicationEpoch: 'epoch-1:headless-merge:runtime-page',
+    snapshotVersion: 1,
+    activeGroupId: 'group-1',
+    activeTabId: 'headless-page-1',
+    activeTabType: 'browser',
+    tabs: [headlessTab]
+  }
+  runtime['acceptedRendererMobileSnapshotByWorktree'].delete(TEST_WORKTREE_ID)
+  const preserved = runtime['buildPreservedHeadlessMobileSessionSnapshot'](snapshot)
+  expect(preserved?.publicationEpoch).toMatch(/^headless-hydrated:/)
+  expect(preserved?.tabs).toEqual([expect.objectContaining({ id: 'headless-page-1' })])
 })

--- a/src/main/runtime/renderer-browser-session-reconciliation.test.ts
+++ b/src/main/runtime/renderer-browser-session-reconciliation.test.ts
@@ -41,6 +41,11 @@ const snapshot: RuntimeMobileSessionTabsSnapshot = {
   tabGroups: [{ id: 'group', activeTabId: 'renderer-tab', tabOrder: ['renderer-tab'] }]
 }
 
+function isHeadlessBuiltPublication(publicationEpoch: string): boolean {
+  const base = publicationEpoch.split(':headless-merge:')[0]
+  return base.startsWith('headless:') || base.startsWith('headless-hydrated:')
+}
+
 /** Drives the reconcile against a stub host and returns the published snapshot, if any. */
 function reconcile(
   host: {
@@ -51,18 +56,40 @@ function reconcile(
   existing: RuntimeMobileSessionTabsSnapshot = snapshot
 ): RuntimeMobileSessionTabsSnapshot | undefined {
   const storeMobileSessionSnapshot = vi.fn()
-  const runtime = OrcaRuntimeWithReconcileHeadlessMobileSessionBrowserTabs.prototype as unknown as {
+  const proto = OrcaRuntimeWithReconcileHeadlessMobileSessionBrowserTabs.prototype as unknown as {
     reconcileHeadlessMobileSessionBrowserTabs(
       worktreeId: string,
       existing: RuntimeMobileSessionTabsSnapshot
     ): void
+    reconcileOffscreenOwnedMobileSessionBrowserTabs(
+      worktreeId: string,
+      existing: RuntimeMobileSessionTabsSnapshot,
+      existingBrowserTabs: RuntimeMobileSessionBrowserTab[]
+    ): void
   }
-  runtime.reconcileHeadlessMobileSessionBrowserTabs.call(
+  proto.reconcileHeadlessMobileSessionBrowserTabs.call(
     {
       buildHeadlessMobileSessionBrowserTabs: () => host.live ?? [],
       getAvailableAuthoritativeWindow: () => (host.attached === false ? null : {}),
       offscreenBrowserBackend: host.offscreen === true ? {} : null,
-      storeMobileSessionSnapshot
+      storeMobileSessionSnapshot,
+      reconcileOffscreenOwnedMobileSessionBrowserTabs:
+        proto.reconcileOffscreenOwnedMobileSessionBrowserTabs,
+      isRendererOwnedMobileBrowserTab(
+        snapshot: RuntimeMobileSessionTabsSnapshot,
+        tab: RuntimeMobileSessionBrowserTab
+      ) {
+        return (
+          tab.placement?.kind !== 'client' && !isHeadlessBuiltPublication(snapshot.publicationEpoch)
+        )
+      },
+      getMobileSessionPublicationEpochAfterHeadlessBrowserChange(
+        snapshot: RuntimeMobileSessionTabsSnapshot
+      ) {
+        return isHeadlessBuiltPublication(snapshot.publicationEpoch)
+          ? 'headless-hydrated:test'
+          : snapshot.publicationEpoch
+      }
     },
     'wt',
     existing
@@ -78,7 +105,9 @@ it('keeps renderer-owned browser pages when refreshing client-hosted pages on an
 })
 
 it.each([false, true])('retires absent offscreen pages when attached=%s', (attached) => {
-  expect(reconcile({ attached, offscreen: true })?.tabs).toEqual([])
+  expect(
+    reconcile({ attached, offscreen: true }, { ...snapshot, publicationEpoch: 'headless:1' })?.tabs
+  ).toEqual([])
 })
 
 it('removes retired client pages and publishes live ones while retaining renderer rows and group order', () => {

--- a/src/main/runtime/renderer-browser-session-reconciliation.test.ts
+++ b/src/main/runtime/renderer-browser-session-reconciliation.test.ts
@@ -75,6 +75,10 @@ function reconcile(
       storeMobileSessionSnapshot,
       reconcileOffscreenOwnedMobileSessionBrowserTabs:
         proto.reconcileOffscreenOwnedMobileSessionBrowserTabs,
+      isHeadlessBuiltMobileSessionPublicationBase: isHeadlessBuiltPublication,
+      getAcceptedRendererIdentityKeysForMobileSessionSnapshot() {
+        return null
+      },
       isRendererOwnedMobileBrowserTab(
         snapshot: RuntimeMobileSessionTabsSnapshot,
         tab: RuntimeMobileSessionBrowserTab

--- a/src/main/runtime/rpc/methods/session-tabs-move-validation.test.ts
+++ b/src/main/runtime/rpc/methods/session-tabs-move-validation.test.ts
@@ -226,7 +226,7 @@ describe('session tab move validation', () => {
     } as never)
     setMobileSessionSnapshot(runtime, {
       worktree: 'wt-1',
-      publicationEpoch: 'epoch-1',
+      publicationEpoch: 'headless:epoch-1',
       snapshotVersion: 1,
       activeGroupId: 'group-1',
       activeTabId: 'terminal-tab::leaf-1',
@@ -270,6 +270,28 @@ describe('session tab move validation', () => {
       targetGroupId: 'group-1',
       tabOrder: ['browser-live-tab', 'terminal-tab']
     })
+
+    moveSessionTab.mockClear()
+    const headlessSnapshot = runtime['mobileSessionTabsByWorktree'].get('wt-1')!
+    setMobileSessionSnapshot(runtime, {
+      ...headlessSnapshot,
+      publicationEpoch: 'renderer:epoch-2'
+    })
+
+    await expect(
+      runtime.moveMobileSessionTab('id:wt-1', {
+        kind: 'reorder',
+        tabId: 'browser-stale',
+        targetGroupId: 'group-1',
+        tabOrder: ['browser-stale', 'browser-live', 'terminal-tab']
+      })
+    ).resolves.toEqual({ moved: true })
+    expect(moveSessionTab).toHaveBeenCalledWith('wt-1', {
+      kind: 'reorder',
+      tabId: 'browser-stale-tab',
+      targetGroupId: 'group-1',
+      tabOrder: ['browser-stale-tab', 'browser-live-tab', 'terminal-tab']
+    })
   })
 
   it('rejects moves into groups hidden from the sanitized session model', async () => {
@@ -281,7 +303,7 @@ describe('session tab move validation', () => {
     } as never)
     setMobileSessionSnapshot(runtime, {
       worktree: 'wt-1',
-      publicationEpoch: 'epoch-1',
+      publicationEpoch: 'headless:epoch-1',
       snapshotVersion: 1,
       activeGroupId: 'group-visible',
       activeTabId: 'terminal-tab::leaf-1',

--- a/src/main/runtime/runtime-mobile-session-projection-contract.ts
+++ b/src/main/runtime/runtime-mobile-session-projection-contract.ts
@@ -1,6 +1,7 @@
 import type { AgentStatusEntry, AgentStatusIpcPayload } from '../../shared/agent-status-types'
 import type {
   BrowserTabInfo,
+  RuntimeMobileSessionBrowserTab,
   RuntimeMobileSessionClientTab,
   RuntimeMobileSessionTabGroup,
   RuntimeMobileSessionTabsSnapshot,
@@ -16,6 +17,10 @@ export type RuntimeMobileSessionProjectionHost = {
   leaves: ReadonlyMap<string, RuntimeLeafRecord>
   ptysById: ReadonlyMap<string, RuntimePtyWorktreeRecord>
   getLiveBrowserTabs(worktreeId: string): Map<string, BrowserTabInfo>
+  isRendererOwnedMobileBrowserTab(
+    snapshot: RuntimeMobileSessionTabsSnapshot,
+    tab: RuntimeMobileSessionBrowserTab
+  ): boolean
   getProviderSessionRows(paneKey: string): AgentStatusIpcPayload[] | undefined
   getProviderSessionSnapshot(): AgentStatusIpcPayload[]
   getLeafKey(tabId: string, leafId: string): string

--- a/src/main/runtime/runtime-mobile-session-projection.ts
+++ b/src/main/runtime/runtime-mobile-session-projection.ts
@@ -53,14 +53,14 @@ export function projectRuntimeMobileSessionTabs(
   for (const tab of snapshot.tabs) {
     if (tab.type === 'browser') {
       const liveTab = tab.browserPageId ? liveBrowserTabsByPageId.get(tab.browserPageId) : undefined
-      if (!liveTab) {
+      if (!liveTab && !host.isRendererOwnedMobileBrowserTab(snapshot, tab)) {
         continue
       }
-      // Why: renderer snapshots lag BrowserView teardown/process swaps; only surface pages the browser bridge can still route to.
+      // Why: renderer snapshots stay authoritative while unmounted; only headless/client tabs need a live bridge page.
       tabs.push({
         ...tab,
-        title: liveTab.title || tab.title,
-        url: liveTab.url || tab.url,
+        title: liveTab?.title || tab.title,
+        url: liveTab?.url || tab.url,
         // Why: bridge "active" means active BrowserView/webContents, not active Orca tab; preserve the renderer's session focus.
         isActive: tab.isActive
       })


### PR DESCRIPTION
## ELI5

A phone or headless client can still see browser tabs the desktop owned even after that workspace is unmounted. Dead offscreen/headless pages are still removed. Closing a desktop-owned tab talks to the desktop; closing a headless page talks to the offscreen backend.

## What Changed

- List and public-id collection keep renderer-owned browser tabs without live `webContents`. Headless-owned and client-placed tabs still require a live page.
- Offscreen reconcile replaces only headless-owned rows while preserving the accepted renderer publisher epoch.
- Reconcile no-ops when the snapshot is not headless-built and has no accepted renderer identity keys. Live offscreen pages cannot enter an unaccepted renderer epoch.
- Ownership follows accepted renderer identity under the current unchanged publisher epoch. It no longer requires a retired `:headless-merge:` suffix. Legacy suffix snapshots still preserve live offscreen pages when that pair is gone.
- Renderer-detach prune rebases remaining runtime rows onto a `headless-hydrated:` publication base so they cannot be misclassified as renderer-owned. A second preserve on that epoch is a no-op.
- Close uses the offscreen backend only for headless-owned pages. Renderer tabs still go through `closeSessionTab`.

## Why

Unmounted desktop workspaces drop live webContents. Treating every missing page as stale hid renderer tabs from paired clients. Current merges keep the renderer publisher epoch unchanged, so a suffix-only owner check misclassified genuinely headless rows as renderer-owned.

## Linked Issue

Addresses #14598 by preserving unmounted renderer-owned browser tabs on current main. Renderer publication epochs remain stable across headless content changes.

## Visual Proof

N/A — no visual redesign. Covered by list/reconcile/close/detach and accepted-epoch review tests.

## Testing

Validation is tied to `3a53bf93b8274258bade1e66b9185d9e19619ca3`, parent `e117a9abf5370dbd24c6fb4c47eaf9bec3bb6a4d`, base `8f78c28248fbfa4d55fb837ab6698ac77d4e35c5`. Current main is `4f0e3806`; compatibility was checked as described below.

- Codex independently ran all seven affected files: 1,304 passed, 1 skipped, including the complete runtime umbrella. Both previously failing independent accepted-epoch regressions pass on this SHA.
- CLI/Node/Web type checks (`--composite false`), all 13 changed-file oxlint/oxfmt checks, native-runtime preflight and diff whitespace checks passed.
- Full non-Docker suite on this exact SHA: 8,243 files passed, 10 failed, 61 skipped; 76,590 tests passed, 27 failed, 391 skipped (725.05 seconds). The 27 failing test identities exactly match the previously verified baseline at `8f78c282`; no additional failures or uncaught errors were reported. The full suite is not green.
- A merge-tree check against current main `4f0e3806` is clean. Its changes since this candidate's base are confined to unrelated native-chat picker files; dependency manifests are unchanged.
- Docker tests were excluded under the local machine policy. Manual mobile/SSH/Windows runtime checks and a packaging build were not run for this rebase.

**Existing-test assertion/fixture changes (declared):**

- `omits stale browser session tabs that no longer have live webContents` is renamed and now expects renderer-owned dead tabs to remain; the same fixture with a `headless:` epoch still filters them.
- Move-validation stale-hide cases use `headless:epoch-1`; a renderer-epoch reorder of the stale tab is added.
- `retires absent offscreen pages` uses a `headless:` snapshot so offscreen retirement still applies to headless-owned rows only.

## Review

Cursor independently reviewed the full branch diff at `3a53bf93b8274258bade1e66b9185d9e19619ca3` and returned PASS, including a fresh security review of ownership, close routing, accepted-epoch fences and detach/prune behavior. Codex reproduced and verified the fixes against the current publisher-epoch contract and ran the checks above.

## Compatibility and Security

No new RPC or stream opcode. SSH/folder workspaces use the same snapshot epoch rules. Mixed-version clients still see a stable renderer publisher epoch.

## AI Disclosure

Cursor ported the residual onto `8f78c28` / `e15ea3f2`, then repaired unaccepted-guard, detach/prune rebase, and current-epoch accepted-identity classification as `3a53bf93`.
