### PR TITLE
fix(agent-hooks): treat SYSTEMROOT as optional in the Git Bash hook wrapper

### DIFF
--- a/src/main/agent-hooks/installer-utils.test.ts
+++ b/src/main/agent-hooks/installer-utils.test.ts
@@ -657,6 +657,8 @@ describe('wrapRuntimeHomeHookCommand', () => {
     expect(command).not.toContain('uname')
     expect(command).toContain('"$HOME/.orca/agent-hooks/claude-hook.cmd"')
     expect(command).toContain('/bin/sh "$HOME/.orca/agent-hooks/claude-hook.sh"')
+    expect(command).toContain('"${SYSTEMROOT-}/System32/WindowsPowerShell/v1.0/powershell.exe"')
+    expect(command).not.toContain('"$SYSTEMROOT/')
     expect(command).not.toMatch(/[A-Z]:[\\/]|\/Users\/|\/home\//)
   })
 

--- a/src/main/agent-hooks/runtime-home-hook-command.ts
+++ b/src/main/agent-hooks/runtime-home-hook-command.ts
@@ -10,7 +10,9 @@ export function wrapRuntimeHomeHookCommand(scriptBaseName: string): string {
   const windowsScript = `"$HOME/.orca/agent-hooks/${scriptBaseName}.cmd"`
   const posixScript = `"$HOME/.orca/agent-hooks/${scriptBaseName}.sh"`
   const drain = POSIX_HOOK_STDIN_DRAIN_COMMAND
-  const powershell = '"$SYSTEMROOT/System32/WindowsPowerShell/v1.0/powershell.exe"'
+  // Why: runners such as Grok refuse to spawn a hook when `$VAR` is unset;
+  // `${SYSTEMROOT-}` matches `${HOME-}` / `${OSTYPE-}` and is a no-op on POSIX.
+  const powershell = '"${SYSTEMROOT-}/System32/WindowsPowerShell/v1.0/powershell.exe"'
   const powershellCommand = `$homePath = $env:HOME -replace '^/([A-Za-z])/', '$1:/'; $scriptPath = Join-Path $homePath '.orca\\agent-hooks\\${scriptBaseName}.cmd'; if (Test-Path -LiteralPath $scriptPath -PathType Leaf) { & $scriptPath; exit $LASTEXITCODE }; [Console]::In.ReadToEnd() | Out-Null; exit 0`
   const encodedCommand = Buffer.from(powershellCommand, 'utf16le').toString('base64')
   const powershellInvocation = `${powershell} -NoProfile -ExecutionPolicy Bypass -EncodedCommand ${encodedCommand}`


### PR DESCRIPTION
## ELI5

The hook command Orca installs for Claude/Grok already treats `HOME` and `OSTYPE` as optional. `SYSTEMROOT` was left as a required `$VAR`. On macOS and Linux that variable does not exist, so Grok refuses to spawn the hook on every tool call. This uses `${SYSTEMROOT-}`, same pattern as the other two, so Windows Git Bash still finds PowerShell and POSIX runners no longer skip the hook.

## What Changed

- `wrapRuntimeHomeHookCommand` now emits `${SYSTEMROOT-}/System32/WindowsPowerShell/...` instead of `$SYSTEMROOT/...`.
- The existing `wrapRuntimeHomeHookCommand` test asserts the optional form and rejects the bare `$SYSTEMROOT/` token.

## Why

Orca 1.4.183 started writing one cross-platform hook command into `~/.claude/settings.json`. Grok expands `$VAR` at spawn time and refuses the command when the variable is unset. `${HOME-}` and `${OSTYPE-}` already survive that check; `$SYSTEMROOT` did not. Using `${SYSTEMROOT-}` keeps the Windows Git Bash PowerShell fallback and makes the command valid on POSIX.

## Linked Issue

Fixes #14794

## Visual Proof

N/A — no UI or interaction change. This only changes the generated hook command string and a unit test.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

On macOS, with `${SYSTEMROOT-}` installed in `~/.claude/settings.json`, a fresh Grok session runs `global/settings` hooks as `success` (session_start 24ms, user_prompt_submit 19ms, stop 26ms) instead of failing in 0ms with `required env var(s) not set: ${SYSTEMROOT}`.

```
pnpm exec vitest run --config config/vitest.config.ts src/main/agent-hooks/installer-utils.test.ts -t 'wrapRuntimeHomeHookCommand'
✓ 4 passed
```

Platforms actually tested: macOS. Windows Git Bash behavior is unchanged (`SYSTEMROOT` is still read when set). Linux/SSH not re-run locally; CI covers the unit test.

## AI Disclosure

<!-- External contributor: no additional notes. -->

## Review

No security surface change. Cross-platform: POSIX default is empty (Unix branch still used); Windows Git Bash still uses `SYSTEMROOT` when present. No SSH, mobile, or path/shortcut impact. Backward compatible: only the generated command token changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Focused unit tests passed locally. Full lint/typecheck/build left to CI.

## Author

- X / Twitter: