### PR TITLE
fix(orchestration): reconcile merged worker worktrees

### DIFF
--- a/src/main/git/remove-worktree.test.ts
+++ b/src/main/git/remove-worktree.test.ts
@@ -108,6 +108,30 @@ branch refs/heads/main
     expectGitCallOrder(calls, 'git worktree remove /repo-feature', 'git branch -d -- feature/test')
   })
 
+  it('refuses automatic removal when the worktree HEAD no longer matches its proof', async () => {
+    mockGitCommands({
+      'git worktree list --porcelain': {
+        stdout: `worktree /repo
+HEAD abc123
+branch refs/heads/main
+
+worktree /repo-feature
+HEAD changed789
+branch refs/heads/feature/test
+`
+      }
+    })
+
+    await expect(
+      removeWorktree('/repo', '/repo-feature', false, { expectedHead: 'def456' })
+    ).rejects.toThrow(
+      'Worktree HEAD changed during automatic deletion: expected def456, found changed789.'
+    )
+
+    expect(getGitCalls()).not.toContain('git worktree remove /repo-feature')
+    expect(moveWorktreeDirectoryToTrashMock).not.toHaveBeenCalled()
+  })
+
   it('preserves the branch when requested for a pre-existing local branch checkout', async () => {
     mockGitCommands({
       'git worktree list --porcelain': {

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -67,6 +67,8 @@ export type AddWorktreeOptions = GitWorktreeExecOptions & {
 export type RemoveWorktreeOptions = GitWorktreeExecOptions & {
   deleteBranch?: boolean
   forceBranchDelete?: boolean
+  /** Exact commit proven safe by an automatic lifecycle owner. Re-read immediately before remove. */
+  expectedHead?: string
   knownRemovedWorktree?: Pick<GitWorktreeInfo, 'branch' | 'head' | 'locked' | 'lockReason'>
 }
 
@@ -1167,7 +1169,18 @@ async function performRemoveWorktree(
   force = false,
   options: RemoveWorktreeOptions = {}
 ): Promise<RemoveWorktreeResult> {
+  const currentWorktree = options.expectedHead
+    ? (await listWorktreesStrict(repoPath, options)).find((worktree) =>
+        areWorktreePathsEqual(worktree.path, worktreePath)
+      )
+    : undefined
+  if (options.expectedHead && currentWorktree?.head !== options.expectedHead) {
+    throw new Error(
+      `Worktree HEAD changed during automatic deletion: expected ${options.expectedHead}, found ${currentWorktree?.head ?? 'none'}.`
+    )
+  }
   const removedWorktree =
+    currentWorktree ??
     options.knownRemovedWorktree ??
     (await listWorktrees(repoPath, options)).find((worktree) =>
       areWorktreePathsEqual(worktree.path, worktreePath)

--- a/src/main/ipc/github-pr-refresh-routing.test.ts
+++ b/src/main/ipc/github-pr-refresh-routing.test.ts
@@ -4,11 +4,15 @@ const mocks = await vi.hoisted(async () => {
   const { createGitHubIpcMocks } = await import('./github-ipc-module-mocks')
   return createGitHubIpcMocks()
 })
+const reconcileWorkerWorktreeLifecyclesMock = vi.hoisted(() => vi.fn())
 
 vi.mock('electron', () => mocks.electron)
 vi.mock('../github/client', () => mocks.client)
 vi.mock('../github/work-item-details', () => mocks.workItemDetails)
 vi.mock('../github/pr-refresh-coordinator', () => mocks.prRefresh)
+vi.mock('../runtime/orchestration/worker-worktree-lifecycle-reconciliation', () => ({
+  reconcileWorkerWorktreeLifecycles: reconcileWorkerWorktreeLifecyclesMock
+}))
 vi.mock('../telemetry/client', () => mocks.telemetry)
 vi.mock('../telemetry/cohort-classifier', () => mocks.cohort)
 vi.mock('./ui', () => mocks.ui)
@@ -26,7 +30,10 @@ describe('registerGitHubHandlers', () => {
   const harness = createGitHubIpcHarness(mocks)
   const { handlers, store, stats } = harness
 
-  beforeEach(harness.reset)
+  beforeEach(() => {
+    harness.reset()
+    reconcileWorkerWorktreeLifecyclesMock.mockReset()
+  })
 
   it('returns typed automatic PR refresh validation skips without enqueueing', async () => {
     registerGitHubHandlers(store as never, stats as never)
@@ -97,6 +104,50 @@ describe('registerGitHubHandlers', () => {
       })
     )
     expect(candidate).not.toHaveProperty('localGitOptions')
+  })
+
+  it('reconciles the owning worktree when automatic refresh observes a merged PR', async () => {
+    reconcileWorkerWorktreeLifecyclesMock.mockResolvedValue({ attempted: 1, removed: 1 })
+    const runtime = { getRuntimeId: vi.fn() }
+    registerGitHubHandlers(store as never, stats as never, runtime as never)
+    const observer = mocks.prRefresh.setPRRefreshOutcomeObserver.mock.calls[0]?.[0]
+    const outcome = {
+      kind: 'found',
+      fetchedAt: Date.now(),
+      pr: {
+        number: 17,
+        title: 'Lifecycle reconciliation',
+        state: 'merged',
+        url: 'https://github.com/stablyai/orca/pull/17',
+        checksStatus: 'success',
+        updatedAt: new Date().toISOString(),
+        mergeable: 'MERGEABLE',
+        headSha: '1111111111111111111111111111111111111111'
+      }
+    }
+
+    observer?.(
+      {
+        cacheKey: '/workspace/repo::feature/lifecycle',
+        repoPath: '/workspace/repo',
+        repoId: 'repo-1',
+        worktreeId: 'repo-1::lifecycle',
+        branch: 'feature/lifecycle',
+        repoKind: 'git',
+        currentHeadOid: '1111111111111111111111111111111111111111'
+      },
+      outcome
+    )
+    await vi.waitFor(() => expect(reconcileWorkerWorktreeLifecyclesMock).toHaveBeenCalledTimes(1))
+
+    expect(reconcileWorkerWorktreeLifecyclesMock).toHaveBeenCalledWith(runtime, {
+      worktreeId: 'repo-1::lifecycle',
+      prEvidence: {
+        worktreeId: 'repo-1::lifecycle',
+        currentHeadOid: '1111111111111111111111111111111111111111',
+        outcome
+      }
+    })
   })
 
   it('keeps manual PR refresh validation strict', async () => {

--- a/src/main/ipc/github.ts
+++ b/src/main/ipc/github.ts
@@ -22,6 +22,8 @@ import { getRepoExecutionHostId } from '../../shared/execution-host'
 import type { TaskSourceContext } from '../../shared/task-source-context'
 import type { Store } from '../persistence'
 import type { StatsCollector } from '../stats/collector'
+import type { OrcaRuntimeService } from '../runtime/orca-runtime'
+import { reconcileWorkerWorktreeLifecycles } from '../runtime/orchestration/worker-worktree-lifecycle-reconciliation'
 import {
   getPRForBranch,
   getIssue,
@@ -240,7 +242,11 @@ function validateAutomaticPRRefreshCandidate(
   return { kind: 'ok', candidate: applyRepoToPRRefreshCandidate(store, result.repo, candidate) }
 }
 
-export function registerGitHubHandlers(store: Store, stats: StatsCollector): void {
+export function registerGitHubHandlers(
+  store: Store,
+  stats: StatsCollector,
+  runtime?: OrcaRuntimeService
+): void {
   function recordPRIfNeeded(repo: Repo, outcome: PRRefreshOutcome): void {
     if (outcome.kind === 'found' && !stats.hasCountedPR(outcome.pr.url)) {
       stats.record({
@@ -258,6 +264,29 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
       store.getRepos().find((r) => resolve(r.path) === resolve(candidate.repoPath))
     if (repo) {
       recordPRIfNeeded(repo, outcome)
+    }
+    if (
+      runtime &&
+      candidate.worktreeId &&
+      outcome.kind === 'found' &&
+      outcome.pr.state === 'merged'
+    ) {
+      // Why: the PR refresh loop is the first deterministic observer of a merge. Feed its
+      // request-time HEAD proof into lifecycle convergence instead of waiting for an agent to
+      // remember bookkeeping after it has already finished.
+      void reconcileWorkerWorktreeLifecycles(runtime, {
+        worktreeId: candidate.worktreeId,
+        prEvidence: {
+          worktreeId: candidate.worktreeId,
+          currentHeadOid: candidate.currentHeadOid ?? null,
+          outcome
+        }
+      }).catch((error) => {
+        console.warn('[orchestration] merged PR lifecycle reconciliation failed', {
+          worktreeId: candidate.worktreeId,
+          error: error instanceof Error ? error.message : String(error)
+        })
+      })
     }
   })
 

--- a/src/main/ipc/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers.test.ts
@@ -508,7 +508,7 @@ describe('registerCoreHandlers', () => {
     expect(registerMiniMaxCredentialsHandlersMock).toHaveBeenCalledWith(rateLimits)
     expect(registerGrokAccountHandlersMock).toHaveBeenCalled()
     expect(registerRateLimitHandlersMock).toHaveBeenCalledWith(rateLimits, codexAccounts)
-    expect(registerGitHubHandlersMock).toHaveBeenCalledWith(store, stats)
+    expect(registerGitHubHandlersMock).toHaveBeenCalledWith(store, stats, runtime)
     expect(registerLinearHandlersMock).toHaveBeenCalled()
     expect(registerJiraHandlersMock).toHaveBeenCalled()
     expect(registerBitbucketHandlersMock).toHaveBeenCalled()

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -151,7 +151,7 @@ export function registerCoreHandlers(
   registerMiniMaxCredentialsHandlers(rateLimits)
   registerGrokAccountHandlers()
   registerRateLimitHandlers(rateLimits, codexAccounts)
-  registerGitHubHandlers(store, stats)
+  registerGitHubHandlers(store, stats, runtime)
   registerGitLabHandlers(store)
   registerHostedReviewHandlers(store, stats)
   registerLinearHandlers()

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -16284,7 +16284,7 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
-  it('resolves tui-idle from a Codex ready prompt even when stale startup lines remain', async () => {
+  it('does not resolve tui-idle from the Codex composer while MCP servers are still starting', async () => {
     const runtime = new OrcaRuntimeService(store)
     runtime.setPtyController({
       spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
@@ -16312,6 +16312,32 @@ describe('OrcaRuntimeService', () => {
     )
 
     await expect(
+      runtime.waitForTerminal(handle, { condition: 'tui-idle', timeoutMs: 20 })
+    ).rejects.toThrow('timeout')
+  })
+
+  it('resolves tui-idle from a Codex ready status after slow MCP startup settles', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+    runtime.onPtyData(
+      'pty-bg',
+      [
+        ' >_ OpenAI Codex (v0.132.0)\n',
+        ' model:       gpt-5.5 high   /model to change\n',
+        ' directory:   ~/orca/workspaces/orca/cli-debug\n',
+        'Starting MCP servers (0/2): codex_apps, computer-use (2s  esc to interrupt)\n',
+        '› Improve documentation in @filename gpt-5.5 high · Ready · cli-debug\n'
+      ].join(''),
+      Date.now()
+    )
+
+    await expect(
       runtime.waitForTerminal(handle, { condition: 'tui-idle', timeoutMs: 1_000 })
     ).resolves.toMatchObject({
       handle,
@@ -16319,6 +16345,90 @@ describe('OrcaRuntimeService', () => {
       satisfied: true,
       status: 'running'
     })
+  })
+
+  it('does not report Codex agent input ready until slow MCP startup settles', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+    runtime.onPtyData(
+      'pty-bg',
+      [
+        '\x1b[?1049h',
+        ' >_ OpenAI Codex (v0.132.0)\n',
+        ' model:       gpt-5.5 high   /model to change\n',
+        ' directory:   ~/orca/workspaces/orca/cli-debug\n',
+        '\x1b[?2004h',
+        'Starting MCP servers (0/2): codex_apps, computer-use (2s  esc to interrupt)\n',
+        '› Improve documentation in @filename\n'
+      ].join(''),
+      Date.now()
+    )
+
+    let settled = false
+    const readiness = runtime
+      .waitForTerminalAgentInputReady(handle, 'codex', 1_000)
+      .then((value) => {
+        settled = true
+        return value
+      })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(settled).toBe(false)
+
+    runtime.onPtyData(
+      'pty-bg',
+      '› Improve documentation in @filename gpt-5.5 high · Ready · cli-debug\n',
+      Date.now()
+    )
+    await expect(readiness).resolves.toBe(true)
+  })
+
+  it('waits for settled Codex startup in a renderer-owned terminal', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      hasPty: () => true,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    syncSinglePty(runtime, 'pty-renderer')
+    const [terminal] = (await runtime.listTerminals(`id:${TEST_WORKTREE_ID}`)).terminals
+    expect(terminal).toBeDefined()
+    runtime.onPtyData(
+      'pty-renderer',
+      [
+        '\x1b[?1049h',
+        ' >_ OpenAI Codex (v0.132.0)\n',
+        ' model:       gpt-5.5 high   /model to change\n',
+        ' directory:   ~/orca/workspaces/orca/renderer-worker\n',
+        '\x1b[?2004h',
+        'Starting MCP servers (0/2): codex_apps, computer-use (2s  esc to interrupt)\n',
+        '› Improve documentation in @filename\n'
+      ].join(''),
+      Date.now()
+    )
+
+    let settled = false
+    const readiness = runtime
+      .waitForTerminalAgentInputReady(terminal!.handle, 'codex', 1_000)
+      .then((value) => {
+        settled = true
+        return value
+      })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(settled).toBe(false)
+
+    runtime.onPtyData(
+      'pty-renderer',
+      '› Improve documentation in @filename gpt-5.5 high · Ready · renderer-worker\n',
+      Date.now()
+    )
+    await expect(readiness).resolves.toBe(true)
   })
 
   it('resolves tui-idle when a stale Codex prompt is followed by Antigravity readiness', async () => {
@@ -47330,6 +47440,148 @@ describe('OrcaRuntimeService', () => {
     expect(result.warning).toBe(
       `orca.yaml archive hook skipped for ${TEST_WORKTREE_PATH}; pass --run-hooks to run it.`
     )
+  })
+
+  it('blocks automatic lifecycle removal when the worktree is pinned', async () => {
+    const pinnedMeta = makeWorktreeMeta({ isPinned: true })
+    const pinnedStore = {
+      ...store,
+      getAllWorktreeMeta: () => ({ [TEST_WORKTREE_ID]: pinnedMeta }),
+      getWorktreeMeta: (worktreeId: string) =>
+        worktreeId === TEST_WORKTREE_ID ? pinnedMeta : undefined,
+      setWorktreeMeta: () => pinnedMeta
+    }
+    const runtime = createWorktreeRemovalRuntime(pinnedStore)
+
+    await expect(
+      runtime.removeManagedWorktree(TEST_WORKTREE_ID, false, false, false, undefined, true)
+    ).rejects.toThrow('Cannot automatically delete pinned worktree')
+
+    expect(assertWorktreeCleanForRemoval).not.toHaveBeenCalled()
+    expect(removeWorktree).not.toHaveBeenCalled()
+  })
+
+  it('re-checks a lifecycle pin immediately before destructive removal', async () => {
+    let mutableMeta = makeWorktreeMeta()
+    const mutableStore = {
+      ...store,
+      getAllWorktreeMeta: () => ({ [TEST_WORKTREE_ID]: mutableMeta }),
+      getWorktreeMeta: (worktreeId: string) =>
+        worktreeId === TEST_WORKTREE_ID ? mutableMeta : undefined,
+      setWorktreeMeta: () => mutableMeta
+    }
+    const runtime = createWorktreeRemovalRuntime(mutableStore)
+    vi.mocked(assertWorktreeCleanForRemoval).mockImplementationOnce(async () => {
+      mutableMeta = makeWorktreeMeta({ isPinned: true })
+    })
+
+    await expect(
+      runtime.removeManagedWorktree(TEST_WORKTREE_ID, false, false, false, undefined, true)
+    ).rejects.toThrow('Cannot automatically delete pinned worktree')
+
+    expect(assertWorktreeCleanForRemoval).toHaveBeenCalled()
+    expect(removeWorktreeLinkedPathsMock).not.toHaveBeenCalled()
+    expect(removeWorktree).not.toHaveBeenCalled()
+  })
+
+  it('blocks automatic lifecycle removal while any live terminal still uses the worktree', async () => {
+    const runtime = createWorktreeRemovalRuntime()
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      listProcesses: async () => [{ id: 'pty-1', cwd: TEST_WORKTREE_PATH, title: 'Shell' }]
+    })
+    syncSinglePty(runtime, 'pty-1', { paneTitle: 'Shell' })
+    runtime.registerPty('pty-1', TEST_WORKTREE_ID)
+
+    await expect(
+      runtime.removeManagedWorktree(TEST_WORKTREE_ID, false, false, false, undefined, true, true)
+    ).rejects.toThrow('while it has active terminals')
+
+    expect(assertWorktreeCleanForRemoval).not.toHaveBeenCalled()
+    expect(removeWorktree).not.toHaveBeenCalled()
+  })
+
+  it('refuses automatic removal when HEAD changes inside the teardown boundary', async () => {
+    const runtime = createWorktreeRemovalRuntime()
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      listProcesses: async () => []
+    })
+    const changedWorktrees = MOCK_GIT_WORKTREES.map((worktree) =>
+      worktree.path === TEST_WORKTREE_PATH ? { ...worktree, head: 'changed-after-merge' } : worktree
+    )
+    let guardCalls = 0
+    const guard = vi.fn(async () => {
+      guardCalls += 1
+      if (guardCalls === 3) {
+        vi.mocked(listWorktreesStrict).mockResolvedValue(changedWorktrees)
+      }
+    })
+
+    await expect(
+      runtime.removeManagedWorktree(
+        TEST_WORKTREE_ID,
+        false,
+        false,
+        false,
+        undefined,
+        true,
+        true,
+        'abc',
+        guard
+      )
+    ).rejects.toThrow(
+      'Worktree HEAD changed during automatic deletion: expected abc, found changed-after-merge.'
+    )
+
+    expect(guard).toHaveBeenCalledTimes(3)
+    expect(removeWorktreeLinkedPathsMock).not.toHaveBeenCalled()
+    expect(removeWorktree).not.toHaveBeenCalled()
+  })
+
+  it('serializes terminal creation behind automatic worktree removal', async () => {
+    const runtime = createWorktreeRemovalRuntime()
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      listProcesses: async () => []
+    })
+    const cleanGate = deferred<void>()
+    vi.mocked(assertWorktreeCleanForRemoval)
+      .mockImplementationOnce(async () => cleanGate.promise)
+      .mockResolvedValue(undefined)
+    vi.mocked(removeWorktree).mockResolvedValue({})
+
+    const removal = runtime.removeManagedWorktree(
+      TEST_WORKTREE_ID,
+      false,
+      false,
+      false,
+      undefined,
+      true,
+      true,
+      'abc'
+    )
+    await vi.waitFor(() => expect(assertWorktreeCleanForRemoval).toHaveBeenCalledTimes(1))
+
+    let spawnLeaseAcquired = false
+    const spawnLease = runtime.acquireWorktreeTerminalSpawn(TEST_WORKTREE_ID).then((release) => {
+      spawnLeaseAcquired = true
+      return release
+    })
+    await Promise.resolve()
+    expect(spawnLeaseAcquired).toBe(false)
+
+    cleanGate.resolve()
+    await expect(removal).resolves.toEqual({})
+    const releaseSpawn = await spawnLease
+    expect(spawnLeaseAcquired).toBe(true)
+    releaseSpawn()
   })
 
   it('passes project shared links through the runtime removal preflight and cleanup', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -2191,6 +2191,7 @@ type RuntimeWorktreeRemovalTarget = {
   id: string
   repoId: string
   path: string
+  isPinned?: boolean
   pushTarget?: GitPushTarget
 }
 
@@ -2210,12 +2211,16 @@ type PreservedBranchCleanupTarget = {
 function getRuntimeWorktreeRemovalOptionsKey(
   force: boolean,
   runHooks: boolean,
-  allowUnverifiedPtyStop: boolean
+  allowUnverifiedPtyStop: boolean,
+  respectPinned: boolean,
+  protectActiveTerminals: boolean,
+  expectedHead?: string,
+  hasAutomaticRemovalGuard = false
 ): string {
   // Why: a forced retry must not coalesce onto the in-flight attempt that just
   // failed the PTY gate — it would inherit that failure instead of retrying.
   const ptyKey = allowUnverifiedPtyStop ? 'allow-unverified-pty' : 'require-pty-stop'
-  return `${force ? 'force' : 'normal'}:${runHooks ? 'run-hooks' : 'skip-hooks'}:${ptyKey}`
+  return `${force ? 'force' : 'normal'}:${runHooks ? 'run-hooks' : 'skip-hooks'}:${ptyKey}:${respectPinned ? 'respect-pinned' : 'ignore-pinned'}:${protectActiveTerminals ? 'protect-active-terminals' : 'stop-active-terminals'}:head=${expectedHead ?? '*'}:${hasAutomaticRemovalGuard ? 'guarded' : 'unguarded'}`
 }
 
 // Null executionHostId means host-unaware: path-only callers match any repo, and the first runtime
@@ -3545,9 +3550,16 @@ export class OrcaRuntimeService {
 
   private async stopPtysForDestructiveWorktreeRemoval(
     worktreeId: string,
-    options: { connectionId?: string; allowUnverifiedStop?: boolean } = {}
+    options: {
+      connectionId?: string
+      allowUnverifiedStop?: boolean
+      protectActiveTerminals?: boolean
+    } = {}
   ): Promise<void> {
-    const { connectionId, allowUnverifiedStop } = options
+    const { connectionId, allowUnverifiedStop, protectActiveTerminals } = options
+    if (protectActiveTerminals) {
+      await this.assertNoActiveTerminalsForAutomaticWorktreeRemoval(worktreeId)
+    }
     const provider = connectionId ? this.getSshProviderFn?.(connectionId) : this.getLocalProvider()
     if (!provider) {
       throw new Error(`PTY provider unavailable for worktree deletion: ${worktreeId}`)
@@ -3573,6 +3585,20 @@ export class OrcaRuntimeService {
     if (total > 0) {
       console.info(
         `[worktree-teardown] ${worktreeId} killed runtime=${teardownResult.runtimeStopped} provider=${teardownResult.providerStopped} registry=${teardownResult.registryStopped}`
+      )
+    }
+  }
+
+  private async assertNoActiveTerminalsForAutomaticWorktreeRemoval(
+    worktreeId: string
+  ): Promise<void> {
+    const inventory = await this.listTerminals(`id:${worktreeId}`, 1, {
+      requireFreshPtyLiveness: true,
+      includeVisualLayouts: false
+    })
+    if (inventory.totalCount > 0) {
+      throw new Error(
+        `Cannot automatically delete worktree ${worktreeId} while it has active terminals.`
       )
     }
   }
@@ -4697,8 +4723,8 @@ export class OrcaRuntimeService {
       deferredDispatchIds: [...deferredDispatchIds]
     }
     this.updateLegacyWorkerTerminalRecoveryRetry(plan, deferredDispatchIds, options)
-    // Why: previously requested releases may only finish after the owning provider's terminals
-    // are rediscovered; this pass runs per scope (local and each reconnected provider).
+    // Why: release retries and merged-PR lifecycle recovery need fresh provider terminal
+    // discovery; this convergence pass runs per scope (local and each reconnected provider).
     void reconcileRequestedWorkerTerminalReleases(this).catch((error) => {
       console.warn('[orchestration] worker terminal release reconciliation failed', { error })
     })
@@ -22228,10 +22254,27 @@ export class OrcaRuntimeService {
     return null
   }
 
-  private waitForStartupDraftReady(handle: string, agent: TuiAgent): Promise<string | null> {
-    const livePty = this.getLivePtyForHandle(handle)
-    const ptyId = livePty?.pty.ptyId
-    if (!ptyId) {
+  async waitForTerminalAgentInputReady(
+    handle: string,
+    agent: TuiAgent,
+    timeoutMs?: number
+  ): Promise<boolean> {
+    return Boolean(await this.waitForStartupDraftReady(handle, agent, timeoutMs, true))
+  }
+
+  private waitForStartupDraftReady(
+    handle: string,
+    agent: TuiAgent,
+    timeoutMs?: number,
+    requireSettledCodexStartup = false
+  ): Promise<string | null> {
+    let ptyId: string
+    try {
+      // Why: orchestration can dispatch into either a runtime-owned PTY or a renderer-owned
+      // leaf. Restricting this gate to getLivePtyForHandle made healthy desktop terminals look
+      // permanently unready even though terminal.wait and terminal.send support both owners.
+      ptyId = this.getTerminalAgentStatusPtyId(handle)
+    } catch {
       return Promise.resolve(null)
     }
     const readySignal =
@@ -22242,6 +22285,7 @@ export class OrcaRuntimeService {
       let quietTimer: NodeJS.Timeout | null = null
       let hardTimer: NodeJS.Timeout | null = null
       let unsubscribe: (() => void) | null = null
+      let sawDraftReadySignal = false
 
       const finish = (value: string | null): void => {
         if (settled) {
@@ -22267,7 +22311,23 @@ export class OrcaRuntimeService {
 
       const observeData = (data: string): void => {
         const { ready, armQuietTimer: shouldArm } = scanner.observe(data)
-        if (ready) {
+        sawDraftReadySignal ||= ready
+        // Why: Codex mounts its composer before slow MCP startup has settled. A prompt glyph is
+        // therefore necessary but not sufficient for safe input; wait for the same settled-ready
+        // evidence used by terminal.wait before handing orchestration a dispatch capability.
+        const codexStartupSettled = (): boolean => {
+          if (agent !== 'codex' || !requireSettledCodexStartup) {
+            return true
+          }
+          let currentText: string
+          try {
+            currentText = this.getTerminalAgentStatusSnapshot(handle, ptyId).waitText
+          } catch {
+            return false
+          }
+          return findCodexReadyPromptIndex(currentText.toLowerCase()) !== null
+        }
+        if (sawDraftReadySignal && codexStartupSettled()) {
           finish(ptyId)
           return
         }
@@ -22277,11 +22337,19 @@ export class OrcaRuntimeService {
       }
 
       unsubscribe = this.subscribeToTerminalData(ptyId, observeData)
+      try {
+        // Why: renderer graph sync may have already captured the composer before the waiter
+        // subscribes, and renderer-owned PTYs do not necessarily populate recentPtyOutputById.
+        observeData(this.getTerminalAgentStatusSnapshot(handle, ptyId).waitText)
+      } catch {
+        finish(null)
+        return
+      }
       const replay = this.recentPtyOutputById.get(ptyId)?.read()
       if (replay) {
         observeData(replay)
       }
-      hardTimer = setTimeout(() => finish(null), resolveDraftPasteReadyTimeoutMs(agent))
+      hardTimer = setTimeout(() => finish(null), resolveDraftPasteReadyTimeoutMs(agent, timeoutMs))
     })
   }
 
@@ -24735,7 +24803,8 @@ export class OrcaRuntimeService {
       const removalTarget = {
         id: worktree.id,
         repoId: worktree.repoId,
-        path: worktree.path
+        path: worktree.path,
+        isPinned: worktree.isPinned
       }
       return worktree.pushTarget
         ? { ...removalTarget, pushTarget: worktree.pushTarget }
@@ -24752,7 +24821,11 @@ export class OrcaRuntimeService {
       // Why: delete requests can arrive after Git no longer lists the worktree.
       // Only exact IDs with persisted Orca metadata are accepted here so
       // branch/path selectors cannot resolve to an arbitrary missing path.
-      return meta.pushTarget ? { ...removalTarget, pushTarget: meta.pushTarget } : removalTarget
+      const persistedTarget = {
+        ...removalTarget,
+        isPinned: meta.isPinned
+      }
+      return meta.pushTarget ? { ...persistedTarget, pushTarget: meta.pushTarget } : persistedTarget
     }
   }
 
@@ -24927,7 +25000,19 @@ export class OrcaRuntimeService {
     // Why (#11960): only an explicit Force Delete waives PTY-stop proof; `force`
     // alone is already set by the ordinary delete confirmation.
     allowUnverifiedPtyStop = false,
-    hostId?: string
+    hostId?: string,
+    // Why: user-invoked deletion remains an explicit override, while lifecycle automation must
+    // treat a pin as durable retention and re-check it inside the removal boundary.
+    respectPinned = false,
+    // Why: explicit user deletion owns terminal teardown, but lifecycle automation must never
+    // terminate an unrelated user terminal that happens to share the completed worker's worktree.
+    protectActiveTerminals = false,
+    // Why: merged-PR reconciliation proves one exact commit. Carry that proof into the runtime
+    // removal boundary so a commit racing the coordinator cannot inherit an obsolete decision.
+    expectedHead?: string,
+    // Why: orchestration ownership is stored outside the generic worktree runtime. Let the owner
+    // re-read its durable references under the same terminal-mutation boundary used for deletion.
+    automaticRemovalGuard?: () => void | Promise<void>
   ): Promise<RemoveWorktreeResult & { warning?: string }> {
     if (!this.store) {
       throw new Error('runtime_unavailable')
@@ -24935,11 +25020,40 @@ export class OrcaRuntimeService {
     const store = this.store
     const cleanupHostId = parseExecutionHostId(hostId)?.id
     const removalTarget = await this.resolveWorktreeRemovalTarget(worktreeSelector)
+    const assertAutomaticRemovalNotPinned = (): void => {
+      if (
+        respectPinned &&
+        (removalTarget.isPinned || store.getWorktreeMeta(removalTarget.id)?.isPinned)
+      ) {
+        throw new Error(`Cannot automatically delete pinned worktree ${removalTarget.id}.`)
+      }
+    }
+    const assertExpectedHead = (actualHead: string | null | undefined): void => {
+      if (expectedHead && actualHead !== expectedHead) {
+        throw new Error(
+          `Worktree HEAD changed during automatic deletion: expected ${expectedHead}, found ${actualHead ?? 'none'}.`
+        )
+      }
+    }
+    const revalidateAutomaticRemoval = async (): Promise<void> => {
+      assertAutomaticRemovalNotPinned()
+      await automaticRemovalGuard?.()
+      assertAutomaticRemovalNotPinned()
+    }
+    assertAutomaticRemovalNotPinned()
     const cleanupScopeKey = preservedBranchCleanupScopeKey({
       worktreeId: removalTarget.id,
       hostId: cleanupHostId
     })
-    const optionsKey = getRuntimeWorktreeRemovalOptionsKey(force, runHooks, allowUnverifiedPtyStop)
+    const optionsKey = getRuntimeWorktreeRemovalOptionsKey(
+      force,
+      runHooks,
+      allowUnverifiedPtyStop,
+      respectPinned,
+      protectActiveTerminals,
+      expectedHead,
+      Boolean(automaticRemovalGuard)
+    )
     const inFlightRemoval = this.removeManagedWorktreeInFlight.get(removalTarget.id)
     if (inFlightRemoval) {
       if (inFlightRemoval.optionsKey === optionsKey) {
@@ -24951,9 +25065,16 @@ export class OrcaRuntimeService {
     // Why: runtime callers can race the same workspace through CLI/mobile
     // retries. Share one destructive Git/filesystem operation per worktree ID.
     const removal = (async (): Promise<RemoveWorktreeResult & { warning?: string }> => {
+      // Worktree terminal creation and removal share this queue. Once cleanup has acquired it,
+      // no new Orca terminal can attach between the final liveness proof and filesystem removal.
+      const releaseTerminalMutation = await this.acquireWorktreeTerminalMutation(removalTarget.id)
       // Why: CLI, mobile and headless serve delete through here rather than the IPC handler; without
       // this span their freezes are as invisible as desktop deletes were before `worktree.remove`.
       return withWorktreeSpan({ stage: 'remove', path: removalTarget.path }, async () => {
+        await revalidateAutomaticRemoval()
+        if (protectActiveTerminals) {
+          await this.assertNoActiveTerminalsForAutomaticWorktreeRemoval(removalTarget.id)
+        }
         const repo = store.getRepo(removalTarget.repoId)
         if (!repo) {
           const orphanHost = parseExecutionHostId(store.getWorktreeMeta(removalTarget.id)?.hostId)
@@ -25068,6 +25189,9 @@ export class OrcaRuntimeService {
           removalTarget.path,
           registeredWorktrees
         )
+        if (registeredWorktree) {
+          assertExpectedHead(registeredWorktree.head)
+        }
         if (!registeredWorktree) {
           let canCleanOrphanedDirectory = false
           if (
@@ -25105,6 +25229,12 @@ export class OrcaRuntimeService {
             if (!force) {
               throw new Error(ORPHANED_WORKTREE_DIRECTORY_MESSAGE)
             }
+            if (expectedHead) {
+              throw new Error(
+                `Cannot prove expected HEAD ${expectedHead} for unregistered worktree ${removalTarget.id}.`
+              )
+            }
+            await revalidateAutomaticRemoval()
             if (repo.connectionId) {
               const removalGate = await this.acquireFileWatcherRemoval(
                 removalTarget.path,
@@ -25114,7 +25244,8 @@ export class OrcaRuntimeService {
               try {
                 await this.stopPtysForDestructiveWorktreeRemoval(removalTarget.id, {
                   connectionId: repo.connectionId,
-                  allowUnverifiedStop: allowUnverifiedPtyStop
+                  allowUnverifiedStop: allowUnverifiedPtyStop,
+                  protectActiveTerminals
                 })
                 await fsProvider!.deletePath(removalTarget.path, true)
                 removalCompleted = true
@@ -25133,7 +25264,8 @@ export class OrcaRuntimeService {
               let removalCompleted = false
               try {
                 await this.stopPtysForDestructiveWorktreeRemoval(removalTarget.id, {
-                  allowUnverifiedStop: allowUnverifiedPtyStop
+                  allowUnverifiedStop: allowUnverifiedPtyStop,
+                  protectActiveTerminals
                 })
                 await removeLocalWorktreePath(removalTarget.path, localWorktreeGitOptions)
                 removalCompleted = true
@@ -25179,11 +25311,18 @@ export class OrcaRuntimeService {
               if (!force) {
                 throw new Error(ORPHANED_WORKTREE_DIRECTORY_MESSAGE)
               }
+              if (expectedHead) {
+                throw new Error(
+                  `Cannot prove expected HEAD ${expectedHead} for unregistered worktree ${removalTarget.id}.`
+                )
+              }
+              await revalidateAutomaticRemoval()
               const removalGate = await this.acquireFileWatcherRemoval(removalTarget.path)
               let removalCompleted = false
               try {
                 await this.stopPtysForDestructiveWorktreeRemoval(removalTarget.id, {
-                  allowUnverifiedStop: allowUnverifiedPtyStop
+                  allowUnverifiedStop: allowUnverifiedPtyStop,
+                  protectActiveTerminals
                 })
                 await removeLocalWorktreePath(removalTarget.path, localWorktreeGitOptions)
                 removalCompleted = true
@@ -25266,6 +25405,8 @@ export class OrcaRuntimeService {
           removedMeta &&
           (await isRuntimeWorktreePathMissing(repo, canonicalWorktreePath, localWorktreeGitOptions))
         ) {
+          await revalidateAutomaticRemoval()
+          assertExpectedHead(registeredWorktree.head)
           const removalResult = await removeStaleLocalWorktreeRegistrationAfterFilesystemRemoval({
             canonicalWorktreePath,
             repoPath: repo.path,
@@ -25303,11 +25444,30 @@ export class OrcaRuntimeService {
           )
           let rawRemovalResult: RemoveWorktreeResult | undefined
           let removalCompleted = false
+          let finalRegisteredWorktree = registeredWorktree
           try {
+            await revalidateAutomaticRemoval()
             await this.stopPtysForDestructiveWorktreeRemoval(removalTarget.id, {
               connectionId: repo.connectionId,
-              allowUnverifiedStop: allowUnverifiedPtyStop
+              allowUnverifiedStop: allowUnverifiedPtyStop,
+              protectActiveTerminals
             })
+            await revalidateAutomaticRemoval()
+            const finalWorktrees = await provider!.listWorktrees(repo.path)
+            const refreshed = findRegisteredDeletableWorktree(
+              repo.path,
+              canonicalWorktreePath,
+              finalWorktrees
+            )
+            if (!refreshed) {
+              throw new Error(
+                `Worktree registration changed during deletion: ${canonicalWorktreePath}. Retry deletion.`
+              )
+            }
+            assertExpectedHead(refreshed.head)
+            assertWorktreeUnlockedForRemoval(refreshed)
+            finalRegisteredWorktree = refreshed
+            await revalidateAutomaticRemoval()
             rawRemovalResult = await (Object.keys(remoteRemoveOptions).length > 0
               ? provider!.removeWorktree(canonicalWorktreePath, force, remoteRemoveOptions)
               : provider!.removeWorktree(canonicalWorktreePath, force))
@@ -25317,7 +25477,7 @@ export class OrcaRuntimeService {
           }
           const removalResult = this.preserveBranchHeadFallback(
             rawRemovalResult,
-            registeredWorktree.head
+            finalRegisteredWorktree.head
           )
           await cleanupUnusedWorktreePushTargetRemoteSsh(
             provider!,
@@ -25330,7 +25490,7 @@ export class OrcaRuntimeService {
             removalTarget.id,
             cleanupHostId,
             removalResult,
-            registeredWorktree.head,
+            finalRegisteredWorktree.head,
             removedPushTarget
           )
           this.clearOptimisticReconcileToken(removalTarget.id)
@@ -25377,6 +25537,7 @@ export class OrcaRuntimeService {
             `Worktree registration changed during deletion: ${canonicalWorktreePath}. Retry deletion.`
           )
         }
+        assertExpectedHead(refreshedRegisteredWorktree.head)
         try {
           // Why: an archive hook can race another Git client that locks the row;
           // recheck before linked-path, watcher, or terminal teardown side effects.
@@ -25392,52 +25553,97 @@ export class OrcaRuntimeService {
         const ignoredLinkedPaths = force
           ? []
           : await findExistingWorktreeSymlinkPaths(canonicalWorktreePath, linkedPaths)
-        try {
-          await (hasLocalWorktreeGitOptions
-            ? assertWorktreeCleanForRemoval(canonicalWorktreePath, force, {
-                ...localWorktreeGitOptions,
-                ...(ignoredLinkedPaths.length > 0
-                  ? { ignoredUntrackedPaths: ignoredLinkedPaths }
-                  : {})
-              })
-            : ignoredLinkedPaths.length > 0
+        const assertStillCleanForRemoval = async (): Promise<void> => {
+          try {
+            await (hasLocalWorktreeGitOptions
               ? assertWorktreeCleanForRemoval(canonicalWorktreePath, force, {
-                  ignoredUntrackedPaths: ignoredLinkedPaths
+                  ...localWorktreeGitOptions,
+                  ...(ignoredLinkedPaths.length > 0
+                    ? { ignoredUntrackedPaths: ignoredLinkedPaths }
+                    : {})
                 })
-              : assertWorktreeCleanForRemoval(canonicalWorktreePath, force))
-        } catch (error) {
-          if (!isOrphanCompatiblePreflightError(error)) {
+              : ignoredLinkedPaths.length > 0
+                ? assertWorktreeCleanForRemoval(canonicalWorktreePath, force, {
+                    ignoredUntrackedPaths: ignoredLinkedPaths
+                  })
+                : assertWorktreeCleanForRemoval(canonicalWorktreePath, force))
+          } catch (error) {
+            if (!isOrphanCompatiblePreflightError(error)) {
+              throw new Error(formatWorktreeRemovalError(error, canonicalWorktreePath, force))
+            }
+            // Why: Git can still classify this as an orphan after preflight;
+            // retain strict PTY teardown before any recursive fallback deletion.
+          }
+        }
+        const refreshRegisteredWorktreeForRemoval = async () => {
+          if (
+            !expectedHead &&
+            !respectPinned &&
+            !protectActiveTerminals &&
+            !automaticRemovalGuard
+          ) {
+            // Explicit legacy deletion already completed its established preflight above. Its
+            // Windows fallback may deliberately make the Git row disappear during teardown.
+            return refreshedRegisteredWorktree
+          }
+          const currentWorktrees = hasLocalWorktreeGitOptions
+            ? await listWorktreesStrict(repo.path, localWorktreeGitOptions)
+            : await listWorktreesStrict(repo.path)
+          const current = findRegisteredDeletableWorktree(
+            repo.path,
+            canonicalWorktreePath,
+            currentWorktrees
+          )
+          if (!current) {
+            throw new Error(
+              `Worktree registration changed during deletion: ${canonicalWorktreePath}. Retry deletion.`
+            )
+          }
+          assertExpectedHead(current.head)
+          try {
+            assertWorktreeUnlockedForRemoval(current)
+          } catch (error) {
             throw new Error(formatWorktreeRemovalError(error, canonicalWorktreePath, force))
           }
-          // Why: Git can still classify this as an orphan after preflight;
-          // retain strict PTY teardown before any recursive fallback deletion.
+          return current
         }
+        await assertStillCleanForRemoval()
 
         let removalResult: RemoveWorktreeResult | undefined
+        let finalRegisteredWorktree = refreshedRegisteredWorktree
         const removalGate = await this.acquireFileWatcherRemoval(canonicalWorktreePath)
         let removalCompleted = false
         try {
+          await revalidateAutomaticRemoval()
           // Why: linked-path deletion is destructive too; PTYs must release every
           // handle before Windows or WSL filesystem cleanup starts.
           await this.stopPtysForDestructiveWorktreeRemoval(removalTarget.id, {
-            allowUnverifiedStop: allowUnverifiedPtyStop
+            allowUnverifiedStop: allowUnverifiedPtyStop,
+            protectActiveTerminals
           })
+          await revalidateAutomaticRemoval()
+          finalRegisteredWorktree = await refreshRegisteredWorktreeForRemoval()
+          await assertStillCleanForRemoval()
 
           if (linkedPaths.length > 0) {
             await removeWorktreeLinkedPaths(canonicalWorktreePath, linkedPaths)
           }
 
           try {
+            await revalidateAutomaticRemoval()
+            finalRegisteredWorktree = await refreshRegisteredWorktreeForRemoval()
+            await assertStillCleanForRemoval()
             const removeOptions = {
               ...(!deleteBranch ? { deleteBranch } : {}),
+              ...(expectedHead ? { expectedHead } : {}),
               // Why: removal already validated the Git row under the selected
               // project runtime; keep branch cleanup on that same canonical row.
-              knownRemovedWorktree: refreshedRegisteredWorktree,
+              knownRemovedWorktree: finalRegisteredWorktree,
               ...localWorktreeGitOptions
             }
             removalResult = this.preserveBranchHeadFallback(
               await removeWorktree(repo.path, canonicalWorktreePath, force, removeOptions),
-              refreshedRegisteredWorktree.head
+              finalRegisteredWorktree.head
             )
           } catch (error) {
             // Why: Git for Windows can deregister a clean worktree before its
@@ -25448,7 +25654,7 @@ export class OrcaRuntimeService {
               canonicalWorktreePath,
               repoPath: repo.path,
               localWorktreeGitOptions,
-              registeredWorktree: refreshedRegisteredWorktree,
+              registeredWorktree: finalRegisteredWorktree,
               deleteBranch,
               closeWatcher: (worktreePath) => this.closeFileWatchersForRemoval(worktreePath)
             })
@@ -25520,7 +25726,7 @@ export class OrcaRuntimeService {
           removalTarget.id,
           cleanupHostId,
           removalResult,
-          refreshedRegisteredWorktree.head,
+          finalRegisteredWorktree.head,
           removedPushTarget
         )
         this.clearOptimisticReconcileToken(removalTarget.id)
@@ -25533,7 +25739,7 @@ export class OrcaRuntimeService {
           ...removalResult,
           ...(warning ? { warning } : {})
         }
-      })
+      }).finally(releaseTerminalMutation)
     })()
     this.removeManagedWorktreeInFlight.set(removalTarget.id, { optionsKey, promise: removal })
     try {
@@ -37707,7 +37913,21 @@ function findCodexReadyPromptIndex(normalized: string): number | null {
   }
   const readySegment = normalized.slice(headerIndex)
   // Why: Codex prints permissions only in YOLO mode; the stable ready header is OpenAI Codex + model + directory.
-  return readySegment.includes('model:') && readySegment.includes('directory:') ? headerIndex : null
+  if (!readySegment.includes('model:') || !readySegment.includes('directory:')) {
+    return null
+  }
+  // Why: Codex mounts its input composer before slow MCP startup has settled. The same banner and
+  // prompt glyph therefore appear while input is still unsafe to submit, and an early bracketed
+  // paste can interrupt MCP startup or disappear. Prefer the live idle OSC title when available;
+  // for hookless previews, require a later explicit Ready status after the most recent startup row.
+  const mcpStartupIndex = readySegment.lastIndexOf('starting mcp server')
+  if (mcpStartupIndex !== -1) {
+    const afterStartup = readySegment.slice(mcpStartupIndex)
+    if (!/[·•]\s*ready\s*[·•]/u.test(afterStartup)) {
+      return null
+    }
+  }
+  return headerIndex
 }
 
 function findAntigravityReadyPromptIndex(normalized: string): number | null {

--- a/src/main/runtime/orchestration/db.ts
+++ b/src/main/runtime/orchestration/db.ts
@@ -6689,7 +6689,10 @@ export class OrchestrationDb {
     )
   }
 
-  requestWorkerTerminalRelease(dispatchId: string):
+  requestWorkerTerminalRelease(
+    dispatchId: string,
+    options: { respectUserRetain?: boolean } = {}
+  ):
     | { disposition: 'requested'; resource: WorkerTerminalResourceRow }
     | { disposition: 'already_released'; resource: WorkerTerminalResourceRow }
     | {
@@ -6722,6 +6725,17 @@ export class OrchestrationDb {
       if (resource.release_state === 'released' || resource.ownership_state === 'released') {
         this.db.exec('COMMIT')
         return { disposition: 'already_released', resource }
+      }
+      if (
+        options.respectUserRetain &&
+        resource.release_state === 'retained' &&
+        resource.retained_reason === 'user_requested'
+      ) {
+        // Why: automatic lifecycle convergence must never race a deliberate retain into a
+        // release. Explicit worker-release keeps the existing override semantics by omitting
+        // this option; the reconciler opts into the atomic retain check.
+        this.db.exec('COMMIT')
+        return { disposition: 'retained', resource, reason: 'user_requested' }
       }
       if (worker.state === 'stopped' || worker.state === 'abandoned') {
         this.db.exec('COMMIT')

--- a/src/main/runtime/orchestration/worker-terminal-release-reconciliation.ts
+++ b/src/main/runtime/orchestration/worker-terminal-release-reconciliation.ts
@@ -1,5 +1,6 @@
 import type { OrcaRuntimeService } from '../orca-runtime'
 import { completeWorkerTerminalRelease } from '../rpc/methods/orchestration-worker-release-completion'
+import { reconcileWorkerWorktreeLifecycles } from './worker-worktree-lifecycle-reconciliation'
 
 export type WorkerTerminalReleaseReconciliationResult = {
   attempted: number
@@ -16,9 +17,9 @@ type ActiveReconciliation = {
 
 const activeReconciliationByRuntime = new WeakMap<OrcaRuntimeService, ActiveReconciliation>()
 
-// Finishes ONLY previously requested releases after startup/reconnect terminal discovery.
-// It never invents release intent: resources outside requested/releasing are untouched, and
-// unresolved identity defers (release_pending) rather than settling or broadening the close.
+// Converges terminal and Orca-created worktree lifecycles after startup/reconnect discovery.
+// Existing release intent is retried first; then exact merged-PR evidence may settle a stale idle
+// worker and request its ordinary release. Retained/failed/unproven resources remain untouched.
 export function reconcileRequestedWorkerTerminalReleases(
   runtime: OrcaRuntimeService
 ): Promise<WorkerTerminalReleaseReconciliationResult> {
@@ -51,6 +52,26 @@ async function runReconciliationPasses(
     combined.pending += pass.pending
     combined.unknown += pass.unknown
     combined.retained += pass.retained
+    // Why: a crash can land after GitHub merged the PR but before task settlement, terminal
+    // release, or worktree removal. Terminal inventory is the existing startup/reconnect recovery
+    // boundary, so extend the SAME coalesced pass instead of adding a cleanup scheduler. Keeping
+    // this inside the rerun loop also consumes a request that arrives during async GitHub lookup.
+    try {
+      const worktrees = await reconcileWorkerWorktreeLifecycles(runtime)
+      if (worktrees.attempted > 0) {
+        console.info('[orchestration] worker worktree lifecycle reconciliation', {
+          attempted: worktrees.attempted,
+          removed: worktrees.removed,
+          alreadyRemoved: worktrees.alreadyRemoved,
+          retained: worktrees.retained,
+          releasePending: worktrees.releasePending
+        })
+      }
+    } catch (error) {
+      console.warn('[orchestration] worker worktree lifecycle reconciliation failed', {
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
   } while (state.rerunRequested)
   if (combined.attempted > 0) {
     // Structured counts only; never transcript content or paths.

--- a/src/main/runtime/orchestration/worker-worktree-lifecycle-helpers.ts
+++ b/src/main/runtime/orchestration/worker-worktree-lifecycle-helpers.ts
@@ -1,0 +1,262 @@
+import type { PRRefreshOutcome } from '../../../shared/github/pull-request-refresh-types'
+import type { PRInfo } from '../../../shared/github/pull-request-types'
+import type { Worktree } from '../../../shared/worktree/types'
+import type { OrcaRuntimeService } from '../orca-runtime'
+import type { OrchestrationDb } from './db'
+import type { WorkerTerminalResourceRow } from './worker-terminal-ownership'
+
+const CREATED_WORKTREE_ACTIONS = new Set(['created_child', 'created_top_level'])
+const ACTIVE_TASK_STATES = new Set(['pending', 'ready', 'dispatched', 'blocked'])
+const ACTIVE_DISPATCH_STATES = new Set(['pending', 'dispatched'])
+const ACTIVE_WORKER_STATES = new Set([
+  'starting',
+  'ready',
+  'start_unknown',
+  'stopping',
+  'stop_unknown'
+])
+
+export type WorkerWorktreeLifecycleReason =
+  | 'not_orchestration_created'
+  | 'no_worktree_resource'
+  | 'explicitly_retained'
+  | 'pinned'
+  | 'failed_or_cancelled'
+  | 'task_not_successful'
+  | 'worktree_not_found'
+  | 'detached_or_unborn_head'
+  | 'pr_not_found'
+  | 'pr_not_merged'
+  | 'pr_lookup_failed'
+  | 'worktree_head_not_merged'
+  | 'task_reconciliation_rejected'
+  | 'worker_still_active'
+  | 'terminal_release_retained'
+  | 'terminal_release_pending'
+  | 'terminal_release_unknown'
+  | 'terminal_not_released'
+  | 'active_worktree_reference'
+  | 'active_terminal_reference'
+  | 'reconciliation_failed'
+  | 'unsafe_to_remove'
+
+export type WorkerWorktreeLifecycleReceipt = {
+  dispatchId: string
+  taskId: string
+  worktreeId: string | null
+  state: 'removed' | 'already_removed' | 'retained' | 'release_pending'
+  reason?: WorkerWorktreeLifecycleReason
+  taskReconciled: boolean
+  pr: { number: number; url: string } | null
+  branch: { state: 'deleted_or_absent' | 'preserved'; name?: string; head?: string } | null
+  detail?: string
+}
+
+export type WorkerWorktreeLifecycleReconciliationResult = {
+  attempted: number
+  removed: number
+  alreadyRemoved: number
+  retained: number
+  releasePending: number
+  results: WorkerWorktreeLifecycleReceipt[]
+}
+
+export type WorkerWorktreePRRefreshEvidence = {
+  worktreeId: string
+  currentHeadOid: string | null
+  outcome: PRRefreshOutcome
+}
+
+export type WorkerResourceEntry = ReturnType<
+  OrchestrationDb['listWorkerTerminalResources']
+>[number] & {
+  resource: WorkerTerminalResourceRow
+}
+
+export async function resolveWorktree(
+  runtime: OrcaRuntimeService,
+  resource: WorkerTerminalResourceRow,
+  base: Omit<WorkerWorktreeLifecycleReceipt, 'state'>
+): Promise<{ value: Worktree } | { receipt: WorkerWorktreeLifecycleReceipt }> {
+  try {
+    return { value: await runtime.showManagedWorktree(`id:${resource.worktree_id}`) }
+  } catch (error) {
+    if (isSelectorNotFound(error) && resource.release_state === 'released') {
+      return { receipt: { ...base, state: 'already_removed' } }
+    }
+    return {
+      receipt: retained(
+        base,
+        'worktree_not_found',
+        isSelectorNotFound(error) ? undefined : errorMessage(error)
+      )
+    }
+  }
+}
+
+export async function resolvePR(
+  runtime: OrcaRuntimeService,
+  worktree: Worktree,
+  evidence?: WorkerWorktreePRRefreshEvidence
+): Promise<PRRefreshOutcome> {
+  if (
+    evidence?.worktreeId === worktree.id &&
+    normalizeOid(evidence.currentHeadOid) === normalizeOid(worktree.head)
+  ) {
+    return evidence.outcome
+  }
+  const branch = worktree.branch.replace(/^refs\/heads\//, '')
+  return runtime.getRepoPRForBranch(
+    worktree.repoId,
+    branch,
+    worktree.linkedPR,
+    worktree.linkedPR,
+    true,
+    worktree.head
+  )
+}
+
+export function prContainsCurrentHead(pr: PRInfo, head: string): boolean {
+  const normalizedHead = normalizeOid(head)
+  return Boolean(
+    normalizedHead &&
+    (normalizeOid(pr.headSha) === normalizedHead ||
+      normalizeOid(pr.confirmedContainedHeadOid) === normalizedHead)
+  )
+}
+
+export function findCreatedWorktreeEffect(
+  db: OrchestrationDb,
+  resource: WorkerTerminalResourceRow
+): { id: string } | null {
+  const originWorker = db.getWorkerDispatch(resource.origin_dispatch_id)
+  if (!originWorker) {
+    return null
+  }
+  try {
+    const effects = JSON.parse(originWorker.effects) as unknown
+    if (!Array.isArray(effects)) {
+      return null
+    }
+    const effect = effects.find(
+      (candidate) =>
+        candidate &&
+        typeof candidate === 'object' &&
+        (candidate as { kind?: unknown }).kind === 'worktree' &&
+        CREATED_WORKTREE_ACTIONS.has(String((candidate as { action?: unknown }).action)) &&
+        typeof (candidate as { id?: unknown }).id === 'string'
+    ) as { id?: string } | undefined
+    return effect?.id ? { id: effect.id } : null
+  } catch {
+    return null
+  }
+}
+
+export function findOtherActiveWorktreeReference(
+  db: OrchestrationDb,
+  dispatchId: string,
+  worktreeId: string
+): string | null {
+  for (const candidate of db.listWorkerTerminalResources()) {
+    if (candidate.dispatchId === dispatchId) {
+      continue
+    }
+    const worker = db.getWorkerDispatch(candidate.dispatchId)
+    if (worker?.worktree_id !== worktreeId) {
+      continue
+    }
+    const task = db.getTask(candidate.taskId)
+    const dispatch = db.getDispatchContextById(candidate.dispatchId)
+    if (
+      (task && ACTIVE_TASK_STATES.has(task.status)) ||
+      (dispatch && ACTIVE_DISPATCH_STATES.has(dispatch.status)) ||
+      ACTIVE_WORKER_STATES.has(worker.state)
+    ) {
+      return candidate.dispatchId
+    }
+  }
+  return null
+}
+
+export function assertNoOtherActiveWorktreeReference(
+  db: OrchestrationDb,
+  dispatchId: string,
+  worktreeId: string
+): void {
+  const activeDispatchId = findOtherActiveWorktreeReference(db, dispatchId, worktreeId)
+  if (activeDispatchId) {
+    throw new Error(
+      `Cannot automatically delete worktree ${worktreeId} while active Dispatch ${activeDispatchId} still references it.`
+    )
+  }
+}
+
+export function classifyRemovalFailure(detail: string): WorkerWorktreeLifecycleReason {
+  if (detail.includes('while it has active terminals')) {
+    return 'active_terminal_reference'
+  }
+  if (detail.includes('while active Dispatch')) {
+    return 'active_worktree_reference'
+  }
+  return 'unsafe_to_remove'
+}
+
+export function isExplicitlyRetained(resource: WorkerTerminalResourceRow): boolean {
+  return (
+    resource.release_state === 'retained' ||
+    resource.ownership_state === 'user_owned' ||
+    resource.ownership_state === 'transferred' ||
+    resource.ownership_state === 'external'
+  )
+}
+
+export function retained(
+  base: Omit<WorkerWorktreeLifecycleReceipt, 'state'>,
+  reason: WorkerWorktreeLifecycleReason,
+  detail?: unknown
+): WorkerWorktreeLifecycleReceipt {
+  return {
+    ...base,
+    state: 'retained',
+    reason,
+    ...(detail === undefined ? {} : { detail: String(detail) })
+  }
+}
+
+export function pending(
+  base: Omit<WorkerWorktreeLifecycleReceipt, 'state'>,
+  reason: WorkerWorktreeLifecycleReason,
+  detail?: string
+): WorkerWorktreeLifecycleReceipt {
+  return {
+    ...base,
+    state: 'release_pending',
+    reason,
+    ...(detail ? { detail } : {})
+  }
+}
+
+export function summarize(
+  results: WorkerWorktreeLifecycleReceipt[]
+): WorkerWorktreeLifecycleReconciliationResult {
+  return {
+    attempted: results.length,
+    removed: results.filter((result) => result.state === 'removed').length,
+    alreadyRemoved: results.filter((result) => result.state === 'already_removed').length,
+    retained: results.filter((result) => result.state === 'retained').length,
+    releasePending: results.filter((result) => result.state === 'release_pending').length,
+    results
+  }
+}
+
+function normalizeOid(value: string | null | undefined): string {
+  return value?.trim().toLowerCase() ?? ''
+}
+
+export function isSelectorNotFound(error: unknown): boolean {
+  return error instanceof Error && error.message === 'selector_not_found'
+}
+
+export function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/src/main/runtime/orchestration/worker-worktree-lifecycle-reconciliation.test.ts
+++ b/src/main/runtime/orchestration/worker-worktree-lifecycle-reconciliation.test.ts
@@ -1,0 +1,530 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { PRRefreshOutcome } from '../../../shared/github/pull-request-refresh-types'
+import type { Worktree } from '../../../shared/worktree/types'
+import { OrcaRuntimeService } from '../orca-runtime'
+import { ORCHESTRATION_METHODS } from '../rpc/methods/orchestration'
+import { OrchestrationDb } from './db'
+import { reconcileRequestedWorkerTerminalReleases } from './worker-terminal-release-reconciliation'
+import { reconcileWorkerWorktreeLifecycles } from './worker-worktree-lifecycle-reconciliation'
+
+describe('worker worktree lifecycle reconciliation', () => {
+  const coordinatorPane = 'tab_coord:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+  const workerPane = 'tab_worker:bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+  const head = '1111111111111111111111111111111111111111'
+  const worktreeId = 'repo::created'
+  let db: OrchestrationDb
+  let runtime: OrcaRuntimeService
+  let runId: string
+  let worktreeExists: boolean
+  let pinned: boolean
+  let prOutcome: PRRefreshOutcome
+  let workerTerminalOpen: boolean
+  let workerAgentStatus: 'working' | 'permission' | 'idle' | null
+  let unrelatedTerminalOpen: boolean
+
+  function createdWorktree(): Worktree {
+    return {
+      id: worktreeId,
+      repoId: 'repo',
+      displayName: 'lifecycle-worker',
+      comment: '',
+      linkedIssue: null,
+      linkedPR: 17,
+      linkedLinearIssue: null,
+      isArchived: false,
+      isUnread: false,
+      isPinned: pinned,
+      sortOrder: 0,
+      lastActivityAt: Date.now(),
+      path: '/tmp/orca-lifecycle-worker',
+      head,
+      branch: 'refs/heads/test/lifecycle-worker',
+      isBare: false,
+      isMainWorktree: false
+    }
+  }
+
+  beforeEach(() => {
+    db = new OrchestrationDb(':memory:')
+    runtime = new OrcaRuntimeService()
+    runtime.setOrchestrationDb(db)
+    runId = db.createRun({
+      objective: 'Lifecycle reconciliation test',
+      coordinatorHandle: 'term_coord',
+      coordinatorPaneKey: coordinatorPane
+    }).id
+    worktreeExists = true
+    pinned = false
+    prOutcome = mergedPR()
+    workerTerminalOpen = true
+    workerAgentStatus = 'idle'
+    unrelatedTerminalOpen = false
+
+    vi.spyOn(runtime, 'getTerminalPaneKey').mockImplementation((handle) =>
+      handle === 'term_coord' ? coordinatorPane : handle === 'term_worker' ? workerPane : null
+    )
+    vi.spyOn(runtime, 'getTerminalProcessIncarnation').mockImplementation((handle) =>
+      handle === 'term_worker' ? 'runtime_test:term_worker:1' : null
+    )
+    vi.spyOn(runtime, 'getOrchestrationDispatchAuthority').mockImplementation((handle) =>
+      handle === 'term_worker'
+        ? ({
+            terminalHandle: handle,
+            paneKey: workerPane,
+            processIncarnation: 'runtime_test:term_worker:1',
+            hostScope: { kind: 'local', hostId: 'local' }
+          } as never)
+        : null
+    )
+    vi.spyOn(runtime, 'validateOrchestrationAgentLauncher').mockImplementation(() => {})
+    vi.spyOn(runtime, 'showTerminal').mockImplementation(
+      async (handle) =>
+        ({
+          handle,
+          worktreeId: handle === 'term_coord' ? 'repo::parent' : worktreeId,
+          status: 'running'
+        }) as never
+    )
+    vi.spyOn(runtime, 'showManagedWorktree').mockImplementation(async (selector) => {
+      if (selector === 'id:repo::parent') {
+        return { id: 'repo::parent', repoId: 'repo' } as never
+      }
+      if (selector === `id:${worktreeId}` && worktreeExists) {
+        return createdWorktree() as never
+      }
+      throw new Error('selector_not_found')
+    })
+    vi.spyOn(runtime, 'showRepo').mockResolvedValue({ id: 'repo', kind: 'git' } as never)
+    vi.spyOn(runtime, 'createManagedWorktree').mockImplementation(async () => ({
+      worktree: createdWorktree(),
+      startupTerminal: { spawned: true, handle: 'term_worker' },
+      setupReceipt: {
+        requested: 'run',
+        hookFound: false,
+        startupPolicy: 'start-immediately',
+        state: 'not_configured'
+      }
+    }))
+    vi.spyOn(runtime, 'listTerminals').mockImplementation(async () => {
+      const terminals = [
+        ...(workerTerminalOpen ? [{ handle: 'term_worker', title: 'Codex' }] : []),
+        ...(unrelatedTerminalOpen ? [{ handle: 'term_unrelated', title: 'Shell' }] : [])
+      ]
+      return { terminals, totalCount: terminals.length, truncated: false } as never
+    })
+    vi.spyOn(runtime, 'waitForTerminal').mockResolvedValue({
+      handle: 'term_worker',
+      condition: 'tui-idle',
+      satisfied: true,
+      status: 'running',
+      exitCode: null
+    })
+    vi.spyOn(runtime, 'waitForTerminalAgentInputReady').mockResolvedValue(true)
+    vi.spyOn(runtime, 'getTerminalOrchestrationCliCommand').mockReturnValue('orca')
+    vi.spyOn(runtime, 'sendTerminalAgentPrompt').mockResolvedValue({
+      handle: 'term_worker',
+      accepted: true,
+      bytesWritten: 1
+    })
+    vi.spyOn(runtime, 'isTerminalRunningAgent').mockResolvedValue(true)
+    vi.spyOn(runtime, 'getTerminalAgentStatus').mockImplementation(async (handle) => {
+      if (handle !== 'term_worker' || !workerTerminalOpen) {
+        throw new Error('terminal_gone')
+      }
+      return { handle, isRunningAgent: true, status: workerAgentStatus }
+    })
+    vi.spyOn(runtime, 'getExactWorkerProviderSession').mockReturnValue(null)
+    vi.spyOn(runtime, 'readTerminal').mockResolvedValue({
+      handle: 'term_worker',
+      status: 'running',
+      tail: ['validated worker result'],
+      truncated: false,
+      nextCursor: '1'
+    })
+    vi.spyOn(runtime, 'closeTerminal').mockImplementation(async () => {
+      workerTerminalOpen = false
+      return { handle: 'term_worker', closed: true } as never
+    })
+    vi.spyOn(runtime, 'notifyMessageArrived').mockImplementation(() => {})
+    vi.spyOn(runtime, 'getRepoPRForBranch').mockImplementation(async () => prOutcome)
+    vi.spyOn(runtime, 'removeManagedWorktree').mockImplementation(async () => {
+      if (!worktreeExists) {
+        throw new Error('selector_not_found')
+      }
+      worktreeExists = false
+      return {}
+    })
+  })
+
+  afterEach(() => {
+    db.close()
+    vi.restoreAllMocks()
+  })
+
+  async function startWorker(): Promise<{ taskId: string; dispatchId: string }> {
+    const task = db.createTask({ spec: 'Implement and merge the lifecycle task', runId })
+    const method = ORCHESTRATION_METHODS.find(
+      (candidate) => candidate.name === 'orchestration.workerStart'
+    )
+    if (!method) {
+      throw new Error('workerStart method is not registered')
+    }
+    const params = method.params!.parse({
+      task: task.id,
+      from: 'term_coord',
+      worktree: 'new-child',
+      name: 'lifecycle-worker',
+      agent: 'codex'
+    })
+    const result = (await method.handler(params, { runtime })) as {
+      dispatchId: string
+      state: string
+    }
+    expect(result.state).toBe('ready')
+    return { taskId: task.id, dispatchId: result.dispatchId }
+  }
+
+  function settle(
+    worker: { taskId: string; dispatchId: string },
+    outcome: 'succeeded' | 'failed' = 'succeeded'
+  ): void {
+    expect(
+      db.settleWorkerReport({
+        taskId: worker.taskId,
+        dispatchId: worker.dispatchId,
+        outcome,
+        result: `worker ${outcome}`
+      }).action
+    ).toBe('settled')
+  }
+
+  it('completes release and non-force worktree removal for a successful merged task', async () => {
+    const worker = await startWorker()
+    settle(worker)
+
+    const result = await reconcileWorkerWorktreeLifecycles(runtime)
+
+    expect(result).toMatchObject({ attempted: 1, removed: 1, retained: 0 })
+    expect(db.getTask(worker.taskId)?.status).toBe('completed')
+    expect(db.getWorkerTerminalResourceByOwner(worker.dispatchId)?.release_state).toBe('released')
+    expect(runtime.closeTerminal).toHaveBeenCalledTimes(1)
+    expect(runtime.removeManagedWorktree).toHaveBeenCalledWith(
+      `id:${worktreeId}`,
+      false,
+      false,
+      false,
+      undefined,
+      true,
+      true,
+      head,
+      expect.any(Function)
+    )
+  })
+
+  it('retains the worktree when worker_done succeeds but the PR remains open', async () => {
+    prOutcome = openPR()
+    const worker = await startWorker()
+    settle(worker)
+
+    const result = await reconcileWorkerWorktreeLifecycles(runtime)
+
+    expect(result.results[0]).toMatchObject({ state: 'retained', reason: 'pr_not_merged' })
+    expect(runtime.closeTerminal).not.toHaveBeenCalled()
+    expect(runtime.removeManagedWorktree).not.toHaveBeenCalled()
+  })
+
+  it('repairs a stale dispatched Task from exact merged-PR evidence before cleanup', async () => {
+    const worker = await startWorker()
+
+    const result = await reconcileWorkerWorktreeLifecycles(runtime)
+
+    expect(result.results[0]).toMatchObject({ state: 'removed', taskReconciled: true })
+    expect(db.getTask(worker.taskId)?.status).toBe('completed')
+    expect(db.getDispatchContextById(worker.dispatchId)?.status).toBe('completed')
+    expect(db.getWorkerDispatch(worker.dispatchId)?.state).toBe('succeeded')
+  })
+
+  it('does not substitute merged-PR evidence while the assigned worker is still active', async () => {
+    const worker = await startWorker()
+    workerAgentStatus = 'working'
+
+    const result = await reconcileWorkerWorktreeLifecycles(runtime)
+
+    expect(result.results[0]).toMatchObject({
+      state: 'retained',
+      reason: 'worker_still_active',
+      taskReconciled: false
+    })
+    expect(db.getTask(worker.taskId)?.status).toBe('dispatched')
+    expect(runtime.closeTerminal).not.toHaveBeenCalled()
+    expect(runtime.removeManagedWorktree).not.toHaveBeenCalled()
+  })
+
+  it('surfaces dirty-worktree refusal and preserves the worktree', async () => {
+    const worker = await startWorker()
+    settle(worker)
+    vi.mocked(runtime.removeManagedWorktree).mockRejectedValueOnce(
+      new Error('Cannot delete worktree with uncommitted changes.')
+    )
+
+    const result = await reconcileWorkerWorktreeLifecycles(runtime)
+
+    expect(result.results[0]).toMatchObject({ state: 'retained', reason: 'unsafe_to_remove' })
+    expect(result.results[0]?.detail).toContain('uncommitted changes')
+    expect(worktreeExists).toBe(true)
+  })
+
+  it('does not terminate an unrelated active terminal during automatic cleanup', async () => {
+    const worker = await startWorker()
+    settle(worker)
+    unrelatedTerminalOpen = true
+    vi.mocked(runtime.removeManagedWorktree).mockRejectedValueOnce(
+      new Error(`Cannot automatically delete worktree ${worktreeId} while it has active terminals.`)
+    )
+
+    const result = await reconcileWorkerWorktreeLifecycles(runtime)
+
+    expect(result.results[0]).toMatchObject({
+      state: 'retained',
+      reason: 'active_terminal_reference'
+    })
+    expect(unrelatedTerminalOpen).toBe(true)
+    expect(worktreeExists).toBe(true)
+  })
+
+  it('retains a completed worktree while another active Dispatch still references it', async () => {
+    const worker = await startWorker()
+    settle(worker)
+    const dependentTask = db.createTask({ spec: 'Continue using the same worktree', runId })
+    const dependent = db.createStartingWorkerDispatch({
+      taskId: dependentTask.id,
+      startOptions: { worktree: `id:${worktreeId}`, agent: 'codex' },
+      runtimeEpoch: runtime.getRuntimeId()
+    })
+    db.prepareStartingWorkerAuthority({
+      dispatchId: dependent.dispatch.id,
+      handle: 'term_dependent',
+      paneKey: 'tab_dependent:cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+      processIncarnation: 'runtime_test:term_dependent:1',
+      worktreeId,
+      effects: [{ kind: 'worktree', action: 'reused', id: worktreeId }],
+      setupState: 'not_applicable',
+      terminalOwnership: 'created'
+    })
+
+    const result = await reconcileWorkerWorktreeLifecycles(runtime, {
+      dispatchId: worker.dispatchId
+    })
+
+    expect(result.results[0]).toMatchObject({
+      state: 'retained',
+      reason: 'active_worktree_reference'
+    })
+    expect(runtime.removeManagedWorktree).not.toHaveBeenCalled()
+  })
+
+  it('re-checks active Dispatch references inside the final removal boundary', async () => {
+    const worker = await startWorker()
+    settle(worker)
+    vi.mocked(runtime.removeManagedWorktree).mockImplementationOnce(
+      async (...args: Parameters<OrcaRuntimeService['removeManagedWorktree']>) => {
+        const dependentTask = db.createTask({ spec: 'Late dependent work', runId })
+        const dependent = db.createStartingWorkerDispatch({
+          taskId: dependentTask.id,
+          startOptions: { worktree: `id:${worktreeId}`, agent: 'codex' },
+          runtimeEpoch: runtime.getRuntimeId()
+        })
+        db.prepareStartingWorkerAuthority({
+          dispatchId: dependent.dispatch.id,
+          handle: 'term_late_dependent',
+          paneKey: 'tab_late:dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+          processIncarnation: 'runtime_test:term_late_dependent:1',
+          worktreeId,
+          effects: [{ kind: 'worktree', action: 'reused', id: worktreeId }],
+          setupState: 'not_applicable',
+          terminalOwnership: 'created'
+        })
+        await args[8]?.()
+        throw new Error('automatic removal guard unexpectedly accepted the late reference')
+      }
+    )
+
+    const result = await reconcileWorkerWorktreeLifecycles(runtime, {
+      dispatchId: worker.dispatchId
+    })
+
+    expect(result.results[0]).toMatchObject({
+      state: 'retained',
+      reason: 'active_worktree_reference'
+    })
+    expect(worktreeExists).toBe(true)
+  })
+
+  it('honors an explicit worker retain as a durable cleanup escape hatch', async () => {
+    const worker = await startWorker()
+    settle(worker)
+    expect(db.retainWorkerTerminalResource(worker.dispatchId).disposition).toBe('retained')
+
+    const result = await reconcileWorkerWorktreeLifecycles(runtime)
+
+    expect(result.results[0]).toMatchObject({ state: 'retained', reason: 'explicitly_retained' })
+    expect(runtime.closeTerminal).not.toHaveBeenCalled()
+    expect(runtime.removeManagedWorktree).not.toHaveBeenCalled()
+  })
+
+  it('is idempotent when cleanup is run twice', async () => {
+    const worker = await startWorker()
+    settle(worker)
+
+    const first = await reconcileWorkerWorktreeLifecycles(runtime)
+    const second = await reconcileWorkerWorktreeLifecycles(runtime)
+
+    expect(first.removed).toBe(1)
+    expect(second.alreadyRemoved).toBe(1)
+    expect(runtime.closeTerminal).toHaveBeenCalledTimes(1)
+    expect(runtime.removeManagedWorktree).toHaveBeenCalledTimes(1)
+  })
+
+  it('recovers after restart when the PR merged before release and cleanup', async () => {
+    const recoveryDir = await mkdtemp(join(tmpdir(), 'orca-lifecycle-restart-'))
+    const recoveryDbPath = join(recoveryDir, 'orchestration.sqlite')
+    try {
+      db.close()
+      db = new OrchestrationDb(recoveryDbPath)
+      runtime.setOrchestrationDb(db)
+      runId = db.createRun({
+        objective: 'Persisted lifecycle restart test',
+        coordinatorHandle: 'term_coord',
+        coordinatorPaneKey: coordinatorPane
+      }).id
+      const worker = await startWorker()
+      settle(worker)
+
+      db.close()
+      db = new OrchestrationDb(recoveryDbPath)
+      runtime.setOrchestrationDb(db)
+
+      await reconcileRequestedWorkerTerminalReleases(runtime)
+
+      expect(db.getTask(worker.taskId)?.status).toBe('completed')
+      expect(db.getWorkerTerminalResourceByOwner(worker.dispatchId)?.release_state).toBe('released')
+      expect(runtime.removeManagedWorktree).toHaveBeenCalledTimes(1)
+      expect(worktreeExists).toBe(false)
+    } finally {
+      db.close()
+      db = new OrchestrationDb(':memory:')
+      runtime.setOrchestrationDb(db)
+      await rm(recoveryDir, { recursive: true, force: true })
+    }
+  })
+
+  it('re-runs the whole recovery pass when reconciliation is requested during PR lookup', async () => {
+    const worker = await startWorker()
+    settle(worker)
+    const firstPR = deferred<PRRefreshOutcome>()
+    vi.mocked(runtime.getRepoPRForBranch)
+      .mockImplementationOnce(async () => firstPR.promise)
+      .mockImplementation(async () => mergedPR())
+
+    const first = reconcileRequestedWorkerTerminalReleases(runtime)
+    await vi.waitFor(() => expect(runtime.getRepoPRForBranch).toHaveBeenCalledTimes(1))
+    const second = reconcileRequestedWorkerTerminalReleases(runtime)
+    expect(second).toBe(first)
+    firstPR.resolve(openPR())
+
+    await expect(first).resolves.toEqual(expect.objectContaining({ attempted: 0 }))
+    expect(runtime.getRepoPRForBranch).toHaveBeenCalledTimes(2)
+    expect(runtime.removeManagedWorktree).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves failed or cancelled work without attempting terminal or worktree deletion', async () => {
+    const worker = await startWorker()
+    settle(worker, 'failed')
+
+    const result = await reconcileWorkerWorktreeLifecycles(runtime)
+
+    expect(result.results[0]).toMatchObject({ state: 'retained', reason: 'failed_or_cancelled' })
+    expect(runtime.closeTerminal).not.toHaveBeenCalled()
+    expect(runtime.removeManagedWorktree).not.toHaveBeenCalled()
+  })
+
+  it('retains a worktree pinned after merge', async () => {
+    const worker = await startWorker()
+    settle(worker)
+    pinned = true
+
+    const result = await reconcileWorkerWorktreeLifecycles(runtime)
+
+    expect(result.results[0]).toMatchObject({ state: 'retained', reason: 'pinned' })
+    expect(runtime.removeManagedWorktree).not.toHaveBeenCalled()
+  })
+
+  it('reports a branch preserved by the existing safe Git cleanup mechanism', async () => {
+    const worker = await startWorker()
+    settle(worker)
+    vi.mocked(runtime.removeManagedWorktree).mockResolvedValueOnce({
+      preservedBranch: {
+        branchName: 'test/lifecycle-worker',
+        head,
+        reason: 'branch_not_merged'
+      }
+    } as never)
+
+    const result = await reconcileWorkerWorktreeLifecycles(runtime)
+
+    expect(result.results[0]).toMatchObject({
+      state: 'removed',
+      branch: { state: 'preserved', name: 'test/lifecycle-worker', head }
+    })
+  })
+
+  it('does not accept a merged PR whose contents do not include the current HEAD', async () => {
+    prOutcome = mergedPR({ headSha: '2222222222222222222222222222222222222222' })
+    const worker = await startWorker()
+    settle(worker)
+
+    const result = await reconcileWorkerWorktreeLifecycles(runtime)
+
+    expect(result.results[0]).toMatchObject({
+      state: 'retained',
+      reason: 'worktree_head_not_merged'
+    })
+    expect(runtime.removeManagedWorktree).not.toHaveBeenCalled()
+  })
+
+  function mergedPR(overrides: { headSha?: string } = {}): PRRefreshOutcome {
+    return {
+      kind: 'found',
+      fetchedAt: Date.now(),
+      pr: {
+        number: 17,
+        title: 'Lifecycle fix',
+        state: 'merged',
+        url: 'https://github.com/stablyai/orca/pull/17',
+        checksStatus: 'success',
+        updatedAt: new Date().toISOString(),
+        mergeable: 'MERGEABLE',
+        headSha: overrides.headSha ?? head
+      }
+    }
+  }
+
+  function openPR(): PRRefreshOutcome {
+    const outcome = mergedPR()
+    if (outcome.kind !== 'found') {
+      throw new Error('unexpected test fixture')
+    }
+    return { ...outcome, pr: { ...outcome.pr, state: 'open' } }
+  }
+
+  function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+    let resolve!: (value: T) => void
+    const promise = new Promise<T>((next) => {
+      resolve = next
+    })
+    return { promise, resolve }
+  }
+})

--- a/src/main/runtime/orchestration/worker-worktree-lifecycle-reconciliation.ts
+++ b/src/main/runtime/orchestration/worker-worktree-lifecycle-reconciliation.ts
@@ -1,0 +1,324 @@
+import type { Worktree } from '../../../shared/worktree/types'
+import type { OrcaRuntimeService } from '../orca-runtime'
+import { completeWorkerTerminalRelease } from '../rpc/methods/orchestration-worker-release-completion'
+import type { OrchestrationDb } from './db'
+import {
+  assertNoOtherActiveWorktreeReference,
+  classifyRemovalFailure,
+  errorMessage,
+  findCreatedWorktreeEffect,
+  findOtherActiveWorktreeReference,
+  isExplicitlyRetained,
+  isSelectorNotFound,
+  pending,
+  prContainsCurrentHead,
+  retained,
+  resolvePR,
+  resolveWorktree,
+  summarize,
+  type WorkerResourceEntry,
+  type WorkerWorktreeLifecycleReceipt,
+  type WorkerWorktreeLifecycleReconciliationResult,
+  type WorkerWorktreePRRefreshEvidence
+} from './worker-worktree-lifecycle-helpers'
+
+export type {
+  WorkerWorktreeLifecycleReason,
+  WorkerWorktreeLifecycleReceipt,
+  WorkerWorktreeLifecycleReconciliationResult,
+  WorkerWorktreePRRefreshEvidence
+} from './worker-worktree-lifecycle-helpers'
+
+type ReconciliationOptions = {
+  dispatchId?: string
+  worktreeId?: string
+  automaticTerminalRelease?: boolean
+  prEvidence?: WorkerWorktreePRRefreshEvidence
+}
+
+// Joins Orca's durable Task/Dispatch/terminal facts to exact GitHub and Git facts. This is
+// intentionally a convergence pass, not an age-based collector: only Orca-created worktrees with
+// a merged PR containing their current HEAD are eligible, and ordinary non-force removal remains
+// the final cleanliness/branch-safety authority.
+export async function reconcileWorkerWorktreeLifecycles(
+  runtime: OrcaRuntimeService,
+  options: ReconciliationOptions = {}
+): Promise<WorkerWorktreeLifecycleReconciliationResult> {
+  const db = runtime.getOrchestrationDb()
+  const entries = db
+    .listWorkerTerminalResources()
+    .filter((entry): entry is WorkerResourceEntry => Boolean(entry.resource))
+    .filter((entry) => !options.dispatchId || entry.dispatchId === options.dispatchId)
+    .filter(
+      (entry) =>
+        !options.worktreeId ||
+        entry.resource.worktree_id === options.worktreeId ||
+        db.getWorkerDispatch(entry.dispatchId)?.worktree_id === options.worktreeId
+    )
+
+  const results: WorkerWorktreeLifecycleReceipt[] = []
+  for (const entry of entries) {
+    const created = findCreatedWorktreeEffect(db, entry.resource)
+    if (!created && !options.dispatchId) {
+      continue
+    }
+    try {
+      results.push(
+        await reconcileWorkerWorktreeLifecycle(runtime, db, entry, created, {
+          automaticTerminalRelease: options.automaticTerminalRelease !== false,
+          prEvidence: options.prEvidence
+        })
+      )
+    } catch (error) {
+      // One malformed or temporarily unavailable resource must not prevent restart recovery for
+      // every other worker. Retain the failing worktree and expose the exact failure in its receipt.
+      results.push({
+        dispatchId: entry.dispatchId,
+        taskId: entry.taskId,
+        worktreeId: entry.resource.worktree_id,
+        state: 'retained',
+        reason: 'reconciliation_failed',
+        taskReconciled: false,
+        pr: null,
+        branch: null,
+        detail: errorMessage(error)
+      })
+    }
+  }
+
+  return summarize(results)
+}
+
+async function reconcileWorkerWorktreeLifecycle(
+  runtime: OrcaRuntimeService,
+  db: OrchestrationDb,
+  entry: WorkerResourceEntry,
+  created: { id: string } | null,
+  options: {
+    automaticTerminalRelease: boolean
+    prEvidence?: WorkerWorktreePRRefreshEvidence
+  }
+): Promise<WorkerWorktreeLifecycleReceipt> {
+  const base = {
+    dispatchId: entry.dispatchId,
+    taskId: entry.taskId,
+    worktreeId: entry.resource.worktree_id,
+    taskReconciled: false,
+    pr: null,
+    branch: null
+  } satisfies Omit<WorkerWorktreeLifecycleReceipt, 'state'>
+
+  if (!created) {
+    return retained(base, 'not_orchestration_created')
+  }
+  if (!entry.resource.worktree_id || created.id !== entry.resource.worktree_id) {
+    return retained(base, 'no_worktree_resource')
+  }
+  if (db.getFederatedDispatch(entry.dispatchId)) {
+    return retained(base, 'terminal_release_retained', 'The worker server owns this lifecycle.')
+  }
+
+  const currentResource = db.getWorkerTerminalResource(entry.resource.id) ?? entry.resource
+  if (isExplicitlyRetained(currentResource)) {
+    return retained(base, 'explicitly_retained')
+  }
+
+  const task = db.getTask(entry.taskId)
+  const dispatch = db.getDispatchContextById(entry.dispatchId)
+  const worker = db.getWorkerDispatch(entry.dispatchId)
+  if (!task || !dispatch || !worker) {
+    return retained(base, 'task_not_successful', 'Task, Dispatch, or worker state is missing.')
+  }
+  if (
+    task.status === 'failed' ||
+    dispatch.status === 'failed' ||
+    dispatch.status === 'circuit_broken' ||
+    ['failed', 'stopped', 'abandoned'].includes(worker.state)
+  ) {
+    return retained(base, 'failed_or_cancelled')
+  }
+
+  const worktree = await resolveWorktree(runtime, entry.resource, base)
+  if ('receipt' in worktree) {
+    return worktree.receipt
+  }
+  if (worktree.value.isPinned) {
+    return retained(base, 'pinned')
+  }
+  if (!worktree.value.head || !worktree.value.branch) {
+    return retained(base, 'detached_or_unborn_head')
+  }
+
+  const prOutcome = await resolvePR(runtime, worktree.value, options.prEvidence)
+  if (prOutcome.kind === 'upstream-error') {
+    return retained(base, 'pr_lookup_failed', prOutcome.message)
+  }
+  if (prOutcome.kind === 'no-pr') {
+    return retained(base, 'pr_not_found')
+  }
+  const pr = prOutcome.pr
+  const withPR = { ...base, pr: { number: pr.number, url: pr.url } }
+  if (pr.state !== 'merged') {
+    return retained(withPR, 'pr_not_merged')
+  }
+  if (!prContainsCurrentHead(pr, worktree.value.head)) {
+    return retained(withPR, 'worktree_head_not_merged')
+  }
+
+  let taskReconciled = false
+  if (
+    task.status === 'dispatched' &&
+    dispatch.status === 'dispatched' &&
+    worker.state === 'ready'
+  ) {
+    try {
+      const agentStatus = await runtime.getTerminalAgentStatus(entry.resource.terminal_handle)
+      if (agentStatus.isRunningAgent && agentStatus.status !== 'idle') {
+        return retained(
+          withPR,
+          'worker_still_active',
+          'The merged PR is authoritative, but the assigned worker is still active.'
+        )
+      }
+    } catch (error) {
+      const detail = errorMessage(error)
+      if (!/(terminal_(?:gone|exited|not_found))|selector_not_found/i.test(detail)) {
+        return retained(
+          withPR,
+          'worker_still_active',
+          `Could not prove that the assigned worker is idle: ${detail}`
+        )
+      }
+      // A terminal that is already gone cannot still be performing useful work. The exact merged
+      // PR remains sufficient to repair the stale durable task state after a crash or reconnect.
+    }
+    const settlement = db.settleWorkerReport({
+      taskId: entry.taskId,
+      dispatchId: entry.dispatchId,
+      outcome: 'succeeded',
+      result: JSON.stringify({
+        provenance: 'merged_pr_reconciliation',
+        outcome: 'succeeded',
+        pr: { number: pr.number, url: pr.url, headSha: pr.headSha ?? null },
+        worktree: { id: worktree.value.id, head: worktree.value.head },
+        completedAt: new Date().toISOString()
+      })
+    })
+    if (settlement.action === 'rejected') {
+      return retained(withPR, 'task_reconciliation_rejected', settlement.reason)
+    }
+    taskReconciled = true
+  }
+
+  const settledTask = db.getTask(entry.taskId)
+  const settledDispatch = db.getDispatchContextById(entry.dispatchId)
+  const settledWorker = db.getWorkerDispatch(entry.dispatchId)
+  const reconciledBase = { ...withPR, taskReconciled }
+  if (
+    settledTask?.status !== 'completed' ||
+    settledDispatch?.status !== 'completed' ||
+    settledWorker?.state !== 'succeeded'
+  ) {
+    return retained(reconciledBase, 'task_not_successful')
+  }
+
+  let releasedResource = db.getWorkerTerminalResource(entry.resource.id) ?? entry.resource
+  if (releasedResource.release_state !== 'released') {
+    if (!options.automaticTerminalRelease) {
+      return retained(reconciledBase, 'terminal_not_released')
+    }
+    const requested = db.requestWorkerTerminalRelease(entry.dispatchId, {
+      respectUserRetain: true
+    })
+    if (requested.disposition === 'retained') {
+      const reason =
+        requested.reason === 'user_requested' ? 'explicitly_retained' : 'terminal_release_retained'
+      return retained(reconciledBase, reason)
+    }
+    if (requested.disposition === 'requested') {
+      const release = await completeWorkerTerminalRelease({
+        runtime,
+        db,
+        dispatchId: entry.dispatchId,
+        resource: requested.resource,
+        mode: 'recovery'
+      })
+      if (release.state === 'release_pending') {
+        return pending(reconciledBase, 'terminal_release_pending', release.lastError)
+      }
+      if (release.state === 'release_unknown') {
+        return pending(reconciledBase, 'terminal_release_unknown', release.lastError)
+      }
+      if (release.state === 'retained') {
+        return retained(reconciledBase, 'terminal_release_retained', release.reason)
+      }
+    }
+    releasedResource = db.getWorkerTerminalResource(entry.resource.id) ?? entry.resource
+  }
+  if (releasedResource.release_state !== 'released') {
+    return pending(reconciledBase, 'terminal_release_pending')
+  }
+
+  const activeReference = findOtherActiveWorktreeReference(db, entry.dispatchId, worktree.value.id)
+  if (activeReference) {
+    return retained(
+      reconciledBase,
+      'active_worktree_reference',
+      `Dispatch ${activeReference} still references this worktree.`
+    )
+  }
+
+  // Re-read immediately before removal so a newly pinned workspace or changed HEAD cannot inherit
+  // an earlier eligibility decision. removeManagedWorktree repeats the pin check inside its own
+  // removal boundary and remains the authority for dirty state and safe branch deletion.
+  let removalWorktree: Worktree
+  try {
+    removalWorktree = await runtime.showManagedWorktree(`id:${worktree.value.id}`)
+  } catch (error) {
+    if (isSelectorNotFound(error)) {
+      return { ...reconciledBase, state: 'already_removed' }
+    }
+    return retained(reconciledBase, 'unsafe_to_remove', errorMessage(error))
+  }
+  if (removalWorktree.isPinned) {
+    return retained(reconciledBase, 'pinned')
+  }
+  if (removalWorktree.head !== worktree.value.head) {
+    return retained(
+      reconciledBase,
+      'worktree_head_not_merged',
+      'Worktree HEAD changed after merged-PR verification.'
+    )
+  }
+
+  try {
+    const removed = await runtime.removeManagedWorktree(
+      `id:${worktree.value.id}`,
+      false,
+      false,
+      false,
+      removalWorktree.hostId,
+      true,
+      true,
+      removalWorktree.head,
+      () => assertNoOtherActiveWorktreeReference(db, entry.dispatchId, worktree.value.id)
+    )
+    return {
+      ...reconciledBase,
+      state: 'removed',
+      branch: removed.preservedBranch
+        ? {
+            state: 'preserved',
+            name: removed.preservedBranch.branchName,
+            head: removed.preservedBranch.head
+          }
+        : { state: 'deleted_or_absent' }
+    }
+  } catch (error) {
+    if (isSelectorNotFound(error)) {
+      return { ...reconciledBase, state: 'already_removed' }
+    }
+    const detail = errorMessage(error)
+    return retained(reconciledBase, classifyRemovalFailure(detail), detail)
+  }
+}

--- a/src/main/runtime/rpc/methods/orchestration-composed-workers.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-composed-workers.test.ts
@@ -55,6 +55,9 @@ describe('orchestration RPC methods', () => {
         status: 'running',
         exitCode: null
       })
+      vi.spyOn(runtime, 'waitForTerminalAgentInputReady').mockResolvedValue(
+        options?.ready !== false
+      )
       vi.mocked(runtime.getTerminalProcessIncarnation).mockImplementation((handle) =>
         handle === 'term_worker' ? 'runtime_test:term_worker:1' : null
       )

--- a/src/main/runtime/rpc/methods/orchestration-federation-agent-launch.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-federation-agent-launch.test.ts
@@ -35,6 +35,7 @@ describe('federated worker agent launch', () => {
       status: 'running',
       exitCode: null
     })
+    vi.spyOn(runtime, 'waitForTerminalAgentInputReady').mockResolvedValue(true)
     // Why: without a stable pane the handler bails at agent_readiness, so the
     // assertions below would pass against a worker that never actually started.
     vi.spyOn(runtime, 'getTerminalPaneKey').mockReturnValue('tab_remote:leaf_remote')

--- a/src/main/runtime/rpc/methods/orchestration-federation-lifecycle-settlement.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-federation-lifecycle-settlement.test.ts
@@ -112,6 +112,7 @@ describe('orchestration federation lifecycle settlement', () => {
       status: 'running',
       exitCode: null
     })
+    vi.spyOn(workerRuntime, 'waitForTerminalAgentInputReady').mockResolvedValue(true)
     vi.spyOn(workerRuntime, 'getTerminalPaneKey').mockReturnValue(
       'tab_worker:bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
     )

--- a/src/main/runtime/rpc/methods/orchestration-federation-output.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-federation-output.test.ts
@@ -142,6 +142,7 @@ describe('orchestration federated worker output', () => {
       status: 'running',
       exitCode: null
     })
+    vi.spyOn(runtime, 'waitForTerminalAgentInputReady').mockResolvedValue(true)
     vi.spyOn(runtime, 'getTerminalPaneKey').mockReturnValue(
       'tab_worker:bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
     )

--- a/src/main/runtime/rpc/methods/orchestration-federation.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-federation.test.ts
@@ -128,6 +128,7 @@ describe('orchestration federation', () => {
       status: 'running',
       exitCode: null
     })
+    vi.spyOn(runtime, 'waitForTerminalAgentInputReady').mockResolvedValue(true)
     vi.spyOn(runtime, 'getTerminalPaneKey').mockReturnValue(
       'tab_worker:bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
     )

--- a/src/main/runtime/rpc/methods/orchestration-send.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-send.test.ts
@@ -8,6 +8,21 @@ import type { OrcaRuntimeService } from '../../orca-runtime'
 import type { RuntimeTerminalSummary } from '../../../../shared/runtime-types'
 import { ORCHESTRATION_CONTRACT_VERSION } from '../../../../shared/protocol-version'
 
+const releaseReconciliationMocks = vi.hoisted(() => ({
+  reconcileRequestedWorkerTerminalReleases: vi.fn().mockResolvedValue({
+    attempted: 0,
+    released: 0,
+    pending: 0,
+    unknown: 0,
+    retained: 0
+  })
+}))
+
+vi.mock(
+  '../../orchestration/worker-terminal-release-reconciliation',
+  () => releaseReconciliationMocks
+)
+
 function lifecycleGroupRecipientError(type: 'worker_done' | 'heartbeat'): string {
   return `${type} messages belong to one exact Dispatch and cannot target a group address.`
 }
@@ -21,6 +36,7 @@ describe('orchestration RPC methods', () => {
   let activeRunId: string | undefined
 
   function setup(withBoundRun = true): void {
+    releaseReconciliationMocks.reconcileRequestedWorkerTerminalReleases.mockClear()
     ;({ db, runtime, ctx, activeRunId } = h.setup(withBoundRun))
   }
 
@@ -724,6 +740,12 @@ describe('orchestration RPC methods', () => {
       expect(db.getTask(task.id)?.status).toBe('completed')
       expect(db.getDispatchContextById(dispatch.id)?.status).toBe('completed')
       expect(db.getActiveDispatchForTerminal('term_worker')).toBeUndefined()
+      expect(
+        releaseReconciliationMocks.reconcileRequestedWorkerTerminalReleases
+      ).toHaveBeenCalledOnce()
+      expect(
+        releaseReconciliationMocks.reconcileRequestedWorkerTerminalReleases
+      ).toHaveBeenCalledWith(runtime)
       // Lock released — a new dispatch to the same terminal must succeed.
       const t2 = db.createTask({ spec: 'follow-up work' })
       expect(() => db.createDispatchContext(t2.id, 'term_worker')).not.toThrow()

--- a/src/main/runtime/rpc/methods/orchestration-worker-release-completion.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-release-completion.ts
@@ -10,6 +10,7 @@ import {
   type WorkerTerminalTailArchive
 } from '../../orchestration/worker-output-archive'
 import type { OrcaRuntimeService } from '../../orca-runtime'
+import type { WorkerWorktreeLifecycleReceipt } from '../../orchestration/worker-worktree-lifecycle-reconciliation'
 import { inspectWorkerTerminal } from './orchestration-worker-observation'
 import { orchestrationTimestampToMs } from './orchestration-worker-output'
 
@@ -21,6 +22,7 @@ export type WorkerReleaseReceipt = {
   archive: { source: string | null; status: string | null } | null
   recovery?: string
   lastError?: string
+  worktree?: WorkerWorktreeLifecycleReceipt | null
 }
 
 type WorkerTerminalReleaseArgs = {

--- a/src/main/runtime/rpc/methods/orchestration-worker-release-recovery.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-release-recovery.test.ts
@@ -63,6 +63,7 @@ describe('orchestration worker release recovery', () => {
       status: 'running',
       exitCode: null
     })
+    vi.spyOn(runtime, 'waitForTerminalAgentInputReady').mockResolvedValue(true)
     vi.spyOn(runtime, 'getTerminalOrchestrationCliCommand').mockReturnValue('orca')
     vi.spyOn(runtime, 'sendTerminalAgentPrompt').mockResolvedValue({
       handle: 'term_worker',

--- a/src/main/runtime/rpc/methods/orchestration-worker-release.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-release.test.ts
@@ -76,6 +76,7 @@ describe('orchestration worker release', () => {
       status: 'running',
       exitCode: null
     })
+    vi.spyOn(runtime, 'waitForTerminalAgentInputReady').mockResolvedValue(true)
     vi.spyOn(runtime, 'getTerminalOrchestrationCliCommand').mockReturnValue('orca')
     vi.spyOn(runtime, 'sendTerminalAgentPrompt').mockResolvedValue({
       handle: 'term_worker',
@@ -801,6 +802,9 @@ describe('orchestration worker release', () => {
     }
     expect(retained).toMatchObject({ state: 'retained', reason: 'user_requested' })
     expect(db.getWorkerTerminalResourceByOwner(dispatchId)?.release_state).toBe('retained')
+    expect(db.requestWorkerTerminalRelease(dispatchId, { respectUserRetain: true })).toMatchObject({
+      disposition: 'retained'
+    })
 
     const release = (await call('orchestration.workerRelease', { dispatch: dispatchId })) as {
       state: string

--- a/src/main/runtime/rpc/methods/orchestration-worker-release.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-release.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod'
 import { OrchestrationError } from '../../orchestration/orchestration-error'
 import type { WorkerTerminalListState } from '../../orchestration/worker-terminal-ownership'
+import {
+  reconcileWorkerWorktreeLifecycles,
+  type WorkerWorktreeLifecycleReceipt
+} from '../../orchestration/worker-worktree-lifecycle-reconciliation'
 import { defineMethod, type RpcMethod } from '../core'
 import { requiredString } from '../schemas'
 import {
@@ -44,14 +48,26 @@ export const ORCHESTRATION_WORKER_RELEASE_METHODS: RpcMethod[] = [
             'Connected-server workers do not support release yet; inspect the worker server directly.'
         }
       }
+      // Why: explicit release is also a recovery boundary. A worker whose completion callback was
+      // lost may still be proven complete by an exact merged PR; repair that durable state before
+      // the settled-only release guard runs.
+      await reconcileWorkerWorktreeLifecycles(runtime, {
+        dispatchId: params.dispatch,
+        automaticTerminalRelease: false
+      }).catch((error) => {
+        console.warn('[orchestration] pre-release worktree reconciliation failed', {
+          dispatchId: params.dispatch,
+          error: error instanceof Error ? error.message : String(error)
+        })
+      })
       const requested = db.requestWorkerTerminalRelease(params.dispatch)
       if (requested.disposition === 'already_released') {
-        return {
+        return attachWorktreeLifecycle(runtime, params.dispatch, {
           dispatchId: params.dispatch,
           state: 'already_released',
           processAction: 'none',
           archive: archiveSummary(requested.resource)
-        }
+        })
       }
       if (requested.disposition === 'retained') {
         const resource = requested.resource
@@ -70,28 +86,29 @@ export const ORCHESTRATION_WORKER_RELEASE_METHODS: RpcMethod[] = [
           })
           if (reconciled.disposition === 'released') {
             runtime.notifyMessageArrived(`dispatch:${params.dispatch}`, 'status')
-            return {
+            return attachWorktreeLifecycle(runtime, params.dispatch, {
               dispatchId: params.dispatch,
               state: 'released',
               processAction: 'none',
               archive: archiveSummary(reconciled.resource)
-            }
+            })
           }
         }
-        return {
+        return attachWorktreeLifecycle(runtime, params.dispatch, {
           dispatchId: params.dispatch,
           state: 'retained',
           reason: requested.reason,
           processAction: 'none',
           archive: archiveSummary(resource)
-        }
+        })
       }
-      return completeWorkerTerminalRelease({
+      const terminal = await completeWorkerTerminalRelease({
         runtime,
         db,
         dispatchId: params.dispatch,
         resource: requested.resource
       })
+      return attachWorktreeLifecycle(runtime, params.dispatch, terminal)
     }
   }),
   defineMethod({
@@ -183,3 +200,29 @@ export const ORCHESTRATION_WORKER_RELEASE_METHODS: RpcMethod[] = [
     })
   })
 ]
+
+async function attachWorktreeLifecycle(
+  runtime: Parameters<typeof reconcileWorkerWorktreeLifecycles>[0],
+  dispatchId: string,
+  terminal: WorkerReleaseReceipt
+): Promise<WorkerReleaseReceipt> {
+  try {
+    const worktrees = await reconcileWorkerWorktreeLifecycles(runtime, {
+      dispatchId,
+      automaticTerminalRelease: false
+    })
+    return { ...terminal, worktree: firstCreatedWorktreeReceipt(worktrees.results) }
+  } catch (error) {
+    console.warn('[orchestration] post-release worktree reconciliation failed', {
+      dispatchId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return terminal
+  }
+}
+
+function firstCreatedWorktreeReceipt(
+  receipts: WorkerWorktreeLifecycleReceipt[]
+): WorkerWorktreeLifecycleReceipt | null {
+  return receipts.find((receipt) => receipt.reason !== 'not_orchestration_created') ?? null
+}

--- a/src/main/runtime/rpc/methods/orchestration-workers-new-worktree.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-workers-new-worktree.test.ts
@@ -63,6 +63,7 @@ describe('orchestration new-worktree workers', () => {
       status: 'running',
       exitCode: null
     })
+    vi.spyOn(runtime, 'waitForTerminalAgentInputReady').mockResolvedValue(true)
     vi.spyOn(runtime, 'waitForSetupTerminalCompletion').mockReturnValue(
       new Promise(() => undefined)
     )
@@ -163,6 +164,30 @@ describe('orchestration new-worktree workers', () => {
       ])
     )
     expect(runtime.createTerminal).not.toHaveBeenCalled()
+  })
+
+  it('waits for the agent input composer before sending dispatch authority', async () => {
+    mockCreatedWorktree()
+    const inputReady = vi.mocked(runtime.waitForTerminalAgentInputReady)
+    const sendPrompt = vi.mocked(runtime.sendTerminalAgentPrompt)
+
+    await startWorker()
+
+    expect(inputReady).toHaveBeenCalledWith('term_worker', 'codex', 60_000)
+    expect(inputReady.mock.invocationCallOrder[0]).toBeLessThan(
+      sendPrompt.mock.invocationCallOrder[0]
+    )
+  })
+
+  it('fails closed without sending or activating a dispatch when the composer never mounts', async () => {
+    mockCreatedWorktree()
+    vi.mocked(runtime.waitForTerminalAgentInputReady).mockResolvedValue(false)
+
+    const { result, task } = await startWorker()
+
+    expect(result).toMatchObject({ state: 'failed', stage: 'agent_readiness' })
+    expect(runtime.sendTerminalAgentPrompt).not.toHaveBeenCalled()
+    expect(db.getTask(task.id)?.status).toBe('failed')
   })
 
   it('passes launch preferences into agent-first worktree creation', async () => {

--- a/src/main/runtime/rpc/methods/orchestration-workers.ts
+++ b/src/main/runtime/rpc/methods/orchestration-workers.ts
@@ -209,6 +209,14 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
               : `Agent did not become ready (${wait.status}).`
           )
         }
+        const inputReady = await runtime.waitForTerminalAgentInputReady(
+          terminalHandle,
+          agent as TuiAgent,
+          params.timeoutMs ?? 60_000
+        )
+        if (!inputReady) {
+          throw new Error('Agent input composer did not become ready before dispatch.')
+        }
         const terminalAuthority = requireWorkerAuthority(runtime, terminalHandle)
         const capability = db.prepareStartingWorkerAuthority({
           dispatchId: started.dispatch.id,

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -15,6 +15,7 @@ import { buildDispatchPreamble } from '../../orchestration/preamble'
 import { formatMessageBanner } from '../../orchestration/formatter'
 import { isGroupAddress, resolveGroupAddress } from '../../orchestration/groups'
 import { reconcileLifecycleMessage } from '../../orchestration/lifecycle-reconciliation'
+import { reconcileRequestedWorkerTerminalReleases } from '../../orchestration/worker-terminal-release-reconciliation'
 import { waitForFederatedLifecycleSettlement } from '../../orchestration/federation-lifecycle-settlement'
 import { abbreviateOrchestrationTasks } from '../../../../shared/orchestration-task-summary'
 import {
@@ -680,6 +681,15 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
             return { message: rejection, lifecycle: reconciled }
           }
           runtime.notifyMessageArrived(msg.to_handle, msg.type)
+          if (reconciled.action === 'completed') {
+            // Why: a merged PR may predate worker_done, so re-enter the coalesced lifecycle pass.
+            void reconcileRequestedWorkerTerminalReleases(runtime).catch((error) => {
+              console.warn('[orchestration] completed worker lifecycle reconciliation failed', {
+                dispatchId: reconciled.dispatchId,
+                error: error instanceof Error ? error.message : String(error)
+              })
+            })
+          }
           return msg.type === 'worker_done'
             ? { message: msg, lifecycle: reconciled }
             : { message: msg }

--- a/tests/e2e/completed-worker-retirement-resume.unit.test.ts
+++ b/tests/e2e/completed-worker-retirement-resume.unit.test.ts
@@ -281,6 +281,7 @@ async function releaseCompletedWorker(terminalState: 'running' | 'exited'): Prom
     status: 'running',
     exitCode: null
   })
+  vi.spyOn(runtime, 'waitForTerminalAgentInputReady').mockResolvedValue(true)
   vi.spyOn(runtime, 'getTerminalOrchestrationCliCommand').mockReturnValue('orca')
   vi.spyOn(runtime, 'sendTerminalAgentPrompt').mockResolvedValue({
     handle: TERMINAL_HANDLE,


### PR DESCRIPTION
## Summary

- wait for Codex to be genuinely input-ready after slow MCP startup before minting dispatch authority or sending the worker prompt
- reconcile merged PR facts into stale task, worker, and worktree lifecycle state through Orca's existing release-recovery loop
- retire only Orca-created, unpinned, unretained, clean worktrees whose exact HEAD is proven merged and which have no active task, worker, terminal, or dependent reference
- make worktree and branch cleanup restart-safe and idempotent without force removal

## Root cause

The worker dispatcher treated the generic `tui-idle` state as input readiness. Codex could expose its composer while MCP servers were still starting, so Orca persisted a dispatch capability and pasted the prompt before the terminal could safely accept it. When that input was lost or interrupted, a later `worker_done` had no matching capability and the task stayed `dispatched`.

Separately, worker release stopped at terminal retirement. There was no deterministic convergence step from a merged PR to stale task settlement and safe worktree/branch removal. The first failure therefore amplified the second, but the cleanup seam also needed fixing independently.

## Reconciliation behavior

- successful `worker_done`, PR refresh observing an exact merged head, and runtime reconnect/startup all request the same coalesced convergence pass
- a merged PR may repair a stale dispatched task only when the assigned worker is idle or gone
- failed/cancelled, federated, reused, retained, pinned, dirty, divergent, live-terminal, actively referenced, or dependency-referenced worktrees are preserved and surfaced
- cleanup re-reads task/dispatch/worker state, pin state, HEAD, cleanliness, terminal liveness, and references immediately before removal
- a repeated pass treats an already-removed released worktree as success

## Verification

- changed-surface suite: 15 files, 1,336 passed, 1 skipped
- TypeScript typecheck: passed for node, CLI, and web under Node 24
- changed-code quality gates: passed with 0 findings across 27 files
- full lint and reliability gates: passed
- full repository run: 52,842 passed, 128 skipped, 26 failed; that run exposed 2 changed-surface fixture failures, both fixed and covered by the green changed-surface rerun. The 24 residual failures reproduce outside this change (23 local Codex runtime-home/auth configuration expectations and 1 Node path-resolution environment assertion)

No existing worktrees were deleted while developing or validating this change.
