### PR TITLE
fix(agent-hooks): treat Kimi <hook_result> envelopes as harness-injected

### DIFF
--- a/src/shared/agent-hook-listener-claude-compatible-vendors.test.ts
+++ b/src/shared/agent-hook-listener-claude-compatible-vendors.test.ts
@@ -164,6 +164,35 @@ describe('shared agent-hook-listener', () => {
     expect(tool!.payload.agentType).toBe('kimi')
   })
 
+  // Why: a Kimi UserPromptSubmit hook re-emits its own <hook_result> envelope as a
+  // prompt; letting it win makes branch auto-naming anchor on the envelope (#14789).
+  it('keeps the typed prompt when a Kimi hook_result envelope follows', () => {
+    const typed = normalizeHookPayload(
+      state,
+      'kimi',
+      {
+        paneKey: PANE_KEY,
+        payload: { hook_event_name: 'UserPromptSubmit', prompt: 'debug the CI config' }
+      },
+      'production'
+    )
+    expect(typed?.payload.prompt).toBe('debug the CI config')
+
+    const envelope = normalizeHookPayload(
+      state,
+      'kimi',
+      {
+        paneKey: PANE_KEY,
+        payload: {
+          hook_event_name: 'UserPromptSubmit',
+          prompt: '<hook_result hook_event="UserPromptSubmit">{}</hook_result>'
+        }
+      },
+      'production'
+    )
+    expect(envelope?.payload.prompt).toBe('debug the CI config')
+  })
+
   it('ignores unproven Kimi compact lifecycle events', () => {
     const pre = normalizeAndAccept(state, 'kimi', {
       hook_event_name: 'PreCompact',

--- a/src/shared/harness-injected-user-turns.test.ts
+++ b/src/shared/harness-injected-user-turns.test.ts
@@ -105,6 +105,18 @@ describe('isKnownHarnessInjectedUserTurnText', () => {
     expect(isKnownHarnessInjectedUserTurnText('<foo-bar@example.com> sent me this')).toBe(false)
   })
 
+  it('classifies the Kimi hook_result envelope while keeping underscore user turns', () => {
+    expect(
+      isKnownHarnessInjectedUserTurnText(
+        '<hook_result hook_event="UserPromptSubmit">{}</hook_result>'
+      )
+    ).toBe(true)
+    expect(isKnownHarnessInjectedUserTurnText('<hook_result>{}</hook_result>')).toBe(true)
+    // The underscore shape alone must not qualify: only allowlisted names do.
+    expect(isKnownHarnessInjectedUserTurnText('<user_query>fix the bug</user_query>')).toBe(false)
+    expect(isKnownHarnessInjectedUserTurnText('<my_widget>pasted</my_widget>')).toBe(false)
+  })
+
   it('does not treat unknown kebab tags as machinery', () => {
     // Only observed harness tags count — a real custom-element paste or a
     // brand-new tag we have not catalogued stays a user turn.

--- a/src/shared/harness-injected-user-turns.ts
+++ b/src/shared/harness-injected-user-turns.ts
@@ -10,7 +10,8 @@
 // `<user_query>` envelope is a genuine user turn, and misclassifying it would
 // hide the turn (drop it from transcripts, demote its session title, or leave
 // the agent visibly done after an interrupt).
-const LEADING_TAG_NAME = /^<([a-z][a-z0-9-]*)(?:[\s>]|$)/
+// Underscores included: harnesses emit both shapes (`<hook_result>`, `<system-reminder>`).
+const LEADING_TAG_NAME = /^<([a-z][a-z0-9_-]*)(?:[\s>]|$)/
 
 // Consumers must only treat tags we have observed from harnesses as machinery;
 // arbitrary kebab tags can be genuine user code.
@@ -24,6 +25,7 @@ const KNOWN_HARNESS_TAG_NAMES = new Set([
   'command-name',
   'cross-session-message',
   'fork-boilerplate',
+  'hook_result',
   'local-command-caveat',
   'local-command-stderr',
   'local-command-stdout',


### PR DESCRIPTION
## ELI5

When you type a request to Kimi, its hook sends Orca a second, robot-written message right after yours: `<hook_result hook_event="UserPromptSubmit">{}</hook_result>`. Orca already knows how to ignore robot messages like this, but it was only recognising the ones written with dashes (`<system-reminder>`), not the ones with underscores. So the robot message overwrote what you actually typed, and the branch got named after the robot message instead of your task.

## What Changed

`src/shared/harness-injected-user-turns.ts`:

- the leading-tag matcher now allows `_` as well as `-`, so `<hook_result ...>` is seen as a tag at all
- `hook_result` added to `KNOWN_HARNESS_TAG_NAMES`

Both are needed: the regex alone would not classify it, and the allowlist entry alone is unreachable because the regex never matches the name.

## Why

`resolvePrompt` in `agent-hook-listener.ts` keeps the cached prompt when `isKnownHarnessInjectedUserTurnText` returns true. That classifier's tag matcher was `/^<([a-z][a-z0-9-]*)(?:[\s>]|$)/`, which cannot match `hook_result`, so the envelope was treated as a genuine user turn and replaced the real prompt. `buildBranchNamePrompt` then received the envelope as `firstPrompt`.

I kept the allowlist approach rather than matching underscore tags generically, because the file's own comment warns that Grok wraps **real** typed prompts in `<user_query>`. Treating the underscore shape itself as machinery would misclassify those. Only the name that was actually observed is added, and there is a test asserting `<user_query>` and `<my_widget>` still count as user turns.

## Linked Issue

Fixes #14789

## Visual Proof

`N/A` - no UI or interaction change. The only visible difference is the generated branch name, which is model output and therefore not stable enough to screenshot meaningfully. The behavioural change is shown by the test below instead.

## Testing

Reproduced through the listener before fixing, using the existing Kimi test harness. A typed prompt followed by the envelope:

```
before: prompt = '<hook_result hook_event="UserPromptSubmit">{}</hook_result>'
after:  prompt = 'debug the CI config'
```

Two tests added:

- `agent-hook-listener-claude-compatible-vendors.test.ts` - the end-to-end one, next to the existing Kimi harness-injection test. Asserts the cached prompt survives the envelope.
- `harness-injected-user-turns.test.ts` - classifier level, including the `<user_query>` / `<my_widget>` non-regression.

Each half of the fix was reverted independently; both mutations fail both tests:

```
AssertionError: expected '<hook_result hook_event="UserPromptSubmit">{}</hook_result>' to be 'debug the CI config'
AssertionError: expected false to be true
```

`vitest run src/shared/` is 4772 passed, 2 failed. Both failures are pre-existing and unrelated (`automation-schedules` expects `Sundays` and gets `Sonntags` on a non-English locale; `external-automation-jobs-file` expects a different error string). Both fail identically with my change stashed. All three `typecheck` projects and `oxlint src/shared/` are clean.

Platforms: pure string classification, no platform, path, shell, or network behaviour. Tested on Linux.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Written with AI assistance (Claude Code, Opus 5). I reproduced the bug through the listener, confirmed the two pre-existing test failures are unrelated by stashing, and ran the mutation checks.

## Review

- **Security**: none. No new input is trusted; the change makes Orca trust *less* transcript content.
- **Cross-platform**: no platform-dependent code paths touched. Pure string matching.
- **Remote SSH**: `harness-injected-user-turns.ts` is in `src/shared/`, so local and SSH targets get identical classification, which is the point of it living there.
- **Mobile**: not touched.
- **Backwards compatibility**: no wire format, RPC param, or persisted shape changes. A previously-misclassified turn is now correctly dropped from prompt caching; nothing that was cached before becomes unreadable.
- **Agent/provider neutrality**: `hook_result` is added to the same observed-shapes allowlist every other harness uses, not behind a Kimi-specific branch, so any harness emitting the same envelope benefits. Grok's `<user_query>` is explicitly protected by test.
- **Performance**: unchanged. Same single regex against the same 256-char bounded head; one more entry in a `Set` lookup.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: N/A
