### PR TITLE
fix(agent-send): keep hookless agents sendable via foreground process proof

### DIFF
--- a/src/renderer/src/components/editor/ReviewNotesSendMenuContent.tsx
+++ b/src/renderer/src/components/editor/ReviewNotesSendMenuContent.tsx
@@ -65,6 +65,7 @@ export function ReviewNotesSendMenuContent({
   const terminalLayoutsByTabId = useAppStore((s) => s.terminalLayoutsByTabId)
   const ptyIdsByTabId = useAppStore(useShallow((s) => selectLivePtyIdsForWorktree(s, worktreeId)))
   const runtimePaneTitlesByTabId = useAppStore((s) => s.runtimePaneTitlesByTabId)
+  const paneForegroundAgentByPaneKey = useAppStore((s) => s.paneForegroundAgentByPaneKey)
   const agentStatusEpoch = useAppStore((s) => s.agentStatusEpoch)
   const agentRows = useWorktreeAgentRows(worktreeId)
   const now = useNow(30_000)
@@ -76,7 +77,8 @@ export function ReviewNotesSendMenuContent({
         tabsByWorktree,
         terminalLayoutsByTabId,
         ptyIdsByTabId,
-        runtimePaneTitlesByTabId
+        runtimePaneTitlesByTabId,
+        paneForegroundAgentByPaneKey
       },
       worktreeId
     )
@@ -88,6 +90,7 @@ export function ReviewNotesSendMenuContent({
     tabsByWorktree,
     terminalLayoutsByTabId,
     runtimePaneTitlesByTabId,
+    paneForegroundAgentByPaneKey,
     ptyIdsByTabId,
     worktreeId
   ])

--- a/src/renderer/src/components/sidebar/worktree-card-send-target-inputs.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-send-target-inputs.test.ts
@@ -16,7 +16,8 @@ const BASE: SendTargetInputsState = {
   tabsByWorktree: {},
   terminalLayoutsByTabId: {},
   ptyIdsByTabId: {},
-  runtimePaneTitlesByTabId: {}
+  runtimePaneTitlesByTabId: {},
+  paneForegroundAgentByPaneKey: {}
 }
 
 function makeMode(worktreeId: string): AgentSendPopoverTargetMode {

--- a/src/renderer/src/components/sidebar/worktree-card-send-target-inputs.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-send-target-inputs.ts
@@ -9,6 +9,7 @@ export type SendTargetInputsState = Pick<
   | 'terminalLayoutsByTabId'
   | 'ptyIdsByTabId'
   | 'runtimePaneTitlesByTabId'
+  | 'paneForegroundAgentByPaneKey'
 >
 
 export type SendTargetControlInputsState = Pick<
@@ -30,7 +31,8 @@ export const EMPTY_SEND_TARGET_INPUTS: RunningAgentTargetState = Object.freeze({
   tabsByWorktree: {},
   terminalLayoutsByTabId: {},
   ptyIdsByTabId: {},
-  runtimePaneTitlesByTabId: {}
+  runtimePaneTitlesByTabId: {},
+  paneForegroundAgentByPaneKey: {}
 })
 
 // Why: the picker mode and freshness epoch are irrelevant to every card except
@@ -59,7 +61,8 @@ export function selectSendTargetInputs(
     tabsByWorktree: s.tabsByWorktree,
     terminalLayoutsByTabId: s.terminalLayoutsByTabId,
     ptyIdsByTabId: s.ptyIdsByTabId,
-    runtimePaneTitlesByTabId: s.runtimePaneTitlesByTabId
+    runtimePaneTitlesByTabId: s.runtimePaneTitlesByTabId,
+    paneForegroundAgentByPaneKey: s.paneForegroundAgentByPaneKey
   }
 }
 

--- a/src/renderer/src/components/sidebar/worktree-list/listing/use-agent-send-target.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/use-agent-send-target.ts
@@ -9,6 +9,7 @@ const EMPTY_TABS_BY_WORKTREE: AppState['tabsByWorktree'] = {}
 const EMPTY_TERMINAL_LAYOUTS_BY_TAB_ID: AppState['terminalLayoutsByTabId'] = {}
 const EMPTY_PTY_IDS_BY_TAB_ID: AppState['ptyIdsByTabId'] = {}
 const EMPTY_RUNTIME_PANE_TITLES_BY_TAB_ID: AppState['runtimePaneTitlesByTabId'] = {}
+const EMPTY_PANE_FOREGROUND_AGENT_BY_PANE_KEY: AppState['paneForegroundAgentByPaneKey'] = {}
 
 // The agent send picker forces its target workspace visible, but only while a running
 // agent there can actually receive the message.
@@ -33,6 +34,11 @@ export function useAgentSendTargetWorktreeId(): string | null {
   const agentTargetRuntimePaneTitlesByTabId = useAppStore((s) =>
     agentSendPopoverTargetMode ? s.runtimePaneTitlesByTabId : EMPTY_RUNTIME_PANE_TITLES_BY_TAB_ID
   )
+  const agentTargetPaneForegroundAgentByPaneKey = useAppStore((s) =>
+    agentSendPopoverTargetMode
+      ? s.paneForegroundAgentByPaneKey
+      : EMPTY_PANE_FOREGROUND_AGENT_BY_PANE_KEY
+  )
   return useMemo(() => {
     void agentTargetStatusEpoch
     if (!agentSendPopoverTargetMode) {
@@ -44,7 +50,8 @@ export function useAgentSendTargetWorktreeId(): string | null {
         tabsByWorktree: agentTargetTabsByWorktree,
         terminalLayoutsByTabId: agentTargetTerminalLayoutsByTabId,
         ptyIdsByTabId: agentTargetPtyIdsByTabId,
-        runtimePaneTitlesByTabId: agentTargetRuntimePaneTitlesByTabId
+        runtimePaneTitlesByTabId: agentTargetRuntimePaneTitlesByTabId,
+        paneForegroundAgentByPaneKey: agentTargetPaneForegroundAgentByPaneKey
       },
       agentSendPopoverTargetMode.worktreeId
     )
@@ -59,6 +66,7 @@ export function useAgentSendTargetWorktreeId(): string | null {
     agentTargetTabsByWorktree,
     agentTargetTerminalLayoutsByTabId,
     agentTargetPtyIdsByTabId,
-    agentTargetRuntimePaneTitlesByTabId
+    agentTargetRuntimePaneTitlesByTabId,
+    agentTargetPaneForegroundAgentByPaneKey
   ])
 }

--- a/src/renderer/src/lib/notes-send-agent-targets.ts
+++ b/src/renderer/src/lib/notes-send-agent-targets.ts
@@ -3,6 +3,7 @@ import type { AppState } from '@/store/types'
 import { isTerminalLeafId, makePaneKey } from '../../../shared/stable-pane-id'
 import { resolveTerminalTitleAgentType } from '../../../shared/terminal-title-agent-type'
 import type { TerminalTab } from '../../../shared/terminal-tab-types'
+import type { TuiAgent } from '../../../shared/tui-agent'
 import { detectAgentSendTitleStatus } from './agent-send-title-status'
 import {
   resolveRuntimePaneTitleLeafResolution,
@@ -98,6 +99,19 @@ export function deriveNotesSendAgentTargets(
   return targets
 }
 
+// Why: process-table identity outlives both hooks and titles; shellForeground
+// proves the agent already exited, so it is the one disqualifying signal.
+function resolveForegroundAgentProcess(
+  state: NotesSendAgentTargetState,
+  paneKey: string
+): TuiAgent | null {
+  const foreground = state.paneForegroundAgentByPaneKey?.[paneKey]
+  if (!foreground?.agent || foreground.shellForeground === true) {
+    return null
+  }
+  return foreground.agent
+}
+
 function resolveNotesTargetAgentType(
   entryAgentType: AgentType | null | undefined,
   launchAgent: AgentType | null | undefined
@@ -125,17 +139,28 @@ function deriveTitleHintAgentTarget(
 
   const paneTitles = state.runtimePaneTitlesByTabId[tab.id]
   const paneTitleResolution = resolveRuntimePaneTitleLeafResolution(layout, paneTitles, leafId)
+  const paneKey = makePaneKey(tab.id, leafId)
   const titleEvidence = detectTitleHintPaneEvidence(paneTitleResolution, tab.title)
   if (!titleEvidence) {
-    // Why: launch metadata predates TUI identity; require a matching current title
-    // before listing either launched or manually started panes.
-    return null
+    // Why: a hookless, title-silent agent is still provable by the pane's
+    // foreground process, so fall back to it before dropping the pane.
+    const foregroundAgent = resolveForegroundAgentProcess(state, paneKey)
+    return foregroundAgent
+      ? {
+          paneKey,
+          tabId: tab.id,
+          leafId,
+          agentType: tab.launchAgent ?? foregroundAgent,
+          tabTitle: tab.title,
+          status: 'eligible'
+        }
+      : null
   }
   const disabledReason =
     titleEvidence.status === 'permission' ? 'Agent needs permission' : undefined
 
   return {
-    paneKey: makePaneKey(tab.id, leafId),
+    paneKey,
     tabId: tab.id,
     leafId,
     agentType: tab.launchAgent ?? resolveTerminalTitleAgentType(titleEvidence.title),

--- a/src/renderer/src/lib/running-agent-targets-foreground-proof.test.ts
+++ b/src/renderer/src/lib/running-agent-targets-foreground-proof.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AGENT_STATUS_STALE_AFTER_MS,
+  type AgentStatusEntry
+} from '../../../shared/agent-status-types'
+import type { TerminalLayoutSnapshot, TerminalTab } from '../../../shared/terminal-tab-types'
+import { makePaneKey } from '../../../shared/stable-pane-id'
+import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
+import {
+  deriveRunningAgentSendTargets,
+  type RunningAgentTargetState
+} from './running-agent-targets'
+import {
+  deriveNotesSendAgentTargets,
+  type NotesSendAgentTargetState
+} from './notes-send-agent-targets'
+
+const WORKTREE_ID = 'wt-1'
+const TAB_ID = 'tab-1'
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+const PTY_ID = 'pty-1'
+const PANE_KEY = makePaneKey(TAB_ID, LEAF_ID)
+const NOW = 90 * 60 * 1000
+const STALE_UPDATED_AT = NOW - AGENT_STATUS_STALE_AFTER_MS - 1
+
+function tab(title: string): TerminalTab {
+  return {
+    id: TAB_ID,
+    worktreeId: WORKTREE_ID,
+    ptyId: PTY_ID,
+    title,
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1
+  }
+}
+
+function layout(): TerminalLayoutSnapshot {
+  return {
+    root: { type: 'leaf', leafId: LEAF_ID },
+    activeLeafId: LEAF_ID,
+    expandedLeafId: null,
+    ptyIdsByLeafId: { [LEAF_ID]: PTY_ID }
+  }
+}
+
+function staleEntry(): AgentStatusEntry {
+  return {
+    paneKey: PANE_KEY,
+    state: 'done',
+    prompt: '',
+    updatedAt: STALE_UPDATED_AT,
+    stateStartedAt: STALE_UPDATED_AT,
+    agentType: 'codex',
+    stateHistory: []
+  }
+}
+
+function baseState(args: {
+  tabTitle: string
+  agentStatusByPaneKey?: Record<string, AgentStatusEntry>
+  foreground?: PaneForegroundAgentEntry
+}): NotesSendAgentTargetState {
+  return {
+    agentStatusByPaneKey: args.agentStatusByPaneKey ?? {},
+    tabsByWorktree: { [WORKTREE_ID]: [tab(args.tabTitle)] },
+    terminalLayoutsByTabId: { [TAB_ID]: layout() },
+    ptyIdsByTabId: { [TAB_ID]: [PTY_ID] },
+    runtimePaneTitlesByTabId: {},
+    paneForegroundAgentByPaneKey: args.foreground ? { [PANE_KEY]: args.foreground } : {}
+  } as NotesSendAgentTargetState
+}
+
+describe('running agent send targets: live foreground process proof', () => {
+  it('keeps a stale hook row sendable when the pane foreground still runs the agent', () => {
+    const targets = deriveRunningAgentSendTargets(
+      baseState({
+        tabTitle: 'zsh',
+        agentStatusByPaneKey: { [PANE_KEY]: staleEntry() },
+        foreground: { agent: 'codex', shellForeground: false }
+      }) as RunningAgentTargetState,
+      WORKTREE_ID,
+      NOW
+    )
+
+    expect(targets).toMatchObject([{ paneKey: PANE_KEY, ptyId: PTY_ID, status: 'eligible' }])
+    expect(targets[0]).not.toHaveProperty('disabledReason')
+  })
+
+  it('still disables a stale hook row once the foreground is proven back at the shell', () => {
+    const targets = deriveRunningAgentSendTargets(
+      baseState({
+        tabTitle: 'zsh',
+        agentStatusByPaneKey: { [PANE_KEY]: staleEntry() },
+        foreground: { agent: null, shellForeground: true }
+      }) as RunningAgentTargetState,
+      WORKTREE_ID,
+      NOW
+    )
+
+    expect(targets).toMatchObject([
+      { paneKey: PANE_KEY, status: 'disabled', disabledReason: 'Agent status is stale' }
+    ])
+  })
+
+  it('disables a stale hook row when no foreground evidence exists at all', () => {
+    const targets = deriveRunningAgentSendTargets(
+      baseState({
+        tabTitle: 'zsh',
+        agentStatusByPaneKey: { [PANE_KEY]: staleEntry() }
+      }) as RunningAgentTargetState,
+      WORKTREE_ID,
+      NOW
+    )
+
+    expect(targets).toMatchObject([
+      { paneKey: PANE_KEY, status: 'disabled', disabledReason: 'Agent status is stale' }
+    ])
+  })
+})
+
+describe('notes send agent targets: live foreground process proof', () => {
+  it('lists a hookless, title-silent pane whose foreground process is a known agent', () => {
+    const targets = deriveNotesSendAgentTargets(
+      baseState({
+        tabTitle: 'zsh',
+        foreground: { agent: 'claude', shellForeground: false }
+      }),
+      WORKTREE_ID,
+      NOW
+    )
+
+    expect(targets).toMatchObject([
+      { paneKey: PANE_KEY, tabId: TAB_ID, leafId: LEAF_ID, agentType: 'claude', status: 'eligible' }
+    ])
+  })
+
+  it('omits a title-silent pane whose foreground is back at the shell', () => {
+    const targets = deriveNotesSendAgentTargets(
+      baseState({
+        tabTitle: 'zsh',
+        foreground: { agent: 'claude', shellForeground: true }
+      }),
+      WORKTREE_ID,
+      NOW
+    )
+
+    expect(targets).toEqual([])
+  })
+})

--- a/src/renderer/src/lib/running-agent-targets.ts
+++ b/src/renderer/src/lib/running-agent-targets.ts
@@ -10,7 +10,7 @@ export type RunningAgentTargetState = Pick<
   AppState,
   'agentStatusByPaneKey' | 'tabsByWorktree' | 'terminalLayoutsByTabId' | 'ptyIdsByTabId'
 > &
-  Partial<Pick<AppState, 'runtimePaneTitlesByTabId'>>
+  Partial<Pick<AppState, 'runtimePaneTitlesByTabId' | 'paneForegroundAgentByPaneKey'>>
 
 export type RunningAgentSendTarget = {
   paneKey: string
@@ -76,7 +76,7 @@ export function deriveRunningAgentSendTargets(
     } else if (decision.hookState === null) {
       if (liveTitleStatus === 'permission') {
         disabledReason = 'Agent needs permission'
-      } else if (liveTitleStatus === null) {
+      } else if (liveTitleStatus === null && !hasLiveForegroundAgentProof(state, paneKey, ptyId)) {
         disabledReason = 'Agent status is stale'
       }
     } else if (!ptyId) {
@@ -100,6 +100,21 @@ export function deriveRunningAgentSendTargets(
   }
 
   return targets
+}
+
+// Why: a long-running agent stops emitting hooks and can hold a title the send
+// detector rejects, so the pane's process-table identity is the remaining proof
+// that the agent is still there (issue #14798: 30-minute hook staleness).
+function hasLiveForegroundAgentProof(
+  state: RunningAgentTargetState,
+  paneKey: string,
+  ptyId: string | null
+): boolean {
+  if (!ptyId) {
+    return false
+  }
+  const foreground = state.paneForegroundAgentByPaneKey?.[paneKey]
+  return foreground?.agent != null && foreground.shellForeground !== true
 }
 
 function detectLiveAgentPaneStatus(


### PR DESCRIPTION
## ELI5

Orca decides "is there an agent in this pane I can send notes to?" by looking at the messages the agent sends it (hooks) and at the pane's title. An agent that has been running a long time stops sending hooks, and its title may not look like anything Orca recognises. After 30 minutes both signals go quiet, so Orca concludes the agent is gone and greys it out, even though the process is still sitting right there. This adds a third way to tell: ask the pane what program is actually running in it.

## What Changed

Two derivation functions now fall back to the pane's foreground process when the other evidence is silent:

- `running-agent-targets.ts` - a stale hook row is no longer disabled if the foreground process is still a known agent
- `notes-send-agent-targets.ts` - a pane with no recognizable title is no longer dropped for the same reason

`paneForegroundAgentByPaneKey` is existing state the pane tracker already publishes at OSC 133 boundaries. Nothing new is collected; it is threaded through the three selectors that feed these derivations.

`shellForeground === true` stays disqualifying, since that is positive evidence the agent exited and the shell has the terminal back.

## Why

`AGENT_STATUS_STALE_AFTER_MS` exists so a dead pane does not linger as a send target forever, which is right. The problem is that hooks and titles are both *agent-cooperative* signals: a well-behaved agent that simply is not talking looks identical to one that died. The process table is not cooperative, so it distinguishes the two.

I used the existing slice rather than lowering or removing the staleness cutoff, because the cutoff is still correct for the case it was written for.

## Linked Issue

Fixes #14798

## Visual Proof

`N/A` - no rendering, styling, or layout change. The affected code is two pure derivation functions plus selector wiring; the menu renders exactly as before, with entries no longer incorrectly greyed out or omitted.

## Testing

`running-agent-targets-foreground-proof.test.ts`, 5 cases covering both derivations, the shell-foreground exclusion, and the no-pty case.

Each fixed expression was reverted independently. Both fail as assertions, not build errors:

```
FAIL > keeps a stale hook row sendable when the pane foreground still runs the agent
AssertionError: expected [ { ...(8) } ] to match object [ { ...(3) } ]
-     "status": "eligible",
+     "status": "disabled",

FAIL > lists a hookless, title-silent pane whose foreground process is a known agent
AssertionError: expected [] to match object [ { ...(5) } ]
```

`vitest run` over `src/renderer/src/lib/` and `src/renderer/src/components/sidebar/` is 6172 passed, and `src/renderer/src/components/editor/` is 1131 passed. `pnpm lint`, `pnpm typecheck` and `pnpm build` all exit 0. Tested on Linux.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Scoped out, deliberately

The issue names a second cause, the current-worktree-only filter. I did not fix it here. `worktreeId` is a required parameter threaded through every derivation and selector plus the `agentSendPopoverTargetMode` store shape, and the "Other worktrees" grouping it asks for is a rendering concern needing visual review. It is a separate PR, and I would rather ship the half that is provable than bundle it with one that is not.

## Known limitation, worth naming

`paneForegroundAgentByPaneKey` is only populated for local native panes. `isForegroundTrackingAllowed` (`pty-connection.ts:2113`) excludes remote-runtime and SSH PTYs, and on Windows restricts to native ConPTY. So SSH and WSL panes still go stale at 30 minutes exactly as before. This fix does not regress them, but it does not help them either, and a complete fix for those needs foreground tracking to exist there first.

## AI Disclosure

Written with AI assistance (Claude Code, Opus 5). I verified the tracking limitation above by reading `isForegroundTrackingAllowed` directly, and ran both mutation checks myself.

## Review

- **Security**: none. Reads existing renderer state; no new IPC, no new input trusted.
- **Cross-platform**: no platform branches added. The Windows/WSL restriction lives in the existing tracker gate and is documented above rather than worked around.
- **Remote SSH**: behaviour unchanged, see the limitation section. The fallback simply never fires there because the slice is empty.
- **Mobile**: not touched.
- **Folder workspaces**: unaffected; the derivations key off panes and tabs, not on a worktree being a git worktree.
- **Backwards compatibility**: no wire format, RPC param, or persisted shape changes. Purely a renderer-side derivation.
- **Agent/provider neutrality**: the check is `agent != null`, any agent the tracker recognises qualifies. No per-agent branching.
- **Performance**: one extra store subscription per menu, using the existing `EMPTY_*` stable-reference pattern so a closed popover does not re-render. The added work per pane is one map lookup.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: N/A
