### PR TITLE
fix(editor): match external file changes across Windows path spellings

### DIFF
--- a/src/renderer/src/components/editor/editor-autosave.ts
+++ b/src/renderer/src/components/editor/editor-autosave.ts
@@ -1,6 +1,10 @@
 import { joinPath } from '@/lib/path'
 import type { OpenFile } from '@/store/slices/editor'
-import { areLocalWindowsWslPathAliases } from '../../../../shared/cross-platform-path'
+import {
+  areLocalWindowsWslPathAliases,
+  isCaseInsensitiveRuntimeRoot,
+  normalizeRuntimePathForComparison
+} from '../../../../shared/cross-platform-path'
 import { isLocalWindowsDesktopClient } from '@/lib/desktop-window-chrome'
 import {
   DEFAULT_EDITOR_AUTO_SAVE_DELAY_MS,
@@ -134,6 +138,11 @@ export function getOpenFilesForExternalFileChange(
     return target.indexedOpenFiles.matches(openFiles)
   }
   const absolutePath = joinPath(target.worktreePath, target.relativePath)
+  // Why: a drive/UNC root folds case and separators, so the same file can be spelled two ways; case-sensitive roots must stay byte-exact.
+  const foldsPathSpelling = isCaseInsensitiveRuntimeRoot(target.worktreePath)
+  const comparisonPath = foldsPathSpelling
+    ? normalizeRuntimePathForComparison(absolutePath)
+    : absolutePath
   const hasRuntimeOwnerFilter = Object.hasOwn(target, 'runtimeEnvironmentId')
   const targetRuntimeOwner = target.runtimeEnvironmentId?.trim() || null
   return openFiles.filter((file) => {
@@ -148,7 +157,9 @@ export function getOpenFilesForExternalFileChange(
     }
     if (file.mode === 'edit' || file.mode === 'markdown-preview') {
       return (
-        file.filePath === absolutePath ||
+        (foldsPathSpelling
+          ? normalizeRuntimePathForComparison(file.filePath) === comparisonPath
+          : file.filePath === comparisonPath) ||
         (target.allowLocalWindowsWslAliases === true &&
           isLocalWindowsDesktopClient() &&
           areLocalWindowsWslPathAliases(file.filePath, absolutePath))

--- a/src/renderer/src/components/editor/editor-external-watch-path-index.ts
+++ b/src/renderer/src/components/editor/editor-external-watch-path-index.ts
@@ -4,6 +4,7 @@ import type { OpenFile } from '@/store/slices/editor'
 import type { FsChangedPayload } from '../../../../shared/filesystem-entry-types'
 import {
   getLocalWindowsWslPathIdentity,
+  isCaseInsensitiveRuntimeRoot,
   normalizeRuntimePathForComparison,
   type LocalWindowsWslPathIdentity
 } from '../../../../shared/cross-platform-path'
@@ -112,11 +113,15 @@ class IndexedOpenFileLookup {
   readonly indexedOpenFiles = new Map<string, IndexedOpenFile>()
   readonly hasCombinedDiffConsumer: boolean
 
+  // Why: a drive/UNC root folds case and separators, so a tab opened as `C:\r\a.ts` must still match a `c:/r/a.ts` watcher event; case-sensitive roots (WSL, POSIX, SSH) keep literal keys.
+  private readonly foldsDirectKeys: boolean
+
   constructor(
     openFiles: OpenFile[],
     scope: WatchScope,
     private readonly allowAliases: boolean
   ) {
+    this.foldsDirectKeys = isCaseInsensitiveRuntimeRoot(scope.worktreePath)
     let hasCombinedDiffConsumer = false
     for (const [index, file] of openFiles.entries()) {
       if (
@@ -148,7 +153,7 @@ class IndexedOpenFileLookup {
       const identity = pathIdentity(file.filePath, allowAliases)
       const indexedFile = { file, index, identity }
       this.indexedOpenFiles.set(file.id, indexedFile)
-      addToListMap(this.directEditors, file.filePath, indexedFile)
+      addToListMap(this.directEditors, this.directKey(file.filePath, identity), indexedFile)
       if (allowAliases) {
         addToListMap(this.aliasEditors, identity.aliasComparisonPath, indexedFile)
         if (identity.isWslUnc) {
@@ -159,6 +164,10 @@ class IndexedOpenFileLookup {
     this.hasCombinedDiffConsumer = hasCombinedDiffConsumer
   }
 
+  private directKey(rawPath: string, identity: LocalWindowsWslPathIdentity): string {
+    return this.foldsDirectKeys ? identity.normalizedPath : rawPath
+  }
+
   matchingOpenFiles(change: IndexedExternalWatchChange): OpenFile[] {
     const aliases = !this.allowAliases
       ? []
@@ -166,7 +175,7 @@ class IndexedOpenFileLookup {
         ? (this.aliasEditors.get(change.identity.aliasComparisonPath) ?? [])
         : (this.wslAliasEditors.get(change.identity.aliasComparisonPath) ?? [])
     return collectMatchingFiles(
-      this.directEditors.get(change.absolutePath) ?? [],
+      this.directEditors.get(this.directKey(change.absolutePath, change.identity)) ?? [],
       aliases,
       this.diffsByRelativePath.get(change.relativePath) ?? []
     )

--- a/src/renderer/src/components/editor/editor-external-watch-windows-path-spelling.test.ts
+++ b/src/renderer/src/components/editor/editor-external-watch-windows-path-spelling.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import { win32 as winPath } from 'node:path'
+import type { OpenFile } from '@/store/slices/editor'
+import type { FsChangedPayload } from '../../../../shared/filesystem-entry-types'
+import { indexEditorExternalWatchBatchPaths } from './editor-external-watch-path-index'
+import { getOpenFilesForExternalFileChange } from './editor-autosave'
+
+const WORKTREE_ID = 'wt-windows'
+// The watch root as the store holds it, and the same root as a Windows tool spells it back.
+const STORE_ROOT = 'C:/Users/dev/repo'
+const AGENT_ROOT = winPath.join('c:\\Users\\dev\\repo')
+
+function editorTab(filePath: string): OpenFile {
+  return {
+    id: 'tab-1',
+    filePath,
+    relativePath: 'src/index.ts',
+    worktreeId: WORKTREE_ID,
+    mode: 'edit',
+    isDirty: false,
+    content: '',
+    language: 'typescript'
+  } as unknown as OpenFile
+}
+
+function updatePayload(absolutePath: string): FsChangedPayload {
+  return {
+    worktreePath: STORE_ROOT,
+    events: [{ kind: 'update', absolutePath, isDirectory: false }]
+  } as unknown as FsChangedPayload
+}
+
+describe('external watch matching across Windows path spellings', () => {
+  it('matches an open tab whose filePath differs only by separator and drive case', () => {
+    const tab = editorTab(winPath.join(AGENT_ROOT, 'src', 'index.ts'))
+    const index = indexEditorExternalWatchBatchPaths(
+      updatePayload(winPath.join(AGENT_ROOT, 'src', 'index.ts')),
+      [tab],
+      { worktreeId: WORKTREE_ID, worktreePath: STORE_ROOT, runtimeEnvironmentId: null }
+    )
+
+    expect(index.changes).toHaveLength(1)
+    expect(index.matchingOpenFiles(index.changes[0])).toEqual([tab])
+  })
+
+  it('matches without the batch index, on the notification fallback path', () => {
+    const tab = editorTab(winPath.join(AGENT_ROOT, 'src', 'index.ts'))
+
+    expect(
+      getOpenFilesForExternalFileChange([tab], {
+        worktreeId: WORKTREE_ID,
+        worktreePath: STORE_ROOT,
+        relativePath: 'src/index.ts',
+        runtimeEnvironmentId: null
+      })
+    ).toEqual([tab])
+  })
+
+  it('still rejects a sibling file under the same root', () => {
+    const tab = editorTab(winPath.join(AGENT_ROOT, 'src', 'index.ts'))
+    const index = indexEditorExternalWatchBatchPaths(
+      updatePayload(winPath.join(AGENT_ROOT, 'src', 'other.ts')),
+      [tab],
+      { worktreeId: WORKTREE_ID, worktreePath: STORE_ROOT, runtimeEnvironmentId: null }
+    )
+
+    expect(index.matchingOpenFiles(index.changes[0])).toEqual([])
+  })
+
+  it('does not fold case for a POSIX root, where names are distinct files', () => {
+    const posixRoot = '/home/dev/repo'
+    const tab = {
+      ...editorTab('/home/dev/repo/src/Index.ts'),
+      relativePath: 'src/Index.ts'
+    }
+    const index = indexEditorExternalWatchBatchPaths(
+      {
+        worktreePath: posixRoot,
+        events: [{ kind: 'update', absolutePath: '/home/dev/repo/src/index.ts', isDirectory: false }]
+      } as unknown as FsChangedPayload,
+      [tab],
+      { worktreeId: WORKTREE_ID, worktreePath: posixRoot, runtimeEnvironmentId: null }
+    )
+
+    expect(index.matchingOpenFiles(index.changes[0])).toEqual([])
+  })
+})


### PR DESCRIPTION
## ELI5

On Windows the same file has several equally valid spellings: `C:\repo\src\a.ts` and `c:/repo/src/a.ts` are the same file. Orca filed your open tabs under one spelling and then looked them up under the other, so when an agent wrote to the file, Orca could not find the tab it belonged to. No reload, no amber banner, nothing.

## What Changed

Two lookups now compare folded path identities instead of raw strings:

- `editor-external-watch-path-index.ts` - `directEditors` is keyed and read through the same `directKey()`, so insert and lookup can no longer disagree
- `editor-autosave.ts` - the same fix on the non-indexed notification fallback

Both are gated on `isCaseInsensitiveRuntimeRoot(worktreePath)`.

## Why

Every other lookup in the index file (`createOrUpdatePaths`, `deleteLookup`, the alias maps) already used the folded identity. These two were the outliers, which is why the bug survived: the surrounding code looks like it handles this.

The gate is not decoration. Folding unconditionally breaks the existing test `keeps aliases literal for SSH, runtimes, and POSIX scopes`, because a WSL UNC tab then wrongly matches a backslash-spelled event:

```
AssertionError: expected [ { relativePath: 'file.ts', ...(7) } ] to deeply equal []
+     "filePath": "//wsl.localhost/Ubuntu/workspace/repo/file.ts",
```

WSL, SSH and POSIX roots are case-sensitive filesystems where `Index.ts` and `index.ts` are genuinely different files, so they must stay byte-exact.

## Correcting the issue report

The issue names `getExternalFileChangeRelativePath` / `relativePathInsideRoot` as the culprit. That is not the bug. I checked it directly:

```
relativePathInsideRoot('C:\\repo', 'c:/repo/src/a.ts')  ->  'src/a.ts'
```

It already normalizes NFC, separators, drive-letter case and WSL aliases. `findTarget` in `useEditorExternalWatch.ts` already wraps both sides in `normalizeRuntimePathForComparison` too. The conclusion in the report was right, the location was not.

## Linked Issue

Fixes #14801

## Visual Proof

`N/A` - no UI change. This restores the existing reload/banner behaviour on a path where it silently never fired; nothing about how it renders changes.

## Testing

`editor-external-watch-windows-path-spelling.test.ts`, 4 cases using `node:path`'s `win32` so they run on Linux: the indexed match, the fallback match, a sibling file that must still not match, and a POSIX root that must not fold.

Each fix reverted independently, both fail as assertions rather than build errors:

```
FAIL > matches an open tab whose filePath differs only by separator and drive case
AssertionError: expected [] to deeply equal [ { id: 'tab-1', ...(7) } ]

FAIL > matches without the batch index, on the notification fallback path
AssertionError: expected [] to deeply equal [ { id: 'tab-1', ...(7) } ]
```

`vitest run` over `src/renderer/src/components/editor/` and `src/renderer/src/hooks/` is 1862 passed across 269 files. `pnpm lint`, `pnpm typecheck` and `pnpm build` all exit 0. Tested on Linux.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Two things I could not settle from here

I am on Linux, so I want to be straight about the limits of this.

First, I could not observe on real Windows *which* spelling reaches `file.filePath` versus `worktreePath` in practice. Open-file call sites take paths from the Explorer tree, QuickOpen, and terminal link routing, and I did not trace each to its origin. The fix makes the comparison spelling-agnostic either way, so it is correct regardless, but I cannot claim from static reading that this is definitely the reporter's exact repro.

Second, the issue separately mentions a parcel-watcher crash fuse silently disabling watching. That is untouched here. If that fuse is what fired for the reporter, this will not help them, and it would need their main-process logs to tell the two apart.

## AI Disclosure

Written with AI assistance (Claude Code, Opus 5). I verified the reporter's stated cause was wrong by running `relativePathInsideRoot` myself, confirmed the case-sensitivity gate is load-bearing by reverting it against the full editor suite, and ran both mutation checks.

## Review

- **Security**: none. Path comparison only; no new input trusted, no filesystem access added.
- **Cross-platform**: this *is* the cross-platform fix. macOS and Windows roots fold; WSL, SSH and POSIX roots stay literal, enforced by the gate and covered by tests on both sides of it.
- **Remote SSH**: preserved deliberately. SSH scopes are case-sensitive and keep byte-exact keys, verified by the existing alias test.
- **Mobile**: not touched.
- **Folder workspaces**: unaffected; comparison is on paths, not on a workspace being a git worktree.
- **Backwards compatibility**: no wire, RPC, or persisted shape change. Renderer-local matching only.
- **Agent/provider neutrality**: nothing agent-specific; any external writer benefits.
- **Performance**: one `normalizeRuntimePathForComparison` per open editor at index build, and one per change at lookup. The identity was already being computed for the alias maps, so this reuses existing work rather than adding a pass.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: N/A
