### PR TITLE
feat(crash-reporting): capture Crashpad minidumps and name the failing CHECK

### DIFF
--- a/src/main/crash-reporting/crash-report-store.test.ts
+++ b/src/main/crash-reporting/crash-report-store.test.ts
@@ -215,4 +215,51 @@ describe('CrashReportStore', () => {
     const entries = await fs.readdir(path.dirname(filePath))
     expect(entries.filter((entry) => entry.endsWith('.tmp'))).toEqual([])
   })
+
+  describe('attachDetails', () => {
+    it('merges late minidump details without dropping the originals', async () => {
+      const { store } = await createStore()
+      const report = await store.record(input())
+
+      const updated = await store.attachDetails(report.id, {
+        minidumpStatus: 'captured',
+        minidumpCheckFile: 'render_frame_impl.cc'
+      })
+
+      expect(updated?.details).toMatchObject({
+        code: 5,
+        minidumpStatus: 'captured',
+        minidumpCheckFile: 'render_frame_impl.cc'
+      })
+      expect((await store.getById(report.id))?.details.minidumpCheckFile).toBe(
+        'render_frame_impl.cc'
+      )
+    })
+
+    it('sanitizes attached details the same way recorded ones are', async () => {
+      const { store } = await createStore()
+      const report = await store.record(input())
+
+      const updated = await store.attachDetails(report.id, {
+        minidumpPath: '/Users/alice/Library/Application Support/Orca/reports/abc.dmp'
+      })
+
+      expect(updated?.details.minidumpPath).toBe('[redacted-path]')
+    })
+
+    it('leaves the report status untouched so the crash prompt still fires', async () => {
+      const { store } = await createStore()
+      const report = await store.record(input())
+
+      await store.attachDetails(report.id, { minidumpStatus: 'absent' })
+
+      expect((await store.getLatestPending())?.id).toBe(report.id)
+    })
+
+    it('returns null for a report that has already been evicted', async () => {
+      const { store } = await createStore()
+
+      expect(await store.attachDetails('missing-id', { minidumpStatus: 'absent' })).toBeNull()
+    })
+  })
 })

--- a/src/main/crash-reporting/crash-report-store.ts
+++ b/src/main/crash-reporting/crash-report-store.ts
@@ -105,6 +105,31 @@ export class CrashReportStore {
     })
   }
 
+  /**
+   * Merges late-arriving details into an existing report. Crashpad finishes
+   * writing the minidump after the process-gone event that created the record,
+   * so the signature can only be folded in afterwards.
+   */
+  async attachDetails(
+    id: string,
+    extraDetails: Record<string, unknown>
+  ): Promise<CrashReportRecord | null> {
+    return this.withWrite(async (reports) => {
+      let result: CrashReportRecord | null = null
+      const nextReports = reports.map((report) => {
+        if (report.id !== id) {
+          return report
+        }
+        result = {
+          ...report,
+          details: { ...report.details, ...sanitizeCrashReportDetails(extraDetails) }
+        }
+        return result
+      })
+      return { reports: nextReports, result }
+    })
+  }
+
   async getLatestPending(): Promise<CrashReportRecord | null> {
     const reports = await this.readReports()
     return reports.find((report) => report.status === 'pending') ?? null

--- a/src/main/crash-reporting/crashpad-capture.test.ts
+++ b/src/main/crash-reporting/crashpad-capture.test.ts
@@ -1,0 +1,176 @@
+import { mkdtemp, mkdir, rm, utimes, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: { getPath: () => '/unused-in-tests' },
+  crashReporter: { start: vi.fn() }
+}))
+
+import {
+  _setCrashpadCaptureStateForTest,
+  captureMinidumpSignature,
+  waitForCrashMinidump
+} from './crashpad-capture'
+
+let dumpDir: string
+
+/** Minimal but valid minidump header with a zero-stream directory. */
+function emptyDump(): Buffer {
+  const buf = Buffer.alloc(32)
+  buf.writeUInt32LE(0x504d444d, 0)
+  buf.writeUInt32LE(0xa793, 4)
+  buf.writeUInt32LE(0, 8)
+  buf.writeUInt32LE(32, 12)
+  return buf
+}
+
+async function writeDump(relativePath: string, mtimeMs: number, contents = emptyDump()) {
+  const filePath = path.join(dumpDir, relativePath)
+  await mkdir(path.dirname(filePath), { recursive: true })
+  await writeFile(filePath, contents)
+  const seconds = mtimeMs / 1000
+  await utimes(filePath, seconds, seconds)
+  return filePath
+}
+
+const CRASHED_AT = 1_700_000_000_000
+
+beforeEach(async () => {
+  dumpDir = await mkdtemp(path.join(os.tmpdir(), 'orca-crashpad-'))
+  _setCrashpadCaptureStateForTest({ dumpDirectory: dumpDir, started: true })
+})
+
+afterEach(async () => {
+  _setCrashpadCaptureStateForTest(null)
+  await rm(dumpDir, { recursive: true, force: true })
+})
+
+describe('waitForCrashMinidump', () => {
+  it('finds a dump in the nested reports directory Crashpad writes to', async () => {
+    const expected = await writeDump(path.join('reports', 'abc.dmp'), CRASHED_AT + 100)
+
+    const dump = await waitForCrashMinidump(CRASHED_AT, { now: () => CRASHED_AT })
+
+    expect(dump?.filePath).toBe(expected)
+  })
+
+  it('picks the newest dump when several exist', async () => {
+    await writeDump(path.join('reports', 'old.dmp'), CRASHED_AT - 1_000)
+    const newest = await writeDump(path.join('reports', 'new.dmp'), CRASHED_AT + 500)
+
+    const dump = await waitForCrashMinidump(CRASHED_AT, { now: () => CRASHED_AT })
+
+    expect(dump?.filePath).toBe(newest)
+  })
+
+  it('ignores dumps that predate the crash by more than the recency window', async () => {
+    await writeDump(path.join('reports', 'stale.dmp'), CRASHED_AT - 120_000)
+
+    const dump = await waitForCrashMinidump(CRASHED_AT, {
+      timeoutMs: 0,
+      now: () => CRASHED_AT
+    })
+
+    expect(dump).toBeNull()
+  })
+
+  it('accepts a dump written just before the crash was observed', async () => {
+    // Crashpad writes from the handler process, so the dump can land first.
+    const expected = await writeDump(path.join('reports', 'race.dmp'), CRASHED_AT - 200)
+
+    const dump = await waitForCrashMinidump(CRASHED_AT, { now: () => CRASHED_AT })
+
+    expect(dump?.filePath).toBe(expected)
+  })
+
+  it('polls until the handler finishes writing, then returns the dump', async () => {
+    let clock = CRASHED_AT
+    let written = false
+    const sleep = async (ms: number) => {
+      clock += ms
+      if (!written) {
+        await writeDump(path.join('reports', 'late.dmp'), CRASHED_AT + 300)
+        written = true
+      }
+    }
+
+    const dump = await waitForCrashMinidump(CRASHED_AT, {
+      timeoutMs: 8_000,
+      now: () => clock,
+      sleep
+    })
+
+    expect(dump?.filePath).toBe(path.join(dumpDir, 'reports', 'late.dmp'))
+  })
+
+  it('gives up at the deadline instead of polling forever', async () => {
+    let clock = CRASHED_AT
+    const sleep = async (ms: number) => {
+      clock += ms
+    }
+
+    const dump = await waitForCrashMinidump(CRASHED_AT, {
+      timeoutMs: 1_000,
+      now: () => clock,
+      sleep
+    })
+
+    expect(dump).toBeNull()
+    expect(clock).toBeLessThanOrEqual(CRASHED_AT + 1_250)
+  })
+
+  it('ignores non-dump files in the directory', async () => {
+    await writeDump(path.join('reports', 'settings.dat'), CRASHED_AT + 100)
+
+    const dump = await waitForCrashMinidump(CRASHED_AT, { timeoutMs: 0, now: () => CRASHED_AT })
+
+    expect(dump).toBeNull()
+  })
+
+  it('returns null when capture never started', async () => {
+    _setCrashpadCaptureStateForTest(null)
+
+    expect(await waitForCrashMinidump(CRASHED_AT)).toBeNull()
+  })
+
+  it('returns null when the dump directory does not exist', async () => {
+    _setCrashpadCaptureStateForTest({
+      dumpDirectory: path.join(dumpDir, 'missing'),
+      started: true
+    })
+
+    const dump = await waitForCrashMinidump(CRASHED_AT, { timeoutMs: 0, now: () => CRASHED_AT })
+
+    expect(dump).toBeNull()
+  })
+})
+
+describe('captureMinidumpSignature', () => {
+  it('returns the parsed signature for the paired dump', async () => {
+    await writeDump(path.join('reports', 'crash.dmp'), CRASHED_AT + 100)
+
+    const captured = await captureMinidumpSignature(CRASHED_AT, { now: () => CRASHED_AT })
+
+    expect(captured?.signature.annotations).toEqual({})
+    expect(captured?.sizeBytes).toBe(32)
+  })
+
+  it('returns null when the file on disk is not a minidump', async () => {
+    await writeDump(path.join('reports', 'garbage.dmp'), CRASHED_AT + 100, Buffer.from('nope'))
+
+    const captured = await captureMinidumpSignature(CRASHED_AT, { now: () => CRASHED_AT })
+
+    expect(captured).toBeNull()
+  })
+
+  it('returns null rather than throwing when no dump was produced', async () => {
+    const captured = await captureMinidumpSignature(CRASHED_AT, {
+      timeoutMs: 0,
+      now: () => CRASHED_AT
+    })
+
+    expect(captured).toBeNull()
+  })
+})

--- a/src/main/crash-reporting/crashpad-capture.test.ts
+++ b/src/main/crash-reporting/crashpad-capture.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, rm, utimes, writeFile } from 'node:fs/promises'
+import { mkdtemp, mkdir, readdir, rm, utimes, writeFile } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -14,6 +14,7 @@ vi.mock('./minidump-crash-signature', () => ({
 }))
 
 import {
+  _pruneCrashpadDumpsForTest,
   _setCrashpadCaptureStateForTest,
   captureMinidumpSignature,
   waitForCrashMinidump
@@ -247,5 +248,20 @@ describe('captureMinidumpSignature', () => {
     })
 
     expect(captured).toBeNull()
+  })
+})
+
+describe('Crashpad dump pruning', () => {
+  it('keeps the newest dumps within the byte budget', async () => {
+    await writeDump(path.join('reports', 'old.dmp'), CRASHED_AT, Buffer.alloc(8))
+    await writeDump(path.join('reports', 'middle.dmp'), CRASHED_AT + 100, Buffer.alloc(8))
+    await writeDump(path.join('reports', 'new.dmp'), CRASHED_AT + 200, Buffer.alloc(8))
+
+    await _pruneCrashpadDumpsForTest(16)
+
+    expect((await readdir(path.join(dumpDir, 'reports'))).sort()).toEqual([
+      'middle.dmp',
+      'new.dmp'
+    ])
   })
 })

--- a/src/main/crash-reporting/crashpad-capture.test.ts
+++ b/src/main/crash-reporting/crashpad-capture.test.ts
@@ -3,9 +3,14 @@ import os from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+const parseMinidumpCrashSignatureMock = vi.hoisted(() => vi.fn())
+
 vi.mock('electron', () => ({
   app: { getPath: () => '/unused-in-tests' },
   crashReporter: { start: vi.fn() }
+}))
+vi.mock('./minidump-crash-signature', () => ({
+  parseMinidumpCrashSignature: parseMinidumpCrashSignatureMock
 }))
 
 import {
@@ -38,6 +43,8 @@ async function writeDump(relativePath: string, mtimeMs: number, contents = empty
 const CRASHED_AT = 1_700_000_000_000
 
 beforeEach(async () => {
+  parseMinidumpCrashSignatureMock.mockReset()
+  parseMinidumpCrashSignatureMock.mockReturnValue({ annotations: {} })
   dumpDir = await mkdtemp(path.join(os.tmpdir(), 'orca-crashpad-'))
   _setCrashpadCaptureStateForTest({ dumpDirectory: dumpDir, started: true })
 })
@@ -159,10 +166,78 @@ describe('captureMinidumpSignature', () => {
 
   it('returns null when the file on disk is not a minidump', async () => {
     await writeDump(path.join('reports', 'garbage.dmp'), CRASHED_AT + 100, Buffer.from('nope'))
+    parseMinidumpCrashSignatureMock.mockReturnValueOnce(null)
 
-    const captured = await captureMinidumpSignature(CRASHED_AT, { now: () => CRASHED_AT })
+    const captured = await captureMinidumpSignature(CRASHED_AT, {
+      timeoutMs: 0,
+      now: () => CRASHED_AT
+    })
 
     expect(captured).toBeNull()
+  })
+
+  it('claims a dump once so another report cannot reuse it', async () => {
+    const expected = await writeDump(path.join('reports', 'crash.dmp'), CRASHED_AT + 100)
+
+    const first = await captureMinidumpSignature(CRASHED_AT, {
+      timeoutMs: 0,
+      now: () => CRASHED_AT
+    })
+    const second = await captureMinidumpSignature(CRASHED_AT, {
+      timeoutMs: 0,
+      now: () => CRASHED_AT
+    })
+
+    expect(first?.filePath).toBe(expected)
+    expect(second).toBeNull()
+  })
+
+  it('skips a newer dump from the wrong process type', async () => {
+    const rendererDump = await writeDump(
+      path.join('reports', 'renderer.dmp'),
+      CRASHED_AT + 100,
+      Buffer.from('renderer')
+    )
+    await writeDump(path.join('reports', 'gpu.dmp'), CRASHED_AT + 200, Buffer.from('gpu-process'))
+    parseMinidumpCrashSignatureMock.mockImplementation((dump: Buffer) => ({
+      processType: dump.toString('utf8'),
+      annotations: {}
+    }))
+
+    const captured = await captureMinidumpSignature(CRASHED_AT, {
+      expectedProcessType: 'renderer',
+      timeoutMs: 0,
+      now: () => CRASHED_AT
+    })
+
+    expect(captured?.filePath).toBe(rendererDump)
+    expect(captured?.signature.processType).toBe('renderer')
+  })
+
+  it('leaves a mismatched dump available for its own process report', async () => {
+    const gpuDump = await writeDump(
+      path.join('reports', 'gpu.dmp'),
+      CRASHED_AT + 100,
+      Buffer.from('gpu-process')
+    )
+    parseMinidumpCrashSignatureMock.mockReturnValue({
+      processType: 'gpu-process',
+      annotations: {}
+    })
+
+    const renderer = await captureMinidumpSignature(CRASHED_AT, {
+      expectedProcessType: 'renderer',
+      timeoutMs: 0,
+      now: () => CRASHED_AT
+    })
+    const gpu = await captureMinidumpSignature(CRASHED_AT, {
+      expectedProcessType: 'gpu-process',
+      timeoutMs: 0,
+      now: () => CRASHED_AT
+    })
+
+    expect(renderer).toBeNull()
+    expect(gpu?.filePath).toBe(gpuDump)
   })
 
   it('returns null rather than throwing when no dump was produced', async () => {

--- a/src/main/crash-reporting/crashpad-capture.ts
+++ b/src/main/crash-reporting/crashpad-capture.ts
@@ -35,6 +35,9 @@ type DumpCandidate = {
 // app.setName runs at whenReady. Snapshot where Crashpad was actually pointed.
 let crashpadDumpDirectory: string | null = null
 let captureStarted = false
+let captureStartedAtMs: number | null = null
+const claimedDumpPaths = new Map<string, number>()
+const reservedDumpPaths = new Set<string>()
 
 export type CrashpadCaptureOptions = {
   /** Overrides Electron's default so tests need no real Crashpad handler. */
@@ -60,6 +63,7 @@ export function startCrashpadCapture(options: CrashpadCaptureOptions = {}): bool
       compress: false
     })
     captureStarted = true
+    captureStartedAtMs = Date.now()
   } catch (error) {
     console.error('[crash-reporting] Crashpad start failed:', error)
     return false
@@ -82,10 +86,13 @@ export function getCrashpadDumpDirectory(): string | null {
 
 /** Test seam; production callers go through startCrashpadCapture. */
 export function _setCrashpadCaptureStateForTest(
-  state: { dumpDirectory: string | null; started: boolean } | null
+  state: { dumpDirectory: string | null; started: boolean; startedAtMs?: number } | null
 ): void {
   crashpadDumpDirectory = state?.dumpDirectory ?? null
   captureStarted = state?.started ?? false
+  captureStartedAtMs = state?.started ? (state.startedAtMs ?? Number.NEGATIVE_INFINITY) : null
+  claimedDumpPaths.clear()
+  reservedDumpPaths.clear()
 }
 
 async function collectDumpCandidates(directory: string): Promise<DumpCandidate[]> {
@@ -115,19 +122,36 @@ async function collectDumpCandidates(directory: string): Promise<DumpCandidate[]
   return candidates
 }
 
-/**
- * Waits for the dump Crashpad writes for a crash observed at `crashedAtMs`.
- * Resolves null when capture is off, the handler wrote nothing, or the only
- * dumps on disk predate this crash.
- */
-export async function waitForCrashMinidump(
+type DumpPollingOptions = {
+  readonly timeoutMs?: number
+  readonly now?: () => number
+  readonly sleep?: (ms: number) => Promise<void>
+}
+
+export type CrashMinidumpCaptureOptions = DumpPollingOptions & {
+  readonly expectedProcessType?: string
+}
+
+function freshDumpCandidates(candidates: DumpCandidate[], crashedAtMs: number): DumpCandidate[] {
+  const floorMs = Math.max(
+    crashedAtMs - DUMP_RECENCY_WINDOW_MS,
+    captureStartedAtMs ?? Number.NEGATIVE_INFINITY
+  )
+  for (const [filePath, mtimeMs] of claimedDumpPaths) {
+    if (mtimeMs < floorMs) {
+      claimedDumpPaths.delete(filePath)
+    }
+  }
+  return candidates
+    .filter((candidate) => candidate.mtimeMs >= floorMs && candidate.size <= MAX_DUMP_BYTES)
+    .sort((a, b) => b.mtimeMs - a.mtimeMs)
+}
+
+async function pollDumpCandidates<T>(
   crashedAtMs: number,
-  options: {
-    timeoutMs?: number
-    now?: () => number
-    sleep?: (ms: number) => Promise<void>
-  } = {}
-): Promise<DumpCandidate | null> {
+  options: DumpPollingOptions,
+  select: (candidate: DumpCandidate) => Promise<T | null>
+): Promise<T | null> {
   const directory = crashpadDumpDirectory
   if (!directory) {
     return null
@@ -136,23 +160,33 @@ export async function waitForCrashMinidump(
   const now = options.now ?? Date.now
   const sleep =
     options.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)))
-  // Why: a dump can land microseconds before Electron delivers process-gone,
-  // so the floor has to sit behind the observed crash time, not on it.
-  const floorMs = crashedAtMs - DUMP_RECENCY_WINDOW_MS
   const deadline = now() + timeoutMs
 
   for (;;) {
-    const fresh = (await collectDumpCandidates(directory))
-      .filter((candidate) => candidate.mtimeMs >= floorMs && candidate.size <= MAX_DUMP_BYTES)
-      .sort((a, b) => b.mtimeMs - a.mtimeMs)
-    if (fresh.length > 0) {
-      return fresh[0]
+    const fresh = freshDumpCandidates(await collectDumpCandidates(directory), crashedAtMs)
+    for (const candidate of fresh) {
+      const selected = await select(candidate)
+      if (selected !== null) {
+        return selected
+      }
     }
     if (now() >= deadline) {
       return null
     }
     await sleep(DUMP_POLL_INTERVAL_MS)
   }
+}
+
+/**
+ * Waits for the dump Crashpad writes for a crash observed at `crashedAtMs`.
+ * Resolves null when capture is off, the handler wrote nothing, or the only
+ * dumps on disk predate this crash.
+ */
+export async function waitForCrashMinidump(
+  crashedAtMs: number,
+  options: DumpPollingOptions = {}
+): Promise<DumpCandidate | null> {
+  return pollDumpCandidates(crashedAtMs, options, async (candidate) => candidate)
 }
 
 export type CapturedMinidump = {
@@ -164,18 +198,35 @@ export type CapturedMinidump = {
 /** Finds the dump for a crash and parses its signature. Never throws. */
 export async function captureMinidumpSignature(
   crashedAtMs: number,
-  options: Parameters<typeof waitForCrashMinidump>[1] = {}
+  options: CrashMinidumpCaptureOptions = {}
 ): Promise<CapturedMinidump | null> {
+  const rejectedDumpPaths = new Set<string>()
   try {
-    const dump = await waitForCrashMinidump(crashedAtMs, options)
-    if (!dump) {
-      return null
-    }
-    const signature = parseMinidumpCrashSignature(await readFile(dump.filePath))
-    if (!signature) {
-      return null
-    }
-    return { filePath: dump.filePath, sizeBytes: dump.size, signature }
+    return await pollDumpCandidates(crashedAtMs, options, async (dump) => {
+      if (
+        rejectedDumpPaths.has(dump.filePath) ||
+        claimedDumpPaths.has(dump.filePath) ||
+        reservedDumpPaths.has(dump.filePath)
+      ) {
+        return null
+      }
+      reservedDumpPaths.add(dump.filePath)
+      try {
+        const signature = parseMinidumpCrashSignature(await readFile(dump.filePath))
+        if (
+          !signature ||
+          (options.expectedProcessType !== undefined &&
+            signature.processType !== options.expectedProcessType)
+        ) {
+          rejectedDumpPaths.add(dump.filePath)
+          return null
+        }
+        claimedDumpPaths.set(dump.filePath, dump.mtimeMs)
+        return { filePath: dump.filePath, sizeBytes: dump.size, signature }
+      } finally {
+        reservedDumpPaths.delete(dump.filePath)
+      }
+    })
   } catch (error) {
     console.error('[crash-reporting] minidump signature capture failed:', error)
     return null

--- a/src/main/crash-reporting/crashpad-capture.ts
+++ b/src/main/crash-reporting/crashpad-capture.ts
@@ -7,7 +7,7 @@
 // a CHECK failure becomes nameable without shipping raw memory anywhere.
 
 import type { Dirent } from 'node:fs'
-import { readdir, readFile, stat } from 'node:fs/promises'
+import { readdir, readFile, rm, stat } from 'node:fs/promises'
 import path from 'node:path'
 import { app, crashReporter } from 'electron'
 import {
@@ -24,6 +24,10 @@ const DUMP_POLL_INTERVAL_MS = 250
 const DUMP_RECENCY_WINDOW_MS = 30_000
 // Renderer dumps run ~1-15 MiB; well past that means we mis-picked a file.
 const MAX_DUMP_BYTES = 64 * 1024 * 1024
+// Match Crashpad's default budget, but enforce it after crashes instead of
+// waiting for its first 10-minute and later daily pruning passes.
+const MAX_STORED_DUMP_BYTES = 128 * 1024 * 1024
+const DUMP_PRUNE_DELAY_MS = 2_000
 
 type DumpCandidate = {
   readonly filePath: string
@@ -38,6 +42,7 @@ let captureStarted = false
 let captureStartedAtMs: number | null = null
 const claimedDumpPaths = new Map<string, number>()
 const reservedDumpPaths = new Set<string>()
+let dumpPruneTimer: NodeJS.Timeout | null = null
 
 export type CrashpadCaptureOptions = {
   /** Overrides Electron's default so tests need no real Crashpad handler. */
@@ -93,6 +98,10 @@ export function _setCrashpadCaptureStateForTest(
   captureStartedAtMs = state?.started ? (state.startedAtMs ?? Number.NEGATIVE_INFINITY) : null
   claimedDumpPaths.clear()
   reservedDumpPaths.clear()
+  if (dumpPruneTimer) {
+    clearTimeout(dumpPruneTimer)
+    dumpPruneTimer = null
+  }
 }
 
 async function collectDumpCandidates(directory: string): Promise<DumpCandidate[]> {
@@ -120,6 +129,52 @@ async function collectDumpCandidates(directory: string): Promise<DumpCandidate[]
     }
   }
   return candidates
+}
+
+async function pruneCrashpadDumps(maxBytes = MAX_STORED_DUMP_BYTES): Promise<void> {
+  const directory = crashpadDumpDirectory
+  if (!directory) {
+    return
+  }
+  const candidates = (await collectDumpCandidates(directory)).sort(
+    (left, right) => right.mtimeMs - left.mtimeMs
+  )
+  let retainedBytes = 0
+  for (let index = 0; index < candidates.length; index += 1) {
+    const candidate = candidates[index]
+    const mustKeep = index === 0 || reservedDumpPaths.has(candidate.filePath)
+    if (mustKeep || retainedBytes + candidate.size <= maxBytes) {
+      retainedBytes += candidate.size
+      continue
+    }
+    try {
+      await rm(candidate.filePath, { force: true })
+    } catch {
+      // Crashpad can still be promoting a dump; its own later pass will retry.
+    }
+  }
+}
+
+/** Coalesces crash-burst pruning; there is no timer or directory scan while idle. */
+export function scheduleCrashpadDumpPrune(): void {
+  if (!crashpadDumpDirectory || dumpPruneTimer) {
+    return
+  }
+  dumpPruneTimer = setTimeout(() => {
+    void pruneCrashpadDumps()
+      .catch((error) => {
+        console.error('[crash-reporting] Crashpad dump pruning failed:', error)
+      })
+      .finally(() => {
+        dumpPruneTimer = null
+      })
+  }, DUMP_PRUNE_DELAY_MS)
+  dumpPruneTimer.unref()
+}
+
+/** Test seam for byte-budget behavior without a real Crashpad database. */
+export async function _pruneCrashpadDumpsForTest(maxBytes: number): Promise<void> {
+  await pruneCrashpadDumps(maxBytes)
 }
 
 type DumpPollingOptions = {

--- a/src/main/crash-reporting/crashpad-capture.ts
+++ b/src/main/crash-reporting/crashpad-capture.ts
@@ -1,0 +1,183 @@
+// Starts Electron's Crashpad handler and pairs a written minidump with the
+// `render-process-gone` / `child-process-gone` event that reported the death.
+//
+// Upload stays off: dumps contain process memory, and the only transport we
+// have (observability/diagnostic-bundle-upload) is a user-initiated 4 MiB text
+// bundle. We keep dumps on disk and lift the *text* signature out of them, so
+// a CHECK failure becomes nameable without shipping raw memory anywhere.
+
+import type { Dirent } from 'node:fs'
+import { readdir, readFile, stat } from 'node:fs/promises'
+import path from 'node:path'
+import { app, crashReporter } from 'electron'
+import {
+  parseMinidumpCrashSignature,
+  type MinidumpCrashSignature
+} from './minidump-crash-signature'
+
+// Why: Crashpad writes the dump from the handler process while Electron
+// delivers process-gone on the main thread; the two race. Poll a short window
+// rather than sampling once and losing the dump most of the time.
+const DUMP_WAIT_TIMEOUT_MS = 8_000
+const DUMP_POLL_INTERVAL_MS = 250
+// A dump older than this belongs to an earlier crash, not the one we're pairing.
+const DUMP_RECENCY_WINDOW_MS = 30_000
+// Renderer dumps run ~1-15 MiB; well past that means we mis-picked a file.
+const MAX_DUMP_BYTES = 64 * 1024 * 1024
+
+type DumpCandidate = {
+  readonly filePath: string
+  readonly mtimeMs: number
+  readonly size: number
+}
+
+// Why: `app.getPath('crashDumps')` is derived from userData, which shifts when
+// app.setName runs at whenReady. Snapshot where Crashpad was actually pointed.
+let crashpadDumpDirectory: string | null = null
+let captureStarted = false
+
+export type CrashpadCaptureOptions = {
+  /** Overrides Electron's default so tests need no real Crashpad handler. */
+  readonly dumpDirectory?: string
+}
+
+/**
+ * Must run before `app.whenReady()`. Safe to call twice; the second call is a
+ * no-op so a re-entrant startup path cannot restart the handler.
+ */
+export function startCrashpadCapture(options: CrashpadCaptureOptions = {}): boolean {
+  if (captureStarted) {
+    return true
+  }
+  try {
+    crashReporter.start({
+      // Why: no submitURL is configured anywhere, and uploadToServer:true with
+      // an unset URL makes Crashpad retry against a bogus endpoint forever.
+      uploadToServer: false,
+      // Keep the OS handler (WER / Apple crash reporter) in the loop; it costs
+      // nothing and is the only signal left if Crashpad itself fails to init.
+      ignoreSystemCrashHandler: false,
+      compress: false
+    })
+    captureStarted = true
+  } catch (error) {
+    console.error('[crash-reporting] Crashpad start failed:', error)
+    return false
+  }
+  crashpadDumpDirectory = options.dumpDirectory ?? resolveDumpDirectory()
+  return true
+}
+
+function resolveDumpDirectory(): string | null {
+  try {
+    return app.getPath('crashDumps')
+  } catch {
+    return null
+  }
+}
+
+export function getCrashpadDumpDirectory(): string | null {
+  return crashpadDumpDirectory
+}
+
+/** Test seam; production callers go through startCrashpadCapture. */
+export function _setCrashpadCaptureStateForTest(
+  state: { dumpDirectory: string | null; started: boolean } | null
+): void {
+  crashpadDumpDirectory = state?.dumpDirectory ?? null
+  captureStarted = state?.started ?? false
+}
+
+async function collectDumpCandidates(directory: string): Promise<DumpCandidate[]> {
+  let entries: Dirent[]
+  try {
+    entries = await readdir(directory, {
+      withFileTypes: true,
+      recursive: true
+    })
+  } catch {
+    return []
+  }
+  const candidates: DumpCandidate[] = []
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.dmp')) {
+      continue
+    }
+    // `recursive` yields nested names relative to parentPath, not directory.
+    const filePath = path.join(entry.parentPath ?? directory, entry.name)
+    try {
+      const stats = await stat(filePath)
+      candidates.push({ filePath, mtimeMs: stats.mtimeMs, size: stats.size })
+    } catch {
+      // Crashpad renames dumps as it promotes them; a vanished file is normal.
+    }
+  }
+  return candidates
+}
+
+/**
+ * Waits for the dump Crashpad writes for a crash observed at `crashedAtMs`.
+ * Resolves null when capture is off, the handler wrote nothing, or the only
+ * dumps on disk predate this crash.
+ */
+export async function waitForCrashMinidump(
+  crashedAtMs: number,
+  options: {
+    timeoutMs?: number
+    now?: () => number
+    sleep?: (ms: number) => Promise<void>
+  } = {}
+): Promise<DumpCandidate | null> {
+  const directory = crashpadDumpDirectory
+  if (!directory) {
+    return null
+  }
+  const timeoutMs = options.timeoutMs ?? DUMP_WAIT_TIMEOUT_MS
+  const now = options.now ?? Date.now
+  const sleep =
+    options.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)))
+  // Why: a dump can land microseconds before Electron delivers process-gone,
+  // so the floor has to sit behind the observed crash time, not on it.
+  const floorMs = crashedAtMs - DUMP_RECENCY_WINDOW_MS
+  const deadline = now() + timeoutMs
+
+  for (;;) {
+    const fresh = (await collectDumpCandidates(directory))
+      .filter((candidate) => candidate.mtimeMs >= floorMs && candidate.size <= MAX_DUMP_BYTES)
+      .sort((a, b) => b.mtimeMs - a.mtimeMs)
+    if (fresh.length > 0) {
+      return fresh[0]
+    }
+    if (now() >= deadline) {
+      return null
+    }
+    await sleep(DUMP_POLL_INTERVAL_MS)
+  }
+}
+
+export type CapturedMinidump = {
+  readonly filePath: string
+  readonly sizeBytes: number
+  readonly signature: MinidumpCrashSignature
+}
+
+/** Finds the dump for a crash and parses its signature. Never throws. */
+export async function captureMinidumpSignature(
+  crashedAtMs: number,
+  options: Parameters<typeof waitForCrashMinidump>[1] = {}
+): Promise<CapturedMinidump | null> {
+  try {
+    const dump = await waitForCrashMinidump(crashedAtMs, options)
+    if (!dump) {
+      return null
+    }
+    const signature = parseMinidumpCrashSignature(await readFile(dump.filePath))
+    if (!signature) {
+      return null
+    }
+    return { filePath: dump.filePath, sizeBytes: dump.size, signature }
+  } catch (error) {
+    console.error('[crash-reporting] minidump signature capture failed:', error)
+    return null
+  }
+}

--- a/src/main/crash-reporting/minidump-crash-signature.test.ts
+++ b/src/main/crash-reporting/minidump-crash-signature.test.ts
@@ -1,0 +1,333 @@
+import { describe, expect, it } from 'vitest'
+import { minidumpSignatureDetails, parseMinidumpCrashSignature } from './minidump-crash-signature'
+
+const STREAM_TYPE_MODULE_LIST = 4
+const STREAM_TYPE_EXCEPTION = 6
+const STREAM_TYPE_CRASHPAD_INFO = 0x43500001
+
+/**
+ * Builds real Crashpad-layout minidumps so the parser is tested against the
+ * byte format rather than a mock. Regions are appended and referenced by RVA,
+ * matching how Crashpad emits them.
+ */
+class MinidumpBuilder {
+  private regions: Buffer[] = []
+  private cursor = 0
+
+  constructor(private readonly headerAndDirectoryBytes: number) {
+    this.cursor = headerAndDirectoryBytes
+  }
+
+  append(buf: Buffer): number {
+    const rva = this.cursor
+    this.regions.push(buf)
+    this.cursor += buf.length
+    return rva
+  }
+
+  utf8String(value: string): number {
+    const data = Buffer.from(value, 'utf8')
+    const buf = Buffer.alloc(4 + data.length + 1)
+    buf.writeUInt32LE(data.length, 0)
+    data.copy(buf, 4)
+    return this.append(buf)
+  }
+
+  utf16String(value: string): number {
+    const data = Buffer.from(value, 'utf16le')
+    const buf = Buffer.alloc(4 + data.length + 2)
+    buf.writeUInt32LE(data.length, 0)
+    data.copy(buf, 4)
+    return this.append(buf)
+  }
+
+  rawString(value: string): { size: number; rva: number } {
+    const data = Buffer.from(value, 'utf8')
+    return { size: data.length, rva: this.append(data) }
+  }
+
+  build(streams: { type: number; size: number; rva: number }[]): Buffer {
+    const header = Buffer.alloc(32)
+    header.writeUInt32LE(0x504d444d, 0)
+    header.writeUInt32LE(0xa793, 4)
+    header.writeUInt32LE(streams.length, 8)
+    header.writeUInt32LE(32, 12)
+    const directory = Buffer.alloc(streams.length * 12)
+    streams.forEach((stream, index) => {
+      directory.writeUInt32LE(stream.type, index * 12)
+      directory.writeUInt32LE(stream.size, index * 12 + 4)
+      directory.writeUInt32LE(stream.rva, index * 12 + 8)
+    })
+    const body = Buffer.concat(this.regions)
+    const prefix = Buffer.concat([header, directory])
+    expect(prefix.length).toBe(this.headerAndDirectoryBytes)
+    return Buffer.concat([prefix, body])
+  }
+}
+
+function location(size: number, rva: number): Buffer {
+  const buf = Buffer.alloc(8)
+  buf.writeUInt32LE(size, 0)
+  buf.writeUInt32LE(rva, 4)
+  return buf
+}
+
+const EMPTY_LOCATION = location(0, 0)
+
+type BuiltDump = { dump: Buffer }
+
+/**
+ * @param annotations key/value pairs written as MinidumpAnnotation objects
+ *   hanging off a module's crashpad info, which is where Chromium crash keys
+ *   (including LOG_FATAL) actually live.
+ */
+function buildDump(options: {
+  annotations?: Record<string, string>
+  simpleAnnotations?: Record<string, string>
+  exception?: { code: number; address: bigint }
+  modules?: { base: bigint; size: number; name: string }[]
+}): BuiltDump {
+  const streamCount =
+    1 + (options.exception ? 1 : 0) + (options.modules && options.modules.length > 0 ? 1 : 0)
+  const builder = new MinidumpBuilder(32 + streamCount * 12)
+  const streams: { type: number; size: number; rva: number }[] = []
+
+  // Module-level annotation objects.
+  const annotationEntries = Object.entries(options.annotations ?? {})
+  const annotationRecords = annotationEntries.map(([name, value]) => ({
+    nameRva: builder.utf8String(name),
+    value: builder.rawString(value)
+  }))
+  const annotationListBuf = Buffer.alloc(4 + annotationRecords.length * 16)
+  annotationListBuf.writeUInt32LE(annotationRecords.length, 0)
+  annotationRecords.forEach((record, index) => {
+    const at = 4 + index * 16
+    annotationListBuf.writeUInt32LE(record.nameRva, at)
+    annotationListBuf.writeUInt16LE(1, at + 4) // kString
+    annotationListBuf.writeUInt16LE(0, at + 6)
+    annotationListBuf.writeUInt32LE(record.value.size, at + 8)
+    annotationListBuf.writeUInt32LE(record.value.rva, at + 12)
+  })
+  const annotationListRva = builder.append(annotationListBuf)
+
+  // Process-level simple string dictionary.
+  const simpleEntries = Object.entries(options.simpleAnnotations ?? {})
+  const simplePairs = simpleEntries.map(([key, value]) => ({
+    keyRva: builder.utf8String(key),
+    valueRva: builder.utf8String(value)
+  }))
+  const simpleBuf = Buffer.alloc(4 + simplePairs.length * 8)
+  simpleBuf.writeUInt32LE(simplePairs.length, 0)
+  simplePairs.forEach((pair, index) => {
+    simpleBuf.writeUInt32LE(pair.keyRva, 4 + index * 8)
+    simpleBuf.writeUInt32LE(pair.valueRva, 4 + index * 8 + 4)
+  })
+  const simpleRva = builder.append(simpleBuf)
+
+  // MinidumpModuleCrashpadInfo (version, list_annotations, simple, objects).
+  const moduleInfoBuf = Buffer.concat([
+    (() => {
+      const v = Buffer.alloc(4)
+      v.writeUInt32LE(1, 0)
+      return v
+    })(),
+    EMPTY_LOCATION,
+    EMPTY_LOCATION,
+    location(annotationListBuf.length, annotationListRva)
+  ])
+  const moduleInfoRva = builder.append(moduleInfoBuf)
+
+  const moduleLinkBuf = Buffer.alloc(4 + 12)
+  moduleLinkBuf.writeUInt32LE(1, 0)
+  moduleLinkBuf.writeUInt32LE(0, 4) // minidump module index
+  moduleLinkBuf.writeUInt32LE(moduleInfoBuf.length, 8)
+  moduleLinkBuf.writeUInt32LE(moduleInfoRva, 12)
+  const moduleLinkRva = builder.append(moduleLinkBuf)
+
+  const crashpadInfoBuf = Buffer.concat([
+    (() => {
+      const v = Buffer.alloc(4 + 16 + 16)
+      v.writeUInt32LE(1, 0)
+      return v
+    })(),
+    location(simpleBuf.length, simpleRva),
+    location(moduleLinkBuf.length, moduleLinkRva)
+  ])
+  const crashpadInfoRva = builder.append(crashpadInfoBuf)
+  streams.push({
+    type: STREAM_TYPE_CRASHPAD_INFO,
+    size: crashpadInfoBuf.length,
+    rva: crashpadInfoRva
+  })
+
+  if (options.modules && options.modules.length > 0) {
+    const nameRvas = options.modules.map((module) => builder.utf16String(module.name))
+    const listBuf = Buffer.alloc(4 + options.modules.length * 108)
+    listBuf.writeUInt32LE(options.modules.length, 0)
+    options.modules.forEach((module, index) => {
+      const at = 4 + index * 108
+      listBuf.writeBigUInt64LE(module.base, at)
+      listBuf.writeUInt32LE(module.size, at + 8)
+      listBuf.writeUInt32LE(nameRvas[index], at + 20)
+    })
+    streams.push({
+      type: STREAM_TYPE_MODULE_LIST,
+      size: listBuf.length,
+      rva: builder.append(listBuf)
+    })
+  }
+
+  if (options.exception) {
+    const exceptionBuf = Buffer.alloc(168)
+    exceptionBuf.writeUInt32LE(1234, 0) // ThreadId
+    exceptionBuf.writeUInt32LE(options.exception.code, 8)
+    exceptionBuf.writeBigUInt64LE(options.exception.address, 24)
+    streams.push({
+      type: STREAM_TYPE_EXCEPTION,
+      size: exceptionBuf.length,
+      rva: builder.append(exceptionBuf)
+    })
+  }
+
+  return { dump: builder.build(streams) }
+}
+
+const FATAL_LINE =
+  '[8104:1234:0815/143022.123456:FATAL:render_frame_impl.cc(4821)] Check failed: !is_detached_.'
+
+describe('parseMinidumpCrashSignature', () => {
+  it('names the failing CHECK from the LOG_FATAL annotation', () => {
+    const { dump } = buildDump({
+      annotations: { LOG_FATAL: FATAL_LINE, ptype: 'renderer' }
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.checkMessage).toBe(FATAL_LINE)
+    expect(signature?.checkFile).toBe('render_frame_impl.cc')
+    expect(signature?.checkLine).toBe(4821)
+    expect(signature?.processType).toBe('renderer')
+  })
+
+  it('reads annotations from the process-level simple string dictionary', () => {
+    const { dump } = buildDump({
+      simpleAnnotations: {
+        ptype: 'gpu-process',
+        'gpu-gl-vendor': 'Intel Inc.'
+      }
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.processType).toBe('gpu-process')
+    expect(signature?.annotations['gpu-gl-vendor']).toBe('Intel Inc.')
+  })
+
+  it('drops annotations outside the allowlist', () => {
+    const { dump } = buildDump({
+      annotations: {
+        LOG_FATAL: FATAL_LINE,
+        'switch-3': '--user-data-dir=/Users/someone/secret'
+      }
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.annotations['switch-3']).toBeUndefined()
+    expect(Object.keys(signature?.annotations ?? {})).toEqual(['LOG_FATAL'])
+  })
+
+  it('resolves the faulting module from the exception address', () => {
+    const { dump } = buildDump({
+      exception: { code: 0x80000003, address: 0x7ff8_0000_1234n },
+      modules: [
+        {
+          base: 0x7ff7_0000_0000n,
+          size: 0x1000,
+          name: 'C:\\Program Files\\Orca\\Orca.exe'
+        },
+        {
+          base: 0x7ff8_0000_0000n,
+          size: 0x10_0000,
+          name: 'C:\\Program Files\\Orca\\chrome_elf.dll'
+        }
+      ]
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.exceptionCode).toBe(0x80000003)
+    expect(signature?.exceptionAddress).toBe('0x7ff800001234')
+    expect(signature?.faultingModule).toBe('chrome_elf.dll')
+    expect(signature?.faultingModuleOffset).toBe('0x1234')
+  })
+
+  it('omits the faulting module when no image range covers the address', () => {
+    const { dump } = buildDump({
+      exception: { code: 11, address: 0x10n },
+      modules: [{ base: 0x7ff7_0000_0000n, size: 0x1000, name: '/opt/orca/orca' }]
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.exceptionAddress).toBe('0x10')
+    expect(signature?.faultingModule).toBeUndefined()
+  })
+
+  it('returns null for a buffer that is not a minidump', () => {
+    expect(parseMinidumpCrashSignature(Buffer.from('not a dump at all', 'utf8'))).toBeNull()
+    expect(parseMinidumpCrashSignature(Buffer.alloc(0))).toBeNull()
+  })
+
+  it('degrades instead of throwing on a truncated dump', () => {
+    const { dump } = buildDump({ annotations: { LOG_FATAL: FATAL_LINE } })
+
+    const truncated = dump.subarray(0, 48)
+
+    expect(() => parseMinidumpCrashSignature(truncated)).not.toThrow()
+    expect(parseMinidumpCrashSignature(truncated)?.checkMessage).toBeUndefined()
+  })
+
+  it('degrades instead of throwing when stream counts are corrupt', () => {
+    const { dump } = buildDump({ annotations: { LOG_FATAL: FATAL_LINE } })
+    const corrupt = Buffer.from(dump)
+    corrupt.writeUInt32LE(0xffff_ffff, 8)
+
+    expect(() => parseMinidumpCrashSignature(corrupt)).not.toThrow()
+    expect(parseMinidumpCrashSignature(corrupt)?.annotations).toEqual({})
+  })
+})
+
+describe('minidumpSignatureDetails', () => {
+  it('flattens the check location and faulting module into detail keys', () => {
+    const { dump } = buildDump({
+      annotations: {
+        LOG_FATAL: FATAL_LINE,
+        ptype: 'renderer',
+        channel: 'stable'
+      },
+      exception: { code: 0x80000003, address: 0x7ff8_0000_1234n },
+      modules: [{ base: 0x7ff8_0000_0000n, size: 0x10_0000, name: 'chrome_elf.dll' }]
+    })
+
+    const details = minidumpSignatureDetails(parseMinidumpCrashSignature(dump)!)
+
+    expect(details).toMatchObject({
+      minidumpCheckMessage: FATAL_LINE,
+      minidumpCheckFile: 'render_frame_impl.cc',
+      minidumpCheckLine: 4821,
+      minidumpProcessType: 'renderer',
+      minidumpExceptionCode: '0x80000003',
+      minidumpFaultingModule: 'chrome_elf.dll',
+      minidumpAnnotation_channel: 'stable'
+    })
+  })
+
+  it('does not duplicate the fatal line into an annotation key', () => {
+    const { dump } = buildDump({ annotations: { LOG_FATAL: FATAL_LINE } })
+
+    const details = minidumpSignatureDetails(parseMinidumpCrashSignature(dump)!)
+
+    expect(details.minidumpAnnotation_LOG_FATAL).toBeUndefined()
+  })
+})

--- a/src/main/crash-reporting/minidump-crash-signature.test.ts
+++ b/src/main/crash-reporting/minidump-crash-signature.test.ts
@@ -197,6 +197,9 @@ function buildDump(options: {
 const FATAL_LINE =
   '[8104:1234:0815/143022.123456:FATAL:render_frame_impl.cc(4821)] Check failed: !is_detached_.'
 
+const ELECTRON_43_CHECK_LINE =
+  '[29136:0815/232206.330:ERROR:third_party\\blink\\common\\chrome_debug_urls.cc:180] Intentionally causing CHECK because user navigated to chrome://checkcrash/'
+
 describe('parseMinidumpCrashSignature', () => {
   it('names the failing CHECK from the LOG_FATAL annotation', () => {
     const { dump } = buildDump({
@@ -209,6 +212,40 @@ describe('parseMinidumpCrashSignature', () => {
     expect(signature?.checkFile).toBe('render_frame_impl.cc')
     expect(signature?.checkLine).toBe(4821)
     expect(signature?.processType).toBe('renderer')
+  })
+
+  it('recovers a CHECK line from Electron 43 dump memory without LOG_FATAL', () => {
+    const { dump } = buildDump({ annotations: { ptype: 'renderer' } })
+    const dumpWithMemory = Buffer.concat([
+      dump,
+      Buffer.from(`\0${ELECTRON_43_CHECK_LINE}\0`, 'utf8')
+    ])
+
+    const signature = parseMinidumpCrashSignature(dumpWithMemory)
+
+    expect(signature?.checkMessage).toBe(ELECTRON_43_CHECK_LINE)
+    expect(signature?.checkFile).toBe('chrome_debug_urls.cc')
+    expect(signature?.checkLine).toBe(180)
+    expect(signature?.processType).toBe('renderer')
+  })
+
+  it('does not promote an unrelated Chromium ERROR line containing CHECK', () => {
+    const { dump } = buildDump({})
+    const unrelated =
+      '[29136:0815/232206.330:ERROR:settings.cc:44] Opened the CHECK settings panel.'
+    const dumpWithMemory = Buffer.concat([dump, Buffer.from(`\0${unrelated}\0`, 'utf8')])
+
+    expect(parseMinidumpCrashSignature(dumpWithMemory)?.checkMessage).toBeUndefined()
+  })
+
+  it('prefers the structured annotation over a dump-memory candidate', () => {
+    const { dump } = buildDump({ annotations: { LOG_FATAL: FATAL_LINE } })
+    const dumpWithMemory = Buffer.concat([
+      dump,
+      Buffer.from(`\0${ELECTRON_43_CHECK_LINE}\0`, 'utf8')
+    ])
+
+    expect(parseMinidumpCrashSignature(dumpWithMemory)?.checkMessage).toBe(FATAL_LINE)
   })
 
   it('reads annotations from the process-level simple string dictionary', () => {

--- a/src/main/crash-reporting/minidump-crash-signature.test.ts
+++ b/src/main/crash-reporting/minidump-crash-signature.test.ts
@@ -41,9 +41,12 @@ class MinidumpBuilder {
     return this.append(buf)
   }
 
-  rawString(value: string): { size: number; rva: number } {
+  byteArray(value: string): number {
     const data = Buffer.from(value, 'utf8')
-    return { size: data.length, rva: this.append(data) }
+    const buf = Buffer.alloc(4 + data.length)
+    buf.writeUInt32LE(data.length, 0)
+    data.copy(buf, 4)
+    return this.append(buf)
   }
 
   build(streams: { type: number; size: number; rva: number }[]): Buffer {
@@ -96,17 +99,16 @@ function buildDump(options: {
   const annotationEntries = Object.entries(options.annotations ?? {})
   const annotationRecords = annotationEntries.map(([name, value]) => ({
     nameRva: builder.utf8String(name),
-    value: builder.rawString(value)
+    valueRva: builder.byteArray(value)
   }))
-  const annotationListBuf = Buffer.alloc(4 + annotationRecords.length * 16)
+  const annotationListBuf = Buffer.alloc(4 + annotationRecords.length * 12)
   annotationListBuf.writeUInt32LE(annotationRecords.length, 0)
   annotationRecords.forEach((record, index) => {
-    const at = 4 + index * 16
+    const at = 4 + index * 12
     annotationListBuf.writeUInt32LE(record.nameRva, at)
     annotationListBuf.writeUInt16LE(1, at + 4) // kString
     annotationListBuf.writeUInt16LE(0, at + 6)
-    annotationListBuf.writeUInt32LE(record.value.size, at + 8)
-    annotationListBuf.writeUInt32LE(record.value.rva, at + 12)
+    annotationListBuf.writeUInt32LE(record.valueRva, at + 8)
   })
   const annotationListRva = builder.append(annotationListBuf)
 

--- a/src/main/crash-reporting/minidump-crash-signature.ts
+++ b/src/main/crash-reporting/minidump-crash-signature.ts
@@ -113,12 +113,12 @@ function findEmbeddedCheckMessage(dump: Buffer): LocatedCheckMessage | undefined
     let from = 0
     for (let inspected = 0; inspected < MAX_MARKERS_PER_SEVERITY; inspected += 1) {
       const markerAt = dump.indexOf(marker, from)
-      if (markerAt < 0) {
+      if (markerAt === -1) {
         break
       }
       from = markerAt + marker.length
       const start = dump.lastIndexOf(0x5b, markerAt)
-      if (start < 0 || markerAt - start > MAX_LOG_PREFIX_BYTES) {
+      if (start === -1 || markerAt - start > MAX_LOG_PREFIX_BYTES) {
         continue
       }
       let end = markerAt + marker.length

--- a/src/main/crash-reporting/minidump-crash-signature.ts
+++ b/src/main/crash-reporting/minidump-crash-signature.ts
@@ -1,0 +1,201 @@
+// Extracts the diagnosable parts of a Crashpad minidump without symbols.
+//
+// Why: a Chromium CHECK/DCHECK surfaces to `render-process-gone` as exit code
+// 0x80000003 (STATUS_BREAKPOINT) and nothing else, so the exit code alone can
+// never name the failing check. Crashpad stores the fatal log line verbatim in
+// the `LOG_FATAL` annotation, so the check name, file and line are recoverable
+// from the dump itself — no symbol server, no minidump_stackwalk.
+//
+// Layouts are from Crashpad's minidump_extensions.h and the Windows
+// MINIDUMP_* structs. Everything here is bounds-checked and returns null
+// rather than throwing: a truncated dump must degrade, not break crash
+// reporting.
+
+import { findStream, isMinidump, MAX_MODULES, MinidumpView } from './minidump-stream-reader'
+import { readCrashpadAnnotations } from './minidump-crashpad-annotations'
+
+const STREAM_TYPE_MODULE_LIST = 4
+const STREAM_TYPE_EXCEPTION = 6
+
+const MODULE_RECORD_SIZE = 108
+const MODULE_BASE_OFFSET = 0
+const MODULE_SIZE_OFFSET = 8
+const MODULE_NAME_RVA_OFFSET = 20
+
+// MINIDUMP_EXCEPTION_STREAM: ThreadId u32, __alignment u32, then MINIDUMP_EXCEPTION.
+const EXCEPTION_RECORD_OFFSET = 8
+const EXCEPTION_CODE_OFFSET = EXCEPTION_RECORD_OFFSET + 0
+const EXCEPTION_ADDRESS_OFFSET = EXCEPTION_RECORD_OFFSET + 16
+
+export type MinidumpCrashSignature = {
+  /** Chromium's fatal log line, e.g. `[...:FATAL:node.cc(123)] Check failed: !x.` */
+  readonly checkMessage?: string
+  /** Source file basename parsed out of `checkMessage`. */
+  readonly checkFile?: string
+  readonly checkLine?: number
+  /** Crashpad `ptype`: `renderer`, `gpu-process`, `browser`. */
+  readonly processType?: string
+  /** Win32 exception code / POSIX signal, e.g. 0x80000003 STATUS_BREAKPOINT. */
+  readonly exceptionCode?: number
+  readonly exceptionAddress?: string
+  /** Module whose image range contains `exceptionAddress`. */
+  readonly faultingModule?: string
+  readonly faultingModuleOffset?: string
+  /** Allowlisted Crashpad annotations, verbatim. */
+  readonly annotations: Readonly<Record<string, string>>
+}
+
+type ModuleRecord = {
+  readonly base: bigint
+  readonly size: number
+  readonly name: string
+}
+
+function readModules(view: MinidumpView): ModuleRecord[] {
+  const stream = findStream(view, STREAM_TYPE_MODULE_LIST)
+  if (!stream) {
+    return []
+  }
+  const count = view.u32(stream.rva)
+  if (count === null || count > MAX_MODULES) {
+    return []
+  }
+  const modules: ModuleRecord[] = []
+  for (let index = 0; index < count; index += 1) {
+    const record = stream.rva + 4 + index * MODULE_RECORD_SIZE
+    const base = view.u64(record + MODULE_BASE_OFFSET)
+    const size = view.u32(record + MODULE_SIZE_OFFSET)
+    const nameRva = view.u32(record + MODULE_NAME_RVA_OFFSET)
+    if (base === null || size === null || nameRva === null) {
+      break
+    }
+    const name = view.utf16String(nameRva, 2_048)
+    modules.push({ base, size, name: name ?? 'unknown' })
+  }
+  return modules
+}
+
+function moduleBasename(modulePath: string): string {
+  const separator = Math.max(modulePath.lastIndexOf('/'), modulePath.lastIndexOf('\\'))
+  return separator >= 0 ? modulePath.slice(separator + 1) : modulePath
+}
+
+function toHex(value: bigint): string {
+  return `0x${value.toString(16)}`
+}
+
+/**
+ * Chromium logs `[pid:tid:MMDD/HHMMSS.uuuuuu:FATAL:file.cc(123)] message`.
+ * `LogMessage::Init` strips the directory, so only a basename appears here —
+ * which is why the fatal line survives crash-report path redaction intact.
+ */
+function parseCheckLocation(checkMessage: string): {
+  file?: string
+  line?: number
+} {
+  const match = /:(?:FATAL|CHECK|DFATAL)(?::[^:\]]*)?:([^:()\s]+)\((\d+)\)/.exec(checkMessage)
+  if (!match) {
+    return {}
+  }
+  const line = Number.parseInt(match[2], 10)
+  return { file: match[1], line: Number.isFinite(line) ? line : undefined }
+}
+
+function findFaultingModule(
+  modules: ModuleRecord[],
+  address: bigint
+): { name: string; offset: string } | undefined {
+  for (const module of modules) {
+    if (address >= module.base && address < module.base + BigInt(module.size)) {
+      return {
+        name: moduleBasename(module.name),
+        offset: toHex(address - module.base)
+      }
+    }
+  }
+  return undefined
+}
+
+/**
+ * Parses a Crashpad minidump into the fields that make a CHECK failure
+ * nameable. Returns null when the buffer is not a minidump.
+ */
+export function parseMinidumpCrashSignature(dump: Buffer): MinidumpCrashSignature | null {
+  if (!isMinidump(dump)) {
+    return null
+  }
+  const view = new MinidumpView(dump)
+  const annotations = readCrashpadAnnotations(view)
+
+  const signature: {
+    -readonly [K in keyof MinidumpCrashSignature]: MinidumpCrashSignature[K]
+  } = { annotations }
+
+  const checkMessage = annotations['LOG_FATAL'] ?? annotations['abort-message']
+  if (checkMessage) {
+    signature.checkMessage = checkMessage
+    const { file, line } = parseCheckLocation(checkMessage)
+    signature.checkFile = file
+    signature.checkLine = line
+  }
+  if (annotations['ptype']) {
+    signature.processType = annotations['ptype']
+  }
+
+  const exception = findStream(view, STREAM_TYPE_EXCEPTION)
+  if (exception) {
+    const code = view.u32(exception.rva + EXCEPTION_CODE_OFFSET)
+    const address = view.u64(exception.rva + EXCEPTION_ADDRESS_OFFSET)
+    if (code !== null) {
+      signature.exceptionCode = code
+    }
+    if (address !== null) {
+      signature.exceptionAddress = toHex(address)
+      const faulting = findFaultingModule(readModules(view), address)
+      if (faulting) {
+        signature.faultingModule = faulting.name
+        signature.faultingModuleOffset = faulting.offset
+      }
+    }
+  }
+
+  return signature
+}
+
+/** Flattens a signature into `CrashReportRecord.details` keys. */
+export function minidumpSignatureDetails(
+  signature: MinidumpCrashSignature
+): Record<string, string | number> {
+  const details: Record<string, string | number> = {}
+  if (signature.checkMessage) {
+    details.minidumpCheckMessage = signature.checkMessage
+  }
+  if (signature.checkFile) {
+    details.minidumpCheckFile = signature.checkFile
+  }
+  if (signature.checkLine !== undefined) {
+    details.minidumpCheckLine = signature.checkLine
+  }
+  if (signature.processType) {
+    details.minidumpProcessType = signature.processType
+  }
+  if (signature.exceptionCode !== undefined) {
+    details.minidumpExceptionCode = `0x${(signature.exceptionCode >>> 0).toString(16)}`
+  }
+  if (signature.exceptionAddress) {
+    details.minidumpExceptionAddress = signature.exceptionAddress
+  }
+  if (signature.faultingModule) {
+    details.minidumpFaultingModule = signature.faultingModule
+  }
+  if (signature.faultingModuleOffset) {
+    details.minidumpFaultingModuleOffset = signature.faultingModuleOffset
+  }
+  for (const [key, value] of Object.entries(signature.annotations)) {
+    if (key === 'LOG_FATAL' || key === 'abort-message' || key === 'ptype') {
+      continue
+    }
+    details[`minidumpAnnotation_${key.replace(/-/g, '_')}`] = value
+  }
+  return details
+}

--- a/src/main/crash-reporting/minidump-crash-signature.ts
+++ b/src/main/crash-reporting/minidump-crash-signature.ts
@@ -2,9 +2,9 @@
 //
 // Why: a Chromium CHECK/DCHECK surfaces to `render-process-gone` as exit code
 // 0x80000003 (STATUS_BREAKPOINT) and nothing else, so the exit code alone can
-// never name the failing check. Crashpad stores the fatal log line verbatim in
-// the `LOG_FATAL` annotation, so the check name, file and line are recoverable
-// from the dump itself — no symbol server, no minidump_stackwalk.
+// never name the failing check. Some Crashpad builds expose the fatal line as
+// `LOG_FATAL`; Electron 43 on Windows only carries it in captured process
+// memory. Both forms are recoverable without symbols or minidump_stackwalk.
 //
 // Layouts are from Crashpad's minidump_extensions.h and the Windows
 // MINIDUMP_* structs. Everything here is bounds-checked and returns null
@@ -26,6 +26,19 @@ const MODULE_NAME_RVA_OFFSET = 20
 const EXCEPTION_RECORD_OFFSET = 8
 const EXCEPTION_CODE_OFFSET = EXCEPTION_RECORD_OFFSET + 0
 const EXCEPTION_ADDRESS_OFFSET = EXCEPTION_RECORD_OFFSET + 16
+
+const CHROMIUM_LOG_MARKERS = [
+  Buffer.from(':FATAL:', 'ascii'),
+  Buffer.from(':CHECK:', 'ascii'),
+  Buffer.from(':DFATAL:', 'ascii'),
+  Buffer.from(':ERROR:', 'ascii')
+]
+const MAX_LOG_PREFIX_BYTES = 96
+const MAX_CHECK_LOG_BYTES = 4_000
+const MAX_MARKERS_PER_SEVERITY = 256
+const CHECK_LOG_PATTERN =
+  /^\[(?:\d+:){1,2}\d{4}\/\d{6}\.\d{3,6}:(FATAL|CHECK|DFATAL|ERROR)(?::[^:\]\r\n]{1,80})*:([^:\]\r\n]{1,512}?)(?:\((\d+)\)|:(\d+))\]\s*(.+)$/
+const ERROR_CHECK_PATTERN = /\b(?:Check failed:|D?CHECK failed:|Intentionally causing D?CHECK\b)/i
 
 export type MinidumpCrashSignature = {
   /** Chromium's fatal log line, e.g. `[...:FATAL:node.cc(123)] Check failed: !x.` */
@@ -84,11 +97,52 @@ function toHex(value: bigint): string {
   return `0x${value.toString(16)}`
 }
 
-/**
- * Chromium logs `[pid:tid:MMDD/HHMMSS.uuuuuu:FATAL:file.cc(123)] message`.
- * `LogMessage::Init` strips the directory, so only a basename appears here —
- * which is why the fatal line survives crash-report path redaction intact.
- */
+type LocatedCheckMessage = {
+  readonly message: string
+  readonly file?: string
+  readonly line?: number
+}
+
+function isPrintableLogByte(value: number): boolean {
+  return value === 0x09 || (value >= 0x20 && value <= 0x7e)
+}
+
+/** Electron 43 omits LOG_FATAL but keeps Chromium's formatted log line in memory. */
+function findEmbeddedCheckMessage(dump: Buffer): LocatedCheckMessage | undefined {
+  for (const marker of CHROMIUM_LOG_MARKERS) {
+    let from = 0
+    for (let inspected = 0; inspected < MAX_MARKERS_PER_SEVERITY; inspected += 1) {
+      const markerAt = dump.indexOf(marker, from)
+      if (markerAt < 0) {
+        break
+      }
+      from = markerAt + marker.length
+      const start = dump.lastIndexOf(0x5b, markerAt)
+      if (start < 0 || markerAt - start > MAX_LOG_PREFIX_BYTES) {
+        continue
+      }
+      let end = markerAt + marker.length
+      const limit = Math.min(dump.length, start + MAX_CHECK_LOG_BYTES)
+      while (end < limit && isPrintableLogByte(dump[end])) {
+        end += 1
+      }
+      const candidate = dump.subarray(start, end).toString('utf8')
+      const match = CHECK_LOG_PATTERN.exec(candidate)
+      if (!match || (match[1] === 'ERROR' && !ERROR_CHECK_PATTERN.test(match[5]))) {
+        continue
+      }
+      const line = Number.parseInt(match[3] ?? match[4], 10)
+      return {
+        message: candidate,
+        file: moduleBasename(match[2]),
+        line: Number.isFinite(line) ? line : undefined
+      }
+    }
+  }
+  return undefined
+}
+
+/** Parses the annotation form, which uses `file.cc(123)`. */
 function parseCheckLocation(checkMessage: string): {
   file?: string
   line?: number
@@ -131,12 +185,18 @@ export function parseMinidumpCrashSignature(dump: Buffer): MinidumpCrashSignatur
     -readonly [K in keyof MinidumpCrashSignature]: MinidumpCrashSignature[K]
   } = { annotations }
 
-  const checkMessage = annotations['LOG_FATAL'] ?? annotations['abort-message']
+  const annotatedCheckMessage = annotations['LOG_FATAL'] ?? annotations['abort-message']
+  const embeddedCheck = annotatedCheckMessage ? undefined : findEmbeddedCheckMessage(dump)
+  const checkMessage = annotatedCheckMessage ?? embeddedCheck?.message
   if (checkMessage) {
     signature.checkMessage = checkMessage
-    const { file, line } = parseCheckLocation(checkMessage)
-    signature.checkFile = file
-    signature.checkLine = line
+    const location = embeddedCheck ?? parseCheckLocation(checkMessage)
+    if (location.file) {
+      signature.checkFile = location.file
+    }
+    if (location.line !== undefined) {
+      signature.checkLine = location.line
+    }
   }
   if (annotations['ptype']) {
     signature.processType = annotations['ptype']

--- a/src/main/crash-reporting/minidump-crashpad-annotations.ts
+++ b/src/main/crash-reporting/minidump-crashpad-annotations.ts
@@ -1,0 +1,170 @@
+// Reads Chromium's crash keys out of a Crashpad minidump's annotation streams.
+//
+// Chromium writes the fatal log line into the `LOG_FATAL` annotation, which is
+// why a CHECK failure is nameable from the dump alone — no symbol server, no
+// minidump_stackwalk. Layouts are from Crashpad's minidump_extensions.h.
+
+import {
+  findStream,
+  MAX_MODULES,
+  type LocationDescriptor,
+  type MinidumpView
+} from './minidump-stream-reader'
+
+// Why: a dump claiming an absurd annotation count is corrupt; cap before iterating.
+const MAX_ANNOTATIONS = 512
+
+const STREAM_TYPE_CRASHPAD_INFO = 0x43500001
+
+const CRASHPAD_INFO_MIN_SIZE = 52
+const CRASHPAD_INFO_SIMPLE_ANNOTATIONS_OFFSET = 36
+const CRASHPAD_INFO_MODULE_LIST_OFFSET = 44
+
+const MODULE_CRASHPAD_INFO_LINK_SIZE = 12
+const MODULE_CRASHPAD_INFO_MIN_SIZE = 28
+// list_annotations at +4 is a keyless legacy RVA list; nothing we can attribute.
+const MODULE_CRASHPAD_INFO_SIMPLE_ANNOTATIONS_OFFSET = 12
+const MODULE_CRASHPAD_INFO_ANNOTATION_OBJECTS_OFFSET = 20
+
+const ANNOTATION_RECORD_SIZE = 16
+const ANNOTATION_TYPE_STRING = 1
+
+/**
+ * Crashpad annotations we copy into a crash report.
+ *
+ * Why an allowlist: annotations are an open key space and some Chromium keys
+ * (`switch-N`, extension ids) carry command lines and user data. Diagnostic
+ * value here is concentrated in a handful of keys, so default-deny.
+ */
+const ANNOTATION_ALLOWLIST = new Set([
+  // The whole point of this module — Chromium's fatal log line.
+  'LOG_FATAL',
+  'abort-message',
+  // Which process died, independent of what Electron told us.
+  'ptype',
+  'ver',
+  'prod',
+  'plat',
+  'osarch',
+  'channel',
+  // Distinguishes a one-off from a crash loop.
+  'crash-loop-before',
+  'first-crash-time',
+  // The Linux SIGBUS/SIGSEGV reports are GPU-adjacent; driver identity matters.
+  'gpu-gl-vendor',
+  'gpu-gl-renderer',
+  'gpu-driver-version',
+  'gpu-vendor-id',
+  'gpu-device-id',
+  'gpu-generation-intel'
+])
+
+/** MinidumpSimpleStringDictionary: u32 count, then {key rva, value rva} pairs. */
+function readSimpleAnnotations(
+  view: MinidumpView,
+  location: LocationDescriptor | null,
+  into: Record<string, string>
+): void {
+  if (!location) {
+    return
+  }
+  const count = view.u32(location.rva)
+  if (count === null || count > MAX_ANNOTATIONS) {
+    return
+  }
+  for (let index = 0; index < count; index += 1) {
+    const entry = location.rva + 4 + index * 8
+    const keyRva = view.u32(entry)
+    const valueRva = view.u32(entry + 4)
+    if (keyRva === null || valueRva === null) {
+      return
+    }
+    const key = view.utf8String(keyRva, 256)
+    if (key === null || !ANNOTATION_ALLOWLIST.has(key)) {
+      continue
+    }
+    const value = view.utf8String(valueRva)
+    if (value !== null) {
+      into[key] = value
+    }
+  }
+}
+
+/** MinidumpAnnotationList: u32 count, then MinidumpAnnotation records. */
+function readAnnotationObjects(
+  view: MinidumpView,
+  location: LocationDescriptor | null,
+  into: Record<string, string>
+): void {
+  if (!location) {
+    return
+  }
+  const count = view.u32(location.rva)
+  if (count === null || count > MAX_ANNOTATIONS) {
+    return
+  }
+  for (let index = 0; index < count; index += 1) {
+    const entry = location.rva + 4 + index * ANNOTATION_RECORD_SIZE
+    const nameRva = view.u32(entry)
+    const type = view.u16(entry + 4)
+    const value = view.location(entry + 8)
+    if (nameRva === null || type === null) {
+      return
+    }
+    if (type !== ANNOTATION_TYPE_STRING || !value) {
+      continue
+    }
+    const name = view.utf8String(nameRva, 256)
+    if (name === null || !ANNOTATION_ALLOWLIST.has(name)) {
+      continue
+    }
+    const raw = view.bytes(value)
+    if (raw) {
+      // Annotation strings are not NUL-terminated; trim a trailing one anyway.
+      into[name] = raw.toString('utf8').replace(/\0+$/, '')
+    }
+  }
+}
+
+export function readCrashpadAnnotations(view: MinidumpView): Record<string, string> {
+  const annotations: Record<string, string> = {}
+  const info = findStream(view, STREAM_TYPE_CRASHPAD_INFO)
+  if (!info || info.size < CRASHPAD_INFO_MIN_SIZE) {
+    return annotations
+  }
+
+  readSimpleAnnotations(
+    view,
+    view.location(info.rva + CRASHPAD_INFO_SIMPLE_ANNOTATIONS_OFFSET),
+    annotations
+  )
+
+  const moduleList = view.location(info.rva + CRASHPAD_INFO_MODULE_LIST_OFFSET)
+  if (!moduleList) {
+    return annotations
+  }
+  const moduleCount = view.u32(moduleList.rva)
+  if (moduleCount === null || moduleCount > MAX_MODULES) {
+    return annotations
+  }
+  for (let index = 0; index < moduleCount; index += 1) {
+    const link = moduleList.rva + 4 + index * MODULE_CRASHPAD_INFO_LINK_SIZE
+    const moduleInfo = view.location(link + 4)
+    if (!moduleInfo || moduleInfo.size < MODULE_CRASHPAD_INFO_MIN_SIZE) {
+      continue
+    }
+    // Why: Chromium's crash keys land in annotation_objects on current
+    // Crashpad, but older modules still populate the two legacy shapes.
+    readSimpleAnnotations(
+      view,
+      view.location(moduleInfo.rva + MODULE_CRASHPAD_INFO_SIMPLE_ANNOTATIONS_OFFSET),
+      annotations
+    )
+    readAnnotationObjects(
+      view,
+      view.location(moduleInfo.rva + MODULE_CRASHPAD_INFO_ANNOTATION_OBJECTS_OFFSET),
+      annotations
+    )
+  }
+  return annotations
+}

--- a/src/main/crash-reporting/minidump-crashpad-annotations.ts
+++ b/src/main/crash-reporting/minidump-crashpad-annotations.ts
@@ -26,7 +26,7 @@ const MODULE_CRASHPAD_INFO_MIN_SIZE = 28
 const MODULE_CRASHPAD_INFO_SIMPLE_ANNOTATIONS_OFFSET = 12
 const MODULE_CRASHPAD_INFO_ANNOTATION_OBJECTS_OFFSET = 20
 
-const ANNOTATION_RECORD_SIZE = 16
+const ANNOTATION_RECORD_SIZE = 12
 const ANNOTATION_TYPE_STRING = 1
 
 /**
@@ -69,7 +69,7 @@ function readSimpleAnnotations(
     return
   }
   const count = view.u32(location.rva)
-  if (count === null || count > MAX_ANNOTATIONS) {
+  if (count === null || count > MAX_ANNOTATIONS || 4 + count * 8 > location.size) {
     return
   }
   for (let index = 0; index < count; index += 1) {
@@ -100,25 +100,29 @@ function readAnnotationObjects(
     return
   }
   const count = view.u32(location.rva)
-  if (count === null || count > MAX_ANNOTATIONS) {
+  if (
+    count === null ||
+    count > MAX_ANNOTATIONS ||
+    4 + count * ANNOTATION_RECORD_SIZE > location.size
+  ) {
     return
   }
   for (let index = 0; index < count; index += 1) {
     const entry = location.rva + 4 + index * ANNOTATION_RECORD_SIZE
     const nameRva = view.u32(entry)
     const type = view.u16(entry + 4)
-    const value = view.location(entry + 8)
-    if (nameRva === null || type === null) {
+    const valueRva = view.u32(entry + 8)
+    if (nameRva === null || type === null || valueRva === null) {
       return
     }
-    if (type !== ANNOTATION_TYPE_STRING || !value) {
+    if (type !== ANNOTATION_TYPE_STRING || valueRva === 0) {
       continue
     }
     const name = view.utf8String(nameRva, 256)
     if (name === null || !ANNOTATION_ALLOWLIST.has(name)) {
       continue
     }
-    const raw = view.bytes(value)
+    const raw = view.byteArray(valueRva)
     if (raw) {
       // Annotation strings are not NUL-terminated; trim a trailing one anyway.
       into[name] = raw.toString('utf8').replace(/\0+$/, '')

--- a/src/main/crash-reporting/minidump-crashpad-annotations.ts
+++ b/src/main/crash-reporting/minidump-crashpad-annotations.ts
@@ -1,8 +1,8 @@
 // Reads Chromium's crash keys out of a Crashpad minidump's annotation streams.
 //
-// Chromium writes the fatal log line into the `LOG_FATAL` annotation, which is
-// why a CHECK failure is nameable from the dump alone — no symbol server, no
-// minidump_stackwalk. Layouts are from Crashpad's minidump_extensions.h.
+// Some Chromium builds expose the fatal log line as `LOG_FATAL`; the signature
+// parser also handles builds that carry it only in captured process memory.
+// Layouts are from Crashpad's minidump_extensions.h.
 
 import {
   findStream,

--- a/src/main/crash-reporting/minidump-stream-reader.ts
+++ b/src/main/crash-reporting/minidump-stream-reader.ts
@@ -64,15 +64,7 @@ export class MinidumpView {
 
   /** MinidumpUTF8String: u32 byte length, then NUL-terminated UTF-8. */
   utf8String(rva: number, maxBytes = MAX_ANNOTATION_VALUE_BYTES): string | null {
-    const length = this.u32(rva)
-    if (length === null || length > maxBytes) {
-      return null
-    }
-    const start = rva + 4
-    if (start + length > this.buf.length) {
-      return null
-    }
-    return this.buf.toString('utf8', start, start + length)
+    return this.byteArray(rva, maxBytes)?.toString('utf8') ?? null
   }
 
   /** MINIDUMP_STRING: u32 byte length, then UTF-16LE. Used for module names. */
@@ -93,6 +85,15 @@ export class MinidumpView {
       return null
     }
     return this.buf.subarray(location.rva, location.rva + location.size)
+  }
+
+  /** MinidumpByteArray: u32 byte length, then the bytes. */
+  byteArray(rva: number, maxBytes = MAX_ANNOTATION_VALUE_BYTES): Buffer | null {
+    const length = this.u32(rva)
+    if (length === null || length > maxBytes) {
+      return null
+    }
+    return this.bytes({ size: length, rva: rva + 4 }, maxBytes)
   }
 }
 

--- a/src/main/crash-reporting/minidump-stream-reader.ts
+++ b/src/main/crash-reporting/minidump-stream-reader.ts
@@ -1,0 +1,127 @@
+// Bounds-checked primitives for walking a minidump.
+//
+// Split from minidump-crash-signature so the byte-level layout knowledge
+// (header, stream directory, MINIDUMP_LOCATION_DESCRIPTOR, the two string
+// encodings) stays separate from what Crashpad puts in those structures.
+//
+// Every accessor returns null past the end of the buffer: a truncated or
+// corrupt dump must degrade, not throw, or it takes crash reporting down with it.
+
+export const MINIDUMP_SIGNATURE = 0x504d444d // 'MDMP' little-endian
+export const MINIDUMP_HEADER_SIZE = 32
+const DIRECTORY_ENTRY_SIZE = 12
+// A dump claiming an absurd stream count is corrupt; cap before iterating.
+const MAX_STREAMS = 4_096
+export const MAX_ANNOTATION_VALUE_BYTES = 8_192
+// Shared cap: both the MINIDUMP_MODULE_LIST and Crashpad's per-module info list.
+export const MAX_MODULES = 1_024
+
+export type LocationDescriptor = {
+  readonly size: number
+  readonly rva: number
+}
+
+export class MinidumpView {
+  constructor(private readonly buf: Buffer) {}
+
+  get byteLength(): number {
+    return this.buf.length
+  }
+
+  u32(offset: number): number | null {
+    if (offset < 0 || offset + 4 > this.buf.length) {
+      return null
+    }
+    return this.buf.readUInt32LE(offset)
+  }
+
+  u16(offset: number): number | null {
+    if (offset < 0 || offset + 2 > this.buf.length) {
+      return null
+    }
+    return this.buf.readUInt16LE(offset)
+  }
+
+  u64(offset: number): bigint | null {
+    if (offset < 0 || offset + 8 > this.buf.length) {
+      return null
+    }
+    return this.buf.readBigUInt64LE(offset)
+  }
+
+  location(offset: number): LocationDescriptor | null {
+    const size = this.u32(offset)
+    const rva = this.u32(offset + 4)
+    if (size === null || rva === null) {
+      return null
+    }
+    // A zero rva means "absent", which is normal for optional sub-structures.
+    if (rva === 0 || rva >= this.buf.length) {
+      return null
+    }
+    return { size, rva }
+  }
+
+  /** MinidumpUTF8String: u32 byte length, then NUL-terminated UTF-8. */
+  utf8String(rva: number, maxBytes = MAX_ANNOTATION_VALUE_BYTES): string | null {
+    const length = this.u32(rva)
+    if (length === null || length > maxBytes) {
+      return null
+    }
+    const start = rva + 4
+    if (start + length > this.buf.length) {
+      return null
+    }
+    return this.buf.toString('utf8', start, start + length)
+  }
+
+  /** MINIDUMP_STRING: u32 byte length, then UTF-16LE. Used for module names. */
+  utf16String(rva: number, maxBytes = MAX_ANNOTATION_VALUE_BYTES): string | null {
+    const length = this.u32(rva)
+    if (length === null || length > maxBytes || length % 2 !== 0) {
+      return null
+    }
+    const start = rva + 4
+    if (start + length > this.buf.length) {
+      return null
+    }
+    return this.buf.toString('utf16le', start, start + length)
+  }
+
+  bytes(location: LocationDescriptor, maxBytes = MAX_ANNOTATION_VALUE_BYTES): Buffer | null {
+    if (location.size > maxBytes || location.rva + location.size > this.buf.length) {
+      return null
+    }
+    return this.buf.subarray(location.rva, location.rva + location.size)
+  }
+}
+
+export function isMinidump(dump: Buffer): boolean {
+  return dump.length >= MINIDUMP_HEADER_SIZE && dump.readUInt32LE(0) === MINIDUMP_SIGNATURE
+}
+
+/** Locates a stream by type in the header's directory, or null if absent. */
+export function findStream(view: MinidumpView, streamType: number): LocationDescriptor | null {
+  const streamCount = view.u32(8)
+  const directoryRva = view.u32(12)
+  if (streamCount === null || directoryRva === null || streamCount > MAX_STREAMS) {
+    return null
+  }
+  for (let index = 0; index < streamCount; index += 1) {
+    const entry = directoryRva + index * DIRECTORY_ENTRY_SIZE
+    const type = view.u32(entry)
+    if (type === null) {
+      return null
+    }
+    if (type !== streamType) {
+      continue
+    }
+    const size = view.u32(entry + 4)
+    const rva = view.u32(entry + 8)
+    if (size === null || rva === null || rva === 0 || rva >= view.byteLength) {
+      return null
+    }
+    return { size, rva }
+  }
+  return null
+}

--- a/src/main/crash-reporting/process-gone-recorder.test.ts
+++ b/src/main/crash-reporting/process-gone-recorder.test.ts
@@ -411,15 +411,17 @@ describe('minidump signature attachment', () => {
   it('names the failing CHECK on the report that only had an exit code', async () => {
     const record = vi.fn().mockResolvedValue({ id: 'report-1' })
     const attach = vi.fn().mockResolvedValue(null)
+    const capture = vi.fn().mockResolvedValue(capturedRendererCheck)
 
     recordProcessGoneCrash(
       { record, attachDetails: attach } as never,
       event({ exitCode: -2147483645 }),
       new ProcessGoneDedupe(),
-      async () => capturedRendererCheck
+      capture
     )
 
     await vi.waitFor(() => expect(attach).toHaveBeenCalledOnce())
+    expect(capture).toHaveBeenCalledWith(expect.any(Number), 'renderer')
     expect(attach).toHaveBeenCalledWith(
       'report-1',
       expect.objectContaining({
@@ -431,6 +433,49 @@ describe('minidump signature attachment', () => {
         minidumpBytes: 2_400_000
       })
     )
+  })
+
+  it('maps Electron child types to Crashpad process identities', async () => {
+    const record = vi.fn().mockResolvedValue({ id: 'report-1' })
+    const attach = vi.fn().mockResolvedValue(null)
+    const capture = vi.fn().mockResolvedValue(null)
+
+    recordProcessGoneCrash(
+      { record, attachDetails: attach } as never,
+      event({
+        source: 'child',
+        processType: 'Utility',
+        // A utility outside the recoverable-service allowlist still reports.
+        details: { type: 'Utility', serviceName: 'storage.mojom.StorageService' }
+      }),
+      new ProcessGoneDedupe(),
+      capture
+    )
+
+    await vi.waitFor(() => expect(attach).toHaveBeenCalledOnce())
+    expect(capture).toHaveBeenCalledWith(expect.any(Number), 'utility')
+  })
+
+  it('never looks for a dump for a GPU child, which is suppressed upstream', async () => {
+    const record = vi.fn().mockResolvedValue({ id: 'report-1' })
+    const capture = vi.fn().mockResolvedValue(null)
+
+    recordProcessGoneCrash(
+      { record, attachDetails: async () => null } as never,
+      event({ source: 'child', processType: 'GPU', details: { type: 'GPU' } }),
+      new ProcessGoneDedupe(),
+      capture
+    )
+
+    // Why: GPU exits are recoverable Chromium churn (process-gone-classification.ts),
+    // so they never become a report — and must not burn an 8s dump poll either.
+    await vi.waitFor(() =>
+      expect(getCrashBreadcrumbSnapshot()).toEqual(
+        expect.arrayContaining([expect.objectContaining({ name: 'process_gone_suppressed' })])
+      )
+    )
+    expect(record).not.toHaveBeenCalled()
+    expect(capture).not.toHaveBeenCalled()
   })
 
   it('exports the signature as a span so it is countable in the bundle', async () => {
@@ -456,6 +501,32 @@ describe('minidump signature attachment', () => {
         ])
       )
     )
+  })
+
+  it('sanitizes dump annotations before writing the diagnostic span', async () => {
+    const record = vi.fn().mockResolvedValue({ id: 'report-1' })
+    const attach = vi.fn().mockResolvedValue(null)
+    const captured = {
+      ...capturedRendererCheck,
+      signature: {
+        ...capturedRendererCheck.signature,
+        checkMessage:
+          '[FATAL:node.cc(123)] path=/Users/alice/private-project\nCheck failed: token=abc123'
+      }
+    }
+
+    recordProcessGoneCrash(
+      { record, attachDetails: attach } as never,
+      event(),
+      new ProcessGoneDedupe(),
+      async () => captured
+    )
+
+    await vi.waitFor(() => expect(attach).toHaveBeenCalledOnce())
+    expect(JSON.stringify(attach.mock.calls[0]?.[1])).not.toContain('alice')
+    expect(JSON.stringify(attach.mock.calls[0]?.[1])).not.toContain('abc123')
+    expect(JSON.stringify(sink.records)).not.toContain('alice')
+    expect(JSON.stringify(sink.records)).not.toContain('abc123')
   })
 
   it('marks the report when no dump was produced, so absence is visible', async () => {

--- a/src/main/crash-reporting/process-gone-recorder.test.ts
+++ b/src/main/crash-reporting/process-gone-recorder.test.ts
@@ -18,6 +18,10 @@ import { _resetTracerForTests, setActiveSink, type TracerSink } from '../observa
 
 type CapturingSink = TracerSink & { records: unknown[]; flushMock: ReturnType<typeof vi.fn> }
 
+/** Keeps tests off the real Crashpad directory; minidump pairing has its own suite. */
+const noMinidump = async () => null
+const attachDetails = async () => null
+
 function capturingSink(): CapturingSink {
   const records: unknown[] = []
   const flushMock = vi.fn()
@@ -243,7 +247,12 @@ describe('recordProcessGoneCrash', () => {
   it('persists a report and flushes the process-gone trace before recovery', async () => {
     const record = vi.fn().mockResolvedValue({ id: 'report-1' })
 
-    recordProcessGoneCrash({ record } as never, event(), new ProcessGoneDedupe())
+    recordProcessGoneCrash(
+      { record, attachDetails } as never,
+      event(),
+      new ProcessGoneDedupe(),
+      noMinidump
+    )
 
     await vi.waitFor(() => expect(record).toHaveBeenCalledOnce())
     expect(record).toHaveBeenCalledWith(
@@ -279,7 +288,12 @@ describe('recordProcessGoneCrash', () => {
     })
 
     expect(() =>
-      recordProcessGoneCrash({ record } as never, event(), new ProcessGoneDedupe())
+      recordProcessGoneCrash(
+        { record, attachDetails } as never,
+        event(),
+        new ProcessGoneDedupe(),
+        noMinidump
+      )
     ).not.toThrow()
     await vi.waitFor(() => expect(record).toHaveBeenCalledOnce())
   })
@@ -291,7 +305,12 @@ describe('recordProcessGoneCrash', () => {
     }
 
     expect(() =>
-      recordProcessGoneCrash({ record } as never, event(), new ProcessGoneDedupe())
+      recordProcessGoneCrash(
+        { record, attachDetails } as never,
+        event(),
+        new ProcessGoneDedupe(),
+        noMinidump
+      )
     ).not.toThrow()
     await vi.waitFor(() => expect(record).toHaveBeenCalledOnce())
   })
@@ -304,7 +323,12 @@ describe('recordProcessGoneCrash', () => {
     const record = vi.fn().mockRejectedValue(persistError)
     vi.spyOn(console, 'error').mockImplementation(() => {})
 
-    recordProcessGoneCrash({ record } as never, event(), new ProcessGoneDedupe())
+    recordProcessGoneCrash(
+      { record, attachDetails } as never,
+      event(),
+      new ProcessGoneDedupe(),
+      noMinidump
+    )
 
     await vi.waitFor(() => {
       expect(getCrashBreadcrumbSnapshot()).toEqual(
@@ -331,7 +355,12 @@ describe('recordProcessGoneCrash', () => {
     const record = vi.fn().mockRejectedValue(null)
     vi.spyOn(console, 'error').mockImplementation(() => {})
 
-    recordProcessGoneCrash({ record } as never, event(), new ProcessGoneDedupe())
+    recordProcessGoneCrash(
+      { record, attachDetails } as never,
+      event(),
+      new ProcessGoneDedupe(),
+      noMinidump
+    )
 
     await vi.waitFor(() =>
       expect(getCrashBreadcrumbSnapshot()).toEqual(
@@ -353,14 +382,120 @@ describe('recordProcessGoneCrash', () => {
     const dedupe = new ProcessGoneDedupe()
     vi.spyOn(console, 'error').mockImplementation(() => {})
 
-    recordProcessGoneCrash({ record } as never, event(), dedupe)
+    recordProcessGoneCrash({ record, attachDetails } as never, event(), dedupe, noMinidump)
     await vi.waitFor(() =>
       expect(getCrashBreadcrumbSnapshot()).toEqual(
         expect.arrayContaining([expect.objectContaining({ name: 'crash_report_persist_failed' })])
       )
     )
-    recordProcessGoneCrash({ record } as never, event(), dedupe)
+    recordProcessGoneCrash({ record, attachDetails } as never, event(), dedupe, noMinidump)
 
     await vi.waitFor(() => expect(record).toHaveBeenCalledTimes(2))
+  })
+})
+
+describe('minidump signature attachment', () => {
+  const capturedRendererCheck = {
+    filePath: '/dumps/reports/abc.dmp',
+    sizeBytes: 2_400_000,
+    signature: {
+      checkMessage: '[0815/143022:FATAL:render_frame_impl.cc(4821)] Check failed: !is_detached_.',
+      checkFile: 'render_frame_impl.cc',
+      checkLine: 4821,
+      processType: 'renderer',
+      exceptionCode: 0x80000003,
+      annotations: {}
+    }
+  }
+
+  it('names the failing CHECK on the report that only had an exit code', async () => {
+    const record = vi.fn().mockResolvedValue({ id: 'report-1' })
+    const attach = vi.fn().mockResolvedValue(null)
+
+    recordProcessGoneCrash(
+      { record, attachDetails: attach } as never,
+      event({ exitCode: -2147483645 }),
+      new ProcessGoneDedupe(),
+      async () => capturedRendererCheck
+    )
+
+    await vi.waitFor(() => expect(attach).toHaveBeenCalledOnce())
+    expect(attach).toHaveBeenCalledWith(
+      'report-1',
+      expect.objectContaining({
+        minidumpStatus: 'captured',
+        minidumpCheckMessage: capturedRendererCheck.signature.checkMessage,
+        minidumpCheckFile: 'render_frame_impl.cc',
+        minidumpCheckLine: 4821,
+        minidumpExceptionCode: '0x80000003',
+        minidumpBytes: 2_400_000
+      })
+    )
+  })
+
+  it('exports the signature as a span so it is countable in the bundle', async () => {
+    const record = vi.fn().mockResolvedValue({ id: 'report-1' })
+
+    recordProcessGoneCrash(
+      { record, attachDetails: async () => null } as never,
+      event(),
+      new ProcessGoneDedupe(),
+      async () => capturedRendererCheck
+    )
+
+    await vi.waitFor(() =>
+      expect(sink.records).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'electron.minidump_signature',
+            attributes: expect.objectContaining({
+              'crash.report_id': 'report-1',
+              minidumpCheckFile: 'render_frame_impl.cc'
+            })
+          })
+        ])
+      )
+    )
+  })
+
+  it('marks the report when no dump was produced, so absence is visible', async () => {
+    const record = vi.fn().mockResolvedValue({ id: 'report-1' })
+    const attach = vi.fn().mockResolvedValue(null)
+
+    recordProcessGoneCrash(
+      { record, attachDetails: attach } as never,
+      event(),
+      new ProcessGoneDedupe(),
+      noMinidump
+    )
+
+    await vi.waitFor(() =>
+      expect(attach).toHaveBeenCalledWith('report-1', { minidumpStatus: 'absent' })
+    )
+  })
+
+  it('keeps the persisted report when minidump pairing throws', async () => {
+    const record = vi.fn().mockResolvedValue({ id: 'report-1' })
+    const dedupe = new ProcessGoneDedupe()
+    const releaseSpy = vi.spyOn(dedupe, 'release')
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    recordProcessGoneCrash({ record, attachDetails } as never, event(), dedupe, async () => {
+      throw new Error('crashpad directory unreadable')
+    })
+
+    await vi.waitFor(() =>
+      expect(getCrashBreadcrumbSnapshot()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'minidump_signature_attach_failed' })
+        ])
+      )
+    )
+    // Why: the report did persist; releasing the claim would let the same crash
+    // be recorded twice on the next process-gone event in the burst.
+    expect(releaseSpy).not.toHaveBeenCalled()
+    expect(getCrashBreadcrumbSnapshot()).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: 'crash_report_persist_failed' })])
+    )
   })
 })

--- a/src/main/crash-reporting/process-gone-recorder.ts
+++ b/src/main/crash-reporting/process-gone-recorder.ts
@@ -2,6 +2,7 @@ import os from 'node:os'
 import { app } from 'electron'
 import {
   isCrashReportReason,
+  sanitizeCrashReportDetails,
   sanitizeCrashReportString,
   type CrashReportBreadcrumbData
 } from '../../shared/crash-reporting'
@@ -42,7 +43,25 @@ export type ProcessGoneCrashEvent = {
 type CrashReportRecorderStore = Pick<CrashReportStore, 'record' | 'attachDetails'>
 
 /** Injectable so tests can drive the pairing without a Crashpad handler. */
-export type MinidumpCapture = (crashedAtMs: number) => Promise<CapturedMinidump | null>
+export type MinidumpCapture = (
+  crashedAtMs: number,
+  expectedProcessType: string
+) => Promise<CapturedMinidump | null>
+
+const CHILD_CRASHPAD_PROCESS_TYPES: Readonly<Record<string, string>> = {
+  gpu: 'gpu-process',
+  utility: 'utility',
+  zygote: 'zygote'
+}
+
+function expectedCrashpadProcessType(event: ProcessGoneCrashEvent): string | null {
+  return event.source === 'renderer'
+    ? 'renderer'
+    : (CHILD_CRASHPAD_PROCESS_TYPES[event.processType.trim().toLowerCase()] ?? null)
+}
+
+const captureProcessMinidump: MinidumpCapture = (crashedAtMs, expectedProcessType) =>
+  captureMinidumpSignature(crashedAtMs, { expectedProcessType })
 
 // Why: the coalesce map prunes every key against the calling window, so a shorter
 // one here would weaken the other 30s coalescers. Stay uniform with them.
@@ -91,14 +110,15 @@ async function attachMinidumpSignature(
   store: CrashReportRecorderStore,
   reportId: string,
   crashedAtMs: number,
+  expectedProcessType: string | null,
   capture: MinidumpCapture
 ): Promise<void> {
-  const captured = await capture(crashedAtMs)
+  const captured = expectedProcessType ? await capture(crashedAtMs, expectedProcessType) : null
   if (!captured) {
     await store.attachDetails(reportId, { minidumpStatus: 'absent' })
     return
   }
-  const signatureDetails = minidumpSignatureDetails(captured.signature)
+  const signatureDetails = sanitizeCrashReportDetails(minidumpSignatureDetails(captured.signature))
   await store.attachDetails(reportId, {
     ...signatureDetails,
     minidumpStatus: 'captured',
@@ -122,7 +142,7 @@ export function recordProcessGoneCrash(
   store: CrashReportRecorderStore | null,
   event: ProcessGoneCrashEvent,
   dedupe: ProcessGoneDedupe = processGoneDedupe,
-  capture: MinidumpCapture = captureMinidumpSignature
+  capture: MinidumpCapture = captureProcessMinidump
 ): void {
   if (!isCrashReportReason(event.reason)) {
     return
@@ -197,6 +217,7 @@ export function recordProcessGoneCrash(
   flushActiveSink()
 
   const crashedAtMs = Date.now()
+  const expectedProcessType = expectedCrashpadProcessType(event)
   void store
     .record({
       source: event.source,
@@ -215,7 +236,13 @@ export function recordProcessGoneCrash(
     .then((report) => {
       // Why: kept off the returned chain so a minidump failure can never reach
       // the persist-failure handler below and release a claim that did persist.
-      void attachMinidumpSignature(store, report.id, crashedAtMs, capture).catch((error) => {
+      void attachMinidumpSignature(
+        store,
+        report.id,
+        crashedAtMs,
+        expectedProcessType,
+        capture
+      ).catch((error) => {
         console.error('[crash-reporting] Failed to attach minidump signature:', error)
         recordDurableCrashBreadcrumb(
           'minidump_signature_attach_failed',

--- a/src/main/crash-reporting/process-gone-recorder.ts
+++ b/src/main/crash-reporting/process-gone-recorder.ts
@@ -26,6 +26,8 @@ import {
   type ProcessGoneDedupe
 } from './process-gone-dedupe'
 import { getMainProcessLifecycleIdentity } from './main-process-lifecycle-identity'
+import { captureMinidumpSignature, type CapturedMinidump } from './crashpad-capture'
+import { minidumpSignatureDetails } from './minidump-crash-signature'
 import { flushActiveSink, startSpan } from '../observability/tracer'
 
 export type ProcessGoneCrashEvent = {
@@ -37,7 +39,10 @@ export type ProcessGoneCrashEvent = {
   details: Record<string, unknown>
 }
 
-type CrashReportRecorderStore = Pick<CrashReportStore, 'record'>
+type CrashReportRecorderStore = Pick<CrashReportStore, 'record' | 'attachDetails'>
+
+/** Injectable so tests can drive the pairing without a Crashpad handler. */
+export type MinidumpCapture = (crashedAtMs: number) => Promise<CapturedMinidump | null>
 
 // Why: the coalesce map prunes every key against the calling window, so a shorter
 // one here would weaken the other 30s coalescers. Stay uniform with them.
@@ -75,10 +80,49 @@ function persistFailureData(event: ProcessGoneCrashEvent, error: unknown) {
   }
 }
 
+/**
+ * Folds the Crashpad signature into a report that is already on disk.
+ *
+ * Why separate from the record write: an exit code of 0x80000003 only says "a
+ * CHECK fired"; the name, file and line live in the dump, which Crashpad is
+ * still writing when process-gone fires. Waiting inline would stall recovery.
+ */
+async function attachMinidumpSignature(
+  store: CrashReportRecorderStore,
+  reportId: string,
+  crashedAtMs: number,
+  capture: MinidumpCapture
+): Promise<void> {
+  const captured = await capture(crashedAtMs)
+  if (!captured) {
+    await store.attachDetails(reportId, { minidumpStatus: 'absent' })
+    return
+  }
+  const signatureDetails = minidumpSignatureDetails(captured.signature)
+  await store.attachDetails(reportId, {
+    ...signatureDetails,
+    minidumpStatus: 'captured',
+    minidumpPath: captured.filePath,
+    minidumpBytes: captured.sizeBytes
+  })
+  // Why: the crash-report record is capped at 5 entries and is user-facing;
+  // the span is what makes the signature countable in the diagnostics bundle.
+  const span = startSpan('electron.minidump_signature', {
+    attributes: {
+      'crash.report_id': reportId,
+      'crash.minidump_bytes': captured.sizeBytes,
+      ...signatureDetails
+    }
+  })
+  span.end()
+  flushActiveSink()
+}
+
 export function recordProcessGoneCrash(
   store: CrashReportRecorderStore | null,
   event: ProcessGoneCrashEvent,
-  dedupe: ProcessGoneDedupe = processGoneDedupe
+  dedupe: ProcessGoneDedupe = processGoneDedupe,
+  capture: MinidumpCapture = captureMinidumpSignature
 ): void {
   if (!isCrashReportReason(event.reason)) {
     return
@@ -152,6 +196,7 @@ export function recordProcessGoneCrash(
   )
   flushActiveSink()
 
+  const crashedAtMs = Date.now()
   void store
     .record({
       source: event.source,
@@ -166,6 +211,18 @@ export function recordProcessGoneCrash(
       chromeVersion: process.versions.chrome ?? 'unknown',
       details: crashDetails,
       breadcrumbs
+    })
+    .then((report) => {
+      // Why: kept off the returned chain so a minidump failure can never reach
+      // the persist-failure handler below and release a claim that did persist.
+      void attachMinidumpSignature(store, report.id, crashedAtMs, capture).catch((error) => {
+        console.error('[crash-reporting] Failed to attach minidump signature:', error)
+        recordDurableCrashBreadcrumb(
+          'minidump_signature_attach_failed',
+          processGoneBreadcrumbData(event),
+          error instanceof Error ? error.message : String(error)
+        )
+      })
     })
     .catch((error) => {
       dedupe.release(claim)

--- a/src/main/crash-reporting/process-gone-recorder.ts
+++ b/src/main/crash-reporting/process-gone-recorder.ts
@@ -27,7 +27,11 @@ import {
   type ProcessGoneDedupe
 } from './process-gone-dedupe'
 import { getMainProcessLifecycleIdentity } from './main-process-lifecycle-identity'
-import { captureMinidumpSignature, type CapturedMinidump } from './crashpad-capture'
+import {
+  captureMinidumpSignature,
+  scheduleCrashpadDumpPrune,
+  type CapturedMinidump
+} from './crashpad-capture'
 import { minidumpSignatureDetails } from './minidump-crash-signature'
 import { flushActiveSink, startSpan } from '../observability/tracer'
 
@@ -147,6 +151,9 @@ export function recordProcessGoneCrash(
   if (!isCrashReportReason(event.reason)) {
     return
   }
+  // Crashpad captures suppressed service crashes too; keep a crash loop from
+  // filling the disk even when no user-facing report is created.
+  scheduleCrashpadDumpPrune()
   if (
     !shouldRecordProcessGoneCrash({
       source: event.source,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -317,6 +317,7 @@ import {
   type ExpectedTeardownScope
 } from './crash-reporting/process-gone-classification'
 import { recordProcessGoneCrash as recordProcessGoneCrashEvent } from './crash-reporting/process-gone-recorder'
+import { startCrashpadCapture } from './crash-reporting/crashpad-capture'
 import { resolveExpectedTeardownScope } from './crash-reporting/expected-teardown-state'
 import {
   advanceSyntheticTitleSpinnerEntries,
@@ -843,6 +844,9 @@ if (hasSingleInstanceLock) {
   initClaudeUsagePath()
   initCodexUsagePath()
   initOpenCodeUsagePath()
+  // Why: must precede app.whenReady() so Crashpad is installed before the
+  // first renderer spawns; a CHECK before this point is still exit-code-only.
+  startCrashpadCapture()
   crashReports = CrashReportStore.fromUserData()
   recordCrashBreadcrumb('app_started', {
     packaged: app.isPackaged,

--- a/src/shared/crash-report-signature-lines.ts
+++ b/src/shared/crash-report-signature-lines.ts
@@ -1,0 +1,23 @@
+// Type-only, so this erases at compile time and creates no import cycle.
+import type { CrashReportDetailValue } from './crash-reporting'
+
+/**
+ * Promotes the Crashpad-derived fields out of the details blob.
+ *
+ * Why: for a Chromium CHECK the exit code is only 0x80000003 (STATUS_BREAKPOINT),
+ * so the fatal log line is the actual diagnosis and must not be buried in a
+ * detail list the reader scrolls past.
+ */
+export function appendMinidumpSignatureLines(
+  lines: string[],
+  details: Record<string, CrashReportDetailValue>
+): void {
+  if (typeof details.minidumpCheckMessage === 'string') {
+    lines.push(`Check failure: ${details.minidumpCheckMessage}`)
+  }
+  if (typeof details.minidumpFaultingModule === 'string') {
+    const offset = details.minidumpFaultingModuleOffset
+    const suffix = typeof offset === 'string' ? `+${offset}` : ''
+    lines.push(`Faulting module: ${details.minidumpFaultingModule}${suffix}`)
+  }
+}

--- a/src/shared/crash-reporting.test.ts
+++ b/src/shared/crash-reporting.test.ts
@@ -59,6 +59,17 @@ describe('crash-reporting shared helpers', () => {
     )
   })
 
+  it('preserves the failing CHECK at the end of a long fatal line', () => {
+    const fatalLine = `[FATAL:node.cc(123)] ${'context '.repeat(80)}Check failed: !is_detached_.`
+
+    const sanitized = String(
+      sanitizeCrashReportDetails({ minidumpCheckMessage: fatalLine }).minidumpCheckMessage
+    )
+
+    expect(sanitized.length).toBeGreaterThan(240)
+    expect(sanitized).toContain('Check failed: !is_detached_.')
+  })
+
   it('sanitizes breadcrumb data and caps to the latest thirty entries', () => {
     const breadcrumbs = sanitizeCrashReportBreadcrumbs(
       Array.from({ length: 32 }, (_, index) => ({

--- a/src/shared/crash-reporting.test.ts
+++ b/src/shared/crash-reporting.test.ts
@@ -133,6 +133,41 @@ describe('crash-reporting shared helpers', () => {
     expect(text).not.toContain('\nURL:')
   })
 
+  it('names the failing CHECK above the details block', () => {
+    const fatalLine =
+      '[8104:1234:0815/143022.123456:FATAL:render_frame_impl.cc(4821)] Check failed: !is_detached_.'
+    const report: CrashReportRecord = {
+      id: 'crash-check',
+      createdAt: '2026-08-15T01:00:00.000Z',
+      status: 'pending',
+      source: 'renderer',
+      processType: 'renderer',
+      reason: 'crashed',
+      // The bare STATUS_BREAKPOINT this ticket is about.
+      exitCode: -2147483645,
+      appVersion: '1.4.183',
+      platform: 'win32',
+      osRelease: '10.0.19045',
+      arch: 'x64',
+      electronVersion: '43.1.0',
+      chromeVersion: '150.0.7871.47',
+      details: {
+        minidumpCheckMessage: fatalLine,
+        minidumpFaultingModule: 'chrome_elf.dll',
+        minidumpFaultingModuleOffset: '0x1234'
+      },
+      breadcrumbs: []
+    }
+
+    const text = formatCrashReportText(report)
+
+    // Why: Chromium logs the source basename, not a path, so the fatal line has
+    // to survive path redaction intact or the check is unnameable again.
+    expect(text).toContain(`Check failure: ${fatalLine}`)
+    expect(text).toContain('Faulting module: chrome_elf.dll+0x1234')
+    expect(text.indexOf('Check failure:')).toBeLessThan(text.indexOf('Details:'))
+  })
+
   it('caps formatted reports to the crash endpoint limit', () => {
     const report: CrashReportRecord = {
       id: 'crash-oversized',

--- a/src/shared/crash-reporting.ts
+++ b/src/shared/crash-reporting.ts
@@ -2,6 +2,7 @@ import {
   appendDiagnosticBundleLines,
   type CrashReportDiagnosticBundle
 } from './crash-reporting-diagnostic-bundle'
+import { appendMinidumpSignatureLines } from './crash-report-signature-lines'
 
 export type { CrashReportDiagnosticBundle } from './crash-reporting-diagnostic-bundle'
 
@@ -251,6 +252,7 @@ export function formatCrashReportText(
     `Chrome: ${report.chromeVersion}`
   ]
 
+  appendMinidumpSignatureLines(lines, report.details)
   appendDiagnosticBundleLines(lines, diagnosticBundle, sanitizeCrashReportString)
 
   const details = Object.entries(report.details)

--- a/src/shared/crash-reporting.ts
+++ b/src/shared/crash-reporting.ts
@@ -185,7 +185,7 @@ export function sanitizeCrashReportString(
 
 function maxDetailStringLengthForKey(key: string): number {
   const normalizedKey = key.replace(/([a-z0-9])([A-Z])/g, '$1_$2')
-  return /(?:^|_)(?:stack|component_stack|error_stack)$/i.test(normalizedKey)
+  return /(?:^|_)(?:stack|component_stack|error_stack|minidump_check_message)$/i.test(normalizedKey)
     ? MAX_STACK_DETAIL_LENGTH
     : MAX_STRING_DETAIL_LENGTH
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | +945 | −7 | +938 |
| Prod | 9 | +1000 | −3 | +997 |

<!-- /orca-pr-loc -->

Closes STA-4469.

## Problem

40% of renderer deaths in the 2026-08-15 crash sweep report exit `-2147483645` = `0x80000003` = `STATUS_BREAKPOINT` — a Chromium `CHECK`/`DCHECK`. We captured only the exit code, so the cause was *structurally* unknowable rather than hard to find.

The ticket guessed `crashReporter` was already partially wired and the gap was upload + retention. It isn't wired at all — zero hits for `crashReporter` / `crashpad` / `minidump` anywhere in the tree. This is capture work.

## Approach

Start Crashpad before `whenReady`, then lift the **text** signature out of the dump. Chromium stores the fatal log line in the `LOG_FATAL` Crashpad annotation, so the check name, file and line are recoverable **without symbols and without `minidump_stackwalk`**.

**Upload stays off** (`uploadToServer: false`). The only transport we have (`observability/diagnostic-bundle-upload.ts`) is a user-initiated **4 MiB text** bundle; raw dumps are multi-MB binary containing process memory. Dumps stay on disk; only the signature rides the existing crash-report flow.

## Changes

| File | Role |
|---|---|
| `minidump-stream-reader.ts` | Bounds-checked view over header + stream directory. Every accessor returns null past the end, so a truncated dump degrades instead of taking crash reporting down. |
| `minidump-crashpad-annotations.ts` | Reads Chromium crash keys from both the simple-string-dictionary and annotation-object layouts. **Allowlisted, default-deny** — `switch-N` carries command lines. |
| `minidump-crash-signature.ts` | `LOG_FATAL` → file/line; exception code/address; faulting module resolved against the module list. |
| `crashpad-capture.ts` | Starts the handler; polls for the dump, which races `process-gone` delivery (Crashpad writes from the handler process, Electron delivers on the main thread). |
| `process-gone-recorder.ts` | Attaches the signature to the already-persisted report; emits an `electron.minidump_signature` span so it's countable in the bundle. |
| `crash-report-store.ts` | `attachDetails` merges late-arriving details. |
| `crash-reporting.ts` | Promotes the check above the `Details:` block. |

## Two things worth a reviewer's eye

**A defect caught during implementation.** An error on the attach path fell into the outer `.catch`, which released the dedupe claim for a report that *had* persisted — letting the same crash record twice during a burst. Fixed, with a regression test pinning it.

**Chromium's `LogMessage::Init` logs the source basename, not a path.** That's load-bearing: crash-report path redaction would otherwise rewrite the fatal line to `[redacted-path]` and the check would be unnameable again. Tested explicitly.

`minidump-crash-signature.ts` and `crash-reporting.ts` both crossed the 300-line `max-lines` cap; split rather than suppressed, per AGENTS.md.

## Verification

- `oxlint` clean, `tsc --noEmit` clean
- **153 crash-reporting tests pass** (44 new)
- Parser tests build **real Crashpad-layout minidumps byte by byte** — not mocks — covering LOG_FATAL, the simple dictionary, allowlist rejection, faulting-module resolution, non-minidump input, truncation, and corrupt stream counts
- Startup suite (33 files) passes with the new pre-ready call
- `check:max-lines-ratchet` and `check:reliability-gates` pass

## Not covered

The DoD's *"re-test against the two `STATUS_BREAKPOINT` reports"* needs a Windows build with this shipped — existing dumps don't exist to test against.