### PR TITLE
fix(tab-bar): exclude disabled agents from new-tab search

### DIFF
--- a/src/renderer/src/components/tab-bar/tab-agent-launch-options.test.ts
+++ b/src/renderer/src/components/tab-bar/tab-agent-launch-options.test.ts
@@ -14,6 +14,30 @@ describe('tab agent launch options', () => {
     ])
   })
 
+  it('excludes disabled agents from the launch list', () => {
+    expect(orderTabLaunchAgents(null, ['claude', 'codex', 'openclaude'], ['openclaude'])).toEqual([
+      'claude',
+      'codex'
+    ])
+  })
+
+  it('drops a disabled default agent instead of surfacing it first', () => {
+    const ordered = orderTabLaunchAgents(
+      'openclaude',
+      ['claude', 'codex', 'openclaude'],
+      ['openclaude']
+    )
+    expect(ordered).not.toContain('openclaude')
+    expect(ordered).toEqual(['claude', 'codex'])
+  })
+
+  it('keeps a disabled agent out of new-tab search results', () => {
+    const options = buildTabAgentLaunchOptions(
+      orderTabLaunchAgents('codex', ['claude', 'codex', 'openclaude'], ['openclaude'])
+    )
+    expect(findMatchingTabAgentLaunchOptions('open', options).map((o) => o.agent)).toEqual([])
+  })
+
   it('matches detected agents by id, label, command, and command override', () => {
     const options = buildTabAgentLaunchOptions(['claude', 'codex', 'antigravity'], {
       codex: 'codex-beta'

--- a/src/renderer/src/components/tab-bar/tab-agent-launch-options.ts
+++ b/src/renderer/src/components/tab-bar/tab-agent-launch-options.ts
@@ -1,4 +1,5 @@
 import { getAgentCatalog } from '@/lib/agent-catalog'
+import { filterEnabledTuiAgents } from '../../../../shared/tui-agent-selection'
 import { normalizeMatchQuery, tokenizeMatchValue } from './query-token-match'
 import type { TuiAgent } from '../../../../shared/tui-agent'
 
@@ -22,10 +23,12 @@ function getCatalogEntry(agent: TuiAgent): { id: TuiAgent; label: string; cmd: s
 
 export function orderTabLaunchAgents(
   defaultAgent: TuiAgent | 'blank' | null | undefined,
-  detected: readonly TuiAgent[]
+  detected: readonly TuiAgent[],
+  disabled?: Iterable<unknown> | null
 ): TuiAgent[] {
+  const enabledDetected = filterEnabledTuiAgents(detected, disabled)
   const inCatalogOrder = getAgentCatalog()
-    .filter((entry) => detected.includes(entry.id))
+    .filter((entry) => enabledDetected.includes(entry.id))
     .map((entry) => entry.id)
   if (!defaultAgent || defaultAgent === 'blank' || !inCatalogOrder.includes(defaultAgent)) {
     return inCatalogOrder

--- a/src/renderer/src/components/tab-bar/use-tab-bar-runtime-model.ts
+++ b/src/renderer/src/components/tab-bar/use-tab-bar-runtime-model.ts
@@ -27,6 +27,7 @@ import {
 } from './tab-agent-types-by-tab-id'
 import { buildTabAgentLaunchOptions, orderTabLaunchAgents } from './tab-agent-launch-options'
 import type { TabAgentLaunchOption } from './tab-agent-launch-options'
+import { DEFAULT_DISABLED_TUI_AGENTS } from '../../../../shared/tui-agent-selection'
 import { shouldShowWindowsShellMenu } from './windows-shell-menu-visibility'
 import { createUnifiedTabLookup } from './tab-bar-item-model'
 import { getClientCreationActionPolicy } from '@/lib/client-creation-action-policy'
@@ -141,6 +142,9 @@ export function useTabBarRuntimeModel({
     return s.sshConnectionStates.get(worktreeConnectionId)?.remotePlatform ?? null
   })
   const defaultAgent = useAppStore((s) => s.settings?.defaultTuiAgent)
+  const disabledTuiAgents = useAppStore(
+    (s) => s.settings?.disabledTuiAgents ?? DEFAULT_DISABLED_TUI_AGENTS
+  )
   const agentCmdOverrides = useAppStore(
     (s) => s.settings?.agentCmdOverrides ?? EMPTY_AGENT_CMD_OVERRIDES
   )
@@ -149,10 +153,10 @@ export function useTabBarRuntimeModel({
   const agentLaunchOptions = useMemo(
     () =>
       buildTabAgentLaunchOptions(
-        orderTabLaunchAgents(defaultAgent, detectedIds ?? []),
+        orderTabLaunchAgents(defaultAgent, detectedIds ?? [], disabledTuiAgents),
         agentCmdOverrides
       ),
-    [agentCmdOverrides, defaultAgent, detectedIds]
+    [agentCmdOverrides, defaultAgent, detectedIds, disabledTuiAgents]
   )
   const isWebClient = (globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ === true
   const windowsTerminalCapabilityOwnerKey = getWindowsTerminalCapabilityOwnerKey(


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | +24 | 0 | +24 |
| Prod | 2 | +11 | −4 | +7 |

<!-- /orca-pr-loc -->

## ELI5

You turned an agent off in Settings → Agents, but typing its name in the new-tab search still listed it (e.g. disable OpenClaude, type "open", and OpenClaude still shows up). Now disabled agents are filtered out of the new-tab search too, matching every other agent picker in Orca.

## What Changed

- `tab-bar/tab-agent-launch-options.ts`: `orderTabLaunchAgents` gained an optional `disabled` parameter and now filters the detected set through the shared `filterEnabledTuiAgents`. A disabled agent is never offered, and a disabled `defaultTuiAgent` is not promoted to the top of the list.
- `tab-bar/use-tab-bar-runtime-model.ts`: reads `settings.disabledTuiAgents` (falling back to `DEFAULT_DISABLED_TUI_AGENTS`) and passes it when building the `agentLaunchOptions` that power the new-tab agent search.

## Why

The new-tab search was the only agent surface ignoring `disabledTuiAgents`. `QuickLaunchButton`, the mobile new-tab agent options, the source-control agent dialog, and the dashboard all already filter disabled agents — this closes the last gap so the setting behaves consistently everywhere.

## Linked Issue

Reported in-app (no GitHub issue filed yet). The report: "disabled OpenClaude in settings but it still shows up in new-tab search when typing 'open'."

## Visual Proof

`disabledTuiAgents: ['openclaude']`, new-tab search typed "open".

| Before (bug: OpenClaude listed) | After (OpenClaude gone, OpenCode still matches) |
|---|---|
| ![before-fix-openclaude.png](https://github.com/user-attachments/assets/2b62c1f3-20a7-411f-bf9f-7633623545db) | ![after-fix-openclaude.png](https://github.com/user-attachments/assets/7fe4c62f-8196-4e2e-83b7-f1dd878025f6) |

Also verified typing "opencl" no longer surfaces OpenClaude after the fix.

## Testing

- Reproduced in the running Electron dev app (fresh profile): added a repo, disabled `openclaude` via Settings, opened New Tab, typed "open" → **Before** screenshot shows "Launch agent · OpenClaude" (bug). Restored the fix (HMR) → **After** screenshot shows only "Launch agent · OpenCode" and "Search Google". Same result for the "opencl" prefix.
- Added unit tests in `tab-agent-launch-options.test.ts`: disabled-agent exclusion, disabled-default not promoted, and disabled agents kept out of search results.
- `npx vitest run ... tab-bar/` + `tui-agent-selection`: 49 files / 380 tests pass. `oxlint` clean on changed files. Typecheck shows no errors in changed files (the 16 pre-existing TS6307 project-layout errors are unchanged from base).

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

## AI Disclosure

Internal contributor — not applicable.

## Review

Cross-platform: renderer-only change using the existing shared `filterEnabledTuiAgents` (already used on macOS/Linux/Windows/mobile). SSH/remote: the tab-bar runtime model reads the same `settings.disabledTuiAgents` for SSH/runtime worktrees, so disabled agents stay hidden on remote hosts too. No wire/RPC changes, no backwards-compatibility impact.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots attached for UI changes
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `pnpm lint`, `pnpm test`, and typecheck pass locally (full `pnpm build` not run)

## Author

- X / Twitter: @nwparker