### PR TITLE
fix(agent-hooks): make the Windows managed hook survive Claude-hooks-compat consumers

### DIFF
--- a/config/tsconfig.cli.json
+++ b/config/tsconfig.cli.json
@@ -14,6 +14,7 @@
     "../src/main/agent-hooks/managed-agent-hook-registry.ts",
     "../src/main/agent-hooks/managed-hook-script-refresh.ts",
     "../src/main/agent-hooks/runtime-home-hook-command.ts",
+    "../src/main/agent-hooks/windows-powershell-hook-launcher.ts",
     "../src/main/amp/agent-status-plugin-source.ts",
     "../src/main/amp/hook-service.ts",
     "../src/main/amp/managed-plugin-install-status.ts",

--- a/src/main/agent-hooks/installer-utils.test.ts
+++ b/src/main/agent-hooks/installer-utils.test.ts
@@ -71,7 +71,10 @@ describe('readHooksJsonWithRaw', () => {
     for (const contents of [`\uFEFF\uFEFF${body}`, ` \uFEFF${body}`, `{\uFEFF"hooks": {}}`]) {
       writeFileSync(configPath, contents, 'utf-8')
 
-      expect(readHooksJsonWithRaw(configPath)).toEqual({ raw: contents, config: null })
+      expect(readHooksJsonWithRaw(configPath)).toEqual({
+        raw: contents,
+        config: null
+      })
     }
   })
 
@@ -82,7 +85,10 @@ describe('readHooksJsonWithRaw', () => {
   it('keeps the raw bytes when the contents are not a JSON object', () => {
     writeFileSync(configPath, 'not json\n', 'utf-8')
 
-    expect(readHooksJsonWithRaw(configPath)).toEqual({ raw: 'not json\n', config: null })
+    expect(readHooksJsonWithRaw(configPath)).toEqual({
+      raw: 'not json\n',
+      config: null
+    })
   })
 })
 
@@ -95,7 +101,9 @@ describe('writeHooksJson', () => {
     writeHooksJson(configPath, { hooks: { Stop: [] } })
 
     expect(lstatSync(configPath).isSymbolicLink()).toBe(true)
-    expect(JSON.parse(readFileSync(targetPath, 'utf-8'))).toEqual({ hooks: { Stop: [] } })
+    expect(JSON.parse(readFileSync(targetPath, 'utf-8'))).toEqual({
+      hooks: { Stop: [] }
+    })
   })
 
   it('does not replace a dangling hook config symlink', () => {
@@ -182,9 +190,15 @@ describe('writeHooksJson', () => {
   })
 
   it('updates the .bak file to the previous version on each write', () => {
-    const v1: HooksConfig = { hooks: { Stop: [{ hooks: [{ type: 'command', command: 'v1' }] }] } }
-    const v2: HooksConfig = { hooks: { Stop: [{ hooks: [{ type: 'command', command: 'v2' }] }] } }
-    const v3: HooksConfig = { hooks: { Stop: [{ hooks: [{ type: 'command', command: 'v3' }] }] } }
+    const v1: HooksConfig = {
+      hooks: { Stop: [{ hooks: [{ type: 'command', command: 'v1' }] }] }
+    }
+    const v2: HooksConfig = {
+      hooks: { Stop: [{ hooks: [{ type: 'command', command: 'v2' }] }] }
+    }
+    const v3: HooksConfig = {
+      hooks: { Stop: [{ hooks: [{ type: 'command', command: 'v3' }] }] }
+    }
 
     writeHooksJson(configPath, v1)
     writeHooksJson(configPath, v2)
@@ -310,7 +324,10 @@ describe('removeManagedCommands', () => {
       [
         {
           hooks: [
-            { type: 'command', command: '/bin/sh "/path/agent-hooks/copilot-hook.sh"' },
+            {
+              type: 'command',
+              command: '/bin/sh "/path/agent-hooks/copilot-hook.sh"'
+            },
             { type: 'command', command: 'echo keep me' }
           ]
         }
@@ -381,7 +398,14 @@ describe('hookDefinitionHasManagedCommand', () => {
     ).toBe(true)
     expect(
       hookDefinitionHasManagedCommand(
-        { hooks: [{ type: 'command', command: '/bin/sh "/path/agent-hooks/copilot-hook.sh"' }] },
+        {
+          hooks: [
+            {
+              type: 'command',
+              command: '/bin/sh "/path/agent-hooks/copilot-hook.sh"'
+            }
+          ]
+        },
         match
       )
     ).toBe(true)
@@ -539,7 +563,7 @@ describe('wrapPosixHookCommand', () => {
 })
 
 const qualifiedWindowsPowerShellCommand =
-  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -ExecutionPolicy Bypass -EncodedCommand \S+$/
+  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -EncodedCommand \S+$/
 
 function decodeWindowsHookCommand(command: string): string {
   const encodedCommand = command.match(/ -EncodedCommand (\S+)$/)?.[1]
@@ -549,7 +573,9 @@ function decodeWindowsHookCommand(command: string): string {
 
 function expectedDecodedWindowsHookCommand(scriptPath: string): string {
   const quoted = `'${scriptPath.replaceAll("'", "''")}'`
-  return `if (Test-Path -LiteralPath ${quoted} -PathType Leaf) { & ${quoted}; exit $LASTEXITCODE }; [Console]::In.ReadToEnd() | Out-Null; exit 0`
+  // Why: the progress silencer leads every encoded payload so PowerShell can't serialize CLIXML
+  // progress records onto stderr and corrupt a consumer that merges it into stdout (#14818).
+  return `$ProgressPreference='SilentlyContinue'; if (Test-Path -LiteralPath ${quoted} -PathType Leaf) { & ${quoted}; exit $LASTEXITCODE }; [Console]::In.ReadToEnd() | Out-Null; exit 0`
 }
 
 describe('wrapWindowsHookCommand', () => {
@@ -725,7 +751,9 @@ describe('wrapRuntimeHomeHookCommand', () => {
       process.platform === 'win32'
         ? join(process.env.ProgramFiles ?? 'C:\\Program Files', 'Git', 'bin', 'bash.exe')
         : '/bin/sh'
-    const result = spawnSync(shell, ['-c', command], { input: Buffer.alloc(1_000_000, 'x') })
+    const result = spawnSync(shell, ['-c', command], {
+      input: Buffer.alloc(1_000_000, 'x')
+    })
 
     expect(result.error).toBeUndefined()
     expect(result.status).toBe(0)

--- a/src/main/agent-hooks/installer-utils.test.ts
+++ b/src/main/agent-hooks/installer-utils.test.ts
@@ -573,8 +573,7 @@ function decodeWindowsHookCommand(command: string): string {
 
 function expectedDecodedWindowsHookCommand(scriptPath: string): string {
   const quoted = `'${scriptPath.replaceAll("'", "''")}'`
-  // Why: the progress silencer leads every encoded payload so PowerShell can't serialize CLIXML
-  // progress records onto stderr and corrupt a consumer that merges it into stdout (#14818).
+  // Why: PowerShell progress CLIXML corrupts consumers that merge stderr into JSON stdout.
   return `$ProgressPreference='SilentlyContinue'; if (Test-Path -LiteralPath ${quoted} -PathType Leaf) { & ${quoted}; exit $LASTEXITCODE }; [Console]::In.ReadToEnd() | Out-Null; exit 0`
 }
 
@@ -757,6 +756,25 @@ describe('wrapRuntimeHomeHookCommand', () => {
 
     expect(result.error).toBeUndefined()
     expect(result.status).toBe(0)
+  })
+
+  it('emits neutral JSON when a lifecycle script is missing', () => {
+    const shell =
+      process.platform === 'win32'
+        ? join(process.env.ProgramFiles ?? 'C:\\Program Files', 'Git', 'bin', 'bash.exe')
+        : '/bin/sh'
+    const result = spawnSync(
+      shell,
+      ['-c', wrapRuntimeHomeHookCommand('missing-orca-hook', { neutralJsonWhenMissing: true })],
+      {
+        env: { ...process.env, HOME: tmpDir.replaceAll('\\', '/') },
+        input: Buffer.alloc(1_000_000, 'x')
+      }
+    )
+
+    expect(result.error).toBeUndefined()
+    expect(result.status, result.stderr.toString()).toBe(0)
+    expect(JSON.parse(result.stdout.toString().trim())).toEqual({})
   })
 })
 

--- a/src/main/agent-hooks/installer-utils.ts
+++ b/src/main/agent-hooks/installer-utils.ts
@@ -16,6 +16,7 @@ import { grantDirAcl, isPermissionError } from '../win32-utils'
 import { POSIX_HOOK_STDIN_DRAIN_COMMAND } from './hook-stdin-contract'
 import { resolveHooksJsonWritePath } from './hook-config-write-path'
 import { writeRollingFileBackup } from '../rolling-file-backup'
+import { wrapWindowsPowerShellEncodedCommand } from './windows-powershell-hook-launcher'
 
 export type HookCommandConfig = {
   type: 'command'
@@ -120,16 +121,14 @@ export function wrapPosixHookCommand(scriptPath: string, env: Record<string, str
   return `if [ -f ${quoted} ] && [ -r ${quoted} ] && [ -x ${quoted} ]; then ${invocation}; else ${POSIX_HOOK_STDIN_DRAIN_COMMAND}; fi`
 }
 
-function quotePowerShellString(value: string): string {
+export function quotePowerShellString(value: string): string {
   return `'${value.replaceAll("'", "''")}'`
 }
 
-function getWindowsPowerShellExecutablePath(): string {
-  const systemRoot = process.env.SystemRoot || 'C:\\Windows'
-  // Why: PATH lookup lets a worktree-local powershell.exe hijack hook payloads.
-  // Forward slashes keep this absolute path shell-friendly for cmd.exe and Git Bash.
-  return `${systemRoot.replaceAll('\\', '/')}/System32/WindowsPowerShell/v1.0/powershell.exe`
-}
+export {
+  wrapWindowsPowerShellEncodedCommand,
+  WINDOWS_POWERSHELL_HOOK_SWITCHES
+} from './windows-powershell-hook-launcher'
 
 export function wrapWindowsHookCommand(
   scriptPath: string,
@@ -141,8 +140,7 @@ export function wrapWindowsHookCommand(
     .map(([key, value]) => `$env:${key} = ${quotePowerShellString(value)}; `)
     .join('')
   const command = `${envPrefix}if (Test-Path -LiteralPath ${quoted} -PathType Leaf) { & ${quoted}; exit $LASTEXITCODE }; [Console]::In.ReadToEnd() | Out-Null; exit 0`
-  const encodedCommand = Buffer.from(command, 'utf16le').toString('base64')
-  return `${getWindowsPowerShellExecutablePath()} -NoProfile -ExecutionPolicy Bypass -EncodedCommand ${encodedCommand}`
+  return wrapWindowsPowerShellEncodedCommand(command)
 }
 
 export const WINDOWS_CMD_SAFE_PATH = /^[A-Za-z0-9_.:\\~-]+$/

--- a/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
+++ b/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
@@ -69,6 +69,7 @@ vi.mock('os', async (importOriginal) => {
 
 import { AntigravityHookService } from '../antigravity/hook-service'
 import { ClaudeHookService } from '../claude/hook-service'
+import { getRemoteManagedCommand } from '../claude/hook-settings'
 import { CodexHookService } from '../codex/hook-service'
 import { CommandCodeHookService } from '../command-code/hook-service'
 import { CopilotHookService } from '../copilot/hook-service'
@@ -155,6 +156,7 @@ const LOCAL_INSTALLERS = [
 type HookRun = {
   exitCode: number | null
   stdinErrors: NodeJS.ErrnoException[]
+  stderr: string
   stdout: string
 }
 
@@ -164,8 +166,9 @@ function runHookProcess(
   env: NodeJS.ProcessEnv
 ): Promise<HookRun> {
   return new Promise((resolve, reject) => {
-    const child = spawn(executable, args, { env, stdio: ['pipe', 'pipe', 'ignore'] })
+    const child = spawn(executable, args, { env, stdio: ['pipe', 'pipe', 'pipe'] })
     const stdinErrors: NodeJS.ErrnoException[] = []
+    let stderr = ''
     let stdout = ''
     const timeout = setTimeout(() => {
       child.kill('SIGKILL')
@@ -178,10 +181,13 @@ function runHookProcess(
     child.stdout.on('data', (chunk: Buffer) => {
       stdout += chunk.toString()
     })
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString()
+    })
     child.stdin.on('error', (error: NodeJS.ErrnoException) => stdinErrors.push(error))
     child.on('close', (exitCode) => {
       clearTimeout(timeout)
-      resolve({ exitCode, stdinErrors, stdout })
+      resolve({ exitCode, stdinErrors, stderr, stdout })
     })
     child.stdin.end(LARGE_PAYLOAD)
   })
@@ -402,11 +408,7 @@ describe('Windows managed hook stdin structure', () => {
     }
   )
 
-  // Why (#14818): this asserts the effect a Claude-hooks-compat consumer actually observes —
-  // running the exact `command` string from settings.json and parsing its stdout — rather than
-  // what the installer intended to write. The shipped `conhost.exe --headless` wrapper passed
-  // every intent-level test while relaying neither stdout nor an exit code, so cursor-agent saw
-  // empty stdout on PreToolUse, called it invalid JSON, and blocked every shell command.
+  // Why: command-shape tests missed conhost discarding the JSON consumers observe (#14818).
   it.skipIf(process.platform !== 'win32')(
     'emits parseable JSON on stdout from the registered Claude hook command, through cmd.exe and Git Bash',
     async () => {
@@ -418,20 +420,15 @@ describe('Windows managed hook stdin structure', () => {
           readFileSync(join(home, '.claude', 'settings.json'), 'utf8')
         ) as { hooks: Record<string, { hooks: { command: string; args?: string[] }[] }[]> }
         const entry = settings.hooks.PreToolUse[0].hooks[0]
-        // Why (#14815): a consumer that ignores `args` must still get a runnable invocation.
         expect(entry.args).toBeUndefined()
 
-        // Why: Git Bash is the reported execution context (#14815) — MSYS rewrites `/`-prefixed
-        // switches and collapses backslash paths, so the command must survive both shells.
+        // Why: MSYS rewrites switches and paths, so the command must survive both shells (#14815).
+        const gitBash = findGitBash()
         const shells = [
           { name: 'cmd.exe', executable: 'cmd.exe', args: ['/d', '/c', entry.command] },
-          { name: 'Git Bash', executable: findGitBash(), args: ['-lc', entry.command] }
+          { name: 'Git Bash', executable: gitBash, args: ['-c', entry.command] }
         ]
-        // Why: USERPROFILE (not homedir()) is what the registered command resolves the script
-        // through at run time, so the child must see the test home for the script to be found.
-        // Why: all three reachable paths must speak JSON — the guard exit (no Orca env), the
-        // reached-curl path (env present, nothing listening), and the launcher's own
-        // missing-script fallback, which never enters the script at all.
+        // Why: cover guard exit, reached curl, and the launcher's missing-script fallback.
         const environments = [
           { name: 'no Orca env', env: hookEnvironment({ USERPROFILE: home }) },
           {
@@ -453,6 +450,7 @@ describe('Windows managed hook stdin structure', () => {
             const label = `${shell.name} / ${environment.name}`
             const result = await runHookProcess(shell.executable, shell.args, environment.env)
             expect(result.exitCode, `${label} exit code`).toBe(0)
+            expect(result.stderr, `${label} stderr`).toBe('')
             expect(() => JSON.parse(result.stdout.trim()), `${label} stdout is JSON`).not.toThrow()
             expect(JSON.parse(result.stdout.trim()), `${label} stdout`).toEqual({})
           }
@@ -462,13 +460,22 @@ describe('Windows managed hook stdin structure', () => {
         rmSync(home, { recursive: true, force: true })
       }
     },
-    // Why: six real process launches, and a Git Bash login shell is slow to start — that overruns
-    // the 5s default once the rest of the suite is competing for cores.
+    // Why: six shell launches can overrun the default while the suite competes for cores.
     60_000
   )
 })
 
 describe.skipIf(process.platform === 'win32')('managed hook stdin lifecycle', () => {
+  it('emits neutral JSON when the Claude lifecycle script is missing', async () => {
+    const command = getRemoteManagedCommand('/home/dev/.orca/agent-hooks/claude-hook.sh')
+    const result = await runPosixHook(command)
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stdinErrors).toHaveLength(0)
+    expect(result.stderr).toBe('')
+    expect(JSON.parse(result.stdout.trim())).toEqual({})
+  })
+
   it('captures stdin before every possible whole-script success exit', async () => {
     const scripts = await generatePosixScripts()
     for (const [agent, script] of scripts) {

--- a/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
+++ b/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
@@ -401,6 +401,71 @@ describe('Windows managed hook stdin structure', () => {
       }
     }
   )
+
+  // Why (#14818): this asserts the effect a Claude-hooks-compat consumer actually observes —
+  // running the exact `command` string from settings.json and parsing its stdout — rather than
+  // what the installer intended to write. The shipped `conhost.exe --headless` wrapper passed
+  // every intent-level test while relaying neither stdout nor an exit code, so cursor-agent saw
+  // empty stdout on PreToolUse, called it invalid JSON, and blocked every shell command.
+  it.skipIf(process.platform !== 'win32')(
+    'emits parseable JSON on stdout from the registered Claude hook command, through cmd.exe and Git Bash',
+    async () => {
+      const home = mkdtempSync(join(tmpdir(), 'orca-hook-stdout-json-'))
+      homedirMock.mockReturnValue(home)
+      try {
+        expect(new ClaudeHookService().install().state).toBe('installed')
+        const settings = JSON.parse(
+          readFileSync(join(home, '.claude', 'settings.json'), 'utf8')
+        ) as { hooks: Record<string, { hooks: { command: string; args?: string[] }[] }[]> }
+        const entry = settings.hooks.PreToolUse[0].hooks[0]
+        // Why (#14815): a consumer that ignores `args` must still get a runnable invocation.
+        expect(entry.args).toBeUndefined()
+
+        // Why: Git Bash is the reported execution context (#14815) — MSYS rewrites `/`-prefixed
+        // switches and collapses backslash paths, so the command must survive both shells.
+        const shells = [
+          { name: 'cmd.exe', executable: 'cmd.exe', args: ['/d', '/c', entry.command] },
+          { name: 'Git Bash', executable: findGitBash(), args: ['-lc', entry.command] }
+        ]
+        // Why: USERPROFILE (not homedir()) is what the registered command resolves the script
+        // through at run time, so the child must see the test home for the script to be found.
+        // Why: all three reachable paths must speak JSON — the guard exit (no Orca env), the
+        // reached-curl path (env present, nothing listening), and the launcher's own
+        // missing-script fallback, which never enters the script at all.
+        const environments = [
+          { name: 'no Orca env', env: hookEnvironment({ USERPROFILE: home }) },
+          {
+            name: 'Orca env with dead listener',
+            env: hookEnvironment({
+              USERPROFILE: home,
+              ORCA_AGENT_HOOK_PORT: '59999',
+              ORCA_AGENT_HOOK_TOKEN: 'token',
+              ORCA_PANE_KEY: 'tab:leaf'
+            })
+          },
+          {
+            name: 'missing managed script',
+            env: hookEnvironment({ USERPROFILE: join(home, 'absent') })
+          }
+        ]
+        for (const shell of shells) {
+          for (const environment of environments) {
+            const label = `${shell.name} / ${environment.name}`
+            const result = await runHookProcess(shell.executable, shell.args, environment.env)
+            expect(result.exitCode, `${label} exit code`).toBe(0)
+            expect(() => JSON.parse(result.stdout.trim()), `${label} stdout is JSON`).not.toThrow()
+            expect(JSON.parse(result.stdout.trim()), `${label} stdout`).toEqual({})
+          }
+        }
+      } finally {
+        homedirMock.mockImplementation(() => process.env.HOME ?? tmpdir())
+        rmSync(home, { recursive: true, force: true })
+      }
+    },
+    // Why: six real process launches, and a Git Bash login shell is slow to start — that overruns
+    // the 5s default once the rest of the suite is competing for cores.
+    60_000
+  )
 })
 
 describe.skipIf(process.platform === 'win32')('managed hook stdin lifecycle', () => {

--- a/src/main/agent-hooks/runtime-home-hook-command.ts
+++ b/src/main/agent-hooks/runtime-home-hook-command.ts
@@ -7,22 +7,26 @@ import {
 const MANAGED_SCRIPT_BASE_NAME = /^[A-Za-z0-9_-]+$/
 const WINDOWS_GIT_BASH_RUNTIME_HOME_UNSAFE = '*\\&*|*\\^*|*\\(*|*\\)*|*\\;*|*,*|*=*|*%*|*\\!*'
 
-export function wrapRuntimeHomeHookCommand(scriptBaseName: string): string {
+export function wrapRuntimeHomeHookCommand(
+  scriptBaseName: string,
+  options: { neutralJsonWhenMissing?: boolean } = {}
+): string {
   if (!MANAGED_SCRIPT_BASE_NAME.test(scriptBaseName)) {
     throw new Error(`Invalid managed script base name: ${scriptBaseName}`)
   }
   const windowsScript = `"$HOME/.orca/agent-hooks/${scriptBaseName}.cmd"`
   const posixScript = `"$HOME/.orca/agent-hooks/${scriptBaseName}.sh"`
   const drain = POSIX_HOOK_STDIN_DRAIN_COMMAND
+  const missingScriptFallback = options.neutralJsonWhenMissing ? `${drain}; printf '{}\\n'` : drain
   const powershell = '"$SYSTEMROOT/System32/WindowsPowerShell/v1.0/powershell.exe"'
-  const powershellCommand = `$homePath = $env:HOME -replace '^/([A-Za-z])/', '$1:/'; $scriptPath = Join-Path $homePath '.orca\\agent-hooks\\${scriptBaseName}.cmd'; if (Test-Path -LiteralPath $scriptPath -PathType Leaf) { & $scriptPath; exit $LASTEXITCODE }; [Console]::In.ReadToEnd() | Out-Null; exit 0`
+  const powershellFallback = options.neutralJsonWhenMissing ? "; Write-Output '{}'" : ''
+  const powershellCommand = `$homePath = $env:HOME -replace '^/([A-Za-z])/', '$1:/'; $scriptPath = Join-Path $homePath '.orca\\agent-hooks\\${scriptBaseName}.cmd'; if (Test-Path -LiteralPath $scriptPath -PathType Leaf) { & $scriptPath; exit $LASTEXITCODE }; [Console]::In.ReadToEnd() | Out-Null${powershellFallback}; exit 0`
   const encodedCommand = encodeWindowsPowerShellHookCommand(powershellCommand)
-  // Why: shares the launcher switch list so this Git Bash branch can't drift and start showing a
-  // console window while the native Windows launcher stays hidden (#14815).
+  // Why: the Git Bash and native Windows launchers must suppress windows identically (#14815).
   const powershellInvocation = `${powershell} ${WINDOWS_POWERSHELL_HOOK_SWITCHES} -EncodedCommand ${encodedCommand}`
-  const encodedWindowsBranch = `if [ -f ${powershell} ]; then ${powershellInvocation}; else ${drain}; fi`
-  const windowsBranch = `if [ -f ${windowsScript} ]; then case "$HOME" in ${WINDOWS_GIT_BASH_RUNTIME_HOME_UNSAFE}) ${encodedWindowsBranch} ;; *) ${windowsScript} ;; esac; else ${drain}; fi`
-  const posixBranch = `if [ -f ${posixScript} ] && [ -r ${posixScript} ] && [ -x ${posixScript} ]; then /bin/sh ${posixScript}; else ${drain}; fi`
+  const encodedWindowsBranch = `if [ -f ${powershell} ]; then ${powershellInvocation}; else ${missingScriptFallback}; fi`
+  const windowsBranch = `if [ -f ${windowsScript} ]; then case "$HOME" in ${WINDOWS_GIT_BASH_RUNTIME_HOME_UNSAFE}) ${encodedWindowsBranch} ;; *) ${windowsScript} ;; esac; else ${missingScriptFallback}; fi`
+  const posixBranch = `if [ -f ${posixScript} ] && [ -r ${posixScript} ] && [ -x ${posixScript} ]; then /bin/sh ${posixScript}; else ${missingScriptFallback}; fi`
   // Why: OSTYPE is shell-owned, so platform selection adds no process to every hook invocation.
-  return `if [ -z "\${HOME-}" ]; then ${drain}; else case "\${OSTYPE-}" in msys*|cygwin*|win32*) ${windowsBranch} ;; *) ${posixBranch} ;; esac; fi`
+  return `if [ -z "\${HOME-}" ]; then ${missingScriptFallback}; else case "\${OSTYPE-}" in msys*|cygwin*|win32*) ${windowsBranch} ;; *) ${posixBranch} ;; esac; fi`
 }

--- a/src/main/agent-hooks/runtime-home-hook-command.ts
+++ b/src/main/agent-hooks/runtime-home-hook-command.ts
@@ -1,4 +1,8 @@
 import { POSIX_HOOK_STDIN_DRAIN_COMMAND } from './hook-stdin-contract'
+import {
+  encodeWindowsPowerShellHookCommand,
+  WINDOWS_POWERSHELL_HOOK_SWITCHES
+} from './windows-powershell-hook-launcher'
 
 const MANAGED_SCRIPT_BASE_NAME = /^[A-Za-z0-9_-]+$/
 const WINDOWS_GIT_BASH_RUNTIME_HOME_UNSAFE = '*\\&*|*\\^*|*\\(*|*\\)*|*\\;*|*,*|*=*|*%*|*\\!*'
@@ -12,8 +16,10 @@ export function wrapRuntimeHomeHookCommand(scriptBaseName: string): string {
   const drain = POSIX_HOOK_STDIN_DRAIN_COMMAND
   const powershell = '"$SYSTEMROOT/System32/WindowsPowerShell/v1.0/powershell.exe"'
   const powershellCommand = `$homePath = $env:HOME -replace '^/([A-Za-z])/', '$1:/'; $scriptPath = Join-Path $homePath '.orca\\agent-hooks\\${scriptBaseName}.cmd'; if (Test-Path -LiteralPath $scriptPath -PathType Leaf) { & $scriptPath; exit $LASTEXITCODE }; [Console]::In.ReadToEnd() | Out-Null; exit 0`
-  const encodedCommand = Buffer.from(powershellCommand, 'utf16le').toString('base64')
-  const powershellInvocation = `${powershell} -NoProfile -ExecutionPolicy Bypass -EncodedCommand ${encodedCommand}`
+  const encodedCommand = encodeWindowsPowerShellHookCommand(powershellCommand)
+  // Why: shares the launcher switch list so this Git Bash branch can't drift and start showing a
+  // console window while the native Windows launcher stays hidden (#14815).
+  const powershellInvocation = `${powershell} ${WINDOWS_POWERSHELL_HOOK_SWITCHES} -EncodedCommand ${encodedCommand}`
   const encodedWindowsBranch = `if [ -f ${powershell} ]; then ${powershellInvocation}; else ${drain}; fi`
   const windowsBranch = `if [ -f ${windowsScript} ]; then case "$HOME" in ${WINDOWS_GIT_BASH_RUNTIME_HOME_UNSAFE}) ${encodedWindowsBranch} ;; *) ${windowsScript} ;; esac; else ${drain}; fi`
   const posixBranch = `if [ -f ${posixScript} ] && [ -r ${posixScript} ] && [ -x ${posixScript} ]; then /bin/sh ${posixScript}; else ${drain}; fi`

--- a/src/main/agent-hooks/windows-powershell-hook-launcher.ts
+++ b/src/main/agent-hooks/windows-powershell-hook-launcher.ts
@@ -1,8 +1,6 @@
-// Why: every Windows hook command that reaches a consumer as a single string is built here, so the
-// window-suppression switch cannot be present in one installer and missing in another (#14815).
+// Why: centralizing the launcher keeps window suppression consistent across installers (#14815).
 
-// Why: PATH lookup lets a worktree-local exe hijack hook payloads.
-// Forward slashes keep this absolute path shell-friendly for cmd.exe and Git Bash.
+// Why: an absolute forward-slash path avoids PATH hijacking and survives cmd.exe and Git Bash.
 export function getWindowsSystem32Path(relativePath: string): string {
   const systemRoot = process.env.SystemRoot || 'C:\\Windows'
   return `${systemRoot.replaceAll('\\', '/')}/System32/${relativePath}`
@@ -12,22 +10,14 @@ export function getWindowsPowerShellExecutablePath(): string {
   return getWindowsSystem32Path('WindowsPowerShell/v1.0/powershell.exe')
 }
 
-// Why: `conhost.exe --headless` (#13443) does not wait for the hosted process and relays neither its
-// exit code nor its stdout — it implements the ConPTY server protocol, not a generic no-window
-// wrapper — so it silently discarded whatever the hook wrote (#14818). `-WindowStyle Hidden`
-// suppresses the window while leaving wait, exit code, and stdout relay intact.
+// Why: unlike conhost, hidden PowerShell relays hook output and exit status (#14818).
 export const WINDOWS_POWERSHELL_HOOK_SWITCHES =
   '-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden'
 
-// Why: with stderr redirected, PowerShell serializes progress records to it as CLIXML
-// (`#< CLIXML...`). A consumer that merges stderr into stdout then sees those bytes ahead of the
-// hook's JSON and fails to parse it — the same failure mode as #14818, from a different stream.
-// Silencing progress keeps both streams clean for every hook payload.
+// Why: redirected PowerShell progress becomes CLIXML that can corrupt merged JSON output.
 const HOOK_PROGRESS_SILENCER = "$ProgressPreference='SilentlyContinue'; "
 
-// Why: base64 keeps the script path out of the command line entirely, so neither cmd.exe nor Git
-// Bash/MSYS can mangle it — MSYS rewrites `/`-prefixed switches into paths and collapses backslash
-// drive paths, and cmd.exe reads a forward-slash path as a switch (#6078, #14815).
+// Why: encoding shields paths and switches from cmd.exe and MSYS rewriting (#6078, #14815).
 export function encodeWindowsPowerShellHookCommand(command: string): string {
   return Buffer.from(`${HOOK_PROGRESS_SILENCER}${command}`, 'utf16le').toString('base64')
 }

--- a/src/main/agent-hooks/windows-powershell-hook-launcher.ts
+++ b/src/main/agent-hooks/windows-powershell-hook-launcher.ts
@@ -1,0 +1,37 @@
+// Why: every Windows hook command that reaches a consumer as a single string is built here, so the
+// window-suppression switch cannot be present in one installer and missing in another (#14815).
+
+// Why: PATH lookup lets a worktree-local exe hijack hook payloads.
+// Forward slashes keep this absolute path shell-friendly for cmd.exe and Git Bash.
+export function getWindowsSystem32Path(relativePath: string): string {
+  const systemRoot = process.env.SystemRoot || 'C:\\Windows'
+  return `${systemRoot.replaceAll('\\', '/')}/System32/${relativePath}`
+}
+
+export function getWindowsPowerShellExecutablePath(): string {
+  return getWindowsSystem32Path('WindowsPowerShell/v1.0/powershell.exe')
+}
+
+// Why: `conhost.exe --headless` (#13443) does not wait for the hosted process and relays neither its
+// exit code nor its stdout — it implements the ConPTY server protocol, not a generic no-window
+// wrapper — so it silently discarded whatever the hook wrote (#14818). `-WindowStyle Hidden`
+// suppresses the window while leaving wait, exit code, and stdout relay intact.
+export const WINDOWS_POWERSHELL_HOOK_SWITCHES =
+  '-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden'
+
+// Why: with stderr redirected, PowerShell serializes progress records to it as CLIXML
+// (`#< CLIXML...`). A consumer that merges stderr into stdout then sees those bytes ahead of the
+// hook's JSON and fails to parse it — the same failure mode as #14818, from a different stream.
+// Silencing progress keeps both streams clean for every hook payload.
+const HOOK_PROGRESS_SILENCER = "$ProgressPreference='SilentlyContinue'; "
+
+// Why: base64 keeps the script path out of the command line entirely, so neither cmd.exe nor Git
+// Bash/MSYS can mangle it — MSYS rewrites `/`-prefixed switches into paths and collapses backslash
+// drive paths, and cmd.exe reads a forward-slash path as a switch (#6078, #14815).
+export function encodeWindowsPowerShellHookCommand(command: string): string {
+  return Buffer.from(`${HOOK_PROGRESS_SILENCER}${command}`, 'utf16le').toString('base64')
+}
+
+export function wrapWindowsPowerShellEncodedCommand(command: string): string {
+  return `${getWindowsPowerShellExecutablePath()} ${WINDOWS_POWERSHELL_HOOK_SWITCHES} -EncodedCommand ${encodeWindowsPowerShellHookCommand(command)}`
+}

--- a/src/main/claude/hook-service.test.ts
+++ b/src/main/claude/hook-service.test.ts
@@ -34,14 +34,31 @@ function hasManagedCommand(hook: TestHook, matcher: (command: string | undefined
 }
 
 describe('getWindowsManagedLifecycleHook', () => {
-  it('resolves the managed script from the runtime Windows profile', () => {
+  it('resolves the managed script from the runtime Windows profile, as a single command string', () => {
     const scriptPath = 'C:\\Users\\%name%\\a^b&c\\.orca\\agent-hooks\\claude-hook.cmd'
     const hook = getWindowsManagedLifecycleHook(scriptPath)
 
-    expect(hook.args?.[0]).toBe('--headless')
-    expect(hook.args?.[1]).toMatch(/\\System32\\cmd\.exe$/i)
-    expect(hook.args?.at(-1)).toBe('%USERPROFILE%\\.orca\\agent-hooks\\claude-hook.cmd')
-    expect(hook.args).not.toContain(scriptPath)
+    // Why (#14815): a separate `args` array isn't honored by every Claude-hooks-compat consumer,
+    // so the invocation must be a single self-contained `command` string.
+    expect(hook.args).toBeUndefined()
+    expect(hook.command).toMatch(
+      /\/powershell\.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden /
+    )
+    expect(hook.command).not.toContain(scriptPath)
+    // Why: no backslash path or `/`-prefixed switch outside the base64 payload — both get
+    // mangled when a Claude-hooks-compat consumer runs the command through Git Bash/MSYS.
+    expect(hook.command.replace(/-EncodedCommand \S+$/, '')).not.toMatch(/\\| \/[a-zA-Z]+( |$)/)
+
+    const encoded = hook.command.match(/-EncodedCommand (\S+)$/)?.[1]
+    const decoded = Buffer.from(encoded ?? '', 'base64').toString('utf16le')
+    expect(decoded).toContain('$env:USERPROFILE')
+    expect(decoded).toContain('.orca\\agent-hooks\\claude-hook.cmd')
+  })
+
+  it('is still recognized as managed by createManagedCommandMatcher (#14825)', () => {
+    const scriptPath = 'C:\\Users\\alice\\.orca\\agent-hooks\\claude-hook.cmd'
+    const hook = getWindowsManagedLifecycleHook(scriptPath)
+    expect(isClaudeManagedCommand(hook.command)).toBe(true)
   })
 })
 
@@ -199,9 +216,18 @@ describe('ClaudeHookService.install', () => {
       expect(hasManagedCommand(legacy.hooks.StopFailure[0].hooks[0], isClaudeManagedCommand)).toBe(
         true
       )
-      expect(
-        readFileSync(join(tmpHome, '.orca', 'agent-hooks', CLAUDE_SCRIPT_FILE_NAME), 'utf-8')
-      ).toContain('DEVIN_PROJECT_DIR')
+      const managedScript = readFileSync(
+        join(tmpHome, '.orca', 'agent-hooks', CLAUDE_SCRIPT_FILE_NAME),
+        'utf-8'
+      )
+      expect(managedScript).toContain('DEVIN_PROJECT_DIR')
+      // Why (#14818): `{}` must be the first thing written to stdout so a Claude-hooks-compat
+      // consumer never sees empty stdout, even on the guard-exit/Devin-skip paths below it.
+      expect(managedScript).toMatch(
+        process.platform === 'win32'
+          ? /^@echo off\r\nsetlocal\r\necho \{\}\r\n/
+          : /^#!\/bin\/sh\nprintf "\{\}\\n"\n/
+      )
     } finally {
       vi.unstubAllEnvs()
       rmSync(tmpHome, { recursive: true, force: true })
@@ -255,7 +281,12 @@ describe('ClaudeHookService.install', () => {
       mkdirSync(join(tmpHome, '.claude'), { recursive: true })
       writeFileSync(
         settingsPath,
-        JSON.stringify({ statusLine: { type: 'command', command: '/usr/local/bin/my-statusline' } })
+        JSON.stringify({
+          statusLine: {
+            type: 'command',
+            command: '/usr/local/bin/my-statusline'
+          }
+        })
       )
 
       expect(new ClaudeHookService().install().state).toBe('installed')
@@ -339,7 +370,7 @@ describe('ClaudeHookService.install', () => {
   })
 
   it.skipIf(process.platform !== 'win32')(
-    'runs portable managed hooks through headless exec form',
+    'runs portable managed hooks through a single headless command string',
     () => {
       const tmpHome = mkdtempSync(join(tmpdir(), 'orca claude home with spaces '))
       vi.stubEnv('HOME', tmpHome)
@@ -351,24 +382,20 @@ describe('ClaudeHookService.install', () => {
           readFileSync(join(tmpHome, '.claude', 'settings.json'), 'utf-8')
         ) as { hooks: Record<string, { hooks: TestHook[] }[]> }
 
-        const system32 = join(process.env.SystemRoot ?? 'C:\\Windows', 'System32')
         const scriptPath = join(tmpHome, '.orca', 'agent-hooks', CLAUDE_SCRIPT_FILE_NAME)
-        const runtimeScriptPath = join(
-          '%USERPROFILE%',
-          '.orca',
-          'agent-hooks',
-          CLAUDE_SCRIPT_FILE_NAME
-        )
 
         for (const eventName of ['UserPromptSubmit', 'Stop', 'StopFailure']) {
           const hook = settings.hooks[eventName]?.[0]?.hooks?.[0]
-          expect(hook).toEqual({
-            type: 'command',
-            command: join(system32, 'conhost.exe'),
-            args: ['--headless', join(system32, 'cmd.exe'), '/d', '/c', runtimeScriptPath],
-            timeout: 10
-          })
-          expect(hook.args).not.toContain(scriptPath)
+          expect(hook?.args).toBeUndefined()
+          expect(hook?.command).toMatch(
+            /\/powershell\.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden /
+          )
+          expect(hook?.command).not.toContain(scriptPath)
+
+          const encoded = hook?.command.match(/-EncodedCommand (\S+)$/)?.[1]
+          const decoded = Buffer.from(encoded ?? '', 'base64').toString('utf16le')
+          expect(decoded).toContain('$env:USERPROFILE')
+          expect(decoded).toContain(`.orca\\agent-hooks\\${CLAUDE_SCRIPT_FILE_NAME}`)
         }
       } finally {
         vi.unstubAllEnvs()
@@ -393,6 +420,9 @@ describe('ClaudeHookService.install', () => {
         expect(script).toContain('--data-urlencode "payload@-"')
         expect(script).toContain('/hook/claude')
         expect(script).not.toMatch(/Invoke-WebRequest/i)
+        // Why (#14818): `{}` must be the first line of output so a Claude-hooks-compat consumer
+        // never sees empty stdout, even on the guard-exit/Devin-skip paths below it.
+        expect(script.split('\r\n')[2]).toBe('echo {}')
       } finally {
         vi.unstubAllEnvs()
         rmSync(tmpHome, { recursive: true, force: true })
@@ -436,6 +466,11 @@ describe('ClaudeHookService.installRemote', () => {
     const script = fs.files.get('/home/dev/.orca/agent-hooks/claude-hook.sh')
     expect(script).toContain('#!/bin/sh')
     expect(script).toContain('DEVIN_PROJECT_DIR')
+    // Why (#14818): `{}` must be the first thing written to stdout so a Claude-hooks-compat
+    // consumer never sees empty stdout, even on the guard-exit paths below it.
+    expect(script!.indexOf('printf "{}\\n"')).toBe(
+      script!.indexOf('#!/bin/sh') + '#!/bin/sh\n'.length
+    )
     // Why: payload is piped to curl via stdin (`payload@-`) so it never lands
     // on the curl command line (EDR oversized-command-line false positive),
     // matching the Windows curl.exe hook post.

--- a/src/main/claude/hook-service.test.ts
+++ b/src/main/claude/hook-service.test.ts
@@ -38,15 +38,12 @@ describe('getWindowsManagedLifecycleHook', () => {
     const scriptPath = 'C:\\Users\\%name%\\a^b&c\\.orca\\agent-hooks\\claude-hook.cmd'
     const hook = getWindowsManagedLifecycleHook(scriptPath)
 
-    // Why (#14815): a separate `args` array isn't honored by every Claude-hooks-compat consumer,
-    // so the invocation must be a single self-contained `command` string.
     expect(hook.args).toBeUndefined()
     expect(hook.command).toMatch(
       /\/powershell\.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden /
     )
     expect(hook.command).not.toContain(scriptPath)
-    // Why: no backslash path or `/`-prefixed switch outside the base64 payload — both get
-    // mangled when a Claude-hooks-compat consumer runs the command through Git Bash/MSYS.
+    // Why: Git Bash/MSYS mangles backslash paths and slash-prefixed switches.
     expect(hook.command.replace(/-EncodedCommand \S+$/, '')).not.toMatch(/\\| \/[a-zA-Z]+( |$)/)
 
     const encoded = hook.command.match(/-EncodedCommand (\S+)$/)?.[1]
@@ -221,8 +218,7 @@ describe('ClaudeHookService.install', () => {
         'utf-8'
       )
       expect(managedScript).toContain('DEVIN_PROJECT_DIR')
-      // Why (#14818): `{}` must be the first thing written to stdout so a Claude-hooks-compat
-      // consumer never sees empty stdout, even on the guard-exit/Devin-skip paths below it.
+      // Why: guard and Devin-skip paths must still return neutral JSON (#14818).
       expect(managedScript).toMatch(
         process.platform === 'win32'
           ? /^@echo off\r\nsetlocal\r\necho \{\}\r\n/
@@ -420,8 +416,7 @@ describe('ClaudeHookService.install', () => {
         expect(script).toContain('--data-urlencode "payload@-"')
         expect(script).toContain('/hook/claude')
         expect(script).not.toMatch(/Invoke-WebRequest/i)
-        // Why (#14818): `{}` must be the first line of output so a Claude-hooks-compat consumer
-        // never sees empty stdout, even on the guard-exit/Devin-skip paths below it.
+        // Why: guard and Devin-skip paths must still return neutral JSON (#14818).
         expect(script.split('\r\n')[2]).toBe('echo {}')
       } finally {
         vi.unstubAllEnvs()
@@ -466,8 +461,7 @@ describe('ClaudeHookService.installRemote', () => {
     const script = fs.files.get('/home/dev/.orca/agent-hooks/claude-hook.sh')
     expect(script).toContain('#!/bin/sh')
     expect(script).toContain('DEVIN_PROJECT_DIR')
-    // Why (#14818): `{}` must be the first thing written to stdout so a Claude-hooks-compat
-    // consumer never sees empty stdout, even on the guard-exit paths below it.
+    // Why: remote guard paths must still return neutral JSON (#14818).
     expect(script!.indexOf('printf "{}\\n"')).toBe(
       script!.indexOf('#!/bin/sh') + '#!/bin/sh\n'.length
     )

--- a/src/main/claude/hook-service.ts
+++ b/src/main/claude/hook-service.ts
@@ -65,8 +65,7 @@ function getManagedScript(
     return [
       '@echo off',
       'setlocal',
-      // Why (#14818): emit `{}` first so a Claude-hooks-compat consumer never sees empty stdout,
-      // even if the guards below exit early.
+      // Why: Claude-compatible permission hooks fail closed on empty stdout (#14818).
       'echo {}',
       // Why: refresh endpoint coordinates for PTYs surviving an Orca restart.
       'if defined ORCA_AGENT_HOOK_ENDPOINT if exist "%ORCA_AGENT_HOOK_ENDPOINT%" call "%ORCA_AGENT_HOOK_ENDPOINT%" 2>nul',
@@ -89,8 +88,7 @@ function getManagedScript(
 
   return [
     '#!/bin/sh',
-    // Why (#14818): emit `{}` first so a Claude-hooks-compat consumer never sees empty stdout,
-    // even if the guards below exit early.
+    // Why: Claude-compatible permission hooks fail closed on empty stdout (#14818).
     'printf "{}\\n"',
     ...buildPosixHookPayloadCapture(),
     ...(options.skipWhenDevinImportsClaude

--- a/src/main/claude/hook-service.ts
+++ b/src/main/claude/hook-service.ts
@@ -65,6 +65,9 @@ function getManagedScript(
     return [
       '@echo off',
       'setlocal',
+      // Why (#14818): emit `{}` first so a Claude-hooks-compat consumer never sees empty stdout,
+      // even if the guards below exit early.
+      'echo {}',
       // Why: refresh endpoint coordinates for PTYs surviving an Orca restart.
       'if defined ORCA_AGENT_HOOK_ENDPOINT if exist "%ORCA_AGENT_HOOK_ENDPOINT%" call "%ORCA_AGENT_HOOK_ENDPOINT%" 2>nul',
       // Why (#11549): the env guards must outrank the Devin skip — the Devin skip parks in more.com,
@@ -86,6 +89,9 @@ function getManagedScript(
 
   return [
     '#!/bin/sh',
+    // Why (#14818): emit `{}` first so a Claude-hooks-compat consumer never sees empty stdout,
+    // even if the guards below exit early.
+    'printf "{}\\n"',
     ...buildPosixHookPayloadCapture(),
     ...(options.skipWhenDevinImportsClaude
       ? [

--- a/src/main/claude/hook-settings.ts
+++ b/src/main/claude/hook-settings.ts
@@ -131,11 +131,15 @@ export function getRemoteConfigPath(remoteHome: string, settings = CLAUDE_HOOK_S
   return `${remoteHome.replace(/\/$/, '')}/${settings.configDirName}/settings.json`
 }
 
-export function getManagedCommand(scriptPath: string): string {
+export function getManagedCommand(
+  scriptPath: string,
+  options: { neutralJsonWhenMissing?: boolean } = {}
+): string {
   const scriptFileName = basename(scriptPath)
   const extension = extname(scriptFileName)
   return wrapRuntimeHomeHookCommand(
-    extension ? scriptFileName.slice(0, -extension.length) : scriptFileName
+    extension ? scriptFileName.slice(0, -extension.length) : scriptFileName,
+    options
   )
 }
 
@@ -144,26 +148,17 @@ export function getManagedLifecycleHook(
   settings = CLAUDE_HOOK_SETTINGS
 ): HookCommandConfig {
   if (process.platform !== 'win32' || !settings.usesWindowsPowerShellLauncher) {
-    return buildManagedCommandHook(getManagedCommand(scriptPath))
+    return buildManagedCommandHook(getManagedCommand(scriptPath, { neutralJsonWhenMissing: true }))
   }
   return getWindowsManagedLifecycleHook(scriptPath)
 }
 
-// Why: `args` is valid Claude Code hook syntax, but `~/.claude/settings.json` is also read by
-// third-party Claude-hooks-compat layers that reimplement execution and ignore it — cursor-agent
-// spawns `command` alone, so the old exec form ran bare conhost.exe, which opens an interactive
-// console that never closes (#14815). A single self-contained `command` string depends on nothing
-// optional, so it survives every consumer.
+// Why: some Claude-compatible consumers ignore `args`, so the invocation must be self-contained.
 export function getWindowsManagedLifecycleHook(scriptPath: string): HookCommandConfig {
   const scriptFileName = win32.basename(scriptPath)
-  // Why: $env:USERPROFILE (resolved at run time by powershell.exe, not baked in) keeps the
-  // managed entry portable across machines/usernames (STA-3348), matching the prior cmd.exe
-  // %USERPROFILE% form.
+  // Why: runtime profile resolution keeps the managed entry portable across users (STA-3348).
   const quotedRelativePath = quotePowerShellString(`.orca\\agent-hooks\\${scriptFileName}`)
-  // Why (#14818): the missing-script fallback must speak JSON too. A Claude-hooks-compat consumer
-  // parses stdout on every event, so a cleaned ~/.orca or a half-finished install would otherwise
-  // hand it empty stdout and get every tool call blocked — the same failure the script's own `{}`
-  // prevents. `{}` is a no-op decision for real Claude Code, identical to writing nothing.
+  // Why: compat consumers require neutral JSON even when the managed script is missing (#14818).
   const innerCommand =
     `$scriptPath = Join-Path $env:USERPROFILE ${quotedRelativePath}; ` +
     'if (Test-Path -LiteralPath $scriptPath -PathType Leaf) { & $scriptPath; exit $LASTEXITCODE }; ' +
@@ -186,7 +181,7 @@ export function hasSameManagedHookInvocation(
 }
 
 export function getRemoteManagedCommand(scriptPath: string): string {
-  return getManagedCommand(scriptPath)
+  return getManagedCommand(scriptPath, { neutralJsonWhenMissing: true })
 }
 
 export function applyManagedHooks(

--- a/src/main/claude/hook-settings.ts
+++ b/src/main/claude/hook-settings.ts
@@ -6,7 +6,9 @@ import {
   getSharedManagedScriptPath,
   isPlainObject,
   MANAGED_HOOK_TIMEOUT_SECONDS,
+  quotePowerShellString,
   removeManagedCommands,
+  wrapWindowsPowerShellEncodedCommand,
   type HookCommandConfig,
   type HookDefinition,
   type HooksConfig
@@ -16,38 +18,59 @@ import { wrapRuntimeHomeHookCommand } from '../agent-hooks/runtime-home-hook-com
 export type ClaudeCompatibleHookSettings = {
   configDirName: '.claude' | '.openclaude'
   scriptBaseName: 'claude-hook' | 'openclaude-hook'
-  supportsExecHookArgs: boolean
+  usesWindowsPowerShellLauncher: boolean
 }
 
 export const CLAUDE_HOOK_SETTINGS: ClaudeCompatibleHookSettings = {
   configDirName: '.claude',
   scriptBaseName: 'claude-hook',
-  supportsExecHookArgs: true
+  usesWindowsPowerShellLauncher: true
 }
 
 export const OPENCLAUDE_HOOK_SETTINGS: ClaudeCompatibleHookSettings = {
   configDirName: '.openclaude',
   scriptBaseName: 'openclaude-hook',
-  supportsExecHookArgs: false
+  usesWindowsPowerShellLauncher: false
 }
 
 export const CLAUDE_EVENTS = [
   // Why: SessionStart is the only event a resumed/idle session emits before the
   // first prompt; without it the sidebar row can't exist until the user types (STA-3386).
-  { eventName: 'SessionStart', definition: { hooks: [{ type: 'command', command: '' }] } },
-  { eventName: 'UserPromptSubmit', definition: { hooks: [{ type: 'command', command: '' }] } },
-  { eventName: 'Stop', definition: { hooks: [{ type: 'command', command: '' }] } },
+  {
+    eventName: 'SessionStart',
+    definition: { hooks: [{ type: 'command', command: '' }] }
+  },
+  {
+    eventName: 'UserPromptSubmit',
+    definition: { hooks: [{ type: 'command', command: '' }] }
+  },
+  {
+    eventName: 'Stop',
+    definition: { hooks: [{ type: 'command', command: '' }] }
+  },
   // Why: OpenClaude skips normal Stop hooks after API/model errors and emits
   // StopFailure instead; without this hook Orca leaves the turn spinning.
-  { eventName: 'StopFailure', definition: { hooks: [{ type: 'command', command: '' }] } },
+  {
+    eventName: 'StopFailure',
+    definition: { hooks: [{ type: 'command', command: '' }] }
+  },
   // Why: subagent/teammate lifecycle feeds the sidebar's child rows and keeps
   // a pane 'working' while background children outlive the lead's turn.
   // TeammateIdle parks turn-based teammates without trusting their permanently
   // "running" background_tasks entry to gate the pane.
   // Older Claude builds ignore unregistered event names (StopFailure precedent).
-  { eventName: 'SubagentStart', definition: { hooks: [{ type: 'command', command: '' }] } },
-  { eventName: 'SubagentStop', definition: { hooks: [{ type: 'command', command: '' }] } },
-  { eventName: 'TeammateIdle', definition: { hooks: [{ type: 'command', command: '' }] } },
+  {
+    eventName: 'SubagentStart',
+    definition: { hooks: [{ type: 'command', command: '' }] }
+  },
+  {
+    eventName: 'SubagentStop',
+    definition: { hooks: [{ type: 'command', command: '' }] }
+  },
+  {
+    eventName: 'TeammateIdle',
+    definition: { hooks: [{ type: 'command', command: '' }] }
+  },
   // Why: PreToolUse gives the dashboard a live readout of the in-flight tool
   // (name + input preview) before it completes.
   {
@@ -120,25 +143,34 @@ export function getManagedLifecycleHook(
   scriptPath: string,
   settings = CLAUDE_HOOK_SETTINGS
 ): HookCommandConfig {
-  if (process.platform !== 'win32' || !settings.supportsExecHookArgs) {
+  if (process.platform !== 'win32' || !settings.usesWindowsPowerShellLauncher) {
     return buildManagedCommandHook(getManagedCommand(scriptPath))
   }
   return getWindowsManagedLifecycleHook(scriptPath)
 }
 
+// Why: `args` is valid Claude Code hook syntax, but `~/.claude/settings.json` is also read by
+// third-party Claude-hooks-compat layers that reimplement execution and ignore it — cursor-agent
+// spawns `command` alone, so the old exec form ran bare conhost.exe, which opens an interactive
+// console that never closes (#14815). A single self-contained `command` string depends on nothing
+// optional, so it survives every consumer.
 export function getWindowsManagedLifecycleHook(scriptPath: string): HookCommandConfig {
-  const system32 = win32.join(process.env.SystemRoot ?? 'C:\\Windows', 'System32')
-  const runtimeScriptPath = win32.join(
-    '%USERPROFILE%',
-    '.orca',
-    'agent-hooks',
-    win32.basename(scriptPath)
-  )
-  // Why: Claude's Windows shell form opens Git Bash consoles; exec form hosts the client in a windowless console.
+  const scriptFileName = win32.basename(scriptPath)
+  // Why: $env:USERPROFILE (resolved at run time by powershell.exe, not baked in) keeps the
+  // managed entry portable across machines/usernames (STA-3348), matching the prior cmd.exe
+  // %USERPROFILE% form.
+  const quotedRelativePath = quotePowerShellString(`.orca\\agent-hooks\\${scriptFileName}`)
+  // Why (#14818): the missing-script fallback must speak JSON too. A Claude-hooks-compat consumer
+  // parses stdout on every event, so a cleaned ~/.orca or a half-finished install would otherwise
+  // hand it empty stdout and get every tool call blocked — the same failure the script's own `{}`
+  // prevents. `{}` is a no-op decision for real Claude Code, identical to writing nothing.
+  const innerCommand =
+    `$scriptPath = Join-Path $env:USERPROFILE ${quotedRelativePath}; ` +
+    'if (Test-Path -LiteralPath $scriptPath -PathType Leaf) { & $scriptPath; exit $LASTEXITCODE }; ' +
+    "[Console]::In.ReadToEnd() | Out-Null; Write-Output '{}'; exit 0"
   return {
     type: 'command',
-    command: win32.join(system32, 'conhost.exe'),
-    args: ['--headless', win32.join(system32, 'cmd.exe'), '/d', '/c', runtimeScriptPath],
+    command: wrapWindowsPowerShellEncodedCommand(innerCommand),
     timeout: MANAGED_HOOK_TIMEOUT_SECONDS
   }
 }

--- a/src/main/codex/hook-service-managed-install.test.ts
+++ b/src/main/codex/hook-service-managed-install.test.ts
@@ -30,7 +30,7 @@ vi.mock('os', async (importOriginal) => {
 import { CodexHookService } from './hook-service'
 
 const WINDOWS_POWERSHELL_LAUNCHER =
-  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -ExecutionPolicy Bypass -EncodedCommand \S+$/
+  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -EncodedCommand \S+$/
 
 const homes = setupCodexHookHomes(homedirMock, getPathMock)
 
@@ -235,24 +235,31 @@ describe('CodexHookService', () => {
       // would block the event loop and starve this handler, so the child is
       // spawned asynchronously while the server drains the request concurrently.
       let resolveReceived: (value: { headers: Record<string, unknown>; body: string }) => void
-      const receivedPromise = new Promise<{ headers: Record<string, unknown>; body: string }>(
-        (resolve) => {
-          resolveReceived = resolve
-        }
-      )
+      const receivedPromise = new Promise<{
+        headers: Record<string, unknown>
+        body: string
+      }>((resolve) => {
+        resolveReceived = resolve
+      })
       const server = createServer((req, res) => {
         const chunks: Buffer[] = []
         req.on('data', (c: Buffer) => chunks.push(c))
         req.on('end', () => {
           res.end('ok')
-          resolveReceived({ headers: req.headers, body: Buffer.concat(chunks).toString('utf-8') })
+          resolveReceived({
+            headers: req.headers,
+            body: Buffer.concat(chunks).toString('utf-8')
+          })
         })
       })
       await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
       const port = (server.address() as AddressInfo).port
 
       try {
-        const payload = JSON.stringify({ prompt: '你好世界', hook_event_name: 'UserPromptSubmit' })
+        const payload = JSON.stringify({
+          prompt: '你好世界',
+          hook_event_name: 'UserPromptSubmit'
+        })
         // Why: this suite may run inside an Orca-launched terminal whose env
         // already carries ORCA_AGENT_HOOK_ENDPOINT/PORT/TOKEN. The managed
         // script sources that endpoint file, so leave it out or the hook posts

--- a/src/main/command-code/hook-service.test.ts
+++ b/src/main/command-code/hook-service.test.ts
@@ -21,7 +21,7 @@ vi.mock('os', async () => {
 import { CommandCodeHookService } from './hook-service'
 
 const WINDOWS_POWERSHELL_LAUNCHER =
-  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -ExecutionPolicy Bypass -EncodedCommand \S+$/
+  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -EncodedCommand \S+$/
 
 describe('CommandCodeHookService', () => {
   let homeDir: string
@@ -136,7 +136,10 @@ describe('CommandCodeHookService', () => {
         body += chunk
       })
       req.on('end', () => {
-        requests.push({ body, token: req.headers['x-orca-agent-hook-token'] })
+        requests.push({
+          body,
+          token: req.headers['x-orca-agent-hook-token']
+        })
         res.statusCode = 204
         res.end()
       })

--- a/src/main/cursor/hook-service.test.ts
+++ b/src/main/cursor/hook-service.test.ts
@@ -31,7 +31,7 @@ const CURSOR_EVENTS = [
 
 const CURSOR_SCRIPT_FILE_NAME = process.platform === 'win32' ? 'cursor-hook.cmd' : 'cursor-hook.sh'
 const WINDOWS_POWERSHELL_LAUNCHER =
-  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -ExecutionPolicy Bypass -EncodedCommand \S+$/
+  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -EncodedCommand \S+$/
 
 describe('CursorHookService', () => {
   let homeDir: string

--- a/src/main/droid/hook-service.test.ts
+++ b/src/main/droid/hook-service.test.ts
@@ -25,7 +25,7 @@ vi.mock('os', async () => {
 import { DroidHookService } from './hook-service'
 
 const WINDOWS_POWERSHELL_LAUNCHER =
-  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -ExecutionPolicy Bypass -EncodedCommand \S+$/
+  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -EncodedCommand \S+$/
 
 describe('DroidHookService', () => {
   let homeDir: string

--- a/src/main/gemini/hook-service.test.ts
+++ b/src/main/gemini/hook-service.test.ts
@@ -26,7 +26,7 @@ vi.mock('os', async (importOriginal) => {
 import { GeminiHookService } from './hook-service'
 
 const WINDOWS_POWERSHELL_LAUNCHER =
-  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -ExecutionPolicy Bypass -EncodedCommand \S+$/
+  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -EncodedCommand \S+$/
 
 describe('GeminiHookService', () => {
   let homeDir: string

--- a/src/main/grok/hook-service.test.ts
+++ b/src/main/grok/hook-service.test.ts
@@ -23,7 +23,7 @@ import { POSIX_HOOK_STDIN_READER } from '../agent-hooks/hook-stdin-contract'
 
 const GROK_SCRIPT_FILE_NAME = process.platform === 'win32' ? 'grok-hook.cmd' : 'grok-hook.sh'
 const WINDOWS_POWERSHELL_LAUNCHER =
-  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -ExecutionPolicy Bypass -EncodedCommand \S+$/
+  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -EncodedCommand \S+$/
 
 type WindowsGrokHookRun = {
   status: number | null
@@ -343,7 +343,11 @@ describe('GrokHookService', () => {
       `${JSON.stringify(
         {
           hooks: {
-            Notification: [{ hooks: [{ type: 'command', command: '/usr/local/bin/user-hook' }] }]
+            Notification: [
+              {
+                hooks: [{ type: 'command', command: '/usr/local/bin/user-hook' }]
+              }
+            ]
           }
         },
         null,


### PR DESCRIPTION
## ELI5

Orca runs small background commands so Claude-compatible agents can report what they are doing. On Windows, some agents ignored part of Orca's command, while the old window-hiding wrapper swallowed the hook's response. That could leave stray console windows or make agents block every tool call because they received no valid answer.

This change gives those agents one complete hidden command and returns `{}`, meaning "Orca has no permission decision; continue normally." The hook now runs without flashing a console, preserves its output and exit status, and works through both cmd.exe and Git Bash.

<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​213 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​52 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​161 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​109 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​42 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​67 |

<!-- /orca-pr-loc -->

## Root cause

`~/.claude/settings.json` is not read only by Claude Code. Third-party **Claude-hooks-compat layers** — cursor-agent, Devin — import the same file and reimplement hook execution independently. Orca's entry therefore has to survive consumers that support strictly *less* than the documented schema. Assuming otherwise produced three separate defects, which together account for both issues.

### 1. The entry depended on `args`, which a compat consumer ignores → #14815

#13443 changed the Windows entry to exec form:

```json
{ "type": "command",
  "command": "C:\WINDOWS\System32\conhost.exe",
  "args": ["--headless", "...cmd.exe", "/d", "/c", "%USERPROFILE%\.orca\agent-hooks\claude-hook.cmd"] }
```

`args` **is** valid Claude Code syntax (verified against the current hooks docs — exec form spawns `command` directly with `args` as argv). The bug is that cursor-agent's compat layer spawns `command` alone. What ran was bare `conhost.exe`, which opens a console hosting an interactive shell in the current directory and never closes. Hook payloads then got typed into those stranded shells as literal input.

The fix is not "use `args` correctly" — it's to stop depending on an optional field at all. The entry is now a single self-contained `command` string.

### 2. `conhost.exe --headless` never relayed anything → #14818

This one invalidates the wrapper #14815 itself recommends. `conhost --headless` implements the ConPTY server protocol; it is not a generic no-window wrapper. It does not wait for the hosted process and relays neither its exit code nor its stdout. Measured directly on Windows 11:

| wrapper | stdout | exit code | waits for child |
| :--- | :--- | :--- | :--- |
| `conhost --headless … "echo X& exit /b 42"` | *(empty)* | *(none)* | no |
| `-WindowStyle Hidden … "…; exit 42"` | `X` | `42` | yes (1580ms for a 1200ms child) |

So every managed hook was fire-and-forget, and anything it printed was discarded. Note this also means #14815's own verification (`exit 0 … output empty`) could not have distinguished a working hook from a broken one — `conhost` returns 0 regardless, which the reporter correctly flagged as a caveat.

Replaced with `-WindowStyle Hidden`, which suppresses the window while keeping wait, exit code, and stdout relay intact. Confirmed visually on a live Windows build that no console flashes.

### 3. The hook never wrote anything to stdout → #14818

`claude-hook.cmd` had no path that wrote to stdout: the env guards exit silently and curl's output goes to `nul`. Claude Code documents exit 0 + empty stdout as *"no decision — the tool call continues through the normal permission flow."* cursor-agent instead treats `PreToolUse` as a permission gate, fails to parse empty stdout as JSON, and fails closed:

```
Error: Hook "C:\Windows\System32\conhost.exe" returned invalid JSON. The command was blocked for safety.
```

Since Orca registers `PreToolUse` with matcher `*`, **every shell command in every cursor-agent session on Windows was blocked.**

The script now writes `{}` as its first output on both the Windows and POSIX branches. Per the hooks docs, `{}` sets none of `decision` / `hookSpecificOutput` / `permissionDecision`, so it is *identical to writing nothing* for real Claude Code — this is not a behavior change there, it just states the "no opinion" explicitly instead of implicitly. Gemini and Antigravity already shipped exactly this pattern; Claude's script was the one that never got it.

> **These two fixes are causally linked.** `{}` cannot reach any consumer while `conhost` is swallowing stdout, so neither works without the other. That is why this is one PR rather than two.

## Also fixed while establishing the contract

- **The launcher's own missing-script fallback returned empty stdout**, reproducing #14818 whenever `~/.orca` was cleaned or an install was half-finished — the script isn't reached at all on that path. It now emits `{}` too. (Found by the new test, not by inspection.)
- **PowerShell writes progress records to stderr as CLIXML** when stderr is redirected. A consumer that merges stderr into stdout would see `#< CLIXML…` ahead of the JSON — the same failure mode from a different stream. Every encoded payload now silences progress; verified stderr goes from CLIXML to empty.
- **`runtime-home-hook-command.ts` built its own launcher with no window suppression** — precisely the drift #14815's suggested fix #1 asks to prevent, and missed by both original PRs. All launcher construction now goes through one `windows-powershell-hook-launcher.ts`, so the switch list cannot be present in one installer and missing in another. This is shared by claude, cursor, copilot, droid, gemini, grok, and command-code.
- Renamed `usesWindowsHeadlessHook` → `usesWindowsPowerShellLauncher`. Nothing is headless anymore, and the flag selects a launcher. OpenClaude stays `false` (unchanged).

## Testing

The previous tests asserted **installer intent** — which is exactly why they passed through all three defects, and what #14815 asks to change. The new regression test asserts the **effect a consumer observes**: it runs the exact `command` string from the generated `settings.json` through **both cmd.exe and Git Bash** (the reported execution context, where MSYS mangles `/`-switches and backslash paths), across all three reachable paths — guard exit, reached-curl, and missing-script — and parses stdout.

**Verified the test has teeth**: it fails with `SyntaxError: Unexpected token` when `conhost --headless` is reintroduced, and passes with the fix.

- `tsc --noEmit` clean; `oxlint` clean; max-lines ratchet clean (no new suppressions).
- Hook suites: 871 passed / 6 failed, and **all 6 failures reproduce identically on `origin/main`** — 4× Windows symlink `EPERM` (needs Developer Mode), 1× antigravity stdin EOF race, 1× Devin POSIX assertion running on Windows. No regressions: the full failure set was diffed against a baseline run of the same suites at `origin/main`.
- Rebased onto current `main`.

Fixes #14815
Fixes #14818