### PR TITLE
fix(claude): emit {} from the managed Windows hook so Claude-hooks-compat consumers don't fail closed

### DIFF
--- a/src/main/agent-hooks/hook-stdin-contract.ts
+++ b/src/main/agent-hooks/hook-stdin-contract.ts
@@ -35,14 +35,24 @@ export const WINDOWS_HOOK_STDIN_DRAIN_COMMAND = `${WINDOWS_HOOK_STDIN_READER} >n
 // that path anyway. This applies to .cmd, the copilot .ps1, and the Git Bash kimi .sh alike.
 // POSIX hooks keep capture-first: their callers close stdin, and exiting mid-write there
 // surfaces as EPIPE the agent can see (#8110).
-export function buildWindowsHookEnvironmentGuardLines(): string[] {
+export function buildWindowsHookEnvironmentGuardLines(
+  options: { emitEmptyJsonStdout?: boolean } = {}
+): string[] {
+  const exitCommand = options.emitEmptyJsonStdout ? '(echo {}& exit /b 0)' : 'exit /b 0'
   return [
-    'if "%ORCA_AGENT_HOOK_PORT%"=="" exit /b 0',
-    'if "%ORCA_AGENT_HOOK_TOKEN%"=="" exit /b 0',
-    'if "%ORCA_PANE_KEY%"=="" exit /b 0'
+    `if "%ORCA_AGENT_HOOK_PORT%"=="" ${exitCommand}`,
+    `if "%ORCA_AGENT_HOOK_TOKEN%"=="" ${exitCommand}`,
+    `if "%ORCA_PANE_KEY%"=="" ${exitCommand}`
   ]
 }
 
-export function buildWindowsHookStdinDrainEpilogue(): string[] {
-  return [`:${WINDOWS_HOOK_STDIN_DRAIN_LABEL}`, WINDOWS_HOOK_STDIN_DRAIN_COMMAND, 'exit /b 0']
+export function buildWindowsHookStdinDrainEpilogue(
+  options: { emitEmptyJsonStdout?: boolean } = {}
+): string[] {
+  return [
+    `:${WINDOWS_HOOK_STDIN_DRAIN_LABEL}`,
+    WINDOWS_HOOK_STDIN_DRAIN_COMMAND,
+    ...(options.emitEmptyJsonStdout ? ['echo {}'] : []),
+    'exit /b 0'
+  ]
 }

--- a/src/main/claude/hook-service.test.ts
+++ b/src/main/claude/hook-service.test.ts
@@ -399,6 +399,36 @@ describe('ClaudeHookService.install', () => {
       }
     }
   )
+
+  // Why (#14818): cursor-agent's Claude-hooks-compat layer treats clean, empty PreToolUse stdout
+  // as an invalid permission verdict and fails closed. Every exit path of the managed .cmd —
+  // the three env guards, the main success path, and the Devin-skip stdin-drain epilogue — must
+  // emit a bare `{}` so that consumer sees a valid (empty) decision instead of nothing.
+  it.skipIf(process.platform !== 'win32')(
+    'emits {} on stdout from every exit path of the managed .cmd (#14818)',
+    () => {
+      const tmpHome = mkdtempSync(join(tmpdir(), 'orca-claude-emptyjson-'))
+      vi.stubEnv('HOME', tmpHome)
+      vi.stubEnv('USERPROFILE', tmpHome)
+      try {
+        expect(new ClaudeHookService().install().state).toBe('installed')
+        const script = readFileSync(
+          join(tmpHome, '.orca', 'agent-hooks', CLAUDE_SCRIPT_FILE_NAME),
+          'utf-8'
+        )
+        for (const guardVar of ['ORCA_AGENT_HOOK_PORT', 'ORCA_AGENT_HOOK_TOKEN', 'ORCA_PANE_KEY']) {
+          expect(script).toContain(`if "%${guardVar}%"=="" (echo {}& exit /b 0)`)
+        }
+        // Why: the curl call itself is silenced (`>nul 2>&1`), so `echo {}` is the only thing the
+        // success path writes to stdout.
+        expect(script).toMatch(/>nul 2>&1\r\necho \{\}\r\nexit \/b 0/)
+        expect(script).toMatch(/orca_agent_hook_drain_stdin[\s\S]*echo \{\}\r\nexit \/b 0/)
+      } finally {
+        vi.unstubAllEnvs()
+        rmSync(tmpHome, { recursive: true, force: true })
+      }
+    }
+  )
 })
 
 describe('ClaudeHookService.installRemote', () => {

--- a/src/main/claude/hook-service.ts
+++ b/src/main/claude/hook-service.ts
@@ -69,7 +69,10 @@ function getManagedScript(
       'if defined ORCA_AGENT_HOOK_ENDPOINT if exist "%ORCA_AGENT_HOOK_ENDPOINT%" call "%ORCA_AGENT_HOOK_ENDPOINT%" 2>nul',
       // Why (#11549): the env guards must outrank the Devin skip — the Devin skip parks in more.com,
       // and outside an Orca pane the caller can abandon stdin, so more.com never returns.
-      ...buildWindowsHookEnvironmentGuardLines(),
+      // Why emitEmptyJsonStdout (#14818): a third-party Claude-hooks-compat consumer (cursor-agent)
+      // treats a clean, empty stdout on PreToolUse as an invalid permission verdict and fails
+      // closed; a bare `{}` is a no-op for real Claude Code but satisfies that consumer's parser.
+      ...buildWindowsHookEnvironmentGuardLines({ emitEmptyJsonStdout: true }),
       ...(options.skipWhenDevinImportsClaude
         ? [
             // Why: Devin imports .claude hooks by default; skip Orca's managed hook there so status posts stay attributed to Devin.
@@ -78,8 +81,9 @@ function getManagedScript(
         : []),
       // Why: use curl.exe to avoid an extra PowerShell startup per hook.
       buildWindowsAgentHookCurlPostCommand('claude'),
+      'echo {}',
       'exit /b 0',
-      ...buildWindowsHookStdinDrainEpilogue(),
+      ...buildWindowsHookStdinDrainEpilogue({ emitEmptyJsonStdout: true }),
       ''
     ].join('\r\n')
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | +30 | 0 | +30 |
| Prod | 2 | +22 | −8 | +14 |

<!-- /orca-pr-loc -->

## Root cause

The managed Windows Claude hook script (`claude-hook.cmd`) never writes anything to stdout on any path: the three env guards (`ORCA_AGENT_HOOK_PORT`/`TOKEN`/`ORCA_PANE_KEY` missing) exit silently, and the curl POST that reports the event to Orca is redirected to `>nul 2>&1`.

I checked the current hook documentation (code.claude.com/docs/en/hooks) for what that means: exit 0 with empty stdout is explicitly documented as a pass-through — "the hook has no decision to report, so the tool call continues through the normal permission flow." An empty JSON object `{}` is documented to mean the same thing for every event, including the permission-decision ones (`PreToolUse`, `PermissionRequest`): none of the decision fields (`decision`, `hookSpecificOutput`, `permissionDecision`) are set, so it's treated as "no decision," identically to no output at all. So for real Claude Code, "write nothing" and "write `{}`" are the same thing.

cursor-agent's third-party Claude-hooks-compat layer doesn't implement that convention. It treats `PreToolUse` as a permission hook that must return a JSON verdict, and empty stdout is invalid JSON to its parser — so it fails closed:

```
Error: Hook "C:\Windows\System32\conhost.exe" returned invalid JSON. The command was blocked for safety.
```

Every shell command in every cursor-agent session on Windows gets blocked, since Orca's own managed hook is registered on `PreToolUse` with matcher `*`.

## Why this is the root-cause fix, not a workaround

Orca doesn't control cursor-agent's parser — there's no fix available there. What Orca does control is its own hook script, and that script currently relies on an *implicit* convention ("nothing on stdout means no opinion") instead of *stating* that opinion explicitly. `{}` is a valid, schema-passing JSON object with no fields set. By the documented contract, it is indistinguishable from no output for real Claude Code — so emitting it is not a behavior change for Claude Code itself. It just makes Orca's script an explicit, spec-compliant "no decision" instead of an implicit one, which happens to also be exactly what a strict but spec-following third-party consumer needs to not choke.

## Fix

Added `emitEmptyJsonStdout` as an **opt-in** option (default `false`, unchanged behavior) on the two shared helpers in `hook-stdin-contract.ts`:

- `buildWindowsHookEnvironmentGuardLines({ emitEmptyJsonStdout: true })` — each of the three env guards becomes `if "%VAR%"=="" (echo {}& exit /b 0)` instead of `if "%VAR%"=="" exit /b 0`.
- `buildWindowsHookStdinDrainEpilogue({ emitEmptyJsonStdout: true })` — the stdin-drain epilogue (used both as the normal tail and as the Devin-skip landing point) emits `echo {}` before its `exit /b 0`.

Wired both into `getManagedScript('local', ...)` in `hook-service.ts` for the Claude `.cmd`, plus one `echo {}` before the main success-path `exit /b 0` after the curl POST. That covers every exit path: the three early guards, the Devin-skip drain, and the normal success path.

The POSIX `.sh` branch and the statusline script are untouched — the statusline's stdout *is* the literal status line text shown in the UI, so emitting `{}` there would show `{}` in the UI. That script is not affected by any change in this PR.

## Scope

The two shared helpers are used by seven other agent hook services (Grok, Gemini, Droid, Devin, Cursor's own installer, Command Code, Codex, Antigravity). None of them were reported to have this problem, and none of them call the new option — the default keeps their generated scripts byte-for-byte identical to before this PR. Verified by running each of their test suites (see below); only Claude's own test file changes shape.

## Testing

- `npx tsc --noEmit -p config/tsconfig.node.json` — clean.
- `hook-service.test.ts` — 15/15 pass, including a new regression test asserting `{}` is emitted from every exit path of the generated `.cmd` (all three guards, the success path, and the drain epilogue).
- Ran the full test suites for every other consumer of the shared helpers (`antigravity`, `command-code`, `droid`, `devin`, `cursor`, `gemini`, `grok`, `codex`, plus `statusline-script.test.ts`) — same 14 pre-existing failures as `origin/main` with no changes applied (codex-session-resume-home path tests + one Devin POSIX-assertion test, both environmental/pre-existing, unrelated to `hook-stdin-contract.ts`), confirming the opt-in default didn't regress any of them.
- Confirmed curl's own stdout/stderr is redirected to `nul` (`buildWindowsAgentHookCurlPostCommand`), so `echo {}` really is the only thing written to the script's stdout — no risk of the HTTP response body contaminating the JSON a consumer parses.

Fixes #14818