### PR TITLE
ci: color added/deleted LoC counts in PR summary

### DIFF
--- a/.github/scripts/pr-test-loc-table.mjs
+++ b/.github/scripts/pr-test-loc-table.mjs
@@ -37,7 +37,7 @@ const COLOR_ADDED = '#1a7f37'
 const COLOR_DELETED = '#cf222e'
 
 function diffMath(color, text) {
-  return `$\\color{${color}}{\\large{\\textbf{\\textsf{${text}}}}}$`
+  return `$\\color{${color}}{\\large{\\mathbf{${text}}}}$`
 }
 
 function diffCell(count) {

--- a/.github/scripts/pr-test-loc-table.mjs
+++ b/.github/scripts/pr-test-loc-table.mjs
@@ -41,9 +41,9 @@ function diffCell(count) {
     return '0'
   }
   if (count > 0) {
-    return `+${count} \`${COLOR_ADDED}\``
+    return `$\\color{${COLOR_ADDED}}{\\textsf{+${count}}}$`
   }
-  return `−${Math.abs(count)} \`${COLOR_DELETED}\``
+  return `$\\color{${COLOR_DELETED}}{\\textsf{−${Math.abs(count)}}}$`
 }
 
 function locTableRow(label, bucket) {

--- a/.github/scripts/pr-test-loc-table.mjs
+++ b/.github/scripts/pr-test-loc-table.mjs
@@ -36,18 +36,14 @@ export function sumChangedFiles(files) {
 const COLOR_ADDED = '#1a7f37'
 const COLOR_DELETED = '#cf222e'
 
-function diffMath(color, text) {
-  return `$\\color{${color}}{\\large{\\mathbf{${text}}}}$`
-}
-
 function diffCell(count) {
   if (count === 0) {
-    return diffMath('white', '0')
+    return '0'
   }
   if (count > 0) {
-    return diffMath(COLOR_ADDED, `+${count}`)
+    return `$\\color{${COLOR_ADDED}}{+}$\u200b${count}`
   }
-  return diffMath(COLOR_DELETED, `−${Math.abs(count)}`)
+  return `$\\color{${COLOR_DELETED}}{−}$\u200b${Math.abs(count)}`
 }
 
 function locTableRow(label, bucket) {

--- a/.github/scripts/pr-test-loc-table.mjs
+++ b/.github/scripts/pr-test-loc-table.mjs
@@ -38,12 +38,12 @@ const COLOR_DELETED = '#cf222e'
 
 function diffCell(count) {
   if (count === 0) {
-    return '0'
+    return `$\\color{white}{\\textbf{0}}$`
   }
   if (count > 0) {
-    return `$\\color{${COLOR_ADDED}}{\\textsf{+${count}}}$`
+    return `$\\color{${COLOR_ADDED}}{\\textbf{+${count}}}$`
   }
-  return `$\\color{${COLOR_DELETED}}{\\textsf{−${Math.abs(count)}}}$`
+  return `$\\color{${COLOR_DELETED}}{\\textbf{−${Math.abs(count)}}}$`
 }
 
 function locTableRow(label, bucket) {

--- a/.github/scripts/pr-test-loc-table.mjs
+++ b/.github/scripts/pr-test-loc-table.mjs
@@ -33,15 +33,27 @@ export function sumChangedFiles(files) {
   return totals
 }
 
-function signed(count) {
+const COLOR_ADDED = '#1a7f37'
+const COLOR_DELETED = '#cf222e'
+
+function colored(text, color) {
+  return `<span style="color:${color}">${text}</span>`
+}
+
+function diffCell(count) {
   if (count === 0) {
     return '0'
   }
-  return count > 0 ? `+${count}` : `−${Math.abs(count)}`
+  if (count > 0) {
+    return colored(`+${count}`, COLOR_ADDED)
+  }
+  return colored(`−${Math.abs(count)}`, COLOR_DELETED)
 }
 
 function locTableRow(label, bucket) {
-  return `| ${label} | ${bucket.files ?? 0} | ${signed(bucket.added)} | ${signed(-(bucket.deleted ?? 0))} | ${signed((bucket.added ?? 0) - (bucket.deleted ?? 0))} |`
+  const added = bucket.added ?? 0
+  const deleted = bucket.deleted ?? 0
+  return `| ${label} | ${bucket.files ?? 0} | ${diffCell(added)} | ${diffCell(-deleted)} | ${diffCell(added - deleted)} |`
 }
 
 export function formatLocTable({ test, nonTest }) {

--- a/.github/scripts/pr-test-loc-table.mjs
+++ b/.github/scripts/pr-test-loc-table.mjs
@@ -36,18 +36,14 @@ export function sumChangedFiles(files) {
 const COLOR_ADDED = '#1a7f37'
 const COLOR_DELETED = '#cf222e'
 
-function colored(text, color) {
-  return `<span style="color:${color}">${text}</span>`
-}
-
 function diffCell(count) {
   if (count === 0) {
     return '0'
   }
   if (count > 0) {
-    return colored(`+${count}`, COLOR_ADDED)
+    return `+${count} \`${COLOR_ADDED}\``
   }
-  return colored(`−${Math.abs(count)}`, COLOR_DELETED)
+  return `−${Math.abs(count)} \`${COLOR_DELETED}\``
 }
 
 function locTableRow(label, bucket) {

--- a/.github/scripts/pr-test-loc-table.mjs
+++ b/.github/scripts/pr-test-loc-table.mjs
@@ -36,14 +36,18 @@ export function sumChangedFiles(files) {
 const COLOR_ADDED = '#1a7f37'
 const COLOR_DELETED = '#cf222e'
 
+function diffMath(color, text) {
+  return `$\\color{${color}}{\\large{\\textbf{\\textsf{${text}}}}}$`
+}
+
 function diffCell(count) {
   if (count === 0) {
-    return `$\\color{white}{\\textbf{0}}$`
+    return diffMath('white', '0')
   }
   if (count > 0) {
-    return `$\\color{${COLOR_ADDED}}{\\textbf{+${count}}}$`
+    return diffMath(COLOR_ADDED, `+${count}`)
   }
-  return `$\\color{${COLOR_DELETED}}{\\textbf{−${Math.abs(count)}}}$`
+  return diffMath(COLOR_DELETED, `−${Math.abs(count)}`)
 }
 
 function locTableRow(label, bucket) {

--- a/config/scripts/pr-test-loc-summary.test.mjs
+++ b/config/scripts/pr-test-loc-summary.test.mjs
@@ -101,6 +101,20 @@ describe('PR test LoC summary', () => {
     })
   })
 
+  it('colors added cells green and deleted or negative-net cells red', () => {
+    const block = renderLocBlock({
+      test: { files: 1, added: 2, deleted: 5 },
+      nonTest: { files: 1, added: 0, deleted: 4 }
+    })
+
+    expect(block).toContain(
+      '| Test | 1 | <span style="color:#1a7f37">+2</span> | <span style="color:#cf222e">−5</span> | <span style="color:#cf222e">−3</span> |'
+    )
+    expect(block).toContain(
+      '| Prod | 1 | 0 | <span style="color:#cf222e">−4</span> | <span style="color:#cf222e">−4</span> |'
+    )
+  })
+
   it('replaces an existing header and prepends when missing', () => {
     const totals = {
       test: { files: 1, added: 2, deleted: 1 },
@@ -109,8 +123,12 @@ describe('PR test LoC summary', () => {
     const block = renderLocBlock(totals)
 
     expect(block).toContain(LOC_HANDS_OFF_COMMENT)
-    expect(block).toContain('| Test | 1 | +2 | −1 | +1 |')
-    expect(block).toContain('| Prod | 1 | +4 | 0 | +4 |')
+    expect(block).toContain(
+      '| Test | 1 | <span style="color:#1a7f37">+2</span> | <span style="color:#cf222e">−1</span> | <span style="color:#1a7f37">+1</span> |'
+    )
+    expect(block).toContain(
+      '| Prod | 1 | <span style="color:#1a7f37">+4</span> | 0 | <span style="color:#1a7f37">+4</span> |'
+    )
     expect(block).not.toContain('| Total |')
     expect(mergeLocBlock('## ELI5\n\nHello\n', totals)).toBe(`${block}\n\n## ELI5\n\nHello\n`)
     expect(mergeLocBlock(`${block}\n\n## ELI5\n`, totals)).toBe(`${block}\n\n## ELI5\n`)
@@ -141,8 +159,12 @@ describe('PR test LoC summary', () => {
     expect(result.status).toBe(0)
     expect(result.stdout.startsWith('<!-- orca-pr-loc -->')).toBe(true)
     expect(result.stdout).toContain(LOC_HANDS_OFF_COMMENT)
-    expect(result.stdout).toContain('| Test | 1 | +6 | −1 | +5 |')
-    expect(result.stdout).toContain('| Prod | 1 | +2 | 0 | +2 |')
+    expect(result.stdout).toContain(
+      '| Test | 1 | <span style="color:#1a7f37">+6</span> | <span style="color:#cf222e">−1</span> | <span style="color:#1a7f37">+5</span> |'
+    )
+    expect(result.stdout).toContain(
+      '| Prod | 1 | <span style="color:#1a7f37">+2</span> | 0 | <span style="color:#1a7f37">+2</span> |'
+    )
     expect(result.stdout).not.toContain('| Total |')
     expect(result.stdout).toContain('## ELI5\n\nHello\n')
     expect(result.stdout.match(/<!-- orca-pr-loc -->/g)).toHaveLength(1)

--- a/config/scripts/pr-test-loc-summary.test.mjs
+++ b/config/scripts/pr-test-loc-summary.test.mjs
@@ -108,10 +108,10 @@ describe('PR test LoC summary', () => {
     })
 
     expect(block).toContain(
-      '| Test | 1 | $\\color{#1a7f37}{\\textsf{+2}}$ | $\\color{#cf222e}{\\textsf{−5}}$ | $\\color{#cf222e}{\\textsf{−3}}$ |'
+      '| Test | 1 | $\\color{#1a7f37}{\\textbf{+2}}$ | $\\color{#cf222e}{\\textbf{−5}}$ | $\\color{#cf222e}{\\textbf{−3}}$ |'
     )
     expect(block).toContain(
-      '| Prod | 1 | 0 | $\\color{#cf222e}{\\textsf{−4}}$ | $\\color{#cf222e}{\\textsf{−4}}$ |'
+      '| Prod | 1 | $\\color{white}{\\textbf{0}}$ | $\\color{#cf222e}{\\textbf{−4}}$ | $\\color{#cf222e}{\\textbf{−4}}$ |'
     )
   })
 
@@ -124,10 +124,10 @@ describe('PR test LoC summary', () => {
 
     expect(block).toContain(LOC_HANDS_OFF_COMMENT)
     expect(block).toContain(
-      '| Test | 1 | $\\color{#1a7f37}{\\textsf{+2}}$ | $\\color{#cf222e}{\\textsf{−1}}$ | $\\color{#1a7f37}{\\textsf{+1}}$ |'
+      '| Test | 1 | $\\color{#1a7f37}{\\textbf{+2}}$ | $\\color{#cf222e}{\\textbf{−1}}$ | $\\color{#1a7f37}{\\textbf{+1}}$ |'
     )
     expect(block).toContain(
-      '| Prod | 1 | $\\color{#1a7f37}{\\textsf{+4}}$ | 0 | $\\color{#1a7f37}{\\textsf{+4}}$ |'
+      '| Prod | 1 | $\\color{#1a7f37}{\\textbf{+4}}$ | $\\color{white}{\\textbf{0}}$ | $\\color{#1a7f37}{\\textbf{+4}}$ |'
     )
     expect(block).not.toContain('| Total |')
     expect(mergeLocBlock('## ELI5\n\nHello\n', totals)).toBe(`${block}\n\n## ELI5\n\nHello\n`)
@@ -160,10 +160,10 @@ describe('PR test LoC summary', () => {
     expect(result.stdout.startsWith('<!-- orca-pr-loc -->')).toBe(true)
     expect(result.stdout).toContain(LOC_HANDS_OFF_COMMENT)
     expect(result.stdout).toContain(
-      '| Test | 1 | $\\color{#1a7f37}{\\textsf{+6}}$ | $\\color{#cf222e}{\\textsf{−1}}$ | $\\color{#1a7f37}{\\textsf{+5}}$ |'
+      '| Test | 1 | $\\color{#1a7f37}{\\textbf{+6}}$ | $\\color{#cf222e}{\\textbf{−1}}$ | $\\color{#1a7f37}{\\textbf{+5}}$ |'
     )
     expect(result.stdout).toContain(
-      '| Prod | 1 | $\\color{#1a7f37}{\\textsf{+2}}$ | 0 | $\\color{#1a7f37}{\\textsf{+2}}$ |'
+      '| Prod | 1 | $\\color{#1a7f37}{\\textbf{+2}}$ | $\\color{white}{\\textbf{0}}$ | $\\color{#1a7f37}{\\textbf{+2}}$ |'
     )
     expect(result.stdout).not.toContain('| Total |')
     expect(result.stdout).toContain('## ELI5\n\nHello\n')

--- a/config/scripts/pr-test-loc-summary.test.mjs
+++ b/config/scripts/pr-test-loc-summary.test.mjs
@@ -108,10 +108,10 @@ describe('PR test LoC summary', () => {
     })
 
     expect(block).toContain(
-      '| Test | 1 | $\\color{#1a7f37}{\\large{\\mathbf{+2}}}$ | $\\color{#cf222e}{\\large{\\mathbf{−5}}}$ | $\\color{#cf222e}{\\large{\\mathbf{−3}}}$ |'
+      '| Test | 1 | $\\color{#1a7f37}{+}$\u200b2 | $\\color{#cf222e}{−}$\u200b5 | $\\color{#cf222e}{−}$\u200b3 |'
     )
     expect(block).toContain(
-      '| Prod | 1 | $\\color{white}{\\large{\\mathbf{0}}}$ | $\\color{#cf222e}{\\large{\\mathbf{−4}}}$ | $\\color{#cf222e}{\\large{\\mathbf{−4}}}$ |'
+      '| Prod | 1 | 0 | $\\color{#cf222e}{−}$\u200b4 | $\\color{#cf222e}{−}$\u200b4 |'
     )
   })
 
@@ -124,10 +124,10 @@ describe('PR test LoC summary', () => {
 
     expect(block).toContain(LOC_HANDS_OFF_COMMENT)
     expect(block).toContain(
-      '| Test | 1 | $\\color{#1a7f37}{\\large{\\mathbf{+2}}}$ | $\\color{#cf222e}{\\large{\\mathbf{−1}}}$ | $\\color{#1a7f37}{\\large{\\mathbf{+1}}}$ |'
+      '| Test | 1 | $\\color{#1a7f37}{+}$\u200b2 | $\\color{#cf222e}{−}$\u200b1 | $\\color{#1a7f37}{+}$\u200b1 |'
     )
     expect(block).toContain(
-      '| Prod | 1 | $\\color{#1a7f37}{\\large{\\mathbf{+4}}}$ | $\\color{white}{\\large{\\mathbf{0}}}$ | $\\color{#1a7f37}{\\large{\\mathbf{+4}}}$ |'
+      '| Prod | 1 | $\\color{#1a7f37}{+}$\u200b4 | 0 | $\\color{#1a7f37}{+}$\u200b4 |'
     )
     expect(block).not.toContain('| Total |')
     expect(mergeLocBlock('## ELI5\n\nHello\n', totals)).toBe(`${block}\n\n## ELI5\n\nHello\n`)
@@ -160,10 +160,10 @@ describe('PR test LoC summary', () => {
     expect(result.stdout.startsWith('<!-- orca-pr-loc -->')).toBe(true)
     expect(result.stdout).toContain(LOC_HANDS_OFF_COMMENT)
     expect(result.stdout).toContain(
-      '| Test | 1 | $\\color{#1a7f37}{\\large{\\mathbf{+6}}}$ | $\\color{#cf222e}{\\large{\\mathbf{−1}}}$ | $\\color{#1a7f37}{\\large{\\mathbf{+5}}}$ |'
+      '| Test | 1 | $\\color{#1a7f37}{+}$\u200b6 | $\\color{#cf222e}{−}$\u200b1 | $\\color{#1a7f37}{+}$\u200b5 |'
     )
     expect(result.stdout).toContain(
-      '| Prod | 1 | $\\color{#1a7f37}{\\large{\\mathbf{+2}}}$ | $\\color{white}{\\large{\\mathbf{0}}}$ | $\\color{#1a7f37}{\\large{\\mathbf{+2}}}$ |'
+      '| Prod | 1 | $\\color{#1a7f37}{+}$\u200b2 | 0 | $\\color{#1a7f37}{+}$\u200b2 |'
     )
     expect(result.stdout).not.toContain('| Total |')
     expect(result.stdout).toContain('## ELI5\n\nHello\n')

--- a/config/scripts/pr-test-loc-summary.test.mjs
+++ b/config/scripts/pr-test-loc-summary.test.mjs
@@ -108,10 +108,10 @@ describe('PR test LoC summary', () => {
     })
 
     expect(block).toContain(
-      '| Test | 1 | $\\color{#1a7f37}{\\large{\\textbf{\\textsf{+2}}}}$ | $\\color{#cf222e}{\\large{\\textbf{\\textsf{−5}}}}$ | $\\color{#cf222e}{\\large{\\textbf{\\textsf{−3}}}}$ |'
+      '| Test | 1 | $\\color{#1a7f37}{\\large{\\mathbf{+2}}}$ | $\\color{#cf222e}{\\large{\\mathbf{−5}}}$ | $\\color{#cf222e}{\\large{\\mathbf{−3}}}$ |'
     )
     expect(block).toContain(
-      '| Prod | 1 | $\\color{white}{\\large{\\textbf{\\textsf{0}}}}$ | $\\color{#cf222e}{\\large{\\textbf{\\textsf{−4}}}}$ | $\\color{#cf222e}{\\large{\\textbf{\\textsf{−4}}}}$ |'
+      '| Prod | 1 | $\\color{white}{\\large{\\mathbf{0}}}$ | $\\color{#cf222e}{\\large{\\mathbf{−4}}}$ | $\\color{#cf222e}{\\large{\\mathbf{−4}}}$ |'
     )
   })
 
@@ -124,10 +124,10 @@ describe('PR test LoC summary', () => {
 
     expect(block).toContain(LOC_HANDS_OFF_COMMENT)
     expect(block).toContain(
-      '| Test | 1 | $\\color{#1a7f37}{\\large{\\textbf{\\textsf{+2}}}}$ | $\\color{#cf222e}{\\large{\\textbf{\\textsf{−1}}}}$ | $\\color{#1a7f37}{\\large{\\textbf{\\textsf{+1}}}}$ |'
+      '| Test | 1 | $\\color{#1a7f37}{\\large{\\mathbf{+2}}}$ | $\\color{#cf222e}{\\large{\\mathbf{−1}}}$ | $\\color{#1a7f37}{\\large{\\mathbf{+1}}}$ |'
     )
     expect(block).toContain(
-      '| Prod | 1 | $\\color{#1a7f37}{\\large{\\textbf{\\textsf{+4}}}}$ | $\\color{white}{\\large{\\textbf{\\textsf{0}}}}$ | $\\color{#1a7f37}{\\large{\\textbf{\\textsf{+4}}}}$ |'
+      '| Prod | 1 | $\\color{#1a7f37}{\\large{\\mathbf{+4}}}$ | $\\color{white}{\\large{\\mathbf{0}}}$ | $\\color{#1a7f37}{\\large{\\mathbf{+4}}}$ |'
     )
     expect(block).not.toContain('| Total |')
     expect(mergeLocBlock('## ELI5\n\nHello\n', totals)).toBe(`${block}\n\n## ELI5\n\nHello\n`)
@@ -160,10 +160,10 @@ describe('PR test LoC summary', () => {
     expect(result.stdout.startsWith('<!-- orca-pr-loc -->')).toBe(true)
     expect(result.stdout).toContain(LOC_HANDS_OFF_COMMENT)
     expect(result.stdout).toContain(
-      '| Test | 1 | $\\color{#1a7f37}{\\large{\\textbf{\\textsf{+6}}}}$ | $\\color{#cf222e}{\\large{\\textbf{\\textsf{−1}}}}$ | $\\color{#1a7f37}{\\large{\\textbf{\\textsf{+5}}}}$ |'
+      '| Test | 1 | $\\color{#1a7f37}{\\large{\\mathbf{+6}}}$ | $\\color{#cf222e}{\\large{\\mathbf{−1}}}$ | $\\color{#1a7f37}{\\large{\\mathbf{+5}}}$ |'
     )
     expect(result.stdout).toContain(
-      '| Prod | 1 | $\\color{#1a7f37}{\\large{\\textbf{\\textsf{+2}}}}$ | $\\color{white}{\\large{\\textbf{\\textsf{0}}}}$ | $\\color{#1a7f37}{\\large{\\textbf{\\textsf{+2}}}}$ |'
+      '| Prod | 1 | $\\color{#1a7f37}{\\large{\\mathbf{+2}}}$ | $\\color{white}{\\large{\\mathbf{0}}}$ | $\\color{#1a7f37}{\\large{\\mathbf{+2}}}$ |'
     )
     expect(result.stdout).not.toContain('| Total |')
     expect(result.stdout).toContain('## ELI5\n\nHello\n')

--- a/config/scripts/pr-test-loc-summary.test.mjs
+++ b/config/scripts/pr-test-loc-summary.test.mjs
@@ -107,8 +107,12 @@ describe('PR test LoC summary', () => {
       nonTest: { files: 1, added: 0, deleted: 4 }
     })
 
-    expect(block).toContain('| Test | 1 | +2 `#1a7f37` | −5 `#cf222e` | −3 `#cf222e` |')
-    expect(block).toContain('| Prod | 1 | 0 | −4 `#cf222e` | −4 `#cf222e` |')
+    expect(block).toContain(
+      '| Test | 1 | $\\color{#1a7f37}{\\textsf{+2}}$ | $\\color{#cf222e}{\\textsf{−5}}$ | $\\color{#cf222e}{\\textsf{−3}}$ |'
+    )
+    expect(block).toContain(
+      '| Prod | 1 | 0 | $\\color{#cf222e}{\\textsf{−4}}$ | $\\color{#cf222e}{\\textsf{−4}}$ |'
+    )
   })
 
   it('replaces an existing header and prepends when missing', () => {
@@ -119,8 +123,12 @@ describe('PR test LoC summary', () => {
     const block = renderLocBlock(totals)
 
     expect(block).toContain(LOC_HANDS_OFF_COMMENT)
-    expect(block).toContain('| Test | 1 | +2 `#1a7f37` | −1 `#cf222e` | +1 `#1a7f37` |')
-    expect(block).toContain('| Prod | 1 | +4 `#1a7f37` | 0 | +4 `#1a7f37` |')
+    expect(block).toContain(
+      '| Test | 1 | $\\color{#1a7f37}{\\textsf{+2}}$ | $\\color{#cf222e}{\\textsf{−1}}$ | $\\color{#1a7f37}{\\textsf{+1}}$ |'
+    )
+    expect(block).toContain(
+      '| Prod | 1 | $\\color{#1a7f37}{\\textsf{+4}}$ | 0 | $\\color{#1a7f37}{\\textsf{+4}}$ |'
+    )
     expect(block).not.toContain('| Total |')
     expect(mergeLocBlock('## ELI5\n\nHello\n', totals)).toBe(`${block}\n\n## ELI5\n\nHello\n`)
     expect(mergeLocBlock(`${block}\n\n## ELI5\n`, totals)).toBe(`${block}\n\n## ELI5\n`)
@@ -151,8 +159,12 @@ describe('PR test LoC summary', () => {
     expect(result.status).toBe(0)
     expect(result.stdout.startsWith('<!-- orca-pr-loc -->')).toBe(true)
     expect(result.stdout).toContain(LOC_HANDS_OFF_COMMENT)
-    expect(result.stdout).toContain('| Test | 1 | +6 `#1a7f37` | −1 `#cf222e` | +5 `#1a7f37` |')
-    expect(result.stdout).toContain('| Prod | 1 | +2 `#1a7f37` | 0 | +2 `#1a7f37` |')
+    expect(result.stdout).toContain(
+      '| Test | 1 | $\\color{#1a7f37}{\\textsf{+6}}$ | $\\color{#cf222e}{\\textsf{−1}}$ | $\\color{#1a7f37}{\\textsf{+5}}$ |'
+    )
+    expect(result.stdout).toContain(
+      '| Prod | 1 | $\\color{#1a7f37}{\\textsf{+2}}$ | 0 | $\\color{#1a7f37}{\\textsf{+2}}$ |'
+    )
     expect(result.stdout).not.toContain('| Total |')
     expect(result.stdout).toContain('## ELI5\n\nHello\n')
     expect(result.stdout.match(/<!-- orca-pr-loc -->/g)).toHaveLength(1)

--- a/config/scripts/pr-test-loc-summary.test.mjs
+++ b/config/scripts/pr-test-loc-summary.test.mjs
@@ -108,10 +108,10 @@ describe('PR test LoC summary', () => {
     })
 
     expect(block).toContain(
-      '| Test | 1 | $\\color{#1a7f37}{\\textbf{+2}}$ | $\\color{#cf222e}{\\textbf{−5}}$ | $\\color{#cf222e}{\\textbf{−3}}$ |'
+      '| Test | 1 | $\\color{#1a7f37}{\\large{\\textbf{\\textsf{+2}}}}$ | $\\color{#cf222e}{\\large{\\textbf{\\textsf{−5}}}}$ | $\\color{#cf222e}{\\large{\\textbf{\\textsf{−3}}}}$ |'
     )
     expect(block).toContain(
-      '| Prod | 1 | $\\color{white}{\\textbf{0}}$ | $\\color{#cf222e}{\\textbf{−4}}$ | $\\color{#cf222e}{\\textbf{−4}}$ |'
+      '| Prod | 1 | $\\color{white}{\\large{\\textbf{\\textsf{0}}}}$ | $\\color{#cf222e}{\\large{\\textbf{\\textsf{−4}}}}$ | $\\color{#cf222e}{\\large{\\textbf{\\textsf{−4}}}}$ |'
     )
   })
 
@@ -124,10 +124,10 @@ describe('PR test LoC summary', () => {
 
     expect(block).toContain(LOC_HANDS_OFF_COMMENT)
     expect(block).toContain(
-      '| Test | 1 | $\\color{#1a7f37}{\\textbf{+2}}$ | $\\color{#cf222e}{\\textbf{−1}}$ | $\\color{#1a7f37}{\\textbf{+1}}$ |'
+      '| Test | 1 | $\\color{#1a7f37}{\\large{\\textbf{\\textsf{+2}}}}$ | $\\color{#cf222e}{\\large{\\textbf{\\textsf{−1}}}}$ | $\\color{#1a7f37}{\\large{\\textbf{\\textsf{+1}}}}$ |'
     )
     expect(block).toContain(
-      '| Prod | 1 | $\\color{#1a7f37}{\\textbf{+4}}$ | $\\color{white}{\\textbf{0}}$ | $\\color{#1a7f37}{\\textbf{+4}}$ |'
+      '| Prod | 1 | $\\color{#1a7f37}{\\large{\\textbf{\\textsf{+4}}}}$ | $\\color{white}{\\large{\\textbf{\\textsf{0}}}}$ | $\\color{#1a7f37}{\\large{\\textbf{\\textsf{+4}}}}$ |'
     )
     expect(block).not.toContain('| Total |')
     expect(mergeLocBlock('## ELI5\n\nHello\n', totals)).toBe(`${block}\n\n## ELI5\n\nHello\n`)
@@ -160,10 +160,10 @@ describe('PR test LoC summary', () => {
     expect(result.stdout.startsWith('<!-- orca-pr-loc -->')).toBe(true)
     expect(result.stdout).toContain(LOC_HANDS_OFF_COMMENT)
     expect(result.stdout).toContain(
-      '| Test | 1 | $\\color{#1a7f37}{\\textbf{+6}}$ | $\\color{#cf222e}{\\textbf{−1}}$ | $\\color{#1a7f37}{\\textbf{+5}}$ |'
+      '| Test | 1 | $\\color{#1a7f37}{\\large{\\textbf{\\textsf{+6}}}}$ | $\\color{#cf222e}{\\large{\\textbf{\\textsf{−1}}}}$ | $\\color{#1a7f37}{\\large{\\textbf{\\textsf{+5}}}}$ |'
     )
     expect(result.stdout).toContain(
-      '| Prod | 1 | $\\color{#1a7f37}{\\textbf{+2}}$ | $\\color{white}{\\textbf{0}}$ | $\\color{#1a7f37}{\\textbf{+2}}$ |'
+      '| Prod | 1 | $\\color{#1a7f37}{\\large{\\textbf{\\textsf{+2}}}}$ | $\\color{white}{\\large{\\textbf{\\textsf{0}}}}$ | $\\color{#1a7f37}{\\large{\\textbf{\\textsf{+2}}}}$ |'
     )
     expect(result.stdout).not.toContain('| Total |')
     expect(result.stdout).toContain('## ELI5\n\nHello\n')

--- a/config/scripts/pr-test-loc-summary.test.mjs
+++ b/config/scripts/pr-test-loc-summary.test.mjs
@@ -107,12 +107,8 @@ describe('PR test LoC summary', () => {
       nonTest: { files: 1, added: 0, deleted: 4 }
     })
 
-    expect(block).toContain(
-      '| Test | 1 | <span style="color:#1a7f37">+2</span> | <span style="color:#cf222e">−5</span> | <span style="color:#cf222e">−3</span> |'
-    )
-    expect(block).toContain(
-      '| Prod | 1 | 0 | <span style="color:#cf222e">−4</span> | <span style="color:#cf222e">−4</span> |'
-    )
+    expect(block).toContain('| Test | 1 | +2 `#1a7f37` | −5 `#cf222e` | −3 `#cf222e` |')
+    expect(block).toContain('| Prod | 1 | 0 | −4 `#cf222e` | −4 `#cf222e` |')
   })
 
   it('replaces an existing header and prepends when missing', () => {
@@ -123,12 +119,8 @@ describe('PR test LoC summary', () => {
     const block = renderLocBlock(totals)
 
     expect(block).toContain(LOC_HANDS_OFF_COMMENT)
-    expect(block).toContain(
-      '| Test | 1 | <span style="color:#1a7f37">+2</span> | <span style="color:#cf222e">−1</span> | <span style="color:#1a7f37">+1</span> |'
-    )
-    expect(block).toContain(
-      '| Prod | 1 | <span style="color:#1a7f37">+4</span> | 0 | <span style="color:#1a7f37">+4</span> |'
-    )
+    expect(block).toContain('| Test | 1 | +2 `#1a7f37` | −1 `#cf222e` | +1 `#1a7f37` |')
+    expect(block).toContain('| Prod | 1 | +4 `#1a7f37` | 0 | +4 `#1a7f37` |')
     expect(block).not.toContain('| Total |')
     expect(mergeLocBlock('## ELI5\n\nHello\n', totals)).toBe(`${block}\n\n## ELI5\n\nHello\n`)
     expect(mergeLocBlock(`${block}\n\n## ELI5\n`, totals)).toBe(`${block}\n\n## ELI5\n`)
@@ -159,12 +151,8 @@ describe('PR test LoC summary', () => {
     expect(result.status).toBe(0)
     expect(result.stdout.startsWith('<!-- orca-pr-loc -->')).toBe(true)
     expect(result.stdout).toContain(LOC_HANDS_OFF_COMMENT)
-    expect(result.stdout).toContain(
-      '| Test | 1 | <span style="color:#1a7f37">+6</span> | <span style="color:#cf222e">−1</span> | <span style="color:#1a7f37">+5</span> |'
-    )
-    expect(result.stdout).toContain(
-      '| Prod | 1 | <span style="color:#1a7f37">+2</span> | 0 | <span style="color:#1a7f37">+2</span> |'
-    )
+    expect(result.stdout).toContain('| Test | 1 | +6 `#1a7f37` | −1 `#cf222e` | +5 `#1a7f37` |')
+    expect(result.stdout).toContain('| Prod | 1 | +2 `#1a7f37` | 0 | +2 `#1a7f37` |')
     expect(result.stdout).not.toContain('| Total |')
     expect(result.stdout).toContain('## ELI5\n\nHello\n')
     expect(result.stdout.match(/<!-- orca-pr-loc -->/g)).toHaveLength(1)


### PR DESCRIPTION
## What Changed

Follow-up to #14738: the test vs non-test LoC table now uses normal numbers with only the sign colored, via GitHub's LaTeX math.

- `+` signs render green (`#1a7f37`), `−` signs render red (`#cf222e`)
- The digits stay in the normal body font
- Net sign is green when positive, red when negative; zero stays plain

## Example

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{+}$​175 | $\color{#cf222e}{−}$​12 | $\color{#1a7f37}{+}$​163 |
| Prod | 4 | $\color{#1a7f37}{+}$​350 | 0 | $\color{#1a7f37}{+}$​350 |

## Testing

- [x] `pnpm exec vitest run --config config/vitest.config.ts config/scripts/pr-test-loc-summary.test.mjs` (9 passed)
- [x] `oxlint` clean