### PR TITLE
fix(windows): stop agent hooks from flashing console windows

### DIFF
--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -22,8 +22,7 @@ const { verifySkillsCliRuntime } = require('./scripts/verify-skills-cli-runtime.
 const isMacHourly = process.env.ORCA_MAC_HOURLY === '1'
 const isMacDaily = process.env.ORCA_MAC_DAILY === '1'
 const isMacAdhoc = process.env.ORCA_MAC_ADHOC === '1'
-const isMacRelease =
-  process.env.ORCA_MAC_RELEASE === '1' || isMacHourly || isMacDaily || isMacAdhoc
+const isMacRelease = process.env.ORCA_MAC_RELEASE === '1' || isMacHourly || isMacDaily || isMacAdhoc
 const isLinuxArm64Release = process.env.ORCA_LINUX_ARM64_RELEASE === '1'
 const localBuildVersion = isMacRelease ? undefined : process.env.ORCA_LOCAL_BUILD_VERSION
 const devChannelBuildVersion = isMacHourly
@@ -308,6 +307,10 @@ module.exports = {
       {
         from: 'native/windows-cli-launcher/.build/orca.exe',
         to: 'bin/orca.exe'
+      },
+      {
+        from: 'native/windows-agent-hook-launcher/.build/orca-agent-hook.exe',
+        to: 'bin/orca-agent-hook.exe'
       },
       {
         from: 'node_modules/agent-browser/bin/agent-browser-win32-x64.exe',

--- a/config/scripts/build-windows-cli-launcher.mjs
+++ b/config/scripts/build-windows-cli-launcher.mjs
@@ -27,7 +27,9 @@ const hookOutputPath =
 const compilerPath = findFrameworkCompiler(process.env)
 
 if (!compilerPath) {
-  throw new Error('Unable to find the .NET Framework C# compiler required for orca.exe.')
+  throw new Error(
+    'Unable to find the .NET Framework C# compiler required for orca.exe and orca-agent-hook.exe.'
+  )
 }
 
 compile(sourcePath, outputPath, 'exe')

--- a/config/scripts/build-windows-cli-launcher.mjs
+++ b/config/scripts/build-windows-cli-launcher.mjs
@@ -15,27 +15,48 @@ if (process.platform !== 'win32') {
 const repoRoot = resolve(import.meta.dirname, '../..')
 const sourcePath = join(repoRoot, 'native', 'windows-cli-launcher', 'OrcaCliLauncher.cs')
 const outputPath = readArg('--output') ?? defaultOutputPath(repoRoot)
+const hookSourcePath = join(
+  repoRoot,
+  'native',
+  'windows-agent-hook-launcher',
+  'OrcaAgentHookLauncher.cs'
+)
+const hookOutputPath =
+  readArg('--hook-output') ??
+  join(repoRoot, 'native', 'windows-agent-hook-launcher', '.build', 'orca-agent-hook.exe')
 const compilerPath = findFrameworkCompiler(process.env)
 
 if (!compilerPath) {
   throw new Error('Unable to find the .NET Framework C# compiler required for orca.exe.')
 }
 
-mkdirSync(dirname(outputPath), { recursive: true })
-const result = spawnSync(
-  compilerPath,
-  ['/nologo', '/target:exe', '/optimize+', '/warnaserror+', `/out:${outputPath}`, sourcePath],
-  { cwd: repoRoot, stdio: 'inherit' }
-)
+compile(sourcePath, outputPath, 'exe')
+compile(hookSourcePath, hookOutputPath, 'winexe')
 
-if (result.signal) {
-  process.kill(process.pid, result.signal)
-}
-if (result.error) {
-  throw result.error
-}
-if (result.status !== 0) {
-  process.exit(result.status ?? 1)
+function compile(inputPath, destinationPath, target) {
+  mkdirSync(dirname(destinationPath), { recursive: true })
+  const result = spawnSync(
+    compilerPath,
+    [
+      '/nologo',
+      `/target:${target}`,
+      '/optimize+',
+      '/warnaserror+',
+      `/out:${destinationPath}`,
+      inputPath
+    ],
+    { cwd: repoRoot, stdio: 'inherit' }
+  )
+
+  if (result.signal) {
+    process.kill(process.pid, result.signal)
+  }
+  if (result.error) {
+    throw result.error
+  }
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1)
+  }
 }
 
 function defaultOutputPath(projectRoot) {

--- a/native/windows-agent-hook-launcher/OrcaAgentHookLauncher.cs
+++ b/native/windows-agent-hook-launcher/OrcaAgentHookLauncher.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+internal static class OrcaAgentHookLauncher
+{
+    private const int StandardInputTimeoutMilliseconds = 1000;
+    private const int ChildExitTimeoutMilliseconds = 2500;
+
+    private static int Main(string[] args)
+    {
+        bool emitNeutralJson = args.Length == 2 && args[0] == "--neutral-json";
+        string scriptPath = args.Length == (emitNeutralJson ? 2 : 1) ? args[args.Length - 1] : null;
+        if (scriptPath == null || !File.Exists(scriptPath))
+        {
+            DrainStandardInputWithTimeout();
+            WriteNeutralJson(emitNeutralJson);
+            return 0;
+        }
+
+        try
+        {
+            string systemDirectory = Environment.GetFolderPath(Environment.SpecialFolder.System);
+            ProcessStartInfo startInfo = new ProcessStartInfo
+            {
+                FileName = Path.Combine(systemDirectory, "cmd.exe"),
+                Arguments = "/d /s /c \"\"%ORCA_AGENT_HOOK_SCRIPT%\"\"",
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                WindowStyle = ProcessWindowStyle.Hidden,
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            };
+            startInfo.EnvironmentVariables["ORCA_AGENT_HOOK_SCRIPT"] = scriptPath;
+
+            using (Process child = Process.Start(startInfo))
+            {
+                Task inputTask = CopyStandardInputAsync(child.StandardInput.BaseStream);
+                Task<string> outputTask = child.StandardOutput.ReadToEndAsync();
+                Task<string> errorTask = child.StandardError.ReadToEndAsync();
+                inputTask.Wait(StandardInputTimeoutMilliseconds);
+                TryClose(child.StandardInput);
+
+                if (!child.WaitForExit(ChildExitTimeoutMilliseconds))
+                {
+                    child.Kill();
+                    child.WaitForExit();
+                }
+                Task.WaitAll(new Task[] { outputTask, errorTask }, ChildExitTimeoutMilliseconds);
+                WriteNeutralJson(emitNeutralJson);
+                return child.ExitCode;
+            }
+        }
+        catch
+        {
+            DrainStandardInputWithTimeout();
+            WriteNeutralJson(emitNeutralJson);
+            return 0;
+        }
+    }
+
+    private static Task CopyStandardInputAsync(Stream destination)
+    {
+        return Task.Run(() =>
+        {
+            try
+            {
+                Console.OpenStandardInput().CopyTo(destination);
+                destination.Flush();
+            }
+            catch
+            {
+                // The caller may leave stdin open after the payload is complete.
+            }
+        });
+    }
+
+    private static void DrainStandardInputWithTimeout()
+    {
+        CopyStandardInputAsync(Stream.Null).Wait(StandardInputTimeoutMilliseconds);
+    }
+
+    private static void TryClose(TextWriter writer)
+    {
+        try
+        {
+            writer.Close();
+        }
+        catch { }
+    }
+
+    private static void WriteNeutralJson(bool enabled)
+    {
+        if (!enabled) return;
+        try
+        {
+            byte[] output = Encoding.UTF8.GetBytes("{}\n");
+            Stream stdout = Console.OpenStandardOutput();
+            stdout.Write(output, 0, output.Length);
+            stdout.Flush();
+        }
+        catch { }
+    }
+}

--- a/native/windows-agent-hook-launcher/OrcaAgentHookLauncher.cs
+++ b/native/windows-agent-hook-launcher/OrcaAgentHookLauncher.cs
@@ -44,14 +44,14 @@ internal static class OrcaAgentHookLauncher
                 inputTask.Wait(StandardInputTimeoutMilliseconds);
                 TryClose(child.StandardInput);
 
-                if (!child.WaitForExit(ChildExitTimeoutMilliseconds))
+                bool childTimedOut = !child.WaitForExit(ChildExitTimeoutMilliseconds);
+                if (childTimedOut)
                 {
-                    child.Kill();
-                    child.WaitForExit();
+                    KillProcessTree(child, systemDirectory);
                 }
                 Task.WaitAll(new Task[] { outputTask, errorTask }, ChildExitTimeoutMilliseconds);
                 WriteNeutralJson(emitNeutralJson);
-                return child.ExitCode;
+                return childTimedOut ? 0 : child.ExitCode;
             }
         }
         catch
@@ -60,6 +60,43 @@ internal static class OrcaAgentHookLauncher
             WriteNeutralJson(emitNeutralJson);
             return 0;
         }
+    }
+
+    private static void KillProcessTree(Process child, string systemDirectory)
+    {
+        try
+        {
+            ProcessStartInfo startInfo = new ProcessStartInfo
+            {
+                FileName = Path.Combine(systemDirectory, "taskkill.exe"),
+                Arguments = "/PID " + child.Id + " /T /F",
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                WindowStyle = ProcessWindowStyle.Hidden,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            };
+            using (Process treeKiller = Process.Start(startInfo))
+            {
+                treeKiller.BeginOutputReadLine();
+                treeKiller.BeginErrorReadLine();
+                if (!treeKiller.WaitForExit(ChildExitTimeoutMilliseconds))
+                {
+                    treeKiller.Kill();
+                }
+            }
+        }
+        catch { }
+
+        if (!child.HasExited)
+        {
+            try
+            {
+                child.Kill();
+            }
+            catch { }
+        }
+        child.WaitForExit(ChildExitTimeoutMilliseconds);
     }
 
     private static Task CopyStandardInputAsync(Stream destination)

--- a/src/main/agent-hooks/managed-hook-config-refresh.ts
+++ b/src/main/agent-hooks/managed-hook-config-refresh.ts
@@ -3,15 +3,22 @@ import { copyFile, lstat, readFile, realpath, rename, rm, stat, writeFile } from
 import { dirname, join } from 'node:path'
 import {
   createManagedCommandMatcher,
+  isPlainObject,
   type HookDefinition,
   type HooksConfig
 } from './installer-utils'
 import { parseHooksJsonText } from './hooks-json-read'
 
-type RefreshManagedHookCommandOptions = {
+export type ManagedHookCommandMigration = {
+  scriptFileName: string
+  resolveCommand: () => Promise<string>
+}
+
+type RefreshManagedHookCommandsOptions = {
   configPath: string
   scriptFileName: string
   resolveCommand: () => Promise<string>
+  additionalMigrations?: ManagedHookCommandMigration[]
 }
 
 function isMissingPathError(error: unknown): boolean {
@@ -73,7 +80,47 @@ function migrateManagedCommands(
         : definitions
     ])
   )
-  return { ...config, hooks }
+  const statusLine = config.statusLine
+  if (
+    !isPlainObject(statusLine) ||
+    typeof statusLine.command !== 'string' ||
+    !matches(statusLine.command)
+  ) {
+    return { ...config, hooks }
+  }
+  return { ...config, hooks, statusLine: { ...statusLine, command } }
+}
+
+function configHasManagedCommand(
+  config: HooksConfig,
+  matches: (command: string | undefined) => boolean
+): boolean {
+  const statusLine = config.statusLine
+  if (
+    isPlainObject(statusLine) &&
+    typeof statusLine.command === 'string' &&
+    matches(statusLine.command)
+  ) {
+    return true
+  }
+  return Object.values(config.hooks ?? {}).some(
+    (definitions) =>
+      Array.isArray(definitions) &&
+      definitions.some((definition) => {
+        const direct =
+          matches(definition.command) || matches(definition.bash) || matches(definition.powershell)
+        return (
+          direct ||
+          (Array.isArray(definition.hooks) &&
+            definition.hooks.some(
+              (hook) =>
+                matches(hook.command) ||
+                (Array.isArray(hook.args) &&
+                  hook.args.some((arg) => typeof arg === 'string' && matches(arg)))
+            ))
+        )
+      })
+  )
 }
 
 async function resolveWritePath(configPath: string): Promise<string> {
@@ -145,39 +192,33 @@ async function writeConfigIfUnchanged(
 }
 
 // Why: stale user-wide configs need launcher migration even when the agent CLI is absent.
-export async function refreshManagedHookCommandIfPresent(
-  options: RefreshManagedHookCommandOptions
+export async function refreshManagedHookCommandsIfPresent(
+  options: RefreshManagedHookCommandsOptions
 ): Promise<boolean> {
   const snapshot = await readExistingConfig(options.configPath)
   if (!snapshot) {
     return false
   }
-  const matches = createManagedCommandMatcher(options.scriptFileName)
-  const hasManagedCommand = Object.values(snapshot.config.hooks ?? {}).some(
-    (definitions) =>
-      Array.isArray(definitions) &&
-      definitions.some((definition) => {
-        const direct =
-          matches(definition.command) || matches(definition.bash) || matches(definition.powershell)
-        return (
-          direct ||
-          (Array.isArray(definition.hooks) &&
-            definition.hooks.some(
-              (hook) =>
-                matches(hook.command) ||
-                (Array.isArray(hook.args) &&
-                  hook.args.some((arg) => typeof arg === 'string' && matches(arg)))
-            ))
-        )
-      })
+  const migrations = [
+    { scriptFileName: options.scriptFileName, resolveCommand: options.resolveCommand },
+    ...(options.additionalMigrations ?? [])
+  ]
+  const applicable = migrations.filter((migration) =>
+    configHasManagedCommand(snapshot.config, createManagedCommandMatcher(migration.scriptFileName))
   )
-  if (!hasManagedCommand) {
+  if (applicable.length === 0) {
     return false
   }
-  const command = await options.resolveCommand()
-  return writeConfigIfUnchanged(
-    options.configPath,
-    snapshot.raw,
-    migrateManagedCommands(snapshot.config, options.scriptFileName, command)
+  const resolved = await Promise.all(
+    applicable.map(async (migration) => ({
+      scriptFileName: migration.scriptFileName,
+      command: await migration.resolveCommand()
+    }))
   )
+  const migrated = resolved.reduce(
+    (config, migration) =>
+      migrateManagedCommands(config, migration.scriptFileName, migration.command),
+    snapshot.config
+  )
+  return writeConfigIfUnchanged(options.configPath, snapshot.raw, migrated)
 }

--- a/src/main/agent-hooks/managed-hook-config-refresh.ts
+++ b/src/main/agent-hooks/managed-hook-config-refresh.ts
@@ -113,7 +113,15 @@ async function writeConfigIfUnchanged(
   config: HooksConfig
 ): Promise<boolean> {
   const writePath = await resolveWritePath(configPath)
-  const currentRaw = await readFile(writePath, 'utf-8')
+  let currentRaw: string
+  try {
+    currentRaw = await readFile(writePath, 'utf-8')
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return false
+    }
+    throw error
+  }
   if (currentRaw !== expectedRaw) {
     return false
   }

--- a/src/main/agent-hooks/managed-hook-config-refresh.ts
+++ b/src/main/agent-hooks/managed-hook-config-refresh.ts
@@ -1,0 +1,175 @@
+import { randomUUID } from 'node:crypto'
+import { copyFile, lstat, readFile, realpath, rename, rm, stat, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import {
+  createManagedCommandMatcher,
+  type HookDefinition,
+  type HooksConfig
+} from './installer-utils'
+import { parseHooksJsonText } from './hooks-json-read'
+
+type RefreshManagedHookCommandOptions = {
+  configPath: string
+  scriptFileName: string
+  resolveCommand: () => Promise<string>
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return error instanceof Error && 'code' in error && error.code === 'ENOENT'
+}
+
+async function readExistingConfig(
+  configPath: string
+): Promise<{ config: HooksConfig; raw: string } | null> {
+  try {
+    const raw = await readFile(configPath, 'utf-8')
+    const config = parseHooksJsonText(raw)
+    return config ? { config, raw } : null
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return null
+    }
+    throw error
+  }
+}
+
+function replaceManagedCommand(
+  definition: HookDefinition,
+  matches: (command: string | undefined) => boolean,
+  command: string
+): HookDefinition {
+  const next = { ...definition }
+  const directKeys = ['command', 'bash', 'powershell'] as const
+  if (directKeys.some((key) => matches(next[key]))) {
+    next.command = command
+    delete next.bash
+    delete next.powershell
+  }
+  if (Array.isArray(next.hooks)) {
+    next.hooks = next.hooks.map((hook) => {
+      const args = Array.isArray(hook.args) ? hook.args : []
+      if (!matches(hook.command) && !args.some((arg) => typeof arg === 'string' && matches(arg))) {
+        return hook
+      }
+      const migrated = { ...hook, command }
+      delete migrated.args
+      return migrated
+    })
+  }
+  return next
+}
+
+function migrateManagedCommands(
+  config: HooksConfig,
+  scriptFileName: string,
+  command: string
+): HooksConfig {
+  const matches = createManagedCommandMatcher(scriptFileName)
+  const hooks = Object.fromEntries(
+    Object.entries(config.hooks ?? {}).map(([eventName, definitions]) => [
+      eventName,
+      Array.isArray(definitions)
+        ? definitions.map((definition) => replaceManagedCommand(definition, matches, command))
+        : definitions
+    ])
+  )
+  return { ...config, hooks }
+}
+
+async function resolveWritePath(configPath: string): Promise<string> {
+  try {
+    return (await lstat(configPath)).isSymbolicLink() ? await realpath(configPath) : configPath
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return configPath
+    }
+    throw error
+  }
+}
+
+async function writeBackup(sourcePath: string): Promise<void> {
+  const backupPath = `${sourcePath}.bak`
+  try {
+    if ((await lstat(backupPath)).isSymbolicLink()) {
+      throw new Error(`Refusing to overwrite symlinked backup: ${backupPath}`)
+    }
+  } catch (error) {
+    if (!isMissingPathError(error)) {
+      throw error
+    }
+  }
+  const temporaryPath = `${backupPath}.${process.pid}.${randomUUID()}.tmp`
+  try {
+    await copyFile(sourcePath, temporaryPath)
+    await rename(temporaryPath, backupPath)
+  } finally {
+    await rm(temporaryPath, { force: true }).catch(() => undefined)
+  }
+}
+
+async function writeConfigIfUnchanged(
+  configPath: string,
+  expectedRaw: string,
+  config: HooksConfig
+): Promise<boolean> {
+  const writePath = await resolveWritePath(configPath)
+  const currentRaw = await readFile(writePath, 'utf-8')
+  if (currentRaw !== expectedRaw) {
+    return false
+  }
+  const serialized = `${JSON.stringify(config, null, 2)}\n`
+  if (serialized === currentRaw) {
+    return true
+  }
+  const temporaryPath = join(dirname(writePath), `.${Date.now()}-${randomUUID()}.tmp`)
+  try {
+    const mode = (await stat(writePath)).mode
+    await writeFile(temporaryPath, serialized, { encoding: 'utf-8', mode })
+    if ((await readFile(writePath, 'utf-8')) !== expectedRaw) {
+      return false
+    }
+    await writeBackup(writePath)
+    await rename(temporaryPath, writePath)
+    return true
+  } finally {
+    await rm(temporaryPath, { force: true }).catch(() => undefined)
+  }
+}
+
+// Why: stale user-wide configs need launcher migration even when the agent CLI is absent.
+export async function refreshManagedHookCommandIfPresent(
+  options: RefreshManagedHookCommandOptions
+): Promise<boolean> {
+  const snapshot = await readExistingConfig(options.configPath)
+  if (!snapshot) {
+    return false
+  }
+  const matches = createManagedCommandMatcher(options.scriptFileName)
+  const hasManagedCommand = Object.values(snapshot.config.hooks ?? {}).some(
+    (definitions) =>
+      Array.isArray(definitions) &&
+      definitions.some((definition) => {
+        const direct =
+          matches(definition.command) || matches(definition.bash) || matches(definition.powershell)
+        return (
+          direct ||
+          (Array.isArray(definition.hooks) &&
+            definition.hooks.some(
+              (hook) =>
+                matches(hook.command) ||
+                (Array.isArray(hook.args) &&
+                  hook.args.some((arg) => typeof arg === 'string' && matches(arg)))
+            ))
+        )
+      })
+  )
+  if (!hasManagedCommand) {
+    return false
+  }
+  const command = await options.resolveCommand()
+  return writeConfigIfUnchanged(
+    options.configPath,
+    snapshot.raw,
+    migrateManagedCommands(snapshot.config, options.scriptFileName, command)
+  )
+}

--- a/src/main/agent-hooks/managed-hook-script-refresh.test.ts
+++ b/src/main/agent-hooks/managed-hook-script-refresh.test.ts
@@ -71,6 +71,7 @@ vi.mock('./windows-agent-hook-launcher', async () => {
 })
 
 import { refreshManagedScriptIfPresent } from './managed-hook-script-refresh'
+import { refreshManagedHookCommandIfPresent } from './managed-hook-config-refresh'
 import {
   MANAGED_AGENT_HOOK_INSTALLERS,
   MANAGED_AGENT_HOOK_SCRIPT_REFRESHERS
@@ -193,6 +194,35 @@ describe('managed hook script refresh', () => {
       expect(hook.args).toBeUndefined()
     } finally {
       homedirMock.mockImplementation(() => process.env.HOME ?? tmpdir())
+      rmSync(home, { recursive: true, force: true })
+    }
+  })
+
+  it('treats a concurrently deleted config as an aborted refresh', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'orca-hook-refresh-deleted-config-'))
+    const configPath = join(home, 'settings.json')
+    const scriptPath = join(home, '.orca', 'agent-hooks', 'claude-hook.cmd')
+    writeFileSync(
+      configPath,
+      `${JSON.stringify({
+        hooks: {
+          Stop: [{ hooks: [{ type: 'command', command: scriptPath }] }]
+        }
+      })}\n`
+    )
+    try {
+      await expect(
+        refreshManagedHookCommandIfPresent({
+          configPath,
+          scriptFileName: 'claude-hook.cmd',
+          resolveCommand: async () => {
+            rmSync(configPath)
+            return 'replacement'
+          }
+        })
+      ).resolves.toBe(false)
+      expect(existsSync(configPath)).toBe(false)
+    } finally {
       rmSync(home, { recursive: true, force: true })
     }
   })

--- a/src/main/agent-hooks/managed-hook-script-refresh.test.ts
+++ b/src/main/agent-hooks/managed-hook-script-refresh.test.ts
@@ -71,7 +71,8 @@ vi.mock('./windows-agent-hook-launcher', async () => {
 })
 
 import { refreshManagedScriptIfPresent } from './managed-hook-script-refresh'
-import { refreshManagedHookCommandIfPresent } from './managed-hook-config-refresh'
+import { refreshManagedHookCommandsIfPresent } from './managed-hook-config-refresh'
+import { wrapRuntimeHomeHookCommand } from './runtime-home-hook-command'
 import {
   MANAGED_AGENT_HOOK_INSTALLERS,
   MANAGED_AGENT_HOOK_SCRIPT_REFRESHERS
@@ -155,7 +156,7 @@ describe('managed hook script refresh', () => {
     }
   })
 
-  it('migrates an existing Windows config even when CLI presence is unavailable', async () => {
+  it('migrates existing Windows hooks and statusline when CLI presence is unavailable', async () => {
     const home = mkdtempSync(join(tmpdir(), 'orca-hook-refresh-config-'))
     homedirMock.mockReturnValue(home)
     try {
@@ -164,7 +165,9 @@ describe('managed hook script refresh', () => {
       mkdirSync(hooksDir, { recursive: true })
       mkdirSync(configDir, { recursive: true })
       const scriptPath = join(hooksDir, 'claude-hook.cmd')
+      const statusLineScriptPath = join(hooksDir, 'claude-statusline.cmd')
       writeFileSync(scriptPath, STALE_WINDOWS_HOOK)
+      writeFileSync(statusLineScriptPath, 'stale statusline')
       writeFileSync(
         join(configDir, 'settings.json'),
         `${JSON.stringify({
@@ -180,6 +183,10 @@ describe('managed hook script refresh', () => {
                 ]
               }
             ]
+          },
+          statusLine: {
+            type: 'command',
+            command: wrapRuntimeHomeHookCommand('claude-statusline')
           }
         })}\n`
       )
@@ -192,6 +199,9 @@ describe('managed hook script refresh', () => {
         `"${join(hooksDir, 'orca-agent-hook.exe')}" --neutral-json "${scriptPath}"`
       )
       expect(hook.args).toBeUndefined()
+      expect(config.statusLine.command).toBe(
+        `"${join(hooksDir, 'orca-agent-hook.exe')}" "${statusLineScriptPath}"`
+      )
     } finally {
       homedirMock.mockImplementation(() => process.env.HOME ?? tmpdir())
       rmSync(home, { recursive: true, force: true })
@@ -212,7 +222,7 @@ describe('managed hook script refresh', () => {
     )
     try {
       await expect(
-        refreshManagedHookCommandIfPresent({
+        refreshManagedHookCommandsIfPresent({
           configPath,
           scriptFileName: 'claude-hook.cmd',
           resolveCommand: async () => {

--- a/src/main/agent-hooks/managed-hook-script-refresh.test.ts
+++ b/src/main/agent-hooks/managed-hook-script-refresh.test.ts
@@ -54,6 +54,22 @@ vi.mock('os', async (importOriginal) => {
   }
 })
 
+vi.mock('./windows-agent-hook-launcher', async () => {
+  const { join } = await import('node:path')
+  const launcherPath = () => join(homedirMock(), '.orca', 'agent-hooks', 'orca-agent-hook.exe')
+  return {
+    installWindowsAgentHookLauncher: launcherPath,
+    installWindowsAgentHookLauncherAsync: async () => launcherPath(),
+    getWindowsAgentHookCommand: (scriptPath: string) => `"${launcherPath()}" "${scriptPath}"`,
+    getWindowsAgentHookCommandAsync: async (scriptPath: string) =>
+      `"${launcherPath()}" "${scriptPath}"`,
+    getWindowsAgentHookJsonCommand: (scriptPath: string) =>
+      `"${launcherPath()}" --neutral-json "${scriptPath}"`,
+    getWindowsAgentHookJsonCommandAsync: async (scriptPath: string) =>
+      `"${launcherPath()}" --neutral-json "${scriptPath}"`
+  }
+})
+
 import { refreshManagedScriptIfPresent } from './managed-hook-script-refresh'
 import {
   MANAGED_AGENT_HOOK_INSTALLERS,
@@ -132,6 +148,49 @@ describe('managed hook script refresh', () => {
       expect(existsSync(join(home, '.claude'))).toBe(false)
       // Why: the statusline script was never installed here, so it must not appear.
       expect(existsSync(join(hooksDir, 'claude-statusline.cmd'))).toBe(false)
+    } finally {
+      homedirMock.mockImplementation(() => process.env.HOME ?? tmpdir())
+      rmSync(home, { recursive: true, force: true })
+    }
+  })
+
+  it('migrates an existing Windows config even when CLI presence is unavailable', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'orca-hook-refresh-config-'))
+    homedirMock.mockReturnValue(home)
+    try {
+      const hooksDir = join(home, '.orca', 'agent-hooks')
+      const configDir = join(home, '.claude')
+      mkdirSync(hooksDir, { recursive: true })
+      mkdirSync(configDir, { recursive: true })
+      const scriptPath = join(hooksDir, 'claude-hook.cmd')
+      writeFileSync(scriptPath, STALE_WINDOWS_HOOK)
+      writeFileSync(
+        join(configDir, 'settings.json'),
+        `${JSON.stringify({
+          hooks: {
+            UserPromptSubmit: [
+              {
+                hooks: [
+                  {
+                    type: 'command',
+                    command: 'C:\\Windows\\System32\\conhost.exe',
+                    args: ['--headless', 'C:\\Windows\\System32\\cmd.exe', '/d', '/c', scriptPath]
+                  }
+                ]
+              }
+            ]
+          }
+        })}\n`
+      )
+
+      await withPlatform('win32', () => new ClaudeHookService().refreshManagedScripts())
+
+      const config = JSON.parse(readFileSync(join(configDir, 'settings.json'), 'utf8'))
+      const hook = config.hooks.UserPromptSubmit[0].hooks[0]
+      expect(hook.command).toBe(
+        `"${join(hooksDir, 'orca-agent-hook.exe')}" --neutral-json "${scriptPath}"`
+      )
+      expect(hook.args).toBeUndefined()
     } finally {
       homedirMock.mockImplementation(() => process.env.HOME ?? tmpdir())
       rmSync(home, { recursive: true, force: true })

--- a/src/main/agent-hooks/windows-agent-hook-launcher.test.ts
+++ b/src/main/agent-hooks/windows-agent-hook-launcher.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { basename, dirname, join } from 'node:path'
 import type * as osModule from 'node:os'
@@ -16,7 +16,8 @@ vi.mock('node:os', async () => {
 import {
   getWindowsAgentHookCommand,
   getWindowsAgentHookJsonCommand,
-  installWindowsAgentHookLauncher
+  installWindowsAgentHookLauncher,
+  installWindowsAgentHookLauncherAsync
 } from './windows-agent-hook-launcher'
 
 describe('Windows agent hook launcher', () => {
@@ -41,6 +42,19 @@ describe('Windows agent hook launcher', () => {
     expect(dirname(installedPath)).toBe(join(homeDir, '.orca', 'agent-hooks'))
     expect(basename(installedPath)).toMatch(/^orca-agent-hook-[a-f0-9]{16}\.exe$/)
     expect(readFileSync(installedPath)).toEqual(readFileSync(sourcePath))
+  })
+
+  it('reuses the content-addressed launcher across repeated installs', async () => {
+    const sourcePath = join(homeDir, 'source.exe')
+    writeFileSync(sourcePath, Buffer.from([0x4d, 0x5a, 0x03, 0x04]))
+
+    const firstPath = installWindowsAgentHookLauncher(sourcePath)
+    const secondPath = installWindowsAgentHookLauncher(sourcePath)
+    const asyncPath = await installWindowsAgentHookLauncherAsync(sourcePath)
+
+    expect(secondPath).toBe(firstPath)
+    expect(asyncPath).toBe(firstPath)
+    expect(readdirSync(dirname(firstPath))).toEqual([basename(firstPath)])
   })
 
   it('quotes launcher and script paths without adding a shell layer', () => {

--- a/src/main/agent-hooks/windows-agent-hook-launcher.test.ts
+++ b/src/main/agent-hooks/windows-agent-hook-launcher.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { basename, dirname, join } from 'node:path'
+import type * as osModule from 'node:os'
+
+const { homedirMock } = vi.hoisted(() => ({
+  homedirMock: vi.fn<() => string>()
+}))
+
+vi.mock('node:os', async () => {
+  const actual = await vi.importActual<typeof osModule>('node:os')
+  return { ...actual, homedir: homedirMock }
+})
+
+import {
+  getWindowsAgentHookCommand,
+  getWindowsAgentHookJsonCommand,
+  installWindowsAgentHookLauncher
+} from './windows-agent-hook-launcher'
+
+describe('Windows agent hook launcher', () => {
+  let homeDir: string
+
+  beforeEach(() => {
+    homeDir = mkdtempSync(join(tmpdir(), 'orca-hook-launcher-home-'))
+    homedirMock.mockReturnValue(homeDir)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    rmSync(homeDir, { recursive: true, force: true })
+  })
+
+  it('installs the bundled launcher under the shared hook directory', () => {
+    const sourcePath = join(homeDir, 'source.exe')
+    writeFileSync(sourcePath, Buffer.from([0x4d, 0x5a, 0x01, 0x02]))
+
+    const installedPath = installWindowsAgentHookLauncher(sourcePath)
+
+    expect(dirname(installedPath)).toBe(join(homeDir, '.orca', 'agent-hooks'))
+    expect(basename(installedPath)).toMatch(/^orca-agent-hook-[a-f0-9]{16}\.exe$/)
+    expect(readFileSync(installedPath)).toEqual(readFileSync(sourcePath))
+  })
+
+  it('quotes launcher and script paths without adding a shell layer', () => {
+    const command = getWindowsAgentHookCommand(
+      'C:\\Users\\Jorge Silva\\.orca\\agent-hooks\\cursor-hook.cmd',
+      'C:\\Users\\Jorge Silva\\.orca\\agent-hooks\\orca-agent-hook.exe'
+    )
+
+    expect(command).toBe(
+      '"C:\\Users\\Jorge Silva\\.orca\\agent-hooks\\orca-agent-hook.exe" ' +
+        '"C:\\Users\\Jorge Silva\\.orca\\agent-hooks\\cursor-hook.cmd"'
+    )
+    expect(command).not.toContain('powershell')
+    expect(command).not.toContain('conhost')
+  })
+
+  it('requests neutral JSON for Claude-compatible lifecycle hooks', () => {
+    const command = getWindowsAgentHookJsonCommand(
+      'C:\\Users\\Jorge Silva\\.orca\\agent-hooks\\claude-hook.cmd',
+      'C:\\Users\\Jorge Silva\\.orca\\agent-hooks\\orca-agent-hook.exe'
+    )
+
+    expect(command).toBe(
+      '"C:\\Users\\Jorge Silva\\.orca\\agent-hooks\\orca-agent-hook.exe" --neutral-json ' +
+        '"C:\\Users\\Jorge Silva\\.orca\\agent-hooks\\claude-hook.cmd"'
+    )
+  })
+})

--- a/src/main/agent-hooks/windows-agent-hook-launcher.ts
+++ b/src/main/agent-hooks/windows-agent-hook-launcher.ts
@@ -11,8 +11,8 @@ function getVersionedLauncherFileName(source: Buffer): string {
   return `orca-agent-hook-${digest}.exe`
 }
 
-function resolveBundledLauncherPath(): string {
-  const candidates = [
+function getBundledLauncherCandidatePaths(): string[] {
+  return [
     ...(process.resourcesPath ? [join(process.resourcesPath, 'bin', LAUNCHER_FILE_NAME)] : []),
     ...(process.env.ORCA_DEV_REPO_ROOT
       ? [
@@ -27,6 +27,10 @@ function resolveBundledLauncherPath(): string {
       : []),
     join(process.cwd(), 'native', 'windows-agent-hook-launcher', '.build', LAUNCHER_FILE_NAME)
   ]
+}
+
+function resolveBundledLauncherPath(): string {
+  const candidates = getBundledLauncherCandidatePaths()
   const sourcePath = candidates.find((candidate) => existsSync(candidate))
   if (!sourcePath) {
     throw new Error('Missing bundled Windows agent hook launcher.')
@@ -35,21 +39,7 @@ function resolveBundledLauncherPath(): string {
 }
 
 async function resolveBundledLauncherPathAsync(): Promise<string> {
-  const candidates = [
-    ...(process.resourcesPath ? [join(process.resourcesPath, 'bin', LAUNCHER_FILE_NAME)] : []),
-    ...(process.env.ORCA_DEV_REPO_ROOT
-      ? [
-          join(
-            process.env.ORCA_DEV_REPO_ROOT,
-            'native',
-            'windows-agent-hook-launcher',
-            '.build',
-            LAUNCHER_FILE_NAME
-          )
-        ]
-      : []),
-    join(process.cwd(), 'native', 'windows-agent-hook-launcher', '.build', LAUNCHER_FILE_NAME)
-  ]
+  const candidates = getBundledLauncherCandidatePaths()
   for (const candidate of candidates) {
     try {
       await access(candidate)

--- a/src/main/agent-hooks/windows-agent-hook-launcher.ts
+++ b/src/main/agent-hooks/windows-agent-hook-launcher.ts
@@ -1,0 +1,159 @@
+import { copyFileSync, existsSync, mkdirSync, readFileSync, renameSync, unlinkSync } from 'node:fs'
+import { access, copyFile, mkdir, readFile, rename, rm } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { createHash, randomUUID } from 'node:crypto'
+
+const LAUNCHER_FILE_NAME = 'orca-agent-hook.exe'
+
+function getVersionedLauncherFileName(source: Buffer): string {
+  const digest = createHash('sha256').update(source).digest('hex').slice(0, 16)
+  return `orca-agent-hook-${digest}.exe`
+}
+
+function resolveBundledLauncherPath(): string {
+  const candidates = [
+    ...(process.resourcesPath ? [join(process.resourcesPath, 'bin', LAUNCHER_FILE_NAME)] : []),
+    ...(process.env.ORCA_DEV_REPO_ROOT
+      ? [
+          join(
+            process.env.ORCA_DEV_REPO_ROOT,
+            'native',
+            'windows-agent-hook-launcher',
+            '.build',
+            LAUNCHER_FILE_NAME
+          )
+        ]
+      : []),
+    join(process.cwd(), 'native', 'windows-agent-hook-launcher', '.build', LAUNCHER_FILE_NAME)
+  ]
+  const sourcePath = candidates.find((candidate) => existsSync(candidate))
+  if (!sourcePath) {
+    throw new Error('Missing bundled Windows agent hook launcher.')
+  }
+  return sourcePath
+}
+
+async function resolveBundledLauncherPathAsync(): Promise<string> {
+  const candidates = [
+    ...(process.resourcesPath ? [join(process.resourcesPath, 'bin', LAUNCHER_FILE_NAME)] : []),
+    ...(process.env.ORCA_DEV_REPO_ROOT
+      ? [
+          join(
+            process.env.ORCA_DEV_REPO_ROOT,
+            'native',
+            'windows-agent-hook-launcher',
+            '.build',
+            LAUNCHER_FILE_NAME
+          )
+        ]
+      : []),
+    join(process.cwd(), 'native', 'windows-agent-hook-launcher', '.build', LAUNCHER_FILE_NAME)
+  ]
+  for (const candidate of candidates) {
+    try {
+      await access(candidate)
+      return candidate
+    } catch {
+      // Try the next packaged or development location.
+    }
+  }
+  throw new Error('Missing bundled Windows agent hook launcher.')
+}
+
+export function installWindowsAgentHookLauncher(sourcePath = resolveBundledLauncherPath()): string {
+  const source = readFileSync(sourcePath)
+  const destinationPath = join(
+    homedir(),
+    '.orca',
+    'agent-hooks',
+    getVersionedLauncherFileName(source)
+  )
+  mkdirSync(dirname(destinationPath), { recursive: true })
+  if (existsSync(destinationPath) && readFileSync(destinationPath).equals(source)) {
+    return destinationPath
+  }
+
+  const temporaryPath = join(dirname(destinationPath), `.${LAUNCHER_FILE_NAME}-${randomUUID()}.tmp`)
+  try {
+    copyFileSync(sourcePath, temporaryPath)
+    try {
+      renameSync(temporaryPath, destinationPath)
+    } catch (error) {
+      // Why: concurrent installers can race to publish the same content-addressed launcher.
+      if (!existsSync(destinationPath) || !readFileSync(destinationPath).equals(source)) {
+        throw error
+      }
+    }
+  } finally {
+    if (existsSync(temporaryPath)) {
+      unlinkSync(temporaryPath)
+    }
+  }
+  return destinationPath
+}
+
+export async function installWindowsAgentHookLauncherAsync(sourcePath?: string): Promise<string> {
+  const resolvedSourcePath = sourcePath ?? (await resolveBundledLauncherPathAsync())
+  const source = await readFile(resolvedSourcePath)
+  const destinationPath = join(
+    homedir(),
+    '.orca',
+    'agent-hooks',
+    getVersionedLauncherFileName(source)
+  )
+  await mkdir(dirname(destinationPath), { recursive: true })
+  try {
+    if ((await readFile(destinationPath)).equals(source)) {
+      return destinationPath
+    }
+  } catch {
+    // Publish the bundled launcher below.
+  }
+
+  const temporaryPath = join(dirname(destinationPath), `.${LAUNCHER_FILE_NAME}-${randomUUID()}.tmp`)
+  try {
+    await copyFile(resolvedSourcePath, temporaryPath)
+    try {
+      await rename(temporaryPath, destinationPath)
+    } catch (error) {
+      try {
+        if ((await readFile(destinationPath)).equals(source)) {
+          return destinationPath
+        }
+      } catch {
+        // Re-throw the publication error below.
+      }
+      throw error
+    }
+  } finally {
+    await rm(temporaryPath, { force: true }).catch(() => undefined)
+  }
+  return destinationPath
+}
+
+function quoteWindowsCommandArgument(value: string): string {
+  return `"${value.replaceAll('"', '\\"')}"`
+}
+
+export function getWindowsAgentHookCommand(
+  scriptPath: string,
+  launcherPath = installWindowsAgentHookLauncher()
+): string {
+  return `${quoteWindowsCommandArgument(launcherPath)} ${quoteWindowsCommandArgument(scriptPath)}`
+}
+
+export function getWindowsAgentHookJsonCommand(
+  scriptPath: string,
+  launcherPath = installWindowsAgentHookLauncher()
+): string {
+  return `${quoteWindowsCommandArgument(launcherPath)} --neutral-json ${quoteWindowsCommandArgument(scriptPath)}`
+}
+
+export async function getWindowsAgentHookCommandAsync(scriptPath: string): Promise<string> {
+  return getWindowsAgentHookCommand(scriptPath, await installWindowsAgentHookLauncherAsync())
+}
+
+export async function getWindowsAgentHookJsonCommandAsync(scriptPath: string): Promise<string> {
+  return getWindowsAgentHookJsonCommand(scriptPath, await installWindowsAgentHookLauncherAsync())
+}

--- a/src/main/claude/claude-managed-script-refresh.ts
+++ b/src/main/claude/claude-managed-script-refresh.ts
@@ -1,0 +1,40 @@
+import { refreshManagedHookCommandsIfPresent } from '../agent-hooks/managed-hook-config-refresh'
+import { refreshManagedScriptIfPresent } from '../agent-hooks/managed-hook-script-refresh'
+import {
+  getConfigPath,
+  getManagedScriptPath,
+  getStatusLineScriptPath,
+  getWindowsManagedCommandMigrations,
+  type ClaudeCompatibleHookSettings
+} from './hook-settings'
+import { getManagedStatusLineScript } from './statusline-script'
+
+export async function refreshClaudeManagedScripts(
+  settings: ClaudeCompatibleHookSettings,
+  lifecycleScript: string
+): Promise<void> {
+  const lifecycleScriptPresent = await refreshManagedScriptIfPresent(
+    getManagedScriptPath(settings),
+    lifecycleScript
+  )
+  const statusLineScriptPresent = await refreshManagedScriptIfPresent(
+    getStatusLineScriptPath(settings),
+    getManagedStatusLineScript('local')
+  )
+  if (process.platform !== 'win32') {
+    return
+  }
+  const [migration, ...additionalMigrations] = getWindowsManagedCommandMigrations(
+    settings,
+    lifecycleScriptPresent,
+    statusLineScriptPresent
+  )
+  if (!migration) {
+    return
+  }
+  await refreshManagedHookCommandsIfPresent({
+    configPath: getConfigPath(settings),
+    ...migration,
+    additionalMigrations
+  })
+}

--- a/src/main/claude/hook-service.test.ts
+++ b/src/main/claude/hook-service.test.ts
@@ -20,8 +20,13 @@ vi.mock('../agent-hooks/windows-agent-hook-launcher', async () => {
   const launcherPath = () => join(homedir(), '.orca', 'agent-hooks', 'orca-agent-hook.exe')
   return {
     installWindowsAgentHookLauncher: launcherPath,
+    installWindowsAgentHookLauncherAsync: async () => launcherPath(),
     getWindowsAgentHookCommand: (scriptPath: string) => `"${launcherPath()}" "${scriptPath}"`,
+    getWindowsAgentHookCommandAsync: async (scriptPath: string) =>
+      `"${launcherPath()}" "${scriptPath}"`,
     getWindowsAgentHookJsonCommand: (scriptPath: string) =>
+      `"${launcherPath()}" --neutral-json "${scriptPath}"`,
+    getWindowsAgentHookJsonCommandAsync: async (scriptPath: string) =>
       `"${launcherPath()}" --neutral-json "${scriptPath}"`
   }
 })

--- a/src/main/claude/hook-service.test.ts
+++ b/src/main/claude/hook-service.test.ts
@@ -14,6 +14,18 @@ vi.mock('electron', () => ({
   }
 }))
 
+vi.mock('../agent-hooks/windows-agent-hook-launcher', async () => {
+  const { homedir } = await import('node:os')
+  const { join } = await import('node:path')
+  const launcherPath = () => join(homedir(), '.orca', 'agent-hooks', 'orca-agent-hook.exe')
+  return {
+    installWindowsAgentHookLauncher: launcherPath,
+    getWindowsAgentHookCommand: (scriptPath: string) => `"${launcherPath()}" "${scriptPath}"`,
+    getWindowsAgentHookJsonCommand: (scriptPath: string) =>
+      `"${launcherPath()}" --neutral-json "${scriptPath}"`
+  }
+})
+
 import type { SFTPWrapper } from 'ssh2'
 import { createManagedCommandMatcher } from '../agent-hooks/installer-utils'
 import { ClaudeHookService } from './hook-service'
@@ -38,10 +50,9 @@ describe('getWindowsManagedLifecycleHook', () => {
     const scriptPath = 'C:\\Users\\%name%\\a^b&c\\.orca\\agent-hooks\\claude-hook.cmd'
     const hook = getWindowsManagedLifecycleHook(scriptPath)
 
-    expect(hook.args?.[0]).toBe('--headless')
-    expect(hook.args?.[1]).toMatch(/\\System32\\cmd\.exe$/i)
-    expect(hook.args?.at(-1)).toBe('%USERPROFILE%\\.orca\\agent-hooks\\claude-hook.cmd')
-    expect(hook.args).not.toContain(scriptPath)
+    expect(hook.command).toContain('orca-agent-hook.exe" --neutral-json')
+    expect(hook.command).toContain(`"${scriptPath}"`)
+    expect(hook.args).toBeUndefined()
   })
 })
 
@@ -219,11 +230,8 @@ describe('ClaudeHookService.install', () => {
         readFileSync(join(tmpHome, '.claude', 'settings.json'), 'utf-8')
       ) as { statusLine?: { type: string; command: string } }
       expect(settings.statusLine?.type).toBe('command')
-      expect(settings.statusLine?.command).toContain(
-        '"$HOME/.orca/agent-hooks/claude-statusline.cmd"'
-      )
-      expect(settings.statusLine?.command).toContain(
-        '"$HOME/.orca/agent-hooks/claude-statusline.sh"'
+      expect(settings.statusLine?.command).toMatch(
+        /^"[^"]*\\orca-agent-hook\.exe" "[^"]*\\claude-statusline\.cmd"$/i
       )
       expect(settings.statusLine?.command).not.toContain(tmpHome.replaceAll('\\', '/'))
 
@@ -339,7 +347,7 @@ describe('ClaudeHookService.install', () => {
   })
 
   it.skipIf(process.platform !== 'win32')(
-    'runs portable managed hooks through headless exec form',
+    'runs managed hooks through the native headless launcher',
     () => {
       const tmpHome = mkdtempSync(join(tmpdir(), 'orca claude home with spaces '))
       vi.stubEnv('HOME', tmpHome)
@@ -351,24 +359,16 @@ describe('ClaudeHookService.install', () => {
           readFileSync(join(tmpHome, '.claude', 'settings.json'), 'utf-8')
         ) as { hooks: Record<string, { hooks: TestHook[] }[]> }
 
-        const system32 = join(process.env.SystemRoot ?? 'C:\\Windows', 'System32')
         const scriptPath = join(tmpHome, '.orca', 'agent-hooks', CLAUDE_SCRIPT_FILE_NAME)
-        const runtimeScriptPath = join(
-          '%USERPROFILE%',
-          '.orca',
-          'agent-hooks',
-          CLAUDE_SCRIPT_FILE_NAME
-        )
+        const launcherPath = join(tmpHome, '.orca', 'agent-hooks', 'orca-agent-hook.exe')
 
         for (const eventName of ['UserPromptSubmit', 'Stop', 'StopFailure']) {
           const hook = settings.hooks[eventName]?.[0]?.hooks?.[0]
           expect(hook).toEqual({
             type: 'command',
-            command: join(system32, 'conhost.exe'),
-            args: ['--headless', join(system32, 'cmd.exe'), '/d', '/c', runtimeScriptPath],
+            command: `"${launcherPath}" --neutral-json "${scriptPath}"`,
             timeout: 10
           })
-          expect(hook.args).not.toContain(scriptPath)
         }
       } finally {
         vi.unstubAllEnvs()
@@ -522,9 +522,9 @@ describe('OpenClaudeHookService-compatible install', () => {
       for (const event of ['UserPromptSubmit', 'Stop', 'StopFailure']) {
         const command = parsed.hooks[event][0].hooks[0].command as string
         expect(isOpenClaudeManagedCommand(command)).toBe(true)
-        expect(command).toContain('"$HOME/.orca/agent-hooks/openclaude-hook.cmd"')
-        expect(command).toContain('"$HOME/.orca/agent-hooks/openclaude-hook.sh"')
-        expect(command).not.toContain(tmpHome.replaceAll('\\', '/'))
+        expect(command).toMatch(
+          /^"[^"]*\\orca-agent-hook\.exe" --neutral-json "[^"]*\\openclaude-hook\.cmd"$/i
+        )
       }
       expect(
         readFileSync(join(tmpHome, '.orca', 'agent-hooks', OPENCLAUDE_SCRIPT_FILE_NAME), 'utf-8')

--- a/src/main/claude/hook-service.ts
+++ b/src/main/claude/hook-service.ts
@@ -9,14 +9,11 @@ import {
   writeManagedScript,
   type HooksConfig
 } from '../agent-hooks/installer-utils'
-import { refreshManagedHookCommandIfPresent } from '../agent-hooks/managed-hook-config-refresh'
 import {
   readHooksJsonRemote,
   writeHooksJsonRemote,
   writeManagedScriptRemote
 } from '../agent-hooks/installer-utils-remote'
-import { refreshManagedScriptIfPresent } from '../agent-hooks/managed-hook-script-refresh'
-import { getWindowsAgentHookJsonCommandAsync } from '../agent-hooks/windows-agent-hook-launcher'
 import {
   buildPosixHookPayloadCapture,
   buildWindowsHookEnvironmentGuardLines,
@@ -24,6 +21,7 @@ import {
   WINDOWS_HOOK_STDIN_DRAIN_LABEL
 } from '../agent-hooks/hook-stdin-contract'
 import { getManagedStatusLineScript } from './statusline-script'
+import { refreshClaudeManagedScripts } from './claude-managed-script-refresh'
 import {
   applyManagedHooks,
   applyManagedStatusLine,
@@ -178,23 +176,10 @@ export class ClaudeHookService {
   }
 
   async refreshManagedScripts(): Promise<void> {
-    const lifecycleScriptPresent = await refreshManagedScriptIfPresent(
-      getManagedScriptPath(this.options.settings),
+    await refreshClaudeManagedScripts(
+      this.options.settings,
       getManagedScript('local', { skipWhenDevinImportsClaude: this.options.agent === 'claude' })
     )
-    // Why: no agent gate — the statusline script only ever exists for claude, so presence is the gate.
-    await refreshManagedScriptIfPresent(
-      getStatusLineScriptPath(this.options.settings),
-      getManagedStatusLineScript('local')
-    )
-    if (process.platform === 'win32' && lifecycleScriptPresent) {
-      const scriptPath = getManagedScriptPath(this.options.settings)
-      await refreshManagedHookCommandIfPresent({
-        configPath: getConfigPath(this.options.settings),
-        scriptFileName: getManagedScriptFileName(this.options.settings),
-        resolveCommand: () => getWindowsAgentHookJsonCommandAsync(scriptPath)
-      })
-    }
   }
 
   install(): AgentHookInstallStatus {

--- a/src/main/claude/hook-service.ts
+++ b/src/main/claude/hook-service.ts
@@ -9,12 +9,14 @@ import {
   writeManagedScript,
   type HooksConfig
 } from '../agent-hooks/installer-utils'
+import { refreshManagedHookCommandIfPresent } from '../agent-hooks/managed-hook-config-refresh'
 import {
   readHooksJsonRemote,
   writeHooksJsonRemote,
   writeManagedScriptRemote
 } from '../agent-hooks/installer-utils-remote'
 import { refreshManagedScriptIfPresent } from '../agent-hooks/managed-hook-script-refresh'
+import { getWindowsAgentHookJsonCommandAsync } from '../agent-hooks/windows-agent-hook-launcher'
 import {
   buildPosixHookPayloadCapture,
   buildWindowsHookEnvironmentGuardLines,
@@ -29,7 +31,7 @@ import {
   CLAUDE_HOOK_SETTINGS,
   getManagedScriptFileName,
   getConfigPath,
-  getManagedCommand,
+  getLocalManagedCommand,
   getManagedLifecycleHook,
   getManagedScriptPath,
   getPosixManagedScriptFileName,
@@ -143,7 +145,7 @@ export class ClaudeHookService {
     }
 
     // Why: report partial registration instead of a false installed state.
-    const expectedHook = getManagedLifecycleHook(scriptPath, this.options.settings)
+    const expectedHook = getManagedLifecycleHook(scriptPath)
     const missing: string[] = []
     let presentCount = 0
     for (const event of CLAUDE_EVENTS) {
@@ -176,7 +178,7 @@ export class ClaudeHookService {
   }
 
   async refreshManagedScripts(): Promise<void> {
-    await refreshManagedScriptIfPresent(
+    const lifecycleScriptPresent = await refreshManagedScriptIfPresent(
       getManagedScriptPath(this.options.settings),
       getManagedScript('local', { skipWhenDevinImportsClaude: this.options.agent === 'claude' })
     )
@@ -185,6 +187,14 @@ export class ClaudeHookService {
       getStatusLineScriptPath(this.options.settings),
       getManagedStatusLineScript('local')
     )
+    if (process.platform === 'win32' && lifecycleScriptPresent) {
+      const scriptPath = getManagedScriptPath(this.options.settings)
+      await refreshManagedHookCommandIfPresent({
+        configPath: getConfigPath(this.options.settings),
+        scriptFileName: getManagedScriptFileName(this.options.settings),
+        resolveCommand: () => getWindowsAgentHookJsonCommandAsync(scriptPath)
+      })
+    }
   }
 
   install(): AgentHookInstallStatus {
@@ -201,7 +211,7 @@ export class ClaudeHookService {
       }
     }
 
-    const hook = getManagedLifecycleHook(scriptPath, this.options.settings)
+    const hook = getManagedLifecycleHook(scriptPath)
     let nextConfig = applyManagedHooks(
       config,
       hook,
@@ -232,7 +242,7 @@ export class ClaudeHookService {
     writeManagedScript(statusLineScriptPath, getManagedStatusLineScript('local'))
     const next = applyManagedStatusLine(
       config,
-      getManagedCommand(statusLineScriptPath),
+      getLocalManagedCommand(statusLineScriptPath),
       scriptFileName
     )
     try {

--- a/src/main/claude/hook-settings.ts
+++ b/src/main/claude/hook-settings.ts
@@ -1,34 +1,34 @@
 import { homedir } from 'node:os'
-import { basename, extname, join, win32 } from 'node:path'
+import { basename, extname, join } from 'node:path'
 import {
   buildManagedCommandHook,
   createManagedCommandMatcher,
   getSharedManagedScriptPath,
   isPlainObject,
-  MANAGED_HOOK_TIMEOUT_SECONDS,
   removeManagedCommands,
   type HookCommandConfig,
   type HookDefinition,
   type HooksConfig
 } from '../agent-hooks/installer-utils'
 import { wrapRuntimeHomeHookCommand } from '../agent-hooks/runtime-home-hook-command'
+import {
+  getWindowsAgentHookCommand,
+  getWindowsAgentHookJsonCommand
+} from '../agent-hooks/windows-agent-hook-launcher'
 
 export type ClaudeCompatibleHookSettings = {
   configDirName: '.claude' | '.openclaude'
   scriptBaseName: 'claude-hook' | 'openclaude-hook'
-  supportsExecHookArgs: boolean
 }
 
 export const CLAUDE_HOOK_SETTINGS: ClaudeCompatibleHookSettings = {
   configDirName: '.claude',
-  scriptBaseName: 'claude-hook',
-  supportsExecHookArgs: true
+  scriptBaseName: 'claude-hook'
 }
 
 export const OPENCLAUDE_HOOK_SETTINGS: ClaudeCompatibleHookSettings = {
   configDirName: '.openclaude',
-  scriptBaseName: 'openclaude-hook',
-  supportsExecHookArgs: false
+  scriptBaseName: 'openclaude-hook'
 }
 
 export const CLAUDE_EVENTS = [
@@ -116,31 +116,21 @@ export function getManagedCommand(scriptPath: string): string {
   )
 }
 
-export function getManagedLifecycleHook(
-  scriptPath: string,
-  settings = CLAUDE_HOOK_SETTINGS
-): HookCommandConfig {
-  if (process.platform !== 'win32' || !settings.supportsExecHookArgs) {
+export function getManagedLifecycleHook(scriptPath: string): HookCommandConfig {
+  if (process.platform !== 'win32') {
     return buildManagedCommandHook(getManagedCommand(scriptPath))
   }
   return getWindowsManagedLifecycleHook(scriptPath)
 }
 
+export function getLocalManagedCommand(scriptPath: string): string {
+  return process.platform === 'win32'
+    ? getWindowsAgentHookCommand(scriptPath)
+    : getManagedCommand(scriptPath)
+}
+
 export function getWindowsManagedLifecycleHook(scriptPath: string): HookCommandConfig {
-  const system32 = win32.join(process.env.SystemRoot ?? 'C:\\Windows', 'System32')
-  const runtimeScriptPath = win32.join(
-    '%USERPROFILE%',
-    '.orca',
-    'agent-hooks',
-    win32.basename(scriptPath)
-  )
-  // Why: Claude's Windows shell form opens Git Bash consoles; exec form hosts the client in a windowless console.
-  return {
-    type: 'command',
-    command: win32.join(system32, 'conhost.exe'),
-    args: ['--headless', win32.join(system32, 'cmd.exe'), '/d', '/c', runtimeScriptPath],
-    timeout: MANAGED_HOOK_TIMEOUT_SECONDS
-  }
+  return buildManagedCommandHook(getWindowsAgentHookJsonCommand(scriptPath))
 }
 
 export function hasSameManagedHookInvocation(

--- a/src/main/claude/hook-settings.ts
+++ b/src/main/claude/hook-settings.ts
@@ -10,10 +10,13 @@ import {
   type HookDefinition,
   type HooksConfig
 } from '../agent-hooks/installer-utils'
+import type { ManagedHookCommandMigration } from '../agent-hooks/managed-hook-config-refresh'
 import { wrapRuntimeHomeHookCommand } from '../agent-hooks/runtime-home-hook-command'
 import {
   getWindowsAgentHookCommand,
-  getWindowsAgentHookJsonCommand
+  getWindowsAgentHookCommandAsync,
+  getWindowsAgentHookJsonCommand,
+  getWindowsAgentHookJsonCommandAsync
 } from '../agent-hooks/windows-agent-hook-launcher'
 
 export type ClaudeCompatibleHookSettings = {
@@ -127,6 +130,29 @@ export function getLocalManagedCommand(scriptPath: string): string {
   return process.platform === 'win32'
     ? getWindowsAgentHookCommand(scriptPath)
     : getManagedCommand(scriptPath)
+}
+
+export function getWindowsManagedCommandMigrations(
+  settings: ClaudeCompatibleHookSettings,
+  lifecycleScriptPresent: boolean,
+  statusLineScriptPresent: boolean
+): ManagedHookCommandMigration[] {
+  const migrations: ManagedHookCommandMigration[] = []
+  if (lifecycleScriptPresent) {
+    const scriptPath = getManagedScriptPath(settings)
+    migrations.push({
+      scriptFileName: getManagedScriptFileName(settings),
+      resolveCommand: () => getWindowsAgentHookJsonCommandAsync(scriptPath)
+    })
+  }
+  if (statusLineScriptPresent) {
+    const scriptPath = getStatusLineScriptPath(settings)
+    migrations.push({
+      scriptFileName: getStatusLineScriptFileName(settings),
+      resolveCommand: () => getWindowsAgentHookCommandAsync(scriptPath)
+    })
+  }
+  return migrations
 }
 
 export function getWindowsManagedLifecycleHook(scriptPath: string): HookCommandConfig {

--- a/src/main/cursor/hook-service.test.ts
+++ b/src/main/cursor/hook-service.test.ts
@@ -15,6 +15,15 @@ vi.mock('os', async () => {
   }
 })
 
+vi.mock('../agent-hooks/windows-agent-hook-launcher', async () => {
+  const { join } = await import('node:path')
+  const launcherPath = () => join(homedirMock(), '.orca', 'agent-hooks', 'orca-agent-hook.exe')
+  return {
+    installWindowsAgentHookLauncher: launcherPath,
+    getWindowsAgentHookCommand: (scriptPath: string) => `"${launcherPath()}" "${scriptPath}"`
+  }
+})
+
 import { CursorHookService } from './hook-service'
 import { POSIX_HOOK_STDIN_READER } from '../agent-hooks/hook-stdin-contract'
 
@@ -30,8 +39,7 @@ const CURSOR_EVENTS = [
 ]
 
 const CURSOR_SCRIPT_FILE_NAME = process.platform === 'win32' ? 'cursor-hook.cmd' : 'cursor-hook.sh'
-const WINDOWS_POWERSHELL_LAUNCHER =
-  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -ExecutionPolicy Bypass -EncodedCommand \S+$/
+const WINDOWS_HEADLESS_LAUNCHER = /^"[^"]*\\orca-agent-hook\.exe" "[^"]*\\cursor-hook\.cmd"$/i
 
 describe('CursorHookService', () => {
   let homeDir: string
@@ -62,7 +70,7 @@ describe('CursorHookService', () => {
     for (const eventName of CURSOR_EVENTS) {
       const definition = config.hooks[eventName]?.[0]
       expect(definition?.command).toMatch(
-        process.platform === 'win32' ? WINDOWS_POWERSHELL_LAUNCHER : /cursor-hook/
+        process.platform === 'win32' ? WINDOWS_HEADLESS_LAUNCHER : /cursor-hook/
       )
       if (process.platform !== 'win32') {
         expect(definition?.command).toContain(join(homeDir, '.orca'))
@@ -106,7 +114,7 @@ describe('CursorHookService', () => {
 
         for (const eventName of ['beforeSubmitPrompt', 'stop']) {
           const command = config.hooks[eventName]?.[0]?.command
-          expect(command).toMatch(WINDOWS_POWERSHELL_LAUNCHER)
+          expect(command).toMatch(WINDOWS_HEADLESS_LAUNCHER)
         }
       } finally {
         rmSync(spaceHome, { recursive: true, force: true })
@@ -148,7 +156,7 @@ describe('CursorHookService', () => {
     expect(
       promptCommands.filter((command) =>
         process.platform === 'win32'
-          ? command !== undefined && WINDOWS_POWERSHELL_LAUNCHER.test(command)
+          ? command !== undefined && WINDOWS_HEADLESS_LAUNCHER.test(command)
           : command?.includes(CURSOR_SCRIPT_FILE_NAME)
       )
     ).toHaveLength(1)

--- a/src/main/cursor/hook-service.test.ts
+++ b/src/main/cursor/hook-service.test.ts
@@ -20,7 +20,10 @@ vi.mock('../agent-hooks/windows-agent-hook-launcher', async () => {
   const launcherPath = () => join(homedirMock(), '.orca', 'agent-hooks', 'orca-agent-hook.exe')
   return {
     installWindowsAgentHookLauncher: launcherPath,
-    getWindowsAgentHookCommand: (scriptPath: string) => `"${launcherPath()}" "${scriptPath}"`
+    installWindowsAgentHookLauncherAsync: async () => launcherPath(),
+    getWindowsAgentHookCommand: (scriptPath: string) => `"${launcherPath()}" "${scriptPath}"`,
+    getWindowsAgentHookCommandAsync: async (scriptPath: string) =>
+      `"${launcherPath()}" "${scriptPath}"`
   }
 })
 

--- a/src/main/cursor/hook-service.ts
+++ b/src/main/cursor/hook-service.ts
@@ -14,7 +14,7 @@ import {
   writeManagedScript,
   type HookDefinition
 } from '../agent-hooks/installer-utils'
-import { refreshManagedHookCommandIfPresent } from '../agent-hooks/managed-hook-config-refresh'
+import { refreshManagedHookCommandsIfPresent } from '../agent-hooks/managed-hook-config-refresh'
 import {
   getWindowsAgentHookCommand,
   getWindowsAgentHookCommandAsync
@@ -112,7 +112,7 @@ export class CursorHookService {
       getManagedScript()
     )
     if (process.platform === 'win32' && scriptPresent) {
-      await refreshManagedHookCommandIfPresent({
+      await refreshManagedHookCommandsIfPresent({
         configPath: getConfigPath(),
         scriptFileName: getManagedScriptFileName(),
         resolveCommand: () => getWindowsAgentHookCommandAsync(getManagedScriptPath())

--- a/src/main/cursor/hook-service.ts
+++ b/src/main/cursor/hook-service.ts
@@ -10,11 +10,15 @@ import {
   readHooksJson,
   removeManagedCommands,
   wrapPosixHookCommand,
-  wrapWindowsHookCommand,
   writeHooksJson,
   writeManagedScript,
   type HookDefinition
 } from '../agent-hooks/installer-utils'
+import { refreshManagedHookCommandIfPresent } from '../agent-hooks/managed-hook-config-refresh'
+import {
+  getWindowsAgentHookCommand,
+  getWindowsAgentHookCommandAsync
+} from '../agent-hooks/windows-agent-hook-launcher'
 import { refreshManagedScriptIfPresent } from '../agent-hooks/managed-hook-script-refresh'
 import {
   readHooksJsonRemote,
@@ -54,7 +58,7 @@ function getManagedScriptPath(): string {
 
 function getManagedCommand(scriptPath: string): string {
   return process.platform === 'win32'
-    ? wrapWindowsHookCommand(scriptPath)
+    ? getWindowsAgentHookCommand(scriptPath)
     : wrapPosixHookCommand(scriptPath)
 }
 
@@ -103,7 +107,17 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
 
 export class CursorHookService {
   async refreshManagedScripts(): Promise<void> {
-    await refreshManagedScriptIfPresent(getManagedScriptPath(), getManagedScript())
+    const scriptPresent = await refreshManagedScriptIfPresent(
+      getManagedScriptPath(),
+      getManagedScript()
+    )
+    if (process.platform === 'win32' && scriptPresent) {
+      await refreshManagedHookCommandIfPresent({
+        configPath: getConfigPath(),
+        scriptFileName: getManagedScriptFileName(),
+        resolveCommand: () => getWindowsAgentHookCommandAsync(getManagedScriptPath())
+      })
+    }
   }
 
   getStatus(): AgentHookInstallStatus {

--- a/src/main/grok/hook-service.test.ts
+++ b/src/main/grok/hook-service.test.ts
@@ -22,7 +22,10 @@ vi.mock('../agent-hooks/windows-agent-hook-launcher', async () => {
   const launcherPath = () => join(homedirMock(), '.orca', 'agent-hooks', 'orca-agent-hook.exe')
   return {
     installWindowsAgentHookLauncher: launcherPath,
-    getWindowsAgentHookCommand: (scriptPath: string) => `"${launcherPath()}" "${scriptPath}"`
+    installWindowsAgentHookLauncherAsync: async () => launcherPath(),
+    getWindowsAgentHookCommand: (scriptPath: string) => `"${launcherPath()}" "${scriptPath}"`,
+    getWindowsAgentHookCommandAsync: async (scriptPath: string) =>
+      `"${launcherPath()}" "${scriptPath}"`
   }
 })
 

--- a/src/main/grok/hook-service.test.ts
+++ b/src/main/grok/hook-service.test.ts
@@ -17,13 +17,21 @@ vi.mock('os', async () => {
   }
 })
 
+vi.mock('../agent-hooks/windows-agent-hook-launcher', async () => {
+  const { join } = await import('node:path')
+  const launcherPath = () => join(homedirMock(), '.orca', 'agent-hooks', 'orca-agent-hook.exe')
+  return {
+    installWindowsAgentHookLauncher: launcherPath,
+    getWindowsAgentHookCommand: (scriptPath: string) => `"${launcherPath()}" "${scriptPath}"`
+  }
+})
+
 import { getGrokToolEventMatcherForTests, GrokHookService } from './hook-service'
 import { buildWindowsGrokHookScript } from './windows-grok-hook-script'
 import { POSIX_HOOK_STDIN_READER } from '../agent-hooks/hook-stdin-contract'
 
 const GROK_SCRIPT_FILE_NAME = process.platform === 'win32' ? 'grok-hook.cmd' : 'grok-hook.sh'
-const WINDOWS_POWERSHELL_LAUNCHER =
-  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -ExecutionPolicy Bypass -EncodedCommand \S+$/
+const WINDOWS_HEADLESS_LAUNCHER = /^"[^"]*\\orca-agent-hook\.exe" "[^"]*\\grok-hook\.cmd"$/i
 
 type WindowsGrokHookRun = {
   status: number | null
@@ -254,7 +262,7 @@ describe('GrokHookService', () => {
     const bareStar = ['*', ''].join('')
     expect(() => new RegExp(bareStar)).toThrow()
     expect(config.hooks.PreToolUse[0].hooks[0].command).toMatch(
-      process.platform === 'win32' ? WINDOWS_POWERSHELL_LAUNCHER : /grok-hook/
+      process.platform === 'win32' ? WINDOWS_HEADLESS_LAUNCHER : /grok-hook/
     )
     if (process.platform !== 'win32') {
       expect(config.hooks.PreToolUse[0].hooks[0].command).toContain(join(homeDir, '.orca'))
@@ -302,7 +310,7 @@ describe('GrokHookService', () => {
 
         for (const eventName of ['SessionStart', 'UserPromptSubmit', 'Stop']) {
           const command = config.hooks[eventName]?.[0]?.hooks?.[0]?.command
-          expect(command).toMatch(WINDOWS_POWERSHELL_LAUNCHER)
+          expect(command).toMatch(WINDOWS_HEADLESS_LAUNCHER)
         }
       } finally {
         rmSync(spaceHome, { recursive: true, force: true })
@@ -363,7 +371,7 @@ describe('GrokHookService', () => {
     expect(
       commands.some((command) =>
         process.platform === 'win32'
-          ? WINDOWS_POWERSHELL_LAUNCHER.test(command)
+          ? WINDOWS_HEADLESS_LAUNCHER.test(command)
           : command.includes(GROK_SCRIPT_FILE_NAME)
       )
     ).toBe(true)

--- a/src/main/grok/hook-service.ts
+++ b/src/main/grok/hook-service.ts
@@ -13,7 +13,7 @@ import {
   writeManagedScript,
   type HookDefinition
 } from '../agent-hooks/installer-utils'
-import { refreshManagedHookCommandIfPresent } from '../agent-hooks/managed-hook-config-refresh'
+import { refreshManagedHookCommandsIfPresent } from '../agent-hooks/managed-hook-config-refresh'
 import {
   getWindowsAgentHookCommand,
   getWindowsAgentHookCommandAsync
@@ -193,7 +193,7 @@ export class GrokHookService {
       getManagedScript()
     )
     if (process.platform === 'win32' && scriptPresent) {
-      await refreshManagedHookCommandIfPresent({
+      await refreshManagedHookCommandsIfPresent({
         configPath: getConfigPath(),
         scriptFileName: getManagedScriptFileName(),
         resolveCommand: () => getWindowsAgentHookCommandAsync(getManagedScriptPath())

--- a/src/main/grok/hook-service.ts
+++ b/src/main/grok/hook-service.ts
@@ -9,11 +9,15 @@ import {
   readHooksJson,
   removeManagedCommands,
   wrapPosixHookCommand,
-  wrapWindowsHookCommand,
   writeHooksJson,
   writeManagedScript,
   type HookDefinition
 } from '../agent-hooks/installer-utils'
+import { refreshManagedHookCommandIfPresent } from '../agent-hooks/managed-hook-config-refresh'
+import {
+  getWindowsAgentHookCommand,
+  getWindowsAgentHookCommandAsync
+} from '../agent-hooks/windows-agent-hook-launcher'
 import { refreshManagedScriptIfPresent } from '../agent-hooks/managed-hook-script-refresh'
 import {
   readHooksJsonRemote,
@@ -103,7 +107,7 @@ function getManagedScriptPath(): string {
 
 function getManagedCommand(scriptPath: string): string {
   return process.platform === 'win32'
-    ? wrapWindowsHookCommand(scriptPath)
+    ? getWindowsAgentHookCommand(scriptPath)
     : wrapPosixHookCommand(scriptPath)
 }
 
@@ -184,7 +188,17 @@ function buildInstalledConfig(
 
 export class GrokHookService {
   async refreshManagedScripts(): Promise<void> {
-    await refreshManagedScriptIfPresent(getManagedScriptPath(), getManagedScript())
+    const scriptPresent = await refreshManagedScriptIfPresent(
+      getManagedScriptPath(),
+      getManagedScript()
+    )
+    if (process.platform === 'win32' && scriptPresent) {
+      await refreshManagedHookCommandIfPresent({
+        configPath: getConfigPath(),
+        scriptFileName: getManagedScriptFileName(),
+        resolveCommand: () => getWindowsAgentHookCommandAsync(getManagedScriptPath())
+      })
+    }
   }
 
   getStatus(): AgentHookInstallStatus {

--- a/src/main/hooks.test.ts
+++ b/src/main/hooks.test.ts
@@ -954,7 +954,8 @@ describe('runHook', () => {
         'echo hello',
         expect.objectContaining({
           cwd: 'C:\\repo\\worktree',
-          shell: 'C:\\Windows\\System32\\cmd.exe'
+          shell: 'C:\\Windows\\System32\\cmd.exe',
+          windowsHide: true
         }),
         expect.any(Function)
       )
@@ -1029,6 +1030,7 @@ describe('runHook', () => {
       callback?.(null, '', '')
       expect(options).toEqual(
         expect.objectContaining({
+          windowsHide: true,
           env: expect.objectContaining({
             ORCA_ROOT_PATH: '/mnt/c/Users/jinwo/git/orca',
             ORCA_WORKTREE_PATH: '/home/jin/feature',

--- a/src/main/hooks.ts
+++ b/src/main/hooks.ts
@@ -753,7 +753,8 @@ export function runHook(
             // across the wsl.exe boundary. Wrap hookEnv (not a fresh env) so
             // the setup-var WSLENV entries registered above (#9206) are kept —
             // promptGuardShellEnv appends its own keys to the existing WSLENV.
-            env: promptGuardShellEnv(hookEnv)
+            env: promptGuardShellEnv(hookEnv),
+            windowsHide: true
           },
           (error, stdout, stderr) => {
             finish(error ?? null, stdout, stderr)
@@ -776,7 +777,8 @@ export function runHook(
         env: promptGuardShellEnv({
           ...process.env,
           ...getSetupEnvVars(repo, cwd)
-        })
+        }),
+        windowsHide: true
       },
       (error, stdout, stderr) => {
         if (error) {


### PR DESCRIPTION
## ELI5

On Windows, agent hooks could briefly open black terminal windows, steal focus, hang after a tool call, or expose hook protocol output such as raw JSON. Orca now runs those hooks through a small windowless launcher, gives Claude-compatible hooks the valid neutral JSON they expect, and forcibly bounds abandoned stdin and child processes so no console or orphan remains.

## What Changed

- Added a packaged Windows GUI-subsystem launcher for managed agent hooks. It starts the system `cmd.exe` with no window, redirects all standard streams, and never resolves executables through the workspace or `PATH`.
- Added bounded lifecycle handling: stdin is accepted for up to 1 second, the child gets up to 2.5 seconds, and a timed-out child is terminated.
- Claude and OpenClaude lifecycle hooks now use one command string with `--neutral-json`, avoiding the older-Claude behavior that ignored separate `args` and rejected empty stdout.
- Cursor and Grok hooks use the same windowless launcher without emitting stdout.
- Launcher filenames are content-addressed, so an Orca update does not need to replace an `.exe` that a concurrent hook still has open.
- Existing managed Claude, Cursor, and Grok configs are migrated asynchronously even if the agent CLI is no longer on `PATH`. Missing or user-removed configs are not recreated, legacy Claude `args` are removed, symlinked configs remain attached to their targets, and writes remain guarded and atomic.
- Direct local Windows and WSL hook subprocesses set `windowsHide: true` as a second backstop.
- Added packaging, build, migration, main-thread I/O, command-shape, and subprocess-option regression coverage.

## Why

The previous Windows paths had several related failure modes:

- shell-form hooks could create a visible `conhost.exe` window and steal focus;
- Claude versions that ignored hook `args` could execute only the host command or treat empty stdout as invalid JSON;
- callers that left stdin open could keep `cmd.exe` / `curl.exe` chains alive;
- already-installed user configs continued invoking stale launchers when the CLI presence gate no longer ran installation.

A GUI-subsystem launcher fixes the window creation at the process boundary. Bounded redirected streams solve the hang/orphan class, while protocol-specific neutral JSON keeps Claude fail-open without leaking output into a visible terminal.

## Linked Issue

Fixes #14815
Fixes #14818
Fixes #14828
Fixes #14837

## Related PRs

Canonical Windows hook fix for #14815 (Claude, Cursor, and Grok). #14825 is a Claude-only predecessor that still emits `conhost.exe --headless` plus encoded PowerShell; it does not cover Cursor/Grok and does not address the #14837 conhost hang class or Cursor's invalid-JSON block (#14818). Prefer this PR; do not merge #14825 first.

## Hosted CI

This is a cross-repository fork PR (`Tauri-EPO/orca` → `stablyai/orca`). GitHub Actions on `b157fd3101a56206bddf06d2221b5f2b965a29a4` have not produced check runs: `gh pr checks` reports none, commit statuses `total_count: 0`, `statusCheckRollup` is empty, `mergeStateStatus` is `UNSTABLE`. Workflow runs exist but never spawned jobs (`conclusion: action_required`, fork-workflow approval, `approvals: []`):

- PR Checks — https://github.com/stablyai/orca/actions/runs/31926606061
- PR test LoC — https://github.com/stablyai/orca/actions/runs/31926605888
- Computer-use e2e — https://github.com/stablyai/orca/actions/runs/31926605898

Maintainer action: approve and run those workflows. Independent Windows unit tests and native launcher probes are in Testing below.

## Visual Proof

`N/A` for rendered Orca UI — no Orca view, layout, or in-app control changes. Linked issues #14815, #14818, #14828, and #14837 have no screenshot or video attachments (the only extra #14828 file is a Discord `message.txt`, not an image), so none is copied here and none is invented.

This is still an OS-console / focus-steal interaction. Public before/after evidence is textual and process-level, not a tab-switchable screenshot pair:

**Before (already public):**

- #14815: stranded visible `conhost.exe` windows; hook JSON typed into the shell (`A sintaxe do nome do arquivo, do nome do diretório ou do rótulo do volume está incorreta.`)
- #14828: black console flash stealing foreground on every Grok tool call
- #14818: console flash per Cursor tool call plus `Hook "C:\Windows\System32\conhost.exe" returned invalid JSON. The command was blocked for safety.`
- #14837: honored-args path is headless, but every event blocks the full 10s timeout and leaks `conhost` / `cmd` / `curl`

**After (already public on this PR; re-verified on head `b157fd3`):**

- Bundled launcher PE subsystem `2` = `IMAGE_SUBSYSTEM_WINDOWS_GUI`
- `--neutral-json` + child `exit /b 7` + leaked echo: exit 7, stdout exactly `{}\n` (`7B-7D-0A`), stderr empty, 77ms
- Silent Cursor/Grok path: exit 7, stdout empty, 180ms
- Missing script: exit 0, stdout `{}\n`, 50ms
- Prior public tree-kill probe: leftover descendants 0 — https://github.com/stablyai/orca/pull/14845#issuecomment-5305886862

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

Author-reported Windows 11 live sessions (not re-run in this compliance pass):

- Fresh Claude session: 8 hook runs; closed stdin completed in at most 114 ms, deliberately open stdin completed in about 1.05 s; stdout was exactly `{}` plus newline, stderr was empty, all 11 managed commands used one command string with no `args`, and no launcher/curl process remained.
- Fresh Cursor session: imported Claude `PreToolUse` returned valid neutral JSON without blocking; Cursor-native hooks exited with no stdout; all probes completed in 82–1145 ms with no stderr or orphaned process.
- Fresh Grok/Codex session: the installed Grok hook completed with deliberately open stdin in about 1.06 s, with no stdout/stderr, PowerShell/conhost command, or orphaned process.
- Exact Git Bash single-command invocation returned `{}` and exit 0 with zero active launchers/curl processes.
- Unicode payload coverage included accented text, CJK, and emoji without corruption.

This compliance pass on detached `b157fd3101a56206bddf06d2221b5f2b965a29a4` (Windows 11):

- Focused `pnpm exec vitest run --config config/vitest.config.ts` on the 6 changed test files: **6 files, 120 passed**
- `pnpm exec oxlint --deny-warnings` on changed TypeScript/JavaScript files: exit 0
- `git diff --check origin/main...HEAD`: clean
- Existing `native/windows-agent-hook-launcher/.build/orca-agent-hook.exe` PE subsystem **2** (`IMAGE_SUBSYSTEM_WINDOWS_GUI`); live launcher probes as in Visual Proof
- Full `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` were not re-run here; those remain the hosted-CI gate after maintainer fork-workflow approval
- `oxfmt --check` is not claimed: it also fails on unchanged `src/main/wsl.ts` in this worktree, so it is not treated as a PR-specific defect

## AI Disclosure

Investigation and implementation were AI-assisted with Claude, Grok, and OpenAI Codex. The final patch, scope, tests, and live Windows evidence were reviewed and verified by me before submission.

## Review

- **Security:** uses absolute system executable paths, redirects standard streams, avoids workspace/`PATH` executable lookup, quotes the managed script path, and only migrates configs that already contain an Orca-managed command.
- **Cross-platform:** the native launcher and config migration are guarded to Windows. macOS and Linux keep their existing POSIX hook paths. No renderer, keyboard, path-format, or native-module ABI behavior changes.
- **SSH / remote / folder workspaces:** remote hook installation remains POSIX and unchanged. The launcher is only selected for local Windows execution; folder workspaces and git worktrees use the same managed user hook path. WSL receives only the existing Electron `windowsHide` spawn option on the Windows host side.
- **Agent compatibility:** Claude/OpenClaude get protocol-valid neutral JSON; Cursor and Grok remain silent. Existing command matchers migrate legacy `.cmd`, `.ps1`, and `.sh` references without touching user-authored hooks.
- **Backwards compatibility:** no RPC, stream, persisted-state, remote-wire, Git, or provider contract changes. Existing configs are upgraded in place and absent configs remain absent.
- **Performance:** the launcher removes PowerShell startup from the hot path, uses async startup refresh I/O, and applies hard upper bounds to stdin and child lifetime.
- **UI / mobile:** no rendered UI or mobile change.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @EnricoPin
