### PR TITLE
fix(daemon): validate spawn cwd asynchronously so one dead share cannot freeze every terminal

### DIFF
--- a/src/main/daemon/client.ts
+++ b/src/main/daemon/client.ts
@@ -17,6 +17,7 @@ import {
   attachStreamEventReader
 } from './daemon-client-ndjson-readers'
 import { writeNotifyWithSettlement } from './daemon-client-notify-settlement'
+import { requestDaemonRpc } from './daemon-client-rpc-request'
 
 const CONNECT_TIMEOUT_MS = 5000
 const CONNECTION_ATTEMPT_WAIT_MS = CONNECT_TIMEOUT_MS * 4
@@ -197,29 +198,29 @@ export class DaemonClient {
   async request<T = unknown>(
     type: string,
     payload: unknown,
-    timeoutMs = REQUEST_TIMEOUT_MS
+    timeoutMs = REQUEST_TIMEOUT_MS,
+    signal?: AbortSignal
   ): Promise<T> {
     if (!this.connected || !this.controlSocket) {
       throw new DaemonProtocolError('Not connected')
     }
+    const generation = this.connectionGeneration
 
-    const id = `req-${++this.requestCounter}`
-    const msg = { id, type, ...(payload !== undefined ? { payload } : {}) }
-    const encoded = encodeNdjson(msg)
-
-    return new Promise<T>((resolve, reject) => {
-      const timer = setTimeout(() => {
-        this.pendingRequests.drop(id)
-        reject(new DaemonProtocolError(`Request ${type} timed out after ${timeoutMs}ms`))
-      }, timeoutMs)
-
-      this.pendingRequests.add(id, {
-        resolve: resolve as (value: unknown) => void,
-        reject,
-        timer
-      })
-
-      this.controlSocket!.write(encoded)
+    return requestDaemonRpc<T>({
+      socket: this.controlSocket,
+      pendingRequests: this.pendingRequests,
+      id: `req-${++this.requestCounter}`,
+      type,
+      payload,
+      timeoutMs,
+      ...(signal ? { signal } : {}),
+      onCreateCancellationFailure: () => this.handleDisconnect(generation),
+      settleCreateCancellation: (sessionId, requestId) =>
+        this.request<{ canceled: boolean }>(
+          'cancelCreateOrAttach',
+          { sessionId, requestId },
+          NOTIFY_SETTLEMENT_TIMEOUT_MS
+        )
     })
   }
 

--- a/src/main/daemon/daemon-client-rpc-request.test.ts
+++ b/src/main/daemon/daemon-client-rpc-request.test.ts
@@ -1,0 +1,107 @@
+import type { Socket } from 'node:net'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { DaemonPendingRequests } from './daemon-client-pending-requests'
+import { requestDaemonRpc } from './daemon-client-rpc-request'
+
+describe('requestDaemonRpc', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('keeps a completed spawn result when cancellation arrives too late', async () => {
+    const pendingRequests = new DaemonPendingRequests()
+    const abort = new AbortController()
+    let finishCancellation: (result: { canceled: boolean }) => void = () => {}
+    const cancellation = new Promise<{ canceled: boolean }>((resolve) => {
+      finishCancellation = resolve
+    })
+    const request = requestDaemonRpc<{ isNew: boolean }>({
+      socket: { write: vi.fn() } as unknown as Socket,
+      pendingRequests,
+      id: 'req-1',
+      type: 'createOrAttach',
+      payload: { sessionId: 'completed-spawn' },
+      timeoutMs: 30_000,
+      signal: abort.signal,
+      onCreateCancellationFailure: vi.fn(),
+      settleCreateCancellation: () => cancellation
+    })
+
+    abort.abort()
+    finishCancellation({ canceled: false })
+    pendingRequests.settle({ id: 'req-1', ok: true, payload: { isNew: true } })
+
+    await expect(request).resolves.toEqual({ isNew: true })
+  })
+
+  it('keeps a completed spawn result when its deadline cancellation arrives too late', async () => {
+    vi.useFakeTimers()
+    const pendingRequests = new DaemonPendingRequests()
+    const settleCreateCancellation = vi.fn(async () => ({ canceled: false }))
+    const request = requestDaemonRpc<{ isNew: boolean }>({
+      socket: { write: vi.fn() } as unknown as Socket,
+      pendingRequests,
+      id: 'req-1',
+      type: 'createOrAttach',
+      payload: { sessionId: 'completed-spawn' },
+      timeoutMs: 10,
+      onCreateCancellationFailure: vi.fn(),
+      settleCreateCancellation
+    })
+
+    await vi.advanceTimersByTimeAsync(10)
+    expect(settleCreateCancellation).toHaveBeenCalledWith('completed-spawn', 'req-1')
+    pendingRequests.settle({ id: 'req-1', ok: true, payload: { isNew: true } })
+
+    await expect(request).resolves.toEqual({ isNew: true })
+  })
+
+  it('rejects a timed-out spawn after the daemon confirms cancellation', async () => {
+    vi.useFakeTimers()
+    const pendingRequests = new DaemonPendingRequests()
+    const request = requestDaemonRpc({
+      socket: { write: vi.fn() } as unknown as Socket,
+      pendingRequests,
+      id: 'req-1',
+      type: 'createOrAttach',
+      payload: { sessionId: 'pending-spawn' },
+      timeoutMs: 10,
+      onCreateCancellationFailure: vi.fn(),
+      settleCreateCancellation: vi.fn(async () => ({ canceled: true }))
+    })
+    const rejected = expect(request).rejects.toThrow('Request createOrAttach timed out after 10ms')
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    await rejected
+    expect(pendingRequests.size).toBe(0)
+  })
+
+  it('disconnects when spawn cancellation cannot be confirmed', async () => {
+    const pendingRequests = new DaemonPendingRequests()
+    const abort = new AbortController()
+    const onCreateCancellationFailure = vi.fn(() => {
+      pendingRequests.rejectAll('Connection lost')
+    })
+    const request = requestDaemonRpc({
+      socket: { write: vi.fn() } as unknown as Socket,
+      pendingRequests,
+      id: 'req-1',
+      type: 'createOrAttach',
+      payload: { sessionId: 'unconfirmed-spawn' },
+      timeoutMs: 30_000,
+      signal: abort.signal,
+      onCreateCancellationFailure,
+      settleCreateCancellation: vi.fn(async () => {
+        throw new Error('settlement failed')
+      })
+    })
+    const rejected = expect(request).rejects.toThrow('Connection lost')
+
+    abort.abort()
+
+    await rejected
+    expect(onCreateCancellationFailure).toHaveBeenCalledOnce()
+    expect(pendingRequests.size).toBe(0)
+  })
+})

--- a/src/main/daemon/daemon-client-rpc-request.ts
+++ b/src/main/daemon/daemon-client-rpc-request.ts
@@ -1,0 +1,107 @@
+import type { Socket } from 'node:net'
+import { encodeNdjson } from './ndjson'
+import { DaemonProtocolError } from './types'
+import type { DaemonPendingRequests } from './daemon-client-pending-requests'
+
+type DaemonRpcRequestOptions = {
+  socket: Socket
+  pendingRequests: DaemonPendingRequests
+  id: string
+  type: string
+  payload: unknown
+  timeoutMs: number
+  signal?: AbortSignal
+  onCreateCancellationFailure: () => void
+  settleCreateCancellation: (sessionId: string, requestId: string) => Promise<{ canceled: boolean }>
+}
+
+export function requestDaemonRpc<T>(opts: DaemonRpcRequestOptions): Promise<T> {
+  const { payload, type } = opts
+  const createSessionId =
+    type === 'createOrAttach' && payload !== null && typeof payload === 'object'
+      ? Reflect.get(payload, 'sessionId')
+      : null
+  const requestPayload =
+    type === 'createOrAttach' && payload !== null && typeof payload === 'object'
+      ? { ...payload, cancelAfterMs: Math.max(1, opts.timeoutMs - 100) }
+      : payload
+  const encoded = encodeNdjson({
+    id: opts.id,
+    type,
+    ...(requestPayload !== undefined ? { payload: requestPayload } : {})
+  })
+
+  return new Promise<T>((resolve, reject) => {
+    let sent = false
+    let cancellationStarted = false
+    let settled = false
+    const removeAbortListener = (): void => opts.signal?.removeEventListener('abort', onAbort)
+    const rejectAndDrop = (error: Error): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      opts.pendingRequests.drop(opts.id)
+      removeAbortListener()
+      clearTimeout(timer)
+      reject(error)
+    }
+    const cancelCreate = (error: Error): void => {
+      if (cancellationStarted) {
+        return
+      }
+      cancellationStarted = true
+      clearTimeout(timer)
+      if (!sent || typeof createSessionId !== 'string') {
+        rejectAndDrop(error)
+        return
+      }
+      void opts
+        .settleCreateCancellation(createSessionId, opts.id)
+        .then((result) => {
+          if (result.canceled) {
+            rejectAndDrop(error)
+          }
+        })
+        .catch(() => {
+          if (!settled) {
+            opts.onCreateCancellationFailure()
+          }
+        })
+    }
+    const timer = setTimeout(() => {
+      const error = new DaemonProtocolError(`Request ${type} timed out after ${opts.timeoutMs}ms`)
+      if (typeof createSessionId === 'string') {
+        cancelCreate(error)
+      } else {
+        rejectAndDrop(error)
+      }
+    }, opts.timeoutMs)
+    const onAbort = (): void => {
+      removeAbortListener()
+      cancelCreate(new Error('client_disconnected'))
+    }
+
+    opts.pendingRequests.add(opts.id, {
+      resolve: (value) => {
+        settled = true
+        removeAbortListener()
+        resolve(value as T)
+      },
+      reject: (error) => {
+        settled = true
+        removeAbortListener()
+        reject(error)
+      },
+      timer
+    })
+
+    opts.signal?.addEventListener('abort', onAbort, { once: true })
+    if (opts.signal?.aborted) {
+      onAbort()
+      return
+    }
+    sent = true
+    opts.socket.write(encoded)
+  })
+}

--- a/src/main/daemon/daemon-foreground-confirmation-protocol.test.ts
+++ b/src/main/daemon/daemon-foreground-confirmation-protocol.test.ts
@@ -3,7 +3,7 @@ import { PREVIOUS_DAEMON_PROTOCOL_VERSIONS, PROTOCOL_VERSION } from './types'
 
 describe('foreground-confirmation daemon protocol', () => {
   it('rejects daemons from before the fresh-confirmation RPC', () => {
-    expect(PROTOCOL_VERSION).toBe(34)
+    expect(PROTOCOL_VERSION).toBe(35)
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(19)
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(22)
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(23)
@@ -17,5 +17,6 @@ describe('foreground-confirmation daemon protocol', () => {
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(31)
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(32)
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(33)
+    expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(34)
   })
 })

--- a/src/main/daemon/daemon-protocol-version.test.ts
+++ b/src/main/daemon/daemon-protocol-version.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   AGENT_SESSION_CLAIM_DAEMON_PROTOCOL_VERSION,
   AGENT_SESSION_CREATE_OPERATION_DAEMON_PROTOCOL_VERSION,
+  ASYNC_CWD_VALIDATION_DAEMON_PROTOCOL_VERSION,
   CODEX_SHELL_LAUNCH_PREFLIGHT_DAEMON_PROTOCOL_VERSION,
   COMPLETION_PROCESS_INSPECTION_PROTOCOL_VERSION,
   GET_FOREGROUND_PROCESS_PROTOCOL_VERSION,
@@ -17,7 +18,8 @@ import {
 
 describe('daemon protocol version', () => {
   it('ships bounded history transfer after the 2031-unsubscribe fact', () => {
-    expect(PROTOCOL_VERSION).toBe(34)
+    expect(PROTOCOL_VERSION).toBe(35)
+    expect(ASYNC_CWD_VALIDATION_DAEMON_PROTOCOL_VERSION).toBe(35)
     expect(CODEX_SHELL_LAUNCH_PREFLIGHT_DAEMON_PROTOCOL_VERSION).toBe(34)
     expect(WSL_POSIX_CWD_DAEMON_PROTOCOL_VERSION).toBe(33)
     expect(SNAPSHOT_SERIALIZER_FIDELITY_DAEMON_PROTOCOL_VERSION).toBe(32)
@@ -29,7 +31,7 @@ describe('daemon protocol version', () => {
     expect(AGENT_SESSION_CLAIM_DAEMON_PROTOCOL_VERSION).toBe(26)
     expect(AGENT_SESSION_CREATE_OPERATION_DAEMON_PROTOCOL_VERSION).toBe(26)
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toEqual(
-      Array.from({ length: 33 }, (_, index) => index + 1)
+      Array.from({ length: 34 }, (_, index) => index + 1)
     )
   })
 

--- a/src/main/daemon/daemon-protocol-version.ts
+++ b/src/main/daemon/daemon-protocol-version.ts
@@ -1,6 +1,7 @@
 // Why: daemons survive app updates, so wire behavior must be version-gated.
-// v34 prepares Codex hook trust at the shell launch boundary; older owners remain attachable.
-export const PROTOCOL_VERSION = 34
+// v35 makes cwd validation async with request-scoped spawn cancellation; older owners stay attachable.
+export const PROTOCOL_VERSION = 35
+export const ASYNC_CWD_VALIDATION_DAEMON_PROTOCOL_VERSION = 35
 export const CODEX_SHELL_LAUNCH_PREFLIGHT_DAEMON_PROTOCOL_VERSION = 34
 export const WSL_POSIX_CWD_DAEMON_PROTOCOL_VERSION = 33
 export const SNAPSHOT_SERIALIZER_FIDELITY_DAEMON_PROTOCOL_VERSION = 32
@@ -28,7 +29,7 @@ export const CLEAN_DISCONNECT_PROTOCOL_VERSION = 24
 export const MODE_2031_UNSUBSCRIBE_FACT_PROTOCOL_VERSION = 29
 export const PREVIOUS_DAEMON_PROTOCOL_VERSIONS = [
   1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27,
-  28, 29, 30, 31, 32, 33
+  28, 29, 30, 31, 32, 33, 34
 ] as const
 
 export function supportsPtyStartupIngress(protocolVersion: number): boolean {

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -588,7 +588,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
       if (opts.signal?.aborted) {
         throw new Error('client_disconnected')
       }
-      return this.client.request<CreateOrAttachResult>('createOrAttach', {
+      const payload = {
         sessionId,
         cols: effectiveCols,
         rows: effectiveRows,
@@ -615,7 +615,15 @@ export class DaemonPtyAdapter implements IPtyProvider {
         ...(!attachOnly && opts.agentSessionEnsure
           ? { agentSessionEnsure: opts.agentSessionEnsure }
           : {})
-      })
+      }
+      return opts.signal
+        ? this.client.request<CreateOrAttachResult>(
+            'createOrAttach',
+            payload,
+            undefined,
+            opts.signal
+          )
+        : this.client.request<CreateOrAttachResult>('createOrAttach', payload)
     }
 
     const createOrAttach = async (

--- a/src/main/daemon/daemon-pty-router.test.ts
+++ b/src/main/daemon/daemon-pty-router.test.ts
@@ -409,7 +409,7 @@ describe('DaemonPtyRouter', () => {
     expect(current.confirmForegroundProcess).toHaveBeenCalledWith('current-session')
   })
 
-  it('preserves older session owners and routes new sessions to v34', async () => {
+  it('preserves older session owners and routes new sessions to v35', async () => {
     const current = createAdapter('current', [], undefined, PROTOCOL_VERSION)
     const legacyV30 = createAdapter(
       'v30',
@@ -425,9 +425,10 @@ describe('DaemonPtyRouter', () => {
     )
     const legacyV32 = createAdapter('v32', ['v32-session'], undefined, 32)
     const legacyV33 = createAdapter('v33', ['v33-session'], undefined, 33)
+    const legacyV34 = createAdapter('v34', ['v34-session'], undefined, 34)
     const router = new DaemonPtyRouter({
       current,
-      legacy: [legacyV30, legacyV31, legacyV32, legacyV33]
+      legacy: [legacyV30, legacyV31, legacyV32, legacyV33, legacyV34]
     })
 
     await router.discoverLegacySessions()
@@ -436,22 +437,26 @@ describe('DaemonPtyRouter', () => {
     await router.spawn({ sessionId: 'v31-session', cols: 80, rows: 24 })
     await router.spawn({ sessionId: 'v32-session', cols: 80, rows: 24 })
     await router.spawn({ sessionId: 'v33-session', cols: 80, rows: 24 })
+    await router.spawn({ sessionId: 'v34-session', cols: 80, rows: 24 })
     const fresh = await router.spawn({ cols: 80, rows: 24 })
     router.write('v30-session', 'old-v30\n')
     router.write('v31-session', 'old-v31\n')
     router.write('v32-session', 'old-v32\n')
     router.write('v33-session', 'old-v33\n')
+    router.write('v34-session', 'old-v34\n')
     router.write(fresh.id, 'new\n')
 
     expect(legacyV30.spawn).toHaveBeenCalledWith({ sessionId: 'v30-session', cols: 80, rows: 24 })
     expect(legacyV31.spawn).toHaveBeenCalledWith({ sessionId: 'v31-session', cols: 80, rows: 24 })
     expect(legacyV32.spawn).toHaveBeenCalledWith({ sessionId: 'v32-session', cols: 80, rows: 24 })
     expect(legacyV33.spawn).toHaveBeenCalledWith({ sessionId: 'v33-session', cols: 80, rows: 24 })
+    expect(legacyV34.spawn).toHaveBeenCalledWith({ sessionId: 'v34-session', cols: 80, rows: 24 })
     expect(current.spawn).toHaveBeenCalledWith({ cols: 80, rows: 24 })
     expect(legacyV30.write).toHaveBeenCalledWith('v30-session', 'old-v30\n')
     expect(legacyV31.write).toHaveBeenCalledWith('v31-session', 'old-v31\n')
     expect(legacyV32.write).toHaveBeenCalledWith('v32-session', 'old-v32\n')
     expect(legacyV33.write).toHaveBeenCalledWith('v33-session', 'old-v33\n')
+    expect(legacyV34.write).toHaveBeenCalledWith('v34-session', 'old-v34\n')
     expect(current.write).toHaveBeenCalledWith(fresh.id, 'new\n')
   })
 

--- a/src/main/daemon/daemon-server-async-spawn-cancellation.test.ts
+++ b/src/main/daemon/daemon-server-async-spawn-cancellation.test.ts
@@ -1,0 +1,183 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DaemonClient } from './client'
+import { createMockSubprocess } from './daemon-pty-adapter-test-harness'
+import { DaemonServer } from './daemon-server'
+import { getDaemonSocketPath } from './daemon-spawner'
+
+describe('daemon async spawn cancellation', () => {
+  let directory: string
+  let server: DaemonServer
+  let client: DaemonClient
+  let releaseSpawn: () => void
+  let spawnStarted: Promise<void>
+  let subprocess: ReturnType<typeof createMockSubprocess>
+
+  beforeEach(async () => {
+    directory = mkdtempSync(join(tmpdir(), 'daemon-async-spawn-cancel-'))
+    let markSpawnStarted: () => void = () => {}
+    spawnStarted = new Promise<void>((resolve) => {
+      markSpawnStarted = resolve
+    })
+    const spawnGate = new Promise<void>((resolve) => {
+      releaseSpawn = resolve
+    })
+    server = new DaemonServer({
+      socketPath: getDaemonSocketPath(directory),
+      tokenPath: join(directory, 'daemon.token'),
+      spawnSubprocess: async () => {
+        subprocess = createMockSubprocess()
+        markSpawnStarted()
+        await spawnGate
+        return subprocess
+      }
+    })
+    await server.start()
+    client = new DaemonClient({
+      socketPath: getDaemonSocketPath(directory),
+      tokenPath: join(directory, 'daemon.token')
+    })
+    await client.ensureConnected()
+  })
+
+  afterEach(async () => {
+    releaseSpawn?.()
+    client?.disconnect()
+    await server?.shutdown()
+    rmSync(directory, { recursive: true, force: true })
+  })
+
+  it.each(['cancelCreateOrAttach', 'kill'] as const)(
+    'reaps a subprocess canceled by %s during async spawn',
+    async (requestType) => {
+      const create = client.request('createOrAttach', {
+        sessionId: 'canceled-spawn',
+        cols: 80,
+        rows: 24
+      })
+      const canceled = expect(create).rejects.toThrow('Attach canceled for session canceled-spawn')
+      await spawnStarted
+
+      await (requestType === 'kill'
+        ? client.request('kill', { sessionId: 'canceled-spawn', immediate: true })
+        : client.request('cancelCreateOrAttach', { sessionId: 'canceled-spawn' }))
+      releaseSpawn()
+      await canceled
+
+      expect(subprocess.forceKill).toHaveBeenCalledOnce()
+      await expect(client.request('listSessions', undefined)).resolves.toEqual({ sessions: [] })
+    }
+  )
+
+  it('reaps a subprocess after its requesting client disconnects', async () => {
+    const create = client
+      .request('createOrAttach', {
+        sessionId: 'disconnected-spawn',
+        cols: 80,
+        rows: 24
+      })
+      .catch(() => undefined)
+    await spawnStarted
+
+    client.disconnect()
+    const daemon = server as unknown as {
+      pendingPtySpawnPreparations: Map<string, Set<{ canceled: boolean }>>
+      host: { listSessions: () => unknown[] }
+    }
+    await vi.waitFor(() =>
+      expect(
+        [...(daemon.pendingPtySpawnPreparations.get('disconnected-spawn') ?? [])][0]?.canceled
+      ).toBe(true)
+    )
+    releaseSpawn()
+    await create
+    await vi.waitFor(() => expect(subprocess.forceKill).toHaveBeenCalledOnce())
+    expect(daemon.host.listSessions()).toEqual([])
+  })
+
+  it('reaps a subprocess after the client request times out', async () => {
+    const create = client.request(
+      'createOrAttach',
+      { sessionId: 'timed-out-spawn', cols: 80, rows: 24 },
+      10
+    )
+    await spawnStarted
+
+    await expect(create).rejects.toThrow('timed out')
+    releaseSpawn()
+
+    await vi.waitFor(() => expect(subprocess.forceKill).toHaveBeenCalledOnce())
+    await expect(client.request('listSessions', undefined)).resolves.toEqual({ sessions: [] })
+  })
+
+  it('reaps a subprocess after the client aborts its request', async () => {
+    const abort = new AbortController()
+    const create = client.request(
+      'createOrAttach',
+      { sessionId: 'aborted-spawn', cols: 80, rows: 24 },
+      30_000,
+      abort.signal
+    )
+    await spawnStarted
+
+    abort.abort()
+    await expect(create).rejects.toThrow('client_disconnected')
+    releaseSpawn()
+
+    await vi.waitFor(() => expect(subprocess.forceKill).toHaveBeenCalledOnce())
+    await expect(client.request('listSessions', undefined)).resolves.toEqual({ sessions: [] })
+  })
+
+  it('does not cancel a sibling request for the same session id', async () => {
+    const first = client.request('createOrAttach', {
+      sessionId: 'shared-session',
+      cols: 80,
+      rows: 24
+    })
+    const abort = new AbortController()
+    const second = client.request(
+      'createOrAttach',
+      { sessionId: 'shared-session', cols: 80, rows: 24 },
+      30_000,
+      abort.signal
+    )
+    await spawnStarted
+    const daemon = server as unknown as {
+      pendingPtySpawnPreparations: Map<string, Set<unknown>>
+    }
+    await vi.waitFor(() =>
+      expect(daemon.pendingPtySpawnPreparations.get('shared-session')?.size).toBe(2)
+    )
+
+    abort.abort()
+    await expect(second).rejects.toThrow('client_disconnected')
+    releaseSpawn()
+
+    await expect(first).resolves.toMatchObject({ isNew: true })
+    expect(subprocess.forceKill).not.toHaveBeenCalled()
+    await expect(client.request('listSessions', undefined)).resolves.toMatchObject({
+      sessions: [expect.objectContaining({ sessionId: 'shared-session' })]
+    })
+  })
+
+  it('reaps an async spawn before daemon shutdown completes', async () => {
+    const create = client
+      .request('createOrAttach', {
+        sessionId: 'shutdown-spawn',
+        cols: 80,
+        rows: 24
+      })
+      .catch(() => undefined)
+    await spawnStarted
+
+    const shutdown = server.shutdown()
+    releaseSpawn()
+    await create
+    await shutdown
+
+    expect(subprocess.forceKill).toHaveBeenCalledOnce()
+    expect(subprocess.dispose).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/daemon/daemon-server.test.ts
+++ b/src/main/daemon/daemon-server.test.ts
@@ -263,7 +263,9 @@ describe('DaemonServer', () => {
           requestType === 'kill'
             ? c.request('kill', { sessionId: 'canceled-preparation', immediate: true })
             : c.request('cancelCreateOrAttach', { sessionId: 'canceled-preparation' })
-        await expect(cancelRequest).resolves.toEqual({})
+        await expect(cancelRequest).resolves.toEqual(
+          requestType === 'kill' ? {} : { canceled: true }
+        )
         finishPreparation()
         await canceledCreates
         expect(spawnSubprocess).not.toHaveBeenCalled()

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -86,8 +86,8 @@ export type DaemonServerOptions = {
     env?: Record<string, string>
     command?: string
     shellOverride?: string
-    // Why the union: see TerminalHostOptions — cwd validation is async so an
-    // unreachable share cannot block this server's RPC loop (STA-4470).
+    isCanceled?: () => boolean
+    // Async production spawns and sync test stubs share this boundary.
   }) => SubprocessHandle | Promise<SubprocessHandle>
 }
 
@@ -100,9 +100,11 @@ type ConnectedClient = {
 
 type PendingPtySpawnPreparation = {
   canceled: boolean
+  cancelTimer?: ReturnType<typeof setTimeout>
   // Why: preparations are keyed by sessionId, but a control-socket close must
   // cancel only the disconnecting client's preps, not another client's (F4).
   clientId: string
+  requestId: string
 }
 
 type PendingShutdownReply = {
@@ -902,10 +904,25 @@ export class DaemonServer {
     this.pendingShutdownReplies.set(key, { start })
   }
 
-  private async preparePtySpawnUnlessCanceled(sessionId: string, clientId: string): Promise<void> {
+  private async preparePtySpawnUnlessCanceled(
+    sessionId: string,
+    clientId: string,
+    requestId: string,
+    cancelAfterMs: unknown
+  ): Promise<PendingPtySpawnPreparation> {
     const preparation: PendingPtySpawnPreparation = {
       canceled: false,
-      clientId
+      clientId,
+      requestId
+    }
+    if (Number.isSafeInteger(cancelAfterMs) && Number(cancelAfterMs) > 0) {
+      preparation.cancelTimer = setTimeout(
+        () => {
+          preparation.canceled = true
+        },
+        Math.min(Number(cancelAfterMs), 300_000)
+      )
+      preparation.cancelTimer.unref()
     }
     const pending = this.pendingPtySpawnPreparations.get(sessionId) ?? new Set()
     pending.add(preparation)
@@ -916,23 +933,48 @@ export class DaemonServer {
       if (preparation.canceled) {
         throw new TerminalAttachCanceledError(sessionId)
       }
-    } finally {
-      pending.delete(preparation)
-      if (pending.size === 0) {
-        this.pendingPtySpawnPreparations.delete(sessionId)
-      }
+      return preparation
+    } catch (error) {
+      this.finishPtySpawnPreparation(sessionId, preparation)
+      throw error
     }
   }
 
-  private cancelPendingPtySpawnPreparations(sessionId: string): boolean {
+  private finishPtySpawnPreparation(
+    sessionId: string,
+    preparation: PendingPtySpawnPreparation
+  ): void {
+    if (preparation.cancelTimer) {
+      clearTimeout(preparation.cancelTimer)
+    }
+    const pending = this.pendingPtySpawnPreparations.get(sessionId)
+    pending?.delete(preparation)
+    if (pending?.size === 0) {
+      this.pendingPtySpawnPreparations.delete(sessionId)
+    }
+  }
+
+  private cancelPendingPtySpawnPreparations(
+    sessionId: string,
+    request?: { clientId: string; requestId?: string }
+  ): boolean {
     const pending = this.pendingPtySpawnPreparations.get(sessionId)
     if (!pending) {
       return false
     }
+    let canceled = false
     for (const preparation of pending) {
+      if (
+        request &&
+        (preparation.clientId !== request.clientId ||
+          (request.requestId !== undefined && preparation.requestId !== request.requestId))
+      ) {
+        continue
+      }
       preparation.canceled = true
+      canceled = true
     }
-    return true
+    return canceled
   }
 
   private cancelAllPendingPtySpawnPreparations(): void {
@@ -1035,6 +1077,7 @@ export class DaemonServer {
         this.createOrAttachInFlight++
         let routedSessionId = p.sessionId
         let result: Awaited<ReturnType<TerminalHost['createOrAttach']>>
+        let spawnPreparation: PendingPtySpawnPreparation | null = null
         try {
           if (
             p.agentSessionEnsure !== undefined &&
@@ -1044,7 +1087,12 @@ export class DaemonServer {
             throw new Error('agent_session_identity_required')
           }
           if (!attachOnly) {
-            await this.preparePtySpawnUnlessCanceled(p.sessionId, clientId)
+            spawnPreparation = await this.preparePtySpawnUnlessCanceled(
+              p.sessionId,
+              clientId,
+              request.id,
+              p.cancelAfterMs
+            )
           }
           if (p.historySeed !== undefined && p.historySeedTransferId !== undefined) {
             throw new Error('Multiple terminal history seed sources')
@@ -1077,6 +1125,7 @@ export class DaemonServer {
               ? { shellReadyTimeoutMs: p.shellReadyTimeoutMs }
               : {}),
             ...(p.agentSessionEnsure ? { agentSessionEnsure: p.agentSessionEnsure } : {}),
+            ...(spawnPreparation ? { isCanceled: () => spawnPreparation?.canceled === true } : {}),
             onSessionResolved: (sessionId) => {
               routedSessionId = sessionId
             },
@@ -1123,6 +1172,9 @@ export class DaemonServer {
             }
           })
         } finally {
+          if (spawnPreparation) {
+            this.finishPtySpawnPreparation(p.sessionId, spawnPreparation)
+          }
           this.createOrAttachInFlight--
           this.reevaluateIdleShutdown()
         }
@@ -1165,8 +1217,14 @@ export class DaemonServer {
       }
 
       case 'cancelCreateOrAttach':
-        this.cancelPendingPtySpawnPreparations(request.payload.sessionId)
-        return {}
+        return {
+          canceled: this.cancelPendingPtySpawnPreparations(request.payload.sessionId, {
+            clientId,
+            ...(typeof request.payload.requestId === 'string'
+              ? { requestId: request.payload.requestId }
+              : {})
+          })
+        }
 
       case 'closeStartupQueryAuthority':
         return {

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -86,7 +86,9 @@ export type DaemonServerOptions = {
     env?: Record<string, string>
     command?: string
     shellOverride?: string
-  }) => SubprocessHandle
+    // Why the union: see TerminalHostOptions — cwd validation is async so an
+    // unreachable share cannot block this server's RPC loop (STA-4470).
+  }) => SubprocessHandle | Promise<SubprocessHandle>
 }
 
 type ConnectedClient = {

--- a/src/main/daemon/pty-subprocess-env-inheritance.test.ts
+++ b/src/main/daemon/pty-subprocess-env-inheritance.test.ts
@@ -52,7 +52,8 @@ vi.mock('../providers/local-pty-utils', async (importOriginal) => {
   return {
     ...actual,
     resolveUnixShellPath: resolveUnixShellPathMock,
-    validateWorkingDirectory: validateWorkingDirectoryMock
+    validateWorkingDirectory: validateWorkingDirectoryMock,
+    validateWorkingDirectoryAsync: validateWorkingDirectoryMock
   }
 })
 
@@ -89,13 +90,13 @@ describe('createPtySubprocess', () => {
     validateWorkingDirectoryMock
   })
 
-  it('expands variables in PATH before spawning a Windows shell', () => {
+  it('expands variables in PATH before spawning a Windows shell', async () => {
     spawnMock.mockReturnValue(mockPtyProcess())
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { value: 'win32' })
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -117,7 +118,7 @@ describe('createPtySubprocess', () => {
     )
   })
 
-  it('does not inherit parent Orca pane identity when caller omits pane env', () => {
+  it('does not inherit parent Orca pane identity when caller omits pane env', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const saved = {
@@ -130,7 +131,7 @@ describe('createPtySubprocess', () => {
     process.env.ORCA_WORKTREE_ID = 'parent-worktree'
 
     try {
-      createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+      await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
     } finally {
       for (const [key, value] of Object.entries(saved)) {
         if (value === undefined) {
@@ -147,7 +148,7 @@ describe('createPtySubprocess', () => {
     expect(env.ORCA_WORKTREE_ID).toBeUndefined()
   })
 
-  it('preserves explicit child Orca pane identity over parent env', () => {
+  it('preserves explicit child Orca pane identity over parent env', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const saved = {
@@ -160,7 +161,7 @@ describe('createPtySubprocess', () => {
     process.env.ORCA_WORKTREE_ID = 'parent-worktree'
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -186,7 +187,7 @@ describe('createPtySubprocess', () => {
     expect(env.ORCA_WORKTREE_ID).toBe('child-worktree')
   })
 
-  it('does not inherit ELECTRON_RUN_AS_NODE from the daemon process env', () => {
+  it('does not inherit ELECTRON_RUN_AS_NODE from the daemon process env', async () => {
     // Why: the daemon is forked with ELECTRON_RUN_AS_NODE=1. If that flag
     // reaches user shells, nested Electron commands run as plain Node.
     const proc = mockPtyProcess()
@@ -195,7 +196,7 @@ describe('createPtySubprocess', () => {
     process.env.ELECTRON_RUN_AS_NODE = '1'
 
     try {
-      createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+      await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
     } finally {
       if (previous === undefined) {
         delete process.env.ELECTRON_RUN_AS_NODE
@@ -208,7 +209,7 @@ describe('createPtySubprocess', () => {
     expect(env.ELECTRON_RUN_AS_NODE).toBeUndefined()
   })
 
-  it('does not inherit legacy attribution state from a pre-upgrade daemon', () => {
+  it('does not inherit legacy attribution state from a pre-upgrade daemon', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const saved = Object.fromEntries(
@@ -219,7 +220,7 @@ describe('createPtySubprocess', () => {
     process.env.PATH = `/tmp/orca-terminal-attribution/posix${delimiter}/usr/bin`
 
     try {
-      createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+      await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
     } finally {
       for (const [key, value] of Object.entries(saved)) {
         if (value === undefined) {
@@ -237,7 +238,7 @@ describe('createPtySubprocess', () => {
     }
   })
 
-  it('does not inherit NODE_ENV from the daemon process env', () => {
+  it('does not inherit NODE_ENV from the daemon process env', async () => {
     // Why: a dev-mode Orca forks the daemon with NODE_ENV=development; leaking
     // Orca's build mode into user shells breaks `next build` and Vitest.
     const proc = mockPtyProcess()
@@ -246,7 +247,7 @@ describe('createPtySubprocess', () => {
     process.env.NODE_ENV = 'development'
 
     try {
-      createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+      await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
     } finally {
       if (previous === undefined) {
         delete process.env.NODE_ENV
@@ -262,7 +263,7 @@ describe('createPtySubprocess', () => {
     expect(env.PATH).toBe(expectedEnv.PATH)
   })
 
-  it('keeps an explicitly requested NODE_ENV for daemon PTY shells', () => {
+  it('keeps an explicitly requested NODE_ENV for daemon PTY shells', async () => {
     // Why: only the ambient value is stripped; a caller-supplied NODE_ENV still wins.
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
@@ -270,7 +271,7 @@ describe('createPtySubprocess', () => {
     process.env.NODE_ENV = 'development'
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -288,7 +289,7 @@ describe('createPtySubprocess', () => {
     expect(env.NODE_ENV).toBe('production')
   })
 
-  it('does not inherit AppImage runtime env into daemon PTY shells', () => {
+  it('does not inherit AppImage runtime env into daemon PTY shells', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
@@ -313,7 +314,7 @@ describe('createPtySubprocess', () => {
     process.env.LD_LIBRARY_PATH = ['/tmp/.mount_orca123/usr/lib', '/opt/audio/lib'].join(delimiter)
 
     try {
-      createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+      await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
     } finally {
       if (platform) {
         Object.defineProperty(process, 'platform', platform)
@@ -337,14 +338,14 @@ describe('createPtySubprocess', () => {
     expect(env.LD_LIBRARY_PATH).toBe('/opt/audio/lib')
   })
 
-  it('does not inherit parent agent hook endpoint for development hook env', () => {
+  it('does not inherit parent agent hook endpoint for development hook env', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const previousEndpoint = process.env.ORCA_AGENT_HOOK_ENDPOINT
     process.env.ORCA_AGENT_HOOK_ENDPOINT = '/tmp/stale-endpoint.env'
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -370,14 +371,14 @@ describe('createPtySubprocess', () => {
     expect(env.ORCA_AGENT_HOOK_TOKEN).toBe('token')
   })
 
-  it('preserves explicit development agent hook endpoint files', () => {
+  it('preserves explicit development agent hook endpoint files', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const previousEndpoint = process.env.ORCA_AGENT_HOOK_ENDPOINT
     process.env.ORCA_AGENT_HOOK_ENDPOINT = '/tmp/stale-endpoint.env'
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -404,11 +405,11 @@ describe('createPtySubprocess', () => {
     expect(env.ORCA_AGENT_HOOK_TOKEN).toBe('token')
   })
 
-  it('passes custom env to spawned process', () => {
+  it('passes custom env to spawned process', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
 
-    createPtySubprocess({
+    await createPtySubprocess({
       sessionId: 'test',
       cols: 80,
       rows: 24,
@@ -420,11 +421,11 @@ describe('createPtySubprocess', () => {
     expect(spawnEnv.MY_VAR).toBe('test-value')
   })
 
-  it('honors explicit terminal env overrides after deleting requested defaults', () => {
+  it('honors explicit terminal env overrides after deleting requested defaults', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
 
-    createPtySubprocess({
+    await createPtySubprocess({
       sessionId: 'test',
       cols: 80,
       rows: 24,
@@ -444,14 +445,14 @@ describe('createPtySubprocess', () => {
     expect(lastCall[2].env.TERM_PROGRAM).toBeUndefined()
   })
 
-  it('collapses its own env merge onto the requested Windows `Path` spelling', () => {
+  it('collapses its own env merge onto the requested Windows `Path` spelling', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
 
     Object.defineProperty(process, 'platform', { value: 'win32' })
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -473,7 +474,7 @@ describe('createPtySubprocess', () => {
     expect(env.Path.split(':')[0]).toBe('/tmp/orca-agent-teams-bin')
   })
 
-  it('keeps the daemon `PATH` block when the requested env has no path key', () => {
+  it('keeps the daemon `PATH` block when the requested env has no path key', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
@@ -482,7 +483,7 @@ describe('createPtySubprocess', () => {
 
     Object.defineProperty(process, 'platform', { value: 'win32' })
     try {
-      createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24, env: { FOO: 'bar' } })
+      await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24, env: { FOO: 'bar' } })
     } finally {
       if (platform) {
         Object.defineProperty(process, 'platform', platform)
@@ -493,14 +494,14 @@ describe('createPtySubprocess', () => {
     expect(env.PATH).toBe(expectedEnv.PATH)
   })
 
-  it('preserves a duplicated path block supplied by main', () => {
+  it('preserves a duplicated path block supplied by main', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
 
     Object.defineProperty(process, 'platform', { value: 'win32' })
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,

--- a/src/main/daemon/pty-subprocess-foreground-degraded-scan.test.ts
+++ b/src/main/daemon/pty-subprocess-foreground-degraded-scan.test.ts
@@ -106,11 +106,11 @@ describe('daemon pty foreground degraded-scan handling', () => {
     rmSync(userDataPath, { recursive: true, force: true })
   })
 
-  function spawnWindowsShell() {
+  async function spawnWindowsShell() {
     Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
     const proc = mockPtyProcess('powershell.exe')
     spawnMock.mockReturnValue(proc)
-    const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+    const handle = await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
     return { proc, handle }
   }
 
@@ -118,7 +118,7 @@ describe('daemon pty foreground degraded-scan handling', () => {
     resolveAgentForegroundProcessMock
       .mockResolvedValueOnce({ available: true, processName: 'claude' })
       .mockResolvedValue({ available: false, processName: null })
-    const { handle } = spawnWindowsShell()
+    const { handle } = await spawnWindowsShell()
 
     await readForegroundAt(handle, 0) // establishes 'claude'
     expect(await readForegroundAt(handle, 1_000)).toBe('claude') // refresh returns degraded → keep
@@ -132,7 +132,7 @@ describe('daemon pty foreground degraded-scan handling', () => {
       .mockResolvedValueOnce({ available: true, processName: 'claude' })
       .mockResolvedValue({ available: true, processName: null })
     readConptyMock.mockResolvedValue(new Set([12345, 999])) // child still attached
-    const { handle } = spawnWindowsShell()
+    const { handle } = await spawnWindowsShell()
 
     await readForegroundAt(handle, 0)
     expect(await readForegroundAt(handle, 1_000)).toBe('claude')
@@ -144,7 +144,7 @@ describe('daemon pty foreground degraded-scan handling', () => {
       .mockResolvedValueOnce({ available: true, processName: 'claude' })
       .mockResolvedValue({ available: true, processName: null })
     readConptyMock.mockResolvedValue(new Set([12345]))
-    const { handle } = spawnWindowsShell()
+    const { handle } = await spawnWindowsShell()
 
     await readForegroundAt(handle, 0)
     await readForegroundAt(handle, 1_000) // refresh clears the cache
@@ -157,7 +157,7 @@ describe('daemon pty foreground degraded-scan handling', () => {
       .mockResolvedValueOnce({ available: true, processName: 'claude' })
       .mockResolvedValue({ available: true, processName: null })
     readConptyMock.mockResolvedValue(null)
-    const { handle } = spawnWindowsShell()
+    const { handle } = await spawnWindowsShell()
 
     await readForegroundAt(handle, 0)
     expect(await readForegroundAt(handle, 1_000)).toBe('claude')

--- a/src/main/daemon/pty-subprocess-foreground-identity.test.ts
+++ b/src/main/daemon/pty-subprocess-foreground-identity.test.ts
@@ -51,7 +51,8 @@ vi.mock('../providers/local-pty-utils', async (importOriginal) => {
   return {
     ...actual,
     resolveUnixShellPath: resolveUnixShellPathMock,
-    validateWorkingDirectory: validateWorkingDirectoryMock
+    validateWorkingDirectory: validateWorkingDirectoryMock,
+    validateWorkingDirectoryAsync: validateWorkingDirectoryMock
   }
 })
 
@@ -84,12 +85,12 @@ describe('createPtySubprocess', () => {
     validateWorkingDirectoryMock
   })
 
-  it('normalizes foreground process names from node-pty', () => {
+  it('normalizes foreground process names from node-pty', async () => {
     const proc = mockPtyProcess()
     proc.process = '/opt/homebrew/bin/codex'
     spawnMock.mockReturnValue(proc)
 
-    const handle = createPtySubprocess({
+    const handle = await createPtySubprocess({
       sessionId: 'test',
       cols: 80,
       rows: 24
@@ -112,7 +113,7 @@ describe('createPtySubprocess', () => {
     )
 
     try {
-      const handle = createPtySubprocess({
+      const handle = await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24
@@ -145,7 +146,7 @@ describe('createPtySubprocess', () => {
     resolveAgentForegroundProcessMock.mockResolvedValue('grok')
 
     try {
-      const handle = createPtySubprocess({
+      const handle = await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24
@@ -179,7 +180,7 @@ describe('createPtySubprocess', () => {
     resolveAgentForegroundProcessMock.mockResolvedValueOnce('grok').mockResolvedValue('node')
 
     try {
-      const handle = createPtySubprocess({
+      const handle = await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24
@@ -223,7 +224,7 @@ describe('createPtySubprocess', () => {
     )
 
     try {
-      const handle = createPtySubprocess({
+      const handle = await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24
@@ -259,7 +260,7 @@ describe('createPtySubprocess', () => {
     )
 
     try {
-      const handle = createPtySubprocess({
+      const handle = await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24
@@ -293,7 +294,7 @@ describe('createPtySubprocess', () => {
     })
 
     try {
-      const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+      const handle = await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
 
       expect(handle.getForegroundProcess()).toBe('powershell.exe')
       await Promise.resolve()
@@ -321,7 +322,7 @@ describe('createPtySubprocess', () => {
     )
 
     try {
-      const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+      const handle = await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
       const confirmation = handle.confirmForegroundProcess!()
       let settled = false
       void confirmation.then(() => {
@@ -356,7 +357,7 @@ describe('createPtySubprocess', () => {
     })
 
     try {
-      const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+      const handle = await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
       await expect(handle.confirmForegroundProcess!()).resolves.toBeNull()
     } finally {
       if (platform) {
@@ -377,7 +378,7 @@ describe('createPtySubprocess', () => {
     })
 
     try {
-      const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+      const handle = await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
       await expect(handle.confirmForegroundProcess!()).resolves.toBeNull()
     } finally {
       if (platform) {
@@ -400,7 +401,7 @@ describe('createPtySubprocess', () => {
     )
 
     try {
-      const handle = createPtySubprocess({
+      const handle = await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24
@@ -436,7 +437,7 @@ describe('createPtySubprocess', () => {
     )
 
     try {
-      const handle = createPtySubprocess({
+      const handle = await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24
@@ -470,7 +471,7 @@ describe('createPtySubprocess', () => {
     resolveAgentForegroundProcessMock.mockResolvedValue('powershell.exe')
 
     try {
-      const handle = createPtySubprocess({
+      const handle = await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -517,7 +518,7 @@ describe('createPtySubprocess', () => {
     )
 
     try {
-      const handle = createPtySubprocess({
+      const handle = await createPtySubprocess({
         sessionId: 'repo::C:\\repo\\orca@@deadbeef',
         cols: 80,
         rows: 24,
@@ -556,7 +557,7 @@ describe('createPtySubprocess', () => {
     resolveAgentForegroundProcessMock.mockResolvedValue('codex')
 
     try {
-      const handle = createPtySubprocess({
+      const handle = await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -578,7 +579,7 @@ describe('createPtySubprocess', () => {
     }
   })
 
-  it('does not schedule foreground enrichment for arbitrary Windows TUIs', () => {
+  it('does not schedule foreground enrichment for arbitrary Windows TUIs', async () => {
     const proc = mockPtyProcess()
     proc.process = 'vim.exe'
     spawnMock.mockReturnValue(proc)
@@ -586,7 +587,7 @@ describe('createPtySubprocess', () => {
     Object.defineProperty(process, 'platform', { value: 'win32' })
 
     try {
-      const handle = createPtySubprocess({
+      const handle = await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24
@@ -601,7 +602,7 @@ describe('createPtySubprocess', () => {
     }
   })
 
-  it('treats node-pty terminal name as inconclusive foreground process', () => {
+  it('treats node-pty terminal name as inconclusive foreground process', async () => {
     const proc = mockPtyProcess()
     proc.process = 'xterm-256color'
     spawnMock.mockReturnValue(proc)
@@ -609,7 +610,7 @@ describe('createPtySubprocess', () => {
     Object.defineProperty(process, 'platform', { value: 'linux' })
 
     try {
-      const handle = createPtySubprocess({
+      const handle = await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24

--- a/src/main/daemon/pty-subprocess-foreground-scan-cadence.test.ts
+++ b/src/main/daemon/pty-subprocess-foreground-scan-cadence.test.ts
@@ -119,17 +119,20 @@ describe('daemon pty foreground scan cadence', () => {
     rmSync(userDataPath, { recursive: true, force: true })
   })
 
-  function spawnShellSubprocess(shellProcessName: string, targetPlatform: 'win32' | 'darwin') {
+  async function spawnShellSubprocess(
+    shellProcessName: string,
+    targetPlatform: 'win32' | 'darwin'
+  ) {
     Object.defineProperty(process, 'platform', { configurable: true, value: targetPlatform })
     const proc = mockPtyProcess(shellProcessName)
     spawnMock.mockReturnValue(proc)
-    const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+    const handle = await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
     return { proc, handle }
   }
 
   it('bounds scans for an idle Windows shell polled every 2s to the 15s retry tier', async () => {
     resolveAgentForegroundProcessMock.mockResolvedValue('powershell.exe')
-    const { handle } = spawnShellSubprocess('powershell.exe', 'win32')
+    const { handle } = await spawnShellSubprocess('powershell.exe', 'win32')
 
     for (let atMs = 0; atMs <= 60_000; atMs += 2_000) {
       expect(await readForegroundAt(handle, atMs)).toBe('powershell.exe')
@@ -142,7 +145,7 @@ describe('daemon pty foreground scan cadence', () => {
 
   it('re-arms the fast retry when PTY output appears on an idle Windows shell', async () => {
     resolveAgentForegroundProcessMock.mockResolvedValueOnce('powershell.exe')
-    const { proc, handle } = spawnShellSubprocess('powershell.exe', 'win32')
+    const { proc, handle } = await spawnShellSubprocess('powershell.exe', 'win32')
 
     await readForegroundAt(handle, 0)
     await readForegroundAt(handle, 2_000)
@@ -164,7 +167,7 @@ describe('daemon pty foreground scan cadence', () => {
 
   it('keeps the fast identity refresh for a Windows session with a cached agent', async () => {
     resolveAgentForegroundProcessMock.mockResolvedValue('codex')
-    const { handle } = spawnShellSubprocess('powershell.exe', 'win32')
+    const { handle } = await spawnShellSubprocess('powershell.exe', 'win32')
 
     await readForegroundAt(handle, 0)
     expect(await readForegroundAt(handle, 1_000)).toBe('codex')
@@ -178,7 +181,7 @@ describe('daemon pty foreground scan cadence', () => {
 
   it('keeps the 5s retry for an idle POSIX shell with no output', async () => {
     resolveAgentForegroundProcessMock.mockResolvedValue('zsh')
-    const { handle } = spawnShellSubprocess('zsh', 'darwin')
+    const { handle } = await spawnShellSubprocess('zsh', 'darwin')
 
     for (let atMs = 0; atMs <= 30_000; atMs += 2_000) {
       expect(await readForegroundAt(handle, atMs)).toBe('zsh')
@@ -192,7 +195,7 @@ describe('daemon pty foreground scan cadence', () => {
     'keeps wrapped pi reads on the cached omp owner between bounded %s scans',
     async (targetPlatform) => {
       resolveAgentForegroundProcessMock.mockResolvedValue('omp')
-      const { handle } = spawnShellSubprocess('pi', targetPlatform)
+      const { handle } = await spawnShellSubprocess('pi', targetPlatform)
 
       const reads: (string | null)[] = []
       for (let atMs = 0; atMs <= 3_000; atMs += 250) {
@@ -216,7 +219,7 @@ describe('daemon pty foreground scan cadence', () => {
   it.each(['darwin', 'win32'] as const)(
     'keeps authoritative %s omp reads on the zero-scan path',
     async (targetPlatform) => {
-      const { handle } = spawnShellSubprocess('omp', targetPlatform)
+      const { handle } = await spawnShellSubprocess('omp', targetPlatform)
 
       for (let atMs = 0; atMs <= 3_000; atMs += 250) {
         expect(await readForegroundAt(handle, atMs)).toBe('omp')
@@ -231,7 +234,7 @@ describe('daemon pty foreground scan cadence', () => {
       resolveAgentForegroundProcessMock
         .mockResolvedValueOnce('omp')
         .mockResolvedValue({ available: false, processName: 'pi' })
-      const { handle } = spawnShellSubprocess('pi', targetPlatform)
+      const { handle } = await spawnShellSubprocess('pi', targetPlatform)
 
       expect(await readForegroundAt(handle, 0)).toBe('pi')
       expect(await readForegroundAt(handle, 1_000)).toBe('omp')

--- a/src/main/daemon/pty-subprocess-git-credential-guard.test.ts
+++ b/src/main/daemon/pty-subprocess-git-credential-guard.test.ts
@@ -51,7 +51,8 @@ vi.mock('../providers/local-pty-utils', async (importOriginal) => {
   return {
     ...actual,
     resolveUnixShellPath: resolveUnixShellPathMock,
-    validateWorkingDirectory: validateWorkingDirectoryMock
+    validateWorkingDirectory: validateWorkingDirectoryMock,
+    validateWorkingDirectoryAsync: validateWorkingDirectoryMock
   }
 })
 
@@ -85,7 +86,7 @@ describe('createPtySubprocess', () => {
     validateWorkingDirectoryMock
   })
 
-  it('appends Git prompt guards after the detached daemon inherited config', () => {
+  it('appends Git prompt guards after the detached daemon inherited config', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
@@ -107,7 +108,7 @@ describe('createPtySubprocess', () => {
     Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'guarded-git-config',
         cols: 80,
         rows: 24,
@@ -145,7 +146,7 @@ describe('createPtySubprocess', () => {
     }
   })
 
-  it('does not infer a guard from caller-set prompt scalars', () => {
+  it('does not infer a guard from caller-set prompt scalars', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const savedGitConfigEnv = Object.fromEntries(
@@ -167,7 +168,7 @@ describe('createPtySubprocess', () => {
     process.env.GIT_CONFIG_VALUE_2 = 'two'
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'explicit-guarded-git-config',
         cols: 80,
         rows: 24,
@@ -201,11 +202,11 @@ describe('createPtySubprocess', () => {
     }
   })
 
-  it('guards a trusted daemon agent whose launch command is wrapped', () => {
+  it('guards a trusted daemon agent whose launch command is wrapped', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
 
-    createPtySubprocess({
+    await createPtySubprocess({
       sessionId: 'trusted-wrapped-agent',
       cols: 80,
       rows: 24,

--- a/src/main/daemon/pty-subprocess-handle-lifecycle.test.ts
+++ b/src/main/daemon/pty-subprocess-handle-lifecycle.test.ts
@@ -51,7 +51,8 @@ vi.mock('../providers/local-pty-utils', async (importOriginal) => {
   return {
     ...actual,
     resolveUnixShellPath: resolveUnixShellPathMock,
-    validateWorkingDirectory: validateWorkingDirectoryMock
+    validateWorkingDirectory: validateWorkingDirectoryMock,
+    validateWorkingDirectoryAsync: validateWorkingDirectoryMock
   }
 })
 
@@ -84,11 +85,11 @@ describe('createPtySubprocess', () => {
     validateWorkingDirectoryMock
   })
 
-  it('returns a SubprocessHandle with correct pid', () => {
+  it('returns a SubprocessHandle with correct pid', async () => {
     const proc = mockPtyProcess(42)
     spawnMock.mockReturnValue(proc)
 
-    const handle = createPtySubprocess({
+    const handle = await createPtySubprocess({
       sessionId: 'test',
       cols: 80,
       rows: 24
@@ -97,31 +98,31 @@ describe('createPtySubprocess', () => {
     expect(handle.pid).toBe(42)
   })
 
-  it('forwards write calls', () => {
+  it('forwards write calls', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
 
-    const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+    const handle = await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
     handle.write('ls\n')
 
     expect(proc.write).toHaveBeenCalledWith('ls\n')
   })
 
-  it('forwards resize calls', () => {
+  it('forwards resize calls', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
 
-    const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+    const handle = await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
     handle.resize(120, 40)
 
     expect(proc.resize).toHaveBeenCalledWith(120, 40)
   })
 
-  it('normalizes invalid initial spawn dimensions', () => {
+  it('normalizes invalid initial spawn dimensions', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
 
-    createPtySubprocess({ sessionId: 'test', cols: 0, rows: -1 })
+    await createPtySubprocess({ sessionId: 'test', cols: 0, rows: -1 })
 
     expect(spawnMock).toHaveBeenCalledWith(
       expect.any(String),
@@ -130,11 +131,11 @@ describe('createPtySubprocess', () => {
     )
   })
 
-  it('ignores transient zero-size resize calls', () => {
+  it('ignores transient zero-size resize calls', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
 
-    const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+    const handle = await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
     handle.resize(0, 0)
     handle.write('still alive\n')
 
@@ -142,24 +143,24 @@ describe('createPtySubprocess', () => {
     expect(proc.write).toHaveBeenCalledWith('still alive\n')
   })
 
-  it('forwards kill calls', () => {
+  it('forwards kill calls', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
 
-    const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+    const handle = await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
     handle.kill()
 
     expect(proc.kill).toHaveBeenCalled()
   })
 
-  it('propagates rejected graceful kills without marking the wrapper dead', () => {
+  it('propagates rejected graceful kills without marking the wrapper dead', async () => {
     const proc = mockPtyProcess()
     proc.kill.mockImplementationOnce(() => {
       throw new Error('native kill rejected')
     })
     spawnMock.mockReturnValue(proc)
 
-    const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+    const handle = await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
     expect(() => handle.kill()).toThrow('native kill rejected')
     handle.write('still owned')
     expect(() => handle.kill()).not.toThrow()
@@ -168,7 +169,7 @@ describe('createPtySubprocess', () => {
     expect(proc.kill).toHaveBeenCalledTimes(2)
   })
 
-  it('propagates rejected force kills so the owner can retry', () => {
+  it('propagates rejected force kills so the owner can retry', async () => {
     const proc = mockPtyProcess(77)
     proc.kill.mockImplementation(() => {
       throw new Error('native fallback rejected')
@@ -182,7 +183,7 @@ describe('createPtySubprocess', () => {
       .mockImplementationOnce(() => true)
 
     try {
-      const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+      const handle = await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
       expect(() => handle.forceKill()).toThrow('SIGKILL rejected')
       expect(() => handle.forceKill()).not.toThrow()
       expect(killSpy).toHaveBeenCalledTimes(2)
@@ -192,23 +193,23 @@ describe('createPtySubprocess', () => {
     }
   })
 
-  it('forceKill sends SIGKILL to the child pid', () => {
+  it('forceKill sends SIGKILL to the child pid', async () => {
     const proc = mockPtyProcess(77)
     spawnMock.mockReturnValue(proc)
     const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
 
-    const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+    const handle = await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
     handle.forceKill()
 
     expect(killSpy).toHaveBeenCalledWith(77, 'SIGKILL')
     killSpy.mockRestore()
   })
 
-  it('routes onData events', () => {
+  it('routes onData events', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
 
-    const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+    const handle = await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
     const data: string[] = []
     handle.onData((d) => data.push(d))
 
@@ -216,11 +217,11 @@ describe('createPtySubprocess', () => {
     expect(data).toEqual(['hello'])
   })
 
-  it('replays data emitted before the Session registers onData', () => {
+  it('replays data emitted before the Session registers onData', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
 
-    const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+    const handle = await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
     proc._simulateData('early setup output\r\n')
     const data: string[] = []
     handle.onData((d) => data.push(d))
@@ -228,11 +229,11 @@ describe('createPtySubprocess', () => {
     expect(data).toEqual(['early setup output\r\n'])
   })
 
-  it('routes onExit events', () => {
+  it('routes onExit events', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
 
-    const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+    const handle = await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
     const codes: number[] = []
     handle.onExit((code) => codes.push(code))
 
@@ -240,11 +241,11 @@ describe('createPtySubprocess', () => {
     expect(codes).toEqual([42])
   })
 
-  it('replays pre-listener data before a pre-listener exit', () => {
+  it('replays pre-listener data before a pre-listener exit', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
 
-    const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+    const handle = await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
     proc._simulateData('last output\r\n')
     proc._simulateExit(7)
     const data: string[] = []
@@ -256,11 +257,11 @@ describe('createPtySubprocess', () => {
     expect(codes).toEqual([7])
   })
 
-  it('preserves pre-listener data when onExit is registered before onData', () => {
+  it('preserves pre-listener data when onExit is registered before onData', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
 
-    const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+    const handle = await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
     proc._simulateData('last output\r\n')
     proc._simulateExit(7)
     const events: string[] = []
@@ -270,12 +271,12 @@ describe('createPtySubprocess', () => {
     expect(events).toEqual(['exit:7', 'data:last output\r\n'])
   })
 
-  it('sends signal via process.kill', () => {
+  it('sends signal via process.kill', async () => {
     const proc = mockPtyProcess(99)
     spawnMock.mockReturnValue(proc)
 
     const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
-    const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+    const handle = await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
     handle.signal('SIGINT')
 
     expect(killSpy).toHaveBeenCalledWith(99, 'SIGINT')
@@ -295,14 +296,14 @@ describe('createPtySubprocess', () => {
       }
     }
 
-    it('neutralizes proc.kill on POSIX inside proc.onExit synchronously', () => {
+    it('neutralizes proc.kill on POSIX inside proc.onExit synchronously', async () => {
       const proc = mockPtyProcess()
       spawnMock.mockReturnValue(proc)
       const origPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
       Object.defineProperty(process, 'platform', { value: 'linux' })
       const originalKill = proc.kill
       try {
-        createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+        await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
         expect(proc.kill).toBe(originalKill)
         proc._simulateExit(0)
         expect(proc.kill).not.toBe(originalKill)
@@ -313,14 +314,14 @@ describe('createPtySubprocess', () => {
       }
     })
 
-    it('DOES NOT neutralize proc.kill on Windows (WindowsTerminal.destroy needs kill)', () => {
+    it('DOES NOT neutralize proc.kill on Windows (WindowsTerminal.destroy needs kill)', async () => {
       const proc = mockPtyProcess()
       spawnMock.mockReturnValue(proc)
       const origPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
       Object.defineProperty(process, 'platform', { value: 'win32' })
       const originalKill = proc.kill
       try {
-        createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+        await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
         proc._simulateExit(0)
         expect(proc.kill).toBe(originalKill)
       } finally {
@@ -328,7 +329,7 @@ describe('createPtySubprocess', () => {
       }
     })
 
-    it('dispose() neutralizes proc.kill on POSIX before calling destroy()', () => {
+    it('dispose() neutralizes proc.kill on POSIX before calling destroy()', async () => {
       const proc = mockPtyProcess() as ReturnType<typeof mockPtyProcess> & {
         destroy: ReturnType<typeof vi.fn>
       }
@@ -338,7 +339,7 @@ describe('createPtySubprocess', () => {
       Object.defineProperty(process, 'platform', { value: 'darwin' })
       const originalKill = proc.kill
       try {
-        const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+        const handle = await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
         handle.dispose()
         expect(proc.kill).not.toBe(originalKill)
         expect(proc.destroy).toHaveBeenCalledOnce()
@@ -347,7 +348,7 @@ describe('createPtySubprocess', () => {
       }
     })
 
-    it('dispose() on Windows calls destroy() without neutralizing kill', () => {
+    it('dispose() on Windows calls destroy() without neutralizing kill', async () => {
       const proc = mockPtyProcess() as ReturnType<typeof mockPtyProcess> & {
         destroy: ReturnType<typeof vi.fn>
       }
@@ -357,7 +358,7 @@ describe('createPtySubprocess', () => {
       Object.defineProperty(process, 'platform', { value: 'win32' })
       const originalKill = proc.kill
       try {
-        const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+        const handle = await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
         handle.dispose()
         expect(proc.kill).toBe(originalKill)
         expect(proc.destroy).toHaveBeenCalledOnce()
@@ -366,7 +367,7 @@ describe('createPtySubprocess', () => {
       }
     })
 
-    it('dispose() on Windows skips destroy after node-pty kill()', () => {
+    it('dispose() on Windows skips destroy after node-pty kill()', async () => {
       const proc = mockPtyProcess() as ReturnType<typeof mockPtyProcess> & {
         destroy: ReturnType<typeof vi.fn>
       }
@@ -375,7 +376,7 @@ describe('createPtySubprocess', () => {
       const origPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
       Object.defineProperty(process, 'platform', { value: 'win32' })
       try {
-        const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+        const handle = await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
         handle.kill()
         handle.dispose()
         expect(proc.kill).toHaveBeenCalledOnce()
@@ -385,7 +386,7 @@ describe('createPtySubprocess', () => {
       }
     })
 
-    it('does not issue a second Windows ConPTY kill when force follows graceful kill', () => {
+    it('does not issue a second Windows ConPTY kill when force follows graceful kill', async () => {
       const proc = mockPtyProcess(123456) as ReturnType<typeof mockPtyProcess> & {
         destroy: ReturnType<typeof vi.fn>
       }
@@ -397,7 +398,7 @@ describe('createPtySubprocess', () => {
       const origPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
       Object.defineProperty(process, 'platform', { value: 'win32' })
       try {
-        const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+        const handle = await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
         handle.kill()
         handle.forceKill()
         handle.dispose()
@@ -411,7 +412,7 @@ describe('createPtySubprocess', () => {
       }
     })
 
-    it('dispose() on Windows skips destroy after forceKill falls back to node-pty kill()', () => {
+    it('dispose() on Windows skips destroy after forceKill falls back to node-pty kill()', async () => {
       const proc = mockPtyProcess(123456) as ReturnType<typeof mockPtyProcess> & {
         destroy: ReturnType<typeof vi.fn>
       }
@@ -423,7 +424,7 @@ describe('createPtySubprocess', () => {
       const origPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
       Object.defineProperty(process, 'platform', { value: 'win32' })
       try {
-        const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+        const handle = await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
         handle.forceKill()
         handle.dispose()
         expect(killSpy).toHaveBeenCalledWith(123456, 'SIGKILL')
@@ -435,13 +436,13 @@ describe('createPtySubprocess', () => {
       }
     })
 
-    it('dispose() is idempotent — second call does not re-invoke destroy', () => {
+    it('dispose() is idempotent — second call does not re-invoke destroy', async () => {
       const proc = mockPtyProcess() as ReturnType<typeof mockPtyProcess> & {
         destroy: ReturnType<typeof vi.fn>
       }
       proc.destroy = vi.fn()
       spawnMock.mockReturnValue(proc)
-      const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+      const handle = await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
       handle.dispose()
       handle.dispose()
       expect(proc.destroy).toHaveBeenCalledOnce()
@@ -454,33 +455,33 @@ describe('createPtySubprocess', () => {
   // proc.kill-neutralization applied to the node-pty instance. Without an
   // internal dead-guard, they can deliver SIGKILL/SIGINT/etc to a stranger.
   describe('forceKill/signal guard against recycled pid after exit', () => {
-    it('forceKill is a no-op once proc.onExit has fired', () => {
+    it('forceKill is a no-op once proc.onExit has fired', async () => {
       const proc = mockPtyProcess(55)
       spawnMock.mockReturnValue(proc)
       const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
-      const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+      const handle = await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
       proc._simulateExit(0)
       handle.forceKill()
       expect(killSpy).not.toHaveBeenCalled()
       killSpy.mockRestore()
     })
 
-    it('signal is a no-op once proc.onExit has fired', () => {
+    it('signal is a no-op once proc.onExit has fired', async () => {
       const proc = mockPtyProcess(55)
       spawnMock.mockReturnValue(proc)
       const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
-      const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+      const handle = await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
       proc._simulateExit(0)
       handle.signal('SIGINT')
       expect(killSpy).not.toHaveBeenCalled()
       killSpy.mockRestore()
     })
 
-    it('forceKill before exit still fires SIGKILL (live child)', () => {
+    it('forceKill before exit still fires SIGKILL (live child)', async () => {
       const proc = mockPtyProcess(77)
       spawnMock.mockReturnValue(proc)
       const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
-      const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+      const handle = await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
       handle.forceKill()
       expect(killSpy).toHaveBeenCalledWith(77, 'SIGKILL')
       killSpy.mockRestore()

--- a/src/main/daemon/pty-subprocess-managed-agent-env.test.ts
+++ b/src/main/daemon/pty-subprocess-managed-agent-env.test.ts
@@ -51,7 +51,8 @@ vi.mock('../providers/local-pty-utils', async (importOriginal) => {
   return {
     ...actual,
     resolveUnixShellPath: resolveUnixShellPathMock,
-    validateWorkingDirectory: validateWorkingDirectoryMock
+    validateWorkingDirectory: validateWorkingDirectoryMock,
+    validateWorkingDirectoryAsync: validateWorkingDirectoryMock
   }
 })
 
@@ -86,14 +87,14 @@ describe('createPtySubprocess', () => {
     validateWorkingDirectoryMock
   })
 
-  it('uses shell wrapper when managed env must survive shell startup', () => {
+  it('uses shell wrapper when managed env must survive shell startup', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { value: 'linux' })
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -114,14 +115,14 @@ describe('createPtySubprocess', () => {
     expect(lastCall[2].env.ORCA_SHELL_READY_MARKER).toBe('0')
   })
 
-  it('uses shell wrapper when OpenCode config must survive shell startup', () => {
+  it('uses shell wrapper when OpenCode config must survive shell startup', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { value: 'linux' })
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -143,14 +144,14 @@ describe('createPtySubprocess', () => {
     expect(lastCall[2].env.ORCA_SHELL_READY_MARKER).toBe('0')
   })
 
-  it('uses shell wrapper when MiMo home must survive shell startup', () => {
+  it('uses shell wrapper when MiMo home must survive shell startup', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { value: 'linux' })
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -172,14 +173,14 @@ describe('createPtySubprocess', () => {
     expect(lastCall[2].env.ORCA_SHELL_READY_MARKER).toBe('0')
   })
 
-  it('uses shell wrapper when typed OMP commands need the status extension', () => {
+  it('uses shell wrapper when typed OMP commands need the status extension', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { value: 'linux' })
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -200,14 +201,14 @@ describe('createPtySubprocess', () => {
     expect(lastCall[2].env.ORCA_SHELL_READY_MARKER).toBe('0')
   })
 
-  it('uses shell wrapper when Codex home must survive shell startup', () => {
+  it('uses shell wrapper when Codex home must survive shell startup', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { value: 'linux' })
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -229,14 +230,14 @@ describe('createPtySubprocess', () => {
     expect(lastCall[2].env.ORCA_SHELL_READY_MARKER).toBe('0')
   })
 
-  it('uses shell wrapper when Agent Teams shim path must survive shell startup', () => {
+  it('uses shell wrapper when Agent Teams shim path must survive shell startup', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { value: 'linux' })
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -259,14 +260,14 @@ describe('createPtySubprocess', () => {
     expect(lastCall[2].env.ORCA_SHELL_READY_MARKER).toBe('0')
   })
 
-  it('keeps plain Codex startup commands on the no-marker wrapper', () => {
+  it('keeps plain Codex startup commands on the no-marker wrapper', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { value: 'linux' })
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -286,14 +287,14 @@ describe('createPtySubprocess', () => {
     expect(lastCall[2].env.ORCA_SHELL_READY_MARKER).toBe('0')
   })
 
-  it('uses shell-ready wrapper for delivery-hinted Codex startup commands', () => {
+  it('uses shell-ready wrapper for delivery-hinted Codex startup commands', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { value: 'linux' })
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -314,14 +315,14 @@ describe('createPtySubprocess', () => {
     expect(lastCall[2].env.ORCA_SHELL_READY_MARKER).toBe('1')
   })
 
-  it('uses shell-ready wrapper for Codex native prefill flags', () => {
+  it('uses shell-ready wrapper for Codex native prefill flags', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { value: 'linux' })
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -341,14 +342,14 @@ describe('createPtySubprocess', () => {
     expect(lastCall[2].env.ORCA_SHELL_READY_MARKER).toBe('1')
   })
 
-  it('deletes requested env keys after merging daemon process env', () => {
+  it('deletes requested env keys after merging daemon process env', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const previousCodexHome = process.env.CODEX_HOME
     process.env.CODEX_HOME = '/host/codex-home'
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -367,7 +368,7 @@ describe('createPtySubprocess', () => {
     expect(lastCall[2].env.CODEX_HOME).toBeUndefined()
   })
 
-  it('deletes daemon-owned Codex overlay pairs when the private marker is requested', () => {
+  it('deletes daemon-owned Codex overlay pairs when the private marker is requested', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const previousCodexHome = process.env.CODEX_HOME
@@ -376,7 +377,7 @@ describe('createPtySubprocess', () => {
     process.env.ORCA_CODEX_HOME = '/daemon/managed/codex-home'
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -401,7 +402,7 @@ describe('createPtySubprocess', () => {
     expect(env.ORCA_CODEX_HOME).toBeUndefined()
   })
 
-  it('strips an inherited per-account self-contained CODEX_HOME overlay in a nested Orca (#5370)', () => {
+  it('strips an inherited per-account self-contained CODEX_HOME overlay in a nested Orca (#5370)', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const previousCodexHome = process.env.CODEX_HOME
@@ -413,7 +414,7 @@ describe('createPtySubprocess', () => {
     process.env.ORCA_CODEX_HOME = perAccountHome
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -438,7 +439,7 @@ describe('createPtySubprocess', () => {
     expect(env.ORCA_CODEX_HOME).toBeUndefined()
   })
 
-  it('preserves a daemon-owned custom Codex home while deleting a stale private marker', () => {
+  it('preserves a daemon-owned custom Codex home while deleting a stale private marker', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
@@ -449,7 +450,7 @@ describe('createPtySubprocess', () => {
     process.env.ORCA_CODEX_HOME = '/daemon/stale/managed-home'
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,

--- a/src/main/daemon/pty-subprocess-windows-shell-launch.test.ts
+++ b/src/main/daemon/pty-subprocess-windows-shell-launch.test.ts
@@ -51,7 +51,8 @@ vi.mock('../providers/local-pty-utils', async (importOriginal) => {
   return {
     ...actual,
     resolveUnixShellPath: resolveUnixShellPathMock,
-    validateWorkingDirectory: validateWorkingDirectoryMock
+    validateWorkingDirectory: validateWorkingDirectoryMock,
+    validateWorkingDirectoryAsync: validateWorkingDirectoryMock
   }
 })
 
@@ -87,7 +88,7 @@ describe('createPtySubprocess', () => {
     validateWorkingDirectoryMock
   })
 
-  it('keeps powershell.exe when the inbox PowerShell implementation is selected on Windows', () => {
+  it('keeps powershell.exe when the inbox PowerShell implementation is selected on Windows', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
@@ -96,7 +97,7 @@ describe('createPtySubprocess', () => {
     isPwshAvailableMock.mockReturnValue(true)
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -116,7 +117,7 @@ describe('createPtySubprocess', () => {
     )
   })
 
-  it('spawns pwsh.exe when PowerShell 7 is selected and available on Windows', () => {
+  it('spawns pwsh.exe when PowerShell 7 is selected and available on Windows', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
@@ -125,7 +126,7 @@ describe('createPtySubprocess', () => {
     isPwshAvailableMock.mockReturnValue(true)
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -145,7 +146,7 @@ describe('createPtySubprocess', () => {
     )
   })
 
-  it('keeps PowerShell 7 selected when the pwsh availability probe is cold-false on Windows', () => {
+  it('keeps PowerShell 7 selected when the pwsh availability probe is cold-false on Windows', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
@@ -154,7 +155,7 @@ describe('createPtySubprocess', () => {
     isPwshAvailableMock.mockReturnValue(false)
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -175,7 +176,7 @@ describe('createPtySubprocess', () => {
     expect(isPwshAvailableMock).not.toHaveBeenCalled()
   })
 
-  it('keeps a pwsh.exe shellOverride when the pwsh availability probe is cold-false on Windows', () => {
+  it('keeps a pwsh.exe shellOverride when the pwsh availability probe is cold-false on Windows', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
@@ -184,7 +185,7 @@ describe('createPtySubprocess', () => {
     isPwshAvailableMock.mockReturnValue(false)
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -205,7 +206,7 @@ describe('createPtySubprocess', () => {
     expect(isPwshAvailableMock).not.toHaveBeenCalled()
   })
 
-  it('ignores the PowerShell implementation setting for cmd.exe on Windows', () => {
+  it('ignores the PowerShell implementation setting for cmd.exe on Windows', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
@@ -214,7 +215,7 @@ describe('createPtySubprocess', () => {
     isPwshAvailableMock.mockReturnValue(true)
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -240,16 +241,16 @@ describe('createPtySubprocess', () => {
     )
   })
 
-  it('embeds short PowerShell startup commands in the Windows shell launch', () => {
+  it('embeds short PowerShell startup commands in the Windows shell launch', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
 
     Object.defineProperty(process, 'platform', { value: 'win32' })
 
-    let handle: ReturnType<typeof createPtySubprocess>
+    let handle: Awaited<ReturnType<typeof createPtySubprocess>>
     try {
-      handle = createPtySubprocess({
+      handle = await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -270,16 +271,16 @@ describe('createPtySubprocess', () => {
     expect(handle!.startupCommandDeliveredInShellArgs).toBe(true)
   })
 
-  it('keeps oversized Windows startup commands on PTY stdin delivery', () => {
+  it('keeps oversized Windows startup commands on PTY stdin delivery', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
 
     Object.defineProperty(process, 'platform', { value: 'win32' })
 
-    let handle: ReturnType<typeof createPtySubprocess>
+    let handle: Awaited<ReturnType<typeof createPtySubprocess>>
     try {
-      handle = createPtySubprocess({
+      handle = await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -305,7 +306,7 @@ describe('createPtySubprocess', () => {
     expect(handle!.startupCommandDeliveredInShellArgs).toBeUndefined()
   })
 
-  it('launches Git Bash with login args and CHERE_INVOKING on Windows', () => {
+  it('launches Git Bash with login args and CHERE_INVOKING on Windows', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
@@ -313,7 +314,7 @@ describe('createPtySubprocess', () => {
     Object.defineProperty(process, 'platform', { value: 'win32' })
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -345,12 +346,12 @@ describe('createPtySubprocess', () => {
     )
   })
 
-  it('rejects a missing explicit native Windows cwd before node-pty spawn', () => {
+  it('rejects a missing explicit native Windows cwd before node-pty spawn', async () => {
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { value: 'win32' })
 
     try {
-      expect(() =>
+      await expect(
         createPtySubprocess({
           sessionId: 'test',
           cols: 80,
@@ -358,7 +359,7 @@ describe('createPtySubprocess', () => {
           cwd: 'C:\\definitely-missing-orca-cwd',
           shellOverride: 'powershell.exe'
         })
-      ).toThrow(/Working directory "C:\\definitely-missing-orca-cwd" does not exist/)
+      ).rejects.toThrow(/Working directory "C:\\definitely-missing-orca-cwd" does not exist/)
     } finally {
       if (platform) {
         Object.defineProperty(process, 'platform', platform)
@@ -368,7 +369,7 @@ describe('createPtySubprocess', () => {
     expect(spawnMock).not.toHaveBeenCalled()
   })
 
-  it('normalizes MSYS drive cwd before spawning daemon PowerShell on Windows', () => {
+  it('normalizes MSYS drive cwd before spawning daemon PowerShell on Windows', async () => {
     const proc = mockPtyProcess()
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { value: 'win32' })
@@ -380,7 +381,7 @@ describe('createPtySubprocess', () => {
     })
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -400,7 +401,7 @@ describe('createPtySubprocess', () => {
     )
   })
 
-  it('adds shell and cwd context when node-pty reports File not found on Windows', () => {
+  it('adds shell and cwd context when node-pty reports File not found on Windows', async () => {
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { value: 'win32' })
     spawnMock.mockImplementation(() => {
@@ -410,14 +411,14 @@ describe('createPtySubprocess', () => {
     process.env.ORCA_APP_VERSION = '1.4.178-test'
 
     try {
-      expect(() =>
+      await expect(
         createPtySubprocess({
           sessionId: 'test',
           cols: 80,
           rows: 24,
           shellOverride: 'not-a-real-shell.exe'
         })
-      ).toThrow(
+      ).rejects.toThrow(
         /Daemon failed to spawn shell "not-a-real-shell\.exe" with cwd ".+": File not found:.*orca: 1\.4\.178-test/
       )
     } finally {

--- a/src/main/daemon/pty-subprocess-wsl-launch.test.ts
+++ b/src/main/daemon/pty-subprocess-wsl-launch.test.ts
@@ -54,7 +54,8 @@ vi.mock('../providers/local-pty-utils', async (importOriginal) => {
   return {
     ...actual,
     resolveUnixShellPath: resolveUnixShellPathMock,
-    validateWorkingDirectory: validateWorkingDirectoryMock
+    validateWorkingDirectory: validateWorkingDirectoryMock,
+    validateWorkingDirectoryAsync: validateWorkingDirectoryMock
   }
 })
 
@@ -91,12 +92,12 @@ describe('createPtySubprocess', () => {
     validateWorkingDirectoryMock
   })
 
-  it('validates the requested Windows cwd before launching WSL on Windows', () => {
+  it('validates the requested Windows cwd before launching WSL on Windows', async () => {
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { value: 'win32' })
 
     try {
-      expect(() =>
+      await expect(
         createPtySubprocess({
           sessionId: 'test',
           cols: 80,
@@ -104,7 +105,7 @@ describe('createPtySubprocess', () => {
           cwd: 'C:\\definitely-missing-orca-wsl-cwd',
           shellOverride: 'wsl.exe'
         })
-      ).toThrow(/Working directory "C:\\definitely-missing-orca-wsl-cwd" does not exist/)
+      ).rejects.toThrow(/Working directory "C:\\definitely-missing-orca-wsl-cwd" does not exist/)
     } finally {
       if (platform) {
         Object.defineProperty(process, 'platform', platform)
@@ -114,7 +115,7 @@ describe('createPtySubprocess', () => {
     expect(spawnMock).not.toHaveBeenCalled()
   })
 
-  it('falls back to /mnt/c before launching WSL when cwd is not a native Windows path', () => {
+  it('falls back to /mnt/c before launching WSL when cwd is not a native Windows path', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
@@ -123,7 +124,7 @@ describe('createPtySubprocess', () => {
     Object.defineProperty(process, 'platform', { value: 'win32' })
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -150,7 +151,7 @@ describe('createPtySubprocess', () => {
     )
   })
 
-  it('uses the preferred WSL distro for daemon WSL terminals with Windows cwd', () => {
+  it('uses the preferred WSL distro for daemon WSL terminals with Windows cwd', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
@@ -160,7 +161,7 @@ describe('createPtySubprocess', () => {
     Object.defineProperty(process, 'platform', { value: 'win32' })
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -181,7 +182,7 @@ describe('createPtySubprocess', () => {
     )
   })
 
-  it('launches WSL for WSL worktree cwd even when a stale Windows shell override is present', () => {
+  it('launches WSL for WSL worktree cwd even when a stale Windows shell override is present', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
@@ -189,7 +190,7 @@ describe('createPtySubprocess', () => {
     Object.defineProperty(process, 'platform', { value: 'win32' })
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -209,7 +210,7 @@ describe('createPtySubprocess', () => {
     )
   })
 
-  it('does not pass a Windows Codex home into daemon WSL terminals', () => {
+  it('does not pass a Windows Codex home into daemon WSL terminals', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
@@ -217,7 +218,7 @@ describe('createPtySubprocess', () => {
     Object.defineProperty(process, 'platform', { value: 'win32' })
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -242,7 +243,7 @@ describe('createPtySubprocess', () => {
     )
   })
 
-  it('does not pass a WSL managed Codex home into daemon Windows terminals', () => {
+  it('does not pass a WSL managed Codex home into daemon Windows terminals', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
@@ -250,7 +251,7 @@ describe('createPtySubprocess', () => {
     Object.defineProperty(process, 'platform', { value: 'win32' })
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -280,7 +281,7 @@ describe('createPtySubprocess', () => {
     )
   })
 
-  it('routes daemon default WSL terminals to the Codex home distro without losing cwd', () => {
+  it('routes daemon default WSL terminals to the Codex home distro without losing cwd', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
@@ -289,7 +290,7 @@ describe('createPtySubprocess', () => {
     Object.defineProperty(process, 'platform', { value: 'win32' })
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -328,7 +329,7 @@ describe('createPtySubprocess', () => {
     )
   })
 
-  it('preserves an explicit Linux Codex home in daemon WSL terminals', () => {
+  it('preserves an explicit Linux Codex home in daemon WSL terminals', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
@@ -336,7 +337,7 @@ describe('createPtySubprocess', () => {
     Object.defineProperty(process, 'platform', { value: 'win32' })
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -358,7 +359,7 @@ describe('createPtySubprocess', () => {
     )
   })
 
-  it('marks Orca terminal handles for WSL env import in daemon WSL terminals', () => {
+  it('marks Orca terminal handles for WSL env import in daemon WSL terminals', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
@@ -370,7 +371,7 @@ describe('createPtySubprocess', () => {
     delete process.env.ORCA_CODEX_HOME
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -413,7 +414,7 @@ describe('createPtySubprocess', () => {
     )
   })
 
-  it('does not mark deleted Powerlevel10k wizard env for daemon WSL import', () => {
+  it('does not mark deleted Powerlevel10k wizard env for daemon WSL import', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
@@ -421,7 +422,7 @@ describe('createPtySubprocess', () => {
     Object.defineProperty(process, 'platform', { value: 'win32' })
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -442,7 +443,7 @@ describe('createPtySubprocess', () => {
 
   it.each(['/home/jin/repo/subdir', '/a', '/c'])(
     'keeps daemon WSL split panes in their distro when cwd is POSIX (%s)',
-    (cwd) => {
+    async (cwd) => {
       const proc = mockPtyProcess()
       spawnMock.mockReturnValue(proc)
       const platform = Object.getOwnPropertyDescriptor(process, 'platform')
@@ -450,7 +451,7 @@ describe('createPtySubprocess', () => {
       Object.defineProperty(process, 'platform', { value: 'win32' })
 
       try {
-        createPtySubprocess({
+        await createPtySubprocess({
           sessionId: 'repo::\\\\wsl.localhost\\Ubuntu\\home\\jin\\repo@@deadbeef',
           cols: 80,
           rows: 24,

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -54,7 +54,8 @@ vi.mock('../providers/local-pty-utils', async (importOriginal) => {
   return {
     ...actual,
     resolveUnixShellPath: resolveUnixShellPathMock,
-    validateWorkingDirectory: validateWorkingDirectoryMock
+    validateWorkingDirectory: validateWorkingDirectoryMock,
+    validateWorkingDirectoryAsync: validateWorkingDirectoryMock
   }
 })
 
@@ -96,7 +97,7 @@ describe('createPtySubprocess', () => {
     validateWorkingDirectoryMock
   })
 
-  it('spawns node-pty with correct options', () => {
+  it('spawns node-pty with correct options', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const onMacosTccSpawnStrategy = vi.fn()
@@ -104,7 +105,7 @@ describe('createPtySubprocess', () => {
     Object.defineProperty(process, 'platform', { value: 'linux' })
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -131,7 +132,7 @@ describe('createPtySubprocess', () => {
     expect(onMacosTccSpawnStrategy).toHaveBeenCalledWith('direct')
   })
 
-  it('does not report a spawn strategy when node-pty fails before launch', () => {
+  it('does not report a spawn strategy when node-pty fails before launch', async () => {
     spawnMock.mockImplementationOnce(() => {
       throw new Error('spawn failed')
     })
@@ -140,7 +141,7 @@ describe('createPtySubprocess', () => {
     Object.defineProperty(process, 'platform', { value: 'linux' })
 
     try {
-      expect(() =>
+      await expect(
         createPtySubprocess({
           sessionId: 'test',
           cols: 80,
@@ -148,7 +149,7 @@ describe('createPtySubprocess', () => {
           env: { SHELL: '/bin/bash' },
           onMacosTccSpawnStrategy
         })
-      ).toThrow('spawn failed')
+      ).rejects.toThrow('spawn failed')
     } finally {
       if (platform) {
         Object.defineProperty(process, 'platform', platform)
@@ -168,7 +169,7 @@ describe('createPtySubprocess', () => {
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(22)
   })
 
-  it('resolves a missing Unix default before spawning node-pty', () => {
+  it('resolves a missing Unix default before spawning node-pty', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     resolveUnixShellPathMock.mockReturnValue('/bin/sh')
@@ -179,7 +180,7 @@ describe('createPtySubprocess', () => {
     delete process.env.SHELL
 
     try {
-      createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24, env: {} })
+      await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24, env: {} })
 
       expect(resolveUnixShellPathMock).toHaveBeenCalledWith('/bin/zsh')
       expect(spawnMock).toHaveBeenCalledWith(
@@ -203,7 +204,7 @@ describe('createPtySubprocess', () => {
     }
   })
 
-  it('derives shell-ready launch config from the resolved fallback shell', () => {
+  it('derives shell-ready launch config from the resolved fallback shell', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     resolveUnixShellPathMock.mockReturnValue('/bin/sh')
@@ -220,7 +221,7 @@ describe('createPtySubprocess', () => {
     delete process.env.ZDOTDIR
 
     try {
-      const handle = createPtySubprocess({
+      const handle = await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -260,7 +261,7 @@ describe('createPtySubprocess', () => {
     }
   })
 
-  it('surfaces the no-executable-shell error before node-pty forks', () => {
+  it('surfaces the no-executable-shell error before node-pty forks', async () => {
     resolveUnixShellPathMock.mockImplementation(() => {
       throw new Error('No executable Unix shell found (tried: /bin/zsh, /bin/bash, /bin/sh)')
     })
@@ -268,9 +269,9 @@ describe('createPtySubprocess', () => {
     Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })
 
     try {
-      expect(() => createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24, env: {} })).toThrow(
-        'No executable Unix shell found'
-      )
+      await expect(
+        createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24, env: {} })
+      ).rejects.toThrow('No executable Unix shell found')
       expect(spawnMock).not.toHaveBeenCalled()
     } finally {
       if (platform) {
@@ -279,14 +280,14 @@ describe('createPtySubprocess', () => {
     }
   })
 
-  it('uses bundled ConPTY for native Windows daemon terminals', () => {
+  it('uses bundled ConPTY for native Windows daemon terminals', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { value: 'win32' })
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -306,14 +307,14 @@ describe('createPtySubprocess', () => {
     )
   })
 
-  it('suppresses the first-run Powerlevel10k wizard for daemon terminals', () => {
+  it('suppresses the first-run Powerlevel10k wizard for daemon terminals', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { value: 'linux' })
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -329,7 +330,7 @@ describe('createPtySubprocess', () => {
     expect(spawnCall[2].env[POWERLEVEL10K_WIZARD_DISABLE_ENV]).toBe('true')
   })
 
-  itOnMacHost('repairs a deleted macOS daemon cwd before spawning node-pty', () => {
+  itOnMacHost('repairs a deleted macOS daemon cwd before spawning node-pty', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
@@ -338,7 +339,7 @@ describe('createPtySubprocess', () => {
     const { restoreCwdStubs, chdirSpy } = stubMissingDaemonCwd()
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -363,7 +364,7 @@ describe('createPtySubprocess', () => {
     )
   })
 
-  itOnPosixHost('repairs a deleted POSIX daemon cwd before Linux node-pty spawn', () => {
+  itOnPosixHost('repairs a deleted POSIX daemon cwd before Linux node-pty spawn', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
@@ -372,7 +373,7 @@ describe('createPtySubprocess', () => {
     const { restoreCwdStubs, chdirSpy } = stubMissingDaemonCwd()
 
     try {
-      createPtySubprocess({
+      await createPtySubprocess({
         sessionId: 'test',
         cols: 80,
         rows: 24,
@@ -395,25 +396,25 @@ describe('createPtySubprocess', () => {
     )
   })
 
-  it('uses SHELL env or defaults to /bin/zsh on non-Windows', () => {
+  it('uses SHELL env or defaults to /bin/zsh on non-Windows', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
 
-    createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+    await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
 
     const shellArg = spawnMock.mock.calls[0][0]
     expect(typeof shellArg).toBe('string')
     expect(shellArg.length).toBeGreaterThan(0)
   })
 
-  it('allows an explicitly requested plain daemon shell at POSIX root', () => {
+  it('allows an explicitly requested plain daemon shell at POSIX root', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { value: 'linux' })
 
     try {
-      createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24, cwd: '/' })
+      await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24, cwd: '/' })
     } finally {
       if (platform) {
         Object.defineProperty(process, 'platform', platform)
@@ -427,7 +428,7 @@ describe('createPtySubprocess', () => {
     )
   })
 
-  it('falls back to the safe default cwd for daemon agent startup without an explicit cwd', () => {
+  it('falls back to the safe default cwd for daemon agent startup without an explicit cwd', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     spawnMock.mockClear()
@@ -440,14 +441,14 @@ describe('createPtySubprocess', () => {
 
     try {
       // Why: omitted cwd resolves to a safe default home; guard must not reject before fallback (#9578).
-      expect(() =>
+      await expect(
         createPtySubprocess({
           sessionId: 'test',
           cols: 80,
           rows: 24,
           command: 'opencode'
         })
-      ).not.toThrow()
+      ).resolves.not.toThrow()
 
       expect(spawnMock).toHaveBeenCalledWith(
         expect.any(String),
@@ -466,13 +467,13 @@ describe('createPtySubprocess', () => {
     }
   })
 
-  it('rejects daemon automatic agent startup at POSIX root', () => {
+  it('rejects daemon automatic agent startup at POSIX root', async () => {
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { value: 'linux' })
     spawnMock.mockClear()
 
     try {
-      expect(() =>
+      await expect(
         createPtySubprocess({
           sessionId: 'test',
           cols: 80,
@@ -480,7 +481,7 @@ describe('createPtySubprocess', () => {
           cwd: '/',
           command: 'claude'
         })
-      ).toThrow(/requires a non-root workspace/)
+      ).rejects.toThrow(/requires a non-root workspace/)
     } finally {
       if (platform) {
         Object.defineProperty(process, 'platform', platform)
@@ -490,20 +491,20 @@ describe('createPtySubprocess', () => {
     expect(spawnMock).not.toHaveBeenCalled()
   })
 
-  it('rejects a missing explicit POSIX cwd before node-pty spawn', () => {
+  it('rejects a missing explicit POSIX cwd before node-pty spawn', async () => {
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { value: 'linux' })
     spawnMock.mockClear()
 
     try {
-      expect(() =>
+      await expect(
         createPtySubprocess({
           sessionId: 'test',
           cols: 80,
           rows: 24,
           cwd: '/definitely-missing-orca-cwd'
         })
-      ).toThrow(/definitely-missing-orca-cwd/)
+      ).rejects.toThrow(/definitely-missing-orca-cwd/)
     } finally {
       if (platform) {
         Object.defineProperty(process, 'platform', platform)
@@ -513,7 +514,7 @@ describe('createPtySubprocess', () => {
     expect(spawnMock).not.toHaveBeenCalled()
   })
 
-  it('combines HOMEDRIVE and HOMEPATH for Windows default cwd', () => {
+  it('combines HOMEDRIVE and HOMEPATH for Windows default cwd', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
@@ -527,7 +528,7 @@ describe('createPtySubprocess', () => {
     process.env.HOMEPATH = '\\Users\\orca'
 
     try {
-      createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+      await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
     } finally {
       if (platform) {
         Object.defineProperty(process, 'platform', platform)

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -132,6 +132,29 @@ describe('createPtySubprocess', () => {
     expect(onMacosTccSpawnStrategy).toHaveBeenCalledWith('direct')
   })
 
+  it('does not spawn after cancellation wins during async cwd validation', async () => {
+    let releaseValidation: () => void = () => {}
+    const validationGate = new Promise<void>((resolve) => {
+      releaseValidation = resolve
+    })
+    validateWorkingDirectoryMock.mockImplementationOnce(() => validationGate)
+    let canceled = false
+
+    const spawning = createPtySubprocess({
+      sessionId: 'canceled-validation',
+      cols: 80,
+      rows: 24,
+      isCanceled: () => canceled
+    })
+    await vi.waitFor(() => expect(validateWorkingDirectoryMock).toHaveBeenCalled())
+
+    canceled = true
+    releaseValidation()
+
+    await expect(spawning).rejects.toThrow('Attach canceled for session canceled-validation')
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
   it('does not report a spawn strategy when node-pty fails before launch', async () => {
     spawnMock.mockImplementationOnce(() => {
       throw new Error('spawn failed')

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -15,7 +15,7 @@ import {
   ensureNodePtySpawnHelperExecutable,
   getNodePtySpawnHelperCandidates,
   resolveUnixShellPath,
-  validateWorkingDirectory
+  validateWorkingDirectoryAsync
 } from '../providers/local-pty-utils'
 import { wrapShellSpawnForMacosTccAttribution } from '../providers/macos-tcc-login-shell'
 import { signalPosixPtyForegroundGroup } from '../pty/posix-pty-foreground-group'
@@ -383,10 +383,10 @@ function isNativeWindowsPath(path: string): boolean {
 /**
  * Validates explicit native Windows cwd paths before ConPTY launch.
  */
-function preflightWindowsPtySpawnEnvironment(args: {
+async function preflightWindowsPtySpawnEnvironment(args: {
   validationCwd: string
   cwdWasExplicit: boolean
-}): void {
+}): Promise<void> {
   if (process.platform !== 'win32' || !args.cwdWasExplicit) {
     return
   }
@@ -395,17 +395,17 @@ function preflightWindowsPtySpawnEnvironment(args: {
     return
   }
 
-  validateWorkingDirectory(args.validationCwd)
+  await validateWorkingDirectoryAsync(args.validationCwd)
 }
 
 /**
  * Validates POSIX spawn cwd before node-pty can fail with an opaque ENOENT.
  */
-function preflightPosixPtySpawnEnvironment(validationCwd: string): void {
+async function preflightPosixPtySpawnEnvironment(validationCwd: string): Promise<void> {
   if (process.platform === 'win32') {
     return
   }
-  validateWorkingDirectory(validationCwd)
+  await validateWorkingDirectoryAsync(validationCwd)
 }
 
 /**
@@ -621,7 +621,7 @@ function spawnDaemonPtyWithWindowsFallback(args: {
  * The returned handle records whether the startup command was already embedded
  * in Windows shell args so the daemon host does not write it a second time.
  */
-export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandle {
+export async function createPtySubprocess(opts: PtySubprocessOptions): Promise<SubprocessHandle> {
   const size = normalizePtySize(opts.cols, opts.rows)
   const env: Record<string, string> = {
     ...mergeGitConfigEnvProtocol(stripInheritedBuildModeEnv(process.env), opts.env),
@@ -855,8 +855,8 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
   // Why: asar packaging can strip +x from node-pty's spawn-helper; the daemon is a separate forked process from the main-process fix.
   ensureNodePtySpawnHelperExecutable()
   preflightUnixPtySpawnEnvironment()
-  preflightPosixPtySpawnEnvironment(validationCwd)
-  preflightWindowsPtySpawnEnvironment({
+  await preflightPosixPtySpawnEnvironment(validationCwd)
+  await preflightWindowsPtySpawnEnvironment({
     validationCwd,
     cwdWasExplicit: opts.cwd !== undefined
   })

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -68,6 +68,7 @@ import {
   type StartupCommandDelivery
 } from '../../shared/codex-startup-delivery'
 import { isShellProcess } from '../../shared/shell-process-detection'
+import { TerminalAttachCanceledError } from './daemon-errors'
 import { parsePtySessionId } from './pty-session-id'
 import { getAgentForegroundContextPaths } from '../providers/agent-foreground-context-paths'
 import { assertSafeAgentStartupCwd, resolveSafePtyDefaultCwd } from '../providers/pty-default-cwd'
@@ -133,6 +134,7 @@ export type PtySubprocessOptions = {
   shellOverride?: string
   terminalWindowsWslDistro?: string | null
   terminalWindowsPowerShellImplementation?: 'auto' | 'powershell.exe' | 'pwsh.exe'
+  isCanceled?: () => boolean
   onMacosTccSpawnStrategy?: (strategy: 'wrapped' | 'direct') => void
 }
 
@@ -860,6 +862,9 @@ export async function createPtySubprocess(opts: PtySubprocessOptions): Promise<S
     validationCwd,
     cwdWasExplicit: opts.cwd !== undefined
   })
+  if (opts.isCanceled?.()) {
+    throw new TerminalAttachCanceledError(opts.sessionId)
+  }
 
   let proc: pty.IPty
   try {

--- a/src/main/daemon/repro-13767-shell-ready-marker-lost-to-exec.test.ts
+++ b/src/main/daemon/repro-13767-shell-ready-marker-lost-to-exec.test.ts
@@ -112,23 +112,23 @@ function runCleanupActions(...actions: (() => void)[]): void {
 
 type RunningFixture = {
   session: Session
-  subprocess: ReturnType<typeof createPtySubprocess>
+  subprocess: Awaited<ReturnType<typeof createPtySubprocess>>
   output: () => string
   readStarted: () => boolean
   subscribe: (settle: () => void) => void
   cleanup: () => Promise<void>
 }
 
-function startFixture(
+async function startFixture(
   fixture: ShellFixture,
   startupContent: string,
   extraFiles: Record<string, string> = {}
-): RunningFixture {
+): Promise<RunningFixture> {
   const tempHome = mkdtempSync(join(tmpdir(), 'orca-shell-ready-exec-'))
   const previousHome = process.env.HOME
   const previousZdotdir = process.env.ZDOTDIR
   const previousOrigZdotdir = process.env.ORCA_ORIG_ZDOTDIR
-  let subprocess: ReturnType<typeof createPtySubprocess> | undefined
+  let subprocess: Awaited<ReturnType<typeof createPtySubprocess>> | undefined
   let session: Session | undefined
   let consoleWarnSpy: { mockRestore: () => void } | undefined
   try {
@@ -141,7 +141,7 @@ function startFixture(
     delete process.env.ORCA_ORIG_ZDOTDIR
     consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
-    subprocess = createPtySubprocess({
+    subprocess = await createPtySubprocess({
       sessionId: `repro-13767-${fixture.startupFile}`,
       cols: 80,
       rows: 24,
@@ -233,7 +233,7 @@ function setEnvironmentValue(key: string, value: string | undefined): void {
 }
 
 async function runExecOracle(fixture: ShellFixture): Promise<void> {
-  const running = startFixture(
+  const running = await startFixture(
     fixture,
     `if [[ -z "\${ORCA_EXEC_REPRO_DONE:-}" ]]; then
   export ORCA_EXEC_REPRO_DONE=1
@@ -253,7 +253,7 @@ fi
 }
 
 async function runReadOracle(fixture: ShellFixture, child: boolean): Promise<void> {
-  const running = startFixture(fixture, child ? fixture.childRead : fixture.secretRead)
+  const running = await startFixture(fixture, child ? fixture.childRead : fixture.secretRead)
   try {
     await waitForCondition(running.readStarted)
     await new Promise((resolve) => setTimeout(resolve, 300))
@@ -309,7 +309,7 @@ describePosix('#13767 shell-ready marker loss across exec', () => {
   zshTest(
     'keeps queued input out of a zle-line-init read after exec',
     async () => {
-      const running = startFixture(
+      const running = await startFixture(
         zshFixture,
         `if [[ -z "\${ORCA_EXEC_REPRO_DONE:-}" ]]; then
   export ORCA_EXEC_REPRO_DONE=1
@@ -357,7 +357,7 @@ zle -N zle-line-init
   sqliteTest(
     'does not treat an exec-replaced readline program as the shell prompt',
     async () => {
-      const running = startFixture(zshFixture, 'exec /usr/bin/sqlite3\n')
+      const running = await startFixture(zshFixture, 'exec /usr/bin/sqlite3\n')
       try {
         await waitForOutput(running.subscribe, () => running.output().includes('sqlite> '))
         await new Promise((resolve) => setTimeout(resolve, 300))
@@ -373,7 +373,7 @@ zle -N zle-line-init
   sqliteTest(
     'does not trust a non-shell executable renamed to the shell basename',
     async () => {
-      const running = startFixture(
+      const running = await startFixture(
         zshFixture,
         'ln -s /usr/bin/sqlite3 "$HOME/zsh" && exec "$HOME/zsh"\n'
       )
@@ -392,7 +392,7 @@ zle -N zle-line-init
   zshTest(
     'retains the timeout backstop when zsh disables bracketed paste',
     async () => {
-      const running = startFixture(
+      const running = await startFixture(
         zshFixture,
         `if [[ -z "\${ORCA_EXEC_REPRO_DONE:-}" ]]; then
   export ORCA_EXEC_REPRO_DONE=1

--- a/src/main/daemon/terminal-host-agent-session-claim.ts
+++ b/src/main/daemon/terminal-host-agent-session-claim.ts
@@ -4,10 +4,11 @@ import type { CreateOrAttachOptions, CreateOrAttachResult } from './terminal-hos
 
 export type InternalCreateOrAttachOptions = CreateOrAttachOptions & {
   agentSessionGeneration?: string
+  isCanceled?: () => boolean
 }
 
 export async function createOrAttachClaimedAgentSession(args: {
-  options: CreateOrAttachOptions
+  options: InternalCreateOrAttachOptions
   owners: ClaimedAgentPtyOwnerRegistry
   isLive: (owner: AgentSessionOwnerBinding) => boolean
   createOrAttach: (options: InternalCreateOrAttachOptions) => Promise<CreateOrAttachResult>

--- a/src/main/daemon/terminal-host-agent-session.test.ts
+++ b/src/main/daemon/terminal-host-agent-session.test.ts
@@ -2,7 +2,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { SubprocessHandle } from './session-subprocess-handle'
 import { TerminalHost } from './terminal-host'
 
-function createClaimedSubprocess(): SubprocessHandle & { exit: () => void } {
+function createClaimedSubprocess(): SubprocessHandle & {
+  emitData: (data: string) => void
+  exit: () => void
+} {
+  let onData: ((data: string) => void) | null = null
   let onExit: ((code: number) => void) | null = null
   return {
     pid: 99_999,
@@ -12,11 +16,14 @@ function createClaimedSubprocess(): SubprocessHandle & { exit: () => void } {
     kill: vi.fn(),
     forceKill: vi.fn(),
     signal: vi.fn(),
-    onData: vi.fn(),
+    onData: (listener) => {
+      onData = listener
+    },
     onExit: (listener) => {
       onExit = listener
     },
     dispose: vi.fn(),
+    emitData: (data) => onData?.(data),
     exit: () => onExit?.(0)
   }
 }
@@ -80,5 +87,93 @@ describe('TerminalHost agent-session claims', () => {
       owner: { ptyId: 'session-claimed-first', surface }
     })
     expect(spawnSubprocess).toHaveBeenCalledOnce()
+  })
+
+  it('rejects a competing claim without replacing the winning stream', async () => {
+    let releaseSpawn: () => void = () => {}
+    const spawnGate = new Promise<void>((resolve) => {
+      releaseSpawn = resolve
+    })
+    host = new TerminalHost({
+      spawnSubprocess: async () => {
+        await spawnGate
+        subprocess = createClaimedSubprocess()
+        return subprocess
+      }
+    })
+    const winningData = vi.fn()
+    const competingData = vi.fn()
+
+    const winning = host.createOrAttach({
+      sessionId: 'shared-requested-id',
+      cols: 80,
+      rows: 24,
+      streamClient: { onData: winningData, onExit: vi.fn() },
+      agentSessionEnsure: { claim, surface }
+    })
+    const competing = host.createOrAttach({
+      sessionId: 'shared-requested-id',
+      cols: 80,
+      rows: 24,
+      streamClient: { onData: competingData, onExit: vi.fn() },
+      agentSessionEnsure: {
+        claim: {
+          ...claim,
+          keyId: 'other-key',
+          identityDigest: 'ccccccccccccccccccccccccccccccccccccccccccc'
+        },
+        surface: { ...surface, terminalHandle: 'term_competing' }
+      }
+    })
+
+    releaseSpawn()
+    await expect(winning).resolves.toMatchObject({ isNew: true })
+    await expect(competing).rejects.toThrow('agent_session_claim_unavailable')
+
+    subprocess?.emitData('winner-only')
+    expect(winningData).toHaveBeenCalledExactlyOnceWith('winner-only')
+    expect(competingData).not.toHaveBeenCalled()
+  })
+
+  it('does not attach a canceled adopter after waiting for a reservation', async () => {
+    let releaseSpawn: () => void = () => {}
+    const spawnGate = new Promise<void>((resolve) => {
+      releaseSpawn = resolve
+    })
+    host = new TerminalHost({
+      spawnSubprocess: async () => {
+        await spawnGate
+        subprocess = createClaimedSubprocess()
+        return subprocess
+      }
+    })
+    const winningData = vi.fn()
+    const canceledData = vi.fn()
+    let canceled = false
+
+    const winning = host.createOrAttach({
+      sessionId: 'reservation-owner',
+      cols: 80,
+      rows: 24,
+      streamClient: { onData: winningData, onExit: vi.fn() },
+      agentSessionEnsure: { claim, surface }
+    })
+    const adopter = host.createOrAttach({
+      sessionId: 'reservation-adopter',
+      cols: 80,
+      rows: 24,
+      streamClient: { onData: canceledData, onExit: vi.fn() },
+      agentSessionEnsure: { claim, surface },
+      isCanceled: () => canceled
+    })
+
+    canceled = true
+    releaseSpawn()
+    await expect(winning).resolves.toMatchObject({ isNew: true })
+    await expect(adopter).rejects.toThrow('Attach canceled for session reservation-owner')
+
+    subprocess?.emitData('winner-only')
+    expect(winningData).toHaveBeenCalledExactlyOnceWith('winner-only')
+    expect(canceledData).not.toHaveBeenCalled()
   })
 })

--- a/src/main/daemon/terminal-host-concurrent-create.test.ts
+++ b/src/main/daemon/terminal-host-concurrent-create.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { SubprocessHandle } from './session-subprocess-handle'
+import { TerminalHost } from './terminal-host'
+
+vi.mock('../pty-descendant-termination', () => ({ killWithDescendantSweep: vi.fn() }))
+
+function mockSubprocess(): SubprocessHandle {
+  let onExitCb: ((code: number) => void) | null = null
+  return {
+    pid: 4242,
+    getForegroundProcess: vi.fn(() => null),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(() => setTimeout(() => onExitCb?.(0), 1)),
+    forceKill: vi.fn(() => onExitCb?.(137)),
+    signal: vi.fn(),
+    onData: vi.fn(),
+    onExit(cb) {
+      onExitCb = cb
+    },
+    dispose: vi.fn()
+  } as unknown as SubprocessHandle
+}
+
+const streamClient = { onData: vi.fn(), onExit: vi.fn() }
+
+function createOptions(sessionId: string) {
+  return { sessionId, cols: 80, rows: 24, streamClient }
+}
+
+describe('concurrent createOrAttach across the async spawn', () => {
+  it('spawns one shell when two callers race the same session id', async () => {
+    // Why: cwd validation is async (STA-4470), so spawnSubprocess now suspends
+    // between the "already exists?" check and the sessions.set that publishes
+    // the session. Without a per-session gate both callers pass the check and
+    // two shells end up hidden behind one id, which strands one of them.
+    let releaseSpawn: () => void = () => {}
+    const spawnGate = new Promise<void>((resolve) => {
+      releaseSpawn = resolve
+    })
+    const spawnSubprocess = vi.fn(async () => {
+      await spawnGate
+      return mockSubprocess()
+    })
+    const host = new TerminalHost({ spawnSubprocess })
+
+    const first = host.createOrAttach(createOptions('race-1'))
+    const second = host.createOrAttach(createOptions('race-1'))
+    releaseSpawn()
+    const results = await Promise.all([first, second])
+
+    expect(spawnSubprocess).toHaveBeenCalledOnce()
+    expect(results.map((result) => result.isNew).sort()).toEqual([false, true])
+    expect(host.listSessions()).toHaveLength(1)
+
+    await host.dispose()
+  })
+
+  it('lets the next caller spawn after a failed spawn releases the gate', async () => {
+    const spawnSubprocess = vi
+      .fn<() => Promise<SubprocessHandle>>()
+      .mockRejectedValueOnce(new Error('Working directory "X" does not exist.'))
+      .mockImplementation(async () => mockSubprocess())
+    const host = new TerminalHost({ spawnSubprocess })
+
+    await expect(host.createOrAttach(createOptions('race-2'))).rejects.toThrow('does not exist')
+    // A rejected spawn publishes nothing, so the id must stay claimable.
+    await expect(host.createOrAttach(createOptions('race-2'))).resolves.toMatchObject({
+      isNew: true
+    })
+
+    expect(spawnSubprocess).toHaveBeenCalledTimes(2)
+
+    await host.dispose()
+  })
+
+  it('keeps distinct session ids spawning in parallel', async () => {
+    let pendingSpawns = 0
+    let maxConcurrent = 0
+    const spawnSubprocess = vi.fn(async () => {
+      pendingSpawns += 1
+      maxConcurrent = Math.max(maxConcurrent, pendingSpawns)
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      pendingSpawns -= 1
+      return mockSubprocess()
+    })
+    const host = new TerminalHost({ spawnSubprocess })
+
+    await Promise.all([
+      host.createOrAttach(createOptions('solo-a')),
+      host.createOrAttach(createOptions('solo-b'))
+    ])
+
+    // Why: the gate is per session id; serializing unrelated sessions would
+    // rebuild the head-of-line blocking this change exists to remove.
+    expect(maxConcurrent).toBe(2)
+
+    await host.dispose()
+  })
+})

--- a/src/main/daemon/terminal-host-concurrent-create.test.ts
+++ b/src/main/daemon/terminal-host-concurrent-create.test.ts
@@ -30,10 +30,7 @@ function createOptions(sessionId: string) {
 
 describe('concurrent createOrAttach across the async spawn', () => {
   it('spawns one shell when two callers race the same session id', async () => {
-    // Why: cwd validation is async (STA-4470), so spawnSubprocess now suspends
-    // between the "already exists?" check and the sessions.set that publishes
-    // the session. Without a per-session gate both callers pass the check and
-    // two shells end up hidden behind one id, which strands one of them.
+    // Both callers reach the async spawn before either can publish the session.
     let releaseSpawn: () => void = () => {}
     const spawnGate = new Promise<void>((resolve) => {
       releaseSpawn = resolve
@@ -64,7 +61,7 @@ describe('concurrent createOrAttach across the async spawn', () => {
     const host = new TerminalHost({ spawnSubprocess })
 
     await expect(host.createOrAttach(createOptions('race-2'))).rejects.toThrow('does not exist')
-    // A rejected spawn publishes nothing, so the id must stay claimable.
+    // A failed spawn must leave the id claimable.
     await expect(host.createOrAttach(createOptions('race-2'))).resolves.toMatchObject({
       isNew: true
     })
@@ -91,10 +88,67 @@ describe('concurrent createOrAttach across the async spawn', () => {
       host.createOrAttach(createOptions('solo-b'))
     ])
 
-    // Why: the gate is per session id; serializing unrelated sessions would
-    // rebuild the head-of-line blocking this change exists to remove.
+    // Global serialization would recreate the cross-session stall.
     expect(maxConcurrent).toBe(2)
 
     await host.dispose()
+  })
+
+  it('waits for an in-flight spawn before disposing its session', async () => {
+    let releaseSpawn: () => void = () => {}
+    const spawnGate = new Promise<void>((resolve) => {
+      releaseSpawn = resolve
+    })
+    const subprocess = mockSubprocess()
+    const host = new TerminalHost({
+      spawnSubprocess: async () => {
+        await spawnGate
+        return subprocess
+      }
+    })
+
+    const creation = host.createOrAttach(createOptions('shutdown-race'))
+    const disposal = host.dispose()
+    let disposed = false
+    void disposal.then(() => {
+      disposed = true
+    })
+
+    await Promise.resolve()
+    expect(disposed).toBe(false)
+
+    releaseSpawn()
+    await creation
+    await disposal
+
+    expect(subprocess.forceKill).toHaveBeenCalledOnce()
+    expect(host.listSessions()).toEqual([])
+  })
+
+  it('fences a queued retry when shutdown overlaps a failed spawn', async () => {
+    let rejectSpawn: () => void = () => {}
+    const spawnGate = new Promise<void>((_resolve, reject) => {
+      rejectSpawn = () => reject(new Error('spawn failed'))
+    })
+    const spawnSubprocess = vi
+      .fn<() => Promise<SubprocessHandle>>()
+      .mockImplementationOnce(async () => {
+        await spawnGate
+        return mockSubprocess()
+      })
+      .mockImplementation(async () => mockSubprocess())
+    const host = new TerminalHost({ spawnSubprocess })
+
+    const first = host.createOrAttach(createOptions('shutdown-retry'))
+    const queued = host.createOrAttach(createOptions('shutdown-retry'))
+    const disposal = host.dispose()
+    rejectSpawn()
+
+    await expect(first).rejects.toThrow('spawn failed')
+    await expect(queued).rejects.toThrow('Terminal host is shutting down')
+    await disposal
+
+    expect(spawnSubprocess).toHaveBeenCalledOnce()
+    expect(host.listSessions()).toEqual([])
   })
 })

--- a/src/main/daemon/terminal-host-options.ts
+++ b/src/main/daemon/terminal-host-options.ts
@@ -17,8 +17,8 @@ export type TerminalHostOptions = {
     shellOverride?: string
     terminalWindowsWslDistro?: string | null
     terminalWindowsPowerShellImplementation?: 'auto' | 'powershell.exe' | 'pwsh.exe'
-    // Why the union: cwd validation is async so an unreachable share cannot block
-    // the daemon's RPC loop (STA-4470). Sync test stubs still satisfy the await.
+    isCanceled?: () => boolean
+    // Async production spawns and sync test stubs share this boundary.
   }) => SubprocessHandle | Promise<SubprocessHandle>
   // Why: login-session death detection (#7936) needs subprocess exits even when no client is attached.
   onSessionReaped?: (sessionId: string) => void

--- a/src/main/daemon/terminal-host-options.ts
+++ b/src/main/daemon/terminal-host-options.ts
@@ -17,7 +17,9 @@ export type TerminalHostOptions = {
     shellOverride?: string
     terminalWindowsWslDistro?: string | null
     terminalWindowsPowerShellImplementation?: 'auto' | 'powershell.exe' | 'pwsh.exe'
-  }) => SubprocessHandle
+    // Why the union: cwd validation is async so an unreachable share cannot block
+    // the daemon's RPC loop (STA-4470). Sync test stubs still satisfy the await.
+  }) => SubprocessHandle | Promise<SubprocessHandle>
   // Why: login-session death detection (#7936) needs subprocess exits even when no client is attached.
   onSessionReaped?: (sessionId: string) => void
   // Why: graceful shutdown checkpoints must finish in-process before teardown.

--- a/src/main/daemon/terminal-host-session-create.ts
+++ b/src/main/daemon/terminal-host-session-create.ts
@@ -10,6 +10,7 @@ import type { TerminalHostOptions } from './terminal-host-options'
 import type { TerminalHostTombstones } from './terminal-host-tombstones'
 import type { TerminalSessionTeardown } from './terminal-session-teardown'
 import { resolveDaemonSessionScrollbackRows } from './daemon-session-scrollback-window'
+import { TerminalAttachCanceledError } from './daemon-errors'
 import { SessionNotFoundError } from './types'
 import { resolveWslSessionContext } from './wsl-session-context'
 
@@ -18,35 +19,15 @@ type TerminalHostSessionCreateDependencies = {
   sessionTeardown: TerminalSessionTeardown
   killedTombstones: TerminalHostTombstones
   spawnSubprocess: TerminalHostOptions['spawnSubprocess']
-  creationFenced: boolean
   onDeadSessionRemoved: (sessionId: string) => void
   onSessionCreated: (sessionId: string, generation: string | undefined, isAlive: boolean) => void
   onSessionExit: (sessionId: string, generation: string | undefined) => void
-  /** In-flight spawns, keyed by session id. Owned by TerminalHost. */
-  pendingCreations: Map<string, Promise<void>>
 }
 
 export async function createOrAttachTerminalSession(
   opts: InternalCreateOrAttachOptions,
   deps: TerminalHostSessionCreateDependencies
 ): Promise<CreateOrAttachResult> {
-  if (deps.creationFenced) {
-    throw new Error('Terminal host is shutting down')
-  }
-  // Why: spawnSubprocess became async so cwd validation cannot block the
-  // daemon's RPC loop (STA-4470). That await sits between the "already exists?"
-  // check below and the sessions.set that publishes the result, so without this
-  // gate two concurrent createOrAttach calls for one session id would both pass
-  // the check and spawn two shells behind a single id.
-  for (
-    let inFlight = deps.pendingCreations.get(opts.sessionId);
-    inFlight !== undefined;
-    inFlight = deps.pendingCreations.get(opts.sessionId)
-  ) {
-    // The loser attaches to whatever the winner published; a failed spawn just
-    // lets this caller try again itself.
-    await inFlight.catch(() => {})
-  }
   opts.onSessionResolved?.(opts.sessionId)
   const existing = deps.sessions.get(opts.sessionId)
 
@@ -91,19 +72,7 @@ export async function createOrAttachTerminalSession(
   deps.killedTombstones.clearForCreate(opts.sessionId)
   const size = normalizePtySize(opts.cols, opts.rows)
   const wslDistro = resolveWslSessionContext(opts)?.distro
-  let settleCreation: () => void = () => {}
-  deps.pendingCreations.set(
-    opts.sessionId,
-    new Promise<void>((resolve) => {
-      settleCreation = resolve
-    })
-  )
-  try {
-    return await spawnAndPublishSession(opts, deps, { size, wslDistro })
-  } finally {
-    deps.pendingCreations.delete(opts.sessionId)
-    settleCreation()
-  }
+  return await spawnAndPublishSession(opts, deps, { size, wslDistro })
 }
 
 async function spawnAndPublishSession(
@@ -124,7 +93,8 @@ async function spawnAndPublishSession(
     ...(opts.launchAgent ? { launchAgent: opts.launchAgent } : {}),
     shellOverride: opts.shellOverride,
     terminalWindowsWslDistro: opts.terminalWindowsWslDistro,
-    terminalWindowsPowerShellImplementation: opts.terminalWindowsPowerShellImplementation
+    terminalWindowsPowerShellImplementation: opts.terminalWindowsPowerShellImplementation,
+    isCanceled: opts.isCanceled
   })
 
   // Why: a fallback shell does not emit the preferred shell's ready marker;
@@ -154,6 +124,18 @@ async function spawnAndPublishSession(
       ? { shellReadyTimeoutMs: opts.shellReadyTimeoutMs }
       : {})
   })
+
+  if (opts.isCanceled?.()) {
+    // Retain cleanup ownership if the native child refuses to exit.
+    deps.sessions.set(opts.sessionId, session)
+    await session.forceKillAndDisposeSubprocess()
+    if (deps.sessions.get(opts.sessionId) === session) {
+      session.dispose()
+      deps.sessions.delete(opts.sessionId)
+      deps.onDeadSessionRemoved(opts.sessionId)
+    }
+    throw new TerminalAttachCanceledError(opts.sessionId)
+  }
 
   deps.sessions.set(opts.sessionId, session)
   deps.onSessionCreated(opts.sessionId, opts.agentSessionGeneration, session.isAlive)

--- a/src/main/daemon/terminal-host-session-create.ts
+++ b/src/main/daemon/terminal-host-session-create.ts
@@ -22,6 +22,8 @@ type TerminalHostSessionCreateDependencies = {
   onDeadSessionRemoved: (sessionId: string) => void
   onSessionCreated: (sessionId: string, generation: string | undefined, isAlive: boolean) => void
   onSessionExit: (sessionId: string, generation: string | undefined) => void
+  /** In-flight spawns, keyed by session id. Owned by TerminalHost. */
+  pendingCreations: Map<string, Promise<void>>
 }
 
 export async function createOrAttachTerminalSession(
@@ -30,6 +32,20 @@ export async function createOrAttachTerminalSession(
 ): Promise<CreateOrAttachResult> {
   if (deps.creationFenced) {
     throw new Error('Terminal host is shutting down')
+  }
+  // Why: spawnSubprocess became async so cwd validation cannot block the
+  // daemon's RPC loop (STA-4470). That await sits between the "already exists?"
+  // check below and the sessions.set that publishes the result, so without this
+  // gate two concurrent createOrAttach calls for one session id would both pass
+  // the check and spawn two shells behind a single id.
+  for (
+    let inFlight = deps.pendingCreations.get(opts.sessionId);
+    inFlight !== undefined;
+    inFlight = deps.pendingCreations.get(opts.sessionId)
+  ) {
+    // The loser attaches to whatever the winner published; a failed spawn just
+    // lets this caller try again itself.
+    await inFlight.catch(() => {})
   }
   opts.onSessionResolved?.(opts.sessionId)
   const existing = deps.sessions.get(opts.sessionId)
@@ -75,7 +91,28 @@ export async function createOrAttachTerminalSession(
   deps.killedTombstones.clearForCreate(opts.sessionId)
   const size = normalizePtySize(opts.cols, opts.rows)
   const wslDistro = resolveWslSessionContext(opts)?.distro
-  const subprocess = deps.spawnSubprocess({
+  let settleCreation: () => void = () => {}
+  deps.pendingCreations.set(
+    opts.sessionId,
+    new Promise<void>((resolve) => {
+      settleCreation = resolve
+    })
+  )
+  try {
+    return await spawnAndPublishSession(opts, deps, { size, wslDistro })
+  } finally {
+    deps.pendingCreations.delete(opts.sessionId)
+    settleCreation()
+  }
+}
+
+async function spawnAndPublishSession(
+  opts: InternalCreateOrAttachOptions,
+  deps: TerminalHostSessionCreateDependencies,
+  ctx: { size: { cols: number; rows: number }; wslDistro: string | undefined }
+): Promise<CreateOrAttachResult> {
+  const { size, wslDistro } = ctx
+  const subprocess = await deps.spawnSubprocess({
     sessionId: opts.sessionId,
     cols: size.cols,
     rows: size.rows,

--- a/src/main/daemon/terminal-host.ts
+++ b/src/main/daemon/terminal-host.ts
@@ -25,6 +25,9 @@ const DEFAULT_MAX_TOMBSTONES = 1000
 
 export class TerminalHost {
   private sessions = new Map<string, Session>()
+  // Why: serializes concurrent creates for one session id across the async
+  // spawn (see terminal-host-session-create).
+  private pendingCreations = new Map<string, Promise<void>>()
   private sessionTeardown = new TerminalSessionTeardown(this.sessions)
   private killedTombstones: TerminalHostTombstones
   private spawnSubprocess: TerminalHostOptions['spawnSubprocess']
@@ -59,6 +62,7 @@ export class TerminalHost {
         }
         const result = await createOrAttachTerminalSession(options, {
           sessions: this.sessions,
+          pendingCreations: this.pendingCreations,
           sessionTeardown: this.sessionTeardown,
           killedTombstones: this.killedTombstones,
           spawnSubprocess: this.spawnSubprocess,

--- a/src/main/daemon/terminal-host.ts
+++ b/src/main/daemon/terminal-host.ts
@@ -5,18 +5,22 @@ import {
   type TakePendingOutputResult,
   type TerminalSnapshot
 } from './types'
-import type { CreateOrAttachOptions, CreateOrAttachResult } from './terminal-host-create-contract'
+import type { CreateOrAttachResult } from './terminal-host-create-contract'
 import type { TerminalHostOptions } from './terminal-host-options'
 import { shutdownTerminalHostSessions } from './terminal-host-session-shutdown'
 import { TerminalSessionTeardown } from './terminal-session-teardown'
 import { ClaimedAgentPtyOwnerRegistry } from '../../shared/claimed-agent-pty-owner'
-import { createOrAttachClaimedAgentSession } from './terminal-host-agent-session-claim'
+import {
+  createOrAttachClaimedAgentSession,
+  type InternalCreateOrAttachOptions
+} from './terminal-host-agent-session-claim'
 import { TerminalHostAgentSessionGenerations } from './terminal-host-agent-session-generations'
 import { resolveTerminalHostSessionCwd } from './terminal-host-session-cwd'
 import { TerminalHostTombstones } from './terminal-host-tombstones'
 import { listLiveTerminalHostSessions } from './terminal-host-session-listing'
 import { createOrAttachTerminalSession } from './terminal-host-session-create'
 import { isShellProcess } from '../../shared/agent-detection'
+import { TerminalAttachCanceledError } from './daemon-errors'
 
 export type { CreateOrAttachOptions, CreateOrAttachResult } from './terminal-host-create-contract'
 export type { TerminalHostOptions } from './terminal-host-options'
@@ -25,8 +29,7 @@ const DEFAULT_MAX_TOMBSTONES = 1000
 
 export class TerminalHost {
   private sessions = new Map<string, Session>()
-  // Why: serializes concurrent creates for one session id across the async
-  // spawn (see terminal-host-session-create).
+  // Serializes creates for one id across async spawn validation.
   private pendingCreations = new Map<string, Promise<void>>()
   private sessionTeardown = new TerminalSessionTeardown(this.sessions)
   private killedTombstones: TerminalHostTombstones
@@ -47,38 +50,67 @@ export class TerminalHost {
     this.killedTombstones = new TerminalHostTombstones(this.maxTombstones)
   }
 
-  async createOrAttach(opts: CreateOrAttachOptions): Promise<CreateOrAttachResult> {
-    return await createOrAttachClaimedAgentSession({
-      options: opts,
-      owners: this.agentSessionOwners,
-      isLive: (owner) =>
-        this.agentSessionGenerations.isCurrent(
-          owner,
-          Boolean(this.sessions.get(owner.ptyId)?.isAlive)
-        ),
-      createOrAttach: async (options) => {
-        if (options.agentSessionGeneration && this.sessions.get(options.sessionId)?.isAlive) {
-          throw new Error('agent_session_claim_unavailable')
-        }
-        const result = await createOrAttachTerminalSession(options, {
-          sessions: this.sessions,
-          pendingCreations: this.pendingCreations,
-          sessionTeardown: this.sessionTeardown,
-          killedTombstones: this.killedTombstones,
-          spawnSubprocess: this.spawnSubprocess,
-          creationFenced: this.creationFenced,
-          onDeadSessionRemoved: (sessionId) => this.agentSessionGenerations.forget(sessionId),
-          onSessionCreated: (sessionId, generation, isAlive) =>
-            this.agentSessionGenerations.remember(sessionId, generation, isAlive),
-          onSessionExit: (sessionId, generation) => {
-            this.agentSessionOwners.release(sessionId, generation)
-            this.agentSessionGenerations.forget(sessionId, generation)
-            this.reapSession(sessionId)
+  async createOrAttach(opts: InternalCreateOrAttachOptions): Promise<CreateOrAttachResult> {
+    this.assertCreateOrAttachAllowed(opts)
+    for (
+      let inFlight = this.pendingCreations.get(opts.sessionId);
+      inFlight !== undefined;
+      inFlight = this.pendingCreations.get(opts.sessionId)
+    ) {
+      await inFlight
+    }
+    this.assertCreateOrAttachAllowed(opts)
+
+    let settleCreation: () => void = () => {}
+    this.pendingCreations.set(
+      opts.sessionId,
+      new Promise<void>((resolve) => {
+        settleCreation = resolve
+      })
+    )
+    try {
+      return await createOrAttachClaimedAgentSession({
+        options: opts,
+        owners: this.agentSessionOwners,
+        isLive: (owner) =>
+          this.agentSessionGenerations.isCurrent(
+            owner,
+            Boolean(this.sessions.get(owner.ptyId)?.isAlive)
+          ),
+        createOrAttach: async (options) => {
+          this.assertCreateOrAttachAllowed(options)
+          if (options.agentSessionGeneration && this.sessions.get(options.sessionId)?.isAlive) {
+            throw new Error('agent_session_claim_unavailable')
           }
-        })
-        return result
-      }
-    })
+          return await createOrAttachTerminalSession(options, {
+            sessions: this.sessions,
+            sessionTeardown: this.sessionTeardown,
+            killedTombstones: this.killedTombstones,
+            spawnSubprocess: this.spawnSubprocess,
+            onDeadSessionRemoved: (sessionId) => this.agentSessionGenerations.forget(sessionId),
+            onSessionCreated: (sessionId, generation, isAlive) =>
+              this.agentSessionGenerations.remember(sessionId, generation, isAlive),
+            onSessionExit: (sessionId, generation) => {
+              this.agentSessionOwners.release(sessionId, generation)
+              this.agentSessionGenerations.forget(sessionId, generation)
+              this.reapSession(sessionId)
+            }
+          })
+        }
+      })
+    } finally {
+      this.pendingCreations.delete(opts.sessionId)
+      settleCreation()
+    }
+  }
+
+  private assertCreateOrAttachAllowed(opts: InternalCreateOrAttachOptions): void {
+    if (this.creationFenced) {
+      throw new Error('Terminal host is shutting down')
+    }
+    if (opts.isCanceled?.()) {
+      throw new TerminalAttachCanceledError(opts.sessionId)
+    }
   }
 
   write(sessionId: string, data: string): void {
@@ -245,6 +277,10 @@ export class TerminalHost {
   }
 
   private async disposeSessions(): Promise<void> {
+    if (this.pendingCreations.size > 0) {
+      // No spawn may publish a session after teardown completes.
+      await Promise.all(this.pendingCreations.values())
+    }
     await shutdownTerminalHostSessions(this.sessions, this.onFinalCheckpoint)
     this.killedTombstones.clear()
   }

--- a/src/main/daemon/types.ts
+++ b/src/main/daemon/types.ts
@@ -26,6 +26,7 @@ export type { TerminalSnapshot } from './terminal-snapshot'
 export {
   AGENT_SESSION_CLAIM_DAEMON_PROTOCOL_VERSION,
   AGENT_SESSION_CREATE_OPERATION_DAEMON_PROTOCOL_VERSION,
+  ASYNC_CWD_VALIDATION_DAEMON_PROTOCOL_VERSION,
   CLEAN_DISCONNECT_PROTOCOL_VERSION,
   COMPLETION_PROCESS_INSPECTION_PROTOCOL_VERSION,
   GET_FOREGROUND_PROCESS_PROTOCOL_VERSION,
@@ -85,6 +86,8 @@ export type CreateOrAttachRequest = {
     terminalWindowsPowerShellImplementation?: 'auto' | 'powershell.exe' | 'pwsh.exe'
     shellReadySupported?: boolean
     shellReadyTimeoutMs?: number
+    /** Server-side fence that prevents a client timeout from publishing an orphan PTY. */
+    cancelAfterMs?: number
     startupIngress?: PtyStartupIngressIntent
     agentSessionEnsure?: {
       claim: AgentSessionExecutionClaim
@@ -102,7 +105,7 @@ export type CloseStartupQueryAuthorityRequest = {
 export type CancelCreateOrAttachRequest = {
   id: string
   type: 'cancelCreateOrAttach'
-  payload: { sessionId: string }
+  payload: { sessionId: string; requestId?: string }
 }
 
 export type WriteRequest = {

--- a/src/main/providers/local-pty-utils.ts
+++ b/src/main/providers/local-pty-utils.ts
@@ -1,9 +1,10 @@
 import { basename, isAbsolute, join } from 'node:path'
 import { existsSync, accessSync, statSync, chmodSync, constants as fsConstants } from 'node:fs'
+import { stat } from 'node:fs/promises'
 import { release } from 'node:os'
 import type * as pty from 'node-pty'
 import { isWslUncPath } from '../../shared/wsl-paths'
-import { wslUncDirectoryExists } from '../wsl'
+import { wslUncDirectoryExists, wslUncDirectoryExistsAsync } from '../wsl'
 import { wrapShellSpawnForMacosTccAttribution } from './macos-tcc-login-shell'
 
 let didEnsureSpawnHelperExecutable = false
@@ -145,6 +146,42 @@ export function validateWorkingDirectory(cwd: string): void {
     throwMissingWorkingDirectory(cwd)
   }
   if (!statSync(cwd).isDirectory()) {
+    throw new Error(`Working directory "${cwd}" is not a directory.`)
+  }
+}
+
+/**
+ * Async twin of {@link validateWorkingDirectory}, for callers on a shared event
+ * loop.
+ *
+ * Why this exists: the sync version blocks the calling thread for as long as the
+ * filesystem takes to answer. Measured on Windows, `existsSync` against an
+ * unreachable UNC share blocks ~21s and `wsl.exe` costs ~1.3s on a cold distro.
+ * In the terminal daemon that freezes the whole RPC loop, so every other
+ * terminal stalls behind one unreachable workspace and clients hit their 30s
+ * request ceiling (STA-4470). Off the daemon, the sync version is still fine.
+ */
+export async function validateWorkingDirectoryAsync(cwd: string): Promise<void> {
+  if (isWslUncPath(cwd)) {
+    const existsInDistro = await wslUncDirectoryExistsAsync(cwd)
+    if (existsInDistro === false) {
+      throwMissingWorkingDirectory(cwd)
+    }
+    if (existsInDistro === true) {
+      return
+    }
+  }
+
+  let stats: Awaited<ReturnType<typeof stat>>
+  try {
+    stats = await stat(cwd)
+  } catch {
+    // Why one stat, not exists-then-stat: the sync path pays the filesystem
+    // timeout twice against an unreachable share. ENOENT and an unreachable
+    // host are indistinguishable here, which matches the sync behaviour.
+    throwMissingWorkingDirectory(cwd)
+  }
+  if (!stats.isDirectory()) {
     throw new Error(`Working directory "${cwd}" is not a directory.`)
   }
 }

--- a/src/main/providers/local-pty-utils.ts
+++ b/src/main/providers/local-pty-utils.ts
@@ -8,6 +8,7 @@ import { wslUncDirectoryExists, wslUncDirectoryExistsAsync } from '../wsl'
 import { wrapShellSpawnForMacosTccAttribution } from './macos-tcc-login-shell'
 
 let didEnsureSpawnHelperExecutable = false
+const pendingWorkingDirectoryValidations = new Map<string, Promise<void>>()
 
 const UNIX_SHELL_FALLBACKS = ['/bin/zsh', '/bin/bash', '/bin/sh'] as const
 
@@ -150,18 +151,25 @@ export function validateWorkingDirectory(cwd: string): void {
   }
 }
 
-/**
- * Async twin of {@link validateWorkingDirectory}, for callers on a shared event
- * loop.
- *
- * Why this exists: the sync version blocks the calling thread for as long as the
- * filesystem takes to answer. Measured on Windows, `existsSync` against an
- * unreachable UNC share blocks ~21s and `wsl.exe` costs ~1.3s on a cold distro.
- * In the terminal daemon that freezes the whole RPC loop, so every other
- * terminal stalls behind one unreachable workspace and clients hit their 30s
- * request ceiling (STA-4470). Off the daemon, the sync version is still fine.
- */
-export async function validateWorkingDirectoryAsync(cwd: string): Promise<void> {
+/** Validate a cwd without blocking the daemon's shared event loop. */
+export function validateWorkingDirectoryAsync(cwd: string): Promise<void> {
+  const key = cwd
+  const pending = pendingWorkingDirectoryValidations.get(key)
+  if (pending) {
+    return pending
+  }
+  const validation = validateWorkingDirectoryUncached(cwd)
+  pendingWorkingDirectoryValidations.set(key, validation)
+  const forget = (): void => {
+    if (pendingWorkingDirectoryValidations.get(key) === validation) {
+      pendingWorkingDirectoryValidations.delete(key)
+    }
+  }
+  void validation.then(forget, forget)
+  return validation
+}
+
+async function validateWorkingDirectoryUncached(cwd: string): Promise<void> {
   if (isWslUncPath(cwd)) {
     const existsInDistro = await wslUncDirectoryExistsAsync(cwd)
     if (existsInDistro === false) {
@@ -176,9 +184,7 @@ export async function validateWorkingDirectoryAsync(cwd: string): Promise<void> 
   try {
     stats = await stat(cwd)
   } catch {
-    // Why one stat, not exists-then-stat: the sync path pays the filesystem
-    // timeout twice against an unreachable share. ENOENT and an unreachable
-    // host are indistinguishable here, which matches the sync behaviour.
+    // One stat avoids paying an unreachable filesystem timeout twice.
     throwMissingWorkingDirectory(cwd)
   }
   if (!stats.isDirectory()) {

--- a/src/main/providers/working-directory-validation.test.ts
+++ b/src/main/providers/working-directory-validation.test.ts
@@ -1,0 +1,92 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const wslUncDirectoryExistsAsyncMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../wsl', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return { ...actual, wslUncDirectoryExistsAsync: wslUncDirectoryExistsAsyncMock }
+})
+
+import { validateWorkingDirectoryAsync } from './local-pty-utils'
+
+let tempDir: string
+
+beforeEach(async () => {
+  wslUncDirectoryExistsAsyncMock.mockReset()
+  wslUncDirectoryExistsAsyncMock.mockResolvedValue(null)
+  tempDir = await mkdtemp(path.join(os.tmpdir(), 'orca-cwd-validate-'))
+})
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true })
+})
+
+describe('validateWorkingDirectoryAsync', () => {
+  it('accepts an existing directory', async () => {
+    await expect(validateWorkingDirectoryAsync(tempDir)).resolves.toBeUndefined()
+  })
+
+  it('rejects a missing directory with the actionable unmounted-volume message', async () => {
+    await expect(validateWorkingDirectoryAsync(path.join(tempDir, 'gone'))).rejects.toThrow(
+      /does not exist.*unmounted volume/s
+    )
+  })
+
+  it('rejects a path that exists but is a file', async () => {
+    const filePath = path.join(tempDir, 'not-a-dir.txt')
+    await writeFile(filePath, 'x')
+
+    await expect(validateWorkingDirectoryAsync(filePath)).rejects.toThrow('is not a directory')
+  })
+
+  it('never blocks the event loop while the filesystem answers', async () => {
+    // Why this test exists: the sync twin blocks ~21s on an unreachable UNC
+    // share, which froze the daemon's whole RPC loop (STA-4470). Proving the
+    // loop still turns is the actual regression guard.
+    let ticked = false
+    const pending = validateWorkingDirectoryAsync(tempDir)
+    setImmediate(() => {
+      ticked = true
+    })
+
+    await pending
+
+    expect(ticked).toBe(true)
+  })
+
+  describe('WSL UNC paths', () => {
+    const wslPath = '\\\\wsl.localhost\\Ubuntu\\home\\jin\\repo'
+
+    beforeEach(() => {
+      vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('asks the distro asynchronously and accepts its yes', async () => {
+      wslUncDirectoryExistsAsyncMock.mockResolvedValue(true)
+
+      await expect(validateWorkingDirectoryAsync(wslPath)).resolves.toBeUndefined()
+      expect(wslUncDirectoryExistsAsyncMock).toHaveBeenCalledWith(wslPath)
+    })
+
+    it(`rejects on the distro no without falling back to a Win32 stat`, async () => {
+      wslUncDirectoryExistsAsyncMock.mockResolvedValue(false)
+
+      await expect(validateWorkingDirectoryAsync(wslPath)).rejects.toThrow(/does not exist/)
+    })
+
+    it('falls back to the filesystem when the distro probe is inconclusive', async () => {
+      // Win32 stat against the 9P share is unreliable, so null must not be a no.
+      wslUncDirectoryExistsAsyncMock.mockResolvedValue(null)
+
+      await expect(validateWorkingDirectoryAsync(wslPath)).rejects.toThrow(/does not exist/)
+      expect(wslUncDirectoryExistsAsyncMock).toHaveBeenCalledOnce()
+    })
+  })
+})

--- a/src/main/providers/working-directory-validation.test.ts
+++ b/src/main/providers/working-directory-validation.test.ts
@@ -43,9 +43,7 @@ describe('validateWorkingDirectoryAsync', () => {
   })
 
   it('never blocks the event loop while the filesystem answers', async () => {
-    // Why this test exists: the sync twin blocks ~21s on an unreachable UNC
-    // share, which froze the daemon's whole RPC loop (STA-4470). Proving the
-    // loop still turns is the actual regression guard.
+    // A dead UNC share must not freeze unrelated daemon RPCs (STA-4470).
     let ticked = false
     const pending = validateWorkingDirectoryAsync(tempDir)
     setImmediate(() => {
@@ -75,6 +73,35 @@ describe('validateWorkingDirectoryAsync', () => {
       expect(wslUncDirectoryExistsAsyncMock).toHaveBeenCalledWith(wslPath)
     })
 
+    it('shares one in-flight probe for the same working directory', async () => {
+      let releaseProbe: () => void = () => {}
+      wslUncDirectoryExistsAsyncMock.mockReturnValue(
+        new Promise<boolean>((resolve) => {
+          releaseProbe = () => resolve(true)
+        })
+      )
+
+      const first = validateWorkingDirectoryAsync(wslPath)
+      const second = validateWorkingDirectoryAsync(wslPath)
+      expect(wslUncDirectoryExistsAsyncMock).toHaveBeenCalledOnce()
+
+      releaseProbe()
+      await expect(Promise.all([first, second])).resolves.toEqual([undefined, undefined])
+    })
+
+    it('keeps byte-distinct working directories in separate probes', async () => {
+      wslUncDirectoryExistsAsyncMock.mockResolvedValue(true)
+      const decomposedPath = `${wslPath}-e\u0301`
+      const composedPath = `${wslPath}-\u00e9`
+
+      await Promise.all([
+        validateWorkingDirectoryAsync(decomposedPath),
+        validateWorkingDirectoryAsync(composedPath)
+      ])
+
+      expect(wslUncDirectoryExistsAsyncMock).toHaveBeenCalledTimes(2)
+    })
+
     it(`rejects on the distro no without falling back to a Win32 stat`, async () => {
       wslUncDirectoryExistsAsyncMock.mockResolvedValue(false)
 
@@ -82,7 +109,7 @@ describe('validateWorkingDirectoryAsync', () => {
     })
 
     it('falls back to the filesystem when the distro probe is inconclusive', async () => {
-      // Win32 stat against the 9P share is unreliable, so null must not be a no.
+      // An inconclusive guest probe is not proof that the directory is missing.
       wslUncDirectoryExistsAsyncMock.mockResolvedValue(null)
 
       await expect(validateWorkingDirectoryAsync(wslPath)).rejects.toThrow(/does not exist/)

--- a/src/shared/local-build-compatibility-contract.json
+++ b/src/shared/local-build-compatibility-contract.json
@@ -3,9 +3,9 @@
   "appId": "com.stablyai.orca",
   "stateSchemaVersion": 1,
   "readableStateSchemaVersions": [1],
-  "daemonProtocolVersion": 34,
+  "daemonProtocolVersion": 35,
   "attachableDaemonProtocolVersions": [
     1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
-    27, 28, 29, 30, 31, 32, 33, 34
+    27, 28, 29, 30, 31, 32, 33, 34, 35
   ]
 }

--- a/src/shared/local-build-compatibility-contract.ts
+++ b/src/shared/local-build-compatibility-contract.ts
@@ -3,9 +3,9 @@ export const LOCAL_BUILD_COMPATIBILITY_CONTRACT = {
   appId: 'com.stablyai.orca',
   stateSchemaVersion: 1,
   readableStateSchemaVersions: [1],
-  daemonProtocolVersion: 34,
+  daemonProtocolVersion: 35,
   attachableDaemonProtocolVersions: [
     1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
-    27, 28, 29, 30, 31, 32, 33, 34
+    27, 28, 29, 30, 31, 32, 33, 34, 35
   ]
 } as const

--- a/tests/e2e/fixtures/daemon-generation-entry.ts
+++ b/tests/e2e/fixtures/daemon-generation-entry.ts
@@ -50,8 +50,8 @@ async function main(): Promise<void> {
     socketPath,
     tokenPath,
     log: createDaemonFileLog(logPath),
-    spawnSubprocess: (options) => {
-      const subprocess = createPtySubprocess(options)
+    spawnSubprocess: async (options) => {
+      const subprocess = await createPtySubprocess(options)
       if (refuseDispose) {
         // Why: models an access-denied/unreapable Windows PTY while keeping the
         // real child and ConPTY handle inside this disposable fixture tree.

--- a/tests/e2e/terminal-foreground-confirmation.unit.test.ts
+++ b/tests/e2e/terminal-foreground-confirmation.unit.test.ts
@@ -61,8 +61,8 @@ describe('daemon foreground confirmation composes with pane tracking', () => {
     }
   })
 
-  function createComposedTracker(publish: ReturnType<typeof vi.fn>) {
-    const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+  async function createComposedTracker(publish: ReturnType<typeof vi.fn>) {
+    const handle = await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
     const tracker = createPaneForegroundAgentTracker({
       getPtyId: () => 'pty-1',
       isTrackablePtyId: () => true,
@@ -82,7 +82,7 @@ describe('daemon foreground confirmation composes with pane tracking', () => {
       })
     )
     const publish = vi.fn()
-    const { tracker } = createComposedTracker(publish)
+    const { tracker } = await createComposedTracker(publish)
 
     tracker.onVisiblePtyBound(true)
     await vi.advanceTimersByTimeAsync(350)
@@ -103,7 +103,7 @@ describe('daemon foreground confirmation composes with pane tracking', () => {
     spawnMock.mockReturnValue(mockWindowsPty())
     resolveForegroundMock.mockResolvedValue('powershell.exe')
     const publish = vi.fn()
-    const { tracker } = createComposedTracker(publish)
+    const { tracker } = await createComposedTracker(publish)
 
     tracker.onCommandFinished()
     await vi.advanceTimersByTimeAsync(350)
@@ -119,7 +119,7 @@ describe('daemon foreground confirmation composes with pane tracking', () => {
       processName: 'powershell.exe'
     })
     const publish = vi.fn()
-    const { tracker } = createComposedTracker(publish)
+    const { tracker } = await createComposedTracker(publish)
 
     tracker.onCommandFinished()
     await vi.advanceTimersByTimeAsync(350 + 1_200 + 6_000)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 13 | +456 | −253 | +203 |
| Prod | 6 | +95 | −13 | +82 |

<!-- /orca-pr-loc -->

Closes STA-4470.

## Problem

`createOrAttach` validated the working directory synchronously on the daemon's shared event loop. On Windows 11, `existsSync` against an unreachable UNC share blocked for about 21 seconds; a cold `wsl.exe` probe took about 1.3 seconds. One dead workspace could therefore stall every terminal RPC and push unrelated creates past the client's 30-second request ceiling.

## Change

- Validate daemon spawn cwd asynchronously, using one `stat` instead of `exists` followed by `stat`.
- Deduplicate only byte-identical in-flight cwd probes; case- or Unicode-distinct filesystem paths remain independent.
- Serialize creates per session id while preserving parallel creates for distinct sessions.
- Carry request-scoped cancellation through validation, native spawn, publication, disconnect, kill, timeout, and shutdown.
- If cancellation arrives after publication, consume the committed create response instead of dropping ownership. If cancellation settlement itself fails, use the existing generation-fenced disconnect cleanup.
- Bump the daemon protocol to v35 so fresh sessions use the new lifecycle while preserved v34 sessions remain attachable.

The affected tab may still wait for the filesystem's accurate answer. The fix removes daemon-wide head-of-line blocking without guessing that a slow VPN mount is missing.

## Reliability contract

- **Invariant (`daemon-pty.spawn-admission-cleanup`):** a slow cwd probe cannot block unrelated daemon RPCs, and no canceled, disconnected, timed-out, or shutdown-fenced create can publish an unowned PTY.
- **Failure source:** STA-4470 plus the async lifecycle races found while reviewing this PR.
- **Oracle:** event-loop progress during cwd validation; same-id/different-id controlled spawn gates; request-scoped abort/timeout/kill/disconnect/shutdown tests; delayed post-publication response harness; v34-owner/v35-fresh routing tests.
- **Gate:** deterministic Vitest coverage in `working-directory-validation.test.ts`, `terminal-host-concurrent-create.test.ts`, `daemon-server-async-spawn-cancellation.test.ts`, and `daemon-client-rpc-request.test.ts`. The absence of a dedicated STA-4470 entry in `reliability-gates.jsonc` is an accepted residual gap for this PR.
- **Provider/platform coverage:** daemon/local lifecycle is covered deterministically; WSL UNC yes/no/inconclusive and byte-distinct paths are covered; existing POSIX semantics remain covered. SSH/relay, folder workspaces, and mobile-facing protocols are unchanged. Preserved v34 owners and fresh v35 routing are covered.
- **Performance budget:** distinct cwd probes remain parallel; identical probes share one promise; no polling, retry loop, subprocess fanout, listener, timer, or unbounded cache was added. Validation entries are removed on both resolve and reject.
- **Diagnostics:** existing daemon request/session logs retain the session id and cancellation/attach errors; focused tests expose ownership and pending-request counts.

## Verification

- `pnpm run typecheck`
- `pnpm lint` (including reliability manifest and max-lines ratchet)
- 1,530 daemon/provider/cross-version tests passed; 3 skipped
- Full repository run: 52,946 passed, 119 skipped
- A later full run after the final cancellation-settlement hardening completed with one unrelated `worktree-base-directory-poller.test.ts` timeout under parallel load; that exact 23-test file passed three consecutive isolated runs
- Independent final release review: CLEAN, no P0/P1/P2 findings
- Real in-memory delayed-response boundary: `sessions=1`, `preparations=0`, `canceled=false`, original create resolved, tracked sessions remained 1, pending requests returned to 0

## Residual gaps

- No physical dead-UNC or WSL-host end-to-end run was available locally.
- Live native Windows/Linux PTY, live SSH/relay/folder-workspace, simultaneous real v34/v35 daemon, and mobile journeys remain environment-dependent; Windows and packaging CI are required before merge.
- No dependency, lockfile, mobile/E2EE surface, runtime stream opcode, persisted user state, schema, or Git/provider behavior changed.
