### PR TITLE
fix(terminal): settle CLI prompts for cursor-agent

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -9739,13 +9739,13 @@
       "providers": ["local", "daemon", "ssh", "remote-runtime"],
       "coveredPlatforms": ["macos", "windows"],
       "coveredProviders": ["local"],
-      "coverageNotes": "Source-built macOS and physical Windows Electron journeys cover the public CLI through RPC, runtime identity, real PTY/ConPTY writes, and a delayed fake Codex composer. Focused units cover CLI intent, fresh Claude/Codex foreground identity, framing bytes, stale-agent shell fallback, and exact legacy behavior for every other configured agent. SSH, daemon, and remote-runtime remain explicit gaps.",
+      "coverageNotes": "Source-built macOS and physical Windows Electron journeys cover the public CLI through RPC, runtime identity, real PTY/ConPTY writes, and a delayed fake Codex composer. Focused units cover CLI intent, fresh Claude/Codex/cursor-agent foreground identity, provider-unwrapped cursor-agent names, framing bytes, stale-agent shell fallback, no wrapper polling, and exact legacy behavior for every other configured agent. SSH, daemon, and remote-runtime remain explicit gaps.",
       "motivatingLinks": [
         "https://linear.app/stably/issue/STA-4328",
         "https://github.com/stablyai/orca/issues/14525"
       ],
-      "invariant": "A public CLI send containing non-empty text plus Enter and no interrupt identifies agent-prompt intent. The owning runtime uses bracketed-paste and settled submit only when a fresh foreground-process read positively identifies the exact target as Claude or Codex on a desktop call; every other agent, stale agent metadata over a shell, text-only input, bare Enter, interrupts, mobile input, query replies, and older clients keep the direct terminal contract.",
-      "oracle": "Launch a bare fake Codex through the real Electron PTY and delay its composer render for 1,200 ms, beyond the legacy generic 500 ms gap. Send a 557-byte prompt with the public CLI and require the marker, zero premature Enter, no rescue Enter, and one submission. POSIX child stdin must retain one bracketed-paste frame; Windows ConPTY consumes that control frame, so runtime tests require the frame at the PTY write boundary while the Windows child requires the exact prompt. The same harness against the installed pre-fix runtime must record one premature Enter and require one bare rescue Enter. Focused units require CLI intent only for text plus Enter, settlement only for freshly identified Claude/Codex, the legacy platform delay for every other configured agent, stale Codex launch identity over a shell to fall back, no wrapper polling, and byte-for-byte direct delivery for non-targets.",
+      "invariant": "A public CLI send containing non-empty text plus Enter and no interrupt identifies agent-prompt intent. The owning runtime uses bracketed-paste and settled submit only when a fresh foreground-process read positively identifies the exact target as Claude, Codex, or cursor-agent on a desktop call; every other agent, unresolved node wrappers, stale agent metadata over a shell, text-only input, bare Enter, interrupts, mobile input, query replies, and older clients keep the direct terminal contract.",
+      "oracle": "Launch a bare fake Codex through the real Electron PTY and delay its composer render for 1,200 ms, beyond the legacy generic 500 ms gap. Send a 557-byte prompt with the public CLI and require the marker, zero premature Enter, no rescue Enter, and one submission. POSIX child stdin must retain one bracketed-paste frame; Windows ConPTY consumes that control frame, so runtime tests require the frame at the PTY write boundary while the Windows child requires the exact prompt. The same harness against the installed pre-fix runtime must record one premature Enter and require one bare rescue Enter. Focused units require CLI intent only for text plus Enter, settlement only for freshly identified Claude/Codex/cursor-agent, the legacy platform delay for every other configured agent, stale Codex launch identity over a shell to fall back, no wrapper polling even when a Cursor title sits behind node, and byte-for-byte direct delivery for non-targets.",
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/cli/handlers/terminal.test.ts src/main/runtime/rpc/terminal-agent-prompt-send.test.ts src/main/runtime/rpc/terminal-send.test.ts src/main/runtime/orca-runtime.test.ts src/shared/agent-prompt-injection.test.ts",
         "pnpm run build:cli && pnpm exec playwright test tests/e2e/terminal-send-agent-prompt-submit.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
@@ -9772,16 +9772,17 @@
         {
           "file": "src/main/runtime/rpc/terminal-agent-prompt-send.test.ts",
           "assertions": [
-            "a freshly proven Claude or Codex desktop target uses settled prompt delivery",
+            "a freshly proven Claude, Codex, or cursor-agent desktop target uses settled prompt delivery",
             "a non-target agent or shell preserves the existing direct send"
           ]
         },
         {
           "file": "src/main/runtime/orca-runtime.test.ts",
           "assertions": [
-            "Claude and Codex wait for marker-gated composer quiescence before submit",
+            "Claude, Codex, and cursor wait for marker-gated composer quiescence before submit",
             "every other configured TUI agent retains the legacy platform delay",
             "a speculative CLI prompt check does not poll wrapper foregrounds",
+            "a provider-unwrapped cursor-agent identity authorizes settlement without polling node",
             "the PTY write boundary retains bracketed framing and one delayed submit"
           ]
         },
@@ -9830,6 +9831,15 @@
           "result": "passed",
           "durationSeconds": 23.2,
           "summary": "After rebasing onto current main, the final narrowed runtime/CLI/RPC suite passed 1,201 tests with one skip, including fresh Claude/Codex identity, stale-agent shell fallback, and legacy timing for every other configured agent."
+        },
+        {
+          "date": "2026-08-16",
+          "runner": "local",
+          "platform": "windows",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/cli/handlers/terminal.test.ts src/main/runtime/rpc/terminal-agent-prompt-send.test.ts src/main/runtime/rpc/terminal-send.test.ts src/main/runtime/orca-runtime.test.ts src/shared/agent-prompt-injection.test.ts",
+          "result": "passed",
+          "durationSeconds": 18.38,
+          "summary": "Cursor follow-up mutant was red on main (provider-unwrapped cursor-agent identity returned false). After adding cursor to the settlement allowlist, the focused CLI/RPC/runtime suite passed 1,205 tests, including cursor marker-gated submit, stale Cursor shell fallback, and a single-shot node wrapper that stays on the legacy path."
         }
       ],
       "runtimeBudget": {
@@ -9846,7 +9856,7 @@
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "Only a CLI request with non-empty text plus Enter and no interrupt adds a bounded fresh foreground read and one non-retrying liveness check. Positively identified Claude and Codex reuse the O(prompt bytes) chunked prompt sender plus one PTY-local listener until post-marker quiescence or the bounded fallback. Every other agent and shell retains the existing direct-send path. Text-only, bare Enter, interrupt, mobile, renderer stream input, and query replies add no work."
+        "evidence": "Only a CLI request with non-empty text plus Enter and no interrupt adds a bounded fresh foreground read and one non-retrying liveness check. Positively identified Claude, Codex, and cursor-agent reuse the O(prompt bytes) chunked prompt sender plus one PTY-local listener until post-marker quiescence or the bounded fallback. Every other agent and shell retains the existing direct-send path. Text-only, bare Enter, interrupt, mobile, renderer stream input, and query replies add no work."
       },
       "promotionCriteria": [
         "Collect live Codex and Claude CLI sends on representative slow systems.",
@@ -9854,7 +9864,7 @@
       ],
       "knownGaps": [
         "Live SSH/daemon/remote-runtime evidence is not yet attached.",
-        "Only Claude and Codex opt into settlement; every other agent retains the legacy behavior until independently validated.",
+        "OpenCode and other non-target agents retain the legacy behavior until independently validated; unresolved node wrappers still fail open without polling.",
         "A new CLI talking to an old host safely loses the optional field and therefore keeps the old timing behavior until the host updates.",
         "The E2E fake agent models the submission race without requiring external agent authentication; live account-backed agents are covered separately."
       ],
@@ -9884,8 +9894,8 @@
         "https://github.com/stablyai/orca/issues/13821",
         "https://github.com/stablyai/orca/issues/14347"
       ],
-      "invariant": "Injected orchestration task prompts for recognized agent CLIs must send the prompt body inside one bracketed-paste frame, sanitize embedded ESC bytes, preserve chunk boundaries without losing the frame, and submit exactly once only after the agent can accept Enter. Claude and Codex must emit a post-paste composer marker and then settle, or reach the bounded fallback first; every other agent retains the platform delay.",
-      "oracle": "Runtime tests assert the exact PTY write sequence, failure cleanup, Claude/Codex marker-gated multi-frame renders, and the legacy platform delay for every other configured agent. The candidate resets settlement on later frames, gives a late marker a fresh bounded window, and still submits once at the hard deadline if output never settles. Orchestration tests assert dispatch/coordinator use the agent prompt path; the live CLI harness covers long Codex-like framing.",
+      "invariant": "Injected orchestration task prompts for recognized agent CLIs must send the prompt body inside one bracketed-paste frame, sanitize embedded ESC bytes, preserve chunk boundaries without losing the frame, and submit exactly once only after the agent can accept Enter. Claude, Codex, and cursor-agent must emit a post-paste composer marker and then settle, or reach the bounded fallback first; every other agent retains the platform delay.",
+      "oracle": "Runtime tests assert the exact PTY write sequence, failure cleanup, Claude/Codex/cursor marker-gated multi-frame renders, and the legacy platform delay for every other configured agent. The candidate resets settlement on later frames, gives a late marker a fresh bounded window, and still submits once at the hard deadline if output never settles. Orchestration tests assert dispatch/coordinator use the agent prompt path; the live CLI harness covers long Codex-like framing.",
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/shared/agent-prompt-injection.test.ts src/main/runtime/orca-runtime.test.ts src/main/runtime/rpc/methods/orchestration-tasks-dispatch.test.ts src/main/runtime/orchestration/coordinator.test.ts",
         "node tests/tools/repro-orchestration-long-prompt.mjs --cli out/bin/orca-dev --mode codex-like --size-kb 32 --timeout-ms 20000"
@@ -9911,7 +9921,7 @@
           "file": "src/main/runtime/orca-runtime.test.ts",
           "assertions": [
             "runtime writes bracketed paste before a delayed submit",
-            "Claude and Codex ignore unrelated and split pre-marker output, then wait for render quiescence before one submit",
+            "Claude, Codex, and cursor ignore unrelated and split pre-marker output, then wait for render quiescence before one submit",
             "every other configured TUI agent retains the platform delay",
             "a late Codex marker receives a fresh settlement window before one submit",
             "a silent Claude composer reaches one bounded fallback submit",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -9739,18 +9739,19 @@
       "providers": ["local", "daemon", "ssh", "remote-runtime"],
       "coveredPlatforms": ["macos", "windows"],
       "coveredProviders": ["local"],
-      "coverageNotes": "Source-built macOS and physical Windows Electron journeys cover the public CLI through RPC, runtime identity, real PTY/ConPTY writes, and a delayed fake Codex composer. Focused units cover CLI intent, fresh Claude/Codex/cursor-agent foreground identity, provider-unwrapped cursor-agent names, framing bytes, stale-agent shell fallback, no wrapper polling, and exact legacy behavior for every other configured agent. SSH, daemon, and remote-runtime remain explicit gaps.",
+      "coverageNotes": "Source-built macOS and physical Windows Electron journeys cover the public CLI through RPC, runtime identity, real PTY/ConPTY writes, and a delayed fake Codex composer. Focused units cover CLI intent, fresh Claude/Codex/cursor-agent foreground identity, provider-unwrapped cursor-agent names, framing bytes, stale-agent shell fallback, no wrapper polling, and exact legacy behavior for every other configured agent. One live Windows journey on b6842cc176 sent a 2,834-byte public CLI prompt to authenticated cursor-agent v2026.08.11-e8db854 through an isolated source-built runtime. SSH, daemon, and remote-runtime remain explicit gaps.",
       "motivatingLinks": [
         "https://linear.app/stably/issue/STA-4328",
         "https://github.com/stablyai/orca/issues/14525"
       ],
       "invariant": "A public CLI send containing non-empty text plus Enter and no interrupt identifies agent-prompt intent. The owning runtime uses bracketed-paste and settled submit only when a fresh foreground-process read positively identifies the exact target as Claude, Codex, or cursor-agent on a desktop call; every other agent, unresolved node wrappers, stale agent metadata over a shell, text-only input, bare Enter, interrupts, mobile input, query replies, and older clients keep the direct terminal contract.",
-      "oracle": "Launch a bare fake Codex through the real Electron PTY and delay its composer render for 1,200 ms, beyond the legacy generic 500 ms gap. Send a 557-byte prompt with the public CLI and require the marker, zero premature Enter, no rescue Enter, and one submission. POSIX child stdin must retain one bracketed-paste frame; Windows ConPTY consumes that control frame, so runtime tests require the frame at the PTY write boundary while the Windows child requires the exact prompt. The same harness against the installed pre-fix runtime must record one premature Enter and require one bare rescue Enter. Focused units require CLI intent only for text plus Enter, settlement only for freshly identified Claude/Codex/cursor-agent, the legacy platform delay for every other configured agent, stale Codex launch identity over a shell to fall back, no wrapper polling even when a Cursor title sits behind node, and byte-for-byte direct delivery for non-targets.",
+      "oracle": "Launch a bare fake Codex through the real Electron PTY and delay its composer render for 1,200 ms, beyond the legacy generic 500 ms gap. Send a 557-byte prompt with the public CLI and require the marker, zero premature Enter, no rescue Enter, and one submission. POSIX child stdin must retain one bracketed-paste frame; Windows ConPTY consumes that control frame, so runtime tests require the frame at the PTY write boundary while the Windows child requires the exact prompt. The same harness against the installed pre-fix runtime must record one premature Enter and require one bare rescue Enter. Focused units require CLI intent only for text plus Enter, settlement only for freshly identified Claude/Codex/cursor-agent, the legacy platform delay for every other configured agent, stale Codex launch identity over a shell to fall back, no wrapper polling even when a Cursor title sits behind node, and byte-for-byte direct delivery for non-targets. A separate live Windows journey launches authenticated cursor-agent in an isolated source-built runtime and requires one public CLI send, the 8s settlement fallback rather than the 1.5s legacy delay, one bracketed-paste frame, paste index #1, and a Working/Cursor Agent transition with no rescue Enter.",
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/cli/handlers/terminal.test.ts src/main/runtime/rpc/terminal-agent-prompt-send.test.ts src/main/runtime/rpc/terminal-send.test.ts src/main/runtime/orca-runtime.test.ts src/shared/agent-prompt-injection.test.ts",
         "pnpm run build:cli && pnpm exec playwright test tests/e2e/terminal-send-agent-prompt-submit.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
         "pnpm.cmd exec playwright test tests/e2e/terminal-send-agent-prompt-submit.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
-        "node tests/tools/repro-terminal-send-submit.mjs --cli orca --worktree <registered-worktree> --discard-report"
+        "node tests/tools/repro-terminal-send-submit.mjs --cli orca --worktree <registered-worktree> --discard-report",
+        "Isolated Windows source-built Electron plus public CLI: orca-dev terminal create --command cursor-agent --force --trust; orca-dev terminal wait --for tui-idle; orca-dev terminal send --text <2834-byte prompt> --enter"
       ],
       "testFiles": [
         "src/cli/handlers/terminal.test.ts",
@@ -9840,6 +9841,15 @@
           "result": "passed",
           "durationSeconds": 18.38,
           "summary": "Cursor follow-up mutant was red on main (provider-unwrapped cursor-agent identity returned false). After adding cursor to the settlement allowlist, the focused CLI/RPC/runtime suite passed 1,205 tests, including cursor marker-gated submit, stale Cursor shell fallback, and a single-shot node wrapper that stays on the legacy path."
+        },
+        {
+          "date": "2026-08-16",
+          "runner": "manual",
+          "platform": "windows",
+          "command": "Isolated Windows source-built Electron plus public CLI: orca-dev terminal create --command cursor-agent --force --trust; orca-dev terminal wait --for tui-idle; orca-dev terminal send --text <2834-byte prompt> --enter",
+          "result": "passed",
+          "durationSeconds": 134,
+          "summary": "Head b6842cc176 live authenticated cursor-agent v2026.08.11-e8db854: one 2,834-byte public CLI send accepted in 8.53s (settlement fallback, not the 1.5s Windows legacy delay), 2,847 bytes written (one bracketed-paste frame), PTY went idle composer to [Pasted text #1 +5 lines] plus Working/Cursor Agent, rescueSent=false. Packaged Orca 1.4.183 stayed on pid 34156 / runtimeId 8eb31102-4988-4a3d-8d0b-b74fac9cacf9. No live mutant was run against 1.4.183; CDP showed the landing page because the PTY was unfocused."
         }
       ],
       "runtimeBudget": {
@@ -9848,11 +9858,11 @@
       },
       "flakeHistory": {
         "status": "unknown",
-        "evidence": "The final oracle passed twice in independent macOS app launches and twice on physical Windows. A shared --repeat-each fixture mode failed before test execution because only one seeded worktree loaded; supported isolated invocations were used for product evidence. CI history is not yet collected."
+        "evidence": "The fake-composer oracle passed twice in independent macOS app launches and twice on physical Windows. One live authenticated cursor-agent Windows CLI send on b6842cc176 also submitted once with no rescue Enter. A shared --repeat-each fixture mode failed before test execution because only one seeded worktree loaded; supported isolated invocations were used for product evidence. CI history is not yet collected."
       },
       "redGreenEvidence": {
         "status": "partial",
-        "evidence": "The fake-composer oracle was red against the installed pre-fix runtime with prematureEnters=1 and rescueSent=true. It also caught a source-built late-identity race with a complete paste frame but one premature Enter before the render gate began resolving foreground identity. The final candidate is green on macOS and Windows with prematureEnters=0 and rescueSent=false."
+        "evidence": "The fake-composer oracle was red against the installed pre-fix runtime with prematureEnters=1 and rescueSent=true. It also caught a source-built late-identity race with a complete paste frame but one premature Enter before the render gate began resolving foreground identity. The final candidate is green on macOS and Windows with prematureEnters=0 and rescueSent=false. Focused cursor-agent units were red on main (provider-unwrapped cursor-agent identity returned false) and green after the allowlist change. A live authenticated cursor-agent Windows CLI send on b6842cc176 is green on the candidate (8.53s settlement fallback, one paste frame, Working, rescueSent=false). Packaged 1.4.183 was left untouched, so the live cursor mutant remains unrun."
       },
       "performanceBudget": {
         "required": true,
@@ -9866,7 +9876,8 @@
         "Live SSH/daemon/remote-runtime evidence is not yet attached.",
         "OpenCode and other non-target agents retain the legacy behavior until independently validated; unresolved node wrappers still fail open without polling.",
         "A new CLI talking to an old host safely loses the optional field and therefore keeps the old timing behavior until the host updates.",
-        "The E2E fake agent models the submission race without requiring external agent authentication; live account-backed agents are covered separately."
+        "The E2E fake agent models the Codex submission race without requiring external agent authentication; it does not launch a cursor-agent composer.",
+        "Live authenticated cursor-agent submit is proven on one isolated Windows CLI send at b6842cc176; CDP could not screenshot the unfocused PTY, the agent was still Working at teardown, and no live mutant was run against packaged 1.4.183."
       ],
       "demotionRule": "Keep experimental or demote to protection none if direct shell/mobile/query input is reframed, an unrecognized target receives bracketed paste, a prompt can emit duplicate Enter, mixed-version decoding rejects the optional field, or the deterministic fake-composer candidate requires a rescue send."
     },
@@ -9886,9 +9897,9 @@
       ],
       "platforms": ["macos", "linux", "windows"],
       "providers": ["local", "daemon", "ssh", "remote-runtime"],
-      "coveredPlatforms": ["macos"],
+      "coveredPlatforms": ["macos", "windows"],
       "coveredProviders": ["local"],
-      "coverageNotes": "Local macOS evidence covers the runtime PTY write contract, live Codex orchestration, a dev-runtime CLI repro, and Claude and Codex composer traces. The render gate stays on the PTY-owning runtime, so paired and SSH callers use the same provider write/output path without a wire change. SSH, daemon, remote-runtime, Linux, and Windows live journeys remain gaps.",
+      "coverageNotes": "Local macOS evidence covers the runtime PTY write contract, live Codex orchestration, a dev-runtime CLI repro, and Claude and Codex composer traces. After the cursor-agent allowlist change, the same focused runtime/orchestration suite also passed on Windows, including marker-gated Cursor submit. The render gate stays on the PTY-owning runtime, so paired and SSH callers use the same provider write/output path without a wire change. Live authenticated cursor-agent CLI send is recorded on terminal-input.cli-agent-prompt-submit; this gate's live orchestration dispatch, SSH, daemon, remote-runtime, and Linux journeys remain gaps.",
       "motivatingLinks": [
         "https://github.com/stablyai/orca/issues/7226",
         "https://github.com/stablyai/orca/issues/13821",
@@ -9956,6 +9967,15 @@
       ],
       "evidenceRuns": [
         {
+          "date": "2026-08-16",
+          "runner": "local",
+          "platform": "windows",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/shared/agent-prompt-injection.test.ts src/main/runtime/orca-runtime.test.ts src/main/runtime/rpc/methods/orchestration-tasks-dispatch.test.ts src/main/runtime/orchestration/coordinator.test.ts",
+          "result": "passed",
+          "durationSeconds": 56.2,
+          "summary": "After the cursor-agent allowlist change, 4 files and 1,229 tests passed on Windows, including marker-gated Cursor submit, stale Cursor shell fallback, and the existing Claude/Codex/orchestration contracts. This is post-fix evidence for the cursor claims this gate's 2026-07-07 through 2026-08-14 entries could not have exercised."
+        },
+        {
           "date": "2026-08-14",
           "runner": "local",
           "platform": "macos",
@@ -10007,15 +10027,15 @@
       },
       "flakeHistory": {
         "status": "unknown",
-        "evidence": "First local macOS evidence only; needs repeated dev-runtime harness runs and provider matrix evidence before promotion."
+        "evidence": "macOS runtime/orchestration evidence plus one Windows post-cursor-fix suite (4 files, 1,229 passed). Needs repeated live orchestration dispatch and provider matrix evidence before promotion."
       },
       "redGreenEvidence": {
         "status": "partial",
-        "evidence": "The original Claude-shaped oracle fails on unmodified main and passes with the render gate. The hardened multi-frame oracle then fails on the first-marker candidate, which submits at 751 ms during an intermediate frame, and passes when the gate requires post-marker quiescence. Codex used the legacy platform delay before this candidate; the late-marker oracle proves the original deadline would pre-empt slow-host settlement without re-arming. The earlier live harness also reproduced the unsafe raw multiline contract before its framing fix. Intentional-break evidence remains local rather than a separate CI job."
+        "evidence": "The original Claude-shaped oracle fails on unmodified main and passes with the render gate. The hardened multi-frame oracle then fails on the first-marker candidate, which submits at 751 ms during an intermediate frame, and passes when the gate requires post-marker quiescence. Codex used the legacy platform delay before this candidate; the late-marker oracle proves the original deadline would pre-empt slow-host settlement without re-arming. The cursor-agent settlement allowlist mutant is red on main (provider-unwrapped cursor-agent identity returned false) and green on the candidate in the shared runtime suite. The earlier live harness also reproduced the unsafe raw multiline contract before its framing fix. Intentional-break evidence remains local rather than a separate CI job."
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "Agent prompt dispatch remains O(prompt bytes) with existing 16KB chunking. Claude and Codex add one PTY-local output listener until 1.5 seconds of post-marker output quiescence or the bounded fallback; each later frame resets one quiet timer. Other agents retain the platform delay. No polling, provider listing, subprocess churn, hidden-pane wakeups, renderer work, or wire traffic is added."
+        "evidence": "Agent prompt dispatch remains O(prompt bytes) with existing 16KB chunking. Claude, Codex, and cursor-agent add one PTY-local output listener until 1.5 seconds of post-marker output quiescence or the bounded fallback; each later frame resets one quiet timer. Other agents retain the platform delay. No polling, provider listing, subprocess churn, hidden-pane wakeups, renderer work, or wire traffic is added."
       },
       "promotionCriteria": [
         "Run the live harness in soak with a self-starting dev runtime or provider-contract fixture.",
@@ -10024,7 +10044,7 @@
       ],
       "knownGaps": [
         "Live harness command currently expects an already-running dev runtime and generated out/bin/orca-dev wrapper.",
-        "No Windows ConPTY, Linux PTY, SSH, daemon, or remote-runtime live evidence yet.",
+        "No live Windows orchestration dispatch, Linux PTY, SSH, daemon, or remote-runtime evidence yet. Live authenticated cursor-agent submit is recorded on terminal-input.cli-agent-prompt-submit, not this orchestration dispatch oracle.",
         "Push-on-idle orchestration message banners remain outside this dispatch-prompt gate."
       ],
       "demotionRule": "Demote or quarantine if the live harness flakes without a product bug or harness bug filed to the terminal-input owner."

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -16914,7 +16914,7 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
-  it.each(['claude', 'codex'] as const)(
+  it.each(['claude', 'codex', 'cursor'] as const)(
     'waits for %s composer output frames to settle before one submit',
     async (agent) => {
       vi.useFakeTimers()
@@ -16990,7 +16990,7 @@ describe('OrcaRuntimeService', () => {
 
   it.each(
     (Object.keys(TUI_AGENT_CONFIG) as TuiAgent[]).filter(
-      (agent) => agent !== 'claude' && agent !== 'codex'
+      (agent) => agent !== 'claude' && agent !== 'codex' && agent !== 'cursor'
     )
   )('preserves the legacy fixed submit delay for %s', async (agent) => {
     vi.useFakeTimers()
@@ -24219,6 +24219,34 @@ describe('OrcaRuntimeService', () => {
     }
   )
 
+  it('authorizes settled CLI prompts after a provider-unwrapped cursor-agent identity', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => 'cursor-agent'
+    })
+    syncSinglePty(runtime, 'pty-1', { paneTitle: 'bash' })
+    const [terminal] = (await runtime.listTerminals()).terminals
+
+    await expect(runtime.isTerminalRunningSettledPromptAgent(terminal.handle)).resolves.toBe(true)
+  })
+
+  it('does not poll an unresolved node wrapper for speculative cursor CLI settlement', async () => {
+    const getForegroundProcess = vi.fn().mockResolvedValue('node')
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess
+    })
+    syncSinglePty(runtime, 'pty-1', { paneTitle: 'Cursor Agent' })
+    const [terminal] = (await runtime.listTerminals()).terminals
+
+    await expect(runtime.isTerminalRunningSettledPromptAgent(terminal.handle)).resolves.toBe(false)
+    expect(getForegroundProcess).toHaveBeenCalledTimes(1)
+  })
+
   it('keeps a recognized non-target agent on legacy CLI prompt delivery', async () => {
     const runtime = new OrcaRuntimeService(store)
     runtime.setPtyController({
@@ -24245,6 +24273,24 @@ describe('OrcaRuntimeService', () => {
       command: 'codex',
       title: 'Codex working',
       launchAgent: 'codex'
+    })
+
+    await expect(runtime.isTerminalRunningAgent(handle)).resolves.toBe(true)
+    await expect(runtime.isTerminalRunningSettledPromptAgent(handle)).resolves.toBe(false)
+  })
+
+  it('keeps stale Cursor launch identity on legacy delivery after the shell returns', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => 'zsh'
+    })
+    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+      command: 'cursor-agent',
+      title: 'Cursor working',
+      launchAgent: 'cursor'
     })
 
     await expect(runtime.isTerminalRunningAgent(handle)).resolves.toBe(true)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -2028,7 +2028,7 @@ const BRACKETED_PASTE_END = '\x1b[201~'
 const BRACKETED_PASTE_QUIET_MS = 1500
 const AGENT_PROMPT_RENDER_TIMEOUT_MS = 8000
 const AGENT_PROMPT_RENDER_QUIET_MS = 1500
-// Why: Claude and Codex emit show-cursor after accepting bracketed paste.
+// Why: Claude, Codex, and cursor-agent composers emit show-cursor after accepting bracketed paste.
 const AGENT_PROMPT_RENDER_MARKER = '\x1b[?25h'
 
 function assertAgentPromptRequestActive(signal?: AbortSignal): void {
@@ -40781,8 +40781,8 @@ function classifyAgentTitle(title: string | null): 'agent' | 'management' | 'neu
 
 function isTerminalSendSettlementAgent(
   agent: TuiAgent | null | undefined
-): agent is 'claude' | 'codex' {
-  return agent === 'claude' || agent === 'codex'
+): agent is 'claude' | 'codex' | 'cursor' {
+  return agent === 'claude' || agent === 'codex' || agent === 'cursor'
 }
 
 function findLastCompleteOscTitleRange(data: string): { start: number; end: number } | null {


### PR DESCRIPTION
## ELI5

`orca terminal send --text … --enter` already waits for Claude and Codex composers to finish rendering before pressing Enter. After #14608, cursor-agent still used the old short delay, so long prompts could sit unsubmitted. This follow-up gives a freshly identified cursor-agent the same wait, without turning unknown `node` wrappers into a slow retry loop.

## What Changed

- Include `cursor` in the CLI/runtime prompt-settlement allowlist used by `terminal send --text --enter` and `sendTerminalAgentPrompt`.
- Keep unresolved interpreter wrappers (`node`) on the legacy direct path with a single foreground read — no 6.5s wrapper polling.
- Keep stale Cursor launch metadata over a returned shell on the legacy path, same as Codex.
- Extend focused runtime tests and the `terminal-input.cli-agent-prompt-submit` / `terminal-input.agent-prompt-injection` reliability gates.

## Why

#14525 reported the paste-vs-Enter race on both Codex and cursor-agent. #14608 fixed Claude and Codex only, because OpenCode and other agents lacked a proven post-paste marker. cursor-agent already has:

- the same bracketed-paste CLI intent path
- a stable foreground name (`cursor-agent`) after the existing provider unwrap of the versioned Node launcher
- the same show-cursor + quiescence gate, with the existing 8s fallback if the marker is late or missing

That is a contract-preserving allowlist extension, not a new settlement policy. Detectable wrappers are the existing `getForegroundProcess` unwrap to `cursor-agent`; wrapping that still reports bare `node` stays fail-open.

## Linked Issue

Fixes #14525

This PR is the remaining cursor-agent scope from #14525 after #14608 settled Claude and Codex only. GitHub already closed #14525 via #14608; the required `Fixes` keyword is kept so GitHub and CodeRabbit attach that issue to this follow-up rather than treating the PR as unlinked.

## Visual Proof

No renderer screenshot: Playwright CDP showed the landing page because the live cursor-agent PTY was unfocused. The change is CLI/PTY submit timing, not a rendered layout, so there is no tab-able UI before/after image.

Before (mutant on `upstream/main`): `isTerminalRunningSettledPromptAgent` returned `false` for a provider-unwrapped `cursor-agent` foreground, so `terminal send --text --enter` kept the 1.5s Windows legacy delay.

After (live Windows on product head `b6842cc176`, https://github.com/stablyai/orca/pull/14851#issuecomment-5306160614):

- Isolated source-built runtime/userData; packaged Orca 1.4.183 stayed on pid `34156` / runtimeId `8eb31102-4988-4a3d-8d0b-b74fac9cacf9`
- Fresh authenticated cursor-agent `v2026.08.11-e8db854`
- One 2,834-byte `orca-dev terminal send --text --enter`; send took 8.53s (candidate 8s settlement fallback, not the 1.5s Windows legacy delay); 2,847 bytes written (one bracketed-paste frame)
- PTY: idle composer → `[Pasted text #1 +5 lines]` + Working / `Cursor Agent`; paste index #1 only; no rescue Enter

Caveats: repository `$electron` skill unavailable (Playwright CDP + public CLI); background PTY not visible in CDP; agent still Working at teardown; no live mutant against packaged 1.4.183.

## Testing

- [x] Automated tests added/updated
- [x] I manually tested these changes locally against a live cursor-agent account (Windows, head `b6842cc176`)

Mutant on `upstream/main`: `isTerminalRunningSettledPromptAgent` returned `false` for a provider-unwrapped `cursor-agent` foreground.

After the allowlist change:

- Focused CLI/RPC/runtime suite: 1,205 passed (`src/cli/handlers/terminal.test.ts`, `src/main/runtime/rpc/terminal-agent-prompt-send.test.ts`, `src/main/runtime/rpc/terminal-send.test.ts`, `src/main/runtime/orca-runtime.test.ts`, `src/shared/agent-prompt-injection.test.ts`)
- Cursor-filtered runtime tests: 17 passed
- Post-fix `terminal-input.agent-prompt-injection` suite on Windows: 4 files, 1,229 passed (`src/shared/agent-prompt-injection.test.ts`, `src/main/runtime/orca-runtime.test.ts`, `src/main/runtime/rpc/methods/orchestration-tasks-dispatch.test.ts`, `src/main/runtime/orchestration/coordinator.test.ts`)
- `pnpm run typecheck:node`
- `pnpm run check:reliability-gates` (85 gates valid)
- `pnpm exec oxlint` and `pnpm exec oxfmt --check` on changed TypeScript files
- `git diff --check`

The full `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` commands were not run locally. Hosted CI will cover them after a maintainer approves the fork workflows.

Live Windows acceptance on head `b6842cc176` (https://github.com/stablyai/orca/pull/14851#issuecomment-5306160614): same journey and caveats as Visual Proof.

Claude/Codex/SSH contracts: Claude and Codex still settle; every other configured agent keeps the legacy platform delay; SSH/daemon/remote-runtime still fail open when foreground identity is not a proven settlement agent; no RPC field, stream opcode, or protocol-version change.

## AI Disclosure

Investigation and implementation were AI-assisted. The patch, tests, and focused validation were reviewed before submission.

## Review

- **Security:** settlement still requires a fresh recognized foreground process; unresolved wrappers and shells do not receive the delayed Enter path from the CLI identity gate.
- **Cross-platform:** identity and timing logic is shared; Windows already unwraps the native Cursor Node launcher to `cursor-agent`.
- **SSH / remote / folder workspaces:** no wire change. Old hosts keep stripping optional `agentPrompt`. Unproven remote foregrounds keep the direct send.
- **Backwards compatibility:** optional `agentPrompt` is unchanged. Codex, Claude, OpenCode, Gemini, and shells keep their previous routing.
- **Performance:** one extra agent on the existing bounded gate; no wrapper retry loop on speculative CLI classification.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @EnricoPin
