### PR TITLE
fix(orchestration): defer mail pointer while the focused window is typing

### DIFF
--- a/src/main/ipc/pty-write-ipc-validation.test.ts
+++ b/src/main/ipc/pty-write-ipc-validation.test.ts
@@ -437,4 +437,41 @@ describe('registerPtyHandlers', () => {
       })
     }
   )
+  it('exposes lastUserInputAt from pty:write and reports Orca window focus', async () => {
+    const mockProc = createMockProc()
+    spawnMock.mockReturnValue(mockProc.proc)
+    const captured: {
+      lastUserInputAt?: (ptyId: string) => number | undefined
+      isOrcaWindowFocused?: () => boolean
+    } = {}
+    const runtime = {
+      setPtyController: (next: {
+        lastUserInputAt?: (ptyId: string) => number | undefined
+        isOrcaWindowFocused?: () => boolean
+      }) => {
+        captured.lastUserInputAt = next.lastUserInputAt
+        captured.isOrcaWindowFocused = next.isOrcaWindowFocused
+      },
+      getDriver: vi.fn(() => ({ kind: 'host' })),
+      noteTerminalSpawnCommand: vi.fn(),
+      onPtySpawned: vi.fn(),
+      onPtyData: vi.fn(),
+      onPtyExit: vi.fn(),
+      createPreAllocatedTerminalHandle: vi.fn(() => null),
+      preAllocateHandleForPty: vi.fn()
+    }
+    registerPtyHandlers(mainWindow as never, runtime as never)
+    const result = (await handlers.get('pty:spawn')!(null, {
+      cols: 80,
+      rows: 24
+    })) as { id: string }
+
+    expect(captured.lastUserInputAt?.(result.id)).toBeUndefined()
+    getPtyWriteListener()(mainWindowIpcEvent, { id: result.id, data: 'h' })
+    expect(captured.lastUserInputAt?.(result.id)).toEqual(expect.any(Number))
+    expect(captured.isOrcaWindowFocused?.()).toBe(true)
+
+    vi.spyOn(mainWindow, 'isFocused').mockReturnValue(false)
+    expect(captured.isOrcaWindowFocused?.()).toBe(false)
+  })
 })

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -3,7 +3,7 @@ import { join, delimiter } from 'node:path'
 import { randomUUID } from 'node:crypto'
 import { statSync } from 'node:fs'
 import {
-  type BrowserWindow,
+  BrowserWindow,
   type IpcMainEvent,
   type IpcMainInvokeEvent,
   type WebContents,
@@ -5431,6 +5431,18 @@ export function registerPtyHandlers(
     write: (ptyId, data) => {
       try {
         return getProviderForPty(ptyId).write(ptyId, data) !== false
+      } catch {
+        return false
+      }
+    },
+    lastUserInputAt: (ptyId) => lastInputAtByPty.get(ptyId),
+    isOrcaWindowFocused: () => {
+      try {
+        if (!mainWindow.isDestroyed() && mainWindow.isFocused()) {
+          return true
+        }
+        const focused = BrowserWindow?.getFocusedWindow?.()
+        return focused != null && focused.isDestroyed?.() !== true
       } catch {
         return false
       }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1772,6 +1772,10 @@ type RuntimePtyController = {
   }>
   write(ptyId: string, data: string): boolean
   writeWithSettlement?(ptyId: string, data: string): Promise<boolean>
+  /** Last renderer keystroke routed through writePtyInput for this pty. */
+  lastUserInputAt?(ptyId: string): number | undefined
+  /** True when any live Orca BrowserWindow currently has focus. */
+  isOrcaWindowFocused?(): boolean
   /** Attach-only adoption of a live local daemon session so its output streams
    *  to main without a renderer pane; never creates, resizes, or focuses.
    *  False on doubt (absent session, SSH-scoped id, non-daemon provider). */
@@ -2979,6 +2983,10 @@ export class OrcaRuntimeService {
       getTabTitle: (tabId) => this.tabs.get(tabId)?.title,
       getTerminalHandleForLeafKey: (leafKey) => this.handleByLeafKey.get(leafKey),
       isLeafPtyProvenAbsent: (ptyId) => this.isLeafPtyProvenAbsent(ptyId),
+      lastUserInputAt: (ptyId) => this.ptyController?.lastUserInputAt?.(ptyId),
+      isOrcaWindowFocused: () => this.ptyController?.isOrcaWindowFocused?.() === true,
+      scheduleMailboxRetry: (mailboxHandle, delayMs) =>
+        this.mailPointerRepointScheduler.schedule(mailboxHandle, delayMs),
       redriveMailbox: (mailboxHandle, reservedTypes) =>
         this.deliverPendingMessagesForHandle(mailboxHandle, reservedTypes),
       writePty: (ptyId, data) => this.writeOrchestrationPointerPty(ptyId, data)

--- a/src/main/runtime/orchestration-mailbox-typing-guard.test.ts
+++ b/src/main/runtime/orchestration-mailbox-typing-guard.test.ts
@@ -2,6 +2,7 @@ import { rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  checkBoundMailbox,
   createBoundRun,
   createDatabase,
   createRuntime,
@@ -138,14 +139,25 @@ describe('orchestration mail pointer typing guard', () => {
     }
     installTypingGuard(harness, state)
     const run = createBoundRun(db, 'Enter typing Run')
-    insertDirectRunMessage(db, run.id, 'Pointer already injected')
+    const message = insertDirectRunMessage(db, run.id, 'Pointer already injected')
 
     await driveToLiveIdle(harness.runtime)
     expect(pointerCount(harness.write)).toBe(1)
     state.lastUserInputAt = performance.now()
+    const redrive = vi.spyOn(harness.runtime, 'deliverPendingMessagesForHandle')
 
     await vi.advanceTimersByTimeAsync(500)
     expect(harness.write.mock.calls.filter(([, payload]) => payload === '\r')).toHaveLength(0)
+    expect(db.getMessageById(message.id)?.delivered_at).toEqual(expect.any(String))
+    expect(redrive).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(5_000)
+    expect(redrive).toHaveBeenCalledWith(`run:${run.id}`)
+    expect(pointerCount(harness.write)).toBe(1)
+    expect(harness.write.mock.calls.filter(([, payload]) => payload === '\r')).toHaveLength(0)
+
+    const checked = await checkBoundMailbox(harness.runtime)
+    expect(checked).toMatchObject({ runId: run.id, count: 1 })
     db.close()
   })
 })

--- a/src/main/runtime/orchestration-mailbox-typing-guard.test.ts
+++ b/src/main/runtime/orchestration-mailbox-typing-guard.test.ts
@@ -1,0 +1,151 @@
+import { rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  createBoundRun,
+  createDatabase,
+  createRuntime,
+  driveToLiveIdle,
+  insertDirectRunMessage,
+  pointerCount,
+  PTY_ID,
+  temporaryDirectories,
+  TERMINAL_HANDLE,
+  type MailboxNotificationHarness
+} from './orchestration-mailbox-notification-test-harness'
+
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn(() => tmpdir()), isPackaged: false },
+  BrowserWindow: { fromId: vi.fn(() => null) },
+  ipcMain: { on: vi.fn(), removeListener: vi.fn() },
+  webContents: { fromId: vi.fn(() => null) }
+}))
+
+type TypingGuardState = {
+  lastUserInputAt: number | undefined
+  focused: boolean
+}
+
+function installTypingGuard(harness: MailboxNotificationHarness, state: TypingGuardState): void {
+  harness.runtime.setPtyController({
+    write: harness.write,
+    kill: vi.fn(),
+    getForegroundProcess: async () => null,
+    lastUserInputAt: (ptyId) => (ptyId === PTY_ID ? state.lastUserInputAt : undefined),
+    isOrcaWindowFocused: () => state.focused
+  } as never)
+}
+
+describe('orchestration mail pointer typing guard', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    for (const directory of temporaryDirectories.splice(0)) {
+      rmSync(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('defers the pointer for 5s of focused PTY typing and retries the run mailbox', async () => {
+    vi.useFakeTimers()
+    const db = createDatabase('orca-mailbox-typing-guard-')
+    const harness = createRuntime(db)
+    const state: TypingGuardState = {
+      lastUserInputAt: performance.now(),
+      focused: true
+    }
+    installTypingGuard(harness, state)
+    const run = createBoundRun(db, 'Typing guard Run')
+    insertDirectRunMessage(db, run.id, 'Do not clobber the draft')
+    const redrive = vi.spyOn(harness.runtime, 'deliverPendingMessagesForHandle')
+
+    await driveToLiveIdle(harness.runtime)
+    expect(pointerCount(harness.write)).toBe(0)
+
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(pointerCount(harness.write)).toBe(0)
+
+    await vi.advanceTimersByTimeAsync(3_000)
+    expect(pointerCount(harness.write)).toBe(1)
+    expect(redrive).toHaveBeenCalledWith(`run:${run.id}`)
+    expect(redrive).not.toHaveBeenCalledWith(TERMINAL_HANDLE)
+
+    await vi.advanceTimersByTimeAsync(500)
+    expect(harness.write).toHaveBeenCalledWith(PTY_ID, '\r')
+    db.close()
+  })
+
+  it('still injects when the user typed recently but Orca is unfocused', async () => {
+    vi.useFakeTimers()
+    const db = createDatabase('orca-mailbox-typing-unfocused-')
+    const harness = createRuntime(db)
+    installTypingGuard(harness, {
+      lastUserInputAt: performance.now(),
+      focused: false
+    })
+    const run = createBoundRun(db, 'Unfocused typing Run')
+    insertDirectRunMessage(db, run.id, 'Deliver while alt-tabbed')
+
+    await driveToLiveIdle(harness.runtime)
+    expect(pointerCount(harness.write)).toBe(1)
+    db.close()
+  })
+
+  it('still defers 200ms after the last key because the gate is 5s not 100ms', async () => {
+    vi.useFakeTimers()
+    const db = createDatabase('orca-mailbox-typing-200ms-')
+    const harness = createRuntime(db)
+    installTypingGuard(harness, {
+      lastUserInputAt: performance.now() - 200,
+      focused: true
+    })
+    const run = createBoundRun(db, '200ms typing Run')
+    insertDirectRunMessage(db, run.id, 'Still typing')
+
+    await driveToLiveIdle(harness.runtime)
+    expect(pointerCount(harness.write)).toBe(0)
+    db.close()
+  })
+
+  it('re-checks typing after a later keystroke during the quiet wait', async () => {
+    vi.useFakeTimers()
+    const db = createDatabase('orca-mailbox-typing-race-')
+    const harness = createRuntime(db)
+    const state: TypingGuardState = {
+      lastUserInputAt: performance.now(),
+      focused: true
+    }
+    installTypingGuard(harness, state)
+    const run = createBoundRun(db, 'Typing race Run')
+    insertDirectRunMessage(db, run.id, 'Keep waiting')
+
+    await driveToLiveIdle(harness.runtime)
+    await vi.advanceTimersByTimeAsync(2_000)
+    state.lastUserInputAt = performance.now()
+    await vi.advanceTimersByTimeAsync(3_000)
+    expect(pointerCount(harness.write)).toBe(0)
+
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(pointerCount(harness.write)).toBe(1)
+    db.close()
+  })
+
+  it('skips the delayed Enter when the user starts typing after the pointer write', async () => {
+    vi.useFakeTimers()
+    const db = createDatabase('orca-mailbox-typing-enter-')
+    const harness = createRuntime(db)
+    const state: TypingGuardState = {
+      lastUserInputAt: performance.now() - 10_000,
+      focused: true
+    }
+    installTypingGuard(harness, state)
+    const run = createBoundRun(db, 'Enter typing Run')
+    insertDirectRunMessage(db, run.id, 'Pointer already injected')
+
+    await driveToLiveIdle(harness.runtime)
+    expect(pointerCount(harness.write)).toBe(1)
+    state.lastUserInputAt = performance.now()
+
+    await vi.advanceTimersByTimeAsync(500)
+    expect(harness.write.mock.calls.filter(([, payload]) => payload === '\r')).toHaveLength(0)
+    db.close()
+  })
+})

--- a/src/main/runtime/orchestration/mail-pointer-repoint-scheduler.test.ts
+++ b/src/main/runtime/orchestration/mail-pointer-repoint-scheduler.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { MailPointerRepointScheduler } from './mail-pointer-repoint-scheduler'
+
+describe('MailPointerRepointScheduler', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('coalesces default repairs at 2s and honors an explicit remaining delay', async () => {
+    vi.useFakeTimers()
+    const repoint = vi.fn()
+    const scheduler = new MailPointerRepointScheduler(repoint)
+
+    scheduler.schedule('run:run_a')
+    scheduler.schedule('run:run_a')
+    await vi.advanceTimersByTimeAsync(1_999)
+    expect(repoint).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(1)
+    expect(repoint).toHaveBeenCalledOnce()
+    expect(repoint).toHaveBeenCalledWith('run:run_a')
+
+    scheduler.schedule('run:run_b', 5_000)
+    scheduler.schedule('run:run_b', 2_000)
+    await vi.advanceTimersByTimeAsync(4_999)
+    expect(repoint).toHaveBeenCalledOnce()
+    await vi.advanceTimersByTimeAsync(1)
+    expect(repoint).toHaveBeenCalledTimes(2)
+    expect(repoint).toHaveBeenLastCalledWith('run:run_b')
+  })
+})

--- a/src/main/runtime/orchestration/mail-pointer-repoint-scheduler.ts
+++ b/src/main/runtime/orchestration/mail-pointer-repoint-scheduler.ts
@@ -5,17 +5,20 @@ export class MailPointerRepointScheduler {
 
   constructor(private readonly repoint: (handle: string) => void) {}
 
-  schedule(handle: string): void {
+  schedule(handle: string, delayMs = MAIL_POINTER_REPOINT_DELAY_MS): void {
     if (this.timersByHandle.has(handle)) {
       return
     }
-    const timer = setTimeout(() => {
-      if (this.timersByHandle.get(handle) !== timer) {
-        return
-      }
-      this.timersByHandle.delete(handle)
-      this.repoint(handle)
-    }, MAIL_POINTER_REPOINT_DELAY_MS)
+    const timer = setTimeout(
+      () => {
+        if (this.timersByHandle.get(handle) !== timer) {
+          return
+        }
+        this.timersByHandle.delete(handle)
+        this.repoint(handle)
+      },
+      Math.max(0, delayMs)
+    )
     timer.unref?.()
     this.timersByHandle.set(handle, timer)
   }

--- a/src/main/runtime/orchestration/mailbox-pointer-delivery.ts
+++ b/src/main/runtime/orchestration/mailbox-pointer-delivery.ts
@@ -1,10 +1,9 @@
 import { isCursorAgentTitle } from '../../../shared/agent-detection'
-import { ORCHESTRATION_DELIVERY_BATCH_LIMIT, type OrchestrationDb } from './db'
+import type { OrchestrationDb } from './db'
 import { formatMessagePointer } from './formatter'
 import type { OrchestrationMailboxDeliveryTarget } from './mailbox-delivery-target'
 import {
-  hasUnfilteredOrchestrationWaiter,
-  messageTypeHasOrchestrationWaiter,
+  collectDeliverableMailboxPointerMessages,
   shouldReleaseOrchestrationPointer,
   type OrchestrationMessageWaiter
 } from './mailbox-pointer-eligibility'
@@ -14,6 +13,7 @@ import {
   type OrchestrationMailboxDeliveryFlight
 } from './mailbox-pointer-state'
 import { submitOrchestrationMailboxPointer } from './mailbox-pointer-submit'
+import { deferMailboxPointerForRecentTyping } from './mailbox-pointer-typing-guard'
 
 export type { OrchestrationMessageWaiter } from './mailbox-pointer-eligibility'
 
@@ -28,6 +28,9 @@ type PointerDeliveryDependencies<TWaiter extends OrchestrationMessageWaiter> = {
   getTabTitle: (tabId: string) => string | null | undefined
   getTerminalHandleForLeafKey: (leafKey: string) => string | undefined
   isLeafPtyProvenAbsent: (ptyId: string) => Promise<boolean>
+  lastUserInputAt?: (ptyId: string) => number | undefined
+  isOrcaWindowFocused?: () => boolean
+  scheduleMailboxRetry?: (mailboxHandle: string, delayMs: number) => void
   redriveMailbox: (mailboxHandle: string, reservedTypes?: ReadonlySet<string>) => void
   writePty: (ptyId: string, data: string) => boolean | Promise<boolean>
 }
@@ -84,26 +87,12 @@ export class OrchestrationMailboxPointerDelivery<TWaiter extends OrchestrationMe
     }
 
     const waiters = this.deps.getMessageWaiters(mailboxHandle)
-    if (hasUnfilteredOrchestrationWaiter(waiters)) {
-      return
-    }
-    const excludedTypes = new Set(options.reservedTypes)
-    for (const waiter of waiters ?? []) {
-      for (const type of waiter.typeFilter ?? []) {
-        excludedTypes.add(type)
-      }
-    }
-    const unread = db
-      .getUndeliveredUnreadMessages(mailboxHandle, undefined, {
-        excludeTypes: [...excludedTypes],
-        limit: ORCHESTRATION_DELIVERY_BATCH_LIMIT
-      })
-      .filter(
-        (message) =>
-          !options.reservedTypes?.has(message.type) &&
-          !messageTypeHasOrchestrationWaiter(waiters, message.type)
-      )
-      .slice(0, ORCHESTRATION_DELIVERY_BATCH_LIMIT)
+    const unread = collectDeliverableMailboxPointerMessages(
+      db,
+      mailboxHandle,
+      waiters,
+      options.reservedTypes
+    )
     if (unread.length === 0 || !leaf.writable || !leaf.ptyId) {
       return
     }
@@ -130,6 +119,10 @@ export class OrchestrationMailboxPointerDelivery<TWaiter extends OrchestrationMe
           this.redeliverAfterProbe(probedLeaf, ptyId, probedMailbox)
       )
     ) {
+      return
+    }
+    // #14832: don't inject into a prompt the user is editing in a focused Orca window
+    if (deferMailboxPointerForRecentTyping({ ptyId: leaf.ptyId, mailboxHandle, ...this.deps })) {
       return
     }
     this.stagePointer(leaf, mailboxHandle, unread, newestSequence)
@@ -261,6 +254,8 @@ export class OrchestrationMailboxPointerDelivery<TWaiter extends OrchestrationMe
               getLeafKey: this.deps.getLeafKey,
               getMessageWaiters: this.deps.getMessageWaiters,
               isLeafPtyProvenAbsent: this.deps.isLeafPtyProvenAbsent,
+              lastUserInputAt: this.deps.lastUserInputAt,
+              isOrcaWindowFocused: this.deps.isOrcaWindowFocused,
               writePty: this.deps.writePty,
               settle: (settledPtyId, settledFlight) => this.settle(settledPtyId, settledFlight),
               redrive: (redriveMailbox, force) => this.redrive(redriveMailbox, force)

--- a/src/main/runtime/orchestration/mailbox-pointer-delivery.ts
+++ b/src/main/runtime/orchestration/mailbox-pointer-delivery.ts
@@ -256,6 +256,7 @@ export class OrchestrationMailboxPointerDelivery<TWaiter extends OrchestrationMe
               isLeafPtyProvenAbsent: this.deps.isLeafPtyProvenAbsent,
               lastUserInputAt: this.deps.lastUserInputAt,
               isOrcaWindowFocused: this.deps.isOrcaWindowFocused,
+              scheduleMailboxRetry: this.deps.scheduleMailboxRetry,
               writePty: this.deps.writePty,
               settle: (settledPtyId, settledFlight) => this.settle(settledPtyId, settledFlight),
               redrive: (redriveMailbox, force) => this.redrive(redriveMailbox, force)

--- a/src/main/runtime/orchestration/mailbox-pointer-delivery.ts
+++ b/src/main/runtime/orchestration/mailbox-pointer-delivery.ts
@@ -1,9 +1,10 @@
 import { isCursorAgentTitle } from '../../../shared/agent-detection'
-import type { OrchestrationDb } from './db'
+import { ORCHESTRATION_DELIVERY_BATCH_LIMIT, type OrchestrationDb } from './db'
 import { formatMessagePointer } from './formatter'
 import type { OrchestrationMailboxDeliveryTarget } from './mailbox-delivery-target'
 import {
-  collectDeliverableMailboxPointerMessages,
+  hasUnfilteredOrchestrationWaiter,
+  messageTypeHasOrchestrationWaiter,
   shouldReleaseOrchestrationPointer,
   type OrchestrationMessageWaiter
 } from './mailbox-pointer-eligibility'
@@ -82,17 +83,31 @@ export class OrchestrationMailboxPointerDelivery<TWaiter extends OrchestrationMe
       return
     }
     if (this.state.hasActiveWatermark(mailboxHandle)) {
-      this.parkRedelivery(mailboxHandle, options.reservedTypes)
+      this.state.parkRedelivery(mailboxHandle, options.reservedTypes)
       return
     }
 
     const waiters = this.deps.getMessageWaiters(mailboxHandle)
-    const unread = collectDeliverableMailboxPointerMessages(
-      db,
-      mailboxHandle,
-      waiters,
-      options.reservedTypes
-    )
+    if (hasUnfilteredOrchestrationWaiter(waiters)) {
+      return
+    }
+    const excludedTypes = new Set(options.reservedTypes)
+    for (const waiter of waiters ?? []) {
+      for (const type of waiter.typeFilter ?? []) {
+        excludedTypes.add(type)
+      }
+    }
+    const unread = db
+      .getUndeliveredUnreadMessages(mailboxHandle, undefined, {
+        excludeTypes: [...excludedTypes],
+        limit: ORCHESTRATION_DELIVERY_BATCH_LIMIT
+      })
+      .filter(
+        (message) =>
+          !options.reservedTypes?.has(message.type) &&
+          !messageTypeHasOrchestrationWaiter(waiters, message.type)
+      )
+      .slice(0, ORCHESTRATION_DELIVERY_BATCH_LIMIT)
     if (unread.length === 0 || !leaf.writable || !leaf.ptyId) {
       return
     }
@@ -126,10 +141,6 @@ export class OrchestrationMailboxPointerDelivery<TWaiter extends OrchestrationMe
       return
     }
     this.stagePointer(leaf, mailboxHandle, unread, newestSequence)
-  }
-
-  parkRedelivery(mailboxHandle: string, reservedTypes?: ReadonlySet<string>): void {
-    this.state.parkRedelivery(mailboxHandle, reservedTypes)
   }
 
   retirePty(ptyId: string): void {
@@ -247,17 +258,8 @@ export class OrchestrationMailboxPointerDelivery<TWaiter extends OrchestrationMe
         () =>
           submitOrchestrationMailboxPointer(
             {
-              mailboxOwner: this.deps.mailboxOwner,
+              ...this.deps,
               state: this.state,
-              getDb: this.deps.getDb,
-              getLeaf: this.deps.getLeaf,
-              getLeafKey: this.deps.getLeafKey,
-              getMessageWaiters: this.deps.getMessageWaiters,
-              isLeafPtyProvenAbsent: this.deps.isLeafPtyProvenAbsent,
-              lastUserInputAt: this.deps.lastUserInputAt,
-              isOrcaWindowFocused: this.deps.isOrcaWindowFocused,
-              scheduleMailboxRetry: this.deps.scheduleMailboxRetry,
-              writePty: this.deps.writePty,
               settle: (settledPtyId, settledFlight) => this.settle(settledPtyId, settledFlight),
               redrive: (redriveMailbox, force) => this.redrive(redriveMailbox, force)
             },
@@ -284,7 +286,7 @@ export class OrchestrationMailboxPointerDelivery<TWaiter extends OrchestrationMe
         currentLeaf?.ptyId !== ptyId ||
         this.deps.mailboxOwner.resolve(currentLeaf, mailboxHandle) !== mailboxHandle
       ) {
-        this.parkRedelivery(mailboxHandle, delivery.reservedTypes)
+        this.state.parkRedelivery(mailboxHandle, delivery.reservedTypes)
         this.redrive(mailboxHandle)
       } else {
         this.deliver(currentLeaf, { mailboxHandle, reservedTypes: delivery.reservedTypes })

--- a/src/main/runtime/orchestration/mailbox-pointer-eligibility.ts
+++ b/src/main/runtime/orchestration/mailbox-pointer-eligibility.ts
@@ -1,4 +1,4 @@
-import { ORCHESTRATION_DELIVERY_BATCH_LIMIT, type OrchestrationDb } from './db'
+import type { OrchestrationDb } from './db'
 
 export type OrchestrationMessageWaiter = { typeFilter: string[] | undefined }
 
@@ -46,32 +46,4 @@ export function shouldReleaseOrchestrationPointer(
       messages.map((message) => message.id)
     ) ?? true
   )
-}
-
-export function collectDeliverableMailboxPointerMessages(
-  db: OrchestrationDb,
-  mailboxHandle: string,
-  waiters: ReadonlySet<OrchestrationMessageWaiter> | undefined,
-  reservedTypes?: ReadonlySet<string>
-): { id: string; type: string; sequence: number }[] {
-  if (hasUnfilteredOrchestrationWaiter(waiters)) {
-    return []
-  }
-  const excludedTypes = new Set(reservedTypes)
-  for (const waiter of waiters ?? []) {
-    for (const type of waiter.typeFilter ?? []) {
-      excludedTypes.add(type)
-    }
-  }
-  return db
-    .getUndeliveredUnreadMessages(mailboxHandle, undefined, {
-      excludeTypes: [...excludedTypes],
-      limit: ORCHESTRATION_DELIVERY_BATCH_LIMIT
-    })
-    .filter(
-      (message) =>
-        !reservedTypes?.has(message.type) &&
-        !messageTypeHasOrchestrationWaiter(waiters, message.type)
-    )
-    .slice(0, ORCHESTRATION_DELIVERY_BATCH_LIMIT)
 }

--- a/src/main/runtime/orchestration/mailbox-pointer-eligibility.ts
+++ b/src/main/runtime/orchestration/mailbox-pointer-eligibility.ts
@@ -1,4 +1,4 @@
-import type { OrchestrationDb } from './db'
+import { ORCHESTRATION_DELIVERY_BATCH_LIMIT, type OrchestrationDb } from './db'
 
 export type OrchestrationMessageWaiter = { typeFilter: string[] | undefined }
 
@@ -46,4 +46,32 @@ export function shouldReleaseOrchestrationPointer(
       messages.map((message) => message.id)
     ) ?? true
   )
+}
+
+export function collectDeliverableMailboxPointerMessages(
+  db: OrchestrationDb,
+  mailboxHandle: string,
+  waiters: ReadonlySet<OrchestrationMessageWaiter> | undefined,
+  reservedTypes?: ReadonlySet<string>
+): { id: string; type: string; sequence: number }[] {
+  if (hasUnfilteredOrchestrationWaiter(waiters)) {
+    return []
+  }
+  const excludedTypes = new Set(reservedTypes)
+  for (const waiter of waiters ?? []) {
+    for (const type of waiter.typeFilter ?? []) {
+      excludedTypes.add(type)
+    }
+  }
+  return db
+    .getUndeliveredUnreadMessages(mailboxHandle, undefined, {
+      excludeTypes: [...excludedTypes],
+      limit: ORCHESTRATION_DELIVERY_BATCH_LIMIT
+    })
+    .filter(
+      (message) =>
+        !reservedTypes?.has(message.type) &&
+        !messageTypeHasOrchestrationWaiter(waiters, message.type)
+    )
+    .slice(0, ORCHESTRATION_DELIVERY_BATCH_LIMIT)
 }

--- a/src/main/runtime/orchestration/mailbox-pointer-submit.test.ts
+++ b/src/main/runtime/orchestration/mailbox-pointer-submit.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { OrchestrationMailboxLeaf } from './mailbox-owner'
+import { OrchestrationMailboxPointerState } from './mailbox-pointer-state'
+import { submitOrchestrationMailboxPointer } from './mailbox-pointer-submit'
+import { MAIL_POINTER_USER_INPUT_QUIESCE_MS } from './mailbox-pointer-typing-guard'
+
+const PTY_ID = 'pty-enter-guard'
+const MAILBOX = 'run:run_enter_guard'
+const LEAF_KEY = 'tab-enter:leaf-enter'
+const LEAF: OrchestrationMailboxLeaf = {
+  tabId: 'tab-enter',
+  leafId: 'leaf-enter',
+  ptyId: PTY_ID,
+  writable: true,
+  lastAgentStatus: 'idle',
+  lastAgentStatusObservedLive: true,
+  lastOscTitle: 'Codex done'
+}
+
+function submitWithTypingGuard(options?: {
+  lastUserInputAt?: number
+  focused?: boolean
+  scheduleMailboxRetry?: (mailboxHandle: string, delayMs: number) => void
+}) {
+  const state = new OrchestrationMailboxPointerState()
+  const flight = state.beginFlight(PTY_ID)
+  state.setWatermark(MAILBOX, 1, PTY_ID, LEAF_KEY)
+  const markAsUndelivered = vi.fn()
+  const writePty = vi.fn(async () => true)
+  const settle = vi.fn()
+  const redrive = vi.fn()
+  const scheduleMailboxRetry = options?.scheduleMailboxRetry ?? vi.fn()
+  submitOrchestrationMailboxPointer(
+    {
+      mailboxOwner: { resolve: () => MAILBOX } as never,
+      state,
+      getDb: () =>
+        ({
+          hasOutstandingRunDelivery: () => false,
+          areUnreadMessages: () => true,
+          markAsUndelivered
+        }) as never,
+      getLeaf: () => LEAF,
+      getLeafKey: () => LEAF_KEY,
+      getMessageWaiters: () => undefined,
+      isLeafPtyProvenAbsent: async () => false,
+      lastUserInputAt: () => options?.lastUserInputAt,
+      isOrcaWindowFocused: () => options?.focused === true,
+      writePty,
+      settle,
+      redrive,
+      scheduleMailboxRetry
+    },
+    {
+      leaf: LEAF,
+      mailboxHandle: MAILBOX,
+      messages: [{ id: 'msg_1', type: 'status' }],
+      newestSequence: 1,
+      ptyId: PTY_ID,
+      flight
+    }
+  )
+  return { state, flight, markAsUndelivered, writePty, settle, redrive, scheduleMailboxRetry }
+}
+
+describe('submitOrchestrationMailboxPointer typing guard', () => {
+  it('deactivates the watermark without undelivering, submitting, or clearing when Enter is deferred', async () => {
+    const scheduled: [string, number][] = []
+    const harness = submitWithTypingGuard({
+      lastUserInputAt: performance.now(),
+      focused: true,
+      scheduleMailboxRetry: (mailboxHandle, delayMs) => scheduled.push([mailboxHandle, delayMs])
+    })
+
+    await vi.waitFor(() => {
+      expect(harness.settle).toHaveBeenCalled()
+    })
+
+    expect(harness.writePty).not.toHaveBeenCalled()
+    expect(harness.markAsUndelivered).not.toHaveBeenCalled()
+    expect(harness.state.hasActiveWatermark(MAILBOX)).toBe(false)
+    expect(harness.state.releaseSupersededWatermark(MAILBOX, 1, PTY_ID, LEAF_KEY)).toBe(false)
+    expect(harness.state.releaseSupersededWatermark(MAILBOX, 2, PTY_ID, LEAF_KEY)).toBe(true)
+    expect(harness.redrive).toHaveBeenCalledWith(MAILBOX, false)
+    expect(scheduled).toHaveLength(1)
+    expect(scheduled[0][0]).toBe(MAILBOX)
+    expect(scheduled[0][1]).toBeGreaterThan(MAIL_POINTER_USER_INPUT_QUIESCE_MS - 250)
+    expect(scheduled[0][1]).toBeLessThanOrEqual(MAIL_POINTER_USER_INPUT_QUIESCE_MS)
+    expect(harness.settle).toHaveBeenCalledWith(PTY_ID, harness.flight)
+  })
+})

--- a/src/main/runtime/orchestration/mailbox-pointer-submit.ts
+++ b/src/main/runtime/orchestration/mailbox-pointer-submit.ts
@@ -8,6 +8,7 @@ import type {
   OrchestrationMailboxDeliveryFlight,
   OrchestrationMailboxPointerState
 } from './mailbox-pointer-state'
+import { shouldDeferMailboxPointerEnter } from './mailbox-pointer-typing-guard'
 
 type PointerSubmitDependencies<TWaiter extends OrchestrationMessageWaiter> = {
   mailboxOwner: OrchestrationMailboxOwner
@@ -17,6 +18,8 @@ type PointerSubmitDependencies<TWaiter extends OrchestrationMessageWaiter> = {
   getLeafKey: (tabId: string, leafId: string) => string
   getMessageWaiters: (mailboxHandle: string) => ReadonlySet<TWaiter> | undefined
   isLeafPtyProvenAbsent: (ptyId: string) => Promise<boolean>
+  lastUserInputAt?: (ptyId: string) => number | undefined
+  isOrcaWindowFocused?: () => boolean
   writePty: (ptyId: string, data: string) => boolean | Promise<boolean>
   settle: (ptyId: string, flight: OrchestrationMailboxDeliveryFlight) => void
   redrive: (mailboxHandle: string, force?: boolean) => void
@@ -66,7 +69,12 @@ export function submitOrchestrationMailboxPointer<TWaiter extends OrchestrationM
           )
         ) {
           releaseWithoutRedrive = true
-        } else {
+        } else if (
+          !shouldDeferMailboxPointerEnter({
+            lastUserInputAt: deps.lastUserInputAt?.(input.ptyId),
+            isOrcaWindowFocused: deps.isOrcaWindowFocused?.() === true
+          })
+        ) {
           submitted = await deps.writePty(input.ptyId, '\r')
         }
       }

--- a/src/main/runtime/orchestration/mailbox-pointer-submit.ts
+++ b/src/main/runtime/orchestration/mailbox-pointer-submit.ts
@@ -8,7 +8,7 @@ import type {
   OrchestrationMailboxDeliveryFlight,
   OrchestrationMailboxPointerState
 } from './mailbox-pointer-state'
-import { shouldDeferMailboxPointerEnter } from './mailbox-pointer-typing-guard'
+import { remainingMailPointerTypingQuiesceMs } from './mailbox-pointer-typing-guard'
 
 type PointerSubmitDependencies<TWaiter extends OrchestrationMessageWaiter> = {
   mailboxOwner: OrchestrationMailboxOwner
@@ -20,6 +20,7 @@ type PointerSubmitDependencies<TWaiter extends OrchestrationMessageWaiter> = {
   isLeafPtyProvenAbsent: (ptyId: string) => Promise<boolean>
   lastUserInputAt?: (ptyId: string) => number | undefined
   isOrcaWindowFocused?: () => boolean
+  scheduleMailboxRetry?: (mailboxHandle: string, delayMs: number) => void
   writePty: (ptyId: string, data: string) => boolean | Promise<boolean>
   settle: (ptyId: string, flight: OrchestrationMailboxDeliveryFlight) => void
   redrive: (mailboxHandle: string, force?: boolean) => void
@@ -69,13 +70,20 @@ export function submitOrchestrationMailboxPointer<TWaiter extends OrchestrationM
           )
         ) {
           releaseWithoutRedrive = true
-        } else if (
-          !shouldDeferMailboxPointerEnter({
+        } else {
+          const remaining = remainingMailPointerTypingQuiesceMs({
             lastUserInputAt: deps.lastUserInputAt?.(input.ptyId),
             isOrcaWindowFocused: deps.isOrcaWindowFocused?.() === true
           })
-        ) {
-          submitted = await deps.writePty(input.ptyId, '\r')
+          if (remaining !== null) {
+            // #14832: retry after quiet for later unread; keep delivered_at so this pointer is not rewritten
+            deps.scheduleMailboxRetry?.(
+              input.mailboxHandle,
+              Math.max(1, Math.ceil(remaining))
+            )
+          } else {
+            submitted = await deps.writePty(input.ptyId, '\r')
+          }
         }
       }
     })

--- a/src/main/runtime/orchestration/mailbox-pointer-typing-guard.test.ts
+++ b/src/main/runtime/orchestration/mailbox-pointer-typing-guard.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MAIL_POINTER_USER_INPUT_QUIESCE_MS,
+  deferMailboxPointerForRecentTyping,
+  remainingMailPointerTypingQuiesceMs,
+  shouldDeferMailboxPointerEnter
+} from './mailbox-pointer-typing-guard'
+
+describe('mailbox pointer typing guard', () => {
+  it('defers only when this PTY was typed recently and an Orca window is focused', () => {
+    expect(
+      remainingMailPointerTypingQuiesceMs({
+        lastUserInputAt: 1_000,
+        isOrcaWindowFocused: true,
+        now: 1_200
+      })
+    ).toBe(MAIL_POINTER_USER_INPUT_QUIESCE_MS - 200)
+    expect(
+      remainingMailPointerTypingQuiesceMs({
+        lastUserInputAt: 1_000,
+        isOrcaWindowFocused: false,
+        now: 1_200
+      })
+    ).toBeNull()
+    expect(
+      remainingMailPointerTypingQuiesceMs({
+        lastUserInputAt: 1_000,
+        isOrcaWindowFocused: true,
+        now: 1_000 + MAIL_POINTER_USER_INPUT_QUIESCE_MS
+      })
+    ).toBeNull()
+    expect(
+      remainingMailPointerTypingQuiesceMs({
+        lastUserInputAt: undefined,
+        isOrcaWindowFocused: true,
+        now: 1_000
+      })
+    ).toBeNull()
+  })
+
+  it('does not treat the 100ms interactive-output window as quiescence', () => {
+    expect(
+      remainingMailPointerTypingQuiesceMs({
+        lastUserInputAt: 1_000,
+        isOrcaWindowFocused: true,
+        now: 1_200
+      })
+    ).toBeGreaterThan(100)
+  })
+
+  it('skips Enter under the same predicate used before the pointer write', () => {
+    expect(
+      shouldDeferMailboxPointerEnter({
+        lastUserInputAt: 1_000,
+        isOrcaWindowFocused: true,
+        now: 1_400
+      })
+    ).toBe(true)
+    expect(
+      shouldDeferMailboxPointerEnter({
+        lastUserInputAt: 1_000,
+        isOrcaWindowFocused: false,
+        now: 1_400
+      })
+    ).toBe(false)
+  })
+
+  it('retries with the mailbox identity and remaining quiet time', () => {
+    const scheduled: [string, number][] = []
+    const deferred = deferMailboxPointerForRecentTyping({
+      ptyId: 'pty-1',
+      mailboxHandle: 'run:run_typing',
+      lastUserInputAt: (ptyId) => (ptyId === 'pty-1' ? 1_000 : undefined),
+      isOrcaWindowFocused: () => true,
+      scheduleMailboxRetry: (mailboxHandle, delayMs) => scheduled.push([mailboxHandle, delayMs]),
+      now: 1_250
+    })
+    expect(deferred).toBe(true)
+    expect(scheduled).toEqual([['run:run_typing', MAIL_POINTER_USER_INPUT_QUIESCE_MS - 250]])
+  })
+})

--- a/src/main/runtime/orchestration/mailbox-pointer-typing-guard.ts
+++ b/src/main/runtime/orchestration/mailbox-pointer-typing-guard.ts
@@ -1,0 +1,50 @@
+export const MAIL_POINTER_USER_INPUT_QUIESCE_MS = 5_000
+
+export function remainingMailPointerTypingQuiesceMs(input: {
+  lastUserInputAt: number | undefined
+  isOrcaWindowFocused: boolean
+  now?: number
+}): number | null {
+  if (!input.isOrcaWindowFocused || input.lastUserInputAt === undefined) {
+    return null
+  }
+  const elapsed = (input.now ?? performance.now()) - input.lastUserInputAt
+  if (elapsed >= MAIL_POINTER_USER_INPUT_QUIESCE_MS) {
+    return null
+  }
+  if (elapsed < 0) {
+    return MAIL_POINTER_USER_INPUT_QUIESCE_MS
+  }
+  return MAIL_POINTER_USER_INPUT_QUIESCE_MS - elapsed
+}
+
+export function shouldDeferMailboxPointerEnter(input: {
+  lastUserInputAt: number | undefined
+  isOrcaWindowFocused: boolean
+  now?: number
+}): boolean {
+  return remainingMailPointerTypingQuiesceMs(input) !== null
+}
+
+export function deferMailboxPointerForRecentTyping(args: {
+  ptyId: string
+  mailboxHandle: string
+  lastUserInputAt?: (ptyId: string) => number | undefined
+  isOrcaWindowFocused?: () => boolean
+  scheduleMailboxRetry?: (mailboxHandle: string, delayMs: number) => void
+  now?: number
+}): boolean {
+  if (!args.scheduleMailboxRetry) {
+    return false
+  }
+  const remaining = remainingMailPointerTypingQuiesceMs({
+    lastUserInputAt: args.lastUserInputAt?.(args.ptyId),
+    isOrcaWindowFocused: args.isOrcaWindowFocused?.() === true,
+    now: args.now
+  })
+  if (remaining === null) {
+    return false
+  }
+  args.scheduleMailboxRetry(args.mailboxHandle, Math.max(1, Math.ceil(remaining)))
+  return true
+}


### PR DESCRIPTION
## ELI5

Idle orchestration mail still typed `orca orchestration check` into a prompt you were already filling in, then hit Enter. That mixed your draft with the pointer and submitted it. This PR waits until that terminal has been quiet for 5 seconds while an Orca window is focused, then delivers — and it checks again before the delayed Enter so a keystroke in that 500ms gap cannot auto-submit.

This replaces the conflicting #14836, which targeted pre-split `orca-runtime` delivery, retried the wrong mailbox identity, passed a delay into a scheduler that did not accept one, skipped the focused-window condition and the Enter-callback guard, and had no tests.

## What Changed

- `RuntimePtyController` exposes `lastUserInputAt` (the existing `lastInputAtByPty` map from `writePtyInput` / `writePtyInputAccepted`) and `isOrcaWindowFocused` (main window or `BrowserWindow.getFocusedWindow()`).
- Before the pointer write, and again before the delayed Enter, delivery defers only when **this PTY** had user input in the last **5s** **and** an Orca window is focused. Unfocused / alt-tabbed sessions still get mail immediately.
- Retry goes through the current `MailPointerRepointScheduler` with an optional remaining-quiet delay and the **run mailbox** identity (`run:<id>`), not the terminal handle.
- Unread/waiter collection stays inlined on the delivery path (the previous `main` logic). `collectDeliverableMailboxPointerMessages` was removed: it was a max-lines extract, not required by #14832.
- No remote wire / RPC / stream change: timestamps and focus stay in the local main process.

## Why

`ptyController.write` used by push-on-idle does not update `lastInputAtByPty`, so the 100ms interactive-output window never saw orchestration writes as user typing — and it is the wrong window anyway. #14836 tried to fix this on the old inlined delivery path and is now unmergeable against the extracted mailbox-pointer modules.

## Linked Issue

Fixes #14832

Replaces #14836 (conflicted with `main` after the mailbox-pointer extraction; incomplete vs the issue spec).

## Visual Proof

N/A — no renderer or visual change. The behavior is a main-process PTY write/Enter guard. Live UI capture was not obtained: a source-built Electron renderer never loaded a URL.

## Testing

- Added unit tests for the 5s+focus predicate (including that 200ms is still inside the window, not the 100ms TUI redraw gate).
- Added scheduler tests for default 2s coalesce vs explicit remaining delay.
- Added runtime tests that fail on `main` and pass here: focused typing defers and retries `run:<id>`; unfocused recent typing still injects; a later keystroke during the wait re-defers; Enter is skipped if the user types after the pointer write.
- Added a PTY IPC test that `pty:write` stamps `lastUserInputAt` and that focus follows `mainWindow.isFocused()`.
- CodeRabbit follow-up at `2623558e88`: restored inlined unread/waiter collection; no function JSDoc added (existing eligibility/typing-guard helpers have none). Focused `vitest` 63 passed / 1 skipped; `oxlint` and `tsc --noEmit -p config/tsconfig.node.json` clean.
- Live Windows attempt (inconclusive): source-built Electron/Playwright launched in isolated Temp userData with packaged 1.4.183 kept separate, but the source-built renderer never loaded a URL, so the focused-typing/delayed-Enter PTY oracle was not observed and manual acceptance remains inconclusive.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated

## AI Disclosure

Implemented with Cursor Grok 4.6 as a dispatched worker on the Tauri-EPO fork.

## Review

Cross-platform: `lastInputAtByPty` is already updated from renderer `pty:write` on macOS/Linux/Windows, including SSH-proxied PTYs whose writes still enter main `writePtyInput`. No hardcoded shortcuts or path separators.

SSH / remote: no wire change. Host-side last-input + local window focus; a headless remote with no focused window does not defer (mail is not stranded). Folder workspaces use the same PTY path. Mobile `writePtyInput` still returns before stamping last-input (known gap, unchanged).

Performance: one `Map.get` + focus check on the idle-mail path, not the per-keystroke hot path. Scheduler still coalesces per mailbox handle.

Security: no new IPC, no new PTY write sources, no credential or prompt content inspection.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Full `pnpm lint` / `pnpm typecheck` / `pnpm test` / `pnpm build` were not run locally. Hosted CI on this fork branch requires maintainer approval (no checks reported).

## Author

- X / Twitter: @EnricoPin
