### PR TITLE
ci: render LoC + and - signs huge bold

### DIFF
--- a/.github/scripts/pr-test-loc-table.mjs
+++ b/.github/scripts/pr-test-loc-table.mjs
@@ -41,9 +41,9 @@ function diffCell(count) {
     return '0'
   }
   if (count > 0) {
-    return `$\\color{${COLOR_ADDED}}{+}$\u200b${count}`
+    return `$\\color{${COLOR_ADDED}}{\\Huge{\\mathbf{+}}}$\u200b${count}`
   }
-  return `$\\color{${COLOR_DELETED}}{−}$\u200b${Math.abs(count)}`
+  return `$\\color{${COLOR_DELETED}}{\\Huge{\\mathbf{−}}}$\u200b${Math.abs(count)}`
 }
 
 function locTableRow(label, bucket) {

--- a/config/scripts/pr-test-loc-summary.test.mjs
+++ b/config/scripts/pr-test-loc-summary.test.mjs
@@ -108,10 +108,10 @@ describe('PR test LoC summary', () => {
     })
 
     expect(block).toContain(
-      '| Test | 1 | $\\color{#1a7f37}{+}$\u200b2 | $\\color{#cf222e}{−}$\u200b5 | $\\color{#cf222e}{−}$\u200b3 |'
+      '| Test | 1 | $\\color{#1a7f37}{\\Huge{\\mathbf{+}}}$\u200b2 | $\\color{#cf222e}{\\Huge{\\mathbf{−}}}$\u200b5 | $\\color{#cf222e}{\\Huge{\\mathbf{−}}}$\u200b3 |'
     )
     expect(block).toContain(
-      '| Prod | 1 | 0 | $\\color{#cf222e}{−}$\u200b4 | $\\color{#cf222e}{−}$\u200b4 |'
+      '| Prod | 1 | 0 | $\\color{#cf222e}{\\Huge{\\mathbf{−}}}$\u200b4 | $\\color{#cf222e}{\\Huge{\\mathbf{−}}}$\u200b4 |'
     )
   })
 
@@ -124,10 +124,10 @@ describe('PR test LoC summary', () => {
 
     expect(block).toContain(LOC_HANDS_OFF_COMMENT)
     expect(block).toContain(
-      '| Test | 1 | $\\color{#1a7f37}{+}$\u200b2 | $\\color{#cf222e}{−}$\u200b1 | $\\color{#1a7f37}{+}$\u200b1 |'
+      '| Test | 1 | $\\color{#1a7f37}{\\Huge{\\mathbf{+}}}$\u200b2 | $\\color{#cf222e}{\\Huge{\\mathbf{−}}}$\u200b1 | $\\color{#1a7f37}{\\Huge{\\mathbf{+}}}$\u200b1 |'
     )
     expect(block).toContain(
-      '| Prod | 1 | $\\color{#1a7f37}{+}$\u200b4 | 0 | $\\color{#1a7f37}{+}$\u200b4 |'
+      '| Prod | 1 | $\\color{#1a7f37}{\\Huge{\\mathbf{+}}}$\u200b4 | 0 | $\\color{#1a7f37}{\\Huge{\\mathbf{+}}}$\u200b4 |'
     )
     expect(block).not.toContain('| Total |')
     expect(mergeLocBlock('## ELI5\n\nHello\n', totals)).toBe(`${block}\n\n## ELI5\n\nHello\n`)
@@ -160,10 +160,10 @@ describe('PR test LoC summary', () => {
     expect(result.stdout.startsWith('<!-- orca-pr-loc -->')).toBe(true)
     expect(result.stdout).toContain(LOC_HANDS_OFF_COMMENT)
     expect(result.stdout).toContain(
-      '| Test | 1 | $\\color{#1a7f37}{+}$\u200b6 | $\\color{#cf222e}{−}$\u200b1 | $\\color{#1a7f37}{+}$\u200b5 |'
+      '| Test | 1 | $\\color{#1a7f37}{\\Huge{\\mathbf{+}}}$\u200b6 | $\\color{#cf222e}{\\Huge{\\mathbf{−}}}$\u200b1 | $\\color{#1a7f37}{\\Huge{\\mathbf{+}}}$\u200b5 |'
     )
     expect(result.stdout).toContain(
-      '| Prod | 1 | $\\color{#1a7f37}{+}$\u200b2 | 0 | $\\color{#1a7f37}{+}$\u200b2 |'
+      '| Prod | 1 | $\\color{#1a7f37}{\\Huge{\\mathbf{+}}}$\u200b2 | 0 | $\\color{#1a7f37}{\\Huge{\\mathbf{+}}}$\u200b2 |'
     )
     expect(result.stdout).not.toContain('| Total |')
     expect(result.stdout).toContain('## ELI5\n\nHello\n')


### PR DESCRIPTION
## What Changed

Follow-up to #14839: the + and − signs in the test vs non-test LoC table are now huge and bold.

- `+` renders green (`#1a7f37`), `−` renders red (`#cf222e`), via `$\color{...}{\Huge{\mathbf{+}}}$`
- Digits stay in the normal body font; zero stays plain

## Example

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​175 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​163 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​350 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​350 |

## Testing

- [x] `pnpm exec vitest run --config config/vitest.config.ts config/scripts/pr-test-loc-summary.test.mjs` (9 passed)
- [x] `oxlint` clean