### PR TITLE
fix(linux): extend GPU software-render fallback to Linux desktop

### DIFF
--- a/src/main/crash-reporting/gpu-crash-fallback-decision.test.ts
+++ b/src/main/crash-reporting/gpu-crash-fallback-decision.test.ts
@@ -129,7 +129,7 @@ describe('GpuCrashFallbackTracker', () => {
 })
 
 describe('isGpuFallbackCrashCandidate', () => {
-  it('tracks only crash-shaped Windows GPU child failures', () => {
+  it('tracks crash-shaped GPU child failures on Windows', () => {
     for (const reason of ['abnormal-exit', 'crashed', 'launch-failed']) {
       expect(
         isGpuFallbackCrashCandidate({
@@ -141,7 +141,19 @@ describe('isGpuFallbackCrashCandidate', () => {
     }
   })
 
-  it('ignores normal GPU exits and non-Windows platforms', () => {
+  it('tracks crash-shaped GPU child failures on Linux', () => {
+    for (const reason of ['abnormal-exit', 'crashed', 'launch-failed']) {
+      expect(
+        isGpuFallbackCrashCandidate({
+          platform: 'linux',
+          processType: 'GPU',
+          reason
+        })
+      ).toBe(true)
+    }
+  })
+
+  it('ignores normal GPU exits and unsupported platforms', () => {
     expect(
       isGpuFallbackCrashCandidate({
         platform: 'win32',
@@ -158,7 +170,7 @@ describe('isGpuFallbackCrashCandidate', () => {
     ).toBe(false)
     expect(
       isGpuFallbackCrashCandidate({
-        platform: 'linux',
+        platform: 'darwin',
         processType: 'GPU',
         reason: 'crashed'
       })

--- a/src/main/crash-reporting/gpu-crash-fallback-decision.ts
+++ b/src/main/crash-reporting/gpu-crash-fallback-decision.ts
@@ -94,7 +94,7 @@ export function isGpuFallbackCrashCandidate({
   reason: string
 }): boolean {
   return (
-    platform === 'win32' &&
+    (platform === 'win32' || platform === 'linux') &&
     isGpuChildProcessType(processType) &&
     GPU_FALLBACK_CRASH_REASONS.has(reason)
   )

--- a/src/main/startup/configure-process.ts
+++ b/src/main/startup/configure-process.ts
@@ -284,7 +284,7 @@ export function enableMainProcessGpuFeatures(): void {
 
   if (process.platform === 'darwin') {
     // Why: Graphite can strand corrupt Metal tiles after idle; Ganesh preserves GPU compositing without the stale surface.
-    // Reached on every macOS launch only because GPU fallback skips this function and is win32-only; if fallback ever
+    // Reached on every macOS launch only because GPU fallback skips this function and is win32|linux only; if fallback ever
     // reaches macOS this must move out of this path or Macs silently lose the fix.
     app.commandLine.appendSwitch('disable-skia-graphite')
   }

--- a/src/main/startup/gpu-fallback-marker.test.ts
+++ b/src/main/startup/gpu-fallback-marker.test.ts
@@ -12,10 +12,15 @@ import {
 
 describe('gpu-fallback-marker', () => {
   let userDataPath: string
-  const environment = {
+  const win32Environment = {
     appVersion: '1.2.3',
     electronVersion: '42.3.3',
     platform: 'win32' as const
+  }
+  const linuxEnvironment = {
+    appVersion: '1.2.3',
+    electronVersion: '42.3.3',
+    platform: 'linux' as const
   }
 
   beforeEach(() => {
@@ -26,11 +31,11 @@ describe('gpu-fallback-marker', () => {
     rmSync(userDataPath, { recursive: true, force: true })
   })
 
-  it('round-trips a written marker', () => {
+  it('round-trips a written Windows marker', () => {
     writeGpuFallbackMarker(
       userDataPath,
       { engagedAt: 123, crashesInWindow: 3, userConfirmed: false },
-      environment
+      win32Environment
     )
     expect(readGpuFallbackMarker(userDataPath)).toEqual({
       schemeVersion: 3,
@@ -43,33 +48,66 @@ describe('gpu-fallback-marker', () => {
     })
   })
 
+  it('round-trips a written Linux marker', () => {
+    writeGpuFallbackMarker(
+      userDataPath,
+      { engagedAt: 456, crashesInWindow: 5, userConfirmed: false },
+      linuxEnvironment
+    )
+    expect(readGpuFallbackMarker(userDataPath)).toEqual({
+      schemeVersion: 3,
+      engagedAt: 456,
+      crashesInWindow: 5,
+      userConfirmed: false,
+      appVersion: '1.2.3',
+      electronVersion: '42.3.3',
+      platform: 'linux'
+    })
+  })
+
   it('persists explicit safe-graphics consent across launches', () => {
     writeGpuFallbackMarker(
       userDataPath,
       { engagedAt: 123, crashesInWindow: 3, userConfirmed: true },
-      environment
+      win32Environment
     )
-    expect(readActiveGpuFallbackMarker(userDataPath, environment)?.userConfirmed).toBe(true)
+    expect(readActiveGpuFallbackMarker(userDataPath, win32Environment)?.userConfirmed).toBe(true)
   })
 
   it('returns null when no marker exists', () => {
     expect(readGpuFallbackMarker(userDataPath)).toBeNull()
-    expect(readActiveGpuFallbackMarker(userDataPath, environment)).toBeNull()
+    expect(readActiveGpuFallbackMarker(userDataPath, win32Environment)).toBeNull()
+    expect(readActiveGpuFallbackMarker(userDataPath, linuxEnvironment)).toBeNull()
   })
 
-  it('keeps an active marker for repeated launches on the same build', () => {
+  it('keeps an active marker for repeated launches on the same build (Windows)', () => {
     writeGpuFallbackMarker(
       userDataPath,
       { engagedAt: 1, crashesInWindow: 4, userConfirmed: false },
-      environment
+      win32Environment
     )
     expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(true)
 
-    const firstRead = readActiveGpuFallbackMarker(userDataPath, environment)
+    const firstRead = readActiveGpuFallbackMarker(userDataPath, win32Environment)
     expect(firstRead?.crashesInWindow).toBe(4)
     expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(true)
 
-    const secondRead = readActiveGpuFallbackMarker(userDataPath, environment)
+    const secondRead = readActiveGpuFallbackMarker(userDataPath, win32Environment)
+    expect(secondRead?.crashesInWindow).toBe(4)
+  })
+
+  it('keeps an active marker for repeated launches on the same build (Linux)', () => {
+    writeGpuFallbackMarker(
+      userDataPath,
+      { engagedAt: 1, crashesInWindow: 4, userConfirmed: false },
+      linuxEnvironment
+    )
+    expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(true)
+
+    const firstRead = readActiveGpuFallbackMarker(userDataPath, linuxEnvironment)
+    expect(firstRead?.crashesInWindow).toBe(4)
+
+    const secondRead = readActiveGpuFallbackMarker(userDataPath, linuxEnvironment)
     expect(secondRead?.crashesInWindow).toBe(4)
   })
 
@@ -77,31 +115,42 @@ describe('gpu-fallback-marker', () => {
     writeGpuFallbackMarker(
       userDataPath,
       { engagedAt: 1, crashesInWindow: 4, userConfirmed: false },
-      environment
+      win32Environment
     )
 
     expect(
       readActiveGpuFallbackMarker(userDataPath, {
-        ...environment,
+        ...win32Environment,
         appVersion: '1.2.4'
       })
     ).toBeNull()
     expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(false)
   })
 
-  it('clears an active marker outside Windows', () => {
+  it('clears a Linux marker when the app build changes', () => {
     writeGpuFallbackMarker(
       userDataPath,
       { engagedAt: 1, crashesInWindow: 4, userConfirmed: false },
-      environment
+      linuxEnvironment
     )
 
     expect(
       readActiveGpuFallbackMarker(userDataPath, {
-        ...environment,
-        platform: 'linux'
+        ...linuxEnvironment,
+        appVersion: '1.2.4'
       })
     ).toBeNull()
+    expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(false)
+  })
+
+  it('clears a marker when the platform changes between supported platforms', () => {
+    writeGpuFallbackMarker(
+      userDataPath,
+      { engagedAt: 1, crashesInWindow: 4, userConfirmed: false },
+      win32Environment
+    )
+
+    expect(readActiveGpuFallbackMarker(userDataPath, linuxEnvironment)).toBeNull()
     expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(false)
   })
 
@@ -112,12 +161,12 @@ describe('gpu-fallback-marker', () => {
     writeGpuFallbackMarker(
       userDataPath,
       { engagedAt: 1, crashesInWindow: 4, userConfirmed: false },
-      environment
+      win32Environment
     )
 
     expect(
       readActiveGpuFallbackMarker(userDataPath, {
-        ...environment,
+        ...win32Environment,
         platform: 'darwin'
       })
     ).toBeNull()
@@ -127,7 +176,7 @@ describe('gpu-fallback-marker', () => {
   it('clears a corrupt or wrong-version marker', () => {
     writeFileSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE), '{ not json')
     expect(readGpuFallbackMarker(userDataPath)).toBeNull()
-    expect(readActiveGpuFallbackMarker(userDataPath, environment)).toBeNull()
+    expect(readActiveGpuFallbackMarker(userDataPath, win32Environment)).toBeNull()
     expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(false)
 
     writeFileSync(
@@ -135,15 +184,31 @@ describe('gpu-fallback-marker', () => {
       JSON.stringify({ schemeVersion: 999, engagedAt: 1, crashesInWindow: 1 })
     )
     expect(readGpuFallbackMarker(userDataPath)).toBeNull()
-    expect(readActiveGpuFallbackMarker(userDataPath, environment)).toBeNull()
+    expect(readActiveGpuFallbackMarker(userDataPath, win32Environment)).toBeNull()
     expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(false)
+  })
+
+  it('rejects a marker with an unsupported platform value', () => {
+    writeFileSync(
+      join(userDataPath, GPU_FALLBACK_MARKER_FILE),
+      JSON.stringify({
+        schemeVersion: 3,
+        engagedAt: 1,
+        crashesInWindow: 3,
+        userConfirmed: false,
+        appVersion: '1.2.3',
+        electronVersion: '42.3.3',
+        platform: 'darwin'
+      })
+    )
+    expect(readGpuFallbackMarker(userDataPath)).toBeNull()
   })
 
   it('can explicitly clear the marker', () => {
     writeGpuFallbackMarker(
       userDataPath,
       { engagedAt: 1, crashesInWindow: 4, userConfirmed: false },
-      environment
+      win32Environment
     )
     clearGpuFallbackMarker(userDataPath)
     expect(readGpuFallbackMarker(userDataPath)).toBeNull()

--- a/src/main/startup/gpu-fallback-marker.ts
+++ b/src/main/startup/gpu-fallback-marker.ts
@@ -13,13 +13,26 @@ import { join } from 'node:path'
 export const GPU_FALLBACK_MARKER_FILE = 'gpu-fallback.json'
 export const GPU_FALLBACK_SCHEME_VERSION = 3
 
+// Why not darwin: enableMainProcessGpuFeatures() carries the macOS
+// disable-skia-graphite fix; skipping it under fallback would silently
+// strip the fix from Macs.
+export type GpuFallbackPlatform = 'win32' | 'linux'
+
+const GPU_FALLBACK_PLATFORMS: ReadonlySet<string> = new Set<GpuFallbackPlatform>(['win32', 'linux'])
+
+export function isGpuFallbackPlatform(value: unknown): value is GpuFallbackPlatform {
+  return typeof value === 'string' && GPU_FALLBACK_PLATFORMS.has(value)
+}
+
 export type GpuFallbackEnvironment = {
   appVersion: string
   electronVersion: string
   platform: NodeJS.Platform
 }
 
-export type WindowsGpuFallbackEnvironment = GpuFallbackEnvironment & { platform: 'win32' }
+export type SupportedGpuFallbackEnvironment = GpuFallbackEnvironment & {
+  platform: GpuFallbackPlatform
+}
 
 export type GpuFallbackMarker = {
   schemeVersion: number
@@ -28,7 +41,7 @@ export type GpuFallbackMarker = {
   userConfirmed: boolean
   appVersion: string
   electronVersion: string
-  platform: 'win32'
+  platform: GpuFallbackPlatform
 }
 
 function markerPath(userDataPath: string): string {
@@ -51,7 +64,7 @@ export function readGpuFallbackMarker(userDataPath: string): GpuFallbackMarker |
       typeof parsed.userConfirmed !== 'boolean' ||
       typeof parsed.appVersion !== 'string' ||
       typeof parsed.electronVersion !== 'string' ||
-      parsed.platform !== 'win32'
+      !isGpuFallbackPlatform(parsed.platform)
     ) {
       return null
     }
@@ -73,7 +86,7 @@ export function readGpuFallbackMarker(userDataPath: string): GpuFallbackMarker |
 export function writeGpuFallbackMarker(
   userDataPath: string,
   info: { engagedAt: number; crashesInWindow: number; userConfirmed: boolean },
-  environment: WindowsGpuFallbackEnvironment
+  environment: SupportedGpuFallbackEnvironment
 ): void {
   const marker: GpuFallbackMarker = {
     schemeVersion: GPU_FALLBACK_SCHEME_VERSION,
@@ -82,7 +95,7 @@ export function writeGpuFallbackMarker(
     userConfirmed: info.userConfirmed,
     appVersion: environment.appVersion,
     electronVersion: environment.electronVersion,
-    platform: 'win32'
+    platform: environment.platform
   }
   writeFileSync(markerPath(userDataPath), JSON.stringify(marker))
 }
@@ -107,7 +120,7 @@ export function readActiveGpuFallbackMarker(
     return null
   }
   if (
-    environment.platform !== 'win32' ||
+    !isGpuFallbackPlatform(environment.platform) ||
     marker.platform !== environment.platform ||
     marker.appVersion !== environment.appVersion ||
     marker.electronVersion !== environment.electronVersion

--- a/src/main/startup/gpu-fallback-switches.test.ts
+++ b/src/main/startup/gpu-fallback-switches.test.ts
@@ -2,19 +2,28 @@ import { describe, expect, it, vi } from 'vitest'
 import { applyGpuFallbackCommandLineSwitches } from './gpu-fallback-switches'
 
 describe('GPU fallback command-line switches', () => {
-  it('applies nothing outside Windows', () => {
-    for (const platform of ['darwin', 'linux'] as const) {
-      const appendSwitch = vi.fn()
-      expect(applyGpuFallbackCommandLineSwitches({ appendSwitch }, platform)).toEqual([])
-      expect(appendSwitch).not.toHaveBeenCalled()
-    }
+  it('applies nothing on unsupported platforms', () => {
+    const appendSwitch = vi.fn()
+    expect(applyGpuFallbackCommandLineSwitches({ appendSwitch }, 'darwin')).toEqual([])
+    expect(appendSwitch).not.toHaveBeenCalled()
   })
 
   // Why: measured on Windows 11 / Electron 43.1.0 — `--disable-gpu` alone still reports
   // GPU: 1 in app.getAppMetrics(); adding --in-process-gpu drops it to 0.
-  it('appends exactly the measured switch set to the Electron command line', () => {
+  it('appends exactly the measured switch set on Windows', () => {
     const appendSwitch = vi.fn()
     const appliedSwitches = applyGpuFallbackCommandLineSwitches({ appendSwitch }, 'win32')
+    expect(appliedSwitches).toEqual([
+      'disable-gpu',
+      'disable-software-rasterizer',
+      'in-process-gpu'
+    ])
+    expect(appendSwitch.mock.calls.map(([name]) => name)).toEqual(appliedSwitches)
+  })
+
+  it('appends the same switch set on Linux', () => {
+    const appendSwitch = vi.fn()
+    const appliedSwitches = applyGpuFallbackCommandLineSwitches({ appendSwitch }, 'linux')
     expect(appliedSwitches).toEqual([
       'disable-gpu',
       'disable-software-rasterizer',

--- a/src/main/startup/gpu-fallback-switches.ts
+++ b/src/main/startup/gpu-fallback-switches.ts
@@ -18,9 +18,8 @@ const GPU_FALLBACK_COMMAND_LINE_SWITCHES = [
   'in-process-gpu'
 ] as const
 
-/** Software rendering is a Windows-only post-crash fallback; every other platform gets nothing. */
 function resolveGpuFallbackSwitches(platform: NodeJS.Platform): readonly string[] {
-  return platform === 'win32' ? GPU_FALLBACK_COMMAND_LINE_SWITCHES : []
+  return platform === 'win32' || platform === 'linux' ? GPU_FALLBACK_COMMAND_LINE_SWITCHES : []
 }
 
 export function applyGpuFallbackCommandLineSwitches(

--- a/src/main/startup/gpu-lifecycle.ts
+++ b/src/main/startup/gpu-lifecycle.ts
@@ -4,9 +4,10 @@ import { destroySystemTray } from '../tray/system-tray'
 import { applyGpuFallbackCommandLineSwitches } from './gpu-fallback-switches'
 import {
   clearGpuFallbackMarker,
+  isGpuFallbackPlatform,
   readActiveGpuFallbackMarker,
   writeGpuFallbackMarker,
-  type WindowsGpuFallbackEnvironment
+  type SupportedGpuFallbackEnvironment
 } from './gpu-fallback-marker'
 import {
   handleGpuFallbackRecoveredLaunch,
@@ -31,9 +32,12 @@ export function updateGpuAccelerationAboutPanel(): void {
   )
 }
 
-function getWindowsGpuFallbackEnvironment(): WindowsGpuFallbackEnvironment | null {
+function getSupportedGpuFallbackEnvironment(): SupportedGpuFallbackEnvironment | null {
   const environment = gpuFallbackEnvironment()
-  return environment.platform === 'win32' ? { ...environment, platform: 'win32' } : null
+  if (!isGpuFallbackPlatform(environment.platform)) {
+    return null
+  }
+  return { ...environment, platform: environment.platform }
 }
 
 // Writes both crash-time and post-recovery consent states through one build-scoped path.
@@ -41,7 +45,7 @@ function persistGpuFallbackMarker(
   userDataPath: string,
   info: { engagedAt: number; crashesInWindow: number; userConfirmed: boolean }
 ): boolean {
-  const environment = getWindowsGpuFallbackEnvironment()
+  const environment = getSupportedGpuFallbackEnvironment()
   if (!environment) {
     return false
   }
@@ -54,9 +58,9 @@ function persistGpuFallbackMarker(
   }
 }
 
-// Read before app.whenReady() so app.disableHardwareAcceleration() takes effect. Windows desktop only.
+// Read before app.whenReady() so app.disableHardwareAcceleration() takes effect. Windows/Linux desktop only.
 export function maybeApplyGpuFallbackForThisLaunch(): void {
-  if (state.isServeMode || process.platform !== 'win32') {
+  if (state.isServeMode || !isGpuFallbackPlatform(process.platform)) {
     return
   }
   const marker = readActiveGpuFallbackMarker(app.getPath('userData'), gpuFallbackEnvironment())


### PR DESCRIPTION
On Linux without a usable GPU, Chromium's GPU child process crashes repeatedly (ContextResult::kTransientFailure / GpuControl.CreateCommandBuffer), eventually taking the renderer down with it.

The existing Windows-only fallback detects a burst of GPU child crashes, persists a build-scoped marker, and disables hardware acceleration on the next launch. This commit extends that machinery to Linux:

- GpuFallbackPlatform union type ('win32' | 'linux') replaces the hardcoded 'win32' platform literal throughout the marker, switches, and crash-decision modules.
- isGpuFallbackCrashCandidate now accepts Linux GPU child crashes.
- resolveGpuFallbackSwitches applies the same switch set on Linux (disable-gpu, disable-software-rasterizer, in-process-gpu).
- maybeApplyGpuFallbackForThisLaunch and the marker write path in handleGpuChildCrash use the platform-generic helpers.
- macOS remains excluded (the Graphite fix in enableMainProcessGpuFeatures must not be skipped).

Tests cover Linux marker round-trip, active-marker persistence across launches, cross-platform marker invalidation, and the Linux switch set.

## ELI5

<!-- Simple high-level explanation -->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- What problem does this solve, and why is this approach right? -->

## Linked Issue

<!-- Link the issue this PR addresses, there should ALWAYS be one -->

Fixes #

## Visual Proof
<!-- REQUIRED for UI / behavior changes. Please attach a BEFORE and AFTER that can easily tabbed/switched. Use videos for when appropriate over screenshots -->
<!-- If there is truly no visual or interaction change, write exactly: `N/A` and briefly say why. -->
<!-- For attachments NEVER add directly to the PR files (do not commit to files), use `gh image` extension or drag + drop (works for any attachment) -->

## Testing

<!-- How did you verify this? Steps a reviewer can follow. Which platforms did you actually test (macOS / Linux / Windows / SSH)? -->

- [ ] I manually tested these changes locally
- [ ] Automated tests added/updated, or explained why not below


## AI Disclosure
<!-- DO NOT FILL IN IF YOU ARE STABLYAI TEAM MEMBER (INTERNAL CONTRIBUTOR), IGNORE SECTION: -->
<!-- Which AI model if anyone was used, please state the details -->

## Review

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [ ] Self-reviewed for correctness, security, and performance
- [ ] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

