### PR TITLE
test(mock-server): serve an omp native-chat scenario

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -184,6 +184,7 @@ Connect from the app using endpoint `ws://localhost:6768` and token `mock-device
 ### Environment variables
 
 - `MOCK_NATIVE_CHAT=1` — serve the native-chat scenario (one live agent tab, empty transcript, image upload) instead of the default terminal fixtures.
+- `MOCK_CHAT_AGENT=omp` — with `MOCK_NATIVE_CHAT=1`, present the scenario's agent tab as omp (no `transcriptPath`, a realistic decoded transcript) instead of the default claude, exercising mobile's omp readability gate and renderer.
 - `MOCK_SERVER_KEY_FILE` — persist the server keypair across restarts so a paired device keeps its public-key pin. A missing or invalid file is re-keyed with a warning, which forces a re-pair.
 
 ### Scenario control files

--- a/mobile/scripts/mock-server-native-chat-scenario.ts
+++ b/mobile/scripts/mock-server-native-chat-scenario.ts
@@ -25,6 +25,10 @@ const TAB_ID = 'chat-tab-1'
 const SESSION_ID = 'mock-chat-session'
 const TRANSCRIPT_PATH = join(tmpdir(), 'mock-transcript.jsonl')
 const MOCK_IMAGE_PATH = join(tmpdir(), 'mock-image.png')
+// Why: omp is the one supported agent whose hook reports no transcript path
+// (`extractAgentProviderSession` keeps only its session id), so the scenario
+// must be able to present that shape — mobile gates omp chat on readability.
+const CHAT_AGENT = process.env.MOCK_CHAT_AGENT === 'omp' ? 'omp' : 'claude'
 
 function readControl(file: string): string {
   try {
@@ -41,28 +45,27 @@ const agentStatus: AgentStatusEntry = {
   prompt: '',
   updatedAt: Date.now(),
   stateStartedAt: Date.now(),
-  agentType: 'claude',
+  agentType: CHAT_AGENT,
   paneKey: `${TAB_ID}:leaf-1`,
   terminalHandle: TERMINAL_HANDLE,
   stateHistory: [],
-  providerSession: {
-    key: 'session_id',
-    id: SESSION_ID,
-    transcriptPath: TRANSCRIPT_PATH
-  }
+  providerSession:
+    CHAT_AGENT === 'omp'
+      ? { key: 'session_id', id: SESSION_ID }
+      : { key: 'session_id', id: SESSION_ID, transcriptPath: TRANSCRIPT_PATH }
 }
 
 function buildTab(): RuntimeMobileSessionTerminalClientTab {
   return {
     type: 'terminal',
     id: TAB_ID,
-    title: 'Claude Code',
+    title: CHAT_AGENT === 'omp' ? 'OMP' : 'Claude Code',
     parentTabId: TAB_ID,
     leafId: 'leaf-1',
     ptyId: 'pty-1',
     status: 'ready',
     terminal: TERMINAL_HANDLE,
-    launchAgent: 'claude',
+    launchAgent: CHAT_AGENT,
     agentStatus,
     viewMode: 'chat',
     isActive: true
@@ -102,6 +105,51 @@ function tabsResultIfChanged(worktree: string): RuntimeMobileSessionTabsResult |
 function worktreeOf(request: RpcRequest): string {
   const raw = request.params?.worktree
   return typeof raw === 'string' ? raw : 'id:mock-worktree'
+}
+
+// Why: shapes mirror what the runtime's omp decoder emits for a real session
+// (thinking→text on the assistant turn, toolCall blocks, toolResult turns), so
+// the phone exercises the same render path a live omp pane would.
+function mockTranscript(): unknown[] {
+  if (CHAT_AGENT !== 'omp') {
+    return []
+  }
+  const t = Date.now() - 1000 * 60 * 5
+  return [
+    {
+      id: 'omp-1',
+      role: 'user',
+      blocks: [{ type: 'text', text: 'why is my deploy failing?' }],
+      timestamp: t,
+      source: 'transcript'
+    },
+    {
+      id: 'omp-2',
+      role: 'assistant',
+      blocks: [
+        { type: 'text', text: 'Let me check the deploy logs first.' },
+        { type: 'tool-call', name: 'bash', input: { command: 'kubectl get pods' } }
+      ],
+      timestamp: t + 1000,
+      source: 'transcript'
+    },
+    {
+      id: 'omp-3',
+      role: 'tool',
+      blocks: [{ type: 'tool-result', output: 'api-7f9c 0/1 CrashLoopBackOff' }],
+      timestamp: t + 2000,
+      source: 'transcript'
+    },
+    {
+      id: 'omp-4',
+      role: 'assistant',
+      blocks: [
+        { type: 'text', text: 'The API pod is crash-looping. Check its logs with kubectl logs.' }
+      ],
+      timestamp: t + 3000,
+      source: 'transcript'
+    }
+  ]
 }
 
 // Why: unsubscribe correlates by worktree, not request id, and a socket that
@@ -209,11 +257,13 @@ export function handleMockNativeChatRequest(
     }
 
     case 'nativeChat.subscribe':
-      respond(success(request.id, { type: 'snapshot', messages: [], hasMore: false }, true))
+      respond(
+        success(request.id, { type: 'snapshot', messages: mockTranscript(), hasMore: false }, true)
+      )
       return true
 
     case 'nativeChat.readSession':
-      respond(success(request.id, { messages: [], hasMore: false }))
+      respond(success(request.id, { messages: mockTranscript(), hasMore: false }))
       return true
 
     case 'terminal.subscribe': {


### PR DESCRIPTION
## Summary

The mock server's native-chat scenario is hardcoded to `claude`, so mobile's omp support can only be exercised against a live runtime. `MOCK_CHAT_AGENT=omp` switches the scenario's agent tab to omp with the two omp-specific shapes that matter:

- a `providerSession` **without** `transcriptPath` — omp's hook discloses only its session id (`extractAgentProviderSession`), and mobile gates omp chat on readability, so this is the shape that must be mockable;
- a four-message decoded transcript (user, assistant with a tool-call block, tool result, assistant) shaped like the runtime's omp decoder output (`decodeOmpTranscriptLine`), so the phone runs the same render path a live omp pane would.

Default behaviour is unchanged: without the env var the scenario is identical to today's claude one.

## Screenshots

No visual change — this populates the existing mock with different data. Verified on the iOS simulator against `MOCK_NATIVE_CHAT=1 MOCK_CHAT_AGENT=omp`: the omp chat view renders all four messages including the tool-call block.

## Testing

- [x] \`pnpm lint\` (mobile) — 0 warnings, 0 errors.
- [x] \`pnpm typecheck\` (mobile) — clean.
- [x] Manual: paired the simulator app to the mock with \`MOCK_CHAT_AGENT=omp\`; the tab presents as OMP with no transcript path and the chat view renders the transcript.

## AI Review Report

**Risks checked:** whether omp needed a transcriptPath to stay realistic; whether the transcript shapes matched the real decoder rather than an invented format; whether default (claude) behaviour could change.

**Findings and outcomes:**
- Confirmed omp's hook reports no transcript path — the omp branch of the providerSession mirrors `extractAgentProviderSession` exactly; adding a path would mock a shape the real runtime never sends.
- Confirmed each block type against `decodeOmpTranscriptLine` output for a real session (text/thinking→text, toolCall→tool-call with object input, toolResult→tool with output) — no invented block types.
- The claude path is bit-identical when the env var is absent (\`CHAT_AGENT\` defaults to \`'claude'\` and every branch resolves to the previous values).

**Cross-platform:** the change is a dev-only Node mock script plus a README line; no app code, no platform-conditional logic.

## Security Audit

- **Input handling** — reads one env var at module load; no untrusted input.
- **Command execution / path handling** — none added.
- **Auth / secrets** — none; dev fixture only, never shipped.
- **Dependencies / IPC** — none added.

**Follow-up:** none identified.