### PR TITLE
fix(persistence): address review feedback on extracted modules

### DIFF
--- a/src/main/persistence-host-partitioned-sessions.test.ts
+++ b/src/main/persistence-host-partitioned-sessions.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import type { WorkspaceSessionState } from '../shared/workspace-session-state-types'
 import { getDefaultWorkspaceSession } from '../shared/constants'
+import { isTerminalLeafId } from '../shared/stable-pane-id'
 import {
   testState,
   createStore,
@@ -163,6 +164,63 @@ describe('Store host-partitioned workspace sessions', () => {
     const store = await createStore()
 
     expect(store.getWorkspaceSession('local').activeRepoId).toBe('canonical-local')
+  })
+
+  it('rewrites legacy pane ids inside a host partition and remaps its leases', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      workspaceSession: makeHostSession('local-repo'),
+      workspaceSessionsByHostId: {
+        'ssh:host-b': {
+          ...getDefaultWorkspaceSession(),
+          activeRepoId: 'repo-ssh',
+          activeWorktreeId: 'repo-ssh::/worktree',
+          activeTabId: 'tab-ssh',
+          tabsByWorktree: {
+            'repo-ssh::/worktree': [
+              {
+                id: 'tab-ssh',
+                worktreeId: 'repo-ssh::/worktree',
+                title: 'Terminal',
+                customTitle: null,
+                color: null,
+                sortOrder: 0,
+                createdAt: 1,
+                ptyId: 'remote-pty'
+              }
+            ]
+          },
+          terminalLayoutsByTabId: {
+            'tab-ssh': {
+              root: { type: 'leaf', leafId: 'pane:1' },
+              activeLeafId: 'pane:1',
+              expandedLeafId: null,
+              ptyIdsByLeafId: { 'pane:1': 'remote-pty' }
+            }
+          }
+        }
+      },
+      sshRemotePtyLeases: [
+        {
+          targetId: 'ssh-1',
+          ptyId: 'remote-pty',
+          worktreeId: 'repo-ssh::/worktree',
+          tabId: 'tab-ssh',
+          leafId: 'pane:1',
+          state: 'detached',
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ]
+    })
+
+    const store = await createStore()
+
+    const root = store.getWorkspaceSession('ssh:host-b').terminalLayoutsByTabId['tab-ssh']?.root
+    const leafId = root?.type === 'leaf' ? root.leafId : null
+    expect(leafId && isTerminalLeafId(leafId)).toBe(true)
+    // The lease follows the partition's rewritten leaf, not the legacy `pane:1`.
+    expect(store.getSshRemotePtyLeases('ssh-1')[0]?.leafId).toBe(leafId)
   })
 
   it('isolates writes: setting host A does not mutate host B or local', async () => {

--- a/src/main/persistence/applying-settings/onboarding-normalization.ts
+++ b/src/main/persistence/applying-settings/onboarding-normalization.ts
@@ -42,10 +42,20 @@ export function normalizeNotificationSettings(value: unknown): NotificationSetti
     typeof rawVolume === 'number' && Number.isFinite(rawVolume)
       ? Math.min(100, Math.max(0, rawVolume))
       : defaults.customSoundVolume
+  // Why field-by-field: a blanket spread let a type-flipped value on disk through, so `enabled: "false"`
+  // stayed truthy and `customSoundPath: 42` reached the sound loader.
+  const booleanOr = (raw: unknown, fallback: boolean): boolean =>
+    typeof raw === 'boolean' ? raw : fallback
   return {
-    ...defaults,
-    ...candidate,
+    enabled: booleanOr(candidate.enabled, defaults.enabled),
+    agentTaskComplete: booleanOr(candidate.agentTaskComplete, defaults.agentTaskComplete),
+    terminalBell: booleanOr(candidate.terminalBell, defaults.terminalBell),
+    suppressWhenFocused: booleanOr(candidate.suppressWhenFocused, defaults.suppressWhenFocused),
     customSoundId,
+    customSoundPath:
+      typeof candidate.customSoundPath === 'string'
+        ? candidate.customSoundPath
+        : defaults.customSoundPath,
     customSoundVolume
   }
 }

--- a/src/main/persistence/applying-settings/ui-selection-normalization.ts
+++ b/src/main/persistence/applying-settings/ui-selection-normalization.ts
@@ -84,12 +84,13 @@ export function normalizeRightSidebarExplorerView(
   view: unknown,
   tab?: unknown
 ): PersistedState['ui']['rightSidebarExplorerView'] {
-  // Why: older builds persisted Search as a standalone activity tab.
-  if (tab === 'search') {
-    return 'search'
-  }
   if (view === 'files' || view === 'search') {
     return view
+  }
+  // Why: older builds persisted Search as a standalone activity tab with no explorer view; 'search'
+  // is still a live tab, so this fallback must not outrank an explicit view.
+  if (tab === 'search') {
+    return 'search'
   }
   return getDefaultUIState().rightSidebarExplorerView
 }

--- a/src/main/persistence/leasing-ssh-ptys/ssh-pty-lease-operations.ts
+++ b/src/main/persistence/leasing-ssh-ptys/ssh-pty-lease-operations.ts
@@ -38,9 +38,14 @@ export function upsertSshRemotePtyLease(
   )
   const existing =
     existingIndex !== -1 ? operations.state.sshRemotePtyLeases[existingIndex] : undefined
+  // Why: callers pass optional fields as explicit `undefined`, which would blank the stored tabId/leafId
+  // (and friends) when re-upserting an existing lease.
+  const definedLease = Object.fromEntries(
+    Object.entries(normalizedLease).filter(([, value]) => value !== undefined)
+  ) as typeof normalizedLease
   const next: SshRemotePtyLease = {
     ...existing,
-    ...normalizedLease,
+    ...definedLease,
     createdAt: existing?.createdAt ?? normalizedLease.createdAt ?? now,
     updatedAt: normalizedLease.updatedAt ?? now
   }

--- a/src/main/persistence/loading-store/store.ts
+++ b/src/main/persistence/loading-store/store.ts
@@ -210,6 +210,7 @@ import {
   stripRetiredGlobalSettings
 } from '../applying-settings/terminal-settings-migrations'
 import {
+  normalizeRightSidebarExplorerView,
   normalizeRightSidebarTab,
   normalizeShowDotfilesByWorktree,
   normalizeSortBy
@@ -1410,6 +1411,12 @@ export class Store {
               // Why: migrate once from the retired Appearance setting only when no explicit chrome preference exists yet.
               rightSidebarOpen,
               rightSidebarTab: normalizeRightSidebarTab(parsed.ui?.rightSidebarTab),
+              // Why here and not in getPersistedUI: only the raw payload still shows the legacy
+              // "Search tab, no explorer view" shape — the defaults spread above fills in 'files'.
+              rightSidebarExplorerView: normalizeRightSidebarExplorerView(
+                parsed.ui?.rightSidebarExplorerView,
+                parsed.ui?.rightSidebarTab
+              ),
               setupGuideSidebarDismissed,
               usagePercentageDisplayChangeNoticeDismissed,
               setupGuideBrowserMilestoneMigrated:

--- a/src/main/persistence/loading-store/user-data-path.ts
+++ b/src/main/persistence/loading-store/user-data-path.ts
@@ -67,6 +67,10 @@ export function getCanonicalUserDataPath(): string {
  * Copy legacy mobile pairing credentials into the canonical userData directory.
  *
  * Copies the registry and E2EE keypair forward as a pair so an update doesn't force a re-pair or mix devices with the wrong key.
+ *
+ * Sources are deliberately left in place: a copy-then-delete has no atomic form across the userData
+ * dirs, and losing the originals to a crash mid-migration would strand every paired device. They stay
+ * readable by an older build the user rolls back to; removing them is a separate cleanup decision.
  */
 export function migrateMobilePairingDataToCanonicalUserDataPath(sourceUserDataDir: string): void {
   const targetUserDataDir = getCanonicalUserDataPath()

--- a/src/main/persistence/restoring-sessions/folder-workspace-operations.ts
+++ b/src/main/persistence/restoring-sessions/folder-workspace-operations.ts
@@ -66,9 +66,10 @@ export class FolderWorkspacePersistenceOperations {
     const group = (this.state.projectGroups ?? []).find(
       (entry) => entry.id === input.projectGroupId
     )
+    // Why trim: the guard below accepts a padded path, so persist the same value it validated.
     const folderPath =
       typeof input.folderPath === 'string' && input.folderPath.trim().length > 0
-        ? input.folderPath
+        ? input.folderPath.trim()
         : group?.parentPath
     if (!group || !folderPath) {
       throw new Error('Folder-backed project group not found.')
@@ -137,7 +138,7 @@ export class FolderWorkspacePersistenceOperations {
       workspace.name = normalizeFolderWorkspaceName(updates.name, workspace.name)
     }
     if (typeof updates.folderPath === 'string' && updates.folderPath.trim().length > 0) {
-      workspace.folderPath = updates.folderPath
+      workspace.folderPath = updates.folderPath.trim()
     }
     if (updates.linkedTask !== undefined) {
       workspace.linkedTask = normalizeWorkspaceLinkedItem(updates.linkedTask)

--- a/src/main/persistence/restoring-sessions/pane-identity-migration.ts
+++ b/src/main/persistence/restoring-sessions/pane-identity-migration.ts
@@ -1,7 +1,6 @@
 import type { LegacyPaneKeyAliasEntry } from '../../../shared/persisted-state-types'
 import type { TerminalLayoutSnapshot } from '../../../shared/terminal-tab-types'
 import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
-import type { MigrationUnsupportedPtyEntry } from '../../../shared/agent-status-types'
 import { isTerminalLeafId, makePaneKey } from '../../../shared/stable-pane-id'
 import { agentHookServer } from '../../agent-hooks/server'
 import { collectLayoutLeafIdsInOrder, firstLayoutLeafId } from './terminal-layout-normalization'
@@ -18,18 +17,14 @@ export function findWorktreeIdForTab(
   return undefined
 }
 
-export type PaneIdentityMigrationEntries = {
-  migrationUnsupportedEntries: MigrationUnsupportedPtyEntry[]
-  legacyPaneKeyAliasEntries: LegacyPaneKeyAliasEntry[]
-}
-
-export function collectMigrationUnsupportedPtyEntries(args: {
+/** Bridges a tab's legacy numeric pane keys to stable ones; returns the alias rows worth persisting. */
+export function registerLegacyPaneKeyAliasesForTab(args: {
   session: WorkspaceSessionState
   tabId: string
   inputLayout: TerminalLayoutSnapshot
   normalizedLayout: TerminalLayoutSnapshot
   leafIdByInputLeafId: Map<string, string>
-}): PaneIdentityMigrationEntries {
+}): LegacyPaneKeyAliasEntry[] {
   const worktreeId = findWorktreeIdForTab(args.session, args.tabId)
   const tab = worktreeId
     ? args.session.tabsByWorktree?.[worktreeId]?.find((entry) => entry.id === args.tabId)
@@ -111,6 +106,5 @@ export function collectMigrationUnsupportedPtyEntries(args: {
       }
     }
   }
-  // Why: legacy numeric pane keys are now bridged by aliases, not persisted as restart-required rows.
-  return { migrationUnsupportedEntries: [], legacyPaneKeyAliasEntries }
+  return legacyPaneKeyAliasEntries
 }

--- a/src/main/persistence/restoring-sessions/terminal-layout-normalization.ts
+++ b/src/main/persistence/restoring-sessions/terminal-layout-normalization.ts
@@ -174,8 +174,13 @@ export function normalizeTerminalLayoutSnapshotForPersistence(
   )
   const inputLeafIdsInOrder = collectLayoutLeafIdsInOrder(inputRoot)
   const preferredLeafIdsInOrder = collectLayoutLeafIdsInOrder(preferredLayout?.root)
-  const usePreferredLeafIds = preferredLeafIdsInOrder.length === inputLeafIdsInOrder.length
+  // Why the uniqueness check: a preferred layout that repeats a UUID would hand two input leaves the
+  // same id, collapsing their pty/buffer/scrollback/title records onto one key.
+  const usePreferredLeafIds =
+    preferredLeafIdsInOrder.length === inputLeafIdsInOrder.length &&
+    new Set(preferredLeafIdsInOrder).size === preferredLeafIdsInOrder.length
   const leafIdByInputLeafId = new Map<string, string>()
+  const claimedLeafIds = new Set<string>()
   for (const [index, leafId] of inputLeafIdsInOrder.entries()) {
     const count = counts.get(leafId) ?? 0
     if (count !== 1 || leafIdByInputLeafId.has(leafId)) {
@@ -184,14 +189,17 @@ export function normalizeTerminalLayoutSnapshotForPersistence(
     }
     if (isTerminalLeafId(leafId)) {
       leafIdByInputLeafId.set(leafId, leafId)
+      claimedLeafIds.add(leafId)
       continue
     }
     changed = true
     const preferredLeafId = usePreferredLeafIds ? preferredLeafIdsInOrder[index] : undefined
-    leafIdByInputLeafId.set(
-      leafId,
-      preferredLeafId && isTerminalLeafId(preferredLeafId) ? preferredLeafId : randomUUID()
-    )
+    const nextLeafId =
+      preferredLeafId && isTerminalLeafId(preferredLeafId) && !claimedLeafIds.has(preferredLeafId)
+        ? preferredLeafId
+        : randomUUID()
+    claimedLeafIds.add(nextLeafId)
+    leafIdByInputLeafId.set(leafId, nextLeafId)
   }
   const root = changed
     ? cloneLayoutWithLeafIds(inputRoot, leafIdByInputLeafId, duplicatedInputLeafIds)

--- a/src/main/persistence/restoring-sessions/workspace-pane-normalization.ts
+++ b/src/main/persistence/restoring-sessions/workspace-pane-normalization.ts
@@ -4,7 +4,7 @@ import type { WorkspaceSessionState } from '../../../shared/workspace-session-st
 import type { MigrationUnsupportedPtyEntry } from '../../../shared/agent-status-types'
 import type { SshRemotePtyLease } from '../../../shared/ssh-types'
 import { isTerminalLeafId, makePaneKey, parsePaneKey } from '../../../shared/stable-pane-id'
-import { collectMigrationUnsupportedPtyEntries } from './pane-identity-migration'
+import { registerLegacyPaneKeyAliasesForTab } from './pane-identity-migration'
 import { normalizeTerminalLayoutSnapshotForPersistence } from './terminal-layout-normalization'
 import {
   legacyMigrationUnsupportedRowsToAliasEntries,
@@ -28,6 +28,8 @@ export function normalizeWorkspaceSessionPaneIdentities(
   let changed = false
   const leafIdByInputLeafIdByTabId = new Map<string, Map<string, string>>()
   const leafIdByPtyIdByTabId = new Map<string, Map<string, string>>()
+  // Why always empty: legacy numeric pane keys are bridged by aliases now, not persisted as
+  // restart-required rows; the field stays so callers keep clearing stale rows written by old builds.
   const migrationUnsupportedEntries: MigrationUnsupportedPtyEntry[] = []
   const legacyPaneKeyAliasEntries: LegacyPaneKeyAliasEntry[] = []
   const terminalLayoutsByTabId: Record<string, TerminalLayoutSnapshot> = {}
@@ -38,7 +40,7 @@ export function normalizeWorkspaceSessionPaneIdentities(
     )
     terminalLayoutsByTabId[tabId] = normalized.snapshot
     leafIdByInputLeafIdByTabId.set(tabId, normalized.leafIdByInputLeafId)
-    const migrationEntries = collectMigrationUnsupportedPtyEntries({
+    const tabAliasEntries = registerLegacyPaneKeyAliasesForTab({
       session,
       tabId,
       inputLayout: layout,
@@ -46,10 +48,7 @@ export function normalizeWorkspaceSessionPaneIdentities(
       leafIdByInputLeafId: normalized.leafIdByInputLeafId
     })
     // Why: old split layouts can generate enough alias rows to exceed V8's argument limit if spread into push().
-    for (const entry of migrationEntries.migrationUnsupportedEntries) {
-      migrationUnsupportedEntries.push(entry)
-    }
-    for (const entry of migrationEntries.legacyPaneKeyAliasEntries) {
+    for (const entry of tabAliasEntries) {
       legacyPaneKeyAliasEntries.push(entry)
     }
     const leafIdByPtyId = new Map<string, string>()
@@ -107,6 +106,19 @@ export function remapSshRemotePtyLeaseLeafIds(
   return { leases: nextLeases, changed }
 }
 
+/** Combines per-tab leaf maps from separate host partitions; an already-mapped tab keeps its mapping. */
+function mergeLeafIdMapsByTabId(
+  target: Map<string, Map<string, string>>,
+  source: Map<string, Map<string, string>>
+): Map<string, Map<string, string>> {
+  const merged = new Map(target)
+  for (const [tabId, leafIds] of source) {
+    const existing = merged.get(tabId)
+    merged.set(tabId, existing ? new Map([...leafIds, ...existing]) : new Map(leafIds))
+  }
+  return merged
+}
+
 export function normalizePersistedPaneIdentityState(state: PersistedState): {
   state: PersistedState
   changed: boolean
@@ -114,20 +126,54 @@ export function normalizePersistedPaneIdentityState(state: PersistedState): {
   legacyPaneKeyAliasEntries: LegacyPaneKeyAliasEntry[]
 } {
   const normalizedSession = normalizeWorkspaceSessionPaneIdentities(state.workspaceSession, {})
+  let leafIdByInputLeafIdByTabId = normalizedSession.leafIdByInputLeafIdByTabId
+  let leafIdByPtyIdByTabId = normalizedSession.leafIdByPtyIdByTabId
+  const hostSessionLegacyPaneKeyAliasEntries: LegacyPaneKeyAliasEntry[] = []
+  // Why: SSH/runtime hosts keep their own session blob, and their legacy leaves need the same UUID
+  // rewrite — otherwise their leases and read markers still point at `pane:1` after migration.
+  const normalizedHostSessions = state.workspaceSessionsByHostId
+    ? { ...state.workspaceSessionsByHostId }
+    : undefined
+  let hostSessionsChanged = false
+  if (normalizedHostSessions) {
+    for (const hostId of Object.keys(
+      normalizedHostSessions
+    ) as (keyof typeof normalizedHostSessions)[]) {
+      const hostSession = normalizedHostSessions[hostId]
+      if (!hostSession) {
+        continue
+      }
+      const normalizedHostSession = normalizeWorkspaceSessionPaneIdentities(hostSession, {})
+      normalizedHostSessions[hostId] = normalizedHostSession.session
+      leafIdByInputLeafIdByTabId = mergeLeafIdMapsByTabId(
+        leafIdByInputLeafIdByTabId,
+        normalizedHostSession.leafIdByInputLeafIdByTabId
+      )
+      leafIdByPtyIdByTabId = mergeLeafIdMapsByTabId(
+        leafIdByPtyIdByTabId,
+        normalizedHostSession.leafIdByPtyIdByTabId
+      )
+      for (const entry of normalizedHostSession.legacyPaneKeyAliasEntries) {
+        hostSessionLegacyPaneKeyAliasEntries.push(entry)
+      }
+      hostSessionsChanged ||= normalizedHostSession.changed
+    }
+  }
   const remappedLeases = remapSshRemotePtyLeaseLeafIds(
     state.sshRemotePtyLeases ?? [],
-    normalizedSession.leafIdByInputLeafIdByTabId,
-    normalizedSession.leafIdByPtyIdByTabId
+    leafIdByInputLeafIdByTabId,
+    leafIdByPtyIdByTabId
   )
   const mergedMigrationUnsupportedEntries: MigrationUnsupportedPtyEntry[] = []
   const mergedLegacyPaneKeyAliasEntries = mergeLegacyPaneKeyAliasEntries([
     ...normalizeLegacyPaneKeyAliasEntries(state.legacyPaneKeyAliasEntries),
     ...legacyMigrationUnsupportedRowsToAliasEntries(state.migrationUnsupportedPtyEntries ?? []),
-    ...normalizedSession.legacyPaneKeyAliasEntries
+    ...normalizedSession.legacyPaneKeyAliasEntries,
+    ...hostSessionLegacyPaneKeyAliasEntries
   ])
   const remappedAcknowledgements = remapAcknowledgedAgentPaneKeys(
     state.ui?.acknowledgedAgentsByPaneKey,
-    normalizedSession.leafIdByInputLeafIdByTabId
+    leafIdByInputLeafIdByTabId
   )
   const migrationUnsupportedChanged = !migrationUnsupportedEntriesEqual(
     state.migrationUnsupportedPtyEntries ?? [],
@@ -139,6 +185,7 @@ export function normalizePersistedPaneIdentityState(state: PersistedState): {
   )
   if (
     !normalizedSession.changed &&
+    !hostSessionsChanged &&
     !remappedLeases.changed &&
     !migrationUnsupportedChanged &&
     !legacyAliasesChanged &&
@@ -155,6 +202,7 @@ export function normalizePersistedPaneIdentityState(state: PersistedState): {
     state: {
       ...state,
       workspaceSession: normalizedSession.session,
+      ...(normalizedHostSessions ? { workspaceSessionsByHostId: normalizedHostSessions } : {}),
       sshRemotePtyLeases: remappedLeases.leases,
       migrationUnsupportedPtyEntries: mergedMigrationUnsupportedEntries,
       legacyPaneKeyAliasEntries: mergedLegacyPaneKeyAliasEntries,

--- a/src/main/persistence/scheduling-automations/automation-definition-operations.ts
+++ b/src/main/persistence/scheduling-automations/automation-definition-operations.ts
@@ -82,6 +82,11 @@ export function updateAutomation(
     throw new Error('Automation not found.')
   }
   const current = operations.state.automations[index]
+  // Why: the renderer forwards a Partial verbatim, so `{ enabled: undefined }` survives structuredClone
+  // and would blank the stored value in the spread below. Explicit clears go through the `null` branches.
+  const definedUpdates = Object.fromEntries(
+    Object.entries(updates).filter(([, value]) => value !== undefined)
+  ) as AutomationUpdateInput
   const repoId = updates.projectId ?? current.projectId
   const repo = operations.state.repos.find((entry) => entry.id === repoId)
   const executionTargetType = repo?.connectionId ? 'ssh' : 'local'
@@ -93,7 +98,7 @@ export function updateAutomation(
   const workspaceMode = updates.workspaceMode ?? current.workspaceMode
   const updated: Automation = {
     ...current,
-    ...updates,
+    ...definedUpdates,
     name: updates.name !== undefined ? updates.name.trim() || 'Untitled automation' : current.name,
     precheck: Object.hasOwn(updates, 'precheck')
       ? normalizeAutomationPrecheck(updates.precheck)

--- a/src/main/persistence/scheduling-automations/automation-schedule-operations.ts
+++ b/src/main/persistence/scheduling-automations/automation-schedule-operations.ts
@@ -17,7 +17,7 @@ export function advanceAutomationNextRun(
   }
   const current = state.automations[index]
   const nextRunAt = nextAutomationOccurrenceAfter(current.rrule, current.dtstart, now)
-  const updated = { ...current, nextRunAt, updatedAt: Date.now() }
+  const updated = { ...current, nextRunAt, updatedAt: now }
   state.automations[index] = updated
   flush()
   return updated

--- a/src/main/persistence/tracking-repos/project-host-operations.ts
+++ b/src/main/persistence/tracking-repos/project-host-operations.ts
@@ -15,6 +15,7 @@ import { getRepoExecutionHostId, normalizeExecutionHostId } from '../../../share
 import { normalizeProjectRuntimePreference } from '../../../shared/project-execution-runtime'
 import type { StoreOwnedPersistedState } from '../loading-store/store-owned-state'
 import { makeProjectHostSetupId } from './project-host-compatibility'
+import { repoGitUsernameCacheKey } from './repo-hydration'
 
 export type ProjectHostMutationOperations = {
   state: StoreOwnedPersistedState
@@ -214,8 +215,9 @@ export class ProjectHostPersistenceOperations {
     if (!repo) {
       return false
     }
-    const previous = this.gitUsernameCache.get(repo.path) ?? repo.gitUsername ?? ''
-    this.gitUsernameCache.set(repo.path, username)
+    const cacheKey = repoGitUsernameCacheKey(repo)
+    const previous = this.gitUsernameCache.get(cacheKey) ?? repo.gitUsername ?? ''
+    this.gitUsernameCache.set(cacheKey, username)
     if (previous === username) {
       return false
     }

--- a/src/main/persistence/tracking-repos/repo-hydration.ts
+++ b/src/main/persistence/tracking-repos/repo-hydration.ts
@@ -1,4 +1,5 @@
 import type { Repo } from '../../../shared/repo-types'
+import { getRepoExecutionHostId } from '../../../shared/execution-host'
 import { getDefaultRepoHookSettings } from '../../../shared/constants'
 import { isFolderRepo } from '../../../shared/repo-kind'
 import { sanitizeRepoIcon } from '../../../shared/repo-icon'
@@ -13,6 +14,17 @@ import {
   normalizeCustomWorktreeVisibilitySources,
   normalizeWorktreeVisibilitySourcePreferences
 } from '../../../shared/worktree/visibility-sources'
+
+/**
+ * Cache key for a repo's resolved git username. Host-scoped because the same checkout path can exist
+ * on local, SSH, and runtime hosts with different `user.name`, and a path-only key hydrates one
+ * host's username onto another (wrong `git-username` branch prefix).
+ */
+export function repoGitUsernameCacheKey(
+  repo: Pick<Repo, 'path' | 'connectionId' | 'executionHostId'>
+): string {
+  return `${getRepoExecutionHostId(repo)}\u0000${repo.path}`
+}
 
 export function hydrateRepo(repo: Repo, gitUsernameCache: ReadonlyMap<string, string>): Repo {
   const {
@@ -41,7 +53,7 @@ export function hydrateRepo(repo: Repo, gitUsernameCache: ReadonlyMap<string, st
   // Why: never spawn git/gh username resolution in hydration — a stuck probe froze Windows startup for minutes (issue #7225); read only cache/persisted value.
   const gitUsername = isFolderRepo(repo)
     ? ''
-    : (gitUsernameCache.get(repo.path) ?? repo.gitUsername ?? '')
+    : (gitUsernameCache.get(repoGitUsernameCacheKey(repo)) ?? repo.gitUsername ?? '')
 
   return {
     ...repoWithoutIcon,

--- a/src/main/persistence/tracking-repos/repo-update-operations.ts
+++ b/src/main/persistence/tracking-repos/repo-update-operations.ts
@@ -4,6 +4,7 @@ import type { ExecutionHostId } from '../../../shared/execution-host'
 import { getRepoExecutionHostId } from '../../../shared/execution-host'
 import { isLegacyRepoForExternalWorktreeVisibility } from '../../../shared/external-worktree-visibility'
 import { normalizeRepoSourceControlAiOverrides } from '../../../shared/source-control-ai'
+import { normalizeWorktreeVisibilitySourcePreferences } from '../../../shared/worktree/visibility-sources'
 import type { StoreOwnedPersistedState } from '../loading-store/store-owned-state'
 import { sanitizeRepoUpdatesForPersistence } from './repo-sanitization'
 
@@ -82,12 +83,17 @@ export class RepoUpdatePersistenceOperations {
       (sanitizedUpdates.agentWorktreeVisibility === 'hide' ||
         sanitizedUpdates.agentWorktreeVisibility === 'show')
     ) {
-      sanitizedUpdates.worktreeVisibilitySourcePreferences = {
+      // Why normalize: the stored value is spread in as-is, so a legacy/corrupt custom map would be
+      // written straight back without passing the same validation as a renderer-supplied patch.
+      const preferences = normalizeWorktreeVisibilitySourcePreferences({
         ...repo.worktreeVisibilitySourcePreferences,
         builtIn: {
           claude: sanitizedUpdates.agentWorktreeVisibility,
           gsd: sanitizedUpdates.agentWorktreeVisibility
         }
+      })
+      if (preferences) {
+        sanitizedUpdates.worktreeVisibilitySourcePreferences = preferences
       }
     }
     if ('projectGroupId' in sanitizedUpdates) {

--- a/src/main/persistence/tracking-repos/repo-worktree-pruning.ts
+++ b/src/main/persistence/tracking-repos/repo-worktree-pruning.ts
@@ -30,18 +30,9 @@ export function pruneWorktreeStateForRepo(
     hostMembership.set(key, result)
     return result
   }
-  // Why: session state (legacy blob + per-host partitions) references worktrees
-  // by the same `${repoId}::${path}` owner key; if it is not pruned here, a
-  // deleted project's worktrees stay in lastVisitedAtByWorktreeId /
-  // sleepingAgentSessionsByPaneKey and get re-materialized into worktreeMeta on
-  // the next launch, surfacing as an orphaned "unknown" workspace.
-  // worktreeMeta is host-classified via belongsToHost, but session partitions
-  // are keyed by host directly. A session owner key carries no host, and the
-  // same key can exist in multiple partitions (shared repo id/path across
-  // hosts). So for session cleanup we collect every prefix-matching owner key
-  // regardless of belongsToHost, and let the per-partition host gating below
-  // decide which partition to touch. (belongsToHost still governs
-  // worktreeMeta/lineage deletion. Collect before deleting worktreeMeta.)
+  // Why: leftover session owner keys re-materialize into worktreeMeta next launch as orphaned
+  // "unknown" workspaces. Owner keys carry no host and can repeat across partitions, so collect every
+  // prefix match (before the worktreeMeta deletes below) and let the per-partition gating decide.
   const ownerKeysToPrune = new Set<string>()
   const collectPrefixedKeys = (keys: Iterable<string>): void => {
     for (const key of keys) {
@@ -61,13 +52,9 @@ export function pruneWorktreeStateForRepo(
       delete state.worktreeMeta[key]
     }
   }
-  // Why: owner keys are `${repoId}::${path}` and do not carry a host, so a
-  // host-scoped prune (hostId != null) must only touch that host's session:
-  // the legacy blob is the local host's session, and each
-  // workspaceSessionsByHostId partition is one non-local host. Pruning every
-  // partition here would wipe a surviving host's tabs, sleeping-agent state,
-  // and active-worktree pointer for a shared repo id/path. A full removal
-  // (hostId === null) still clears every host.
+  // Why: a host-scoped prune must touch only that host's session (legacy blob = local, one partition
+  // per remote host); pruning every partition would wipe a surviving host's tabs and sleeping agents
+  // for a shared repo id/path. A full removal (hostId === null) still clears every host.
   const pruneLegacyLocalSession = hostId === null || hostId === LOCAL_EXECUTION_HOST_ID
   const pruneAllHostPartitions = hostId === null
   if (pruneLegacyLocalSession) {

--- a/src/main/persistence/tracking-repos/worktree-identity-migration.ts
+++ b/src/main/persistence/tracking-repos/worktree-identity-migration.ts
@@ -159,6 +159,9 @@ export function migrateWorktreeIdentity(
   const movedLineage = state.worktreeLineageById[newWorktreeId]
   if (movedLineage && movedLineage.worktreeId === oldWorktreeId) {
     movedLineage.worktreeId = newWorktreeId
+    // Why: moveKey reports nothing when the record already sat under the new key, so flag the repair
+    // ourselves or the caller skips the save and the stale id comes back on reload.
+    changed = true
   }
   // Why: children carry this as parentWorktreeId; keep the denormalized path-derived id consistent (parentWorktreeInstanceId is stable).
   for (const lineage of Object.values(state.worktreeLineageById)) {

--- a/src/main/persistence/tracking-repos/worktree-metadata-normalization.ts
+++ b/src/main/persistence/tracking-repos/worktree-metadata-normalization.ts
@@ -23,7 +23,10 @@ export const STALE_DURABLE_WRITE_TEMP_AGE_MS = 24 * 60 * 60 * 1000
 
 export function gcStaleWorktreeMeta(state: StoreOwnedPersistedState): number {
   // Why: a hand-corrupted "worktreeMeta": null overrides the defaults merge; normalize here instead of throwing.
+  // Companion lineage maps get the same guard because the deletes below index them directly.
   state.worktreeMeta ??= {}
+  state.worktreeLineageById ??= {}
+  state.workspaceLineageByChildKey ??= {}
   const repoById = new Map(state.repos.map((repo) => [repo.id, repo]))
   const projectIds = new Set((state.projects ?? []).map((project) => project.id))
   const now = Date.now()
@@ -79,14 +82,24 @@ export function gcStaleWorktreeMeta(state: StoreOwnedPersistedState): number {
 
 export function normalizeWorktreeLinkedItemMetadata(state: StoreOwnedPersistedState): boolean {
   let changed = false
+  // Why: a hand-corrupted null lineage map would throw on the companion deletes below.
+  state.worktreeLineageById ??= {}
+  state.workspaceLineageByChildKey ??= {}
   const rawWorktreeMeta = state.worktreeMeta as unknown
   if (
     typeof rawWorktreeMeta !== 'object' ||
     rawWorktreeMeta === null ||
     Array.isArray(rawWorktreeMeta)
   ) {
+    const hadLineage =
+      Object.keys(state.worktreeLineageById).length > 0 ||
+      Object.keys(state.workspaceLineageByChildKey).length > 0
     state.worktreeMeta = {}
-    changed = rawWorktreeMeta !== undefined
+    // Companions go with the discarded map; a stranded lineage row would otherwise re-attach to a
+    // worktree recreated at the same repoId::path.
+    state.worktreeLineageById = {}
+    state.workspaceLineageByChildKey = {}
+    changed = rawWorktreeMeta !== undefined || hadLineage
   }
   for (const [key, meta] of Object.entries(state.worktreeMeta)) {
     // Why: hand-corrupted non-object entries are a real input class; drop them here because gcStaleWorktreeMeta


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​58 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​58 |
| Prod | 17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​166 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​60 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​106 |

<!-- /orca-pr-loc -->

## ELI5

The persistence refactor in #14252 got review feedback after it merged. This PR applies those fixes: mostly load-time normalization that was skipping remote hosts, plus a handful of spots where an `undefined` value quietly erased stored data.

## What Changed

**Correctness fixes**

- **Host-partitioned sessions were never pane-normalized.** `normalizePersistedPaneIdentityState` only ever touched the legacy `workspaceSession` blob, so an SSH/runtime partition kept its legacy `pane:N` leaves forever — and its SSH leases and read markers pointed at ids that no longer existed. Every partition is now normalized, and the merged leaf maps drive lease + acknowledgement remapping.
- **Duplicate preferred leaf ids collapsed two panes onto one.** A preferred layout repeating a UUID handed two input leaves the same id, merging their pty/buffer/scrollback/title records. Uniqueness is now required, with a per-assignment `claimedLeafIds` guard.
- **`updateAutomation` blanked fields.** The renderer forwards a `Partial` verbatim and `{ enabled: undefined }` survives `structuredClone`, so the spread wrote `undefined` over stored values. Undefined keys are filtered out; the explicit `null` clear-branches are untouched.
- **Git-username cache was keyed by path alone.** The same checkout path exists on local, SSH, and runtime hosts with different `user.name`, so one host's username hydrated onto another (wrong `git-username` branch prefix). The key is now host-scoped.
- **Renamed worktrees kept a stale `lineage.worktreeId`.** `moveKey` reports nothing when the record already sits under the new key, so the repair skipped the save and the stale id returned on reload.
- **Worktree meta GC indexed lineage maps without guarding them,** and a corrupt `worktreeMeta` left its lineage companions stranded — a row would re-attach to a worktree later recreated at the same `repoId::path`.
- **`rightSidebarExplorerView`:** an explicit view now outranks the legacy "Search was a standalone tab" fallback. The legacy migration moved to the load path, where the raw payload still shows the old shape (after the defaults merge it always reads `files`).

**Hardening / cleanup**

- Notification settings are validated field-by-field instead of blanket-spread, so a type-flipped value on disk (`enabled: "false"`, `customSoundPath: 42`) can't reach the sound loader.
- Synthesized `worktreeVisibilitySourcePreferences` go through the same normalizer as a renderer-supplied patch.
- SSH lease upsert strips explicit `undefined` before merging onto an existing lease.
- `advanceAutomationNextRun` stamps `updatedAt` with the caller's `now` instead of a second `Date.now()`.
- Persisted `folderPath` is trimmed (the guard already validated the trimmed form).
- `collectMigrationUnsupportedPtyEntries` → `registerLegacyPaneKeyAliasesForTab`, dropping a return field that was always empty; the mobile-pairing migration documents why it leaves its sources in place.

## Why

These are review findings on already-merged code, so they're fixed forward rather than amended into #14252. The theme is that the extraction moved load-time normalization into per-lifecycle modules and, in doing so, left the host-partitioned session state outside the normalizers that the legacy blob still ran through — which only shows up for SSH and runtime hosts.

## Linked Issue

Follow-up to #14252 (post-merge review feedback). No separate issue.

## Visual Proof

`N/A` — main-process persistence and load-time migration only; no UI surface changes.

## Testing

- `pnpm vitest run src/main` — 2055 files / 21,822 tests pass (run against the pre-rebase tree); `src/main/persistence` (37 files / 588 tests) re-run green on this branch after rebasing onto current `main`.
- `pnpm run typecheck:node`, `oxlint`, and `oxfmt --check` clean.
- New regression test: `persistence-host-partitioned-sessions.test.ts` covers a legacy `pane:1` leaf inside an `ssh:` partition — its layout is rewritten and its lease follows. Verified the test **fails** with the fix disabled and passes with it enabled.
- Platforms: exercised via the automated suite on macOS. The SSH/remote path is covered by the new partition test rather than a live host; no platform-specific branches were added.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

Reviewer attention worth spending on the intentional behavior changes:

1. `normalizeNotificationSettings` now drops unknown keys, so a `settings.notifications` field written by a newer build no longer round-trips through an older one.
2. A corrupt (non-object) `worktreeMeta` now clears `worktreeLineageById` / `workspaceLineageByChildKey` too — lineage previously survived that case.
3. `folderPath` is stored trimmed; a directory name legitimately ending in whitespace (legal on POSIX) would resolve differently.
4. Users with remote partitions holding legacy leaves get a one-time rewrite + save on first launch — that's the point of the fix, but it is a write on a load that previously reported "unchanged".

One reviewer suggestion was deliberately **not** applied: skipping GC for unowned worktree metas that carry no `hostId`. Metas predating host stamping have no `hostId`, so that guard would strand every legacy orphan permanently, and it breaks an existing deliberate assertion (`persistence-flush-and-save-scheduling.test.ts` requires an unowned orphan with a missing local path to be collected). Code already skips metas explicitly stamped to a non-local host. Deciding what an unstamped orphan means is a design call, not a minimal fix.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
