### PR TITLE
fix(crash-reporting): give the parking census a retained breadcrumb slot without starving memory highwaters

### DIFF
--- a/src/main/crash-reporting/crash-breadcrumb-store.test.ts
+++ b/src/main/crash-reporting/crash-breadcrumb-store.test.ts
@@ -49,6 +49,48 @@ describe('crash breadcrumb store', () => {
     expect(snapshot.at(-1)?.data).toEqual({ index: 31 })
   })
 
+  it('retains the newest coalesced parking census across later activity', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-15T12:00:00.000Z'))
+    recordCrashBreadcrumb('renderer_memory_highwater', {
+      rendererSurface: 'main',
+      thresholdPct: 80
+    })
+    recordCoalescedCrashBreadcrumb({
+      name: 'terminal_parking_pass',
+      data: { managers: 49, panes: 60, sampledAtMs: Date.now() },
+      coalesceKey: 'terminal_parking_pass',
+      minIntervalMs: 30_000
+    })
+    vi.advanceTimersByTime(1_000)
+    recordCoalescedCrashBreadcrumb({
+      name: 'terminal_parking_pass',
+      data: { managers: 28, panes: 34, sampledAtMs: Date.now() },
+      coalesceKey: 'terminal_parking_pass',
+      minIntervalMs: 30_000
+    })
+    for (let index = 0; index < 32; index += 1) {
+      recordCrashBreadcrumb(`later_event_${index}`, { index })
+    }
+
+    const snapshot = getCrashBreadcrumbSnapshot()
+    const parkingPasses = snapshot.filter(
+      (breadcrumb) => breadcrumb.name === 'terminal_parking_pass'
+    )
+
+    expect(snapshot).toHaveLength(30)
+    expect(parkingPasses).toHaveLength(1)
+    expect(snapshot.some((breadcrumb) => breadcrumb.name === 'renderer_memory_highwater')).toBe(
+      true
+    )
+    expect(parkingPasses[0]?.data).toEqual({
+      managers: 28,
+      panes: 34,
+      sampledAtMs: Date.now(),
+      suppressedSinceLast: 1
+    })
+  })
+
   it('caps retained high-water profiles', () => {
     for (let index = 0; index < 5; index += 1) {
       recordCrashBreadcrumb('renderer_memory_highwater', {
@@ -60,6 +102,31 @@ describe('crash breadcrumb store', () => {
     expect(
       getCrashBreadcrumbSnapshot().map((breadcrumb) => breadcrumb.data?.rendererSurface)
     ).toEqual(['surface-1', 'surface-2', 'surface-3', 'surface-4'])
+  })
+
+  it('keeps four memory profiles alongside parking census across many surfaces', () => {
+    for (let index = 0; index < 12; index += 1) {
+      recordCrashBreadcrumb('renderer_memory_highwater', {
+        rendererSurface: `surface-${index}`,
+        thresholdPct: 80
+      })
+      recordCrashBreadcrumb('terminal_parking_pass', { managers: index, panes: index + 1 })
+    }
+
+    const snapshot = getCrashBreadcrumbSnapshot()
+    const memoryProfiles = snapshot.filter(
+      (breadcrumb) => breadcrumb.name === 'renderer_memory_highwater'
+    )
+
+    expect(memoryProfiles.map((breadcrumb) => breadcrumb.data?.rendererSurface)).toEqual([
+      'surface-8',
+      'surface-9',
+      'surface-10',
+      'surface-11'
+    ])
+    expect(snapshot.filter((breadcrumb) => breadcrumb.name === 'terminal_parking_pass')).toEqual([
+      expect.objectContaining({ data: { managers: 11, panes: 12 } })
+    ])
   })
 
   it('redacts sensitive breadcrumb fields before they can be snapshotted', () => {

--- a/src/main/crash-reporting/crash-breadcrumb-store.test.ts
+++ b/src/main/crash-reporting/crash-breadcrumb-store.test.ts
@@ -104,12 +104,22 @@ describe('crash breadcrumb store', () => {
     ).toEqual(['surface-1', 'surface-2', 'surface-3', 'surface-4'])
   })
 
-  it('keeps four memory profiles alongside parking census across many surfaces', () => {
+  it('keeps memory profiles and parking census from starving each other', () => {
+    recordCrashBreadcrumb('terminal_parking_pass', { managers: 1, panes: 1 })
     for (let index = 0; index < 12; index += 1) {
       recordCrashBreadcrumb('renderer_memory_highwater', {
         rendererSurface: `surface-${index}`,
         thresholdPct: 80
       })
+    }
+
+    expect(
+      getCrashBreadcrumbSnapshot().filter(
+        (breadcrumb) => breadcrumb.name === 'terminal_parking_pass'
+      )
+    ).toHaveLength(1)
+
+    for (let index = 0; index < 12; index += 1) {
       recordCrashBreadcrumb('terminal_parking_pass', { managers: index, panes: index + 1 })
     }
 

--- a/src/main/crash-reporting/crash-breadcrumb-store.ts
+++ b/src/main/crash-reporting/crash-breadcrumb-store.ts
@@ -6,8 +6,10 @@ import {
 } from '../../shared/crash-reporting'
 
 const MAX_BREADCRUMBS = 30
-// Why: retain two thresholds for each renderer surface without growing the ring.
-const MAX_RETAINED_BREADCRUMBS = 4
+// Why: preserve four memory highwaters and one named singleton within the 30-entry snapshot.
+const MAX_RETAINED_BREADCRUMBS = 5
+const MAX_RETAINED_MEMORY_BREADCRUMBS = 4
+const RETAINED_SINGLETON_BREADCRUMB_NAMES = new Set(['terminal_parking_pass'])
 // Why: coalesceKey embeds an open-string agentType (length-trimmed only, never
 // enum-checked), so the key space is unbounded over a long multi-agent/SSH session.
 // Bound the coalesce map the same way ProcessGoneDedupe bounds its key map.
@@ -27,6 +29,9 @@ let retainedBreadcrumbs = new Map<string, CrashReportBreadcrumb>()
 let coalescedBreadcrumbs = new Map<string, CoalescedBreadcrumbState>()
 
 function retainedBreadcrumbKey(breadcrumb: CrashReportBreadcrumb): string | null {
+  if (RETAINED_SINGLETON_BREADCRUMB_NAMES.has(breadcrumb.name)) {
+    return breadcrumb.name
+  }
   if (breadcrumb.name !== 'renderer_memory_highwater') {
     return null
   }
@@ -55,6 +60,15 @@ export function recordCrashBreadcrumb(
   if (retainedKey) {
     retainedBreadcrumbs.delete(retainedKey)
     retainedBreadcrumbs.set(retainedKey, breadcrumb)
+    const memoryKeys = [...retainedBreadcrumbs.entries()]
+      .filter(([, retained]) => retained.name === 'renderer_memory_highwater')
+      .map(([key]) => key)
+    while (memoryKeys.length > MAX_RETAINED_MEMORY_BREADCRUMBS) {
+      const oldestMemoryKey = memoryKeys.shift()
+      if (oldestMemoryKey) {
+        retainedBreadcrumbs.delete(oldestMemoryKey)
+      }
+    }
     while (retainedBreadcrumbs.size > MAX_RETAINED_BREADCRUMBS) {
       const oldestKey = retainedBreadcrumbs.keys().next()
       if (oldestKey.done) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​77 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​77 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​14 |

<!-- /orca-pr-loc -->

## ELI5

Crash reports carry a short list of recent breadcrumbs plus a few "keep this one no matter
what" slots. Those keep-forever slots were all spoken for by memory-highwater records, so a
newly added parking-census breadcrumb kept getting pushed out of the report before anyone
could read it. This adds one named keep-forever slot for it, and caps the memory ones
separately so the two kinds can't starve each other.

## What Changed

`src/main/crash-reporting/crash-breadcrumb-store.ts` only:

- `MAX_RETAINED_BREADCRUMBS` 4 → 5.
- New `MAX_RETAINED_MEMORY_BREADCRUMBS = 4`, so memory-highwater retention is capped
  independently of the total.
- `retainedBreadcrumbKey` grants a retained slot to the named parking-census crumb.

## Why

Split out of #14660 at its reviewer's recommendation, and at the repo owner's direction.

#14660 is instrumentation-only — it adds a parking-pass telemetry breadcrumb and claims no
product behaviour change. But guaranteeing that crumb survives to the bundle **cannot** be
achieved by ordinary ring coalescing; it needs a retained slot. Changing shared retention is
policy that every breadcrumb producer in the app is subject to, and it has a user-visible
consequence, so it does not belong inside a terminal-telemetry PR where reverting the
telemetry would silently revert the retention policy too.

**Five is the minimal budget:** it preserves all four existing memory slots and adds exactly
one named singleton slot. Nothing else moves.

## Trade-offs

- **User-visible consequence, stated plainly: every crash report now carries one fewer
  ordinary recent breadcrumb.** The recent-ring slice shrinks by one to fund the retained
  slot. This affects all crash reports, not just terminal ones.
- The retained key is a named singleton rather than a general mechanism. That is deliberate —
  a general allowlist would be over-abstraction for one caller — but it means the next
  producer wanting a retained slot must touch this file again.
- Starvation was the obvious risk and is disproved by test, not by argument (below).

## Linked Issue

No tracked issue. This is carved out of #14660, which came from the #orca-crashes sweep of
2026-08-14. **#14660 depends on this landing** — a durability improvement, not a correctness
gate: without it the telemetry still functions and coalesces, but its census crumb is
evictable under ring pressure.

## Visual Proof

`N/A` — main-process breadcrumb retention policy, no UI surface.

## Testing

- Standalone: 1 file, **15/15** tests.
- #14660 without this change: 7 files, **94/94** — confirming the telemetry stands alone
  (functional and coalesced, just evictable).
- Materialized merge of `origin/main` + this branch + #14660 + #14666 (merge SHA
  `2a811e75b5`): **18/18 crash-reporting reporters, 171/171 tests**. Merged tree actually
  built and run, not a `git merge-tree` exit code.
- **Starvation proof:** a 12-surface interleaving test retains the newest four memory
  highwaters *plus* the latest parking census, so neither class can evict the other.

- [ ] I manually tested these changes locally — *not applicable; main-process retention
  policy, covered by the tests above.*
- [x] Automated tests added/updated

## AI Disclosure

## Adversarial Review

Carved out of #14660 during that PR's merge-gate review. The retention change was found by
that review (the census crumb was being evicted — "trailing-state loss"), and the same
reviewer then recommended it be split rather than shipped inline. It has **not** had an
independent adversarial loop of its own as a standalone PR; treat it as needing one.

## Review

- **Security:** no new data captured; a retained slot holds a crumb the app already records.
- **Cross-platform:** main-process only, no platform-conditional paths.
- **Remote/SSH, mobile:** unaffected.
- **Backwards compatibility:** additive retention policy; no schema or wire change.
- **Performance:** one extra retained entry; the added filter runs only on retained writes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass — *focused suites and
  the materialized merge pass; full lint/test/build left to CI.*

## Author

- X / Twitter: @BrennanKB5
