### PR TITLE
ci: run the daily macOS build 4 hours later

### DIFF
--- a/.github/workflows/daily-mac-build.yml
+++ b/.github/workflows/daily-mac-build.yml
@@ -5,7 +5,7 @@ name: Daily macOS Dev Build
 # hourly.
 #
 # Schedule is a single UTC cron (GH Actions has no timezone-aware schedules).
-# 14:15 UTC is early morning Pacific year-round (6:15am PST / 7:15am PDT). Minute
+# 18:15 UTC is late morning Pacific year-round (10:15am PST / 11:15am PDT). Minute
 # 15 avoids stacking with hourly-mac-build, which fires at minute 0 every hour.
 #
 # Deliberately narrow scope:
@@ -45,8 +45,8 @@ name: Daily macOS Dev Build
 
 on:
   schedule:
-    # Once a day, early morning Pacific. Single cron — no DST twin, no clock gate.
-    - cron: '15 14 * * *'
+    # Once a day, late morning Pacific. Single cron — no DST twin, no clock gate.
+    - cron: '15 18 * * *'
   workflow_dispatch:
     inputs:
       force:

--- a/config/scripts/daily-build-version.mjs
+++ b/config/scripts/daily-build-version.mjs
@@ -60,7 +60,7 @@ export function nextDailyBuildNumber(baseVersion, releaseNames = []) {
 }
 
 /**
- * `1.4.163 • 01 • Aug 9, 6:15AM • e698241` — the human-facing release title,
+ * `1.4.163 • 01 • Aug 9, 10:15AM • e698241` — the human-facing release title,
  * shown verbatim in both the GitHub releases list and the in-app build picker.
  */
 export function formatDailyReleaseName(version, buildNumber, commit, date) {

--- a/config/scripts/daily-build-version.test.mjs
+++ b/config/scripts/daily-build-version.test.mjs
@@ -45,27 +45,27 @@ describe('formatDailyReleaseName', () => {
     formatDailyReleaseName('1.4.163-daily.x', buildNumber, commit, new Date(iso))
 
   it('renders version, number, Pacific timestamp, and short sha', () => {
-    // 13:15 UTC is 6:15AM PDT in July (the daily cut time).
-    expect(name('2026-07-28T13:15:00Z')).toBe('1.4.163 • 01 • Jul 28, 6:15AM • e698241')
+    // 17:15 UTC is 10:15AM PDT in July (the daily cut time).
+    expect(name('2026-07-28T17:15:00Z')).toBe('1.4.163 • 01 • Jul 28, 10:15AM • e698241')
   })
 
   // Why both sides of DST: the tag's stamp is UTC and the title is Pacific, so
   // the offset between them is not a constant. A test pinned to one season would
   // pass all summer and start failing in November.
   it('follows the Pacific offset across DST', () => {
-    expect(name('2026-01-15T14:15:00Z')).toBe('1.4.163 • 01 • Jan 15, 6:15AM • e698241')
-    expect(name('2026-07-28T13:15:00Z')).toBe('1.4.163 • 01 • Jul 28, 6:15AM • e698241')
+    expect(name('2026-01-15T18:15:00Z')).toBe('1.4.163 • 01 • Jan 15, 10:15AM • e698241')
+    expect(name('2026-07-28T17:15:00Z')).toBe('1.4.163 • 01 • Jul 28, 10:15AM • e698241')
   })
 
   it('pads to two digits and grows past them', () => {
-    expect(name('2026-07-28T13:15:00Z', 9)).toContain(' • 09 • ')
-    expect(name('2026-07-28T13:15:00Z', 42)).toContain(' • 42 • ')
+    expect(name('2026-07-28T17:15:00Z', 9)).toContain(' • 09 • ')
+    expect(name('2026-07-28T17:15:00Z', 42)).toContain(' • 42 • ')
   })
 
   it('rejects a build number that is not a positive integer', () => {
-    expect(() => name('2026-07-28T13:15:00Z', 0)).toThrow(/positive integer/)
-    expect(() => name('2026-07-28T13:15:00Z', -1)).toThrow(/positive integer/)
-    expect(() => name('2026-07-28T13:15:00Z', 1.5)).toThrow(/positive integer/)
+    expect(() => name('2026-07-28T17:15:00Z', 0)).toThrow(/positive integer/)
+    expect(() => name('2026-07-28T17:15:00Z', -1)).toThrow(/positive integer/)
+    expect(() => name('2026-07-28T17:15:00Z', 1.5)).toThrow(/positive integer/)
   })
 
   it('rejects an invalid timestamp', () => {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | 0 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | 0 |

<!-- /orca-pr-loc -->

## ELI5

The signed daily macOS build used to cut around 6–7am Pacific. That is too early. This moves the cut 4 hours later, to late morning Pacific.

## What Changed

The Daily macOS Dev Build workflow now fires at 18:15 UTC instead of 14:15 UTC. That is 10:15am PST / 11:15am PDT. Release-title examples and tests follow the new cut time.

## Why

The previous early-morning slot shipped before a useful amount of the day's work landed. Late morning keeps the same single UTC cron (no DST twin) and still avoids the hourly build at minute 0.

## Linked Issue

None filed.

## Visual Proof

N/A — this is a GitHub Actions cron and title-format test change. No UI or interaction change.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

`pnpm exec vitest run config/scripts/daily-build-version.test.mjs --config config/vitest.config.ts` — 14 passed. Cron itself is schedule-only and is not exercised until the workflow is on `main`.

The live Orca automation **Daily prod-release-scan** was moved separately to 2:00pm PT so it still runs after this later daily.

## AI Disclosure

<!-- Internal contributor — skipped -->

## Review

- Security: schedule and comment/test string updates only. No secrets, tokens, or publish-path changes.
- Cross-platform: the daily remains macOS-only, same as before. Linux/Windows release channels are unchanged.
- Remote SSH / folder workspaces: no runtime path. This is CI schedule + title formatting.
- Mobile / agents / git providers: not touched.
- Performance: one daily job still, just later. Minute 15 still avoids stacking with hourly-mac-build.
- Backwards compatibility: existing daily tags and picker titles stay valid. New titles show 10:15AM Pacific at the new cut.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Daily-build-version tests passed locally. Full lint/typecheck/build not run for this cron-only change; CI will be cancelled per merge request.

## Author

- X / Twitter: @JinjingLiang
