### PR TITLE
ci: run full e2e against the daily cut commit

### DIFF
--- a/.github/workflows/daily-mac-build.yml
+++ b/.github/workflows/daily-mac-build.yml
@@ -10,8 +10,10 @@ name: Daily macOS Dev Build
 #
 # Deliberately narrow scope:
 #   - macOS only. Other platforms keep using RC/stable.
-#   - No tests, no lint, no e2e. This channel trades safety for latency; PR CI
-#     and release-cut remain the gates that matter.
+#   - No tests or lint on the build job. After a live publish we fire-and-forget
+#     the full E2E workflow at the cut SHA (same detached dispatch as
+#     release-cut). A red suite must not fail or delay the daily.
+#   - PR CI and release-cut remain the gates that matter.
 #   - Signed AND notarized, exactly like a release. The notary round trip is the
 #     one slow step kept: macOS anchors a notarized app's TCC grants on identifier
 #     + team rather than on its cdhash, so those grants survive an update. Without
@@ -70,6 +72,9 @@ env:
 jobs:
   build-daily-mac:
     if: github.repository == 'stablyai/orca'
+    outputs:
+      head_sha: ${{ steps.freshness.outputs.head_sha }}
+      published: ${{ steps.publish_live.outcome == 'success' && 'true' || 'false' }}
     runs-on: blacksmith-6vcpu-macos-15
     # Why 150: it must exceed the worst case the retry budgets below can produce
     # (install 3x10 + publish 2x45 = 120, plus ~25 for checkout/build/verify), or
@@ -469,3 +474,34 @@ jobs:
             gh release delete "$tag" --repo "$DAILY_REPO" --yes --cleanup-tag || \
               echo "::warning::Could not prune $tag"
           done <<<"$stale"
+
+  # Why detached dispatch, not a reusable workflow in this graph: the full suite
+  # is currently red on main. Inlining it here would fail the daily after the
+  # signed build already published. Same pattern as release-cut's post-release-e2e.
+  #
+  # Why --ref main plus the SHA input: daily tags live on orca-daily, not this
+  # repo, so there is no cut tag for `gh workflow run --ref`. The workflow file
+  # comes from main; checkout uses the exact commit this daily built.
+  post-daily-e2e:
+    needs: build-daily-mac
+    if: ${{ needs.build-daily-mac.outputs.published == 'true' && needs.build-daily-mac.outputs.head_sha != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Dispatch cut-scoped E2E
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA: ${{ needs.build-daily-mac.outputs.head_sha }}
+        run: |
+          for attempt in 1 2 3; do
+            if gh workflow run e2e.yml \
+              --repo "$GITHUB_REPOSITORY" \
+              --ref main \
+              --raw-field "ref=$SHA"; then
+              echo "Dispatched post-daily E2E for $SHA."
+              exit 0
+            fi
+            [[ "$attempt" -eq 3 ]] || sleep "$((attempt * 5))"
+          done
+          echo "::warning::Failed to dispatch post-daily E2E for $SHA after 3 attempts."

--- a/config/scripts/daily-e2e-dispatch-contract.test.mjs
+++ b/config/scripts/daily-e2e-dispatch-contract.test.mjs
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { parse } from 'yaml'
+
+const projectDir = resolve(import.meta.dirname, '../..')
+const dailyWorkflow = parse(
+  readFileSync(join(projectDir, '.github/workflows/daily-mac-build.yml'), 'utf8')
+)
+const e2eWorkflow = parse(readFileSync(join(projectDir, '.github/workflows/e2e.yml'), 'utf8'))
+
+describe('daily E2E dispatch contract', () => {
+  it('dispatches SHA-scoped full E2E only after a live daily publish', () => {
+    const buildJob = dailyWorkflow.jobs['build-daily-mac']
+    const dispatchJob = dailyWorkflow.jobs['post-daily-e2e']
+    const dispatchStep = dispatchJob.steps.find((step) => step.name === 'Dispatch cut-scoped E2E')
+
+    expect(dailyWorkflow.jobs.e2e).toBeUndefined()
+    expect(buildJob.outputs.head_sha).toBe('${{ steps.freshness.outputs.head_sha }}')
+    expect(buildJob.outputs.published).toBe(
+      "${{ steps.publish_live.outcome == 'success' && 'true' || 'false' }}"
+    )
+    expect(dispatchJob.needs).toBe('build-daily-mac')
+    expect(dispatchJob.if).toBe(
+      "${{ needs.build-daily-mac.outputs.published == 'true' && needs.build-daily-mac.outputs.head_sha != '' }}"
+    )
+    expect(dispatchJob.permissions.actions).toBe('write')
+    expect(dispatchStep.env.SHA).toBe('${{ needs.build-daily-mac.outputs.head_sha }}')
+    expect(dispatchStep.run).toContain('gh workflow run e2e.yml')
+    expect(dispatchStep.run).toContain('--ref main')
+    expect(dispatchStep.run).toContain('--raw-field "ref=$SHA"')
+    expect(dispatchStep.run).toContain('for attempt in 1 2 3')
+    expect(dispatchStep.run).toContain('[[ "$attempt" -eq 3 ]] || sleep')
+    expect(dispatchStep.run).toContain('::warning::Failed to dispatch post-daily E2E')
+  })
+
+  it('leaves test_files unset so the dispatched run takes the full suite', () => {
+    const dispatchJob = dailyWorkflow.jobs['post-daily-e2e']
+    const dispatchStep = dispatchJob.steps.find((step) => step.name === 'Dispatch cut-scoped E2E')
+
+    expect(dispatchStep.run).not.toContain('test_files')
+    expect(e2eWorkflow.on.workflow_call.inputs.test_files.required).toBe(false)
+    expect(e2eWorkflow.jobs.e2e.if).toBe("inputs.test_files == ''")
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​45 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​45 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​38 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​36 |

<!-- /orca-pr-loc -->

## ELI5

When the daily macOS build actually ships, we now kick off the full E2E suite against the exact commit that was cut. The daily itself still publishes even if E2E is red.

## What Changed

`daily-mac-build.yml` grows a detached `post-daily-e2e` job, same idea as release-cut. After a live publish it runs `gh workflow run e2e.yml` with `ref` set to the cut SHA and leaves `test_files` empty so the reusable workflow takes the full 10-shard suite plus the SSH Docker lane.

Daily tags live on `orca-daily`, not this repo, so the dispatch uses `--ref main` for the workflow file and the SHA input for checkout.

## Why

A daily cut with no E2E left the signed build untested. Inlining the suite would fail the daily — scheduled E2E is currently red on main — so this stays fire-and-forget.

## Linked Issue

None filed.

## Visual Proof

N/A — GitHub Actions dispatch only. No UI or interaction change.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

`pnpm exec vitest run config/scripts/daily-e2e-dispatch-contract.test.mjs config/scripts/release-e2e-dispatch-contract.test.mjs --config config/vitest.config.ts` — 5 passed.

## AI Disclosure

<!-- Internal contributor — skipped -->

## Review

- Security: dispatch uses `GITHUB_TOKEN` with job-level `actions: write` only. No extra secrets. Same token exception GitHub already allows for `workflow_dispatch`.
- Cross-platform: E2E workflow stays Linux/xvfb as today. Daily macOS build unchanged.
- Remote SSH: the dispatched full suite still includes the SSH Docker isolation lane.
- Mobile / agents / git providers: not touched.
- Performance: one extra E2E run on days that actually publish a daily. Skipped dailies do not dispatch.
- Backwards compatibility: skipped or failed dailies do not start E2E. A failed dispatch is a warning, not a failed daily.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Contract tests passed locally. CI will be cancelled on merge.

## Author

- X / Twitter: @JinjingLiang
