### PR TITLE
fix(github): make check log excerpts readable before they reach the UI and prompts

### DIFF
--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -43,7 +43,7 @@ import {
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { sliceCheckLogTail } from '../../shared/check-job-log-tail-slice'
+import { toReadableCheckLogExcerpt } from '../../shared/check-job-log-excerpt'
 import {
   classifyPRRefreshError,
   safePRRefreshErrorMessage
@@ -4174,7 +4174,7 @@ async function attachFailedJobLogTails(
         ['api', `repos/${ownerRepo.owner}/${ownerRepo.repo}/actions/jobs/${job.id}/logs`],
         ghOptions
       )
-      job.logTail = sliceCheckLogTail(stdout)
+      job.logTail = toReadableCheckLogExcerpt(stdout)
     } catch (err) {
       rethrowCheckDetailsAbort(ghOptions.signal, err)
       console.warn('getPRCheckDetails workflow job log fetch failed:', err)

--- a/src/shared/check-job-log-excerpt.test.ts
+++ b/src/shared/check-job-log-excerpt.test.ts
@@ -84,6 +84,14 @@ describe('boundRawCheckLogTail', () => {
     expect(bounded).toBe('kept line')
   })
 
+  it('treats a bare CR as a line boundary', () => {
+    const head = `${'a'.repeat(MAX_RAW_CHECK_LOG_CHARS)}\r`
+
+    const bounded = boundRawCheckLogTail(`${head}kept line`)
+
+    expect(bounded).toBe('kept line')
+  })
+
   it('keeps the tail when the bounded slice has no line break', () => {
     const bounded = boundRawCheckLogTail('b'.repeat(MAX_RAW_CHECK_LOG_CHARS + 10))
 

--- a/src/shared/check-job-log-excerpt.test.ts
+++ b/src/shared/check-job-log-excerpt.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import {
+  boundRawCheckLogTail,
+  MAX_RAW_CHECK_LOG_CHARS,
+  toReadableCheckLogExcerpt
+} from './check-job-log-excerpt'
+import {
+  PR_CHECK_LOG_TAIL_BYTES,
+  PR_CHECK_LOG_TAIL_EARLIER_SEPARATOR
+} from './check-job-log-tail-slice'
+
+const ESC = '\u001b'
+const RED = `${ESC}[31m`
+const RESET = `${ESC}[0m`
+
+describe('toReadableCheckLogExcerpt', () => {
+  it('returns an empty excerpt for an empty log', () => {
+    expect(toReadableCheckLogExcerpt('')).toBe('')
+  })
+
+  it('strips ANSI colour sequences a workflow printed', () => {
+    const excerpt = toReadableCheckLogExcerpt(`${RED}##[error]Process exited with code 1${RESET}`)
+
+    expect(excerpt).toBe('##[error]Process exited with code 1')
+    expect(excerpt).not.toContain(ESC)
+  })
+
+  it('strips escapes from every line, not just the first', () => {
+    const coloured = Array.from(
+      { length: 400 },
+      (_, index) => `${RED}step ${index} still running${RESET}`
+    ).join('\n')
+
+    const excerpt = toReadableCheckLogExcerpt(coloured)
+
+    expect(excerpt).not.toContain(ESC)
+    expect(excerpt.split('\n').at(-1)).toBe('step 399 still running')
+  })
+
+  it('breaks carriage-return progress into lines instead of one clamped blob', () => {
+    const progress = Array.from({ length: 5_000 }, (_, index) => `downloading ${index}%`).join('\r')
+
+    const excerpt = toReadableCheckLogExcerpt(`${progress}\n##[error]Process exited with code 1`)
+
+    expect(excerpt).toContain('##[error]Process exited with code 1')
+    // Without CR normalisation the redraws stay one line, and the byte cap then
+    // spends the whole excerpt budget on a single unreadable progress fragment.
+    expect(excerpt.split('\n').length).toBeGreaterThan(100)
+    expect(Buffer.from(excerpt, 'utf8').byteLength).toBeLessThanOrEqual(PR_CHECK_LOG_TAIL_BYTES)
+  })
+
+  it('keeps the earlier-error window working through the excerpt', () => {
+    const lines = [
+      '##[error]the real failure',
+      ...Array.from({ length: 500 }, (_, index) => `noise line ${index}`)
+    ]
+
+    const excerpt = toReadableCheckLogExcerpt(lines.join('\n'))
+
+    expect(excerpt).toContain('##[error]the real failure')
+    expect(excerpt).toContain(PR_CHECK_LOG_TAIL_EARLIER_SEPARATOR)
+  })
+
+  it('bounds a multi-megabyte log before slicing it', () => {
+    const filler = 'x'.repeat(MAX_RAW_CHECK_LOG_CHARS * 2)
+
+    const excerpt = toReadableCheckLogExcerpt(`${filler}\n##[error]Process exited with code 1`)
+
+    expect(excerpt).toContain('##[error]Process exited with code 1')
+    expect(Buffer.from(excerpt, 'utf8').byteLength).toBeLessThanOrEqual(PR_CHECK_LOG_TAIL_BYTES)
+  })
+})
+
+describe('boundRawCheckLogTail', () => {
+  it('passes a log within the bound through untouched', () => {
+    expect(boundRawCheckLogTail('short log')).toBe('short log')
+  })
+
+  it('drops the partial first line so a halved escape cannot survive', () => {
+    const head = `${'a'.repeat(MAX_RAW_CHECK_LOG_CHARS)}\n`
+
+    const bounded = boundRawCheckLogTail(`${head}kept line`)
+
+    expect(bounded).toBe('kept line')
+  })
+
+  it('keeps the tail when the bounded slice has no line break', () => {
+    const bounded = boundRawCheckLogTail('b'.repeat(MAX_RAW_CHECK_LOG_CHARS + 10))
+
+    expect(bounded).toHaveLength(MAX_RAW_CHECK_LOG_CHARS)
+  })
+})

--- a/src/shared/check-job-log-excerpt.ts
+++ b/src/shared/check-job-log-excerpt.ts
@@ -1,0 +1,44 @@
+import { stripAnsiEscapeSequences } from './ansi-escape-sequences'
+import { sliceCheckLogTail } from './check-job-log-tail-slice'
+
+// Why: stripping makes several full passes over the input and the slice splits
+// every line into an array, so a multi-megabyte job log would stall the
+// main-process event loop before it is trimmed to the excerpt budget anyway.
+// 512 K chars is far more than any excerpt can keep.
+export const MAX_RAW_CHECK_LOG_CHARS = 512 * 1024
+
+/**
+ * Cut a raw CI job log down to a bounded tail before any per-character work.
+ *
+ * Drops the partial first line so an escape sequence cut in half cannot survive
+ * stripping as visible garbage.
+ */
+export function boundRawCheckLogTail(log: string): string {
+  if (log.length <= MAX_RAW_CHECK_LOG_CHARS) {
+    return log
+  }
+  const tail = log.slice(log.length - MAX_RAW_CHECK_LOG_CHARS)
+  const firstLineBreak = tail.indexOf('\n')
+  return firstLineBreak === -1 ? tail : tail.slice(firstLineBreak + 1)
+}
+
+/**
+ * Turn a raw CI job log into the bounded, readable excerpt Orca stores on a
+ * check job.
+ *
+ * The excerpt is untrusted web content: a PR author controls what CI prints, it
+ * is rendered verbatim in a `<pre>` and embedded in the fix-checks agent prompt.
+ * Escape sequences left in would show as literal garbage, eat the byte budget
+ * that should hold real failure output, and hide error markers from the
+ * earlier-error scan.
+ */
+export function toReadableCheckLogExcerpt(log: string): string {
+  if (!log) {
+    return ''
+  }
+  const readable = stripAnsiEscapeSequences(boundRawCheckLogTail(log))
+    // Why: progress output redraws with bare CR, which would otherwise make the
+    // whole job log a single line and defeat the line-based tail.
+    .replace(/\r\n?/g, '\n')
+  return sliceCheckLogTail(readable).trim()
+}

--- a/src/shared/check-job-log-excerpt.ts
+++ b/src/shared/check-job-log-excerpt.ts
@@ -11,14 +11,15 @@ export const MAX_RAW_CHECK_LOG_CHARS = 512 * 1024
  * Cut a raw CI job log down to a bounded tail before any per-character work.
  *
  * Drops the partial first line so an escape sequence cut in half cannot survive
- * stripping as visible garbage.
+ * stripping as visible garbage. CR counts as a boundary: the redraw-only output
+ * this excerpt exists to tame carries no LF at all.
  */
 export function boundRawCheckLogTail(log: string): string {
   if (log.length <= MAX_RAW_CHECK_LOG_CHARS) {
     return log
   }
   const tail = log.slice(log.length - MAX_RAW_CHECK_LOG_CHARS)
-  const firstLineBreak = tail.indexOf('\n')
+  const firstLineBreak = tail.search(/[\r\n]/)
   return firstLineBreak === -1 ? tail : tail.slice(firstLineBreak + 1)
 }
 

--- a/src/shared/gitlab-job-log-excerpt.ts
+++ b/src/shared/gitlab-job-log-excerpt.ts
@@ -1,4 +1,5 @@
 import { stripAnsiEscapeSequences } from './ansi-escape-sequences'
+import { boundRawCheckLogTail } from './check-job-log-excerpt'
 import { sliceCheckLogTail } from './check-job-log-tail-slice'
 import type { GitLabJobTraceResult } from './gitlab-types'
 
@@ -7,21 +8,6 @@ import type { GitLabJobTraceResult } from './gitlab-types'
 const SECTION_MARKER_PREFIX_PATTERN = /^section_(?:start|end):\d+:[^\r\n]*?\r/gm
 // Sections without a visible header leave a marker-only line; drop it whole.
 const SECTION_MARKER_LINE_PATTERN = /^section_(?:start|end):\d+:[^\r\n]*\n?/gm
-
-// Why: stripping makes several full passes over the input, so a multi-megabyte CI log
-// would stall the main-process event loop before the tail is trimmed to 16 KB anyway.
-// 512 K chars is far more than the excerpt can keep, even with markup removed.
-const MAX_RAW_TRACE_CHARS = 512 * 1024
-
-function rawTraceTail(trace: string): string {
-  if (trace.length <= MAX_RAW_TRACE_CHARS) {
-    return trace
-  }
-  const tail = trace.slice(trace.length - MAX_RAW_TRACE_CHARS)
-  // Drop the partial first line so a marker or escape cut in half cannot survive stripping.
-  const firstLineBreak = tail.indexOf('\n')
-  return firstLineBreak === -1 ? tail : tail.slice(firstLineBreak + 1)
-}
 
 /**
  * Turn a raw `glab api .../jobs/:id/trace` body into a bounded, readable excerpt.
@@ -37,7 +23,7 @@ export function gitLabJobTraceToLogExcerpt(trace: string): string {
   // Order matters: ANSI first so the erase-to-EOL sequence between the marker's CR
   // and its header text is gone, CR normalisation last so the marker patterns can
   // still see the CR that separates a marker from its visible header.
-  const readable = stripAnsiEscapeSequences(rawTraceTail(trace))
+  const readable = stripAnsiEscapeSequences(boundRawCheckLogTail(trace))
     .replace(SECTION_MARKER_PREFIX_PATTERN, '')
     .replace(SECTION_MARKER_LINE_PATTERN, '')
     // Why: progress output redraws with bare CR, which would otherwise make the


### PR DESCRIPTION
GitHub check log excerpts skipped the readability pipeline that GitLab job traces already go through, so escape sequences and carriage-return progress output reached both the log excerpt UI and the fix-checks agent prompt verbatim.

## The asymmetry

`gitLabJobTraceToLogExcerpt` bounds the raw trace, strips ANSI, normalises CR and only then slices. The GitHub path called `sliceCheckLogTail(stdout)` directly:

```ts
// src/main/github/client.ts
job.logTail = sliceCheckLogTail(stdout)
```

Two measured consequences.

**Escape sequences reach the excerpt.** `CheckJobLogTail` renders the excerpt as `<pre>{logTail}</pre>` with no ANSI interpretation, so a coloured workflow log shows its escape codes as literal text. The same string is embedded in `buildFixBrokenChecksPrompt`, where it spends tokens on markup.

**Carriage-return progress collapses the excerpt.** Tools that redraw with bare `\r` (npm, pnpm, docker pulls) produce no `\n`, and `sliceCheckLogTail` splits on `/\r?\n/`. The whole job log stays one line, so the 16 KB byte cap returns a mid-line fragment of progress spam instead of the failure:

| | before | after |
|---|---|---|
| lines in excerpt | 2 | 200 |
| bytes | 16,384 | 3,595 |

## Change

Factor the provider-neutral part of the GitLab pipeline into `src/shared/check-job-log-excerpt.ts` (`boundRawCheckLogTail`, `toReadableCheckLogExcerpt`) and run the GitHub path through it. `gitlab-job-log-excerpt.ts` now shares the bound and keeps its GitLab-specific section-marker step in the same order as before, so its behaviour is unchanged and its existing tests cover the refactor.

The bound matters for more than tidiness: `sliceCheckLogTail` splits the entire raw log into a line array, and a GitHub job log can be tens of megabytes. GitLab already guarded this; GitHub did not.

## Scope note

Two things I expected to be broken turned out not to be, so they are deliberately not touched:

- Colour codes do **not** hide `##[error]` markers from the earlier-error scan — `ERROR_LINE_PATTERN` is a substring test, so a wrapped marker still matches.
- Colour codes do **not** normally starve the byte budget — the 200-line cap binds first in the common case.

## Verification

- New `src/shared/check-job-log-excerpt.test.ts`; reverting the implementation to the old one-line behaviour fails 3 of its cases, so they pin the actual change rather than restating it.
- `typecheck:node` / `typecheck:web` / `typecheck:cli`, the full `pnpm run lint` gate, and `oxfmt --check` all pass.
- Full unit suite: 53,020 passing. The 3 failing files on my machine (`ssh-posix-command-wrapper`, the two live-zsh PTY readiness suites) fail identically at `main` here and are unrelated.

## Wire compatibility

`logTail` is content the host publishes to remote clients, so this reaches old clients with no wire change. It is a content cleanup, not a format change — old clients render the excerpt in the same `<pre>` — and it makes GitHub match the GitLab behaviour those clients already receive.
