### PR TITLE
feat(editor): LSP support in the editor and diff views (tsgo-first)

### DIFF
--- a/src/main/ipc/lsp.ts
+++ b/src/main/ipc/lsp.ts
@@ -1,0 +1,63 @@
+import { app, ipcMain, webContents } from 'electron'
+import type { Store } from '../persistence'
+import {
+  LSP_REQUEST_METHODS,
+  type LspChangeDocumentArgs,
+  type LspCloseDocumentArgs,
+  type LspOpenDocumentArgs,
+  type LspOpenDocumentResult,
+  type LspRequestArgs
+} from '../../shared/lsp-types'
+import { createLspSessionManager } from '../lsp/lsp-session-manager'
+import { resolveAuthorizedPath } from './filesystem-auth'
+import { isDescendantOrEqual } from './filesystem-path-containment'
+
+export function registerLspHandlers(store: Store): void {
+  const manager = createLspSessionManager()
+  // Why: diagnostics go to every window; sessions are keyed by workspace, and
+  // stale-model payloads are dropped renderer-side by uri lookup.
+  manager.onDiagnostics((payload) => {
+    for (const contents of webContents.getAllWebContents()) {
+      if (!contents.isDestroyed()) {
+        contents.send('lsp:diagnostics', payload)
+      }
+    }
+  })
+  app.on('will-quit', () => manager.disposeAll())
+
+  ipcMain.handle(
+    'lsp:openDocument',
+    async (_event, args: LspOpenDocumentArgs): Promise<LspOpenDocumentResult> => {
+      const filePath = await resolveAuthorizedPath(args.filePath, store)
+      const rootPath = await resolveAuthorizedPath(args.rootPath, store)
+      // Why: both paths are individually authorized, but rootPath becomes the
+      // server's cwd/workspace — it must actually contain the opened file, or a
+      // renderer could scope a code-executing server (gopls, rust-analyzer) to
+      // an unrelated allowed root.
+      if (!isDescendantOrEqual(filePath, rootPath)) {
+        throw new Error('LSP document must be inside its workspace root')
+      }
+      return manager.openDocument({
+        filePath,
+        rootPath,
+        languageId: args.languageId,
+        text: args.text
+      })
+    }
+  )
+
+  ipcMain.handle('lsp:changeDocument', (_event, args: LspChangeDocumentArgs): void => {
+    manager.changeDocument(args.sessionId, args.fileUri, args.text)
+  })
+
+  ipcMain.handle('lsp:closeDocument', (_event, args: LspCloseDocumentArgs): void => {
+    manager.closeDocument(args.sessionId, args.fileUri)
+  })
+
+  ipcMain.handle('lsp:request', (_event, args: LspRequestArgs): Promise<unknown> => {
+    if (!LSP_REQUEST_METHODS.includes(args.method)) {
+      return Promise.reject(new Error(`Unsupported LSP method: ${String(args.method)}`))
+    }
+    return manager.request(args.sessionId, args.method, args.params)
+  })
+}

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -8,6 +8,7 @@ import type { StatsCollector } from '../stats/collector'
 import { registerFilesystemHandlers } from './filesystem'
 import type { CommitMessageAgentEnvironmentResolvers } from '../text-generation/commit-message-agent-environment'
 import { registerFilesystemWatcherHandlers } from './filesystem-watcher'
+import { registerLspHandlers } from './lsp'
 import { registerUsageProviderHandlers } from './usage-provider-handlers'
 import { registerGitHubHandlers } from './github'
 import { registerGitLabHandlers } from './gitlab'
@@ -209,6 +210,7 @@ export function registerCoreHandlers(
     registerFilesystemHandlers(store)
   }
   registerFilesystemWatcherHandlers()
+  registerLspHandlers(store)
   registerRuntimeHandlers(runtime)
   registerRuntimeEnvironmentHandlers(store)
   registerEphemeralVmHandlers(store, pluginService)

--- a/src/main/lsp/lsp-file-uri-key.test.ts
+++ b/src/main/lsp/lsp-file-uri-key.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { canonicalFileUriKey } from './lsp-file-uri-key'
+
+describe('canonicalFileUriKey', () => {
+  it('maps Node and vscode-uri forms of the same Windows path to one key', () => {
+    expect(canonicalFileUriKey('file:///C:/dev/repo/a.ts')).toBe(
+      canonicalFileUriKey('file:///c%3A/dev/repo/a.ts')
+    )
+  })
+
+  it('folds percent-encoding differences on posix paths', () => {
+    expect(canonicalFileUriKey('file:///Users/dev/my%20project/a.ts')).toBe(
+      canonicalFileUriKey('file:///Users/dev/my project/a.ts')
+    )
+  })
+
+  it('keeps distinct paths distinct and survives malformed encodings', () => {
+    expect(canonicalFileUriKey('file:///a/b.ts')).not.toBe(canonicalFileUriKey('file:///a/c.ts'))
+    expect(canonicalFileUriKey('file:///a/%zz')).toBe('file:///a/%zz')
+  })
+})

--- a/src/main/lsp/lsp-file-uri-key.ts
+++ b/src/main/lsp/lsp-file-uri-key.ts
@@ -1,0 +1,17 @@
+/** Canonical map key for a file:// URI. Servers mint their own URI form —
+ *  vscode-uri lowercases drive letters and percent-encodes ':' where Node's
+ *  pathToFileURL does not — so exact-string matching drops their messages.
+ *  Decode, then fold the drive letter, so both forms land on one key. */
+export function canonicalFileUriKey(uri: string): string {
+  let decoded: string
+  try {
+    decoded = decodeURIComponent(uri)
+  } catch {
+    decoded = uri
+  }
+  return decoded.replace(
+    /^(file:\/\/\/)([A-Za-z])(:)/,
+    (_match, prefix: string, drive: string, colon: string) =>
+      `${prefix}${drive.toLowerCase()}${colon}`
+  )
+}

--- a/src/main/lsp/lsp-initialize-params.ts
+++ b/src/main/lsp/lsp-initialize-params.ts
@@ -1,0 +1,28 @@
+import { basename } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+/** Client capabilities for Orca's LSP bridge: hover, definition, completion,
+ *  push + pull diagnostics, full-text sync. Advertising `diagnostic` lets
+ *  pull-model servers (tsgo/TS7) expose their diagnosticProvider. */
+export function buildLspInitializeParams(rootPath: string): object {
+  const rootUri = pathToFileURL(rootPath).toString()
+  return {
+    processId: process.pid,
+    rootUri,
+    workspaceFolders: [{ uri: rootUri, name: basename(rootPath) }],
+    capabilities: {
+      textDocument: {
+        hover: { contentFormat: ['markdown', 'plaintext'] },
+        definition: {},
+        references: {},
+        completion: {
+          completionItem: { snippetSupport: false, documentationFormat: ['markdown', 'plaintext'] }
+        },
+        publishDiagnostics: {},
+        diagnostic: {},
+        synchronization: { didSave: false }
+      },
+      workspace: { workspaceFolders: true }
+    }
+  }
+}

--- a/src/main/lsp/lsp-message-framing.test.ts
+++ b/src/main/lsp/lsp-message-framing.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { encodeLspMessage, LspMessageDecoder } from './lsp-message-framing'
+
+function frame(message: unknown): Buffer {
+  return encodeLspMessage(message)
+}
+
+describe('encodeLspMessage', () => {
+  it('uses the utf8 byte length, not the string length', () => {
+    const encoded = encodeLspMessage({ text: 'héllo' }).toString('utf8')
+    const body = encoded.slice(encoded.indexOf('\r\n\r\n') + 4)
+    expect(encoded).toContain(`Content-Length: ${Buffer.byteLength(body, 'utf8')}\r\n\r\n`)
+  })
+})
+
+describe('LspMessageDecoder', () => {
+  it('decodes a message split across arbitrary chunk boundaries', () => {
+    const decoder = new LspMessageDecoder()
+    const encoded = frame({ jsonrpc: '2.0', id: 1, result: { value: 'héllo' } })
+    const out: unknown[] = []
+    for (let i = 0; i < encoded.length; i += 3) {
+      out.push(...decoder.push(encoded.subarray(i, i + 3)))
+    }
+    expect(out).toEqual([{ jsonrpc: '2.0', id: 1, result: { value: 'héllo' } }])
+  })
+
+  it('decodes multiple messages arriving in one chunk', () => {
+    const decoder = new LspMessageDecoder()
+    const chunk = Buffer.concat([frame({ id: 1 }), frame({ id: 2 }), frame({ id: 3 })])
+    expect(decoder.push(chunk)).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }])
+  })
+
+  it('tolerates extra headers like Content-Type', () => {
+    const decoder = new LspMessageDecoder()
+    const body = JSON.stringify({ id: 7 })
+    const raw = Buffer.from(
+      `Content-Length: ${body.length}\r\nContent-Type: application/vscode-jsonrpc; charset=utf-8\r\n\r\n${body}`,
+      'utf8'
+    )
+    expect(decoder.push(raw)).toEqual([{ id: 7 }])
+  })
+
+  it('skips a malformed body and keeps decoding subsequent messages', () => {
+    const decoder = new LspMessageDecoder()
+    const bad = Buffer.from('Content-Length: 3\r\n\r\n{{{', 'utf8')
+    expect(decoder.push(Buffer.concat([bad, frame({ id: 2 })]))).toEqual([{ id: 2 }])
+  })
+})

--- a/src/main/lsp/lsp-message-framing.ts
+++ b/src/main/lsp/lsp-message-framing.ts
@@ -1,0 +1,47 @@
+/** LSP base-protocol framing: `Content-Length: N\r\n\r\n<N bytes of JSON>`. */
+
+const HEADER_TERMINATOR = '\r\n\r\n'
+
+export function encodeLspMessage(message: unknown): Buffer {
+  const body = Buffer.from(JSON.stringify(message), 'utf8')
+  return Buffer.concat([Buffer.from(`Content-Length: ${body.length}\r\n\r\n`, 'ascii'), body])
+}
+
+/** Incremental decoder: feed stdout chunks, get back complete JSON messages. */
+export class LspMessageDecoder {
+  private buffer: Buffer = Buffer.alloc(0)
+  private expectedBodyLength: number | null = null
+
+  push(chunk: Buffer): unknown[] {
+    this.buffer = this.buffer.length === 0 ? chunk : Buffer.concat([this.buffer, chunk])
+    const messages: unknown[] = []
+    for (;;) {
+      if (this.expectedBodyLength === null) {
+        const headerEnd = this.buffer.indexOf(HEADER_TERMINATOR)
+        if (headerEnd === -1) {
+          return messages
+        }
+        const header = this.buffer.subarray(0, headerEnd).toString('ascii')
+        const lengthMatch = /content-length:\s*(\d+)/i.exec(header)
+        this.buffer = this.buffer.subarray(headerEnd + HEADER_TERMINATOR.length)
+        if (!lengthMatch) {
+          // Why: a headerless frame means the stream is corrupt; skipping it and
+          // resynchronizing on the next header loses one message, not the session.
+          continue
+        }
+        this.expectedBodyLength = Number(lengthMatch[1])
+      }
+      if (this.buffer.length < this.expectedBodyLength) {
+        return messages
+      }
+      const body = this.buffer.subarray(0, this.expectedBodyLength).toString('utf8')
+      this.buffer = this.buffer.subarray(this.expectedBodyLength)
+      this.expectedBodyLength = null
+      try {
+        messages.push(JSON.parse(body))
+      } catch {
+        // Why: one malformed body shouldn't kill the whole session stream.
+      }
+    }
+  }
+}

--- a/src/main/lsp/lsp-server-catalog.test.ts
+++ b/src/main/lsp/lsp-server-catalog.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  resetLspServerAvailabilityForTests,
+  resolveLspServerForLanguage,
+  toLspDocumentLanguageId
+} from './lsp-server-catalog'
+
+describe('toLspDocumentLanguageId', () => {
+  it('maps react dialects by extension and passes everything else through', () => {
+    expect(toLspDocumentLanguageId('typescript', '/a/App.tsx')).toBe('typescriptreact')
+    expect(toLspDocumentLanguageId('typescript', '/a/app.ts')).toBe('typescript')
+    expect(toLspDocumentLanguageId('javascript', '/a/App.JSX')).toBe('javascriptreact')
+    expect(toLspDocumentLanguageId('python', '/a/x.py')).toBe('python')
+  })
+})
+
+describe('resolveLspServerForLanguage', () => {
+  beforeEach(() => resetLspServerAvailabilityForTests())
+
+  it('prefers tsgo for typescript when installed', async () => {
+    const resolved = await resolveLspServerForLanguage('typescript', () => Promise.resolve(true))
+    expect(resolved?.serverId).toBe('tsgo')
+    expect(resolved?.args).toEqual(['--lsp', '--stdio'])
+  })
+
+  it('falls back to typescript-language-server when tsgo is missing', async () => {
+    const resolved = await resolveLspServerForLanguage('typescript', (command) =>
+      Promise.resolve(command !== 'tsgo')
+    )
+    expect(resolved?.serverId).toBe('typescript-language-server')
+  })
+
+  it('returns null for unknown languages and when nothing is installed', async () => {
+    expect(await resolveLspServerForLanguage('plaintext', () => Promise.resolve(true))).toBeNull()
+    expect(await resolveLspServerForLanguage('go', () => Promise.resolve(false))).toBeNull()
+  })
+
+  it('caches probe verdicts per command', async () => {
+    let probes = 0
+    const probe = (): Promise<boolean> => {
+      probes++
+      return Promise.resolve(true)
+    }
+    await resolveLspServerForLanguage('typescript', probe)
+    await resolveLspServerForLanguage('javascript', probe)
+    expect(probes).toBe(1)
+  })
+})

--- a/src/main/lsp/lsp-server-catalog.ts
+++ b/src/main/lsp/lsp-server-catalog.ts
@@ -1,0 +1,90 @@
+import { isCommandOnLocalPath } from '../ipc/command-path-resolver'
+
+export type LspServerDescriptor = {
+  serverId: string
+  command: string
+  args: readonly string[]
+}
+
+type LspServerCatalogEntry = {
+  languages: readonly string[]
+  /** Tried in order; the first command found on PATH wins. */
+  candidates: readonly LspServerDescriptor[]
+}
+
+/** Servers Orca knows how to drive. Nothing is bundled: a server is used only
+ *  when the user already has its binary on PATH. */
+export const LSP_SERVER_CATALOG: readonly LspServerCatalogEntry[] = [
+  {
+    languages: ['typescript', 'javascript'],
+    candidates: [
+      // Why: tsgo (native TypeScript 7 / @typescript/native-preview) is the
+      // fast path and the only server that works in tsserver-less TS7 repos.
+      { serverId: 'tsgo', command: 'tsgo', args: ['--lsp', '--stdio'] },
+      {
+        serverId: 'typescript-language-server',
+        command: 'typescript-language-server',
+        args: ['--stdio']
+      }
+    ]
+  },
+  {
+    languages: ['python'],
+    candidates: [{ serverId: 'pyright', command: 'pyright-langserver', args: ['--stdio'] }]
+  },
+  { languages: ['go'], candidates: [{ serverId: 'gopls', command: 'gopls', args: [] }] },
+  {
+    languages: ['rust'],
+    candidates: [{ serverId: 'rust-analyzer', command: 'rust-analyzer', args: [] }]
+  }
+]
+
+// Why: PATH probing hits the filesystem; editors re-open files constantly, so
+// remember each verdict for the app lifetime (installing a server mid-session
+// is picked up after restart, like agent detection).
+const availabilityByCommand = new Map<string, Promise<boolean>>()
+
+function isServerCommandAvailable(
+  command: string,
+  probe: (command: string) => Promise<boolean>
+): Promise<boolean> {
+  let availability = availabilityByCommand.get(command)
+  if (!availability) {
+    availability = probe(command).catch(() => false)
+    availabilityByCommand.set(command, availability)
+  }
+  return availability
+}
+
+export async function resolveLspServerForLanguage(
+  languageId: string,
+  probe: (command: string) => Promise<boolean> = isCommandOnLocalPath
+): Promise<LspServerDescriptor | null> {
+  const entry = LSP_SERVER_CATALOG.find((candidate) => candidate.languages.includes(languageId))
+  if (!entry) {
+    return null
+  }
+  for (const descriptor of entry.candidates) {
+    if (await isServerCommandAvailable(descriptor.command, probe)) {
+      return descriptor
+    }
+  }
+  return null
+}
+
+export function resetLspServerAvailabilityForTests(): void {
+  availabilityByCommand.clear()
+}
+
+/** Monaco has no react language ids (.tsx shares 'typescript'), but LSP servers
+ *  key script kind off the didOpen languageId — tsserver parses a 'typescript'
+ *  .tsx as plain TS and errors on every JSX element. */
+export function toLspDocumentLanguageId(languageId: string, filePath: string): string {
+  if (languageId === 'typescript' && /\.tsx$/i.test(filePath)) {
+    return 'typescriptreact'
+  }
+  if (languageId === 'javascript' && /\.jsx$/i.test(filePath)) {
+    return 'javascriptreact'
+  }
+  return languageId
+}

--- a/src/main/lsp/lsp-server-spawn.ts
+++ b/src/main/lsp/lsp-server-spawn.ts
@@ -1,0 +1,28 @@
+import { spawn } from 'node:child_process'
+import type { ChildProcessWithoutNullStreams } from 'node:child_process'
+import { getSpawnArgsForWindows } from '../../shared/windows-batch-spawn'
+import { resolveWindowsCommand } from '../win32-utils'
+import type { LspServerDescriptor } from './lsp-server-catalog'
+
+export type SpawnLspServer = (
+  descriptor: LspServerDescriptor,
+  rootPath: string
+) => ChildProcessWithoutNullStreams
+
+export const spawnLspServer: SpawnLspServer = (descriptor, rootPath) => {
+  // Why: npm-installed servers are .cmd shims on Windows; resolve the PATH entry
+  // and route batch scripts through cmd.exe explicitly (spawn+shell hits DEP0190).
+  const command = resolveWindowsCommand(descriptor.command)
+  const { spawnCmd, spawnArgs } = getSpawnArgsForWindows(command, [...descriptor.args])
+  const child = spawn(spawnCmd, spawnArgs, {
+    cwd: rootPath,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    windowsHide: true,
+    // Why: hydrateShellPath already merged the login-shell PATH into process.env.
+    env: process.env
+  })
+  // Why: nothing reads stderr; an undrained pipe blocks the server once the OS
+  // buffer fills (rust-analyzer and gopls log there routinely).
+  child.stderr.resume()
+  return child
+}

--- a/src/main/lsp/lsp-session-manager.test.ts
+++ b/src/main/lsp/lsp-session-manager.test.ts
@@ -1,0 +1,221 @@
+import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
+import { pathToFileURL } from 'node:url'
+import type { ChildProcessWithoutNullStreams } from 'node:child_process'
+import { describe, expect, it, vi } from 'vitest'
+import { encodeLspMessage, LspMessageDecoder } from './lsp-message-framing'
+import { createLspSessionManager } from './lsp-session-manager'
+
+type JsonRpcMessage = {
+  jsonrpc: '2.0'
+  id?: number
+  method?: string
+  params?: unknown
+  result?: unknown
+}
+
+/** Fake server that auto-answers `initialize` and records everything sent to it. */
+function createFakeServer(serverCapabilities: Record<string, unknown> = {}) {
+  const child = new EventEmitter() as ChildProcessWithoutNullStreams & EventEmitter
+  const stdin = new PassThrough()
+  const stdout = new PassThrough()
+  Object.assign(child, { stdin, stdout, stderr: new PassThrough(), kill: vi.fn() })
+
+  const received: JsonRpcMessage[] = []
+  const decoder = new LspMessageDecoder()
+  stdin.on('data', (chunk: Buffer) => {
+    for (const message of decoder.push(chunk) as JsonRpcMessage[]) {
+      received.push(message)
+      if (message.method === 'initialize' && message.id !== undefined) {
+        stdout.write(
+          encodeLspMessage({
+            jsonrpc: '2.0',
+            id: message.id,
+            result: { capabilities: serverCapabilities }
+          })
+        )
+      }
+    }
+  })
+
+  return {
+    child,
+    received,
+    reply(id: number, result: unknown): void {
+      stdout.write(encodeLspMessage({ jsonrpc: '2.0', id, result }))
+    },
+    notify(method: string, params: unknown): void {
+      stdout.write(encodeLspMessage({ jsonrpc: '2.0', method, params }))
+    },
+    requestFromServer(id: number | string, method: string, params: unknown): void {
+      stdout.write(encodeLspMessage({ jsonrpc: '2.0', id, method, params }))
+    },
+    async waitFor(predicate: (message: JsonRpcMessage) => boolean): Promise<JsonRpcMessage> {
+      for (let attempt = 0; attempt < 200; attempt++) {
+        const match = received.find(predicate)
+        if (match) {
+          return match
+        }
+        await new Promise((resolve) => setTimeout(resolve, 5))
+      }
+      throw new Error('fake server never received the expected message')
+    }
+  }
+}
+
+function createManagerWithFakeServer(serverCapabilities?: Record<string, unknown>) {
+  const fake = createFakeServer(serverCapabilities)
+  const spawnServer = vi.fn(() => fake.child)
+  const manager = createLspSessionManager({
+    spawnServer,
+    probeCommand: () => Promise.resolve(true)
+  })
+  return { fake, manager, spawnServer }
+}
+
+const openArgs = {
+  filePath: '/workspace/repo/src/index.ts',
+  rootPath: '/workspace/repo',
+  languageId: 'typescript',
+  text: 'const x = 1'
+}
+
+describe('createLspSessionManager', () => {
+  it('returns no session when no server matches the language', async () => {
+    const { manager, spawnServer } = createManagerWithFakeServer()
+    const result = await manager.openDocument({ ...openArgs, languageId: 'plaintext' })
+    expect(result).toEqual({
+      sessionId: null,
+      fileUri: null,
+      serverId: null,
+      pullDiagnostics: false
+    })
+    expect(spawnServer).not.toHaveBeenCalled()
+  })
+
+  it('initializes once, sends didOpen, and reuses the session per root', async () => {
+    const { fake, manager, spawnServer } = createManagerWithFakeServer()
+    const first = await manager.openDocument(openArgs)
+    const second = await manager.openDocument({
+      ...openArgs,
+      filePath: '/workspace/repo/src/other.ts'
+    })
+    expect(first.sessionId).toBe(second.sessionId)
+    expect(first.fileUri).toBe(pathToFileURL(openArgs.filePath).toString())
+    expect(first.serverId).toBe('tsgo')
+    expect(first.pullDiagnostics).toBe(false)
+    expect(spawnServer).toHaveBeenCalledTimes(1)
+    await fake.waitFor((m) => m.method === 'initialized')
+    const didOpens = fake.received.filter((m) => m.method === 'textDocument/didOpen')
+    expect(didOpens).toHaveLength(2)
+  })
+
+  it('reports pullDiagnostics when the server advertises a diagnosticProvider', async () => {
+    const { manager } = createManagerWithFakeServer({ diagnosticProvider: { identifier: 'ts' } })
+    const opened = await manager.openDocument(openArgs)
+    expect(opened.pullDiagnostics).toBe(true)
+  })
+
+  it('answers workspace/configuration with one null per requested item', async () => {
+    const { fake, manager } = createManagerWithFakeServer()
+    await manager.openDocument(openArgs)
+    fake.requestFromServer('cfg-1', 'workspace/configuration', {
+      items: [{ section: 'a' }, { section: 'b' }]
+    })
+    const reply = await fake.waitFor((m) => (m.id as unknown) === 'cfg-1' && m.method === undefined)
+    expect(reply.result).toEqual([null, null])
+  })
+
+  it('routes requests and resolves with the server result', async () => {
+    const { fake, manager } = createManagerWithFakeServer()
+    const { sessionId } = await manager.openDocument(openArgs)
+    const pending = manager.request(sessionId!, 'textDocument/hover', { position: {} })
+    const hoverRequest = await fake.waitFor((m) => m.method === 'textDocument/hover')
+    fake.reply(hoverRequest.id!, { contents: 'docs' })
+    await expect(pending).resolves.toEqual({ contents: 'docs' })
+  })
+
+  it('forwards publishDiagnostics for open documents only', async () => {
+    const { fake, manager } = createManagerWithFakeServer()
+    const diagnostics = vi.fn()
+    manager.onDiagnostics(diagnostics)
+    const { sessionId, fileUri } = await manager.openDocument(openArgs)
+    fake.notify('textDocument/publishDiagnostics', {
+      uri: fileUri,
+      diagnostics: [{ message: 'boom' }]
+    })
+    fake.notify('textDocument/publishDiagnostics', {
+      uri: 'file:///workspace/repo/never-opened.ts',
+      diagnostics: [{ message: 'ignored' }]
+    })
+    await vi.waitFor(() => expect(diagnostics).toHaveBeenCalledTimes(1))
+    expect(diagnostics).toHaveBeenCalledWith({
+      sessionId,
+      fileUri,
+      diagnostics: [{ message: 'boom' }]
+    })
+  })
+
+  it('sends didChange with growing versions and didClose only at refcount zero', async () => {
+    const { fake, manager } = createManagerWithFakeServer()
+    const { sessionId, fileUri } = await manager.openDocument(openArgs)
+    // Why: a repeat open re-syncs text (last writer wins), producing version 2.
+    await manager.openDocument({ ...openArgs, text: 'const x = 1.5' })
+    manager.changeDocument(sessionId!, fileUri!, 'const x = 2')
+    manager.closeDocument(sessionId!, fileUri!)
+    manager.changeDocument(sessionId!, fileUri!, 'const x = 3')
+    manager.closeDocument(sessionId!, fileUri!)
+    await fake.waitFor((m) => m.method === 'textDocument/didClose')
+    const changes = fake.received.filter((m) => m.method === 'textDocument/didChange')
+    expect(
+      changes.map((m) => (m.params as { textDocument: { version: number } }).textDocument.version)
+    ).toEqual([2, 3, 4])
+    expect(fake.received.filter((m) => m.method === 'textDocument/didClose')).toHaveLength(1)
+  })
+
+  it('forwards publishDiagnostics whose URI encodes the path differently', async () => {
+    const { fake, manager } = createManagerWithFakeServer()
+    const diagnostics = vi.fn()
+    manager.onDiagnostics(diagnostics)
+    const { sessionId, fileUri } = await manager.openDocument(openArgs)
+    // Why: vscode-uri-based servers percent-encode where pathToFileURL does not.
+    fake.notify('textDocument/publishDiagnostics', {
+      uri: fileUri!.replace('index.ts', 'index%2Ets'),
+      diagnostics: [{ message: 'boom' }]
+    })
+    await vi.waitFor(() => expect(diagnostics).toHaveBeenCalledTimes(1))
+    expect(diagnostics).toHaveBeenCalledWith({
+      sessionId,
+      fileUri,
+      diagnostics: [{ message: 'boom' }]
+    })
+  })
+
+  it('announces .tsx documents as typescriptreact in didOpen', async () => {
+    const { fake, manager } = createManagerWithFakeServer()
+    await manager.openDocument({ ...openArgs, filePath: '/workspace/repo/src/App.tsx' })
+    const didOpen = await fake.waitFor((m) => m.method === 'textDocument/didOpen')
+    expect(
+      (didOpen.params as { textDocument: { languageId: string } }).textDocument.languageId
+    ).toBe('typescriptreact')
+  })
+
+  it('rejects in-flight requests when the server exits', async () => {
+    const { fake, manager } = createManagerWithFakeServer()
+    const { sessionId } = await manager.openDocument(openArgs)
+    const pending = manager.request(sessionId!, 'textDocument/definition', {})
+    await fake.waitFor((m) => m.method === 'textDocument/definition')
+    fake.child.emit('exit', 1)
+    await expect(pending).rejects.toThrow('LSP server exited')
+    await expect(manager.request(sessionId!, 'textDocument/hover', {})).rejects.toThrow(
+      'Unknown LSP session'
+    )
+  })
+
+  it('kills every child on disposeAll', async () => {
+    const { fake, manager } = createManagerWithFakeServer()
+    await manager.openDocument(openArgs)
+    manager.disposeAll()
+    expect(fake.child.kill).toHaveBeenCalled()
+  })
+})

--- a/src/main/lsp/lsp-session-manager.ts
+++ b/src/main/lsp/lsp-session-manager.ts
@@ -1,0 +1,321 @@
+import { pathToFileURL } from 'node:url'
+import type { LspOpenDocumentResult, LspRequestMethod } from '../../shared/lsp-types'
+import { canonicalFileUriKey } from './lsp-file-uri-key'
+import { buildLspInitializeParams } from './lsp-initialize-params'
+import { encodeLspMessage, LspMessageDecoder } from './lsp-message-framing'
+import { resolveLspServerForLanguage, toLspDocumentLanguageId } from './lsp-server-catalog'
+import type { LspServerDescriptor } from './lsp-server-catalog'
+import { spawnLspServer } from './lsp-server-spawn'
+import type { SpawnLspServer } from './lsp-server-spawn'
+import type { LspDiagnosticsListener, LspSession, OpenDocumentState } from './lsp-session-state'
+
+export type { LspDiagnosticsListener } from './lsp-session-state'
+
+const MAX_CONCURRENT_SESSIONS = 6
+const REQUEST_TIMEOUT_MS = 15_000
+// Why: keep a doc-less server briefly for tab switches, but don't hold
+// memory-heavy servers (tsserver, rust-analyzer) open indefinitely.
+const IDLE_SHUTDOWN_MS = 3 * 60_000
+
+export type LspSessionManager = ReturnType<typeof createLspSessionManager>
+
+export function createLspSessionManager(deps?: {
+  spawnServer?: SpawnLspServer
+  probeCommand?: (command: string) => Promise<boolean>
+}) {
+  const sessionsByKey = new Map<string, LspSession>()
+  const sessionsById = new Map<string, LspSession>()
+  const diagnosticsListeners = new Set<LspDiagnosticsListener>()
+  let nextSessionNumber = 1
+
+  function send(session: LspSession, message: unknown): void {
+    if (!session.disposed) {
+      session.child.stdin.write(encodeLspMessage(message))
+    }
+  }
+
+  function sendRequest(session: LspSession, method: string, params: unknown): Promise<unknown> {
+    if (session.disposed) {
+      return Promise.reject(new Error('LSP session is closed'))
+    }
+    const id = session.nextRequestId++
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        session.pending.delete(id)
+        reject(new Error(`LSP request timed out: ${method}`))
+      }, REQUEST_TIMEOUT_MS)
+      session.pending.set(id, { resolve, reject, timer })
+      send(session, { jsonrpc: '2.0', id, method, params })
+    })
+  }
+
+  function handleServerMessage(session: LspSession, message: unknown): void {
+    const parsed = message as {
+      id?: number | string
+      method?: string
+      result?: unknown
+      error?: { message?: string }
+      params?: { uri?: string; diagnostics?: unknown[] }
+    }
+    if (parsed.id !== undefined && parsed.method === undefined) {
+      const pending = session.pending.get(Number(parsed.id))
+      if (!pending) {
+        return
+      }
+      session.pending.delete(Number(parsed.id))
+      clearTimeout(pending.timer)
+      if (parsed.error) {
+        pending.reject(new Error(parsed.error.message ?? 'LSP request failed'))
+      } else {
+        pending.resolve(parsed.result ?? null)
+      }
+      return
+    }
+    if (parsed.method === 'textDocument/publishDiagnostics' && parsed.params?.uri) {
+      // Why: servers may publish for files the editor never opened (project-wide
+      // scans); forwarding only open docs keeps renderer marker state bounded.
+      // Match on the canonical key — servers mint their own URI form.
+      const document = session.documentsByUri.get(canonicalFileUriKey(parsed.params.uri))
+      if (!document) {
+        return
+      }
+      for (const listener of diagnosticsListeners) {
+        listener({
+          sessionId: session.sessionId,
+          fileUri: document.fileUri,
+          diagnostics: parsed.params.diagnostics ?? []
+        })
+      }
+      return
+    }
+    if (parsed.id !== undefined && parsed.method !== undefined) {
+      // Why: answer server→client requests so servers that await them don't
+      // stall. workspace/configuration expects one entry per requested item
+      // (pyright hangs on a bare null); everything else accepts null.
+      const configurationItems = (parsed.params as { items?: unknown[] } | undefined)?.items
+      const result =
+        parsed.method === 'workspace/configuration' && Array.isArray(configurationItems)
+          ? configurationItems.map(() => null)
+          : null
+      send(session, { jsonrpc: '2.0', id: parsed.id, result })
+    }
+  }
+
+  function disposeSession(session: LspSession, error?: Error): void {
+    if (session.disposed) {
+      return
+    }
+    session.disposed = true
+    if (session.idleTimer) {
+      clearTimeout(session.idleTimer)
+      session.idleTimer = null
+    }
+    for (const pending of session.pending.values()) {
+      clearTimeout(pending.timer)
+      pending.reject(error ?? new Error('LSP session closed'))
+    }
+    session.pending.clear()
+    session.documentsByUri.clear()
+    sessionsByKey.delete(session.key)
+    sessionsById.delete(session.sessionId)
+    session.child.kill()
+  }
+
+  function scheduleIdleShutdown(session: LspSession): void {
+    if (session.idleTimer) {
+      clearTimeout(session.idleTimer)
+    }
+    session.idleTimer = setTimeout(() => {
+      if (session.documentsByUri.size === 0) {
+        send(session, { jsonrpc: '2.0', method: 'exit' })
+        disposeSession(session)
+      }
+    }, IDLE_SHUTDOWN_MS)
+  }
+
+  function createSession(
+    descriptor: LspServerDescriptor,
+    rootPath: string,
+    key: string
+  ): LspSession {
+    const child = (deps?.spawnServer ?? spawnLspServer)(descriptor, rootPath)
+    const session: LspSession = {
+      sessionId: `lsp-${nextSessionNumber++}`,
+      key,
+      serverId: descriptor.serverId,
+      child,
+      nextRequestId: 1,
+      pending: new Map(),
+      documentsByUri: new Map(),
+      initialization: Promise.resolve(),
+      pullDiagnostics: false,
+      idleTimer: null,
+      disposed: false
+    }
+    const decoder = new LspMessageDecoder()
+    child.stdout.on('data', (chunk: Buffer) => {
+      for (const message of decoder.push(chunk)) {
+        handleServerMessage(session, message)
+      }
+    })
+    child.on('error', (error) => disposeSession(session, error))
+    child.on('exit', () => disposeSession(session, new Error('LSP server exited')))
+    child.stdin.on('error', () => disposeSession(session, new Error('LSP server pipe closed')))
+
+    session.initialization = sendRequest(
+      session,
+      'initialize',
+      buildLspInitializeParams(rootPath)
+    ).then((result) => {
+      const capabilities = (result as { capabilities?: { diagnosticProvider?: unknown } } | null)
+        ?.capabilities
+      session.pullDiagnostics = Boolean(capabilities?.diagnosticProvider)
+      send(session, { jsonrpc: '2.0', method: 'initialized', params: {} })
+    })
+    // Why: a failed handshake must not surface as an unhandled rejection; open
+    // callers await initialization and observe the failure there.
+    session.initialization.catch(() => {})
+    return session
+  }
+
+  const noSession: LspOpenDocumentResult = {
+    sessionId: null,
+    fileUri: null,
+    serverId: null,
+    pullDiagnostics: false
+  }
+
+  async function openDocument(args: {
+    filePath: string
+    rootPath: string
+    languageId: string
+    text: string
+  }): Promise<LspOpenDocumentResult> {
+    const descriptor = await resolveLspServerForLanguage(args.languageId, deps?.probeCommand)
+    if (!descriptor) {
+      return noSession
+    }
+    const key = `${descriptor.serverId} ${args.rootPath}`
+    let session = sessionsByKey.get(key)
+    if (!session || session.disposed) {
+      if (sessionsByKey.size >= MAX_CONCURRENT_SESSIONS) {
+        return noSession
+      }
+      session = createSession(descriptor, args.rootPath, key)
+      sessionsByKey.set(key, session)
+      sessionsById.set(session.sessionId, session)
+    }
+    try {
+      await session.initialization
+    } catch {
+      disposeSession(session)
+      return noSession
+    }
+    if (session.disposed) {
+      return noSession
+    }
+    if (session.idleTimer) {
+      clearTimeout(session.idleTimer)
+      session.idleTimer = null
+    }
+    const fileUri = pathToFileURL(args.filePath).toString()
+    const documentKey = canonicalFileUriKey(fileUri)
+    const existing = session.documentsByUri.get(documentKey)
+    if (existing) {
+      existing.refCount++
+      // Why: a second surface (diff pane vs editor tab) can open the same file
+      // with different text; last writer wins so the server tracks what's shown.
+      sendDidChange(session, existing.fileUri, existing, args.text)
+    } else {
+      session.documentsByUri.set(documentKey, { fileUri, version: 1, refCount: 1 })
+      send(session, {
+        jsonrpc: '2.0',
+        method: 'textDocument/didOpen',
+        params: {
+          textDocument: {
+            uri: fileUri,
+            languageId: toLspDocumentLanguageId(args.languageId, args.filePath),
+            version: 1,
+            text: args.text
+          }
+        }
+      })
+    }
+    return {
+      sessionId: session.sessionId,
+      fileUri,
+      serverId: session.serverId,
+      pullDiagnostics: session.pullDiagnostics
+    }
+  }
+
+  function sendDidChange(
+    session: LspSession,
+    fileUri: string,
+    document: OpenDocumentState,
+    text: string
+  ): void {
+    document.version++
+    send(session, {
+      jsonrpc: '2.0',
+      method: 'textDocument/didChange',
+      params: {
+        textDocument: { uri: fileUri, version: document.version },
+        contentChanges: [{ text }]
+      }
+    })
+  }
+
+  function changeDocument(sessionId: string, fileUri: string, text: string): void {
+    const session = sessionsById.get(sessionId)
+    const document = session?.documentsByUri.get(canonicalFileUriKey(fileUri))
+    if (!session || !document) {
+      return
+    }
+    sendDidChange(session, document.fileUri, document, text)
+  }
+
+  function closeDocument(sessionId: string, fileUri: string): void {
+    const session = sessionsById.get(sessionId)
+    const documentKey = canonicalFileUriKey(fileUri)
+    const document = session?.documentsByUri.get(documentKey)
+    if (!session || !document) {
+      return
+    }
+    document.refCount--
+    if (document.refCount > 0) {
+      return
+    }
+    session.documentsByUri.delete(documentKey)
+    send(session, {
+      jsonrpc: '2.0',
+      method: 'textDocument/didClose',
+      params: { textDocument: { uri: document.fileUri } }
+    })
+    if (session.documentsByUri.size === 0) {
+      scheduleIdleShutdown(session)
+    }
+  }
+
+  function request(sessionId: string, method: LspRequestMethod, params: unknown): Promise<unknown> {
+    const session = sessionsById.get(sessionId)
+    if (!session) {
+      return Promise.reject(new Error('Unknown LSP session'))
+    }
+    return sendRequest(session, method, params)
+  }
+
+  function onDiagnostics(listener: LspDiagnosticsListener): () => void {
+    diagnosticsListeners.add(listener)
+    return () => diagnosticsListeners.delete(listener)
+  }
+
+  function disposeAll(): void {
+    for (const session of sessionsById.values()) {
+      send(session, { jsonrpc: '2.0', method: 'exit' })
+      disposeSession(session)
+    }
+  }
+
+  return { openDocument, changeDocument, closeDocument, request, onDiagnostics, disposeAll }
+}

--- a/src/main/lsp/lsp-session-state.ts
+++ b/src/main/lsp/lsp-session-state.ts
@@ -1,0 +1,33 @@
+import type { ChildProcessWithoutNullStreams } from 'node:child_process'
+
+export type PendingRequest = {
+  resolve: (result: unknown) => void
+  reject: (error: Error) => void
+  timer: NodeJS.Timeout
+}
+
+// Why: documentsByUri is keyed by canonicalFileUriKey; keep the exact URI the
+// client knows so diagnostics forwarded to the renderer match its lookups.
+export type OpenDocumentState = { fileUri: string; version: number; refCount: number }
+
+export type LspSession = {
+  sessionId: string
+  key: string
+  serverId: string
+  child: ChildProcessWithoutNullStreams
+  nextRequestId: number
+  pending: Map<number, PendingRequest>
+  documentsByUri: Map<string, OpenDocumentState>
+  initialization: Promise<void>
+  // Why: pull-model servers (tsgo, TS7) advertise diagnosticProvider and never
+  // push; the renderer must know which model this session speaks.
+  pullDiagnostics: boolean
+  idleTimer: NodeJS.Timeout | null
+  disposed: boolean
+}
+
+export type LspDiagnosticsListener = (payload: {
+  sessionId: string
+  fileUri: string
+  diagnostics: unknown[]
+}) => void

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -33,6 +33,7 @@ import type { GitLabApi } from './api/gitlab-api'
 import type { BitbucketApi, HostedReviewApi } from './api/hosted-review-api'
 import type { JiraApi } from './api/jira-api'
 import type { LinearApi } from './api/linear-api'
+import type { LspApi } from './api/lsp-api'
 import type { MobileApi } from './api/mobile-api'
 import type { NativeChatApi } from './api/native-chat-api'
 import type { OnboardingApi, StarNagApi } from './api/onboarding-api'
@@ -133,6 +134,7 @@ export type PreloadApi = {
   aiVault: AiVaultApi
   nativeChat: NativeChatApi
   fs: FilesystemApi['fs']
+  lsp: LspApi
   git: Merged<GitInspectionApi & GitOperationApi>
   ui: Merged<UiCommandEventApi & UiWindowApi>
   runtime: RuntimeApi['runtime']

--- a/src/preload/api/lsp-api.ts
+++ b/src/preload/api/lsp-api.ts
@@ -1,0 +1,16 @@
+import type {
+  LspChangeDocumentArgs,
+  LspCloseDocumentArgs,
+  LspDiagnosticsPayload,
+  LspOpenDocumentArgs,
+  LspOpenDocumentResult,
+  LspRequestArgs
+} from '../../shared/lsp-types'
+
+export type LspApi = {
+  openDocument: (args: LspOpenDocumentArgs) => Promise<LspOpenDocumentResult>
+  changeDocument: (args: LspChangeDocumentArgs) => Promise<void>
+  closeDocument: (args: LspCloseDocumentArgs) => Promise<void>
+  request: (args: LspRequestArgs) => Promise<unknown>
+  onDiagnostics: (callback: (payload: LspDiagnosticsPayload) => void) => () => void
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -279,6 +279,14 @@ import type {
   LocalLogTailReadResult,
   LocalLogTailWatchArgs
 } from '../shared/local-log-tail-types'
+import type {
+  LspChangeDocumentArgs,
+  LspCloseDocumentArgs,
+  LspDiagnosticsPayload,
+  LspOpenDocumentArgs,
+  LspOpenDocumentResult,
+  LspRequestArgs
+} from '../shared/lsp-types'
 import { subscribeRuntimeEnvironmentFromPreload } from './runtime-environment-subscriptions'
 import type { RuntimeEnvironmentSubscriptionHandle } from './runtime-environment-subscriptions'
 import type { HostedReviewForBranchArgs } from '../shared/hosted-review'
@@ -2494,6 +2502,22 @@ const api = {
     openSetup: (args?: { id?: string }): Promise<unknown> =>
       ipcRenderer.invoke('computerUsePermissions:openSetup', args),
     reset: (): Promise<unknown> => ipcRenderer.invoke('computerUsePermissions:reset')
+  },
+
+  lsp: {
+    openDocument: (args: LspOpenDocumentArgs): Promise<LspOpenDocumentResult> =>
+      ipcRenderer.invoke('lsp:openDocument', args),
+    changeDocument: (args: LspChangeDocumentArgs): Promise<void> =>
+      ipcRenderer.invoke('lsp:changeDocument', args),
+    closeDocument: (args: LspCloseDocumentArgs): Promise<void> =>
+      ipcRenderer.invoke('lsp:closeDocument', args),
+    request: (args: LspRequestArgs): Promise<unknown> => ipcRenderer.invoke('lsp:request', args),
+    onDiagnostics: (callback: (payload: LspDiagnosticsPayload) => void): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, payload: LspDiagnosticsPayload): void =>
+        callback(payload)
+      ipcRenderer.on('lsp:diagnostics', listener)
+      return () => ipcRenderer.removeListener('lsp:diagnostics', listener)
+    }
   },
 
   shell: {

--- a/src/renderer/src/components/editor/DiffSectionItem.tsx
+++ b/src/renderer/src/components/editor/DiffSectionItem.tsx
@@ -23,6 +23,7 @@ import { useDiffSectionFallbackCleanup } from './useDiffSectionFallbackCleanup'
 import { submitDiffSectionComment } from './diff-section-comment-submit'
 import type { DiffSectionItemProps } from './diff-section-item-props'
 import { useDiffSectionModelLifecycle } from './use-diff-section-model-lifecycle'
+import { useMonacoLspForDiff } from './use-monaco-lsp-for-diff'
 
 export function DiffSectionItem({
   section,
@@ -80,6 +81,13 @@ export function DiffSectionItem({
   )
 
   const [modifiedEditor, setModifiedEditor] = useState<monacoEditor.ICodeEditor | null>(null)
+  useMonacoLspForDiff({
+    modifiedEditor,
+    relativePath: section.path,
+    worktreeId,
+    language,
+    modelIdentity: modelPathBase
+  })
   const diffEditorRef = useRef<monacoEditor.IStandaloneDiffEditor | null>(null)
   const sectionBodyRef = useRef<HTMLDivElement | null>(null)
   const lineNumberOptionsSubRef = useRef<{ dispose: () => void } | null>(null)

--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -21,6 +21,8 @@ import { diffEditorScrollbarOptions } from './diff-editor-scrollbar-options'
 import { LargeDiffFallback } from './LargeDiffFallback'
 import { getLargeDiffRenderLimit } from './large-diff-render-limit'
 import { useDiffViewerLargeDiffLifecycle } from './useDiffViewerLargeDiffLifecycle'
+import { submitDiffViewerComment } from './diff-viewer-comment-submit'
+import { useMonacoLspForDiff } from './use-monaco-lsp-for-diff'
 import { getDiffViewerLargeDiffSaveAction } from './diff-viewer-large-diff-save-action'
 import type { DiffViewerProps } from './diff-viewer-props'
 import { buildDiffEditorWordWrapOptions } from './diff-editor-word-wrap-options'
@@ -75,6 +77,13 @@ export default function DiffViewer({
   const diffBodyRef = useRef<HTMLDivElement | null>(null)
   const lineNumberOptionsSubRef = useRef<{ dispose: () => void } | null>(null)
   const [modifiedEditor, setModifiedEditor] = useState<editor.ICodeEditor | null>(null)
+  useMonacoLspForDiff({
+    modifiedEditor,
+    relativePath,
+    worktreeId,
+    language,
+    modelIdentity: modifiedModelKey ?? modelKey
+  })
   const [popover, setPopover] = useState<{
     lineNumber: number
     startLine?: number
@@ -235,34 +244,16 @@ export default function DiffViewer({
     if (!popover) {
       return
     }
-    if (onAddLineComment) {
-      const ok = await onAddLineComment({
-        lineNumber: popover.lineNumber,
-        startLine: popover.startLine,
-        body
-      })
-      if (ok) {
-        setPopover(null)
-      }
-      return
-    }
-    if (!worktreeId) {
-      return
-    }
-    // Why: await persistence — a null result (failed save) keeps the popover open for retry instead of losing the draft.
-    const result = await addDiffComment({
-      worktreeId,
-      filePath: relativePath,
-      source: 'diff',
-      startLine: popover.startLine,
-      lineNumber: popover.lineNumber,
+    const persisted = await submitDiffViewerComment({
+      addDiffComment,
       body,
-      side: 'modified'
+      onAddLineComment,
+      popover,
+      relativePath,
+      worktreeId
     })
-    if (result) {
+    if (persisted) {
       setPopover(null)
-    } else {
-      console.error('Failed to add diff comment — draft preserved')
     }
   }
 

--- a/src/renderer/src/components/editor/MonacoEditor.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.tsx
@@ -19,6 +19,7 @@ import { useMonacoContentSyncBridge } from './use-monaco-content-sync-bridge'
 import { useMonacoMarkdownAnnotations } from './use-monaco-markdown-annotations'
 import { useMonacoEditorDecorations } from './use-monaco-editor-decorations'
 import { useMonacoEditorMount } from './use-monaco-editor-mount'
+import { useMonacoLsp } from './use-monaco-lsp'
 import { snapshotMonacoViewState } from './monaco-view-state-persistence'
 import { MonacoMarkdownAnnotationOverlay } from './MonacoMarkdownAnnotationOverlay'
 
@@ -128,6 +129,8 @@ export default function MonacoEditor({
     filePath,
     onContentChange
   })
+  useMonacoLsp({ mountedEditor, filePath, language, worktreeId, liveTail })
+
   const annotations = useMonacoMarkdownAnnotations({
     mountedEditor,
     editorContainerRef,

--- a/src/renderer/src/components/editor/diff-viewer-comment-submit.ts
+++ b/src/renderer/src/components/editor/diff-viewer-comment-submit.ts
@@ -1,0 +1,62 @@
+type DiffViewerPopoverTarget = {
+  lineNumber: number
+  startLine?: number
+}
+
+type AddDiffComment = (args: {
+  worktreeId: string
+  filePath: string
+  source: 'diff'
+  startLine?: number
+  lineNumber: number
+  body: string
+  side: 'modified'
+}) => Promise<unknown>
+
+/** Single-file DiffViewer variant of submitDiffSectionComment: resolves to
+ *  whether the comment persisted, so the caller keeps the draft open on failure. */
+export async function submitDiffViewerComment({
+  addDiffComment,
+  body,
+  onAddLineComment,
+  popover,
+  relativePath,
+  worktreeId
+}: {
+  addDiffComment: AddDiffComment
+  body: string
+  onAddLineComment?: (args: {
+    lineNumber: number
+    startLine?: number
+    body: string
+  }) => Promise<boolean>
+  popover: DiffViewerPopoverTarget
+  relativePath: string
+  worktreeId?: string
+}): Promise<boolean> {
+  if (onAddLineComment) {
+    return onAddLineComment({
+      lineNumber: popover.lineNumber,
+      startLine: popover.startLine,
+      body
+    })
+  }
+  if (!worktreeId) {
+    return false
+  }
+  // Why: await persistence — a failed save keeps the popover open for retry
+  // instead of losing the draft.
+  const result = await addDiffComment({
+    worktreeId,
+    filePath: relativePath,
+    source: 'diff',
+    startLine: popover.startLine,
+    lineNumber: popover.lineNumber,
+    body,
+    side: 'modified'
+  })
+  if (!result) {
+    console.error('Failed to add diff comment — draft preserved')
+  }
+  return Boolean(result)
+}

--- a/src/renderer/src/components/editor/use-monaco-lsp-for-diff.ts
+++ b/src/renderer/src/components/editor/use-monaco-lsp-for-diff.ts
@@ -1,0 +1,49 @@
+import { useEffect } from 'react'
+import type { editor } from 'monaco-editor'
+import { useAppStore } from '@/store'
+import { findWorktreeById } from '@/store/slices/worktree-helpers'
+import { getConnectionId } from '@/lib/connection-context'
+import { attachMonacoLspDocument } from '@/lib/monaco-lsp/monaco-lsp-attach'
+import { resolveAnnotationPathInsideWorktree } from './check-annotation-path'
+
+/** Attach the modified pane of a diff to a local language server so hover,
+ *  definitions, and diagnostics reflect real project types instead of the
+ *  sandboxed single-file worker. The original (base) pane stays plain. */
+export function useMonacoLspForDiff(params: {
+  modifiedEditor: editor.ICodeEditor | null
+  relativePath: string
+  worktreeId: string | undefined
+  language: string
+  /** Changes whenever the diff's Monaco models are re-created. */
+  modelIdentity: string
+}): void {
+  const { modifiedEditor, relativePath, worktreeId, language, modelIdentity } = params
+  const worktreePath = useAppStore((s) =>
+    worktreeId ? (findWorktreeById(s.worktreesByRepo, worktreeId)?.path ?? null) : null
+  )
+
+  useEffect(() => {
+    if (!modifiedEditor || !worktreeId || !worktreePath) {
+      return
+    }
+    if (getConnectionId(worktreeId) !== null) {
+      return
+    }
+    const resolved = resolveAnnotationPathInsideWorktree(worktreePath, relativePath)
+    if (!resolved) {
+      return
+    }
+    const model = modifiedEditor.getModel()
+    if (!model || model.isDisposed()) {
+      return
+    }
+    return attachMonacoLspDocument({
+      model,
+      filePath: resolved.absolutePath,
+      rootPath: worktreePath,
+      worktreeId,
+      languageId: language
+    })
+    // Why: modelIdentity re-attaches after the diff surface swaps its models.
+  }, [modifiedEditor, worktreeId, worktreePath, relativePath, language, modelIdentity])
+}

--- a/src/renderer/src/components/editor/use-monaco-lsp.ts
+++ b/src/renderer/src/components/editor/use-monaco-lsp.ts
@@ -1,0 +1,42 @@
+import { useEffect } from 'react'
+import type { editor } from 'monaco-editor'
+import { useAppStore } from '@/store'
+import { findWorktreeById } from '@/store/slices/worktree-helpers'
+import { getConnectionId } from '@/lib/connection-context'
+import { attachMonacoLspDocument } from '@/lib/monaco-lsp/monaco-lsp-attach'
+
+/** Attach the mounted editor's document to a local language server, when one
+ *  exists for the language. Remote/SSH workspaces and surfaces without the lsp
+ *  bridge silently get no LSP. */
+export function useMonacoLsp(params: {
+  mountedEditor: editor.IStandaloneCodeEditor | null
+  filePath: string
+  language: string
+  worktreeId: string | undefined
+  liveTail: boolean
+}): void {
+  const { mountedEditor, filePath, language, worktreeId, liveTail } = params
+  const worktreePath = useAppStore((s) =>
+    worktreeId ? (findWorktreeById(s.worktreesByRepo, worktreeId)?.path ?? null) : null
+  )
+
+  useEffect(() => {
+    if (!mountedEditor || !worktreeId || !worktreePath || liveTail) {
+      return
+    }
+    if (getConnectionId(worktreeId) !== null) {
+      return
+    }
+    const model = mountedEditor.getModel()
+    if (!model || model.isDisposed()) {
+      return
+    }
+    return attachMonacoLspDocument({
+      model,
+      filePath,
+      rootPath: worktreePath,
+      worktreeId,
+      languageId: language
+    })
+  }, [mountedEditor, filePath, language, worktreeId, worktreePath, liveTail])
+}

--- a/src/renderer/src/components/status-bar/LspStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/LspStatusSegment.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import { useAppStore } from '@/store'
+import { useLspStatusForFile } from '@/lib/monaco-lsp/monaco-lsp-status'
+
+/** Language-server indicator for the active editor file: hidden when no
+ *  server is attached, amber while starting, emerald with the server name
+ *  (e.g. tsgo) once running. */
+export function LspStatusSegment({ iconOnly }: { iconOnly: boolean }): React.JSX.Element | null {
+  const activeFilePath = useAppStore(
+    (s) => s.openFiles.find((file) => file.id === s.activeFileId)?.filePath ?? null
+  )
+  const status = useLspStatusForFile(activeFilePath)
+  if (!status) {
+    return null
+  }
+  const starting = status.state === 'starting'
+  const serverLabel = status.serverId ?? 'LSP'
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="flex cursor-default select-none items-center gap-1.5 text-[11px] text-muted-foreground">
+          <span
+            className={cn(
+              'size-1.5 rounded-full',
+              starting ? 'animate-pulse bg-amber-500' : 'bg-emerald-500'
+            )}
+          />
+          {iconOnly
+            ? null
+            : starting
+              ? translate('auto.components.status.bar.LspStatusSegment.badge', 'LSP')
+              : serverLabel}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top" sideOffset={6}>
+        {starting
+          ? translate(
+              'auto.components.status.bar.LspStatusSegment.starting',
+              'Language server starting…'
+            )
+          : `${translate(
+              'auto.components.status.bar.LspStatusSegment.running',
+              'Language server'
+            )}: ${serverLabel}`}
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -72,6 +72,7 @@ import {
 import { UpdateStatusSegment } from './UpdateStatusSegment'
 import { SkillUpdateStatusSegment } from './SkillUpdateStatusSegment'
 import { CaffeinateStatusSegment } from './CaffeinateStatusSegment'
+import { LspStatusSegment } from './LspStatusSegment'
 import { RemoteServerUpdateStatusSegment } from './RemoteServerUpdateStatusSegment'
 import { isStatusBarItemAvailable } from './status-bar-agent-gating'
 import { getVisibleUsageProvider, isUsageEmptyState } from './status-bar-provider-visibility'
@@ -2351,6 +2352,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
       <div className="flex-1" />
 
       <div className="flex items-center gap-3">
+        <LspStatusSegment iconOnly={iconOnly} />
         {!isPairedWebClientWindow() ? <CaffeinateStatusSegment iconOnly={iconOnly} /> : null}
         <RemoteServerUpdateStatusSegment iconOnly={iconOnly} />
         <SkillUpdateStatusSegment iconOnly={iconOnly} />

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3701,6 +3701,11 @@
             "onDescription": "Keep this computer awake continuously",
             "autoDescription": "Stay awake while an agent is working",
             "offDescription": "Allow normal system sleep behavior"
+          },
+          "LspStatusSegment": {
+            "starting": "Language server starting…",
+            "running": "Language server",
+            "badge": "LSP"
           }
         }
       },

--- a/src/renderer/src/lib/monaco-lsp/lsp-monaco-conversion.test.ts
+++ b/src/renderer/src/lib/monaco-lsp/lsp-monaco-conversion.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from 'vitest'
+import {
+  fileUriToPath,
+  lspCompletionToMonaco,
+  lspDefinitionToLocations,
+  lspDiagnosticsToMonacoMarkers,
+  lspHoverToMonaco,
+  lspPullDiagnosticsToItems,
+  lspRangeToMonaco,
+  toLspPosition
+} from './lsp-monaco-conversion'
+
+const lspRange = { start: { line: 0, character: 4 }, end: { line: 2, character: 0 } }
+const monacoRange = { startLineNumber: 1, startColumn: 5, endLineNumber: 3, endColumn: 1 }
+
+describe('position and range mapping', () => {
+  it('shifts Monaco 1-based positions to LSP 0-based', () => {
+    expect(toLspPosition({ lineNumber: 10, column: 3 })).toEqual({ line: 9, character: 2 })
+  })
+
+  it('shifts LSP ranges to Monaco ranges', () => {
+    expect(lspRangeToMonaco(lspRange)).toEqual(monacoRange)
+  })
+})
+
+describe('lspHoverToMonaco', () => {
+  it('handles MarkupContent', () => {
+    expect(lspHoverToMonaco({ contents: { kind: 'markdown', value: '**doc**' } })).toEqual({
+      contents: [{ value: '**doc**' }]
+    })
+  })
+
+  it('fences language-tagged MarkedStrings and keeps the range', () => {
+    expect(
+      lspHoverToMonaco({
+        contents: [{ language: 'typescript', value: 'const x: number' }, 'extra'],
+        range: lspRange
+      })
+    ).toEqual({
+      contents: [{ value: '```typescript\nconst x: number\n```' }, { value: 'extra' }],
+      range: monacoRange
+    })
+  })
+
+  it('returns null for empty hovers', () => {
+    expect(lspHoverToMonaco(null)).toBeNull()
+    expect(lspHoverToMonaco({ contents: [] })).toBeNull()
+    expect(lspHoverToMonaco({ contents: '   ' })).toBeNull()
+  })
+})
+
+describe('lspDefinitionToLocations', () => {
+  it('normalizes single Location, Location[], and LocationLink[]', () => {
+    const location = { uri: 'file:///a.ts', range: lspRange }
+    expect(lspDefinitionToLocations(location)).toEqual([
+      { uri: 'file:///a.ts', range: monacoRange }
+    ])
+    expect(lspDefinitionToLocations([location])).toHaveLength(1)
+    expect(
+      lspDefinitionToLocations([
+        {
+          targetUri: 'file:///b.ts',
+          targetRange: { start: { line: 5, character: 0 }, end: { line: 9, character: 0 } },
+          targetSelectionRange: lspRange
+        }
+      ])
+    ).toEqual([{ uri: 'file:///b.ts', range: monacoRange }])
+    expect(lspDefinitionToLocations(null)).toEqual([])
+  })
+})
+
+describe('lspCompletionToMonaco', () => {
+  const enums = { kinds: { Text: 18, Function: 1, Method: 0 }, snippetRule: 4 }
+  const defaultRange = monacoRange
+
+  it('maps LSP kinds to the provided Monaco kind enum', () => {
+    const { suggestions } = lspCompletionToMonaco(
+      { isIncomplete: true, items: [{ label: 'fn', kind: 3 }] },
+      defaultRange,
+      enums
+    )
+    expect(suggestions).toEqual([{ label: 'fn', kind: 1, insertText: 'fn', range: defaultRange }])
+  })
+
+  it('prefers textEdit newText and range, and flags snippets', () => {
+    const { suggestions, incomplete } = lspCompletionToMonaco(
+      {
+        isIncomplete: true,
+        items: [
+          {
+            label: 'log',
+            kind: 2,
+            insertText: 'ignored',
+            insertTextFormat: 2,
+            textEdit: { newText: 'log($1)', range: lspRange }
+          }
+        ]
+      },
+      defaultRange,
+      enums
+    )
+    expect(incomplete).toBe(true)
+    expect(suggestions[0]).toMatchObject({
+      insertText: 'log($1)',
+      insertTextRules: 4,
+      range: monacoRange,
+      kind: 0
+    })
+  })
+
+  it('accepts a bare CompletionItem[] response', () => {
+    const { suggestions, incomplete } = lspCompletionToMonaco([{ label: 'a' }], defaultRange, enums)
+    expect(incomplete).toBe(false)
+    expect(suggestions[0].kind).toBe(18)
+  })
+})
+
+describe('lspDiagnosticsToMonacoMarkers', () => {
+  const severities = { Error: 8, Warning: 4, Info: 2, Hint: 1 }
+
+  it('maps severity, code objects, and range', () => {
+    const markers = lspDiagnosticsToMonacoMarkers(
+      [
+        { range: lspRange, message: 'bad', severity: 2, code: { value: 2304 }, source: 'ts' },
+        { range: lspRange, message: 'unknown severity defaults to error' }
+      ],
+      severities
+    )
+    expect(markers[0]).toEqual({
+      ...monacoRange,
+      severity: 4,
+      message: 'bad',
+      code: '2304',
+      source: 'ts'
+    })
+    expect(markers[1].severity).toBe(8)
+  })
+
+  it('drops malformed entries', () => {
+    expect(
+      lspDiagnosticsToMonacoMarkers(
+        [null, { message: 'no range' }, { range: lspRange }],
+        severities
+      )
+    ).toEqual([])
+  })
+})
+
+describe('lspPullDiagnosticsToItems', () => {
+  it('returns items for full reports and null otherwise', () => {
+    const items = [{ range: lspRange, message: 'bad' }]
+    expect(lspPullDiagnosticsToItems({ kind: 'full', items })).toBe(items)
+    expect(lspPullDiagnosticsToItems({ kind: 'unchanged', resultId: 'a' })).toBeNull()
+    expect(lspPullDiagnosticsToItems(null)).toBeNull()
+    expect(lspPullDiagnosticsToItems({ kind: 'full' })).toBeNull()
+  })
+})
+
+describe('fileUriToPath', () => {
+  it('decodes posix paths', () => {
+    expect(fileUriToPath('file:///Users/dev/my%20project/a.ts')).toBe('/Users/dev/my project/a.ts')
+  })
+
+  it('converts drive-letter URIs to Windows paths', () => {
+    expect(fileUriToPath('file:///C:/dev/repo/a.ts')).toBe('C:\\dev\\repo\\a.ts')
+    expect(fileUriToPath('file:///c%3A/dev/a.ts')).toBe('c:\\dev\\a.ts')
+  })
+
+  it('rejects non-file and remote-host URIs', () => {
+    expect(fileUriToPath('untitled:Untitled-1')).toBeNull()
+    expect(fileUriToPath('file://server/share/a.ts')).toBeNull()
+    expect(fileUriToPath('file://localhost/a.ts')).toBe('/a.ts')
+  })
+})

--- a/src/renderer/src/lib/monaco-lsp/lsp-monaco-conversion.ts
+++ b/src/renderer/src/lib/monaco-lsp/lsp-monaco-conversion.ts
@@ -1,0 +1,249 @@
+/** Pure LSP↔Monaco shape converters. LSP is 0-based, Monaco 1-based; both use
+ *  UTF-16 columns, so only the off-by-one shift is needed. Monaco enum objects
+ *  are passed in by the caller so this module stays import-free and node-testable. */
+
+import type { IRange } from 'monaco-editor'
+
+export const LSP_MARKER_OWNER = 'orca-lsp'
+
+export type LspPosition = { line: number; character: number }
+export type LspRange = { start: LspPosition; end: LspPosition }
+
+type LspMarkupContent = { kind?: string; value: string }
+type LspMarkedString = string | { language: string; value: string }
+type LspLocation = { uri: string; range: LspRange }
+type LspLocationLink = { targetUri: string; targetRange: LspRange; targetSelectionRange?: LspRange }
+
+export function toLspPosition(position: { lineNumber: number; column: number }): LspPosition {
+  return { line: position.lineNumber - 1, character: position.column - 1 }
+}
+
+export function lspRangeToMonaco(range: LspRange): IRange {
+  return {
+    startLineNumber: range.start.line + 1,
+    startColumn: range.start.character + 1,
+    endLineNumber: range.end.line + 1,
+    endColumn: range.end.character + 1
+  }
+}
+
+function markedStringToMarkdown(content: LspMarkedString | LspMarkupContent): string {
+  if (typeof content === 'string') {
+    return content
+  }
+  if ('language' in content && content.language) {
+    return `\`\`\`${content.language}\n${content.value}\n\`\`\``
+  }
+  return content.value
+}
+
+export function lspHoverToMonaco(
+  result: unknown
+): { contents: { value: string }[]; range?: IRange } | null {
+  const hover = result as {
+    contents?: LspMarkedString | LspMarkupContent | (LspMarkedString | LspMarkupContent)[]
+    range?: LspRange
+  } | null
+  if (!hover?.contents) {
+    return null
+  }
+  const parts = Array.isArray(hover.contents) ? hover.contents : [hover.contents]
+  const contents = parts
+    .map(markedStringToMarkdown)
+    .filter((value) => value.trim().length > 0)
+    .map((value) => ({ value }))
+  if (contents.length === 0) {
+    return null
+  }
+  return hover.range ? { contents, range: lspRangeToMonaco(hover.range) } : { contents }
+}
+
+export function lspDefinitionToLocations(result: unknown): { uri: string; range: IRange }[] {
+  if (!result) {
+    return []
+  }
+  const items = Array.isArray(result) ? result : [result]
+  return items.flatMap((item) => {
+    const link = item as Partial<LspLocationLink> & Partial<LspLocation>
+    if (link.targetUri && link.targetRange) {
+      return [
+        {
+          uri: link.targetUri,
+          range: lspRangeToMonaco(link.targetSelectionRange ?? link.targetRange)
+        }
+      ]
+    }
+    if (link.uri && link.range) {
+      return [{ uri: link.uri, range: lspRangeToMonaco(link.range) }]
+    }
+    return []
+  })
+}
+
+// LSP CompletionItemKind codes (1-based) by Monaco kind name.
+const LSP_COMPLETION_KIND_NAMES: readonly string[] = [
+  'Text',
+  'Method',
+  'Function',
+  'Constructor',
+  'Field',
+  'Variable',
+  'Class',
+  'Interface',
+  'Module',
+  'Property',
+  'Unit',
+  'Value',
+  'Enum',
+  'Keyword',
+  'Snippet',
+  'Color',
+  'File',
+  'Reference',
+  'Folder',
+  'EnumMember',
+  'Constant',
+  'Struct',
+  'Event',
+  'Operator',
+  'TypeParameter'
+]
+
+type LspCompletionItem = {
+  label: string
+  kind?: number
+  detail?: string
+  documentation?: string | LspMarkupContent
+  sortText?: string
+  filterText?: string
+  insertText?: string
+  insertTextFormat?: number
+  textEdit?: { newText: string; range?: LspRange; insert?: LspRange; replace?: LspRange }
+}
+
+export type MonacoSuggestionShape = {
+  label: string
+  kind: number
+  detail?: string
+  documentation?: { value: string }
+  sortText?: string
+  filterText?: string
+  insertText: string
+  insertTextRules?: number
+  range: IRange
+}
+
+export function lspCompletionToMonaco(
+  result: unknown,
+  defaultRange: IRange,
+  enums: { kinds: Record<string, number>; snippetRule: number }
+): { suggestions: MonacoSuggestionShape[]; incomplete: boolean } {
+  const list = result as
+    | { items?: LspCompletionItem[]; isIncomplete?: boolean }
+    | LspCompletionItem[]
+    | null
+  const items = Array.isArray(list) ? list : (list?.items ?? [])
+  const incomplete = !Array.isArray(list) && list?.isIncomplete === true
+  const suggestions = items.map((item): MonacoSuggestionShape => {
+    const editRange = item.textEdit?.range ?? item.textEdit?.insert
+    const kindName = LSP_COMPLETION_KIND_NAMES[(item.kind ?? 1) - 1] ?? 'Text'
+    const suggestion: MonacoSuggestionShape = {
+      label: item.label,
+      kind: enums.kinds[kindName] ?? enums.kinds.Text,
+      insertText: item.textEdit?.newText ?? item.insertText ?? item.label,
+      range: editRange ? lspRangeToMonaco(editRange) : defaultRange
+    }
+    if (item.detail) {
+      suggestion.detail = item.detail
+    }
+    if (item.documentation) {
+      suggestion.documentation = { value: markedStringToMarkdown(item.documentation) }
+    }
+    if (item.sortText) {
+      suggestion.sortText = item.sortText
+    }
+    if (item.filterText) {
+      suggestion.filterText = item.filterText
+    }
+    if (item.insertTextFormat === 2) {
+      suggestion.insertTextRules = enums.snippetRule
+    }
+    return suggestion
+  })
+  return { suggestions, incomplete }
+}
+
+type LspDiagnostic = {
+  range: LspRange
+  message: string
+  severity?: number
+  code?: string | number | { value: string | number }
+  source?: string
+}
+
+export type MonacoMarkerShape = IRange & {
+  severity: number
+  message: string
+  code?: string
+  source?: string
+}
+
+export function lspDiagnosticsToMonacoMarkers(
+  diagnostics: unknown[],
+  severities: { Error: number; Warning: number; Info: number; Hint: number }
+): MonacoMarkerShape[] {
+  const severityByLspCode = [severities.Error, severities.Warning, severities.Info, severities.Hint]
+  return (diagnostics as LspDiagnostic[])
+    .filter((diagnostic) => diagnostic?.range && typeof diagnostic.message === 'string')
+    .map((diagnostic) => {
+      const code =
+        typeof diagnostic.code === 'object' && diagnostic.code !== null
+          ? diagnostic.code.value
+          : diagnostic.code
+      const marker: MonacoMarkerShape = {
+        ...lspRangeToMonaco(diagnostic.range),
+        severity: severityByLspCode[(diagnostic.severity ?? 1) - 1] ?? severities.Error,
+        message: diagnostic.message
+      }
+      if (code !== undefined) {
+        marker.code = String(code)
+      }
+      if (diagnostic.source) {
+        marker.source = diagnostic.source
+      }
+      return marker
+    })
+}
+
+/** Pull-diagnostics response (textDocument/diagnostic) → diagnostic items.
+ *  Null means "keep the current markers" (kind: 'unchanged' or malformed). */
+export function lspPullDiagnosticsToItems(result: unknown): unknown[] | null {
+  const report = result as { kind?: string; items?: unknown[] } | null
+  if (report?.kind === 'full' && Array.isArray(report.items)) {
+    return report.items
+  }
+  return null
+}
+
+/** file:// URI → local absolute path (posix or Windows). Null for anything else. */
+export function fileUriToPath(uri: string): string | null {
+  const match = /^file:\/\/(?<host>[^/]*)(?<path>\/.*)$/i.exec(uri)
+  if (!match?.groups) {
+    return null
+  }
+  const host = match.groups.host
+  if (host && host !== 'localhost') {
+    return null
+  }
+  let decoded: string
+  try {
+    decoded = decodeURIComponent(match.groups.path)
+  } catch {
+    return null
+  }
+  const driveMatch = /^\/([A-Za-z]:)(\/.*)?$/.exec(decoded)
+  if (driveMatch) {
+    return `${driveMatch[1]}${(driveMatch[2] ?? '/').replace(/\//g, '\\')}`
+  }
+  return decoded
+}

--- a/src/renderer/src/lib/monaco-lsp/monaco-lsp-attach.ts
+++ b/src/renderer/src/lib/monaco-lsp/monaco-lsp-attach.ts
@@ -1,0 +1,44 @@
+import type { editor } from 'monaco-editor'
+import { monaco } from '@/lib/monaco-setup'
+import { closeLspDocumentForModel, openLspDocumentForModel } from './monaco-lsp-documents'
+import { clearLspMarkers, ensureLspSupportForLanguage } from './monaco-lsp-providers'
+
+/** Open `model` as an LSP document and lazily register the language's
+ *  providers; returns the detach cleanup. Shared by the file editor and the
+ *  diff viewer's modified pane. */
+export function attachMonacoLspDocument(params: {
+  model: editor.ITextModel
+  filePath: string
+  rootPath: string
+  worktreeId: string
+  languageId: string
+}): () => void {
+  const modelUri = params.model.uri.toString()
+  const clear = (staleModel: editor.ITextModel): void => clearLspMarkers(monaco, staleModel)
+  let closed = false
+  let opened = false
+  void openLspDocumentForModel({
+    model: params.model,
+    filePath: params.filePath,
+    rootPath: params.rootPath,
+    worktreeId: params.worktreeId,
+    languageId: params.languageId
+  }).then((entry) => {
+    if (!entry) {
+      return
+    }
+    if (closed) {
+      // Why: the surface unmounted while the open round-trip was in flight.
+      closeLspDocumentForModel(modelUri, clear)
+      return
+    }
+    opened = true
+    ensureLspSupportForLanguage(monaco, params.languageId)
+  })
+  return () => {
+    closed = true
+    if (opened) {
+      closeLspDocumentForModel(modelUri, clear)
+    }
+  }
+}

--- a/src/renderer/src/lib/monaco-lsp/monaco-lsp-documents.test.ts
+++ b/src/renderer/src/lib/monaco-lsp/monaco-lsp-documents.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { editor } from 'monaco-editor'
+
+vi.mock('@/lib/monaco-setup', () => ({
+  monaco: {
+    editor: { setModelMarkers: vi.fn() },
+    MarkerSeverity: { Error: 8, Warning: 4, Info: 2, Hint: 1 }
+  }
+}))
+
+import {
+  closeLspDocumentForModel,
+  getLspEntriesForSessionDocument,
+  openLspDocumentForModel
+} from './monaco-lsp-documents'
+
+type FakeModel = editor.ITextModel & { setFakeValue: (text: string) => void }
+
+function fakeModel(uri: string, text: string): FakeModel {
+  let value = text
+  return {
+    uri: { toString: () => uri },
+    getValue: () => value,
+    isDisposed: () => false,
+    onDidChangeContent: () => ({ dispose: vi.fn() }),
+    setFakeValue: (next: string) => {
+      value = next
+    }
+  } as unknown as FakeModel
+}
+
+const OPEN_RESULT = {
+  sessionId: 'lsp-1',
+  fileUri: 'file:///w/src/a.ts',
+  serverId: 'tsgo',
+  pullDiagnostics: false
+}
+
+const openParams = {
+  filePath: '/w/src/a.ts',
+  rootPath: '/w',
+  worktreeId: 'wt-1',
+  languageId: 'typescript'
+}
+
+function stubLspApi(): {
+  openDocument: ReturnType<typeof vi.fn>
+  changeDocument: ReturnType<typeof vi.fn>
+} {
+  const api = {
+    openDocument: vi.fn().mockResolvedValue(OPEN_RESULT),
+    changeDocument: vi.fn().mockResolvedValue(undefined),
+    closeDocument: vi.fn().mockResolvedValue(undefined),
+    request: vi.fn().mockResolvedValue(null),
+    onDiagnostics: vi.fn(() => () => {})
+  }
+  ;(globalThis as { window?: unknown }).window ??= globalThis
+  ;(window as { api?: unknown }).api = { lsp: api } as never
+  return api
+}
+
+describe('openLspDocumentForModel', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('fans diagnostics routing out to every surface of the same server document', async () => {
+    stubLspApi()
+    const tabModel = fakeModel('file:///w/src/a.ts', 'x')
+    const diffModel = fakeModel('diff-section:wt-1:a:0:modified', 'x')
+    await openLspDocumentForModel({ ...openParams, model: tabModel })
+    await openLspDocumentForModel({ ...openParams, model: diffModel })
+    expect(getLspEntriesForSessionDocument('lsp-1', OPEN_RESULT.fileUri)).toHaveLength(2)
+
+    // Why: closing one surface must not delete the other surface's routing.
+    closeLspDocumentForModel(tabModel.uri.toString(), () => {})
+    const remaining = getLspEntriesForSessionDocument('lsp-1', OPEN_RESULT.fileUri)
+    expect(remaining).toHaveLength(1)
+    expect(remaining[0].model).toBe(diffModel)
+    closeLspDocumentForModel(diffModel.uri.toString(), () => {})
+    expect(getLspEntriesForSessionDocument('lsp-1', OPEN_RESULT.fileUri)).toHaveLength(0)
+  })
+
+  it('re-syncs text that changed while the open round-trip was in flight', async () => {
+    const api = stubLspApi()
+    const model = fakeModel('file:///w/src/b.ts', 'before')
+    api.openDocument.mockImplementation(async () => {
+      model.setFakeValue('after keystrokes')
+      return { ...OPEN_RESULT, fileUri: 'file:///w/src/b.ts' }
+    })
+    await openLspDocumentForModel({ ...openParams, filePath: '/w/src/b.ts', model })
+    await vi.waitFor(() =>
+      expect(api.changeDocument).toHaveBeenCalledWith({
+        sessionId: 'lsp-1',
+        fileUri: 'file:///w/src/b.ts',
+        text: 'after keystrokes'
+      })
+    )
+    closeLspDocumentForModel(model.uri.toString(), () => {})
+  })
+})

--- a/src/renderer/src/lib/monaco-lsp/monaco-lsp-documents.ts
+++ b/src/renderer/src/lib/monaco-lsp/monaco-lsp-documents.ts
@@ -1,0 +1,223 @@
+import type { IDisposable, editor } from 'monaco-editor'
+import { monaco } from '@/lib/monaco-setup'
+import {
+  LSP_MARKER_OWNER,
+  lspDiagnosticsToMonacoMarkers,
+  lspPullDiagnosticsToItems
+} from './lsp-monaco-conversion'
+import { setLspFileStatus } from './monaco-lsp-status'
+
+// Why: batch keystrokes into one didChange without letting hover/completion
+// requests observe text older than this window (providers flush first).
+const CHANGE_DEBOUNCE_MS = 250
+
+export type LspDocumentEntry = {
+  sessionId: string
+  fileUri: string
+  filePath: string
+  rootPath: string
+  worktreeId: string
+  serverId: string | null
+  /** True when the server never pushes publishDiagnostics (tsgo/TS7 model);
+   *  we request textDocument/diagnostic after open and after each sync. */
+  pullDiagnostics: boolean
+  model: editor.ITextModel
+  refCount: number
+  changeTimer: ReturnType<typeof setTimeout> | null
+  // Why: providers await this before requesting so the server saw the latest text.
+  lastSync: Promise<void>
+  contentListener: IDisposable
+}
+
+const entriesByModelUri = new Map<string, LspDocumentEntry>()
+// Why: one server document can back several models at once (editor tab + diff
+// pane of the same file), so diagnostics routing must fan out, not overwrite.
+const entriesBySessionDocument = new Map<string, Set<LspDocumentEntry>>()
+
+function sessionDocumentKey(sessionId: string, fileUri: string): string {
+  return `${sessionId} ${fileUri}`
+}
+
+function registerSessionDocumentEntry(entry: LspDocumentEntry): void {
+  const key = sessionDocumentKey(entry.sessionId, entry.fileUri)
+  const entries = entriesBySessionDocument.get(key) ?? new Set()
+  entries.add(entry)
+  entriesBySessionDocument.set(key, entries)
+}
+
+function unregisterSessionDocumentEntry(entry: LspDocumentEntry): void {
+  const key = sessionDocumentKey(entry.sessionId, entry.fileUri)
+  const entries = entriesBySessionDocument.get(key)
+  entries?.delete(entry)
+  if (entries?.size === 0) {
+    entriesBySessionDocument.delete(key)
+  }
+}
+
+async function pullDiagnosticsNow(entry: LspDocumentEntry): Promise<void> {
+  if (!entry.pullDiagnostics) {
+    return
+  }
+  try {
+    const result = await window.api.lsp.request({
+      sessionId: entry.sessionId,
+      method: 'textDocument/diagnostic',
+      params: { textDocument: { uri: entry.fileUri } }
+    })
+    const items = lspPullDiagnosticsToItems(result)
+    // Why: entry may have closed while the request was in flight.
+    if (
+      items &&
+      !entry.model.isDisposed() &&
+      entriesByModelUri.get(entry.model.uri.toString()) === entry
+    ) {
+      monaco.editor.setModelMarkers(
+        entry.model,
+        LSP_MARKER_OWNER,
+        lspDiagnosticsToMonacoMarkers(items, monaco.MarkerSeverity)
+      )
+    }
+  } catch {
+    // A dead or slow server must never break editing; markers just go stale.
+  }
+}
+
+function sendChangeNow(entry: LspDocumentEntry): void {
+  if (entry.changeTimer !== null) {
+    clearTimeout(entry.changeTimer)
+    entry.changeTimer = null
+  }
+  if (entry.model.isDisposed()) {
+    return
+  }
+  const text = entry.model.getValue()
+  entry.lastSync = entry.lastSync
+    .then(() =>
+      window.api.lsp.changeDocument({ sessionId: entry.sessionId, fileUri: entry.fileUri, text })
+    )
+    .then(() => pullDiagnosticsNow(entry))
+    .catch(() => {})
+}
+
+export async function openLspDocumentForModel(params: {
+  model: editor.ITextModel
+  filePath: string
+  rootPath: string
+  worktreeId: string
+  languageId: string
+}): Promise<LspDocumentEntry | null> {
+  const { model, filePath, rootPath, worktreeId, languageId } = params
+  const modelUri = model.uri.toString()
+  const existing = entriesByModelUri.get(modelUri)
+  if (existing) {
+    existing.refCount++
+    return existing
+  }
+  setLspFileStatus(filePath, { state: 'starting', serverId: null })
+  const openedText = model.getValue()
+  let opened: {
+    sessionId: string | null
+    fileUri: string | null
+    serverId?: string | null
+    pullDiagnostics?: boolean
+  }
+  try {
+    opened = await window.api.lsp.openDocument({
+      filePath,
+      rootPath,
+      languageId,
+      text: openedText
+    })
+  } catch {
+    setLspFileStatus(filePath, null)
+    return null
+  }
+  if (!opened?.sessionId || !opened.fileUri) {
+    setLspFileStatus(filePath, null)
+    return null
+  }
+  // Why: an unmount+remount can race the async open; refcount the late entry too.
+  const raced = entriesByModelUri.get(modelUri)
+  if (raced) {
+    raced.refCount++
+    void window.api.lsp
+      .closeDocument({ sessionId: opened.sessionId, fileUri: opened.fileUri })
+      .catch(() => {})
+    return raced
+  }
+  const entry: LspDocumentEntry = {
+    sessionId: opened.sessionId,
+    fileUri: opened.fileUri,
+    filePath,
+    rootPath,
+    worktreeId,
+    serverId: opened.serverId ?? null,
+    pullDiagnostics: opened.pullDiagnostics === true,
+    model,
+    refCount: 1,
+    changeTimer: null,
+    lastSync: Promise.resolve(),
+    contentListener: model.onDidChangeContent(() => {
+      if (entry.changeTimer !== null) {
+        clearTimeout(entry.changeTimer)
+      }
+      entry.changeTimer = setTimeout(() => sendChangeNow(entry), CHANGE_DEBOUNCE_MS)
+    })
+  }
+  entriesByModelUri.set(modelUri, entry)
+  registerSessionDocumentEntry(entry)
+  setLspFileStatus(filePath, { state: 'running', serverId: entry.serverId })
+  // Why: keystrokes during the open round-trip predate the change listener;
+  // re-sync when the buffer moved so the server isn't pinned to stale text.
+  if (!model.isDisposed() && model.getValue() !== openedText) {
+    sendChangeNow(entry)
+  }
+  void pullDiagnosticsNow(entry)
+  return entry
+}
+
+export function flushPendingLspChange(entry: LspDocumentEntry): Promise<void> {
+  if (entry.changeTimer !== null) {
+    sendChangeNow(entry)
+  }
+  return entry.lastSync
+}
+
+export function getLspEntryForModelUri(modelUri: string): LspDocumentEntry | null {
+  return entriesByModelUri.get(modelUri) ?? null
+}
+
+export function getLspEntriesForSessionDocument(
+  sessionId: string,
+  fileUri: string
+): LspDocumentEntry[] {
+  return [...(entriesBySessionDocument.get(sessionDocumentKey(sessionId, fileUri)) ?? [])]
+}
+
+export function closeLspDocumentForModel(
+  modelUri: string,
+  clearMarkers: (model: editor.ITextModel) => void
+): void {
+  const entry = entriesByModelUri.get(modelUri)
+  if (!entry) {
+    return
+  }
+  entry.refCount--
+  if (entry.refCount > 0) {
+    return
+  }
+  entriesByModelUri.delete(modelUri)
+  unregisterSessionDocumentEntry(entry)
+  setLspFileStatus(entry.filePath, null)
+  entry.contentListener.dispose()
+  if (entry.changeTimer !== null) {
+    clearTimeout(entry.changeTimer)
+    entry.changeTimer = null
+  }
+  if (!entry.model.isDisposed()) {
+    clearMarkers(entry.model)
+  }
+  void window.api.lsp
+    .closeDocument({ sessionId: entry.sessionId, fileUri: entry.fileUri })
+    .catch(() => {})
+}

--- a/src/renderer/src/lib/monaco-lsp/monaco-lsp-providers.ts
+++ b/src/renderer/src/lib/monaco-lsp/monaco-lsp-providers.ts
@@ -1,0 +1,222 @@
+import type * as MonacoNamespace from 'monaco-editor'
+import type { IDisposable, IPosition, IRange, editor, languages } from 'monaco-editor'
+import { relativePathInsideRoot } from '../../../../shared/cross-platform-path'
+import { detectLanguage } from '@/lib/language-detect'
+import { useAppStore } from '@/store'
+import {
+  LSP_MARKER_OWNER,
+  fileUriToPath,
+  lspCompletionToMonaco,
+  lspDefinitionToLocations,
+  lspDiagnosticsToMonacoMarkers,
+  lspHoverToMonaco,
+  toLspPosition
+} from './lsp-monaco-conversion'
+import {
+  flushPendingLspChange,
+  getLspEntriesForSessionDocument,
+  getLspEntryForModelUri
+} from './monaco-lsp-documents'
+import type { LspDocumentEntry } from './monaco-lsp-documents'
+
+type MonacoApi = typeof MonacoNamespace
+
+let providerMonaco: MonacoApi | null = null
+let disposables: IDisposable[] = []
+let unsubscribeDiagnostics: (() => void) | null = null
+const registeredLanguages = new Set<string>()
+
+async function requestForModel(
+  model: editor.ITextModel,
+  position: IPosition,
+  method:
+    | 'textDocument/hover'
+    | 'textDocument/definition'
+    | 'textDocument/references'
+    | 'textDocument/completion',
+  extraParams?: Record<string, unknown>
+): Promise<{ entry: LspDocumentEntry; result: unknown } | null> {
+  const entry = getLspEntryForModelUri(model.uri.toString())
+  if (!entry) {
+    return null
+  }
+  try {
+    await flushPendingLspChange(entry)
+    const result = await window.api.lsp.request({
+      sessionId: entry.sessionId,
+      method,
+      params: {
+        textDocument: { uri: entry.fileUri },
+        position: toLspPosition(position),
+        ...extraParams
+      }
+    })
+    return { entry, result }
+  } catch {
+    // Why: a dead or slow server must never break plain editing; features
+    // simply don't answer.
+    return null
+  }
+}
+
+/** LSP locations → Monaco locations; same-file hits reuse the live model's
+ *  URI so navigation stays within the current surface. */
+function toMonacoLocations(
+  monaco: MonacoApi,
+  model: editor.ITextModel,
+  entry: LspDocumentEntry,
+  result: unknown
+): { uri: editor.ITextModel['uri']; range: IRange }[] {
+  // Why: compare path-of-URI to path-of-URI — entry.filePath is the raw
+  // renderer path, while server locations echo main's realpath'd fileUri
+  // (symlinked roots, Windows drive casing).
+  const entryPath = fileUriToPath(entry.fileUri)
+  return lspDefinitionToLocations(result).map((location) => ({
+    uri: fileUriToPath(location.uri) === entryPath ? model.uri : monaco.Uri.parse(location.uri),
+    range: location.range
+  }))
+}
+
+function openDefinitionTarget(
+  source: editor.ICodeEditor,
+  resource: { toString: () => string },
+  selectionOrPosition: IRange | IPosition
+): boolean {
+  const sourceModelUri = source.getModel()?.uri.toString()
+  const entry = sourceModelUri ? getLspEntryForModelUri(sourceModelUri) : null
+  const absolutePath = fileUriToPath(resource.toString())
+  if (!entry || !absolutePath) {
+    return false
+  }
+  const relativePath = relativePathInsideRoot(entry.rootPath, absolutePath)
+  if (relativePath === null || relativePath === '') {
+    return false
+  }
+  const line =
+    'startLineNumber' in selectionOrPosition
+      ? selectionOrPosition.startLineNumber
+      : selectionOrPosition.lineNumber
+  const column =
+    'startColumn' in selectionOrPosition
+      ? selectionOrPosition.startColumn
+      : selectionOrPosition.column
+  useAppStore.getState().openFile({
+    filePath: absolutePath,
+    relativePath,
+    worktreeId: entry.worktreeId,
+    language: detectLanguage(relativePath),
+    mode: 'edit'
+  })
+  // Why: match search/annotation navigation — the destination editor mounts
+  // asynchronously, so hand the reveal off after it owns layout.
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      useAppStore
+        .getState()
+        .setPendingEditorReveal({ filePath: absolutePath, line, column, matchLength: 0 })
+    })
+  })
+  return true
+}
+
+function ensureGlobalLspWiring(monaco: MonacoApi): void {
+  disposables.push(
+    monaco.editor.registerEditorOpener({
+      openCodeEditor: (source, resource, selectionOrPosition) =>
+        selectionOrPosition ? openDefinitionTarget(source, resource, selectionOrPosition) : false
+    })
+  )
+  try {
+    const unsubscribe = window.api.lsp.onDiagnostics((payload) => {
+      const entries = getLspEntriesForSessionDocument(payload.sessionId, payload.fileUri)
+      if (entries.length === 0) {
+        return
+      }
+      const markers = lspDiagnosticsToMonacoMarkers(payload.diagnostics, monaco.MarkerSeverity)
+      for (const entry of entries) {
+        if (!entry.model.isDisposed()) {
+          monaco.editor.setModelMarkers(entry.model, LSP_MARKER_OWNER, markers)
+        }
+      }
+    })
+    if (typeof unsubscribe === 'function') {
+      unsubscribeDiagnostics = unsubscribe
+    }
+  } catch {
+    // Why: surfaces without the lsp bridge (web fallback) just skip diagnostics.
+  }
+}
+
+/** Register LSP-backed language features once per language id. Called only
+ *  after a document successfully opened, so unsupported setups register nothing. */
+export function ensureLspSupportForLanguage(monaco: MonacoApi, languageId: string): void {
+  if (providerMonaco !== monaco) {
+    // Why: a re-created Monaco (window reload) makes old registrations stale.
+    for (const disposable of disposables) {
+      disposable.dispose()
+    }
+    disposables = []
+    registeredLanguages.clear()
+    unsubscribeDiagnostics?.()
+    unsubscribeDiagnostics = null
+    providerMonaco = monaco
+    ensureGlobalLspWiring(monaco)
+  }
+  if (registeredLanguages.has(languageId)) {
+    return
+  }
+  registeredLanguages.add(languageId)
+
+  disposables.push(
+    monaco.languages.registerHoverProvider(languageId, {
+      provideHover: async (model, position) => {
+        const response = await requestForModel(model, position, 'textDocument/hover')
+        return response ? lspHoverToMonaco(response.result) : null
+      }
+    }),
+    monaco.languages.registerDefinitionProvider(languageId, {
+      provideDefinition: async (model, position) => {
+        const response = await requestForModel(model, position, 'textDocument/definition')
+        return response ? toMonacoLocations(monaco, model, response.entry, response.result) : null
+      }
+    }),
+    monaco.languages.registerReferenceProvider(languageId, {
+      provideReferences: async (model, position) => {
+        const response = await requestForModel(model, position, 'textDocument/references', {
+          context: { includeDeclaration: true }
+        })
+        return response ? toMonacoLocations(monaco, model, response.entry, response.result) : null
+      }
+    }),
+    monaco.languages.registerCompletionItemProvider(languageId, {
+      triggerCharacters: ['.', '"', "'", '/', '@', ':'],
+      provideCompletionItems: async (model, position) => {
+        const response = await requestForModel(model, position, 'textDocument/completion')
+        if (!response) {
+          return { suggestions: [] }
+        }
+        const word = model.getWordUntilPosition(position)
+        const defaultRange: IRange = {
+          startLineNumber: position.lineNumber,
+          startColumn: word.startColumn,
+          endLineNumber: position.lineNumber,
+          endColumn: position.column
+        }
+        const converted = lspCompletionToMonaco(response.result, defaultRange, {
+          kinds: monaco.languages.CompletionItemKind as unknown as Record<string, number>,
+          snippetRule: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet
+        })
+        return {
+          // Why: the converter emits numeric enum values so it stays node-testable;
+          // the shapes are structurally identical to Monaco's CompletionItem.
+          suggestions: converted.suggestions as unknown as languages.CompletionItem[],
+          incomplete: converted.incomplete
+        }
+      }
+    })
+  )
+}
+
+export function clearLspMarkers(monaco: MonacoApi, model: editor.ITextModel): void {
+  monaco.editor.setModelMarkers(model, LSP_MARKER_OWNER, [])
+}

--- a/src/renderer/src/lib/monaco-lsp/monaco-lsp-status.ts
+++ b/src/renderer/src/lib/monaco-lsp/monaco-lsp-status.ts
@@ -1,0 +1,40 @@
+import { useSyncExternalStore } from 'react'
+
+/** Per-file LSP attachment state, keyed by absolute file path. Drives the
+ *  editor header badge; 'starting' covers spawn + initialize round-trip. */
+export type LspFileStatus = { state: 'starting' | 'running'; serverId: string | null }
+
+const statusByFilePath = new Map<string, LspFileStatus>()
+const listeners = new Set<() => void>()
+
+function emit(): void {
+  for (const listener of listeners) {
+    listener()
+  }
+}
+
+export function setLspFileStatus(filePath: string, status: LspFileStatus | null): void {
+  if (status === null) {
+    if (statusByFilePath.delete(filePath)) {
+      emit()
+    }
+    return
+  }
+  const previous = statusByFilePath.get(filePath)
+  if (previous?.state === status.state && previous.serverId === status.serverId) {
+    return
+  }
+  statusByFilePath.set(filePath, status)
+  emit()
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+export function useLspStatusForFile(filePath: string | null): LspFileStatus | null {
+  return useSyncExternalStore(subscribe, () =>
+    filePath ? (statusByFilePath.get(filePath) ?? null) : null
+  )
+}

--- a/src/renderer/src/lib/monaco-setup.ts
+++ b/src/renderer/src/lib/monaco-setup.ts
@@ -59,6 +59,28 @@ const diagnosticsOptions = {
 monacoTS.typescriptDefaults.setDiagnosticsOptions(diagnosticsOptions)
 monacoTS.javascriptDefaults.setDiagnosticsOptions(diagnosticsOptions)
 
+// Why: the same sandboxed worker also answers hover/completion/definition with
+// import types collapsed to `any` — misleading for the same reason as the
+// diagnostics above. Disable exactly the features the local LSP bridge
+// (lib/monaco-lsp) replaces when a language server is installed; without one,
+// plain text beats confidently wrong types. Everything the bridge does NOT
+// provide (signature help, rename, code actions, inlay hints, outline,
+// formatting) stays on the worker so no surface loses it outright.
+const tsWorkerModeConfiguration = {
+  completionItems: false,
+  hovers: false,
+  definitions: false,
+  references: false
+}
+monacoTS.typescriptDefaults.setModeConfiguration({
+  ...monacoTS.typescriptDefaults.modeConfiguration,
+  ...tsWorkerModeConfiguration
+})
+monacoTS.javascriptDefaults.setModeConfiguration({
+  ...monacoTS.javascriptDefaults.modeConfiguration,
+  ...tsWorkerModeConfiguration
+})
+
 // Why: .tsx/.jsx files share the base 'typescript'/'javascript' language ids
 // in Monaco's registry (there is no separate 'typescriptreact' id), so the
 // compiler options on those defaults apply to both. Without jsx enabled, the

--- a/src/shared/lsp-types.ts
+++ b/src/shared/lsp-types.ts
@@ -1,0 +1,57 @@
+/** Wire contract for the local LSP bridge (renderer ↔ main). Local workspaces
+ *  only — remote/SSH/web surfaces have no `lsp` API and degrade to no LSP. */
+
+export const LSP_REQUEST_METHODS = [
+  'textDocument/hover',
+  'textDocument/definition',
+  'textDocument/references',
+  'textDocument/completion',
+  'textDocument/diagnostic'
+] as const
+
+export type LspRequestMethod = (typeof LSP_REQUEST_METHODS)[number]
+
+export type LspOpenDocumentArgs = {
+  /** Absolute local path of the file being edited. */
+  filePath: string
+  /** Absolute local path of the workspace root the server is scoped to. */
+  rootPath: string
+  /** Monaco language id (e.g. 'typescript', 'python'). */
+  languageId: string
+  /** Full document text at open time. */
+  text: string
+}
+
+export type LspOpenDocumentResult = {
+  sessionId: string | null
+  /** Canonical file:// URI for filePath, computed by main so both sides agree. */
+  fileUri: string | null
+  /** Which catalog server answered (e.g. 'tsgo'), for the editor status badge. */
+  serverId: string | null
+  /** True when the server wants pull diagnostics (textDocument/diagnostic)
+   *  instead of pushing publishDiagnostics. */
+  pullDiagnostics: boolean
+}
+
+export type LspChangeDocumentArgs = {
+  sessionId: string
+  fileUri: string
+  text: string
+}
+
+export type LspCloseDocumentArgs = {
+  sessionId: string
+  fileUri: string
+}
+
+export type LspRequestArgs = {
+  sessionId: string
+  method: LspRequestMethod
+  params: unknown
+}
+
+export type LspDiagnosticsPayload = {
+  sessionId: string
+  fileUri: string
+  diagnostics: unknown[]
+}


### PR DESCRIPTION
## ELI5

Orca's editor now understands your code the way VS Code does. When you have a language server installed (tsgo, pyright, gopls, rust-analyzer…), hovering a symbol shows its real type, cmd+click jumps to its definition in any file, Find All References works across the project, completions know your project, and real errors get red squiggles — in both the regular editor and the diff views where agent work gets reviewed. A small status-bar dot shows which server is attached. If you have no server installed, nothing changes.

## What Changed

- **Main process** (`src/main/lsp/`): spawns user-installed language servers per local workspace root over stdio (hand-rolled LSP framing, zero new dependencies), with an ordered catalog per language — `tsgo --lsp` first for TS/JS (the only server that works in tsserver-less `typescript@7` repos), falling back to `typescript-language-server`, plus pyright/gopls/rust-analyzer. Sessions are refcounted per document, idle-shutdown after 3 min, killed on quit, capped at 6.
- **IPC/preload**: one `lsp` namespace (open/change/close document, allowlisted requests, diagnostics push). Paths validated with the existing `resolveAuthorizedPath` plus a containment check that the file lives inside its workspace root.
- **Renderer** (`src/renderer/src/lib/monaco-lsp/`): Monaco providers for hover, definition, references, completion; **push and pull diagnostics** (tsgo/TS7 use the pull model — `textDocument/diagnostic` after open and after each debounced edit); cross-file navigation reuses the existing `openFile` + pending-reveal flow. Providers register lazily per language only after a document successfully attaches.
- **Diff views**: the modified pane of both `DiffViewer` and `DiffSectionItem` attaches too (diff content is full file text, so positions align). The original pane stays plain.
- **Status bar**: new `LspStatusSegment` — hidden when nothing is attached, amber while starting, green dot + server name when running.
- **`monaco-setup.ts`**: the sandboxed TS worker's hover/completion/definition/references are disabled — exactly the features the bridge replaces, and the same reasoning as the worker's already-disabled diagnostics (imports collapse to `any`, confidently wrong). Signature help, rename, code actions, outline, and formatting stay on the worker.
- Extracted `submitDiffViewerComment` (mirroring the existing `submitDiffSectionComment`) to keep `DiffViewer.tsx` under the max-lines budget; behavior-preserving.

## Why

Orca's core loop is reviewing agent-written code, but the editor only had the sandboxed single-file TS worker: hover types collapse to `any`, navigation cannot leave the file, and semantic diagnostics are disabled because they were all false positives. `monaco-codebase-search.ts` explicitly notes text search stands in "until Orca has semantic LSP references". Driving real, user-installed language servers fixes all of that with zero bundled binaries and zero behavior change for users who don't have one — and going tsgo-first keeps TS support working as the ecosystem moves to TypeScript 7, which no longer ships `tsserver.js` at all.

## Linked Issue

Fixes #14872

## Visual Proof

**Before**: none of these affordances exist — hovering an imported symbol shows `any` (or nothing), cmd+click and references cannot leave the file, no diagnostics, no status-bar indicator.

**After** — real hover types in the editor, tsgo dot in the status bar (bottom right):

![Hover in editor with tsgo status segment](https://raw.githubusercontent.com/moishinetzer/orca/assets/editor-lsp-pr/lsp-hover-editor.png)

**After** — full interface hover with docs inside a branch **diff view**:

![Hover in diff view](https://raw.githubusercontent.com/moishinetzer/orca/assets/editor-lsp-pr/lsp-hover-diff.png)

## Testing

- `pnpm lint`, `pnpm typecheck` (all three tsconfig projects), and `pnpm run build:electron-vite` pass locally; `pnpm test` for the new suites: 41 tests across framing, URI canonicalization, server catalog, session manager (fake-server lifecycle: initialize handshake, didOpen/didChange versioning across two surfaces, pull-capability detection, `workspace/configuration` replies, diagnostics URI-form matching, crash recovery), LSP↔Monaco conversions, and the renderer document registry (multi-surface fan-out, mid-open keystroke resync).
- Live-verified on **macOS** in the dev app against real servers: tsgo hover/definition/completion + pull diagnostics (planted TS2322 came back at the right range), typescript-language-server hover on a TS5 repo, cross-file references (18 hits across 3 files), diff-view attach, and the status segment (see screenshots).
- **Windows/Linux not tested on real machines.** The Windows spawn path uses the repo's own `resolveWindowsCommand` + `getSpawnArgsForWindows` helpers (npm servers are `.cmd` shims; plain spawn would ENOENT/EINVAL), and document matching canonicalizes URI forms (vscode-uri `c%3A` vs Node `C:`) — both covered by unit tests, but a real-Windows smoke test by a maintainer would be valuable.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Built with Claude Code (model: Claude Fable 5), driven and reviewed by me. Three adversarial AI review passes (main-process/IPC security, renderer lifecycle, LSP protocol conformance & cross-platform) were run against the change; their blockers were fixed before opening this PR and the residual limitations are listed below.

## Review

Summary of the AI review across the requested axes:

- **Security**: IPC surface validates both paths via `resolveAuthorizedPath` and enforces file⊂root containment so a renderer cannot scope a code-executing server (gopls/rust-analyzer run build scripts) to an unrelated allowed root. Request methods are allowlisted; spawn commands come from a fixed catalog, never from renderer input.
- **Cross-platform**: Windows `.cmd` shim spawning via existing repo helpers; URI canonicalization for drive-letter/percent-encoding differences; `.tsx`/`.jsx` announced as `typescriptreact`/`javascriptreact` per LSP convention; paths handled with Node utilities.
- **SSH/remote/local**: local worktrees only by design — remote/SSH/web surfaces skip attachment (connection-id gate; web preload falls back safely). No wire-protocol changes, so mixed client/host versions are unaffected.
- **Agents/integrations**: no interaction with agent lanes, terminals, or git providers; the editor/diff surfaces gain providers only.
- **Performance**: full-text sync debounced at 250 ms; per-language provider registration only after a successful attach; servers idle-shutdown after 3 min; session cap; stderr drained to prevent pipe-fill stalls.
- **UI**: status segment follows the existing segment pattern and STYLEGUIDE tokens; strings localized via the `auto.` catalog.

Known limitations (deliberate, to keep this PR reviewable — happy to file follow-ups): no auto-import `additionalTextEdits`/`completionItem/resolve`; go-to-definition outside the workspace root (Go stdlib, site-packages) is a silent no-op; no `workspace/didChangeWatchedFiles` (gopls relies on client watching; tsserver/pyright/rust-analyzer self-watch); pull-model diagnostics refresh on the file's own edits, not cross-file; no `$/cancelRequest`; UNC/`\\wsl$` paths not yet mapped; a window reload orphans that window's open documents until idle shutdown.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: (available on request)

🤖 Generated with [Claude Code](https://claude.com/claude-code)