### PR TITLE
feat(right-sidebar): agent context panel — instruction files, skills, MCP, hooks and plugins per workspace

### DIFF
--- a/src/main/agent-context/agent-config-file-sources.ts
+++ b/src/main/agent-context/agent-config-file-sources.ts
@@ -1,0 +1,188 @@
+import type { AgentType } from '../../shared/agent-status-types'
+import type { AgentContextScope } from '../../shared/agent-context'
+import type { McpConfigCandidate } from '../../shared/mcp-config'
+import { MCP_CONFIG_CANDIDATES } from '../../shared/mcp-config'
+import { defaultAgentContextPathApi, type AgentContextPathApi } from './agent-context-sources'
+
+export type McpFileSource = {
+  id: string
+  path: string
+  scope: AgentContextScope
+  agents: AgentType[]
+  candidate: McpConfigCandidate
+  /** JSON files: additional object paths holding servers for this workspace
+   *  (Claude keeps `claude mcp add` local-scope servers under `projects.<cwd>.mcpServers`). */
+  extraServersPaths?: string[][]
+  /** Codex `config.toml` declares servers as `[mcp_servers.<name>]` tables. */
+  format?: 'json' | 'codex-toml'
+}
+
+export type SettingsFileSource = {
+  id: string
+  path: string
+  scope: AgentContextScope
+  agents: AgentType[]
+}
+
+const HOME_MCP_CANDIDATES: {
+  candidate: McpConfigCandidate
+  segments: string[]
+  agents: AgentType[]
+}[] = [
+  {
+    candidate: {
+      format: 'claude',
+      label: 'Claude user',
+      relativePath: '.claude.json',
+      serversPath: ['mcpServers']
+    },
+    segments: ['.claude.json'],
+    agents: ['claude']
+  },
+  {
+    candidate: {
+      format: 'cursor',
+      label: 'Cursor user',
+      relativePath: '.cursor/mcp.json',
+      serversPath: ['mcpServers']
+    },
+    segments: ['.cursor', 'mcp.json'],
+    agents: ['cursor']
+  },
+  {
+    candidate: {
+      format: 'workspace',
+      label: 'Gemini user',
+      relativePath: '.gemini/settings.json',
+      serversPath: ['mcpServers']
+    },
+    segments: ['.gemini', 'settings.json'],
+    agents: ['gemini']
+  }
+]
+
+const OPENCODE_MCP_CANDIDATE: McpConfigCandidate = {
+  format: 'workspace',
+  label: 'OpenCode',
+  relativePath: 'opencode.json',
+  serversPath: ['mcp']
+}
+
+const CODEX_MCP_CANDIDATE: McpConfigCandidate = {
+  format: 'workspace',
+  label: 'Codex',
+  relativePath: '.codex/config.toml',
+  serversPath: ['mcp_servers']
+}
+
+function agentsForMcpCandidate(candidate: McpConfigCandidate): AgentType[] {
+  switch (candidate.format) {
+    case 'cursor':
+      return ['cursor']
+    case 'claude':
+      return ['claude']
+    default:
+      // `.mcp.json` is Claude's project-scope file; other agents read it via plugins only.
+      return ['claude']
+  }
+}
+
+export function buildMcpFileSources(args: {
+  homeDir: string
+  cwd: string | null
+  pathApi?: AgentContextPathApi
+}): McpFileSource[] {
+  const pathApi = args.pathApi ?? defaultAgentContextPathApi
+  const sources: McpFileSource[] = HOME_MCP_CANDIDATES.map((entry) => ({
+    id: `home-mcp:${entry.candidate.relativePath}`,
+    path: pathApi.join(args.homeDir, ...entry.segments),
+    scope: 'home',
+    agents: [...entry.agents],
+    candidate: entry.candidate,
+    extraServersPaths:
+      entry.candidate.relativePath === '.claude.json' && args.cwd
+        ? [['projects', args.cwd, 'mcpServers']]
+        : undefined
+  }))
+  sources.push(
+    {
+      id: 'home-mcp:.codex/config.toml',
+      path: pathApi.join(args.homeDir, '.codex', 'config.toml'),
+      scope: 'home',
+      agents: ['codex'],
+      candidate: CODEX_MCP_CANDIDATE,
+      format: 'codex-toml'
+    },
+    {
+      id: 'home-mcp:opencode.json',
+      path: pathApi.join(args.homeDir, '.config', 'opencode', 'opencode.json'),
+      scope: 'home',
+      agents: ['opencode'],
+      candidate: OPENCODE_MCP_CANDIDATE
+    }
+  )
+  if (!args.cwd) {
+    return sources
+  }
+  for (const candidate of MCP_CONFIG_CANDIDATES) {
+    sources.push({
+      id: `project-mcp:${candidate.relativePath}`,
+      path: pathApi.join(args.cwd, ...candidate.relativePath.split('/')),
+      scope: 'project',
+      agents: agentsForMcpCandidate(candidate),
+      candidate
+    })
+  }
+  sources.push(
+    {
+      id: 'project-mcp:.codex/config.toml',
+      path: pathApi.join(args.cwd, '.codex', 'config.toml'),
+      scope: 'project',
+      agents: ['codex'],
+      candidate: CODEX_MCP_CANDIDATE,
+      format: 'codex-toml'
+    },
+    {
+      id: 'project-mcp:opencode.json',
+      path: pathApi.join(args.cwd, 'opencode.json'),
+      scope: 'project',
+      agents: ['opencode'],
+      candidate: OPENCODE_MCP_CANDIDATE
+    }
+  )
+  return sources
+}
+
+/** Claude merges user, project, then project-local settings — hooks and enabledPlugins live here. */
+export function buildClaudeSettingsSources(args: {
+  homeDir: string
+  cwd: string | null
+  pathApi?: AgentContextPathApi
+}): SettingsFileSource[] {
+  const pathApi = args.pathApi ?? defaultAgentContextPathApi
+  const sources: SettingsFileSource[] = [
+    {
+      id: 'home-claude-settings',
+      path: pathApi.join(args.homeDir, '.claude', 'settings.json'),
+      scope: 'home',
+      agents: ['claude']
+    }
+  ]
+  if (args.cwd) {
+    sources.push(
+      {
+        id: 'project-claude-settings',
+        path: pathApi.join(args.cwd, '.claude', 'settings.json'),
+        scope: 'project',
+        agents: ['claude']
+      },
+      {
+        id: 'project-claude-settings-local',
+        path: pathApi.join(args.cwd, '.claude', 'settings.local.json'),
+        scope: 'project',
+        agents: ['claude']
+      }
+    )
+  }
+  return sources
+}

--- a/src/main/agent-context/agent-config-file-sources.ts
+++ b/src/main/agent-context/agent-config-file-sources.ts
@@ -68,6 +68,21 @@ const OPENCODE_MCP_CANDIDATE: McpConfigCandidate = {
   serversPath: ['mcp']
 }
 
+const GEMINI_PROJECT_MCP_CANDIDATE: McpConfigCandidate = {
+  format: 'workspace',
+  label: 'Gemini workspace',
+  relativePath: '.gemini/settings.json',
+  serversPath: ['mcpServers']
+}
+
+/** VS Code / Copilot keep workspace MCP servers under `servers`, not `mcpServers`. */
+const COPILOT_MCP_CANDIDATE: McpConfigCandidate = {
+  format: 'workspace',
+  label: 'Copilot workspace',
+  relativePath: '.vscode/mcp.json',
+  serversPath: ['servers']
+}
+
 const CODEX_MCP_CANDIDATE: McpConfigCandidate = {
   format: 'workspace',
   label: 'Codex',
@@ -148,6 +163,20 @@ export function buildMcpFileSources(args: {
       scope: 'project',
       agents: ['opencode'],
       candidate: OPENCODE_MCP_CANDIDATE
+    },
+    {
+      id: 'project-mcp:.gemini/settings.json',
+      path: pathApi.join(args.cwd, '.gemini', 'settings.json'),
+      scope: 'project',
+      agents: ['gemini'],
+      candidate: GEMINI_PROJECT_MCP_CANDIDATE
+    },
+    {
+      id: 'project-mcp:.vscode/mcp.json',
+      path: pathApi.join(args.cwd, '.vscode', 'mcp.json'),
+      scope: 'project',
+      agents: ['copilot'],
+      candidate: COPILOT_MCP_CANDIDATE
     }
   )
   return sources

--- a/src/main/agent-context/agent-context-inspection.test.ts
+++ b/src/main/agent-context/agent-context-inspection.test.ts
@@ -1,9 +1,10 @@
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { dirname, join, posix, win32 } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { inspectAgentContext } from './agent-context-inspection'
 import { buildInstructionFileSources, MAX_ANCESTOR_LEVELS } from './agent-context-sources'
+import { buildMcpFileSources } from './agent-config-file-sources'
 
 let root: string
 let homeDir: string
@@ -25,7 +26,9 @@ describe('inspectAgentContext', () => {
   it('reports instruction files per agent, including ancestors, with existence', async () => {
     await writeFile(join(homeDir, '.claude', 'CLAUDE.md'), '# global')
     await writeFile(join(cwd, 'CLAUDE.md'), '# app')
+    await mkdir(join(root, 'repo', '.git'), { recursive: true })
     await writeFile(join(root, 'repo', 'AGENTS.md'), '# repo agents')
+    await writeFile(join(root, 'AGENTS.md'), '# outside the repo')
     await writeFile(join(cwd, '.cursor', 'rules', 'style.mdc'), 'rule')
     await writeFile(join(cwd, '.cursor', 'rules', 'notes.txt'), 'ignored')
 
@@ -48,6 +51,19 @@ describe('inspectAgentContext', () => {
     )
     expect(repoAgents?.exists).toBe(true)
     expect(repoAgents?.agents).toContain('codex')
+    expect(repoAgents?.agents).not.toContain('cursor')
+    // Why: the Codex-family walk ends at the git root; Claude's carries on.
+    const outsidePaths = report.instructionFiles
+      .filter((file) => file.scope === 'ancestor' && dirname(file.path) === root)
+      .map((file) => file.label)
+    expect(outsidePaths).toEqual(['CLAUDE.md', 'CLAUDE.local.md'])
+  })
+
+  it('treats a rules folder without rule files as checked but empty', async () => {
+    const report = await inspectAgentContext({ target: { kind: 'native-host', homeDir, cwd } })
+    expect(
+      report.instructionFiles.find((file) => file.id === 'project-cursor-rules-dir')
+    ).toMatchObject({ exists: false, entryCount: 0 })
   })
 
   it('summarises Claude hooks and plugin decisions with the deciding settings file winning', async () => {
@@ -109,6 +125,26 @@ describe('inspectAgentContext', () => {
     ).toBe(false)
   })
 
+  it('reads MCP servers out of an oversized ~/.claude.json instead of calling it invalid', async () => {
+    await writeFile(
+      join(homeDir, '.claude.json'),
+      JSON.stringify({
+        mcpServers: { global: { command: 'g' } },
+        projects: {
+          [cwd]: {
+            mcpServers: { local: { url: 'http://localhost:1' } },
+            history: 'x'.repeat(300 * 1024)
+          }
+        },
+        cachedChangelog: 'y'.repeat(200 * 1024)
+      })
+    )
+    const report = await inspectAgentContext({ target: { kind: 'native-host', homeDir, cwd } })
+    const claude = report.mcpFiles.find((file) => file.id === 'home-mcp:.claude.json')
+    expect(claude?.inspection.status).toBe('valid')
+    expect(claude?.inspection.servers.map((server) => server.name)).toEqual(['global', 'local'])
+  })
+
   it('merges Claude project-scoped servers from ~/.claude.json and reads Codex and OpenCode files', async () => {
     await writeFile(
       join(homeDir, '.claude.json'),
@@ -149,6 +185,10 @@ describe('inspectAgentContext', () => {
     const report = await inspectAgentContext({ target: { kind: 'native-host', homeDir, cwd } })
     const claude = report.mcpFiles.find((file) => file.id === 'home-mcp:.claude.json')
     expect(claude?.inspection.servers.map((server) => server.name)).toEqual(['global', 'local'])
+    // Why: the project-local scope shadows the user scope for the same name.
+    expect(claude?.inspection.servers.find((server) => server.name === 'global')?.command).toBe(
+      'dup'
+    )
     const codex = report.mcpFiles.find((file) => file.id === 'home-mcp:.codex/config.toml')
     expect(codex?.inspection.status).toBe('valid')
     expect(codex?.inspection.servers).toEqual([
@@ -184,6 +224,79 @@ describe('inspectAgentContext', () => {
   })
 })
 
+describe('inspectAgentContext access-path routing', () => {
+  it('opens every row through toAccessPath while reporting the display path', async () => {
+    const displayHome = '/wsl/home/u'
+    const displayCwd = '/wsl/home/u/repo'
+    const toAccessPath = (displayPath: string): string =>
+      join(root, 'mount', ...displayPath.split('/').filter(Boolean))
+    await mkdir(toAccessPath(`${displayCwd}/.claude`), { recursive: true })
+    await mkdir(toAccessPath(`${displayHome}/.claude`), { recursive: true })
+    await writeFile(toAccessPath(`${displayCwd}/CLAUDE.md`), '# app')
+    await writeFile(
+      toAccessPath(`${displayCwd}/.mcp.json`),
+      JSON.stringify({ mcpServers: { linear: { command: 'npx' } } })
+    )
+    await writeFile(
+      toAccessPath(`${displayHome}/.claude/settings.json`),
+      JSON.stringify({ hooks: { Stop: [{ hooks: [{ type: 'command', command: 'say' }] }] } })
+    )
+
+    const report = await inspectAgentContext({
+      target: { kind: 'wsl', distro: 'Ubuntu', homeDir: displayHome, cwd: displayCwd },
+      toAccessPath,
+      pathApi: posix
+    })
+    expect(report.instructionFiles.find((file) => file.id === 'project-claude-md')).toMatchObject({
+      path: `${displayCwd}/CLAUDE.md`,
+      exists: true
+    })
+    expect(report.mcpFiles.find((file) => file.id === 'project-mcp:.mcp.json')).toMatchObject({
+      path: `${displayCwd}/.mcp.json`,
+      inspection: { exists: true, servers: [expect.objectContaining({ name: 'linear' })] }
+    })
+    expect(report.hookFiles.find((file) => file.id === 'home-claude-settings')).toMatchObject({
+      path: `${displayHome}/.claude/settings.json`,
+      hookCount: 1
+    })
+  })
+})
+
+describe('buildMcpFileSources', () => {
+  it('names the agent that reads each MCP file and where its servers live', () => {
+    const sources = buildMcpFileSources({ homeDir: '/h', cwd: '/h/repo', pathApi: posix })
+    const byId = new Map(sources.map((source) => [source.id, source]))
+    expect(byId.get('home-mcp:.claude.json')).toMatchObject({
+      path: '/h/.claude.json',
+      agents: ['claude'],
+      extraServersPaths: [['projects', '/h/repo', 'mcpServers']]
+    })
+    expect(byId.get('home-mcp:.codex/config.toml')).toMatchObject({
+      agents: ['codex'],
+      format: 'codex-toml'
+    })
+    expect(byId.get('project-mcp:.vscode/mcp.json')).toMatchObject({
+      path: '/h/repo/.vscode/mcp.json',
+      agents: ['copilot'],
+      candidate: expect.objectContaining({ serversPath: ['servers'] })
+    })
+    expect(byId.get('project-mcp:.gemini/settings.json')).toMatchObject({
+      agents: ['gemini'],
+      scope: 'project'
+    })
+    expect(byId.get('project-mcp:.cursor/mcp.json')).toMatchObject({ agents: ['cursor'] })
+    expect(byId.get('project-mcp:opencode.json')).toMatchObject({
+      agents: ['opencode'],
+      candidate: expect.objectContaining({ serversPath: ['mcp'] })
+    })
+    expect(
+      buildMcpFileSources({ homeDir: '/h', cwd: null, pathApi: posix }).every(
+        (source) => source.scope === 'home'
+      )
+    ).toBe(true)
+  })
+})
+
 describe('buildInstructionFileSources', () => {
   it('walks exactly MAX_ANCESTOR_LEVELS parents when the home directory is not reached', () => {
     const outside = join(root, 'elsewhere')
@@ -194,20 +307,47 @@ describe('buildInstructionFileSources', () => {
     const ancestors = buildInstructionFileSources({ homeDir, cwd: nested }).filter(
       (source) => source.scope === 'ancestor'
     )
-    // Two rows (CLAUDE.md + AGENTS.md) per ancestor level.
+    // Two Claude rows (CLAUDE.md + CLAUDE.local.md) per ancestor level; no git root, so no AGENTS.md.
     expect(ancestors).toHaveLength(MAX_ANCESTOR_LEVELS * 2)
     expect(ancestors[0]?.path).toBe(join(dirname(nested), 'CLAUDE.md'))
+    expect(ancestors.every((source) => source.label !== 'AGENTS.md')).toBe(true)
   })
 
-  it('stops the ancestor walk at the home directory', () => {
+  it('stops the ancestor walk at the home directory, comparing paths as the host does', () => {
     const nested = join(homeDir, 'a', 'b')
     const ancestors = buildInstructionFileSources({ homeDir, cwd: nested }).filter(
       (source) => source.scope === 'ancestor'
     )
     expect(ancestors.map((source) => source.path)).toEqual([
       join(homeDir, 'a', 'CLAUDE.md'),
-      join(homeDir, 'a', 'AGENTS.md')
+      join(homeDir, 'a', 'CLAUDE.local.md')
     ])
+    const windows = buildInstructionFileSources({
+      homeDir: 'C:\\Users\\Shane',
+      cwd: 'c:\\users\\shane\\src\\app',
+      pathApi: win32
+    }).filter((source) => source.scope === 'ancestor')
+    expect(windows.map((source) => source.path)).toEqual([
+      'c:\\users\\shane\\src\\CLAUDE.md',
+      'c:\\users\\shane\\src\\CLAUDE.local.md'
+    ])
+  })
+
+  it('offers AGENTS.md to Codex-family agents from parents up to the git root only', () => {
+    const gitRootDir = join(root, 'repo')
+    const agentsRows = buildInstructionFileSources({ homeDir, cwd, gitRootDir }).filter(
+      (source) => source.scope === 'ancestor' && source.label === 'AGENTS.md'
+    )
+    expect(agentsRows.map((source) => source.path)).toEqual([
+      join(root, 'repo', 'packages', 'AGENTS.md'),
+      join(root, 'repo', 'AGENTS.md')
+    ])
+    expect(agentsRows[0]?.agents).toEqual(['codex', 'opencode', 'amp', 'pi'])
+    expect(
+      buildInstructionFileSources({ homeDir, cwd, gitRootDir: cwd }).some(
+        (source) => source.scope === 'ancestor' && source.label === 'AGENTS.md'
+      )
+    ).toBe(false)
   })
 
   it('omits project and ancestor rows without a workspace', () => {

--- a/src/main/agent-context/agent-context-inspection.test.ts
+++ b/src/main/agent-context/agent-context-inspection.test.ts
@@ -1,0 +1,137 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { inspectAgentContext } from './agent-context-inspection'
+import { buildInstructionFileSources, MAX_ANCESTOR_LEVELS } from './agent-context-sources'
+
+let root: string
+let homeDir: string
+let cwd: string
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'orca-agent-context-'))
+  homeDir = join(root, 'home')
+  cwd = join(root, 'repo', 'packages', 'app')
+  await mkdir(join(homeDir, '.claude'), { recursive: true })
+  await mkdir(join(cwd, '.cursor', 'rules'), { recursive: true })
+})
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+describe('inspectAgentContext', () => {
+  it('reports instruction files per agent, including ancestors, with existence', async () => {
+    await writeFile(join(homeDir, '.claude', 'CLAUDE.md'), '# global')
+    await writeFile(join(cwd, 'CLAUDE.md'), '# app')
+    await writeFile(join(root, 'repo', 'AGENTS.md'), '# repo agents')
+    await writeFile(join(cwd, '.cursor', 'rules', 'style.mdc'), 'rule')
+    await writeFile(join(cwd, '.cursor', 'rules', 'notes.txt'), 'ignored')
+
+    const report = await inspectAgentContext({
+      target: { kind: 'native-host', homeDir, cwd }
+    })
+    const byId = new Map(report.instructionFiles.map((file) => [file.id, file]))
+
+    expect(byId.get('home-claude-md')).toMatchObject({
+      exists: true,
+      scope: 'home',
+      agents: ['claude']
+    })
+    expect(byId.get('project-claude-md')?.exists).toBe(true)
+    expect(byId.get('project-claude-md')?.sizeBytes).toBe(5)
+    expect(byId.get('project-gemini-md')?.exists).toBe(false)
+    expect(byId.get('project-cursor-rules-dir')).toMatchObject({ exists: true, entryCount: 1 })
+    const repoAgents = report.instructionFiles.find(
+      (file) => file.scope === 'ancestor' && file.path === join(root, 'repo', 'AGENTS.md')
+    )
+    expect(repoAgents?.exists).toBe(true)
+    expect(repoAgents?.agents).toContain('codex')
+  })
+
+  it('summarises Claude hooks and plugin decisions with the deciding settings file winning', async () => {
+    await writeFile(
+      join(homeDir, '.claude', 'settings.json'),
+      JSON.stringify({
+        enabledPlugins: { 'adhd@local': true, 'other@market': true },
+        hooks: {
+          PreToolUse: [{ matcher: 'Bash', hooks: [{ type: 'command', command: 'echo' }] }],
+          Stop: [
+            {
+              hooks: [
+                { type: 'command', command: 'a' },
+                { type: 'command', command: 'b' }
+              ]
+            }
+          ]
+        }
+      })
+    )
+    await mkdir(join(cwd, '.claude'), { recursive: true })
+    await writeFile(
+      join(cwd, '.claude', 'settings.local.json'),
+      JSON.stringify({ enabledPlugins: { 'other@market': false } })
+    )
+
+    const report = await inspectAgentContext({
+      target: { kind: 'native-host', homeDir, cwd }
+    })
+
+    const homeHooks = report.hookFiles.find((file) => file.id === 'home-claude-settings')
+    expect(homeHooks).toMatchObject({ exists: true, events: ['PreToolUse', 'Stop'], hookCount: 3 })
+    expect(report.hookFiles.find((file) => file.id === 'project-claude-settings')?.exists).toBe(
+      false
+    )
+    expect(report.plugins).toEqual([
+      expect.objectContaining({ name: 'adhd@local', enabled: true, scope: 'home' }),
+      expect.objectContaining({ name: 'other@market', enabled: false, scope: 'project' })
+    ])
+  })
+
+  it('inspects MCP files at home and project scope through the shared inspector', async () => {
+    await writeFile(
+      join(homeDir, '.claude.json'),
+      JSON.stringify({ mcpServers: { linear: { command: 'npx', args: ['linear-mcp'] } } })
+    )
+    await writeFile(join(cwd, '.mcp.json'), '{ not json')
+
+    const report = await inspectAgentContext({
+      target: { kind: 'native-host', homeDir, cwd }
+    })
+    const home = report.mcpFiles.find((file) => file.id === 'home-mcp:.claude.json')
+    expect(home?.inspection.status).toBe('valid')
+    expect(home?.inspection.servers.map((server) => server.name)).toEqual(['linear'])
+    const project = report.mcpFiles.find((file) => file.id === 'project-mcp:.mcp.json')
+    expect(project?.inspection.status).toBe('invalid')
+    expect(
+      report.mcpFiles.find((file) => file.id === 'project-mcp:.cursor/mcp.json')?.inspection.exists
+    ).toBe(false)
+  })
+
+  it('reports an invalid settings file instead of dropping it', async () => {
+    await writeFile(join(homeDir, '.claude', 'settings.json'), '{')
+    const report = await inspectAgentContext({ target: { kind: 'native-host', homeDir, cwd } })
+    const home = report.hookFiles.find((file) => file.id === 'home-claude-settings')
+    expect(home?.exists).toBe(true)
+    expect(home?.error).toBeTruthy()
+  })
+})
+
+describe('buildInstructionFileSources', () => {
+  it('stops the ancestor walk at the home directory and at the level cap', () => {
+    const nested = join(
+      homeDir,
+      ...Array.from({ length: MAX_ANCESTOR_LEVELS + 3 }, (_, i) => `d${i}`)
+    )
+    const sources = buildInstructionFileSources({ homeDir, cwd: nested })
+    const ancestors = sources.filter((source) => source.scope === 'ancestor')
+    expect(ancestors.length).toBeLessThanOrEqual(MAX_ANCESTOR_LEVELS * 2)
+    expect(ancestors.every((source) => !source.path.startsWith(join(homeDir, 'CLAUDE')))).toBe(true)
+  })
+
+  it('omits project and ancestor rows without a workspace', () => {
+    const sources = buildInstructionFileSources({ homeDir, cwd: null })
+    expect(sources.every((source) => source.scope === 'home')).toBe(true)
+  })
+})

--- a/src/main/agent-context/agent-context-inspection.test.ts
+++ b/src/main/agent-context/agent-context-inspection.test.ts
@@ -1,6 +1,6 @@
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { inspectAgentContext } from './agent-context-inspection'
 import { buildInstructionFileSources, MAX_ANCESTOR_LEVELS } from './agent-context-sources'
@@ -185,15 +185,29 @@ describe('inspectAgentContext', () => {
 })
 
 describe('buildInstructionFileSources', () => {
-  it('stops the ancestor walk at the home directory and at the level cap', () => {
+  it('walks exactly MAX_ANCESTOR_LEVELS parents when the home directory is not reached', () => {
+    const outside = join(root, 'elsewhere')
     const nested = join(
-      homeDir,
+      outside,
       ...Array.from({ length: MAX_ANCESTOR_LEVELS + 3 }, (_, i) => `d${i}`)
     )
-    const sources = buildInstructionFileSources({ homeDir, cwd: nested })
-    const ancestors = sources.filter((source) => source.scope === 'ancestor')
-    expect(ancestors.length).toBeLessThanOrEqual(MAX_ANCESTOR_LEVELS * 2)
-    expect(ancestors.every((source) => !source.path.startsWith(join(homeDir, 'CLAUDE')))).toBe(true)
+    const ancestors = buildInstructionFileSources({ homeDir, cwd: nested }).filter(
+      (source) => source.scope === 'ancestor'
+    )
+    // Two rows (CLAUDE.md + AGENTS.md) per ancestor level.
+    expect(ancestors).toHaveLength(MAX_ANCESTOR_LEVELS * 2)
+    expect(ancestors[0]?.path).toBe(join(dirname(nested), 'CLAUDE.md'))
+  })
+
+  it('stops the ancestor walk at the home directory', () => {
+    const nested = join(homeDir, 'a', 'b')
+    const ancestors = buildInstructionFileSources({ homeDir, cwd: nested }).filter(
+      (source) => source.scope === 'ancestor'
+    )
+    expect(ancestors.map((source) => source.path)).toEqual([
+      join(homeDir, 'a', 'CLAUDE.md'),
+      join(homeDir, 'a', 'AGENTS.md')
+    ])
   })
 
   it('omits project and ancestor rows without a workspace', () => {

--- a/src/main/agent-context/agent-context-inspection.test.ts
+++ b/src/main/agent-context/agent-context-inspection.test.ts
@@ -109,6 +109,72 @@ describe('inspectAgentContext', () => {
     ).toBe(false)
   })
 
+  it('merges Claude project-scoped servers from ~/.claude.json and reads Codex and OpenCode files', async () => {
+    await writeFile(
+      join(homeDir, '.claude.json'),
+      JSON.stringify({
+        mcpServers: { global: { command: 'g' } },
+        projects: {
+          [cwd]: {
+            mcpServers: { local: { url: 'http://localhost:1' }, global: { command: 'dup' } }
+          },
+          '/elsewhere': { mcpServers: { other: { command: 'x' } } }
+        }
+      })
+    )
+    await mkdir(join(homeDir, '.codex'), { recursive: true })
+    await writeFile(
+      join(homeDir, '.codex', 'config.toml'),
+      [
+        'model = "gpt-5"',
+        '',
+        '[mcp_servers.codegraph]',
+        'command = "codegraph"',
+        'args = ["serve", "--mcp"]',
+        '',
+        '[mcp_servers."remote one"]',
+        'url = "https://mcp.example" # trailing comment',
+        'enabled = false',
+        '',
+        '[[skills.config]]',
+        'path = "/x"'
+      ].join('\n')
+    )
+    await mkdir(join(homeDir, '.config', 'opencode'), { recursive: true })
+    await writeFile(
+      join(homeDir, '.config', 'opencode', 'opencode.json'),
+      JSON.stringify({ mcp: { oc: { type: 'local', command: ['bun', 'x'] } } })
+    )
+
+    const report = await inspectAgentContext({ target: { kind: 'native-host', homeDir, cwd } })
+    const claude = report.mcpFiles.find((file) => file.id === 'home-mcp:.claude.json')
+    expect(claude?.inspection.servers.map((server) => server.name)).toEqual(['global', 'local'])
+    const codex = report.mcpFiles.find((file) => file.id === 'home-mcp:.codex/config.toml')
+    expect(codex?.inspection.status).toBe('valid')
+    expect(codex?.inspection.servers).toEqual([
+      expect.objectContaining({
+        name: 'codegraph',
+        transport: 'stdio',
+        command: 'codegraph',
+        status: 'enabled'
+      }),
+      expect.objectContaining({
+        name: 'remote one',
+        transport: 'http',
+        url: 'https://mcp.example',
+        status: 'disabled'
+      })
+    ])
+    const opencode = report.mcpFiles.find((file) => file.id === 'home-mcp:opencode.json')
+    expect(opencode?.inspection.servers).toEqual([
+      expect.objectContaining({ name: 'oc', transport: 'stdio', command: 'bun' })
+    ])
+    expect(
+      report.mcpFiles.find((file) => file.id === 'project-mcp:.codex/config.toml')?.inspection
+        .exists
+    ).toBe(false)
+  })
+
   it('reports an invalid settings file instead of dropping it', async () => {
     await writeFile(join(homeDir, '.claude', 'settings.json'), '{')
     const report = await inspectAgentContext({ target: { kind: 'native-host', homeDir, cwd } })

--- a/src/main/agent-context/agent-context-inspection.ts
+++ b/src/main/agent-context/agent-context-inspection.ts
@@ -7,10 +7,12 @@ import type {
   AgentContextPlugin,
   AgentContextReport
 } from '../../shared/agent-context'
-import { inspectMcpConfigContent, type McpConfigInspection } from '../../shared/mcp-config'
 import { inspectCodexMcpToml } from './codex-mcp-toml'
+import { inspectJsonMcpFile } from './json-mcp-file'
 import {
   buildInstructionFileSources,
+  defaultAgentContextPathApi,
+  MAX_ANCESTOR_LEVELS,
   type AgentContextPathApi,
   type InstructionFileSource
 } from './agent-context-sources'
@@ -67,6 +69,26 @@ async function readBoundedText(pathValue: string): Promise<string | null> {
   }
 }
 
+/** The nearest directory at or above `cwd` holding a `.git` entry (a worktree's `.git` is a file). */
+async function findGitRootDir(
+  cwd: string,
+  pathApi: AgentContextPathApi,
+  toAccessPath: (displayPath: string) => string
+): Promise<string | null> {
+  let current = cwd
+  for (let level = 0; level <= MAX_ANCESTOR_LEVELS; level += 1) {
+    if (await statOrNull(toAccessPath(pathApi.join(current, '.git')))) {
+      return current
+    }
+    const parent = pathApi.dirname(current)
+    if (!parent || parent === current) {
+      return null
+    }
+    current = parent
+  }
+  return null
+}
+
 async function countRuleFiles(dirPath: string): Promise<number | null> {
   try {
     // Why: Cursor and Copilot both read rule files from nested folders.
@@ -91,9 +113,10 @@ async function inspectInstructionFile(
   }
   if (source.kind === 'directory') {
     const entryCount = await countRuleFiles(accessPath)
+    // Why: a rules folder with no rule files loads nothing — checked but empty.
     return {
       ...base,
-      exists: entryCount !== null,
+      exists: entryCount !== null && entryCount > 0,
       sizeBytes: null,
       updatedAt: null,
       entryCount: entryCount ?? undefined
@@ -104,26 +127,6 @@ async function inspectInstructionFile(
     return { ...base, exists: false, sizeBytes: null, updatedAt: null }
   }
   return { ...base, exists: true, sizeBytes: fileStat.size, updatedAt: fileStat.mtimeMs }
-}
-
-/** Merges servers from every configured object path; the first path's inspection carries status. */
-function inspectJsonMcpFile(source: McpFileSource, content: string | null): McpConfigInspection {
-  const primary = inspectMcpConfigContent(source.candidate, content)
-  if (!source.extraServersPaths?.length || primary.status !== 'valid') {
-    return primary
-  }
-  const seen = new Set(primary.servers.map((server) => server.name))
-  const servers = [...primary.servers]
-  for (const serversPath of source.extraServersPaths) {
-    const extra = inspectMcpConfigContent({ ...source.candidate, serversPath }, content)
-    for (const server of extra.servers) {
-      if (!seen.has(server.name)) {
-        seen.add(server.name)
-        servers.push(server)
-      }
-    }
-  }
-  return { ...primary, servers }
 }
 
 async function inspectMcpFile(
@@ -246,10 +249,14 @@ export async function inspectAgentContext(
   args: AgentContextInspectionArgs
 ): Promise<AgentContextReport> {
   const toAccessPath = args.toAccessPath ?? ((displayPath: string) => displayPath)
-  const sourceArgs = { homeDir: args.target.homeDir, cwd: args.target.cwd, pathApi: args.pathApi }
+  const pathApi = args.pathApi ?? defaultAgentContextPathApi
+  const sourceArgs = { homeDir: args.target.homeDir, cwd: args.target.cwd, pathApi }
+  const gitRootDir = args.target.cwd
+    ? await findGitRootDir(args.target.cwd, pathApi, toAccessPath)
+    : null
   const [instructionFiles, mcpFiles, settings] = await Promise.all([
     Promise.all(
-      buildInstructionFileSources(sourceArgs).map((source) =>
+      buildInstructionFileSources({ ...sourceArgs, gitRootDir }).map((source) =>
         inspectInstructionFile(source, toAccessPath)
       )
     ),

--- a/src/main/agent-context/agent-context-inspection.ts
+++ b/src/main/agent-context/agent-context-inspection.ts
@@ -1,0 +1,237 @@
+import type { Stats } from 'node:fs'
+import { open, readdir, stat } from 'node:fs/promises'
+import type {
+  AgentContextHookFile,
+  AgentContextInstructionFile,
+  AgentContextMcpFile,
+  AgentContextPlugin,
+  AgentContextReport
+} from '../../shared/agent-context'
+import { inspectMcpConfigContent } from '../../shared/mcp-config'
+import {
+  buildClaudeSettingsSources,
+  buildInstructionFileSources,
+  buildMcpFileSources,
+  type AgentContextPathApi,
+  type InstructionFileSource,
+  type McpFileSource,
+  type SettingsFileSource
+} from './agent-context-sources'
+
+// Why: settings and MCP files are small JSON; anything past this is not config.
+const MAX_CONFIG_BYTES = 4 * 1024 * 1024
+const RULE_FILE_PATTERN = /\.(md|mdc)$/i
+
+export type AgentContextInspectionArgs = {
+  target: AgentContextReport['target']
+  /** Maps a display path (as built by the source tables) to the path node fs can open. */
+  toAccessPath?: (displayPath: string) => string
+  pathApi?: AgentContextPathApi
+}
+
+async function statOrNull(pathValue: string): Promise<Stats | null> {
+  try {
+    return await stat(pathValue)
+  } catch {
+    return null
+  }
+}
+
+async function readBoundedText(pathValue: string): Promise<string | null> {
+  const fileStat = await statOrNull(pathValue)
+  if (!fileStat || !fileStat.isFile()) {
+    return null
+  }
+  if (fileStat.size > MAX_CONFIG_BYTES) {
+    return null
+  }
+  const file = await open(pathValue, 'r')
+  try {
+    const buffer = Buffer.alloc(fileStat.size)
+    const { bytesRead } = await file.read(buffer, 0, buffer.length, 0)
+    return buffer.subarray(0, bytesRead).toString('utf8')
+  } finally {
+    await file.close()
+  }
+}
+
+async function countRuleFiles(dirPath: string): Promise<number | null> {
+  try {
+    const entries = await readdir(dirPath, { withFileTypes: true })
+    return entries.filter((entry) => entry.isFile() && RULE_FILE_PATTERN.test(entry.name)).length
+  } catch {
+    return null
+  }
+}
+
+async function inspectInstructionFile(
+  source: InstructionFileSource,
+  toAccessPath: (displayPath: string) => string
+): Promise<AgentContextInstructionFile> {
+  const accessPath = toAccessPath(source.path)
+  const base = {
+    id: source.id,
+    label: source.label,
+    path: source.path,
+    scope: source.scope,
+    agents: [...source.agents]
+  }
+  if (source.kind === 'directory') {
+    const entryCount = await countRuleFiles(accessPath)
+    return {
+      ...base,
+      exists: entryCount !== null,
+      sizeBytes: null,
+      updatedAt: null,
+      entryCount: entryCount ?? undefined
+    }
+  }
+  const fileStat = await statOrNull(accessPath)
+  if (!fileStat || !fileStat.isFile()) {
+    return { ...base, exists: false, sizeBytes: null, updatedAt: null }
+  }
+  return { ...base, exists: true, sizeBytes: fileStat.size, updatedAt: fileStat.mtimeMs }
+}
+
+async function inspectMcpFile(
+  source: McpFileSource,
+  toAccessPath: (displayPath: string) => string
+): Promise<AgentContextMcpFile> {
+  const content = await readBoundedText(toAccessPath(source.path))
+  return {
+    id: source.id,
+    path: source.path,
+    scope: source.scope,
+    agents: [...source.agents],
+    inspection: inspectMcpConfigContent(source.candidate, content)
+  }
+}
+
+function parseJsonObject(content: string): Record<string, unknown> | null {
+  const parsed: unknown = JSON.parse(content)
+  return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+    ? (parsed as Record<string, unknown>)
+    : null
+}
+
+/** Claude hooks: `{ [event]: [{ matcher?, hooks: [{type, command}] }] }`. */
+export function summarizeClaudeHooks(settings: Record<string, unknown>): {
+  events: string[]
+  hookCount: number
+} {
+  const hooks = settings.hooks
+  if (!hooks || typeof hooks !== 'object' || Array.isArray(hooks)) {
+    return { events: [], hookCount: 0 }
+  }
+  const events: string[] = []
+  let hookCount = 0
+  for (const [event, groups] of Object.entries(hooks as Record<string, unknown>)) {
+    if (!Array.isArray(groups)) {
+      continue
+    }
+    let eventHooks = 0
+    for (const group of groups) {
+      const entries =
+        group && typeof group === 'object' ? (group as { hooks?: unknown }).hooks : undefined
+      eventHooks += Array.isArray(entries) ? entries.length : 0
+    }
+    if (eventHooks > 0) {
+      events.push(event)
+      hookCount += eventHooks
+    }
+  }
+  return { events, hookCount }
+}
+
+export function summarizeClaudeEnabledPlugins(
+  settings: Record<string, unknown>
+): { name: string; enabled: boolean }[] {
+  const enabledPlugins = settings.enabledPlugins
+  if (!enabledPlugins || typeof enabledPlugins !== 'object' || Array.isArray(enabledPlugins)) {
+    return []
+  }
+  return Object.entries(enabledPlugins as Record<string, unknown>)
+    .filter(([, value]) => typeof value === 'boolean')
+    .map(([name, value]) => ({ name, enabled: value === true }))
+}
+
+async function inspectClaudeSettings(
+  source: SettingsFileSource,
+  toAccessPath: (displayPath: string) => string
+): Promise<{ hookFile: AgentContextHookFile; plugins: AgentContextPlugin[] }> {
+  const base = { id: source.id, path: source.path, scope: source.scope, agents: [...source.agents] }
+  const content = await readBoundedText(toAccessPath(source.path))
+  if (content === null) {
+    return { hookFile: { ...base, exists: false, events: [], hookCount: 0 }, plugins: [] }
+  }
+  let settings: Record<string, unknown> | null
+  try {
+    settings = parseJsonObject(content)
+  } catch (error) {
+    return {
+      hookFile: {
+        ...base,
+        exists: true,
+        events: [],
+        hookCount: 0,
+        error: error instanceof Error ? error.message : 'Invalid JSON'
+      },
+      plugins: []
+    }
+  }
+  if (!settings) {
+    return { hookFile: { ...base, exists: true, events: [], hookCount: 0 }, plugins: [] }
+  }
+  const { events, hookCount } = summarizeClaudeHooks(settings)
+  const plugins = summarizeClaudeEnabledPlugins(settings).map((plugin) => ({
+    id: `${source.id}:${plugin.name}`,
+    name: plugin.name,
+    agents: [...source.agents],
+    enabled: plugin.enabled,
+    sourcePath: source.path,
+    scope: source.scope
+  }))
+  return { hookFile: { ...base, exists: true, events, hookCount }, plugins }
+}
+
+/**
+ * Later settings files win for the same plugin (user → project → local), so
+ * the panel shows one row per plugin with the deciding file.
+ */
+export function mergePluginDecisions(plugins: AgentContextPlugin[]): AgentContextPlugin[] {
+  const byName = new Map<string, AgentContextPlugin>()
+  for (const plugin of plugins) {
+    byName.set(plugin.name, plugin)
+  }
+  return [...byName.values()].sort((a, b) => a.name.localeCompare(b.name))
+}
+
+export async function inspectAgentContext(
+  args: AgentContextInspectionArgs
+): Promise<AgentContextReport> {
+  const toAccessPath = args.toAccessPath ?? ((displayPath: string) => displayPath)
+  const sourceArgs = { homeDir: args.target.homeDir, cwd: args.target.cwd, pathApi: args.pathApi }
+  const [instructionFiles, mcpFiles, settings] = await Promise.all([
+    Promise.all(
+      buildInstructionFileSources(sourceArgs).map((source) =>
+        inspectInstructionFile(source, toAccessPath)
+      )
+    ),
+    Promise.all(
+      buildMcpFileSources(sourceArgs).map((source) => inspectMcpFile(source, toAccessPath))
+    ),
+    Promise.all(
+      buildClaudeSettingsSources(sourceArgs).map((source) =>
+        inspectClaudeSettings(source, toAccessPath)
+      )
+    )
+  ])
+  return {
+    target: args.target,
+    instructionFiles,
+    mcpFiles,
+    hookFiles: settings.map((entry) => entry.hookFile),
+    plugins: mergePluginDecisions(settings.flatMap((entry) => entry.plugins)),
+    scannedAt: Date.now()
+  }
+}

--- a/src/main/agent-context/agent-context-inspection.ts
+++ b/src/main/agent-context/agent-context-inspection.ts
@@ -1,5 +1,5 @@
 import type { Stats } from 'node:fs'
-import { open, readdir, stat } from 'node:fs/promises'
+import { open, readdir, stat, type FileHandle } from 'node:fs/promises'
 import type {
   AgentContextHookFile,
   AgentContextInstructionFile,
@@ -48,19 +48,29 @@ async function readBoundedText(pathValue: string): Promise<string | null> {
   if (fileStat.size > MAX_CONFIG_BYTES) {
     return null
   }
-  const file = await open(pathValue, 'r')
+  // Why: one unreadable file (EACCES, deleted between stat and open) must not
+  // fail the whole report; it reads as missing, like a file that never existed.
+  let file: FileHandle
+  try {
+    file = await open(pathValue, 'r')
+  } catch {
+    return null
+  }
   try {
     const buffer = Buffer.alloc(fileStat.size)
     const { bytesRead } = await file.read(buffer, 0, buffer.length, 0)
     return buffer.subarray(0, bytesRead).toString('utf8')
+  } catch {
+    return null
   } finally {
-    await file.close()
+    await file.close().catch(() => undefined)
   }
 }
 
 async function countRuleFiles(dirPath: string): Promise<number | null> {
   try {
-    const entries = await readdir(dirPath, { withFileTypes: true })
+    // Why: Cursor and Copilot both read rule files from nested folders.
+    const entries = await readdir(dirPath, { withFileTypes: true, recursive: true })
     return entries.filter((entry) => entry.isFile() && RULE_FILE_PATTERN.test(entry.name)).length
   } catch {
     return null

--- a/src/main/agent-context/agent-context-inspection.ts
+++ b/src/main/agent-context/agent-context-inspection.ts
@@ -7,16 +7,19 @@ import type {
   AgentContextPlugin,
   AgentContextReport
 } from '../../shared/agent-context'
-import { inspectMcpConfigContent } from '../../shared/mcp-config'
+import { inspectMcpConfigContent, type McpConfigInspection } from '../../shared/mcp-config'
+import { inspectCodexMcpToml } from './codex-mcp-toml'
+import {
+  buildInstructionFileSources,
+  type AgentContextPathApi,
+  type InstructionFileSource
+} from './agent-context-sources'
 import {
   buildClaudeSettingsSources,
-  buildInstructionFileSources,
   buildMcpFileSources,
-  type AgentContextPathApi,
-  type InstructionFileSource,
   type McpFileSource,
   type SettingsFileSource
-} from './agent-context-sources'
+} from './agent-config-file-sources'
 
 // Why: settings and MCP files are small JSON; anything past this is not config.
 const MAX_CONFIG_BYTES = 4 * 1024 * 1024
@@ -93,6 +96,26 @@ async function inspectInstructionFile(
   return { ...base, exists: true, sizeBytes: fileStat.size, updatedAt: fileStat.mtimeMs }
 }
 
+/** Merges servers from every configured object path; the first path's inspection carries status. */
+function inspectJsonMcpFile(source: McpFileSource, content: string | null): McpConfigInspection {
+  const primary = inspectMcpConfigContent(source.candidate, content)
+  if (!source.extraServersPaths?.length || primary.status !== 'valid') {
+    return primary
+  }
+  const seen = new Set(primary.servers.map((server) => server.name))
+  const servers = [...primary.servers]
+  for (const serversPath of source.extraServersPaths) {
+    const extra = inspectMcpConfigContent({ ...source.candidate, serversPath }, content)
+    for (const server of extra.servers) {
+      if (!seen.has(server.name)) {
+        seen.add(server.name)
+        servers.push(server)
+      }
+    }
+  }
+  return { ...primary, servers }
+}
+
 async function inspectMcpFile(
   source: McpFileSource,
   toAccessPath: (displayPath: string) => string
@@ -103,7 +126,10 @@ async function inspectMcpFile(
     path: source.path,
     scope: source.scope,
     agents: [...source.agents],
-    inspection: inspectMcpConfigContent(source.candidate, content)
+    inspection:
+      source.format === 'codex-toml'
+        ? inspectCodexMcpToml(source.candidate, content)
+        : inspectJsonMcpFile(source, content)
   }
 }
 

--- a/src/main/agent-context/agent-context-sources.ts
+++ b/src/main/agent-context/agent-context-sources.ts
@@ -20,7 +20,7 @@ export type InstructionFileSource = {
 // unbounded stat walk; agents themselves stop at the repo or home boundary.
 export const MAX_ANCESTOR_LEVELS = 8
 
-/** Agents that read a shared `AGENTS.md` at the workspace root and its ancestors. */
+/** Agents that read a shared `AGENTS.md` at the workspace root. */
 export const AGENTS_MD_READERS: AgentType[] = [
   'codex',
   'opencode',
@@ -29,6 +29,23 @@ export const AGENTS_MD_READERS: AgentType[] = [
   'copilot',
   'pi'
 ]
+
+/**
+ * Agents that also read `AGENTS.md` from parent folders, up to the git root.
+ * Cursor and Copilot read only the workspace root's file.
+ */
+export const AGENTS_MD_ANCESTOR_READERS: AgentType[] = ['codex', 'opencode', 'amp', 'pi']
+
+const WINDOWS_PATH_PATTERN = /^(?:[A-Za-z]:[\\/]|[\\/]{2}[^\\/]+[\\/])/
+
+/** Path equality the way the host's filesystem sees it: Windows paths ignore case and separator style. */
+export function isSamePath(a: string, b: string): boolean {
+  const normalize = (value: string): string => {
+    const unified = value.replace(/\\/g, '/').replace(/\/+$/, '')
+    return WINDOWS_PATH_PATTERN.test(value) ? unified.toLowerCase() : unified
+  }
+  return normalize(a) === normalize(b)
+}
 
 function ancestorDirs(cwd: string, pathApi: AgentContextPathApi): string[] {
   const dirs: string[] = []
@@ -48,14 +65,20 @@ function ancestorDirs(cwd: string, pathApi: AgentContextPathApi): string[] {
  * Every instruction file a supported agent loads for a session rooted at `cwd`.
  * The table is the product: each row names the agents that read the path so the
  * panel can group by agent without re-deriving vendor conventions.
+ *
+ * `gitRootDir` is the workspace's repository root (the nearest ancestor with a
+ * `.git`), or `null` when there is none: Codex-family agents stop their
+ * `AGENTS.md` walk there, Claude walks every parent up to the home directory.
  */
 export function buildInstructionFileSources(args: {
   homeDir: string
   cwd: string | null
+  gitRootDir?: string | null
   pathApi?: AgentContextPathApi
 }): InstructionFileSource[] {
   const pathApi = args.pathApi ?? defaultAgentContextPathApi
   const { homeDir, cwd } = args
+  const gitRootDir = args.gitRootDir ?? null
   const sources: InstructionFileSource[] = [
     {
       id: 'home-claude-md',
@@ -167,10 +190,12 @@ export function buildInstructionFileSources(args: {
       kind: 'directory'
     }
   )
-  // Why: Claude and Codex both walk up from cwd, so a monorepo root file
-  // applies to a nested workspace even though it is outside the worktree.
+  // Why: Claude walks up from cwd to home, so a monorepo root file applies to a
+  // nested workspace even though it is outside the worktree; Codex-family
+  // agents walk only as far as the repository root.
+  let insideGitRoot = gitRootDir !== null && !isSamePath(cwd, gitRootDir)
   for (const dir of ancestorDirs(cwd, pathApi)) {
-    if (dir === homeDir) {
+    if (isSamePath(dir, homeDir)) {
       break
     }
     sources.push(
@@ -183,14 +208,25 @@ export function buildInstructionFileSources(args: {
         kind: 'file'
       },
       {
+        id: `ancestor-claude-local-md:${dir}`,
+        label: 'CLAUDE.local.md',
+        path: pathApi.join(dir, 'CLAUDE.local.md'),
+        scope: 'ancestor',
+        agents: ['claude'],
+        kind: 'file'
+      }
+    )
+    if (insideGitRoot) {
+      sources.push({
         id: `ancestor-agents-md:${dir}`,
         label: 'AGENTS.md',
         path: pathApi.join(dir, 'AGENTS.md'),
         scope: 'ancestor',
-        agents: [...AGENTS_MD_READERS],
+        agents: [...AGENTS_MD_ANCESTOR_READERS],
         kind: 'file'
-      }
-    )
+      })
+      insideGitRoot = gitRootDir !== null && !isSamePath(dir, gitRootDir)
+    }
   }
   return sources
 }

--- a/src/main/agent-context/agent-context-sources.ts
+++ b/src/main/agent-context/agent-context-sources.ts
@@ -1,0 +1,324 @@
+import { basename, dirname, join, type posix } from 'node:path'
+import type { AgentType } from '../../shared/agent-status-types'
+import type { AgentContextScope } from '../../shared/agent-context'
+import type { McpConfigCandidate } from '../../shared/mcp-config'
+import { MCP_CONFIG_CANDIDATES } from '../../shared/mcp-config'
+
+export type AgentContextPathApi = Pick<typeof posix, 'basename' | 'dirname' | 'join'>
+
+export type InstructionFileSource = {
+  id: string
+  label: string
+  path: string
+  scope: AgentContextScope
+  agents: AgentType[]
+  /** Directory sources count their rule files instead of reporting a size. */
+  kind: 'file' | 'directory'
+}
+
+export type McpFileSource = {
+  id: string
+  path: string
+  scope: AgentContextScope
+  agents: AgentType[]
+  candidate: McpConfigCandidate
+}
+
+export type SettingsFileSource = {
+  id: string
+  path: string
+  scope: AgentContextScope
+  agents: AgentType[]
+}
+
+const defaultPathApi: AgentContextPathApi = { basename, dirname, join }
+
+// Why: capped so a workspace nested deep under `/` cannot fan out into an
+// unbounded stat walk; agents themselves stop at the repo or home boundary.
+export const MAX_ANCESTOR_LEVELS = 8
+
+/** Agents that read a shared `AGENTS.md` at the workspace root and its ancestors. */
+export const AGENTS_MD_READERS: AgentType[] = [
+  'codex',
+  'opencode',
+  'amp',
+  'cursor',
+  'copilot',
+  'pi'
+]
+
+function ancestorDirs(cwd: string, pathApi: AgentContextPathApi): string[] {
+  const dirs: string[] = []
+  let current = cwd
+  for (let level = 0; level < MAX_ANCESTOR_LEVELS; level += 1) {
+    const parent = pathApi.dirname(current)
+    if (!parent || parent === current) {
+      break
+    }
+    dirs.push(parent)
+    current = parent
+  }
+  return dirs
+}
+
+/**
+ * Every instruction file a supported agent loads for a session rooted at `cwd`.
+ * The table is the product: each row names the agents that read the path so the
+ * panel can group by agent without re-deriving vendor conventions.
+ */
+export function buildInstructionFileSources(args: {
+  homeDir: string
+  cwd: string | null
+  pathApi?: AgentContextPathApi
+}): InstructionFileSource[] {
+  const pathApi = args.pathApi ?? defaultPathApi
+  const { homeDir, cwd } = args
+  const sources: InstructionFileSource[] = [
+    {
+      id: 'home-claude-md',
+      label: 'CLAUDE.md',
+      path: pathApi.join(homeDir, '.claude', 'CLAUDE.md'),
+      scope: 'home',
+      agents: ['claude'],
+      kind: 'file'
+    },
+    {
+      id: 'home-codex-agents-md',
+      label: 'AGENTS.md',
+      path: pathApi.join(homeDir, '.codex', 'AGENTS.md'),
+      scope: 'home',
+      agents: ['codex'],
+      kind: 'file'
+    },
+    {
+      id: 'home-gemini-md',
+      label: 'GEMINI.md',
+      path: pathApi.join(homeDir, '.gemini', 'GEMINI.md'),
+      scope: 'home',
+      agents: ['gemini'],
+      kind: 'file'
+    },
+    {
+      id: 'home-opencode-agents-md',
+      label: 'AGENTS.md',
+      path: pathApi.join(homeDir, '.config', 'opencode', 'AGENTS.md'),
+      scope: 'home',
+      agents: ['opencode'],
+      kind: 'file'
+    }
+  ]
+  if (!cwd) {
+    return sources
+  }
+  sources.push(
+    {
+      id: 'project-claude-md',
+      label: 'CLAUDE.md',
+      path: pathApi.join(cwd, 'CLAUDE.md'),
+      scope: 'project',
+      agents: ['claude'],
+      kind: 'file'
+    },
+    {
+      id: 'project-claude-local-md',
+      label: 'CLAUDE.local.md',
+      path: pathApi.join(cwd, 'CLAUDE.local.md'),
+      scope: 'project',
+      agents: ['claude'],
+      kind: 'file'
+    },
+    {
+      id: 'project-dot-claude-md',
+      label: '.claude/CLAUDE.md',
+      path: pathApi.join(cwd, '.claude', 'CLAUDE.md'),
+      scope: 'project',
+      agents: ['claude'],
+      kind: 'file'
+    },
+    {
+      id: 'project-agents-md',
+      label: 'AGENTS.md',
+      path: pathApi.join(cwd, 'AGENTS.md'),
+      scope: 'project',
+      agents: [...AGENTS_MD_READERS],
+      kind: 'file'
+    },
+    {
+      id: 'project-gemini-md',
+      label: 'GEMINI.md',
+      path: pathApi.join(cwd, 'GEMINI.md'),
+      scope: 'project',
+      agents: ['gemini'],
+      kind: 'file'
+    },
+    {
+      id: 'project-cursorrules',
+      label: '.cursorrules',
+      path: pathApi.join(cwd, '.cursorrules'),
+      scope: 'project',
+      agents: ['cursor'],
+      kind: 'file'
+    },
+    {
+      id: 'project-cursor-rules-dir',
+      label: '.cursor/rules/',
+      path: pathApi.join(cwd, '.cursor', 'rules'),
+      scope: 'project',
+      agents: ['cursor'],
+      kind: 'directory'
+    },
+    {
+      id: 'project-copilot-instructions',
+      label: '.github/copilot-instructions.md',
+      path: pathApi.join(cwd, '.github', 'copilot-instructions.md'),
+      scope: 'project',
+      agents: ['copilot'],
+      kind: 'file'
+    },
+    {
+      id: 'project-copilot-instructions-dir',
+      label: '.github/instructions/',
+      path: pathApi.join(cwd, '.github', 'instructions'),
+      scope: 'project',
+      agents: ['copilot'],
+      kind: 'directory'
+    }
+  )
+  // Why: Claude and Codex both walk up from cwd, so a monorepo root file
+  // applies to a nested workspace even though it is outside the worktree.
+  for (const dir of ancestorDirs(cwd, pathApi)) {
+    if (dir === homeDir) {
+      break
+    }
+    sources.push(
+      {
+        id: `ancestor-claude-md:${dir}`,
+        label: 'CLAUDE.md',
+        path: pathApi.join(dir, 'CLAUDE.md'),
+        scope: 'ancestor',
+        agents: ['claude'],
+        kind: 'file'
+      },
+      {
+        id: `ancestor-agents-md:${dir}`,
+        label: 'AGENTS.md',
+        path: pathApi.join(dir, 'AGENTS.md'),
+        scope: 'ancestor',
+        agents: [...AGENTS_MD_READERS],
+        kind: 'file'
+      }
+    )
+  }
+  return sources
+}
+
+const HOME_MCP_CANDIDATES: {
+  candidate: McpConfigCandidate
+  segments: string[]
+  agents: AgentType[]
+}[] = [
+  {
+    candidate: {
+      format: 'claude',
+      label: 'Claude user',
+      relativePath: '.claude.json',
+      serversPath: ['mcpServers']
+    },
+    segments: ['.claude.json'],
+    agents: ['claude']
+  },
+  {
+    candidate: {
+      format: 'cursor',
+      label: 'Cursor user',
+      relativePath: '.cursor/mcp.json',
+      serversPath: ['mcpServers']
+    },
+    segments: ['.cursor', 'mcp.json'],
+    agents: ['cursor']
+  },
+  {
+    candidate: {
+      format: 'workspace',
+      label: 'Gemini user',
+      relativePath: '.gemini/settings.json',
+      serversPath: ['mcpServers']
+    },
+    segments: ['.gemini', 'settings.json'],
+    agents: ['gemini']
+  }
+]
+
+function agentsForMcpCandidate(candidate: McpConfigCandidate): AgentType[] {
+  switch (candidate.format) {
+    case 'cursor':
+      return ['cursor']
+    case 'claude':
+      return ['claude']
+    default:
+      // `.mcp.json` is Claude's project-scope file; other agents read it via plugins only.
+      return ['claude']
+  }
+}
+
+export function buildMcpFileSources(args: {
+  homeDir: string
+  cwd: string | null
+  pathApi?: AgentContextPathApi
+}): McpFileSource[] {
+  const pathApi = args.pathApi ?? defaultPathApi
+  const sources: McpFileSource[] = HOME_MCP_CANDIDATES.map((entry) => ({
+    id: `home-mcp:${entry.candidate.relativePath}`,
+    path: pathApi.join(args.homeDir, ...entry.segments),
+    scope: 'home',
+    agents: [...entry.agents],
+    candidate: entry.candidate
+  }))
+  if (!args.cwd) {
+    return sources
+  }
+  for (const candidate of MCP_CONFIG_CANDIDATES) {
+    sources.push({
+      id: `project-mcp:${candidate.relativePath}`,
+      path: pathApi.join(args.cwd, ...candidate.relativePath.split('/')),
+      scope: 'project',
+      agents: agentsForMcpCandidate(candidate),
+      candidate
+    })
+  }
+  return sources
+}
+
+/** Claude merges user, project, then project-local settings — hooks and enabledPlugins live here. */
+export function buildClaudeSettingsSources(args: {
+  homeDir: string
+  cwd: string | null
+  pathApi?: AgentContextPathApi
+}): SettingsFileSource[] {
+  const pathApi = args.pathApi ?? defaultPathApi
+  const sources: SettingsFileSource[] = [
+    {
+      id: 'home-claude-settings',
+      path: pathApi.join(args.homeDir, '.claude', 'settings.json'),
+      scope: 'home',
+      agents: ['claude']
+    }
+  ]
+  if (args.cwd) {
+    sources.push(
+      {
+        id: 'project-claude-settings',
+        path: pathApi.join(args.cwd, '.claude', 'settings.json'),
+        scope: 'project',
+        agents: ['claude']
+      },
+      {
+        id: 'project-claude-settings-local',
+        path: pathApi.join(args.cwd, '.claude', 'settings.local.json'),
+        scope: 'project',
+        agents: ['claude']
+      }
+    )
+  }
+  return sources
+}

--- a/src/main/agent-context/agent-context-sources.ts
+++ b/src/main/agent-context/agent-context-sources.ts
@@ -1,10 +1,10 @@
 import { basename, dirname, join, type posix } from 'node:path'
 import type { AgentType } from '../../shared/agent-status-types'
 import type { AgentContextScope } from '../../shared/agent-context'
-import type { McpConfigCandidate } from '../../shared/mcp-config'
-import { MCP_CONFIG_CANDIDATES } from '../../shared/mcp-config'
 
 export type AgentContextPathApi = Pick<typeof posix, 'basename' | 'dirname' | 'join'>
+
+export const defaultAgentContextPathApi: AgentContextPathApi = { basename, dirname, join }
 
 export type InstructionFileSource = {
   id: string
@@ -15,23 +15,6 @@ export type InstructionFileSource = {
   /** Directory sources count their rule files instead of reporting a size. */
   kind: 'file' | 'directory'
 }
-
-export type McpFileSource = {
-  id: string
-  path: string
-  scope: AgentContextScope
-  agents: AgentType[]
-  candidate: McpConfigCandidate
-}
-
-export type SettingsFileSource = {
-  id: string
-  path: string
-  scope: AgentContextScope
-  agents: AgentType[]
-}
-
-const defaultPathApi: AgentContextPathApi = { basename, dirname, join }
 
 // Why: capped so a workspace nested deep under `/` cannot fan out into an
 // unbounded stat walk; agents themselves stop at the repo or home boundary.
@@ -71,7 +54,7 @@ export function buildInstructionFileSources(args: {
   cwd: string | null
   pathApi?: AgentContextPathApi
 }): InstructionFileSource[] {
-  const pathApi = args.pathApi ?? defaultPathApi
+  const pathApi = args.pathApi ?? defaultAgentContextPathApi
   const { homeDir, cwd } = args
   const sources: InstructionFileSource[] = [
     {
@@ -206,117 +189,6 @@ export function buildInstructionFileSources(args: {
         scope: 'ancestor',
         agents: [...AGENTS_MD_READERS],
         kind: 'file'
-      }
-    )
-  }
-  return sources
-}
-
-const HOME_MCP_CANDIDATES: {
-  candidate: McpConfigCandidate
-  segments: string[]
-  agents: AgentType[]
-}[] = [
-  {
-    candidate: {
-      format: 'claude',
-      label: 'Claude user',
-      relativePath: '.claude.json',
-      serversPath: ['mcpServers']
-    },
-    segments: ['.claude.json'],
-    agents: ['claude']
-  },
-  {
-    candidate: {
-      format: 'cursor',
-      label: 'Cursor user',
-      relativePath: '.cursor/mcp.json',
-      serversPath: ['mcpServers']
-    },
-    segments: ['.cursor', 'mcp.json'],
-    agents: ['cursor']
-  },
-  {
-    candidate: {
-      format: 'workspace',
-      label: 'Gemini user',
-      relativePath: '.gemini/settings.json',
-      serversPath: ['mcpServers']
-    },
-    segments: ['.gemini', 'settings.json'],
-    agents: ['gemini']
-  }
-]
-
-function agentsForMcpCandidate(candidate: McpConfigCandidate): AgentType[] {
-  switch (candidate.format) {
-    case 'cursor':
-      return ['cursor']
-    case 'claude':
-      return ['claude']
-    default:
-      // `.mcp.json` is Claude's project-scope file; other agents read it via plugins only.
-      return ['claude']
-  }
-}
-
-export function buildMcpFileSources(args: {
-  homeDir: string
-  cwd: string | null
-  pathApi?: AgentContextPathApi
-}): McpFileSource[] {
-  const pathApi = args.pathApi ?? defaultPathApi
-  const sources: McpFileSource[] = HOME_MCP_CANDIDATES.map((entry) => ({
-    id: `home-mcp:${entry.candidate.relativePath}`,
-    path: pathApi.join(args.homeDir, ...entry.segments),
-    scope: 'home',
-    agents: [...entry.agents],
-    candidate: entry.candidate
-  }))
-  if (!args.cwd) {
-    return sources
-  }
-  for (const candidate of MCP_CONFIG_CANDIDATES) {
-    sources.push({
-      id: `project-mcp:${candidate.relativePath}`,
-      path: pathApi.join(args.cwd, ...candidate.relativePath.split('/')),
-      scope: 'project',
-      agents: agentsForMcpCandidate(candidate),
-      candidate
-    })
-  }
-  return sources
-}
-
-/** Claude merges user, project, then project-local settings — hooks and enabledPlugins live here. */
-export function buildClaudeSettingsSources(args: {
-  homeDir: string
-  cwd: string | null
-  pathApi?: AgentContextPathApi
-}): SettingsFileSource[] {
-  const pathApi = args.pathApi ?? defaultPathApi
-  const sources: SettingsFileSource[] = [
-    {
-      id: 'home-claude-settings',
-      path: pathApi.join(args.homeDir, '.claude', 'settings.json'),
-      scope: 'home',
-      agents: ['claude']
-    }
-  ]
-  if (args.cwd) {
-    sources.push(
-      {
-        id: 'project-claude-settings',
-        path: pathApi.join(args.cwd, '.claude', 'settings.json'),
-        scope: 'project',
-        agents: ['claude']
-      },
-      {
-        id: 'project-claude-settings-local',
-        path: pathApi.join(args.cwd, '.claude', 'settings.local.json'),
-        scope: 'project',
-        agents: ['claude']
       }
     )
   }

--- a/src/main/agent-context/agent-context-target.test.ts
+++ b/src/main/agent-context/agent-context-target.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { AgentContextReport } from '../../shared/agent-context'
+
+type InspectArgs = {
+  target: AgentContextReport['target']
+  toAccessPath?: (displayPath: string) => string
+  pathApi?: { join: (...parts: string[]) => string }
+}
+
+const inspectAgentContext = vi.hoisted(() =>
+  vi.fn(
+    async (_args: unknown): Promise<AgentContextReport> => ({
+      target: { kind: 'native-host', homeDir: '', cwd: null },
+      instructionFiles: [],
+      mcpFiles: [],
+      hookFiles: [],
+      plugins: [],
+      scannedAt: 0
+    })
+  )
+)
+vi.mock('./agent-context-inspection', () => ({ inspectAgentContext }))
+vi.mock('node:os', () => ({ homedir: () => '/home/native' }))
+
+import { inspectAgentContextOnTarget } from './agent-context-target'
+
+describe('inspectAgentContextOnTarget', () => {
+  it('reads WSL targets through the UNC mount with POSIX display paths', async () => {
+    await inspectAgentContextOnTarget({
+      kind: 'wsl',
+      distro: 'Ubuntu',
+      homeDir: '/home/u',
+      cwd: '/home/u/repo'
+    })
+    const args = inspectAgentContext.mock.calls.at(-1)?.[0] as InspectArgs
+    expect(args.target).toEqual({
+      kind: 'wsl',
+      distro: 'Ubuntu',
+      homeDir: '/home/u',
+      cwd: '/home/u/repo'
+    })
+    expect(args.toAccessPath?.('/home/u/.claude/CLAUDE.md')).toBe(
+      '\\\\wsl.localhost\\Ubuntu\\home\\u\\.claude\\CLAUDE.md'
+    )
+    expect(args.toAccessPath?.('/mnt/c/src/repo/AGENTS.md')).toBe('C:\\src\\repo\\AGENTS.md')
+    // Why: sources must be built with POSIX joins even when Orca runs on Windows.
+    expect(args.pathApi?.join('/home/u', '.codex', 'config.toml')).toBe(
+      '/home/u/.codex/config.toml'
+    )
+  })
+
+  it('reads native targets from the local home directory', async () => {
+    await inspectAgentContextOnTarget({ kind: 'native-host', cwd: undefined })
+    const args = inspectAgentContext.mock.calls.at(-1)?.[0] as InspectArgs
+    expect(args.target).toEqual({ kind: 'native-host', homeDir: '/home/native', cwd: null })
+    expect(args.toAccessPath).toBeUndefined()
+  })
+})

--- a/src/main/agent-context/agent-context-target.ts
+++ b/src/main/agent-context/agent-context-target.ts
@@ -1,0 +1,27 @@
+import { homedir } from 'node:os'
+import { posix } from 'node:path'
+import type { AgentContextReport } from '../../shared/agent-context'
+import { toWindowsWslPath } from '../../shared/wsl-paths'
+import type { ResolvedSkillDiscoveryTarget } from '../skills/skill-discovery-target'
+import { inspectAgentContext } from './agent-context-inspection'
+
+/**
+ * Inspect the agent context on the same host skill discovery resolved. WSL
+ * targets are read through their `\\wsl.localhost` UNC mount so the report
+ * carries POSIX display paths while node fs opens the Windows view of them.
+ */
+export async function inspectAgentContextOnTarget(
+  resolved: ResolvedSkillDiscoveryTarget
+): Promise<AgentContextReport> {
+  if (resolved.kind === 'wsl') {
+    const distro = resolved.distro
+    return inspectAgentContext({
+      target: { kind: 'wsl', distro, homeDir: resolved.homeDir, cwd: resolved.cwd },
+      toAccessPath: (displayPath) => toWindowsWslPath(displayPath, distro),
+      pathApi: posix
+    })
+  }
+  return inspectAgentContext({
+    target: { kind: 'native-host', homeDir: homedir(), cwd: resolved.cwd ?? null }
+  })
+}

--- a/src/main/agent-context/codex-mcp-toml.test.ts
+++ b/src/main/agent-context/codex-mcp-toml.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import type { McpConfigCandidate } from '../../shared/mcp-config'
+import { inspectCodexMcpToml } from './codex-mcp-toml'
+
+const candidate: McpConfigCandidate = {
+  format: 'workspace',
+  label: 'Codex',
+  relativePath: '.codex/config.toml',
+  serversPath: ['mcp_servers']
+}
+
+describe('inspectCodexMcpToml', () => {
+  it('reports a missing file without servers', () => {
+    expect(inspectCodexMcpToml(candidate, null)).toEqual({
+      candidate,
+      exists: false,
+      status: 'missing',
+      servers: []
+    })
+  })
+
+  it('reads stdio and http servers, quoted names, disabled flags and comments', () => {
+    const toml = [
+      'model = "gpt-5" # unrelated top-level key',
+      '',
+      '[mcp_servers.linear]',
+      'command = "npx"',
+      'args = ["-y", "@linear/mcp"] # inline comment',
+      '',
+      '[mcp_servers."my server"]',
+      "url = 'https://example.test/mcp#frag'",
+      'enabled = false',
+      '',
+      '[projects."/some/path"]',
+      'command = "should-not-leak"',
+      ''
+    ].join('\r\n')
+    const result = inspectCodexMcpToml(candidate, toml)
+    expect(result.status).toBe('valid')
+    expect(result.servers).toEqual([
+      expect.objectContaining({
+        name: 'linear',
+        transport: 'stdio',
+        status: 'enabled',
+        command: 'npx'
+      }),
+      expect.objectContaining({
+        name: 'my server',
+        transport: 'http',
+        status: 'disabled',
+        url: 'https://example.test/mcp#frag'
+      })
+    ])
+  })
+
+  it('keeps reading after multi-line arrays and env sub-tables', () => {
+    const toml = [
+      '[mcp_servers.gh]',
+      'command = "docker"',
+      'args = [',
+      '  "run",',
+      '  "-i", # keep stdin',
+      '  "ghcr.io/github/github-mcp-server"',
+      ']',
+      '',
+      '[mcp_servers.gh.env]',
+      'GITHUB_TOKEN = "ghp_123456789012345678"',
+      '',
+      '[mcp_servers.second]',
+      'command = "uvx"',
+      'args = ["thing"]',
+      ''
+    ].join('\n')
+    const result = inspectCodexMcpToml(candidate, toml)
+    expect(result.servers.map((server) => [server.name, server.status])).toEqual([
+      ['gh', 'enabled'],
+      ['second', 'enabled']
+    ])
+    expect(result.servers[0].env).toEqual({ GITHUB_TOKEN: expect.not.stringContaining('123456') })
+  })
+
+  it('marks a table without command or url as invalid rather than dropping it', () => {
+    const result = inspectCodexMcpToml(candidate, '[mcp_servers.broken]\nenabled = true\n')
+    expect(result.servers).toEqual([expect.objectContaining({ name: 'broken', status: 'invalid' })])
+  })
+})

--- a/src/main/agent-context/codex-mcp-toml.ts
+++ b/src/main/agent-context/codex-mcp-toml.ts
@@ -5,30 +5,64 @@ import type {
 } from '../../shared/mcp-config'
 import { summarizeMcpServer } from '../../shared/mcp-server-inspection'
 
-// Why: `[mcp_servers.<name>]` tables with a handful of scalar keys are the whole
-// surface Codex uses; a full TOML parser is not in the tree, so read exactly that.
-const TABLE_HEADER =
-  /^\s*\[\s*mcp_servers\s*\.\s*(?:"([^"]+)"|'([^']+)'|([A-Za-z0-9_-]+))\s*\]\s*(?:#.*)?$/
-const OTHER_TABLE_HEADER = /^\s*\[\[?[^\]]*\]\]?\s*(?:#.*)?$/
-const SCALAR = /^\s*([A-Za-z0-9_-]+)\s*=\s*(.+?)\s*$/
+// Why: `[mcp_servers.<name>]` tables with scalar keys, an args array and an
+// optional `env` sub-table are the whole surface Codex uses; a full TOML
+// parser is not in the tree, so read exactly that.
+const SERVER_TABLE_HEADER =
+  /^\s*\[\s*mcp_servers\s*\.\s*(?:"([^"]+)"|'([^']+)'|([A-Za-z0-9_-]+))\s*(?:\.\s*([A-Za-z0-9_.-]+)\s*)?\]\s*(?:#.*)?$/
+const ANY_TABLE_HEADER = /^\s*\[\[?[^\]]*\]\]?\s*(?:#.*)?$/
+const KEY_VALUE = /^\s*(?:"([^"]+)"|'([^']+)'|([A-Za-z0-9_-]+))\s*=\s*(.+?)\s*$/
 
-function parseScalar(raw: string): unknown {
-  const trimmed = raw.replace(/\s+#.*$/, '').trim()
-  if (/^"(?:[^"\\]|\\.)*"$/.test(trimmed) || /^'[^']*'$/.test(trimmed)) {
-    return trimmed.slice(1, -1)
+function stripComment(raw: string): string {
+  let quote: string | null = null
+  for (let index = 0; index < raw.length; index += 1) {
+    const char = raw[index]
+    if (quote) {
+      if (char === '\\' && quote === '"') {
+        index += 1
+      } else if (char === quote) {
+        quote = null
+      }
+    } else if (char === '"' || char === "'") {
+      quote = char
+    } else if (char === '#') {
+      return raw.slice(0, index)
+    }
   }
+  return raw
+}
+
+function unquote(raw: string): string {
+  return /^"(?:[^"\\]|\\.)*"$/.test(raw) || /^'[^']*'$/.test(raw) ? raw.slice(1, -1) : raw
+}
+
+function parseValue(raw: string): unknown {
+  const trimmed = stripComment(raw).trim()
   if (trimmed === 'true' || trimmed === 'false') {
     return trimmed === 'true'
   }
-  if (/^\[.*\]$/.test(trimmed)) {
+  if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
     return trimmed
       .slice(1, -1)
       .split(',')
       .map((part) => part.trim())
       .filter(Boolean)
-      .map((part) => (/^["'].*["']$/.test(part) ? part.slice(1, -1) : part))
+      .map(unquote)
   }
-  return trimmed
+  return unquote(trimmed)
+}
+
+function bracketDepth(raw: string): number {
+  const stripped = stripComment(raw)
+  let depth = 0
+  for (const char of stripped) {
+    if (char === '[') {
+      depth += 1
+    } else if (char === ']') {
+      depth -= 1
+    }
+  }
+  return depth
 }
 
 /** Servers declared as `[mcp_servers.<name>]` tables in a Codex `config.toml`. */
@@ -41,25 +75,54 @@ export function inspectCodexMcpToml(
   }
   const tables = new Map<string, Record<string, unknown>>()
   let current: Record<string, unknown> | null = null
+  let pending: { key: string; value: string; depth: number } | null = null
   for (const line of content.split(/\r?\n/)) {
-    const header = TABLE_HEADER.exec(line)
-    if (header) {
-      const name = header[1] ?? header[2] ?? header[3] ?? ''
-      current = tables.get(name) ?? {}
-      tables.set(name, current)
+    if (pending) {
+      pending.value += ` ${line}`
+      pending.depth += bracketDepth(line)
+      if (pending.depth <= 0 && current) {
+        current[pending.key] = parseValue(pending.value)
+        pending = null
+      }
       continue
     }
-    if (OTHER_TABLE_HEADER.test(line)) {
+    const header = SERVER_TABLE_HEADER.exec(line)
+    if (header) {
+      const name = header[1] ?? header[2] ?? header[3] ?? ''
+      const server = tables.get(name) ?? {}
+      tables.set(name, server)
+      // Why: `[mcp_servers.x.env]` is the server's env table; deeper or other
+      // sub-tables have no summary meaning, so their keys are skipped.
+      if (header[4] === undefined) {
+        current = server
+      } else if (header[4] === 'env') {
+        const env = (server.env as Record<string, unknown> | undefined) ?? {}
+        server.env = env
+        current = env
+      } else {
+        current = null
+      }
+      continue
+    }
+    if (ANY_TABLE_HEADER.test(line)) {
       current = null
       continue
     }
     if (!current) {
       continue
     }
-    const scalar = SCALAR.exec(line)
-    if (scalar) {
-      current[scalar[1]] = parseScalar(scalar[2])
+    const keyValue = KEY_VALUE.exec(line)
+    if (!keyValue) {
+      continue
     }
+    const key = keyValue[1] ?? keyValue[2] ?? keyValue[3] ?? ''
+    const rawValue = keyValue[4]
+    const depth = bracketDepth(rawValue)
+    if (depth > 0) {
+      pending = { key, value: rawValue, depth }
+      continue
+    }
+    current[key] = parseValue(rawValue)
   }
   const servers: McpServerSummary[] = [...tables.entries()].map(([name, entry]) =>
     summarizeMcpServer(name, entry)

--- a/src/main/agent-context/codex-mcp-toml.ts
+++ b/src/main/agent-context/codex-mcp-toml.ts
@@ -1,0 +1,68 @@
+import type {
+  McpConfigCandidate,
+  McpConfigInspection,
+  McpServerSummary
+} from '../../shared/mcp-config'
+import { summarizeMcpServer } from '../../shared/mcp-server-inspection'
+
+// Why: `[mcp_servers.<name>]` tables with a handful of scalar keys are the whole
+// surface Codex uses; a full TOML parser is not in the tree, so read exactly that.
+const TABLE_HEADER =
+  /^\s*\[\s*mcp_servers\s*\.\s*(?:"([^"]+)"|'([^']+)'|([A-Za-z0-9_-]+))\s*\]\s*(?:#.*)?$/
+const OTHER_TABLE_HEADER = /^\s*\[\[?[^\]]*\]\]?\s*(?:#.*)?$/
+const SCALAR = /^\s*([A-Za-z0-9_-]+)\s*=\s*(.+?)\s*$/
+
+function parseScalar(raw: string): unknown {
+  const trimmed = raw.replace(/\s+#.*$/, '').trim()
+  if (/^"(?:[^"\\]|\\.)*"$/.test(trimmed) || /^'[^']*'$/.test(trimmed)) {
+    return trimmed.slice(1, -1)
+  }
+  if (trimmed === 'true' || trimmed === 'false') {
+    return trimmed === 'true'
+  }
+  if (/^\[.*\]$/.test(trimmed)) {
+    return trimmed
+      .slice(1, -1)
+      .split(',')
+      .map((part) => part.trim())
+      .filter(Boolean)
+      .map((part) => (/^["'].*["']$/.test(part) ? part.slice(1, -1) : part))
+  }
+  return trimmed
+}
+
+/** Servers declared as `[mcp_servers.<name>]` tables in a Codex `config.toml`. */
+export function inspectCodexMcpToml(
+  candidate: McpConfigCandidate,
+  content: string | null
+): McpConfigInspection {
+  if (content === null) {
+    return { candidate, exists: false, status: 'missing', servers: [] }
+  }
+  const tables = new Map<string, Record<string, unknown>>()
+  let current: Record<string, unknown> | null = null
+  for (const line of content.split(/\r?\n/)) {
+    const header = TABLE_HEADER.exec(line)
+    if (header) {
+      const name = header[1] ?? header[2] ?? header[3] ?? ''
+      current = tables.get(name) ?? {}
+      tables.set(name, current)
+      continue
+    }
+    if (OTHER_TABLE_HEADER.test(line)) {
+      current = null
+      continue
+    }
+    if (!current) {
+      continue
+    }
+    const scalar = SCALAR.exec(line)
+    if (scalar) {
+      current[scalar[1]] = parseScalar(scalar[2])
+    }
+  }
+  const servers: McpServerSummary[] = [...tables.entries()].map(([name, entry]) =>
+    summarizeMcpServer(name, entry)
+  )
+  return { candidate, exists: true, status: 'valid', servers }
+}

--- a/src/main/agent-context/json-mcp-file.ts
+++ b/src/main/agent-context/json-mcp-file.ts
@@ -1,0 +1,84 @@
+import { inspectMcpConfigContent, type McpConfigInspection } from '../../shared/mcp-config'
+import { isMcpConfigInspectionTextWithinLimit } from '../../shared/mcp-config-inspection-limits'
+import type { McpFileSource } from './agent-config-file-sources'
+
+function pluckObject(value: unknown, pathSegments: readonly string[]): unknown {
+  let current = value
+  for (const segment of pathSegments) {
+    if (!current || typeof current !== 'object' || Array.isArray(current)) {
+      return undefined
+    }
+    current = (current as Record<string, unknown>)[segment]
+  }
+  return current
+}
+
+function setObject(
+  target: Record<string, unknown>,
+  pathSegments: readonly string[],
+  value: unknown
+): void {
+  let current = target
+  pathSegments.slice(0, -1).forEach((segment) => {
+    const next = current[segment]
+    if (!next || typeof next !== 'object') {
+      current[segment] = {}
+    }
+    current = current[segment] as Record<string, unknown>
+  })
+  current[pathSegments.at(-1) as string] = value
+}
+
+/**
+ * `~/.claude.json` is Claude's whole client state — project histories, caches,
+ * onboarding flags — and routinely outgrows the shared MCP text limit. Only the
+ * server objects are inspected, so keep just those and let the shared limits
+ * judge what is actually a server collection.
+ */
+function narrowToServerPaths(content: string, paths: readonly (readonly string[])[]): string {
+  if (isMcpConfigInspectionTextWithinLimit(content)) {
+    return content
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(content)
+  } catch {
+    return content
+  }
+  const narrowed: Record<string, unknown> = {}
+  for (const serversPath of paths) {
+    const value = pluckObject(parsed, serversPath)
+    if (value !== undefined) {
+      setObject(narrowed, serversPath, value)
+    }
+  }
+  return JSON.stringify(narrowed)
+}
+
+/**
+ * Merges servers from every configured object path. Later paths are the more
+ * specific ones (Claude's project-local scope), and a name that appears in a
+ * more specific scope shadows the broader one — the same rule Claude applies.
+ */
+export function inspectJsonMcpFile(
+  source: McpFileSource,
+  content: string | null
+): McpConfigInspection {
+  const extraPaths = source.extraServersPaths ?? []
+  const narrowed =
+    content === null
+      ? null
+      : narrowToServerPaths(content, [source.candidate.serversPath, ...extraPaths])
+  const primary = inspectMcpConfigContent(source.candidate, narrowed)
+  if (extraPaths.length === 0 || primary.status !== 'valid') {
+    return primary
+  }
+  const byName = new Map(primary.servers.map((server) => [server.name, server]))
+  for (const serversPath of extraPaths) {
+    const extra = inspectMcpConfigContent({ ...source.candidate, serversPath }, narrowed)
+    for (const server of extra.servers) {
+      byName.set(server.name, server)
+    }
+  }
+  return { ...primary, servers: [...byName.values()] }
+}

--- a/src/main/ipc/agent-context.ts
+++ b/src/main/ipc/agent-context.ts
@@ -1,0 +1,15 @@
+import { ipcMain } from 'electron'
+import type { AgentContextInspectTarget, AgentContextReport } from '../../shared/agent-context'
+import { SkillDiscoveryTargetSchema } from '../../shared/skills'
+import { inspectAgentContextOnTarget } from '../agent-context/agent-context-target'
+import { resolveSkillDiscoveryTarget } from '../skills/skill-discovery-target'
+
+export function registerAgentContextHandlers(): void {
+  ipcMain.handle(
+    'agentContext:inspect',
+    async (_event, target?: AgentContextInspectTarget): Promise<AgentContextReport> => {
+      const parsedTarget = target ? SkillDiscoveryTargetSchema.parse(target) : undefined
+      return inspectAgentContextOnTarget(resolveSkillDiscoveryTarget(parsedTarget))
+    }
+  )
+}

--- a/src/main/ipc/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers.test.ts
@@ -226,6 +226,10 @@ vi.mock('./skills', () => ({
   registerSkillsHandlers: registerSkillsHandlersMock
 }))
 
+vi.mock('./agent-context', () => ({
+  registerAgentContextHandlers: vi.fn()
+}))
+
 vi.mock('./workspace-space', () => ({
   registerWorkspaceSpaceHandlers: registerWorkspaceSpaceHandlersMock
 }))

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -39,6 +39,7 @@ import { registerSessionHandlers } from './session'
 import { registerSettingsHandlers } from './settings'
 import { registerDiagnosticsHandlers } from './diagnostics'
 import { registerSkillsHandlers } from './skills'
+import { registerAgentContextHandlers } from './agent-context'
 import { registerWorkspaceSpaceHandlers } from './workspace-space'
 import { registerWorkspacePortHandlers } from './workspace-ports'
 import { registerLocalhostWorktreeLabelHandlers } from './localhost-worktree-labels'
@@ -176,6 +177,7 @@ export function registerCoreHandlers(
   registerComputerUsePermissionHandlers()
   registerSettingsHandlers(store, agentAwakeService)
   registerSkillsHandlers(store)
+  registerAgentContextHandlers()
   if (automations) {
     registerAutomationHandlers(store, automations)
   }

--- a/src/main/persistence-right-sidebar-tab.test.ts
+++ b/src/main/persistence-right-sidebar-tab.test.ts
@@ -16,12 +16,18 @@ vi.mock('electron', () => ({
 import { normalizeRightSidebarTab } from './persistence'
 
 describe('normalizeRightSidebarTab', () => {
-  it.each(['explorer', 'search', 'vault', 'workspaces', 'source-control', 'checks', 'ports'])(
-    'preserves the built-in %s tab',
-    (tab) => {
-      expect(normalizeRightSidebarTab(tab)).toBe(tab)
-    }
-  )
+  it.each([
+    'explorer',
+    'search',
+    'vault',
+    'workspaces',
+    'source-control',
+    'checks',
+    'ports',
+    'agent-context'
+  ])('preserves the built-in %s tab', (tab) => {
+    expect(normalizeRightSidebarTab(tab)).toBe(tab)
+  })
 
   // Regression: pr-checks was missing from the allow-list, so the folder
   // PR Checks tab silently reset to Explorer on every app restart.

--- a/src/main/persistence/applying-settings/ui-selection-normalization.ts
+++ b/src/main/persistence/applying-settings/ui-selection-normalization.ts
@@ -68,7 +68,8 @@ export function normalizeRightSidebarTab(tab: unknown): PersistedState['ui']['ri
     tab === 'pr-checks' ||
     tab === 'source-control' ||
     tab === 'checks' ||
-    tab === 'ports'
+    tab === 'ports' ||
+    tab === 'agent-context'
   ) {
     return tab
   }

--- a/src/main/runtime/rpc/methods/agent-context.test.ts
+++ b/src/main/runtime/rpc/methods/agent-context.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { RpcContext } from '../core'
+
+vi.mock('../../../skills/skill-discovery-target', () => ({
+  resolveSkillDiscoveryTarget: vi.fn((target) => ({ kind: 'native-host', cwd: target?.cwd }))
+}))
+vi.mock('../../../agent-context/agent-context-target', () => ({
+  inspectAgentContextOnTarget: vi.fn(async (resolved) => ({
+    target: { kind: 'native-host', homeDir: '/home/u', cwd: resolved.cwd ?? null },
+    instructionFiles: [],
+    mcpFiles: [],
+    hookFiles: [],
+    plugins: [],
+    scannedAt: 1
+  }))
+}))
+
+import { AGENT_CONTEXT_METHODS } from './agent-context'
+import { inspectAgentContextOnTarget } from '../../../agent-context/agent-context-target'
+import { resolveSkillDiscoveryTarget } from '../../../skills/skill-discovery-target'
+
+const WSL_RUNTIME = {
+  status: 'resolved',
+  runtime: {
+    kind: 'wsl',
+    hostPlatform: 'wsl',
+    projectId: 'project-1',
+    distro: 'Ubuntu',
+    reason: 'project-override',
+    cacheKey: 'wsl:Ubuntu'
+  }
+} as const
+
+function makeContext(
+  resolveProjectRuntimeForWorktree: (worktreeId: string | null | undefined) => unknown = () =>
+    undefined
+): RpcContext {
+  return { runtime: { resolveProjectRuntimeForWorktree } } as unknown as RpcContext
+}
+
+function inspectMethod() {
+  const method = AGENT_CONTEXT_METHODS.find((entry) => entry.name === 'agentContext.inspect')
+  if (!method) {
+    throw new Error('agentContext.inspect method not registered')
+  }
+  return method
+}
+
+describe('agentContext.inspect RPC', () => {
+  it('resolves the same host skill discovery would, from the executing runtime', async () => {
+    const resolveProjectRuntimeForWorktree = vi.fn(() => WSL_RUNTIME)
+    const report = await inspectMethod().handler(
+      { cwd: '/home/u/repo', worktreeId: 'worktree-1' },
+      makeContext(resolveProjectRuntimeForWorktree)
+    )
+    expect(resolveProjectRuntimeForWorktree).toHaveBeenCalledWith('worktree-1')
+    expect(vi.mocked(resolveSkillDiscoveryTarget)).toHaveBeenLastCalledWith(
+      expect.objectContaining({ cwd: '/home/u/repo', projectRuntime: WSL_RUNTIME })
+    )
+    expect(vi.mocked(inspectAgentContextOnTarget)).toHaveBeenLastCalledWith(
+      expect.objectContaining({ cwd: '/home/u/repo' })
+    )
+    expect(report).toMatchObject({ target: { cwd: '/home/u/repo' } })
+  })
+
+  it('keeps a caller-supplied project runtime', async () => {
+    const resolveProjectRuntimeForWorktree = vi.fn()
+    await inspectMethod().handler(
+      { cwd: '/repo', worktreeId: 'worktree-1', projectRuntime: WSL_RUNTIME },
+      makeContext(resolveProjectRuntimeForWorktree)
+    )
+    expect(resolveProjectRuntimeForWorktree).not.toHaveBeenCalled()
+  })
+
+  it('accepts an empty params payload', () => {
+    expect(inspectMethod().params?.parse(undefined)).toEqual({})
+  })
+})

--- a/src/main/runtime/rpc/methods/agent-context.ts
+++ b/src/main/runtime/rpc/methods/agent-context.ts
@@ -1,0 +1,22 @@
+import { defineMethod, type RpcMethod } from '../core'
+import { SkillDiscoveryTargetSchema } from '../../../../shared/skills'
+import { inspectAgentContextOnTarget } from '../../../agent-context/agent-context-target'
+import { resolveSkillDiscoveryTarget } from '../../../skills/skill-discovery-target'
+
+export const AGENT_CONTEXT_METHODS: RpcMethod[] = [
+  defineMethod({
+    name: 'agentContext.inspect',
+    params: SkillDiscoveryTargetSchema.default({}),
+    handler: async (params, { runtime }) => {
+      // Why: mirrors skills.discover — the executing runtime owns WSL project
+      // preferences, so a remote caller sends worktree identity only.
+      const target = params.projectRuntime
+        ? params
+        : {
+            ...params,
+            projectRuntime: runtime.resolveProjectRuntimeForWorktree(params.worktreeId)
+          }
+      return inspectAgentContextOnTarget(resolveSkillDiscoveryTarget(target))
+    }
+  })
+]

--- a/src/main/runtime/rpc/methods/client-ui-schemas.ts
+++ b/src/main/runtime/rpc/methods/client-ui-schemas.ts
@@ -48,7 +48,8 @@ const STATIC_RIGHT_SIDEBAR_TABS = [
   'pr-checks',
   'source-control',
   'checks',
-  'ports'
+  'ports',
+  'agent-context'
 ] as const
 // Plugin panels are open-ended `plugin:<publisher>.<id>/<panel>` keys, so the
 // schema validates their shape rather than enumerating them.

--- a/src/main/runtime/rpc/methods/index.ts
+++ b/src/main/runtime/rpc/methods/index.ts
@@ -33,6 +33,7 @@ import { CLIENT_EVENT_METHODS } from './client-events'
 import { WORKSPACE_PORT_METHODS } from './workspace-ports'
 import { PLUGIN_METHODS } from './plugins'
 import { SKILL_METHODS } from './skills'
+import { AGENT_CONTEXT_METHODS } from './agent-context'
 import { CLIPBOARD_METHODS } from './clipboard'
 import { HOST_CAPABILITY_METHODS } from './host-capabilities'
 import { EMULATOR_METHODS } from './emulator'
@@ -79,6 +80,7 @@ export const ALL_RPC_METHODS: readonly RpcAnyMethod[] = [
   ...WORKSPACE_PORT_METHODS,
   ...PLUGIN_METHODS,
   ...SKILL_METHODS,
+  ...AGENT_CONTEXT_METHODS,
   ...CLIPBOARD_METHODS,
   ...HOST_CAPABILITY_METHODS,
   ...CLIENT_EVENT_METHODS,

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -8,6 +8,7 @@ import type {
 } from './api/agent-account-api'
 import type { AgentHooksApi, HooksApi } from './api/agent-hook-api'
 import type { SkillsApi } from './api/agent-skill-api'
+import type { AgentContextApi } from './api/agent-context-api'
 import type { AgentAwakeApi, AgentStatusApi, AgentTrustApi } from './api/agent-status-api'
 import type {
   ClaudeUsageApi,
@@ -115,6 +116,7 @@ export type PreloadApi = {
   computerUsePermissions: ComputerUsePermissionsApi
   shell: ShellApi
   skills: SkillsApi
+  agentContext: AgentContextApi
   pet: PetApi
   browser: BrowserApi
   emulator: EmulatorApi

--- a/src/preload/api/agent-context-api.ts
+++ b/src/preload/api/agent-context-api.ts
@@ -1,0 +1,5 @@
+import type { AgentContextInspectTarget, AgentContextReport } from '../../shared/agent-context'
+
+export type AgentContextApi = {
+  inspect: (target?: AgentContextInspectTarget) => Promise<AgentContextReport>
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -131,6 +131,7 @@ import type {
   ShellOpenLocalPathResult
 } from '../shared/shell-open-types'
 import type { SkillDiscoveryResult, SkillDiscoveryTarget } from '../shared/skills'
+import type { AgentContextInspectTarget, AgentContextReport } from '../shared/agent-context'
 import type {
   SkillFreshnessInventory,
   SkillUpdateRun,
@@ -2548,6 +2549,11 @@ const api = {
       ipcRenderer.on('skills:updateRun', listener)
       return () => ipcRenderer.removeListener('skills:updateRun', listener)
     }
+  },
+
+  agentContext: {
+    inspect: (target?: AgentContextInspectTarget): Promise<AgentContextReport> =>
+      ipcRenderer.invoke('agentContext:inspect', target)
   },
 
   pet: {

--- a/src/renderer/src/components/right-sidebar/AiVaultPanelControls.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultPanelControls.tsx
@@ -37,15 +37,13 @@ import { translate } from '@/i18n/i18n'
 import type { AiVaultHostScopeOption } from './ai-vault-host-scope'
 import { AiVaultSessionLimitMenu } from './AiVaultSessionLimitMenu'
 import {
+  SIDEBAR_AGENT_BULK_ACTION_CLASS,
   SIDEBAR_SCOPE_TOGGLE_GROUP_CLASS,
   SIDEBAR_SCOPE_TOGGLE_ITEM_CLASS
 } from './sidebar-scope-toggle'
 import type { AiVaultSessionLimit } from './ai-vault-session-limit'
 
 const VAULT_HEADER_CONTROL_CLASS = 'size-6 shrink-0'
-
-const AGENT_BULK_ACTION_CLASS =
-  'rounded-full px-2 py-0.5 text-[11px] font-normal text-muted-foreground focus:text-foreground'
 
 const VAULT_SCOPE_TOGGLE_ITEM_CLASS = `${SIDEBAR_SCOPE_TOGGLE_ITEM_CLASS} @max-[300px]/ai-vault:px-1.5`
 
@@ -283,7 +281,7 @@ export function VaultViewMenu({
                 event.preventDefault()
                 onAllAgentsEnabledChange(true)
               }}
-              className={AGENT_BULK_ACTION_CLASS}
+              className={SIDEBAR_AGENT_BULK_ACTION_CLASS}
             >
               {translate(
                 'auto.components.right.sidebar.AiVaultPanelControls.selectAllAgents',
@@ -296,7 +294,7 @@ export function VaultViewMenu({
                 event.preventDefault()
                 onAllAgentsEnabledChange(false)
               }}
-              className={AGENT_BULK_ACTION_CLASS}
+              className={SIDEBAR_AGENT_BULK_ACTION_CLASS}
             >
               {translate('auto.components.right.sidebar.AiVaultPanelControls.clearAgents', 'Clear')}
             </DropdownMenuItem>

--- a/src/renderer/src/components/right-sidebar/AiVaultPanelControls.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultPanelControls.tsx
@@ -36,6 +36,10 @@ import { agentLabel, type AiVaultSessionGroup } from './ai-vault-session-filters
 import { translate } from '@/i18n/i18n'
 import type { AiVaultHostScopeOption } from './ai-vault-host-scope'
 import { AiVaultSessionLimitMenu } from './AiVaultSessionLimitMenu'
+import {
+  SIDEBAR_SCOPE_TOGGLE_GROUP_CLASS,
+  SIDEBAR_SCOPE_TOGGLE_ITEM_CLASS
+} from './sidebar-scope-toggle'
 import type { AiVaultSessionLimit } from './ai-vault-session-limit'
 
 const VAULT_HEADER_CONTROL_CLASS = 'size-6 shrink-0'
@@ -43,11 +47,7 @@ const VAULT_HEADER_CONTROL_CLASS = 'size-6 shrink-0'
 const AGENT_BULK_ACTION_CLASS =
   'rounded-full px-2 py-0.5 text-[11px] font-normal text-muted-foreground focus:text-foreground'
 
-// Why: match ToggleGroup's spacing+outline qualifiers so selected edges out-specify its border-l-0 collapse.
-const VAULT_SCOPE_SELECTED_EDGE_CLASS =
-  'data-[spacing=0]:data-[variant=outline]:aria-[checked=true]:border-l data-[spacing=0]:data-[variant=outline]:data-[state=on]:border-l'
-
-const VAULT_SCOPE_TOGGLE_ITEM_CLASS = `h-7 min-h-7 min-w-0 flex-1 basis-0 shrink border border-transparent bg-transparent px-2.5 text-[11px] font-medium leading-none text-foreground shadow-none hover:bg-sidebar-accent hover:text-sidebar-accent-foreground aria-[checked=true]:border-foreground/20 aria-[checked=true]:bg-foreground/10 aria-[checked=true]:text-foreground aria-[checked=true]:shadow-xs aria-[checked=true]:hover:bg-foreground/15 aria-[checked=true]:hover:text-foreground data-[state=on]:border-foreground/20 data-[state=on]:bg-foreground/10 data-[state=on]:text-foreground data-[state=on]:shadow-xs data-[state=on]:hover:bg-foreground/15 data-[state=on]:hover:text-foreground ${VAULT_SCOPE_SELECTED_EDGE_CLASS} @max-[300px]/ai-vault:px-1.5`
+const VAULT_SCOPE_TOGGLE_ITEM_CLASS = `${SIDEBAR_SCOPE_TOGGLE_ITEM_CLASS} @max-[300px]/ai-vault:px-1.5`
 
 export function VaultGroupHeader({
   group,
@@ -110,7 +110,7 @@ export function VaultScopeSwitch({
         }
       }}
       variant="outline"
-      className="h-7 w-full rounded-md border border-sidebar-border bg-sidebar-accent/35 shadow-xs"
+      className={SIDEBAR_SCOPE_TOGGLE_GROUP_CLASS}
       aria-label={translate(
         'auto.components.right.sidebar.AiVaultPanelControls.scopeAriaLabel',
         'Session History scope: {{value0}}',

--- a/src/renderer/src/components/right-sidebar/WorkspaceContextPanel.test.tsx
+++ b/src/renderer/src/components/right-sidebar/WorkspaceContextPanel.test.tsx
@@ -143,7 +143,7 @@ describe('WorkspaceContextPanel', () => {
 
   it('reveals checked-but-empty locations when toggled', () => {
     act(() => root.render(<WorkspaceContextPanel />))
-    const checkbox = container.querySelector('input[type="checkbox"]') as HTMLInputElement
+    const checkbox = container.querySelector('[role="checkbox"]') as HTMLButtonElement
     act(() => {
       checkbox.click()
     })

--- a/src/renderer/src/components/right-sidebar/WorkspaceContextPanel.test.tsx
+++ b/src/renderer/src/components/right-sidebar/WorkspaceContextPanel.test.tsx
@@ -242,7 +242,7 @@ describe('WorkspaceContextPanel', () => {
 
   it('filters to one section from the filter strip', () => {
     act(() => root.render(<WorkspaceContextPanel />))
-    const mcpTab = [...container.querySelectorAll('[role="tab"]')].find(
+    const mcpTab = [...container.querySelectorAll('[role="radio"]')].find(
       (el) => el.textContent === 'MCP'
     ) as HTMLButtonElement
     act(() => mcpTab.click())
@@ -424,7 +424,8 @@ describe('workspace-context-model', () => {
   it('splits the report between the workspace tree and the user home', () => {
     const full = report()
     const workspace = filterReportByScope(full, 'workspace')
-    expect(workspace?.instructionFiles.map((file) => file.scope)).toEqual(['project', 'project'])
+    expect(workspace?.instructionFiles.length).toBeGreaterThan(0)
+    expect(workspace?.instructionFiles.every((file) => file.scope !== 'home')).toBe(true)
     expect(workspace?.plugins).toHaveLength(0)
     const user = filterReportByScope(full, 'user')
     expect(user?.instructionFiles.map((file) => file.id)).toEqual(['home-claude-md'])

--- a/src/renderer/src/components/right-sidebar/WorkspaceContextPanel.test.tsx
+++ b/src/renderer/src/components/right-sidebar/WorkspaceContextPanel.test.tsx
@@ -1,0 +1,217 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AgentContextReport } from '../../../../shared/agent-context'
+import type { DiscoveredSkill } from '../../../../shared/skills'
+import { selectWorkspaceSkills, groupInstructionFiles } from './workspace-context-model'
+
+const testState = vi.hoisted(() => ({
+  worktree: null as null | { id: string; path: string; branch: string },
+  context: {
+    report: null as AgentContextReport | null,
+    loading: false,
+    error: null as string | null,
+    skills: [] as DiscoveredSkill[],
+    skillsLoading: false,
+    refresh: () => {}
+  },
+  openFile: [] as { filePath: string; relativePath: string }[]
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: <T,>(selector: (state: { openFile: (file: unknown) => void }) => T): T =>
+    selector({
+      openFile: (file) => {
+        testState.openFile.push(file as { filePath: string; relativePath: string })
+      }
+    })
+}))
+vi.mock('@/store/selectors', () => ({ useActiveWorktree: () => testState.worktree }))
+vi.mock('./use-workspace-agent-context', () => ({
+  useWorkspaceAgentContext: () => ({
+    worktreeId: testState.worktree?.id ?? null,
+    worktreePath: testState.worktree?.path ?? null,
+    ...testState.context
+  })
+}))
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string, values?: Record<string, unknown>) =>
+    values ? fallback.replace('{{value0}}', String(values.value0)) : fallback
+}))
+
+import WorkspaceContextPanel from './WorkspaceContextPanel'
+
+function report(overrides: Partial<AgentContextReport> = {}): AgentContextReport {
+  return {
+    target: { kind: 'native-host', homeDir: '/home/u', cwd: '/home/u/repo' },
+    instructionFiles: [
+      {
+        id: 'home-claude-md',
+        label: 'CLAUDE.md',
+        path: '/home/u/.claude/CLAUDE.md',
+        scope: 'home',
+        agents: ['claude'],
+        exists: true,
+        sizeBytes: 120,
+        updatedAt: 1
+      },
+      {
+        id: 'project-claude-md',
+        label: 'CLAUDE.md',
+        path: '/home/u/repo/CLAUDE.md',
+        scope: 'project',
+        agents: ['claude'],
+        exists: true,
+        sizeBytes: 2048,
+        updatedAt: 1
+      },
+      {
+        id: 'project-gemini-md',
+        label: 'GEMINI.md',
+        path: '/home/u/repo/GEMINI.md',
+        scope: 'project',
+        agents: ['gemini'],
+        exists: false,
+        sizeBytes: null,
+        updatedAt: null
+      }
+    ],
+    mcpFiles: [
+      {
+        id: 'project-mcp:.mcp.json',
+        path: '/home/u/repo/.mcp.json',
+        scope: 'project',
+        agents: ['claude'],
+        inspection: {
+          candidate: {
+            format: 'workspace',
+            label: 'Workspace',
+            relativePath: '.mcp.json',
+            serversPath: ['mcpServers']
+          },
+          exists: true,
+          status: 'valid',
+          servers: [{ name: 'linear', transport: 'stdio', status: 'enabled', command: 'npx' }]
+        }
+      }
+    ],
+    hookFiles: [],
+    plugins: [
+      {
+        id: 'p1',
+        name: 'adhd@local',
+        agents: ['claude'],
+        enabled: true,
+        sourcePath: '/home/u/.claude/settings.json',
+        scope: 'home'
+      }
+    ],
+    scannedAt: 1,
+    ...overrides
+  }
+}
+
+describe('WorkspaceContextPanel', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    testState.worktree = { id: 'wt-1', path: '/home/u/repo', branch: 'main' }
+    testState.context.report = report()
+    testState.openFile = []
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  it('lists present instruction files and hides missing ones by default', () => {
+    act(() => root.render(<WorkspaceContextPanel />))
+    const text = container.textContent ?? ''
+    expect(text).toContain('/home/u/repo/CLAUDE.md')
+    expect(text).toContain('2.0 KB')
+    expect(text).not.toContain('GEMINI.md')
+    expect(text).toContain('linear')
+    expect(text).toContain('Agent context')
+  })
+
+  it('reveals checked-but-empty locations when toggled', () => {
+    act(() => root.render(<WorkspaceContextPanel />))
+    const checkbox = container.querySelector('input[type="checkbox"]') as HTMLInputElement
+    act(() => {
+      checkbox.click()
+    })
+    expect(container.textContent).toContain('GEMINI.md')
+    expect(container.textContent).toContain('not found')
+  })
+
+  it('opens a workspace-scoped instruction file in the editor on click', () => {
+    act(() => root.render(<WorkspaceContextPanel />))
+    const button = [...container.querySelectorAll('button')].find((el) =>
+      el.textContent?.includes('/home/u/repo/CLAUDE.md')
+    )
+    expect(button).toBeDefined()
+    act(() => button?.click())
+    expect(testState.openFile).toEqual([
+      expect.objectContaining({ relativePath: 'CLAUDE.md', filePath: '/home/u/repo/CLAUDE.md' })
+    ])
+  })
+
+  it('shows the empty state without an active worktree', () => {
+    testState.worktree = null
+    act(() => root.render(<WorkspaceContextPanel />))
+    expect(container.textContent).toContain('Select a workspace')
+  })
+})
+
+describe('workspace-context-model', () => {
+  it('keeps global skills and only repo skills rooted in the workspace', () => {
+    const skill = (id: string, sourceKind: DiscoveredSkill['sourceKind'], rootPath: string) =>
+      ({
+        id,
+        name: id,
+        description: null,
+        providers: ['claude'],
+        sourceKind,
+        sourceLabel: '',
+        rootPath,
+        directoryPath: rootPath,
+        skillFilePath: `${rootPath}/SKILL.md`,
+        installed: true,
+        updatedAt: null
+      }) satisfies DiscoveredSkill
+    const selected = selectWorkspaceSkills(
+      [
+        skill('home', 'home', '/home/u/.claude/skills'),
+        skill('mine', 'repo', '/home/u/repo/.claude/skills'),
+        skill('other', 'repo', '/home/u/other-repo/.claude/skills'),
+        skill('win', 'repo', 'C:\\Users\\u\\Repo\\.claude\\skills')
+      ],
+      '/home/u/repo'
+    )
+    expect(selected.map((entry) => entry.id)).toEqual(['home', 'mine'])
+    expect(
+      selectWorkspaceSkills(
+        [skill('win', 'repo', 'C:\\Users\\u\\Repo\\.claude\\skills')],
+        'c:/users/u/repo'
+      ).map((entry) => entry.id)
+    ).toEqual(['win'])
+  })
+
+  it('groups instruction files by scope, project first, dropping missing unless asked', () => {
+    const files = report().instructionFiles
+    expect(
+      groupInstructionFiles(files, false).map((group) => [group.scope, group.files.length])
+    ).toEqual([
+      ['project', 1],
+      ['home', 1]
+    ])
+    expect(groupInstructionFiles(files, true).map((group) => group.files.length)).toEqual([2, 1])
+  })
+})

--- a/src/renderer/src/components/right-sidebar/WorkspaceContextPanel.test.tsx
+++ b/src/renderer/src/components/right-sidebar/WorkspaceContextPanel.test.tsx
@@ -4,8 +4,14 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AgentContextReport } from '../../../../shared/agent-context'
-import type { DiscoveredSkill } from '../../../../shared/skills'
-import { selectWorkspaceSkills, groupInstructionFiles } from './workspace-context-model'
+import type { DiscoveredSkill, SkillDiscoverySource } from '../../../../shared/skills'
+import {
+  agentsInContext,
+  filterReportByAgent,
+  groupInstructionFiles,
+  selectSkillsForAgent,
+  selectWorkspaceSkills
+} from './workspace-context-model'
 
 const testState = vi.hoisted(() => ({
   worktree: null as null | { id: string; path: string; branch: string },
@@ -14,6 +20,7 @@ const testState = vi.hoisted(() => ({
     loading: false,
     error: null as string | null,
     skills: [] as DiscoveredSkill[],
+    skillSources: [] as SkillDiscoverySource[],
     skillsLoading: false,
     refresh: () => {}
   },
@@ -35,6 +42,33 @@ vi.mock('./use-workspace-agent-context', () => ({
     worktreePath: testState.worktree?.path ?? null,
     ...testState.context
   })
+}))
+vi.mock('@/components/agent/AgentCombobox', () => ({
+  default: ({
+    value,
+    agents,
+    onValueChange
+  }: {
+    value: string | null
+    agents: { id: string }[]
+    onValueChange: (agent: string | null) => void
+  }) => (
+    <select
+      data-testid="agent-filter"
+      value={value ?? ''}
+      onChange={(event) => onValueChange(event.target.value || null)}
+    >
+      <option value="">All agents</option>
+      {agents.map((agent) => (
+        <option key={agent.id} value={agent.id}>
+          {agent.id}
+        </option>
+      ))}
+    </select>
+  )
+}))
+vi.mock('@/lib/agent-catalog', () => ({
+  AGENT_CATALOG: ['claude', 'codex', 'gemini', 'grok'].map((id) => ({ id, label: id }))
 }))
 vi.mock('@/i18n/i18n', () => ({
   translate: (_key: string, fallback: string, values?: Record<string, unknown>) =>
@@ -175,6 +209,23 @@ describe('WorkspaceContextPanel', () => {
     expect(text).not.toContain('adhd@local')
   })
 
+  it('offers only agents present in the workspace and narrows every section to the chosen one', () => {
+    act(() => root.render(<WorkspaceContextPanel />))
+    const select = container.querySelector('[data-testid="agent-filter"]') as HTMLSelectElement
+    expect([...select.options].map((option) => option.value)).toEqual(['', 'claude', 'gemini'])
+    act(() => {
+      select.value = 'gemini'
+      select.dispatchEvent(new Event('change', { bubbles: true }))
+    })
+    const checkbox = container.querySelector('[role="checkbox"]') as HTMLButtonElement
+    act(() => checkbox.click())
+    const text = container.textContent ?? ''
+    expect(text).toContain('GEMINI.md')
+    expect(text).not.toContain('/home/u/repo/CLAUDE.md')
+    expect(text).not.toContain('linear')
+    expect(text).not.toContain('adhd@local')
+  })
+
   it('shows the empty state without an active worktree', () => {
     testState.worktree = null
     act(() => root.render(<WorkspaceContextPanel />))
@@ -225,5 +276,82 @@ describe('workspace-context-model', () => {
       ['home', 1]
     ])
     expect(groupInstructionFiles(files, true).map((group) => group.files.length)).toEqual([2, 1])
+  })
+
+  it('narrows the report and skills to one agent', () => {
+    const full = report()
+    const claude = filterReportByAgent(full, 'claude')
+    expect(claude?.instructionFiles.map((file) => file.id)).toEqual([
+      'home-claude-md',
+      'project-claude-md'
+    ])
+    expect(claude?.mcpFiles).toHaveLength(1)
+    const gemini = filterReportByAgent(full, 'gemini')
+    expect(gemini?.instructionFiles.map((file) => file.id)).toEqual(['project-gemini-md'])
+    expect(gemini?.mcpFiles).toHaveLength(0)
+    expect(gemini?.plugins).toHaveLength(0)
+    expect(filterReportByAgent(full, null)).toBe(full)
+
+    const sources: SkillDiscoverySource[] = [
+      {
+        id: 'a',
+        label: 'Agent skills home',
+        path: '/h/.agents/skills',
+        sourceKind: 'home',
+        providers: ['agent-skills'],
+        owner: null,
+        exists: true
+      },
+      {
+        id: 'g',
+        label: 'Grok home',
+        path: '/h/.grok/skills',
+        sourceKind: 'home',
+        providers: ['agent-skills'],
+        owner: 'grok',
+        exists: true
+      },
+      {
+        id: 'c',
+        label: 'Claude home',
+        path: '/h/.claude/skills',
+        sourceKind: 'home',
+        providers: ['claude'],
+        owner: 'claude',
+        exists: true
+      }
+    ]
+    const skill = (id: string, rootPath: string, providers: DiscoveredSkill['providers']) =>
+      ({
+        id,
+        name: id,
+        description: null,
+        providers,
+        sourceKind: 'home',
+        sourceLabel: '',
+        rootPath,
+        directoryPath: rootPath,
+        skillFilePath: `${rootPath}/${id}/SKILL.md`,
+        installed: true,
+        updatedAt: null
+      }) satisfies DiscoveredSkill
+    const skills = [
+      skill('shared', '/h/.agents/skills', ['agent-skills']),
+      skill('grok-only', '/h/.grok/skills', ['agent-skills']),
+      skill('claude-only', '/h/.claude/skills', ['claude']),
+      skill('plugin', '/h/.claude/plugins/cache/x', ['claude'])
+    ]
+    expect(selectSkillsForAgent(skills, sources, 'grok').map((entry) => entry.id)).toEqual([
+      'shared',
+      'grok-only'
+    ])
+    expect(selectSkillsForAgent(skills, sources, 'claude').map((entry) => entry.id)).toEqual([
+      'shared',
+      'claude-only',
+      'plugin'
+    ])
+    expect(agentsInContext(full, skills, sources).sort()).toEqual(
+      ['claude', 'gemini', 'grok'].sort()
+    )
   })
 })

--- a/src/renderer/src/components/right-sidebar/WorkspaceContextPanel.test.tsx
+++ b/src/renderer/src/components/right-sidebar/WorkspaceContextPanel.test.tsx
@@ -15,9 +15,15 @@ import {
   selectWorkspaceSkills
 } from './workspace-context-model'
 
+;(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true
+
 const testState = vi.hoisted(() => ({
   worktree: null as null | { id: string; path: string; branch: string },
   context: {
+    hostId: 'local' as string,
+    unavailable: null as null | 'ssh' | 'runtime-unresolved',
     report: null as AgentContextReport | null,
     loading: false,
     error: null as string | null,
@@ -30,11 +36,17 @@ const testState = vi.hoisted(() => ({
 }))
 
 vi.mock('@/store', () => ({
-  useAppStore: <T,>(selector: (state: { openFile: (file: unknown) => void }) => T): T =>
+  useAppStore: <T,>(
+    selector: (state: {
+      openFile: (file: unknown) => void
+      runtimeEnvironments: { id: string; name: string }[]
+    }) => T
+  ): T =>
     selector({
       openFile: (file) => {
         testState.openFile.push(file as { filePath: string; relativePath: string })
-      }
+      },
+      runtimeEnvironments: [{ id: 'env-1', name: 'Build box' }]
     })
 }))
 vi.mock('@/store/selectors', () => ({ useActiveWorktree: () => testState.worktree }))
@@ -67,14 +79,14 @@ vi.mock('./workspace-context-controls', () => ({
   ),
   ContextViewMenu: ({
     agentOptions,
-    agents,
+    disabledAgents,
     showMissing,
     onAgentEnabledChange,
     onAllAgentsEnabledChange,
     onShowMissingChange
   }: {
     agentOptions: readonly string[]
-    agents: readonly string[] | null
+    disabledAgents: readonly string[]
     showMissing: boolean
     onAgentEnabledChange: (agent: string, enabled: boolean) => void
     onAllAgentsEnabledChange: (enabled: boolean) => void
@@ -86,8 +98,8 @@ vi.mock('./workspace-context-controls', () => ({
           key={agent}
           type="button"
           data-testid={`agent-${agent}`}
-          aria-pressed={agents === null || agents.includes(agent)}
-          onClick={() => onAgentEnabledChange(agent, !(agents === null || agents.includes(agent)))}
+          aria-pressed={!disabledAgents.includes(agent)}
+          onClick={() => onAgentEnabledChange(agent, disabledAgents.includes(agent))}
         >
           {agent}
         </button>
@@ -115,7 +127,9 @@ vi.mock('@/lib/agent-catalog', () => ({
 }))
 vi.mock('@/i18n/i18n', () => ({
   translate: (_key: string, fallback: string, values?: Record<string, unknown>) =>
-    values ? fallback.replace('{{value0}}', String(values.value0)) : fallback
+    values
+      ? fallback.replace(/\{\{(value\d)\}\}/g, (_match, name: string) => String(values[name]))
+      : fallback
 }))
 
 import WorkspaceContextPanel from './WorkspaceContextPanel'
@@ -153,6 +167,16 @@ function report(overrides: Partial<AgentContextReport> = {}): AgentContextReport
         exists: false,
         sizeBytes: null,
         updatedAt: null
+      },
+      {
+        id: 'home-gemini-md',
+        label: 'GEMINI.md',
+        path: '/home/u/.gemini/GEMINI.md',
+        scope: 'home',
+        agents: ['gemini'],
+        exists: true,
+        sizeBytes: 40,
+        updatedAt: 1
       }
     ],
     mcpFiles: [
@@ -199,8 +223,12 @@ describe('WorkspaceContextPanel', () => {
     document.body.appendChild(container)
     root = createRoot(container)
     testState.worktree = { id: 'wt-1', path: '/home/u/repo', branch: 'main' }
+    testState.context.hostId = 'local'
+    testState.context.unavailable = null
     testState.context.report = report()
     testState.openFile = []
+    // Why: view options persist across mounts on purpose; tests start clean.
+    window.localStorage.clear()
   })
 
   afterEach(() => {
@@ -213,9 +241,33 @@ describe('WorkspaceContextPanel', () => {
     const text = container.textContent ?? ''
     expect(text).toContain('/home/u/repo/CLAUDE.md')
     expect(text).toContain('2.0 KB')
-    expect(text).not.toContain('GEMINI.md')
+    expect(text).not.toContain('/home/u/repo/GEMINI.md')
     expect(text).toContain('linear')
     expect(text).toContain('Agent context')
+  })
+
+  it('names the host the report was read on', () => {
+    act(() => root.render(<WorkspaceContextPanel />))
+    expect(container.textContent).toContain('Local')
+    testState.context.report = report({
+      target: { kind: 'wsl', distro: 'Ubuntu', homeDir: '/home/u', cwd: '/home/u/repo' }
+    })
+    act(() => root.render(<WorkspaceContextPanel />))
+    expect(container.textContent).toContain('WSL Ubuntu')
+    testState.context.hostId = 'runtime:env-1'
+    act(() => root.render(<WorkspaceContextPanel />))
+    expect(container.textContent).toContain('Build box')
+  })
+
+  it('says why nothing is shown for SSH and unresolved-runtime workspaces', () => {
+    testState.context.unavailable = 'ssh'
+    testState.context.report = null
+    act(() => root.render(<WorkspaceContextPanel />))
+    expect(container.textContent).toContain('not available for SSH workspaces')
+    expect(container.textContent).not.toContain('No instruction files')
+    testState.context.unavailable = 'runtime-unresolved'
+    act(() => root.render(<WorkspaceContextPanel />))
+    expect(container.textContent).toContain('Waiting for the runtime')
   })
 
   it('reveals checked-but-empty locations when toggled', () => {
@@ -224,8 +276,28 @@ describe('WorkspaceContextPanel', () => {
     act(() => {
       toggle.click()
     })
-    expect(container.textContent).toContain('GEMINI.md')
+    expect(container.textContent).toContain('/home/u/repo/GEMINI.md')
     expect(container.textContent).toContain('not found')
+  })
+
+  it('keeps the view options across a remount', () => {
+    act(() => root.render(<WorkspaceContextPanel />))
+    act(() =>
+      (container.querySelector('[data-testid="show-missing"]') as HTMLButtonElement).click()
+    )
+    act(() =>
+      (container.querySelector('[data-testid="agent-claude"]') as HTMLButtonElement).click()
+    )
+    act(() => root.unmount())
+    root = createRoot(container)
+    act(() => root.render(<WorkspaceContextPanel />))
+    expect(container.textContent).toContain('/home/u/repo/GEMINI.md')
+    expect(container.textContent).not.toContain('/home/u/repo/CLAUDE.md')
+    expect(
+      (container.querySelector('[data-testid="agent-claude"]') as HTMLButtonElement).getAttribute(
+        'aria-pressed'
+      )
+    ).toBe('false')
   })
 
   it('opens a workspace-scoped instruction file in the editor on click', () => {
@@ -265,6 +337,24 @@ describe('WorkspaceContextPanel', () => {
     expect(text).not.toContain('/home/u/repo/CLAUDE.md')
     expect(text).not.toContain('linear')
     expect(text).not.toContain('adhd@local')
+    expect(text).toContain('Hidden by the current filter.')
+    expect(text).not.toContain('No MCP config files found.')
+  })
+
+  it('tells filtered-empty apart from truly empty when every agent is cleared', () => {
+    act(() => root.render(<WorkspaceContextPanel />))
+    act(() =>
+      (container.querySelector('[data-testid="agents-clear"]') as HTMLButtonElement).click()
+    )
+    const text = container.textContent ?? ''
+    expect(text).toContain('Hidden by the current filter.')
+    expect(text).not.toContain('No instruction files found')
+    const hooksTab = [...container.querySelectorAll('[role="radio"]')].find(
+      (el) => el.textContent === 'Hooks'
+    ) as HTMLButtonElement
+    act(() => hooksTab.click())
+    // Why: hooks were empty before any filter, so this stays the plain empty copy.
+    expect(container.textContent).toContain('No agent hooks configured.')
   })
 
   it('narrows to workspace-scoped rows with the scope switch', () => {
@@ -333,9 +423,9 @@ describe('workspace-context-model', () => {
       groupInstructionFiles(files, false).map((group) => [group.scope, group.files.length])
     ).toEqual([
       ['project', 1],
-      ['home', 1]
+      ['home', 2]
     ])
-    expect(groupInstructionFiles(files, true).map((group) => group.files.length)).toEqual([2, 1])
+    expect(groupInstructionFiles(files, true).map((group) => group.files.length)).toEqual([2, 2])
   })
 
   it('narrows the report and skills to the chosen agents', () => {
@@ -347,11 +437,14 @@ describe('workspace-context-model', () => {
     ])
     expect(claude?.mcpFiles).toHaveLength(1)
     const gemini = filterReportByAgents(full, ['gemini'])
-    expect(gemini?.instructionFiles.map((file) => file.id)).toEqual(['project-gemini-md'])
+    expect(gemini?.instructionFiles.map((file) => file.id)).toEqual([
+      'project-gemini-md',
+      'home-gemini-md'
+    ])
     expect(gemini?.mcpFiles).toHaveLength(0)
     expect(gemini?.plugins).toHaveLength(0)
     expect(filterReportByAgents(full, null)).toBe(full)
-    expect(filterReportByAgents(full, ['claude', 'gemini'])?.instructionFiles).toHaveLength(3)
+    expect(filterReportByAgents(full, ['claude', 'gemini'])?.instructionFiles).toHaveLength(4)
     expect(filterReportByAgents(full, [])?.instructionFiles).toHaveLength(0)
 
     const sources: SkillDiscoverySource[] = [
@@ -428,7 +521,10 @@ describe('workspace-context-model', () => {
     expect(workspace?.instructionFiles.every((file) => file.scope !== 'home')).toBe(true)
     expect(workspace?.plugins).toHaveLength(0)
     const user = filterReportByScope(full, 'user')
-    expect(user?.instructionFiles.map((file) => file.id)).toEqual(['home-claude-md'])
+    expect(user?.instructionFiles.map((file) => file.id)).toEqual([
+      'home-claude-md',
+      'home-gemini-md'
+    ])
     expect(user?.mcpFiles).toHaveLength(0)
     expect(filterReportByScope(full, 'all')).toBe(full)
   })

--- a/src/renderer/src/components/right-sidebar/WorkspaceContextPanel.test.tsx
+++ b/src/renderer/src/components/right-sidebar/WorkspaceContextPanel.test.tsx
@@ -7,9 +7,11 @@ import type { AgentContextReport } from '../../../../shared/agent-context'
 import type { DiscoveredSkill, SkillDiscoverySource } from '../../../../shared/skills'
 import {
   agentsInContext,
-  filterReportByAgent,
+  filterReportByAgents,
+  filterReportByScope,
   groupInstructionFiles,
-  selectSkillsForAgent,
+  selectSkillsForAgents,
+  selectSkillsForScope,
   selectWorkspaceSkills
 } from './workspace-context-model'
 
@@ -43,28 +45,69 @@ vi.mock('./use-workspace-agent-context', () => ({
     ...testState.context
   })
 }))
-vi.mock('@/components/agent/AgentCombobox', () => ({
-  default: ({
-    value,
-    agents,
-    onValueChange
+// Why: Radix menus and toggle groups need pointer/layout APIs happy-dom lacks;
+// the panel test drives the same props through plain controls.
+vi.mock('./workspace-context-controls', () => ({
+  ContextScopeSwitch: ({
+    scope,
+    onScopeChange
   }: {
-    value: string | null
-    agents: { id: string }[]
-    onValueChange: (agent: string | null) => void
+    scope: string
+    onScopeChange: (scope: 'workspace' | 'user' | 'all') => void
   }) => (
     <select
-      data-testid="agent-filter"
-      value={value ?? ''}
-      onChange={(event) => onValueChange(event.target.value || null)}
+      data-testid="scope"
+      value={scope}
+      onChange={(event) => onScopeChange(event.target.value as 'workspace' | 'user' | 'all')}
     >
-      <option value="">All agents</option>
-      {agents.map((agent) => (
-        <option key={agent.id} value={agent.id}>
-          {agent.id}
-        </option>
-      ))}
+      <option value="workspace">Workspace</option>
+      <option value="user">User</option>
+      <option value="all">All</option>
     </select>
+  ),
+  ContextViewMenu: ({
+    agentOptions,
+    agents,
+    showMissing,
+    onAgentEnabledChange,
+    onAllAgentsEnabledChange,
+    onShowMissingChange
+  }: {
+    agentOptions: readonly string[]
+    agents: readonly string[] | null
+    showMissing: boolean
+    onAgentEnabledChange: (agent: string, enabled: boolean) => void
+    onAllAgentsEnabledChange: (enabled: boolean) => void
+    onShowMissingChange: (showMissing: boolean) => void
+  }) => (
+    <div data-testid="view-menu">
+      {agentOptions.map((agent) => (
+        <button
+          key={agent}
+          type="button"
+          data-testid={`agent-${agent}`}
+          aria-pressed={agents === null || agents.includes(agent)}
+          onClick={() => onAgentEnabledChange(agent, !(agents === null || agents.includes(agent)))}
+        >
+          {agent}
+        </button>
+      ))}
+      <button
+        type="button"
+        data-testid="agents-clear"
+        onClick={() => onAllAgentsEnabledChange(false)}
+      >
+        clear
+      </button>
+      <button
+        type="button"
+        data-testid="show-missing"
+        aria-pressed={showMissing}
+        onClick={() => onShowMissingChange(!showMissing)}
+      >
+        missing
+      </button>
+    </div>
   )
 }))
 vi.mock('@/lib/agent-catalog', () => ({
@@ -177,9 +220,9 @@ describe('WorkspaceContextPanel', () => {
 
   it('reveals checked-but-empty locations when toggled', () => {
     act(() => root.render(<WorkspaceContextPanel />))
-    const checkbox = container.querySelector('[role="checkbox"]') as HTMLButtonElement
+    const toggle = container.querySelector('[data-testid="show-missing"]') as HTMLButtonElement
     act(() => {
-      checkbox.click()
+      toggle.click()
     })
     expect(container.textContent).toContain('GEMINI.md')
     expect(container.textContent).toContain('not found')
@@ -211,19 +254,36 @@ describe('WorkspaceContextPanel', () => {
 
   it('offers only agents present in the workspace and narrows every section to the chosen one', () => {
     act(() => root.render(<WorkspaceContextPanel />))
-    const select = container.querySelector('[data-testid="agent-filter"]') as HTMLSelectElement
-    expect([...select.options].map((option) => option.value)).toEqual(['', 'claude', 'gemini'])
-    act(() => {
-      select.value = 'gemini'
-      select.dispatchEvent(new Event('change', { bubbles: true }))
-    })
-    const checkbox = container.querySelector('[role="checkbox"]') as HTMLButtonElement
-    act(() => checkbox.click())
+    const menu = container.querySelector('[data-testid="view-menu"]') as HTMLElement
+    expect(
+      [...menu.querySelectorAll('[data-testid^="agent-"]')].map((el) => el.textContent)
+    ).toEqual(['claude', 'gemini'])
+    act(() => (menu.querySelector('[data-testid="agent-claude"]') as HTMLButtonElement).click())
+    act(() => (menu.querySelector('[data-testid="show-missing"]') as HTMLButtonElement).click())
     const text = container.textContent ?? ''
     expect(text).toContain('GEMINI.md')
     expect(text).not.toContain('/home/u/repo/CLAUDE.md')
     expect(text).not.toContain('linear')
     expect(text).not.toContain('adhd@local')
+  })
+
+  it('narrows to workspace-scoped rows with the scope switch', () => {
+    act(() => root.render(<WorkspaceContextPanel />))
+    const select = container.querySelector('[data-testid="scope"]') as HTMLSelectElement
+    act(() => {
+      select.value = 'workspace'
+      select.dispatchEvent(new Event('change', { bubbles: true }))
+    })
+    const text = container.textContent ?? ''
+    expect(text).toContain('/home/u/repo/CLAUDE.md')
+    expect(text).not.toContain('/home/u/.claude/CLAUDE.md')
+    expect(text).not.toContain('adhd@local')
+    act(() => {
+      select.value = 'user'
+      select.dispatchEvent(new Event('change', { bubbles: true }))
+    })
+    expect(container.textContent).toContain('/home/u/.claude/CLAUDE.md')
+    expect(container.textContent).not.toContain('linear')
   })
 
   it('shows the empty state without an active worktree', () => {
@@ -278,19 +338,21 @@ describe('workspace-context-model', () => {
     expect(groupInstructionFiles(files, true).map((group) => group.files.length)).toEqual([2, 1])
   })
 
-  it('narrows the report and skills to one agent', () => {
+  it('narrows the report and skills to the chosen agents', () => {
     const full = report()
-    const claude = filterReportByAgent(full, 'claude')
+    const claude = filterReportByAgents(full, ['claude'])
     expect(claude?.instructionFiles.map((file) => file.id)).toEqual([
       'home-claude-md',
       'project-claude-md'
     ])
     expect(claude?.mcpFiles).toHaveLength(1)
-    const gemini = filterReportByAgent(full, 'gemini')
+    const gemini = filterReportByAgents(full, ['gemini'])
     expect(gemini?.instructionFiles.map((file) => file.id)).toEqual(['project-gemini-md'])
     expect(gemini?.mcpFiles).toHaveLength(0)
     expect(gemini?.plugins).toHaveLength(0)
-    expect(filterReportByAgent(full, null)).toBe(full)
+    expect(filterReportByAgents(full, null)).toBe(full)
+    expect(filterReportByAgents(full, ['claude', 'gemini'])?.instructionFiles).toHaveLength(3)
+    expect(filterReportByAgents(full, [])?.instructionFiles).toHaveLength(0)
 
     const sources: SkillDiscoverySource[] = [
       {
@@ -341,11 +403,11 @@ describe('workspace-context-model', () => {
       skill('claude-only', '/h/.claude/skills', ['claude']),
       skill('plugin', '/h/.claude/plugins/cache/x', ['claude'])
     ]
-    expect(selectSkillsForAgent(skills, sources, 'grok').map((entry) => entry.id)).toEqual([
+    expect(selectSkillsForAgents(skills, sources, ['grok']).map((entry) => entry.id)).toEqual([
       'shared',
       'grok-only'
     ])
-    expect(selectSkillsForAgent(skills, sources, 'claude').map((entry) => entry.id)).toEqual([
+    expect(selectSkillsForAgents(skills, sources, ['claude']).map((entry) => entry.id)).toEqual([
       'shared',
       'claude-only',
       'plugin'
@@ -353,5 +415,20 @@ describe('workspace-context-model', () => {
     expect(agentsInContext(full, skills, sources).sort()).toEqual(
       ['claude', 'gemini', 'grok'].sort()
     )
+    expect(selectSkillsForScope(skills, 'user').map((entry) => entry.id)).toEqual(
+      skills.map((entry) => entry.id)
+    )
+    expect(selectSkillsForScope(skills, 'workspace')).toEqual([])
+  })
+
+  it('splits the report between the workspace tree and the user home', () => {
+    const full = report()
+    const workspace = filterReportByScope(full, 'workspace')
+    expect(workspace?.instructionFiles.map((file) => file.scope)).toEqual(['project', 'project'])
+    expect(workspace?.plugins).toHaveLength(0)
+    const user = filterReportByScope(full, 'user')
+    expect(user?.instructionFiles.map((file) => file.id)).toEqual(['home-claude-md'])
+    expect(user?.mcpFiles).toHaveLength(0)
+    expect(filterReportByScope(full, 'all')).toBe(full)
   })
 })

--- a/src/renderer/src/components/right-sidebar/WorkspaceContextPanel.test.tsx
+++ b/src/renderer/src/components/right-sidebar/WorkspaceContextPanel.test.tsx
@@ -38,8 +38,13 @@ const testState = vi.hoisted(() => ({
     runtimeEnvironmentId?: string | null
   }[],
   authorized: [] as string[],
+  authorizeRejects: false,
   allowAbsolutePaths: true
 }))
+
+const { toastErrorMock } = vi.hoisted(() => ({ toastErrorMock: vi.fn() }))
+
+vi.mock('sonner', () => ({ toast: { error: toastErrorMock } }))
 
 vi.mock('@/store', () => ({
   useAppStore: <T,>(
@@ -237,10 +242,15 @@ describe('WorkspaceContextPanel', () => {
     testState.context.report = report()
     testState.openFile = []
     testState.authorized = []
+    testState.authorizeRejects = false
     testState.allowAbsolutePaths = true
+    toastErrorMock.mockReset()
     ;(window as unknown as { api: unknown }).api = {
       fs: {
         authorizeExternalPath: async ({ targetPath }: { targetPath: string }) => {
+          if (testState.authorizeRejects) {
+            throw new Error('path not authorized')
+          }
           testState.authorized.push(targetPath)
         }
       }
@@ -354,6 +364,23 @@ describe('WorkspaceContextPanel', () => {
       el.textContent?.includes('/home/u/repo/.mcp.json')
     )
     expect(mcpRow).toBeDefined()
+  })
+
+  it('opens nothing and warns when the external-path grant is refused', async () => {
+    testState.authorizeRejects = true
+    act(() => root.render(<WorkspaceContextPanel />))
+    const button = [...container.querySelectorAll('button')].find((el) =>
+      el.textContent?.includes('/home/u/.claude/CLAUDE.md')
+    )
+    expect(button).toBeDefined()
+    await act(async () => {
+      button?.click()
+      await Promise.resolve()
+    })
+    expect(testState.openFile).toEqual([])
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      "Couldn't open /home/u/.claude/CLAUDE.md — path not authorized."
+    )
   })
 
   it('offers no external opens when the workspace is not local', () => {

--- a/src/renderer/src/components/right-sidebar/WorkspaceContextPanel.test.tsx
+++ b/src/renderer/src/components/right-sidebar/WorkspaceContextPanel.test.tsx
@@ -163,6 +163,18 @@ describe('WorkspaceContextPanel', () => {
     ])
   })
 
+  it('filters to one section from the filter strip', () => {
+    act(() => root.render(<WorkspaceContextPanel />))
+    const mcpTab = [...container.querySelectorAll('[role="tab"]')].find(
+      (el) => el.textContent === 'MCP'
+    ) as HTMLButtonElement
+    act(() => mcpTab.click())
+    const text = container.textContent ?? ''
+    expect(text).toContain('linear')
+    expect(text).not.toContain('/home/u/repo/CLAUDE.md')
+    expect(text).not.toContain('adhd@local')
+  })
+
   it('shows the empty state without an active worktree', () => {
     testState.worktree = null
     act(() => root.render(<WorkspaceContextPanel />))

--- a/src/renderer/src/components/right-sidebar/WorkspaceContextPanel.test.tsx
+++ b/src/renderer/src/components/right-sidebar/WorkspaceContextPanel.test.tsx
@@ -32,7 +32,13 @@ const testState = vi.hoisted(() => ({
     skillsLoading: false,
     refresh: () => {}
   },
-  openFile: [] as { filePath: string; relativePath: string }[]
+  openFile: [] as {
+    filePath: string
+    relativePath: string
+    runtimeEnvironmentId?: string | null
+  }[],
+  authorized: [] as string[],
+  allowAbsolutePaths: true
 }))
 
 vi.mock('@/store', () => ({
@@ -44,12 +50,15 @@ vi.mock('@/store', () => ({
   ): T =>
     selector({
       openFile: (file) => {
-        testState.openFile.push(file as { filePath: string; relativePath: string })
+        testState.openFile.push(file as (typeof testState.openFile)[number])
       },
       runtimeEnvironments: [{ id: 'env-1', name: 'Build box' }]
     })
 }))
 vi.mock('@/store/selectors', () => ({ useActiveWorktree: () => testState.worktree }))
+vi.mock('@/components/tab-bar/tab-create-entry-local-path', () => ({
+  createTabEntryAllowAbsolutePathsSelector: () => () => testState.allowAbsolutePaths
+}))
 vi.mock('./use-workspace-agent-context', () => ({
   useWorkspaceAgentContext: () => ({
     worktreeId: testState.worktree?.id ?? null,
@@ -227,6 +236,15 @@ describe('WorkspaceContextPanel', () => {
     testState.context.unavailable = null
     testState.context.report = report()
     testState.openFile = []
+    testState.authorized = []
+    testState.allowAbsolutePaths = true
+    ;(window as unknown as { api: unknown }).api = {
+      fs: {
+        authorizeExternalPath: async ({ targetPath }: { targetPath: string }) => {
+          testState.authorized.push(targetPath)
+        }
+      }
+    }
     // Why: view options persist across mounts on purpose; tests start clean.
     window.localStorage.clear()
   })
@@ -310,6 +328,45 @@ describe('WorkspaceContextPanel', () => {
     expect(testState.openFile).toEqual([
       expect.objectContaining({ relativePath: 'CLAUDE.md', filePath: '/home/u/repo/CLAUDE.md' })
     ])
+    expect(testState.authorized).toEqual([])
+  })
+
+  it('opens files outside the worktree as authorized external files on a local workspace', async () => {
+    act(() => root.render(<WorkspaceContextPanel />))
+    const button = [...container.querySelectorAll('button')].find((el) =>
+      el.textContent?.includes('/home/u/.claude/CLAUDE.md')
+    )
+    expect(button).toBeDefined()
+    await act(async () => {
+      button?.click()
+      await Promise.resolve()
+    })
+    expect(testState.authorized).toEqual(['/home/u/.claude/CLAUDE.md'])
+    expect(testState.openFile).toEqual([
+      expect.objectContaining({
+        filePath: '/home/u/.claude/CLAUDE.md',
+        relativePath: '/home/u/.claude/CLAUDE.md',
+        runtimeEnvironmentId: null
+      })
+    ])
+    // MCP rows open their config file the same way.
+    const mcpRow = [...container.querySelectorAll('button')].find((el) =>
+      el.textContent?.includes('/home/u/repo/.mcp.json')
+    )
+    expect(mcpRow).toBeDefined()
+  })
+
+  it('offers no external opens when the workspace is not local', () => {
+    testState.allowAbsolutePaths = false
+    act(() => root.render(<WorkspaceContextPanel />))
+    const homeRow = [...container.querySelectorAll('button')].find((el) =>
+      el.textContent?.includes('/home/u/.claude/CLAUDE.md')
+    )
+    expect(homeRow).toBeUndefined()
+    const repoRow = [...container.querySelectorAll('button')].find((el) =>
+      el.textContent?.includes('/home/u/repo/CLAUDE.md')
+    )
+    expect(repoRow).toBeDefined()
   })
 
   it('filters to one section from the filter strip', () => {

--- a/src/renderer/src/components/right-sidebar/WorkspaceContextPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/WorkspaceContextPanel.tsx
@@ -255,7 +255,7 @@ export default function WorkspaceContextPanel(): React.JSX.Element {
       {error ? (
         <div className="border-b border-border px-4 py-2 text-xs text-destructive">{error}</div>
       ) : null}
-      <div className="scrollbar-sleek min-h-0 flex-1 overflow-y-auto">
+      <div className="scrollbar-sleek min-h-0 flex-1 overflow-y-auto overflow-x-hidden">
         {showSection('instructions') && (
           <ContextSection
             title={translate(

--- a/src/renderer/src/components/right-sidebar/WorkspaceContextPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/WorkspaceContextPanel.tsx
@@ -5,6 +5,7 @@ import { detectLanguage } from '@/lib/language-detect'
 import { joinPath } from '@/lib/path'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { AGENT_CATALOG } from '@/lib/agent-catalog'
 import type { TuiAgent } from '../../../../shared/tui-agent'
 import { translate } from '@/i18n/i18n'
@@ -219,32 +220,31 @@ export default function WorkspaceContextPanel(): React.JSX.Element {
       <div className="border-b border-border px-3 py-1.5">
         <ContextScopeSwitch scope={scope} onScopeChange={setScope} />
       </div>
-      <div
-        role="tablist"
+      <ToggleGroup
+        type="single"
+        spacing={1}
+        value={filter}
+        onValueChange={(value) => {
+          if (value) {
+            setFilter(value as SectionFilter)
+          }
+        }}
         aria-label={translate(
           'auto.components.rightSidebar.WorkspaceContextPanel.filterLabel',
           'Filter sections'
         )}
-        className="flex flex-wrap gap-1 border-b border-border px-3 py-1.5"
+        className="w-full flex-wrap justify-start rounded-none border-b border-border px-3 py-1.5"
       >
         {SECTION_FILTERS.map((key) => (
-          <button
+          <ToggleGroupItem
             key={key}
-            type="button"
-            role="tab"
-            aria-selected={filter === key}
-            onClick={() => setFilter(key)}
-            className={cn(
-              'rounded-md px-2 py-0.5 text-[11px] transition-colors',
-              filter === key
-                ? 'bg-accent text-accent-foreground'
-                : 'text-muted-foreground hover:bg-accent/60 hover:text-foreground'
-            )}
+            value={key}
+            className="h-6 min-h-6 min-w-0 rounded-md border-0 px-2 text-[11px] font-normal text-muted-foreground shadow-none hover:bg-accent/60 hover:text-foreground data-[state=on]:bg-accent data-[state=on]:text-accent-foreground"
           >
             {sectionFilterLabel(key)}
-          </button>
+          </ToggleGroupItem>
         ))}
-      </div>
+      </ToggleGroup>
       {error ? (
         <div className="border-b border-border px-4 py-2 text-xs text-destructive">{error}</div>
       ) : null}

--- a/src/renderer/src/components/right-sidebar/WorkspaceContextPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/WorkspaceContextPanel.tsx
@@ -1,9 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react'
-import type { AgentContextInstructionFile } from '../../../../shared/agent-context'
 import type { TuiAgent } from '../../../../shared/tui-agent'
-import { detectLanguage } from '@/lib/language-detect'
-import { joinPath } from '@/lib/path'
 import { AGENT_CATALOG } from '@/lib/agent-catalog'
+import { createTabEntryAllowAbsolutePathsSelector } from '@/components/tab-bar/tab-create-entry-local-path'
 import { translate } from '@/i18n/i18n'
 import { useAppStore } from '@/store'
 import { useActiveWorktree } from '@/store/selectors'
@@ -17,7 +15,6 @@ import {
   filterReportByAgents,
   filterReportByScope,
   groupSkillsBySource,
-  isPathInside,
   selectSkillsForAgents,
   selectSkillsForScope,
   selectWorkspaceSkills
@@ -28,8 +25,10 @@ import {
   HookFilesBody,
   InstructionFilesBody,
   McpFilesBody,
-  PluginsBody
+  PluginsBody,
+  type OpenContextPath
 } from './workspace-context-sections'
+import { canOpenWorkspaceContextPath, openWorkspaceContextPath } from './workspace-context-open'
 import {
   useWorkspaceContextViewOptions,
   type ContextSectionKey
@@ -41,12 +40,6 @@ const DEFAULT_OPEN: Record<ContextSectionKey, boolean> = {
   mcp: true,
   hooks: false,
   plugins: false
-}
-
-function relativeToWorkspace(pathValue: string, workspaceCwd: string): string {
-  const normalized = pathValue.replace(/\\/g, '/')
-  const base = workspaceCwd.replace(/\\/g, '/').replace(/\/+$/, '')
-  return normalized.slice(base.length + 1)
 }
 
 function unavailableText(reason: WorkspaceAgentContextUnavailable): string {
@@ -133,24 +126,35 @@ export default function WorkspaceContextPanel(): React.JSX.Element {
   const bodyProps = (key: keyof typeof counts) => ({
     report,
     showMissing,
-    hiddenByFilter: hiddenByFilter(key)
+    hiddenByFilter: hiddenByFilter(key),
+    openPath
   })
 
-  const openInstructionFile = useCallback(
-    (file: AgentContextInstructionFile) => {
-      if (!worktree || !workspaceCwd || !isPathInside(file.path, workspaceCwd)) {
-        return
+  const allowAbsolutePathsSelector = useMemo(
+    () => createTabEntryAllowAbsolutePathsSelector(worktree?.id ?? '', { skip: !worktree }),
+    [worktree]
+  )
+  const allowAbsolutePaths = useAppStore(allowAbsolutePathsSelector)
+  const reportTarget = fullReport?.target ?? null
+  const openPath = useCallback<OpenContextPath>(
+    (displayPath) => {
+      if (!worktree || !reportTarget) {
+        return undefined
       }
-      const relativePath = relativeToWorkspace(file.path, workspaceCwd)
-      openFile({
-        filePath: joinPath(worktree.path, relativePath),
-        relativePath,
-        worktreeId: worktree.id,
-        language: detectLanguage(relativePath),
-        mode: 'edit'
-      })
+      if (!canOpenWorkspaceContextPath({ displayPath, reportTarget, allowAbsolutePaths })) {
+        return undefined
+      }
+      return () =>
+        void openWorkspaceContextPath({
+          displayPath,
+          reportTarget,
+          worktree,
+          allowAbsolutePaths,
+          authorizeExternalPath: (args) => window.api.fs.authorizeExternalPath(args),
+          openFile
+        })
     },
-    [openFile, workspaceCwd, worktree]
+    [allowAbsolutePaths, openFile, reportTarget, worktree]
   )
 
   if (!worktree) {
@@ -202,10 +206,7 @@ export default function WorkspaceContextPanel(): React.JSX.Element {
               count={report ? counts.instructionFiles : null}
               {...sectionState('instructions')}
             >
-              <InstructionFilesBody
-                {...bodyProps('instructionFiles')}
-                onOpen={openInstructionFile}
-              />
+              <InstructionFilesBody {...bodyProps('instructionFiles')} />
             </ContextSection>
           )}
 
@@ -250,6 +251,7 @@ export default function WorkspaceContextPanel(): React.JSX.Element {
                         primary={skill.name}
                         secondary={skill.skillFilePath}
                         agents={skill.providers.filter((provider) => provider !== 'agent-skills')}
+                        onClick={openPath(skill.skillFilePath)}
                         title={skill.description ?? skill.skillFilePath}
                       />
                     ))}

--- a/src/renderer/src/components/right-sidebar/WorkspaceContextPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/WorkspaceContextPanel.tsx
@@ -1,21 +1,27 @@
 import React, { useCallback, useMemo, useState } from 'react'
-import { RefreshCw } from 'lucide-react'
+import { RefreshCw, X } from 'lucide-react'
 import type { AgentContextInstructionFile } from '../../../../shared/agent-context'
 import { detectLanguage } from '@/lib/language-detect'
 import { joinPath } from '@/lib/path'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
+import AgentCombobox from '@/components/agent/AgentCombobox'
+import { AGENT_CATALOG } from '@/lib/agent-catalog'
+import type { TuiAgent } from '../../../../shared/tui-agent'
 import { translate } from '@/i18n/i18n'
 import { useAppStore } from '@/store'
 import { useActiveWorktree } from '@/store/selectors'
 import { useWorkspaceAgentContext } from './use-workspace-agent-context'
 import {
+  agentsInContext,
   countPresent,
+  filterReportByAgent,
   formatBytes,
   groupInstructionFiles,
   groupSkillsBySource,
   isPathInside,
+  selectSkillsForAgent,
   selectWorkspaceSkills
 } from './workspace-context-model'
 import { ContextRow, ContextSection, EmptyRow, scopeLabel } from './workspace-context-rows'
@@ -69,7 +75,20 @@ function sectionFilterLabel(key: SectionFilter): string {
 export default function WorkspaceContextPanel(): React.JSX.Element {
   const worktree = useActiveWorktree()
   const openFile = useAppStore((s) => s.openFile)
-  const { report, loading, error, skills, skillsLoading, refresh } = useWorkspaceAgentContext()
+  const {
+    report: fullReport,
+    loading,
+    error,
+    skills,
+    skillSources,
+    skillsLoading,
+    refresh
+  } = useWorkspaceAgentContext()
+  const [agentFilter, setAgentFilter] = useState<TuiAgent | null>(null)
+  const report = useMemo(
+    () => filterReportByAgent(fullReport, agentFilter),
+    [fullReport, agentFilter]
+  )
   const [showMissing, setShowMissing] = useState(false)
   const [filter, setFilter] = useState<SectionFilter>('all')
   const showSection = (key: SectionKey): boolean => filter === 'all' || filter === key
@@ -81,9 +100,16 @@ export default function WorkspaceContextPanel(): React.JSX.Element {
 
   const workspaceCwd = report?.target.cwd ?? null
   const workspaceSkills = useMemo(
-    () => selectWorkspaceSkills(skills, workspaceCwd),
-    [skills, workspaceCwd]
+    () =>
+      selectSkillsForAgent(selectWorkspaceSkills(skills, workspaceCwd), skillSources, agentFilter),
+    [agentFilter, skillSources, skills, workspaceCwd]
   )
+  const agentOptions = useMemo(() => {
+    const present = new Set(
+      agentsInContext(fullReport, selectWorkspaceSkills(skills, workspaceCwd), skillSources)
+    )
+    return AGENT_CATALOG.filter((entry) => present.has(entry.id))
+  }, [fullReport, skillSources, skills, workspaceCwd])
   const counts = countPresent(report)
   const skillGroups = useMemo(() => groupSkillsBySource(workspaceSkills), [workspaceSkills])
   const instructionGroups = useMemo(
@@ -155,6 +181,39 @@ export default function WorkspaceContextPanel(): React.JSX.Element {
         >
           <RefreshCw className={cn(loading && 'animate-spin')} />
         </Button>
+      </div>
+      <div className="flex items-center gap-1 border-b border-border px-3 py-1.5">
+        <AgentCombobox
+          agents={agentOptions}
+          value={agentFilter}
+          onValueChange={setAgentFilter}
+          allowBlankTerminal={false}
+          allowNarrowTrigger
+          emptyLabel={translate(
+            'auto.components.rightSidebar.WorkspaceContextPanel.allAgents',
+            'All agents'
+          )}
+          triggerClassName="h-7 min-w-0 flex-1"
+        />
+        {agentFilter ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            onClick={() => setAgentFilter(null)}
+            aria-label={translate(
+              'auto.components.rightSidebar.WorkspaceContextPanel.clearAgentFilter',
+              'Show all agents'
+            )}
+            title={translate(
+              'auto.components.rightSidebar.WorkspaceContextPanel.clearAgentFilter',
+              'Show all agents'
+            )}
+            className="text-muted-foreground hover:text-foreground"
+          >
+            <X />
+          </Button>
+        ) : null}
       </div>
       <div
         role="tablist"

--- a/src/renderer/src/components/right-sidebar/WorkspaceContextPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/WorkspaceContextPanel.tsx
@@ -4,6 +4,8 @@ import type { AgentContextInstructionFile } from '../../../../shared/agent-conte
 import { detectLanguage } from '@/lib/language-detect'
 import { joinPath } from '@/lib/path'
 import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
 import { translate } from '@/i18n/i18n'
 import { useAppStore } from '@/store'
 import { useActiveWorktree } from '@/store/selectors'
@@ -139,18 +141,20 @@ export default function WorkspaceContextPanel(): React.JSX.Element {
             {hostLabel ? ` · ${hostLabel}` : ''}
           </div>
         </div>
-        <button
+        <Button
           type="button"
+          variant="ghost"
+          size="icon-xs"
           onClick={refresh}
           aria-label={translate(
             'auto.components.rightSidebar.WorkspaceContextPanel.refresh',
             'Refresh'
           )}
           title={translate('auto.components.rightSidebar.WorkspaceContextPanel.refresh', 'Refresh')}
-          className="rounded p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          className="text-muted-foreground hover:text-foreground"
         >
-          <RefreshCw className={cn('size-3.5', loading && 'animate-spin')} />
-        </button>
+          <RefreshCw className={cn(loading && 'animate-spin')} />
+        </Button>
       </div>
       <div
         role="tablist"
@@ -178,12 +182,11 @@ export default function WorkspaceContextPanel(): React.JSX.Element {
           </button>
         ))}
       </div>
-      <label className="flex cursor-pointer items-center gap-2 border-b border-border px-4 py-1.5 text-[11px] text-muted-foreground">
-        <input
-          type="checkbox"
-          className="size-3"
+      <label className="flex cursor-pointer items-center gap-2 border-b border-border px-4 py-1.5 text-xs text-muted-foreground">
+        <Checkbox
+          className="size-3.5"
           checked={showMissing}
-          onChange={(event) => setShowMissing(event.target.checked)}
+          onCheckedChange={(checked) => setShowMissing(checked === true)}
         />
         {translate(
           'auto.components.rightSidebar.WorkspaceContextPanel.showMissing',
@@ -204,7 +207,7 @@ export default function WorkspaceContextPanel(): React.JSX.Element {
             open={filter === 'instructions' || open.instructions}
             onToggle={() => toggle('instructions')}
           >
-            {instructionGroups.length === 0 ? (
+            {report && instructionGroups.length === 0 ? (
               <EmptyRow
                 text={translate(
                   'auto.components.rightSidebar.WorkspaceContextPanel.noInstructions',

--- a/src/renderer/src/components/right-sidebar/WorkspaceContextPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/WorkspaceContextPanel.tsx
@@ -1,12 +1,10 @@
 import React, { useCallback, useMemo, useState } from 'react'
-import { RefreshCw, X } from 'lucide-react'
+import { RefreshCw } from 'lucide-react'
 import type { AgentContextInstructionFile } from '../../../../shared/agent-context'
 import { detectLanguage } from '@/lib/language-detect'
 import { joinPath } from '@/lib/path'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
-import { Checkbox } from '@/components/ui/checkbox'
-import AgentCombobox from '@/components/agent/AgentCombobox'
 import { AGENT_CATALOG } from '@/lib/agent-catalog'
 import type { TuiAgent } from '../../../../shared/tui-agent'
 import { translate } from '@/i18n/i18n'
@@ -16,14 +14,18 @@ import { useWorkspaceAgentContext } from './use-workspace-agent-context'
 import {
   agentsInContext,
   countPresent,
-  filterReportByAgent,
+  filterReportByAgents,
+  filterReportByScope,
   formatBytes,
   groupInstructionFiles,
   groupSkillsBySource,
   isPathInside,
-  selectSkillsForAgent,
-  selectWorkspaceSkills
+  selectSkillsForAgents,
+  selectSkillsForScope,
+  selectWorkspaceSkills,
+  type ContextScopeFilter
 } from './workspace-context-model'
+import { ContextScopeSwitch, ContextViewMenu } from './workspace-context-controls'
 import { ContextRow, ContextSection, EmptyRow, scopeLabel } from './workspace-context-rows'
 import { HookFilesBody, McpFilesBody, PluginsBody } from './workspace-context-sections'
 
@@ -84,12 +86,15 @@ export default function WorkspaceContextPanel(): React.JSX.Element {
     skillsLoading,
     refresh
   } = useWorkspaceAgentContext()
-  const [agentFilter, setAgentFilter] = useState<TuiAgent | null>(null)
-  const report = useMemo(
-    () => filterReportByAgent(fullReport, agentFilter),
-    [fullReport, agentFilter]
-  )
+  // Why: `null` means every agent present — the default survives a rescan
+  // that adds an agent, where an explicit list would silently hide it.
+  const [agentFilter, setAgentFilter] = useState<TuiAgent[] | null>(null)
+  const [scope, setScope] = useState<ContextScopeFilter>('all')
   const [showMissing, setShowMissing] = useState(false)
+  const report = useMemo(
+    () => filterReportByScope(filterReportByAgents(fullReport, agentFilter), scope),
+    [fullReport, agentFilter, scope]
+  )
   const [filter, setFilter] = useState<SectionFilter>('all')
   const showSection = (key: SectionKey): boolean => filter === 'all' || filter === key
   const [open, setOpen] = useState<Record<SectionKey, boolean>>(DEFAULT_OPEN)
@@ -101,15 +106,31 @@ export default function WorkspaceContextPanel(): React.JSX.Element {
   const workspaceCwd = report?.target.cwd ?? null
   const workspaceSkills = useMemo(
     () =>
-      selectSkillsForAgent(selectWorkspaceSkills(skills, workspaceCwd), skillSources, agentFilter),
-    [agentFilter, skillSources, skills, workspaceCwd]
+      selectSkillsForScope(
+        selectSkillsForAgents(
+          selectWorkspaceSkills(skills, workspaceCwd),
+          skillSources,
+          agentFilter
+        ),
+        scope
+      ),
+    [agentFilter, scope, skillSources, skills, workspaceCwd]
   )
   const agentOptions = useMemo(() => {
     const present = new Set(
       agentsInContext(fullReport, selectWorkspaceSkills(skills, workspaceCwd), skillSources)
     )
-    return AGENT_CATALOG.filter((entry) => present.has(entry.id))
+    return AGENT_CATALOG.filter((entry) => present.has(entry.id)).map((entry) => entry.id)
   }, [fullReport, skillSources, skills, workspaceCwd])
+  const setAgentEnabled = useCallback(
+    (agent: TuiAgent, enabled: boolean) =>
+      setAgentFilter((current) => {
+        const base = current ?? agentOptions
+        return enabled ? [...new Set([...base, agent])] : base.filter((entry) => entry !== agent)
+      }),
+    [agentOptions]
+  )
+  const adjustmentCount = (agentFilter ? 1 : 0) + (showMissing ? 1 : 0)
   const counts = countPresent(report)
   const skillGroups = useMemo(() => groupSkillsBySource(workspaceSkills), [workspaceSkills])
   const instructionGroups = useMemo(
@@ -167,6 +188,19 @@ export default function WorkspaceContextPanel(): React.JSX.Element {
             {hostLabel ? ` · ${hostLabel}` : ''}
           </div>
         </div>
+        <ContextViewMenu
+          agentOptions={agentOptions}
+          agents={agentFilter}
+          showMissing={showMissing}
+          adjustmentCount={adjustmentCount}
+          onAgentEnabledChange={setAgentEnabled}
+          onAllAgentsEnabledChange={(enabled) => setAgentFilter(enabled ? null : [])}
+          onShowMissingChange={setShowMissing}
+          onReset={() => {
+            setAgentFilter(null)
+            setShowMissing(false)
+          }}
+        />
         <Button
           type="button"
           variant="ghost"
@@ -182,38 +216,8 @@ export default function WorkspaceContextPanel(): React.JSX.Element {
           <RefreshCw className={cn(loading && 'animate-spin')} />
         </Button>
       </div>
-      <div className="flex items-center gap-1 border-b border-border px-3 py-1.5">
-        <AgentCombobox
-          agents={agentOptions}
-          value={agentFilter}
-          onValueChange={setAgentFilter}
-          allowBlankTerminal={false}
-          allowNarrowTrigger
-          emptyLabel={translate(
-            'auto.components.rightSidebar.WorkspaceContextPanel.allAgents',
-            'All agents'
-          )}
-          triggerClassName="h-7 min-w-0 flex-1"
-        />
-        {agentFilter ? (
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-xs"
-            onClick={() => setAgentFilter(null)}
-            aria-label={translate(
-              'auto.components.rightSidebar.WorkspaceContextPanel.clearAgentFilter',
-              'Show all agents'
-            )}
-            title={translate(
-              'auto.components.rightSidebar.WorkspaceContextPanel.clearAgentFilter',
-              'Show all agents'
-            )}
-            className="text-muted-foreground hover:text-foreground"
-          >
-            <X />
-          </Button>
-        ) : null}
+      <div className="border-b border-border px-3 py-1.5">
+        <ContextScopeSwitch scope={scope} onScopeChange={setScope} />
       </div>
       <div
         role="tablist"
@@ -241,17 +245,6 @@ export default function WorkspaceContextPanel(): React.JSX.Element {
           </button>
         ))}
       </div>
-      <label className="flex cursor-pointer items-center gap-2 border-b border-border px-4 py-1.5 text-xs text-muted-foreground">
-        <Checkbox
-          className="size-3.5"
-          checked={showMissing}
-          onCheckedChange={(checked) => setShowMissing(checked === true)}
-        />
-        {translate(
-          'auto.components.rightSidebar.WorkspaceContextPanel.showMissing',
-          'Show locations that were checked but empty'
-        )}
-      </label>
       {error ? (
         <div className="border-b border-border px-4 py-2 text-xs text-destructive">{error}</div>
       ) : null}

--- a/src/renderer/src/components/right-sidebar/WorkspaceContextPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/WorkspaceContextPanel.tsx
@@ -14,12 +14,21 @@ import {
   groupInstructionFiles,
   groupSkillsBySource,
   isPathInside,
-  selectWorkspaceSkills,
-  sortByScope
+  selectWorkspaceSkills
 } from './workspace-context-model'
 import { ContextRow, ContextSection, EmptyRow, scopeLabel } from './workspace-context-rows'
+import { HookFilesBody, McpFilesBody, PluginsBody } from './workspace-context-sections'
 
 type SectionKey = 'instructions' | 'skills' | 'mcp' | 'hooks' | 'plugins'
+type SectionFilter = SectionKey | 'all'
+const SECTION_FILTERS: SectionFilter[] = [
+  'all',
+  'instructions',
+  'skills',
+  'mcp',
+  'hooks',
+  'plugins'
+]
 
 const DEFAULT_OPEN: Record<SectionKey, boolean> = {
   instructions: true,
@@ -35,11 +44,33 @@ function relativeToWorkspace(pathValue: string, workspaceCwd: string): string {
   return normalized.slice(base.length + 1)
 }
 
+function sectionFilterLabel(key: SectionFilter): string {
+  switch (key) {
+    case 'all':
+      return translate('auto.components.rightSidebar.WorkspaceContextPanel.filterAll', 'All')
+    case 'instructions':
+      return translate(
+        'auto.components.rightSidebar.WorkspaceContextPanel.instructions',
+        'Instructions'
+      )
+    case 'skills':
+      return translate('auto.components.rightSidebar.WorkspaceContextPanel.skills', 'Skills')
+    case 'mcp':
+      return translate('auto.components.rightSidebar.WorkspaceContextPanel.filterMcp', 'MCP')
+    case 'hooks':
+      return translate('auto.components.rightSidebar.WorkspaceContextPanel.hooks', 'Hooks')
+    default:
+      return translate('auto.components.rightSidebar.WorkspaceContextPanel.plugins', 'Plugins')
+  }
+}
+
 export default function WorkspaceContextPanel(): React.JSX.Element {
   const worktree = useActiveWorktree()
   const openFile = useAppStore((s) => s.openFile)
   const { report, loading, error, skills, skillsLoading, refresh } = useWorkspaceAgentContext()
   const [showMissing, setShowMissing] = useState(false)
+  const [filter, setFilter] = useState<SectionFilter>('all')
+  const showSection = (key: SectionKey): boolean => filter === 'all' || filter === key
   const [open, setOpen] = useState<Record<SectionKey, boolean>>(DEFAULT_OPEN)
   const toggle = useCallback(
     (key: SectionKey) => setOpen((current) => ({ ...current, [key]: !current[key] })),
@@ -121,6 +152,32 @@ export default function WorkspaceContextPanel(): React.JSX.Element {
           <RefreshCw className={cn('size-3.5', loading && 'animate-spin')} />
         </button>
       </div>
+      <div
+        role="tablist"
+        aria-label={translate(
+          'auto.components.rightSidebar.WorkspaceContextPanel.filterLabel',
+          'Filter sections'
+        )}
+        className="flex flex-wrap gap-1 border-b border-border px-3 py-1.5"
+      >
+        {SECTION_FILTERS.map((key) => (
+          <button
+            key={key}
+            type="button"
+            role="tab"
+            aria-selected={filter === key}
+            onClick={() => setFilter(key)}
+            className={cn(
+              'rounded-md px-2 py-0.5 text-[11px] transition-colors',
+              filter === key
+                ? 'bg-accent text-accent-foreground'
+                : 'text-muted-foreground hover:bg-accent/60 hover:text-foreground'
+            )}
+          >
+            {sectionFilterLabel(key)}
+          </button>
+        ))}
+      </div>
       <label className="flex cursor-pointer items-center gap-2 border-b border-border px-4 py-1.5 text-[11px] text-muted-foreground">
         <input
           type="checkbox"
@@ -137,255 +194,145 @@ export default function WorkspaceContextPanel(): React.JSX.Element {
         <div className="border-b border-border px-4 py-2 text-xs text-destructive">{error}</div>
       ) : null}
       <div className="scrollbar-sleek min-h-0 flex-1 overflow-y-auto">
-        <ContextSection
-          title={translate(
-            'auto.components.rightSidebar.WorkspaceContextPanel.instructions',
-            'Instructions'
-          )}
-          count={report ? counts.instructionFiles : null}
-          open={open.instructions}
-          onToggle={() => toggle('instructions')}
-        >
-          {instructionGroups.length === 0 ? (
-            <EmptyRow
-              text={translate(
-                'auto.components.rightSidebar.WorkspaceContextPanel.noInstructions',
-                'No instruction files found for this workspace.'
-              )}
-            />
-          ) : (
-            instructionGroups.map((group) => (
-              <div key={group.scope}>
-                <div className="px-3 pt-1 text-[10px] uppercase tracking-wide text-muted-foreground">
-                  {scopeLabel(group.scope)}
-                </div>
-                {group.files.map((file) => (
-                  <ContextRow
-                    key={file.id}
-                    primary={file.label}
-                    secondary={file.path}
-                    meta={
-                      file.entryCount !== undefined
-                        ? translate(
-                            'auto.components.rightSidebar.WorkspaceContextPanel.ruleCount',
-                            '{{value0}} rules',
-                            { value0: file.entryCount }
-                          )
-                        : file.exists
-                          ? formatBytes(file.sizeBytes)
-                          : translate(
-                              'auto.components.rightSidebar.WorkspaceContextPanel.missing',
-                              'not found'
-                            )
-                    }
-                    agents={file.agents}
-                    muted={!file.exists}
-                    onClick={
-                      file.exists && file.scope === 'project' && file.entryCount === undefined
-                        ? () => openInstructionFile(file)
-                        : undefined
-                    }
-                    title={file.path}
-                  />
-                ))}
-              </div>
-            ))
-          )}
-        </ContextSection>
-
-        <ContextSection
-          title={translate('auto.components.rightSidebar.WorkspaceContextPanel.skills', 'Skills')}
-          count={skillsLoading && workspaceSkills.length === 0 ? null : workspaceSkills.length}
-          open={open.skills}
-          onToggle={() => toggle('skills')}
-        >
-          {workspaceSkills.length === 0 ? (
-            <EmptyRow
-              text={
-                skillsLoading
-                  ? translate(
-                      'auto.components.rightSidebar.WorkspaceContextPanel.scanning',
-                      'Scanning…'
-                    )
-                  : translate(
-                      'auto.components.rightSidebar.WorkspaceContextPanel.noSkills',
-                      'No skills discovered.'
-                    )
-              }
-            />
-          ) : (
-            skillGroups.map((group) => (
-              <div key={group.label}>
-                <div className="flex items-baseline px-3 pt-1 text-[10px] uppercase tracking-wide text-muted-foreground">
-                  <span className="min-w-0 flex-1 truncate">{group.label}</span>
-                  <span className="tabular-nums">{group.skills.length}</span>
-                </div>
-                {group.skills.map((skill) => (
-                  <ContextRow
-                    key={skill.id}
-                    primary={skill.name}
-                    secondary={skill.skillFilePath}
-                    agents={skill.providers.filter((provider) => provider !== 'agent-skills')}
-                    title={skill.description ?? skill.skillFilePath}
-                  />
-                ))}
-              </div>
-            ))
-          )}
-        </ContextSection>
-
-        <ContextSection
-          title={translate('auto.components.rightSidebar.WorkspaceContextPanel.mcp', 'MCP servers')}
-          count={report ? counts.mcpServers : null}
-          open={open.mcp}
-          onToggle={() => toggle('mcp')}
-        >
-          {report && report.mcpFiles.every((file) => !file.inspection.exists) && !showMissing ? (
-            <EmptyRow
-              text={translate(
-                'auto.components.rightSidebar.WorkspaceContextPanel.noMcp',
-                'No MCP config files found.'
-              )}
-            />
-          ) : (
-            sortByScope(report?.mcpFiles ?? [])
-              .filter((file) => file.inspection.exists || showMissing)
-              .map((file) => (
-                <div key={file.id}>
-                  <ContextRow
-                    primary={file.inspection.candidate.label}
-                    secondary={file.path}
-                    meta={
-                      !file.inspection.exists
-                        ? translate(
-                            'auto.components.rightSidebar.WorkspaceContextPanel.missing',
-                            'not found'
-                          )
-                        : file.inspection.status === 'invalid'
+        {showSection('instructions') && (
+          <ContextSection
+            title={translate(
+              'auto.components.rightSidebar.WorkspaceContextPanel.instructions',
+              'Instructions'
+            )}
+            count={report ? counts.instructionFiles : null}
+            open={filter === 'instructions' || open.instructions}
+            onToggle={() => toggle('instructions')}
+          >
+            {instructionGroups.length === 0 ? (
+              <EmptyRow
+                text={translate(
+                  'auto.components.rightSidebar.WorkspaceContextPanel.noInstructions',
+                  'No instruction files found for this workspace.'
+                )}
+              />
+            ) : (
+              instructionGroups.map((group) => (
+                <div key={group.scope}>
+                  <div className="px-3 pt-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+                    {scopeLabel(group.scope)}
+                  </div>
+                  {group.files.map((file) => (
+                    <ContextRow
+                      key={file.id}
+                      primary={file.label}
+                      secondary={file.path}
+                      meta={
+                        file.entryCount !== undefined
                           ? translate(
-                              'auto.components.rightSidebar.WorkspaceContextPanel.invalid',
-                              'invalid'
+                              'auto.components.rightSidebar.WorkspaceContextPanel.ruleCount',
+                              '{{value0}} rules',
+                              { value0: file.entryCount }
                             )
-                          : String(file.inspection.servers.length)
-                    }
-                    agents={file.agents}
-                    muted={!file.inspection.exists}
-                    title={file.inspection.error ?? file.path}
-                  />
-                  {file.inspection.servers.map((server) => (
-                    <div
-                      key={`${file.id}:${server.name}`}
-                      className="flex items-baseline gap-2 py-0.5 pl-6 pr-3 text-xs"
-                    >
-                      <span
-                        className={cn(
-                          'min-w-0 truncate',
-                          server.status === 'enabled'
-                            ? 'text-foreground'
-                            : 'text-muted-foreground line-through'
-                        )}
-                      >
-                        {server.name}
-                      </span>
-                      <span className="ml-auto shrink-0 font-mono text-[10px] text-muted-foreground">
-                        {server.transport === 'http'
-                          ? (server.url ?? server.transport)
-                          : (server.command ?? server.transport)}
-                      </span>
-                    </div>
+                          : file.exists
+                            ? formatBytes(file.sizeBytes)
+                            : translate(
+                                'auto.components.rightSidebar.WorkspaceContextPanel.missing',
+                                'not found'
+                              )
+                      }
+                      agents={file.agents}
+                      muted={!file.exists}
+                      onClick={
+                        file.exists && file.scope === 'project' && file.entryCount === undefined
+                          ? () => openInstructionFile(file)
+                          : undefined
+                      }
+                      title={file.path}
+                    />
                   ))}
                 </div>
               ))
-          )}
-        </ContextSection>
+            )}
+          </ContextSection>
+        )}
 
-        <ContextSection
-          title={translate('auto.components.rightSidebar.WorkspaceContextPanel.hooks', 'Hooks')}
-          count={report ? counts.hooks : null}
-          open={open.hooks}
-          onToggle={() => toggle('hooks')}
-        >
-          {sortByScope(report?.hookFiles ?? [])
-            .filter((file) => file.hookCount > 0 || file.error || showMissing)
-            .map((file) => (
-              <ContextRow
-                key={file.id}
-                primary={
-                  file.error
+        {showSection('skills') && (
+          <ContextSection
+            title={translate('auto.components.rightSidebar.WorkspaceContextPanel.skills', 'Skills')}
+            count={skillsLoading && workspaceSkills.length === 0 ? null : workspaceSkills.length}
+            open={filter === 'skills' || open.skills}
+            onToggle={() => toggle('skills')}
+          >
+            {workspaceSkills.length === 0 ? (
+              <EmptyRow
+                text={
+                  skillsLoading
                     ? translate(
-                        'auto.components.rightSidebar.WorkspaceContextPanel.invalidSettings',
-                        'Invalid settings file'
+                        'auto.components.rightSidebar.WorkspaceContextPanel.scanning',
+                        'Scanning…'
                       )
-                    : file.events.length > 0
-                      ? file.events.join(', ')
-                      : translate(
-                          'auto.components.rightSidebar.WorkspaceContextPanel.noHooksInFile',
-                          'No hooks'
-                        )
-                }
-                secondary={file.path}
-                meta={
-                  file.exists
-                    ? String(file.hookCount)
                     : translate(
-                        'auto.components.rightSidebar.WorkspaceContextPanel.missing',
-                        'not found'
+                        'auto.components.rightSidebar.WorkspaceContextPanel.noSkills',
+                        'No skills discovered.'
                       )
                 }
-                agents={file.agents}
-                muted={!file.exists || file.hookCount === 0}
-                title={file.error ?? file.path}
               />
-            ))}
-          {report && counts.hooks === 0 && !showMissing ? (
-            <EmptyRow
-              text={translate(
-                'auto.components.rightSidebar.WorkspaceContextPanel.noHooks',
-                'No agent hooks configured.'
-              )}
-            />
-          ) : null}
-        </ContextSection>
-
-        <ContextSection
-          title={translate('auto.components.rightSidebar.WorkspaceContextPanel.plugins', 'Plugins')}
-          count={report ? counts.plugins : null}
-          open={open.plugins}
-          onToggle={() => toggle('plugins')}
-        >
-          {report && report.plugins.length === 0 ? (
-            <EmptyRow
-              text={translate(
-                'auto.components.rightSidebar.WorkspaceContextPanel.noPlugins',
-                'No plugin settings found.'
-              )}
-            />
-          ) : (
-            (report?.plugins ?? [])
-              .filter((plugin) => plugin.enabled || showMissing)
-              .map((plugin) => (
-                <ContextRow
-                  key={plugin.id}
-                  primary={plugin.name}
-                  secondary={plugin.sourcePath}
-                  meta={
-                    plugin.enabled
-                      ? translate(
-                          'auto.components.rightSidebar.WorkspaceContextPanel.enabled',
-                          'enabled'
-                        )
-                      : translate(
-                          'auto.components.rightSidebar.WorkspaceContextPanel.disabled',
-                          'disabled'
-                        )
-                  }
-                  agents={plugin.agents}
-                  muted={!plugin.enabled}
-                  title={plugin.sourcePath}
-                />
+            ) : (
+              skillGroups.map((group) => (
+                <div key={group.label}>
+                  <div className="flex items-baseline px-3 pt-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+                    <span className="min-w-0 flex-1 truncate">{group.label}</span>
+                    <span className="tabular-nums">{group.skills.length}</span>
+                  </div>
+                  {group.skills.map((skill) => (
+                    <ContextRow
+                      key={skill.id}
+                      primary={skill.name}
+                      secondary={skill.skillFilePath}
+                      agents={skill.providers.filter((provider) => provider !== 'agent-skills')}
+                      title={skill.description ?? skill.skillFilePath}
+                    />
+                  ))}
+                </div>
               ))
-          )}
-        </ContextSection>
+            )}
+          </ContextSection>
+        )}
+
+        {showSection('mcp') && (
+          <ContextSection
+            title={translate(
+              'auto.components.rightSidebar.WorkspaceContextPanel.mcp',
+              'MCP servers'
+            )}
+            count={report ? counts.mcpServers : null}
+            open={filter === 'mcp' || open.mcp}
+            onToggle={() => toggle('mcp')}
+          >
+            <McpFilesBody report={report} showMissing={showMissing} />
+          </ContextSection>
+        )}
+
+        {showSection('hooks') && (
+          <ContextSection
+            title={translate('auto.components.rightSidebar.WorkspaceContextPanel.hooks', 'Hooks')}
+            count={report ? counts.hooks : null}
+            open={filter === 'hooks' || open.hooks}
+            onToggle={() => toggle('hooks')}
+          >
+            <HookFilesBody report={report} showMissing={showMissing} />
+          </ContextSection>
+        )}
+
+        {showSection('plugins') && (
+          <ContextSection
+            title={translate(
+              'auto.components.rightSidebar.WorkspaceContextPanel.plugins',
+              'Plugins'
+            )}
+            count={report ? counts.plugins : null}
+            open={filter === 'plugins' || open.plugins}
+            onToggle={() => toggle('plugins')}
+          >
+            <PluginsBody report={report} showMissing={showMissing} />
+          </ContextSection>
+        )}
       </div>
     </div>
   )

--- a/src/renderer/src/components/right-sidebar/WorkspaceContextPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/WorkspaceContextPanel.tsx
@@ -1,47 +1,41 @@
 import React, { useCallback, useMemo, useState } from 'react'
-import { RefreshCw } from 'lucide-react'
 import type { AgentContextInstructionFile } from '../../../../shared/agent-context'
+import type { TuiAgent } from '../../../../shared/tui-agent'
 import { detectLanguage } from '@/lib/language-detect'
 import { joinPath } from '@/lib/path'
-import { cn } from '@/lib/utils'
-import { Button } from '@/components/ui/button'
-import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { AGENT_CATALOG } from '@/lib/agent-catalog'
-import type { TuiAgent } from '../../../../shared/tui-agent'
 import { translate } from '@/i18n/i18n'
 import { useAppStore } from '@/store'
 import { useActiveWorktree } from '@/store/selectors'
-import { useWorkspaceAgentContext } from './use-workspace-agent-context'
+import {
+  useWorkspaceAgentContext,
+  type WorkspaceAgentContextUnavailable
+} from './use-workspace-agent-context'
 import {
   agentsInContext,
   countPresent,
   filterReportByAgents,
   filterReportByScope,
-  formatBytes,
-  groupInstructionFiles,
   groupSkillsBySource,
   isPathInside,
   selectSkillsForAgents,
   selectSkillsForScope,
-  selectWorkspaceSkills,
-  type ContextScopeFilter
+  selectWorkspaceSkills
 } from './workspace-context-model'
-import { ContextScopeSwitch, ContextViewMenu } from './workspace-context-controls'
-import { ContextRow, ContextSection, EmptyRow, scopeLabel } from './workspace-context-rows'
-import { HookFilesBody, McpFilesBody, PluginsBody } from './workspace-context-sections'
+import { WorkspaceContextHeader, workspaceContextHostLabel } from './workspace-context-header'
+import { ContextRow, ContextSection, EmptyRow } from './workspace-context-rows'
+import {
+  HookFilesBody,
+  InstructionFilesBody,
+  McpFilesBody,
+  PluginsBody
+} from './workspace-context-sections'
+import {
+  useWorkspaceContextViewOptions,
+  type ContextSectionKey
+} from './workspace-context-view-options'
 
-type SectionKey = 'instructions' | 'skills' | 'mcp' | 'hooks' | 'plugins'
-type SectionFilter = SectionKey | 'all'
-const SECTION_FILTERS: SectionFilter[] = [
-  'all',
-  'instructions',
-  'skills',
-  'mcp',
-  'hooks',
-  'plugins'
-]
-
-const DEFAULT_OPEN: Record<SectionKey, boolean> = {
+const DEFAULT_OPEN: Record<ContextSectionKey, boolean> = {
   instructions: true,
   skills: true,
   mcp: true,
@@ -55,30 +49,33 @@ function relativeToWorkspace(pathValue: string, workspaceCwd: string): string {
   return normalized.slice(base.length + 1)
 }
 
-function sectionFilterLabel(key: SectionFilter): string {
-  switch (key) {
-    case 'all':
-      return translate('auto.components.rightSidebar.WorkspaceContextPanel.filterAll', 'All')
-    case 'instructions':
-      return translate(
-        'auto.components.rightSidebar.WorkspaceContextPanel.instructions',
-        'Instructions'
+function unavailableText(reason: WorkspaceAgentContextUnavailable): string {
+  return reason === 'ssh'
+    ? translate(
+        'auto.components.rightSidebar.WorkspaceContextPanel.unavailableSsh',
+        'Agent context is not available for SSH workspaces yet.'
       )
-    case 'skills':
-      return translate('auto.components.rightSidebar.WorkspaceContextPanel.skills', 'Skills')
-    case 'mcp':
-      return translate('auto.components.rightSidebar.WorkspaceContextPanel.filterMcp', 'MCP')
-    case 'hooks':
-      return translate('auto.components.rightSidebar.WorkspaceContextPanel.hooks', 'Hooks')
-    default:
-      return translate('auto.components.rightSidebar.WorkspaceContextPanel.plugins', 'Plugins')
-  }
+    : translate(
+        'auto.components.rightSidebar.WorkspaceContextPanel.unavailableRuntime',
+        'Waiting for the runtime that owns this workspace.'
+      )
+}
+
+function CenteredNote({ text }: { text: string }): React.JSX.Element {
+  return (
+    <div className="flex min-h-0 flex-1 items-center justify-center p-6 text-center text-sm text-muted-foreground">
+      {text}
+    </div>
+  )
 }
 
 export default function WorkspaceContextPanel(): React.JSX.Element {
   const worktree = useActiveWorktree()
   const openFile = useAppStore((s) => s.openFile)
+  const runtimeEnvironments = useAppStore((s) => s.runtimeEnvironments)
   const {
+    hostId,
+    unavailable,
     report: fullReport,
     loading,
     error,
@@ -87,64 +84,61 @@ export default function WorkspaceContextPanel(): React.JSX.Element {
     skillsLoading,
     refresh
   } = useWorkspaceAgentContext()
-  // Why: `null` means every agent present — the default survives a rescan
-  // that adds an agent, where an explicit list would silently hide it.
-  const [agentFilter, setAgentFilter] = useState<TuiAgent[] | null>(null)
-  const [scope, setScope] = useState<ContextScopeFilter>('all')
-  const [showMissing, setShowMissing] = useState(false)
+  const { options, update, setAgentEnabled, setAllAgentsEnabled, reset } =
+    useWorkspaceContextViewOptions()
+  const { disabledAgents, scope, section, showMissing } = options
+
+  const workspaceCwd = fullReport?.target.cwd ?? null
+  const allWorkspaceSkills = useMemo(
+    () => selectWorkspaceSkills(skills, workspaceCwd),
+    [skills, workspaceCwd]
+  )
+  const agentOptions = useMemo(() => {
+    const present = new Set(agentsInContext(fullReport, allWorkspaceSkills, skillSources))
+    return AGENT_CATALOG.filter((entry) => present.has(entry.id)).map((entry) => entry.id)
+  }, [allWorkspaceSkills, fullReport, skillSources])
+  const enabledAgents = useMemo(
+    () => agentOptions.filter((agent) => !disabledAgents.includes(agent)),
+    [agentOptions, disabledAgents]
+  )
+  const agentFilter: readonly TuiAgent[] | null = disabledAgents.length === 0 ? null : enabledAgents
   const report = useMemo(
     () => filterReportByScope(filterReportByAgents(fullReport, agentFilter), scope),
     [fullReport, agentFilter, scope]
   )
-  const [filter, setFilter] = useState<SectionFilter>('all')
-  const showSection = (key: SectionKey): boolean => filter === 'all' || filter === key
-  const [open, setOpen] = useState<Record<SectionKey, boolean>>(DEFAULT_OPEN)
-  const toggle = useCallback(
-    (key: SectionKey) => setOpen((current) => ({ ...current, [key]: !current[key] })),
-    []
-  )
-
-  const workspaceCwd = report?.target.cwd ?? null
   const workspaceSkills = useMemo(
     () =>
       selectSkillsForScope(
-        selectSkillsForAgents(
-          selectWorkspaceSkills(skills, workspaceCwd),
-          skillSources,
-          agentFilter
-        ),
+        selectSkillsForAgents(allWorkspaceSkills, skillSources, agentFilter),
         scope
       ),
-    [agentFilter, scope, skillSources, skills, workspaceCwd]
+    [agentFilter, allWorkspaceSkills, scope, skillSources]
   )
-  const agentOptions = useMemo(() => {
-    const present = new Set(
-      agentsInContext(fullReport, selectWorkspaceSkills(skills, workspaceCwd), skillSources)
-    )
-    return AGENT_CATALOG.filter((entry) => present.has(entry.id)).map((entry) => entry.id)
-  }, [fullReport, skillSources, skills, workspaceCwd])
-  const setAgentEnabled = useCallback(
-    (agent: TuiAgent, enabled: boolean) =>
-      setAgentFilter((current) => {
-        const base = current ?? agentOptions
-        return enabled ? [...new Set([...base, agent])] : base.filter((entry) => entry !== agent)
-      }),
-    [agentOptions]
-  )
-  const adjustmentCount = (agentFilter ? 1 : 0) + (showMissing ? 1 : 0)
   const counts = countPresent(report)
+  const fullCounts = countPresent(fullReport)
   const skillGroups = useMemo(() => groupSkillsBySource(workspaceSkills), [workspaceSkills])
-  const instructionGroups = useMemo(
-    () => groupInstructionFiles(report?.instructionFiles ?? [], showMissing),
-    [report, showMissing]
+  const showSection = (key: ContextSectionKey): boolean => section === 'all' || section === key
+  const [open, setOpen] = useState<Record<ContextSectionKey, boolean>>(DEFAULT_OPEN)
+  const toggle = useCallback(
+    (key: ContextSectionKey) => setOpen((current) => ({ ...current, [key]: !current[key] })),
+    []
   )
+  const sectionState = (key: ContextSectionKey) => ({
+    open: section === key || open[key],
+    onToggle: () => toggle(key)
+  })
+  // Why: an empty section reads differently when the unfiltered report has rows.
+  const hiddenByFilter = (key: keyof typeof counts): boolean =>
+    fullCounts[key] > 0 && counts[key] === 0
+  const bodyProps = (key: keyof typeof counts) => ({
+    report,
+    showMissing,
+    hiddenByFilter: hiddenByFilter(key)
+  })
 
   const openInstructionFile = useCallback(
     (file: AgentContextInstructionFile) => {
-      if (!worktree || !workspaceCwd || !file.exists || file.entryCount !== undefined) {
-        return
-      }
-      if (!isPathInside(file.path, workspaceCwd)) {
+      if (!worktree || !workspaceCwd || !isPathInside(file.path, workspaceCwd)) {
         return
       }
       const relativePath = relativeToWorkspace(file.path, workspaceCwd)
@@ -161,234 +155,147 @@ export default function WorkspaceContextPanel(): React.JSX.Element {
 
   if (!worktree) {
     return (
-      <div className="flex min-h-0 flex-1 items-center justify-center p-6 text-center text-sm text-muted-foreground">
-        {translate(
+      <CenteredNote
+        text={translate(
           'auto.components.rightSidebar.WorkspaceContextPanel.noWorkspace',
           'Select a workspace to see the context its agents load.'
         )}
-      </div>
+      />
     )
   }
 
-  const hostLabel =
-    report?.target.kind === 'wsl'
-      ? `WSL · ${report.target.distro ?? ''}`
-      : report
-        ? translate('auto.components.rightSidebar.WorkspaceContextPanel.hostLocal', 'This host')
-        : ''
+  const hostLabel = workspaceContextHostLabel({
+    hostId,
+    runtimeEnvironments,
+    reportTarget: fullReport?.target ?? null
+  })
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
-      <div className="flex items-start gap-2 border-b border-border px-4 py-3">
-        <div className="min-w-0 flex-1">
-          <div className="truncate text-sm font-medium text-foreground">
-            {translate('auto.components.rightSidebar.WorkspaceContextPanel.title', 'Agent context')}
-          </div>
-          <div className="mt-0.5 truncate text-xs text-muted-foreground">
-            {worktree.branch.replace(/^refs\/heads\//, '') || worktree.path}
-            {hostLabel ? ` · ${hostLabel}` : ''}
-          </div>
-        </div>
-        <ContextViewMenu
-          agentOptions={agentOptions}
-          agents={agentFilter}
-          showMissing={showMissing}
-          adjustmentCount={adjustmentCount}
-          onAgentEnabledChange={setAgentEnabled}
-          onAllAgentsEnabledChange={(enabled) => setAgentFilter(enabled ? null : [])}
-          onShowMissingChange={setShowMissing}
-          onReset={() => {
-            setAgentFilter(null)
-            setShowMissing(false)
-          }}
-        />
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-xs"
-          onClick={refresh}
-          aria-label={translate(
-            'auto.components.rightSidebar.WorkspaceContextPanel.refresh',
-            'Refresh'
-          )}
-          title={translate('auto.components.rightSidebar.WorkspaceContextPanel.refresh', 'Refresh')}
-          className="text-muted-foreground hover:text-foreground"
-        >
-          <RefreshCw className={cn(loading && 'animate-spin')} />
-        </Button>
-      </div>
-      <div className="border-b border-border px-3 py-1.5">
-        <ContextScopeSwitch scope={scope} onScopeChange={setScope} />
-      </div>
-      <ToggleGroup
-        type="single"
-        spacing={1}
-        value={filter}
-        onValueChange={(value) => {
-          if (value) {
-            setFilter(value as SectionFilter)
-          }
-        }}
-        aria-label={translate(
-          'auto.components.rightSidebar.WorkspaceContextPanel.filterLabel',
-          'Filter sections'
-        )}
-        className="w-full flex-wrap justify-start rounded-none border-b border-border px-3 py-1.5"
-      >
-        {SECTION_FILTERS.map((key) => (
-          <ToggleGroupItem
-            key={key}
-            value={key}
-            className="h-6 min-h-6 min-w-0 rounded-md border-0 px-2 text-[11px] font-normal text-muted-foreground shadow-none hover:bg-accent/60 hover:text-foreground data-[state=on]:bg-accent data-[state=on]:text-accent-foreground"
-          >
-            {sectionFilterLabel(key)}
-          </ToggleGroupItem>
-        ))}
-      </ToggleGroup>
+      <WorkspaceContextHeader
+        subtitle={worktree.branch.replace(/^refs\/heads\//, '') || worktree.path}
+        hostLabel={hostLabel}
+        loading={loading}
+        agentOptions={agentOptions}
+        options={options}
+        onScopeChange={(next) => update({ scope: next })}
+        onSectionChange={(next) => update({ section: next })}
+        onAgentEnabledChange={setAgentEnabled}
+        onAllAgentsEnabledChange={(enabled) => setAllAgentsEnabled(enabled, agentOptions)}
+        onShowMissingChange={(next) => update({ showMissing: next })}
+        onReset={reset}
+        onRefresh={refresh}
+      />
       {error ? (
         <div className="border-b border-border px-4 py-2 text-xs text-destructive">{error}</div>
       ) : null}
-      <div className="scrollbar-sleek min-h-0 flex-1 overflow-y-auto overflow-x-hidden">
-        {showSection('instructions') && (
-          <ContextSection
-            title={translate(
-              'auto.components.rightSidebar.WorkspaceContextPanel.instructions',
-              'Instructions'
-            )}
-            count={report ? counts.instructionFiles : null}
-            open={filter === 'instructions' || open.instructions}
-            onToggle={() => toggle('instructions')}
-          >
-            {report && instructionGroups.length === 0 ? (
-              <EmptyRow
-                text={translate(
-                  'auto.components.rightSidebar.WorkspaceContextPanel.noInstructions',
-                  'No instruction files found for this workspace.'
-                )}
+      {unavailable ? (
+        <CenteredNote text={unavailableText(unavailable)} />
+      ) : (
+        <div className="scrollbar-sleek min-h-0 flex-1 overflow-y-auto overflow-x-hidden">
+          {showSection('instructions') && (
+            <ContextSection
+              title={translate(
+                'auto.components.rightSidebar.WorkspaceContextPanel.instructions',
+                'Instructions'
+              )}
+              count={report ? counts.instructionFiles : null}
+              {...sectionState('instructions')}
+            >
+              <InstructionFilesBody
+                {...bodyProps('instructionFiles')}
+                onOpen={openInstructionFile}
               />
-            ) : (
-              instructionGroups.map((group) => (
-                <div key={group.scope}>
-                  <div className="px-3 pt-1 text-[10px] uppercase tracking-wide text-muted-foreground">
-                    {scopeLabel(group.scope)}
+            </ContextSection>
+          )}
+
+          {showSection('skills') && (
+            <ContextSection
+              title={translate(
+                'auto.components.rightSidebar.WorkspaceContextPanel.skills',
+                'Skills'
+              )}
+              count={skillsLoading && workspaceSkills.length === 0 ? null : workspaceSkills.length}
+              {...sectionState('skills')}
+            >
+              {workspaceSkills.length === 0 ? (
+                <EmptyRow
+                  text={
+                    skillsLoading
+                      ? translate(
+                          'auto.components.rightSidebar.WorkspaceContextPanel.scanning',
+                          'Scanning…'
+                        )
+                      : allWorkspaceSkills.length > 0
+                        ? translate(
+                            'auto.components.rightSidebar.WorkspaceContextPanel.hiddenByFilter',
+                            'Hidden by the current filter.'
+                          )
+                        : translate(
+                            'auto.components.rightSidebar.WorkspaceContextPanel.noSkills',
+                            'No skills discovered.'
+                          )
+                  }
+                />
+              ) : (
+                skillGroups.map((group) => (
+                  <div key={group.label}>
+                    <div className="flex items-baseline px-3 pt-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+                      <span className="min-w-0 flex-1 truncate">{group.label}</span>
+                      <span className="tabular-nums">{group.skills.length}</span>
+                    </div>
+                    {group.skills.map((skill) => (
+                      <ContextRow
+                        key={skill.id}
+                        primary={skill.name}
+                        secondary={skill.skillFilePath}
+                        agents={skill.providers.filter((provider) => provider !== 'agent-skills')}
+                        title={skill.description ?? skill.skillFilePath}
+                      />
+                    ))}
                   </div>
-                  {group.files.map((file) => (
-                    <ContextRow
-                      key={file.id}
-                      primary={file.label}
-                      secondary={file.path}
-                      meta={
-                        file.entryCount !== undefined
-                          ? translate(
-                              'auto.components.rightSidebar.WorkspaceContextPanel.ruleCount',
-                              '{{value0}} rules',
-                              { value0: file.entryCount }
-                            )
-                          : file.exists
-                            ? formatBytes(file.sizeBytes)
-                            : translate(
-                                'auto.components.rightSidebar.WorkspaceContextPanel.missing',
-                                'not found'
-                              )
-                      }
-                      agents={file.agents}
-                      muted={!file.exists}
-                      onClick={
-                        file.exists && file.scope === 'project' && file.entryCount === undefined
-                          ? () => openInstructionFile(file)
-                          : undefined
-                      }
-                      title={file.path}
-                    />
-                  ))}
-                </div>
-              ))
-            )}
-          </ContextSection>
-        )}
+                ))
+              )}
+            </ContextSection>
+          )}
 
-        {showSection('skills') && (
-          <ContextSection
-            title={translate('auto.components.rightSidebar.WorkspaceContextPanel.skills', 'Skills')}
-            count={skillsLoading && workspaceSkills.length === 0 ? null : workspaceSkills.length}
-            open={filter === 'skills' || open.skills}
-            onToggle={() => toggle('skills')}
-          >
-            {workspaceSkills.length === 0 ? (
-              <EmptyRow
-                text={
-                  skillsLoading
-                    ? translate(
-                        'auto.components.rightSidebar.WorkspaceContextPanel.scanning',
-                        'Scanning…'
-                      )
-                    : translate(
-                        'auto.components.rightSidebar.WorkspaceContextPanel.noSkills',
-                        'No skills discovered.'
-                      )
-                }
-              />
-            ) : (
-              skillGroups.map((group) => (
-                <div key={group.label}>
-                  <div className="flex items-baseline px-3 pt-1 text-[10px] uppercase tracking-wide text-muted-foreground">
-                    <span className="min-w-0 flex-1 truncate">{group.label}</span>
-                    <span className="tabular-nums">{group.skills.length}</span>
-                  </div>
-                  {group.skills.map((skill) => (
-                    <ContextRow
-                      key={skill.id}
-                      primary={skill.name}
-                      secondary={skill.skillFilePath}
-                      agents={skill.providers.filter((provider) => provider !== 'agent-skills')}
-                      title={skill.description ?? skill.skillFilePath}
-                    />
-                  ))}
-                </div>
-              ))
-            )}
-          </ContextSection>
-        )}
+          {showSection('mcp') && (
+            <ContextSection
+              title={translate(
+                'auto.components.rightSidebar.WorkspaceContextPanel.mcp',
+                'MCP servers'
+              )}
+              count={report ? counts.mcpServers : null}
+              {...sectionState('mcp')}
+            >
+              <McpFilesBody {...bodyProps('mcpServers')} />
+            </ContextSection>
+          )}
 
-        {showSection('mcp') && (
-          <ContextSection
-            title={translate(
-              'auto.components.rightSidebar.WorkspaceContextPanel.mcp',
-              'MCP servers'
-            )}
-            count={report ? counts.mcpServers : null}
-            open={filter === 'mcp' || open.mcp}
-            onToggle={() => toggle('mcp')}
-          >
-            <McpFilesBody report={report} showMissing={showMissing} />
-          </ContextSection>
-        )}
+          {showSection('hooks') && (
+            <ContextSection
+              title={translate('auto.components.rightSidebar.WorkspaceContextPanel.hooks', 'Hooks')}
+              count={report ? counts.hooks : null}
+              {...sectionState('hooks')}
+            >
+              <HookFilesBody {...bodyProps('hooks')} />
+            </ContextSection>
+          )}
 
-        {showSection('hooks') && (
-          <ContextSection
-            title={translate('auto.components.rightSidebar.WorkspaceContextPanel.hooks', 'Hooks')}
-            count={report ? counts.hooks : null}
-            open={filter === 'hooks' || open.hooks}
-            onToggle={() => toggle('hooks')}
-          >
-            <HookFilesBody report={report} showMissing={showMissing} />
-          </ContextSection>
-        )}
-
-        {showSection('plugins') && (
-          <ContextSection
-            title={translate(
-              'auto.components.rightSidebar.WorkspaceContextPanel.plugins',
-              'Plugins'
-            )}
-            count={report ? counts.plugins : null}
-            open={filter === 'plugins' || open.plugins}
-            onToggle={() => toggle('plugins')}
-          >
-            <PluginsBody report={report} showMissing={showMissing} />
-          </ContextSection>
-        )}
-      </div>
+          {showSection('plugins') && (
+            <ContextSection
+              title={translate(
+                'auto.components.rightSidebar.WorkspaceContextPanel.plugins',
+                'Plugins'
+              )}
+              count={report ? counts.plugins : null}
+              {...sectionState('plugins')}
+            >
+              <PluginsBody {...bodyProps('plugins')} />
+            </ContextSection>
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/renderer/src/components/right-sidebar/WorkspaceContextPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/WorkspaceContextPanel.tsx
@@ -1,0 +1,392 @@
+import React, { useCallback, useMemo, useState } from 'react'
+import { RefreshCw } from 'lucide-react'
+import type { AgentContextInstructionFile } from '../../../../shared/agent-context'
+import { detectLanguage } from '@/lib/language-detect'
+import { joinPath } from '@/lib/path'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import { useAppStore } from '@/store'
+import { useActiveWorktree } from '@/store/selectors'
+import { useWorkspaceAgentContext } from './use-workspace-agent-context'
+import {
+  countPresent,
+  formatBytes,
+  groupInstructionFiles,
+  groupSkillsBySource,
+  isPathInside,
+  selectWorkspaceSkills,
+  sortByScope
+} from './workspace-context-model'
+import { ContextRow, ContextSection, EmptyRow, scopeLabel } from './workspace-context-rows'
+
+type SectionKey = 'instructions' | 'skills' | 'mcp' | 'hooks' | 'plugins'
+
+const DEFAULT_OPEN: Record<SectionKey, boolean> = {
+  instructions: true,
+  skills: true,
+  mcp: true,
+  hooks: false,
+  plugins: false
+}
+
+function relativeToWorkspace(pathValue: string, workspaceCwd: string): string {
+  const normalized = pathValue.replace(/\\/g, '/')
+  const base = workspaceCwd.replace(/\\/g, '/').replace(/\/+$/, '')
+  return normalized.slice(base.length + 1)
+}
+
+export default function WorkspaceContextPanel(): React.JSX.Element {
+  const worktree = useActiveWorktree()
+  const openFile = useAppStore((s) => s.openFile)
+  const { report, loading, error, skills, skillsLoading, refresh } = useWorkspaceAgentContext()
+  const [showMissing, setShowMissing] = useState(false)
+  const [open, setOpen] = useState<Record<SectionKey, boolean>>(DEFAULT_OPEN)
+  const toggle = useCallback(
+    (key: SectionKey) => setOpen((current) => ({ ...current, [key]: !current[key] })),
+    []
+  )
+
+  const workspaceCwd = report?.target.cwd ?? null
+  const workspaceSkills = useMemo(
+    () => selectWorkspaceSkills(skills, workspaceCwd),
+    [skills, workspaceCwd]
+  )
+  const counts = countPresent(report)
+  const skillGroups = useMemo(() => groupSkillsBySource(workspaceSkills), [workspaceSkills])
+  const instructionGroups = useMemo(
+    () => groupInstructionFiles(report?.instructionFiles ?? [], showMissing),
+    [report, showMissing]
+  )
+
+  const openInstructionFile = useCallback(
+    (file: AgentContextInstructionFile) => {
+      if (!worktree || !workspaceCwd || !file.exists || file.entryCount !== undefined) {
+        return
+      }
+      if (!isPathInside(file.path, workspaceCwd)) {
+        return
+      }
+      const relativePath = relativeToWorkspace(file.path, workspaceCwd)
+      openFile({
+        filePath: joinPath(worktree.path, relativePath),
+        relativePath,
+        worktreeId: worktree.id,
+        language: detectLanguage(relativePath),
+        mode: 'edit'
+      })
+    },
+    [openFile, workspaceCwd, worktree]
+  )
+
+  if (!worktree) {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center p-6 text-center text-sm text-muted-foreground">
+        {translate(
+          'auto.components.rightSidebar.WorkspaceContextPanel.noWorkspace',
+          'Select a workspace to see the context its agents load.'
+        )}
+      </div>
+    )
+  }
+
+  const hostLabel =
+    report?.target.kind === 'wsl'
+      ? `WSL · ${report.target.distro ?? ''}`
+      : report
+        ? translate('auto.components.rightSidebar.WorkspaceContextPanel.hostLocal', 'This host')
+        : ''
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
+      <div className="flex items-start gap-2 border-b border-border px-4 py-3">
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm font-medium text-foreground">
+            {translate('auto.components.rightSidebar.WorkspaceContextPanel.title', 'Agent context')}
+          </div>
+          <div className="mt-0.5 truncate text-xs text-muted-foreground">
+            {worktree.branch.replace(/^refs\/heads\//, '') || worktree.path}
+            {hostLabel ? ` · ${hostLabel}` : ''}
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={refresh}
+          aria-label={translate(
+            'auto.components.rightSidebar.WorkspaceContextPanel.refresh',
+            'Refresh'
+          )}
+          title={translate('auto.components.rightSidebar.WorkspaceContextPanel.refresh', 'Refresh')}
+          className="rounded p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+        >
+          <RefreshCw className={cn('size-3.5', loading && 'animate-spin')} />
+        </button>
+      </div>
+      <label className="flex cursor-pointer items-center gap-2 border-b border-border px-4 py-1.5 text-[11px] text-muted-foreground">
+        <input
+          type="checkbox"
+          className="size-3"
+          checked={showMissing}
+          onChange={(event) => setShowMissing(event.target.checked)}
+        />
+        {translate(
+          'auto.components.rightSidebar.WorkspaceContextPanel.showMissing',
+          'Show locations that were checked but empty'
+        )}
+      </label>
+      {error ? (
+        <div className="border-b border-border px-4 py-2 text-xs text-destructive">{error}</div>
+      ) : null}
+      <div className="scrollbar-sleek min-h-0 flex-1 overflow-y-auto">
+        <ContextSection
+          title={translate(
+            'auto.components.rightSidebar.WorkspaceContextPanel.instructions',
+            'Instructions'
+          )}
+          count={report ? counts.instructionFiles : null}
+          open={open.instructions}
+          onToggle={() => toggle('instructions')}
+        >
+          {instructionGroups.length === 0 ? (
+            <EmptyRow
+              text={translate(
+                'auto.components.rightSidebar.WorkspaceContextPanel.noInstructions',
+                'No instruction files found for this workspace.'
+              )}
+            />
+          ) : (
+            instructionGroups.map((group) => (
+              <div key={group.scope}>
+                <div className="px-3 pt-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+                  {scopeLabel(group.scope)}
+                </div>
+                {group.files.map((file) => (
+                  <ContextRow
+                    key={file.id}
+                    primary={file.label}
+                    secondary={file.path}
+                    meta={
+                      file.entryCount !== undefined
+                        ? translate(
+                            'auto.components.rightSidebar.WorkspaceContextPanel.ruleCount',
+                            '{{value0}} rules',
+                            { value0: file.entryCount }
+                          )
+                        : file.exists
+                          ? formatBytes(file.sizeBytes)
+                          : translate(
+                              'auto.components.rightSidebar.WorkspaceContextPanel.missing',
+                              'not found'
+                            )
+                    }
+                    agents={file.agents}
+                    muted={!file.exists}
+                    onClick={
+                      file.exists && file.scope === 'project' && file.entryCount === undefined
+                        ? () => openInstructionFile(file)
+                        : undefined
+                    }
+                    title={file.path}
+                  />
+                ))}
+              </div>
+            ))
+          )}
+        </ContextSection>
+
+        <ContextSection
+          title={translate('auto.components.rightSidebar.WorkspaceContextPanel.skills', 'Skills')}
+          count={skillsLoading && workspaceSkills.length === 0 ? null : workspaceSkills.length}
+          open={open.skills}
+          onToggle={() => toggle('skills')}
+        >
+          {workspaceSkills.length === 0 ? (
+            <EmptyRow
+              text={
+                skillsLoading
+                  ? translate(
+                      'auto.components.rightSidebar.WorkspaceContextPanel.scanning',
+                      'Scanning…'
+                    )
+                  : translate(
+                      'auto.components.rightSidebar.WorkspaceContextPanel.noSkills',
+                      'No skills discovered.'
+                    )
+              }
+            />
+          ) : (
+            skillGroups.map((group) => (
+              <div key={group.label}>
+                <div className="flex items-baseline px-3 pt-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+                  <span className="min-w-0 flex-1 truncate">{group.label}</span>
+                  <span className="tabular-nums">{group.skills.length}</span>
+                </div>
+                {group.skills.map((skill) => (
+                  <ContextRow
+                    key={skill.id}
+                    primary={skill.name}
+                    secondary={skill.skillFilePath}
+                    agents={skill.providers.filter((provider) => provider !== 'agent-skills')}
+                    title={skill.description ?? skill.skillFilePath}
+                  />
+                ))}
+              </div>
+            ))
+          )}
+        </ContextSection>
+
+        <ContextSection
+          title={translate('auto.components.rightSidebar.WorkspaceContextPanel.mcp', 'MCP servers')}
+          count={report ? counts.mcpServers : null}
+          open={open.mcp}
+          onToggle={() => toggle('mcp')}
+        >
+          {report && report.mcpFiles.every((file) => !file.inspection.exists) && !showMissing ? (
+            <EmptyRow
+              text={translate(
+                'auto.components.rightSidebar.WorkspaceContextPanel.noMcp',
+                'No MCP config files found.'
+              )}
+            />
+          ) : (
+            sortByScope(report?.mcpFiles ?? [])
+              .filter((file) => file.inspection.exists || showMissing)
+              .map((file) => (
+                <div key={file.id}>
+                  <ContextRow
+                    primary={file.inspection.candidate.label}
+                    secondary={file.path}
+                    meta={
+                      !file.inspection.exists
+                        ? translate(
+                            'auto.components.rightSidebar.WorkspaceContextPanel.missing',
+                            'not found'
+                          )
+                        : file.inspection.status === 'invalid'
+                          ? translate(
+                              'auto.components.rightSidebar.WorkspaceContextPanel.invalid',
+                              'invalid'
+                            )
+                          : String(file.inspection.servers.length)
+                    }
+                    agents={file.agents}
+                    muted={!file.inspection.exists}
+                    title={file.inspection.error ?? file.path}
+                  />
+                  {file.inspection.servers.map((server) => (
+                    <div
+                      key={`${file.id}:${server.name}`}
+                      className="flex items-baseline gap-2 py-0.5 pl-6 pr-3 text-xs"
+                    >
+                      <span
+                        className={cn(
+                          'min-w-0 truncate',
+                          server.status === 'enabled'
+                            ? 'text-foreground'
+                            : 'text-muted-foreground line-through'
+                        )}
+                      >
+                        {server.name}
+                      </span>
+                      <span className="ml-auto shrink-0 font-mono text-[10px] text-muted-foreground">
+                        {server.transport === 'http'
+                          ? (server.url ?? server.transport)
+                          : (server.command ?? server.transport)}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              ))
+          )}
+        </ContextSection>
+
+        <ContextSection
+          title={translate('auto.components.rightSidebar.WorkspaceContextPanel.hooks', 'Hooks')}
+          count={report ? counts.hooks : null}
+          open={open.hooks}
+          onToggle={() => toggle('hooks')}
+        >
+          {sortByScope(report?.hookFiles ?? [])
+            .filter((file) => file.hookCount > 0 || file.error || showMissing)
+            .map((file) => (
+              <ContextRow
+                key={file.id}
+                primary={
+                  file.error
+                    ? translate(
+                        'auto.components.rightSidebar.WorkspaceContextPanel.invalidSettings',
+                        'Invalid settings file'
+                      )
+                    : file.events.length > 0
+                      ? file.events.join(', ')
+                      : translate(
+                          'auto.components.rightSidebar.WorkspaceContextPanel.noHooksInFile',
+                          'No hooks'
+                        )
+                }
+                secondary={file.path}
+                meta={
+                  file.exists
+                    ? String(file.hookCount)
+                    : translate(
+                        'auto.components.rightSidebar.WorkspaceContextPanel.missing',
+                        'not found'
+                      )
+                }
+                agents={file.agents}
+                muted={!file.exists || file.hookCount === 0}
+                title={file.error ?? file.path}
+              />
+            ))}
+          {report && counts.hooks === 0 && !showMissing ? (
+            <EmptyRow
+              text={translate(
+                'auto.components.rightSidebar.WorkspaceContextPanel.noHooks',
+                'No agent hooks configured.'
+              )}
+            />
+          ) : null}
+        </ContextSection>
+
+        <ContextSection
+          title={translate('auto.components.rightSidebar.WorkspaceContextPanel.plugins', 'Plugins')}
+          count={report ? counts.plugins : null}
+          open={open.plugins}
+          onToggle={() => toggle('plugins')}
+        >
+          {report && report.plugins.length === 0 ? (
+            <EmptyRow
+              text={translate(
+                'auto.components.rightSidebar.WorkspaceContextPanel.noPlugins',
+                'No plugin settings found.'
+              )}
+            />
+          ) : (
+            (report?.plugins ?? [])
+              .filter((plugin) => plugin.enabled || showMissing)
+              .map((plugin) => (
+                <ContextRow
+                  key={plugin.id}
+                  primary={plugin.name}
+                  secondary={plugin.sourcePath}
+                  meta={
+                    plugin.enabled
+                      ? translate(
+                          'auto.components.rightSidebar.WorkspaceContextPanel.enabled',
+                          'enabled'
+                        )
+                      : translate(
+                          'auto.components.rightSidebar.WorkspaceContextPanel.disabled',
+                          'disabled'
+                        )
+                  }
+                  agents={plugin.agents}
+                  muted={!plugin.enabled}
+                  title={plugin.sourcePath}
+                />
+              ))
+          )}
+        </ContextSection>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/right-sidebar/right-sidebar-panel-content.tsx
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-panel-content.tsx
@@ -11,6 +11,7 @@ const AiVaultPanel = lazy(() => import('./AiVaultPanel'))
 const FolderWorkspaceWorktreesPanel = lazy(() => import('./FolderWorkspaceWorktreesPanel'))
 const FolderWorkspacePrChecksPanel = lazy(() => import('./FolderWorkspacePrChecksPanel'))
 const PluginPanel = lazy(() => import('./PluginPanel'))
+const WorkspaceContextPanel = lazy(() => import('./WorkspaceContextPanel'))
 
 type RightSidebarPanelContentProps = {
   effectiveTab: ActiveRightSidebarTab
@@ -34,6 +35,7 @@ export function RightSidebarPanelContent({
           <PortsPanel isVisible={rightSidebarOpen && effectiveTab === 'ports'} />
         )}
         {effectiveTab === 'vault' && <AiVaultPanel />}
+        {effectiveTab === 'agent-context' && <WorkspaceContextPanel />}
         {effectiveTab === 'workspaces' && <FolderWorkspaceWorktreesPanel />}
         {effectiveTab === 'pr-checks' && (
           <FolderWorkspacePrChecksPanel

--- a/src/renderer/src/components/right-sidebar/sidebar-scope-toggle.ts
+++ b/src/renderer/src/components/right-sidebar/sidebar-scope-toggle.ts
@@ -7,3 +7,7 @@ export const SIDEBAR_SCOPE_TOGGLE_ITEM_CLASS = `h-7 min-h-7 min-w-0 flex-1 basis
 
 export const SIDEBAR_SCOPE_TOGGLE_GROUP_CLASS =
   'h-7 w-full rounded-md border border-sidebar-border bg-sidebar-accent/35 shadow-xs'
+
+/** "Select all" / "Clear" pills inside a right-sidebar view menu's agent list. */
+export const SIDEBAR_AGENT_BULK_ACTION_CLASS =
+  'rounded-full px-2 py-0.5 text-[11px] font-normal text-muted-foreground focus:text-foreground'

--- a/src/renderer/src/components/right-sidebar/sidebar-scope-toggle.ts
+++ b/src/renderer/src/components/right-sidebar/sidebar-scope-toggle.ts
@@ -1,0 +1,9 @@
+// Why: match ToggleGroup's spacing+outline qualifiers so selected edges out-specify its border-l-0 collapse.
+const SIDEBAR_SCOPE_SELECTED_EDGE_CLASS =
+  'data-[spacing=0]:data-[variant=outline]:aria-[checked=true]:border-l data-[spacing=0]:data-[variant=outline]:data-[state=on]:border-l'
+
+/** Segmented scope switch shared by right-sidebar panels (Session History, Agent context). */
+export const SIDEBAR_SCOPE_TOGGLE_ITEM_CLASS = `h-7 min-h-7 min-w-0 flex-1 basis-0 shrink border border-transparent bg-transparent px-2.5 text-[11px] font-medium leading-none text-foreground shadow-none hover:bg-sidebar-accent hover:text-sidebar-accent-foreground aria-[checked=true]:border-foreground/20 aria-[checked=true]:bg-foreground/10 aria-[checked=true]:text-foreground aria-[checked=true]:shadow-xs aria-[checked=true]:hover:bg-foreground/15 aria-[checked=true]:hover:text-foreground data-[state=on]:border-foreground/20 data-[state=on]:bg-foreground/10 data-[state=on]:text-foreground data-[state=on]:shadow-xs data-[state=on]:hover:bg-foreground/15 data-[state=on]:hover:text-foreground ${SIDEBAR_SCOPE_SELECTED_EDGE_CLASS}`
+
+export const SIDEBAR_SCOPE_TOGGLE_GROUP_CLASS =
+  'h-7 w-full rounded-md border border-sidebar-border bg-sidebar-accent/35 shadow-xs'

--- a/src/renderer/src/components/right-sidebar/use-right-sidebar-activity-items.ts
+++ b/src/renderer/src/components/right-sidebar/use-right-sidebar-activity-items.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { Plug, Files, GitBranch, ListChecks, Workflow } from 'lucide-react'
+import { BookOpenText, Plug, Files, GitBranch, ListChecks, Workflow } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { useRepoById } from '@/store/selectors'
 import { isFolderRepo } from '../../../../shared/repo-kind'
@@ -103,6 +103,12 @@ export function useRightSidebarActivityItems({
         title: translate('auto.components.right.sidebar.index.83a10e3c44', 'Checks'),
         shortcut: checksShortcut === 'Unassigned' ? '' : checksShortcut,
         gitOnly: true
+      },
+      {
+        id: 'agent-context',
+        icon: BookOpenText,
+        title: translate('auto.components.right.sidebar.index.agentContext', 'Agent context'),
+        shortcut: ''
       },
       {
         id: 'ports',

--- a/src/renderer/src/components/right-sidebar/use-workspace-agent-context.test.tsx
+++ b/src/renderer/src/components/right-sidebar/use-workspace-agent-context.test.tsx
@@ -7,24 +7,35 @@ import type { AgentContextReport } from '../../../../shared/agent-context'
 
 const testState = vi.hoisted(() => ({
   worktree: null as null | { id: string; path: string },
-  runtimeTarget: { kind: 'local' } as unknown,
+  hostKind: 'local' as 'local' | 'runtime' | 'ssh' | 'unresolved',
   pending: new Map<string, (report: AgentContextReport) => void>()
 }))
 
 vi.mock('@/store/selectors', () => ({ useActiveWorktree: () => testState.worktree }))
-vi.mock('@/hooks/use-active-skill-discovery-runtime-target', () => ({
-  useActiveSkillDiscoveryRuntimeTarget: () => testState.runtimeTarget
+vi.mock('@/store', () => ({
+  useAppStore: <T,>(selector: (state: unknown) => T): T => selector({})
 }))
-vi.mock('@/hooks/useActiveProjectSkillRuntime', () => ({
-  useActiveProjectSkillRuntime: () => ({ discoveryTarget: { runtime: 'native-host' } })
+vi.mock('@/components/native-chat/native-chat-skill-discovery-context', () => ({
+  selectNativeChatSkillStateInputs: (state: unknown) => state
 }))
-vi.mock('@/hooks/useInstalledAgentSkills', () => ({
-  useInstalledAgentSkillNames: () => ({
-    skills: [],
-    sources: [],
-    loading: false,
-    refresh: async () => true
-  })
+vi.mock('./workspace-context-target', () => ({
+  resolveWorkspaceContextTarget: (_state: unknown, worktreeId: string | null) => {
+    if (!worktreeId || !testState.worktree || testState.hostKind === 'unresolved') {
+      return null
+    }
+    const cwd = testState.worktree.path
+    return {
+      key: JSON.stringify([testState.hostKind, cwd]),
+      cwd,
+      executionHostKind: testState.hostKind,
+      runtimeTarget: { kind: 'local' },
+      discoveryTarget: { cwd, worktreeId }
+    }
+  }
+}))
+vi.mock('@/runtime/runtime-skills-client', () => ({
+  // Why: skills stay pending; these tests watch the report path.
+  discoverSkillsForRuntimeTarget: () => new Promise(() => {})
 }))
 vi.mock('@/runtime/runtime-agent-context-client', () => ({
   inspectAgentContextForRuntimeTarget: (_runtime: unknown, target: { cwd: string }) =>
@@ -60,6 +71,7 @@ describe('useWorkspaceAgentContext', () => {
   }
 
   beforeEach(() => {
+    testState.hostKind = 'local'
     container = document.createElement('div')
     document.body.appendChild(container)
     root = createRoot(container)
@@ -93,6 +105,21 @@ describe('useWorkspaceAgentContext', () => {
     })
     expect(latest?.report?.target.cwd).toBe('/w/b')
     expect(latest?.loading).toBe(false)
+  })
+
+  it('names why nothing can be read for SSH and unresolved-runtime workspaces', () => {
+    testState.worktree = { id: 'a', path: '/w/a' }
+    testState.hostKind = 'ssh'
+    act(() => root.render(<Probe />))
+    expect(latest?.unavailable).toBe('ssh')
+    expect(latest?.loading).toBe(false)
+    expect(testState.pending.size).toBe(0)
+
+    testState.hostKind = 'unresolved'
+    testState.worktree = { id: 'b', path: '/w/b' }
+    act(() => root.render(<Probe />))
+    expect(latest?.unavailable).toBe('runtime-unresolved')
+    expect(latest?.report).toBeNull()
   })
 
   it('clears the report and stops loading without a worktree', () => {

--- a/src/renderer/src/components/right-sidebar/use-workspace-agent-context.test.tsx
+++ b/src/renderer/src/components/right-sidebar/use-workspace-agent-context.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AgentContextReport } from '../../../../shared/agent-context'
+
+const testState = vi.hoisted(() => ({
+  worktree: null as null | { id: string; path: string },
+  runtimeTarget: { kind: 'local' } as unknown,
+  pending: new Map<string, (report: AgentContextReport) => void>()
+}))
+
+vi.mock('@/store/selectors', () => ({ useActiveWorktree: () => testState.worktree }))
+vi.mock('@/hooks/use-active-skill-discovery-runtime-target', () => ({
+  useActiveSkillDiscoveryRuntimeTarget: () => testState.runtimeTarget
+}))
+vi.mock('@/hooks/useActiveProjectSkillRuntime', () => ({
+  useActiveProjectSkillRuntime: () => ({ discoveryTarget: { runtime: 'native-host' } })
+}))
+vi.mock('@/hooks/useInstalledAgentSkills', () => ({
+  useInstalledAgentSkillNames: () => ({
+    skills: [],
+    sources: [],
+    loading: false,
+    refresh: async () => true
+  })
+}))
+vi.mock('@/runtime/runtime-agent-context-client', () => ({
+  inspectAgentContextForRuntimeTarget: (_runtime: unknown, target: { cwd: string }) =>
+    new Promise<AgentContextReport>((resolve) => {
+      testState.pending.set(target.cwd, resolve)
+    })
+}))
+
+import {
+  useWorkspaceAgentContext,
+  type WorkspaceAgentContextState
+} from './use-workspace-agent-context'
+
+function reportFor(cwd: string): AgentContextReport {
+  return {
+    target: { kind: 'native-host', homeDir: '/home/u', cwd },
+    instructionFiles: [],
+    mcpFiles: [],
+    hookFiles: [],
+    plugins: [],
+    scannedAt: 1
+  }
+}
+
+describe('useWorkspaceAgentContext', () => {
+  let container: HTMLDivElement
+  let root: Root
+  let latest: WorkspaceAgentContextState | null = null
+
+  function Probe(): null {
+    latest = useWorkspaceAgentContext()
+    return null
+  }
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    testState.pending.clear()
+    latest = null
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  it('never shows the previous workspace report after a switch, even if its scan lands later', async () => {
+    testState.worktree = { id: 'a', path: '/w/a' }
+    act(() => root.render(<Probe />))
+    expect(latest?.loading).toBe(true)
+    expect(latest?.report).toBeNull()
+
+    testState.worktree = { id: 'b', path: '/w/b' }
+    act(() => root.render(<Probe />))
+    expect(latest?.report).toBeNull()
+
+    await act(async () => {
+      testState.pending.get('/w/a')?.(reportFor('/w/a'))
+    })
+    expect(latest?.report).toBeNull()
+    expect(latest?.loading).toBe(true)
+
+    await act(async () => {
+      testState.pending.get('/w/b')?.(reportFor('/w/b'))
+    })
+    expect(latest?.report?.target.cwd).toBe('/w/b')
+    expect(latest?.loading).toBe(false)
+  })
+
+  it('clears the report and stops loading without a worktree', () => {
+    testState.worktree = null
+    act(() => root.render(<Probe />))
+    expect(latest?.report).toBeNull()
+    expect(latest?.loading).toBe(false)
+    expect(latest?.worktreePath).toBeNull()
+  })
+})

--- a/src/renderer/src/components/right-sidebar/use-workspace-agent-context.test.tsx
+++ b/src/renderer/src/components/right-sidebar/use-workspace-agent-context.test.tsx
@@ -5,6 +5,10 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AgentContextReport } from '../../../../shared/agent-context'
 
+;(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true
+
 const testState = vi.hoisted(() => ({
   worktree: null as null | { id: string; path: string },
   hostKind: 'local' as 'local' | 'runtime' | 'ssh' | 'unresolved',
@@ -19,6 +23,7 @@ vi.mock('@/components/native-chat/native-chat-skill-discovery-context', () => ({
   selectNativeChatSkillStateInputs: (state: unknown) => state
 }))
 vi.mock('./workspace-context-target', () => ({
+  resolveWorkspaceExecutionHostId: () => 'local',
   resolveWorkspaceContextTarget: (_state: unknown, worktreeId: string | null) => {
     if (!worktreeId || !testState.worktree || testState.hostKind === 'unresolved') {
       return null

--- a/src/renderer/src/components/right-sidebar/use-workspace-agent-context.ts
+++ b/src/renderer/src/components/right-sidebar/use-workspace-agent-context.ts
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { AgentContextReport } from '../../../../shared/agent-context'
-import type { DiscoveredSkill, SkillDiscoveryTarget } from '../../../../shared/skills'
+import type {
+  DiscoveredSkill,
+  SkillDiscoverySource,
+  SkillDiscoveryTarget
+} from '../../../../shared/skills'
 import { useActiveProjectSkillRuntime } from '@/hooks/useActiveProjectSkillRuntime'
 import { useActiveSkillDiscoveryRuntimeTarget } from '@/hooks/use-active-skill-discovery-runtime-target'
 import { useInstalledAgentSkillNames } from '@/hooks/useInstalledAgentSkills'
@@ -15,6 +19,7 @@ export type WorkspaceAgentContextState = {
   loading: boolean
   error: string | null
   skills: readonly DiscoveredSkill[]
+  skillSources: readonly SkillDiscoverySource[]
   skillsLoading: boolean
   refresh: () => void
 }
@@ -100,6 +105,7 @@ export function useWorkspaceAgentContext(): WorkspaceAgentContextState {
     loading,
     error,
     skills: skillState.skills,
+    skillSources: skillState.sources,
     skillsLoading: skillState.loading,
     refresh
   }

--- a/src/renderer/src/components/right-sidebar/use-workspace-agent-context.ts
+++ b/src/renderer/src/components/right-sidebar/use-workspace-agent-context.ts
@@ -45,7 +45,13 @@ export function useWorkspaceAgentContext(): WorkspaceAgentContextState {
     discoveryTarget
   })
 
-  const [report, setReport] = useState<AgentContextReport | null>(null)
+  // Why: keyed to the target so a workspace switch never shows (or opens files
+  // from) the previous workspace's report while the new scan is in flight.
+  const [keyedReport, setKeyedReport] = useState<{
+    key: string
+    report: AgentContextReport
+  } | null>(null)
+  const report = keyedReport?.key === discoveryTargetKey ? keyedReport.report : null
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [generation, setGeneration] = useState(0)
@@ -55,7 +61,7 @@ export function useWorkspaceAgentContext(): WorkspaceAgentContextState {
 
   useEffect(() => {
     if (!runtimeTarget || !discoveryTarget) {
-      setReport(null)
+      setKeyedReport(null)
       setLoading(false)
       setError(null)
       return
@@ -66,7 +72,7 @@ export function useWorkspaceAgentContext(): WorkspaceAgentContextState {
     void inspectAgentContextForRuntimeTarget(runtimeTarget, discoveryTarget)
       .then((next) => {
         if (mountedRef.current && latestKeyRef.current === requestKey) {
-          setReport(next)
+          setKeyedReport({ key: requestKey, report: next })
         }
       })
       .catch((cause: unknown) => {

--- a/src/renderer/src/components/right-sidebar/use-workspace-agent-context.ts
+++ b/src/renderer/src/components/right-sidebar/use-workspace-agent-context.ts
@@ -2,13 +2,17 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import type { AgentContextReport } from '../../../../shared/agent-context'
 import type { DiscoveredSkill, SkillDiscoverySource } from '../../../../shared/skills'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
 import { selectNativeChatSkillStateInputs } from '@/components/native-chat/native-chat-skill-discovery-context'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import { inspectAgentContextForRuntimeTarget } from '@/runtime/runtime-agent-context-client'
 import { discoverSkillsForRuntimeTarget } from '@/runtime/runtime-skills-client'
 import { useAppStore } from '@/store'
 import { useActiveWorktree } from '@/store/selectors'
-import { resolveWorkspaceContextTarget } from './workspace-context-target'
+import {
+  resolveWorkspaceContextTarget,
+  resolveWorkspaceExecutionHostId
+} from './workspace-context-target'
 
 /** Why the panel has nothing to show even though a workspace is active. */
 export type WorkspaceAgentContextUnavailable = 'ssh' | 'runtime-unresolved'
@@ -16,6 +20,8 @@ export type WorkspaceAgentContextUnavailable = 'ssh' | 'runtime-unresolved'
 export type WorkspaceAgentContextState = {
   worktreeId: string | null
   worktreePath: string | null
+  /** The host that runs the workspace's agents, where the report is read. */
+  hostId: ExecutionHostId
   unavailable: WorkspaceAgentContextUnavailable | null
   report: AgentContextReport | null
   loading: boolean
@@ -40,6 +46,10 @@ export function useWorkspaceAgentContext(): WorkspaceAgentContextState {
   const worktree = useActiveWorktree()
   const worktreeId = worktree?.id ?? null
   const inputs = useAppStore(useShallow(selectNativeChatSkillStateInputs))
+  const hostId = useMemo(
+    () => resolveWorkspaceExecutionHostId(inputs, worktreeId),
+    [inputs, worktreeId]
+  )
   const target = useMemo(
     () => resolveWorkspaceContextTarget(inputs, worktreeId),
     [inputs, worktreeId]
@@ -124,6 +134,7 @@ export function useWorkspaceAgentContext(): WorkspaceAgentContextState {
   return {
     worktreeId,
     worktreePath: target?.cwd ?? worktree?.path ?? null,
+    hostId,
     unavailable,
     report: current(keyedReport, targetKey),
     loading,

--- a/src/renderer/src/components/right-sidebar/use-workspace-agent-context.ts
+++ b/src/renderer/src/components/right-sidebar/use-workspace-agent-context.ts
@@ -1,0 +1,100 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type { AgentContextReport } from '../../../../shared/agent-context'
+import type { DiscoveredSkill, SkillDiscoveryTarget } from '../../../../shared/skills'
+import { useActiveProjectSkillRuntime } from '@/hooks/useActiveProjectSkillRuntime'
+import { useActiveSkillDiscoveryRuntimeTarget } from '@/hooks/use-active-skill-discovery-runtime-target'
+import { useInstalledAgentSkillNames } from '@/hooks/useInstalledAgentSkills'
+import { useMountedRef } from '@/hooks/useMountedRef'
+import { inspectAgentContextForRuntimeTarget } from '@/runtime/runtime-agent-context-client'
+import { useActiveWorktree } from '@/store/selectors'
+
+export type WorkspaceAgentContextState = {
+  worktreeId: string | null
+  worktreePath: string | null
+  report: AgentContextReport | null
+  loading: boolean
+  error: string | null
+  skills: readonly DiscoveredSkill[]
+  skillsLoading: boolean
+  refresh: () => void
+}
+
+/**
+ * Agent context (instruction files, MCP, hooks, plugins) plus discovered skills
+ * for the active worktree, read on the host that runs its agents.
+ */
+export function useWorkspaceAgentContext(): WorkspaceAgentContextState {
+  const worktree = useActiveWorktree()
+  const worktreeId = worktree?.id ?? null
+  const worktreePath = worktree?.path ?? null
+  const runtimeTarget = useActiveSkillDiscoveryRuntimeTarget()
+  const { discoveryTarget: projectDiscoveryTarget } = useActiveProjectSkillRuntime()
+
+  const discoveryTarget = useMemo<SkillDiscoveryTarget | undefined>(
+    () =>
+      worktreePath
+        ? { ...projectDiscoveryTarget, cwd: worktreePath, worktreeId: worktreeId ?? undefined }
+        : undefined,
+    [projectDiscoveryTarget, worktreeId, worktreePath]
+  )
+  // Why: the target's identity churns with store writes; key effects on content.
+  const discoveryTargetKey = JSON.stringify([runtimeTarget, discoveryTarget])
+
+  const skillState = useInstalledAgentSkillNames([], {
+    enabled: Boolean(discoveryTarget),
+    discoveryTarget
+  })
+
+  const [report, setReport] = useState<AgentContextReport | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [generation, setGeneration] = useState(0)
+  const mountedRef = useMountedRef()
+  const latestKeyRef = useRef(discoveryTargetKey)
+  latestKeyRef.current = discoveryTargetKey
+
+  useEffect(() => {
+    if (!runtimeTarget || !discoveryTarget) {
+      setReport(null)
+      setLoading(false)
+      setError(null)
+      return
+    }
+    const requestKey = discoveryTargetKey
+    setLoading(true)
+    setError(null)
+    void inspectAgentContextForRuntimeTarget(runtimeTarget, discoveryTarget)
+      .then((next) => {
+        if (mountedRef.current && latestKeyRef.current === requestKey) {
+          setReport(next)
+        }
+      })
+      .catch((cause: unknown) => {
+        if (mountedRef.current && latestKeyRef.current === requestKey) {
+          setError(cause instanceof Error ? cause.message : String(cause))
+        }
+      })
+      .finally(() => {
+        if (mountedRef.current && latestKeyRef.current === requestKey) {
+          setLoading(false)
+        }
+      })
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- runtimeTarget/discoveryTarget are folded into discoveryTargetKey
+  }, [discoveryTargetKey, generation, mountedRef])
+
+  const refresh = useCallback(() => {
+    setGeneration((current) => current + 1)
+    void skillState.refresh()
+  }, [skillState])
+
+  return {
+    worktreeId,
+    worktreePath,
+    report,
+    loading,
+    error,
+    skills: skillState.skills,
+    skillsLoading: skillState.loading,
+    refresh
+  }
+}

--- a/src/renderer/src/components/right-sidebar/use-workspace-agent-context.ts
+++ b/src/renderer/src/components/right-sidebar/use-workspace-agent-context.ts
@@ -1,20 +1,22 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useShallow } from 'zustand/react/shallow'
 import type { AgentContextReport } from '../../../../shared/agent-context'
-import type {
-  DiscoveredSkill,
-  SkillDiscoverySource,
-  SkillDiscoveryTarget
-} from '../../../../shared/skills'
-import { useActiveProjectSkillRuntime } from '@/hooks/useActiveProjectSkillRuntime'
-import { useActiveSkillDiscoveryRuntimeTarget } from '@/hooks/use-active-skill-discovery-runtime-target'
-import { useInstalledAgentSkillNames } from '@/hooks/useInstalledAgentSkills'
+import type { DiscoveredSkill, SkillDiscoverySource } from '../../../../shared/skills'
+import { selectNativeChatSkillStateInputs } from '@/components/native-chat/native-chat-skill-discovery-context'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import { inspectAgentContextForRuntimeTarget } from '@/runtime/runtime-agent-context-client'
+import { discoverSkillsForRuntimeTarget } from '@/runtime/runtime-skills-client'
+import { useAppStore } from '@/store'
 import { useActiveWorktree } from '@/store/selectors'
+import { resolveWorkspaceContextTarget } from './workspace-context-target'
+
+/** Why the panel has nothing to show even though a workspace is active. */
+export type WorkspaceAgentContextUnavailable = 'ssh' | 'runtime-unresolved'
 
 export type WorkspaceAgentContextState = {
   worktreeId: string | null
   worktreePath: string | null
+  unavailable: WorkspaceAgentContextUnavailable | null
   report: AgentContextReport | null
   loading: boolean
   error: string | null
@@ -24,6 +26,12 @@ export type WorkspaceAgentContextState = {
   refresh: () => void
 }
 
+type Keyed<T> = { key: string; value: T }
+
+function current<T>(keyed: Keyed<T> | null, key: string | null): T | null {
+  return keyed && key !== null && keyed.key === key ? keyed.value : null
+}
+
 /**
  * Agent context (instruction files, MCP, hooks, plugins) plus discovered skills
  * for the active worktree, read on the host that runs its agents.
@@ -31,87 +39,98 @@ export type WorkspaceAgentContextState = {
 export function useWorkspaceAgentContext(): WorkspaceAgentContextState {
   const worktree = useActiveWorktree()
   const worktreeId = worktree?.id ?? null
-  const worktreePath = worktree?.path ?? null
-  const runtimeTarget = useActiveSkillDiscoveryRuntimeTarget()
-  const { discoveryTarget: projectDiscoveryTarget } = useActiveProjectSkillRuntime()
-
-  const discoveryTarget = useMemo<SkillDiscoveryTarget | undefined>(
-    () =>
-      worktreePath
-        ? { ...projectDiscoveryTarget, cwd: worktreePath, worktreeId: worktreeId ?? undefined }
-        : undefined,
-    [projectDiscoveryTarget, worktreeId, worktreePath]
+  const inputs = useAppStore(useShallow(selectNativeChatSkillStateInputs))
+  const target = useMemo(
+    () => resolveWorkspaceContextTarget(inputs, worktreeId),
+    [inputs, worktreeId]
   )
-  // Why: the target's identity churns with store writes; key effects on content.
-  const discoveryTargetKey = JSON.stringify([runtimeTarget, discoveryTarget])
+  const targetKey = target?.key ?? null
+  const unavailable: WorkspaceAgentContextUnavailable | null =
+    target?.executionHostKind === 'ssh'
+      ? 'ssh'
+      : worktreeId && !target
+        ? 'runtime-unresolved'
+        : null
 
-  const skillState = useInstalledAgentSkillNames([], {
-    enabled: Boolean(discoveryTarget),
-    discoveryTarget
-  })
-
-  // Why: keyed to the target so a workspace switch never shows (or opens files
-  // from) the previous workspace's report while the new scan is in flight.
-  const [keyedReport, setKeyedReport] = useState<{
-    key: string
-    report: AgentContextReport
-  } | null>(null)
-  const report = keyedReport?.key === discoveryTargetKey ? keyedReport.report : null
+  // Why: results are keyed to the target so a workspace switch never shows (or
+  // opens files from) the previous workspace while the new scan is in flight.
+  const [keyedReport, setKeyedReport] = useState<Keyed<AgentContextReport> | null>(null)
+  const [keyedSkills, setKeyedSkills] = useState<Keyed<{
+    skills: DiscoveredSkill[]
+    sources: SkillDiscoverySource[]
+  }> | null>(null)
   const [loading, setLoading] = useState(false)
+  const [skillsLoading, setSkillsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [generation, setGeneration] = useState(0)
   const mountedRef = useMountedRef()
-  const latestKeyRef = useRef(discoveryTargetKey)
-  latestKeyRef.current = discoveryTargetKey
-  // Why: the effect keys on the serialised target, so the live objects travel
-  // by ref instead of being (unstable) dependencies.
-  const targetsRef = useRef({ runtimeTarget, discoveryTarget })
-  targetsRef.current = { runtimeTarget, discoveryTarget }
+  const latestKeyRef = useRef(targetKey)
+  latestKeyRef.current = targetKey
+  // Why: effects key on the serialised target; the live object travels by ref.
+  const targetRef = useRef(target)
+  targetRef.current = target
 
   useEffect(() => {
-    const { runtimeTarget, discoveryTarget } = targetsRef.current
-    if (!runtimeTarget || !discoveryTarget) {
-      setKeyedReport(null)
+    const active = targetRef.current
+    if (!active || active.executionHostKind === 'ssh') {
       setLoading(false)
+      setSkillsLoading(false)
       setError(null)
       return
     }
-    const requestKey = discoveryTargetKey
+    const requestKey = active.key
+    const still = (): boolean => mountedRef.current && latestKeyRef.current === requestKey
     setLoading(true)
+    setSkillsLoading(true)
     setError(null)
-    void inspectAgentContextForRuntimeTarget(runtimeTarget, discoveryTarget)
+    void inspectAgentContextForRuntimeTarget(active.runtimeTarget, active.discoveryTarget)
       .then((next) => {
-        if (mountedRef.current && latestKeyRef.current === requestKey) {
-          setKeyedReport({ key: requestKey, report: next })
+        if (still()) {
+          setKeyedReport({ key: requestKey, value: next })
         }
       })
       .catch((cause: unknown) => {
-        if (mountedRef.current && latestKeyRef.current === requestKey) {
+        if (still()) {
           setError(cause instanceof Error ? cause.message : String(cause))
         }
       })
       .finally(() => {
-        if (mountedRef.current && latestKeyRef.current === requestKey) {
+        if (still()) {
           setLoading(false)
         }
       })
-  }, [discoveryTargetKey, generation, mountedRef])
+    void discoverSkillsForRuntimeTarget(active.runtimeTarget, {
+      ...active.discoveryTarget,
+      refresh: generation > 0
+    })
+      .then((next) => {
+        if (still()) {
+          setKeyedSkills({ key: requestKey, value: { skills: next.skills, sources: next.sources } })
+        }
+      })
+      .catch(() => {
+        // Why: the report is still useful without skills; the section shows empty.
+      })
+      .finally(() => {
+        if (still()) {
+          setSkillsLoading(false)
+        }
+      })
+  }, [targetKey, generation, mountedRef])
 
-  const refreshSkills = skillState.refresh
-  const refresh = useCallback(() => {
-    setGeneration((current) => current + 1)
-    void refreshSkills()
-  }, [refreshSkills])
+  const refresh = useCallback(() => setGeneration((value) => value + 1), [])
+  const skillResult = current(keyedSkills, targetKey)
 
   return {
     worktreeId,
-    worktreePath,
-    report,
+    worktreePath: target?.cwd ?? worktree?.path ?? null,
+    unavailable,
+    report: current(keyedReport, targetKey),
     loading,
     error,
-    skills: skillState.skills,
-    skillSources: skillState.sources,
-    skillsLoading: skillState.loading,
+    skills: skillResult?.skills ?? [],
+    skillSources: skillResult?.sources ?? [],
+    skillsLoading,
     refresh
   }
 }

--- a/src/renderer/src/components/right-sidebar/use-workspace-agent-context.ts
+++ b/src/renderer/src/components/right-sidebar/use-workspace-agent-context.ts
@@ -63,8 +63,13 @@ export function useWorkspaceAgentContext(): WorkspaceAgentContextState {
   const mountedRef = useMountedRef()
   const latestKeyRef = useRef(discoveryTargetKey)
   latestKeyRef.current = discoveryTargetKey
+  // Why: the effect keys on the serialised target, so the live objects travel
+  // by ref instead of being (unstable) dependencies.
+  const targetsRef = useRef({ runtimeTarget, discoveryTarget })
+  targetsRef.current = { runtimeTarget, discoveryTarget }
 
   useEffect(() => {
+    const { runtimeTarget, discoveryTarget } = targetsRef.current
     if (!runtimeTarget || !discoveryTarget) {
       setKeyedReport(null)
       setLoading(false)
@@ -90,13 +95,13 @@ export function useWorkspaceAgentContext(): WorkspaceAgentContextState {
           setLoading(false)
         }
       })
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- runtimeTarget/discoveryTarget are folded into discoveryTargetKey
   }, [discoveryTargetKey, generation, mountedRef])
 
+  const refreshSkills = skillState.refresh
   const refresh = useCallback(() => {
     setGeneration((current) => current + 1)
-    void skillState.refresh()
-  }, [skillState])
+    void refreshSkills()
+  }, [refreshSkills])
 
   return {
     worktreeId,

--- a/src/renderer/src/components/right-sidebar/workspace-context-controls.tsx
+++ b/src/renderer/src/components/right-sidebar/workspace-context-controls.tsx
@@ -1,6 +1,5 @@
 import type React from 'react'
 import { ListFilter } from 'lucide-react'
-import type { AgentType } from '../../../../shared/agent-status-types'
 import type { TuiAgent } from '../../../../shared/tui-agent'
 import { Button } from '@/components/ui/button'
 import {
@@ -15,13 +14,11 @@ import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { AgentIcon, getAgentLabel } from '@/lib/agent-catalog'
 import { translate } from '@/i18n/i18n'
 import {
+  SIDEBAR_AGENT_BULK_ACTION_CLASS,
   SIDEBAR_SCOPE_TOGGLE_GROUP_CLASS,
   SIDEBAR_SCOPE_TOGGLE_ITEM_CLASS
 } from './sidebar-scope-toggle'
 import type { ContextScopeFilter } from './workspace-context-model'
-
-const AGENT_BULK_ACTION_CLASS =
-  'rounded-full px-2 py-0.5 text-[11px] font-normal text-muted-foreground focus:text-foreground'
 
 /** Workspace / User / All — the same segmented switch Session History uses for its scope. */
 export function ContextScopeSwitch({
@@ -62,12 +59,12 @@ export function ContextScopeSwitch({
 
 /**
  * View options — which agents' context to show plus the empty-location toggle.
- * `agents === null` means every agent present; the list only offers agents that
- * actually read something in this workspace.
+ * The list only offers agents that actually read something in this workspace;
+ * agents are tracked as the disabled set so a newly found agent shows up on.
  */
 export function ContextViewMenu({
   agentOptions,
-  agents,
+  disabledAgents,
   showMissing,
   adjustmentCount,
   onAgentEnabledChange,
@@ -76,7 +73,7 @@ export function ContextViewMenu({
   onReset
 }: {
   agentOptions: readonly TuiAgent[]
-  agents: readonly AgentType[] | null
+  disabledAgents: readonly TuiAgent[]
   showMissing: boolean
   adjustmentCount: number
   onAgentEnabledChange: (agent: TuiAgent, enabled: boolean) => void
@@ -84,9 +81,9 @@ export function ContextViewMenu({
   onShowMissingChange: (showMissing: boolean) => void
   onReset: () => void
 }): React.JSX.Element {
-  const isEnabled = (agent: TuiAgent): boolean => agents === null || agents.includes(agent)
-  const allSelected = agents === null || agentOptions.every(isEnabled)
-  const noneSelected = agents !== null && agents.length === 0
+  const isEnabled = (agent: TuiAgent): boolean => !disabledAgents.includes(agent)
+  const allSelected = agentOptions.every(isEnabled)
+  const noneSelected = agentOptions.length > 0 && !agentOptions.some(isEnabled)
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -124,7 +121,7 @@ export function ContextViewMenu({
                 event.preventDefault()
                 onAllAgentsEnabledChange(true)
               }}
-              className={AGENT_BULK_ACTION_CLASS}
+              className={SIDEBAR_AGENT_BULK_ACTION_CLASS}
             >
               {translate(
                 'auto.components.rightSidebar.WorkspaceContextPanel.selectAllAgents',
@@ -137,7 +134,7 @@ export function ContextViewMenu({
                 event.preventDefault()
                 onAllAgentsEnabledChange(false)
               }}
-              className={AGENT_BULK_ACTION_CLASS}
+              className={SIDEBAR_AGENT_BULK_ACTION_CLASS}
             >
               {translate('auto.components.rightSidebar.WorkspaceContextPanel.clearAgents', 'Clear')}
             </DropdownMenuItem>

--- a/src/renderer/src/components/right-sidebar/workspace-context-controls.tsx
+++ b/src/renderer/src/components/right-sidebar/workspace-context-controls.tsx
@@ -1,0 +1,182 @@
+import type React from 'react'
+import { ListFilter } from 'lucide-react'
+import type { AgentType } from '../../../../shared/agent-status-types'
+import type { TuiAgent } from '../../../../shared/tui-agent'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+import { AgentIcon, getAgentLabel } from '@/lib/agent-catalog'
+import { translate } from '@/i18n/i18n'
+import {
+  SIDEBAR_SCOPE_TOGGLE_GROUP_CLASS,
+  SIDEBAR_SCOPE_TOGGLE_ITEM_CLASS
+} from './sidebar-scope-toggle'
+import type { ContextScopeFilter } from './workspace-context-model'
+
+const AGENT_BULK_ACTION_CLASS =
+  'rounded-full px-2 py-0.5 text-[11px] font-normal text-muted-foreground focus:text-foreground'
+
+/** Workspace / User / All — the same segmented switch Session History uses for its scope. */
+export function ContextScopeSwitch({
+  scope,
+  onScopeChange
+}: {
+  scope: ContextScopeFilter
+  onScopeChange: (scope: ContextScopeFilter) => void
+}): React.JSX.Element {
+  return (
+    <ToggleGroup
+      type="single"
+      value={scope}
+      onValueChange={(value) => {
+        if (value === 'workspace' || value === 'user' || value === 'all') {
+          onScopeChange(value)
+        }
+      }}
+      variant="outline"
+      className={SIDEBAR_SCOPE_TOGGLE_GROUP_CLASS}
+      aria-label={translate(
+        'auto.components.rightSidebar.WorkspaceContextPanel.scopeAriaLabel',
+        'Agent context scope'
+      )}
+    >
+      <ToggleGroupItem value="workspace" className={SIDEBAR_SCOPE_TOGGLE_ITEM_CLASS}>
+        {translate('auto.components.rightSidebar.WorkspaceContextPanel.scopeProject', 'Workspace')}
+      </ToggleGroupItem>
+      <ToggleGroupItem value="user" className={SIDEBAR_SCOPE_TOGGLE_ITEM_CLASS}>
+        {translate('auto.components.rightSidebar.WorkspaceContextPanel.scopeHome', 'User')}
+      </ToggleGroupItem>
+      <ToggleGroupItem value="all" className={SIDEBAR_SCOPE_TOGGLE_ITEM_CLASS}>
+        {translate('auto.components.rightSidebar.WorkspaceContextPanel.filterAll', 'All')}
+      </ToggleGroupItem>
+    </ToggleGroup>
+  )
+}
+
+/**
+ * View options — which agents' context to show plus the empty-location toggle.
+ * `agents === null` means every agent present; the list only offers agents that
+ * actually read something in this workspace.
+ */
+export function ContextViewMenu({
+  agentOptions,
+  agents,
+  showMissing,
+  adjustmentCount,
+  onAgentEnabledChange,
+  onAllAgentsEnabledChange,
+  onShowMissingChange,
+  onReset
+}: {
+  agentOptions: readonly TuiAgent[]
+  agents: readonly AgentType[] | null
+  showMissing: boolean
+  adjustmentCount: number
+  onAgentEnabledChange: (agent: TuiAgent, enabled: boolean) => void
+  onAllAgentsEnabledChange: (enabled: boolean) => void
+  onShowMissingChange: (showMissing: boolean) => void
+  onReset: () => void
+}): React.JSX.Element {
+  const isEnabled = (agent: TuiAgent): boolean => agents === null || agents.includes(agent)
+  const allSelected = agents === null || agentOptions.every(isEnabled)
+  const noneSelected = agents !== null && agents.length === 0
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          className="relative text-muted-foreground hover:text-foreground"
+          aria-label={translate(
+            'auto.components.rightSidebar.WorkspaceContextPanel.viewOptions',
+            'Agent context view options'
+          )}
+        >
+          <ListFilter className="size-3" />
+          {adjustmentCount > 0 ? (
+            <span
+              aria-hidden
+              className="absolute -right-1 -top-1 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-primary px-1 text-[9px] font-medium leading-none text-primary-foreground"
+            >
+              {adjustmentCount}
+            </span>
+          ) : null}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" sideOffset={6} className="w-56">
+        <div className="flex items-center justify-between px-2 py-1">
+          <span className="text-[11px] font-semibold text-muted-foreground">
+            {translate('auto.components.rightSidebar.WorkspaceContextPanel.agents', 'Agents')}
+          </span>
+          {/* Why: real menu items so arrow keys reach them; preventDefault keeps the menu open. */}
+          <div className="flex items-center gap-1">
+            <DropdownMenuItem
+              disabled={allSelected}
+              onSelect={(event) => {
+                event.preventDefault()
+                onAllAgentsEnabledChange(true)
+              }}
+              className={AGENT_BULK_ACTION_CLASS}
+            >
+              {translate(
+                'auto.components.rightSidebar.WorkspaceContextPanel.selectAllAgents',
+                'Select all'
+              )}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              disabled={noneSelected}
+              onSelect={(event) => {
+                event.preventDefault()
+                onAllAgentsEnabledChange(false)
+              }}
+              className={AGENT_BULK_ACTION_CLASS}
+            >
+              {translate('auto.components.rightSidebar.WorkspaceContextPanel.clearAgents', 'Clear')}
+            </DropdownMenuItem>
+          </div>
+        </div>
+        {agentOptions.map((agent) => (
+          <DropdownMenuCheckboxItem
+            key={agent}
+            checked={isEnabled(agent)}
+            onCheckedChange={(checked) => onAgentEnabledChange(agent, checked === true)}
+            onSelect={(event) => event.preventDefault()}
+          >
+            <AgentIcon agent={agent} size={14} />
+            {getAgentLabel(agent)}
+          </DropdownMenuCheckboxItem>
+        ))}
+        <DropdownMenuSeparator />
+        <DropdownMenuCheckboxItem
+          checked={showMissing}
+          onCheckedChange={(checked) => onShowMissingChange(checked === true)}
+          onSelect={(event) => event.preventDefault()}
+        >
+          {translate(
+            'auto.components.rightSidebar.WorkspaceContextPanel.showMissing',
+            'Show locations that were checked but empty'
+          )}
+        </DropdownMenuCheckboxItem>
+        {adjustmentCount > 0 ? (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={onReset}>
+              {translate(
+                'auto.components.rightSidebar.WorkspaceContextPanel.resetView',
+                'Reset view'
+              )}
+            </DropdownMenuItem>
+          </>
+        ) : null}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/src/renderer/src/components/right-sidebar/workspace-context-header.tsx
+++ b/src/renderer/src/components/right-sidebar/workspace-context-header.tsx
@@ -1,0 +1,172 @@
+import type React from 'react'
+import { RefreshCw, Server } from 'lucide-react'
+import type { AgentContextReport } from '../../../../shared/agent-context'
+import {
+  getExecutionHostLabel,
+  parseExecutionHostId,
+  type ExecutionHostId
+} from '../../../../shared/execution-host'
+import type { PublicKnownRuntimeEnvironment } from '../../../../shared/runtime-environments'
+import type { TuiAgent } from '../../../../shared/tui-agent'
+import { Button } from '@/components/ui/button'
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import { ContextScopeSwitch, ContextViewMenu } from './workspace-context-controls'
+import type { ContextScopeFilter } from './workspace-context-model'
+import {
+  CONTEXT_SECTION_FILTERS,
+  type ContextSectionFilter,
+  type WorkspaceContextViewOptions
+} from './workspace-context-view-options'
+
+/**
+ * Where the report was read, in the words Session History uses for the same
+ * host: a runtime environment by its name, an SSH target by its id, this
+ * client by platform — plus the WSL distro when the local read went there.
+ */
+export function workspaceContextHostLabel(args: {
+  hostId: ExecutionHostId
+  runtimeEnvironments: readonly Pick<PublicKnownRuntimeEnvironment, 'id' | 'name'>[]
+  reportTarget: AgentContextReport['target'] | null
+}): string {
+  const parsed = parseExecutionHostId(args.hostId)
+  if (parsed?.kind === 'runtime') {
+    const environment = args.runtimeEnvironments.find((entry) => entry.id === parsed.environmentId)
+    return environment?.name.trim() || getExecutionHostLabel(parsed.id)
+  }
+  const hostLabel = getExecutionHostLabel(args.hostId)
+  if (args.reportTarget?.kind === 'wsl') {
+    return translate(
+      'auto.components.rightSidebar.WorkspaceContextPanel.hostWsl',
+      '{{value0}} · WSL {{value1}}',
+      { value0: hostLabel, value1: args.reportTarget.distro ?? '' }
+    ).trim()
+  }
+  return hostLabel
+}
+
+function sectionFilterLabel(key: ContextSectionFilter): string {
+  switch (key) {
+    case 'all':
+      return translate('auto.components.rightSidebar.WorkspaceContextPanel.filterAll', 'All')
+    case 'instructions':
+      return translate(
+        'auto.components.rightSidebar.WorkspaceContextPanel.instructions',
+        'Instructions'
+      )
+    case 'skills':
+      return translate('auto.components.rightSidebar.WorkspaceContextPanel.skills', 'Skills')
+    case 'mcp':
+      return translate('auto.components.rightSidebar.WorkspaceContextPanel.filterMcp', 'MCP')
+    case 'hooks':
+      return translate('auto.components.rightSidebar.WorkspaceContextPanel.hooks', 'Hooks')
+    default:
+      return translate('auto.components.rightSidebar.WorkspaceContextPanel.plugins', 'Plugins')
+  }
+}
+
+export function WorkspaceContextHeader({
+  subtitle,
+  hostLabel,
+  loading,
+  agentOptions,
+  options,
+  onScopeChange,
+  onSectionChange,
+  onAgentEnabledChange,
+  onAllAgentsEnabledChange,
+  onShowMissingChange,
+  onReset,
+  onRefresh
+}: {
+  subtitle: string
+  hostLabel: string
+  loading: boolean
+  agentOptions: readonly TuiAgent[]
+  options: WorkspaceContextViewOptions
+  onScopeChange: (scope: ContextScopeFilter) => void
+  onSectionChange: (section: ContextSectionFilter) => void
+  onAgentEnabledChange: (agent: TuiAgent, enabled: boolean) => void
+  onAllAgentsEnabledChange: (enabled: boolean) => void
+  onShowMissingChange: (showMissing: boolean) => void
+  onReset: () => void
+  onRefresh: () => void
+}): React.JSX.Element {
+  const adjustmentCount =
+    (options.disabledAgents.length > 0 ? 1 : 0) + (options.showMissing ? 1 : 0)
+  return (
+    <>
+      <div className="flex items-start gap-2 border-b border-border px-4 py-3">
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm font-medium text-foreground">
+            {translate('auto.components.rightSidebar.WorkspaceContextPanel.title', 'Agent context')}
+          </div>
+          <div className="mt-0.5 truncate text-xs text-muted-foreground">{subtitle}</div>
+          <div
+            className="mt-0.5 flex min-w-0 items-center gap-1 text-[11px] text-muted-foreground"
+            title={translate(
+              'auto.components.rightSidebar.WorkspaceContextPanel.hostTitle',
+              'Read on the host that runs this workspace'
+            )}
+          >
+            <Server className="size-3 shrink-0" />
+            <span className="min-w-0 truncate">{hostLabel}</span>
+          </div>
+        </div>
+        <ContextViewMenu
+          agentOptions={agentOptions}
+          disabledAgents={options.disabledAgents}
+          showMissing={options.showMissing}
+          adjustmentCount={adjustmentCount}
+          onAgentEnabledChange={onAgentEnabledChange}
+          onAllAgentsEnabledChange={onAllAgentsEnabledChange}
+          onShowMissingChange={onShowMissingChange}
+          onReset={onReset}
+        />
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          onClick={onRefresh}
+          aria-label={translate(
+            'auto.components.rightSidebar.WorkspaceContextPanel.refresh',
+            'Refresh'
+          )}
+          title={translate('auto.components.rightSidebar.WorkspaceContextPanel.refresh', 'Refresh')}
+          className="text-muted-foreground hover:text-foreground"
+        >
+          <RefreshCw className={cn(loading && 'animate-spin')} />
+        </Button>
+      </div>
+      <div className="border-b border-border px-3 py-1.5">
+        <ContextScopeSwitch scope={options.scope} onScopeChange={onScopeChange} />
+      </div>
+      <ToggleGroup
+        type="single"
+        spacing={1}
+        value={options.section}
+        onValueChange={(value) => {
+          if (value) {
+            onSectionChange(value as ContextSectionFilter)
+          }
+        }}
+        aria-label={translate(
+          'auto.components.rightSidebar.WorkspaceContextPanel.filterLabel',
+          'Filter sections'
+        )}
+        className="w-full flex-wrap justify-start rounded-none border-b border-border px-3 py-1.5"
+      >
+        {CONTEXT_SECTION_FILTERS.map((key) => (
+          <ToggleGroupItem
+            key={key}
+            value={key}
+            className="h-6 min-h-6 min-w-0 rounded-md border-0 px-2 text-[11px] font-normal text-muted-foreground shadow-none hover:bg-accent/60 hover:text-foreground data-[state=on]:bg-accent data-[state=on]:text-accent-foreground"
+          >
+            {sectionFilterLabel(key)}
+          </ToggleGroupItem>
+        ))}
+      </ToggleGroup>
+    </>
+  )
+}

--- a/src/renderer/src/components/right-sidebar/workspace-context-model.ts
+++ b/src/renderer/src/components/right-sidebar/workspace-context-model.ts
@@ -170,6 +170,29 @@ export function selectSkillsForAgents(
   return skills.filter((skill) => agents.some((agent) => skillBelongsToAgent(skill, agent, owners)))
 }
 
+type ReportRow = { agents: AgentType[]; scope: AgentContextScope }
+
+/** Every row of every kind, in one list, for filters and rollups that treat them alike. */
+function reportRows(report: AgentContextReport | null): ReportRow[] {
+  if (!report) {
+    return []
+  }
+  return [...report.instructionFiles, ...report.mcpFiles, ...report.hookFiles, ...report.plugins]
+}
+
+function filterReportRows(
+  report: AgentContextReport,
+  keep: (row: ReportRow) => boolean
+): AgentContextReport {
+  return {
+    ...report,
+    instructionFiles: report.instructionFiles.filter(keep),
+    mcpFiles: report.mcpFiles.filter(keep),
+    hookFiles: report.hookFiles.filter(keep),
+    plugins: report.plugins.filter(keep)
+  }
+}
+
 /** The report narrowed to rows any of the given agents reads; `null` returns it unchanged. */
 export function filterReportByAgents(
   report: AgentContextReport | null,
@@ -178,22 +201,21 @@ export function filterReportByAgents(
   if (!report || !agents) {
     return report
   }
-  const reads = (row: { agents: AgentType[] }): boolean =>
-    row.agents.some((agent) => agents.includes(agent))
-  return {
-    ...report,
-    instructionFiles: report.instructionFiles.filter(reads),
-    mcpFiles: report.mcpFiles.filter(reads),
-    hookFiles: report.hookFiles.filter(reads),
-    plugins: report.plugins.filter(reads)
-  }
+  return filterReportRows(report, (row) => row.agents.some((agent) => agents.includes(agent)))
 }
 
 /** Where a row comes from: the workspace tree (and its parents) or the user's home. */
 export type ContextScopeFilter = 'workspace' | 'user' | 'all'
 
 function scopeMatches(scope: AgentContextScope, filter: ContextScopeFilter): boolean {
-  return filter === 'all' || (filter === 'user') === (scope === 'home')
+  switch (filter) {
+    case 'all':
+      return true
+    case 'user':
+      return scope === 'home'
+    default:
+      return scope === 'project' || scope === 'ancestor'
+  }
 }
 
 export function filterReportByScope(
@@ -203,14 +225,7 @@ export function filterReportByScope(
   if (!report || filter === 'all') {
     return report
   }
-  const inScope = (row: { scope: AgentContextScope }): boolean => scopeMatches(row.scope, filter)
-  return {
-    ...report,
-    instructionFiles: report.instructionFiles.filter(inScope),
-    mcpFiles: report.mcpFiles.filter(inScope),
-    hookFiles: report.hookFiles.filter(inScope),
-    plugins: report.plugins.filter(inScope)
-  }
+  return filterReportRows(report, (row) => scopeMatches(row.scope, filter))
 }
 
 /** Repo skills belong to the workspace; home, plugin and bundled skills belong to the user. */
@@ -221,7 +236,8 @@ export function selectSkillsForScope(
   if (filter === 'all') {
     return [...skills]
   }
-  return skills.filter((skill) => (filter === 'workspace') === (skill.sourceKind === 'repo'))
+  const wantRepo = filter === 'workspace'
+  return skills.filter((skill) => (skill.sourceKind === 'repo') === wantRepo)
 }
 
 /** Every agent that reads at least one row or owns at least one skill root here. */
@@ -231,12 +247,7 @@ export function agentsInContext(
   sources: readonly SkillDiscoverySource[]
 ): AgentType[] {
   const agents = new Set<AgentType>()
-  for (const row of [
-    ...(report?.instructionFiles ?? []),
-    ...(report?.mcpFiles ?? []),
-    ...(report?.hookFiles ?? []),
-    ...(report?.plugins ?? [])
-  ]) {
+  for (const row of reportRows(report)) {
     for (const agent of row.agents) {
       agents.add(agent)
     }

--- a/src/renderer/src/components/right-sidebar/workspace-context-model.ts
+++ b/src/renderer/src/components/right-sidebar/workspace-context-model.ts
@@ -4,7 +4,7 @@ import type {
   AgentContextScope
 } from '../../../../shared/agent-context'
 import type { AgentType } from '../../../../shared/agent-status-types'
-import type { DiscoveredSkill } from '../../../../shared/skills'
+import type { DiscoveredSkill, SkillDiscoverySource } from '../../../../shared/skills'
 import { TUI_AGENT_DISPLAY_NAMES } from '../../../../shared/tui-agent-display-names'
 import type { TuiAgent } from '../../../../shared/tui-agent'
 
@@ -132,4 +132,88 @@ export function groupSkillsBySource(skills: readonly DiscoveredSkill[]): SkillSo
       label,
       skills: [...bucket.skills].sort((a, b) => a.name.localeCompare(b.name))
     }))
+}
+
+/** Which agent owns each discovered skill root; `null` marks a shared root every agent reads. */
+export function skillRootOwners(
+  sources: readonly SkillDiscoverySource[]
+): Map<string, AgentType | null> {
+  return new Map(sources.map((source) => [source.path, source.owner]))
+}
+
+function skillBelongsToAgent(
+  skill: DiscoveredSkill,
+  agent: AgentType,
+  owners: Map<string, AgentType | null>
+): boolean {
+  const roots = skill.rootPaths?.length ? skill.rootPaths : [skill.rootPath]
+  return roots.some((root) => {
+    const owner = owners.get(root)
+    // Why: a root discovery did not enumerate (e.g. a plugin root) falls back
+    // to the skill's providers, where `agent-skills` means every agent.
+    if (owner === undefined) {
+      return skill.providers.includes(agent as never) || skill.providers.includes('agent-skills')
+    }
+    return owner === null || owner === agent
+  })
+}
+
+export function selectSkillsForAgent(
+  skills: readonly DiscoveredSkill[],
+  sources: readonly SkillDiscoverySource[],
+  agent: AgentType | null
+): DiscoveredSkill[] {
+  if (!agent) {
+    return [...skills]
+  }
+  const owners = skillRootOwners(sources)
+  return skills.filter((skill) => skillBelongsToAgent(skill, agent, owners))
+}
+
+/** The report narrowed to rows the given agent reads; `null` returns it unchanged. */
+export function filterReportByAgent(
+  report: AgentContextReport | null,
+  agent: AgentType | null
+): AgentContextReport | null {
+  if (!report || !agent) {
+    return report
+  }
+  const reads = (row: { agents: AgentType[] }): boolean => row.agents.includes(agent)
+  return {
+    ...report,
+    instructionFiles: report.instructionFiles.filter(reads),
+    mcpFiles: report.mcpFiles.filter(reads),
+    hookFiles: report.hookFiles.filter(reads),
+    plugins: report.plugins.filter(reads)
+  }
+}
+
+/** Every agent that reads at least one row or owns at least one skill root here. */
+export function agentsInContext(
+  report: AgentContextReport | null,
+  skills: readonly DiscoveredSkill[],
+  sources: readonly SkillDiscoverySource[]
+): AgentType[] {
+  const agents = new Set<AgentType>()
+  for (const row of [
+    ...(report?.instructionFiles ?? []),
+    ...(report?.mcpFiles ?? []),
+    ...(report?.hookFiles ?? []),
+    ...(report?.plugins ?? [])
+  ]) {
+    for (const agent of row.agents) {
+      agents.add(agent)
+    }
+  }
+  const owners = skillRootOwners(sources)
+  for (const skill of skills) {
+    const roots = skill.rootPaths?.length ? skill.rootPaths : [skill.rootPath]
+    for (const root of roots) {
+      const owner = owners.get(root)
+      if (owner) {
+        agents.add(owner)
+      }
+    }
+  }
+  return [...agents]
 }

--- a/src/renderer/src/components/right-sidebar/workspace-context-model.ts
+++ b/src/renderer/src/components/right-sidebar/workspace-context-model.ts
@@ -172,14 +172,6 @@ export function selectSkillsForAgents(
 
 type ReportRow = { agents: AgentType[]; scope: AgentContextScope }
 
-/** Every row of every kind, in one list, for filters and rollups that treat them alike. */
-function reportRows(report: AgentContextReport | null): ReportRow[] {
-  if (!report) {
-    return []
-  }
-  return [...report.instructionFiles, ...report.mcpFiles, ...report.hookFiles, ...report.plugins]
-}
-
 function filterReportRows(
   report: AgentContextReport,
   keep: (row: ReportRow) => boolean
@@ -240,14 +232,27 @@ export function selectSkillsForScope(
   return skills.filter((skill) => (skill.sourceKind === 'repo') === wantRepo)
 }
 
-/** Every agent that reads at least one row or owns at least one skill root here. */
+/** Rows that actually load something — a checked-but-empty location counts for nobody. */
+function presentReportRows(report: AgentContextReport | null): ReportRow[] {
+  if (!report) {
+    return []
+  }
+  return [
+    ...report.instructionFiles.filter((file) => file.exists),
+    ...report.mcpFiles.filter((file) => file.inspection.exists),
+    ...report.hookFiles.filter((file) => file.hookCount > 0),
+    ...report.plugins.filter((plugin) => plugin.enabled)
+  ]
+}
+
+/** Every agent that loads at least one row or owns at least one skill root here. */
 export function agentsInContext(
   report: AgentContextReport | null,
   skills: readonly DiscoveredSkill[],
   sources: readonly SkillDiscoverySource[]
 ): AgentType[] {
   const agents = new Set<AgentType>()
-  for (const row of reportRows(report)) {
+  for (const row of presentReportRows(report)) {
     for (const agent of row.agents) {
       agents.add(agent)
     }

--- a/src/renderer/src/components/right-sidebar/workspace-context-model.ts
+++ b/src/renderer/src/components/right-sidebar/workspace-context-model.ts
@@ -1,0 +1,131 @@
+import type {
+  AgentContextInstructionFile,
+  AgentContextReport,
+  AgentContextScope
+} from '../../../../shared/agent-context'
+import type { AgentType } from '../../../../shared/agent-status-types'
+import type { DiscoveredSkill } from '../../../../shared/skills'
+import { TUI_AGENT_DISPLAY_NAMES } from '../../../../shared/tui-agent-display-names'
+import type { TuiAgent } from '../../../../shared/tui-agent'
+
+export function agentDisplayName(agent: AgentType): string {
+  return TUI_AGENT_DISPLAY_NAMES[agent as TuiAgent] ?? agent
+}
+
+export const SCOPE_ORDER: Record<AgentContextScope, number> = { project: 0, ancestor: 1, home: 2 }
+
+export function sortByScope<T extends { scope: AgentContextScope }>(rows: readonly T[]): T[] {
+  return [...rows].sort((a, b) => SCOPE_ORDER[a.scope] - SCOPE_ORDER[b.scope])
+}
+
+export function formatBytes(sizeBytes: number | null): string {
+  if (sizeBytes === null) {
+    return ''
+  }
+  if (sizeBytes < 1024) {
+    return `${sizeBytes} B`
+  }
+  const kib = sizeBytes / 1024
+  return kib < 100 ? `${kib.toFixed(1)} KB` : `${Math.round(kib)} KB`
+}
+
+function normalizePathForPrefix(pathValue: string): string {
+  return pathValue.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase()
+}
+
+/** Whether `child` is `parent` or sits inside it, tolerant of separator style. */
+export function isPathInside(child: string, parent: string): boolean {
+  const normalizedChild = normalizePathForPrefix(child)
+  const normalizedParent = normalizePathForPrefix(parent)
+  return normalizedChild === normalizedParent || normalizedChild.startsWith(`${normalizedParent}/`)
+}
+
+/**
+ * Discovery scans every locally registered repo's skill roots; the panel keeps
+ * global roots plus repo roots that belong to this workspace only.
+ */
+export function selectWorkspaceSkills(
+  skills: readonly DiscoveredSkill[],
+  workspaceCwd: string | null
+): DiscoveredSkill[] {
+  return skills.filter((skill) => {
+    if (skill.sourceKind !== 'repo') {
+      return true
+    }
+    if (!workspaceCwd) {
+      return false
+    }
+    const roots = skill.rootPaths?.length ? skill.rootPaths : [skill.rootPath]
+    return roots.some((root) => isPathInside(root, workspaceCwd))
+  })
+}
+
+export type InstructionFileGroup = {
+  scope: AgentContextScope
+  files: AgentContextInstructionFile[]
+}
+
+export function groupInstructionFiles(
+  files: readonly AgentContextInstructionFile[],
+  showMissing: boolean
+): InstructionFileGroup[] {
+  const groups = new Map<AgentContextScope, AgentContextInstructionFile[]>()
+  for (const file of sortByScope(files)) {
+    if (!file.exists && !showMissing) {
+      continue
+    }
+    const bucket = groups.get(file.scope) ?? []
+    bucket.push(file)
+    groups.set(file.scope, bucket)
+  }
+  return [...groups.entries()].map(([scope, groupFiles]) => ({ scope, files: groupFiles }))
+}
+
+export function countPresent(report: AgentContextReport | null): {
+  instructionFiles: number
+  mcpServers: number
+  hooks: number
+  plugins: number
+} {
+  if (!report) {
+    return { instructionFiles: 0, mcpServers: 0, hooks: 0, plugins: 0 }
+  }
+  return {
+    instructionFiles: report.instructionFiles.filter((file) => file.exists).length,
+    mcpServers: report.mcpFiles.reduce((sum, file) => sum + file.inspection.servers.length, 0),
+    hooks: report.hookFiles.reduce((sum, file) => sum + file.hookCount, 0),
+    plugins: report.plugins.filter((plugin) => plugin.enabled).length
+  }
+}
+
+export type SkillSourceGroup = { label: string; skills: DiscoveredSkill[] }
+
+const SKILL_SOURCE_KIND_ORDER: Record<DiscoveredSkill['sourceKind'], number> = {
+  repo: 0,
+  home: 1,
+  plugin: 2,
+  bundled: 3
+}
+
+/** Workspace-local skills first, then per-agent homes, then plugin caches. */
+export function groupSkillsBySource(skills: readonly DiscoveredSkill[]): SkillSourceGroup[] {
+  const groups = new Map<
+    string,
+    { kind: DiscoveredSkill['sourceKind']; skills: DiscoveredSkill[] }
+  >()
+  for (const skill of skills) {
+    const bucket = groups.get(skill.sourceLabel) ?? { kind: skill.sourceKind, skills: [] }
+    bucket.skills.push(skill)
+    groups.set(skill.sourceLabel, bucket)
+  }
+  return [...groups.entries()]
+    .sort(
+      ([labelA, a], [labelB, b]) =>
+        SKILL_SOURCE_KIND_ORDER[a.kind] - SKILL_SOURCE_KIND_ORDER[b.kind] ||
+        labelA.localeCompare(labelB)
+    )
+    .map(([label, bucket]) => ({
+      label,
+      skills: [...bucket.skills].sort((a, b) => a.name.localeCompare(b.name))
+    }))
+}

--- a/src/renderer/src/components/right-sidebar/workspace-context-model.ts
+++ b/src/renderer/src/components/right-sidebar/workspace-context-model.ts
@@ -158,27 +158,28 @@ function skillBelongsToAgent(
   })
 }
 
-export function selectSkillsForAgent(
+export function selectSkillsForAgents(
   skills: readonly DiscoveredSkill[],
   sources: readonly SkillDiscoverySource[],
-  agent: AgentType | null
+  agents: readonly AgentType[] | null
 ): DiscoveredSkill[] {
-  if (!agent) {
+  if (!agents) {
     return [...skills]
   }
   const owners = skillRootOwners(sources)
-  return skills.filter((skill) => skillBelongsToAgent(skill, agent, owners))
+  return skills.filter((skill) => agents.some((agent) => skillBelongsToAgent(skill, agent, owners)))
 }
 
-/** The report narrowed to rows the given agent reads; `null` returns it unchanged. */
-export function filterReportByAgent(
+/** The report narrowed to rows any of the given agents reads; `null` returns it unchanged. */
+export function filterReportByAgents(
   report: AgentContextReport | null,
-  agent: AgentType | null
+  agents: readonly AgentType[] | null
 ): AgentContextReport | null {
-  if (!report || !agent) {
+  if (!report || !agents) {
     return report
   }
-  const reads = (row: { agents: AgentType[] }): boolean => row.agents.includes(agent)
+  const reads = (row: { agents: AgentType[] }): boolean =>
+    row.agents.some((agent) => agents.includes(agent))
   return {
     ...report,
     instructionFiles: report.instructionFiles.filter(reads),
@@ -186,6 +187,41 @@ export function filterReportByAgent(
     hookFiles: report.hookFiles.filter(reads),
     plugins: report.plugins.filter(reads)
   }
+}
+
+/** Where a row comes from: the workspace tree (and its parents) or the user's home. */
+export type ContextScopeFilter = 'workspace' | 'user' | 'all'
+
+function scopeMatches(scope: AgentContextScope, filter: ContextScopeFilter): boolean {
+  return filter === 'all' || (filter === 'user') === (scope === 'home')
+}
+
+export function filterReportByScope(
+  report: AgentContextReport | null,
+  filter: ContextScopeFilter
+): AgentContextReport | null {
+  if (!report || filter === 'all') {
+    return report
+  }
+  const inScope = (row: { scope: AgentContextScope }): boolean => scopeMatches(row.scope, filter)
+  return {
+    ...report,
+    instructionFiles: report.instructionFiles.filter(inScope),
+    mcpFiles: report.mcpFiles.filter(inScope),
+    hookFiles: report.hookFiles.filter(inScope),
+    plugins: report.plugins.filter(inScope)
+  }
+}
+
+/** Repo skills belong to the workspace; home, plugin and bundled skills belong to the user. */
+export function selectSkillsForScope(
+  skills: readonly DiscoveredSkill[],
+  filter: ContextScopeFilter
+): DiscoveredSkill[] {
+  if (filter === 'all') {
+    return [...skills]
+  }
+  return skills.filter((skill) => (filter === 'workspace') === (skill.sourceKind === 'repo'))
 }
 
 /** Every agent that reads at least one row or owns at least one skill root here. */

--- a/src/renderer/src/components/right-sidebar/workspace-context-model.ts
+++ b/src/renderer/src/components/right-sidebar/workspace-context-model.ts
@@ -29,8 +29,12 @@ export function formatBytes(sizeBytes: number | null): string {
   return kib < 100 ? `${kib.toFixed(1)} KB` : `${Math.round(kib)} KB`
 }
 
+const WINDOWS_PATH_PATTERN = /^(?:[A-Za-z]:[\\/]|[\\/]{2}[^\\/]+[\\/])/
+
+/** Windows drive and UNC paths compare case-insensitively; POSIX paths keep case. */
 function normalizePathForPrefix(pathValue: string): string {
-  return pathValue.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase()
+  const normalized = pathValue.replace(/\\/g, '/').replace(/\/+$/, '')
+  return WINDOWS_PATH_PATTERN.test(pathValue) ? normalized.toLowerCase() : normalized
 }
 
 /** Whether `child` is `parent` or sits inside it, tolerant of separator style. */

--- a/src/renderer/src/components/right-sidebar/workspace-context-open.test.ts
+++ b/src/renderer/src/components/right-sidebar/workspace-context-open.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('sonner', () => ({ toast: { error: vi.fn() } }))
+vi.mock('@/i18n/i18n', () => ({ translate: (_key: string, fallback: string) => fallback }))
+
+import {
+  canOpenWorkspaceContextPath,
+  openWorkspaceContextPath,
+  workspaceContextAccessPath
+} from './workspace-context-open'
+
+const wslTarget = {
+  kind: 'wsl' as const,
+  distro: 'Ubuntu',
+  homeDir: '/home/u',
+  cwd: '/home/u/repo'
+}
+
+describe('workspace-context-open', () => {
+  it('opens WSL report paths through the UNC mount, native ones as they are', () => {
+    expect(workspaceContextAccessPath('/home/u/.claude.json', wslTarget)).toBe(
+      '\\\\wsl.localhost\\Ubuntu\\home\\u\\.claude.json'
+    )
+    expect(workspaceContextAccessPath('/mnt/c/src/AGENTS.md', wslTarget)).toBe('C:\\src\\AGENTS.md')
+    expect(
+      workspaceContextAccessPath('/home/u/x', {
+        kind: 'native-host',
+        homeDir: '/home/u',
+        cwd: null
+      })
+    ).toBe('/home/u/x')
+  })
+
+  it('always allows worktree files and gates the rest on the external-open permission', () => {
+    const inside = { displayPath: '/home/u/repo/CLAUDE.md', reportTarget: wslTarget }
+    const outside = { displayPath: '/home/u/.claude/CLAUDE.md', reportTarget: wslTarget }
+    expect(canOpenWorkspaceContextPath({ ...inside, allowAbsolutePaths: false })).toBe(true)
+    expect(canOpenWorkspaceContextPath({ ...outside, allowAbsolutePaths: false })).toBe(false)
+    expect(canOpenWorkspaceContextPath({ ...outside, allowAbsolutePaths: true })).toBe(true)
+  })
+
+  it('opens a WSL worktree file by its worktree-relative path and a home file as an authorized external', async () => {
+    const openFile = vi.fn()
+    const authorizeExternalPath = vi.fn(async () => {})
+    const worktree = { id: 'wt', path: '\\\\wsl.localhost\\Ubuntu\\home\\u\\repo' }
+    await openWorkspaceContextPath({
+      displayPath: '/home/u/repo/.mcp.json',
+      reportTarget: wslTarget,
+      worktree,
+      allowAbsolutePaths: true,
+      authorizeExternalPath,
+      openFile
+    })
+    expect(authorizeExternalPath).not.toHaveBeenCalled()
+    expect(openFile).toHaveBeenLastCalledWith(
+      expect.objectContaining({ relativePath: '.mcp.json', worktreeId: 'wt' })
+    )
+    await openWorkspaceContextPath({
+      displayPath: '/home/u/.codex/config.toml',
+      reportTarget: wslTarget,
+      worktree,
+      allowAbsolutePaths: true,
+      authorizeExternalPath,
+      openFile
+    })
+    const unc = '\\\\wsl.localhost\\Ubuntu\\home\\u\\.codex\\config.toml'
+    expect(authorizeExternalPath).toHaveBeenCalledWith({ targetPath: unc })
+    expect(openFile).toHaveBeenLastCalledWith(
+      expect.objectContaining({ filePath: unc, relativePath: unc, runtimeEnvironmentId: null }),
+      expect.objectContaining({ suppressActiveRuntimeFallback: true })
+    )
+  })
+
+  it('does nothing for an external path when the workspace is not local', async () => {
+    const openFile = vi.fn()
+    await openWorkspaceContextPath({
+      displayPath: '/home/u/.claude.json',
+      reportTarget: wslTarget,
+      worktree: { id: 'wt', path: '/home/u/repo' },
+      allowAbsolutePaths: false,
+      authorizeExternalPath: vi.fn(async () => {}),
+      openFile
+    })
+    expect(openFile).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/right-sidebar/workspace-context-open.ts
+++ b/src/renderer/src/components/right-sidebar/workspace-context-open.ts
@@ -1,0 +1,102 @@
+import { toast } from 'sonner'
+import type { AgentContextReport } from '../../../../shared/agent-context'
+import { toWindowsWslPath } from '../../../../shared/wsl-paths'
+import { detectLanguage } from '@/lib/language-detect'
+import { joinPath } from '@/lib/path'
+import { translate } from '@/i18n/i18n'
+import type { OpenFile } from '@/store/slices/editor'
+import { isPathInside } from './workspace-context-model'
+
+export type WorkspaceContextOpenArgs = {
+  /** The path as the report shows it — POSIX for a WSL read. */
+  displayPath: string
+  reportTarget: AgentContextReport['target']
+  worktree: { id: string; path: string }
+  /** Whether Orca may open files outside the worktree on this workspace's host. */
+  allowAbsolutePaths: boolean
+  authorizeExternalPath: (args: { targetPath: string }) => Promise<void>
+  openFile: (
+    file: Omit<OpenFile, 'id' | 'isDirty'>,
+    options?: { preview?: boolean; suppressActiveRuntimeFallback?: boolean }
+  ) => void
+}
+
+function relativeToWorkspace(pathValue: string, workspaceCwd: string): string {
+  const normalized = pathValue.replace(/\\/g, '/')
+  const base = workspaceCwd.replace(/\\/g, '/').replace(/\/+$/, '')
+  return normalized.slice(base.length + 1)
+}
+
+/** The path node fs opens for a report path: WSL reads go through the UNC mount. */
+export function workspaceContextAccessPath(
+  displayPath: string,
+  reportTarget: AgentContextReport['target']
+): string {
+  return reportTarget.kind === 'wsl' && reportTarget.distro
+    ? toWindowsWslPath(displayPath, reportTarget.distro)
+    : displayPath
+}
+
+/**
+ * Whether a row can open in the editor: anything inside the worktree always
+ * can; a file elsewhere on disk (home configs, plugin caches) only when the
+ * workspace is local, where Orca's external-file grant applies.
+ */
+export function canOpenWorkspaceContextPath(
+  args: Pick<WorkspaceContextOpenArgs, 'displayPath' | 'reportTarget' | 'allowAbsolutePaths'>
+): boolean {
+  const workspaceCwd = args.reportTarget.cwd
+  if (workspaceCwd && isPathInside(args.displayPath, workspaceCwd)) {
+    return true
+  }
+  return args.allowAbsolutePaths
+}
+
+/** Open a report path in the editor, as a worktree file when it is one, else as an authorized external file. */
+export async function openWorkspaceContextPath(args: WorkspaceContextOpenArgs): Promise<void> {
+  const { displayPath, reportTarget, worktree } = args
+  const workspaceCwd = reportTarget.cwd
+  if (workspaceCwd && isPathInside(displayPath, workspaceCwd)) {
+    const relativePath = relativeToWorkspace(displayPath, workspaceCwd)
+    args.openFile({
+      filePath: joinPath(worktree.path, relativePath),
+      relativePath,
+      worktreeId: worktree.id,
+      language: detectLanguage(relativePath),
+      mode: 'edit'
+    })
+    return
+  }
+  if (!args.allowAbsolutePaths) {
+    return
+  }
+  const accessPath = workspaceContextAccessPath(displayPath, reportTarget)
+  try {
+    // Why: the click is the trust gesture; the exact path is what gets granted.
+    await args.authorizeExternalPath({ targetPath: accessPath })
+  } catch {
+    toast.error(
+      translate(
+        'auto.components.rightSidebar.WorkspaceContextPanel.openNotAuthorized',
+        "Couldn't open {{value0}} — path not authorized.",
+        { value0: displayPath }
+      )
+    )
+    return
+  }
+  args.openFile(
+    {
+      filePath: accessPath,
+      // Why: an external file keeps relativePath === filePath so the editor
+      // reads the authorized path, not a worktree-relative reinterpretation.
+      relativePath: accessPath,
+      worktreeId: worktree.id,
+      // Why: read on the client-local host — pin local ownership so an active
+      // runtime cannot reinterpret the path as remote.
+      runtimeEnvironmentId: null,
+      language: detectLanguage(accessPath),
+      mode: 'edit'
+    },
+    { preview: false, suppressActiveRuntimeFallback: true }
+  )
+}

--- a/src/renderer/src/components/right-sidebar/workspace-context-rows.tsx
+++ b/src/renderer/src/components/right-sidebar/workspace-context-rows.tsx
@@ -1,0 +1,139 @@
+import type React from 'react'
+import { ChevronDown, ChevronRight } from 'lucide-react'
+import type { AgentContextScope } from '../../../../shared/agent-context'
+import type { AgentType } from '../../../../shared/agent-status-types'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import { agentDisplayName } from './workspace-context-model'
+
+export function scopeLabel(scope: AgentContextScope): string {
+  switch (scope) {
+    case 'project':
+      return translate(
+        'auto.components.rightSidebar.WorkspaceContextPanel.scopeProject',
+        'Workspace'
+      )
+    case 'ancestor':
+      return translate(
+        'auto.components.rightSidebar.WorkspaceContextPanel.scopeAncestor',
+        'Parent folder'
+      )
+    default:
+      return translate('auto.components.rightSidebar.WorkspaceContextPanel.scopeHome', 'User')
+  }
+}
+
+export function AgentChips({ agents }: { agents: readonly AgentType[] }): React.JSX.Element {
+  return (
+    <span className="flex flex-wrap items-center gap-1">
+      {agents.map((agent) => (
+        <span
+          key={agent}
+          className="rounded-sm border border-border px-1 py-px text-[10px] leading-4 text-muted-foreground"
+        >
+          {agentDisplayName(agent)}
+        </span>
+      ))}
+    </span>
+  )
+}
+
+export function ContextSection({
+  title,
+  count,
+  open,
+  onToggle,
+  children
+}: {
+  title: string
+  count: number | null
+  open: boolean
+  onToggle: () => void
+  children: React.ReactNode
+}): React.JSX.Element {
+  const Chevron = open ? ChevronDown : ChevronRight
+  return (
+    <section className="border-b border-border last:border-b-0">
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={open}
+        className="flex w-full items-center gap-1.5 px-3 py-2 text-left text-[11px] font-semibold uppercase tracking-[0.05em] text-muted-foreground hover:bg-accent/60 hover:text-foreground"
+      >
+        <Chevron className="size-3 shrink-0" />
+        <span className="min-w-0 flex-1 truncate">{title}</span>
+        {count !== null ? <span className="tabular-nums">{count}</span> : null}
+      </button>
+      {open ? <div className="pb-2">{children}</div> : null}
+    </section>
+  )
+}
+
+export function ContextRow({
+  primary,
+  secondary,
+  meta,
+  agents,
+  muted = false,
+  onClick,
+  title
+}: {
+  primary: string
+  secondary?: string
+  meta?: string
+  agents?: readonly AgentType[]
+  muted?: boolean
+  onClick?: () => void
+  title?: string
+}): React.JSX.Element {
+  const body = (
+    <>
+      <div className="flex min-w-0 items-baseline gap-2">
+        <span
+          className={cn(
+            'min-w-0 truncate text-xs',
+            muted ? 'text-muted-foreground' : 'text-foreground'
+          )}
+        >
+          {primary}
+        </span>
+        {meta ? (
+          <span className="ml-auto shrink-0 text-[10px] tabular-nums text-muted-foreground">
+            {meta}
+          </span>
+        ) : null}
+      </div>
+      {secondary ? (
+        <div className="truncate font-mono text-[10px] leading-4 text-muted-foreground" dir="rtl">
+          <bdi>{secondary}</bdi>
+        </div>
+      ) : null}
+      {agents && agents.length > 0 ? (
+        <div className="mt-0.5">
+          <AgentChips agents={agents} />
+        </div>
+      ) : null}
+    </>
+  )
+  const className = cn(
+    'block w-full px-3 py-1 text-left',
+    onClick &&
+      'hover:bg-accent/60 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring'
+  )
+  if (onClick) {
+    return (
+      <button type="button" className={className} onClick={onClick} title={title}>
+        {body}
+      </button>
+    )
+  }
+  return (
+    <div className={className} title={title}>
+      {body}
+    </div>
+  )
+}
+
+export function EmptyRow({ text }: { text: string }): React.JSX.Element {
+  return <div className="px-3 py-1 text-xs text-muted-foreground">{text}</div>
+}

--- a/src/renderer/src/components/right-sidebar/workspace-context-rows.tsx
+++ b/src/renderer/src/components/right-sidebar/workspace-context-rows.tsx
@@ -98,7 +98,7 @@ export function ContextRow({
           {primary}
         </span>
         {meta ? (
-          <span className="ml-auto shrink-0 text-[10px] tabular-nums text-muted-foreground">
+          <span className="ml-auto min-w-0 max-w-[50%] shrink-0 truncate text-[10px] tabular-nums text-muted-foreground">
             {meta}
           </span>
         ) : null}

--- a/src/renderer/src/components/right-sidebar/workspace-context-sections.tsx
+++ b/src/renderer/src/components/right-sidebar/workspace-context-sections.tsx
@@ -1,12 +1,12 @@
 import type React from 'react'
-import type {
-  AgentContextInstructionFile,
-  AgentContextReport
-} from '../../../../shared/agent-context'
+import type { AgentContextReport } from '../../../../shared/agent-context'
 import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
 import { formatBytes, groupInstructionFiles, sortByScope } from './workspace-context-model'
 import { ContextRow, EmptyRow, scopeLabel } from './workspace-context-rows'
+
+/** Resolves a click handler for a report path, or nothing when Orca cannot open it here. */
+export type OpenContextPath = (displayPath: string) => (() => void) | undefined
 
 type SectionBodyProps = {
   /** Already narrowed by the agent and scope filters. */
@@ -14,6 +14,7 @@ type SectionBodyProps = {
   showMissing: boolean
   /** The unfiltered report has rows here; the filters hid all of them. */
   hiddenByFilter: boolean
+  openPath: OpenContextPath
 }
 
 function emptyText(hiddenByFilter: boolean, none: string): string {
@@ -29,10 +30,8 @@ export function InstructionFilesBody({
   report,
   showMissing,
   hiddenByFilter,
-  onOpen
-}: SectionBodyProps & {
-  onOpen: (file: AgentContextInstructionFile) => void
-}): React.JSX.Element {
+  openPath
+}: SectionBodyProps): React.JSX.Element {
   const groups = groupInstructionFiles(report?.instructionFiles ?? [], showMissing)
   if (report && groups.length === 0) {
     return (
@@ -76,9 +75,7 @@ export function InstructionFilesBody({
               agents={file.agents}
               muted={!file.exists}
               onClick={
-                file.exists && file.scope === 'project' && file.entryCount === undefined
-                  ? () => onOpen(file)
-                  : undefined
+                file.exists && file.entryCount === undefined ? openPath(file.path) : undefined
               }
               title={file.path}
             />
@@ -92,7 +89,8 @@ export function InstructionFilesBody({
 export function McpFilesBody({
   report,
   showMissing,
-  hiddenByFilter
+  hiddenByFilter,
+  openPath
 }: SectionBodyProps): React.JSX.Element {
   const files = sortByScope(report?.mcpFiles ?? []).filter(
     (file) => file.inspection.exists || showMissing
@@ -130,6 +128,7 @@ export function McpFilesBody({
               }
               agents={file.agents}
               muted={!file.inspection.exists}
+              onClick={file.inspection.exists ? openPath(file.path) : undefined}
               title={file.inspection.error ?? file.path}
             />
             {file.inspection.servers.map((server) => (
@@ -167,7 +166,8 @@ export function McpFilesBody({
 export function HookFilesBody({
   report,
   showMissing,
-  hiddenByFilter
+  hiddenByFilter,
+  openPath
 }: SectionBodyProps): React.JSX.Element {
   const files = sortByScope(report?.hookFiles ?? []).filter(
     (file) => file.hookCount > 0 || file.error || showMissing
@@ -198,6 +198,7 @@ export function HookFilesBody({
           }
           agents={file.agents}
           muted={!file.exists || file.hookCount === 0}
+          onClick={file.exists ? openPath(file.path) : undefined}
           title={file.error ?? file.path}
         />
       ))}
@@ -219,7 +220,8 @@ export function HookFilesBody({
 export function PluginsBody({
   report,
   showMissing,
-  hiddenByFilter
+  hiddenByFilter,
+  openPath
 }: SectionBodyProps): React.JSX.Element {
   const plugins = (report?.plugins ?? []).filter((plugin) => plugin.enabled || showMissing)
   return (
@@ -250,6 +252,7 @@ export function PluginsBody({
             }
             agents={plugin.agents}
             muted={!plugin.enabled}
+            onClick={openPath(plugin.sourcePath)}
             title={plugin.sourcePath}
           />
         ))

--- a/src/renderer/src/components/right-sidebar/workspace-context-sections.tsx
+++ b/src/renderer/src/components/right-sidebar/workspace-context-sections.tsx
@@ -57,7 +57,10 @@ export function McpFilesBody({ report, showMissing }: SectionBodyProps): React.J
                   >
                     {server.name}
                   </span>
-                  <span className="ml-auto shrink-0 font-mono text-[10px] text-muted-foreground">
+                  <span
+                    className="ml-auto min-w-0 max-w-[60%] truncate font-mono text-[10px] text-muted-foreground"
+                    title={server.transport === 'http' ? server.url : server.command}
+                  >
                     {server.transport === 'http'
                       ? (server.url ?? server.transport)
                       : (server.command ?? server.transport)}

--- a/src/renderer/src/components/right-sidebar/workspace-context-sections.tsx
+++ b/src/renderer/src/components/right-sidebar/workspace-context-sections.tsx
@@ -1,120 +1,214 @@
 import type React from 'react'
-import type { AgentContextReport } from '../../../../shared/agent-context'
+import type {
+  AgentContextInstructionFile,
+  AgentContextReport
+} from '../../../../shared/agent-context'
 import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
-import { countPresent, sortByScope } from './workspace-context-model'
-import { ContextRow, EmptyRow } from './workspace-context-rows'
+import { formatBytes, groupInstructionFiles, sortByScope } from './workspace-context-model'
+import { ContextRow, EmptyRow, scopeLabel } from './workspace-context-rows'
 
-type SectionBodyProps = { report: AgentContextReport | null; showMissing: boolean }
+type SectionBodyProps = {
+  /** Already narrowed by the agent and scope filters. */
+  report: AgentContextReport | null
+  showMissing: boolean
+  /** The unfiltered report has rows here; the filters hid all of them. */
+  hiddenByFilter: boolean
+}
 
-export function McpFilesBody({ report, showMissing }: SectionBodyProps): React.JSX.Element {
+function emptyText(hiddenByFilter: boolean, none: string): string {
+  return hiddenByFilter
+    ? translate(
+        'auto.components.rightSidebar.WorkspaceContextPanel.hiddenByFilter',
+        'Hidden by the current filter.'
+      )
+    : none
+}
+
+export function InstructionFilesBody({
+  report,
+  showMissing,
+  hiddenByFilter,
+  onOpen
+}: SectionBodyProps & {
+  onOpen: (file: AgentContextInstructionFile) => void
+}): React.JSX.Element {
+  const groups = groupInstructionFiles(report?.instructionFiles ?? [], showMissing)
+  if (report && groups.length === 0) {
+    return (
+      <EmptyRow
+        text={emptyText(
+          hiddenByFilter,
+          translate(
+            'auto.components.rightSidebar.WorkspaceContextPanel.noInstructions',
+            'No instruction files found for this workspace.'
+          )
+        )}
+      />
+    )
+  }
   return (
     <>
-      {report && report.mcpFiles.every((file) => !file.inspection.exists) && !showMissing ? (
-        <EmptyRow
-          text={translate(
-            'auto.components.rightSidebar.WorkspaceContextPanel.noMcp',
-            'No MCP config files found.'
-          )}
-        />
-      ) : (
-        sortByScope(report?.mcpFiles ?? [])
-          .filter((file) => file.inspection.exists || showMissing)
-          .map((file) => (
-            <div key={file.id}>
-              <ContextRow
-                primary={file.inspection.candidate.label}
-                secondary={file.path}
-                meta={
-                  !file.inspection.exists
-                    ? translate(
+      {groups.map((group) => (
+        <div key={group.scope}>
+          <div className="px-3 pt-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+            {scopeLabel(group.scope)}
+          </div>
+          {group.files.map((file) => (
+            <ContextRow
+              key={file.id}
+              primary={file.label}
+              secondary={file.path}
+              meta={
+                file.entryCount !== undefined
+                  ? translate(
+                      'auto.components.rightSidebar.WorkspaceContextPanel.ruleCount',
+                      '{{value0}} rules',
+                      { value0: file.entryCount }
+                    )
+                  : file.exists
+                    ? formatBytes(file.sizeBytes)
+                    : translate(
                         'auto.components.rightSidebar.WorkspaceContextPanel.missing',
                         'not found'
                       )
-                    : file.inspection.status === 'invalid'
-                      ? translate(
-                          'auto.components.rightSidebar.WorkspaceContextPanel.invalid',
-                          'invalid'
-                        )
-                      : String(file.inspection.servers.length)
-                }
-                agents={file.agents}
-                muted={!file.inspection.exists}
-                title={file.inspection.error ?? file.path}
-              />
-              {file.inspection.servers.map((server) => (
-                <div
-                  key={`${file.id}:${server.name}`}
-                  className="flex items-baseline gap-2 py-0.5 pl-6 pr-3 text-xs"
+              }
+              agents={file.agents}
+              muted={!file.exists}
+              onClick={
+                file.exists && file.scope === 'project' && file.entryCount === undefined
+                  ? () => onOpen(file)
+                  : undefined
+              }
+              title={file.path}
+            />
+          ))}
+        </div>
+      ))}
+    </>
+  )
+}
+
+export function McpFilesBody({
+  report,
+  showMissing,
+  hiddenByFilter
+}: SectionBodyProps): React.JSX.Element {
+  const files = sortByScope(report?.mcpFiles ?? []).filter(
+    (file) => file.inspection.exists || showMissing
+  )
+  return (
+    <>
+      {report && files.length === 0 ? (
+        <EmptyRow
+          text={emptyText(
+            hiddenByFilter,
+            translate(
+              'auto.components.rightSidebar.WorkspaceContextPanel.noMcp',
+              'No MCP config files found.'
+            )
+          )}
+        />
+      ) : (
+        files.map((file) => (
+          <div key={file.id}>
+            <ContextRow
+              primary={file.inspection.candidate.label}
+              secondary={file.path}
+              meta={
+                !file.inspection.exists
+                  ? translate(
+                      'auto.components.rightSidebar.WorkspaceContextPanel.missing',
+                      'not found'
+                    )
+                  : file.inspection.status === 'invalid'
+                    ? translate(
+                        'auto.components.rightSidebar.WorkspaceContextPanel.invalid',
+                        'invalid'
+                      )
+                    : String(file.inspection.servers.length)
+              }
+              agents={file.agents}
+              muted={!file.inspection.exists}
+              title={file.inspection.error ?? file.path}
+            />
+            {file.inspection.servers.map((server) => (
+              <div
+                key={`${file.id}:${server.name}`}
+                className="flex items-baseline gap-2 py-0.5 pl-6 pr-3 text-xs"
+              >
+                <span
+                  className={cn(
+                    'min-w-0 truncate',
+                    server.status === 'enabled'
+                      ? 'text-foreground'
+                      : 'text-muted-foreground line-through'
+                  )}
                 >
-                  <span
-                    className={cn(
-                      'min-w-0 truncate',
-                      server.status === 'enabled'
-                        ? 'text-foreground'
-                        : 'text-muted-foreground line-through'
-                    )}
-                  >
-                    {server.name}
-                  </span>
-                  <span
-                    className="ml-auto min-w-0 max-w-[60%] truncate font-mono text-[10px] text-muted-foreground"
-                    title={server.transport === 'http' ? server.url : server.command}
-                  >
-                    {server.transport === 'http'
-                      ? (server.url ?? server.transport)
-                      : (server.command ?? server.transport)}
-                  </span>
-                </div>
-              ))}
-            </div>
-          ))
+                  {server.name}
+                </span>
+                <span
+                  className="ml-auto min-w-0 max-w-[60%] truncate font-mono text-[10px] text-muted-foreground"
+                  title={server.transport === 'http' ? server.url : server.command}
+                >
+                  {server.transport === 'http'
+                    ? (server.url ?? server.transport)
+                    : (server.command ?? server.transport)}
+                </span>
+              </div>
+            ))}
+          </div>
+        ))
       )}
     </>
   )
 }
 
-export function HookFilesBody({ report, showMissing }: SectionBodyProps): React.JSX.Element {
-  const counts = countPresent(report)
+export function HookFilesBody({
+  report,
+  showMissing,
+  hiddenByFilter
+}: SectionBodyProps): React.JSX.Element {
+  const files = sortByScope(report?.hookFiles ?? []).filter(
+    (file) => file.hookCount > 0 || file.error || showMissing
+  )
   return (
     <>
-      {sortByScope(report?.hookFiles ?? [])
-        .filter((file) => file.hookCount > 0 || file.error || showMissing)
-        .map((file) => (
-          <ContextRow
-            key={file.id}
-            primary={
-              file.error
-                ? translate(
-                    'auto.components.rightSidebar.WorkspaceContextPanel.invalidSettings',
-                    'Invalid settings file'
-                  )
-                : file.events.length > 0
-                  ? file.events.join(', ')
-                  : translate(
-                      'auto.components.rightSidebar.WorkspaceContextPanel.noHooksInFile',
-                      'No hooks'
-                    )
-            }
-            secondary={file.path}
-            meta={
-              file.exists
-                ? String(file.hookCount)
+      {files.map((file) => (
+        <ContextRow
+          key={file.id}
+          primary={
+            file.error
+              ? translate(
+                  'auto.components.rightSidebar.WorkspaceContextPanel.invalidSettings',
+                  'Invalid settings file'
+                )
+              : file.events.length > 0
+                ? file.events.join(', ')
                 : translate(
-                    'auto.components.rightSidebar.WorkspaceContextPanel.missing',
-                    'not found'
+                    'auto.components.rightSidebar.WorkspaceContextPanel.noHooksInFile',
+                    'No hooks'
                   )
-            }
-            agents={file.agents}
-            muted={!file.exists || file.hookCount === 0}
-            title={file.error ?? file.path}
-          />
-        ))}
-      {report && counts.hooks === 0 && !showMissing ? (
+          }
+          secondary={file.path}
+          meta={
+            file.exists
+              ? String(file.hookCount)
+              : translate('auto.components.rightSidebar.WorkspaceContextPanel.missing', 'not found')
+          }
+          agents={file.agents}
+          muted={!file.exists || file.hookCount === 0}
+          title={file.error ?? file.path}
+        />
+      ))}
+      {report && files.length === 0 ? (
         <EmptyRow
-          text={translate(
-            'auto.components.rightSidebar.WorkspaceContextPanel.noHooks',
-            'No agent hooks configured.'
+          text={emptyText(
+            hiddenByFilter,
+            translate(
+              'auto.components.rightSidebar.WorkspaceContextPanel.noHooks',
+              'No agent hooks configured.'
+            )
           )}
         />
       ) : null}
@@ -122,40 +216,43 @@ export function HookFilesBody({ report, showMissing }: SectionBodyProps): React.
   )
 }
 
-export function PluginsBody({ report, showMissing }: SectionBodyProps): React.JSX.Element {
+export function PluginsBody({
+  report,
+  showMissing,
+  hiddenByFilter
+}: SectionBodyProps): React.JSX.Element {
+  const plugins = (report?.plugins ?? []).filter((plugin) => plugin.enabled || showMissing)
   return (
     <>
-      {report && report.plugins.length === 0 ? (
+      {report && plugins.length === 0 ? (
         <EmptyRow
-          text={translate(
-            'auto.components.rightSidebar.WorkspaceContextPanel.noPlugins',
-            'No plugin settings found.'
+          text={emptyText(
+            hiddenByFilter,
+            translate(
+              'auto.components.rightSidebar.WorkspaceContextPanel.noPlugins',
+              'No enabled plugins found.'
+            )
           )}
         />
       ) : (
-        (report?.plugins ?? [])
-          .filter((plugin) => plugin.enabled || showMissing)
-          .map((plugin) => (
-            <ContextRow
-              key={plugin.id}
-              primary={plugin.name}
-              secondary={plugin.sourcePath}
-              meta={
-                plugin.enabled
-                  ? translate(
-                      'auto.components.rightSidebar.WorkspaceContextPanel.enabled',
-                      'enabled'
-                    )
-                  : translate(
-                      'auto.components.rightSidebar.WorkspaceContextPanel.disabled',
-                      'disabled'
-                    )
-              }
-              agents={plugin.agents}
-              muted={!plugin.enabled}
-              title={plugin.sourcePath}
-            />
-          ))
+        plugins.map((plugin) => (
+          <ContextRow
+            key={plugin.id}
+            primary={plugin.name}
+            secondary={plugin.sourcePath}
+            meta={
+              plugin.enabled
+                ? translate('auto.components.rightSidebar.WorkspaceContextPanel.enabled', 'enabled')
+                : translate(
+                    'auto.components.rightSidebar.WorkspaceContextPanel.disabled',
+                    'disabled'
+                  )
+            }
+            agents={plugin.agents}
+            muted={!plugin.enabled}
+            title={plugin.sourcePath}
+          />
+        ))
       )}
     </>
   )

--- a/src/renderer/src/components/right-sidebar/workspace-context-sections.tsx
+++ b/src/renderer/src/components/right-sidebar/workspace-context-sections.tsx
@@ -1,0 +1,159 @@
+import type React from 'react'
+import type { AgentContextReport } from '../../../../shared/agent-context'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import { countPresent, sortByScope } from './workspace-context-model'
+import { ContextRow, EmptyRow } from './workspace-context-rows'
+
+type SectionBodyProps = { report: AgentContextReport | null; showMissing: boolean }
+
+export function McpFilesBody({ report, showMissing }: SectionBodyProps): React.JSX.Element {
+  return (
+    <>
+      {report && report.mcpFiles.every((file) => !file.inspection.exists) && !showMissing ? (
+        <EmptyRow
+          text={translate(
+            'auto.components.rightSidebar.WorkspaceContextPanel.noMcp',
+            'No MCP config files found.'
+          )}
+        />
+      ) : (
+        sortByScope(report?.mcpFiles ?? [])
+          .filter((file) => file.inspection.exists || showMissing)
+          .map((file) => (
+            <div key={file.id}>
+              <ContextRow
+                primary={file.inspection.candidate.label}
+                secondary={file.path}
+                meta={
+                  !file.inspection.exists
+                    ? translate(
+                        'auto.components.rightSidebar.WorkspaceContextPanel.missing',
+                        'not found'
+                      )
+                    : file.inspection.status === 'invalid'
+                      ? translate(
+                          'auto.components.rightSidebar.WorkspaceContextPanel.invalid',
+                          'invalid'
+                        )
+                      : String(file.inspection.servers.length)
+                }
+                agents={file.agents}
+                muted={!file.inspection.exists}
+                title={file.inspection.error ?? file.path}
+              />
+              {file.inspection.servers.map((server) => (
+                <div
+                  key={`${file.id}:${server.name}`}
+                  className="flex items-baseline gap-2 py-0.5 pl-6 pr-3 text-xs"
+                >
+                  <span
+                    className={cn(
+                      'min-w-0 truncate',
+                      server.status === 'enabled'
+                        ? 'text-foreground'
+                        : 'text-muted-foreground line-through'
+                    )}
+                  >
+                    {server.name}
+                  </span>
+                  <span className="ml-auto shrink-0 font-mono text-[10px] text-muted-foreground">
+                    {server.transport === 'http'
+                      ? (server.url ?? server.transport)
+                      : (server.command ?? server.transport)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          ))
+      )}
+    </>
+  )
+}
+
+export function HookFilesBody({ report, showMissing }: SectionBodyProps): React.JSX.Element {
+  const counts = countPresent(report)
+  return (
+    <>
+      {sortByScope(report?.hookFiles ?? [])
+        .filter((file) => file.hookCount > 0 || file.error || showMissing)
+        .map((file) => (
+          <ContextRow
+            key={file.id}
+            primary={
+              file.error
+                ? translate(
+                    'auto.components.rightSidebar.WorkspaceContextPanel.invalidSettings',
+                    'Invalid settings file'
+                  )
+                : file.events.length > 0
+                  ? file.events.join(', ')
+                  : translate(
+                      'auto.components.rightSidebar.WorkspaceContextPanel.noHooksInFile',
+                      'No hooks'
+                    )
+            }
+            secondary={file.path}
+            meta={
+              file.exists
+                ? String(file.hookCount)
+                : translate(
+                    'auto.components.rightSidebar.WorkspaceContextPanel.missing',
+                    'not found'
+                  )
+            }
+            agents={file.agents}
+            muted={!file.exists || file.hookCount === 0}
+            title={file.error ?? file.path}
+          />
+        ))}
+      {report && counts.hooks === 0 && !showMissing ? (
+        <EmptyRow
+          text={translate(
+            'auto.components.rightSidebar.WorkspaceContextPanel.noHooks',
+            'No agent hooks configured.'
+          )}
+        />
+      ) : null}
+    </>
+  )
+}
+
+export function PluginsBody({ report, showMissing }: SectionBodyProps): React.JSX.Element {
+  return (
+    <>
+      {report && report.plugins.length === 0 ? (
+        <EmptyRow
+          text={translate(
+            'auto.components.rightSidebar.WorkspaceContextPanel.noPlugins',
+            'No plugin settings found.'
+          )}
+        />
+      ) : (
+        (report?.plugins ?? [])
+          .filter((plugin) => plugin.enabled || showMissing)
+          .map((plugin) => (
+            <ContextRow
+              key={plugin.id}
+              primary={plugin.name}
+              secondary={plugin.sourcePath}
+              meta={
+                plugin.enabled
+                  ? translate(
+                      'auto.components.rightSidebar.WorkspaceContextPanel.enabled',
+                      'enabled'
+                    )
+                  : translate(
+                      'auto.components.rightSidebar.WorkspaceContextPanel.disabled',
+                      'disabled'
+                    )
+              }
+              agents={plugin.agents}
+              muted={!plugin.enabled}
+              title={plugin.sourcePath}
+            />
+          ))
+      )}
+    </>
+  )
+}

--- a/src/renderer/src/components/right-sidebar/workspace-context-target.ts
+++ b/src/renderer/src/components/right-sidebar/workspace-context-target.ts
@@ -1,0 +1,92 @@
+import type { SkillDiscoveryTarget } from '../../../../shared/skills'
+import { parseExecutionHostId } from '../../../../shared/execution-host'
+import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
+import type { RuntimeClientTarget } from '@/runtime/runtime-rpc-client'
+import {
+  getExplicitRuntimeEnvironmentIdForWorktree,
+  getExecutionHostIdForWorktree
+} from '@/lib/worktree-runtime-owner'
+import { getLocalProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
+import type { NativeChatSkillStateInputs } from '@/components/native-chat/native-chat-skill-discovery-context'
+
+export type WorkspaceContextTarget = {
+  key: string
+  cwd: string
+  executionHostKind: 'local' | 'runtime' | 'ssh'
+  runtimeTarget: RuntimeClientTarget
+  discoveryTarget: SkillDiscoveryTarget
+}
+
+function resolveWorkspaceCwd(state: NativeChatSkillStateInputs, worktreeId: string): string | null {
+  for (const worktrees of Object.values(state.worktreesByRepo)) {
+    const worktree = worktrees.find((entry) => entry.id === worktreeId)
+    if (worktree) {
+      return worktree.path
+    }
+  }
+  const workspaceScope = parseWorkspaceKey(worktreeId)
+  if (workspaceScope?.type === 'folder') {
+    return (
+      state.folderWorkspaces.find((workspace) => workspace.id === workspaceScope.folderWorkspaceId)
+        ?.folderPath ?? null
+    )
+  }
+  return null
+}
+
+/**
+ * Which host runs this workspace's agents, and therefore where its context is
+ * read — the same rule native chat applies to skill discovery, minus the pane:
+ * SSH workspaces are inspected nowhere (the client cannot read that disk), an
+ * environment-owned workspace resolves on its runtime, everything else here.
+ */
+export function resolveWorkspaceContextTarget(
+  state: NativeChatSkillStateInputs,
+  worktreeId: string | null
+): WorkspaceContextTarget | null {
+  if (!worktreeId) {
+    return null
+  }
+  const cwd = resolveWorkspaceCwd(state, worktreeId)
+  if (!cwd) {
+    return null
+  }
+  const hostId = getExecutionHostIdForWorktree(state, worktreeId)
+  const parsedHost = parseExecutionHostId(hostId)
+  if (parsedHost?.kind === 'ssh') {
+    return {
+      key: JSON.stringify(['ssh', hostId, cwd]),
+      cwd,
+      executionHostKind: 'ssh',
+      runtimeTarget: { kind: 'local' },
+      discoveryTarget: { cwd, worktreeId }
+    }
+  }
+  const runtimeEnvironmentId = getExplicitRuntimeEnvironmentIdForWorktree(state, worktreeId)
+  if (parsedHost?.kind === 'runtime' && !runtimeEnvironmentId) {
+    return null
+  }
+  const runtimeTarget: RuntimeClientTarget = runtimeEnvironmentId
+    ? { kind: 'environment', environmentId: runtimeEnvironmentId }
+    : { kind: 'local' }
+  const projectRuntime = runtimeEnvironmentId
+    ? undefined
+    : getLocalProjectExecutionRuntimeContext(state, worktreeId)
+  const projectRuntimeKey =
+    projectRuntime?.status === 'resolved'
+      ? projectRuntime.runtime.cacheKey
+      : projectRuntime?.repair.cacheKey
+  return {
+    key: JSON.stringify([
+      runtimeTarget.kind,
+      runtimeTarget.kind === 'environment' ? runtimeTarget.environmentId : null,
+      hostId,
+      projectRuntimeKey ?? null,
+      cwd
+    ]),
+    cwd,
+    executionHostKind: runtimeEnvironmentId ? 'runtime' : 'local',
+    runtimeTarget,
+    discoveryTarget: { cwd, worktreeId, ...(projectRuntime ? { projectRuntime } : {}) }
+  }
+}

--- a/src/renderer/src/components/right-sidebar/workspace-context-target.ts
+++ b/src/renderer/src/components/right-sidebar/workspace-context-target.ts
@@ -1,5 +1,9 @@
 import type { SkillDiscoveryTarget } from '../../../../shared/skills'
-import { parseExecutionHostId } from '../../../../shared/execution-host'
+import {
+  LOCAL_EXECUTION_HOST_ID,
+  parseExecutionHostId,
+  type ExecutionHostId
+} from '../../../../shared/execution-host'
 import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
 import type { RuntimeClientTarget } from '@/runtime/runtime-rpc-client'
 import {
@@ -34,10 +38,18 @@ function resolveWorkspaceCwd(state: NativeChatSkillStateInputs, worktreeId: stri
   return null
 }
 
+/** The host that runs this workspace's agents — where the panel reads. */
+export function resolveWorkspaceExecutionHostId(
+  state: NativeChatSkillStateInputs,
+  worktreeId: string | null
+): ExecutionHostId {
+  return worktreeId ? getExecutionHostIdForWorktree(state, worktreeId) : LOCAL_EXECUTION_HOST_ID
+}
+
 /**
- * Which host runs this workspace's agents, and therefore where its context is
- * read — the same rule native chat applies to skill discovery, minus the pane:
- * SSH workspaces are inspected nowhere (the client cannot read that disk), an
+ * Where a workspace's context is read: on the host that runs its agents — the
+ * same rule native chat applies to skill discovery, minus the pane. SSH
+ * workspaces are inspected nowhere (the client cannot read that disk), an
  * environment-owned workspace resolves on its runtime, everything else here.
  */
 export function resolveWorkspaceContextTarget(
@@ -51,11 +63,11 @@ export function resolveWorkspaceContextTarget(
   if (!cwd) {
     return null
   }
-  const hostId = getExecutionHostIdForWorktree(state, worktreeId)
-  const parsedHost = parseExecutionHostId(hostId)
+  const workspaceHostId = resolveWorkspaceExecutionHostId(state, worktreeId)
+  const parsedHost = parseExecutionHostId(workspaceHostId)
   if (parsedHost?.kind === 'ssh') {
     return {
-      key: JSON.stringify(['ssh', hostId, cwd]),
+      key: JSON.stringify(['ssh', parsedHost.id, cwd]),
       cwd,
       executionHostKind: 'ssh',
       runtimeTarget: { kind: 'local' },
@@ -80,7 +92,7 @@ export function resolveWorkspaceContextTarget(
     key: JSON.stringify([
       runtimeTarget.kind,
       runtimeTarget.kind === 'environment' ? runtimeTarget.environmentId : null,
-      hostId,
+      workspaceHostId,
       projectRuntimeKey ?? null,
       cwd
     ]),

--- a/src/renderer/src/components/right-sidebar/workspace-context-view-options.test.ts
+++ b/src/renderer/src/components/right-sidebar/workspace-context-view-options.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createDefaultWorkspaceContextViewOptions,
+  normalizeWorkspaceContextViewOptions,
+  readWorkspaceContextViewOptions,
+  WORKSPACE_CONTEXT_VIEW_OPTIONS_STORAGE_KEY,
+  writeWorkspaceContextViewOptions
+} from './workspace-context-view-options'
+
+function memoryStorage(): {
+  getItem: (key: string) => string | null
+  setItem: (key: string, value: string) => void
+  data: Map<string, string>
+} {
+  const data = new Map<string, string>()
+  return {
+    data,
+    getItem: (key) => data.get(key) ?? null,
+    setItem: (key, value) => {
+      data.set(key, value)
+    }
+  }
+}
+
+describe('workspace-context-view-options', () => {
+  it('round-trips through storage and drops what it does not recognise', () => {
+    const storage = memoryStorage()
+    writeWorkspaceContextViewOptions(
+      { disabledAgents: ['codex', 'codex'], scope: 'user', section: 'mcp', showMissing: true },
+      storage
+    )
+    expect(readWorkspaceContextViewOptions(storage)).toEqual({
+      disabledAgents: ['codex'],
+      scope: 'user',
+      section: 'mcp',
+      showMissing: true
+    })
+    storage.data.set(
+      WORKSPACE_CONTEXT_VIEW_OPTIONS_STORAGE_KEY,
+      JSON.stringify({ disabledAgents: ['not-an-agent', 'grok'], scope: 'nope', section: 3 })
+    )
+    expect(readWorkspaceContextViewOptions(storage)).toEqual({
+      ...createDefaultWorkspaceContextViewOptions(),
+      disabledAgents: ['grok']
+    })
+  })
+
+  it('falls back to defaults on unreadable storage', () => {
+    const storage = memoryStorage()
+    storage.data.set(WORKSPACE_CONTEXT_VIEW_OPTIONS_STORAGE_KEY, '{not json')
+    expect(readWorkspaceContextViewOptions(storage)).toEqual(
+      createDefaultWorkspaceContextViewOptions()
+    )
+    expect(readWorkspaceContextViewOptions(null)).toEqual(
+      createDefaultWorkspaceContextViewOptions()
+    )
+    expect(normalizeWorkspaceContextViewOptions(undefined)).toEqual(
+      createDefaultWorkspaceContextViewOptions()
+    )
+  })
+})

--- a/src/renderer/src/components/right-sidebar/workspace-context-view-options.ts
+++ b/src/renderer/src/components/right-sidebar/workspace-context-view-options.ts
@@ -1,0 +1,145 @@
+import { useCallback, useState } from 'react'
+import type { TuiAgent } from '../../../../shared/tui-agent'
+import { isTuiAgent } from '../../../../shared/tui-agent-config'
+import type { ContextScopeFilter } from './workspace-context-model'
+
+export const WORKSPACE_CONTEXT_VIEW_OPTIONS_STORAGE_KEY = 'orca.agentContext.viewOptions.v1'
+
+export type ContextSectionKey = 'instructions' | 'skills' | 'mcp' | 'hooks' | 'plugins'
+export type ContextSectionFilter = ContextSectionKey | 'all'
+export const CONTEXT_SECTION_FILTERS: ContextSectionFilter[] = [
+  'all',
+  'instructions',
+  'skills',
+  'mcp',
+  'hooks',
+  'plugins'
+]
+
+/**
+ * How the panel is being looked at. Agents are stored as the disabled set so a
+ * newly discovered agent shows up enabled instead of silently filtered out.
+ */
+export type WorkspaceContextViewOptions = {
+  disabledAgents: TuiAgent[]
+  scope: ContextScopeFilter
+  section: ContextSectionFilter
+  showMissing: boolean
+}
+
+type ViewOptionsStorage = {
+  getItem: (key: string) => string | null
+  setItem: (key: string, value: string) => void
+}
+
+export function createDefaultWorkspaceContextViewOptions(): WorkspaceContextViewOptions {
+  return { disabledAgents: [], scope: 'all', section: 'all', showMissing: false }
+}
+
+function isScope(value: unknown): value is ContextScopeFilter {
+  return value === 'workspace' || value === 'user' || value === 'all'
+}
+
+export function normalizeWorkspaceContextViewOptions(value: unknown): WorkspaceContextViewOptions {
+  const record = value && typeof value === 'object' ? (value as Record<string, unknown>) : {}
+  const defaults = createDefaultWorkspaceContextViewOptions()
+  return {
+    disabledAgents: Array.isArray(record.disabledAgents)
+      ? [...new Set(record.disabledAgents)].filter(isTuiAgent)
+      : defaults.disabledAgents,
+    scope: isScope(record.scope) ? record.scope : defaults.scope,
+    section: CONTEXT_SECTION_FILTERS.includes(record.section as ContextSectionFilter)
+      ? (record.section as ContextSectionFilter)
+      : defaults.section,
+    showMissing: typeof record.showMissing === 'boolean' ? record.showMissing : defaults.showMissing
+  }
+}
+
+function rendererStorage(): ViewOptionsStorage | null {
+  if (typeof window === 'undefined') {
+    return null
+  }
+  try {
+    return window.localStorage
+  } catch {
+    return null
+  }
+}
+
+export function readWorkspaceContextViewOptions(
+  storage: ViewOptionsStorage | null = rendererStorage()
+): WorkspaceContextViewOptions {
+  try {
+    const raw = storage?.getItem(WORKSPACE_CONTEXT_VIEW_OPTIONS_STORAGE_KEY)
+    return raw
+      ? normalizeWorkspaceContextViewOptions(JSON.parse(raw))
+      : createDefaultWorkspaceContextViewOptions()
+  } catch {
+    return createDefaultWorkspaceContextViewOptions()
+  }
+}
+
+export function writeWorkspaceContextViewOptions(
+  options: WorkspaceContextViewOptions,
+  storage: ViewOptionsStorage | null = rendererStorage()
+): void {
+  try {
+    storage?.setItem(
+      WORKSPACE_CONTEXT_VIEW_OPTIONS_STORAGE_KEY,
+      JSON.stringify(normalizeWorkspaceContextViewOptions(options))
+    )
+  } catch {
+    // Why: a full or blocked localStorage only loses the preference, not the panel.
+  }
+}
+
+/** Panel view options that survive tab switches and restarts (per client, like Session History). */
+export function useWorkspaceContextViewOptions(): {
+  options: WorkspaceContextViewOptions
+  update: (patch: Partial<WorkspaceContextViewOptions>) => void
+  setAgentEnabled: (agent: TuiAgent, enabled: boolean) => void
+  setAllAgentsEnabled: (enabled: boolean, agents: readonly TuiAgent[]) => void
+  reset: () => void
+} {
+  const [options, setOptions] = useState<WorkspaceContextViewOptions>(() =>
+    readWorkspaceContextViewOptions()
+  )
+  const commit = useCallback(
+    (next: (current: WorkspaceContextViewOptions) => WorkspaceContextViewOptions) =>
+      setOptions((current) => {
+        const candidate = next(current)
+        writeWorkspaceContextViewOptions(candidate)
+        return candidate
+      }),
+    []
+  )
+  const update = useCallback(
+    (patch: Partial<WorkspaceContextViewOptions>) =>
+      commit((current) => ({ ...current, ...patch })),
+    [commit]
+  )
+  const setAgentEnabled = useCallback(
+    (agent: TuiAgent, enabled: boolean) =>
+      commit((current) => ({
+        ...current,
+        disabledAgents: enabled
+          ? current.disabledAgents.filter((entry) => entry !== agent)
+          : [...new Set([...current.disabledAgents, agent])]
+      })),
+    [commit]
+  )
+  const setAllAgentsEnabled = useCallback(
+    (enabled: boolean, agents: readonly TuiAgent[]) =>
+      commit((current) => ({ ...current, disabledAgents: enabled ? [] : [...agents] })),
+    [commit]
+  )
+  const reset = useCallback(
+    () =>
+      commit((current) => ({
+        ...createDefaultWorkspaceContextViewOptions(),
+        section: current.section
+      })),
+    [commit]
+  )
+  return { options, update, setAgentEnabled, setAllAgentsEnabled, reset }
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14953,7 +14953,8 @@
           "unavailableRuntime": "Waiting for the runtime that owns this workspace.",
           "hiddenByFilter": "Hidden by the current filter.",
           "hostWsl": "{{value0}} · WSL {{value1}}",
-          "hostTitle": "Read on the host that runs this workspace"
+          "hostTitle": "Read on the host that runs this workspace",
+          "openNotAuthorized": "Couldn't open {{value0}} — path not authorized."
         }
       },
       "link": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14916,7 +14916,6 @@
         },
         "WorkspaceContextPanel": {
           "noWorkspace": "Select a workspace to see the context its agents load.",
-          "hostLocal": "This host",
           "title": "Agent context",
           "refresh": "Refresh",
           "showMissing": "Show locations that were checked but empty",
@@ -14935,7 +14934,7 @@
           "noHooksInFile": "No hooks",
           "noHooks": "No agent hooks configured.",
           "plugins": "Plugins",
-          "noPlugins": "No plugin settings found.",
+          "noPlugins": "No enabled plugins found.",
           "enabled": "enabled",
           "disabled": "disabled",
           "scopeProject": "Workspace",
@@ -14944,14 +14943,17 @@
           "filterAll": "All",
           "filterMcp": "MCP",
           "filterLabel": "Filter sections",
-          "allAgents": "All agents",
-          "clearAgentFilter": "Show all agents",
           "scopeAriaLabel": "Agent context scope",
           "viewOptions": "Agent context view options",
           "agents": "Agents",
           "selectAllAgents": "Select all",
           "clearAgents": "Clear",
-          "resetView": "Reset view"
+          "resetView": "Reset view",
+          "unavailableSsh": "Agent context is not available for SSH workspaces yet.",
+          "unavailableRuntime": "Waiting for the runtime that owns this workspace.",
+          "hiddenByFilter": "Hidden by the current filter.",
+          "hostWsl": "{{value0}} · WSL {{value1}}",
+          "hostTitle": "Read on the host that runs this workspace"
         }
       },
       "link": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14940,7 +14940,10 @@
           "disabled": "disabled",
           "scopeProject": "Workspace",
           "scopeAncestor": "Parent folder",
-          "scopeHome": "User"
+          "scopeHome": "User",
+          "filterAll": "All",
+          "filterMcp": "MCP",
+          "filterLabel": "Filter sections"
         }
       },
       "link": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14943,7 +14943,9 @@
           "scopeHome": "User",
           "filterAll": "All",
           "filterMcp": "MCP",
-          "filterLabel": "Filter sections"
+          "filterLabel": "Filter sections",
+          "allAgents": "All agents",
+          "clearAgentFilter": "Show all agents"
         }
       },
       "link": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14945,7 +14945,13 @@
           "filterMcp": "MCP",
           "filterLabel": "Filter sections",
           "allAgents": "All agents",
-          "clearAgentFilter": "Show all agents"
+          "clearAgentFilter": "Show all agents",
+          "scopeAriaLabel": "Agent context scope",
+          "viewOptions": "Agent context view options",
+          "agents": "Agents",
+          "selectAllAgents": "Select all",
+          "clearAgents": "Clear",
+          "resetView": "Reset view"
         }
       },
       "link": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11620,7 +11620,8 @@
             "fc3095d2ed": "explorer",
             "aiVaultSessionHistory": "Agents",
             "folderWorkspaces": "Attached worktrees",
-            "parentPrChecks": "PR Checks"
+            "parentPrChecks": "PR Checks",
+            "agentContext": "Agent context"
           },
           "right": {
             "panel": {
@@ -14912,6 +14913,34 @@
           "actionsUnavailable": "Plugin actions are not available in this client.",
           "messageTooLarge": "Message exceeds the size limit.",
           "tooManyRequests": "Too many requests."
+        },
+        "WorkspaceContextPanel": {
+          "noWorkspace": "Select a workspace to see the context its agents load.",
+          "hostLocal": "This host",
+          "title": "Agent context",
+          "refresh": "Refresh",
+          "showMissing": "Show locations that were checked but empty",
+          "instructions": "Instructions",
+          "noInstructions": "No instruction files found for this workspace.",
+          "ruleCount": "{{value0}} rules",
+          "missing": "not found",
+          "skills": "Skills",
+          "scanning": "Scanning…",
+          "noSkills": "No skills discovered.",
+          "mcp": "MCP servers",
+          "noMcp": "No MCP config files found.",
+          "invalid": "invalid",
+          "hooks": "Hooks",
+          "invalidSettings": "Invalid settings file",
+          "noHooksInFile": "No hooks",
+          "noHooks": "No agent hooks configured.",
+          "plugins": "Plugins",
+          "noPlugins": "No plugin settings found.",
+          "enabled": "enabled",
+          "disabled": "disabled",
+          "scopeProject": "Workspace",
+          "scopeAncestor": "Parent folder",
+          "scopeHome": "User"
         }
       },
       "link": {

--- a/src/renderer/src/runtime/runtime-agent-context-client.ts
+++ b/src/renderer/src/runtime/runtime-agent-context-client.ts
@@ -1,0 +1,24 @@
+import type { AgentContextInspectTarget, AgentContextReport } from '../../../shared/agent-context'
+import { callRuntimeRpc, type RuntimeClientTarget } from './runtime-rpc-client'
+
+const AGENT_CONTEXT_TIMEOUT_MS = 15_000
+
+/**
+ * Inspect agent context on the runtime that runs the agents — same host rule as
+ * `discoverSkillsForRuntimeTarget`: a remote runtime receives workspace identity
+ * only, never the client's WSL/project-runtime resolution.
+ */
+export async function inspectAgentContextForRuntimeTarget(
+  runtimeTarget: RuntimeClientTarget,
+  target?: AgentContextInspectTarget
+): Promise<AgentContextReport> {
+  if (runtimeTarget.kind === 'local') {
+    return window.api.agentContext.inspect(target)
+  }
+  return callRuntimeRpc<AgentContextReport>(
+    runtimeTarget,
+    'agentContext.inspect',
+    { cwd: target?.cwd, worktreeId: target?.worktreeId },
+    { timeoutMs: AGENT_CONTEXT_TIMEOUT_MS }
+  )
+}

--- a/src/renderer/src/store/right-sidebar-route.ts
+++ b/src/renderer/src/store/right-sidebar-route.ts
@@ -46,7 +46,8 @@ export function normalizeRightSidebarRoute(
     tab === 'pr-checks' ||
     tab === 'source-control' ||
     tab === 'checks' ||
-    tab === 'ports'
+    tab === 'ports' ||
+    tab === 'agent-context'
   ) {
     return {
       rightSidebarTab: tab,

--- a/src/renderer/src/web/web-preload-api-ui.test.ts
+++ b/src/renderer/src/web/web-preload-api-ui.test.ts
@@ -607,6 +607,53 @@ describe('web UI preload API', () => {
     )
   })
 
+  it('forwards only workspace identity for paired agent context inspection', async () => {
+    const calls: { method: string; params: unknown }[] = []
+    vi.doMock('./web-runtime-client', () => ({
+      WebRuntimeClient: class {
+        call(method: string, params: unknown): Promise<RuntimeRpcResponse<unknown>> {
+          calls.push({ method, params })
+          return Promise.resolve({
+            id: method,
+            ok: true,
+            result: {
+              target: { kind: 'native-host', homeDir: '/home/u', cwd: '/repo/worktree' },
+              instructionFiles: [],
+              mcpFiles: [],
+              hookFiles: [],
+              plugins: [],
+              scannedAt: 1
+            },
+            _meta: { runtimeId: 'runtime-1' }
+          })
+        }
+
+        close(): void {}
+      }
+    }))
+
+    const globals = installBrowserGlobals('Linux')
+    writeStoredRuntimeEnvironment(globals.storage)
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+
+    await expect(
+      globals.window.api.agentContext.inspect({
+        cwd: '/repo/worktree',
+        worktreeId: 'wt-1',
+        runtime: 'wsl',
+        wslDistro: 'Ubuntu',
+        projectRuntime: {
+          status: 'resolved',
+          runtime: { kind: 'wsl', distro: 'Ubuntu' }
+        } as never
+      })
+    ).resolves.toMatchObject({ target: { cwd: '/repo/worktree' } })
+    expect(calls).toEqual([
+      { method: 'agentContext.inspect', params: { cwd: '/repo/worktree', worktreeId: 'wt-1' } }
+    ])
+  })
+
   it('rejects paired web skill discovery failures instead of returning an empty scan', async () => {
     vi.doMock('./web-runtime-client', () => ({
       WebRuntimeClient: class {

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -45,6 +45,7 @@ import type {
 import type { WorkspaceLineage, WorktreeLineage } from '../../../shared/worktree/lineage-types'
 import type { DetectedWorktreeListResult, Worktree } from '../../../shared/worktree/types'
 import type { SkillDiscoveryResult } from '../../../shared/skills'
+import type { AgentContextReport } from '../../../shared/agent-context'
 import type { SkillFreshnessInventory } from '../../../shared/skill-freshness'
 import type { SshConnectionState, SshTarget } from '../../../shared/ssh-types'
 import {
@@ -915,6 +916,7 @@ function createWebPreloadApi(): Partial<PreloadApi> {
     updater: createUpdaterApi(),
     shell: createShellApi(),
     skills: createSkillsApi(),
+    agentContext: createAgentContextApi(),
     pty: createPtyApi(),
     ssh: createSshApi(),
     wsl: {
@@ -3133,6 +3135,13 @@ function createSkillsApi(): NonNullable<Partial<PreloadApi>['skills']> {
     acknowledgeUpdateRun: () => Promise.resolve(),
     getUpdateRun: () => Promise.resolve({ state: 'idle' as const }),
     onUpdateRun: () => () => {}
+  }
+}
+
+function createAgentContextApi(): NonNullable<Partial<PreloadApi>['agentContext']> {
+  return {
+    inspect: (target) =>
+      callRuntimeResult<AgentContextReport>('agentContext.inspect', target, 15_000)
   }
 }
 

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -3140,8 +3140,14 @@ function createSkillsApi(): NonNullable<Partial<PreloadApi>['skills']> {
 
 function createAgentContextApi(): NonNullable<Partial<PreloadApi>['agentContext']> {
   return {
+    // Why: the paired runtime owns its WSL/project-runtime resolution; a client
+    // target describes the client's host, so only workspace identity crosses.
     inspect: (target) =>
-      callRuntimeResult<AgentContextReport>('agentContext.inspect', target, 15_000)
+      callRuntimeResult<AgentContextReport>(
+        'agentContext.inspect',
+        { cwd: target?.cwd, worktreeId: target?.worktreeId },
+        15_000
+      )
   }
 }
 

--- a/src/shared/agent-context.ts
+++ b/src/shared/agent-context.ts
@@ -1,0 +1,75 @@
+import type { AgentType } from './agent-status-types'
+import type { McpConfigInspection } from './mcp-config'
+import type { SkillDiscoveryTarget } from './skills'
+
+/** Where a context source sits relative to the workspace. */
+export type AgentContextScope = 'home' | 'project' | 'ancestor'
+
+/**
+ * One instruction file an agent loads at session start (CLAUDE.md, AGENTS.md,
+ * GEMINI.md, .cursorrules, …). `agents` lists every agent that reads the file;
+ * shared files (AGENTS.md) carry several.
+ */
+export type AgentContextInstructionFile = {
+  id: string
+  label: string
+  /** Host-native display path (POSIX for WSL/SSH targets). */
+  path: string
+  scope: AgentContextScope
+  agents: AgentType[]
+  exists: boolean
+  sizeBytes: number | null
+  updatedAt: number | null
+  /** Directory sources (e.g. `.cursor/rules/`) report how many rule files they hold. */
+  entryCount?: number
+}
+
+export type AgentContextMcpFile = {
+  id: string
+  /** Host-native display path. */
+  path: string
+  scope: AgentContextScope
+  agents: AgentType[]
+  inspection: McpConfigInspection
+}
+
+export type AgentContextHookFile = {
+  id: string
+  path: string
+  scope: AgentContextScope
+  agents: AgentType[]
+  exists: boolean
+  /** Hook event names declared in the file, e.g. `PreToolUse`. */
+  events: string[]
+  /** Total hook entries across all events. */
+  hookCount: number
+  error?: string
+}
+
+export type AgentContextPlugin = {
+  id: string
+  name: string
+  agents: AgentType[]
+  enabled: boolean
+  /** Settings file that decided `enabled`. */
+  sourcePath: string
+  scope: AgentContextScope
+}
+
+export type AgentContextReport = {
+  target: {
+    kind: 'native-host' | 'wsl'
+    distro?: string
+    /** Display paths — POSIX for WSL. */
+    homeDir: string
+    cwd: string | null
+  }
+  instructionFiles: AgentContextInstructionFile[]
+  mcpFiles: AgentContextMcpFile[]
+  hookFiles: AgentContextHookFile[]
+  plugins: AgentContextPlugin[]
+  scannedAt: number
+}
+
+/** Same host/workspace addressing as skill discovery: the two always name one host. */
+export type AgentContextInspectTarget = SkillDiscoveryTarget

--- a/src/shared/ui-chrome-types.ts
+++ b/src/shared/ui-chrome-types.ts
@@ -90,6 +90,7 @@ export type RightSidebarTab =
   | 'source-control'
   | 'checks'
   | 'ports'
+  | 'agent-context'
   // Plugin-contributed panels are keyed `plugin:<pluginId>/<panelId>` so the
   // static union stays closed while plugin tabs remain type-representable.
   | `plugin:${string}`


### PR DESCRIPTION
## ELI5

A new **Agent context** tab in the right sidebar shows, for the workspace you have open, everything the coding agents will load when they start: which `CLAUDE.md` / `AGENTS.md` / `GEMINI.md` / Cursor / Copilot instruction files apply (and from where), which skills are found, which MCP servers are configured, which hooks fire, and which plugins are on or off — with each row tagged by the agent(s) that read it. It can be narrowed by agent, by Workspace/User scope and by section (the same controls Session History has), says which host it read on, and every row opens in the editor. Read-only; nothing is changed on disk.

## What Changed

- **Main — `src/main/agent-context/`**: a source table (`agent-context-sources.ts`: per-agent instruction files at user / workspace / ancestor scope; `agent-config-file-sources.ts`: MCP config files and Claude settings files) and an inspector (`agent-context-inspection.ts`) returning an `AgentContextReport`.
  - Ancestor policy per agent: Claude walks `CLAUDE.md` + `CLAUDE.local.md` up to the home dir (Windows paths compared case-insensitively); Codex / OpenCode / Amp / Pi read `AGENTS.md` from parents **only up to the git root** (nearest `.git`, file or dir); Cursor / Copilot read the workspace root only. Walk capped at 8 levels.
  - MCP: workspace `.mcp.json`, `.cursor/mcp.json`, `.vscode/mcp.json` (`servers`), `.claude/mcp.json`, `.codex/config.toml`, `opencode.json`, `.gemini/settings.json`; user `~/.claude.json`, `~/.cursor/mcp.json`, `~/.gemini/settings.json`, `~/.codex/config.toml`, `~/.config/opencode/opencode.json`. JSON files use the shared `inspectMcpConfigContent`; `~/.claude.json` (Claude's whole client state, routinely > 256 KiB) is parsed and only its `mcpServers` / `projects[cwd].mcpServers` objects are handed to the shared inspector, local names shadowing user ones (`json-mcp-file.ts`). Codex TOML gets a small reader for `[mcp_servers.*]` tables incl. multi-line `args` and `env` sub-tables (`codex-mcp-toml.ts`).
  - Hooks/plugins parse Claude's `hooks` and `enabledPlugins` (user → project → local, later file wins). A `.cursor/rules/` folder with no rule files is checked-but-empty, not "0 rules present".
- **Target resolution**: reuses `resolveSkillDiscoveryTarget`, so native-host vs WSL is decided exactly as for skills; WSL reads go through the `\\wsl.localhost` mount with POSIX display paths.
- **Transports**: `agentContext:inspect` IPC + `agentContext.inspect` runtime RPC method + web-preload shim + `runtime-agent-context-client.ts` (local → IPC, environment → RPC, forwarding `{cwd, worktreeId}` only — same rule as `discoverSkillsForRuntimeTarget`). Skills are discovered at the **worktree's** cwd, so linked worktrees see their own checked-in skills.
- **Renderer**: `WorkspaceContextPanel` (right-sidebar tab `agent-context`, persisted across restarts) with:
  - `use-workspace-agent-context.ts` + `workspace-context-target.ts`: the report is read on the host that runs the workspace's agents (local / WSL project runtime / remote runtime env); SSH workspaces get an explicit "not available" state, an unresolved runtime an empty state; results are keyed to the target so a workspace switch never shows the previous one's files.
  - Header names the host (`Local Linux`, `Local Windows · WSL Ubuntu`, runtime env name, SSH target id) — a fact of the workspace, not a picker.
  - **View menu** (`workspace-context-controls.tsx`, mirroring `AiVaultPanelControls`): agent checkboxes (only agents that load something here are offered), Select all / Clear, "show locations that were checked but empty", Reset view. **Scope switch** Workspace / User / All (shared `sidebar-scope-toggle.ts` classes). **Section strip** All / Instructions / Skills / MCP / Hooks / Plugins. All persisted per client in localStorage (`workspace-context-view-options.ts`, `disabledAgents` model like Session History's).
  - Empty sections say "Hidden by the current filter." when the unfiltered report has rows.
  - **Every present row opens** (`workspace-context-open.ts`): worktree files by relative path; files outside the worktree (home configs, plugin settings, home/plugin `SKILL.md`, MCP configs) via `authorizeExternalPath` + `openFile` with local ownership pinned — the same pipeline as the tab-bar absolute-path open and Session History's View log — offered only when the workspace is local (`createTabEntryAllowAbsolutePathsSelector`); WSL paths mapped through the UNC mount.
- i18n: `en.json` keys under `auto.components.rightSidebar.WorkspaceContextPanel.*` and `auto.components.right.sidebar.index.agentContext`.

## Why

Across several agents in one workspace there is no way to see what each will actually load; the answer is spread over `~/.claude`, `~/.codex`, `~/.gemini`, `~/.config/opencode` and the repo, under different vendor rules. This is the census that #13601 (enable/disable controls) needs underneath it, and it is useful on its own for "why is the agent ignoring my rule / which AGENTS.md won?". Read-only first: writes into vendor config files are a design decision for maintainers; enumeration is not.

## Linked Issue

Fixes #14874

## Visual Proof

Before: no such tab (the activity bar ends at Checks/Ports). After, dark mode, on a workspace with Claude, Codex, Gemini, OpenCode, Cursor and Copilot configured (Linux, dev build under WSLg):

| Panel — host line, scope switch, section strip, per-row agent tags | View menu — only agents present here |
|---|---|
| ![panel](https://raw.githubusercontent.com/smanaton/orca/screenshots-agent-context/agent-context-panel/dark-panel.png) | ![view menu](https://raw.githubusercontent.com/smanaton/orca/screenshots-agent-context/agent-context-panel/dark-view-menu.png) |

MCP section, `~/.claude.json` opened in the editor from its row:

![MCP + open](https://raw.githubusercontent.com/smanaton/orca/screenshots-agent-context/agent-context-panel/dark-open.png)

## Testing

- [x] I manually tested these changes locally — `pnpm dev` on Linux (WSL2/WSLg) and the Windows dev build against a WSL project: opened this repo, verified instruction files/sizes, skills, MCP files (incl. Codex TOML and the large `~/.claude.json`), hooks, plugins; agent / scope / section filters and their persistence across tab switches; opening worktree rows and home rows (`~/.claude.json`, `~/.codex/config.toml`) in the editor. Not exercised by hand: a remote runtime environment (rides the existing skill-discovery RPC plumbing; covered by the RPC method test).
- [x] Automated tests: `src/main/agent-context/agent-context-inspection.test.ts` (per-agent rows incl. the git-root ancestor policy, empty rules dir, hooks/plugin precedence, MCP home+project via the shared inspector, oversized `~/.claude.json`, local-shadows-user, access-path routing for WSL, `buildMcpFileSources` mapping), `agent-context-target.test.ts`, `codex-mcp-toml.test.ts`, `src/main/runtime/rpc/methods/agent-context.test.ts`, `persistence-right-sidebar-tab.test.ts`; renderer: `WorkspaceContextPanel.test.tsx` (host label, SSH/unresolved states, filters, hidden-by-filter copy, view-option persistence across remount, relative + external opens, no external opens off-local), `use-workspace-agent-context.test.tsx`, `workspace-context-view-options.test.ts`, `workspace-context-open.test.ts`.

```
pnpm typecheck                                   # clean
pnpm exec oxlint src/main/agent-context src/renderer/src/components/right-sidebar   # clean
pnpm run verify:localization-catalog / -extraction / -coverage                      # clean
pnpm exec vitest run --config config/vitest.config.ts src/main/agent-context src/main/runtime/rpc/methods/agent-context.test.ts src/renderer/src/components/right-sidebar
# 217 files, 1923 tests passed
```

## AI Disclosure

Built with Claude Code (Claude Fable 5), reviewed and driven by the author.

## Review

- **Cross-platform**: paths built with `node:path` (posix for WSL targets); the WSL branch is Windows-only by construction (`resolveSkillDiscoveryTarget` throws otherwise). No shortcuts added.
- **SSH/remote/local**: local IPC for the local host; runtime RPC executes on the remote host with workspace identity only. SSH-connection workspaces show an explicit unavailable state instead of reading the client's disk at a remote path. External-file opens are offered only on local workspaces.
- **Agent/integration compatibility**: additive; per-agent conventions live in one table each for instruction files and config files, easy to extend.
- **Performance**: ~40 stats + a handful of small JSON reads per panel open, on demand only; skills come from the existing cached discovery.
- **Security**: read-only; MCP env values pass through the shared inspector's masking; settings files are size-capped (4 MB) before parse.
- **UI**: shadcn tokens/utilities only; muted rows for missing locations; agent chips use `border-border` / `text-muted-foreground`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — lint/typecheck/test as above; `pnpm build` left to CI

## Author

- GitHub: @smanaton

