### PR TITLE
feat(browser): preserve executor across authority changes

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -2589,6 +2589,7 @@
         "server-owned page-command issue and result ledger",
         "same-socket paired-runtime control requests",
         "paired desktop browser-host lifecycle composition",
+        "same-pairing browser-host authority replacement",
         "bounded client-page reconciliation execution",
         "proof-driven server page-reconciliation orchestration",
         "capability-gated client-page reconciliation commands",
@@ -2734,7 +2735,8 @@
           "assertions": [
             "exact current pages retain without navigation while runtime-missing pages restore and client orphans close",
             "profile, execution-host, authority, generation, and outcome-unknown mismatches require a close-before-restore barrier",
-            "old-epoch reclaim requires one exact persisted previous authority, authenticated paired-device provenance, an epoch transition, and the same browser-host client identity while allowing counters to restart under the new epoch",
+            "old-epoch reclaim requires one exact persisted previous authority on the same runtime, authenticated paired-device provenance, an epoch transition, and the same browser-host client identity while allowing counters to restart under the new epoch",
+            "a runtime-authority change, including an SSH page whose route key omits runtime identity, requires close-before-restore instead of DOM-preserving reclaim",
             "duplicate and over-capacity inventories fail atomically before returning a partial plan",
             "invalid identities, generations, URLs, states, limits, duplicate inventories, and over-capacity inventories fail atomically while valid records and action lists are immutable"
           ]
@@ -2840,6 +2842,7 @@
         {
           "file": "src/main/browser/paired-runtime-browser-client-host.test.ts",
           "assertions": [
+            "reconciliation is advertised only when the composed host explicitly enables it beside complete inventory",
             "exact dispatcher authority exists before the first same-socket command can arrive",
             "explicit close shuts transport before aborting every owned page handler",
             "dispatcher abort still runs when lease cleanup rejects",
@@ -2859,7 +2862,7 @@
           "file": "src/main/browser/paired-runtime-browser-client-host-composition.test.ts",
           "assertions": [
             "exact route authority activates before the first page command",
-            "host attach samples the executor's exact page inventory once",
+            "each initial or reconnect attach samples a fresh exact executor inventory while the compatibility gate binds to the latest published snapshot",
             "control loss suspends routes without closing pages and command admission waits for exact route recovery",
             "one command gate spans repeated loss while stale route recoveries cannot close the replacement",
             "page retirement settles dispatcher ownership before guest cleanup and ledger forget",
@@ -2867,6 +2870,10 @@
             "shutdown closes control transport before executor pages and every retained route",
             "non-settling handlers remove network reach immediately and defer page cleanup until exact late settlement",
             "deferred executor cleanup failures remain fenced and emit an observable composition error",
+            "same-pairing runtime replacement retires old routes, fences guest navigation, waits for old handlers, and activates retained inventory only after exact reconciliation echo",
+            "a legacy replacement remains available for empty inventory but cannot activate routes for unreconciled retained pages",
+            "retired-route cleanup failure closes the composition before replacement authority can activate",
+            "late callbacks from a replaced host generation cannot suspend or close its replacement",
             "cleanly absent failed creates are forgotten while unresolved cleanup remains fenced"
           ]
         },
@@ -2896,6 +2903,10 @@
             "legacy-valid command identities remain executable even when optional inventory cannot encode them",
             "executor capacity cannot exceed the shared 256-page attach limit",
             "failed retirement leaves immutable outcome-unknown inventory without a retryable live-page handle",
+            "authority transition retains page inventory while fencing old navigation and uses the replacement connection identity for future pages",
+            "in-flight old-authority creation rechecks transition state and releases its route without committing a page",
+            "transition revocation failure keeps later commands fenced while exact cleanup still completes",
+            "ordinary navigation requires the page inventory to match the exact command authority",
             "terminal navigation fencing revokes retained grants once and blocks late in-flight creation without inferring destruction",
             "revocation failure remains observable while exact guest, renderer, Session, and route cleanup still run"
           ]
@@ -2904,6 +2915,7 @@
           "file": "src/main/browser/browser-client-page-reconciliation-adapters.test.ts",
           "assertions": [
             "reclaim moves one exact retained guest to a new authority without remounting",
+            "DOM-preserving reclaim is rejected when the runtime authority changes",
             "restore creates fresh authority and destroys it when initial navigation cannot be proven",
             "close targets only exact prior authority",
             "renderer failure or abort after main rekey retires both possible exact renderer identities, preserves unrelated pages, destroys the guest, and reports outcome unknown"
@@ -2933,6 +2945,8 @@
           "file": "src/main/browser/paired-runtime-browser-client-host-registry.test.ts",
           "assertions": [
             "one environment pairing revision shares one host composition",
+            "a same-pairing runtime change preserves that composition and delegates exact authority replacement",
+            "a failed authority replacement retains a cleanup tombstone and cannot expose a half-active successor",
             "a changed pairing revision closes before its replacement starts",
             "unsettled host cleanup retains a bounded tombstone, blocks replacement, and releases only when deferred cleanup proves completion",
             "unresolved deferred cleanup remains fail-closed until authenticated reconciliation or process restart",
@@ -2950,6 +2964,8 @@
             "one transient route failure retries without closing healthy routes",
             "a superseded route recovery retains no retry timer",
             "persistent route failure exhausts bounded grace without leaking retry timers",
+            "authority retirement blocks admission and reconnect while retaining suspended SSH routes until exact page release",
+            "final shutdown force-closes retained retired routes",
             "registry shutdown closes every route and rejects later admission"
           ]
         },
@@ -3172,6 +3188,7 @@
           "file": "src/main/runtime/browser-network-tunnel-paired-runtime.integration.test.ts",
           "assertions": [
             "attach, page-command delivery, and result settlement share one exact authenticated connection and paired identity",
+            "same-runtime authority replacement commits placement only after the exact completed client result",
             "SOCKS HTTP bytes cross the dedicated authenticated E2EE subscription to runtime-native TCP",
             "closing the route destroys the execution-host destination socket"
           ]

--- a/docs/sta-4150-client-hosted-browser-progress.md
+++ b/docs/sta-4150-client-hosted-browser-progress.md
@@ -1,6 +1,6 @@
 # STA-4150 Client-Hosted Browser Progress
 
-Last updated: 2026-08-15
+Last updated: 2026-08-16
 
 This is the durable ownership ledger for
 [STA-4150](https://linear.app/stably/issue/STA-4150/refactor-remote-browser-to-client-hosted-electron-webviews).
@@ -36,9 +36,21 @@ Old clients and callers that omit placement must retain current server-hosted be
 - Stage 0 compatibility hardening: PR
   [#14402](https://github.com/stablyai/orca/pull/14402) is merged. It is not the long-term
   architecture and is not part of this draft stack.
-- Latest published stack tip: `sta-4150-browser-reconciliation-orchestration`, draft PR
-  [#14769](https://github.com/stablyai/orca/pull/14769), stacked on reconciliation-adapter PR
-  [#14763](https://github.com/stablyai/orca/pull/14763).
+- Latest published stack tip: `sta-4150-browser-client-executor-authority-transition`, draft PR
+  [#14876](https://github.com/stablyai/orca/pull/14876), stacked exactly on corrected
+  reconciliation-orchestration PR [#14769](https://github.com/stablyai/orca/pull/14769). It
+  preserves the concrete client executor and retained Electron inventory across a same-pairing
+  runtime change. The 40-patch series is based directly on `origin/main@1b6d2403cb`; #14876 CI is
+  running.
+- A fresh review reproduced two blockers before publication: an unnegotiated replacement could
+  retain old-runtime inventory indefinitely, and an in-flight create could commit after authority
+  transition began. The candidate now requires exact reconciliation echo before activating
+  retained inventory, allows legacy replacement only for empty inventory, and rechecks transition
+  state before every create/reconciliation commit.
+- Final review reproduced a reconnect-only stale-inventory defect: the client sampled inventory
+  once per host generation, so later reconnect attaches could republish the initial empty or stale
+  snapshot. Every attach now samples fresh executor inventory, with a deterministic regression
+  test and an updated reliability-gate assertion.
 - PR #14769 CI exposed one stale combined-stack expectation in both Node shards: replacing a host
   lease now makes the exact old page terminal retirement-pending before the new lease is installed,
   rather than reporting only a stale lease. The deterministic baseline was 1 failed / 4 passed;
@@ -47,10 +59,28 @@ Old clients and callers that omit placement must retain current server-hosted be
   sampled as an empty string before the attached guest exposed `about:blank`. The fixture now waits
   on that observable readiness condition instead of weakening the blank-page assertion; 3/3 fresh
   isolated Electron runs pass.
-- The 37 published patches plus the local orchestration patch are cascade-rebased onto
-  `origin/main@92fb276040`. Range-diff marked all 38 patches identical. Safety pointer
-  `sta-4150-safety-pre-92fb-orchestration-20260815` preserves the old series; no rewritten public
-  branch has been pushed at this checkpoint.
+- The latest rebase onto `origin/main@1b6d2403cb` was conflict-free, advanced all 38 local stage
+  branches, and `git range-diff` marked all 40 patches identical. Safety tags
+  `sta-4150-safety-pre-paired-fixture-amend-20260816`,
+  `sta-4150-safety-pre-fd1-authority-rebase-20260816`, and
+  `sta-4150-safety-pre-1b6-authority-rebase-20260816` preserve the prior tips. All 37 existing
+  draft branches were updated with exact force-with-lease checks; public #14769 is now
+  `a2d6eece6d`, and the new authority branch is published as draft #14876.
+- Latest-base validation passes the paired authority/tunnel integration (3/3), the broad authority
+  and reconnect package (23 files / 279 tests), the Session/WebContents quarantine gate (12 files /
+  142 tests), the old/new terminal-wire matrix (5/5), full Node/CLI/web typecheck, full lint and
+  zero-warning audits, the 88-gate reliability manifest, changed-code quality, desktop build, and a
+  real Docker/OpenSSH SOCKS oracle (2/2). The two wire/security P2 leads are resolved for this
+  stage: arbitrary authenticated tunnel destinations are required browser behavior, while exact
+  SSH execution-host grants belong to activation and are already rejected before registration
+  when absent. The focused routing package passes 3 files / 23 tests, shared compatibility passes
+  3 files / 46 tests, and the mobile legacy fixture passes 1/1 in its own workspace. The bounded
+  lifecycle/resource review found no P0/P1/P2 defect. Rejected cleanup remains an intentional
+  unknown-outcome tombstone: a 3-file / 36-test oracle proves an ambiguously closed route cannot be
+  recreated or reused and is still retried during final registry cleanup. Page, operation, route,
+  retired-route-set, recovery-waiter, and reconnect resources are bounded; both OpenCode tabs were
+  closed. The post-rebase affected authority suite passes 11 files / 173 tests, full Node/CLI/web
+  typecheck passes, and full lint plus native/type-aware audits and all 88 reliability gates pass.
 - Published lease-fence placement-retirement stage: draft PR
   [#14753](https://github.com/stablyai/orca/pull/14753). It makes exact terminal host-generation
   placement retirement non-cancellable without inferring destruction or releasing capacity.
@@ -66,23 +96,106 @@ Old clients and callers that omit placement must retain current server-hosted be
 - Published admission stage: `sta-4150-browser-host-admission-fairness`. It reserves browser-host
   capacity per authenticated paired device, keeps ordinary waits available, and retries explicit
   admission pressure inside existing attach/reconnect deadlines.
-- Current main has one unrelated type-aware lint warning in
-  `config/scripts/pr-test-loc-summary.test.mjs:88`, introduced by #14738 and byte-identical on this
-  branch. STA-4150 changed-code quality is clean; do not mix that CI-script fix into this stage.
 - PR #14566: final lifecycle/correctness/security review clean; all 43 required CI checks pass.
 - Published bridge branch: `sta-4150-browser-client-page-mount-bridge` locally rebased to
   `830cb95c25`, draft PR [#14578](https://github.com/stablyai/orca/pull/14578), stacked on #14566;
   its prior head passed every substantive job while GitHub's aggregate `verify` remained queued.
 - Published renderer-registry branch: `sta-4150-browser-client-page-renderer-registry`, draft PR
   [#14596](https://github.com/stablyai/orca/pull/14596), stacked on #14578.
-- Feature state: **production-inert and not user-visible**. No capability advertisement, default
-  client placement, live page registration, or server-placement migration is enabled.
+- Current stack-tip state is **not yet activated or user-visible**, because capability
+  advertisement, default client placement, live host registration, and normal caller routing are
+  not connected yet. This is only the current development-stack boundary. The next feature layer
+  must activate and prove the end-to-end desktop path; no further standalone compatibility
+  substrate should be added first.
 - Design evidence: `remote-browser-client-hosting.md`, SHA-256
   `d5f6a16df09286388e4d335a8bd896ce0260e9f626ddcc79d8043eff7159a4e0`.
 - OSS reference: T3Code commit `184d8ef33b8f42869fb84f66a33984185b81dc47` keeps shared
   logical preview state, registers the exact Electron `WebContents`, and queues navigation until
   registration. Orca additionally needs authenticated execution-host routing, remote DNS,
   scoped partitions, mixed-version fencing, and fail-closed cleanup.
+
+## Revised delivery plan
+
+The implementation target is one activated desktop vertical slice. Compatibility belongs at the
+page-placement boundary, not throughout the new engine:
+
+- Eligible capable Electron desktops default new pages to client placement.
+- Old, web/mobile, headless, browserless, and explicit-server callers keep the current server path.
+- Placement is immutable for a page generation. There is no live engine migration, speculative
+  client-then-server fallback, or duplicate page execution.
+- Additive optional fields and negotiated capabilities protect old peers. They must not turn the
+  client-hosted engine into a second implementation of the server engine.
+
+### Phase A: finish and prove the feature
+
+1. Completed: corrected #14769 and authority-transition draft #14876 are published on the latest
+   base with the bounded lifecycle/resource review and sticky-cleanup oracle clean.
+2. Build one activation branch above authority transition. This branch must connect capability
+   advertisement, eligible default placement, live host registration, all normal browser/agent/CLI
+   call routing, renderer mount, local input and browser chrome, fail-closed execution-host
+   networking, failure UX/telemetry, and a kill switch for newly created pages.
+3. Prove the activated tip before reshaping history: deterministic placement/authority failures,
+   real paired Electron, no-screencast client pages, remote DNS/localhost/subresources, tunnel-loss
+   containment, reconnect/restart, old/new peers, server fallback for ineligible callers,
+   headed/headless/browserless hosts, SSH/WSL/native, folder/worktree, and the platform matrix.
+4. Add no new substrate PR between authority transition and activation. Add a secondary-channel PR
+   only if ticket acceptance requires mobile/web mirroring or a separately bounded large-result
+   transport.
+
+### Phase B: replace development history with the landing stack
+
+The 37 draft PRs remain development and evidence history while Phase A is changing. Do not relink,
+rebase, or individually production-harden that chain. After the activated tip is green, preserve it
+with a safety ref and replay the same implementation from latest `origin/main` into five branches:
+
+| Order | Landing PR                           | Cohesive scope                                                                   |
+| ----- | ------------------------------------ | -------------------------------------------------------------------------------- |
+| 1     | Contracts and placement              | Optional wire contracts, capabilities, placement model, compatibility policy     |
+| 2     | Paired tunnel and execution routing  | Bounded tunnel, remote DNS, SSH/WSL/native routes, admission and accounting      |
+| 3     | Electron isolation and lifecycle     | Partitions, quarantine, exact WebContents ownership, mount, navigation, cleanup  |
+| 4     | Command authority and reconciliation | Leases, dispatch/results, replacement, reconnect, inventory and reconciliation   |
+| 5     | Activated desktop product path       | Advertisement, default selection, callers, UI/input, kill switch, telemetry, E2E |
+
+Each PR is a review boundary and each cumulative tip must compile and pass its owned deterministic
+tests. The lower PRs do not need to be independently deployable: do not add two-way shims, dormant
+fallback machinery, or temporary product flags just so a partial stack could ship alone. Production
+readiness is decided at PR 5, whose final tree must exactly match the already-proven Phase A tip.
+
+Construct and validate the replacement branches locally before registering them with `gh stack`.
+Then adopt them in dependency order, submit draft PRs non-interactively, verify the generated bases,
+and record the old-to-new mapping before closing any superseded draft. If a lower-layer defect is
+found, fix its owning branch and cascade-rebase only the branches above it. Do not merge or mark any
+PR ready during this work.
+
+The intended replacement branch chain is:
+
+```text
+origin/main
+  └─ sta-4150-landing-contracts-placement
+     └─ sta-4150-landing-paired-tunnel-routing
+        └─ sta-4150-landing-electron-lifecycle
+           └─ sta-4150-landing-command-authority
+              └─ sta-4150-landing-desktop-activation
+```
+
+Stack mechanics:
+
+1. Rebase and fully revalidate the activated development tip on the latest `origin/main`, then
+   preserve both its base and tip with safety refs.
+2. Build the five named branches locally from that exact base. Preserve dependency order and allow
+   multiple commits per branch; do not add temporary runtime behavior just to isolate a review
+   layer.
+3. Require the fifth branch tree to equal the preserved activated tip, and use `git range-diff` to
+   account for every rewritten commit before any GitHub mutation.
+4. Adopt the existing local branches with `gh stack init --base main <branches...>`, then use
+   `gh stack submit --auto --remote origin`. Draft is the default; never pass `--open`.
+5. Verify the chain with `gh stack view --json`, replace generated PR titles and bodies with the
+   staged scope and test evidence, and keep Linear In Progress.
+6. Put review fixes on the lowest branch that owns them, run `gh stack rebase --upstack`, and
+   revalidate every affected cumulative tip. Never use `gh stack merge` for this ticket.
+
+The kill switch changes placement only for pages created after it is disabled. It must not migrate,
+replace, or silently fall back an existing client-hosted page.
 
 ## Draft stack
 
@@ -128,6 +241,7 @@ ownership.
 | [#14759](https://github.com/stablyai/orca/pull/14759) | Command contracts  | Negotiated reclaim, restore, and close command contracts                  |
 | [#14763](https://github.com/stablyai/orca/pull/14763) | Client adapters    | Exact retained-page reclaim, restore, close, and fail-closed cleanup      |
 | [#14769](https://github.com/stablyai/orca/pull/14769) | Orchestration      | Proof-driven command issue, replay, reservation, and placement commit     |
+| [#14876](https://github.com/stablyai/orca/pull/14876) | Authority change   | Preserve executor, pages, routes, and exact reconciliation across runtime |
 
 ## Published stage: exact renderer bridge (#14578)
 
@@ -560,23 +674,13 @@ Validation and review:
 
 ## Remaining implementation order
 
-1. Monitor #14763 CI without merging or marking it ready; production advertisement stays disabled.
-2. Add a dedicated authenticated server action-issuance path that binds one immutable plan to its
-   exact lease and client inventory. Preserve the client executor across the authority transition;
-   a transport or composition restart must not destroy the retained guest before reclaim.
-3. Rekey server placement only after the exact client command result proves reclaim or restore;
-   keep outcome-unknown inventory fenced and rerun a fresh plan after any phase-one failure.
-4. Add optional placement to logical session-tab publication and renderer state. Follow
-   `docs/reference/remote-wire-compatibility.md`; old callers and clients remain server-hosted.
-5. Route create and every existing browser command by explicit placement. Never silently fall
-   back or migrate a live page.
-6. Add local browser chrome and interaction-owner fencing for client placement.
-7. Add mobile mirroring and dedicated large-result channels without coupling them to control or
-   terminal multiplexing.
-8. Run real Electron containment and traffic proof, then headed/headless/browserless paired
-   journeys and the physical platform/provider matrix.
-9. Enable client placement only behind a kill switch for newly created eligible desktop pages;
-   retain explicit server placement and rollback that does not move existing pages.
+1. Implement the complete activated desktop slice directly above authority transition; do not add
+   another inert substrate layer.
+2. Run deterministic, paired-Electron, containment, rolling-version, execution-host, workspace,
+   browserless, and physical-platform acceptance against that activated tip.
+3. If acceptance does not require a secondary transport, stop at the desktop feature boundary.
+4. Rebuild the proven tree as the five-PR landing stack above, verify exact final-tree equality, and
+   preserve an auditable old-to-new PR mapping and range-diff.
 
 ## Compatibility costs and risks
 
@@ -842,6 +946,35 @@ Published proof-driven reconciliation-orchestration stage (#14769):
   (`1153c604-bbb5-4293-af33-cfb4143170c9`) was posted, and the ticket remains In Progress. No PR
   was merged or marked ready.
 
+Current local authority-transition stage:
+
+- Baseline: replacing `authorityRuntimeId` for the same pairing destroyed the composition and its
+  retained Electron page inventory. The first production seam made the registry test green while
+  Node typecheck remained red because the composition lacked `replaceAuthority`.
+- Candidate: old routes suspend and retire synchronously; old navigation grants revoke before
+  asynchronous cleanup; old handlers settle before the executor changes connection identity; a
+  fresh host and route set then attach the immutable old inventory for close/restore reconciliation.
+- Fresh review red/green: a replacement without reconciliation echo previously resolved while
+  publishing one old-runtime page. It now fails before replacement route activation and dispatcher
+  admission; empty inventory still permits a legacy replacement. An in-flight old-authority create
+  previously completed after transition began; it now fails and releases its route. Retired-route
+  rejection also closes the composition before replacement activation, while transition revocation
+  failure remains fenced and exact cleanup completes.
+- SSH constraint: execution-host keys may omit runtime identity, so any runtime change requires
+  close-then-restore rather than DOM-preserving reclaim. Same-runtime/new-epoch reclaim remains
+  supported.
+- Latest-base validation: focused authority/reconciliation coverage passes 9 files / 136 tests;
+  reconnect and lease-lifecycle coverage passes 14 files / 169 tests. The paired integration passed
+  3/3 before the final rebase and still needs its latest-base rerun; broader affected coverage,
+  mixed-version wire, full typecheck/lint/audits, builds, and fresh reviews also remain queued.
+- The 40-patch stack rebased conflict-free onto `origin/main@fd1dba9db9`; `git range-diff` marked all
+  40 patches identical. Safety tags `sta-4150-safety-pre-paired-fixture-amend-20260816` and
+  `sta-4150-safety-pre-fd1-authority-rebase-20260816` preserve the prior tips. No rewritten branch
+  has been pushed at this checkpoint.
+- No new field or opcode was added. The existing optional reconciliation version is advertised only
+  by the otherwise uncalled composed client-host path, must be echoed exactly, and remains inert
+  because no production capability advertisement or browser-create caller exists.
+
 Do not promote narrow deterministic evidence into a live-topology claim. Record exact commands,
 topology, versions, and explicit gaps at every later checkpoint.
 
@@ -943,6 +1076,10 @@ topology, versions, and explicit gaps at every later checkpoint.
   PR [#14769](https://github.com/stablyai/orca/pull/14769) on #14763.
 - GitHub auto-attached #14769 to STA-4150. Posted exactly one orchestration checkpoint comment
   (`1153c604-bbb5-4293-af33-cfb4143170c9`) and kept the ticket In Progress.
+- Locally committed #14769's bounded-deadline assertion fix and the authority-transition stage,
+  then cascade-rebased all 40 patches and 37 local stack refs onto `origin/main@d2ffe1f362` with an
+  exact 40/40 range-diff. No rewritten branch, new PR, GitHub comment, Linear mutation, or status
+  change has been published at this checkpoint.
 - No PR was merged or marked ready.
 
 ## Completion rule

--- a/src/main/browser/browser-client-host-command-authority.ts
+++ b/src/main/browser/browser-client-host-command-authority.ts
@@ -1,7 +1,17 @@
 import type {
+  BrowserClientHostedPageInventory,
   BrowserClientHostCommandEvent,
   BrowserClientHostLeaseAuthority
 } from '../../shared/browser-client-host-protocol'
+
+type BrowserClientPageAuthority = Pick<
+  BrowserClientHostedPageInventory,
+  | 'authorityRuntimeId'
+  | 'authorityEpoch'
+  | 'browserHostClientId'
+  | 'browserHostGeneration'
+  | 'pageHostGeneration'
+>
 
 export function assertBrowserClientHostCommandAuthority(
   authority: BrowserClientHostLeaseAuthority,
@@ -38,5 +48,18 @@ export function sameBrowserClientHostLeaseAuthority(
     left.pageInventoryProtocolVersion === right.pageInventoryProtocolVersion &&
     left.leaseReconnectProtocolVersion === right.leaseReconnectProtocolVersion &&
     left.pageReconciliationProtocolVersion === right.pageReconciliationProtocolVersion
+  )
+}
+
+export function sameBrowserClientPageAuthority(
+  left: BrowserClientPageAuthority,
+  right: BrowserClientPageAuthority
+): boolean {
+  return (
+    left.authorityRuntimeId === right.authorityRuntimeId &&
+    left.authorityEpoch === right.authorityEpoch &&
+    left.browserHostClientId === right.browserHostClientId &&
+    left.browserHostGeneration === right.browserHostGeneration &&
+    left.pageHostGeneration === right.pageHostGeneration
   )
 }

--- a/src/main/browser/browser-client-network-route-registry.test.ts
+++ b/src/main/browser/browser-client-network-route-registry.test.ts
@@ -45,6 +45,37 @@ describe('BrowserClientNetworkRouteRegistry', () => {
     expect(route.close).toHaveBeenCalledOnce()
   })
 
+  it('keeps an ambiguously closed route fenced until final registry cleanup', async () => {
+    const cleanupError = new Error('route cleanup outcome unknown')
+    const route = createRoute()
+    let closed = false
+    route.close.mockImplementation(async () => {
+      closed = true
+      throw cleanupError
+    })
+    route.reconnect.mockImplementation(async () => {
+      if (closed) {
+        throw new Error('Browser network route is closed')
+      }
+      return { host: '127.0.0.1', port: 43123 }
+    })
+    const routeFactory = vi.fn(() => route)
+    const registry = new BrowserClientNetworkRouteRegistry({ authority, createRoute: routeFactory })
+    const key = browserNetworkExecutionHostKey({
+      kind: 'native',
+      runtimeId: 'runtime-a',
+      revision: 7
+    })
+    const retained = await registry.retain(key, signal())
+
+    await expect(retained.release()).rejects.toThrow(cleanupError)
+    await expect(registry.retain(key, signal())).rejects.toThrow('Browser network route is closed')
+    expect(routeFactory).toHaveBeenCalledOnce()
+
+    await expect(registry.close()).rejects.toThrow('Browser client network route cleanup failed')
+    expect(route.close).toHaveBeenCalledTimes(3)
+  })
+
   it('rejects a native route for a different authority runtime', async () => {
     const routeFactory = vi.fn(() => createRoute())
     const registry = new BrowserClientNetworkRouteRegistry({
@@ -118,6 +149,53 @@ describe('BrowserClientNetworkRouteRegistry', () => {
         signal()
       )
     ).rejects.toThrow('browser_client_network_route_registry_closed')
+  })
+
+  it('retires old authority routes without destroying them before exact page cleanup', async () => {
+    const route = createRoute()
+    const registry = new BrowserClientNetworkRouteRegistry({
+      authority,
+      createRoute: () => route
+    })
+    const key = browserNetworkExecutionHostKey({
+      kind: 'ssh',
+      targetId: 'ssh-a',
+      providerEpoch: 'provider-a',
+      connectionGeneration: 1
+    })
+    const retained = await registry.retain(key, signal())
+
+    const retirement = registry.retire(new Error('authority replaced'))
+
+    expect(route.suspend).toHaveBeenCalledOnce()
+    expect(route.close).not.toHaveBeenCalled()
+    await expect(registry.retain(key, signal())).rejects.toThrow(
+      'browser_client_network_route_registry_retired'
+    )
+    await expect(registry.reconnect()).rejects.toThrow(
+      'browser_client_network_route_registry_retired'
+    )
+
+    await retained.release()
+    await expect(retirement).resolves.toBeUndefined()
+    expect(route.close).toHaveBeenCalledOnce()
+  })
+
+  it('force-closes retained retired routes during final shutdown', async () => {
+    const route = createRoute()
+    const registry = new BrowserClientNetworkRouteRegistry({
+      authority,
+      createRoute: () => route
+    })
+    await registry.retain(
+      browserNetworkExecutionHostKey({ kind: 'native', runtimeId: 'runtime-a', revision: 1 }),
+      signal()
+    )
+
+    void registry.retire()
+    await registry.close()
+
+    expect(route.close).toHaveBeenCalledOnce()
   })
 
   it('suspends every retained transport and restores the same listener address', async () => {

--- a/src/main/browser/browser-client-network-route-registry.ts
+++ b/src/main/browser/browser-client-network-route-registry.ts
@@ -37,6 +37,7 @@ export class BrowserClientNetworkRouteRegistry {
   private recoveryGeneration = 0
   private recovery: { generation: number; abort: AbortController; promise: Promise<void> } | null =
     null
+  private retirement: ReturnType<typeof createRouteRetirement> | null = null
   private readonly reconnectGraceMs: number
   private readonly reconnectRetryDelayMs: number
   private suspended = false
@@ -105,6 +106,23 @@ export class BrowserClientNetworkRouteRegistry {
     return this.closePromise
   }
 
+  retire(error = new Error('Browser client network route registry is retired')): Promise<void> {
+    if (this.closed) {
+      return this.closePromise ?? Promise.resolve()
+    }
+    const retirement = (this.retirement ??= createRouteRetirement())
+    if (!this.suspended) {
+      try {
+        this.suspend(error)
+      } catch (suspensionError) {
+        retirement.reject(suspensionError)
+        throw suspensionError
+      }
+    }
+    this.settleRetirement()
+    return retirement.promise
+  }
+
   suspend(error = new Error('Browser client network routes suspended')): void {
     if (this.closed) {
       return
@@ -129,6 +147,9 @@ export class BrowserClientNetworkRouteRegistry {
   reconnect(): Promise<void> {
     if (this.closed) {
       return Promise.reject(new Error('browser_client_network_route_registry_closed'))
+    }
+    if (this.retirement) {
+      return Promise.reject(new Error('browser_client_network_route_registry_retired'))
     }
     if (!this.suspended) {
       return Promise.resolve()
@@ -173,6 +194,9 @@ export class BrowserClientNetworkRouteRegistry {
     if (this.closed) {
       throw new Error('browser_client_network_route_registry_closed')
     }
+    if (this.retirement) {
+      throw new Error('browser_client_network_route_registry_retired')
+    }
     if (this.suspended) {
       throw new Error('browser_client_network_route_registry_suspended')
     }
@@ -189,8 +213,11 @@ export class BrowserClientNetworkRouteRegistry {
     if (retained.references !== 0 || this.routes.get(retained.key) !== retained) {
       return
     }
-    this.routes.delete(retained.key)
     await retained.route.close()
+    if (this.routes.get(retained.key) === retained) {
+      this.routes.delete(retained.key)
+    }
+    this.settleRetirement()
   }
 
   private async releaseAfterFailedRetain(retained: RetainedRoute, error: unknown): Promise<void> {
@@ -212,9 +239,34 @@ export class BrowserClientNetworkRouteRegistry {
       result.status === 'rejected' ? [result.reason] : []
     )
     if (failures.length > 0) {
+      this.retirement?.reject(
+        new AggregateError(failures, 'Browser client network route cleanup failed')
+      )
       throw new AggregateError(failures, 'Browser client network route cleanup failed')
     }
+    this.settleRetirement()
   }
+
+  private settleRetirement(): void {
+    if (this.retirement && this.routes.size === 0) {
+      this.retirement.resolve()
+    }
+  }
+}
+
+function createRouteRetirement(): {
+  promise: Promise<void>
+  resolve: () => void
+  reject: (error: unknown) => void
+} {
+  let resolve = (): void => {}
+  let reject = (_error: unknown): void => {}
+  const promise = new Promise<void>((innerResolve, innerReject) => {
+    resolve = innerResolve
+    reject = innerReject
+  })
+  void promise.catch(() => undefined)
+  return { promise, resolve, reject }
 }
 
 function assertRouteAddress(address: { host: string; port: number }): void {

--- a/src/main/browser/browser-client-page-command-executor.test.ts
+++ b/src/main/browser/browser-client-page-command-executor.test.ts
@@ -681,6 +681,111 @@ describe('BrowserClientPageCommandExecutor', () => {
     await executor.close()
   })
 
+  it('retains inventory while fencing old pages and uses the replacement route identity', async () => {
+    const { dependencies, executor } = createHarness()
+    await executor.handle(createCommand('createPage'), new AbortController().signal)
+
+    executor.beginAuthorityTransition()
+
+    expect(executor.snapshotPageInventory()).toEqual([
+      expect.objectContaining({ browserPageId: 'page-a', authorityRuntimeId: 'runtime-a' })
+    ])
+    expect(dependencies.routeWebContents.revokeNavigation).toHaveBeenCalledOnce()
+    await expect(
+      executor.handle(createCommand('navigate'), new AbortController().signal)
+    ).resolves.toEqual({
+      status: 'failed',
+      errorCode: 'browser_client_page_executor_closed'
+    })
+
+    executor.completeAuthorityTransition('authority-record-b')
+    await expect(
+      executor.handle(
+        createCommand('navigate', {
+          authorityRuntimeId: 'runtime-b',
+          authorityEpoch: 'epoch-b',
+          browserHostGeneration: 1
+        }),
+        new AbortController().signal
+      )
+    ).resolves.toEqual({
+      status: 'failed',
+      errorCode: 'browser_client_page_generation_stale'
+    })
+    expect(dependencies.routeWebContents.navigateGuest).not.toHaveBeenCalled()
+
+    await executor.retirePage('page-a', 7)
+    await executor.handle(
+      createCommand('createPage', {
+        authorityRuntimeId: 'runtime-b',
+        authorityEpoch: 'epoch-b',
+        browserPageId: 'page-b',
+        pageHostGeneration: 1
+      }),
+      new AbortController().signal
+    )
+
+    expect(dependencies.routeSessions.preparePage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        identity: expect.objectContaining({ authorityConnectionIdentity: 'authority-record-b' })
+      })
+    )
+  })
+
+  it('releases an in-flight old-authority create during transition', async () => {
+    const { dependencies, executor, order, route } = createHarness()
+    let resolveRoute = (_route: typeof route): void => {}
+    dependencies.retainNetworkRoute.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveRoute = resolve
+        })
+    )
+    const creating = executor.handle(createCommand('createPage'), new AbortController().signal)
+    await Promise.resolve()
+
+    executor.beginAuthorityTransition()
+    resolveRoute(route)
+
+    await expect(creating).resolves.toEqual({
+      status: 'failed',
+      errorCode: 'browser_client_page_executor_closed'
+    })
+    expect(executor.snapshotPageInventory()).toEqual([])
+    expect(dependencies.routeWebContents.grantNavigation).not.toHaveBeenCalled()
+    expect(order).toEqual(['release-route'])
+    executor.completeAuthorityTransition('authority-record-b')
+    await executor.close()
+  })
+
+  it('keeps transition fail-closed when navigation revocation throws', async () => {
+    const { dependencies, executor, order } = createHarness()
+    await executor.handle(createCommand('createPage'), new AbortController().signal)
+    dependencies.routeWebContents.revokeNavigation.mockImplementationOnce(() => {
+      order.push('revoke-navigation')
+      throw new Error('transition revocation failed')
+    })
+
+    expect(() => executor.beginAuthorityTransition()).toThrow(
+      'Browser client page navigation fencing failed'
+    )
+    await expect(
+      executor.handle(createCommand('navigate'), new AbortController().signal)
+    ).resolves.toEqual({
+      status: 'failed',
+      errorCode: 'browser_client_page_executor_closed'
+    })
+
+    await executor.close()
+    expect(order.slice(-5)).toEqual([
+      'revoke-navigation',
+      'retire-guest',
+      'retire-renderer-page',
+      'release-session',
+      'release-route'
+    ])
+  })
+
   it('continues exact page cleanup when navigation revocation throws', async () => {
     const { dependencies, executor, order } = createHarness()
     await executor.handle(createCommand('createPage'), new AbortController().signal)

--- a/src/main/browser/browser-client-page-command-executor.ts
+++ b/src/main/browser/browser-client-page-command-executor.ts
@@ -24,6 +24,7 @@ import {
   isBrowserClientPageCleanupFailure
 } from './browser-client-page-command-failure'
 import { BrowserClientPageNavigationFence } from './browser-client-page-navigation-fence'
+import { sameBrowserClientPageAuthority } from './browser-client-host-command-authority'
 import { executeBrowserClientPageReconciliationCommand } from './browser-client-page-reconciliation'
 import type {
   BrowserClientPageLifecycleRegistry,
@@ -52,9 +53,12 @@ export class BrowserClientPageCommandExecutor {
   private readonly failedPages = new Map<string, BrowserClientHostedPageInventory>()
   private readonly navigationFence = new BrowserClientPageNavigationFence()
   private closePromise: Promise<void> | null = null
+  private authorityConnectionIdentity: string
+  private authorityTransitioning = false
   private closed = false
 
   constructor(private readonly dependencies: BrowserClientPageCommandExecutorDependencies) {
+    this.authorityConnectionIdentity = dependencies.authorityConnectionIdentity
     this.maxPages = dependencies.maxPages ?? BROWSER_CLIENT_HOST_PAGE_INVENTORY_MAX_PAGES
     if (
       !Number.isInteger(this.maxPages) ||
@@ -69,7 +73,7 @@ export class BrowserClientPageCommandExecutor {
     event: BrowserClientHostCommandEvent,
     signal: AbortSignal
   ): Promise<BrowserClientHostCommandResult> {
-    if (this.closed || this.navigationFence.isFenced) {
+    if (this.closed || this.authorityTransitioning || this.navigationFence.isFenced) {
       return { status: 'failed', errorCode: 'browser_client_page_executor_closed' }
     }
     try {
@@ -94,7 +98,8 @@ export class BrowserClientPageCommandExecutor {
             pages: this.pages,
             failedPages: this.failedPages,
             routeWebContents: this.dependencies.routeWebContents,
-            assertAvailable: () => this.navigationFence.assertAvailable(this.closed),
+            assertAvailable: () =>
+              this.navigationFence.assertAvailable(this.closed || this.authorityTransitioning),
             createPage: (command, commandSignal) => this.createPage(command, commandSignal),
             navigate: (command, commandSignal) => this.navigate(command, commandSignal),
             retirePage: (browserPageId, generation) => this.retirePage(browserPageId, generation),
@@ -136,6 +141,24 @@ export class BrowserClientPageCommandExecutor {
     this.navigationFence.fence(this.pages.values(), (claim) =>
       this.dependencies.routeWebContents.revokeNavigation(claim)
     )
+  }
+
+  beginAuthorityTransition(): void {
+    if (this.closed || this.authorityTransitioning) {
+      throw new Error('browser_client_page_authority_transition_unavailable')
+    }
+    this.authorityTransitioning = true
+    this.navigationFence.revoke(this.pages.values(), (claim) =>
+      this.dependencies.routeWebContents.revokeNavigation(claim)
+    )
+  }
+
+  completeAuthorityTransition(authorityConnectionIdentity: string): void {
+    if (this.closed || !this.authorityTransitioning || !authorityConnectionIdentity) {
+      throw new Error('browser_client_page_authority_transition_unavailable')
+    }
+    this.authorityConnectionIdentity = authorityConnectionIdentity
+    this.authorityTransitioning = false
   }
 
   async retirePage(browserPageId: string, pageHostGeneration: number): Promise<boolean> {
@@ -198,10 +221,13 @@ export class BrowserClientPageCommandExecutor {
     signal: AbortSignal
   ): Promise<void> {
     await createReservedBrowserClientPage(
-      this.dependencies,
+      {
+        ...this.dependencies,
+        authorityConnectionIdentity: this.authorityConnectionIdentity
+      },
       event,
       signal,
-      () => this.navigationFence.assertAvailable(this.closed),
+      () => this.navigationFence.assertAvailable(this.closed || this.authorityTransitioning),
       (page) => this.pages.set(event.browserPageId, page)
     )
   }
@@ -215,7 +241,8 @@ export class BrowserClientPageCommandExecutor {
       !page ||
       page.generation !== event.pageHostGeneration ||
       page.retiring ||
-      page.reconciling
+      page.reconciling ||
+      !sameBrowserClientPageAuthority(page.inventory, event)
     ) {
       throw new BrowserClientPageCommandError('browser_client_page_generation_stale')
     }

--- a/src/main/browser/browser-client-page-navigation-fence.ts
+++ b/src/main/browser/browser-client-page-navigation-fence.ts
@@ -24,6 +24,13 @@ export class BrowserClientPageNavigationFence {
       return
     }
     this.fenced = true
+    this.revoke(pages, revoke)
+  }
+
+  revoke(
+    pages: Iterable<BrowserClientPageNavigationClaim>,
+    revoke: (claim: BrowserRouteGuestLifecycleClaim) => void
+  ): void {
     const failures: unknown[] = []
     for (const page of pages) {
       try {

--- a/src/main/browser/browser-client-page-reconciliation-adapters.test.ts
+++ b/src/main/browser/browser-client-page-reconciliation-adapters.test.ts
@@ -159,6 +159,25 @@ describe('browser client page reconciliation adapters', () => {
     ])
   })
 
+  it('rejects DOM-preserving reclaim across runtime authorities', async () => {
+    const { executor, renderer, routeWebContents } = createHarness()
+    await executor.handle(command('createPage'), new AbortController().signal)
+
+    await expect(
+      executor.handle(
+        command('reclaimPage', { authorityRuntimeId: 'runtime-b' }),
+        new AbortController().signal
+      )
+    ).resolves.toEqual({
+      status: 'failed',
+      errorCode: 'browser_client_page_reconciliation_authority_stale'
+    })
+
+    expect(renderer.rekeyPage).not.toHaveBeenCalled()
+    expect(routeWebContents.rekeyGuestLifecycle).not.toHaveBeenCalled()
+    expect(executor.hasPage('page-a', 7)).toBe(true)
+  })
+
   it('closes only the exact stale authority and leaves mismatches untouched', async () => {
     const { executor, renderer } = createHarness()
     await executor.handle(command('createPage'), new AbortController().signal)

--- a/src/main/browser/browser-client-page-reconciliation.ts
+++ b/src/main/browser/browser-client-page-reconciliation.ts
@@ -7,6 +7,7 @@ import {
   assertCurrentBrowserClientPageRenderer,
   browserClientPageIdentity
 } from './browser-client-page-command-admission'
+import { sameBrowserClientPageAuthority } from './browser-client-host-command-authority'
 import { BrowserClientPageCommandError } from './browser-client-page-command-failure'
 import {
   createBrowserClientPageInventory,
@@ -63,6 +64,7 @@ async function reclaimPage(
     !page ||
     page.retiring ||
     page.reconciling ||
+    page.inventory.authorityRuntimeId !== event.authorityRuntimeId ||
     !sameBrowserClientPageAuthority(page.inventory, event.command.previousAuthority) ||
     page.inventory.browserProfileId !== event.command.browserProfileId ||
     page.inventory.executionHostKey !== event.command.executionHostKey
@@ -210,25 +212,6 @@ async function failClosedRekeyedPage(
     })
   }
   throw error
-}
-
-function sameBrowserClientPageAuthority(
-  inventory: BrowserClientHostedPageInventory,
-  authority: {
-    authorityRuntimeId: string
-    authorityEpoch: string
-    browserHostClientId: string
-    browserHostGeneration: number
-    pageHostGeneration: number
-  }
-): boolean {
-  return (
-    inventory.authorityRuntimeId === authority.authorityRuntimeId &&
-    inventory.authorityEpoch === authority.authorityEpoch &&
-    inventory.browserHostClientId === authority.browserHostClientId &&
-    inventory.browserHostGeneration === authority.browserHostGeneration &&
-    inventory.pageHostGeneration === authority.pageHostGeneration
-  )
 }
 
 function reconciliationCreateEvent(

--- a/src/main/browser/paired-runtime-browser-client-host-composition.test.ts
+++ b/src/main/browser/paired-runtime-browser-client-host-composition.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import type {
+  BrowserClientHostedPageInventory,
   BrowserClientHostCommandEvent,
   BrowserClientHostLeaseAuthority
 } from '../../shared/browser-client-host-protocol'
@@ -12,6 +13,18 @@ const authority: BrowserClientHostLeaseAuthority = {
   browserHostGeneration: 4,
   pageCommandProtocolVersion: 1
 }
+
+const replacementAuthority: BrowserClientHostLeaseAuthority = {
+  ...authority,
+  authorityRuntimeId: 'runtime-b',
+  authorityEpoch: 'epoch-b',
+  browserHostGeneration: 1,
+  pageInventoryProtocolVersion: 1,
+  pageReconciliationProtocolVersion: 1
+}
+
+const initialInput = { authorityConnectionIdentity: 'authority-record-a' }
+const replacementInput = { authorityConnectionIdentity: 'authority-record-b' }
 
 describe('PairedRuntimeBrowserClientHostComposition', () => {
   it('activates exact route authority before admitting page commands', async () => {
@@ -32,6 +45,123 @@ describe('PairedRuntimeBrowserClientHostComposition', () => {
       expect.objectContaining({ browserPageId: 'page-a', state: 'active' })
     ])
     expect(rig.executor.snapshotPageInventory).toHaveBeenCalledOnce()
+  })
+
+  it('publishes a fresh inventory snapshot for every reconnect attach', () => {
+    const rig = createRig({ pageInventory: [] })
+    rig.executor.snapshotPageInventory
+      .mockReturnValueOnce([])
+      .mockReturnValueOnce([retainedPageInventory()])
+    rig.createComposition()
+
+    expect(rig.hostOptions.getPageInventory?.()).toEqual([])
+    expect(rig.hostOptions.getPageInventory?.()).toEqual([
+      expect.objectContaining({ browserPageId: 'page-a', state: 'active' })
+    ])
+    expect(rig.executor.snapshotPageInventory).toHaveBeenCalledTimes(2)
+  })
+
+  it('preserves inventory while replacing authority with fresh routes', async () => {
+    const rig = createRig()
+    const composition = rig.createComposition()
+    await composition.start()
+
+    await expect(composition.replaceAuthority(replacementInput)).resolves.toEqual(
+      replacementAuthority
+    )
+
+    expect(rig.replacementInventory).toEqual([
+      expect.objectContaining({ browserPageId: 'page-a', authorityRuntimeId: 'runtime-a' })
+    ])
+    expect(rig.executor.close).not.toHaveBeenCalled()
+    expect(rig.routes.close).not.toHaveBeenCalled()
+    expect(rig.order).toEqual([
+      'activate-routes',
+      'retire-routes',
+      'fence-authority-transition',
+      'close-host',
+      'complete-authority-transition',
+      'attach-replacement-inventory',
+      'activate-replacement-routes'
+    ])
+  })
+
+  it('rejects retained inventory when replacement cannot reconcile it', async () => {
+    const rig = createRig({
+      replacementAuthority: {
+        ...replacementAuthority,
+        pageInventoryProtocolVersion: undefined,
+        pageReconciliationProtocolVersion: undefined
+      }
+    })
+    const composition = rig.createComposition()
+    await composition.start()
+
+    await expect(composition.replaceAuthority(replacementInput)).rejects.toThrow(
+      'browser_client_page_reconciliation_unsupported'
+    )
+
+    expect(rig.replacementInventory).toEqual([
+      expect.objectContaining({ browserPageId: 'page-a', authorityRuntimeId: 'runtime-a' })
+    ])
+    expect(rig.replacementRoutes.close).not.toHaveBeenCalled()
+    expect(rig.order).not.toContain('activate-replacement-routes')
+    await composition.close()
+  })
+
+  it('allows a legacy replacement when there is no retained inventory', async () => {
+    const legacyAuthority = {
+      ...replacementAuthority,
+      pageInventoryProtocolVersion: undefined,
+      pageReconciliationProtocolVersion: undefined
+    }
+    const rig = createRig({ pageInventory: [], replacementAuthority: legacyAuthority })
+    const composition = rig.createComposition()
+    await composition.start()
+
+    await expect(composition.replaceAuthority(replacementInput)).resolves.toEqual(legacyAuthority)
+
+    expect(rig.replacementInventory).toEqual([])
+    expect(rig.order).toContain('activate-replacement-routes')
+    await composition.close()
+  })
+
+  it('waits for old handlers and ignores their late callbacks before replacement', async () => {
+    const rig = createRig({ hostSettled: false })
+    const composition = rig.createComposition()
+    await composition.start()
+    const oldCallbacks = rig.hostOptionsHistory[0]!
+
+    const replacing = composition.replaceAuthority(replacementInput)
+    await Promise.resolve()
+    expect(rig.hosts).toHaveLength(1)
+
+    rig.settleHandlers()
+    await replacing
+    oldCallbacks.onError?.(new Error('late old-host failure'))
+    oldCallbacks.onTransportLost?.(new Error('late old-host loss'))
+
+    expect(rig.hosts).toHaveLength(2)
+    expect(rig.hosts[1]!.close).not.toHaveBeenCalled()
+    expect(rig.replacementRoutes.suspend).not.toHaveBeenCalled()
+    expect(rig.onError).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when retired routes reject during replacement', async () => {
+    const routeRetireError = new Error('route retirement failed')
+    const rig = createRig({ routeRetireError })
+    const composition = rig.createComposition()
+    await composition.start()
+
+    await expect(composition.replaceAuthority(replacementInput)).rejects.toThrow(
+      'paired_runtime_browser_client_host_composition_closed'
+    )
+    await composition.whenClosed()
+
+    expect(rig.onError).toHaveBeenCalledWith(routeRetireError)
+    expect(rig.executor.close).toHaveBeenCalledOnce()
+    expect(rig.routes.close).toHaveBeenCalledOnce()
+    expect(rig.order).not.toContain('activate-replacement-routes')
   })
 
   it('suspends routes without closing pages and gates commands through recovery', async () => {
@@ -199,22 +329,38 @@ describe('PairedRuntimeBrowserClientHostComposition', () => {
   })
 })
 
-function createRig(options: { executorCloseError?: Error; hostSettled?: boolean } = {}) {
+function createRig(
+  options: {
+    executorCloseError?: Error
+    hostSettled?: boolean
+    pageInventory?: readonly BrowserClientHostedPageInventory[]
+    replacementAuthority?: BrowserClientHostLeaseAuthority
+    routeRetireError?: Error
+  } = {}
+) {
   const order: string[] = []
   let settleHandlers = (): void => {}
   const handlersSettled = new Promise<void>((resolve) => {
     settleHandlers = resolve
   })
-  const routes = {
+  const createRoutes = (replacement = false) => ({
     retain: vi.fn(),
     suspend: vi.fn(() => {
-      order.push('suspend-routes')
+      order.push(replacement ? 'suspend-replacement-routes' : 'suspend-routes')
     }),
     reconnect: vi.fn(async () => {}),
+    retire: vi.fn(async () => {
+      order.push(replacement ? 'retire-replacement-routes' : 'retire-routes')
+      if (!replacement && options.routeRetireError) {
+        throw options.routeRetireError
+      }
+    }),
     close: vi.fn(async () => {
-      order.push('close-routes')
+      order.push(replacement ? 'close-replacement-routes' : 'close-routes')
     })
-  }
+  })
+  const routes = createRoutes()
+  const replacementRoutes = createRoutes(true)
   const executor = {
     handle: vi.fn(async () => {
       order.push('handle-command')
@@ -225,22 +371,16 @@ function createRig(options: { executorCloseError?: Error; hostSettled?: boolean 
       return true
     }),
     hasUnresolvedPage: vi.fn(() => false),
+    beginAuthorityTransition: vi.fn(() => {
+      order.push('fence-authority-transition')
+    }),
+    completeAuthorityTransition: vi.fn(() => {
+      order.push('complete-authority-transition')
+    }),
     fenceNavigation: vi.fn(() => {
       order.push('fence-navigation')
     }),
-    snapshotPageInventory: vi.fn(() => [
-      {
-        authorityRuntimeId: 'runtime-a',
-        authorityEpoch: 'epoch-a',
-        browserHostClientId: 'client-a',
-        browserHostGeneration: 4,
-        browserPageId: 'page-a',
-        pageHostGeneration: 7,
-        browserProfileId: 'profile-a',
-        executionHostKey: 'execution-host-a',
-        state: 'active' as const
-      }
-    ]),
+    snapshotPageInventory: vi.fn(() => options.pageInventory ?? [retainedPageInventory()]),
     close: vi.fn(async () => {
       order.push('close-executor')
       if (options.executorCloseError) {
@@ -248,7 +388,7 @@ function createRig(options: { executorCloseError?: Error; hostSettled?: boolean 
       }
     })
   }
-  let hostOptions: {
+  type HostOptions = {
     getPageInventory?: () => readonly unknown[]
     onAuthority?: (next: BrowserClientHostLeaseAuthority) => void
     onTransportLost?: (error: Error) => void
@@ -258,11 +398,27 @@ function createRig(options: { executorCloseError?: Error; hostSettled?: boolean 
       event: BrowserClientHostCommandEvent,
       signal: AbortSignal
     ) => Promise<{ status: 'completed' | 'failed'; errorCode?: string }>
-  } = {}
-  const host = {
+  }
+  const hostOptionsHistory: HostOptions[] = []
+  const hosts: {
+    start: ReturnType<typeof vi.fn>
+    retirePage: ReturnType<typeof vi.fn>
+    forgetPage: ReturnType<typeof vi.fn>
+    whenHandlersSettled: ReturnType<typeof vi.fn>
+    close: ReturnType<typeof vi.fn>
+  }[] = []
+  let replacementInventory: readonly unknown[] = []
+  const makeHost = (callbacks: HostOptions, replacement: boolean) => ({
     start: vi.fn(async () => {
-      hostOptions.onAuthority?.(authority)
-      return authority
+      const nextAuthority = replacement
+        ? (options.replacementAuthority ?? replacementAuthority)
+        : authority
+      if (replacement) {
+        replacementInventory = callbacks.getPageInventory?.() ?? []
+        order.push('attach-replacement-inventory')
+      }
+      callbacks.onAuthority?.(nextAuthority)
+      return nextAuthority
     }),
     retirePage: vi.fn(async () => {
       order.push('retire-dispatcher-page')
@@ -274,35 +430,64 @@ function createRig(options: { executorCloseError?: Error; hostSettled?: boolean 
     }),
     whenHandlersSettled: vi.fn(() => handlersSettled),
     close: vi.fn(async () => {
-      order.push('close-host')
-      return options.hostSettled ?? true
+      order.push(replacement ? 'close-replacement-host' : 'close-host')
+      return replacement ? true : (options.hostSettled ?? true)
     })
-  }
+  })
   const onError = vi.fn()
   return {
     order,
     routes,
+    replacementRoutes,
     executor,
-    host,
+    hosts,
+    hostOptionsHistory,
     onError,
     settleHandlers,
     get hostOptions() {
-      return hostOptions
+      return hostOptionsHistory.at(-1) ?? {}
+    },
+    get host() {
+      return hosts[0]!
+    },
+    get replacementInventory() {
+      return replacementInventory
     },
     createComposition: () =>
       new PairedRuntimeBrowserClientHostComposition({
-        createRoutes: (next) => {
-          expect(next).toEqual(authority)
-          order.push('activate-routes')
-          return routes
+        initialInput,
+        createRoutes: (input, nextAuthority) => {
+          const replacement = input === replacementInput
+          expect(nextAuthority).toEqual(
+            replacement ? (options.replacementAuthority ?? replacementAuthority) : authority
+          )
+          order.push(replacement ? 'activate-replacement-routes' : 'activate-routes')
+          return replacement ? replacementRoutes : routes
         },
         createExecutor: () => executor,
-        createHost: (next) => {
-          hostOptions = next
+        createHost: (input, callbacks) => {
+          const replacement = input === replacementInput
+          hostOptionsHistory.push(callbacks)
+          const host = makeHost(callbacks, replacement)
+          hosts.push(host)
           return host
         },
         onError
       })
+  }
+}
+
+function retainedPageInventory(): BrowserClientHostedPageInventory {
+  return {
+    authorityRuntimeId: 'runtime-a',
+    authorityEpoch: 'epoch-a',
+    browserHostClientId: 'client-a',
+    browserHostGeneration: 4,
+    browserPageId: 'page-a',
+    pageHostGeneration: 7,
+    browserProfileId: 'profile-a',
+    executionHostKey: 'execution-host-a',
+    state: 'active'
   }
 }
 

--- a/src/main/browser/paired-runtime-browser-client-host-composition.ts
+++ b/src/main/browser/paired-runtime-browser-client-host-composition.ts
@@ -5,13 +5,13 @@ import type {
   BrowserClientHostLeaseAuthority
 } from '../../shared/browser-client-host-protocol'
 import type { BrowserClientPageNetworkRoute } from './browser-client-page-cleanup'
-import { sameBrowserClientHostLeaseAuthority } from './browser-client-host-command-authority'
+import {
+  type ComposedBrowserClientNetworkRoutes,
+  PairedRuntimeBrowserClientHostRouteSets
+} from './paired-runtime-browser-client-host-route-sets'
 
-type ComposedNetworkRoutes = {
-  retain(key: string, signal: AbortSignal): Promise<BrowserClientPageNetworkRoute>
-  suspend(error?: Error): void
-  reconnect(): Promise<void>
-  close(error?: Error): Promise<void>
+type BrowserClientHostAuthorityTransitionInput = {
+  authorityConnectionIdentity: string
 }
 
 type ComposedPageExecutor = {
@@ -22,6 +22,8 @@ type ComposedPageExecutor = {
   retirePage(browserPageId: string, pageHostGeneration: number): Promise<boolean>
   hasUnresolvedPage(browserPageId: string, pageHostGeneration: number): boolean
   snapshotPageInventory(): readonly BrowserClientHostedPageInventory[]
+  beginAuthorityTransition(): void
+  completeAuthorityTransition(authorityConnectionIdentity: string): void
   fenceNavigation(): void
   close(): Promise<void>
 }
@@ -34,53 +36,62 @@ type ComposedClientHost = {
   close(error?: Error): Promise<boolean>
 }
 
-type PairedRuntimeBrowserClientHostCompositionOptions = {
-  createRoutes(authority: BrowserClientHostLeaseAuthority): ComposedNetworkRoutes
-  createExecutor(options: {
-    retainNetworkRoute(
-      executionHostKey: string,
-      signal: AbortSignal
-    ): Promise<BrowserClientPageNetworkRoute>
-  }): ComposedPageExecutor
-  createHost(options: {
-    handler(
-      event: BrowserClientHostCommandEvent,
-      signal: AbortSignal
-    ): Promise<BrowserClientHostCommandResult>
-    onAuthority(authority: BrowserClientHostLeaseAuthority): void
-    getPageInventory(): readonly BrowserClientHostedPageInventory[]
-    onError(error: Error): void
-    onTransportLost(error: Error): void
-    onReconnected(authority: BrowserClientHostLeaseAuthority): void
-  }): ComposedClientHost
+type ClientHostCallbacks = {
+  handler(
+    event: BrowserClientHostCommandEvent,
+    signal: AbortSignal
+  ): Promise<BrowserClientHostCommandResult>
+  onAuthority(authority: BrowserClientHostLeaseAuthority): void
+  getPageInventory(): readonly BrowserClientHostedPageInventory[]
+  onError(error: Error): void
+  onTransportLost(error: Error): void
+  onReconnected(authority: BrowserClientHostLeaseAuthority): void
+}
+
+type PairedRuntimeBrowserClientHostCompositionOptions<
+  Start extends BrowserClientHostAuthorityTransitionInput
+> = {
+  initialInput: Start
+  createRoutes(
+    input: Start,
+    authority: BrowserClientHostLeaseAuthority
+  ): ComposedBrowserClientNetworkRoutes
+  createExecutor(
+    input: Start,
+    options: {
+      retainNetworkRoute(
+        executionHostKey: string,
+        signal: AbortSignal
+      ): Promise<BrowserClientPageNetworkRoute>
+    }
+  ): ComposedPageExecutor
+  createHost(input: Start, callbacks: ClientHostCallbacks): ComposedClientHost
   onError?: (error: Error) => void
 }
 
-export class PairedRuntimeBrowserClientHostComposition {
+export class PairedRuntimeBrowserClientHostComposition<
+  Start extends BrowserClientHostAuthorityTransitionInput
+> {
   private readonly executor: ComposedPageExecutor
-  private readonly host: ComposedClientHost
-  private routes: ComposedNetworkRoutes | null = null
+  private host: ComposedClientHost
+  private readonly routeSets: PairedRuntimeBrowserClientHostRouteSets<Start>
   private startPromise: Promise<BrowserClientHostLeaseAuthority> | null = null
   private closePromise: Promise<boolean> | null = null
   private deferredExecutorClose: Promise<void> | null = null
-  private routeRecovery: ReturnType<typeof createRouteRecoveryGate> | null = null
-  private routeAuthority: BrowserClientHostLeaseAuthority | null = null
-  private routeRecoveryGeneration = 0
+  private hostGeneration = 0
   private closed = false
   private errorReported = false
 
-  constructor(private readonly options: PairedRuntimeBrowserClientHostCompositionOptions) {
-    this.executor = options.createExecutor({
-      retainNetworkRoute: (key, signal) => this.requireRoutes().retain(key, signal)
+  constructor(private readonly options: PairedRuntimeBrowserClientHostCompositionOptions<Start>) {
+    this.routeSets = new PairedRuntimeBrowserClientHostRouteSets({
+      createRoutes: options.createRoutes,
+      onRecoveryError: (error) => this.handleHostError(error),
+      onCleanupError: (error) => this.handleHostError(error)
     })
-    this.host = options.createHost({
-      handler: (event, signal) => this.handleCommand(event, signal),
-      getPageInventory: () => this.executor.snapshotPageInventory(),
-      onAuthority: (authority) => this.activateRoutes(authority),
-      onTransportLost: (error) => this.suspendRoutes(error),
-      onReconnected: (authority) => this.reconnectRoutes(authority),
-      onError: (error) => this.handleHostError(error)
+    this.executor = options.createExecutor(options.initialInput, {
+      retainNetworkRoute: (key, signal) => this.routeSets.retain(key, signal)
     })
+    this.host = this.createHost(options.initialInput, false)
   }
 
   start(): Promise<BrowserClientHostLeaseAuthority> {
@@ -88,6 +99,22 @@ export class PairedRuntimeBrowserClientHostComposition {
       return Promise.reject(new Error('paired_runtime_browser_client_host_composition_closed'))
     }
     this.startPromise ??= this.host.start()
+    return this.startPromise
+  }
+
+  replaceAuthority(input: Start): Promise<BrowserClientHostLeaseAuthority> {
+    if (this.closed) {
+      return Promise.reject(new Error('paired_runtime_browser_client_host_composition_closed'))
+    }
+    const error = new Error('Browser client host runtime authority was replaced')
+    this.hostGeneration += 1
+    try {
+      this.routeSets.retireCurrent(error)
+      this.executor.beginAuthorityTransition()
+    } catch (transitionError) {
+      return Promise.reject(transitionError)
+    }
+    this.startPromise = this.finishAuthorityReplacement(input, error)
     return this.startPromise
   }
 
@@ -113,9 +140,9 @@ export class PairedRuntimeBrowserClientHostComposition {
   close(error = new Error('Browser client host composition is closed')): Promise<boolean> {
     if (!this.closed) {
       this.closed = true
+      this.hostGeneration += 1
       this.fenceTerminalAuthority(error)
     }
-    this.rejectRouteRecovery(error)
     this.closePromise ??= this.closeComposition(error)
     return this.closePromise
   }
@@ -128,100 +155,88 @@ export class PairedRuntimeBrowserClientHostComposition {
     await this.deferredExecutorClose
   }
 
-  private activateRoutes(authority: BrowserClientHostLeaseAuthority): void {
-    if (this.closed || this.routes) {
-      throw new Error('browser_client_network_route_authority_unavailable')
+  private createHost(input: Start, requiresReconciliation: boolean): ComposedClientHost {
+    const generation = ++this.hostGeneration
+    let publishedInventory: readonly BrowserClientHostedPageInventory[] | null = null
+    return this.options.createHost(input, {
+      handler: (event, signal) => this.handleCommand(generation, event, signal),
+      getPageInventory: () => {
+        if (this.hostGeneration !== generation) {
+          return []
+        }
+        publishedInventory = this.executor.snapshotPageInventory()
+        return publishedInventory
+      },
+      onAuthority: (authority) => {
+        if (this.hostGeneration === generation) {
+          if (
+            requiresReconciliation &&
+            publishedInventory?.length &&
+            authority.pageReconciliationProtocolVersion !== 1
+          ) {
+            throw new Error('browser_client_page_reconciliation_unsupported')
+          }
+          this.routeSets.activate(input, authority)
+        }
+      },
+      onTransportLost: (error) => {
+        if (this.hostGeneration === generation) {
+          this.routeSets.suspend(error)
+        }
+      },
+      onReconnected: (authority) => {
+        if (this.hostGeneration === generation) {
+          this.routeSets.reconnect(authority)
+        }
+      },
+      onError: (error) => {
+        if (this.hostGeneration === generation) {
+          this.handleHostError(error)
+        }
+      }
+    })
+  }
+
+  private async finishAuthorityReplacement(
+    input: Start,
+    error: Error
+  ): Promise<BrowserClientHostLeaseAuthority> {
+    const previousHost = this.host
+    const settled = await previousHost.close(error)
+    if (!settled) {
+      await previousHost.whenHandlersSettled()
     }
-    this.routeAuthority = authority
-    this.routes = this.options.createRoutes(authority)
+    if (this.closed) {
+      throw new Error('paired_runtime_browser_client_host_composition_closed')
+    }
+    this.executor.completeAuthorityTransition(input.authorityConnectionIdentity)
+    const replacementHost = this.createHost(input, true)
+    this.host = replacementHost
+    return replacementHost.start()
   }
 
   private async handleCommand(
+    generation: number,
     event: BrowserClientHostCommandEvent,
     signal: AbortSignal
   ): Promise<BrowserClientHostCommandResult> {
-    const recovery = this.routeRecovery
-    if (recovery) {
-      await waitForRouteRecovery(recovery.promise, signal)
+    if (this.hostGeneration !== generation) {
+      throw new Error('browser_client_host_command_aborted')
     }
-    if (this.closed || signal.aborted) {
+    await this.routeSets.waitForRecovery(signal)
+    if (this.closed || signal.aborted || this.hostGeneration !== generation) {
       throw new Error('browser_client_host_command_aborted')
     }
     return this.executor.handle(event, signal)
   }
 
-  private suspendRoutes(error: Error): void {
-    if (this.closed) {
-      return
-    }
-    const routes = this.requireRoutes()
-    if (!this.routeRecovery) {
-      this.routeRecovery = createRouteRecoveryGate()
-      void this.routeRecovery.promise.catch(() => undefined)
-    }
-    this.routeRecoveryGeneration += 1
-    routes.suspend(error)
-  }
-
-  private reconnectRoutes(authority: BrowserClientHostLeaseAuthority): void {
-    if (
-      this.closed ||
-      !this.routeAuthority ||
-      !sameBrowserClientHostLeaseAuthority(this.routeAuthority, authority)
-    ) {
-      throw new Error('browser_client_network_route_authority_changed')
-    }
-    const recovery = this.routeRecovery
-    if (!recovery) {
-      throw new Error('browser_client_network_route_recovery_unexpected')
-    }
-    const generation = this.routeRecoveryGeneration
-    void this.requireRoutes()
-      .reconnect()
-      .then(() => {
-        if (this.routeRecovery === recovery && this.routeRecoveryGeneration === generation) {
-          this.routeRecovery = null
-          recovery.resolve()
-        }
-      })
-      .catch((error) => {
-        const routeError = asError(error)
-        if (this.routeRecovery !== recovery || this.routeRecoveryGeneration !== generation) {
-          return
-        }
-        this.routeRecovery = null
-        recovery.reject(routeError)
-        this.handleHostError(routeError)
-      })
-  }
-
-  private rejectRouteRecovery(error: Error): void {
-    const recovery = this.routeRecovery
-    if (!recovery) {
-      return
-    }
-    this.routeRecovery = null
-    recovery.reject(error)
-  }
-
   private fenceTerminalAuthority(error: Error): void {
-    try {
-      this.routes?.suspend(error)
-    } catch (routeError) {
-      this.reportCleanupError(asError(routeError))
-    }
+    this.routeSets.fence(error)
     try {
       this.executor.fenceNavigation()
     } catch (navigationError) {
       this.reportCleanupError(asError(navigationError))
     }
-  }
-
-  private requireRoutes(): ComposedNetworkRoutes {
-    if (!this.routes || this.closed) {
-      throw new Error('browser_client_network_route_authority_unavailable')
-    }
-    return this.routes
   }
 
   private async closeComposition(error: Error): Promise<boolean> {
@@ -245,7 +260,7 @@ export class PairedRuntimeBrowserClientHostComposition {
       )
     }
     try {
-      await this.routes?.close(error)
+      await this.routeSets.close(error)
     } catch (routeError) {
       failures.push(routeError)
     }
@@ -267,52 +282,14 @@ export class PairedRuntimeBrowserClientHostComposition {
     this.errorReported = true
     try {
       this.options.onError?.(error)
-    } catch {
-      // Reporting cannot retain a failed browser host composition.
-    }
+    } catch {}
   }
 
   private reportCleanupError(error: Error): void {
     try {
       this.options.onError?.(error)
-    } catch {
-      // Reporting cannot release ambiguous cleanup state.
-    }
+    } catch {}
   }
-}
-
-function createRouteRecoveryGate(): {
-  promise: Promise<void>
-  resolve: () => void
-  reject: (error: Error) => void
-} {
-  let resolve = (): void => {}
-  let reject = (_error: Error): void => {}
-  const promise = new Promise<void>((innerResolve, innerReject) => {
-    resolve = innerResolve
-    reject = innerReject
-  })
-  return { promise, resolve, reject }
-}
-
-function waitForRouteRecovery(recovery: Promise<void>, signal: AbortSignal): Promise<void> {
-  if (signal.aborted) {
-    return Promise.reject(new Error('browser_client_host_command_aborted'))
-  }
-  return new Promise((resolve, reject) => {
-    const abort = (): void => reject(new Error('browser_client_host_command_aborted'))
-    signal.addEventListener('abort', abort, { once: true })
-    void recovery.then(
-      () => {
-        signal.removeEventListener('abort', abort)
-        resolve()
-      },
-      (error) => {
-        signal.removeEventListener('abort', abort)
-        reject(error)
-      }
-    )
-  })
 }
 
 function asError(error: unknown): Error {

--- a/src/main/browser/paired-runtime-browser-client-host-registry.test.ts
+++ b/src/main/browser/paired-runtime-browser-client-host-registry.test.ts
@@ -40,6 +40,46 @@ describe('PairedRuntimeBrowserClientHostRegistry', () => {
     expect(order).toEqual(['start-first', 'close-first', 'start-second'])
   })
 
+  it('preserves the composition across a runtime authority transition', async () => {
+    const composition = createComposition()
+    const compositionFactory = vi.fn(() => composition)
+    const registry = new PairedRuntimeBrowserClientHostRegistry({
+      createComposition: compositionFactory
+    })
+    await registry.start(input(11))
+
+    await registry.start(input(11, 'runtime-b'))
+
+    expect(compositionFactory).toHaveBeenCalledOnce()
+    expect(composition.replaceAuthority).toHaveBeenCalledWith(input(11, 'runtime-b'))
+    expect(composition.close).not.toHaveBeenCalled()
+  })
+
+  it('keeps a failed authority transition tombstoned until cleanup settles', async () => {
+    const cleanup = deferred<void>()
+    const failed = createComposition(undefined, undefined, undefined, false, cleanup.promise)
+    failed.replaceAuthority.mockRejectedValueOnce(new Error('replacement attach failed'))
+    const replacement = createComposition()
+    const compositionFactory = vi.fn().mockReturnValueOnce(failed).mockReturnValueOnce(replacement)
+    const registry = new PairedRuntimeBrowserClientHostRegistry({
+      createComposition: compositionFactory
+    })
+    await registry.start(input(11))
+
+    await expect(registry.start(input(11, 'runtime-b'))).rejects.toThrow(
+      'replacement attach failed'
+    )
+    await expect(registry.start(input(11, 'runtime-b'))).rejects.toThrow(
+      'paired_runtime_browser_client_host_cleanup_pending'
+    )
+    expect(replacement.start).not.toHaveBeenCalled()
+
+    cleanup.resolve()
+    await cleanup.promise
+    await expect(registry.start(input(11, 'runtime-b'))).resolves.toEqual(authority)
+    expect(replacement.start).toHaveBeenCalledOnce()
+  })
+
   it('blocks replacement when the old host cannot prove handler settlement', async () => {
     const cleanup = deferred<void>()
     const first = createComposition(undefined, undefined, undefined, false, cleanup.promise)
@@ -135,6 +175,7 @@ function createComposition(
       }
       return authority
     }),
+    replaceAuthority: vi.fn(async () => ({ ...authority, authorityRuntimeId: 'runtime-b' })),
     retirePage: vi.fn(async () => true),
     close: vi.fn(async () => {
       if (order && closeLabel) {
@@ -156,10 +197,10 @@ function deferred<T>() {
   return { promise, reject, resolve }
 }
 
-function input(pairingRevision: number) {
+function input(pairingRevision: number, authorityRuntimeId = 'runtime-a') {
   return {
     environmentId: 'environment-a',
     pairingRevision,
-    authorityRuntimeId: 'runtime-a'
+    authorityRuntimeId
   }
 }

--- a/src/main/browser/paired-runtime-browser-client-host-registry.ts
+++ b/src/main/browser/paired-runtime-browser-client-host-registry.ts
@@ -6,8 +6,9 @@ export type PairedRuntimeBrowserClientHostStart = {
   authorityRuntimeId: string
 }
 
-type RegisteredBrowserClientHost = {
+type RegisteredBrowserClientHost<Start> = {
   start(): Promise<BrowserClientHostLeaseAuthority>
+  replaceAuthority(input: Start): Promise<BrowserClientHostLeaseAuthority>
   retirePage(browserPageId: string, pageHostGeneration: number): Promise<boolean>
   close(error?: Error): Promise<boolean>
   whenClosed(): Promise<void>
@@ -16,13 +17,13 @@ type RegisteredBrowserClientHost = {
 type PairedRuntimeBrowserClientHostRegistryOptions<
   Start extends PairedRuntimeBrowserClientHostStart
 > = {
-  createComposition(input: Start): RegisteredBrowserClientHost
+  createComposition(input: Start): RegisteredBrowserClientHost<Start>
 }
 
-type EnvironmentHostRecord = {
+type EnvironmentHostRecord<Start> = {
   pairingRevision: number
   authorityRuntimeId: string
-  composition: RegisteredBrowserClientHost
+  composition: RegisteredBrowserClientHost<Start>
   authority: Promise<BrowserClientHostLeaseAuthority>
   cleanupPending: boolean
 }
@@ -30,7 +31,7 @@ type EnvironmentHostRecord = {
 export class PairedRuntimeBrowserClientHostRegistry<
   Start extends PairedRuntimeBrowserClientHostStart = PairedRuntimeBrowserClientHostStart
 > {
-  private readonly hosts = new Map<string, EnvironmentHostRecord>()
+  private readonly hosts = new Map<string, EnvironmentHostRecord<Start>>()
   private readonly operations = new Map<string, Promise<void>>()
   private closePromise: Promise<void> | null = null
   private closed = false
@@ -54,6 +55,16 @@ export class PairedRuntimeBrowserClientHostRegistry<
         existing.authorityRuntimeId === input.authorityRuntimeId
       ) {
         return existing.authority
+      }
+      if (existing?.pairingRevision === input.pairingRevision) {
+        existing.authorityRuntimeId = input.authorityRuntimeId
+        existing.authority = existing.composition.replaceAuthority(input)
+        try {
+          return await existing.authority
+        } catch (error) {
+          await this.cleanupFailedStart(input.environmentId, existing, error)
+          throw error
+        }
       }
       if (existing) {
         let settled = false
@@ -84,12 +95,7 @@ export class PairedRuntimeBrowserClientHostRegistry<
       try {
         return await authority
       } catch (error) {
-        const cleanupSettled = await composition.close(asError(error)).catch(() => false)
-        if (cleanupSettled && this.hosts.get(input.environmentId) === record) {
-          this.hosts.delete(input.environmentId)
-        } else {
-          this.retainCleanupTombstone(input.environmentId, record)
-        }
+        await this.cleanupFailedStart(input.environmentId, record, error)
         throw error
       }
     })
@@ -169,7 +175,23 @@ export class PairedRuntimeBrowserClientHostRegistry<
     }
   }
 
-  private retainCleanupTombstone(environmentId: string, record: EnvironmentHostRecord): void {
+  private async cleanupFailedStart(
+    environmentId: string,
+    record: EnvironmentHostRecord<Start>,
+    error: unknown
+  ): Promise<void> {
+    const cleanupSettled = await record.composition.close(asError(error)).catch(() => false)
+    if (cleanupSettled && this.hosts.get(environmentId) === record) {
+      this.hosts.delete(environmentId)
+    } else {
+      this.retainCleanupTombstone(environmentId, record)
+    }
+  }
+
+  private retainCleanupTombstone(
+    environmentId: string,
+    record: EnvironmentHostRecord<Start>
+  ): void {
     if (record.cleanupPending) {
       return
     }

--- a/src/main/browser/paired-runtime-browser-client-host-route-sets.ts
+++ b/src/main/browser/paired-runtime-browser-client-host-route-sets.ts
@@ -1,0 +1,192 @@
+import type { BrowserClientHostLeaseAuthority } from '../../shared/browser-client-host-protocol'
+import type { BrowserClientPageNetworkRoute } from './browser-client-page-cleanup'
+import { sameBrowserClientHostLeaseAuthority } from './browser-client-host-command-authority'
+
+export type ComposedBrowserClientNetworkRoutes = {
+  retain(key: string, signal: AbortSignal): Promise<BrowserClientPageNetworkRoute>
+  suspend(error?: Error): void
+  reconnect(): Promise<void>
+  retire(error?: Error): Promise<void>
+  close(error?: Error): Promise<void>
+}
+
+type RouteSetOptions<Start> = {
+  createRoutes(
+    input: Start,
+    authority: BrowserClientHostLeaseAuthority
+  ): ComposedBrowserClientNetworkRoutes
+  onRecoveryError(error: Error): void
+  onCleanupError(error: Error): void
+}
+
+export class PairedRuntimeBrowserClientHostRouteSets<Start> {
+  private current: {
+    authority: BrowserClientHostLeaseAuthority
+    routes: ComposedBrowserClientNetworkRoutes
+  } | null = null
+  private readonly retired = new Set<ComposedBrowserClientNetworkRoutes>()
+  private recovery: ReturnType<typeof createRouteRecoveryGate> | null = null
+  private recoveryGeneration = 0
+  private closed = false
+
+  constructor(private readonly options: RouteSetOptions<Start>) {}
+
+  retain(key: string, signal: AbortSignal): Promise<BrowserClientPageNetworkRoute> {
+    return this.requireCurrent().routes.retain(key, signal)
+  }
+
+  activate(input: Start, authority: BrowserClientHostLeaseAuthority): void {
+    if (this.closed || this.current) {
+      throw new Error('browser_client_network_route_authority_unavailable')
+    }
+    this.current = { authority, routes: this.options.createRoutes(input, authority) }
+  }
+
+  suspend(error: Error): void {
+    if (this.closed) {
+      return
+    }
+    if (!this.recovery) {
+      this.recovery = createRouteRecoveryGate()
+      void this.recovery.promise.catch(() => undefined)
+    }
+    this.recoveryGeneration += 1
+    this.requireCurrent().routes.suspend(error)
+  }
+
+  reconnect(authority: BrowserClientHostLeaseAuthority): void {
+    const current = this.current
+    if (
+      this.closed ||
+      !current ||
+      !sameBrowserClientHostLeaseAuthority(current.authority, authority)
+    ) {
+      throw new Error('browser_client_network_route_authority_changed')
+    }
+    const recovery = this.recovery
+    if (!recovery) {
+      throw new Error('browser_client_network_route_recovery_unexpected')
+    }
+    const generation = this.recoveryGeneration
+    void current.routes
+      .reconnect()
+      .then(() => {
+        if (this.recovery === recovery && this.recoveryGeneration === generation) {
+          this.recovery = null
+          recovery.resolve()
+        }
+      })
+      .catch((error) => this.failRecovery(recovery, generation, asError(error)))
+  }
+
+  waitForRecovery(signal: AbortSignal): Promise<void> {
+    return this.recovery ? waitForRouteRecovery(this.recovery.promise, signal) : Promise.resolve()
+  }
+
+  retireCurrent(error: Error): void {
+    this.rejectRecovery(error)
+    const current = this.current
+    if (!current) {
+      return
+    }
+    this.current = null
+    this.retired.add(current.routes)
+    const retiring = current.routes.retire(error)
+    void retiring.then(
+      () => this.retired.delete(current.routes),
+      (retirementError) => this.options.onCleanupError(asError(retirementError))
+    )
+  }
+
+  fence(error: Error): void {
+    try {
+      this.current?.routes.suspend(error)
+    } catch (routeError) {
+      this.options.onCleanupError(asError(routeError))
+    }
+  }
+
+  async close(error: Error): Promise<void> {
+    this.closed = true
+    this.rejectRecovery(error)
+    const routes = new Set(this.retired)
+    if (this.current) {
+      routes.add(this.current.routes)
+    }
+    this.current = null
+    const results = await Promise.allSettled([...routes].map((entry) => entry.close(error)))
+    const failures = results.flatMap((result) =>
+      result.status === 'rejected' ? [result.reason] : []
+    )
+    if (failures.length > 0) {
+      throw new AggregateError(failures, 'Browser client host route cleanup failed')
+    }
+  }
+
+  private requireCurrent(): NonNullable<PairedRuntimeBrowserClientHostRouteSets<Start>['current']> {
+    if (!this.current || this.closed) {
+      throw new Error('browser_client_network_route_authority_unavailable')
+    }
+    return this.current
+  }
+
+  private failRecovery(
+    recovery: ReturnType<typeof createRouteRecoveryGate>,
+    generation: number,
+    error: Error
+  ): void {
+    if (this.recovery !== recovery || this.recoveryGeneration !== generation) {
+      return
+    }
+    this.recovery = null
+    recovery.reject(error)
+    this.options.onRecoveryError(error)
+  }
+
+  private rejectRecovery(error: Error): void {
+    const recovery = this.recovery
+    if (!recovery) {
+      return
+    }
+    this.recovery = null
+    recovery.reject(error)
+  }
+}
+
+function createRouteRecoveryGate(): {
+  promise: Promise<void>
+  resolve: () => void
+  reject: (error: Error) => void
+} {
+  let resolve = (): void => {}
+  let reject = (_error: Error): void => {}
+  const promise = new Promise<void>((innerResolve, innerReject) => {
+    resolve = innerResolve
+    reject = innerReject
+  })
+  return { promise, resolve, reject }
+}
+
+function waitForRouteRecovery(recovery: Promise<void>, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) {
+    return Promise.reject(new Error('browser_client_host_command_aborted'))
+  }
+  return new Promise((resolve, reject) => {
+    const abort = (): void => reject(new Error('browser_client_host_command_aborted'))
+    signal.addEventListener('abort', abort, { once: true })
+    void recovery.then(
+      () => {
+        signal.removeEventListener('abort', abort)
+        resolve()
+      },
+      (error) => {
+        signal.removeEventListener('abort', abort)
+        reject(error)
+      }
+    )
+  })
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error))
+}

--- a/src/main/browser/paired-runtime-browser-client-host-runtime.ts
+++ b/src/main/browser/paired-runtime-browser-client-host-runtime.ts
@@ -33,31 +33,29 @@ const browserClientHosts =
   new PairedRuntimeBrowserClientHostRegistry<ProductionBrowserClientHostStart>({
     createComposition: (input) =>
       new PairedRuntimeBrowserClientHostComposition({
-        createRoutes: (authority) => createNetworkRoutes(input.pairing, authority),
-        createExecutor: ({ retainNetworkRoute }) =>
+        initialInput: input,
+        createRoutes: (next, authority) => createNetworkRoutes(next.pairing, authority),
+        createExecutor: (next, { retainNetworkRoute }) =>
           new BrowserClientPageCommandExecutor({
-            orcaProfileId: input.orcaProfileId,
-            authorityConnectionIdentity: input.authorityConnectionIdentity,
+            orcaProfileId: next.orcaProfileId,
+            authorityConnectionIdentity: next.authorityConnectionIdentity,
             retainNetworkRoute,
             selectRenderer: selectBrowserClientPageRenderer,
             routeSessions: browserRouteSessionRegistry,
             routeWebContents: browserRouteWebContentsRegistry
           }),
-        createHost: ({
-          handler,
-          getPageInventory,
-          onAuthority,
-          onTransportLost,
-          onReconnected,
-          onError
-        }) =>
+        createHost: (
+          next,
+          { handler, getPageInventory, onAuthority, onTransportLost, onReconnected, onError }
+        ) =>
           new PairedRuntimeBrowserClientHost({
-            pairing: input.pairing,
-            authorityRuntimeId: input.authorityRuntimeId,
+            pairing: next.pairing,
+            authorityRuntimeId: next.authorityRuntimeId,
             browserHostClientId,
             hostCapabilities: ['webview'],
             handler,
             getPageInventory,
+            pageReconciliationProtocolVersion: 1,
             onAuthority,
             onTransportLost,
             onReconnected,

--- a/src/main/browser/paired-runtime-browser-client-host.test.ts
+++ b/src/main/browser/paired-runtime-browser-client-host.test.ts
@@ -65,6 +65,35 @@ describe('PairedRuntimeBrowserClientHost', () => {
     await host.close()
   })
 
+  it('advertises reconciliation only when the composed host enables it', async () => {
+    const { callbacks } = subscribeHost()
+    const host = createHost(
+      () => ({ status: 'completed' }),
+      undefined,
+      undefined,
+      () => [],
+      1
+    )
+    const starting = host.start()
+    await vi.waitFor(() => expect(callbacks.current).toBeDefined())
+
+    expect(subscribeRemoteRuntimeRequestMock.mock.calls[0]?.[2]).toMatchObject({
+      pageCommandProtocolVersion: 1,
+      pageInventoryProtocolVersion: 1,
+      pageReconciliationProtocolVersion: 1
+    })
+    callbacks.current!.onResponse({
+      ...readyResponse(),
+      result: {
+        ...readyResponse().result,
+        pageInventoryProtocolVersion: 1,
+        pageReconciliationProtocolVersion: 1
+      }
+    })
+    await expect(starting).resolves.toMatchObject({ pageReconciliationProtocolVersion: 1 })
+    await host.close()
+  })
+
   it('constructs command authority before the first command can arrive', async () => {
     const { callbacks, sendRequest } = subscribeHost()
     const handler = vi.fn((_command: BrowserClientHostCommandEvent, _signal: AbortSignal) => ({
@@ -301,7 +330,8 @@ function createHost(
   ) => BrowserClientHostCommandResult | Promise<BrowserClientHostCommandResult>,
   onError?: (error: Error) => void,
   dispatcher?: { joinTimeoutMs?: number },
-  getPageInventory?: () => readonly BrowserClientHostedPageInventory[]
+  getPageInventory?: () => readonly BrowserClientHostedPageInventory[],
+  pageReconciliationProtocolVersion?: 1
 ): PairedRuntimeBrowserClientHost {
   return new PairedRuntimeBrowserClientHost({
     pairing,
@@ -310,6 +340,7 @@ function createHost(
     hostCapabilities: ['webview'],
     handler,
     getPageInventory,
+    ...(pageReconciliationProtocolVersion ? { pageReconciliationProtocolVersion } : {}),
     onError,
     dispatcher
   })

--- a/src/main/browser/paired-runtime-browser-client-host.ts
+++ b/src/main/browser/paired-runtime-browser-client-host.ts
@@ -19,6 +19,7 @@ export type PairedRuntimeBrowserClientHostOptions = {
   hostCapabilities: readonly string[]
   handler: CommandHandler
   getPageInventory?: () => readonly BrowserClientHostedPageInventory[]
+  pageReconciliationProtocolVersion?: 1
   dispatcher?: DispatcherLimits
   timeoutMs?: number
   subscription?: RemoteRuntimeSubscriptionOptions
@@ -48,6 +49,9 @@ export class PairedRuntimeBrowserClientHost {
         ? {
             pageInventoryProtocolVersion: 1,
             leaseReconnectProtocolVersion: 1,
+            ...(options.pageReconciliationProtocolVersion
+              ? { pageReconciliationProtocolVersion: options.pageReconciliationProtocolVersion }
+              : {}),
             getPageInventory: options.getPageInventory
           }
         : {}),

--- a/src/main/ipc/runtime-environments-subscription-teardown.test.ts
+++ b/src/main/ipc/runtime-environments-subscription-teardown.test.ts
@@ -62,8 +62,7 @@ vi.mock('./runtime-environment-request-connections', () => ({
   closeRemoteRuntimeRequestConnection: closeRemoteRuntimeRequestConnectionMock
 }))
 vi.mock('../browser/paired-runtime-browser-client-host-runtime', () => ({
-  closePairedRuntimeBrowserClientHostEnvironment:
-    closePairedRuntimeBrowserClientHostEnvironmentMock
+  closePairedRuntimeBrowserClientHostEnvironment: closePairedRuntimeBrowserClientHostEnvironmentMock
 }))
 
 import {

--- a/src/main/runtime/browser-host-page-reconciliation-executor.test.ts
+++ b/src/main/runtime/browser-host-page-reconciliation-executor.test.ts
@@ -47,7 +47,7 @@ const priorPageAuthority = (
 
 function reconciliationPlan() {
   const previous = {
-    authorityRuntimeId: 'runtime-old',
+    authorityRuntimeId: 'runtime-new',
     authorityEpoch: 'epoch-old',
     browserHostClientId: 'client-a',
     browserHostGeneration: 4,

--- a/src/main/runtime/browser-host-page-reconciliation-orchestration.test.ts
+++ b/src/main/runtime/browser-host-page-reconciliation-orchestration.test.ts
@@ -378,7 +378,7 @@ function leaseIdentity(lease: {
 
 function oldPage(browserPageId: string): BrowserClientHostedPageInventory {
   return {
-    authorityRuntimeId: 'runtime-old',
+    authorityRuntimeId: 'runtime-new',
     authorityEpoch: 'epoch-old',
     browserHostClientId: 'host-a',
     browserHostGeneration: 4,

--- a/src/main/runtime/browser-host-page-reconciliation-plan.test.ts
+++ b/src/main/runtime/browser-host-page-reconciliation-plan.test.ts
@@ -97,9 +97,9 @@ describe('browser host page reconciliation plan', () => {
     })
   })
 
-  it('reclaims only an exact persisted previous authority without navigation', () => {
+  it('reclaims only an exact persisted previous authority on the same runtime', () => {
     const previous = {
-      authorityRuntimeId: 'runtime-old',
+      authorityRuntimeId: 'runtime-new',
       authorityEpoch: 'epoch-old',
       browserHostClientId: 'client-a',
       browserHostGeneration: 4,
@@ -190,7 +190,7 @@ describe('browser host page reconciliation plan', () => {
 
   it('permits generation counters to restart under a new authority epoch', () => {
     const previous = {
-      authorityRuntimeId: 'runtime-old',
+      authorityRuntimeId: 'runtime-new',
       authorityEpoch: 'epoch-old',
       browserHostClientId: 'client-a',
       browserHostGeneration: 9,
@@ -207,6 +207,29 @@ describe('browser host page reconciliation plan', () => {
     expect(planBrowserHostPageReconciliation([intent], [page], inventorySource).reclaim).toEqual([
       { intent, page }
     ])
+  })
+
+  it('closes and restores an SSH page instead of reclaiming it across runtimes', () => {
+    const previous = {
+      authorityRuntimeId: 'runtime-old',
+      authorityEpoch: 'epoch-old',
+      browserHostClientId: 'client-a',
+      browserHostGeneration: 4,
+      pageHostGeneration: 7,
+      pairedDeviceId: 'device-a'
+    }
+    const intent = currentIntent({
+      executionHostKey: JSON.stringify(['ssh', 'target-a', 'provider-a', 3]),
+      reclaimFrom: previous
+    })
+    const page = currentPage({
+      ...inventoryPageAuthority(previous),
+      executionHostKey: intent.executionHostKey
+    })
+
+    expect(
+      planBrowserHostPageReconciliation([intent], [page], inventorySource).closeThenRestore
+    ).toEqual([{ intent, page }])
   })
 
   it('rejects restart reclaim from a different authenticated paired device', () => {

--- a/src/main/runtime/browser-host-page-reconciliation-plan.ts
+++ b/src/main/runtime/browser-host-page-reconciliation-plan.ts
@@ -106,6 +106,7 @@ function canReclaimPage(
     intent.reclaimFrom &&
     intent.reclaimFrom.pairedDeviceId === inventoryPairedDeviceId &&
     intent.authorityEpoch !== intent.reclaimFrom.authorityEpoch &&
+    intent.authorityRuntimeId === intent.reclaimFrom.authorityRuntimeId &&
     sameAuthority(intent.reclaimFrom, page) &&
     intent.browserHostClientId === intent.reclaimFrom.browserHostClientId &&
     intent.browserProfileId === page.browserProfileId &&

--- a/src/main/runtime/browser-network-tunnel-paired-runtime.integration.test.ts
+++ b/src/main/runtime/browser-network-tunnel-paired-runtime.integration.test.ts
@@ -103,7 +103,7 @@ describe('paired runtime browser network tunnel', () => {
     expect(errors).toEqual([])
   })
 
-  it('commits reconciliation placement after a real paired command result', async () => {
+  it('commits same-runtime reconciliation placement after a real paired command result', async () => {
     const userDataPath = mkdtempSync(join(tmpdir(), 'orca-browser-reconciliation-'))
     resources.push(() => rmSync(userDataPath, { recursive: true, force: true }))
     const runtime = new OrcaRuntimeService({} as never)
@@ -126,7 +126,7 @@ describe('paired runtime browser network tunnel', () => {
       throw new Error('Runtime pairing identity is unavailable')
     }
     const oldPage = {
-      authorityRuntimeId: 'runtime-old',
+      authorityRuntimeId: runtime.getRuntimeId(),
       authorityEpoch: 'epoch-old',
       browserHostClientId: 'integration-browser-host',
       browserHostGeneration: 4,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​527 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​46 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​481 |
| Prod | 13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​681 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​241 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​440 |

<!-- /orca-pr-loc -->

## Summary

Preserves the concrete Electron page executor and retained page inventory when the runtime authority changes inside the same authenticated pairing revision. The old host and route authority are fenced first, old handlers settle, a fresh authority connection and route set are installed, and retained pages are reconciled before new commands are admitted.

This is the final authority review layer before the activated desktop slice. It does not add a two-way fallback, live client/server migration, or temporary compatibility machinery for partial deployment.

Linear: [STA-4150](https://linear.app/stably/issue/STA-4150/refactor-remote-browser-to-client-hosted-electron-webviews)

## Compatibility

- Pairing-revision replacement still closes the old composition before replacement.
- Same-pairing replacement preserves inventory only when the negotiated inventory and reconciliation protocols can prove it; legacy peers are accepted only with empty retained inventory.
- Old callbacks, commands, routes, navigation grants, and authority identities are generation-fenced.
- Ambiguous host, executor, page, or route cleanup remains fail-closed and bounded.
- No new wire field or opcode is introduced in this layer; existing optional negotiated contracts remain the boundary.
- Server placement, browserless/ineligible callers, SSH, WSL, native hosts, folder workspaces, and worktrees are not rerouted by this review layer.

## Evidence

- Deterministic affected authority/reconciliation suite: 11 files / 173 tests.
- Lifecycle tombstone oracle: 3 files / 36 tests.
- Focused execution-host routing: 3 files / 23 tests.
- Shared compatibility: 3 files / 46 tests; mobile legacy fixture: 1/1.
- Full Node, CLI, and web typecheck.
- Full lint, native and type-aware audits, max-lines ratchet, localization checks, and 88 reliability gates.
- Conflict-free rebase onto `origin/main@1b6d2403cb`; all 40 patches were identical under `git range-diff` before the ledger-only checkpoint update.

## Next

The next stacked branch activates the complete eligible Electron desktop path: capability advertisement, default client placement, live host registration, normal browser/agent/CLI routing, renderer presentation and local input/chrome, exact SSH/native execution-host grants, kill switch, failure UX/telemetry, and paired-Electron proof. The feature is judged production-ready only at that activated tip.