### PR TITLE
fix(orchestration): wait for Codex composer before paste

### DIFF
--- a/src/main/runtime/agent-prompt-receipt-correlation.test.ts
+++ b/src/main/runtime/agent-prompt-receipt-correlation.test.ts
@@ -31,6 +31,7 @@ describe('agent prompt receipt correlation', () => {
       () => undefined,
       'codex'
     )
+    runtime.onPtyData('pty-prompt', '\x1b[?2004h\x1b[?1049h\x1b[1m›\x1b[0m', Date.now())
     runtime.onPtyData('pty-prompt', '\x1b]0;Codex working\x07', Date.now())
 
     const firstPromise = runtime.sendTerminalAgentPrompt(handle, 'first prompt', {

--- a/src/main/runtime/agent-prompt-submission-runtime.test.ts
+++ b/src/main/runtime/agent-prompt-submission-runtime.test.ts
@@ -12,6 +12,7 @@ import { OrcaRuntimeService } from './orca-runtime'
 import { makeStore } from './runtime-rpc-worktree-store-fixtures'
 
 const createPromptRuntime = createAgentPromptSubmissionRuntime
+const CODEX_COMPOSER_READY_BYTES = '\x1b[?2004h\x1b[?1049h\x1b[1m›\x1b[0m'
 
 vi.mock('../git/worktree', () => ({
   listWorktrees: vi.fn().mockResolvedValue([
@@ -450,6 +451,7 @@ describe('agent prompt submission runtime', () => {
         runtime.onPtyData('pty-prompt', 'output from the existing turn', Date.now())
       }
     }, 'codex')
+    runtime.onPtyData('pty-prompt', CODEX_COMPOSER_READY_BYTES, Date.now())
     runtime.onPtyData(
       'pty-prompt',
       '\x1b]9999;{"state":"working","agentType":"aider"}\x07',
@@ -565,6 +567,7 @@ describe('agent prompt submission runtime', () => {
     vi.setSystemTime(1_000)
     const hook = { state: 'working' as const, stateStartedAt: 1_000 }
     const { runtime, handle, writes } = await createHookOnlyPromptRuntime(hook, 'codex')
+    runtime.onPtyData('pty-prompt', CODEX_COMPOSER_READY_BYTES, Date.now())
 
     const firstPromise = runtime.sendTerminalAgentPrompt(handle, 'first prompt', {
       acceptQueued: true,
@@ -766,6 +769,7 @@ describe('agent prompt submission runtime', () => {
   it('reserves a lifecycle transition for only one queued prompt receipt', async () => {
     vi.useFakeTimers()
     const { runtime, handle } = await createAgentPromptSubmissionRuntime(() => undefined, 'codex')
+    runtime.onPtyData('pty-prompt', CODEX_COMPOSER_READY_BYTES, Date.now())
     runtime.onPtyData('pty-prompt', '\x1b]0;Codex working\x07', Date.now())
 
     const firstPromise = runtime.sendTerminalAgentPrompt(handle, 'first prompt', {

--- a/src/main/runtime/orca-runtime-codex-composer-wait.test.ts
+++ b/src/main/runtime/orca-runtime-codex-composer-wait.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { AGENT_PROMPT_BRACKETED_PASTE_END } from '../../shared/agent-prompt-injection'
+import {
+  agentSessionLeaseFixture,
+  agentSessionRecordFixture
+} from '../../shared/agent-session-record.test-fixture'
+import { agentSessionPtyWriteGate } from './agent-session-pty-write-gate'
 import { createAgentPromptSubmissionRuntime } from './agent-prompt-submission-runtime-test-fixture'
 import { acknowledgeAgentPromptSubmit } from './orca-runtime-test-mocks.spec'
 
@@ -27,6 +32,10 @@ vi.mock('../git/worktree', () => ({
 }))
 
 describe('Codex composer wait before prompt paste', () => {
+  afterEach(() => {
+    agentSessionPtyWriteGate.detachRecordLookup()
+  })
+
   it('waits for Codex composer readiness before writing prompt bytes', async () => {
     vi.useFakeTimers()
     try {
@@ -119,5 +128,46 @@ describe('Codex composer wait before prompt paste', () => {
 
     await rejection
     expect(writes).toEqual([])
+  })
+
+  it('refuses a native-owned Codex pane before waiting for a composer', async () => {
+    vi.useFakeTimers()
+    try {
+      const { runtime, handle, writes } = await createAgentPromptSubmissionRuntime(
+        () => undefined,
+        'codex'
+      )
+      const record = agentSessionRecordFixture(agentSessionLeaseFixture({ runtimeKind: 'native' }))
+      agentSessionPtyWriteGate.attachRecordLookup((sessionId) =>
+        sessionId === record.sessionId ? record : null
+      )
+      agentSessionPtyWriteGate.bindPty('pty-prompt', record.sessionId)
+
+      let failure: unknown
+      const pending = runtime
+        .sendTerminalAgentPrompt(handle, 'review this change')
+        .catch((error) => {
+          failure = error
+        })
+      await vi.advanceTimersByTimeAsync(1)
+
+      expect(failure).toMatchObject({
+        name: 'AgentSessionPtyWriteRefusedError',
+        refusal: expect.objectContaining({
+          code: 'agent_session_conflict',
+          ownerRuntimeKind: 'native'
+        })
+      })
+      expect(writes).toEqual([])
+      await vi.advanceTimersByTimeAsync(20_000)
+      expect(failure).toMatchObject({
+        name: 'AgentSessionPtyWriteRefusedError',
+        refusal: expect.objectContaining({ code: 'agent_session_conflict' })
+      })
+      expect(writes).toEqual([])
+      await pending
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/src/main/runtime/orca-runtime-codex-composer-wait.test.ts
+++ b/src/main/runtime/orca-runtime-codex-composer-wait.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from 'vitest'
+import { AGENT_PROMPT_BRACKETED_PASTE_END } from '../../shared/agent-prompt-injection'
+import { createAgentPromptSubmissionRuntime } from './agent-prompt-submission-runtime-test-fixture'
+import { acknowledgeAgentPromptSubmit } from './orca-runtime-test-mocks.spec'
+
+const CODEX_COMPOSER_READY_BYTES = '\x1b[?2004h\x1b[?1049h\x1b[1m›\x1b[0m'
+
+vi.mock('../git/worktree', () => ({
+  listWorktrees: vi.fn().mockResolvedValue([
+    {
+      path: '/tmp/worktree-a',
+      head: 'abc',
+      branch: 'feature/prompt-verification',
+      isBare: false,
+      isMainWorktree: false
+    }
+  ]),
+  listWorktreesStrict: vi.fn().mockResolvedValue([
+    {
+      path: '/tmp/worktree-a',
+      head: 'abc',
+      branch: 'feature/prompt-verification',
+      isBare: false,
+      isMainWorktree: false
+    }
+  ])
+}))
+
+describe('Codex composer wait before prompt paste', () => {
+  it('waits for Codex composer readiness before writing prompt bytes', async () => {
+    vi.useFakeTimers()
+    try {
+      const { runtime, handle, writes } = await createAgentPromptSubmissionRuntime(
+        (nextRuntime, data) => {
+          if (data.includes(AGENT_PROMPT_BRACKETED_PASTE_END)) {
+            setTimeout(
+              () => nextRuntime.onPtyData('pty-prompt', '\x1b[?25hcomposer redraw', Date.now()),
+              1
+            )
+          }
+          acknowledgeAgentPromptSubmit(nextRuntime, 'pty-prompt', data)
+        },
+        'codex'
+      )
+
+      const sendPromise = runtime.sendTerminalAgentPrompt(handle, 'review this change')
+      await vi.advanceTimersByTimeAsync(100)
+      expect(writes).toEqual([])
+
+      runtime.onPtyData('pty-prompt', '\x1b[?20', Date.now())
+      await vi.advanceTimersByTimeAsync(1)
+      expect(writes).toEqual([])
+      runtime.onPtyData('pty-prompt', CODEX_COMPOSER_READY_BYTES.slice(5), Date.now())
+      await vi.advanceTimersByTimeAsync(1)
+      expect(writes.join('')).toContain('review this change')
+
+      await vi.advanceTimersByTimeAsync(1_500)
+      await sendPromise
+      expect(writes.filter((data) => data === '\r')).toHaveLength(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('fails a Codex prompt without writing when composer readiness times out', async () => {
+    vi.useFakeTimers()
+    try {
+      const { runtime, handle, writes } = await createAgentPromptSubmissionRuntime(
+        () => undefined,
+        'codex'
+      )
+
+      const sendPromise = runtime.sendTerminalAgentPrompt(handle, 'review this change')
+      const rejection = expect(sendPromise).rejects.toThrow('agent_composer_not_ready')
+      await vi.advanceTimersByTimeAsync(20_000)
+
+      await rejection
+      expect(writes).toEqual([])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('fails a Codex composer wait immediately when its PTY exits', async () => {
+    vi.useFakeTimers()
+    try {
+      const { runtime, handle, writes } = await createAgentPromptSubmissionRuntime(
+        () => undefined,
+        'codex'
+      )
+      let failure: unknown
+      const sendPromise = runtime
+        .sendTerminalAgentPrompt(handle, 'review this change')
+        .catch((error: unknown) => {
+          failure = error
+        })
+
+      runtime.onPtyExit('pty-prompt', 7)
+      await vi.advanceTimersByTimeAsync(1)
+
+      expect(failure).toMatchObject({ message: 'terminal_exited' })
+      expect(writes).toEqual([])
+      await sendPromise
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('revalidates the PTY generation after Codex composer readiness', async () => {
+    const { runtime, handle, writes } = await createAgentPromptSubmissionRuntime(
+      () => undefined,
+      'codex'
+    )
+
+    const sendPromise = runtime.sendTerminalAgentPrompt(handle, 'review this change')
+    const rejection = expect(sendPromise).rejects.toThrow('terminal_exited')
+    runtime.onPtyData('pty-prompt', CODEX_COMPOSER_READY_BYTES, Date.now())
+    runtime.onPtyExit('pty-prompt', 7)
+
+    await rejection
+    expect(writes).toEqual([])
+  })
+})

--- a/src/main/runtime/orca-runtime-composer-cancellation-review.test.ts
+++ b/src/main/runtime/orca-runtime-composer-cancellation-review.test.ts
@@ -1,0 +1,58 @@
+import { expect, it, vi } from 'vitest'
+import { createAgentPromptSubmissionRuntime } from './agent-prompt-submission-runtime-test-fixture'
+
+vi.mock('../git/worktree', () => ({
+  listWorktrees: vi.fn().mockResolvedValue([
+    {
+      path: '/tmp/worktree-a',
+      head: 'abc',
+      branch: 'feature/prompt-verification',
+      isBare: false,
+      isMainWorktree: false
+    }
+  ]),
+  listWorktreesStrict: vi.fn().mockResolvedValue([
+    {
+      path: '/tmp/worktree-a',
+      head: 'abc',
+      branch: 'feature/prompt-verification',
+      isBare: false,
+      isMainWorktree: false
+    }
+  ])
+}))
+
+it.each([false, true])(
+  'honors cancellation during composer readiness (already aborted: %s)',
+  async (alreadyAborted) => {
+    vi.useFakeTimers()
+    try {
+      const { runtime, handle, writes } = await createAgentPromptSubmissionRuntime(
+        () => undefined,
+        'codex'
+      )
+      const controller = new AbortController()
+      if (alreadyAborted) {
+        controller.abort()
+      }
+      let failure: unknown
+      const pending = runtime
+        .sendTerminalAgentPrompt(handle, 'cancel this prompt', { signal: controller.signal })
+        .catch((error) => {
+          failure = error
+        })
+      await vi.advanceTimersByTimeAsync(10)
+      if (!alreadyAborted) {
+        controller.abort()
+      }
+      await vi.advanceTimersByTimeAsync(10)
+      expect.soft(failure).toBeDefined()
+      expect.soft(writes).toEqual([])
+      await vi.advanceTimersByTimeAsync(20_000)
+      await pending
+      expect.soft(failure).toMatchObject({ message: 'request_aborted' })
+    } finally {
+      vi.useRealTimers()
+    }
+  }
+)

--- a/src/main/runtime/orca-runtime-controller-knows-pty-is-live.ts
+++ b/src/main/runtime/orca-runtime-controller-knows-pty-is-live.ts
@@ -136,7 +136,7 @@ export class OrcaRuntimeWithControllerKnowsPtyIsLive extends OrcaRuntimeWithReso
       }
       await assertTerminalInputWithinLimitWithYield(payload)
       const generation = this.getPtyLifecycleGeneration(pty.pty.ptyId)
-      await this.waitForCodexPromptComposer(pty.pty.ptyId)
+      await this.waitForCodexPromptComposer(pty.pty.ptyId, options.signal)
       if (
         this.getPtyLifecycleGeneration(pty.pty.ptyId) !== generation ||
         this.ptysById.get(pty.pty.ptyId) !== pty.pty ||
@@ -180,7 +180,7 @@ export class OrcaRuntimeWithControllerKnowsPtyIsLive extends OrcaRuntimeWithReso
     }
     const ptyId = leaf.ptyId
     const generation = this.getPtyLifecycleGeneration(ptyId)
-    await this.waitForCodexPromptComposer(ptyId)
+    await this.waitForCodexPromptComposer(ptyId, options.signal)
     if (this.getPtyLifecycleGeneration(ptyId) !== generation) {
       throw new Error('terminal_exited')
     }
@@ -202,7 +202,7 @@ export class OrcaRuntimeWithControllerKnowsPtyIsLive extends OrcaRuntimeWithReso
     }
   }
 
-  protected async waitForCodexPromptComposer(ptyId: string): Promise<void> {
+  protected async waitForCodexPromptComposer(ptyId: string, signal?: AbortSignal): Promise<void> {
     const pty = this.ptysById.get(ptyId)
     if ((pty?.launchAgent ?? pty?.foregroundAgent) !== 'codex') {
       return
@@ -214,7 +214,8 @@ export class OrcaRuntimeWithControllerKnowsPtyIsLive extends OrcaRuntimeWithReso
         subscribeToExit: (id, listener) => this.subscribeToPtyExit(id, listener)
       },
       ptyId,
-      'codex'
+      'codex',
+      signal
     )
     if (!ready) {
       throw new Error('agent_composer_not_ready')

--- a/src/main/runtime/orca-runtime-controller-knows-pty-is-live.ts
+++ b/src/main/runtime/orca-runtime-controller-knows-pty-is-live.ts
@@ -9,6 +9,7 @@ import {
 } from './terminal-send-payload'
 import { buildAgentPromptPasteBytes } from '../../shared/agent-prompt-injection'
 import { waitForPtyDraftInputReady } from './runtime-pty-draft-input-ready'
+import { agentSessionPtyWriteGate } from './agent-session-pty-write-gate'
 
 export class OrcaRuntimeWithControllerKnowsPtyIsLive extends OrcaRuntimeWithResolveTerminalPane {
   protected controllerKnowsPtyIsLive(ptyId: string): boolean {
@@ -136,6 +137,8 @@ export class OrcaRuntimeWithControllerKnowsPtyIsLive extends OrcaRuntimeWithReso
       }
       await assertTerminalInputWithinLimitWithYield(payload)
       const generation = this.getPtyLifecycleGeneration(pty.pty.ptyId)
+      // Why: native/Structured Chat can own the pane with no composer; wait would hide typed refusal.
+      agentSessionPtyWriteGate.assertAdmitted(pty.pty.ptyId)
       await this.waitForCodexPromptComposer(pty.pty.ptyId, options.signal)
       if (
         this.getPtyLifecycleGeneration(pty.pty.ptyId) !== generation ||
@@ -180,6 +183,7 @@ export class OrcaRuntimeWithControllerKnowsPtyIsLive extends OrcaRuntimeWithReso
     }
     const ptyId = leaf.ptyId
     const generation = this.getPtyLifecycleGeneration(ptyId)
+    agentSessionPtyWriteGate.assertAdmitted(ptyId)
     await this.waitForCodexPromptComposer(ptyId, options.signal)
     if (this.getPtyLifecycleGeneration(ptyId) !== generation) {
       throw new Error('terminal_exited')

--- a/src/main/runtime/orca-runtime-controller-knows-pty-is-live.ts
+++ b/src/main/runtime/orca-runtime-controller-knows-pty-is-live.ts
@@ -8,6 +8,7 @@ import {
   buildTerminalSendPayload
 } from './terminal-send-payload'
 import { buildAgentPromptPasteBytes } from '../../shared/agent-prompt-injection'
+import { waitForPtyDraftInputReady } from './runtime-pty-draft-input-ready'
 
 export class OrcaRuntimeWithControllerKnowsPtyIsLive extends OrcaRuntimeWithResolveTerminalPane {
   protected controllerKnowsPtyIsLive(ptyId: string): boolean {
@@ -135,6 +136,14 @@ export class OrcaRuntimeWithControllerKnowsPtyIsLive extends OrcaRuntimeWithReso
       }
       await assertTerminalInputWithinLimitWithYield(payload)
       const generation = this.getPtyLifecycleGeneration(pty.pty.ptyId)
+      await this.waitForCodexPromptComposer(pty.pty.ptyId)
+      if (
+        this.getPtyLifecycleGeneration(pty.pty.ptyId) !== generation ||
+        this.ptysById.get(pty.pty.ptyId) !== pty.pty ||
+        !pty.pty.connected
+      ) {
+        throw new Error('terminal_exited')
+      }
       const delivery = await this.serializeAgentPromptSubmission(
         pty.pty.ptyId,
         generation,
@@ -169,11 +178,20 @@ export class OrcaRuntimeWithControllerKnowsPtyIsLive extends OrcaRuntimeWithReso
     if (await this.isLeafPtyProvenAbsent(leaf.ptyId)) {
       throw new Error('terminal_not_writable')
     }
-    const generation = this.getPtyLifecycleGeneration(leaf.ptyId)
-    const delivery = await this.serializeAgentPromptSubmission(leaf.ptyId, generation, async () => {
-      this.assertLiveTerminalHandleTargetsPty(handle, leaf.ptyId!)
-      this.assertAgentPromptGeneration(leaf.ptyId!, generation)
-      return await this.writeTerminalAgentPrompt(handle, leaf.ptyId!, generation, payload, options)
+    const ptyId = leaf.ptyId
+    const generation = this.getPtyLifecycleGeneration(ptyId)
+    await this.waitForCodexPromptComposer(ptyId)
+    if (this.getPtyLifecycleGeneration(ptyId) !== generation) {
+      throw new Error('terminal_exited')
+    }
+    const current = this.getLiveLeafForHandle(handle).leaf
+    if (!current.writable || current.ptyId !== ptyId || (await this.isLeafPtyProvenAbsent(ptyId))) {
+      throw new Error('terminal_not_writable')
+    }
+    const delivery = await this.serializeAgentPromptSubmission(ptyId, generation, async () => {
+      this.assertLiveTerminalHandleTargetsPty(handle, ptyId)
+      this.assertAgentPromptGeneration(ptyId, generation)
+      return await this.writeTerminalAgentPrompt(handle, ptyId, generation, payload, options)
     })
     const bytesWritten = Buffer.byteLength(payload, 'utf8') + delivery.submits
     return {
@@ -181,6 +199,25 @@ export class OrcaRuntimeWithControllerKnowsPtyIsLive extends OrcaRuntimeWithReso
       accepted: true,
       bytesWritten,
       ...(delivery.prompt ? { prompt: delivery.prompt } : {})
+    }
+  }
+
+  protected async waitForCodexPromptComposer(ptyId: string): Promise<void> {
+    const pty = this.ptysById.get(ptyId)
+    if ((pty?.launchAgent ?? pty?.foregroundAgent) !== 'codex') {
+      return
+    }
+    const ready = await waitForPtyDraftInputReady(
+      {
+        subscribeToData: (id, listener) => this.subscribeToTerminalData(id, listener),
+        readRecentOutput: (id) => this.recentPtyOutputById.get(id)?.read(),
+        subscribeToExit: (id, listener) => this.subscribeToPtyExit(id, listener)
+      },
+      ptyId,
+      'codex'
+    )
+    if (!ready) {
+      throw new Error('agent_composer_not_ready')
     }
   }
 }

--- a/src/main/runtime/orca-runtime-tests/terminal-creation-and-readiness-part-07.spec.ts
+++ b/src/main/runtime/orca-runtime-tests/terminal-creation-and-readiness-part-07.spec.ts
@@ -557,6 +557,9 @@ describe('OrcaRuntimeService', () => {
         const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
           launchAgent: agent
         })
+        if (agent === 'codex') {
+          runtime.onPtyData('pty-bg', '\x1b[?2004h\x1b[?1049h\x1b[1m›\x1b[0m', Date.now())
+        }
         const assertAuthority = vi.fn()
 
         const sendPromise = runtime.sendTerminalAgentPrompt(handle, 'review this change', {

--- a/src/main/runtime/orca-runtime-tests/terminal-creation-and-readiness-part-08.spec.ts
+++ b/src/main/runtime/orca-runtime-tests/terminal-creation-and-readiness-part-08.spec.ts
@@ -116,6 +116,7 @@ describe('OrcaRuntimeService', () => {
       const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
         launchAgent: 'codex'
       })
+      runtime.onPtyData('pty-bg', '\x1b[?2004h\x1b[?1049h\x1b[1m›\x1b[0m', Date.now())
 
       const sendPromise = runtime.sendTerminalAgentPrompt(handle, 'review this change')
       await vi.advanceTimersByTimeAsync(8_000)

--- a/src/main/runtime/orca-runtime-tests/terminal-creation-and-readiness-part-08.spec.ts
+++ b/src/main/runtime/orca-runtime-tests/terminal-creation-and-readiness-part-08.spec.ts
@@ -44,6 +44,7 @@ describe('OrcaRuntimeService', () => {
       const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
 
       await expect(runtime.isTerminalRunningSettledPromptAgent(handle)).resolves.toBe(true)
+      runtime.onPtyData('pty-bg', '\x1b[?2004h\x1b[?1049h\x1b[1m›\x1b[0m', Date.now())
       const sendPromise = runtime.sendTerminalAgentPrompt(handle, 'review this change')
       await vi.advanceTimersByTimeAsync(1_199)
       expect(writes).not.toContain('\r')

--- a/src/main/runtime/orchestration-structured-chat-lease.test.ts
+++ b/src/main/runtime/orchestration-structured-chat-lease.test.ts
@@ -322,6 +322,7 @@ describe('orchestration while Structured Chat owns an agent session', () => {
 
   it('stops a prompt when Structured Chat takes the lease between paste chunks', async () => {
     await establishOwner('tui', 'spawn-tui', 1)
+    runtime.onPtyData(WORKER.ptyId, '\x1b[?2004h\x1b[?1049h\x1b[1m›\x1b[0m', Date.now())
     let writesStarted = 0
 
     await expect(

--- a/src/main/runtime/rpc/methods/orchestration/worker/worker-start-prompt-contract.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration/worker/worker-start-prompt-contract.test.ts
@@ -83,6 +83,7 @@ async function createPromptContractHarness(
     }
   }, 'codex')
   const { runtime, handle } = fixture
+  runtime.onPtyData('pty-prompt', '\x1b[?2004h\x1b[?1049h\x1b[1m›\x1b[0m', Date.now())
   runtime.onPtyData('pty-prompt', '\x1b]0;Codex idle\x07', Date.now())
 
   const temporaryRoot = mkdtempSync(join(tmpdir(), 'orca-worker-prompt-contract-'))
@@ -284,6 +285,7 @@ describe('orchestration worker-start prompt contract', () => {
   it('does not attribute output from the old busy turn to a queued prompt', async () => {
     vi.useFakeTimers()
     const { runtime, handle } = await createAgentPromptSubmissionRuntime(() => undefined, 'codex')
+    runtime.onPtyData('pty-prompt', '\x1b[?2004h\x1b[?1049h\x1b[1m›\x1b[0m', Date.now())
     runtime.onPtyData('pty-prompt', '\x1b]0;Codex working\x07', Date.now())
     const pending = runtime.sendTerminalAgentPrompt(handle, 'queued prompt', {
       acceptQueued: true,

--- a/src/main/runtime/rpc/terminal-prompt-delivery-receipt.test.ts
+++ b/src/main/runtime/rpc/terminal-prompt-delivery-receipt.test.ts
@@ -49,6 +49,8 @@ function request(
   }
 }
 
+const CODEX_COMPOSER_READY_BYTES = '\x1b[?2004h\x1b[?1049h\x1b[1m›\x1b[0m'
+
 async function createHarness(agent: TuiAgent, busy = false) {
   const created = await createAgentPromptSubmissionRuntime(() => undefined, agent)
   created.runtime.setPtyController({
@@ -68,6 +70,9 @@ async function createHarness(agent: TuiAgent, busy = false) {
       `\x1b]9999;{"state":"working","agentType":"${agent}"}\x07`,
       Date.now()
     )
+  }
+  if (agent === 'codex') {
+    created.runtime.onPtyData('pty-prompt', CODEX_COMPOSER_READY_BYTES, Date.now())
   }
   return {
     ...created,

--- a/src/main/runtime/runtime-pty-draft-exited-cleanup-review.test.ts
+++ b/src/main/runtime/runtime-pty-draft-exited-cleanup-review.test.ts
@@ -1,0 +1,43 @@
+import { expect, it, vi } from 'vitest'
+import { waitForPtyDraftInputReady } from './runtime-pty-draft-input-ready'
+
+it('leaves no abort listener when exit subscription reports an already-exited PTY synchronously', async () => {
+  const controller = new AbortController()
+  const activeAbortListeners = new Set<unknown>()
+  const add = controller.signal.addEventListener.bind(controller.signal)
+  const remove = controller.signal.removeEventListener.bind(controller.signal)
+  vi.spyOn(controller.signal, 'addEventListener').mockImplementation((type, listener, options) => {
+    if (type === 'abort') {
+      activeAbortListeners.add(listener)
+    }
+    add(type, listener, options)
+  })
+  vi.spyOn(controller.signal, 'removeEventListener').mockImplementation(
+    (type, listener, options) => {
+      if (type === 'abort') {
+        activeAbortListeners.delete(listener)
+      }
+      remove(type, listener, options)
+    }
+  )
+  const unsubscribeData = vi.fn()
+  const unsubscribeExit = vi.fn()
+  await expect(
+    waitForPtyDraftInputReady(
+      {
+        subscribeToData: () => unsubscribeData,
+        subscribeToExit: (_id, listener) => {
+          listener()
+          return unsubscribeExit
+        },
+        readRecentOutput: () => undefined
+      },
+      'exited-pty',
+      'codex',
+      controller.signal
+    )
+  ).rejects.toThrow('terminal_exited')
+  expect.soft(unsubscribeData).toHaveBeenCalledOnce()
+  expect.soft(unsubscribeExit).toHaveBeenCalledOnce()
+  expect.soft(activeAbortListeners.size).toBe(0)
+})

--- a/src/main/runtime/runtime-pty-draft-input-ready.test.ts
+++ b/src/main/runtime/runtime-pty-draft-input-ready.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  waitForPtyDraftInputReady,
+  type PtyDraftInputReadyHost
+} from './runtime-pty-draft-input-ready'
+
+const CODEX_COMPOSER_READY_BYTES = '\x1b[?2004h\x1b[?1049h\x1b[1m›\x1b[0m'
+
+function createHost(initial?: string): PtyDraftInputReadyHost & {
+  emit: (data: string) => void
+  exit: () => void
+} {
+  const dataListeners = new Set<(data: string) => void>()
+  const exitListeners = new Set<() => void>()
+  let recent = initial
+  return {
+    subscribeToData(_ptyId, listener) {
+      dataListeners.add(listener)
+      return () => {
+        dataListeners.delete(listener)
+      }
+    },
+    readRecentOutput() {
+      return recent
+    },
+    subscribeToExit(_ptyId, listener) {
+      exitListeners.add(listener)
+      return () => {
+        exitListeners.delete(listener)
+      }
+    },
+    emit(data) {
+      recent = `${recent ?? ''}${data}`
+      for (const listener of dataListeners) {
+        listener(data)
+      }
+    },
+    exit() {
+      for (const listener of exitListeners) {
+        listener()
+      }
+    }
+  }
+}
+
+describe('waitForPtyDraftInputReady', () => {
+  it('resolves true from replayed Codex composer bytes', async () => {
+    const host = createHost(CODEX_COMPOSER_READY_BYTES)
+    await expect(waitForPtyDraftInputReady(host, 'pty-1', 'codex')).resolves.toBe(true)
+  })
+
+  it('resolves true when Codex composer bytes arrive after subscribe', async () => {
+    const host = createHost()
+    const wait = waitForPtyDraftInputReady(host, 'pty-1', 'codex')
+    host.emit('\x1b[?20')
+    host.emit(CODEX_COMPOSER_READY_BYTES.slice(5))
+    await expect(wait).resolves.toBe(true)
+  })
+
+  it('resolves false when the Codex hard timeout elapses', async () => {
+    vi.useFakeTimers()
+    try {
+      const host = createHost()
+      const wait = waitForPtyDraftInputReady(host, 'pty-1', 'codex')
+      await vi.advanceTimersByTimeAsync(20_000)
+      await expect(wait).resolves.toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('rejects when the PTY exits before composer readiness', async () => {
+    const host = createHost()
+    const wait = waitForPtyDraftInputReady(host, 'pty-1', 'codex')
+    host.exit()
+    await expect(wait).rejects.toThrow('terminal_exited')
+  })
+})

--- a/src/main/runtime/runtime-pty-draft-input-ready.test.ts
+++ b/src/main/runtime/runtime-pty-draft-input-ready.test.ts
@@ -9,6 +9,7 @@ const CODEX_COMPOSER_READY_BYTES = '\x1b[?2004h\x1b[?1049h\x1b[1m›\x1b[0m'
 function createHost(initial?: string): PtyDraftInputReadyHost & {
   emit: (data: string) => void
   exit: () => void
+  listenerCounts: () => { data: number; exit: number }
 } {
   const dataListeners = new Set<(data: string) => void>()
   const exitListeners = new Set<() => void>()
@@ -39,6 +40,9 @@ function createHost(initial?: string): PtyDraftInputReadyHost & {
       for (const listener of exitListeners) {
         listener()
       }
+    },
+    listenerCounts() {
+      return { data: dataListeners.size, exit: exitListeners.size }
     }
   }
 }
@@ -74,5 +78,45 @@ describe('waitForPtyDraftInputReady', () => {
     const wait = waitForPtyDraftInputReady(host, 'pty-1', 'codex')
     host.exit()
     await expect(wait).rejects.toThrow('terminal_exited')
+    expect(host.listenerCounts()).toEqual({ data: 0, exit: 0 })
+  })
+
+  it('rejects an already-aborted wait before replayed composer bytes', async () => {
+    const host = createHost(CODEX_COMPOSER_READY_BYTES)
+    const controller = new AbortController()
+    controller.abort()
+    await expect(
+      waitForPtyDraftInputReady(host, 'pty-1', 'codex', controller.signal)
+    ).rejects.toThrow('request_aborted')
+    expect(host.listenerCounts()).toEqual({ data: 0, exit: 0 })
+  })
+
+  it('rejects mid-wait abort and disposes listeners before later data or exit', async () => {
+    vi.useFakeTimers()
+    try {
+      const host = createHost()
+      const controller = new AbortController()
+      const wait = waitForPtyDraftInputReady(host, 'pty-1', 'codex', controller.signal)
+      await vi.advanceTimersByTimeAsync(10)
+      controller.abort()
+      await expect(wait).rejects.toThrow('request_aborted')
+      expect(host.listenerCounts()).toEqual({ data: 0, exit: 0 })
+      host.emit(CODEX_COMPOSER_READY_BYTES)
+      host.exit()
+      await vi.advanceTimersByTimeAsync(20_000)
+      expect(host.listenerCounts()).toEqual({ data: 0, exit: 0 })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('prefers request_aborted when abort races a PTY exit', async () => {
+    const host = createHost()
+    const controller = new AbortController()
+    const wait = waitForPtyDraftInputReady(host, 'pty-1', 'codex', controller.signal)
+    controller.abort()
+    host.exit()
+    await expect(wait).rejects.toThrow('request_aborted')
+    expect(host.listenerCounts()).toEqual({ data: 0, exit: 0 })
   })
 })

--- a/src/main/runtime/runtime-pty-draft-input-ready.ts
+++ b/src/main/runtime/runtime-pty-draft-input-ready.ts
@@ -26,6 +26,7 @@ export function waitForPtyDraftInputReady(
     let hardTimer: NodeJS.Timeout | null = null
     let unsubscribeData: (() => void) | null = null
     let unsubscribeExit: (() => void) | null = null
+    let listenersBound = false
 
     const onAbort = (): void => {
       fail(new Error('request_aborted'))
@@ -52,7 +53,9 @@ export function waitForPtyDraftInputReady(
         return
       }
       settled = true
-      cleanup()
+      if (listenersBound) {
+        cleanup()
+      }
       resolve(value)
     }
 
@@ -61,7 +64,9 @@ export function waitForPtyDraftInputReady(
         return
       }
       settled = true
-      cleanup()
+      if (listenersBound) {
+        cleanup()
+      }
       reject(error)
     }
 
@@ -103,7 +108,14 @@ export function waitForPtyDraftInputReady(
       }
       fail(new Error('terminal_exited'))
     })
-    signal?.addEventListener('abort', onAbort, { once: true })
+    if (!settled) {
+      signal?.addEventListener('abort', onAbort, { once: true })
+    }
+    listenersBound = true
+    if (settled) {
+      cleanup()
+      return
+    }
     if (abortIfRequested()) {
       return
     }

--- a/src/main/runtime/runtime-pty-draft-input-ready.ts
+++ b/src/main/runtime/runtime-pty-draft-input-ready.ts
@@ -14,7 +14,8 @@ export type PtyDraftInputReadyHost = {
 export function waitForPtyDraftInputReady(
   host: PtyDraftInputReadyHost,
   ptyId: string,
-  agent: TuiAgent
+  agent: TuiAgent,
+  signal?: AbortSignal
 ): Promise<boolean> {
   const readySignal =
     TUI_AGENT_CONFIG[agent].draftPasteReadySignal ?? 'render-quiet-after-bracketed-paste'
@@ -26,15 +27,24 @@ export function waitForPtyDraftInputReady(
     let unsubscribeData: (() => void) | null = null
     let unsubscribeExit: (() => void) | null = null
 
+    const onAbort = (): void => {
+      fail(new Error('request_aborted'))
+    }
+
     const cleanup = (): void => {
       if (quietTimer) {
         clearTimeout(quietTimer)
+        quietTimer = null
       }
       if (hardTimer) {
         clearTimeout(hardTimer)
+        hardTimer = null
       }
       unsubscribeData?.()
+      unsubscribeData = null
       unsubscribeExit?.()
+      unsubscribeExit = null
+      signal?.removeEventListener('abort', onAbort)
     }
 
     const finish = (value: boolean): void => {
@@ -55,7 +65,18 @@ export function waitForPtyDraftInputReady(
       reject(error)
     }
 
+    const abortIfRequested = (): boolean => {
+      if (!signal?.aborted) {
+        return false
+      }
+      onAbort()
+      return true
+    }
+
     const observeData = (data: string): void => {
+      if (abortIfRequested()) {
+        return
+      }
       const { ready, armQuietTimer } = scanner.observe(data)
       if (ready) {
         finish(true)
@@ -67,17 +88,36 @@ export function waitForPtyDraftInputReady(
       if (quietTimer) {
         clearTimeout(quietTimer)
       }
-      quietTimer = setTimeout(() => finish(true), BRACKETED_PASTE_QUIET_MS)
+      quietTimer = setTimeout(() => {
+        if (abortIfRequested()) {
+          return
+        }
+        finish(true)
+      }, BRACKETED_PASTE_QUIET_MS)
     }
 
     unsubscribeData = host.subscribeToData(ptyId, observeData)
-    unsubscribeExit = host.subscribeToExit(ptyId, () => fail(new Error('terminal_exited')))
+    unsubscribeExit = host.subscribeToExit(ptyId, () => {
+      if (abortIfRequested()) {
+        return
+      }
+      fail(new Error('terminal_exited'))
+    })
+    signal?.addEventListener('abort', onAbort, { once: true })
+    if (abortIfRequested()) {
+      return
+    }
     const replay = host.readRecentOutput(ptyId)
     if (replay) {
       observeData(replay)
     }
     if (!settled) {
-      hardTimer = setTimeout(() => finish(false), resolveDraftPasteReadyTimeoutMs(agent))
+      hardTimer = setTimeout(() => {
+        if (abortIfRequested()) {
+          return
+        }
+        finish(false)
+      }, resolveDraftPasteReadyTimeoutMs(agent))
     }
   })
 }

--- a/src/main/runtime/runtime-pty-draft-input-ready.ts
+++ b/src/main/runtime/runtime-pty-draft-input-ready.ts
@@ -1,0 +1,83 @@
+import { createDraftPasteReadyScanner } from '../../shared/draft-paste-ready-scanner'
+import { resolveDraftPasteReadyTimeoutMs } from '../../shared/draft-paste-ready-timeout'
+import { TUI_AGENT_CONFIG } from '../../shared/tui-agent-config'
+import type { TuiAgent } from '../../shared/tui-agent'
+
+const BRACKETED_PASTE_QUIET_MS = 1500
+
+export type PtyDraftInputReadyHost = {
+  subscribeToData: (ptyId: string, listener: (data: string) => void) => () => void
+  readRecentOutput: (ptyId: string) => string | undefined
+  subscribeToExit: (ptyId: string, listener: () => void) => () => void
+}
+
+export function waitForPtyDraftInputReady(
+  host: PtyDraftInputReadyHost,
+  ptyId: string,
+  agent: TuiAgent
+): Promise<boolean> {
+  const readySignal =
+    TUI_AGENT_CONFIG[agent].draftPasteReadySignal ?? 'render-quiet-after-bracketed-paste'
+  return new Promise<boolean>((resolve, reject) => {
+    let settled = false
+    const scanner = createDraftPasteReadyScanner(readySignal)
+    let quietTimer: NodeJS.Timeout | null = null
+    let hardTimer: NodeJS.Timeout | null = null
+    let unsubscribeData: (() => void) | null = null
+    let unsubscribeExit: (() => void) | null = null
+
+    const cleanup = (): void => {
+      if (quietTimer) {
+        clearTimeout(quietTimer)
+      }
+      if (hardTimer) {
+        clearTimeout(hardTimer)
+      }
+      unsubscribeData?.()
+      unsubscribeExit?.()
+    }
+
+    const finish = (value: boolean): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      cleanup()
+      resolve(value)
+    }
+
+    const fail = (error: unknown): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      cleanup()
+      reject(error)
+    }
+
+    const observeData = (data: string): void => {
+      const { ready, armQuietTimer } = scanner.observe(data)
+      if (ready) {
+        finish(true)
+        return
+      }
+      if (!armQuietTimer) {
+        return
+      }
+      if (quietTimer) {
+        clearTimeout(quietTimer)
+      }
+      quietTimer = setTimeout(() => finish(true), BRACKETED_PASTE_QUIET_MS)
+    }
+
+    unsubscribeData = host.subscribeToData(ptyId, observeData)
+    unsubscribeExit = host.subscribeToExit(ptyId, () => fail(new Error('terminal_exited')))
+    const replay = host.readRecentOutput(ptyId)
+    if (replay) {
+      observeData(replay)
+    }
+    if (!settled) {
+      hardTimer = setTimeout(() => finish(false), resolveDraftPasteReadyTimeoutMs(agent))
+    }
+  })
+}


### PR DESCRIPTION
## ELI5

Codex can turn on bracketed paste before its composer is actually ready. Orca now waits for that composer signal, then pastes. If the PTY dies while waiting, the send fails instead of writing into a dead session.

## What Changed

- Before writing a Codex prompt, wait for the composer-ready PTY signal (`?2004h`, alt-screen, bold `›`).
- Abort the wait immediately if the PTY exits; re-check generation and writability after the wait.
- Honor `options.signal` inside the composer wait on both prompt paths, and dispose data/exit listeners plus quiet/hard timers on abort (including pre-aborted, buffered-ready, and PTY-exit races). Aborted waits reject `request_aborted` instead of waiting out the 20s timeout as `agent_composer_not_ready`.
- Dispose subscriptions correctly even when subscribing to an already-exited PTY invokes the exit callback synchronously; no abort listener is registered after settlement.
- Call the existing `agentSessionPtyWriteGate.assertAdmitted` preflight on both `sendTerminalAgentPrompt` paths **before** the composer wait. Native/Structured Chat can own the pane with no composer; waiting first hid the typed ownership refusal as `agent_composer_not_ready`. Per-write `assertAdmitted` / `assertReadmitted` still run at write time.
- Existing post-paste Enter gating, cancellation, generation, and permission assertions stay.

## Why

#14575 waits for Codex to redraw after paste and before Enter. That protects submit timing, but an MCP-heavy startup can redraw before that point and erase an early paste entirely. Waiting for the strong composer signal before paste closes that earlier race without changing the remote wire contract.

## Linked Issue

Partially addresses #9976 (the Codex `input-missing` startup race; this PR does not implement the issue's broader delivery-state or first-turn deadline contract).

## Visual Proof

N/A — no visual redesign. Behavior is covered by deterministic PTY/runtime tests.

## Testing

Validation is tied to `c610ce71d5673bb1d2bfdabba52e1ef5d1b6838b`, based on main `8f78c28248fbfa4d55fb837ab6698ac77d4e35c5`.

- Independent final-SHA Vitest: 10 files passed, 1,335 tests passed / 1 skipped, including the complete `orca-runtime.test.ts` umbrella, all 12 delivery-receipt tests, Structured Chat refusal/lease-transfer cases, and composer readiness/cancellation/cleanup regressions.
- CLI/Node/Web direct typechecks with `--composite false`, all 13 changed-file lint/format checks, native dependency preflight, and diff whitespace checks passed.
- Full non-Docker suite on ancestor `3bf2a31f60`: 8,241 files passed / 14 failed / 61 skipped; 76,586 tests passed / 41 failed / 391 skipped, 836.47 seconds. All 27 known clean-main failure names match. Thirteen additional runtime failures led to the final pre-wait ownership check and explicitly scoped fixture inputs described below; all pass in the final-SHA run. One cross-version checkout import timed out and produced a subsequent lock-file exception. The unchanged checkout file passed all 10 tests in separate candidate and clean-main reruns with no unhandled error; the full-load failure was not reproduced.
- The final delta from the full-tested ancestor is one production file (the existing write-admission preflight before both composer waits) and four test files. The entire affected runtime umbrella and changed tests were rerun on the final SHA. A second full-suite run was not performed; this does not claim a fully green final-SHA full suite.
- Physical Codex TUI, Windows/WSL/SSH smoke tests and production build were not run. No rendered UI change.

**Existing-test Codex readiness seeds (declared):** these cases already launched `codex` and would now fail `agent_composer_not_ready` before their original assertions. Each was given `\x1b[?2004h\x1b[?1049h\x1b[1m›\x1b[0m` on `pty-prompt` / `pty-bg` / the Structured Chat worker PTY only; assertions were not weakened.

- `agent-prompt-submission-runtime.test.ts`: queued receipt with existing-turn output; hook-only oldest queued receipt; one lifecycle reservation.
- `agent-prompt-receipt-correlation.test.ts`: FIFO historical lifecycle edges.
- `worker-start-prompt-contract.test.ts`: Codex harness (accepted/swallowed worker-start) and the busy-turn queued send.
- `terminal-creation-and-readiness-part-07.spec.ts`: Codex branch of composer-frame settle-before-submit.
- `terminal-creation-and-readiness-part-08.spec.ts`: late Codex render marker / fresh quiescence, **and** the foreground-detected Codex settle case (`createTerminal` without `launchAgent`; `getForegroundProcess` returns `codex`). Original post-paste Enter-gating assertions stay.
- `orchestration-structured-chat-lease.test.ts`: **only** `stops a prompt when Structured Chat takes the lease between paste chunks`. That case starts as TUI, so preflight admits; Codex launch identity still waits for composer before the first paste chunk. The two native-owner refusal tests (`fails worker-start truthfully…`, `reports a real gate refusal…`) are **not** seeded — they must keep failing immediately with typed `agent_session_conflict` / zero bytes, not after a 20s composer wait.
- `rpc/terminal-prompt-delivery-receipt.test.ts`: file-local `createHarness(agent, busy)` seeds **only** when `agent === 'codex'`. Claude and aider harnesses stay unseeded. Every receipt/dedup/queue/draft assertion is unchanged. This is a fixture adaptation: the harness already launched Codex and replaced the write controller, but never emitted composer-ready bytes, so the new pre-paste wait starved paste/Enter and the original receipt assertions never ran.

`createAgentPromptSubmissionRuntime` itself is **not** auto-seeded, so the new wait-before-write, timeout/exit, abort-during-wait, and native-owner preflight tests still observe an empty write list.

Independent review cases in `orca-runtime-composer-cancellation-review.test.ts` were copied with unused-import/format cleanup only; both `it.each` abort assertions (`failure` defined quickly, `writes === []`, still `request_aborted` after 20s) are unchanged.

## Review

Cursor exact-SHA review PASS on `c610ce71d5`, followed by independent Codex source review and the final checks above. The two native-owner refusal tests remain unseeded and preserve their typed refusal and zero-byte assertions. The shared prompt fixture remains unseeded, preserving readiness timeout, exit and cancellation coverage. Existing permission, generation, Enter-gating, receipt and replay assertions remain.

## Compatibility and Security

Send-path only; `waitForWorktreeStartupDraft` is unchanged. Non-Codex agents skip the wait. Remote/SSH PTYs use the same composer signal. No new RPC method or stream opcode.

## AI Disclosure

Cursor ported and reviewed the rebase onto `8f78c28`. Codex independently reviewed the candidate, supplied cancellation/cleanup regression cases, and ran final checks.
