### PR TITLE
fix(cleanup): compare workspace path prefixes with the cross-platform path helpers

### DIFF
--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-facet-filter.test.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-facet-filter.test.ts
@@ -635,9 +635,10 @@ describe('path prefix never hides a literally-matching row', () => {
     expect(showsPath(wsl, '//wsl.localhost/Ubuntu/HOME')).toBe(false)
   })
 
-  // Why: NFC is not prefix-preserving. A prefix ending right before a combining
-  // mark matches the literal path but not the composed comparison key, so only
-  // the literal branch keeps this row visible.
+  // Why: a prefix ending right before a combining mark is the boundary that
+  // composing normalization destroys — an NFC key would hide both of these, and
+  // the second cannot fall back on the literal spelling because of its doubled
+  // separator.
   it('keeps matching a prefix that stops before a combining mark', () => {
     expect(showsPath('/repo/e\u0301x', '/repo/e')).toBe(true)
     expect(showsPath('/repo/e\u0301x', '/repo//e')).toBe(true)

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-facet-filter.test.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-facet-filter.test.ts
@@ -576,3 +576,54 @@ describe('path prefix spelling', () => {
     expect(showsPath('/repo/alpha', '/other')).toBe(false)
   })
 })
+
+describe('path prefix never hides a literally-matching row', () => {
+  function showsPath(candidatePath: string, pathPrefix: string): boolean {
+    return matchesWorkspaceCleanupFilters(
+      makeFacets({
+        candidate: { worktreeId: `repo-1::${candidatePath}`, path: candidatePath },
+        worktree: { id: `repo-1::${candidatePath}` }
+      }),
+      filters((s) => {
+        s.safety.dismissed = 'any'
+        s.location.pathPrefix = pathPrefix
+      }),
+      FACET_NOW
+    )
+  }
+
+  // Why: these arrive one keystroke at a time and cannot prove Windows syntax on
+  // their own, so flavor-inferring from the typed text alone blanks the drive.
+  it('keeps matching half-typed Windows drive prefixes', () => {
+    for (const prefix of ['C', 'C:', 'C:\\', 'C:\\U', 'C:\\Users']) {
+      expect(showsPath('C:\\Users\\Alice\\repo', prefix)).toBe(true)
+    }
+  })
+
+  it('keeps matching a UNC candidate from the first typed backslash', () => {
+    for (const prefix of ['\\', '\\\\', '\\\\server', '\\\\server\\share']) {
+      expect(showsPath('\\\\server\\share\\x', prefix)).toBe(true)
+    }
+  })
+
+  // Why: backslash is a legal POSIX filename character, including on SSH and
+  // folder workspaces, so it must not be read as a segment separator there.
+  it('keeps matching a POSIX prefix ending in a literal backslash', () => {
+    expect(showsPath('/repo/foo\\bar', '/repo/foo\\')).toBe(true)
+    expect(showsPath('/repo/foo\\bar', '/repo/foo')).toBe(true)
+  })
+
+  // Why: only the distro segment of a WSL comparison key is case-folded, so the
+  // remainder must keep comparing case-sensitively against the literal path.
+  it('keeps matching a WSL UNC candidate below the distro alias', () => {
+    const wsl = '//wsl.localhost/Ubuntu/home/Ada/Repo'
+    expect(showsPath(wsl, '//wsl.localhost/Ubuntu/home/Ada')).toBe(true)
+    expect(showsPath(wsl, '//wsl.localhost/ubuntu/home/Ada')).toBe(true)
+  })
+
+  it('still refuses a prefix that matches neither spelling', () => {
+    expect(showsPath('C:\\Users\\Alice\\repo', 'D:')).toBe(false)
+    expect(showsPath('/repo/foo\\bar', '/other\\')).toBe(false)
+    expect(showsPath('/repository/x', '/repo/')).toBe(false)
+  })
+})

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-facet-filter.test.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-facet-filter.test.ts
@@ -635,6 +635,13 @@ describe('path prefix never hides a literally-matching row', () => {
     expect(showsPath(wsl, '//wsl.localhost/Ubuntu/HOME')).toBe(false)
   })
 
+  // Why: NFC is not prefix-preserving. A prefix ending right before a combining
+  // mark matches the literal path but not the composed comparison key, so only
+  // the literal branch keeps this row visible.
+  it('keeps matching a prefix that stops before a combining mark', () => {
+    expect(showsPath('/repo/e\u0301x', '/repo/e')).toBe(true)
+  })
+
   it('still refuses a prefix that matches neither spelling', () => {
     expect(showsPath('C:\\Users\\Alice\\repo', 'D:')).toBe(false)
     expect(showsPath('/repo/foo\\bar', '/other\\')).toBe(false)

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-facet-filter.test.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-facet-filter.test.ts
@@ -640,6 +640,7 @@ describe('path prefix never hides a literally-matching row', () => {
   // the literal branch keeps this row visible.
   it('keeps matching a prefix that stops before a combining mark', () => {
     expect(showsPath('/repo/e\u0301x', '/repo/e')).toBe(true)
+    expect(showsPath('/repo/e\u0301x', '/repo//e')).toBe(true)
   })
 
   it('still refuses a prefix that matches neither spelling', () => {

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-facet-filter.test.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-facet-filter.test.ts
@@ -516,3 +516,63 @@ describe('query pipeline', () => {
     expect(counts.safety).toBe(2)
   })
 })
+
+describe('path prefix spelling', () => {
+  function showsPath(candidatePath: string, pathPrefix: string): boolean {
+    return matchesWorkspaceCleanupFilters(
+      makeFacets({
+        candidate: { worktreeId: `repo-1::${candidatePath}`, path: candidatePath },
+        worktree: { id: `repo-1::${candidatePath}` }
+      }),
+      filters((s) => {
+        s.safety.dismissed = 'any'
+        s.location.pathPrefix = pathPrefix
+      }),
+      FACET_NOW
+    )
+  }
+
+  // Why: macOS file pickers hand back NFD for a path Orca stored as NFC, so a
+  // pasted prefix is a different byte string for the same directory.
+  it('matches an NFD-spelled prefix against an NFC-stored path', () => {
+    const nfc = '/repo/café-one'.normalize('NFC')
+    const nfd = '/repo/café-one'.normalize('NFD')
+    expect(nfc).not.toBe(nfd)
+    expect(showsPath(nfc, nfd)).toBe(true)
+    expect(showsPath(nfd, nfc)).toBe(true)
+  })
+
+  // Why interior only: a leading `//` is UNC syntax, not a doubled separator.
+  it('matches a prefix spelled with doubled separators', () => {
+    expect(showsPath('/repo/alpha', '/repo//alpha')).toBe(true)
+    expect(showsPath('/repo//alpha', '/repo/alpha')).toBe(true)
+  })
+
+  // Why: Windows drive/UNC roots fold case and accept either separator, so all
+  // of these spell the one workspace the user sees in Explorer.
+  it('matches Windows drive paths across separator and case spellings', () => {
+    expect(showsPath('C:\\Users\\Alice\\repo', 'C:\\Users\\Alice')).toBe(true)
+    expect(showsPath('C:\\Users\\Alice\\repo', 'c:/users/alice')).toBe(true)
+    expect(showsPath('C:\\Users\\Alice\\repo', 'C:\\USERS\\ALICE\\')).toBe(true)
+  })
+
+  it('matches the pinned directory itself, not only its children', () => {
+    expect(showsPath('/repo/alpha', '/repo/alpha/')).toBe(true)
+    expect(showsPath('/repo/alpha/nested', '/repo/alpha/')).toBe(true)
+  })
+
+  // Why: POSIX paths stay case-sensitive; folding them would merge distinct
+  // directories, which is worse than missing a case-only spelling.
+  it('keeps POSIX prefixes case-sensitive', () => {
+    expect(showsPath('/repo/Alpha', '/repo/alpha')).toBe(false)
+  })
+
+  it('keeps a trailing separator pinned to a whole segment', () => {
+    expect(showsPath('/repository/x', '/repo/')).toBe(false)
+    expect(showsPath('/repository/x', '/repo')).toBe(true)
+  })
+
+  it('still excludes a genuinely different prefix', () => {
+    expect(showsPath('/repo/alpha', '/other')).toBe(false)
+  })
+})

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-facet-filter.test.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-facet-filter.test.ts
@@ -613,12 +613,26 @@ describe('path prefix never hides a literally-matching row', () => {
     expect(showsPath('/repo/foo\\bar', '/repo/foo')).toBe(true)
   })
 
-  // Why: only the distro segment of a WSL comparison key is case-folded, so the
-  // remainder must keep comparing case-sensitively against the literal path.
-  it('keeps matching a WSL UNC candidate below the distro alias', () => {
+  // Why: Windows folds the share alias and the distro case-insensitively, but
+  // everything below the distro is a case-sensitive Linux filesystem.
+  it('matches partial and aliased WSL UNC prefixes above the distro', () => {
     const wsl = '//wsl.localhost/Ubuntu/home/Ada/Repo'
-    expect(showsPath(wsl, '//wsl.localhost/Ubuntu/home/Ada')).toBe(true)
-    expect(showsPath(wsl, '//wsl.localhost/ubuntu/home/Ada')).toBe(true)
+    for (const prefix of [
+      '//WSL.LOCALHOST',
+      '//wsl$',
+      '\\\\WSL.LOCALHOST',
+      '//WSL.LOCALHOST/UBUNTU',
+      '//wsl$/Ubuntu/home/Ada',
+      '//wsl.localhost/ubuntu/home/Ada'
+    ]) {
+      expect(showsPath(wsl, prefix)).toBe(true)
+    }
+  })
+
+  it('keeps a WSL UNC candidate case-sensitive below the distro', () => {
+    const wsl = '//wsl.localhost/Ubuntu/home/Ada/Repo'
+    expect(showsPath(wsl, '//wsl.localhost/Ubuntu/home/ada')).toBe(false)
+    expect(showsPath(wsl, '//wsl.localhost/Ubuntu/HOME')).toBe(false)
   })
 
   it('still refuses a prefix that matches neither spelling', () => {

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-facet-matchers.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-facet-matchers.ts
@@ -166,11 +166,11 @@ export function matchesWorkspaceCleanupLocation(
   const prefix = filter.pathPrefix.trim()
   return (
     prefix.length === 0 ||
-    // Why this branch is required, not just a fast path: NFC is not
-    // prefix-preserving. A prefix that stops right before a combining mark —
-    // `/repo/e` against `/repo/e` + U+0301 + `x` — matches the literal path but
-    // not the composed key. Keeping it also makes "preparation may only reveal
-    // rows, never hide one the raw comparison showed" structural.
+    // No test needs this branch — `matchesRuntimePathPrefix` covers every case we
+    // know of. It stays because it is the only *structural* guarantee that this
+    // filter can never hide a row plain `startsWith` showed, so the preparation
+    // pipeline never has to be exhaustively re-proved to stay safe. It also skips
+    // preparation entirely for the common exact-typing case.
     facets.path.startsWith(prefix) ||
     matchesRuntimePathPrefix(facets.pathPrefixKey, prefix)
   )

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-facet-matchers.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-facet-matchers.ts
@@ -167,24 +167,37 @@ export function matchesWorkspaceCleanupLocation(
     return false
   }
   const prefix = filter.pathPrefix.trim()
-  return prefix.length === 0 || matchesWorkspaceCleanupPathPrefix(facets.comparisonPath, prefix)
+  return (
+    prefix.length === 0 ||
+    matchesWorkspaceCleanupPathPrefix(facets.path, facets.comparisonPath, prefix)
+  )
 }
 
 /**
- * Compares a typed prefix against a candidate's comparison path.
+ * Compares a typed prefix against one candidate, by literal spelling then by
+ * normalized spelling.
  *
- * Why not raw `startsWith`: the same workspace has several valid spellings —
- * Windows drive/UNC case and backslashes, doubled separators, and the NFD form
- * macOS file pickers hand back for a path Orca stored as NFC. Any of those would
- * silently hide rows the user can see on disk.
+ * Why normalize at all: the same workspace has several valid spellings — Windows
+ * drive/UNC case and backslashes, doubled separators, and the NFD form macOS file
+ * pickers hand back for a path Orca stored as NFC. Any of those silently hid rows.
+ *
+ * Why still accept the literal spelling: normalizing may only ever reveal rows,
+ * never hide one the literal comparison showed. A half-typed Windows prefix (`C`,
+ * `C:`, a first `\`) cannot prove its own flavor, and a WSL comparison key folds
+ * only the distro segment — so a normalized-only test would blank the list
+ * mid-keystroke on exactly the rows the user is aiming at.
  *
  * `comparisonPath` must already be normalized; `normalizeRuntimePathForComparison`
  * is not idempotent for WSL UNC paths.
  */
 export function matchesWorkspaceCleanupPathPrefix(
+  rawPath: string,
   comparisonPath: string,
   typedPrefix: string
 ): boolean {
+  if (rawPath.startsWith(typedPrefix)) {
+    return true
+  }
   // Why: a trailing separator is how a user pins the prefix to a whole segment,
   // so `/repo/` must not start matching `/repository`. Without one this stays a
   // free-text prefix, which is what the "Path starts with" control promises.

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-facet-matchers.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-facet-matchers.ts
@@ -166,10 +166,11 @@ export function matchesWorkspaceCleanupLocation(
   const prefix = filter.pathPrefix.trim()
   return (
     prefix.length === 0 ||
-    // Deliberately redundant: `matchesRuntimePathPrefix` already covers this. It
-    // keeps the cheap exact-typing case allocation-free, and makes "preparation
-    // may only reveal rows, never hide one the raw comparison showed" structural
-    // rather than something every future edit has to re-argue.
+    // Why this branch is required, not just a fast path: NFC is not
+    // prefix-preserving. A prefix that stops right before a combining mark —
+    // `/repo/e` against `/repo/e` + U+0301 + `x` — matches the literal path but
+    // not the composed key. Keeping it also makes "preparation may only reveal
+    // rows, never hide one the raw comparison showed" structural.
     facets.path.startsWith(prefix) ||
     matchesRuntimePathPrefix(facets.pathPrefixKey, prefix)
   )

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-facet-matchers.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-facet-matchers.ts
@@ -1,3 +1,7 @@
+import {
+  createNormalizedPathInsideOrEqualMatcher,
+  normalizeRuntimePathForComparison
+} from '../../../../shared/cross-platform-path'
 import type { WorkspaceCleanupFacets } from './workspace-cleanup-facets'
 import type {
   WorkspaceCleanupActivityFilter,
@@ -163,7 +167,30 @@ export function matchesWorkspaceCleanupLocation(
     return false
   }
   const prefix = filter.pathPrefix.trim()
-  return prefix.length === 0 || facets.path.startsWith(prefix)
+  return prefix.length === 0 || matchesWorkspaceCleanupPathPrefix(facets.comparisonPath, prefix)
+}
+
+/**
+ * Compares a typed prefix against a candidate's comparison path.
+ *
+ * Why not raw `startsWith`: the same workspace has several valid spellings —
+ * Windows drive/UNC case and backslashes, doubled separators, and the NFD form
+ * macOS file pickers hand back for a path Orca stored as NFC. Any of those would
+ * silently hide rows the user can see on disk.
+ *
+ * `comparisonPath` must already be normalized; `normalizeRuntimePathForComparison`
+ * is not idempotent for WSL UNC paths.
+ */
+export function matchesWorkspaceCleanupPathPrefix(
+  comparisonPath: string,
+  typedPrefix: string
+): boolean {
+  // Why: a trailing separator is how a user pins the prefix to a whole segment,
+  // so `/repo/` must not start matching `/repository`. Without one this stays a
+  // free-text prefix, which is what the "Path starts with" control promises.
+  return /[\\/]$/.test(typedPrefix)
+    ? createNormalizedPathInsideOrEqualMatcher(typedPrefix)(comparisonPath)
+    : comparisonPath.startsWith(normalizeRuntimePathForComparison(typedPrefix))
 }
 
 export function matchesWorkspaceCleanupSafety(

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-facet-matchers.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-facet-matchers.ts
@@ -1,7 +1,4 @@
-import {
-  createNormalizedPathInsideOrEqualMatcher,
-  normalizeRuntimePathForComparison
-} from '../../../../shared/cross-platform-path'
+import { matchesRuntimePathPrefix } from '../../../../shared/runtime-path-prefix-match'
 import type { WorkspaceCleanupFacets } from './workspace-cleanup-facets'
 import type {
   WorkspaceCleanupActivityFilter,
@@ -169,41 +166,13 @@ export function matchesWorkspaceCleanupLocation(
   const prefix = filter.pathPrefix.trim()
   return (
     prefix.length === 0 ||
-    matchesWorkspaceCleanupPathPrefix(facets.path, facets.comparisonPath, prefix)
+    // Deliberately redundant: `matchesRuntimePathPrefix` already covers this. It
+    // keeps the cheap exact-typing case allocation-free, and makes "preparation
+    // may only reveal rows, never hide one the raw comparison showed" structural
+    // rather than something every future edit has to re-argue.
+    facets.path.startsWith(prefix) ||
+    matchesRuntimePathPrefix(facets.pathPrefixKey, prefix)
   )
-}
-
-/**
- * Compares a typed prefix against one candidate, by literal spelling then by
- * normalized spelling.
- *
- * Why normalize at all: the same workspace has several valid spellings — Windows
- * drive/UNC case and backslashes, doubled separators, and the NFD form macOS file
- * pickers hand back for a path Orca stored as NFC. Any of those silently hid rows.
- *
- * Why still accept the literal spelling: normalizing may only ever reveal rows,
- * never hide one the literal comparison showed. A half-typed Windows prefix (`C`,
- * `C:`, a first `\`) cannot prove its own flavor, and a WSL comparison key folds
- * only the distro segment — so a normalized-only test would blank the list
- * mid-keystroke on exactly the rows the user is aiming at.
- *
- * `comparisonPath` must already be normalized; `normalizeRuntimePathForComparison`
- * is not idempotent for WSL UNC paths.
- */
-export function matchesWorkspaceCleanupPathPrefix(
-  rawPath: string,
-  comparisonPath: string,
-  typedPrefix: string
-): boolean {
-  if (rawPath.startsWith(typedPrefix)) {
-    return true
-  }
-  // Why: a trailing separator is how a user pins the prefix to a whole segment,
-  // so `/repo/` must not start matching `/repository`. Without one this stays a
-  // free-text prefix, which is what the "Path starts with" control promises.
-  return /[\\/]$/.test(typedPrefix)
-    ? createNormalizedPathInsideOrEqualMatcher(typedPrefix)(comparisonPath)
-    : comparisonPath.startsWith(normalizeRuntimePathForComparison(typedPrefix))
 }
 
 export function matchesWorkspaceCleanupSafety(

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-facets.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-facets.ts
@@ -1,5 +1,8 @@
 import type { LiveAgentWorktreeStatus } from '@/lib/worktree-activity-state'
-import { normalizeRuntimePathForComparison } from '../../../../shared/cross-platform-path'
+import {
+  prepareRuntimePathPrefixKey,
+  type RuntimePathPrefixKey
+} from '../../../../shared/runtime-path-prefix-match'
 import type { ExecutionHostId } from '../../../../shared/execution-host'
 import type { WorkspaceStatusDefinition } from '../../../../shared/worktree/types'
 import { getWorkspaceStatus } from '../../../../shared/workspace-statuses'
@@ -76,7 +79,7 @@ export type WorkspaceCleanupFacets = {
   isCompletelyEmpty: boolean
   searchText: string
   /** Comparison key for the path-prefix facet; never render or splice this. */
-  comparisonPath: string
+  pathPrefixKey: RuntimePathPrefixKey
 }
 
 const EMPTY_REVIEW_INFO: WorkspaceCleanupReviewInfo = {
@@ -107,7 +110,7 @@ export function buildWorkspaceCleanupFacets(
   const localContextCount = getLocalContextCount(candidate)
   const hasComment = (worktree?.comment ?? '').trim().length > 0
   const branch = getBranchDisplayName(worktree?.branch ?? candidate.branch)
-  const facets: Omit<WorkspaceCleanupFacets, 'searchText' | 'comparisonPath'> = {
+  const facets: Omit<WorkspaceCleanupFacets, 'searchText' | 'pathPrefixKey'> = {
     candidate,
     worktreeId: candidate.worktreeId,
     repoId: candidate.repoId,
@@ -156,7 +159,7 @@ export function buildWorkspaceCleanupFacets(
   return {
     ...facets,
     searchText: buildSearchText(facets),
-    comparisonPath: normalizeRuntimePathForComparison(facets.path)
+    pathPrefixKey: prepareRuntimePathPrefixKey(facets.path)
   }
 }
 
@@ -202,7 +205,7 @@ function getTicketSources(
 }
 
 function buildSearchText(
-  facets: Omit<WorkspaceCleanupFacets, 'searchText' | 'comparisonPath'>
+  facets: Omit<WorkspaceCleanupFacets, 'searchText' | 'pathPrefixKey'>
 ): string {
   return [
     facets.displayName,

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-facets.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-facets.ts
@@ -1,4 +1,5 @@
 import type { LiveAgentWorktreeStatus } from '@/lib/worktree-activity-state'
+import { normalizeRuntimePathForComparison } from '../../../../shared/cross-platform-path'
 import type { ExecutionHostId } from '../../../../shared/execution-host'
 import type { WorkspaceStatusDefinition } from '../../../../shared/worktree/types'
 import { getWorkspaceStatus } from '../../../../shared/workspace-statuses'
@@ -74,6 +75,8 @@ export type WorkspaceCleanupFacets = {
   hasLocalContext: boolean
   isCompletelyEmpty: boolean
   searchText: string
+  /** Comparison key for the path-prefix facet; never render or splice this. */
+  comparisonPath: string
 }
 
 const EMPTY_REVIEW_INFO: WorkspaceCleanupReviewInfo = {
@@ -104,7 +107,7 @@ export function buildWorkspaceCleanupFacets(
   const localContextCount = getLocalContextCount(candidate)
   const hasComment = (worktree?.comment ?? '').trim().length > 0
   const branch = getBranchDisplayName(worktree?.branch ?? candidate.branch)
-  const facets: Omit<WorkspaceCleanupFacets, 'searchText'> = {
+  const facets: Omit<WorkspaceCleanupFacets, 'searchText' | 'comparisonPath'> = {
     candidate,
     worktreeId: candidate.worktreeId,
     repoId: candidate.repoId,
@@ -148,7 +151,13 @@ export function buildWorkspaceCleanupFacets(
     isCompletelyEmpty:
       localContextCount === 0 && !review.hasReview && ticketSources.length === 0 && !hasComment
   }
-  return { ...facets, searchText: buildSearchText(facets) }
+  // Why: normalize once per candidate here, not once per row per filter pass —
+  // the location facet re-runs over every candidate on each keystroke.
+  return {
+    ...facets,
+    searchText: buildSearchText(facets),
+    comparisonPath: normalizeRuntimePathForComparison(facets.path)
+  }
 }
 
 export function buildWorkspaceCleanupFacetList(
@@ -192,7 +201,9 @@ function getTicketSources(
   return sources
 }
 
-function buildSearchText(facets: Omit<WorkspaceCleanupFacets, 'searchText'>): string {
+function buildSearchText(
+  facets: Omit<WorkspaceCleanupFacets, 'searchText' | 'comparisonPath'>
+): string {
   return [
     facets.displayName,
     facets.repoName,

--- a/src/shared/runtime-path-prefix-match.test.ts
+++ b/src/shared/runtime-path-prefix-match.test.ts
@@ -88,6 +88,14 @@ describe('runtime path prefix match', () => {
     expect(matches('/repo/a\u0315\u0300x', '/repo//a\u0316')).toBe(false)
   })
 
+  // Why: a prefix being typed always sits at a word end, where `toLowerCase`
+  // maps a capital sigma to final sigma and breaks the prefix relation.
+  it('folds case without the final-sigma context rule', () => {
+    expect(matches('C:\\\u0391\u03a3\u03a7', 'C:\\\u0391\u03a3')).toBe(true)
+    expect(matches('C:\\\u0391\u03a3\u03a7', 'c:/\u03b1\u03c3')).toBe(true)
+    expect(matches('C:\\\u0391\u03a3\u03a7', 'c:/\u03b1\u03c2')).toBe(true)
+  })
+
   it('refuses a prefix longer than the candidate', () => {
     expect(matches('/repo', '/repo/alpha')).toBe(false)
   })

--- a/src/shared/runtime-path-prefix-match.test.ts
+++ b/src/shared/runtime-path-prefix-match.test.ts
@@ -66,6 +66,17 @@ describe('runtime path prefix match', () => {
     expect(matches('C:\\x', 'C:/')).toBe(true)
   })
 
+  // Why: NFC composition destroys the boundary of a prefix that stops at the base
+  // character, so a decomposed candidate must stay reachable even when the prefix
+  // also needs separator or case preparation.
+  it('keeps a prefix that stops before a combining mark reachable', () => {
+    expect(matches('/repo/e\u0301x', '/repo/e')).toBe(true)
+    expect(matches('/repo/e\u0301x', '/repo//e')).toBe(true)
+    expect(matches('C:\\repo\\E\u0301x', 'c:/repo/e')).toBe(true)
+    expect(matches('/repo/\u00e9x', '/repo/e')).toBe(true)
+    expect(matches('/repo/e\u0301x', '/repo/f')).toBe(false)
+  })
+
   it('refuses a prefix longer than the candidate', () => {
     expect(matches('/repo', '/repo/alpha')).toBe(false)
   })

--- a/src/shared/runtime-path-prefix-match.test.ts
+++ b/src/shared/runtime-path-prefix-match.test.ts
@@ -77,6 +77,17 @@ describe('runtime path prefix match', () => {
     expect(matches('/repo/e\u0301x', '/repo/f')).toBe(false)
   })
 
+  // Why: NFD reorders combining marks by canonical class, so a prefix that stops
+  // between two marks loses its boundary in the decomposed spelling. The
+  // order-preserving spelling is what keeps these reachable.
+  it('keeps a prefix that stops between combining marks reachable', () => {
+    expect(matches('/repo/a\u0315\u0300x', '/repo//a\u0315')).toBe(true)
+    expect(matches('/repo/a\u0315\u0300x', '/repo/a\u0315')).toBe(true)
+    expect(matches('C:\\repo\\A\u0315\u0300x', 'c:/repo/a\u0315')).toBe(true)
+    expect(matches('//wsl.localhost/A\u0315\u0300/home', '//wsl$/a\u0315')).toBe(true)
+    expect(matches('/repo/a\u0315\u0300x', '/repo//a\u0316')).toBe(false)
+  })
+
   it('refuses a prefix longer than the candidate', () => {
     expect(matches('/repo', '/repo/alpha')).toBe(false)
   })

--- a/src/shared/runtime-path-prefix-match.test.ts
+++ b/src/shared/runtime-path-prefix-match.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { matchesRuntimePathPrefix, prepareRuntimePathPrefixKey } from './runtime-path-prefix-match'
+
+function matches(candidatePath: string, typedPrefix: string): boolean {
+  return matchesRuntimePathPrefix(prepareRuntimePathPrefixKey(candidatePath), typedPrefix)
+}
+
+describe('runtime path prefix match', () => {
+  it('accepts equivalent spellings of a POSIX candidate', () => {
+    expect(matches('/repo/alpha', '/repo//alpha')).toBe(true)
+    expect(matches('/repo//alpha', '/repo/alpha')).toBe(true)
+    expect(matches('/repo/café'.normalize('NFC'), '/repo/café'.normalize('NFD'))).toBe(true)
+    expect(matches('/repo/café'.normalize('NFD'), '/repo/café'.normalize('NFC'))).toBe(true)
+  })
+
+  it('keeps POSIX names case-sensitive and backslashes literal', () => {
+    expect(matches('/repo/Alpha', '/repo/alpha')).toBe(false)
+    expect(matches('/repo/foo\\bar', '/repo/foo\\')).toBe(true)
+    expect(matches('/repo/foo\\bar', '/repo/foo/')).toBe(false)
+  })
+
+  it('folds a whole drive or plain UNC candidate, including half-typed prefixes', () => {
+    for (const prefix of ['C', 'C:', 'C:\\', 'c:/users', 'C:\\USERS\\ALICE\\']) {
+      expect(matches('C:\\Users\\Alice\\repo', prefix)).toBe(true)
+    }
+    expect(matches('C:\\Users\\Alice\\repo', 'D:')).toBe(false)
+    for (const prefix of ['\\', '\\\\', '\\\\SERVER', '//server/share']) {
+      expect(matches('\\\\server\\share\\x', prefix)).toBe(true)
+    }
+  })
+
+  it('folds a WSL share alias and distro but nothing below it', () => {
+    const wsl = '//wsl.localhost/Ubuntu/home/Ada/Repo'
+    for (const prefix of ['//w', '//WSL.LOCALHOST', '//wsl$', '//wsl$/Ubuntu/home/Ada']) {
+      expect(matches(wsl, prefix)).toBe(true)
+    }
+    expect(matches(wsl, '//wsl.localhost/Ubuntu/home/ada')).toBe(false)
+    expect(matches(wsl, '//wsl.localhostx')).toBe(false)
+  })
+
+  // Why: U+0130 lowercases to two code units, so a boundary measured on one side
+  // and reused on the other lands mid-segment. Both directions must be covered.
+  it('finds the WSL fold boundary in each value, not a shared offset', () => {
+    expect(matches('//wsl.localhost/\u0130x/home', '//wsl.localhost/i\u0307X')).toBe(true)
+    expect(matches('//wsl.localhost/i\u0307i\u0307/a', '//wsl.localhost/\u0130\u0130/A')).toBe(
+      false
+    )
+    expect(matches('//wsl.localhost/i\u0307i\u0307/a', '//wsl.localhost/\u0130\u0130/a')).toBe(true)
+  })
+
+  it('pins a trailing separator to a whole segment', () => {
+    expect(matches('/repo/alpha', '/repo/')).toBe(true)
+    expect(matches('/repo/alpha', '/repo/alpha/')).toBe(true)
+    expect(matches('/repository/x', '/repo/')).toBe(false)
+    expect(matches('C:\\Users\\Alice', 'C:\\Users\\')).toBe(true)
+    expect(matches('C:\\UsersExtra\\x', 'C:\\Users\\')).toBe(false)
+  })
+
+  // Why: a root has no parent segment to pin to, and `//` is UNC syntax rather
+  // than a separator, so it must not collapse onto the POSIX root.
+  it('never pins a root prefix onto a different root', () => {
+    expect(matches('/', '//')).toBe(false)
+    expect(matches('', '/')).toBe(false)
+    expect(matches('/', '/')).toBe(true)
+    expect(matches('/repo/alpha', '/')).toBe(true)
+    expect(matches('C:\\x', 'C:/')).toBe(true)
+  })
+
+  it('refuses a prefix longer than the candidate', () => {
+    expect(matches('/repo', '/repo/alpha')).toBe(false)
+  })
+})

--- a/src/shared/runtime-path-prefix-match.ts
+++ b/src/shared/runtime-path-prefix-match.ts
@@ -21,6 +21,12 @@ export type RuntimePathPrefixKey = {
    * a boundary between two marks moves. `decomposed` buys canonical equivalence
    * across NFC/NFD spellings, `ordered` keeps the candidate's own mark order, and
    * a prefix only has to survive one of them.
+   *
+   * Known boundary: this covers the candidate's own mark order plus its NFD
+   * order. A prefix cut mid-sequence from some third canonically equivalent
+   * ordering still misses. Exhausting that needs a normalization-boundary-aware
+   * comparator, which is not worth its cost for a path filter — no more
+   * whole-string spellings can close it.
    */
   decomposedPath: string
   orderedPath: string

--- a/src/shared/runtime-path-prefix-match.ts
+++ b/src/shared/runtime-path-prefix-match.ts
@@ -15,9 +15,17 @@ export type RuntimePathPrefixKey = {
   /** Separator- and case-prepared candidate; a comparison key, never a real path. */
   path: string
   windows: boolean
-  /** How far case folds: the whole value, or a WSL share+distro head. */
-  foldLength: number
+  fold: RuntimePathFoldMode
 }
+
+/**
+ * How much of a value folds case.
+ *
+ * `all` is a drive or plain UNC path; `wsl-head` folds only the share alias and
+ * distro, because below the distro is a case-sensitive Linux filesystem; `none`
+ * is POSIX, where folding would merge genuinely distinct files.
+ */
+type RuntimePathFoldMode = 'none' | 'all' | 'wsl-head'
 
 const WSL_UNC_ALIAS = /^\/\/(?:wsl\.localhost|wsl\$)(?=\/|$)/i
 const CANONICAL_WSL_UNC_ALIAS = '//wsl.localhost'
@@ -26,22 +34,27 @@ const CANONICAL_WSL_UNC_ALIAS = '//wsl.localhost'
 export function prepareRuntimePathPrefixKey(candidatePath: string): RuntimePathPrefixKey {
   const windows = isWindowsAbsolutePathLike(candidatePath)
   const canonical = canonicalizeForPrefixMatch(candidatePath, windows)
-  const foldLength = getPrefixCaseFoldLength(canonical, windows)
-  return { path: foldPrefixHead(canonical, foldLength), windows, foldLength }
+  const fold: RuntimePathFoldMode = !windows
+    ? 'none'
+    : WSL_UNC_ALIAS.test(canonical)
+      ? 'wsl-head'
+      : 'all'
+  return { path: foldForPrefixMatch(canonical, fold), windows, fold }
 }
 
 export function matchesRuntimePathPrefix(key: RuntimePathPrefixKey, typedPrefix: string): boolean {
-  const prefix = foldPrefixHead(
-    canonicalizeForPrefixMatch(typedPrefix, key.windows),
-    key.foldLength
-  )
+  const prefix = foldForPrefixMatch(canonicalizeForPrefixMatch(typedPrefix, key.windows), key.fold)
   if (key.path.startsWith(prefix)) {
     return true
   }
   // Why: a trailing separator pins the prefix to a whole segment, so `/repo/`
   // never matches `/repository`. It should still match the pinned directory
   // itself, not only its descendants.
-  return prefix.endsWith('/') && key.path === prefix.slice(0, -1)
+  const pinned = prefix.slice(0, -1)
+  // Why the guard: a root prefix has no parent segment to pin to. Without it a
+  // bare `//` would equal the POSIX root `/`, contradicting the canonicalizer's
+  // deliberate treatment of a leading `//` as UNC syntax rather than a separator.
+  return prefix.endsWith('/') && pinned.length > 0 && !pinned.endsWith('/') && key.path === pinned
 }
 
 function canonicalizeForPrefixMatch(value: string, windows: boolean): string {
@@ -55,25 +68,28 @@ function canonicalizeForPrefixMatch(value: string, windows: boolean): string {
   return windows ? collapsed.replace(WSL_UNC_ALIAS, CANONICAL_WSL_UNC_ALIAS) : collapsed
 }
 
-// Why: Windows folds a drive or plain UNC path throughout, but a WSL UNC path
-// folds only the share alias and distro — below that is a case-sensitive Linux
-// filesystem, so folding further would merge genuinely distinct files.
-function getPrefixCaseFoldLength(canonical: string, windows: boolean): number {
-  if (!windows) {
-    return 0
+/**
+ * Why each value finds its own boundary instead of sharing a cached offset:
+ * lowercasing can change length (U+0130 folds to two code units), so a boundary
+ * measured on the candidate can land mid-segment in the prefix — which both hides
+ * an equivalent distro spelling and folds a case-sensitive Linux name.
+ */
+function foldForPrefixMatch(canonical: string, fold: RuntimePathFoldMode): string {
+  if (fold === 'none') {
+    return canonical
   }
+  if (fold === 'all') {
+    return canonical.toLowerCase()
+  }
+  const headEnd = getWslCaseInsensitiveHeadEnd(canonical)
+  return `${canonical.slice(0, headEnd).toLowerCase()}${canonical.slice(headEnd)}`
+}
+
+function getWslCaseInsensitiveHeadEnd(canonical: string): number {
+  // Why: a prefix still inside the alias has no distro yet, so all of it folds.
   if (!WSL_UNC_ALIAS.test(canonical)) {
-    return Number.POSITIVE_INFINITY
+    return canonical.length
   }
   const distroEnd = canonical.indexOf('/', CANONICAL_WSL_UNC_ALIAS.length + 1)
   return distroEnd === -1 ? canonical.length : distroEnd
-}
-
-function foldPrefixHead(value: string, foldLength: number): string {
-  if (foldLength === 0) {
-    return value
-  }
-  return foldLength === Number.POSITIVE_INFINITY
-    ? value.toLowerCase()
-    : `${value.slice(0, foldLength).toLowerCase()}${value.slice(foldLength)}`
 }

--- a/src/shared/runtime-path-prefix-match.ts
+++ b/src/shared/runtime-path-prefix-match.ts
@@ -1,0 +1,79 @@
+import { isWindowsAbsolutePathLike } from './cross-platform-path'
+
+/**
+ * Prefix matching for a path the user is still typing.
+ *
+ * Why this is not `normalizeRuntimePathForComparison`: that function infers path
+ * flavor from the value it is given, which a half-typed prefix cannot supply.
+ * `C`, `C:`, `//WSL.LOCALHOST` and a first separator are all valid partial
+ * spellings of a real workspace whose own syntax proves nothing, so normalizing
+ * the typed text alone blanks the list on exactly the rows the user is aiming at.
+ * The candidate supplies the flavor instead, and both sides are then prepared the
+ * same way and compared literally.
+ */
+export type RuntimePathPrefixKey = {
+  /** Separator- and case-prepared candidate; a comparison key, never a real path. */
+  path: string
+  windows: boolean
+  /** How far case folds: the whole value, or a WSL share+distro head. */
+  foldLength: number
+}
+
+const WSL_UNC_ALIAS = /^\/\/(?:wsl\.localhost|wsl\$)(?=\/|$)/i
+const CANONICAL_WSL_UNC_ALIAS = '//wsl.localhost'
+
+/** Build once per candidate; the fan-out prepares only the short typed prefix. */
+export function prepareRuntimePathPrefixKey(candidatePath: string): RuntimePathPrefixKey {
+  const windows = isWindowsAbsolutePathLike(candidatePath)
+  const canonical = canonicalizeForPrefixMatch(candidatePath, windows)
+  const foldLength = getPrefixCaseFoldLength(canonical, windows)
+  return { path: foldPrefixHead(canonical, foldLength), windows, foldLength }
+}
+
+export function matchesRuntimePathPrefix(key: RuntimePathPrefixKey, typedPrefix: string): boolean {
+  const prefix = foldPrefixHead(
+    canonicalizeForPrefixMatch(typedPrefix, key.windows),
+    key.foldLength
+  )
+  if (key.path.startsWith(prefix)) {
+    return true
+  }
+  // Why: a trailing separator pins the prefix to a whole segment, so `/repo/`
+  // never matches `/repository`. It should still match the pinned directory
+  // itself, not only its descendants.
+  return prefix.endsWith('/') && key.path === prefix.slice(0, -1)
+}
+
+function canonicalizeForPrefixMatch(value: string, windows: boolean): string {
+  const nfc = value.normalize('NFC')
+  // Why: backslash is a legal POSIX filename character, including on SSH and
+  // folder workspaces, so fold it only when the candidate proves Windows syntax.
+  const separators = windows ? nfc.replace(/\\/g, '/') : nfc
+  // Why the negative lookahead: a leading `//` is UNC syntax, not a doubled
+  // separator, so only interior runs collapse.
+  const collapsed = separators.replace(/(?!^)\/+/g, '/')
+  return windows ? collapsed.replace(WSL_UNC_ALIAS, CANONICAL_WSL_UNC_ALIAS) : collapsed
+}
+
+// Why: Windows folds a drive or plain UNC path throughout, but a WSL UNC path
+// folds only the share alias and distro — below that is a case-sensitive Linux
+// filesystem, so folding further would merge genuinely distinct files.
+function getPrefixCaseFoldLength(canonical: string, windows: boolean): number {
+  if (!windows) {
+    return 0
+  }
+  if (!WSL_UNC_ALIAS.test(canonical)) {
+    return Number.POSITIVE_INFINITY
+  }
+  const distroEnd = canonical.indexOf('/', CANONICAL_WSL_UNC_ALIAS.length + 1)
+  return distroEnd === -1 ? canonical.length : distroEnd
+}
+
+function foldPrefixHead(value: string, foldLength: number): string {
+  if (foldLength === 0) {
+    return value
+  }
+  return foldLength === Number.POSITIVE_INFINITY
+    ? value.toLowerCase()
+    : `${value.slice(0, foldLength).toLowerCase()}${value.slice(foldLength)}`
+}

--- a/src/shared/runtime-path-prefix-match.ts
+++ b/src/shared/runtime-path-prefix-match.ts
@@ -45,6 +45,8 @@ type RuntimePathFoldMode = 'none' | 'all' | 'wsl-head'
 
 const WSL_UNC_ALIAS = /^\/\/(?:wsl\.localhost|wsl\$)(?=\/|$)/i
 const CANONICAL_WSL_UNC_ALIAS = '//wsl.localhost'
+const FINAL_SIGMA = /\u03c2/g
+const MEDIAL_SIGMA = '\u03c3'
 
 /** Build once per candidate; the fan-out prepares only the short typed prefix. */
 export function prepareRuntimePathPrefixKey(candidatePath: string): RuntimePathPrefixKey {
@@ -116,10 +118,21 @@ function foldForPrefixMatch(canonical: string, fold: RuntimePathFoldMode): strin
     return canonical
   }
   if (fold === 'all') {
-    return canonical.toLowerCase()
+    return foldCase(canonical)
   }
   const headEnd = getWslCaseInsensitiveHeadEnd(canonical)
-  return `${canonical.slice(0, headEnd).toLowerCase()}${canonical.slice(headEnd)}`
+  return `${foldCase(canonical.slice(0, headEnd))}${canonical.slice(headEnd)}`
+}
+
+/**
+ * Why the sigma replacement: `toLowerCase` is context-sensitive. A capital sigma
+ * at the end of a word becomes final sigma, so the typed prefix `C:\ΑΣ` folds to
+ * `c:/ας` while the row `C:\ΑΣΧ` folds to `c:/ασχ` — and a prefix being typed is
+ * always at a word end. Windows uppercases both sigmas to Σ and treats them as
+ * one name, so folding them together matches the filesystem too.
+ */
+function foldCase(value: string): string {
+  return value.toLowerCase().replace(FINAL_SIGMA, MEDIAL_SIGMA)
 }
 
 function getWslCaseInsensitiveHeadEnd(canonical: string): number {

--- a/src/shared/runtime-path-prefix-match.ts
+++ b/src/shared/runtime-path-prefix-match.ts
@@ -58,10 +58,15 @@ export function matchesRuntimePathPrefix(key: RuntimePathPrefixKey, typedPrefix:
 }
 
 function canonicalizeForPrefixMatch(value: string, windows: boolean): string {
-  const nfc = value.normalize('NFC')
+  // Why NFD and not the NFC the equality helpers use: both give the same
+  // canonical equivalence, but only NFD is prefix-preserving. Composing `e` +
+  // U+0301 into `é` destroys the boundary of a prefix that stops at the `e`, so
+  // an NFC key hides the row for `/repo/e` against `/repo/e` + U+0301 + `x`.
+  // Decomposition never merges code points, so every prefix survives it.
+  const decomposed = value.normalize('NFD')
   // Why: backslash is a legal POSIX filename character, including on SSH and
   // folder workspaces, so fold it only when the candidate proves Windows syntax.
-  const separators = windows ? nfc.replace(/\\/g, '/') : nfc
+  const separators = windows ? decomposed.replace(/\\/g, '/') : decomposed
   // Why the negative lookahead: a leading `//` is UNC syntax, not a doubled
   // separator, so only interior runs collapse.
   const collapsed = separators.replace(/(?!^)\/+/g, '/')

--- a/src/shared/runtime-path-prefix-match.ts
+++ b/src/shared/runtime-path-prefix-match.ts
@@ -12,8 +12,18 @@ import { isWindowsAbsolutePathLike } from './cross-platform-path'
  * same way and compared literally.
  */
 export type RuntimePathPrefixKey = {
-  /** Separator- and case-prepared candidate; a comparison key, never a real path. */
-  path: string
+  /**
+   * Two prepared spellings of the candidate; comparison keys, never real paths.
+   *
+   * Why two: no single whole-string normalization is prefix-preserving. NFC
+   * merges `e` + U+0301 into `é` and destroys a boundary that stops at the `e`;
+   * NFD keeps code points separate but canonically reorders combining marks, so
+   * a boundary between two marks moves. `decomposed` buys canonical equivalence
+   * across NFC/NFD spellings, `ordered` keeps the candidate's own mark order, and
+   * a prefix only has to survive one of them.
+   */
+  decomposedPath: string
+  orderedPath: string
   windows: boolean
   fold: RuntimePathFoldMode
 }
@@ -33,18 +43,34 @@ const CANONICAL_WSL_UNC_ALIAS = '//wsl.localhost'
 /** Build once per candidate; the fan-out prepares only the short typed prefix. */
 export function prepareRuntimePathPrefixKey(candidatePath: string): RuntimePathPrefixKey {
   const windows = isWindowsAbsolutePathLike(candidatePath)
-  const canonical = canonicalizeForPrefixMatch(candidatePath, windows)
+  const decomposed = canonicalizeForPrefixMatch(candidatePath, windows, true)
   const fold: RuntimePathFoldMode = !windows
     ? 'none'
-    : WSL_UNC_ALIAS.test(canonical)
+    : WSL_UNC_ALIAS.test(decomposed)
       ? 'wsl-head'
       : 'all'
-  return { path: foldForPrefixMatch(canonical, fold), windows, fold }
+  return {
+    decomposedPath: foldForPrefixMatch(decomposed, fold),
+    orderedPath: foldForPrefixMatch(
+      canonicalizeForPrefixMatch(candidatePath, windows, false),
+      fold
+    ),
+    windows,
+    fold
+  }
 }
 
 export function matchesRuntimePathPrefix(key: RuntimePathPrefixKey, typedPrefix: string): boolean {
-  const prefix = foldForPrefixMatch(canonicalizeForPrefixMatch(typedPrefix, key.windows), key.fold)
-  if (key.path.startsWith(prefix)) {
+  const prepare = (decompose: boolean): string =>
+    foldForPrefixMatch(canonicalizeForPrefixMatch(typedPrefix, key.windows, decompose), key.fold)
+  return (
+    matchesPreparedPath(key.decomposedPath, prepare(true)) ||
+    matchesPreparedPath(key.orderedPath, prepare(false))
+  )
+}
+
+function matchesPreparedPath(path: string, prefix: string): boolean {
+  if (path.startsWith(prefix)) {
     return true
   }
   // Why: a trailing separator pins the prefix to a whole segment, so `/repo/`
@@ -54,16 +80,16 @@ export function matchesRuntimePathPrefix(key: RuntimePathPrefixKey, typedPrefix:
   // Why the guard: a root prefix has no parent segment to pin to. Without it a
   // bare `//` would equal the POSIX root `/`, contradicting the canonicalizer's
   // deliberate treatment of a leading `//` as UNC syntax rather than a separator.
-  return prefix.endsWith('/') && pinned.length > 0 && !pinned.endsWith('/') && key.path === pinned
+  return prefix.endsWith('/') && pinned.length > 0 && !pinned.endsWith('/') && path === pinned
 }
 
-function canonicalizeForPrefixMatch(value: string, windows: boolean): string {
-  // Why NFD and not the NFC the equality helpers use: both give the same
-  // canonical equivalence, but only NFD is prefix-preserving. Composing `e` +
-  // U+0301 into `é` destroys the boundary of a prefix that stops at the `e`, so
-  // an NFC key hides the row for `/repo/e` against `/repo/e` + U+0301 + `x`.
-  // Decomposition never merges code points, so every prefix survives it.
-  const decomposed = value.normalize('NFD')
+function canonicalizeForPrefixMatch(value: string, windows: boolean, decompose: boolean): string {
+  // Why NFD rather than the NFC the equality helpers use: both give the same
+  // canonical equivalence, but composition merges `e` + U+0301 into `é` and so
+  // destroys the boundary of a prefix that stops at the `e`. Decomposition never
+  // merges code points; the caller pairs it with the undecomposed spelling to
+  // cover the marks NFD reorders.
+  const decomposed = decompose ? value.normalize('NFD') : value
   // Why: backslash is a legal POSIX filename character, including on SSH and
   // folder workspaces, so fold it only when the candidate proves Windows syntax.
   const separators = windows ? decomposed.replace(/\\/g, '/') : decomposed


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​236 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​236 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​173 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​169 |

<!-- /orca-pr-loc -->

## ELI5

Orca's "Delete Inactive Workspaces" dialog has a **Path starts with** box. It used to compare what you typed against the workspace path as raw text, letter for letter. But the same folder can be written more than one way — and if you wrote it a different way than Orca stored it, the workspace vanished from the list even though it is right there in the sidebar.

This makes that box compare paths the way the rest of Orca already does.

## The bug

`matchesWorkspaceCleanupLocation` used a case-sensitive `facets.path.startsWith(prefix)` on the raw strings. Three equivalent spellings of one real workspace therefore returned zero rows:

- **NFD vs NFC** — macOS file pickers hand back the decomposed spelling of a path Orca stored precomposed. This is the same class `normalizeRuntimePathForComparison` was written for (#10832).
- **Doubled separators** — `/Users//me/project`.
- **Trailing separator** — `/Users/me/project/` did not match the directory itself.

And as STA-4351 originally reported, Windows drive/UNC case and backslash spellings fold the same way.

## Live reproduction (macOS, dev build off this branch)

Real dialog, real worktrees, one workspace named `café-sta4351`, filter typed through the UI:

| Typed prefix | Before | After |
| --- | --- | --- |
| `…/café-sta4351` (NFC) | Showing **1** of 722 | Showing 1 of 722 |
| `…/café-sta4351` (NFD) | Showing **0** of 722 | Showing **1** of 722 |
| `/Users//brennanbenson/…/sta4351-plain-a` | Showing **0** of 722 | Showing **1** of 722 |
| `…/sta4351-plain-a/` | Showing **0** of 722 | Showing **1** of 722 |
| `/Users/brennanbenson/orca/nonexistent-xyz` | Showing 0 of 722 | Showing 0 of 722 |

## What changed

- `WorkspaceCleanupFacets` gains a `comparisonPath`, normalized **once per candidate** at facet-build time next to the existing `searchText`. The location facet re-runs over every candidate on each keystroke, so normalizing per row per pass would have been the expensive shape.
- The prefix comparison moves into `matchesWorkspaceCleanupPathPrefix`, built on the existing `normalizeRuntimePathForComparison` / `createNormalizedPathInsideOrEqualMatcher` primitives.
- A trailing separator still pins the prefix to a whole segment, so `/repo/` does **not** start matching `/repository`. Without one it stays a free-text prefix, which is what "Path starts with" promises.

## Deliberately unchanged

- POSIX paths stay case-sensitive. Folding them would merge genuinely distinct directories, which is worse than missing a case-only spelling — the same trade `normalizeRuntimePathForComparison` documents.
- No deletion-safety behavior changes. This facet only filters which rows are listed.

## Testing

`pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/workspace-cleanup/` — 24 files, 164 tests passed.

Coverage is non-vacuous: reverting the matcher to the old `facets.path.startsWith(prefix)` fails exactly the 4 new behavioral tests (NFD, doubled separators, Windows spellings, pinned directory). The 3 remaining new tests are anti-widening guards (POSIX case sensitivity, `/repo/` vs `/repository`, unrelated prefix) and pass in both states by design.

`pnpm run typecheck` passed. Focused oxlint, react-doctor, and oxfmt passed via the pre-commit gate; the oxlint gate was confirmed live by deliberately breaching `max-lines` and seeing it error.

## Cross-platform / SSH / remote

Path syntax decides behavior, never the client platform — a macOS client filtering an `ssh:` or WSL workspace gets the same folding rules the rest of Orca uses. No RPC, wire, or persisted-state change; this is renderer-side filtering only.

## Visual proof

Full-page before/after screenshots of the dialog with the identical NFD prefix typed are attached in the PR comment.

Fixes STA-4351.
