### PR TITLE
feat(appearance): make workspace split divider color configurable

### DIFF
--- a/src/main/codex-accounts/runtime-home-settings-test-fixtures.ts
+++ b/src/main/codex-accounts/runtime-home-settings-test-fixtures.ts
@@ -50,6 +50,8 @@ export function createSettings(overrides: TestSettingsOverrides = {}): GlobalSet
     terminalUseSeparateLightTheme: false,
     terminalThemeLight: 'orca-light',
     terminalDividerColorLight: '#ffffff',
+    tabGroupSplitDividerColorDark: '#71717a',
+    tabGroupSplitDividerColorLight: '#868690',
     terminalInactivePaneOpacity: 0.5,
     terminalActivePaneOpacity: 1,
     terminalPaneOpacityTransitionMs: 150,

--- a/src/main/codex-accounts/service-test-harness.ts
+++ b/src/main/codex-accounts/service-test-harness.ts
@@ -70,6 +70,8 @@ export function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalS
     terminalUseSeparateLightTheme: false,
     terminalThemeLight: 'orca-light',
     terminalDividerColorLight: '#ffffff',
+    tabGroupSplitDividerColorDark: '#71717a',
+    tabGroupSplitDividerColorLight: '#868690',
     terminalInactivePaneOpacity: 0.5,
     terminalActivePaneOpacity: 1,
     terminalPaneOpacityTransitionMs: 150,

--- a/src/renderer/src/app-shell/use-document-appearance.ts
+++ b/src/renderer/src/app-shell/use-document-appearance.ts
@@ -1,8 +1,18 @@
 import { useEffect } from 'react'
+import type { GlobalSettings } from '../../../shared/global-settings-types'
 import { buildAppFontFamily } from '@/lib/app-font-family'
-import { applyDocumentTheme } from '../lib/document-theme'
+import { applyDocumentTheme, resolveDocumentTheme } from '../lib/document-theme'
+import { applyTabGroupSplitDividerAppearance } from '../lib/tab-group-split-divider-appearance'
 import { scheduleRuntimeGraphSync } from '../runtime/sync-runtime-graph'
 import { useAppStore } from '../store'
+
+function applyWorkspaceSplitDivider(settings: GlobalSettings): void {
+  applyTabGroupSplitDividerAppearance(
+    document.documentElement,
+    settings,
+    resolveDocumentTheme(settings.theme)
+  )
+}
 
 /** Applies the settings-driven theme and app font to the document root. */
 export function useDocumentAppearance(): void {
@@ -15,16 +25,20 @@ export function useDocumentAppearance(): void {
 
     if (settings.theme === 'dark') {
       applyDocumentTheme('dark')
+      applyWorkspaceSplitDivider(settings)
       return undefined
     } else if (settings.theme === 'light') {
       applyDocumentTheme('light')
+      applyWorkspaceSplitDivider(settings)
       return undefined
     }
     // system
     const mq = window.matchMedia('(prefers-color-scheme: dark)')
     applyDocumentTheme('system')
+    applyWorkspaceSplitDivider(settings)
     const handler = (): void => {
       applyDocumentTheme('system')
+      applyWorkspaceSplitDivider(settings)
       // System theme changes don't mutate the store, so mobile terminal colors need an explicit graph republish.
       scheduleRuntimeGraphSync()
     }

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -241,9 +241,11 @@
   --markdown-search-match-active: #fb923c;
   /* Why: tab-group splits use a dedicated divider — `--border` is too faint on
      card/editor surfaces when panes are side-by-side or stacked. Default must
-     meet >=3:1 against `--card`, not only the hover/drag strong state. */
+     meet >=3:1 against `--card`, not only the hover/drag strong state.
+     Settings can override --tab-group-split-divider; hover/drag stays a
+     stronger mix of that color so a custom value still has a drag affordance. */
   --tab-group-split-divider: #868690;
-  --tab-group-split-divider-strong: #71717a;
+  --tab-group-split-divider-strong: color-mix(in srgb, var(--tab-group-split-divider) 82%, #000000);
 }
 
 /* ── Dark Mode ───────────────────────────────────────── */
@@ -353,7 +355,7 @@
   --markdown-search-match-active: #fb923c;
   /* Brighter than terminal defaults so the always-visible line clears 3:1 on `--card`. */
   --tab-group-split-divider: #71717a;
-  --tab-group-split-divider-strong: #a1a1aa;
+  --tab-group-split-divider-strong: color-mix(in srgb, var(--tab-group-split-divider) 70%, #ffffff);
 }
 
 .plugin-security-chrome {

--- a/src/renderer/src/components/settings/AppearancePane.test.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.test.tsx
@@ -495,6 +495,16 @@ describe('AppearancePane', () => {
     expect(container.textContent).not.toContain('Advanced')
   })
 
+  it('shows workspace split divider controls for a control-specific search', async () => {
+    mocks.state.settingsSearchQuery = 'tab group'
+    const container = await renderAppearancePane(getDefaultSettings('/tmp'))
+
+    expect(container.textContent).toContain('Workspace Split Divider (Dark)')
+    expect(container.textContent).toContain('Workspace Split Divider (Light)')
+    expect(container.textContent).not.toContain('Theme')
+    expect(container.textContent).not.toContain('Advanced')
+  })
+
   it('updates the workspace split divider color from Window & Sidebar', async () => {
     mocks.state.settingsSearchQuery = ''
     const updateSettings = vi.fn()

--- a/src/renderer/src/components/settings/AppearancePane.test.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.test.tsx
@@ -489,8 +489,33 @@ describe('AppearancePane', () => {
     const container = await renderAppearancePane(getDefaultSettings('/tmp'))
 
     expect(container.textContent).toContain('Left Sidebar Appearance')
+    expect(container.textContent).toContain('Workspace Split Divider (Dark)')
+    expect(container.textContent).toContain('Workspace Split Divider (Light)')
     expect(container.textContent).toContain('Status Bar')
     expect(container.textContent).not.toContain('Advanced')
+  })
+
+  it('updates the workspace split divider color from Window & Sidebar', async () => {
+    mocks.state.settingsSearchQuery = ''
+    const updateSettings = vi.fn()
+    const container = await renderAppearancePane(getDefaultSettings('/tmp'), updateSettings)
+    const colorInput = Array.from(container.querySelectorAll<HTMLInputElement>('input')).find(
+      (input) => input.type !== 'color' && input.value.toLowerCase() === '#71717a'
+    )
+
+    expect(container.textContent).toContain('Workspace Split Divider (Dark)')
+    expect(colorInput).toBeDefined()
+
+    await act(async () => {
+      if (!colorInput) {
+        throw new Error('expected a dark workspace split color input')
+      }
+      const assignValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+      assignValue?.call(colorInput, '#171717')
+      colorInput.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+
+    expect(updateSettings).toHaveBeenCalledWith({ tabGroupSplitDividerColorDark: '#171717' })
   })
 
   it('expands status bar controls for a section-label search', async () => {

--- a/src/renderer/src/components/settings/AppearancePane.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.tsx
@@ -23,6 +23,7 @@ import {
   getThemeEntries,
   getTitlebarEntries,
   getTypographyEntries,
+  getWorkspaceSplitDividerEntries,
   getZoomEntries
 } from './appearance-search'
 import { getTerminalAppearanceSearchEntries } from './terminal-search'
@@ -158,7 +159,8 @@ export function AppearancePane({
     ...getSidebarEntries(),
     ...getLayoutEntries(),
     getLeftSidebarAppearanceEntry(),
-    getWorkspaceCardLayoutEntry()
+    getWorkspaceCardLayoutEntry(),
+    ...getWorkspaceSplitDividerEntries()
   ]
 
   const interfaceMatches = matchesSettingsSearch(searchQuery, interfaceSearchEntries)

--- a/src/renderer/src/components/settings/AppearancePane.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.tsx
@@ -131,7 +131,7 @@ export function AppearancePane({
   )
   const windowSidebarSummary = translate(
     'auto.components.settings.AppearancePane.windowSidebarSummary',
-    'Sidebar, status bar, and file explorer'
+    'Sidebar, status bar, file explorer, and workspace split divider'
   )
 
   // Search-entry buckets per section so a query can force-open the matching one.

--- a/src/renderer/src/components/settings/AppearanceWindowSidebarSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceWindowSidebarSection.tsx
@@ -21,6 +21,7 @@ import {
 } from './appearance-search'
 import { USAGE_PERCENTAGE_DISPLAY_SETTING_ID } from './appearance-usage-percentage-search'
 import { LeftSidebarAppearanceSetting } from './LeftSidebarAppearanceSetting'
+import { AppearanceWorkspaceSplitDividerSettings } from './AppearanceWorkspaceSplitDividerSettings'
 import {
   getLeftSidebarAppearanceEntry,
   getShowPinnedWorktreesInGroupsEntry,
@@ -123,6 +124,12 @@ export function AppearanceWindowSidebarSection({
         >
           <LeftSidebarAppearanceSetting settings={settings} updateSettings={updateSettings} />
         </SearchableSetting>
+
+        <AppearanceWorkspaceSplitDividerSettings
+          settings={settings}
+          updateSettings={updateSettings}
+          forceVisiblePrimary={forceVisiblePrimary}
+        />
 
         <SearchableSetting
           title={statusBarTitle}

--- a/src/renderer/src/components/settings/AppearanceWorkspaceSplitDividerSettings.tsx
+++ b/src/renderer/src/components/settings/AppearanceWorkspaceSplitDividerSettings.tsx
@@ -4,9 +4,9 @@ import {
   DEFAULT_TAB_GROUP_SPLIT_DIVIDER_DARK,
   DEFAULT_TAB_GROUP_SPLIT_DIVIDER_LIGHT
 } from '../../../../shared/tab-group-split-divider'
-import { translate } from '@/i18n/i18n'
 import { ColorField } from './SettingsFormControls'
 import { SearchableSetting } from './SearchableSetting'
+import { getWorkspaceSplitDividerEntries } from './appearance-search'
 
 export function AppearanceWorkspaceSplitDividerSettings({
   settings,
@@ -17,49 +17,33 @@ export function AppearanceWorkspaceSplitDividerSettings({
   updateSettings: (updates: Partial<GlobalSettings>) => void
   forceVisiblePrimary?: boolean
 }): React.JSX.Element {
-  const darkTitle = translate(
-    'auto.components.settings.AppearanceWorkspaceSplitDividerSettings.darkTitle',
-    'Workspace Split Divider (Dark)'
-  )
-  const darkDescription = translate(
-    'auto.components.settings.AppearanceWorkspaceSplitDividerSettings.darkDescription',
-    'Color of the split line between workspace panes in dark mode. This is the column between a terminal tab and an editor, not the in-terminal split.'
-  )
-  const lightTitle = translate(
-    'auto.components.settings.AppearanceWorkspaceSplitDividerSettings.lightTitle',
-    'Workspace Split Divider (Light)'
-  )
-  const lightDescription = translate(
-    'auto.components.settings.AppearanceWorkspaceSplitDividerSettings.lightDescription',
-    'Color of the split line between workspace panes in light mode.'
-  )
-  const keywords = ['workspace', 'split', 'divider', 'pane', 'color', 'tab group']
+  const [darkEntry, lightEntry] = getWorkspaceSplitDividerEntries()
 
   return (
     <>
       <SearchableSetting
-        title={darkTitle}
-        description={darkDescription}
-        keywords={keywords}
+        title={darkEntry.title}
+        description={darkEntry.description}
+        keywords={darkEntry.keywords}
         forceVisible={forceVisiblePrimary}
       >
         <ColorField
-          label={darkTitle}
-          description={darkDescription}
+          label={darkEntry.title}
+          description={darkEntry.description ?? ''}
           value={settings.tabGroupSplitDividerColorDark}
           fallback={DEFAULT_TAB_GROUP_SPLIT_DIVIDER_DARK}
           onChange={(value) => updateSettings({ tabGroupSplitDividerColorDark: value })}
         />
       </SearchableSetting>
       <SearchableSetting
-        title={lightTitle}
-        description={lightDescription}
-        keywords={keywords}
+        title={lightEntry.title}
+        description={lightEntry.description}
+        keywords={lightEntry.keywords}
         forceVisible={forceVisiblePrimary}
       >
         <ColorField
-          label={lightTitle}
-          description={lightDescription}
+          label={lightEntry.title}
+          description={lightEntry.description ?? ''}
           value={settings.tabGroupSplitDividerColorLight}
           fallback={DEFAULT_TAB_GROUP_SPLIT_DIVIDER_LIGHT}
           onChange={(value) => updateSettings({ tabGroupSplitDividerColorLight: value })}

--- a/src/renderer/src/components/settings/AppearanceWorkspaceSplitDividerSettings.tsx
+++ b/src/renderer/src/components/settings/AppearanceWorkspaceSplitDividerSettings.tsx
@@ -1,0 +1,70 @@
+import type React from 'react'
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import {
+  DEFAULT_TAB_GROUP_SPLIT_DIVIDER_DARK,
+  DEFAULT_TAB_GROUP_SPLIT_DIVIDER_LIGHT
+} from '../../../../shared/tab-group-split-divider'
+import { translate } from '@/i18n/i18n'
+import { ColorField } from './SettingsFormControls'
+import { SearchableSetting } from './SearchableSetting'
+
+export function AppearanceWorkspaceSplitDividerSettings({
+  settings,
+  updateSettings,
+  forceVisiblePrimary = false
+}: {
+  settings: GlobalSettings
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+  forceVisiblePrimary?: boolean
+}): React.JSX.Element {
+  const darkTitle = translate(
+    'auto.components.settings.AppearanceWorkspaceSplitDividerSettings.darkTitle',
+    'Workspace Split Divider (Dark)'
+  )
+  const darkDescription = translate(
+    'auto.components.settings.AppearanceWorkspaceSplitDividerSettings.darkDescription',
+    'Color of the split line between workspace panes in dark mode. This is the column between a terminal tab and an editor, not the in-terminal split.'
+  )
+  const lightTitle = translate(
+    'auto.components.settings.AppearanceWorkspaceSplitDividerSettings.lightTitle',
+    'Workspace Split Divider (Light)'
+  )
+  const lightDescription = translate(
+    'auto.components.settings.AppearanceWorkspaceSplitDividerSettings.lightDescription',
+    'Color of the split line between workspace panes in light mode.'
+  )
+  const keywords = ['workspace', 'split', 'divider', 'pane', 'color', 'tab group']
+
+  return (
+    <>
+      <SearchableSetting
+        title={darkTitle}
+        description={darkDescription}
+        keywords={keywords}
+        forceVisible={forceVisiblePrimary}
+      >
+        <ColorField
+          label={darkTitle}
+          description={darkDescription}
+          value={settings.tabGroupSplitDividerColorDark}
+          fallback={DEFAULT_TAB_GROUP_SPLIT_DIVIDER_DARK}
+          onChange={(value) => updateSettings({ tabGroupSplitDividerColorDark: value })}
+        />
+      </SearchableSetting>
+      <SearchableSetting
+        title={lightTitle}
+        description={lightDescription}
+        keywords={keywords}
+        forceVisible={forceVisiblePrimary}
+      >
+        <ColorField
+          label={lightTitle}
+          description={lightDescription}
+          value={settings.tabGroupSplitDividerColorLight}
+          fallback={DEFAULT_TAB_GROUP_SPLIT_DIVIDER_LIGHT}
+          onChange={(value) => updateSettings({ tabGroupSplitDividerColorLight: value })}
+        />
+      </SearchableSetting>
+    </>
+  )
+}

--- a/src/renderer/src/components/settings/appearance-search.ts
+++ b/src/renderer/src/components/settings/appearance-search.ts
@@ -173,6 +173,58 @@ export const getStatusBarEntries = createLocalizedCatalog((): SettingsSearchEntr
 
 export { getLeftSidebarAppearanceEntry, getSidebarEntries }
 
+const workspaceSplitDividerKeywords = (): string[] => [
+  ...translateSearchKeyword(
+    'auto.components.settings.appearance.search.workspaceSplitDivider.workspace',
+    'workspace'
+  ),
+  ...translateSearchKeyword(
+    'auto.components.settings.appearance.search.workspaceSplitDivider.split',
+    'split'
+  ),
+  ...translateSearchKeyword(
+    'auto.components.settings.appearance.search.workspaceSplitDivider.divider',
+    'divider'
+  ),
+  ...translateSearchKeyword(
+    'auto.components.settings.appearance.search.workspaceSplitDivider.pane',
+    'pane'
+  ),
+  ...translateSearchKeyword(
+    'auto.components.settings.appearance.search.workspaceSplitDivider.color',
+    'color'
+  ),
+  ...translateSearchKeyword(
+    'auto.components.settings.appearance.search.workspaceSplitDivider.tabGroup',
+    'tab group'
+  )
+]
+
+export const getWorkspaceSplitDividerEntries = createLocalizedCatalog((): SettingsSearchEntry[] => [
+  {
+    title: translate(
+      'auto.components.settings.AppearanceWorkspaceSplitDividerSettings.darkTitle',
+      'Workspace Split Divider (Dark)'
+    ),
+    description: translate(
+      'auto.components.settings.AppearanceWorkspaceSplitDividerSettings.darkDescription',
+      'Color of the split line between workspace panes in dark mode. This is the column between a terminal tab and an editor, not the in-terminal split.'
+    ),
+    keywords: workspaceSplitDividerKeywords()
+  },
+  {
+    title: translate(
+      'auto.components.settings.AppearanceWorkspaceSplitDividerSettings.lightTitle',
+      'Workspace Split Divider (Light)'
+    ),
+    description: translate(
+      'auto.components.settings.AppearanceWorkspaceSplitDividerSettings.lightDescription',
+      'Color of the split line between workspace panes in light mode.'
+    ),
+    keywords: workspaceSplitDividerKeywords()
+  }
+])
+
 export const getAppIconEntries = createLocalizedCatalog((): SettingsSearchEntry[] => [
   {
     title: translate('auto.components.settings.appearance.search.2b313598c6', 'App Icon'),
@@ -240,6 +292,7 @@ function buildAppearancePaneSearchEntries(
     ...getTitlebarEntries(),
     ...getStatusBarEntries(),
     ...getSidebarEntries(),
+    ...getWorkspaceSplitDividerEntries(),
     ...getAppIconEntries(),
     ...getSystemTrayEntries(options),
     ...getMenuBarIconEntries(options)

--- a/src/renderer/src/components/settings/appearance-search.ts
+++ b/src/renderer/src/components/settings/appearance-search.ts
@@ -215,7 +215,7 @@ const getAppearanceSectionEntries = createLocalizedCatalog((): SettingsSearchEnt
     ),
     description: translate(
       'auto.components.settings.AppearancePane.windowSidebarSummary',
-      'Sidebar, status bar, and file explorer'
+      'Sidebar, status bar, file explorer, and workspace split divider'
     )
   }
 ])

--- a/src/renderer/src/components/settings/setting-labels.ts
+++ b/src/renderer/src/components/settings/setting-labels.ts
@@ -23,6 +23,8 @@ export const SETTING_LABELS: Partial<Record<keyof GlobalSettings, string>> = {
   terminalPaddingY: 'Padding Y',
   terminalDividerColorDark: 'Divider Color (Dark)',
   terminalDividerColorLight: 'Divider Color (Light)',
+  tabGroupSplitDividerColorDark: 'Workspace Split Divider (Dark)',
+  tabGroupSplitDividerColorLight: 'Workspace Split Divider (Light)',
   terminalInactivePaneOpacity: 'Inactive Pane Opacity',
   windowBackgroundBlur: 'Window Background Blur'
 }

--- a/src/renderer/src/components/settings/terminal-search.test.ts
+++ b/src/renderer/src/components/settings/terminal-search.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import { getTerminalPaneSearchEntries } from './terminal-search'
-import { getAppearancePaneSearchEntries, getSidebarEntries } from './appearance-search'
+import {
+  getAppearancePaneSearchEntries,
+  getSidebarEntries,
+  getWorkspaceSplitDividerEntries
+} from './appearance-search'
 import {
   getShowPinnedWorktreesInGroupsEntry,
   getWorkspaceCardLayoutEntry
@@ -232,6 +236,14 @@ describe('getTerminalPaneSearchEntries', () => {
       expect(matchesSettingsSearch(query, osc52)).toBe(true)
     }
   )
+
+  it('includes workspace split divider controls in the Appearance catalog', () => {
+    const [darkEntry, lightEntry] = getWorkspaceSplitDividerEntries()
+
+    expect(getAppearancePaneSearchEntries()).toContainEqual(darkEntry)
+    expect(getAppearancePaneSearchEntries()).toContainEqual(lightEntry)
+    expect(matchesSettingsSearch('tab group', getAppearancePaneSearchEntries())).toBe(true)
+  })
 
   it('includes pinned worktree duplicate display in sidebar and Appearance search', () => {
     const entry = getShowPinnedWorktreesInGroupsEntry()

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6251,7 +6251,7 @@
           "interfaceTitle": "Interface",
           "terminalTitle": "Terminal",
           "windowSidebarTitle": "Window & Sidebar",
-          "windowSidebarSummary": "Sidebar, status bar, and file explorer",
+          "windowSidebarSummary": "Sidebar, status bar, file explorer, and workspace split divider",
           "statusBarCount": "{{value0}} indicators visible.",
           "gitIgnoredGlossary": "Files matched by .gitignore.",
           "statusBarDescription": "Choose which indicators appear in the status bar.",
@@ -11232,6 +11232,12 @@
         },
         "shortcutDefinitionCatalog": {
           "missionControlConflict": "Blocked by Mission Control. Remap here or change it in System Settings."
+        },
+        "AppearanceWorkspaceSplitDividerSettings": {
+          "darkTitle": "Workspace Split Divider (Dark)",
+          "darkDescription": "Color of the split line between workspace panes in dark mode. This is the column between a terminal tab and an editor, not the in-terminal split.",
+          "lightTitle": "Workspace Split Divider (Light)",
+          "lightDescription": "Color of the split line between workspace panes in light mode."
         }
       },
       "right": {

--- a/src/renderer/src/lib/tab-group-split-divider-appearance.test.ts
+++ b/src/renderer/src/lib/tab-group-split-divider-appearance.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest'
+import { DEFAULT_TAB_GROUP_SPLIT_DIVIDER_DARK } from '../../../shared/tab-group-split-divider'
+import {
+  applyTabGroupSplitDividerAppearance,
+  resolveTabGroupSplitDividerAppearance
+} from './tab-group-split-divider-appearance'
+
+describe('tab-group split divider appearance', () => {
+  it('uses the dark workspace setting when the document is dark', () => {
+    expect(
+      resolveTabGroupSplitDividerAppearance(
+        {
+          tabGroupSplitDividerColorDark: '#171717',
+          tabGroupSplitDividerColorLight: '#cccccc'
+        },
+        true
+      )
+    ).toBe('#171717')
+  })
+
+  it('uses the light workspace setting when the document is light', () => {
+    expect(
+      resolveTabGroupSplitDividerAppearance(
+        {
+          tabGroupSplitDividerColorDark: '#171717',
+          tabGroupSplitDividerColorLight: '#cccccc'
+        },
+        false
+      )
+    ).toBe('#cccccc')
+  })
+
+  it('writes the resolved color onto the document token', () => {
+    const setProperty = vi.fn()
+    applyTabGroupSplitDividerAppearance(
+      { style: { setProperty } },
+      {
+        tabGroupSplitDividerColorDark: '#171717',
+        tabGroupSplitDividerColorLight: '#cccccc'
+      },
+      true
+    )
+    expect(setProperty).toHaveBeenCalledWith('--tab-group-split-divider', '#171717')
+  })
+
+  it('falls back to the shipped dark token when settings are missing', () => {
+    expect(resolveTabGroupSplitDividerAppearance(null, true)).toBe(
+      DEFAULT_TAB_GROUP_SPLIT_DIVIDER_DARK
+    )
+  })
+})

--- a/src/renderer/src/lib/tab-group-split-divider-appearance.ts
+++ b/src/renderer/src/lib/tab-group-split-divider-appearance.ts
@@ -1,0 +1,32 @@
+import type { GlobalSettings } from '../../../shared/global-settings-types'
+import {
+  DEFAULT_TAB_GROUP_SPLIT_DIVIDER_DARK,
+  DEFAULT_TAB_GROUP_SPLIT_DIVIDER_LIGHT,
+  resolveTabGroupSplitDividerColor
+} from '../../../shared/tab-group-split-divider'
+
+type TabGroupSplitDividerSettings = Pick<
+  GlobalSettings,
+  'tabGroupSplitDividerColorDark' | 'tabGroupSplitDividerColorLight'
+>
+
+export function resolveTabGroupSplitDividerAppearance(
+  settings: TabGroupSplitDividerSettings | null | undefined,
+  isDark: boolean
+): string {
+  return resolveTabGroupSplitDividerColor(
+    isDark ? settings?.tabGroupSplitDividerColorDark : settings?.tabGroupSplitDividerColorLight,
+    isDark ? DEFAULT_TAB_GROUP_SPLIT_DIVIDER_DARK : DEFAULT_TAB_GROUP_SPLIT_DIVIDER_LIGHT
+  )
+}
+
+export function applyTabGroupSplitDividerAppearance(
+  root: { style: { setProperty: (name: string, value: string) => void } },
+  settings: TabGroupSplitDividerSettings | null | undefined,
+  isDark: boolean
+): void {
+  root.style.setProperty(
+    '--tab-group-split-divider',
+    resolveTabGroupSplitDividerAppearance(settings, isDark)
+  )
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -31,6 +31,10 @@ import { DEFAULT_SETUP_AGENT_STARTUP_POLICY } from './setup-agent-startup-policy
 import { DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT } from './terminal-scrollback-policy'
 import { DEFAULT_USAGE_PERCENTAGE_DISPLAY } from './usage-percentage-display'
 import { DEFAULT_STATUS_BAR_USAGE_MODE } from './status-bar-usage-mode'
+import {
+  DEFAULT_TAB_GROUP_SPLIT_DIVIDER_DARK,
+  DEFAULT_TAB_GROUP_SPLIT_DIVIDER_LIGHT
+} from './tab-group-split-divider'
 
 export { DEFAULT_STATUS_BAR_ITEMS } from './status-bar-defaults'
 export {
@@ -222,6 +226,8 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     terminalThemeLight: 'Builtin Tango Light',
     terminalCustomThemes: [],
     terminalDividerColorLight: '#d4d4d8',
+    tabGroupSplitDividerColorDark: DEFAULT_TAB_GROUP_SPLIT_DIVIDER_DARK,
+    tabGroupSplitDividerColorLight: DEFAULT_TAB_GROUP_SPLIT_DIVIDER_LIGHT,
     terminalInactivePaneOpacity: DEFAULT_TERMINAL_INACTIVE_PANE_OPACITY,
     terminalActivePaneOpacity: 1,
     terminalPaneOpacityTransitionMs: 140,

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -136,6 +136,9 @@ export type GlobalSettings = {
   terminalUseSeparateLightTheme: boolean
   terminalThemeLight: string
   terminalDividerColorLight: string
+  /** Workspace tab-group split (terminal | editor), not the in-terminal pane divider. */
+  tabGroupSplitDividerColorDark: string
+  tabGroupSplitDividerColorLight: string
   terminalInactivePaneOpacity: number
   terminalActivePaneOpacity: number
   terminalPaneOpacityTransitionMs: number

--- a/src/shared/tab-group-split-divider.test.ts
+++ b/src/shared/tab-group-split-divider.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_TAB_GROUP_SPLIT_DIVIDER_DARK,
+  resolveTabGroupSplitDividerColor
+} from './tab-group-split-divider'
+
+describe('resolveTabGroupSplitDividerColor', () => {
+  it('keeps a valid hash color', () => {
+    expect(resolveTabGroupSplitDividerColor('#171717', DEFAULT_TAB_GROUP_SPLIT_DIVIDER_DARK)).toBe(
+      '#171717'
+    )
+  })
+
+  it('prefixes a valid hashless hex color', () => {
+    expect(resolveTabGroupSplitDividerColor('171717', DEFAULT_TAB_GROUP_SPLIT_DIVIDER_DARK)).toBe(
+      '#171717'
+    )
+  })
+
+  it('falls back for empty or invalid values', () => {
+    expect(resolveTabGroupSplitDividerColor(undefined, DEFAULT_TAB_GROUP_SPLIT_DIVIDER_DARK)).toBe(
+      DEFAULT_TAB_GROUP_SPLIT_DIVIDER_DARK
+    )
+    expect(resolveTabGroupSplitDividerColor('  ', DEFAULT_TAB_GROUP_SPLIT_DIVIDER_DARK)).toBe(
+      DEFAULT_TAB_GROUP_SPLIT_DIVIDER_DARK
+    )
+    expect(
+      resolveTabGroupSplitDividerColor('not-a-color', DEFAULT_TAB_GROUP_SPLIT_DIVIDER_DARK)
+    ).toBe(DEFAULT_TAB_GROUP_SPLIT_DIVIDER_DARK)
+  })
+})

--- a/src/shared/tab-group-split-divider.ts
+++ b/src/shared/tab-group-split-divider.ts
@@ -1,0 +1,17 @@
+import { HEX_COLOR_RE } from './color-validation'
+
+/** Current dark workspace split token. Keep this the default so existing layouts do not shift. */
+export const DEFAULT_TAB_GROUP_SPLIT_DIVIDER_DARK = '#71717a'
+/** Current light workspace split token. */
+export const DEFAULT_TAB_GROUP_SPLIT_DIVIDER_LIGHT = '#868690'
+
+export function resolveTabGroupSplitDividerColor(
+  value: string | undefined,
+  fallback: string
+): string {
+  const trimmed = value?.trim()
+  if (!trimmed || !HEX_COLOR_RE.test(trimmed)) {
+    return fallback
+  }
+  return trimmed.startsWith('#') ? trimmed : `#${trimmed}`
+}


### PR DESCRIPTION
## ELI5

The gray column between a terminal tab and an editor/browser tab now has its own color pickers. Changing **Dark Divider Color** still only affects splits *inside* a terminal tab, which is what that setting always did.

## What Changed

Settings → Appearance → **Window & Sidebar** now has **Workspace Split Divider (Dark)** and **Workspace Split Divider (Light)**. They write `tabGroupSplitDividerColorDark` / `Light` onto `--tab-group-split-divider`. Hover/drag uses a stronger mix of that same color.

The existing terminal divider pickers are unchanged. New keys default to today's tokens (`#71717a` dark, `#868690` light), so people who never customized a divider keep the current workspace line.

## Why

**Dark Divider Color** says it “controls the split divider line between panes,” but it only paints `.pane-divider` inside a terminal tab. The line people actually look at — `.tab-group-split-resize-handle` between workspace panes — was hardcoded. Reusing the terminal color would silently restyle every uncustomized workspace split (`#71717a` → `#3f3f46`). A sibling pair under Window & Sidebar keeps the two surfaces independent.

## Linked Issue

Fixes #14887

## Visual Proof

**Before:** Dark Divider Color saved as `#171717`. Split Terminal Right went near-black. The workspace column between a Claude/Grok terminal and a markdown editor stayed zinc (`#71717a`, sampled ~`#76777c`).

**After:** Window & Sidebar exposes two workspace pickers. Changing the dark picker to `#171717` persists `tabGroupSplitDividerColorDark` and sets `--tab-group-split-divider` on the document root. The in-terminal divider is unaffected.

I have local before captures from the #14887 investigation (settings picker at `#171717`, workspace column still zinc). I could not upload binaries through `gh` from this environment; happy to drop them on the PR if maintainers want the files.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Local gates (macOS, Node 26 / pnpm 10; repo wants Node 24):

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [ ] `pnpm test` — 53,498 passed / 166 skipped / 3 failed in the full run. The three failures are unrelated environment flakes (macOS helper owner-loss PID file, relay grace timeout, Electron cookie-import spawn timeout). Two of those three passed when rerun in isolation; the helper-owner-loss case still flakes locally. Feature coverage: 30/30 (`tab-group-split-divider`, appearance apply, AppearancePane search + color persist).

Reviewer steps:

1. Settings → Appearance → Window & Sidebar → set **Workspace Split Divider (Dark)** to `#171717`.
2. Split a terminal tab next to an editor. The workspace column should go near-black.
3. Use Split Terminal Right. The inner divider should still follow **Dark Divider Color**, not the new workspace picker.
4. Repeat in light mode with the light picker.
5. Search Settings for `workspace split divider` and for `Window & Sidebar`.

Not exercised live: Linux, Windows, SSH host. Those paths share the same renderer CSS variable and settings merge; no RPC, path, or shortcut change.

## AI Disclosure

Implemented and reviewed with Grok 4.6 (xAI).

## Review

- **Cross-platform:** reuses existing `ColorField` / settings merge. No new shortcuts, path separators, or Electron menu accelerators.
- **SSH / remote / folder workspaces:** appearance is renderer-only. Local, SSH, WSL, and folder workspaces use the same tab-group split handle. No wire, RPC, or stream change.
- **Agents / git providers:** no agent, Git, or review-surface change.
- **Performance:** one `setProperty` on the document root when settings or system theme change. Hover/drag stays CSS `color-mix`.
- **UI:** placed under Window & Sidebar (workspace chrome), not Terminal theme, so the copy matches the surface. Search keywords include workspace/split/divider.
- **Security:** hex colors validated with the existing `HEX_COLOR_RE`; invalid values fall back to the shipped tokens. No new IPC, filesystem, or network.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- Defaults stay the current contrast-safe tokens so existing layouts do not shift.
- Hover/drag no longer uses a fixed `#a1a1aa`; it tracks the chosen base color.
- Mobile uses the same CSS variable if it renders workspace splits; no mobile-specific API.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author
