### PR TITLE
fix(relay): drop duplicate pty.ackData no-op handler and reject overwrites

### DIFF
--- a/src/relay/dispatcher-handler-registration.test.ts
+++ b/src/relay/dispatcher-handler-registration.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { RelayDispatcher } from './dispatcher'
+
+describe('RelayDispatcher handler registration', () => {
+  it('rejects a duplicate notification handler instead of silently overwriting', () => {
+    const dispatcher = new RelayDispatcher(() => true)
+    try {
+      dispatcher.onNotification('pty.ackData', () => {})
+      expect(() => dispatcher.onNotification('pty.ackData', () => {})).toThrow(
+        'Notification handler already registered: pty.ackData'
+      )
+    } finally {
+      dispatcher.dispose()
+    }
+  })
+
+  it('rejects a duplicate request handler instead of silently overwriting', () => {
+    const dispatcher = new RelayDispatcher(() => true)
+    try {
+      dispatcher.onRequest('relay.status', async () => ({ ok: true }))
+      expect(() => dispatcher.onRequest('relay.status', async () => ({ ok: true }))).toThrow(
+        'Request handler already registered: relay.status'
+      )
+    } finally {
+      dispatcher.dispose()
+    }
+  })
+
+  it('allows the same method name as a request and a notification', () => {
+    const dispatcher = new RelayDispatcher(() => true)
+    try {
+      dispatcher.onNotification('session.registerRoot', () => {})
+      expect(() =>
+        dispatcher.onRequest('session.registerRoot', async () => ({ ok: true }))
+      ).not.toThrow()
+    } finally {
+      dispatcher.dispose()
+    }
+  })
+})

--- a/src/relay/dispatcher.ts
+++ b/src/relay/dispatcher.ts
@@ -209,10 +209,17 @@ export class RelayDispatcher {
   }
 
   onRequest(method: string, handler: MethodHandler): void {
+    // Map.set would silently overwrite a prior handler — fail loudly instead.
+    if (this.requestHandlers.has(method)) {
+      throw new Error(`Request handler already registered: ${method}`)
+    }
     this.requestHandlers.set(method, handler)
   }
 
   onNotification(method: string, handler: NotificationHandler): void {
+    if (this.notificationHandlers.has(method)) {
+      throw new Error(`Notification handler already registered: ${method}`)
+    }
     this.notificationHandlers.set(method, handler)
   }
 

--- a/src/relay/pty-handler-spawn-admission.test.ts
+++ b/src/relay/pty-handler-spawn-admission.test.ts
@@ -79,7 +79,6 @@ describe('PtyHandler', () => {
     const notifMethods = Array.from(dispatcher._notificationHandlers.keys())
     expect(notifMethods).toContain('pty.data')
     expect(notifMethods).toContain('pty.resize')
-    expect(notifMethods).toContain('pty.ackData')
   })
 
   it('rejects strict process inspection for a missing relay PTY', async () => {

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -866,9 +866,6 @@ export class PtyHandler {
 
     this.dispatcher.onNotification('pty.data', (p) => this.writeData(p))
     this.dispatcher.onNotification('pty.resize', (p) => this.resize(p))
-    this.dispatcher.onNotification('pty.ackData', (_p) => {
-      /* flow control ack -- not yet enforced */
-    })
   }
 
   private isLikelyInteractiveRedraw(data: string): boolean {


### PR DESCRIPTION
## Problem

`pty.ackData` had two handlers registered on the same `RelayDispatcher`:

- `PtyHandler` (`src/relay/pty-handler.ts`) registered a **no-op** (`/* flow control ack -- not yet enforced */`).
- `SshPtyConsumerSessionAdapter` (`src/relay/ssh-pty-consumer-session-adapter.ts`) registered the **real** handler that calls `sourceCredit.acknowledge(...)`.

`Dispatcher.onNotification` / `onRequest` store handlers via `Map.set`, so the surviving handler depended on construction order in `src/relay/relay.ts`. If the no-op registered last, credit ACKs would be silently dropped and the PTY source credit window would never release — freezing fullscreen TUIs after their redraw output exhausts the 256 KB window.

## Fix

- Remove the dead no-op handler from `PtyHandler` (flow-control ACKs are owned by `SshPtyConsumerSessionAdapter`).
- Make `onRequest` / `onNotification` throw on duplicate registration instead of silently overwriting, so order-dependent shadowing cannot recur.

## Verification

- Added `src/relay/dispatcher-handler-registration.test.ts` covering duplicate request/notification rejection and request+notification name coexistence.
- Updated `pty-handler-spawn-admission.test.ts` (PtyHandler no longer claims `pty.ackData`).
- `vitest run` on the touched and adjacent relay suites: 120 tests pass.

Relates to #14843 (mobile fullscreen TUI freeze investigation).
