### PR TITLE
fix(orchestration): refuse ready reset during active dispatch

### DIFF
--- a/src/main/runtime/rpc/methods/orchestration-tasks-dispatch.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-tasks-dispatch.test.ts
@@ -185,6 +185,25 @@ describe('orchestration RPC methods', () => {
       expect(db.getActiveDispatchForTerminal('term_a')).toBeUndefined()
     })
 
+    it('rejects resetting a task to ready while its dispatch is active', async () => {
+      setup()
+      const task = db.createTask({ spec: 'work' })
+      const dispatch = db.createDispatchContext(task.id, 'term_a')
+
+      await expect(
+        call('orchestration.taskUpdate', {
+          id: task.id,
+          status: 'ready'
+        })
+      ).rejects.toMatchObject({
+        code: 'task_not_startable',
+        message: expect.stringContaining(`active Dispatch ${dispatch.id}`)
+      })
+
+      expect(db.getTask(task.id)?.status).toBe('dispatched')
+      expect(db.getDispatchContextById(dispatch.id)?.status).toBe('dispatched')
+    })
+
     it('throws on nonexistent task', async () => {
       setup()
       await expect(

--- a/src/main/runtime/rpc/methods/orchestration-tasks-dispatch.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-tasks-dispatch.test.ts
@@ -185,24 +185,30 @@ describe('orchestration RPC methods', () => {
       expect(db.getActiveDispatchForTerminal('term_a')).toBeUndefined()
     })
 
-    it('rejects resetting a task to ready while its dispatch is active', async () => {
-      setup()
-      const task = db.createTask({ spec: 'work' })
-      const dispatch = db.createDispatchContext(task.id, 'term_a')
+    it.each(['pending', 'dispatched'] as const)(
+      'rejects resetting a task to ready while its dispatch is %s',
+      async (dispatchStatus) => {
+        setup()
+        const task = db.createTask({ spec: 'work' })
+        const dispatch =
+          dispatchStatus === 'pending'
+            ? db.createStartingWorkerDispatch({ taskId: task.id, startOptions: {} }).dispatch
+            : db.createDispatchContext(task.id, 'term_a')
 
-      await expect(
-        call('orchestration.taskUpdate', {
-          id: task.id,
-          status: 'ready'
+        await expect(
+          call('orchestration.taskUpdate', {
+            id: task.id,
+            status: 'ready'
+          })
+        ).rejects.toMatchObject({
+          code: 'task_not_startable',
+          message: expect.stringContaining(`active Dispatch ${dispatch.id}`)
         })
-      ).rejects.toMatchObject({
-        code: 'task_not_startable',
-        message: expect.stringContaining(`active Dispatch ${dispatch.id}`)
-      })
 
-      expect(db.getTask(task.id)?.status).toBe('dispatched')
-      expect(db.getDispatchContextById(dispatch.id)?.status).toBe('dispatched')
-    })
+        expect(db.getTask(task.id)?.status).toBe('dispatched')
+        expect(db.getDispatchContextById(dispatch.id)?.status).toBe(dispatchStatus)
+      }
+    )
 
     it('throws on nonexistent task', async () => {
       setup()

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -1409,6 +1409,17 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
           `Task ${params.id} was not found in Run ${run.id}.`
         )
       }
+      const latestDispatch = db.getDispatchContext(params.id)
+      if (
+        params.status === 'ready' &&
+        latestDispatch &&
+        (latestDispatch.status === 'pending' || latestDispatch.status === 'dispatched')
+      ) {
+        throw new OrchestrationError(
+          'task_not_startable',
+          `Task ${params.id} has active Dispatch ${latestDispatch.id}; settle it before resetting the Task to ready.`
+        )
+      }
       const task = db.updateTaskStatus(params.id, params.status, params.result)
       if (!task) {
         throw new Error(`Task not found: ${params.id}`)


### PR DESCRIPTION
## ELI5

A task that already belongs to a running worker can no longer be silently put back into the ready queue. Orca now stops the command and names the active dispatch that must be handled first.

## What changed

- Check the task latest dispatch before orchestration.taskUpdate writes status ready.
- Reject pending or dispatched contexts with the existing task_not_startable error code and include the dispatch ID.
- Add a regression test proving both task and dispatch stay dispatched after the rejected update.

## Why

Previously, task-update --status ready changed the task row while leaving its dispatch active. The worker eventual worker_done was then rejected because the task and dispatch states no longer agreed.

Closes #14904.

## Compatibility

This adds no RPC field, opcode, or schema change. It uses the existing task_not_startable error code, so mixed-version clients retain their current error handling and receive the more actionable message.

## Testing

- Regression test first failed because the promise resolved and the task became ready.
- pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/methods/orchestration-tasks-dispatch.test.ts — 32 passed.
- pnpm typecheck — passed.
- pnpm lint — passed.
- pnpm run check:code-quality:changed — 0 findings across 2 changed files.

## AI Disclosure

Implemented and reviewed with OpenAI Codex. The change was verified against the current source, reproduced with a failing test, and validated locally before submission.

## Checklist

- [x] Scoped to the reported bug
- [x] Regression coverage added
- [x] No new protocol surface
- [x] Relevant tests, typecheck, lint, and changed-code quality pass