### PR TITLE
fix(orchestration): settle failed task dispatches

### DIFF
--- a/src/main/runtime/orchestration/db-task-terminal-settlement.test.ts
+++ b/src/main/runtime/orchestration/db-task-terminal-settlement.test.ts
@@ -14,11 +14,11 @@ describe('task terminal settlement', () => {
   it.each(['completed', 'failed'] as const)(
     'rolls back a %s task when dispatch settlement fails',
     (status) => {
-      db = new OrchestrationDb(':memory:')
-      const task = db.createTask({ spec: 'work' })
-      const dependent = db.createTask({ spec: 'next', deps: [task.id] })
-      const dispatch = db.createDispatchContext(task.id, 'term_worker')
-      sqliteFor(db).exec(`
+      const currentDb = (db = new OrchestrationDb(':memory:'))
+      const task = currentDb.createTask({ spec: 'work' })
+      const dependent = currentDb.createTask({ spec: 'next', deps: [task.id] })
+      const dispatch = currentDb.createDispatchContext(task.id, 'term_worker')
+      sqliteFor(currentDb).exec(`
         CREATE TRIGGER reject_dispatch_settlement
         BEFORE UPDATE OF status ON dispatch_contexts
         BEGIN
@@ -26,20 +26,20 @@ describe('task terminal settlement', () => {
         END;
       `)
 
-      expect(() => db.updateTaskStatus(task.id, status, 'manual terminal update')).toThrow(
+      expect(() => currentDb.updateTaskStatus(task.id, status, 'manual terminal update')).toThrow(
         'forced dispatch settlement failure'
       )
-      expect(db.getTask(task.id)).toMatchObject({
+      expect(currentDb.getTask(task.id)).toMatchObject({
         status: 'dispatched',
         result: null,
         completed_at: null
       })
-      expect(db.getDispatchContextById(dispatch.id)).toMatchObject({
+      expect(currentDb.getDispatchContextById(dispatch.id)).toMatchObject({
         status: 'dispatched',
         completed_at: null,
         capability_revoked_at: null
       })
-      expect(db.getTask(dependent.id)?.status).toBe('pending')
+      expect(currentDb.getTask(dependent.id)?.status).toBe('pending')
     }
   )
 
@@ -56,4 +56,54 @@ describe('task terminal settlement', () => {
     expect(db.getTask(task.id)?.status).toBe('dispatched')
     expect(db.getDispatchContextById(dispatch.id)?.status).toBe('dispatched')
   })
+
+  it.each(['completed', 'failed'] as const)(
+    'rejects a %s task update while its worker is still active',
+    (status) => {
+      const currentDb = (db = new OrchestrationDb(':memory:'))
+      const task = currentDb.createTask({ spec: 'supervised work' })
+      const started = currentDb.createStartingWorkerDispatch({ taskId: task.id, startOptions: {} })
+      const capability = currentDb.prepareStartingWorkerAuthority({
+        dispatchId: started.dispatch.id,
+        handle: 'term_worker',
+        paneKey: 'tab_worker:leaf_worker',
+        processIncarnation: 'worker:1',
+        worktreeId: 'repo::worker',
+        setupState: 'not_applicable',
+        effects: [],
+        terminalOwnership: 'created'
+      })
+      currentDb.markWorkerDispatchReady(started.dispatch.id)
+
+      expect(() => currentDb.updateTaskStatus(task.id, status, 'must not persist')).toThrowError(
+        expect.objectContaining({
+          code: 'task_not_startable',
+          data: { taskId: task.id, dispatchId: started.dispatch.id }
+        })
+      )
+      expect(currentDb.getTask(task.id)).toMatchObject({
+        status: 'dispatched',
+        result: null,
+        completed_at: null
+      })
+      expect(currentDb.getDispatchContextById(started.dispatch.id)).toMatchObject({
+        status: 'dispatched',
+        completed_at: null,
+        capability_revoked_at: null
+      })
+      expect(currentDb.getWorkerDispatch(started.dispatch.id)?.state).toBe('ready')
+      expect(currentDb.getWorkerTerminalResourceByOwner(started.dispatch.id)).toMatchObject({
+        ownership_state: 'owned',
+        release_state: 'not_requested'
+      })
+      expect(
+        currentDb.verifyDispatchCapability({
+          dispatchId: started.dispatch.id,
+          capability,
+          paneKey: 'tab_worker:leaf_worker',
+          processIncarnation: 'worker:1'
+        })
+      ).toEqual({ valid: true })
+    }
+  )
 })

--- a/src/main/runtime/orchestration/db-task-terminal-settlement.test.ts
+++ b/src/main/runtime/orchestration/db-task-terminal-settlement.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import type Database from '../../sqlite/sync-database'
+import { OrchestrationDb } from './db'
+
+function sqliteFor(db: OrchestrationDb): Database.Database {
+  return (db as unknown as { db: Database.Database }).db
+}
+
+describe('task terminal settlement', () => {
+  let db: OrchestrationDb | undefined
+
+  afterEach(() => db?.close())
+
+  it.each(['completed', 'failed'] as const)(
+    'rolls back a %s task when dispatch settlement fails',
+    (status) => {
+      db = new OrchestrationDb(':memory:')
+      const task = db.createTask({ spec: 'work' })
+      const dependent = db.createTask({ spec: 'next', deps: [task.id] })
+      const dispatch = db.createDispatchContext(task.id, 'term_worker')
+      sqliteFor(db).exec(`
+        CREATE TRIGGER reject_dispatch_settlement
+        BEFORE UPDATE OF status ON dispatch_contexts
+        BEGIN
+          SELECT RAISE(ABORT, 'forced dispatch settlement failure');
+        END;
+      `)
+
+      expect(() => db.updateTaskStatus(task.id, status, 'manual terminal update')).toThrow(
+        'forced dispatch settlement failure'
+      )
+      expect(db.getTask(task.id)).toMatchObject({
+        status: 'dispatched',
+        result: null,
+        completed_at: null
+      })
+      expect(db.getDispatchContextById(dispatch.id)).toMatchObject({
+        status: 'dispatched',
+        completed_at: null,
+        capability_revoked_at: null
+      })
+      expect(db.getTask(dependent.id)?.status).toBe('pending')
+    }
+  )
+
+  it('does not commit a caller-owned transaction', () => {
+    db = new OrchestrationDb(':memory:')
+    const task = db.createTask({ spec: 'work' })
+    const dispatch = db.createDispatchContext(task.id, 'term_worker')
+    const sqlite = sqliteFor(db)
+
+    sqlite.exec('BEGIN IMMEDIATE')
+    db.updateTaskStatus(task.id, 'failed')
+    sqlite.exec('ROLLBACK')
+
+    expect(db.getTask(task.id)?.status).toBe('dispatched')
+    expect(db.getDispatchContextById(dispatch.id)?.status).toBe('dispatched')
+  })
+})

--- a/src/main/runtime/orchestration/db.ts
+++ b/src/main/runtime/orchestration/db.ts
@@ -4592,7 +4592,9 @@ export class OrchestrationDb {
 
     if (status === 'completed') {
       this.promoteReadyTasks(id)
-      this.completeActiveDispatchForTask(id)
+    }
+    if (status === 'completed' || status === 'failed') {
+      this.settleActiveDispatchForTask(id, status)
     }
 
     return this.getTask(id)
@@ -7360,13 +7362,24 @@ export class OrchestrationDb {
   }
 
   completeActiveDispatchForTask(taskId: string): void {
+    this.settleActiveDispatchForTask(taskId, 'completed')
+  }
+
+  private settleActiveDispatchForTask(taskId: string, status: 'completed' | 'failed'): void {
     const active = this.db
       .prepare(
         "SELECT * FROM dispatch_contexts WHERE task_id = ? AND status IN ('pending', 'dispatched') ORDER BY rowid DESC LIMIT 1"
       )
       .get(taskId) as DispatchContextRow | undefined
     if (active) {
-      this.completeDispatch(active.id)
+      this.db
+        .prepare(
+          `UPDATE dispatch_contexts
+           SET status = ?, completed_at = datetime('now'),
+               capability_revoked_at = COALESCE(capability_revoked_at, datetime('now'))
+           WHERE id = ?`
+        )
+        .run(status, active.id)
     }
   }
 

--- a/src/main/runtime/orchestration/db.ts
+++ b/src/main/runtime/orchestration/db.ts
@@ -4582,22 +4582,32 @@ export class OrchestrationDb {
   }
 
   updateTaskStatus(id: string, status: TaskStatus, result?: string): TaskRow | undefined {
-    const completedAt =
-      status === 'completed' || status === 'failed' ? new Date().toISOString() : null
-    this.db
-      .prepare(
-        'UPDATE tasks SET status = ?, result = COALESCE(?, result), completed_at = COALESCE(?, completed_at) WHERE id = ?'
-      )
-      .run(status, result ?? null, completedAt, id)
+    // Why: SAVEPOINT is atomic standalone and nests without committing a caller-owned transaction.
+    this.db.exec('SAVEPOINT update_task_status')
+    try {
+      const completedAt =
+        status === 'completed' || status === 'failed' ? new Date().toISOString() : null
+      this.db
+        .prepare(
+          'UPDATE tasks SET status = ?, result = COALESCE(?, result), completed_at = COALESCE(?, completed_at) WHERE id = ?'
+        )
+        .run(status, result ?? null, completedAt, id)
 
-    if (status === 'completed') {
-      this.promoteReadyTasks(id)
-    }
-    if (status === 'completed' || status === 'failed') {
-      this.settleActiveDispatchForTask(id, status)
-    }
+      if (status === 'completed') {
+        this.promoteReadyTasks(id)
+      }
+      if (status === 'completed' || status === 'failed') {
+        this.settleActiveDispatchForTask(id, status)
+      }
 
-    return this.getTask(id)
+      const task = this.getTask(id)
+      this.db.exec('RELEASE update_task_status')
+      return task
+    } catch (error) {
+      this.db.exec('ROLLBACK TO update_task_status')
+      this.db.exec('RELEASE update_task_status')
+      throw error
+    }
   }
 
   // Why: runs in the status-update transaction, so a completed task never leaves its ready children unpromoted.

--- a/src/main/runtime/orchestration/db.ts
+++ b/src/main/runtime/orchestration/db.ts
@@ -4585,18 +4585,51 @@ export class OrchestrationDb {
     // Why: SAVEPOINT is atomic standalone and nests without committing a caller-owned transaction.
     this.db.exec('SAVEPOINT update_task_status')
     try {
-      const completedAt =
-        status === 'completed' || status === 'failed' ? new Date().toISOString() : null
-      this.db
+      const terminalStatus = status === 'completed' || status === 'failed'
+      const completedAt = terminalStatus ? new Date().toISOString() : null
+      const update = this.db
         .prepare(
-          'UPDATE tasks SET status = ?, result = COALESCE(?, result), completed_at = COALESCE(?, completed_at) WHERE id = ?'
+          `UPDATE tasks
+           SET status = ?, result = COALESCE(?, result),
+               completed_at = COALESCE(?, completed_at)
+           WHERE id = ?
+             AND (
+               ? = 0 OR NOT EXISTS (
+                 SELECT 1
+                 FROM dispatch_contexts active
+                 JOIN worker_dispatches worker ON worker.dispatch_id = active.id
+                 WHERE active.task_id = tasks.id
+                   AND active.status IN ('pending', 'dispatched')
+                   AND worker.state NOT IN ('failed', 'succeeded', 'stopped', 'abandoned')
+               )
+             )`
         )
-        .run(status, result ?? null, completedAt, id)
+        .run(status, result ?? null, completedAt, id, terminalStatus ? 1 : 0)
+
+      if (update.changes !== 1 && terminalStatus) {
+        const activeWorker = this.db
+          .prepare(
+            `SELECT active.id
+             FROM dispatch_contexts active
+             JOIN worker_dispatches worker ON worker.dispatch_id = active.id
+             WHERE active.task_id = ? AND active.status IN ('pending', 'dispatched')
+               AND worker.state NOT IN ('failed', 'succeeded', 'stopped', 'abandoned')
+             ORDER BY active.rowid DESC LIMIT 1`
+          )
+          .get(id) as Pick<DispatchContextRow, 'id'> | undefined
+        if (activeWorker) {
+          throw new OrchestrationError(
+            'task_not_startable',
+            `Task ${id} cannot move to ${status} while supervised Dispatch ${activeWorker.id} is active; stop or settle its worker first.`,
+            { taskId: id, dispatchId: activeWorker.id }
+          )
+        }
+      }
 
       if (status === 'completed') {
         this.promoteReadyTasks(id)
       }
-      if (status === 'completed' || status === 'failed') {
+      if (terminalStatus) {
         this.settleActiveDispatchForTask(id, status)
       }
 

--- a/src/main/runtime/rpc/methods/orchestration-tasks-dispatch.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-tasks-dispatch.test.ts
@@ -172,18 +172,30 @@ describe('orchestration RPC methods', () => {
       expect(result.task.result).toBe('{"ok": true}')
     })
 
-    it('completion frees the active dispatch context', async () => {
-      setup()
-      const task = db.createTask({ spec: 'work' })
-      db.createDispatchContext(task.id, 'term_a')
+    it.each(['completed', 'failed'] as const)(
+      '%s frees the active dispatch context',
+      async (status) => {
+        setup()
+        const task = db.createTask({ spec: 'work' })
+        db.createDispatchContext(task.id, 'term_a')
 
-      await call('orchestration.taskUpdate', {
-        id: task.id,
-        status: 'completed'
-      })
+        const result = (await call('orchestration.taskUpdate', {
+          id: task.id,
+          status
+        })) as { task: { status: string } }
 
-      expect(db.getActiveDispatchForTerminal('term_a')).toBeUndefined()
-    })
+        expect(result.task.status).toBe(status)
+        expect(db.getActiveDispatchForTerminal('term_a')).toBeUndefined()
+        expect(db.getDispatchContext(task.id)).toMatchObject({
+          status,
+          completed_at: expect.any(String),
+          capability_revoked_at: expect.any(String)
+        })
+
+        const next = db.createTask({ spec: 'next' })
+        expect(() => db.createDispatchContext(next.id, 'term_a')).not.toThrow()
+      }
+    )
 
     it('throws on nonexistent task', async () => {
       setup()

--- a/src/main/runtime/rpc/methods/orchestration-tasks-dispatch.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-tasks-dispatch.test.ts
@@ -177,7 +177,28 @@ describe('orchestration RPC methods', () => {
       async (status) => {
         setup()
         const task = db.createTask({ spec: 'work' })
-        db.createDispatchContext(task.id, 'term_a')
+        const paneKey = 'tab_worker:11111111-1111-4111-8111-111111111111'
+        const processIncarnation = 'test:worker:1'
+        const dispatch = db.createDispatchContext(
+          task.id,
+          'term_a',
+          paneKey,
+          undefined,
+          processIncarnation
+        )
+        const capability = db.mintDispatchCapability({
+          dispatchId: dispatch.id,
+          paneKey,
+          processIncarnation
+        })
+        expect(
+          db.verifyDispatchCapability({
+            dispatchId: dispatch.id,
+            capability,
+            paneKey,
+            processIncarnation
+          })
+        ).toEqual({ valid: true })
 
         const result = (await call('orchestration.taskUpdate', {
           id: task.id,
@@ -191,6 +212,14 @@ describe('orchestration RPC methods', () => {
           completed_at: expect.any(String),
           capability_revoked_at: expect.any(String)
         })
+        expect(
+          db.verifyDispatchCapability({
+            dispatchId: dispatch.id,
+            capability,
+            paneKey,
+            processIncarnation
+          })
+        ).toEqual({ valid: false, reason: `Dispatch ${dispatch.id} capability is revoked.` })
 
         const next = db.createTask({ spec: 'next' })
         expect(() => db.createDispatchContext(next.id, 'term_a')).not.toThrow()


### PR DESCRIPTION
## ELI5

Marking a context-only dispatched task as failed stopped the task, but left its terminal lane reserved forever. This makes the failed dispatch stop too, so the terminal can accept new work. Supervised and federated workers keep their own lifecycle authority and cannot be silently orphaned by a direct task update.

## What Changed

- settle the latest active context-only dispatch whenever `task-update` moves its task to `completed` or `failed`
- stamp dispatch completion, revoke its capability, and release terminal occupancy
- atomically reject terminal task updates while the active dispatch still has a live worker
- preserve worker, terminal-resource, and capability state on that rejection
- wrap the task write, dependency promotion, and dispatch settlement in a nested-safe SQLite savepoint
- cover terminal settlement, rollback, terminal reuse, and live-worker preservation

## Why

`updateTaskStatus` already treated both `completed` and `failed` as terminal when setting `completed_at`, but only `completed` settled the associated dispatch. A failed context-only task therefore remained paired with a `dispatched` context and permanently blocked that terminal.

Worker-backed dispatches are different: their report/stop flow owns task, dispatch, process, and resource settlement. Directly settling only the task/context would free terminal occupancy while the worker remained live. The SQL guard keeps that lifecycle intact for local and federated workers.

## Linked Issue

Fixes #14914

## Visual Proof

N/A — this changes orchestration database state transitions and has no UI surface.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Executed on macOS against current head:

- RED: the new `completed` and `failed` live-worker regressions both failed before the guard with `expected function to throw an error, but it didn't`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orchestration/db-task-terminal-settlement.test.ts src/main/runtime/orchestration/orchestration-worker-dispatch-db.test.ts src/main/runtime/rpc/methods/orchestration-tasks-dispatch.test.ts src/main/runtime/orchestration/federation-sync.test.ts src/main/runtime/rpc/methods/orchestration-worker-release.test.ts` — 5 files, 97 tests passed
- `pnpm typecheck:node` — passed
- changed-file `oxlint`, `oxfmt --check`, and `git diff --check` — passed
- `pnpm build` — desktop and native build passed

Full repository `pnpm test` and full `pnpm lint` were not rerun; the focused lifecycle suites, typecheck, changed-file static checks, and complete build cover this SQLite-only change.

## AI Disclosure

OpenAI Codex was used for root-cause analysis, implementation, TDD, and review. Grok 4.6 identified the live-worker lifecycle blocker before this amendment. Its final pass requested changes for a missing-task fallthrough and broader state coverage; the missing-task path is pre-existing and non-mutating, and the worker-state/federated predicate was independently checked against the current schema and lifecycle writers. Grok approval is not claimed.

## Review

- Independent Codex review of the amended diff: APPROVED with no confirmed findings after source inspection, focused tests, typecheck, lint, and a SQLite `changes()` probe.
- CodeRabbit full review of current head `c5b759f27d` completed with no actionable comments.
- Security: no new command or authorization surface; context settlement revokes the existing dispatch capability, while live workers retain their authority.
- Cross-platform: SQLite-only state transition with no OS-specific behavior.
- Remote/SSH: no RPC schema or wire change; each host applies the invariant in its own orchestration database.
- Federated: federated dispatches share the guarded `worker_dispatches` row and remain worker-owned until report/stop settlement.
- Mobile: no mobile-specific consumer or UI change.
- Performance: one indexed task update plus a bounded diagnostic lookup only when the guarded update rejects.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, path/shortcut, and mixed-host impact considered
- [ ] Full `pnpm lint` and `pnpm test` pass (focused lint/tests, typecheck, and full build pass)

## Author

- GitHub: @bbingz

