### PR TITLE
fix(mobile): present pending Relay fallback accurately

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1026,8 +1026,8 @@
       "motivatingLinks": [
         "https://linear.app/stably/issue/STA-4153/mobile-app-disconnects-frequently"
       ],
-      "invariant": "A provider-wanted host without a logical client retries every current-generation pre-client failure until success or explicit cancellation, while release, disconnect, forget, refresh, and stale async continuations preserve their distinct resurrection policies. Direct sessions probe after authenticated silence and terminate after three fair misses. Relay sessions emit no periodic idle or demand-driven probes, use rate-limited foreground probes, and terminate after two fair misses. Authenticated traffic, scheduler stalls, and replacement identities cannot manufacture death. An in-flight Relay fallback must not inherit a failed direct path's warning or Tailscale hint.",
-      "oracle": "Inject rejected and never-settling catalog reads, missing profiles, synchronous construction failure, release, refresh, forget, revival, and stale completion under fake time. Require bounded 1s through 60s retry, exact current-generation publication, and no zero-owner or forgotten-client resurrection. Inject direct and relay authenticated text/binary traffic, silent probe windows, stalled clocks, replacement identities, and failed writes. Require direct three-miss tolerance; Relay zero idle and demand-driven liveness traffic, one foreground probe sequence, two fair 4s misses, a 10s voluntary rate limit, no old-session network-change probe, and delivery-unknown mutations without replay. Project a Relay-pending path over five failed Tailscale attempts and require a neutral Relay-specific verdict with no Tailscale warning.",
+      "invariant": "A provider-wanted host without a logical client retries every current-generation pre-client failure until success or explicit cancellation, while release, disconnect, forget, refresh, and stale async continuations preserve their distinct resurrection policies. Direct sessions probe after authenticated silence and terminate after three fair misses. Relay sessions emit no periodic idle or demand-driven probes, use rate-limited foreground probes, and terminate after two fair misses. Authenticated traffic, scheduler stalls, and replacement identities cannot manufacture death. Relay recovery must notify presentation independently of transport-state changes, must not inherit a failed direct path's Tailscale hint, and must retain long-outage escalation.",
+      "oracle": "Inject rejected and never-settling catalog reads, missing profiles, synchronous construction failure, release, refresh, forget, revival, and stale completion under fake time. Require bounded 1s through 60s retry, exact current-generation publication, and no zero-owner or forgotten-client resurrection. Inject direct and relay authenticated text/binary traffic, silent probe windows, stalled clocks, replacement identities, and failed writes. Require direct three-miss tolerance; Relay zero idle and demand-driven liveness traffic, one foreground probe sequence, two fair 4s misses, a 10s voluntary rate limit, no old-session network-change probe, and delivery-unknown mutations without replay. Start and clear Relay recovery without changing transport state and require observers to rerender. Project five failed Tailscale attempts into a neutral Relay-specific verdict, then require twelve attempts to produce a Relay-specific unreachable verdict with no Tailscale hint.",
       "commands": [
         "pnpm --dir mobile exec vitest run --root .. mobile/src/transport/client-context.test.ts mobile/src/transport/host-open-recovery.test.tsx mobile/src/transport/host-open-retry-scheduler.test.ts mobile/src/transport/rpc-session-liveness-watchdog.test.ts mobile/src/transport/rpc-session-liveness-integration.test.ts mobile/src/transport/mobile-relay-rpc-session.test.ts mobile/src/transport/mobile-relay-rpc-session-liveness.test.ts mobile/src/transport/mobile-endpoint-nudge-router.test.ts mobile/src/transport/mobile-relay-e2ee-link.test.ts mobile/src/transport/stable-logical-rpc-client.test.ts mobile/src/transport/connection-health.test.ts"
       ],
@@ -1047,7 +1047,10 @@
       "assertionRefs": [
         {
           "file": "mobile/src/transport/client-context.test.ts",
-          "assertions": ["a retired close-on-release owner closes an ownerless manual reconnect"]
+          "assertions": [
+            "a retired close-on-release owner closes an ownerless manual reconnect",
+            "a Relay recovery path change rerenders observers without a transport-state change"
+          ]
         },
         {
           "file": "mobile/src/transport/host-open-recovery.test.tsx",
@@ -1098,12 +1101,16 @@
         },
         {
           "file": "mobile/src/transport/stable-logical-rpc-client.test.ts",
-          "assertions": ["a delivery-unknown mutation is not replayed onto a replacement Relay"]
+          "assertions": [
+            "a delivery-unknown mutation is not replayed onto a replacement Relay",
+            "Relay recovery path changes publish and remain pending between failed dials"
+          ]
         },
         {
           "file": "mobile/src/transport/connection-health.test.ts",
           "assertions": [
-            "a Relay fallback pending over five failed Tailscale attempts remains neutral and omits the Tailscale hint"
+            "a Relay fallback pending over five failed Tailscale attempts remains neutral and omits the Tailscale hint",
+            "a prolonged Relay recovery escalates without reviving the Tailscale hint"
           ]
         }
       ],
@@ -1115,7 +1122,7 @@
           "command": "pnpm --dir mobile exec vitest run --root .. mobile/src/transport/client-context.test.ts mobile/src/transport/host-open-recovery.test.tsx mobile/src/transport/host-open-retry-scheduler.test.ts mobile/src/transport/rpc-session-liveness-watchdog.test.ts mobile/src/transport/rpc-session-liveness-integration.test.ts mobile/src/transport/mobile-relay-rpc-session.test.ts mobile/src/transport/mobile-relay-rpc-session-liveness.test.ts mobile/src/transport/mobile-endpoint-nudge-router.test.ts mobile/src/transport/mobile-relay-e2ee-link.test.ts mobile/src/transport/stable-logical-rpc-client.test.ts mobile/src/transport/connection-health.test.ts",
           "result": "passed",
           "durationSeconds": 0.74,
-          "summary": "Eleven focused files passed 81 deterministic provider lifecycle, path presentation, direct/Relay liveness, traffic, and delivery-ambiguity tests."
+          "summary": "Eleven focused files passed 84 deterministic provider lifecycle, path presentation, direct/Relay liveness, traffic, and delivery-ambiguity tests."
         }
       ],
       "runtimeBudget": {

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1022,14 +1022,14 @@
       "providers": ["lan", "tailscale", "cloud-relay"],
       "coveredPlatforms": ["macos"],
       "coveredProviders": ["lan", "tailscale", "cloud-relay"],
-      "coverageNotes": "Deterministic React/provider tests cover catalog, missing-host, construction, cancellation, release, forget, refresh, backoff, and stale-generation outcomes. Direct sessions cover idle probing and three fair misses. Relay sessions cover zero idle polling, rate-limited foreground probes, two fair misses, authenticated activity before semantic decoding, delivery ambiguity, scheduler stalls, and write failure. Physical iOS/Android sleep, carrier/Tailscale loss, and production relay paths remain live-test gaps.",
+      "coverageNotes": "Deterministic React/provider tests cover catalog, missing-host, construction, cancellation, release, forget, refresh, backoff, stale-generation outcomes, and path-aware recovery presentation. Direct sessions cover idle probing and three fair misses. Relay sessions cover zero idle polling, rate-limited foreground probes, two fair misses, authenticated activity before semantic decoding, delivery ambiguity, scheduler stalls, and write failure. Physical iOS/Android sleep, carrier/Tailscale loss, and production relay paths remain live-test gaps.",
       "motivatingLinks": [
         "https://linear.app/stably/issue/STA-4153/mobile-app-disconnects-frequently"
       ],
-      "invariant": "A provider-wanted host without a logical client retries every current-generation pre-client failure until success or explicit cancellation, while release, disconnect, forget, refresh, and stale async continuations preserve their distinct resurrection policies. Direct sessions probe after authenticated silence and terminate after three fair misses. Relay sessions emit no periodic idle or demand-driven probes, use rate-limited foreground probes, and terminate after two fair misses. Authenticated traffic, scheduler stalls, and replacement identities cannot manufacture death.",
-      "oracle": "Inject rejected and never-settling catalog reads, missing profiles, synchronous construction failure, release, refresh, forget, revival, and stale completion under fake time. Require bounded 1s through 60s retry, exact current-generation publication, and no zero-owner or forgotten-client resurrection. Inject direct and relay authenticated text/binary traffic, silent probe windows, stalled clocks, replacement identities, and failed writes. Require direct three-miss tolerance; Relay zero idle and demand-driven liveness traffic, one foreground probe sequence, two fair 4s misses, a 10s voluntary rate limit, no old-session network-change probe, and delivery-unknown mutations without replay.",
+      "invariant": "A provider-wanted host without a logical client retries every current-generation pre-client failure until success or explicit cancellation, while release, disconnect, forget, refresh, and stale async continuations preserve their distinct resurrection policies. Direct sessions probe after authenticated silence and terminate after three fair misses. Relay sessions emit no periodic idle or demand-driven probes, use rate-limited foreground probes, and terminate after two fair misses. Authenticated traffic, scheduler stalls, and replacement identities cannot manufacture death. An in-flight Relay fallback must not inherit a failed direct path's warning or Tailscale hint.",
+      "oracle": "Inject rejected and never-settling catalog reads, missing profiles, synchronous construction failure, release, refresh, forget, revival, and stale completion under fake time. Require bounded 1s through 60s retry, exact current-generation publication, and no zero-owner or forgotten-client resurrection. Inject direct and relay authenticated text/binary traffic, silent probe windows, stalled clocks, replacement identities, and failed writes. Require direct three-miss tolerance; Relay zero idle and demand-driven liveness traffic, one foreground probe sequence, two fair 4s misses, a 10s voluntary rate limit, no old-session network-change probe, and delivery-unknown mutations without replay. Project a Relay-pending path over five failed Tailscale attempts and require a neutral Relay-specific verdict with no Tailscale warning.",
       "commands": [
-        "pnpm --dir mobile exec vitest run --root .. mobile/src/transport/client-context.test.ts mobile/src/transport/host-open-recovery.test.tsx mobile/src/transport/host-open-retry-scheduler.test.ts mobile/src/transport/rpc-session-liveness-watchdog.test.ts mobile/src/transport/rpc-session-liveness-integration.test.ts mobile/src/transport/mobile-relay-rpc-session.test.ts mobile/src/transport/mobile-relay-rpc-session-liveness.test.ts mobile/src/transport/mobile-endpoint-nudge-router.test.ts mobile/src/transport/mobile-relay-e2ee-link.test.ts mobile/src/transport/stable-logical-rpc-client.test.ts"
+        "pnpm --dir mobile exec vitest run --root .. mobile/src/transport/client-context.test.ts mobile/src/transport/host-open-recovery.test.tsx mobile/src/transport/host-open-retry-scheduler.test.ts mobile/src/transport/rpc-session-liveness-watchdog.test.ts mobile/src/transport/rpc-session-liveness-integration.test.ts mobile/src/transport/mobile-relay-rpc-session.test.ts mobile/src/transport/mobile-relay-rpc-session-liveness.test.ts mobile/src/transport/mobile-endpoint-nudge-router.test.ts mobile/src/transport/mobile-relay-e2ee-link.test.ts mobile/src/transport/stable-logical-rpc-client.test.ts mobile/src/transport/connection-health.test.ts"
       ],
       "testFiles": [
         "mobile/src/transport/client-context.test.ts",
@@ -1041,7 +1041,8 @@
         "mobile/src/transport/mobile-relay-rpc-session-liveness.test.ts",
         "mobile/src/transport/mobile-endpoint-nudge-router.test.ts",
         "mobile/src/transport/mobile-relay-e2ee-link.test.ts",
-        "mobile/src/transport/stable-logical-rpc-client.test.ts"
+        "mobile/src/transport/stable-logical-rpc-client.test.ts",
+        "mobile/src/transport/connection-health.test.ts"
       ],
       "assertionRefs": [
         {
@@ -1098,17 +1099,23 @@
         {
           "file": "mobile/src/transport/stable-logical-rpc-client.test.ts",
           "assertions": ["a delivery-unknown mutation is not replayed onto a replacement Relay"]
+        },
+        {
+          "file": "mobile/src/transport/connection-health.test.ts",
+          "assertions": [
+            "a Relay fallback pending over five failed Tailscale attempts remains neutral and omits the Tailscale hint"
+          ]
         }
       ],
       "evidenceRuns": [
         {
-          "date": "2026-08-14",
+          "date": "2026-08-16",
           "runner": "local",
           "platform": "macos",
-          "command": "pnpm --dir mobile exec vitest run --root .. mobile/src/transport/client-context.test.ts mobile/src/transport/host-open-recovery.test.tsx mobile/src/transport/host-open-retry-scheduler.test.ts mobile/src/transport/rpc-session-liveness-watchdog.test.ts mobile/src/transport/rpc-session-liveness-integration.test.ts mobile/src/transport/mobile-relay-rpc-session.test.ts mobile/src/transport/mobile-relay-rpc-session-liveness.test.ts mobile/src/transport/mobile-endpoint-nudge-router.test.ts mobile/src/transport/mobile-relay-e2ee-link.test.ts mobile/src/transport/stable-logical-rpc-client.test.ts",
+          "command": "pnpm --dir mobile exec vitest run --root .. mobile/src/transport/client-context.test.ts mobile/src/transport/host-open-recovery.test.tsx mobile/src/transport/host-open-retry-scheduler.test.ts mobile/src/transport/rpc-session-liveness-watchdog.test.ts mobile/src/transport/rpc-session-liveness-integration.test.ts mobile/src/transport/mobile-relay-rpc-session.test.ts mobile/src/transport/mobile-relay-rpc-session-liveness.test.ts mobile/src/transport/mobile-endpoint-nudge-router.test.ts mobile/src/transport/mobile-relay-e2ee-link.test.ts mobile/src/transport/stable-logical-rpc-client.test.ts mobile/src/transport/connection-health.test.ts",
           "result": "passed",
           "durationSeconds": 0.74,
-          "summary": "Ten focused files passed 66 deterministic provider lifecycle, direct/Relay liveness, traffic, and delivery-ambiguity tests."
+          "summary": "Eleven focused files passed 81 deterministic provider lifecycle, path presentation, direct/Relay liveness, traffic, and delivery-ambiguity tests."
         }
       ],
       "runtimeBudget": {

--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -31,8 +31,8 @@ import {
 import { useWorktreeResync } from '../../../src/transport/use-worktree-resync'
 import { startHostWorktreeRefresh } from '../../../src/worktree/host-worktree-refresh'
 import {
-  useConnectionPath,
   useLastConnectedAt,
+  usePendingConnectionPath,
   useReconnectAttempt
 } from '../../../src/transport/client-context-connection-metrics'
 import {
@@ -139,7 +139,7 @@ export function HostScreen({
   const { client, state: connState } = useHostClient(hostId)
   const reconnectAttempts = useReconnectAttempt(hostId)
   const lastConnectedAt = useLastConnectedAt(hostId)
-  const connectionPath = useConnectionPath(hostId)
+  const pendingConnectionPath = usePendingConnectionPath(hostId)
   const clientRef = useRef<RpcClient | null>(null)
   const fetchWorktreesInFlightRef = useRef(false)
   // Why: useRef, not useMemo — React may discard memoized values, which would silently
@@ -820,7 +820,7 @@ export function HostScreen({
               state: connState,
               reconnectAttempts,
               lastConnectedAt,
-              path: connectionPath
+              pendingPath: pendingConnectionPath
             })
             return (
               <>

--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -31,6 +31,7 @@ import {
 import { useWorktreeResync } from '../../../src/transport/use-worktree-resync'
 import { startHostWorktreeRefresh } from '../../../src/worktree/host-worktree-refresh'
 import {
+  useConnectionPath,
   useLastConnectedAt,
   useReconnectAttempt
 } from '../../../src/transport/client-context-connection-metrics'
@@ -138,6 +139,7 @@ export function HostScreen({
   const { client, state: connState } = useHostClient(hostId)
   const reconnectAttempts = useReconnectAttempt(hostId)
   const lastConnectedAt = useLastConnectedAt(hostId)
+  const connectionPath = useConnectionPath(hostId)
   const clientRef = useRef<RpcClient | null>(null)
   const fetchWorktreesInFlightRef = useRef(false)
   // Why: useRef, not useMemo — React may discard memoized values, which would silently
@@ -817,7 +819,8 @@ export function HostScreen({
             const headerVerdict = classifyConnection({
               state: connState,
               reconnectAttempts,
-              lastConnectedAt
+              lastConnectedAt,
+              path: connectionPath
             })
             return (
               <>

--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -60,8 +60,8 @@ import {
 } from '../../../../src/storage/preferences'
 import { useHostClient, useForceReconnect } from '../../../../src/transport/client-context'
 import {
-  useConnectionPath,
   useLastConnectedAt,
+  usePendingConnectionPath,
   useReconnectAttempt
 } from '../../../../src/transport/client-context-connection-metrics'
 import {
@@ -737,7 +737,7 @@ export default function SessionScreen() {
   const { client, state: connState } = useHostClient(hostId)
   const reconnectAttempts = useReconnectAttempt(hostId)
   const lastConnectedAt = useLastConnectedAt(hostId)
-  const connectionPath = useConnectionPath(hostId)
+  const pendingConnectionPath = usePendingConnectionPath(hostId)
   const forceReconnectHost = useForceReconnect()
   const { name: worktreeName, resolution: worktreeResolution } = useLiveWorktreeName({
     client,
@@ -4152,7 +4152,7 @@ export default function SessionScreen() {
     reconnectAttempts,
     lastConnectedAt,
     endpoint: hostEndpoint,
-    path: connectionPath
+    pendingPath: pendingConnectionPath
   })
   const showConnectionRetry =
     connectionVerdict.kind === 'warning' || connectionVerdict.kind === 'unreachable'

--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -60,6 +60,7 @@ import {
 } from '../../../../src/storage/preferences'
 import { useHostClient, useForceReconnect } from '../../../../src/transport/client-context'
 import {
+  useConnectionPath,
   useLastConnectedAt,
   useReconnectAttempt
 } from '../../../../src/transport/client-context-connection-metrics'
@@ -736,6 +737,7 @@ export default function SessionScreen() {
   const { client, state: connState } = useHostClient(hostId)
   const reconnectAttempts = useReconnectAttempt(hostId)
   const lastConnectedAt = useLastConnectedAt(hostId)
+  const connectionPath = useConnectionPath(hostId)
   const forceReconnectHost = useForceReconnect()
   const { name: worktreeName, resolution: worktreeResolution } = useLiveWorktreeName({
     client,
@@ -4149,7 +4151,8 @@ export default function SessionScreen() {
     state: connState,
     reconnectAttempts,
     lastConnectedAt,
-    endpoint: hostEndpoint
+    endpoint: hostEndpoint,
+    path: connectionPath
   })
   const showConnectionRetry =
     connectionVerdict.kind === 'warning' || connectionVerdict.kind === 'unreachable'

--- a/mobile/app/h/[hostId]/tasks.tsx
+++ b/mobile/app/h/[hostId]/tasks.tsx
@@ -36,6 +36,7 @@ import type { RpcClient } from '../../../src/transport/rpc-client'
 import type { RpcSuccess } from '../../../src/transport/types'
 import { useHostClient } from '../../../src/transport/client-context'
 import {
+  useConnectionPath,
   useLastConnectedAt,
   useReconnectAttempt
 } from '../../../src/transport/client-context-connection-metrics'
@@ -2073,6 +2074,7 @@ export default function MobileTasksScreen() {
   const { client, state: connState } = useHostClient(hostId)
   const reconnectAttempts = useReconnectAttempt(hostId)
   const lastConnectedAt = useLastConnectedAt(hostId)
+  const connectionPath = useConnectionPath(hostId)
   const clientRef = useRef<RpcClient | null>(null)
   const loadGenerationRef = useRef(0)
   const taskResumeRef = useRef<TaskResumeState>({})
@@ -8673,7 +8675,8 @@ export default function MobileTasksScreen() {
   const headerVerdict = classifyConnection({
     state: connState,
     reconnectAttempts,
-    lastConnectedAt
+    lastConnectedAt,
+    path: connectionPath
   })
   const emptyLabel =
     connState !== 'connected'

--- a/mobile/app/h/[hostId]/tasks.tsx
+++ b/mobile/app/h/[hostId]/tasks.tsx
@@ -36,8 +36,8 @@ import type { RpcClient } from '../../../src/transport/rpc-client'
 import type { RpcSuccess } from '../../../src/transport/types'
 import { useHostClient } from '../../../src/transport/client-context'
 import {
-  useConnectionPath,
   useLastConnectedAt,
+  usePendingConnectionPath,
   useReconnectAttempt
 } from '../../../src/transport/client-context-connection-metrics'
 import { classifyConnection } from '../../../src/transport/connection-health'
@@ -2074,7 +2074,7 @@ export default function MobileTasksScreen() {
   const { client, state: connState } = useHostClient(hostId)
   const reconnectAttempts = useReconnectAttempt(hostId)
   const lastConnectedAt = useLastConnectedAt(hostId)
-  const connectionPath = useConnectionPath(hostId)
+  const pendingConnectionPath = usePendingConnectionPath(hostId)
   const clientRef = useRef<RpcClient | null>(null)
   const loadGenerationRef = useRef(0)
   const taskResumeRef = useRef<TaskResumeState>({})
@@ -8676,7 +8676,7 @@ export default function MobileTasksScreen() {
     state: connState,
     reconnectAttempts,
     lastConnectedAt,
-    path: connectionPath
+    pendingPath: pendingConnectionPath
   })
   const emptyLabel =
     connState !== 'connected'

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -765,7 +765,8 @@ export default function HomeScreen() {
               state,
               reconnectAttempts: attempts,
               lastConnectedAt,
-              endpoint: item.endpoint
+              endpoint: item.endpoint,
+              path: hostPaths[item.id] ?? 'lan'
             })
             return (
               <MobileHostCard

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -259,6 +259,10 @@ export default function HomeScreen() {
     () => Object.fromEntries(allClients.map(({ hostId, path }) => [hostId, path])),
     [allClients]
   )
+  const hostPendingPaths = useMemo(
+    () => Object.fromEntries(allClients.map(({ hostId, pendingPath }) => [hostId, pendingPath])),
+    [allClients]
+  )
   const disconnectHostClient = useDisconnectHostClient()
   const forgetHostClient = useForgetHostClient()
   const forceReconnectHost = useForceReconnect()
@@ -766,7 +770,7 @@ export default function HomeScreen() {
               reconnectAttempts: attempts,
               lastConnectedAt,
               endpoint: item.endpoint,
-              path: hostPaths[item.id] ?? 'lan'
+              pendingPath: hostPendingPaths[item.id] ?? null
             })
             return (
               <MobileHostCard

--- a/mobile/src/components/MobileHostCard.test.tsx
+++ b/mobile/src/components/MobileHostCard.test.tsx
@@ -94,22 +94,23 @@ describe('MobileHostCard', () => {
   it('names the relay while the dial is still in flight', async () => {
     const lines = await renderCard(undefined, {
       state: 'connecting',
-      verdict: { kind: 'normal', label: 'Connecting…' },
+      verdict: { kind: 'normal', label: 'Connecting via Relay…' },
       path: 'relay'
     })
 
-    expect(lines).toContain('Connecting…')
-    expect(lines).toContain(' · Orca Relay')
+    expect(lines).toContain('Connecting via Relay…')
+    expect(lines).not.toContain(' · Orca Relay')
   })
 
   it('names the relay while a failed direct dial is still retrying', async () => {
     const lines = await renderCard(undefined, {
       state: 'reconnecting',
-      verdict: { kind: 'normal', label: 'Reconnecting…' },
+      verdict: { kind: 'normal', label: 'Connecting via Relay…' },
       path: 'relay'
     })
 
-    expect(lines).toContain(' · Orca Relay')
+    expect(lines).toContain('Connecting via Relay…')
+    expect(lines).not.toContain(' · Orca Relay')
   })
 
   it('leaves an idle disconnected host unlabelled', async () => {

--- a/mobile/src/components/MobileHostCard.tsx
+++ b/mobile/src/components/MobileHostCard.tsx
@@ -25,11 +25,6 @@ export function MobileHostCard(props: {
   const credentialUnavailable = props.credentialStatus === 'temporarily-unavailable'
   const credentialMissing = props.credentialStatus === 'missing'
   const connected = props.state === 'connected' && !credentialUnavailable && !credentialMissing
-  // Why: a relay dial can run for seconds behind "Connecting…"/"Reconnecting…"; naming the
-  // path mid-wait tells the user the phone is off-LAN rather than hung (F5). Only 'relay' is
-  // named — 'lan' doubles as the unknown-path default, so it would be a guess before connect.
-  const dialingPath =
-    ['connecting', 'handshaking', 'reconnecting'].includes(props.state) && props.path === 'relay'
   const isError =
     credentialMissing || ['warning', 'unreachable', 'auth-failed'].includes(props.verdict.kind)
   const statusLabel = credentialMissing
@@ -44,7 +39,7 @@ export function MobileHostCard(props: {
       : props.verdict
   const worktreeSummary = homeHostWorktreeSummary(props.worktreeInfo)
   const connectionPathLabel =
-    !credentialMissing && !credentialUnavailable && (connected || dialingPath)
+    !credentialMissing && !credentialUnavailable && connected
       ? mobileConnectionPathLabel(props.path)
       : null
   const discoveryHint =

--- a/mobile/src/transport/client-context-connection-metrics.ts
+++ b/mobile/src/transport/client-context-connection-metrics.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useRpcClientContext, type RpcClientContextValue } from './client-context'
+import type { MobileConnectionPath } from './stable-logical-rpc-client'
 
 export function useReconnectAttempt(hostId: string | undefined): number {
   return useHostMetric(hostId, (context, id) => context.getReconnectAttempt(id), 0)
@@ -7,6 +8,10 @@ export function useReconnectAttempt(hostId: string | undefined): number {
 
 export function useLastConnectedAt(hostId: string | undefined): number | null {
   return useHostMetric(hostId, (context, id) => context.getLastConnectedAt(id), null)
+}
+
+export function useConnectionPath(hostId: string | undefined): MobileConnectionPath {
+  return useHostMetric(hostId, (context, id) => context.getActivePath(id), 'lan')
 }
 
 function useHostMetric<T>(

--- a/mobile/src/transport/client-context-connection-metrics.ts
+++ b/mobile/src/transport/client-context-connection-metrics.ts
@@ -10,8 +10,8 @@ export function useLastConnectedAt(hostId: string | undefined): number | null {
   return useHostMetric(hostId, (context, id) => context.getLastConnectedAt(id), null)
 }
 
-export function useConnectionPath(hostId: string | undefined): MobileConnectionPath {
-  return useHostMetric(hostId, (context, id) => context.getActivePath(id), 'lan')
+export function usePendingConnectionPath(hostId: string | undefined): MobileConnectionPath | null {
+  return useHostMetric(hostId, (context, id) => context.getPendingPath(id), null)
 }
 
 function useHostMetric<T>(

--- a/mobile/src/transport/client-context.test.ts
+++ b/mobile/src/transport/client-context.test.ts
@@ -414,7 +414,7 @@ describe('useAllHostClients', () => {
     connectMock.mockReturnValue(client)
     loadHostsMock.mockResolvedValue([HOST])
     let pendingPath: MobileConnectionPath | null | undefined
-    let renderer: ReturnType<typeof create> | null = null
+    let renderer!: ReturnType<typeof create>
 
     function Probe(): null {
       pendingPath = useAllHostClients([HOST.id])[0]?.pendingPath
@@ -430,7 +430,7 @@ describe('useAllHostClients', () => {
     act(() => client.emitPendingPath('relay'))
     expect(pendingPath).toBe('relay')
 
-    act(() => renderer?.unmount())
+    act(() => renderer.unmount())
   })
 
   it('only opens the requested startup subset', async () => {

--- a/mobile/src/transport/client-context.test.ts
+++ b/mobile/src/transport/client-context.test.ts
@@ -3,6 +3,7 @@ import { act, create, type ReactTestRenderer } from 'react-test-renderer'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ConnectionState } from './types'
 import type { RpcClient } from './rpc-client'
+import type { MobileConnectionPath } from './stable-logical-rpc-client'
 
 const connectMock = vi.fn()
 const loadHostsMock = vi.fn()
@@ -31,12 +32,15 @@ import { selectHomeAutoConnectHostIds } from './home-host-auto-connect'
 
 type FakeClient = RpcClient & {
   emitState: (state: ConnectionState) => void
+  emitPendingPath: (path: MobileConnectionPath | null) => void
   closeMock: ReturnType<typeof vi.fn>
 }
 
 function makeFakeClient(initialState: ConnectionState): FakeClient {
   let state = initialState
+  let pendingPath: MobileConnectionPath | null = null
   const listeners = new Set<(state: ConnectionState) => void>()
+  const pathListeners = new Set<() => void>()
   const closeMock = vi.fn()
   return {
     sendRequest: vi.fn(),
@@ -45,6 +49,12 @@ function makeFakeClient(initialState: ConnectionState): FakeClient {
     getState: () => state,
     getReconnectAttempt: () => 0,
     getLastConnectedAt: () => null,
+    getActivePath: () => 'tailscale',
+    getPendingPath: () => pendingPath,
+    onConnectionPathChange: (listener: () => void) => {
+      pathListeners.add(listener)
+      return () => pathListeners.delete(listener)
+    },
     onStateChange: (listener) => {
       listeners.add(listener)
       return () => listeners.delete(listener)
@@ -56,6 +66,12 @@ function makeFakeClient(initialState: ConnectionState): FakeClient {
       state = next
       for (const listener of listeners) {
         listener(next)
+      }
+    },
+    emitPendingPath: (next) => {
+      pendingPath = next
+      for (const listener of pathListeners) {
+        listener()
       }
     }
   } as FakeClient
@@ -393,6 +409,30 @@ describe('useHostClient', () => {
 })
 
 describe('useAllHostClients', () => {
+  it('rerenders when Relay becomes pending without a transport-state change', async () => {
+    const client = makeFakeClient('reconnecting')
+    connectMock.mockReturnValue(client)
+    loadHostsMock.mockResolvedValue([HOST])
+    let pendingPath: MobileConnectionPath | null | undefined
+    let renderer: ReactTestRenderer | null = null
+
+    function Probe(): null {
+      pendingPath = useAllHostClients([HOST.id])[0]?.pendingPath
+      return null
+    }
+
+    await act(async () => {
+      renderer = create(createElement(RpcClientProvider, null, createElement(Probe)))
+      await Promise.resolve()
+    })
+    expect(pendingPath).toBeNull()
+
+    act(() => client.emitPendingPath('relay'))
+    expect(pendingPath).toBe('relay')
+
+    act(() => renderer?.unmount())
+  })
+
   it('only opens the requested startup subset', async () => {
     const host2 = { ...HOST, id: 'host-2', name: 'Host 2' }
     connectMock.mockReturnValue(makeFakeClient('connected'))

--- a/mobile/src/transport/client-context.test.ts
+++ b/mobile/src/transport/client-context.test.ts
@@ -414,7 +414,7 @@ describe('useAllHostClients', () => {
     connectMock.mockReturnValue(client)
     loadHostsMock.mockResolvedValue([HOST])
     let pendingPath: MobileConnectionPath | null | undefined
-    let renderer: ReactTestRenderer | null = null
+    let renderer: ReturnType<typeof create> | null = null
 
     function Probe(): null {
       pendingPath = useAllHostClients([HOST.id])[0]?.pendingPath

--- a/mobile/src/transport/client-context.tsx
+++ b/mobile/src/transport/client-context.tsx
@@ -76,6 +76,7 @@ export function RpcClientProvider({ children }: { children: ReactNode }) {
       primedHostsRef.current.delete(hostId)
     }
     entry?.unsubState()
+    entry?.unsubConnectionPath()
     storeRef.current.delete(hostId)
     entry?.client.close()
     notifyHostState(hostId, 'disconnected')
@@ -242,6 +243,7 @@ export function RpcClientProvider({ children }: { children: ReactNode }) {
       manualDemandRef.current.add(hostId)
       if (entry) {
         entry.unsubState()
+        entry.unsubConnectionPath()
         entry.client.close()
         storeRef.current.delete(hostId)
       }
@@ -260,8 +262,10 @@ export function RpcClientProvider({ children }: { children: ReactNode }) {
     [openEntry]
   )
 
-  const { getKnownState, getState, getReconnectAttempt, getLastConnectedAt, getActivePath } =
-    useMemo(() => createHostClientSelectors(storeRef.current, pendingOpensRef.current), [])
+  const selectors = useMemo(
+    () => createHostClientSelectors(storeRef.current, pendingOpensRef.current),
+    []
+  )
 
   const subscribeHostState = useCallback(
     (hostId: string, listener: (state: ConnectionState) => void) =>
@@ -318,11 +322,7 @@ export function RpcClientProvider({ children }: { children: ReactNode }) {
       refreshHostClient,
       forgetHostClient,
       disconnectHostClient,
-      getState,
-      getKnownState,
-      getReconnectAttempt,
-      getLastConnectedAt,
-      getActivePath,
+      ...selectors,
       subscribeHostState,
       getAllClients,
       subscribeAllHosts,
@@ -337,11 +337,7 @@ export function RpcClientProvider({ children }: { children: ReactNode }) {
       refreshHostClient,
       forgetHostClient,
       disconnectHostClient,
-      getState,
-      getKnownState,
-      getReconnectAttempt,
-      getLastConnectedAt,
-      getActivePath,
+      selectors,
       subscribeHostState,
       getAllClients,
       subscribeAllHosts,

--- a/mobile/src/transport/connection-health.test.ts
+++ b/mobile/src/transport/connection-health.test.ts
@@ -25,7 +25,8 @@ describe('classifyConnection Tailscale hint', () => {
     const verdict = classifyConnection({
       ...base,
       reconnectAttempts: 3,
-      endpoint: 'ws://100.65.9.106:6768'
+      endpoint: 'ws://100.65.9.106:6768',
+      path: 'tailscale'
     })
     expect(verdict).toMatchObject({ kind: 'warning', hint: 'check Tailscale' })
   })
@@ -68,6 +69,20 @@ describe('classifyConnection Tailscale hint', () => {
       nowMs: 1_000_000
     })
     expect(verdict).toEqual({ kind: 'normal', label: 'Connected' })
+  })
+
+  it('presents an in-flight relay fallback instead of the failed Tailscale path', () => {
+    const incident = {
+      ...base,
+      reconnectAttempts: 5,
+      endpoint: 'ws://100.88.90.25:6768',
+      path: 'relay' as const
+    }
+
+    const verdict = classifyConnection(incident)
+
+    expect(verdict).toEqual({ kind: 'normal', label: 'Connecting via Relay…' })
+    expect(verdictDisplayLabel(verdict)).not.toContain('Tailscale')
   })
 })
 

--- a/mobile/src/transport/connection-health.test.ts
+++ b/mobile/src/transport/connection-health.test.ts
@@ -26,7 +26,7 @@ describe('classifyConnection Tailscale hint', () => {
       ...base,
       reconnectAttempts: 3,
       endpoint: 'ws://100.65.9.106:6768',
-      path: 'tailscale'
+      pendingPath: null
     })
     expect(verdict).toMatchObject({ kind: 'warning', hint: 'check Tailscale' })
   })
@@ -76,12 +76,29 @@ describe('classifyConnection Tailscale hint', () => {
       ...base,
       reconnectAttempts: 5,
       endpoint: 'ws://100.88.90.25:6768',
-      path: 'relay' as const
+      pendingPath: 'relay' as const
     }
 
-    const verdict = classifyConnection(incident)
+    for (const state of ['connecting', 'handshaking', 'reconnecting', 'disconnected'] as const) {
+      const verdict = classifyConnection({ ...incident, state })
+      expect(verdict).toEqual({ kind: 'normal', label: 'Connecting via Relay…' })
+      expect(verdictDisplayLabel(verdict)).not.toContain('Tailscale')
+    }
+  })
 
-    expect(verdict).toEqual({ kind: 'normal', label: 'Connecting via Relay…' })
+  it('escalates a prolonged relay recovery without reviving the Tailscale hint', () => {
+    const verdict = classifyConnection({
+      ...base,
+      reconnectAttempts: 12,
+      endpoint: 'ws://100.88.90.25:6768',
+      pendingPath: 'relay'
+    })
+
+    expect(verdict).toEqual({
+      kind: 'unreachable',
+      label: "Can't connect via Relay",
+      reason: 'never-connected'
+    })
     expect(verdictDisplayLabel(verdict)).not.toContain('Tailscale')
   })
 })

--- a/mobile/src/transport/connection-health.ts
+++ b/mobile/src/transport/connection-health.ts
@@ -50,7 +50,7 @@ export function classifyConnection(args: {
   // Optional pinned host endpoint — enables the Tailscale hint on
   // warning/unreachable verdicts. Callers without it get plain labels.
   endpoint?: string | null
-  path?: MobileConnectionPath
+  pendingPath?: MobileConnectionPath | null
   nowMs?: number
 }): ConnectionVerdict {
   const { state, reconnectAttempts, lastConnectedAt } = args
@@ -67,12 +67,20 @@ export function classifyConnection(args: {
     return { kind: 'normal', label: 'Connected' }
   }
 
-  if (state === 'disconnected') {
-    return { kind: 'normal', label: 'Disconnected' }
+  if (args.pendingPath === 'relay') {
+    if (reconnectAttempts >= UNREACHABLE_ATTEMPTS) {
+      if (lastConnectedAt == null) {
+        return { kind: 'unreachable', label: "Can't connect via Relay", reason: 'never-connected' }
+      }
+      if (now - lastConnectedAt >= STALE_SINCE_LAST_CONNECT_MS) {
+        return { kind: 'unreachable', label: "Can't connect via Relay", reason: 'stale' }
+      }
+    }
+    return { kind: 'normal', label: 'Connecting via Relay…' }
   }
 
-  if (args.path === 'relay') {
-    return { kind: 'normal', label: 'Connecting via Relay…' }
+  if (state === 'disconnected') {
+    return { kind: 'normal', label: 'Disconnected' }
   }
 
   // connecting / handshaking / reconnecting from here. The gates apply to all

--- a/mobile/src/transport/connection-health.ts
+++ b/mobile/src/transport/connection-health.ts
@@ -1,4 +1,5 @@
 import { isTailscaleEndpoint } from '../../../src/shared/remote-runtime-tailscale-hint'
+import type { MobileConnectionPath } from './stable-logical-rpc-client'
 import type { ConnectionState } from './types'
 
 // Why: thresholds for escalating connection UX from neutral
@@ -49,6 +50,7 @@ export function classifyConnection(args: {
   // Optional pinned host endpoint — enables the Tailscale hint on
   // warning/unreachable verdicts. Callers without it get plain labels.
   endpoint?: string | null
+  path?: MobileConnectionPath
   nowMs?: number
 }): ConnectionVerdict {
   const { state, reconnectAttempts, lastConnectedAt } = args
@@ -67,6 +69,10 @@ export function classifyConnection(args: {
 
   if (state === 'disconnected') {
     return { kind: 'normal', label: 'Disconnected' }
+  }
+
+  if (args.path === 'relay') {
+    return { kind: 'normal', label: 'Connecting via Relay…' }
   }
 
   // connecting / handshaking / reconnecting from here. The gates apply to all

--- a/mobile/src/transport/host-client-context-state.ts
+++ b/mobile/src/transport/host-client-context-state.ts
@@ -84,7 +84,9 @@ export function createHostClientSelectors(
     getLastConnectedAt: (hostId: string): number | null =>
       entries.get(hostId)?.client.getLastConnectedAt() ?? null,
     getActivePath: (hostId: string): MobileConnectionPath =>
-      clientActivePath(entries.get(hostId)?.client)
+      clientActivePath(entries.get(hostId)?.client),
+    getPendingPath: (hostId: string): MobileConnectionPath | null =>
+      clientPendingPath(entries.get(hostId)?.client)
   }
 }
 
@@ -95,4 +97,9 @@ export function clientActivePath(client: RpcClient | undefined): MobileConnectio
   }
   // Why: during migration the pending path is what the user is waiting on.
   return logical.getPendingPath?.() ?? logical.getActivePath()
+}
+
+export function clientPendingPath(client: RpcClient | undefined): MobileConnectionPath | null {
+  const logical = client as Partial<StableLogicalRpcClient> | undefined
+  return logical?.getPendingPath?.() ?? null
 }

--- a/mobile/src/transport/host-entry-opener.ts
+++ b/mobile/src/transport/host-entry-opener.ts
@@ -4,6 +4,7 @@ import { openHostLogicalClient } from './host-logical-client'
 import type { HostClientOpenRegistry } from './host-client-open-registry'
 import type { HostOpenRetryScheduler } from './host-open-retry-scheduler'
 import type { RpcClient } from './rpc-client'
+import type { StableLogicalRpcClient } from './stable-logical-rpc-client'
 import type { ConnectionState, HostProfile } from './types'
 
 export type HostClientStoreEntry = {
@@ -11,6 +12,7 @@ export type HostClientStoreEntry = {
   state: ConnectionState
   refCount: number
   unsubState: () => void
+  unsubConnectionPath: () => void
 }
 
 type HostEntryOpenerState = {
@@ -113,11 +115,20 @@ export async function openHostClientEntry(
       current.state = next
       state.notifyHostState(hostId, next)
     })
+    const logical = client as Partial<StableLogicalRpcClient>
+    const unsubConnectionPath =
+      logical.onConnectionPathChange?.(() => {
+        const current = state.store.get(hostId)
+        if (current) {
+          state.notifyHostState(hostId, current.state)
+        }
+      }) ?? (() => {})
     const entry: HostClientStoreEntry = {
       client,
       state: client.getState(),
       refCount: state.pendingAcquisitions.get(hostId) ?? 0,
-      unsubState
+      unsubState,
+      unsubConnectionPath
     }
     state.pendingAcquisitions.delete(hostId)
     state.store.set(hostId, entry)

--- a/mobile/src/transport/logical-client-connection-path.ts
+++ b/mobile/src/transport/logical-client-connection-path.ts
@@ -1,0 +1,45 @@
+import type { MobileConnectionPath } from './stable-logical-rpc-client'
+
+export class LogicalClientConnectionPath {
+  private migration: MobileConnectionPath | null = null
+  private recovery: MobileConnectionPath | null = null
+  private readonly listeners = new Set<() => void>()
+
+  constructor(private readonly isConnected: () => boolean) {}
+
+  pending(): MobileConnectionPath | null {
+    return this.isConnected() ? null : (this.migration ?? this.recovery)
+  }
+
+  setMigration(path: MobileConnectionPath | null): void {
+    this.update(() => {
+      this.migration = path
+    })
+  }
+
+  clearMigrationAfterConnected(): void {
+    this.migration = null
+  }
+
+  setRecovery(path: MobileConnectionPath | null): void {
+    this.update(() => {
+      this.recovery = path
+    })
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
+  }
+
+  private update(apply: () => void): void {
+    const previous = this.pending()
+    apply()
+    if (previous === this.pending()) {
+      return
+    }
+    for (const listener of this.listeners) {
+      listener()
+    }
+  }
+}

--- a/mobile/src/transport/mobile-endpoint-supervisor-test-fakes.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor-test-fakes.ts
@@ -65,6 +65,7 @@ export class FakeRelaySession extends FakeSession implements MobileRelayRpcSessi
 
 export class FakeLogicalClient extends FakeSession implements StableLogicalRpcClient {
   private path: MobileConnectionPath
+  private recoveryPath: MobileConnectionPath | null = null
   private generation = 1
 
   constructor(state: ConnectionState, path: MobileConnectionPath) {
@@ -95,8 +96,11 @@ export class FakeLogicalClient extends FakeSession implements StableLogicalRpcCl
   )
   suspendActiveSession = vi.fn(() => this.publishState('disconnected'))
   getActivePath = () => this.path
-  // This fake migrates instantly, so no dial is ever in flight to name.
-  getPendingPath = () => null
+  getPendingPath = () => this.recoveryPath
+  setRecoveryPath = vi.fn((path: MobileConnectionPath | null) => {
+    this.recoveryPath = path
+  })
+  onConnectionPathChange = vi.fn(() => () => {})
   getGeneration = () => this.generation
 }
 

--- a/mobile/src/transport/mobile-endpoint-supervisor.test.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.test.ts
@@ -91,6 +91,24 @@ describe('mobile endpoint supervisor', () => {
     supervisor.stop()
   })
 
+  it('keeps Relay pending through a failed dial cooldown and clears it on stop', async () => {
+    const logical = new FakeLogicalClient('reconnecting', 'lan')
+    const deps = dependencies({
+      openRelay: vi.fn(() => new FakeRelaySession('disconnected', new RelayOuterError(4408))),
+      randomBytes: () => new Uint8Array([128, 0])
+    })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+
+    expect(logical.getPendingPath()).toBe('relay')
+    await vi.advanceTimersByTimeAsync(249)
+    expect(logical.getPendingPath()).toBe('relay')
+
+    supervisor.stop()
+    expect(logical.getPendingPath()).toBeNull()
+  })
+
   it('does not spend a queued relay retry while direct authentication is progressing', async () => {
     const logical = new FakeLogicalClient('disconnected', 'lan')
     const openRelay = vi.fn(() => new FakeRelaySession('disconnected', new RelayOuterError(4408)))

--- a/mobile/src/transport/mobile-endpoint-supervisor.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.ts
@@ -146,6 +146,7 @@ export class MobileEndpointSupervisor {
     }
     this.unsubscribeState = this.logical.onStateChange((state) => {
       if (state === 'connected') {
+        this.logical.setRecoveryPath(null)
         this.directGrace.clear()
         if (this.logical.getActivePath() !== 'relay') {
           void this.rotateCredentialIfNeeded(this.relayReconnect.resetForDirectConnection())
@@ -154,12 +155,16 @@ export class MobileEndpointSupervisor {
       } else {
         // Why: the direct client enters reconnecting after its first failed
         // dial and may never publish disconnected while its retry loop lives.
+        if (this.relayReconnect.needsRecovery(state)) {
+          this.logical.setRecoveryPath('relay')
+        }
         this.relayReconnect.handleStateFailure(this.logical, state)
       }
     })
     if (this.relayReconnect.needsRecovery(this.logical.getState())) {
       // Why: the first direct dial can fail while encrypted relay credentials
       // are still loading, before the supervisor subscribes to state changes.
+      this.logical.setRecoveryPath('relay')
       await this.recoverRelay()
     } else {
       this.directProbe.schedule()
@@ -171,6 +176,9 @@ export class MobileEndpointSupervisor {
     const wasForeground = this.foreground
     this.foreground = foreground
     if (foreground) {
+      if (this.relayReconnect.needsRecovery(this.logical.getState())) {
+        this.logical.setRecoveryPath('relay')
+      }
       this.relayReconnect.handleForeground(this.logical, wasForeground)
       this.directProbe.schedule(0)
       this.directGrace.arm()
@@ -181,6 +189,7 @@ export class MobileEndpointSupervisor {
       this.relayReconnect.clear()
       this.leaseRotation.clear()
       this.directGrace.clear()
+      this.logical.setRecoveryPath(null)
     }
   }
 
@@ -191,11 +200,11 @@ export class MobileEndpointSupervisor {
   stop(): void {
     this.stopped = true
     this.unsubscribeState?.()
-    this.unsubscribeState = null
     this.directProbe.clear()
     this.relayReconnect.clear()
     this.leaseRotation.clear()
     this.directGrace.clear()
+    this.logical.setRecoveryPath(null)
   }
 
   // forceReplacement: dial past the "direct still looks live" guard — a lease

--- a/mobile/src/transport/mobile-relay-runtime-failover.test.ts
+++ b/mobile/src/transport/mobile-relay-runtime-failover.test.ts
@@ -90,6 +90,8 @@ class FakeRelaySession extends FakeSession implements MobileRelayRpcSession {
 
 class FakeLogicalClient extends FakeSession implements StableLogicalRpcClient {
   private path: MobileConnectionPath
+  private recoveryPath: MobileConnectionPath | null = null
+  private generation = 1
 
   constructor(state: ConnectionState, path: MobileConnectionPath) {
     super(state)
@@ -102,10 +104,18 @@ class FakeLogicalClient extends FakeSession implements StableLogicalRpcClient {
       throw new Error(`replacement session ${session.getState()}`)
     }
     this.path = path
+    this.recoveryPath = null
+    this.generation += 1
     this.publishState('connected')
   })
   suspendActiveSession = vi.fn(() => this.publishState('disconnected'))
   getActivePath = () => this.path
+  getPendingPath = () => this.recoveryPath
+  setRecoveryPath = vi.fn((path: MobileConnectionPath | null) => {
+    this.recoveryPath = path
+  })
+  onConnectionPathChange = vi.fn(() => () => {})
+  getGeneration = () => this.generation
 }
 
 const relay = {

--- a/mobile/src/transport/rpc-client-context-contract.ts
+++ b/mobile/src/transport/rpc-client-context-contract.ts
@@ -21,6 +21,7 @@ export type RpcClientContextValue = {
   getReconnectAttempt: (hostId: string) => number
   getLastConnectedAt: (hostId: string) => number | null
   getActivePath: (hostId: string) => MobileConnectionPath
+  getPendingPath: (hostId: string) => MobileConnectionPath | null
   subscribeHostState: (hostId: string, listener: (state: ConnectionState) => void) => () => void
   getAllClients: () => { hostId: string; client: RpcClient }[]
   subscribeAllHosts: (listener: () => void) => () => void

--- a/mobile/src/transport/stable-logical-rpc-client.test.ts
+++ b/mobile/src/transport/stable-logical-rpc-client.test.ts
@@ -4,7 +4,8 @@ import type { RpcClient } from './rpc-client'
 import { isRpcDeliveryUnknown, markRpcDeliveryUnknown } from './rpc-delivery-ambiguity'
 import {
   createStableLogicalRpcClient,
-  LogicalClientCutoverError
+  LogicalClientCutoverError,
+  type MobileConnectionPath
 } from './stable-logical-rpc-client'
 
 class FakeSession implements RpcClient {
@@ -259,10 +260,13 @@ describe('stable logical RPC client', () => {
     const client = createStableLogicalRpcClient(direct, 'lan')
     direct.setState('reconnecting')
     const states: ConnectionState[] = []
+    const paths: (MobileConnectionPath | null)[] = []
     client.onStateChange((next) => states.push(next))
+    client.onConnectionPathChange(() => paths.push(client.getPendingPath()))
 
     const migrating = client.migrateTo(replacement, 'relay')
     expect(client.getPendingPath()).toBe('relay')
+    expect(paths).toEqual(['relay'])
     replacement.setState('connecting')
     replacement.setState('handshaking')
 
@@ -276,6 +280,26 @@ describe('stable logical RPC client', () => {
     expect(states).toEqual(['connected'])
     expect(client.getPendingPath()).toBeNull()
     expect(client.getActivePath()).toBe('relay')
+  })
+
+  it('publishes recovery-path changes and keeps Relay pending between failed dials', async () => {
+    const direct = new FakeSession('reconnecting')
+    const replacement = new FakeSession('connecting')
+    const client = createStableLogicalRpcClient(direct, 'tailscale')
+    const paths: (MobileConnectionPath | null)[] = []
+    client.onConnectionPathChange(() => paths.push(client.getPendingPath()))
+
+    client.setRecoveryPath('relay')
+    const migrating = client.migrateTo(replacement, 'relay')
+    replacement.setState('disconnected')
+    await expect(migrating).rejects.toThrow(/disconnected/)
+
+    expect(client.getPendingPath()).toBe('relay')
+    expect(paths).toEqual(['relay'])
+
+    client.setRecoveryPath(null)
+    expect(client.getPendingPath()).toBeNull()
+    expect(paths).toEqual(['relay', null])
   })
 
   it('drops the pending path when the previous session recovers mid-dial', async () => {

--- a/mobile/src/transport/stable-logical-rpc-client.ts
+++ b/mobile/src/transport/stable-logical-rpc-client.ts
@@ -6,6 +6,7 @@ import {
 } from './migration-dial-state-forwarder'
 import { waitForAuthenticated } from './replacement-session-authentication'
 import { projectMobileRpcRequestParams } from './mobile-rpc-request-projection'
+import { LogicalClientConnectionPath } from './logical-client-connection-path'
 
 export type MobileConnectionPath = 'lan' | 'tailscale' | 'relay'
 
@@ -47,9 +48,10 @@ export type StableLogicalRpcClient = RpcClient & {
   ): Promise<void>
   suspendActiveSession(): void
   getActivePath(): MobileConnectionPath
-  // Non-null only while a migration dial is publishing its own phases — the path the
-  // user is waiting on, which the still-bound active path can't name.
+  // The path the user is waiting on while migration or scheduled recovery is active.
   getPendingPath(): MobileConnectionPath | null
+  setRecoveryPath(path: MobileConnectionPath | null): void
+  onConnectionPathChange(listener: () => void): () => void
   getGeneration(): number
 }
 
@@ -59,7 +61,6 @@ export function createStableLogicalRpcClient(
 ): StableLogicalRpcClient {
   let activeSession = initialSession
   let activePath = initialPath
-  let pendingPath: MobileConnectionPath | null = null
   let generation = 1
   let closed = false
   let suspended = false
@@ -69,6 +70,7 @@ export function createStableLogicalRpcClient(
   const pendingRequests = new Set<PendingRequest>()
   const stateListeners = new Set<(state: ConnectionState) => void>()
   let state = initialSession.getState()
+  const connectionPath = new LogicalClientConnectionPath(() => state === 'connected')
 
   bindActiveState(initialSession, generation)
 
@@ -207,7 +209,7 @@ export function createStableLogicalRpcClient(
       // (direct dial fails) sits in 'reconnecting' — already amber, so forwarding adds
       // nothing, but the user still has no idea relay is what's being tried.
       if (suspended || state !== 'connected') {
-        pendingPath = path
+        connectionPath.setMigration(path)
       }
       const forwarder = forwardMigrationDialState({
         session: nextSession,
@@ -259,6 +261,7 @@ export function createStableLogicalRpcClient(
       }
       pendingRequests.clear()
       state = nextSession.getState()
+      connectionPath.clearMigrationAfterConnected()
       for (const listener of stateListeners) {
         listener(state)
       }
@@ -268,7 +271,9 @@ export function createStableLogicalRpcClient(
     getActivePath: () => activePath,
     // Why: a previous session that recovers mid-dial makes the pending path a lie —
     // once we're connected the user is no longer waiting on anything.
-    getPendingPath: () => (state === 'connected' ? null : pendingPath),
+    getPendingPath: () => connectionPath.pending(),
+    setRecoveryPath: (path) => connectionPath.setRecovery(path),
+    onConnectionPathChange: (listener) => connectionPath.subscribe(listener),
     getGeneration: () => generation
   }
 
@@ -276,7 +281,9 @@ export function createStableLogicalRpcClient(
 
   function endDialForwarding(forwarder: MigrationDialStateForwarder, failed: boolean): void {
     forwarder.stop()
-    pendingPath = null
+    if (failed) {
+      connectionPath.setMigration(null)
+    }
     // Why: only walk back phases we published ourselves — a 'connected' here came from
     // the still-live previous session and outranks the dead dial.
     if (failed && forwarder.forwarded() && state !== 'connected') {

--- a/mobile/src/transport/use-all-host-clients.ts
+++ b/mobile/src/transport/use-all-host-clients.ts
@@ -136,10 +136,19 @@ export function useAllHostClients(hostIds: string[], options?: UseAllHostClients
       client: RpcClient
       state: ConnectionState
       path: MobileConnectionPath
+      pendingPath: MobileConnectionPath | null
     }>((hostId) => {
       const client = clientsByHostId.get(hostId)
       return client
-        ? [{ hostId, client, state: ctx.getState(hostId), path: ctx.getActivePath(hostId) }]
+        ? [
+            {
+              hostId,
+              client,
+              state: ctx.getState(hostId),
+              path: ctx.getActivePath(hostId),
+              pendingPath: ctx.getPendingPath(hostId)
+            }
+          ]
         : []
     })
   }, [ctx, hostIds, tick])


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​132 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​125 |
| Prod | 17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​175 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​44 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​131 |

<!-- /orca-pr-loc -->

## Summary

- track Relay recovery separately from the currently bound direct/Tailscale session
- notify mobile connection surfaces when that pending path changes, even if the transport state does not
- show `Connecting via Relay…` during normal fallback and failed-dial cooldowns
- retain the existing prolonged-outage escalation as `Can't connect via Relay`, without a contradictory Tailscale hint

## Deterministic reproduction

The incident state is a Tailscale direct session at `100.88.90.25:6768` with five failed reconnect attempts while the mobile endpoint supervisor has scheduled Relay recovery.

The same injected state-machine oracle produces:

- main / candidate branch with the presentation branch disabled: `Can't connect — check Tailscale`
- this PR: `Connecting via Relay…`

The tests also hold the Relay presentation through a failed dial cooldown, verify that a path-only change rerenders consumers, clear it on connection/background/stop, and restore a Relay-specific unreachable verdict at the existing 12-attempt long-outage threshold.

## Transport and traffic impact

None. The new state is in-memory presentation metadata. It adds no Relay requests, probes, timers, retries, sockets, wire fields, or background Relay occupancy. Happy-path and failure-path Relay traffic are unchanged.

The transient Relay director `503` visible in the field log can still delay fallback; this PR reports that fallback accurately but does not change Relay director availability or retry cadence.

## Validation

- three independent OpenCode reviews in the same worktree: all approve after two legitimate first-pass findings were fixed
- full mobile suite: 448 files passed; 3,526 tests passed; 3 skipped
- focused mobile transport suite: 109 tests passed
- reliability lifecycle gate: 11 files; 84 tests passed
- mobile TypeScript and lint passed
- changed-code quality and React checks reported no new findings
- reliability manifest, max-lines ratchet, formatting, and `git diff --check` passed

## Remaining gap

An already-active Relay session reports reconnect attempt `0`, so its historical long-outage escalation can remain neutral. That behavior predates this PR and is neither caused nor worsened here. Physical iOS/Android sleep and production-network validation remain live-test gaps.
