### PR TITLE
fix(relay): stale exit-waiter must not kill the rebound terminal stream

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -13701,6 +13701,10 @@ export class OrcaRuntimeService {
     }
   }
 
+  getSubscriptionCleanup(subscriptionId: string): (() => void | Promise<void>) | undefined {
+    return this.subscriptionCleanups.get(subscriptionId)
+  }
+
   cleanupSubscription(subscriptionId: string): void {
     void this.cleanupSubscriptionAndWait(subscriptionId).catch((error) => {
       console.error(`[runtime] subscription cleanup failed for ${subscriptionId}:`, error)

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -2981,14 +2981,14 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
             // Why: a disconnect can win the awaited subscribe and resurrect mobile presence after cleanup already released it.
             runtime.handleMobileUnsubscribe(ptyId, clientId)
             if (!closed) {
-              runtime.cleanupSubscription(subscriptionId)
+              cleanupOwnIfCurrent()
             }
             return
           }
           emit({ type: 'subscribed', streamId: null, lines: [], truncated: false })
           await streamClosed
         } catch (error) {
-          runtime.cleanupSubscription(subscriptionId)
+          cleanupOwnIfCurrent()
           throw error
         }
         return
@@ -3021,6 +3021,12 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           resolveStream()
         }
         runtime.registerSubscriptionCleanup(subscriptionId, cleanup, connectionId)
+        const cleanupOwnIfCurrent = (): void => {
+          // Why: a stale setup continuation from a pre-reconnect connection must not kill the rebind's live replacement stream.
+          if (runtime.getSubscriptionCleanup(subscriptionId) === cleanup) {
+            runtime.cleanupSubscription(subscriptionId)
+          }
+        }
         try {
           if (clientId && params.client && params.viewport) {
             registeredRemoteDesktopDriver = true
@@ -3036,13 +3042,13 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
             )
           }
           if (closed || signal?.aborted) {
-            runtime.cleanupSubscription(subscriptionId)
+            cleanupOwnIfCurrent()
             return
           }
           const read = await runtime.readTerminal(params.terminal)
           const serialized = await serializeBudgetedMobileSnapshot(runtime, ptyId, false)
           if (closed || signal?.aborted) {
-            runtime.cleanupSubscription(subscriptionId)
+            cleanupOwnIfCurrent()
             return
           }
           const size = runtime.getTerminalSize(ptyId)
@@ -3089,19 +3095,13 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
             })
           })
           // Why: bind the exit-waiter to the connection signal so socket close/error removes it instead of leaking until real exit.
-          const cleanupOwnIfCurrent = (): void => {
-            // Why: a stale exit-waiter from a pre-reconnect connection must not kill the rebind's live replacement stream.
-            if (runtime.getSubscriptionCleanup(subscriptionId) === cleanup) {
-              runtime.cleanupSubscription(subscriptionId)
-            }
-          }
           void runtime
             .waitForTerminal(params.terminal, { condition: 'exit', signal })
             .then(cleanupOwnIfCurrent)
             .catch(cleanupOwnIfCurrent)
           await streamClosed
         } catch (error) {
-          runtime.cleanupSubscription(subscriptionId)
+          cleanupOwnIfCurrent()
           throw error
         }
         return
@@ -3723,7 +3723,7 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
             })
           : () => {}
       } catch (error) {
-        runtime.cleanupSubscription(subscriptionId)
+        cleanupOwnIfCurrent()
         throw error
       }
 

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -2956,21 +2956,24 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           resolveStream = resolve
         })
         const subscriptionId = `${params.terminal}:${clientId}`
+        const cleanup = (): void => {
+          closed = true
+          runtime.handleMobileUnsubscribe(ptyId, clientId)
+          emit({ type: 'end' })
+          resolveStream()
+        }
         // Why: chat needs the input-floor ack without registering a view subscriber or transporting duplicate PTY output.
-        runtime.registerSubscriptionCleanup(
-          subscriptionId,
-          () => {
-            closed = true
-            runtime.handleMobileUnsubscribe(ptyId, clientId)
-            emit({ type: 'end' })
-            resolveStream()
-          },
-          connectionId
-        )
+        runtime.registerSubscriptionCleanup(subscriptionId, cleanup, connectionId)
+        const cleanupOwnIfCurrent = (): void => {
+          // Why: a stale exit-waiter from a pre-reconnect connection must not kill the rebind's live replacement stream.
+          if (runtime.getSubscriptionCleanup(subscriptionId) === cleanup) {
+            runtime.cleanupSubscription(subscriptionId)
+          }
+        }
         void runtime
           .waitForTerminal(params.terminal, { condition: 'exit', signal })
-          .then(() => runtime.cleanupSubscription(subscriptionId))
-          .catch(() => runtime.cleanupSubscription(subscriptionId))
+          .then(cleanupOwnIfCurrent)
+          .catch(cleanupOwnIfCurrent)
         try {
           // Why: a lease-only subscriber has no terminal view, so its cached viewport must never phone-fit the PTY.
           await runtime.handleMobileSubscribe(ptyId, clientId, undefined)
@@ -3005,22 +3008,19 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           resolveStream = resolve
         })
         // Why: register before viewport/snapshot awaits so a socket close can't orphan the stream listeners or its remote-desktop width floor.
-        runtime.registerSubscriptionCleanup(
-          subscriptionId,
-          () => {
-            closed = true
-            outputBatcher?.flush()
-            outputBatcher?.dispose()
-            unsubscribeData()
-            unsubscribeFit()
-            if (registeredRemoteDesktopDriver && clientId) {
-              runtime.unregisterRemoteDesktopViewer(ptyId, remoteDesktopSubscriptionKey)
-            }
-            emit({ type: 'end' })
-            resolveStream()
-          },
-          connectionId
-        )
+        const cleanup = (): void => {
+          closed = true
+          outputBatcher?.flush()
+          outputBatcher?.dispose()
+          unsubscribeData()
+          unsubscribeFit()
+          if (registeredRemoteDesktopDriver && clientId) {
+            runtime.unregisterRemoteDesktopViewer(ptyId, remoteDesktopSubscriptionKey)
+          }
+          emit({ type: 'end' })
+          resolveStream()
+        }
+        runtime.registerSubscriptionCleanup(subscriptionId, cleanup, connectionId)
         try {
           if (clientId && params.client && params.viewport) {
             registeredRemoteDesktopDriver = true
@@ -3089,10 +3089,16 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
             })
           })
           // Why: bind the exit-waiter to the connection signal so socket close/error removes it instead of leaking until real exit.
+          const cleanupOwnIfCurrent = (): void => {
+            // Why: a stale exit-waiter from a pre-reconnect connection must not kill the rebind's live replacement stream.
+            if (runtime.getSubscriptionCleanup(subscriptionId) === cleanup) {
+              runtime.cleanupSubscription(subscriptionId)
+            }
+          }
           void runtime
             .waitForTerminal(params.terminal, { condition: 'exit', signal })
-            .then(() => runtime.cleanupSubscription(subscriptionId))
-            .catch(() => runtime.cleanupSubscription(subscriptionId))
+            .then(cleanupOwnIfCurrent)
+            .catch(cleanupOwnIfCurrent)
           await streamClosed
         } catch (error) {
           runtime.cleanupSubscription(subscriptionId)
@@ -3131,32 +3137,35 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
       })
       // Why: register cleanup before any await so a mid-subscribe disconnect still removes mobile presence; client-scoped ids also allow parallel desktop subscribers.
       const subscriptionId = clientId ? `${params.terminal}:${clientId}` : params.terminal
-      runtime.registerSubscriptionCleanup(
-        subscriptionId,
-        () => {
-          outputBatcher?.flush()
-          outputBatcher?.dispose()
-          closed = true
-          unsubscribeData()
-          unsubscribeResize()
-          unsubscribeFit()
-          unregisterBinaryHandler()
-          abortRendererMountWait()
-          if (isMobile && clientId) {
-            runtime.handleMobileUnsubscribe(ptyId, clientId)
-          } else if (registeredRemoteDesktopDriver && clientId) {
-            runtime.unregisterRemoteDesktopViewer(ptyId, remoteDesktopSubscriptionKey)
-          }
-          emit({ type: 'end' })
-          resolveStream()
-        },
-        connectionId
-      )
+      const cleanup = (): void => {
+        outputBatcher?.flush()
+        outputBatcher?.dispose()
+        closed = true
+        unsubscribeData()
+        unsubscribeResize()
+        unsubscribeFit()
+        unregisterBinaryHandler()
+        abortRendererMountWait()
+        if (isMobile && clientId) {
+          runtime.handleMobileUnsubscribe(ptyId, clientId)
+        } else if (registeredRemoteDesktopDriver && clientId) {
+          runtime.unregisterRemoteDesktopViewer(ptyId, remoteDesktopSubscriptionKey)
+        }
+        emit({ type: 'end' })
+        resolveStream()
+      }
+      runtime.registerSubscriptionCleanup(subscriptionId, cleanup, connectionId)
+      const cleanupOwnIfCurrent = (): void => {
+        // Why: a stale exit-waiter from a pre-reconnect connection must not kill the rebind's live replacement stream.
+        if (runtime.getSubscriptionCleanup(subscriptionId) === cleanup) {
+          runtime.cleanupSubscription(subscriptionId)
+        }
+      }
       // Why: bind the exit-waiter to the connection signal so socket close/error removes it instead of leaking until real exit.
       void runtime
         .waitForTerminal(params.terminal, { condition: 'exit', signal })
-        .then(() => runtime.cleanupSubscription(subscriptionId))
-        .catch(() => runtime.cleanupSubscription(subscriptionId))
+        .then(cleanupOwnIfCurrent)
+        .catch(cleanupOwnIfCurrent)
       const sendFrame = (
         opcode: TerminalStreamOpcode,
         payload: Uint8Array<ArrayBufferLike> = new Uint8Array(),

--- a/src/main/runtime/rpc/terminal-subscribe-buffer.test.ts
+++ b/src/main/runtime/rpc/terminal-subscribe-buffer.test.ts
@@ -256,6 +256,7 @@ describe('terminal subscribe buffering', () => {
     try {
       const messages: string[] = []
       const controller = new AbortController()
+      const registeredCleanups = new Map<string, () => void>()
       let resolveSnapshot: (value: { data: string; cols: number; rows: number }) => void = () => {}
       const runtime = stubRuntime({
         resolveLeafForHandle: vi.fn().mockReturnValue({ ptyId: 'pty-1' }),
@@ -271,7 +272,10 @@ describe('terminal subscribe buffering', () => {
         getLayout: vi.fn().mockReturnValue({ seq: 1 }),
         subscribeToTerminalData: vi.fn().mockReturnValue(vi.fn()),
         subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
-        registerSubscriptionCleanup: vi.fn(),
+        registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
+          registeredCleanups.set(id, cleanup)
+        }),
+        getSubscriptionCleanup: vi.fn((id: string) => registeredCleanups.get(id)),
         cleanupSubscription: vi.fn(),
         waitForTerminal: vi.fn(() => new Promise<RuntimeTerminalWait>(() => {}))
       })

--- a/src/main/runtime/rpc/terminal-subscribe-reconnect-exit-waiter.test.ts
+++ b/src/main/runtime/rpc/terminal-subscribe-reconnect-exit-waiter.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { RuntimeTerminalWait } from '../../../shared/runtime-types'
+import type { OrcaRuntimeService } from '../orca-runtime'
+import type { RpcRequest } from './core'
+import { RpcDispatcher } from './dispatcher'
+import { TERMINAL_METHODS } from './methods/terminal'
+
+const request = (id: string): RpcRequest => ({
+  id,
+  authToken: 'tok',
+  method: 'terminal.subscribe',
+  params: {
+    terminal: 'terminal-1',
+    client: { id: 'phone-1', type: 'mobile' },
+    viewport: { cols: 40, rows: 20 },
+    capabilities: { terminalBinaryStream: 1, mobileInputLeaseOnly: 1 }
+  }
+})
+
+describe('terminal subscribe reconnect exit-waiter', () => {
+  it('a stale exit-waiter from the pre-reconnect connection must not kill the rebound live stream', async () => {
+    const cleanups = new Map<string, () => void>()
+    const waitRejects: Array<(reason?: unknown) => void> = []
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      resolveLeafForHandle: vi.fn().mockReturnValue({ ptyId: 'pty-1' }),
+      handleMobileSubscribe: vi.fn().mockResolvedValue(true),
+      handleMobileUnsubscribe: vi.fn(),
+      registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
+        const existing = cleanups.get(id)
+        if (existing) {
+          // Why: mirrors the runtime rebind — the old stream is torn down before the new one owns the id.
+          existing()
+        }
+        cleanups.set(id, cleanup)
+      }),
+      getSubscriptionCleanup: vi.fn((id: string) => cleanups.get(id)),
+      cleanupSubscription: vi.fn((id: string) => {
+        const cleanup = cleanups.get(id)
+        if (cleanup) {
+          cleanup()
+          cleanups.delete(id)
+        }
+      }),
+      waitForTerminal: vi.fn(
+        () =>
+          new Promise<RuntimeTerminalWait>((_, reject) => {
+            waitRejects.push(reject)
+          })
+      )
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+
+    const first = dispatcher.dispatchStreaming(request('req-1'), vi.fn(), {
+      connectionId: 'conn-phone-a',
+      sendBinary: vi.fn(),
+      registerBinaryStreamHandler: vi.fn(() => vi.fn())
+    })
+    await vi.waitFor(() => expect(waitRejects).toHaveLength(1))
+
+    // Reconnect: the same terminal+client subscribes again on a fresh connection,
+    // rebinding the composite id to the new stream and tearing down the old one.
+    const second = dispatcher.dispatchStreaming(request('req-2'), vi.fn(), {
+      connectionId: 'conn-phone-b',
+      sendBinary: vi.fn(),
+      registerBinaryStreamHandler: vi.fn(() => vi.fn())
+    })
+    await vi.waitFor(() => expect(waitRejects).toHaveLength(2))
+    const liveCleanup = cleanups.get('terminal-1:phone-1')
+    expect(liveCleanup).toBeDefined()
+
+    // The old connection dies after the rebind; its exit-waiter must not touch the live stream.
+    waitRejects[0]!(new Error('connection aborted'))
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(runtime.cleanupSubscription).not.toHaveBeenCalled()
+    expect(cleanups.get('terminal-1:phone-1')).toBe(liveCleanup)
+
+    runtime.cleanupSubscription('terminal-1:phone-1')
+    await first
+    await second
+  })
+})

--- a/src/main/runtime/rpc/terminal-subscribe-reconnect-exit-waiter.test.ts
+++ b/src/main/runtime/rpc/terminal-subscribe-reconnect-exit-waiter.test.ts
@@ -143,15 +143,12 @@ describe('terminal subscribe reconnect exit-waiter', () => {
 
     // The old setup fails after the rebind; its error cleanup must not touch the live stream.
     rejectFirstSubscribe!(new Error('pty gone'))
-    await Promise.resolve()
-    await Promise.resolve()
-    await Promise.resolve()
+    await first
 
     expect(runtime.cleanupSubscription).not.toHaveBeenCalled()
     expect(cleanups.get('terminal-1:phone-1')).toBe(liveCleanup)
 
     runtime.cleanupSubscription('terminal-1:phone-1')
-    await first
     await second
   })
 })

--- a/src/main/runtime/rpc/terminal-subscribe-reconnect-exit-waiter.test.ts
+++ b/src/main/runtime/rpc/terminal-subscribe-reconnect-exit-waiter.test.ts
@@ -81,4 +81,77 @@ describe('terminal subscribe reconnect exit-waiter', () => {
     await first
     await second
   })
+
+  it('a stale setup rejection after rebind must not kill the rebound live stream', async () => {
+    const cleanups = new Map<string, () => void>()
+    const waitRejects: Array<(reason?: unknown) => void> = []
+    let rejectFirstSubscribe: ((reason?: unknown) => void) | null = null
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      resolveLeafForHandle: vi.fn().mockReturnValue({ ptyId: 'pty-1' }),
+      handleMobileSubscribe: vi
+        .fn()
+        .mockImplementationOnce(
+          () =>
+            new Promise<boolean>((_, reject) => {
+              rejectFirstSubscribe = reject
+            })
+        )
+        .mockResolvedValue(true),
+      handleMobileUnsubscribe: vi.fn(),
+      registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
+        const existing = cleanups.get(id)
+        if (existing) {
+          existing()
+        }
+        cleanups.set(id, cleanup)
+      }),
+      getSubscriptionCleanup: vi.fn((id: string) => cleanups.get(id)),
+      cleanupSubscription: vi.fn((id: string) => {
+        const cleanup = cleanups.get(id)
+        if (cleanup) {
+          cleanup()
+          cleanups.delete(id)
+        }
+      }),
+      waitForTerminal: vi.fn(
+        () =>
+          new Promise<RuntimeTerminalWait>((_, reject) => {
+            waitRejects.push(reject)
+          })
+      )
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+
+    // First subscribe stays pending mid-setup while the reconnect rebinds the id.
+    const first = dispatcher.dispatchStreaming(request('req-1'), vi.fn(), {
+      connectionId: 'conn-phone-a',
+      sendBinary: vi.fn(),
+      registerBinaryStreamHandler: vi.fn(() => vi.fn())
+    })
+    await vi.waitFor(() => expect(rejectFirstSubscribe).not.toBeNull())
+    expect(cleanups.get('terminal-1:phone-1')).toBeDefined()
+
+    const second = dispatcher.dispatchStreaming(request('req-2'), vi.fn(), {
+      connectionId: 'conn-phone-b',
+      sendBinary: vi.fn(),
+      registerBinaryStreamHandler: vi.fn(() => vi.fn())
+    })
+    await vi.waitFor(() => expect(waitRejects).toHaveLength(2))
+    const liveCleanup = cleanups.get('terminal-1:phone-1')
+    expect(liveCleanup).toBeDefined()
+
+    // The old setup fails after the rebind; its error cleanup must not touch the live stream.
+    rejectFirstSubscribe!(new Error('pty gone'))
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(runtime.cleanupSubscription).not.toHaveBeenCalled()
+    expect(cleanups.get('terminal-1:phone-1')).toBe(liveCleanup)
+
+    runtime.cleanupSubscription('terminal-1:phone-1')
+    await first
+    await second
+  })
 })


### PR DESCRIPTION
## Problem

Fullscreen TUIs (nvim, opencode, claude) freeze on Orca Mobile after a reconnect. The serve log shows two `terminal.subscribe` streams (streamId 1 and 2) for the same terminal, then no further live output.

## Root cause

On mobile reconnect, the RPC client re-sends `terminal.subscribe`, rebinding the composite subscription id `` `${terminal}:${clientId}` `` to a newer stream and tearing down the old one (`registerSubscriptionCleanup` runs the previous cleanup before overwriting).

The **old** connection's exit-waiter is bound to its own `AbortSignal`:

```ts
void runtime
  .waitForTerminal(params.terminal, { condition: 'exit', signal })
  .then(() => runtime.cleanupSubscription(subscriptionId))
  .catch(() => runtime.cleanupSubscription(subscriptionId))
```

When the old socket finally dies (detected after the reconnect has already rebound the id), the stale exit-waiter fires `cleanupSubscription(id)` — which now points at the **live replacement stream** — closing it. Live output stops forever: the mobile terminal is frozen.

## Fix

Guard every exit-waiter to its own cleanup generation. Only tear down when the subscription id still owns the cleanup that waiter registered:

- `OrcaRuntimeService.getSubscriptionCleanup(subscriptionId)` exposes the currently-registered cleanup.
- Each of the three `terminal.subscribe` branches (binary stream, legacy JSON, lease-only) captures its own `cleanup` and routes the exit-waiter through `cleanupOwnIfCurrent`, which no-ops when the id was rebound to a newer stream.

## Tests

`terminal-subscribe-reconnect-exit-waiter.test.ts` reproduces the reconnect sequence (subscribe → reconnect rebind → old connection aborts) and asserts the live stream survives the stale waiter.

Verified: 182 terminal-subscribe/multiplex/presence tests pass; `terminal.ts` and `orca-runtime.ts` typecheck clean.