### PR TITLE
fix(mobile): keep retired names on an RPC error and route the host's created name (STA-4479, STA-4480)

### DIFF
--- a/mobile/src/tasks/worktree-create-retry.test.ts
+++ b/mobile/src/tasks/worktree-create-retry.test.ts
@@ -173,6 +173,44 @@ describe('createWorktreeWithNameRetry', () => {
     expect(attempts.map((attempt) => attempt.params.name)).toEqual(['nautilus-2', 'nautilus-3'])
   })
 
+  it('routes to the name the host actually created, not the one this client proposed', async () => {
+    // The host advances past a retired cwd on its own, so the created workspace can carry a later
+    // candidate than the one sent. Routing on the proposal titles the workspace wrongly until the
+    // live-name hook catches up.
+    const client = {
+      sendRequest: async () => ({
+        id: '1',
+        ok: true,
+        result: { worktree: { id: 'wt-1', displayName: 'nautilus-4' } },
+        _meta: { runtimeId: 'r' }
+      })
+    } as unknown as RpcClient
+
+    await expect(
+      createWorktreeWithNameRetry({
+        client,
+        baseName: 'nautilus',
+        nameWasGenerated: true,
+        buildParams: (name) => ({ repo: 'id:r', name, nameWasGenerated: true }),
+        supportsIdempotentCutoverRetry: false
+      })
+    ).resolves.toEqual({ worktreeId: 'wt-1', name: 'nautilus-4' })
+  })
+
+  it('falls back to the proposed name when the host answers without one', async () => {
+    const attempts: Attempt[] = []
+    const client = scriptedClient([{ id: 'wt-1' }], attempts)
+
+    await expect(
+      createWorktreeWithNameRetry({
+        client,
+        baseName: 'otter',
+        buildParams: (name) => ({ repo: 'id:r', name }),
+        supportsIdempotentCutoverRetry: false
+      })
+    ).resolves.toEqual({ worktreeId: 'wt-1', name: 'otter' })
+  })
+
   it('does not replay an ambiguous cutover when the host lacks idempotency support', async () => {
     const attempts: Attempt[] = []
     const client = scriptedClient([{ throws: new LogicalClientCutoverError() }], attempts)

--- a/mobile/src/tasks/worktree-create-retry.ts
+++ b/mobile/src/tasks/worktree-create-retry.ts
@@ -67,8 +67,17 @@ export async function createWorktreeWithNameRetry(
       supportsIdempotentCutoverRetry
     )
     if (response.ok) {
-      const result = (response as RpcSuccess).result as { worktree: { id: string } }
-      return { worktreeId: result.worktree.id, name: candidateName }
+      const result = (response as RpcSuccess).result as {
+        worktree: { id: string; displayName?: unknown }
+      }
+      // Why not `candidateName`: the host advances past a retired cwd on its own, so the workspace
+      // it created can carry a later candidate than the one proposed here. Routing on the proposal
+      // titles the new workspace wrongly until the live-name hook corrects it.
+      const createdName = result.worktree.displayName
+      return {
+        worktreeId: result.worktree.id,
+        name: typeof createdName === 'string' && createdName ? createdName : candidateName
+      }
     }
     lastError = response.error.message
     if (!isRetryableWorktreeCreateConflict(lastError ?? '')) {

--- a/mobile/src/worktree/use-retired-worktree-names.test.tsx
+++ b/mobile/src/worktree/use-retired-worktree-names.test.tsx
@@ -46,19 +46,38 @@ function mountNames() {
         renderer.update(createElement(Probe, props))
       })
     },
+    /** Full RPC envelopes on purpose: a bare `{ result }` is not what the transport delivers, and
+     *  faking one is what let a resolved *error* envelope read as an empty registry. */
     async settle(
       index: number,
       retiredNamesByRepo: Record<string, unknown>,
       retiredNameTiersByRepo: Record<string, unknown> = {}
     ) {
       await act(async () => {
-        pending[index]!.resolve({ result: { retiredNamesByRepo, retiredNameTiersByRepo } })
+        pending[index]!.resolve({
+          id: '1',
+          ok: true,
+          result: { retiredNamesByRepo, retiredNameTiersByRepo },
+          _meta: { runtimeId: 'r' }
+        })
         await Promise.resolve()
       })
     },
     async fail(index: number) {
       await act(async () => {
         pending[index]!.reject(new Error('host unreachable'))
+        await Promise.resolve()
+      })
+    },
+    /** A host-side error: the RPC *resolves* carrying an error envelope, it does not reject. */
+    async refuse(index: number) {
+      await act(async () => {
+        pending[index]!.resolve({
+          id: '1',
+          ok: false,
+          error: { code: 'internal_error', message: 'registry unavailable' },
+          _meta: { runtimeId: 'r' }
+        })
         await Promise.resolve()
       })
     }
@@ -109,6 +128,18 @@ describe('useRetiredWorktreeNames', () => {
     await probe.fail(1)
 
     expect(probe.names).toEqual(['nautilus'])
+  })
+
+  // Regression: an RPC error envelope resolves rather than rejecting, so it slipped past the
+  // `.catch` and was read as "this repo has retired nothing", blanking the cache.
+  it('keeps previously loaded names when the host answers with an error', async () => {
+    const probe = mountNames()
+    await probe.settle(0, { 'repo-1': ['nautilus'] }, { 'repo-1': 2 })
+
+    probe.rerender({ repoId: 'repo-1', refreshKey: 'b' })
+    await probe.refuse(1)
+
+    expect(probe.registry).toEqual({ exhaustedTiers: 2, names: ['nautilus'] })
   })
 
   // Regression: the effect used to depend on [client, repoId] only, so a workspace created while

--- a/mobile/src/worktree/use-retired-worktree-names.ts
+++ b/mobile/src/worktree/use-retired-worktree-names.ts
@@ -38,10 +38,11 @@ export function useRetiredWorktreeNames(
     }
     void client
       .sendRequest('worktree.listRetiredNames', { repo: `id:${activeRepoId}` })
+      // Why the envelope check and not just `.catch`: an RPC error *resolves* carrying
+      // `ok: false`, so a host-side failure used to read as "this repo has retired nothing" and
+      // blank the cache — un-retiring every name until the next successful refresh.
       .then((response) =>
-        settle(
-          readRetiredNameRegistryForRepo((response as { result?: unknown }).result, activeRepoId)
-        )
+        settle(response.ok ? readRetiredNameRegistryForRepo(response.result, activeRepoId) : null)
       )
       .catch(() => settle(null))
     return () => {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​70 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​69 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​15 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 |

<!-- /orca-pr-loc -->

Fixes STA-4479 (P2) and STA-4480 (P2). Both regressions from #14350, both on mobile's
generated-name suggestion surface. Neither can leak history — the host still refuses reuse — so this
branches from `main` rather than the host-side stack (#14917 → #14919 → #14924); it shares no files
with it.

## STA-4479 — an RPC error blanked the retired-name cache

`RpcClient.sendRequest` **resolves** with `{ ok: false, error }` for a host-side failure; it only
rejects on transport failures. The hook read `response.result` unconditionally, so an error envelope
produced `undefined` → `readRetiredNameRegistryForRepo` returned an *empty* registry (not null) →
`retiredNamesAfterRefresh` stored it and overwrote the previous good answer. The `.catch` never saw
it.

Empty means "nothing is retired", which is the one direction `retired-name-cache.ts` exists to
prevent — its own doc says mobile "blanked the list on any error, which un-retires names". The
transport-level fix landed then; the envelope-level one did not.

Now the envelope decides: `response.ok ? read(response.result) : null`, and `null` already means
"hold the previous answer" in the shared cache rules.

**Test-harness correction, called out because it changes existing tests**: the hook's test client
resolved bare `{ result }` objects with no `ok` field, which the transport never delivers. That fake
is exactly what let this bug hide. The harness now emits real `RpcSuccess`/`RpcFailure` envelopes.

## STA-4480 — mobile routed the name it proposed, not the one the host created

`createWorktreeWithNameRetry` returned `{ worktreeId, name: candidateName }`. The host advances past
a retired cwd on its own, so the created workspace can carry a later candidate than the one sent —
and `onCreated(result.worktreeId, result.name)` then titles the new workspace wrongly until the
live-name hook corrects it.

It now prefers `result.worktree.displayName`, falling back to the proposal when a host answers
without one. No wire change: `displayName` is an existing required field on `Worktree`; the fallback
covers a malformed or unexpected envelope rather than a version skew.

## Tests

RED against unfixed production code (`git checkout origin/main -- <both files>`, tests kept — note
the 17 pre-existing tests still pass against the corrected harness, so only the two new assertions
fail):

```
FAIL worktree-create-retry.test.ts > routes to the name the host actually created, not the one this client proposed
  -   "name": "nautilus-4",
  +   "name": "nautilus",
FAIL use-retired-worktree-names.test.tsx > keeps previously loaded names when the host answers with an error
  -   "exhaustedTiers": 2,  "names": [ "nautilus" ],
  +   "exhaustedTiers": 0,  "names": [],
```

GREEN: full mobile suite, 3524 passed / 3 skipped across 448 files. `tsc -p mobile/tsconfig.json`
exit 0, oxlint exit 0.

## Not covered

Mobile emulator QA was not run for this change; both defects are asserted at the unit level only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
