### PR TITLE
fix(worktree): require host-qualified identity for workspace deletion (STA-4448)

### DIFF
--- a/src/renderer/src/components/sidebar/DeleteWorktreeDialog.tsx
+++ b/src/renderer/src/components/sidebar/DeleteWorktreeDialog.tsx
@@ -27,6 +27,7 @@ import {
   isFolderWorkspaceDelete as getIsFolderWorkspaceDelete
 } from './delete-worktree-dialog-copy'
 import { translate } from '@/i18n/i18n'
+import { toWorktreeRemovalTarget } from '../../../../shared/worktree/removal'
 import { useDeleteWorktreeStatusHydration } from './use-delete-worktree-status-hydration'
 import { useConfirmedWorktreeDeleteTargets } from './use-confirmed-worktree-delete-targets'
 
@@ -233,10 +234,19 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
         // inside the dialog — it runs the destructive retry directly without
         // the shared toast wrapper. Close immediately because workspace cards
         // already show the deleting state while the retry runs.
+        // Why the lookup (STA-4448): the confirmed row carries the host the
+        // removal must land on; a bare id would let force delete another host's
+        // checkout at the same path.
+        const forceTarget = currentWorktrees.find((entry) => entry.id === worktreeId)
+        if (!forceTarget) {
+          return
+        }
         const commitFocus = prepareActiveWorktreeFocusAfterDelete(worktreeId)
         // Why (#11960): this IS the explicit Force Delete, so it may also waive
         // the PTY-stop proof — unlike the confirmed delete in the branch below.
-        const deletePromise = removeWorktree(worktreeId, true, { allowUnverifiedPtyStop: true })
+        const deletePromise = removeWorktree(toWorktreeRemovalTarget(forceTarget), true, {
+          allowUnverifiedPtyStop: true
+        })
         closeModal()
         deletePromise
           .then((result) => {

--- a/src/renderer/src/components/sidebar/ForgetSshWorkspaceDialog.tsx
+++ b/src/renderer/src/components/sidebar/ForgetSshWorkspaceDialog.tsx
@@ -14,6 +14,8 @@ import { useMountedRef } from '@/hooks/useMountedRef'
 import { useAppStore } from '@/store'
 import { translate } from '@/i18n/i18n'
 import { runWorktreeDeleteWithToast } from './delete-worktree-flow'
+import { toSshExecutionHostId } from '../../../../shared/execution-host'
+import type { WorktreeRemovalTarget } from '../../../../shared/worktree/removal'
 import type { SshWorkspaceForgetResolution } from './ssh-workspace-forget-resolution'
 
 type ForgetSshWorkspaceModalData = {
@@ -51,6 +53,13 @@ export function ForgetSshWorkspaceDialog(): React.JSX.Element | null {
   }
   const { worktreeId, displayName, resolution } = modalData
   const canReconnect = resolution.kind === 'disconnected'
+  // This dialog only opens for a workspace pinned to a named SSH target, so that
+  // target IS the host the removal was confirmed against (STA-4448).
+  const removalTarget: WorktreeRemovalTarget = {
+    id: worktreeId,
+    executionHostId:
+      resolution.kind === 'not-ssh' ? null : toSshExecutionHostId(resolution.targetId)
+  }
 
   const done = (): void => {
     if (mountedRef.current) {
@@ -83,7 +92,7 @@ export function ForgetSshWorkspaceDialog(): React.JSX.Element | null {
     }
     // Close before the delete toast fires so the two don't overlap.
     closeModal()
-    void runWorktreeDeleteWithToast(worktreeId, displayName)
+    void runWorktreeDeleteWithToast(removalTarget, displayName)
     if (mountedRef.current) {
       setBusy(null)
     }
@@ -95,7 +104,7 @@ export function ForgetSshWorkspaceDialog(): React.JSX.Element | null {
     try {
       const result = await useAppStore
         .getState()
-        .removeWorktree(worktreeId, false, { mode: 'forget-local' })
+        .removeWorktree(removalTarget, false, { mode: 'forget-local' })
       if (!result.ok) {
         toast.error(result.error)
         if (mountedRef.current) {

--- a/src/renderer/src/components/sidebar/delete-worktree-failure-toast.tsx
+++ b/src/renderer/src/components/sidebar/delete-worktree-failure-toast.tsx
@@ -3,6 +3,7 @@ import { Button } from '../ui/button'
 import { getDeleteWorktreeToastCopy } from './delete-worktree-toast'
 import { translate } from '@/i18n/i18n'
 import {
+  isAmbiguousHostRemovalError,
   isLockedWorktreeRemovalError,
   type WorktreeForceDeleteReason
 } from '../../../../shared/worktree/removal'
@@ -96,7 +97,13 @@ export function showDeleteWorktreeFailureToast({
       <DeleteWorktreeFailureToastBody
         description={toastCopy.description}
         canForceDelete={canForceDelete}
-        showViewChanges={!isLockedWorktreeRemovalError(error) || hasKnownChanges === true}
+        // Why: View opens the workspace diff by id, and an id that two hosts share cannot
+        // pick one — the button would either do nothing useful or open the other machine's
+        // changes. Hide it for the collision refusal.
+        showViewChanges={
+          !isAmbiguousHostRemovalError(error) &&
+          (!isLockedWorktreeRemovalError(error) || hasKnownChanges === true)
+        }
         onViewChanges={onViewChanges}
         onForceDelete={onForceDelete}
         toastId={id}

--- a/src/renderer/src/components/sidebar/delete-worktree-flow.test.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-flow.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
 
 const mocks = vi.hoisted(() => {
   const state = {
@@ -12,7 +13,7 @@ const mocks = vi.hoisted(() => {
         path: string
         displayName: string
         isMainWorktree: boolean
-        hostId?: string
+        hostId?: ExecutionHostId
       }
     >(),
     repos: [] as { id: string; displayName: string; connectionId?: string }[],
@@ -89,7 +90,7 @@ function setWorktrees(
     path?: string
     displayName?: string
     isMainWorktree?: boolean
-    hostId?: string
+    hostId?: ExecutionHostId
   }[]
 ): void {
   mocks.state.worktreeMap = new Map(
@@ -228,9 +229,13 @@ describe('delete worktree flow', () => {
 
     const deletion = runWorktreeDeletesInParallel(targets)
     await vi.waitFor(() =>
-      expect(mocks.state.removeWorktree).toHaveBeenCalledWith('wt-1', false, {
-        suppressPreservedBranchToast: true
-      })
+      expect(mocks.state.removeWorktree).toHaveBeenCalledWith(
+        { id: 'wt-1', executionHostId: null },
+        false,
+        {
+          suppressPreservedBranchToast: true
+        }
+      )
     )
     setWorktrees([
       { id: 'wt-1', instanceId: 'instance-1', path: '/workspaces/first-longer' },
@@ -239,9 +244,13 @@ describe('delete worktree flow', () => {
     finishFirst({ ok: true })
 
     await expect(deletion).resolves.toEqual(['wt-1'])
-    expect(mocks.state.removeWorktree).not.toHaveBeenCalledWith('wt-2', false, {
-      suppressPreservedBranchToast: true
-    })
+    expect(mocks.state.removeWorktree).not.toHaveBeenCalledWith(
+      { id: 'wt-2', executionHostId: null },
+      false,
+      {
+        suppressPreservedBranchToast: true
+      }
+    )
     expect(toast.info).toHaveBeenCalledWith(
       'Workspace list changed',
       expect.objectContaining({
@@ -282,7 +291,10 @@ describe('delete worktree flow', () => {
 
     expect(started).toBe(true)
     expect(mocks.state.openModal).not.toHaveBeenCalled()
-    expect(mocks.state.removeWorktree).toHaveBeenCalledWith('wt-1', false)
+    expect(mocks.state.removeWorktree).toHaveBeenCalledWith(
+      { id: 'wt-1', executionHostId: null },
+      false
+    )
     await vi.waitFor(() => {
       expect(onDeleted).toHaveBeenCalledWith(['wt-1'])
     })
@@ -291,7 +303,7 @@ describe('delete worktree flow', () => {
   it('notifies onDeleted after a skip-confirm force delete succeeds', async () => {
     mocks.state.settings = { skipDeleteWorktreeConfirm: true }
     mocks.state.removeWorktree
-      .mockImplementationOnce(async (worktreeId: string) => {
+      .mockImplementationOnce(async ({ id: worktreeId }: { id: string }) => {
         mocks.state.deleteStateByWorktreeId[worktreeId] = {
           isDeleting: false,
           error: 'changed files',
@@ -313,9 +325,14 @@ describe('delete worktree flow', () => {
     await vi.waitFor(() => {
       // Why (#11960): clicking Force Delete on the failure toast is an explicit
       // force, so it also waives the PTY-stop proof the first attempt failed.
-      expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(2, 'wt-1', true, {
-        allowUnverifiedPtyStop: true
-      })
+      expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(
+        2,
+        { id: 'wt-1', executionHostId: null },
+        true,
+        {
+          allowUnverifiedPtyStop: true
+        }
+      )
       expect(onDeleted).toHaveBeenCalledWith(['wt-1'])
     })
   })
@@ -323,7 +340,7 @@ describe('delete worktree flow', () => {
   it('does not offer force delete for a locked worktree', async () => {
     mocks.state.settings = { skipDeleteWorktreeConfirm: true }
     mocks.state.removeWorktree
-      .mockImplementationOnce(async (worktreeId: string) => {
+      .mockImplementationOnce(async ({ id: worktreeId }: { id: string }) => {
         mocks.state.deleteStateByWorktreeId[worktreeId] = {
           isDeleting: false,
           error: 'Worktree is locked by Git.',
@@ -453,7 +470,10 @@ describe('delete worktree flow', () => {
     runWorktreeDelete('wt-1', { expectedInstanceId: 'instance-1' })
 
     expect(toast.info).not.toHaveBeenCalled()
-    expect(mocks.state.removeWorktree).toHaveBeenCalledWith('wt-1', false)
+    expect(mocks.state.removeWorktree).toHaveBeenCalledWith(
+      { id: 'wt-1', executionHostId: null },
+      false
+    )
   })
 
   // Why: the delete-current-workspace shortcut (useIpcEvents) forwards whatever workspace is
@@ -475,7 +495,10 @@ describe('delete worktree flow', () => {
     runWorktreeDelete('wt-1')
 
     expect(toast.info).not.toHaveBeenCalled()
-    expect(mocks.state.removeWorktree).toHaveBeenCalledWith('wt-1', false)
+    expect(mocks.state.removeWorktree).toHaveBeenCalledWith(
+      { id: 'wt-1', executionHostId: null },
+      false
+    )
   })
 
   it('opens project removal confirmation for a primary workspace', () => {

--- a/src/renderer/src/components/sidebar/delete-worktree-flow.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-flow.ts
@@ -1,5 +1,6 @@
 import { useAppStore } from '@/store'
 import { getAllWorktreesFromState, getWorktreeMapFromState } from '@/store/selectors'
+import { toWorktreeRemovalTarget } from '../../../../shared/worktree/removal'
 import { findRepoForHost } from '@/store/slices/repo-host-identity'
 import {
   showNoDeletableWorkspacesToast,
@@ -93,7 +94,7 @@ export function runWorktreeDelete(worktreeId: string, options: WorktreeDeleteOpt
   const hasLineageChildren = deleteLineage.descendants.length > 0
   const skipConfirm = state.settings?.skipDeleteWorktreeConfirm ?? false
   if (skipConfirm && !hasLineageChildren) {
-    void runWorktreeDeleteWithToast(worktreeId, target.displayName)
+    void runWorktreeDeleteWithToast(toWorktreeRemovalTarget(target), target.displayName)
     return
   }
   state.openModal('delete-worktree', {

--- a/src/renderer/src/components/sidebar/delete-worktree-parallel-flow.test.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-parallel-flow.test.ts
@@ -136,12 +136,22 @@ describe('runWorktreeDeletesInParallel', () => {
     ])
 
     expect(mocks.state.removeWorktree).toHaveBeenCalledTimes(2)
-    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(1, 'wt-1', false, {
-      suppressPreservedBranchToast: true
-    })
-    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(2, 'wt-2', false, {
-      suppressPreservedBranchToast: true
-    })
+    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(
+      1,
+      { id: 'wt-1', executionHostId: null },
+      false,
+      {
+        suppressPreservedBranchToast: true
+      }
+    )
+    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(
+      2,
+      { id: 'wt-2', executionHostId: null },
+      false,
+      {
+        suppressPreservedBranchToast: true
+      }
+    )
     expect(mocks.state.markWorktreesDeleting).toHaveBeenCalledWith(['wt-1', 'wt-2'])
 
     second.resolve({ ok: true })
@@ -172,16 +182,26 @@ describe('runWorktreeDeletesInParallel', () => {
       canForceDelete: false
     })
     expect(mocks.state.removeWorktree).toHaveBeenCalledTimes(1)
-    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(1, 'child', false, {
-      suppressPreservedBranchToast: true
-    })
+    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(
+      1,
+      { id: 'child', executionHostId: null },
+      false,
+      {
+        suppressPreservedBranchToast: true
+      }
+    )
 
     childDelete.resolve({ ok: true })
 
     await expect(deleted).resolves.toEqual(['parent', 'child'])
-    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(2, 'parent', false, {
-      suppressPreservedBranchToast: true
-    })
+    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(
+      2,
+      { id: 'parent', executionHostId: null },
+      false,
+      {
+        suppressPreservedBranchToast: true
+      }
+    )
   })
 
   it('deletes nested workspaces before their parent within the same repo', async () => {
@@ -190,12 +210,22 @@ describe('runWorktreeDeletesInParallel', () => {
       { id: 'child', displayName: 'child', repoId: 'repo-a', path: '/workspaces/parent/child' }
     ])
 
-    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(1, 'child', false, {
-      suppressPreservedBranchToast: true
-    })
-    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(2, 'parent', false, {
-      suppressPreservedBranchToast: true
-    })
+    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(
+      1,
+      { id: 'child', executionHostId: null },
+      false,
+      {
+        suppressPreservedBranchToast: true
+      }
+    )
+    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(
+      2,
+      { id: 'parent', executionHostId: null },
+      false,
+      {
+        suppressPreservedBranchToast: true
+      }
+    )
   })
 
   it('passes confirmed force to each delete', async () => {
@@ -207,12 +237,22 @@ describe('runWorktreeDeletesInParallel', () => {
       { force: true }
     )
 
-    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(1, 'wt-1', true, {
-      suppressPreservedBranchToast: true
-    })
-    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(2, 'wt-2', true, {
-      suppressPreservedBranchToast: true
-    })
+    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(
+      1,
+      { id: 'wt-1', executionHostId: null },
+      true,
+      {
+        suppressPreservedBranchToast: true
+      }
+    )
+    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(
+      2,
+      { id: 'wt-2', executionHostId: null },
+      true,
+      {
+        suppressPreservedBranchToast: true
+      }
+    )
   })
 
   it('deletes a duplicated target identity only once', async () => {
@@ -230,19 +270,24 @@ describe('runWorktreeDeletesInParallel', () => {
 
     expect(mocks.state.markWorktreesDeleting).toHaveBeenCalledWith(['wt-1'])
     expect(mocks.state.removeWorktree).toHaveBeenCalledTimes(1)
-    expect(mocks.state.removeWorktree).toHaveBeenCalledWith('wt-1', false)
+    expect(mocks.state.removeWorktree).toHaveBeenCalledWith(
+      { id: 'wt-1', executionHostId: null },
+      false
+    )
     expect(toast.error).not.toHaveBeenCalled()
   })
 
   it('clears a pending ancestor when a nested descendant delete fails', async () => {
-    mocks.state.removeWorktree.mockImplementationOnce(async (worktreeId: string) => {
-      mocks.state.deleteStateByWorktreeId[worktreeId] = {
-        isDeleting: false,
-        error: 'changed files',
-        canForceDelete: true
+    mocks.state.removeWorktree.mockImplementationOnce(
+      async ({ id: worktreeId }: { id: string }) => {
+        mocks.state.deleteStateByWorktreeId[worktreeId] = {
+          isDeleting: false,
+          error: 'changed files',
+          canForceDelete: true
+        }
+        return { ok: false, error: 'changed files' }
       }
-      return { ok: false, error: 'changed files' }
-    })
+    )
 
     await expect(
       runDeletesForCurrentWorktrees([
@@ -252,9 +297,14 @@ describe('runWorktreeDeletesInParallel', () => {
     ).resolves.toEqual([])
 
     expect(mocks.state.removeWorktree).toHaveBeenCalledTimes(1)
-    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(1, 'child', false, {
-      suppressPreservedBranchToast: true
-    })
+    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(
+      1,
+      { id: 'child', executionHostId: null },
+      false,
+      {
+        suppressPreservedBranchToast: true
+      }
+    )
     expect(mocks.state.clearWorktreeDeleteState).toHaveBeenCalledWith('parent')
     expect(mocks.state.deleteStateByWorktreeId['parent']).toBeUndefined()
   })

--- a/src/renderer/src/components/sidebar/delete-worktree-toast.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-toast.ts
@@ -1,5 +1,6 @@
 import { translate } from '@/i18n/i18n'
 import {
+  isAmbiguousHostRemovalError,
   isLockedWorktreeRemovalError,
   isProvenLivePtyRemovalError,
   type WorktreeForceDeleteReason
@@ -16,6 +17,24 @@ export function getDeleteWorktreeToastCopy(
   error: string,
   lockReason: string | null = null
 ): DeleteWorktreeToastCopy {
+  // Why: the raw refusal names execution-host routing, which is Orca's problem, not the
+  // user's. Say what it means for their workspace and that nothing was lost; there is no
+  // action they can take, so offer none rather than a remedy that does not work.
+  if (isAmbiguousHostRemovalError(error)) {
+    return {
+      title: translate(
+        'auto.components.sidebar.delete.worktree.toast.1d0fa5c0a5',
+        'Failed to delete workspace {{value0}}',
+        { value0: worktreeName }
+      ),
+      description: translate(
+        'auto.components.sidebar.delete.worktree.toast.ambiguousHost',
+        "This workspace exists on more than one machine at the same path, so Orca can't tell which one to remove. Nothing was deleted. We're improving this — for now, delete it directly on the machine you want it gone from."
+      ),
+      isDestructive: false
+    }
+  }
+
   if (isLockedWorktreeRemovalError(error)) {
     return {
       title: translate(

--- a/src/renderer/src/components/sidebar/ssh-host-remove-workspaces.ts
+++ b/src/renderer/src/components/sidebar/ssh-host-remove-workspaces.ts
@@ -28,12 +28,16 @@ export async function clearSshHostWorkspaces(
   const store = useAppStore.getState()
   const forgetLocalOnly = mode === 'forget-local'
   const failedIds: string[] = []
+  // Every workspace in this resolution is pinned to the SSH target being
+  // removed, so that target is the host each removal is confirmed against
+  // (STA-4448) — a bare id could land on a local checkout at the same path.
+  const hostId = toSshExecutionHostId(resolution.targetId)
 
   for (const worktreeId of resolution.workspaceWorktreeIds) {
     // Why: sequential, not parallel — deletes on the same repo contend on git
     // ref locks, and forget is cheap enough that ordering keeps failures legible.
     const result = await store.removeWorktree(
-      worktreeId,
+      { id: worktreeId, executionHostId: hostId },
       false,
       forgetLocalOnly ? { mode: 'forget-local' } : undefined
     )
@@ -48,7 +52,6 @@ export async function clearSshHostWorkspaces(
   // wrong (local) project could be removed and the SSH ghost left behind. For an
   // offline/ghost host this hits the local backend path (no live runtime target),
   // clearing Orca's records without a successful remote call.
-  const hostId = toSshExecutionHostId(resolution.targetId)
   for (const repoId of resolution.hostRepoIds) {
     try {
       await store.removeProject(repoId, { hostId })

--- a/src/renderer/src/components/sidebar/worktree-delete-execution.ts
+++ b/src/renderer/src/components/sidebar/worktree-delete-execution.ts
@@ -8,6 +8,10 @@ import {
   normalizeRuntimePathForComparison
 } from '../../../../shared/cross-platform-path'
 import type { Worktree } from '../../../../shared/worktree/types'
+import {
+  toWorktreeRemovalTarget,
+  type WorktreeRemovalTarget
+} from '../../../../shared/worktree/removal'
 import { prepareActiveWorktreeFocusAfterDelete } from './active-worktree-focus-after-delete'
 import { showDeleteWorktreeFailureToast } from './delete-worktree-failure-toast'
 import { showWorkspaceListChangedToast } from './stale-workspace-list-toast'
@@ -32,7 +36,10 @@ function isStrictDescendantPath(parentPath: string, childPath: string): boolean 
 }
 
 export async function runWorktreeDeletesInParallel(
-  targets: readonly Pick<Worktree, 'id' | 'instanceId' | 'displayName' | 'repoId' | 'path'>[],
+  targets: readonly Pick<
+    Worktree,
+    'id' | 'instanceId' | 'displayName' | 'repoId' | 'path' | 'hostId'
+  >[],
   options: WorktreeDeleteWithToastOptions = {}
 ): Promise<string[]> {
   // A destructive command must run once per identity even if a refresh duplicated rows.
@@ -82,16 +89,20 @@ export async function runWorktreeDeletesInParallel(
             useAppStore.getState().clearWorktreeDeleteState(target.id)
             continue
           }
-          const deleted = await runWorktreeDeleteWithToast(target.id, target.displayName, {
-            ...options,
-            focusSuccessorOnDelete: false,
-            suppressPreservedBranchToast: aggregatePreservedBranches,
-            ...(snapshotPruneBatch ? { snapshotPruneBatchId: snapshotPruneBatch.batchId } : {}),
-            onPreservedBranch: (branch) => {
-              preservedBranches.push(branch)
-              options.onPreservedBranch?.(branch)
+          const deleted = await runWorktreeDeleteWithToast(
+            toWorktreeRemovalTarget(target),
+            target.displayName,
+            {
+              ...options,
+              focusSuccessorOnDelete: false,
+              suppressPreservedBranchToast: aggregatePreservedBranches,
+              ...(snapshotPruneBatch ? { snapshotPruneBatchId: snapshotPruneBatch.batchId } : {}),
+              onPreservedBranch: (branch) => {
+                preservedBranches.push(branch)
+                options.onPreservedBranch?.(branch)
+              }
             }
-          })
+          )
           if (deleted) {
             deletedInGroup.push(target.id)
           } else {
@@ -133,10 +144,11 @@ export async function runWorktreeDeletesInParallel(
 
 /** Shared confirmed and skip-confirm execution with consistent failure recovery. */
 export function runWorktreeDeleteWithToast(
-  worktreeId: string,
+  target: WorktreeRemovalTarget,
   worktreeName: string,
   options: WorktreeDeleteWithToastOptions = {}
 ): Promise<boolean> {
+  const worktreeId = target.id
   const removeWorktree = useAppStore.getState().removeWorktree
   const commitFocus = prepareActiveWorktreeFocusAfterDelete(worktreeId)
   const focusSuccessor = options.focusSuccessorOnDelete !== false
@@ -147,8 +159,8 @@ export function runWorktreeDeleteWithToast(
   }
   const removal =
     Object.keys(removeOptions).length > 0
-      ? removeWorktree(worktreeId, options.force === true, removeOptions)
-      : removeWorktree(worktreeId, options.force === true)
+      ? removeWorktree(target, options.force === true, removeOptions)
+      : removeWorktree(target, options.force === true)
   return removal
     .then((result) => {
       if (result.ok) {
@@ -185,7 +197,7 @@ export function runWorktreeDeleteWithToast(
           // The explicit Force Delete retry may waive an unverified PTY-stop proof.
           const forceRemoval = useAppStore
             .getState()
-            .removeWorktree(worktreeId, true, { allowUnverifiedPtyStop: true })
+            .removeWorktree(target, true, { allowUnverifiedPtyStop: true })
           forceRemoval
             .then((forceResult) => {
               if (!forceResult.ok) {

--- a/src/renderer/src/components/sidebar/worktree-delete-host-qualification.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-delete-host-qualification.test.ts
@@ -1,0 +1,230 @@
+/**
+ * STA-4448, end to end from the sidebar: the exact reported user path.
+ *
+ *   1. The same repo sits at the same path on two hosts, so both publish the id
+ *      `repoId::path`. The sidebar's id-keyed projection keeps ONE row for it.
+ *   2. The user OPENS the local workspace, which sets `activeWorktreeId`.
+ *   3. The user deletes the sidebar row, which belongs to the SSH host.
+ *   4. Before this fix, removal routing short-circuited to the ACTIVE host and
+ *      destroyed the LOCAL checkout and its uncommitted work.
+ *
+ * This drives the real sidebar funnel (`runWorktreeDelete` /
+ * `runWorktreeDeletesInParallel`) into the real store action, so it covers the
+ * caller carrying the confirmed host as well as the chokepoint enforcing it. The
+ * only fakes are the removal transports, and they ACTUALLY delete the temp
+ * directory of the host they are routed to — see the shared fixture.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as fs from 'node:fs'
+import type { AppState } from '@/store/types'
+import type { Worktree } from '../../../../shared/worktree/types'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
+import { makeWorktree } from '@/store/slices/worktrees-slice-test-fixtures'
+import {
+  createTestStore,
+  mockApi,
+  resetRemoteRuntimeMocks,
+  resetWorktreeSliceModuleMemory,
+  runtimeEnvironmentCall
+} from '@/store/slices/worktrees-slice-test-harness'
+import {
+  cleanupHostCheckouts,
+  createHostCheckout,
+  installRemovalTransports,
+  COLLIDING_WORKTREE_ID as WORKTREE_ID,
+  COLLIDING_WORKTREE_PATH as WORKTREE_PATH,
+  HOST_COLLISION_MESSAGE,
+  LOCAL_HOST,
+  SSH_HOST
+} from '@/store/slices/worktree-removal-host-collision-fixture'
+
+const storeRef = vi.hoisted(() => ({ current: null as unknown as { getState: () => AppState } }))
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: () => storeRef.current.getState()
+  }
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    warning: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+    dismiss: vi.fn()
+  }
+}))
+
+vi.mock('@/lib/worktree-activation', () => ({ activateAndRevealWorktree: vi.fn() }))
+
+vi.mock('./delete-worktree-failure-toast', () => ({
+  showDeleteWorktreeFailureToast: vi.fn()
+}))
+
+import { showDeleteWorktreeFailureToast } from './delete-worktree-failure-toast'
+import { runWorktreeDelete, runWorktreeDeletesInParallel } from './delete-worktree-flow'
+
+function failureToastCount(): number {
+  return vi.mocked(showDeleteWorktreeFailureToast).mock.calls.length
+}
+
+function rowOnHost(hostId: ExecutionHostId): Worktree {
+  return makeWorktree({
+    id: WORKTREE_ID,
+    repoId: 'repo1',
+    path: WORKTREE_PATH,
+    displayName: 'shared-workspace',
+    instanceId: `instance-${hostId}`,
+    hostId
+  })
+}
+
+/**
+ * Seeds both hosts' rows for the colliding id. `worktreesByRepo` order matters:
+ * the sidebar's id-keyed projection keeps the LAST row, and that is the row the
+ * user sees and deletes.
+ */
+function seedCollidingSidebar(
+  store: ReturnType<typeof createTestStore>,
+  displayedRowHostId: ExecutionHostId
+): void {
+  const otherHostId = displayedRowHostId === LOCAL_HOST ? SSH_HOST : LOCAL_HOST
+  store.setState({
+    repos: [{ id: 'repo1', path: '/repo1', displayName: 'Repo 1', executionHostId: LOCAL_HOST }],
+    worktreesByRepo: { repo1: [rowOnHost(otherHostId), rowOnHost(displayedRowHostId)] },
+    // The user opened the LOCAL workspace, so removal routing prefers local.
+    activeWorktreeId: WORKTREE_ID,
+    activeWorkspaceExecutionHostId: LOCAL_HOST,
+    activeView: 'terminal',
+    activePendingCreationId: null,
+    settings: { skipDeleteWorktreeConfirm: true },
+    sshConnectionStates: new Map([['ssh-1', { targetId: 'ssh-1', status: 'connected' }]]),
+    sshTargetLabels: new Map([['ssh-1', 'SSH One']]),
+    worktreeLineageById: {}
+  } as unknown as Partial<AppState>)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  resetRemoteRuntimeMocks()
+  resetWorktreeSliceModuleMemory()
+  storeRef.current = createTestStore()
+})
+
+afterEach(cleanupHostCheckouts)
+
+describe('STA-4448 sidebar delete: the confirmed row decides the host', () => {
+  it('leaves the ACTIVE local checkout on disk when the SSH row is deleted', async () => {
+    const local = createHostCheckout(LOCAL_HOST)
+    const ssh = createHostCheckout(SSH_HOST)
+    const routedHostIds: string[] = []
+    installRemovalTransports(
+      { remove: mockApi.worktrees.remove, runtimeCall: runtimeEnvironmentCall },
+      { [LOCAL_HOST]: local.root, [SSH_HOST]: ssh.root },
+      routedHostIds
+    )
+    const store = storeRef.current as ReturnType<typeof createTestStore>
+    seedCollidingSidebar(store, SSH_HOST)
+
+    // Right-click the sidebar row → Delete Workspace (confirmation skipped).
+    runWorktreeDelete(WORKTREE_ID)
+    // Settle on either outcome so the disk assertion below is what reports a
+    // regression, rather than a spy that was never reached.
+    await vi.waitFor(() => expect(routedHostIds.length + failureToastCount()).toBeGreaterThan(0))
+
+    expect(
+      fs.existsSync(local.markerPath),
+      `the ACTIVE local checkout must survive deleting the SSH row; removal was routed to hostId=${routedHostIds.join(',') || '<none>'}`
+    ).toBe(true)
+    // Fail closed, do not reroute: rerouting the colliding row is #14606's job.
+    expect(fs.existsSync(ssh.markerPath)).toBe(true)
+    expect(routedHostIds).toEqual([])
+    expect(vi.mocked(showDeleteWorktreeFailureToast).mock.calls[0]?.[0]).toMatchObject({
+      error: HOST_COLLISION_MESSAGE,
+      canForceDelete: false
+    })
+    // The row survives the refusal, so the user can still act on it.
+    expect(store.getState().worktreesByRepo.repo1).toHaveLength(2)
+  })
+
+  it('leaves the ACTIVE local checkout on disk through the batch delete path', async () => {
+    const local = createHostCheckout(LOCAL_HOST)
+    const ssh = createHostCheckout(SSH_HOST)
+    const routedHostIds: string[] = []
+    installRemovalTransports(
+      { remove: mockApi.worktrees.remove, runtimeCall: runtimeEnvironmentCall },
+      { [LOCAL_HOST]: local.root, [SSH_HOST]: ssh.root },
+      routedHostIds
+    )
+    const store = storeRef.current as ReturnType<typeof createTestStore>
+    seedCollidingSidebar(store, SSH_HOST)
+
+    const deletedIds = await runWorktreeDeletesInParallel([rowOnHost(SSH_HOST)], { force: true })
+
+    expect(
+      fs.existsSync(local.markerPath),
+      `the ACTIVE local checkout must survive a batch delete of the SSH row; removal was routed to hostId=${routedHostIds.join(',') || '<none>'}`
+    ).toBe(true)
+    expect(fs.existsSync(ssh.markerPath)).toBe(true)
+    expect(routedHostIds).toEqual([])
+    expect(deletedIds).toEqual([])
+  })
+
+  it('still deletes the local checkout for real when the local row is the one deleted', async () => {
+    const local = createHostCheckout(LOCAL_HOST)
+    const ssh = createHostCheckout(SSH_HOST)
+    const routedHostIds: string[] = []
+    installRemovalTransports(
+      { remove: mockApi.worktrees.remove, runtimeCall: runtimeEnvironmentCall },
+      { [LOCAL_HOST]: local.root, [SSH_HOST]: ssh.root },
+      routedHostIds
+    )
+    const store = storeRef.current as ReturnType<typeof createTestStore>
+    seedCollidingSidebar(store, LOCAL_HOST)
+
+    runWorktreeDelete(WORKTREE_ID)
+    await vi.waitFor(() => expect(routedHostIds).toEqual([LOCAL_HOST]))
+
+    // Confirming the row that IS the active local host deletes it, as asked.
+    expect(fs.existsSync(local.markerPath)).toBe(false)
+    expect(fs.existsSync(ssh.markerPath)).toBe(true)
+    expect(showDeleteWorktreeFailureToast).not.toHaveBeenCalled()
+  })
+
+  it('still deletes an ordinary single-host SSH workspace for real', async () => {
+    const ssh = createHostCheckout(SSH_HOST)
+    const routedHostIds: string[] = []
+    installRemovalTransports(
+      { remove: mockApi.worktrees.remove, runtimeCall: runtimeEnvironmentCall },
+      { [SSH_HOST]: ssh.root },
+      routedHostIds
+    )
+    const store = storeRef.current as ReturnType<typeof createTestStore>
+    store.setState({
+      repos: [
+        {
+          id: 'repo1',
+          path: '/repo1',
+          displayName: 'Repo 1',
+          executionHostId: SSH_HOST,
+          connectionId: 'ssh-1'
+        }
+      ],
+      worktreesByRepo: { repo1: [rowOnHost(SSH_HOST)] },
+      activeWorktreeId: null,
+      activeView: 'terminal',
+      activePendingCreationId: null,
+      settings: { skipDeleteWorktreeConfirm: true },
+      sshConnectionStates: new Map([['ssh-1', { targetId: 'ssh-1', status: 'connected' }]]),
+      sshTargetLabels: new Map([['ssh-1', 'SSH One']]),
+      worktreeLineageById: {}
+    } as unknown as Partial<AppState>)
+
+    runWorktreeDelete(WORKTREE_ID)
+    await vi.waitFor(() => expect(routedHostIds).toEqual([SSH_HOST]))
+
+    expect(fs.existsSync(ssh.markerPath)).toBe(false)
+    expect(showDeleteWorktreeFailureToast).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-delete-request.ts
+++ b/src/renderer/src/components/sidebar/worktree-delete-request.ts
@@ -1,12 +1,14 @@
 import type { Worktree } from '../../../../shared/worktree/types'
 import type { PreservedBranchCleanup } from '@/lib/preserved-branch-cleanup'
+import { normalizeExecutionHostId } from '../../../../shared/execution-host'
 
 export type WorktreeBatchDeleteOptions = {
   forceConfirm?: boolean
   onDeleted?: (worktreeIds: string[]) => void
 }
 
-export type WorktreeDeleteIdentity = Pick<Worktree, 'id' | 'instanceId'>
+/** `hostId` rides along because `id` alone repeats across hosts (STA-4448). */
+export type WorktreeDeleteIdentity = Pick<Worktree, 'id' | 'instanceId' | 'hostId'>
 
 export type WorktreeDeleteOptions = {
   expectedInstanceId?: string
@@ -23,9 +25,9 @@ export type WorktreeDeleteWithToastOptions = {
 }
 
 export function toWorktreeDeleteIdentities(
-  worktrees: readonly Pick<Worktree, 'id' | 'instanceId'>[]
+  worktrees: readonly Pick<Worktree, 'id' | 'instanceId' | 'hostId'>[]
 ): WorktreeDeleteIdentity[] {
-  return worktrees.map(({ id, instanceId }) => ({ id, instanceId }))
+  return worktrees.map(({ id, instanceId, hostId }) => ({ id, instanceId, hostId }))
 }
 
 export function resolveWorktreeBatchDeleteTargets(
@@ -46,6 +48,13 @@ export function resolveWorktreeBatchDeleteTargets(
     if (typeof request !== 'string' && (!target || target.instanceId !== request.instanceId)) {
       return null
     }
+    // Why (STA-4448): the id-keyed map holds one row per `repoId::path`, so a
+    // refresh can swap in another host's row for the confirmed id. `instanceId`
+    // misses that whenever either row predates instance ids, and confirming a
+    // remote row must never fall through to a local checkout at the same path.
+    if (typeof request !== 'string' && request.hostId && target?.hostId !== request.hostId) {
+      return null
+    }
     if (target && !target.isMainWorktree) {
       targets.push(target)
     }
@@ -62,8 +71,12 @@ export function readWorktreeDeleteIdentities(value: unknown): WorktreeDeleteIden
       return []
     }
     const instanceId = 'instanceId' in entry ? entry.instanceId : undefined
-    return instanceId === undefined || typeof instanceId === 'string'
-      ? [{ id: entry.id, instanceId }]
-      : []
+    if (instanceId !== undefined && typeof instanceId !== 'string') {
+      return []
+    }
+    const hostId = normalizeExecutionHostId(
+      'hostId' in entry && typeof entry.hostId === 'string' ? entry.hostId : null
+    )
+    return [{ id: entry.id, instanceId, ...(hostId ? { hostId } : {}) }]
   })
 }

--- a/src/renderer/src/components/status-bar/WorkspaceSpaceManagerPanel.tsx
+++ b/src/renderer/src/components/status-bar/WorkspaceSpaceManagerPanel.tsx
@@ -1624,7 +1624,13 @@ export function WorkspaceSpaceManagerPanel(): React.JSX.Element {
       // discarded silently; a failed row gets this explicit recovery path.
       const commitFocus = prepareActiveWorktreeFocusAfterDelete(worktree.worktreeId)
       // Why (#11960): explicit force recovery, so it may also waive PTY-stop proof.
-      void removeWorktree(worktree.worktreeId, true, { allowUnverifiedPtyStop: true })
+      // Why the host (STA-4448): the Space scan lists one row per host, so a bare
+      // id would let this force delete another host's checkout at the same path.
+      void removeWorktree(
+        { id: worktree.worktreeId, executionHostId: worktree.executionHostId ?? null },
+        true,
+        { allowUnverifiedPtyStop: true }
+      )
         .then((result) => {
           if (!result.ok) {
             toast.error(

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4990,7 +4990,8 @@
               "locked": "This workspace is locked by Git. Run git worktree unlock <worktree-path> from its repository, then retry deletion.",
               "lockedReason": "This workspace is locked by Git. Git reported: {{value0}}. Run git worktree unlock <worktree-path> from its repository, then retry deletion.",
               "unstoppedPty": "Orca could not confirm every terminal in this workspace has exited, so it stopped before deleting any files. Use Force Delete to remove it anyway.",
-              "unstoppedPtyLive": "This workspace still has running terminals, so Orca stopped before deleting any files. Force Delete will kill them and discard any uncommitted work they hold."
+              "unstoppedPtyLive": "This workspace still has running terminals, so Orca stopped before deleting any files. Force Delete will kill them and discard any uncommitted work they hold.",
+              "ambiguousHost": "This workspace exists on more than one machine at the same path, so Orca can't tell which one to remove. Nothing was deleted. We're improving this — for now, delete it directly on the machine you want it gone from."
             }
           }
         },

--- a/src/renderer/src/lib/worktree-operation-route.ts
+++ b/src/renderer/src/lib/worktree-operation-route.ts
@@ -74,6 +74,33 @@ function ownerRecordsOnHost(
 }
 
 /**
+ * Every host that currently claims `worktreeId`. Unqualified rows contribute
+ * nothing: a row with no `hostId` may well be the same host as a qualified one,
+ * so counting it as its own owner would invent collisions during migration.
+ */
+export function collectWorktreeOwnerExecutionHostIds(
+  state: WorktreeOperationRouteState,
+  worktreeId: string
+): ExecutionHostId[] {
+  const hostIds = new Set<ExecutionHostId>()
+  for (const worktrees of Object.values(state.worktreesByRepo ?? {})) {
+    for (const worktree of worktrees) {
+      const hostId = worktree.id === worktreeId ? parseExecutionHostId(worktree.hostId)?.id : null
+      if (hostId) {
+        hostIds.add(hostId)
+      }
+    }
+  }
+  for (const worktree of findIndexedDetectedWorktrees(state.detectedWorktreesByRepo, worktreeId)) {
+    const hostId = parseExecutionHostId(worktree.hostId)?.id
+    if (hostId) {
+      hostIds.add(hostId)
+    }
+  }
+  return Array.from(hostIds)
+}
+
+/**
  * The active workspace's host selection is authoritative identity, but it carries no transport:
  * an `ssh:` host reached through a paired HUB names the target, not the HUB that proxies it. Keep
  * the selected host and recover the runtime owner from the matching owner rows (#11346).

--- a/src/renderer/src/store/slices/editor-state-worktree-purge-leak.test.ts
+++ b/src/renderer/src/store/slices/editor-state-worktree-purge-leak.test.ts
@@ -85,7 +85,7 @@ describe('worktree removal purges per-file editor + git-huge state (leak regress
     const store = createTestStore()
     seedEditorState(store)
 
-    const result = await store.getState().removeWorktree(WT)
+    const result = await store.getState().removeWorktree({ id: WT, executionHostId: null })
     expect(result).toEqual({ ok: true })
 
     const s = store.getState()

--- a/src/renderer/src/store/slices/generation-records-worktree-removal-leak.test.ts
+++ b/src/renderer/src/store/slices/generation-records-worktree-removal-leak.test.ts
@@ -132,7 +132,7 @@ describe('worktree removal evicts generation records (leak regression)', () => {
         commitRecord(OTHER, OTHER_PATH)
       )
 
-    const result = await store.getState().removeWorktree(WT)
+    const result = await store.getState().removeWorktree({ id: WT, executionHostId: null })
     expect(result).toEqual({ ok: true })
 
     const s = store.getState()

--- a/src/renderer/src/store/slices/native-chat-launch-draft-teardown.test.ts
+++ b/src/renderer/src/store/slices/native-chat-launch-draft-teardown.test.ts
@@ -100,7 +100,7 @@ describe('nativeChatLaunchDraftByTabId teardown', () => {
     const store = createTestStore()
     seedDrafts(store)
 
-    const result = await store.getState().removeWorktree(WT1)
+    const result = await store.getState().removeWorktree({ id: WT1, executionHostId: null })
 
     expect(result).toEqual({ ok: true })
     const s = store.getState()

--- a/src/renderer/src/store/slices/store-worktree-removal-cascade.test.ts
+++ b/src/renderer/src/store/slices/store-worktree-removal-cascade.test.ts
@@ -120,7 +120,7 @@ describe('removeWorktree cascade', () => {
       'repo1::/path/wt2': 'fix: keep draft'
     })
 
-    const result = await store.getState().removeWorktree(worktreeId)
+    const result = await store.getState().removeWorktree({ id: worktreeId, executionHostId: null })
     const s = store.getState()
 
     expect(result).toEqual({ ok: true })
@@ -163,7 +163,7 @@ describe('removeWorktree cascade', () => {
       }
     })
 
-    const result = await store.getState().removeWorktree(worktreeId)
+    const result = await store.getState().removeWorktree({ id: worktreeId, executionHostId: null })
 
     expect(result).toEqual({
       ok: true,
@@ -199,7 +199,9 @@ describe('removeWorktree cascade', () => {
 
     const result = await store
       .getState()
-      .removeWorktree(worktreeId, false, { suppressPreservedBranchToast: true })
+      .removeWorktree({ id: worktreeId, executionHostId: null }, false, {
+        suppressPreservedBranchToast: true
+      })
 
     expect(result).toEqual({
       ok: true,
@@ -226,7 +228,7 @@ describe('removeWorktree cascade', () => {
       activeTabId: 'tab1'
     })
 
-    const result = await store.getState().removeWorktree(worktreeId)
+    const result = await store.getState().removeWorktree({ id: worktreeId, executionHostId: null })
     const s = store.getState()
 
     expect(result).toEqual({ ok: false, error })
@@ -368,7 +370,7 @@ describe('removeWorktree cascade', () => {
       terminalLayoutsByTabId: {}
     })
 
-    const result = await store.getState().removeWorktree(worktreeId)
+    const result = await store.getState().removeWorktree({ id: worktreeId, executionHostId: null })
 
     expect(result).toEqual({ ok: false, error })
     expect(store.getState().deleteStateByWorktreeId[worktreeId]).toEqual({
@@ -396,7 +398,7 @@ describe('removeWorktree cascade', () => {
       terminalLayoutsByTabId: {}
     })
 
-    const result = await store.getState().removeWorktree(worktreeId)
+    const result = await store.getState().removeWorktree({ id: worktreeId, executionHostId: null })
 
     expect(result).toEqual({ ok: false, error })
     expect(store.getState().deleteStateByWorktreeId[worktreeId]).toEqual({
@@ -424,7 +426,7 @@ describe('removeWorktree cascade', () => {
       terminalLayoutsByTabId: {}
     })
 
-    const result = await store.getState().removeWorktree(worktreeId)
+    const result = await store.getState().removeWorktree({ id: worktreeId, executionHostId: null })
 
     expect(result).toEqual({ ok: false, error })
     expect(store.getState().deleteStateByWorktreeId[worktreeId]).toEqual({
@@ -453,7 +455,7 @@ describe('removeWorktree cascade', () => {
       terminalLayoutsByTabId: {}
     })
 
-    const result = await store.getState().removeWorktree(worktreeId)
+    const result = await store.getState().removeWorktree({ id: worktreeId, executionHostId: null })
 
     expect(result).toEqual({ ok: false, error })
     expect(store.getState().deleteStateByWorktreeId[worktreeId]).toEqual({
@@ -479,7 +481,9 @@ describe('removeWorktree cascade', () => {
       terminalLayoutsByTabId: {}
     })
 
-    const result = await store.getState().removeWorktree(worktreeId, true)
+    const result = await store
+      .getState()
+      .removeWorktree({ id: worktreeId, executionHostId: null }, true)
     const s = store.getState()
 
     expect(result).toEqual({ ok: false, error: 'fatal error' })
@@ -510,7 +514,7 @@ describe('removeWorktree cascade', () => {
       terminalLayoutsByTabId: {}
     })
 
-    const result = await store.getState().removeWorktree(worktreeId)
+    const result = await store.getState().removeWorktree({ id: worktreeId, executionHostId: null })
 
     expect(result).toEqual({
       ok: false,
@@ -545,7 +549,7 @@ describe('removeWorktree cascade', () => {
       terminalLayoutsByTabId: {}
     })
 
-    const result = await store.getState().removeWorktree(worktreeId)
+    const result = await store.getState().removeWorktree({ id: worktreeId, executionHostId: null })
 
     expect(result.ok).toBe(false)
     expect(store.getState().deleteStateByWorktreeId[worktreeId]?.canForceDelete).toBe(false)
@@ -568,7 +572,7 @@ describe('removeWorktree cascade', () => {
       terminalLayoutsByTabId: {}
     })
 
-    const result = await store.getState().removeWorktree(worktreeId)
+    const result = await store.getState().removeWorktree({ id: worktreeId, executionHostId: null })
 
     expect(result).toEqual({ ok: false, error })
     expect(store.getState().deleteStateByWorktreeId[worktreeId]).toEqual({
@@ -616,7 +620,9 @@ describe('removeWorktree cascade', () => {
         terminalLayoutsByTabId: {}
       })
 
-      const result = await store.getState().removeWorktree(worktreeId)
+      const result = await store
+        .getState()
+        .removeWorktree({ id: worktreeId, executionHostId: null })
 
       expect(result).toEqual({ ok: false, error })
       expect(store.getState().deleteStateByWorktreeId[worktreeId]).toEqual({
@@ -648,7 +654,7 @@ describe('removeWorktree cascade', () => {
       terminalLayoutsByTabId: {}
     })
 
-    const result = await store.getState().removeWorktree(worktreeId)
+    const result = await store.getState().removeWorktree({ id: worktreeId, executionHostId: null })
 
     expect(result.ok).toBe(false)
     expect(store.getState().deleteStateByWorktreeId[worktreeId]?.canForceDelete).toBe(true)
@@ -708,7 +714,7 @@ describe('removeWorktree cascade', () => {
       activeTabId: 'tab2'
     })
 
-    await store.getState().removeWorktree(wt1)
+    await store.getState().removeWorktree({ id: wt1, executionHostId: null })
     const s = store.getState()
 
     // wt2 is untouched
@@ -755,7 +761,7 @@ describe('removeWorktree cascade', () => {
       }
     })
 
-    const result = await store.getState().removeWorktree(worktreeId)
+    const result = await store.getState().removeWorktree({ id: worktreeId, executionHostId: null })
 
     expect(result).toEqual({ ok: true })
     expect(callOrder).toEqual(['remove', 'kill'])

--- a/src/renderer/src/store/slices/tab-worktree-orphan-map-purge-leak.test.ts
+++ b/src/renderer/src/store/slices/tab-worktree-orphan-map-purge-leak.test.ts
@@ -131,7 +131,7 @@ describe('tab/worktree removal evicts the module maps it previously leaked', () 
     const store = createTestStore()
     seedMaps(store)
 
-    const result = await store.getState().removeWorktree(WT1)
+    const result = await store.getState().removeWorktree({ id: WT1, executionHostId: null })
     expect(result).toEqual({ ok: true })
 
     expect(getDetachedHeadAutoDerivedDisplayNameForTests(WT1)).toBeUndefined()

--- a/src/renderer/src/store/slices/workspace-cleanup-removal-preflight.test.ts
+++ b/src/renderer/src/store/slices/workspace-cleanup-removal-preflight.test.ts
@@ -49,7 +49,7 @@ describe('workspace cleanup removal and protection', () => {
     })
     installWorkspaceCleanupApi(scan)
 
-    const removeWorktree = vi.fn(async (worktreeId: string) => {
+    const removeWorktree = vi.fn(async ({ id: worktreeId }: { id: string }) => {
       deleteOrder.push(worktreeId)
       activeDeletes += 1
       maxActiveDeletes = Math.max(maxActiveDeletes, activeDeletes)
@@ -79,9 +79,13 @@ describe('workspace cleanup removal and protection', () => {
       'repo-a::/repo/parent',
       'repo-c::/other'
     ])
-    expect(removeWorktree).toHaveBeenCalledWith('repo-c::/other', true, {
-      suppressPreservedBranchToast: true
-    })
+    expect(removeWorktree).toHaveBeenCalledWith(
+      { id: 'repo-c::/other', executionHostId: 'local' },
+      true,
+      {
+        suppressPreservedBranchToast: true
+      }
+    )
     expect(store.getState().workspaceCleanupScan?.candidates).toEqual([])
   })
 
@@ -112,9 +116,13 @@ describe('workspace cleanup removal and protection', () => {
         }
       ]
     })
-    expect(removeWorktree).toHaveBeenCalledWith(candidate.worktreeId, false, {
-      suppressPreservedBranchToast: true
-    })
+    expect(removeWorktree).toHaveBeenCalledWith(
+      { id: candidate.worktreeId, executionHostId: 'local' },
+      false,
+      {
+        suppressPreservedBranchToast: true
+      }
+    )
   })
 
   it('forwards the snapshot batch through each successful removal', async () => {
@@ -129,10 +137,11 @@ describe('workspace cleanup removal and protection', () => {
       snapshotPruneBatchId: 'batch-1'
     })
 
-    expect(removeWorktree).toHaveBeenCalledWith(candidate.worktreeId, false, {
-      suppressPreservedBranchToast: true,
-      snapshotPruneBatchId: 'batch-1'
-    })
+    expect(removeWorktree).toHaveBeenCalledWith(
+      { id: candidate.worktreeId, executionHostId: 'ssh:ssh-1' },
+      false,
+      { suppressPreservedBranchToast: true, snapshotPruneBatchId: 'batch-1' }
+    )
   })
 
   it('demotes an active suggested workspace when it was not viewed from cleanup', async () => {
@@ -244,9 +253,13 @@ describe('workspace cleanup removal and protection', () => {
       removedIds: [WORKTREE_ID],
       failures: []
     })
-    expect(removeWorktree).toHaveBeenCalledWith(WORKTREE_ID, false, {
-      suppressPreservedBranchToast: true
-    })
+    expect(removeWorktree).toHaveBeenCalledWith(
+      { id: WORKTREE_ID, executionHostId: 'local' },
+      false,
+      {
+        suppressPreservedBranchToast: true
+      }
+    )
   })
 
   it('defers git checks for locally active workspaces on initial scans', async () => {
@@ -358,9 +371,13 @@ describe('workspace cleanup removal and protection', () => {
         failures: []
       }
     )
-    expect(removeWorktree).toHaveBeenCalledWith(WORKTREE_ID, false, {
-      suppressPreservedBranchToast: true
-    })
+    expect(removeWorktree).toHaveBeenCalledWith(
+      { id: WORKTREE_ID, executionHostId: 'local' },
+      false,
+      {
+        suppressPreservedBranchToast: true
+      }
+    )
   })
 
   it('fails a queued removal that now needs a force the user never approved', async () => {
@@ -416,9 +433,13 @@ describe('workspace cleanup removal and protection', () => {
         approvedCandidates: [approvedCandidate]
       })
     ).resolves.toEqual({ removedIds: [WORKTREE_ID], failures: [] })
-    expect(removeWorktree).toHaveBeenCalledWith(WORKTREE_ID, true, {
-      suppressPreservedBranchToast: true
-    })
+    expect(removeWorktree).toHaveBeenCalledWith(
+      { id: WORKTREE_ID, executionHostId: 'local' },
+      true,
+      {
+        suppressPreservedBranchToast: true
+      }
+    )
   })
 
   it('fails a removal that reveals concrete git risk after an unverified force approval', async () => {

--- a/src/renderer/src/store/slices/workspace-cleanup-wrong-host-removal-guard.test.ts
+++ b/src/renderer/src/store/slices/workspace-cleanup-wrong-host-removal-guard.test.ts
@@ -338,7 +338,7 @@ describe('STA-4343 minimal guard: cleanup refuses a removal it cannot attribute 
     store.setState({
       removeWorktree: vi.fn(async (...args: Parameters<typeof originalRemoveWorktree>) => {
         const result = await originalRemoveWorktree(...args)
-        if (args[0] === FIRST_WORKTREE_ID) {
+        if (args[0].id === FIRST_WORKTREE_ID) {
           store.setState({
             activeWorktreeId: WORKTREE_ID,
             activeWorkspaceExecutionHostId: HOST_B_HOST_ID,

--- a/src/renderer/src/store/slices/workspace-cleanup.ts
+++ b/src/renderer/src/store/slices/workspace-cleanup.ts
@@ -405,7 +405,7 @@ export const createWorkspaceCleanupSlice: StateCreator<AppState, [], [], Workspa
         continue
       }
       const result = await get().removeWorktree(
-        candidate.worktreeId,
+        { id: candidate.worktreeId, executionHostId: scannedHostId },
         shouldForceWorkspaceCleanupRemoval(candidate),
         // Why: cleanup reports outcomes in its own summary toasts; per-row
         // preserved-branch warnings would stack one toast per removed row.

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -10,7 +10,6 @@ import type {
   CreateWorktreeArgs,
   CreateWorktreeResult,
   ForceDeleteWorktreeBranchResult,
-  RemoveWorktreeResult,
   SetupDecision
 } from '../../../../shared/worktree/create-types'
 import type { WorktreeStartupLaunch } from '../../../../shared/worktree/launch-types'
@@ -25,7 +24,10 @@ import type {
   Worktree
 } from '../../../../shared/worktree/types'
 import type { TaskSourceContext } from '../../../../shared/task-source-context'
-import type { WorktreeForceDeleteReason } from '../../../../shared/worktree/removal'
+import type {
+  WorktreeForceDeleteReason,
+  WorktreeRemovalTarget
+} from '../../../../shared/worktree/removal'
 import type { TerminalGitHubPRLink } from '../../../../shared/terminal-github-pr-link-detector'
 import type { ExecutionHostId } from '../../../../shared/execution-host'
 import type {
@@ -40,6 +42,7 @@ import type {
 import { getRepoIdFromWorktreeId } from '../../../../shared/worktree/id'
 import type { AppState } from '../types'
 import type { WorktreeRefreshAllOptions } from './worktree-refresh-options'
+import type { RendererRemoveWorktreeResult } from './worktree-removal-result'
 export { getRepoIdFromWorktreeId } from '../../../../shared/worktree/id'
 
 export type WorktreeDeleteState = {
@@ -49,13 +52,6 @@ export type WorktreeDeleteState = {
   canForceDelete: boolean
   forceDeleteReason: WorktreeForceDeleteReason | null
   lockReason?: string | null
-}
-
-type RendererRemoveWorktreeResult = Omit<RemoveWorktreeResult, 'preservedBranch'> & {
-  preservedBranch?: NonNullable<RemoveWorktreeResult['preservedBranch']> & {
-    hostId?: ExecutionHostId
-    runtimeEnvironmentId?: string
-  }
 }
 
 export type WorktreeFetchOptions = {
@@ -243,8 +239,10 @@ export type WorktreeSlice = {
   /** Point the content panel at a pending creation (or clear it with null). */
   setActivePendingWorktreeCreation: (creationId: string | null) => void
   prefetchWorktreeCreateBase: (repoId: string, baseBranch?: string) => Promise<void>
+  /** Destructive: takes a host-qualified target because `id` alone repeats
+   *  across hosts and would delete another host's checkout (STA-4448). */
   removeWorktree: (
-    worktreeId: string,
+    target: WorktreeRemovalTarget,
     force?: boolean,
     // 'forget-local' drops the workspace from Orca only (no remote Git/FS work)
     // for workspaces pinned to a removed/disconnected SSH host. Reuses the same

--- a/src/renderer/src/store/slices/worktree-removal-host-collision-fixture.ts
+++ b/src/renderer/src/store/slices/worktree-removal-host-collision-fixture.ts
@@ -1,0 +1,85 @@
+/**
+ * Shared rig for the STA-4448 wrong-host removal tests.
+ *
+ * One REAL temp directory per execution host stands in for that host's checkout,
+ * each holding a marker file for its uncommitted work. The removal transports are
+ * the only fakes and they ACTUALLY delete the directory of whichever host they are
+ * routed to, so the assertions gate on filesystem state rather than call
+ * arguments — and the single-host controls delete for real through the same rig.
+ */
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
+
+export const COLLIDING_WORKTREE_ID = 'repo1::/shared/workspace/path'
+export const COLLIDING_WORKTREE_PATH = '/shared/workspace/path'
+export const LOCAL_HOST: ExecutionHostId = 'local'
+export const SSH_HOST: ExecutionHostId = 'ssh:ssh-1'
+export const RELAY_HOST: ExecutionHostId = 'runtime:env-1'
+
+export const HOST_COLLISION_MESSAGE =
+  'Error: this workspace exists on multiple hosts at the same path'
+export const HOST_UNRESOLVED_MESSAGE =
+  'Orca cannot tell which host owns this workspace. Refresh projects and review it again.'
+
+export type HostCheckout = { root: string; markerPath: string }
+
+const hostDirCleanup: (() => void)[] = []
+
+/** One real directory per host; its marker file is that host's uncommitted work. */
+export function createHostCheckout(hostId: ExecutionHostId): HostCheckout {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'sta4448-'))
+  hostDirCleanup.push(() => fs.rmSync(root, { recursive: true, force: true }))
+  const markerPath = path.join(root, 'UNCOMMITTED_WORK')
+  fs.writeFileSync(markerPath, `uncommitted work on ${hostId}`)
+  return { root, markerPath }
+}
+
+export function cleanupHostCheckouts(): void {
+  for (const cleanup of hostDirCleanup.splice(0)) {
+    cleanup()
+  }
+}
+
+export type RemovalTransportMocks = {
+  remove: { mockImplementation: (impl: (args: { hostId?: string }) => unknown) => unknown }
+  runtimeCall: {
+    mockImplementation: (
+      impl: (args: { method: string; params?: { hostId?: string } }) => unknown
+    ) => unknown
+  }
+}
+
+/**
+ * Points both destructive transports at the per-host directories: `worktrees.remove`
+ * carries local and SSH removals, `runtimeEnvironments.call` carries paired-runtime
+ * ones. Every routed host id is appended to `routedHostIds` so a refusal can assert
+ * that nothing was dispatched at all.
+ */
+export function installRemovalTransports(
+  transports: RemovalTransportMocks,
+  rootsByHostId: Partial<Record<ExecutionHostId, string>>,
+  routedHostIds: string[]
+): void {
+  const deleteOnHost = (hostId: string | undefined): void => {
+    routedHostIds.push(hostId ?? '<missing>')
+    const root = hostId ? rootsByHostId[hostId as ExecutionHostId] : undefined
+    if (root) {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  }
+  transports.remove.mockImplementation(async (args: { hostId?: string }) => {
+    deleteOnHost(args.hostId)
+    return {}
+  })
+  transports.runtimeCall.mockImplementation(
+    (args: { method: string; params?: { hostId?: string } }) => {
+      // Only the removal RPC is destructive; capability probes share this transport.
+      if (args.method === 'worktree.rm') {
+        deleteOnHost(args.params?.hostId)
+      }
+      return { id: 'rpc-rm', ok: true, result: {}, _meta: { runtimeId: 'runtime-remote' } }
+    }
+  )
+}

--- a/src/renderer/src/store/slices/worktree-removal-host-qualification.test.ts
+++ b/src/renderer/src/store/slices/worktree-removal-host-qualification.test.ts
@@ -1,0 +1,337 @@
+/**
+ * STA-4448: a destructive workspace removal must land on the host whose row the
+ * user confirmed — never on whichever host routing happens to prefer.
+ *
+ * A workspace id is `repoId::path` with no host component, so the local host, an
+ * SSH host and a paired runtime can all publish the SAME id. Removal routing
+ * short-circuits to the ACTIVE workspace's host (`resolveActiveWorkspaceRoute`),
+ * and `state.activeWorktreeId === worktreeId` is true for a colliding id no
+ * matter which row was confirmed. Confirming the remote row therefore issued the
+ * destructive call against the LOCAL checkout and destroyed its uncommitted
+ * work, while the row the user picked survived.
+ *
+ * The fix makes host qualification MANDATORY at `removeWorktree` — the one
+ * chokepoint every delete entry point funnels through — and fails closed rather
+ * than rerouting. Rerouting a colliding row to its right host is #14606's job.
+ *
+ * Rig: one REAL temp directory per host stands in for that host's checkout, each
+ * holding a marker file. The transports (`worktrees.remove` for local/SSH,
+ * `runtimeEnvironments.call` for a paired runtime) are the only fakes, and they
+ * ACTUALLY delete the directory of whichever host they are routed to. The gate
+ * is filesystem state, not call arguments. The single-host controls delete for
+ * real through the same rig, so a passing refusal assertion cannot come from a
+ * rig that never deletes anything.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as fs from 'node:fs'
+import type { AppState } from '../types'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
+import { makeWorktree } from './worktrees-slice-test-fixtures'
+import {
+  createTestStore,
+  mockApi,
+  resetRemoteRuntimeMocks,
+  resetWorktreeSliceModuleMemory,
+  runtimeEnvironmentCall
+} from './worktrees-slice-test-harness'
+import {
+  cleanupHostCheckouts,
+  createHostCheckout,
+  installRemovalTransports as installTransports,
+  COLLIDING_WORKTREE_ID as WORKTREE_ID,
+  COLLIDING_WORKTREE_PATH as WORKTREE_PATH,
+  HOST_COLLISION_MESSAGE,
+  HOST_UNRESOLVED_MESSAGE,
+  LOCAL_HOST,
+  RELAY_HOST,
+  SSH_HOST
+} from './worktree-removal-host-collision-fixture'
+
+vi.mock('sonner', () => ({
+  toast: {
+    warning: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+    dismiss: vi.fn()
+  }
+}))
+
+const FOLDER_WORKSPACE_ID = 'folder:fw-1'
+
+function installRemovalTransports(
+  rootsByHostId: Partial<Record<ExecutionHostId, string>>,
+  routedHostIds: string[]
+): void {
+  installTransports(
+    { remove: mockApi.worktrees.remove, runtimeCall: runtimeEnvironmentCall },
+    rootsByHostId,
+    routedHostIds
+  )
+}
+
+function rowOnHost(hostId: ExecutionHostId) {
+  return makeWorktree({ id: WORKTREE_ID, repoId: 'repo1', path: WORKTREE_PATH, hostId })
+}
+
+function seedHosts(
+  store: ReturnType<typeof createTestStore>,
+  rows: readonly ReturnType<typeof rowOnHost>[],
+  extra: Partial<AppState> = {}
+): void {
+  store.setState({
+    repos: [{ id: 'repo1', path: '/repo1', displayName: 'Repo 1', executionHostId: LOCAL_HOST }],
+    worktreesByRepo: { repo1: [...rows] },
+    ...extra
+  } as Partial<AppState>)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  resetRemoteRuntimeMocks()
+  resetWorktreeSliceModuleMemory()
+})
+
+afterEach(cleanupHostCheckouts)
+
+describe('STA-4448: a colliding id cannot delete the host the user did not confirm', () => {
+  it.each([
+    { label: 'a normal delete', force: false, options: undefined },
+    {
+      label: 'an explicit force delete',
+      force: true,
+      options: { allowUnverifiedPtyStop: true } as const
+    }
+  ])(
+    'leaves the ACTIVE local checkout on disk when $label confirms the SSH row',
+    async ({ force, options }) => {
+      const local = createHostCheckout(LOCAL_HOST)
+      const ssh = createHostCheckout(SSH_HOST)
+      const routedHostIds: string[] = []
+      installRemovalTransports({ [LOCAL_HOST]: local.root, [SSH_HOST]: ssh.root }, routedHostIds)
+
+      const store = createTestStore()
+      // The user opened the LOCAL workspace, so removal routing prefers local.
+      seedHosts(store, [rowOnHost(LOCAL_HOST), rowOnHost(SSH_HOST)], {
+        activeWorktreeId: WORKTREE_ID,
+        activeWorkspaceExecutionHostId: LOCAL_HOST
+      } as Partial<AppState>)
+
+      // The user right-clicked the SSH row and confirmed its deletion.
+      const result = await store
+        .getState()
+        .removeWorktree({ id: WORKTREE_ID, executionHostId: SSH_HOST }, force, options)
+
+      expect(
+        fs.existsSync(local.markerPath),
+        `the ACTIVE local checkout must survive confirming the SSH row; removal was routed to hostId=${routedHostIds.join(',') || '<none>'}`
+      ).toBe(true)
+      // Fail closed, do not reroute: rerouting the colliding row is #14606's job.
+      expect(fs.existsSync(ssh.markerPath)).toBe(true)
+      expect(routedHostIds).toEqual([])
+      expect(result).toEqual({ ok: false, error: HOST_COLLISION_MESSAGE })
+    }
+  )
+
+  it('leaves the ACTIVE local checkout on disk when a paired-runtime row is confirmed', async () => {
+    const local = createHostCheckout(LOCAL_HOST)
+    const relay = createHostCheckout(RELAY_HOST)
+    const routedHostIds: string[] = []
+    installRemovalTransports({ [LOCAL_HOST]: local.root, [RELAY_HOST]: relay.root }, routedHostIds)
+
+    const store = createTestStore()
+    seedHosts(store, [rowOnHost(LOCAL_HOST), rowOnHost(RELAY_HOST)], {
+      activeWorktreeId: WORKTREE_ID,
+      activeWorkspaceExecutionHostId: LOCAL_HOST
+    } as Partial<AppState>)
+
+    const result = await store
+      .getState()
+      .removeWorktree({ id: WORKTREE_ID, executionHostId: RELAY_HOST })
+
+    expect(fs.existsSync(local.markerPath), 'the ACTIVE local checkout must survive').toBe(true)
+    expect(fs.existsSync(relay.markerPath)).toBe(true)
+    expect(routedHostIds).toEqual([])
+    expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
+    expect(result).toEqual({ ok: false, error: HOST_COLLISION_MESSAGE })
+  })
+
+  it('refuses a caller that omits the host while the id collides across hosts', async () => {
+    const local = createHostCheckout(LOCAL_HOST)
+    const ssh = createHostCheckout(SSH_HOST)
+    const routedHostIds: string[] = []
+    installRemovalTransports({ [LOCAL_HOST]: local.root, [SSH_HOST]: ssh.root }, routedHostIds)
+
+    const store = createTestStore()
+    seedHosts(store, [rowOnHost(LOCAL_HOST), rowOnHost(SSH_HOST)], {
+      activeWorktreeId: WORKTREE_ID,
+      activeWorkspaceExecutionHostId: LOCAL_HOST
+    } as Partial<AppState>)
+
+    // An unqualified target is the shape #14606's optional contract allowed any
+    // caller to send; it must not be able to resolve a collision by omission.
+    const result = await store
+      .getState()
+      .removeWorktree({ id: WORKTREE_ID, executionHostId: null }, true, {
+        allowUnverifiedPtyStop: true
+      })
+
+    expect(fs.existsSync(local.markerPath)).toBe(true)
+    expect(fs.existsSync(ssh.markerPath)).toBe(true)
+    expect(routedHostIds).toEqual([])
+    expect(result).toEqual({ ok: false, error: HOST_COLLISION_MESSAGE })
+  })
+
+  it('refuses a confirmed host that no longer owns the id', async () => {
+    const local = createHostCheckout(LOCAL_HOST)
+    const routedHostIds: string[] = []
+    installRemovalTransports({ [LOCAL_HOST]: local.root }, routedHostIds)
+
+    const store = createTestStore()
+    // The SSH row is gone from the refreshed list, but its removal was confirmed.
+    seedHosts(store, [rowOnHost(LOCAL_HOST)])
+
+    const result = await store
+      .getState()
+      .removeWorktree({ id: WORKTREE_ID, executionHostId: SSH_HOST })
+
+    expect(fs.existsSync(local.markerPath), 'the local checkout must survive').toBe(true)
+    expect(routedHostIds).toEqual([])
+    expect(result).toEqual({ ok: false, error: HOST_UNRESOLVED_MESSAGE })
+  })
+
+  it('keeps forget-local available on a colliding id and touches no files', async () => {
+    const local = createHostCheckout(LOCAL_HOST)
+    const ssh = createHostCheckout(SSH_HOST)
+    const routedHostIds: string[] = []
+    installRemovalTransports({ [LOCAL_HOST]: local.root, [SSH_HOST]: ssh.root }, routedHostIds)
+    mockApi.worktrees.forgetLocal.mockResolvedValue({})
+
+    const store = createTestStore()
+    seedHosts(store, [rowOnHost(LOCAL_HOST), rowOnHost(SSH_HOST)], {
+      activeWorktreeId: WORKTREE_ID,
+      activeWorkspaceExecutionHostId: LOCAL_HOST
+    } as Partial<AppState>)
+
+    const result = await store
+      .getState()
+      .removeWorktree({ id: WORKTREE_ID, executionHostId: SSH_HOST }, false, {
+        mode: 'forget-local'
+      })
+
+    // forget-local drops Orca's records only, so it stays available precisely
+    // when the owning host is gone and routing can no longer resolve.
+    expect(result).toEqual({ ok: true })
+    expect(fs.existsSync(local.markerPath)).toBe(true)
+    expect(fs.existsSync(ssh.markerPath)).toBe(true)
+    expect(routedHostIds).toEqual([])
+    expect(mockApi.worktrees.forgetLocal).toHaveBeenCalledWith(
+      expect.objectContaining({ worktreeId: WORKTREE_ID, hostId: SSH_HOST })
+    )
+  })
+})
+
+describe('STA-4448: ordinary single-host deletion still deletes for real', () => {
+  it.each([
+    { label: 'a normal delete', force: false, options: undefined },
+    {
+      label: 'an explicit force delete',
+      force: true,
+      options: { allowUnverifiedPtyStop: true } as const
+    }
+  ])('deletes the confirmed local checkout through $label', async ({ force, options }) => {
+    const local = createHostCheckout(LOCAL_HOST)
+    const routedHostIds: string[] = []
+    installRemovalTransports({ [LOCAL_HOST]: local.root }, routedHostIds)
+
+    const store = createTestStore()
+    seedHosts(store, [rowOnHost(LOCAL_HOST)], {
+      activeWorktreeId: WORKTREE_ID,
+      activeWorkspaceExecutionHostId: LOCAL_HOST
+    } as Partial<AppState>)
+
+    const result = await store
+      .getState()
+      .removeWorktree({ id: WORKTREE_ID, executionHostId: LOCAL_HOST }, force, options)
+
+    expect(result).toEqual({ ok: true })
+    expect(routedHostIds).toEqual([LOCAL_HOST])
+    expect(fs.existsSync(local.markerPath)).toBe(false)
+  })
+
+  it('deletes the confirmed SSH checkout for real', async () => {
+    const ssh = createHostCheckout(SSH_HOST)
+    const routedHostIds: string[] = []
+    installRemovalTransports({ [SSH_HOST]: ssh.root }, routedHostIds)
+
+    const store = createTestStore()
+    seedHosts(store, [rowOnHost(SSH_HOST)])
+
+    const result = await store
+      .getState()
+      .removeWorktree({ id: WORKTREE_ID, executionHostId: SSH_HOST })
+
+    expect(result).toEqual({ ok: true })
+    expect(routedHostIds).toEqual([SSH_HOST])
+    expect(fs.existsSync(ssh.markerPath)).toBe(false)
+  })
+
+  it('deletes the confirmed paired-runtime checkout through its runtime transport', async () => {
+    const relay = createHostCheckout(RELAY_HOST)
+    const routedHostIds: string[] = []
+    installRemovalTransports({ [RELAY_HOST]: relay.root }, routedHostIds)
+
+    const store = createTestStore()
+    seedHosts(store, [rowOnHost(RELAY_HOST)], {
+      settings: { activeRuntimeEnvironmentId: 'env-1' }
+    } as Partial<AppState>)
+
+    const result = await store
+      .getState()
+      .removeWorktree({ id: WORKTREE_ID, executionHostId: RELAY_HOST })
+
+    expect(result).toEqual({ ok: true })
+    expect(routedHostIds).toEqual([RELAY_HOST])
+    expect(mockApi.worktrees.remove).not.toHaveBeenCalled()
+    expect(fs.existsSync(relay.markerPath)).toBe(false)
+  })
+
+  it('deletes a pre-host-qualified row that declares no host at all', async () => {
+    const local = createHostCheckout(LOCAL_HOST)
+    const routedHostIds: string[] = []
+    installRemovalTransports({ [LOCAL_HOST]: local.root }, routedHostIds)
+
+    const store = createTestStore()
+    // Snapshot/legacy rows publish no hostId; the repo's host still routes them.
+    seedHosts(store, [makeWorktree({ id: WORKTREE_ID, repoId: 'repo1', path: WORKTREE_PATH })])
+
+    const result = await store.getState().removeWorktree({ id: WORKTREE_ID, executionHostId: null })
+
+    expect(result).toEqual({ ok: true })
+    expect(routedHostIds).toEqual([LOCAL_HOST])
+    expect(fs.existsSync(local.markerPath)).toBe(false)
+  })
+
+  it('deletes a folder workspace, which is not a git worktree at all', async () => {
+    const local = createHostCheckout(LOCAL_HOST)
+    const routedHostIds: string[] = []
+    installRemovalTransports({ [LOCAL_HOST]: local.root }, routedHostIds)
+
+    const store = createTestStore()
+    store.setState({
+      repos: [],
+      worktreesByRepo: {},
+      folderWorkspaces: [{ id: 'fw-1', executionHostId: LOCAL_HOST }]
+    } as unknown as Partial<AppState>)
+
+    const result = await store
+      .getState()
+      .removeWorktree({ id: FOLDER_WORKSPACE_ID, executionHostId: LOCAL_HOST }, true, {
+        allowUnverifiedPtyStop: true
+      })
+
+    expect(result).toEqual({ ok: true })
+    expect(routedHostIds).toEqual([LOCAL_HOST])
+    expect(fs.existsSync(local.markerPath)).toBe(false)
+  })
+})

--- a/src/renderer/src/store/slices/worktree-removal-host-qualification.test.ts
+++ b/src/renderer/src/store/slices/worktree-removal-host-qualification.test.ts
@@ -231,6 +231,38 @@ describe('STA-4448: a colliding id cannot delete the host the user did not confi
   })
 })
 
+describe('a refused removal must not strand the row on a "Deleting…" spinner', () => {
+  it.each([
+    {
+      label: 'the wrong-host refusal',
+      seedRows: () => [rowOnHost(LOCAL_HOST), rowOnHost(SSH_HOST)],
+      target: { id: WORKTREE_ID, executionHostId: SSH_HOST } as const
+    },
+    {
+      label: 'the unresolvable-route refusal',
+      seedRows: () => [rowOnHost(LOCAL_HOST), rowOnHost(SSH_HOST)],
+      target: { id: WORKTREE_ID, executionHostId: null } as const
+    }
+  ])('clears the delete state after $label', async ({ seedRows, target }) => {
+    const store = createTestStore()
+    seedHosts(store, seedRows(), {
+      activeWorktreeId: WORKTREE_ID,
+      activeWorkspaceExecutionHostId: LOCAL_HOST
+    } as Partial<AppState>)
+
+    // Callers mark rows deleting up front so the sidebar shows progress immediately.
+    store.getState().markWorktreesDeleting([WORKTREE_ID])
+    expect(store.getState().deleteStateByWorktreeId[WORKTREE_ID]?.isDeleting).toBe(true)
+
+    const result = await store.getState().removeWorktree(target, false, undefined)
+
+    expect(result.ok).toBe(false)
+    // Why: the refusal returns before removeWorktree's try/catch, so without an
+    // explicit clear the row keeps spinning long after the toast auto-dismisses.
+    expect(store.getState().deleteStateByWorktreeId[WORKTREE_ID]?.isDeleting).toBeFalsy()
+  })
+})
+
 describe('STA-4448: ordinary single-host deletion still deletes for real', () => {
   it.each([
     { label: 'a normal delete', force: false, options: undefined },

--- a/src/renderer/src/store/slices/worktree-removal-maps-leak.test.ts
+++ b/src/renderer/src/store/slices/worktree-removal-maps-leak.test.ts
@@ -155,7 +155,7 @@ describe('worktree removal evicts the per-worktree + per-page maps it previously
     const store = createTestStore()
     seedWorktreeKeyedMaps(store)
 
-    const result = await store.getState().removeWorktree(WT1)
+    const result = await store.getState().removeWorktree({ id: WT1, executionHostId: null })
     expect(result).toEqual({ ok: true })
 
     const s = store.getState()
@@ -255,7 +255,7 @@ describe('worktree removal evicts the per-worktree + per-page maps it previously
       }
     })
 
-    const result = await store.getState().removeWorktree(WT1)
+    const result = await store.getState().removeWorktree({ id: WT1, executionHostId: null })
 
     expect(result).toEqual({ ok: true })
     const s = store.getState()

--- a/src/renderer/src/store/slices/worktree-removal-result.ts
+++ b/src/renderer/src/store/slices/worktree-removal-result.ts
@@ -1,0 +1,16 @@
+import type { ExecutionHostId } from '../../../../shared/execution-host'
+import type { RemoveWorktreeResult } from '../../../../shared/worktree/create-types'
+
+/**
+ * What `removeWorktree` resolves with on success.
+ *
+ * The renderer widens main's result: a preserved branch has to name the host (and
+ * paired-runtime transport) it was preserved on, or the follow-up force-delete
+ * cannot find it again on a multi-host repo.
+ */
+export type RendererRemoveWorktreeResult = Omit<RemoveWorktreeResult, 'preservedBranch'> & {
+  preservedBranch?: NonNullable<RemoveWorktreeResult['preservedBranch']> & {
+    hostId?: ExecutionHostId
+    runtimeEnvironmentId?: string
+  }
+}

--- a/src/renderer/src/store/slices/worktrees-remote-runtime-removal.test.ts
+++ b/src/renderer/src/store/slices/worktrees-remote-runtime-removal.test.ts
@@ -48,9 +48,11 @@ describe('worktree remote runtime mutations', () => {
       worktreesByRepo: { repo1: [wt] }
     } as Partial<AppState>)
 
-    const result = await store.getState().removeWorktree(wt.id, false, {
-      snapshotPruneBatchId: 'batch-1'
-    })
+    const result = await store
+      .getState()
+      .removeWorktree({ id: wt.id, executionHostId: null }, false, {
+        snapshotPruneBatchId: 'batch-1'
+      })
 
     expect(result).toEqual({ ok: true })
     expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
@@ -109,7 +111,7 @@ describe('worktree remote runtime mutations', () => {
       worktreesByRepo: { 'repo-ssh': [wt] }
     } as Partial<AppState>)
 
-    const result = await store.getState().removeWorktree(wt.id)
+    const result = await store.getState().removeWorktree({ id: wt.id, executionHostId: null })
 
     expect(result).toEqual({
       ok: true,
@@ -191,11 +193,11 @@ describe('worktree remote runtime mutations', () => {
       worktreesByRepo: { 'repo-shared': [localWorktree] }
     } as Partial<AppState>)
 
-    await store.getState().removeWorktree(worktreeId)
+    await store.getState().removeWorktree({ id: worktreeId, executionHostId: null })
     store.setState({
       worktreesByRepo: { 'repo-shared': [remoteWorktree] }
     } as Partial<AppState>)
-    await store.getState().removeWorktree(worktreeId)
+    await store.getState().removeWorktree({ id: worktreeId, executionHostId: null })
 
     await store
       .getState()
@@ -261,11 +263,11 @@ describe('worktree remote runtime mutations', () => {
       worktreesByRepo: { 'repo-shared': [localWorktree] }
     } as Partial<AppState>)
 
-    await store.getState().removeWorktree(worktreeId)
+    await store.getState().removeWorktree({ id: worktreeId, executionHostId: 'local' })
     store.setState({
       worktreesByRepo: { 'repo-shared': [remoteWorktree] }
     } as Partial<AppState>)
-    await store.getState().removeWorktree(worktreeId)
+    await store.getState().removeWorktree({ id: worktreeId, executionHostId: 'ssh:shared-target' })
 
     const result = await store
       .getState()
@@ -306,7 +308,7 @@ describe('worktree remote runtime mutations', () => {
       }
     } as Partial<AppState>)
 
-    const result = await store.getState().removeWorktree(worktreeId)
+    const result = await store.getState().removeWorktree({ id: worktreeId, executionHostId: null })
 
     expect(result).toEqual({
       ok: false,
@@ -337,7 +339,7 @@ describe('worktree remote runtime mutations', () => {
         worktreesByRepo: { 'repo-gone': [wt] }
       } as Partial<AppState>)
 
-      const result = await store.getState().removeWorktree(wt.id)
+      const result = await store.getState().removeWorktree({ id: wt.id, executionHostId: null })
 
       expect(result).toEqual({ ok: true })
       expect(mockApi.worktrees.forgetLocal).toHaveBeenCalledWith({
@@ -376,7 +378,7 @@ describe('worktree remote runtime mutations', () => {
       worktreesByRepo: { 'repo-shared': [original] }
     } as Partial<AppState>)
 
-    const result = await store.getState().removeWorktree(worktreeId)
+    const result = await store.getState().removeWorktree({ id: worktreeId, executionHostId: null })
 
     expect(result).toEqual({
       ok: false,
@@ -408,7 +410,7 @@ describe('worktree remote runtime mutations', () => {
       worktreesByRepo: { repo1: [wt] }
     } as Partial<AppState>)
 
-    const result = await store.getState().removeWorktree(wt.id)
+    const result = await store.getState().removeWorktree({ id: wt.id, executionHostId: null })
 
     expect(result).toEqual({
       ok: false,
@@ -426,7 +428,7 @@ describe('worktree remote runtime mutations', () => {
     const wt = makeWorktree({ id: 'repo1::/w/one', repoId: 'repo1', path: '/w/one' })
     store.setState({ worktreesByRepo: { repo1: [wt] } } as Partial<AppState>)
 
-    await store.getState().removeWorktree(wt.id, true)
+    await store.getState().removeWorktree({ id: wt.id, executionHostId: null }, true)
     expect(mockApi.worktrees.remove).toHaveBeenLastCalledWith(
       expect.objectContaining({ force: true, allowUnverifiedPtyStop: false })
     )
@@ -436,7 +438,9 @@ describe('worktree remote runtime mutations', () => {
     const retry = makeWorktree({ id: 'repo1::/w/two', repoId: 'repo1', path: '/w/two' })
     store.setState({ worktreesByRepo: { repo1: [retry] } } as Partial<AppState>)
 
-    await store.getState().removeWorktree(retry.id, true, { allowUnverifiedPtyStop: true })
+    await store.getState().removeWorktree({ id: retry.id, executionHostId: null }, true, {
+      allowUnverifiedPtyStop: true
+    })
     expect(mockApi.worktrees.remove).toHaveBeenLastCalledWith(
       expect.objectContaining({ force: true, allowUnverifiedPtyStop: true })
     )
@@ -464,7 +468,7 @@ describe('worktree remote runtime mutations', () => {
       worktreesByRepo: { 'repo-ssh': [wt] }
     } as Partial<AppState>)
 
-    const result = await store.getState().removeWorktree(wt.id)
+    const result = await store.getState().removeWorktree({ id: wt.id, executionHostId: null })
 
     expect(result).toEqual({ ok: true })
     expect(mockApi.worktrees.remove).toHaveBeenCalledWith({
@@ -502,7 +506,7 @@ describe('worktree remote runtime mutations', () => {
       }
     } as Partial<AppState>)
 
-    const result = await store.getState().removeWorktree(worktreeId)
+    const result = await store.getState().removeWorktree({ id: worktreeId, executionHostId: null })
 
     expect(result).toEqual({
       ok: false,

--- a/src/renderer/src/store/slices/worktrees-removal-state-cleanup.test.ts
+++ b/src/renderer/src/store/slices/worktrees-removal-state-cleanup.test.ts
@@ -52,7 +52,7 @@ describe('removeWorktree state cleanup', () => {
     const staleProbe = beginHugeRepoWarningProbe(removed)
     expect(markHugeRepoWarningDismissed(staleProbe)).toBe(true)
 
-    await store.getState().removeWorktree(removed.id)
+    await store.getState().removeWorktree({ id: removed.id, executionHostId: null })
 
     // The same-path replacement can reuse persisted instance metadata.
     const replacementProbe = beginHugeRepoWarningProbe({ ...removed })
@@ -74,7 +74,7 @@ describe('removeWorktree state cleanup', () => {
     expect(markHugeRepoWarningDismissed(retainedProbe)).toBe(true)
     mockApi.worktrees.remove.mockRejectedValueOnce(new Error('delete failed'))
 
-    const result = await store.getState().removeWorktree(retained.id)
+    const result = await store.getState().removeWorktree({ id: retained.id, executionHostId: null })
 
     expect(result).toEqual({ ok: false, error: 'delete failed' })
     expect(hasDismissedHugeRepoWarning(retainedProbe)).toBe(true)
@@ -99,7 +99,7 @@ describe('removeWorktree state cleanup', () => {
     expect(getHostedReviewLinkMutationGenerationForTests(removed.id)).toBeGreaterThan(0)
     expect(getHostedReviewLinkMutationGenerationForTests(surviving.id)).toBeGreaterThan(0)
 
-    await store.getState().removeWorktree(removed.id)
+    await store.getState().removeWorktree({ id: removed.id, executionHostId: null })
 
     expect(getHostedReviewLinkMutationGenerationForTests(removed.id)).toBe(0)
     expect(getHostedReviewLinkMutationGenerationForTests(surviving.id)).toBeGreaterThan(0)
@@ -121,7 +121,7 @@ describe('removeWorktree state cleanup', () => {
       canExpandPaneByTabId: { 'removed-tab': false, 'surviving-tab': true }
     } as unknown as Partial<AppState>)
 
-    await store.getState().removeWorktree(removed.id)
+    await store.getState().removeWorktree({ id: removed.id, executionHostId: null })
 
     expect(store.getState().expandedPaneByTabId).toEqual({ 'surviving-tab': false })
     expect(store.getState().canExpandPaneByTabId).toEqual({ 'surviving-tab': true })
@@ -160,7 +160,7 @@ describe('removeWorktree state cleanup', () => {
       }
     } as Partial<AppState>)
 
-    await store.getState().removeWorktree(removed.id)
+    await store.getState().removeWorktree({ id: removed.id, executionHostId: null })
 
     expect(store.getState().automaticAgentResumeClaimsByTabId).toEqual({
       'surviving-tab': {
@@ -197,7 +197,7 @@ describe('removeWorktree state cleanup', () => {
       }
     ])
 
-    await store.getState().removeWorktree('repo1::/path/wt1')
+    await store.getState().removeWorktree({ id: 'repo1::/path/wt1', executionHostId: null })
 
     // Only the orphaned runtime-owned project setup is purged; the user's SSH project is untouched.
     expect(deleteProjectHostSetup).toHaveBeenCalledTimes(1)
@@ -228,7 +228,9 @@ describe('removeWorktree state cleanup', () => {
       }
     } as unknown as Partial<AppState>)
 
-    const result = await store.getState().removeWorktree('repo1::/path/wt1')
+    const result = await store
+      .getState()
+      .removeWorktree({ id: 'repo1::/path/wt1', executionHostId: null })
 
     expect(result).toEqual({ ok: true })
     // Draft for file-1 should be removed, draft for file-2 should remain
@@ -254,7 +256,7 @@ describe('removeWorktree state cleanup', () => {
       }
     } as Partial<AppState>)
 
-    await store.getState().removeWorktree(wt.id)
+    await store.getState().removeWorktree({ id: wt.id, executionHostId: null })
 
     expect(store.getState().worktreeLineageById).toEqual({
       'repo1::/path/wt2': siblingLineage
@@ -285,7 +287,7 @@ describe('removeWorktree state cleanup', () => {
       }
     } as unknown as Partial<AppState>)
 
-    await store.getState().removeWorktree('repo1::/path/wt1')
+    await store.getState().removeWorktree({ id: 'repo1::/path/wt1', executionHostId: null })
 
     expect(store.getState().markdownViewMode).toEqual({ 'file-2': 'source' })
   })
@@ -314,7 +316,7 @@ describe('removeWorktree state cleanup', () => {
       }
     } as unknown as Partial<AppState>)
 
-    await store.getState().removeWorktree('repo1::/path/wt1')
+    await store.getState().removeWorktree({ id: 'repo1::/path/wt1', executionHostId: null })
 
     expect(store.getState().editorViewMode).toEqual({ 'file-2': 'changes' })
   })
@@ -343,7 +345,7 @@ describe('removeWorktree state cleanup', () => {
       }
     } as unknown as Partial<AppState>)
 
-    await store.getState().removeWorktree('repo1::/path/wt1')
+    await store.getState().removeWorktree({ id: 'repo1::/path/wt1', executionHostId: null })
 
     expect(store.getState().markdownFrontmatterVisible).toEqual({ 'file-2': true })
   })
@@ -372,7 +374,7 @@ describe('removeWorktree state cleanup', () => {
       }
     } as unknown as Partial<AppState>)
 
-    await store.getState().removeWorktree('repo1::/path/wt1')
+    await store.getState().removeWorktree({ id: 'repo1::/path/wt1', executionHostId: null })
 
     expect(store.getState().markdownFrontmatterVisible).toEqual({ 'file-2': true })
   })
@@ -395,7 +397,7 @@ describe('removeWorktree state cleanup', () => {
     }
 
     try {
-      await store.getState().removeWorktree(wt.id)
+      await store.getState().removeWorktree({ id: wt.id, executionHostId: null })
     } finally {
       globalWithDocument.document = originalDocument
     }
@@ -417,7 +419,7 @@ describe('removeWorktree state cleanup', () => {
       }
     } as Partial<AppState>)
 
-    await store.getState().removeWorktree('repo1::/path/wt1')
+    await store.getState().removeWorktree({ id: 'repo1::/path/wt1', executionHostId: null })
 
     expect(store.getState().expandedDirs).toEqual({
       'repo1::/path/wt2': new Set(['test'])
@@ -436,7 +438,7 @@ describe('removeWorktree state cleanup', () => {
       }
     } as Partial<AppState>)
 
-    await store.getState().removeWorktree('repo1::/path/wt1')
+    await store.getState().removeWorktree({ id: 'repo1::/path/wt1', executionHostId: null })
 
     expect(store.getState().showDotfilesByWorktree).toEqual({
       'repo1::/path/wt2': false
@@ -455,7 +457,7 @@ describe('removeWorktree state cleanup', () => {
       }
     } as Partial<AppState>)
 
-    await store.getState().removeWorktree('repo1::/path/wt1')
+    await store.getState().removeWorktree({ id: 'repo1::/path/wt1', executionHostId: null })
 
     expect(store.getState().activeTabIdByWorktree).toEqual({
       'repo1::/path/wt2': 'tab-2'
@@ -474,7 +476,7 @@ describe('removeWorktree state cleanup', () => {
       }
     } as Partial<AppState>)
 
-    await store.getState().removeWorktree('repo1::/path/wt1')
+    await store.getState().removeWorktree({ id: 'repo1::/path/wt1', executionHostId: null })
 
     expect(store.getState().tabBarOrderByWorktree).toEqual({
       'repo1::/path/wt2': ['tab-2']
@@ -513,7 +515,7 @@ describe('removeWorktree state cleanup', () => {
       }
     } as unknown as Partial<AppState>)
 
-    await store.getState().removeWorktree('repo1::/path/wt1')
+    await store.getState().removeWorktree({ id: 'repo1::/path/wt1', executionHostId: null })
 
     expect(store.getState().pendingReconnectTabByWorktree).toEqual({
       'repo1::/path/wt2': ['tab-2']
@@ -580,7 +582,7 @@ describe('removeWorktree state cleanup', () => {
       }
     } as unknown as Partial<AppState>)
 
-    await store.getState().removeWorktree('repo1::/path/wt1')
+    await store.getState().removeWorktree({ id: 'repo1::/path/wt1', executionHostId: null })
 
     expect(store.getState().gitStatusByWorktree).toEqual({
       'repo1::/path/wt2': [{ path: 'b.ts' }]
@@ -627,7 +629,7 @@ describe('removeWorktree state cleanup', () => {
       }
     } as unknown as Partial<AppState>)
 
-    await store.getState().removeWorktree('repo1::/path/wt1')
+    await store.getState().removeWorktree({ id: 'repo1::/path/wt1', executionHostId: null })
 
     expect(store.getState().recentlyClosedBrowserTabsByWorktree).toEqual({
       'repo1::/path/wt2': [{ workspace: { id: 'workspace-2' }, pages: [] }]
@@ -645,7 +647,7 @@ describe('removeWorktree state cleanup', () => {
       editorDrafts: drafts
     } as Partial<AppState>)
 
-    await store.getState().removeWorktree('repo1::/path/wt1')
+    await store.getState().removeWorktree({ id: 'repo1::/path/wt1', executionHostId: null })
 
     // The same reference should be returned (no unnecessary shallow copy)
     expect(store.getState().editorDrafts).toBe(drafts)

--- a/src/renderer/src/store/slices/worktrees/teardown/remove-worktree-host-guard.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/remove-worktree-host-guard.ts
@@ -1,0 +1,41 @@
+import { translate } from '@/i18n/i18n'
+import {
+  collectWorktreeOwnerExecutionHostIds,
+  type WorktreeOperationRouteState
+} from '@/lib/worktree-operation-route'
+import type { ExecutionHostId } from '../../../../../../shared/execution-host'
+import {
+  verifyWorktreeRemovalHost,
+  type WorktreeRemovalTarget
+} from '../../../../../../shared/worktree/removal'
+
+/**
+ * The refusal to report, or null when the removal provably lands on the host
+ * whose row was confirmed (STA-4448).
+ *
+ * Reuses the cleanup dialog's copy (#14731) so both delete surfaces explain a
+ * wrong-host refusal in the same words.
+ */
+export function refuseWrongHostWorktreeRemoval(
+  state: WorktreeOperationRouteState,
+  target: WorktreeRemovalTarget,
+  routeExecutionHostId: ExecutionHostId | null
+): string | null {
+  const verdict = verifyWorktreeRemovalHost({
+    confirmedExecutionHostId: target.executionHostId,
+    ownerExecutionHostIds: collectWorktreeOwnerExecutionHostIds(state, target.id),
+    routeExecutionHostId
+  })
+  if (verdict.kind === 'allowed') {
+    return null
+  }
+  return verdict.reason === 'collision'
+    ? translate(
+        'auto.store.slices.workspace.cleanup.hostCollision',
+        'Error: this workspace exists on multiple hosts at the same path'
+      )
+    : translate(
+        'auto.store.slices.workspace.cleanup.hostUnresolved',
+        'Orca cannot tell which host owns this workspace. Refresh projects and review it again.'
+      )
+}

--- a/src/renderer/src/store/slices/worktrees/teardown/remove-worktree.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/remove-worktree.ts
@@ -19,6 +19,7 @@ import {
   resolveWorktreeOperationRouteResult,
   settingsForWorktreeOperationRoute
 } from '@/lib/worktree-operation-route'
+import { refuseWrongHostWorktreeRemoval } from './remove-worktree-host-guard'
 import { captureWorktreeOperationGenerationGuard } from '@/lib/worktree-operation-generation'
 import {
   classifyWorktreeForceDeleteReason,
@@ -42,13 +43,28 @@ export function createRemoveWorktree(
   set: WorktreeSliceSet,
   get: WorktreeSliceGet
 ): WorktreeSlice['removeWorktree'] {
-  return async (worktreeId, force, options) => {
+  return async (removalTarget, force, options) => {
+    const worktreeId = removalTarget.id
     const forgetLocalOnly = options?.mode === 'forget-local'
     const removalRoute = resolveWorktreeOperationRoute(get(), worktreeId)
     if (!forgetLocalOnly && !removalRoute) {
       return { ok: false, error: WORKTREE_REMOVAL_AMBIGUOUS_ERROR }
     }
-    const hostId = removalRoute?.executionHostId ?? undefined
+    // Why (STA-4448): this is the ONE chokepoint every delete entry point shares,
+    // so host qualification is enforced here rather than at any single caller —
+    // a guard bolted onto the sidebar would drift from the cleanup dialog's.
+    // forget-local is exempt: it removes no files or Git state (see
+    // `worktrees:forgetLocal`), and it must stay available precisely when the
+    // owning host is gone and routing can no longer resolve.
+    const wrongHostRefusal = forgetLocalOnly
+      ? null
+      : refuseWrongHostWorktreeRemoval(get(), removalTarget, removalRoute?.executionHostId ?? null)
+    if (wrongHostRefusal) {
+      return { ok: false, error: wrongHostRefusal }
+    }
+    // The confirmed host outranks the route: they can only differ on the
+    // forget-local path, where the confirmed row is the better evidence.
+    const hostId = removalTarget.executionHostId ?? removalRoute?.executionHostId ?? undefined
     const removalGenerationGuard = removalRoute
       ? captureWorktreeOperationGenerationGuard(
           get,

--- a/src/renderer/src/store/slices/worktrees/teardown/remove-worktree.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/remove-worktree.ts
@@ -48,6 +48,11 @@ export function createRemoveWorktree(
     const forgetLocalOnly = options?.mode === 'forget-local'
     const removalRoute = resolveWorktreeOperationRoute(get(), worktreeId)
     if (!forgetLocalOnly && !removalRoute) {
+      // Why: callers mark rows deleting up front for immediate sidebar feedback
+      // (worktree-delete-execution.ts), and these refusals return before the
+      // try/catch that would otherwise clear it — so the row would sit on a
+      // "Deleting…" spinner forever after the toast auto-dismisses.
+      get().clearWorktreeDeleteState(worktreeId)
       return { ok: false, error: WORKTREE_REMOVAL_AMBIGUOUS_ERROR }
     }
     // Why (STA-4448): this is the ONE chokepoint every delete entry point shares,
@@ -60,6 +65,7 @@ export function createRemoveWorktree(
       ? null
       : refuseWrongHostWorktreeRemoval(get(), removalTarget, removalRoute?.executionHostId ?? null)
     if (wrongHostRefusal) {
+      get().clearWorktreeDeleteState(worktreeId)
       return { ok: false, error: wrongHostRefusal }
     }
     // The confirmed host outranks the route: they can only differ on the

--- a/src/shared/worktree/removal.ts
+++ b/src/shared/worktree/removal.ts
@@ -1,4 +1,5 @@
-import type { GitWorktreeInfo } from './types'
+import type { ExecutionHostId } from '../execution-host'
+import type { GitWorktreeInfo, Worktree } from './types'
 
 export const LOCKED_WORKTREE_REMOVAL_PREFIX = 'Worktree is locked by Git.'
 
@@ -121,4 +122,65 @@ export function classifyWorktreeForceDeleteReason(
     return 'dirty'
   }
   return null
+}
+
+// ─── Host qualification (STA-4448) ───────────────────────────────────
+//
+// A workspace id is `repoId::path` with no host component, so the local host, an
+// SSH host and a paired runtime can all publish the SAME id. Removing by that id
+// alone destroys whichever checkout routing happens to pick — and routing prefers
+// the ACTIVE workspace's host, which is usually not the row the user confirmed.
+//
+// So a destructive removal travels as a host-qualified target, and the chokepoint
+// refuses whenever the confirmed host is not where the removal would actually
+// land. Fail closed, never reroute: rerouting a colliding row to its right host is
+// #14606's job and needs evidence this layer does not have.
+
+/**
+ * Identity for a destructive workspace removal.
+ *
+ * `executionHostId` is required but nullable on purpose: `null` states that the
+ * confirmed row itself declares no host (a pre-host-qualified snapshot row), so
+ * a caller has to make that claim deliberately instead of omitting the field.
+ */
+export type WorktreeRemovalTarget = {
+  id: string
+  executionHostId: ExecutionHostId | null
+}
+
+export function toWorktreeRemovalTarget(
+  worktree: Pick<Worktree, 'id' | 'hostId'>
+): WorktreeRemovalTarget {
+  return { id: worktree.id, executionHostId: worktree.hostId ?? null }
+}
+
+export type WorktreeRemovalHostVerdict =
+  | { kind: 'allowed' }
+  /** `collision`: two hosts own the id. `unresolved`: one owner, but not the confirmed one. */
+  | { kind: 'refused'; reason: 'collision' | 'unresolved' }
+
+/**
+ * Allows a removal only when it provably lands on the host whose row was
+ * confirmed.
+ *
+ * An unqualified target still deletes while the id has at most one declared
+ * owner — that keeps legacy/snapshot rows and folder workspaces working — but
+ * it can never resolve a collision, so it is refused as soon as one exists.
+ */
+export function verifyWorktreeRemovalHost(args: {
+  /** Host the confirmed row declared, or null when it declared none. */
+  confirmedExecutionHostId: ExecutionHostId | null
+  /** Every host that currently claims this id; unqualified rows contribute nothing. */
+  ownerExecutionHostIds: readonly ExecutionHostId[]
+  /** Host the removal would actually reach, as resolved by operation routing. */
+  routeExecutionHostId: ExecutionHostId | null
+}): WorktreeRemovalHostVerdict {
+  const collides = new Set(args.ownerExecutionHostIds).size > 1
+  if (!args.confirmedExecutionHostId) {
+    return collides ? { kind: 'refused', reason: 'collision' } : { kind: 'allowed' }
+  }
+  if (args.routeExecutionHostId === args.confirmedExecutionHostId) {
+    return { kind: 'allowed' }
+  }
+  return { kind: 'refused', reason: collides ? 'collision' : 'unresolved' }
 }

--- a/src/shared/worktree/removal.ts
+++ b/src/shared/worktree/removal.ts
@@ -46,6 +46,20 @@ export function isProvenLivePtyRemovalError(error: string): boolean {
   )
 }
 
+/**
+ * True when the removal was refused because the same workspace path exists on
+ * more than one execution host, so routing cannot say which one the row is.
+ *
+ * Matched on the message because the refusal is raised as a plain Error from
+ * the store slice; keep this in step with WORKTREE_REMOVAL_AMBIGUOUS_ERROR.
+ */
+export function isAmbiguousHostRemovalError(error: string): boolean {
+  return error.includes(AMBIGUOUS_HOST_REMOVAL_MARKER)
+}
+
+/** The stable fragment of WORKTREE_REMOVAL_AMBIGUOUS_ERROR that identifies the refusal. */
+export const AMBIGUOUS_HOST_REMOVAL_MARKER = 'ambiguous across hosts'
+
 export function createLockedWorktreeRemovalError(lockReason?: string): Error {
   const reason = lockReason?.trim()
   return new Error(


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​836 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​131 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​705 |
| Prod | 18 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​389 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​43 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​346 |

<!-- /orca-pr-loc -->

## ELI5

A workspace's id is just `repoId::path`. It has no host in it. So your laptop, an SSH box and a paired
runtime can all publish the **same id** for what are three different checkouts. When you clicked delete
on the remote row, Orca looked up "which host?" by asking the *active* workspace — and got your **local**
checkout. It deleted that instead, uncommitted work and all, while the row you actually picked stayed on
screen. This PR makes the delete carry the host you confirmed, and refuses when the delete would land
somewhere else.

## What Changed

Host qualification is now **mandatory at the single chokepoint every delete surface shares**,
`removeWorktree`.

- `src/shared/worktree/removal.ts` — new `WorktreeRemovalTarget` (`{ id, executionHostId }`),
  `toWorktreeRemovalTarget()`, and the pure verdict function `verifyWorktreeRemovalHost()`.
  `executionHostId` is required but **nullable**: `null` is a caller *stating* "this row declares no
  host" (legacy/snapshot rows, folder workspaces), not a caller forgetting the field.
- `remove-worktree.ts` — `removeWorktree(target, …)` now takes the qualified target and calls the new
  `refuseWrongHostWorktreeRemoval()` guard before any destructive work. The confirmed host outranks the
  route.
- `worktree-operation-route.ts` — `collectWorktreeOwnerExecutionHostIds()` enumerates every host that
  claims an id (unqualified rows contribute nothing, so migration can't invent collisions).
- All destructive callers migrated to pass a host-qualified target.
- `worktree-delete-request.ts` — `WorktreeDeleteIdentity` carries `hostId`, and batch-target resolution
  rejects a request whose confirmed `hostId` no longer matches the row a refresh swapped in.
- `worktree-removal-result.ts` — extracted `RendererRemoveWorktreeResult` out of `worktree-helpers.ts`
  (import-cycle avoidance; no behavior change).
- 16 new outcome tests, plus a shared collision fixture.

**Omitting the host is a type error**, so a future delete entry point cannot be written unguarded.

## Why

**P0 data loss.** A workspace id is `repoId::path` with no host component, so local, SSH and paired
runtime rows can share one id. Removal routing short-circuits to the ACTIVE workspace's host, and
`activeWorktreeId === id` holds for a colliding id no matter which row was confirmed — so confirming the
**remote** row issued the destructive IPC against the **local** checkout and destroyed its uncommitted
work, while the row the user picked survived.

**Why not another caller-side guard.** #14731 guarded a *caller* (the cleanup preflight), which is
exactly why every other delete surface sailed straight past it. Guarding one more caller would have the
same shape and the same failure mode. This puts qualification at the one chokepoint they all share and
lets the type system enforce it.

**Approach (a): fail closed, never reroute.** When the confirmed host is not where the removal would
land, refuse. Rerouting a colliding row to its correct host is #14606's job and needs evidence this
layer does not have — and #14606 can now **adopt** this contract rather than reconcile with it.

**`forget-local` is deliberately exempt.** It removes no files and no Git state; it drops the workspace
from Orca's own records. It must keep working *precisely* when the owning host is gone and routing can
no longer resolve — which is the one situation the guard would refuse in.

**Refusal copy reuses #14731's existing strings** (`auto.store.slices.workspace.cleanup.hostCollision` /
`.hostUnresolved`). **No new user-facing strings**; `en.json` is untouched.

### Per-caller verdict table (all 8 destructive callers)

| # | Caller | Verdict | How the host is obtained |
|---|--------|---------|--------------------------|
| 1 | `delete-worktree-flow.ts` → skip-confirm delete | **Qualified** | `toWorktreeRemovalTarget(target)` from the resolved row |
| 2 | `worktree-delete-execution.ts` → `runWorktreeDeleteWithToast` (confirmed delete, and the batch path) | **Qualified** | takes a `WorktreeRemovalTarget`; batch uses `toWorktreeRemovalTarget(target)` |
| 3 | `worktree-delete-execution.ts` → in-toast Force Delete retry | **Qualified** | reuses the same confirmed `target` |
| 4 | `DeleteWorktreeDialog.tsx` → in-dialog Force Delete | **Qualified** | looks the confirmed row up in `currentWorktrees`; **returns early if the row is gone** rather than force-deleting a bare id |
| 5 | `workspace-cleanup.ts` → cleanup removal | **Qualified** | `scannedHostId` — the host the scan actually inspected |
| 6 | `WorkspaceSpaceManagerPanel.tsx` → Space-manager force recovery *(not in the ticket)* | **Qualified** | `worktree.executionHostId` from the scan row (the panel lists one row per host) |
| 7 | `ssh-host-remove-workspaces.ts` → clear all workspaces for an SSH host *(not in the ticket)* | **Qualified** | `toSshExecutionHostId(resolution.targetId)` — every row in the resolution is pinned to that target |
| 8 | `ForgetSshWorkspaceDialog.tsx` → forget / delete for a disconnected SSH host *(not in the ticket)* | **Qualified**; the forget path is **exempt by design** | the dialog only opens for a workspace pinned to a named SSH target |

Callers 6, 7 and 8 are the three the ticket does not mention. They were reachable by the same mechanism.

**Out of scope, called out so it isn't mistaken for covered:** the mobile client calls `worktree.rm`
directly over the wire and is **not** covered by this renderer guard. It is not exposed to this defect's
mechanism — a mobile session is bound to one host, so the transport *is* the host selection — and
qualifying it would be a wire change requiring capability negotiation per
`docs/reference/remote-wire-compatibility.md`.

## Linked Issue

STA-4448. Related: #14731 (the caller-side guard this generalizes), #14606 (rerouting — can adopt this
contract).

Fixes #

## Visual Proof

`N/A` — no new UI and no new copy. The only user-visible change is that a delete which would have hit
the wrong host now refuses using #14731's existing refusal strings instead of destroying the wrong
checkout. See KNOWN GAPS below regarding rendered-UI validation.

## Testing

Red-first evidence (recorded by the implementing agent, on this exact code):

- **Guard removed → 8/16 RED**, with the failure
  `the ACTIVE local checkout must survive … removal was routed to hostId=local: expected false to be true`
  — i.e. the test observes the actual data-loss mechanism, not a message string.
- **Production fully reverted → 14/16 RED.** That non-vacuity count is the number that matters: the
  tests fail for the real reason, not because a type changed shape.

Automated (all run locally in this worktree):

- `pnpm run typecheck` — **clean across all 3 projects** (node, cli, web).
- The 6 directly affected specs — **6 files / 65 tests passed**:
  `worktree-removal-host-qualification.test.ts` (12 new), `worktree-delete-host-qualification.test.ts`
  (4 new), `worktrees-remote-runtime-removal.test.ts`, `store-worktree-removal-cascade.test.ts`,
  `workspace-cleanup-wrong-host-removal-guard.test.ts`, `delete-worktree-parallel-flow.test.ts`.
- Wider blast radius, because the rebase pulled in 29 commits of `main`:
  `src/renderer/src/store/slices` — **263 files / 2624 tests passed**;
  `src/renderer/src/components/sidebar` — **249 files / 2179 tests passed**. **Zero failures**, so
  nothing to classify as pre-existing.
- Lint/format: `oxlint --type-aware` and `oxfmt` on all 29 changed files. **Note:** the
  `check:code-quality:changed` / `check:react-doctor:changed` *wrappers* crash on this box — it runs
  node v26 against the repo's required node 24, so pnpm's engine `WARN` lands inside oxlint's JSON
  stdout and breaks the parse. That is pre-existing and unrelated to this change, so the underlying
  oxlint scans were run directly instead. The one oxlint finding
  (`workspace-cleanup.ts:217 no-unnecessary-boolean-literal-compare`) is on a line this PR does not
  touch and blames to #14731 on `main` — pre-existing.

**Rebase note, and it doubles as evidence the approach works:** rebasing onto current `main` pulled in
two test call sites `main` had added while this branch was based on an older commit. They were still
passing a bare string id. **The type system caught both** (`TS2345`) instead of letting them reach
`removeWorktree` and crash on `removalTarget.id`. That is exactly the failure mode approach (a) was
chosen to make impossible for future entry points. Both were migrated to their row's **actual** host
(`local` and `ssh:shared-target`) rather than `null`, preserving the two-distinct-hosts scenario the
test is named for.

Platforms: the change is renderer-side host-identity logic with no path or shell handling, so it is
platform-agnostic; verified on Linux. SSH and paired-runtime rows are covered directly by the new
tests, and folder workspaces are covered by the unqualified-target path (still deletes while the id has
at most one declared owner).

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

### KNOWN GAPS — stated plainly

1. **No rendered-UI validation.** The `$electron` skill is not installed on this box and there is no
   desktop session. Per standing orders, computer-use was **not** substituted. Risk is low because
   there is no new UI and no new copy, but this is a real gap, not a formality.
2. **Real two-host field validation is outstanding.** All filesystem-level evidence here comes from the
   test suite, not from two live hosts sharing a path.
3. **Mobile is not covered** by this guard — see the out-of-scope note above.

## AI Disclosure

<!-- Internal contributor -->

## Review

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general
backwards compatibility, performance.

- **Security / data integrity:** this is the point of the PR — it closes a path that destroyed the wrong
  host's uncommitted work.
- **Backwards compatibility:** unqualified (`executionHostId: null`) targets still delete while the id
  has at most one declared owner, so pre-host-qualified snapshot rows and folder workspaces keep
  working. No wire change; no IPC signature change.
- **SSH / remote:** covered by new tests including HUB-owned SSH rows and paired-runtime transport.
- **Mobile:** unchanged and uncovered — see above.
- **Performance:** the new owner enumeration is one pass over already-loaded in-memory state, on the
  delete path only.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm typecheck` and the relevant test suites pass locally; lint run directly (see Testing).
      `pnpm build` not run locally — left to CI.

## Author

<!-- Internal contributor -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
