### PR TITLE
fix(workspace): retire removed-workspace snapshot tombstones once their holders release (STA-4451)

### DIFF
--- a/src/main/ipc/workspace-cleanup-process-preflight.test.ts
+++ b/src/main/ipc/workspace-cleanup-process-preflight.test.ts
@@ -22,6 +22,8 @@ vi.mock('../memory/pty-registry', () => ({
 }))
 
 vi.mock('../workspace-cleanup-scan-snapshot', () => ({
+  beginWorkspaceCleanupScanSnapshotProducer: vi.fn(() => 'producer:1'),
+  finishWorkspaceCleanupScanSnapshotProducer: vi.fn(),
   persistWorkspaceCleanupScanResult: vi.fn(async () => undefined),
   readWorkspaceCleanupScanSnapshot: vi.fn(async () => null)
 }))

--- a/src/main/ipc/workspace-cleanup-process-preflight.test.ts
+++ b/src/main/ipc/workspace-cleanup-process-preflight.test.ts
@@ -22,10 +22,12 @@ vi.mock('../memory/pty-registry', () => ({
 }))
 
 vi.mock('../workspace-cleanup-scan-snapshot', () => ({
-  beginWorkspaceCleanupScanSnapshotProducer: vi.fn(() => 'producer:1'),
-  finishWorkspaceCleanupScanSnapshotProducer: vi.fn(),
   persistWorkspaceCleanupScanResult: vi.fn(async () => undefined),
-  readWorkspaceCleanupScanSnapshot: vi.fn(async () => null)
+  readWorkspaceCleanupScanSnapshot: vi.fn(async () => null),
+  withWorkspaceCleanupScanSnapshotProducer: vi.fn(
+    async (_directory: string, produce: (producer: unknown) => Promise<unknown>) =>
+      produce({ seq: 1, beginWrite: () => () => {} })
+  )
 }))
 
 vi.mock('../workspace-cleanup-removal-snapshot-prune', () => ({

--- a/src/main/ipc/workspace-cleanup-snapshot-ipc.test.ts
+++ b/src/main/ipc/workspace-cleanup-snapshot-ipc.test.ts
@@ -24,6 +24,8 @@ vi.mock('electron', () => ({
 }))
 
 vi.mock('../workspace-cleanup-scan-snapshot', () => ({
+  beginWorkspaceCleanupScanSnapshotProducer: vi.fn(() => 'producer:1'),
+  finishWorkspaceCleanupScanSnapshotProducer: vi.fn(),
   persistWorkspaceCleanupScanResult: persistScanResultMock,
   readWorkspaceCleanupScanSnapshot: readScanSnapshotMock
 }))

--- a/src/main/ipc/workspace-cleanup-snapshot-ipc.test.ts
+++ b/src/main/ipc/workspace-cleanup-snapshot-ipc.test.ts
@@ -10,10 +10,24 @@ const { persistScanResultMock, readScanSnapshotMock, scanWorkspaceCleanupMock } 
   })
 )
 
-const { beginProducerMock, finishProducerMock } = vi.hoisted(() => ({
-  beginProducerMock: vi.fn(() => 'producer:1'),
-  finishProducerMock: vi.fn()
-}))
+const { withProducerMock, producerToken, fenceLog } = vi.hoisted(() => {
+  const fenceLog: string[] = []
+  const producerToken = { seq: 7, beginWrite: vi.fn(() => vi.fn()) }
+  return {
+    fenceLog,
+    producerToken,
+    withProducerMock: vi.fn(
+      async (_directory: string, produce: (producer: unknown) => Promise<unknown>) => {
+        fenceLog.push('open')
+        try {
+          return await produce(producerToken)
+        } finally {
+          fenceLog.push('close')
+        }
+      }
+    )
+  }
+})
 
 const { beginPruneBatchMock, finishPruneBatchMock, recordPruneMock } = vi.hoisted(() => ({
   beginPruneBatchMock: vi.fn(),
@@ -29,10 +43,9 @@ vi.mock('electron', () => ({
 }))
 
 vi.mock('../workspace-cleanup-scan-snapshot', () => ({
-  beginWorkspaceCleanupScanSnapshotProducer: beginProducerMock,
-  finishWorkspaceCleanupScanSnapshotProducer: finishProducerMock,
   persistWorkspaceCleanupScanResult: persistScanResultMock,
-  readWorkspaceCleanupScanSnapshot: readScanSnapshotMock
+  readWorkspaceCleanupScanSnapshot: readScanSnapshotMock,
+  withWorkspaceCleanupScanSnapshotProducer: withProducerMock
 }))
 
 vi.mock('./workspace-cleanup-scan', () => ({
@@ -75,9 +88,11 @@ function makeEmptyStore(): Store {
 describe('workspace cleanup snapshot IPC', () => {
   beforeEach(() => {
     vi.mocked(ipcMain.handle).mockClear()
-    beginProducerMock.mockClear()
-    finishProducerMock.mockClear()
-    persistScanResultMock.mockReset().mockResolvedValue(undefined)
+    withProducerMock.mockClear()
+    fenceLog.length = 0
+    persistScanResultMock.mockReset().mockImplementation(async () => {
+      fenceLog.push('persist')
+    })
     readScanSnapshotMock.mockReset()
     scanWorkspaceCleanupMock.mockReset().mockImplementation(async (_store, args, options) => {
       const result = { scannedAt: NOW, candidates: [], errors: [] }
@@ -105,34 +120,23 @@ describe('workspace cleanup snapshot IPC', () => {
     const args = { includeAllWorkspaces: true }
     const result = await handler?.(makeScanEvent(), args)
 
-    expect(persistScanResultMock).toHaveBeenCalledWith('/profile-a', args, result)
+    // The token is the write capability; persisting with anything else would escape the fence.
+    expect(persistScanResultMock).toHaveBeenCalledWith('/profile-a', args, result, producerToken)
   })
 
-  it('fences the snapshot producer across a broad scan, settling only after persistence', async () => {
+  it('runs a broad scan and its persist inside one snapshot producer bracket', async () => {
     registerWorkspaceCleanupHandlers(makeEmptyStore())
     const handler = vi
       .mocked(ipcMain.handle)
       .mock.calls.find(([channel]) => channel === 'workspaceCleanup:scan')?.[1]
-    let releasePersist = (): void => {}
-    persistScanResultMock.mockReturnValue(
-      new Promise<void>((resolve) => {
-        releasePersist = () => resolve()
-      })
-    )
 
     await handler?.(makeScanEvent(), { includeAllWorkspaces: true })
 
-    expect(beginProducerMock).toHaveBeenCalledWith('/profile-a')
-    // Still in flight: the scan can only stop resurrecting rows once its write lands.
-    expect(finishProducerMock).not.toHaveBeenCalled()
-
-    releasePersist()
-    await Promise.resolve()
-    await Promise.resolve()
-    expect(finishProducerMock).toHaveBeenCalledWith('/profile-a', 'producer:1')
+    expect(withProducerMock).toHaveBeenCalledWith('/profile-a', expect.any(Function))
+    expect(fenceLog).toEqual(['open', 'persist', 'close'])
   })
 
-  it('settles the snapshot producer when a broad scan fails without persisting', async () => {
+  it('closes the snapshot producer bracket when a broad scan fails without persisting', async () => {
     registerWorkspaceCleanupHandlers(makeEmptyStore())
     const handler = vi
       .mocked(ipcMain.handle)
@@ -142,11 +146,9 @@ describe('workspace cleanup snapshot IPC', () => {
     await expect(handler?.(makeScanEvent(), { includeAllWorkspaces: true })).rejects.toThrow(
       'scan exploded'
     )
-    await Promise.resolve()
-    await Promise.resolve()
 
     expect(persistScanResultMock).not.toHaveBeenCalled()
-    expect(finishProducerMock).toHaveBeenCalledWith('/profile-a', 'producer:1')
+    expect(fenceLog).toEqual(['open', 'close'])
   })
 
   it('does not fence a targeted scan, which never persists', async () => {
@@ -157,8 +159,7 @@ describe('workspace cleanup snapshot IPC', () => {
 
     await handler?.(makeScanEvent(), { worktreeId: 'repo-1::/repo-feature' })
 
-    expect(beginProducerMock).not.toHaveBeenCalled()
-    expect(finishProducerMock).not.toHaveBeenCalled()
+    expect(withProducerMock).not.toHaveBeenCalled()
   })
 
   it('does not rewrite the fleet snapshot for a focused scan', async () => {

--- a/src/main/ipc/workspace-cleanup-snapshot-ipc.test.ts
+++ b/src/main/ipc/workspace-cleanup-snapshot-ipc.test.ts
@@ -10,6 +10,11 @@ const { persistScanResultMock, readScanSnapshotMock, scanWorkspaceCleanupMock } 
   })
 )
 
+const { beginProducerMock, finishProducerMock } = vi.hoisted(() => ({
+  beginProducerMock: vi.fn(() => 'producer:1'),
+  finishProducerMock: vi.fn()
+}))
+
 const { beginPruneBatchMock, finishPruneBatchMock, recordPruneMock } = vi.hoisted(() => ({
   beginPruneBatchMock: vi.fn(),
   finishPruneBatchMock: vi.fn().mockResolvedValue(undefined),
@@ -24,8 +29,8 @@ vi.mock('electron', () => ({
 }))
 
 vi.mock('../workspace-cleanup-scan-snapshot', () => ({
-  beginWorkspaceCleanupScanSnapshotProducer: vi.fn(() => 'producer:1'),
-  finishWorkspaceCleanupScanSnapshotProducer: vi.fn(),
+  beginWorkspaceCleanupScanSnapshotProducer: beginProducerMock,
+  finishWorkspaceCleanupScanSnapshotProducer: finishProducerMock,
   persistWorkspaceCleanupScanResult: persistScanResultMock,
   readWorkspaceCleanupScanSnapshot: readScanSnapshotMock
 }))
@@ -70,6 +75,8 @@ function makeEmptyStore(): Store {
 describe('workspace cleanup snapshot IPC', () => {
   beforeEach(() => {
     vi.mocked(ipcMain.handle).mockClear()
+    beginProducerMock.mockClear()
+    finishProducerMock.mockClear()
     persistScanResultMock.mockReset().mockResolvedValue(undefined)
     readScanSnapshotMock.mockReset()
     scanWorkspaceCleanupMock.mockReset().mockImplementation(async (_store, args, options) => {
@@ -99,6 +106,59 @@ describe('workspace cleanup snapshot IPC', () => {
     const result = await handler?.(makeScanEvent(), args)
 
     expect(persistScanResultMock).toHaveBeenCalledWith('/profile-a', args, result)
+  })
+
+  it('fences the snapshot producer across a broad scan, settling only after persistence', async () => {
+    registerWorkspaceCleanupHandlers(makeEmptyStore())
+    const handler = vi
+      .mocked(ipcMain.handle)
+      .mock.calls.find(([channel]) => channel === 'workspaceCleanup:scan')?.[1]
+    let releasePersist = (): void => {}
+    persistScanResultMock.mockReturnValue(
+      new Promise<void>((resolve) => {
+        releasePersist = () => resolve()
+      })
+    )
+
+    await handler?.(makeScanEvent(), { includeAllWorkspaces: true })
+
+    expect(beginProducerMock).toHaveBeenCalledWith('/profile-a')
+    // Still in flight: the scan can only stop resurrecting rows once its write lands.
+    expect(finishProducerMock).not.toHaveBeenCalled()
+
+    releasePersist()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(finishProducerMock).toHaveBeenCalledWith('/profile-a', 'producer:1')
+  })
+
+  it('settles the snapshot producer when a broad scan fails without persisting', async () => {
+    registerWorkspaceCleanupHandlers(makeEmptyStore())
+    const handler = vi
+      .mocked(ipcMain.handle)
+      .mock.calls.find(([channel]) => channel === 'workspaceCleanup:scan')?.[1]
+    scanWorkspaceCleanupMock.mockRejectedValueOnce(new Error('scan exploded'))
+
+    await expect(handler?.(makeScanEvent(), { includeAllWorkspaces: true })).rejects.toThrow(
+      'scan exploded'
+    )
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(persistScanResultMock).not.toHaveBeenCalled()
+    expect(finishProducerMock).toHaveBeenCalledWith('/profile-a', 'producer:1')
+  })
+
+  it('does not fence a targeted scan, which never persists', async () => {
+    registerWorkspaceCleanupHandlers(makeEmptyStore())
+    const handler = vi
+      .mocked(ipcMain.handle)
+      .mock.calls.find(([channel]) => channel === 'workspaceCleanup:scan')?.[1]
+
+    await handler?.(makeScanEvent(), { worktreeId: 'repo-1::/repo-feature' })
+
+    expect(beginProducerMock).not.toHaveBeenCalled()
+    expect(finishProducerMock).not.toHaveBeenCalled()
   })
 
   it('does not rewrite the fleet snapshot for a focused scan', async () => {

--- a/src/main/ipc/workspace-cleanup.test.ts
+++ b/src/main/ipc/workspace-cleanup.test.ts
@@ -72,6 +72,8 @@ vi.mock('./pty', () => ({
 
 // Why: snapshot persistence does real file I/O; covered in workspace-cleanup-snapshot-ipc.test.ts.
 vi.mock('../workspace-cleanup-scan-snapshot', () => ({
+  beginWorkspaceCleanupScanSnapshotProducer: vi.fn(() => 'producer:1'),
+  finishWorkspaceCleanupScanSnapshotProducer: vi.fn(),
   persistWorkspaceCleanupScanResult: vi.fn(async () => undefined),
   readWorkspaceCleanupScanSnapshot: vi.fn(async () => null)
 }))

--- a/src/main/ipc/workspace-cleanup.test.ts
+++ b/src/main/ipc/workspace-cleanup.test.ts
@@ -72,10 +72,12 @@ vi.mock('./pty', () => ({
 
 // Why: snapshot persistence does real file I/O; covered in workspace-cleanup-snapshot-ipc.test.ts.
 vi.mock('../workspace-cleanup-scan-snapshot', () => ({
-  beginWorkspaceCleanupScanSnapshotProducer: vi.fn(() => 'producer:1'),
-  finishWorkspaceCleanupScanSnapshotProducer: vi.fn(),
   persistWorkspaceCleanupScanResult: vi.fn(async () => undefined),
-  readWorkspaceCleanupScanSnapshot: vi.fn(async () => null)
+  readWorkspaceCleanupScanSnapshot: vi.fn(async () => null),
+  withWorkspaceCleanupScanSnapshotProducer: vi.fn(
+    async (_directory: string, produce: (producer: unknown) => Promise<unknown>) =>
+      produce({ seq: 1, beginWrite: () => () => {} })
+  )
 }))
 
 import { scanWorkspaceCleanup } from './workspace-cleanup'

--- a/src/main/ipc/workspace-cleanup.ts
+++ b/src/main/ipc/workspace-cleanup.ts
@@ -18,6 +18,8 @@ import { parseExecutionHostId } from '../../shared/execution-host'
 import { scanWorkspaceCleanup } from './workspace-cleanup-scan'
 import { hasTargetedWorkspaceCleanupScan } from './workspace-cleanup-scan-targets'
 import {
+  beginWorkspaceCleanupScanSnapshotProducer,
+  finishWorkspaceCleanupScanSnapshotProducer,
   persistWorkspaceCleanupScanResult,
   readWorkspaceCleanupScanSnapshot
 } from '../workspace-cleanup-scan-snapshot'
@@ -72,6 +74,11 @@ export function registerWorkspaceCleanupHandlers(
         activeScans.set(scanKey, controller)
       }
       const targeted = hasTargetedWorkspaceCleanupScan(scanArgs)
+      // Only a broad scan persists, so only a broad scan can resurrect a row pruned while it ran.
+      const snapshotProducer = targeted
+        ? undefined
+        : beginWorkspaceCleanupScanSnapshotProducer(snapshotDirectory)
+      let snapshotPersistence: Promise<void> | undefined
       const broadScanKey = getBroadScanModeKey(sender.id, scanArgs)
       if (!targeted) {
         // Why: two same-mode broad fleet scans from one renderer can only be a
@@ -99,10 +106,22 @@ export function registerWorkspaceCleanupHandlers(
         // fleet snapshot. worktreeIds: [] is still targeted — persisting its
         // empty result would wipe the fleet cache.
         if (!targeted) {
-          void persistWorkspaceCleanupScanResult(snapshotDirectory, scanArgs, result)
+          snapshotPersistence = persistWorkspaceCleanupScanResult(
+            snapshotDirectory,
+            scanArgs,
+            result
+          )
+          void snapshotPersistence
         }
         return result
       } finally {
+        // Settle the fence only once this scan can no longer write: after its persist resolves, or
+        // immediately when it ended (cancelled, aborted, threw) without starting one.
+        if (snapshotProducer !== undefined) {
+          void Promise.allSettled([snapshotPersistence]).then(() =>
+            finishWorkspaceCleanupScanSnapshotProducer(snapshotDirectory, snapshotProducer)
+          )
+        }
         if (!sender.isDestroyed()) {
           sender.removeListener('destroyed', onSenderDestroyed)
         }

--- a/src/main/ipc/workspace-cleanup.ts
+++ b/src/main/ipc/workspace-cleanup.ts
@@ -18,11 +18,11 @@ import { parseExecutionHostId } from '../../shared/execution-host'
 import { scanWorkspaceCleanup } from './workspace-cleanup-scan'
 import { hasTargetedWorkspaceCleanupScan } from './workspace-cleanup-scan-targets'
 import {
-  beginWorkspaceCleanupScanSnapshotProducer,
-  finishWorkspaceCleanupScanSnapshotProducer,
   persistWorkspaceCleanupScanResult,
-  readWorkspaceCleanupScanSnapshot
+  readWorkspaceCleanupScanSnapshot,
+  withWorkspaceCleanupScanSnapshotProducer
 } from '../workspace-cleanup-scan-snapshot'
+import type { WorkspaceSnapshotPruneProducerToken } from '../workspace-snapshot-prune-tombstone-holders'
 import {
   beginWorkspaceCleanupRemovalSnapshotPruneBatch,
   finishWorkspaceCleanupRemovalSnapshotPruneBatch,
@@ -74,11 +74,6 @@ export function registerWorkspaceCleanupHandlers(
         activeScans.set(scanKey, controller)
       }
       const targeted = hasTargetedWorkspaceCleanupScan(scanArgs)
-      // Only a broad scan persists, so only a broad scan can resurrect a row pruned while it ran.
-      const snapshotProducer = targeted
-        ? undefined
-        : beginWorkspaceCleanupScanSnapshotProducer(snapshotDirectory)
-      let snapshotPersistence: Promise<void> | undefined
       const broadScanKey = getBroadScanModeKey(sender.id, scanArgs)
       if (!targeted) {
         // Why: two same-mode broad fleet scans from one renderer can only be a
@@ -91,7 +86,9 @@ export function registerWorkspaceCleanupHandlers(
       // work, not merely mute its progress events.
       const onSenderDestroyed = (): void => controller.abort()
       sender.once('destroyed', onSenderDestroyed)
-      try {
+      const runScan = async (
+        producer?: WorkspaceSnapshotPruneProducerToken
+      ): Promise<WorkspaceCleanupScanResult> => {
         const result = await scanWorkspaceCleanup(store, scanArgs, {
           signal: controller.signal,
           onProgress: scanArgs.scanId
@@ -102,26 +99,21 @@ export function registerWorkspaceCleanupHandlers(
               }
             : undefined
         })
-        // Focused scans are live-only; persisting each rewrites and fsyncs the
-        // fleet snapshot. worktreeIds: [] is still targeted — persisting its
-        // empty result would wipe the fleet cache.
-        if (!targeted) {
-          snapshotPersistence = persistWorkspaceCleanupScanResult(
-            snapshotDirectory,
-            scanArgs,
-            result
-          )
-          void snapshotPersistence
+        // Fire-and-forget: the fence stays open until the write settles, but the reply must not
+        // wait on it.
+        if (producer) {
+          void persistWorkspaceCleanupScanResult(snapshotDirectory, scanArgs, result, producer)
         }
         return result
+      }
+      try {
+        // Focused scans are live-only, so they never take the fence: persisting each would rewrite
+        // and fsync the fleet snapshot. worktreeIds: [] is still targeted — persisting its empty
+        // result would wipe the fleet cache.
+        return targeted
+          ? await runScan()
+          : await withWorkspaceCleanupScanSnapshotProducer(snapshotDirectory, runScan)
       } finally {
-        // Settle the fence only once this scan can no longer write: after its persist resolves, or
-        // immediately when it ended (cancelled, aborted, threw) without starting one.
-        if (snapshotProducer !== undefined) {
-          void Promise.allSettled([snapshotPersistence]).then(() =>
-            finishWorkspaceCleanupScanSnapshotProducer(snapshotDirectory, snapshotProducer)
-          )
-        }
         if (!sender.isDestroyed()) {
           sender.removeListener('destroyed', onSenderDestroyed)
         }

--- a/src/main/ipc/workspace-space.test.ts
+++ b/src/main/ipc/workspace-space.test.ts
@@ -42,6 +42,8 @@ vi.mock('../workspace-space-analysis', () => ({
 }))
 
 vi.mock('../workspace-space-analysis-snapshot', () => ({
+  beginWorkspaceSpaceAnalysisSnapshotProducer: vi.fn(() => 'producer:1'),
+  finishWorkspaceSpaceAnalysisSnapshotProducer: vi.fn(),
   persistWorkspaceSpaceAnalysisSnapshot: persistAnalysisSnapshotMock,
   readWorkspaceSpaceAnalysisSnapshot: readAnalysisSnapshotMock
 }))

--- a/src/main/ipc/workspace-space.test.ts
+++ b/src/main/ipc/workspace-space.test.ts
@@ -13,6 +13,8 @@ const {
   handleMock,
   persistAnalysisSnapshotMock,
   readAnalysisSnapshotMock,
+  beginProducerMock,
+  finishProducerMock,
   WorkspaceSpaceScanCancelledErrorMock
 } = vi.hoisted(() => {
   const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>()
@@ -25,6 +27,8 @@ const {
     }),
     persistAnalysisSnapshotMock: vi.fn(),
     readAnalysisSnapshotMock: vi.fn(),
+    beginProducerMock: vi.fn(() => 'producer:1'),
+    finishProducerMock: vi.fn(),
     WorkspaceSpaceScanCancelledErrorMock: class WorkspaceSpaceScanCancelledError extends Error {}
   }
 })
@@ -42,8 +46,8 @@ vi.mock('../workspace-space-analysis', () => ({
 }))
 
 vi.mock('../workspace-space-analysis-snapshot', () => ({
-  beginWorkspaceSpaceAnalysisSnapshotProducer: vi.fn(() => 'producer:1'),
-  finishWorkspaceSpaceAnalysisSnapshotProducer: vi.fn(),
+  beginWorkspaceSpaceAnalysisSnapshotProducer: beginProducerMock,
+  finishWorkspaceSpaceAnalysisSnapshotProducer: finishProducerMock,
   persistWorkspaceSpaceAnalysisSnapshot: persistAnalysisSnapshotMock,
   readWorkspaceSpaceAnalysisSnapshot: readAnalysisSnapshotMock
 }))
@@ -83,6 +87,8 @@ function createStore(): Store {
 describe('registerWorkspaceSpaceHandlers', () => {
   beforeEach(() => {
     analyzeWorkspaceSpaceMock.mockReset()
+    beginProducerMock.mockClear()
+    finishProducerMock.mockClear()
     persistAnalysisSnapshotMock.mockReset().mockResolvedValue(undefined)
     readAnalysisSnapshotMock.mockReset().mockResolvedValue(null)
   })
@@ -123,6 +129,44 @@ describe('registerWorkspaceSpaceHandlers', () => {
 
     await expect(handler!(createEvent())).resolves.toEqual(createAnalyzeResult(2))
     expect(analyzeWorkspaceSpaceMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('fences the snapshot producer across an analysis, settling only after persistence', async () => {
+    const store = createStore()
+    analyzeWorkspaceSpaceMock.mockResolvedValueOnce(createAnalysis(1))
+    let releasePersist = (): void => {}
+    persistAnalysisSnapshotMock.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        releasePersist = () => resolve()
+      })
+    )
+
+    registerWorkspaceSpaceHandlers(store)
+    await handlers.get('workspaceSpace:analyze')!(createEvent())
+
+    expect(beginProducerMock).toHaveBeenCalledTimes(1)
+    // Still in flight: the analysis can only stop resurrecting rows once its write lands.
+    expect(finishProducerMock).not.toHaveBeenCalled()
+
+    releasePersist()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(finishProducerMock).toHaveBeenCalledWith(expect.any(String), 'producer:1')
+  })
+
+  it('settles the snapshot producer when an analysis fails without persisting', async () => {
+    const store = createStore()
+    analyzeWorkspaceSpaceMock.mockRejectedValueOnce(new Error('analysis exploded'))
+
+    registerWorkspaceSpaceHandlers(store)
+    await expect(handlers.get('workspaceSpace:analyze')!(createEvent())).rejects.toThrow(
+      'analysis exploded'
+    )
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(persistAnalysisSnapshotMock).not.toHaveBeenCalled()
+    expect(finishProducerMock).toHaveBeenCalledWith(expect.any(String), 'producer:1')
   })
 
   it('forwards scan progress to the requesting renderer', async () => {

--- a/src/main/ipc/workspace-space.test.ts
+++ b/src/main/ipc/workspace-space.test.ts
@@ -13,13 +13,18 @@ const {
   handleMock,
   persistAnalysisSnapshotMock,
   readAnalysisSnapshotMock,
-  beginProducerMock,
-  finishProducerMock,
+  withProducerMock,
+  producerToken,
+  fenceLog,
   WorkspaceSpaceScanCancelledErrorMock
 } = vi.hoisted(() => {
   const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>()
+  const fenceLog: string[] = []
+  const producerToken = { seq: 7, beginWrite: vi.fn(() => vi.fn()) }
   return {
     handlers,
+    fenceLog,
+    producerToken,
     analyzeWorkspaceSpaceMock: vi.fn(),
     removeHandlerMock: vi.fn(),
     handleMock: vi.fn((channel: string, handler: (...args: unknown[]) => Promise<unknown>) => {
@@ -27,8 +32,16 @@ const {
     }),
     persistAnalysisSnapshotMock: vi.fn(),
     readAnalysisSnapshotMock: vi.fn(),
-    beginProducerMock: vi.fn(() => 'producer:1'),
-    finishProducerMock: vi.fn(),
+    withProducerMock: vi.fn(
+      async (_directory: string, produce: (producer: unknown) => Promise<unknown>) => {
+        fenceLog.push('open')
+        try {
+          return await produce(producerToken)
+        } finally {
+          fenceLog.push('close')
+        }
+      }
+    ),
     WorkspaceSpaceScanCancelledErrorMock: class WorkspaceSpaceScanCancelledError extends Error {}
   }
 })
@@ -46,10 +59,9 @@ vi.mock('../workspace-space-analysis', () => ({
 }))
 
 vi.mock('../workspace-space-analysis-snapshot', () => ({
-  beginWorkspaceSpaceAnalysisSnapshotProducer: beginProducerMock,
-  finishWorkspaceSpaceAnalysisSnapshotProducer: finishProducerMock,
   persistWorkspaceSpaceAnalysisSnapshot: persistAnalysisSnapshotMock,
-  readWorkspaceSpaceAnalysisSnapshot: readAnalysisSnapshotMock
+  readWorkspaceSpaceAnalysisSnapshot: readAnalysisSnapshotMock,
+  withWorkspaceSpaceAnalysisSnapshotProducer: withProducerMock
 }))
 
 import { registerWorkspaceSpaceHandlers } from './workspace-space'
@@ -87,9 +99,11 @@ function createStore(): Store {
 describe('registerWorkspaceSpaceHandlers', () => {
   beforeEach(() => {
     analyzeWorkspaceSpaceMock.mockReset()
-    beginProducerMock.mockClear()
-    finishProducerMock.mockClear()
-    persistAnalysisSnapshotMock.mockReset().mockResolvedValue(undefined)
+    withProducerMock.mockClear()
+    fenceLog.length = 0
+    persistAnalysisSnapshotMock.mockReset().mockImplementation(async () => {
+      fenceLog.push('persist')
+    })
     readAnalysisSnapshotMock.mockReset().mockResolvedValue(null)
   })
 
@@ -131,30 +145,21 @@ describe('registerWorkspaceSpaceHandlers', () => {
     expect(analyzeWorkspaceSpaceMock).toHaveBeenCalledTimes(2)
   })
 
-  it('fences the snapshot producer across an analysis, settling only after persistence', async () => {
+  it('runs an analysis and its persist inside one snapshot producer bracket', async () => {
     const store = createStore()
-    analyzeWorkspaceSpaceMock.mockResolvedValueOnce(createAnalysis(1))
-    let releasePersist = (): void => {}
-    persistAnalysisSnapshotMock.mockReturnValueOnce(
-      new Promise<void>((resolve) => {
-        releasePersist = () => resolve()
-      })
-    )
+    const analysis = createAnalysis(1)
+    analyzeWorkspaceSpaceMock.mockResolvedValueOnce(analysis)
 
     registerWorkspaceSpaceHandlers(store)
     await handlers.get('workspaceSpace:analyze')!(createEvent())
 
-    expect(beginProducerMock).toHaveBeenCalledTimes(1)
-    // Still in flight: the analysis can only stop resurrecting rows once its write lands.
-    expect(finishProducerMock).not.toHaveBeenCalled()
-
-    releasePersist()
-    await Promise.resolve()
-    await Promise.resolve()
-    expect(finishProducerMock).toHaveBeenCalledWith(expect.any(String), 'producer:1')
+    expect(withProducerMock).toHaveBeenCalledWith('/profile-a', expect.any(Function))
+    expect(fenceLog).toEqual(['open', 'persist', 'close'])
+    // The token is the write capability; persisting with anything else would escape the fence.
+    expect(persistAnalysisSnapshotMock).toHaveBeenCalledWith('/profile-a', analysis, producerToken)
   })
 
-  it('settles the snapshot producer when an analysis fails without persisting', async () => {
+  it('closes the snapshot producer bracket when an analysis fails without persisting', async () => {
     const store = createStore()
     analyzeWorkspaceSpaceMock.mockRejectedValueOnce(new Error('analysis exploded'))
 
@@ -162,11 +167,9 @@ describe('registerWorkspaceSpaceHandlers', () => {
     await expect(handlers.get('workspaceSpace:analyze')!(createEvent())).rejects.toThrow(
       'analysis exploded'
     )
-    await Promise.resolve()
-    await Promise.resolve()
 
     expect(persistAnalysisSnapshotMock).not.toHaveBeenCalled()
-    expect(finishProducerMock).toHaveBeenCalledWith(expect.any(String), 'producer:1')
+    expect(fenceLog).toEqual(['open', 'close'])
   })
 
   it('forwards scan progress to the requesting renderer', async () => {
@@ -293,7 +296,7 @@ describe('registerWorkspaceSpaceHandlers', () => {
     const analyzeHandler = handlers.get('workspaceSpace:analyze')
 
     await expect(analyzeHandler!(createEvent())).resolves.toEqual({ ok: true, analysis })
-    expect(persistAnalysisSnapshotMock).toHaveBeenCalledWith('/profile-a', analysis)
+    expect(persistAnalysisSnapshotMock).toHaveBeenCalledWith('/profile-a', analysis, producerToken)
   })
 
   it('serves the cached analysis through getCachedAnalysis', async () => {

--- a/src/main/ipc/workspace-space.ts
+++ b/src/main/ipc/workspace-space.ts
@@ -11,6 +11,8 @@ import {
   WorkspaceSpaceScanCancelledError
 } from '../workspace-space-analysis'
 import {
+  beginWorkspaceSpaceAnalysisSnapshotProducer,
+  finishWorkspaceSpaceAnalysisSnapshotProducer,
   persistWorkspaceSpaceAnalysisSnapshot,
   readWorkspaceSpaceAnalysisSnapshot
 } from '../workspace-space-analysis-snapshot'
@@ -32,6 +34,8 @@ export function registerWorkspaceSpaceHandlers(store: Store): void {
   ipcMain.removeHandler('workspaceSpace:getCachedAnalysis')
   ipcMain.handle('workspaceSpace:analyze', async (event): Promise<WorkspaceSpaceAnalyzeResult> => {
     if (!inFlightScan) {
+      const snapshotProducer = beginWorkspaceSpaceAnalysisSnapshotProducer(snapshotDirectory)
+      let snapshotPersistence: Promise<void> | undefined
       const controller = new AbortController()
       const scanId = `${Date.now()}-${Math.random().toString(36).slice(2)}`
       let latestProgress: WorkspaceSpaceScanProgress = {
@@ -98,7 +102,8 @@ export function registerWorkspaceSpaceHandlers(store: Store): void {
         .then((analysis): WorkspaceSpaceAnalyzeResult => {
           // Fire-and-forget: a ~6-minute cold analysis must survive reload/restart, but
           // persistence must never delay or fail the reply.
-          void persistWorkspaceSpaceAnalysisSnapshot(snapshotDirectory, analysis)
+          snapshotPersistence = persistWorkspaceSpaceAnalysisSnapshot(snapshotDirectory, analysis)
+          void snapshotPersistence
           return { ok: true, analysis }
         })
         .catch((error: unknown): WorkspaceSpaceAnalyzeResult => {
@@ -108,6 +113,11 @@ export function registerWorkspaceSpaceHandlers(store: Store): void {
           throw error
         })
         .finally(() => {
+          // Settle the fence only once this analysis can no longer write: after its persist
+          // resolves, or immediately when it ended (cancelled, failed) without starting one.
+          void Promise.allSettled([snapshotPersistence]).then(() =>
+            finishWorkspaceSpaceAnalysisSnapshotProducer(snapshotDirectory, snapshotProducer)
+          )
           inFlightScan = null
         })
     }

--- a/src/main/ipc/workspace-space.ts
+++ b/src/main/ipc/workspace-space.ts
@@ -11,10 +11,9 @@ import {
   WorkspaceSpaceScanCancelledError
 } from '../workspace-space-analysis'
 import {
-  beginWorkspaceSpaceAnalysisSnapshotProducer,
-  finishWorkspaceSpaceAnalysisSnapshotProducer,
   persistWorkspaceSpaceAnalysisSnapshot,
-  readWorkspaceSpaceAnalysisSnapshot
+  readWorkspaceSpaceAnalysisSnapshot,
+  withWorkspaceSpaceAnalysisSnapshotProducer
 } from '../workspace-space-analysis-snapshot'
 
 const PROGRESS_EMIT_INTERVAL_MS = 100
@@ -34,8 +33,6 @@ export function registerWorkspaceSpaceHandlers(store: Store): void {
   ipcMain.removeHandler('workspaceSpace:getCachedAnalysis')
   ipcMain.handle('workspaceSpace:analyze', async (event): Promise<WorkspaceSpaceAnalyzeResult> => {
     if (!inFlightScan) {
-      const snapshotProducer = beginWorkspaceSpaceAnalysisSnapshotProducer(snapshotDirectory)
-      let snapshotPersistence: Promise<void> | undefined
       const controller = new AbortController()
       const scanId = `${Date.now()}-${Math.random().toString(36).slice(2)}`
       let latestProgress: WorkspaceSpaceScanProgress = {
@@ -90,36 +87,33 @@ export function registerWorkspaceSpaceHandlers(store: Store): void {
         promise: Promise.resolve(null as never)
       }
       inFlightScan = scan
-      scan.promise = analyzeWorkspaceSpace(store, {
-        scanId,
-        signal: controller.signal,
-        onProgress: (progress) => {
-          latestProgress = progress
-          scan.progress = progress
-          sendProgress(progress)
-        }
-      })
-        .then((analysis): WorkspaceSpaceAnalyzeResult => {
-          // Fire-and-forget: a ~6-minute cold analysis must survive reload/restart, but
-          // persistence must never delay or fail the reply.
-          snapshotPersistence = persistWorkspaceSpaceAnalysisSnapshot(snapshotDirectory, analysis)
-          void snapshotPersistence
-          return { ok: true, analysis }
-        })
-        .catch((error: unknown): WorkspaceSpaceAnalyzeResult => {
-          if (error instanceof WorkspaceSpaceScanCancelledError) {
-            return { ok: false, cancelled: true }
+      // The fence opens before the analysis starts and stays open until its write settles, so a
+      // workspace removed mid-analysis cannot be restored by this result.
+      scan.promise = withWorkspaceSpaceAnalysisSnapshotProducer(snapshotDirectory, (producer) =>
+        analyzeWorkspaceSpace(store, {
+          scanId,
+          signal: controller.signal,
+          onProgress: (progress) => {
+            latestProgress = progress
+            scan.progress = progress
+            sendProgress(progress)
           }
-          throw error
         })
-        .finally(() => {
-          // Settle the fence only once this analysis can no longer write: after its persist
-          // resolves, or immediately when it ended (cancelled, failed) without starting one.
-          void Promise.allSettled([snapshotPersistence]).then(() =>
-            finishWorkspaceSpaceAnalysisSnapshotProducer(snapshotDirectory, snapshotProducer)
-          )
-          inFlightScan = null
-        })
+          .then((analysis): WorkspaceSpaceAnalyzeResult => {
+            // Fire-and-forget: a ~6-minute cold analysis must survive reload/restart, but
+            // persistence must never delay or fail the reply.
+            void persistWorkspaceSpaceAnalysisSnapshot(snapshotDirectory, analysis, producer)
+            return { ok: true, analysis }
+          })
+          .catch((error: unknown): WorkspaceSpaceAnalyzeResult => {
+            if (error instanceof WorkspaceSpaceScanCancelledError) {
+              return { ok: false, cancelled: true }
+            }
+            throw error
+          })
+      ).finally(() => {
+        inFlightScan = null
+      })
     }
     return inFlightScan.promise
   })

--- a/src/main/workspace-cleanup-scan-snapshot.test.ts
+++ b/src/main/workspace-cleanup-scan-snapshot.test.ts
@@ -28,14 +28,18 @@ vi.mock('./sidecar-snapshot-file', async (importOriginal) => {
 })
 
 import {
+  beginWorkspaceCleanupScanSnapshotProducer,
   finalizeWorkspaceCleanupScanSnapshotPrunes,
+  finishWorkspaceCleanupScanSnapshotProducer,
   persistWorkspaceCleanupScanResult,
   pruneWorkspaceCleanupScanSnapshot,
   pruneWorkspaceCleanupScanSnapshots,
   readWorkspaceCleanupScanSnapshot,
   registerWorkspaceCleanupScanSnapshotPruneTombstones,
-  workspaceCleanupScanSnapshotFingerprint
+  workspaceCleanupScanSnapshotFingerprint,
+  workspaceCleanupScanSnapshotTombstoneCountForTests
 } from './workspace-cleanup-scan-snapshot'
+import { WORKSPACE_SNAPSHOT_PRUNE_PRODUCER_TIMEOUT_MS } from './workspace-snapshot-prune-index'
 
 const SNAPSHOT_FILE = 'orca-workspace-cleanup-scan.json'
 const NOW = 1_700_000_000_000
@@ -354,6 +358,8 @@ describe('workspace cleanup scan snapshot', () => {
       ...makeBroadResult([local, remote]),
       scannedAt: Date.now() - 1
     }
+    // The scan is in flight before the removal, so it is a fenced producer of this sidecar.
+    beginWorkspaceCleanupScanSnapshotProducer(userDataDirHolder.dir)
     await pruneWorkspaceCleanupScanSnapshots(userDataDirHolder.dir, [
       { worktreeId: local.worktreeId, executionHostId: 'local' },
       { worktreeId: remote.worktreeId, executionHostId: 'ssh:ssh-1' }
@@ -412,6 +418,138 @@ describe('workspace cleanup scan snapshot', () => {
       candidate
     ])
     now.mockRestore()
+  })
+
+  it('retains no tombstone when a removal races no scan at all', async () => {
+    const candidate = makeCandidate()
+    const now = vi.spyOn(Date, 'now').mockReturnValue(100)
+    await pruneWorkspaceCleanupScanSnapshot(
+      userDataDirHolder.dir,
+      candidate.worktreeId,
+      candidate.executionHostId
+    )
+
+    expect(workspaceCleanupScanSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(0)
+    // Nothing was fenced, so a result predating the prune is no longer suppressed.
+    await persistWorkspaceCleanupScanResult(
+      userDataDirHolder.dir,
+      { includeAllWorkspaces: true },
+      { ...makeBroadResult([candidate]), scannedAt: 99 }
+    )
+    expect((await readWorkspaceCleanupScanSnapshot(userDataDirHolder.dir))?.candidates).toEqual([
+      candidate
+    ])
+    now.mockRestore()
+  })
+
+  it('does not accumulate tombstones as workspaces are removed', async () => {
+    for (let index = 0; index < 25; index += 1) {
+      await pruneWorkspaceCleanupScanSnapshot(
+        userDataDirHolder.dir,
+        `repo-1::/repo-removed-${index}`,
+        'local'
+      )
+    }
+
+    expect(workspaceCleanupScanSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(0)
+  })
+
+  it('holds a tombstone until the scan in flight when it was pruned settles', async () => {
+    const candidate = makeCandidate()
+    const producer = beginWorkspaceCleanupScanSnapshotProducer(userDataDirHolder.dir)
+    const now = vi.spyOn(Date, 'now').mockReturnValue(200)
+    await pruneWorkspaceCleanupScanSnapshot(
+      userDataDirHolder.dir,
+      candidate.worktreeId,
+      candidate.executionHostId
+    )
+
+    expect(workspaceCleanupScanSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(1)
+    await persistWorkspaceCleanupScanResult(
+      userDataDirHolder.dir,
+      { includeAllWorkspaces: true },
+      { ...makeBroadResult([candidate]), scannedAt: 100 }
+    )
+    expect((await readWorkspaceCleanupScanSnapshot(userDataDirHolder.dir))?.candidates).toEqual([])
+
+    finishWorkspaceCleanupScanSnapshotProducer(userDataDirHolder.dir, producer)
+
+    expect(workspaceCleanupScanSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(0)
+    await persistWorkspaceCleanupScanResult(
+      userDataDirHolder.dir,
+      { includeAllWorkspaces: true },
+      { ...makeBroadResult([candidate]), scannedAt: 100 }
+    )
+    expect((await readWorkspaceCleanupScanSnapshot(userDataDirHolder.dir))?.candidates).toEqual([
+      candidate
+    ])
+    now.mockRestore()
+  })
+
+  it('retires a tombstone whose scan never settles once the producer timeout passes', async () => {
+    const candidate = makeCandidate()
+    beginWorkspaceCleanupScanSnapshotProducer(userDataDirHolder.dir)
+    const now = vi.spyOn(Date, 'now').mockReturnValue(200)
+    await pruneWorkspaceCleanupScanSnapshot(
+      userDataDirHolder.dir,
+      candidate.worktreeId,
+      candidate.executionHostId
+    )
+    expect(workspaceCleanupScanSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(1)
+
+    now.mockReturnValue(201 + WORKSPACE_SNAPSHOT_PRUNE_PRODUCER_TIMEOUT_MS)
+    await persistWorkspaceCleanupScanResult(
+      userDataDirHolder.dir,
+      { includeAllWorkspaces: true },
+      { ...makeBroadResult([candidate]), scannedAt: 100 }
+    )
+
+    expect(workspaceCleanupScanSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(0)
+    expect((await readWorkspaceCleanupScanSnapshot(userDataDirHolder.dir))?.candidates).toEqual([
+      candidate
+    ])
+    now.mockRestore()
+  })
+
+  it('flushes a batched tombstone even when a scan settles before the batch closes', async () => {
+    const candidate = makeCandidate()
+    const target = { worktreeId: candidate.worktreeId, executionHostId: 'local' as const }
+    await persistWorkspaceCleanupScanResult(
+      userDataDirHolder.dir,
+      { includeAllWorkspaces: true },
+      makeBroadResult([candidate])
+    )
+    const producer = beginWorkspaceCleanupScanSnapshotProducer(userDataDirHolder.dir)
+    registerWorkspaceCleanupScanSnapshotPruneTombstones(userDataDirHolder.dir, [target])
+    finishWorkspaceCleanupScanSnapshotProducer(userDataDirHolder.dir, producer)
+
+    // The deferred flush still holds it, so finalize can still find and prune the row.
+    expect(workspaceCleanupScanSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(1)
+    await finalizeWorkspaceCleanupScanSnapshotPrunes(userDataDirHolder.dir, [target])
+
+    expect((await readWorkspaceCleanupScanSnapshot(userDataDirHolder.dir))?.candidates).toEqual([])
+    expect(workspaceCleanupScanSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(0)
+  })
+
+  it('does not let one removal batch flush retire another batch tombstone', async () => {
+    const first = makeCandidate()
+    const second = makeCandidate({ worktreeId: 'repo-1::/repo-second', path: '/repo-second' })
+    const firstTarget = { worktreeId: first.worktreeId, executionHostId: 'local' as const }
+    const secondTarget = { worktreeId: second.worktreeId, executionHostId: 'local' as const }
+    await persistWorkspaceCleanupScanResult(
+      userDataDirHolder.dir,
+      { includeAllWorkspaces: true },
+      makeBroadResult([first, second])
+    )
+    registerWorkspaceCleanupScanSnapshotPruneTombstones(userDataDirHolder.dir, [firstTarget])
+    registerWorkspaceCleanupScanSnapshotPruneTombstones(userDataDirHolder.dir, [secondTarget])
+
+    await finalizeWorkspaceCleanupScanSnapshotPrunes(userDataDirHolder.dir, [firstTarget])
+    expect(workspaceCleanupScanSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(1)
+
+    await finalizeWorkspaceCleanupScanSnapshotPrunes(userDataDirHolder.dir, [secondTarget])
+    expect((await readWorkspaceCleanupScanSnapshot(userDataDirHolder.dir))?.candidates).toEqual([])
+    expect(workspaceCleanupScanSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(0)
   })
 
   it('patches and prunes host-colliding workspace ids independently', async () => {

--- a/src/main/workspace-cleanup-scan-snapshot.test.ts
+++ b/src/main/workspace-cleanup-scan-snapshot.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type {
   WorkspaceCleanupCandidate,
+  WorkspaceCleanupScanArgs,
   WorkspaceCleanupScanResult
 } from '../shared/workspace-cleanup'
 
@@ -28,18 +29,18 @@ vi.mock('./sidecar-snapshot-file', async (importOriginal) => {
 })
 
 import {
-  beginWorkspaceCleanupScanSnapshotProducer,
   finalizeWorkspaceCleanupScanSnapshotPrunes,
-  finishWorkspaceCleanupScanSnapshotProducer,
   persistWorkspaceCleanupScanResult,
   pruneWorkspaceCleanupScanSnapshot,
   pruneWorkspaceCleanupScanSnapshots,
   readWorkspaceCleanupScanSnapshot,
   registerWorkspaceCleanupScanSnapshotPruneTombstones,
+  withWorkspaceCleanupScanSnapshotProducer,
   workspaceCleanupScanSnapshotFingerprint,
   workspaceCleanupScanSnapshotTombstoneCountForTests
 } from './workspace-cleanup-scan-snapshot'
 import { WORKSPACE_SNAPSHOT_PRUNE_PRODUCER_TIMEOUT_MS } from './workspace-snapshot-prune-index'
+import { openWorkspaceSnapshotPruneProducer } from './workspace-snapshot-prune-producer-fixtures'
 
 const SNAPSHOT_FILE = 'orca-workspace-cleanup-scan.json'
 const NOW = 1_700_000_000_000
@@ -79,6 +80,22 @@ function makeBroadResult(candidates: WorkspaceCleanupCandidate[]): WorkspaceClea
   return { scannedAt: NOW, candidates, errors: [] }
 }
 
+/** A scan whose fence opens at persist time — one that raced no removal. */
+function persistScan(
+  snapshotDirectory: string,
+  args: WorkspaceCleanupScanArgs,
+  result: WorkspaceCleanupScanResult
+): Promise<void> {
+  return withWorkspaceCleanupScanSnapshotProducer(snapshotDirectory, (producer) =>
+    persistWorkspaceCleanupScanResult(snapshotDirectory, args, result, producer)
+  )
+}
+
+const openScan = (
+  snapshotDirectory: string
+): ReturnType<typeof openWorkspaceSnapshotPruneProducer> =>
+  openWorkspaceSnapshotPruneProducer(withWorkspaceCleanupScanSnapshotProducer, snapshotDirectory)
+
 describe('workspace cleanup scan snapshot', () => {
   beforeEach(async () => {
     snapshotWriteSpy.mockClear()
@@ -101,11 +118,7 @@ describe('workspace cleanup scan snapshot', () => {
     })
     const result = makeBroadResult([makeCandidate(), sshCandidate])
 
-    await persistWorkspaceCleanupScanResult(
-      userDataDirHolder.dir,
-      { includeAllWorkspaces: true },
-      result
-    )
+    await persistScan(userDataDirHolder.dir, { includeAllWorkspaces: true }, result)
 
     await expect(readWorkspaceCleanupScanSnapshot(userDataDirHolder.dir)).resolves.toEqual(result)
   })
@@ -116,12 +129,8 @@ describe('workspace cleanup scan snapshot', () => {
       candidates: [makeCandidate({ displayName: 'Newer' })],
       errors: []
     }
-    await persistWorkspaceCleanupScanResult(
-      userDataDirHolder.dir,
-      { includeAllWorkspaces: true },
-      newer
-    )
-    await persistWorkspaceCleanupScanResult(
+    await persistScan(userDataDirHolder.dir, { includeAllWorkspaces: true }, newer)
+    await persistScan(
       userDataDirHolder.dir,
       { includeAllWorkspaces: true },
       makeBroadResult([makeCandidate({ displayName: 'Older' })])
@@ -184,14 +193,14 @@ describe('workspace cleanup scan snapshot', () => {
       path: '/repo-other',
       branch: 'other'
     })
-    await persistWorkspaceCleanupScanResult(
+    await persistScan(
       userDataDirHolder.dir,
       { includeAllWorkspaces: true },
       makeBroadResult([stale, other])
     )
 
     const rescanned = makeCandidate({ tier: 'protected', blockers: ['dirty-files'] })
-    await persistWorkspaceCleanupScanResult(
+    await persistScan(
       userDataDirHolder.dir,
       { worktreeId: stale.worktreeId },
       { scannedAt: NOW + 60_000, candidates: [rescanned], errors: [] }
@@ -204,14 +213,14 @@ describe('workspace cleanup scan snapshot', () => {
   })
 
   it('appends targeted rows the snapshot has not seen yet', async () => {
-    await persistWorkspaceCleanupScanResult(
+    await persistScan(
       userDataDirHolder.dir,
       { includeAllWorkspaces: true },
       makeBroadResult([makeCandidate()])
     )
 
     const created = makeCandidate({ worktreeId: 'repo-1::/repo-new', path: '/repo-new' })
-    await persistWorkspaceCleanupScanResult(
+    await persistScan(
       userDataDirHolder.dir,
       { worktreeId: created.worktreeId },
       { scannedAt: NOW + 1, candidates: [created], errors: [] }
@@ -225,7 +234,7 @@ describe('workspace cleanup scan snapshot', () => {
   })
 
   it('does not create a snapshot from a targeted scan alone', async () => {
-    await persistWorkspaceCleanupScanResult(
+    await persistScan(
       userDataDirHolder.dir,
       { worktreeId: 'repo-1::/repo-feature' },
       makeBroadResult([makeCandidate()])
@@ -242,14 +251,10 @@ describe('workspace cleanup scan snapshot', () => {
       makeCandidate(),
       makeCandidate({ worktreeId: 'repo-1::/b', path: '/b' })
     ])
-    await persistWorkspaceCleanupScanResult(
-      userDataDirHolder.dir,
-      { includeAllWorkspaces: true },
-      broad
-    )
+    await persistScan(userDataDirHolder.dir, { includeAllWorkspaces: true }, broad)
 
     const legacyRow = makeCandidate({ tier: 'review', selectedByDefault: false })
-    await persistWorkspaceCleanupScanResult(
+    await persistScan(
       userDataDirHolder.dir,
       {},
       { scannedAt: NOW + 1, candidates: [legacyRow], errors: [] }
@@ -262,7 +267,7 @@ describe('workspace cleanup scan snapshot', () => {
 
   it('prunes a removed worktree so it cannot resurrect from cache', async () => {
     const kept = makeCandidate({ worktreeId: 'repo-1::/repo-kept', path: '/repo-kept' })
-    await persistWorkspaceCleanupScanResult(
+    await persistScan(
       userDataDirHolder.dir,
       { includeAllWorkspaces: true },
       makeBroadResult([makeCandidate(), kept])
@@ -299,7 +304,7 @@ describe('workspace cleanup scan snapshot', () => {
       path: '/remote-removed'
     })
     const kept = makeCandidate({ worktreeId: 'repo-1::/kept', path: '/kept' })
-    await persistWorkspaceCleanupScanResult(
+    await persistScan(
       userDataDirHolder.dir,
       { includeAllWorkspaces: true },
       makeBroadResult([localCollision, remoteCollision, localRemoved, remoteRemoved, kept])
@@ -334,7 +339,7 @@ describe('workspace cleanup scan snapshot', () => {
   it('keeps profile snapshots isolated', async () => {
     const otherProfile = await mkdtemp(join(tmpdir(), 'orca-cleanup-snapshot-other-'))
     try {
-      await persistWorkspaceCleanupScanResult(
+      await persistScan(
         userDataDirHolder.dir,
         { includeAllWorkspaces: true },
         makeBroadResult([makeCandidate()])
@@ -354,12 +359,9 @@ describe('workspace cleanup scan snapshot', () => {
       executionHostId: 'ssh:ssh-1',
       path: '/remote-feature'
     })
-    const staleResult = {
-      ...makeBroadResult([local, remote]),
-      scannedAt: Date.now() - 1
-    }
+    const staleResult = makeBroadResult([local, remote])
     // The scan is in flight before the removal, so it is a fenced producer of this sidecar.
-    beginWorkspaceCleanupScanSnapshotProducer(userDataDirHolder.dir)
+    const scan = await openScan(userDataDirHolder.dir)
     await pruneWorkspaceCleanupScanSnapshots(userDataDirHolder.dir, [
       { worktreeId: local.worktreeId, executionHostId: 'local' },
       { worktreeId: remote.worktreeId, executionHostId: 'ssh:ssh-1' }
@@ -368,16 +370,14 @@ describe('workspace cleanup scan snapshot', () => {
     await persistWorkspaceCleanupScanResult(
       userDataDirHolder.dir,
       { includeAllWorkspaces: true },
-      staleResult
+      staleResult,
+      scan.producer
     )
     expect((await readWorkspaceCleanupScanSnapshot(userDataDirHolder.dir))?.candidates).toEqual([])
 
-    const recreated = { ...staleResult, scannedAt: Date.now() + 1 }
-    await persistWorkspaceCleanupScanResult(
-      userDataDirHolder.dir,
-      { includeAllWorkspaces: true },
-      recreated
-    )
+    await scan.finish()
+    // A scan started after the removal is not fenced, so a re-created workspace comes back.
+    await persistScan(userDataDirHolder.dir, { includeAllWorkspaces: true }, staleResult)
     expect((await readWorkspaceCleanupScanSnapshot(userDataDirHolder.dir))?.candidates).toEqual([
       local,
       remote
@@ -385,7 +385,8 @@ describe('workspace cleanup scan snapshot', () => {
   })
 
   it('registers a tombstone immediately without rewriting the sidecar', async () => {
-    const staleResult = { ...makeBroadResult([makeCandidate()]), scannedAt: Date.now() - 1 }
+    const staleResult = makeBroadResult([makeCandidate()])
+    const scan = await openScan(userDataDirHolder.dir)
 
     registerWorkspaceCleanupScanSnapshotPruneTombstones(userDataDirHolder.dir, [
       { worktreeId: 'repo-1::/repo-feature', executionHostId: 'local' }
@@ -395,34 +396,32 @@ describe('workspace cleanup scan snapshot', () => {
     await persistWorkspaceCleanupScanResult(
       userDataDirHolder.dir,
       { includeAllWorkspaces: true },
-      staleResult
+      staleResult,
+      scan.producer
     )
     expect((await readWorkspaceCleanupScanSnapshot(userDataDirHolder.dir))?.candidates).toEqual([])
+    await scan.finish()
   })
 
-  it('keeps the original tombstone time when a removal batch flushes', async () => {
+  it('does not fence a scan that started after a removal batch registered', async () => {
     const candidate = makeCandidate()
     const target = { worktreeId: candidate.worktreeId, executionHostId: 'local' as const }
-    const now = vi.spyOn(Date, 'now').mockReturnValue(100)
     registerWorkspaceCleanupScanSnapshotPruneTombstones(userDataDirHolder.dir, [target])
-    now.mockReturnValue(200)
 
     await finalizeWorkspaceCleanupScanSnapshotPrunes(userDataDirHolder.dir, [target])
-    await persistWorkspaceCleanupScanResult(
+    await persistScan(
       userDataDirHolder.dir,
       { includeAllWorkspaces: true },
-      { ...makeBroadResult([candidate]), scannedAt: 150 }
+      makeBroadResult([candidate])
     )
 
     expect((await readWorkspaceCleanupScanSnapshot(userDataDirHolder.dir))?.candidates).toEqual([
       candidate
     ])
-    now.mockRestore()
   })
 
   it('retains no tombstone when a removal races no scan at all', async () => {
     const candidate = makeCandidate()
-    const now = vi.spyOn(Date, 'now').mockReturnValue(100)
     await pruneWorkspaceCleanupScanSnapshot(
       userDataDirHolder.dir,
       candidate.worktreeId,
@@ -430,16 +429,15 @@ describe('workspace cleanup scan snapshot', () => {
     )
 
     expect(workspaceCleanupScanSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(0)
-    // Nothing was fenced, so a result predating the prune is no longer suppressed.
-    await persistWorkspaceCleanupScanResult(
+    // Nothing was fenced, so a later scan is free to persist the row again.
+    await persistScan(
       userDataDirHolder.dir,
       { includeAllWorkspaces: true },
-      { ...makeBroadResult([candidate]), scannedAt: 99 }
+      makeBroadResult([candidate])
     )
     expect((await readWorkspaceCleanupScanSnapshot(userDataDirHolder.dir))?.candidates).toEqual([
       candidate
     ])
-    now.mockRestore()
   })
 
   it('does not accumulate tombstones as workspaces are removed', async () => {
@@ -456,8 +454,7 @@ describe('workspace cleanup scan snapshot', () => {
 
   it('holds a tombstone until the scan in flight when it was pruned settles', async () => {
     const candidate = makeCandidate()
-    const producer = beginWorkspaceCleanupScanSnapshotProducer(userDataDirHolder.dir)
-    const now = vi.spyOn(Date, 'now').mockReturnValue(200)
+    const scan = await openScan(userDataDirHolder.dir)
     await pruneWorkspaceCleanupScanSnapshot(
       userDataDirHolder.dir,
       candidate.worktreeId,
@@ -468,60 +465,93 @@ describe('workspace cleanup scan snapshot', () => {
     await persistWorkspaceCleanupScanResult(
       userDataDirHolder.dir,
       { includeAllWorkspaces: true },
-      { ...makeBroadResult([candidate]), scannedAt: 100 }
+      makeBroadResult([candidate]),
+      scan.producer
     )
     expect((await readWorkspaceCleanupScanSnapshot(userDataDirHolder.dir))?.candidates).toEqual([])
 
-    finishWorkspaceCleanupScanSnapshotProducer(userDataDirHolder.dir, producer)
+    await scan.finish()
 
     expect(workspaceCleanupScanSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(0)
-    await persistWorkspaceCleanupScanResult(
+    await persistScan(
       userDataDirHolder.dir,
       { includeAllWorkspaces: true },
-      { ...makeBroadResult([candidate]), scannedAt: 100 }
+      makeBroadResult([candidate])
     )
     expect((await readWorkspaceCleanupScanSnapshot(userDataDirHolder.dir))?.candidates).toEqual([
       candidate
     ])
-    now.mockRestore()
   })
 
-  it('retires a tombstone whose scan never settles once the producer timeout passes', async () => {
+  it('keeps holding a tombstone when the wall clock jumps past the producer timeout', async () => {
+    // A laptop sleep/resume moves Date.now() while the scan's promise does not; expiring the
+    // holder on that reading retires a tombstone whose producer is still about to write.
     const candidate = makeCandidate()
-    beginWorkspaceCleanupScanSnapshotProducer(userDataDirHolder.dir)
-    const now = vi.spyOn(Date, 'now').mockReturnValue(200)
+    const scan = await openScan(userDataDirHolder.dir)
     await pruneWorkspaceCleanupScanSnapshot(
       userDataDirHolder.dir,
       candidate.worktreeId,
       candidate.executionHostId
     )
-    expect(workspaceCleanupScanSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(1)
+    const now = vi
+      .spyOn(Date, 'now')
+      .mockReturnValue(NOW + WORKSPACE_SNAPSHOT_PRUNE_PRODUCER_TIMEOUT_MS * 48)
 
-    now.mockReturnValue(201 + WORKSPACE_SNAPSHOT_PRUNE_PRODUCER_TIMEOUT_MS)
+    expect(workspaceCleanupScanSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(1)
     await persistWorkspaceCleanupScanResult(
       userDataDirHolder.dir,
       { includeAllWorkspaces: true },
-      { ...makeBroadResult([candidate]), scannedAt: 100 }
+      makeBroadResult([candidate]),
+      scan.producer
     )
 
-    expect(workspaceCleanupScanSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(0)
-    expect((await readWorkspaceCleanupScanSnapshot(userDataDirHolder.dir))?.candidates).toEqual([
-      candidate
-    ])
+    expect((await readWorkspaceCleanupScanSnapshot(userDataDirHolder.dir))?.candidates).toEqual([])
+    expect(workspaceCleanupScanSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(1)
     now.mockRestore()
+    await scan.finish()
+  })
+
+  it('retires a tombstone whose scan never settles once the producer timeout elapses', async () => {
+    vi.useFakeTimers()
+    try {
+      const candidate = makeCandidate()
+      const scan = await openScan(userDataDirHolder.dir)
+      await pruneWorkspaceCleanupScanSnapshot(
+        userDataDirHolder.dir,
+        candidate.worktreeId,
+        candidate.executionHostId
+      )
+      expect(workspaceCleanupScanSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(1)
+
+      await vi.advanceTimersByTimeAsync(WORKSPACE_SNAPSHOT_PRUNE_PRODUCER_TIMEOUT_MS + 1)
+      expect(workspaceCleanupScanSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(0)
+
+      // Losing the bound disarms the producer, so the row it still holds cannot come back.
+      snapshotWriteSpy.mockClear()
+      await persistWorkspaceCleanupScanResult(
+        userDataDirHolder.dir,
+        { includeAllWorkspaces: true },
+        makeBroadResult([candidate]),
+        scan.producer
+      )
+      expect(snapshotWriteSpy).not.toHaveBeenCalled()
+      await scan.finish()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('flushes a batched tombstone even when a scan settles before the batch closes', async () => {
     const candidate = makeCandidate()
     const target = { worktreeId: candidate.worktreeId, executionHostId: 'local' as const }
-    await persistWorkspaceCleanupScanResult(
+    await persistScan(
       userDataDirHolder.dir,
       { includeAllWorkspaces: true },
       makeBroadResult([candidate])
     )
-    const producer = beginWorkspaceCleanupScanSnapshotProducer(userDataDirHolder.dir)
+    const scan = await openScan(userDataDirHolder.dir)
     registerWorkspaceCleanupScanSnapshotPruneTombstones(userDataDirHolder.dir, [target])
-    finishWorkspaceCleanupScanSnapshotProducer(userDataDirHolder.dir, producer)
+    await scan.finish()
 
     // The deferred flush still holds it, so finalize can still find and prune the row.
     expect(workspaceCleanupScanSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(1)
@@ -536,7 +566,7 @@ describe('workspace cleanup scan snapshot', () => {
     const second = makeCandidate({ worktreeId: 'repo-1::/repo-second', path: '/repo-second' })
     const firstTarget = { worktreeId: first.worktreeId, executionHostId: 'local' as const }
     const secondTarget = { worktreeId: second.worktreeId, executionHostId: 'local' as const }
-    await persistWorkspaceCleanupScanResult(
+    await persistScan(
       userDataDirHolder.dir,
       { includeAllWorkspaces: true },
       makeBroadResult([first, second])
@@ -559,7 +589,7 @@ describe('workspace cleanup scan snapshot', () => {
       executionHostId: 'ssh:ssh-1',
       repoName: 'Remote repo'
     })
-    await persistWorkspaceCleanupScanResult(
+    await persistScan(
       userDataDirHolder.dir,
       { includeAllWorkspaces: true },
       makeBroadResult([local, remote])
@@ -570,7 +600,7 @@ describe('workspace cleanup scan snapshot', () => {
       tier: 'protected',
       blockers: ['dirty-files']
     })
-    await persistWorkspaceCleanupScanResult(
+    await persistScan(
       userDataDirHolder.dir,
       { worktreeId: remote.worktreeId },
       { scannedAt: NOW + 1, candidates: [rescannedRemote], errors: [] }

--- a/src/main/workspace-cleanup-scan-snapshot.test.ts
+++ b/src/main/workspace-cleanup-scan-snapshot.test.ts
@@ -493,9 +493,11 @@ describe('workspace cleanup scan snapshot', () => {
       candidate.worktreeId,
       candidate.executionHostId
     )
+    // Anchor on the real clock: NOW is a fixture constant in the past, so offsetting it would
+    // step the clock backwards instead of forwards.
     const now = vi
       .spyOn(Date, 'now')
-      .mockReturnValue(NOW + WORKSPACE_SNAPSHOT_PRUNE_PRODUCER_TIMEOUT_MS * 48)
+      .mockReturnValue(Date.now() + WORKSPACE_SNAPSHOT_PRUNE_PRODUCER_TIMEOUT_MS * 48)
 
     expect(workspaceCleanupScanSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(1)
     await persistWorkspaceCleanupScanResult(

--- a/src/main/workspace-cleanup-scan-snapshot.ts
+++ b/src/main/workspace-cleanup-scan-snapshot.ts
@@ -17,7 +17,10 @@ import {
   workspaceSnapshotPruneTargetKeys,
   type WorkspaceSnapshotPruneTarget
 } from './workspace-snapshot-prune-index'
-import { createWorkspaceSnapshotPruneTombstoneRegistry } from './workspace-snapshot-prune-tombstone-holders'
+import {
+  createWorkspaceSnapshotPruneTombstoneRegistry,
+  type WorkspaceSnapshotPruneProducerToken
+} from './workspace-snapshot-prune-tombstone-holders'
 
 const SNAPSHOT_FILE_NAME = 'orca-workspace-cleanup-scan.json'
 const SNAPSHOT_VERSION = 2
@@ -28,9 +31,8 @@ const tombstoneRegistry = createWorkspaceSnapshotPruneTombstoneRegistry((directo
   sidecarSnapshotFile(directory, SNAPSHOT_FILE_NAME)
 )
 
-/** Bracket every scan that may persist to this sidecar so its tombstones retire when it settles. */
-export const beginWorkspaceCleanupScanSnapshotProducer = tombstoneRegistry.beginProducer
-export const finishWorkspaceCleanupScanSnapshotProducer = tombstoneRegistry.finishProducer
+/** Run every scan that may persist to this sidecar inside the fence — the only source of a token. */
+export const withWorkspaceCleanupScanSnapshotProducer = tombstoneRegistry.withProducer
 
 /** Retention probe: STA-4451 is about how many tombstones survive, not just which rows they hide. */
 export const workspaceCleanupScanSnapshotTombstoneCountForTests = (
@@ -156,11 +158,12 @@ export function registerWorkspaceCleanupScanSnapshotPruneTombstones(
 
 function excludeRowsPrunedDuringScan(
   file: string,
-  result: WorkspaceCleanupScanResult
+  result: WorkspaceCleanupScanResult,
+  producerSeq: number
 ): WorkspaceCleanupScanResult {
   const prunedKeys = activeWorkspaceSnapshotPruneKeys(
     tombstoneRegistry.tombstones(file),
-    result.scannedAt
+    producerSeq
   )
   if (prunedKeys.size === 0) {
     return result
@@ -171,36 +174,6 @@ function excludeRowsPrunedDuringScan(
       !prunedKeys.has(workspaceSnapshotPruneKey(candidate.worktreeId))
   )
   return candidates.length === result.candidates.length ? result : { ...result, candidates }
-}
-
-function clearSupersededPrunes(
-  file: string,
-  result: WorkspaceCleanupScanResult,
-  broad: boolean
-): void {
-  const pruned = tombstoneRegistry.tombstones(file)
-  if (!pruned) {
-    return
-  }
-  const candidateKeys = broad
-    ? undefined
-    : new Set(
-        result.candidates.flatMap((candidate) => [
-          workspaceSnapshotPruneKey(candidate.worktreeId, candidate.executionHostId),
-          workspaceSnapshotPruneKey(candidate.worktreeId)
-        ])
-      )
-  for (const [key, entry] of pruned) {
-    // A held tombstone outranks supersession: the holder is exactly the writer that could still
-    // resurrect the row with a result older than this one.
-    if (
-      entry.holders.size === 0 &&
-      entry.prunedAt < result.scannedAt &&
-      (broad || candidateKeys?.has(key))
-    ) {
-      pruned.delete(key)
-    }
-  }
 }
 
 /**
@@ -215,12 +188,19 @@ const lastPersistedScannedAtByFile = new Map<string, number>()
 export async function persistWorkspaceCleanupScanResult(
   snapshotDirectory: string,
   args: WorkspaceCleanupScanArgs,
-  result: WorkspaceCleanupScanResult
+  result: WorkspaceCleanupScanResult,
+  producer: WorkspaceSnapshotPruneProducerToken
 ): Promise<void> {
   const file = sidecarSnapshotFile(snapshotDirectory, SNAPSHOT_FILE_NAME)
+  const endWrite = producer.beginWrite(file)
+  if (!endWrite) {
+    // The producer was bounded out, so its tombstones have already retired. Writing now is exactly
+    // the resurrection they existed to prevent — drop this result instead.
+    return
+  }
   try {
     await withSidecarSnapshotQueue(file, async () => {
-      const filteredResult = excludeRowsPrunedDuringScan(file, result)
+      const filteredResult = excludeRowsPrunedDuringScan(file, result, producer.seq)
       // worktreeIds (even empty) is a targeted scan; persisting it as broad
       // would replace the fleet snapshot with a subset.
       const broad =
@@ -237,7 +217,6 @@ export async function persistWorkspaceCleanupScanResult(
         }
         await writeSnapshot(file, filteredResult)
         lastPersistedScannedAtByFile.set(file, filteredResult.scannedAt)
-        clearSupersededPrunes(file, result, true)
         return
       }
       if (filteredResult.candidates.length === 0) {
@@ -249,10 +228,11 @@ export async function persistWorkspaceCleanupScanResult(
         return
       }
       await writeSnapshot(file, patchCandidates(existing, filteredResult.candidates))
-      clearSupersededPrunes(file, result, false)
     })
   } catch (error) {
     console.warn('[workspace-cleanup] failed to persist scan snapshot:', error)
+  } finally {
+    endWrite()
   }
 }
 

--- a/src/main/workspace-cleanup-scan-snapshot.ts
+++ b/src/main/workspace-cleanup-scan-snapshot.ts
@@ -13,19 +13,29 @@ import {
 import type { ExecutionHostId } from '../shared/execution-host'
 import {
   activeWorkspaceSnapshotPruneKeys,
-  registerWorkspaceSnapshotPrunesForFile,
   workspaceSnapshotPruneKey,
   workspaceSnapshotPruneTargetKeys,
-  type WorkspaceSnapshotPruneTarget,
-  type WorkspaceSnapshotPruneTombstone
+  type WorkspaceSnapshotPruneTarget
 } from './workspace-snapshot-prune-index'
+import { createWorkspaceSnapshotPruneTombstoneRegistry } from './workspace-snapshot-prune-tombstone-holders'
 
 const SNAPSHOT_FILE_NAME = 'orca-workspace-cleanup-scan.json'
 const SNAPSHOT_VERSION = 2
 
 export type WorkspaceCleanupScanSnapshotPruneTarget = WorkspaceSnapshotPruneTarget
 
-const prunedWorkspacesByFile = new Map<string, Map<string, WorkspaceSnapshotPruneTombstone>>()
+const tombstoneRegistry = createWorkspaceSnapshotPruneTombstoneRegistry((directory) =>
+  sidecarSnapshotFile(directory, SNAPSHOT_FILE_NAME)
+)
+
+/** Bracket every scan that may persist to this sidecar so its tombstones retire when it settles. */
+export const beginWorkspaceCleanupScanSnapshotProducer = tombstoneRegistry.beginProducer
+export const finishWorkspaceCleanupScanSnapshotProducer = tombstoneRegistry.finishProducer
+
+/** Retention probe: STA-4451 is about how many tombstones survive, not just which rows they hide. */
+export const workspaceCleanupScanSnapshotTombstoneCountForTests = (
+  snapshotDirectory: string
+): number => tombstoneRegistry.count(sidecarSnapshotFile(snapshotDirectory, SNAPSHOT_FILE_NAME))
 
 type PersistedWorkspaceCleanupScanSnapshot = {
   version: number
@@ -135,10 +145,12 @@ export function registerWorkspaceCleanupScanSnapshotPruneTombstones(
   if (targets.length === 0) {
     return
   }
-  registerWorkspaceSnapshotPrunesForFile(
-    prunedWorkspacesByFile,
+  // Deferred: the flush is a holder too, or a settling producer would retire the tombstone before
+  // finalize runs and finalize would skip the sidecar rewrite it was tombstoned for.
+  tombstoneRegistry.register(
     sidecarSnapshotFile(snapshotDirectory, SNAPSHOT_FILE_NAME),
-    targets
+    targets,
+    true
   )
 }
 
@@ -147,7 +159,7 @@ function excludeRowsPrunedDuringScan(
   result: WorkspaceCleanupScanResult
 ): WorkspaceCleanupScanResult {
   const prunedKeys = activeWorkspaceSnapshotPruneKeys(
-    prunedWorkspacesByFile.get(file),
+    tombstoneRegistry.tombstones(file),
     result.scannedAt
   )
   if (prunedKeys.size === 0) {
@@ -166,7 +178,7 @@ function clearSupersededPrunes(
   result: WorkspaceCleanupScanResult,
   broad: boolean
 ): void {
-  const pruned = prunedWorkspacesByFile.get(file)
+  const pruned = tombstoneRegistry.tombstones(file)
   if (!pruned) {
     return
   }
@@ -179,12 +191,15 @@ function clearSupersededPrunes(
         ])
       )
   for (const [key, entry] of pruned) {
-    if (entry.prunedAt < result.scannedAt && (broad || candidateKeys?.has(key))) {
+    // A held tombstone outranks supersession: the holder is exactly the writer that could still
+    // resurrect the row with a result older than this one.
+    if (
+      entry.holders.size === 0 &&
+      entry.prunedAt < result.scannedAt &&
+      (broad || candidateKeys?.has(key))
+    ) {
       pruned.delete(key)
     }
-  }
-  if (pruned.size === 0) {
-    prunedWorkspacesByFile.delete(file)
   }
 }
 
@@ -252,11 +267,12 @@ async function pruneWorkspaceCleanupScanSnapshotsWithRegisteredTombstones(
   const file = sidecarSnapshotFile(snapshotDirectory, SNAPSHOT_FILE_NAME)
   const targetKeys = workspaceSnapshotPruneTargetKeys(targets)
   if (registerTombstones) {
-    registerWorkspaceSnapshotPrunesForFile(prunedWorkspacesByFile, file, targets)
+    // Immediate: no flush holder, this call performs the sidecar rewrite itself.
+    tombstoneRegistry.register(file, targets, false)
   }
   try {
     await withSidecarSnapshotQueue(file, async () => {
-      const registered = prunedWorkspacesByFile.get(file)
+      const registered = tombstoneRegistry.tombstones(file)
       const coalescedTargetKeys = registerTombstones
         ? targetKeys
         : new Set([...targetKeys].filter((key) => registered?.has(key)))
@@ -280,6 +296,10 @@ async function pruneWorkspaceCleanupScanSnapshotsWithRegisteredTombstones(
     })
   } catch (error) {
     console.warn('[workspace-cleanup] failed to prune scan snapshot:', error)
+  } finally {
+    if (!registerTombstones) {
+      tombstoneRegistry.releaseFlush(file, targetKeys)
+    }
   }
 }
 

--- a/src/main/workspace-snapshot-prune-index.ts
+++ b/src/main/workspace-snapshot-prune-index.ts
@@ -5,9 +5,22 @@ export type WorkspaceSnapshotPruneTarget = {
   executionHostId?: ExecutionHostId
 }
 
+/**
+ * `holders` is the retirement gate (STA-4451): the writers that could still resurrect this row.
+ * `producerDeadline` bounds only the producer holders — see the tombstone registry.
+ */
 export type WorkspaceSnapshotPruneTombstone = WorkspaceSnapshotPruneTarget & {
   prunedAt: number
+  producerDeadline: number
+  holders: Set<string>
 }
+
+/**
+ * Bounded fallback for a producer that never reports back — a scan wedged on an unreachable SSH
+ * host, or a renderer torn down mid-scan. Deliberately longer than the removal batch's idle
+ * timeout so it can never preempt a pending flush, which it does not police.
+ */
+export const WORKSPACE_SNAPSHOT_PRUNE_PRODUCER_TIMEOUT_MS = 10 * 60 * 1000
 
 export function workspaceSnapshotPruneKey(
   worktreeId: string,
@@ -39,19 +52,27 @@ export function activeWorkspaceSnapshotPruneKeys(
   return keys
 }
 
+/** A tombstone nobody holds can no longer stop anything, so it is never stored. */
 export function registerWorkspaceSnapshotPrunesForFile(
-  tombstonesByFile: Map<string, Map<string, WorkspaceSnapshotPruneTombstone>>,
-  file: string,
-  targets: readonly WorkspaceSnapshotPruneTarget[]
+  tombstones: Map<string, WorkspaceSnapshotPruneTombstone>,
+  targets: readonly WorkspaceSnapshotPruneTarget[],
+  holders: Iterable<string>
 ): void {
-  const tombstones = tombstonesByFile.get(file) ?? new Map()
   const prunedAt = Date.now()
   for (const { worktreeId, executionHostId } of targets) {
-    tombstones.set(workspaceSnapshotPruneKey(worktreeId, executionHostId), {
+    const key = workspaceSnapshotPruneKey(worktreeId, executionHostId)
+    // Union, never replace: a re-registered target may still be held by an earlier batch.
+    const merged = new Set([...(tombstones.get(key)?.holders ?? []), ...holders])
+    if (merged.size === 0) {
+      tombstones.delete(key)
+      continue
+    }
+    tombstones.set(key, {
       worktreeId,
       ...(executionHostId ? { executionHostId } : {}),
-      prunedAt
+      prunedAt,
+      producerDeadline: prunedAt + WORKSPACE_SNAPSHOT_PRUNE_PRODUCER_TIMEOUT_MS,
+      holders: merged
     })
   }
-  tombstonesByFile.set(file, tombstones)
 }

--- a/src/main/workspace-snapshot-prune-index.ts
+++ b/src/main/workspace-snapshot-prune-index.ts
@@ -7,20 +7,29 @@ export type WorkspaceSnapshotPruneTarget = {
 
 /**
  * `holders` is the retirement gate (STA-4451): the writers that could still resurrect this row.
- * `producerDeadline` bounds only the producer holders — see the tombstone registry.
+ * `prunedSeq` orders this prune against the producers that were already running when it landed.
  */
 export type WorkspaceSnapshotPruneTombstone = WorkspaceSnapshotPruneTarget & {
-  prunedAt: number
-  producerDeadline: number
+  prunedSeq: number
   holders: Set<string>
 }
 
 /**
- * Bounded fallback for a producer that never reports back — a scan wedged on an unreachable SSH
- * host, or a renderer torn down mid-scan. Deliberately longer than the removal batch's idle
- * timeout so it can never preempt a pending flush, which it does not police.
+ * Bounds a producer that never reports back — a scan wedged on an unreachable SSH host, or a
+ * renderer torn down mid-scan. Deliberately longer than the removal batch's idle timeout so it can
+ * never preempt a pending flush, which it does not police.
  */
 export const WORKSPACE_SNAPSHOT_PRUNE_PRODUCER_TIMEOUT_MS = 10 * 60 * 1000
+
+// Why not Date.now(): a sleep/resume or an NTP correction moves the wall clock while an in-flight
+// scan's promise does not, which would order a prune against a producer that never advanced.
+let lastSequence = 0
+
+/** Process-lifetime ordering source for prunes and producer starts. */
+export function nextWorkspaceSnapshotPruneSequence(): number {
+  lastSequence += 1
+  return lastSequence
+}
 
 export function workspaceSnapshotPruneKey(
   worktreeId: string,
@@ -39,13 +48,14 @@ export function workspaceSnapshotPruneTargetKeys(
   )
 }
 
+/** Tombstones registered after this producer opened its fence — its result predates them. */
 export function activeWorkspaceSnapshotPruneKeys(
   tombstones: ReadonlyMap<string, WorkspaceSnapshotPruneTombstone> | undefined,
-  scannedAt: number
+  producerSeq: number
 ): Set<string> {
   const keys = new Set<string>()
   for (const [key, entry] of tombstones ?? []) {
-    if (entry.prunedAt >= scannedAt) {
+    if (entry.prunedSeq > producerSeq) {
       keys.add(key)
     }
   }
@@ -57,16 +67,21 @@ export function registerWorkspaceSnapshotPrunesForFile(
   targets: readonly WorkspaceSnapshotPruneTarget[],
   holders: Iterable<string>
 ): void {
-  const prunedAt = Date.now()
+  const prunedSeq = nextWorkspaceSnapshotPruneSequence()
   for (const { worktreeId, executionHostId } of targets) {
     const key = workspaceSnapshotPruneKey(worktreeId, executionHostId)
     // Union, never replace: a re-registered target may still be held by an earlier batch.
     const merged = new Set([...(tombstones.get(key)?.holders ?? []), ...holders])
+    if (merged.size === 0) {
+      // Nothing can resurrect this row, so there is nothing to remember. Retirement stays
+      // single-sourced in the registry's release path instead of needing a sweeper.
+      tombstones.delete(key)
+      continue
+    }
     tombstones.set(key, {
       worktreeId,
       ...(executionHostId ? { executionHostId } : {}),
-      prunedAt,
-      producerDeadline: prunedAt + WORKSPACE_SNAPSHOT_PRUNE_PRODUCER_TIMEOUT_MS,
+      prunedSeq,
       holders: merged
     })
   }

--- a/src/main/workspace-snapshot-prune-index.ts
+++ b/src/main/workspace-snapshot-prune-index.ts
@@ -52,7 +52,6 @@ export function activeWorkspaceSnapshotPruneKeys(
   return keys
 }
 
-/** A tombstone nobody holds can no longer stop anything, so it is never stored. */
 export function registerWorkspaceSnapshotPrunesForFile(
   tombstones: Map<string, WorkspaceSnapshotPruneTombstone>,
   targets: readonly WorkspaceSnapshotPruneTarget[],
@@ -63,10 +62,6 @@ export function registerWorkspaceSnapshotPrunesForFile(
     const key = workspaceSnapshotPruneKey(worktreeId, executionHostId)
     // Union, never replace: a re-registered target may still be held by an earlier batch.
     const merged = new Set([...(tombstones.get(key)?.holders ?? []), ...holders])
-    if (merged.size === 0) {
-      tombstones.delete(key)
-      continue
-    }
     tombstones.set(key, {
       worktreeId,
       ...(executionHostId ? { executionHostId } : {}),

--- a/src/main/workspace-snapshot-prune-producer-fixtures.ts
+++ b/src/main/workspace-snapshot-prune-producer-fixtures.ts
@@ -1,0 +1,40 @@
+import type { WorkspaceSnapshotPruneProducerToken } from './workspace-snapshot-prune-tombstone-holders'
+
+type WithWorkspaceSnapshotPruneProducer = <T>(
+  snapshotDirectory: string,
+  produce: (producer: WorkspaceSnapshotPruneProducerToken) => Promise<T>
+) => Promise<T>
+
+export type OpenWorkspaceSnapshotPruneProducer = {
+  producer: WorkspaceSnapshotPruneProducerToken
+  /** Close the bracket and wait for the fence to settle. */
+  finish: () => Promise<void>
+}
+
+/**
+ * Hold a producer's fence open across test steps the way an in-flight scan holds it in production,
+ * where the bracket spans a scan the test does not have.
+ */
+export async function openWorkspaceSnapshotPruneProducer(
+  withProducer: WithWorkspaceSnapshotPruneProducer,
+  snapshotDirectory: string
+): Promise<OpenWorkspaceSnapshotPruneProducer> {
+  let close = (): void => {}
+  let announce = (_producer: WorkspaceSnapshotPruneProducerToken): void => {}
+  const opened = new Promise<WorkspaceSnapshotPruneProducerToken>((resolve) => {
+    announce = resolve
+  })
+  const bracket = withProducer(snapshotDirectory, async (producer) => {
+    announce(producer)
+    await new Promise<void>((resolve) => {
+      close = resolve
+    })
+  })
+  return {
+    producer: await opened,
+    finish: async () => {
+      close()
+      await bracket
+    }
+  }
+}

--- a/src/main/workspace-snapshot-prune-tombstone-holders.ts
+++ b/src/main/workspace-snapshot-prune-tombstone-holders.ts
@@ -1,4 +1,5 @@
 import {
+  nextWorkspaceSnapshotPruneSequence,
   registerWorkspaceSnapshotPrunesForFile,
   WORKSPACE_SNAPSHOT_PRUNE_PRODUCER_TIMEOUT_MS,
   type WorkspaceSnapshotPruneTarget,
@@ -9,12 +10,26 @@ import {
 export const WORKSPACE_SNAPSHOT_PRUNE_FLUSH_HOLDER = 'flush'
 
 /**
+ * Write capability for one sidecar, minted only by `withProducer`. `persist*` takes it as a
+ * required parameter, so a future persist call site cannot compile without opening the fence.
+ */
+export type WorkspaceSnapshotPruneProducerToken = {
+  /** Where this producer sits in the prune order: tombstones registered after it fence its result. */
+  readonly seq: number
+  /**
+   * Claim the capability for `file` and get its release. Null once the producer was bounded out, or
+   * when the token was minted for a different sidecar — a disarmed producer must never write.
+   */
+  readonly beginWrite: (file: string) => (() => void) | null
+}
+
+/**
  * Owns tombstone lifetime for one sidecar file (STA-4451). A tombstone only has to outlive the
- * writers that could still put the removed row back, so it is retired as soon as the last of them
- * releases it — never on a wall clock, except as the bounded fallback for a producer that hangs.
+ * writers that could still put the removed row back, so it is retired when the last of them
+ * releases it — never on a clock reading.
  */
 export type WorkspaceSnapshotPruneTombstoneRegistry = {
-  /** Live tombstones for this sidecar, with expired producer holders already dropped. */
+  /** Live tombstones for this sidecar. */
   tombstones: (file: string) => Map<string, WorkspaceSnapshotPruneTombstone> | undefined
   /** `deferred` marks a batch that tombstones now and rewrites the sidecar at finalize. */
   register: (
@@ -22,10 +37,15 @@ export type WorkspaceSnapshotPruneTombstoneRegistry = {
     targets: readonly WorkspaceSnapshotPruneTarget[],
     deferred: boolean
   ) => void
-  /** Open the window in which this scan may still persist a pre-prune result. */
-  beginProducer: (snapshotDirectory: string) => string
-  /** Close it — the scan persisted, failed, or ended without persisting. */
-  finishProducer: (snapshotDirectory: string, holder: string) => void
+  /**
+   * Run `produce` inside the fence. Its tombstones are held from before it starts until it can no
+   * longer write, and the returned promise settles with `produce` — a write it left in flight keeps
+   * the fence open without delaying the caller.
+   */
+  withProducer: <T>(
+    snapshotDirectory: string,
+    produce: (producer: WorkspaceSnapshotPruneProducerToken) => Promise<T>
+  ) => Promise<T>
   releaseFlush: (file: string, keys: ReadonlySet<string>) => void
   count: (file: string) => number
 }
@@ -45,33 +65,13 @@ export function createWorkspaceSnapshotPruneTombstoneRegistry(
         tombstones?.delete(key)
       }
     }
+    if (tombstones?.size === 0) {
+      tombstonesByFile.delete(file)
+    }
   }
 
-  const live = (file: string): Map<string, WorkspaceSnapshotPruneTombstone> | undefined => {
-    const tombstones = tombstonesByFile.get(file)
-    if (!tombstones) {
-      return undefined
-    }
-    const now = Date.now()
-    for (const [key, entry] of tombstones) {
-      // Presume a producer past its deadline settled. The flush holder is the batch's to release.
-      if (entry.producerDeadline <= now) {
-        for (const holder of entry.holders) {
-          if (holder !== WORKSPACE_SNAPSHOT_PRUNE_FLUSH_HOLDER) {
-            entry.holders.delete(holder)
-          }
-        }
-      }
-      if (entry.holders.size === 0) {
-        tombstones.delete(key)
-      }
-    }
-    if (tombstones.size === 0) {
-      tombstonesByFile.delete(file)
-      return undefined
-    }
-    return tombstones
-  }
+  const live = (file: string): Map<string, WorkspaceSnapshotPruneTombstone> | undefined =>
+    tombstonesByFile.get(file)
 
   return {
     tombstones: live,
@@ -83,23 +83,66 @@ export function createWorkspaceSnapshotPruneTombstoneRegistry(
       ])
       if (tombstones.size > 0) {
         tombstonesByFile.set(file, tombstones)
+      } else {
+        tombstonesByFile.delete(file)
       }
     },
-    beginProducer(snapshotDirectory) {
+    async withProducer(snapshotDirectory, produce) {
       const file = resolveFile(snapshotDirectory)
       const holder = `producer:${(nextProducerId += 1)}`
       const active = activeProducersByFile.get(file) ?? new Set<string>()
       active.add(holder)
       activeProducersByFile.set(file, active)
-      return holder
-    },
-    finishProducer(snapshotDirectory, holder) {
-      const file = resolveFile(snapshotDirectory)
-      const active = activeProducersByFile.get(file)
-      if (active?.delete(holder) && active.size === 0) {
-        activeProducersByFile.delete(file)
+
+      let writes = 0
+      let closed = false
+      let disarmed = false
+      const settle = (): void => {
+        // A producer with a write in flight is demonstrably alive, so the bound waits it out: the
+        // holder is only ever dropped while the producer holds no capability to use it.
+        if (disarmed || !closed || writes > 0) {
+          return
+        }
+        disarmed = true
+        clearTimeout(bound)
+        const holders = activeProducersByFile.get(file)
+        if (holders?.delete(holder) && holders.size === 0) {
+          activeProducersByFile.delete(file)
+        }
+        release(file, holder)
       }
-      release(file, holder)
+      // setTimeout runs on the runtime's monotonic clock, so a lid-close cannot expire a live scan.
+      const bound = setTimeout(() => {
+        closed = true
+        settle()
+      }, WORKSPACE_SNAPSHOT_PRUNE_PRODUCER_TIMEOUT_MS)
+      bound.unref?.()
+
+      const producer: WorkspaceSnapshotPruneProducerToken = {
+        seq: nextWorkspaceSnapshotPruneSequence(),
+        beginWrite: (target) => {
+          if (closed || target !== file) {
+            return null
+          }
+          writes += 1
+          let released = false
+          return () => {
+            if (released) {
+              return
+            }
+            released = true
+            writes -= 1
+            settle()
+          }
+        }
+      }
+
+      try {
+        return await produce(producer)
+      } finally {
+        closed = true
+        settle()
+      }
     },
     releaseFlush: (file, keys) => release(file, WORKSPACE_SNAPSHOT_PRUNE_FLUSH_HOLDER, keys),
     count: (file) => live(file)?.size ?? 0

--- a/src/main/workspace-snapshot-prune-tombstone-holders.ts
+++ b/src/main/workspace-snapshot-prune-tombstone-holders.ts
@@ -1,0 +1,109 @@
+import {
+  registerWorkspaceSnapshotPrunesForFile,
+  WORKSPACE_SNAPSHOT_PRUNE_PRODUCER_TIMEOUT_MS,
+  type WorkspaceSnapshotPruneTarget,
+  type WorkspaceSnapshotPruneTombstone
+} from './workspace-snapshot-prune-index'
+
+/** Held by a deferred removal batch between its tombstone write and its sidecar flush. */
+export const WORKSPACE_SNAPSHOT_PRUNE_FLUSH_HOLDER = 'flush'
+
+/**
+ * Owns tombstone lifetime for one sidecar file (STA-4451). A tombstone only has to outlive the
+ * writers that could still put the removed row back, so it is retired as soon as the last of them
+ * releases it — never on a wall clock, except as the bounded fallback for a producer that hangs.
+ */
+export type WorkspaceSnapshotPruneTombstoneRegistry = {
+  /** Live tombstones for this sidecar, with expired producer holders already dropped. */
+  tombstones: (file: string) => Map<string, WorkspaceSnapshotPruneTombstone> | undefined
+  /** `deferred` marks a batch that tombstones now and rewrites the sidecar at finalize. */
+  register: (
+    file: string,
+    targets: readonly WorkspaceSnapshotPruneTarget[],
+    deferred: boolean
+  ) => void
+  /** Open the window in which this scan may still persist a pre-prune result. */
+  beginProducer: (snapshotDirectory: string) => string
+  /** Close it — the scan persisted, failed, or ended without persisting. */
+  finishProducer: (snapshotDirectory: string, holder: string) => void
+  releaseFlush: (file: string, keys: ReadonlySet<string>) => void
+  count: (file: string) => number
+}
+
+export function createWorkspaceSnapshotPruneTombstoneRegistry(
+  resolveFile: (snapshotDirectory: string) => string
+): WorkspaceSnapshotPruneTombstoneRegistry {
+  const tombstonesByFile = new Map<string, Map<string, WorkspaceSnapshotPruneTombstone>>()
+  const activeProducersByFile = new Map<string, Set<string>>()
+  let nextProducerId = 0
+
+  const release = (file: string, holder: string, keys?: ReadonlySet<string>): void => {
+    const tombstones = tombstonesByFile.get(file)
+    for (const [key, entry] of tombstones ?? []) {
+      // Guard on membership: releasing one holder must not retire tombstones held by others.
+      if ((!keys || keys.has(key)) && entry.holders.delete(holder) && entry.holders.size === 0) {
+        tombstones?.delete(key)
+      }
+    }
+  }
+
+  const live = (file: string): Map<string, WorkspaceSnapshotPruneTombstone> | undefined => {
+    const tombstones = tombstonesByFile.get(file)
+    if (!tombstones) {
+      return undefined
+    }
+    const now = Date.now()
+    for (const [key, entry] of tombstones) {
+      // Presume a producer past its deadline settled. The flush holder is the batch's to release.
+      if (entry.producerDeadline <= now) {
+        for (const holder of entry.holders) {
+          if (holder !== WORKSPACE_SNAPSHOT_PRUNE_FLUSH_HOLDER) {
+            entry.holders.delete(holder)
+          }
+        }
+      }
+      if (entry.holders.size === 0) {
+        tombstones.delete(key)
+      }
+    }
+    if (tombstones.size === 0) {
+      tombstonesByFile.delete(file)
+      return undefined
+    }
+    return tombstones
+  }
+
+  return {
+    tombstones: live,
+    register(file, targets, deferred) {
+      const tombstones = live(file) ?? new Map()
+      registerWorkspaceSnapshotPrunesForFile(tombstones, targets, [
+        ...(deferred ? [WORKSPACE_SNAPSHOT_PRUNE_FLUSH_HOLDER] : []),
+        ...(activeProducersByFile.get(file) ?? [])
+      ])
+      if (tombstones.size > 0) {
+        tombstonesByFile.set(file, tombstones)
+      }
+    },
+    beginProducer(snapshotDirectory) {
+      const file = resolveFile(snapshotDirectory)
+      const holder = `producer:${(nextProducerId += 1)}`
+      const active = activeProducersByFile.get(file) ?? new Set<string>()
+      active.add(holder)
+      activeProducersByFile.set(file, active)
+      return holder
+    },
+    finishProducer(snapshotDirectory, holder) {
+      const file = resolveFile(snapshotDirectory)
+      const active = activeProducersByFile.get(file)
+      if (active?.delete(holder) && active.size === 0) {
+        activeProducersByFile.delete(file)
+      }
+      release(file, holder)
+    },
+    releaseFlush: (file, keys) => release(file, WORKSPACE_SNAPSHOT_PRUNE_FLUSH_HOLDER, keys),
+    count: (file) => live(file)?.size ?? 0
+  }
+}
+
+export { WORKSPACE_SNAPSHOT_PRUNE_PRODUCER_TIMEOUT_MS }

--- a/src/main/workspace-snapshot-pruning.bench.test.ts
+++ b/src/main/workspace-snapshot-pruning.bench.test.ts
@@ -8,11 +8,13 @@ import type { WorkspaceCleanupCandidate } from '../shared/workspace-cleanup'
 import type { WorkspaceSpaceWorktree } from '../shared/workspace-space-types'
 import {
   persistWorkspaceCleanupScanResult,
-  pruneWorkspaceCleanupScanSnapshots
+  pruneWorkspaceCleanupScanSnapshots,
+  withWorkspaceCleanupScanSnapshotProducer
 } from './workspace-cleanup-scan-snapshot'
 import {
   persistWorkspaceSpaceAnalysisSnapshot,
-  pruneWorkspaceSpaceAnalysisSnapshots
+  pruneWorkspaceSpaceAnalysisSnapshots,
+  withWorkspaceSpaceAnalysisSnapshotProducer
 } from './workspace-space-analysis-snapshot'
 
 const describeBench = process.env.ORCA_WORKSPACE_SNAPSHOT_PRUNE_BENCH ? describe : describe.skip
@@ -37,21 +39,30 @@ describeBench('workspace snapshot bulk pruning', () => {
       worktreeId: candidate.worktreeId,
       executionHostId: candidate.executionHostId
     }))
-    await persistWorkspaceCleanupScanResult(
-      snapshotDirectory,
-      { includeAllWorkspaces: true },
-      { scannedAt: 1, candidates, errors: [] }
+    await withWorkspaceCleanupScanSnapshotProducer(snapshotDirectory, (producer) =>
+      persistWorkspaceCleanupScanResult(
+        snapshotDirectory,
+        { includeAllWorkspaces: true },
+        { scannedAt: 1, candidates, errors: [] },
+        producer
+      )
     )
-    await persistWorkspaceSpaceAnalysisSnapshot(snapshotDirectory, {
-      scannedAt: 1,
-      totalSizeBytes: ROW_COUNT * 1_000,
-      reclaimableBytes: ROW_COUNT * 1_000,
-      worktreeCount: ROW_COUNT,
-      scannedWorktreeCount: ROW_COUNT,
-      unavailableWorktreeCount: 0,
-      repos: makeRepoSummaries(worktrees),
-      worktrees
-    })
+    await withWorkspaceSpaceAnalysisSnapshotProducer(snapshotDirectory, (producer) =>
+      persistWorkspaceSpaceAnalysisSnapshot(
+        snapshotDirectory,
+        {
+          scannedAt: 1,
+          totalSizeBytes: ROW_COUNT * 1_000,
+          reclaimableBytes: ROW_COUNT * 1_000,
+          worktreeCount: ROW_COUNT,
+          scannedWorktreeCount: ROW_COUNT,
+          unavailableWorktreeCount: 0,
+          repos: makeRepoSummaries(worktrees),
+          worktrees
+        },
+        producer
+      )
+    )
 
     const startedAt = performance.now()
     await Promise.all([

--- a/src/main/workspace-space-analysis-row-pruning.ts
+++ b/src/main/workspace-space-analysis-row-pruning.ts
@@ -1,0 +1,89 @@
+import type { ExecutionHostId } from '../shared/execution-host'
+import type {
+  WorkspaceSpaceAnalysis,
+  WorkspaceSpaceWorktree
+} from '../shared/workspace-space-types'
+
+function analysisRepoKey(entry: { repoId: string; executionHostId?: ExecutionHostId }): string {
+  return JSON.stringify([entry.executionHostId, entry.repoId])
+}
+
+export function withoutWorktreeRows(
+  analysis: WorkspaceSpaceAnalysis,
+  shouldRemove: (row: WorkspaceSpaceWorktree) => boolean
+): WorkspaceSpaceAnalysis {
+  const worktrees: WorkspaceSpaceWorktree[] = []
+  const removedByRepo = new Map<
+    string,
+    {
+      worktreeCount: number
+      scannedWorktreeCount: number
+      unavailableWorktreeCount: number
+      totalSizeBytes: number
+      reclaimableBytes: number
+    }
+  >()
+  let removedCount = 0
+  let scannedDelta = 0
+  let unavailableDelta = 0
+  let totalSizeDelta = 0
+  let reclaimableDelta = 0
+  for (const row of analysis.worktrees) {
+    if (!shouldRemove(row)) {
+      worktrees.push(row)
+      continue
+    }
+    const scanned = row.status === 'ok' ? 1 : 0
+    const unavailable = row.status === 'ok' ? 0 : 1
+    removedCount += 1
+    scannedDelta += scanned
+    unavailableDelta += unavailable
+    totalSizeDelta += row.sizeBytes
+    reclaimableDelta += row.reclaimableBytes
+    const key = analysisRepoKey(row)
+    const delta = removedByRepo.get(key) ?? {
+      worktreeCount: 0,
+      scannedWorktreeCount: 0,
+      unavailableWorktreeCount: 0,
+      totalSizeBytes: 0,
+      reclaimableBytes: 0
+    }
+    delta.worktreeCount += 1
+    delta.scannedWorktreeCount += scanned
+    delta.unavailableWorktreeCount += unavailable
+    delta.totalSizeBytes += row.sizeBytes
+    delta.reclaimableBytes += row.reclaimableBytes
+    removedByRepo.set(key, delta)
+  }
+  if (removedCount === 0) {
+    return analysis
+  }
+  return {
+    ...analysis,
+    worktrees,
+    worktreeCount: Math.max(0, analysis.worktreeCount - removedCount),
+    scannedWorktreeCount: Math.max(0, analysis.scannedWorktreeCount - scannedDelta),
+    unavailableWorktreeCount: Math.max(0, analysis.unavailableWorktreeCount - unavailableDelta),
+    totalSizeBytes: Math.max(0, analysis.totalSizeBytes - totalSizeDelta),
+    reclaimableBytes: Math.max(0, analysis.reclaimableBytes - reclaimableDelta),
+    repos: analysis.repos.map((repo) => {
+      const delta = removedByRepo.get(analysisRepoKey(repo))
+      return delta
+        ? {
+            ...repo,
+            worktreeCount: Math.max(0, repo.worktreeCount - delta.worktreeCount),
+            scannedWorktreeCount: Math.max(
+              0,
+              repo.scannedWorktreeCount - delta.scannedWorktreeCount
+            ),
+            unavailableWorktreeCount: Math.max(
+              0,
+              repo.unavailableWorktreeCount - delta.unavailableWorktreeCount
+            ),
+            totalSizeBytes: Math.max(0, repo.totalSizeBytes - delta.totalSizeBytes),
+            reclaimableBytes: Math.max(0, repo.reclaimableBytes - delta.reclaimableBytes)
+          }
+        : repo
+    })
+  }
+}

--- a/src/main/workspace-space-analysis-snapshot.test.ts
+++ b/src/main/workspace-space-analysis-snapshot.test.ts
@@ -454,9 +454,11 @@ describe('workspace space analysis snapshot', () => {
       row.worktreeId,
       row.executionHostId
     )
+    // Anchor on the real clock: NOW is a fixture constant in the past, so offsetting it would
+    // step the clock backwards instead of forwards.
     const now = vi
       .spyOn(Date, 'now')
-      .mockReturnValue(NOW + WORKSPACE_SNAPSHOT_PRUNE_PRODUCER_TIMEOUT_MS * 48)
+      .mockReturnValue(Date.now() + WORKSPACE_SNAPSHOT_PRUNE_PRODUCER_TIMEOUT_MS * 48)
 
     expect(workspaceSpaceAnalysisSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(1)
     await persistWorkspaceSpaceAnalysisSnapshot(

--- a/src/main/workspace-space-analysis-snapshot.test.ts
+++ b/src/main/workspace-space-analysis-snapshot.test.ts
@@ -28,17 +28,17 @@ vi.mock('./sidecar-snapshot-file', async (importOriginal) => {
 })
 
 import {
-  beginWorkspaceSpaceAnalysisSnapshotProducer,
   finalizeWorkspaceSpaceAnalysisSnapshotPrunes,
-  finishWorkspaceSpaceAnalysisSnapshotProducer,
   persistWorkspaceSpaceAnalysisSnapshot,
   pruneWorkspaceSpaceAnalysisSnapshot,
   pruneWorkspaceSpaceAnalysisSnapshots,
   readWorkspaceSpaceAnalysisSnapshot,
   registerWorkspaceSpaceAnalysisSnapshotPruneTombstones,
+  withWorkspaceSpaceAnalysisSnapshotProducer,
   workspaceSpaceAnalysisSnapshotTombstoneCountForTests
 } from './workspace-space-analysis-snapshot'
 import { WORKSPACE_SNAPSHOT_PRUNE_PRODUCER_TIMEOUT_MS } from './workspace-snapshot-prune-index'
+import { openWorkspaceSnapshotPruneProducer } from './workspace-snapshot-prune-producer-fixtures'
 
 const SNAPSHOT_FILE = 'orca-workspace-space-analysis.json'
 const NOW = 1_700_000_000_000
@@ -101,6 +101,21 @@ function makeAnalysis(worktrees: WorkspaceSpaceWorktree[]): WorkspaceSpaceAnalys
   }
 }
 
+/** An analysis whose fence opens at persist time — one that raced no removal. */
+function persistAnalysis(
+  snapshotDirectory: string,
+  analysis: WorkspaceSpaceAnalysis
+): Promise<void> {
+  return withWorkspaceSpaceAnalysisSnapshotProducer(snapshotDirectory, (producer) =>
+    persistWorkspaceSpaceAnalysisSnapshot(snapshotDirectory, analysis, producer)
+  )
+}
+
+const openAnalysis = (
+  snapshotDirectory: string
+): ReturnType<typeof openWorkspaceSnapshotPruneProducer> =>
+  openWorkspaceSnapshotPruneProducer(withWorkspaceSpaceAnalysisSnapshotProducer, snapshotDirectory)
+
 describe('workspace space analysis snapshot', () => {
   beforeEach(async () => {
     snapshotWriteSpy.mockClear()
@@ -114,7 +129,7 @@ describe('workspace space analysis snapshot', () => {
   it('round-trips a completed analysis', async () => {
     const analysis = makeAnalysis([makeWorktreeRow()])
 
-    await persistWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir, analysis)
+    await persistAnalysis(userDataDirHolder.dir, analysis)
 
     await expect(readWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir)).resolves.toEqual(
       analysis
@@ -137,7 +152,7 @@ describe('workspace space analysis snapshot', () => {
       omittedTopLevelSizeBytes: 500
     })
 
-    await persistWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir, makeAnalysis([row]))
+    await persistAnalysis(userDataDirHolder.dir, makeAnalysis([row]))
 
     const cached = await readWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir)
     expect(cached?.worktrees[0]).toMatchObject({
@@ -199,10 +214,7 @@ describe('workspace space analysis snapshot', () => {
       sizeBytes: 1000,
       reclaimableBytes: 0
     })
-    await persistWorkspaceSpaceAnalysisSnapshot(
-      userDataDirHolder.dir,
-      makeAnalysis([removed, kept])
-    )
+    await persistAnalysis(userDataDirHolder.dir, makeAnalysis([removed, kept]))
 
     snapshotWriteSpy.mockClear()
     await pruneWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir, removed.worktreeId, 'local')
@@ -261,7 +273,7 @@ describe('workspace space analysis snapshot', () => {
       sizeBytes: 500,
       reclaimableBytes: 500
     })
-    await persistWorkspaceSpaceAnalysisSnapshot(
+    await persistAnalysis(
       userDataDirHolder.dir,
       makeAnalysis([localCollision, remoteCollision, localRemoved, remoteRemoved, kept])
     )
@@ -308,10 +320,7 @@ describe('workspace space analysis snapshot', () => {
   it('keeps profile snapshots isolated', async () => {
     const otherProfile = await mkdtemp(join(tmpdir(), 'orca-space-snapshot-other-'))
     try {
-      await persistWorkspaceSpaceAnalysisSnapshot(
-        userDataDirHolder.dir,
-        makeAnalysis([makeWorktreeRow()])
-      )
+      await persistAnalysis(userDataDirHolder.dir, makeAnalysis([makeWorktreeRow()]))
 
       await expect(readWorkspaceSpaceAnalysisSnapshot(otherProfile)).resolves.toBeNull()
     } finally {
@@ -327,22 +336,24 @@ describe('workspace space analysis snapshot', () => {
       isRemote: true,
       path: '/remote-feature'
     })
-    const staleAnalysis = {
-      ...makeAnalysis([local, remote]),
-      scannedAt: Date.now() - 1
-    }
+    const staleAnalysis = makeAnalysis([local, remote])
     // The analysis is in flight before the removal, so it is a fenced producer of this sidecar.
-    beginWorkspaceSpaceAnalysisSnapshotProducer(userDataDirHolder.dir)
+    const analysis = await openAnalysis(userDataDirHolder.dir)
     await pruneWorkspaceSpaceAnalysisSnapshots(userDataDirHolder.dir, [
       { worktreeId: local.worktreeId, executionHostId: 'local' },
       { worktreeId: remote.worktreeId, executionHostId: 'ssh:ssh-1' }
     ])
 
-    await persistWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir, staleAnalysis)
+    await persistWorkspaceSpaceAnalysisSnapshot(
+      userDataDirHolder.dir,
+      staleAnalysis,
+      analysis.producer
+    )
     expect((await readWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir))?.worktrees).toEqual([])
 
-    const recreated = { ...staleAnalysis, scannedAt: Date.now() + 1 }
-    await persistWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir, recreated)
+    await analysis.finish()
+    // An analysis started after the removal is not fenced, so a re-created workspace comes back.
+    await persistAnalysis(userDataDirHolder.dir, staleAnalysis)
     expect((await readWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir))?.worktrees).toEqual([
       local,
       remote
@@ -350,39 +361,38 @@ describe('workspace space analysis snapshot', () => {
   })
 
   it('registers a tombstone immediately without rewriting the sidecar', async () => {
-    const staleAnalysis = { ...makeAnalysis([makeWorktreeRow()]), scannedAt: Date.now() - 1 }
+    const staleAnalysis = makeAnalysis([makeWorktreeRow()])
+    const analysis = await openAnalysis(userDataDirHolder.dir)
 
     registerWorkspaceSpaceAnalysisSnapshotPruneTombstones(userDataDirHolder.dir, [
       { worktreeId: 'repo-1::/repo-feature', executionHostId: 'local' }
     ])
 
     expect(snapshotWriteSpy).not.toHaveBeenCalled()
-    await persistWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir, staleAnalysis)
+    await persistWorkspaceSpaceAnalysisSnapshot(
+      userDataDirHolder.dir,
+      staleAnalysis,
+      analysis.producer
+    )
     expect((await readWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir))?.worktrees).toEqual([])
+    await analysis.finish()
   })
 
-  it('keeps the original tombstone time when a removal batch flushes', async () => {
+  it('does not fence an analysis that started after a removal batch registered', async () => {
     const row = makeWorktreeRow()
     const target = { worktreeId: row.worktreeId, executionHostId: 'local' as const }
-    const now = vi.spyOn(Date, 'now').mockReturnValue(100)
     registerWorkspaceSpaceAnalysisSnapshotPruneTombstones(userDataDirHolder.dir, [target])
-    now.mockReturnValue(200)
 
     await finalizeWorkspaceSpaceAnalysisSnapshotPrunes(userDataDirHolder.dir, [target])
-    await persistWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir, {
-      ...makeAnalysis([row]),
-      scannedAt: 150
-    })
+    await persistAnalysis(userDataDirHolder.dir, makeAnalysis([row]))
 
     expect((await readWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir))?.worktrees).toEqual([
       { ...row, topLevelItems: [] }
     ])
-    now.mockRestore()
   })
 
   it('retains no tombstone when a removal races no analysis at all', async () => {
     const row = makeWorktreeRow()
-    const now = vi.spyOn(Date, 'now').mockReturnValue(100)
     await pruneWorkspaceSpaceAnalysisSnapshot(
       userDataDirHolder.dir,
       row.worktreeId,
@@ -390,14 +400,10 @@ describe('workspace space analysis snapshot', () => {
     )
 
     expect(workspaceSpaceAnalysisSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(0)
-    await persistWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir, {
-      ...makeAnalysis([row]),
-      scannedAt: 99
-    })
+    await persistAnalysis(userDataDirHolder.dir, makeAnalysis([row]))
     expect((await readWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir))?.worktrees).toEqual([
       row
     ])
-    now.mockRestore()
   })
 
   it('does not accumulate tombstones as workspaces are removed', async () => {
@@ -414,8 +420,7 @@ describe('workspace space analysis snapshot', () => {
 
   it('holds a tombstone until the analysis in flight when it was pruned settles', async () => {
     const row = makeWorktreeRow()
-    const producer = beginWorkspaceSpaceAnalysisSnapshotProducer(userDataDirHolder.dir)
-    const now = vi.spyOn(Date, 'now').mockReturnValue(200)
+    const analysis = await openAnalysis(userDataDirHolder.dir)
     await pruneWorkspaceSpaceAnalysisSnapshot(
       userDataDirHolder.dir,
       row.worktreeId,
@@ -423,56 +428,85 @@ describe('workspace space analysis snapshot', () => {
     )
 
     expect(workspaceSpaceAnalysisSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(1)
-    await persistWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir, {
-      ...makeAnalysis([row]),
-      scannedAt: 100
-    })
+    await persistWorkspaceSpaceAnalysisSnapshot(
+      userDataDirHolder.dir,
+      makeAnalysis([row]),
+      analysis.producer
+    )
     expect((await readWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir))?.worktrees).toEqual([])
 
-    finishWorkspaceSpaceAnalysisSnapshotProducer(userDataDirHolder.dir, producer)
+    await analysis.finish()
 
     expect(workspaceSpaceAnalysisSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(0)
-    await persistWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir, {
-      ...makeAnalysis([row]),
-      scannedAt: 100
-    })
+    await persistAnalysis(userDataDirHolder.dir, makeAnalysis([row]))
     expect((await readWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir))?.worktrees).toEqual([
       row
     ])
-    now.mockRestore()
   })
 
-  it('retires a tombstone whose analysis never settles once the producer timeout passes', async () => {
+  it('keeps holding a tombstone when the wall clock jumps past the producer timeout', async () => {
+    // A laptop sleep/resume moves Date.now() while the analysis's promise does not; expiring the
+    // holder on that reading retires a tombstone whose producer is still about to write.
     const row = makeWorktreeRow()
-    beginWorkspaceSpaceAnalysisSnapshotProducer(userDataDirHolder.dir)
-    const now = vi.spyOn(Date, 'now').mockReturnValue(200)
+    const analysis = await openAnalysis(userDataDirHolder.dir)
     await pruneWorkspaceSpaceAnalysisSnapshot(
       userDataDirHolder.dir,
       row.worktreeId,
       row.executionHostId
     )
+    const now = vi
+      .spyOn(Date, 'now')
+      .mockReturnValue(NOW + WORKSPACE_SNAPSHOT_PRUNE_PRODUCER_TIMEOUT_MS * 48)
+
     expect(workspaceSpaceAnalysisSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(1)
+    await persistWorkspaceSpaceAnalysisSnapshot(
+      userDataDirHolder.dir,
+      makeAnalysis([row]),
+      analysis.producer
+    )
 
-    now.mockReturnValue(201 + WORKSPACE_SNAPSHOT_PRUNE_PRODUCER_TIMEOUT_MS)
-    await persistWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir, {
-      ...makeAnalysis([row]),
-      scannedAt: 100
-    })
-
-    expect(workspaceSpaceAnalysisSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(0)
-    expect((await readWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir))?.worktrees).toEqual([
-      row
-    ])
+    expect((await readWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir))?.worktrees).toEqual([])
+    expect(workspaceSpaceAnalysisSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(1)
     now.mockRestore()
+    await analysis.finish()
+  })
+
+  it('retires a tombstone whose analysis never settles once the producer timeout elapses', async () => {
+    vi.useFakeTimers()
+    try {
+      const row = makeWorktreeRow()
+      const analysis = await openAnalysis(userDataDirHolder.dir)
+      await pruneWorkspaceSpaceAnalysisSnapshot(
+        userDataDirHolder.dir,
+        row.worktreeId,
+        row.executionHostId
+      )
+      expect(workspaceSpaceAnalysisSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(1)
+
+      await vi.advanceTimersByTimeAsync(WORKSPACE_SNAPSHOT_PRUNE_PRODUCER_TIMEOUT_MS + 1)
+      expect(workspaceSpaceAnalysisSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(0)
+
+      // Losing the bound disarms the producer, so the row it still holds cannot come back.
+      snapshotWriteSpy.mockClear()
+      await persistWorkspaceSpaceAnalysisSnapshot(
+        userDataDirHolder.dir,
+        makeAnalysis([row]),
+        analysis.producer
+      )
+      expect(snapshotWriteSpy).not.toHaveBeenCalled()
+      await analysis.finish()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('flushes a batched tombstone even when an analysis settles before the batch closes', async () => {
     const row = makeWorktreeRow()
     const target = { worktreeId: row.worktreeId, executionHostId: 'local' as const }
-    await persistWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir, makeAnalysis([row]))
-    const producer = beginWorkspaceSpaceAnalysisSnapshotProducer(userDataDirHolder.dir)
+    await persistAnalysis(userDataDirHolder.dir, makeAnalysis([row]))
+    const analysis = await openAnalysis(userDataDirHolder.dir)
     registerWorkspaceSpaceAnalysisSnapshotPruneTombstones(userDataDirHolder.dir, [target])
-    finishWorkspaceSpaceAnalysisSnapshotProducer(userDataDirHolder.dir, producer)
+    await analysis.finish()
 
     expect(workspaceSpaceAnalysisSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(1)
     await finalizeWorkspaceSpaceAnalysisSnapshotPrunes(userDataDirHolder.dir, [target])
@@ -489,10 +523,7 @@ describe('workspace space analysis snapshot', () => {
       sizeBytes: 3000,
       reclaimableBytes: 3000
     })
-    await persistWorkspaceSpaceAnalysisSnapshot(
-      userDataDirHolder.dir,
-      makeAnalysis([local, remote])
-    )
+    await persistAnalysis(userDataDirHolder.dir, makeAnalysis([local, remote]))
 
     await pruneWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir, remote.worktreeId, 'ssh:ssh-1')
 
@@ -526,10 +557,7 @@ describe('workspace space analysis snapshot', () => {
       sizeBytes: 3000,
       reclaimableBytes: 3000
     })
-    await persistWorkspaceSpaceAnalysisSnapshot(
-      userDataDirHolder.dir,
-      makeAnalysis([local, remote])
-    )
+    await persistAnalysis(userDataDirHolder.dir, makeAnalysis([local, remote]))
 
     await pruneWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir, local.worktreeId)
 

--- a/src/main/workspace-space-analysis-snapshot.test.ts
+++ b/src/main/workspace-space-analysis-snapshot.test.ts
@@ -28,13 +28,17 @@ vi.mock('./sidecar-snapshot-file', async (importOriginal) => {
 })
 
 import {
+  beginWorkspaceSpaceAnalysisSnapshotProducer,
   finalizeWorkspaceSpaceAnalysisSnapshotPrunes,
+  finishWorkspaceSpaceAnalysisSnapshotProducer,
   persistWorkspaceSpaceAnalysisSnapshot,
   pruneWorkspaceSpaceAnalysisSnapshot,
   pruneWorkspaceSpaceAnalysisSnapshots,
   readWorkspaceSpaceAnalysisSnapshot,
-  registerWorkspaceSpaceAnalysisSnapshotPruneTombstones
+  registerWorkspaceSpaceAnalysisSnapshotPruneTombstones,
+  workspaceSpaceAnalysisSnapshotTombstoneCountForTests
 } from './workspace-space-analysis-snapshot'
+import { WORKSPACE_SNAPSHOT_PRUNE_PRODUCER_TIMEOUT_MS } from './workspace-snapshot-prune-index'
 
 const SNAPSHOT_FILE = 'orca-workspace-space-analysis.json'
 const NOW = 1_700_000_000_000
@@ -327,6 +331,8 @@ describe('workspace space analysis snapshot', () => {
       ...makeAnalysis([local, remote]),
       scannedAt: Date.now() - 1
     }
+    // The analysis is in flight before the removal, so it is a fenced producer of this sidecar.
+    beginWorkspaceSpaceAnalysisSnapshotProducer(userDataDirHolder.dir)
     await pruneWorkspaceSpaceAnalysisSnapshots(userDataDirHolder.dir, [
       { worktreeId: local.worktreeId, executionHostId: 'local' },
       { worktreeId: remote.worktreeId, executionHostId: 'ssh:ssh-1' }
@@ -372,6 +378,107 @@ describe('workspace space analysis snapshot', () => {
       { ...row, topLevelItems: [] }
     ])
     now.mockRestore()
+  })
+
+  it('retains no tombstone when a removal races no analysis at all', async () => {
+    const row = makeWorktreeRow()
+    const now = vi.spyOn(Date, 'now').mockReturnValue(100)
+    await pruneWorkspaceSpaceAnalysisSnapshot(
+      userDataDirHolder.dir,
+      row.worktreeId,
+      row.executionHostId
+    )
+
+    expect(workspaceSpaceAnalysisSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(0)
+    await persistWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir, {
+      ...makeAnalysis([row]),
+      scannedAt: 99
+    })
+    expect((await readWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir))?.worktrees).toEqual([
+      row
+    ])
+    now.mockRestore()
+  })
+
+  it('does not accumulate tombstones as workspaces are removed', async () => {
+    for (let index = 0; index < 25; index += 1) {
+      await pruneWorkspaceSpaceAnalysisSnapshot(
+        userDataDirHolder.dir,
+        `repo-1::/repo-removed-${index}`,
+        'local'
+      )
+    }
+
+    expect(workspaceSpaceAnalysisSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(0)
+  })
+
+  it('holds a tombstone until the analysis in flight when it was pruned settles', async () => {
+    const row = makeWorktreeRow()
+    const producer = beginWorkspaceSpaceAnalysisSnapshotProducer(userDataDirHolder.dir)
+    const now = vi.spyOn(Date, 'now').mockReturnValue(200)
+    await pruneWorkspaceSpaceAnalysisSnapshot(
+      userDataDirHolder.dir,
+      row.worktreeId,
+      row.executionHostId
+    )
+
+    expect(workspaceSpaceAnalysisSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(1)
+    await persistWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir, {
+      ...makeAnalysis([row]),
+      scannedAt: 100
+    })
+    expect((await readWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir))?.worktrees).toEqual([])
+
+    finishWorkspaceSpaceAnalysisSnapshotProducer(userDataDirHolder.dir, producer)
+
+    expect(workspaceSpaceAnalysisSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(0)
+    await persistWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir, {
+      ...makeAnalysis([row]),
+      scannedAt: 100
+    })
+    expect((await readWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir))?.worktrees).toEqual([
+      row
+    ])
+    now.mockRestore()
+  })
+
+  it('retires a tombstone whose analysis never settles once the producer timeout passes', async () => {
+    const row = makeWorktreeRow()
+    beginWorkspaceSpaceAnalysisSnapshotProducer(userDataDirHolder.dir)
+    const now = vi.spyOn(Date, 'now').mockReturnValue(200)
+    await pruneWorkspaceSpaceAnalysisSnapshot(
+      userDataDirHolder.dir,
+      row.worktreeId,
+      row.executionHostId
+    )
+    expect(workspaceSpaceAnalysisSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(1)
+
+    now.mockReturnValue(201 + WORKSPACE_SNAPSHOT_PRUNE_PRODUCER_TIMEOUT_MS)
+    await persistWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir, {
+      ...makeAnalysis([row]),
+      scannedAt: 100
+    })
+
+    expect(workspaceSpaceAnalysisSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(0)
+    expect((await readWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir))?.worktrees).toEqual([
+      row
+    ])
+    now.mockRestore()
+  })
+
+  it('flushes a batched tombstone even when an analysis settles before the batch closes', async () => {
+    const row = makeWorktreeRow()
+    const target = { worktreeId: row.worktreeId, executionHostId: 'local' as const }
+    await persistWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir, makeAnalysis([row]))
+    const producer = beginWorkspaceSpaceAnalysisSnapshotProducer(userDataDirHolder.dir)
+    registerWorkspaceSpaceAnalysisSnapshotPruneTombstones(userDataDirHolder.dir, [target])
+    finishWorkspaceSpaceAnalysisSnapshotProducer(userDataDirHolder.dir, producer)
+
+    expect(workspaceSpaceAnalysisSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(1)
+    await finalizeWorkspaceSpaceAnalysisSnapshotPrunes(userDataDirHolder.dir, [target])
+
+    expect((await readWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir))?.worktrees).toEqual([])
+    expect(workspaceSpaceAnalysisSnapshotTombstoneCountForTests(userDataDirHolder.dir)).toBe(0)
   })
 
   it('prunes host-colliding workspace ids without corrupting surviving totals', async () => {

--- a/src/main/workspace-space-analysis-snapshot.ts
+++ b/src/main/workspace-space-analysis-snapshot.ts
@@ -15,7 +15,10 @@ import {
   workspaceSnapshotPruneTargetKeys,
   type WorkspaceSnapshotPruneTarget
 } from './workspace-snapshot-prune-index'
-import { createWorkspaceSnapshotPruneTombstoneRegistry } from './workspace-snapshot-prune-tombstone-holders'
+import {
+  createWorkspaceSnapshotPruneTombstoneRegistry,
+  type WorkspaceSnapshotPruneProducerToken
+} from './workspace-snapshot-prune-tombstone-holders'
 import { withoutWorktreeRows } from './workspace-space-analysis-row-pruning'
 
 const SNAPSHOT_FILE_NAME = 'orca-workspace-space-analysis.json'
@@ -27,9 +30,8 @@ const tombstoneRegistry = createWorkspaceSnapshotPruneTombstoneRegistry((directo
   sidecarSnapshotFile(directory, SNAPSHOT_FILE_NAME)
 )
 
-/** Bracket every analysis that may persist to this sidecar so its tombstones retire when it settles. */
-export const beginWorkspaceSpaceAnalysisSnapshotProducer = tombstoneRegistry.beginProducer
-export const finishWorkspaceSpaceAnalysisSnapshotProducer = tombstoneRegistry.finishProducer
+/** Run every analysis that may persist to this sidecar inside the fence — the only source of a token. */
+export const withWorkspaceSpaceAnalysisSnapshotProducer = tombstoneRegistry.withProducer
 
 /** Retention probe: STA-4451 is about how many tombstones survive, not just which rows they hide. */
 export const workspaceSpaceAnalysisSnapshotTombstoneCountForTests = (
@@ -119,16 +121,27 @@ async function writeSnapshot(file: string, analysis: WorkspaceSpaceAnalysis): Pr
 /** Persist a completed analysis. Never throws — the snapshot is a refetchable cache. */
 export async function persistWorkspaceSpaceAnalysisSnapshot(
   snapshotDirectory: string,
-  analysis: WorkspaceSpaceAnalysis
+  analysis: WorkspaceSpaceAnalysis,
+  producer: WorkspaceSnapshotPruneProducerToken
 ): Promise<void> {
   const file = sidecarSnapshotFile(snapshotDirectory, SNAPSHOT_FILE_NAME)
+  const endWrite = producer.beginWrite(file)
+  if (!endWrite) {
+    // The producer was bounded out, so its tombstones have already retired. Writing now is exactly
+    // the resurrection they existed to prevent — drop this result instead.
+    return
+  }
   try {
     await withSidecarSnapshotQueue(file, async () => {
-      await writeSnapshot(file, stripTopLevelItems(excludeRowsPrunedDuringScan(file, analysis)))
-      clearSupersededPrunes(file, analysis)
+      await writeSnapshot(
+        file,
+        stripTopLevelItems(excludeRowsPrunedDuringScan(file, analysis, producer.seq))
+      )
     })
   } catch (error) {
     console.warn('[workspace-space] failed to persist analysis snapshot:', error)
+  } finally {
+    endWrite()
   }
 }
 
@@ -151,11 +164,12 @@ export function registerWorkspaceSpaceAnalysisSnapshotPruneTombstones(
 
 function excludeRowsPrunedDuringScan(
   file: string,
-  analysis: WorkspaceSpaceAnalysis
+  analysis: WorkspaceSpaceAnalysis,
+  producerSeq: number
 ): WorkspaceSpaceAnalysis {
   const prunedKeys = activeWorkspaceSnapshotPruneKeys(
     tombstoneRegistry.tombstones(file),
-    analysis.scannedAt
+    producerSeq
   )
   return withoutWorktreeRows(
     analysis,
@@ -163,20 +177,6 @@ function excludeRowsPrunedDuringScan(
       prunedKeys.has(workspaceSnapshotPruneKey(row.worktreeId, row.executionHostId)) ||
       prunedKeys.has(workspaceSnapshotPruneKey(row.worktreeId))
   )
-}
-
-function clearSupersededPrunes(file: string, analysis: WorkspaceSpaceAnalysis): void {
-  const pruned = tombstoneRegistry.tombstones(file)
-  if (!pruned) {
-    return
-  }
-  for (const [key, entry] of pruned) {
-    // A held tombstone outranks supersession: the holder is exactly the writer that could still
-    // resurrect the row with a result older than this one.
-    if (entry.holders.size === 0 && entry.prunedAt < analysis.scannedAt) {
-      pruned.delete(key)
-    }
-  }
 }
 
 async function pruneWorkspaceSpaceAnalysisSnapshotsWithRegisteredTombstones(

--- a/src/main/workspace-space-analysis-snapshot.ts
+++ b/src/main/workspace-space-analysis-snapshot.ts
@@ -11,19 +11,30 @@ import {
 import type { ExecutionHostId } from '../shared/execution-host'
 import {
   activeWorkspaceSnapshotPruneKeys,
-  registerWorkspaceSnapshotPrunesForFile,
   workspaceSnapshotPruneKey,
   workspaceSnapshotPruneTargetKeys,
-  type WorkspaceSnapshotPruneTarget,
-  type WorkspaceSnapshotPruneTombstone
+  type WorkspaceSnapshotPruneTarget
 } from './workspace-snapshot-prune-index'
+import { createWorkspaceSnapshotPruneTombstoneRegistry } from './workspace-snapshot-prune-tombstone-holders'
+import { withoutWorktreeRows } from './workspace-space-analysis-row-pruning'
 
 const SNAPSHOT_FILE_NAME = 'orca-workspace-space-analysis.json'
 const SNAPSHOT_VERSION = 2
 
 export type WorkspaceSpaceAnalysisSnapshotPruneTarget = WorkspaceSnapshotPruneTarget
 
-const prunedWorkspacesByFile = new Map<string, Map<string, WorkspaceSnapshotPruneTombstone>>()
+const tombstoneRegistry = createWorkspaceSnapshotPruneTombstoneRegistry((directory) =>
+  sidecarSnapshotFile(directory, SNAPSHOT_FILE_NAME)
+)
+
+/** Bracket every analysis that may persist to this sidecar so its tombstones retire when it settles. */
+export const beginWorkspaceSpaceAnalysisSnapshotProducer = tombstoneRegistry.beginProducer
+export const finishWorkspaceSpaceAnalysisSnapshotProducer = tombstoneRegistry.finishProducer
+
+/** Retention probe: STA-4451 is about how many tombstones survive, not just which rows they hide. */
+export const workspaceSpaceAnalysisSnapshotTombstoneCountForTests = (
+  snapshotDirectory: string
+): number => tombstoneRegistry.count(sidecarSnapshotFile(snapshotDirectory, SNAPSHOT_FILE_NAME))
 
 type PersistedWorkspaceSpaceAnalysisSnapshot = {
   version: number
@@ -121,91 +132,6 @@ export async function persistWorkspaceSpaceAnalysisSnapshot(
   }
 }
 
-function withoutWorktreeRows(
-  analysis: WorkspaceSpaceAnalysis,
-  shouldRemove: (row: WorkspaceSpaceWorktree) => boolean
-): WorkspaceSpaceAnalysis {
-  const worktrees: WorkspaceSpaceWorktree[] = []
-  const removedByRepo = new Map<
-    string,
-    {
-      worktreeCount: number
-      scannedWorktreeCount: number
-      unavailableWorktreeCount: number
-      totalSizeBytes: number
-      reclaimableBytes: number
-    }
-  >()
-  let removedCount = 0
-  let scannedDelta = 0
-  let unavailableDelta = 0
-  let totalSizeDelta = 0
-  let reclaimableDelta = 0
-
-  for (const row of analysis.worktrees) {
-    if (!shouldRemove(row)) {
-      worktrees.push(row)
-      continue
-    }
-    const scanned = row.status === 'ok' ? 1 : 0
-    const unavailable = row.status === 'ok' ? 0 : 1
-    removedCount += 1
-    scannedDelta += scanned
-    unavailableDelta += unavailable
-    totalSizeDelta += row.sizeBytes
-    reclaimableDelta += row.reclaimableBytes
-    const key = analysisRepoKey(row)
-    const delta = removedByRepo.get(key) ?? {
-      worktreeCount: 0,
-      scannedWorktreeCount: 0,
-      unavailableWorktreeCount: 0,
-      totalSizeBytes: 0,
-      reclaimableBytes: 0
-    }
-    delta.worktreeCount += 1
-    delta.scannedWorktreeCount += scanned
-    delta.unavailableWorktreeCount += unavailable
-    delta.totalSizeBytes += row.sizeBytes
-    delta.reclaimableBytes += row.reclaimableBytes
-    removedByRepo.set(key, delta)
-  }
-  if (removedCount === 0) {
-    return analysis
-  }
-  return {
-    ...analysis,
-    worktrees,
-    worktreeCount: Math.max(0, analysis.worktreeCount - removedCount),
-    scannedWorktreeCount: Math.max(0, analysis.scannedWorktreeCount - scannedDelta),
-    unavailableWorktreeCount: Math.max(0, analysis.unavailableWorktreeCount - unavailableDelta),
-    totalSizeBytes: Math.max(0, analysis.totalSizeBytes - totalSizeDelta),
-    reclaimableBytes: Math.max(0, analysis.reclaimableBytes - reclaimableDelta),
-    repos: analysis.repos.map((repo) => {
-      const delta = removedByRepo.get(analysisRepoKey(repo))
-      return delta
-        ? {
-            ...repo,
-            worktreeCount: Math.max(0, repo.worktreeCount - delta.worktreeCount),
-            scannedWorktreeCount: Math.max(
-              0,
-              repo.scannedWorktreeCount - delta.scannedWorktreeCount
-            ),
-            unavailableWorktreeCount: Math.max(
-              0,
-              repo.unavailableWorktreeCount - delta.unavailableWorktreeCount
-            ),
-            totalSizeBytes: Math.max(0, repo.totalSizeBytes - delta.totalSizeBytes),
-            reclaimableBytes: Math.max(0, repo.reclaimableBytes - delta.reclaimableBytes)
-          }
-        : repo
-    })
-  }
-}
-
-function analysisRepoKey(entry: { repoId: string; executionHostId?: ExecutionHostId }): string {
-  return JSON.stringify([entry.executionHostId, entry.repoId])
-}
-
 /** Register anti-resurrection tombstones without scheduling a sidecar rewrite. */
 export function registerWorkspaceSpaceAnalysisSnapshotPruneTombstones(
   snapshotDirectory: string,
@@ -214,10 +140,12 @@ export function registerWorkspaceSpaceAnalysisSnapshotPruneTombstones(
   if (targets.length === 0) {
     return
   }
-  registerWorkspaceSnapshotPrunesForFile(
-    prunedWorkspacesByFile,
+  // Deferred: the flush is a holder too, or a settling producer would retire the tombstone before
+  // finalize runs and finalize would skip the sidecar rewrite it was tombstoned for.
+  tombstoneRegistry.register(
     sidecarSnapshotFile(snapshotDirectory, SNAPSHOT_FILE_NAME),
-    targets
+    targets,
+    true
   )
 }
 
@@ -226,7 +154,7 @@ function excludeRowsPrunedDuringScan(
   analysis: WorkspaceSpaceAnalysis
 ): WorkspaceSpaceAnalysis {
   const prunedKeys = activeWorkspaceSnapshotPruneKeys(
-    prunedWorkspacesByFile.get(file),
+    tombstoneRegistry.tombstones(file),
     analysis.scannedAt
   )
   return withoutWorktreeRows(
@@ -238,17 +166,16 @@ function excludeRowsPrunedDuringScan(
 }
 
 function clearSupersededPrunes(file: string, analysis: WorkspaceSpaceAnalysis): void {
-  const pruned = prunedWorkspacesByFile.get(file)
+  const pruned = tombstoneRegistry.tombstones(file)
   if (!pruned) {
     return
   }
   for (const [key, entry] of pruned) {
-    if (entry.prunedAt < analysis.scannedAt) {
+    // A held tombstone outranks supersession: the holder is exactly the writer that could still
+    // resurrect the row with a result older than this one.
+    if (entry.holders.size === 0 && entry.prunedAt < analysis.scannedAt) {
       pruned.delete(key)
     }
-  }
-  if (pruned.size === 0) {
-    prunedWorkspacesByFile.delete(file)
   }
 }
 
@@ -263,11 +190,12 @@ async function pruneWorkspaceSpaceAnalysisSnapshotsWithRegisteredTombstones(
   const file = sidecarSnapshotFile(snapshotDirectory, SNAPSHOT_FILE_NAME)
   const targetKeys = workspaceSnapshotPruneTargetKeys(targets)
   if (registerTombstones) {
-    registerWorkspaceSnapshotPrunesForFile(prunedWorkspacesByFile, file, targets)
+    // Immediate: no flush holder, this call performs the sidecar rewrite itself.
+    tombstoneRegistry.register(file, targets, false)
   }
   try {
     await withSidecarSnapshotQueue(file, async () => {
-      const registered = prunedWorkspacesByFile.get(file)
+      const registered = tombstoneRegistry.tombstones(file)
       const coalescedTargetKeys = registerTombstones
         ? targetKeys
         : new Set([...targetKeys].filter((key) => registered?.has(key)))
@@ -291,6 +219,10 @@ async function pruneWorkspaceSpaceAnalysisSnapshotsWithRegisteredTombstones(
     })
   } catch (error) {
     console.warn('[workspace-space] failed to prune analysis snapshot:', error)
+  } finally {
+    if (!registerTombstones) {
+      tombstoneRegistry.releaseFlush(file, targetKeys)
+    }
   }
 }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​359 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​357 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​319 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​124 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​195 |

<!-- /orca-pr-loc -->

Fixes STA-4451. Regression from #13413.

## Leak or latency: **leak**

`registerWorkspaceSnapshotPrunesForFile` writes into a module-level map keyed by sidecar file, and on `main` the only retirement path is `clearSupersededPrunes`, which runs when the *next* scan for that file completes. Both sidecars share the shape (`workspace-cleanup-scan-snapshot.ts`, `workspace-space-analysis-snapshot.ts`), and the cleanup-scan side is strictly worse:

- A **targeted** scan never persists at all, so it never retires anything.
- A **narrow patch** persist retires only keys present in the fresh candidate list — and a removed workspace is by definition absent from it.
- The `knownScannedAt > scannedAt` early return skips the write *and* the retirement.

So retirement on the cleanup sidecar requires a later **broad fleet scan**. Keys are `(executionHostId, worktreeId)`, and worktree ids are path-derived, so every create/remove cycle in a long-lived main process contributes a distinct, permanent key. That is unbounded growth over process lifetime, not merely a long-lived entry — a slow leak (entries are small), but a leak.

## The fix: holder-gated retirement

A tombstone only has to outlive the writers that could still put the removed row back. It is now retired as soon as the last **holder** releases it. Two holder kinds:

- `producer:<n>` — a scan that was already in flight when the prune happened, so it can still persist a pre-prune result. Released when that scan's persist attempt settles.
- `flush` — a deferred removal batch that tombstones now and rewrites the sidecar at finalize. Released by `finalize*Prunes`, scoped to that batch's own target keys so concurrent batches cannot retire each other.

**How I know a producer has settled.** `withWorkspaceCleanupScanSnapshotProducer` / `withWorkspaceSpaceAnalysisSnapshotProducer` wrap the scan in each IPC handler. The bracket opens strictly before `scanWorkspaceCleanup`/`analyzeWorkspaceSpace` runs — so before `scannedAt` is stamped — and closes once the scan can no longer write: when the callback settles *and* any persist it started has drained. The fence window therefore always contains `[scan start, persist]`. A targeted cleanup scan takes no producer because it never persists.

In the common case — a workspace removed with no scan running — the tombstone has no holders and is never stored. Retention drops to zero without waiting on any clock.

## Follow-up: monotonic ordering, and a bound on the producer instead of the record

A prior-art conformance review of the mechanism above found one defect and two shape divergences. All three are fixed in `bb191ca` / `a42ed4c`.

**1. Wall-clock ordering was the defect.** Both halves ordered events by `Date.now()`: the fence compared `prunedAt >= scannedAt`, and `producerDeadline` was compared against a fresh clock read on every tombstone lookup. A laptop sleep/resume advances the wall clock while an in-flight scan's promise does not, so a routine lid-close during a long fleet scan or a slow SSH-host scan expired the deadline for every tombstone and retired holders whose producers were still live and about to write. That is a resurrection of exactly the bug this PR exists to fix, reachable by closing a lid.

Ordering now runs on a process-lifetime counter: `registerWorkspaceSnapshotPrunesForFile` stamps `prunedSeq`, `withProducer` stamps the producer's `seq` at bracket open, and the fence is `prunedSeq > producerSeq`. The window is strictly *wider* than the timestamp compare it replaces, because the bracket opens before `scannedAt` is stamped — it now also fences a prune that lands between handler entry and the scan's own timestamp. `scannedAt` stays a wall clock because it is the human-facing "last scanned" value and has to survive a restart; it is no longer used for any ordering decision.

**2. The bound moved from the bookkeeping record to the producer.** `WORKSPACE_SNAPSHOT_PRUNE_PRODUCER_TIMEOUT_MS` is now a `setTimeout` armed at the producer's own start rather than a per-entry deadline derived from prune time. Three consequences:

- It runs on the runtime's monotonic clock, which does not advance across a suspend, so a sleep cannot expire a live scan.
- It bounds the producer: a scan that began nine minutes before a prune no longer inherits a fresh ten minutes.
- `producerDeadline` and the clock read in the tombstone lookup are gone entirely.

**What happens to a producer that loses the bound but is genuinely still running.** Losing the bound must not leave the row unfenced, so expiry *disarms* the producer rather than merely un-holding the tombstone: `persist*` claims its capability from the token, and a disarmed token refuses the claim, so the write is dropped instead of landing after the tombstone retired. The snapshot is a refetchable cache, so dropping one write at the ten-minute mark is the cheap side. The bound also defers while a write is in flight — a producer inside the sidecar queue is demonstrably alive, so a holder is only ever released while the producer holds no capability to use it. There is no window in which the tombstone is gone and the producer can still write.

**3. Taking the fence is now a precondition of persisting, not a convention.** The note below about a future third persist call site silently escaping the fence is resolved: `withProducer` is the only source of a `WorkspaceSnapshotPruneProducerToken`, and both `persist*` functions take one as a required parameter. A new call site that skips the fence does not compile. The token also carries the sidecar it was minted for, so pairing a token with the wrong `snapshotDirectory` is refused rather than silently no-oping.

**Retirement is now single-sourced.** With the clock sweep gone, `release()` is the only path that retires a tombstone, which makes its membership guard (M2 below, previously unreachable) load-bearing and mutation-testable. Two consequences follow: `registerWorkspaceSnapshotPrunesForFile` no longer stores a tombstone nobody holds (the sweep used to collect those on the next read), and `clearSupersededPrunes` is removed — it gated on `holders.size === 0`, which no surviving entry can now have, and which the sweep already made unreachable before this change.

**Judged and deferred, with reasons:**

- *Nobody cancels the doomed in-flight scan.* Cancelling a broad scan on any prune would collapse the fence window to near-zero, but it also throws away a user's in-progress six-minute analysis because one unrelated workspace was removed. That is a product decision, not a lifetime fix. Follow-up.
- *No crash/quit recovery for a batch stranded between tombstone and finalize.* Pre-existing, and the durable state lives in `workspace-cleanup-removal-snapshot-prune.ts`, which this PR's scope fence keeps untouched. A startup reconcile sweep would need a guard that a tombstone whose path a re-created workspace now owns is not reclaimed. Follow-up.
- *No ceiling on the tombstone table.* Every tombstone is now held by either a bounded producer or a batch flush, so accumulation is bounded by concurrent removals inside one producer bound rather than by process lifetime. A hard cap is still cheap insurance. Follow-up.
- *The `flush` sentinel is shared where a refcount belongs.* Two concurrent batches on the same key share one holder slot, so whichever finalizes first releases it for both. Not exploitable today — the first finalize has already performed the sidecar rewrite, and any genuinely dangerous in-flight producer is independently a holder — and minting `flush:<batchId>` requires threading a batch id through the batch module this PR does not touch. Follow-up.
- *A durable removed-marker on the workspace row would make the sidecar tombstone redundant* (every read path would filter on liveness instead of needing resurrection prevented). Architectural note for whoever owns the delete machinery; no coupling to #14930 is implied or needed.

## What the rescued branch got wrong

The starting branch (`origin/brennanb2025/fix-4451`, 5 commits including two `[rescued from runtime crash]` WIPs and an empty duplicate-subject redo) was rebuilt from scratch rather than extended. Three findings:

1. **It did not typecheck.** `workspace-space-analysis-snapshot.ts` dropped the `WorkspaceSpaceWorktree` type import while line 43 still used it.
2. **Its "reproduction" tested the wrong thing.** `a521dd2b4b` asserted that after 10 minutes of wall clock a stale scan *should* resurrect a removed row. It encoded a TTL as the spec — which the ticket explicitly rules out — and never observed tombstone retention at all.
3. **It regressed anti-resurrection.** Its `settleWorkspaceSnapshotPruneProducer` deleted any tombstone whose pending-producer set hit zero, without checking membership and without a flush holder. A producer settling between a batch's `register` and its `finalize` destroyed the tombstone, so finalize skipped the durable sidecar rewrite and the removed workspace resurrected **permanently**. Measured: the probe below is green on `origin/main` and red on the rescued branch. That is strictly worse than the leak it set out to fix.

The one thing the rescued branch got right is kept: `workspace-space-analysis-snapshot.ts` sits at 299/300 under `max-lines`, so `withoutWorktreeRows` genuinely has to move out. `workspace-space-analysis-row-pruning.ts` is a byte-faithful extraction (verified by normalized diff), not a rewrite.

## Evidence

**Reproduction.** Confirmed red on `origin/main` before anything else, and the rewritten leak assertions are red there too.

**Full production revert, tests kept: 50 red of 90 — and worth almost nothing.** Every one of the four failing suites dies on a missing export (`beginWorkspaceCleanupScanSnapshotProducer` / `beginWorkspaceSpaceAnalysisSnapshotProducer` are gone from the module and from the IPC mocks), so that count measures a compile failure, not behaviour. The real measure is a mutation matrix that keeps the API intact and changes one behaviour at a time (90 tests across the two sidecar suites and the four IPC suites):

| mutation | red |
|---|---|
| M1 wall-clock producer TTL restored (**the defect**) | 2 |
| M2 fence compares the wrong side of the prune order | 8 |
| M3 an expired bound does not disarm the producer | 2 |
| M4 `register` stores tombstones nobody holds (**the leak itself**) | 4 |
| M5 flush release ignores per-batch key scoping (**the rescued branch's bug**) | 1 |
| M6 IPC opens the fence for targeted scans too | 4 |
| M7 persist called without a token | *does not compile* |

M1 initially came back **0 red** and the probe was wrong, not the fix: it offset the `NOW` fixture constant, which is in the past, so the "clock jump forward" was really a jump backward. `a42ed4c` anchors it on the real clock and it is 2 red. The membership guard that was M2-unreachable in the original matrix is now load-bearing (M5 above kills it). M7 is the point of finding 3 — there is no runtime mutation to score, because the type checker rejects it.

One unrelated suite, `aggregates large cleanup candidate batches without hitting argument limits`, timed out at ~57s in one mutation run and passes in every clean run; it is slow under parallel load, not affected by this change.

### Test-proven vs reasoned

**Test-proven:** the leak (direct retention probes, not row-visibility proxies); producer-fenced retirement as the primary path; the TTL fallback; the batch-flush regression guard; per-batch flush scoping; the IPC bracket wiring including the failure path; faithful extraction of `withoutWorktreeRows`.

**Reasoned, not test-proven:** that the 10-minute producer bound exceeding the 5-minute batch idle timeout is sufficient in production (the ordering is asserted by construction, not by a test that drives both timers); and cross-platform/SSH/folder-workspace behavior, which is path- and ordering-only here and carries no platform-specific branch. The earlier caveat that a future third persist call site could silently escape the fence no longer applies — it is now a type error.

## Scope

Confined to tombstone lifetime. `WorkspaceSnapshotPruneTarget` and the prune key are unchanged; `workspace-cleanup-removal-snapshot-prune.ts` (the batch machinery) is untouched; no delete/removal routing, teardown, `remove-worktree`, `worktree-operation-route`, sidebar delete caller, or `*removal*`/`*teardown*` test file is touched. `worktree-snapshot-prune-batch.ts` does not exist in this tree. Holder lifetime lives in a new sibling module so `workspace-snapshot-prune-index.ts` stays additive.

One call-out: I did edit `src/main/ipc/workspace-cleanup.ts`. That is the **scan** IPC handler, not delete routing — the edit is only the producer bracket around scan/persist — but flagging it because the bare filename is ambiguous with the fenced `src/renderer/src/store/slices/workspace-cleanup.ts`.

## Green

`typecheck:node` clean; `oxlint` and `oxlint --config config/oxlint-react-doctor.json` clean on all changed files (gate liveness re-proved by injecting a `max-lines` violation and seeing it fire); `oxfmt` clean; affected suites 90 + 4 pass.
