### PR TITLE
fix(native-chat): enforce each pending send's own boundary in glue matching (STA-4477)

### DIFF
--- a/config/scripts/native-chat-live-session-benchmark.ts
+++ b/config/scripts/native-chat-live-session-benchmark.ts
@@ -15,8 +15,9 @@ import { surfaceSkillInvocationUserTurns } from '../../src/shared/native-chat-co
 import { prepareNativeChatLiveMessages } from '../../src/renderer/src/components/native-chat/native-chat-live-message-preparation'
 import { mergeNativeChatLiveSession } from '../../src/renderer/src/components/native-chat/native-chat-live-status'
 import {
-  matchingNativeChatUserTexts,
-  selectPendingIndicesRepresentedByUserTexts
+  matchingNativeChatUserRows,
+  selectPendingIndicesRepresentedByUserRows,
+  type NativeChatUserRow
 } from '../../src/renderer/src/components/native-chat/native-chat-pending-occurrence'
 import { pendingSendsAsMessages } from '../../src/renderer/src/components/native-chat/native-chat-pending'
 import { assembleNativeChatSession } from '../../src/renderer/src/components/native-chat/native-chat-session-assembler'
@@ -36,6 +37,7 @@ let sessionSink: NativeChatSession | null = null
 let messageArraySink: NativeChatMessage[] | null = null
 let contentSink = ''
 let pendingMatchSink: Set<number> | null = null
+let userRowSink: readonly NativeChatUserRow[] | null = null
 const benchmarkStartedAt = performance.now()
 
 function proseFixture(count: number, bytes: number, withTurnId: boolean): NativeChatMessage[] {
@@ -94,10 +96,10 @@ function directMessageUpdateSession(messages: NativeChatMessage[]): NativeChatSe
 }
 
 function oldEmptyPending(messages: NativeChatMessage[]): NativeChatMessage[] {
-  pendingMatchSink = selectPendingIndicesRepresentedByUserTexts(
-    [],
-    matchingNativeChatUserTexts(messages)
-  )
+  // An empty queue makes the renderer skip candidate-row construction entirely, so the
+  // row scan is the whole cost here — keep it escaping and let the matcher take its exit.
+  userRowSink = matchingNativeChatUserRows(messages)
+  pendingMatchSink = selectPendingIndicesRepresentedByUserRows([], [])
   return []
 }
 
@@ -328,6 +330,7 @@ strictEqual(sessionSink?.sessionId, 'benchmark', 'session outputs did not escape
 strictEqual(Array.isArray(messageArraySink), true, 'message arrays did not escape')
 strictEqual(contentSink.length > 0, true, 'message content did not escape')
 strictEqual(pendingMatchSink instanceof Set, true, 'pending baseline scan did not escape')
+strictEqual(Array.isArray(userRowSink), true, 'user row scan did not escape')
 console.log(
   `validated=${validatedCases} cases, checksum=${checksum}, capped calibrations=${cappedCalibrations}, runtime=${(
     performance.now() - benchmarkStartedAt

--- a/src/renderer/src/components/native-chat/NativeChatInteractiveCard.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatInteractiveCard.test.tsx
@@ -5,7 +5,7 @@ import '@testing-library/jest-dom/vitest'
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { NativeChatMessage } from '../../../../shared/native-chat-types'
-import { applyCommandMarkerBoundaries } from './native-chat-pending'
+import { applyCommandMarkerBoundaries } from './native-chat-command-marker'
 import type { NativeChatInteractiveSend } from './use-native-chat-interactive-send'
 
 const INITIAL_PROMPT = JSON.stringify({

--- a/src/renderer/src/components/native-chat/NativeChatView.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatView.tsx
@@ -18,21 +18,23 @@ import {
   shouldShowNativeChatWorking
 } from './native-chat-working-suppression'
 import {
-  applyCommandMarkerBoundaries,
   appendPendingSendCache,
-  commandMarkersAsMessages,
-  appendCommandMarkerCache,
   launchPromptAsMessage,
   pendingSendsAsMessages,
   nextNativeChatPendingSendId,
   prunePendingSends,
-  readCommandMarkerCache,
   readPendingSendCache,
   shouldPruneLaunchPrompt,
   writePendingSendCache,
-  type NativeChatCommandMarker,
   type NativeChatPendingSend
 } from './native-chat-pending'
+import {
+  appendCommandMarkerCache,
+  applyCommandMarkerBoundaries,
+  commandMarkersAsMessages,
+  readCommandMarkerCache,
+  type NativeChatCommandMarker
+} from './native-chat-command-marker'
 import {
   deriveNativeChatStreamingText,
   nativeChatStreamingMessage

--- a/src/renderer/src/components/native-chat/native-chat-command-marker.ts
+++ b/src/renderer/src/components/native-chat/native-chat-command-marker.ts
@@ -1,0 +1,111 @@
+// Locally-recorded slash commands (e.g. `/clear`). They dispatch into the
+// agent's TUI rather than the conversation, so native chat renders its own
+// marker line and applies their transcript boundaries — kept out of the
+// optimistic-send pruning in native-chat-pending.ts, which is a separate rule.
+
+import type { NativeChatMessage } from '../../../../shared/native-chat-types'
+import { setBoundedScopeCacheEntry } from './native-chat-composer-scope-cache'
+
+/** A locally-recorded slash command (e.g. `/clear`). Slash commands dispatch to
+ *  the agent's TUI and are not chat turns, so we surface a small system line as
+ *  feedback that the command ran rather than echoing a user bubble. */
+export type NativeChatCommandMarker = {
+  id: string
+  /** The command as typed, e.g. `/clear`. */
+  command: string
+  sentAt: number
+}
+
+export type NativeChatCommandMarkerScope = {
+  paneKey: string
+  agent: string
+  sessionId: string | null
+}
+
+const COMMAND_MARKER_LIMIT = 8
+const commandMarkerCache = new Map<string, NativeChatCommandMarker[]>()
+let commandMarkerCounter = 0
+
+function commandMarkerScopeKey(scope: NativeChatCommandMarkerScope): string {
+  return `${scope.paneKey}\0${scope.agent}\0${scope.sessionId ?? ''}`
+}
+
+export function readCommandMarkerCache(
+  scope: NativeChatCommandMarkerScope
+): NativeChatCommandMarker[] {
+  return [...(commandMarkerCache.get(commandMarkerScopeKey(scope)) ?? [])]
+}
+
+export function appendCommandMarkerCache(
+  scope: NativeChatCommandMarkerScope,
+  command: string,
+  sentAt = Date.now()
+): NativeChatCommandMarker[] {
+  commandMarkerCounter += 1
+  const key = commandMarkerScopeKey(scope)
+  // Why: native/TUI view switches remount the chat surface, but slash commands
+  // are not transcript turns, so their local feedback needs a pane-scoped cache.
+  const next = [
+    ...(commandMarkerCache.get(key) ?? []),
+    { id: `${sentAt}-${commandMarkerCounter}`, command, sentAt }
+  ].slice(-COMMAND_MARKER_LIMIT)
+  // Why: the per-key array is capped at 8, but the KEY (paneKey\0agent\0sessionId,
+  // sessionId changes on every /clear) is ephemeral and was never evicted, so it
+  // grew one entry per (pane, session) for the renderer's whole life. LRU-bound
+  // the key count (mirrors the #7566 draft/attachment caches in this folder).
+  setBoundedScopeCacheEntry(commandMarkerCache, key, next)
+  return [...next]
+}
+
+export function clearCommandMarkerCacheForTests(): void {
+  commandMarkerCache.clear()
+  commandMarkerCounter = 0
+}
+
+function isClearCommand(command: string): boolean {
+  return command.trim().toLowerCase().split(/\s+/)[0] === '/clear'
+}
+
+function latestClearSentAt(markers: readonly NativeChatCommandMarker[]): number | null {
+  let latest: number | null = null
+  for (const marker of markers) {
+    if (isClearCommand(marker.command) && (latest === null || marker.sentAt > latest)) {
+      latest = marker.sentAt
+    }
+  }
+  return latest
+}
+
+export function applyCommandMarkerBoundaries(
+  messages: readonly NativeChatMessage[],
+  markers: readonly NativeChatCommandMarker[]
+): NativeChatMessage[] {
+  const clearSentAt = latestClearSentAt(markers)
+  if (clearSentAt === null) {
+    return messages as NativeChatMessage[]
+  }
+  // Why: `/clear` mutates the TUI/transcript asynchronously. Hide the current
+  // transcript immediately so native chat reflects the command before the agent
+  // writes a replacement session or truncates the file.
+  return messages.filter((message) => message.timestamp !== null && message.timestamp > clearSentAt)
+}
+
+/** Render command markers as compact `system` messages. The `system` role draws
+ *  as a muted aside (not a user bubble); the text avoids the harness noise
+ *  prefixes so stripNoiseMessages keeps it. */
+export function commandMarkersAsMessages(
+  markers: readonly NativeChatCommandMarker[]
+): NativeChatMessage[] {
+  return markers.map((marker) => ({
+    id: `command:${marker.id}`,
+    role: 'system' as const,
+    blocks: [{ type: 'text' as const, text: `Ran ${marker.command}` }],
+    timestamp: marker.sentAt,
+    source: 'scrape' as const
+  }))
+}
+
+/** True when a message id was minted for a slash-command marker. */
+export function isCommandMarkerId(id: string): boolean {
+  return id.startsWith('command:')
+}

--- a/src/renderer/src/components/native-chat/native-chat-pending-occurrence.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending-occurrence.ts
@@ -79,17 +79,21 @@ export function advancedNativeChatUserContentCounts(
   return advanced
 }
 
-/** User texts that already have a later non-user turn (ready to prune echoes). */
-export function advancedNativeChatUserTexts(
+/** A transcript user turn, kept identifiable so a caller can decide which
+ *  pending sends it is allowed to represent. */
+export type NativeChatUserRow = { id: string; text: string }
+
+/** User rows that already have a later non-user turn (ready to prune echoes). */
+export function advancedNativeChatUserRows(
   messages: readonly NativeChatMessage[]
-): readonly string[] {
-  const advanced: string[] = []
-  const waiting: string[] = []
+): readonly NativeChatUserRow[] {
+  const advanced: NativeChatUserRow[] = []
+  const waiting: NativeChatUserRow[] = []
   for (const message of messages) {
     if (message.role === 'user') {
       const text = normalizedNativeChatUserMessageText(message)
       if (text) {
-        waiting.push(text)
+        waiting.push({ id: message.id, text })
       }
       continue
     }
@@ -99,18 +103,18 @@ export function advancedNativeChatUserTexts(
   return advanced
 }
 
-/** All user texts (for hiding optimistic echoes once the turn exists). */
-export function matchingNativeChatUserTexts(
+/** All user rows (for hiding optimistic echoes once the turn exists). */
+export function matchingNativeChatUserRows(
   messages: readonly NativeChatMessage[]
-): readonly string[] {
-  const texts: string[] = []
+): readonly NativeChatUserRow[] {
+  const rows: NativeChatUserRow[] = []
   for (const message of messages) {
     const text = normalizedNativeChatUserMessageText(message)
     if (text) {
-      texts.push(text)
+      rows.push({ id: message.id, text })
     }
   }
-  return texts
+  return rows
 }
 
 /**
@@ -149,32 +153,49 @@ export function countLeadingPendingTextsGluedToUserText(
   return 0
 }
 
+/** A transcript row a glue match may consume, carrying the send boundaries it
+ *  satisfies — this matcher has no clock of its own. */
+export type NativeChatGluedUserRow = {
+  text: string
+  /** Indices into `pending` this row landed after. A row that already existed
+   *  when a send was issued can never be that send's echo. */
+  representablePendingIndices: ReadonlySet<number>
+}
+
 /**
  * Mark pending entries represented only by multi-send glue (2+ consecutive
  * optimistic texts concatenated into one transcript user row). Exact single
  * matches stay in the content-key/occurrence path so repeated prompts and
  * send boundaries keep their existing semantics.
- *
- * `userTexts` must already be filtered to rows after the oldest entry's send
- * boundary — this matcher has no clock of its own.
  */
-export function selectPendingIndicesRepresentedByUserTexts(
+export function selectPendingIndicesRepresentedByUserRows(
   pending: readonly NativeChatPendingOccurrence[],
-  userTexts: readonly string[]
+  rows: readonly NativeChatGluedUserRow[]
 ): Set<number> {
   const represented = new Set<number>()
-  if (pending.length < 2 || userTexts.length === 0) {
+  if (pending.length < 2 || rows.length === 0) {
     return represented
   }
   const remaining = pending.map((entry, index) => ({
     index,
     text: normalizeNativeChatPendingText(entry.text)
   }))
-  for (const userText of userTexts) {
-    const open = remaining.filter((entry) => !represented.has(entry.index) && entry.text.length > 0)
+  for (const row of rows) {
+    const open: typeof remaining = []
+    for (const entry of remaining) {
+      if (represented.has(entry.index) || entry.text.length === 0) {
+        continue
+      }
+      // Glue consumes a leading run, so a send this row predates ends the run
+      // rather than being skipped over — adjacency is what makes it glue.
+      if (!row.representablePendingIndices.has(entry.index)) {
+        break
+      }
+      open.push(entry)
+    }
     const gluedCount = countLeadingPendingTextsGluedToUserText(
       open.map((entry) => entry.text),
-      userText
+      row.text
     )
     // Why: gluedCount === 1 is an exact match — leave it to occurrence counting.
     if (gluedCount < 2) {

--- a/src/renderer/src/components/native-chat/native-chat-pending.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.test.ts
@@ -2,24 +2,26 @@ import { describe, expect, it } from 'vitest'
 import type { NativeChatMessage } from '../../../../shared/native-chat-types'
 import {
   appendPendingSendCache,
-  appendCommandMarkerCache,
-  applyCommandMarkerBoundaries,
-  clearCommandMarkerCacheForTests,
   clearPendingSendCacheForTests,
-  commandMarkersAsMessages,
-  isCommandMarkerId,
   isLaunchPromptMessageId,
   isPendingMessageId,
   launchPromptAsMessage,
   nextNativeChatPendingSendId,
   pendingSendsAsMessages,
   prunePendingSends,
-  readCommandMarkerCache,
   readPendingSendCache,
   shouldPruneLaunchPrompt,
   writePendingSendCache,
   type NativeChatPendingSend
 } from './native-chat-pending'
+import {
+  appendCommandMarkerCache,
+  applyCommandMarkerBoundaries,
+  clearCommandMarkerCacheForTests,
+  commandMarkersAsMessages,
+  isCommandMarkerId,
+  readCommandMarkerCache
+} from './native-chat-command-marker'
 import { stripNoiseMessages } from './native-chat-noise'
 
 function userMessage(id: string, text: string, timestamp = 1): NativeChatMessage {
@@ -329,6 +331,47 @@ describe('glued rapid sends', () => {
 
     expect(prunePendingSends(pending, history)).toEqual(pending)
     expect(pendingSendsAsMessages(pending, history)).toHaveLength(2)
+  })
+
+  // A row that already existed when a send was issued can never be that send's
+  // echo — for EVERY queued send, not just the oldest one the glue run starts at.
+  it('keeps a queued send whose own boundary is newer than the glued row (STA-4477)', () => {
+    const gluedRow = userMessage('glue-row', 'fix the bug', 6000)
+    const messages = [
+      GLUE_BOUNDARY,
+      gluedRow,
+      assistantMessage('glue-answer', 'fixed', 6100),
+      userMessage('later-history', 'anything', 6200)
+    ]
+    // 'fix the' was queued before the row landed; 'bug' only after it.
+    const pending = [
+      gluePending('p1', 'fix the'),
+      {
+        id: 'p2',
+        text: 'bug',
+        sentAt: 7000,
+        afterMessageId: 'glue-answer',
+        afterMessageTimestamp: 6100
+      }
+    ]
+
+    expect(prunePendingSends(pending, messages)).toEqual(pending)
+    expect(pendingSendsAsMessages(pending, messages)).toHaveLength(2)
+  })
+
+  it('still retires the leading run the glued row did land after (STA-4477)', () => {
+    const gluedRow = userMessage('glue-row', 'first second', 6000)
+    const messages = [GLUE_BOUNDARY, gluedRow, assistantMessage('glue-answer', 'done', 6100)]
+    const third = {
+      id: 'p3',
+      text: 'third',
+      sentAt: 7000,
+      afterMessageId: 'glue-row',
+      afterMessageTimestamp: gluedRow.timestamp
+    }
+    const pending = [gluePending('p1', 'first'), gluePending('p2', 'second'), third]
+
+    expect(prunePendingSends(pending, messages)).toEqual([third])
   })
 })
 

--- a/src/renderer/src/components/native-chat/native-chat-pending.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.test.ts
@@ -335,28 +335,65 @@ describe('glued rapid sends', () => {
 
   // A row that already existed when a send was issued can never be that send's
   // echo — for EVERY queued send, not just the oldest one the glue run starts at.
-  it('keeps a queued send whose own boundary is newer than the glued row (STA-4477)', () => {
+  const mixedAgeGlue = (): { messages: NativeChatMessage[]; pending: NativeChatPendingSend[] } => {
     const gluedRow = userMessage('glue-row', 'fix the bug', 6000)
-    const messages = [
-      GLUE_BOUNDARY,
-      gluedRow,
-      assistantMessage('glue-answer', 'fixed', 6100),
-      userMessage('later-history', 'anything', 6200)
-    ]
-    // 'fix the' was queued before the row landed; 'bug' only after it.
+    return {
+      messages: [
+        GLUE_BOUNDARY,
+        gluedRow,
+        assistantMessage('glue-answer', 'fixed', 6100),
+        userMessage('later-history', 'anything', 6200)
+      ],
+      // 'fix the' was queued before the row landed; 'bug' only after it.
+      pending: [
+        gluePending('p1', 'fix the'),
+        {
+          id: 'p2',
+          text: 'bug',
+          sentAt: 7000,
+          afterMessageId: 'glue-answer',
+          afterMessageTimestamp: 6100
+        }
+      ]
+    }
+  }
+
+  it('keeps a queued send whose own boundary is newer than the glued row (STA-4477)', () => {
+    const { messages, pending } = mixedAgeGlue()
+
+    expect(prunePendingSends(pending, messages)).toEqual(pending)
+  })
+
+  // Separate from the prune case on purpose: the render path is what makes the
+  // bubble visually vanish, and a shared `it` would mask it behind the first
+  // failing assertion.
+  it('still renders a queued send whose own boundary is newer than the row (STA-4477)', () => {
+    const { messages, pending } = mixedAgeGlue()
+
+    expect(pendingSendsAsMessages(pending, messages)).toHaveLength(2)
+  })
+
+  // Glue is adjacency: a send the row predates ends the run rather than being
+  // skipped, so a row must never bridge across a send it cannot represent.
+  it('never glues across a send the row cannot represent (STA-4477)', () => {
+    const gluedRow = userMessage('glue-row', 'alpha gamma', 6000)
+    const messages = [GLUE_BOUNDARY, gluedRow, assistantMessage('glue-answer', 'ok', 6100)]
     const pending = [
-      gluePending('p1', 'fix the'),
+      gluePending('p1', 'alpha'),
+      // Queued after the row landed, so the row is not its echo...
       {
         id: 'p2',
-        text: 'bug',
+        text: 'beta',
         sentAt: 7000,
-        afterMessageId: 'glue-answer',
-        afterMessageTimestamp: 6100
-      }
+        afterMessageId: 'glue-row',
+        afterMessageTimestamp: 6000
+      },
+      // ...and 'alpha'+'gamma' must not close over the gap it leaves.
+      gluePending('p3', 'gamma')
     ]
 
     expect(prunePendingSends(pending, messages)).toEqual(pending)
-    expect(pendingSendsAsMessages(pending, messages)).toHaveLength(2)
+    expect(pendingSendsAsMessages(pending, messages)).toHaveLength(3)
   })
 
   it('still retires the leading run the glued row did land after (STA-4477)', () => {

--- a/src/renderer/src/components/native-chat/native-chat-pending.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.ts
@@ -8,15 +8,17 @@ import { setBoundedScopeCacheEntry } from './native-chat-composer-scope-cache'
 import type { NativeChatLaunchPrompt } from '@/lib/native-chat-launch-prompt'
 import {
   advancedNativeChatUserContentCounts,
-  advancedNativeChatUserTexts,
+  advancedNativeChatUserRows,
   assignNativeChatPendingOccurrence,
   matchingNativeChatUserContentCounts,
-  matchingNativeChatUserTexts,
+  matchingNativeChatUserRows,
   nativeChatPendingContentKey,
   nativeChatPendingMatchKey,
   nativeChatPendingMatchingAfter,
   nativeChatPendingOccurrence,
-  selectPendingIndicesRepresentedByUserTexts
+  selectPendingIndicesRepresentedByUserRows,
+  type NativeChatGluedUserRow,
+  type NativeChatUserRow
 } from './native-chat-pending-occurrence'
 
 /** An optimistic, not-yet-confirmed composer send. */
@@ -126,23 +128,35 @@ function messageIsAfterPendingTimestamp(
 }
 
 /**
- * Rows a glue match may consume. Glue always starts at the oldest still-open
- * echo, so that echo's send boundary is the floor: unbounded, an older turn
- * whose text happens to split across the queue ("fix the bug" vs "fix the" +
- * "bug") would retire sends issued long after it. A missing message boundary
- * falls back to send time — a fuzzy match must never reach further back than
- * an exact one.
+ * Rows a glue match may consume, each tagged with the sends it landed after.
+ * Unbounded, an older turn whose text happens to split across the queue ("fix
+ * the bug" vs "fix the" + "bug") would retire sends issued long after it — so
+ * every send carries its OWN boundary into the match, not just the oldest one
+ * the run starts at (#14663 pruned newer queued prompts against older rows).
+ * A missing message boundary falls back to send time: a fuzzy match must never
+ * reach further back than an exact one.
  */
-function gluedCandidateMessages(
+function gluedCandidateRows(
   messages: readonly NativeChatMessage[],
-  open: readonly NativeChatPendingSend[]
-): readonly NativeChatMessage[] {
-  const oldest = open[0]
+  open: readonly NativeChatPendingSend[],
+  rowsOf: (messages: readonly NativeChatMessage[]) => readonly NativeChatUserRow[]
+): readonly NativeChatGluedUserRow[] {
+  const anchored = open.map((entry) =>
+    entry.afterMessageId === undefined ? { ...entry, afterMessageId: null } : entry
+  )
+  const oldest = anchored[0]
   if (!oldest) {
     return []
   }
-  const anchor = oldest.afterMessageId === undefined ? { ...oldest, afterMessageId: null } : oldest
-  return messagesAfterPendingBoundary(messages, anchor)
+  const rowIdsAfterOwnBoundary = anchored.map(
+    (entry) => new Set(rowsOf(messagesAfterPendingBoundary(messages, entry)).map((row) => row.id))
+  )
+  return rowsOf(messagesAfterPendingBoundary(messages, oldest)).map((row) => ({
+    text: row.text,
+    representablePendingIndices: new Set(
+      rowIdsAfterOwnBoundary.flatMap((ids, index) => (ids.has(row.id) ? [index] : []))
+    )
+  }))
 }
 
 /**
@@ -175,9 +189,9 @@ export function prunePendingSends(
   // transcript carries one row ("joke"+"continue"→"jokecontinue") that no exact
   // key matches. Drop those echoes once an assistant turn advances past it.
   const stillOpen = pending.filter((_, index) => exactKeep[index])
-  const gluedRepresented = selectPendingIndicesRepresentedByUserTexts(
+  const gluedRepresented = selectPendingIndicesRepresentedByUserRows(
     stillOpen,
-    advancedNativeChatUserTexts(gluedCandidateMessages(messages, stillOpen))
+    gluedCandidateRows(messages, stillOpen, advancedNativeChatUserRows)
   )
   const next = pending.filter((entry, index) => {
     if (!exactKeep[index]) {
@@ -218,9 +232,9 @@ export function pendingSendsAsMessages(
   // Hide optimistic echoes that were glued into a single transcript user row
   // even before the assistant reply lands (matching, not advanced).
   const stillVisible = pending.filter((_, index) => exactVisible[index])
-  const gluedRepresented = selectPendingIndicesRepresentedByUserTexts(
+  const gluedRepresented = selectPendingIndicesRepresentedByUserRows(
     stillVisible,
-    matchingNativeChatUserTexts(gluedCandidateMessages(existingMessages, stillVisible))
+    gluedCandidateRows(existingMessages, stillVisible, matchingNativeChatUserRows)
   )
   return pending
     .filter((entry, index) => {
@@ -298,108 +312,4 @@ export function nextNativeChatPendingSendId(now = Date.now()): string {
 
 export function isLaunchPromptMessageId(id: string): boolean {
   return id.startsWith('launch-pending:')
-}
-
-/** A locally-recorded slash command (e.g. `/clear`). Slash commands dispatch to
- *  the agent's TUI and are not chat turns, so we surface a small system line as
- *  feedback that the command ran rather than echoing a user bubble. */
-export type NativeChatCommandMarker = {
-  id: string
-  /** The command as typed, e.g. `/clear`. */
-  command: string
-  sentAt: number
-}
-
-export type NativeChatCommandMarkerScope = {
-  paneKey: string
-  agent: string
-  sessionId: string | null
-}
-
-const COMMAND_MARKER_LIMIT = 8
-const commandMarkerCache = new Map<string, NativeChatCommandMarker[]>()
-let commandMarkerCounter = 0
-
-function commandMarkerScopeKey(scope: NativeChatCommandMarkerScope): string {
-  return `${scope.paneKey}\0${scope.agent}\0${scope.sessionId ?? ''}`
-}
-
-export function readCommandMarkerCache(
-  scope: NativeChatCommandMarkerScope
-): NativeChatCommandMarker[] {
-  return [...(commandMarkerCache.get(commandMarkerScopeKey(scope)) ?? [])]
-}
-
-export function appendCommandMarkerCache(
-  scope: NativeChatCommandMarkerScope,
-  command: string,
-  sentAt = Date.now()
-): NativeChatCommandMarker[] {
-  commandMarkerCounter += 1
-  const key = commandMarkerScopeKey(scope)
-  // Why: native/TUI view switches remount the chat surface, but slash commands
-  // are not transcript turns, so their local feedback needs a pane-scoped cache.
-  const next = [
-    ...(commandMarkerCache.get(key) ?? []),
-    { id: `${sentAt}-${commandMarkerCounter}`, command, sentAt }
-  ].slice(-COMMAND_MARKER_LIMIT)
-  // Why: the per-key array is capped at 8, but the KEY (paneKey\0agent\0sessionId,
-  // sessionId changes on every /clear) is ephemeral and was never evicted, so it
-  // grew one entry per (pane, session) for the renderer's whole life. LRU-bound
-  // the key count (mirrors the #7566 draft/attachment caches in this folder).
-  setBoundedScopeCacheEntry(commandMarkerCache, key, next)
-  return [...next]
-}
-
-export function clearCommandMarkerCacheForTests(): void {
-  commandMarkerCache.clear()
-  commandMarkerCounter = 0
-}
-
-function isClearCommand(command: string): boolean {
-  return command.trim().toLowerCase().split(/\s+/)[0] === '/clear'
-}
-
-function latestClearSentAt(markers: readonly NativeChatCommandMarker[]): number | null {
-  let latest: number | null = null
-  for (const marker of markers) {
-    if (isClearCommand(marker.command) && (latest === null || marker.sentAt > latest)) {
-      latest = marker.sentAt
-    }
-  }
-  return latest
-}
-
-export function applyCommandMarkerBoundaries(
-  messages: readonly NativeChatMessage[],
-  markers: readonly NativeChatCommandMarker[]
-): NativeChatMessage[] {
-  const clearSentAt = latestClearSentAt(markers)
-  if (clearSentAt === null) {
-    return messages as NativeChatMessage[]
-  }
-  // Why: `/clear` mutates the TUI/transcript asynchronously. Hide the current
-  // transcript immediately so native chat reflects the command before the agent
-  // writes a replacement session or truncates the file.
-  return messages.filter((message) => message.timestamp !== null && message.timestamp > clearSentAt)
-}
-
-/** Render command markers as compact `system` messages. The `system` role draws
- *  as a muted aside (not a user bubble); the text avoids the harness noise
- *  prefixes so stripNoiseMessages keeps it. */
-export function commandMarkersAsMessages(
-  markers: readonly NativeChatCommandMarker[]
-): NativeChatMessage[] {
-  return markers.map((marker) => ({
-    id: `command:${marker.id}`,
-    role: 'system' as const,
-    blocks: [{ type: 'text' as const, text: `Ran ${marker.command}` }],
-    timestamp: marker.sentAt,
-    source: 'scrape' as const
-  }))
-}
-
-/** True when a message id was minted for a slash-command marker. */
-export function isCommandMarkerId(id: string): boolean {
-  return id.startsWith('command:')
 }

--- a/src/renderer/src/components/native-chat/native-chat-pending.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.ts
@@ -141,22 +141,28 @@ function gluedCandidateRows(
   open: readonly NativeChatPendingSend[],
   rowsOf: (messages: readonly NativeChatMessage[]) => readonly NativeChatUserRow[]
 ): readonly NativeChatGluedUserRow[] {
-  const anchored = open.map((entry) =>
+  const [oldest, ...newer] = open.map((entry) =>
     entry.afterMessageId === undefined ? { ...entry, afterMessageId: null } : entry
   )
-  const oldest = anchored[0]
-  if (!oldest) {
+  // Glue needs a run of 2+ sends, so a lone queued echo — by far the common
+  // case while an agent streams — skips the per-send boundary scans entirely.
+  if (!oldest || newer.length === 0) {
     return []
   }
-  const rowIdsAfterOwnBoundary = anchored.map(
+  const newerRowIds = newer.map(
     (entry) => new Set(rowsOf(messagesAfterPendingBoundary(messages, entry)).map((row) => row.id))
   )
-  return rowsOf(messagesAfterPendingBoundary(messages, oldest)).map((row) => ({
-    text: row.text,
-    representablePendingIndices: new Set(
-      rowIdsAfterOwnBoundary.flatMap((ids, index) => (ids.has(row.id) ? [index] : []))
-    )
-  }))
+  // The run always starts at the oldest open send, so its rows are the whole
+  // candidate set and index 0 is representable in every one of them.
+  return rowsOf(messagesAfterPendingBoundary(messages, oldest)).map((row) => {
+    const representablePendingIndices = new Set([0])
+    newerRowIds.forEach((ids, index) => {
+      if (ids.has(row.id)) {
+        representablePendingIndices.add(index + 1)
+      }
+    })
+    return { text: row.text, representablePendingIndices }
+  })
 }
 
 /**


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​87 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​80 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​209 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​156 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​53 |

<!-- /orca-pr-loc -->

## ELI5

When you fire off two chat prompts in a row, the agent's terminal sometimes swallows them onto one line, so both show up in the transcript as a single user turn. Native chat knows how to recognize that and clear the two "queued" bubbles. But it was checking that merged row against only the *oldest* waiting prompt — so a prompt you typed *after* that row already landed could also be marked "already delivered" and quietly thrown away. This makes every waiting prompt prove the row came after *it*, individually.

## What Changed

**Desktop / renderer only.** `mobile/` is untouched.

1. **Every pending send carries its own transcript boundary into glue matching.** `gluedCandidateRows` now tags each candidate row with the set of pending indices that row actually landed after, instead of filtering the whole candidate list by `open[0]`'s boundary and then matching the entire open queue against it.

2. **A send the row predates ends the run instead of being skipped.** In `selectPendingIndicesRepresentedByUserRows`, a candidate that the row cannot represent `break`s out of the open run rather than being filtered out of it. Glue consumes a *leading, adjacent* run — adjacency is the whole reason a merged row is attributable at all, so skipping over a non-representable send would let a row claim two prompts that were never adjacent.

3. **Exact matches are untouched.** `gluedCount < 2` still returns to the occurrence/content-key path, so repeated prompts and ordinary single landings keep their existing semantics.

4. **Forced file split, pure move.** `native-chat-pending.ts` was at **299 of its 300** effective-line budget (`max-lines`, `skipBlankLines` + `skipComments`) on `main`. One added line breaks the build, and this repo never bumps or disables `max-lines`. The slash-command marker cache — a genuinely separate rule that never participated in pending pruning — moves verbatim into `native-chat-command-marker.ts`. Verified byte-identical to the code it replaced; only import sites changed.

## Why

`prunePendingSends` and `pendingSendsAsMessages` both derived their glue candidates from a single anchor:

```ts
const oldest = open[0]
return messagesAfterPendingBoundary(messages, anchor)   // ← one boundary for the whole queue
```

That is safe only while the queue is a single burst. As soon as one prompt is queued *after* a glued row has landed, that older row is still in the candidate list for the newer prompt, and if the row's text happens to spell the concatenation of the queue (`"fix the bug"` vs `"fix the"` + `"bug"`), the newer prompt is pruned as already-delivered. The bubble vanishes and no transcript turn ever appears for it — the prompt is simply lost.

A fuzzy match must never reach further back than an exact one. The exact paths already call `messagesAfterPendingBoundary(messages, entry)` per entry; the glue path was the only match path without a per-send boundary.

## Linked Issue

Refs STA-4477. Original PR #14663.

## Visual Proof

Not applicable — pure non-visual matching logic behind existing UI, with no rendered change in any passing case. The user-visible effect of the bug is the *absence* of a bubble, which the deterministic tests below assert directly on both the pruning and the rendering entry point.

## Testing

```bash
pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/native-chat
pnpm exec tsc --noEmit -p config/tsconfig.tc.web.json
PATH=/opt/homebrew/opt/node@24/bin:$PATH node config/scripts/check-changed-code-quality.mjs -- origin/main
pnpm exec oxfmt --check src/renderer/src/components/native-chat/*.ts src/renderer/src/components/native-chat/NativeChatView.tsx
```

Results at this HEAD, rebased onto `bf6dc6fcba`:

- Native-chat suites: **73 files / 768 tests passed**.
- `tsc --noEmit` (web project): clean. `tsc -b` deliberately not used — its emit poisons vitest.
- Changed-code quality, type-aware quality, React Doctor: **0 new findings across 6 changed files**.
- Oxfmt: clean on all 5 changed source files.

**Red-first / non-vacuity.** Reverting the production files wholesale is not a clean measurement here, because the fix renames the matcher's API and 2 of 3 test files then fail to *load* rather than fail an assertion. So the behavioural revert was done surgically instead — `representablePendingIndices` set to every index, which is exactly the pre-fix "one anchor for the whole queue" semantics with the new signature:

```
× keeps a queued send whose own boundary is newer than the glued row (STA-4477)
  AssertionError: expected [] to deeply equal [ { id: 'p1', …(4) }, …(1) ]
  Test Files  1 failed (1)
       Tests  1 failed | 61 passed (62)
```

That is the P1 verbatim: both pending sends pruned (`[]`) where only the older one had actually landed. The companion test `still retires the leading run the glued row did land after` stays green under the same mutation, so the fix is pinned from both sides and is not simply disabling glue.

STA-4477 was re-confirmed present on current `origin/main` before fixing — `gluedCandidateMessages` there still filters by `open[0]` alone.

## Review

- **Security / supply chain** — no dependencies, IO, network, secrets, shell, or persisted state.
- **Backward compatibility / data loss** — this *removes* a data-loss path; it never widens retirement. The added per-send bound can only make the matcher retire fewer entries, never more, so the failure direction is a bubble lingering (recoverable, visible) rather than a prompt disappearing (silent, unrecoverable).
- **Remote wire** — none. `NativeChatPendingSend` is renderer-local state; nothing here is an RPC param, a stream frame, or content a host publishes. Checked against `docs/reference/remote-wire-compatibility.md` rules 1–3.
- **Cross-platform** — pure string/array logic; no platform, path, or shell branch. macOS/Linux/Windows identical.
- **Performance** — one extra `Set` per open pending entry per pass, bounded by `PENDING_SEND_LIMIT = 8`; all allocations invocation-local.
- **Scope** — 6 files, all under `src/renderer/src/components/native-chat/`. The file split is forced by the 300-line cap, not elective.

## Checklist

- [x] Root cause identified and fixed at the seam that lacked the bound
- [x] Red-first reproduction quoted, with a mutation that isolates the behaviour from the API rename
- [x] Over-correction pinned by a companion test
- [x] File split proven a verbatim move, forced by `max-lines` (never bumped, never disabled)
- [x] Wire, cross-platform, and data-loss direction reviewed

## AI Disclosure

Authored and reviewed with AI assistance.

## Author

- X / Twitter: @BrennanKB5
