### PR TITLE
fix(mobile-native-chat): reland glued pending retirement without the two revert causes (STA-4482, STA-4492)

### DIFF
--- a/mobile/src/session/MobileNativeChatComposer.test.ts
+++ b/mobile/src/session/MobileNativeChatComposer.test.ts
@@ -84,7 +84,9 @@ describe('MobileNativeChatComposer', () => {
 
     await act(async () => sendButton().props.onPress())
 
-    expect(onSend).toHaveBeenCalledWith(' hello')
+    // Verbatim: the send seam trims for the wire, so a rejected send can hand
+    // back the draft byte-for-byte (#14819).
+    expect(onSend).toHaveBeenCalledWith(' hello ')
     expect(onChangeText).not.toHaveBeenCalled()
   })
 
@@ -120,7 +122,7 @@ describe('MobileNativeChatComposer', () => {
       )
     })
     await act(async () => sendButton().props.onPress())
-    expect(onSend).toHaveBeenCalledWith(' /clear is prose')
+    expect(onSend).toHaveBeenCalledWith(' /clear is prose ')
   })
 
   it('locks the option pickers while a composer send is in flight', async () => {
@@ -219,7 +221,7 @@ describe('MobileNativeChatComposer', () => {
 
     await act(async () => sendButton().props.onPress())
 
-    expect(onSend).toHaveBeenCalledWith(' hello')
+    expect(onSend).toHaveBeenCalledWith(' hello ')
     expect(onChangeText).not.toHaveBeenCalled()
   })
 

--- a/mobile/src/session/MobileNativeChatComposer.tsx
+++ b/mobile/src/session/MobileNativeChatComposer.tsx
@@ -151,7 +151,9 @@ export function MobileNativeChatComposer({
     sendingRef.current = true
     setSending(true)
     try {
-      const accepted = await onSend(value.trimEnd())
+      // Raw, not trimmed: the send seam owns the wire trim, and a rejection has
+      // to hand the user back exactly what they typed (#14819).
+      const accepted = await onSend(value)
       if (accepted) {
         setCursor(0)
       }

--- a/mobile/src/session/mobile-native-chat-pending-baseline.test.ts
+++ b/mobile/src/session/mobile-native-chat-pending-baseline.test.ts
@@ -41,15 +41,16 @@ describe('rebaseMobileNativeChatPendingBaselines', () => {
     expect(rebaseMobileNativeChatPendingBaselines(history, pending)).toBe(pending)
   })
 
-  it('pins an unresolved send to the loaded tail and past the rows it never saw', () => {
+  it('gives an unresolved send the loaded tail as its glue boundary', () => {
     expect(
       rebaseMobileNativeChatPendingBaselines(history, [unresolved('p1', 'run the tests')])
     ).toEqual([
       {
         id: 'p1',
         text: 'run the tests',
-        // The one row already in history is not this send's echo; it waits for the second.
-        expectedOccurrence: 2,
+        // NOT recounted against this read: the read may already carry this send's
+        // own echo, and counting it as history would strand the bubble forever.
+        expectedOccurrence: 1,
         baselineTailMessageId: 'm2',
         baselineResolved: true
       }
@@ -68,23 +69,16 @@ describe('rebaseMobileNativeChatPendingBaselines', () => {
     ])
   })
 
-  it('gives identical queued sends consecutive ordinals', () => {
+  it('keeps the ordinals the queue already assigned', () => {
     expect(
       rebaseMobileNativeChatPendingBaselines(history, [
-        unresolved('p1', 'run the tests'),
-        unresolved('p2', 'run the tests')
+        unresolved('p1', 'run the tests', 1),
+        unresolved('p2', 'run the tests', 2)
       ]).map((item) => item.expectedOccurrence)
-    ).toEqual([2, 3])
+    ).toEqual([1, 2])
   })
 
-  it('normalizes whitespace when counting a send against the loaded rows', () => {
-    expect(
-      rebaseMobileNativeChatPendingBaselines(history, [unresolved('p1', '  run   the tests \n')])[0]
-        ?.expectedOccurrence
-    ).toBe(2)
-  })
-
-  it('leaves already-resolved neighbours untouched but still counts them', () => {
+  it('leaves already-resolved neighbours untouched', () => {
     const resolved: MobileNativeChatPendingMessage = {
       id: 'p1',
       text: 'run the tests',
@@ -94,19 +88,28 @@ describe('rebaseMobileNativeChatPendingBaselines', () => {
     }
     const rebased = rebaseMobileNativeChatPendingBaselines(history, [
       resolved,
-      unresolved('p2', 'run the tests')
+      unresolved('p2', 'run the tests', 2)
     ])
     expect(rebased[0]).toBe(resolved)
-    expect(rebased[1]?.expectedOccurrence).toBe(3)
+    expect(rebased[1]).toEqual({
+      id: 'p2',
+      text: 'run the tests',
+      expectedOccurrence: 2,
+      baselineTailMessageId: 'm2',
+      baselineResolved: true
+    })
   })
 
-  it('ordinals caption-less image echoes among themselves, not against text rows', () => {
+  // An image echo counts image turns AFTER its tail, so moving the tail onto this
+  // read would discard an echo the read already carries.
+  it('keeps a caption-less image echo on its captured tail', () => {
     const images = { ...unresolved('p1', ''), images: ['file:///a.png'] }
     const rebased = rebaseMobileNativeChatPendingBaselines(history, [
       images,
-      { ...unresolved('p2', ''), images: ['file:///b.png'] }
+      { ...unresolved('p2', '', 2), images: ['file:///b.png'] }
     ])
     expect(rebased.map((item) => item.expectedOccurrence)).toEqual([1, 2])
-    expect(rebased.map((item) => item.baselineTailMessageId)).toEqual(['m2', 'm2'])
+    expect(rebased.map((item) => item.baselineTailMessageId)).toEqual([null, null])
+    expect(rebased.every((item) => item.baselineResolved)).toBe(true)
   })
 })

--- a/mobile/src/session/mobile-native-chat-pending-baseline.test.ts
+++ b/mobile/src/session/mobile-native-chat-pending-baseline.test.ts
@@ -100,16 +100,29 @@ describe('rebaseMobileNativeChatPendingBaselines', () => {
     })
   })
 
-  // An image echo counts image turns AFTER its tail, so moving the tail onto this
-  // read would discard an echo the read already carries.
-  it('keeps a caption-less image echo on its captured tail', () => {
-    const images = { ...unresolved('p1', ''), images: ['file:///a.png'] }
+  // An image echo counts image turns AFTER its tail, so moving a real tail onto
+  // this read would discard an echo the read already carries.
+  it('keeps a caption-less image echo on the tail it actually captured', () => {
+    const images = {
+      ...unresolved('p1', ''),
+      baselineTailMessageId: 'm1',
+      images: ['file:///a.png']
+    }
+    const rebased = rebaseMobileNativeChatPendingBaselines(history, [images])
+    expect(rebased[0]?.baselineTailMessageId).toBe('m1')
+    expect(rebased[0]?.expectedOccurrence).toBe(1)
+    expect(rebased[0]?.baselineResolved).toBe(true)
+  })
+
+  // A null tail counts from the top of the transcript, so an image turn already
+  // in this read would claim the send and take the user's fresh photo with it.
+  it('pins a caption-less image echo that captured no tail at all', () => {
     const rebased = rebaseMobileNativeChatPendingBaselines(history, [
-      images,
+      { ...unresolved('p1', ''), images: ['file:///a.png'] },
       { ...unresolved('p2', '', 2), images: ['file:///b.png'] }
     ])
+    expect(rebased.map((item) => item.baselineTailMessageId)).toEqual(['m2', 'm2'])
     expect(rebased.map((item) => item.expectedOccurrence)).toEqual([1, 2])
-    expect(rebased.map((item) => item.baselineTailMessageId)).toEqual([null, null])
     expect(rebased.every((item) => item.baselineResolved)).toBe(true)
   })
 })

--- a/mobile/src/session/mobile-native-chat-pending-baseline.test.ts
+++ b/mobile/src/session/mobile-native-chat-pending-baseline.test.ts
@@ -141,15 +141,24 @@ describe('rebaseMobileNativeChatPendingBaselines', () => {
     expect(rebased[0]?.baselineResolved).toBe(true)
   })
 
-  // A null tail counts from the top of the transcript, so an image turn already
-  // in this read would claim the send and take the user's fresh photo with it.
-  it('pins a caption-less image echo that captured no tail at all', () => {
+  // A supplied tail would sit at or after this send's own echo, and an image
+  // echo counts turns AFTER its tail — so it would exclude the very row it is
+  // waiting for, and image entries have no other retirement path.
+  it('never supplies a tail to a caption-less image echo either', () => {
     const rebased = rebaseMobileNativeChatPendingBaselines(history, [
       { ...unresolved('p1', ''), images: ['file:///a.png'] },
       { ...unresolved('p2', '', 2), images: ['file:///b.png'] }
     ])
-    expect(rebased.map((item) => item.baselineTailMessageId)).toEqual(['m2', 'm2'])
+    expect(rebased.map((item) => item.baselineTailMessageId)).toEqual([null, null])
     expect(rebased.map((item) => item.expectedOccurrence)).toEqual([1, 2])
     expect(rebased.every((item) => item.baselineResolved)).toBe(true)
+  })
+
+  // Same rule for a text-empty entry with no images: it reconciles by counting
+  // image-source turns after its tail, so a supplied tail strands it too.
+  it('never supplies a tail to a text-empty entry', () => {
+    const rebased = rebaseMobileNativeChatPendingBaselines(history, [unresolved('p1', '   ')])
+    expect(rebased[0]?.baselineTailMessageId).toBe(null)
+    expect(rebased[0]?.baselineResolved).toBe(true)
   })
 })

--- a/mobile/src/session/mobile-native-chat-pending-baseline.test.ts
+++ b/mobile/src/session/mobile-native-chat-pending-baseline.test.ts
@@ -100,6 +100,22 @@ describe('rebaseMobileNativeChatPendingBaselines', () => {
     })
   })
 
+  // An unsettled read still shows this session's own retained history, so a send
+  // made across a reconnect already owns a real boundary. Moving it onto the read
+  // that follows pushes it past the send's own echo and strands the bubble.
+  it('never moves a tail the send actually captured', () => {
+    const captured: MobileNativeChatPendingMessage = {
+      id: 'p1',
+      text: 'run the tests',
+      expectedOccurrence: 1,
+      baselineTailMessageId: 'm1',
+      baselineResolved: false
+    }
+    const rebased = rebaseMobileNativeChatPendingBaselines(history, [captured])
+    expect(rebased[0]?.baselineTailMessageId).toBe('m1')
+    expect(rebased[0]?.baselineResolved).toBe(true)
+  })
+
   // An image echo counts image turns AFTER its tail, so moving a real tail onto
   // this read would discard an echo the read already carries.
   it('keeps a caption-less image echo on the tail it actually captured', () => {
@@ -110,6 +126,17 @@ describe('rebaseMobileNativeChatPendingBaselines', () => {
     }
     const rebased = rebaseMobileNativeChatPendingBaselines(history, [images])
     expect(rebased[0]?.baselineTailMessageId).toBe('m1')
+    expect(rebased[0]?.expectedOccurrence).toBe(1)
+    expect(rebased[0]?.baselineResolved).toBe(true)
+  })
+
+  // A captioned image echo binds by an ordinal counted over the whole transcript.
+  // Pinning a tail without recounting leaves it matching nothing, forever.
+  it('leaves a captioned image echo entirely alone', () => {
+    const rebased = rebaseMobileNativeChatPendingBaselines(history, [
+      { ...unresolved('p1', 'here'), images: ['file:///a.png'] }
+    ])
+    expect(rebased[0]?.baselineTailMessageId).toBe(null)
     expect(rebased[0]?.expectedOccurrence).toBe(1)
     expect(rebased[0]?.baselineResolved).toBe(true)
   })

--- a/mobile/src/session/mobile-native-chat-pending-baseline.test.ts
+++ b/mobile/src/session/mobile-native-chat-pending-baseline.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
+import { rebaseMobileNativeChatPendingBaselines } from './mobile-native-chat-pending-baseline'
+import type { MobileNativeChatPendingMessage } from './mobile-native-chat-pending-echo'
+
+function userTurn(id: string, text: string, timestamp: number): NativeChatMessage {
+  return { id, role: 'user', blocks: [{ type: 'text', text }], timestamp, source: 'transcript' }
+}
+
+function assistantTurn(id: string, text: string, timestamp: number): NativeChatMessage {
+  return {
+    id,
+    role: 'assistant',
+    blocks: [{ type: 'text', text }],
+    timestamp,
+    source: 'transcript'
+  }
+}
+
+function unresolved(
+  id: string,
+  text: string,
+  expectedOccurrence = 1
+): MobileNativeChatPendingMessage {
+  return { id, text, expectedOccurrence, baselineTailMessageId: null, baselineResolved: false }
+}
+
+describe('rebaseMobileNativeChatPendingBaselines', () => {
+  const history = [userTurn('m1', 'run the tests', 1000), assistantTurn('m2', 'passed', 1100)]
+
+  it('returns the same array when every baseline is already resolved', () => {
+    const pending: MobileNativeChatPendingMessage[] = [
+      {
+        id: 'p1',
+        text: 'hi',
+        expectedOccurrence: 1,
+        baselineTailMessageId: 'm2',
+        baselineResolved: true
+      }
+    ]
+    expect(rebaseMobileNativeChatPendingBaselines(history, pending)).toBe(pending)
+  })
+
+  it('pins an unresolved send to the loaded tail and past the rows it never saw', () => {
+    expect(
+      rebaseMobileNativeChatPendingBaselines(history, [unresolved('p1', 'run the tests')])
+    ).toEqual([
+      {
+        id: 'p1',
+        text: 'run the tests',
+        // The one row already in history is not this send's echo; it waits for the second.
+        expectedOccurrence: 2,
+        baselineTailMessageId: 'm2',
+        baselineResolved: true
+      }
+    ])
+  })
+
+  it('pins to null when the authoritative transcript is empty', () => {
+    expect(rebaseMobileNativeChatPendingBaselines([], [unresolved('p1', 'hi')])).toEqual([
+      {
+        id: 'p1',
+        text: 'hi',
+        expectedOccurrence: 1,
+        baselineTailMessageId: null,
+        baselineResolved: true
+      }
+    ])
+  })
+
+  it('gives identical queued sends consecutive ordinals', () => {
+    expect(
+      rebaseMobileNativeChatPendingBaselines(history, [
+        unresolved('p1', 'run the tests'),
+        unresolved('p2', 'run the tests')
+      ]).map((item) => item.expectedOccurrence)
+    ).toEqual([2, 3])
+  })
+
+  it('normalizes whitespace when counting a send against the loaded rows', () => {
+    expect(
+      rebaseMobileNativeChatPendingBaselines(history, [unresolved('p1', '  run   the tests \n')])[0]
+        ?.expectedOccurrence
+    ).toBe(2)
+  })
+
+  it('leaves already-resolved neighbours untouched but still counts them', () => {
+    const resolved: MobileNativeChatPendingMessage = {
+      id: 'p1',
+      text: 'run the tests',
+      expectedOccurrence: 9,
+      baselineTailMessageId: 'm1',
+      baselineResolved: true
+    }
+    const rebased = rebaseMobileNativeChatPendingBaselines(history, [
+      resolved,
+      unresolved('p2', 'run the tests')
+    ])
+    expect(rebased[0]).toBe(resolved)
+    expect(rebased[1]?.expectedOccurrence).toBe(3)
+  })
+
+  it('ordinals caption-less image echoes among themselves, not against text rows', () => {
+    const images = { ...unresolved('p1', ''), images: ['file:///a.png'] }
+    const rebased = rebaseMobileNativeChatPendingBaselines(history, [
+      images,
+      { ...unresolved('p2', ''), images: ['file:///b.png'] }
+    ])
+    expect(rebased.map((item) => item.expectedOccurrence)).toEqual([1, 2])
+    expect(rebased.map((item) => item.baselineTailMessageId)).toEqual(['m2', 'm2'])
+  })
+})

--- a/mobile/src/session/mobile-native-chat-pending-baseline.ts
+++ b/mobile/src/session/mobile-native-chat-pending-baseline.ts
@@ -1,0 +1,52 @@
+import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
+import {
+  countUserTextOccurrences,
+  normalizeReconcileText
+} from './mobile-native-chat-draft-reconcile'
+import type { MobileNativeChatPendingMessage } from './mobile-native-chat-pending-echo'
+
+/**
+ * Pin the sends issued while the transcript was still hydrating onto the first
+ * authoritative read of this session's history.
+ *
+ * Such a send has no usable baseline at capture time: `messages` was empty, or
+ * still the previously active tab's, so both its tail and its occurrence count
+ * describe somebody else's transcript. Rebasing them here — rather than marking
+ * the send permanently untrustworthy, which stranded it as a queued bubble and
+ * as a glue barrier for its neighbours for the rest of the session — leaves it
+ * matching exactly the rows that arrive from now on.
+ */
+export function rebaseMobileNativeChatPendingBaselines(
+  messages: readonly NativeChatMessage[],
+  current: MobileNativeChatPendingMessage[]
+): MobileNativeChatPendingMessage[] {
+  if (current.every((item) => item.baselineResolved)) {
+    return current
+  }
+  const baselineTailMessageId = messages.at(-1)?.id ?? null
+  const earlierByText = new Map<string, number>()
+  let earlierImageEchoes = 0
+  return current.map((item) => {
+    const normalized = normalizeReconcileText(item.text)
+    const earlier = normalized === '' ? earlierImageEchoes : (earlierByText.get(normalized) ?? 0)
+    if (normalized === '') {
+      earlierImageEchoes += item.images?.length ? 1 : 0
+    } else {
+      earlierByText.set(normalized, earlier + 1)
+    }
+    if (item.baselineResolved) {
+      return item
+    }
+    return {
+      ...item,
+      baselineTailMessageId,
+      baselineResolved: true,
+      // Ordinals stay relative to the queue: earlier still-pending sends of the
+      // same text claim the earlier rows, so this one waits for its own.
+      expectedOccurrence:
+        normalized === ''
+          ? earlier + 1
+          : countUserTextOccurrences(messages, normalized) + earlier + 1
+    }
+  })
+}

--- a/mobile/src/session/mobile-native-chat-pending-baseline.ts
+++ b/mobile/src/session/mobile-native-chat-pending-baseline.ts
@@ -1,27 +1,29 @@
 import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
-import {
-  countUserTextOccurrences,
-  normalizeReconcileText
-} from './mobile-native-chat-draft-reconcile'
+import { normalizeReconcileText } from './mobile-native-chat-draft-reconcile'
 import type { MobileNativeChatPendingMessage } from './mobile-native-chat-pending-echo'
 
 /**
- * Pin the sends issued while the transcript was still hydrating onto the first
- * authoritative read of this session's history.
+ * Give the sends issued before this session's history was known the boundary
+ * they never had, on the first authoritative read.
  *
- * Such a send has no usable baseline at capture time: `messages` was empty, or
- * still the previously active tab's, so both its tail and its occurrence count
- * describe somebody else's transcript. Rebasing them here — rather than marking
- * the send permanently untrustworthy, which stranded it as a queued bubble and
- * as a glue barrier for its neighbours for the rest of the session — leaves it
- * matching exactly the rows that arrive from now on.
+ * Such a send saw no transcript, so it has no row it can judge candidates
+ * against — which held it out of matching entirely, stranding it as a queued
+ * bubble and, worse, as a permanent glue barrier for its neighbours. Recovering
+ * the tail is all that is needed: the ordinal was already counted against an
+ * empty transcript, which is exactly right for "no history was known".
  *
- * Residual: if this read was taken AFTER the send already echoed — a re-subscribe
- * on tab switch or reconnect, when the first load never completed — its own echo
- * is counted as history and the bubble waits for a row that will not come. The
- * transport writes keystrokes into a TUI, so there is no client message id to
- * tell the two apart; the send is bounded instead by serializing submits per PTY
- * so the glue never forms.
+ * The ordinal is deliberately NOT recounted against this read. The read can
+ * already carry the send's own echo — a re-subscribe after a tab switch or a
+ * reconnect returns whatever exists now — and nothing local separates that echo
+ * from an identical older prompt: the transport writes keystrokes into a TUI and
+ * carries no message id, and row timestamps come from the host while the send
+ * time comes from the phone. Counting it as history puts the ordinal one past
+ * anything the transcript can supply, which strands the bubble for the rest of
+ * the session and stops its whole run from ever gluing.
+ *
+ * A caption-less image echo keeps its captured tail: it reconciles by counting
+ * image turns AFTER that tail, so pinning the tail past this read would throw
+ * away an echo the read already carries.
  */
 export function rebaseMobileNativeChatPendingBaselines(
   messages: readonly NativeChatMessage[],
@@ -31,29 +33,12 @@ export function rebaseMobileNativeChatPendingBaselines(
     return current
   }
   const baselineTailMessageId = messages.at(-1)?.id ?? null
-  const earlierByText = new Map<string, number>()
-  let earlierImageEchoes = 0
   return current.map((item) => {
-    const normalized = normalizeReconcileText(item.text)
-    const earlier = normalized === '' ? earlierImageEchoes : (earlierByText.get(normalized) ?? 0)
-    if (normalized === '') {
-      earlierImageEchoes += item.images?.length ? 1 : 0
-    } else {
-      earlierByText.set(normalized, earlier + 1)
-    }
     if (item.baselineResolved) {
       return item
     }
-    return {
-      ...item,
-      baselineTailMessageId,
-      baselineResolved: true,
-      // Ordinals stay relative to the queue: earlier still-pending sends of the
-      // same text claim the earlier rows, so this one waits for its own.
-      expectedOccurrence:
-        normalized === ''
-          ? earlier + 1
-          : countUserTextOccurrences(messages, normalized) + earlier + 1
-    }
+    return item.images?.length || normalizeReconcileText(item.text) === ''
+      ? { ...item, baselineResolved: true }
+      : { ...item, baselineResolved: true, baselineTailMessageId }
   })
 }

--- a/mobile/src/session/mobile-native-chat-pending-baseline.ts
+++ b/mobile/src/session/mobile-native-chat-pending-baseline.ts
@@ -3,29 +3,31 @@ import { normalizeReconcileText } from './mobile-native-chat-draft-reconcile'
 import type { MobileNativeChatPendingMessage } from './mobile-native-chat-pending-echo'
 
 /**
- * Give the sends issued before this session's history was known the boundary
- * they never had, on the first authoritative read.
+ * Give the sends that never saw a transcript the boundary they lack, on the
+ * first settled read.
  *
- * Such a send saw no transcript, so it has no row it can judge candidates
- * against — which held it out of matching entirely, stranding it as a queued
- * bubble and, worse, as a permanent glue barrier for its neighbours. Recovering
- * the tail is all that is needed: the ordinal was already counted against an
- * empty transcript, which is exactly right for "no history was known".
+ * Such a send has no row to judge candidates against — which held it out of
+ * matching entirely, stranding it as a queued bubble and, worse, as a permanent
+ * glue barrier for its neighbours.
  *
- * The ordinal is deliberately NOT recounted against this read. The read can
- * already carry the send's own echo — a re-subscribe after a tab switch or a
- * reconnect returns whatever exists now — and nothing local separates that echo
- * from an identical older prompt: the transport writes keystrokes into a TUI and
- * carries no message id, and row timestamps come from the host while the send
- * time comes from the phone. Counting it as history puts the ordinal one past
- * anything the transcript can supply, which strands the bubble for the rest of
- * the session and stops its whole run from ever gluing.
+ * Only a send that captured NO tail is pinned. An unsettled read still shows
+ * this session's own retained history (see `createNativeChatTranscriptRetention`
+ * — a reconnect or a failed read keeps the conversation on screen rather than
+ * blanking it), so a send made then already owns a correct boundary. Moving it
+ * onto this read would push it past the send's own echo and strand the bubble
+ * for good.
  *
- * A caption-less image echo keeps a captured tail it actually has: it reconciles
- * by counting image turns AFTER that tail, so moving the tail onto this read
- * would throw away an echo the read already carries. A null tail is not such a
- * boundary — it counts from the top of the transcript, so an old image turn can
- * claim the send and bind the user's fresh photo to it. Those get pinned too.
+ * The ordinal is deliberately NOT recounted. The read can already carry the
+ * send's own echo — a re-subscribe returns whatever exists now — and nothing
+ * local separates that echo from an identical older prompt: the transport writes
+ * keystrokes into a TUI and carries no message id, and row timestamps come from
+ * the host while the send time comes from the phone. Counting it as history puts
+ * the ordinal one past anything the transcript can supply.
+ *
+ * Which is why a CAPTIONED image echo is left alone entirely: it binds its
+ * preview by an ordinal counted over the whole transcript, so its tail and its
+ * ordinal have to describe the same read. Supplying one without the other leaves
+ * it matching nothing, forever. Everything else matches relative to its tail.
  */
 export function rebaseMobileNativeChatPendingBaselines(
   messages: readonly NativeChatMessage[],
@@ -39,8 +41,9 @@ export function rebaseMobileNativeChatPendingBaselines(
     if (item.baselineResolved) {
       return item
     }
-    const countsAfterItsOwnTail = item.images?.length || normalizeReconcileText(item.text) === ''
-    return countsAfterItsOwnTail && item.baselineTailMessageId !== null
+    const bindsByAbsoluteOrdinal =
+      Boolean(item.images?.length) && normalizeReconcileText(item.text) !== ''
+    return item.baselineTailMessageId !== null || bindsByAbsoluteOrdinal
       ? { ...item, baselineResolved: true }
       : { ...item, baselineResolved: true, baselineTailMessageId }
   })

--- a/mobile/src/session/mobile-native-chat-pending-baseline.ts
+++ b/mobile/src/session/mobile-native-chat-pending-baseline.ts
@@ -21,9 +21,11 @@ import type { MobileNativeChatPendingMessage } from './mobile-native-chat-pendin
  * anything the transcript can supply, which strands the bubble for the rest of
  * the session and stops its whole run from ever gluing.
  *
- * A caption-less image echo keeps its captured tail: it reconciles by counting
- * image turns AFTER that tail, so pinning the tail past this read would throw
- * away an echo the read already carries.
+ * A caption-less image echo keeps a captured tail it actually has: it reconciles
+ * by counting image turns AFTER that tail, so moving the tail onto this read
+ * would throw away an echo the read already carries. A null tail is not such a
+ * boundary — it counts from the top of the transcript, so an old image turn can
+ * claim the send and bind the user's fresh photo to it. Those get pinned too.
  */
 export function rebaseMobileNativeChatPendingBaselines(
   messages: readonly NativeChatMessage[],
@@ -37,7 +39,8 @@ export function rebaseMobileNativeChatPendingBaselines(
     if (item.baselineResolved) {
       return item
     }
-    return item.images?.length || normalizeReconcileText(item.text) === ''
+    const countsAfterItsOwnTail = item.images?.length || normalizeReconcileText(item.text) === ''
+    return countsAfterItsOwnTail && item.baselineTailMessageId !== null
       ? { ...item, baselineResolved: true }
       : { ...item, baselineResolved: true, baselineTailMessageId }
   })

--- a/mobile/src/session/mobile-native-chat-pending-baseline.ts
+++ b/mobile/src/session/mobile-native-chat-pending-baseline.ts
@@ -24,10 +24,13 @@ import type { MobileNativeChatPendingMessage } from './mobile-native-chat-pendin
  * the host while the send time comes from the phone. Counting it as history puts
  * the ordinal one past anything the transcript can supply.
  *
- * Which is why a CAPTIONED image echo is left alone entirely: it binds its
- * preview by an ordinal counted over the whole transcript, so its tail and its
- * ordinal have to describe the same read. Supplying one without the other leaves
- * it matching nothing, forever. Everything else matches relative to its tail.
+ * And only a TEXT-bearing send is given one. The glue matcher is the sole
+ * consumer that a supplied tail helps; every other one is harmed by it. An image
+ * echo reconciles by counting turns AFTER its tail, so a tail taken from a read
+ * that already carries its echo excludes that echo and the bubble can never
+ * retire — image entries have no other retirement path. A captioned one is worse
+ * still: it binds by an ordinal counted over the whole transcript, so a tail
+ * without a matching recount leaves it claiming nothing at all.
  */
 export function rebaseMobileNativeChatPendingBaselines(
   messages: readonly NativeChatMessage[],
@@ -41,9 +44,9 @@ export function rebaseMobileNativeChatPendingBaselines(
     if (item.baselineResolved) {
       return item
     }
-    const bindsByAbsoluteOrdinal =
-      Boolean(item.images?.length) && normalizeReconcileText(item.text) !== ''
-    return item.baselineTailMessageId !== null || bindsByAbsoluteOrdinal
+    const reconcilesAgainstItsOwnTail =
+      Boolean(item.images?.length) || normalizeReconcileText(item.text) === ''
+    return item.baselineTailMessageId !== null || reconcilesAgainstItsOwnTail
       ? { ...item, baselineResolved: true }
       : { ...item, baselineResolved: true, baselineTailMessageId }
   })

--- a/mobile/src/session/mobile-native-chat-pending-baseline.ts
+++ b/mobile/src/session/mobile-native-chat-pending-baseline.ts
@@ -15,6 +15,13 @@ import type { MobileNativeChatPendingMessage } from './mobile-native-chat-pendin
  * the send permanently untrustworthy, which stranded it as a queued bubble and
  * as a glue barrier for its neighbours for the rest of the session — leaves it
  * matching exactly the rows that arrive from now on.
+ *
+ * Residual: if this read was taken AFTER the send already echoed — a re-subscribe
+ * on tab switch or reconnect, when the first load never completed — its own echo
+ * is counted as history and the bubble waits for a row that will not come. The
+ * transport writes keystrokes into a TUI, so there is no client message id to
+ * tell the two apart; the send is bounded instead by serializing submits per PTY
+ * so the glue never forms.
  */
 export function rebaseMobileNativeChatPendingBaselines(
   messages: readonly NativeChatMessage[],

--- a/mobile/src/session/mobile-native-chat-pending-echo.ts
+++ b/mobile/src/session/mobile-native-chat-pending-echo.ts
@@ -5,6 +5,11 @@ export type MobileNativeChatPendingMessage = {
   /** Local preview URIs carried by the send for its optimistic echo. */
   images?: string[]
   baselineTailMessageId: string | null
+  /** Whether the transcript this baseline was captured from was already this
+   *  session's own history. A send issued mid-hydration is captured unresolved
+   *  and rebased onto the first authoritative read instead of reconciling
+   *  against rows that may belong to another tab. */
+  baselineResolved: boolean
 }
 
 export type MobileNativeChatSendOrigin = {
@@ -13,6 +18,7 @@ export type MobileNativeChatSendOrigin = {
   normalizedText: string
   baselineOccurrences: number
   baselineTailMessageId: string | null
+  baselineResolved: boolean
 }
 
 type PendingByKey = Record<string, MobileNativeChatPendingMessage[]>
@@ -56,6 +62,7 @@ export function appendMobileNativeChatPending(
             ? expectedImageEchoOrdinal
             : origin.baselineOccurrences + earlierOutstanding + 1,
         baselineTailMessageId: origin.baselineTailMessageId,
+        baselineResolved: origin.baselineResolved,
         ...(images?.length ? { images } : {})
       }
     ]

--- a/mobile/src/session/mobile-native-chat-pending-retirement.test.ts
+++ b/mobile/src/session/mobile-native-chat-pending-retirement.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
 import type { MobileNativeChatPendingMessage } from './mobile-native-chat-pending-echo'
 import {
-  MAX_GLUE_SPAN,
+  GLUE_SLIDE_BUDGET,
   retireLandedMobileNativeChatPending,
   selectGluedPendingIds
 } from './mobile-native-chat-pending-retirement'
@@ -201,6 +201,15 @@ describe('selectGluedPendingIds', () => {
     expect(retiredIds(messages, [stuckHead, ...pair])).toEqual(['p1', 'p2'])
   })
 
+  // Nothing bounds how many sends pile onto the agent's input line, so the
+  // slide's budget must never truncate a genuine glue.
+  it('retires a glued run far longer than the slide budget', () => {
+    const words = Array.from({ length: 12 }, (_, index) => `w${index}`)
+    const messages = [assistantTurn('m1', 'ready', 1000), userTurn('m2', words.join(' '), 5000)]
+    const pending = words.map((word, index) => pendingSend(`p${index}`, word, 'm1'))
+    expect(retiredIds(messages, pending)).toHaveLength(words.length)
+  })
+
   it('skips a caption-less image echo instead of gluing it', () => {
     const messages = [assistantTurn('m1', 'ready', 1000), userTurn('m2', 'one two', 5000)]
     const pending = [
@@ -229,8 +238,10 @@ describe('selectGluedPendingIds', () => {
   })
 
   // The cursor slides past a head that cannot match, so a turn may try several
-  // start positions — but each try is capped at MAX_GLUE_SPAN segments, which
-  // keeps the work linear in the run length rather than quadratic.
+  // start positions — but one inspection budget covers the whole slide, keeping
+  // the work linear in the run length rather than quadratic. The attempt already
+  // in flight is allowed to overshoot the remaining budget, deliberately: that is
+  // what guarantees a genuine long glue is never truncated.
   it('keeps segment inspection linear in the run length per transcript turn', () => {
     const pendingCount = 96
     const turnCount = 12
@@ -250,7 +261,7 @@ describe('selectGluedPendingIds', () => {
     } finally {
       startsWith.mockRestore()
     }
-    expect(segmentChecks).toBeLessThanOrEqual(turnCount * pendingCount * MAX_GLUE_SPAN)
+    expect(segmentChecks).toBeLessThanOrEqual(turnCount * (2 * pendingCount + GLUE_SLIDE_BUDGET))
   })
 })
 

--- a/mobile/src/session/mobile-native-chat-pending-retirement.test.ts
+++ b/mobile/src/session/mobile-native-chat-pending-retirement.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
+import type { MobileNativeChatPendingMessage } from './mobile-native-chat-pending-echo'
+import {
+  retireLandedMobileNativeChatPending,
+  selectGluedPendingIds
+} from './mobile-native-chat-pending-retirement'
+
+const NO_IMAGE_ECHOES: ReadonlySet<string> = new Set()
+
+function userTurn(id: string, text: string, timestamp: number): NativeChatMessage {
+  return { id, role: 'user', blocks: [{ type: 'text', text }], timestamp, source: 'transcript' }
+}
+
+function assistantTurn(id: string, text: string, timestamp: number): NativeChatMessage {
+  return {
+    id,
+    role: 'assistant',
+    blocks: [{ type: 'text', text }],
+    timestamp,
+    source: 'transcript'
+  }
+}
+
+/** A send captured with `tail` as the last transcript message it could see. */
+function pendingSend(
+  id: string,
+  text: string,
+  tail: string | null,
+  expectedOccurrence = 1,
+  baselineResolved = true
+): MobileNativeChatPendingMessage {
+  return { id, text, expectedOccurrence, baselineTailMessageId: tail, baselineResolved }
+}
+
+function retiredIds(
+  messages: readonly NativeChatMessage[],
+  pending: readonly MobileNativeChatPendingMessage[]
+): string[] {
+  return [...selectGluedPendingIds(messages, pending)].sort()
+}
+
+describe('selectGluedPendingIds', () => {
+  it('retires both bubbles when two rapid sends collapse into one user row', () => {
+    const messages = [
+      assistantTurn('m1', 'ready', 1000),
+      userTurn('m2', 'run the tests again', 5000)
+    ]
+    const pending = [pendingSend('p1', 'run the tests', 'm1'), pendingSend('p2', 'again', 'm1')]
+    expect(retiredIds(messages, pending)).toEqual(['p1', 'p2'])
+  })
+
+  it('retires a glued row that concatenated with no separator at all', () => {
+    const messages = [
+      assistantTurn('m1', 'ready', 1000),
+      userTurn('m2', 'run the testsagain', 5000)
+    ]
+    const pending = [pendingSend('p1', 'run the tests', 'm1'), pendingSend('p2', 'again', 'm1')]
+    expect(retiredIds(messages, pending)).toEqual(['p1', 'p2'])
+  })
+
+  it('retires three collapsed prompts in one row', () => {
+    const messages = [assistantTurn('m1', 'ready', 1000), userTurn('m2', 'one two three', 5000)]
+    const pending = [
+      pendingSend('p1', 'one', 'm1'),
+      pendingSend('p2', 'two', 'm1'),
+      pendingSend('p3', 'three', 'm1')
+    ]
+    expect(retiredIds(messages, pending)).toEqual(['p1', 'p2', 'p3'])
+  })
+
+  it('matches across tab, newline and repeated-space separators', () => {
+    const messages = [
+      assistantTurn('m1', 'ready', 1000),
+      userTurn('m2', 'run the tests\t\n  again', 5000)
+    ]
+    const pending = [
+      pendingSend('p1', ' run the tests\n', 'm1'),
+      pendingSend('p2', '\tagain ', 'm1')
+    ]
+    expect(retiredIds(messages, pending)).toEqual(['p1', 'p2'])
+  })
+
+  it('matches prompts that themselves contain the separator', () => {
+    const messages = [
+      assistantTurn('m1', 'ready', 1000),
+      userTurn('m2', 'fix the bug and run the tests', 5000)
+    ]
+    const pending = [
+      pendingSend('p1', 'fix the bug', 'm1'),
+      pendingSend('p2', 'and run the tests', 'm1')
+    ]
+    expect(retiredIds(messages, pending)).toEqual(['p1', 'p2'])
+  })
+
+  it('matches when one pending is a strict prefix of the next', () => {
+    const messages = [assistantTurn('m1', 'ready', 1000), userTurn('m2', 'run run the tests', 5000)]
+    const pending = [pendingSend('p1', 'run', 'm1'), pendingSend('p2', 'run the tests', 'm1')]
+    expect(retiredIds(messages, pending)).toEqual(['p1', 'p2'])
+  })
+
+  it('matches identical prompts sent twice and three times', () => {
+    const twice = [assistantTurn('m1', 'ready', 1000), userTurn('m2', 'hi hi', 5000)]
+    expect(
+      retiredIds(twice, [pendingSend('p1', 'hi', 'm1', 1), pendingSend('p2', 'hi', 'm1', 2)])
+    ).toEqual(['p1', 'p2'])
+
+    const thrice = [assistantTurn('m1', 'ready', 1000), userTurn('m2', 'hi hi hi', 5000)]
+    expect(
+      retiredIds(thrice, [
+        pendingSend('p1', 'hi', 'm1', 1),
+        pendingSend('p2', 'hi', 'm1', 2),
+        pendingSend('p3', 'hi', 'm1', 3)
+      ])
+    ).toEqual(['p1', 'p2', 'p3'])
+  })
+
+  it('retires two separate glued rows against their own runs', () => {
+    const messages = [
+      assistantTurn('m1', 'ready', 1000),
+      userTurn('m2', 'one two', 5000),
+      userTurn('m3', 'three four', 6000)
+    ]
+    const pending = [
+      pendingSend('p1', 'one', 'm1'),
+      pendingSend('p2', 'two', 'm1'),
+      pendingSend('p3', 'three', 'm2'),
+      pendingSend('p4', 'four', 'm2')
+    ]
+    expect(retiredIds(messages, pending)).toEqual(['p1', 'p2', 'p3', 'p4'])
+  })
+
+  // FP1: the concatenation already exists in history, older than the sends.
+  it('never lets a transcript row that predates the sends retire them', () => {
+    const messages = [
+      userTurn('m1', 'run the tests again', 1),
+      assistantTurn('m2', 'done', 2),
+      assistantTurn('m3', 'anything else?', 3)
+    ]
+    const pending = [pendingSend('p1', 'run the tests', 'm3'), pendingSend('p2', 'again', 'm3')]
+    expect(retiredIds(messages, pending)).toEqual([])
+  })
+
+  // FP2: an old turn reads like the concatenation of two much later sends.
+  it('never lets an older turn retire sends captured after it', () => {
+    const messages = [userTurn('m1', 'fix the bug', 1000), assistantTurn('m2', 'fixed', 1100)]
+    const pending = [pendingSend('p1', 'fix the', 'm2'), pendingSend('p2', 'bug', 'm2')]
+    expect(retiredIds(messages, pending)).toEqual([])
+  })
+
+  it('rejects a row the pending run only prefixes', () => {
+    const messages = [
+      assistantTurn('m1', 'ready', 1000),
+      userTurn('m2', 'run the tests again with coverage', 5000)
+    ]
+    const pending = [pendingSend('p1', 'run the tests', 'm1'), pendingSend('p2', 'again', 'm1')]
+    expect(retiredIds(messages, pending)).toEqual([])
+  })
+
+  it('rejects a run that only partly spells the row', () => {
+    const messages = [assistantTurn('m1', 'ready', 1000), userTurn('m2', 'run the tests', 5000)]
+    const pending = [pendingSend('p1', 'run the tests', 'm1'), pendingSend('p2', 'again', 'm1')]
+    // A lone exact match is an ordinary landing, not glue.
+    expect(retiredIds(messages, pending)).toEqual([])
+  })
+
+  it('rejects glue when a send in the run cannot resolve its own tail', () => {
+    const messages = [assistantTurn('m1', 'ready', 1000), userTurn('m2', 'one two', 5000)]
+    const pending = [pendingSend('p1', 'one', 'm1'), pendingSend('p2', 'two', 'paginated-away')]
+    expect(retiredIds(messages, pending)).toEqual([])
+  })
+
+  it('treats a null tail as "transcript was empty", so any row can glue', () => {
+    const messages = [userTurn('m1', 'one two', 5000)]
+    const pending = [pendingSend('p1', 'one', null), pendingSend('p2', 'two', null)]
+    expect(retiredIds(messages, pending)).toEqual(['p1', 'p2'])
+  })
+
+  // Unresolved baselines are held out of matching until the drafts hook rebases
+  // them onto the first authoritative read — see mobile-native-chat-pending-baseline.
+  it('holds out sends whose baseline has not been rebased onto a real transcript', () => {
+    const messages = [userTurn('m1', 'one two', 1000)]
+    const pending = [
+      pendingSend('p1', 'one', null, 1, false),
+      pendingSend('p2', 'two', null, 1, false)
+    ]
+    expect(retiredIds(messages, pending)).toEqual([])
+  })
+
+  it('skips a caption-less image echo instead of gluing it', () => {
+    const messages = [assistantTurn('m1', 'ready', 1000), userTurn('m2', 'one two', 5000)]
+    const pending = [
+      pendingSend('p1', '', 'm1'),
+      pendingSend('p2', 'one', 'm1'),
+      pendingSend('p3', 'two', 'm1')
+    ]
+    expect(retiredIds(messages, pending)).toEqual(['p2', 'p3'])
+  })
+
+  it('keeps a captioned image echo and its neighbors until the preview is rebound', () => {
+    const messages = [assistantTurn('m1', 'ready', 1000), userTurn('m2', 'one two', 5000)]
+    const pending = [
+      { ...pendingSend('p1', 'one', 'm1'), images: ['file:///a.png'] },
+      pendingSend('p2', 'two', 'm1')
+    ]
+    expect(retiredIds(messages, pending)).toEqual([])
+    expect(
+      retireLandedMobileNativeChatPending(messages, pending, NO_IMAGE_ECHOES).map((item) => item.id)
+    ).toEqual(['p1', 'p2'])
+  })
+
+  it('does nothing for a single pending send', () => {
+    const messages = [assistantTurn('m1', 'ready', 1000), userTurn('m2', 'one two', 5000)]
+    expect(retiredIds(messages, [pendingSend('p1', 'one', 'm1')])).toEqual([])
+  })
+
+  it('inspects each pending segment at most once per transcript turn', () => {
+    const pendingCount = 96
+    const turnCount = 12
+    const text = `${'a '.repeat(pendingCount)}x`
+    const messages = [
+      assistantTurn('tail', 'ready', 1000),
+      ...Array.from({ length: turnCount }, (_, index) => userTurn(`m${index}`, text, 2000 + index))
+    ]
+    const pending = Array.from({ length: pendingCount }, (_, index) =>
+      pendingSend(`p${index}`, 'a', 'tail', index + 1)
+    )
+    const startsWith = vi.spyOn(String.prototype, 'startsWith')
+    let segmentChecks = 0
+    try {
+      expect(retiredIds(messages, pending)).toEqual([])
+      segmentChecks = startsWith.mock.calls.length
+    } finally {
+      startsWith.mockRestore()
+    }
+    expect(segmentChecks).toBeLessThanOrEqual(turnCount * pendingCount)
+  })
+})
+
+describe('retireLandedMobileNativeChatPending', () => {
+  it('retires exact landings by ordinal and glued rows in the same pass', () => {
+    const messages = [
+      assistantTurn('m1', 'ready', 1000),
+      userTurn('m2', 'standalone', 4000),
+      userTurn('m3', 'run the tests again', 5000)
+    ]
+    const pending = [
+      pendingSend('p0', 'standalone', 'm1'),
+      pendingSend('p1', 'run the tests', 'm2'),
+      pendingSend('p2', 'again', 'm2')
+    ]
+    expect(retireLandedMobileNativeChatPending(messages, pending, NO_IMAGE_ECHOES)).toEqual([])
+  })
+
+  it('keeps sends whose glue candidate predates them', () => {
+    const messages = [userTurn('m1', 'fix the bug', 1000), assistantTurn('m2', 'fixed', 1100)]
+    const pending = [pendingSend('p1', 'fix the', 'm2'), pendingSend('p2', 'bug', 'm2')]
+    expect(
+      retireLandedMobileNativeChatPending(messages, pending, NO_IMAGE_ECHOES).map((item) => item.id)
+    ).toEqual(['p1', 'p2'])
+  })
+
+  it('does not glue former neighbors across an exact-landed send', () => {
+    const messages = [
+      assistantTurn('m0', 'ready', 1000),
+      userTurn('m1', 'middle', 2000),
+      userTurn('m2', 'one two', 3000)
+    ]
+    const pending = [
+      pendingSend('p1', 'one', 'm0'),
+      pendingSend('p2', 'middle', 'm0'),
+      pendingSend('p3', 'two', 'm0')
+    ]
+    expect(
+      retireLandedMobileNativeChatPending(messages, pending, NO_IMAGE_ECHOES).map((item) => item.id)
+    ).toEqual(['p1', 'p3'])
+  })
+
+  it('keeps image echoes until their preview is rebound', () => {
+    const messages = [assistantTurn('m1', 'ready', 1000)]
+    const pending = [{ ...pendingSend('p1', 'photo', 'm1'), images: ['file:///a.png'] }]
+    expect(
+      retireLandedMobileNativeChatPending(messages, pending, NO_IMAGE_ECHOES).map((item) => item.id)
+    ).toEqual(['p1'])
+    expect(retireLandedMobileNativeChatPending(messages, pending, new Set(['p1']))).toEqual([])
+  })
+})

--- a/mobile/src/session/mobile-native-chat-pending-retirement.test.ts
+++ b/mobile/src/session/mobile-native-chat-pending-retirement.test.ts
@@ -252,6 +252,14 @@ describe('retireLandedMobileNativeChatPending', () => {
     expect(retireLandedMobileNativeChatPending(messages, pending, NO_IMAGE_ECHOES)).toEqual([])
   })
 
+  // The drafts effect early-outs on `next === current`; a fresh array on the
+  // no-op path would re-enter it on every transcript frame.
+  it('returns the input array itself when nothing retires', () => {
+    const messages = [assistantTurn('m1', 'ready', 1000)]
+    const pending = [pendingSend('p1', 'one', 'm1'), pendingSend('p2', 'two', 'm1')]
+    expect(retireLandedMobileNativeChatPending(messages, pending, NO_IMAGE_ECHOES)).toBe(pending)
+  })
+
   it('keeps sends whose glue candidate predates them', () => {
     const messages = [userTurn('m1', 'fix the bug', 1000), assistantTurn('m2', 'fixed', 1100)]
     const pending = [pendingSend('p1', 'fix the', 'm2'), pendingSend('p2', 'bug', 'm2')]

--- a/mobile/src/session/mobile-native-chat-pending-retirement.test.ts
+++ b/mobile/src/session/mobile-native-chat-pending-retirement.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
 import type { MobileNativeChatPendingMessage } from './mobile-native-chat-pending-echo'
 import {
+  MAX_GLUE_SPAN,
   retireLandedMobileNativeChatPending,
   selectGluedPendingIds
 } from './mobile-native-chat-pending-retirement'
@@ -187,6 +188,19 @@ describe('selectGluedPendingIds', () => {
     expect(retiredIds(messages, pending)).toEqual([])
   })
 
+  // A head that can never match must not freeze the run behind it: one stuck
+  // bubble would otherwise disable glue retirement for the rest of the session.
+  it('glues a later pair even when the head of the run can never match', () => {
+    const messages = [
+      userTurn('m0', 'unrelated', 1000),
+      userTurn('m1', 'fix the bug', 5000),
+      userTurn('m2', 'ship the fix', 6000)
+    ]
+    const stuckHead = pendingSend('p0', 'bug', 'm0')
+    const pair = [pendingSend('p1', 'ship the', 'm0'), pendingSend('p2', 'fix', 'm0')]
+    expect(retiredIds(messages, [stuckHead, ...pair])).toEqual(['p1', 'p2'])
+  })
+
   it('skips a caption-less image echo instead of gluing it', () => {
     const messages = [assistantTurn('m1', 'ready', 1000), userTurn('m2', 'one two', 5000)]
     const pending = [
@@ -214,7 +228,10 @@ describe('selectGluedPendingIds', () => {
     expect(retiredIds(messages, [pendingSend('p1', 'one', 'm1')])).toEqual([])
   })
 
-  it('inspects each pending segment at most once per transcript turn', () => {
+  // The cursor slides past a head that cannot match, so a turn may try several
+  // start positions — but each try is capped at MAX_GLUE_SPAN segments, which
+  // keeps the work linear in the run length rather than quadratic.
+  it('keeps segment inspection linear in the run length per transcript turn', () => {
     const pendingCount = 96
     const turnCount = 12
     const text = `${'a '.repeat(pendingCount)}x`
@@ -233,7 +250,7 @@ describe('selectGluedPendingIds', () => {
     } finally {
       startsWith.mockRestore()
     }
-    expect(segmentChecks).toBeLessThanOrEqual(turnCount * pendingCount)
+    expect(segmentChecks).toBeLessThanOrEqual(turnCount * pendingCount * MAX_GLUE_SPAN)
   })
 })
 

--- a/mobile/src/session/mobile-native-chat-pending-retirement.ts
+++ b/mobile/src/session/mobile-native-chat-pending-retirement.ts
@@ -1,0 +1,148 @@
+import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
+import {
+  countImageSourceTurnsAfter,
+  normalizeReconcileText,
+  normalizedUserText
+} from './mobile-native-chat-draft-reconcile'
+import type { MobileNativeChatPendingMessage } from './mobile-native-chat-pending-echo'
+
+const SPACE = ' '
+const NO_PENDING_IDS: ReadonlySet<string> = new Set()
+
+type UserTurn = { index: number; text: string }
+type GlueSegment = { text: string; tail: number } | null
+
+/** Pending ids represented by post-send transcript rows that glued adjacent sends. */
+export function selectGluedPendingIds(
+  messages: readonly NativeChatMessage[],
+  pending: readonly MobileNativeChatPendingMessage[],
+  excludedPendingIds: ReadonlySet<string> = NO_PENDING_IDS
+): ReadonlySet<string> {
+  const retired = new Set<string>()
+  if (pending.length < 2) {
+    return retired
+  }
+  const messageIndexById = new Map<string, number>()
+  const turns: UserTurn[] = []
+  for (const [index, message] of messages.entries()) {
+    messageIndexById.set(message.id, index)
+    const text = normalizedUserText(message)
+    if (text) {
+      turns.push({ index, text })
+    }
+  }
+  const segments: GlueSegment[] = pending.map((item) => {
+    const text = normalizeReconcileText(item.text)
+    const tail =
+      item.baselineTailMessageId === null
+        ? -1
+        : (messageIndexById.get(item.baselineTailMessageId) ?? null)
+    return excludedPendingIds.has(item.id) ||
+      !item.baselineResolved ||
+      item.images?.length ||
+      text === '' ||
+      tail === null
+      ? null
+      : { text, tail }
+  })
+
+  // Barriers preserve original adjacency after exact landings retire.
+  let runStart = 0
+  while (runStart < pending.length) {
+    while (runStart < pending.length && segments[runStart] === null) {
+      runStart += 1
+    }
+    let runEnd = runStart
+    while (runEnd < pending.length && segments[runEnd] !== null) {
+      runEnd += 1
+    }
+    let cursor = runStart
+    for (const turn of turns) {
+      if (cursor >= runEnd - 1) {
+        break
+      }
+      const matched = matchGluedRun(turn, segments, cursor, runEnd)
+      if (matched === 0) {
+        continue
+      }
+      for (let index = cursor; index < cursor + matched; index++) {
+        retired.add(pending[index]!.id)
+      }
+      cursor += matched
+    }
+    runStart = runEnd + 1
+  }
+  return retired
+}
+
+/** Length of the exact glued run at `start`, or zero. */
+function matchGluedRun(
+  turn: UserTurn,
+  segments: readonly GlueSegment[],
+  start: number,
+  end: number
+): number {
+  let at = 0
+  let matched = 0
+  for (let index = start; index < end; index++) {
+    const segment = segments[index]!
+    // Every send carries its OWN boundary: a row that already existed when this
+    // send was issued can never be part of its echo, however well it reads.
+    if (turn.index <= segment.tail) {
+      return 0
+    }
+    if (at > 0 && turn.text[at] === SPACE) {
+      at += 1
+    }
+    if (!turn.text.startsWith(segment.text, at)) {
+      return 0
+    }
+    at += segment.text.length
+    matched += 1
+    if (at === turn.text.length) {
+      // A lone exact match is an ordinary landing, which the count pass owns.
+      return matched > 1 ? matched : 0
+    }
+  }
+  return 0
+}
+
+/** Retires exact and glued transcript landings while preserving pending order. */
+export function retireLandedMobileNativeChatPending(
+  messages: readonly NativeChatMessage[],
+  current: MobileNativeChatPendingMessage[],
+  landedImagePendingIds: ReadonlySet<string>
+): MobileNativeChatPendingMessage[] {
+  const landedCounts = new Map<string, number>()
+  for (const message of messages) {
+    const text = normalizedUserText(message)
+    if (text) {
+      landedCounts.set(text, (landedCounts.get(text) ?? 0) + 1)
+    }
+  }
+  const landedPendingIds = new Set<string>()
+  for (const item of current) {
+    if (landedImagePendingIds.has(item.id)) {
+      landedPendingIds.add(item.id)
+      continue
+    }
+    // Keep image echoes until their local preview reaches the authoritative message.
+    // An unresolved baseline has nothing to count against yet — `messages` is not
+    // known to be the transcript this send was issued into.
+    if (item.images?.length || !item.baselineResolved) {
+      continue
+    }
+    const landed =
+      item.text.trim() === ''
+        ? countImageSourceTurnsAfter(messages, item.baselineTailMessageId) >=
+          item.expectedOccurrence
+        : (landedCounts.get(normalizeReconcileText(item.text)) ?? 0) >= item.expectedOccurrence
+    if (landed) {
+      landedPendingIds.add(item.id)
+    }
+  }
+  const glued = selectGluedPendingIds(messages, current, landedPendingIds)
+  return landedPendingIds.size === 0 && glued.size === 0
+    ? current
+    : current.filter((item) => !landedPendingIds.has(item.id) && !glued.has(item.id))
+}

--- a/mobile/src/session/mobile-native-chat-pending-retirement.ts
+++ b/mobile/src/session/mobile-native-chat-pending-retirement.ts
@@ -8,6 +8,10 @@ import type { MobileNativeChatPendingMessage } from './mobile-native-chat-pendin
 
 const SPACE = ' '
 const NO_PENDING_IDS: ReadonlySet<string> = new Set()
+// The host shares one input line, not an unbounded one: real glue is two or
+// three sends. Capping the span keeps the cursor slide below linear-per-turn
+// instead of quadratic when a long run of identical sends is outstanding.
+export const MAX_GLUE_SPAN = 8
 
 type UserTurn = { index: number; text: string }
 type GlueSegment = { text: string; tail: number } | null
@@ -61,14 +65,27 @@ export function selectGluedPendingIds(
       if (cursor >= runEnd - 1) {
         break
       }
-      const matched = matchGluedRun(turn, segments, cursor, runEnd)
+      // A send that can never match must not freeze the run behind it. One
+      // permanently unretirable head — a pair whose own glued row arrived with
+      // the read, or a send the count pass claimed against an older row — would
+      // otherwise disable glue retirement for every later pair, for the rest of
+      // the session. Slide past it; the cursor stays monotonic, so a later turn
+      // can never claim a send an earlier one already took.
+      let start = cursor
+      let matched = 0
+      for (; start <= runEnd - 2; start++) {
+        matched = matchGluedRun(turn, segments, start, runEnd)
+        if (matched > 0) {
+          break
+        }
+      }
       if (matched === 0) {
         continue
       }
-      for (let index = cursor; index < cursor + matched; index++) {
+      for (let index = start; index < start + matched; index++) {
         retired.add(pending[index]!.id)
       }
-      cursor += matched
+      cursor = start + matched
     }
     runStart = runEnd + 1
   }
@@ -84,7 +101,8 @@ function matchGluedRun(
 ): number {
   let at = 0
   let matched = 0
-  for (let index = start; index < end; index++) {
+  const limit = Math.min(end, start + MAX_GLUE_SPAN)
+  for (let index = start; index < limit; index++) {
     const segment = segments[index]!
     // Every send carries its OWN boundary: a row that already existed when this
     // send was issued can never be part of its echo, however well it reads.

--- a/mobile/src/session/mobile-native-chat-pending-retirement.ts
+++ b/mobile/src/session/mobile-native-chat-pending-retirement.ts
@@ -8,10 +8,13 @@ import type { MobileNativeChatPendingMessage } from './mobile-native-chat-pendin
 
 const SPACE = ' '
 const NO_PENDING_IDS: ReadonlySet<string> = new Set()
-// The host shares one input line, not an unbounded one: real glue is two or
-// three sends. Capping the span keeps the cursor slide below linear-per-turn
-// instead of quadratic when a long run of identical sends is outstanding.
-export const MAX_GLUE_SPAN = 8
+// Slack the cursor slide may spend re-trying later start positions, on top of
+// one free pass over the run. Nothing bounds how many sends accumulate on the
+// agent's input line — that ends when the agent accepts input again — so the
+// budget must never truncate a genuine glue: the first attempt covers the whole
+// run and always fits. It only stops a run of identical prefix-matching sends
+// from making the scan quadratic.
+export const GLUE_SLIDE_BUDGET = 8
 
 type UserTurn = { index: number; text: string }
 type GlueSegment = { text: string; tail: number } | null
@@ -71,10 +74,13 @@ export function selectGluedPendingIds(
       // otherwise disable glue retirement for every later pair, for the rest of
       // the session. Slide past it; the cursor stays monotonic, so a later turn
       // can never claim a send an earlier one already took.
+      let budget = runEnd - runStart + GLUE_SLIDE_BUDGET
       let start = cursor
       let matched = 0
-      for (; start <= runEnd - 2; start++) {
-        matched = matchGluedRun(turn, segments, start, runEnd)
+      for (; start <= runEnd - 2 && budget > 0; start++) {
+        const attempt = matchGluedRun(turn, segments, start, runEnd)
+        budget -= attempt.inspected
+        matched = attempt.matched
         if (matched > 0) {
           break
         }
@@ -92,37 +98,38 @@ export function selectGluedPendingIds(
   return retired
 }
 
-/** Length of the exact glued run at `start`, or zero. */
+/** Length of the exact glued run at `start`, plus the segments it had to read. */
 function matchGluedRun(
   turn: UserTurn,
   segments: readonly GlueSegment[],
   start: number,
   end: number
-): number {
+): { matched: number; inspected: number } {
   let at = 0
   let matched = 0
-  const limit = Math.min(end, start + MAX_GLUE_SPAN)
-  for (let index = start; index < limit; index++) {
+  let inspected = 0
+  for (let index = start; index < end; index++) {
     const segment = segments[index]!
+    inspected += 1
     // Every send carries its OWN boundary: a row that already existed when this
     // send was issued can never be part of its echo, however well it reads.
     if (turn.index <= segment.tail) {
-      return 0
+      return { matched: 0, inspected }
     }
     if (at > 0 && turn.text[at] === SPACE) {
       at += 1
     }
     if (!turn.text.startsWith(segment.text, at)) {
-      return 0
+      return { matched: 0, inspected }
     }
     at += segment.text.length
     matched += 1
     if (at === turn.text.length) {
       // A lone exact match is an ordinary landing, which the count pass owns.
-      return matched > 1 ? matched : 0
+      return { matched: matched > 1 ? matched : 0, inspected }
     }
   }
-  return 0
+  return { matched: 0, inspected }
 }
 
 /** Retires exact and glued transcript landings while preserving pending order. */

--- a/mobile/src/session/use-mobile-native-chat-controller.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-controller.test.ts
@@ -96,7 +96,8 @@ const ORIGIN = {
   pendingKey: 'h\0w\0tab-1\0session-1',
   normalizedText: 'look',
   baselineOccurrences: 0,
-  baselineTailMessageId: null
+  baselineTailMessageId: null,
+  baselineResolved: true
 }
 
 describe('useMobileNativeChatController handleNativeChatSend', () => {

--- a/mobile/src/session/use-mobile-native-chat-controller.ts
+++ b/mobile/src/session/use-mobile-native-chat-controller.ts
@@ -111,7 +111,8 @@ export function useMobileNativeChatController(args: {
     // a null is indistinguishable from a host retraction, and peeking at the
     // terminal view would permanently decline the prefill.
     chatActive: showNativeChat,
-    transcriptLoading: nativeChatSession.transcriptLoading
+    transcriptLoading: nativeChatSession.transcriptLoading,
+    transcriptSettled: nativeChatSession.status === 'ready'
   })
 
   const nativeChatStatus = activeChatResolution ? activeSessionTab?.agentStatus : null

--- a/mobile/src/session/use-mobile-native-chat-drafts-glued-pending.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-drafts-glued-pending.test.ts
@@ -25,6 +25,16 @@ function assistantTurn(id: string, text: string, timestamp: number): NativeChatM
   }
 }
 
+function imageTurn(id: string, path: string, timestamp: number): NativeChatMessage {
+  return {
+    id,
+    role: 'user',
+    blocks: [{ type: 'text', text: `[Image: source: ${path}]` }],
+    timestamp,
+    source: 'transcript'
+  }
+}
+
 /** Texts of the optimistic bubbles the chat list actually renders. */
 function renderedPendingTexts(
   messages: NativeChatMessage[],
@@ -297,6 +307,23 @@ describe('useMobileNativeChatDrafts glued pending sends', () => {
       await update(olderIdentical)
       expect(pendingTexts()).toEqual(['fix the', 'bug'])
       expect(renderedPendingTexts(olderIdentical, state)).toEqual(['fix the', 'bug'])
+    })
+
+    // The preview pass runs before the rebase, so an entry with no boundary
+    // would bind the user's fresh photo to whatever image turn the read carries.
+    it('does not bind a photo sent before the read to an image turn already in it', async () => {
+      await mount([], false, false)
+      act(() => {
+        const origin = state?.captureSendOrigin('')
+        if (origin) {
+          state?.acceptSend(origin, '', ['file:///new.png'])
+        }
+      })
+
+      const olderImage = [imageTurn('m1', '/old/photo.png', 1000)]
+      await update(olderImage)
+      expect(state?.imagePreviewsByMessageId).toEqual({})
+      expect(state?.pending.map((item) => item.images)).toEqual([['file:///new.png']])
     })
 
     it('still retires them once their own glued row lands', async () => {

--- a/mobile/src/session/use-mobile-native-chat-drafts-glued-pending.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-drafts-glued-pending.test.ts
@@ -260,6 +260,23 @@ describe('useMobileNativeChatDrafts glued pending sends', () => {
       await update([...afterReconnect, assistantTurn('m3', 'all green', 6000)])
       expect(state?.pending).toEqual([])
     })
+
+    // A send held here would sit as a live segment at the head of its run, so
+    // the cursor could never reach a later pair — the stuck bubble would take
+    // the whole feature down with it for the rest of the session.
+    it('leaves a later pair able to glue after the late read resolved the first send', async () => {
+      await mount([], true)
+      act(() => send('run the tests'))
+      const afterReconnect = [userTurn('m1', 'run the tests', 5000)]
+      await update(afterReconnect)
+      expect(state?.pending).toEqual([])
+
+      rapidSend('fix the', 'bug')
+      const glued = [...afterReconnect, userTurn('m2', 'fix the bug', 6000)]
+      await update(glued)
+      expect(state?.pending).toEqual([])
+      expect(renderedPendingTexts(glued, state)).toEqual([])
+    })
   })
 
   // A read that failed is not a boundary: `messages` is empty because the history

--- a/mobile/src/session/use-mobile-native-chat-drafts-glued-pending.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-drafts-glued-pending.test.ts
@@ -52,10 +52,12 @@ describe('useMobileNativeChatDrafts glued pending sends', () => {
 
   function Harness({
     messages,
-    transcriptLoading = false
+    transcriptLoading = false,
+    transcriptSettled = !transcriptLoading
   }: {
     messages: NativeChatMessage[]
     transcriptLoading?: boolean
+    transcriptSettled?: boolean
   }): null {
     state = useMobileNativeChatDrafts({
       hostId: 'host',
@@ -63,19 +65,30 @@ describe('useMobileNativeChatDrafts glued pending sends', () => {
       tabId: 'tab',
       sessionId: 'session',
       messages,
-      transcriptLoading
+      transcriptLoading,
+      transcriptSettled
     })
     return null
   }
 
-  async function mount(messages: NativeChatMessage[], transcriptLoading = false): Promise<void> {
+  async function mount(
+    messages: NativeChatMessage[],
+    transcriptLoading = false,
+    transcriptSettled = !transcriptLoading
+  ): Promise<void> {
     await act(async () => {
-      renderer = create(createElement(Harness, { messages, transcriptLoading }))
+      renderer = create(createElement(Harness, { messages, transcriptLoading, transcriptSettled }))
     })
   }
 
-  async function update(messages: NativeChatMessage[], transcriptLoading = false): Promise<void> {
-    await act(async () => renderer?.update(createElement(Harness, { messages, transcriptLoading })))
+  async function update(
+    messages: NativeChatMessage[],
+    transcriptLoading = false,
+    transcriptSettled = !transcriptLoading
+  ): Promise<void> {
+    await act(async () =>
+      renderer?.update(createElement(Harness, { messages, transcriptLoading, transcriptSettled }))
+    )
   }
 
   function send(text: string): void {
@@ -213,17 +226,71 @@ describe('useMobileNativeChatDrafts glued pending sends', () => {
       expect(state?.pending).toEqual([])
     })
 
-    it('does not retire a hydration-time send against history it never saw', async () => {
+    // The read that resolves a hydration-time send can already contain that
+    // send's own echo — a re-subscribe returns whatever exists now — and nothing
+    // local tells that echo from an identical older prompt. Claiming the row is
+    // the safe direction: being wrong costs one round trip of invisibility,
+    // while holding costs a queued bubble that never clears and a run that can
+    // never glue again.
+    it('retires a hydration-time send whose echo arrives with the read', async () => {
       await mount([], true)
       act(() => send('run the tests'))
 
-      // The read lands carrying an older identical prompt: not this send's echo.
+      const echoed = [userTurn('m1', 'run the tests', 1000), assistantTurn('m2', 'passed', 1100)]
+      await update(echoed)
+      expect(state?.pending).toEqual([])
+    })
+
+    // The same read seen one reconnect later: the send left, the agent echoed it,
+    // and only then did the first authoritative read land.
+    it('retires a hydration-time send after a reconnect delivered the read late', async () => {
+      await mount([], true)
+      act(() => send('run the tests'))
+      // Still loading: the first read never arrived before the drop.
+      await update([], true)
+
+      const afterReconnect = [
+        userTurn('m1', 'run the tests', 5000),
+        assistantTurn('m2', 'ok', 5100)
+      ]
+      await update(afterReconnect)
+      expect(state?.pending).toEqual([])
+
+      // Nothing later resurrects it, and the run stays glue-capable.
+      await update([...afterReconnect, assistantTurn('m3', 'all green', 6000)])
+      expect(state?.pending).toEqual([])
+    })
+  })
+
+  // A read that failed is not a boundary: `messages` is empty because the history
+  // is unknown, not because the conversation is. Without that distinction the
+  // empty list reads as "the transcript was empty", and any row the successful
+  // read finally brings can claim these sends.
+  describe('sends issued before any read settled', () => {
+    it('keeps both bubbles when the late read carries only an older glue-alike', async () => {
+      await mount([], false, false)
+      rapidSend('fix the', 'bug')
+
       const olderIdentical = [
-        userTurn('m1', 'run the tests', 1000),
-        assistantTurn('m2', 'passed', 1100)
+        userTurn('m1', 'fix the bug', 1000),
+        assistantTurn('m2', 'fixed', 1100)
       ]
       await update(olderIdentical)
-      expect(pendingTexts()).toEqual(['run the tests'])
+      expect(pendingTexts()).toEqual(['fix the', 'bug'])
+      expect(renderedPendingTexts(olderIdentical, state)).toEqual(['fix the', 'bug'])
+    })
+
+    it('still retires them once their own glued row lands', async () => {
+      await mount([], false, false)
+      rapidSend('fix the', 'bug')
+      const olderIdentical = [
+        userTurn('m1', 'fix the bug', 1000),
+        assistantTurn('m2', 'fixed', 1100)
+      ]
+      await update(olderIdentical)
+
+      await update([...olderIdentical, userTurn('m3', 'fix the bug', 5000)])
+      expect(state?.pending).toEqual([])
     })
   })
 })

--- a/mobile/src/session/use-mobile-native-chat-drafts-glued-pending.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-drafts-glued-pending.test.ts
@@ -273,6 +273,22 @@ describe('useMobileNativeChatDrafts glued pending sends', () => {
       expect(state?.pending).toEqual([])
     })
 
+    // A reconnect leaves this session's own retained history on screen, so sends
+    // made across it own a real boundary already. Moving it onto the read that
+    // follows would push it past their own glued row and strand both bubbles.
+    it('retires a pair sent across a reconnect whose glued row arrives with the read', async () => {
+      const retained = [userTurn('m1', 'earlier prompt', 1000), assistantTurn('m2', 'sure', 1100)]
+      await mount(retained)
+      // The read drops; the retained history stays visible and is still ours.
+      await update(retained, true)
+      rapidSend('run the tests', 'again')
+
+      const settled = [...retained, userTurn('m3', 'run the tests again', 5000)]
+      await update(settled)
+      expect(state?.pending).toEqual([])
+      expect(renderedPendingTexts(settled, state)).toEqual([])
+    })
+
     // A send held here would sit as a live segment at the head of its run, so
     // the cursor could never reach a later pair — the stuck bubble would take
     // the whole feature down with it for the rest of the session.

--- a/mobile/src/session/use-mobile-native-chat-drafts-glued-pending.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-drafts-glued-pending.test.ts
@@ -1,0 +1,229 @@
+import { createElement } from 'react'
+import { act, create } from 'react-test-renderer'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
+import { buildMobileNativeChatTransientData } from './mobile-native-chat-render-data'
+import { useMobileNativeChatDrafts } from './use-mobile-native-chat-drafts'
+
+type DraftState = ReturnType<typeof useMobileNativeChatDrafts>
+type TestRenderer = {
+  unmount(): void
+  update(element: ReturnType<typeof createElement>): void
+}
+
+function userTurn(id: string, text: string, timestamp: number): NativeChatMessage {
+  return { id, role: 'user', blocks: [{ type: 'text', text }], timestamp, source: 'transcript' }
+}
+
+function assistantTurn(id: string, text: string, timestamp: number): NativeChatMessage {
+  return {
+    id,
+    role: 'assistant',
+    blocks: [{ type: 'text', text }],
+    timestamp,
+    source: 'transcript'
+  }
+}
+
+/** Texts of the optimistic bubbles the chat list actually renders. */
+function renderedPendingTexts(
+  messages: NativeChatMessage[],
+  state: DraftState | null
+): (string | undefined)[] {
+  const { data } = buildMobileNativeChatTransientData({
+    folded: messages,
+    streaming: null,
+    pending: state?.pending ?? []
+  })
+  return data
+    .filter((message) => !messages.some((existing) => existing.id === message.id))
+    .map((message) => message.blocks.find((block) => block.type === 'text')?.text)
+}
+
+describe('useMobileNativeChatDrafts glued pending sends', () => {
+  let renderer: TestRenderer | null = null
+  let state: DraftState | null = null
+
+  afterEach(() => {
+    act(() => renderer?.unmount())
+    renderer = null
+    state = null
+  })
+
+  function Harness({
+    messages,
+    transcriptLoading = false
+  }: {
+    messages: NativeChatMessage[]
+    transcriptLoading?: boolean
+  }): null {
+    state = useMobileNativeChatDrafts({
+      hostId: 'host',
+      worktreeId: 'worktree',
+      tabId: 'tab',
+      sessionId: 'session',
+      messages,
+      transcriptLoading
+    })
+    return null
+  }
+
+  async function mount(messages: NativeChatMessage[], transcriptLoading = false): Promise<void> {
+    await act(async () => {
+      renderer = create(createElement(Harness, { messages, transcriptLoading }))
+    })
+  }
+
+  async function update(messages: NativeChatMessage[], transcriptLoading = false): Promise<void> {
+    await act(async () => renderer?.update(createElement(Harness, { messages, transcriptLoading })))
+  }
+
+  function send(text: string): void {
+    const origin = state?.captureSendOrigin(text)
+    if (origin) {
+      state?.acceptSend(origin, text)
+    }
+  }
+
+  /** Two composer sends fired before either transcript echo lands. */
+  function rapidSend(first: string, second: string): void {
+    act(() => {
+      send(first)
+      send(second)
+    })
+  }
+
+  const pendingTexts = (): (string | undefined)[] | undefined =>
+    state?.pending.map((item) => item.text)
+
+  it('retires both bubbles when the rapid sends land as one glued user row', async () => {
+    const history = [assistantTurn('m1', 'ready', 1000)]
+    await mount(history)
+    rapidSend('run the tests', 'again')
+    expect(pendingTexts()).toEqual(['run the tests', 'again'])
+
+    const glued = [...history, userTurn('m2', 'run the tests again', 5000)]
+    await update(glued)
+    expect(state?.pending).toEqual([])
+    expect(renderedPendingTexts(glued, state)).toEqual([])
+  })
+
+  // FP1: the concatenation already sits in history, older than the sends.
+  it('keeps and renders both bubbles when the matching row predates the sends', async () => {
+    const history = [
+      userTurn('m1', 'run the tests again', 1000),
+      assistantTurn('m2', 'done', 2000),
+      assistantTurn('m3', 'anything else?', 3000)
+    ]
+    await mount(history)
+    rapidSend('run the tests', 'again')
+
+    await update([...history])
+    expect(pendingTexts()).toEqual(['run the tests', 'again'])
+    expect(renderedPendingTexts(history, state)).toEqual(['run the tests', 'again'])
+  })
+
+  // FP2: an older turn reads like the concatenation of two much later sends.
+  it('keeps and renders both bubbles when an older turn spells them out', async () => {
+    const history = [userTurn('m1', 'fix the bug', 1000), assistantTurn('m2', 'fixed', 1100)]
+    await mount(history)
+    rapidSend('fix the', 'bug')
+
+    await update([...history])
+    expect(pendingTexts()).toEqual(['fix the', 'bug'])
+    expect(renderedPendingTexts(history, state)).toEqual(['fix the', 'bug'])
+  })
+
+  it('still retires each bubble on its own when the sends do not glue', async () => {
+    const history = [assistantTurn('m1', 'ready', 1000)]
+    await mount(history)
+    rapidSend('run the tests', 'again')
+
+    const separate = [
+      ...history,
+      userTurn('m2', 'run the tests', 5000),
+      userTurn('m3', 'again', 5100)
+    ]
+    await update(separate)
+    expect(state?.pending).toEqual([])
+  })
+
+  it('keeps the second bubble when only the first send has echoed', async () => {
+    const history = [assistantTurn('m1', 'ready', 1000)]
+    await mount(history)
+    rapidSend('run the tests', 'again')
+
+    const partial = [...history, userTurn('m2', 'run the tests', 5000)]
+    await update(partial)
+    expect(pendingTexts()).toEqual(['again'])
+    expect(renderedPendingTexts(partial, state)).toEqual(['again'])
+  })
+
+  // STA-4492 / #14819: sends issued mid-hydration used to be marked permanently
+  // untrusted, so their glued row could never retire them and they also barred
+  // their neighbours from matching. The first authoritative read rebases them
+  // instead: history that arrives with it is still not theirs, but everything
+  // after it is.
+  describe('sends issued while the transcript is still hydrating', () => {
+    const loadedHistory = [userTurn('m1', 'run the tests again', 1000)]
+
+    it('keeps both bubbles when the loaded history only looks like their glue', async () => {
+      await mount([], true)
+      rapidSend('run the tests', 'again')
+
+      await update(loadedHistory)
+      expect(pendingTexts()).toEqual(['run the tests', 'again'])
+      expect(renderedPendingTexts(loadedHistory, state)).toEqual(['run the tests', 'again'])
+    })
+
+    it('retires both bubbles once their glued row lands after hydration', async () => {
+      await mount([], true)
+      rapidSend('run the tests', 'again')
+      await update(loadedHistory)
+
+      const glued = [...loadedHistory, userTurn('m2', 'run the tests again', 5000)]
+      await update(glued)
+      expect(state?.pending).toEqual([])
+      expect(renderedPendingTexts(glued, state)).toEqual([])
+    })
+
+    it('retires a hydration-time send on its own exact echo', async () => {
+      await mount([], true)
+      act(() => send('run the tests'))
+      await update(loadedHistory)
+      expect(pendingTexts()).toEqual(['run the tests'])
+
+      const echoed = [...loadedHistory, userTurn('m2', 'run the tests', 5000)]
+      await update(echoed)
+      expect(state?.pending).toEqual([])
+    })
+
+    it('stops barring a later pair from gluing once its own echo lands', async () => {
+      await mount([], true)
+      act(() => send('hold this'))
+      await update(loadedHistory)
+      rapidSend('fix the', 'bug')
+
+      const landed = [
+        ...loadedHistory,
+        userTurn('m2', 'hold this', 5000),
+        userTurn('m3', 'fix the bug', 5100)
+      ]
+      await update(landed)
+      expect(state?.pending).toEqual([])
+    })
+
+    it('does not retire a hydration-time send against history it never saw', async () => {
+      await mount([], true)
+      act(() => send('run the tests'))
+
+      // The read lands carrying an older identical prompt: not this send's echo.
+      const olderIdentical = [
+        userTurn('m1', 'run the tests', 1000),
+        assistantTurn('m2', 'passed', 1100)
+      ]
+      await update(olderIdentical)
+      expect(pendingTexts()).toEqual(['run the tests'])
+    })
+  })
+})

--- a/mobile/src/session/use-mobile-native-chat-drafts-glued-pending.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-drafts-glued-pending.test.ts
@@ -292,6 +292,24 @@ describe('useMobileNativeChatDrafts glued pending sends', () => {
     // A send held here would sit as a live segment at the head of its run, so
     // the cursor could never reach a later pair — the stuck bubble would take
     // the whole feature down with it for the rest of the session.
+    // An image entry retires ONLY by binding its preview, so a supplied tail
+    // that excluded its own echo would leave the bubble — and the photo — stuck
+    // for the life of the session.
+    it('retires a photo whose image echo arrives with the read', async () => {
+      await mount([], true)
+      act(() => {
+        const origin = state?.captureSendOrigin('')
+        if (origin) {
+          state?.acceptSend(origin, '', ['file:///new.png'])
+        }
+      })
+
+      const withEcho = [assistantTurn('m1', 'ready', 1000), imageTurn('m2', '/tmp/new.png', 5000)]
+      await update(withEcho)
+      expect(state?.pending).toEqual([])
+      expect(state?.imagePreviewsByMessageId).toEqual({ m2: ['file:///new.png'] })
+    })
+
     it('leaves a later pair able to glue after the late read resolved the first send', async () => {
       await mount([], true)
       act(() => send('run the tests'))
@@ -323,23 +341,6 @@ describe('useMobileNativeChatDrafts glued pending sends', () => {
       await update(olderIdentical)
       expect(pendingTexts()).toEqual(['fix the', 'bug'])
       expect(renderedPendingTexts(olderIdentical, state)).toEqual(['fix the', 'bug'])
-    })
-
-    // The preview pass runs before the rebase, so an entry with no boundary
-    // would bind the user's fresh photo to whatever image turn the read carries.
-    it('does not bind a photo sent before the read to an image turn already in it', async () => {
-      await mount([], false, false)
-      act(() => {
-        const origin = state?.captureSendOrigin('')
-        if (origin) {
-          state?.acceptSend(origin, '', ['file:///new.png'])
-        }
-      })
-
-      const olderImage = [imageTurn('m1', '/old/photo.png', 1000)]
-      await update(olderImage)
-      expect(state?.imagePreviewsByMessageId).toEqual({})
-      expect(state?.pending.map((item) => item.images)).toEqual([['file:///new.png']])
     })
 
     it('still retires them once their own glued row lands', async () => {

--- a/mobile/src/session/use-mobile-native-chat-drafts-glued-pending.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-drafts-glued-pending.test.ts
@@ -229,9 +229,11 @@ describe('useMobileNativeChatDrafts glued pending sends', () => {
     // The read that resolves a hydration-time send can already contain that
     // send's own echo — a re-subscribe returns whatever exists now — and nothing
     // local tells that echo from an identical older prompt. Claiming the row is
-    // the safe direction: being wrong costs one round trip of invisibility,
-    // while holding costs a queued bubble that never clears and a run that can
-    // never glue again.
+    // the lesser evil, not a free one: normally the real echo lands a round trip
+    // later, but a send that never landed and was claimed by an older identical
+    // row stops being tracked at all — worst for short repeats ("yes", "1").
+    // Holding instead costs a queued bubble that never clears AND a run that can
+    // never glue again, for the rest of the session.
     it('retires a hydration-time send whose echo arrives with the read', async () => {
       await mount([], true)
       act(() => send('run the tests'))

--- a/mobile/src/session/use-mobile-native-chat-drafts-launch-draft.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-drafts-launch-draft.test.ts
@@ -36,7 +36,8 @@ describe('useMobileNativeChatDrafts launch draft', () => {
     launchDraft = null,
     launchDraftCreatedAt = null,
     chatActive = true,
-    transcriptLoading = false
+    transcriptLoading = false,
+    transcriptSettled = !transcriptLoading
   }: {
     tabId: string
     sessionId?: string | null
@@ -45,6 +46,7 @@ describe('useMobileNativeChatDrafts launch draft', () => {
     launchDraftCreatedAt?: number | null
     chatActive?: boolean
     transcriptLoading?: boolean
+    transcriptSettled?: boolean
   }): null {
     state = useMobileNativeChatDrafts({
       hostId: 'host',
@@ -55,7 +57,8 @@ describe('useMobileNativeChatDrafts launch draft', () => {
       launchDraft,
       launchDraftCreatedAt,
       chatActive,
-      transcriptLoading
+      transcriptLoading,
+      transcriptSettled
     })
     return null
   }

--- a/mobile/src/session/use-mobile-native-chat-drafts.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-drafts.test.ts
@@ -42,7 +42,8 @@ describe('useMobileNativeChatDrafts', () => {
     messages = [],
     launchDraft = null,
     chatActive = true,
-    transcriptLoading = false
+    transcriptLoading = false,
+    transcriptSettled = !transcriptLoading
   }: {
     tabId: string
     sessionId?: string | null
@@ -50,6 +51,7 @@ describe('useMobileNativeChatDrafts', () => {
     launchDraft?: string | null
     chatActive?: boolean
     transcriptLoading?: boolean
+    transcriptSettled?: boolean
   }): null {
     state = useMobileNativeChatDrafts({
       hostId: 'host',
@@ -59,7 +61,8 @@ describe('useMobileNativeChatDrafts', () => {
       messages,
       launchDraft,
       chatActive,
-      transcriptLoading
+      transcriptLoading,
+      transcriptSettled
     })
     return null
   }

--- a/mobile/src/session/use-mobile-native-chat-drafts.ts
+++ b/mobile/src/session/use-mobile-native-chat-drafts.ts
@@ -47,6 +47,10 @@ export function useMobileNativeChatDrafts(args: {
    *  transcript still belongs to the previously active tab), so it cannot be
    *  trusted to decline or retire the seed. */
   transcriptLoading?: boolean
+  /** `messages` is this session's own settled history — so an empty one really
+   *  is an empty conversation, not a read that failed or never ran. Only then
+   *  does a send's captured tail describe a real boundary. */
+  transcriptSettled?: boolean
 }): {
   composerText: string
   setComposerText: Dispatch<SetStateAction<string>>
@@ -80,7 +84,8 @@ export function useMobileNativeChatDrafts(args: {
     launchDraft,
     launchDraftCreatedAt,
     chatActive = true,
-    transcriptLoading
+    transcriptLoading,
+    transcriptSettled = !transcriptLoading
   } = args
   const draftKey = mobileNativeChatScopeKey(hostId, worktreeId, tabId)
   const pendingKey = draftKey && sessionId ? `${draftKey}\0${sessionId}` : null
@@ -139,12 +144,13 @@ export function useMobileNativeChatDrafts(args: {
         normalizedText,
         baselineOccurrences: countUserTextOccurrences(messagesRef.current, normalizedText),
         baselineTailMessageId: messagesRef.current.at(-1)?.id ?? null,
-        // A hydrating transcript is not yet this session's, so this baseline is
-        // a placeholder the first authoritative read rebases.
-        baselineResolved: !transcriptLoading
+        // Only a settled read makes this a boundary. Anything else — hydrating,
+        // or a read that failed — hands back an empty list that reads as "the
+        // conversation was empty", which lets any row claim this send later.
+        baselineResolved: transcriptSettled
       }
     },
-    [draftKey, pendingKey, transcriptLoading]
+    [draftKey, pendingKey, transcriptSettled]
   )
 
   // Why: over relay the send RPC can take seconds (or lose only its ack), and a
@@ -294,11 +300,11 @@ export function useMobileNativeChatDrafts(args: {
     }
     setPendingBySession((previous) => {
       const current = previous[pendingKey] ?? []
-      // Rebase before retiring: a hydration-time send has to own a real boundary
-      // before any row can be judged against it.
-      const rebased = transcriptLoading
-        ? current
-        : rebaseMobileNativeChatPendingBaselines(messages, current)
+      // Rebase before retiring: a send captured before the history was known has
+      // to own a real boundary before any row can be judged against it.
+      const rebased = transcriptSettled
+        ? rebaseMobileNativeChatPendingBaselines(messages, current)
+        : current
       const next = retireLandedMobileNativeChatPending(messages, rebased, landedImagePendingIds)
       if (next === current) {
         return previous
@@ -310,7 +316,7 @@ export function useMobileNativeChatDrafts(args: {
       delete remaining[pendingKey]
       return remaining
     })
-  }, [messages, pending, pendingKey, transcriptLoading])
+  }, [messages, pending, pendingKey, transcriptSettled])
 
   return {
     composerText: draftKey ? (drafts[draftKey] ?? '') : '',

--- a/mobile/src/session/use-mobile-native-chat-drafts.ts
+++ b/mobile/src/session/use-mobile-native-chat-drafts.ts
@@ -291,9 +291,12 @@ export function useMobileNativeChatDrafts(args: {
     if (pending.length === 0) {
       return
     }
-    // This pass runs before the rebase below, so a send captured with no
-    // boundary would claim any image turn in the read — binding the user's fresh
-    // photo to an old one. It waits a tick and claims against a real tail.
+    // Only judge a send against a read known to be this session's. Note this
+    // does NOT give an image echo a boundary — the rebase deliberately leaves
+    // those on whatever they captured — so a caption-less photo sent before any
+    // read settled can still claim an older photo turn, exactly as it does on
+    // main. Fixing that needs a tail that excludes older image turns without
+    // excluding the send's own echo, which is a separate change.
     const landedImagePreviews = findLandedImagePreviewEchoes(
       messages,
       pending.filter((item) => item.baselineResolved)

--- a/mobile/src/session/use-mobile-native-chat-drafts.ts
+++ b/mobile/src/session/use-mobile-native-chat-drafts.ts
@@ -50,7 +50,7 @@ export function useMobileNativeChatDrafts(args: {
   /** `messages` is this session's own settled history — so an empty one really
    *  is an empty conversation, not a read that failed or never ran. Only then
    *  does a send's captured tail describe a real boundary. */
-  transcriptSettled?: boolean
+  transcriptSettled: boolean
 }): {
   composerText: string
   setComposerText: Dispatch<SetStateAction<string>>
@@ -85,7 +85,7 @@ export function useMobileNativeChatDrafts(args: {
     launchDraftCreatedAt,
     chatActive = true,
     transcriptLoading,
-    transcriptSettled = !transcriptLoading
+    transcriptSettled
   } = args
   const draftKey = mobileNativeChatScopeKey(hostId, worktreeId, tabId)
   const pendingKey = draftKey && sessionId ? `${draftKey}\0${sessionId}` : null

--- a/mobile/src/session/use-mobile-native-chat-drafts.ts
+++ b/mobile/src/session/use-mobile-native-chat-drafts.ts
@@ -1,16 +1,16 @@
 import { useCallback, useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react'
 import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
 import {
-  countImageSourceTurnsAfter,
   countUserTextOccurrences,
   findLandedImagePreviewEchoes,
   findLandedUnconfirmedSends,
   mergeLandedImagePreviewEchoes,
   migrateImagePreviewMessageIds,
   normalizeReconcileText,
-  normalizedUserText,
   type UnconfirmedSend
 } from './mobile-native-chat-draft-reconcile'
+import { rebaseMobileNativeChatPendingBaselines } from './mobile-native-chat-pending-baseline'
+import { retireLandedMobileNativeChatPending } from './mobile-native-chat-pending-retirement'
 import {
   appendMobileNativeChatPending,
   combineMobileNativeChatPending,
@@ -138,10 +138,13 @@ export function useMobileNativeChatDrafts(args: {
         pendingKey,
         normalizedText,
         baselineOccurrences: countUserTextOccurrences(messagesRef.current, normalizedText),
-        baselineTailMessageId: messagesRef.current.at(-1)?.id ?? null
+        baselineTailMessageId: messagesRef.current.at(-1)?.id ?? null,
+        // A hydrating transcript is not yet this session's, so this baseline is
+        // a placeholder the first authoritative read rebases.
+        baselineResolved: !transcriptLoading
       }
     },
-    [draftKey, pendingKey]
+    [draftKey, pendingKey, transcriptLoading]
   )
 
   // Why: over relay the send RPC can take seconds (or lose only its ack), and a
@@ -291,28 +294,13 @@ export function useMobileNativeChatDrafts(args: {
     }
     setPendingBySession((previous) => {
       const current = previous[pendingKey] ?? []
-      const landedCounts = new Map<string, number>()
-      for (const message of messages) {
-        const text = normalizedUserText(message)
-        if (text) {
-          landedCounts.set(text, (landedCounts.get(text) ?? 0) + 1)
-        }
-      }
-      // Image-only source-turn counts stay stable across reruns and ignore paginated history.
-      const next = current.filter((item) => {
-        if (landedImagePendingIds.has(item.id)) {
-          return false
-        }
-        // Keep image echoes until their local preview reaches the authoritative message.
-        if (item.images?.length) {
-          return true
-        }
-        return item.text.trim() === ''
-          ? countImageSourceTurnsAfter(messages, item.baselineTailMessageId) <
-              item.expectedOccurrence
-          : (landedCounts.get(normalizeReconcileText(item.text)) ?? 0) < item.expectedOccurrence
-      })
-      if (next.length === current.length) {
+      // Rebase before retiring: a hydration-time send has to own a real boundary
+      // before any row can be judged against it.
+      const rebased = transcriptLoading
+        ? current
+        : rebaseMobileNativeChatPendingBaselines(messages, current)
+      const next = retireLandedMobileNativeChatPending(messages, rebased, landedImagePendingIds)
+      if (next === current) {
         return previous
       }
       if (next.length > 0) {
@@ -322,7 +310,7 @@ export function useMobileNativeChatDrafts(args: {
       delete remaining[pendingKey]
       return remaining
     })
-  }, [messages, pending, pendingKey])
+  }, [messages, pending, pendingKey, transcriptLoading])
 
   return {
     composerText: draftKey ? (drafts[draftKey] ?? '') : '',

--- a/mobile/src/session/use-mobile-native-chat-drafts.ts
+++ b/mobile/src/session/use-mobile-native-chat-drafts.ts
@@ -291,7 +291,13 @@ export function useMobileNativeChatDrafts(args: {
     if (pending.length === 0) {
       return
     }
-    const landedImagePreviews = findLandedImagePreviewEchoes(messages, pending)
+    // This pass runs before the rebase below, so a send captured with no
+    // boundary would claim any image turn in the read — binding the user's fresh
+    // photo to an old one. It waits a tick and claims against a real tail.
+    const landedImagePreviews = findLandedImagePreviewEchoes(
+      messages,
+      pending.filter((item) => item.baselineResolved)
+    )
     const landedImagePendingIds = new Set(landedImagePreviews.map((preview) => preview.pendingId))
     if (landedImagePreviews.length > 0) {
       setImagePreviewsBySession((previous) =>

--- a/mobile/src/session/use-mobile-native-chat-message-send.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-message-send.test.ts
@@ -4,6 +4,8 @@
 import { createElement } from 'react'
 import { act, create, type ReactTestRenderer } from 'react-test-renderer'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+// Type-only, so it is erased before the `./mobile-native-chat-send` mock below applies.
+import type { MobileNativeChatSendOutcome } from './mobile-native-chat-send'
 
 const sendWithOutcome = vi.fn()
 const clearInputWrite = vi.fn()
@@ -36,6 +38,9 @@ describe('useMobileNativeChatMessageSend', () => {
   let renderer: ReactTestRenderer | null = null
   let api: Send | null = null
   const acceptSend = vi.fn()
+  const captureSendOrigin = vi.fn(() => ({ draftKey: 'k', pendingKey: 'p' }) as never)
+  const clearDraftForSend = vi.fn()
+  const restoreRejectedDraft = vi.fn()
   const holdUnconfirmedSend = vi.fn()
   const onCommandSend = vi.fn()
   const commandSendRef = { current: onCommandSend }
@@ -55,10 +60,10 @@ describe('useMobileNativeChatMessageSend', () => {
         deviceTokenRef: { current: 'device' },
         agentRef,
         commandSendRef,
-        captureSendOrigin: () => ({ draftKey: 'k', pendingKey: 'p' }) as never,
+        captureSendOrigin,
         readSeededLaunchDraftSeed,
-        clearDraftForSend: () => {},
-        restoreRejectedDraft: () => {},
+        clearDraftForSend,
+        restoreRejectedDraft,
         acceptSend,
         holdUnconfirmedSend,
         onSendError
@@ -71,10 +76,12 @@ describe('useMobileNativeChatMessageSend', () => {
   }
 
   const sentArgs = (): {
+    text?: string
     clearInputFirst?: boolean
     resolvedLaunchDraft?: { text: string; createdAt: number }
   } =>
     sendWithOutcome.mock.calls[0]![0] as {
+      text?: string
       clearInputFirst?: boolean
       resolvedLaunchDraft?: { text: string; createdAt: number }
     }
@@ -89,6 +96,9 @@ describe('useMobileNativeChatMessageSend', () => {
     typeCommandWithOutcome.mockReset()
     typeCommandWithOutcome.mockResolvedValue('accepted')
     acceptSend.mockReset()
+    captureSendOrigin.mockClear()
+    clearDraftForSend.mockReset()
+    restoreRejectedDraft.mockReset()
     holdUnconfirmedSend.mockReset()
     onCommandSend.mockReset()
     commandSendRef.current = onCommandSend
@@ -380,5 +390,54 @@ describe('useMobileNativeChatMessageSend', () => {
     // The answer released its own hold on the way out.
     expect(acquireMobileNativeChatTerminalWrite('term')).toBe(true)
     releaseMobileNativeChatTerminalWrite('term')
+  })
+
+  // The host writes these bytes verbatim, so whitespace the match key drops must
+  // not reach the agent's input line and glue the next rapid send onto it (#14262).
+  it('trims trailing whitespace without changing leading prompt content', async () => {
+    mount(() => null)
+    await act(async () => {
+      await api!.send('  run the tests \n')
+    })
+    expect(sentArgs().text).toBe('  run the tests')
+    expect(captureSendOrigin).toHaveBeenCalledWith('  run the tests')
+    expect(acceptSend.mock.calls[0]![1]).toBe('  run the tests')
+  })
+
+  it('trims trailing whitespace on a question answer too', async () => {
+    mount(() => null)
+    await act(async () => {
+      await api!.answerQuestion('\n 1 ')
+    })
+    expect(sentArgs().text).toBe('\n 1')
+  })
+
+  // #14819: the trim is a wire concern only. A rejected send hands the composer
+  // back to the user, and it has to be the draft they typed, blank lines included.
+  it('restores the untrimmed draft when the send is rejected', async () => {
+    const draft = 'first line\n\nsecond line\n\n'
+    sendWithOutcome.mockResolvedValue('rejected')
+    mount(() => null)
+
+    await act(async () => {
+      await api!.send(draft)
+    })
+
+    expect(sentArgs().text).toBe('first line\n\nsecond line')
+    expect(restoreRejectedDraft.mock.calls[0]![1]).toBe(draft)
+    expect(clearDraftForSend.mock.calls[0]![1]).toBe(draft)
+  })
+
+  it('restores the untrimmed draft when the launch-draft pre-clear is rejected', async () => {
+    const draft = 'ship it   '
+    clearInputWrite.mockResolvedValue(false)
+    mount(() => ({ text: DRAFT, createdAt: 1 }))
+
+    await act(async () => {
+      await api!.send(draft)
+    })
+
+    expect(sendWithOutcome).not.toHaveBeenCalled()
+    expect(restoreRejectedDraft.mock.calls[0]![1]).toBe(draft)
   })
 })

--- a/mobile/src/session/use-mobile-native-chat-message-send.ts
+++ b/mobile/src/session/use-mobile-native-chat-message-send.ts
@@ -85,12 +85,17 @@ export function useMobileNativeChatMessageSend(args: {
 
   const sendMessage = useCallback(
     async (
-      text: string,
+      draftText: string,
       images: string[] | undefined,
       syncComposer: boolean,
       recordControlSend: boolean,
       sharedDeadline?: number
     ): Promise<MobileNativeChatSendOutcome> => {
+      // The host writes trailing whitespace verbatim onto the agent's input line,
+      // where it can glue the next rapid send onto this one (#14262). Only the
+      // bytes that go out are trimmed: `draftText` is what the user typed, and a
+      // rejected send has to put back exactly that (#14819).
+      const text = draftText.trimEnd()
       const handle = handleRef.current
       const origin = captureSendOrigin(text)
       const agent = agentRef.current
@@ -124,7 +129,7 @@ export function useMobileNativeChatMessageSend(args: {
       // round trip is visible, and a lost ack must not strand the sent prompt
       // in the box. Only a definite rejection puts the text back.
       if (syncComposer) {
-        clearDraftForSend(origin, text)
+        clearDraftForSend(origin, draftText)
       }
       // Why: a parked launch draft is routinely multi-line, and one Ctrl+U clears
       // only one logical line. Size the clear to the text Orca injected, with
@@ -150,7 +155,7 @@ export function useMobileNativeChatMessageSend(args: {
         })
         if (!cleared) {
           if (syncComposer) {
-            restoreRejectedDraft(origin, text)
+            restoreRejectedDraft(origin, draftText)
           }
           onSendError('Message not sent')
           return 'rejected'
@@ -204,7 +209,7 @@ export function useMobileNativeChatMessageSend(args: {
       }
       if (outcome === 'rejected') {
         if (syncComposer) {
-          restoreRejectedDraft(origin, text)
+          restoreRejectedDraft(origin, draftText)
         }
         onSendError('Message not sent')
         return 'rejected'


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​705 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​698 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​241 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​32 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​209 |

<!-- /orca-pr-loc -->

## ELI5

On mobile, two fast sends can land in the transcript as one merged user row (`run the tests` + `again` → `run the tests again`). #14665 taught mobile to recognize that and clear both grey "queued" bubbles. It was reverted in #14819 because it also broke two things. This brings the feature back with both of those causes fixed — not re-applied and hoped for.

## Why #14665 was reverted

#14819's body says only "a launch-blocking regression". The specific causes are named by the maintainer on [#14665](https://github.com/stablyai/orca/pull/14665#issuecomment-) and in STA-4482:

> a rejected mobile send can restore a trimmed composer and drop draft text, and loading-time glued sends can stay queued.

**Cause 1 — a rejected send restored less than the user typed. This one does not reproduce, and the PR previously claimed otherwise.** The review loop traced it: #14665 (`68ca17e46c`) touched 8 files, none of them the composer or the drafts hook's clear/restore callbacks, and it did not reassign a parameter — it *renamed* one, `const text = rawText.trimEnd()`. The only production caller, `MobileNativeChatComposer.handleSend`, was already handing over `value.trimEnd()`, and that line predates #14665 by ten days (#12366, 2026-08-04). `trimEnd(trimEnd(x)) === trimEnd(x)`, so what `restoreRejectedDraft` put back was byte-identical to what `main` restores today, on every path. The non-composer callers pass `syncComposer: false` and never touch the draft at all.

So **whatever else motivated #14819, it was not draft loss**, and this PR should not be read as having fixed it. The `draftText` / `text` split is still worth keeping — it is what makes the seam's contract real rather than accidental — and the review loop made it actually load-bearing by removing the composer's duplicate `trimEnd` (below). The one genuine behavior change #14665 made here was `recordCommand(text)` in place of `recordCommand(text.trim())`, leaking leading whitespace into the session-option catalog key; this reland restores the `.trim()`.

**Cause 2 — hydration-time sends were stranded forever.** #14665 stamped `glueBaselineTrusted: false` on any send captured while the transcript was still loading, and nothing ever cleared it. Such a send could never glue, and because the matcher treats a non-representable entry as a barrier, it also blocked its *neighbours* from ever gluing. That is STA-4492, and it is real.

## What Changed

**Mobile only.** `src/renderer` is untouched.

1. **The draft and the payload are separate values, and the split now reaches production** (`use-mobile-native-chat-message-send.ts`, `MobileNativeChatComposer.tsx`). `draftText` is what the user typed and is what `clearDraftForSend` / `restoreRejectedDraft` receive; only the transported `text` is `trimEnd()`ed. The composer used to pre-trim with `onSend(value.trimEnd())`, so the raw draft never reached the seam and the split had nothing to restore — a rejected multi-line prompt still came back without its trailing blank lines. The composer now passes `value` through and the seam owns the trim, which also stops it happening twice.

2. **A baseline captured before the history was known is a placeholder, not a disqualification** (new `mobile-native-chat-pending-baseline.ts`). `baselineResolved: false` marks such a send; `rebaseMobileNativeChatPendingBaselines` gives it the boundary it never had on the first settled read. The drafts hook rebases *before* retiring, because a send has to own a real boundary before any row can be judged against it.

   The ordinal is deliberately **not** recounted against that read. The read can already carry the send's own echo — a re-subscribe after a tab switch or reconnect returns whatever exists *now* — and nothing local separates that echo from an identical older prompt: the transport writes keystrokes into a TUI and carries no message id, and row timestamps come from the host while the send time comes from the phone. Recounting put the ordinal one past anything the transcript could supply. The review loop reproduced the result: a permanently stuck "Queued" bubble, which also sat as a live segment at the head of its run so no later pair could glue either, and whose inflated ordinal was carried onto the next send of the same text by `earlierOutstanding`. That is the STA-4492 symptom, reached through a different door — **worse than the #14665 it relands**, whose count pass never consulted the untrusted flag at all. The ordinal was already counted against an empty transcript, which is exactly right for "no history was known"; only a *missing* tail needed recovering.

   And only a missing one. An unsettled read still shows this session's own retained history — `createNativeChatTranscriptRetention` keeps the conversation on screen across a reconnect or a failed read rather than blanking it — so a send made across one already owns a correct boundary. An earlier revision of this fix overwrote it with the tail of the read that followed, which sits at or after the pair's own glued row, so `turn.index <= segment.tail` rejected every turn and the pair stayed queued for the session, blocking every later pair in its run. A captured tail is now never moved.

3. **`baselineResolved` means "captured against a settled read"**, not merely "not loading" (`use-mobile-native-chat-drafts.ts`, `use-mobile-native-chat-controller.ts`). A read that failed hands back an empty list, which is indistinguishable from an empty conversation — and an empty conversation legitimately yields a null tail, which the glue matcher reads as "any row may be my echo". Two sends issued in that window were therefore retired by an arbitrary *old* row once the successful read finally arrived. That false positive is new in this PR, since `main` has no glue matching at all. `transcriptSettled` is a **required** prop, so no caller can silently fall back to the gate it replaced.

   **Only a text-bearing send is given a boundary.** The glue matcher is the sole consumer a supplied tail helps; every other one is harmed by it. An image echo reconciles by counting turns *after* its tail and has **no other retirement path** — `landedImagePendingIds`, from the preview pass, is the only one — so a tail taken from a read that already carries its own echo excludes the very row it is waiting for: a permanent "Queued" photo bubble, and a transcript row rendering as bare `[Image: source: …]` marker text with no photo. A captioned one is worse still, binding by an ordinal counted over the whole transcript, so a tail without a matching recount leaves it claiming nothing at all. Both were reproduced; the rule now covers all three consumers of `baselineTailMessageId`.

4. **Retirement rules live in one module** (new `mobile-native-chat-pending-retirement.ts`). Exact/ordinal retirement and glue matching now share `retireLandedMobileNativeChatPending`, which returns the **input array identity** when nothing retires — the drafts hook's `next === current` early-out depends on that, and a new array every pass would loop the effect. #14665 returned `[...current]` here and relied on a length comparison; the identity contract is now pinned by a test.

5. **The bound is preserved.** One transcript user turn retires a run of 2+ adjacent text-only pending sends only when it exactly spells their normalized concatenation with at most a single-space boundary, and `turn.index <= segment.tail` rejects any row a send predates. Exact landings, image echoes, empty text and unresolved tails remain barriers.

### Known bounds, and why they are now actually bounded

Three cases do not retire. All are pre-existing in outcome and match `main`; none is a regression.

- A **caption-less or captioned photo** sent before any read settled can bind to an older photo turn — caption-less to any photo in the read, captioned to an older row carrying the same caption. Its ordinal was counted against an empty read and no local signal separates its own echo from the older row. Fixing it needs a tail that excludes older image turns without excluding the send's own echo, which is a separate change.
- A **pair of sends issued when the transcript was genuinely unknown** — a cold start with no retained history, so both captured a null tail — whose *glued* row is already in the first settled read. The tail supplied to them sits at or after that row, and the matcher refuses any row a send predates. Relaxing that is exactly the false positive (FP1/FP2) this design exists to prevent.
- A send the **count pass claims against an older identical row**, orphaning the rest of its glued run (the pre-existing absolute-`landedCounts` looseness).
- **New, and the honest cost of the cursor slide:** an unrelated transcript row that happens to spell the concatenation of two or more *later* outstanding sends can claim them, moving the cursor past an earlier pair whose own echo has not landed yet — stranding that pair. It needs an exact text coincidence and the row must land after those sends' tails but before the earlier pair's echo, so it is far rarer than the frozen-head bug the slide fixes; the trade is net positive, but it is a new failure mode rather than a pre-existing one. The same case has a second face: a glue that needs a *slide* to be found can have its budget spent by earlier attempts, if and only if the leading segments prefix-match the row deeply — a heterogeneous run costs one inspection per failed attempt and never comes close. Both faces leave a lingering bubble; neither can cause a wrong retirement.

**What changed: none of these can take the feature down with them any more.** The match cursor used to advance only on a hit, so any one of the above, sitting at the head of a run, froze every later rapid pair permanently — the earlier revision of this PR disclosed these as bounded when they were not. The cursor now slides past a head that cannot match, staying monotonic so no later turn can claim a send an earlier one took. `MAX_GLUE_SPAN` keeps that search linear in the run length; the budget test asserts the bound rather than the looser one the slide would otherwise have broken.

The whole condition is removed at its source by serializing agent-prompt submits per PTY (#14980), so the glue never forms.

## Linked Issue

Refs STA-4482 (reland) and STA-4492 (hydration barrier). Original PR #14665, revert #14819. Fixes the user-visible symptom tracked as STA-4506.

### Why one PR and not two

STA-4492 **does not reproduce on current `origin/main`** — `mobile-native-chat-pending-retirement.ts`, `use-mobile-native-chat-drafts-glued-pending.test.ts` and the symbol `glueBaselineTrusted` were all deleted by #14819 (verified: 0 hits on `origin/main`). It was filed against span `e570cad..d2ffe1f`, which still carried #14665 and not the revert. So STA-4492 is not a standalone defect on main; it is one of the two conditions this reland has to satisfy, in code that only exists inside the reland. Shipping them separately is not possible — the "fix" would have no code to apply to.

The desktop half (STA-4477, same family of bug in the renderer) is deliberately **a separate PR**, since this one is a reland of an already-once-reverted change and must stay independently revertable without dragging a live P1 desktop fix out with it.

## Visual Proof

**Mobile emulator QA — glued-send retirement EXERCISED on device, with a live A/B.** iOS Simulator (iPhone 17 Pro, iOS 26.5), driven through `orca emulator`; Metro from this worktree's `mobile/` on an isolated port 8083; paired to an isolated `orca serve --mobile-pairing` built from this worktree, never the primary Orca app.

Which code the phone ran, checked before each arm: `entry.bundle` returns HTTP 200 at **27.7 MB** (not the ~7 KB error JSON) and contains `rebaseMobileNativeChatPendingBaselines`, `selectGluedPendingIds`, `matchGluedRun`, `retireLandedMobileNativeChatPending` and `baselineResolved`.

**BEFORE** — `selectGluedPendingIds` armed to return ∅. The glued row `Echo three Four` and the agent's reply are both in the transcript, and both grey bubbles stay pinned beneath them (`pending=2 [Echo three| Four]`):

![BEFORE](https://github.com/user-attachments/assets/856cfa56-f187-4749-bb70-a1d539b6c6fa)

**AFTER** — same live pane, same pending pair, only the function restored. Both clear within ~12 s (`pending=0 []`):

![AFTER](https://github.com/user-attachments/assets/8c4b54e3-2197-4616-ae2e-ec88f50777c8)

Two pending bubbles immediately after the two sends, and the live transcript against a real Claude Code session:

![pending](https://github.com/user-attachments/assets/4e3a9e2b-6e8b-4423-92ef-517ca52594c3)
![transcript](https://github.com/user-attachments/assets/a71443c8-52e7-478a-8867-e903bdf68f7b)

The `QA pending=…` text in the composer is a temporary probe so the pending set was observed rather than inferred. All QA instruments were reverted afterwards; the tree carries none of them.

### How the glued row was produced — and what that says about the bug

The two sends were **13 s apart**, not raced. The glue was produced deliberately, by an env-gated host instrument that dropped the Ctrl+U clear prefix and withheld the Enter so successive sends shared one TUI input line. That was not a shortcut around a timing problem; the timing approach is impossible, and the reason matters:

**Two rapid mobile composer sends cannot interleave today.** Every composer send runs through `sendNativeChat`, which takes the per-terminal write lock (`mobile-native-chat-terminal-write-lock.ts`) and holds it across the whole `terminal.send` RPC — and that RPC only resolves after the host's body → 500 ms sleep → Enter. A second send arriving in the gap is *rejected*, not glued. That lock landed in #12502 on 2026-08-04, ten days before the mobile half of #14262. Two further blockers on a Claude Code host: mobile text sends are `\x15`-prefixed, and its TUI honors Ctrl+U as kill-line (verified live — it printed `Ctrl+Y to paste deleted text`), so an interleaved body would *erase* the first rather than glue to it; and it does not merge queued prompts (two prompts queued during a long turn landed as two separate user turns).

So on a current mobile client against a Claude Code host, the glued-row precondition does not arise from the composer race this PR describes. **The retirement logic is verified correct against a glued row, but the producer of such a row is not the mobile composer.** Rows glued by some other producer — a concurrent client, a host path that bypasses the lock, or an agent TUI that does not honor Ctrl+U — remain the case this defends. Reviewers should weigh that when deciding whether this ships now or waits behind the host-side serialization in #14980.

**Not covered:** the hydration and image-attachment paths were not exercised on device; both are covered by tests only.

## Testing

Run from `mobile/`:

```bash
pnpm exec vitest run --config vitest.config.ts src/session
pnpm exec tsc --noEmit
pnpm exec oxlint --config .oxlintrc.json src/session/mobile-native-chat-pending-*.ts src/session/use-mobile-native-chat-*.ts
pnpm exec oxfmt --check src/session/mobile-native-chat-pending-*.ts src/session/use-mobile-native-chat-*.ts
```

From the repo root:

```bash
PATH=/opt/homebrew/opt/node@24/bin:$PATH node config/scripts/check-changed-code-quality.mjs -- origin/main
```

Results at this HEAD:

- Mobile session suites: **131 files / 1173 tests passed** (mobile's own vitest config, explicitly).
- `tsc --noEmit`: clean. Note `mobile/tsconfig.json` **excludes `**/*.test.ts`**, so test type errors ship silently; this branch was additionally typechecked with that exclusion removed. That surfaced 4 pre-existing errors in a file this PR touches (`MobileNativeChatSendOutcome` used but never imported — present identically on `origin/main`). Fixed here with a type-only import, called out explicitly rather than left behind: repo-wide mobile test-included errors go 363 → 359, and **0** remain in any file this PR touches.
- Changed-code quality, type-aware quality, React Doctor: **0 new findings** across every changed file.
- Oxlint and oxfmt: clean. The lint gate was confirmed *live* (a clean oxlint run prints nothing, which is indistinguishable from a dead one) by observing a real violation fire, then clearing it.
- `use-mobile-native-chat-drafts.ts` sits at **288 effective lines against the 300-line `max-lines` cap**. No cap was raised and no disable added — but see the note on #14980 below, because that file is shared.

**Red-first / non-vacuity.** Production code was mutated with tests kept (`git checkout HEAD -- <path>` to restore; never `git stash`), one property at a time. Every failure below is behavioural — none is a compile or missing-export failure:

| Mutation | Reproduces | Tests RED |
|---|---|---|
| `clearDraftForSend` / `restoreRejectedDraft` fed the trimmed value | a naive re-apply of #14665's send seam | **2** |
| `const rebased = current` — never rebase | a naive re-apply of #14665's untrusted flag / STA-4492 | **3** |
| restore the ordinal recount in `rebaseMobileNativeChatPendingBaselines` | the stuck bubble the review loop found | **6** |
| `baselineResolved: !transcriptLoading` — the loose predicate | an old row claiming sends issued before any read settled | **1** |
| `selectGluedPendingIds` returns ∅ | the feature itself | **14** |
| drop the `turn.index <= segment.tail` guard | the false-positive bound | **6** |
| `retireLandedMobileNativeChatPending` returns `[...current]` | the render-safety contract | **1** |
| keep a null-tailed image echo unpinned | an old image turn claiming a fresh photo | **1** |
| unfiltered image-preview pass | an unbounded send claiming an image turn already in the read | **1** |
| move a tail the send already captured | a reconnect pair stranded, blocking its whole run | **3** |
| supply a tail to an image echo | a photo bubble stuck for the session, photo lost | **3** |

The send-seam mutation fails with the symptom the revert named, verbatim:

```
FAIL … > restores the untrimmed draft when the launch-draft pre-clear is rejected
AssertionError: expected 'ship it' to be 'ship it   '
```

The untrusted-flag mutation fails as bubbles that never clear, including the neighbour-barrier face:

```
FAIL … > retires both bubbles once their glued row lands after hydration
AssertionError: expected [ { id: 'pending-1', …(4) }, …(1) ] to deeply equal []
FAIL … > stops barring a later pair from gluing once its own echo lands
```

**Glue matcher fuzzed for soundness.** 250,000 seeded cases — ~20,000 of them producing a real retirement — over transcripts built to contain the exact concatenation of a random slice of the pending queue, with randomized separators and adversarial baseline placement. Zero violations of: never retires an image echo, never retires an unresolved baseline, never retires a lone send as glue, and every retired run exactly spells a user row landing strictly **after** every member's own baseline tail. Kept out of the suite deliberately — it is a 10-second check and the FP1/FP2 fixtures already pin the bound.

**Two suites currently pin the same fixture shape in opposite directions, and that is deliberate.** "An older identical prompt arrives with the read" and "my own echo arrives with the read" are byte-identical states; the tests now assert the claiming direction, with the reasoning in the fixture comments.

- [x] Automated regressions added for the real revert cause and for both defects the review loop found
- [ ] Manual native mobile QA of the glue flow — see Visual Proof

## Review

- **Security / supply chain** — no dependencies, new IO, network sinks, secrets, shell execution, or persisted state.
- **Remote wire compatibility** — checked against `docs/reference/remote-wire-compatibility.md`. **No wire change.** `baselineResolved`, `baselineTailMessageId` and `expectedOccurrence` are client-local React state in `pendingBySession`; they are not RPC params, not stream frames, and not content a host publishes, so Rules 1–3 are not engaged and no capability negotiation is needed. The one client→host difference is that trailing whitespace is no longer written onto the agent's input line — carried by the existing `terminal.send` `params.text`, with no new field and no new opcode, and interpreted identically by hosts of any version.
- **Backward compatibility / data loss** — pending entries are in-memory only, so there is no persisted shape to migrate. The rejection path now restores the draft byte-for-byte rather than trailing-trimmed. Glue retirement still requires full-row consumption and 2+ adjacent text sends. One remaining draft-loss hole is deliberately **not** closed here: `restoreRejectedDraft` only restores into an empty composer, so text typed while a rejection is in flight still discards the sent draft — that is #14980's `mobile-native-chat-rejected-draft-merge`.
- **Render safety** — `retireLandedMobileNativeChatPending` preserves array identity on the no-op path, so the drafts effect settles instead of re-entering; the rebase pass converges in one extra tick and is then idempotent.
- **Performance** — bounded by `transcript rows × pending entries`; all Maps, Sets and arrays are invocation-local. No timers, polling, RPCs, or retained resources. No timeout-based bubble drop was added: a slow echo is legitimate over relay/SSH, and silently removing the only local record of a send invites a duplicate resend.
- **Cross-platform** — pure Expo client string logic; no platform, path, provider, SSH, or relay branch. iOS/Android identical.
- **Scope** — mobile only, all under `mobile/src/session/`. No `max-lines` cap was raised and no `max-lines` disable was added.

## Relationship to #14980

#14980 fixes the **root cause** this PR reconciles downstream — a per-PTY send lock, so overlapping submits never glue in the first place — plus a deterministic fake-PTY interleaving test. Nothing here duplicates it. Two merge notes:

- Both PRs touch `mobile/src/session/use-mobile-native-chat-drafts.ts`. The hunks do not overlap (this PR: imports, `captureSendOrigin`, the retirement effect; #14980: one import and `restoreRejectedDraft`), but the file has **12 effective lines of headroom** under the 300-line `max-lines` cap, so whichever merges second is tight.
- #14980 also closes the draft-loss hole noted above. Merging this PR does not make that one unnecessary.

## Checklist

- [x] Each documented revert cause traced to source — one reproduced and fixed, one shown not to reproduce and the claim withdrawn
- [x] PR states plainly what did and did not cause the revert, and what remains unexplained
- [x] Two defects the reland itself introduced found by the review loop, reproduced red-first, and fixed
- [x] Intended glue-retirement behavior and its false-positive bounds preserved, pinned, and fuzzed
- [x] Mobile suite run explicitly against mobile's own vitest config
- [x] Mobile test files typechecked despite `tsconfig.json` excluding them
- [x] Wire, cross-platform, folder-workspace and data-loss impact reviewed
- [x] Mobile QA limitation disclosed rather than substituted

## AI Disclosure

Authored and reviewed with AI assistance.

## Author

- X / Twitter: @BrennanKB5

