### PR TITLE
fix(editor): preserve rich markdown selection across tab switches

### DIFF
--- a/src/renderer/src/components/editor/rich-markdown-auto-focus.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-auto-focus.test.ts
@@ -80,6 +80,27 @@ describe('autoFocusRichEditor', () => {
     expect(focus).toHaveBeenCalledWith(null, { scrollIntoView: false })
   })
 
+  it('restores the selection after an editor tab activation', () => {
+    let runFrame: FrameRequestCallback = () => {}
+    const tab = document.createElement('div')
+    tab.dataset.tabId = 'editor-tab'
+    tab.tabIndex = 0
+    document.body.append(tab)
+    tab.focus()
+    const selection = Object.create(TextSelection.prototype)
+    const focus = vi.fn()
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      runFrame = callback
+      return 8
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+
+    autoFocusRichEditor(createEditor(focus, vi.fn(), selection), null)
+    runFrame(0)
+
+    expect(focus).toHaveBeenCalledWith(null, { scrollIntoView: false })
+  })
+
   it('starts at the beginning for an explicit handoff', () => {
     const selection = Object.create(TextSelection.prototype)
     const { focus, runFrame } = setupScheduledFocus(null, true, selection)

--- a/src/renderer/src/components/editor/rich-markdown-auto-focus.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-auto-focus.test.ts
@@ -1,22 +1,26 @@
 // @vitest-environment happy-dom
 import type { Editor } from '@tiptap/react'
+import { TextSelection } from '@tiptap/pm/state'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { autoFocusRichEditor } from './rich-markdown-auto-focus'
 
 function createEditor(
   focus = vi.fn(),
-  domFocus: (options?: FocusOptions) => void = vi.fn()
+  domFocus: (options?: FocusOptions) => void = vi.fn(),
+  selection: object = {}
 ): Editor {
   return {
     isDestroyed: false,
     commands: { focus },
+    state: { selection },
     view: { dom: { focus: domFocus } }
   } as unknown as Editor
 }
 
 function setupScheduledFocus(
   activeElement: object | null,
-  force = false
+  force = false,
+  selection: object = {}
 ): {
   focus: ReturnType<typeof vi.fn>
   runFrame: () => void
@@ -31,7 +35,7 @@ function setupScheduledFocus(
   })
   vi.stubGlobal('cancelAnimationFrame', vi.fn())
   vi.stubGlobal('document', { activeElement, body: {} })
-  autoFocusRichEditor(createEditor(focus), null, force)
+  autoFocusRichEditor(createEditor(focus, vi.fn(), selection), null, force)
 
   return {
     focus,
@@ -68,6 +72,21 @@ describe('autoFocusRichEditor', () => {
     expect(focus).toHaveBeenCalledWith('start', { scrollIntoView: false })
   })
 
+  it('preserves a restored text selection on an ordinary remount', () => {
+    const selection = Object.create(TextSelection.prototype)
+    const { focus, runFrame } = setupScheduledFocus(null, false, selection)
+    runFrame()
+
+    expect(focus).toHaveBeenCalledWith(null, { scrollIntoView: false })
+  })
+
+  it('starts at the beginning for an explicit handoff', () => {
+    const selection = Object.create(TextSelection.prototype)
+    const { focus, runFrame } = setupScheduledFocus(null, true, selection)
+    runFrame()
+
+    expect(focus).toHaveBeenCalledWith('start', { scrollIntoView: false })
+  })
   it('honors an explicit focus handoff', () => {
     const { focus, runFrame } = setupScheduledFocus({}, true)
     runFrame()

--- a/src/renderer/src/components/editor/rich-markdown-auto-focus.ts
+++ b/src/renderer/src/components/editor/rich-markdown-auto-focus.ts
@@ -1,4 +1,5 @@
 import type { Editor } from '@tiptap/react'
+import { TextSelection } from '@tiptap/pm/state'
 
 /**
  * Auto-focuses the rich markdown editor on mount so users can start typing
@@ -34,17 +35,18 @@ export function autoFocusRichEditor(
     if (!canTakeFocus) {
       return
     }
-    // Why: pass 'start' (not null) to resolve to a proper TextSelection at
-    // doc position 1. With null, Tiptap keeps whatever the editor's current
-    // selection happens to be on mount — for a freshly-created empty doc
-    // that's an AllSelection, which renders as a visible 0-width highlight
-    // inside the placeholder instead of a normal blinking caret.
+    // Why: a freshly-created empty document has an AllSelection, so focus it at
+    // the start to render a normal caret. Ordinary remounts may already have a
+    // restored TextSelection, which null preserves instead of resetting it.
+    // Explicit handoffs still start at position 1.
+    const focusPosition =
+      force || !(nextEditor.state.selection instanceof TextSelection) ? 'start' : null
     //
     // Why: `scrollIntoView: false` prevents Tiptap's focus command from
     // scrolling the cursor into view, which would otherwise race with
     // useEditorScrollRestore's RAF retry loop and clobber the cached
     // scroll position on every tab switch.
-    nextEditor.commands.focus('start', { scrollIntoView: false })
+    nextEditor.commands.focus(focusPosition, { scrollIntoView: false })
   })
   return () => {
     if (frameId !== null) {

--- a/src/renderer/src/components/editor/rich-markdown-auto-focus.ts
+++ b/src/renderer/src/components/editor/rich-markdown-auto-focus.ts
@@ -31,17 +31,17 @@ export function autoFocusRichEditor(
     // Why: explicit file-open requests may hand focus to the editor; ordinary
     // lazy mounts must still leave unrelated fields and dialogs alone.
     const canTakeFocus =
-      force || active === null || active === document.body || (rootEl?.contains(active) ?? false)
+      force ||
+      active === null ||
+      active === document.body ||
+      (rootEl?.contains(active) ?? false) ||
+      (active instanceof HTMLElement && active.hasAttribute('data-tab-id'))
     if (!canTakeFocus) {
       return
     }
-    // Why: a freshly-created empty document has an AllSelection, so focus it at
-    // the start to render a normal caret. Ordinary remounts may already have a
-    // restored TextSelection, which null preserves instead of resetting it.
-    // Explicit handoffs still start at position 1.
+    // Preserve a restored TextSelection; forced and non-text focus starts at position 1.
     const focusPosition =
       force || !(nextEditor.state.selection instanceof TextSelection) ? 'start' : null
-    //
     // Why: `scrollIntoView: false` prevents Tiptap's focus command from
     // scrolling the cursor into view, which would otherwise race with
     // useEditorScrollRestore's RAF retry loop and clobber the cached

--- a/src/renderer/src/components/editor/useClosedEditorTabCleanup.test.tsx
+++ b/src/renderer/src/components/editor/useClosedEditorTabCleanup.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment happy-dom
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { OpenFile } from '@/store/slices/editor'
+import { richMarkdownSelectionCache } from '@/lib/scroll-cache'
+import { useClosedEditorTabCleanup } from './useClosedEditorTabCleanup'
+
+vi.mock('monaco-editor', () => ({
+  editor: { getModel: vi.fn(() => null) },
+  Uri: { parse: vi.fn((value: string) => value) }
+}))
+
+const openFile = {
+  id: '/repo/a.md',
+  filePath: '/repo/a.md',
+  relativePath: 'a.md',
+  worktreeId: 'worktree-1',
+  language: 'markdown',
+  isDirty: false,
+  mode: 'edit'
+} satisfies OpenFile
+
+beforeEach(() => {
+  richMarkdownSelectionCache.clear()
+})
+
+describe('useClosedEditorTabCleanup', () => {
+  it('removes rich selections owned by a closed tab only', () => {
+    richMarkdownSelectionCache.set('/repo/a.md:rich', { from: 2, to: 2 })
+    richMarkdownSelectionCache.set('/repo/a.md::pane-2:rich', { from: 3, to: 4 })
+    richMarkdownSelectionCache.set('/repo/b.md:rich', { from: 5, to: 5 })
+    const { rerender } = renderHook(({ files }) => useClosedEditorTabCleanup(files), {
+      initialProps: { files: [openFile] }
+    })
+
+    rerender({ files: [] })
+
+    expect(richMarkdownSelectionCache.has('/repo/a.md:rich')).toBe(false)
+    expect(richMarkdownSelectionCache.has('/repo/a.md::pane-2:rich')).toBe(false)
+    expect(richMarkdownSelectionCache.get('/repo/b.md:rich')).toEqual({ from: 5, to: 5 })
+  })
+})

--- a/src/renderer/src/components/editor/useClosedEditorTabCleanup.ts
+++ b/src/renderer/src/components/editor/useClosedEditorTabCleanup.ts
@@ -5,6 +5,7 @@ import {
   cursorPositionCache,
   diffViewStateCache,
   pdfViewPositionCache,
+  richMarkdownSelectionCache,
   scrollTopCache
 } from '@/lib/scroll-cache'
 import {
@@ -47,6 +48,8 @@ function disposeClosedEditorTab(prevId: string, prevFile: OpenFile): void {
       scrollTopCache.delete(`${prevFile.filePath}:rich`)
       scrollTopCache.delete(`${prevFile.filePath}:preview`)
       scrollTopCache.delete(`${prevFile.filePath}:mermaid-diagram`)
+      richMarkdownSelectionCache.delete(`${prevFile.filePath}:rich`)
+      deleteCacheEntriesByPrefix(richMarkdownSelectionCache, `${prevFile.filePath}::`)
       cursorPositionCache.delete(prevFile.filePath)
       deleteCacheEntriesByPrefix(cursorPositionCache, `${prevFile.filePath}::`)
       // Why: only 'edit' tabs ever get a PDF scroll key (see EditorContent).

--- a/src/renderer/src/components/editor/useEditorScrollRestore.test.tsx
+++ b/src/renderer/src/components/editor/useEditorScrollRestore.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment happy-dom
+import type { Editor } from '@tiptap/react'
+import { TextSelection } from '@tiptap/pm/state'
+import { renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { richMarkdownSelectionCache, scrollTopCache } from '@/lib/scroll-cache'
+import { useEditorScrollRestore } from './useEditorScrollRestore'
+import { autoFocusRichEditor } from './rich-markdown-auto-focus'
+
+function createEditor(from: number, to: number, docSize = 100, setTextSelection = vi.fn()): Editor {
+  return {
+    commands: { setTextSelection },
+    state: {
+      doc: { content: { size: docSize } },
+      selection: { from, to }
+    }
+  } as unknown as Editor
+}
+
+beforeEach(() => {
+  richMarkdownSelectionCache.clear()
+  scrollTopCache.clear()
+})
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('useEditorScrollRestore', () => {
+  it('snapshots the rich editor selection before unmount', () => {
+    const container = document.createElement('div')
+    const editor = createEditor(4, 7)
+    const { unmount } = renderHook(() =>
+      useEditorScrollRestore({ current: container }, 'file.md:rich', editor)
+    )
+
+    unmount()
+
+    expect(richMarkdownSelectionCache.get('file.md:rich')).toEqual({ from: 4, to: 7 })
+  })
+
+  it('restores and clamps a cached selection to the current document', () => {
+    const container = document.createElement('div')
+    const setTextSelection = vi.fn()
+    const editor = createEditor(1, 1, 9, setTextSelection)
+    richMarkdownSelectionCache.set('file.md:rich', { from: 6, to: 15 })
+
+    renderHook(() => useEditorScrollRestore({ current: container }, 'file.md:rich', editor))
+
+    expect(setTextSelection).toHaveBeenCalledWith({ from: 6, to: 9 })
+  })
+
+  it('keeps the restored selection when deferred autofocus lands', () => {
+    let runFrame: FrameRequestCallback = () => {
+      throw new Error('expected focus frame to be scheduled')
+    }
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      runFrame = callback
+      return 9
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+    const state: {
+      doc: { content: { size: number } }
+      selection: object
+    } = {
+      doc: { content: { size: 20 } },
+      selection: { from: 1, to: 1 }
+    }
+    const setTextSelection = vi.fn((selection: { from: number; to: number }) => {
+      const restoredSelection = Object.create(TextSelection.prototype)
+      Object.defineProperties(restoredSelection, {
+        from: { value: selection.from },
+        to: { value: selection.to }
+      })
+      state.selection = restoredSelection
+    })
+    const focus = vi.fn()
+    const editor = {
+      isDestroyed: false,
+      commands: { focus, setTextSelection },
+      state
+    } as unknown as Editor
+    const container = document.createElement('div')
+    richMarkdownSelectionCache.set('file.md:rich', { from: 6, to: 8 })
+
+    autoFocusRichEditor(editor, null)
+    renderHook(() => useEditorScrollRestore({ current: container }, 'file.md:rich', editor))
+    runFrame(0)
+
+    expect(setTextSelection).toHaveBeenCalledWith({ from: 6, to: 8 })
+    expect(focus).toHaveBeenCalledWith(null, { scrollIntoView: false })
+  })
+})

--- a/src/renderer/src/components/editor/useEditorScrollRestore.ts
+++ b/src/renderer/src/components/editor/useEditorScrollRestore.ts
@@ -1,9 +1,9 @@
 import { useLayoutEffect, type RefObject } from 'react'
 import type { Editor } from '@tiptap/react'
-import { scrollTopCache, setWithLRU } from '@/lib/scroll-cache'
+import { richMarkdownSelectionCache, scrollTopCache, setWithLRU } from '@/lib/scroll-cache'
 
 /**
- * Saves and restores scroll position for the rich markdown editor.
+ * Saves and restores scroll position and text selection for the rich markdown editor.
  * Extracted to keep the editor component under the max-lines lint limit.
  */
 export function useEditorScrollRestore(
@@ -46,6 +46,15 @@ export function useEditorScrollRestore(
       container.removeEventListener('scroll', onScroll)
     }
   }, [scrollContainerRef, scrollCacheKey])
+  useLayoutEffect(() => {
+    if (!editor) {
+      return
+    }
+    return () => {
+      const { from, to } = editor.state.selection
+      setWithLRU(richMarkdownSelectionCache, scrollCacheKey, { from, to })
+    }
+  }, [editor, scrollCacheKey])
 
   // Restore scroll position with RAF retry loop for async Tiptap content.
   useLayoutEffect(() => {
@@ -84,4 +93,18 @@ export function useEditorScrollRestore(
     // editor is null on the first render, so the retry loop would start before
     // content is mounted and exhaust its 30 frames before Tiptap hydrates.
   }, [scrollContainerRef, scrollCacheKey, editor])
+
+  useLayoutEffect(() => {
+    if (!editor) {
+      return
+    }
+    const savedSelection = richMarkdownSelectionCache.get(scrollCacheKey)
+    if (savedSelection) {
+      const docSize = editor.state.doc.content.size
+      editor.commands.setTextSelection({
+        from: Math.min(savedSelection.from, docSize),
+        to: Math.min(savedSelection.to, docSize)
+      })
+    }
+  }, [editor, scrollCacheKey])
 }

--- a/src/renderer/src/lib/scroll-cache.test.ts
+++ b/src/renderer/src/lib/scroll-cache.test.ts
@@ -3,12 +3,14 @@ import {
   cursorPositionCache,
   diffViewStateCache,
   pdfViewPositionCache,
+  richMarkdownSelectionCache,
   setWithLRU,
   scrollTopCache
 } from './scroll-cache'
 
 beforeEach(() => {
   scrollTopCache.clear()
+  richMarkdownSelectionCache.clear()
   cursorPositionCache.clear()
   diffViewStateCache.clear()
   pdfViewPositionCache.clear()

--- a/src/renderer/src/lib/scroll-cache.ts
+++ b/src/renderer/src/lib/scroll-cache.ts
@@ -35,6 +35,9 @@ export function setWithLRU<K, V>(
 // React re-renders (unlike Zustand, which would broadcast state changes on
 // every scroll event even though no component renders from scroll position).
 export const scrollTopCache = new Map<string, number>()
+// ProseMirror selections use document offsets, so they cannot share Monaco's
+// line-and-column cursor cache.
+export const richMarkdownSelectionCache = new Map<string, { from: number; to: number }>()
 
 // Why: Same rationale as scrollTopCache — module-scoped avoids Zustand
 // re-renders on every cursor move.

--- a/tests/e2e/rich-markdown-selection-restore.spec.ts
+++ b/tests/e2e/rich-markdown-selection-restore.spec.ts
@@ -1,0 +1,76 @@
+import path from 'node:path'
+import { test, expect } from './helpers/orca-app'
+import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import {
+  cleanupMarkdownFixture,
+  createMarkdownFixture,
+  getActiveWorktreeContext,
+  openMarkdownFixture,
+  waitForRichMarkdownEditor
+} from './helpers/markdown-ordered-list-exit'
+
+const SELECTED_TEXT = 'Selection persists across tab switches.'
+
+test.describe('Rich Markdown selection restoration', () => {
+  test.beforeEach(async ({ orcaPage }) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+  })
+
+  test('restores a native text selection after an A to B to A tab switch', async ({
+    orcaPage
+  }, testInfo) => {
+    const context = await getActiveWorktreeContext(orcaPage)
+    let fileA: string | null = null
+    let fileB: string | null = null
+
+    try {
+      fileA = await createMarkdownFixture(
+        context,
+        'selection-restore-a',
+        testInfo.workerIndex,
+        `${SELECTED_TEXT}\n\n## Proof context\n\nThe highlighted sentence must remain selected.\n`
+      )
+      fileB = await createMarkdownFixture(
+        context,
+        'selection-restore-b',
+        testInfo.workerIndex,
+        '# Intermediate tab\n\nSwitching here unmounts the first rich Markdown editor.\n'
+      )
+      await openMarkdownFixture(orcaPage, context, fileA)
+      await openMarkdownFixture(orcaPage, context, fileB)
+
+      const tabA = orcaPage
+        .locator('[data-tab-id]')
+        .filter({ hasText: path.basename(fileA) })
+        .last()
+      const tabB = orcaPage
+        .locator('[data-tab-id]')
+        .filter({ hasText: path.basename(fileB) })
+        .last()
+      await expect(tabA).toBeVisible()
+      await expect(tabB).toBeVisible()
+
+      await tabA.click()
+      const editor = await waitForRichMarkdownEditor(orcaPage)
+      await expect(editor).toContainText(SELECTED_TEXT, { timeout: 25_000 })
+      await editor.click()
+      await orcaPage.keyboard.press('ControlOrMeta+Home')
+      await orcaPage.keyboard.press('Shift+End')
+      await expect
+        .poll(() => orcaPage.evaluate(() => window.getSelection()?.toString().trim() ?? ''))
+        .toBe(SELECTED_TEXT)
+
+      await tabB.click()
+      await expect(editor).toContainText('Intermediate tab', { timeout: 25_000 })
+      await tabA.click()
+      await expect(editor).toContainText(SELECTED_TEXT, { timeout: 25_000 })
+      await expect
+        .poll(() => orcaPage.evaluate(() => window.getSelection()?.toString().trim() ?? ''))
+        .toBe(SELECTED_TEXT)
+    } finally {
+      await cleanupMarkdownFixture(fileA)
+      await cleanupMarkdownFixture(fileB)
+    }
+  })
+})


### PR DESCRIPTION
## ELI5

Switching away from a rich Markdown file and back now returns the caret and selection to the same place instead of resetting them to the start.

## What Changed

- Cache each rich Markdown selection with the existing pane-scoped editor view-state key.
- Restore the selection synchronously on remount and keep deferred autofocus from overwriting it.
- Let a remounted rich editor reclaim DOM focus from the editor tab that activated it, while leaving unrelated controls and dialogs alone.
- Preserve the existing empty-document and explicit Explorer focus behavior.
- Remove legacy and pane-scoped selection entries when the owning tab closes.
- Add unit coverage plus a real Electron A → B → A regression test that asserts the native browser selection.

## Why

Monaco already snapshots scroll and cursor state synchronously, and the rich editor already restores scroll state. The missing piece was ProseMirror selection state. A restored selection also had to be coordinated with the existing deferred autofocus; otherwise the next animation frame moved it back to the document start.

Windows Electron validation caught one additional focus handoff: after clicking the original tab, the restored ProseMirror selection was correct internally but the tab element still owned DOM focus, so no native selection was visible. Commit `4bf7e1e54` allows that specific tab-to-editor handoff and adds E2E coverage for it.

This keeps the existing pane-scoped key design, so two panes showing the same file retain independent view state.

## Linked Issue

Fixes #14800

## Visual Proof

Windows Electron, rich Markdown editor, A → B → A:

| 1. Select text in A | 2. Switch to B | 3. Return to A; selection restored |
| --- | --- | --- |
| <img width="1879" height="1128" alt="Selected text before switching tabs" src="https://github.com/user-attachments/assets/190ec893-8f14-4a34-9c9f-87a4546b317f" /> | <img width="1879" height="1128" alt="Intermediate rich Markdown tab" src="https://github.com/user-attachments/assets/8660aeb5-72fc-4f34-a03a-6adbc7f1d8ac" /> | <img width="1879" height="1128" alt="Text selection restored after returning to the original tab" src="https://github.com/user-attachments/assets/e8e6986e-51ee-4838-a2f3-34d2614c3b32" /> |

The final capture shows the same native blue highlight after the original editor was unmounted and remounted.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- Windows Electron Playwright E2E: 1 passed; native `window.getSelection()` restored after A → B → A.
- Windows Electron E2E build: passed.
- Focused Vitest: 2 files, 13 tests passed on Windows and in the remote Linux container.
- Oxfmt check: changed files passed.
- Native-plugin and type-aware Oxlint: 0 warnings, 0 errors on Windows and remote Linux.
- Remote Linux container: Node 24, pnpm 10.24.0, offline cached install.
- Full renderer typecheck was attempted previously in a 2.2 GiB container but did not complete because the compiler entered sustained memory pressure; CI/full-suite checks remain pending.

## AI Disclosure

OpenAI Codex (GPT-5) was used for repository inspection, implementation, test development, and code review. The submitted diff was independently reviewed twice, and the author remains responsible for the changes.

## Review

- Security: in-memory numeric document positions only; no new external input or persistence.
- Cross-platform and SSH: no platform APIs or filesystem paths added.
- Backwards compatibility: existing scroll, empty-document autofocus, explicit Explorer focus behavior, and unrelated-control focus guards are retained.
- Performance: one bounded LRU entry per rich editor view-state key, using the existing cache limit.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or N/A with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] pnpm lint, pnpm typecheck, pnpm test, and pnpm build pass (or CI will cover; local preferred)

## Author

- X / Twitter: N/A
