### PR TITLE
fix(agent-hooks): re-fence OpenCode panes and re-poll stale title reads

### DIFF
--- a/src/main/agent-hooks/server-opencode-lifecycle.test.ts
+++ b/src/main/agent-hooks/server-opencode-lifecycle.test.ts
@@ -20,7 +20,8 @@ describe('AgentHookServer OpenCode lifecycle', () => {
     post: (
       payload: Record<string, unknown>,
       launchToken: string,
-      paneKey?: string
+      paneKey?: string,
+      source?: 'opencode' | 'mimo-code'
     ) => Promise<Response>
   }> {
     const server = new AgentHookServer()
@@ -29,8 +30,8 @@ describe('AgentHookServer OpenCode lifecycle', () => {
     const env = server.buildPtyEnv()
     return {
       server,
-      post: (payload, launchToken, paneKey = PANE) =>
-        fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/opencode`, {
+      post: (payload, launchToken, paneKey = PANE, source = 'opencode') =>
+        fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/${source}`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -127,7 +128,7 @@ describe('AgentHookServer OpenCode lifecycle', () => {
     ])
   })
 
-  it('replaces a destination token fence when pane authority transfers', async () => {
+  it('clears the destination token fence when pane authority transfers', async () => {
     const { server, post } = await setup()
     await post(
       { hook_event_name: 'SessionBusy', sessionID: 'target-old' },
@@ -142,6 +143,16 @@ describe('AgentHookServer OpenCode lifecycle', () => {
     )
     await post({ hook_event_name: 'SessionBusy', sessionID: 'source' }, 'source-token')
 
+    // The destination fence rejects the source token until the transfer removes it.
+    await post(
+      { hook_event_name: 'SessionBusy', sessionID: 'source-before-transfer' },
+      'source-token',
+      TARGET_PANE
+    )
+    expect(
+      server.getStatusSnapshot().find((entry) => entry.paneKey === TARGET_PANE)?.providerSession
+    ).toEqual({ key: 'session_id', id: 'target-fresh' })
+
     server.transferPaneAuthority(PANE, TARGET_PANE, 'pty-opencode')
     await post(
       { hook_event_name: 'SessionBusy', sessionID: 'source-after-transfer' },
@@ -154,6 +165,97 @@ describe('AgentHookServer OpenCode lifecycle', () => {
         paneKey: TARGET_PANE,
         providerSession: { key: 'session_id', id: 'source-after-transfer' }
       })
+    ])
+  })
+
+  it('re-fences on a new SessionStart while the pane stays authorized', async () => {
+    const { server, post } = await setup()
+    await post({ hook_event_name: 'SessionBusy', sessionID: 'old' }, 'old-token')
+    server.retirePaneAuthority(PANE)
+    await post({ hook_event_name: 'SessionStart', sessionID: 'restart' }, 'restart-token')
+    await post({ hook_event_name: 'SessionBusy', sessionID: 'restart' }, 'restart-token')
+    // The stale old-token follow-up stays fenced out.
+    await post({ hook_event_name: 'SessionBusy', sessionID: 'old' }, 'old-token')
+    expect(server.getStatusSnapshot()).toEqual([
+      expect.objectContaining({ providerSession: { key: 'session_id', id: 'restart' } })
+    ])
+
+    // Why: the runtime defers retirement while an agent stays in the foreground, so a
+    // genuinely new process can start in a still-authorized pane. Its SessionStart must
+    // replace the stale fence — not be swallowed as a stale event (rowless reuse).
+    await post({ hook_event_name: 'SessionStart', sessionID: 'fresh' }, 'fresh-token')
+    await post({ hook_event_name: 'SessionBusy', sessionID: 'fresh' }, 'fresh-token')
+
+    expect(server.getStatusSnapshot()).toEqual([
+      expect.objectContaining({ providerSession: { key: 'session_id', id: 'fresh' } })
+    ])
+  })
+
+  it('keeps the fence when a live pane sees a tokenless SessionStart', async () => {
+    const { server, post } = await setup()
+    await post({ hook_event_name: 'SessionBusy', sessionID: 'old' }, 'old-token')
+    server.retirePaneAuthority(PANE)
+    await post({ hook_event_name: 'SessionStart', sessionID: 'restart' }, 'restart-token')
+    await post({ hook_event_name: 'SessionBusy', sessionID: 'restart' }, 'restart-token')
+
+    // Why: an untokened boundary cannot prove which process it belongs to, so dropping
+    // the fence for it would reopen the pane to every stale token.
+    await post({ hook_event_name: 'SessionStart', sessionID: 'tokenless' }, '')
+    await post({ hook_event_name: 'SessionBusy', sessionID: 'old' }, 'old-token')
+
+    expect(server.getStatusSnapshot()).toEqual([
+      expect.objectContaining({ providerSession: { key: 'session_id', id: 'restart' } })
+    ])
+  })
+
+  it('does not let a stale explicit prompt re-fence a live pane', async () => {
+    const { server, post } = await setup()
+    await post({ hook_event_name: 'SessionBusy', sessionID: 'old' }, 'old-token')
+    server.retirePaneAuthority(PANE)
+    await post({ hook_event_name: 'SessionStart', sessionID: 'restart' }, 'restart-token')
+    await post({ hook_event_name: 'SessionBusy', sessionID: 'restart' }, 'restart-token')
+
+    // Why: prompts recur mid-session, so honoring one as a process boundary would hand
+    // the pane back to any still-live stale process.
+    await post(
+      {
+        hook_event_name: 'MessagePart',
+        role: 'user',
+        text: 'stale prompt',
+        messageID: 'message-stale',
+        sessionID: 'old'
+      },
+      'old-token'
+    )
+    await post({ hook_event_name: 'SessionBusy', sessionID: 'old' }, 'old-token')
+
+    expect(server.getStatusSnapshot()).toEqual([
+      expect.objectContaining({ providerSession: { key: 'session_id', id: 'restart' }, prompt: '' })
+    ])
+  })
+
+  it('restarts a retired mimo-code pane on an explicit user prompt', async () => {
+    const { server, post } = await setup()
+    await post({ hook_event_name: 'SessionBusy', sessionID: 'old' }, 'old-token', PANE, 'mimo-code')
+    server.retirePaneAuthority(PANE)
+
+    // Why: mimo-code emits no SessionStart, so the explicit prompt is its only restart
+    // boundary — excluding it would strand every retired mimo-code pane.
+    await post(
+      {
+        hook_event_name: 'MessagePart',
+        role: 'user',
+        text: 'continue the task',
+        messageID: 'message-resumed',
+        sessionID: 'resumed'
+      },
+      'resume-token',
+      PANE,
+      'mimo-code'
+    )
+
+    expect(server.getStatusSnapshot()).toEqual([
+      expect.objectContaining({ state: 'working', prompt: 'continue the task' })
     ])
   })
 })

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -1015,6 +1015,22 @@ export class AgentHookServer {
     }
     if (!paneRetired) {
       const tokenFence = this.restartedStatusLaunchTokenHashByPaneKey.get(ownerPaneKey)
+      // Why: deferred retirement lets a new process start in a still-authorized pane, so
+      // its tokened SessionStart re-fences; prompts recur, so a stale process would win.
+      if (
+        event?.hookEventName === 'SessionStart' &&
+        event.isReplay !== true &&
+        tokenFence !== undefined
+      ) {
+        const startedLaunchToken = event.launchToken?.trim()
+        if (startedLaunchToken) {
+          this.restartedStatusLaunchTokenHashByPaneKey.set(
+            ownerPaneKey,
+            createHash('sha256').update(startedLaunchToken).digest('hex')
+          )
+          return 'accept'
+        }
+      }
       if (event && tokenFence) {
         const launchToken = event.launchToken?.trim()
         if (!launchToken || createHash('sha256').update(launchToken).digest('hex') !== tokenFence) {
@@ -1025,16 +1041,17 @@ export class AgentHookServer {
     }
     // Why: a new session boundary or explicit prompt proves a live lifecycle, while its
     // token fences follow-up status without restoring retired orchestration authority.
-    const freshOpenCodePrompt =
-      event?.source === 'opencode' &&
+    // OpenCode-family vendors carry that boundary in an explicit-prompt MessagePart —
+    // mimo-code emits no SessionStart at all, so excluding it strands its retired panes.
+    const freshOpenCodeFamilyPrompt =
+      (event?.source === 'opencode' || event?.source === 'mimo-code') &&
       event.hookEventName === 'MessagePart' &&
       event.hasExplicitPrompt === true
-    if (
-      (event?.hookEventName === 'UserPromptSubmit' ||
-        event?.hookEventName === 'SessionStart' ||
-        freshOpenCodePrompt) &&
-      event?.isReplay !== true
-    ) {
+    const isRestartBoundary =
+      event?.hookEventName === 'UserPromptSubmit' ||
+      event?.hookEventName === 'SessionStart' ||
+      freshOpenCodeFamilyPrompt
+    if (isRestartBoundary && event?.isReplay !== true) {
       this.closedAgentStatusPaneKeys.delete(paneKey)
       this.closedAgentStatusPaneKeys.delete(ownerPaneKey)
       const launchToken = event.launchToken?.trim()

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -13095,7 +13095,11 @@ describe('OrcaRuntimeService', () => {
   it('keeps OpenCode launch authority while command-finished leaves it in foreground', async () => {
     const spawn = vi.fn().mockResolvedValue({ id: 'pty-opencode', incarnationId: 'process-1' })
     const retireAuthority = vi.fn()
-    const getForegroundProcess = vi.fn(async () => 'opencode')
+    let resolveForegroundProcess: ((process: string | null) => void) | undefined
+    const foregroundProcess = new Promise<string | null>((resolve) => {
+      resolveForegroundProcess = resolve
+    })
+    const getForegroundProcess = vi.fn(() => foregroundProcess)
     const runtime = new OrcaRuntimeService(store, undefined, {
       attestAgentHookCompatibilityAuthority: (candidate) => ({
         paneKey: candidate.paneKey,
@@ -13141,19 +13145,23 @@ describe('OrcaRuntimeService', () => {
 
     runtime.onPtyData('pty-opencode', '\x1b]133;D;0\x07', 100)
     await vi.waitFor(() => expect(getForegroundProcess).toHaveBeenCalled())
+    resolveForegroundProcess?.('opencode')
+    await new Promise<void>((resolve) => setImmediate(resolve))
 
     expect(retireAuthority).not.toHaveBeenCalled()
     expect(runtime.verifyOrchestrationCompatibilityCaller(evidence)).not.toBeNull()
   })
 
-  it('ignores a stale OpenCode foreground result after a newer title observation', async () => {
-    let resolveForegroundProcess: ((process: string | null) => void) | undefined
-    const foregroundProcess = new Promise<string | null>((resolve) => {
-      resolveForegroundProcess = resolve
+  it('re-polls after a newer title observation instead of trusting the stale read', async () => {
+    let resolveStaleForegroundProcess: ((process: string | null) => void) | undefined
+    const staleForegroundProcess = new Promise<string | null>((resolve) => {
+      resolveStaleForegroundProcess = resolve
     })
     const spawn = vi.fn().mockResolvedValue({ id: 'pty-opencode-race', incarnationId: 'process-1' })
     const retireAuthority = vi.fn()
-    const getForegroundProcess = vi.fn(() => foregroundProcess)
+    const getForegroundProcess = vi
+      .fn(async (): Promise<string | null> => 'opencode')
+      .mockReturnValueOnce(staleForegroundProcess)
     const runtime = new OrcaRuntimeService(store, undefined, {
       retireAgentHookCompatibilityAuthority: retireAuthority
     })
@@ -13187,13 +13195,66 @@ describe('OrcaRuntimeService', () => {
     })
 
     runtime.onPtyData('pty-opencode-race', '\x1b]133;D;0\x07', 100)
-    await vi.waitFor(() => expect(getForegroundProcess).toHaveBeenCalled())
+    await vi.waitFor(() => expect(getForegroundProcess).toHaveBeenCalledTimes(1))
     runtime.onPtyData('pty-opencode-race', '\x1b]0;OpenCode working\x07', 101)
-    resolveForegroundProcess?.(null)
-    await foregroundProcess
-    await Promise.resolve()
+    resolveStaleForegroundProcess?.(null)
+    // Settles the discarded stale read and the re-poll it schedules.
+    await new Promise<void>((resolve) => setImmediate(resolve))
+    await new Promise<void>((resolve) => setImmediate(resolve))
 
     expect(retireAuthority).not.toHaveBeenCalled()
+  })
+
+  it('retires OpenCode launch authority when the re-poll finds no agent in foreground', async () => {
+    let resolveStaleForegroundProcess: ((process: string | null) => void) | undefined
+    const staleForegroundProcess = new Promise<string | null>((resolve) => {
+      resolveStaleForegroundProcess = resolve
+    })
+    const spawn = vi.fn().mockResolvedValue({ id: 'pty-opencode-gone', incarnationId: 'process-1' })
+    const retireAuthority = vi.fn()
+    const getForegroundProcess = vi
+      .fn(async (): Promise<string | null> => 'bash')
+      .mockReturnValueOnce(staleForegroundProcess)
+    const runtime = new OrcaRuntimeService(store, undefined, {
+      retireAgentHookCompatibilityAuthority: retireAuthority
+    })
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess
+    })
+    runtime.setNotifier({
+      worktreesChanged: vi.fn(),
+      reposChanged: vi.fn(),
+      activateWorktree: vi.fn(),
+      createTerminal: vi.fn(),
+      revealTerminalSession: vi.fn().mockResolvedValue({ tabId: 'tab-opencode-gone' }),
+      splitTerminal: vi.fn(),
+      renameTerminal: vi.fn(),
+      focusTerminal: vi.fn(),
+      closeTerminal: vi.fn(),
+      sleepWorktree: vi.fn(),
+      terminalFitOverrideChanged: vi.fn(),
+      terminalDriverChanged: vi.fn()
+    })
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, { tabs: [], leaves: [] })
+
+    await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+      command: 'opencode',
+      launchConfig: { agentCommand: 'opencode', agentArgs: '', agentEnv: {} },
+      launchAgent: 'opencode'
+    })
+    const spawnEnv =
+      (spawn.mock.calls[0]?.[0] as { env?: Record<string, string> } | undefined)?.env ?? {}
+
+    runtime.onPtyData('pty-opencode-gone', '\x1b]133;D;0\x07', 100)
+    await vi.waitFor(() => expect(getForegroundProcess).toHaveBeenCalledTimes(1))
+    runtime.onPtyData('pty-opencode-gone', '\x1b]0;OpenCode working\x07', 101)
+    resolveStaleForegroundProcess?.(null)
+
+    await vi.waitFor(() => expect(retireAuthority).toHaveBeenCalledWith(spawnEnv.ORCA_PANE_KEY))
   })
 
   it('retires only receipted restored PTY authority on command completion and exit', () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1876,6 +1876,8 @@ const MOBILE_TERMINAL_CREATE_RESULT_TTL_MS = 60_000
 const WORKTREE_CREATE_RESULT_TTL_MS = 60_000
 const FOREGROUND_AGENT_WRAPPER_RETRY_INTERVAL_MS = 150
 const FOREGROUND_AGENT_WRAPPER_RETRY_TIMEOUT_MS = 6_500
+// Bounded so a PTY emitting titles in a tight loop cannot re-poll forever.
+const OPENCODE_COMMAND_FINISHED_STALE_TITLE_RETRIES = 2
 const BRACKETED_PASTE_BEGIN = '\x1b[200~'
 const BRACKETED_PASTE_END = '\x1b[201~'
 const BRACKETED_PASTE_QUIET_MS = 1500
@@ -12742,7 +12744,10 @@ export class OrcaRuntimeService {
     }
   }
 
-  private retirePtyAgentLaunchAuthorityAfterCommandFinished(ptyId: string): void {
+  private retirePtyAgentLaunchAuthorityAfterCommandFinished(
+    ptyId: string,
+    remainingStaleTitleRetries = OPENCODE_COMMAND_FINISHED_STALE_TITLE_RETRIES
+  ): void {
     const pty = this.ptysById.get(ptyId)
     if (pty?.launchAgent !== 'opencode') {
       this.retirePtyAgentLaunchAuthority(ptyId)
@@ -12760,9 +12765,20 @@ export class OrcaRuntimeService {
       if (
         current !== pty ||
         current.incarnationId !== incarnationId ||
-        current.lastOscTitleAt !== titleObservedAt ||
         result.controller !== this.ptyController
       ) {
+        return
+      }
+      if (current.lastOscTitleAt !== titleObservedAt) {
+        // Why: a newer title raced this read, so the result proves nothing. Drop
+        // it but re-poll, otherwise authority survives an OpenCode exit until
+        // the next command-finished event.
+        if (remainingStaleTitleRetries > 0) {
+          this.retirePtyAgentLaunchAuthorityAfterCommandFinished(
+            ptyId,
+            remainingStaleTitleRetries - 1
+          )
+        }
         return
       }
       if (result.available && recognizeAgentProcess(result.process)?.agent === 'opencode') {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​177 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​163 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​43 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​33 |

<!-- /orca-pr-loc -->

Follow-up to #14866 (Preserve OpenCode session across command completion).

## What changed

**Re-fence a still-authorized pane on a new SessionStart** (`src/main/agent-hooks/server.ts`)
The runtime defers launch-authority retirement while an agent stays in the foreground, so a genuinely new OpenCode process can start in a pane that still carries the previous restart's token fence. Its `SessionStart` previously hit the fence check first and was suppressed, leaving the reused pane rowless (the STA-3386 case this feature targets). A tokened `SessionStart` on a non-retired pane now replaces the stale fence and is accepted. Tokenless boundaries and explicit prompts deliberately do **not** re-fence — they cannot prove which process they belong to, and prompts recur mid-session.

**Restore mimo-code's restart boundary** (`src/main/agent-hooks/server.ts`)
mimo-code emits no `SessionStart` at all, so restricting the explicit-prompt boundary to opencode-only stranded every retired mimo-code pane. The explicit-prompt `MessagePart` restart boundary now covers the whole OpenCode family again, matching the plugin behavior for both.

**Bounded re-poll instead of dropping the read** (`src/main/runtime/orca-runtime.ts`)
When a newer title observation races the command-finished foreground read, the stale result is dropped and the read is re-issued (bounded to 2 retries) instead of silently giving up. This closes the window where authority survived an OpenCode exit until the *next* command-finished event.

## Tests
- New lifecycle tests: re-fence on new `SessionStart` while pane stays authorized; tokenless `SessionStart` keeps the fence; stale explicit prompt does not re-fence; retired mimo-code pane restarts on an explicit user prompt; destination token fence cleared on pane-authority transfer.
- New runtime tests: re-polls after a newer title observation; retires authority when the re-poll finds no agent in foreground.
- `vitest`: agent-hooks + opencode + mimo + shared listener suites (724 passed), runtime OpenCode authority tests (7 passed).
- `tsc --noEmit -p config/tsconfig.node.json` clean.