### PR TITLE
fix(cursor): replace dropped --yolo default with --force

### DIFF
--- a/src/main/persistence-settings-update.test.ts
+++ b/src/main/persistence-settings-update.test.ts
@@ -429,7 +429,7 @@ describe('Store', () => {
     expect(store.getSettings().agentDefaultArgs).toMatchObject({
       claude: '--dangerously-skip-permissions',
       codex: '--dangerously-bypass-approvals-and-sandbox',
-      cursor: '--yolo'
+      cursor: '--force'
     })
     expect(store.getSettings().agentDefaultEnv).toMatchObject({
       goose: { GOOSE_MODE: 'auto' }
@@ -482,6 +482,29 @@ describe('Store', () => {
       '--model opencode/gpt-5'
     )
     expect((readDataFile() as PersistedState).settings.agentDefaultArgs?.kilo).toBe('')
+  })
+
+  it('rewrites persisted Cursor --yolo args to --force', async () => {
+    writeFileSync(
+      join(testState.dir, 'orca-data.json'),
+      JSON.stringify({
+        settings: {
+          agentYoloDefaultsMigrated: true,
+          agentDefaultArgs: {
+            cursor: '--yolo --model auto',
+            claude: '--dangerously-skip-permissions'
+          }
+        }
+      })
+    )
+    const store = await createStore()
+    store.flush()
+
+    expect(store.getSettings().agentDefaultArgs?.cursor).toBe('--force --model auto')
+    expect(store.getSettings().agentDefaultArgs?.claude).toBe('--dangerously-skip-permissions')
+    expect((readDataFile() as PersistedState).settings.agentDefaultArgs?.cursor).toBe(
+      '--force --model auto'
+    )
   })
 
   it('normalizes app icon on load and update', async () => {

--- a/src/main/persistence/loading-store/store.ts
+++ b/src/main/persistence/loading-store/store.ts
@@ -1075,7 +1075,8 @@ export class Store {
         if (
           parsed.settings?.agentYoloDefaultsMigrated !== true ||
           hasUnsupportedTuiAgentArgs('opencode', parsed.settings?.agentDefaultArgs?.opencode) ||
-          hasUnsupportedTuiAgentArgs('kilo', parsed.settings?.agentDefaultArgs?.kilo)
+          hasUnsupportedTuiAgentArgs('kilo', parsed.settings?.agentDefaultArgs?.kilo) ||
+          hasUnsupportedTuiAgentArgs('cursor', parsed.settings?.agentDefaultArgs?.cursor)
         ) {
           this.loadNeedsSave = true
         }

--- a/src/shared/constants.test.ts
+++ b/src/shared/constants.test.ts
@@ -136,7 +136,7 @@ describe('getDefaultSettings', () => {
       claude: '--dangerously-skip-permissions',
       codex: '--dangerously-bypass-approvals-and-sandbox',
       gemini: '--yolo',
-      cursor: '--yolo',
+      cursor: '--force',
       copilot: '--yolo',
       grok: '--permission-mode bypassPermissions'
     })

--- a/src/shared/tui-agent-launch-defaults.test.ts
+++ b/src/shared/tui-agent-launch-defaults.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import {
+  hasUnsupportedTuiAgentArgs,
+  normalizeTuiAgentArgsRecord,
+  resolveTuiAgentLaunchArgs
+} from './tui-agent-launch-defaults'
+import { YOLO_TUI_AGENT_ARGS } from './tui-agent-permissions'
+
+describe('tui agent launch defaults', () => {
+  it('defaults Cursor YOLO to --force', () => {
+    expect(YOLO_TUI_AGENT_ARGS.cursor).toBe('--force')
+    expect(resolveTuiAgentLaunchArgs('cursor', undefined)).toBe('--force')
+  })
+
+  it('rewrites persisted Cursor --yolo to --force and keeps extra args', () => {
+    expect(
+      normalizeTuiAgentArgsRecord({
+        cursor: '--yolo --model auto'
+      })
+    ).toEqual({
+      cursor: '--force --model auto'
+    })
+  })
+
+  it('treats persisted Cursor --yolo as stale so load can persist the rewrite', () => {
+    expect(hasUnsupportedTuiAgentArgs('cursor', '--yolo')).toBe(true)
+    expect(hasUnsupportedTuiAgentArgs('cursor', '--force')).toBe(false)
+    expect(hasUnsupportedTuiAgentArgs('cursor', '--yolo --model auto')).toBe(true)
+  })
+
+  it('still strips OpenCode skip-permissions without rewriting Cursor', () => {
+    expect(
+      normalizeTuiAgentArgsRecord({
+        opencode: '--dangerously-skip-permissions --model opencode/gpt-5',
+        cursor: '--force'
+      })
+    ).toEqual({
+      opencode: '--model opencode/gpt-5',
+      cursor: '--force'
+    })
+  })
+})

--- a/src/shared/tui-agent-launch-defaults.ts
+++ b/src/shared/tui-agent-launch-defaults.ts
@@ -7,6 +7,12 @@ const UNSUPPORTED_TUI_AGENT_ARGS: Partial<Record<TuiAgent, readonly string[]>> =
   kilo: ['--dangerously-skip-permissions']
 }
 
+// Why: Cursor Agent renamed YOLO from --yolo to --force; persisted --yolo now exits unknown option.
+const RELOCATED_TUI_AGENT_ARGS: Partial<Record<TuiAgent, readonly { from: string; to: string }[]>> =
+  {
+    cursor: [{ from: '--yolo', to: '--force' }]
+  }
+
 export const DEFAULT_TUI_AGENT_ARGS: Partial<Record<TuiAgent, string>> = YOLO_TUI_AGENT_ARGS
 
 export const DEFAULT_TUI_AGENT_ENV: Partial<Record<TuiAgent, Record<string, string>>> =
@@ -20,17 +26,22 @@ export function hasUnsupportedTuiAgentArgs(agent: TuiAgent, value: unknown): boo
   if (typeof value !== 'string') {
     return false
   }
-  return (UNSUPPORTED_TUI_AGENT_ARGS[agent] ?? []).some((arg) => argPattern(arg).test(value))
+  if ((UNSUPPORTED_TUI_AGENT_ARGS[agent] ?? []).some((arg) => argPattern(arg).test(value))) {
+    return true
+  }
+  return (RELOCATED_TUI_AGENT_ARGS[agent] ?? []).some(({ from }) => argPattern(from).test(value))
 }
 
 function sanitizeTuiAgentLaunchArgs(agent: TuiAgent, args: string): string {
-  const unsupportedArgs = UNSUPPORTED_TUI_AGENT_ARGS[agent]
-  if (!unsupportedArgs) {
-    return args.trim()
+  let next = args
+  for (const { from, to } of RELOCATED_TUI_AGENT_ARGS[agent] ?? []) {
+    next = next.replace(argPattern(from), `$1${to}`)
   }
   // Why: a few agents have removed, relocated, or never exposed Claude-style
   // skip-permission flags on the interactive TUI command Orca launches.
-  return unsupportedArgs.reduce((next, arg) => next.replace(argPattern(arg), ' '), args).trim()
+  return (UNSUPPORTED_TUI_AGENT_ARGS[agent] ?? [])
+    .reduce((sanitized, arg) => sanitized.replace(argPattern(arg), ' '), next)
+    .trim()
 }
 
 export function normalizeTuiAgentArgsRecord(value: unknown): Partial<Record<TuiAgent, string>> {

--- a/src/shared/tui-agent-permissions.test.ts
+++ b/src/shared/tui-agent-permissions.test.ts
@@ -50,6 +50,16 @@ describe('tui agent permissions', () => {
     ).toBe('mixed')
   })
 
+  it('resolves Cursor --force as yolo', () => {
+    expect(
+      resolveTuiAgentPermissionMode({
+        agent: 'cursor',
+        agentArgs: YOLO_TUI_AGENT_ARGS.cursor,
+        agentEnv: {}
+      })
+    ).toBe('yolo')
+  })
+
   it('resolves one Codex yolo launch as yolo', () => {
     expect(
       resolveTuiAgentPermissionMode({

--- a/src/shared/tui-agent-permissions.ts
+++ b/src/shared/tui-agent-permissions.ts
@@ -18,7 +18,7 @@ export const YOLO_TUI_AGENT_ARGS: Partial<Record<TuiAgent, string>> = {
   cline: '--auto-approve true',
   'command-code': '--yolo',
   continue: '--allow "*"',
-  cursor: '--yolo',
+  cursor: '--force',
   kimi: '--yolo',
   'mistral-vibe': '--agent auto-approve',
   'qwen-code': '--approval-mode yolo',

--- a/src/shared/tui-agent-startup.test.ts
+++ b/src/shared/tui-agent-startup.test.ts
@@ -732,6 +732,21 @@ describe('tui agent startup plans', () => {
     expect(plan?.launchConfig).toEqual({ agentCommand: 'claude', agentArgs: '', agentEnv: {} })
   })
 
+  it('rewrites persisted Cursor --yolo onto --force before launch', () => {
+    const agentDefaultArgs = normalizeTuiAgentArgsRecord({
+      cursor: '--yolo'
+    })
+    const plan = buildAgentStartupPlan({
+      agent: 'cursor',
+      prompt: 'fix it',
+      cmdOverrides: {},
+      agentArgs: resolveTuiAgentLaunchArgs('cursor', agentDefaultArgs),
+      platform: 'linux'
+    })
+
+    expect(plan?.launchCommand).toBe("cursor-agent '--force' 'fix it'")
+  })
+
   it('does not append the unsupported OpenCode TUI skip-permissions arg', () => {
     const agentDefaultArgs = normalizeTuiAgentArgsRecord({
       opencode: '--dangerously-skip-permissions'


### PR DESCRIPTION
## ELI5

Orca still starts Cursor Agent with `--yolo`. Newer `cursor-agent` does not know that flag, so the tab dies immediately. This PR starts it with `--force` instead, and rewrites old saved `--yolo` settings so existing installs do not stay broken.

## What Changed

- Default Cursor YOLO launch arg is now `--force` (`YOLO_TUI_AGENT_ARGS.cursor`).
- Persisted `cursor` args that still contain `--yolo` are rewritten to `--force` on load/save (same sanitize path as OpenCode/Kilo stale flags, but replace instead of strip so extra user args stay).
- Load persists that rewrite so `orca-data.json` does not keep the dead flag.

## Why

Current `cursor-agent --help` documents `-f, --force` (“Force allow commands unless explicitly denied”) and rejects `--yolo` with `error: unknown option '--yolo'`. The default was last verified in #5185 when `--yolo` still worked. `agentYoloDefaultsMigrated` never overwrites an already-migrated `cursor` value, so changing only the default would leave existing YOLO users broken.

OpenCode/Kilo already scrub removed flags. Cursor still has a YOLO flag, so this relocates `--yolo` → `--force` instead of deleting it.

## Linked Issue

Fixes #14944

## Visual Proof

N/A — launch argv / persisted settings only. Settings → Agents still shows the same YOLO/Manual/Mixed control; only the Cursor command string behind YOLO changes.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Local (macOS):

```text
pnpm exec vitest run --config config/vitest.config.ts \
  src/shared/tui-agent-launch-defaults.test.ts \
  src/shared/tui-agent-permissions.test.ts \
  src/shared/tui-agent-startup.test.ts \
  src/shared/constants.test.ts \
  src/main/persistence-settings-update.test.ts
```

144 tests passed. I did not run a live Cursor Agent pane in this checkout (no packaged Orca build). CI should cover lint/typecheck/full test.

Platforms actually exercised: unit tests only (macOS host). The change is a shared string rewrite used by local, SSH, and Windows launch paths.

## Review

- **Cross-platform:** argv rewrite is in shared launch-default sanitization. Windows/Linux/macOS all go through `normalizeTuiAgentArgsRecord` / `resolveTuiAgentLaunchArgs`. No path, shortcut, or shell-specific code.
- **SSH / remote / folder workspaces:** settings are host-persisted and applied when building the launch command; the same sanitize runs on load/update. No assumption that Git or a local `cursor-agent` exists at persist time.
- **Agents / integrations:** only Cursor’s YOLO token is relocated. OpenCode/Kilo strip behavior is unchanged and covered by the existing persistence test plus a regression that Cursor `--force` is left alone.
- **Performance:** one extra regex pass per agent on settings normalize (load/save), not a hot path.
- **UI:** no visual/layout change.
- **Security:** `--force` is the documented Cursor equivalent of the previous auto-approve default. We do not broaden permissions beyond what YOLO already meant. Custom extra args are preserved.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Local: targeted vitest + oxlint on touched files + `pnpm typecheck:node`. Full `pnpm lint` / `pnpm test` / `pnpm build` left to CI (repo wants pnpm 10 / Node 24; this machine is pnpm 9 / Node 22).

## Author

- X / Twitter: [@kyungyeolb](https://x.com/kyungyeolb)
