### PR TITLE
fix(repos): never probe the client filesystem for a remote repo icon

### DIFF
--- a/src/main/repo-icon-autodetect.test.ts
+++ b/src/main/repo-icon-autodetect.test.ts
@@ -144,6 +144,30 @@ describe('detectRepoIcon', () => {
     await expect(detectRepoIcon({ repoPath, kind: 'folder' })).resolves.toBeUndefined()
   })
 
+  it('returns no icon for an SSH-hosted repo whose filesystem provider is missing', async () => {
+    // Why: the same path exists on the client machine — reading it would hand
+    // back the local repository's icon for a remote repo.
+    const repoPath = await makeTempRepoDir()
+    await writeFile(join(repoPath, 'favicon.png'), Buffer.from(PNG_1X1_BASE64, 'base64'))
+    await writeFile(
+      join(repoPath, 'package.json'),
+      JSON.stringify({ homepage: 'https://app.example.com/docs' })
+    )
+
+    await expect(
+      detectRepoIcon({ repoPath, kind: 'folder', connectionId: 'ssh-target-not-connected' })
+    ).resolves.toBeUndefined()
+  })
+
+  it('still detects local icons when the repo has no connection', async () => {
+    const repoPath = await makeTempRepoDir()
+    await writeFile(join(repoPath, 'favicon.png'), Buffer.from(PNG_1X1_BASE64, 'base64'))
+
+    await expect(
+      detectRepoIcon({ repoPath, kind: 'folder', connectionId: null })
+    ).resolves.toMatchObject({ source: 'file', label: 'favicon.png' })
+  })
+
   it('falls back to the GitHub owner avatar for GitHub repos', async () => {
     const repoPath = await makeTempRepoDir()
     await gitExecFileAsync(['init'], { cwd: repoPath })

--- a/src/main/repo-icon-autodetect.ts
+++ b/src/main/repo-icon-autodetect.ts
@@ -103,16 +103,20 @@ export async function detectRepoIcon({
 }): Promise<RepoIcon | undefined> {
   try {
     const fsProvider = connectionId ? getSshFilesystemProvider(connectionId) : undefined
-    const fileIcon = await detectRepoFileIcon(repoPath, fsProvider)
-    if (fileIcon) {
-      return fileIcon
-    }
+    // Why: a remote repoPath with no provider must not be probed on the client
+    // filesystem — a same-named local path answers for the wrong repository.
+    if (fsProvider || !connectionId) {
+      const fileIcon = await detectRepoFileIcon(repoPath, { connectionId, fsProvider })
+      if (fileIcon) {
+        return fileIcon
+      }
 
-    const homepageIcon = fsProvider
-      ? await detectRemotePackageHomepageIcon(repoPath, fsProvider)
-      : await detectLocalPackageHomepageIcon(repoPath)
-    if (homepageIcon) {
-      return homepageIcon
+      const homepageIcon = fsProvider
+        ? await detectRemotePackageHomepageIcon(repoPath, fsProvider)
+        : await detectLocalPackageHomepageIcon(repoPath)
+      if (homepageIcon) {
+        return homepageIcon
+      }
     }
 
     if (kind === 'git') {

--- a/src/main/repo-icon-file-detection.test.ts
+++ b/src/main/repo-icon-file-detection.test.ts
@@ -1,6 +1,15 @@
+import { readFile, stat } from 'node:fs/promises'
+import type * as FsPromisesModule from 'node:fs/promises'
 import { describe, expect, it, vi } from 'vitest'
 import type { FileReadResult, FileStat, IFilesystemProvider } from './providers/types'
 import { detectRepoFileIcon } from './repo-icon-file-detection'
+
+// Why: the boundary assertion is "no local read happened", which needs the real
+// fs entrypoints spied rather than stubbed.
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof FsPromisesModule>()
+  return { ...actual, stat: vi.fn(actual.stat), readFile: vi.fn(actual.readFile) }
+})
 
 const WEBP_BASE64 = 'UklGRhoAAABXRUJQVlA4IA4AAAAwAQCdASoBAAEAAQIlSkwAAA=='
 const PNG_BASE64 =
@@ -28,7 +37,7 @@ describe('detectRepoFileIcon remote probing', () => {
       readFile: async () => ({ content: WEBP_BASE64, isBinary: true, mimeType: 'image/webp' })
     })
 
-    await expect(detectRepoFileIcon('/repo', provider)).resolves.toEqual({
+    await expect(detectRepoFileIcon('/repo', { fsProvider: provider })).resolves.toEqual({
       type: 'image',
       src: `data:image/webp;base64,${WEBP_BASE64}`,
       source: 'file',
@@ -52,7 +61,7 @@ describe('detectRepoFileIcon remote probing', () => {
       }
     })
 
-    await expect(detectRepoFileIcon('/repo', provider)).resolves.toMatchObject({
+    await expect(detectRepoFileIcon('/repo', { fsProvider: provider })).resolves.toMatchObject({
       source: 'file',
       label: 'favicon.png'
     })
@@ -75,8 +84,30 @@ describe('detectRepoFileIcon remote probing', () => {
       }
     })
 
-    await expect(detectRepoFileIcon('/repo', provider)).resolves.toBeNull()
+    await expect(detectRepoFileIcon('/repo', { fsProvider: provider })).resolves.toBeNull()
     expect(maxActiveStats).toBeGreaterThan(1)
     expect(maxActiveStats).toBeLessThanOrEqual(6)
+  })
+})
+
+describe('detectRepoFileIcon connection boundary', () => {
+  it('never reads the client filesystem for a remote repo whose provider is missing', async () => {
+    vi.mocked(stat).mockClear()
+    vi.mocked(readFile).mockClear()
+
+    await expect(
+      detectRepoFileIcon('/repo', { connectionId: 'ssh-target-1', fsProvider: undefined })
+    ).resolves.toBeNull()
+
+    expect(stat).not.toHaveBeenCalled()
+    expect(readFile).not.toHaveBeenCalled()
+  })
+
+  it('still probes the local filesystem for a repo with no connection', async () => {
+    vi.mocked(stat).mockClear()
+
+    await expect(detectRepoFileIcon('/repo', { connectionId: null })).resolves.toBeNull()
+
+    expect(stat).toHaveBeenCalled()
   })
 })

--- a/src/main/repo-icon-file-detection.ts
+++ b/src/main/repo-icon-file-detection.ts
@@ -260,7 +260,18 @@ async function detectRemoteImageIcon(
 
 export function detectRepoFileIcon(
   repoPath: string,
-  fsProvider?: IFilesystemProvider
+  {
+    connectionId,
+    fsProvider
+  }: { connectionId?: string | null; fsProvider?: IFilesystemProvider } = {}
 ): Promise<RepoIcon | null> {
-  return fsProvider ? detectRemoteImageIcon(repoPath, fsProvider) : detectLocalImageIcon(repoPath)
+  if (fsProvider) {
+    return detectRemoteImageIcon(repoPath, fsProvider)
+  }
+  if (connectionId) {
+    // Why: repoPath lives on the SSH host, so a dropped provider must fail closed —
+    // a same-named local path would hand back another repository's icon.
+    return Promise.resolve(null)
+  }
+  return detectLocalImageIcon(repoPath)
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​58 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​55 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​26 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​15 |

<!-- /orca-pr-loc -->

## The rule

An operation on a **remote** `repoPath` must never fall back to the client machine's filesystem. "We could not ask the host" has to fail closed. Already stated in:

- `src/renderer/src/lib/connection-context.ts:22-24` — *"Callers must not fall back to a LOCAL read of a remote path"*
- `src/main/source-control/repo-default-branch.ts:76-78` — *"a dropped SSH provider must not fall back to local git — the repoPath is remote, so a local run could answer for the wrong repo"*
- `src/main/runtime/orca-runtime.ts:24242-24246`

## The site

`src/main/repo-icon-file-detection.ts:265` (pre-change):

```ts
return fsProvider ? detectRemoteImageIcon(repoPath, fsProvider) : detectLocalImageIcon(repoPath)
```

reached from `src/main/repo-icon-autodetect.ts:105-113`. The ternary keys off *provider presence*, not *repo location*. When the repo is SSH-hosted but `getSshFilesystemProvider(connectionId)` returns `undefined` — connection dropped, or not yet reattached after a restore — this stats and reads the **client** filesystem at a remote absolute path. On a machine where a same-named path exists locally (very common: `~/code/<repo>` on both sides), the sidebar shows the *wrong repository's* icon, silently and persistently, since the detected icon is stored on the repo record at add time.

The identical fallback sat five lines below in the package-homepage probe (`detectLocalPackageHomepageIcon`), so it is closed by the same gate.

## The fix

`connectionId` was already resolved in `detectRepoIcon` — it just was not passed down. It is now threaded into `detectRepoFileIcon`, which distinguishes the three cases explicitly:

| repo | provider | behavior |
| --- | --- | --- |
| local (`connectionId` null/undefined) | — | local probe, **unchanged** |
| remote | present | remote probe, **unchanged** |
| remote | missing | **no icon** (the existing not-detected path) |

`detectRepoIcon` gates both filesystem probes on the same condition. The GitHub-avatar fallback is deliberately untouched: it routes through the connection-aware git transport (`getRepoSlug(repoPath, connectionId)`), not the client filesystem, so a missing *filesystem* provider must not suppress it.

Remoteness is derived from the threaded connection identity only — never inferred from the path string.

## Red-first evidence

Both new assertions were verified failing before the fix, by reverting source while keeping the tests.

**RED-A — end-to-end, source reverted to `HEAD` (`git checkout HEAD -- src/main/repo-icon-autodetect.ts`).** A real temp repo with a `favicon.png`, `connectionId: 'ssh-target-not-connected'`, no provider registered:

```
FAIL src/main/repo-icon-autodetect.test.ts > detectRepoIcon >
     returns no icon for an SSH-hosted repo whose filesystem provider is missing
AssertionError: expected { type: 'image', …(3) } to be undefined

- Expected: undefined
+ Received: {
    "label": "favicon.png",
    "source": "file",
    "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB…",
    "type": "image",
  }

Tests  1 failed | 15 passed (16)
```

That received value **is the defect**: the local repo's icon returned for a remote repo.

**RED-B — guard-only revert** (new signature kept, only the `if (connectionId) return null` block deleted), so the unit assertion cannot pass for the wrong reason:

```
FAIL src/main/repo-icon-file-detection.test.ts > detectRepoFileIcon connection boundary >
     never reads the client filesystem for a remote repo whose provider is missing

expect(stat).not.toHaveBeenCalled()
  37th vi.fn() call: [ "/repo/src/index.html" ]
  Number of calls: 37

Tests  1 failed | 4 passed (5)
```

37 local `stat` calls against the remote path. The unit test spies the real `node:fs/promises` entrypoints, so it asserts the absence of the read itself rather than only the return value.

**GREEN** (fix restored): `Test Files 3 passed (3) · Tests 28 passed (28)` across `repo-icon-file-detection.test.ts`, `repo-icon-autodetect.test.ts`, `repos-add-linked-worktree.test.ts`.

## Local-repo behavior is unchanged

`connectionId` is null/undefined for every local repo (the local add/clone/create call sites do not pass one), so the guard is never reached and the local probe runs exactly as before. Two tests pin this rather than leaving it to inspection:

- `still detects local icons when the repo has no connection` — `connectionId: null` still returns the `favicon.png` icon.
- `still probes the local filesystem for a repo with no connection` — asserts `stat` **is** called, so the guard cannot silently widen into local repos.

All 14 pre-existing icon-detection tests pass untouched (only the `detectRepoFileIcon` call sites were updated for the options-object argument).

## Gates

- `npx oxlint` on the four changed files — clean (verified live: it flagged a `consistent-type-imports` violation on the first pass, which is fixed).
- `oxfmt` via lint-staged; react-doctor config also ran on commit. No prettier.
- `tsc --noEmit -p config/tsconfig.node.json` — clean. No `tsc -b`.
- No `max-lines` disable added.

## Scope

Four files, one behavior change. No new files, no renames, no product surface touched.


## Review QA evidence

Validated commit `64128add6e` in the exact PR worktree with isolated Electron user data and Playwright CDP. `pnpm build:relay` passed before connecting; app identity reported `Orca: brennanb2025/gate-14947`.

A disposable Ubuntu 22.04 Linux SSH target (`linux-arm64`, Node 20.20.2) hosted a real `demo-project` cloned from a transferred Git bundle after direct HTTPS clone was blocked by authentication. Connected `repos.addRemote` discovered the remote `favicon.png`; the rendered sidebar showed the project on the SSH host, and SSH backing-state checks confirmed `/work/demo-project`, branch `main`, its worktree, and only the deliberate icon fixture.

![Connected Linux SSH repo with its remotely detected icon](https://github.com/user-attachments/assets/5b928c35-c0d3-479a-8af3-314f2270e016)

After disconnecting, the rendered app showed `Connect` and `0 hosts`; a real `repos.addRemote` call failed with the not-connected error and left repo state unchanged despite an identically pathed local repo/icon fixture.

![Disconnected SSH host with no local fallback](https://github.com/user-attachments/assets/0de0da30-d34f-4a2f-a7fb-968542338327)

The product API rejects a disconnected remote add before icon detection, so the exact missing-filesystem-provider race cannot be driven through the user surface without bypassing the changed code. That branch is covered by the deterministic no-local-`stat`/`readFile` tests and the end-to-end icon test. Renderer console had zero errors; relay logs showed successful handshake/streaming and clean disconnect. The app session, remote repo/target, container, relay, keys, profile, and temporary bundles were removed after verification.