### PR TITLE
fix(github): scope GHES host-auth cache to the executing connection

### DIFF
--- a/src/main/github/github-api-repository.test.ts
+++ b/src/main/github/github-api-repository.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as SshGitDispatch from '../providers/ssh-git-dispatch'
 import type * as GitHubEnterpriseRepository from './github-enterprise-repository'
 import type * as GhUtils from './gh-utils'
-import type * as SshGitDispatch from '../providers/ssh-git-dispatch'
 
 const {
   getEnterpriseGitHubRepoSlugMock,
@@ -267,5 +267,64 @@ describe('origin repository cache', () => {
     await expect(getOriginGitHubApiRepository('/repo')).resolves.toBeNull()
     await expect(getOriginGitHubApiRepository('/repo')).resolves.toBeNull()
     expect(getEnterpriseGitHubRepoSlugMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not reuse a cached answer after the SSH provider reconnects', async () => {
+    const oldRepository = {
+      owner: 'old-owner',
+      repo: 'widgets',
+      host: 'github.acme-corp.com'
+    }
+    const newRepository = {
+      owner: 'new-owner',
+      repo: 'widgets',
+      host: 'github.acme-corp.com'
+    }
+    getSshGitProviderGenerationMock.mockReturnValue(1)
+    getEnterpriseGitHubRepoSlugMock
+      .mockResolvedValueOnce(oldRepository)
+      .mockResolvedValueOnce(newRepository)
+
+    await expect(getOriginGitHubApiRepository('/repo', 'ssh-1')).resolves.toEqual(oldRepository)
+    await expect(getOriginGitHubApiRepository('/repo', 'ssh-1')).resolves.toEqual(oldRepository)
+    expect(getEnterpriseGitHubRepoSlugMock).toHaveBeenCalledTimes(1)
+
+    getSshGitProviderGenerationMock.mockReturnValue(2)
+    await expect(getOriginGitHubApiRepository('/repo', 'ssh-1')).resolves.toEqual(newRepository)
+    expect(getEnterpriseGitHubRepoSlugMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('isolates an in-flight probe from an older SSH provider generation', async () => {
+    const oldRepository = {
+      owner: 'old-owner',
+      repo: 'widgets',
+      host: 'github.acme-corp.com'
+    }
+    const newRepository = {
+      owner: 'new-owner',
+      repo: 'widgets',
+      host: 'github.acme-corp.com'
+    }
+    let resolveOldProbe: (repository: typeof oldRepository) => void = () => {}
+    const oldProbeResult = new Promise<typeof oldRepository>((resolve) => {
+      resolveOldProbe = resolve
+    })
+    getEnterpriseGitHubRepoSlugMock
+      .mockImplementationOnce(() => oldProbeResult)
+      .mockResolvedValueOnce(newRepository)
+    getSshGitProviderGenerationMock.mockReturnValue(1)
+
+    const oldProbe = getOriginGitHubApiRepository('/repo', 'ssh-1')
+    await vi.waitFor(() => expect(getEnterpriseGitHubRepoSlugMock).toHaveBeenCalledTimes(1))
+
+    getSshGitProviderGenerationMock.mockReturnValue(2)
+    const newProbe = getOriginGitHubApiRepository('/repo', 'ssh-1')
+    await vi.waitFor(() => expect(getEnterpriseGitHubRepoSlugMock).toHaveBeenCalledTimes(2))
+    await expect(newProbe).resolves.toEqual(newRepository)
+
+    resolveOldProbe(oldRepository)
+    await expect(oldProbe).resolves.toEqual(oldRepository)
+    await expect(getOriginGitHubApiRepository('/repo', 'ssh-1')).resolves.toEqual(newRepository)
+    expect(getEnterpriseGitHubRepoSlugMock).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/main/github/github-api-repository.test.ts
+++ b/src/main/github/github-api-repository.test.ts
@@ -294,6 +294,24 @@ describe('origin repository cache', () => {
     expect(getEnterpriseGitHubRepoSlugMock).toHaveBeenCalledTimes(2)
   })
 
+  it('does not reuse a cached negative after the SSH provider reconnects', async () => {
+    const repository = {
+      owner: 'acme',
+      repo: 'widgets',
+      host: 'github.acme-corp.com'
+    }
+    getSshGitProviderGenerationMock.mockReturnValue(1)
+    getEnterpriseGitHubRepoSlugMock.mockResolvedValueOnce(null).mockResolvedValueOnce(repository)
+
+    await expect(getOriginGitHubApiRepository('/repo', 'ssh-1')).resolves.toBeNull()
+    await expect(getOriginGitHubApiRepository('/repo', 'ssh-1')).resolves.toBeNull()
+    expect(getEnterpriseGitHubRepoSlugMock).toHaveBeenCalledTimes(1)
+
+    getSshGitProviderGenerationMock.mockReturnValue(2)
+    await expect(getOriginGitHubApiRepository('/repo', 'ssh-1')).resolves.toEqual(repository)
+    expect(getEnterpriseGitHubRepoSlugMock).toHaveBeenCalledTimes(2)
+  })
+
   it('isolates an in-flight probe from an older SSH provider generation', async () => {
     const oldRepository = {
       owner: 'old-owner',

--- a/src/main/github/github-enterprise-repository.test.ts
+++ b/src/main/github/github-enterprise-repository.test.ts
@@ -27,6 +27,7 @@ import {
   isGitHubHostAuthenticatedForGlobalCli
 } from './github-enterprise-repository'
 import { _resetSshHostnameResolutionCache } from './github-ssh-host-alias-resolution'
+import { registerSshGitProvider, unregisterSshGitProvider } from '../providers/ssh-git-dispatch'
 
 function mockOriginRemote(url: string): void {
   gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
@@ -411,6 +412,74 @@ describe('isGitHubHostAuthenticated', () => {
       false
     )
     expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not reuse a cached answer after the SSH provider reconnects', async () => {
+    const connectionId = 'ssh-reconnected-auth-cache'
+    ghExecFileAsyncMock
+      .mockResolvedValueOnce({
+        stdout:
+          'github.acme-corp.com\n  ✓ Logged in to github.acme-corp.com account kelora (keyring)',
+        stderr: ''
+      })
+      .mockResolvedValueOnce({
+        stdout: 'github.com\n  ✓ Logged in to github.com account kelora (keyring)',
+        stderr: ''
+      })
+
+    registerSshGitProvider(connectionId, {} as never)
+    try {
+      await expect(
+        isGitHubHostAuthenticated('github.acme-corp.com', '/repo', connectionId)
+      ).resolves.toBe(true)
+      await expect(
+        isGitHubHostAuthenticated('github.acme-corp.com', '/repo', connectionId)
+      ).resolves.toBe(true)
+      expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1)
+
+      registerSshGitProvider(connectionId, {} as never)
+      await expect(
+        isGitHubHostAuthenticated('github.acme-corp.com', '/repo', connectionId)
+      ).resolves.toBe(false)
+    } finally {
+      unregisterSshGitProvider(connectionId)
+    }
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not join an in-flight auth probe from an older SSH provider generation', async () => {
+    const connectionId = 'ssh-reconnected-auth-in-flight'
+    let finishOldProbe: (() => void) | undefined
+    ghExecFileAsyncMock
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            finishOldProbe = () =>
+              resolve({
+                stdout:
+                  'github.acme-corp.com\n  ✓ Logged in to github.acme-corp.com account kelora (keyring)',
+                stderr: ''
+              })
+          })
+      )
+      .mockResolvedValueOnce({
+        stdout: 'github.com\n  ✓ Logged in to github.com account kelora (keyring)',
+        stderr: ''
+      })
+
+    registerSshGitProvider(connectionId, {} as never)
+    try {
+      const oldProbe = isGitHubHostAuthenticated('github.acme-corp.com', '/repo', connectionId)
+      registerSshGitProvider(connectionId, {} as never)
+      const newProbe = isGitHubHostAuthenticated('github.acme-corp.com', '/repo', connectionId)
+
+      await expect(newProbe).resolves.toBe(false)
+      expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(2)
+      finishOldProbe?.()
+      await expect(oldProbe).resolves.toBe(true)
+    } finally {
+      unregisterSshGitProvider(connectionId)
+    }
   })
 
   // The probe answers differ by runtime: a local repo gets a cwd, a

--- a/src/main/github/github-enterprise-repository.test.ts
+++ b/src/main/github/github-enterprise-repository.test.ts
@@ -392,14 +392,53 @@ describe('isGitHubHostAuthenticated', () => {
     }
   })
 
-  it('shares the native gh auth probe across SSH connections', async () => {
-    mockHostAuthenticated()
+  it('does not share a cached answer between SSH connections at the same path', async () => {
+    ghExecFileAsyncMock
+      .mockResolvedValueOnce({
+        stdout:
+          'github.acme-corp.com\n  ✓ Logged in to github.acme-corp.com account kelora (keyring)',
+        stderr: ''
+      })
+      .mockResolvedValueOnce({
+        stdout: 'github.com\n  ✓ Logged in to github.com account kelora (keyring)',
+        stderr: ''
+      })
 
-    await isGitHubHostAuthenticated('github.acme-corp.com', '/remote/a', 'ssh-1')
-    await isGitHubHostAuthenticated('github.acme-corp.com', '/remote/b', 'ssh-2')
-
-    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    await expect(isGitHubHostAuthenticated('github.acme-corp.com', '/repo', 'ssh-1')).resolves.toBe(
+      true
+    )
+    await expect(isGitHubHostAuthenticated('github.acme-corp.com', '/repo', 'ssh-2')).resolves.toBe(
+      false
+    )
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(2)
   })
+
+  // The probe answers differ by runtime: a local repo gets a cwd, a
+  // connection-backed repo does not. Sharing one entry attributes whichever
+  // resolved first to both hosts.
+  it.each([
+    ['local resolves first', [null, 'ssh-1'] as const, [true, false]],
+    ['connection resolves first', ['ssh-1', null] as const, [false, true]]
+  ])(
+    'does not cross-attribute auth between a local and a connection-backed repo at the same path (%s)',
+    async (_label, connectionIds, expected) => {
+      ghExecFileAsyncMock.mockImplementation(
+        async (_args: string[], options: { cwd?: string }) => ({
+          stdout: options.cwd
+            ? 'github.acme-corp.com\n  ✓ Logged in to github.acme-corp.com account kelora (keyring)'
+            : 'github.com\n  ✓ Logged in to github.com account kelora (keyring)',
+          stderr: ''
+        })
+      )
+
+      for (const [index, connectionId] of connectionIds.entries()) {
+        await expect(
+          isGitHubHostAuthenticated('github.acme-corp.com', '/repo', connectionId)
+        ).resolves.toBe(expected[index])
+      }
+      expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(2)
+    }
+  )
 
   it('does not target an unconfigured remote host with ambient credentials', async () => {
     mockHostAuthenticated('github.acme-corp.com')

--- a/src/main/github/github-enterprise-repository.ts
+++ b/src/main/github/github-enterprise-repository.ts
@@ -20,7 +20,8 @@ import { resolveSshConfigHostname } from './github-ssh-host-alias-resolution'
 import { parseWslPath } from '../wsl'
 import {
   getSshGitProvider,
-  SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE
+  SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE,
+  getSshGitProviderGeneration
 } from '../providers/ssh-git-dispatch'
 import { isStableMissingGitRemoteError } from '../git/stable-missing-git-remote-error'
 
@@ -45,13 +46,14 @@ const hostAuthInFlight = new Map<string, Promise<string | null | undefined>>()
 // repos, but the answer still describes that connection's runtime (it is probed
 // without the repository cwd). Keying it per connection stops a local repo and
 // an SSH-hosted repo at the same path from adopting each other's auth state.
+// Provider generation fences stale answers when reconnect replaces the runtime.
 function runtimeCacheKey(
   repoPath: string,
   connectionId?: string | null,
   wslDistro?: string
 ): string {
   if (connectionId) {
-    return `connection:${connectionId}`
+    return `connection:${connectionId}:${getSshGitProviderGeneration(connectionId)}`
   }
   const resolvedDistro = wslDistro ?? parseWslPath(repoPath)?.distro
   return `local:${resolvedDistro?.toLowerCase() ?? 'host'}`

--- a/src/main/github/github-enterprise-repository.ts
+++ b/src/main/github/github-enterprise-repository.ts
@@ -41,9 +41,18 @@ type HostAuthCacheEntry = {
 const hostAuthCache = new Map<string, HostAuthCacheEntry>()
 const hostAuthInFlight = new Map<string, Promise<string | null | undefined>>()
 
-// Why: connection-backed Git operations execute remotely, but gh intentionally
-// executes on the native host. Only WSL selects a distinct gh config/runtime.
-function runtimeCacheKey(repoPath: string, wslDistro?: string): string {
+// Why: gh intentionally executes on the native host even for connection-backed
+// repos, but the answer still describes that connection's runtime (it is probed
+// without the repository cwd). Keying it per connection stops a local repo and
+// an SSH-hosted repo at the same path from adopting each other's auth state.
+function runtimeCacheKey(
+  repoPath: string,
+  connectionId?: string | null,
+  wslDistro?: string
+): string {
+  if (connectionId) {
+    return `connection:${connectionId}`
+  }
   const resolvedDistro = wslDistro ?? parseWslPath(repoPath)?.distro
   return `local:${resolvedDistro?.toLowerCase() ?? 'host'}`
 }
@@ -134,7 +143,7 @@ async function resolveAuthenticatedGitHubHost(
   localGitOptions: LocalGitExecOptions = {}
 ): Promise<string | null | undefined> {
   const normalizedHost = normalizeGitHubHost(host)?.authority ?? host.trim().toLowerCase()
-  const cacheKey = `${runtimeCacheKey(repoPath, localGitOptions.wslDistro)}\0${normalizedHost}`
+  const cacheKey = `${runtimeCacheKey(repoPath, connectionId, localGitOptions.wslDistro)}\0${normalizedHost}`
   const now = Date.now()
   pruneHostAuthCache(now)
   const cached = hostAuthCache.get(cacheKey)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​191 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​185 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 |

<!-- /orca-pr-loc -->

## The rule

`AGENTS.md` (Git Binary Compatibility): **capability state must be scoped to the host that executes** — native, WSL distro, SSH provider, or relay connection. State derived on the client must not be attributed to a remote host, and vice versa.

## The site

`src/main/github/github-enterprise-repository.ts:39-44` built the GHES host-auth cache key from `runtimeCacheKey(repoPath, wslDistro)` and **omitted `connectionId`**:

```ts
function runtimeCacheKey(repoPath: string, wslDistro?: string): string {
  const resolvedDistro = wslDistro ?? parseWslPath(repoPath)?.distro
  return `local:${resolvedDistro?.toLowerCase() ?? 'host'}`
}
```

The answer it caches is `gh auth status`, resolved from the **client's** gh (`resolveAuthenticatedGitHubHost`, ~L143-160). Two lookups at the same `repoPath` — one local, one connection-backed, or two different SSH connections — collapse onto one entry. Whichever resolves first decides "is this GHES host authenticated" for all of them.

That is not merely a wasted-spawn issue: the two probes genuinely differ. `ghRepoExecOptions` returns `{ cwd: repoPath }` for a local repo and `{}` for a connection-backed one, so the cached string describes a different gh invocation than the one the second caller would have made. The laptop's answer gets attributed to the remote host.

## The fix

Include the connection identity in the runtime cache key, and scope the entry to the host it actually describes:

```ts
if (connectionId) {
  return `connection:${connectionId}:${getSshGitProviderGeneration(connectionId)}`
}
// unchanged local / WSL path below
```

**Not in scope:** `gh` still executes on the native host on purpose (the design intent recorded at `github-enterprise-repository.ts:39-41`). This PR does not move gh execution — only the cache key changes.

## Red-first evidence

The three new tests were committed first and run against **unmodified** source. All three fail:

```
$ git checkout HEAD~1 -- src/main/github/github-enterprise-repository.ts
$ npx vitest run --config config/vitest.config.ts \
    src/main/github/github-enterprise-repository.test.ts -t 'same path'

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 3 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  isGitHubHostAuthenticated > does not share a cached answer between SSH connections at the same path
AssertionError: expected true to be false // Object.is equality
 FAIL  isGitHubHostAuthenticated > does not cross-attribute auth between a local and a connection-backed repo at the same path (local resolves first)
AssertionError: expected true to be false // Object.is equality
 FAIL  isGitHubHostAuthenticated > does not cross-attribute auth between a local and a connection-backed repo at the same path (connection resolves first)
AssertionError: expected false to be true // Object.is equality

      Tests  3 failed | 36 skipped (39)
```

With the fix applied:

```
$ npx vitest run --config config/vitest.config.ts src/main/github/github-enterprise-repository.test.ts
 Test Files  1 passed (1)
      Tests  41 passed (41)
```

The assertions are on the **answer**, not just the spawn count — each test makes the two probes return different auth inventories (distinguished by whether gh got a `cwd`), so a shared entry produces a demonstrably wrong `true`/`false`, not merely a saved subprocess. The `(local resolves first)` / `(connection resolves first)` pair proves the contamination runs in both directions.

### One existing test was inverted

`shares the native gh auth probe across SSH connections` asserted exactly the defective behavior (`toHaveBeenCalledTimes(1)` for `ssh-1` then `ssh-2`). It is replaced by `does not share a cached answer between SSH connections at the same path`, which asserts the connections get independent answers. Flagging it explicitly since it is a deliberate behavior change, not incidental churn.

### Reconnect fencing

The connection key also includes the SSH provider generation. A reconnect cannot reuse a cached answer or join an in-flight probe started by the replaced provider; two focused tests cover both cases. Repeated calls within one generation still reuse the bounded cache, so reconnect adds at most one fresh auth probe per host.

## Local / WSL behavior is unchanged

When `connectionId` is falsy the function returns the identical `local:${distro ?? 'host'}` key as before — same implicit-WSL-UNC derivation via `parseWslPath`, same `toLowerCase()`. The pre-existing coverage for that path is untouched and still green:

- `caches per runtime+host so detection polling does not re-spawn gh`
- `does not share cache state across WSL distros`
- `derives cache scope from an implicit WSL UNC repository path`
- `probes gh in the repository WSL runtime, not the host/default distro`

One intentional consequence worth naming: `isGitHubHostAuthenticatedForGlobalCli` passes the sentinel `connectionId: 'project-host-validation'` (to suppress `cwd`), so it now gets its own bucket instead of sharing `local:host`. That is the same correctness property — it is a genuinely different gh invocation — at the cost of at most one extra `gh auth status` per 60s TTL.

## Gates

| Gate | Result |
| --- | --- |
| `vitest src/main/github src/main/source-control` | 73 files, **783 passed** |
| `tsc --noEmit -p config/tsconfig.node.json` | exit 0 |
| `oxlint` (changed files) | clean |
| `check-changed-code-quality.mjs` | 0 new findings across 2 changed files (native + type-aware + React Doctor) |
| `check-max-lines-ratchet.mjs` | OK, no new bypasses |
| `check-reliability-gates.mjs` | 85 gates passed |
| `oxfmt` | applied (no prettier) |

Rebased onto `origin/main` at `96b03bab4f` and re-verified green there.

🤖 Generated with [Claude Code](https://claude.ai/code)
