### PR TITLE
STA-4150: define client-hosted browser contracts

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -2644,6 +2644,102 @@
       "demotionRule": "Demote if one paired HTML action can create duplicate client or host browser identities, lose the requested split, steal editor focus before an explicit browser click, lose browser focus after that click, or remove unrelated editor or terminal state on close."
     },
     {
+      "id": "browser-network-tunnel.bounded-fail-closed-route",
+      "title": "Client-hosted browser routes stay bounded and fail closed",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "browser-runtime",
+      "layer": "shared-protocol-main-network-contract",
+      "surfaces": [
+        "client-hosted browser tunnel framing",
+        "execution-host TCP credit flow",
+        "main-owned loopback SOCKS5 route"
+      ],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local", "remote-runtime", "ssh", "wsl"],
+      "coveredPlatforms": ["macos"],
+      "coveredProviders": [],
+      "coverageNotes": "Deterministic protocol, injected-socket, and loopback-listener tests cover strict framing, remote-DNS targets, exact write-settlement credit, bounded receive windows, stale generations, retired stream IDs, half-close ordering, SOCKS CONNECT, bind/close races, listener wildcard normalization, unsupported commands, and unavailable routes. No native, paired, SSH, or WSL destination provider is covered yet.",
+      "motivatingLinks": [
+        "https://linear.app/stably/issue/STA-4150/refactor-remote-browser-to-client-hosted-electron-webviews"
+      ],
+      "invariant": "A client-hosted browser network route preserves destination names for execution-host DNS, admits only versioned bounded frames, replenishes credit only after destination writes settle, rejects stale or reused stream identities, and never falls back to desktop DNS or sockets when the selected route is unavailable. The local SOCKS endpoint accepts only loopback CONNECT and rejects unsupported commands.",
+      "oracle": "Encode and decode each tunnel boundary with exact generation, stream, length, opcode, payload, and credit assertions. Drive one injected destination through open, data, write settlement, receive-window exhaustion, half-close, duplicate stream, stale generation, and teardown. Drive a real loopback SOCKS client through greeting and domain CONNECT, assert the final connector receives the unchanged hostname, echo bytes through the injected route, normalize only listener wildcards, reject BIND, and return failure without another connection when the route is offline.",
+      "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts src/shared/browser-network-capabilities.test.ts src/shared/browser-network-tunnel-protocol.test.ts src/main/browser/browser-network-tunnel-session.test.ts src/main/browser/remote-browser-socks-server.test.ts"
+      ],
+      "testFiles": [
+        "src/shared/browser-network-capabilities.test.ts",
+        "src/shared/browser-network-tunnel-protocol.test.ts",
+        "src/main/browser/browser-network-tunnel-session.test.ts",
+        "src/main/browser/remote-browser-socks-server.test.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/shared/browser-network-tunnel-protocol.test.ts",
+          "assertions": [
+            "remote DNS names round-trip without client resolution",
+            "unknown versions, opcodes, oversized payloads, and length mismatches fail closed"
+          ]
+        },
+        {
+          "file": "src/main/browser/browser-network-tunnel-session.test.ts",
+          "assertions": [
+            "destination writes replenish client credit only after settlement",
+            "stale generations and reused stream IDs cannot replace the current destination"
+          ]
+        },
+        {
+          "file": "src/main/browser/remote-browser-socks-server.test.ts",
+          "assertions": [
+            "domain CONNECT preserves the final execution-host DNS target",
+            "unsupported commands and unavailable routes open no fallback destination"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-08-13",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/shared/browser-network-capabilities.test.ts src/shared/browser-network-tunnel-protocol.test.ts src/main/browser/browser-network-tunnel-session.test.ts src/main/browser/remote-browser-socks-server.test.ts",
+          "result": "passed",
+          "durationSeconds": 0.2,
+          "summary": "Four files passed 25 deterministic capability, codec, credit, generation, half-close, SOCKS routing, remote-DNS, and fail-closed tests."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 2,
+        "scope": "four deterministic protocol, injected-stream, and loopback-socket test files"
+      },
+      "flakeHistory": {
+        "status": "unknown",
+        "evidence": "The deterministic suite passed locally; CI and soak history have not started."
+      },
+      "redGreenEvidence": {
+        "status": "partial",
+        "evidence": "The protocol and tunnel-session oracles fail on origin/main 3246b73add because the modules do not exist, then pass on the candidate. The same source checkout recorded the SOCKS oracle red before its route implementation and green after it. Mutation/revert evidence remains to be collected before promotion."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "Data frames, send credit, pending destination bytes and chunk counts, streams, SOCKS handshake and pipelined application bytes are bounded. Credit returns only from the destination write callback, and the injected transport must explicitly accept each frame. Aggregate route, browser-host, and process ledgers plus drain-aware fair scheduling remain required before live tunnel advertisement."
+      },
+      "promotionCriteria": [
+        "Add aggregate route, browser-host, and process memory ledgers plus fair scheduling.",
+        "Approve all same-host local processes and users as inside the desktop trust boundary or replace SOCKS no-auth with Chromium-compatible process isolation.",
+        "Run one dedicated paired-runtime binary tunnel journey with old/new peer coverage.",
+        "Add SSH2, system SSH, WSL, Linux, and physical Windows evidence.",
+        "Prove an Electron partition routes loopback, DNS, HTTP, HTTPS, WebSocket, workers, and speculative traffic without desktop fallback."
+      ],
+      "knownGaps": [
+        "No runtime capability is advertised and no live paired tunnel or webview uses these primitives yet.",
+        "Aggregate encrypted-WebSocket and destination-buffer accounting is not implemented.",
+        "The loopback SOCKS endpoint uses Chromium-compatible no-auth and is not safe to activate until its desktop trust boundary is approved or isolated.",
+        "SSH, WSL, browserless serve, Electron proxy policy, UDP denial, and desktop DNS/socket capture are not exercised."
+      ],
+      "demotionRule": "Keep experimental or demote if a route can resolve names on the desktop, exceed a byte or stream bound, replenish credit before destination settlement, accept a stale generation or reused stream ID, expose the SOCKS listener off-loopback, accept BIND/UDP, or fall back when the selected route is unavailable."
+    },
+    {
       "id": "browser-stream.bounded-reconnect",
       "title": "Remote browser streams recover within a bounded retry budget",
       "maturity": "experimental",

--- a/src/main/browser/browser-network-tunnel-destination-flow.ts
+++ b/src/main/browser/browser-network-tunnel-destination-flow.ts
@@ -1,0 +1,113 @@
+import {
+  BROWSER_NETWORK_TUNNEL_MAX_DATA_BYTES,
+  decodeBrowserNetworkTunnelWindowUpdate
+} from '../../shared/browser-network-tunnel-protocol'
+import {
+  BROWSER_NETWORK_TUNNEL_INITIAL_WINDOW_BYTES,
+  BROWSER_NETWORK_TUNNEL_MAX_PENDING_SOCKET_BYTES,
+  BROWSER_NETWORK_TUNNEL_MAX_PENDING_SOCKET_CHUNKS,
+  type BrowserNetworkTunnelStream
+} from './browser-network-tunnel-stream-state'
+
+type BrowserNetworkTunnelDestinationFlowActions = {
+  isCurrent: () => boolean
+  sendData: (bytes: Uint8Array<ArrayBufferLike>) => void
+  sendHalfClose: () => void
+  finalizeClose: () => void
+}
+
+export function writeBrowserNetworkDestination(
+  stream: BrowserNetworkTunnelStream,
+  payload: Uint8Array<ArrayBufferLike>,
+  onSettled: (bytes: number) => void
+): string | null {
+  if (!stream.connected || stream.clientEnded) {
+    return 'invalid_client_data'
+  }
+  if (payload.byteLength > stream.receiveCredit) {
+    return 'receive_window_exceeded'
+  }
+  if (payload.byteLength === 0) {
+    return null
+  }
+  stream.receiveCredit -= payload.byteLength
+  const bytes = payload.slice()
+  stream.socket.write(bytes, () => onSettled(bytes.byteLength))
+  return null
+}
+
+export function grantBrowserNetworkDestinationCredit(
+  stream: BrowserNetworkTunnelStream,
+  payload: Uint8Array<ArrayBufferLike>
+): string | null {
+  if (!stream.connected) {
+    return 'invalid_client_credit'
+  }
+  const credit = decodeBrowserNetworkTunnelWindowUpdate(payload)
+  if (!credit || stream.sendCredit + credit > BROWSER_NETWORK_TUNNEL_INITIAL_WINDOW_BYTES) {
+    return 'send_window_overflow'
+  }
+  stream.sendCredit += credit
+  return null
+}
+
+export function queueBrowserNetworkDestinationData(
+  stream: BrowserNetworkTunnelStream,
+  bytes: Uint8Array<ArrayBufferLike>
+): string | null {
+  if (!stream.connected || stream.destinationEnded || stream.destinationClosed) {
+    return 'invalid_destination_data'
+  }
+  if (
+    stream.pendingToClientBytes + bytes.byteLength >
+      BROWSER_NETWORK_TUNNEL_MAX_PENDING_SOCKET_BYTES ||
+    stream.pendingToClient.length >= BROWSER_NETWORK_TUNNEL_MAX_PENDING_SOCKET_CHUNKS
+  ) {
+    return 'destination_buffer_overflow'
+  }
+  stream.pendingToClient.push(bytes.slice())
+  stream.pendingToClientBytes += bytes.byteLength
+  return null
+}
+
+export function flushBrowserNetworkDestination(
+  stream: BrowserNetworkTunnelStream,
+  actions: BrowserNetworkTunnelDestinationFlowActions
+): void {
+  while (stream.sendCredit > 0 && stream.pendingToClient.length > 0 && actions.isCurrent()) {
+    const next = stream.pendingToClient[0]!
+    const length = Math.min(
+      next.byteLength,
+      stream.sendCredit,
+      BROWSER_NETWORK_TUNNEL_MAX_DATA_BYTES
+    )
+    actions.sendData(next.subarray(0, length))
+    stream.sendCredit -= length
+    stream.pendingToClientBytes -= length
+    if (length === next.byteLength) {
+      stream.pendingToClient.shift()
+    } else {
+      stream.pendingToClient[0] = next.slice(length)
+    }
+  }
+  if (!actions.isCurrent()) {
+    return
+  }
+  if (stream.pendingToClient.length > 0) {
+    stream.socket.pause()
+    return
+  }
+  if (stream.destinationEnded) {
+    actions.sendHalfClose()
+    if (!stream.destinationClosed) {
+      return
+    }
+  }
+  if (stream.destinationClosed) {
+    actions.finalizeClose()
+  } else if (stream.sendCredit === 0) {
+    stream.socket.pause()
+  } else {
+    stream.socket.resume()
+  }
+}

--- a/src/main/browser/browser-network-tunnel-frame-sender.ts
+++ b/src/main/browser/browser-network-tunnel-frame-sender.ts
@@ -1,0 +1,16 @@
+import {
+  encodeBrowserNetworkTunnelFrame,
+  type BrowserNetworkTunnelFrame
+} from '../../shared/browser-network-tunnel-protocol'
+import type { BrowserNetworkTunnelSessionOptions } from './browser-network-tunnel-stream-state'
+
+export function sendBrowserNetworkTunnelFrame(
+  sendBinary: BrowserNetworkTunnelSessionOptions['sendBinary'],
+  frame: BrowserNetworkTunnelFrame
+): boolean {
+  try {
+    return sendBinary(encodeBrowserNetworkTunnelFrame(frame))
+  } catch {
+    return false
+  }
+}

--- a/src/main/browser/browser-network-tunnel-session.test.ts
+++ b/src/main/browser/browser-network-tunnel-session.test.ts
@@ -1,0 +1,461 @@
+import { EventEmitter } from 'node:events'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  BrowserNetworkTunnelOpcode,
+  decodeBrowserNetworkTunnelFrame,
+  decodeBrowserNetworkTunnelWindowUpdate,
+  encodeBrowserNetworkTunnelFrame,
+  encodeBrowserNetworkTunnelOpen,
+  encodeBrowserNetworkTunnelWindowUpdate
+} from '../../shared/browser-network-tunnel-protocol'
+import {
+  BROWSER_NETWORK_TUNNEL_INITIAL_WINDOW_BYTES,
+  type BrowserNetworkTunnelSocket
+} from './browser-network-tunnel-stream-state'
+import { BrowserNetworkTunnelSession } from './browser-network-tunnel-session'
+
+class FakeSocket extends EventEmitter implements BrowserNetworkTunnelSocket {
+  readonly writes: Uint8Array<ArrayBufferLike>[] = []
+  readonly writeCallbacks: (() => void)[] = []
+  destroyed = false
+  paused = false
+  ended = false
+
+  setNoDelay(): this {
+    return this
+  }
+
+  pause(): this {
+    this.paused = true
+    return this
+  }
+
+  resume(): this {
+    this.paused = false
+    return this
+  }
+
+  write(bytes: Uint8Array<ArrayBufferLike>, callback?: () => void): boolean {
+    this.writes.push(bytes.slice())
+    if (callback) {
+      this.writeCallbacks.push(callback)
+    }
+    return true
+  }
+
+  end(): this {
+    this.ended = true
+    return this
+  }
+
+  destroy(): this {
+    this.destroyed = true
+    return this
+  }
+}
+
+function frame(
+  opcode: BrowserNetworkTunnelOpcode,
+  payload: Uint8Array<ArrayBufferLike> = new Uint8Array(),
+  streamId = 3,
+  tunnelGeneration = 7
+): Uint8Array {
+  return encodeBrowserNetworkTunnelFrame({ opcode, tunnelGeneration, streamId, payload })
+}
+
+describe('BrowserNetworkTunnelSession', () => {
+  it('opens the exact remote DNS target and grants bounded receive credit', () => {
+    const socket = new FakeSocket()
+    const connect = vi.fn(() => socket)
+    const sent: Uint8Array<ArrayBufferLike>[] = []
+    const session = new BrowserNetworkTunnelSession({
+      tunnelGeneration: 7,
+      connect,
+      sendBinary: (bytes) => {
+        sent.push(bytes)
+        return true
+      }
+    })
+
+    session.handleBinary(
+      frame(
+        BrowserNetworkTunnelOpcode.Open,
+        encodeBrowserNetworkTunnelOpen({ host: 'split-horizon.internal', port: 443 })
+      )
+    )
+    socket.emit('connect')
+
+    expect(connect).toHaveBeenCalledWith({ host: 'split-horizon.internal', port: 443 })
+    expect(socket.paused).toBe(true)
+    expect(sent.map(decodeBrowserNetworkTunnelFrame)).toEqual([
+      expect.objectContaining({ opcode: BrowserNetworkTunnelOpcode.Opened, streamId: 3 }),
+      expect.objectContaining({ opcode: BrowserNetworkTunnelOpcode.WindowUpdate, streamId: 3 })
+    ])
+    const credit = decodeBrowserNetworkTunnelFrame(sent[1]!)
+    expect(credit && decodeBrowserNetworkTunnelWindowUpdate(credit.payload)).toBe(
+      BROWSER_NETWORK_TUNNEL_INITIAL_WINDOW_BYTES
+    )
+  })
+
+  it('replenishes client credit only after the destination write settles', () => {
+    const socket = new FakeSocket()
+    const sent: Uint8Array<ArrayBufferLike>[] = []
+    const session = new BrowserNetworkTunnelSession({
+      tunnelGeneration: 7,
+      connect: () => socket,
+      sendBinary: (bytes) => {
+        sent.push(bytes)
+        return true
+      }
+    })
+    session.handleBinary(
+      frame(
+        BrowserNetworkTunnelOpcode.Open,
+        encodeBrowserNetworkTunnelOpen({ host: 'localhost', port: 8080 })
+      )
+    )
+    socket.emit('connect')
+    sent.length = 0
+
+    session.handleBinary(frame(BrowserNetworkTunnelOpcode.Data, new Uint8Array([1, 2, 3])))
+
+    expect(socket.writes).toEqual([new Uint8Array([1, 2, 3])])
+    expect(sent).toEqual([])
+
+    socket.writeCallbacks[0]?.()
+    const update = decodeBrowserNetworkTunnelFrame(sent[0]!)
+    expect(update?.opcode).toBe(BrowserNetworkTunnelOpcode.WindowUpdate)
+    expect(update && decodeBrowserNetworkTunnelWindowUpdate(update.payload)).toBe(3)
+  })
+
+  it('does not read destination bytes before the client grants credit', () => {
+    const socket = new FakeSocket()
+    const sent: Uint8Array<ArrayBufferLike>[] = []
+    const session = new BrowserNetworkTunnelSession({
+      tunnelGeneration: 7,
+      connect: () => socket,
+      sendBinary: (bytes) => {
+        sent.push(bytes)
+        return true
+      }
+    })
+    session.handleBinary(
+      frame(
+        BrowserNetworkTunnelOpcode.Open,
+        encodeBrowserNetworkTunnelOpen({ host: 'localhost', port: 8080 })
+      )
+    )
+    socket.emit('connect')
+    sent.length = 0
+
+    session.handleBinary(
+      frame(BrowserNetworkTunnelOpcode.WindowUpdate, encodeBrowserNetworkTunnelWindowUpdate(3))
+    )
+    socket.emit('data', new Uint8Array([4, 5, 6, 7]))
+
+    const first = decodeBrowserNetworkTunnelFrame(sent[0]!)
+    expect(first?.opcode).toBe(BrowserNetworkTunnelOpcode.Data)
+    expect(first?.payload).toEqual(new Uint8Array([4, 5, 6]))
+    expect(socket.paused).toBe(true)
+
+    session.handleBinary(
+      frame(BrowserNetworkTunnelOpcode.WindowUpdate, encodeBrowserNetworkTunnelWindowUpdate(1))
+    )
+    const second = decodeBrowserNetworkTunnelFrame(sent[1]!)
+    expect(second?.payload).toEqual(new Uint8Array([7]))
+  })
+
+  it('fences stale generations and closes every stream on disposal', () => {
+    const socket = new FakeSocket()
+    const connect = vi.fn(() => socket)
+    const sent: Uint8Array<ArrayBufferLike>[] = []
+    const session = new BrowserNetworkTunnelSession({
+      tunnelGeneration: 7,
+      connect,
+      sendBinary: (bytes) => {
+        sent.push(bytes)
+        return true
+      }
+    })
+
+    session.handleBinary(
+      frame(
+        BrowserNetworkTunnelOpcode.Open,
+        encodeBrowserNetworkTunnelOpen({ host: 'stale.internal', port: 80 }),
+        3,
+        6
+      )
+    )
+    expect(connect).not.toHaveBeenCalled()
+
+    session.handleBinary(
+      frame(
+        BrowserNetworkTunnelOpcode.Open,
+        encodeBrowserNetworkTunnelOpen({ host: 'current.internal', port: 80 })
+      )
+    )
+    session.close()
+
+    expect(socket.destroyed).toBe(true)
+  })
+
+  it('rejects stream reuse without replacing the original destination', () => {
+    const firstSocket = new FakeSocket()
+    const secondSocket = new FakeSocket()
+    const connect = vi.fn().mockReturnValueOnce(firstSocket).mockReturnValueOnce(secondSocket)
+    const sent: Uint8Array<ArrayBufferLike>[] = []
+    const session = new BrowserNetworkTunnelSession({
+      tunnelGeneration: 7,
+      connect,
+      sendBinary: (bytes) => {
+        sent.push(bytes)
+        return true
+      }
+    })
+    const open = (host: string): void =>
+      session.handleBinary(
+        frame(BrowserNetworkTunnelOpcode.Open, encodeBrowserNetworkTunnelOpen({ host, port: 80 }))
+      )
+
+    open('first.internal')
+    open('second.internal')
+
+    expect(connect).toHaveBeenCalledTimes(1)
+    expect(firstSocket.destroyed).toBe(true)
+    expect(secondSocket.destroyed).toBe(false)
+    const error = decodeBrowserNetworkTunnelFrame(sent.at(-1)!)
+    expect(error?.opcode).toBe(BrowserNetworkTunnelOpcode.Error)
+    expect(error ? new TextDecoder().decode(error.payload) : '').toBe('stream_id_reused')
+  })
+
+  it('rejects current-generation frames for unknown and retired stream IDs', () => {
+    const socket = new FakeSocket()
+    const sent: Uint8Array<ArrayBufferLike>[] = []
+    const connect = vi.fn(() => socket)
+    const session = new BrowserNetworkTunnelSession({
+      tunnelGeneration: 7,
+      connect,
+      sendBinary: (bytes) => {
+        sent.push(bytes)
+        return true
+      }
+    })
+    const open = frame(
+      BrowserNetworkTunnelOpcode.Open,
+      encodeBrowserNetworkTunnelOpen({ host: 'localhost', port: 80 })
+    )
+
+    session.handleBinary(open)
+    session.handleBinary(frame(BrowserNetworkTunnelOpcode.Close))
+    session.handleBinary(open)
+
+    expect(connect).toHaveBeenCalledTimes(1)
+    expect(socket.destroyed).toBe(true)
+    expect(decodeBrowserNetworkTunnelFrame(sent.at(-1)!)?.opcode).toBe(
+      BrowserNetworkTunnelOpcode.Error
+    )
+
+    const otherSocket = new FakeSocket()
+    const unknownSession = new BrowserNetworkTunnelSession({
+      tunnelGeneration: 7,
+      connect: () => otherSocket,
+      sendBinary: () => true
+    })
+    unknownSession.handleBinary(
+      frame(
+        BrowserNetworkTunnelOpcode.Open,
+        encodeBrowserNetworkTunnelOpen({ host: 'localhost', port: 80 })
+      )
+    )
+    unknownSession.handleBinary(frame(BrowserNetworkTunnelOpcode.Data, new Uint8Array([1]), 4))
+    expect(otherSocket.destroyed).toBe(true)
+  })
+
+  it('accepts unused out-of-order stream IDs without permitting reuse', () => {
+    const firstSocket = new FakeSocket()
+    const secondSocket = new FakeSocket()
+    const connect = vi.fn().mockReturnValueOnce(firstSocket).mockReturnValueOnce(secondSocket)
+    const session = new BrowserNetworkTunnelSession({
+      tunnelGeneration: 7,
+      connect,
+      sendBinary: () => true
+    })
+    const open = (streamId: number): void =>
+      session.handleBinary(
+        frame(
+          BrowserNetworkTunnelOpcode.Open,
+          encodeBrowserNetworkTunnelOpen({ host: 'localhost', port: 80 }),
+          streamId
+        )
+      )
+
+    open(5)
+    session.handleBinary(frame(BrowserNetworkTunnelOpcode.Close, new Uint8Array(), 5))
+    open(3)
+
+    expect(connect).toHaveBeenCalledTimes(2)
+    expect(secondSocket.destroyed).toBe(false)
+  })
+
+  it('fences invalid half-close transitions and emits destination EOF once', () => {
+    const socket = new FakeSocket()
+    const sent: Uint8Array<ArrayBufferLike>[] = []
+    const session = new BrowserNetworkTunnelSession({
+      tunnelGeneration: 7,
+      connect: () => socket,
+      sendBinary: (bytes) => {
+        sent.push(bytes)
+        return true
+      }
+    })
+    session.handleBinary(
+      frame(
+        BrowserNetworkTunnelOpcode.Open,
+        encodeBrowserNetworkTunnelOpen({ host: 'localhost', port: 80 })
+      )
+    )
+    socket.emit('connect')
+    session.handleBinary(frame(BrowserNetworkTunnelOpcode.HalfClose))
+    session.handleBinary(frame(BrowserNetworkTunnelOpcode.Data, new Uint8Array([1])))
+    expect(socket.ended).toBe(true)
+    expect(socket.destroyed).toBe(true)
+
+    const responseSocket = new FakeSocket()
+    const responseFrames: Uint8Array<ArrayBufferLike>[] = []
+    const responseSession = new BrowserNetworkTunnelSession({
+      tunnelGeneration: 7,
+      connect: () => responseSocket,
+      sendBinary: (bytes) => {
+        responseFrames.push(bytes)
+        return true
+      }
+    })
+    responseSession.handleBinary(
+      frame(
+        BrowserNetworkTunnelOpcode.Open,
+        encodeBrowserNetworkTunnelOpen({ host: 'localhost', port: 80 })
+      )
+    )
+    responseSocket.emit('connect')
+    responseFrames.length = 0
+    responseSession.handleBinary(
+      frame(BrowserNetworkTunnelOpcode.WindowUpdate, encodeBrowserNetworkTunnelWindowUpdate(1))
+    )
+    responseSocket.emit('data', new Uint8Array([1]))
+    responseSocket.emit('end')
+    responseSession.handleBinary(
+      frame(BrowserNetworkTunnelOpcode.WindowUpdate, encodeBrowserNetworkTunnelWindowUpdate(1))
+    )
+    expect(
+      responseFrames
+        .map(decodeBrowserNetworkTunnelFrame)
+        .filter((item) => item?.opcode === BrowserNetworkTunnelOpcode.HalfClose)
+    ).toHaveLength(1)
+  })
+
+  it('flushes credited destination bytes before close', () => {
+    const socket = new FakeSocket()
+    const sent: Uint8Array<ArrayBufferLike>[] = []
+    const session = new BrowserNetworkTunnelSession({
+      tunnelGeneration: 7,
+      connect: () => socket,
+      sendBinary: (bytes) => {
+        sent.push(bytes)
+        return true
+      }
+    })
+    session.handleBinary(
+      frame(
+        BrowserNetworkTunnelOpcode.Open,
+        encodeBrowserNetworkTunnelOpen({ host: 'localhost', port: 80 })
+      )
+    )
+    socket.emit('connect')
+    sent.length = 0
+    session.handleBinary(
+      frame(BrowserNetworkTunnelOpcode.WindowUpdate, encodeBrowserNetworkTunnelWindowUpdate(1))
+    )
+    socket.emit('data', new Uint8Array([1, 2]))
+    socket.emit('end')
+    socket.emit('close')
+
+    expect(socket.destroyed).toBe(false)
+    session.handleBinary(
+      frame(BrowserNetworkTunnelOpcode.WindowUpdate, encodeBrowserNetworkTunnelWindowUpdate(1))
+    )
+    const decoded = sent.map(decodeBrowserNetworkTunnelFrame)
+    expect(decoded.filter((item) => item?.opcode === BrowserNetworkTunnelOpcode.Data)).toEqual([
+      expect.objectContaining({ payload: new Uint8Array([1]) }),
+      expect.objectContaining({ payload: new Uint8Array([2]) })
+    ])
+    expect(decoded.at(-1)?.opcode).toBe(BrowserNetworkTunnelOpcode.Close)
+    expect(socket.destroyed).toBe(true)
+  })
+
+  it('fails closed on pre-connect credit and synchronous transport failure', () => {
+    const socket = new FakeSocket()
+    const session = new BrowserNetworkTunnelSession({
+      tunnelGeneration: 7,
+      connect: () => socket,
+      sendBinary: () => true
+    })
+    session.handleBinary(
+      frame(
+        BrowserNetworkTunnelOpcode.Open,
+        encodeBrowserNetworkTunnelOpen({ host: 'localhost', port: 80 })
+      )
+    )
+    session.handleBinary(
+      frame(BrowserNetworkTunnelOpcode.WindowUpdate, encodeBrowserNetworkTunnelWindowUpdate(1))
+    )
+    expect(socket.destroyed).toBe(true)
+
+    const throwingSocket = new FakeSocket()
+    const throwingSession = new BrowserNetworkTunnelSession({
+      tunnelGeneration: 7,
+      connect: () => throwingSocket,
+      sendBinary: () => {
+        throw new Error('transport closed')
+      }
+    })
+    throwingSession.handleBinary(
+      frame(
+        BrowserNetworkTunnelOpcode.Open,
+        encodeBrowserNetworkTunnelOpen({ host: 'localhost', port: 80 })
+      )
+    )
+    expect(() => throwingSocket.emit('connect')).not.toThrow()
+    expect(throwingSocket.destroyed).toBe(true)
+  })
+
+  it('closes a stream that exceeds its receive window', () => {
+    const socket = new FakeSocket()
+    const sent: Uint8Array<ArrayBufferLike>[] = []
+    const session = new BrowserNetworkTunnelSession({
+      tunnelGeneration: 7,
+      connect: () => socket,
+      sendBinary: (bytes) => {
+        sent.push(bytes)
+        return true
+      }
+    })
+    session.handleBinary(
+      frame(
+        BrowserNetworkTunnelOpcode.Open,
+        encodeBrowserNetworkTunnelOpen({ host: 'localhost', port: 80 })
+      )
+    )
+    socket.emit('connect')
+    sent.length = 0
+    const chunk = new Uint8Array(64 * 1024)
+    for (let index = 0; index < 4; index += 1) {
+      session.handleBinary(frame(BrowserNetworkTunnelOpcode.Data, chunk))
+    }
+    session.handleBinary(frame(BrowserNetworkTunnelOpcode.Data, new Uint8Array([1])))
+
+    expect(socket.destroyed).toBe(true)
+    expect(decodeBrowserNetworkTunnelFrame(sent.at(-1)!)?.opcode).toBe(
+      BrowserNetworkTunnelOpcode.Error
+    )
+  })
+})

--- a/src/main/browser/browser-network-tunnel-session.ts
+++ b/src/main/browser/browser-network-tunnel-session.ts
@@ -1,0 +1,321 @@
+import {
+  BrowserNetworkTunnelOpcode,
+  decodeBrowserNetworkTunnelFrame,
+  decodeBrowserNetworkTunnelOpen,
+  encodeBrowserNetworkTunnelWindowUpdate,
+  type BrowserNetworkTunnelFrame
+} from '../../shared/browser-network-tunnel-protocol'
+import {
+  flushBrowserNetworkDestination,
+  grantBrowserNetworkDestinationCredit,
+  queueBrowserNetworkDestinationData,
+  writeBrowserNetworkDestination
+} from './browser-network-tunnel-destination-flow'
+import { sendBrowserNetworkTunnelFrame } from './browser-network-tunnel-frame-sender'
+import {
+  BROWSER_NETWORK_TUNNEL_CONNECT_TIMEOUT_MS,
+  BROWSER_NETWORK_TUNNEL_INITIAL_WINDOW_BYTES,
+  reserveBrowserNetworkTunnelStreamId,
+  validateBrowserNetworkTunnelGeneration,
+  type BrowserNetworkTunnelSessionOptions,
+  type BrowserNetworkTunnelSocket,
+  type BrowserNetworkTunnelStream
+} from './browser-network-tunnel-stream-state'
+
+const BROWSER_NETWORK_TUNNEL_MAX_STREAMS = 128
+
+export class BrowserNetworkTunnelSession {
+  private readonly tunnelGeneration: number
+  private readonly connect: BrowserNetworkTunnelSessionOptions['connect']
+  private readonly sendBinary: BrowserNetworkTunnelSessionOptions['sendBinary']
+  private readonly streams = new Map<number, BrowserNetworkTunnelStream>()
+  private readonly openedStreamIds = new Set<number>()
+  private closed = false
+
+  constructor(options: BrowserNetworkTunnelSessionOptions) {
+    validateBrowserNetworkTunnelGeneration(options.tunnelGeneration)
+    this.tunnelGeneration = options.tunnelGeneration
+    this.connect = options.connect
+    this.sendBinary = options.sendBinary
+  }
+
+  handleBinary(bytes: Uint8Array<ArrayBufferLike>): void {
+    if (this.closed) {
+      return
+    }
+    const frame = decodeBrowserNetworkTunnelFrame(bytes)
+    if (!frame) {
+      this.close()
+      return
+    }
+    if (frame.tunnelGeneration !== this.tunnelGeneration) {
+      return
+    }
+    this.handleFrame(frame)
+  }
+
+  close(): void {
+    if (this.closed) {
+      return
+    }
+    this.closed = true
+    for (const stream of this.streams.values()) {
+      this.retireStream(stream)
+    }
+    this.streams.clear()
+  }
+
+  private handleFrame(frame: BrowserNetworkTunnelFrame): void {
+    if (frame.opcode === BrowserNetworkTunnelOpcode.Ping) {
+      this.send(BrowserNetworkTunnelOpcode.Pong, frame.streamId, frame.payload)
+      return
+    }
+    if (frame.opcode === BrowserNetworkTunnelOpcode.Pong) {
+      return
+    }
+    if (frame.opcode === BrowserNetworkTunnelOpcode.Open) {
+      this.openStream(frame)
+      return
+    }
+    const stream = this.streams.get(frame.streamId)
+    if (!stream) {
+      this.close()
+      return
+    }
+    if (frame.opcode === BrowserNetworkTunnelOpcode.Data) {
+      this.writeToDestination(stream, frame.payload)
+    } else if (frame.opcode === BrowserNetworkTunnelOpcode.WindowUpdate) {
+      this.grantDestinationCredit(stream, frame.payload)
+    } else if (frame.opcode === BrowserNetworkTunnelOpcode.HalfClose) {
+      this.halfCloseDestination(stream)
+    } else if (
+      frame.opcode === BrowserNetworkTunnelOpcode.Close ||
+      frame.opcode === BrowserNetworkTunnelOpcode.Error
+    ) {
+      this.deleteStream(stream)
+    } else {
+      this.failStream(stream, 'invalid_stream_transition')
+    }
+  }
+
+  private openStream(frame: BrowserNetworkTunnelFrame): void {
+    const identityError = reserveBrowserNetworkTunnelStreamId(this.openedStreamIds, frame.streamId)
+    if (identityError) {
+      this.sendError(frame.streamId, identityError)
+      this.close()
+      return
+    }
+    if (this.streams.size >= BROWSER_NETWORK_TUNNEL_MAX_STREAMS) {
+      this.sendError(frame.streamId, 'stream_limit_exceeded')
+      return
+    }
+    const target = decodeBrowserNetworkTunnelOpen(frame.payload)
+    if (!target) {
+      this.sendError(frame.streamId, 'invalid_open_target')
+      return
+    }
+    let socket: BrowserNetworkTunnelSocket
+    try {
+      socket = this.connect(target)
+    } catch {
+      this.sendError(frame.streamId, 'destination_connect_failed')
+      return
+    }
+    const stream: BrowserNetworkTunnelStream = {
+      id: frame.streamId,
+      socket,
+      connected: false,
+      closed: false,
+      receiveCredit: BROWSER_NETWORK_TUNNEL_INITIAL_WINDOW_BYTES,
+      sendCredit: 0,
+      pendingToClient: [],
+      pendingToClientBytes: 0,
+      clientEnded: false,
+      destinationEnded: false,
+      destinationClosed: false,
+      destinationHalfCloseSent: false,
+      connectTimeout: setTimeout(
+        () => this.failStream(stream, 'destination_connect_timeout'),
+        BROWSER_NETWORK_TUNNEL_CONNECT_TIMEOUT_MS
+      )
+    }
+    this.streams.set(stream.id, stream)
+    socket.setNoDelay(true)
+    socket.pause()
+    socket.on('connect', () => this.onDestinationConnected(stream))
+    socket.on('data', (data) => this.onDestinationData(stream, data))
+    socket.on('end', () => this.onDestinationEnd(stream))
+    socket.on('close', () => this.onDestinationClose(stream))
+    socket.on('error', () => this.failStream(stream, 'destination_error'))
+  }
+
+  private onDestinationConnected(stream: BrowserNetworkTunnelStream): void {
+    if (!this.isCurrent(stream) || stream.connected) {
+      return
+    }
+    stream.connected = true
+    clearTimeout(stream.connectTimeout)
+    this.send(BrowserNetworkTunnelOpcode.Opened, stream.id)
+    this.send(
+      BrowserNetworkTunnelOpcode.WindowUpdate,
+      stream.id,
+      encodeBrowserNetworkTunnelWindowUpdate(BROWSER_NETWORK_TUNNEL_INITIAL_WINDOW_BYTES)
+    )
+  }
+
+  private writeToDestination(
+    stream: BrowserNetworkTunnelStream,
+    payload: Uint8Array<ArrayBufferLike>
+  ): void {
+    const error = writeBrowserNetworkDestination(stream, payload, (bytes) => {
+      if (!this.isCurrent(stream)) {
+        return
+      }
+      stream.receiveCredit += bytes
+      this.send(
+        BrowserNetworkTunnelOpcode.WindowUpdate,
+        stream.id,
+        encodeBrowserNetworkTunnelWindowUpdate(bytes)
+      )
+    })
+    if (error) {
+      this.failStream(stream, error)
+    }
+  }
+
+  private grantDestinationCredit(
+    stream: BrowserNetworkTunnelStream,
+    payload: Uint8Array<ArrayBufferLike>
+  ): void {
+    const error = grantBrowserNetworkDestinationCredit(stream, payload)
+    if (error) {
+      this.failStream(stream, error)
+      return
+    }
+    this.flushDestinationData(stream)
+  }
+
+  private onDestinationData(
+    stream: BrowserNetworkTunnelStream,
+    bytes: Uint8Array<ArrayBufferLike>
+  ): void {
+    if (!this.isCurrent(stream) || bytes.byteLength === 0) {
+      return
+    }
+    const error = queueBrowserNetworkDestinationData(stream, bytes)
+    if (error) {
+      this.failStream(stream, error)
+      return
+    }
+    this.flushDestinationData(stream)
+  }
+
+  private flushDestinationData(stream: BrowserNetworkTunnelStream): void {
+    flushBrowserNetworkDestination(stream, {
+      isCurrent: () => this.isCurrent(stream),
+      sendData: (bytes) => this.send(BrowserNetworkTunnelOpcode.Data, stream.id, bytes),
+      sendHalfClose: () => this.sendDestinationHalfClose(stream),
+      finalizeClose: () => this.finalizeDestinationClose(stream)
+    })
+  }
+
+  private onDestinationEnd(stream: BrowserNetworkTunnelStream): void {
+    if (!this.isCurrent(stream)) {
+      return
+    }
+    if (stream.destinationEnded) {
+      this.failStream(stream, 'duplicate_destination_half_close')
+      return
+    }
+    stream.destinationEnded = true
+    if (stream.pendingToClient.length === 0) {
+      this.sendDestinationHalfClose(stream)
+    }
+  }
+
+  private onDestinationClose(stream: BrowserNetworkTunnelStream): void {
+    if (!this.isCurrent(stream)) {
+      return
+    }
+    stream.destinationClosed = true
+    if (stream.pendingToClient.length === 0) {
+      this.finalizeDestinationClose(stream)
+    }
+  }
+
+  private failStream(stream: BrowserNetworkTunnelStream, code: string): void {
+    if (!this.isCurrent(stream)) {
+      return
+    }
+    this.sendError(stream.id, code)
+    this.deleteStream(stream)
+  }
+
+  private sendError(streamId: number, code: string): void {
+    this.send(BrowserNetworkTunnelOpcode.Error, streamId, new TextEncoder().encode(code))
+  }
+
+  private send(
+    opcode: BrowserNetworkTunnelOpcode,
+    streamId: number,
+    payload: Uint8Array<ArrayBufferLike> = new Uint8Array()
+  ): void {
+    if (this.closed) {
+      return
+    }
+    const accepted = sendBrowserNetworkTunnelFrame(this.sendBinary, {
+      opcode,
+      tunnelGeneration: this.tunnelGeneration,
+      streamId,
+      payload
+    })
+    if (!accepted) {
+      this.close()
+    }
+  }
+
+  private halfCloseDestination(stream: BrowserNetworkTunnelStream): void {
+    if (!stream.connected || stream.clientEnded) {
+      this.failStream(stream, 'invalid_client_half_close')
+      return
+    }
+    stream.clientEnded = true
+    stream.socket.end()
+  }
+
+  private sendDestinationHalfClose(stream: BrowserNetworkTunnelStream): void {
+    if (stream.destinationHalfCloseSent) {
+      return
+    }
+    stream.destinationHalfCloseSent = true
+    this.send(BrowserNetworkTunnelOpcode.HalfClose, stream.id)
+  }
+
+  private finalizeDestinationClose(stream: BrowserNetworkTunnelStream): void {
+    this.send(BrowserNetworkTunnelOpcode.Close, stream.id)
+    this.deleteStream(stream)
+  }
+
+  private deleteStream(stream: BrowserNetworkTunnelStream): void {
+    if (!this.isCurrent(stream)) {
+      return
+    }
+    this.streams.delete(stream.id)
+    this.retireStream(stream)
+  }
+
+  private retireStream(stream: BrowserNetworkTunnelStream): void {
+    if (stream.closed) {
+      return
+    }
+    stream.closed = true
+    clearTimeout(stream.connectTimeout)
+    stream.pendingToClient = []
+    stream.pendingToClientBytes = 0
+    stream.socket.destroy()
+  }
+
+  private isCurrent(stream: BrowserNetworkTunnelStream): boolean {
+    return !this.closed && !stream.closed && this.streams.get(stream.id) === stream
+  }
+}

--- a/src/main/browser/browser-network-tunnel-stream-state.ts
+++ b/src/main/browser/browser-network-tunnel-stream-state.ts
@@ -1,0 +1,65 @@
+export const BROWSER_NETWORK_TUNNEL_INITIAL_WINDOW_BYTES = 256 * 1024
+export const BROWSER_NETWORK_TUNNEL_CONNECT_TIMEOUT_MS = 10_000
+export const BROWSER_NETWORK_TUNNEL_MAX_PENDING_SOCKET_BYTES = 256 * 1024
+export const BROWSER_NETWORK_TUNNEL_MAX_PENDING_SOCKET_CHUNKS = 256
+const BROWSER_NETWORK_TUNNEL_MAX_STREAM_IDS = 65_536
+
+export function validateBrowserNetworkTunnelGeneration(generation: number): void {
+  if (!Number.isInteger(generation) || generation < 1 || generation > 0xffff_ffff) {
+    throw new Error('Browser tunnel generation is invalid')
+  }
+}
+
+export function reserveBrowserNetworkTunnelStreamId(
+  openedStreamIds: Set<number>,
+  streamId: number
+): 'stream_id_reused' | 'stream_id_budget_exhausted' | null {
+  if (openedStreamIds.has(streamId)) {
+    return 'stream_id_reused'
+  }
+  if (openedStreamIds.size >= BROWSER_NETWORK_TUNNEL_MAX_STREAM_IDS) {
+    return 'stream_id_budget_exhausted'
+  }
+  openedStreamIds.add(streamId)
+  return null
+}
+
+export type BrowserNetworkTunnelSocket = {
+  destroyed: boolean
+  setNoDelay(noDelay?: boolean): BrowserNetworkTunnelSocket
+  pause(): BrowserNetworkTunnelSocket
+  resume(): BrowserNetworkTunnelSocket
+  write(bytes: Uint8Array<ArrayBufferLike>, callback?: () => void): boolean
+  end(): BrowserNetworkTunnelSocket
+  destroy(): BrowserNetworkTunnelSocket
+  on(event: 'connect', listener: () => void): BrowserNetworkTunnelSocket
+  on(
+    event: 'data',
+    listener: (bytes: Uint8Array<ArrayBufferLike>) => void
+  ): BrowserNetworkTunnelSocket
+  on(event: 'end' | 'close', listener: () => void): BrowserNetworkTunnelSocket
+  on(event: 'error', listener: (error: Error) => void): BrowserNetworkTunnelSocket
+}
+
+export type BrowserNetworkTunnelStream = {
+  id: number
+  socket: BrowserNetworkTunnelSocket
+  connected: boolean
+  closed: boolean
+  receiveCredit: number
+  sendCredit: number
+  pendingToClient: Uint8Array<ArrayBufferLike>[]
+  pendingToClientBytes: number
+  clientEnded: boolean
+  destinationEnded: boolean
+  destinationClosed: boolean
+  destinationHalfCloseSent: boolean
+  connectTimeout: ReturnType<typeof setTimeout>
+}
+
+export type BrowserNetworkTunnelSessionOptions = {
+  tunnelGeneration: number
+  connect: (target: BrowserNetworkTunnelOpen) => BrowserNetworkTunnelSocket
+  sendBinary: (bytes: Uint8Array<ArrayBufferLike>) => boolean
+}
+import type { BrowserNetworkTunnelOpen } from '../../shared/browser-network-tunnel-protocol'

--- a/src/main/browser/remote-browser-socks-server.test.ts
+++ b/src/main/browser/remote-browser-socks-server.test.ts
@@ -1,0 +1,197 @@
+import { once } from 'node:events'
+import { connect, type Socket } from 'node:net'
+import { PassThrough } from 'node:stream'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { RemoteBrowserSocksServer } from './remote-browser-socks-server'
+
+const servers: RemoteBrowserSocksServer[] = []
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) => server.close()))
+})
+
+async function connectClient(server: RemoteBrowserSocksServer): Promise<Socket> {
+  const address = await server.listen()
+  const socket = connect(address.port, address.host)
+  await once(socket, 'connect')
+  return socket
+}
+
+async function readExact(socket: Socket, size: number): Promise<Uint8Array> {
+  const chunks: Buffer[] = []
+  let total = 0
+  while (total < size) {
+    const [chunk] = (await once(socket, 'data')) as [Buffer]
+    chunks.push(chunk)
+    total += chunk.byteLength
+  }
+  const combined = Buffer.concat(chunks)
+  if (combined.byteLength > size) {
+    socket.unshift(combined.subarray(size))
+  }
+  return combined.subarray(0, size)
+}
+
+async function greet(socket: Socket): Promise<void> {
+  socket.write(new Uint8Array([5, 1, 0]))
+  expect(Array.from(await readExact(socket, 2))).toEqual([5, 0])
+}
+
+function domainConnectRequest(host: string, port: number, command = 1): Uint8Array {
+  const name = new TextEncoder().encode(host)
+  const request = new Uint8Array(7 + name.byteLength)
+  const view = new DataView(request.buffer)
+  request.set([5, command, 0, 3, name.byteLength], 0)
+  request.set(name, 5)
+  view.setUint16(5 + name.byteLength, port, false)
+  return request
+}
+
+describe('RemoteBrowserSocksServer', () => {
+  it('passes domain names unchanged to the execution-host route', async () => {
+    const upstream = new PassThrough()
+    const open = vi.fn(async () => upstream)
+    const server = new RemoteBrowserSocksServer({ open })
+    servers.push(server)
+    const socket = await connectClient(server)
+    await greet(socket)
+
+    socket.write(domainConnectRequest('split-horizon.internal.', 8443))
+
+    expect(Array.from(await readExact(socket, 10))).toEqual([5, 0, 0, 1, 0, 0, 0, 0, 0, 0])
+    expect(open).toHaveBeenCalledWith({ host: 'split-horizon.internal.', port: 8443 })
+
+    socket.write('remote bytes')
+    expect(new TextDecoder().decode(await readExact(socket, 12))).toBe('remote bytes')
+    socket.destroy()
+  })
+
+  it('normalizes listener wildcards only at the final route boundary', async () => {
+    const open = vi.fn(async () => new PassThrough())
+    const server = new RemoteBrowserSocksServer({ open })
+    servers.push(server)
+    const socket = await connectClient(server)
+    await greet(socket)
+
+    socket.write(domainConnectRequest('0.0.0.0', 3000))
+    await readExact(socket, 10)
+
+    expect(open).toHaveBeenCalledWith({ host: '127.0.0.1', port: 3000 })
+    socket.destroy()
+  })
+
+  it('rejects unsupported commands without opening a destination', async () => {
+    const open = vi.fn(async () => new PassThrough())
+    const server = new RemoteBrowserSocksServer({ open })
+    servers.push(server)
+    const socket = await connectClient(server)
+    await greet(socket)
+
+    socket.write(domainConnectRequest('localhost', 80, 2))
+
+    expect(Array.from(await readExact(socket, 10))).toEqual([5, 7, 0, 1, 0, 0, 0, 0, 0, 0])
+    expect(open).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when the execution-host route is unavailable', async () => {
+    const open = vi.fn(async () => {
+      throw new Error('route offline')
+    })
+    const server = new RemoteBrowserSocksServer({ open })
+    servers.push(server)
+    const socket = await connectClient(server)
+    await greet(socket)
+
+    socket.write(domainConnectRequest('localhost', 3000))
+
+    expect(Array.from(await readExact(socket, 10))).toEqual([5, 1, 0, 1, 0, 0, 0, 0, 0, 0])
+    expect(open).toHaveBeenCalledTimes(1)
+  })
+
+  it('contains synchronous route failures and large pipelined requests', async () => {
+    const failingServer = new RemoteBrowserSocksServer({
+      open: () => {
+        throw new Error('route failed synchronously')
+      }
+    })
+    servers.push(failingServer)
+    const failingSocket = await connectClient(failingServer)
+    await greet(failingSocket)
+    failingSocket.write(domainConnectRequest('localhost', 3000))
+    expect(Array.from(await readExact(failingSocket, 10))).toEqual([5, 1, 0, 1, 0, 0, 0, 0, 0, 0])
+
+    let resolveOpen: ((stream: PassThrough) => void) | undefined
+    const open = vi.fn(
+      () =>
+        new Promise<PassThrough>((resolve) => {
+          resolveOpen = resolve
+        })
+    )
+    const server = new RemoteBrowserSocksServer({ open })
+    servers.push(server)
+    const socket = await connectClient(server)
+    await greet(socket)
+    const payload = Buffer.alloc(4 * 1024, 7)
+    socket.write(Buffer.concat([domainConnectRequest('localhost', 443), payload]))
+    await vi.waitFor(() => expect(open).toHaveBeenCalledTimes(1))
+    resolveOpen?.(new PassThrough())
+    await readExact(socket, 10)
+    expect(await readExact(socket, payload.byteLength)).toEqual(payload)
+    socket.destroy()
+  })
+
+  it('closes deterministically during bind and with a failed half-open peer', async () => {
+    const server = new RemoteBrowserSocksServer({
+      open: async () => new PassThrough()
+    })
+    servers.push(server)
+    const listening = server.listen()
+    const closing = server.close()
+    const address = await listening
+    await closing
+    const postCloseSocket = connect(address.port, address.host)
+    await expect(once(postCloseSocket, 'connect')).rejects.toBeTruthy()
+    await expect(server.listen()).rejects.toThrow('closed')
+
+    const peerServer = new RemoteBrowserSocksServer({
+      open: async () => new PassThrough()
+    })
+    servers.push(peerServer)
+    const peerAddress = await peerServer.listen()
+    const peer = connect({ ...peerAddress, allowHalfOpen: true })
+    await once(peer, 'connect')
+    await greet(peer)
+    peer.write(domainConnectRequest('localhost', 80, 2))
+    await readExact(peer, 10)
+    await expect(
+      Promise.race([
+        peerServer.close().then(() => 'closed'),
+        new Promise<string>((resolve) => setTimeout(() => resolve('timed-out'), 1_000))
+      ])
+    ).resolves.toBe('closed')
+    peer.destroy()
+  })
+
+  it('cannot resolve a pending route after pipelined input exceeds its bound', async () => {
+    let resolveOpen: ((stream: PassThrough) => void) | undefined
+    const open = vi.fn(
+      () =>
+        new Promise<PassThrough>((resolve) => {
+          resolveOpen = resolve
+        })
+    )
+    const server = new RemoteBrowserSocksServer({ open })
+    servers.push(server)
+    const socket = await connectClient(server)
+    await greet(socket)
+    socket.write(domainConnectRequest('localhost', 443))
+    await vi.waitFor(() => expect(open).toHaveBeenCalledTimes(1))
+
+    socket.write(Buffer.alloc(300 * 1024, 7))
+    expect(Array.from(await readExact(socket, 10))).toEqual([5, 1, 0, 1, 0, 0, 0, 0, 0, 0])
+    const upstream = new PassThrough()
+    resolveOpen?.(upstream)
+    await vi.waitFor(() => expect(upstream.destroyed).toBe(true))
+    expect(upstream.readableLength).toBe(0)
+  })
+})

--- a/src/main/browser/remote-browser-socks-server.ts
+++ b/src/main/browser/remote-browser-socks-server.ts
@@ -1,0 +1,298 @@
+import { createServer, type Server, type Socket } from 'node:net'
+import type { Duplex } from 'node:stream'
+
+const SOCKS_VERSION = 5
+const SOCKS_NO_AUTH = 0
+const SOCKS_CONNECT = 1
+const SOCKS_IPV4 = 1
+const SOCKS_DOMAIN = 3
+const SOCKS_IPV6 = 4
+const MAX_HANDSHAKE_BYTES = 2048
+const MAX_PENDING_UPSTREAM_BYTES = 256 * 1024
+const HANDSHAKE_TIMEOUT_MS = 10_000
+const SUCCESS_RESPONSE = new Uint8Array([5, 0, 0, 1, 0, 0, 0, 0, 0, 0])
+
+export type RemoteBrowserNetworkTarget = {
+  host: string
+  port: number
+}
+
+type RemoteBrowserSocksServerOptions = {
+  open: (target: RemoteBrowserNetworkTarget) => Promise<Duplex>
+}
+
+type SocksRequest = {
+  consumed: number
+  command: number
+  target: RemoteBrowserNetworkTarget
+}
+
+export class RemoteBrowserSocksServer {
+  private readonly open: RemoteBrowserSocksServerOptions['open']
+  private readonly server: Server
+  private readonly clients = new Set<Socket>()
+  private listenPromise: Promise<{ host: string; port: number }> | null = null
+  private closePromise: Promise<void> | null = null
+  private state: 'idle' | 'starting' | 'listening' | 'closing' | 'closed' = 'idle'
+
+  constructor(options: RemoteBrowserSocksServerOptions) {
+    this.open = options.open
+    this.server = createServer((socket) => this.accept(socket))
+    this.server.maxConnections = 128
+  }
+
+  listen(): Promise<{ host: string; port: number }> {
+    if (this.state === 'closing' || this.state === 'closed') {
+      return Promise.reject(new Error('Browser SOCKS server is closed'))
+    }
+    if (this.listenPromise) {
+      return this.listenPromise
+    }
+    this.state = 'starting'
+    this.listenPromise = new Promise((resolve, reject) => {
+      const onError = (error: Error): void => {
+        this.state = 'closed'
+        reject(error)
+      }
+      this.server.once('error', onError)
+      this.server.listen(0, '127.0.0.1', () => {
+        this.server.off('error', onError)
+        const address = this.server.address()
+        if (!address || typeof address === 'string') {
+          reject(new Error('Browser SOCKS server did not bind a TCP address'))
+          return
+        }
+        if (this.state === 'starting') {
+          this.state = 'listening'
+        }
+        resolve({ host: '127.0.0.1', port: address.port })
+      })
+    })
+    return this.listenPromise
+  }
+
+  async close(): Promise<void> {
+    if (this.closePromise) {
+      return this.closePromise
+    }
+    this.state = 'closing'
+    this.closePromise = this.closeServer()
+    return this.closePromise
+  }
+
+  private async closeServer(): Promise<void> {
+    if (this.listenPromise) {
+      await this.listenPromise.catch(() => undefined)
+    }
+    for (const socket of this.clients) {
+      socket.destroy()
+    }
+    this.clients.clear()
+    if (!this.server.listening) {
+      this.state = 'closed'
+      return
+    }
+    await new Promise<void>((resolve, reject) => {
+      this.server.close((error) => (error ? reject(error) : resolve()))
+    })
+    this.state = 'closed'
+  }
+
+  private accept(socket: Socket): void {
+    if (!isLoopbackAddress(socket.remoteAddress)) {
+      socket.destroy()
+      return
+    }
+    this.clients.add(socket)
+    let phase: 'greeting' | 'request' | 'opening' | 'connected' | 'closed' = 'greeting'
+    let buffered = Buffer.alloc(0)
+    const timeout = setTimeout(() => socket.destroy(), HANDSHAKE_TIMEOUT_MS)
+    const cleanup = (): void => {
+      phase = 'closed'
+      clearTimeout(timeout)
+      this.clients.delete(socket)
+    }
+    const finishFailure = (reply: Uint8Array): void => {
+      if (phase === 'closed') {
+        return
+      }
+      phase = 'closed'
+      clearTimeout(timeout)
+      buffered = Buffer.alloc(0)
+      socket.pause()
+      socket.end(reply, () => socket.destroy())
+    }
+    const fail = (replyCode: number): void => finishFailure(socksReply(replyCode))
+    const onData = (chunk: Buffer): void => {
+      if (phase === 'closed' || phase === 'connected') {
+        return
+      }
+      buffered = Buffer.concat([buffered, chunk])
+      if (phase === 'opening') {
+        if (buffered.byteLength > MAX_PENDING_UPSTREAM_BYTES) {
+          fail(1)
+        }
+        return
+      }
+      if (phase === 'greeting' && buffered.byteLength > MAX_HANDSHAKE_BYTES) {
+        fail(1)
+        return
+      }
+      if (phase === 'greeting') {
+        if (buffered.byteLength < 2) {
+          return
+        }
+        const methodCount = buffered[1]!
+        if (buffered.byteLength < 2 + methodCount) {
+          return
+        }
+        if (
+          buffered[0] !== SOCKS_VERSION ||
+          !buffered.subarray(2, 2 + methodCount).includes(SOCKS_NO_AUTH)
+        ) {
+          finishFailure(new Uint8Array([SOCKS_VERSION, 0xff]))
+          return
+        }
+        buffered = buffered.subarray(2 + methodCount)
+        socket.write(new Uint8Array([SOCKS_VERSION, SOCKS_NO_AUTH]))
+        phase = 'request'
+      }
+      if (phase !== 'request') {
+        return
+      }
+      const parsed = parseSocksRequest(buffered)
+      if (parsed === undefined) {
+        if (buffered.byteLength > MAX_HANDSHAKE_BYTES) {
+          fail(1)
+        }
+        return
+      }
+      if (parsed === null) {
+        fail(8)
+        return
+      }
+      buffered = buffered.subarray(parsed.consumed)
+      if (buffered.byteLength > MAX_PENDING_UPSTREAM_BYTES) {
+        fail(1)
+        return
+      }
+      if (parsed.command !== SOCKS_CONNECT) {
+        fail(7)
+        return
+      }
+      phase = 'opening'
+      void Promise.resolve()
+        .then(() => this.open(normalizeListenerWildcard(parsed.target)))
+        .then(
+          (upstream) => {
+            if (phase !== 'opening' || socket.destroyed) {
+              upstream.destroy()
+              return
+            }
+            phase = 'connected'
+            clearTimeout(timeout)
+            socket.off('data', onData)
+            socket.write(SUCCESS_RESPONSE)
+            if (buffered.byteLength > 0) {
+              upstream.write(buffered)
+              buffered = Buffer.alloc(0)
+            }
+            socket.pipe(upstream)
+            upstream.pipe(socket)
+            upstream.once('error', () => socket.destroy())
+            upstream.once('close', () => socket.destroy())
+            socket.once('close', () => upstream.destroy())
+          },
+          () => fail(1)
+        )
+    }
+    socket.on('data', onData)
+    socket.once('error', cleanup)
+    socket.once('close', cleanup)
+  }
+}
+
+function parseSocksRequest(buffer: Uint8Array): SocksRequest | null | undefined {
+  if (buffer.byteLength < 4) {
+    return undefined
+  }
+  if (buffer[0] !== SOCKS_VERSION || buffer[2] !== 0) {
+    return null
+  }
+  const addressType = buffer[3]
+  let host: string
+  let addressEnd: number
+  if (addressType === SOCKS_IPV4) {
+    if (buffer.byteLength < 10) {
+      return undefined
+    }
+    host = Array.from(buffer.subarray(4, 8)).join('.')
+    addressEnd = 8
+  } else if (addressType === SOCKS_DOMAIN) {
+    if (buffer.byteLength < 5) {
+      return undefined
+    }
+    const length = buffer[4]!
+    addressEnd = 5 + length
+    if (length === 0 || buffer.byteLength < addressEnd + 2) {
+      return length === 0 ? null : undefined
+    }
+    try {
+      host = new TextDecoder('utf-8', { fatal: true }).decode(buffer.subarray(5, addressEnd))
+    } catch {
+      return null
+    }
+  } else if (addressType === SOCKS_IPV6) {
+    if (buffer.byteLength < 22) {
+      return undefined
+    }
+    host = formatIpv6(buffer.subarray(4, 20))
+    addressEnd = 20
+  } else {
+    return null
+  }
+  if (!host || buffer.byteLength < addressEnd + 2) {
+    return undefined
+  }
+  const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength)
+  const port = view.getUint16(addressEnd, false)
+  if (port === 0) {
+    return null
+  }
+  return {
+    consumed: addressEnd + 2,
+    command: buffer[1]!,
+    target: { host, port }
+  }
+}
+
+function normalizeListenerWildcard(target: RemoteBrowserNetworkTarget): RemoteBrowserNetworkTarget {
+  if (target.host === '0.0.0.0') {
+    return { ...target, host: '127.0.0.1' }
+  }
+  if (target.host === '::' || target.host === '0:0:0:0:0:0:0:0') {
+    return { ...target, host: '::1' }
+  }
+  return target
+}
+
+function formatIpv6(bytes: Uint8Array): string {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  return Array.from({ length: 8 }, (_, index) =>
+    view.getUint16(index * 2, false).toString(16)
+  ).join(':')
+}
+
+function socksReply(code: number): Uint8Array {
+  const reply = SUCCESS_RESPONSE.slice()
+  reply[1] = code
+  return reply
+}
+
+function isLoopbackAddress(address: string | undefined): boolean {
+  return (
+    address === '::1' ||
+    address?.startsWith('127.') === true ||
+    address?.toLowerCase().startsWith('::ffff:127.') === true
+  )
+}

--- a/src/shared/browser-network-capabilities.test.ts
+++ b/src/shared/browser-network-capabilities.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import {
+  BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY,
+  BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY,
+  BROWSER_SCREENCAST_RUNTIME_CAPABILITY,
+  RUNTIME_CAPABILITIES
+} from './protocol-version'
+
+describe('browser network capabilities', () => {
+  it('keeps client hosting, network tunneling, and screencast independent', () => {
+    expect(BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY).toBe('browser.clientHost.v1')
+    expect(BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY).toBe('network.browserTunnel.v1')
+    expect(BROWSER_SCREENCAST_RUNTIME_CAPABILITY).toBe('browser.screencast.v1')
+  })
+
+  it('does not advertise unregistered client-host or tunnel implementations', () => {
+    expect(RUNTIME_CAPABILITIES).not.toContain(BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY)
+    expect(RUNTIME_CAPABILITIES).not.toContain(BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY)
+    expect(RUNTIME_CAPABILITIES).toContain(BROWSER_SCREENCAST_RUNTIME_CAPABILITY)
+  })
+})

--- a/src/shared/browser-network-tunnel-protocol.test.ts
+++ b/src/shared/browser-network-tunnel-protocol.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import {
+  BROWSER_NETWORK_TUNNEL_MAX_DATA_BYTES,
+  BrowserNetworkTunnelOpcode,
+  decodeBrowserNetworkTunnelFrame,
+  decodeBrowserNetworkTunnelOpen,
+  decodeBrowserNetworkTunnelWindowUpdate,
+  encodeBrowserNetworkTunnelFrame,
+  encodeBrowserNetworkTunnelOpen,
+  encodeBrowserNetworkTunnelWindowUpdate
+} from './browser-network-tunnel-protocol'
+
+describe('browser-network-tunnel-protocol', () => {
+  it('round-trips remote DNS names without resolving them on the client', () => {
+    const encoded = encodeBrowserNetworkTunnelFrame({
+      opcode: BrowserNetworkTunnelOpcode.Open,
+      tunnelGeneration: 7,
+      streamId: 19,
+      payload: encodeBrowserNetworkTunnelOpen({ host: 'service.internal.', port: 8443 })
+    })
+
+    const decoded = decodeBrowserNetworkTunnelFrame(encoded)
+
+    expect(decoded).toMatchObject({
+      opcode: BrowserNetworkTunnelOpcode.Open,
+      tunnelGeneration: 7,
+      streamId: 19
+    })
+    expect(decoded && decodeBrowserNetworkTunnelOpen(decoded.payload)).toEqual({
+      host: 'service.internal.',
+      port: 8443
+    })
+  })
+
+  it('round-trips exact credit without accepting zero or overflow', () => {
+    const payload = encodeBrowserNetworkTunnelWindowUpdate(256 * 1024)
+
+    expect(decodeBrowserNetworkTunnelWindowUpdate(payload)).toBe(256 * 1024)
+    expect(decodeBrowserNetworkTunnelWindowUpdate(new Uint8Array(4))).toBeNull()
+
+    const overflow = payload.slice()
+    new DataView(overflow.buffer).setUint32(0, 0xffffffff, false)
+    expect(decodeBrowserNetworkTunnelWindowUpdate(overflow)).toBeNull()
+  })
+
+  it('rejects malformed, unknown, oversized, and length-mismatched frames', () => {
+    const encoded = encodeBrowserNetworkTunnelFrame({
+      opcode: BrowserNetworkTunnelOpcode.Data,
+      tunnelGeneration: 1,
+      streamId: 2,
+      payload: new Uint8Array([1, 2, 3])
+    })
+
+    expect(decodeBrowserNetworkTunnelFrame(encoded.subarray(0, 15))).toBeNull()
+
+    const badVersion = encoded.slice()
+    badVersion[1] = 2
+    expect(decodeBrowserNetworkTunnelFrame(badVersion)).toBeNull()
+
+    const badOpcode = encoded.slice()
+    badOpcode[2] = 255
+    expect(decodeBrowserNetworkTunnelFrame(badOpcode)).toBeNull()
+
+    const wrongLength = encoded.slice()
+    new DataView(wrongLength.buffer).setUint32(12, 99, false)
+    expect(decodeBrowserNetworkTunnelFrame(wrongLength)).toBeNull()
+
+    expect(() =>
+      encodeBrowserNetworkTunnelFrame({
+        opcode: BrowserNetworkTunnelOpcode.Data,
+        tunnelGeneration: 1,
+        streamId: 2,
+        payload: new Uint8Array(BROWSER_NETWORK_TUNNEL_MAX_DATA_BYTES + 1)
+      })
+    ).toThrow('payload')
+  })
+
+  it('rejects invalid open targets and payloads on control-only opcodes', () => {
+    expect(() => encodeBrowserNetworkTunnelOpen({ host: '', port: 80 })).toThrow('host')
+    expect(() => encodeBrowserNetworkTunnelOpen({ host: 'localhost', port: 0 })).toThrow('port')
+
+    expect(() =>
+      encodeBrowserNetworkTunnelFrame({
+        opcode: BrowserNetworkTunnelOpcode.Opened,
+        tunnelGeneration: 1,
+        streamId: 2,
+        payload: new Uint8Array([1])
+      })
+    ).toThrow('empty')
+  })
+
+  it('rejects identities that cannot be represented as unsigned 32-bit values', () => {
+    const payload = new Uint8Array()
+    expect(() =>
+      encodeBrowserNetworkTunnelFrame({
+        opcode: BrowserNetworkTunnelOpcode.Ping,
+        tunnelGeneration: 0x1_0000_0000,
+        streamId: 0,
+        payload
+      })
+    ).toThrow('generation')
+    expect(() =>
+      encodeBrowserNetworkTunnelFrame({
+        opcode: BrowserNetworkTunnelOpcode.Data,
+        tunnelGeneration: 1,
+        streamId: 0x1_0000_0000,
+        payload
+      })
+    ).toThrow('stream id')
+  })
+})

--- a/src/shared/browser-network-tunnel-protocol.ts
+++ b/src/shared/browser-network-tunnel-protocol.ts
@@ -1,0 +1,213 @@
+const BROWSER_NETWORK_TUNNEL_KIND = 0x6e
+const BROWSER_NETWORK_TUNNEL_VERSION = 1
+const HEADER_BYTES = 16
+const MAX_OPEN_HOST_BYTES = 1024
+const MAX_CONTROL_PAYLOAD_BYTES = 1024
+const MAX_UINT32 = 0xffff_ffff
+
+export const BROWSER_NETWORK_TUNNEL_MAX_DATA_BYTES = 64 * 1024
+export const BROWSER_NETWORK_TUNNEL_MAX_WINDOW_UPDATE_BYTES = 16 * 1024 * 1024
+
+export enum BrowserNetworkTunnelOpcode {
+  Open = 1,
+  Opened = 2,
+  Data = 3,
+  WindowUpdate = 4,
+  HalfClose = 5,
+  Close = 6,
+  Error = 7,
+  Ping = 8,
+  Pong = 9
+}
+
+export type BrowserNetworkTunnelFrame = {
+  opcode: BrowserNetworkTunnelOpcode
+  tunnelGeneration: number
+  streamId: number
+  payload: Uint8Array<ArrayBufferLike>
+}
+
+export type BrowserNetworkTunnelOpen = {
+  host: string
+  port: number
+}
+
+export function encodeBrowserNetworkTunnelFrame(frame: BrowserNetworkTunnelFrame): Uint8Array {
+  validateFrameIdentity(frame)
+  validatePayload(frame.opcode, frame.payload)
+  const output = new Uint8Array(HEADER_BYTES + frame.payload.byteLength)
+  const view = new DataView(output.buffer, output.byteOffset, output.byteLength)
+  view.setUint8(0, BROWSER_NETWORK_TUNNEL_KIND)
+  view.setUint8(1, BROWSER_NETWORK_TUNNEL_VERSION)
+  view.setUint8(2, frame.opcode)
+  view.setUint8(3, 0)
+  view.setUint32(4, frame.tunnelGeneration, false)
+  view.setUint32(8, frame.streamId, false)
+  view.setUint32(12, frame.payload.byteLength, false)
+  output.set(frame.payload, HEADER_BYTES)
+  return output
+}
+
+export function decodeBrowserNetworkTunnelFrame(
+  bytes: Uint8Array<ArrayBufferLike>
+): BrowserNetworkTunnelFrame | null {
+  if (bytes.byteLength < HEADER_BYTES) {
+    return null
+  }
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  const opcode = view.getUint8(2)
+  const tunnelGeneration = view.getUint32(4, false)
+  const streamId = view.getUint32(8, false)
+  const payloadLength = view.getUint32(12, false)
+  if (
+    view.getUint8(0) !== BROWSER_NETWORK_TUNNEL_KIND ||
+    view.getUint8(1) !== BROWSER_NETWORK_TUNNEL_VERSION ||
+    view.getUint8(3) !== 0 ||
+    !isBrowserNetworkTunnelOpcode(opcode) ||
+    payloadLength !== bytes.byteLength - HEADER_BYTES
+  ) {
+    return null
+  }
+  const payload = bytes.subarray(HEADER_BYTES)
+  try {
+    validateFrameIdentity({ opcode, tunnelGeneration, streamId, payload })
+    validatePayload(opcode, payload)
+  } catch {
+    return null
+  }
+  return { opcode, tunnelGeneration, streamId, payload }
+}
+
+export function encodeBrowserNetworkTunnelOpen(target: BrowserNetworkTunnelOpen): Uint8Array {
+  if (!target.host || target.host.includes('\0')) {
+    throw new Error('Browser tunnel host is invalid')
+  }
+  if (!Number.isInteger(target.port) || target.port < 1 || target.port > 65_535) {
+    throw new Error('Browser tunnel port is invalid')
+  }
+  const host = new TextEncoder().encode(target.host)
+  if (host.byteLength > MAX_OPEN_HOST_BYTES) {
+    throw new Error('Browser tunnel host is too long')
+  }
+  const output = new Uint8Array(4 + host.byteLength)
+  const view = new DataView(output.buffer)
+  view.setUint16(0, target.port, false)
+  view.setUint16(2, host.byteLength, false)
+  output.set(host, 4)
+  return output
+}
+
+export function decodeBrowserNetworkTunnelOpen(
+  payload: Uint8Array<ArrayBufferLike>
+): BrowserNetworkTunnelOpen | null {
+  if (payload.byteLength < 5) {
+    return null
+  }
+  const view = new DataView(payload.buffer, payload.byteOffset, payload.byteLength)
+  const port = view.getUint16(0, false)
+  const hostLength = view.getUint16(2, false)
+  if (
+    port === 0 ||
+    hostLength === 0 ||
+    hostLength > MAX_OPEN_HOST_BYTES ||
+    hostLength + 4 !== payload.byteLength
+  ) {
+    return null
+  }
+  try {
+    const host = new TextDecoder('utf-8', { fatal: true }).decode(payload.subarray(4))
+    if (!host || host.includes('\0')) {
+      return null
+    }
+    return { host, port }
+  } catch {
+    return null
+  }
+}
+
+export function encodeBrowserNetworkTunnelWindowUpdate(bytes: number): Uint8Array {
+  if (
+    !Number.isInteger(bytes) ||
+    bytes < 1 ||
+    bytes > BROWSER_NETWORK_TUNNEL_MAX_WINDOW_UPDATE_BYTES
+  ) {
+    throw new Error('Browser tunnel window update is invalid')
+  }
+  const payload = new Uint8Array(4)
+  new DataView(payload.buffer).setUint32(0, bytes, false)
+  return payload
+}
+
+export function decodeBrowserNetworkTunnelWindowUpdate(
+  payload: Uint8Array<ArrayBufferLike>
+): number | null {
+  if (payload.byteLength !== 4) {
+    return null
+  }
+  const bytes = new DataView(payload.buffer, payload.byteOffset, payload.byteLength).getUint32(
+    0,
+    false
+  )
+  return bytes > 0 && bytes <= BROWSER_NETWORK_TUNNEL_MAX_WINDOW_UPDATE_BYTES ? bytes : null
+}
+
+function validateFrameIdentity(frame: BrowserNetworkTunnelFrame): void {
+  if (
+    !Number.isInteger(frame.tunnelGeneration) ||
+    frame.tunnelGeneration < 1 ||
+    frame.tunnelGeneration > MAX_UINT32
+  ) {
+    throw new Error('Browser tunnel generation is invalid')
+  }
+  const connectionFrame =
+    frame.opcode !== BrowserNetworkTunnelOpcode.Ping &&
+    frame.opcode !== BrowserNetworkTunnelOpcode.Pong
+  if (
+    !Number.isInteger(frame.streamId) ||
+    frame.streamId < (connectionFrame ? 1 : 0) ||
+    frame.streamId > MAX_UINT32
+  ) {
+    throw new Error('Browser tunnel stream id is invalid')
+  }
+}
+
+function validatePayload(
+  opcode: BrowserNetworkTunnelOpcode,
+  payload: Uint8Array<ArrayBufferLike>
+): void {
+  if (opcode === BrowserNetworkTunnelOpcode.Data) {
+    if (payload.byteLength > BROWSER_NETWORK_TUNNEL_MAX_DATA_BYTES) {
+      throw new Error('Browser tunnel data payload is too large')
+    }
+    return
+  }
+  if (opcode === BrowserNetworkTunnelOpcode.Open) {
+    if (!decodeBrowserNetworkTunnelOpen(payload)) {
+      throw new Error('Browser tunnel open payload is invalid')
+    }
+    return
+  }
+  if (opcode === BrowserNetworkTunnelOpcode.WindowUpdate) {
+    if (!decodeBrowserNetworkTunnelWindowUpdate(payload)) {
+      throw new Error('Browser tunnel window update payload is invalid')
+    }
+    return
+  }
+  if (
+    opcode === BrowserNetworkTunnelOpcode.Opened ||
+    opcode === BrowserNetworkTunnelOpcode.HalfClose ||
+    opcode === BrowserNetworkTunnelOpcode.Close
+  ) {
+    if (payload.byteLength !== 0) {
+      throw new Error('Browser tunnel control payload must be empty')
+    }
+    return
+  }
+  if (payload.byteLength > MAX_CONTROL_PAYLOAD_BYTES) {
+    throw new Error('Browser tunnel control payload is too large')
+  }
+}
+
+function isBrowserNetworkTunnelOpcode(value: number): value is BrowserNetworkTunnelOpcode {
+  return value >= BrowserNetworkTunnelOpcode.Open && value <= BrowserNetworkTunnelOpcode.Pong
+}

--- a/src/shared/protocol-version.ts
+++ b/src/shared/protocol-version.ts
@@ -73,6 +73,8 @@ export const BROWSER_CERTIFICATE_TRUST_RUNTIME_CAPABILITY = 'browser.certificate
 // treat a preallocated page ID as canonical when this is advertised.
 export const BROWSER_TAB_CREATE_KNOWN_ID_RUNTIME_CAPABILITY =
   'browser.tab-create-known-id.v1' as const
+export const BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY = 'browser.clientHost.v1' as const
+export const BROWSER_NETWORK_TUNNEL_RUNTIME_CAPABILITY = 'network.browserTunnel.v1' as const
 // Why: hosts without this strip terminal.send's inputKind (zod object drops
 // unknown keys), so a mobile xterm query reply would land as ordinary
 // floor-taking input. Mobile must not forward replies unless advertised.


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​790 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​790 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1124 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1124 |

<!-- /orca-pr-loc -->

## Summary

Stack 1/5 for STA-4150. Defines the additive, capability-gated client-host, tunnel, lease, placement, and command contracts. This layer does not advertise support or change normal browser placement.

## Compatibility

- Optional fields preserve old callers and old clients.
- Existing server/offscreen browser behavior is unchanged.
- No new stream opcode is introduced.

## Validation

- Full Node/CLI/web typecheck
- Full lint, audits, max-lines, localization, and 86 reliability gates
- Focused shared contract suite: 3 tests passed

Draft only. Do not merge outside the complete stack.