### PR TITLE
fix(daemon): preserve sessions during uncertain Windows recovery

### DIFF
--- a/src/main/daemon/daemon-errors.ts
+++ b/src/main/daemon/daemon-errors.ts
@@ -1,3 +1,5 @@
+import { PtyWriteUnavailableError } from '../providers/pty-write-unavailable-error'
+
 // Error classes shared across the daemon protocol boundary (client, server,
 // host). Split from types.ts, which is capped for wire-shape declarations.
 export class TerminalAttachCanceledError extends Error {
@@ -21,7 +23,7 @@ export class SessionNotFoundError extends Error {
   }
 }
 
-export class TerminalSessionOwnerUnverifiedError extends Error {
+export class TerminalSessionOwnerUnverifiedError extends PtyWriteUnavailableError {
   constructor(sessionId: string) {
     super(`Terminal session owner could not be verified: ${sessionId}`)
     this.name = 'TerminalSessionOwnerUnverifiedError'

--- a/src/main/daemon/daemon-init-dependency-mocks.ts
+++ b/src/main/daemon/daemon-init-dependency-mocks.ts
@@ -254,8 +254,16 @@ export function createNetConnectStubs(state: DaemonInitMockState): NetConnectStu
         on(event: string, cb: () => void) {
           handlers[event]?.push(cb)
           if (event === 'error') {
-            queueMicrotask(() => cb())
+            queueMicrotask(() =>
+              (cb as (error: NodeJS.ErrnoException) => void)(
+                Object.assign(new Error('missing endpoint'), { code: 'ENOENT' })
+              )
+            )
           }
+          return this
+        },
+        off(event: string, cb: () => void) {
+          handlers[event] = handlers[event]?.filter((handler) => handler !== cb) ?? []
           return this
         },
         removeListener(event: string, cb: () => void) {
@@ -277,6 +285,10 @@ export function createNetConnectStubs(state: DaemonInitMockState): NetConnectStu
           if ((live && event === 'connect') || (!live && event === 'error')) {
             queueMicrotask(() => callback())
           }
+          return this
+        },
+        off(event: string, callback: () => void) {
+          handlers[event] = handlers[event]?.filter((handler) => handler !== callback) ?? []
           return this
         },
         removeListener(event: string, callback: () => void) {

--- a/src/main/daemon/daemon-init-mock-types.ts
+++ b/src/main/daemon/daemon-init-mock-types.ts
@@ -45,7 +45,7 @@ export type MockAdapterConstructor = new (opts: MockAdapter['options']) => MockA
 
 /** Handle the fake spawner hands back from ensureRunning/getHandle. */
 export type MockSpawnerHandle = {
-  mode?: 'degraded-new-pty-fallback'
+  mode?: 'degraded-new-pty-fallback' | 'held'
   releaseAdoptionLease?: () => void
   shutdown: () => Promise<void>
 }
@@ -53,6 +53,7 @@ export type MockSpawnerHandle = {
 /** Slice of net.Socket the daemon socket probe drives. */
 export type MockProbeSocket = {
   on: (event: string, callback: () => void) => MockProbeSocket
+  off: (event: string, callback: () => void) => MockProbeSocket
   removeListener: (event: string, callback: () => void) => MockProbeSocket
   destroy: () => void
 }
@@ -93,7 +94,7 @@ export type MockLocalPtyProvider = {
 export type EnsureRunningOverride = () => Promise<{
   socketPath: string
   tokenPath: string
-  mode?: 'degraded-new-pty-fallback'
+  mode?: 'degraded-new-pty-fallback' | 'held'
 }>
 
 /** Every stub daemon-init's suites share, plus the control knobs they mutate per test. */

--- a/src/main/daemon/daemon-init-provider-installation.test.ts
+++ b/src/main/daemon/daemon-init-provider-installation.test.ts
@@ -255,6 +255,26 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     expect(adapterInstances[0].listProcesses).toHaveBeenCalled()
   })
 
+  it('installs a held daemon without requiring an adoption handshake', async () => {
+    const mod = await importFresh()
+    ensureRunningOverrides.push(async () => ({
+      socketPath: '/fake/held-socket',
+      tokenPath: '/fake/held-token',
+      mode: 'held'
+    }))
+
+    await mod.initDaemonPtyProvider()
+
+    const { DegradedDaemonPtyProvider } = await import('./degraded-daemon-pty-provider')
+    const provider = mod.getDaemonProvider()
+    expect(provider).toBeInstanceOf(DegradedDaemonPtyProvider)
+    expect(adapterInstances[0].establishLifecycleLease).not.toHaveBeenCalled()
+    expect(adoptionLeaseReleases[0]).not.toHaveBeenCalled()
+    await expect(provider!.spawn({ cols: 80, rows: 24 })).resolves.toEqual({
+      id: 'local-fallback-pty'
+    })
+  })
+
   it('rechecks the preserved daemon endpoint before recovering fresh-spawn routing', async () => {
     const mod = await importFresh()
     ensureRunningOverrides.push(async () => ({

--- a/src/main/daemon/daemon-init-replacement-reporting.test.ts
+++ b/src/main/daemon/daemon-init-replacement-reporting.test.ts
@@ -265,6 +265,10 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
           }
           return this
         },
+        off(event: string, cb: () => void) {
+          handlers[event] = handlers[event]?.filter((handler) => handler !== cb) ?? []
+          return this
+        },
         removeListener(event: string, cb: () => void) {
           handlers[event] = handlers[event]?.filter((handler) => handler !== cb) ?? []
           return this

--- a/src/main/daemon/daemon-init-restart-sequence.test.ts
+++ b/src/main/daemon/daemon-init-restart-sequence.test.ts
@@ -418,6 +418,10 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
           }
           return this
         },
+        off(event: string, cb: () => void) {
+          handlers[event] = handlers[event]?.filter((handler) => handler !== cb) ?? []
+          return this
+        },
         removeListener(event: string, cb: () => void) {
           handlers[event] = handlers[event]?.filter((handler) => handler !== cb) ?? []
           return this
@@ -447,6 +451,10 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
       const socket = {
         on(event: string, cb: () => void) {
           handlers[event]?.add(cb)
+          return this
+        },
+        off(event: string, cb: () => void) {
+          handlers[event]?.delete(cb)
           return this
         },
         removeListener(event: string, cb: () => void) {

--- a/src/main/daemon/daemon-init-test-harness.ts
+++ b/src/main/daemon/daemon-init-test-harness.ts
@@ -58,6 +58,10 @@ function createDaemonInitMockState(): DaemonInitMockState {
         }
         return this
       },
+      off(event: string, cb: () => void) {
+        handlers[event] = handlers[event]?.filter((handler) => handler !== cb) ?? []
+        return this
+      },
       removeListener(event: string, cb: () => void) {
         handlers[event] = handlers[event]?.filter((handler) => handler !== cb) ?? []
         return this

--- a/src/main/daemon/daemon-init-wedged-daemon-grace.test.ts
+++ b/src/main/daemon/daemon-init-wedged-daemon-grace.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { WEDGED_DAEMON_GRACE_RETRIES } from './daemon-init'
+import { FAKE_RUNTIME_DIR } from './daemon-init-test-harness'
 
 const {
   probeSocketExistsMock,
@@ -54,6 +55,10 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
         if (event === 'connect') {
           queueMicrotask(() => cb())
         }
+        return this
+      },
+      off(event: string, cb: () => void) {
+        handlers[event] = handlers[event]?.filter((handler) => handler !== cb) ?? []
         return this
       },
       removeListener(event: string, cb: () => void) {

--- a/src/main/daemon/daemon-init-wedged-daemon-grace.test.ts
+++ b/src/main/daemon/daemon-init-wedged-daemon-grace.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { WEDGED_DAEMON_GRACE_RETRIES } from './daemon-init'
-import { FAKE_RUNTIME_DIR } from './daemon-init-test-harness'
 
 const {
   probeSocketExistsMock,
@@ -104,8 +103,8 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     expect(forkMock).not.toHaveBeenCalled()
   })
 
-  it('replaces a permanently wedged daemon after the grace window is exhausted (#8689)', async () => {
-    // Why: a socket that accepts connections but never answers hello was preserved forever (#8689); after grace it must be replaced.
+  it('holds a connectable daemon when occupancy stays unknown after the grace window', async () => {
+    // Unknown occupancy is not permission to kill ConPTY-owned sessions.
     const mod = await importFresh()
     await mod.initDaemonPtyProvider()
 
@@ -116,7 +115,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
         disconnect: vi.fn()
       }
     }
-    // Permanent wedge: every probe times out, then the freshly spawned daemon accepts the temporary adoption lease.
+    // Every occupancy probe times out while the incumbent still owns the endpoint.
     let daemonClientConstructionCount = 0
     daemonClientMock.mockImplementation(function MockDaemonClient() {
       daemonClientConstructionCount++
@@ -159,23 +158,15 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     try {
-      await launcher('/fake/socket', '/fake/token')
+      const handle = await launcher('/fake/socket', '/fake/token')
 
-      expect(killStaleDaemonMock).toHaveBeenCalledWith(
-        FAKE_RUNTIME_DIR,
-        '/fake/socket',
-        '/fake/token'
-      )
-      expect(forkMock).toHaveBeenCalled()
+      expect(handle).toMatchObject({ mode: 'held' })
+      expect(killStaleDaemonMock).not.toHaveBeenCalled()
+      expect(forkMock).not.toHaveBeenCalled()
       // The launcher probes the full grace budget: 1 initial probe + WEDGED_DAEMON_GRACE_RETRIES retries.
-      expect(daemonClientMock).toHaveBeenCalledTimes(3 + WEDGED_DAEMON_GRACE_RETRIES)
-      // Why: this replace path used to kill the daemon with no log, so a post-hoc
-      // reader could not tell it apart from an adoption; the verdict must be recorded.
+      expect(daemonClientMock).toHaveBeenCalledTimes(2 + WEDGED_DAEMON_GRACE_RETRIES)
       expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Replacing daemon that failed the health check')
-      )
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining(`graceRetries=${WEDGED_DAEMON_GRACE_RETRIES}`)
+        expect.stringContaining('HOLDING daemon with unverifiable occupancy')
       )
     } finally {
       warnSpy.mockRestore()

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -14,10 +14,16 @@ import {
   replaceDaemonPidFile,
   unlinkOwnedDaemonPidFile,
   type DaemonLauncher,
+  type DaemonLaunchMode,
   type DaemonPidFile,
   type DaemonProcessHandle
 } from './daemon-spawner'
 import { DAEMON_EXIT_ENDPOINT_OCCUPIED } from './daemon-endpoint-ownership'
+import { endpointIsProvenDead, probeSocketConnect } from './daemon-endpoint-probe'
+import {
+  shouldDisableUnknownOccupancyHold,
+  shouldForceDaemonInventoryUnavailable
+} from './daemon-supervision-fault-injection'
 import { DaemonPtyAdapter, type DaemonRespawnReason } from './daemon-pty-adapter'
 import { DaemonPtyRouter } from './daemon-pty-router'
 import { DaemonClient } from './client'
@@ -177,6 +183,9 @@ async function getAliveDaemonSessionCount(
   tokenPath: string,
   protocolVersion = PROTOCOL_VERSION
 ): Promise<number | null> {
+  if (shouldForceDaemonInventoryUnavailable()) {
+    return null
+  }
   const client = new DaemonClient({ socketPath, tokenPath, protocolVersion })
   try {
     await client.ensureConnected()
@@ -192,7 +201,7 @@ async function getAliveDaemonSessionCount(
 function createPreservedDaemonHandle(
   runtimeDir: string,
   protocolVersion = PROTOCOL_VERSION,
-  mode?: 'degraded-new-pty-fallback'
+  mode?: DaemonLaunchMode
 ): DaemonProcessHandle {
   const handle: DaemonProcessHandle = {
     shutdown: async () => {
@@ -474,9 +483,12 @@ function createOutOfProcessLauncher(
       adoptionClient.disconnect()
       adoptionClient = null
     }
-    const preserveDaemon = async (
-      mode?: 'degraded-new-pty-fallback'
-    ): Promise<DaemonProcessHandle> => {
+    const holdIncumbentDaemon = (): DaemonProcessHandle => {
+      adoptionClient?.disconnect()
+      adoptionClient = null
+      return createPreservedDaemonHandle(runtimeDir, PROTOCOL_VERSION, 'held')
+    }
+    const preserveDaemon = async (mode?: DaemonLaunchMode): Promise<DaemonProcessHandle> => {
       const connectedClient = adoptionClient ?? undefined
       adoptionClient = null
       return holdDaemonAdoptionLease(
@@ -599,6 +611,18 @@ function createOutOfProcessLauncher(
             `[daemon] Preserving daemon that failed the health check because it owns ${liveSessionCount} live session${liveSessionCount === 1 ? '' : 's'}`
           )
           return preserveDaemon()
+        }
+        // Unverifiable occupancy is not authority to destroy the incumbent process tree.
+        if (
+          liveSessionCount === null &&
+          health !== 'rejected' &&
+          !shouldDisableUnknownOccupancyHold() &&
+          !endpointIsProvenDead(await probeSocketConnect(socketPath))
+        ) {
+          console.warn(
+            `[daemon] DEGRADED MODE: HOLDING daemon with unverifiable occupancy (health=${health}, graceRetries=${graceRetry}). Replacing it could end live terminals; fresh terminals run locally until it recovers or you restart it.`
+          )
+          return holdIncumbentDaemon()
         }
         // Why: the sibling replace branches announce themselves, but this one used
         // to kill a daemon silently — leaving no way to tell a replacement apart
@@ -989,12 +1013,14 @@ export async function initDaemonPtyProvider(
   let routedAdapter: DaemonProvider = newAdapter
   try {
     // Why: the launcher's temporary pair closes only after this permanent pair is established, leaving no adoption gap.
-    await newAdapter.establishLifecycleLease()
-    releaseDaemonAdoptionLease(newSpawner.getHandle())
+    if (launchMode !== 'held') {
+      await newAdapter.establishLifecycleLease()
+      releaseDaemonAdoptionLease(newSpawner.getHandle())
+    }
 
     legacyAdapters = await createLegacyDaemonAdapters(runtimeDir)
     routedAdapter =
-      launchMode === 'degraded-new-pty-fallback'
+      launchMode === 'degraded-new-pty-fallback' || launchMode === 'held'
         ? new DegradedDaemonPtyProvider({
             current: newAdapter,
             legacy: legacyAdapters,

--- a/src/main/daemon/daemon-pty-adapter-daemon-recovery.test.ts
+++ b/src/main/daemon/daemon-pty-adapter-daemon-recovery.test.ts
@@ -233,28 +233,52 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
 
     it('joins a request-path respawn instead of forking a second daemon', async () => {
       let releaseRespawn!: () => void
+      let respawnCalls = 0
       const respawn = vi.fn(async () => {
-        await new Promise<void>((resolve) => {
-          releaseRespawn = resolve
-        })
+        respawnCalls += 1
+        if (respawnCalls > 1) {
+          throw new Error('unexpected second respawn')
+        }
+        await new Promise<void>((resolve) => (releaseRespawn = resolve))
         restartServerOnRespawn()
         await server.start()
       })
       const healingAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, respawn })
+      const adapterInternals = healingAdapter as unknown as {
+        ensureConnected(): Promise<void>
+      }
       try {
         const { id } = await healingAdapter.spawn({ cols: 80, rows: 24 })
         const client = (healingAdapter as unknown as { client: DaemonClient }).client
         await server.shutdown()
         await waitFor(() => !client.isConnected())
 
+        let releaseStaleAttempt!: () => void
+        let staleAttemptStarted!: () => void
+        const staleAttempt = new Promise<void>((resolve) => (staleAttemptStarted = resolve))
+        const realEnsureConnected = adapterInternals.ensureConnected.bind(adapterInternals)
+        vi.spyOn(adapterInternals, 'ensureConnected')
+          .mockImplementationOnce(async () => {
+            staleAttemptStarted()
+            await new Promise<void>((resolve) => (releaseStaleAttempt = resolve))
+            throw Object.assign(new Error('connect ENOENT from stale request'), {
+              code: 'ENOENT',
+              syscall: 'connect'
+            })
+          })
+          .mockImplementation(realEnsureConnected)
+
         const newSpawn = healingAdapter.spawn({
           sessionId: 'request-path-session',
           cols: 80,
           rows: 24
         })
-        await waitFor(() => releaseRespawn !== undefined)
+        await staleAttempt
         expect(() => healingAdapter.write(id, 'queued')).toThrow(PtyWriteUnavailableError)
+        await waitFor(() => releaseRespawn !== undefined)
         releaseRespawn()
+        await waitFor(() => client.isConnected())
+        releaseStaleAttempt()
 
         await expect(newSpawn).resolves.toMatchObject({ id: 'request-path-session' })
         expect(respawn).toHaveBeenCalledTimes(1)

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -243,6 +243,8 @@ export class DaemonPtyAdapter implements IPtyProvider {
   private respawnAdoptionClosed = false
   // Why: concurrent spawn() calls hitting a dead daemon would each fork their own; this promise coalesces respawns so only the first forks and the rest await it.
   private respawnPromise: Promise<void> | null = null
+  // A late failure retries the replacement it straddled instead of replacing that replacement.
+  private respawnGeneration = 0
   private staleBundleReplacementPromise: Promise<void> | null = null
   private writeRecoveryPromise: Promise<void> | null = null
   private writeRecoveryAttempted = false
@@ -2560,6 +2562,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
   }
 
   private async withDaemonRetry<T>(fn: () => Promise<T>): Promise<T> {
+    const attemptGeneration = this.respawnGeneration
     try {
       return await fn()
     } catch (err) {
@@ -2574,12 +2577,11 @@ export class DaemonPtyAdapter implements IPtyProvider {
       if (this.respawnAdoptionClosed || !this.respawnFn || !isDaemonGoneError(err)) {
         throw err
       }
-      if (!this.respawnPromise) {
-        this.respawnPromise = this.doRespawn().finally(() => {
-          this.respawnPromise = null
-        })
+      if (attemptGeneration === this.respawnGeneration) {
+        await this.ensureRespawn()
+      } else if (this.respawnPromise) {
+        await this.respawnPromise
       }
-      await this.respawnPromise
       try {
         return await fn()
       } finally {
@@ -2688,15 +2690,10 @@ export class DaemonPtyAdapter implements IPtyProvider {
 
     // Why: replacing the daemon kills its sessions without exit fanout; emit exits first so panes don't write to dead PTYs.
     this.fanoutSyntheticExits(-1)
-    if (!this.respawnPromise) {
-      this.respawnPromise = this.doRespawn(
-        '[daemon] macOS system resolver unavailable - respawning daemon',
-        'unhealthy_resolver'
-      ).finally(() => {
-        this.respawnPromise = null
-      })
-    }
-    await this.respawnPromise
+    await this.ensureRespawn(
+      '[daemon] macOS system resolver unavailable - respawning daemon',
+      'unhealthy_resolver'
+    )
   }
 
   /** Replace a stale packaged daemon only after its live sessions drain. */
@@ -2742,15 +2739,10 @@ export class DaemonPtyAdapter implements IPtyProvider {
     }
 
     this.fanoutSyntheticExits(-1)
-    if (!this.respawnPromise) {
-      this.respawnPromise = this.doRespawn(
-        '[daemon] Packaged daemon is stale - respawning from the current app bundle',
-        'stale_bundle'
-      ).finally(() => {
-        this.respawnPromise = null
-      })
-    }
-    await this.respawnPromise
+    await this.ensureRespawn(
+      '[daemon] Packaged daemon is stale - respawning from the current app bundle',
+      'stale_bundle'
+    )
   }
 
   /** Replace a TCC-severed daemon only after its live sessions drain. */
@@ -2782,15 +2774,10 @@ export class DaemonPtyAdapter implements IPtyProvider {
     }
 
     this.fanoutSyntheticExits(-1)
-    if (!this.respawnPromise) {
-      this.respawnPromise = this.doRespawn(
-        '[daemon] macOS TCC attribution severed - respawning daemon under the current app binary',
-        'severed_tcc_attribution'
-      ).finally(() => {
-        this.respawnPromise = null
-      })
-    }
-    await this.respawnPromise
+    await this.ensureRespawn(
+      '[daemon] macOS TCC attribution severed - respawning daemon under the current app binary',
+      'severed_tcc_attribution'
+    )
   }
 
   private async getDaemonLiveSessionCount(): Promise<number | null> {
@@ -2825,6 +2812,22 @@ export class DaemonPtyAdapter implements IPtyProvider {
       throw new Error('Daemon adapter closed during respawn')
     }
     this.pendingRespawnAdoptionRelease = releaseAdoptionLease ?? null
+  }
+
+  private ensureRespawn(message?: string, reason?: DaemonRespawnReason): Promise<void> {
+    if (!this.respawnPromise) {
+      const respawn = this.doRespawn(message, reason)
+        .then(() => {
+          this.respawnGeneration += 1
+        })
+        .finally(() => {
+          if (this.respawnPromise === respawn) {
+            this.respawnPromise = null
+          }
+        })
+      this.respawnPromise = respawn
+    }
+    return this.respawnPromise
   }
 
   private releasePendingRespawnAdoptionLease(): void {

--- a/src/main/daemon/daemon-spawner.ts
+++ b/src/main/daemon/daemon-spawner.ts
@@ -28,8 +28,10 @@ export type DaemonPidFile = {
   spawnerExecPath?: string
 }
 
+export type DaemonLaunchMode = 'degraded-new-pty-fallback' | 'held'
+
 export type DaemonProcessHandle = {
-  mode?: 'degraded-new-pty-fallback'
+  mode?: DaemonLaunchMode
   releaseAdoptionLease?(): void
   shutdown(): Promise<void>
 }

--- a/src/main/daemon/daemon-supervision-fault-injection.ts
+++ b/src/main/daemon/daemon-supervision-fault-injection.ts
@@ -1,0 +1,12 @@
+export const E2E_FORCE_DAEMON_INVENTORY_UNAVAILABLE_ENV =
+  'ORCA_E2E_FORCE_DAEMON_INVENTORY_UNAVAILABLE'
+
+export const E2E_DISABLE_UNKNOWN_OCCUPANCY_HOLD_ENV = 'ORCA_E2E_DISABLE_UNKNOWN_OCCUPANCY_HOLD'
+
+export function shouldForceDaemonInventoryUnavailable(): boolean {
+  return process.env[E2E_FORCE_DAEMON_INVENTORY_UNAVAILABLE_ENV] === '1'
+}
+
+export function shouldDisableUnknownOccupancyHold(): boolean {
+  return process.env[E2E_DISABLE_UNKNOWN_OCCUPANCY_HOLD_ENV] === '1'
+}

--- a/src/main/daemon/degraded-daemon-pty-provider.test.ts
+++ b/src/main/daemon/degraded-daemon-pty-provider.test.ts
@@ -5,6 +5,7 @@ import type { DaemonPtyAdapter } from './daemon-pty-adapter'
 import type { IPtyProvider, PtySpawnOptions, PtySpawnResult } from '../providers/types'
 import type { PtyProcessInspection } from '../providers/pty-process-inspection'
 import { SessionNotFoundError, TerminalSessionOwnerUnverifiedError } from './daemon-errors'
+import { PtyWriteUnavailableError } from '../providers/pty-write-unavailable-error'
 
 type ProviderMock = IPtyProvider & {
   probePtyLiveness: (id: string) => Promise<boolean | null>
@@ -158,6 +159,32 @@ it('forwards dead-endpoint write-unavailable signals from the daemon adapters', 
   unsubscribe()
   current.triggerWriteUnavailable('after-unsubscribe')
   expect(recovered).toEqual(['daemon-pane', 'legacy-pane'])
+})
+
+it('fences mutating operations when no provider can prove session ownership', async () => {
+  const current = createDaemonAdapter('daemon')
+  const fallback = createProvider('fallback')
+  const provider = new DegradedDaemonPtyProvider({ current, legacy: [], fallback })
+
+  expect(() => provider.write('unverified-session', 'input')).toThrow(
+    TerminalSessionOwnerUnverifiedError
+  )
+  expect(() => provider.write('unverified-session', 'input')).toThrow(PtyWriteUnavailableError)
+  await expect(provider.writeWithSettlement('unverified-session', 'input')).rejects.toBeInstanceOf(
+    TerminalSessionOwnerUnverifiedError
+  )
+  expect(() => provider.resize('unverified-session', 80, 24)).toThrow(
+    TerminalSessionOwnerUnverifiedError
+  )
+  await expect(provider.shutdown('unverified-session', { immediate: true })).rejects.toBeInstanceOf(
+    TerminalSessionOwnerUnverifiedError
+  )
+  await expect(provider.sendSignal('unverified-session', 'SIGINT')).rejects.toBeInstanceOf(
+    TerminalSessionOwnerUnverifiedError
+  )
+
+  expect(fallback.write).not.toHaveBeenCalled()
+  expect(fallback.shutdown).not.toHaveBeenCalled()
 })
 
 it('routes attach-only to a legacy session created after startup inventory', async () => {

--- a/src/main/daemon/degraded-daemon-pty-provider.ts
+++ b/src/main/daemon/degraded-daemon-pty-provider.ts
@@ -15,7 +15,8 @@ import {
   adoptOwningProvider,
   attachDaemonOwnedSession,
   findDaemonAdapter,
-  listProviderSessionIds
+  listProviderSessionIds,
+  ownerForDaemonOwnedOperation
 } from './degraded-daemon-session-routing'
 import { DegradedDaemonFreshSpawnRouter } from './degraded-daemon-fresh-spawn-routing'
 import { DegradedDaemonOwnerRecovery } from './degraded-daemon-owner-recovery'
@@ -109,18 +110,18 @@ export class DegradedDaemonPtyProvider implements IPtyProvider {
     )?.providesAgentSessionOwnerListings?.(ptyId) === true
 
   write(id: string, data: string): boolean | void {
-    return this.providerFor(id).write(id, data)
+    return this.ownerFor(id).write(id, data)
   }
 
   async writeWithSettlement(id: string, data: string): Promise<boolean> {
-    const provider = this.providerFor(id)
+    const provider = this.ownerFor(id)
     return provider.writeWithSettlement
       ? await provider.writeWithSettlement(id, data)
       : provider.write(id, data) !== false
   }
 
   resize(id: string, cols: number, rows: number): void {
-    this.providerFor(id).resize(id, cols, rows)
+    this.ownerFor(id).resize(id, cols, rows)
   }
 
   pauseProducer(id: string): void {
@@ -139,14 +140,14 @@ export class DegradedDaemonPtyProvider implements IPtyProvider {
     id: string,
     opts: { immediate?: boolean; keepHistory?: boolean; deadlineMs?: number }
   ): Promise<void> {
-    await this.providerFor(id).shutdown(id, opts)
+    await this.ownerFor(id).shutdown(id, opts)
     if (!opts.keepHistory) {
       this.sessionProviders.delete(id)
     }
   }
 
   async sendSignal(id: string, signal: string): Promise<void> {
-    await this.providerFor(id).sendSignal(id, signal)
+    await this.ownerFor(id).sendSignal(id, signal)
   }
 
   async getCwd(id: string): Promise<string> {
@@ -343,6 +344,10 @@ export class DegradedDaemonPtyProvider implements IPtyProvider {
       this.findProviderForExistingSession(sessionId) ??
       this.fallback
     )
+  }
+
+  private ownerFor(sessionId: string): IPtyProvider {
+    return ownerForDaemonOwnedOperation(this.providerFor(sessionId), this.fallback, sessionId)
   }
 
   private findProviderForExistingSession(sessionId: string): IPtyProvider | null {

--- a/src/main/daemon/degraded-daemon-session-routing.ts
+++ b/src/main/daemon/degraded-daemon-session-routing.ts
@@ -1,6 +1,6 @@
 import type { IPtyProvider } from '../providers/types'
 import type { DaemonPtyAdapter } from './daemon-pty-adapter'
-import { SessionNotFoundError } from './daemon-errors'
+import { SessionNotFoundError, TerminalSessionOwnerUnverifiedError } from './daemon-errors'
 
 export function listProviderSessionIds(
   sessionProviders: ReadonlyMap<string, IPtyProvider>,
@@ -24,6 +24,17 @@ export async function attachDaemonOwnedSession(
     throw new SessionNotFoundError(sessionId)
   }
   return await owner.attach(sessionId)
+}
+
+export function ownerForDaemonOwnedOperation(
+  owner: IPtyProvider,
+  fallback: IPtyProvider,
+  sessionId: string
+): IPtyProvider {
+  if (owner === fallback && fallback.hasPty?.(sessionId) !== true) {
+    throw new TerminalSessionOwnerUnverifiedError(sessionId)
+  }
+  return owner
 }
 
 /** Probes providers for an id absent from the routing map and adopts the

--- a/tests/e2e/daemon-unknown-occupancy-preservation.spec.ts
+++ b/tests/e2e/daemon-unknown-occupancy-preservation.spec.ts
@@ -1,0 +1,151 @@
+import { existsSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import type { ElectronApplication, TestInfo } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import { TEST_REPO_PATH_FILE } from './global-setup'
+import {
+  discoverActivePtyId,
+  execInTerminal,
+  getTerminalContent,
+  waitForActiveTerminalManager,
+  waitForPaneCount,
+  waitForTerminalOutput
+} from './helpers/terminal'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import { attachRepoAndOpenTerminal, createRestartSession } from './helpers/orca-restart'
+import { E2E_FORCE_DAEMON_HEALTH_UNREACHABLE_ENV } from '../../src/main/daemon/daemon-health'
+import {
+  E2E_DISABLE_UNKNOWN_OCCUPANCY_HOLD_ENV,
+  E2E_FORCE_DAEMON_INVENTORY_UNAVAILABLE_ENV
+} from '../../src/main/daemon/daemon-supervision-fault-injection'
+import { PROTOCOL_VERSION } from '../../src/main/daemon/types'
+import {
+  processIdentityIsAlive,
+  recordProcessIdentity,
+  type RecordedProcessIdentity
+} from './helpers/daemon-generation-processes'
+
+const GUARD_DECISION_DELAY_MS = 3_000
+
+function readDaemonPid(userDataDir: string): number {
+  const pidPath = path.join(userDataDir, 'daemon', `daemon-v${PROTOCOL_VERSION}.pid`)
+  const parsed = JSON.parse(readFileSync(pidPath, 'utf8')) as { pid?: unknown }
+  if (typeof parsed.pid !== 'number') {
+    throw new Error(`Daemon pid file did not contain a numeric pid: ${readFileSync(pidPath)}`)
+  }
+  return parsed.pid
+}
+
+async function recordTerminalShell(page: Parameters<typeof getTerminalContent>[0]) {
+  const marker = `ORCA_SHELL_PID_${Date.now()}`
+  const ptyId = await discoverActivePtyId(page)
+  await execInTerminal(page, ptyId, `node -e "console.log('${marker}=' + process.ppid)"`)
+  await waitForTerminalOutput(page, `${marker}=`)
+  const match = new RegExp(`${marker}=(\\d+)`).exec(await getTerminalContent(page))
+  if (!match) {
+    throw new Error('Terminal shell pid marker was not observed')
+  }
+  return { ptyId, identity: await recordProcessIdentity(Number(match[1])) }
+}
+
+async function expectIdentityAlive(
+  identity: RecordedProcessIdentity,
+  alive: boolean
+): Promise<void> {
+  await expect.poll(() => processIdentityIsAlive(identity), { timeout: 15_000 }).toBe(alive)
+}
+
+async function runOracle(testInfo: TestInfo, holdEnabled: boolean): Promise<void> {
+  testInfo.setTimeout(120_000)
+  test.skip(process.platform !== 'win32', 'Windows process-identity oracle')
+  const repoPath = readFileSync(TEST_REPO_PATH_FILE, 'utf8').trim()
+  test.skip(!repoPath || !existsSync(repoPath), 'Global setup did not produce a seeded test repo')
+
+  const session = createRestartSession(testInfo)
+  let firstApp: ElectronApplication | null = null
+  let secondApp: ElectronApplication | null = null
+  try {
+    const firstLaunch = await session.launch()
+    firstApp = firstLaunch.app
+    const worktreeId = await attachRepoAndOpenTerminal(firstLaunch.page, repoPath)
+    await waitForSessionReady(firstLaunch.page)
+    await waitForActiveWorktree(firstLaunch.page)
+    await ensureTerminalVisible(firstLaunch.page)
+    await waitForActiveTerminalManager(firstLaunch.page, 30_000)
+    await waitForPaneCount(firstLaunch.page, 1, 30_000)
+
+    const shell = await recordTerminalShell(firstLaunch.page)
+    const beforeMarker = `UNKNOWN_OCCUPANCY_BEFORE_${Date.now()}`
+    await execInTerminal(firstLaunch.page, shell.ptyId, `echo ${beforeMarker}`)
+    await waitForTerminalOutput(firstLaunch.page, beforeMarker)
+    const daemon = await recordProcessIdentity(readDaemonPid(session.userDataDir))
+
+    await session.close(firstApp)
+    firstApp = null
+    await expectIdentityAlive(daemon, true)
+    await expectIdentityAlive(shell.identity, true)
+
+    const stderrLines: string[] = []
+    const secondLaunch = await session.launch({
+      extraEnv: {
+        [E2E_FORCE_DAEMON_HEALTH_UNREACHABLE_ENV]: '1',
+        [E2E_FORCE_DAEMON_INVENTORY_UNAVAILABLE_ENV]: '1',
+        ...(holdEnabled ? {} : { [E2E_DISABLE_UNKNOWN_OCCUPANCY_HOLD_ENV]: '1' }),
+        ORCA_E2E_DAEMON_INIT_DELAY_MS: String(GUARD_DECISION_DELAY_MS)
+      },
+      onStderr: (chunk) => stderrLines.push(chunk)
+    })
+    secondApp = secondLaunch.app
+    await waitForSessionReady(secondLaunch.page)
+
+    if (!holdEnabled) {
+      await expectIdentityAlive(daemon, false)
+      await expectIdentityAlive(shell.identity, false)
+      await expect
+        .poll(() => stderrLines.join(''), { timeout: 10_000 })
+        .toMatch(/replacing daemon/i)
+      return
+    }
+
+    await expectIdentityAlive(daemon, true)
+    await expectIdentityAlive(shell.identity, true)
+    expect(readDaemonPid(session.userDataDir)).toBe(daemon.pid)
+    await expect.poll(() => stderrLines.join(''), { timeout: 10_000 }).toMatch(/holding daemon/i)
+    expect(stderrLines.join('')).not.toMatch(/replacing daemon/i)
+
+    await expect
+      .poll(() => secondLaunch.page.evaluate(() => window.__store?.getState().activeWorktreeId), {
+        timeout: 15_000
+      })
+      .toBe(worktreeId)
+    await ensureTerminalVisible(secondLaunch.page)
+    await waitForActiveTerminalManager(secondLaunch.page, 30_000)
+    await waitForPaneCount(secondLaunch.page, 1, 30_000)
+    await waitForTerminalOutput(secondLaunch.page, beforeMarker, 20_000)
+    expect(await getTerminalContent(secondLaunch.page)).not.toContain('--- session restored ---')
+
+    const afterMarker = `UNKNOWN_OCCUPANCY_AFTER_${Date.now()}`
+    await execInTerminal(secondLaunch.page, shell.ptyId, `echo ${afterMarker}`)
+    await waitForTerminalOutput(secondLaunch.page, afterMarker, 20_000)
+  } finally {
+    if (secondApp) {
+      await session.close(secondApp)
+    }
+    if (firstApp) {
+      await session.close(firstApp)
+    }
+    await session.dispose()
+  }
+}
+
+test.describe.configure({ mode: 'serial' })
+
+test('@headful preserves daemon and shell identities when occupancy is unknown', async (// oxlint-disable-next-line no-empty-pattern -- This oracle owns an isolated two-launch fixture.
+{}, testInfo) => {
+  await runOracle(testInfo, true)
+})
+
+test('@headful same oracle destroys identities when the hold is disabled', async (// oxlint-disable-next-line no-empty-pattern -- This oracle owns an isolated two-launch fixture.
+{}, testInfo) => {
+  await runOracle(testInfo, false)
+})


### PR DESCRIPTION
## Summary

- hold an unresponsive incumbent when daemon occupancy cannot be verified instead of treating unknown as permission to kill its PTYs
- route fresh terminals locally while held and fence mutating operations whose owning provider is unverified
- make request/write recovery adopt a completed respawn generation instead of initiating a second replacement
- add deterministic unit and physical Windows Electron/CDP process-identity oracles

## Root cause

Current main retries health and `listSessions`, but `null` occupancy falls through to `killStaleDaemon()`. On Windows, forced daemon termination also destroys its ConPTY-owned shells/workers. Separately, `respawnPromise` covered only `doRespawn()`: a request begun before recovery could settle after that promise cleared and make a second supervisor decision.

A post-1.4.182 UNC-cwd fix removed one concrete event-loop wedge trigger, but not either unsafe supervision policy.

## Fix

A non-rejected endpoint is replaceable only when its endpoint is proven dead or its daemon reports zero live sessions. Otherwise the launcher returns a lease-free `held` handle and installs the existing degraded provider. No RPC/stream/wire or orchestration schema changes are made.

Respawns now advance a generation on successful completion. A daemon-gone error that straddled that completion retries the completed generation; it does not fork again.

## Evidence

Baseline latest main `9f3a912c1e`:

- unknown-occupancy unit oracle: red; old handle is killed/replaced instead of held
- controlled request/write race: red; two `Daemon died — respawning` lines and second-respawn rejection
- physical Windows original named-pipe race: red with `ENOENT`

Candidate `7eeb904ce5`:

- focused daemon/IPC: 137 passed, 1 skipped
- full typecheck, oxlint, max-lines ratchet: passed
- e2e-mode Electron build: passed
- headed Windows Electron/CDP isolated-profile oracle: 2/2 passed
  - hold enabled: exact daemon + shell identities survive; no cold-restore banner; same PTY accepts a new write
  - hold disabled: identical setup kills both identities
- existing native reconnect/disposal and counted-session preservation Electron controls: 3/3 passed

The broad daemon directory run reached 1,423 passes and six unrelated existing Windows/environment failures: filesystem `.sock` EACCES tests, host WSL distro assumptions, and async cwd-validation fixture failures.

## Scope and tradeoff

This intentionally does not rebind durable Runs or weaken incarnation fencing. If a permanently wedged empty daemon cannot prove it is empty, Orca stays degraded until recovery or explicit Manage Sessions restart; preserving a possible live agent is favored over automatic replacement.

Closes #14644
Linear: STA-4390