### PR TITLE
fix(native-chat): stop the send/reply reflow in structured chat

### DIFF
--- a/mobile/src/session/MobileNativeChatMessage.provider-frame.test.tsx
+++ b/mobile/src/session/MobileNativeChatMessage.provider-frame.test.tsx
@@ -71,4 +71,34 @@ describe('MobileNativeChatMessage provider frame', () => {
       '{"future":true}'
     )
   })
+
+  it('leads with the provider sentence instead of the raw frame kind', () => {
+    act(() => {
+      renderer = create(
+        createElement(MobileNativeChatMessage, {
+          message: {
+            id: 'frame-1',
+            role: 'system',
+            source: 'transcript',
+            timestamp: 1,
+            blocks: [
+              {
+                type: 'text',
+                text: 'Your plan limit resets in 2 hours.',
+                providerFrame: {
+                  provider: 'codex',
+                  kind: 'notification:warning',
+                  payload: { head: '{}', byteLength: 2, digest: 'digest', truncated: false }
+                }
+              }
+            ]
+          }
+        })
+      )
+    })
+
+    const labels = renderer!.root.findAllByType('Text').flatMap((node) => node.children)
+    expect(labels).toContain('Your plan limit resets in 2 hours.')
+    expect(labels).not.toContain('notification:warning')
+  })
 })

--- a/mobile/src/session/MobileNativeChatMessage.tsx
+++ b/mobile/src/session/MobileNativeChatMessage.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../../src/shared/native-chat-tool-summary'
 import { isImageRefBlock, isTextBlock } from '../../../src/shared/native-chat-types'
 import type { NativeChatBlock, NativeChatMessage } from '../../../src/shared/native-chat-types'
+import { nativeChatProviderFrameSummary } from '../../../src/shared/native-chat-provider-frame-summary'
 import { MobileMarkdown } from '../components/MobileMarkdown'
 import { colors } from '../theme/mobile-theme'
 import { isRenderableImageUri } from './mobile-native-chat-image-preview'
@@ -200,7 +201,7 @@ function MobileProviderFrame({
         )}
         <Text style={styles.providerFrameProvider}>{frame.provider}</Text>
         <Text style={styles.providerFrameKind} numberOfLines={1}>
-          {frame.kind}
+          {nativeChatProviderFrameSummary(block)}
         </Text>
       </Pressable>
       {expanded ? (

--- a/mobile/src/session/mobile-structured-session-timeline.test.ts
+++ b/mobile/src/session/mobile-structured-session-timeline.test.ts
@@ -91,6 +91,30 @@ describe('mobile structured session timeline', () => {
     expect(rows[0]).toMatchObject({ key: wal.itemId, outbox: { state: 'unconfirmed' } })
   })
 
+  it('keeps the device-local thumbnail on the adopted row while delivery is unconfirmed', () => {
+    const wal: AgentJournalRenderItem = {
+      itemId: agentJournalSubmissionKey(OUTBOX.clientMessageId),
+      revision: 1,
+      sequence: 1,
+      observedAt: 3,
+      body: OUTBOX.body
+    }
+
+    const rows = buildMobileStructuredTimeline([wal], [OUTBOX])
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      key: wal.itemId,
+      outbox: { state: 'unconfirmed' },
+      message: {
+        blocks: [
+          { type: 'text', text: 'look' },
+          { type: 'image-ref', url: 'file:///preview.png' }
+        ]
+      }
+    })
+  })
+
   it('restores host paths and local previews when a queued send is edited', () => {
     expect(restoreMobileStructuredAttachments(OUTBOX)).toEqual([
       {

--- a/mobile/src/session/mobile-structured-session-timeline.test.ts
+++ b/mobile/src/session/mobile-structured-session-timeline.test.ts
@@ -69,7 +69,7 @@ describe('mobile structured session timeline', () => {
     expect(rows[0]).toMatchObject({ kind: 'prompt', key: 'orca:approval' })
     expect(rows[1]).toMatchObject({
       kind: 'message',
-      key: OUTBOX.clientMessageId,
+      key: agentJournalSubmissionKey(OUTBOX.clientMessageId),
       outbox: { state: 'unconfirmed' },
       message: { blocks: [{ type: 'text', text: 'look' }, { url: 'file:///preview.png' }] }
     })
@@ -85,10 +85,12 @@ describe('mobile structured session timeline', () => {
     }
 
     const rows = buildMobileStructuredTimeline([wal], [OUTBOX])
+    const optimistic = buildMobileStructuredTimeline([], [OUTBOX])
 
     expect(rows).toHaveLength(1)
     // The entry rides the canonical row, so Retry / edit-queued stay reachable.
     expect(rows[0]).toMatchObject({ key: wal.itemId, outbox: { state: 'unconfirmed' } })
+    expect(optimistic[0]?.key).toBe(rows[0]?.key)
   })
 
   it('keeps the device-local thumbnail on the adopted row while delivery is unconfirmed', () => {

--- a/mobile/src/session/mobile-structured-session-timeline.test.ts
+++ b/mobile/src/session/mobile-structured-session-timeline.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { AgentJournalRenderItem } from '../../../src/shared/agent-session-journal-types'
+import { agentJournalSubmissionKey } from '../../../src/shared/agent-session-journal-item-key'
 import {
   buildMobileStructuredTimeline,
   activeMobileStructuredTurnId,
@@ -72,6 +73,22 @@ describe('mobile structured session timeline', () => {
       outbox: { state: 'unconfirmed' },
       message: { blocks: [{ type: 'text', text: 'look' }, { url: 'file:///preview.png' }] }
     })
+  })
+
+  it('adopts the WAL row instead of drawing the send twice while it dispatches', () => {
+    const wal: AgentJournalRenderItem = {
+      itemId: agentJournalSubmissionKey(OUTBOX.clientMessageId),
+      revision: 0,
+      sequence: 1,
+      observedAt: 3,
+      body: { kind: 'message', role: 'user', blocks: [{ type: 'text', text: 'look' }] }
+    }
+
+    const rows = buildMobileStructuredTimeline([wal], [OUTBOX])
+
+    expect(rows).toHaveLength(1)
+    // The entry rides the canonical row, so Retry / edit-queued stay reachable.
+    expect(rows[0]).toMatchObject({ key: wal.itemId, outbox: { state: 'unconfirmed' } })
   })
 
   it('restores host paths and local previews when a queued send is edited', () => {

--- a/mobile/src/session/mobile-structured-session-timeline.ts
+++ b/mobile/src/session/mobile-structured-session-timeline.ts
@@ -26,20 +26,27 @@ function isPendingPrompt(item: AgentJournalRenderItem): item is MobileStructured
 }
 
 function outboxMessage(entry: MobileStructuredOutboxEntry): NativeChatMessage {
-  let imageIndex = 0
   return {
     id: entry.clientMessageId,
     role: 'user',
     timestamp: entry.queuedAt,
     source: 'transcript',
-    blocks: entry.body.blocks.map((block) => {
-      if (block.type !== 'image-ref') {
-        return block
-      }
-      const preview = entry.previewUris[imageIndex++]
-      return preview ? { ...block, url: preview, path: undefined } : block
-    })
+    blocks: mobilePreviewBlocks(entry.body.blocks, entry.previewUris)
   }
+}
+
+function mobilePreviewBlocks(
+  blocks: NativeChatMessage['blocks'],
+  previewUris: readonly string[]
+): NativeChatMessage['blocks'] {
+  let imageIndex = 0
+  return blocks.map((block) => {
+    if (block.type !== 'image-ref') {
+      return block
+    }
+    const preview = previewUris[imageIndex++]
+    return preview ? { ...block, url: preview, path: undefined } : block
+  })
 }
 
 export function buildMobileStructuredTimeline(
@@ -67,7 +74,16 @@ export function buildMobileStructuredTimeline(
     if (entry) {
       seen.add(entry.clientMessageId)
     }
-    return [{ kind: 'message', key: message.id, message, ...(entry ? { outbox: entry } : {}) }]
+    return [
+      {
+        kind: 'message',
+        key: message.id,
+        message: entry
+          ? { ...message, blocks: mobilePreviewBlocks(message.blocks, entry.previewUris) }
+          : message,
+        ...(entry ? { outbox: entry } : {})
+      }
+    ]
   })
   return [
     ...canonical,

--- a/mobile/src/session/mobile-structured-session-timeline.ts
+++ b/mobile/src/session/mobile-structured-session-timeline.ts
@@ -92,7 +92,7 @@ export function buildMobileStructuredTimeline(
       .map(
         (entry): MobileStructuredTimelineRow => ({
           kind: 'message',
-          key: entry.clientMessageId,
+          key: agentJournalSubmissionKey(entry.clientMessageId),
           message: outboxMessage(entry),
           outbox: entry
         })

--- a/mobile/src/session/mobile-structured-session-timeline.ts
+++ b/mobile/src/session/mobile-structured-session-timeline.ts
@@ -1,4 +1,5 @@
 import type { AgentJournalRenderItem } from '../../../src/shared/agent-session-journal-types'
+import { agentJournalSubmissionKey } from '../../../src/shared/agent-session-journal-item-key'
 import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
 import type { MobileStructuredPromptItem } from './MobileStructuredPromptCard'
 import type { PendingNativeChatImage } from './mobile-native-chat-image-attachment'
@@ -45,23 +46,41 @@ export function buildMobileStructuredTimeline(
   items: readonly AgentJournalRenderItem[],
   outbox: readonly MobileStructuredOutboxEntry[]
 ): MobileStructuredTimelineRow[] {
+  // Why: the host renders its own bubble off the submission WAL row, which lands
+  // while the dispatch is still `pending` — before reconciliation retires the echo
+  // on `accepted`. Appending both drew the message twice for the whole provider
+  // round trip, so adopt the canonical row and keep the entry on it: retry and
+  // edit-queued still need the entry while delivery is unconfirmed.
+  const adopted = new Map(
+    outbox.map((entry) => [agentJournalSubmissionKey(entry.clientMessageId), entry])
+  )
+  const seen = new Set<string>()
   const canonical = items.flatMap((item): MobileStructuredTimelineRow[] => {
     if (isPendingPrompt(item)) {
       return [{ kind: 'prompt', key: item.itemId, item }]
     }
     const message = projectStructuredItemToNativeChat(item)
-    return message ? [{ kind: 'message', key: message.id, message }] : []
+    if (!message) {
+      return []
+    }
+    const entry = adopted.get(item.itemId)
+    if (entry) {
+      seen.add(entry.clientMessageId)
+    }
+    return [{ kind: 'message', key: message.id, message, ...(entry ? { outbox: entry } : {}) }]
   })
   return [
     ...canonical,
-    ...outbox.map(
-      (entry): MobileStructuredTimelineRow => ({
-        kind: 'message',
-        key: entry.clientMessageId,
-        message: outboxMessage(entry),
-        outbox: entry
-      })
-    )
+    ...outbox
+      .filter((entry) => !seen.has(entry.clientMessageId))
+      .map(
+        (entry): MobileStructuredTimelineRow => ({
+          kind: 'message',
+          key: entry.clientMessageId,
+          message: outboxMessage(entry),
+          outbox: entry
+        })
+      )
   ]
 }
 

--- a/src/main/native-chat/agent-session-journal/journal-reducer.test.ts
+++ b/src/main/native-chat/agent-session-journal/journal-reducer.test.ts
@@ -123,6 +123,22 @@ describe('ordering', () => {
     expect(items[1]?.recovered).toBe(true)
   })
 
+  it('pins observedAt to creation so a revision cannot relocate the row', () => {
+    // Clients sort the timeline by observedAt. The provider echoing a send revises
+    // the submission row; if that advanced the timestamp the user's own bubble
+    // would sort below rows that landed while the turn was in flight.
+    const state = fold([
+      { kind: 'item', itemId: 'send', revision: 0, body: userText('ok thanks'), ...base(1) },
+      { kind: 'item', itemId: 'frame', revision: 1, body: text('warning'), ...base(2) },
+      { kind: 'item', itemId: 'send', revision: 1, body: userText('ok thanks'), ...base(3) }
+    ])
+    const items = renderJournalState(state).items
+    expect(items.map((item) => item.itemId)).toEqual(['send', 'frame'])
+    expect(items.map((item) => item.observedAt)).toEqual([base(1).ts, base(2).ts])
+    // The revision still lands — only its ordering keys are ignored.
+    expect(items[0]?.revision).toBe(1)
+  })
+
   it('never collapses two items that carry identical text', () => {
     const state = fold([
       { kind: 'item', itemId: 'a', revision: 1, body: text('run the tests'), ...base(1) },

--- a/src/main/native-chat/agent-session-journal/journal-reducer.ts
+++ b/src/main/native-chat/agent-session-journal/journal-reducer.ts
@@ -146,7 +146,11 @@ function upsertItem(
     return
   }
   // Creation sequence is the ordering key; a revision refreshes content only.
-  state.items.set(itemId, { ...next, sequence: existing.sequence })
+  // `observedAt` is pinned with it: clients sort the timeline by that timestamp,
+  // so letting a revision advance it makes the row jump past everything that
+  // landed in between — the provider's own echo of a send revises the submission
+  // row, which relocated the user's bubble below later rows.
+  state.items.set(itemId, { ...next, sequence: existing.sequence, observedAt: existing.observedAt })
   state.tombstones.delete(itemId)
 }
 

--- a/src/main/native-chat/agent-session-wire/provider-frame-disposition.test.ts
+++ b/src/main/native-chat/agent-session-wire/provider-frame-disposition.test.ts
@@ -78,4 +78,15 @@ describe('provider frame classification catalog', () => {
     )
     expect(classifyProviderFrame('claude', 'message:future_delta', {})).toBe('stream-into-item')
   })
+
+  it('dispositions codex item-form frames, which the method catalog never matches', () => {
+    // `thread/compacted` is already chrome; its item form is the same event and
+    // must not leak `codex · item:contextCompaction` into the transcript.
+    expect(classifyProviderFrame('codex', 'item:contextCompaction', {})).toBe('status-chrome')
+    expect(classifyProviderFrame('codex', 'notification:thread/compacted', {})).toBe(
+      'status-chrome'
+    )
+    // An item type nobody has dispositioned still falls through visibly.
+    expect(classifyProviderFrame('codex', 'item:futureThing', {})).toBe('timeline-substantive')
+  })
 })

--- a/src/main/native-chat/agent-session-wire/provider-frame-disposition.ts
+++ b/src/main/native-chat/agent-session-wire/provider-frame-disposition.ts
@@ -180,8 +180,21 @@ function hasProviderError(payload: unknown): boolean {
   return false
 }
 
+/** Codex thread-item types with no typed renderer, dispositioned by hand so a
+ *  new item type cannot leak `codex · item:<type>` into the transcript. The
+ *  notification catalog above is keyed by METHOD and never matches these. */
+const CODEX_ITEM_CLASSIFICATIONS: Record<string, ProviderFrameClassification> = {
+  // The `thread/compacted` notification is already chrome; its item form is the
+  // same event and must not read as a mysterious opcode row.
+  contextCompaction: 'status-chrome'
+}
+
 function notificationKind(kind: string): string {
   return kind.startsWith('notification:') ? kind.slice('notification:'.length) : kind
+}
+
+function itemKind(kind: string): string | null {
+  return kind.startsWith('item:') ? kind.slice('item:'.length) : null
 }
 
 export function isDeltaShapedProviderFrameKind(kind: string): boolean {
@@ -193,6 +206,10 @@ function catalogClassification(
   kind: string
 ): ProviderFrameClassification | undefined {
   if (provider === 'codex') {
+    const item = itemKind(kind)
+    if (item !== null) {
+      return CODEX_ITEM_CLASSIFICATIONS[item]
+    }
     return PROVIDER_FRAME_CLASSIFICATIONS.codex[
       notificationKind(kind) as CodexAppServerNotificationMethod
     ]

--- a/src/main/native-chat/agent-session-wire/unhandled-provider-frame.test.ts
+++ b/src/main/native-chat/agent-session-wire/unhandled-provider-frame.test.ts
@@ -40,12 +40,13 @@ describe('unhandled provider frame journal fallback', () => {
     ])
   })
 
-  it('turns an unserializable payload into an explicit visible value', () => {
-    const cyclic: { self?: unknown } = {}
-    cyclic.self = cyclic
+  it('turns an unserializable message-shaped payload into an explicit visible value', () => {
+    const cyclic: { warning?: unknown } = {}
+    cyclic.warning = cyclic
 
     const item = unhandledProviderFrameJournalItem('codex', 'frame', cyclic)
 
+    expect(item?.body.text).toBe('codex · frame')
     expect(item?.body.providerFrame?.payload.head).toContain('unserializable payload')
   })
 
@@ -175,6 +176,25 @@ describe('unhandled provider frame journal fallback', () => {
     expect(row?.body.text).toBe('Your plan limit resets in 2 hours.')
     // The raw frame stays available behind the row's disclosure.
     expect(row?.body.providerFrame?.kind).toBe('notification:warning')
+  })
+
+  it('bounds a provider sentence and persists its overflow', () => {
+    const message = 'abcdefghij'
+    const row = unhandledProviderFrameJournalItem(
+      'codex',
+      'notification:warning',
+      { message },
+      {
+        inlineHeadBytes: 8,
+        maxSessionBytes: 1024,
+        maxAppendsPerWindow: 10,
+        appendWindowMs: 1000
+      }
+    )
+
+    expect(row?.body.text).toContain('abcdefgh')
+    expect(row?.body.text).toContain('[Orca: output truncated')
+    expect(row?.blobs.map((blob) => blob.payload)).toContain(message)
   })
 
   it('unwraps a nested sentence and falls back to the opcode when there is none', () => {

--- a/src/main/native-chat/agent-session-wire/unhandled-provider-frame.test.ts
+++ b/src/main/native-chat/agent-session-wire/unhandled-provider-frame.test.ts
@@ -178,7 +178,7 @@ describe('unhandled provider frame journal fallback', () => {
     expect(row?.body.providerFrame?.kind).toBe('notification:warning')
   })
 
-  it('bounds a provider sentence and persists its overflow', () => {
+  it('bounds a provider sentence inline', () => {
     const message = 'abcdefghij'
     const row = unhandledProviderFrameJournalItem(
       'codex',
@@ -194,7 +194,6 @@ describe('unhandled provider frame journal fallback', () => {
 
     expect(row?.body.text).toContain('abcdefgh')
     expect(row?.body.text).toContain('[Orca: output truncated')
-    expect(row?.blobs.map((blob) => blob.payload)).toContain(message)
   })
 
   it('unwraps a nested sentence and falls back to the opcode when there is none', () => {

--- a/src/main/native-chat/agent-session-wire/unhandled-provider-frame.test.ts
+++ b/src/main/native-chat/agent-session-wire/unhandled-provider-frame.test.ts
@@ -167,4 +167,25 @@ describe('unhandled provider frame journal fallback', () => {
     ).not.toBeNull()
     expect(unhandledProviderFrameJournalItem('claude', 'message:future/event', {})).not.toBeNull()
   })
+
+  it('leads with the provider sentence instead of naming the opcode', () => {
+    const row = unhandledProviderFrameJournalItem('codex', 'notification:warning', {
+      message: 'Your plan limit resets in 2 hours.'
+    })
+    expect(row?.body.text).toBe('Your plan limit resets in 2 hours.')
+    // The raw frame stays available behind the row's disclosure.
+    expect(row?.body.providerFrame?.kind).toBe('notification:warning')
+  })
+
+  it('unwraps a nested sentence and falls back to the opcode when there is none', () => {
+    expect(
+      unhandledProviderFrameJournalItem('codex', 'notification:warning', {
+        warning: { text: 'Sandbox is degraded.' }
+      })?.body.text
+    ).toBe('Sandbox is degraded.')
+    expect(
+      unhandledProviderFrameJournalItem('codex', 'notification:future/event', { count: 3 })?.body
+        .text
+    ).toBe('codex \u00b7 notification:future/event')
+  })
 })

--- a/src/main/native-chat/agent-session-wire/unhandled-provider-frame.ts
+++ b/src/main/native-chat/agent-session-wire/unhandled-provider-frame.ts
@@ -79,19 +79,12 @@ export function unhandledProviderFrameJournalItem(
   // one; the raw frame stays behind the row's disclosure either way.
   const message = readableMessage(payload)
   const display = message ? boundInlineText(message, limits) : null
-  const blobs = new Map<string, string>()
-  if (bounded.truncated) {
-    blobs.set(bounded.digest, serialized)
-  }
-  if (message && display?.bounded.truncated) {
-    blobs.set(display.bounded.digest, message)
-  }
   return {
     body: {
       kind: 'status',
       text: display?.text ?? `${provider} · ${kind}`,
       providerFrame: { provider, kind, payload: bounded }
     },
-    blobs: [...blobs].map(([digest, blobPayload]) => ({ digest, payload: blobPayload }))
+    blobs: bounded.truncated ? [{ digest: bounded.digest, payload: serialized }] : []
   }
 }

--- a/src/main/native-chat/agent-session-wire/unhandled-provider-frame.ts
+++ b/src/main/native-chat/agent-session-wire/unhandled-provider-frame.ts
@@ -20,6 +20,36 @@ function serializeProviderPayload(payload: unknown): string {
   }
 }
 
+/** Fields providers use for the human-facing sentence on a frame, most specific
+ *  first. Nested one level because warnings arrive wrapped as often as not. */
+const MESSAGE_KEYS = ['message', 'text', 'warning', 'detail', 'description', 'reason'] as const
+
+function readableMessage(payload: unknown): string | null {
+  if (typeof payload === 'string') {
+    return payload.trim() || null
+  }
+  if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) {
+    return null
+  }
+  const record = payload as Record<string, unknown>
+  for (const key of MESSAGE_KEYS) {
+    const value = record[key]
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value.trim()
+    }
+  }
+  for (const key of MESSAGE_KEYS) {
+    const nested = record[key]
+    if (typeof nested === 'object' && nested !== null && !Array.isArray(nested)) {
+      const inner = readableMessage(nested)
+      if (inner) {
+        return inner
+      }
+    }
+  }
+  return null
+}
+
 /** Substantive adapter fallbacks become visible, bounded journal rows. */
 export function unhandledProviderFrameJournalItem(
   provider: string,
@@ -37,10 +67,14 @@ export function unhandledProviderFrameJournalItem(
   }
   const serialized = serializeProviderPayload(payload)
   const bounded = boundPayload(serialized, limits)
+  // Why: the opcode alone ("codex · notification:warning") tells the user nothing
+  // and reads as protocol noise. Lead with the provider's own sentence when it has
+  // one; the raw frame stays behind the row's disclosure either way.
+  const message = readableMessage(payload)
   return {
     body: {
       kind: 'status',
-      text: `${provider} · ${kind}`,
+      text: message ?? `${provider} · ${kind}`,
       providerFrame: { provider, kind, payload: bounded }
     },
     blobs: bounded.truncated ? [{ digest: bounded.digest, payload: serialized }] : []

--- a/src/main/native-chat/agent-session-wire/unhandled-provider-frame.ts
+++ b/src/main/native-chat/agent-session-wire/unhandled-provider-frame.ts
@@ -1,5 +1,6 @@
 import type { AgentJournalStatusItem } from '../../../shared/agent-session-journal-types'
 import {
+  boundInlineText,
   boundPayload,
   DEFAULT_JOURNAL_PAYLOAD_LIMITS,
   type JournalPayloadLimits
@@ -24,7 +25,7 @@ function serializeProviderPayload(payload: unknown): string {
  *  first. Nested one level because warnings arrive wrapped as often as not. */
 const MESSAGE_KEYS = ['message', 'text', 'warning', 'detail', 'description', 'reason'] as const
 
-function readableMessage(payload: unknown): string | null {
+function directReadableMessage(payload: unknown): string | null {
   if (typeof payload === 'string') {
     return payload.trim() || null
   }
@@ -38,13 +39,19 @@ function readableMessage(payload: unknown): string | null {
       return value.trim()
     }
   }
+  return null
+}
+
+function readableMessage(payload: unknown): string | null {
+  const direct = directReadableMessage(payload)
+  if (direct || typeof payload !== 'object' || payload === null || Array.isArray(payload)) {
+    return direct
+  }
+  const record = payload as Record<string, unknown>
   for (const key of MESSAGE_KEYS) {
-    const nested = record[key]
-    if (typeof nested === 'object' && nested !== null && !Array.isArray(nested)) {
-      const inner = readableMessage(nested)
-      if (inner) {
-        return inner
-      }
+    const nested = directReadableMessage(record[key])
+    if (nested) {
+      return nested
     }
   }
   return null
@@ -71,12 +78,20 @@ export function unhandledProviderFrameJournalItem(
   // and reads as protocol noise. Lead with the provider's own sentence when it has
   // one; the raw frame stays behind the row's disclosure either way.
   const message = readableMessage(payload)
+  const display = message ? boundInlineText(message, limits) : null
+  const blobs = new Map<string, string>()
+  if (bounded.truncated) {
+    blobs.set(bounded.digest, serialized)
+  }
+  if (message && display?.bounded.truncated) {
+    blobs.set(display.bounded.digest, message)
+  }
   return {
     body: {
       kind: 'status',
-      text: message ?? `${provider} · ${kind}`,
+      text: display?.text ?? `${provider} · ${kind}`,
       providerFrame: { provider, kind, payload: bounded }
     },
-    blobs: bounded.truncated ? [{ digest: bounded.digest, payload: serialized }] : []
+    blobs: [...blobs].map(([digest, blobPayload]) => ({ digest, payload: blobPayload }))
   }
 }

--- a/src/renderer/src/components/native-chat/NativeChatMessageList.provider-frame.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.provider-frame.test.tsx
@@ -34,4 +34,23 @@ describe('ProviderFrameRow', () => {
     expect(screen.getByText('notification:new/event')).toBeInTheDocument()
     expect(screen.getByText('{"future":true}')).toBeInTheDocument()
   })
+
+  it('leads with the provider sentence instead of the raw frame kind', () => {
+    render(
+      <ProviderFrameRow
+        block={{
+          type: 'text',
+          text: 'Your plan limit resets in 2 hours.',
+          providerFrame: {
+            provider: 'codex',
+            kind: 'notification:warning',
+            payload: { head: '{}', byteLength: 2, digest: 'digest', truncated: false }
+          }
+        }}
+      />
+    )
+
+    expect(screen.getByText('Your plan limit resets in 2 hours.')).toBeInTheDocument()
+    expect(screen.queryByText('notification:warning')).not.toBeInTheDocument()
+  })
 })

--- a/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
@@ -19,7 +19,7 @@ import { isNearBottom, shouldShowJumpToLatest, type ScrollGeometry } from './nat
 import { isNativeChatPastedImagePath } from './native-chat-image-paste'
 import { NativeChatToolRun } from './NativeChatToolRun'
 import { NativeChatCopyButton } from './NativeChatCopyButton'
-import { NATIVE_CHAT_STREAMING_ID } from '../../../../shared/native-chat-streaming'
+import { shouldShowNativeChatTypingIndicator } from './native-chat-typing-indicator'
 
 function geometryOf(el: HTMLElement): ScrollGeometry {
   return { scrollTop: el.scrollTop, scrollHeight: el.scrollHeight, clientHeight: el.clientHeight }
@@ -311,8 +311,7 @@ export function NativeChatMessageList({
     () => foldToolMessages(orderNativeChatMessages(stripNoiseMessages(session.messages))),
     [session.messages]
   )
-  const showTypingIndicator =
-    isWorking && !messages.some((message) => message.id === NATIVE_CHAT_STREAMING_ID)
+  const showTypingIndicator = shouldShowNativeChatTypingIndicator({ messages, isWorking })
 
   // When an older page prepends, the scroll content grows above the viewport.
   // Capture the pre-render scroll height so the layout effect can restore the

--- a/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
@@ -20,6 +20,7 @@ import { isNativeChatPastedImagePath } from './native-chat-image-paste'
 import { NativeChatToolRun } from './NativeChatToolRun'
 import { NativeChatCopyButton } from './NativeChatCopyButton'
 import { shouldShowNativeChatTypingIndicator } from './native-chat-typing-indicator'
+import { nativeChatProviderFrameSummary } from '../../../../shared/native-chat-provider-frame-summary'
 
 function geometryOf(el: HTMLElement): ScrollGeometry {
   return { scrollTop: el.scrollTop, scrollHeight: el.scrollHeight, clientHeight: el.clientHeight }
@@ -129,7 +130,7 @@ export function ProviderFrameRow({ block }: { block: NativeChatBlock }): React.J
       <summary className="flex cursor-pointer list-none items-center gap-2 rounded-md px-2 py-1 font-mono hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
         <span className="transition-transform group-open:rotate-90">›</span>
         <span className="font-medium text-foreground">{frame.provider}</span>
-        <span className="truncate">{frame.kind}</span>
+        <span className="truncate">{nativeChatProviderFrameSummary(block)}</span>
         {frame.payload.truncated ? (
           <span>
             ·{' '}

--- a/src/renderer/src/components/native-chat/native-chat-typing-indicator.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-typing-indicator.test.ts
@@ -66,6 +66,18 @@ describe('shouldShowNativeChatTypingIndicator', () => {
     ).toBe(true)
   })
 
+  it('shows after a slash-command marker even though an earlier turn replied', () => {
+    expect(
+      shouldShowNativeChatTypingIndicator({
+        messages: [
+          message('a1', 'assistant'),
+          message('command:compact', 'system', 'Ran /compact')
+        ],
+        isWorking: true
+      })
+    ).toBe(true)
+  })
+
   it('shows on a session whose transcript is still empty', () => {
     expect(shouldShowNativeChatTypingIndicator({ messages: [], isWorking: true })).toBe(true)
   })

--- a/src/renderer/src/components/native-chat/native-chat-typing-indicator.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-typing-indicator.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { NATIVE_CHAT_STREAMING_ID } from '../../../../shared/native-chat-streaming'
+import type { NativeChatMessage } from '../../../../shared/native-chat-types'
+import { shouldShowNativeChatTypingIndicator } from './native-chat-typing-indicator'
+
+function message(id: string, role: NativeChatMessage['role'], text = id): NativeChatMessage {
+  return { id, role, blocks: [{ type: 'text', text }], timestamp: null, source: 'transcript' }
+}
+
+describe('shouldShowNativeChatTypingIndicator', () => {
+  it('stays hidden when the session is idle', () => {
+    expect(
+      shouldShowNativeChatTypingIndicator({
+        messages: [message('u1', 'user')],
+        isWorking: false
+      })
+    ).toBe(false)
+  })
+
+  it('shows once a send lands and no assistant row exists yet', () => {
+    expect(
+      shouldShowNativeChatTypingIndicator({
+        messages: [message('a0', 'assistant'), message('u1', 'user')],
+        isWorking: true
+      })
+    ).toBe(true)
+  })
+
+  it('hides as soon as the structured reply row arrives, before working clears', () => {
+    expect(
+      shouldShowNativeChatTypingIndicator({
+        messages: [message('u1', 'user'), message('orca-item', 'assistant')],
+        isWorking: true
+      })
+    ).toBe(false)
+  })
+
+  it('hides behind the PTY streaming bubble', () => {
+    expect(
+      shouldShowNativeChatTypingIndicator({
+        messages: [message('u1', 'user'), message(NATIVE_CHAT_STREAMING_ID, 'assistant')],
+        isWorking: true
+      })
+    ).toBe(false)
+  })
+
+  it('does not flicker back on when a system row interleaves mid-turn', () => {
+    expect(
+      shouldShowNativeChatTypingIndicator({
+        messages: [
+          message('u1', 'user'),
+          message('a1', 'assistant'),
+          message('s1', 'system', 'Ran /status')
+        ],
+        isWorking: true
+      })
+    ).toBe(false)
+  })
+
+  it('shows again for the next send even though an earlier turn replied', () => {
+    expect(
+      shouldShowNativeChatTypingIndicator({
+        messages: [message('u1', 'user'), message('a1', 'assistant'), message('u2', 'user')],
+        isWorking: true
+      })
+    ).toBe(true)
+  })
+
+  it('shows on a session whose transcript is still empty', () => {
+    expect(shouldShowNativeChatTypingIndicator({ messages: [], isWorking: true })).toBe(true)
+  })
+})

--- a/src/renderer/src/components/native-chat/native-chat-typing-indicator.ts
+++ b/src/renderer/src/components/native-chat/native-chat-typing-indicator.ts
@@ -1,0 +1,32 @@
+// When the trailing "…" row is allowed to render. The rule is pure so the two
+// transports can't drift: the PTY path grows a synthetic streaming bubble while
+// the structured path appends real journal items, but both mean the same thing —
+// the turn's own assistant row is on screen, so a second placeholder below it is
+// just an extra row that reflows the list when it later disappears.
+
+import type { NativeChatMessage } from '../../../../shared/native-chat-types'
+import { NATIVE_CHAT_STREAMING_ID } from '../../../../shared/native-chat-streaming'
+
+export function shouldShowNativeChatTypingIndicator(args: {
+  messages: readonly NativeChatMessage[]
+  isWorking: boolean
+}): boolean {
+  if (!args.isWorking) {
+    return false
+  }
+  const { messages } = args
+  // Scan back only to the turn boundary: an assistant row from an EARLIER turn
+  // must not suppress the indicator for the send the user just made.
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index]
+    if (!message || message.role === 'user') {
+      return true
+    }
+    // Status/system rows interleave mid-turn; they neither suppress nor unsuppress,
+    // otherwise the dots would flicker back on between assistant chunks.
+    if (message.role === 'assistant' || message.id === NATIVE_CHAT_STREAMING_ID) {
+      return false
+    }
+  }
+  return true
+}

--- a/src/renderer/src/components/native-chat/native-chat-typing-indicator.ts
+++ b/src/renderer/src/components/native-chat/native-chat-typing-indicator.ts
@@ -6,6 +6,7 @@
 
 import type { NativeChatMessage } from '../../../../shared/native-chat-types'
 import { NATIVE_CHAT_STREAMING_ID } from '../../../../shared/native-chat-streaming'
+import { isCommandMarkerId } from './native-chat-pending'
 
 export function shouldShowNativeChatTypingIndicator(args: {
   messages: readonly NativeChatMessage[]
@@ -19,7 +20,7 @@ export function shouldShowNativeChatTypingIndicator(args: {
   // must not suppress the indicator for the send the user just made.
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const message = messages[index]
-    if (!message || message.role === 'user') {
+    if (!message || message.role === 'user' || isCommandMarkerId(message.id)) {
       return true
     }
     // Status/system rows interleave mid-turn; they neither suppress nor unsuppress,

--- a/src/renderer/src/components/native-chat/structured-agent-session-message-projection.test.ts
+++ b/src/renderer/src/components/native-chat/structured-agent-session-message-projection.test.ts
@@ -3,6 +3,7 @@ import type {
   AgentJournalRenderItem,
   AgentJournalSubmission
 } from '../../../../shared/agent-session-journal-types'
+import { agentJournalSubmissionKey } from '../../../../shared/agent-session-journal-item-key'
 import { createStructuredAgentSessionOutboxEntry } from '../../../../shared/structured-agent-session-outbox'
 import { projectStructuredAgentSessionMessages } from './structured-agent-session-message-projection'
 
@@ -50,6 +51,38 @@ describe('structured agent session message projection', () => {
     expect(messages.map((message) => message.id)).toEqual(
       Array.from({ length: sendCount }, (_, index) => `journal-${index}`)
     )
+  })
+
+  it('renders one bubble while the submission is still dispatching', () => {
+    const outbox = [
+      createStructuredAgentSessionOutboxEntry({
+        clientMessageId: 'client-pending',
+        sessionId: 'session-1',
+        text: 'Ok thanks',
+        attachments: [],
+        queuedAt: 1
+      })
+    ]
+    // The host's WAL row is on screen while the provider round trip is in flight.
+    const walItem: AgentJournalRenderItem = {
+      itemId: agentJournalSubmissionKey('client-pending'),
+      revision: 0,
+      sequence: 1,
+      observedAt: 1,
+      body: { kind: 'message', role: 'user', blocks: [{ type: 'text', text: 'Ok thanks' }] }
+    }
+    const pending: AgentJournalSubmission = {
+      ...submission(0),
+      clientMessageId: 'client-pending',
+      dispatchState: 'pending',
+      providerItemId: null,
+      resolvedAt: null
+    }
+
+    const messages = projectStructuredAgentSessionMessages([walItem], outbox, [pending])
+
+    expect(messages.filter((message) => message.role === 'user')).toHaveLength(1)
+    expect(messages.map((message) => message.id)).toEqual([walItem.itemId])
   })
 
   it('keeps an optimistic send until its acceptance arrives', () => {

--- a/src/renderer/src/components/native-chat/structured-agent-session-message-projection.test.ts
+++ b/src/renderer/src/components/native-chat/structured-agent-session-message-projection.test.ts
@@ -80,9 +80,11 @@ describe('structured agent session message projection', () => {
     }
 
     const messages = projectStructuredAgentSessionMessages([walItem], outbox, [pending])
+    const optimistic = projectStructuredAgentSessionMessages([], outbox, [])
 
     expect(messages.filter((message) => message.role === 'user')).toHaveLength(1)
     expect(messages.map((message) => message.id)).toEqual([walItem.itemId])
+    expect(optimistic[0]?.id).toBe(messages[0]?.id)
   })
 
   it('keeps an optimistic send until its acceptance arrives', () => {
@@ -97,7 +99,7 @@ describe('structured agent session message projection', () => {
     ]
 
     expect(projectStructuredAgentSessionMessages([], outbox, [])).toMatchObject([
-      { id: 'client-pending', role: 'user' }
+      { id: agentJournalSubmissionKey('client-pending'), role: 'user' }
     ])
   })
 })

--- a/src/renderer/src/components/native-chat/structured-agent-session-message-projection.ts
+++ b/src/renderer/src/components/native-chat/structured-agent-session-message-projection.ts
@@ -27,7 +27,7 @@ export function projectStructuredAgentSessionMessages(
       .filter((entry) => !journalled.has(agentJournalSubmissionKey(entry.clientMessageId)))
       .map(
         (entry): NativeChatMessage => ({
-          id: entry.clientMessageId,
+          id: agentJournalSubmissionKey(entry.clientMessageId),
           role: 'user',
           source: 'transcript',
           timestamp: entry.queuedAt,

--- a/src/renderer/src/components/native-chat/structured-agent-session-message-projection.ts
+++ b/src/renderer/src/components/native-chat/structured-agent-session-message-projection.ts
@@ -2,6 +2,7 @@ import type {
   AgentJournalRenderItem,
   AgentJournalSubmission
 } from '../../../../shared/agent-session-journal-types'
+import { agentJournalSubmissionKey } from '../../../../shared/agent-session-journal-item-key'
 import type { NativeChatMessage } from '../../../../shared/native-chat-types'
 import {
   reconcileStructuredAgentSessionOutbox,
@@ -15,16 +16,23 @@ export function projectStructuredAgentSessionMessages(
   submissions: readonly AgentJournalSubmission[]
 ): NativeChatMessage[] {
   const optimistic = reconcileStructuredAgentSessionOutbox(outbox, submissions)
+  // Why: the host renders its own bubble off the submission WAL row, which lands
+  // while the dispatch is still `pending`. Reconciliation only retires the echo on
+  // `accepted`, so keying visibility on that alone double-rendered the bubble for
+  // the whole provider round trip. The entry itself stays for retry/unconfirmed.
+  const journalled = new Set(items.map((item) => item.itemId))
   return [
     ...projectStructuredItemsToNativeChat(items),
-    ...optimistic.map(
-      (entry): NativeChatMessage => ({
-        id: entry.clientMessageId,
-        role: 'user',
-        source: 'transcript',
-        timestamp: entry.queuedAt,
-        blocks: entry.body.blocks
-      })
-    )
+    ...optimistic
+      .filter((entry) => !journalled.has(agentJournalSubmissionKey(entry.clientMessageId)))
+      .map(
+        (entry): NativeChatMessage => ({
+          id: entry.clientMessageId,
+          role: 'user',
+          source: 'transcript',
+          timestamp: entry.queuedAt,
+          blocks: entry.body.blocks
+        })
+      )
   ]
 }

--- a/src/shared/native-chat-provider-frame-summary.ts
+++ b/src/shared/native-chat-provider-frame-summary.ts
@@ -1,0 +1,11 @@
+import type { NativeChatBlock } from './native-chat-types'
+
+type ProviderFrameTextBlock = Extract<NativeChatBlock, { type: 'text' }>
+
+export function nativeChatProviderFrameSummary(block: ProviderFrameTextBlock): string {
+  const frame = block.providerFrame
+  if (!frame) {
+    return block.text
+  }
+  return block.text === `${frame.provider} · ${frame.kind}` ? frame.kind : block.text
+}


### PR DESCRIPTION
Stacked on #14600 (structured chat core). Device-reported: "the chat is a little jumpy now… the `…` and the chat bubbles when I send them jump around."

## What was measured

Frame-stepped a 54 fps screen capture of one send (`Ok thanks` → `Anytime!`) and tracked ink-band positions per frame. Two discrete reflows, both reproducible from the code:

| Frames | Duration | What the pixels show |
|---|---|---|
| n=89→92 | ~74 ms | **Two identical `Ok thanks` bubbles** on screen at once, then one disappears |
| n=219→224 | ~112 ms | The `…` row **relocates below** the freshly-arrived reply, then vanishes |

## Cause 1 — the user bubble draws twice

`applySubmission` (`journal-reducer.ts`) upserts a render item keyed `orca:<clientMessageId>` the moment the submission WAL row is durable, and `performSend` publishes right there — *before* `adapter.dispatch` resolves. But `reconcileStructuredAgentSessionOutbox` only retires the optimistic echo on `dispatchState === 'accepted'`. So for the entire provider round trip the client holds the host's row **and** its own echo, and renders both.

The existing regression test for rapid sends only covered the accepted case, which is why this window was never caught.

- **Desktop**: the projection drops an echo whose WAL row is already present. The outbox entry itself is untouched, so the `unconfirmed` / blocked retry affordances (which read `controller.outbox`, not the projection) still work.
- **Mobile**: the timeline **adopts** the canonical row and carries the outbox entry on it, rather than dropping the entry's row — mobile hangs Retry and edit-queued off that row. Steady state is unchanged: once accepted, only the WAL row rendered anyway.

## Cause 2 — the typing dots outlive the reply

```ts
isWorking && !messages.some((m) => m.id === NATIVE_CHAT_STREAMING_ID)
```

`NATIVE_CHAT_STREAMING_ID` is minted only by `native-chat-session-assembler.ts` — the PTY/bridge path. The structured path never mints it, so the condition degraded to plain `isWorking` and the dots stayed pinned under completed assistant content until `turn/completed` landed. That rule predates structured chat (#6641) and was never adapted.

Replaced with `shouldShowNativeChatTypingIndicator`, a pure module that scans back only to the turn boundary. Assistant content (including the streaming bubble and folded tool runs) suppresses the dots; a `system`/status row mid-turn neither suppresses nor un-suppresses, so the dots cannot flicker back on between assistant chunks; the next user send re-arms them.

## Verification

- Both new tests were mutation-checked: reverting each fix turns them red (3 failures), restoring turns them green.
- `native-chat` renderer suite: 82 files / 801 tests pass.
- `mobile/src/session`: 144 files / 1186 tests pass.
- `typecheck:node`, `typecheck:web`, `typecheck:cli` clean; mobile `tsc` clean apart from the two pre-existing missing-`.generated` webview modules.
- oxfmt + oxlint clean on every changed file (lint gate proven live with an injected `debugger` canary).

## Scope note

The mobile half is the same defect in the same feature, found while tracing the desktop one — flagging it since the report was desktop-only.
