### PR TITLE
fix(daemon): bound cwd validation and attach-only requests on a dead share

### DIFF
--- a/src/main/daemon/client.ts
+++ b/src/main/daemon/client.ts
@@ -214,6 +214,7 @@ export class DaemonClient {
       payload,
       timeoutMs,
       ...(signal ? { signal } : {}),
+      unmatchedCancelGraceMs: NOTIFY_SETTLEMENT_TIMEOUT_MS,
       onCreateCancellationFailure: () => this.handleDisconnect(generation),
       settleCreateCancellation: (sessionId, requestId) =>
         this.request<{ canceled: boolean }>(

--- a/src/main/daemon/daemon-client-rpc-request.test.ts
+++ b/src/main/daemon/daemon-client-rpc-request.test.ts
@@ -23,6 +23,7 @@ describe('requestDaemonRpc', () => {
       payload: { sessionId: 'completed-spawn' },
       timeoutMs: 30_000,
       signal: abort.signal,
+      unmatchedCancelGraceMs: 5_000,
       onCreateCancellationFailure: vi.fn(),
       settleCreateCancellation: () => cancellation
     })
@@ -45,6 +46,7 @@ describe('requestDaemonRpc', () => {
       type: 'createOrAttach',
       payload: { sessionId: 'completed-spawn' },
       timeoutMs: 10,
+      unmatchedCancelGraceMs: 5_000,
       onCreateCancellationFailure: vi.fn(),
       settleCreateCancellation
     })
@@ -66,12 +68,39 @@ describe('requestDaemonRpc', () => {
       type: 'createOrAttach',
       payload: { sessionId: 'pending-spawn' },
       timeoutMs: 10,
+      unmatchedCancelGraceMs: 5_000,
       onCreateCancellationFailure: vi.fn(),
       settleCreateCancellation: vi.fn(async () => ({ canceled: true }))
     })
     const rejected = expect(request).rejects.toThrow('Request createOrAttach timed out after 10ms')
 
     await vi.advanceTimersByTimeAsync(10)
+
+    await rejected
+    expect(pendingRequests.size).toBe(0)
+  })
+
+  it('rejects an unmatched cancellation once the grace window elapses', async () => {
+    vi.useFakeTimers()
+    const pendingRequests = new DaemonPendingRequests()
+    // attach-only: the daemon registers no cancellable spawn, so it can never
+    // match the cancel and no response is coming either.
+    const request = requestDaemonRpc({
+      socket: { write: vi.fn() } as unknown as Socket,
+      pendingRequests,
+      id: 'req-1',
+      type: 'createOrAttach',
+      payload: { sessionId: 'attach-only-spawn', attachOnly: true },
+      timeoutMs: 10,
+      unmatchedCancelGraceMs: 5_000,
+      onCreateCancellationFailure: vi.fn(),
+      settleCreateCancellation: vi.fn(async () => ({ canceled: false }))
+    })
+    const rejected = expect(request).rejects.toThrow('Request createOrAttach timed out after 10ms')
+
+    await vi.advanceTimersByTimeAsync(10)
+    expect(pendingRequests.size).toBe(1)
+    await vi.advanceTimersByTimeAsync(5_000)
 
     await rejected
     expect(pendingRequests.size).toBe(0)
@@ -91,6 +120,7 @@ describe('requestDaemonRpc', () => {
       payload: { sessionId: 'unconfirmed-spawn' },
       timeoutMs: 30_000,
       signal: abort.signal,
+      unmatchedCancelGraceMs: 5_000,
       onCreateCancellationFailure,
       settleCreateCancellation: vi.fn(async () => {
         throw new Error('settlement failed')

--- a/src/main/daemon/daemon-client-rpc-request.ts
+++ b/src/main/daemon/daemon-client-rpc-request.ts
@@ -1,6 +1,7 @@
 import type { Socket } from 'node:net'
 import { encodeNdjson } from './ndjson'
 import { DaemonProtocolError } from './types'
+import { isTerminalAttachCanceledMessage } from './daemon-errors'
 import type { DaemonPendingRequests } from './daemon-client-pending-requests'
 
 type DaemonRpcRequestOptions = {
@@ -11,6 +12,12 @@ type DaemonRpcRequestOptions = {
   payload: unknown
   timeoutMs: number
   signal?: AbortSignal
+  /**
+   * How long to keep waiting after the daemon says it could not match a cancel.
+   * A create that already published a result still has a response in flight, but
+   * an attach-only request has nothing coming, so the wait must be bounded.
+   */
+  unmatchedCancelGraceMs: number
   onCreateCancellationFailure: () => void
   settleCreateCancellation: (sessionId: string, requestId: string) => Promise<{ canceled: boolean }>
 }
@@ -35,7 +42,20 @@ export function requestDaemonRpc<T>(opts: DaemonRpcRequestOptions): Promise<T> {
     let sent = false
     let cancellationStarted = false
     let settled = false
+    let unmatchedCancelTimer: NodeJS.Timeout | null = null
+    // Why: our cancel makes the daemon reject the request too (a queued create
+    // abandoning an aborted wait). Callers key recovery off `client_disconnected`,
+    // so letting that race pick the message rolls back terminals it should keep.
+    // Scoped to the daemon's cancellation reply: a real disconnect still wins.
+    let cancellationError: Error | null = null
     const removeAbortListener = (): void => opts.signal?.removeEventListener('abort', onAbort)
+    const clearTimers = (): void => {
+      clearTimeout(timer)
+      if (unmatchedCancelTimer) {
+        clearTimeout(unmatchedCancelTimer)
+        unmatchedCancelTimer = null
+      }
+    }
     const rejectAndDrop = (error: Error): void => {
       if (settled) {
         return
@@ -43,7 +63,7 @@ export function requestDaemonRpc<T>(opts: DaemonRpcRequestOptions): Promise<T> {
       settled = true
       opts.pendingRequests.drop(opts.id)
       removeAbortListener()
-      clearTimeout(timer)
+      clearTimers()
       reject(error)
     }
     const cancelCreate = (error: Error): void => {
@@ -51,6 +71,7 @@ export function requestDaemonRpc<T>(opts: DaemonRpcRequestOptions): Promise<T> {
         return
       }
       cancellationStarted = true
+      cancellationError = error
       clearTimeout(timer)
       if (!sent || typeof createSessionId !== 'string') {
         rejectAndDrop(error)
@@ -61,6 +82,17 @@ export function requestDaemonRpc<T>(opts: DaemonRpcRequestOptions): Promise<T> {
         .then((result) => {
           if (result.canceled) {
             rejectAndDrop(error)
+            return
+          }
+          // Unmatched cancel: a create that already published a result will
+          // still answer, so keep waiting — but only for a bounded window, or an
+          // attach-only request queued behind a hung create never settles at all.
+          if (!settled && !unmatchedCancelTimer) {
+            unmatchedCancelTimer = setTimeout(
+              () => rejectAndDrop(error),
+              opts.unmatchedCancelGraceMs
+            )
+            unmatchedCancelTimer.unref?.()
           }
         })
         .catch(() => {
@@ -86,12 +118,18 @@ export function requestDaemonRpc<T>(opts: DaemonRpcRequestOptions): Promise<T> {
       resolve: (value) => {
         settled = true
         removeAbortListener()
+        clearTimers()
         resolve(value as T)
       },
       reject: (error) => {
         settled = true
         removeAbortListener()
-        reject(error)
+        clearTimers()
+        reject(
+          cancellationError !== null && isTerminalAttachCanceledMessage(error.message)
+            ? cancellationError
+            : error
+        )
       },
       timer
     })

--- a/src/main/daemon/daemon-errors.ts
+++ b/src/main/daemon/daemon-errors.ts
@@ -1,10 +1,17 @@
 // Error classes shared across the daemon protocol boundary (client, server,
 // host). Split from types.ts, which is capped for wire-shape declarations.
+const ATTACH_CANCELED_PREFIX = 'Attach canceled for session '
+
 export class TerminalAttachCanceledError extends Error {
   constructor(sessionId: string) {
-    super(`Attach canceled for session ${sessionId}`)
+    super(`${ATTACH_CANCELED_PREFIX}${sessionId}`)
     this.name = 'TerminalAttachCanceledError'
   }
+}
+
+/** Recognizes the daemon's attach-cancellation across the wire, where only the message survives. */
+export function isTerminalAttachCanceledMessage(message: string): boolean {
+  return message.startsWith(ATTACH_CANCELED_PREFIX)
 }
 
 export class DaemonProtocolError extends Error {

--- a/src/main/daemon/daemon-server-async-spawn-cancellation.test.ts
+++ b/src/main/daemon/daemon-server-async-spawn-cancellation.test.ts
@@ -130,6 +130,37 @@ describe('daemon async spawn cancellation', () => {
     await expect(client.request('listSessions', undefined)).resolves.toEqual({ sessions: [] })
   })
 
+  it('matches a cancel for an attach-only request queued behind a hung create', async () => {
+    const create = client.request('createOrAttach', {
+      sessionId: 'shared-session',
+      cols: 80,
+      rows: 24
+    })
+    // Only queues behind the create once that create is actually in flight.
+    await spawnStarted
+    const abort = new AbortController()
+    const attach = client.request(
+      'createOrAttach',
+      { sessionId: 'shared-session', cols: 80, rows: 24, attachOnly: true },
+      30_000,
+      abort.signal
+    )
+    const daemon = server as unknown as {
+      pendingPtySpawnPreparations: Map<string, Set<unknown>>
+    }
+    // Attach-only used to register nothing, so the daemon could not match the
+    // cancel and the client dropped its only timeout.
+    await vi.waitFor(() =>
+      expect(daemon.pendingPtySpawnPreparations.get('shared-session')?.size).toBe(2)
+    )
+
+    abort.abort()
+    await expect(attach).rejects.toThrow('client_disconnected')
+
+    releaseSpawn()
+    await expect(create).resolves.toMatchObject({ isNew: true })
+  })
+
   it('does not cancel a sibling request for the same session id', async () => {
     const first = client.request('createOrAttach', {
       sessionId: 'shared-session',

--- a/src/main/daemon/daemon-server-kill-attribution.test.ts
+++ b/src/main/daemon/daemon-server-kill-attribution.test.ts
@@ -98,7 +98,11 @@ describe('daemon kill attribution', () => {
       }
     })
     const daemon = server as unknown as DaemonServerPrivate
-    const pendingPreparation = { canceled: false, clientId: 'control-42' }
+    const pendingPreparation = {
+      canceled: false,
+      controller: new AbortController(),
+      clientId: 'control-42'
+    }
     daemon.pendingPtySpawnPreparations.set('agent-session', new Set([pendingPreparation]))
     vi.spyOn(daemon.host, 'kill').mockRejectedValue(new SessionNotFoundError('agent-session'))
 

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -100,11 +100,19 @@ type ConnectedClient = {
 
 type PendingPtySpawnPreparation = {
   canceled: boolean
+  // Why: `canceled` is only polled between spawn steps; the signal is what
+  // actually interrupts an in-progress cwd probe on a dead share.
+  readonly controller: AbortController
   cancelTimer?: ReturnType<typeof setTimeout>
   // Why: preparations are keyed by sessionId, but a control-socket close must
   // cancel only the disconnecting client's preps, not another client's (F4).
   clientId: string
   requestId: string
+}
+
+function cancelPtySpawnPreparation(preparation: PendingPtySpawnPreparation): void {
+  preparation.canceled = true
+  preparation.controller.abort()
 }
 
 type PendingShutdownReply = {
@@ -904,21 +912,28 @@ export class DaemonServer {
     this.pendingShutdownReplies.set(key, { start })
   }
 
-  private async preparePtySpawnUnlessCanceled(
+  /**
+   * Registers a cancellable preparation without doing spawn preflight. Every
+   * createOrAttach registers one, including attach-only: without it the server
+   * cannot match the client's cancel, and an attach-only request queued behind a
+   * hung create is bounded by neither side.
+   */
+  private registerPtySpawnPreparation(
     sessionId: string,
     clientId: string,
     requestId: string,
     cancelAfterMs: unknown
-  ): Promise<PendingPtySpawnPreparation> {
+  ): PendingPtySpawnPreparation {
     const preparation: PendingPtySpawnPreparation = {
       canceled: false,
+      controller: new AbortController(),
       clientId,
       requestId
     }
     if (Number.isSafeInteger(cancelAfterMs) && Number(cancelAfterMs) > 0) {
       preparation.cancelTimer = setTimeout(
         () => {
-          preparation.canceled = true
+          cancelPtySpawnPreparation(preparation)
         },
         Math.min(Number(cancelAfterMs), 300_000)
       )
@@ -927,16 +942,17 @@ export class DaemonServer {
     const pending = this.pendingPtySpawnPreparations.get(sessionId) ?? new Set()
     pending.add(preparation)
     this.pendingPtySpawnPreparations.set(sessionId, pending)
-    try {
-      // Why: register before the async probe so a concurrent close can cancel this creation before a subprocess exists.
-      await this.preparePtySpawn()
-      if (preparation.canceled) {
-        throw new TerminalAttachCanceledError(sessionId)
-      }
-      return preparation
-    } catch (error) {
-      this.finishPtySpawnPreparation(sessionId, preparation)
-      throw error
+    return preparation
+  }
+
+  private async preparePtySpawnUnlessCanceled(
+    sessionId: string,
+    preparation: PendingPtySpawnPreparation
+  ): Promise<void> {
+    // Why: registered before the async probe so a concurrent close can cancel this creation before a subprocess exists.
+    await this.preparePtySpawn()
+    if (preparation.canceled) {
+      throw new TerminalAttachCanceledError(sessionId)
     }
   }
 
@@ -971,7 +987,7 @@ export class DaemonServer {
       ) {
         continue
       }
-      preparation.canceled = true
+      cancelPtySpawnPreparation(preparation)
       canceled = true
     }
     return canceled
@@ -987,7 +1003,7 @@ export class DaemonServer {
     for (const pending of this.pendingPtySpawnPreparations.values()) {
       for (const preparation of pending) {
         if (preparation.clientId === clientId) {
-          preparation.canceled = true
+          cancelPtySpawnPreparation(preparation)
         }
       }
     }
@@ -1086,13 +1102,14 @@ export class DaemonServer {
           ) {
             throw new Error('agent_session_identity_required')
           }
+          spawnPreparation = this.registerPtySpawnPreparation(
+            p.sessionId,
+            clientId,
+            request.id,
+            p.cancelAfterMs
+          )
           if (!attachOnly) {
-            spawnPreparation = await this.preparePtySpawnUnlessCanceled(
-              p.sessionId,
-              clientId,
-              request.id,
-              p.cancelAfterMs
-            )
+            await this.preparePtySpawnUnlessCanceled(p.sessionId, spawnPreparation)
           }
           if (p.historySeed !== undefined && p.historySeedTransferId !== undefined) {
             throw new Error('Multiple terminal history seed sources')
@@ -1125,7 +1142,12 @@ export class DaemonServer {
               ? { shellReadyTimeoutMs: p.shellReadyTimeoutMs }
               : {}),
             ...(p.agentSessionEnsure ? { agentSessionEnsure: p.agentSessionEnsure } : {}),
-            ...(spawnPreparation ? { isCanceled: () => spawnPreparation?.canceled === true } : {}),
+            ...(spawnPreparation
+              ? {
+                  isCanceled: () => spawnPreparation?.canceled === true,
+                  cancelSignal: spawnPreparation.controller.signal
+                }
+              : {}),
             onSessionResolved: (sessionId) => {
               routedSessionId = sessionId
             },

--- a/src/main/daemon/pty-subprocess-cwd-cancel-identity.test.ts
+++ b/src/main/daemon/pty-subprocess-cwd-cancel-identity.test.ts
@@ -1,0 +1,96 @@
+// A canceled cwd probe must leave the daemon as the one cancellation identity
+// the wire carries. Clients key recovery off it, and an unrecognized message
+// takes the rollback branch that closes a terminal the user still has (#7718).
+import { describe, expect, it, vi } from 'vitest'
+import type * as LocalPtyUtils from '../providers/local-pty-utils'
+
+const {
+  spawnMock,
+  isPwshAvailableMock,
+  validateWorkingDirectoryMock,
+  validateWorkingDirectoryAsyncMock,
+  resolveUnixShellPathMock,
+  resolveAgentForegroundProcessMock
+} = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+  isPwshAvailableMock: vi.fn(),
+  resolveUnixShellPathMock: vi.fn((shellPath: string) => shellPath),
+  resolveAgentForegroundProcessMock: vi.fn(),
+  validateWorkingDirectoryMock: vi.fn(),
+  validateWorkingDirectoryAsyncMock: vi.fn()
+}))
+
+vi.mock('node-pty', () => ({ spawn: spawnMock }))
+vi.mock('../pwsh', () => ({ isPwshAvailable: isPwshAvailableMock }))
+
+vi.mock('../providers/local-pty-utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof LocalPtyUtils>()
+  return {
+    ...actual,
+    resolveUnixShellPath: resolveUnixShellPathMock,
+    validateWorkingDirectory: validateWorkingDirectoryMock,
+    validateWorkingDirectoryAsync: validateWorkingDirectoryAsyncMock
+  }
+})
+
+vi.mock('../providers/agent-foreground-process', () => ({
+  resolveAgentForegroundProcessWithAvailability: async (...args: unknown[]) => {
+    const value = await resolveAgentForegroundProcessMock(...args)
+    return value && typeof value === 'object' && 'available' in value
+      ? value
+      : { available: true, processName: value }
+  }
+}))
+
+vi.mock('../providers/windows-conpty-process-membership', () => ({
+  readWindowsConptyProcessIds: () => Promise.resolve(new Set([12345]))
+}))
+
+import { createPtySubprocess } from './pty-subprocess'
+import { TerminalAttachCanceledError } from './daemon-errors'
+import { WorkingDirectoryValidationAbortedError } from '../providers/working-directory-validation'
+import { useDaemonPtySubprocessEnv } from './pty-subprocess-test-harness'
+
+describe('createPtySubprocess cwd cancellation identity', () => {
+  useDaemonPtySubprocessEnv({
+    spawnMock,
+    isPwshAvailableMock,
+    resolveUnixShellPathMock,
+    resolveAgentForegroundProcessMock,
+    validateWorkingDirectoryMock
+  })
+
+  it('reports a canceled cwd probe as an attach cancellation, not a spawn failure', async () => {
+    validateWorkingDirectoryAsyncMock.mockRejectedValue(
+      new WorkingDirectoryValidationAbortedError('/Volumes/dead/repo')
+    )
+    const abort = new AbortController()
+    abort.abort()
+
+    await expect(
+      createPtySubprocess({
+        sessionId: 'canceled-cwd-session',
+        cols: 80,
+        rows: 24,
+        cwd: '/Volumes/dead/repo',
+        cancelSignal: abort.signal
+      })
+    ).rejects.toThrow(TerminalAttachCanceledError)
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
+  it('leaves a genuine missing-directory failure alone', async () => {
+    validateWorkingDirectoryAsyncMock.mockRejectedValue(
+      new Error('Working directory "/gone" does not exist. It may have been deleted.')
+    )
+
+    await expect(
+      createPtySubprocess({
+        sessionId: 'missing-cwd-session',
+        cols: 80,
+        rows: 24,
+        cwd: '/gone'
+      })
+    ).rejects.toThrow(/does not exist/)
+  })
+})

--- a/src/main/daemon/pty-subprocess-wsl-launch.test.ts
+++ b/src/main/daemon/pty-subprocess-wsl-launch.test.ts
@@ -465,7 +465,8 @@ describe('createPtySubprocess', () => {
       }
 
       expect(validateWorkingDirectoryMock).toHaveBeenCalledWith(
-        `\\\\wsl.localhost\\Ubuntu${cwd.replaceAll('/', '\\')}`
+        `\\\\wsl.localhost\\Ubuntu${cwd.replaceAll('/', '\\')}`,
+        expect.anything()
       )
       expect(spawnMock).toHaveBeenCalledWith(
         'wsl.exe',

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -15,7 +15,8 @@ import {
   ensureNodePtySpawnHelperExecutable,
   getNodePtySpawnHelperCandidates,
   resolveUnixShellPath,
-  validateWorkingDirectoryAsync
+  validateWorkingDirectoryAsync,
+  WorkingDirectoryValidationAbortedError
 } from '../providers/local-pty-utils'
 import { wrapShellSpawnForMacosTccAttribution } from '../providers/macos-tcc-login-shell'
 import { signalPosixPtyForegroundGroup } from '../pty/posix-pty-foreground-group'
@@ -866,12 +867,22 @@ export async function createPtySubprocess(opts: PtySubprocessOptions): Promise<S
   // Why: asar packaging can strip +x from node-pty's spawn-helper; the daemon is a separate forked process from the main-process fix.
   ensureNodePtySpawnHelperExecutable()
   preflightUnixPtySpawnEnvironment()
-  await preflightPosixPtySpawnEnvironment(validationCwd, opts.cancelSignal)
-  await preflightWindowsPtySpawnEnvironment({
-    validationCwd,
-    cwdWasExplicit: opts.cwd !== undefined,
-    ...(opts.cancelSignal ? { signal: opts.cancelSignal } : {})
-  })
+  try {
+    await preflightPosixPtySpawnEnvironment(validationCwd, opts.cancelSignal)
+    await preflightWindowsPtySpawnEnvironment({
+      validationCwd,
+      cwdWasExplicit: opts.cwd !== undefined,
+      ...(opts.cancelSignal ? { signal: opts.cancelSignal } : {})
+    })
+  } catch (error) {
+    // Why: the wire must carry one cancellation identity. Clients key recovery
+    // off it, and an unrecognized message takes the rollback branch that closes
+    // a terminal the user still has (#7718).
+    if (error instanceof WorkingDirectoryValidationAbortedError) {
+      throw new TerminalAttachCanceledError(opts.sessionId)
+    }
+    throw error
+  }
   if (opts.isCanceled?.()) {
     throw new TerminalAttachCanceledError(opts.sessionId)
   }

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -135,6 +135,8 @@ export type PtySubprocessOptions = {
   terminalWindowsWslDistro?: string | null
   terminalWindowsPowerShellImplementation?: 'auto' | 'powershell.exe' | 'pwsh.exe'
   isCanceled?: () => boolean
+  /** Aborts in-progress cwd validation; `isCanceled` is only polled between steps. */
+  cancelSignal?: AbortSignal
   onMacosTccSpawnStrategy?: (strategy: 'wrapped' | 'direct') => void
 }
 
@@ -388,6 +390,7 @@ function isNativeWindowsPath(path: string): boolean {
 async function preflightWindowsPtySpawnEnvironment(args: {
   validationCwd: string
   cwdWasExplicit: boolean
+  signal?: AbortSignal
 }): Promise<void> {
   if (process.platform !== 'win32' || !args.cwdWasExplicit) {
     return
@@ -397,17 +400,23 @@ async function preflightWindowsPtySpawnEnvironment(args: {
     return
   }
 
-  await validateWorkingDirectoryAsync(args.validationCwd)
+  await validateWorkingDirectoryAsync(
+    args.validationCwd,
+    args.signal ? { signal: args.signal } : {}
+  )
 }
 
 /**
  * Validates POSIX spawn cwd before node-pty can fail with an opaque ENOENT.
  */
-async function preflightPosixPtySpawnEnvironment(validationCwd: string): Promise<void> {
+async function preflightPosixPtySpawnEnvironment(
+  validationCwd: string,
+  signal?: AbortSignal
+): Promise<void> {
   if (process.platform === 'win32') {
     return
   }
-  await validateWorkingDirectoryAsync(validationCwd)
+  await validateWorkingDirectoryAsync(validationCwd, signal ? { signal } : {})
 }
 
 /**
@@ -857,10 +866,11 @@ export async function createPtySubprocess(opts: PtySubprocessOptions): Promise<S
   // Why: asar packaging can strip +x from node-pty's spawn-helper; the daemon is a separate forked process from the main-process fix.
   ensureNodePtySpawnHelperExecutable()
   preflightUnixPtySpawnEnvironment()
-  await preflightPosixPtySpawnEnvironment(validationCwd)
+  await preflightPosixPtySpawnEnvironment(validationCwd, opts.cancelSignal)
   await preflightWindowsPtySpawnEnvironment({
     validationCwd,
-    cwdWasExplicit: opts.cwd !== undefined
+    cwdWasExplicit: opts.cwd !== undefined,
+    ...(opts.cancelSignal ? { signal: opts.cancelSignal } : {})
   })
   if (opts.isCanceled?.()) {
     throw new TerminalAttachCanceledError(opts.sessionId)

--- a/src/main/daemon/terminal-host-agent-session-claim.ts
+++ b/src/main/daemon/terminal-host-agent-session-claim.ts
@@ -5,6 +5,7 @@ import type { CreateOrAttachOptions, CreateOrAttachResult } from './terminal-hos
 export type InternalCreateOrAttachOptions = CreateOrAttachOptions & {
   agentSessionGeneration?: string
   isCanceled?: () => boolean
+  cancelSignal?: AbortSignal
 }
 
 export async function createOrAttachClaimedAgentSession(args: {

--- a/src/main/daemon/terminal-host-concurrent-create.test.ts
+++ b/src/main/daemon/terminal-host-concurrent-create.test.ts
@@ -94,6 +94,35 @@ describe('concurrent createOrAttach across the async spawn', () => {
     await host.dispose()
   })
 
+  it('lets a canceled caller stop waiting on a create stuck on a dead share', async () => {
+    let releaseSpawn: () => void = () => {}
+    const spawnGate = new Promise<void>((resolve) => {
+      releaseSpawn = resolve
+    })
+    const host = new TerminalHost({
+      spawnSubprocess: async () => {
+        await spawnGate
+        return mockSubprocess()
+      }
+    })
+
+    const stuck = host.createOrAttach(createOptions('dead-share-session'))
+    const abort = new AbortController()
+    const queued = host.createOrAttach({
+      ...createOptions('dead-share-session'),
+      cancelSignal: abort.signal
+    })
+    abort.abort()
+
+    // Without this the queued caller waits out the hung probe, holding a create
+    // in flight and blocking shutdown/idle behind it.
+    await expect(queued).rejects.toThrow('Attach canceled')
+
+    releaseSpawn()
+    await stuck
+    await host.dispose()
+  })
+
   it('waits for an in-flight spawn before disposing its session', async () => {
     let releaseSpawn: () => void = () => {}
     const spawnGate = new Promise<void>((resolve) => {

--- a/src/main/daemon/terminal-host-options.ts
+++ b/src/main/daemon/terminal-host-options.ts
@@ -18,6 +18,7 @@ export type TerminalHostOptions = {
     terminalWindowsWslDistro?: string | null
     terminalWindowsPowerShellImplementation?: 'auto' | 'powershell.exe' | 'pwsh.exe'
     isCanceled?: () => boolean
+    cancelSignal?: AbortSignal
     // Async production spawns and sync test stubs share this boundary.
   }) => SubprocessHandle | Promise<SubprocessHandle>
   // Why: login-session death detection (#7936) needs subprocess exits even when no client is attached.

--- a/src/main/daemon/terminal-host-session-create.ts
+++ b/src/main/daemon/terminal-host-session-create.ts
@@ -94,7 +94,8 @@ async function spawnAndPublishSession(
     shellOverride: opts.shellOverride,
     terminalWindowsWslDistro: opts.terminalWindowsWslDistro,
     terminalWindowsPowerShellImplementation: opts.terminalWindowsPowerShellImplementation,
-    isCanceled: opts.isCanceled
+    isCanceled: opts.isCanceled,
+    ...(opts.cancelSignal ? { cancelSignal: opts.cancelSignal } : {})
   })
 
   // Why: a fallback shell does not emit the preferred shell's ready marker;

--- a/src/main/daemon/terminal-host.ts
+++ b/src/main/daemon/terminal-host.ts
@@ -23,6 +23,22 @@ import { isShellProcess } from '../../shared/agent-detection'
 import { TerminalAttachCanceledError } from './daemon-errors'
 
 export type { CreateOrAttachOptions, CreateOrAttachResult } from './terminal-host-create-contract'
+
+/** Never resolves; only rejects, so it can bound a wait without settling it. */
+function rejectOnAbort(signal: AbortSignal | undefined, sessionId: string): Promise<never> {
+  if (!signal) {
+    return new Promise<never>(() => {})
+  }
+  return new Promise<never>((_resolve, reject) => {
+    if (signal.aborted) {
+      reject(new TerminalAttachCanceledError(sessionId))
+      return
+    }
+    signal.addEventListener('abort', () => reject(new TerminalAttachCanceledError(sessionId)), {
+      once: true
+    })
+  })
+}
 export type { TerminalHostOptions } from './terminal-host-options'
 
 const DEFAULT_MAX_TOMBSTONES = 1000
@@ -57,7 +73,11 @@ export class TerminalHost {
       inFlight !== undefined;
       inFlight = this.pendingCreations.get(opts.sessionId)
     ) {
-      await inFlight
+      // Why: the create ahead of us can be stuck on an unreachable share for
+      // minutes. Waiting unconditionally is what let one dead path strand every
+      // later create and attach for the session, so a canceled caller leaves.
+      await Promise.race([inFlight, rejectOnAbort(opts.cancelSignal, opts.sessionId)])
+      this.assertCreateOrAttachAllowed(opts)
     }
     this.assertCreateOrAttachAllowed(opts)
 

--- a/src/main/providers/local-pty-utils.ts
+++ b/src/main/providers/local-pty-utils.ts
@@ -1,14 +1,17 @@
 import { basename, isAbsolute, join } from 'node:path'
 import { existsSync, accessSync, statSync, chmodSync, constants as fsConstants } from 'node:fs'
-import { stat } from 'node:fs/promises'
-import { release } from 'node:os'
 import type * as pty from 'node-pty'
-import { isWslUncPath } from '../../shared/wsl-paths'
-import { wslUncDirectoryExists, wslUncDirectoryExistsAsync } from '../wsl'
 import { wrapShellSpawnForMacosTccAttribution } from './macos-tcc-login-shell'
+import { formatLocalPtyEnvironmentDiag } from './working-directory-validation'
+
+export {
+  formatLocalPtyEnvironmentDiag,
+  validateWorkingDirectory,
+  validateWorkingDirectoryAsync,
+  WorkingDirectoryValidationAbortedError
+} from './working-directory-validation'
 
 let didEnsureSpawnHelperExecutable = false
-const pendingWorkingDirectoryValidations = new Map<string, Promise<void>>()
 
 const UNIX_SHELL_FALLBACKS = ['/bin/zsh', '/bin/bash', '/bin/sh'] as const
 
@@ -99,96 +102,6 @@ export function ensureNodePtySpawnHelperExecutable(): void {
     console.warn(
       `[pty] Failed to ensure node-pty spawn-helper is executable: ${error instanceof Error ? error.message : String(error)}`
     )
-  }
-}
-
-function formatLocalPtyEnvironmentDiag(extra: Record<string, string> = {}): string {
-  const systemVersion =
-    (process as NodeJS.Process & { getSystemVersion?: () => string }).getSystemVersion?.() ||
-    release()
-  const parts = {
-    ...extra,
-    arch: process.arch,
-    platform: `${process.platform} ${systemVersion}`,
-    orca: process.env.ORCA_APP_VERSION?.trim() || '0.0.0-dev'
-  }
-  return Object.entries(parts)
-    .map(([key, value]) => `${key}: ${value}`)
-    .join(', ')
-}
-
-function throwMissingWorkingDirectory(cwd: string): never {
-  throw new Error(
-    `Working directory "${cwd}" does not exist. ` +
-      `It may have been deleted or is on an unmounted volume ` +
-      `(${formatLocalPtyEnvironmentDiag({ cwd })}).`
-  )
-}
-
-/**
- * Validate that a working directory exists and is a directory.
- * Throws a descriptive Error if not.
- */
-export function validateWorkingDirectory(cwd: string): void {
-  // Why: Win32 fs.statSync against the WSL 9P share (\\wsl.localhost\...) can
-  // falsely report ENOENT for directories that exist on the Linux side. Ask the
-  // distro itself; only fall back to the fs check when wsl.exe is inconclusive.
-  if (isWslUncPath(cwd)) {
-    const existsInDistro = wslUncDirectoryExists(cwd)
-    if (existsInDistro === false) {
-      throwMissingWorkingDirectory(cwd)
-    }
-    if (existsInDistro === true) {
-      return
-    }
-  }
-
-  if (!existsSync(cwd)) {
-    throwMissingWorkingDirectory(cwd)
-  }
-  if (!statSync(cwd).isDirectory()) {
-    throw new Error(`Working directory "${cwd}" is not a directory.`)
-  }
-}
-
-/** Validate a cwd without blocking the daemon's shared event loop. */
-export function validateWorkingDirectoryAsync(cwd: string): Promise<void> {
-  const key = cwd
-  const pending = pendingWorkingDirectoryValidations.get(key)
-  if (pending) {
-    return pending
-  }
-  const validation = validateWorkingDirectoryUncached(cwd)
-  pendingWorkingDirectoryValidations.set(key, validation)
-  const forget = (): void => {
-    if (pendingWorkingDirectoryValidations.get(key) === validation) {
-      pendingWorkingDirectoryValidations.delete(key)
-    }
-  }
-  void validation.then(forget, forget)
-  return validation
-}
-
-async function validateWorkingDirectoryUncached(cwd: string): Promise<void> {
-  if (isWslUncPath(cwd)) {
-    const existsInDistro = await wslUncDirectoryExistsAsync(cwd)
-    if (existsInDistro === false) {
-      throwMissingWorkingDirectory(cwd)
-    }
-    if (existsInDistro === true) {
-      return
-    }
-  }
-
-  let stats: Awaited<ReturnType<typeof stat>>
-  try {
-    stats = await stat(cwd)
-  } catch {
-    // One stat avoids paying an unreachable filesystem timeout twice.
-    throwMissingWorkingDirectory(cwd)
-  }
-  if (!stats.isDirectory()) {
-    throw new Error(`Working directory "${cwd}" is not a directory.`)
   }
 }
 

--- a/src/main/providers/working-directory-validation.test.ts
+++ b/src/main/providers/working-directory-validation.test.ts
@@ -107,20 +107,33 @@ describe('validateWorkingDirectoryAsync', () => {
       expect(wslUncDirectoryExistsAsyncMock).toHaveBeenCalledOnce()
     })
 
-    it('stops a never-settling probe from poisoning the path forever', async () => {
+    it('never pins a second probe on a path whose probe is still hung', async () => {
       vi.useFakeTimers()
       try {
         wslUncDirectoryExistsAsyncMock.mockReturnValue(new Promise<boolean>(() => {}))
+        const hung = deadShare('still-hung')
 
-        const poisoned = deadShare('evicted')
-        void validateWorkingDirectoryAsync(poisoned).catch(() => {})
-        await vi.advanceTimersByTimeAsync(30_000)
-        void validateWorkingDirectoryAsync(poisoned).catch(() => {})
+        // `fs.stat` is uninterruptible, so retiring the entry on a timer would
+        // free no libuv thread — it would only let each retry pin another, and
+        // the default pool of 4 is exhausted after a few rounds.
+        for (let retry = 0; retry < 4; retry += 1) {
+          void validateWorkingDirectoryAsync(hung).catch(() => {})
+          await vi.advanceTimersByTimeAsync(60_000)
+        }
 
-        expect(wslUncDirectoryExistsAsyncMock).toHaveBeenCalledTimes(2)
+        expect(wslUncDirectoryExistsAsyncMock).toHaveBeenCalledOnce()
       } finally {
         vi.useRealTimers()
       }
+    })
+
+    it('re-probes once the previous probe settles, so a recovered mount is seen', async () => {
+      wslUncDirectoryExistsAsyncMock.mockResolvedValueOnce(false).mockResolvedValueOnce(true)
+      const recovering = deadShare('recovers')
+
+      await expect(validateWorkingDirectoryAsync(recovering)).rejects.toThrow(/does not exist/)
+      await expect(validateWorkingDirectoryAsync(recovering)).resolves.toBeUndefined()
+      expect(wslUncDirectoryExistsAsyncMock).toHaveBeenCalledTimes(2)
     })
   })
 

--- a/src/main/providers/working-directory-validation.test.ts
+++ b/src/main/providers/working-directory-validation.test.ts
@@ -55,6 +55,75 @@ describe('validateWorkingDirectoryAsync', () => {
     expect(ticked).toBe(true)
   })
 
+  describe('cancellation', () => {
+    // Unique per test: the dedupe map is module-level, and a never-settling
+    // probe would otherwise leak into later cases.
+    const deadShare = (name: string): string => `\\\\wsl.localhost\\Ubuntu\\dead-${name}`
+
+    beforeEach(() => {
+      vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('lets an aborted caller give up on a probe that never answers', async () => {
+      // fs.stat takes no signal, so the caller leaves; the probe keeps running.
+      wslUncDirectoryExistsAsyncMock.mockReturnValue(new Promise<boolean>(() => {}))
+      const abort = new AbortController()
+
+      const pending = validateWorkingDirectoryAsync(deadShare('abort'), { signal: abort.signal })
+      abort.abort()
+
+      await expect(pending).rejects.toThrow('was canceled')
+    })
+
+    it('rejects immediately when the signal is already aborted', async () => {
+      wslUncDirectoryExistsAsyncMock.mockReturnValue(new Promise<boolean>(() => {}))
+
+      await expect(
+        validateWorkingDirectoryAsync(deadShare('pre-aborted'), { signal: AbortSignal.abort() })
+      ).rejects.toThrow('was canceled')
+    })
+
+    it('leaves the shared probe intact for callers that are still waiting', async () => {
+      let releaseProbe: () => void = () => {}
+      wslUncDirectoryExistsAsyncMock.mockReturnValue(
+        new Promise<boolean>((resolve) => {
+          releaseProbe = () => resolve(true)
+        })
+      )
+      const abort = new AbortController()
+
+      const shared = deadShare('shared')
+      const staying = validateWorkingDirectoryAsync(shared)
+      const leaving = validateWorkingDirectoryAsync(shared, { signal: abort.signal })
+      abort.abort()
+      await expect(leaving).rejects.toThrow('was canceled')
+
+      releaseProbe()
+      await expect(staying).resolves.toBeUndefined()
+      expect(wslUncDirectoryExistsAsyncMock).toHaveBeenCalledOnce()
+    })
+
+    it('stops a never-settling probe from poisoning the path forever', async () => {
+      vi.useFakeTimers()
+      try {
+        wslUncDirectoryExistsAsyncMock.mockReturnValue(new Promise<boolean>(() => {}))
+
+        const poisoned = deadShare('evicted')
+        void validateWorkingDirectoryAsync(poisoned).catch(() => {})
+        await vi.advanceTimersByTimeAsync(30_000)
+        void validateWorkingDirectoryAsync(poisoned).catch(() => {})
+
+        expect(wslUncDirectoryExistsAsyncMock).toHaveBeenCalledTimes(2)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+  })
+
   describe('WSL UNC paths', () => {
     const wslPath = '\\\\wsl.localhost\\Ubuntu\\home\\jin\\repo'
 

--- a/src/main/providers/working-directory-validation.ts
+++ b/src/main/providers/working-directory-validation.ts
@@ -9,8 +9,6 @@ import { isWslUncPath } from '../../shared/wsl-paths'
 import { wslUncDirectoryExists, wslUncDirectoryExistsAsync } from '../wsl'
 
 const pendingWorkingDirectoryValidations = new Map<string, Promise<void>>()
-/** Upper bound on how long one unreachable path may keep poisoning the dedupe map. */
-const WORKING_DIRECTORY_VALIDATION_CACHE_MS = 30_000
 
 /** Thrown when the caller gave up on a probe that is still running. */
 export class WorkingDirectoryValidationAbortedError extends Error {
@@ -86,18 +84,19 @@ export function validateWorkingDirectoryAsync(
   if (!validation) {
     validation = validateWorkingDirectoryUncached(cwd)
     pendingWorkingDirectoryValidations.set(key, validation)
-    const settled = validation
+    const started = validation
+    // Why: dropped only on settle. `fs.stat` is uninterruptible, so retiring a
+    // still-running probe on a timer frees no libuv thread — it only lets the
+    // next caller pin a second one, and a few retries against one dead mount
+    // exhaust the default pool of 4 and stall every other async fs read in the
+    // daemon. Callers escape through `signal` instead, so sharing one hung probe
+    // no longer strands them.
     const forget = (): void => {
-      if (pendingWorkingDirectoryValidations.get(key) === settled) {
+      if (pendingWorkingDirectoryValidations.get(key) === started) {
         pendingWorkingDirectoryValidations.delete(key)
       }
     }
     void validation.then(forget, forget)
-    // Why: a mount that never answers would otherwise pin this entry forever,
-    // so every later create for the same path joins a promise that cannot settle
-    // — turning one dead share into a permanent, cross-session stall.
-    const eviction = setTimeout(forget, WORKING_DIRECTORY_VALIDATION_CACHE_MS)
-    eviction.unref?.()
   }
   const signal = options.signal
   if (!signal) {

--- a/src/main/providers/working-directory-validation.ts
+++ b/src/main/providers/working-directory-validation.ts
@@ -1,0 +1,141 @@
+// Validates a PTY working directory before spawn, so node-pty cannot fail with
+// an opaque ENOENT. Split from local-pty-utils to keep that file under its line
+// cap; the async path carries the cancellation contract described below.
+
+import { existsSync, statSync } from 'node:fs'
+import { stat } from 'node:fs/promises'
+import { release } from 'node:os'
+import { isWslUncPath } from '../../shared/wsl-paths'
+import { wslUncDirectoryExists, wslUncDirectoryExistsAsync } from '../wsl'
+
+const pendingWorkingDirectoryValidations = new Map<string, Promise<void>>()
+/** Upper bound on how long one unreachable path may keep poisoning the dedupe map. */
+const WORKING_DIRECTORY_VALIDATION_CACHE_MS = 30_000
+
+/** Thrown when the caller gave up on a probe that is still running. */
+export class WorkingDirectoryValidationAbortedError extends Error {
+  constructor(cwd: string) {
+    super(`Working directory validation for "${cwd}" was canceled.`)
+    this.name = 'WorkingDirectoryValidationAbortedError'
+  }
+}
+
+export function formatLocalPtyEnvironmentDiag(extra: Record<string, string> = {}): string {
+  const systemVersion =
+    (process as NodeJS.Process & { getSystemVersion?: () => string }).getSystemVersion?.() ||
+    release()
+  const parts = {
+    ...extra,
+    arch: process.arch,
+    platform: `${process.platform} ${systemVersion}`,
+    orca: process.env.ORCA_APP_VERSION?.trim() || '0.0.0-dev'
+  }
+  return Object.entries(parts)
+    .map(([key, value]) => `${key}: ${value}`)
+    .join(', ')
+}
+
+function throwMissingWorkingDirectory(cwd: string): never {
+  throw new Error(
+    `Working directory "${cwd}" does not exist. ` +
+      `It may have been deleted or is on an unmounted volume ` +
+      `(${formatLocalPtyEnvironmentDiag({ cwd })}).`
+  )
+}
+
+/**
+ * Validate that a working directory exists and is a directory.
+ * Throws a descriptive Error if not.
+ */
+export function validateWorkingDirectory(cwd: string): void {
+  // Why: Win32 fs.statSync against the WSL 9P share (\\wsl.localhost\...) can
+  // falsely report ENOENT for directories that exist on the Linux side. Ask the
+  // distro itself; only fall back to the fs check when wsl.exe is inconclusive.
+  if (isWslUncPath(cwd)) {
+    const existsInDistro = wslUncDirectoryExists(cwd)
+    if (existsInDistro === false) {
+      throwMissingWorkingDirectory(cwd)
+    }
+    if (existsInDistro === true) {
+      return
+    }
+  }
+
+  if (!existsSync(cwd)) {
+    throwMissingWorkingDirectory(cwd)
+  }
+  if (!statSync(cwd).isDirectory()) {
+    throw new Error(`Working directory "${cwd}" is not a directory.`)
+  }
+}
+
+/**
+ * Validate a cwd without blocking the daemon's shared event loop.
+ *
+ * `fs.stat` takes no AbortSignal and a dead SMB/NFS mount can hang it for
+ * minutes, so an aborted caller abandons the shared probe rather than
+ * interrupting it: the probe stays shared for whoever is still waiting, and the
+ * caller stops holding a create in flight.
+ */
+export function validateWorkingDirectoryAsync(
+  cwd: string,
+  options: { signal?: AbortSignal } = {}
+): Promise<void> {
+  const key = cwd
+  let validation = pendingWorkingDirectoryValidations.get(key)
+  if (!validation) {
+    validation = validateWorkingDirectoryUncached(cwd)
+    pendingWorkingDirectoryValidations.set(key, validation)
+    const settled = validation
+    const forget = (): void => {
+      if (pendingWorkingDirectoryValidations.get(key) === settled) {
+        pendingWorkingDirectoryValidations.delete(key)
+      }
+    }
+    void validation.then(forget, forget)
+    // Why: a mount that never answers would otherwise pin this entry forever,
+    // so every later create for the same path joins a promise that cannot settle
+    // — turning one dead share into a permanent, cross-session stall.
+    const eviction = setTimeout(forget, WORKING_DIRECTORY_VALIDATION_CACHE_MS)
+    eviction.unref?.()
+  }
+  const signal = options.signal
+  if (!signal) {
+    return validation
+  }
+  const shared = validation
+  // The shared probe outlives this caller; keep it from surfacing as unhandled.
+  void shared.catch(() => {})
+  return new Promise<void>((resolve, reject) => {
+    const onAbort = (): void => reject(new WorkingDirectoryValidationAbortedError(cwd))
+    if (signal.aborted) {
+      onAbort()
+      return
+    }
+    signal.addEventListener('abort', onAbort, { once: true })
+    shared.then(resolve, reject).finally(() => signal.removeEventListener('abort', onAbort))
+  })
+}
+
+async function validateWorkingDirectoryUncached(cwd: string): Promise<void> {
+  if (isWslUncPath(cwd)) {
+    const existsInDistro = await wslUncDirectoryExistsAsync(cwd)
+    if (existsInDistro === false) {
+      throwMissingWorkingDirectory(cwd)
+    }
+    if (existsInDistro === true) {
+      return
+    }
+  }
+
+  let stats: Awaited<ReturnType<typeof stat>>
+  try {
+    stats = await stat(cwd)
+  } catch {
+    // One stat avoids paying an unreachable filesystem timeout twice.
+    throwMissingWorkingDirectory(cwd)
+  }
+  if (!stats.isDirectory()) {
+    throw new Error(`Working directory "${cwd}" is not a directory.`)
+  }
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​275 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​273 |
| Prod | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​296 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​131 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​165 |

<!-- /orca-pr-loc -->

Follow-up hardening on #14848 (merged, not reverted).

#14848 made cwd validation async so one dead share could not freeze every terminal. Two ways for a single unreachable path to strand work remained. Both claims in STA-4541 were verified against the code before fixing.

## 1. Cancel did not abort the probe

`isCanceled` is only polled *between* spawn steps (`pty-subprocess.ts:865`), so `fs.stat` on a dead SMB/NFS/UNC path ran to completion. The create stayed in flight, later creates for that session queued behind it (`terminal-host.ts:55-61`), and shutdown/idle waited on it.

- Carry an `AbortSignal` alongside the existing poll, so a canceled caller abandons the probe.
- Make the per-session queue wait abortable, so a canceled *queued* request stops waiting too.
- The shared probe keeps running for whoever still wants it — an aborting caller never breaks another waiter (pinned by a test).
- Evict the dedupe entry on a hard cap. **Found while fixing:** the map only evicted on settle, so a never-settling probe permanently poisoned that path for *any* session, turning a per-session stall into a cross-session one.

## 2. Attach-only lost its only timeout

Attach-only registered no cancellable preparation (`daemon-server.ts:1089`), so the daemon could not match the client's cancel, and the client had already cleared its timer — neither side bounded the request.

- Register the preparation for every `createOrAttach`; run spawn preflight only when not attach-only.
- Give the client a bounded grace window when the daemon reports an unmatched cancel.

## Error identity

Aborting the queue wait makes the daemon reject the queued request, which races the client's own cancellation. `client_disconnected` gates mobile terminal rollback (`orca-runtime.ts:27719`), so the wrong error would close terminals it should keep (#7718). The cancellation reason now wins deterministically — but scoped to the daemon's own attach-cancellation, so a genuine disconnect still surfaces as itself. A test caught this.

## Notes

Splits working-directory validation out of `local-pty-utils.ts` to stay under the line cap (no `max-lines` disable added).

## Testing

Daemon + providers suites: 2254 passed. New coverage for abort-during-probe, dedupe eviction, shared-probe survival, canceled queued caller, and attach-only cancel. Typecheck and lint clean.

STA-4541