### PR TITLE
fix(native-chat): keep structured rows put and stop raw opcode rows

### DIFF
--- a/mobile/src/session/MobileNativeChatMessage.provider-frame.test.tsx
+++ b/mobile/src/session/MobileNativeChatMessage.provider-frame.test.tsx
@@ -71,4 +71,34 @@ describe('MobileNativeChatMessage provider frame', () => {
       '{"future":true}'
     )
   })
+
+  it('leads with the provider sentence instead of the raw frame kind', () => {
+    act(() => {
+      renderer = create(
+        createElement(MobileNativeChatMessage, {
+          message: {
+            id: 'frame-1',
+            role: 'system',
+            source: 'transcript',
+            timestamp: 1,
+            blocks: [
+              {
+                type: 'text',
+                text: 'Your plan limit resets in 2 hours.',
+                providerFrame: {
+                  provider: 'codex',
+                  kind: 'notification:warning',
+                  payload: { head: '{}', byteLength: 2, digest: 'digest', truncated: false }
+                }
+              }
+            ]
+          }
+        })
+      )
+    })
+
+    const labels = renderer!.root.findAllByType('Text').flatMap((node) => node.children)
+    expect(labels).toContain('Your plan limit resets in 2 hours.')
+    expect(labels).not.toContain('notification:warning')
+  })
 })

--- a/mobile/src/session/MobileNativeChatMessage.tsx
+++ b/mobile/src/session/MobileNativeChatMessage.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../../src/shared/native-chat-tool-summary'
 import { isImageRefBlock, isTextBlock } from '../../../src/shared/native-chat-types'
 import type { NativeChatBlock, NativeChatMessage } from '../../../src/shared/native-chat-types'
+import { nativeChatProviderFrameSummary } from '../../../src/shared/native-chat-provider-frame-summary'
 import { MobileMarkdown } from '../components/MobileMarkdown'
 import { colors } from '../theme/mobile-theme'
 import { isRenderableImageUri } from './mobile-native-chat-image-preview'
@@ -200,7 +201,7 @@ function MobileProviderFrame({
         )}
         <Text style={styles.providerFrameProvider}>{frame.provider}</Text>
         <Text style={styles.providerFrameKind} numberOfLines={1}>
-          {frame.kind}
+          {nativeChatProviderFrameSummary(block)}
         </Text>
       </Pressable>
       {expanded ? (

--- a/src/main/native-chat/agent-session-journal/journal-reducer.test.ts
+++ b/src/main/native-chat/agent-session-journal/journal-reducer.test.ts
@@ -123,6 +123,22 @@ describe('ordering', () => {
     expect(items[1]?.recovered).toBe(true)
   })
 
+  it('pins observedAt to creation so a revision cannot relocate the row', () => {
+    // Clients sort the timeline by observedAt. The provider echoing a send revises
+    // the submission row; if that advanced the timestamp the user's own bubble
+    // would sort below rows that landed while the turn was in flight.
+    const state = fold([
+      { kind: 'item', itemId: 'send', revision: 0, body: userText('ok thanks'), ...base(1) },
+      { kind: 'item', itemId: 'frame', revision: 1, body: text('warning'), ...base(2) },
+      { kind: 'item', itemId: 'send', revision: 1, body: userText('ok thanks'), ...base(3) }
+    ])
+    const items = renderJournalState(state).items
+    expect(items.map((item) => item.itemId)).toEqual(['send', 'frame'])
+    expect(items.map((item) => item.observedAt)).toEqual([base(1).ts, base(2).ts])
+    // The revision still lands — only its ordering keys are ignored.
+    expect(items[0]?.revision).toBe(1)
+  })
+
   it('never collapses two items that carry identical text', () => {
     const state = fold([
       { kind: 'item', itemId: 'a', revision: 1, body: text('run the tests'), ...base(1) },

--- a/src/main/native-chat/agent-session-journal/journal-reducer.ts
+++ b/src/main/native-chat/agent-session-journal/journal-reducer.ts
@@ -146,7 +146,11 @@ function upsertItem(
     return
   }
   // Creation sequence is the ordering key; a revision refreshes content only.
-  state.items.set(itemId, { ...next, sequence: existing.sequence })
+  // `observedAt` is pinned with it: clients sort the timeline by that timestamp,
+  // so letting a revision advance it makes the row jump past everything that
+  // landed in between — the provider's own echo of a send revises the submission
+  // row, which relocated the user's bubble below later rows.
+  state.items.set(itemId, { ...next, sequence: existing.sequence, observedAt: existing.observedAt })
   state.tombstones.delete(itemId)
 }
 

--- a/src/main/native-chat/agent-session-wire/provider-frame-disposition.test.ts
+++ b/src/main/native-chat/agent-session-wire/provider-frame-disposition.test.ts
@@ -78,4 +78,15 @@ describe('provider frame classification catalog', () => {
     )
     expect(classifyProviderFrame('claude', 'message:future_delta', {})).toBe('stream-into-item')
   })
+
+  it('dispositions codex item-form frames, which the method catalog never matches', () => {
+    // `thread/compacted` is already chrome; its item form is the same event and
+    // must not leak `codex · item:contextCompaction` into the transcript.
+    expect(classifyProviderFrame('codex', 'item:contextCompaction', {})).toBe('status-chrome')
+    expect(classifyProviderFrame('codex', 'notification:thread/compacted', {})).toBe(
+      'status-chrome'
+    )
+    // An item type nobody has dispositioned still falls through visibly.
+    expect(classifyProviderFrame('codex', 'item:futureThing', {})).toBe('timeline-substantive')
+  })
 })

--- a/src/main/native-chat/agent-session-wire/provider-frame-disposition.ts
+++ b/src/main/native-chat/agent-session-wire/provider-frame-disposition.ts
@@ -180,8 +180,21 @@ function hasProviderError(payload: unknown): boolean {
   return false
 }
 
+/** Codex thread-item types with no typed renderer, dispositioned by hand so a
+ *  new item type cannot leak `codex · item:<type>` into the transcript. The
+ *  notification catalog above is keyed by METHOD and never matches these. */
+const CODEX_ITEM_CLASSIFICATIONS: Record<string, ProviderFrameClassification> = {
+  // The `thread/compacted` notification is already chrome; its item form is the
+  // same event and must not read as a mysterious opcode row.
+  contextCompaction: 'status-chrome'
+}
+
 function notificationKind(kind: string): string {
   return kind.startsWith('notification:') ? kind.slice('notification:'.length) : kind
+}
+
+function itemKind(kind: string): string | null {
+  return kind.startsWith('item:') ? kind.slice('item:'.length) : null
 }
 
 export function isDeltaShapedProviderFrameKind(kind: string): boolean {
@@ -193,6 +206,10 @@ function catalogClassification(
   kind: string
 ): ProviderFrameClassification | undefined {
   if (provider === 'codex') {
+    const item = itemKind(kind)
+    if (item !== null) {
+      return CODEX_ITEM_CLASSIFICATIONS[item]
+    }
     return PROVIDER_FRAME_CLASSIFICATIONS.codex[
       notificationKind(kind) as CodexAppServerNotificationMethod
     ]

--- a/src/main/native-chat/agent-session-wire/unhandled-provider-frame.test.ts
+++ b/src/main/native-chat/agent-session-wire/unhandled-provider-frame.test.ts
@@ -40,12 +40,13 @@ describe('unhandled provider frame journal fallback', () => {
     ])
   })
 
-  it('turns an unserializable payload into an explicit visible value', () => {
-    const cyclic: { self?: unknown } = {}
-    cyclic.self = cyclic
+  it('turns an unserializable message-shaped payload into an explicit visible value', () => {
+    const cyclic: { warning?: unknown } = {}
+    cyclic.warning = cyclic
 
     const item = unhandledProviderFrameJournalItem('codex', 'frame', cyclic)
 
+    expect(item?.body.text).toBe('codex · frame')
     expect(item?.body.providerFrame?.payload.head).toContain('unserializable payload')
   })
 
@@ -175,6 +176,25 @@ describe('unhandled provider frame journal fallback', () => {
     expect(row?.body.text).toBe('Your plan limit resets in 2 hours.')
     // The raw frame stays available behind the row's disclosure.
     expect(row?.body.providerFrame?.kind).toBe('notification:warning')
+  })
+
+  it('bounds a provider sentence and persists its overflow', () => {
+    const message = 'abcdefghij'
+    const row = unhandledProviderFrameJournalItem(
+      'codex',
+      'notification:warning',
+      { message },
+      {
+        inlineHeadBytes: 8,
+        maxSessionBytes: 1024,
+        maxAppendsPerWindow: 10,
+        appendWindowMs: 1000
+      }
+    )
+
+    expect(row?.body.text).toContain('abcdefgh')
+    expect(row?.body.text).toContain('[Orca: output truncated')
+    expect(row?.blobs.map((blob) => blob.payload)).toContain(message)
   })
 
   it('unwraps a nested sentence and falls back to the opcode when there is none', () => {

--- a/src/main/native-chat/agent-session-wire/unhandled-provider-frame.test.ts
+++ b/src/main/native-chat/agent-session-wire/unhandled-provider-frame.test.ts
@@ -178,7 +178,7 @@ describe('unhandled provider frame journal fallback', () => {
     expect(row?.body.providerFrame?.kind).toBe('notification:warning')
   })
 
-  it('bounds a provider sentence and persists its overflow', () => {
+  it('bounds a provider sentence inline', () => {
     const message = 'abcdefghij'
     const row = unhandledProviderFrameJournalItem(
       'codex',
@@ -194,7 +194,6 @@ describe('unhandled provider frame journal fallback', () => {
 
     expect(row?.body.text).toContain('abcdefgh')
     expect(row?.body.text).toContain('[Orca: output truncated')
-    expect(row?.blobs.map((blob) => blob.payload)).toContain(message)
   })
 
   it('unwraps a nested sentence and falls back to the opcode when there is none', () => {

--- a/src/main/native-chat/agent-session-wire/unhandled-provider-frame.test.ts
+++ b/src/main/native-chat/agent-session-wire/unhandled-provider-frame.test.ts
@@ -167,4 +167,25 @@ describe('unhandled provider frame journal fallback', () => {
     ).not.toBeNull()
     expect(unhandledProviderFrameJournalItem('claude', 'message:future/event', {})).not.toBeNull()
   })
+
+  it('leads with the provider sentence instead of naming the opcode', () => {
+    const row = unhandledProviderFrameJournalItem('codex', 'notification:warning', {
+      message: 'Your plan limit resets in 2 hours.'
+    })
+    expect(row?.body.text).toBe('Your plan limit resets in 2 hours.')
+    // The raw frame stays available behind the row's disclosure.
+    expect(row?.body.providerFrame?.kind).toBe('notification:warning')
+  })
+
+  it('unwraps a nested sentence and falls back to the opcode when there is none', () => {
+    expect(
+      unhandledProviderFrameJournalItem('codex', 'notification:warning', {
+        warning: { text: 'Sandbox is degraded.' }
+      })?.body.text
+    ).toBe('Sandbox is degraded.')
+    expect(
+      unhandledProviderFrameJournalItem('codex', 'notification:future/event', { count: 3 })?.body
+        .text
+    ).toBe('codex \u00b7 notification:future/event')
+  })
 })

--- a/src/main/native-chat/agent-session-wire/unhandled-provider-frame.ts
+++ b/src/main/native-chat/agent-session-wire/unhandled-provider-frame.ts
@@ -79,19 +79,12 @@ export function unhandledProviderFrameJournalItem(
   // one; the raw frame stays behind the row's disclosure either way.
   const message = readableMessage(payload)
   const display = message ? boundInlineText(message, limits) : null
-  const blobs = new Map<string, string>()
-  if (bounded.truncated) {
-    blobs.set(bounded.digest, serialized)
-  }
-  if (message && display?.bounded.truncated) {
-    blobs.set(display.bounded.digest, message)
-  }
   return {
     body: {
       kind: 'status',
       text: display?.text ?? `${provider} · ${kind}`,
       providerFrame: { provider, kind, payload: bounded }
     },
-    blobs: [...blobs].map(([digest, blobPayload]) => ({ digest, payload: blobPayload }))
+    blobs: bounded.truncated ? [{ digest: bounded.digest, payload: serialized }] : []
   }
 }

--- a/src/main/native-chat/agent-session-wire/unhandled-provider-frame.ts
+++ b/src/main/native-chat/agent-session-wire/unhandled-provider-frame.ts
@@ -20,6 +20,36 @@ function serializeProviderPayload(payload: unknown): string {
   }
 }
 
+/** Fields providers use for the human-facing sentence on a frame, most specific
+ *  first. Nested one level because warnings arrive wrapped as often as not. */
+const MESSAGE_KEYS = ['message', 'text', 'warning', 'detail', 'description', 'reason'] as const
+
+function readableMessage(payload: unknown): string | null {
+  if (typeof payload === 'string') {
+    return payload.trim() || null
+  }
+  if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) {
+    return null
+  }
+  const record = payload as Record<string, unknown>
+  for (const key of MESSAGE_KEYS) {
+    const value = record[key]
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value.trim()
+    }
+  }
+  for (const key of MESSAGE_KEYS) {
+    const nested = record[key]
+    if (typeof nested === 'object' && nested !== null && !Array.isArray(nested)) {
+      const inner = readableMessage(nested)
+      if (inner) {
+        return inner
+      }
+    }
+  }
+  return null
+}
+
 /** Substantive adapter fallbacks become visible, bounded journal rows. */
 export function unhandledProviderFrameJournalItem(
   provider: string,
@@ -37,10 +67,14 @@ export function unhandledProviderFrameJournalItem(
   }
   const serialized = serializeProviderPayload(payload)
   const bounded = boundPayload(serialized, limits)
+  // Why: the opcode alone ("codex · notification:warning") tells the user nothing
+  // and reads as protocol noise. Lead with the provider's own sentence when it has
+  // one; the raw frame stays behind the row's disclosure either way.
+  const message = readableMessage(payload)
   return {
     body: {
       kind: 'status',
-      text: `${provider} · ${kind}`,
+      text: message ?? `${provider} · ${kind}`,
       providerFrame: { provider, kind, payload: bounded }
     },
     blobs: bounded.truncated ? [{ digest: bounded.digest, payload: serialized }] : []

--- a/src/main/native-chat/agent-session-wire/unhandled-provider-frame.ts
+++ b/src/main/native-chat/agent-session-wire/unhandled-provider-frame.ts
@@ -1,5 +1,6 @@
 import type { AgentJournalStatusItem } from '../../../shared/agent-session-journal-types'
 import {
+  boundInlineText,
   boundPayload,
   DEFAULT_JOURNAL_PAYLOAD_LIMITS,
   type JournalPayloadLimits
@@ -24,7 +25,7 @@ function serializeProviderPayload(payload: unknown): string {
  *  first. Nested one level because warnings arrive wrapped as often as not. */
 const MESSAGE_KEYS = ['message', 'text', 'warning', 'detail', 'description', 'reason'] as const
 
-function readableMessage(payload: unknown): string | null {
+function directReadableMessage(payload: unknown): string | null {
   if (typeof payload === 'string') {
     return payload.trim() || null
   }
@@ -38,13 +39,19 @@ function readableMessage(payload: unknown): string | null {
       return value.trim()
     }
   }
+  return null
+}
+
+function readableMessage(payload: unknown): string | null {
+  const direct = directReadableMessage(payload)
+  if (direct || typeof payload !== 'object' || payload === null || Array.isArray(payload)) {
+    return direct
+  }
+  const record = payload as Record<string, unknown>
   for (const key of MESSAGE_KEYS) {
-    const nested = record[key]
-    if (typeof nested === 'object' && nested !== null && !Array.isArray(nested)) {
-      const inner = readableMessage(nested)
-      if (inner) {
-        return inner
-      }
+    const nested = directReadableMessage(record[key])
+    if (nested) {
+      return nested
     }
   }
   return null
@@ -71,12 +78,20 @@ export function unhandledProviderFrameJournalItem(
   // and reads as protocol noise. Lead with the provider's own sentence when it has
   // one; the raw frame stays behind the row's disclosure either way.
   const message = readableMessage(payload)
+  const display = message ? boundInlineText(message, limits) : null
+  const blobs = new Map<string, string>()
+  if (bounded.truncated) {
+    blobs.set(bounded.digest, serialized)
+  }
+  if (message && display?.bounded.truncated) {
+    blobs.set(display.bounded.digest, message)
+  }
   return {
     body: {
       kind: 'status',
-      text: message ?? `${provider} · ${kind}`,
+      text: display?.text ?? `${provider} · ${kind}`,
       providerFrame: { provider, kind, payload: bounded }
     },
-    blobs: bounded.truncated ? [{ digest: bounded.digest, payload: serialized }] : []
+    blobs: [...blobs].map(([digest, blobPayload]) => ({ digest, payload: blobPayload }))
   }
 }

--- a/src/renderer/src/components/native-chat/NativeChatMessageList.provider-frame.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.provider-frame.test.tsx
@@ -34,4 +34,23 @@ describe('ProviderFrameRow', () => {
     expect(screen.getByText('notification:new/event')).toBeInTheDocument()
     expect(screen.getByText('{"future":true}')).toBeInTheDocument()
   })
+
+  it('leads with the provider sentence instead of the raw frame kind', () => {
+    render(
+      <ProviderFrameRow
+        block={{
+          type: 'text',
+          text: 'Your plan limit resets in 2 hours.',
+          providerFrame: {
+            provider: 'codex',
+            kind: 'notification:warning',
+            payload: { head: '{}', byteLength: 2, digest: 'digest', truncated: false }
+          }
+        }}
+      />
+    )
+
+    expect(screen.getByText('Your plan limit resets in 2 hours.')).toBeInTheDocument()
+    expect(screen.queryByText('notification:warning')).not.toBeInTheDocument()
+  })
 })

--- a/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
@@ -20,6 +20,7 @@ import { isNativeChatPastedImagePath } from './native-chat-image-paste'
 import { NativeChatToolRun } from './NativeChatToolRun'
 import { NativeChatCopyButton } from './NativeChatCopyButton'
 import { shouldShowNativeChatTypingIndicator } from './native-chat-typing-indicator'
+import { nativeChatProviderFrameSummary } from '../../../../shared/native-chat-provider-frame-summary'
 
 function geometryOf(el: HTMLElement): ScrollGeometry {
   return { scrollTop: el.scrollTop, scrollHeight: el.scrollHeight, clientHeight: el.clientHeight }
@@ -129,7 +130,7 @@ export function ProviderFrameRow({ block }: { block: NativeChatBlock }): React.J
       <summary className="flex cursor-pointer list-none items-center gap-2 rounded-md px-2 py-1 font-mono hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
         <span className="transition-transform group-open:rotate-90">›</span>
         <span className="font-medium text-foreground">{frame.provider}</span>
-        <span className="truncate">{frame.kind}</span>
+        <span className="truncate">{nativeChatProviderFrameSummary(block)}</span>
         {frame.payload.truncated ? (
           <span>
             ·{' '}

--- a/src/shared/native-chat-provider-frame-summary.ts
+++ b/src/shared/native-chat-provider-frame-summary.ts
@@ -1,0 +1,11 @@
+import type { NativeChatBlock } from './native-chat-types'
+
+type ProviderFrameTextBlock = Extract<NativeChatBlock, { type: 'text' }>
+
+export function nativeChatProviderFrameSummary(block: ProviderFrameTextBlock): string {
+  const frame = block.providerFrame
+  if (!frame) {
+    return block.text
+  }
+  return block.text === `${frame.provider} · ${frame.kind}` ? frame.kind : block.text
+}


### PR DESCRIPTION
Stacked on #14963 (which is stacked on #14600). Device-reported: two rows appeared *after* a send, then relocated *above* it once Codex replied — plus "what are those and should we be showing them?"

## The reordering

The journal is explicit that **sequence is the sole ordering key**, and `upsertItem` deliberately pins `sequence` across revisions ("a revision refreshes content only"). But it let `observedAt` advance to the revising row's timestamp — and the desktop list throws sequence away and re-sorts by `timestamp` then `id` (`orderNativeChatMessages` → `compareMessages`).

The chain, which matches the report exactly:

1. Send lands. Submission WAL row → item `orca:<clientMessageId>`, `observedAt = T1`.
2. Codex emits `item:contextCompaction` and `notification:warning` at `T2 > T1` → they render **below** the bubble. ✓ "they did show up after"
3. Codex echoes the user turn as its own item at `T3 > T2`. `resolveJournalItemId` aliases it onto the submission key, `upsertItem` bumps the revision — and `observedAt` becomes `T3`.
4. The list re-sorts: the bubble is now the newest row and drops below both frames. ✓ "after codex responded, they got moved to before"

Fix: pin `observedAt` alongside `sequence`. It is read in exactly one place — `structured-agent-session-projection.ts` maps it to the message `timestamp` — so this makes "when the row entered the transcript" stable, which is what both clients already assume.

## What those two rows were

Both are the no-silent-drop fallback for frames with no typed renderer, which prints `provider · kind`:

- **`item:contextCompaction`** — Codex compacted its context. It leaked because `classifyProviderFrame` looks its kind up in a catalog keyed by notification **method**; `item:<type>` kinds never match, so it defaulted to `timeline-substantive`. Note the catalog already classifies the `thread/compacted` *notification* as `status-chrome` — the item form is the same event, so this was an inconsistency, not a decision. Codex item types now get their own disposition table and compaction is chrome. Undispositioned item types still fall through visibly, so a new provider release can't go invisible.
- **`notification:warning`** — genuinely classified `error-surface`, i.e. deliberately visible. The problem was that the row named the opcode and hid the actual warning text inside the collapsible payload. The fallback now leads with the provider's own sentence (`message` / `text` / `warning` / `detail` / `description` / `reason`, incl. one nesting level) and keeps the raw frame behind the disclosure.

## Scope note

I did **not** touch `item:webSearch`. An existing test pins it as a visible provider frame, so its rendering is a deliberate decision to revisit separately (it's already on the "richer typed rendering" backlog) rather than something to change under a bug fix.

## Verification

- All four new tests mutation-checked: reverting the three source changes turns them red, restoring turns them green.
- `src/main/native-chat` + `src/main/codex` + renderer `native-chat`: 222 files / 2484 tests pass.
- `mobile/src/session`: 144 files / 1186 tests pass.
- `typecheck:node`, `typecheck:web`, `typecheck:cli` clean. oxfmt + oxlint clean.
