### PR TITLE
fix(test): run the login-shell probe against a shell the machine has

### DIFF
--- a/src/main/startup/login-shell-environment.test.ts
+++ b/src/main/startup/login-shell-environment.test.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs'
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -12,6 +13,19 @@ const originalZdotdir = process.env.ZDOTDIR
 const SHELL_ONLY_VARIABLE = 'ORCA_TEST_LOGIN_SHELL_ONLY'
 const originalShellOnlyValue = process.env[SHELL_ONLY_VARIABLE]
 let testHome: string | null = null
+
+// Why: this case spawns a REAL login shell, so it can only run against one the
+// machine actually has. Hardcoding /bin/zsh made it fail on Linux CI, where zsh
+// is not installed — the resolver simply returned the parent env and the
+// assertion read `undefined`. Each entry pairs a shell with the profile file an
+// interactive login shell of that family sources (bash reads .bash_profile when
+// it is a login shell, never .bashrc).
+const REAL_SHELL_CANDIDATES = [
+  { path: '/bin/zsh', profileFile: '.zshenv' },
+  { path: '/bin/bash', profileFile: '.bash_profile' }
+] as const
+
+const realShell = REAL_SHELL_CANDIDATES.find((candidate) => existsSync(candidate.path)) ?? null
 
 afterEach(async () => {
   resetLoginShellEnvironmentCacheForTests()
@@ -48,17 +62,22 @@ describe('resolveLoginShellEnvironment', () => {
     ).resolves.toMatchObject({ EXAMPLE_GATEWAY_TOKEN: 'shell-exported' })
   })
 
-  it.runIf(process.platform !== 'win32')(
+  it.runIf(realShell !== null)(
     'captures a profile export missing from the parent process',
     async () => {
+      const shell = realShell!
       testHome = await mkdtemp(join(tmpdir(), 'orca-login-shell-env-'))
-      await writeFile(join(testHome, '.zshenv'), `export ${SHELL_ONLY_VARIABLE}=shell-only\n`)
+      await writeFile(
+        join(testHome, shell.profileFile),
+        `export ${SHELL_ONLY_VARIABLE}=shell-only\n`
+      )
       process.env.HOME = testHome
+      // zsh reads .zshenv from ZDOTDIR when set; harmless for the bash variant.
       process.env.ZDOTDIR = testHome
       delete process.env[SHELL_ONLY_VARIABLE]
 
       const environment = await resolveLoginShellEnvironment({
-        shellOverride: '/bin/zsh',
+        shellOverride: shell.path,
         force: true
       })
       expect(environment[SHELL_ONLY_VARIABLE]).toBe('shell-only')


### PR DESCRIPTION
Targets #14600's branch directly, because the failure predates the PRs stacked on it.

## The failure

`tests node 24 11/16` and `tests node 26 11/16` are red on every branch stacked on `brennanb2025/codex-structured-core`:

```
FAIL src/main/startup/login-shell-environment.test.ts
  > resolveLoginShellEnvironment > captures a profile export missing from the parent process
AssertionError: expected undefined to be 'shell-only'
```

The case spawns a **real** login shell and hardcodes `/bin/zsh`. The tests job runs on `ubuntu-latest` (`.github/workflows/pr.yml:254`), which has no zsh, so the spawn fails, `resolveLoginShellEnvironment` falls back to the parent environment, and the assertion reads `undefined`. It passes on macOS, which is why it was never caught locally.

Worth flagging: **#14600 itself reports no checks** (`gh pr checks 14600` → "no checks reported on the branch"), so this has been invisible on the merge candidate and only shows up on PRs stacked above it.

## The fix

Pick the first shell the machine actually has, paired with the profile file that family sources under the resolver's `-ilc` probe. A login bash reads `.bash_profile`, never `.bashrc` — verified directly:

```
.bash_profile -> 'shell-only'
.profile      -> 'shell-only'
.bashrc       -> ''
```

Linux therefore keeps real coverage through the bash candidate instead of trading the failure for a skip.

## Verification

- Passes on the zsh candidate (macOS default) and, with the candidate order flipped to force it, on the bash candidate — the branch Linux CI will take.
- Mutation-checked: pointing both candidates at a profile filename the shell does not source turns the test red, so it still proves the profile is being sourced rather than reading the parent env.
- `typecheck:node` clean; oxfmt + oxlint clean.
