### PR TITLE
docs(mobile): add Android APK install guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ Pair with your desktop app to monitor and steer your agents from your phone.
 - **iOS:** [Download on the App Store](https://apps.apple.com/us/app/orca-ide/id6766130217) or [join TestFlight](https://testflight.apple.com/join/YjeGMQBA)
 - **Android:** [Download APK 0.0.43](https://github.com/stablyai/orca/releases/download/mobile-android-v0.0.43/app-release.apk)
 
+If the APK download stalls or the installer does not open, open the link in Chrome or another full browser and follow the [Android APK install guide](https://www.onorca.dev/docs/android-apk).
+
 ---
 
 ## Community &amp; Support

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Pair with your desktop app to monitor and steer your agents from your phone.
 - **iOS:** [Download on the App Store](https://apps.apple.com/us/app/orca-ide/id6766130217) or [join TestFlight](https://testflight.apple.com/join/YjeGMQBA)
 - **Android:** [Download APK 0.0.43](https://github.com/stablyai/orca/releases/download/mobile-android-v0.0.43/app-release.apk)
 
-If the APK download stalls or the installer does not open, open the link in Chrome or another full browser and follow the [Android APK install guide](https://www.onorca.dev/docs/android-apk).
+To install Orca Mobile on Android, open the APK link in Chrome or another full browser and follow the [Android install guide](https://www.onorca.dev/docs/android-apk).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -230,9 +230,7 @@ yay -S stably-orca-bin
 Pair with your desktop app to monitor and steer your agents from your phone.
 
 - **iOS:** [Download on the App Store](https://apps.apple.com/us/app/orca-ide/id6766130217) or [join TestFlight](https://testflight.apple.com/join/YjeGMQBA)
-- **Android:** [Download APK 0.0.43](https://github.com/stablyai/orca/releases/download/mobile-android-v0.0.43/app-release.apk)
-
-To install Orca Mobile on Android, open the APK link in Chrome or another full browser and follow the [Android install guide](https://www.onorca.dev/docs/android-apk).
+- **Android:** [Download APK 0.0.43](https://github.com/stablyai/orca/releases/download/mobile-android-v0.0.43/app-release.apk) · [Install guide](https://www.onorca.dev/docs/android-apk)
 
 ---
 

--- a/src/renderer/src/components/mobile/MobileAndroidInstallHelp.tsx
+++ b/src/renderer/src/components/mobile/MobileAndroidInstallHelp.tsx
@@ -1,0 +1,43 @@
+import { translate } from '@/i18n/i18n'
+
+type MobileAndroidInstallHelpProps = {
+  onOpenGuide: () => void
+}
+
+export function MobileAndroidInstallHelp({
+  onOpenGuide
+}: MobileAndroidInstallHelpProps): React.JSX.Element {
+  return (
+    <div className="mt-4 rounded-lg border border-border bg-muted/30 p-3">
+      <p className="text-xs font-medium text-foreground">
+        {translate('auto.components.mobile.MobileHero.androidHelp.title', 'APK trouble?')}
+      </p>
+      <ul className="mt-1.5 list-disc space-y-1 pl-4 text-xs leading-relaxed text-muted-foreground">
+        <li>
+          {translate(
+            'auto.components.mobile.MobileHero.androidHelp.fullBrowser',
+            'Open the link in a full browser, not an in-app browser.'
+          )}
+        </li>
+        <li>
+          {translate(
+            'auto.components.mobile.MobileHero.androidHelp.downloads',
+            'Open app-release.apk from Downloads and allow only the app opening it to install unknown apps.'
+          )}
+        </li>
+        <li>
+          {translate(
+            'auto.components.mobile.MobileHero.androidHelp.samsung',
+            'On Samsung, temporarily turn off Auto Blocker, then turn it back on after installing.'
+          )}
+        </li>
+      </ul>
+      <button type="button" className="mp-text-link mt-2" onClick={onOpenGuide}>
+        {translate(
+          'auto.components.mobile.MobileHero.androidHelp.guide',
+          'Full Android install guide'
+        )}
+      </button>
+    </div>
+  )
+}

--- a/src/renderer/src/components/mobile/MobileAndroidInstallHelp.tsx
+++ b/src/renderer/src/components/mobile/MobileAndroidInstallHelp.tsx
@@ -1,3 +1,5 @@
+import { ExternalLink } from 'lucide-react'
+import { Button } from '@/components/ui/button'
 import { translate } from '@/i18n/i18n'
 
 type MobileAndroidInstallHelpProps = {
@@ -8,36 +10,15 @@ export function MobileAndroidInstallHelp({
   onOpenGuide
 }: MobileAndroidInstallHelpProps): React.JSX.Element {
   return (
-    <div className="mt-4 rounded-lg border border-border bg-muted/30 p-3">
-      <p className="text-xs font-medium text-foreground">
-        {translate('auto.components.mobile.MobileHero.androidHelp.title', 'APK trouble?')}
-      </p>
-      <ul className="mt-1.5 list-disc space-y-1 pl-4 text-xs leading-relaxed text-muted-foreground">
-        <li>
-          {translate(
-            'auto.components.mobile.MobileHero.androidHelp.fullBrowser',
-            'Open the link in a full browser, not an in-app browser.'
-          )}
-        </li>
-        <li>
-          {translate(
-            'auto.components.mobile.MobileHero.androidHelp.downloads',
-            'Open app-release.apk from Downloads and allow only the app opening it to install unknown apps.'
-          )}
-        </li>
-        <li>
-          {translate(
-            'auto.components.mobile.MobileHero.androidHelp.samsung',
-            'On Samsung, temporarily turn off Auto Blocker, then turn it back on after installing.'
-          )}
-        </li>
-      </ul>
-      <button type="button" className="mp-text-link mt-2" onClick={onOpenGuide}>
-        {translate(
-          'auto.components.mobile.MobileHero.androidHelp.guide',
-          'Full Android install guide'
-        )}
-      </button>
-    </div>
+    <Button
+      type="button"
+      variant="link"
+      size="xs"
+      className="mt-2 h-6 px-0 text-xs text-muted-foreground hover:text-foreground"
+      onClick={onOpenGuide}
+    >
+      {translate('auto.components.mobile.MobileHero.androidHelp.guide', 'Install guide')}
+      <ExternalLink className="size-3" />
+    </Button>
   )
 }

--- a/src/renderer/src/components/mobile/MobileHero.test.tsx
+++ b/src/renderer/src/components/mobile/MobileHero.test.tsx
@@ -72,6 +72,7 @@ describe('HeroFlow height', () => {
         installCopy={{ ctaLabel: 'Open TestFlight', url: 'https://example.com' }}
         iosChannel="preview"
         onIosChannelChange={vi.fn()}
+        onOpenAndroidInstallGuide={vi.fn()}
         onOpenInstallUrl={vi.fn()}
         onCopyInstallUrl={vi.fn()}
         pairQrDataUrl={null}
@@ -119,6 +120,7 @@ describe('HeroFlow height', () => {
         installCopy={{ ctaLabel: 'Open TestFlight', url: 'https://example.com' }}
         iosChannel="preview"
         onIosChannelChange={vi.fn()}
+        onOpenAndroidInstallGuide={vi.fn()}
         onOpenInstallUrl={vi.fn()}
         onCopyInstallUrl={vi.fn()}
         pairQrDataUrl={null}
@@ -151,6 +153,21 @@ describe('HeroFlow height', () => {
 
     expect(viewport).toHaveStyle({ height: '520px' })
     expect(screen.getByText('Step 1 of 2').closest('.mp-flow-screen')).toHaveAttribute('inert')
+  })
+
+  it('shows focused APK help on Android and opens the full guide', async () => {
+    const user = userEvent.setup()
+    const onOpenAndroidInstallGuide = vi.fn()
+    renderFlow(0, {
+      platform: 'android',
+      installCopy: { ctaLabel: 'Download APK', url: 'https://example.com/app-release.apk' },
+      onOpenAndroidInstallGuide
+    })
+
+    expect(screen.getByText('APK trouble?')).toBeInTheDocument()
+    expect(screen.getByText(/full browser, not an in-app browser/)).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Full Android install guide' }))
+    expect(onOpenAndroidInstallGuide).toHaveBeenCalledOnce()
   })
 
   it('shows Relay mint failure with no QR and the beta note', () => {

--- a/src/renderer/src/components/mobile/MobileHero.test.tsx
+++ b/src/renderer/src/components/mobile/MobileHero.test.tsx
@@ -155,7 +155,7 @@ describe('HeroFlow height', () => {
     expect(screen.getByText('Step 1 of 2').closest('.mp-flow-screen')).toHaveAttribute('inert')
   })
 
-  it('shows focused APK help on Android and opens the full guide', async () => {
+  it('opens the APK install guide without duplicating its troubleshooting steps', async () => {
     const user = userEvent.setup()
     const onOpenAndroidInstallGuide = vi.fn()
     renderFlow(0, {
@@ -164,9 +164,8 @@ describe('HeroFlow height', () => {
       onOpenAndroidInstallGuide
     })
 
-    expect(screen.getByText('APK trouble?')).toBeInTheDocument()
-    expect(screen.getByText(/full browser, not an in-app browser/)).toBeInTheDocument()
-    await user.click(screen.getByRole('button', { name: 'Full Android install guide' }))
+    expect(screen.queryByText(/full browser, not an in-app browser/)).not.toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Install guide' }))
     expect(onOpenAndroidInstallGuide).toHaveBeenCalledOnce()
   })
 

--- a/src/renderer/src/components/mobile/MobileHero.tsx
+++ b/src/renderer/src/components/mobile/MobileHero.tsx
@@ -7,6 +7,7 @@ import { getChannelTagline, type InstallCopy, type IosChannel } from './mobile-p
 import type { MobilePairingConnectionMode } from '../../../../shared/mobile-pairing-connection-mode'
 import type { MobileRelayMintFailure } from '../../../../shared/mobile-relay-mint-failure'
 import { MobileHeroPairingStep } from './MobileHeroPairingStep'
+import { MobileAndroidInstallHelp } from './MobileAndroidInstallHelp'
 export { HeroIntro } from './MobileHeroIntro'
 export { HeroPaired, type PairedDevice } from './MobileHeroPairedDevices'
 import { translate } from '@/i18n/i18n'
@@ -22,6 +23,7 @@ type HeroFlowProps = {
   installCopy: InstallCopy
   iosChannel: IosChannel
   onIosChannelChange: (next: IosChannel) => void
+  onOpenAndroidInstallGuide: () => void
   onOpenInstallUrl: () => void
   onCopyInstallUrl: () => void
   pairQrDataUrl: string | null
@@ -60,6 +62,7 @@ export function HeroFlow({
   installCopy,
   iosChannel,
   onIosChannelChange,
+  onOpenAndroidInstallGuide,
   onOpenInstallUrl,
   onCopyInstallUrl,
   pairQrDataUrl,
@@ -200,6 +203,9 @@ export function HeroFlow({
                   {translate('auto.components.mobile.MobileHero.aa97420ba4', 'Copy install link')}
                 </button>
               </div>
+              {platform === 'android' ? (
+                <MobileAndroidInstallHelp onOpenGuide={onOpenAndroidInstallGuide} />
+              ) : null}
             </div>
             <div className="mp-qr mp-qr-large">
               {installQrUrl ? (

--- a/src/renderer/src/components/mobile/MobilePage.test.tsx
+++ b/src/renderer/src/components/mobile/MobilePage.test.tsx
@@ -62,6 +62,7 @@ vi.mock('./MobilePageContent', () => ({
     onRetryRelay: () => void
     selectedAddress: string | undefined
     loadNetworkInterfaces: () => void
+    openAndroidInstallGuide: () => void
     refreshingNetworkInterfaces: boolean
     stage: string | null
     stepIdx: number
@@ -99,6 +100,9 @@ vi.mock('./MobilePageContent', () => ({
       </button>
       <button type="button" onClick={props.loadNetworkInterfaces}>
         Refresh addresses
+      </button>
+      <button type="button" onClick={props.openAndroidInstallGuide}>
+        Open Android install guide
       </button>
       <button
         type="button"
@@ -164,6 +168,15 @@ describe('MobilePage pairing connection mode', () => {
     await user.click(screen.getByRole('button', { name: 'Enter flow' }))
     await user.click(screen.getByRole('button', { name: 'Continue' }))
   }
+
+  it('opens Android troubleshooting in the system browser', async () => {
+    const user = userEvent.setup()
+    render(<MobilePage />)
+
+    await user.click(screen.getByRole('button', { name: 'Open Android install guide' }))
+
+    expect(window.api.shell.openUrl).toHaveBeenCalledWith('https://www.onorca.dev/docs/android-apk')
+  })
 
   it('defaults signed-in pairing to Anywhere and remints when same-network is selected', async () => {
     const user = userEvent.setup()

--- a/src/renderer/src/components/mobile/MobilePage.tsx
+++ b/src/renderer/src/components/mobile/MobilePage.tsx
@@ -75,7 +75,10 @@ export default function MobilePage(): React.JSX.Element {
     stage
   } = useMobilePagePairedDevices({ stepIdx, setStepIdx })
   const installQrUrl = useMobileInstallQr(stage, platform, iosChannel)
-  const { copyInstallUrl, openInstallUrl } = useMobileInstallActions(platform, iosChannel)
+  const { copyInstallUrl, openAndroidInstallGuide, openInstallUrl } = useMobileInstallActions(
+    platform,
+    iosChannel
+  )
 
   const { generatePairing } = useMobilePairingGeneration({
     connectionMode,
@@ -322,6 +325,7 @@ export default function MobilePage(): React.JSX.Element {
       setIosChannel={setIosChannel}
       loadNetworkInterfaces={() => void loadNetworkInterfaces()}
       networkInterfaces={networkInterfaces}
+      openAndroidInstallGuide={openAndroidInstallGuide}
       openInstallUrl={openInstallUrl}
       pairAnotherDevice={pairAnotherDevice}
       pairLoading={pairLoading}

--- a/src/renderer/src/components/mobile/MobilePageContent.tsx
+++ b/src/renderer/src/components/mobile/MobilePageContent.tsx
@@ -36,6 +36,7 @@ type MobilePageContentProps = {
   setIosChannel: (channel: IosChannel) => void
   loadNetworkInterfaces: () => void
   networkInterfaces: MobileNetworkInterface[]
+  openAndroidInstallGuide: () => void
   openInstallUrl: () => void
   pairAnotherDevice: () => void
   pairLoading: boolean
@@ -82,6 +83,7 @@ export function MobilePageContent({
   setIosChannel,
   loadNetworkInterfaces,
   networkInterfaces,
+  openAndroidInstallGuide,
   openInstallUrl,
   pairAnotherDevice,
   pairLoading,
@@ -133,6 +135,7 @@ export function MobilePageContent({
               installCopy={getInstallCopy(platform, iosChannel)}
               iosChannel={iosChannel}
               onIosChannelChange={setIosChannel}
+              onOpenAndroidInstallGuide={openAndroidInstallGuide}
               onOpenInstallUrl={openInstallUrl}
               onCopyInstallUrl={copyInstallUrl}
               pairQrDataUrl={pairQrDataUrl}

--- a/src/renderer/src/components/mobile/mobile-platform-copy.ts
+++ b/src/renderer/src/components/mobile/mobile-platform-copy.ts
@@ -7,6 +7,8 @@ export type IosChannel = 'stable' | 'preview'
 
 export type InstallCopy = { ctaLabel: string; url: string }
 
+export const ANDROID_INSTALL_GUIDE_URL = 'https://www.onorca.dev/docs/android-apk'
+
 const IOS_CHANNEL_COPY: Record<IosChannel, InstallCopy> = {
   stable: {
     ctaLabel: 'Open App Store',

--- a/src/renderer/src/components/mobile/use-mobile-install-actions.ts
+++ b/src/renderer/src/components/mobile/use-mobile-install-actions.ts
@@ -3,17 +3,25 @@ import { toast } from 'sonner'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import { translate } from '@/i18n/i18n'
 import type { Platform } from './MobileHero'
-import { getInstallCopy, type IosChannel } from './mobile-platform-copy'
+import { ANDROID_INSTALL_GUIDE_URL, getInstallCopy, type IosChannel } from './mobile-platform-copy'
 
 export function useMobileInstallActions(
   platform: Platform,
   iosChannel: IosChannel
-): { copyInstallUrl: () => Promise<void>; openInstallUrl: () => void } {
+): {
+  copyInstallUrl: () => Promise<void>
+  openAndroidInstallGuide: () => void
+  openInstallUrl: () => void
+} {
   const mountedRef = useMountedRef()
 
   const openInstallUrl = useCallback((): void => {
     void window.api.shell.openUrl(getInstallCopy(platform, iosChannel).url)
   }, [iosChannel, platform])
+
+  const openAndroidInstallGuide = useCallback((): void => {
+    void window.api.shell.openUrl(ANDROID_INSTALL_GUIDE_URL)
+  }, [])
 
   const copyInstallUrl = useCallback(async (): Promise<void> => {
     try {
@@ -33,5 +41,5 @@ export function useMobileInstallActions(
     }
   }, [iosChannel, mountedRef, platform])
 
-  return { copyInstallUrl, openInstallUrl }
+  return { copyInstallUrl, openAndroidInstallGuide, openInstallUrl }
 }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -13085,7 +13085,14 @@
           "pairThisPc": "Pair this PC.",
           "pairThisComputer": "Pair this computer.",
           "directAddressDisclosure": "Also use a faster local path",
-          "directAddressHint": "Optional. Pick the Wi‑Fi or Tailscale address your phone should use when nearby — usually faster than Relay. Relay still works when you’re away."
+          "directAddressHint": "Optional. Pick the Wi‑Fi or Tailscale address your phone should use when nearby — usually faster than Relay. Relay still works when you’re away.",
+          "androidHelp": {
+            "title": "APK trouble?",
+            "fullBrowser": "Open the link in a full browser, not an in-app browser.",
+            "downloads": "Open app-release.apk from Downloads and allow only the app opening it to install unknown apps.",
+            "samsung": "On Samsung, temporarily turn off Auto Blocker, then turn it back on after installing.",
+            "guide": "Full Android install guide"
+          }
         },
         "MobilePage": {
           "e17393c6a3": "Phone preview",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -13087,11 +13087,7 @@
           "directAddressDisclosure": "Also use a faster local path",
           "directAddressHint": "Optional. Pick the Wi‑Fi or Tailscale address your phone should use when nearby — usually faster than Relay. Relay still works when you’re away.",
           "androidHelp": {
-            "title": "APK trouble?",
-            "fullBrowser": "Open the link in a full browser, not an in-app browser.",
-            "downloads": "Open app-release.apk from Downloads and allow only the app opening it to install unknown apps.",
-            "samsung": "On Samsung, temporarily turn off Auto Blocker, then turn it back on after installing.",
-            "guide": "Full Android install guide"
+            "guide": "Install guide"
           }
         },
         "MobilePage": {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​29 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​29 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​56 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​50 |

<!-- /orca-pr-loc -->

## Summary

- add one troubleshooting sentence below the README Android download link
- add a compact Android-only troubleshooting section to the desktop Mobile download step
- open the canonical full guide in the system browser and cover the link/copy with focused tests

The canonical full guide is in [stablyai/orca-marketing-website#244](https://github.com/stablyai/orca-marketing-website/pull/244), because onorca.dev docs are sourced from that repository.

## Evidence

The STA-4498 screenshot is an Android Custom Tab stuck at `133.02 MB / 133.02 MB`; the current GitHub release asset is exactly 133,018,667 bytes and returns HTTP 200. The APK itself parses as Android 7.0+ and includes ARM32, ARM64, x86, and x86_64 libraries, so the reported state precedes package installation and does not indicate an Orca download-backend or ABI failure.

## Validation so far

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/mobile/MobileHero.test.tsx src/renderer/src/components/mobile/MobilePage.test.tsx` (31 tests)
- `pnpm typecheck`
- localization catalog, extraction, and coverage checks
- max-lines ratchet

Visual validation and independent review remain in progress while this PR is draft.

Closes #14827. Tracks [STA-4498](https://linear.app/stably/issue/STA-4498).