### PR TITLE
Bump mobile app.json to 0.0.44

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Orca",
     "slug": "orca-mobile",
-    "version": "0.0.43",
+    "version": "0.0.44",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",
@@ -75,7 +75,7 @@
       "allowBackup": false,
       "permissions": ["RECORD_AUDIO", "MODIFY_AUDIO_SETTINGS"],
       "package": "com.stably.orca.mobile",
-      "versionCode": 12
+      "versionCode": 13
     },
     "plugins": [
       "expo-router",


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | 0 |

<!-- /orca-pr-loc -->

## Summary
- Bump `mobile/app.json` `expo.version` to **0.0.44** so the repo matches the next iOS/Android release.
- Bump `expo.android.versionCode` 12 → **13**. `prepare-android-release.mjs` refuses to change versionCode at release time; Android rejects APK upgrades that keep the shipped 0.0.43 code 12.
- Leave `expo.ios.buildNumber` to CI (next TestFlight build for this train).

Both platforms shipped **0.0.43** from `cbca291aa7` (iOS TestFlight via [run 31734192167](https://github.com/stablyai/orca/actions/runs/31734192167); Android [mobile-android-v0.0.43](https://github.com/stablyai/orca/releases/tag/mobile-android-v0.0.43)). This PR only prepares the marketing version. Do not push release tags until it is merged.

## Headline changes since 0.0.43
- Desktop-parity Project / Run on picker for new worktrees (#14457)
- Self-heal host opens and harden session liveness (#14333)
- Recover session tabs while a terminal is still pending-handle (#14623, #14916)

## What's New (App Store)
```
This update adds a desktop-parity Project and Run on picker for new worktrees, more reliable pairing and reconnect, and session recovery when a terminal is still starting, plus reliability fixes and more parity with the Orca desktop app.
```

## Verification
- `node -e` confirms `expo.version` is `0.0.44`, `ios.buildNumber` is still `1`, `android.versionCode` is `13`.
- No native or generated files touched; version-only change.