### PR TITLE
fix(grok): strip quotes from GROK_HOME in the Windows hook

### DIFF
--- a/src/main/grok/hook-service.test.ts
+++ b/src/main/grok/hook-service.test.ts
@@ -118,7 +118,7 @@ describe('GrokHookService', () => {
     expect(script).toContain('set "ORCA_GROK_HOME="')
     expect(script).toContain('if not defined GROK_HOME goto :orca_grok_home_ready')
     expect(script).toContain('%GROK_HOME:~4096,1%')
-    expect(script).toContain('set "ORCA_GROK_HOME=%GROK_HOME%"')
+    expect(script).toContain('set "ORCA_GROK_HOME=%GROK_HOME:"=%"')
     expect(script).toContain('%ORCA_GROK_HOME:~4096,1%')
     expect(script).toContain(':orca_grok_home_ready')
     expect(script).toContain('if not defined ORCA_GROK_HOME goto :orca_grok_home_ready')
@@ -269,7 +269,7 @@ describe('GrokHookService', () => {
       expect(script).toContain('%SystemRoot%\\System32\\curl.exe')
       // Why: windows-grok-hook-script.test.ts pins the GROK_HOME guard shape itself,
       // and does so on every platform rather than only on Windows runners.
-      expect(script).toContain('set "ORCA_GROK_HOME=%GROK_HOME%"')
+      expect(script).toContain('set "ORCA_GROK_HOME=%GROK_HOME:"=%"')
       expect(script).toContain('--data-urlencode "grokHome=%ORCA_GROK_HOME%"')
     } else {
       // Why: payload is piped to curl via stdin (`payload@-`) so it never lands

--- a/src/main/grok/windows-grok-hook-script.test.ts
+++ b/src/main/grok/windows-grok-hook-script.test.ts
@@ -26,8 +26,9 @@ function findUnguardedSubstringReads(lines: readonly string[]): string[] {
       defined.add(guarded[1])
     }
     // A value is provably non-empty only if something outside an expansion survives:
-    // `set "V=%OTHER%"` may undefine V, `set "V=%V%."` cannot.
-    for (const [, name, value] of line.matchAll(/set "(\w+)=([^"]*)"/g)) {
+    // `set "V=%OTHER%"` may undefine V, `set "V=%V%."` cannot. The lazy value stops at
+    // the quote that closes the `set`, so a substitution like `%V:"=%` stays one token.
+    for (const [, name, value] of line.matchAll(/set "(\w+)=(.*?)"(?=\s|$)/g)) {
       if (value.replaceAll(/%[^%]*%/g, '') === '') {
         defined.delete(name)
       } else {
@@ -93,6 +94,7 @@ describe.skipIf(process.platform !== 'win32')('buildWindowsGrokHookScript (win32
     grokHome: string | null
     paneKey: string | null
     worktreeId: string | null
+    payload: string | null
   }
 
   const PANE_KEY = 'tab!1:pane!2'
@@ -149,7 +151,8 @@ describe.skipIf(process.platform !== 'win32')('buildWindowsGrokHookScript (win32
               stderr,
               grokHome: posted?.get('grokHome') ?? null,
               paneKey: posted?.get('paneKey') ?? null,
-              worktreeId: posted?.get('worktreeId') ?? null
+              worktreeId: posted?.get('worktreeId') ?? null,
+              payload: posted?.get('payload') ?? null
             })
           )
         })
@@ -186,6 +189,36 @@ describe.skipIf(process.platform !== 'win32')('buildWindowsGrokHookScript (win32
 
     expect(result.status).toBe(0)
     expect(result.grokHome).toBe('C:\\Users\\test\\.grok\\.')
+  })
+
+  // Why (#14221): `setx GROK_HOME "C:\path\"` stores `C:\path"` — the CRT turns the
+  // `\"` into a literal quote. That quote unbalanced the trailing-backslash `if`, so
+  // cmd aborted the whole script before curl and every Grok hook event failed.
+  it('exits 0 and strips a trailing quote from GROK_HOME', async () => {
+    const result = await runHook('C:\\Users\\test\\.grok"')
+
+    expect(result.stderr).not.toContain('unexpected at this time')
+    expect(result.status).toBe(0)
+    expect(result.grokHome).toBe('C:\\Users\\test\\.grok')
+    expect(result.payload).toBe('{"session_id":"s"}')
+  })
+
+  // Why: an embedded quote closed curl's `grokHome=` argument early, which swallowed
+  // the `^` continuation and dropped the `payload@-` line — a silent, exit-0 failure.
+  it('strips an embedded quote without truncating the curl arguments', async () => {
+    const result = await runHook('C:\\Users\\a"b\\.grok')
+
+    expect(result.status).toBe(0)
+    expect(result.grokHome).toBe('C:\\Users\\ab\\.grok')
+    expect(result.payload).toBe('{"session_id":"s"}')
+  })
+
+  it('posts an empty grokHome when GROK_HOME is only a quote', async () => {
+    const result = await runHook('"')
+
+    expect(result.status).toBe(0)
+    expect(result.grokHome).toBe('')
+    expect(result.payload).toBe('{"session_id":"s"}')
   })
 
   it('drops a GROK_HOME past the envelope limit', async () => {

--- a/src/main/grok/windows-grok-hook-script.ts
+++ b/src/main/grok/windows-grok-hook-script.ts
@@ -21,6 +21,7 @@ const WINDOWS_GROK_HOOK_POST_COMMAND = buildWindowsAgentHookPostCommand('grok', 
  *
  * - Guard substring ops behind `if defined` + goto (not a parenthesized block).
  * - Reject oversized values before copying them onto a cmd input line.
+ * - Strip `"` before the value reaches an `if` operand or the curl argument.
  */
 export function buildWindowsGrokHookScript(): string {
   return [
@@ -35,7 +36,10 @@ export function buildWindowsGrokHookScript(): string {
     'set "ORCA_GROK_HOME="',
     'if not defined GROK_HOME goto :orca_grok_home_ready',
     `if not "%GROK_HOME:~${GROK_HOME_ENVELOPE_MAX_LENGTH},1%"=="" goto :orca_grok_home_ready`,
-    'set "ORCA_GROK_HOME=%GROK_HOME%"',
+    // Why (#14221): `setx GROK_HOME "C:\path\"` stores a literal trailing quote, which
+    // unbalances the trailing-backslash `if` below (exit 255) and truncates the curl
+    // argument. `"` is illegal in a Windows path, so strip it rather than preserve it.
+    'set "ORCA_GROK_HOME=%GROK_HOME:"=%"',
     'if not defined ORCA_GROK_HOME goto :orca_grok_home_ready',
     'if "%ORCA_GROK_HOME:~-1%"=="\\" set "ORCA_GROK_HOME=%ORCA_GROK_HOME%."',
     // Why: the trailing-backslash safety sentinel counts toward the relay envelope.


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​38 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​33 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 |

<!-- /orca-pr-loc -->

Related to #14221, but **does not fix it** — see "What this is not" below.

## What this fixes

A literal `"` anywhere in `GROK_HOME` breaks the Windows Grok hook. Verified against real `cmd.exe`:

| `GROK_HOME` | exit | result |
|---|---|---|
| `C:\Users\me\.grok"` | **255** | never reaches curl — `=C:\Users\me\.grok".\" was unexpected at this time.` |
| `"C:\Users\me\.grok"` | **255** | never reaches curl |
| `C:\Users\a"b\.grok` | 0 | `grokHome=C:\Users\ab\.grok ^`, **`payload` silently dropped** |

The value is copied verbatim into a cmd variable and then used as an `if` operand:

```
set "ORCA_GROK_HOME=%GROK_HOME%"
if "%ORCA_GROK_HOME:~-1%"=="\" set "ORCA_GROK_HOME=%ORCA_GROK_HOME%."
```

A quote unbalances that operand and cmd aborts the script with 255 before curl. A quote in the middle is sneakier: exit 0, but it closes curl's `--data-urlencode "grokHome=..."` early, swallowing the `^` continuation and the `--data-urlencode "payload@-"` line with it — a corrupted post with no payload, at exit 0.

How a quote gets in: `setx` goes through CRT argv parsing, so a trailing backslash escapes the closing quote. Confirmed:

```
> setx GROK_HOME "C:\Users\me\.grok\"
> reg query HKCU\Environment /v GROK_HOME
    GROK_HOME    REG_SZ    C:\Users\me\.grok"
```

Grok-only because `GROK_HOME` is the only user-controlled value any managed hook script interpolates; the others use `ORCA_*` vars Orca sets itself.

## Fix

```diff
-'set "ORCA_GROK_HOME=%GROK_HOME%"',
+'set "ORCA_GROK_HOME=%GROK_HOME:"=%"',
```

`"` is illegal in a Windows path, so stripping cannot discard a usable value. The existing `if not defined` guard already covers a value that strips to empty, and the envelope check stays conservative since stripping only shortens.

## What this is not

I originally wrote this up as the fix for #14221. That was wrong, and the error text is what settles it.

#14221 reports **`The syntax of the command is incorrect.`** The quote bug never produces that string. I swept 22 quote shapes; every failure says `... was unexpected at this time.` — zero matches for the reported text.

That exact message has a different, specific fingerprint. It is produced by the **unguarded trailing-backslash line with an empty/undefined `GROK_HOME`** — i.e. the pre-#11782 script:

```
          reporter's isolated snippet (empty, unguarded)  status=255  "The syntax of the command is incorrect."   <-- MATCH
          pre-#11782 shape, GROK_HOME undefined           status=255  "The syntax of the command is incorrect."   <-- MATCH
          pre-#11782 shape, GROK_HOME empty               status=255  "The syntax of the command is incorrect."   <-- MATCH
          pre-#11782 shape, GROK_HOME trailing quote      status=255  "=C:\...\.grok\".\" was unexpected at this time."
          current shipped shape, any of the above         status=0    (posts fine)
```

So the reporter's on-disk `grok-hook.cmd` is a **pre-#11782 script**, even though #11782 shipped in v1.4.174 and they report v1.4.180. The current builder is correctly guarded and all of its win32 tests pass. **The real #14221 is that the managed script on disk was never refreshed to the fixed version** — a `refreshManagedScriptIfPresent` / install-path problem, not a script-content problem. That needs separate diagnosis and I have not done it.

This also means the reporter's diagnosis was right about their own file, and the counter-argument in the comments was right that current source is guarded but wrong to infer the user's file matches current source.

## Tests

Three cases added to the win32 suite that spawns real `cmd.exe` (trailing quote, embedded quote, quote-only). All three fail without the one-line fix and pass with it. The embedded-quote case asserts `payload` survives, since that failure was invisible at exit 0 — `payload` is now captured in the shared `runHook` helper.

The static guard's `set` matcher widened to `(.*?)"(?=\s|$)`; the old `[^"]*` stopped at the quote inside `%GROK_HOME:"=%` and would have read the new line as provably non-empty, masking a regression.

Verified unchanged across the full battery of other `GROK_HOME` shapes (`&`, `|`, `^`, `%`, `!`, parens, spaces, UNC, unicode, trailing space/backslash, oversized).

## On the AutoRun theory in the comments

Confirmed production reaches the `.cmd` through PowerShell without `/d`, so `Command Processor\AutoRun` executes there and is suppressed in every test — a real coverage gap. But it is not #14221: with a deliberately malformed `AutoRun` the hook still exited 0 and posted correctly, and `AutoRun` is agent-agnostic so it cannot explain Grok-only failure. Worth hardening separately.

## Test plan

- `npx vitest run src/main/grok` — 14 passed (win32, real `cmd.exe`)
- Reverting only the one-line fix fails exactly the three new tests
- `src/main/agent-hooks` has 4 failures on this branch, all identical on unmodified `main` (symlink privileges + a pre-existing stdin-lifecycle case)
- `tsc --noEmit -p config/tsconfig.node.json` and `oxlint` clean
