### PR TITLE
fix(mobile): reland truthful Relay recovery status

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -943,10 +943,10 @@
       "providers": ["lan", "tailscale", "cloud-relay"],
       "coveredPlatforms": ["macos"],
       "coveredProviders": ["lan", "tailscale", "cloud-relay"],
-      "coverageNotes": "Deterministic TypeScript tests cover shared close-code policy, foreground retry timers, direct-winner cancellation, and concurrent LAN/Tailscale authentication. Physical iOS/Android radios, GFE, and production relay recovery remain live-test gaps.",
+      "coverageNotes": "Deterministic TypeScript tests cover shared close-code policy, foreground retry timers, direct-winner cancellation, credential-gated Relay presentation, and concurrent LAN/Tailscale authentication. Physical iOS/Android radios, GFE, and production relay recovery remain live-test gaps.",
       "motivatingLinks": ["https://github.com/stablyai/orca-cloud/pull/96"],
-      "invariant": "A foregrounded paired phone must recover from relay HOST_OFFLINE without a foreground or network-change signal, while direct recovery must select the first authenticated configured LAN or Tailscale endpoint without serial timeout delays. Backgrounding, direct success, or stop must cancel pending work, and losing probes must close without affecting the winner.",
-      "oracle": "Inject deterministic relay close codes, random bytes, fake timers, and independently controlled direct clients. Require HOST_OFFLINE to replace any faster transport timer with one 5-15 second retry, require no retry before the selected delay, race all unique non-relay endpoints, select the first authenticated path, close every loser exactly once, and retain no retry after direct connectivity wins.",
+      "invariant": "A foregrounded paired phone must recover from relay HOST_OFFLINE without a foreground or network-change signal, while direct recovery must select the first authenticated configured LAN or Tailscale endpoint without serial timeout delays. Relay recovery presentation starts only for a failed active Relay or a dial backed by an eligible credential, and remains pending through a genuine failed-dial cooldown. Backgrounding, direct success, or stop must cancel pending work, and losing probes must close without affecting the winner.",
+      "oracle": "Inject deterministic relay close codes, missing and expired credentials, delayed credential reads, random bytes, fake timers, and independently controlled direct clients. Require HOST_OFFLINE to replace any faster transport timer with one 5-15 second retry, require no retry before the selected delay, keep Relay presentation absent when no socket can open, clear it across lifecycle races, retain it through real dial cooldowns, race all unique non-relay endpoints, select the first authenticated path, close every loser exactly once, and retain no retry after direct connectivity wins.",
       "commands": [
         "pnpm --dir mobile exec vitest run --root .. mobile/src/transport/mobile-direct-endpoint-probe.test.ts mobile/src/transport/mobile-relay-reconnect-controller.test.ts mobile/src/transport/mobile-endpoint-supervisor.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/shared/mobile-relay-close-codes.test.ts --reporter=dot"
@@ -975,7 +975,10 @@
         {
           "file": "mobile/src/transport/mobile-endpoint-supervisor.test.ts",
           "assertions": [
-            "a foregrounded supervisor retries HOST_OFFLINE without an external lifecycle signal"
+            "a foregrounded supervisor retries HOST_OFFLINE without an external lifecycle signal",
+            "a missing or expired credential never presents a Relay connection that cannot start",
+            "backgrounding during credential selection cannot publish a stale Relay recovery path",
+            "a genuine failed Relay dial remains pending through its retry cooldown"
           ]
         },
         {
@@ -985,21 +988,21 @@
       ],
       "evidenceRuns": [
         {
-          "date": "2026-07-25",
+          "date": "2026-08-16",
           "runner": "local",
           "platform": "macos",
           "command": "pnpm --dir mobile exec vitest run --root .. mobile/src/transport/mobile-direct-endpoint-probe.test.ts mobile/src/transport/mobile-relay-reconnect-controller.test.ts mobile/src/transport/mobile-endpoint-supervisor.test.ts",
           "result": "passed",
-          "durationSeconds": 0.89,
-          "summary": "Three focused mobile transport files passed with 39 assertions."
+          "durationSeconds": 1.23,
+          "summary": "Three focused mobile transport files passed with 54 assertions."
         },
         {
-          "date": "2026-07-25",
+          "date": "2026-08-16",
           "runner": "local",
           "platform": "macos",
           "command": "pnpm exec vitest run --config config/vitest.config.ts src/shared/mobile-relay-close-codes.test.ts --reporter=dot",
           "result": "passed",
-          "durationSeconds": 0.19,
+          "durationSeconds": 0.17,
           "summary": "The shared close-code contract passed with five assertions."
         }
       ],
@@ -1049,14 +1052,14 @@
       "providers": ["lan", "tailscale", "cloud-relay"],
       "coveredPlatforms": ["macos"],
       "coveredProviders": ["lan", "tailscale", "cloud-relay"],
-      "coverageNotes": "Deterministic React/provider tests cover catalog, missing-host, construction, cancellation, release, forget, refresh, backoff, and stale-generation outcomes. Direct sessions cover idle probing and three fair misses. Relay sessions cover zero idle polling, rate-limited foreground probes, two fair misses, authenticated activity before semantic decoding, delivery ambiguity, scheduler stalls, and write failure. Physical iOS/Android sleep, carrier/Tailscale loss, and production relay paths remain live-test gaps.",
+      "coverageNotes": "Deterministic React/provider tests cover catalog, missing-host, construction, cancellation, release, forget, refresh, backoff, stale-generation outcomes, and path-aware recovery presentation. Direct sessions cover idle probing and three fair misses. Relay sessions cover zero idle polling, rate-limited foreground probes, two fair misses, authenticated activity before semantic decoding, delivery ambiguity, scheduler stalls, and write failure. Physical iOS/Android sleep, carrier/Tailscale loss, and production relay paths remain live-test gaps.",
       "motivatingLinks": [
         "https://linear.app/stably/issue/STA-4153/mobile-app-disconnects-frequently"
       ],
-      "invariant": "A provider-wanted host without a logical client retries every current-generation pre-client failure until success or explicit cancellation, while release, disconnect, forget, refresh, and stale async continuations preserve their distinct resurrection policies. Direct sessions probe after authenticated silence and terminate after three fair misses. Relay sessions emit no periodic idle or demand-driven probes, use rate-limited foreground probes, and terminate after two fair misses. Authenticated traffic, scheduler stalls, and replacement identities cannot manufacture death.",
-      "oracle": "Inject rejected and never-settling catalog reads, missing profiles, synchronous construction failure, release, refresh, forget, revival, and stale completion under fake time. Require bounded 1s through 60s retry, exact current-generation publication, and no zero-owner or forgotten-client resurrection. Inject direct and relay authenticated text/binary traffic, silent probe windows, stalled clocks, replacement identities, and failed writes. Require direct three-miss tolerance; Relay zero idle and demand-driven liveness traffic, one foreground probe sequence, two fair 4s misses, a 10s voluntary rate limit, no old-session network-change probe, and delivery-unknown mutations without replay.",
+      "invariant": "A provider-wanted host without a logical client retries every current-generation pre-client failure until success or explicit cancellation, while release, disconnect, forget, refresh, and stale async continuations preserve their distinct resurrection policies. Direct sessions probe after authenticated silence and terminate after three fair misses. Relay sessions emit no periodic idle or demand-driven probes, use rate-limited foreground probes, and terminate after two fair misses. Authenticated traffic, scheduler stalls, and replacement identities cannot manufacture death. Relay recovery must notify presentation independently of transport-state changes, must not inherit a failed direct path's Tailscale hint, and must retain long-outage escalation.",
+      "oracle": "Inject rejected and never-settling catalog reads, missing profiles, synchronous construction failure, release, refresh, forget, revival, and stale completion under fake time. Require bounded 1s through 60s retry, exact current-generation publication, and no zero-owner or forgotten-client resurrection. Inject direct and relay authenticated text/binary traffic, silent probe windows, stalled clocks, replacement identities, and failed writes. Require direct three-miss tolerance; Relay zero idle and demand-driven liveness traffic, one foreground probe sequence, two fair 4s misses, a 10s voluntary rate limit, no old-session network-change probe, and delivery-unknown mutations without replay. Start and clear Relay recovery without changing transport state and require observers to rerender. Project five failed Tailscale attempts into a neutral Relay-specific verdict, then require twelve attempts to produce a Relay-specific unreachable verdict with no Tailscale hint.",
       "commands": [
-        "pnpm --dir mobile exec vitest run --root .. mobile/src/transport/client-context.test.ts mobile/src/transport/host-open-recovery.test.tsx mobile/src/transport/host-open-retry-scheduler.test.ts mobile/src/transport/rpc-session-liveness-watchdog.test.ts mobile/src/transport/rpc-session-liveness-integration.test.ts mobile/src/transport/mobile-relay-rpc-session.test.ts mobile/src/transport/mobile-relay-rpc-session-liveness.test.ts mobile/src/transport/mobile-endpoint-nudge-router.test.ts mobile/src/transport/mobile-relay-e2ee-link.test.ts mobile/src/transport/stable-logical-rpc-client.test.ts"
+        "pnpm --dir mobile exec vitest run --root .. mobile/src/transport/client-context.test.ts mobile/src/transport/host-open-recovery.test.tsx mobile/src/transport/host-open-retry-scheduler.test.ts mobile/src/transport/rpc-session-liveness-watchdog.test.ts mobile/src/transport/rpc-session-liveness-integration.test.ts mobile/src/transport/mobile-relay-rpc-session.test.ts mobile/src/transport/mobile-relay-rpc-session-liveness.test.ts mobile/src/transport/mobile-endpoint-nudge-router.test.ts mobile/src/transport/mobile-relay-e2ee-link.test.ts mobile/src/transport/stable-logical-rpc-client.test.ts mobile/src/transport/connection-health.test.ts"
       ],
       "testFiles": [
         "mobile/src/transport/client-context.test.ts",
@@ -1068,12 +1071,16 @@
         "mobile/src/transport/mobile-relay-rpc-session-liveness.test.ts",
         "mobile/src/transport/mobile-endpoint-nudge-router.test.ts",
         "mobile/src/transport/mobile-relay-e2ee-link.test.ts",
-        "mobile/src/transport/stable-logical-rpc-client.test.ts"
+        "mobile/src/transport/stable-logical-rpc-client.test.ts",
+        "mobile/src/transport/connection-health.test.ts"
       ],
       "assertionRefs": [
         {
           "file": "mobile/src/transport/client-context.test.ts",
-          "assertions": ["a retired close-on-release owner closes an ownerless manual reconnect"]
+          "assertions": [
+            "a retired close-on-release owner closes an ownerless manual reconnect",
+            "a Relay recovery path change rerenders observers without a transport-state change"
+          ]
         },
         {
           "file": "mobile/src/transport/host-open-recovery.test.tsx",
@@ -1124,18 +1131,29 @@
         },
         {
           "file": "mobile/src/transport/stable-logical-rpc-client.test.ts",
-          "assertions": ["a delivery-unknown mutation is not replayed onto a replacement Relay"]
+          "assertions": [
+            "a delivery-unknown mutation is not replayed onto a replacement Relay",
+            "Relay recovery path changes publish and remain pending between failed dials",
+            "a connected path clears recovery state before any later disconnect"
+          ]
+        },
+        {
+          "file": "mobile/src/transport/connection-health.test.ts",
+          "assertions": [
+            "a Relay fallback pending over five failed Tailscale attempts remains neutral and omits the Tailscale hint",
+            "a prolonged Relay recovery escalates without reviving the Tailscale hint"
+          ]
         }
       ],
       "evidenceRuns": [
         {
-          "date": "2026-08-14",
+          "date": "2026-08-16",
           "runner": "local",
           "platform": "macos",
-          "command": "pnpm --dir mobile exec vitest run --root .. mobile/src/transport/client-context.test.ts mobile/src/transport/host-open-recovery.test.tsx mobile/src/transport/host-open-retry-scheduler.test.ts mobile/src/transport/rpc-session-liveness-watchdog.test.ts mobile/src/transport/rpc-session-liveness-integration.test.ts mobile/src/transport/mobile-relay-rpc-session.test.ts mobile/src/transport/mobile-relay-rpc-session-liveness.test.ts mobile/src/transport/mobile-endpoint-nudge-router.test.ts mobile/src/transport/mobile-relay-e2ee-link.test.ts mobile/src/transport/stable-logical-rpc-client.test.ts",
+          "command": "pnpm --dir mobile exec vitest run --root .. mobile/src/transport/client-context.test.ts mobile/src/transport/host-open-recovery.test.tsx mobile/src/transport/host-open-retry-scheduler.test.ts mobile/src/transport/rpc-session-liveness-watchdog.test.ts mobile/src/transport/rpc-session-liveness-integration.test.ts mobile/src/transport/mobile-relay-rpc-session.test.ts mobile/src/transport/mobile-relay-rpc-session-liveness.test.ts mobile/src/transport/mobile-endpoint-nudge-router.test.ts mobile/src/transport/mobile-relay-e2ee-link.test.ts mobile/src/transport/stable-logical-rpc-client.test.ts mobile/src/transport/connection-health.test.ts",
           "result": "passed",
-          "durationSeconds": 0.74,
-          "summary": "Ten focused files passed 66 deterministic provider lifecycle, direct/Relay liveness, traffic, and delivery-ambiguity tests."
+          "durationSeconds": 0.77,
+          "summary": "Eleven focused files passed 85 deterministic provider lifecycle, path presentation, direct/Relay liveness, traffic, and delivery-ambiguity tests."
         }
       ],
       "runtimeBudget": {

--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -32,6 +32,7 @@ import { useWorktreeResync } from '../../../src/transport/use-worktree-resync'
 import { startHostWorktreeRefresh } from '../../../src/worktree/host-worktree-refresh'
 import {
   useLastConnectedAt,
+  usePendingConnectionPath,
   useReconnectAttempt
 } from '../../../src/transport/client-context-connection-metrics'
 import {
@@ -138,6 +139,7 @@ export function HostScreen({
   const { client, state: connState } = useHostClient(hostId)
   const reconnectAttempts = useReconnectAttempt(hostId)
   const lastConnectedAt = useLastConnectedAt(hostId)
+  const pendingConnectionPath = usePendingConnectionPath(hostId)
   const clientRef = useRef<RpcClient | null>(null)
   const fetchWorktreesInFlightRef = useRef(false)
   // Why: useRef, not useMemo — React may discard memoized values, which would silently
@@ -817,7 +819,8 @@ export function HostScreen({
             const headerVerdict = classifyConnection({
               state: connState,
               reconnectAttempts,
-              lastConnectedAt
+              lastConnectedAt,
+              pendingPath: pendingConnectionPath
             })
             return (
               <>

--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -61,6 +61,7 @@ import {
 import { useHostClient, useForceReconnect } from '../../../../src/transport/client-context'
 import {
   useLastConnectedAt,
+  usePendingConnectionPath,
   useReconnectAttempt
 } from '../../../../src/transport/client-context-connection-metrics'
 import {
@@ -736,6 +737,7 @@ export default function SessionScreen() {
   const { client, state: connState } = useHostClient(hostId)
   const reconnectAttempts = useReconnectAttempt(hostId)
   const lastConnectedAt = useLastConnectedAt(hostId)
+  const pendingConnectionPath = usePendingConnectionPath(hostId)
   const forceReconnectHost = useForceReconnect()
   const { name: worktreeName, resolution: worktreeResolution } = useLiveWorktreeName({
     client,
@@ -4171,7 +4173,8 @@ export default function SessionScreen() {
     state: connState,
     reconnectAttempts,
     lastConnectedAt,
-    endpoint: hostEndpoint
+    endpoint: hostEndpoint,
+    pendingPath: pendingConnectionPath
   })
   const showConnectionRetry =
     connectionVerdict.kind === 'warning' || connectionVerdict.kind === 'unreachable'

--- a/mobile/app/h/[hostId]/tasks.tsx
+++ b/mobile/app/h/[hostId]/tasks.tsx
@@ -37,6 +37,7 @@ import type { RpcSuccess } from '../../../src/transport/types'
 import { useHostClient } from '../../../src/transport/client-context'
 import {
   useLastConnectedAt,
+  usePendingConnectionPath,
   useReconnectAttempt
 } from '../../../src/transport/client-context-connection-metrics'
 import { classifyConnection } from '../../../src/transport/connection-health'
@@ -2073,6 +2074,7 @@ export default function MobileTasksScreen() {
   const { client, state: connState } = useHostClient(hostId)
   const reconnectAttempts = useReconnectAttempt(hostId)
   const lastConnectedAt = useLastConnectedAt(hostId)
+  const pendingConnectionPath = usePendingConnectionPath(hostId)
   const clientRef = useRef<RpcClient | null>(null)
   const loadGenerationRef = useRef(0)
   const taskResumeRef = useRef<TaskResumeState>({})
@@ -8673,7 +8675,8 @@ export default function MobileTasksScreen() {
   const headerVerdict = classifyConnection({
     state: connState,
     reconnectAttempts,
-    lastConnectedAt
+    lastConnectedAt,
+    pendingPath: pendingConnectionPath
   })
   const emptyLabel =
     connState !== 'connected'

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -259,6 +259,10 @@ export default function HomeScreen() {
     () => Object.fromEntries(allClients.map(({ hostId, path }) => [hostId, path])),
     [allClients]
   )
+  const hostPendingPaths = useMemo(
+    () => Object.fromEntries(allClients.map(({ hostId, pendingPath }) => [hostId, pendingPath])),
+    [allClients]
+  )
   const disconnectHostClient = useDisconnectHostClient()
   const forgetHostClient = useForgetHostClient()
   const forceReconnectHost = useForceReconnect()
@@ -765,7 +769,8 @@ export default function HomeScreen() {
               state,
               reconnectAttempts: attempts,
               lastConnectedAt,
-              endpoint: item.endpoint
+              endpoint: item.endpoint,
+              pendingPath: hostPendingPaths[item.id] ?? null
             })
             return (
               <MobileHostCard

--- a/mobile/src/components/MobileHostCard.test.tsx
+++ b/mobile/src/components/MobileHostCard.test.tsx
@@ -94,22 +94,23 @@ describe('MobileHostCard', () => {
   it('names the relay while the dial is still in flight', async () => {
     const lines = await renderCard(undefined, {
       state: 'connecting',
-      verdict: { kind: 'normal', label: 'Connecting…' },
+      verdict: { kind: 'normal', label: 'Connecting via Relay…' },
       path: 'relay'
     })
 
-    expect(lines).toContain('Connecting…')
-    expect(lines).toContain(' · Orca Relay')
+    expect(lines).toContain('Connecting via Relay…')
+    expect(lines).not.toContain(' · Orca Relay')
   })
 
   it('names the relay while a failed direct dial is still retrying', async () => {
     const lines = await renderCard(undefined, {
       state: 'reconnecting',
-      verdict: { kind: 'normal', label: 'Reconnecting…' },
+      verdict: { kind: 'normal', label: 'Connecting via Relay…' },
       path: 'relay'
     })
 
-    expect(lines).toContain(' · Orca Relay')
+    expect(lines).toContain('Connecting via Relay…')
+    expect(lines).not.toContain(' · Orca Relay')
   })
 
   it('leaves an idle disconnected host unlabelled', async () => {

--- a/mobile/src/components/MobileHostCard.tsx
+++ b/mobile/src/components/MobileHostCard.tsx
@@ -25,11 +25,6 @@ export function MobileHostCard(props: {
   const credentialUnavailable = props.credentialStatus === 'temporarily-unavailable'
   const credentialMissing = props.credentialStatus === 'missing'
   const connected = props.state === 'connected' && !credentialUnavailable && !credentialMissing
-  // Why: a relay dial can run for seconds behind "Connecting…"/"Reconnecting…"; naming the
-  // path mid-wait tells the user the phone is off-LAN rather than hung (F5). Only 'relay' is
-  // named — 'lan' doubles as the unknown-path default, so it would be a guess before connect.
-  const dialingPath =
-    ['connecting', 'handshaking', 'reconnecting'].includes(props.state) && props.path === 'relay'
   const isError =
     credentialMissing || ['warning', 'unreachable', 'auth-failed'].includes(props.verdict.kind)
   const statusLabel = credentialMissing
@@ -44,7 +39,7 @@ export function MobileHostCard(props: {
       : props.verdict
   const worktreeSummary = homeHostWorktreeSummary(props.worktreeInfo)
   const connectionPathLabel =
-    !credentialMissing && !credentialUnavailable && (connected || dialingPath)
+    !credentialMissing && !credentialUnavailable && connected
       ? mobileConnectionPathLabel(props.path)
       : null
   const discoveryHint =

--- a/mobile/src/transport/client-context-connection-metrics.ts
+++ b/mobile/src/transport/client-context-connection-metrics.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useRpcClientContext, type RpcClientContextValue } from './client-context'
+import type { MobileConnectionPath } from './stable-logical-rpc-client'
 
 export function useReconnectAttempt(hostId: string | undefined): number {
   return useHostMetric(hostId, (context, id) => context.getReconnectAttempt(id), 0)
@@ -7,6 +8,10 @@ export function useReconnectAttempt(hostId: string | undefined): number {
 
 export function useLastConnectedAt(hostId: string | undefined): number | null {
   return useHostMetric(hostId, (context, id) => context.getLastConnectedAt(id), null)
+}
+
+export function usePendingConnectionPath(hostId: string | undefined): MobileConnectionPath | null {
+  return useHostMetric(hostId, (context, id) => context.getPendingPath(id), null)
 }
 
 function useHostMetric<T>(

--- a/mobile/src/transport/client-context.test.ts
+++ b/mobile/src/transport/client-context.test.ts
@@ -3,6 +3,7 @@ import { act, create, type ReactTestRenderer } from 'react-test-renderer'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ConnectionState } from './types'
 import type { RpcClient } from './rpc-client'
+import type { MobileConnectionPath } from './stable-logical-rpc-client'
 
 const connectMock = vi.fn()
 const loadHostsMock = vi.fn()
@@ -31,12 +32,15 @@ import { selectHomeAutoConnectHostIds } from './home-host-auto-connect'
 
 type FakeClient = RpcClient & {
   emitState: (state: ConnectionState) => void
+  emitPendingPath: (path: MobileConnectionPath | null) => void
   closeMock: ReturnType<typeof vi.fn>
 }
 
 function makeFakeClient(initialState: ConnectionState): FakeClient {
   let state = initialState
+  let pendingPath: MobileConnectionPath | null = null
   const listeners = new Set<(state: ConnectionState) => void>()
+  const pathListeners = new Set<() => void>()
   const closeMock = vi.fn()
   return {
     sendRequest: vi.fn(),
@@ -45,6 +49,12 @@ function makeFakeClient(initialState: ConnectionState): FakeClient {
     getState: () => state,
     getReconnectAttempt: () => 0,
     getLastConnectedAt: () => null,
+    getActivePath: () => 'tailscale',
+    getPendingPath: () => pendingPath,
+    onConnectionPathChange: (listener: () => void) => {
+      pathListeners.add(listener)
+      return () => pathListeners.delete(listener)
+    },
     onStateChange: (listener) => {
       listeners.add(listener)
       return () => listeners.delete(listener)
@@ -56,6 +66,12 @@ function makeFakeClient(initialState: ConnectionState): FakeClient {
       state = next
       for (const listener of listeners) {
         listener(next)
+      }
+    },
+    emitPendingPath: (next) => {
+      pendingPath = next
+      for (const listener of pathListeners) {
+        listener()
       }
     }
   } as FakeClient
@@ -393,6 +409,30 @@ describe('useHostClient', () => {
 })
 
 describe('useAllHostClients', () => {
+  it('rerenders when Relay becomes pending without a transport-state change', async () => {
+    const client = makeFakeClient('reconnecting')
+    connectMock.mockReturnValue(client)
+    loadHostsMock.mockResolvedValue([HOST])
+    let pendingPath: MobileConnectionPath | null | undefined
+    let renderer!: ReturnType<typeof create>
+
+    function Probe(): null {
+      pendingPath = useAllHostClients([HOST.id])[0]?.pendingPath
+      return null
+    }
+
+    await act(async () => {
+      renderer = create(createElement(RpcClientProvider, null, createElement(Probe)))
+      await Promise.resolve()
+    })
+    expect(pendingPath).toBeNull()
+
+    act(() => client.emitPendingPath('relay'))
+    expect(pendingPath).toBe('relay')
+
+    act(() => renderer.unmount())
+  })
+
   it('only opens the requested startup subset', async () => {
     const host2 = { ...HOST, id: 'host-2', name: 'Host 2' }
     connectMock.mockReturnValue(makeFakeClient('connected'))

--- a/mobile/src/transport/client-context.tsx
+++ b/mobile/src/transport/client-context.tsx
@@ -76,6 +76,7 @@ export function RpcClientProvider({ children }: { children: ReactNode }) {
       primedHostsRef.current.delete(hostId)
     }
     entry?.unsubState()
+    entry?.unsubConnectionPath()
     storeRef.current.delete(hostId)
     entry?.client.close()
     notifyHostState(hostId, 'disconnected')
@@ -242,6 +243,7 @@ export function RpcClientProvider({ children }: { children: ReactNode }) {
       manualDemandRef.current.add(hostId)
       if (entry) {
         entry.unsubState()
+        entry.unsubConnectionPath()
         entry.client.close()
         storeRef.current.delete(hostId)
       }
@@ -260,8 +262,10 @@ export function RpcClientProvider({ children }: { children: ReactNode }) {
     [openEntry]
   )
 
-  const { getKnownState, getState, getReconnectAttempt, getLastConnectedAt, getActivePath } =
-    useMemo(() => createHostClientSelectors(storeRef.current, pendingOpensRef.current), [])
+  const selectors = useMemo(
+    () => createHostClientSelectors(storeRef.current, pendingOpensRef.current),
+    []
+  )
 
   const subscribeHostState = useCallback(
     (hostId: string, listener: (state: ConnectionState) => void) =>
@@ -318,11 +322,7 @@ export function RpcClientProvider({ children }: { children: ReactNode }) {
       refreshHostClient,
       forgetHostClient,
       disconnectHostClient,
-      getState,
-      getKnownState,
-      getReconnectAttempt,
-      getLastConnectedAt,
-      getActivePath,
+      ...selectors,
       subscribeHostState,
       getAllClients,
       subscribeAllHosts,
@@ -337,11 +337,7 @@ export function RpcClientProvider({ children }: { children: ReactNode }) {
       refreshHostClient,
       forgetHostClient,
       disconnectHostClient,
-      getState,
-      getKnownState,
-      getReconnectAttempt,
-      getLastConnectedAt,
-      getActivePath,
+      selectors,
       subscribeHostState,
       getAllClients,
       subscribeAllHosts,

--- a/mobile/src/transport/connection-health.test.ts
+++ b/mobile/src/transport/connection-health.test.ts
@@ -25,7 +25,8 @@ describe('classifyConnection Tailscale hint', () => {
     const verdict = classifyConnection({
       ...base,
       reconnectAttempts: 3,
-      endpoint: 'ws://100.65.9.106:6768'
+      endpoint: 'ws://100.65.9.106:6768',
+      pendingPath: null
     })
     expect(verdict).toMatchObject({ kind: 'warning', hint: 'check Tailscale' })
   })
@@ -68,6 +69,37 @@ describe('classifyConnection Tailscale hint', () => {
       nowMs: 1_000_000
     })
     expect(verdict).toEqual({ kind: 'normal', label: 'Connected' })
+  })
+
+  it('presents an in-flight relay fallback instead of the failed Tailscale path', () => {
+    const incident = {
+      ...base,
+      reconnectAttempts: 5,
+      endpoint: 'ws://100.88.90.25:6768',
+      pendingPath: 'relay' as const
+    }
+
+    for (const state of ['connecting', 'handshaking', 'reconnecting', 'disconnected'] as const) {
+      const verdict = classifyConnection({ ...incident, state })
+      expect(verdict).toEqual({ kind: 'normal', label: 'Connecting via Relay…' })
+      expect(verdictDisplayLabel(verdict)).not.toContain('Tailscale')
+    }
+  })
+
+  it('escalates a prolonged relay recovery without reviving the Tailscale hint', () => {
+    const verdict = classifyConnection({
+      ...base,
+      reconnectAttempts: 12,
+      endpoint: 'ws://100.88.90.25:6768',
+      pendingPath: 'relay'
+    })
+
+    expect(verdict).toEqual({
+      kind: 'unreachable',
+      label: "Can't connect via Relay",
+      reason: 'never-connected'
+    })
+    expect(verdictDisplayLabel(verdict)).not.toContain('Tailscale')
   })
 })
 

--- a/mobile/src/transport/connection-health.ts
+++ b/mobile/src/transport/connection-health.ts
@@ -1,4 +1,5 @@
 import { isTailscaleEndpoint } from '../../../src/shared/remote-runtime-tailscale-hint'
+import type { MobileConnectionPath } from './stable-logical-rpc-client'
 import type { ConnectionState } from './types'
 
 // Why: thresholds for escalating connection UX from neutral
@@ -49,6 +50,7 @@ export function classifyConnection(args: {
   // Optional pinned host endpoint — enables the Tailscale hint on
   // warning/unreachable verdicts. Callers without it get plain labels.
   endpoint?: string | null
+  pendingPath?: MobileConnectionPath | null
   nowMs?: number
 }): ConnectionVerdict {
   const { state, reconnectAttempts, lastConnectedAt } = args
@@ -63,6 +65,18 @@ export function classifyConnection(args: {
 
   if (state === 'connected') {
     return { kind: 'normal', label: 'Connected' }
+  }
+
+  if (args.pendingPath === 'relay') {
+    if (reconnectAttempts >= UNREACHABLE_ATTEMPTS) {
+      if (lastConnectedAt == null) {
+        return { kind: 'unreachable', label: "Can't connect via Relay", reason: 'never-connected' }
+      }
+      if (now - lastConnectedAt >= STALE_SINCE_LAST_CONNECT_MS) {
+        return { kind: 'unreachable', label: "Can't connect via Relay", reason: 'stale' }
+      }
+    }
+    return { kind: 'normal', label: 'Connecting via Relay…' }
   }
 
   if (state === 'disconnected') {

--- a/mobile/src/transport/host-client-context-state.ts
+++ b/mobile/src/transport/host-client-context-state.ts
@@ -84,7 +84,9 @@ export function createHostClientSelectors(
     getLastConnectedAt: (hostId: string): number | null =>
       entries.get(hostId)?.client.getLastConnectedAt() ?? null,
     getActivePath: (hostId: string): MobileConnectionPath =>
-      clientActivePath(entries.get(hostId)?.client)
+      clientActivePath(entries.get(hostId)?.client),
+    getPendingPath: (hostId: string): MobileConnectionPath | null =>
+      clientPendingPath(entries.get(hostId)?.client)
   }
 }
 
@@ -95,4 +97,9 @@ export function clientActivePath(client: RpcClient | undefined): MobileConnectio
   }
   // Why: during migration the pending path is what the user is waiting on.
   return logical.getPendingPath?.() ?? logical.getActivePath()
+}
+
+export function clientPendingPath(client: RpcClient | undefined): MobileConnectionPath | null {
+  const logical = client as Partial<StableLogicalRpcClient> | undefined
+  return logical?.getPendingPath?.() ?? null
 }

--- a/mobile/src/transport/host-entry-opener.ts
+++ b/mobile/src/transport/host-entry-opener.ts
@@ -4,6 +4,7 @@ import { openHostLogicalClient } from './host-logical-client'
 import type { HostClientOpenRegistry } from './host-client-open-registry'
 import type { HostOpenRetryScheduler } from './host-open-retry-scheduler'
 import type { RpcClient } from './rpc-client'
+import type { StableLogicalRpcClient } from './stable-logical-rpc-client'
 import type { ConnectionState, HostProfile } from './types'
 
 export type HostClientStoreEntry = {
@@ -11,6 +12,7 @@ export type HostClientStoreEntry = {
   state: ConnectionState
   refCount: number
   unsubState: () => void
+  unsubConnectionPath: () => void
 }
 
 type HostEntryOpenerState = {
@@ -113,11 +115,20 @@ export async function openHostClientEntry(
       current.state = next
       state.notifyHostState(hostId, next)
     })
+    const logical = client as Partial<StableLogicalRpcClient>
+    const unsubConnectionPath =
+      logical.onConnectionPathChange?.(() => {
+        const current = state.store.get(hostId)
+        if (current) {
+          state.notifyHostState(hostId, current.state)
+        }
+      }) ?? (() => {})
     const entry: HostClientStoreEntry = {
       client,
       state: client.getState(),
       refCount: state.pendingAcquisitions.get(hostId) ?? 0,
-      unsubState
+      unsubState,
+      unsubConnectionPath
     }
     state.pendingAcquisitions.delete(hostId)
     state.store.set(hostId, entry)

--- a/mobile/src/transport/logical-client-connection-path.ts
+++ b/mobile/src/transport/logical-client-connection-path.ts
@@ -1,0 +1,46 @@
+import type { MobileConnectionPath } from './stable-logical-rpc-client'
+
+export class LogicalClientConnectionPath {
+  private migration: MobileConnectionPath | null = null
+  private recovery: MobileConnectionPath | null = null
+  private readonly listeners = new Set<() => void>()
+
+  constructor(private readonly isConnected: () => boolean) {}
+
+  pending(): MobileConnectionPath | null {
+    return this.isConnected() ? null : (this.migration ?? this.recovery)
+  }
+
+  setMigration(path: MobileConnectionPath | null): void {
+    this.update(() => {
+      this.migration = path
+    })
+  }
+
+  clearAfterConnected(): void {
+    this.migration = null
+    this.recovery = null
+  }
+
+  setRecovery(path: MobileConnectionPath | null): void {
+    this.update(() => {
+      this.recovery = path
+    })
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
+  }
+
+  private update(apply: () => void): void {
+    const previous = this.pending()
+    apply()
+    if (previous === this.pending()) {
+      return
+    }
+    for (const listener of this.listeners) {
+      listener()
+    }
+  }
+}

--- a/mobile/src/transport/mobile-endpoint-supervisor-test-fakes.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor-test-fakes.ts
@@ -65,6 +65,7 @@ export class FakeRelaySession extends FakeSession implements MobileRelayRpcSessi
 
 export class FakeLogicalClient extends FakeSession implements StableLogicalRpcClient {
   private path: MobileConnectionPath
+  private recoveryPath: MobileConnectionPath | null = null
   private generation = 1
 
   constructor(state: ConnectionState, path: MobileConnectionPath) {
@@ -95,8 +96,11 @@ export class FakeLogicalClient extends FakeSession implements StableLogicalRpcCl
   )
   suspendActiveSession = vi.fn(() => this.publishState('disconnected'))
   getActivePath = () => this.path
-  // This fake migrates instantly, so no dial is ever in flight to name.
-  getPendingPath = () => null
+  getPendingPath = () => this.recoveryPath
+  setRecoveryPath = vi.fn((path: MobileConnectionPath | null) => {
+    this.recoveryPath = path
+  })
+  onConnectionPathChange = vi.fn(() => () => {})
   getGeneration = () => this.generation
 }
 

--- a/mobile/src/transport/mobile-endpoint-supervisor-test-fakes.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor-test-fakes.ts
@@ -67,6 +67,7 @@ export class FakeLogicalClient extends FakeSession implements StableLogicalRpcCl
   private path: MobileConnectionPath
   private recoveryPath: MobileConnectionPath | null = null
   private generation = 1
+  private readonly pathListeners = new Set<() => void>()
 
   constructor(state: ConnectionState, path: MobileConnectionPath) {
     super(state)
@@ -90,17 +91,28 @@ export class FakeLogicalClient extends FakeSession implements StableLogicalRpcCl
         throw new Error('migration superseded')
       }
       this.path = path
+      this.recoveryPath = null
       this.generation += 1
+      // Connected-state publication carries the migration cleanup.
       this.publishState('connected')
     }
   )
   suspendActiveSession = vi.fn(() => this.publishState('disconnected'))
   getActivePath = () => this.path
-  getPendingPath = () => this.recoveryPath
+  getPendingPath = () => (this.getState() === 'connected' ? null : this.recoveryPath)
   setRecoveryPath = vi.fn((path: MobileConnectionPath | null) => {
+    const previous = this.getPendingPath()
     this.recoveryPath = path
+    if (previous !== this.getPendingPath()) {
+      for (const listener of this.pathListeners) {
+        listener()
+      }
+    }
   })
-  onConnectionPathChange = vi.fn(() => () => {})
+  onConnectionPathChange = vi.fn((listener: () => void) => {
+    this.pathListeners.add(listener)
+    return () => this.pathListeners.delete(listener)
+  })
   getGeneration = () => this.generation
 }
 

--- a/mobile/src/transport/mobile-endpoint-supervisor.test.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.test.ts
@@ -91,6 +91,63 @@ describe('mobile endpoint supervisor', () => {
     supervisor.stop()
   })
 
+  it('does not announce Relay when credential selection finishes after backgrounding', async () => {
+    const logical = new FakeLogicalClient('reconnecting', 'lan')
+    let finishCredentialRead: ((value: MobileRelayCredentialBundle) => void) | undefined
+    const credentialReadPending = new Promise<MobileRelayCredentialBundle>((resolve) => {
+      finishCredentialRead = resolve
+    })
+    const readBundle = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockReturnValueOnce(credentialReadPending)
+    const deps = dependencies({ readBundle })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    const starting = supervisor.start()
+    await vi.waitFor(() => expect(readBundle).toHaveBeenCalledTimes(2))
+    supervisor.setForeground(false)
+    finishCredentialRead?.(bundle)
+    await starting
+
+    expect(deps.openRelay).not.toHaveBeenCalled()
+    expect(logical.setRecoveryPath).not.toHaveBeenCalledWith('relay')
+    expect(logical.getPendingPath()).toBeNull()
+    supervisor.stop()
+  })
+
+  it('does not announce Relay without a dialable credential', async () => {
+    const logical = new FakeLogicalClient('reconnecting', 'lan')
+    const expired = { ...bundle, current: { ...bundle.current, expiresAt: Date.now() - 1 } }
+    const deps = dependencies({ readBundle: vi.fn(async () => expired) })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+
+    expect(deps.openRelay).not.toHaveBeenCalled()
+    expect(logical.setRecoveryPath).not.toHaveBeenCalledWith('relay')
+    expect(logical.getPendingPath()).toBeNull()
+    supervisor.stop()
+  })
+
+  it('keeps Relay pending through a failed dial cooldown and clears it on stop', async () => {
+    const logical = new FakeLogicalClient('reconnecting', 'lan')
+    const deps = dependencies({
+      openRelay: vi.fn(() => new FakeRelaySession('disconnected', new RelayOuterError(4408))),
+      randomBytes: () => new Uint8Array([128, 0])
+    })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+
+    expect(logical.getPendingPath()).toBe('relay')
+    await vi.advanceTimersByTimeAsync(249)
+    expect(logical.getPendingPath()).toBe('relay')
+
+    supervisor.stop()
+    expect(logical.getPendingPath()).toBeNull()
+  })
+
   it('does not spend a queued relay retry while direct authentication is progressing', async () => {
     const logical = new FakeLogicalClient('disconnected', 'lan')
     const openRelay = vi.fn(() => new FakeRelaySession('disconnected', new RelayOuterError(4408)))
@@ -187,10 +244,27 @@ describe('mobile endpoint supervisor', () => {
     logical.publishState('disconnected')
 
     expect(openRelay).toHaveBeenCalledOnce()
+    expect(logical.getPendingPath()).toBe('relay')
     await vi.advanceTimersByTimeAsync(249)
     expect(openRelay).toHaveBeenCalledOnce()
     await vi.advanceTimersByTimeAsync(1)
     expect(openRelay).toHaveBeenCalledTimes(2)
+    supervisor.stop()
+  })
+
+  it('does not announce recovery when an active Relay drops after credential expiry', async () => {
+    const logical = new FakeLogicalClient('connected', 'relay')
+    const expired = { ...bundle, current: { ...bundle.current, expiresAt: Date.now() - 1 } }
+    const deps = dependencies({ readBundle: vi.fn(async () => expired) })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+    await supervisor.start()
+
+    logical.publishState('disconnected')
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(deps.openRelay).not.toHaveBeenCalled()
+    expect(logical.setRecoveryPath).not.toHaveBeenCalledWith('relay')
+    expect(logical.getPendingPath()).toBeNull()
     supervisor.stop()
   })
 
@@ -432,6 +506,7 @@ describe('mobile endpoint supervisor', () => {
 
     expect(openRelay).toHaveBeenCalledOnce()
     expect(deps.writeBundle).not.toHaveBeenCalled()
+    expect(logical.getPendingPath()).toBeNull()
 
     logical.publishState('connected')
     await vi.waitFor(() => expect(deps.writeBundle).toHaveBeenCalledOnce())

--- a/mobile/src/transport/mobile-endpoint-supervisor.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.ts
@@ -17,6 +17,7 @@ import type { MobileRelayCredentialBundle } from './mobile-relay-credential-bund
 import { MobileEndpointNudgeRouter } from './mobile-endpoint-nudge-router'
 import { MobileRelayDirectGraceTimer } from './mobile-relay-direct-grace-timer'
 import { MobileRelaySessionEstablisher } from './mobile-relay-session-establisher'
+import * as recoveryPresentation from './mobile-relay-recovery-presentation'
 import type { StableLogicalRpcClient } from './stable-logical-rpc-client'
 import type { ForegroundNudgeReason, HostProfile } from './types'
 
@@ -154,6 +155,7 @@ export class MobileEndpointSupervisor {
       } else {
         // Why: the direct client enters reconnecting after its first failed
         // dial and may never publish disconnected while its retry loop lives.
+        recoveryPresentation.onActiveFailure(this.logical, this.relayReconnect, state, this.bundle)
         this.relayReconnect.handleStateFailure(this.logical, state)
       }
     })
@@ -181,12 +183,11 @@ export class MobileEndpointSupervisor {
       this.relayReconnect.clear()
       this.leaseRotation.clear()
       this.directGrace.clear()
+      this.logical.setRecoveryPath(null)
     }
   }
 
-  nudge(reason: ForegroundNudgeReason): void {
-    this.nudgeRouter.nudge(reason)
-  }
+  nudge = (reason: ForegroundNudgeReason): void => this.nudgeRouter.nudge(reason)
 
   stop(): void {
     this.stopped = true
@@ -196,6 +197,7 @@ export class MobileEndpointSupervisor {
     this.relayReconnect.clear()
     this.leaseRotation.clear()
     this.directGrace.clear()
+    this.logical.setRecoveryPath(null)
   }
 
   // forceReplacement: dial past the "direct still looks live" guard — a lease
@@ -235,7 +237,6 @@ export class MobileEndpointSupervisor {
       return
     }
     this.operationInFlight = true
-    let lastError: Error | null = null
     let retryAfterOperation = false
     try {
       const selection = await selectDialableRelayCredentials({
@@ -246,6 +247,7 @@ export class MobileEndpointSupervisor {
       })
       this.bundle = selection.bundle
       if (selection.credentials.length === 0) {
+        this.logical.setRecoveryPath(null)
         // Why: "expired" vs "missing" separates a sleep-past-expiry phone
         // (needs re-pair or LAN) from a Keychain failure in field reports.
         this.logRelay(
@@ -261,6 +263,12 @@ export class MobileEndpointSupervisor {
         }
         return
       }
+      const recoveryNeeded =
+        forceReplacement || this.relayReconnect.needsRecovery(this.logical.getState())
+      if (this.stopped || !this.foreground || !recoveryNeeded) {
+        return
+      }
+      this.logical.setRecoveryPath('relay')
       const dialed = await this.sessionEstablisher.dialEligible(selection.credentials)
       if (dialed.outcome === 'established') {
         // Why: a fresh socket satisfies any replacement intent queued mid-dial.
@@ -269,15 +277,16 @@ export class MobileEndpointSupervisor {
         return
       }
       if (dialed.outcome === 'aborted') {
+        this.logical.setRecoveryPath(null)
         // Why: direct won the race or the supervisor went inactive — not a
         // failure; booking backoff would delay the next genuine recovery.
         return
       }
-      lastError = dialed.error
       // Why: cleanup may happen while a relay dial is awaiting the network;
       // record its outcome without recreating a foreground retry timer.
       const scheduleRetry = (!forceReplacement || ownsRecovery) && this.foreground && !this.stopped
-      this.relayReconnect.registerFailure(lastError, scheduleRetry)
+      this.relayReconnect.registerFailure(dialed.error, scheduleRetry)
+      recoveryPresentation.clearIfCredentialBlocked(this.logical, this.relayReconnect)
       if (ownsRecovery) {
         suspendRelayIfStillConnected(this.relayReconnect, this.logical)
       }

--- a/mobile/src/transport/mobile-relay-reconnect-controller.ts
+++ b/mobile/src/transport/mobile-relay-reconnect-controller.ts
@@ -7,8 +7,11 @@ import type { MobileRelayRpcSession } from './mobile-relay-rpc-session'
 import { MobileE2EEAuthenticationError } from './mobile-e2ee-v2-physical-channel'
 import { RelayOuterError } from './mobile-relay-e2ee-link'
 import { RELAY_STABLE_CONNECTION_MS, RelayRetryDelays } from './mobile-relay-retry-delays'
+import { RelayCredentialEligibility } from './relay-credential-eligibility'
 import type { StableLogicalRpcClient } from './stable-logical-rpc-client'
 import type { ConnectionState, ForegroundNudgeReason } from './types'
+
+type RelayCredentialLease = { expiresAt: number; version: number }
 
 export type RelayReconnectDependencies = {
   now: () => number
@@ -28,7 +31,7 @@ export class RelayReconnectController {
   private recoveryGate: RecoveryGate | null = null
   private gateReprobePending = false
   private gateReprobeStreak = 0
-  private readonly rejectedCredentialVersions = new Set<number>()
+  private readonly credentials: RelayCredentialEligibility
   private readonly delays: RelayRetryDelays
 
   constructor(
@@ -36,6 +39,7 @@ export class RelayReconnectController {
     private readonly onRetry: (forceReplacement?: boolean) => void
   ) {
     this.delays = new RelayRetryDelays(dependencies.randomBytes)
+    this.credentials = new RelayCredentialEligibility(dependencies.now)
   }
 
   handleForeground(logical: StableLogicalRpcClient, wasForeground: boolean): void {
@@ -105,7 +109,7 @@ export class RelayReconnectController {
 
   resetForDirectConnection(): boolean {
     const needsCredentialRefresh =
-      this.recoveryGate === 'fresh-credential' || this.rejectedCredentialVersions.size > 0
+      this.recoveryGate === 'fresh-credential' || this.credentials.hasRejected()
     this.activeSession = null
     this.activeRelayConnectedAt = null
     if (needsCredentialRefresh) {
@@ -126,22 +130,22 @@ export class RelayReconnectController {
 
   completeCredentialRefresh(): void {
     if (this.recoveryGate === 'fresh-credential') {
-      this.rejectedCredentialVersions.clear()
+      this.credentials.clearRejected()
       this.reset()
     }
   }
 
-  eligibleCredentials<T extends { expiresAt: number; version: number }>(
+  blocksUntilFreshCredential = (): boolean => this.recoveryGate === 'fresh-credential'
+
+  hasDialableCredential(...credentials: (RelayCredentialLease | null | undefined)[]): boolean {
+    return this.credentials.hasDialable(...credentials)
+  }
+
+  eligibleCredentials<T extends RelayCredentialLease>(
     ...credentials: Array<T | null | undefined>
   ): T[] {
-    const eligible = credentials.filter((credential): credential is T =>
-      Boolean(
-        credential &&
-        credential.expiresAt > this.dependencies.now() &&
-        !this.rejectedCredentialVersions.has(credential.version)
-      )
-    )
-    if (eligible.length === 0 && this.rejectedCredentialVersions.size > 0) {
+    const eligible = this.credentials.eligible(...credentials)
+    if (eligible.length === 0 && this.credentials.hasRejected()) {
       this.recoveryGate = 'fresh-credential'
       this.clearTimer()
       this.scheduleGateReprobe()
@@ -152,7 +156,7 @@ export class RelayReconnectController {
   // For callers that found no dialable credential at all: keep a slow retry
   // alive so a later durable write can recover.
   armCredentialReprobe(): void {
-    if (this.rejectedCredentialVersions.size > 0) {
+    if (this.credentials.hasRejected()) {
       this.recoveryGate = 'fresh-credential'
       this.clearTimer()
       this.scheduleGateReprobe()
@@ -176,14 +180,12 @@ export class RelayReconnectController {
 
   // A durable bundle whose current version is not rejected reopens the gate.
   acceptFreshCredential(version: number): void {
-    if (this.recoveryGate === 'fresh-credential' && !this.rejectedCredentialVersions.has(version)) {
+    if (this.recoveryGate === 'fresh-credential' && !this.credentials.isRejected(version)) {
       this.liftGate()
     }
   }
 
-  recordRejectedCredential(version: number): void {
-    this.rejectedCredentialVersions.add(version)
-  }
+  recordRejectedCredential = (version: number): void => this.credentials.recordRejected(version)
 
   registerActiveFailure(logical: StableLogicalRpcClient): void {
     if (logical.getActivePath() !== 'relay') {

--- a/mobile/src/transport/mobile-relay-recovery-presentation.ts
+++ b/mobile/src/transport/mobile-relay-recovery-presentation.ts
@@ -1,0 +1,29 @@
+import type { MobileRelayCredentialBundle } from './mobile-relay-credential-bundle'
+import type { RelayReconnectController } from './mobile-relay-reconnect-controller'
+import type { StableLogicalRpcClient } from './stable-logical-rpc-client'
+import type { ConnectionState } from './types'
+
+export function onActiveFailure(
+  logical: StableLogicalRpcClient,
+  controller: RelayReconnectController,
+  state: ConnectionState,
+  bundle: MobileRelayCredentialBundle | null
+): void {
+  if (
+    controller.needsRecovery(state) &&
+    logical.getActivePath() === 'relay' &&
+    bundle &&
+    controller.hasDialableCredential(bundle.current, bundle.grace)
+  ) {
+    logical.setRecoveryPath('relay')
+  }
+}
+
+export function clearIfCredentialBlocked(
+  logical: StableLogicalRpcClient,
+  controller: RelayReconnectController
+): void {
+  if (controller.blocksUntilFreshCredential()) {
+    logical.setRecoveryPath(null)
+  }
+}

--- a/mobile/src/transport/mobile-relay-runtime-failover.test.ts
+++ b/mobile/src/transport/mobile-relay-runtime-failover.test.ts
@@ -90,6 +90,8 @@ class FakeRelaySession extends FakeSession implements MobileRelayRpcSession {
 
 class FakeLogicalClient extends FakeSession implements StableLogicalRpcClient {
   private path: MobileConnectionPath
+  private recoveryPath: MobileConnectionPath | null = null
+  private generation = 1
 
   constructor(state: ConnectionState, path: MobileConnectionPath) {
     super(state)
@@ -102,10 +104,18 @@ class FakeLogicalClient extends FakeSession implements StableLogicalRpcClient {
       throw new Error(`replacement session ${session.getState()}`)
     }
     this.path = path
+    this.recoveryPath = null
+    this.generation += 1
     this.publishState('connected')
   })
   suspendActiveSession = vi.fn(() => this.publishState('disconnected'))
   getActivePath = () => this.path
+  getPendingPath = () => this.recoveryPath
+  setRecoveryPath = vi.fn((path: MobileConnectionPath | null) => {
+    this.recoveryPath = path
+  })
+  onConnectionPathChange = vi.fn(() => () => {})
+  getGeneration = () => this.generation
 }
 
 const relay = {
@@ -237,12 +247,15 @@ describe('relay runtime recovery without direct connectivity', () => {
     await supervisor.start()
     await vi.advanceTimersByTimeAsync(0)
     expect(deps.openRelay).not.toHaveBeenCalled()
+    expect(logical.setRecoveryPath).not.toHaveBeenCalledWith('relay')
+    expect(logical.getPendingPath()).toBeNull()
 
     readBundle.mockImplementation(async () => bundleWith(3, Number.MAX_SAFE_INTEGER))
     // Pre-fix, an expired bundle produced a silent no-op with nothing scheduled.
     await vi.advanceTimersByTimeAsync(60_000)
 
     expect(deps.openRelay).toHaveBeenCalledOnce()
+    expect(logical.setRecoveryPath).toHaveBeenCalledWith('relay')
     expect(logical.getActivePath()).toBe('relay')
     supervisor.stop()
   })

--- a/mobile/src/transport/mobile-relay-runtime-failover.test.ts
+++ b/mobile/src/transport/mobile-relay-runtime-failover.test.ts
@@ -92,6 +92,7 @@ class FakeLogicalClient extends FakeSession implements StableLogicalRpcClient {
   private path: MobileConnectionPath
   private recoveryPath: MobileConnectionPath | null = null
   private generation = 1
+  private readonly pathListeners = new Set<() => void>()
 
   constructor(state: ConnectionState, path: MobileConnectionPath) {
     super(state)
@@ -106,15 +107,25 @@ class FakeLogicalClient extends FakeSession implements StableLogicalRpcClient {
     this.path = path
     this.recoveryPath = null
     this.generation += 1
+    // Connected-state publication carries the migration cleanup.
     this.publishState('connected')
   })
   suspendActiveSession = vi.fn(() => this.publishState('disconnected'))
   getActivePath = () => this.path
-  getPendingPath = () => this.recoveryPath
+  getPendingPath = () => (this.getState() === 'connected' ? null : this.recoveryPath)
   setRecoveryPath = vi.fn((path: MobileConnectionPath | null) => {
+    const previous = this.getPendingPath()
     this.recoveryPath = path
+    if (previous !== this.getPendingPath()) {
+      for (const listener of this.pathListeners) {
+        listener()
+      }
+    }
   })
-  onConnectionPathChange = vi.fn(() => () => {})
+  onConnectionPathChange = vi.fn((listener: () => void) => {
+    this.pathListeners.add(listener)
+    return () => this.pathListeners.delete(listener)
+  })
   getGeneration = () => this.generation
 }
 

--- a/mobile/src/transport/relay-credential-eligibility.ts
+++ b/mobile/src/transport/relay-credential-eligibility.ts
@@ -1,0 +1,41 @@
+type RelayCredentialLease = { expiresAt: number; version: number }
+
+export class RelayCredentialEligibility {
+  private readonly rejectedVersions = new Set<number>()
+
+  constructor(private readonly now: () => number) {}
+
+  hasRejected(): boolean {
+    return this.rejectedVersions.size > 0
+  }
+
+  clearRejected(): void {
+    this.rejectedVersions.clear()
+  }
+
+  isRejected(version: number): boolean {
+    return this.rejectedVersions.has(version)
+  }
+
+  recordRejected(version: number): void {
+    this.rejectedVersions.add(version)
+  }
+
+  hasDialable(...credentials: (RelayCredentialLease | null | undefined)[]): boolean {
+    return credentials.some((credential) => this.isDialable(credential))
+  }
+
+  eligible<T extends RelayCredentialLease>(...credentials: (T | null | undefined)[]): T[] {
+    return credentials.filter((credential): credential is T => this.isDialable(credential))
+  }
+
+  private isDialable<T extends RelayCredentialLease>(
+    credential: T | null | undefined
+  ): credential is T {
+    return Boolean(
+      credential &&
+      credential.expiresAt > this.now() &&
+      !this.rejectedVersions.has(credential.version)
+    )
+  }
+}

--- a/mobile/src/transport/rpc-client-context-contract.ts
+++ b/mobile/src/transport/rpc-client-context-contract.ts
@@ -21,6 +21,7 @@ export type RpcClientContextValue = {
   getReconnectAttempt: (hostId: string) => number
   getLastConnectedAt: (hostId: string) => number | null
   getActivePath: (hostId: string) => MobileConnectionPath
+  getPendingPath: (hostId: string) => MobileConnectionPath | null
   subscribeHostState: (hostId: string, listener: (state: ConnectionState) => void) => () => void
   getAllClients: () => { hostId: string; client: RpcClient }[]
   subscribeAllHosts: (listener: () => void) => () => void

--- a/mobile/src/transport/stable-logical-rpc-client.test.ts
+++ b/mobile/src/transport/stable-logical-rpc-client.test.ts
@@ -4,7 +4,8 @@ import type { RpcClient } from './rpc-client'
 import { isRpcDeliveryUnknown, markRpcDeliveryUnknown } from './rpc-delivery-ambiguity'
 import {
   createStableLogicalRpcClient,
-  LogicalClientCutoverError
+  LogicalClientCutoverError,
+  type MobileConnectionPath
 } from './stable-logical-rpc-client'
 
 class FakeSession implements RpcClient {
@@ -259,10 +260,13 @@ describe('stable logical RPC client', () => {
     const client = createStableLogicalRpcClient(direct, 'lan')
     direct.setState('reconnecting')
     const states: ConnectionState[] = []
+    const paths: (MobileConnectionPath | null)[] = []
     client.onStateChange((next) => states.push(next))
+    client.onConnectionPathChange(() => paths.push(client.getPendingPath()))
 
     const migrating = client.migrateTo(replacement, 'relay')
     expect(client.getPendingPath()).toBe('relay')
+    expect(paths).toEqual(['relay'])
     replacement.setState('connecting')
     replacement.setState('handshaking')
 
@@ -276,6 +280,37 @@ describe('stable logical RPC client', () => {
     expect(states).toEqual(['connected'])
     expect(client.getPendingPath()).toBeNull()
     expect(client.getActivePath()).toBe('relay')
+  })
+
+  it('publishes recovery-path changes and keeps Relay pending between failed dials', async () => {
+    const direct = new FakeSession('reconnecting')
+    const replacement = new FakeSession('connecting')
+    const client = createStableLogicalRpcClient(direct, 'tailscale')
+    const paths: (MobileConnectionPath | null)[] = []
+    client.onConnectionPathChange(() => paths.push(client.getPendingPath()))
+
+    client.setRecoveryPath('relay')
+    const migrating = client.migrateTo(replacement, 'relay')
+    replacement.setState('disconnected')
+    await expect(migrating).rejects.toThrow(/disconnected/)
+
+    expect(client.getPendingPath()).toBe('relay')
+    expect(paths).toEqual(['relay'])
+
+    client.setRecoveryPath(null)
+    expect(client.getPendingPath()).toBeNull()
+    expect(paths).toEqual(['relay', null])
+  })
+
+  it('does not revive a stale recovery path after a connection later drops', () => {
+    const direct = new FakeSession('reconnecting')
+    const client = createStableLogicalRpcClient(direct, 'tailscale')
+
+    client.setRecoveryPath('relay')
+    direct.setState('connected')
+    direct.setState('reconnecting')
+
+    expect(client.getPendingPath()).toBeNull()
   })
 
   it('drops the pending path when the previous session recovers mid-dial', async () => {

--- a/mobile/src/transport/stable-logical-rpc-client.ts
+++ b/mobile/src/transport/stable-logical-rpc-client.ts
@@ -6,6 +6,7 @@ import {
 } from './migration-dial-state-forwarder'
 import { waitForAuthenticated } from './replacement-session-authentication'
 import { projectMobileRpcRequestParams } from './mobile-rpc-request-projection'
+import { LogicalClientConnectionPath } from './logical-client-connection-path'
 
 export type MobileConnectionPath = 'lan' | 'tailscale' | 'relay'
 
@@ -47,9 +48,10 @@ export type StableLogicalRpcClient = RpcClient & {
   ): Promise<void>
   suspendActiveSession(): void
   getActivePath(): MobileConnectionPath
-  // Non-null only while a migration dial is publishing its own phases — the path the
-  // user is waiting on, which the still-bound active path can't name.
+  // The path the user is waiting on while migration or scheduled recovery is active.
   getPendingPath(): MobileConnectionPath | null
+  setRecoveryPath(path: MobileConnectionPath | null): void
+  onConnectionPathChange(listener: () => void): () => void
   getGeneration(): number
 }
 
@@ -59,7 +61,6 @@ export function createStableLogicalRpcClient(
 ): StableLogicalRpcClient {
   let activeSession = initialSession
   let activePath = initialPath
-  let pendingPath: MobileConnectionPath | null = null
   let generation = 1
   let closed = false
   let suspended = false
@@ -69,6 +70,7 @@ export function createStableLogicalRpcClient(
   const pendingRequests = new Set<PendingRequest>()
   const stateListeners = new Set<(state: ConnectionState) => void>()
   let state = initialSession.getState()
+  const connectionPath = new LogicalClientConnectionPath(() => state === 'connected')
 
   bindActiveState(initialSession, generation)
 
@@ -207,7 +209,7 @@ export function createStableLogicalRpcClient(
       // (direct dial fails) sits in 'reconnecting' — already amber, so forwarding adds
       // nothing, but the user still has no idea relay is what's being tried.
       if (suspended || state !== 'connected') {
-        pendingPath = path
+        connectionPath.setMigration(path)
       }
       const forwarder = forwardMigrationDialState({
         session: nextSession,
@@ -259,6 +261,7 @@ export function createStableLogicalRpcClient(
       }
       pendingRequests.clear()
       state = nextSession.getState()
+      connectionPath.clearAfterConnected()
       for (const listener of stateListeners) {
         listener(state)
       }
@@ -268,7 +271,9 @@ export function createStableLogicalRpcClient(
     getActivePath: () => activePath,
     // Why: a previous session that recovers mid-dial makes the pending path a lie —
     // once we're connected the user is no longer waiting on anything.
-    getPendingPath: () => (state === 'connected' ? null : pendingPath),
+    getPendingPath: () => connectionPath.pending(),
+    setRecoveryPath: (path) => connectionPath.setRecovery(path),
+    onConnectionPathChange: (listener) => connectionPath.subscribe(listener),
     getGeneration: () => generation
   }
 
@@ -276,7 +281,9 @@ export function createStableLogicalRpcClient(
 
   function endDialForwarding(forwarder: MigrationDialStateForwarder, failed: boolean): void {
     forwarder.stop()
-    pendingPath = null
+    if (failed) {
+      connectionPath.setMigration(null)
+    }
     // Why: only walk back phases we published ourselves — a 'connected' here came from
     // the still-live previous session and outranks the dead dial.
     if (failed && forwarder.forwarded() && state !== 'connected') {
@@ -314,6 +321,9 @@ export function createStableLogicalRpcClient(
       return
     }
     state = next
+    if (next === 'connected') {
+      connectionPath.clearAfterConnected()
+    }
     for (const listener of stateListeners) {
       listener(next)
     }

--- a/mobile/src/transport/use-all-host-clients.ts
+++ b/mobile/src/transport/use-all-host-clients.ts
@@ -136,10 +136,19 @@ export function useAllHostClients(hostIds: string[], options?: UseAllHostClients
       client: RpcClient
       state: ConnectionState
       path: MobileConnectionPath
+      pendingPath: MobileConnectionPath | null
     }>((hostId) => {
       const client = clientsByHostId.get(hostId)
       return client
-        ? [{ hostId, client, state: ctx.getState(hostId), path: ctx.getActivePath(hostId) }]
+        ? [
+            {
+              hostId,
+              client,
+              state: ctx.getState(hostId),
+              path: ctx.getActivePath(hostId),
+              pendingPath: ctx.getPendingPath(hostId)
+            }
+          ]
         : []
     })
   }, [ctx, hostIds, tick])


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​214 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​207 |
| Prod | 20 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​299 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​76 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​223 |

<!-- /orca-pr-loc -->

## ELI5

When direct/Tailscale connectivity fails, Orca may try its cloud Relay. Mobile should say `Connecting via Relay…` only when Relay can actually be attempted. The reverted implementation could claim that indefinitely even when the phone had no usable Relay credential. This reland keeps the useful fallback UI while making it truthful.

## What Changed

- Track the active connection path separately from a pending migration or Relay-recovery path.
- Publish Relay recovery only after selecting a dialable credential, or when a previously active Relay drops with a still-dialable credential.
- Keep Relay pending through genuine failed-dial cooldowns and long-outage escalation.
- Clear pending Relay for missing, expired, or rejected credentials; aborted dials; direct reconnection; backgrounding; and shutdown.
- Notify React consumers when only the pending path changes.
- Make the endpoint-supervisor test doubles mirror production path masking and notification behavior.

## Why

This relands #14922 after the #14976 revert while fixing STA-4567's launch-blocking regression. The prior implementation set Relay pending before credential eligibility was known. If SecureStore had no usable credential, `openRelay()` never ran while the UI still claimed `Connecting via Relay…` indefinitely.

The new presentation state follows the existing dial workflow without changing it. There are no new Relay probes, requests, retries, sockets, timers, wire fields, or occupancy, so happy-path and failure-path Relay load are unchanged.

## Linked Issue

- [STA-4567](https://linear.app/stably/issue/STA-4567)
- Relands #14922 after #14976

## Visual Proof

N/A — this timing-dependent transport-state behavior is covered deterministically; there is no stable screenshot fixture for the credential and network races.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Validation:

- Full mobile suite: 450 files passed; 3,551 tests passed; 3 skipped.
- Focused transport/UI suite: 7 files and 118 tests passed.
- Mobile TypeScript, oxlint, and formatting passed.
- Changed-code quality and React checks passed.
- Reliability manifest and max-lines ratchet passed.
- CI covers packaging and the repository-wide matrix.

## Review

- CodeRabbit's test-double fidelity comment was valid and addressed in `e0da6c7f34`.
- The generic docstring warning is not actionable for this TypeScript change; adding boilerplate comments would conflict with the repository's concise-comment guidance.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- Security: no credential material is exposed or persisted differently.
- Cross-platform and mobile lifecycle behavior are covered; no platform-specific path or shortcut behavior changes.
- SSH, folder workspaces, and remote-wire compatibility are unaffected.
- Performance and Relay capacity: in-memory presentation updates only; zero added cloud Relay traffic or connection occupancy.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: N/A
