### PR TITLE
Add multi-desktop mobile project view

### DIFF
--- a/mobile/app/experimental-settings.tsx
+++ b/mobile/app/experimental-settings.tsx
@@ -1,0 +1,133 @@
+import { useCallback, useEffect, useState } from 'react'
+import { View, Text, StyleSheet, Pressable, ScrollView, Switch } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { useRouter } from 'expo-router'
+import { ChevronLeft } from 'lucide-react-native'
+import { colors, spacing, typography } from '../src/theme/mobile-theme'
+import { loadProjectsHomeEnabled, saveProjectsHomeEnabled } from '../src/storage/preferences'
+
+export default function ExperimentalSettingsScreen(): React.JSX.Element {
+  const router = useRouter()
+  const insets = useSafeAreaInsets()
+  const [projectsHome, setProjectsHome] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    void loadProjectsHomeEnabled().then((enabled) => {
+      if (!cancelled) {
+        setProjectsHome(enabled)
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const toggleProjectsHome = useCallback((enabled: boolean) => {
+    setProjectsHome(enabled)
+    void saveProjectsHomeEnabled(enabled)
+  }, [])
+
+  return (
+    <View style={[styles.container, { paddingTop: insets.top + spacing.sm }]}>
+      <View style={styles.topRow}>
+        <Pressable
+          style={styles.backButton}
+          onPress={() => router.back()}
+          accessibilityRole="button"
+          accessibilityLabel="Back"
+        >
+          <ChevronLeft size={22} color={colors.textSecondary} />
+        </Pressable>
+        <Text style={styles.heading}>Experimental</Text>
+      </View>
+
+      <ScrollView
+        contentContainerStyle={{ paddingBottom: insets.bottom + spacing.lg }}
+        showsVerticalScrollIndicator={false}
+      >
+        <Text style={styles.intro}>
+          Unfinished features. They can change or disappear in any release.
+        </Text>
+
+        <View style={styles.section}>
+          <View style={styles.row}>
+            <View style={styles.rowContent}>
+              <Text style={styles.rowLabel}>Projects home</Text>
+              <Text style={styles.rowSublabel}>
+                Replace the list of desktops with one workspace list covering every paired desktop,
+                filterable by host.
+              </Text>
+            </View>
+            <Switch
+              value={projectsHome}
+              onValueChange={toggleProjectsHome}
+              trackColor={{ false: colors.bgRaised, true: colors.textSecondary }}
+              thumbColor={colors.textPrimary}
+              accessibilityLabel="Projects home"
+            />
+          </View>
+        </View>
+      </ScrollView>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.bgBase,
+    paddingHorizontal: spacing.lg
+  },
+  topRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: spacing.xl
+  },
+  backButton: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: spacing.sm
+  },
+  heading: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: colors.textPrimary
+  },
+  intro: {
+    fontSize: typography.metaSize,
+    color: colors.textSecondary,
+    lineHeight: 17,
+    marginBottom: spacing.md,
+    paddingHorizontal: spacing.xs
+  },
+  section: {
+    backgroundColor: colors.bgPanel,
+    borderRadius: 12,
+    overflow: 'hidden'
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm + 2,
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.md + 2
+  },
+  rowContent: {
+    flex: 1,
+    gap: spacing.xs
+  },
+  rowLabel: {
+    fontSize: typography.bodySize,
+    fontWeight: '500',
+    color: colors.textPrimary
+  },
+  rowSublabel: {
+    fontSize: typography.metaSize,
+    color: colors.textSecondary,
+    lineHeight: 17
+  }
+})

--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -5,16 +5,10 @@ import { useFocusEffect, useLocalSearchParams, usePathname, useRouter } from 'ex
 import {
   Search,
   X,
-  Pin,
   List,
-  SlidersHorizontal,
-  Layers,
-  ChevronDown,
-  ChevronRight,
   ChevronLeft,
   Plus,
   Moon,
-  Filter,
   Check,
   UserCircle,
   PanelLeftClose,
@@ -42,7 +36,8 @@ import type { RpcSuccess } from '../../../src/transport/types'
 import { StatusDot } from '../../../src/components/StatusDot'
 import { NewWorktreeModalController } from '../../../src/components/NewWorktreeModalController'
 import { NewWorkspaceFab, FAB_SIZE } from '../../../src/components/NewWorkspaceFab'
-import { MobileRepoIcon } from '../../../src/components/MobileRepoIcon'
+import { WorkspaceListControls } from '../../../src/components/WorkspaceListControls'
+import { WorkspaceSectionHeader } from '../../../src/components/WorkspaceSectionHeader'
 import { WorktreeListRow } from '../../../src/components/WorktreeListRow'
 import { useNow } from '../../../src/hooks/use-now'
 import { useActiveWorktreeScroll } from '../../../src/hooks/use-active-worktree-scroll'
@@ -59,7 +54,7 @@ import { HostRouteNoticeBanner } from '../../../src/components/HostRouteNoticeBa
 import { visibleHostRouteNotice } from '../../../src/host-route-notice'
 import { MobileSearchField } from '../../../src/components/MobileSearchField'
 import { WorkspaceDetailPlaceholder } from '../../../src/components/WorkspaceDetailPlaceholder'
-import { getCachedWorktrees, setCachedWorktrees } from '../../../src/cache/worktree-cache'
+import { getCachedWorkspaceCatalog, setCachedWorktrees } from '../../../src/cache/worktree-cache'
 import { setCachedRepos } from '../../../src/cache/repo-cache'
 import { colors, radii, spacing, typography } from '../../../src/theme/mobile-theme'
 import { useResponsiveLayout } from '../../../src/layout/responsive-layout'
@@ -131,9 +126,7 @@ export function HostScreen({
   const insets = useSafeAreaInsets()
   // Why: cap and center the list on wide/tablet canvases; on phones isWideLayout is false so it stays edge-to-edge.
   const { isWideLayout, contentMaxWidth } = useResponsiveLayout()
-  const [initialCache] = useState(() =>
-    hostId ? (getCachedWorktrees(hostId) as Worktree[] | null) : null
-  )
+  const [initialCache] = useState(() => (hostId ? getCachedWorkspaceCatalog(hostId) : null))
   // Shared client per host owned by RpcClientProvider. See docs/mobile-shared-client-per-host.md.
   const { client, state: connState } = useHostClient(hostId)
   const reconnectAttempts = useReconnectAttempt(hostId)
@@ -333,7 +326,7 @@ export function HostScreen({
     setRepoIconsByName(new Map())
     repoMetadataFetchedAtRef.current = 0
     // Why: useState initializer runs only on first mount, so re-seed the cache when Expo Router reuses this screen for a new hostId.
-    const freshCache = hostId ? (getCachedWorktrees(hostId) as Worktree[] | null) : null
+    const freshCache = hostId ? getCachedWorkspaceCatalog(hostId) : null
     setCatalogError(null)
     if (freshCache) {
       setWorktrees(freshCache)
@@ -884,60 +877,15 @@ export function HostScreen({
         {embedded ? (
           <View style={styles.embeddedToolbar}>
             <View style={styles.embeddedToolbarRow}>
-              <Pressable
-                style={[
-                  styles.filterChip,
-                  styles.embeddedFilterChip,
-                  activeFilterCount > 0 && styles.filterChipActive
-                ]}
-                onPress={() => setShowFilterModal(true)}
-                accessibilityRole="button"
-                accessibilityLabel={`Filter workspaces${activeFilterCount > 0 ? `, ${activeFilterCount} active` : ''}`}
-              >
-                <Filter
-                  size={12}
-                  color={activeFilterCount > 0 ? colors.textPrimary : colors.textSecondary}
-                />
-                <Text
-                  style={[
-                    styles.filterChipText,
-                    activeFilterCount > 0 && styles.filterChipTextActive
-                  ]}
-                  numberOfLines={1}
-                >
-                  Filter{activeFilterCount > 0 ? ` ${activeFilterCount}` : ''}
-                </Text>
-              </Pressable>
-
-              <Pressable
-                style={[styles.modeButton, styles.embeddedModeButton]}
-                onPress={() => setShowSortPicker(true)}
-                accessibilityRole="button"
-                accessibilityLabel={`Sort by ${selectedSortLabel}`}
-              >
-                <SlidersHorizontal size={14} color={colors.textSecondary} />
-                <Text style={styles.sortLabel} numberOfLines={1}>
-                  {selectedSortLabel}
-                </Text>
-              </Pressable>
-
-              <Pressable
-                style={[styles.modeButton, styles.embeddedModeButton]}
-                onPress={() => setShowGroupPicker(true)}
-                accessibilityRole="button"
-                accessibilityLabel="Group workspaces"
-              >
-                <Layers size={14} color={colors.textSecondary} />
-                <Text style={styles.sortLabel} numberOfLines={1}>
-                  {groupMode === 'none'
-                    ? 'Group'
-                    : groupMode === 'workspaceStatus'
-                      ? 'Status'
-                      : groupMode === 'repo'
-                        ? 'Repo'
-                        : 'PR'}
-                </Text>
-              </Pressable>
+              <WorkspaceListControls
+                layout="compact"
+                activeFilterCount={activeFilterCount}
+                sortLabel={selectedSortLabel}
+                groupMode={groupMode}
+                onOpenFilter={() => setShowFilterModal(true)}
+                onOpenSort={() => setShowSortPicker(true)}
+                onOpenGroup={() => setShowGroupPicker(true)}
+              />
             </View>
 
             <View style={styles.embeddedToolbarRow}>
@@ -1023,43 +971,15 @@ export function HostScreen({
           </View>
         ) : (
           <View style={styles.toolbar}>
-            <Pressable
-              style={[styles.filterChip, activeFilterCount > 0 && styles.filterChipActive]}
-              onPress={() => setShowFilterModal(true)}
-            >
-              <Filter
-                size={12}
-                color={activeFilterCount > 0 ? colors.textPrimary : colors.textSecondary}
-              />
-              <Text
-                style={[
-                  styles.filterChipText,
-                  activeFilterCount > 0 && styles.filterChipTextActive
-                ]}
-              >
-                Filter{activeFilterCount > 0 ? ` (${activeFilterCount})` : ''}
-              </Text>
-            </Pressable>
-
-            <Pressable style={styles.modeButton} onPress={() => setShowSortPicker(true)}>
-              <SlidersHorizontal size={14} color={colors.textSecondary} />
-              <Text style={styles.sortLabel} numberOfLines={1}>
-                {selectedSortLabel}
-              </Text>
-            </Pressable>
-
-            <Pressable style={styles.modeButton} onPress={() => setShowGroupPicker(true)}>
-              <Layers size={14} color={colors.textSecondary} />
-              <Text style={styles.sortLabel} numberOfLines={1}>
-                {groupMode === 'none'
-                  ? 'Group'
-                  : groupMode === 'workspaceStatus'
-                    ? 'Status'
-                    : groupMode === 'repo'
-                      ? 'Repo'
-                      : 'PR'}
-              </Text>
-            </Pressable>
+            <WorkspaceListControls
+              layout="row"
+              activeFilterCount={activeFilterCount}
+              sortLabel={selectedSortLabel}
+              groupMode={groupMode}
+              onOpenFilter={() => setShowFilterModal(true)}
+              onOpenSort={() => setShowSortPicker(true)}
+              onOpenGroup={() => setShowGroupPicker(true)}
+            />
 
             <View style={styles.toolbarSpacer} />
 
@@ -1161,34 +1081,17 @@ export function HostScreen({
             if (!section.title) {
               return null
             }
-            const isCollapsed = collapsedGroups.has(section.key)
-            const rawSection = rawSections.find((s) => s.key === section.key)
-            const count = rawSection?.data.length ?? 0
-            const repoSectionColor =
-              groupMode === 'repo' ? uniqueRepoColors.get(section.title) : null
-            const repoSectionIcon = groupMode === 'repo' ? repoIconsByName.get(section.title) : null
+            const byRepo = groupMode === 'repo'
             return (
-              <Pressable style={styles.sectionHeader} onPress={() => toggleCollapsed(section.key)}>
-                {isCollapsed ? (
-                  <ChevronRight size={12} color={colors.textMuted} style={styles.sectionIcon} />
-                ) : (
-                  <ChevronDown size={12} color={colors.textMuted} style={styles.sectionIcon} />
-                )}
-                {section.icon === 'pin' && (
-                  <Pin size={12} color={colors.textMuted} style={styles.sectionIcon} />
-                )}
-                {groupMode === 'repo' ? (
-                  <View style={styles.sectionRepoIcon}>
-                    <MobileRepoIcon
-                      repoIcon={repoSectionIcon}
-                      size={14}
-                      color={repoSectionColor ?? colors.textSecondary}
-                    />
-                  </View>
-                ) : null}
-                <Text style={styles.sectionTitle}>{section.title}</Text>
-                <Text style={styles.sectionCount}>{count}</Text>
-              </Pressable>
+              <WorkspaceSectionHeader
+                title={section.title}
+                count={rawSections.find((s) => s.key === section.key)?.data.length ?? 0}
+                collapsed={collapsedGroups.has(section.key)}
+                pinnedGroup={section.icon === 'pin'}
+                repoIcon={byRepo ? (repoIconsByName.get(section.title) ?? null) : undefined}
+                repoColor={byRepo ? (uniqueRepoColors.get(section.title) ?? null) : null}
+                onToggle={() => toggleCollapsed(section.key)}
+              />
             )
           }}
           ItemSeparatorComponent={ListSeparator}
@@ -1505,58 +1408,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     gap: spacing.sm
   },
-  embeddedFilterChip: {
-    flex: 1,
-    minWidth: 0,
-    height: 30,
-    justifyContent: 'center',
-    paddingHorizontal: spacing.xs,
-    paddingVertical: 0
-  },
-  embeddedModeButton: {
-    flex: 1,
-    minWidth: 0,
-    height: 30,
-    justifyContent: 'center',
-    paddingHorizontal: spacing.xs,
-    paddingVertical: 0
-  },
-  filterChip: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 4,
-    paddingHorizontal: spacing.sm + 2,
-    paddingVertical: spacing.xs,
-    borderRadius: 12,
-    borderWidth: 1,
-    borderColor: colors.borderSubtle
-  },
-  filterChipActive: {
-    borderColor: colors.textSecondary,
-    backgroundColor: colors.bgRaised
-  },
-  filterChipText: {
-    fontSize: 12,
-    color: colors.textSecondary
-  },
-  filterChipTextActive: {
-    color: colors.textPrimary
-  },
-  modeButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    flexShrink: 1,
-    minWidth: 0,
-    gap: 4,
-    paddingHorizontal: spacing.sm,
-    paddingVertical: spacing.xs
-  },
-  sortLabel: {
-    flexShrink: 1,
-    minWidth: 0,
-    fontSize: 12,
-    color: colors.textSecondary
-  },
   toolbarSpacer: {
     flex: 1
   },
@@ -1602,31 +1453,6 @@ const styles = StyleSheet.create({
   },
   list: {
     paddingBottom: spacing.lg
-  },
-  sectionHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: spacing.lg,
-    paddingTop: spacing.md,
-    paddingBottom: spacing.xs
-  },
-  sectionIcon: {
-    marginRight: spacing.xs
-  },
-  sectionRepoIcon: {
-    marginRight: spacing.xs
-  },
-  sectionTitle: {
-    fontSize: 11,
-    fontWeight: '600',
-    color: colors.textMuted,
-    textTransform: 'uppercase',
-    letterSpacing: 0.5
-  },
-  sectionCount: {
-    fontSize: 11,
-    color: colors.textMuted,
-    marginLeft: spacing.xs
   },
   separator: {
     height: 1,

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -21,7 +21,7 @@ import { useOpenMobileHostEdit } from '../src/transport/use-open-mobile-host-edi
 import { removeHostAndCloseClient } from '../src/transport/host-removal-lifecycle'
 import { fetchHomeHostWorktreeInfo } from '../src/worktree/home-host-worktree-fetch'
 import { totalHomeStats, type HomeStatsSummary } from '../src/stats/home-stats-total'
-import type { HomeWorktreeSummary, HostWorktreeInfo } from '../src/worktree/home-worktree-info'
+import type { HostWorktreeInfo } from '../src/worktree/home-worktree-info'
 import type { RpcClient } from '../src/transport/rpc-client'
 import { createHostConnectRefetchGate } from '../src/transport/host-connect-refetch-gate'
 import { sendSingleFlightRequest } from '../src/transport/request-single-flight'
@@ -29,7 +29,8 @@ import {
   useDisconnectHostClient,
   useForceReconnect,
   useForgetHostClient,
-  usePrimeHosts
+  usePrimeHosts,
+  useRpcClientContext
 } from '../src/transport/client-context'
 import { useAllHostClients } from '../src/transport/use-all-host-clients'
 import {
@@ -46,6 +47,9 @@ import type { ConnectionState, HostCatalogEntry, HostProfile } from '../src/tran
 import { triggerMediumImpact } from '../src/platform/haptics'
 import { OrcaLogo } from '../src/components/OrcaLogo'
 import { MobileHostCard } from '../src/components/MobileHostCard'
+import { ProjectsHomeList } from '../src/components/ProjectsHomeList'
+import type { DesktopClient } from '../src/worktree/use-merged-desktop-catalogs'
+import { loadProjectsHomeEnabled } from '../src/storage/preferences'
 import { MobileHomeQuickActions } from '../src/components/MobileHomeQuickActions'
 import { TaskProviderLogo } from '../src/components/TaskProviderLogo'
 import { ActionSheetModal } from '../src/components/ActionSheetModal'
@@ -79,6 +83,8 @@ import {
 import { hostRouteWithNotice } from '../src/host-route-notice'
 import { hostNewWorktreeRoute } from '../src/host-route-action-state'
 import { hostEndpointLabel } from '../src/transport/host-endpoint-label'
+import { acquireTransientHostClient } from '../src/transport/transient-host-client'
+import { buildProjectsHomeDesktopRoster } from '../src/worktree/projects-home-desktop-roster'
 
 type HomeTaskSettings = {
   visibleTaskProviders?: unknown
@@ -244,6 +250,8 @@ export default function HomeScreen() {
   // Why: focus can fire repeatedly while an async gate is pending; one probe per
   // mount avoids duplicate storage/permission reads and competing navigation.
   const onboardingOptInCheckedRef = useRef(false)
+  // Experimental: swaps the desktop cards for one merged workspace list.
+  const [projectsHomeEnabled, setProjectsHomeEnabled] = useState(false)
 
   // Why: shared clients from the per-host store, not N independent WebSockets. See docs/mobile-shared-client-per-host.md.
   const hosts = useMemo(() => selectConnectableHostProfiles(hostCatalog), [hostCatalog])
@@ -263,6 +271,12 @@ export default function HomeScreen() {
   const forgetHostClient = useForgetHostClient()
   const forceReconnectHost = useForceReconnect()
   const primeHosts = usePrimeHosts()
+  const rpcClientContext = useRpcClientContext()
+  const acquireProjectsHomeClient = useCallback(
+    (profile: HostProfile, signal?: AbortSignal, onClientOwned?: (client: RpcClient) => void) =>
+      acquireTransientHostClient(rpcClientContext, profile, { signal, onClientOwned }),
+    [rpcClientContext]
+  )
   // Why: prime the cache with loaded HostProfiles to avoid a second serialized Keychain pass (multi-second connect latency) on cold start.
   useEffect(() => {
     if (hosts.length > 0) {
@@ -333,6 +347,12 @@ export default function HomeScreen() {
         }
         if (onboardingSteps.length > 0) {
           router.replace(mobileOnboardingDestination(onboardingSteps))
+        }
+      })
+      // Re-read on focus so returning from Settings applies the toggle immediately.
+      void loadProjectsHomeEnabled().then((enabled) => {
+        if (!stale) {
+          setProjectsHomeEnabled(enabled)
         }
       })
       void AsyncStorage.getItem(LAST_VISITED_WORKTREE_STORAGE_KEY).then((raw) => {
@@ -524,7 +544,7 @@ export default function HomeScreen() {
         hostStates,
         worktreeInfo,
         lastVisited,
-        cachedWorktrees: (hostId) => getCachedWorktrees(hostId) as HomeWorktreeSummary[] | null
+        cachedWorktrees: (hostId) => getCachedWorktrees(hostId)
       }),
     [sortedHosts, hostStates, worktreeInfo, lastVisited]
   )
@@ -535,12 +555,7 @@ export default function HomeScreen() {
   // through and the session screen bounces once the host answers (F7).
   const openResume = useCallback(
     (card: HomeResumeCard) => {
-      if (
-        isResumeTargetConfirmedMissing(
-          card,
-          getProvenCachedWorktrees(card.hostId) as HomeWorktreeSummary[] | null
-        )
-      ) {
+      if (isResumeTargetConfirmedMissing(card, getProvenCachedWorktrees(card.hostId))) {
         router.push(hostRouteWithNotice(card.hostId, 'worktree-missing'))
         return
       }
@@ -657,6 +672,23 @@ export default function HomeScreen() {
       setConfirmRemove(hostToRemove)
       Alert.alert('Could not remove host', 'Please try again.')
     }
+  }
+
+  const desktops = useMemo<DesktopClient[]>(() => {
+    return buildProjectsHomeDesktopRoster(
+      hostCatalog,
+      allClients,
+      autoConnectHostIds,
+      acquireProjectsHomeClient
+    )
+  }, [acquireProjectsHomeClient, allClients, autoConnectHostIds, hostCatalog])
+
+  // Experimental Projects home replaces the desktop cards outright. It needs at
+  // least one connectable desktop: onboarding owns the unpaired state, and a
+  // catalog of only unpaired hosts must keep the cards, whose repair tap is the
+  // sole route back to pairing.
+  if (projectsHomeEnabled && hosts.length > 0) {
+    return <ProjectsHomeList desktops={desktops} onOpenSettings={() => router.push('/settings')} />
   }
 
   return (

--- a/mobile/app/settings.tsx
+++ b/mobile/app/settings.tsx
@@ -16,6 +16,7 @@ import {
   Info,
   Bell,
   Wrench,
+  FlaskConical,
   Shield,
   LifeBuoy,
   Mic,
@@ -148,6 +149,15 @@ export default function SettingsScreen() {
           >
             <Bell size={16} color={colors.textSecondary} />
             <Text style={styles.rowLabel}>Notifications</Text>
+            <ChevronRight size={16} color={colors.textMuted} />
+          </Pressable>
+          <View style={styles.separator} />
+          <Pressable
+            style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
+            onPress={() => router.push('/experimental-settings')}
+          >
+            <FlaskConical size={16} color={colors.textSecondary} />
+            <Text style={styles.rowLabel}>Experimental</Text>
             <ChevronRight size={16} color={colors.textMuted} />
           </Pressable>
           <View style={styles.separator} />

--- a/mobile/src/cache/repo-cache.test.ts
+++ b/mobile/src/cache/repo-cache.test.ts
@@ -4,23 +4,51 @@ import { getCachedRepos, setCachedRepos } from './repo-cache'
 
 describe('repo cache', () => {
   it('returns recent host-scoped repos', () => {
-    const repos = [{ id: 'repo-1' }]
+    const repos = [{ id: 'repo-1', displayName: 'Repo 1' }]
 
     setCachedRepos('host-1', repos)
 
-    expect(getCachedRepos('host-1')).toBe(repos)
+    expect(getCachedRepos('host-1')).toEqual(repos)
     expect(getCachedRepos('host-2')).toBeNull()
   })
 
-  it('expires stale entries', () => {
+  it('keeps validated stale entries available as an explicit fallback', () => {
     vi.useFakeTimers()
     try {
-      setCachedRepos('host-stale', [{ id: 'repo-stale' }])
+      setCachedRepos('host-stale', [{ id: 'repo-stale', displayName: 'Stale' }])
       vi.advanceTimersByTime(60_001)
+      setCachedRepos('host-stale', [
+        { id: 'repo-poisoned', displayName: 'Poisoned', badgeColor: 'not-a-color' }
+      ])
 
       expect(getCachedRepos('host-stale')).toBeNull()
+      expect(getCachedRepos('host-stale', { allowStale: true })).toEqual([
+        { id: 'repo-stale', displayName: 'Stale' }
+      ])
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('does not replace safe metadata with malformed render decorations', () => {
+    const safe = [{ id: 'repo-safe', displayName: 'Safe', badgeColor: '#abcdef' }]
+    setCachedRepos('host-poisoned', safe)
+
+    setCachedRepos('host-poisoned', [
+      {
+        id: 'repo-poisoned',
+        displayName: 'Poisoned',
+        badgeColor: 'url(javascript:alert(1))'
+      }
+    ])
+    setCachedRepos('host-poisoned', [
+      {
+        id: 'repo-poisoned-icon',
+        displayName: 'Poisoned icon',
+        repoIcon: { type: 'image', source: 'favicon', src: 'http://example.test/icon.png' }
+      }
+    ])
+
+    expect(getCachedRepos('host-poisoned')).toEqual(safe)
   })
 })

--- a/mobile/src/cache/repo-cache.ts
+++ b/mobile/src/cache/repo-cache.ts
@@ -2,8 +2,27 @@
 // host-scoped cache lets workspace creation open from the last known list while
 // a fresh repo.list refresh happens in the background.
 
+import { normalizeExecutionHostId, type ExecutionHostId } from '../../../src/shared/execution-host'
+import type { GitRemoteIdentity } from '../../../src/shared/git-remote-identity'
+import type { GitHubRepositoryIdentity } from '../../../src/shared/github/pull-request-types'
+import { normalizeRepoBadgeColor } from '../../../src/shared/repo-badge-color'
+import { sanitizeRepoIcon, type RepoIcon } from '../../../src/shared/repo-icon'
+
+export type CachedRepo = {
+  id: string
+  displayName: string
+  path?: string
+  badgeColor?: string
+  connectionId?: string | null
+  executionHostId?: ExecutionHostId | null
+  kind?: 'git' | 'folder'
+  upstream?: GitHubRepositoryIdentity | null
+  repoIcon?: RepoIcon | null
+  gitRemoteIdentity?: GitRemoteIdentity | null
+}
+
 type CachedRepos = {
-  repos: unknown[]
+  repos: CachedRepo[]
   at: number
 }
 
@@ -12,9 +31,117 @@ const cache = new Map<string, CachedRepos>()
 const MAX_AGE_MS = 60_000
 const MAX_ENTRIES = 20
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function optionalString(value: unknown): value is string | undefined {
+  return value === undefined || typeof value === 'string'
+}
+
+function nullableString(value: unknown): value is string | null | undefined {
+  return value === null || optionalString(value)
+}
+
+function readUpstream(value: unknown): GitHubRepositoryIdentity | null | undefined {
+  if (value === undefined || value === null) {
+    return value
+  }
+  if (
+    !isRecord(value) ||
+    typeof value.owner !== 'string' ||
+    value.owner.length === 0 ||
+    typeof value.repo !== 'string' ||
+    value.repo.length === 0 ||
+    !optionalString(value.host)
+  ) {
+    return undefined
+  }
+  return {
+    owner: value.owner,
+    repo: value.repo,
+    ...(value.host ? { host: value.host } : {})
+  }
+}
+
+function readGitRemoteIdentity(value: unknown): GitRemoteIdentity | null | undefined {
+  if (value === undefined || value === null) {
+    return value
+  }
+  if (
+    !isRecord(value) ||
+    typeof value.canonicalKey !== 'string' ||
+    typeof value.remoteName !== 'string' ||
+    typeof value.remoteUrl !== 'string'
+  ) {
+    return undefined
+  }
+  return {
+    canonicalKey: value.canonicalKey,
+    remoteName: value.remoteName,
+    remoteUrl: value.remoteUrl
+  }
+}
+
+function readRepo(value: unknown): CachedRepo | null {
+  if (!isRecord(value)) {
+    return null
+  }
+  const executionHostId =
+    value.executionHostId === undefined || value.executionHostId === null
+      ? value.executionHostId
+      : typeof value.executionHostId === 'string'
+        ? normalizeExecutionHostId(value.executionHostId)
+        : null
+  const badgeColor =
+    value.badgeColor === undefined ? undefined : normalizeRepoBadgeColor(value.badgeColor)
+  const repoIcon = sanitizeRepoIcon(value.repoIcon)
+  const upstream = readUpstream(value.upstream)
+  const gitRemoteIdentity = readGitRemoteIdentity(value.gitRemoteIdentity)
+  if (
+    typeof value.id !== 'string' ||
+    value.id.length === 0 ||
+    typeof value.displayName !== 'string' ||
+    !optionalString(value.path) ||
+    !nullableString(value.connectionId) ||
+    (value.executionHostId !== undefined && value.executionHostId !== null && !executionHostId) ||
+    (value.badgeColor !== undefined && !badgeColor) ||
+    (value.kind !== undefined && value.kind !== 'git' && value.kind !== 'folder') ||
+    (value.upstream !== undefined && upstream === undefined) ||
+    (value.repoIcon !== undefined && repoIcon === undefined) ||
+    (value.gitRemoteIdentity !== undefined && gitRemoteIdentity === undefined)
+  ) {
+    return null
+  }
+  return {
+    id: value.id,
+    displayName: value.displayName,
+    ...(typeof value.path === 'string' ? { path: value.path } : {}),
+    ...(badgeColor ? { badgeColor } : {}),
+    ...(value.connectionId !== undefined ? { connectionId: value.connectionId } : {}),
+    ...(executionHostId !== undefined ? { executionHostId } : {}),
+    ...(value.kind ? { kind: value.kind } : {}),
+    ...(upstream !== undefined ? { upstream } : {}),
+    ...(repoIcon !== undefined ? { repoIcon } : {}),
+    ...(gitRemoteIdentity !== undefined ? { gitRemoteIdentity } : {})
+  }
+}
+
+export function readMobileRepoCatalog(value: unknown): CachedRepo[] | null {
+  if (!Array.isArray(value)) {
+    return null
+  }
+  const repos = value.map(readRepo)
+  return repos.every((repo) => repo !== null) ? repos : null
+}
+
 export function setCachedRepos(hostId: string, repos: unknown[]): void {
+  const validated = readMobileRepoCatalog(repos)
+  if (!validated) {
+    return
+  }
   cache.delete(hostId)
-  cache.set(hostId, { repos, at: Date.now() })
+  cache.set(hostId, { repos: validated, at: Date.now() })
   if (cache.size > MAX_ENTRIES) {
     const oldest = cache.keys().next().value
     if (oldest) {
@@ -23,14 +150,21 @@ export function setCachedRepos(hostId: string, repos: unknown[]): void {
   }
 }
 
-export function getCachedRepos(hostId: string): unknown[] | null {
+export function getCachedRepos(
+  hostId: string,
+  options: { allowStale?: boolean } = {}
+): CachedRepo[] | null {
   const entry = cache.get(hostId)
   if (!entry) {
     return null
   }
-  if (Date.now() - entry.at > MAX_AGE_MS) {
+  if (!options.allowStale && Date.now() - entry.at > MAX_AGE_MS) {
+    return null
+  }
+  const validated = readMobileRepoCatalog(entry.repos)
+  if (!validated) {
     cache.delete(hostId)
     return null
   }
-  return entry.repos
+  return validated
 }

--- a/mobile/src/cache/worktree-cache.test.ts
+++ b/mobile/src/cache/worktree-cache.test.ts
@@ -112,6 +112,15 @@ describe('worktree-cache provenance', () => {
     expect(getProvenCachedWorktrees(hostId)).toBeNull()
   })
 
+  it('keeps a valid summary entry when the full-catalog reader cannot use it', () => {
+    const hostId = 'host-summary-shape'
+    const seeded = [summary('a')]
+    setCachedWorktrees(hostId, seeded)
+
+    expect(getCachedWorkspaceCatalog(hostId)).toBeNull()
+    expect(getCachedWorktrees(hostId)).toEqual(seeded)
+  })
+
   it('reports nothing proven for a host it has never cached', () => {
     expect(getProvenCachedWorktrees('host-never-seen')).toBeNull()
   })

--- a/mobile/src/cache/worktree-cache.test.ts
+++ b/mobile/src/cache/worktree-cache.test.ts
@@ -1,5 +1,38 @@
 import { describe, expect, it } from 'vitest'
-import { setCachedWorktrees, getCachedWorktrees, getProvenCachedWorktrees } from './worktree-cache'
+import {
+  getCachedWorktrees,
+  getCachedWorkspaceCatalog,
+  getProvenCachedWorktrees,
+  setCachedWorktrees
+} from './worktree-cache'
+import type { Worktree } from '../worktree/workspace-list-types'
+
+function summary(worktreeId: string, displayName = worktreeId) {
+  return {
+    worktreeId,
+    repo: 'orca',
+    branch: 'main',
+    displayName,
+    liveTerminalCount: 0
+  }
+}
+
+function workspace(worktreeId: string): Worktree {
+  return {
+    worktreeId,
+    repoId: 'repo-1',
+    repo: 'orca',
+    branch: 'main',
+    displayName: worktreeId,
+    path: `/tmp/${worktreeId}`,
+    liveTerminalCount: 0,
+    hasAttachedPty: false,
+    preview: '',
+    unread: false,
+    isPinned: false,
+    linkedPR: null
+  }
+}
 
 // Why: AC #8498 guarantees a reconnect refetch writes through the
 // same cache path the host detail screen seeds from, so a reconnect can't
@@ -7,11 +40,8 @@ import { setCachedWorktrees, getCachedWorktrees, getProvenCachedWorktrees } from
 describe('worktree-cache write-through', () => {
   it('returns the most-recently written snapshot, not a stale one', () => {
     const hostId = 'host-write-through'
-    const stale = [{ worktreeId: 'a', name: 'stale' }]
-    const fresh = [
-      { worktreeId: 'a', name: 'fresh' },
-      { worktreeId: 'b', name: 'added' }
-    ]
+    const stale = [summary('a', 'stale')]
+    const fresh = [summary('a', 'fresh'), summary('b', 'added')]
 
     setCachedWorktrees(hostId, stale)
     expect(getCachedWorktrees(hostId)).toEqual(stale)
@@ -28,13 +58,10 @@ describe('worktree-cache write-through', () => {
     // on (re)mount as its initialCache. A reconnect that writes
     // through must therefore surface here instead of the pre-reconnect data.
     const hostId = 'host-remount'
-    setCachedWorktrees(hostId, [{ worktreeId: 'old', name: 'pre-reconnect' }])
+    setCachedWorktrees(hostId, [summary('old', 'pre-reconnect')])
 
     // Reconnect refetch lands a fresh snapshot and writes it through.
-    const reconnected = [
-      { worktreeId: 'old', name: 'post-reconnect' },
-      { worktreeId: 'new', name: 'now-visible' }
-    ]
+    const reconnected = [summary('old', 'post-reconnect'), summary('new', 'now-visible')]
     setCachedWorktrees(hostId, reconnected)
 
     // A fresh screen mount reads the cache — must see the connected set.
@@ -48,7 +75,7 @@ describe('worktree-cache write-through', () => {
 describe('worktree-cache provenance', () => {
   it('withholds unmarked writes from the proven reader', () => {
     const hostId = 'host-seeded'
-    const seeded = [{ worktreeId: 'a' }]
+    const seeded = [summary('a')]
 
     setCachedWorktrees(hostId, seeded)
 
@@ -58,7 +85,7 @@ describe('worktree-cache provenance', () => {
 
   it('exposes a host-listed catalog to the proven reader', () => {
     const hostId = 'host-proven'
-    const listed = [{ worktreeId: 'a' }, { worktreeId: 'b' }]
+    const listed = [summary('a'), summary('b')]
 
     setCachedWorktrees(hostId, listed, { proven: true })
 
@@ -67,25 +94,37 @@ describe('worktree-cache provenance', () => {
 
   it('keeps a fresh proven catalog when an unproven seed lands after it', () => {
     const hostId = 'host-kept'
-    const listed = [{ worktreeId: 'a' }, { worktreeId: 'b' }]
+    const listed = [summary('a'), summary('b')]
     setCachedWorktrees(hostId, listed, { proven: true })
 
     // A cold-start snapshot seed must neither truncate nor de-prove the host-listed rows.
-    setCachedWorktrees(hostId, [{ worktreeId: 'a' }])
+    setCachedWorktrees(hostId, [summary('a')])
 
     expect(getProvenCachedWorktrees(hostId)).toEqual(listed)
   })
 
   it('lets an unproven seed replace another unproven entry', () => {
     const hostId = 'host-reseeded'
-    setCachedWorktrees(hostId, [{ worktreeId: 'a' }])
-    setCachedWorktrees(hostId, [{ worktreeId: 'b' }])
+    setCachedWorktrees(hostId, [summary('a')])
+    setCachedWorktrees(hostId, [summary('b')])
 
-    expect(getCachedWorktrees(hostId)).toEqual([{ worktreeId: 'b' }])
+    expect(getCachedWorktrees(hostId)).toEqual([summary('b')])
     expect(getProvenCachedWorktrees(hostId)).toBeNull()
   })
 
   it('reports nothing proven for a host it has never cached', () => {
     expect(getProvenCachedWorktrees('host-never-seen')).toBeNull()
+  })
+
+  it('keeps a safe full catalog when a malformed full payload tries to replace it', () => {
+    const hostId = 'host-poisoned'
+    const safe = workspace('safe')
+    setCachedWorktrees(hostId, [safe], { proven: true })
+
+    setCachedWorktrees(hostId, [
+      { ...workspace('poison'), linkedPR: { number: '7', state: 'open' } }
+    ])
+
+    expect(getCachedWorkspaceCatalog(hostId)).toEqual([safe])
   })
 })

--- a/mobile/src/cache/worktree-cache.ts
+++ b/mobile/src/cache/worktree-cache.ts
@@ -2,8 +2,12 @@
 // so the host detail page can render instantly on navigation instead of
 // waiting for a fresh RPC connection + fetch cycle.
 
+import { readMergedWorktreeRows } from '../worktree/merged-desktop-catalog-response'
+import type { HomeWorktreeSummary } from '../worktree/home-worktree-info'
+import type { Worktree } from '../worktree/workspace-list-types'
+
 type CachedWorktrees = {
-  worktrees: unknown[]
+  worktrees: Worktree[] | HomeWorktreeSummary[]
   at: number
   // Whether the host itself listed these rows this session, as opposed to a cold-start seed
   // rebuilt from a persisted snapshot. Only a proven list can prove a worktree *absent*.
@@ -20,6 +24,10 @@ export function setCachedWorktrees(
   worktrees: unknown[],
   options?: { proven?: boolean }
 ): void {
+  const validated = readMergedWorktreeRows(worktrees) ?? readHomeWorktreeSummaries(worktrees)
+  if (!validated) {
+    return
+  }
   // Why: a cold-start snapshot seed landing after a live worktree.ps must not erase
   // the proof — or truncate the host-listed rows — the resume check depends on.
   if (options?.proven !== true && readFreshEntry(hostId)?.proven) {
@@ -31,7 +39,7 @@ export function setCachedWorktrees(
   cache.delete(hostId)
   // Default false: a caller that has not said where the rows came from must never be taken
   // as grounds for redirecting the user away from a workspace.
-  cache.set(hostId, { worktrees, at: Date.now(), proven: options?.proven === true })
+  cache.set(hostId, { worktrees: validated, at: Date.now(), proven: options?.proven === true })
   if (cache.size > MAX_ENTRIES) {
     const oldest = cache.keys().next().value
     if (oldest) {
@@ -40,15 +48,109 @@ export function setCachedWorktrees(
   }
 }
 
-export function getCachedWorktrees(hostId: string): unknown[] | null {
-  return readFreshEntry(hostId)?.worktrees ?? null
+export function getCachedWorktrees(hostId: string): HomeWorktreeSummary[] | null {
+  return readValidatedSummaries(hostId, readFreshEntry(hostId))
+}
+
+export function getCachedWorkspaceCatalog(hostId: string): Worktree[] | null {
+  return readValidatedCatalog(hostId, readFreshEntry(hostId))
 }
 
 /** The rows only when the host listed them itself — null whenever absence cannot be trusted,
  *  which is every unproven or expired entry. */
-export function getProvenCachedWorktrees(hostId: string): unknown[] | null {
+export function getProvenCachedWorktrees(hostId: string): HomeWorktreeSummary[] | null {
   const entry = readFreshEntry(hostId)
-  return entry?.proven ? entry.worktrees : null
+  return entry?.proven ? readValidatedSummaries(hostId, entry) : null
+}
+
+export function getProvenCachedWorkspaceCatalog(hostId: string): Worktree[] | null {
+  const entry = readFreshEntry(hostId)
+  return entry?.proven ? readValidatedCatalog(hostId, entry) : null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function readHomeWorktreeSummaries(value: unknown): HomeWorktreeSummary[] | null {
+  if (!Array.isArray(value)) {
+    return null
+  }
+  const summaries: HomeWorktreeSummary[] = []
+  for (const row of value) {
+    if (
+      !isRecord(row) ||
+      'repoId' in row ||
+      'linkedPR' in row ||
+      'agents' in row ||
+      typeof row.worktreeId !== 'string' ||
+      typeof row.repo !== 'string' ||
+      typeof row.branch !== 'string' ||
+      typeof row.displayName !== 'string' ||
+      typeof row.liveTerminalCount !== 'number' ||
+      !Number.isFinite(row.liveTerminalCount) ||
+      (row.status !== undefined &&
+        row.status !== 'working' &&
+        row.status !== 'active' &&
+        row.status !== 'permission' &&
+        row.status !== 'done' &&
+        row.status !== 'inactive') ||
+      (row.isActive !== undefined && typeof row.isActive !== 'boolean') ||
+      (row.lastOutputAt !== undefined &&
+        (typeof row.lastOutputAt !== 'number' || !Number.isFinite(row.lastOutputAt)))
+    ) {
+      return null
+    }
+    summaries.push({
+      worktreeId: row.worktreeId,
+      repo: row.repo,
+      branch: row.branch,
+      displayName: row.displayName,
+      liveTerminalCount: row.liveTerminalCount,
+      ...(row.status !== undefined ? { status: row.status } : {}),
+      ...(row.isActive !== undefined ? { isActive: row.isActive } : {}),
+      ...(row.lastOutputAt !== undefined ? { lastOutputAt: row.lastOutputAt } : {})
+    })
+  }
+  return summaries
+}
+
+function readValidatedSummaries(
+  hostId: string,
+  entry: CachedWorktrees | null
+): HomeWorktreeSummary[] | null {
+  if (!entry) {
+    return null
+  }
+  const validated =
+    readHomeWorktreeSummaries(entry.worktrees) ??
+    readMergedWorktreeRows(entry.worktrees)?.map((row) => ({
+      worktreeId: row.worktreeId,
+      repo: row.repo,
+      branch: row.branch,
+      displayName: row.displayName,
+      liveTerminalCount: row.liveTerminalCount,
+      ...(row.status !== undefined ? { status: row.status } : {}),
+      ...(row.isActive !== undefined ? { isActive: row.isActive } : {}),
+      ...(row.lastOutputAt !== undefined ? { lastOutputAt: row.lastOutputAt } : {})
+    }))
+  if (!validated) {
+    cache.delete(hostId)
+    return null
+  }
+  return validated
+}
+
+function readValidatedCatalog(hostId: string, entry: CachedWorktrees | null): Worktree[] | null {
+  if (!entry) {
+    return null
+  }
+  const validated = readMergedWorktreeRows(entry.worktrees)
+  if (!validated) {
+    cache.delete(hostId)
+    return null
+  }
+  return validated
 }
 
 function readFreshEntry(hostId: string): CachedWorktrees | null {

--- a/mobile/src/cache/worktree-cache.ts
+++ b/mobile/src/cache/worktree-cache.ts
@@ -147,7 +147,9 @@ function readValidatedCatalog(hostId: string, entry: CachedWorktrees | null): Wo
   }
   const validated = readMergedWorktreeRows(entry.worktrees)
   if (!validated) {
-    cache.delete(hostId)
+    if (!readHomeWorktreeSummaries(entry.worktrees)) {
+      cache.delete(hostId)
+    }
     return null
   }
   return validated

--- a/mobile/src/components/NewWorktreeModal.tsx
+++ b/mobile/src/components/NewWorktreeModal.tsx
@@ -42,7 +42,7 @@ import {
   resolveNewWorktreeAgentSelection,
   type NewWorktreeAgentOption as AgentOption
 } from './new-worktree-agent-selection'
-import { getCachedRepos, setCachedRepos } from '../cache/repo-cache'
+import { getCachedRepos, readMobileRepoCatalog, setCachedRepos } from '../cache/repo-cache'
 import { useLastVisitedWorktreeRepoId } from '../worktree/use-last-visited-worktree-repo'
 import {
   getMobileNewWorkspaceDialogEligibleRepos,
@@ -87,6 +87,14 @@ type Repo = Pick<SharedRepo, 'id' | 'displayName' | 'path'> &
       | 'gitRemoteIdentity'
     >
   >
+
+function readNewWorktreeRepos(value: unknown): Repo[] | null {
+  const repos = readMobileRepoCatalog(value)
+  if (!repos) {
+    return null
+  }
+  return repos.filter((repo): repo is Repo => typeof repo.path === 'string')
+}
 
 type SetupDecision = 'inherit' | 'run' | 'skip'
 type SetupRunPolicy = 'ask' | 'run-by-default' | 'skip-by-default'
@@ -196,7 +204,9 @@ function NewWorktreeModalContent({
   onCreated,
   onClose
 }: Props) {
-  const [initialRepos] = useState(() => (hostId ? (getCachedRepos(hostId) as Repo[] | null) : null))
+  const [initialRepos] = useState(() =>
+    hostId ? readNewWorktreeRepos(getCachedRepos(hostId, { allowStale: true })) : null
+  )
   const [repos, setRepos] = useState<Repo[]>(initialRepos ?? [])
   const [selectedRepo, setSelectedRepo] = useState<Repo | null>(null)
   // Why: a deleted workspace's directory can still hold agent conversation state keyed by cwd, so
@@ -338,15 +348,19 @@ function NewWorktreeModalContent({
           return
         }
         if (repoResponse.ok) {
-          const result = (repoResponse as RpcSuccess).result as { repos: Repo[] }
-          setRepos(result.repos)
+          const result = (repoResponse as RpcSuccess).result as { repos?: unknown }
+          const receivedRepos = readNewWorktreeRepos(result.repos)
+          if (!receivedRepos) {
+            return
+          }
+          setRepos(receivedRepos)
           if (hostId) {
-            setCachedRepos(hostId, result.repos)
+            setCachedRepos(hostId, receivedRepos)
           }
           setSelectedRepo((current) => {
             // Why: the optimistic cache can include repos removed before the
             // fresh repo.list returns; never create against a stale repo id.
-            return refreshMobileNewWorkspaceDialogSelectedRepo(result.repos, current)
+            return refreshMobileNewWorkspaceDialogSelectedRepo(receivedRepos, current)
           })
         }
       })

--- a/mobile/src/components/ProjectsHomeFilterDrawer.tsx
+++ b/mobile/src/components/ProjectsHomeFilterDrawer.tsx
@@ -1,0 +1,146 @@
+// Filter sheet for the merged Projects home. Mirrors the per-host list's sheet and
+// adds the execution-host section, which only a cross-desktop list can offer.
+
+import { View, Text, StyleSheet, Pressable } from 'react-native'
+import { Check } from 'lucide-react-native'
+import { colors, spacing, typography } from '../theme/mobile-theme'
+import type { ExecutionHostFilterOption } from '../worktree/merged-desktop-workspaces'
+import type { FilterState } from '../worktree/workspace-list-types'
+import { BottomDrawer } from './BottomDrawer'
+
+type Props = {
+  visible: boolean
+  filters: FilterState
+  executionHostOptions: readonly ExecutionHostFilterOption[]
+  activeFilterCount: number
+  onToggleHideSleeping: () => void
+  onToggleHideDefaultBranch: () => void
+  onToggleExecutionHost: (hostId: string) => void
+  onClearFilters: () => void
+  onClose: () => void
+}
+
+export function ProjectsHomeFilterDrawer({
+  visible,
+  filters,
+  executionHostOptions,
+  activeFilterCount,
+  onToggleHideSleeping,
+  onToggleHideDefaultBranch,
+  onToggleExecutionHost,
+  onClearFilters,
+  onClose
+}: Props): React.JSX.Element {
+  const selectedHostIds = filters.filterExecutionHostIds
+  return (
+    <BottomDrawer visible={visible} onClose={onClose}>
+      <View style={styles.header}>
+        <Text style={styles.title}>Filter</Text>
+        {activeFilterCount > 0 ? (
+          <Pressable onPress={onClearFilters} accessibilityRole="button">
+            <Text style={styles.clearText}>Clear filters</Text>
+          </Pressable>
+        ) : null}
+      </View>
+
+      <Text style={styles.sectionLabel}>Workspaces</Text>
+      <View style={styles.group}>
+        <Pressable style={styles.row} onPress={onToggleHideSleeping} accessibilityRole="button">
+          <Text style={styles.rowText}>Hide sleeping</Text>
+          {filters.hideSleeping ? <Check size={14} color={colors.textPrimary} /> : null}
+        </Pressable>
+        <View style={styles.separator} />
+        <Pressable
+          style={styles.row}
+          onPress={onToggleHideDefaultBranch}
+          accessibilityRole="button"
+        >
+          <Text style={styles.rowText}>Hide default branch</Text>
+          {filters.hideDefaultBranch ? <Check size={14} color={colors.textPrimary} /> : null}
+        </Pressable>
+      </View>
+
+      {/* One host means the section can only be a no-op or a way to empty the list. */}
+      {executionHostOptions.length > 1 ? (
+        <>
+          <Text style={styles.sectionLabel}>Hosts</Text>
+          <View style={styles.group}>
+            {executionHostOptions.map((option, index) => (
+              <View key={option.id}>
+                {index > 0 ? <View style={styles.separator} /> : null}
+                <Pressable
+                  style={styles.row}
+                  onPress={() => onToggleExecutionHost(option.id)}
+                  accessibilityRole="button"
+                >
+                  <Text style={styles.rowText} numberOfLines={1}>
+                    {option.label}
+                  </Text>
+                  <Text style={styles.rowCount}>{option.count}</Text>
+                  {selectedHostIds?.has(option.id) ? (
+                    <Check size={14} color={colors.textPrimary} />
+                  ) : null}
+                </Pressable>
+              </View>
+            ))}
+          </View>
+        </>
+      ) : null}
+    </BottomDrawer>
+  )
+}
+
+const styles = StyleSheet.create({
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing.xs,
+    marginBottom: spacing.md
+  },
+  title: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: colors.textPrimary
+  },
+  clearText: {
+    fontSize: 13,
+    color: colors.textSecondary
+  },
+  sectionLabel: {
+    fontSize: 11,
+    fontWeight: '600',
+    color: colors.textMuted,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginBottom: spacing.xs,
+    paddingHorizontal: spacing.xs
+  },
+  group: {
+    backgroundColor: colors.bgPanel,
+    borderRadius: 12,
+    overflow: 'hidden',
+    marginBottom: spacing.md
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.md + 2,
+    gap: spacing.sm
+  },
+  rowText: {
+    flex: 1,
+    fontSize: typography.bodySize,
+    color: colors.textPrimary
+  },
+  rowCount: {
+    fontSize: typography.metaSize,
+    color: colors.textMuted
+  },
+  separator: {
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: colors.borderSubtle,
+    marginHorizontal: spacing.md
+  }
+})

--- a/mobile/src/components/ProjectsHomeList.tsx
+++ b/mobile/src/components/ProjectsHomeList.tsx
@@ -1,0 +1,406 @@
+// The merged Projects home: every paired desktop's workspaces in one list, with
+// the same filter / sort / group controls as the per-host list. Replaces Home's
+// desktop cards when the Projects home experiment is on.
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { View, Text, StyleSheet, Pressable, SectionList, RefreshControl } from 'react-native'
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
+import { useRouter } from 'expo-router'
+import { MonitorSmartphone, Search, Settings, X } from 'lucide-react-native'
+import { useNow } from '../hooks/use-now'
+import { useResponsiveLayout } from '../layout/responsive-layout'
+import { useOpenMobileSession } from '../session/use-open-mobile-session'
+import { hostStackHostRoute } from '../navigation/host-stack-navigation'
+import { colors, spacing, typography } from '../theme/mobile-theme'
+import {
+  executionHostFilterOptions,
+  getMergedDesktopRepoId,
+  mergeDesktopWorkspaces,
+  type MergedWorkspace
+} from '../worktree/merged-desktop-workspaces'
+import {
+  useMergedDesktopCatalogs,
+  type DesktopClient
+} from '../worktree/use-merged-desktop-catalogs'
+import { getMobileWorkspaceLineageGroupKey } from '../worktree/mobile-workspace-lineage'
+import { useProjectsHomeViewState } from '../worktree/use-projects-home-view-state'
+import { buildSections, getWorktreeStatus } from '../worktree/workspace-list-sections'
+import {
+  WORKSPACE_GROUP_OPTIONS,
+  WORKSPACE_SORT_OPTIONS
+} from '../worktree/workspace-list-picker-options'
+import { repoColor } from '../worktree/repo-color'
+import { MobileSearchField } from './MobileSearchField'
+import { OrcaLogo } from './OrcaLogo'
+import { PickerModal } from './PickerModal'
+import { ProjectsHomeFilterDrawer } from './ProjectsHomeFilterDrawer'
+import { WorkspaceListControls } from './WorkspaceListControls'
+import { WorkspaceSectionHeader } from './WorkspaceSectionHeader'
+import { WorktreeListRow } from './WorktreeListRow'
+
+type Props = {
+  desktops: readonly DesktopClient[]
+  onOpenSettings: () => void
+}
+
+function ListSeparator(): React.JSX.Element {
+  return <View style={styles.separator} />
+}
+
+export function ProjectsHomeList({ desktops, onOpenSettings }: Props): React.JSX.Element {
+  const router = useRouter()
+  const insets = useSafeAreaInsets()
+  const { isWideLayout, contentMaxWidth } = useResponsiveLayout()
+  const openMobileSession = useOpenMobileSession()
+  const now = useNow(30_000)
+  const [search, setSearch] = useState('')
+  const [showSearch, setShowSearch] = useState(false)
+  const [showSortPicker, setShowSortPicker] = useState(false)
+  const [showGroupPicker, setShowGroupPicker] = useState(false)
+  const [showFilters, setShowFilters] = useState(false)
+  const [showDesktopPicker, setShowDesktopPicker] = useState(false)
+  const [refreshing, setRefreshing] = useState(false)
+  const view = useProjectsHomeViewState()
+  const { catalogs, loading, refresh, rosterSettled } = useMergedDesktopCatalogs(desktops)
+
+  const workspaces = useMemo(() => mergeDesktopWorkspaces(catalogs), [catalogs])
+  const hostOptions = useMemo(() => executionHostFilterOptions(workspaces), [workspaces])
+  useEffect(() => {
+    if (rosterSettled && catalogs.length === desktops.length) {
+      view.pruneExecutionHosts(hostOptions)
+    }
+  }, [catalogs.length, desktops.length, hostOptions, rosterSettled, view.pruneExecutionHosts])
+  const repoIconsById = useMemo(
+    () =>
+      new Map(
+        catalogs.flatMap((catalog) =>
+          (catalog.repos ?? []).flatMap((repo) =>
+            repo.repoIcon
+              ? [[getMergedDesktopRepoId(catalog.desktopHostId, repo.id), repo.repoIcon] as const]
+              : []
+          )
+        )
+      ),
+    [catalogs]
+  )
+  const repoColorsById = useMemo(
+    () =>
+      new Map(
+        catalogs.flatMap((catalog) =>
+          (catalog.repos ?? []).map(
+            (repo) =>
+              [
+                getMergedDesktopRepoId(catalog.desktopHostId, repo.id),
+                repo.badgeColor || repoColor(repo.displayName)
+              ] as const
+          )
+        )
+      ),
+    [catalogs]
+  )
+  // Ready paired desktops can connect when their host stack opens, even when
+  // they sit outside Home's persistent-client budget.
+  const unavailableHostIds = useMemo(
+    () =>
+      new Set(
+        desktops
+          .filter((desktop) => desktop.state !== 'connected' && !desktop.availableOnDemand)
+          .map((desktop) => desktop.hostId)
+      ),
+    [desktops]
+  )
+
+  // Pinning is per-desktop state the merged list does not own yet, so no pins.
+  const noPins = useMemo(() => new Set<string>(), [])
+  const build = useCallback(
+    (collapsedGroups?: ReadonlySet<string>) =>
+      buildSections(
+        workspaces,
+        view.settings.sortMode,
+        view.filters,
+        search,
+        view.settings.groupMode,
+        noPins,
+        undefined,
+        undefined,
+        collapsedGroups
+      ),
+    [workspaces, view.settings.sortMode, view.settings.groupMode, view.filters, search, noPins]
+  )
+  const sections = useMemo(() => build(view.collapsedGroups), [build, view.collapsedGroups])
+  // Group headers show the true group size, so they read the uncollapsed build.
+  const rawSections = useMemo(() => build(), [build])
+
+  const onRefresh = useCallback(() => {
+    setRefreshing(true)
+    void refresh().finally(() => setRefreshing(false))
+  }, [refresh])
+
+  const openWorkspace = useCallback(
+    (item: MergedWorkspace) => {
+      openMobileSession({
+        hostId: item.desktopHostId,
+        worktreeId: item.desktopWorktreeId,
+        name: item.displayName || item.repo
+      })
+    },
+    [openMobileSession]
+  )
+
+  const toggleLineage = useCallback(
+    (item: MergedWorkspace) =>
+      view.toggleCollapsedGroup(getMobileWorkspaceLineageGroupKey(item.worktreeId)),
+    [view]
+  )
+  const openHostScreen = useCallback(
+    (hostId: string) => router.push(hostStackHostRoute(hostId)),
+    [router]
+  )
+  const desktopOptions = useMemo(
+    () =>
+      desktops.map((desktop) => ({
+        value: desktop.hostId,
+        label: desktop.hostName,
+        subtitle:
+          desktop.state === 'connected'
+            ? 'Connected'
+            : desktop.availableOnDemand
+              ? 'Connect on open'
+              : 'Not connected'
+      })),
+    [desktops]
+  )
+
+  const sortLabel =
+    WORKSPACE_SORT_OPTIONS.find((option) => option.value === view.settings.sortMode)?.label ??
+    'Recent'
+  const byRepo = view.settings.groupMode === 'repo'
+
+  return (
+    <SafeAreaView style={styles.container} edges={['top']}>
+      <View style={styles.topChrome}>
+        <View style={styles.titleRow}>
+          <View style={styles.logoMark}>
+            <OrcaLogo size={18} />
+          </View>
+          <Text style={styles.title}>Projects</Text>
+          {/* New workspace, Tasks and Accounts all live on a single desktop's
+              screen, so the merged list must keep a route to one. */}
+          <Pressable
+            style={styles.iconButton}
+            onPress={() => setShowDesktopPicker(true)}
+            accessibilityRole="button"
+            accessibilityLabel="Open a desktop"
+          >
+            <MonitorSmartphone size={18} color={colors.textSecondary} />
+          </Pressable>
+          <Pressable
+            style={styles.iconButton}
+            onPress={onOpenSettings}
+            accessibilityRole="button"
+            accessibilityLabel="Settings"
+          >
+            <Settings size={18} color={colors.textSecondary} />
+          </Pressable>
+        </View>
+
+        <View style={styles.toolbar}>
+          <WorkspaceListControls
+            layout="row"
+            activeFilterCount={view.activeFilterCount}
+            sortLabel={sortLabel}
+            groupMode={view.settings.groupMode}
+            onOpenFilter={() => setShowFilters(true)}
+            onOpenSort={() => setShowSortPicker(true)}
+            onOpenGroup={() => setShowGroupPicker(true)}
+          />
+          <View style={styles.toolbarSpacer} />
+          <Pressable
+            style={styles.searchToggle}
+            onPress={() => setShowSearch((visible) => !visible)}
+            accessibilityRole="button"
+            accessibilityLabel={showSearch ? 'Close search' : 'Search workspaces'}
+          >
+            {showSearch ? (
+              <X size={16} color={colors.textSecondary} />
+            ) : (
+              <Search size={16} color={colors.textSecondary} />
+            )}
+          </Pressable>
+        </View>
+      </View>
+
+      {showSearch ? (
+        <View style={styles.searchBar}>
+          <MobileSearchField
+            value={search}
+            onChangeText={setSearch}
+            placeholder="Search workspaces…"
+            autoFocus
+            focusKey={showSearch}
+            accessibilityLabel="Search workspaces"
+          />
+        </View>
+      ) : null}
+
+      {sections.length === 0 ? (
+        <View style={styles.centered}>
+          <Text style={styles.emptyText}>
+            {loading
+              ? 'Loading workspaces…'
+              : workspaces.length === 0
+                ? 'No workspaces on your paired desktops yet.'
+                : 'No workspaces match your filters.'}
+          </Text>
+        </View>
+      ) : (
+        <SectionList
+          sections={sections}
+          keyExtractor={(item) => item.sectionListKey ?? item.worktreeId}
+          stickySectionHeadersEnabled={false}
+          keyboardShouldPersistTaps="handled"
+          keyboardDismissMode="on-drag"
+          contentContainerStyle={[
+            styles.list,
+            { paddingBottom: spacing.xl + insets.bottom },
+            isWideLayout && { maxWidth: contentMaxWidth, width: '100%', alignSelf: 'center' }
+          ]}
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={onRefresh}
+              tintColor={colors.textSecondary}
+              colors={[colors.textSecondary]}
+            />
+          }
+          ItemSeparatorComponent={ListSeparator}
+          renderSectionHeader={({ section }) => {
+            if (!section.title) {
+              return null
+            }
+            const repoId = byRepo && section.icon !== 'pin' ? section.data[0]?.repoId : undefined
+            return (
+              <WorkspaceSectionHeader
+                title={section.title}
+                count={rawSections.find((raw) => raw.key === section.key)?.data.length ?? 0}
+                collapsed={view.collapsedGroups.has(section.key)}
+                pinnedGroup={section.icon === 'pin'}
+                repoIcon={repoId ? (repoIconsById.get(repoId) ?? null) : undefined}
+                repoColor={repoId ? (repoColorsById.get(repoId) ?? null) : null}
+                onToggle={() => view.toggleCollapsedGroup(section.key)}
+              />
+            )
+          }}
+          renderItem={({ item }) => (
+            <WorktreeListRow
+              item={item}
+              isReadOnly={unavailableHostIds.has(item.desktopHostId)}
+              now={now}
+              status={getWorktreeStatus(item)}
+              repoColor={repoColorsById.get(item.repoId) ?? repoColor(item.repo)}
+              repoIcon={repoIconsById.get(item.repoId) ?? null}
+              hideRepo={byRepo}
+              onPress={openWorkspace}
+              onToggleLineage={toggleLineage}
+            />
+          )}
+        />
+      )}
+
+      <PickerModal
+        visible={showSortPicker}
+        title="Sort By"
+        options={WORKSPACE_SORT_OPTIONS}
+        selected={view.settings.sortMode}
+        onSelect={(value) => {
+          view.setSortMode(value)
+          setShowSortPicker(false)
+        }}
+        onClose={() => setShowSortPicker(false)}
+      />
+
+      <PickerModal
+        visible={showGroupPicker}
+        title="Group By"
+        options={WORKSPACE_GROUP_OPTIONS}
+        selected={view.settings.groupMode}
+        onSelect={(value) => {
+          view.setGroupMode(value)
+          setShowGroupPicker(false)
+        }}
+        onClose={() => setShowGroupPicker(false)}
+      />
+
+      <PickerModal
+        visible={showDesktopPicker}
+        title="Open Desktop"
+        options={desktopOptions}
+        selected=""
+        onSelect={(hostId) => {
+          setShowDesktopPicker(false)
+          openHostScreen(hostId)
+        }}
+        onClose={() => setShowDesktopPicker(false)}
+      />
+
+      <ProjectsHomeFilterDrawer
+        visible={showFilters}
+        filters={view.filters}
+        executionHostOptions={hostOptions}
+        activeFilterCount={view.activeFilterCount}
+        onToggleHideSleeping={view.toggleHideSleeping}
+        onToggleHideDefaultBranch={view.toggleHideDefaultBranch}
+        onToggleExecutionHost={view.toggleExecutionHost}
+        onClearFilters={view.clearFilters}
+        onClose={() => setShowFilters(false)}
+      />
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: colors.bgBase },
+  topChrome: {
+    backgroundColor: colors.bgPanel,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.borderSubtle
+  },
+  titleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.xs,
+    minHeight: 40
+  },
+  logoMark: { width: 22, height: 22, alignItems: 'center', justifyContent: 'center' },
+  title: { flex: 1, fontSize: 17, fontWeight: '700', color: colors.textPrimary },
+  iconButton: { width: 32, height: 32, alignItems: 'center', justifyContent: 'center' },
+  toolbar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: spacing.xs + 2,
+    paddingHorizontal: spacing.md,
+    gap: spacing.sm,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: colors.borderSubtle
+  },
+  toolbarSpacer: { flex: 1 },
+  searchToggle: { padding: spacing.xs },
+  searchBar: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.borderSubtle,
+    backgroundColor: colors.bgPanel
+  },
+  centered: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: spacing.xl },
+  emptyText: { color: colors.textSecondary, fontSize: typography.bodySize, textAlign: 'center' },
+  list: { paddingBottom: spacing.lg },
+  separator: {
+    height: 1,
+    backgroundColor: colors.borderSubtle,
+    marginLeft: spacing.lg + 24,
+    marginRight: spacing.lg
+  }
+})

--- a/mobile/src/components/WorkspaceListControls.tsx
+++ b/mobile/src/components/WorkspaceListControls.tsx
@@ -1,0 +1,124 @@
+// The Filter / Sort / Group trio above every workspace list. Shared so the phone
+// toolbar, the tablet sidebar and the merged Projects home cannot drift apart.
+
+import { Text, StyleSheet, Pressable } from 'react-native'
+import { Filter, Layers, SlidersHorizontal } from 'lucide-react-native'
+import { colors, spacing } from '../theme/mobile-theme'
+import { groupModeLabel, type MobileGroupMode } from '../worktree/workspace-view-settings'
+
+type Props = {
+  /** 'compact' gives the chips equal widths for the narrow tablet sidebar. */
+  layout: 'row' | 'compact'
+  activeFilterCount: number
+  sortLabel: string
+  groupMode: MobileGroupMode
+  onOpenFilter: () => void
+  onOpenSort: () => void
+  onOpenGroup: () => void
+}
+
+export function WorkspaceListControls({
+  layout,
+  activeFilterCount,
+  sortLabel,
+  groupMode,
+  onOpenFilter,
+  onOpenSort,
+  onOpenGroup
+}: Props): React.JSX.Element {
+  const compact = layout === 'compact'
+  const filtered = activeFilterCount > 0
+  return (
+    <>
+      <Pressable
+        style={[
+          styles.filterChip,
+          compact && styles.compactChip,
+          filtered && styles.filterChipActive
+        ]}
+        onPress={onOpenFilter}
+        accessibilityRole="button"
+        accessibilityLabel={`Filter workspaces${filtered ? `, ${activeFilterCount} active` : ''}`}
+      >
+        <Filter size={12} color={filtered ? colors.textPrimary : colors.textSecondary} />
+        <Text
+          style={[styles.filterChipText, filtered && styles.filterChipTextActive]}
+          numberOfLines={1}
+        >
+          {filtered ? `Filter ${activeFilterCount}` : 'Filter'}
+        </Text>
+      </Pressable>
+
+      <Pressable
+        style={[styles.modeButton, compact && styles.compactChip]}
+        onPress={onOpenSort}
+        accessibilityRole="button"
+        accessibilityLabel={`Sort by ${sortLabel}`}
+      >
+        <SlidersHorizontal size={14} color={colors.textSecondary} />
+        <Text style={styles.modeLabel} numberOfLines={1}>
+          {sortLabel}
+        </Text>
+      </Pressable>
+
+      <Pressable
+        style={[styles.modeButton, compact && styles.compactChip]}
+        onPress={onOpenGroup}
+        accessibilityRole="button"
+        accessibilityLabel="Group workspaces"
+      >
+        <Layers size={14} color={colors.textSecondary} />
+        <Text style={styles.modeLabel} numberOfLines={1}>
+          {groupModeLabel(groupMode)}
+        </Text>
+      </Pressable>
+    </>
+  )
+}
+
+const styles = StyleSheet.create({
+  filterChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingHorizontal: spacing.sm + 2,
+    paddingVertical: spacing.xs,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: colors.borderSubtle
+  },
+  filterChipActive: {
+    borderColor: colors.textSecondary,
+    backgroundColor: colors.bgRaised
+  },
+  filterChipText: {
+    fontSize: 12,
+    color: colors.textSecondary
+  },
+  filterChipTextActive: {
+    color: colors.textPrimary
+  },
+  modeButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexShrink: 1,
+    minWidth: 0,
+    gap: 4,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs
+  },
+  modeLabel: {
+    flexShrink: 1,
+    minWidth: 0,
+    fontSize: 12,
+    color: colors.textSecondary
+  },
+  compactChip: {
+    flex: 1,
+    minWidth: 0,
+    height: 30,
+    justifyContent: 'center',
+    paddingHorizontal: spacing.xs,
+    paddingVertical: 0
+  }
+})

--- a/mobile/src/components/WorkspaceSectionHeader.tsx
+++ b/mobile/src/components/WorkspaceSectionHeader.tsx
@@ -1,0 +1,83 @@
+// Collapsible group header for workspace lists (per-host and merged Projects home).
+
+import { View, Text, StyleSheet, Pressable } from 'react-native'
+import { ChevronDown, ChevronRight, Pin } from 'lucide-react-native'
+import type { RepoIcon } from '../../../src/shared/repo-icon'
+import { colors, spacing } from '../theme/mobile-theme'
+import { MobileRepoIcon } from './MobileRepoIcon'
+
+type Props = {
+  title: string
+  /** Row count before collapsing, so a collapsed group still shows its size. */
+  count: number
+  collapsed: boolean
+  pinnedGroup?: boolean
+  /** Set when grouping by repo; the header then leads with the repo's icon. */
+  repoIcon?: RepoIcon | null
+  repoColor?: string | null
+  onToggle: () => void
+}
+
+export function WorkspaceSectionHeader({
+  title,
+  count,
+  collapsed,
+  pinnedGroup = false,
+  repoIcon,
+  repoColor,
+  onToggle
+}: Props): React.JSX.Element {
+  const showRepoIcon = repoIcon !== undefined || repoColor != null
+  return (
+    <Pressable
+      style={styles.sectionHeader}
+      onPress={onToggle}
+      accessibilityRole="button"
+      accessibilityState={{ expanded: !collapsed }}
+      accessibilityLabel={`${title}, ${count} workspace${count === 1 ? '' : 's'}`}
+    >
+      {collapsed ? (
+        <ChevronRight size={12} color={colors.textMuted} style={styles.sectionIcon} />
+      ) : (
+        <ChevronDown size={12} color={colors.textMuted} style={styles.sectionIcon} />
+      )}
+      {pinnedGroup ? <Pin size={12} color={colors.textMuted} style={styles.sectionIcon} /> : null}
+      {showRepoIcon ? (
+        <View style={styles.sectionIcon}>
+          <MobileRepoIcon
+            repoIcon={repoIcon ?? null}
+            size={14}
+            color={repoColor ?? colors.textSecondary}
+          />
+        </View>
+      ) : null}
+      <Text style={styles.sectionTitle}>{title}</Text>
+      <Text style={styles.sectionCount}>{count}</Text>
+    </Pressable>
+  )
+}
+
+const styles = StyleSheet.create({
+  sectionHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.xs
+  },
+  sectionIcon: {
+    marginRight: spacing.xs
+  },
+  sectionTitle: {
+    fontSize: 11,
+    fontWeight: '600',
+    color: colors.textMuted,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5
+  },
+  sectionCount: {
+    fontSize: 11,
+    color: colors.textMuted,
+    marginLeft: spacing.xs
+  }
+})

--- a/mobile/src/storage/preferences.ts
+++ b/mobile/src/storage/preferences.ts
@@ -192,6 +192,22 @@ export async function saveHostDockWidth(width: number): Promise<void> {
   await AsyncStorage.setItem(DOCK_WIDTH_KEY, String(clampHostDockWidth(width)))
 }
 
+const PROJECTS_HOME_KEY = 'orca:experimental:projectsHome'
+
+// Why default-off: this replaces Home's desktop list with one merged workspace
+// list, so it changes the app's entry screen. Opt in from Settings > Experimental.
+export async function loadProjectsHomeEnabled(): Promise<boolean> {
+  try {
+    return (await AsyncStorage.getItem(PROJECTS_HOME_KEY)) === 'true'
+  } catch {
+    return false
+  }
+}
+
+export async function saveProjectsHomeEnabled(enabled: boolean): Promise<void> {
+  await AsyncStorage.setItem(PROJECTS_HOME_KEY, String(enabled))
+}
+
 export type MobileTerminalLinkOpenMode = 'orca-browser' | 'phone-browser'
 
 const TERMINAL_LINK_OPEN_MODE_KEY = 'orca:terminalLinkOpenMode'

--- a/mobile/src/storage/preferences.ts
+++ b/mobile/src/storage/preferences.ts
@@ -205,7 +205,7 @@ export async function loadProjectsHomeEnabled(): Promise<boolean> {
 }
 
 export async function saveProjectsHomeEnabled(enabled: boolean): Promise<void> {
-  await AsyncStorage.setItem(PROJECTS_HOME_KEY, String(enabled))
+  await AsyncStorage.setItem(PROJECTS_HOME_KEY, String(enabled)).catch(() => undefined)
 }
 
 export type MobileTerminalLinkOpenMode = 'orca-browser' | 'phone-browser'

--- a/mobile/src/storage/projects-home-enabled-preference.test.ts
+++ b/mobile/src/storage/projects-home-enabled-preference.test.ts
@@ -1,0 +1,15 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { describe, expect, it, vi } from 'vitest'
+import { saveProjectsHomeEnabled } from './preferences'
+
+vi.mock('@react-native-async-storage/async-storage', () => ({
+  default: { setItem: vi.fn() }
+}))
+
+describe('projects home enabled preference', () => {
+  it('absorbs best-effort storage failures', async () => {
+    vi.mocked(AsyncStorage.setItem).mockRejectedValue(new Error('storage unavailable'))
+
+    await expect(saveProjectsHomeEnabled(true)).resolves.toBeUndefined()
+  })
+})

--- a/mobile/src/storage/projects-home-view-settings.test.ts
+++ b/mobile/src/storage/projects-home-view-settings.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_PROJECTS_HOME_VIEW_SETTINGS,
+  parseProjectsHomeViewSettings
+} from './projects-home-view-settings'
+
+describe('parseProjectsHomeViewSettings', () => {
+  it('falls back to defaults for absent or unparseable records', () => {
+    expect(parseProjectsHomeViewSettings(null)).toEqual(DEFAULT_PROJECTS_HOME_VIEW_SETTINGS)
+    expect(parseProjectsHomeViewSettings('{oops')).toEqual(DEFAULT_PROJECTS_HOME_VIEW_SETTINGS)
+    expect(parseProjectsHomeViewSettings('"a string"')).toEqual(DEFAULT_PROJECTS_HOME_VIEW_SETTINGS)
+  })
+
+  it('keeps recognised fields and defaults the rest', () => {
+    const parsed = parseProjectsHomeViewSettings(
+      JSON.stringify({ groupMode: 'prStatus', hideSleeping: true })
+    )
+
+    expect(parsed.groupMode).toBe('prStatus')
+    expect(parsed.hideSleeping).toBe(true)
+    expect(parsed.sortMode).toBe(DEFAULT_PROJECTS_HOME_VIEW_SETTINGS.sortMode)
+    expect(parsed.hideDefaultBranch).toBe(false)
+  })
+
+  it('rejects modes a newer build may have written', () => {
+    const parsed = parseProjectsHomeViewSettings(
+      JSON.stringify({ groupMode: 'byMoonPhase', sortMode: 'entropy' })
+    )
+
+    expect(parsed.groupMode).toBe(DEFAULT_PROJECTS_HOME_VIEW_SETTINGS.groupMode)
+    expect(parsed.sortMode).toBe(DEFAULT_PROJECTS_HOME_VIEW_SETTINGS.sortMode)
+  })
+
+  it('keeps scoped and legacy host filter ids while dropping invalid values', () => {
+    const parsed = parseProjectsHomeViewSettings(
+      JSON.stringify({
+        executionHostIds: [
+          'local',
+          '["desktop","ssh:gpu-box"]',
+          '["desktop",null]',
+          '',
+          42,
+          'nonsense:x',
+          'local'
+        ]
+      })
+    )
+
+    expect(parsed.executionHostIds).toEqual([
+      'local',
+      '["desktop","ssh:gpu-box"]',
+      '["desktop",null]'
+    ])
+  })
+})

--- a/mobile/src/storage/projects-home-view-settings.test.ts
+++ b/mobile/src/storage/projects-home-view-settings.test.ts
@@ -1,10 +1,20 @@
-import { describe, expect, it } from 'vitest'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   DEFAULT_PROJECTS_HOME_VIEW_SETTINGS,
-  parseProjectsHomeViewSettings
+  parseProjectsHomeViewSettings,
+  saveProjectsHomeViewSettings
 } from './projects-home-view-settings'
 
+vi.mock('@react-native-async-storage/async-storage', () => ({
+  default: { setItem: vi.fn() }
+}))
+
 describe('parseProjectsHomeViewSettings', () => {
+  beforeEach(() => {
+    vi.mocked(AsyncStorage.setItem).mockReset()
+  })
+
   it('falls back to defaults for absent or unparseable records', () => {
     expect(parseProjectsHomeViewSettings(null)).toEqual(DEFAULT_PROJECTS_HOME_VIEW_SETTINGS)
     expect(parseProjectsHomeViewSettings('{oops')).toEqual(DEFAULT_PROJECTS_HOME_VIEW_SETTINGS)
@@ -51,5 +61,13 @@ describe('parseProjectsHomeViewSettings', () => {
       '["desktop","ssh:gpu-box"]',
       '["desktop",null]'
     ])
+  })
+
+  it('absorbs best-effort storage failures', async () => {
+    vi.mocked(AsyncStorage.setItem).mockRejectedValue(new Error('storage unavailable'))
+
+    await expect(
+      saveProjectsHomeViewSettings(DEFAULT_PROJECTS_HOME_VIEW_SETTINGS)
+    ).resolves.toBeUndefined()
   })
 })

--- a/mobile/src/storage/projects-home-view-settings.test.ts
+++ b/mobile/src/storage/projects-home-view-settings.test.ts
@@ -69,5 +69,6 @@ describe('parseProjectsHomeViewSettings', () => {
     await expect(
       saveProjectsHomeViewSettings(DEFAULT_PROJECTS_HOME_VIEW_SETTINGS)
     ).resolves.toBeUndefined()
+    expect(AsyncStorage.setItem).toHaveBeenCalledTimes(1)
   })
 })

--- a/mobile/src/storage/projects-home-view-settings.ts
+++ b/mobile/src/storage/projects-home-view-settings.ts
@@ -103,5 +103,5 @@ export async function loadProjectsHomeViewSettings(): Promise<ProjectsHomeViewSe
 export async function saveProjectsHomeViewSettings(
   settings: ProjectsHomeViewSettings
 ): Promise<void> {
-  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(settings))
+  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(settings)).catch(() => undefined)
 }

--- a/mobile/src/storage/projects-home-view-settings.ts
+++ b/mobile/src/storage/projects-home-view-settings.ts
@@ -1,0 +1,107 @@
+// Group/sort/filter state for the merged Projects home list.
+//
+// Why local instead of the desktop's ui.get/ui.set like the per-host list: this
+// list spans every paired desktop, so there is no single desktop whose persisted
+// UI state it could belong to. Writing to all of them would let a phone-side
+// filter change mutate every paired machine.
+
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { normalizeExecutionHostId } from '../../../src/shared/execution-host'
+import type { MobileGroupMode, MobileSortMode } from '../worktree/workspace-view-settings'
+
+const STORAGE_KEY = 'orca:projectsHome:view'
+
+export type ProjectsHomeViewSettings = {
+  groupMode: MobileGroupMode
+  sortMode: MobileSortMode
+  hideSleeping: boolean
+  hideDefaultBranch: boolean
+  executionHostIds: string[]
+}
+
+export const DEFAULT_PROJECTS_HOME_VIEW_SETTINGS: ProjectsHomeViewSettings = {
+  groupMode: 'repo',
+  sortMode: 'recent',
+  hideSleeping: false,
+  hideDefaultBranch: false,
+  executionHostIds: []
+}
+
+const GROUP_MODES: readonly MobileGroupMode[] = ['none', 'workspaceStatus', 'repo', 'prStatus']
+const SORT_MODES: readonly MobileSortMode[] = ['smart', 'name', 'recent', 'repo', 'manual']
+
+function isPersistedFilterId(value: unknown): value is string {
+  if (typeof value !== 'string' || value.length === 0 || value.length > 1024) {
+    return false
+  }
+  if (normalizeExecutionHostId(value)) {
+    return true
+  }
+  try {
+    const parsed: unknown = JSON.parse(value)
+    return (
+      Array.isArray(parsed) &&
+      parsed.length === 2 &&
+      typeof parsed[0] === 'string' &&
+      parsed[0].length > 0 &&
+      parsed[0].length <= 512 &&
+      (parsed[1] === null ||
+        (typeof parsed[1] === 'string' && normalizeExecutionHostId(parsed[1]) !== null))
+    )
+  } catch {
+    return false
+  }
+}
+
+function persistedFilterIds(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+  return [...new Set(value.filter(isPersistedFilterId))]
+}
+
+/**
+ * Reads persisted settings, falling back per field. A partial or corrupt record
+ * must still open a usable list, so anything unrecognised takes the default
+ * rather than failing the whole read.
+ */
+export function parseProjectsHomeViewSettings(raw: string | null): ProjectsHomeViewSettings {
+  if (!raw) {
+    return DEFAULT_PROJECTS_HOME_VIEW_SETTINGS
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return DEFAULT_PROJECTS_HOME_VIEW_SETTINGS
+  }
+  if (typeof parsed !== 'object' || parsed === null) {
+    return DEFAULT_PROJECTS_HOME_VIEW_SETTINGS
+  }
+  const record = parsed as Partial<Record<keyof ProjectsHomeViewSettings, unknown>>
+  return {
+    groupMode: GROUP_MODES.includes(record.groupMode as MobileGroupMode)
+      ? (record.groupMode as MobileGroupMode)
+      : DEFAULT_PROJECTS_HOME_VIEW_SETTINGS.groupMode,
+    sortMode: SORT_MODES.includes(record.sortMode as MobileSortMode)
+      ? (record.sortMode as MobileSortMode)
+      : DEFAULT_PROJECTS_HOME_VIEW_SETTINGS.sortMode,
+    hideSleeping: record.hideSleeping === true,
+    hideDefaultBranch: record.hideDefaultBranch === true,
+    executionHostIds: persistedFilterIds(record.executionHostIds)
+  }
+}
+
+export async function loadProjectsHomeViewSettings(): Promise<ProjectsHomeViewSettings> {
+  try {
+    return parseProjectsHomeViewSettings(await AsyncStorage.getItem(STORAGE_KEY))
+  } catch {
+    return DEFAULT_PROJECTS_HOME_VIEW_SETTINGS
+  }
+}
+
+export async function saveProjectsHomeViewSettings(
+  settings: ProjectsHomeViewSettings
+): Promise<void> {
+  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(settings))
+}

--- a/mobile/src/transport/transient-host-client.test.ts
+++ b/mobile/src/transport/transient-host-client.test.ts
@@ -1,0 +1,375 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { RpcClient } from './rpc-client'
+import type { RpcClientContextValue } from './rpc-client-context-contract'
+import { acquireTransientHostClient } from './transient-host-client'
+import type { HostProfile } from './types'
+
+const host: HostProfile = {
+  id: 'desktop-4',
+  name: 'Desktop 4',
+  endpoint: 'wss://desktop-4.example.test',
+  deviceToken: 'token',
+  publicKeyB64: 'public-key',
+  lastConnected: 1
+}
+
+describe('acquireTransientHostClient', () => {
+  it('does nothing for a pre-aborted acquisition', async () => {
+    vi.useFakeTimers()
+    try {
+      const controller = new AbortController()
+      controller.abort()
+      const onClientOwned = vi.fn()
+      const context = {
+        acquire: vi.fn(),
+        subscribeAllHosts: vi.fn(),
+        subscribeHostState: vi.fn(),
+        getAllClients: vi.fn(),
+        getKnownState: vi.fn(),
+        releaseAndCloseIfUnused: vi.fn()
+      } as unknown as RpcClientContextValue
+
+      await expect(
+        acquireTransientHostClient(context, host, { signal: controller.signal, onClientOwned })
+      ).resolves.toBeNull()
+      expect(context.acquire).not.toHaveBeenCalled()
+      expect(context.subscribeAllHosts).not.toHaveBeenCalled()
+      expect(context.subscribeHostState).not.toHaveBeenCalled()
+      expect(context.releaseAndCloseIfUnused).not.toHaveBeenCalled()
+      expect(onClientOwned).not.toHaveBeenCalled()
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('releases an existing client lease exactly once', async () => {
+    const client = {} as RpcClient
+    const releaseAndCloseIfUnused = vi.fn()
+    const context = {
+      acquire: vi.fn(() => client),
+      subscribeAllHosts: vi.fn(() => vi.fn()),
+      subscribeHostState: vi.fn(() => vi.fn()),
+      getAllClients: vi.fn(() => [{ hostId: host.id, client }]),
+      getKnownState: vi.fn(() => 'connected'),
+      releaseAndCloseIfUnused
+    } as unknown as RpcClientContextValue
+
+    const lease = await acquireTransientHostClient(context, host)
+    expect(lease?.client).toBe(client)
+    lease?.release()
+    lease?.release()
+    expect(releaseAndCloseIfUnused).toHaveBeenCalledOnce()
+  })
+
+  it('releases ownership when opening the paired desktop fails', async () => {
+    let notify = () => {}
+    const releaseAndCloseIfUnused = vi.fn()
+    const context = {
+      acquire: vi.fn(() => null),
+      subscribeAllHosts: vi.fn((listener: () => void) => {
+        notify = listener
+        return vi.fn()
+      }),
+      subscribeHostState: vi.fn(() => vi.fn()),
+      getAllClients: vi.fn(() => []),
+      getKnownState: vi
+        .fn<() => 'connecting' | 'auth-failed'>()
+        .mockReturnValueOnce('connecting')
+        .mockReturnValue('auth-failed'),
+      releaseAndCloseIfUnused
+    } as unknown as RpcClientContextValue
+
+    const pending = acquireTransientHostClient(context, host)
+    await Promise.resolve()
+    notify()
+    await expect(pending).resolves.toBeNull()
+    expect(releaseAndCloseIfUnused).toHaveBeenCalledOnce()
+  })
+
+  it('serializes transient leases across callers', async () => {
+    const firstClient = {} as RpcClient
+    const secondClient = {} as RpcClient
+    const firstContext = {
+      acquire: vi.fn(() => firstClient),
+      subscribeAllHosts: vi.fn(() => vi.fn()),
+      subscribeHostState: vi.fn(() => vi.fn()),
+      getAllClients: vi.fn(() => [{ hostId: host.id, client: firstClient }]),
+      getKnownState: vi.fn(() => 'connected'),
+      releaseAndCloseIfUnused: vi.fn()
+    } as unknown as RpcClientContextValue
+    const secondContext = {
+      acquire: vi.fn(() => secondClient),
+      subscribeAllHosts: vi.fn(() => vi.fn()),
+      subscribeHostState: vi.fn(() => vi.fn()),
+      getAllClients: vi.fn(() => [{ hostId: 'desktop-5', client: secondClient }]),
+      getKnownState: vi.fn(() => 'connected'),
+      releaseAndCloseIfUnused: vi.fn()
+    } as unknown as RpcClientContextValue
+
+    const first = await acquireTransientHostClient(firstContext, host)
+    const secondPending = acquireTransientHostClient(secondContext, { ...host, id: 'desktop-5' })
+    await Promise.resolve()
+    expect(secondContext.acquire).not.toHaveBeenCalled()
+
+    first?.release()
+    const second = await secondPending
+    expect(second?.client).toBe(secondClient)
+    second?.release()
+  })
+
+  it('cancels a pending acquisition and releases its turn', async () => {
+    vi.useFakeTimers()
+    try {
+      const controller = new AbortController()
+      const releaseAndCloseIfUnused = vi.fn()
+      const context = {
+        acquire: vi.fn(() => null),
+        subscribeAllHosts: vi.fn(() => vi.fn()),
+        subscribeHostState: vi.fn(() => vi.fn()),
+        getAllClients: vi.fn(() => []),
+        getKnownState: vi.fn(() => 'connecting'),
+        releaseAndCloseIfUnused
+      } as unknown as RpcClientContextValue
+
+      const pending = acquireTransientHostClient(context, host, { signal: controller.signal })
+      await Promise.resolve()
+      controller.abort()
+
+      await expect(pending).resolves.toBeNull()
+      expect(releaseAndCloseIfUnused).toHaveBeenCalledOnce()
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not acquire after an abort races a granted queue turn', async () => {
+    const firstClient = {} as RpcClient
+    const first = await acquireTransientHostClient(
+      {
+        acquire: vi.fn(() => firstClient),
+        subscribeAllHosts: vi.fn(() => vi.fn()),
+        subscribeHostState: vi.fn(() => vi.fn()),
+        getAllClients: vi.fn(() => [{ hostId: host.id, client: firstClient }]),
+        getKnownState: vi.fn(() => 'connected'),
+        releaseAndCloseIfUnused: vi.fn()
+      } as unknown as RpcClientContextValue,
+      host
+    )
+    const controller = new AbortController()
+    const secondContext = {
+      acquire: vi.fn(() => ({}) as RpcClient),
+      subscribeAllHosts: vi.fn(() => vi.fn()),
+      subscribeHostState: vi.fn(() => vi.fn()),
+      getAllClients: vi.fn(() => []),
+      getKnownState: vi.fn(() => 'connected'),
+      releaseAndCloseIfUnused: vi.fn()
+    } as unknown as RpcClientContextValue
+    const thirdClient = {} as RpcClient
+    const thirdContext = {
+      acquire: vi.fn(() => thirdClient),
+      subscribeAllHosts: vi.fn(() => vi.fn()),
+      subscribeHostState: vi.fn(() => vi.fn()),
+      getAllClients: vi.fn(() => [{ hostId: 'desktop-6', client: thirdClient }]),
+      getKnownState: vi.fn(() => 'connected'),
+      releaseAndCloseIfUnused: vi.fn()
+    } as unknown as RpcClientContextValue
+    const second = acquireTransientHostClient(
+      secondContext,
+      { ...host, id: 'desktop-5' },
+      {
+        signal: controller.signal
+      }
+    )
+    const third = acquireTransientHostClient(thirdContext, { ...host, id: 'desktop-6' })
+
+    first?.release()
+    controller.abort()
+
+    await expect(second).resolves.toBeNull()
+    expect(secondContext.acquire).not.toHaveBeenCalled()
+    const thirdLease = await third
+    expect(thirdLease?.client).toBe(thirdClient)
+    thirdLease?.release()
+  })
+
+  it('skips a pre-aborted queued caller and grants the next turn', async () => {
+    const firstClient = {} as RpcClient
+    const first = await acquireTransientHostClient(
+      {
+        acquire: vi.fn(() => firstClient),
+        subscribeAllHosts: vi.fn(() => vi.fn()),
+        subscribeHostState: vi.fn(() => vi.fn()),
+        getAllClients: vi.fn(() => [{ hostId: host.id, client: firstClient }]),
+        getKnownState: vi.fn(() => 'connected'),
+        releaseAndCloseIfUnused: vi.fn()
+      } as unknown as RpcClientContextValue,
+      host
+    )
+    const controller = new AbortController()
+    controller.abort()
+    const skippedContext = {
+      acquire: vi.fn(),
+      subscribeAllHosts: vi.fn(),
+      subscribeHostState: vi.fn(),
+      getAllClients: vi.fn(),
+      getKnownState: vi.fn(),
+      releaseAndCloseIfUnused: vi.fn()
+    } as unknown as RpcClientContextValue
+    const skipped = acquireTransientHostClient(
+      skippedContext,
+      { ...host, id: 'desktop-5' },
+      { signal: controller.signal }
+    )
+    const finalClient = {} as RpcClient
+    const finalContext = {
+      acquire: vi.fn(() => finalClient),
+      subscribeAllHosts: vi.fn(() => vi.fn()),
+      subscribeHostState: vi.fn(() => vi.fn()),
+      getAllClients: vi.fn(() => [{ hostId: 'desktop-6', client: finalClient }]),
+      getKnownState: vi.fn(() => 'connected'),
+      releaseAndCloseIfUnused: vi.fn()
+    } as unknown as RpcClientContextValue
+    const final = acquireTransientHostClient(finalContext, { ...host, id: 'desktop-6' })
+
+    await expect(skipped).resolves.toBeNull()
+    expect(skippedContext.acquire).not.toHaveBeenCalled()
+    expect(skippedContext.subscribeAllHosts).not.toHaveBeenCalled()
+    expect(skippedContext.subscribeHostState).not.toHaveBeenCalled()
+
+    first?.release()
+    const finalLease = await final
+    expect(finalLease?.client).toBe(finalClient)
+    finalLease?.release()
+  })
+
+  it('waits for a published disconnected client to reconnect', async () => {
+    const client = {} as RpcClient
+    let notifyState = () => {}
+    let state: 'disconnected' | 'connected' = 'disconnected'
+    const context = {
+      acquire: vi.fn(() => client),
+      subscribeAllHosts: vi.fn(() => vi.fn()),
+      subscribeHostState: vi.fn((_hostId: string, listener: () => void) => {
+        notifyState = listener
+        return vi.fn()
+      }),
+      getAllClients: vi.fn(() => [{ hostId: host.id, client }]),
+      getKnownState: vi.fn(() => state),
+      releaseAndCloseIfUnused: vi.fn()
+    } as unknown as RpcClientContextValue
+
+    const pending = acquireTransientHostClient(context, host)
+    await Promise.resolve()
+    expect(context.acquire).toHaveBeenCalledOnce()
+
+    state = 'connected'
+    notifyState()
+    const lease = await pending
+    expect(lease?.client).toBe(client)
+    lease?.release()
+  })
+
+  it('times out an unreachable owner and lets the next host acquire', async () => {
+    vi.useFakeTimers()
+    try {
+      const unreachableClient = {} as RpcClient
+      const unreachableRelease = vi.fn()
+      const unreachable = acquireTransientHostClient(
+        {
+          acquire: vi.fn(() => unreachableClient),
+          subscribeAllHosts: vi.fn(() => vi.fn()),
+          subscribeHostState: vi.fn(() => vi.fn()),
+          getAllClients: vi.fn(() => [{ hostId: host.id, client: unreachableClient }]),
+          getKnownState: vi.fn(() => 'connecting'),
+          releaseAndCloseIfUnused: unreachableRelease
+        } as unknown as RpcClientContextValue,
+        host,
+        { timeoutMs: 100 }
+      )
+      const nextClient = {} as RpcClient
+      const nextContext = {
+        acquire: vi.fn(() => nextClient),
+        subscribeAllHosts: vi.fn(() => vi.fn()),
+        subscribeHostState: vi.fn(() => vi.fn()),
+        getAllClients: vi.fn(() => [{ hostId: 'desktop-5', client: nextClient }]),
+        getKnownState: vi.fn(() => 'connected'),
+        releaseAndCloseIfUnused: vi.fn()
+      } as unknown as RpcClientContextValue
+      const next = acquireTransientHostClient(
+        nextContext,
+        { ...host, id: 'desktop-5' },
+        { timeoutMs: 1_000 }
+      )
+
+      await vi.advanceTimersByTimeAsync(100)
+
+      await expect(unreachable).resolves.toBeNull()
+      expect(unreachableRelease).toHaveBeenCalledOnce()
+      const nextLease = await next
+      expect(nextLease?.client).toBe(nextClient)
+      nextLease?.release()
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('times out while queued without blocking later FIFO callers', async () => {
+    vi.useFakeTimers()
+    try {
+      const firstClient = {} as RpcClient
+      const first = await acquireTransientHostClient(
+        {
+          acquire: vi.fn(() => firstClient),
+          subscribeAllHosts: vi.fn(() => vi.fn()),
+          subscribeHostState: vi.fn(() => vi.fn()),
+          getAllClients: vi.fn(() => [{ hostId: host.id, client: firstClient }]),
+          getKnownState: vi.fn(() => 'connected'),
+          releaseAndCloseIfUnused: vi.fn()
+        } as unknown as RpcClientContextValue,
+        host
+      )
+      const timedOutContext = {
+        acquire: vi.fn(),
+        subscribeAllHosts: vi.fn(() => vi.fn()),
+        subscribeHostState: vi.fn(() => vi.fn()),
+        getAllClients: vi.fn(() => []),
+        getKnownState: vi.fn(() => 'connecting'),
+        releaseAndCloseIfUnused: vi.fn()
+      } as unknown as RpcClientContextValue
+      const timedOut = acquireTransientHostClient(
+        timedOutContext,
+        { ...host, id: 'desktop-5' },
+        { timeoutMs: 50 }
+      )
+      const finalClient = {} as RpcClient
+      const finalContext = {
+        acquire: vi.fn(() => finalClient),
+        subscribeAllHosts: vi.fn(() => vi.fn()),
+        subscribeHostState: vi.fn(() => vi.fn()),
+        getAllClients: vi.fn(() => [{ hostId: 'desktop-6', client: finalClient }]),
+        getKnownState: vi.fn(() => 'connected'),
+        releaseAndCloseIfUnused: vi.fn()
+      } as unknown as RpcClientContextValue
+      const final = acquireTransientHostClient(
+        finalContext,
+        { ...host, id: 'desktop-6' },
+        { timeoutMs: 1_000 }
+      )
+
+      await vi.advanceTimersByTimeAsync(50)
+      await expect(timedOut).resolves.toBeNull()
+      expect(timedOutContext.acquire).not.toHaveBeenCalled()
+
+      first?.release()
+      const finalLease = await final
+      expect(finalLease?.client).toBe(finalClient)
+      finalLease?.release()
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/mobile/src/transport/transient-host-client.ts
+++ b/mobile/src/transport/transient-host-client.ts
@@ -1,0 +1,162 @@
+import type { HostClientAcquisition } from './host-client-acquisition-registry'
+import type { HostProfile } from './types'
+import type { RpcClient } from './rpc-client'
+import type { RpcClientContextValue } from './rpc-client-context-contract'
+
+export type TransientHostClientLease = {
+  client: RpcClient
+  release: () => void
+}
+
+const ACQUIRE_TIMEOUT_MS = 12_000
+
+type TurnWaiter = {
+  grant: () => boolean
+}
+
+let turnActive = false
+const turnWaiters: TurnWaiter[] = []
+
+function releaseTurn(): void {
+  while (turnWaiters.length > 0) {
+    const waiter = turnWaiters.shift()
+    if (waiter?.grant()) {
+      return
+    }
+  }
+  turnActive = false
+}
+
+function acquireTurn(signal?: AbortSignal): Promise<(() => void) | null> {
+  if (signal?.aborted) {
+    return Promise.resolve(null)
+  }
+  if (!turnActive) {
+    turnActive = true
+    return Promise.resolve(releaseTurn)
+  }
+  return new Promise((resolve) => {
+    let waiting = true
+    const onAbort = () => {
+      if (waiting) {
+        waiting = false
+        resolve(null)
+      }
+    }
+    signal?.addEventListener('abort', onAbort, { once: true })
+    turnWaiters.push({
+      grant: () => {
+        signal?.removeEventListener('abort', onAbort)
+        if (!waiting || signal?.aborted) {
+          return false
+        }
+        waiting = false
+        resolve(releaseTurn)
+        return true
+      }
+    })
+  })
+}
+
+export function acquireTransientHostClient(
+  context: RpcClientContextValue,
+  host: HostProfile,
+  options: {
+    signal?: AbortSignal
+    timeoutMs?: number
+    onClientOwned?: (client: RpcClient) => void
+  } = {}
+): Promise<TransientHostClientLease | null> {
+  if (options.signal?.aborted) {
+    return Promise.resolve(null)
+  }
+  const acquisition: HostClientAcquisition = {}
+  const acquisitionAbort = new AbortController()
+  const abortAcquisition = () => acquisitionAbort.abort()
+  options.signal?.addEventListener('abort', abortAcquisition, { once: true })
+  const timeout = setTimeout(abortAcquisition, options.timeoutMs ?? ACQUIRE_TIMEOUT_MS)
+  const cleanupAcquisition = () => {
+    clearTimeout(timeout)
+    options.signal?.removeEventListener('abort', abortAcquisition)
+  }
+  return acquireTurn(acquisitionAbort.signal).then((unlock) => {
+    if (!unlock) {
+      cleanupAcquisition()
+      return null
+    }
+    if (acquisitionAbort.signal.aborted) {
+      unlock()
+      cleanupAcquisition()
+      return null
+    }
+    return new Promise((resolve) => {
+      let settled = false
+      let unsubscribeAllHosts = () => {}
+      let unsubscribeHostState = () => {}
+      const cleanupWait = () => {
+        unsubscribeAllHosts()
+        unsubscribeHostState()
+        acquisitionAbort.signal.removeEventListener('abort', abortPending)
+        cleanupAcquisition()
+      }
+      const releaseOwnership = () => {
+        context.releaseAndCloseIfUnused(host.id, acquisition)
+        unlock()
+      }
+      const finish = (client: RpcClient | null) => {
+        if (settled) {
+          return
+        }
+        settled = true
+        cleanupWait()
+        if (!client) {
+          releaseOwnership()
+          resolve(null)
+          return
+        }
+        let released = false
+        const release = () => {
+          if (!released) {
+            released = true
+            options.signal?.removeEventListener('abort', release)
+            releaseOwnership()
+          }
+        }
+        if (options.signal?.aborted) {
+          release()
+          resolve(null)
+          return
+        }
+        options.signal?.addEventListener('abort', release, { once: true })
+        resolve({ client, release })
+      }
+      const abortPending = () => finish(null)
+      acquisitionAbort.signal.addEventListener('abort', abortPending, { once: true })
+      const readClient = () =>
+        context.getAllClients().find((entry) => entry.hostId === host.id)?.client ?? null
+      const settleFromContext = () => {
+        const client = readClient()
+        if (client) {
+          options.onClientOwned?.(client)
+        }
+        const state = context.getKnownState(host.id)
+        if (client && state === 'connected') {
+          finish(client)
+        } else if (state === 'auth-failed') {
+          finish(null)
+        }
+      }
+      try {
+        unsubscribeAllHosts = context.subscribeAllHosts(settleFromContext)
+        unsubscribeHostState = context.subscribeHostState(host.id, settleFromContext)
+        const client = context.acquire(host.id, acquisition, host)
+        if (client) {
+          options.onClientOwned?.(client)
+        }
+        settleFromContext()
+      } catch {
+        finish(null)
+      }
+    })
+  })
+}

--- a/mobile/src/worktree/merged-desktop-catalog-response.ts
+++ b/mobile/src/worktree/merged-desktop-catalog-response.ts
@@ -1,0 +1,165 @@
+import { normalizeExecutionHostId } from '../../../src/shared/execution-host'
+import { readMobileRepoCatalog } from '../cache/repo-cache'
+import type { RuntimeWorktreeAgentRow } from '../../../src/shared/runtime-types'
+import type { RepoSummary } from './host-worktree-rpc-types'
+import type { Worktree } from './workspace-list-types'
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function isOptionalString(value: unknown): boolean {
+  return value === undefined || typeof value === 'string'
+}
+
+function isOptionalNullableString(value: unknown): boolean {
+  return value === null || isOptionalString(value)
+}
+
+function isOptionalBoolean(value: unknown): boolean {
+  return value === undefined || typeof value === 'boolean'
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+function isOptionalNumber(value: unknown): boolean {
+  return value === undefined || isFiniteNumber(value)
+}
+
+function isOptionalNullableNumber(value: unknown): boolean {
+  return value === null || isOptionalNumber(value)
+}
+
+function isOptionalStringArray(value: unknown): boolean {
+  return (
+    value === undefined || (Array.isArray(value) && value.every((item) => typeof item === 'string'))
+  )
+}
+
+function isLinkedPullRequest(value: unknown): value is Worktree['linkedPR'] {
+  return (
+    value === null ||
+    (isRecord(value) && isFiniteNumber(value.number) && typeof value.state === 'string')
+  )
+}
+
+function isAgentState(value: unknown): boolean {
+  return value === 'working' || value === 'blocked' || value === 'waiting' || value === 'done'
+}
+
+function isAgent(value: unknown): value is RuntimeWorktreeAgentRow {
+  return (
+    isRecord(value) &&
+    typeof value.paneKey === 'string' &&
+    value.paneKey.length > 0 &&
+    (value.parentPaneKey === null || typeof value.parentPaneKey === 'string') &&
+    isAgentState(value.state) &&
+    (value.agentType === null ||
+      (typeof value.agentType === 'string' && value.agentType.length > 0)) &&
+    typeof value.prompt === 'string' &&
+    isOptionalNullableString(value.taskTitle) &&
+    isOptionalNullableString(value.displayName) &&
+    isOptionalNullableString(value.lastAssistantMessage) &&
+    isOptionalNullableString(value.toolName) &&
+    isOptionalNullableString(value.toolInput) &&
+    typeof value.interrupted === 'boolean' &&
+    isFiniteNumber(value.stateStartedAt) &&
+    isFiniteNumber(value.updatedAt) &&
+    isOptionalBoolean(value.restoredUnconfirmed)
+  )
+}
+
+function isOptionalAgents(value: unknown): boolean {
+  return value === undefined || (Array.isArray(value) && value.every(isAgent))
+}
+
+function isWorktree(value: unknown): value is Worktree {
+  if (!isRecord(value)) {
+    return false
+  }
+  const kind = value.workspaceKind
+  const hostId = value.hostId
+  return (
+    (kind === undefined || kind === 'git' || kind === 'folder-workspace') &&
+    (hostId === undefined ||
+      (typeof hostId === 'string' && normalizeExecutionHostId(hostId) !== null)) &&
+    typeof value.worktreeId === 'string' &&
+    value.worktreeId.length > 0 &&
+    typeof value.repoId === 'string' &&
+    typeof value.repo === 'string' &&
+    typeof value.branch === 'string' &&
+    typeof value.displayName === 'string' &&
+    typeof value.path === 'string' &&
+    isFiniteNumber(value.liveTerminalCount) &&
+    typeof value.hasAttachedPty === 'boolean' &&
+    typeof value.preview === 'string' &&
+    typeof value.unread === 'boolean' &&
+    typeof value.isPinned === 'boolean' &&
+    isLinkedPullRequest(value.linkedPR) &&
+    (value.sectionListKey === undefined || typeof value.sectionListKey === 'string') &&
+    (value.executionHostFilterId === undefined ||
+      typeof value.executionHostFilterId === 'string') &&
+    (value.executionHostFilterLabel === undefined ||
+      typeof value.executionHostFilterLabel === 'string') &&
+    (value.terminalPlatform === undefined || typeof value.terminalPlatform === 'string') &&
+    (value.workspaceStatus === undefined || typeof value.workspaceStatus === 'string') &&
+    isOptionalNumber(value.sortOrder) &&
+    isOptionalNumber(value.manualOrder) &&
+    isOptionalNumber(value.lastActivityAt) &&
+    isOptionalNumber(value.createdAt) &&
+    isOptionalBoolean(value.isArchived) &&
+    isOptionalBoolean(value.isMainWorktree) &&
+    isOptionalBoolean(value.hasHostSidebarActivity) &&
+    isOptionalString(value.worktreeInstanceId) &&
+    isOptionalString(value.lineageWorktreeInstanceId) &&
+    isOptionalString(value.parentWorktreeInstanceId) &&
+    isOptionalNullableString(value.parentWorktreeId) &&
+    isOptionalStringArray(value.childWorktreeIds) &&
+    isOptionalNumber(value.lineageDepth) &&
+    isOptionalNumber(value.lineageChildCount) &&
+    isOptionalBoolean(value.lineageCollapsed) &&
+    isOptionalBoolean(value.isLastLineageChild) &&
+    isOptionalNullableNumber(value.lastOutputAt) &&
+    isOptionalBoolean(value.isActive) &&
+    isOptionalNullableNumber(value.linkedIssue) &&
+    isOptionalNullableString(value.linkedLinearIssue) &&
+    isOptionalNullableNumber(value.linkedGitLabMR) &&
+    isOptionalNullableNumber(value.linkedGitLabIssue) &&
+    (value.comment === undefined || typeof value.comment === 'string') &&
+    (value.status === undefined ||
+      value.status === 'working' ||
+      value.status === 'active' ||
+      value.status === 'permission' ||
+      value.status === 'done' ||
+      value.status === 'inactive') &&
+    isOptionalAgents(value.agents)
+  )
+}
+
+export function readMergedWorktreeCatalog(value: unknown): Worktree[] | null {
+  if (!isRecord(value)) {
+    return null
+  }
+  return readMergedWorktreeRows(value.worktrees)
+}
+
+export function readMergedWorktreeRows(value: unknown): Worktree[] | null {
+  if (!Array.isArray(value) || !value.every(isWorktree)) {
+    return null
+  }
+  return value.map((worktree) => ({
+    ...worktree,
+    ...(worktree.linkedPR ? { linkedPR: { ...worktree.linkedPR } } : {}),
+    ...(worktree.childWorktreeIds ? { childWorktreeIds: [...worktree.childWorktreeIds] } : {}),
+    ...(worktree.agents ? { agents: worktree.agents.map((agent) => ({ ...agent })) } : {})
+  }))
+}
+
+export function readMergedRepoCatalog(value: unknown): RepoSummary[] | null {
+  if (!isRecord(value) || !Array.isArray(value.repos)) {
+    return null
+  }
+  return readMobileRepoCatalog(value.repos)
+}

--- a/mobile/src/worktree/merged-desktop-workspaces.test.ts
+++ b/mobile/src/worktree/merged-desktop-workspaces.test.ts
@@ -1,0 +1,331 @@
+import { describe, expect, it } from 'vitest'
+import {
+  executionHostFilterOptions,
+  mergeDesktopWorkspaces,
+  retainRepresentedExecutionHostIds,
+  type DesktopWorkspaceCatalog
+} from './merged-desktop-workspaces'
+import { readMergedRepoCatalog, readMergedWorktreeCatalog } from './merged-desktop-catalog-response'
+import { filterWorktrees } from './workspace-list-sections'
+import type { FilterState, Worktree } from './workspace-list-types'
+
+function worktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    workspaceKind: 'git',
+    worktreeId: 'wt-1',
+    repoId: 'repo-1',
+    repo: 'orca',
+    branch: 'main',
+    displayName: 'main',
+    path: '/tmp/wt-1',
+    liveTerminalCount: 0,
+    hasAttachedPty: false,
+    preview: '',
+    unread: false,
+    isPinned: false,
+    linkedPR: null,
+    ...overrides
+  }
+}
+
+function catalog(overrides: Partial<DesktopWorkspaceCatalog> = {}): DesktopWorkspaceCatalog {
+  return {
+    desktopHostId: 'macbook',
+    desktopHostName: 'MacBook',
+    worktrees: [worktree()],
+    ...overrides
+  }
+}
+
+function filters(overrides: Partial<FilterState> = {}): FilterState {
+  return {
+    filterRepoIds: new Set(),
+    hideSleeping: false,
+    hideDefaultBranch: false,
+    alwaysShowDefaultBranch: true,
+    ...overrides
+  }
+}
+
+describe('mergeDesktopWorkspaces', () => {
+  it('keeps rows from two desktops distinct when their worktree ids collide', () => {
+    const merged = mergeDesktopWorkspaces([
+      catalog(),
+      catalog({ desktopHostId: 'desktop', desktopHostName: 'Desktop' })
+    ])
+
+    expect(merged).toHaveLength(2)
+    expect(new Set(merged.map((row) => row.worktreeId)).size).toBe(2)
+    expect(merged.map((row) => row.desktopWorktreeId)).toEqual(['wt-1', 'wt-1'])
+    expect(merged.map((row) => row.desktopHostId)).toEqual(['macbook', 'desktop'])
+    expect(new Set(merged.map((row) => row.repoId)).size).toBe(2)
+  })
+
+  it('keeps delimiter-bearing desktop and local id tuples distinct', () => {
+    const merged = mergeDesktopWorkspaces([
+      catalog({
+        desktopHostId: 'a::b',
+        worktrees: [worktree({ worktreeId: 'c', repoId: 'c' })]
+      }),
+      catalog({
+        desktopHostId: 'a',
+        worktrees: [worktree({ worktreeId: 'b::c', repoId: 'b::c' })]
+      })
+    ])
+
+    expect(new Set(merged.map((row) => row.worktreeId)).size).toBe(2)
+    expect(new Set(merged.map((row) => row.repoId)).size).toBe(2)
+  })
+
+  it('rewrites lineage links inside the same desktop so a parent still resolves', () => {
+    const merged = mergeDesktopWorkspaces([
+      catalog({
+        worktrees: [
+          worktree({ worktreeId: 'parent', childWorktreeIds: ['child'] }),
+          worktree({ worktreeId: 'child', parentWorktreeId: 'parent' })
+        ]
+      })
+    ])
+
+    const child = merged.find((row) => row.desktopWorktreeId === 'child')
+    expect(child?.parentWorktreeId).toBe(merged[0]?.worktreeId)
+    expect(merged[0]?.childWorktreeIds).toEqual([child?.worktreeId])
+  })
+
+  it('leaves a root workspace parentless instead of namespacing null', () => {
+    const merged = mergeDesktopWorkspaces([catalog()])
+    expect(merged[0]?.parentWorktreeId).toBeNull()
+  })
+
+  it('resolves the execution host from the repo when the payload omits hostId', () => {
+    const merged = mergeDesktopWorkspaces([
+      catalog({
+        worktrees: [worktree({ repoId: 'repo-ssh' }), worktree({ worktreeId: 'wt-2' })],
+        repos: [
+          { id: 'repo-ssh', displayName: 'orca', executionHostId: 'ssh:gpu-box' },
+          { id: 'repo-1', displayName: 'orca' }
+        ]
+      })
+    ])
+
+    expect(merged[0]?.hostId).toBe('ssh:gpu-box')
+    expect(merged[1]?.hostId).toBe('local')
+  })
+
+  it('prefers the worktree hostId over the repo fallback', () => {
+    const merged = mergeDesktopWorkspaces([
+      catalog({
+        worktrees: [worktree({ hostId: 'runtime:node-a', repoId: 'repo-ssh' })],
+        repos: [{ id: 'repo-ssh', displayName: 'orca', executionHostId: 'ssh:gpu-box' }]
+      })
+    ])
+
+    expect(merged[0]?.hostId).toBe('runtime:node-a')
+  })
+
+  it('keeps equal execution-host ids distinct across paired desktops', () => {
+    const merged = mergeDesktopWorkspaces([
+      catalog({
+        desktopHostId: 'laptop',
+        desktopHostName: 'Laptop',
+        worktrees: [worktree({ hostId: 'ssh:gpu-box' })]
+      }),
+      catalog({
+        desktopHostId: 'tower',
+        desktopHostName: 'Tower',
+        worktrees: [worktree({ hostId: 'ssh:gpu-box' })]
+      })
+    ])
+    const options = executionHostFilterOptions(merged)
+
+    expect(new Set(options.map((option) => option.id)).size).toBe(2)
+    expect(options.map((option) => option.label).sort()).toEqual([
+      'Laptop · gpu-box',
+      'Tower · gpu-box'
+    ])
+    const kept = filterWorktrees(
+      merged,
+      filters({ filterExecutionHostIds: new Set([options[0]!.id]) }),
+      ''
+    )
+    expect(kept.map((row) => row.desktopHostId)).toEqual([
+      options[0]!.label.startsWith('Laptop') ? 'laptop' : 'tower'
+    ])
+  })
+
+  it('does not guess local ownership for a legacy folder row with no host metadata', () => {
+    const merged = mergeDesktopWorkspaces([
+      catalog({
+        worktrees: [
+          worktree({ workspaceKind: 'folder-workspace', repoId: 'folder-workspace:group-1' })
+        ],
+        repos: []
+      })
+    ])
+
+    expect(merged[0]?.hostId).toBeUndefined()
+    expect(executionHostFilterOptions(merged)[0]?.label).toBe('MacBook · Unknown host')
+  })
+})
+
+describe('merged catalog response validation', () => {
+  it('rejects malformed success payloads and invalid explicit host ids', () => {
+    expect(readMergedWorktreeCatalog({})).toBeNull()
+    expect(
+      readMergedWorktreeCatalog({ worktrees: [worktree({ hostId: 'ssh:' as never })] })
+    ).toBeNull()
+    expect(
+      readMergedRepoCatalog({
+        repos: [{ id: 'repo', displayName: 'Repo', executionHostId: 'ssh:' }]
+      })
+    ).toBeNull()
+  })
+
+  it('normalizes safe repo decorations and rejects unsafe color and icon sinks', () => {
+    expect(
+      readMergedRepoCatalog({
+        repos: [
+          {
+            id: 'repo',
+            displayName: 'Repo',
+            badgeColor: ' ABC ',
+            repoIcon: { type: 'emoji', emoji: ' 🚀 ' }
+          }
+        ]
+      })
+    ).toEqual([
+      {
+        id: 'repo',
+        displayName: 'Repo',
+        badgeColor: '#aabbcc',
+        repoIcon: { type: 'emoji', emoji: '🚀' }
+      }
+    ])
+    expect(
+      readMergedRepoCatalog({
+        repos: [{ id: 'repo', displayName: 'Repo', badgeColor: 'url(javascript:alert(1))' }]
+      })
+    ).toBeNull()
+    expect(
+      readMergedRepoCatalog({
+        repos: [
+          {
+            id: 'repo',
+            displayName: 'Repo',
+            repoIcon: { type: 'image', source: 'favicon', src: 'http://example.test/icon.png' }
+          }
+        ]
+      })
+    ).toBeNull()
+    expect(
+      readMergedRepoCatalog({
+        repos: [
+          {
+            id: 'repo',
+            displayName: 'Repo',
+            repoIcon: { type: 'emoji', emoji: '🚀'.repeat(17) }
+          }
+        ]
+      })
+    ).toBeNull()
+  })
+
+  it('accepts legacy rows that omit hostId', () => {
+    expect(readMergedWorktreeCatalog({ worktrees: [worktree()] })).toEqual([worktree()])
+  })
+
+  it('rejects malformed linked pull requests and agent rows', () => {
+    expect(
+      readMergedWorktreeCatalog({
+        worktrees: [worktree({ linkedPR: { number: '12', state: 'open' } as never })]
+      })
+    ).toBeNull()
+    expect(
+      readMergedWorktreeCatalog({
+        worktrees: [
+          worktree({
+            agents: [
+              {
+                paneKey: 'pane-1',
+                parentPaneKey: null,
+                state: 'working',
+                agentType: 'codex',
+                prompt: 'Review',
+                taskTitle: null,
+                displayName: null,
+                lastAssistantMessage: null,
+                toolName: null,
+                toolInput: null,
+                interrupted: false,
+                stateStartedAt: 1,
+                updatedAt: 'now'
+              } as never
+            ]
+          })
+        ]
+      })
+    ).toBeNull()
+  })
+})
+
+describe('executionHostFilterOptions', () => {
+  it('offers only represented hosts, most populated first', () => {
+    const options = executionHostFilterOptions([
+      worktree({ hostId: 'ssh:gpu-box' }),
+      worktree({ hostId: 'ssh:gpu-box' }),
+      worktree({})
+    ])
+
+    expect(options.map((option) => option.id)).toEqual(['ssh:gpu-box', 'local'])
+    expect(options[0]?.count).toBe(2)
+    expect(options[0]?.label).toBe('gpu-box')
+  })
+})
+
+describe('retainRepresentedExecutionHostIds', () => {
+  it('drops a selection whose host disappeared so the list cannot stay empty', () => {
+    const options = executionHostFilterOptions([worktree({ hostId: 'ssh:gpu-box' })])
+    const retained = retainRepresentedExecutionHostIds(
+      new Set(['ssh:gpu-box', 'ssh:retired'] as const),
+      options
+    )
+
+    expect([...retained]).toEqual(['ssh:gpu-box'])
+  })
+})
+
+describe('filterWorktrees execution host filter', () => {
+  it('keeps only the selected hosts', () => {
+    const rows = [
+      worktree({ worktreeId: 'a', hostId: 'ssh:gpu-box' }),
+      worktree({ worktreeId: 'b', hostId: 'local' })
+    ]
+
+    const kept = filterWorktrees(
+      rows,
+      filters({ filterExecutionHostIds: new Set(['ssh:gpu-box'] as const) }),
+      ''
+    )
+
+    expect(kept.map((row) => row.worktreeId)).toEqual(['a'])
+  })
+
+  it('treats an absent hostId as local so older host payloads stay visible', () => {
+    const rows = [worktree({ worktreeId: 'legacy' })]
+
+    const kept = filterWorktrees(
+      rows,
+      filters({ filterExecutionHostIds: new Set(['local'] as const) }),
+      ''
+    )
+
+    expect(kept.map((row) => row.worktreeId)).toEqual(['legacy'])
+  })
+
+  it('is a no-op when nothing is selected', () => {
+    const rows = [worktree({ hostId: 'ssh:gpu-box' })]
+    expect(filterWorktrees(rows, filters({ filterExecutionHostIds: new Set() }), '')).toHaveLength(
+      1
+    )
+  })
+})

--- a/mobile/src/worktree/merged-desktop-workspaces.ts
+++ b/mobile/src/worktree/merged-desktop-workspaces.ts
@@ -1,0 +1,154 @@
+// Merges the workspace catalogs of every paired desktop into one list, the way
+// the desktop sidebar merges the workspaces of every execution host it owns.
+//
+// Two paired desktops are independent Orca installs, so nothing about their ids
+// is globally unique. Row identity is therefore rewritten here, once, before any
+// list code sees it; execution-host identity is resolved here too so the shared
+// filter/group/sort pipeline stays unaware that more than one desktop exists.
+
+import {
+  LOCAL_EXECUTION_HOST_ID,
+  getExecutionHostLabel,
+  getRepoExecutionHostId,
+  normalizeExecutionHostId,
+  type ExecutionHostId
+} from '../../../src/shared/execution-host'
+import type { RepoSummary } from './host-worktree-rpc-types'
+import type { Worktree } from './workspace-list-types'
+
+/** One paired desktop's catalog, as already read by the Home screen. */
+export type DesktopWorkspaceCatalog = {
+  desktopHostId: string
+  desktopHostName: string
+  worktrees: readonly Worktree[]
+  repos?: readonly RepoSummary[]
+}
+
+export type MergedWorkspace = Worktree & {
+  /** Paired desktop this row came from - the RPC target for opening it. */
+  desktopHostId: string
+  desktopHostName: string
+  /** Id on its own desktop, before this module namespaced it. */
+  desktopWorktreeId: string
+}
+
+function tupleId(kind: 'repo' | 'worktree', desktopHostId: string, localId: string): string {
+  return JSON.stringify([kind, desktopHostId, localId])
+}
+
+export function getMergedDesktopRepoId(desktopHostId: string, repoId: string): string {
+  return tupleId('repo', desktopHostId, repoId)
+}
+
+function getMergedDesktopWorktreeId(desktopHostId: string, worktreeId: string): string {
+  return tupleId('worktree', desktopHostId, worktreeId)
+}
+
+function resolveExecutionHostId(
+  worktree: Worktree,
+  reposById: ReadonlyMap<string, RepoSummary>
+): ExecutionHostId | null {
+  if (worktree.hostId !== undefined) {
+    return normalizeExecutionHostId(worktree.hostId)
+  }
+  const repo = reposById.get(worktree.repoId)
+  // Why mirror getWorktreeExecutionHostId's precedence: a repo pinned to an SSH
+  // connection owns every workspace under it, even ones whose payload predates
+  // hostId. Falling straight to local would file those under the wrong host.
+  if (!repo) {
+    return null
+  }
+  return getRepoExecutionHostId({
+    connectionId: repo.connectionId ?? null,
+    executionHostId: repo.executionHostId ?? null
+  })
+}
+
+function filterIdentity(
+  catalog: DesktopWorkspaceCatalog,
+  executionHostId: ExecutionHostId | null
+): { id: string; label: string } {
+  const hostLabel = executionHostId ? getExecutionHostLabel(executionHostId) : 'Unknown host'
+  return {
+    id: JSON.stringify([catalog.desktopHostId, executionHostId]),
+    label: `${catalog.desktopHostName} · ${hostLabel}`
+  }
+}
+
+/**
+ * Flattens every desktop's catalog into one list whose row ids are unique across
+ * desktops. Lineage keeps working because parent links are rewritten with the
+ * same namespace, so a parent is only ever found on its own desktop.
+ */
+export function mergeDesktopWorkspaces(
+  catalogs: readonly DesktopWorkspaceCatalog[]
+): MergedWorkspace[] {
+  const merged: MergedWorkspace[] = []
+  for (const catalog of catalogs) {
+    const reposById = new Map((catalog.repos ?? []).map((repo) => [repo.id, repo]))
+    for (const worktree of catalog.worktrees) {
+      const executionHostId = resolveExecutionHostId(worktree, reposById)
+      const executionHostFilter = filterIdentity(catalog, executionHostId)
+      merged.push({
+        ...worktree,
+        worktreeId: getMergedDesktopWorktreeId(catalog.desktopHostId, worktree.worktreeId),
+        repoId: getMergedDesktopRepoId(catalog.desktopHostId, worktree.repoId),
+        parentWorktreeId: worktree.parentWorktreeId
+          ? getMergedDesktopWorktreeId(catalog.desktopHostId, worktree.parentWorktreeId)
+          : (worktree.parentWorktreeId ?? null),
+        ...(worktree.childWorktreeIds
+          ? {
+              childWorktreeIds: worktree.childWorktreeIds.map((id) =>
+                getMergedDesktopWorktreeId(catalog.desktopHostId, id)
+              )
+            }
+          : {}),
+        hostId: executionHostId ?? undefined,
+        executionHostFilterId: executionHostFilter.id,
+        executionHostFilterLabel: executionHostFilter.label,
+        desktopHostId: catalog.desktopHostId,
+        desktopHostName: catalog.desktopHostName,
+        desktopWorktreeId: worktree.worktreeId
+      })
+    }
+  }
+  return merged
+}
+
+export type ExecutionHostFilterOption = {
+  id: string
+  label: string
+  count: number
+}
+
+/**
+ * The execution hosts represented in a merged list, most-populated first, for
+ * the filter drawer. Only hosts that actually own a row are offered, so the
+ * drawer can never present a filter that empties the list.
+ */
+export function executionHostFilterOptions(
+  worktrees: readonly Worktree[]
+): ExecutionHostFilterOption[] {
+  const options = new Map<string, ExecutionHostFilterOption>()
+  for (const worktree of worktrees) {
+    const id = worktree.executionHostFilterId ?? worktree.hostId ?? LOCAL_EXECUTION_HOST_ID
+    const current = options.get(id)
+    options.set(id, {
+      id,
+      label:
+        worktree.executionHostFilterLabel ??
+        getExecutionHostLabel(worktree.hostId ?? LOCAL_EXECUTION_HOST_ID),
+      count: (current?.count ?? 0) + 1
+    })
+  }
+  return [...options.values()].sort((a, b) => b.count - a.count || a.label.localeCompare(b.label))
+}
+
+/** Drops selections that no longer match any row so a stale filter cannot hide everything. */
+export function retainRepresentedExecutionHostIds(
+  selected: ReadonlySet<string>,
+  options: readonly ExecutionHostFilterOption[]
+): Set<string> {
+  const represented = new Set(options.map((option) => option.id))
+  return new Set([...selected].filter((id) => represented.has(id)))
+}

--- a/mobile/src/worktree/mobile-workspace-lineage.test.ts
+++ b/mobile/src/worktree/mobile-workspace-lineage.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { applyMobileWorkspaceLineage } from './mobile-workspace-lineage'
+import {
+  applyMobileWorkspaceLineage,
+  getMobileWorkspaceLineageGroupKey
+} from './mobile-workspace-lineage'
 import type { Worktree } from './workspace-list-sections'
 
 function worktree(overrides: Partial<Worktree> = {}): Worktree {
@@ -61,7 +64,10 @@ describe('applyMobileWorkspaceLineage', () => {
     const parent = worktree({ worktreeId: 'parent' })
     const child = worktree({ worktreeId: 'child', parentWorktreeId: 'parent' })
 
-    const rows = applyMobileWorkspaceLineage([child, parent], new Set(['workspace-lineage:parent']))
+    const rows = applyMobileWorkspaceLineage(
+      [child, parent],
+      new Set([getMobileWorkspaceLineageGroupKey('parent')])
+    )
 
     expect(rows.map((row) => row.worktreeId)).toEqual(['parent'])
     expect(rows[0]?.lineageChildCount).toBe(1)

--- a/mobile/src/worktree/mobile-workspace-lineage.ts
+++ b/mobile/src/worktree/mobile-workspace-lineage.ts
@@ -1,7 +1,7 @@
 import type { Worktree } from './workspace-list-types'
 
 export function getMobileWorkspaceLineageGroupKey(worktreeId: string): string {
-  return `workspace-lineage:${encodeURIComponent(worktreeId)}`
+  return JSON.stringify(['workspace-lineage', worktreeId])
 }
 
 function hasValidLineageParent(worktree: Worktree, parent: Worktree): boolean {
@@ -19,13 +19,13 @@ function hasValidLineageParent(worktree: Worktree, parent: Worktree): boolean {
   )
 }
 
-export function applyMobileWorkspaceLineage(
-  worktrees: readonly Worktree[],
+export function applyMobileWorkspaceLineage<T extends Worktree>(
+  worktrees: readonly T[],
   collapsedGroups: ReadonlySet<string> = new Set()
-): Worktree[] {
+): T[] {
   const visibleIds = new Set(worktrees.map((worktree) => worktree.worktreeId))
   const worktreeById = new Map(worktrees.map((worktree) => [worktree.worktreeId, worktree]))
-  const childrenByParentId = new Map<string, Worktree[]>()
+  const childrenByParentId = new Map<string, T[]>()
   const childIds = new Set<string>()
 
   for (const worktree of worktrees) {
@@ -46,9 +46,9 @@ export function applyMobileWorkspaceLineage(
     childrenByParentId.set(parentId, children)
   }
 
-  const result: Worktree[] = []
+  const result: T[] = []
   const emitted = new Set<string>()
-  const markDescendantsEmitted = (worktree: Worktree): void => {
+  const markDescendantsEmitted = (worktree: T): void => {
     for (const child of childrenByParentId.get(worktree.worktreeId) ?? []) {
       if (!emitted.has(child.worktreeId)) {
         emitted.add(child.worktreeId)
@@ -56,7 +56,7 @@ export function applyMobileWorkspaceLineage(
       }
     }
   }
-  const emit = (worktree: Worktree, depth: number, isLastChild: boolean): void => {
+  const emit = (worktree: T, depth: number, isLastChild: boolean): void => {
     if (emitted.has(worktree.worktreeId)) {
       return
     }

--- a/mobile/src/worktree/projects-home-desktop-roster.test.ts
+++ b/mobile/src/worktree/projects-home-desktop-roster.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { RpcClient } from '../transport/rpc-client'
+import type { HostCatalogEntry, HostProfile } from '../transport/types'
+import { buildProjectsHomeDesktopRoster } from './projects-home-desktop-roster'
+
+function profile(id: string): HostProfile {
+  return {
+    id,
+    name: id,
+    endpoint: `wss://${id}.example.test`,
+    deviceToken: 'token',
+    publicKeyB64: 'public-key',
+    lastConnected: 1
+  }
+}
+
+function catalogEntry(
+  id: string,
+  credentialStatus: HostCatalogEntry['credentialStatus'] = 'ready'
+) {
+  const host = profile(id)
+  return {
+    ...host,
+    credentialStatus,
+    profile: credentialStatus === 'ready' ? host : null
+  }
+}
+
+describe('buildProjectsHomeDesktopRoster', () => {
+  it('keeps every paired desktop actionable through existing or on-demand clients', () => {
+    const clients = Array.from({ length: 4 }, () => ({}) as RpcClient)
+    const acquireClient = vi.fn()
+    const roster = buildProjectsHomeDesktopRoster(
+      [
+        catalogEntry('desktop-1'),
+        catalogEntry('desktop-2'),
+        catalogEntry('desktop-3'),
+        catalogEntry('desktop-4'),
+        catalogEntry('desktop-5'),
+        catalogEntry('desktop-6', 'missing')
+      ],
+      clients.map((client, index) => ({
+        hostId: `desktop-${index + 1}`,
+        client,
+        state: 'connected' as const
+      })),
+      ['desktop-1', 'desktop-2', 'desktop-3'],
+      acquireClient
+    )
+
+    expect(roster).toHaveLength(6)
+    expect(roster.slice(0, 3).map((desktop) => desktop.client)).toEqual(clients.slice(0, 3))
+    expect(roster[3]).toMatchObject({
+      hostId: 'desktop-4',
+      client: clients[3],
+      state: 'connected',
+      availableOnDemand: false
+    })
+    expect(roster[4]).toMatchObject({
+      hostId: 'desktop-5',
+      client: null,
+      state: 'disconnected',
+      availableOnDemand: true,
+      acquireClient
+    })
+    expect(roster[5]).toMatchObject({
+      hostId: 'desktop-6',
+      client: null,
+      state: 'auth-failed',
+      availableOnDemand: false
+    })
+  })
+})

--- a/mobile/src/worktree/projects-home-desktop-roster.test.ts
+++ b/mobile/src/worktree/projects-home-desktop-roster.test.ts
@@ -37,7 +37,10 @@ describe('buildProjectsHomeDesktopRoster', () => {
         catalogEntry('desktop-3'),
         catalogEntry('desktop-4'),
         catalogEntry('desktop-5'),
-        catalogEntry('desktop-6', 'missing')
+        {
+          ...catalogEntry('desktop-6', 'missing'),
+          profile: profile('desktop-6')
+        }
       ],
       clients.map((client, index) => ({
         hostId: `desktop-${index + 1}`,
@@ -69,5 +72,7 @@ describe('buildProjectsHomeDesktopRoster', () => {
       state: 'auth-failed',
       availableOnDemand: false
     })
+    expect(roster[5]).not.toHaveProperty('profile')
+    expect(roster[5]).not.toHaveProperty('acquireClient')
   })
 })

--- a/mobile/src/worktree/projects-home-desktop-roster.ts
+++ b/mobile/src/worktree/projects-home-desktop-roster.ts
@@ -1,0 +1,40 @@
+import { resolveHomeHostConnectionState } from '../transport/home-host-auto-connect'
+import type { RpcClient } from '../transport/rpc-client'
+import type { TransientHostClientLease } from '../transport/transient-host-client'
+import type { ConnectionState, HostCatalogEntry, HostProfile } from '../transport/types'
+import type { DesktopClient } from './use-merged-desktop-catalogs'
+
+type KnownHostClient = {
+  hostId: string
+  client: RpcClient
+  state: ConnectionState
+}
+
+export function buildProjectsHomeDesktopRoster(
+  hostCatalog: readonly HostCatalogEntry[],
+  knownClients: readonly KnownHostClient[],
+  autoConnectHostIds: readonly string[],
+  acquireClient: (
+    host: HostProfile,
+    signal?: AbortSignal,
+    onClientOwned?: (client: RpcClient) => void
+  ) => Promise<TransientHostClientLease | null>
+): DesktopClient[] {
+  const clients = new Map(knownClients.map((entry) => [entry.hostId, entry] as const))
+  return hostCatalog.map((host) => {
+    const entry = clients.get(host.id)
+    return {
+      hostId: host.id,
+      hostName: host.name,
+      client: entry?.client ?? null,
+      availableOnDemand: !entry && host.profile != null,
+      state:
+        host.credentialStatus === 'missing'
+          ? 'auth-failed'
+          : host.credentialStatus === 'temporarily-unavailable'
+            ? 'disconnected'
+            : resolveHomeHostConnectionState(host.id, entry?.state, autoConnectHostIds),
+      ...(host.profile ? { profile: host.profile, acquireClient } : {})
+    }
+  })
+}

--- a/mobile/src/worktree/projects-home-desktop-roster.ts
+++ b/mobile/src/worktree/projects-home-desktop-roster.ts
@@ -23,18 +23,19 @@ export function buildProjectsHomeDesktopRoster(
   const clients = new Map(knownClients.map((entry) => [entry.hostId, entry] as const))
   return hostCatalog.map((host) => {
     const entry = clients.get(host.id)
+    const onDemandProfile = host.credentialStatus === 'ready' ? host.profile : null
     return {
       hostId: host.id,
       hostName: host.name,
       client: entry?.client ?? null,
-      availableOnDemand: !entry && host.profile != null,
+      availableOnDemand: !entry && onDemandProfile != null,
       state:
         host.credentialStatus === 'missing'
           ? 'auth-failed'
           : host.credentialStatus === 'temporarily-unavailable'
             ? 'disconnected'
             : resolveHomeHostConnectionState(host.id, entry?.state, autoConnectHostIds),
-      ...(host.profile ? { profile: host.profile, acquireClient } : {})
+      ...(onDemandProfile ? { profile: onDemandProfile, acquireClient } : {})
     }
   })
 }

--- a/mobile/src/worktree/use-merged-desktop-catalogs.test.ts
+++ b/mobile/src/worktree/use-merged-desktop-catalogs.test.ts
@@ -1,0 +1,505 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { describe, expect, it, vi } from 'vitest'
+import { getProvenCachedWorktrees } from '../cache/worktree-cache'
+import type { RpcClient } from '../transport/rpc-client'
+import type { HostProfile, RpcResponse } from '../transport/types'
+import {
+  useMergedDesktopCatalogs,
+  type DesktopClient,
+  type MergedDesktopCatalogs
+} from './use-merged-desktop-catalogs'
+import type { Worktree } from './workspace-list-types'
+
+type PendingRequest = {
+  method: string
+  resolve: (response: RpcResponse) => void
+}
+
+type TestClient = {
+  rpc: RpcClient
+  pending: PendingRequest[]
+  emit: (payload: unknown) => void
+}
+
+function success(result: unknown): RpcResponse {
+  return { id: 'response', ok: true, result, _meta: { runtimeId: 'runtime' } }
+}
+
+function failure(): RpcResponse {
+  return {
+    id: 'response',
+    ok: false,
+    error: { code: 'offline', message: 'offline' },
+    _meta: { runtimeId: 'runtime' }
+  }
+}
+
+function row(id: string): Worktree {
+  return {
+    workspaceKind: 'git',
+    worktreeId: id,
+    repoId: 'repo-1',
+    repo: 'orca',
+    branch: 'main',
+    displayName: id,
+    path: `/tmp/${id}`,
+    liveTerminalCount: 0,
+    hasAttachedPty: false,
+    preview: '',
+    unread: false,
+    isPinned: false,
+    linkedPR: null
+  }
+}
+
+function makeClient(): TestClient {
+  const pending: PendingRequest[] = []
+  let listener: (payload: unknown) => void = () => {}
+  const rpc = {
+    sendRequest: (method: string) =>
+      new Promise<RpcResponse>((resolve) => pending.push({ method, resolve })),
+    subscribe: (_method: string, _params: unknown, next: (payload: unknown) => void) => {
+      listener = next
+      return () => {
+        listener = () => {}
+      }
+    }
+  } as unknown as RpcClient
+  return { rpc, pending, emit: (payload) => listener(payload) }
+}
+
+function desktop(
+  hostId: string,
+  client: TestClient,
+  state: DesktopClient['state'],
+  hostName = hostId.toUpperCase()
+): DesktopClient {
+  return { hostId, hostName, client: client.rpc, state }
+}
+
+function profile(id: string): HostProfile {
+  return {
+    id,
+    name: id.toUpperCase(),
+    endpoint: `wss://${id}.example.test`,
+    deviceToken: 'token',
+    publicKeyB64: 'public-key',
+    lastConnected: 1
+  }
+}
+
+function mountCatalogs(initial: readonly DesktopClient[]) {
+  let latest: MergedDesktopCatalogs | null = null
+  function Probe({ desktops }: { desktops: readonly DesktopClient[] }) {
+    latest = useMergedDesktopCatalogs(desktops)
+    return null
+  }
+  let renderer!: ReactTestRenderer
+  act(() => {
+    renderer = create(createElement(Probe, { desktops: initial }))
+  })
+  return {
+    get value(): MergedDesktopCatalogs {
+      if (!latest) {
+        throw new Error('probe did not render')
+      }
+      return latest
+    },
+    rebind(desktops: readonly DesktopClient[]) {
+      act(() => renderer.update(createElement(Probe, { desktops })))
+    },
+    unmount() {
+      act(() => renderer.unmount())
+    }
+  }
+}
+
+function takePending(client: TestClient, method: string): PendingRequest {
+  const index = client.pending.findIndex((request) => request.method === method)
+  if (index === -1) {
+    throw new Error(`no pending ${method}`)
+  }
+  return client.pending.splice(index, 1)[0]!
+}
+
+async function settlePending(request: PendingRequest, response: RpcResponse): Promise<void> {
+  await act(async () => {
+    request.resolve(response)
+    await Promise.resolve()
+  })
+}
+
+async function settle(client: TestClient, method: string, response: RpcResponse): Promise<void> {
+  await settlePending(takePending(client, method), response)
+}
+
+async function settleCatalog(
+  client: TestClient,
+  worktrees: Worktree[],
+  repos: unknown[] = [{ id: 'repo-1', displayName: 'orca' }]
+): Promise<void> {
+  await settle(client, 'worktree.ps', success({ worktrees }))
+  await settle(client, 'repo.list', success({ repos }))
+}
+
+describe('useMergedDesktopCatalogs', () => {
+  it('fetches desktops beyond the three-client home budget one at a time and releases them', async () => {
+    const clients = Array.from({ length: 5 }, () => makeClient())
+    const active = new Set<string>()
+    const acquired: string[] = []
+    const released: string[] = []
+    const acquireClient: NonNullable<DesktopClient['acquireClient']> = async (host) => {
+      acquired.push(host.id)
+      active.add(host.id)
+      expect(active.size).toBe(1)
+      const index = Number(host.id.slice(-1)) - 1
+      return {
+        client: clients[index]!.rpc,
+        release: () => {
+          active.delete(host.id)
+          released.push(host.id)
+        }
+      }
+    }
+    const probe = mountCatalogs([
+      desktop('host-1', clients[0]!, 'connected'),
+      desktop('host-2', clients[1]!, 'connected'),
+      desktop('host-3', clients[2]!, 'connected'),
+      {
+        hostId: 'host-4',
+        hostName: 'HOST-4',
+        client: null,
+        state: 'disconnected',
+        profile: profile('host-4'),
+        acquireClient
+      },
+      {
+        hostId: 'host-5',
+        hostName: 'HOST-5',
+        client: null,
+        state: 'disconnected',
+        profile: profile('host-5'),
+        acquireClient
+      }
+    ])
+
+    await act(async () => {
+      clients
+        .slice(0, 3)
+        .forEach((client, index) =>
+          takePending(client, 'worktree.ps').resolve(
+            success({ worktrees: [row(`row-${index + 1}`)] })
+          )
+        )
+      await Promise.resolve()
+      clients
+        .slice(0, 3)
+        .forEach((client) => takePending(client, 'repo.list').resolve(success({ repos: [] })))
+      await Promise.resolve()
+    })
+    expect(acquired).toEqual(['host-4'])
+    expect(probe.value.rosterSettled).toBe(false)
+
+    await settleCatalog(clients[3]!, [row('row-4')])
+    await act(() => Promise.resolve())
+    expect(acquired).toEqual(['host-4', 'host-5'])
+    expect(released).toEqual(['host-4'])
+
+    await settleCatalog(clients[4]!, [row('row-5')])
+    expect(probe.value.catalogs.map((catalog) => catalog.desktopHostId)).toEqual([
+      'host-1',
+      'host-2',
+      'host-3',
+      'host-4',
+      'host-5'
+    ])
+    expect(released).toEqual(['host-4', 'host-5'])
+    expect(active.size).toBe(0)
+    expect(probe.value.rosterSettled).toBe(true)
+  })
+
+  it('does not abort an on-demand refresh when its client is published', async () => {
+    const client = makeClient()
+    let signal: AbortSignal | undefined
+    let resolveLease!: (lease: { client: RpcClient; release: () => void }) => void
+    let markOwned!: (client: RpcClient) => void
+    const acquireClient: NonNullable<DesktopClient['acquireClient']> = (
+      _host,
+      nextSignal,
+      onClientOwned
+    ) => {
+      signal = nextSignal
+      markOwned = onClientOwned ?? (() => {})
+      return new Promise((resolve) => {
+        resolveLease = resolve
+      })
+    }
+    const onDemand: DesktopClient = {
+      hostId: 'published-transient',
+      hostName: 'Published transient',
+      client: null,
+      state: 'disconnected',
+      profile: profile('published-transient'),
+      acquireClient
+    }
+    const release = vi.fn()
+    const probe = mountCatalogs([onDemand])
+    await act(() => Promise.resolve())
+
+    await act(async () => {
+      markOwned(client.rpc)
+      probe.rebind([{ ...onDemand, client: client.rpc, state: 'connected' }])
+      resolveLease({ client: client.rpc, release })
+      await Promise.resolve()
+    })
+    expect(signal?.aborted).toBe(false)
+    expect(client.pending.map((request) => request.method)).toEqual(['worktree.ps'])
+    await settleCatalog(client, [row('transient-result')])
+
+    expect(probe.value.catalogs[0]?.worktrees[0]?.worktreeId).toBe('transient-result')
+    expect(release).toHaveBeenCalledOnce()
+    probe.unmount()
+  })
+
+  it('refreshes again when a persistent owner keeps the transient client', async () => {
+    const client = makeClient()
+    let resolveLease!: (lease: { client: RpcClient; release: () => void }) => void
+    let markOwned!: (client: RpcClient) => void
+    const acquireClient: NonNullable<DesktopClient['acquireClient']> = (
+      _host,
+      _signal,
+      onClientOwned
+    ) => {
+      markOwned = onClientOwned ?? (() => {})
+      return new Promise((resolve) => {
+        resolveLease = resolve
+      })
+    }
+    const onDemand: DesktopClient = {
+      hostId: 'persistent-takeover',
+      hostName: 'Persistent takeover',
+      client: null,
+      state: 'disconnected',
+      profile: profile('persistent-takeover'),
+      acquireClient
+    }
+    const probe = mountCatalogs([onDemand])
+    await act(() => Promise.resolve())
+
+    await act(async () => {
+      markOwned(client.rpc)
+      probe.rebind([{ ...onDemand, client: client.rpc, state: 'connected' }])
+      resolveLease({ client: client.rpc, release: vi.fn() })
+      await Promise.resolve()
+    })
+    await settleCatalog(client, [row('transient-pass')])
+    await act(() => Promise.resolve())
+    await settleCatalog(client, [row('persistent-pass')])
+
+    expect(probe.value.catalogs[0]?.worktrees[0]?.worktreeId).toBe('persistent-pass')
+  })
+
+  it('retains a disconnected desktop while another desktop refreshes', async () => {
+    const left = makeClient()
+    const right = makeClient()
+    const probe = mountCatalogs([
+      desktop('left-retain', left, 'connected'),
+      desktop('right-retain', right, 'connected')
+    ])
+
+    await settleCatalog(left, [row('left-old')])
+    await settleCatalog(right, [row('right-old')])
+    expect(probe.value.catalogs.flatMap((catalog) => catalog.worktrees)).toHaveLength(2)
+
+    probe.rebind([
+      desktop('left-retain', left, 'disconnected'),
+      desktop('right-retain', right, 'connected')
+    ])
+    await settleCatalog(right, [row('right-new')])
+
+    expect(probe.value.catalogs.map((catalog) => catalog.worktrees[0]?.worktreeId)).toEqual([
+      'left-old',
+      'right-new'
+    ])
+  })
+
+  it('fences a late response from a replaced client with the same host id', async () => {
+    const oldClient = makeClient()
+    const newClient = makeClient()
+    const probe = mountCatalogs([desktop('same-host-race', oldClient, 'connected')])
+
+    probe.rebind([desktop('same-host-race', newClient, 'connected')])
+    await settleCatalog(newClient, [row('new-client')])
+    expect(probe.value.catalogs[0]?.worktrees[0]?.worktreeId).toBe('new-client')
+
+    await settleCatalog(oldClient, [row('old-client')])
+    expect(probe.value.catalogs[0]?.worktrees[0]?.worktreeId).toBe('new-client')
+  })
+
+  it('refreshes when the runtime reports a workspace snapshot change', async () => {
+    const client = makeClient()
+    const probe = mountCatalogs([desktop('snapshot-change', client, 'connected')])
+    await settleCatalog(client, [row('before')])
+
+    act(() => client.emit({ type: 'worktreesChanged' }))
+    await settleCatalog(client, [row('after')])
+
+    expect(probe.value.catalogs[0]?.worktrees[0]?.worktreeId).toBe('after')
+  })
+
+  it('accepts an earlier overlapping success when the newer request fails', async () => {
+    const client = makeClient()
+    const probe = mountCatalogs([desktop('overlap-fallback', client, 'connected')])
+    const earlier = takePending(client, 'worktree.ps')
+
+    act(() => client.emit({ type: 'worktreesChanged' }))
+    await settlePending(earlier, success({ worktrees: [row('earlier-success')] }))
+    const newer = takePending(client, 'worktree.ps')
+    const earlierRepos = takePending(client, 'repo.list')
+    await settlePending(newer, failure())
+    await settlePending(earlierRepos, success({ repos: [] }))
+
+    expect(probe.value.catalogs[0]?.worktrees[0]?.worktreeId).toBe('earlier-success')
+  })
+
+  it('keeps a newer overlapping success when the older request finishes last', async () => {
+    const client = makeClient()
+    const probe = mountCatalogs([desktop('overlap-newest', client, 'connected')])
+    const earlier = takePending(client, 'worktree.ps')
+
+    act(() => client.emit({ type: 'worktreesChanged' }))
+    await settlePending(earlier, success({ worktrees: [row('older-success')] }))
+    const newer = takePending(client, 'worktree.ps')
+    const earlierRepos = takePending(client, 'repo.list')
+    await settlePending(newer, success({ worktrees: [row('newer-success')] }))
+    const newerRepos = takePending(client, 'repo.list')
+    await settlePending(newerRepos, success({ repos: [] }))
+    await settlePending(earlierRepos, success({ repos: [] }))
+
+    expect(probe.value.catalogs[0]?.worktrees[0]?.worktreeId).toBe('newer-success')
+  })
+
+  it('accepts an initial response after the desktop is renamed', async () => {
+    const client = makeClient()
+    const probe = mountCatalogs([desktop('rename-fetch', client, 'connected', 'Before')])
+
+    probe.rebind([desktop('rename-fetch', client, 'connected', 'After')])
+    await settleCatalog(client, [row('renamed-host')])
+
+    expect(probe.value.catalogs[0]).toMatchObject({
+      desktopHostName: 'After',
+      worktrees: [{ worktreeId: 'renamed-host' }]
+    })
+  })
+
+  it('does not mutate cache after unmount', async () => {
+    const client = makeClient()
+    const probe = mountCatalogs([desktop('unmount-fence', client, 'connected')])
+    const request = takePending(client, 'worktree.ps')
+    probe.unmount()
+
+    await settlePending(request, success({ worktrees: [row('too-late')] }))
+    await settle(client, 'repo.list', success({ repos: [] }))
+
+    expect(getProvenCachedWorktrees('unmount-fence')).toBeNull()
+  })
+
+  it('cancels and releases a transient lease that resolves after unmount', async () => {
+    const client = makeClient()
+    let resolveLease!: (lease: { client: RpcClient; release: () => void }) => void
+    let signal: AbortSignal | undefined
+    const release = vi.fn()
+    const acquireClient: NonNullable<DesktopClient['acquireClient']> = (_host, nextSignal) => {
+      signal = nextSignal
+      return new Promise((resolve) => {
+        resolveLease = resolve
+      })
+    }
+    const probe = mountCatalogs([
+      {
+        hostId: 'transient-unmount',
+        hostName: 'Transient',
+        client: null,
+        state: 'disconnected',
+        profile: profile('transient-unmount'),
+        acquireClient
+      }
+    ])
+    await act(() => Promise.resolve())
+    probe.unmount()
+
+    await act(async () => {
+      resolveLease({ client: client.rpc, release })
+      await Promise.resolve()
+    })
+
+    expect(signal?.aborted).toBe(true)
+    expect(release).toHaveBeenCalledOnce()
+  })
+
+  it('preserves proven rows and repo metadata across malformed and failed refreshes', async () => {
+    const client = makeClient()
+    const probe = mountCatalogs([desktop('invalid-refresh', client, 'connected')])
+    await settleCatalog(
+      client,
+      [row('before')],
+      [{ id: 'repo-1', displayName: 'orca', connectionId: 'gpu-box' }]
+    )
+
+    act(() => client.emit({ type: 'worktreesChanged' }))
+    await settle(client, 'worktree.ps', success({ nope: [] }))
+    expect(probe.value.catalogs[0]?.worktrees[0]?.worktreeId).toBe('before')
+
+    act(() => client.emit({ type: 'worktreesChanged' }))
+    await settle(
+      client,
+      'worktree.ps',
+      success({ worktrees: [{ ...row('bad-agents'), agents: [{ paneKey: 7 }] }] })
+    )
+    expect(probe.value.catalogs[0]?.worktrees[0]?.worktreeId).toBe('before')
+
+    act(() => client.emit({ type: 'worktreesChanged' }))
+    await settle(
+      client,
+      'worktree.ps',
+      success({
+        worktrees: [{ ...row('bad-linked-pr'), linkedPR: { number: '7', state: 'open' } }]
+      })
+    )
+    expect(probe.value.catalogs[0]?.worktrees[0]?.worktreeId).toBe('before')
+
+    act(() => client.emit({ type: 'worktreesChanged' }))
+    await settle(client, 'worktree.ps', failure())
+    expect(probe.value.catalogs[0]?.worktrees[0]?.worktreeId).toBe('before')
+
+    act(() => client.emit({ type: 'worktreesChanged' }))
+    await settle(client, 'worktree.ps', success({ worktrees: [row('after')] }))
+    await settle(client, 'repo.list', success({ nope: [] }))
+    expect(probe.value.catalogs[0]).toMatchObject({
+      worktrees: [{ worktreeId: 'after' }],
+      repos: [{ connectionId: 'gpu-box' }]
+    })
+
+    act(() => client.emit({ type: 'reposChanged' }))
+    await settle(client, 'worktree.ps', success({ worktrees: [row('unsafe-decoration')] }))
+    await settle(
+      client,
+      'repo.list',
+      success({
+        repos: [
+          {
+            id: 'repo-1',
+            displayName: 'orca',
+            badgeColor: 'url(javascript:alert(1))',
+            repoIcon: { type: 'image', source: 'favicon', src: 'http://example.test/icon.png' }
+          }
+        ]
+      })
+    )
+    expect(probe.value.catalogs[0]).toMatchObject({
+      worktrees: [{ worktreeId: 'unsafe-decoration' }],
+      repos: [{ connectionId: 'gpu-box' }]
+    })
+  })
+})

--- a/mobile/src/worktree/use-merged-desktop-catalogs.ts
+++ b/mobile/src/worktree/use-merged-desktop-catalogs.ts
@@ -1,0 +1,324 @@
+// Reads every connected desktop's workspace catalog for the merged Projects home.
+//
+// One desktop failing is normal (a laptop asleep, a relay dropping), so each is
+// fetched independently and a failure falls back to that desktop's proven cache
+// instead of emptying the list.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type { RuntimeClientEventStreamMessage } from '../../../src/shared/runtime-client-events'
+import { getCachedRepos, setCachedRepos } from '../cache/repo-cache'
+import { getProvenCachedWorkspaceCatalog, setCachedWorktrees } from '../cache/worktree-cache'
+import type { RpcClient } from '../transport/rpc-client'
+import type { ConnectionState, HostProfile } from '../transport/types'
+import type { TransientHostClientLease } from '../transport/transient-host-client'
+import { sendSingleFlightRequest } from '../transport/request-single-flight'
+import type { DesktopWorkspaceCatalog } from './merged-desktop-workspaces'
+import type { RepoSummary } from './host-worktree-rpc-types'
+import { WORKTREE_PS_FULL_LIMIT } from './worktree-catalog-snapshot-client'
+import { readMergedRepoCatalog, readMergedWorktreeCatalog } from './merged-desktop-catalog-response'
+
+export type DesktopClient = {
+  hostId: string
+  hostName: string
+  client: RpcClient | null
+  state: ConnectionState
+  availableOnDemand?: boolean
+  profile?: HostProfile
+  acquireClient?: (
+    host: HostProfile,
+    signal?: AbortSignal,
+    onClientOwned?: (client: RpcClient) => void
+  ) => Promise<TransientHostClientLease | null>
+}
+
+type CatalogsByHostId = Record<string, DesktopWorkspaceCatalog>
+
+const clientIdentities = new WeakMap<RpcClient, number>()
+let nextClientIdentity = 1
+const profileIdentities = new WeakMap<HostProfile, number>()
+let nextProfileIdentity = 1
+
+function clientIdentity(client: RpcClient): number {
+  const existing = clientIdentities.get(client)
+  if (existing !== undefined) {
+    return existing
+  }
+  const identity = nextClientIdentity++
+  clientIdentities.set(client, identity)
+  return identity
+}
+
+function profileIdentity(profile: HostProfile | undefined): number {
+  if (!profile) {
+    return 0
+  }
+  const existing = profileIdentities.get(profile)
+  if (existing !== undefined) {
+    return existing
+  }
+  const identity = nextProfileIdentity++
+  profileIdentities.set(profile, identity)
+  return identity
+}
+
+function cachedCatalog(hostId: string, hostName: string): DesktopWorkspaceCatalog | null {
+  const worktrees = getProvenCachedWorkspaceCatalog(hostId)
+  if (!worktrees) {
+    return null
+  }
+  const repos = readMergedRepoCatalog({
+    repos: getCachedRepos(hostId, { allowStale: true }) ?? []
+  })
+  return {
+    desktopHostId: hostId,
+    desktopHostName: hostName,
+    worktrees,
+    repos: repos ?? []
+  }
+}
+
+async function fetchCatalog(
+  desktop: DesktopClient,
+  client: RpcClient
+): Promise<DesktopWorkspaceCatalog | null> {
+  const worktreeResponse = await sendSingleFlightRequest(client, desktop.hostId, 'worktree.ps', {
+    limit: WORKTREE_PS_FULL_LIMIT
+  })
+  if (!worktreeResponse.ok) {
+    return null
+  }
+  const worktrees = readMergedWorktreeCatalog(worktreeResponse.result)
+  if (!worktrees) {
+    return null
+  }
+  // Repo metadata only decorates rows and resolves the execution host of older
+  // payloads, so a failure here must not discard the workspaces we just proved.
+  let repos: RepoSummary[] = []
+  try {
+    const repoResponse = await client.sendRequest('repo.list')
+    const receivedRepos = repoResponse.ok ? readMergedRepoCatalog(repoResponse.result) : null
+    repos = receivedRepos ?? cachedRepos(desktop.hostId)
+  } catch {
+    repos = cachedRepos(desktop.hostId)
+  }
+
+  return {
+    desktopHostId: desktop.hostId,
+    desktopHostName: desktop.hostName,
+    worktrees,
+    repos
+  }
+}
+
+function cachedRepos(hostId: string): RepoSummary[] {
+  return readMergedRepoCatalog({ repos: getCachedRepos(hostId, { allowStale: true }) ?? [] }) ?? []
+}
+
+function subscribeToCatalogChanges(
+  desktop: DesktopClient & { client: RpcClient },
+  refresh: () => void
+): () => void {
+  let ready = false
+  return desktop.client.subscribe('runtime.clientEvents.subscribe', null, (payload: unknown) => {
+    if (!payload || typeof payload !== 'object') {
+      return
+    }
+    const event = payload as RuntimeClientEventStreamMessage | { type: 'error' }
+    if (event.type === 'ready') {
+      if (ready) {
+        refresh()
+      }
+      ready = true
+    } else if (event.type === 'worktreesChanged' || event.type === 'reposChanged') {
+      refresh()
+    } else if (event.type === 'end' || event.type === 'error') {
+      ready = false
+    }
+  })
+}
+
+export type MergedDesktopCatalogs = {
+  catalogs: DesktopWorkspaceCatalog[]
+  /** True until the first fetch settles and nothing was recoverable from cache. */
+  loading: boolean
+  /** True only after every persistent and on-demand desktop attempt settles. */
+  rosterSettled: boolean
+  refresh: () => Promise<void>
+}
+
+export function useMergedDesktopCatalogs(
+  desktops: readonly DesktopClient[]
+): MergedDesktopCatalogs {
+  const [catalogsByHostId, setCatalogsByHostId] = useState<CatalogsByHostId>({})
+  const [settled, setSettled] = useState(false)
+  const desktopsRef = useRef<readonly DesktopClient[]>(desktops)
+  const mountedRef = useRef(false)
+  const requestSequenceRef = useRef(0)
+  const acceptedRequestSequenceRef = useRef<Record<string, number>>({})
+  const transientAbortRef = useRef<AbortController | null>(null)
+  const transientClientsRef = useRef<Map<string, { client: RpcClient; requestSequence: number }>>(
+    new Map()
+  )
+
+  const rosterKey = JSON.stringify(
+    desktops
+      .map((desktop) => [desktop.hostId, desktop.hostName, profileIdentity(desktop.profile)])
+      .sort()
+  )
+  const connectedKey = JSON.stringify(
+    desktops
+      .filter(
+        (desktop): desktop is DesktopClient & { client: RpcClient } =>
+          desktop.state === 'connected' &&
+          desktop.client !== null &&
+          transientClientsRef.current.get(desktop.hostId)?.client !== desktop.client
+      )
+      .map((desktop) => [desktop.hostId, clientIdentity(desktop.client)])
+      .sort()
+  )
+  const refresh = useCallback(async () => {
+    transientAbortRef.current?.abort()
+    const transientAbort = new AbortController()
+    transientAbortRef.current = transientAbort
+    setSettled(false)
+    const requestSequence = ++requestSequenceRef.current
+    const targets = desktopsRef.current
+    const connected = targets.filter(
+      (desktop): desktop is DesktopClient & { client: RpcClient } =>
+        desktop.state === 'connected' && desktop.client !== null
+    )
+    const applyResults = (
+      results: {
+        desktop: DesktopClient
+        client: RpcClient
+        catalog: DesktopWorkspaceCatalog | null
+      }[]
+    ) => {
+      if (!mountedRef.current) {
+        return
+      }
+      const currentByHostId = new Map(
+        desktopsRef.current.map((desktop) => [desktop.hostId, desktop])
+      )
+      const accepted = results.filter(({ desktop, client, catalog }) => {
+        const current = currentByHostId.get(desktop.hostId)
+        if (
+          !catalog ||
+          !current ||
+          current.profile !== desktop.profile ||
+          (current.client !== null && current.client !== client) ||
+          requestSequence <= (acceptedRequestSequenceRef.current[desktop.hostId] ?? 0)
+        ) {
+          return false
+        }
+        acceptedRequestSequenceRef.current[desktop.hostId] = requestSequence
+        setCachedWorktrees(desktop.hostId, [...catalog.worktrees], { proven: true })
+        setCachedRepos(desktop.hostId, [...(catalog.repos ?? [])])
+        return true
+      })
+      setCatalogsByHostId((prev) => {
+        const next: CatalogsByHostId = {}
+        const resultsByHostId = new Map(accepted.map((result) => [result.desktop.hostId, result]))
+        for (const desktop of desktopsRef.current) {
+          const result = resultsByHostId.get(desktop.hostId)
+          const resolved =
+            result?.catalog ??
+            prev[desktop.hostId] ??
+            cachedCatalog(desktop.hostId, desktop.hostName)
+          if (resolved) {
+            next[desktop.hostId] = { ...resolved, desktopHostName: desktop.hostName }
+          }
+        }
+        return next
+      })
+    }
+    const connectedResults = await Promise.all(
+      connected.map((desktop) =>
+        fetchCatalog(desktop, desktop.client)
+          .catch(() => null)
+          .then((catalog) => ({ desktop, client: desktop.client, catalog }))
+      )
+    )
+    applyResults(connectedResults)
+    if (!mountedRef.current || transientAbort.signal.aborted) {
+      return
+    }
+    for (const desktop of targets) {
+      if (desktop.client || !desktop.profile || !desktop.acquireClient) {
+        continue
+      }
+      const lease = await desktop.acquireClient(
+        desktop.profile,
+        transientAbort.signal,
+        (client) => {
+          transientClientsRef.current.set(desktop.hostId, { client, requestSequence })
+        }
+      )
+      if (!lease) {
+        const ownership = transientClientsRef.current.get(desktop.hostId)
+        if (ownership?.requestSequence === requestSequence) {
+          transientClientsRef.current.delete(desktop.hostId)
+        }
+        continue
+      }
+      try {
+        if (!mountedRef.current || transientAbort.signal.aborted) {
+          return
+        }
+        const catalog = await fetchCatalog(desktop, lease.client).catch(() => null)
+        if (!mountedRef.current || transientAbort.signal.aborted) {
+          return
+        }
+        applyResults([{ desktop, client: lease.client, catalog }])
+      } finally {
+        lease.release()
+        const ownership = transientClientsRef.current.get(desktop.hostId)
+        if (ownership?.requestSequence === requestSequence && ownership.client === lease.client) {
+          transientClientsRef.current.delete(desktop.hostId)
+        }
+      }
+      if (!mountedRef.current || transientAbort.signal.aborted) {
+        return
+      }
+    }
+    setSettled(true)
+  }, [])
+
+  useEffect(() => {
+    desktopsRef.current = desktops
+  }, [desktops])
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      transientAbortRef.current?.abort()
+    }
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+  }, [connectedKey, refresh, rosterKey])
+
+  useEffect(() => {
+    const cleanups = desktopsRef.current
+      .filter((desktop) => desktop.state === 'connected')
+      .filter(
+        (desktop): desktop is DesktopClient & { client: RpcClient } => desktop.client !== null
+      )
+      .map((desktop) => subscribeToCatalogChanges(desktop, () => void refresh()))
+    return () => cleanups.forEach((cleanup) => cleanup())
+  }, [connectedKey, refresh])
+
+  const catalogs = useMemo(
+    () =>
+      desktops.flatMap((desktop) => {
+        const catalog =
+          catalogsByHostId[desktop.hostId] ?? cachedCatalog(desktop.hostId, desktop.hostName)
+        return catalog ? [{ ...catalog, desktopHostName: desktop.hostName }] : []
+      }),
+    [desktops, catalogsByHostId]
+  )
+
+  return { catalogs, loading: !settled && catalogs.length === 0, rosterSettled: settled, refresh }
+}

--- a/mobile/src/worktree/use-projects-home-view-state.test.ts
+++ b/mobile/src/worktree/use-projects-home-view-state.test.ts
@@ -29,6 +29,14 @@ vi.mock('../storage/projects-home-view-settings', async (importOriginal) => {
 const KEEP = '["desktop-a","local"]'
 const STALE = '["desktop-b","ssh:retired"]'
 
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
 describe('useProjectsHomeViewState', () => {
   let renderer: ReactTestRenderer | null = null
   let latest: ProjectsHomeViewState | null = null
@@ -70,6 +78,34 @@ describe('useProjectsHomeViewState', () => {
     expect(saveProjectsHomeViewSettings).toHaveBeenCalledWith(
       expect.objectContaining({ executionHostIds: [KEEP] })
     )
+    act(() => renderer?.unmount())
+  })
+
+  it('merges and persists changes made before hydration finishes', async () => {
+    const load = deferred<ProjectsHomeViewSettings>()
+    vi.mocked(loadProjectsHomeViewSettings).mockReturnValue(load.promise)
+    await mount()
+
+    act(() => latest?.toggleHideSleeping())
+    await act(async () => {
+      load.resolve({
+        groupMode: 'prStatus',
+        sortMode: 'name',
+        hideSleeping: false,
+        hideDefaultBranch: true,
+        executionHostIds: [KEEP]
+      })
+      await load.promise
+    })
+
+    expect(latest?.settings).toEqual({
+      groupMode: 'prStatus',
+      sortMode: 'name',
+      hideSleeping: true,
+      hideDefaultBranch: true,
+      executionHostIds: [KEEP]
+    })
+    expect(saveProjectsHomeViewSettings).toHaveBeenCalledWith(latest?.settings)
     act(() => renderer?.unmount())
   })
 })

--- a/mobile/src/worktree/use-projects-home-view-state.test.ts
+++ b/mobile/src/worktree/use-projects-home-view-state.test.ts
@@ -1,0 +1,75 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  loadProjectsHomeViewSettings,
+  saveProjectsHomeViewSettings,
+  type ProjectsHomeViewSettings
+} from '../storage/projects-home-view-settings'
+import {
+  useProjectsHomeViewState,
+  type ProjectsHomeViewState
+} from './use-projects-home-view-state'
+
+type ProjectsHomeViewSettingsStorage = {
+  DEFAULT_PROJECTS_HOME_VIEW_SETTINGS: ProjectsHomeViewSettings
+  loadProjectsHomeViewSettings: typeof loadProjectsHomeViewSettings
+  saveProjectsHomeViewSettings: typeof saveProjectsHomeViewSettings
+}
+
+vi.mock('../storage/projects-home-view-settings', async (importOriginal) => {
+  const original = await importOriginal<ProjectsHomeViewSettingsStorage>()
+  return {
+    ...original,
+    loadProjectsHomeViewSettings: vi.fn(),
+    saveProjectsHomeViewSettings: vi.fn()
+  }
+})
+
+const KEEP = '["desktop-a","local"]'
+const STALE = '["desktop-b","ssh:retired"]'
+
+describe('useProjectsHomeViewState', () => {
+  let renderer: ReactTestRenderer | null = null
+  let latest: ProjectsHomeViewState | null = null
+
+  beforeEach(() => {
+    renderer = null
+    latest = null
+    vi.mocked(loadProjectsHomeViewSettings)
+      .mockReset()
+      .mockResolvedValue({
+        groupMode: 'repo',
+        sortMode: 'recent',
+        hideSleeping: false,
+        hideDefaultBranch: false,
+        executionHostIds: [KEEP, STALE]
+      })
+    vi.mocked(saveProjectsHomeViewSettings).mockReset().mockResolvedValue(undefined)
+  })
+
+  async function mount(): Promise<void> {
+    function Probe(): null {
+      latest = useProjectsHomeViewState()
+      return null
+    }
+    await act(async () => {
+      renderer = create(createElement(Probe))
+      await Promise.resolve()
+    })
+  }
+
+  it('prunes a persisted host selection that no longer has a represented row', async () => {
+    await mount()
+
+    act(() => {
+      latest?.pruneExecutionHosts([{ id: KEEP, label: 'Desktop A · Local Mac', count: 1 }])
+    })
+
+    expect(latest?.settings.executionHostIds).toEqual([KEEP])
+    expect(saveProjectsHomeViewSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ executionHostIds: [KEEP] })
+    )
+    act(() => renderer?.unmount())
+  })
+})

--- a/mobile/src/worktree/use-projects-home-view-state.ts
+++ b/mobile/src/worktree/use-projects-home-view-state.ts
@@ -1,7 +1,7 @@
 // View state (group / sort / filters / collapsed groups) for the merged Projects
 // home, persisted locally. Kept out of the screen so the screen stays a renderer.
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   DEFAULT_PROJECTS_HOME_VIEW_SETTINGS,
   loadProjectsHomeViewSettings,
@@ -34,17 +34,36 @@ export function useProjectsHomeViewState(): ProjectsHomeViewState {
   const [settings, setSettings] = useState<ProjectsHomeViewSettings>(
     DEFAULT_PROJECTS_HOME_VIEW_SETTINGS
   )
+  const settingsRef = useRef(settings)
+  const hydratedRef = useRef(false)
+  const dirtyKeysRef = useRef(new Set<keyof ProjectsHomeViewSettings>())
   // Why: collapsed groups are view-session state, not a preference — a group the
   // user folded to scan one repo should not still be folded next launch.
   const [collapsedGroups, setCollapsedGroups] = useState<ReadonlySet<string>>(new Set())
-  const [hydrated, setHydrated] = useState(false)
 
   useEffect(() => {
     let cancelled = false
     void loadProjectsHomeViewSettings().then((loaded) => {
       if (!cancelled) {
-        setSettings(loaded)
-        setHydrated(true)
+        const current = settingsRef.current
+        const dirty = dirtyKeysRef.current
+        const merged = {
+          groupMode: dirty.has('groupMode') ? current.groupMode : loaded.groupMode,
+          sortMode: dirty.has('sortMode') ? current.sortMode : loaded.sortMode,
+          hideSleeping: dirty.has('hideSleeping') ? current.hideSleeping : loaded.hideSleeping,
+          hideDefaultBranch: dirty.has('hideDefaultBranch')
+            ? current.hideDefaultBranch
+            : loaded.hideDefaultBranch,
+          executionHostIds: dirty.has('executionHostIds')
+            ? current.executionHostIds
+            : loaded.executionHostIds
+        }
+        settingsRef.current = merged
+        hydratedRef.current = true
+        setSettings(merged)
+        if (dirty.size > 0) {
+          void saveProjectsHomeViewSettings(merged)
+        }
       }
     })
     return () => {
@@ -52,19 +71,24 @@ export function useProjectsHomeViewState(): ProjectsHomeViewState {
     }
   }, [])
 
-  const update = useCallback(
-    (patch: Partial<ProjectsHomeViewSettings>) => {
-      setSettings((prev) => {
-        const next = { ...prev, ...patch }
-        // Why the guard: writing before the load resolves would persist the
-        // defaults over settings still in flight and silently reset the user.
-        if (hydrated) {
-          void saveProjectsHomeViewSettings(next)
-        }
-        return next
-      })
+  const commitSettings = useCallback(
+    (next: ProjectsHomeViewSettings, changedKeys: readonly (keyof ProjectsHomeViewSettings)[]) => {
+      settingsRef.current = next
+      setSettings(next)
+      if (hydratedRef.current) {
+        void saveProjectsHomeViewSettings(next)
+      } else {
+        changedKeys.forEach((key) => dirtyKeysRef.current.add(key))
+      }
     },
-    [hydrated]
+    []
+  )
+
+  const update = useCallback(
+    <Key extends keyof ProjectsHomeViewSettings>(patch: Pick<ProjectsHomeViewSettings, Key>) => {
+      commitSettings({ ...settingsRef.current, ...patch }, Object.keys(patch) as Key[])
+    },
+    [commitSettings]
   )
 
   const filters = useMemo<FilterState>(
@@ -85,41 +109,27 @@ export function useProjectsHomeViewState(): ProjectsHomeViewState {
 
   const toggleExecutionHost = useCallback(
     (hostId: string) => {
-      setSettings((prev) => {
-        const selected = new Set(prev.executionHostIds)
-        if (!selected.delete(hostId)) {
-          selected.add(hostId)
-        }
-        const next = { ...prev, executionHostIds: [...selected] }
-        if (hydrated) {
-          void saveProjectsHomeViewSettings(next)
-        }
-        return next
-      })
+      const selected = new Set(settingsRef.current.executionHostIds)
+      if (!selected.delete(hostId)) {
+        selected.add(hostId)
+      }
+      update({ executionHostIds: [...selected] })
     },
-    [hydrated]
+    [update]
   )
 
   const pruneExecutionHosts = useCallback(
     (options: readonly ExecutionHostFilterOption[]) => {
-      setSettings((prev) => {
-        const retained = [
-          ...retainRepresentedExecutionHostIds(new Set(prev.executionHostIds), options)
-        ]
-        if (
-          retained.length === prev.executionHostIds.length &&
-          retained.every((id, index) => id === prev.executionHostIds[index])
-        ) {
-          return prev
-        }
-        const next = { ...prev, executionHostIds: retained }
-        if (hydrated) {
-          void saveProjectsHomeViewSettings(next)
-        }
-        return next
-      })
+      const previous = settingsRef.current.executionHostIds
+      const retained = [...retainRepresentedExecutionHostIds(new Set(previous), options)]
+      if (
+        retained.length !== previous.length ||
+        retained.some((id, index) => id !== previous[index])
+      ) {
+        update({ executionHostIds: retained })
+      }
     },
-    [hydrated]
+    [update]
   )
 
   const toggleCollapsedGroup = useCallback((key: string) => {
@@ -140,12 +150,12 @@ export function useProjectsHomeViewState(): ProjectsHomeViewState {
     setGroupMode: useCallback((groupMode) => update({ groupMode }), [update]),
     setSortMode: useCallback((sortMode) => update({ sortMode }), [update]),
     toggleHideSleeping: useCallback(
-      () => update({ hideSleeping: !settings.hideSleeping }),
-      [update, settings.hideSleeping]
+      () => update({ hideSleeping: !settingsRef.current.hideSleeping }),
+      [update]
     ),
     toggleHideDefaultBranch: useCallback(
-      () => update({ hideDefaultBranch: !settings.hideDefaultBranch }),
-      [update, settings.hideDefaultBranch]
+      () => update({ hideDefaultBranch: !settingsRef.current.hideDefaultBranch }),
+      [update]
     ),
     toggleExecutionHost,
     pruneExecutionHosts,

--- a/mobile/src/worktree/use-projects-home-view-state.ts
+++ b/mobile/src/worktree/use-projects-home-view-state.ts
@@ -1,0 +1,158 @@
+// View state (group / sort / filters / collapsed groups) for the merged Projects
+// home, persisted locally. Kept out of the screen so the screen stays a renderer.
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  DEFAULT_PROJECTS_HOME_VIEW_SETTINGS,
+  loadProjectsHomeViewSettings,
+  saveProjectsHomeViewSettings,
+  type ProjectsHomeViewSettings
+} from '../storage/projects-home-view-settings'
+import type { FilterState } from './workspace-list-types'
+import {
+  retainRepresentedExecutionHostIds,
+  type ExecutionHostFilterOption
+} from './merged-desktop-workspaces'
+import type { MobileGroupMode, MobileSortMode } from './workspace-view-settings'
+
+export type ProjectsHomeViewState = {
+  settings: ProjectsHomeViewSettings
+  filters: FilterState
+  activeFilterCount: number
+  collapsedGroups: ReadonlySet<string>
+  setGroupMode: (mode: MobileGroupMode) => void
+  setSortMode: (mode: MobileSortMode) => void
+  toggleHideSleeping: () => void
+  toggleHideDefaultBranch: () => void
+  toggleExecutionHost: (hostId: string) => void
+  pruneExecutionHosts: (options: readonly ExecutionHostFilterOption[]) => void
+  clearFilters: () => void
+  toggleCollapsedGroup: (key: string) => void
+}
+
+export function useProjectsHomeViewState(): ProjectsHomeViewState {
+  const [settings, setSettings] = useState<ProjectsHomeViewSettings>(
+    DEFAULT_PROJECTS_HOME_VIEW_SETTINGS
+  )
+  // Why: collapsed groups are view-session state, not a preference — a group the
+  // user folded to scan one repo should not still be folded next launch.
+  const [collapsedGroups, setCollapsedGroups] = useState<ReadonlySet<string>>(new Set())
+  const [hydrated, setHydrated] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    void loadProjectsHomeViewSettings().then((loaded) => {
+      if (!cancelled) {
+        setSettings(loaded)
+        setHydrated(true)
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const update = useCallback(
+    (patch: Partial<ProjectsHomeViewSettings>) => {
+      setSettings((prev) => {
+        const next = { ...prev, ...patch }
+        // Why the guard: writing before the load resolves would persist the
+        // defaults over settings still in flight and silently reset the user.
+        if (hydrated) {
+          void saveProjectsHomeViewSettings(next)
+        }
+        return next
+      })
+    },
+    [hydrated]
+  )
+
+  const filters = useMemo<FilterState>(
+    () => ({
+      filterRepoIds: new Set(),
+      hideSleeping: settings.hideSleeping,
+      hideDefaultBranch: settings.hideDefaultBranch,
+      alwaysShowDefaultBranch: true,
+      filterExecutionHostIds: new Set(settings.executionHostIds)
+    }),
+    [settings]
+  )
+
+  const activeFilterCount =
+    (settings.hideSleeping ? 1 : 0) +
+    (settings.hideDefaultBranch ? 1 : 0) +
+    settings.executionHostIds.length
+
+  const toggleExecutionHost = useCallback(
+    (hostId: string) => {
+      setSettings((prev) => {
+        const selected = new Set(prev.executionHostIds)
+        if (!selected.delete(hostId)) {
+          selected.add(hostId)
+        }
+        const next = { ...prev, executionHostIds: [...selected] }
+        if (hydrated) {
+          void saveProjectsHomeViewSettings(next)
+        }
+        return next
+      })
+    },
+    [hydrated]
+  )
+
+  const pruneExecutionHosts = useCallback(
+    (options: readonly ExecutionHostFilterOption[]) => {
+      setSettings((prev) => {
+        const retained = [
+          ...retainRepresentedExecutionHostIds(new Set(prev.executionHostIds), options)
+        ]
+        if (
+          retained.length === prev.executionHostIds.length &&
+          retained.every((id, index) => id === prev.executionHostIds[index])
+        ) {
+          return prev
+        }
+        const next = { ...prev, executionHostIds: retained }
+        if (hydrated) {
+          void saveProjectsHomeViewSettings(next)
+        }
+        return next
+      })
+    },
+    [hydrated]
+  )
+
+  const toggleCollapsedGroup = useCallback((key: string) => {
+    setCollapsedGroups((prev) => {
+      const next = new Set(prev)
+      if (!next.delete(key)) {
+        next.add(key)
+      }
+      return next
+    })
+  }, [])
+
+  return {
+    settings,
+    filters,
+    activeFilterCount,
+    collapsedGroups,
+    setGroupMode: useCallback((groupMode) => update({ groupMode }), [update]),
+    setSortMode: useCallback((sortMode) => update({ sortMode }), [update]),
+    toggleHideSleeping: useCallback(
+      () => update({ hideSleeping: !settings.hideSleeping }),
+      [update, settings.hideSleeping]
+    ),
+    toggleHideDefaultBranch: useCallback(
+      () => update({ hideDefaultBranch: !settings.hideDefaultBranch }),
+      [update, settings.hideDefaultBranch]
+    ),
+    toggleExecutionHost,
+    pruneExecutionHosts,
+    clearFilters: useCallback(
+      () => update({ hideSleeping: false, hideDefaultBranch: false, executionHostIds: [] }),
+      [update]
+    ),
+    toggleCollapsedGroup
+  }
+}

--- a/mobile/src/worktree/workspace-list-ordering.ts
+++ b/mobile/src/worktree/workspace-list-ordering.ts
@@ -51,11 +51,11 @@ function compareByAgentAttention(a: Worktree, b: Worktree, now: number): number 
   )
 }
 
-export function sortWorktrees(
-  worktrees: Worktree[],
+export function sortWorktrees<T extends Worktree>(
+  worktrees: T[],
   mode: MobileSortMode,
   now = Date.now()
-): Worktree[] {
+): T[] {
   if (mode === 'manual') {
     return [...worktrees].sort((a, b) => {
       const aRank = getManualSortRank(a)

--- a/mobile/src/worktree/workspace-list-sections.test.ts
+++ b/mobile/src/worktree/workspace-list-sections.test.ts
@@ -9,6 +9,7 @@ import {
   sortWorktrees
 } from './workspace-list-sections'
 import { DEFAULT_MOBILE_WORKSPACE_STATUSES } from './mobile-workspace-statuses'
+import { getMobileWorkspaceLineageGroupKey } from './mobile-workspace-lineage'
 
 function worktree(overrides: Partial<Worktree> = {}): Worktree {
   const worktreePath = join('/tmp', 'orca', 'worktrees', 'feature')
@@ -547,11 +548,11 @@ describe('buildSections', () => {
 
     expect(withoutSectionListKeys(sections)).toEqual([
       {
-        key: 'repo:repo-1',
+        key: '["repo","repo-1"]',
         title: 'orca',
         data: [worktree({ repoId: 'repo-1', repo: 'orca' })]
       },
-      { key: 'repo:repo-missing', title: 'zoom-img', data: [] }
+      { key: '["repo","repo-missing"]', title: 'zoom-img', data: [] }
     ])
   })
 
@@ -589,7 +590,7 @@ describe('buildSections', () => {
     )
 
     expect(withoutSectionListKeys(sections)).toEqual([
-      { key: 'repo:repo-matching', title: 'zoom-img', data: [] }
+      { key: '["repo","repo-matching"]', title: 'zoom-img', data: [] }
     ])
   })
 
@@ -613,7 +614,7 @@ describe('buildSections', () => {
     )
 
     expect(withoutSectionListKeys(sections)).toEqual([
-      { key: 'repo:repo-empty', title: 'empty-repo', data: [] }
+      { key: '["repo","repo-empty"]', title: 'empty-repo', data: [] }
     ])
   })
 
@@ -776,7 +777,7 @@ describe('buildSections', () => {
       new Set(),
       new Map(),
       DEFAULT_MOBILE_WORKSPACE_STATUSES,
-      new Set(['workspace-lineage:parent'])
+      new Set([getMobileWorkspaceLineageGroupKey('parent')])
     )
 
     expect(sections[0]?.data.map((worktree) => worktree.worktreeId)).toEqual(['parent'])

--- a/mobile/src/worktree/workspace-list-sections.ts
+++ b/mobile/src/worktree/workspace-list-sections.ts
@@ -1,3 +1,4 @@
+import { LOCAL_EXECUTION_HOST_ID } from '../../../src/shared/execution-host'
 import type { WorkspaceStatusDefinition } from '../../../src/shared/worktree/types'
 import {
   DEFAULT_MOBILE_WORKSPACE_STATUSES,
@@ -14,13 +15,17 @@ import { sortWorktrees } from './workspace-list-ordering'
 export type { FilterState, Section, Worktree } from './workspace-list-types'
 export { CREATE_GRACE_MS, getWorktreeStatus, sortWorktrees } from './workspace-list-ordering'
 
-function makeSection(
+function sectionIdentity(...parts: string[]): string {
+  return JSON.stringify(parts)
+}
+
+function makeSection<T extends Worktree>(
   key: string,
   title: string,
-  data: Worktree[],
+  data: T[],
   icon?: 'pin',
   collapsedGroups?: ReadonlySet<string>
-): Section {
+): Section<T> {
   const rows = collapsedGroups ? applyMobileWorkspaceLineage(data, collapsedGroups) : data
   return {
     key,
@@ -28,7 +33,7 @@ function makeSection(
     ...(icon ? { icon } : {}),
     data: rows.map((worktree) => ({
       ...worktree,
-      sectionListKey: `${key}:${worktree.worktreeId}`
+      sectionListKey: sectionIdentity('row', key, worktree.worktreeId)
     }))
   }
 }
@@ -78,7 +83,7 @@ function isSleepingSweepExempt(w: Worktree, alwaysShowDefaultBranch: boolean | u
   return w.isMainWorktree ?? (w.workspaceKind === 'folder-workspace' || isDefaultBranchWorkspace(w))
 }
 
-function orderMainWorktreeFirst(worktrees: Worktree[]): Worktree[] {
+function orderMainWorktreeFirst<T extends Worktree>(worktrees: T[]): T[] {
   const mainWorktrees = worktrees.filter((worktree) => worktree.isMainWorktree)
   if (mainWorktrees.length === 0) {
     return worktrees
@@ -86,11 +91,11 @@ function orderMainWorktreeFirst(worktrees: Worktree[]): Worktree[] {
   return [...mainWorktrees, ...worktrees.filter((worktree) => !worktree.isMainWorktree)]
 }
 
-export function filterWorktrees(
-  worktrees: Worktree[],
+export function filterWorktrees<T extends Worktree>(
+  worktrees: T[],
   filters: FilterState,
   search: string
-): Worktree[] {
+): T[] {
   let result = worktrees.filter((w) => !w.isArchived)
   if (filters.hideSleeping) {
     result = result.filter(
@@ -102,6 +107,13 @@ export function filterWorktrees(
   }
   if (filters.filterRepoIds.size > 0) {
     result = result.filter((w) => filters.filterRepoIds.has(w.repoId))
+  }
+  const executionHostIds = filters.filterExecutionHostIds
+  if (executionHostIds && executionHostIds.size > 0) {
+    // Merged rows carry a desktop-scoped id; legacy per-host rows fall back local.
+    result = result.filter((w) =>
+      executionHostIds.has(w.executionHostFilterId ?? w.hostId ?? LOCAL_EXECUTION_HOST_ID)
+    )
   }
   if (search.trim()) {
     const q = search.toLowerCase()
@@ -119,8 +131,8 @@ export function isWorktreePinned(w: Worktree, localPins: Set<string>): boolean {
   return w.isPinned || localPins.has(w.worktreeId)
 }
 
-export function buildSections(
-  worktrees: Worktree[],
+export function buildSections<T extends Worktree>(
+  worktrees: T[],
   sortMode: MobileSortMode,
   filters: FilterState,
   search: string,
@@ -129,7 +141,7 @@ export function buildSections(
   repoIdsByName: ReadonlyMap<string, string> = new Map(),
   workspaceStatuses: readonly WorkspaceStatusDefinition[] = DEFAULT_MOBILE_WORKSPACE_STATUSES,
   collapsedGroups: ReadonlySet<string> = new Set()
-): Section[] {
+): Section<T>[] {
   const filtered = filterWorktrees(worktrees, filters, search)
   const sorted = sortWorktrees(filtered, sortMode)
 
@@ -138,7 +150,7 @@ export function buildSections(
   // groups preserves exact cross-surface order and literal section counts.
   const canonicalGroupWorktrees = sorted
 
-  const sections: Section[] = []
+  const sections: Section<T>[] = []
   if (pinned.length > 0) {
     sections.push(makeSection('pinned', 'Pinned', pinned, 'pin'))
   }
@@ -148,14 +160,14 @@ export function buildSections(
       sections.push(makeSection('all', 'All', canonicalGroupWorktrees, undefined, collapsedGroups))
     }
   } else if (groupMode === 'repo') {
-    const byRepo = new Map<string, Worktree[]>()
+    const byRepo = new Map<string, { title: string; items: T[] }>()
     for (const w of canonicalGroupWorktrees) {
-      const key = w.repo || 'Unknown'
-      const list = byRepo.get(key)
-      if (list) {
-        list.push(w)
+      const key = w.repoId || w.repo || 'Unknown'
+      const group = byRepo.get(key)
+      if (group) {
+        group.items.push(w)
       } else {
-        byRepo.set(key, [w])
+        byRepo.set(key, { title: w.repo || 'Unknown', items: [w] })
       }
     }
     const representedRepoIds = new Set(worktrees.map((w) => w.repoId))
@@ -170,19 +182,25 @@ export function buildSections(
       if (query && !displayName.toLowerCase().includes(query)) {
         continue
       }
-      if (!byRepo.has(displayName)) {
-        byRepo.set(displayName, [])
+      if (!byRepo.has(id)) {
+        byRepo.set(id, { title: displayName, items: [] })
       }
     }
-    for (const [repo, items] of byRepo) {
-      const key = `repo:${repoIdsByName.get(repo) ?? repo}`
+    for (const [repoId, group] of byRepo) {
+      const key = sectionIdentity('repo', repoId)
       sections.push(
-        makeSection(key, repo, orderMainWorktreeFirst(items), undefined, collapsedGroups)
+        makeSection(
+          key,
+          group.title,
+          orderMainWorktreeFirst(group.items),
+          undefined,
+          collapsedGroups
+        )
       )
     }
   } else if (groupMode === 'workspaceStatus') {
     const renderableWorkspaceStatuses = coerceMobileWorkspaceStatuses(workspaceStatuses)
-    const byStatus = new Map<string, Worktree[]>()
+    const byStatus = new Map<string, T[]>()
     for (const w of canonicalGroupWorktrees) {
       const key = getMobileWorkspaceStatus(w, renderableWorkspaceStatuses)
       const list = byStatus.get(key)
@@ -207,7 +225,7 @@ export function buildSections(
       }
     }
   } else if (groupMode === 'prStatus') {
-    const byGroup = new Map<string, Worktree[]>()
+    const byGroup = new Map<string, T[]>()
     for (const w of canonicalGroupWorktrees) {
       const key = getPRGroupKey(w)
       const list = byGroup.get(key)
@@ -222,7 +240,7 @@ export function buildSections(
       if (items && items.length > 0) {
         sections.push(
           makeSection(
-            `pr:${groupKey}`,
+            sectionIdentity('pr', groupKey),
             PR_GROUP_LABELS[groupKey],
             items,
             undefined,

--- a/mobile/src/worktree/workspace-list-types.ts
+++ b/mobile/src/worktree/workspace-list-types.ts
@@ -7,6 +7,9 @@ export type Worktree = {
   worktreeId: string
   repoId: string
   hostId?: ExecutionHostId
+  /** Opaque filter identity when one list combines multiple desktop catalogs. */
+  executionHostFilterId?: string
+  executionHostFilterLabel?: string
   terminalPlatform?: NodeJS.Platform
   repo: string
   branch: string
@@ -54,6 +57,19 @@ export type FilterState = {
   hideDefaultBranch: boolean
   /** Absent means on: #8873's exemption must fail open on older host payloads. */
   alwaysShowDefaultBranch?: boolean
+  /**
+   * Execution hosts (local / WSL / SSH) to keep, mirroring the desktop sidebar's
+   * visibleWorkspaceHostIds. Absent or empty means every host, so a payload from
+   * a runtime that omits hostId is never filtered away.
+   */
+  filterExecutionHostIds?: ReadonlySet<string>
 }
 
-export type Section = { key: string; title: string; icon?: 'pin'; data: Worktree[] }
+// Generic over the row shape so a merged cross-desktop list keeps its own row
+// type through the filter/group/sort pipeline instead of widening to Worktree.
+export type Section<T extends Worktree = Worktree> = {
+  key: string
+  title: string
+  icon?: 'pin'
+  data: T[]
+}

--- a/mobile/src/worktree/workspace-view-settings.ts
+++ b/mobile/src/worktree/workspace-view-settings.ts
@@ -38,6 +38,18 @@ const GROUP_FROM_DESKTOP: Record<NonNullable<WorkspaceViewSettings['groupBy']>, 
 
 const SORT_VALUES: readonly MobileSortMode[] = ['smart', 'name', 'recent', 'repo', 'manual']
 
+const GROUP_LABELS: Record<MobileGroupMode, string> = {
+  none: 'Group',
+  workspaceStatus: 'Status',
+  repo: 'Repo',
+  prStatus: 'PR'
+}
+
+/** Short toolbar label for the group-by control (not the picker's own labels). */
+export function groupModeLabel(mode: MobileGroupMode): string {
+  return GROUP_LABELS[mode]
+}
+
 export function groupModeToDesktop(
   mode: MobileGroupMode
 ): NonNullable<WorkspaceViewSettings['groupBy']> {


### PR DESCRIPTION
## Summary

- Aggregate projects and workspaces from paired desktops in the mobile home view.
- Add project search, grouping, sorting, host filtering, and experimental view settings.
- Preserve validated cached data during disconnects and fence transient host access across refresh races.

## Tests

- `pnpm --dir mobile test`
- `pnpm --dir mobile exec vitest run src/transport/transient-host-client.test.ts src/worktree/merged-desktop-workspaces.test.ts src/worktree/projects-home-desktop-roster.test.ts src/worktree/use-merged-desktop-catalogs.test.ts src/worktree/use-projects-home-view-state.test.ts src/cache/repo-cache.test.ts src/cache/worktree-cache.test.ts`
- `pnpm --dir mobile typecheck`
- `pnpm --dir mobile lint`
- `pnpm exec oxlint --config config/oxlint-code-quality-native-plugins.json mobile --deny-warnings`
- `pnpm run check:react-doctor:changed`
- `pnpm run check:max-lines-ratchet`
- `pnpm exec oxfmt --check` on all changed files

Review and implementation were assisted by AI; a human made final decisions.