### PR TITLE
fix(runtime): keep a superseded lease-only subscribe from releasing live mobile presence

### DIFF
--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -2976,7 +2976,12 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           await runtime.handleMobileSubscribe(ptyId, clientId, undefined)
           if (closed || signal?.aborted) {
             // Why: a disconnect can win the awaited subscribe and resurrect mobile presence after cleanup already released it.
-            runtime.handleMobileUnsubscribe(ptyId, clientId)
+            // Why the ownership check: presence is keyed by (ptyId, clientId) with no
+            // refcount, and `closed` is exactly the post-rebind state — releasing here
+            // would delete the replacement subscriber's presence, not ours.
+            if (registration.isCurrent()) {
+              runtime.handleMobileUnsubscribe(ptyId, clientId)
+            }
             if (!closed) {
               registration.releaseIfCurrent()
             }

--- a/src/main/runtime/rpc/terminal-subscribe-lease-presence.test.ts
+++ b/src/main/runtime/rpc/terminal-subscribe-lease-presence.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { RuntimeTerminalWait } from '../../../shared/runtime-types'
+import type { OrcaRuntimeService } from '../orca-runtime'
+import type { RpcRequest } from './core'
+import { RpcDispatcher } from './dispatcher'
+import { TERMINAL_METHODS } from './methods/terminal'
+import { createSubscriptionRegistryDouble } from './subscription-registry-test-double'
+
+const leaseOnlyParams = {
+  terminal: 'terminal-1',
+  client: { id: 'phone-1', type: 'mobile' },
+  capabilities: { terminalBinaryStream: 1, mobileInputLeaseOnly: 1 }
+}
+
+const makeRequest = (): RpcRequest => ({
+  id: 'req-1',
+  authToken: 'tok',
+  method: 'terminal.subscribe',
+  params: leaseOnlyParams
+})
+
+const streamOptions = (connectionId: string) => ({
+  connectionId,
+  sendBinary: vi.fn(),
+  registerBinaryStreamHandler: vi.fn(() => vi.fn())
+})
+
+describe('lease-only mobile presence ownership', () => {
+  it('does not release the replacement subscriber presence when a superseded subscribe resumes', async () => {
+    const registry = createSubscriptionRegistryDouble()
+    let releaseFirstSubscribe = (): void => {}
+    const handleMobileSubscribe = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<boolean>((resolve) => {
+            releaseFirstSubscribe = () => resolve(true)
+          })
+      )
+      .mockResolvedValue(true)
+    const handleMobileUnsubscribe = vi.fn()
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      registerRemoteTerminalViewSubscriber: () => () => {},
+      requestRendererTerminalTabMount: () => false,
+      resolveLeafForHandle: vi.fn().mockReturnValue({ ptyId: 'pty-1' }),
+      handleMobileSubscribe,
+      handleMobileUnsubscribe,
+      registerSubscriptionCleanup: vi.fn(registry.registerSubscriptionCleanup),
+      registerOwnedSubscriptionCleanup: vi.fn(registry.registerOwnedSubscriptionCleanup),
+      cleanupSubscription: vi.fn(registry.cleanupSubscription),
+      cleanupSubscriptionIfOwnedByConnection: vi.fn(
+        registry.cleanupSubscriptionIfOwnedByConnection
+      ),
+      waitForTerminal: vi.fn(() => new Promise<RuntimeTerminalWait>(() => {}))
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+
+    void dispatcher.dispatchStreaming(makeRequest(), vi.fn(), streamOptions('conn-a'))
+    await vi.waitFor(() => expect(handleMobileSubscribe).toHaveBeenCalledTimes(1))
+
+    // Reconnect rebinds the id while the first subscribe is still awaiting.
+    void dispatcher.dispatchStreaming(makeRequest(), vi.fn(), streamOptions('conn-b'))
+    await vi.waitFor(() => expect(handleMobileSubscribe).toHaveBeenCalledTimes(2))
+
+    // Why a baseline delta: both generations share (ptyId, clientId), so the rebind's
+    // own legitimate release is indistinguishable from a stale one by arguments alone.
+    const releasesAfterRebind = handleMobileUnsubscribe.mock.calls.length
+
+    releaseFirstSubscribe()
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(handleMobileUnsubscribe.mock.calls.length).toBe(releasesAfterRebind)
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​75 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​75 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 |

<!-- /orca-pr-loc -->

## ELI5

A phone that reconnects gets a fresh terminal subscription, but the old one may still be mid-`await`. When that old handler wakes up and sees "my stream is closed", it releases the phone's presence — except presence is filed under `(pty, phone)`, which the *new* subscription now uses too. So the dead handler deletes the live one's presence on its way out.

## What Changed

One guard: the lease-only branch releases mobile presence only if its registration still owns the subscription.

```ts
if (registration.isCurrent()) {
  runtime.handleMobileUnsubscribe(ptyId, clientId)
}
```

## Why

`handleMobileUnsubscribe` is a keyed `inner.delete(clientId)` with **no refcount** (`orca-runtime.ts:16108-16119`), and both generations share an identical `(ptyId, clientId)`. The resume-after-await at `terminal.ts:2977` fires when `closed || signal?.aborted` — and `closed === true` is *exactly* the post-rebind state, because the rebind runs the old generation's cleanup synchronously inside `registerSubscriptionCleanup`. So the superseded handler reliably deletes the live subscriber's presence.

Distinct from the freeze in the parent PR: output keeps flowing. What is lost is phone-fit and remote-view presence, so the terminal stops auto-fitting to the phone's viewport. Same defect family — a stale generation acting on a shared key — which is why it uses the same ownership handle.

## Linked Issue

Refs #14843 (found while investigating; not the reported freeze)

Fixes #

## Visual Proof

`N/A` — no rendered surface changes in this diff. The observable effect is that a reconnected phone keeps its server-side auto-fit ownership.

## Testing

`terminal-subscribe-lease-presence.test.ts` drives a lease-only subscribe, leaves `handleMobileSubscribe` pending, rebinds the id on a second connection, then resolves the first.

Because both generations share `(ptyId, clientId)`, arguments alone cannot distinguish the rebind's own legitimate release from a stale one — so the test snapshots the call count immediately after the rebind and asserts it does not increase.

**Mutation-verified:** removing the `isCurrent()` guard turns it red (`expected 2 to be 1`).

- Targeted suites: 22 files / 99 tests pass.
- `pnpm tc` exit 0; `oxfmt` + `oxlint` clean.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

- **Stacked on #14992** — merge that first; this branch is based on it and depends on `registerOwnedSubscriptionCleanup`.
- **Known limitation, deliberately not fixed here:** an evicted generation's still-pending `handleMobileSubscribe` can resolve late and *write* into the same presence entry (`orca-runtime.ts:16069-16077`), clobbering the live generation's viewport baseline. It cannot delete presence, so it cannot cause a freeze — value corruption only. Named here so it is not rediscovered as a missed case.
- **Backwards compatibility:** server-only, no wire change.
- **Remote/SSH, cross-platform:** unaffected; platform-independent server logic.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @BrennanKB5
