### PR TITLE
fix(agent-hooks): default-form managed hook vars so a static precheck cannot reject them

### DIFF
--- a/config/scripts/verify-agent-hook-stdin-lifecycle.mjs
+++ b/config/scripts/verify-agent-hook-stdin-lifecycle.mjs
@@ -320,7 +320,7 @@ async function verifyInstalledLauncher(home, payload) {
   )
   if (
     !command ||
-    !command.includes('"$HOME/.orca/agent-hooks/claude-hook.sh"') ||
+    !command.includes('"${HOME-}/.orca/agent-hooks/claude-hook.sh"') ||
     !command.includes('] && [ -r ') ||
     !command.includes('else { command -p cat')
   ) {

--- a/src/main/agent-hooks/installer-utils.test.ts
+++ b/src/main/agent-hooks/installer-utils.test.ts
@@ -270,6 +270,16 @@ describe('createManagedCommandMatcher', () => {
     expect(match(command)).toBe(true)
   })
 
+  it('matches the pre-default-form launcher so upgrades replace it instead of duplicating', () => {
+    // Why: installs before the ${VAR-} conversion emitted bare $HOME/$SYSTEMROOT. The sweep must
+    // still recognize them, or an upgrade would leave the stale entry beside the new one.
+    expect(
+      match(
+        'if [ -z "$HOME" ]; then :; else if [ -f "$HOME/.orca/agent-hooks/claude-hook.sh" ]; then /bin/sh "$HOME/.orca/agent-hooks/claude-hook.sh"; fi; fi'
+      )
+    ).toBe(true)
+  })
+
   it('matches PowerShell and POSIX variants across Copilot platform switches', () => {
     const matchPosix = createManagedCommandMatcher('copilot-hook.sh')
     const matchPowerShell = createManagedCommandMatcher('copilot-hook.ps1')
@@ -678,12 +688,28 @@ describe('wrapRuntimeHomeHookCommand', () => {
     const command = wrapRuntimeHomeHookCommand('claude-hook')
 
     expect(command).toContain('case "${OSTYPE-}" in msys*|cygwin*|win32*)')
-    expect(command).toContain('case "$HOME" in *\\&*|*\\^*|*\\(*|*\\)*|*\\;*|*,*|*=*|*%*|*\\!*)')
+    expect(command).toContain('case "${HOME-}" in *\\&*|*\\^*|*\\(*|*\\)*|*\\;*|*,*|*=*|*%*|*\\!*)')
     expect(command).not.toContain('uname')
-    expect(command).toContain('"$HOME/.orca/agent-hooks/claude-hook.cmd"')
-    expect(command).toContain('/bin/sh "$HOME/.orca/agent-hooks/claude-hook.sh"')
+    expect(command).toContain('"${HOME-}/.orca/agent-hooks/claude-hook.cmd"')
+    expect(command).toContain('/bin/sh "${HOME-}/.orca/agent-hooks/claude-hook.sh"')
     expect(command).not.toMatch(/[A-Z]:[\\/]|\/Users\/|\/home\//)
   })
+
+  // Why: a static hook precheck (Grok) rejects the whole command on any bare reference it cannot
+  // resolve, including one in a branch that platform never takes.
+  it.each([
+    ['default', undefined],
+    ['neutral-json', { neutralJsonWhenMissing: true }]
+  ])(
+    'references every variable in default form (%s) so a static precheck cannot reject it',
+    (_label, options) => {
+      const command = wrapRuntimeHomeHookCommand('claude-hook', options)
+
+      expect(command).toContain('"${SYSTEMROOT-}/System32/WindowsPowerShell/v1.0/powershell.exe"')
+      expect(command).not.toMatch(/\$(?!\{)[A-Za-z_]/)
+      expect(command).not.toMatch(/\$\{[A-Za-z_][A-Za-z0-9_]*\}/)
+    }
+  )
 
   it('rejects a script base name that could inject shell syntax', () => {
     expect(() => wrapRuntimeHomeHookCommand('claude-hook; echo injected')).toThrow(

--- a/src/main/agent-hooks/runtime-home-hook-command.ts
+++ b/src/main/agent-hooks/runtime-home-hook-command.ts
@@ -14,18 +14,20 @@ export function wrapRuntimeHomeHookCommand(
   if (!MANAGED_SCRIPT_BASE_NAME.test(scriptBaseName)) {
     throw new Error(`Invalid managed script base name: ${scriptBaseName}`)
   }
-  const windowsScript = `"$HOME/.orca/agent-hooks/${scriptBaseName}.cmd"`
-  const posixScript = `"$HOME/.orca/agent-hooks/${scriptBaseName}.sh"`
+  // Why: default-form every var — a static hook precheck (Grok) rejects the whole command on a bare
+  // reference it cannot resolve, even in a branch that platform never takes.
+  const windowsScript = `"\${HOME-}/.orca/agent-hooks/${scriptBaseName}.cmd"`
+  const posixScript = `"\${HOME-}/.orca/agent-hooks/${scriptBaseName}.sh"`
   const drain = POSIX_HOOK_STDIN_DRAIN_COMMAND
   const missingScriptFallback = options.neutralJsonWhenMissing ? `${drain}; printf '{}\\n'` : drain
-  const powershell = '"$SYSTEMROOT/System32/WindowsPowerShell/v1.0/powershell.exe"'
+  const powershell = '"${SYSTEMROOT-}/System32/WindowsPowerShell/v1.0/powershell.exe"'
   const powershellFallback = options.neutralJsonWhenMissing ? "; Write-Output '{}'" : ''
   const powershellCommand = `$homePath = $env:HOME -replace '^/([A-Za-z])/', '$1:/'; $scriptPath = Join-Path $homePath '.orca\\agent-hooks\\${scriptBaseName}.cmd'; if (Test-Path -LiteralPath $scriptPath -PathType Leaf) { & $scriptPath; exit $LASTEXITCODE }; [Console]::In.ReadToEnd() | Out-Null${powershellFallback}; exit 0`
   const encodedCommand = encodeWindowsPowerShellHookCommand(powershellCommand)
   // Why: the Git Bash and native Windows launchers must suppress windows identically (#14815).
   const powershellInvocation = `${powershell} ${WINDOWS_POWERSHELL_HOOK_SWITCHES} -EncodedCommand ${encodedCommand}`
   const encodedWindowsBranch = `if [ -f ${powershell} ]; then ${powershellInvocation}; else ${missingScriptFallback}; fi`
-  const windowsBranch = `if [ -f ${windowsScript} ]; then case "$HOME" in ${WINDOWS_GIT_BASH_RUNTIME_HOME_UNSAFE}) ${encodedWindowsBranch} ;; *) ${windowsScript} ;; esac; else ${missingScriptFallback}; fi`
+  const windowsBranch = `if [ -f ${windowsScript} ]; then case "\${HOME-}" in ${WINDOWS_GIT_BASH_RUNTIME_HOME_UNSAFE}) ${encodedWindowsBranch} ;; *) ${windowsScript} ;; esac; else ${missingScriptFallback}; fi`
   const posixBranch = `if [ -f ${posixScript} ] && [ -r ${posixScript} ] && [ -x ${posixScript} ]; then /bin/sh ${posixScript}; else ${missingScriptFallback}; fi`
   // Why: OSTYPE is shell-owned, so platform selection adds no process to every hook invocation.
   return `if [ -z "\${HOME-}" ]; then ${missingScriptFallback}; else case "\${OSTYPE-}" in msys*|cygwin*|win32*) ${windowsBranch} ;; *) ${posixBranch} ;; esac; fi`

--- a/src/main/claude/hook-service.test.ts
+++ b/src/main/claude/hook-service.test.ts
@@ -242,10 +242,10 @@ describe('ClaudeHookService.install', () => {
       ) as { statusLine?: { type: string; command: string } }
       expect(settings.statusLine?.type).toBe('command')
       expect(settings.statusLine?.command).toContain(
-        '"$HOME/.orca/agent-hooks/claude-statusline.cmd"'
+        '"${HOME-}/.orca/agent-hooks/claude-statusline.cmd"'
       )
       expect(settings.statusLine?.command).toContain(
-        '"$HOME/.orca/agent-hooks/claude-statusline.sh"'
+        '"${HOME-}/.orca/agent-hooks/claude-statusline.sh"'
       )
       expect(settings.statusLine?.command).not.toContain(tmpHome.replaceAll('\\', '/'))
 
@@ -454,7 +454,7 @@ describe('ClaudeHookService.installRemote', () => {
     ]) {
       expect(parsed.hooks[event]).toBeTruthy()
       const cmd = parsed.hooks[event][0].hooks[0].command as string
-      expect(cmd).toContain('"$HOME/.orca/agent-hooks/claude-hook.sh"')
+      expect(cmd).toContain('"${HOME-}/.orca/agent-hooks/claude-hook.sh"')
       expect(cmd).not.toContain('/home/dev/.orca/agent-hooks/claude-hook.sh')
     }
     // Managed script body
@@ -551,8 +551,8 @@ describe('OpenClaudeHookService-compatible install', () => {
       for (const event of ['UserPromptSubmit', 'Stop', 'StopFailure']) {
         const command = parsed.hooks[event][0].hooks[0].command as string
         expect(isOpenClaudeManagedCommand(command)).toBe(true)
-        expect(command).toContain('"$HOME/.orca/agent-hooks/openclaude-hook.cmd"')
-        expect(command).toContain('"$HOME/.orca/agent-hooks/openclaude-hook.sh"')
+        expect(command).toContain('"${HOME-}/.orca/agent-hooks/openclaude-hook.cmd"')
+        expect(command).toContain('"${HOME-}/.orca/agent-hooks/openclaude-hook.sh"')
         expect(command).not.toContain(tmpHome.replaceAll('\\', '/'))
       }
       expect(
@@ -582,7 +582,7 @@ describe('OpenClaudeHookService-compatible install', () => {
     })
     const parsed = JSON.parse(fs.files.get('/home/dev/.openclaude/settings.json')!)
     const command = parsed.hooks.StopFailure[0].hooks[0].command as string
-    expect(command).toContain('"$HOME/.orca/agent-hooks/openclaude-hook.sh"')
+    expect(command).toContain('"${HOME-}/.orca/agent-hooks/openclaude-hook.sh"')
     expect(command).not.toContain('/home/dev/.orca/agent-hooks/openclaude-hook.sh')
     expect(fs.files.get('/home/dev/.orca/agent-hooks/openclaude-hook.sh')).toContain('/hook/claude')
   })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​35 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​26 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |

<!-- /orca-pr-loc -->

Fixes STA-4434 / #14794.

## The bug

The managed hook command Orca writes into `~/.claude/settings.json` embedded a **bare** `$SYSTEMROOT` (`runtime-home-hook-command.ts:13`). Grok also loads Claude's settings hooks, and it statically prechecks env-var references across the *whole* command string before spawning it. `SYSTEMROOT` doesn't exist on macOS, so the reference inside the never-taken Windows branch made Grok refuse the hook on every event:

```
hook not executed: required env var(s) not set: ${SYSTEMROOT}
```

## Severity is lower than the ticket suggests

Worth stating plainly, because the ticket is filed P1:

- **Grok fails these open.** From its own embedded docs: *"All hook failures (timeouts, crashes, malformed output, missing required env vars) are fail-open: the failure is recorded for the UI scrollback but the tool call is not blocked."*
- **No status was lost.** Orca installs Grok's native hook separately (`managed-agent-hook-registry.ts:33` → `~/.grok/hooks/orca-status.json`), with absolute paths and no `$SYSTEMROOT`. That carries the real status reporting.

Net symptom is a swallowed failure line per tool call. Real, worth fixing, but cosmetic — suggest re-prioritising.

## The fix

`$SYSTEMROOT` → `${SYSTEMROOT-}`, plus the three bare `$HOME` refs → `${HOME-}`.

**This has no execution-time effect.** `$VAR` and `${VAR-}` expand identically in POSIX shells absent `set -u`, set or unset:

```
unset:  bare=[]     defaultform=[]     IDENTICAL
set:    bare=[xyz]  defaultform=[xyz]  IDENTICAL
```

Only the static precheck observes the difference. Under `set -u` the default form is strictly better.

### Not a casing bug — do not "fix" the uppercase

Uppercase `$SYSTEMROOT` is **correct** here. Measured in Git Bash on a real Windows host:

```
UPPER=[C:\WINDOWS]   <- $SYSTEMROOT is SET
MIXED=[]             <- $SystemRoot is UNDEFINED
OLD_GUARD=PASS  NEW_GUARD=PASS
```

Cygwin and the msys2-runtime fork Git Bash ships force-uppercase a fixed set of Windows env names (`environ.cc`, `renv_arr`, applied by `ucenv()`), `SYSTEMROOT` among them. This is the reverse of the TypeScript convention elsewhere in the repo (`process.env.SystemRoot`), because those readers run *on* the host while this string is *shipped to* it.

### Why `$HOME` too

So the regression test can assert **zero** bare variable references with no exemption. A `SYSTEMROOT`-specific assertion wouldn't have caught this class of bug being introduced in the first place. Slightly wider than the one-token ticket fix; behaviourally identical, and it converts a contingent invariant into a structural one.

### Why not `${SYSTEMROOT-C:/Windows}`

Two reasons: `installer-utils.test.ts:660` asserts the command contains no absolute path (it's written to remote hosts with different drives/homes), and the default would be dead code anyway — it can only fire where `SYSTEMROOT` is unset, i.e. a non-Windows shell, where the `[ -f ... ]` guard fails regardless.

## Verification

![sta4434-before-after.png](https://github.com/user-attachments/assets/488de89d-0004-430b-87e2-318bdf713715)

Before/after above is two real `pnpm dev` Electron runs on the same Windows host with an isolated `USERPROFILE`, at the fix commit and its parent — showing the command Orca actually wrote to `~/.claude/settings.json`. There is deliberately no UI screenshot: the hook-status surface reads "installed" both before and after, because the broken command installs fine and only fails later inside Grok's precheck, so a UI capture would show no difference and prove nothing.

- **Real Electron on Windows.** Built and ran this branch on a Windows host with an isolated `USERPROFILE`/`HOME`, let the app install hooks, then inspected what it wrote: `${SYSTEMROOT-}` present, bare `$SYSTEMROOT` count **0**, bare `$HOME/.orca` count **0**.
- **Git Bash guard comparison** on that host — old and new forms both PASS (above).
- **Mutation-tested the new test**: reverting the source fix makes it fail with the expected assertion, so the guard is live rather than vacuous.
- `installer-utils.test.ts` + `hook-service.test.ts`: 67 passed, 5 skipped. Typecheck, oxlint, oxfmt clean.

## Upgrade behaviour

Stale bare-form entries are **replaced, not duplicated** — `createManagedCommandMatcher` keys on the script filename and is insensitive to this edit. Added a test pinning that it still matches the pre-fix form.

Two honest limits: repair is presence-gated (`managed-agent-hook-controls.ts:153-165`), so a user without a detected Claude CLI keeps the stale entry and the noise; and while old and new Orca versions share a host's settings.json they will rewrite past each other until versions converge (byte-identical writes are skipped, but the two strings never are). Both are inherent to any command-string change and not worth a migration pass for a cosmetic defect.

## Supersedes #14838

That PR changes this same line as 1 of 12 files in an unrelated grab-bag ("fix: resolve five easy issue regressions"), and its description misdiagnoses the cause as a Windows install-path dependency. This PR is scoped to the actual defect and updates all ten sites that pin the old text — including `config/scripts/verify-agent-hook-stdin-lifecycle.mjs:323`, which lives outside `src/` and a `src/`-scoped search misses.
