### PR TITLE
fix(orchestration): stop the usage cards recommending orchestration for handoffs

### DIFF
--- a/src/renderer/src/components/settings/OrchestrationPane.tsx
+++ b/src/renderer/src/components/settings/OrchestrationPane.tsx
@@ -208,8 +208,8 @@ export function OrchestrationPane({
           'How to use it'
         )}
         description={translate(
-          'auto.components.settings.OrchestrationPane.52e0634e2c',
-          'Ask a coordinator agent to use orchestration for handoffs, worktree handovers, and sequential or parallel child agents.'
+          'auto.components.settings.OrchestrationPane.orchestrationScope',
+          'Ask a coordinator agent to use orchestration to supervise child agents, coordinate task DAGs, and gate decisions — not to hand off ownership.'
         )}
         examples={getOrchestrationUsageExamples()}
         resolveIcon={resolveOrchestrationExampleIcon}

--- a/src/renderer/src/components/settings/OrchestrationPane.tsx
+++ b/src/renderer/src/components/settings/OrchestrationPane.tsx
@@ -1,5 +1,12 @@
 import { useState } from 'react'
-import { ArrowRightLeft, GitBranch, ListChecks, Workflow, type LucideIcon } from 'lucide-react'
+import {
+  CircleCheckBig,
+  GitBranch,
+  ListChecks,
+  SignpostBig,
+  Workflow,
+  type LucideIcon
+} from 'lucide-react'
 import { ORCHESTRATION_SKILL_NAME } from '@/lib/agent-feature-install-commands'
 import type { SkillUsageExample } from '@/lib/skill-usage-example'
 import {
@@ -40,8 +47,8 @@ import {
 } from './nested-worker-depth-copy'
 
 const EXAMPLE_ICONS = {
-  handoff: ArrowRightLeft,
-  'worktree-handoff': ArrowRightLeft,
+  'supervised-worker': CircleCheckBig,
+  'decision-gate': SignpostBig,
   'child-sequence': ListChecks,
   'child-parallel': GitBranch,
   'child-worktrees': Workflow
@@ -104,8 +111,8 @@ export function OrchestrationPane({
         'Agent Orchestration'
       )}
       description={translate(
-        'auto.components.settings.OrchestrationPane.2aacdb0517',
-        'Coordinate coding agents across handoffs, worktree handovers, and child-agent work.'
+        'auto.components.settings.OrchestrationPane.paneScope',
+        'Coordinate coding agents across supervised tasks, decision gates, and child-agent work.'
       )}
       keywords={searchEntries[0].keywords}
       forceVisible
@@ -117,8 +124,8 @@ export function OrchestrationPane({
           'Orchestration skill'
         )}
         description={translate(
-          'auto.components.settings.OrchestrationPane.9bedd2a6e5',
-          'Enables agents to hand off context and coordinate work through Orca.'
+          'auto.components.settings.OrchestrationPane.skillScope',
+          'Enables agents to dispatch, supervise and coordinate other agents through Orca.'
         )}
         command={orchestrationInstallCommand}
         installedCommand={orchestrationUpdateCommand}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -700,7 +700,11 @@
             "worktreeHandoffSummary": "Move work to an agent that is already running in a different branch.",
             "childSequenceSummary": "Use child agents one after another when each phase depends on the last.",
             "childParallelSummary": "Split non-overlapping investigation or implementation tasks across child agents.",
-            "prSplitSummary": "Give each child agent its own worktree so parallel implementation stays reviewable."
+            "prSplitSummary": "Give each child agent its own worktree so parallel implementation stays reviewable.",
+            "superviseTitle": "Supervise a worker to completion",
+            "superviseSummary": "Dispatch a task and wait for the worker to report done or escalate.",
+            "decisionGateTitle": "Pause for a decision before continuing",
+            "decisionGateSummary": "Let a child agent block on your answer instead of guessing."
           }
         }
       },
@@ -7494,7 +7498,8 @@
           "2aacdb0517": "Coordinate coding agents across handoffs, worktree handovers, and child-agent work.",
           "191ac34567": "Agent Orchestration",
           "nestedWorkerDepthTitle": "Nested worker depth",
-          "nestedWorkerDepthDescription": "How many generations of dispatched workers may spawn their own workers. 1 keeps the agent tree flat: a coordinator dispatches workers, and those workers do not dispatch."
+          "nestedWorkerDepthDescription": "How many generations of dispatched workers may spawn their own workers. 1 keeps the agent tree flat: a coordinator dispatches workers, and those workers do not dispatch.",
+          "orchestrationScope": "Ask a coordinator agent to use orchestration to supervise child agents, coordinate task DAGs, and gate decisions — not to hand off ownership."
         },
         "OrchestrationSetupCard": {
           "e7d2a5146c": "Enables agents to hand off context and coordinate work through Orca.",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -7499,7 +7499,9 @@
           "191ac34567": "Agent Orchestration",
           "nestedWorkerDepthTitle": "Nested worker depth",
           "nestedWorkerDepthDescription": "How many generations of dispatched workers may spawn their own workers. 1 keeps the agent tree flat: a coordinator dispatches workers, and those workers do not dispatch.",
-          "orchestrationScope": "Ask a coordinator agent to use orchestration to supervise child agents, coordinate task DAGs, and gate decisions — not to hand off ownership."
+          "orchestrationScope": "Ask a coordinator agent to use orchestration to supervise child agents, coordinate task DAGs, and gate decisions — not to hand off ownership.",
+          "paneScope": "Coordinate coding agents across supervised tasks, decision gates, and child-agent work.",
+          "skillScope": "Enables agents to dispatch, supervise and coordinate other agents through Orca."
         },
         "OrchestrationSetupCard": {
           "e7d2a5146c": "Enables agents to hand off context and coordinate work through Orca.",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -704,7 +704,7 @@
             "superviseTitle": "Supervise a worker to completion",
             "superviseSummary": "Dispatch a task and wait for the worker to report done or escalate.",
             "decisionGateTitle": "Pause for a decision before continuing",
-            "decisionGateSummary": "Let a child agent block on your answer instead of guessing."
+            "decisionGateSummary": "Gate the next dispatch on your approval instead of letting agents guess."
           }
         }
       },

--- a/src/renderer/src/lib/orchestration-usage-examples.ts
+++ b/src/renderer/src/lib/orchestration-usage-examples.ts
@@ -4,27 +4,30 @@ import type { SkillUsageExample } from './skill-usage-example'
 
 export const getOrchestrationUsageExamples = createLocalizedCatalog((): SkillUsageExample[] => [
   {
-    id: 'handoff',
-    title: translate('auto.lib.orchestration.usage.examples.5e0d489fe1', 'Hand off an active task'),
+    id: 'supervised-worker',
+    title: translate(
+      'auto.lib.orchestration.usage.examples.superviseTitle',
+      'Supervise a worker to completion'
+    ),
     summary: translate(
-      'auto.lib.orchestration.usage.examples.handoffSummary',
-      'Move ownership to another agent with enough context to continue.'
+      'auto.lib.orchestration.usage.examples.superviseSummary',
+      'Dispatch a task and wait for the worker to report done or escalate.'
     ),
     prompt:
-      'Use /orchestration to hand this billing settings task to the idle Claude agent. Include the goal, current context, and what they should finish next.'
+      'Use /orchestration to dispatch the billing settings migration to an idle Claude agent, then wait for worker_done before starting the follow-up.'
   },
   {
-    id: 'worktree-handoff',
+    id: 'decision-gate',
     title: translate(
-      'auto.lib.orchestration.usage.examples.ab0e9803b7',
-      'Hand off to another worktree'
+      'auto.lib.orchestration.usage.examples.decisionGateTitle',
+      'Pause for a decision before continuing'
     ),
     summary: translate(
-      'auto.lib.orchestration.usage.examples.worktreeHandoffSummary',
-      'Move work to an agent that is already running in a different branch.'
+      'auto.lib.orchestration.usage.examples.decisionGateSummary',
+      'Let a child agent block on your answer instead of guessing.'
     ),
     prompt:
-      'Use /orchestration to hand this settings cleanup to the agent in the settings-polish worktree. Send the goal, relevant files, and expected result.'
+      'Use /orchestration to run this schema change with a decision gate before the destructive migration step, so it waits for my approval.'
   },
   {
     id: 'child-sequence',

--- a/src/renderer/src/lib/orchestration-usage-examples.ts
+++ b/src/renderer/src/lib/orchestration-usage-examples.ts
@@ -24,10 +24,10 @@ export const getOrchestrationUsageExamples = createLocalizedCatalog((): SkillUsa
     ),
     summary: translate(
       'auto.lib.orchestration.usage.examples.decisionGateSummary',
-      'Let a child agent block on your answer instead of guessing.'
+      'Gate the next dispatch on your approval instead of letting agents guess.'
     ),
     prompt:
-      'Use /orchestration to run this schema change with a decision gate before the destructive migration step, so it waits for my approval.'
+      'Use /orchestration to run this schema change and open a decision gate before dispatching the destructive migration step, so it waits for my approval.'
   },
   {
     id: 'child-sequence',


### PR DESCRIPTION
## ELI5

The orchestration Settings pane shows five example cards under "How to use it". The first two told agents to use orchestration to hand work off to another agent — which is the one thing the orchestration skill guide tells them not to do. This swaps those two for the two cases the guide lists that had no card at all.

## What Changed

`src/renderer/src/lib/orchestration-usage-examples.ts` — replaced two of five cards:

| Removed | Added |
| --- | --- |
| `handoff` — "Hand off an active task" / *Move ownership to another agent* | `supervised-worker` — "Supervise a worker to completion" / *Dispatch a task and wait for the worker to report done or escalate* |
| `worktree-handoff` — "Hand off to another worktree" / *Move work to an agent already running in a different branch* | `decision-gate` — "Pause for a decision before continuing" / *Let a child agent block on your answer instead of guessing* |

`src/renderer/src/components/settings/OrchestrationPane.tsx` — the section description said orchestration is for "handoffs, worktree handovers, and sequential or parallel child agents". It now states the boundary: supervise child agents, coordinate task DAGs, gate decisions — not hand off ownership.

The three child-agent cards are untouched; they were already correct. Card count stays at five.

## Why

Fixes #14104.

`skill-guides/orchestration.md`, under **When To Use**:

> Do not use orchestration merely because the user says "hand off", "handoff", "handover", "give this to another agent", or asks for another worktree/agent/model/effort. Those are full ownership transfers unless the user explicitly asks to supervise, monitor, wait for worker completion/results, coordinate a DAG, use decision gates, or keep a blocking ask/reply loop.

Both removed cards used those exact words in their titles and prompts, and one described itself as *"Move ownership to another agent"* — the guide's own definition of the thing to avoid. As #14104 puts it, an agent that follows the card ends up creating a Run and Tasks nobody will ever supervise.

**On why they were replaced rather than repointed.** #14104 suggests the cards could say "for handoffs use the worktree/terminal handoff commands". I did not do that: this list is titled "How to use it" and sits inside the orchestration skill's own pane, reached by `/orchestration`. A card there whose advice is "do not use this" is the right message in the wrong place, and the guide already carries it in **When To Use**, which is what agents read. The scope boundary went into the pane description instead, where it describes the skill rather than instructing away from it.

The replacements are not invented: **When To Use** lists four cases, and the three surviving cards all illustrate the same one (child agents). Waiting on `worker_done` or `escalation`, and decision gates, had no card at all. After this the five cards cover the guide's four cases instead of covering one of them three times.

## Linked Issue

Fixes #14104

Related: #14842, which reports the same class of problem on a different surface — the installed orchestration stub omits the Tool Boundary, so agents pick non-Orca mechanisms before the guide is ever loaded. Not addressed here.

## Visual Proof

Settings → Orchestration → "How to use it". Before and after, in text since this is copy only:

```text
BEFORE
  Ask a coordinator agent to use orchestration for handoffs, worktree
  handovers, and sequential or parallel child agents.

  • Hand off an active task
  • Hand off to another worktree
  • Run a phased workflow
  • Run independent work in parallel
  • Split a large change into smaller PRs

AFTER
  Ask a coordinator agent to use orchestration to supervise child agents,
  coordinate task DAGs, and gate decisions — not to hand off ownership.

  • Supervise a worker to completion
  • Pause for a decision before continuing
  • Run a phased workflow
  • Run independent work in parallel
  • Split a large change into smaller PRs
```

Happy to attach screenshots if the text rendering is not enough — I could not launch the packaged app on this machine (missing MSVC toolchain, see #14918), so I did not want to claim a screenshot I had not taken.

## Testing

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/OrchestrationPane.test.tsx` → 3 passed. That test asserts five examples and that each title renders; both still hold.
- `pnpm run sync:localization-catalog` added the five new keys to `en.json`; `verify:localization-catalog`, `verify:localization-extraction` and `verify:localization-coverage` all pass.
- `pnpm exec tsc --noEmit -p config/tsconfig.tc.web.json` and `pnpm exec oxlint src/renderer/` clean.

Tested on Windows 11.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

No new tests: the existing pane test already covers the count and that every card title renders, and this change swaps content rather than behaviour.

**One thing for reviewers to decide.** The five replaced keys are now orphaned in `en.json` and the other locales. I left them, because `sync:localization-catalog --fix` is additive and `verify:localization-extraction` already reports 2347 unreferenced English entries — removing five would be inconsistent with the repo's current practice. Say the word and I will strip them across all five locales.

The new strings are English-only for now, like the other 1360–1370 untranslated keys per locale.

## AI Disclosure

Written with Claude Opus 5 via Claude Code. The copy and the scope decision were made in collaboration with the author; the edits and verification runs were agent-assisted.

## Review

- **Security:** none — user-facing copy only.
- **Cross-platform:** no platform-specific code; the strings render identically everywhere.
- **Remote SSH / Mobile:** unaffected.
- **Agents and integrations:** provider-neutral. The cards name Claude only as an example, as they did before.
- **Backwards compatibility:** localization keys are additive; older catalogs fall back to the inline English default.
- **Performance:** unaffected.
- **UI quality:** card count and layout unchanged; only titles, summaries and prompts differ.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Note on the last box: the localization gates, the renderer typecheck, `oxlint` and the affected test all pass locally. The full `pnpm test` cannot start on this Windows machine for the toolchain reason in #14918 — unrelated to this change, which touches no native code.

## Author

- X / Twitter: @EnricoPin
