### PR TITLE
feat(panes): detach a terminal tab group into its own window

### DIFF
--- a/config/scripts/check-pane-realm-safety.mjs
+++ b/config/scripts/check-pane-realm-safety.mjs
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+/** Reject opener-realm DOM reads from every pane-reachable local module. */
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const SOURCE_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mts', '.cts', '.mjs', '.cjs']
+const SOURCE_FILE_PATTERN = /\.[cm]?[jt]sx?$/
+const TEST_FILE_PATTERN = /\.(?:test|spec)\.[cm]?[jt]sx?$/
+const STATIC_IMPORT_PATTERN =
+  /\b(?:import|export)\s+(?:type\s+)?(?:[^'";]*?\s+from\s+)?['"]([^'"\n]+)['"]/g
+const DYNAMIC_IMPORT_PATTERN = /\bimport\s*\(\s*['"]([^'"\n]+)['"]\s*\)/g
+const STATIC_REQUIRE_PATTERN = /\brequire\s*\(\s*['"]([^'"\n]+)['"]\s*\)/g
+
+const SCOPES = [
+  'src/renderer/src/components/terminal-pane',
+  'src/renderer/src/components/tab-group',
+  'src/renderer/src/components/tab-bar',
+  'src/renderer/src/components/floating-terminal',
+  'src/renderer/src/lib/pane-manager'
+]
+const PANE_REACHABLE_ENTRY_FILES = [
+  'src/renderer/src/components/Terminal.tsx',
+  'src/renderer/src/components/CodexRestartChip.tsx',
+  'src/renderer/src/app-shell/app-command-handlers.ts',
+  'src/renderer/src/app-shell/use-global-keybindings.ts',
+  'src/renderer/src/hooks/usePrimarySelectionPaste.ts',
+  'src/renderer/src/lib/editable-target.ts',
+  'src/renderer/src/lib/focus-terminal-tab-surface.ts',
+  'src/renderer/src/lib/primary-selection-capture.ts',
+  'src/renderer/src/lib/primary-selection-paste.ts'
+]
+const PANE_GRAPH_SOURCE_ROOTS = ['src/renderer/src', 'src/shared']
+// Terminal-only detached groups never render these exact main-document surfaces.
+const MAIN_DOCUMENT_ONLY_SOURCE_FILES = [
+  'src/renderer/src/app-shell/use-floating-workspace-panel.ts',
+  'src/renderer/src/components/browser-pane/BrowserAddressBar.tsx',
+  'src/renderer/src/components/browser-pane/BrowserPane.tsx',
+  'src/renderer/src/components/browser-pane/markup/useMarkupKeyboardShortcuts.ts',
+  'src/renderer/src/components/contextual-tours/ContextualTourOverlay.tsx',
+  'src/renderer/src/components/contextual-tours/ContextualTourOverlaySurface.tsx',
+  'src/renderer/src/components/contextual-tours/contextual-tour-gate.ts',
+  'src/renderer/src/components/editor/CombinedDiffViewer.tsx',
+  'src/renderer/src/components/editor/IpynbViewer.tsx',
+  'src/renderer/src/components/editor/MarkdownPreview.tsx',
+  'src/renderer/src/components/editor/NotesSendMenu.tsx',
+  'src/renderer/src/components/editor/RichMarkdownEditorSurface.tsx',
+  'src/renderer/src/components/editor/RichMarkdownLinkBubble.tsx',
+  'src/renderer/src/components/editor/RichMarkdownReviewNoteLayer.tsx',
+  'src/renderer/src/components/editor/image-viewer-dom-zoom.ts',
+  'src/renderer/src/components/editor/markdown-preview-annotation-shortcut.ts',
+  'src/renderer/src/components/editor/markdown-preview-search.ts',
+  'src/renderer/src/components/editor/rich-markdown-auto-focus.ts',
+  'src/renderer/src/components/editor/rich-markdown-visual-line.ts',
+  'src/renderer/src/components/editor/use-rich-markdown-table-context-menu.ts',
+  'src/renderer/src/components/editor/use-rich-markdown-table-control-target.ts',
+  'src/renderer/src/components/editor/useMarkdownPreviewShortcut.ts',
+  'src/renderer/src/components/editor/usePreserveSectionDuringExternalEdit.ts',
+  'src/renderer/src/components/editor/useRichMarkdownPendingFocus.ts',
+  'src/renderer/src/components/editor/useRichMarkdownSearch.ts',
+  'src/renderer/src/components/native-chat/use-native-chat-paste-bridge.ts',
+  'src/renderer/src/components/sidebar/AddRepoStartSteps.tsx',
+  'src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx',
+  'src/renderer/src/components/sidebar/WorkspaceKanbanLaneGrid.tsx',
+  'src/renderer/src/components/sidebar/WorkspaceKanbanSettingsMenu.tsx',
+  'src/renderer/src/components/sidebar/WorktreeCardAgents.tsx',
+  'src/renderer/src/components/sidebar/WorktreeContextMenu.tsx',
+  'src/renderer/src/components/sidebar/host-header-drag-dom.ts',
+  'src/renderer/src/components/sidebar/project-group-header-drag-contract.ts',
+  'src/renderer/src/components/sidebar/project-header-drag-contract.ts',
+  'src/renderer/src/components/sidebar/use-sidebar-feedback-environment-prefill.ts',
+  'src/renderer/src/components/sidebar/use-workspace-kanban-area-selection.ts',
+  'src/renderer/src/components/sidebar/use-workspace-kanban-card-pointer-drag.ts',
+  'src/renderer/src/components/sidebar/use-workspace-kanban-outside-dismiss.ts',
+  'src/renderer/src/components/sidebar/use-workspace-kanban-shift-wheel-scroll.ts',
+  'src/renderer/src/components/sidebar/use-workspace-status-drop.ts',
+  'src/renderer/src/components/sidebar/use-worktree-card-activation-actions.ts',
+  'src/renderer/src/components/sidebar/useWorkspaceBoardPanel.ts',
+  'src/renderer/src/components/sidebar/workspace-kanban-area-selection-dom.ts',
+  'src/renderer/src/components/sidebar/workspace-kanban-card-pointer-drag-dom.ts',
+  'src/renderer/src/components/sidebar/workspace-kanban-card-pointer-drag-start.ts',
+  'src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx',
+  'src/renderer/src/components/sidebar/worktree-card-dom-events.ts',
+  'src/renderer/src/components/sidebar/worktree-list/drag/status-target.ts',
+  'src/renderer/src/components/sidebar/worktree-list/drag/use-status-row-drag.ts',
+  'src/renderer/src/components/sidebar/worktree-list/navigation/use-keyboard.ts',
+  'src/renderer/src/components/sidebar/worktree-list/navigation/use-selection.ts',
+  'src/renderer/src/components/sidebar/worktree-sidebar-pointer-drag-dom.ts'
+]
+
+const PATTERNS = [
+  {
+    name: 'bare instanceof against a DOM constructor',
+    regex:
+      /instanceof (HTMLElement|HTMLTextAreaElement|HTMLInputElement|HTMLAnchorElement|HTMLCanvasElement|HTMLDivElement|Element|Node|InputEvent|CompositionEvent|KeyboardEvent|MouseEvent|DragEvent|FocusEvent|PointerEvent)\b/,
+    fix: 'use realm-safe predicates from @/lib/cross-realm-dom-predicates'
+  },
+  {
+    name: 'document.activeElement',
+    regex: /document\.activeElement/,
+    fix: 'use activeElementFor(node) from @/lib/cross-realm-dom-predicates'
+  }
+]
+
+function toProjectPath(root, file) {
+  return path.relative(root, file).split(path.sep).join('/')
+}
+
+function sourceFiles(root, directory) {
+  const absoluteDirectory = path.resolve(root, directory)
+  if (!existsSync(absoluteDirectory)) {
+    return []
+  }
+  const files = []
+  for (const entry of readdirSync(absoluteDirectory, { withFileTypes: true })) {
+    const file = path.join(absoluteDirectory, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...sourceFiles(root, file))
+    } else if (SOURCE_FILE_PATTERN.test(entry.name) && !TEST_FILE_PATTERN.test(entry.name)) {
+      files.push(file)
+    }
+  }
+  return files
+}
+
+function importSpecifiers(source) {
+  return [
+    ...source.matchAll(STATIC_IMPORT_PATTERN),
+    ...source.matchAll(DYNAMIC_IMPORT_PATTERN),
+    ...source.matchAll(STATIC_REQUIRE_PATTERN)
+  ].map((match) => match[1])
+}
+
+function resolveLocalImport(root, importer, rawSpecifier) {
+  const specifier = rawSpecifier.split(/[?#]/, 1)[0]
+  if (!specifier.startsWith('.') && !specifier.startsWith('@/')) {
+    return null
+  }
+  const unresolved = specifier.startsWith('@/')
+    ? path.resolve(root, 'src/renderer/src', specifier.slice(2))
+    : path.resolve(path.dirname(importer), specifier)
+  const candidates = [
+    unresolved,
+    ...SOURCE_EXTENSIONS.map((extension) => `${unresolved}${extension}`),
+    ...SOURCE_EXTENSIONS.map((extension) => path.join(unresolved, `index${extension}`))
+  ]
+  for (const candidate of candidates) {
+    if (
+      existsSync(candidate) &&
+      statSync(candidate).isFile() &&
+      SOURCE_FILE_PATTERN.test(candidate) &&
+      !TEST_FILE_PATTERN.test(candidate)
+    ) {
+      return candidate
+    }
+  }
+  return null
+}
+
+export function collectPaneReachableFiles(
+  root = process.cwd(),
+  {
+    scopes = SCOPES,
+    entries = PANE_REACHABLE_ENTRY_FILES,
+    sourceRoots = PANE_GRAPH_SOURCE_ROOTS
+  } = {}
+) {
+  const files = new Set(scopes.flatMap((scope) => sourceFiles(root, scope)))
+  const graphRoots = sourceRoots.map((sourceRoot) => path.resolve(root, sourceRoot))
+  const pending = entries.map((entry) => path.resolve(root, entry)).filter(existsSync)
+  const visited = new Set()
+  while (pending.length > 0) {
+    const file = pending.pop()
+    if (visited.has(file)) {
+      continue
+    }
+    visited.add(file)
+    files.add(file)
+    for (const specifier of importSpecifiers(readFileSync(file, 'utf8'))) {
+      const imported = resolveLocalImport(root, file, specifier)
+      if (
+        imported &&
+        graphRoots.some(
+          (graphRoot) => imported === graphRoot || imported.startsWith(`${graphRoot}${path.sep}`)
+        ) &&
+        !visited.has(imported)
+      ) {
+        pending.push(imported)
+      }
+    }
+  }
+  return [...files].sort()
+}
+
+export function findPaneRealmSafetyHits(root = process.cwd(), options) {
+  const files = collectPaneReachableFiles(root, options)
+  const mainDocumentOnlyFiles = new Set(
+    MAIN_DOCUMENT_ONLY_SOURCE_FILES.map((sourceFile) => path.resolve(root, sourceFile))
+  )
+  return PATTERNS.map((pattern) => {
+    const hits = []
+    for (const file of files) {
+      if (mainDocumentOnlyFiles.has(file)) {
+        continue
+      }
+      for (const [index, line] of readFileSync(file, 'utf8').split(/\r?\n/).entries()) {
+        const code = line.trim()
+        if (pattern.regex.test(line) && !code.startsWith('//') && !code.startsWith('*')) {
+          hits.push(`${toProjectPath(root, file)}:${index + 1}:${code}`)
+        }
+      }
+    }
+    return { ...pattern, hits }
+  }).filter((result) => result.hits.length > 0)
+}
+
+export function main(root = process.cwd()) {
+  const failures = findPaneRealmSafetyHits(root)
+  for (const failure of failures) {
+    console.error(`\n${failure.name} — ${failure.hits.length} site(s). Fix: ${failure.fix}`)
+    for (const hit of failure.hits) {
+      console.error(`  ${hit}`)
+    }
+  }
+  if (failures.length > 0) {
+    console.error(
+      '\nPane code must stay realm-safe; see config/scripts/check-pane-realm-safety.mjs'
+    )
+    return 1
+  }
+  console.log('pane realm safety: ok')
+  return 0
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  process.exitCode = main()
+}

--- a/config/scripts/check-pane-realm-safety.test.mjs
+++ b/config/scripts/check-pane-realm-safety.test.mjs
@@ -1,0 +1,161 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { collectPaneReachableFiles, findPaneRealmSafetyHits } from './check-pane-realm-safety.mjs'
+
+const tempDirs = []
+
+function fixture(files) {
+  const root = mkdtempSync(path.join(tmpdir(), 'orca-pane-realm-'))
+  tempDirs.push(root)
+  for (const [relativePath, source] of Object.entries(files)) {
+    const file = path.join(root, relativePath)
+    mkdirSync(path.dirname(file), { recursive: true })
+    writeFileSync(file, source)
+  }
+  return root
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop(), { force: true, recursive: true })
+  }
+})
+
+describe('pane realm import graph', () => {
+  it('follows terminal pane imports into renderer runtime modules', () => {
+    const files = collectPaneReachableFiles(process.cwd()).map((file) =>
+      path.relative(process.cwd(), file).split(path.sep).join('/')
+    )
+
+    expect(files).toContain('src/renderer/src/components/terminal-pane/pty-connection.ts')
+    expect(files).toContain('src/renderer/src/runtime/sync-runtime-graph.ts')
+  })
+
+  it('follows pane entry imports across renderer source directories', () => {
+    const root = fixture({
+      'src/renderer/src/components/Terminal.tsx': "import '../app-shell/unsafe'\n",
+      'src/renderer/src/app-shell/unsafe.ts': 'export const unsafe = value instanceof HTMLElement\n'
+    })
+
+    const failures = findPaneRealmSafetyHits(root)
+
+    expect(failures[0]?.hits).toEqual([
+      'src/renderer/src/app-shell/unsafe.ts:1:export const unsafe = value instanceof HTMLElement'
+    ])
+  })
+
+  it('scans markdown link dependencies used by terminal panes', () => {
+    const root = fixture({
+      'src/renderer/src/components/Terminal.tsx':
+        "import './terminal-pane/terminal-file-open-routing'\n",
+      'src/renderer/src/components/terminal-pane/terminal-file-open-routing.ts':
+        "import { unsafe } from '@/components/editor/markdown-internal-links'\n",
+      'src/renderer/src/components/editor/markdown-internal-links.ts':
+        'export const unsafe = value instanceof HTMLElement\n'
+    })
+
+    const failures = findPaneRealmSafetyHits(root)
+
+    expect(failures[0]?.hits).toEqual([
+      'src/renderer/src/components/editor/markdown-internal-links.ts:1:export const unsafe = value instanceof HTMLElement'
+    ])
+  })
+
+  it('scans webview registry dependencies used by terminal panes', () => {
+    const root = fixture({
+      'src/renderer/src/components/Terminal.tsx':
+        "import './terminal-pane/use-terminal-pane-lifecycle'\n",
+      'src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts':
+        "import { unsafe } from '../browser-pane/webview-registry'\n",
+      'src/renderer/src/components/browser-pane/webview-registry.ts':
+        'export const unsafe = document.activeElement\n'
+    })
+
+    const failures = findPaneRealmSafetyHits(root)
+
+    expect(failures[0]?.hits).toEqual([
+      'src/renderer/src/components/browser-pane/webview-registry.ts:1:export const unsafe = document.activeElement'
+    ])
+  })
+
+  it('resolves aliases, TSX index files, re-exports, and cycles', () => {
+    const root = fixture({
+      'src/renderer/src/entry.ts': "import '@/pane'\n",
+      'src/renderer/src/pane/index.tsx': "export { unsafe } from './floating'\n",
+      'src/renderer/src/pane/floating.ts':
+        "import './cycle'\nexport const unsafe = (value) => value instanceof HTMLElement\n",
+      'src/renderer/src/pane/cycle.ts': "import './floating'\n"
+    })
+
+    const options = {
+      scopes: [],
+      entries: ['src/renderer/src/entry.ts'],
+      sourceRoots: ['src/renderer/src']
+    }
+    const files = collectPaneReachableFiles(root, options).map((file) =>
+      path.relative(root, file).split(path.sep).join('/')
+    )
+    const failures = findPaneRealmSafetyHits(root, options)
+
+    expect(files).toEqual([
+      'src/renderer/src/entry.ts',
+      'src/renderer/src/pane/cycle.ts',
+      'src/renderer/src/pane/floating.ts',
+      'src/renderer/src/pane/index.tsx'
+    ])
+    expect(failures[0]?.hits).toEqual([
+      'src/renderer/src/pane/floating.ts:2:export const unsafe = (value) => value instanceof HTMLElement'
+    ])
+  })
+
+  it('does not traverse package imports or test files', () => {
+    const root = fixture({
+      'src/renderer/src/entry.ts': "import 'react'\nimport './entry.test'\n",
+      'src/renderer/src/entry.test.ts': 'value instanceof HTMLElement\n'
+    })
+
+    expect(
+      findPaneRealmSafetyHits(root, {
+        scopes: [],
+        entries: ['src/renderer/src/entry.ts'],
+        sourceRoots: ['src/renderer/src']
+      })
+    ).toEqual([])
+  })
+
+  it('follows static CommonJS requires', () => {
+    const root = fixture({
+      'src/renderer/src/entry.cjs': "require('./unsafe')\n",
+      'src/renderer/src/unsafe.cjs': 'module.exports = value instanceof HTMLElement\n'
+    })
+
+    const failures = findPaneRealmSafetyHits(root, {
+      scopes: [],
+      entries: ['src/renderer/src/entry.cjs'],
+      sourceRoots: ['src/renderer/src']
+    })
+
+    expect(failures[0]?.hits).toEqual([
+      'src/renderer/src/unsafe.cjs:1:module.exports = value instanceof HTMLElement'
+    ])
+  })
+
+  it('rejects opener-realm CompositionEvent checks', () => {
+    const root = fixture({
+      'src/renderer/src/entry.ts':
+        'export const composition = (event) => event instanceof CompositionEvent\n'
+    })
+
+    const failures = findPaneRealmSafetyHits(root, {
+      scopes: [],
+      entries: ['src/renderer/src/entry.ts'],
+      sourceRoots: ['src/renderer/src']
+    })
+
+    expect(failures[0]?.hits).toEqual([
+      'src/renderer/src/entry.ts:1:export const composition = (event) => event instanceof CompositionEvent'
+    ])
+  })
+})

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "main": "./out/main/index.js",
   "scripts": {
     "format": "oxfmt --write .",
-    "lint": "oxlint && pnpm run audit:code-quality:native && pnpm run audit:code-quality:type-aware && pnpm run check:reliability-gates && pnpm run check:max-lines-ratchet && pnpm run verify:bundled-skill-guides && pnpm run verify:skill-bundle-manifest && pnpm run verify:localization-catalog && pnpm run verify:localization-extraction && pnpm run verify:localization-coverage",
+    "lint": "oxlint && pnpm run audit:code-quality:native && pnpm run audit:code-quality:type-aware && pnpm run check:reliability-gates && pnpm run check:max-lines-ratchet && pnpm run check:pane-realm-safety && pnpm run verify:bundled-skill-guides && pnpm run verify:skill-bundle-manifest && pnpm run verify:localization-catalog && pnpm run verify:localization-extraction && pnpm run verify:localization-coverage",
     "audit:code-quality": "pnpm run audit:code-quality:native && pnpm run audit:code-quality:type-aware && pnpm run audit:react-doctor",
     "audit:code-quality:native": "oxlint --config config/oxlint-code-quality-native-plugins.json src config tests mobile --deny-warnings",
     "audit:code-quality:type-aware": "oxlint --type-aware --config config/oxlint-code-quality-type-aware.json src config tests --deny-warnings",
@@ -28,6 +28,7 @@
     "test:skill-sharing:release": "vitest run --config config/vitest.config.ts src/main/skills src/main/runtime/rpc/methods/skills.test.ts src/relay/skill-install-handler.test.ts src/shared/skill-bundle-install-contract.test.ts src/shared/skill-install-contract.test.ts src/shared/skill-install-failure.test.ts src/shared/skill-package-manifest.test.ts",
     "test:repro:remote-agent-session": "pnpm run build:cli && pnpm run build:electron-vite && node config/scripts/remote-agent-session-authority-repro.mjs",
     "check:reliability-gates": "node config/scripts/check-reliability-gates.mjs",
+    "check:pane-realm-safety": "node config/scripts/check-pane-realm-safety.mjs",
     "check:max-lines-ratchet": "node config/scripts/check-max-lines-ratchet.mjs",
     "check:feature-wall-assets": "node config/scripts/check-feature-wall-assets.mjs",
     "generate:bundled-skill-guides": "node config/scripts/generate-bundled-skill-guides.mjs --write",

--- a/src/main/window/privileged-window-navigation.test.ts
+++ b/src/main/window/privileged-window-navigation.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { openExternalMock } = vi.hoisted(() => ({ openExternalMock: vi.fn() }))
+
+vi.mock('electron', () => ({ shell: { openExternal: openExternalMock } }))
+vi.mock('@electron-toolkit/utils', () => ({ is: { dev: false } }))
+
+import { installPrivilegedWindowNavigationPolicy } from './privileged-window-navigation'
+
+type Handler = (...args: any[]) => unknown
+
+function makeContents() {
+  const handlers = new Map<string, Handler>()
+  return {
+    handlers,
+    contents: {
+      on: vi.fn((event: string, handler: Handler) => handlers.set(event, handler)),
+      setWindowOpenHandler: vi.fn((handler: Handler) => handlers.set('window-open', handler))
+    }
+  }
+}
+
+describe('installPrivilegedWindowNavigationPolicy', () => {
+  beforeEach(() => openExternalMock.mockReset())
+
+  it('hardens every verified auxiliary webContents', () => {
+    const opener = makeContents()
+    const child = makeContents()
+    installPrivilegedWindowNavigationPolicy(opener.contents as never)
+
+    opener.handlers.get('did-create-window')?.(
+      { webContents: child.contents },
+      { url: 'about:blank', frameName: 'orca-aux-pane:group-1' }
+    )
+
+    expect(child.contents.setWindowOpenHandler).toHaveBeenCalledTimes(1)
+    expect(child.handlers.get('window-open')?.({ url: 'https://example.com' })).toEqual({
+      action: 'deny'
+    })
+    const preventDefault = vi.fn()
+    child.handlers.get('will-navigate')?.({ preventDefault }, 'https://example.com/path')
+    expect(preventDefault).toHaveBeenCalledTimes(1)
+    expect(openExternalMock).toHaveBeenCalledWith('https://example.com/')
+    expect(openExternalMock).toHaveBeenCalledWith('https://example.com/path')
+  })
+
+  it('does not attach auxiliary policy to unverified children', () => {
+    const opener = makeContents()
+    const child = makeContents()
+    installPrivilegedWindowNavigationPolicy(opener.contents as never)
+
+    opener.handlers.get('did-create-window')?.(
+      { webContents: child.contents },
+      { url: 'https://example.com', frameName: 'orca-aux-pane:group-1' }
+    )
+    opener.handlers.get('did-create-window')?.(
+      { webContents: child.contents },
+      { url: 'about:blank', frameName: 'untrusted' }
+    )
+
+    expect(child.contents.setWindowOpenHandler).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/window/privileged-window-navigation.ts
+++ b/src/main/window/privileged-window-navigation.ts
@@ -1,10 +1,74 @@
 import { shell, type WebContents } from 'electron'
 import { is } from '@electron-toolkit/utils'
 import { normalizeExternalBrowserUrl } from '../../shared/browser-url'
+import {
+  AUX_WINDOW_DEFAULT_SIZE,
+  isAuxWindowFrameName,
+  parseAuxWindowFeatures
+} from '../../shared/aux-window'
+import { rectHasVisibleAreaOnAnyDisplay } from './window-bounds-validation'
+
+/** Enough of the window must be on-screen that its titlebar stays grabbable. */
+const AUX_WINDOW_MIN_VISIBLE_PX = 120
+
+function installDenyByDefaultNavigationPolicy(contents: WebContents): void {
+  contents.setWindowOpenHandler(({ url }) => {
+    const externalUrl = normalizeExternalBrowserUrl(url)
+    if (externalUrl) {
+      void shell.openExternal(externalUrl)
+    }
+    return { action: 'deny' }
+  })
+  contents.on('will-navigate', (event, url) => {
+    const externalUrl = normalizeExternalBrowserUrl(url)
+    if (externalUrl) {
+      void shell.openExternal(externalUrl)
+    }
+    event.preventDefault()
+  })
+}
 
 /** Keep remote documents from inheriting an Orca window's privileged preload. */
 export function installPrivilegedWindowNavigationPolicy(contents: WebContents): void {
-  contents.setWindowOpenHandler(({ url }) => {
+  contents.on('did-create-window', (child, details) => {
+    if (details.url === 'about:blank' && isAuxWindowFrameName(details.frameName)) {
+      installDenyByDefaultNavigationPolicy(child.webContents)
+    }
+  })
+  contents.setWindowOpenHandler(({ url, frameName, features }) => {
+    // Why: about:blank inherits privileged parent webPreferences, including
+    // preload. Keep it same-origin for portals and harden its webContents when
+    // Electron reports the verified child through did-create-window.
+    if (url === 'about:blank' && isAuxWindowFrameName(frameName)) {
+      const requested = parseAuxWindowFeatures(features)
+      const bounds = {
+        width: requested.width ?? AUX_WINDOW_DEFAULT_SIZE.width,
+        height: requested.height ?? AUX_WINDOW_DEFAULT_SIZE.height,
+        ...(requested.x !== undefined && requested.y !== undefined
+          ? { x: requested.x, y: requested.y }
+          : {})
+      }
+      // Why: a restored window must land on a display that still exists — an
+      // unplugged monitor would otherwise put it offscreen and unreachable.
+      const placeable =
+        requested.x !== undefined &&
+        requested.y !== undefined &&
+        rectHasVisibleAreaOnAnyDisplay(
+          { x: requested.x, y: requested.y, width: bounds.width, height: bounds.height },
+          AUX_WINDOW_MIN_VISIBLE_PX,
+          AUX_WINDOW_MIN_VISIBLE_PX
+        )
+      const placement = placeable ? bounds : { width: bounds.width, height: bounds.height }
+      return {
+        action: 'allow',
+        overrideBrowserWindowOptions: {
+          // Native frame: matches the dashboard pop-out, which deliberately
+          // skips the custom titlebar (dashboard-popout-window.ts:169-173).
+          ...placement,
+          webPreferences: { sandbox: true, contextIsolation: true }
+        }
+      }
+    }
     const externalUrl = normalizeExternalBrowserUrl(url)
     if (externalUrl) {
       void shell.openExternal(externalUrl)

--- a/src/renderer/src/app-shell/app-command-handlers.test.ts
+++ b/src/renderer/src/app-shell/app-command-handlers.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AppShortcutState } from './app-command-handlers'
+
+const setRenamingTabId = vi.hoisted(() => vi.fn())
+const storeState = vi.hoisted(() => ({
+  activeTabId: 'main-tab' as string | null,
+  activeTabType: 'terminal' as 'terminal' | 'editor',
+  groupsByWorktree: {
+    aux: [
+      {
+        id: 'aux-group',
+        worktreeId: 'aux',
+        activeTabId: 'aux-unified',
+        tabOrder: ['aux-unified']
+      }
+    ]
+  },
+  unifiedTabsByWorktree: {
+    aux: [
+      {
+        id: 'aux-unified',
+        entityId: 'aux-terminal',
+        groupId: 'aux-group',
+        worktreeId: 'aux',
+        contentType: 'terminal' as const
+      }
+    ]
+  },
+  setRenamingTabId
+}))
+
+vi.mock('../store', () => ({
+  useAppStore: Object.assign(vi.fn(), { getState: () => storeState })
+}))
+
+vi.mock('@/lib/floating-workspace-terminal-actions', () => ({
+  isFloatingWorkspacePanelFocused: () => false
+}))
+
+import { createAppCommandHandlers } from './app-command-handlers'
+
+function state(overrides: Partial<AppShortcutState> = {}): AppShortcutState {
+  return {
+    activeView: 'terminal',
+    activeWorktreeId: 'main',
+    actions: {} as AppShortcutState['actions'],
+    creationLayoutActive: false,
+    floatingTerminalEnabled: true,
+    floatingTerminalOpen: false,
+    floatingVisibleTabCount: 0,
+    keybindings: {},
+    openFloatingWorkspaceMaximized: vi.fn(),
+    pluginCommands: [] as unknown as AppShortcutState['pluginCommands'],
+    setFloatingTerminalOpen: vi.fn(),
+    terminalShortcutPolicy: 'orca-first',
+    workspaceChromeActive: true,
+    ...overrides
+  }
+}
+
+describe('tab rename command routing', () => {
+  beforeEach(() => {
+    setRenamingTabId.mockReset()
+    storeState.activeTabId = 'main-tab'
+    storeState.activeTabType = 'terminal'
+  })
+
+  it('preserves main-window chrome and tab-type guards', () => {
+    const mainTarget = { worktreeId: 'main', groupId: 'main-group', auxiliary: false }
+
+    expect(
+      createAppCommandHandlers(
+        state({ workspaceChromeActive: false }),
+        undefined,
+        'app',
+        mainTarget
+      ).get('tab.rename')?.()
+    ).toBe(false)
+
+    storeState.activeTabType = 'editor'
+    expect(
+      createAppCommandHandlers(state(), undefined, 'app', mainTarget).get('tab.rename')?.()
+    ).toBe(false)
+    expect(setRenamingTabId).not.toHaveBeenCalled()
+  })
+
+  it('routes an auxiliary-window rename to its active terminal', () => {
+    const auxiliaryTarget = { worktreeId: 'aux', groupId: 'aux-group', auxiliary: true }
+
+    expect(
+      createAppCommandHandlers(
+        state({ workspaceChromeActive: false }),
+        undefined,
+        'app',
+        auxiliaryTarget
+      ).get('tab.rename')?.()
+    ).toBe(true)
+    expect(setRenamingTabId).toHaveBeenCalledWith('aux-terminal')
+  })
+})

--- a/src/renderer/src/app-shell/app-command-handlers.ts
+++ b/src/renderer/src/app-shell/app-command-handlers.ts
@@ -14,6 +14,12 @@ import type {
   PhysicalModifierToken
 } from '../../../shared/keybindings'
 import { shortcutPlatform } from './app-window-chrome'
+import { isHTMLElement } from '@/lib/cross-realm-dom-predicates'
+import {
+  auxiliaryTerminalShortcutTarget,
+  resolveTerminalShortcutTabId,
+  type TerminalShortcutTarget
+} from '@/components/terminal/aux-pane-shortcut-target'
 
 type AppStoreState = ReturnType<typeof useAppStore.getState>
 
@@ -29,6 +35,7 @@ export type ShortcutDispatchInput = {
   target: EventTarget | null
   defaultPrevented: boolean
   preventDefault: () => void
+  stopImmediatePropagation?: () => void
 }
 
 export type AppShortcutActions = ReturnType<typeof useAppShortcutActions>
@@ -65,7 +72,7 @@ export function useAppShortcutActions() {
 }
 
 export function getKeybindingContext(target: EventTarget | null): KeybindingContext {
-  return target instanceof HTMLElement && target.classList.contains('xterm-helper-textarea')
+  return isHTMLElement(target) && target.classList.contains('xterm-helper-textarea')
     ? 'terminal'
     : 'app'
 }
@@ -80,7 +87,8 @@ export function getKeybindingContext(target: EventTarget | null): KeybindingCont
 export function createAppCommandHandlers(
   state: AppShortcutState,
   input?: ShortcutDispatchInput,
-  keybindingContext: KeybindingContext = 'app'
+  keybindingContext: KeybindingContext = 'app',
+  shortcutTarget: TerminalShortcutTarget | null = null
 ): Map<KeybindingActionId, () => boolean> {
   const {
     activeView,
@@ -95,6 +103,7 @@ export function createAppCommandHandlers(
     workspaceChromeActive
   } = state
   const floatingWorkspaceFocused = isFloatingWorkspacePanelFocused()
+  const auxiliaryShortcutTarget = auxiliaryTerminalShortcutTarget(shortcutTarget)
   const canRevealRightSidebar = !creationLayoutActive && canShowRightSidebarForView(activeView)
   const claim = (actionId: KeybindingActionId, run: () => void): boolean => {
     input?.preventDefault()
@@ -168,15 +177,18 @@ export function createAppCommandHandlers(
       'tab.rename',
       () => {
         const store = useAppStore.getState()
+        const targetTabId = auxiliaryShortcutTarget
+          ? resolveTerminalShortcutTabId(auxiliaryShortcutTarget, store)
+          : store.activeTabId
         if (
-          !workspaceChromeActive ||
+          (!auxiliaryShortcutTarget && !workspaceChromeActive) ||
           floatingWorkspaceFocused ||
-          store.activeTabType !== 'terminal' ||
-          !store.activeTabId
+          (!auxiliaryShortcutTarget && store.activeTabType !== 'terminal') ||
+          !targetTabId
         ) {
           return false
         }
-        return claim('tab.rename', () => store.setRenamingTabId(store.activeTabId!))
+        return claim('tab.rename', () => store.setRenamingTabId(targetTabId))
       }
     ],
     [

--- a/src/renderer/src/app-shell/use-global-keybindings.ts
+++ b/src/renderer/src/app-shell/use-global-keybindings.ts
@@ -40,13 +40,15 @@ import {
 } from './app-command-handlers'
 import type { AppChromeLayout } from './use-app-chrome-layout'
 import type { FloatingWorkspacePanelState } from './use-floating-workspace-panel'
+import { addEventListenerOnAllWindows } from '@/lib/aux-pane-window-registry'
+import { activeElementFor, isElement, isNode } from '@/lib/cross-realm-dom-predicates'
+import {
+  getTerminalShortcutPaneHandle,
+  resolveTerminalShortcutTabId,
+  resolveTerminalShortcutTarget
+} from '@/components/terminal/aux-pane-shortcut-target'
 
-/**
- * Registers the window-level shortcut listeners and the app command dispatcher.
- *
- * Window key listeners are global and long-lived: one registration, but the handler reads
- * current shortcut state each key event through a ref.
- */
+/** Registers long-lived window shortcuts that read current committed state through a ref. */
 export function useGlobalKeybindings(args: {
   layout: AppChromeLayout
   floatingWorkspace: FloatingWorkspacePanelState
@@ -110,12 +112,13 @@ export function useGlobalKeybindings(args: {
       }
       // The Settings shortcut recorder captures existing shortcuts, so global handlers must not fire while its button has focus.
       if (
-        input.target instanceof Element &&
+        isElement(input.target) &&
         input.target.closest('[data-shortcut-recorder-active]') !== null
       ) {
         return
       }
       const context = getKeybindingContext(input.target)
+      const shortcutTarget = resolveTerminalShortcutTarget(input.target, useAppStore.getState())
 
       // Note: some shortcuts are also intercepted in createMainWindow.ts before-input-event (for browser-guest focus); the renderer keeps handlers for local focus.
 
@@ -135,14 +138,26 @@ export function useGlobalKeybindings(args: {
         })
       }
 
+      if (context === 'terminal' && shortcutTarget?.auxiliary && matchShortcut('tab.close')) {
+        const terminalTabId = resolveTerminalShortcutTabId(shortcutTarget, useAppStore.getState())
+        const pane = terminalTabId ? getTerminalShortcutPaneHandle(terminalTabId) : null
+        // Why: suppress Chromium aux-window close while its pane handle mounts.
+        input.preventDefault()
+        input.stopImmediatePropagation?.()
+        if (pane) {
+          notifyTerminalCapture('tab.close')
+          pane.closeActivePane()
+        }
+        return
+      }
       const canRevealRightSidebar = !creationLayoutActive && canShowRightSidebarForView(activeView)
 
       if (matchShortcut('sidebar.search.toggle') && canRevealRightSidebar) {
         // With a folder selected in the explorer, Cmd/Ctrl+Shift+F means "Find in Folder" — seed the include pattern with it, not a text search.
-        const selectedFolderRelativePath =
-          document.activeElement instanceof Element
-            ? selectedExplorerFolderRelativePath(document.activeElement)
-            : null
+        const activeElement = activeElementFor(isNode(input.target) ? input.target : null)
+        const selectedFolderRelativePath = isElement(activeElement)
+          ? selectedExplorerFolderRelativePath(activeElement)
+          : null
         if (selectedFolderRelativePath !== null && activeWorktreeId) {
           input.preventDefault()
           notifyTerminalCapture('sidebar.search.toggle')
@@ -235,7 +250,7 @@ export function useGlobalKeybindings(args: {
         }
       }
 
-      const handlers = createAppCommandHandlers(state, input, context)
+      const handlers = createAppCommandHandlers(state, input, context, shortcutTarget)
       for (const actionId of PLUGIN_COMMAND_ALIAS_ACTION_IDS) {
         if (matchShortcut(actionId) && handlers.get(actionId)?.()) {
           return
@@ -274,7 +289,8 @@ export function useGlobalKeybindings(args: {
           doubleTapModifier: detected.modifier,
           target: e.target,
           defaultPrevented: e.defaultPrevented,
-          preventDefault: () => e.preventDefault()
+          preventDefault: () => e.preventDefault(),
+          stopImmediatePropagation: () => e.stopImmediatePropagation()
         })
         return
       }
@@ -287,7 +303,8 @@ export function useGlobalKeybindings(args: {
         shiftKey: e.shiftKey,
         target: e.target,
         defaultPrevented: e.defaultPrevented,
-        preventDefault: () => e.preventDefault()
+        preventDefault: () => e.preventDefault(),
+        stopImmediatePropagation: () => e.stopImmediatePropagation()
       })
     }
 
@@ -309,14 +326,16 @@ export function useGlobalKeybindings(args: {
     // Why: a window blur mid-gesture must not leave the detector armed.
     const onBlur = (): void => doubleTapDetector.reset()
 
-    window.addEventListener('keydown', onKeyDown, { capture: true })
-    window.addEventListener('keyup', onKeyUp, { capture: true })
-    window.addEventListener('blur', onBlur)
+    const removeListeners = [
+      addEventListenerOnAllWindows('keydown', onKeyDown, { capture: true }),
+      addEventListenerOnAllWindows('keyup', onKeyUp, { capture: true }),
+      addEventListenerOnAllWindows('blur', onBlur)
+    ]
     return () => {
       unregisterAppCommandDispatcher()
-      window.removeEventListener('keydown', onKeyDown, { capture: true })
-      window.removeEventListener('keyup', onKeyUp, { capture: true })
-      window.removeEventListener('blur', onBlur)
+      for (const removeListener of removeListeners) {
+        removeListener()
+      }
     }
   }, [])
 }

--- a/src/renderer/src/components/CodexRestartChip.tsx
+++ b/src/renderer/src/components/CodexRestartChip.tsx
@@ -91,7 +91,8 @@ function LoudRestartOverlay({
       return
     }
     const paneScope = root.parentElement
-    if (shouldFocusMobileDriverAction(document.activeElement, document.body, paneScope)) {
+    const paneDocument = root.ownerDocument
+    if (shouldFocusMobileDriverAction(paneDocument.activeElement, paneDocument.body, paneScope)) {
       root.focus()
     }
   }, [isVisible, noticeKey, shouldFocus])

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -82,6 +82,13 @@ import {
   handleSwitchTabAcrossAllTypes,
   handleSwitchTerminalTab
 } from '../hooks/ipc-tab-switch'
+import { getKeybindingContext } from '../app-shell/app-command-handlers'
+import { addEventListenerOnAllWindows } from '@/lib/aux-pane-window-registry'
+import {
+  resolveTerminalCreationShortcutWorktreeId,
+  resolveTerminalShortcutTarget,
+  type TerminalShortcutTarget
+} from './terminal/aux-pane-shortcut-target'
 import TabGroupSplitLayout from './tab-group/TabGroupSplitLayout'
 import AiVaultSessionDropLayer from './tab-group/AiVaultSessionDropLayer'
 import { shouldAutoCreateInitialTerminal } from './terminal/initial-terminal'
@@ -171,11 +178,7 @@ import {
   isFloatingWorkspacePanelFocused,
   switchFloatingWorkspaceTab
 } from '@/lib/floating-workspace-terminal-actions'
-import {
-  keybindingMatchesAction,
-  type KeybindingActionId,
-  type KeybindingContext
-} from '../../../shared/keybindings'
+import { keybindingMatchesAction, type KeybindingActionId } from '../../../shared/keybindings'
 import { matchesRecentTabSwitcherChord } from '../../../shared/window-shortcut-policy'
 import { showTerminalShortcutCaptureNotification } from '@/lib/terminal-shortcut-capture-notification'
 import { useContextualTour } from './contextual-tours/use-contextual-tour'
@@ -287,12 +290,6 @@ function isPinnedEditorFileTab(
   )
 }
 
-function getKeybindingContext(target: EventTarget | null): KeybindingContext {
-  return target instanceof HTMLElement && target.classList.contains('xterm-helper-textarea')
-    ? 'terminal'
-    : 'app'
-}
-
 function Terminal(): React.JSX.Element | null {
   const mountedWorktreeIdsRef = useRef(new Set<string>())
   // Why an array: browser-guest eviction needs activation order (LRU), not just membership.
@@ -384,6 +381,8 @@ function Terminal(): React.JSX.Element | null {
   const closeBrowserTab = useAppStore((s) => s.closeBrowserTab)
   const setActiveBrowserTab = useAppStore((s) => s.setActiveBrowserTab)
   const groupsByWorktree = useAppStore((s) => s.groupsByWorktree)
+  const unifiedTabsByWorktree = useAppStore((s) => s.unifiedTabsByWorktree)
+  const detachedGroupIds = useAppStore((s) => s.detachedGroupIds)
   const layoutByWorktree = useAppStore((s) => s.layoutByWorktree)
   const activeGroupIdByWorktree = useAppStore((s) => s.activeGroupIdByWorktree)
   const ensureWorktreeRootGroup = useAppStore((s) => s.ensureWorktreeRootGroup)
@@ -407,8 +406,29 @@ function Terminal(): React.JSX.Element | null {
     for (const portal of activityTerminalPortals) {
       ids.add(portal.tabId)
     }
+    const detached = new Set(detachedGroupIds)
+    for (const [worktreeId, groups] of Object.entries(groupsByWorktree)) {
+      const unifiedTabs = unifiedTabsByWorktree[worktreeId] ?? []
+      for (const group of groups) {
+        if (!detached.has(group.id) || !group.activeTabId) {
+          continue
+        }
+        const tab = unifiedTabs.find((candidate) => candidate.id === group.activeTabId)
+        if (tab?.contentType === 'terminal') {
+          ids.add(tab.entityId)
+        }
+      }
+    }
     return Array.from(ids)
-  }, [activeTabId, activeTabType, activeView, activityTerminalPortals])
+  }, [
+    activeTabId,
+    activeTabType,
+    activeView,
+    activityTerminalPortals,
+    detachedGroupIds,
+    groupsByWorktree,
+    unifiedTabsByWorktree
+  ])
 
   useEffect(() => {
     // Why: hibernation must treat terminals portaled into foreground surfaces as visible even when not the active tab.
@@ -450,6 +470,14 @@ function Terminal(): React.JSX.Element | null {
       getEffectiveLayout(worktreeId, layoutByWorktree, groupsByWorktree, activeGroupIdByWorktree),
     [activeGroupIdByWorktree, groupsByWorktree, layoutByWorktree]
   )
+  const detachedWorktreeIds = useMemo(() => {
+    const detached = new Set(detachedGroupIds)
+    return new Set(
+      Object.entries(groupsByWorktree).flatMap(([worktreeId, groups]) =>
+        groups.some((group) => detached.has(group.id)) ? [worktreeId] : []
+      )
+    )
+  }, [detachedGroupIds, groupsByWorktree])
   const effectiveActiveLayout = renderedActiveWorktreeId
     ? getEffectiveLayoutForWorktree(renderedActiveWorktreeId)
     : undefined
@@ -939,7 +967,9 @@ function Terminal(): React.JSX.Element | null {
         terminalWorktreeParkCooldownUntilRef.current.delete(worktreeId)
         continue
       }
-      const isVisible = activeView === 'terminal' && renderedActiveWorktreeId === worktreeId
+      const isVisible =
+        (activeView === 'terminal' && renderedActiveWorktreeId === worktreeId) ||
+        detachedWorktreeIds.has(worktreeId)
       const shouldMeasureHiddenWorktree =
         !isVisible && measurableBackgroundWorktreeIdsRef.current.has(worktreeId)
       const hasActivityTerminalPortal = portalWorktreeIds.has(worktreeId)
@@ -1178,6 +1208,7 @@ function Terminal(): React.JSX.Element | null {
     pendingStartupByTabId,
     pairedRuntimeParkingEnvironmentIds,
     renderedActiveWorktreeId,
+    detachedWorktreeIds,
     tabsByWorktree,
     terminalParkingEnabled,
     terminalParkingRevision,
@@ -1540,17 +1571,19 @@ function Terminal(): React.JSX.Element | null {
   }, [activeWorktreeId, hydrationSucceeded, workspaceSessionReady])
 
   const handleNewTab = useCallback(
-    (shellOverride?: string) => {
-      if (!activeWorktreeId) {
+    (shellOverride?: string, shortcutTarget?: TerminalShortcutTarget | null) => {
+      const worktreeId = shortcutTarget?.worktreeId ?? activeWorktreeId
+      if (!worktreeId) {
         return
       }
       const targetGroupId =
-        useAppStore.getState().activeGroupIdByWorktree[activeWorktreeId] ??
-        useAppStore.getState().groupsByWorktree[activeWorktreeId]?.[0]?.id
-      const runtimeEnvironmentId = getActiveWorktreeRuntimeEnvironmentId(activeWorktreeId)
+        shortcutTarget?.groupId ??
+        useAppStore.getState().activeGroupIdByWorktree[worktreeId] ??
+        useAppStore.getState().groupsByWorktree[worktreeId]?.[0]?.id
+      const runtimeEnvironmentId = getActiveWorktreeRuntimeEnvironmentId(worktreeId)
       if (isWebRuntimeSessionActive(runtimeEnvironmentId)) {
         void createWebRuntimeSessionTerminal({
-          worktreeId: activeWorktreeId,
+          worktreeId,
           environmentId: runtimeEnvironmentId,
           targetGroupId,
           command: shellOverride,
@@ -1559,17 +1592,17 @@ function Terminal(): React.JSX.Element | null {
         return
       }
       if (!shellOverride && targetGroupId) {
-        void openNewTerminalTabInActiveWorkspace(targetGroupId)
+        void openNewTerminalTabInActiveWorkspace(targetGroupId, worktreeId)
         return
       }
-      const newTab = createTab(activeWorktreeId, undefined, shellOverride)
+      const newTab = createTab(worktreeId, targetGroupId, shellOverride)
       setActiveTabType('terminal')
       // Why: persist tab-bar order with the new terminal appended; else reconcileOrder falls back to terminals-first and jumps it to index 0 before editor tabs.
       const state = useAppStore.getState()
-      const currentTerminals = state.tabsByWorktree[activeWorktreeId] ?? []
-      const currentEditors = state.openFiles.filter((f) => f.worktreeId === activeWorktreeId)
-      const currentBrowsers = state.browserTabsByWorktree[activeWorktreeId] ?? []
-      const stored = state.tabBarOrderByWorktree[activeWorktreeId]
+      const currentTerminals = state.tabsByWorktree[worktreeId] ?? []
+      const currentEditors = state.openFiles.filter((f) => f.worktreeId === worktreeId)
+      const currentBrowsers = state.browserTabsByWorktree[worktreeId] ?? []
+      const stored = state.tabBarOrderByWorktree[worktreeId]
       const termIds = currentTerminals.map((t) => t.id)
       const editorIds = currentEditors.map((f) => f.id)
       const browserIds = currentBrowsers.map((tab) => tab.id)
@@ -1585,7 +1618,7 @@ function Terminal(): React.JSX.Element | null {
       // The new tab is already in base via termIds; move it to the end
       const order = base.filter((id) => id !== newTab.id)
       order.push(newTab.id)
-      setTabBarOrder(activeWorktreeId, order)
+      setTabBarOrder(worktreeId, order)
       // Why: shell-specific creation still uses the legacy path; keep focus here until the lifted action accepts shell overrides.
       focusTerminalTabSurface(newTab.id)
     },
@@ -1599,17 +1632,19 @@ function Terminal(): React.JSX.Element | null {
   )
 
   const handleNewAgentTab = useCallback(
-    (agent: TuiAgent) => {
-      if (!activeWorktreeId) {
+    (agent: TuiAgent, shortcutTarget?: TerminalShortcutTarget | null) => {
+      const worktreeId = shortcutTarget?.worktreeId ?? activeWorktreeId
+      if (!worktreeId) {
         return
       }
       const state = useAppStore.getState()
       const targetGroupId =
-        state.activeGroupIdByWorktree[activeWorktreeId] ??
-        state.groupsByWorktree[activeWorktreeId]?.[0]?.id
+        shortcutTarget?.groupId ??
+        state.activeGroupIdByWorktree[worktreeId] ??
+        state.groupsByWorktree[worktreeId]?.[0]?.id
       const result = launchAgentInNewTab({
         agent,
-        worktreeId: activeWorktreeId,
+        worktreeId,
         groupId: targetGroupId,
         launchSource: 'shortcut'
       })
@@ -1626,54 +1661,66 @@ function Terminal(): React.JSX.Element | null {
     [activeWorktreeId]
   )
 
-  const handleNewSimulatorTab = useCallback(() => {
-    if (!activeWorktreeId) {
-      return
-    }
-    const targetGroupId =
-      useAppStore.getState().activeGroupIdByWorktree[activeWorktreeId] ??
-      useAppStore.getState().groupsByWorktree[activeWorktreeId]?.[0]?.id
-    void openMobileEmulatorTab(activeWorktreeId, {
-      placement: 'rightSplit',
-      targetGroupId: targetGroupId ?? undefined
-    }).catch(showClientCreationActionError)
-  }, [activeWorktreeId])
-
-  const handleNewBrowserTab = useCallback(() => {
-    if (!activeWorktreeId) {
-      return
-    }
-    const targetGroupId =
-      useAppStore.getState().activeGroupIdByWorktree[activeWorktreeId] ??
-      useAppStore.getState().groupsByWorktree[activeWorktreeId]?.[0]?.id
-    if (targetGroupId) {
-      void openNewBrowserTabInActiveWorkspace(targetGroupId).catch(showClientCreationActionError)
-      return
-    }
-    const state = useAppStore.getState()
-    const browserAvailability = getClientCreationActionPolicy(state, activeWorktreeId)[
-      'managed-browser'
-    ]
-    if (browserAvailability.state !== 'enabled') {
-      toast.error(browserAvailability.reason)
-      return
-    }
-    const defaultUrl = state.browserDefaultUrl ?? 'about:blank'
-    const runtimeEnvironmentId = getActiveWorktreeRuntimeEnvironmentId(activeWorktreeId)
-    if (browserAvailability.provider === 'paired-runtime' && runtimeEnvironmentId) {
-      void createWebRuntimeSessionBrowserTab({
-        worktreeId: activeWorktreeId,
-        environmentId: runtimeEnvironmentId,
-        url: defaultUrl
+  const handleNewSimulatorTab = useCallback(
+    (shortcutTarget?: TerminalShortcutTarget | null) => {
+      const worktreeId = shortcutTarget?.worktreeId ?? activeWorktreeId
+      if (!worktreeId) {
+        return
+      }
+      const targetGroupId =
+        shortcutTarget?.groupId ??
+        useAppStore.getState().activeGroupIdByWorktree[worktreeId] ??
+        useAppStore.getState().groupsByWorktree[worktreeId]?.[0]?.id
+      void openMobileEmulatorTab(worktreeId, {
+        placement: 'rightSplit',
+        targetGroupId: targetGroupId ?? undefined
       }).catch(showClientCreationActionError)
-      return
-    }
-    createBrowserTab(activeWorktreeId, defaultUrl, {
-      title: translate('auto.components.Terminal.37da0d736f', 'New Browser Tab'),
-      focusAddressBar: true,
-      ...(runtimeEnvironmentId ? { browserRuntimeEnvironmentId: null } : {})
-    })
-  }, [activeWorktreeId, createBrowserTab, openNewBrowserTabInActiveWorkspace])
+    },
+    [activeWorktreeId]
+  )
+
+  const handleNewBrowserTab = useCallback(
+    (shortcutTarget?: TerminalShortcutTarget | null) => {
+      const worktreeId = shortcutTarget?.worktreeId ?? activeWorktreeId
+      if (!worktreeId) {
+        return
+      }
+      const targetGroupId =
+        shortcutTarget?.groupId ??
+        useAppStore.getState().activeGroupIdByWorktree[worktreeId] ??
+        useAppStore.getState().groupsByWorktree[worktreeId]?.[0]?.id
+      if (targetGroupId) {
+        void openNewBrowserTabInActiveWorkspace(targetGroupId, worktreeId).catch(
+          showClientCreationActionError
+        )
+        return
+      }
+      const state = useAppStore.getState()
+      const browserAvailability = getClientCreationActionPolicy(state, worktreeId)[
+        'managed-browser'
+      ]
+      if (browserAvailability.state !== 'enabled') {
+        toast.error(browserAvailability.reason)
+        return
+      }
+      const defaultUrl = state.browserDefaultUrl ?? 'about:blank'
+      const runtimeEnvironmentId = getActiveWorktreeRuntimeEnvironmentId(worktreeId)
+      if (browserAvailability.provider === 'paired-runtime' && runtimeEnvironmentId) {
+        void createWebRuntimeSessionBrowserTab({
+          worktreeId,
+          environmentId: runtimeEnvironmentId,
+          url: defaultUrl
+        }).catch(showClientCreationActionError)
+        return
+      }
+      createBrowserTab(worktreeId, defaultUrl, {
+        title: translate('auto.components.Terminal.37da0d736f', 'New Browser Tab'),
+        focusAddressBar: true,
+        ...(runtimeEnvironmentId ? { browserRuntimeEnvironmentId: null } : {})
+      })
+    },
+    [activeWorktreeId, createBrowserTab, openNewBrowserTabInActiveWorkspace]
+  )
 
   const handleOpenEntry = useCallback(async (args: TabCreateEntryArgs) => {
     await openTabBarEntry(args)
@@ -1723,18 +1770,23 @@ function Terminal(): React.JSX.Element | null {
     [activeWorktreeId, createBrowserTab]
   )
 
-  const handleNewFile = useCallback(async () => {
-    if (!activeWorktreeId) {
-      return
-    }
-    const targetGroupId =
-      useAppStore.getState().activeGroupIdByWorktree[activeWorktreeId] ??
-      useAppStore.getState().groupsByWorktree[activeWorktreeId]?.[0]?.id
-    if (!targetGroupId) {
-      return
-    }
-    await openNewMarkdownInActiveWorkspace(targetGroupId)
-  }, [activeWorktreeId, openNewMarkdownInActiveWorkspace])
+  const handleNewFile = useCallback(
+    async (shortcutTarget?: TerminalShortcutTarget | null) => {
+      const worktreeId = shortcutTarget?.worktreeId ?? activeWorktreeId
+      if (!worktreeId) {
+        return
+      }
+      const targetGroupId =
+        shortcutTarget?.groupId ??
+        useAppStore.getState().activeGroupIdByWorktree[worktreeId] ??
+        useAppStore.getState().groupsByWorktree[worktreeId]?.[0]?.id
+      if (!targetGroupId) {
+        return
+      }
+      await openNewMarkdownInActiveWorkspace(targetGroupId, worktreeId)
+    },
+    [activeWorktreeId, openNewMarkdownInActiveWorkspace]
+  )
 
   const handleCloseTab = useCallback((tabId: string) => {
     closeTerminalTab(tabId)
@@ -2002,7 +2054,7 @@ function Terminal(): React.JSX.Element | null {
 
   // Keyboard shortcuts
   useEffect(() => {
-    if (!activeWorktreeId) {
+    if (!activeWorktreeId && detachedGroupIds.length === 0) {
       return
     }
 
@@ -2013,6 +2065,7 @@ function Terminal(): React.JSX.Element | null {
         ? 'win32'
         : 'linux'
     const onKeyDown = (e: KeyboardEvent): void => {
+      const shortcutTarget = resolveTerminalShortcutTarget(e.target, useAppStore.getState())
       const context = getKeybindingContext(e.target)
       const floatingWorkspaceFocused = isFloatingWorkspacePanelFocused()
       const matchShortcut = (actionId: KeybindingActionId): boolean =>
@@ -2038,7 +2091,7 @@ function Terminal(): React.JSX.Element | null {
           void createFloatingWorkspaceTerminalTab(useAppStore.getState())
           return
         }
-        handleNewTab()
+        handleNewTab(undefined, shortcutTarget)
         return
       }
 
@@ -2049,7 +2102,7 @@ function Terminal(): React.JSX.Element | null {
         let agentActionId: KeybindingActionId | null = null
         let agentToLaunch: TuiAgent | null = null
         if (matchShortcut('tab.newAgent')) {
-          const connectionId = getConnectionId(activeWorktreeId)
+          const connectionId = shortcutTarget ? getConnectionId(shortcutTarget.worktreeId) : null
           agentActionId = 'tab.newAgent'
           agentToLaunch = resolveDefaultAgentForNewTab({
             defaultTuiAgent: state.settings?.defaultTuiAgent,
@@ -2076,7 +2129,7 @@ function Terminal(): React.JSX.Element | null {
           e.preventDefault()
           notifyTerminalCapture(agentActionId)
           if (agentToLaunch) {
-            handleNewAgentTab(agentToLaunch)
+            handleNewAgentTab(agentToLaunch, shortcutTarget)
           } else {
             toast.message(
               translate(
@@ -2094,7 +2147,9 @@ function Terminal(): React.JSX.Element | null {
         e.preventDefault()
         notifyTerminalCapture('tab.reopenClosed')
         try {
-          useAppStore.getState().reopenClosedTab(activeWorktreeId)
+          if (shortcutTarget) {
+            useAppStore.getState().reopenClosedTab(shortcutTarget.worktreeId)
+          }
         } catch (error) {
           showClientCreationActionError(error)
         }
@@ -2105,9 +2160,15 @@ function Terminal(): React.JSX.Element | null {
       if (!e.repeat && matchShortcut('tab.newBrowser')) {
         e.preventDefault()
         notifyTerminalCapture('tab.newBrowser')
+        const targetWorktreeId = floatingWorkspaceFocused
+          ? FLOATING_TERMINAL_WORKTREE_ID
+          : shortcutTarget?.worktreeId
+        if (!targetWorktreeId) {
+          return
+        }
         const browserAvailability = getClientCreationActionPolicy(
           useAppStore.getState(),
-          floatingWorkspaceFocused ? FLOATING_TERMINAL_WORKTREE_ID : activeWorktreeId
+          targetWorktreeId
         )['managed-browser']
         if (browserAvailability.state !== 'enabled') {
           toast.error(browserAvailability.reason)
@@ -2119,7 +2180,7 @@ function Terminal(): React.JSX.Element | null {
           )
           return
         }
-        handleNewBrowserTab()
+        handleNewBrowserTab(shortcutTarget)
         return
       }
 
@@ -2127,16 +2188,23 @@ function Terminal(): React.JSX.Element | null {
       if (!e.repeat && mobileEmulatorEnabled && matchShortcut('tab.newSimulator')) {
         e.preventDefault()
         notifyTerminalCapture('tab.newSimulator')
+        const targetWorktreeId = resolveTerminalCreationShortcutWorktreeId(
+          shortcutTarget,
+          floatingWorkspaceFocused
+        )
+        if (!targetWorktreeId) {
+          return
+        }
         const simulatorAvailability = getClientCreationActionPolicy(
           useAppStore.getState(),
-          activeWorktreeId
+          targetWorktreeId
         )['mobile-emulator']
         if (simulatorAvailability.state !== 'enabled') {
           toast.error(simulatorAvailability.reason)
           return
         }
         if (!floatingWorkspaceFocused) {
-          handleNewSimulatorTab()
+          handleNewSimulatorTab(shortcutTarget)
         }
         return
       }
@@ -2201,7 +2269,7 @@ function Terminal(): React.JSX.Element | null {
           })
           return
         }
-        void handleNewFile()
+        void handleNewFile(shortcutTarget)
         return
       }
 
@@ -2222,7 +2290,10 @@ function Terminal(): React.JSX.Element | null {
           return
         }
         const state = useAppStore.getState()
-        if (state.activeTabType === 'terminal' && context === 'terminal') {
+        if (
+          context === 'terminal' &&
+          (shortcutTarget?.auxiliary || state.activeTabType === 'terminal')
+        ) {
           return
         }
         e.preventDefault()
@@ -2257,7 +2328,7 @@ function Terminal(): React.JSX.Element | null {
         e.preventDefault()
         e.stopPropagation()
         e.stopImmediatePropagation()
-        handleSwitchRecentTab()
+        handleSwitchRecentTab(shortcutTarget ?? undefined)
         return
       }
 
@@ -2293,9 +2364,9 @@ function Terminal(): React.JSX.Element | null {
             switchAllTypesDirection !== null ? 'all-types' : 'same-type'
           )
         } else if (switchAllTypesDirection !== null) {
-          handleSwitchTabAcrossAllTypes(switchAllTypesDirection)
+          handleSwitchTabAcrossAllTypes(switchAllTypesDirection, shortcutTarget ?? undefined)
         } else {
-          handleSwitchTab(switchSameTypeDirection ?? 1)
+          handleSwitchTab(switchSameTypeDirection ?? 1, shortcutTarget ?? undefined)
         }
       }
 
@@ -2314,14 +2385,14 @@ function Terminal(): React.JSX.Element | null {
         if (floatingWorkspaceFocused) {
           switchFloatingWorkspaceTab(useAppStore.getState(), terminalTabDirection, 'terminal')
         } else {
-          handleSwitchTerminalTab(terminalTabDirection)
+          handleSwitchTerminalTab(terminalTabDirection, shortcutTarget ?? undefined)
         }
       }
     }
-    window.addEventListener('keydown', onKeyDown, { capture: true })
-    return () => window.removeEventListener('keydown', onKeyDown, { capture: true })
+    return addEventListenerOnAllWindows('keydown', onKeyDown, { capture: true })
   }, [
     activeWorktreeId,
+    detachedGroupIds,
     handleNewBrowserTab,
     handleNewSimulatorTab,
     handleNewFile,
@@ -2518,7 +2589,7 @@ function Terminal(): React.JSX.Element | null {
       {anyMountedWorktreeHasLayout ? (
         <div
           className={`relative flex flex-1 min-w-0 min-h-0 overflow-hidden${
-            effectiveActiveLayout
+            effectiveActiveLayout || detachedWorktreeIds.size > 0
               ? ''
               : retainBrowserGuestPaint
                 ? ' opacity-0 pointer-events-none'
@@ -2536,6 +2607,7 @@ function Terminal(): React.JSX.Element | null {
               // Why: strict '=== terminal' (not !== settings) so the terminal/browser surface hides on the tasks page too.
               const isVisible =
                 activeView === 'terminal' && workspace.id === renderedActiveWorktreeId
+              const hasDetachedGroup = detachedWorktreeIds.has(workspace.id)
               const shouldMeasureHiddenWorktree =
                 !isVisible && measurableBackgroundWorktreeIdsRef.current.has(workspace.id)
               const shouldColdParkTerminalPanes =
@@ -2550,6 +2622,7 @@ function Terminal(): React.JSX.Element | null {
                   layout={layout}
                   focusedGroupId={activeGroupIdByWorktree[workspace.id]}
                   isVisible={isVisible}
+                  hasDetachedGroup={hasDetachedGroup}
                   shouldMeasureHiddenWorktree={shouldMeasureHiddenWorktree}
                   shouldColdParkTerminalPanes={shouldColdParkTerminalPanes}
                   isForceParked={forceParkedTerminalWorktreeIds.has(workspace.id)}
@@ -2815,6 +2888,7 @@ const WorktreeSplitSurface = React.memo(function WorktreeSplitSurface({
   layout,
   focusedGroupId,
   isVisible,
+  hasDetachedGroup,
   shouldMeasureHiddenWorktree,
   shouldColdParkTerminalPanes,
   isForceParked,
@@ -2827,6 +2901,7 @@ const WorktreeSplitSurface = React.memo(function WorktreeSplitSurface({
   layout: TabGroupLayoutNode
   focusedGroupId?: string
   isVisible: boolean
+  hasDetachedGroup: boolean
   shouldMeasureHiddenWorktree: boolean
   shouldColdParkTerminalPanes: boolean
   isForceParked: boolean
@@ -2838,7 +2913,10 @@ const WorktreeSplitSurface = React.memo(function WorktreeSplitSurface({
   const hasAutomationVisibleBrowser = useBrowserAutomationVisibilityForAny(browserPageIds)
   const hasMobileDrivenBrowser = useBrowserMobileDriverForAny(browserPageIds)
   const shouldKeepPaintable =
-    shouldMeasureHiddenWorktree || hasAutomationVisibleBrowser || hasMobileDrivenBrowser
+    hasDetachedGroup ||
+    shouldMeasureHiddenWorktree ||
+    hasAutomationVisibleBrowser ||
+    hasMobileDrivenBrowser
 
   return (
     <div

--- a/src/renderer/src/components/aux-window-container-context.tsx
+++ b/src/renderer/src/components/aux-window-container-context.tsx
@@ -1,0 +1,20 @@
+import { createContext, useContext } from 'react'
+
+/**
+ * The element floating layers should portal into for the current subtree.
+ *
+ * Radix's Portal defaults to `globalThis.document.body`, which is resolved in
+ * the main realm — so a menu or tooltip opened from a pane that lives in a
+ * detached window would render into the wrong window. `DetachedTabGroupWindow`
+ * provides its own container here, and React context crosses portals, so every
+ * descendant picks it up without threading a prop through each call site.
+ *
+ * `null` means "the main window", which is Radix's own default.
+ */
+const AuxWindowContainerContext = createContext<HTMLElement | null>(null)
+
+export const AuxWindowContainerProvider = AuxWindowContainerContext.Provider
+
+export function useAuxWindowContainer(): HTMLElement | null {
+  return useContext(AuxWindowContainerContext)
+}

--- a/src/renderer/src/components/browser-pane/webview-registry.test.ts
+++ b/src/renderer/src/components/browser-pane/webview-registry.test.ts
@@ -18,6 +18,7 @@ function createWebview(overrides: Partial<Electron.WebviewTag> = {}): Electron.W
     blur: vi.fn(),
     remove: vi.fn(),
     contains: vi.fn(() => false),
+    ownerDocument: document,
     ...overrides
   }) as unknown as Electron.WebviewTag
 }
@@ -297,7 +298,7 @@ describe('webview registry drag listeners', () => {
   it('moves focus back to the renderer before detaching the focused webview', async () => {
     const { moveFocusToRendererBeforeWebviewDetach } = await import('./webview-registry')
     const webview = createWebview()
-    vi.stubGlobal('document', { activeElement: webview })
+    Object.defineProperty(webview.ownerDocument, 'activeElement', { value: webview })
 
     moveFocusToRendererBeforeWebviewDetach(webview)
 
@@ -309,7 +310,7 @@ describe('webview registry drag listeners', () => {
     const { moveFocusToRendererBeforeWebviewDetach } = await import('./webview-registry')
     const activeElement = { blur: vi.fn() } as unknown as HTMLElement
     const webview = createWebview({ contains: vi.fn(() => true) })
-    vi.stubGlobal('document', { activeElement })
+    Object.defineProperty(webview.ownerDocument, 'activeElement', { value: activeElement })
 
     moveFocusToRendererBeforeWebviewDetach(webview)
 
@@ -322,7 +323,7 @@ describe('webview registry drag listeners', () => {
       await import('./webview-registry')
     const inactiveWebview = createWebview()
     const focusedWebview = createWebview()
-    vi.stubGlobal('document', { activeElement: focusedWebview })
+    Object.defineProperty(focusedWebview.ownerDocument, 'activeElement', { value: focusedWebview })
 
     registerPersistentWebview('page-1', inactiveWebview)
     registerPersistentWebview('page-2', focusedWebview)
@@ -338,11 +339,24 @@ describe('webview registry drag listeners', () => {
     const { moveFocusToRendererBeforeWebviewDetach } = await import('./webview-registry')
     const activeElement = { blur: vi.fn() } as unknown as HTMLElement
     const webview = createWebview()
-    vi.stubGlobal('document', { activeElement })
+    Object.defineProperty(webview.ownerDocument, 'activeElement', { value: activeElement })
 
     moveFocusToRendererBeforeWebviewDetach(webview)
 
     expect(activeElement.blur).not.toHaveBeenCalled()
     expect(window.focus).not.toHaveBeenCalled()
+  })
+
+  it('reads focus from the webview owning document', async () => {
+    const { moveFocusToRendererBeforeWebviewDetach } = await import('./webview-registry')
+    const foreignDocument = { activeElement: null } as unknown as Document
+    const webview = createWebview({ ownerDocument: foreignDocument })
+    Object.defineProperty(foreignDocument, 'activeElement', { value: webview })
+
+    moveFocusToRendererBeforeWebviewDetach(webview)
+
+    expect(document.activeElement).toBeNull()
+    expect(webview.blur).toHaveBeenCalledTimes(1)
+    expect(window.focus).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/src/components/browser-pane/webview-registry.ts
+++ b/src/renderer/src/components/browser-pane/webview-registry.ts
@@ -223,7 +223,7 @@ function moveFocusToRendererIfWebviewOwnsFocus(webview: Electron.WebviewTag): bo
   if (typeof document === 'undefined' || typeof window === 'undefined') {
     return false
   }
-  const activeElement = document.activeElement as HTMLElement | null
+  const activeElement = webview.ownerDocument.activeElement as HTMLElement | null
   if (!activeElement) {
     return false
   }

--- a/src/renderer/src/components/editor/editor-autosave-controller.test.ts
+++ b/src/renderer/src/components/editor/editor-autosave-controller.test.ts
@@ -137,7 +137,9 @@ function makeSessionReadyState(): Partial<AppState> {
     worktreesByRepo: {},
     lastKnownRelayPtyIdByTabId: {},
     lastVisitedAtByWorktreeId: {},
-    defaultTerminalTabsAppliedByWorktreeId: {}
+    defaultTerminalTabsAppliedByWorktreeId: {},
+    detachedGroupIds: [],
+    auxWindowBoundsByGroupId: {}
   } as Partial<AppState>
 }
 

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -119,6 +119,7 @@ import { translate } from '@/i18n/i18n'
 import { consumeFloatingTerminalOpenMaximizedIntent } from '@/lib/floating-terminal'
 import { selectFloatingTerminalPanelInputs } from './floating-terminal-panel-inputs'
 import { getClientCreationActionPolicy } from '@/lib/client-creation-action-policy'
+import { activeElementFor, isHTMLElement, isNode } from '../../lib/cross-realm-dom-predicates'
 const LOCAL_RUNTIME_SETTINGS = { activeRuntimeEnvironmentId: null } as const
 const NO_ACTIVITY_TERMINAL_PORTALS = []
 
@@ -164,7 +165,7 @@ type FloatingTerminalPanelBoundsState = {
 }
 
 function isFloatingTerminalDragTarget(target: EventTarget): boolean {
-  return !(target instanceof HTMLElement && target.closest(FLOATING_TERMINAL_NO_DRAG_SELECTOR))
+  return !(isHTMLElement(target) && target.closest(FLOATING_TERMINAL_NO_DRAG_SELECTOR))
 }
 
 function readInitialPanelBounds(): FloatingTerminalPanelBoundsState {
@@ -1060,10 +1061,10 @@ export function FloatingTerminalPanel({
   }, [activeGroup, closeFloatingItems])
 
   const focusPanelForShortcuts = useCallback((preserveExistingPanelFocus = true) => {
-    const active = document.activeElement
+    const active = activeElementFor(panelRef.current)
     if (
       preserveExistingPanelFocus &&
-      active instanceof HTMLElement &&
+      isHTMLElement(active) &&
       active.closest('[data-floating-terminal-panel]') !== null
     ) {
       // Why: dragging the titlebar while xterm/editor already has focus should
@@ -1415,7 +1416,7 @@ export function FloatingTerminalPanel({
       }
       const target = event.target
       if (
-        !(target instanceof HTMLElement) ||
+        !isHTMLElement(target) ||
         (target !== panelRef.current &&
           target.closest(FLOATING_TERMINAL_SHORTCUT_SURFACE_SELECTOR) === null)
       ) {
@@ -1442,8 +1443,8 @@ export function FloatingTerminalPanel({
 
     const isPanelFocused = (): boolean => {
       const panel = panelRef.current
-      const active = document.activeElement
-      return Boolean(panel && active instanceof HTMLElement && panel.contains(active))
+      const active = activeElementFor(panel)
+      return Boolean(panel && isHTMLElement(active) && panel.contains(active))
     }
 
     const handleFloatingPanelKeyDown = (event: KeyboardEvent): void => {
@@ -1631,14 +1632,14 @@ export function FloatingTerminalPanel({
 
     const handleOutsidePointerDown = (event: PointerEvent): void => {
       const panel = panelRef.current
-      if (!panel || !(event.target instanceof Node) || panel.contains(event.target)) {
+      if (!panel || !isNode(event.target) || panel.contains(event.target)) {
         return
       }
       reportFloatingFocus(null, true)
       // Cancel any pending emptying-close reclaim: an outside pointer-down is a genuine ownership release.
       clearFloatingPanelReclaimIntent()
-      const active = document.activeElement
-      if (active instanceof HTMLElement && panel.contains(active)) {
+      const active = activeElementFor(panel)
+      if (isHTMLElement(active) && panel.contains(active)) {
         // Why: regular tab strip items are non-focusable, so clicking them can
         // leave xterm's hidden textarea focused unless we explicitly release it.
         active.blur()
@@ -1646,9 +1647,9 @@ export function FloatingTerminalPanel({
     }
     const handleWindowBlur = (): void => {
       const panel = panelRef.current
-      const active = document.activeElement
+      const active = activeElementFor(panel)
       reclaimTerminalInputOnWindowFocusRef.current = null
-      if (!panel || !(active instanceof HTMLElement) || !panel.contains(active)) {
+      if (!panel || !isHTMLElement(active) || !panel.contains(active)) {
         return
       }
       // Why: browser webviews focus out-of-process and do not emit renderer
@@ -1675,10 +1676,10 @@ export function FloatingTerminalPanel({
       }
       reclaimTerminalInputOnWindowFocusRef.current = null
       const panel = panelRef.current
-      const active = document.activeElement
+      const active = activeElementFor(panel)
       if (
         panel &&
-        active instanceof HTMLElement &&
+        isHTMLElement(active) &&
         panel.contains(active) &&
         isFloatingWorkspaceTerminalInputTarget(active)
       ) {

--- a/src/renderer/src/components/settings/DetachedPanesExperimentalSetting.tsx
+++ b/src/renderer/src/components/settings/DetachedPanesExperimentalSetting.tsx
@@ -1,0 +1,54 @@
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import { translate } from '@/i18n/i18n'
+import { Label } from '../ui/label'
+import { SearchableSetting } from './SearchableSetting'
+import { SettingsSwitch } from './SettingsFormControls'
+
+type DetachedPanesExperimentalSettingProps = {
+  settings: GlobalSettings
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+}
+
+export function DetachedPanesExperimentalSetting({
+  settings,
+  updateSettings
+}: DetachedPanesExperimentalSettingProps): React.JSX.Element {
+  const enabled = settings.experimentalDetachedPanes === true
+
+  return (
+    <SearchableSetting
+      title={translate(
+        'components.settings.experimentalPane.detachedPanes.title',
+        'Detached Panes'
+      )}
+      description={translate(
+        'components.settings.experimentalPane.detachedPanes.description',
+        'Move a terminal tab group into its own window, for a second monitor.'
+      )}
+      keywords={['detach', 'window', 'multi-window', 'monitor', 'pane']}
+      className="space-y-3 py-2"
+      id="experimental-detached-panes"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 shrink space-y-0.5">
+          <Label>
+            {translate(
+              'components.settings.experimentalPane.detachedPanes.title',
+              'Detached Panes'
+            )}
+          </Label>
+          <p className="text-xs text-muted-foreground">
+            {translate(
+              'components.settings.experimentalPane.detachedPanes.copy',
+              'Adds "Move Group to New Window" to the tab menu for terminal-only groups. Detached windows do not yet have a native right-click menu, and paste from the Edit menu does not reach them — use the keyboard inside the terminal.'
+            )}
+          </p>
+        </div>
+        <SettingsSwitch
+          checked={enabled}
+          onChange={() => updateSettings({ experimentalDetachedPanes: !enabled })}
+        />
+      </div>
+    </SearchableSetting>
+  )
+}

--- a/src/renderer/src/components/settings/ExperimentalPane.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.tsx
@@ -10,6 +10,7 @@ import { NumberField, SettingsSwitch } from './SettingsFormControls'
 import { translate } from '@/i18n/i18n'
 import { NativeChatExperimentalSetting } from './NativeChatExperimentalSetting'
 import { AgentDashboardExperimentalSetting } from './AgentDashboardExperimentalSetting'
+import { DetachedPanesExperimentalSetting } from './DetachedPanesExperimentalSetting'
 import { EphemeralVmsExperimentalSetting } from './EphemeralVmsExperimentalSetting'
 import {
   MAX_AGENT_HIBERNATION_IDLE_MS,
@@ -139,6 +140,8 @@ export function ExperimentalPane({
       {showAgentDashboard ? (
         <AgentDashboardExperimentalSetting settings={settings} updateSettings={updateSettings} />
       ) : null}
+
+      <DetachedPanesExperimentalSetting settings={settings} updateSettings={updateSettings} />
 
       {showNativeChat ? (
         <NativeChatExperimentalSetting settings={settings} updateSettings={updateSettings} />

--- a/src/renderer/src/components/tab-bar/RecentTabSwitcher.test.tsx
+++ b/src/renderer/src/components/tab-bar/RecentTabSwitcher.test.tsx
@@ -214,4 +214,24 @@ describe('RecentTabSwitcher', () => {
       root.unmount()
     })
   })
+
+  it('preserves the main-window active-view guard for DOM Ctrl+Tab', async () => {
+    const store = makeStore()
+    store.activeView = 'settings'
+    getStateMock.mockReturnValue(store)
+    const { root } = await renderSwitcher()
+    const terminal = appendTerminalTextarea()
+
+    await dispatchKeyboard(terminal.input, 'keydown', {
+      key: 'Tab',
+      code: 'Tab',
+      ctrlKey: true
+    })
+
+    expect(document.body.querySelector('[role="listbox"]')).toBeNull()
+
+    await act(async () => {
+      root.unmount()
+    })
+  })
 })

--- a/src/renderer/src/components/tab-bar/RecentTabSwitcher.tsx
+++ b/src/renderer/src/components/tab-bar/RecentTabSwitcher.tsx
@@ -15,10 +15,19 @@ import {
   type RecentTabSwitcherItem
 } from './recent-tab-switching'
 import { translate } from '@/i18n/i18n'
+import { addEventListenerOnAllWindows } from '@/lib/aux-pane-window-registry'
+import {
+  auxiliaryTerminalShortcutTarget,
+  resolveTerminalShortcutTarget,
+  type TerminalShortcutTarget
+} from '../terminal/aux-pane-shortcut-target'
+import { isNode } from '@/lib/cross-realm-dom-predicates'
 
 type SwitcherState = {
   items: RecentTabSwitcherItem[]
   selectedIndex: number
+  portalContainer: HTMLElement
+  target: TerminalShortcutTarget | null
 }
 
 function consumeKeyboardEvent(event: KeyboardEvent): void {
@@ -54,23 +63,32 @@ export default function RecentTabSwitcher(): React.JSX.Element | null {
   }, [])
 
   const openOrAdvance = useCallback(
-    (direction: 1 | -1): void => {
+    (
+      direction: 1 | -1,
+      target: TerminalShortcutTarget | null = null,
+      portalContainer: HTMLElement = document.body
+    ): void => {
       const store = useAppStore.getState()
-      if (store.activeView !== 'terminal' || !store.activeWorktreeId) {
+      const worktreeId = target?.worktreeId ?? store.activeWorktreeId
+      if ((!target && store.activeView !== 'terminal') || !worktreeId) {
         return
       }
 
       const model = buildRecentTabSwitcherModel(
         store,
-        store.activeWorktreeId,
-        normalizeCtrlTabOrderMode(store.settings?.ctrlTabOrderMode)
+        worktreeId,
+        normalizeCtrlTabOrderMode(store.settings?.ctrlTabOrderMode),
+        target?.groupId
       )
       if (!model) {
         return
       }
 
       const current = switcherRef.current
-      const selectedKey = current?.items[current.selectedIndex]?.key ?? null
+      const sameTarget =
+        current?.target?.worktreeId === target?.worktreeId &&
+        current?.target?.groupId === target?.groupId
+      const selectedKey = sameTarget ? (current?.items[current.selectedIndex]?.key ?? null) : null
       const currentIndex =
         selectedKey == null
           ? model.activeIndex
@@ -80,7 +98,7 @@ export default function RecentTabSwitcher(): React.JSX.Element | null {
         currentIndex,
         direction
       )
-      setSwitcherState({ items: model.items, selectedIndex })
+      setSwitcherState({ items: model.items, selectedIndex, portalContainer, target })
     },
     [setSwitcherState]
   )
@@ -118,7 +136,13 @@ export default function RecentTabSwitcher(): React.JSX.Element | null {
         // CDP/test-dispatched keys can reach the renderer directly. Respect the
         // keybinding registry here too so tests do not bypass user customization.
         consumeKeyboardEvent(event)
-        openOrAdvance(event.shiftKey ? -1 : 1)
+        const target = auxiliaryTerminalShortcutTarget(
+          resolveTerminalShortcutTarget(event.target, store)
+        )
+        const portalContainer = isNode(event.target)
+          ? (event.target.ownerDocument?.body ?? document.body)
+          : document.body
+        openOrAdvance(event.shiftKey ? -1 : 1, target, portalContainer)
         return
       }
       if (!switcherRef.current) {
@@ -136,13 +160,15 @@ export default function RecentTabSwitcher(): React.JSX.Element | null {
       consumeKeyboardEvent(event)
       commit()
     }
-    window.addEventListener('keydown', onKeyDown, { capture: true })
-    window.addEventListener('keyup', onKeyUp, { capture: true })
-    window.addEventListener('blur', cancel)
+    const removeListeners = [
+      addEventListenerOnAllWindows('keydown', onKeyDown, { capture: true }),
+      addEventListenerOnAllWindows('keyup', onKeyUp, { capture: true }),
+      addEventListenerOnAllWindows('blur', cancel)
+    ]
     return () => {
-      window.removeEventListener('keydown', onKeyDown, { capture: true })
-      window.removeEventListener('keyup', onKeyUp, { capture: true })
-      window.removeEventListener('blur', cancel)
+      for (const removeListener of removeListeners) {
+        removeListener()
+      }
     }
   }, [cancel, commit, openOrAdvance])
 
@@ -186,6 +212,6 @@ export default function RecentTabSwitcher(): React.JSX.Element | null {
         </div>
       </div>
     </div>,
-    document.body
+    switcher.portalContainer
   )
 }

--- a/src/renderer/src/components/tab-bar/SortableTab.rename-shortcut.test.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.rename-shortcut.test.tsx
@@ -13,6 +13,9 @@ const storeState = vi.hoisted(
     retainedAgentsByPaneKey: Record<string, unknown>
     renamingTabId: string | null
     keybindings: Record<string, unknown>
+    detachedGroupIds: string[]
+    detachTabGroup: () => void
+    reattachTabGroup: () => void
     repos: unknown[]
     setRenamingTabId: ReturnType<typeof vi.fn>
     terminalLayoutsByTabId: Record<string, unknown>
@@ -25,6 +28,9 @@ const storeState = vi.hoisted(
     retainedAgentsByPaneKey: {},
     renamingTabId: null as string | null,
     keybindings: {},
+    detachedGroupIds: [],
+    detachTabGroup: vi.fn(),
+    reattachTabGroup: vi.fn(),
     repos: [],
     setRenamingTabId: vi.fn((tabId: string | null) => {
       storeState.renamingTabId = tabId
@@ -74,6 +80,9 @@ vi.mock('@dnd-kit/sortable', () => ({
 }))
 
 vi.mock('lucide-react', () => ({
+  ExternalLink: function ExternalLink(props: Record<string, unknown>) {
+    return { type: 'ExternalLink', props }
+  },
   ArrowDown: function ArrowDown(props: Record<string, unknown>) {
     return { type: 'ArrowDown', props }
   },

--- a/src/renderer/src/components/tab-bar/SortableTab.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.tsx
@@ -218,6 +218,7 @@ export default function SortableTab({
       ref={setNodeRef}
       data-testid="sortable-tab"
       data-tab-id={tab.id}
+      data-unified-tab-id={unifiedTabId}
       data-tab-title={tabTitle}
       data-pinned={isPinned ? 'true' : 'false'}
       // Why: DOM attribute lets E2E assert real selection state; a store-only check would miss render breaks (PR #1186 shipped in #1193).

--- a/src/renderer/src/components/tab-bar/SortableTabContextMenu.test.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTabContextMenu.test.tsx
@@ -12,6 +12,9 @@ const storeMock = vi.hoisted(() => ({
   dropUnifiedTab: vi.fn(),
   state: {
     keybindings: {},
+    detachedGroupIds: [],
+    detachTabGroup: vi.fn(),
+    reattachTabGroup: vi.fn(),
     unifiedTabsByWorktree: {},
     groupsByWorktree: {}
   } as Record<string, unknown>
@@ -50,6 +53,7 @@ vi.mock('@/components/ui/dropdown-menu', () => ({
 }))
 
 vi.mock('lucide-react', () => ({
+  ExternalLink: () => null,
   ArrowDown: () => null,
   ArrowLeft: () => null,
   ArrowRight: () => null,
@@ -152,6 +156,9 @@ beforeEach(() => {
   storeMock.dropUnifiedTab.mockReset()
   storeMock.state = {
     keybindings: {},
+    detachedGroupIds: [],
+    detachTabGroup: vi.fn(),
+    reattachTabGroup: vi.fn(),
     dropUnifiedTab: storeMock.dropUnifiedTab,
     groupsByWorktree: {
       'wt-1': [

--- a/src/renderer/src/components/tab-bar/SortableTabContextMenu.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTabContextMenu.tsx
@@ -7,7 +7,8 @@ import {
   Pencil,
   SquareTerminal,
   X,
-  ListX
+  ListX,
+  ExternalLink
 } from 'lucide-react'
 import {
   DropdownMenu,
@@ -142,6 +143,19 @@ export function SortableTabContextMenu({
   onToggleViewMode
 }: SortableTabContextMenuProps): React.JSX.Element {
   const keybindings = useAppStore((state) => state.keybindings)
+  const detachTabGroup = useAppStore((state) => state.detachTabGroup)
+  const reattachTabGroup = useAppStore((state) => state.reattachTabGroup)
+  const isGroupDetached = useAppStore((state) => state.detachedGroupIds.includes(groupId))
+  // Why: browser and editor panes still read focus from the main document, so
+  // only terminal-only groups are offered for detach until those are migrated.
+  const canDetachGroup = useAppStore((state) => {
+    if (state.settings?.experimentalDetachedPanes !== true) {
+      return false
+    }
+    const tabs = state.unifiedTabsByWorktree[tab.worktreeId] ?? []
+    const groupTabs = tabs.filter((entry) => entry.groupId === groupId)
+    return groupTabs.length > 0 && groupTabs.every((entry) => entry.contentType === 'terminal')
+  })
   const splitRightShortcut = formatShortcutLabel('terminal.splitRight', keybindings)
   const splitDownShortcut = formatShortcutLabel('terminal.splitDown', keybindings)
 
@@ -200,6 +214,27 @@ export function SortableTabContextMenu({
             ? translate('auto.components.tab.bar.SortableTabContextMenu.417722e9c2', 'Unpin Tab')
             : translate('auto.components.tab.bar.SortableTabContextMenu.60f958ec75', 'Pin Tab')}
         </DropdownMenuItem>
+        {canDetachGroup || isGroupDetached ? (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onSelect={() =>
+                isGroupDetached ? reattachTabGroup(groupId) : detachTabGroup(groupId)
+              }
+            >
+              <ExternalLink className="size-3.5" />
+              {isGroupDetached
+                ? translate(
+                    'components.tab.bar.SortableTabContextMenu.returnGroupToMainWindow',
+                    'Return Group to Main Window'
+                  )
+                : translate(
+                    'components.tab.bar.SortableTabContextMenu.moveGroupToNewWindow',
+                    'Move Group to New Window'
+                  )}
+            </DropdownMenuItem>
+          </>
+        ) : null}
         <DropdownMenuSeparator />
         <DropdownMenuItem onSelect={() => !isPinned && onClose(tab.id)} disabled={isPinned}>
           <X className="size-3.5" />

--- a/src/renderer/src/components/tab-bar/TabBarCreateEntry.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntry.tsx
@@ -39,6 +39,7 @@ import {
   EMPTY_TAB_RESULTS
 } from './tab-create-entry-empty-options'
 import type { TabBarCreateEntryProps } from './tab-create-entry-props'
+import { activeElementFor } from '@/lib/cross-realm-dom-predicates'
 
 export default function TabBarCreateEntry(props: TabBarCreateEntryProps): React.JSX.Element {
   return <TabBarCreateEntrySession key={String(props.menuOpen)} {...props} />
@@ -126,7 +127,7 @@ function TabBarCreateEntrySession({
       const firstItem = menu.querySelector(
         '[role="menuitem"]:not([data-disabled]):not([aria-disabled="true"])'
       )
-      if (firstItem && document.activeElement === firstItem) {
+      if (firstItem && activeElementFor(firstItem) === firstItem) {
         event.preventDefault()
         event.stopPropagation()
         input.focus()

--- a/src/renderer/src/components/tab-bar/recent-tab-switching.test.ts
+++ b/src/renderer/src/components/tab-bar/recent-tab-switching.test.ts
@@ -110,6 +110,30 @@ describe('buildRecentTabSwitcherModel', () => {
 
     expect(model).toBeNull()
   })
+
+  it('uses an explicitly targeted detached group instead of the main active group', () => {
+    const state = stateWithTabs(['tab-a'], ['tab-a'], 'tab-a')
+    const detachedTabs = [
+      { ...tab('detached-a', 'terminal-a', 'Detached A'), groupId: 'detached-group' },
+      { ...tab('detached-b', 'terminal-b', 'Detached B'), groupId: 'detached-group' }
+    ]
+    state.groupsByWorktree[WT].push({
+      id: 'detached-group',
+      worktreeId: WT,
+      activeTabId: 'detached-b',
+      tabOrder: ['detached-a', 'detached-b'],
+      recentTabIds: ['detached-a', 'detached-b']
+    })
+    state.unifiedTabsByWorktree[WT].push(...detachedTabs)
+    state.openFiles.push(
+      { id: 'terminal-a', worktreeId: WT } as AppState['openFiles'][number],
+      { id: 'terminal-b', worktreeId: WT } as AppState['openFiles'][number]
+    )
+
+    const model = buildRecentTabSwitcherModel(state, WT, 'mru', 'detached-group')
+
+    expect(model?.items.map((item) => item.label)).toEqual(['Detached B', 'Detached A'])
+  })
 })
 
 describe('getNextRecentTabSwitcherIndex', () => {

--- a/src/renderer/src/components/tab-bar/recent-tab-switching.ts
+++ b/src/renderer/src/components/tab-bar/recent-tab-switching.ts
@@ -152,9 +152,16 @@ function orderByMru(
 export function buildRecentTabSwitcherModel(
   state: RecentTabSwitchingState,
   worktreeId: string,
-  mode: CtrlTabOrderMode
+  mode: CtrlTabOrderMode,
+  groupId?: string
 ): RecentTabSwitcherModel | null {
-  const visibleEntries = getActiveTabNavOrder(state, worktreeId)
+  const navigationState = groupId
+    ? {
+        ...state,
+        activeGroupIdByWorktree: { ...state.activeGroupIdByWorktree, [worktreeId]: groupId }
+      }
+    : state
+  const visibleEntries = getActiveTabNavOrder(navigationState, worktreeId)
   if (visibleEntries.length <= 1) {
     return null
   }
@@ -174,8 +181,8 @@ export function buildRecentTabSwitcherModel(
       return [item.key, item] as const
     })
   )
-  const activeKey = getActiveVisibleTabKey(state, worktreeId, visibleEntries)
-  const group = findActiveGroup(state, worktreeId)
+  const activeKey = getActiveVisibleTabKey(navigationState, worktreeId, visibleEntries)
+  const group = findActiveGroup(navigationState, worktreeId)
   const orderedItems =
     mode === 'mru'
       ? orderByMru(visibleEntries, itemByKey, group, activeKey)

--- a/src/renderer/src/components/tab-bar/tab-strip-content-resize-observers.ts
+++ b/src/renderer/src/components/tab-bar/tab-strip-content-resize-observers.ts
@@ -1,3 +1,4 @@
+import { isHTMLElement } from '../../lib/cross-realm-dom-predicates'
 export function bindTabStripContentResizeObservers(
   strip: HTMLElement,
   onResize: () => void
@@ -8,7 +9,7 @@ export function bindTabStripContentResizeObservers(
     resizeObserver.disconnect()
     resizeObserver.observe(strip)
     for (const child of strip.children) {
-      if (child instanceof HTMLElement) {
+      if (isHTMLElement(child)) {
         resizeObserver.observe(child)
       }
     }

--- a/src/renderer/src/components/tab-bar/tab-title-tooltip.test.tsx
+++ b/src/renderer/src/components/tab-bar/tab-title-tooltip.test.tsx
@@ -93,8 +93,20 @@ vi.mock('@/lib/use-tab-agent', () => ({
 }))
 
 vi.mock('../../store', () => ({
-  useAppStore: (selector: (state: { unreadTerminalTabs: Record<string, boolean> }) => unknown) =>
-    selector({ unreadTerminalTabs: {} })
+  useAppStore: (
+    selector: (state: {
+      unreadTerminalTabs: Record<string, boolean>
+      detachedGroupIds: string[]
+      detachTabGroup: () => void
+      reattachTabGroup: () => void
+    }) => unknown
+  ) =>
+    selector({
+      unreadTerminalTabs: {},
+      detachedGroupIds: [],
+      detachTabGroup: () => {},
+      reattachTabGroup: () => {}
+    })
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/tab-group/AiVaultSessionDropLayer.tsx
+++ b/src/renderer/src/components/tab-group/AiVaultSessionDropLayer.tsx
@@ -23,6 +23,7 @@ import { resolveDropZone } from './tab-drop-zone'
 import type { TabDropZone } from './useTabDragSplit'
 import { translate } from '@/i18n/i18n'
 import type { AiVaultPrepareSessionResumeResult } from '../../../../shared/ai-vault-resume-preparation'
+import { isNode } from '../../lib/cross-realm-dom-predicates'
 
 type PaneDropTarget = {
   groupId: string
@@ -382,7 +383,7 @@ export default function AiVaultSessionDropLayer({
 
   const handleDragLeave = useCallback((event: React.DragEvent<HTMLDivElement>) => {
     const relatedTarget = event.relatedTarget
-    if (relatedTarget instanceof Node && event.currentTarget.contains(relatedTarget)) {
+    if (isNode(relatedTarget) && event.currentTarget.contains(relatedTarget)) {
       return
     }
     setTarget(null)

--- a/src/renderer/src/components/tab-group/DetachedTabGroupWindow.tsx
+++ b/src/renderer/src/components/tab-group/DetachedTabGroupWindow.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { openAuxPaneWindow, type AuxPaneWindow } from '@/lib/aux-pane-window'
+import {
+  registerAuxPaneContainer,
+  unregisterAuxPaneContainer
+} from '@/lib/aux-pane-window-registry'
+import { useAppStore } from '../../store'
+import { AuxWindowContainerProvider } from '../aux-window-container-context'
+
+/**
+ * Hosts a detached tab group in its own OS window.
+ *
+ * Same renderer, separate document: `children` are the ordinary pane tree, so
+ * the store, IPC and PTY delivery are untouched. Closing the window (either
+ * from here or by the user) reattaches the group to the main layout.
+ */
+export default function DetachedTabGroupWindow({
+  groupId,
+  title,
+  children
+}: {
+  groupId: string
+  title: string
+  children: React.ReactNode
+}): React.JSX.Element | null {
+  const reattachTabGroup = useAppStore((state) => state.reattachTabGroup)
+  const recordAuxWindowBounds = useAppStore((state) => state.recordAuxWindowBounds)
+  const [aux, setAux] = useState<AuxPaneWindow | null>(null)
+
+  useEffect(() => {
+    const opened = openAuxPaneWindow({
+      groupId,
+      title,
+      bounds: useAppStore.getState().auxWindowBoundsByGroupId[groupId] ?? null,
+      onClose: () => reattachTabGroup(groupId),
+      onBoundsChange: (bounds) => recordAuxWindowBounds(groupId, bounds)
+    })
+    if (!opened) {
+      // Why: a blocked open must not strand the group in limbo — put it back.
+      reattachTabGroup(groupId)
+      return
+    }
+    setAux(opened)
+    // Why: terminal panes live in a sibling overlay layer, not inside the group
+    // body — they need this container to follow the group into the window.
+    registerAuxPaneContainer(groupId, opened.container)
+    return () => {
+      setAux(null)
+      unregisterAuxPaneContainer(groupId)
+      opened.close()
+    }
+    // Why: reopening on a title change would tear down the pane's PTY view.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [groupId])
+
+  useEffect(() => {
+    if (aux) {
+      aux.window.document.title = title
+    }
+  }, [aux, title])
+
+  if (!aux) {
+    return null
+  }
+  return createPortal(
+    // Why: menus and tooltips opened inside this window must portal into it,
+    // not into the main window's document.body (Radix's default).
+    <AuxWindowContainerProvider value={aux.container}>{children}</AuxWindowContainerProvider>,
+    aux.container
+  )
+}

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.drag.test.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.drag.test.tsx
@@ -17,7 +17,9 @@ vi.mock('../../store', () => ({
   useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
     selector({
       recordFeatureInteraction: recordFeatureInteractionMock,
-      setTabGroupSplitRatio: setTabGroupSplitRatioMock
+      setTabGroupSplitRatio: setTabGroupSplitRatioMock,
+      detachedGroupIds: [],
+      unifiedTabsByWorktree: {}
     })
 }))
 

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.test.ts
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.test.ts
@@ -9,11 +9,23 @@ const useAppStoreMock = vi.fn(
     selector: (state: {
       recordFeatureInteraction: typeof recordFeatureInteractionMock
       setTabGroupSplitRatio: typeof setTabGroupSplitRatioMock
+      detachedGroupIds: string[]
+      groupsByWorktree: Record<
+        string,
+        { id: string; activeTabId: string | null; tabOrder: string[] }[]
+      >
+      unifiedTabsByWorktree: Record<
+        string,
+        { id: string; groupId: string; label: string; customLabel: string | null }[]
+      >
     }) => unknown
   ) =>
     selector({
       recordFeatureInteraction: recordFeatureInteractionMock,
-      setTabGroupSplitRatio: setTabGroupSplitRatioMock
+      setTabGroupSplitRatio: setTabGroupSplitRatioMock,
+      detachedGroupIds: [],
+      groupsByWorktree: {},
+      unifiedTabsByWorktree: {}
     })
 )
 vi.mock('../../store', () => ({
@@ -21,6 +33,15 @@ vi.mock('../../store', () => ({
     selector: (state: {
       recordFeatureInteraction: typeof recordFeatureInteractionMock
       setTabGroupSplitRatio: typeof setTabGroupSplitRatioMock
+      detachedGroupIds: string[]
+      groupsByWorktree: Record<
+        string,
+        { id: string; activeTabId: string | null; tabOrder: string[] }[]
+      >
+      unifiedTabsByWorktree: Record<
+        string,
+        { id: string; groupId: string; label: string; customLabel: string | null }[]
+      >
     }) => unknown
   ) => useAppStoreMock(selector)
 }))
@@ -46,7 +67,7 @@ vi.mock('./useTabDragSplit', () => ({
   })
 }))
 
-import TabGroupSplitLayout from './TabGroupSplitLayout'
+import TabGroupSplitLayout, { detachedTabGroupWindowTitle } from './TabGroupSplitLayout'
 
 type ReactElementLike = {
   type: string | ((props: Record<string, unknown>) => unknown)
@@ -134,6 +155,45 @@ describe('TabGroupSplitLayout', () => {
         reserveCollapsedSidebarHeaderSpace: true
       })
     )
+  })
+
+  it('uses the detached group active tab for the window title', () => {
+    const groups = [
+      {
+        id: 'group-1',
+        worktreeId: 'wt-1',
+        activeTabId: 'tab-2',
+        tabOrder: ['tab-1', 'tab-2']
+      }
+    ]
+    const tabs = [
+      {
+        id: 'tab-1',
+        entityId: 'terminal-1',
+        groupId: 'group-1',
+        worktreeId: 'wt-1',
+        contentType: 'terminal' as const,
+        label: 'First',
+        customLabel: null,
+        color: null,
+        sortOrder: 0,
+        createdAt: 1
+      },
+      {
+        id: 'tab-2',
+        entityId: 'terminal-2',
+        groupId: 'group-1',
+        worktreeId: 'wt-1',
+        contentType: 'terminal' as const,
+        label: 'Second',
+        customLabel: 'Active title',
+        color: null,
+        sortOrder: 1,
+        createdAt: 2
+      }
+    ]
+
+    expect(detachedTabGroupWindowTitle('group-1', groups, tabs)).toBe('Active title')
   })
 
   it('wires the split layout root to drag cleanup ownership', () => {

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { DndContext, DragOverlay } from '@dnd-kit/core'
-import type { TabGroupLayoutNode } from '../../../../shared/tab-types'
+import type { Tab, TabGroup, TabGroupLayoutNode } from '../../../../shared/tab-types'
 import { useAppStore } from '../../store'
 import TabGroupPanel from './TabGroupPanel'
+import DetachedTabGroupWindow from './DetachedTabGroupWindow'
 import TabDragPreview from '../tab-bar/TabDragPreview'
 import { TabDragProvider } from './tab-drag-context'
 import TabPaneColumnSplitDragOverlay from './TabPaneColumnSplitDragOverlay'
@@ -10,6 +11,17 @@ import { type HoveredTabInsertion, useTabDragSplit } from './useTabDragSplit'
 
 const MIN_RATIO = 0.15
 const MAX_RATIO = 0.85
+
+export function detachedTabGroupWindowTitle(
+  groupId: string,
+  groups: readonly TabGroup[],
+  tabs: readonly Tab[]
+): string {
+  const group = groups.find((candidate) => candidate.id === groupId)
+  const titleTabId = group?.activeTabId ?? group?.tabOrder[0]
+  const titleTab = tabs.find((tab) => tab.id === titleTabId && tab.groupId === groupId)
+  return titleTab?.customLabel ?? titleTab?.label ?? 'Orca'
+}
 
 function ResizeHandle({
   direction,
@@ -141,6 +153,16 @@ function ResizeHandle({
   )
 }
 
+/** True when every leaf under `node` is detached, so it renders no DOM here. */
+function isNodeDetached(node: TabGroupLayoutNode, detachedGroupIds: string[]): boolean {
+  if (node.type === 'leaf') {
+    return detachedGroupIds.includes(node.groupId)
+  }
+  return (
+    isNodeDetached(node.first, detachedGroupIds) && isNodeDetached(node.second, detachedGroupIds)
+  )
+}
+
 function SplitNode({
   node,
   nodePath,
@@ -176,9 +198,22 @@ function SplitNode({
 }): React.JSX.Element {
   const setTabGroupSplitRatio = useAppStore((state) => state.setTabGroupSplitRatio)
   const recordFeatureInteraction = useAppStore((state) => state.recordFeatureInteraction)
+  const leafGroupId = node.type === 'leaf' ? node.groupId : null
+  const detachedGroupIds = useAppStore((state) => state.detachedGroupIds)
+  const isDetached = leafGroupId !== null && detachedGroupIds.includes(leafGroupId)
+  const detachedWindowTitle = useAppStore((state) => {
+    if (leafGroupId === null) {
+      return 'Orca'
+    }
+    return detachedTabGroupWindowTitle(
+      leafGroupId,
+      state.groupsByWorktree[worktreeId] ?? [],
+      state.unifiedTabsByWorktree[worktreeId] ?? []
+    )
+  })
 
   if (node.type === 'leaf') {
-    return (
+    const panel = (
       <TabGroupPanel
         groupId={node.groupId}
         worktreeId={worktreeId}
@@ -203,10 +238,27 @@ function SplitNode({
         }
       />
     )
+    if (isDetached) {
+      // Why: the pane keeps its place in the layout tree while it lives in the
+      // aux window, so reattaching is a no-op for every sibling and the PTY
+      // view is never unmounted.
+      return (
+        <DetachedTabGroupWindow groupId={node.groupId} title={detachedWindowTitle}>
+          {panel}
+        </DetachedTabGroupWindow>
+      )
+    }
+    return panel
   }
 
   const isHorizontal = node.direction === 'horizontal'
-  const ratio = node.ratio ?? 0.5
+  const rawRatio = node.ratio ?? 0.5
+  // Why: a detached child renders through a portal, so it contributes no DOM
+  // here. Its flex wrapper would still reserve its share and leave a permanent
+  // blank rectangle, so collapse it and give the space to the sibling.
+  const firstDetached = isNodeDetached(node.first, detachedGroupIds)
+  const secondDetached = isNodeDetached(node.second, detachedGroupIds)
+  const ratio = firstDetached ? 0 : secondDetached ? 1 : rawRatio
 
   return (
     <div
@@ -234,11 +286,13 @@ function SplitNode({
           hoveredTabInsertion={hoveredTabInsertion}
         />
       </div>
-      <ResizeHandle
-        direction={node.direction}
-        onResizeStart={() => recordFeatureInteraction('terminal-panes')}
-        onRatioChange={(nextRatio) => setTabGroupSplitRatio(worktreeId, nodePath, nextRatio)}
-      />
+      {firstDetached || secondDetached ? null : (
+        <ResizeHandle
+          direction={node.direction}
+          onResizeStart={() => recordFeatureInteraction('terminal-panes')}
+          onRatioChange={(nextRatio) => setTabGroupSplitRatio(worktreeId, nodePath, nextRatio)}
+        />
+      )}
       <div className="flex min-w-0 min-h-0 overflow-hidden" style={{ flex: `${1 - ratio} 1 0%` }}>
         <SplitNode
           node={node.second}

--- a/src/renderer/src/components/tab-group/tab-drag-pointer-sensor.ts
+++ b/src/renderer/src/components/tab-group/tab-drag-pointer-sensor.ts
@@ -7,6 +7,7 @@ import type {
   SensorInstance,
   SensorProps
 } from '@dnd-kit/core'
+import { isNode } from '../../lib/cross-realm-dom-predicates'
 
 type PointerCoordinates = { x: number; y: number }
 
@@ -62,7 +63,7 @@ function getOwnerDocument(target: EventTarget | null): Document {
   if (target instanceof Document) {
     return target
   }
-  if (target instanceof Node) {
+  if (isNode(target)) {
     return target.ownerDocument ?? document
   }
   return document

--- a/src/renderer/src/components/terminal-pane/MobileDriverOverlay.tsx
+++ b/src/renderer/src/components/terminal-pane/MobileDriverOverlay.tsx
@@ -9,6 +9,7 @@ import {
   getMobileDriverOverlayCollapseState
 } from './mobile-driver-overlay-collapse'
 import { translate } from '@/i18n/i18n'
+import { activeElementFor } from '@/lib/cross-realm-dom-predicates'
 
 type Props = {
   driver: DriverState
@@ -218,7 +219,8 @@ function LoudOverlay({
   // the next Space/Enter into Take back / Restore. See PR #1899 follow-up.
   useEffect(() => {
     const paneScope = rootRef.current?.parentElement
-    if (shouldFocusMobileDriverAction(document.activeElement, document.body, paneScope)) {
+    const paneDocument = paneScope?.ownerDocument ?? document
+    if (shouldFocusMobileDriverAction(activeElementFor(paneScope), paneDocument.body, paneScope)) {
       actionRef.current?.focus()
     }
   }, [])

--- a/src/renderer/src/components/terminal-pane/PinnedTabCloseDialog.tsx
+++ b/src/renderer/src/components/terminal-pane/PinnedTabCloseDialog.tsx
@@ -12,6 +12,7 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { Label } from '@/components/ui/label'
 import { useAppStore } from '@/store'
 import { translate } from '@/i18n/i18n'
+import { AuxWindowContainerProvider } from '@/components/aux-window-container-context'
 
 /** Confirmation prompt shown when a pinned tab is about to be closed. Driven by
  *  store state so every close path (keyboard, native menu, CLI) can route a
@@ -44,56 +45,58 @@ export default function PinnedTabCloseDialog(): React.JSX.Element {
   }
 
   return (
-    <Dialog
-      open={request !== null}
-      onOpenChange={(isOpen) => {
-        if (!isOpen) {
-          dismissPinnedTabClose()
-        }
-      }}
-    >
-      <DialogContent className="max-w-sm" showCloseButton={false}>
-        <DialogHeader>
-          <DialogTitle className="text-sm">
-            {translate(
-              'auto.components.terminal.pane.PinnedTabCloseDialog.6c190f295a',
-              'Close pinned tab?'
-            )}
-          </DialogTitle>
-          <DialogDescription className="text-xs">
-            {translate(
-              'auto.components.terminal.pane.PinnedTabCloseDialog.0d1963f4a6',
-              'This tab is pinned. Are you sure you want to close it?'
-            )}
-          </DialogDescription>
-        </DialogHeader>
-        {tabLabel ? (
-          <p className="truncate text-xs font-medium text-foreground" title={tabLabel}>
-            {tabLabel}
-          </p>
-        ) : null}
-        <div className="flex items-center gap-2">
-          <Checkbox
-            id={checkboxId}
-            checked={dontAskAgain}
-            onCheckedChange={(checked) => setDontAskAgain(checked === true)}
-          />
-          <Label htmlFor={checkboxId} className="text-xs font-normal text-muted-foreground">
-            {translate(
-              'auto.components.terminal.pane.PinnedTabCloseDialog.dont_ask_again',
-              "Don't ask again for pinned tabs"
-            )}
-          </Label>
-        </div>
-        <DialogFooter className="gap-2">
-          <Button type="button" variant="outline" size="sm" onClick={dismissPinnedTabClose}>
-            {translate('auto.components.terminal.pane.PinnedTabCloseDialog.0b38ee2f86', 'Cancel')}
-          </Button>
-          <Button type="button" variant="destructive" size="sm" autoFocus onClick={handleConfirm}>
-            {translate('auto.components.terminal.pane.PinnedTabCloseDialog.c337c9d75c', 'Close')}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+    <AuxWindowContainerProvider value={request?.dialogContainer ?? null}>
+      <Dialog
+        open={request !== null}
+        onOpenChange={(isOpen) => {
+          if (!isOpen) {
+            dismissPinnedTabClose()
+          }
+        }}
+      >
+        <DialogContent className="max-w-sm" showCloseButton={false}>
+          <DialogHeader>
+            <DialogTitle className="text-sm">
+              {translate(
+                'auto.components.terminal.pane.PinnedTabCloseDialog.6c190f295a',
+                'Close pinned tab?'
+              )}
+            </DialogTitle>
+            <DialogDescription className="text-xs">
+              {translate(
+                'auto.components.terminal.pane.PinnedTabCloseDialog.0d1963f4a6',
+                'This tab is pinned. Are you sure you want to close it?'
+              )}
+            </DialogDescription>
+          </DialogHeader>
+          {tabLabel ? (
+            <p className="truncate text-xs font-medium text-foreground" title={tabLabel}>
+              {tabLabel}
+            </p>
+          ) : null}
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id={checkboxId}
+              checked={dontAskAgain}
+              onCheckedChange={(checked) => setDontAskAgain(checked === true)}
+            />
+            <Label htmlFor={checkboxId} className="text-xs font-normal text-muted-foreground">
+              {translate(
+                'auto.components.terminal.pane.PinnedTabCloseDialog.dont_ask_again',
+                "Don't ask again for pinned tabs"
+              )}
+            </Label>
+          </div>
+          <DialogFooter className="gap-2">
+            <Button type="button" variant="outline" size="sm" onClick={dismissPinnedTabClose}>
+              {translate('auto.components.terminal.pane.PinnedTabCloseDialog.0b38ee2f86', 'Cancel')}
+            </Button>
+            <Button type="button" variant="destructive" size="sm" autoFocus onClick={handleConfirm}>
+              {translate('auto.components.terminal.pane.PinnedTabCloseDialog.c337c9d75c', 'Close')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </AuxWindowContainerProvider>
   )
 }

--- a/src/renderer/src/components/terminal-pane/RunningTerminalCloseDialog.tsx
+++ b/src/renderer/src/components/terminal-pane/RunningTerminalCloseDialog.tsx
@@ -1,6 +1,7 @@
 import { useAppStore } from '@/store'
 import { useRunningTerminalCloseConfirmStore } from '@/store/running-terminal-close-confirm'
 import CloseTerminalDialog from './CloseTerminalDialog'
+import { AuxWindowContainerProvider } from '@/components/aux-window-container-context'
 
 /** Hosts the running-process close confirmation for tab-level closes (tab-strip X,
  *  middle-click, tab menu, tab groups, floating panel) so they share the prompt Cmd+W
@@ -23,23 +24,25 @@ export default function RunningTerminalCloseDialog(): React.JSX.Element {
   const pinnedRequest = useAppStore((state) => state.pinnedTabCloseConfirm)
 
   return (
-    <CloseTerminalDialog
-      open={request !== null && pinnedRequest === null}
-      copyKind={request?.copyKind ?? 'command'}
-      {...(request?.tabLabel ? { tabLabel: request.tabLabel } : {})}
-      // Why: a queued request swaps tabs in the already-open dialog, so the reopen reset
-      // never runs; naming the subject is what clears the previous tab's opt-out tick.
-      {...(request ? { subjectKey: request.terminalTabId } : {})}
-      onCancel={dismissClose}
-      onConfirm={(dontAskAgain) => {
-        if (dontAskAgain) {
-          void updateSettings({ skipCloseTerminalWithRunningProcessConfirm: true })
-          // Why: the user just opted out of this prompt; a queued one must not still appear.
-          confirmAllCloses()
-          return
-        }
-        confirmClose()
-      }}
-    />
+    <AuxWindowContainerProvider value={request?.dialogContainer ?? null}>
+      <CloseTerminalDialog
+        open={request !== null && pinnedRequest === null}
+        copyKind={request?.copyKind ?? 'command'}
+        {...(request?.tabLabel ? { tabLabel: request.tabLabel } : {})}
+        // Why: a queued request swaps tabs in the already-open dialog, so the reopen reset
+        // never runs; naming the subject is what clears the previous tab's opt-out tick.
+        {...(request ? { subjectKey: request.terminalTabId } : {})}
+        onCancel={dismissClose}
+        onConfirm={(dontAskAgain) => {
+          if (dontAskAgain) {
+            void updateSettings({ skipCloseTerminalWithRunningProcessConfirm: true })
+            // Why: the user just opted out of this prompt; a queued one must not still appear.
+            confirmAllCloses()
+            return
+          }
+          confirmClose()
+        }}
+      />
+    </AuxWindowContainerProvider>
   )
 }

--- a/src/renderer/src/components/terminal-pane/TerminalOverlaySlot.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalOverlaySlot.tsx
@@ -1,12 +1,27 @@
-import { memo, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import {
+  memo,
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore
+} from 'react'
 import { createPortal } from 'react-dom'
 import { useAppStore } from '../../store'
 import { SYNC_FIT_PANES_EVENT } from '@/constants/terminal'
 import { tabGroupBodyAnchorName } from '../tab-group/tab-group-body-anchor'
+import {
+  getAuxPaneContainer,
+  getAuxPaneContainerForDocument,
+  subscribeToAuxPaneContainers
+} from '@/lib/aux-pane-window-registry'
 import type { ActivityTerminalPortalTarget } from '../activity/activity-terminal-portal'
 import TerminalPane from './TerminalPane'
 import { closeTerminalTab } from '../terminal/terminal-tab-actions'
 import { shouldDeferParkedPtyExitTabClose } from './terminal-parked-tab-watchers'
+import { AuxWindowContainerProvider } from '../aux-window-container-context'
+import { getTerminalShortcutPaneRefCallback } from '../terminal/aux-pane-shortcut-target'
 
 const HAS_CSS_ANCHOR_POSITIONING =
   typeof CSS !== 'undefined' &&
@@ -63,6 +78,9 @@ export const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
   leaveWorktreeIfEmpty
 }: TerminalOverlaySlotProps): React.JSX.Element {
   const anchorName = groupId !== undefined ? tabGroupBodyAnchorName(groupId) : undefined
+  const auxContainer = useSyncExternalStore(subscribeToAuxPaneContainers, () =>
+    getAuxPaneContainer(groupId)
+  )
   const overlayRef = useRef<HTMLDivElement | null>(null)
   const [measuredFallbackRect, setMeasuredFallbackRect] = useState<MeasuredFallbackRect | null>(
     null
@@ -81,7 +99,9 @@ export const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
     }
 
     const findBody = (): HTMLElement | null => {
-      for (const candidate of document.querySelectorAll<HTMLElement>('[data-tab-group-body-id]')) {
+      // Why: a detached group's body lives in the aux window's document.
+      const scope = auxContainer?.ownerDocument ?? document
+      for (const candidate of scope.querySelectorAll<HTMLElement>('[data-tab-group-body-id]')) {
         if (candidate.dataset.tabGroupBodyId === groupId) {
           return candidate
         }
@@ -132,7 +152,7 @@ export const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
       resizeObserver.disconnect()
       window.removeEventListener('resize', updateRect)
     }
-  }, [anchorName, groupId, isVisible])
+  }, [anchorName, auxContainer, groupId, isVisible])
 
   useLayoutEffect(() => {
     if (!isVisible || !anchorName) {
@@ -214,42 +234,56 @@ export const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
     }
   }, [groupId, onFocusOwningGroup])
 
+  const portalOwnerDocument = activityTerminalPortal?.target.ownerDocument
+  const paneAuxContainer = portalOwnerDocument
+    ? getAuxPaneContainerForDocument(portalOwnerDocument)
+    : auxContainer
+  const preserveOpenerSelection = paneAuxContainer !== null
   const terminalPane = (
-    <TerminalPane
-      key={`${terminalTabId}-${terminalGeneration ?? 0}`}
-      tabId={terminalTabId}
-      worktreeId={worktreeId}
-      cwd={startupCwd ?? worktreePath}
-      isActive={isActive || activityTerminalPortal?.active === true}
-      // Why: split-group changes reparent TabGroupPanel subtrees. Keeping the
-      // TerminalPane mounted here preserves alt-screen TUI state while this
-      // flag still lets hidden tabs throttle rendering.
-      isVisible={isVisible || activityTerminalPortal !== null}
-      isWorktreeActive={isWorktreeActive || activityTerminalPortal !== null}
-      isolatedPaneKey={activityTerminalPortal?.paneKey ?? null}
-      onPtyExit={(ptyId) => {
-        if (consumeSuppressedPtyExit(ptyId)) {
-          return
-        }
-        // Why: a parked multi-leaf tab has no PaneManager to promote split
-        // siblings, so closing the tab here would kill them; the reveal
-        // remount handles dead PTYs per leaf instead.
-        if (shouldDeferParkedPtyExitTabClose(terminalTabId, ptyId)) {
-          return
-        }
-        closeTerminalTab(terminalTabId, {
-          reason: 'pty-exit',
-          lifecyclePtyId: ptyId,
-          onClosed: leaveWorktreeIfEmpty
-        })
-      }}
-      onCloseTab={() => {
-        // Why: route through closeTerminalTab (not the raw store closeTab) so a
-        // pinned tab hits the confirmation guard. The overlay's direct
-        // store.closeTab was the path that closed pinned terminals silently.
-        closeTerminalTab(terminalTabId, { onClosed: leaveWorktreeIfEmpty })
-      }}
-    />
+    <AuxWindowContainerProvider value={paneAuxContainer}>
+      <TerminalPane
+        ref={getTerminalShortcutPaneRefCallback(terminalTabId)}
+        key={`${terminalTabId}-${terminalGeneration ?? 0}`}
+        tabId={terminalTabId}
+        worktreeId={worktreeId}
+        cwd={startupCwd ?? worktreePath}
+        isActive={isActive || activityTerminalPortal?.active === true}
+        // Why: split-group changes reparent TabGroupPanel subtrees. Keeping the
+        // TerminalPane mounted here preserves alt-screen TUI state while this
+        // flag still lets hidden tabs throttle rendering.
+        isVisible={isVisible || activityTerminalPortal !== null}
+        isWorktreeActive={isWorktreeActive || activityTerminalPortal !== null}
+        isolatedPaneKey={activityTerminalPortal?.paneKey ?? null}
+        onPtyExit={(ptyId) => {
+          if (consumeSuppressedPtyExit(ptyId)) {
+            return
+          }
+          // Why: a parked multi-leaf tab has no PaneManager to promote split
+          // siblings, so closing the tab here would kill them; the reveal
+          // remount handles dead PTYs per leaf instead.
+          if (shouldDeferParkedPtyExitTabClose(terminalTabId, ptyId)) {
+            return
+          }
+          closeTerminalTab(terminalTabId, {
+            reason: 'pty-exit',
+            lifecyclePtyId: ptyId,
+            ...(preserveOpenerSelection ? {} : { onClosed: leaveWorktreeIfEmpty }),
+            dialogContainer: paneAuxContainer,
+            preserveOpenerSelection
+          })
+        }}
+        onCloseTab={() => {
+          // Why: route through closeTerminalTab (not the raw store closeTab) so a
+          // pinned tab hits the confirmation guard. The overlay's direct
+          // store.closeTab was the path that closed pinned terminals silently.
+          closeTerminalTab(terminalTabId, {
+            ...(preserveOpenerSelection ? {} : { onClosed: leaveWorktreeIfEmpty }),
+            dialogContainer: paneAuxContainer,
+            preserveOpenerSelection
+          })
+        }}
+      />
+    </AuxWindowContainerProvider>
   )
 
   if (activityTerminalPortal) {
@@ -260,7 +294,7 @@ export const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
     )
   }
 
-  return (
+  const overlay = (
     <div
       ref={overlayRef}
       style={style}
@@ -274,4 +308,11 @@ export const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
           floating overlay. */}
     </div>
   )
+
+  // Why: the pane must share a document with its group body — CSS anchor
+  // positioning cannot reach across windows.
+  if (auxContainer) {
+    return createPortal(overlay, auxContainer, `aux-terminal-${terminalTabId}`)
+  }
+  return overlay
 })

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -206,7 +206,7 @@ import {
 const NATIVE_CHAT_ROOT_SELECTOR = '[data-native-chat-root="true"]'
 
 function isInsideNativeChatRoot(target: EventTarget | null): boolean {
-  return target instanceof Element && target.closest(NATIVE_CHAT_ROOT_SELECTOR) !== null
+  return isElement(target) && target.closest(NATIVE_CHAT_ROOT_SELECTOR) !== null
 }
 
 // Why: registry lives in a leaf module to break the slice → TerminalPane → store → slice import cycle that leaves createTerminalSlice undefined at init.
@@ -248,6 +248,12 @@ import {
 } from './regular-terminal-focus-ownership'
 import { useTerminalQuickCommandHosts } from '@/hooks/use-terminal-quick-command-hosts'
 import { refreshTerminalImeInputContext } from './terminal-ime-input-context-refresh'
+import {
+  activeElementFor,
+  isElement,
+  isHTMLElement,
+  isNode
+} from '../../lib/cross-realm-dom-predicates'
 
 type TerminalPaneProps = {
   tabId: string
@@ -1515,7 +1521,7 @@ function TerminalPane(
     if (!applied) {
       restoreExpandedLayoutFrom(snapshots)
       const root = containerRef.current?.firstElementChild
-      if (root instanceof HTMLElement) {
+      if (isHTMLElement(root)) {
         // Why: Activity requested an exact pane; if it can't be resolved, fail closed rather than show the whole split terminal.
         snapshots.set(root, { display: root.style.display, flex: root.style.flex })
         root.style.display = 'none'
@@ -1823,7 +1829,7 @@ function TerminalPane(
     const onPointerDown = (event: PointerEvent): void => {
       releaseTerminalFocusForOutsidePointerDown({
         container,
-        activeElement: document.activeElement,
+        activeElement: activeElementFor(container),
         pointerTarget: event.target,
         syncFocused
       })
@@ -1832,7 +1838,7 @@ function TerminalPane(
       // Why: webview/browser handoff keeps the helper textarea focused, so clear only the main-process mirror and let guest focus proceed.
       releasedHelperOnWindowBlur = releaseTerminalFocusForWindowBlur({
         container,
-        activeElement: document.activeElement,
+        activeElement: activeElementFor(container),
         syncFocused
       })
     }
@@ -1841,7 +1847,7 @@ function TerminalPane(
       if (
         resyncTerminalFocusForWindowFocus({
           container,
-          activeElement: document.activeElement,
+          activeElement: activeElementFor(container),
           syncFocused,
           releasedHelper: releasedHelperOnWindowBlur
         })
@@ -1850,10 +1856,8 @@ function TerminalPane(
       }
     }
 
-    if (
-      isXtermHelperTextarea(document.activeElement) &&
-      container.contains(document.activeElement)
-    ) {
+    const activeInPaneDocument = activeElementFor(container)
+    if (isXtermHelperTextarea(activeInPaneDocument) && container.contains(activeInPaneDocument)) {
       syncFocused(true)
     }
     container.addEventListener('focusin', onFocusIn)
@@ -2002,7 +2006,7 @@ function TerminalPane(
         useAppStore.getState(),
         worktreeId
       )
-      const activeElementAtDispatch = document.activeElement
+      const activeElementAtDispatch = activeElementFor(container)
       void pasteTerminalClipboard({
         readClipboardText,
         saveClipboardImageAsTempFile: window.api.ui.saveClipboardImageAsTempFile,
@@ -2032,7 +2036,7 @@ function TerminalPane(
     const onKeyPaste = (e: KeyboardEvent): void => {
       const target = e.target
       if (
-        (target instanceof Element && target.closest('[data-terminal-search-root]')) ||
+        (isElement(target) && target.closest('[data-terminal-search-root]')) ||
         isInsideNativeChatRoot(target)
       ) {
         return
@@ -2090,7 +2094,7 @@ function TerminalPane(
     const onPaste = (e: ClipboardEvent): void => {
       const target = e.target
       if (
-        (target instanceof Element && target.closest('[data-terminal-search-root]')) ||
+        (isElement(target) && target.closest('[data-terminal-search-root]')) ||
         isInsideNativeChatRoot(target)
       ) {
         return
@@ -2126,9 +2130,9 @@ function TerminalPane(
     }
 
     const onAppMenuPaste = (event: Event): void => {
-      const activeElementAtDispatch = document.activeElement
+      const activeElementAtDispatch = activeElementFor(container)
       if (
-        !(activeElementAtDispatch instanceof Element) ||
+        !isElement(activeElementAtDispatch) ||
         !container.contains(activeElementAtDispatch) ||
         activeElementAtDispatch.closest('[data-terminal-search-root]') ||
         isInsideNativeChatRoot(activeElementAtDispatch)
@@ -2167,9 +2171,9 @@ function TerminalPane(
     }
 
     const onAppMenuSelectionAction = (event: Event): void => {
-      const activeElement = document.activeElement
+      const activeElement = activeElementFor(container)
       if (
-        !(activeElement instanceof Element) ||
+        !isElement(activeElement) ||
         !container.contains(activeElement) ||
         isEditableTarget(activeElement) ||
         activeElement.closest('[data-terminal-search-root]') ||
@@ -2225,8 +2229,9 @@ function TerminalPane(
     const onPointerDown = (event: PointerEvent): void => {
       clearTerminalTabUnread(tabId)
       clearWorktreeUnread(worktreeId)
-      const paneElement =
-        event.target instanceof Element ? event.target.closest('.pane[data-leaf-id]') : null
+      const paneElement = isElement(event.target)
+        ? event.target.closest('.pane[data-leaf-id]')
+        : null
       const leafId = paneElement?.getAttribute('data-leaf-id')
       if (leafId) {
         clearTerminalPaneUnread(makePaneKey(tabId, leafId))
@@ -2409,7 +2414,7 @@ function TerminalPane(
     const markPointerBlurIntent = (event: PointerEvent): void => {
       const input = renameInputRef.current
       const target = event.target
-      if (input && target instanceof Node && input.contains(target)) {
+      if (input && isNode(target) && input.contains(target)) {
         return
       }
       renameUserRequestedBlurCommitRef.current = true
@@ -2523,7 +2528,7 @@ function TerminalPane(
           renameSessionIdRef.current === sessionId &&
           renamingPaneId === paneId &&
           renameInputRef.current === input &&
-          document.activeElement === input
+          activeElementFor(input) === input
         ) {
           renameBlurCommitEnabledRef.current = true
         }
@@ -2668,7 +2673,7 @@ function TerminalPane(
 
   const terminalShouldHandleMiddleClick = useCallback(
     (target: EventTarget | null): target is Node => {
-      if (!(target instanceof Element)) {
+      if (!isElement(target)) {
         return false
       }
       if (target.closest('[data-terminal-search-root]')) {

--- a/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.tsx
@@ -22,6 +22,7 @@ const EMPTY_TERMINAL_TABS: readonly TerminalTab[] = []
 const EMPTY_UNIFIED_TABS: readonly Tab[] = []
 const EMPTY_GROUPS: readonly TabGroup[] = []
 const EMPTY_ACTIVITY_PORTALS: ActivityTerminalPortalTarget[] = []
+const EMPTY_DETACHED_GROUP_IDS: readonly string[] = []
 
 const TerminalPaneOverlayLayer = memo(function TerminalPaneOverlayLayer({
   worktreeId,
@@ -47,12 +48,13 @@ const TerminalPaneOverlayLayer = memo(function TerminalPaneOverlayLayer({
   /** Cold-activation deferred tabs receive immediate parked watcher coverage. */
   activationDeferredMountTabIds?: ReadonlySet<string> | null
 }): React.JSX.Element | null {
-  const { terminalTabs, unifiedTabs, groups, activeGroupId } = useAppStore(
+  const { terminalTabs, unifiedTabs, groups, activeGroupId, detachedGroupIds } = useAppStore(
     useShallow((state) => ({
       terminalTabs: state.tabsByWorktree[worktreeId] ?? EMPTY_TERMINAL_TABS,
       unifiedTabs: state.unifiedTabsByWorktree[worktreeId] ?? EMPTY_UNIFIED_TABS,
       groups: state.groupsByWorktree[worktreeId] ?? EMPTY_GROUPS,
-      activeGroupId: state.activeGroupIdByWorktree[worktreeId]
+      activeGroupId: state.activeGroupIdByWorktree[worktreeId],
+      detachedGroupIds: state.detachedGroupIds ?? EMPTY_DETACHED_GROUP_IDS
     }))
   )
   const focusGroup = useAppStore((state) => state.focusGroup)
@@ -112,12 +114,15 @@ const TerminalPaneOverlayLayer = memo(function TerminalPaneOverlayLayer({
     }
     return null
   }, [activeGroupId, assignments])
+  const hasDetachedGroup = detachedGroupIds.some((groupId) =>
+    groups.some((group) => group.id === groupId)
+  )
 
   const parkedTerminalTabIds = useTerminalTabColdParking({
     worktreeId,
     terminalTabs,
     assignments,
-    isWorktreeActive,
+    isWorktreeActive: isWorktreeActive || hasDetachedGroup,
     activeTerminalTabId,
     coldParkTerminalPanes,
     isForceParked,
@@ -138,8 +143,11 @@ const TerminalPaneOverlayLayer = memo(function TerminalPaneOverlayLayer({
         )
         .map((terminalTab) => {
           const assignment = assignments.get(terminalTab.id)
-          const isVisible = Boolean(isWorktreeActive && assignment?.isActiveInGroup)
-          const isActive = Boolean(isVisible && assignment?.groupId === activeGroupId)
+          const isDetached = Boolean(assignment && detachedGroupIds.includes(assignment.groupId))
+          const isVisible = Boolean(assignment?.isActiveInGroup && (isWorktreeActive || isDetached))
+          const isActive = Boolean(
+            isVisible && (isDetached || assignment?.groupId === activeGroupId)
+          )
           const activityTerminalPortal = findActivityTerminalPortal(activityTerminalPortals, {
             worktreeId,
             tabId: terminalTab.id
@@ -156,7 +164,7 @@ const TerminalPaneOverlayLayer = memo(function TerminalPaneOverlayLayer({
               worktreePath={worktreePath}
               startupCwd={terminalTab.startupCwd}
               groupId={assignment?.groupId}
-              isWorktreeActive={isWorktreeActive}
+              isWorktreeActive={isWorktreeActive || isDetached}
               isVisible={isVisible}
               isActive={isActive}
               activityTerminalPortal={activityTerminalPortal}

--- a/src/renderer/src/components/terminal-pane/expand-collapse.ts
+++ b/src/renderer/src/components/terminal-pane/expand-collapse.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import { safeFit } from '@/lib/pane-manager/pane-tree-ops'
+import { isHTMLElement } from '../../lib/cross-realm-dom-predicates'
 
 type ExpandCollapseState = {
   expandedPaneIdRef: React.MutableRefObject<number | null>
@@ -64,7 +65,7 @@ export function applyExpandedLayoutTo(
       break
     }
     for (const child of Array.from(parent.children)) {
-      if (!(child instanceof HTMLElement)) {
+      if (!isHTMLElement(child)) {
         continue
       }
       rememberPaneStyle(snapshots, child)

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines -- Why: terminal keyboard routing keeps shortcut
  * precedence in one ordered handler so shell input, pane commands, search, and
  * split actions do not race across separate window listeners. */
-import { useEffect } from 'react'
+import { useLayoutEffect } from 'react'
 import type { IDisposable } from '@xterm/xterm'
 import type { ManagedPane, PaneManager } from '@/lib/pane-manager/pane-manager'
 import type { PtyTransport } from './pty-transport'
@@ -56,6 +56,8 @@ import {
   markTerminalPinnedViewport,
   syncTerminalScrollIntentFromViewport
 } from '@/lib/pane-manager/terminal-scroll-intent'
+import { isHTMLElement, isInputEvent } from '../../lib/cross-realm-dom-predicates'
+import { addEventListenerOnAllWindows } from '@/lib/aux-pane-window-registry'
 
 export function resolveTerminalKeyboardShortcutAction(
   event: Parameters<typeof resolveTerminalShortcutAction>[0],
@@ -105,7 +107,7 @@ export function recordKeyboardCreatedTerminalPaneSplit(
 const MAX_OBSERVED_ENTER_KEYDOWNS_PER_CODE = 8
 
 function isEditableTarget(target: EventTarget | null): boolean {
-  if (!(target instanceof HTMLElement)) {
+  if (!isHTMLElement(target)) {
     return false
   }
 
@@ -266,7 +268,7 @@ export function useTerminalKeyboardShortcuts({
   keybindings,
   terminalShortcutPolicy = 'orca-first'
 }: KeyboardHandlersDeps): void {
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!isActive) {
       return
     }
@@ -971,7 +973,7 @@ export function useTerminalKeyboardShortcuts({
     // Why: modern Chromium can skip keypress and insert via beforeinput; block
     // only this chord's text so an IME commit in the same window remains intact.
     const onNativeOnlyBeforeInput = (e: Event): void => {
-      if (!(e instanceof InputEvent) || !nativeOnlyShortcutTracker.shouldSuppressBeforeInput(e)) {
+      if (!isInputEvent(e) || !nativeOnlyShortcutTracker.shouldSuppressBeforeInput(e)) {
         return
       }
       e.preventDefault()
@@ -989,25 +991,26 @@ export function useTerminalKeyboardShortcuts({
       observedEnterKeydownTimeStamps.clear()
     }
 
-    window.addEventListener('keydown', onModifierDown, { capture: true })
-    window.addEventListener('keyup', onKeyUp, { capture: true })
-    window.addEventListener('keydown', onKeyDown, { capture: true })
-    window.addEventListener('keypress', onNativeOnlyShortcutCompanion, { capture: true })
-    window.addEventListener('keyup', onNativeOnlyShortcutCompanion, { capture: true })
-    window.addEventListener('beforeinput', onNativeOnlyBeforeInput, { capture: true })
-    window.addEventListener('blur', onNativeOnlyBlur)
+    // Why: a detached pane's keystrokes land in another window's document, and
+    // DOM events do not cross documents — binding only the opener leaves every
+    // terminal shortcut dead inside a detached window.
+    const disposers = [
+      addEventListenerOnAllWindows('keydown', onModifierDown, { capture: true }),
+      addEventListenerOnAllWindows('keyup', onKeyUp, { capture: true }),
+      addEventListenerOnAllWindows('keydown', onKeyDown, { capture: true }),
+      addEventListenerOnAllWindows('keypress', onNativeOnlyShortcutCompanion, { capture: true }),
+      addEventListenerOnAllWindows('keyup', onNativeOnlyShortcutCompanion, { capture: true }),
+      addEventListenerOnAllWindows('beforeinput', onNativeOnlyBeforeInput, { capture: true }),
+      addEventListenerOnAllWindows('blur', onNativeOnlyBlur)
+    ]
     return () => {
       optionKittyReleases.clear()
       modifiedEnterChordOwner.clear()
       deferredNewlineSender.clearRedispatchedEnters()
       observedEnterKeydownTimeStamps.clear()
-      window.removeEventListener('keydown', onModifierDown, { capture: true })
-      window.removeEventListener('keyup', onKeyUp, { capture: true })
-      window.removeEventListener('keydown', onKeyDown, { capture: true })
-      window.removeEventListener('keypress', onNativeOnlyShortcutCompanion, { capture: true })
-      window.removeEventListener('keyup', onNativeOnlyShortcutCompanion, { capture: true })
-      window.removeEventListener('beforeinput', onNativeOnlyBeforeInput, { capture: true })
-      window.removeEventListener('blur', onNativeOnlyBlur)
+      for (const dispose of disposers) {
+        dispose()
+      }
     }
   }, [
     isActive,

--- a/src/renderer/src/components/terminal-pane/layout-serialization.ts
+++ b/src/renderer/src/components/terminal-pane/layout-serialization.ts
@@ -18,6 +18,7 @@ import {
   normalizeTerminalLayoutSnapshot,
   resolveRootlessTerminalLayoutLeafId
 } from './terminal-layout-leaf-ids'
+import { isHTMLElement } from '../../lib/cross-realm-dom-predicates'
 
 export {
   collectLeafIdsInOrder,
@@ -67,7 +68,7 @@ export function buildFontFamily(fontFamily: string): string {
 export function getLayoutChildNodes(split: HTMLElement): HTMLElement[] {
   return Array.from(split.children).filter(
     (child): child is HTMLElement =>
-      child instanceof HTMLElement &&
+      isHTMLElement(child) &&
       (child.classList.contains('pane') || child.classList.contains('pane-split'))
   )
 }
@@ -126,7 +127,7 @@ export function serializeTerminalLayout(
   leafIdByPaneId?: ReadonlyMap<number, string>
 ): TerminalLayoutSnapshot {
   const rootNode = serializePaneTree(
-    root?.firstElementChild instanceof HTMLElement ? root.firstElementChild : null
+    isHTMLElement(root?.firstElementChild) ? root.firstElementChild : null
   )
   const activeLeafId = activePaneId === null ? null : leafIdByPaneId?.get(activePaneId)
   const expandedLeafId = expandedPaneId === null ? null : leafIdByPaneId?.get(expandedPaneId)

--- a/src/renderer/src/components/terminal-pane/pane-helpers.ts
+++ b/src/renderer/src/components/terminal-pane/pane-helpers.ts
@@ -1,21 +1,27 @@
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
+import { isHTMLElement } from '../../lib/cross-realm-dom-predicates'
 
 export function fitPanes(manager: PaneManager): void {
   manager.fitAllPanes()
 }
 
 export function focusActivePane(manager: PaneManager): void {
-  // Why: tab rename focuses the input on the next frame. A queued terminal
-  // layout focus can land in between mount and focus, blurring rename closed.
-  if (typeof document !== 'undefined' && document.querySelector('[data-tab-rename-input="true"]')) {
-    return
-  }
-  const activeElement = typeof document === 'undefined' ? null : document.activeElement
-  if (shouldPreserveEditableFocus(activeElement)) {
-    return
-  }
   const panes = manager.getPanes()
   const activePane = manager.getActivePane() ?? panes[0]
+  // Why: a detached pane lives in an auxiliary window, so rename state and
+  // focus must be read from that pane's own document — the main one reports
+  // <body> while the aux window holds focus.
+  const paneDocument =
+    activePane?.terminal.element?.ownerDocument ??
+    (typeof document === 'undefined' ? null : document)
+  // Why: tab rename focuses the input on the next frame. A queued terminal
+  // layout focus can land in between mount and focus, blurring rename closed.
+  if (paneDocument?.querySelector('[data-tab-rename-input="true"]')) {
+    return
+  }
+  if (shouldPreserveEditableFocus(paneDocument?.activeElement ?? null)) {
+    return
+  }
   activePane?.terminal.focus()
 }
 
@@ -43,7 +49,7 @@ export function isLinuxUserAgent(
 }
 
 function shouldPreserveEditableFocus(element: Element | null): boolean {
-  if (!(element instanceof HTMLElement)) {
+  if (!isHTMLElement(element)) {
     return false
   }
   if (element.classList.contains('xterm-helper-textarea') || element.closest('.xterm')) {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -340,6 +340,8 @@ import {
 } from './renderer-owned-agent-status-registry'
 import type { DirectSshPaneRetryAttempt } from '@/store/slices/direct-ssh-terminal-recovery'
 import { directSshAuthoritiesEqual } from '@/store/slices/direct-ssh-terminal-authority-ledger'
+import { activeElementFor, isElement } from '../../lib/cross-realm-dom-predicates'
+import { isAnyAuxPaneDocumentVisible } from '@/lib/aux-pane-window-registry'
 
 const pendingSpawnByPaneKey = new Map<string, Promise<string | null>>()
 const SSH_SESSION_EXPIRED_ERROR = 'SSH_SESSION_EXPIRED'
@@ -475,7 +477,9 @@ function terminalOwnsDomFocus(terminal: TerminalWithFocusMode): boolean {
   if (typeof document === 'undefined' || !terminal.textarea) {
     return false
   }
-  return document.activeElement === terminal.textarea
+  // Why: a detached pane's textarea lives in the aux window's document, where
+  // the main document's activeElement is <body> — resolve against its owner.
+  return activeElementFor(terminal.textarea) === terminal.textarea
 }
 
 const CURSOR_AGENT_REATTACH_HEADER = 'Cursor Agent'
@@ -924,6 +928,13 @@ function shouldWritePtyOutputForeground(isPaneVisible: boolean): boolean {
   // backgrounded. Treat hidden documents like background tabs so Chromium
   // timer throttling cannot pin terminal writes on the renderer foreground path.
   if (document.visibilityState === 'visible') {
+    return true
+  }
+  // Why: a detached pane lives in another OS window. Chromium marks the main
+  // webContents hidden when it is minimized OR merely covered — including by
+  // that very window — so trusting the main document alone starves a terminal
+  // the user is actively watching.
+  if (isAnyAuxPaneDocumentVisible()) {
     return true
   }
   // Why: macOS occlusion tracking can wedge visibilityState at 'hidden' after
@@ -4529,7 +4540,7 @@ export function connectPanePty(
   // moment connectPanePty runs (it's the .pane element). Both report the
   // same layout signal — when the outer pane resizes, the inner xterm
   // container resizes too — so this is the safe element to observe.
-  if (geometryReportObserver && pane.container instanceof Element) {
+  if (geometryReportObserver && isElement(pane.container)) {
     geometryReportObserver.observe(pane.container)
   }
 

--- a/src/renderer/src/components/terminal-pane/regular-terminal-focus-ownership.ts
+++ b/src/renderer/src/components/terminal-pane/regular-terminal-focus-ownership.ts
@@ -4,15 +4,15 @@ import {
   scheduleNextFrame,
   type TerminalImeInputContextRefocusScheduler
 } from './terminal-ime-input-context-refresh'
+import { isHTMLElement, isNode } from '../../lib/cross-realm-dom-predicates'
 
 export type TerminalInputFocusSync = (focused: boolean) => void
 export type RefocusScheduler = TerminalImeInputContextRefocusScheduler
 export const REGULAR_TERMINAL_INPUT_FOCUSED_ATTRIBUTE = 'data-regular-terminal-input-focused'
 
 export function isXtermHelperTextarea(target: EventTarget | null): target is HTMLElement {
-  return target instanceof HTMLElement && target.classList.contains('xterm-helper-textarea')
+  return isHTMLElement(target) && target.classList.contains('xterm-helper-textarea')
 }
-
 export function setRegularTerminalInputFocusAttribute(focused: boolean): void {
   if (typeof document === 'undefined') {
     return
@@ -158,8 +158,4 @@ function syncFocusAfterFailedReclaim(
   if (!isXtermHelperTextarea(activeElement)) {
     syncFocused(false)
   }
-}
-
-function isNode(value: EventTarget | null): value is Node {
-  return typeof Node !== 'undefined' && value instanceof Node
 }

--- a/src/renderer/src/components/terminal-pane/session-restored-banner-pane-state.ts
+++ b/src/renderer/src/components/terminal-pane/session-restored-banner-pane-state.ts
@@ -1,4 +1,5 @@
 import type { ManagedPane } from '@/lib/pane-manager/pane-manager'
+import { isElement, isNode } from '../../lib/cross-realm-dom-predicates'
 
 export type SessionRestoredBannerPane = Pick<ManagedPane, 'id' | 'container'>
 
@@ -55,12 +56,11 @@ export function getSessionRestoredBannerDismissPaneId(
   event: SessionRestoredBannerDismissEvent,
   panes: readonly SessionRestoredBannerPane[]
 ): number | null {
-  const targetElement =
-    event.target instanceof Element
-      ? event.target
-      : event.target instanceof Node
-        ? event.target.parentElement
-        : null
+  const targetElement = isElement(event.target)
+    ? event.target
+    : isNode(event.target)
+      ? event.target.parentElement
+      : null
   const paneElement = targetElement?.closest('.pane[data-leaf-id]')
   if (!paneElement) {
     return null

--- a/src/renderer/src/components/terminal-pane/terminal-ime-composition-tracker.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-composition-tracker.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment happy-dom
+import { Window } from 'happy-dom'
 import { describe, expect, it } from 'vitest'
 import {
   installTerminalImeCompositionTracker,
@@ -56,6 +57,31 @@ describe('installTerminalImeCompositionTracker', () => {
     harness.composition('compositionupdate', 'ni')
     harness.composition('compositionupdate', '')
     expect(harness.tracker.isActive()).toBe(true)
+  })
+
+  it('handles an empty compositionupdate from a detached window realm', () => {
+    const childWindow = new Window()
+    const element = childWindow.document.createElement('div') as unknown as HTMLElement
+    const tracker = installTerminalImeCompositionTracker(element)
+    try {
+      const composition = (type: string, data: string): void => {
+        const event = new childWindow.CompositionEvent(type, { bubbles: true })
+        Object.defineProperties(event, {
+          data: { value: data },
+          view: { value: childWindow }
+        })
+        element.dispatchEvent(event as unknown as Event)
+      }
+
+      composition('compositionstart', '')
+      composition('compositionupdate', '')
+      composition('compositionend', '')
+
+      expect(tracker.isCandidateKeyGuardActive()).toBe(true)
+    } finally {
+      tracker.dispose()
+      childWindow.close()
+    }
   })
 
   it('clears on compositionend', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-ime-composition-tracker.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-composition-tracker.ts
@@ -1,4 +1,5 @@
 import type { IDisposable } from '@xterm/xterm'
+import { isCompositionEvent, isInputEvent } from '../../lib/cross-realm-dom-predicates'
 
 export type TerminalImeCompositionTracker = IDisposable & {
   isActive: () => boolean
@@ -62,7 +63,7 @@ export function installTerminalImeCompositionTracker(
     // Why: Sogou/fcitx can emit empty compositionupdate data while its
     // candidate popup is still open — empty data must not deactivate.
     // compositionend, non-composition input, and blur own deactivation.
-    if (!(event instanceof CompositionEvent)) {
+    if (!isCompositionEvent(event)) {
       return
     }
     if (event.data === '') {
@@ -79,7 +80,7 @@ export function installTerminalImeCompositionTracker(
     sawEmptyCompositionUpdate = false
   }
   const handleInput = (event: Event): void => {
-    if (event instanceof InputEvent && event.inputType === 'insertCompositionText') {
+    if (isInputEvent(event) && event.inputType === 'insertCompositionText') {
       return
     }
     active = false

--- a/src/renderer/src/components/terminal-pane/terminal-ime-input-context-refresh.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-input-context-refresh.ts
@@ -1,3 +1,4 @@
+import { isHTMLElement } from '../../lib/cross-realm-dom-predicates'
 export type TerminalImeInputContextRefocusScheduler = (callback: () => void) => void
 
 export type TerminalImeInputContextRefreshOptions = {
@@ -12,7 +13,7 @@ export type TerminalImeInputContextRefreshOptions = {
 const refreshingHelpers = new WeakSet<HTMLElement>()
 
 export function isTerminalImeInputContextRefreshing(target: EventTarget | null): boolean {
-  return target instanceof HTMLElement && refreshingHelpers.has(target)
+  return isHTMLElement(target) && refreshingHelpers.has(target)
 }
 
 function isMacUserAgent(): boolean {

--- a/src/renderer/src/components/terminal-pane/terminal-ime-native-text-forwarder.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-native-text-forwarder.ts
@@ -6,6 +6,7 @@ import {
   type ImeReleaseKeyEvent
 } from './terminal-ime-kitty-commit-encoding'
 import { getLayoutCharacterForCode } from '../../lib/keyboard-layout/layout-base-character'
+import { isHTMLTextAreaElement, isInputEvent } from '../../lib/cross-realm-dom-predicates'
 
 // Why: a plain printable keydown never produces terminal bytes. Bytes for
 // printable characters come only from the `input` event, which on macOS *is*
@@ -311,7 +312,7 @@ export function installTerminalImeNativeTextForwarder(args: {
   }
 
   const forwardCommittedText = (event: Event): void => {
-    if (!(event instanceof InputEvent)) {
+    if (!isInputEvent(event)) {
       return
     }
     // Why: an accepted composition transaction already owns its commit; letting
@@ -350,7 +351,7 @@ export function installTerminalImeNativeTextForwarder(args: {
     }
     event.stopImmediatePropagation()
     // Clear the helper textarea so the committed text doesn't accumulate.
-    if (event.target instanceof HTMLTextAreaElement) {
+    if (isHTMLTextAreaElement(event.target)) {
       event.target.value = ''
     }
   }

--- a/src/renderer/src/components/terminal-pane/terminal-keyboard-scope.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-keyboard-scope.ts
@@ -1,8 +1,9 @@
+import { isNode } from '../../lib/cross-realm-dom-predicates'
 export function keyboardEventBelongsToScope(event: KeyboardEvent, scope: HTMLElement): boolean {
   const target = event.target
-  if (target instanceof Node && scope.contains(target)) {
+  if (isNode(target) && scope.contains(target)) {
     return true
   }
   const activeElement = scope.ownerDocument.activeElement
-  return activeElement instanceof Node && scope.contains(activeElement)
+  return isNode(activeElement) && scope.contains(activeElement)
 }

--- a/src/renderer/src/components/terminal-pane/terminal-paste-target-state.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-paste-target-state.ts
@@ -1,3 +1,5 @@
+import { activeElementFor } from '../../lib/cross-realm-dom-predicates'
+
 type TerminalPastePaneIdentity = {
   id: number
   leafId: string
@@ -49,7 +51,9 @@ export function isTerminalPanePasteFocusCurrent({
   requireSameFocusedElement,
   activeElementAtDispatch,
   paneContainer,
-  activeElement = typeof document === 'undefined' ? null : document.activeElement
+  // Why: paneContainer names the document that actually owns this pane's focus
+  // — the main document reports <body> while an aux window holds it.
+  activeElement = activeElementFor(paneContainer)
 }: TerminalPanePasteFocusState): boolean {
   if (!requireSameFocusedElement || activeElementAtDispatch === null) {
     return true

--- a/src/renderer/src/components/terminal-pane/terminal-render-desync-sentinel.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-render-desync-sentinel.ts
@@ -13,6 +13,7 @@ import {
   type SentinelRendererState,
   type SentinelRenderInternals
 } from './terminal-render-desync-frame'
+import { isNode } from '../../lib/cross-realm-dom-predicates'
 
 /**
  * Flag-gated render-desync sentinel for WebGL terminal panes.
@@ -175,7 +176,7 @@ export function maybeStartTerminalRenderDesyncSentinel(): void {
       return
     }
     const target = event.target
-    if (!(target instanceof Node)) {
+    if (!isNode(target)) {
       return
     }
     let clickedTerminal: unknown = null

--- a/src/renderer/src/components/terminal-pane/use-terminal-context-menu-trigger.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-context-menu-trigger.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import type { TerminalPasteSource } from './terminal-paste-coordinator'
 import { copyTerminalSelection } from './terminal-selection-copy'
+import { isNode } from '../../lib/cross-realm-dom-predicates'
 
 const CLOSE_ALL_CONTEXT_MENUS_EVENT = 'orca-close-all-context-menus'
 
@@ -99,7 +100,7 @@ export function useTerminalContextMenuTrigger({
       return
     }
     const target = event.target
-    if (!(target instanceof Node)) {
+    if (!isNode(target)) {
       event.preventDefault()
       contextPaneIdRef.current = null
       return

--- a/src/renderer/src/components/terminal-pane/useTerminalFontZoom.ts
+++ b/src/renderer/src/components/terminal-pane/useTerminalFontZoom.ts
@@ -4,6 +4,7 @@ import { dispatchZoomLevelChanged } from '@/lib/zoom-events'
 import { safeFit } from '@/lib/pane-manager/pane-tree-ops'
 import { overridePendingPaneMetricOptions } from '@/lib/pane-manager/pane-metric-options-deferral'
 import { getPaneOwnedActiveHelperTextarea } from './regular-terminal-focus-ownership'
+import { activeElementFor } from '@/lib/cross-realm-dom-predicates'
 
 type FontZoomDeps = {
   isActive: boolean
@@ -30,7 +31,7 @@ export function useTerminalFontZoom({
 
     return window.api.ui.onTerminalZoom((direction) => {
       const container = containerRef.current
-      if (!container || !getPaneOwnedActiveHelperTextarea(container, document.activeElement)) {
+      if (!container || !getPaneOwnedActiveHelperTextarea(container, activeElementFor(container))) {
         return
       }
       const manager = managerRef.current

--- a/src/renderer/src/components/terminal/aux-pane-shortcut-target.test.ts
+++ b/src/renderer/src/components/terminal/aux-pane-shortcut-target.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
+import {
+  registerAuxPaneContainer,
+  unregisterAuxPaneContainer
+} from '@/lib/aux-pane-window-registry'
+import {
+  auxiliaryTerminalShortcutTarget,
+  getTerminalShortcutPaneHandle,
+  getTerminalShortcutPaneRefCallback,
+  resolveTerminalCreationShortcutWorktreeId,
+  resolveTerminalShortcutTabId,
+  resolveTerminalShortcutTarget
+} from './aux-pane-shortcut-target'
+
+const GROUP_ID = 'detached-group'
+
+afterEach(() => {
+  unregisterAuxPaneContainer(GROUP_ID)
+})
+
+describe('resolveTerminalShortcutTarget', () => {
+  it('keeps only auxiliary targets for main-window guard overrides', () => {
+    const main = { worktreeId: 'main', groupId: 'main-group', auxiliary: false }
+    const auxiliary = { worktreeId: 'aux', groupId: GROUP_ID, auxiliary: true }
+
+    expect(auxiliaryTerminalShortcutTarget(main)).toBeNull()
+    expect(auxiliaryTerminalShortcutTarget(auxiliary)).toBe(auxiliary)
+  })
+
+  it('scopes floating creation policy to the floating workspace', () => {
+    const main = { worktreeId: 'main', groupId: 'main-group', auxiliary: false }
+
+    expect(resolveTerminalCreationShortcutWorktreeId(main, false)).toBe('main')
+    expect(resolveTerminalCreationShortcutWorktreeId(main, true)).toBe(
+      FLOATING_TERMINAL_WORKTREE_ID
+    )
+  })
+
+  it('uses the focused aux group owner instead of the main active worktree', () => {
+    const auxDocument = document.implementation.createHTMLDocument('Aux')
+    const container = auxDocument.createElement('div')
+    const target = auxDocument.createElement('textarea')
+    container.append(target)
+    registerAuxPaneContainer(GROUP_ID, container)
+
+    expect(
+      resolveTerminalShortcutTarget(target, {
+        activeWorktreeId: 'main-worktree',
+        activeGroupIdByWorktree: { 'main-worktree': 'main-group' },
+        groupsByWorktree: {
+          'main-worktree': [
+            {
+              id: 'main-group',
+              worktreeId: 'main-worktree',
+              activeTabId: null,
+              tabOrder: []
+            }
+          ],
+          'detached-worktree': [
+            {
+              id: GROUP_ID,
+              worktreeId: 'detached-worktree',
+              activeTabId: null,
+              tabOrder: []
+            }
+          ]
+        }
+      })
+    ).toEqual({ worktreeId: 'detached-worktree', groupId: GROUP_ID, auxiliary: true })
+  })
+
+  it('resolves the active terminal entity in the aux group', () => {
+    expect(
+      resolveTerminalShortcutTabId(
+        { worktreeId: 'detached-worktree', groupId: GROUP_ID },
+        {
+          groupsByWorktree: {
+            'detached-worktree': [
+              {
+                id: GROUP_ID,
+                worktreeId: 'detached-worktree',
+                activeTabId: 'unified-terminal',
+                tabOrder: ['unified-terminal']
+              }
+            ]
+          },
+          unifiedTabsByWorktree: {
+            'detached-worktree': [
+              {
+                id: 'unified-terminal',
+                entityId: 'terminal-entity',
+                groupId: GROUP_ID,
+                worktreeId: 'detached-worktree',
+                contentType: 'terminal',
+                label: 'Terminal',
+                customLabel: null,
+                color: null,
+                sortOrder: 0,
+                createdAt: 1
+              }
+            ]
+          }
+        }
+      )
+    ).toBe('terminal-entity')
+  })
+
+  it('routes the resolved terminal to its mounted pane command handle', () => {
+    const closeActivePane = vi.fn()
+    const ref = getTerminalShortcutPaneRefCallback('terminal-entity')
+    ref({ closeActivePane })
+
+    getTerminalShortcutPaneHandle('terminal-entity')?.closeActivePane()
+
+    expect(closeActivePane).toHaveBeenCalledOnce()
+    ref(null)
+    expect(getTerminalShortcutPaneHandle('terminal-entity')).toBeNull()
+  })
+})

--- a/src/renderer/src/components/terminal/aux-pane-shortcut-target.ts
+++ b/src/renderer/src/components/terminal/aux-pane-shortcut-target.ts
@@ -1,0 +1,82 @@
+import type { Tab, TabGroup } from '../../../../shared/tab-types'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
+import { createTerminalPaneHandleRegistry } from '@/components/floating-terminal/terminal-pane-handle-registry'
+import { getAuxPaneGroupIdForTarget } from '@/lib/aux-pane-window-registry'
+
+export type TerminalShortcutTarget = {
+  worktreeId: string
+  groupId: string | undefined
+  auxiliary: boolean
+}
+
+export function auxiliaryTerminalShortcutTarget(
+  target: TerminalShortcutTarget | null
+): TerminalShortcutTarget | null {
+  return target?.auxiliary ? target : null
+}
+
+export function resolveTerminalCreationShortcutWorktreeId(
+  target: TerminalShortcutTarget | null,
+  floatingWorkspaceFocused: boolean
+): string | null {
+  return floatingWorkspaceFocused ? FLOATING_TERMINAL_WORKTREE_ID : (target?.worktreeId ?? null)
+}
+
+type TerminalShortcutPaneHandle = { closeActivePane: () => void }
+const terminalShortcutPaneHandles = createTerminalPaneHandleRegistry<TerminalShortcutPaneHandle>()
+
+export const getTerminalShortcutPaneHandle = (tabId: string): TerminalShortcutPaneHandle | null =>
+  terminalShortcutPaneHandles.getHandle(tabId)
+
+export const getTerminalShortcutPaneRefCallback = (
+  tabId: string
+): ((handle: TerminalShortcutPaneHandle | null) => void) =>
+  terminalShortcutPaneHandles.getRefCallback(tabId)
+
+export function resolveTerminalShortcutTabId(
+  target: Pick<TerminalShortcutTarget, 'worktreeId' | 'groupId'>,
+  state: {
+    groupsByWorktree: Record<string, TabGroup[]>
+    unifiedTabsByWorktree: Record<string, Tab[]>
+  }
+): string | null {
+  const group = target.groupId
+    ? (state.groupsByWorktree[target.worktreeId] ?? []).find(
+        (candidate) => candidate.id === target.groupId
+      )
+    : undefined
+  if (!group?.activeTabId) {
+    return null
+  }
+  const tab = (state.unifiedTabsByWorktree[target.worktreeId] ?? []).find(
+    (candidate) => candidate.id === group.activeTabId
+  )
+  return tab?.contentType === 'terminal' ? tab.entityId : null
+}
+
+export function resolveTerminalShortcutTarget(
+  target: EventTarget | null,
+  state: {
+    activeWorktreeId: string | null
+    activeGroupIdByWorktree: Record<string, string>
+    groupsByWorktree: Record<string, TabGroup[]>
+  }
+): TerminalShortcutTarget | null {
+  const auxGroupId = getAuxPaneGroupIdForTarget(target)
+  if (auxGroupId) {
+    for (const [worktreeId, groups] of Object.entries(state.groupsByWorktree)) {
+      if (groups.some((group) => group.id === auxGroupId)) {
+        return { worktreeId, groupId: auxGroupId, auxiliary: true }
+      }
+    }
+    return null
+  }
+  const worktreeId = state.activeWorktreeId
+  return worktreeId
+    ? {
+        worktreeId,
+        groupId: state.activeGroupIdByWorktree[worktreeId],
+        auxiliary: false
+      }
+    : null
+}

--- a/src/renderer/src/components/terminal/running-terminal-close-guard.ts
+++ b/src/renderer/src/components/terminal/running-terminal-close-guard.ts
@@ -71,8 +71,9 @@ export function guardRunningTerminalClose(params: {
   tabLabel: string
   onClose: () => void
   onCancel?: () => void
+  dialogContainer?: HTMLElement | null
 }): void {
-  const { terminalTabId, tabLabel, onClose, onCancel } = params
+  const { terminalTabId, tabLabel, onClose, onCancel, dialogContainer } = params
   const state = useAppStore.getState()
   const settings = state.settings
   const ptyIds = collectTabPtyIds(state, terminalTabId)
@@ -104,7 +105,8 @@ export function guardRunningTerminalClose(params: {
       tabLabel,
       copyKind,
       onConfirm: onClose,
-      ...(onCancel ? { onCancel } : {})
+      ...(onCancel ? { onCancel } : {}),
+      ...(dialogContainer ? { dialogContainer } : {})
     })
     // Why: only once the prompt is actually up — if either call above throws, the close must
     // still be free to fall through and happen.

--- a/src/renderer/src/components/terminal/terminal-tab-actions.test.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-actions.test.ts
@@ -509,6 +509,40 @@ describe('closeTerminalTab', () => {
     expect(closeUnifiedTab).not.toHaveBeenCalled()
   })
 
+  it('preserves opener selection when closing an auxiliary tab in the same worktree', () => {
+    const closeTab = vi.fn()
+    const setActiveTab = vi.fn()
+    const setActiveTabType = vi.fn()
+    const setActiveBrowserTab = vi.fn()
+    const setActiveFile = vi.fn()
+    const setActiveWorktree = vi.fn()
+    getStateMock.mockReturnValue({
+      settings: { activeRuntimeEnvironmentId: null },
+      tabsByWorktree: { 'wt-1': [{ id: 'aux-terminal' }] },
+      unifiedTabsByWorktree: {},
+      activeWorktreeId: 'wt-1',
+      activeTabId: 'aux-terminal',
+      activeTabType: 'browser',
+      openFiles: [{ id: 'editor-1', worktreeId: 'wt-1' }],
+      browserTabsByWorktree: { 'wt-1': [{ id: 'browser-1' }] },
+      closeTab,
+      setActiveTab,
+      setActiveTabType,
+      setActiveBrowserTab,
+      setActiveFile,
+      setActiveWorktree
+    })
+
+    closeTerminalTab('aux-terminal', { preserveOpenerSelection: true })
+
+    expect(closeTab).toHaveBeenCalledWith('aux-terminal')
+    expect(setActiveTab).not.toHaveBeenCalled()
+    expect(setActiveTabType).not.toHaveBeenCalled()
+    expect(setActiveBrowserTab).not.toHaveBeenCalled()
+    expect(setActiveFile).not.toHaveBeenCalled()
+    expect(setActiveWorktree).not.toHaveBeenCalled()
+  })
+
   it('routes closes on a remote worktree to the host even when the local→host map has no entry', () => {
     // Why: regression for the close-reappear bug. On a remote-owned worktree the
     // tab is host-authoritative; when the map has no entry (e.g. a plain-UUID host

--- a/src/renderer/src/components/terminal/terminal-tab-actions.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-actions.ts
@@ -55,6 +55,8 @@ export function closeTerminalTab(
     precomputedCloseState?: PrecomputedTerminalCloseState
     onClosed?: () => void
     onCancel?: () => void
+    dialogContainer?: HTMLElement | null
+    preserveOpenerSelection?: boolean
   }
 ): void {
   const state = useAppStore.getState()
@@ -109,7 +111,8 @@ export function closeTerminalTab(
         isPinned: true,
         tabLabel: resolvePinnedTabLabel(state, owningWorktreeId, terminalTabId),
         onClose: () => closeTerminalTab(tabId, { ...options, force: true }),
-        ...(options?.onCancel ? { onCancel: options.onCancel } : {})
+        ...(options?.onCancel ? { onCancel: options.onCancel } : {}),
+        ...(options?.dialogContainer ? { dialogContainer: options.dialogContainer } : {})
       })
       return
     }
@@ -125,7 +128,8 @@ export function closeTerminalTab(
       // Why: re-enter instead of continuing inline so pinned/route/precomputed state is
       // re-validated against fresh state after an arbitrarily long dialog.
       onClose: () => closeTerminalTab(tabId, { ...options, skipRunningProcessConfirm: true }),
-      ...(options?.onCancel ? { onCancel: options.onCancel } : {})
+      ...(options?.onCancel ? { onCancel: options.onCancel } : {}),
+      ...(options?.dialogContainer ? { dialogContainer: options.dialogContainer } : {})
     })
     return
   }
@@ -211,7 +215,7 @@ export function closeTerminalTab(
         ? { precomputedRetirementPlan: options.precomputedRetirementPlan }
         : {})
     })
-    if (state.activeWorktreeId === owningWorktreeId) {
+    if (state.activeWorktreeId === owningWorktreeId && !options?.preserveOpenerSelection) {
       // Why: only deactivate the worktree when no tabs of any kind remain.
       // Editor files are a separate tab type; closing the last terminal tab
       // should switch to the editor view instead of tearing down the workspace.
@@ -233,7 +237,11 @@ export function closeTerminalTab(
     return
   }
 
-  if (state.activeWorktreeId === owningWorktreeId && terminalTabId === state.activeTabId) {
+  if (
+    state.activeWorktreeId === owningWorktreeId &&
+    terminalTabId === state.activeTabId &&
+    !options?.preserveOpenerSelection
+  ) {
     const currentIndex = currentTerminalTabIds?.indexOf(terminalTabId) ?? -1
     const nextTabId = precomputedCloseState
       ? precomputedCloseState.nextTerminalTabId

--- a/src/renderer/src/components/ui/command.tsx
+++ b/src/renderer/src/components/ui/command.tsx
@@ -6,6 +6,7 @@ import { SearchIcon } from 'lucide-react'
 import { Dialog as DialogPrimitive } from 'radix-ui'
 
 import { cn } from '@/lib/utils'
+import { useAuxWindowContainer } from '@/components/aux-window-container-context'
 
 function Command({ className, ...props }: React.ComponentProps<typeof CommandPrimitive>) {
   return (
@@ -42,10 +43,11 @@ function CommandDialog({
   commandProps?: React.ComponentProps<typeof CommandPrimitive>
 }) {
   const { className: commandClassName, ...commandRootProps } = commandProps ?? {}
+  const auxContainer = useAuxWindowContainer()
 
   return (
     <DialogPrimitive.Root {...props}>
-      <DialogPrimitive.Portal>
+      <DialogPrimitive.Portal container={auxContainer ?? undefined}>
         <DialogPrimitive.Overlay
           // Why: matches the DialogOverlay recipe — deeper scrim + 2px backdrop
           // blur so the dark canvas lifts off the command palette. A flat

--- a/src/renderer/src/components/ui/context-menu.tsx
+++ b/src/renderer/src/components/ui/context-menu.tsx
@@ -3,6 +3,7 @@ import { ChevronRightIcon, CircleIcon } from 'lucide-react'
 import { ContextMenu as ContextMenuPrimitive } from 'radix-ui'
 
 import { cn } from '@/lib/utils'
+import { useAuxWindowContainer } from '@/components/aux-window-container-context'
 
 function ContextMenu({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Root>) {
   return <ContextMenuPrimitive.Root data-slot="context-menu" modal={false} {...props} />
@@ -53,8 +54,9 @@ function ContextMenuSubContent({
   style,
   ...props
 }: React.ComponentProps<typeof ContextMenuPrimitive.SubContent>) {
+  const auxContainer = useAuxWindowContainer()
   return (
-    <ContextMenuPrimitive.Portal>
+    <ContextMenuPrimitive.Portal container={auxContainer ?? undefined}>
       <ContextMenuPrimitive.SubContent
         data-slot="context-menu-sub-content"
         className={cn(
@@ -75,8 +77,9 @@ function ContextMenuContent({
   style,
   ...props
 }: React.ComponentProps<typeof ContextMenuPrimitive.Content>) {
+  const auxContainer = useAuxWindowContainer()
   return (
-    <ContextMenuPrimitive.Portal>
+    <ContextMenuPrimitive.Portal container={auxContainer ?? undefined}>
       <ContextMenuPrimitive.Content
         data-slot="context-menu-content"
         className={cn(

--- a/src/renderer/src/components/ui/dialog.tsx
+++ b/src/renderer/src/components/ui/dialog.tsx
@@ -7,6 +7,7 @@ import { Dialog as DialogPrimitive } from 'radix-ui'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { translate } from '@/i18n/i18n'
+import { useAuxWindowContainer } from '@/components/aux-window-container-context'
 
 function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />
@@ -17,7 +18,14 @@ function DialogTrigger({ ...props }: React.ComponentProps<typeof DialogPrimitive
 }
 
 function DialogPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
-  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+  const auxContainer = useAuxWindowContainer()
+  return (
+    <DialogPrimitive.Portal
+      data-slot="dialog-portal"
+      {...props}
+      container={props.container ?? auxContainer ?? undefined}
+    />
+  )
 }
 
 function DialogClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.Close>) {

--- a/src/renderer/src/components/ui/dropdown-menu.tsx
+++ b/src/renderer/src/components/ui/dropdown-menu.tsx
@@ -3,6 +3,7 @@ import { CheckIcon, ChevronRightIcon, CircleIcon } from 'lucide-react'
 import { DropdownMenu as DropdownMenuPrimitive } from 'radix-ui'
 
 import { cn } from '@/lib/utils'
+import { useAuxWindowContainer } from '@/components/aux-window-container-context'
 
 function DropdownMenu({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
   return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
@@ -11,7 +12,14 @@ function DropdownMenu({ ...props }: React.ComponentProps<typeof DropdownMenuPrim
 function DropdownMenuPortal({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
-  return <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+  const auxContainer = useAuxWindowContainer()
+  return (
+    <DropdownMenuPrimitive.Portal
+      data-slot="dropdown-menu-portal"
+      {...props}
+      container={props.container ?? auxContainer ?? undefined}
+    />
+  )
 }
 
 function DropdownMenuTrigger({
@@ -26,8 +34,9 @@ function DropdownMenuContent({
   style,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  const auxContainer = useAuxWindowContainer()
   return (
-    <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Portal container={auxContainer ?? undefined}>
       <DropdownMenuPrimitive.Content
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
@@ -203,8 +212,9 @@ function DropdownMenuSubContent({
   style,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  const auxContainer = useAuxWindowContainer()
   return (
-    <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Portal container={auxContainer ?? undefined}>
       <DropdownMenuPrimitive.SubContent
         data-slot="dropdown-menu-sub-content"
         className={cn(

--- a/src/renderer/src/components/ui/popover.tsx
+++ b/src/renderer/src/components/ui/popover.tsx
@@ -5,6 +5,7 @@ import { Popover as PopoverPrimitive } from 'radix-ui'
 
 import { cn } from '@/lib/utils'
 import { updatePopoverContentRef } from './popover-content-ref'
+import { useAuxWindowContainer } from '@/components/aux-window-container-context'
 
 function Popover(props: React.ComponentProps<typeof PopoverPrimitive.Root>) {
   return <PopoverPrimitive.Root data-slot="popover" {...props} />
@@ -30,6 +31,7 @@ function PopoverContent({
 }: React.ComponentProps<typeof PopoverPrimitive.Content> & {
   portalContainer?: HTMLElement | null
 }) {
+  const auxContainer = useAuxWindowContainer()
   const wheelFrameIdsRef = React.useRef<Set<number>>(new Set())
 
   const cancelWheelFrames = React.useCallback(() => {
@@ -88,7 +90,7 @@ function PopoverContent({
   )
 
   return (
-    <PopoverPrimitive.Portal container={portalContainer ?? undefined}>
+    <PopoverPrimitive.Portal container={portalContainer ?? auxContainer ?? undefined}>
       <PopoverPrimitive.Content
         data-slot="popover-content"
         align={align}

--- a/src/renderer/src/components/ui/select.tsx
+++ b/src/renderer/src/components/ui/select.tsx
@@ -5,6 +5,7 @@ import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from 'lucide-react'
 import { Select as SelectPrimitive } from 'radix-ui'
 
 import { cn } from '@/lib/utils'
+import { useAuxWindowContainer } from '@/components/aux-window-container-context'
 
 function Select({ ...props }: React.ComponentProps<typeof SelectPrimitive.Root>) {
   return <SelectPrimitive.Root data-slot="select" {...props} />
@@ -50,8 +51,9 @@ function SelectContent({
 }: React.ComponentProps<typeof SelectPrimitive.Content> & {
   portalContainer?: HTMLElement | null
 }) {
+  const auxContainer = useAuxWindowContainer()
   return (
-    <SelectPrimitive.Portal container={portalContainer ?? undefined}>
+    <SelectPrimitive.Portal container={portalContainer ?? auxContainer ?? undefined}>
       <SelectPrimitive.Content
         data-slot="select-content"
         // Why: matches the dropdown-menu recipe — translucent surface, solid

--- a/src/renderer/src/components/ui/tooltip.tsx
+++ b/src/renderer/src/components/ui/tooltip.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { Tooltip as TooltipPrimitive } from 'radix-ui'
 
 import { cn } from '@/lib/utils'
+import { useAuxWindowContainer } from '@/components/aux-window-container-context'
 
 function TooltipProvider({
   delayDuration = 0,
@@ -35,8 +36,9 @@ function TooltipContent({
   children,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Content> & { showArrow?: boolean }) {
+  const auxContainer = useAuxWindowContainer()
   return (
-    <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Portal container={auxContainer ?? undefined}>
       <TooltipPrimitive.Content
         data-slot="tooltip-content"
         sideOffset={sideOffset}

--- a/src/renderer/src/hooks/ipc-tab-switch.ts
+++ b/src/renderer/src/hooks/ipc-tab-switch.ts
@@ -17,25 +17,36 @@ type CycleContext = {
   groupTabIdInNav: string | null
 }
 
+type TabCycleTarget = { worktreeId: string; groupId?: string }
+
 /**
  * Shared setup for the type-scoped and across-all-types tab-cycle actions.
  * Returns null when there is no active worktree or the visible nav has at most
  * one tab (nothing to cycle).
  */
-function resolveCycleContext(): CycleContext | null {
+function resolveCycleContext(target?: TabCycleTarget, allowSingle = false): CycleContext | null {
   const store = useAppStore.getState()
-  const worktreeId = store.activeWorktreeId
+  const worktreeId = target?.worktreeId ?? store.activeWorktreeId
   if (!worktreeId) {
     return null
   }
   // Why: walk the active group's visible order so drag-reordered tabs cycle
   // in the sequence the user sees. See getActiveTabNavOrder for the stale
   // legacy-order bug this replaces.
-  const allTabIds = getActiveTabNavOrder(store, worktreeId)
-  if (allTabIds.length <= 1) {
+  const navigationState = target?.groupId
+    ? {
+        ...store,
+        activeGroupIdByWorktree: {
+          ...store.activeGroupIdByWorktree,
+          [worktreeId]: target.groupId
+        }
+      }
+    : store
+  const allTabIds = getActiveTabNavOrder(navigationState, worktreeId)
+  if (allTabIds.length <= (allowSingle ? 0 : 1)) {
     return null
   }
-  const activeGroupId = store.activeGroupIdByWorktree[worktreeId]
+  const activeGroupId = target?.groupId ?? store.activeGroupIdByWorktree[worktreeId]
   const group = activeGroupId
     ? (store.groupsByWorktree[worktreeId] ?? []).find((candidate) => candidate.id === activeGroupId)
     : undefined
@@ -93,8 +104,8 @@ export function activateCyclableTab(store: AppStoreState, next: TypeCyclableTab)
  * Extracted from useIpcEvents to keep file size under the max-lines lint threshold.
  * Returns true if a tab switch occurred, false otherwise.
  */
-export function handleSwitchTab(direction: number): boolean {
-  const ctx = resolveCycleContext()
+export function handleSwitchTab(direction: number, target?: TabCycleTarget): boolean {
+  const ctx = resolveCycleContext(target)
   if (!ctx) {
     return false
   }
@@ -124,8 +135,8 @@ export function handleSwitchTab(direction: number): boolean {
  * inverse via the seed migration (see PR #1281 for the original type-scope
  * rationale). Returns true if a tab switch occurred, false otherwise.
  */
-export function handleSwitchTabAcrossAllTypes(direction: number): boolean {
-  const ctx = resolveCycleContext()
+export function handleSwitchTabAcrossAllTypes(direction: number, target?: TabCycleTarget): boolean {
+  const ctx = resolveCycleContext(target)
   if (!ctx) {
     return false
   }
@@ -150,8 +161,8 @@ export function handleSwitchTabAcrossAllTypes(direction: number): boolean {
  * Handle Ctrl+Tab MRU quick-toggle across every visible tab in the active group.
  * Returns true if a tab switch occurred, false otherwise.
  */
-export function handleSwitchRecentTab(): boolean {
-  const ctx = resolveCycleContext()
+export function handleSwitchRecentTab(target?: TabCycleTarget): boolean {
+  const ctx = resolveCycleContext(target)
   if (!ctx) {
     return false
   }
@@ -159,7 +170,7 @@ export function handleSwitchRecentTab(): boolean {
   if (!groupTabIdInNav) {
     return false
   }
-  const groupId = store.activeGroupIdByWorktree[worktreeId]
+  const groupId = target?.groupId ?? store.activeGroupIdByWorktree[worktreeId]
   const group = groupId
     ? (store.groupsByWorktree[worktreeId] ?? []).find((candidate) => candidate.id === groupId)
     : undefined
@@ -188,26 +199,29 @@ export function handleSwitchRecentTab(): boolean {
  * Handle Ctrl+PageUp/PageDown switching across terminal tabs only.
  * Returns true if a terminal tab switch occurred, false otherwise.
  */
-export function handleSwitchTerminalTab(direction: number): boolean {
-  const store = useAppStore.getState()
-  const worktreeId = store.activeWorktreeId
-  if (!worktreeId) {
+export function handleSwitchTerminalTab(direction: number, target?: TabCycleTarget): boolean {
+  const ctx = resolveCycleContext(target, true)
+  if (!ctx) {
     return false
   }
+  const { store, allTabIds, groupTabIdInNav } = ctx
   // Why: reuse the same visible-order source as handleSwitchTab so drag-reordered
   // tabs still cycle in the sequence shown in the active tab strip.
-  const terminalTabs = getActiveTabNavOrder(store, worktreeId).filter(
-    (entry) => entry.type === 'terminal'
-  )
+  const terminalTabs = allTabIds.filter((entry) => entry.type === 'terminal')
   if (terminalTabs.length === 0) {
     return false
   }
-  const currentId = getActiveEntityIdForTabType(
-    store.activeTabType,
-    store.activeTabId,
-    store.activeFileId,
-    store.activeBrowserTabId
-  )
+  const activeGroupTab = groupTabIdInNav
+    ? terminalTabs.find((tab) => tab.tabId === groupTabIdInNav)?.id
+    : undefined
+  const currentId =
+    activeGroupTab ??
+    getActiveEntityIdForTabType(
+      store.activeTabType,
+      store.activeTabId,
+      store.activeFileId,
+      store.activeBrowserTabId
+    )
   // Why: when an editor/browser tab is active, jump to the first terminal on
   // forward navigation instead of skipping to index 1.
   const idx = terminalTabs.findIndex((t) => t.id === currentId)

--- a/src/renderer/src/hooks/remote-workspace-target-sync.test.ts
+++ b/src/renderer/src/hooks/remote-workspace-target-sync.test.ts
@@ -115,6 +115,8 @@ function appState(overrides: Record<string, unknown> = {}): AppState {
     sshConnectionStates: new Map(),
     lastVisitedAtByWorktreeId: {},
     defaultTerminalTabsAppliedByWorktreeId: {},
+    detachedGroupIds: [],
+    auxWindowBoundsByGroupId: {},
     hydrateWorkspaceSession: vi.fn(),
     hydrateTabsSession: vi.fn(),
     hydrateEditorSession: vi.fn(),

--- a/src/renderer/src/hooks/usePrimarySelectionPaste.ts
+++ b/src/renderer/src/hooks/usePrimarySelectionPaste.ts
@@ -12,6 +12,8 @@ import {
   type EditablePrimarySelectionPasteTarget
 } from '@/lib/primary-selection-paste'
 import { readCurrentPrimarySelectionText } from '@/lib/primary-selection-capture'
+import { addEventListenerOnAllDocuments } from '@/lib/aux-pane-window-registry'
+import { isDocument, isElement, isInputEvent, isNode } from '@/lib/cross-realm-dom-predicates'
 
 const PRIMARY_SELECTION_PENDING_TARGET_TTL_MS = 750
 
@@ -28,8 +30,8 @@ export function isDefaultPrimarySelectionMiddleClickPasteUserAgent(
   return isLinuxUserAgent(userAgent) || isMacUserAgent(userAgent)
 }
 
-function captureCurrentSelection(): void {
-  const text = readCurrentPrimarySelectionText()
+function captureCurrentSelection(sourceDocument: Document): void {
+  const text = readCurrentPrimarySelectionText(sourceDocument)
   if (text) {
     setPrimarySelectionText(text)
   }
@@ -45,7 +47,7 @@ function suppressEvent(event: Event): void {
 // scope terminal-armed suppression to that surface so unrelated document pastes
 // (right-click Paste, keyboard paste into another control) are never swallowed.
 function isTerminalNativePasteTarget(target: EventTarget | null): boolean {
-  if (!(target instanceof Element)) {
+  if (!isElement(target)) {
     return false
   }
   return target.classList.contains('xterm-helper-textarea') || target.closest('.xterm') !== null
@@ -57,7 +59,7 @@ function isPrimarySelectionPasteTargetCurrent(
   const activeElement = target.ownerDocument.activeElement
   return (
     target.isConnected &&
-    activeElement instanceof Node &&
+    isNode(activeElement) &&
     (activeElement === target || target.contains(activeElement))
   )
 }
@@ -69,7 +71,7 @@ export function usePrimarySelectionPaste(enabled: boolean): void {
     let pendingMiddleUntil = 0
 
     const targetMatchesPending = (target: EventTarget | null): boolean => {
-      if (!pendingMiddleTarget || !(target instanceof Node)) {
+      if (!pendingMiddleTarget || !isNode(target)) {
         return false
       }
       return target === pendingMiddleTarget || pendingMiddleTarget.contains(target)
@@ -91,10 +93,7 @@ export function usePrimarySelectionPaste(enabled: boolean): void {
     }
 
     const suppressPendingPasteInput = (event: InputEvent | ClipboardEvent): void => {
-      const isPasteInputEvent =
-        typeof InputEvent !== 'function' ||
-        !(event instanceof InputEvent) ||
-        event.inputType === 'insertFromPaste'
+      const isPasteInputEvent = !isInputEvent(event) || event.inputType === 'insertFromPaste'
       if (!isPasteInputEvent) {
         return
       }
@@ -144,31 +143,39 @@ export function usePrimarySelectionPaste(enabled: boolean): void {
 
       // Why: when users opt out on Linux, Chromium can still perform native
       // primary-selection paste unless the middle-click paste pipeline is stopped.
-      document.addEventListener('mousedown', onMouseDown, true)
-      document.addEventListener('beforeinput', suppressPendingPasteInput, true)
-      document.addEventListener('paste', suppressPendingPasteInput, true)
-      document.addEventListener('mouseup', onMouseUp, true)
-      document.addEventListener('auxclick', onAuxClick, true)
+      const removeListeners = [
+        addEventListenerOnAllDocuments('mousedown', onMouseDown as EventListener, true),
+        addEventListenerOnAllDocuments(
+          'beforeinput',
+          suppressPendingPasteInput as EventListener,
+          true
+        ),
+        addEventListenerOnAllDocuments('paste', suppressPendingPasteInput as EventListener, true),
+        addEventListenerOnAllDocuments('mouseup', onMouseUp as EventListener, true),
+        addEventListenerOnAllDocuments('auxclick', onAuxClick as EventListener, true)
+      ]
 
       return () => {
         setPrimarySelectionEnabled(false)
-        document.removeEventListener('mousedown', onMouseDown, true)
-        document.removeEventListener('beforeinput', suppressPendingPasteInput, true)
-        document.removeEventListener('paste', suppressPendingPasteInput, true)
-        document.removeEventListener('mouseup', onMouseUp, true)
-        document.removeEventListener('auxclick', onAuxClick, true)
+        for (const removeListener of removeListeners) {
+          removeListener()
+        }
       }
     }
 
     let captureTimer: number | null = null
 
-    const scheduleCapture = (): void => {
+    let captureDocument = document
+    const scheduleCapture = (event: Event): void => {
+      if (isDocument(event.currentTarget)) {
+        captureDocument = event.currentTarget
+      }
       if (captureTimer !== null) {
         window.clearTimeout(captureTimer)
       }
       captureTimer = window.setTimeout(() => {
         captureTimer = null
-        captureCurrentSelection()
+        captureCurrentSelection(captureDocument)
       }, 100)
     }
 
@@ -210,28 +217,29 @@ export function usePrimarySelectionPaste(enabled: boolean): void {
       suppressEvent(event)
     }
 
-    document.addEventListener('selectionchange', scheduleCapture)
-    document.addEventListener('mouseup', scheduleCapture, true)
-    document.addEventListener('keyup', scheduleCapture, true)
-    document.addEventListener('mousedown', onMouseDown, true)
-    document.addEventListener('beforeinput', suppressPendingPasteInput, true)
-    document.addEventListener('paste', suppressPendingPasteInput, true)
-    document.addEventListener('mouseup', onMouseUp, true)
-    document.addEventListener('auxclick', onAuxClick, true)
+    const removeListeners = [
+      addEventListenerOnAllDocuments('selectionchange', scheduleCapture, false),
+      addEventListenerOnAllDocuments('mouseup', scheduleCapture, true),
+      addEventListenerOnAllDocuments('keyup', scheduleCapture, true),
+      addEventListenerOnAllDocuments('mousedown', onMouseDown as EventListener, true),
+      addEventListenerOnAllDocuments(
+        'beforeinput',
+        suppressPendingPasteInput as EventListener,
+        true
+      ),
+      addEventListenerOnAllDocuments('paste', suppressPendingPasteInput as EventListener, true),
+      addEventListenerOnAllDocuments('mouseup', onMouseUp as EventListener, true),
+      addEventListenerOnAllDocuments('auxclick', onAuxClick as EventListener, true)
+    ]
 
     return () => {
       setPrimarySelectionEnabled(false)
       if (captureTimer !== null) {
         window.clearTimeout(captureTimer)
       }
-      document.removeEventListener('selectionchange', scheduleCapture)
-      document.removeEventListener('mouseup', scheduleCapture, true)
-      document.removeEventListener('keyup', scheduleCapture, true)
-      document.removeEventListener('mousedown', onMouseDown, true)
-      document.removeEventListener('beforeinput', suppressPendingPasteInput, true)
-      document.removeEventListener('paste', suppressPendingPasteInput, true)
-      document.removeEventListener('mouseup', onMouseUp, true)
-      document.removeEventListener('auxclick', onAuxClick, true)
+      for (const removeListener of removeListeners) {
+        removeListener()
+      }
     }
   }, [enabled])
 }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -15934,7 +15934,9 @@
         "SortableTabContextMenu": {
           "switchToTerminalView": "Switch to terminal view",
           "switchToChatView": "Switch to chat view",
-          "closeTabsToLeft": "Close Tabs To The Left"
+          "closeTabsToLeft": "Close Tabs To The Left",
+          "returnGroupToMainWindow": "Return Group to Main Window",
+          "moveGroupToNewWindow": "Move Group to New Window"
         },
         "BrowserTab": {
           "closeOthers": "Close Others",
@@ -16151,6 +16153,15 @@
       "bar": {
         "workspaceSpace": {
           "otherTopLevelItems": "Other top-level items ({{value0}})"
+        }
+      }
+    },
+    "settings": {
+      "experimentalPane": {
+        "detachedPanes": {
+          "title": "Detached Panes",
+          "description": "Move a terminal tab group into its own window, for a second monitor.",
+          "copy": "Adds \"Move Group to New Window\" to the tab menu for terminal-only groups. Detached windows do not yet have a native right-click menu, and paste from the Edit menu does not reach them — use the keyboard inside the terminal."
         }
       }
     }

--- a/src/renderer/src/lib/app-menu-paste.ts
+++ b/src/renderer/src/lib/app-menu-paste.ts
@@ -8,6 +8,7 @@ import {
   findOwnedTextControlPasteTarget,
   shouldClaimTextControlPastePayload
 } from './text-control-paste-ownership'
+import { activeElementFor } from './cross-realm-dom-predicates'
 
 export const APP_MENU_PASTE_EVENT = 'orca-app-menu-paste'
 
@@ -39,7 +40,7 @@ export function dispatchAppMenuPasteEvent(target: Window = window): boolean {
 }
 
 export function findFocusedAppMenuTextControlPasteTarget(
-  activeElement: Element | null = typeof document === 'undefined' ? null : document.activeElement
+  activeElement: Element | null = activeElementFor(null)
 ): HTMLInputElement | HTMLTextAreaElement | null {
   return findOwnedTextControlPasteTarget(activeElement)
 }
@@ -67,7 +68,7 @@ export async function handleAppMenuPasteRequest({
   readClipboardText,
   performNativePaste,
   dispatchOwnedPasteEvent = dispatchAppMenuPasteEvent,
-  getActiveElement = () => document.activeElement,
+  getActiveElement = () => activeElementFor(null),
   nativePasteMode = 'paste'
 }: AppMenuPasteRequestDeps): Promise<AppMenuPasteRequestResult> {
   const startedAtMs = getNowMs()

--- a/src/renderer/src/lib/aux-pane-window-registry.test.ts
+++ b/src/renderer/src/lib/aux-pane-window-registry.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  addEventListenerOnAllDocuments,
+  getAuxPaneContainerForDocument,
+  getAuxPaneGroupIdForTarget,
+  getPaneDocuments,
+  registerAuxPaneContainer,
+  unregisterAuxPaneContainer
+} from './aux-pane-window-registry'
+
+const GROUP_ID = 'aux-group'
+
+afterEach(() => {
+  unregisterAuxPaneContainer(GROUP_ID)
+})
+
+describe('aux pane document registry', () => {
+  it('resolves targets and keeps document listeners synchronized', () => {
+    const auxDocument = document.implementation.createHTMLDocument('Aux')
+    const container = auxDocument.createElement('div')
+    const target = auxDocument.createElement('button')
+    container.append(target)
+    registerAuxPaneContainer(GROUP_ID, container)
+
+    expect(getAuxPaneGroupIdForTarget(target)).toBe(GROUP_ID)
+    expect(getAuxPaneContainerForDocument(auxDocument)).toBe(container)
+    expect(getPaneDocuments()).toContain(auxDocument)
+
+    const handler = vi.fn()
+    const remove = addEventListenerOnAllDocuments('mousedown', handler)
+    auxDocument.dispatchEvent(new Event('mousedown'))
+    expect(handler).toHaveBeenCalledOnce()
+
+    unregisterAuxPaneContainer(GROUP_ID)
+    auxDocument.dispatchEvent(new Event('mousedown'))
+    expect(handler).toHaveBeenCalledOnce()
+    remove()
+  })
+})

--- a/src/renderer/src/lib/aux-pane-window-registry.ts
+++ b/src/renderer/src/lib/aux-pane-window-registry.ts
@@ -1,0 +1,182 @@
+/**
+ * Which auxiliary window (if any) currently hosts a detached tab group.
+ *
+ * Terminal panes do not render inside the tab-group body — `TerminalOverlaySlot`
+ * renders them in a sibling overlay layer and positions them over the body with
+ * CSS anchor positioning. That only works within one document, so when a group
+ * is portaled into an aux window its panes must follow. This registry is how
+ * the overlay slot finds the container to portal into.
+ */
+type Listener = () => void
+
+const containersByGroupId = new Map<string, HTMLElement>()
+const listeners = new Set<Listener>()
+
+function emit(): void {
+  for (const listener of listeners) {
+    listener()
+  }
+}
+
+export function registerAuxPaneContainer(groupId: string, container: HTMLElement): void {
+  containersByGroupId.set(groupId, container)
+  emit()
+}
+
+export function unregisterAuxPaneContainer(groupId: string): void {
+  if (containersByGroupId.delete(groupId)) {
+    emit()
+  }
+}
+
+export function getAuxPaneContainer(groupId: string | undefined): HTMLElement | null {
+  return groupId ? (containersByGroupId.get(groupId) ?? null) : null
+}
+
+export function getAuxPaneContainerForDocument(ownerDocument: Document): HTMLElement | null {
+  for (const container of containersByGroupId.values()) {
+    if (container.ownerDocument === ownerDocument) {
+      return container
+    }
+  }
+  return null
+}
+
+export function getPaneDocuments(): Document[] {
+  const paneDocuments = [
+    document,
+    ...new Set(Array.from(containersByGroupId.values(), (container) => container.ownerDocument))
+  ]
+  return paneDocuments.sort(
+    (left, right) => Number(right.hasFocus?.() === true) - Number(left.hasFocus?.() === true)
+  )
+}
+
+export function getAuxPaneGroupIdForTarget(target: EventTarget | null): string | null {
+  const ownerDocument = (target as Node | null)?.ownerDocument
+  if (!ownerDocument) {
+    return null
+  }
+  for (const [groupId, container] of containersByGroupId) {
+    if (container.ownerDocument === ownerDocument) {
+      return groupId
+    }
+  }
+  return null
+}
+
+/**
+ * True when any detached pane's window is currently visible.
+ *
+ * The hidden-PTY delivery gate asks "is the app in the foreground" by reading
+ * the main document's `visibilityState`. With a detached pane that answer is
+ * wrong in the dangerous direction: Chromium marks the main webContents hidden
+ * when it is minimized *or merely covered* — including by the aux window itself
+ * — and the gate then drops bytes for a terminal the user is actively watching.
+ *
+ * ponytail: coarse on purpose — any visible aux window keeps delivery on for
+ * every pane, rather than resolving each pane's own document. Per-pane
+ * resolution needs a container handle threaded through PtyConnectionDeps; do
+ * that if background panes ever prove expensive enough to matter.
+ */
+export function isAnyAuxPaneDocumentVisible(): boolean {
+  for (const container of containersByGroupId.values()) {
+    if (container.ownerDocument.visibilityState === 'visible') {
+      return true
+    }
+  }
+  return false
+}
+
+export function subscribeToAuxPaneContainers(listener: Listener): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+/**
+ * Register a DOM listener on the main window and on every detached pane window,
+ * keeping the set in sync as windows open and close.
+ *
+ * DOM events do not cross documents: a listener on the opener never sees a
+ * child document's keydown. Anything doing global event delegation that must
+ * also work inside a detached pane has to register per window.
+ *
+ * App-level `CustomEvent` buses are the opposite case — those stay on the
+ * opener window only, so both sides agree on one bus.
+ */
+export function addEventListenerOnAllWindows<K extends keyof WindowEventMap>(
+  type: K,
+  handler: (event: WindowEventMap[K]) => void,
+  options?: AddEventListenerOptions
+): () => void {
+  const attached = new Set<Window>()
+
+  const sync = (): void => {
+    const wanted = new Set<Window>([window])
+    for (const container of containersByGroupId.values()) {
+      const view = container.ownerDocument.defaultView
+      if (view) {
+        wanted.add(view)
+      }
+    }
+    for (const view of attached) {
+      if (!wanted.has(view)) {
+        view.removeEventListener(type, handler as EventListener, options)
+        attached.delete(view)
+      }
+    }
+    for (const view of wanted) {
+      if (!attached.has(view)) {
+        view.addEventListener(type, handler as EventListener, options)
+        attached.add(view)
+      }
+    }
+  }
+
+  sync()
+  const unsubscribe = subscribeToAuxPaneContainers(sync)
+  return () => {
+    unsubscribe()
+    for (const view of attached) {
+      view.removeEventListener(type, handler as EventListener, options)
+    }
+    attached.clear()
+  }
+}
+
+export function addEventListenerOnAllDocuments(
+  type: string,
+  handler: EventListener,
+  options?: boolean | AddEventListenerOptions
+): () => void {
+  const attached = new Set<Document>()
+  const sync = (): void => {
+    const wanted = new Set<Document>([document])
+    for (const container of containersByGroupId.values()) {
+      wanted.add(container.ownerDocument)
+    }
+    for (const target of attached) {
+      if (!wanted.has(target)) {
+        target.removeEventListener(type, handler, options)
+        attached.delete(target)
+      }
+    }
+    for (const target of wanted) {
+      if (!attached.has(target)) {
+        target.addEventListener(type, handler, options)
+        attached.add(target)
+      }
+    }
+  }
+  sync()
+  const unsubscribe = subscribeToAuxPaneContainers(sync)
+  return () => {
+    unsubscribe()
+    for (const target of attached) {
+      target.removeEventListener(type, handler, options)
+    }
+    attached.clear()
+  }
+}

--- a/src/renderer/src/lib/aux-pane-window.ts
+++ b/src/renderer/src/lib/aux-pane-window.ts
@@ -1,0 +1,155 @@
+import {
+  auxWindowFrameName,
+  auxWindowFeatures,
+  type AuxWindowBounds
+} from '../../../shared/aux-window'
+
+export type AuxPaneWindow = {
+  window: Window
+  /** Container the caller portals into. Lives in the child document. */
+  container: HTMLElement
+  close: () => void
+}
+
+/** Poll interval for geometry. Window move/resize emit no event to the opener. */
+const BOUNDS_SAMPLE_MS = 1000
+
+function readBounds(child: Window): AuxWindowBounds | null {
+  const { screenX, screenY, outerWidth, outerHeight } = child
+  if (!Number.isFinite(screenX) || outerWidth === 0 || outerHeight === 0) {
+    return null
+  }
+  return { x: screenX, y: screenY, width: outerWidth, height: outerHeight }
+}
+
+/**
+ * Open an `about:blank` child window and mirror the app's stylesheets into it.
+ *
+ * The child shares this renderer's JS realm — one store, one IPC surface, one
+ * PTY delivery path — so only its DOM is separate. Nodes React portals into it
+ * are minted in the CHILD realm, which is why pane code must use the
+ * realm-resolved DOM helpers rather than bare `window`/`document`/`instanceof`.
+ */
+export function openAuxPaneWindow(options: {
+  groupId: string
+  title: string
+  bounds: AuxWindowBounds | null
+  onClose: () => void
+  onBoundsChange: (bounds: AuxWindowBounds) => void
+}): AuxPaneWindow | null {
+  const child = window.open(
+    'about:blank',
+    auxWindowFrameName(options.groupId),
+    auxWindowFeatures(options.bounds)
+  )
+  if (!child) {
+    return null
+  }
+
+  child.document.title = options.title
+  copyStyles(child.document)
+  // Why: styles injected after open (theme switches, lazily-mounted CSS) would
+  // otherwise never reach the child.
+  const headObserver = new MutationObserver((records) => {
+    for (const record of records) {
+      for (const node of record.addedNodes) {
+        if (isStyleNode(node)) {
+          child.document.head.appendChild(child.document.importNode(node, true))
+        }
+      }
+    }
+  })
+  headObserver.observe(document.head, { childList: true })
+
+  const container = child.document.createElement('div')
+  container.style.cssText = 'position:fixed;inset:0;display:flex;overflow:hidden'
+  child.document.body.style.cssText = 'margin:0;overflow:hidden'
+  child.document.body.appendChild(container)
+  // Why: the child inherits the root theme classes (dark mode, platform shell)
+  // that Tailwind and the design tokens key off.
+  child.document.documentElement.className = document.documentElement.className
+  child.document.documentElement.style.cssText = document.documentElement.style.cssText
+  const rootObserver = new MutationObserver(() => {
+    child.document.documentElement.className = document.documentElement.className
+    child.document.documentElement.style.cssText = document.documentElement.style.cssText
+  })
+  rootObserver.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['class', 'style']
+  })
+
+  // Why: there is no move/resize event the opener can observe on a child
+  // window, so sample geometry and store the last good value for restore.
+  const boundsTimer = window.setInterval(() => {
+    const bounds = readBounds(child)
+    if (bounds) {
+      options.onBoundsChange(bounds)
+    }
+  }, BOUNDS_SAMPLE_MS)
+
+  // Why: a child window outlives an opener reload unless we close it, and the
+  // listener is removed on teardown so repeated detaches don't accumulate.
+  const closeChildWithOpener = (): void => {
+    child.close()
+  }
+  window.addEventListener('pagehide', closeChildWithOpener)
+
+  let closed = false
+  const teardown = (): void => {
+    headObserver.disconnect()
+    rootObserver.disconnect()
+    window.clearInterval(boundsTimer)
+    window.removeEventListener('pagehide', closeChildWithOpener)
+    const bounds = readBounds(child)
+    if (bounds) {
+      options.onBoundsChange(bounds)
+    }
+  }
+  // Why: close() is the OWNER tearing the window down (unmount, reattach, or
+  // StrictMode's dev-only mount/cleanup/mount replay). It must not report a
+  // user-initiated close — doing so flips the group back to attached and makes
+  // the feature snap shut the moment it opens in a dev build.
+  const close = (): void => {
+    if (closed) {
+      return
+    }
+    closed = true
+    teardown()
+    child.removeEventListener('pagehide', onPageHide)
+    child.close()
+  }
+  function onPageHide(): void {
+    if (closed) {
+      return
+    }
+    closed = true
+    teardown()
+    options.onClose()
+  }
+  // Why: the user can close the OS window directly; the group must come home.
+  child.addEventListener('pagehide', onPageHide)
+
+  return { window: child, container, close }
+}
+
+function isStyleNode(node: Node): node is HTMLElement {
+  // Why: cross-realm — `node` comes from this document, so a plain nodeName
+  // check avoids depending on which realm minted it.
+  return node.nodeName === 'STYLE' || node.nodeName === 'LINK'
+}
+
+function copyStyles(target: Document): void {
+  for (const node of document.head.querySelectorAll('link[rel="stylesheet"], style')) {
+    target.head.appendChild(target.importNode(node, true))
+  }
+  // Why: constructed stylesheets (CSSOM `.sheet` writes) are invisible to both
+  // node cloning and MutationObserver — VS Code carries the same carve-out.
+  if (document.adoptedStyleSheets.length > 0) {
+    try {
+      target.adoptedStyleSheets = [...document.adoptedStyleSheets]
+    } catch {
+      // Non-fatal: those styles simply do not reach the child. Throwing here
+      // would strand an already-open window with no close() wired to it.
+    }
+  }
+}

--- a/src/renderer/src/lib/cross-realm-dom-predicates.ts
+++ b/src/renderer/src/lib/cross-realm-dom-predicates.ts
@@ -1,0 +1,78 @@
+/** Resolve DOM constructors from each value's realm; app-level events stay on opener window. */
+
+function realmOf(value: unknown): (Window & typeof globalThis) | null {
+  const node = value as Node | null | undefined
+  const view = node?.ownerDocument?.defaultView
+  if (view) {
+    return view as Window & typeof globalThis
+  }
+  // Documents have no ownerDocument; events carry their view instead.
+  const doc = value as Document | null | undefined
+  if (doc?.defaultView) {
+    return doc.defaultView as Window & typeof globalThis
+  }
+  const event = value as UIEvent | null | undefined
+  if (event?.view) {
+    return event.view as Window & typeof globalThis
+  }
+  return typeof window === 'undefined' ? null : window
+}
+
+function isInstanceOf<T>(value: unknown, ctorName: string): value is T {
+  if (value === null || typeof value !== 'object') {
+    return false
+  }
+  const realm = realmOf(value)
+  const ctor = realm?.[ctorName as keyof typeof realm] as unknown
+  if (typeof ctor === 'function' && value instanceof (ctor as new () => unknown)) {
+    return true
+  }
+  // Fall back to the opener's constructor so same-realm values still match when
+  // the value carries no usable view (detached nodes, synthetic test doubles).
+  const globalCtor = (globalThis as Record<string, unknown>)[ctorName]
+  return typeof globalCtor === 'function' && value instanceof (globalCtor as new () => unknown)
+}
+
+export function isNode(value: unknown): value is Node {
+  return isInstanceOf<Node>(value, 'Node')
+}
+
+export function isElement(value: unknown): value is Element {
+  return isInstanceOf<Element>(value, 'Element')
+}
+
+export function isHTMLElement(value: unknown): value is HTMLElement {
+  return isInstanceOf<HTMLElement>(value, 'HTMLElement')
+}
+
+export function isHTMLInputElement(value: unknown): value is HTMLInputElement {
+  return isInstanceOf<HTMLInputElement>(value, 'HTMLInputElement')
+}
+
+export function isHTMLTextAreaElement(value: unknown): value is HTMLTextAreaElement {
+  return isInstanceOf<HTMLTextAreaElement>(value, 'HTMLTextAreaElement')
+}
+
+export function isInputEvent(value: unknown): value is InputEvent {
+  return isInstanceOf<InputEvent>(value, 'InputEvent')
+}
+
+export function isCompositionEvent(value: unknown): value is CompositionEvent {
+  return isInstanceOf<CompositionEvent>(value, 'CompositionEvent')
+}
+
+export function isDocument(value: unknown): value is Document {
+  return isInstanceOf<Document>(value, 'Document')
+}
+
+/**
+ * The focused element in the document that owns `reference`.
+ *
+ * `document.activeElement` answers for the MAIN document only — while an aux
+ * window holds focus the main document reports `<body>`, so any
+ * `document.activeElement === paneNode` comparison is permanently false.
+ */
+export function activeElementFor(reference: Node | null | undefined): Element | null {
+  const doc = reference?.ownerDocument ?? (typeof document === 'undefined' ? null : document)
+  return doc?.activeElement ?? null
+}

--- a/src/renderer/src/lib/editable-target.ts
+++ b/src/renderer/src/lib/editable-target.ts
@@ -2,7 +2,7 @@
 // onboarding flow) so an in-progress text edit never gets hijacked by a
 // capture-phase keydown handler.
 export function isEditableTarget(target: EventTarget | null): boolean {
-  if (!(target instanceof HTMLElement)) {
+  if (!isHTMLElement(target)) {
     return false
   }
 
@@ -21,3 +21,4 @@ export function isEditableTarget(target: EventTarget | null): boolean {
     null
   )
 }
+import { isHTMLElement } from './cross-realm-dom-predicates'

--- a/src/renderer/src/lib/floating-workspace-shortcut-policy.ts
+++ b/src/renderer/src/lib/floating-workspace-shortcut-policy.ts
@@ -6,6 +6,7 @@ import {
   type KeybindingOverrides,
   type PhysicalModifierToken
 } from '../../../shared/keybindings'
+import { isHTMLElement } from './cross-realm-dom-predicates'
 
 // Partial<> on the key/modifier fields so a synthetic double-tap input (which
 // carries no key/modifier flags) satisfies this shape; target stays required.
@@ -34,7 +35,7 @@ export function isFloatingWorkspacePanelShortcutTarget(
   target: EventTarget | null,
   panelRoot: HTMLElement | null = null
 ): boolean {
-  if (!(target instanceof HTMLElement)) {
+  if (!isHTMLElement(target)) {
     return false
   }
   return (

--- a/src/renderer/src/lib/floating-workspace-terminal-actions.ts
+++ b/src/renderer/src/lib/floating-workspace-terminal-actions.ts
@@ -12,6 +12,7 @@ import type { AppState } from '@/store/types'
 import { TOGGLE_FLOATING_TERMINAL_EVENT } from './floating-terminal'
 import { focusTerminalTabSurface } from './focus-terminal-tab-surface'
 import { keybindingMatchesAction, type KeybindingOverrides } from '../../../shared/keybindings'
+import { isHTMLElement } from './cross-realm-dom-predicates'
 export {
   createFloatingWorkspaceBrowserTab,
   createFloatingWorkspaceMarkdownTab,
@@ -214,17 +215,17 @@ export function isFloatingWorkspacePanelFocused(
   doc: Pick<Document, 'activeElement'> | null = typeof document === 'undefined' ? null : document
 ): boolean {
   const active = doc?.activeElement
-  return active instanceof HTMLElement && active.closest(FLOATING_WORKSPACE_PANEL_SELECTOR) !== null
+  return isHTMLElement(active) && active.closest(FLOATING_WORKSPACE_PANEL_SELECTOR) !== null
 }
 
 // Event-target-aware panel membership (vs isFloatingWorkspacePanelFocused which reads only activeElement).
 // Used for routing ownership when activeElement is transiently body/null during blur/IME churn (F6/F7).
 export function isEventTargetInsideFloatingWorkspacePanel(target: EventTarget | null): boolean {
-  return target instanceof HTMLElement && target.closest(FLOATING_WORKSPACE_PANEL_SELECTOR) !== null
+  return isHTMLElement(target) && target.closest(FLOATING_WORKSPACE_PANEL_SELECTOR) !== null
 }
 
 export function isFloatingWorkspaceTerminalInputTarget(target: EventTarget | null): boolean {
-  if (!(target instanceof HTMLElement)) {
+  if (!isHTMLElement(target)) {
     return false
   }
   if (target.closest(FLOATING_WORKSPACE_PANEL_SELECTOR) === null) {

--- a/src/renderer/src/lib/focus-terminal-tab-surface.test.ts
+++ b/src/renderer/src/lib/focus-terminal-tab-surface.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { focusTerminalTabSurface } from './focus-terminal-tab-surface'
+import { registerAuxPaneContainer, unregisterAuxPaneContainer } from './aux-pane-window-registry'
 
 const mocks = vi.hoisted(() => ({
   refreshTerminalImeInputContext: vi.fn()
@@ -11,6 +12,7 @@ vi.mock('@/components/terminal-pane/terminal-ime-input-context-refresh', () => (
 
 describe('focusTerminalTabSurface', () => {
   afterEach(() => {
+    unregisterAuxPaneContainer('aux-group')
     mocks.refreshTerminalImeInputContext.mockClear()
     vi.unstubAllGlobals()
   })
@@ -35,6 +37,28 @@ describe('focusTerminalTabSurface', () => {
     focusTerminalTabSurface('tab-1')
 
     expect(textarea.focus).toHaveBeenCalled()
+  })
+
+  it('focuses a terminal mounted in an auxiliary document', () => {
+    flushAnimationFrames()
+    const textarea = { focus: vi.fn() }
+    const auxDocument = {
+      activeElement: null,
+      body: {},
+      hasFocus: () => true,
+      querySelector: vi.fn((selector: string) =>
+        selector === '[data-terminal-tab-id="tab-aux"] .xterm-helper-textarea' ? textarea : null
+      )
+    } as unknown as Document
+    registerAuxPaneContainer('aux-group', { ownerDocument: auxDocument } as HTMLElement)
+    vi.stubGlobal('document', {
+      querySelector: vi.fn(() => null),
+      hasFocus: () => false
+    })
+
+    focusTerminalTabSurface('tab-aux')
+
+    expect(textarea.focus).toHaveBeenCalledOnce()
   })
 
   it('optionally refreshes the focused helper native input context', () => {

--- a/src/renderer/src/lib/focus-terminal-tab-surface.ts
+++ b/src/renderer/src/lib/focus-terminal-tab-surface.ts
@@ -1,4 +1,5 @@
 import { refreshTerminalImeInputContext } from '@/components/terminal-pane/terminal-ime-input-context-refresh'
+import { getPaneDocuments } from '@/lib/aux-pane-window-registry'
 
 /**
  * Move keyboard focus into the xterm instance for a freshly-mounted terminal
@@ -21,8 +22,9 @@ type FocusTerminalTabSurfaceOptions = {
 
 function focusTerminalHelper(helper: HTMLElement, options: FocusTerminalTabSurfaceOptions): void {
   if (options.onlyIfFocusUnclaimed) {
-    const active = document.activeElement
-    if (active !== helper && active !== null && active !== document.body) {
+    const paneDocument = helper.ownerDocument ?? document
+    const active = paneDocument.activeElement
+    if (active !== helper && active !== null && active !== paneDocument.body) {
       return
     }
   }
@@ -45,8 +47,14 @@ function cancelPendingFocusFrames(): void {
   pendingFocusFrameIds = []
 }
 
-function canUseSinglePaneStaleLeafFallback(tabId: string, leafId: string): boolean {
-  const tabElement = document.querySelector(`[data-terminal-tab-id="${cssAttributeString(tabId)}"]`)
+function canUseSinglePaneStaleLeafFallback(
+  paneDocument: Document,
+  tabId: string,
+  leafId: string
+): boolean {
+  const tabElement = paneDocument.querySelector(
+    `[data-terminal-tab-id="${cssAttributeString(tabId)}"]`
+  )
   const expectedLeafIds = tabElement
     ?.getAttribute('data-terminal-layout-leaf-ids')
     ?.split(' ')
@@ -64,29 +72,36 @@ export function focusTerminalTabSurface(
     pendingFocusFrameIds = pendingFocusFrameIds.filter((frameId) => frameId !== firstFrameId)
     const secondFrameId = requestAnimationFrame(() => {
       pendingFocusFrameIds = pendingFocusFrameIds.filter((frameId) => frameId !== secondFrameId)
-      // Why: this can be queued before inline tab rename mounts. If it runs
-      // afterward, focusing xterm blurs the rename input and commits it closed.
-      if (document.querySelector('[data-tab-rename-input="true"]')) {
-        return
-      }
       const escapedTabId = cssAttributeString(tabId)
       const scopedSelector = leafId
         ? `[data-terminal-tab-id="${escapedTabId}"] [data-leaf-id="${cssAttributeString(leafId)}"] .xterm-helper-textarea`
         : `[data-terminal-tab-id="${escapedTabId}"] .xterm-helper-textarea`
-      const scoped = document.querySelector(scopedSelector) as HTMLElement | null
+      const paneDocuments = getPaneDocuments()
+      const paneDocument =
+        paneDocuments.find((candidate) => candidate.querySelector(scopedSelector)) ?? null
+      // Why: this can be queued before inline tab rename mounts. If it runs
+      // afterward, focusing xterm blurs the rename input and commits it closed.
+      if (paneDocument?.querySelector('[data-tab-rename-input="true"]')) {
+        return
+      }
+      const scoped = paneDocument?.querySelector(scopedSelector) as HTMLElement | null
       if (scoped) {
         focusTerminalHelper(scoped, options)
         return
       }
       if (leafId) {
-        if (!canUseSinglePaneStaleLeafFallback(tabId, leafId)) {
+        const tabDocument =
+          paneDocuments.find((candidate) =>
+            candidate.querySelector(`[data-terminal-tab-id="${escapedTabId}"]`)
+          ) ?? null
+        if (!tabDocument || !canUseSinglePaneStaleLeafFallback(tabDocument, tabId, leafId)) {
           // Why: exact mobile split-pane focus must not silently focus a sibling
           // pane when the requested UUID leaf has not mounted yet.
           return
         }
         // Why: old single-pane remounts could remint the leaf id. Only recover
         // after the tab layout no longer expects the requested leaf.
-        const tabScopedHelpers = document.querySelectorAll(
+        const tabScopedHelpers = tabDocument.querySelectorAll(
           `[data-terminal-tab-id="${escapedTabId}"] .xterm-helper-textarea`
         )
         if (tabScopedHelpers.length === 1) {
@@ -98,7 +113,11 @@ export function focusTerminalTabSurface(
         }
         return
       }
-      const fallback = document.querySelector('.xterm-helper-textarea') as HTMLElement | null
+      const fallbackDocument =
+        paneDocuments.find((candidate) => candidate.hasFocus?.() === true) ?? paneDocuments[0]
+      const fallback = fallbackDocument?.querySelector(
+        '.xterm-helper-textarea'
+      ) as HTMLElement | null
       if (fallback) {
         focusTerminalHelper(fallback, options)
       }

--- a/src/renderer/src/lib/pane-manager/pane-divider-drag.ts
+++ b/src/renderer/src/lib/pane-manager/pane-divider-drag.ts
@@ -90,17 +90,25 @@ export function attachDividerDrag(
     }
   })
 
+  // Why: a detached pane's divider lives in another window's document, and a
+  // listener on the opener never sees its pointer events — resizing would start
+  // on pointerdown and then never move.
+  const dividerWindow = (): (Window & typeof globalThis) | null =>
+    (divider.ownerDocument?.defaultView as (Window & typeof globalThis) | null) ??
+    (typeof window === 'undefined' ? null : window)
+
   const addWindowListeners = (): void => {
-    if (windowListenersAttached || typeof window === 'undefined') {
+    const view = dividerWindow()
+    if (windowListenersAttached || !view) {
       return
     }
     // Why: Chromium can transiently lose capture while the button remains held,
     // so window events keep ownership until pointerup, pointercancel, or blur.
     windowListenersAttached = true
-    window.addEventListener('pointermove', onPointerMove, true)
-    window.addEventListener('pointerup', onPointerUp, true)
-    window.addEventListener('pointercancel', onPointerCancel, true)
-    window.addEventListener('blur', onWindowBlur, true)
+    view.addEventListener('pointermove', onPointerMove, true)
+    view.addEventListener('pointerup', onPointerUp, true)
+    view.addEventListener('pointercancel', onPointerCancel, true)
+    view.addEventListener('blur', onWindowBlur, true)
   }
 
   const removeWindowListeners = (): void => {
@@ -108,10 +116,11 @@ export function attachDividerDrag(
       return
     }
     windowListenersAttached = false
-    window.removeEventListener('pointermove', onPointerMove, true)
-    window.removeEventListener('pointerup', onPointerUp, true)
-    window.removeEventListener('pointercancel', onPointerCancel, true)
-    window.removeEventListener('blur', onWindowBlur, true)
+    const view = dividerWindow()
+    view?.removeEventListener('pointermove', onPointerMove, true)
+    view?.removeEventListener('pointerup', onPointerUp, true)
+    view?.removeEventListener('pointercancel', onPointerCancel, true)
+    view?.removeEventListener('blur', onWindowBlur, true)
   }
 
   const releasePointerCaptureIfHeld = (pointerId: number | null): void => {

--- a/src/renderer/src/lib/pane-manager/pane-manager-layout-sweeps.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-layout-sweeps.ts
@@ -1,6 +1,7 @@
 import type { ManagedPaneInternal } from './pane-manager-types'
 import { equalizePaneSplitSizes } from './pane-tree-ops'
 import { fitRevealedPane } from './pane-reveal-fit'
+import { isHTMLElement } from '../cross-realm-dom-predicates'
 
 // Why: a raw synchronous fit on reveal can apply a transient DOM<->WebGL
 // cell-metric grid and reflow-garble diff-painting inline TUIs; see fitRevealedPane.
@@ -32,7 +33,7 @@ export function equalizeManagedPaneSizes(
   }
 
   const changed = equalizePaneSplitSizes(
-    root.firstElementChild instanceof HTMLElement ? root.firstElementChild : null
+    isHTMLElement(root.firstElementChild) ? root.firstElementChild : null
   )
   if (!changed) {
     return

--- a/src/renderer/src/lib/pane-manager/pane-pointer-focus.ts
+++ b/src/renderer/src/lib/pane-manager/pane-pointer-focus.ts
@@ -1,3 +1,4 @@
+import { isElement } from '../cross-realm-dom-predicates'
 const APP_CONTROL_SELECTOR = [
   'input:not(.xterm-helper-textarea)',
   'textarea:not(.xterm-helper-textarea)',
@@ -11,7 +12,7 @@ const APP_CONTROL_SELECTOR = [
 ].join(',')
 
 export function shouldFocusTerminalFromPanePointerDown(target: EventTarget | null): boolean {
-  if (typeof Element === 'undefined' || !(target instanceof Element)) {
+  if (typeof Element === 'undefined' || !isElement(target)) {
     return true
   }
 

--- a/src/renderer/src/lib/pane-manager/pane-subtree-split.ts
+++ b/src/renderer/src/lib/pane-manager/pane-subtree-split.ts
@@ -6,6 +6,7 @@ import type {
 } from './pane-manager-types'
 import type { DragReorderCallbacks } from './pane-drag-reorder'
 import { splitManagedPane } from './pane-split-close'
+import { isHTMLElement } from '../cross-realm-dom-predicates'
 
 export type SplitPaneAroundLeafIdsOptions = {
   ratio?: number
@@ -136,7 +137,7 @@ function placeCreatedPaneBeforeSource(
   }
   const divider = Array.from(split.children).find(
     (child): child is HTMLElement =>
-      child instanceof HTMLElement && child.classList.contains('pane-divider')
+      isHTMLElement(child) && child.classList.contains('pane-divider')
   )
   if (!divider) {
     return false

--- a/src/renderer/src/lib/pane-manager/pane-tree-ops.ts
+++ b/src/renderer/src/lib/pane-manager/pane-tree-ops.ts
@@ -8,6 +8,7 @@ import type {
 import { createDivider, disposeDivider } from './pane-divider'
 import { disposeWebgl, attachWebgl } from './pane-webgl-renderer'
 import { safeFit } from './pane-fit'
+import { isHTMLElement } from '../cross-realm-dom-predicates'
 
 export {
   cancelPendingSafeFitContinuations,
@@ -82,7 +83,7 @@ export function detachPaneFromTree(pane: ManagedPaneInternal, callbacks: TreeOps
   // Find sibling (skip dividers)
   const children = Array.from(parent.children).filter(
     (child): child is HTMLElement =>
-      child instanceof HTMLElement &&
+      isHTMLElement(child) &&
       (child.classList.contains('pane') || child.classList.contains('pane-split'))
   )
   const sibling = children.find((c) => c !== container) ?? null
@@ -234,7 +235,7 @@ export function applyPaneFlexStyle(el: HTMLElement): void {
 export function removeDividers(parent: HTMLElement): void {
   const dividers = Array.from(parent.children).filter(
     (child): child is HTMLElement =>
-      child instanceof HTMLElement && child.classList.contains('pane-divider')
+      isHTMLElement(child) && child.classList.contains('pane-divider')
   )
   for (const d of dividers) {
     disposeDivider(d)
@@ -246,7 +247,7 @@ export function removeDividers(parent: HTMLElement): void {
 export function findPaneChildren(parent: HTMLElement): HTMLElement[] {
   return Array.from(parent.children).filter(
     (child): child is HTMLElement =>
-      child instanceof HTMLElement &&
+      isHTMLElement(child) &&
       (child.classList.contains('pane') || child.classList.contains('pane-split'))
   )
 }

--- a/src/renderer/src/lib/pane-manager/terminal-scroll-intent-dom-tracking.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-scroll-intent-dom-tracking.ts
@@ -13,6 +13,7 @@ import {
   isTerminalScrollIntentRebuildInFlight,
   onTerminalScrollIntentBufferRebuildComplete
 } from './terminal-scroll-intent-rebuild'
+import { isElement } from '../cross-realm-dom-predicates'
 
 const XTERM_SCROLL_INTENT_POINTER_TARGET_CLASSES = [
   'xterm-viewport',
@@ -24,7 +25,7 @@ const XTERM_SCROLL_INTENT_POINTER_TARGET_SELECTOR = XTERM_SCROLL_INTENT_POINTER_
 ).join(',')
 
 function isTerminalScrollIntentPointerTarget(target: EventTarget | null): target is Element {
-  if (typeof Element === 'undefined' || !(target instanceof Element)) {
+  if (typeof Element === 'undefined' || !isElement(target)) {
     return false
   }
   // xterm's custom scrollbar uses separate thumb/track nodes from the viewport.

--- a/src/renderer/src/lib/primary-selection-capture.ts
+++ b/src/renderer/src/lib/primary-selection-capture.ts
@@ -1,19 +1,20 @@
 import { PRIMARY_SELECTION_MAX_LENGTH } from './primary-selection'
+import { isElement, isHTMLInputElement, isHTMLTextAreaElement } from './cross-realm-dom-predicates'
 
 const TEXT_INPUT_TYPES = new Set(['', 'email', 'password', 'search', 'tel', 'text', 'url'])
 
 function isTextInputElement(element: Element): element is HTMLInputElement {
-  return element instanceof HTMLInputElement && TEXT_INPUT_TYPES.has(element.type)
+  return isHTMLInputElement(element) && TEXT_INPUT_TYPES.has(element.type)
 }
 
 export function isPrimarySelectionTextControl(
   element: Element
 ): element is HTMLInputElement | HTMLTextAreaElement {
-  return isTextInputElement(element) || element instanceof HTMLTextAreaElement
+  return isTextInputElement(element) || isHTMLTextAreaElement(element)
 }
 
 function readTextControlSelection(element: HTMLInputElement | HTMLTextAreaElement): string | null {
-  if (element instanceof HTMLInputElement && element.type === 'password') {
+  if (isHTMLInputElement(element) && element.type === 'password') {
     return null
   }
 
@@ -53,12 +54,13 @@ function getRangeTextLengthUpTo(range: Range, maxLength: number): number {
     return length > maxLength
   }
 
-  if (root.nodeType === Node.TEXT_NODE) {
+  if (root.nodeType === 3) {
     addTextNode(root as Text)
     return length
   }
 
-  const walker = ownerDocument.createTreeWalker(root, NodeFilter.SHOW_TEXT)
+  const showText = ownerDocument.defaultView?.NodeFilter.SHOW_TEXT ?? 4
+  const walker = ownerDocument.createTreeWalker(root, showText)
   let node = walker.nextNode()
   while (node) {
     if (addTextNode(node as Text)) {
@@ -80,8 +82,8 @@ function selectionTextLengthExceeds(selection: Selection, maxLength: number): bo
   return false
 }
 
-function readDocumentSelection(): string | null {
-  const selection = window.getSelection()
+function readDocumentSelection(sourceDocument: Document): string | null {
+  const selection = sourceDocument.getSelection()
   if (!selection || selection.isCollapsed) {
     return null
   }
@@ -92,9 +94,11 @@ function readDocumentSelection(): string | null {
   return text.length > 0 ? text : null
 }
 
-export function readCurrentPrimarySelectionText(): string | null {
-  const activeElement = document.activeElement
-  if (activeElement instanceof Element) {
+export function readCurrentPrimarySelectionText(
+  sourceDocument: Document = document
+): string | null {
+  const activeElement = sourceDocument.activeElement
+  if (isElement(activeElement)) {
     const textControl = activeElement.closest('input, textarea')
     if (textControl && isPrimarySelectionTextControl(textControl)) {
       const text = readTextControlSelection(textControl)
@@ -104,5 +108,5 @@ export function readCurrentPrimarySelectionText(): string | null {
     }
   }
 
-  return readDocumentSelection()
+  return readDocumentSelection(sourceDocument)
 }

--- a/src/renderer/src/lib/primary-selection-paste.ts
+++ b/src/renderer/src/lib/primary-selection-paste.ts
@@ -1,6 +1,7 @@
 import { yieldToEventLoop } from '../../../shared/event-loop-yield'
 import { getUtf8ChunkEndIndex } from '../../../shared/utf8-byte-limits'
 import { isPrimarySelectionTextControl } from './primary-selection-capture'
+import { isElement, isHTMLElement } from './cross-realm-dom-predicates'
 import {
   TEXT_CONTROL_PASTE_CHUNK_MAX_BYTES,
   TEXT_CONTROL_PASTE_DIRECT_MAX_BYTES,
@@ -25,15 +26,16 @@ type PrimarySelectionPasteOptions = {
 }
 
 function dispatchInputEvent(target: Element, text: string | null): void {
+  const view = target.ownerDocument.defaultView
   const event =
-    typeof InputEvent === 'function'
-      ? new InputEvent('input', {
+    typeof view?.InputEvent === 'function'
+      ? new view.InputEvent('input', {
           bubbles: true,
           cancelable: false,
           data: text,
           inputType: 'insertFromPaste'
         })
-      : new Event('input', { bubbles: true, cancelable: false })
+      : new (view?.Event ?? Event)('input', { bubbles: true, cancelable: false })
   target.dispatchEvent(event)
 }
 
@@ -203,7 +205,7 @@ async function pasteIntoContentEditable(
 export function findEditablePrimarySelectionPasteTarget(
   target: EventTarget | null
 ): EditablePrimarySelectionPasteTarget | null {
-  if (!(target instanceof Element)) {
+  if (!isElement(target)) {
     return null
   }
   if (target.closest('.xterm-helper-textarea')) {
@@ -218,7 +220,7 @@ export function findEditablePrimarySelectionPasteTarget(
     return textControl
   }
 
-  let element: HTMLElement | null = target instanceof HTMLElement ? target : target.parentElement
+  let element: HTMLElement | null = isHTMLElement(target) ? target : target.parentElement
   while (element) {
     if (element.getAttribute('contenteditable') === 'false') {
       return null

--- a/src/renderer/src/lib/text-control-paste-ownership.ts
+++ b/src/renderer/src/lib/text-control-paste-ownership.ts
@@ -1,4 +1,5 @@
 import { isPrimarySelectionTextControl } from './primary-selection-capture'
+import { activeElementFor, isElement, isNode } from './cross-realm-dom-predicates'
 import {
   TEXT_CONTROL_PASTE_DIRECT_MAX_BYTES,
   TEXT_CONTROL_PASTE_MAX_BYTES,
@@ -25,9 +26,9 @@ export type TextControlPastePayloadOwnership =
     }
 
 export function findOwnedTextControlPasteTarget(
-  activeElement: Element | null = typeof document === 'undefined' ? null : document.activeElement
+  activeElement: Element | null = activeElementFor(null)
 ): HTMLInputElement | HTMLTextAreaElement | null {
-  if (!(activeElement instanceof Element)) {
+  if (!isElement(activeElement)) {
     return null
   }
   const textControl = activeElement.closest('input, textarea')
@@ -42,9 +43,9 @@ export function findOwnedTextControlPasteTarget(
 
 export function findOwnedPasteEventTextControlTarget(
   eventTarget: EventTarget | null,
-  activeElement: Element | null = typeof document === 'undefined' ? null : document.activeElement
+  activeElement: Element | null = activeElementFor(isNode(eventTarget) ? eventTarget : null)
 ): HTMLInputElement | HTMLTextAreaElement | null {
-  if (!(eventTarget instanceof Element)) {
+  if (!isElement(eventTarget)) {
     return null
   }
   if (eventTarget.closest('.xterm-helper-textarea')) {

--- a/src/renderer/src/lib/workspace-session-browser-history.test.ts
+++ b/src/renderer/src/lib/workspace-session-browser-history.test.ts
@@ -31,7 +31,9 @@ function createSnapshot(browserUrlHistory: BrowserHistoryEntry[]): WorkspaceSess
     worktreesByRepo: {},
     lastKnownRelayPtyIdByTabId: {},
     lastVisitedAtByWorktreeId: {},
-    defaultTerminalTabsAppliedByWorktreeId: {}
+    defaultTerminalTabsAppliedByWorktreeId: {},
+    detachedGroupIds: [],
+    auxWindowBoundsByGroupId: {}
   }
 }
 

--- a/src/renderer/src/lib/workspace-session-detached-panes.ts
+++ b/src/renderer/src/lib/workspace-session-detached-panes.ts
@@ -1,0 +1,21 @@
+import type { AuxWindowBounds } from '../../../shared/aux-window'
+import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
+
+/**
+ * Detached-pane fields for the persisted session.
+ *
+ * Omitted entirely when nothing is detached, so ordinary sessions carry neither
+ * key and older builds keep hydrating them as "nothing detached".
+ */
+export function buildDetachedPaneSessionData(snapshot: {
+  detachedGroupIds: string[]
+  auxWindowBoundsByGroupId: Record<string, AuxWindowBounds>
+}): Pick<WorkspaceSessionState, 'detachedGroupIds' | 'auxWindowBoundsByGroupId'> {
+  return {
+    detachedGroupIds: snapshot.detachedGroupIds.length > 0 ? snapshot.detachedGroupIds : undefined,
+    auxWindowBoundsByGroupId:
+      Object.keys(snapshot.auxWindowBoundsByGroupId).length > 0
+        ? snapshot.auxWindowBoundsByGroupId
+        : undefined
+  }
+}

--- a/src/renderer/src/lib/workspace-session-editor-drafts.test.ts
+++ b/src/renderer/src/lib/workspace-session-editor-drafts.test.ts
@@ -33,6 +33,8 @@ function createSnapshot(
     lastKnownRelayPtyIdByTabId: {},
     lastVisitedAtByWorktreeId: {},
     defaultTerminalTabsAppliedByWorktreeId: {},
+    detachedGroupIds: [],
+    auxWindowBoundsByGroupId: {},
     ...overrides
   }
 }

--- a/src/renderer/src/lib/workspace-session-host-field-ownership.ts
+++ b/src/renderer/src/lib/workspace-session-host-field-ownership.ts
@@ -31,6 +31,9 @@ export const WORKSPACE_SESSION_FIELD_OWNERSHIP = {
   tabGroups: 'worktreeKeyed',
   tabGroupLayouts: 'worktreeKeyed',
   activeGroupIdByWorktree: 'worktreeKeyed',
+  // Why: aux windows are an app-level surface, not per-host state.
+  detachedGroupIds: 'global',
+  auxWindowBoundsByGroupId: 'global',
   lastVisitedAtByWorktreeId: 'worktreeKeyed',
   defaultTerminalTabsAppliedByWorktreeId: 'worktreeKeyed',
   activeWorkspaceKey: 'global',

--- a/src/renderer/src/lib/workspace-session-liveness.test.ts
+++ b/src/renderer/src/lib/workspace-session-liveness.test.ts
@@ -32,6 +32,8 @@ function createSnapshot(
     lastKnownRelayPtyIdByTabId: {},
     lastVisitedAtByWorktreeId: {},
     defaultTerminalTabsAppliedByWorktreeId: {},
+    detachedGroupIds: [],
+    auxWindowBoundsByGroupId: {},
     ...overrides
   }
 }

--- a/src/renderer/src/lib/workspace-session-patch.test.ts
+++ b/src/renderer/src/lib/workspace-session-patch.test.ts
@@ -60,6 +60,8 @@ function createSnapshot(
     groupsByWorktree: {},
     layoutByWorktree: {},
     activeGroupIdByWorktree: {},
+    detachedGroupIds: [],
+    auxWindowBoundsByGroupId: {},
     sshConnectionStates: new Map(),
     repos: [],
     worktreesByRepo: {},
@@ -306,6 +308,31 @@ describe('buildWorkspaceSessionPatch', () => {
     expect(patch.activeGroupIdByWorktree?.['wt-1']).toBe('group-left')
   })
 
+  it('persists detached IDs and live bounds in incremental patches', () => {
+    const bounds = { x: 10, y: 20, width: 900, height: 600 }
+    const patch = buildWorkspaceSessionPatch(
+      createSnapshot({
+        detachedGroupIds: ['group-1'],
+        auxWindowBoundsByGroupId: { 'group-1': bounds }
+      }),
+      ['detachedGroupIds']
+    )
+
+    expect(patch).toEqual({
+      detachedGroupIds: ['group-1'],
+      auxWindowBoundsByGroupId: { 'group-1': bounds }
+    })
+  })
+
+  it('keeps detached-state clearing keys in incremental patches', () => {
+    const patch = buildWorkspaceSessionPatch(createSnapshot(), ['auxWindowBoundsByGroupId'])
+
+    expect(Object.hasOwn(patch, 'detachedGroupIds')).toBe(true)
+    expect(Object.hasOwn(patch, 'auxWindowBoundsByGroupId')).toBe(true)
+    expect(patch.detachedGroupIds).toBeUndefined()
+    expect(patch.auxWindowBoundsByGroupId).toBeUndefined()
+  })
+
   it('persists default terminal tab idempotency marker changes', () => {
     const patch = buildWorkspaceSessionPatch(
       createSnapshot({ defaultTerminalTabsAppliedByWorktreeId: { 'wt-1': true } }),
@@ -319,7 +346,11 @@ describe('buildWorkspaceSessionPatch', () => {
 
   it('keeps default terminal tab marker clearing keys in patches', () => {
     const patch = buildWorkspaceSessionPatch(
-      createSnapshot({ defaultTerminalTabsAppliedByWorktreeId: {} }),
+      createSnapshot({
+        defaultTerminalTabsAppliedByWorktreeId: {},
+        detachedGroupIds: [],
+        auxWindowBoundsByGroupId: {}
+      }),
       ['defaultTerminalTabsAppliedByWorktreeId']
     )
 

--- a/src/renderer/src/lib/workspace-session-patch.ts
+++ b/src/renderer/src/lib/workspace-session-patch.ts
@@ -7,15 +7,18 @@ import { normalizeBrowserHistoryEntries } from '../../../shared/workspace-sessio
 import {
   buildActiveConnectionIdsAtShutdown,
   buildEditorSessionData,
-  buildPersistedBrowserPagesByWorkspace,
-  buildPersistedBrowserTabsByWorktree,
   buildSanitizedTabsByWorktree,
   buildTerminalSessionData,
   type WorkspaceSessionSnapshot
 } from './workspace-session'
+import {
+  buildPersistedBrowserPagesByWorkspace,
+  buildPersistedBrowserTabsByWorktree
+} from './workspace-session-persisted-browser-collections'
 import { buildPersistedUnifiedTabSessionData } from './workspace-session-unified-tabs'
 import { buildLastVisitedAtByWorktreeId } from './workspace-session-focus-recency'
 import { buildSleepingAgentSessionData } from './workspace-session-sleeping-agents'
+import { buildDetachedPaneSessionData } from './workspace-session-detached-panes'
 
 type SessionRelevantField = keyof WorkspaceSessionSnapshot
 
@@ -136,6 +139,9 @@ export function buildWorkspaceSessionPatch(
     ] as const)
   ) {
     Object.assign(patch, buildPersistedUnifiedTabSessionData(snapshot))
+  }
+  if (hasAnyChangedField(changed, ['detachedGroupIds', 'auxWindowBoundsByGroupId'] as const)) {
+    Object.assign(patch, buildDetachedPaneSessionData(snapshot))
   }
   if (changed.has('lastVisitedAtByWorktreeId')) {
     patch.lastVisitedAtByWorktreeId = buildLastVisitedAtByWorktreeId(snapshot)

--- a/src/renderer/src/lib/workspace-session-persisted-browser-collections.ts
+++ b/src/renderer/src/lib/workspace-session-persisted-browser-collections.ts
@@ -1,0 +1,27 @@
+import type { BrowserPage, BrowserWorkspace } from '../../../shared/browser-workspace-types'
+import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
+
+// Why: `loading` is transient view state — persisting it would restore a
+// permanently-spinning tab after a restart.
+
+export function buildPersistedBrowserTabsByWorktree(
+  browserTabsByWorktree: Record<string, BrowserWorkspace[]>
+): WorkspaceSessionState['browserTabsByWorktree'] {
+  return Object.fromEntries(
+    Object.entries(browserTabsByWorktree).map(([worktreeId, tabs]) => [
+      worktreeId,
+      tabs.map((tab) => ({ ...tab, loading: false }))
+    ])
+  )
+}
+
+export function buildPersistedBrowserPagesByWorkspace(
+  browserPagesByWorkspace: Record<string, BrowserPage[]>
+): WorkspaceSessionState['browserPagesByWorkspace'] {
+  return Object.fromEntries(
+    Object.entries(browserPagesByWorkspace).map(([workspaceId, pages]) => [
+      workspaceId,
+      pages.map((page) => ({ ...page, loading: false }))
+    ])
+  )
+}

--- a/src/renderer/src/lib/workspace-session-relevant-fields.test.ts
+++ b/src/renderer/src/lib/workspace-session-relevant-fields.test.ts
@@ -27,6 +27,8 @@ describe('SESSION_RELEVANT_FIELDS', () => {
     groupsByWorktree: true,
     layoutByWorktree: true,
     activeGroupIdByWorktree: true,
+    detachedGroupIds: true,
+    auxWindowBoundsByGroupId: true,
     sshConnectionStates: true,
     repos: true,
     worktreesByRepo: true,

--- a/src/renderer/src/lib/workspace-session.test.ts
+++ b/src/renderer/src/lib/workspace-session.test.ts
@@ -20,6 +20,8 @@ function createSnapshot(overrides: Partial<AppState> = {}): AppState {
       'tab-1': { root: null, activeLeafId: null, expandedLeafId: null }
     },
     activeTabIdByWorktree: { 'wt-1': 'tab-1', 'wt-2': 'tab-2' },
+    detachedGroupIds: [],
+    auxWindowBoundsByGroupId: {},
     editorDrafts: {},
     markdownFrontmatterVisible: {},
     openFiles: [

--- a/src/renderer/src/lib/workspace-session.ts
+++ b/src/renderer/src/lib/workspace-session.ts
@@ -5,6 +5,11 @@ import type {
   WorkspaceSessionState
 } from '../../../shared/workspace-session-state-types'
 import { pruneLocalTerminalScrollbackBuffers } from '../../../shared/workspace-session-terminal-buffers'
+import { buildDetachedPaneSessionData } from './workspace-session-detached-panes'
+import {
+  buildPersistedBrowserPagesByWorkspace,
+  buildPersistedBrowserTabsByWorktree
+} from './workspace-session-persisted-browser-collections'
 import { normalizeBrowserHistoryEntries } from '../../../shared/workspace-session-browser-history'
 import type { AppState } from '../store'
 import type { OpenFile } from '../store/slices/editor'
@@ -45,6 +50,8 @@ export type WorkspaceSessionSnapshot = Pick<
   | 'groupsByWorktree'
   | 'layoutByWorktree'
   | 'activeGroupIdByWorktree'
+  | 'detachedGroupIds'
+  | 'auxWindowBoundsByGroupId'
   | 'sshConnectionStates'
   | 'repos'
   | 'worktreesByRepo'
@@ -80,6 +87,8 @@ export const SESSION_RELEVANT_FIELDS = [
   'groupsByWorktree',
   'layoutByWorktree',
   'activeGroupIdByWorktree',
+  'detachedGroupIds',
+  'auxWindowBoundsByGroupId',
   'sshConnectionStates',
   'repos',
   'worktreesByRepo',
@@ -200,28 +209,6 @@ export function buildBrowserSessionData(
   }
 }
 
-export function buildPersistedBrowserTabsByWorktree(
-  browserTabsByWorktree: Record<string, BrowserWorkspace[]>
-): WorkspaceSessionState['browserTabsByWorktree'] {
-  return Object.fromEntries(
-    Object.entries(browserTabsByWorktree).map(([worktreeId, tabs]) => [
-      worktreeId,
-      tabs.map((tab) => ({ ...tab, loading: false }))
-    ])
-  )
-}
-
-export function buildPersistedBrowserPagesByWorkspace(
-  browserPagesByWorkspace: Record<string, BrowserPage[]>
-): WorkspaceSessionState['browserPagesByWorkspace'] {
-  return Object.fromEntries(
-    Object.entries(browserPagesByWorkspace).map(([workspaceId, pages]) => [
-      workspaceId,
-      pages.map((page) => ({ ...page, loading: false }))
-    ])
-  )
-}
-
 export function buildSanitizedTabsByWorktree(
   tabsByWorktree: WorkspaceSessionSnapshot['tabsByWorktree']
 ): WorkspaceSessionState['tabsByWorktree'] {
@@ -327,6 +314,7 @@ export function buildWorkspaceSessionPayload(
       terminalSessionData.remoteSessionIdsByTabId ?? null
     ),
     remoteSessionIdsByTabId: terminalSessionData.remoteSessionIdsByTabId,
+    ...buildDetachedPaneSessionData(snapshot),
     // Why: omit when empty so builds that never stamped focus-recency don't bloat the payload. See docs/cmd-j-empty-query-ordering.md.
     lastVisitedAtByWorktreeId: buildLastVisitedAtByWorktreeId(snapshot),
     defaultTerminalTabsAppliedByWorktreeId:

--- a/src/renderer/src/runtime/sync-runtime-graph.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph.ts
@@ -7,6 +7,7 @@ import {
 import { warnTerminalLifecycleAnomaly } from '@/components/terminal-pane/terminal-lifecycle-diagnostics'
 import { getEagerPtyBufferHandle } from '@/components/terminal-pane/pty-dispatcher'
 import { createBrowserUuid } from '@/lib/browser-uuid'
+import { isHTMLElement } from '@/lib/cross-realm-dom-predicates'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import { resolveLeafIdForManager } from '@/lib/pane-manager/pane-key-resolution'
 import { getSystemPrefersDark, resolveEffectiveTerminalAppearance } from '@/lib/terminal-theme'
@@ -748,8 +749,7 @@ async function syncRuntimeGraph(): Promise<void> {
     const manager = registeredTab.getManager()
     const container = registeredTab.getContainer()
     const activePaneId = manager?.getActivePane()?.id ?? null
-    const root =
-      container?.firstElementChild instanceof HTMLElement ? container.firstElementChild : null
+    const root = isHTMLElement(container?.firstElementChild) ? container.firstElementChild : null
 
     graph.tabs.push({
       tabId,
@@ -1108,9 +1108,7 @@ function captureMountedTerminalSurface(
     paneLeafIds,
     hasLiveActivePane: activePane !== null,
     liveActiveLeafId: activePane !== null ? (manager?.getLeafId(activePane.id) ?? null) : null,
-    liveLayoutRoot: serializePaneTree(
-      typeof HTMLElement !== 'undefined' && firstChild instanceof HTMLElement ? firstChild : null
-    ),
+    liveLayoutRoot: serializePaneTree(isHTMLElement(firstChild) ? firstChild : null),
     numericPaneIdByLeafId,
     ptyIdByNumericPaneId,
     tabWideAgentHintLeafId: registered.getTabWideAgentHintLeafId()

--- a/src/renderer/src/runtime/web-session-tabs-sync-layout-groups.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync-layout-groups.test.ts
@@ -248,6 +248,92 @@ describe('applyWebSessionTabsSnapshot', () => {
     expect(editorTab).toMatchObject({ id: 'host-readme-unified', groupId: 'group-editor' })
   })
 
+  it('reattaches a remote group when its snapshot adds nonterminal content', () => {
+    const localTerminalTab: Tab = {
+      id: 'local-terminal',
+      entityId: 'local-terminal',
+      groupId: 'host-group-1',
+      worktreeId: WT,
+      contentType: 'terminal',
+      label: 'Terminal',
+      customLabel: null,
+      color: null,
+      sortOrder: 0,
+      createdAt: NOW,
+      isPreview: false,
+      isPinned: false
+    }
+    const patch = applyWebSessionTabsSnapshot(
+      makeState({
+        detachedGroupIds: ['host-group-1'],
+        auxWindowBoundsByGroupId: {
+          'host-group-1': { x: 10, y: 20, width: 800, height: 600 }
+        },
+        tabsByWorktree: {
+          [WT]: [
+            {
+              id: localTerminalTab.entityId,
+              ptyId: 'local-pty',
+              worktreeId: WT,
+              title: 'Terminal',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: NOW
+            }
+          ]
+        },
+        unifiedTabsByWorktree: { [WT]: [localTerminalTab] },
+        groupsByWorktree: {
+          [WT]: [
+            {
+              id: 'host-group-1',
+              worktreeId: WT,
+              activeTabId: localTerminalTab.id,
+              tabOrder: [localTerminalTab.id]
+            }
+          ]
+        }
+      }),
+      makeSnapshot(
+        [
+          {
+            type: 'markdown',
+            id: 'host-readme-unified',
+            title: 'README.md',
+            filePath: '/repo/README.md',
+            relativePath: 'README.md',
+            language: 'markdown',
+            mode: 'edit',
+            isDirty: false,
+            isActive: true,
+            sourceFileId: '/repo/README.md',
+            sourceFilePath: '/repo/README.md',
+            sourceRelativePath: 'README.md',
+            documentVersion: 'file:/repo/README.md'
+          }
+        ],
+        {
+          activeTabId: 'host-readme-unified',
+          activeTabType: 'markdown',
+          tabGroups: [
+            {
+              id: 'host-group-1',
+              activeTabId: 'host-readme-unified',
+              tabOrder: ['host-readme-unified']
+            }
+          ]
+        }
+      ),
+      ENV,
+      NOW
+    ) as Partial<WebSessionTabsSyncState>
+
+    expect(patch.detachedGroupIds).toEqual([])
+    expect(patch.auxWindowBoundsByGroupId).toBeUndefined()
+    expect(patch.groupsByWorktree?.[WT]?.[0]?.tabOrder).toContain('host-readme-unified')
+  })
+
   it('preserves local browser position when appending a new remote terminal', () => {
     const firstTerminalId = toWebTerminalSurfaceTabId('host-tab-1')
     const secondTerminalId = toWebTerminalSurfaceTabId('host-tab-2')

--- a/src/renderer/src/runtime/web-session-tabs-sync-test-harness.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync-test-harness.ts
@@ -55,6 +55,7 @@ export function makeState(
     browserCertificateFailuresByPageId: {},
     browserPagesByWorkspace: {},
     browserTabsByWorktree: {},
+    detachedGroupIds: [],
     groupsByWorktree: {},
     layoutByWorktree: {},
     openFiles: [],
@@ -65,6 +66,7 @@ export function makeState(
     terminalLayoutsByTabId: {},
     unifiedTabsByWorktree: {},
     unreadTerminalTabs: {},
+    auxWindowBoundsByGroupId: {},
     sortEpoch: 0,
     ...overrides
   }

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -100,6 +100,7 @@ import {
   buildWebSessionExistingTabIndex,
   type WebSessionExistingTabIndex
 } from './web-session-existing-tab-index'
+import { buildDetachedTabGroupIntegrityPatch } from '@/store/slices/detached-tab-groups'
 
 const WEB_SESSION_GROUP_PREFIX = 'web-session-tabs:'
 export const WEB_SESSION_TABS_VISIBILITY_RESUME_STAGGER_MS = 100
@@ -218,7 +219,15 @@ export type WebSessionTabsSyncState = Pick<
   | 'unreadTerminalTabs'
   | 'sortEpoch'
 > &
-  Partial<Pick<AppState, 'automaticAgentResumeClaimsByTabId' | 'pendingStartupByTabId'>>
+  Partial<
+    Pick<
+      AppState,
+      | 'automaticAgentResumeClaimsByTabId'
+      | 'auxWindowBoundsByGroupId'
+      | 'detachedGroupIds'
+      | 'pendingStartupByTabId'
+    >
+  >
 
 type WebSessionTabsBatchRecordKey =
   | 'activeBrowserTabIdByWorktree'
@@ -3243,9 +3252,22 @@ function applyWebSessionTabsSnapshotWithContext(
     now,
     batchContext
   )
+  const detachedGroupIntegrityPatch = buildDetachedTabGroupIntegrityPatch(
+    {
+      detachedGroupIds: state.detachedGroupIds ?? [],
+      auxWindowBoundsByGroupId: state.auxWindowBoundsByGroupId ?? {},
+      groupsByWorktree: state.groupsByWorktree,
+      unifiedTabsByWorktree: state.unifiedTabsByWorktree
+    },
+    {
+      groupsByWorktree: nextGroupsByWorktree,
+      unifiedTabsByWorktree: nextUnifiedTabsByWorktree
+    }
+  )
 
   const patch: Partial<WebSessionTabsSyncState> = {
     ...agentStatusPatch,
+    ...detachedGroupIntegrityPatch,
     ...(nextOpenFiles !== state.openFiles ? { openFiles: nextOpenFiles } : {}),
     ...(nextTabsByWorktree !== state.tabsByWorktree ? { tabsByWorktree: nextTabsByWorktree } : {}),
     ...(nextBrowserTabsByWorktree !== state.browserTabsByWorktree

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -5,6 +5,7 @@ import { createSparsePresetsSlice } from './slices/sparse-presets'
 import { createWorktreeSlice } from './slices/worktrees'
 import { createTerminalSlice } from './slices/terminals'
 import { createTabsSlice } from './slices/tabs'
+import { createDetachedTabGroupsSlice } from './slices/detached-tab-groups'
 import { createUISlice } from './slices/ui'
 import { createSettingsSlice } from './slices/settings'
 import { createKeybindingsSlice } from './slices/keybindings'
@@ -67,6 +68,7 @@ export const useAppStore = create<AppState>()((...a) => {
     ...createWorktreeSlice(...a),
     ...createTerminalSlice(...a),
     ...createTabsSlice(...a),
+    ...createDetachedTabGroupsSlice(...a),
     ...createUISlice(...a),
     ...createSettingsSlice(...a),
     ...createKeybindingsSlice(...a),

--- a/src/renderer/src/store/pinned-tab-close-guard.ts
+++ b/src/renderer/src/store/pinned-tab-close-guard.ts
@@ -39,8 +39,9 @@ export function guardPinnedTabClose(params: {
   tabLabel: string
   onClose: () => void
   onCancel?: () => void
+  dialogContainer?: HTMLElement | null
 }): void {
-  const { isPinned, tabLabel, onClose, onCancel } = params
+  const { isPinned, tabLabel, onClose, onCancel, dialogContainer } = params
   if (!isPinned) {
     onClose()
     return
@@ -55,6 +56,7 @@ export function guardPinnedTabClose(params: {
   state.requestPinnedTabCloseConfirm({
     tabLabel,
     onConfirm: onClose,
-    ...(onCancel ? { onCancel } : {})
+    ...(onCancel ? { onCancel } : {}),
+    ...(dialogContainer ? { dialogContainer } : {})
   })
 }

--- a/src/renderer/src/store/running-terminal-close-confirm.ts
+++ b/src/renderer/src/store/running-terminal-close-confirm.ts
@@ -9,6 +9,7 @@ export type RunningTerminalCloseConfirmRequest = {
   copyKind: CloseTerminalDialogCopyKind
   onConfirm: () => void
   onCancel?: () => void
+  dialogContainer?: HTMLElement | null
 }
 
 export type RunningTerminalCloseConfirmState = {

--- a/src/renderer/src/store/slices/browser.ts
+++ b/src/renderer/src/store/slices/browser.ts
@@ -154,7 +154,10 @@ export type BrowserSlice = {
     url: string,
     options?: CreateBrowserTabOptions
   ) => BrowserWorkspace
-  openNewBrowserTabInActiveWorkspace: (groupId: string) => Promise<void>
+  openNewBrowserTabInActiveWorkspace: (
+    groupId: string,
+    worktreeIdOverride?: string
+  ) => Promise<void>
   openBrowserProfileTabInActiveWorkspace: (url: string, profileId: string) => Promise<boolean>
   closeBrowserTab: (tabId: string) => void
   shutdownWorktreeBrowsers: (worktreeId: string) => Promise<void>
@@ -718,9 +721,9 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
     return browserTab
   },
 
-  openNewBrowserTabInActiveWorkspace: async (groupId) => {
+  openNewBrowserTabInActiveWorkspace: async (groupId, worktreeIdOverride) => {
     const state = get()
-    const worktreeId = state.activeWorktreeId
+    const worktreeId = worktreeIdOverride ?? state.activeWorktreeId
     if (!worktreeId) {
       return
     }

--- a/src/renderer/src/store/slices/cmd-j-create-actions.test.ts
+++ b/src/renderer/src/store/slices/cmd-j-create-actions.test.ts
@@ -191,6 +191,89 @@ describe('Cmd+J lifted creation actions', () => {
     expect(store.getState().tabsByWorktree['wt-1'] ?? []).toEqual([])
   })
 
+  it('does not change global selection when creating a native background-worktree terminal', async () => {
+    delete pairedWebFlag.__ORCA_WEB_CLIENT__
+    const store = createTestStore()
+    seedActiveWorkspace(store)
+    store.setState({
+      activeTabId: 'main-tab',
+      activeTabType: 'browser',
+      repos: [{ ...TEST_REPO, executionHostId: 'local' }],
+      worktreesByRepo: {
+        [TEST_REPO.id]: [
+          makeWorktree({ id: 'wt-1', repoId: TEST_REPO.id, hostId: 'local' }),
+          makeWorktree({ id: 'wt-2', repoId: TEST_REPO.id, hostId: 'local' })
+        ]
+      },
+      groupsByWorktree: {
+        ...store.getState().groupsByWorktree,
+        'wt-2': [{ id: 'group-2', worktreeId: 'wt-2', activeTabId: null, tabOrder: [] }]
+      },
+      activeGroupIdByWorktree: {
+        ...store.getState().activeGroupIdByWorktree,
+        'wt-2': 'group-2'
+      }
+    })
+
+    await store.getState().openNewTerminalTabInActiveWorkspace('group-2', 'wt-2')
+
+    expect(store.getState().tabsByWorktree['wt-2']).toHaveLength(1)
+    expect(store.getState()).toMatchObject({
+      activeWorktreeId: 'wt-1',
+      activeTabId: 'main-tab',
+      activeTabType: 'browser'
+    })
+  })
+
+  it('does not select a background worktree during web-runtime terminal creation', async () => {
+    createWebRuntimeSessionTerminalMock.mockResolvedValue(false)
+    const store = createTestStore()
+    seedActiveWorkspace(store)
+    store.setState({
+      activeTabId: 'main-tab',
+      activeTabType: 'browser',
+      worktreesByRepo: {
+        [TEST_REPO.id]: [
+          makeWorktree({
+            id: 'wt-1',
+            repoId: TEST_REPO.id,
+            hostId: 'runtime:runtime-1',
+            runtimeOwnerEnvironmentId: 'runtime-1'
+          }),
+          makeWorktree({
+            id: 'wt-2',
+            repoId: TEST_REPO.id,
+            hostId: 'runtime:runtime-1',
+            runtimeOwnerEnvironmentId: 'runtime-1'
+          })
+        ]
+      },
+      groupsByWorktree: {
+        ...store.getState().groupsByWorktree,
+        'wt-2': [{ id: 'group-2', worktreeId: 'wt-2', activeTabId: null, tabOrder: [] }]
+      },
+      activeGroupIdByWorktree: {
+        ...store.getState().activeGroupIdByWorktree,
+        'wt-2': 'group-2'
+      }
+    })
+
+    await store.getState().openNewTerminalTabInActiveWorkspace('group-2', 'wt-2')
+
+    expect(createWebRuntimeSessionTerminalMock).toHaveBeenCalledWith({
+      worktreeId: 'wt-2',
+      environmentId: 'runtime-1',
+      targetGroupId: 'group-2',
+      activate: false,
+      selectWorktree: false
+    })
+    expect(store.getState()).toMatchObject({
+      activeWorktreeId: 'wt-1',
+      activeTabId: 'main-tab',
+      activeTabType: 'browser'
+    })
+  })
+
   it('does not create a local folder terminal while paired ownership is unresolved', async () => {
     const folderId = 'folder-1'
     const workspaceKey = folderWorkspaceKey(folderId)

--- a/src/renderer/src/store/slices/detached-tab-groups-hydration.test.ts
+++ b/src/renderer/src/store/slices/detached-tab-groups-hydration.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import type { WorkspaceSessionState } from '../../../../shared/workspace-session-state-types'
+import { createTestStore, makeTabGroup, makeUnifiedTab, makeWorktree } from './store-test-helpers'
+
+const WORKTREE_ID = 'repo1::/tmp/feature'
+
+describe('detached tab group hydration', () => {
+  it('restores only live terminal-only groups and prunes stale bounds', () => {
+    const store = createTestStore()
+    store.setState({
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: WORKTREE_ID, repoId: 'repo1' })]
+      }
+    })
+    const session: WorkspaceSessionState = {
+      activeRepoId: 'repo1',
+      activeWorktreeId: WORKTREE_ID,
+      activeTabId: 'terminal-1',
+      tabsByWorktree: {},
+      terminalLayoutsByTabId: {},
+      unifiedTabs: {
+        [WORKTREE_ID]: [
+          makeUnifiedTab({
+            id: 'terminal-1',
+            worktreeId: WORKTREE_ID,
+            groupId: 'terminal-group'
+          }),
+          makeUnifiedTab({
+            id: 'editor-1',
+            worktreeId: WORKTREE_ID,
+            groupId: 'mixed-group',
+            contentType: 'editor'
+          })
+        ]
+      },
+      tabGroups: {
+        [WORKTREE_ID]: [
+          makeTabGroup({
+            id: 'terminal-group',
+            worktreeId: WORKTREE_ID,
+            activeTabId: 'terminal-1',
+            tabOrder: ['terminal-1']
+          }),
+          makeTabGroup({
+            id: 'mixed-group',
+            worktreeId: WORKTREE_ID,
+            activeTabId: 'editor-1',
+            tabOrder: ['editor-1']
+          })
+        ]
+      },
+      detachedGroupIds: ['terminal-group', 'mixed-group', 'missing-group'],
+      auxWindowBoundsByGroupId: {
+        'terminal-group': { x: 1, y: 2, width: 900, height: 600 },
+        'mixed-group': { x: 3, y: 4, width: 900, height: 600 },
+        'missing-group': { x: 5, y: 6, width: 900, height: 600 }
+      }
+    }
+
+    store.getState().hydrateTabsSession(session)
+
+    expect(store.getState().detachedGroupIds).toEqual(['terminal-group'])
+    expect(store.getState().auxWindowBoundsByGroupId).toEqual({
+      'terminal-group': { x: 1, y: 2, width: 900, height: 600 },
+      'mixed-group': { x: 3, y: 4, width: 900, height: 600 }
+    })
+  })
+})

--- a/src/renderer/src/store/slices/detached-tab-groups.test.ts
+++ b/src/renderer/src/store/slices/detached-tab-groups.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import { createTestStore } from './store-test-helpers'
+
+function createTerminalGroup(store: ReturnType<typeof createTestStore>, id: string): string {
+  return store.getState().createUnifiedTab('worktree-1', 'terminal', { id }).groupId
+}
+
+describe('detached tab groups', () => {
+  it('detaches, stays idempotent, and reattaches', () => {
+    const store = createTestStore()
+    const group1 = createTerminalGroup(store, 'terminal-1')
+    const terminal2 = store
+      .getState()
+      .createUnifiedTabInSplit(
+        'worktree-1',
+        'terminal',
+        { sourceGroupId: group1, splitDirection: 'right' },
+        { id: 'terminal-2' }
+      )!
+
+    expect(store.getState().detachedGroupIds).toEqual([])
+
+    store.getState().detachTabGroup(group1)
+    store.getState().detachTabGroup(group1)
+    expect(store.getState().detachedGroupIds).toEqual([group1])
+
+    store.getState().detachTabGroup(terminal2.groupId)
+    expect(store.getState().detachedGroupIds).toEqual([group1, terminal2.groupId])
+
+    store.getState().reattachTabGroup(group1)
+    expect(store.getState().detachedGroupIds).toEqual([terminal2.groupId])
+  })
+
+  it('keeps the same state object when nothing changes', () => {
+    const store = createTestStore()
+    const groupId = createTerminalGroup(store, 'terminal-1')
+    store.getState().detachTabGroup(groupId)
+    const before = store.getState().detachedGroupIds
+
+    // Why: a fresh array on a no-op would re-render every pane subscribing to it.
+    store.getState().detachTabGroup(groupId)
+    store.getState().reattachTabGroup('group-absent')
+    expect(store.getState().detachedGroupIds).toBe(before)
+  })
+
+  it('rejects nonterminal groups and reattaches before adding nonterminal content', () => {
+    const store = createTestStore()
+    const terminalGroup = createTerminalGroup(store, 'terminal-1')
+    const editor = store
+      .getState()
+      .createUnifiedTabInSplit(
+        'worktree-1',
+        'editor',
+        { sourceGroupId: terminalGroup, splitDirection: 'right' },
+        { id: 'editor-1' }
+      )!
+
+    store.getState().detachTabGroup(editor.groupId)
+    expect(store.getState().detachedGroupIds).toEqual([])
+
+    store.getState().detachTabGroup(terminalGroup)
+    store.getState().createUnifiedTab('worktree-1', 'browser', {
+      id: 'browser-1',
+      targetGroupId: terminalGroup
+    })
+    expect(store.getState().detachedGroupIds).toEqual([])
+  })
+
+  it('reattaches a destination receiving nonterminal content', () => {
+    const store = createTestStore()
+    const terminalGroup = createTerminalGroup(store, 'terminal-1')
+    const editor = store
+      .getState()
+      .createUnifiedTabInSplit(
+        'worktree-1',
+        'editor',
+        { sourceGroupId: terminalGroup, splitDirection: 'right' },
+        { id: 'editor-1' }
+      )!
+    store.getState().detachTabGroup(terminalGroup)
+
+    expect(store.getState().moveUnifiedTabToGroup(editor.id, terminalGroup)).toBe(true)
+    expect(store.getState().detachedGroupIds).toEqual([])
+  })
+
+  it('prunes detached state and bounds when a group disappears', () => {
+    const store = createTestStore()
+    const firstGroup = createTerminalGroup(store, 'terminal-1')
+    const second = store
+      .getState()
+      .createUnifiedTabInSplit(
+        'worktree-1',
+        'terminal',
+        { sourceGroupId: firstGroup, splitDirection: 'right' },
+        { id: 'terminal-2' }
+      )!
+    store.getState().detachTabGroup(second.groupId)
+    store
+      .getState()
+      .recordAuxWindowBounds(second.groupId, { x: 10, y: 20, width: 900, height: 600 })
+
+    expect(store.getState().moveUnifiedTabToGroup(second.id, firstGroup)).toBe(true)
+    expect(store.getState().detachedGroupIds).toEqual([])
+    expect(store.getState().auxWindowBoundsByGroupId).toEqual({})
+
+    store
+      .getState()
+      .recordAuxWindowBounds(second.groupId, { x: 30, y: 40, width: 900, height: 600 })
+    expect(store.getState().auxWindowBoundsByGroupId).toEqual({})
+  })
+})

--- a/src/renderer/src/store/slices/detached-tab-groups.ts
+++ b/src/renderer/src/store/slices/detached-tab-groups.ts
@@ -1,0 +1,143 @@
+import type { StateCreator } from 'zustand'
+import type { AuxWindowBounds } from '../../../../shared/aux-window'
+import type { AppState } from '../types'
+import type { Tab, TabGroup } from '../../../../shared/tab-types'
+
+type DetachedTabGroupState = Pick<
+  AppState,
+  'detachedGroupIds' | 'auxWindowBoundsByGroupId' | 'groupsByWorktree' | 'unifiedTabsByWorktree'
+>
+
+function liveGroupIds(groupsByWorktree: Record<string, TabGroup[]>): Set<string> {
+  return new Set(
+    Object.values(groupsByWorktree).flatMap((groups) => groups.map((group) => group.id))
+  )
+}
+
+function terminalOnlyGroupIds(
+  groupsByWorktree: Record<string, TabGroup[]>,
+  unifiedTabsByWorktree: Record<string, Tab[]>
+): Set<string> {
+  const eligible = new Set<string>()
+  for (const [worktreeId, groups] of Object.entries(groupsByWorktree)) {
+    const tabsById = new Map(
+      (unifiedTabsByWorktree[worktreeId] ?? []).map((tab) => [tab.id, tab] as const)
+    )
+    for (const group of groups) {
+      if (
+        group.tabOrder.length > 0 &&
+        group.tabOrder.every((tabId) => tabsById.get(tabId)?.contentType === 'terminal')
+      ) {
+        eligible.add(group.id)
+      }
+    }
+  }
+  return eligible
+}
+
+export function buildDetachedTabGroupIntegrityPatch(
+  state: DetachedTabGroupState,
+  next: Partial<Pick<DetachedTabGroupState, 'groupsByWorktree' | 'unifiedTabsByWorktree'>> = {}
+): Partial<Pick<AppState, 'detachedGroupIds' | 'auxWindowBoundsByGroupId'>> {
+  const groupsByWorktree = next.groupsByWorktree ?? state.groupsByWorktree
+  const unifiedTabsByWorktree = next.unifiedTabsByWorktree ?? state.unifiedTabsByWorktree
+  const currentDetachedGroupIds = state.detachedGroupIds ?? []
+  const currentBounds = state.auxWindowBoundsByGroupId ?? {}
+  if (currentDetachedGroupIds.length === 0 && Object.keys(currentBounds).length === 0) {
+    return {}
+  }
+  const liveIds = liveGroupIds(groupsByWorktree)
+  const eligibleIds =
+    currentDetachedGroupIds.length > 0
+      ? terminalOnlyGroupIds(groupsByWorktree, unifiedTabsByWorktree)
+      : null
+  const detachedGroupIds =
+    eligibleIds === null
+      ? currentDetachedGroupIds
+      : currentDetachedGroupIds.filter((groupId) => eligibleIds.has(groupId))
+  const auxWindowBoundsByGroupId = Object.fromEntries(
+    Object.entries(currentBounds).filter(([groupId]) => liveIds.has(groupId))
+  )
+  return {
+    ...(detachedGroupIds.length !== currentDetachedGroupIds.length ? { detachedGroupIds } : {}),
+    ...(Object.keys(auxWindowBoundsByGroupId).length !== Object.keys(currentBounds).length
+      ? { auxWindowBoundsByGroupId }
+      : {})
+  }
+}
+
+export type DetachedTabGroupsSlice = {
+  /**
+   * Tab groups rendered into their own OS window instead of the main layout.
+   * Persisted in the workspace session so the windows reopen on restart.
+   */
+  detachedGroupIds: string[]
+  /** Last known screen bounds per detached group, so a window reopens in place. */
+  auxWindowBoundsByGroupId: Record<string, AuxWindowBounds>
+  detachTabGroup: (groupId: string) => void
+  reattachTabGroup: (groupId: string) => void
+  recordAuxWindowBounds: (groupId: string, bounds: AuxWindowBounds) => void
+  hydrateDetachedTabGroups: (
+    detachedGroupIds: string[],
+    auxWindowBoundsByGroupId: Record<string, AuxWindowBounds>
+  ) => void
+}
+
+export const createDetachedTabGroupsSlice: StateCreator<
+  AppState,
+  [],
+  [],
+  DetachedTabGroupsSlice
+> = (set) => ({
+  detachedGroupIds: [],
+  auxWindowBoundsByGroupId: {},
+  detachTabGroup: (groupId) =>
+    set((state) => {
+      if (state.detachedGroupIds.includes(groupId)) {
+        return state
+      }
+      const eligibleIds = terminalOnlyGroupIds(state.groupsByWorktree, state.unifiedTabsByWorktree)
+      return eligibleIds.has(groupId)
+        ? { detachedGroupIds: [...state.detachedGroupIds, groupId] }
+        : state
+    }),
+  reattachTabGroup: (groupId) =>
+    set((state) =>
+      state.detachedGroupIds.includes(groupId)
+        ? { detachedGroupIds: state.detachedGroupIds.filter((id) => id !== groupId) }
+        : state
+    ),
+  recordAuxWindowBounds: (groupId, bounds) =>
+    set((state) => {
+      if (!liveGroupIds(state.groupsByWorktree).has(groupId)) {
+        return state
+      }
+      const previous = state.auxWindowBoundsByGroupId[groupId]
+      if (
+        previous &&
+        previous.x === bounds.x &&
+        previous.y === bounds.y &&
+        previous.width === bounds.width &&
+        previous.height === bounds.height
+      ) {
+        return state
+      }
+      return {
+        auxWindowBoundsByGroupId: { ...state.auxWindowBoundsByGroupId, [groupId]: bounds }
+      }
+    }),
+  hydrateDetachedTabGroups: (detachedGroupIds, auxWindowBoundsByGroupId) =>
+    set((state) => {
+      const candidate = {
+        ...state,
+        detachedGroupIds: [...detachedGroupIds],
+        auxWindowBoundsByGroupId: { ...auxWindowBoundsByGroupId }
+      }
+      const patch = buildDetachedTabGroupIntegrityPatch(candidate)
+      return {
+        detachedGroupIds: patch.detachedGroupIds ?? candidate.detachedGroupIds,
+        auxWindowBoundsByGroupId:
+          patch.auxWindowBoundsByGroupId ?? candidate.auxWindowBoundsByGroupId
+      }
+    })
+})

--- a/src/renderer/src/store/slices/editor/actions/markdown-preview-actions.ts
+++ b/src/renderer/src/store/slices/editor/actions/markdown-preview-actions.ts
@@ -24,9 +24,9 @@ export function createMarkdownPreviewActions(
   | 'pinFile'
 > {
   return {
-    openNewMarkdownInActiveWorkspace: async (groupId) => {
+    openNewMarkdownInActiveWorkspace: async (groupId, worktreeIdOverride) => {
       const state = get()
-      const worktreeId = state.activeWorktreeId
+      const worktreeId = worktreeIdOverride ?? state.activeWorktreeId
       if (!worktreeId) {
         return
       }

--- a/src/renderer/src/store/slices/editor/types/editor-files-slice.ts
+++ b/src/renderer/src/store/slices/editor/types/editor-files-slice.ts
@@ -46,7 +46,7 @@ export type EditorFilesSlice = {
       reopenId?: string
     }
   ) => string
-  openNewMarkdownInActiveWorkspace: (groupId: string) => Promise<void>
+  openNewMarkdownInActiveWorkspace: (groupId: string, worktreeIdOverride?: string) => Promise<void>
   // Why: sequences openFile/setMarkdownViewMode/reveal around an async Monaco remount. See docs/markdown-internal-link-opening-design.md.
   activateMarkdownLink: (
     rawHref: string | undefined,

--- a/src/renderer/src/store/slices/partial-detached-tab-group-hydration.ts
+++ b/src/renderer/src/store/slices/partial-detached-tab-group-hydration.ts
@@ -1,0 +1,59 @@
+import type { AuxWindowBounds } from '../../../../shared/aux-window'
+import type { Tab, TabGroup } from '../../../../shared/tab-types'
+import { buildDetachedTabGroupIntegrityPatch } from './detached-tab-groups'
+
+type DetachedState = {
+  detachedGroupIds: string[]
+  auxWindowBoundsByGroupId: Record<string, AuxWindowBounds>
+  groupsByWorktree: Record<string, TabGroup[]>
+  unifiedTabsByWorktree: Record<string, Tab[]>
+}
+
+function groupOwners(groupsByWorktree: Record<string, TabGroup[]>): Map<string, string> {
+  const owners = new Map<string, string>()
+  for (const [worktreeId, groups] of Object.entries(groupsByWorktree)) {
+    for (const group of groups) {
+      owners.set(group.id, worktreeId)
+    }
+  }
+  return owners
+}
+
+export function mergePartialDetachedTabGroupHydration(args: {
+  current: DetachedState
+  incoming: Pick<DetachedState, 'detachedGroupIds' | 'auxWindowBoundsByGroupId'>
+  nextGroupsByWorktree: Record<string, TabGroup[]>
+  nextUnifiedTabsByWorktree: Record<string, Tab[]>
+  replaceWorkspaceKeys: ReadonlySet<string>
+}): Pick<DetachedState, 'detachedGroupIds' | 'auxWindowBoundsByGroupId'> {
+  const currentOwners = groupOwners(args.current.groupsByWorktree)
+  const nextOwners = groupOwners(args.nextGroupsByWorktree)
+  const retainedIds = args.current.detachedGroupIds.filter((groupId) => {
+    const owner = currentOwners.get(groupId)
+    return owner !== undefined && !args.replaceWorkspaceKeys.has(owner)
+  })
+  const incomingIds = args.incoming.detachedGroupIds.filter((groupId) => {
+    const owner = nextOwners.get(groupId)
+    return owner !== undefined && args.replaceWorkspaceKeys.has(owner)
+  })
+  const detachedGroupIds = [...new Set([...retainedIds, ...incomingIds])]
+  const auxWindowBoundsByGroupId = Object.fromEntries(
+    [...nextOwners].flatMap(([groupId, owner]) => {
+      const bounds = args.replaceWorkspaceKeys.has(owner)
+        ? args.incoming.auxWindowBoundsByGroupId[groupId]
+        : args.current.auxWindowBoundsByGroupId[groupId]
+      return bounds ? [[groupId, bounds] as const] : []
+    })
+  )
+  const candidate = {
+    detachedGroupIds,
+    auxWindowBoundsByGroupId,
+    groupsByWorktree: args.nextGroupsByWorktree,
+    unifiedTabsByWorktree: args.nextUnifiedTabsByWorktree
+  }
+  const patch = buildDetachedTabGroupIntegrityPatch(candidate)
+  return {
+    detachedGroupIds: patch.detachedGroupIds ?? detachedGroupIds,
+    auxWindowBoundsByGroupId: patch.auxWindowBoundsByGroupId ?? auxWindowBoundsByGroupId
+  }
+}

--- a/src/renderer/src/store/slices/pinned-tab-close-confirm.ts
+++ b/src/renderer/src/store/slices/pinned-tab-close-confirm.ts
@@ -7,6 +7,7 @@ export type PinnedTabCloseConfirmRequest = {
   tabLabel: string
   onConfirm: () => void
   onCancel?: () => void
+  dialogContainer?: HTMLElement | null
 }
 
 export type PinnedTabCloseConfirmSlice = {

--- a/src/renderer/src/store/slices/store-test-helpers.ts
+++ b/src/renderer/src/store/slices/store-test-helpers.ts
@@ -9,6 +9,7 @@ import { createSparsePresetsSlice } from './sparse-presets'
 import { createWorktreeSlice } from './worktrees'
 import { createTerminalSlice } from './terminals'
 import { createTabsSlice } from './tabs'
+import { createDetachedTabGroupsSlice } from './detached-tab-groups'
 import { createUISlice } from './ui'
 import { createSettingsSlice } from './settings'
 import { createKeybindingsSlice } from './keybindings'
@@ -66,6 +67,7 @@ export function createTestStore() {
     ...createWorktreeSlice(...a),
     ...createTerminalSlice(...a),
     ...createTabsSlice(...a),
+    ...createDetachedTabGroupsSlice(...a),
     ...createUISlice(...a),
     ...createSettingsSlice(...a),
     ...createKeybindingsSlice(...a),

--- a/src/renderer/src/store/slices/tabs-session-hydration.test.ts
+++ b/src/renderer/src/store/slices/tabs-session-hydration.test.ts
@@ -428,6 +428,87 @@ describe('TabsSlice', () => {
       expect(store.getState().groupsByWorktree[siblingWorktreeId]).toBe(siblingGroups)
     })
 
+    it('merges detached state across partial SSH and folder hydration scopes', () => {
+      const siblingWorktreeId = 'folder::host-b::workspace-b'
+      const targetGroup = makeTabGroup({
+        id: 'group-host-a',
+        worktreeId: WT,
+        activeTabId: 'tab-host-a',
+        tabOrder: ['tab-host-a']
+      })
+      const siblingGroup = makeTabGroup({
+        id: 'group-host-b',
+        worktreeId: siblingWorktreeId,
+        activeTabId: 'tab-host-b',
+        tabOrder: ['tab-host-b']
+      })
+      const targetTab = makeUnifiedTab({
+        id: 'tab-host-a',
+        worktreeId: WT,
+        groupId: targetGroup.id
+      })
+      const siblingTab = makeUnifiedTab({
+        id: 'tab-host-b',
+        worktreeId: siblingWorktreeId,
+        groupId: siblingGroup.id
+      })
+      store.setState({
+        worktreesByRepo: { repo1: [makeWorktree({ id: WT, repoId: 'repo1' })] },
+        unifiedTabsByWorktree: { [WT]: [targetTab], [siblingWorktreeId]: [siblingTab] },
+        groupsByWorktree: { [WT]: [targetGroup], [siblingWorktreeId]: [siblingGroup] },
+        detachedGroupIds: [siblingGroup.id],
+        auxWindowBoundsByGroupId: {
+          [siblingGroup.id]: { x: 10, y: 20, width: 800, height: 600 }
+        }
+      })
+
+      store.getState().hydrateTabsSession(
+        {
+          activeRepoId: 'repo1',
+          activeWorktreeId: WT,
+          activeTabId: targetTab.id,
+          tabsByWorktree: {},
+          terminalLayoutsByTabId: {},
+          unifiedTabs: { [WT]: [targetTab] },
+          tabGroups: { [WT]: [targetGroup] },
+          detachedGroupIds: [targetGroup.id],
+          auxWindowBoundsByGroupId: {
+            [targetGroup.id]: { x: 30, y: 40, width: 900, height: 700 }
+          }
+        },
+        { replaceWorkspaceKeys: [WT] }
+      )
+
+      expect(store.getState().detachedGroupIds).toEqual([siblingGroup.id, targetGroup.id])
+      expect(store.getState().auxWindowBoundsByGroupId).toEqual({
+        [siblingGroup.id]: { x: 10, y: 20, width: 800, height: 600 },
+        [targetGroup.id]: { x: 30, y: 40, width: 900, height: 700 }
+      })
+
+      store.getState().hydrateTabsSession(
+        {
+          activeRepoId: 'repo1',
+          activeWorktreeId: WT,
+          activeTabId: targetTab.id,
+          tabsByWorktree: {},
+          terminalLayoutsByTabId: {},
+          unifiedTabs: { [WT]: [targetTab] },
+          tabGroups: { [WT]: [targetGroup] },
+          detachedGroupIds: [],
+          auxWindowBoundsByGroupId: {
+            [targetGroup.id]: { x: 50, y: 60, width: 1000, height: 800 }
+          }
+        },
+        { replaceWorkspaceKeys: [WT] }
+      )
+
+      expect(store.getState().detachedGroupIds).toEqual([siblingGroup.id])
+      expect(store.getState().auxWindowBoundsByGroupId).toEqual({
+        [siblingGroup.id]: { x: 10, y: 20, width: 800, height: 600 },
+        [targetGroup.id]: { x: 50, y: 60, width: 1000, height: 800 }
+      })
+    })
+
     it('deletes omitted target chrome while preserving sibling references', () => {
       const siblingWorktreeId = 'repo2::/tmp/sibling'
       const targetGroup = makeTabGroup({

--- a/src/renderer/src/store/slices/tabs.ts
+++ b/src/renderer/src/store/slices/tabs.ts
@@ -44,6 +44,8 @@ import {
   buildValidWorktreeIdsForSessionHydration,
   collectPersistedWorktreeIdsForSessionHydration
 } from './degraded-repo-worktree-validity'
+import { buildDetachedTabGroupIntegrityPatch } from './detached-tab-groups'
+import { mergePartialDetachedTabGroupHydration } from './partial-detached-tab-group-hydration'
 
 export type TabSplitDirection = 'left' | 'right' | 'up' | 'down'
 
@@ -814,6 +816,13 @@ export function projectWorktreeTabModelReconciliation(
         ? buildOrphanTerminalCleanupPatch(state, worktreeId, orphanTerminalIds)
         : {})
     }
+    Object.assign(
+      patch,
+      buildDetachedTabGroupIntegrityPatch(state, {
+        groupsByWorktree: patch.groupsByWorktree,
+        unifiedTabsByWorktree: patch.unifiedTabsByWorktree
+      })
+    )
   }
 
   return {
@@ -888,25 +897,31 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
       const nextRecent = shouldActivate
         ? pushRecentTabId(sanitizedRecent, created.id)
         : sanitizedRecent
+      const nextUnifiedTabsByWorktree = {
+        ...state.unifiedTabsByWorktree,
+        [worktreeId]: [...nextTabs, created]
+      }
+      const nextGroupsByWorktree = {
+        ...groupsByWorktree,
+        [worktreeId]: updateGroup(groupsByWorktree[worktreeId] ?? [], {
+          ...group,
+          activeTabId: nextActiveTabId,
+          tabOrder: nextOrder,
+          recentTabIds: nextRecent
+        })
+      }
       return {
-        unifiedTabsByWorktree: {
-          ...state.unifiedTabsByWorktree,
-          [worktreeId]: [...nextTabs, created]
-        },
-        groupsByWorktree: {
-          ...groupsByWorktree,
-          [worktreeId]: updateGroup(groupsByWorktree[worktreeId] ?? [], {
-            ...group,
-            activeTabId: nextActiveTabId,
-            tabOrder: nextOrder,
-            recentTabIds: nextRecent
-          })
-        },
+        unifiedTabsByWorktree: nextUnifiedTabsByWorktree,
+        groupsByWorktree: nextGroupsByWorktree,
         activeGroupIdByWorktree,
         layoutByWorktree: {
           ...state.layoutByWorktree,
           [worktreeId]: state.layoutByWorktree[worktreeId] ?? { type: 'leaf', groupId: group.id }
-        }
+        },
+        ...buildDetachedTabGroupIntegrityPatch(state, {
+          groupsByWorktree: nextGroupsByWorktree,
+          unifiedTabsByWorktree: nextUnifiedTabsByWorktree
+        })
       }
     })
     if (init?.recordInteraction !== false) {
@@ -1235,7 +1250,17 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
               worktreeId,
               nextActiveGroupIdByWorktree[worktreeId] ?? null
             )
-          : {})
+          : {}),
+        ...buildDetachedTabGroupIntegrityPatch(current, {
+          groupsByWorktree: {
+            ...current.groupsByWorktree,
+            [worktreeId]: nextGroups
+          },
+          unifiedTabsByWorktree: {
+            ...current.unifiedTabsByWorktree,
+            [worktreeId]: nextTabs
+          }
+        })
       }
     })
 
@@ -1626,7 +1651,13 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
               worktreeId,
               collapsedState.activeGroupIdByWorktree[worktreeId] ?? null
             )
-          : {})
+          : {}),
+        ...buildDetachedTabGroupIntegrityPatch(current, {
+          groupsByWorktree: {
+            ...current.groupsByWorktree,
+            [worktreeId]: remainingGroups
+          }
+        })
       }
     })
     return true
@@ -1767,7 +1798,11 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
               worktreeId,
               nextActiveGroupIdByWorktreeResolved[worktreeId] ?? null
             )
-          : {})
+          : {}),
+        ...buildDetachedTabGroupIntegrityPatch(state, {
+          groupsByWorktree: nextGroupsByWorktree,
+          unifiedTabsByWorktree: nextUnifiedTabsByWorktree
+        })
       }
     })
     if (moved && opts?.recordInteraction !== false) {
@@ -1938,7 +1973,11 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
               worktreeId,
               resolvedTargetGroupId
             )
-          : {})
+          : {}),
+        ...buildDetachedTabGroupIntegrityPatch(state, {
+          groupsByWorktree: nextGroupsByWorktree,
+          unifiedTabsByWorktree: nextUnifiedTabsByWorktree
+        })
       }
     })
     if (moved) {
@@ -2049,32 +2088,55 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
     }
     addAdditionalValidWorkspaceKeys(validWorktreeIds, options)
     const hydrated = buildHydratedTabState(session, validWorktreeIds)
+    const detachedCandidate = {
+      detachedGroupIds: session.detachedGroupIds ?? [],
+      auxWindowBoundsByGroupId: session.auxWindowBoundsByGroupId ?? {},
+      groupsByWorktree: hydrated.groupsByWorktree,
+      unifiedTabsByWorktree: hydrated.unifiedTabsByWorktree
+    }
+    const detachedPatch = buildDetachedTabGroupIntegrityPatch(detachedCandidate)
+    const restoredDetachedState = {
+      detachedGroupIds: detachedPatch.detachedGroupIds ?? detachedCandidate.detachedGroupIds,
+      auxWindowBoundsByGroupId:
+        detachedPatch.auxWindowBoundsByGroupId ?? detachedCandidate.auxWindowBoundsByGroupId
+    }
     if (!options?.replaceWorkspaceKeys) {
-      set(hydrated)
+      set({ ...hydrated, ...restoredDetachedState })
       return
     }
     const replaceWorkspaceKeys = new Set(options.replaceWorkspaceKeys)
-    set((current) => ({
-      unifiedTabsByWorktree: replaceWorkspaceRecordKeys(
+    set((current) => {
+      const unifiedTabsByWorktree = replaceWorkspaceRecordKeys(
         current.unifiedTabsByWorktree,
         hydrated.unifiedTabsByWorktree,
         replaceWorkspaceKeys
-      ),
-      groupsByWorktree: replaceWorkspaceRecordKeys(
+      )
+      const groupsByWorktree = replaceWorkspaceRecordKeys(
         current.groupsByWorktree,
         hydrated.groupsByWorktree,
         replaceWorkspaceKeys
-      ),
-      activeGroupIdByWorktree: replaceWorkspaceRecordKeys(
-        current.activeGroupIdByWorktree,
-        hydrated.activeGroupIdByWorktree,
-        replaceWorkspaceKeys
-      ),
-      layoutByWorktree: replaceWorkspaceRecordKeys(
-        current.layoutByWorktree,
-        hydrated.layoutByWorktree,
-        replaceWorkspaceKeys
       )
-    }))
+      return {
+        unifiedTabsByWorktree,
+        groupsByWorktree,
+        activeGroupIdByWorktree: replaceWorkspaceRecordKeys(
+          current.activeGroupIdByWorktree,
+          hydrated.activeGroupIdByWorktree,
+          replaceWorkspaceKeys
+        ),
+        layoutByWorktree: replaceWorkspaceRecordKeys(
+          current.layoutByWorktree,
+          hydrated.layoutByWorktree,
+          replaceWorkspaceKeys
+        ),
+        ...mergePartialDetachedTabGroupHydration({
+          current,
+          incoming: restoredDetachedState,
+          nextGroupsByWorktree: groupsByWorktree,
+          nextUnifiedTabsByWorktree: unifiedTabsByWorktree,
+          replaceWorkspaceKeys
+        })
+      }
+    })
   }
 })

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -635,7 +635,10 @@ export type TerminalSlice = {
       forceHostRuntime?: boolean
     }
   ) => TerminalTab
-  openNewTerminalTabInActiveWorkspace: (groupId: string) => Promise<void>
+  openNewTerminalTabInActiveWorkspace: (
+    groupId: string,
+    worktreeIdOverride?: string
+  ) => Promise<void>
   closeTab: (
     tabId: string,
     opts?: {
@@ -1500,12 +1503,13 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
     return tab
   },
 
-  openNewTerminalTabInActiveWorkspace: async (groupId) => {
+  openNewTerminalTabInActiveWorkspace: async (groupId, worktreeIdOverride) => {
     const state = get()
-    const worktreeId = state.activeWorktreeId
+    const worktreeId = worktreeIdOverride ?? state.activeWorktreeId
     if (!worktreeId) {
       return
     }
+    const activate = state.activeWorktreeId === worktreeId
     const workspaceScope = parseWorkspaceKey(worktreeId)
     const worktreeRoute =
       worktreeId === FLOATING_TERMINAL_WORKTREE_ID || workspaceScope?.type === 'folder'
@@ -1523,16 +1527,19 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         worktreeId,
         environmentId: runtimeEnvironmentId,
         targetGroupId: groupId,
-        activate: true
+        activate,
+        ...(activate ? {} : { selectWorktree: false })
       })
       return
     }
     if (isWebClientLocation() && worktreeId !== FLOATING_TERMINAL_WORKTREE_ID) {
       return
     }
-    const terminal = get().createTab(worktreeId, groupId)
-    get().setActiveTab(terminal.id)
-    get().setActiveTabType('terminal')
+    const terminal = get().createTab(worktreeId, groupId, undefined, { activate })
+    if (activate) {
+      get().setActiveTab(terminal.id)
+      get().setActiveTabType('terminal')
+    }
     const latest = get()
     const currentTerminals = latest.tabsByWorktree[worktreeId] ?? []
     const currentEditors = latest.openFiles.filter((file) => file.worktreeId === worktreeId)
@@ -1552,7 +1559,9 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
     }
     // Why: Cmd+J shares the titlebar-button creation path, so append the new terminal after mixed editor/browser tabs, not first.
     get().setTabBarOrder(worktreeId, [...base.filter((id) => id !== terminal.id), terminal.id])
-    focusTerminalTabSurface(terminal.id)
+    if (activate) {
+      focusTerminalTabSurface(terminal.id)
+    }
   },
 
   closeTab: (tabId, opts) => {

--- a/src/renderer/src/store/slices/worktrees-purge-terminal-state.test.ts
+++ b/src/renderer/src/store/slices/worktrees-purge-terminal-state.test.ts
@@ -311,4 +311,60 @@ describe('purgeWorktreeTerminalState direct (design §4.4)', () => {
     expect(store.getState().groupsByWorktree).toBe(groupsByWorktree)
     expect(store.getState().layoutByWorktree).toBe(layoutByWorktree)
   })
+
+  it('atomically prunes detached ids and bounds during bulk worktree purge', () => {
+    const store = createTestStore()
+    store.setState({
+      groupsByWorktree: {
+        removed: [
+          {
+            id: 'removed-group',
+            worktreeId: 'removed',
+            activeTabId: 'removed-tab',
+            tabOrder: ['removed-tab']
+          }
+        ],
+        surviving: [
+          {
+            id: 'surviving-group',
+            worktreeId: 'surviving',
+            activeTabId: 'surviving-tab',
+            tabOrder: ['surviving-tab']
+          }
+        ]
+      },
+      unifiedTabsByWorktree: {
+        removed: [
+          {
+            id: 'removed-tab',
+            entityId: 'removed-terminal',
+            groupId: 'removed-group',
+            worktreeId: 'removed',
+            contentType: 'terminal'
+          }
+        ],
+        surviving: [
+          {
+            id: 'surviving-tab',
+            entityId: 'surviving-terminal',
+            groupId: 'surviving-group',
+            worktreeId: 'surviving',
+            contentType: 'terminal'
+          }
+        ]
+      },
+      detachedGroupIds: ['removed-group', 'surviving-group'],
+      auxWindowBoundsByGroupId: {
+        'removed-group': { x: 1, y: 2, width: 300, height: 200 },
+        'surviving-group': { x: 3, y: 4, width: 500, height: 400 }
+      }
+    } as unknown as Partial<AppState>)
+
+    store.getState().purgeWorktreeTerminalState(['removed'])
+
+    expect(store.getState().detachedGroupIds).toEqual(['surviving-group'])
+    expect(store.getState().auxWindowBoundsByGroupId).toEqual({
+      'surviving-group': { x: 3, y: 4, width: 500, height: 400 }
+    })
+  })
 })

--- a/src/renderer/src/store/slices/worktrees-removal-state-cleanup.test.ts
+++ b/src/renderer/src/store/slices/worktrees-removal-state-cleanup.test.ts
@@ -532,6 +532,66 @@ describe('removeWorktree state cleanup', () => {
     })
   })
 
+  it('removes detached ids and bounds owned by the removed worktree only', async () => {
+    const store = createTestStore()
+    const removed = makeWorktree({ id: 'repo1::/path/wt1', repoId: 'repo1', path: '/path/wt1' })
+    const surviving = makeWorktree({ id: 'repo1::/path/wt2', repoId: 'repo1', path: '/path/wt2' })
+
+    store.setState({
+      worktreesByRepo: { repo1: [removed, surviving] },
+      groupsByWorktree: {
+        [removed.id]: [
+          {
+            id: 'removed-group',
+            worktreeId: removed.id,
+            activeTabId: 'removed-tab',
+            tabOrder: ['removed-tab']
+          }
+        ],
+        [surviving.id]: [
+          {
+            id: 'surviving-group',
+            worktreeId: surviving.id,
+            activeTabId: 'surviving-tab',
+            tabOrder: ['surviving-tab']
+          }
+        ]
+      },
+      unifiedTabsByWorktree: {
+        [removed.id]: [
+          {
+            id: 'removed-tab',
+            entityId: 'removed-terminal',
+            groupId: 'removed-group',
+            worktreeId: removed.id,
+            contentType: 'terminal'
+          }
+        ],
+        [surviving.id]: [
+          {
+            id: 'surviving-tab',
+            entityId: 'surviving-terminal',
+            groupId: 'surviving-group',
+            worktreeId: surviving.id,
+            contentType: 'terminal'
+          }
+        ]
+      },
+      detachedGroupIds: ['removed-group', 'surviving-group'],
+      auxWindowBoundsByGroupId: {
+        'removed-group': { x: 1, y: 2, width: 300, height: 200 },
+        'surviving-group': { x: 3, y: 4, width: 500, height: 400 }
+      }
+    } as unknown as Partial<AppState>)
+
+    await store.getState().removeWorktree(removed.id)
+
+    expect(store.getState().detachedGroupIds).toEqual(['surviving-group'])
+    expect(store.getState().auxWindowBoundsByGroupId).toEqual({
+      'surviving-group': { x: 3, y: 4, width: 500, height: 400 }
+    })
+  })
+
   it('cleans up git caches for the removed worktree', async () => {
     const store = createTestStore()
     const wt = makeWorktree({ id: 'repo1::/path/wt1', repoId: 'repo1', path: '/path/wt1' })

--- a/src/renderer/src/store/slices/worktrees/teardown/remove-worktree-store-cleanup.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/remove-worktree-store-cleanup.ts
@@ -1,5 +1,6 @@
 import { worktreeWorkspaceKey } from '../../../../../../shared/workspace-scope'
 import type { WorktreeSliceSet } from '../listing/worktree-slice-types'
+import { buildDetachedTabGroupIntegrityPatch } from '../../detached-tab-groups'
 
 export function applyRemoveWorktreeSuccessState(
   set: WorktreeSliceSet,
@@ -228,6 +229,10 @@ export function applyRemoveWorktreeSuccessState(
       groupsByWorktree: nextGroupsByWorktree,
       layoutByWorktree: nextLayoutByWorktree,
       activeGroupIdByWorktree: nextActiveGroupIdByWorktree,
+      ...buildDetachedTabGroupIntegrityPatch(s, {
+        groupsByWorktree: nextGroupsByWorktree,
+        unifiedTabsByWorktree: nextUnifiedTabsByWorktree
+      }),
       editorDrafts: nextEditorDrafts,
       markdownViewMode: nextMarkdownViewMode,
       editorViewMode: nextEditorViewMode,

--- a/src/renderer/src/store/slices/worktrees/teardown/worktree-purge-state.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/worktree-purge-state.ts
@@ -4,6 +4,7 @@ import { parseWorkspaceKey } from '../../../../../../shared/workspace-scope'
 import { pruneHostedReviewLinkMutationGenerations } from '../metadata/hosted-review-link-mutation'
 import { collectWorktreePurgeDoomedIds } from './worktree-purge-doomed-ids'
 import { createWorktreePurgeOmitters } from './worktree-purge-omitters'
+import { buildDetachedTabGroupIntegrityPatch } from '../../detached-tab-groups'
 
 export function buildWorktreePurgeState(s: AppState, worktreeIds: string[]): Partial<AppState> {
   const worktreeIdSet = new Set(worktreeIds)
@@ -51,6 +52,8 @@ export function buildWorktreePurgeState(s: AppState, worktreeIds: string[]): Par
     return next
   })()
   const nextAgentStatusByPaneKey = omitByPaneKeyTabPrefix(s.agentStatusByPaneKey)
+  const nextUnifiedTabsByWorktree = omitByWorktree(s.unifiedTabsByWorktree)
+  const nextGroupsByWorktree = omitByWorktree(s.groupsByWorktree)
 
   return {
     // Worktree-scoped terminal/tab state
@@ -131,10 +134,14 @@ export function buildWorktreePurgeState(s: AppState, worktreeIds: string[]): Par
     rightSidebarTabByWorktree: pruneRightSidebarTabByWorktree(),
     rightSidebarExplorerViewByWorktree: omitByWorktree(s.rightSidebarExplorerViewByWorktree ?? {}),
     // Split-tab / unified tab state
-    unifiedTabsByWorktree: omitByWorktree(s.unifiedTabsByWorktree),
-    groupsByWorktree: omitByWorktree(s.groupsByWorktree),
+    unifiedTabsByWorktree: nextUnifiedTabsByWorktree,
+    groupsByWorktree: nextGroupsByWorktree,
     layoutByWorktree: omitByWorktree(s.layoutByWorktree),
     activeGroupIdByWorktree: omitByWorktree(s.activeGroupIdByWorktree),
+    ...buildDetachedTabGroupIntegrityPatch(s, {
+      groupsByWorktree: nextGroupsByWorktree,
+      unifiedTabsByWorktree: nextUnifiedTabsByWorktree
+    }),
     // Git status caches
     gitStatusByWorktree: omitByWorktree(s.gitStatusByWorktree),
     // Why: keyed by worktreeId; re-keyed on rename but missed by both removal paths (upstream-status entry).

--- a/src/renderer/src/store/types.ts
+++ b/src/renderer/src/store/types.ts
@@ -3,6 +3,7 @@ import type { SparsePresetsSlice } from './slices/sparse-presets'
 import type { WorktreeSlice } from './slices/worktrees'
 import type { TerminalSlice } from './slices/terminals'
 import type { TabsSlice } from './slices/tabs'
+import type { DetachedTabGroupsSlice } from './slices/detached-tab-groups'
 import type { UISlice } from './slices/ui'
 import type { SettingsSlice } from './slices/settings'
 import type { KeybindingsSlice } from './slices/keybindings'
@@ -49,6 +50,7 @@ export type AppState = RepoSlice &
   WorktreeSlice &
   TerminalSlice &
   TabsSlice &
+  DetachedTabGroupsSlice &
   UISlice &
   SettingsSlice &
   KeybindingsSlice &

--- a/src/shared/aux-window.test.ts
+++ b/src/shared/aux-window.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AUX_WINDOW_DEFAULT_SIZE,
+  auxWindowFeatures,
+  auxWindowFrameName,
+  isAuxWindowFrameName,
+  parseAuxWindowFeatures
+} from './aux-window'
+
+describe('aux window features', () => {
+  it('uses one validated browsing context per detached group', () => {
+    expect(auxWindowFrameName('group-1')).toBe('orca-aux-pane:group-1')
+    expect(auxWindowFrameName('group-2')).not.toBe(auxWindowFrameName('group-1'))
+    expect(isAuxWindowFrameName(auxWindowFrameName('group_2'))).toBe(true)
+    expect(isAuxWindowFrameName('orca-aux-pane:../../unsafe')).toBe(false)
+    expect(() => auxWindowFrameName('')).toThrow('Invalid detached pane group id')
+  })
+
+  it('round-trips bounds through the features string', () => {
+    const bounds = { x: 120, y: 80, width: 1024, height: 700 }
+    expect(parseAuxWindowFeatures(auxWindowFeatures(bounds))).toEqual(bounds)
+  })
+
+  it('omits position when there is nothing persisted yet', () => {
+    const parsed = parseAuxWindowFeatures(auxWindowFeatures(null))
+    expect(parsed).toEqual(AUX_WINDOW_DEFAULT_SIZE)
+    expect(parsed.x).toBeUndefined()
+  })
+
+  it('rounds fractional bounds — Electron rejects non-integers', () => {
+    const parsed = parseAuxWindowFeatures(
+      auxWindowFeatures({ x: 10.6, y: 20.4, width: 800.5, height: 600.2 })
+    )
+    expect(parsed).toEqual({ x: 11, y: 20, width: 801, height: 600 })
+  })
+
+  it('ignores garbage rather than producing NaN bounds', () => {
+    expect(parseAuxWindowFeatures('width=abc,height=,left=5,nonsense')).toEqual({ x: 5 })
+  })
+})

--- a/src/shared/aux-window.ts
+++ b/src/shared/aux-window.ts
@@ -1,0 +1,77 @@
+/**
+ * Detached panes are same-renderer auxiliary windows: the main renderer opens an
+ * `about:blank` child and portals a tab group into it. Main matches this frame
+ * name to allow the open (privileged-window-navigation.ts) — every other
+ * `window.open` from an Orca window is still denied.
+ */
+const AUX_WINDOW_FRAME_NAME_PREFIX = 'orca-aux-pane:'
+const AUX_WINDOW_GROUP_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/
+
+export function auxWindowFrameName(groupId: string): string {
+  if (!AUX_WINDOW_GROUP_ID_PATTERN.test(groupId)) {
+    throw new Error('Invalid detached pane group id')
+  }
+  return `${AUX_WINDOW_FRAME_NAME_PREFIX}${groupId}`
+}
+
+export function isAuxWindowFrameName(frameName: string): boolean {
+  return (
+    frameName.startsWith(AUX_WINDOW_FRAME_NAME_PREFIX) &&
+    AUX_WINDOW_GROUP_ID_PATTERN.test(frameName.slice(AUX_WINDOW_FRAME_NAME_PREFIX.length))
+  )
+}
+
+/** Screen position and size of a detached pane's window, persisted per group. */
+export type AuxWindowBounds = {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+export const AUX_WINDOW_DEFAULT_SIZE = { width: 900, height: 600 } as const
+
+/**
+ * `window.open` features string. Bounds travel this way because the renderer
+ * cannot construct a BrowserWindow directly — main parses them back out in
+ * `privileged-window-navigation.ts`.
+ */
+export function auxWindowFeatures(bounds: AuxWindowBounds | null): string {
+  const size = bounds ?? {
+    ...AUX_WINDOW_DEFAULT_SIZE,
+    x: Number.NaN,
+    y: Number.NaN
+  }
+  const parts = [`width=${Math.round(size.width)}`, `height=${Math.round(size.height)}`]
+  if (Number.isFinite(size.x) && Number.isFinite(size.y)) {
+    parts.push(`left=${Math.round(size.x)}`, `top=${Math.round(size.y)}`)
+  }
+  return parts.join(',')
+}
+
+/** Parse the features string produced by `auxWindowFeatures`. */
+export function parseAuxWindowFeatures(features: string): Partial<AuxWindowBounds> {
+  const parsed: Partial<AuxWindowBounds> = {}
+  for (const entry of features.split(',')) {
+    const [rawKey, rawValue] = entry.split('=')
+    const value = Number.parseInt(rawValue ?? '', 10)
+    if (!Number.isFinite(value)) {
+      continue
+    }
+    switch (rawKey?.trim()) {
+      case 'width':
+        parsed.width = value
+        break
+      case 'height':
+        parsed.height = value
+        break
+      case 'left':
+        parsed.x = value
+        break
+      case 'top':
+        parsed.y = value
+        break
+    }
+  }
+  return parsed
+}

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -410,6 +410,9 @@ export type GlobalSettings = {
   /** Experimental: left-sidebar Agents view — threaded feed of agent completions, blocking/unread state, worktree creation. */
   experimentalActivity: boolean
   /** Experimental: pop-out Kanban dashboard for monitoring and opening agent terminals across worktrees. */
+  /** Detach a tab group into its own OS window. Off by default while the
+   *  aux window still lacks a native context menu and menu-driven paste. */
+  experimentalDetachedPanes?: boolean
   experimentalAgentDashboardPopout?: boolean
   /** How the Agent Dashboard opens: an in-window companion board or a separate pop-out window. Defaults to in-window. */
   experimentalAgentDashboardMode?: AgentDashboardMode

--- a/src/shared/workspace-session-detached-panes-schema.ts
+++ b/src/shared/workspace-session-detached-panes-schema.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod'
+import { salvagedOptional, salvagingArray, salvagingRecord } from './zod-salvage'
+
+/** Bounds of a detached pane's OS window, as persisted in the workspace session. */
+const auxWindowBoundsSchema = z.object({
+  x: z.number(),
+  y: z.number(),
+  width: z.number(),
+  height: z.number()
+})
+
+/**
+ * Session fields describing detached panes. Both are optional: a session
+ * written before this feature simply hydrates as "nothing detached".
+ */
+export const detachedPaneSessionFields = {
+  detachedGroupIds: salvagedOptional('detachedGroupIds', salvagingArray(z.string())),
+  auxWindowBoundsByGroupId: salvagedOptional(
+    'auxWindowBoundsByGroupId',
+    salvagingRecord(z.string(), auxWindowBoundsSchema)
+  )
+}

--- a/src/shared/workspace-session-schema.ts
+++ b/src/shared/workspace-session-schema.ts
@@ -12,6 +12,7 @@
  * Only a payload that is not a session at all falls back to defaults.
  */
 import { z } from 'zod'
+import { detachedPaneSessionFields } from './workspace-session-detached-panes-schema'
 import type { WorkspaceKey } from './folder-workspace-types'
 import type { TabGroupLayoutNode } from './tab-types'
 import type { TerminalPaneLayoutNode } from './terminal-tab-types'
@@ -283,6 +284,7 @@ export const workspaceSessionStateSchema: z.ZodType<WorkspaceSessionState> = z.o
     'activeGroupIdByWorktree',
     salvagingRecord(worktreeIdSchema, z.string())
   ),
+  ...detachedPaneSessionFields,
   activeConnectionIdsAtShutdown: salvagedOptional(
     'activeConnectionIdsAtShutdown',
     salvagingArray(z.string())

--- a/src/shared/workspace-session-state-types.ts
+++ b/src/shared/workspace-session-state-types.ts
@@ -1,3 +1,4 @@
+import type { AuxWindowBounds } from './aux-window'
 import type { ExecutionHostId } from './execution-host'
 import type { SleepingAgentSessionRecord } from './agent-session-resume'
 import type { WorkspaceKey } from './folder-workspace-types'
@@ -72,6 +73,13 @@ export type WorkspaceSessionState = {
   tabGroupLayouts?: Record<string, TabGroupLayoutNode>
   /** Per-worktree focused group at shutdown. */
   activeGroupIdByWorktree?: Record<string, string>
+  /** Tab groups that were detached into their own OS window at shutdown, so
+   *  the windows reopen on restart. Absent in sessions written by older
+   *  builds — hydration treats that as "nothing detached". */
+  detachedGroupIds?: string[]
+  /** Last known screen bounds of each detached group's window, so a restored
+   *  window reappears where the user left it. */
+  auxWindowBoundsByGroupId?: Record<string, AuxWindowBounds>
   /** SSH target IDs that were connected at shutdown. Used on startup to
    *  auto-reconnect before attempting remote PTY reattach. */
   activeConnectionIdsAtShutdown?: string[]

--- a/tests/e2e/detached-tab-group-restore.spec.ts
+++ b/tests/e2e/detached-tab-group-restore.spec.ts
@@ -1,0 +1,84 @@
+import { existsSync, readFileSync } from 'node:fs'
+import type { ElectronApplication } from '@stablyai/playwright-test'
+import { expect, test } from './helpers/orca-app'
+import { attachRepoAndOpenTerminal, createRestartSession } from './helpers/orca-restart'
+import { ensureTerminalVisible, waitForSessionReady } from './helpers/store'
+import { waitForActiveTerminalManager } from './helpers/terminal'
+import { TEST_REPO_PATH_FILE } from './global-setup'
+
+function seededRepoPath(): string {
+  const repoPath = existsSync(TEST_REPO_PATH_FILE)
+    ? readFileSync(TEST_REPO_PATH_FILE, 'utf8').trim()
+    : ''
+  if (!repoPath || !existsSync(repoPath)) {
+    throw new Error('Detached-window restart E2E requires the seeded test repo from global setup')
+  }
+  return repoPath
+}
+
+test('reopens a detached tab group window after quit and relaunch', async (// oxlint-disable-next-line no-empty-pattern -- this test owns both Electron launches.
+{}, testInfo) => {
+  test.setTimeout(300_000)
+  const repoPath = seededRepoPath()
+  const session = createRestartSession(testInfo)
+  let firstApp: ElectronApplication | null = null
+  let secondApp: ElectronApplication | null = null
+
+  try {
+    const first = await session.launch()
+    firstApp = first.app
+    await waitForSessionReady(first.page)
+    await attachRepoAndOpenTerminal(first.page, repoPath)
+    await ensureTerminalVisible(first.page)
+    await waitForActiveTerminalManager(first.page, 30_000)
+
+    const groupId = await first.page.evaluate(() => {
+      const state = window.__store.getState()
+      const worktreeId = state.activeWorktreeId
+      return worktreeId ? (state.groupsByWorktree[worktreeId]?.[0]?.id ?? null) : null
+    })
+    expect(groupId).not.toBeNull()
+
+    const firstAuxPromise = firstApp.waitForEvent('window', { timeout: 30_000 })
+    await first.page.evaluate((id) => {
+      window.__store.getState().detachTabGroup(id)
+    }, groupId)
+    const firstAux = await firstAuxPromise
+    await expect(firstAux.locator('.xterm-screen')).toBeVisible({ timeout: 30_000 })
+
+    // Why: the session writer is debounced — quitting too early persists nothing.
+    await first.page.waitForTimeout(3_000)
+    await session.close(firstApp)
+    firstApp = null
+
+    const second = await session.launch()
+    secondApp = second.app
+
+    // Why: two windows now exist at startup, and the harness hands back
+    // whichever appeared first — identify them by URL instead of assuming.
+    const isAux = (page: { url: () => string }): boolean => page.url() === 'about:blank'
+    const deadline = Date.now() + 60_000
+    let restoredAux: (typeof second)['page'] | undefined
+    let mainPage: (typeof second)['page'] | undefined
+    while (Date.now() < deadline && (!restoredAux || !mainPage)) {
+      const windows = secondApp.windows()
+      restoredAux = windows.find(isAux)
+      mainPage = windows.find((page) => !isAux(page))
+      if (!restoredAux || !mainPage) {
+        await second.page.waitForTimeout(500).catch(() => undefined)
+      }
+    }
+    expect(restoredAux, 'detached window should reopen on restart').toBeDefined()
+    expect(mainPage).toBeDefined()
+
+    await expect(restoredAux!.locator('.xterm-screen')).toBeVisible({ timeout: 60_000 })
+    await expect(mainPage!.locator('.xterm-screen')).toHaveCount(0, { timeout: 15_000 })
+  } finally {
+    for (const app of [secondApp, firstApp]) {
+      if (app) {
+        await session.close(app).catch(() => undefined)
+      }
+    }
+    await session.dispose()
+  }
+})

--- a/tests/e2e/detached-tab-group-window.spec.ts
+++ b/tests/e2e/detached-tab-group-window.spec.ts
@@ -1,0 +1,290 @@
+import { expect, test } from './helpers/orca-app'
+import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import { execInTerminal } from './helpers/terminal'
+
+// Why E2E rather than a slice test: the thing under test is an actual second
+// Electron window and a React portal into its document. A store test would
+// assert the id list and prove nothing about a terminal rendering over there.
+test('keeps two detached windows themed, shortcut-aware, and independently closable', async ({
+  orcaPage,
+  electronApp
+}) => {
+  test.setTimeout(180_000)
+  await waitForSessionReady(orcaPage)
+  await waitForActiveWorktree(orcaPage)
+
+  await orcaPage.evaluate(() => {
+    void window.__store.getState().updateSettings({ experimentalDetachedPanes: true })
+  })
+
+  const groupIds = await orcaPage.evaluate(() => {
+    const state = window.__store.getState()
+    const worktreeId = state.activeWorktreeId
+    const firstGroupId = worktreeId ? state.groupsByWorktree[worktreeId]?.[0]?.id : undefined
+    if (!worktreeId || !firstGroupId) {
+      return null
+    }
+    const secondGroupId = state.createEmptySplitGroup(worktreeId, firstGroupId, 'right')
+    if (!secondGroupId) {
+      return null
+    }
+    state.createTab(worktreeId, secondGroupId, undefined, { activate: true })
+    return [firstGroupId, secondGroupId]
+  })
+  expect(groupIds).not.toBeNull()
+
+  const firstAuxPromise = electronApp.waitForEvent('window', { timeout: 30_000 })
+  await orcaPage.evaluate((id) => {
+    window.__store.getState().detachTabGroup(id)
+  }, groupIds![0])
+  const firstAux = await firstAuxPromise
+  await firstAux.waitForLoadState('domcontentloaded')
+
+  const secondAuxPromise = electronApp.waitForEvent('window', { timeout: 30_000 })
+  await orcaPage.evaluate((id) => {
+    window.__store.getState().detachTabGroup(id)
+  }, groupIds![1])
+  const secondAux = await secondAuxPromise
+  await secondAux.waitForLoadState('domcontentloaded')
+
+  for (const auxPage of [firstAux, secondAux]) {
+    await expect(auxPage.locator('.xterm-screen')).toBeVisible({ timeout: 30_000 })
+    expect(await auxPage.evaluate(() => document.styleSheets.length > 0)).toBe(true)
+  }
+  const resolveFirstAuxTerminal = () =>
+    orcaPage.evaluate((groupId) => {
+      const state = window.__store.getState()
+      const owner = Object.entries(state.groupsByWorktree).find(([, groups]) =>
+        groups.some((group) => group.id === groupId)
+      )
+      const group = owner?.[1].find((candidate) => candidate.id === groupId)
+      const unifiedTab = owner
+        ? state.unifiedTabsByWorktree[owner[0]]?.find(
+            (candidate) => candidate.id === group?.activeTabId
+          )
+        : undefined
+      const terminal = owner
+        ? state.tabsByWorktree[owner[0]]?.find((candidate) => candidate.id === unifiedTab?.entityId)
+        : undefined
+      const ptyId = terminal?.ptyId ?? state.ptyIdsByTabId[unifiedTab?.entityId ?? '']?.[0]
+      return unifiedTab?.contentType === 'terminal' && ptyId
+        ? { tabId: unifiedTab.entityId, ptyId }
+        : null
+    }, groupIds![0])
+  await expect.poll(resolveFirstAuxTerminal, { timeout: 20_000 }).not.toBeNull()
+  const firstAuxTerminal = await resolveFirstAuxTerminal()
+  expect(firstAuxTerminal).not.toBeNull()
+
+  await expect(orcaPage.locator('.xterm-screen')).toHaveCount(0, { timeout: 15_000 })
+
+  await orcaPage.evaluate(() => window.__store.getState().setSidebarOpen(true))
+  await expect(orcaPage.locator('[data-worktree-sidebar]')).toBeVisible()
+  await firstAux.locator('.xterm-helper-textarea:visible').focus()
+  await firstAux.keyboard.press(process.platform === 'darwin' ? 'Meta+B' : 'Control+B')
+  await expect(orcaPage.locator('[data-worktree-sidebar]')).toHaveCount(0)
+
+  await orcaPage.evaluate(() => {
+    void window.__store.getState().updateSettings({ theme: 'light' })
+  })
+  await expect
+    .poll(() => firstAux.evaluate(() => document.documentElement.classList.contains('light')))
+    .toBe(true)
+  expect(await secondAux.evaluate(() => document.documentElement.classList.contains('light'))).toBe(
+    true
+  )
+
+  const pinnedTabId = await orcaPage.evaluate((groupId) => {
+    const state = window.__store.getState()
+    const tabId = state.groupsByWorktree[state.activeWorktreeId!]?.find(
+      (group) => group.id === groupId
+    )?.activeTabId
+    if (tabId) {
+      state.pinTab(tabId)
+    }
+    return tabId ?? null
+  }, groupIds![0])
+  expect(pinnedTabId).not.toBeNull()
+  await firstAux.locator('.xterm-helper-textarea:visible').focus()
+  await firstAux.keyboard.press(process.platform === 'darwin' ? 'Meta+W' : 'Control+W')
+  await expect(firstAux.getByRole('dialog')).toContainText('Close pinned tab?')
+  await expect(orcaPage.getByRole('dialog')).toHaveCount(0)
+  await firstAux.getByRole('button', { name: 'Cancel' }).click()
+  await orcaPage.evaluate((tabId) => window.__store.getState().unpinTab(tabId), pinnedTabId!)
+
+  const workspaceIds = await orcaPage.evaluate(async (name) => {
+    const state = window.__store.getState()
+    const worktreeId = state.activeWorktreeId
+    const worktree = Object.values(state.worktreesByRepo)
+      .flat()
+      .find((candidate) => candidate.id === worktreeId)
+    if (!worktreeId || !worktree) {
+      return null
+    }
+    const alternate = await state.createWorktree(worktree.repoId, name)
+    state.setActiveWorktree(alternate.worktree.id)
+    return { originalWorktreeId: worktreeId, alternateWorktreeId: alternate.worktree.id }
+  }, `e2e-detached-pane-${Date.now()}`)
+  expect(workspaceIds).not.toBeNull()
+  await expect
+    .poll(() => orcaPage.evaluate(() => window.__store.getState().activeWorktreeId))
+    .toBe(workspaceIds!.alternateWorktreeId)
+  await expect(firstAux.locator('.xterm-screen:visible')).toHaveCount(1)
+  const originalGroupTabIds = await orcaPage.evaluate(
+    ({ groupId, worktreeId }) =>
+      window.__store.getState().groupsByWorktree[worktreeId]?.find((group) => group.id === groupId)
+        ?.tabOrder ?? [],
+    { groupId: groupIds![0], worktreeId: workspaceIds!.originalWorktreeId }
+  )
+  const originalAuxTabCount = await firstAux.locator('[data-testid="sortable-tab"]').count()
+  await firstAux.locator('.xterm-helper-textarea:visible').focus()
+  await firstAux.keyboard.press(process.platform === 'darwin' ? 'Meta+T' : 'Control+T')
+  await expect(firstAux.locator('[data-testid="sortable-tab"]')).toHaveCount(
+    originalAuxTabCount + 1
+  )
+  const findNewTabId = () =>
+    orcaPage.evaluate(
+      ({ groupId, previousIds }) => {
+        const state = window.__store.getState()
+        const group = Object.values(state.groupsByWorktree)
+          .flat()
+          .find((candidate) => candidate.id === groupId)
+        return group?.tabOrder.find((tabId) => !previousIds.includes(tabId)) ?? null
+      },
+      { groupId: groupIds![0], previousIds: originalGroupTabIds }
+    )
+  await expect.poll(findNewTabId).not.toBeNull()
+  const newTabId = await findNewTabId()
+  expect(newTabId).not.toBeNull()
+  await orcaPage.evaluate(() => {
+    const state = window.__store.getState()
+    state.openSettingsTarget({ pane: 'appearance', repoId: null })
+    state.openSettingsPage()
+    state.setActiveWorktree(null)
+  })
+  await expect(orcaPage.locator('[data-settings-section="appearance"]')).toBeVisible()
+  await expect(firstAux.locator('.xterm-screen:visible')).toHaveCount(1)
+
+  await firstAux.locator('.xterm-helper-textarea:visible').focus()
+  await firstAux.keyboard.down('Control')
+  await firstAux.keyboard.down('Tab')
+  await expect(firstAux.getByRole('listbox', { name: 'Switch tabs' })).toBeVisible()
+  await expect(orcaPage.getByRole('listbox', { name: 'Switch tabs' })).toHaveCount(0)
+  await firstAux.keyboard.up('Tab')
+  await firstAux.keyboard.up('Control')
+  await expect(
+    firstAux.locator('[data-testid="sortable-tab"][data-active="true"]')
+  ).not.toHaveAttribute('data-unified-tab-id', newTabId!)
+
+  const switchedTabId = await firstAux
+    .locator('[data-testid="sortable-tab"][data-active="true"]')
+    .getAttribute('data-unified-tab-id')
+  expect(switchedTabId).toBe(firstAuxTerminal!.tabId)
+  await orcaPage.evaluate((tabId) => window.__store.getState().pinTab(tabId), switchedTabId!)
+  await firstAux.locator('.xterm-helper-textarea:visible').focus()
+  await firstAux.evaluate(
+    () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+  )
+  await firstAux.keyboard.press(process.platform === 'darwin' ? 'Meta+W' : 'Control+W')
+  await expect(firstAux.getByRole('dialog')).toContainText('Close pinned tab?')
+  await expect(orcaPage.getByRole('dialog')).toHaveCount(0)
+  await firstAux.getByRole('button', { name: 'Cancel' }).click()
+  await orcaPage.evaluate((tabId) => window.__store.getState().unpinTab(tabId), switchedTabId!)
+
+  const mainEditorFileId = await orcaPage.evaluate((worktreeId) => {
+    const state = window.__store.getState()
+    const worktree = Object.values(state.worktreesByRepo)
+      .flat()
+      .find((candidate) => candidate.id === worktreeId)
+    if (!worktree) {
+      return null
+    }
+    state.setActiveView('terminal')
+    state.setActiveWorktree(worktreeId)
+    const groupId = state.ensureWorktreeRootGroup(worktreeId)
+    const separator = worktree.path.includes('\\') ? '\\' : '/'
+    const filePath = `${worktree.path}${separator}package.json`
+    state.openFile(
+      {
+        filePath,
+        relativePath: 'package.json',
+        worktreeId,
+        language: 'json',
+        mode: 'edit'
+      },
+      { preview: false, targetGroupId: groupId }
+    )
+    const fileId =
+      window.__store.getState().openFiles.find((file) => file.filePath === filePath)?.id ?? null
+    if (fileId) {
+      state.setActiveFile(fileId)
+      state.setActiveTabType('editor')
+    }
+    return fileId
+  }, workspaceIds!.alternateWorktreeId)
+  expect(mainEditorFileId).not.toBeNull()
+  await expect(orcaPage.locator('.monaco-editor')).toBeVisible()
+
+  await execInTerminal(orcaPage, firstAuxTerminal!.ptyId, 'node -e "setTimeout(()=>{},300000)"')
+  await expect
+    .poll(
+      async () =>
+        (
+          await orcaPage.evaluate(
+            (ptyId) => window.api.pty.inspectProcess(ptyId),
+            firstAuxTerminal!.ptyId
+          )
+        ).foregroundProcess,
+      { timeout: 20_000 }
+    )
+    .toMatch(/^node(?:\.exe)?$/i)
+  await firstAux.locator('.xterm-helper-textarea:visible').focus()
+  await firstAux.keyboard.press(process.platform === 'darwin' ? 'Meta+W' : 'Control+W')
+  await expect(firstAux.getByText(/Stop running command\?|Stop this agent\?/)).toBeVisible()
+  await expect(orcaPage.locator('.monaco-editor')).toBeVisible()
+  await firstAux.getByRole('button', { name: 'Cancel' }).click()
+  await orcaPage.evaluate((ptyId) => window.api.pty.write(ptyId, '\u0003'), firstAuxTerminal!.ptyId)
+
+  const mainBrowserTabId = await orcaPage.evaluate((worktreeId) => {
+    const state = window.__store.getState()
+    const groupId = state.ensureWorktreeRootGroup(worktreeId)
+    const browser = state.createBrowserTab(worktreeId, 'about:blank', {
+      activate: true,
+      focusAddressBar: false,
+      targetGroupId: groupId
+    })
+    state.setActiveTabType('browser')
+    return browser.id
+  }, workspaceIds!.alternateWorktreeId)
+  const mainBrowser = orcaPage.locator(`[data-browser-overlay-tab-id="${mainBrowserTabId}"]`)
+  await expect(mainBrowser).toBeVisible()
+
+  const auxTabCountBeforeNormalClose = await firstAux
+    .locator('[data-testid="sortable-tab"]')
+    .count()
+  await expect
+    .poll(() =>
+      orcaPage.evaluate((ptyId) => window.api.pty.inspectProcess(ptyId), firstAuxTerminal!.ptyId)
+    )
+    .toMatchObject({ hasChildProcesses: false })
+  await firstAux
+    .locator(`[data-terminal-overlay-tab-id="${switchedTabId}"] .xterm-helper-textarea`)
+    .focus()
+  await firstAux.keyboard.press(process.platform === 'darwin' ? 'Meta+W' : 'Control+W')
+  await expect(firstAux.locator('[data-testid="sortable-tab"]')).toHaveCount(
+    auxTabCountBeforeNormalClose - 1
+  )
+  await expect(mainBrowser).toBeVisible()
+
+  await orcaPage.evaluate((worktreeId) => {
+    const state = window.__store.getState()
+    state.setActiveWorktree(worktreeId)
+    state.setActiveView('terminal')
+  }, workspaceIds!.originalWorktreeId)
+
+  await firstAux.close()
+  await expect(orcaPage.locator('.xterm-screen:visible')).toHaveCount(1, { timeout: 30_000 })
+  await expect(secondAux.locator('.xterm-screen')).toBeVisible()
+
+  await secondAux.close()
+  await expect(orcaPage.locator('.xterm-screen:visible')).toHaveCount(2, { timeout: 30_000 })
+})


### PR DESCRIPTION
## ELI5

Terminal-only tab groups can move into separate Orca windows without creating a second renderer or terminal session. The main window and detached windows continue sharing one store and PTY lifecycle.

## What Changed

- Add opt-in detached terminal-group windows with auxiliary-window-aware focus, shortcuts, menus, paste, theme, title, and lifecycle handling.
- Persist detached group IDs and window bounds in full and incremental workspace sessions, including partial SSH and folder hydration.
- Keep main-window shortcut guards unchanged while routing auxiliary shortcuts to their focused pane.
- Prevent background-worktree terminal creation from changing global worktree or tab selection in native and web-runtime paths.
- Extend pane realm safety scanning through static CommonJS require calls.

## Why

Multi-monitor users need terminal groups in separate OS windows without duplicating renderer state, IPC ownership, or PTY processes. Review fixes preserve existing main-window behavior and close persistence, hydration, realm, and background-focus gaps.

## Linked Issue

N/A — no linked issue was provided for this branch.

## Visual Proof

N/A — no new visual proof was captured in this review-fix task. Earlier detached-window E2E evidence remains applicable; this update did not run E2E, Playwright, or Electron checks.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Current update:

- `pnpm exec vitest run --config config/vitest.config.ts <9 focused files>` — 69 passed
- `pnpm run typecheck:web`
- `pnpm exec oxfmt --check <21 changed files>`
- Direct `oxlint` on changed source and tests
- `pnpm run check:pane-realm-safety`
- Localization catalog, extraction, and coverage verification
- Workflow, topology, artifact, secret-signature, and `git diff --check` checks
- No new E2E or full Vitest run, per task constraint

Existing feature validation before this review update:

- 154 focused tests
- Web typecheck, lint, format, realm, and diff checks
- Detached-window E2E coverage from earlier feature validation

## AI Disclosure

Review and implementation were assisted by AI; a human made final decisions.

## Review

Addressed current-head feedback for main-window shortcut guards, active detached titles, simulator policy ownership, incremental detached persistence, partial hydration bounds, background terminal focus, CommonJS scanner traversal, localization namespace consistency, and test cleanup.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No new wire opcode or required remote field. Existing optional session fields remain backward-compatible. Runtime ownership checks cover local, SSH, folder-workspace, and paired-host paths. Platform shortcut behavior remains `CmdOrCtrl`/runtime-aware.

## Checklist

- [ ] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (focused local checks passed; CI covers broad commands)

## Author

N/A