### PR TITLE
fix(skills): harden cross-host bundle installs

### DIFF
--- a/src/main/ipc/skill-cloud-ipc-handlers.ts
+++ b/src/main/ipc/skill-cloud-ipc-handlers.ts
@@ -52,7 +52,8 @@ function registerSharingHandlers(
     {
       publishVersion: (request) => runtime.publishSkillPackageVersion(request),
       createShare: (packageId, request) => runtime.createSkillPackageShare(packageId, request)
-    }
+    },
+    { installStateDirectory: join(app.getPath('userData'), 'skill-installs') }
   )
   handleMainWindowSkillIpc('skills:prepareShare', async (_event, value: unknown) => {
     const input = skillSharePrepareIpcSchema.parse(value)

--- a/src/main/runtime/orca-runtime-skill-recovery.test.ts
+++ b/src/main/runtime/orca-runtime-skill-recovery.test.ts
@@ -29,4 +29,13 @@ describe('managed skill startup recovery', () => {
     finishRecovery()
     await expect(listing).resolves.toEqual([])
   })
+
+  it('continues skill management after startup recovery fails', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const runtime = new OrcaRuntimeService(null, undefined, {
+      skillTransactionRecovery: Promise.reject(new Error('transient-recovery-failure'))
+    })
+
+    await expect(runtime.listManagedSkillInstalls()).resolves.toEqual([])
+  })
 })

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -186,7 +186,6 @@ import type {
   SkillBundleInstallRequest,
   SkillBundleInstallResult
 } from '../../shared/skill-bundle-install-contract'
-import { SkillBundleInstallPreviewSchema } from '../../shared/skill-bundle-install-contract'
 import { executeSkillInstallRequest } from '../skills/skill-install-request-service'
 import { executeSkillBundleInstallRequest } from '../skills/skill-bundle-install-request-service'
 import type { SkillInstallDestinationAuthority } from '../skills/skill-install-destinations'
@@ -211,7 +210,10 @@ import type {
 } from '../../shared/skill-upload-session-contract'
 import { SkillUploadSessionService } from '../skills/skill-upload-session-service'
 import type { SkillSshWorkspaceAuthority } from '../../shared/skill-ssh-relay-contract'
-import { installSkillBundleOnSshHost } from '../skills/skill-bundle-ssh-relay-service'
+import {
+  installSkillBundleOnSshHost,
+  previewSkillBundleInstallOnSshHost
+} from '../skills/skill-bundle-ssh-relay-service'
 import {
   installSkillOnSshHost,
   listSkillInstallsOnSshHost,
@@ -3567,7 +3569,11 @@ export class OrcaRuntimeService {
       this.store?.setMobileClientTabSelections?.(state)
     })
     this.orchestrationEnvironmentTransport = deps?.orchestrationEnvironmentTransport ?? null
-    this.skillTransactionRecovery = deps?.skillTransactionRecovery ?? Promise.resolve()
+    this.skillTransactionRecovery = (deps?.skillTransactionRecovery ?? Promise.resolve()).catch(
+      (error) => {
+        console.warn('[skills] startup transaction recovery failed:', error)
+      }
+    )
     if (stats) {
       this.stats = stats
       this.agentDetector = new AgentDetector(stats)
@@ -4832,10 +4838,16 @@ export class OrcaRuntimeService {
     const selectedSkills = selectDiscoveredSkills(discoveredSkills, request.skillSelectors)
     const operationRoot = join(app.getPath('userData'), 'agent-skill-share-operations')
     const cloud = this.requireSkillCloudService()
-    const preparations = new SkillSharePreparationService(operationRoot, {
-      publishVersion: (input) => cloud.publishVersion(input),
-      createShare: (packageId, input) => cloud.createShare(packageId, input)
-    })
+    const preparations = new SkillSharePreparationService(
+      operationRoot,
+      {
+        publishVersion: (input) => cloud.publishVersion(input),
+        createShare: (packageId, input) => cloud.createShare(packageId, input)
+      },
+      {
+        installStateDirectory: join(app.getPath('userData'), 'skill-installs')
+      }
+    )
     let preparationId: string | null = null
     const cancel = (): void => {
       if (preparationId) {
@@ -5171,37 +5183,18 @@ export class OrcaRuntimeService {
   async previewSharedSkillBundleInstallRequest(
     request: SkillBundleInstallPreviewRequest
   ): Promise<SkillBundleInstallPreview> {
-    if (await this.resolveSkillSshTarget(request.destination)) {
-      const previews: SkillInstallPreview[] = []
-      for (let offset = 0; offset < request.selectedSkills.length; offset += 8) {
-        const batch = request.selectedSkills.slice(offset, offset + 8)
-        previews.push(
-          ...(await Promise.all(
-            batch.map((skill) =>
-              this.previewSharedSkillInstallRequest({
-                package: {
-                  packageId: request.package.packageId,
-                  versionId: request.package.versionId,
-                  packageDigest: skill.digest,
-                  archiveSha256: request.package.archiveSha256,
-                  compressedBytes: request.package.compressedBytes
-                },
-                name: skill.name,
-                destination: request.destination
-              })
-            )
-          ))
-        )
-      }
-      return SkillBundleInstallPreviewSchema.parse({
-        packageId: request.package.packageId,
-        versionId: request.package.versionId,
-        bundleDigest: request.package.bundleDigest,
-        destinationIdentity: previews[0]?.destinationIdentity ?? '',
-        skills: request.selectedSkills.map((skill, index) => ({
-          ...skill,
-          currentState: previews[index].currentState
-        }))
+    const sshTarget = await this.resolveSkillSshTarget(request.destination)
+    if (sshTarget) {
+      return previewSkillBundleInstallOnSshHost({
+        provider: sshTarget.provider,
+        request: {
+          ...request,
+          destination:
+            request.destination.scope === 'global'
+              ? { scope: 'global', executionTarget: { kind: 'host' } }
+              : request.destination
+        },
+        workspace: sshTarget.workspace
       })
     }
     await this.skillTransactionRecovery
@@ -5399,13 +5392,15 @@ export class OrcaRuntimeService {
   }
 
   private async resolveSkillSshTarget(destination: SkillInstallRequest['destination']): Promise<{
-    provider: IPtyProvider
+    provider: () => IPtyProvider
     workspace?: SkillSshWorkspaceAuthority
   } | null> {
     if (destination.scope === 'global') {
-      return destination.executionTarget?.kind === 'ssh'
-        ? { provider: this.requireSkillSshProvider(destination.executionTarget.connectionId) }
-        : null
+      if (destination.executionTarget?.kind !== 'ssh') {
+        return null
+      }
+      const connectionId = destination.executionTarget.connectionId
+      return { provider: () => this.requireSkillSshProvider(connectionId) }
     }
     if (destination.worktreeId) {
       const repo = this.listRepos().find(
@@ -5419,7 +5414,7 @@ export class OrcaRuntimeService {
         throw new Error('skill-install-workspace-not-found')
       }
       return {
-        provider: this.requireSkillSshProvider(repo.connectionId),
+        provider: () => this.requireSkillSshProvider(repo.connectionId!),
         workspace: { kind: 'worktree', id: worktree.id, path: worktree.path }
       }
     }
@@ -5430,7 +5425,7 @@ export class OrcaRuntimeService {
       return null
     }
     return {
-      provider: this.requireSkillSshProvider(folder.connectionId),
+      provider: () => this.requireSkillSshProvider(folder.connectionId!),
       workspace: { kind: 'folder', id: folder.id, path: folder.folderPath }
     }
   }

--- a/src/main/skills/skill-bundle-creation.test.ts
+++ b/src/main/skills/skill-bundle-creation.test.ts
@@ -49,6 +49,9 @@ describe('skill bundle creation and extraction', () => {
       versionId: 'version_windows',
       bundleName: 'windows-bundle'
     })
+    expect(created.manifest.skills[0].files).toContainEqual(
+      expect.objectContaining({ path: 'run.sh', executable: true })
+    )
 
     await expect(
       extractSkillBundleArchive({

--- a/src/main/skills/skill-bundle-creation.test.ts
+++ b/src/main/skills/skill-bundle-creation.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -36,6 +36,29 @@ afterEach(async () => {
 })
 
 describe('skill bundle creation and extraction', () => {
+  it('verifies manifest executable paths without Windows mode bits', async () => {
+    const root = await temporaryDirectory()
+    const source = await createSkill(root, 'script-skill', 'Script')
+    const script = join(source, 'run.sh')
+    await writeFile(script, '#!/bin/sh\necho ok\n')
+    await chmod(script, 0o700)
+    const created = await createSkillBundleArchive({
+      sources: [{ sourceDirectory: source }],
+      archivePath: join(root, 'bundle.tar.gz'),
+      packageId: 'package_windows',
+      versionId: 'version_windows',
+      bundleName: 'windows-bundle'
+    })
+
+    await expect(
+      extractSkillBundleArchive({
+        archivePath: created.archivePath,
+        destinationDirectory: join(root, 'windows-extracted'),
+        platform: 'win32'
+      })
+    ).resolves.toMatchObject({ manifest: { bundleName: 'windows-bundle' } })
+  })
+
   it('round trips multiple skills through an Agent Plugins compatible root', async () => {
     const root = await temporaryDirectory()
     const alpha = await createSkill(root, 'alpha-skill', 'Alpha')

--- a/src/main/skills/skill-bundle-creation.ts
+++ b/src/main/skills/skill-bundle-creation.ts
@@ -24,7 +24,11 @@ import { observeSkillPackage, type ObservedSkillPackage } from './skill-package-
 import { writeSkillTarGzip, type SkillTarWriteEntry } from './skill-package-tar'
 import { startSkillPhaseOperation } from './skill-operation-observability'
 
-export type SkillBundleSource = { id?: string; sourceDirectory: string }
+export type SkillBundleSource = {
+  id?: string
+  sourceDirectory: string
+  executablePaths?: ReadonlySet<string>
+}
 
 export type CreatedSkillBundle = {
   pluginManifest: AgentPluginManifestV1
@@ -92,7 +96,14 @@ async function stageSkill(input: {
     force: false,
     errorOnExist: true
   })
-  const stagedObservation = await observeSkillPackage(stagedDirectory)
+  const stagedObservation = await observeSkillPackage(
+    stagedDirectory,
+    undefined,
+    input.source.executablePaths,
+    undefined,
+    process.platform,
+    process.platform === 'win32'
+  )
   if (!observationsMatch(input.sourceObservation, stagedObservation)) {
     throw new Error('skill-package-source-changed-during-staging')
   }
@@ -135,7 +146,14 @@ async function createSkillBundleArchiveUnobserved(
     const observed = await Promise.all(
       batch.map(async (source) => {
         const [observation, markdown] = await Promise.all([
-          observeSkillPackage(source.sourceDirectory),
+          observeSkillPackage(
+            source.sourceDirectory,
+            undefined,
+            source.executablePaths,
+            undefined,
+            process.platform,
+            process.platform === 'win32'
+          ),
           readFile(join(source.sourceDirectory, 'SKILL.md'), 'utf8')
         ])
         const summary = summarizeSkillMarkdown(markdown)

--- a/src/main/skills/skill-bundle-extraction.ts
+++ b/src/main/skills/skill-bundle-extraction.ts
@@ -130,9 +130,20 @@ async function verifySkill(input: {
   directory: string
   manifest: SkillBundleManifestV1['skills'][number]
   signal?: AbortSignal
+  platform: NodeJS.Platform
 }): Promise<void> {
   throwIfCancelled(input.signal)
-  const observed = await observeSkillPackage(input.directory, undefined, undefined, input.signal)
+  const executablePaths =
+    input.platform === 'win32'
+      ? new Set(input.manifest.files.filter((file) => file.executable).map((file) => file.path))
+      : undefined
+  const observed = await observeSkillPackage(
+    input.directory,
+    undefined,
+    executablePaths,
+    input.signal,
+    input.platform
+  )
   throwIfCancelled(input.signal)
   if (
     observed.observedDigest !== input.manifest.digest ||
@@ -163,6 +174,7 @@ export async function extractSkillBundleArchive(input: {
   expectedPackageId?: string
   expectedVersionId?: string
   signal?: AbortSignal
+  platform?: NodeJS.Platform
 }): Promise<SkillBundleExtractionResult> {
   const archive = await openSkillTarGzip(input.archivePath)
   let destinationCreated = false
@@ -227,7 +239,8 @@ export async function extractSkillBundleArchive(input: {
           verifySkill({
             directory: join(skillsDirectory, skill.name),
             manifest: skill,
-            signal: input.signal
+            signal: input.signal,
+            platform: input.platform ?? process.platform
           })
         )
       )

--- a/src/main/skills/skill-bundle-install-service.test.ts
+++ b/src/main/skills/skill-bundle-install-service.test.ts
@@ -258,5 +258,35 @@ describe('skill bundle installation', () => {
         }
       ]
     })
+
+    await rm(providerPath, { recursive: true })
+    const retried = await installSkillBundle({
+      operationId: 'operation_provider_retry',
+      archivePath: bundle.archivePath,
+      packageId: bundle.manifest.packageId,
+      versionId: bundle.manifest.versionId,
+      bundleDigest: bundle.manifest.bundleDigest,
+      selectedSkillIds: ['alpha-skill'],
+      expectedArchiveSha256: bundle.archiveSha256,
+      scope: 'global',
+      homeDirectory,
+      orcaStateDirectory: join(root, 'state'),
+      detectedProviders: ['claude'],
+      destinationIdentity: 'local-global',
+      hostIdentity: 'host_1'
+    })
+
+    expect(retried).toMatchObject({
+      status: 'complete',
+      skills: [
+        {
+          name: 'alpha-skill',
+          status: 'unchanged',
+          placements: expect.arrayContaining([
+            expect.objectContaining({ provider: 'claude', status: 'unchanged' })
+          ])
+        }
+      ]
+    })
   })
 })

--- a/src/main/skills/skill-bundle-ssh-relay-service.test.ts
+++ b/src/main/skills/skill-bundle-ssh-relay-service.test.ts
@@ -270,4 +270,43 @@ describe('previewSkillBundleInstallOnSshHost', () => {
     ).rejects.toThrow('skill-bundle-ssh-update-required')
     expect(requestHostRpc).toHaveBeenCalledOnce()
   })
+
+  it('adopts the current provider generation when preview retries after reconnect', async () => {
+    const request = previewRequest()
+    const response = {
+      packageId: request.package.packageId,
+      versionId: request.package.versionId,
+      bundleDigest: request.package.bundleDigest,
+      destinationIdentity: 'global:ssh-host',
+      skills: request.selectedSkills.map((skill) => ({
+        ...skill,
+        currentState: 'missing' as const
+      }))
+    }
+    const secondRpc = vi.fn(async (method: string) =>
+      method === 'relay.status' ? { capabilities: ['skills.preview.bundle.v1'] } : response
+    )
+    const secondProvider = { requestHostRpc: secondRpc } as unknown as IPtyProvider
+    let currentProvider: IPtyProvider
+    const firstRpc = vi.fn(async (method: string) => {
+      if (method === 'relay.status') {
+        return { capabilities: ['skills.preview.bundle.v1'] }
+      }
+      currentProvider = secondProvider
+      throw new Error('disconnected-provider-generation')
+    })
+    currentProvider = { requestHostRpc: firstRpc } as unknown as IPtyProvider
+
+    await expect(
+      previewSkillBundleInstallOnSshHost({ provider: () => currentProvider, request })
+    ).resolves.toEqual(response)
+    expect(firstRpc.mock.calls.map(([method]) => method)).toEqual([
+      'relay.status',
+      'skills.previewBundleInstall'
+    ])
+    expect(secondRpc.mock.calls.map(([method]) => method)).toEqual([
+      'relay.status',
+      'skills.previewBundleInstall'
+    ])
+  })
 })

--- a/src/main/skills/skill-bundle-ssh-relay-service.test.ts
+++ b/src/main/skills/skill-bundle-ssh-relay-service.test.ts
@@ -3,10 +3,16 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import type { SkillBundleInstallRequest } from '../../shared/skill-bundle-install-contract'
+import type {
+  SkillBundleInstallPreviewRequest,
+  SkillBundleInstallRequest
+} from '../../shared/skill-bundle-install-contract'
 import { SKILL_PACKAGE_CONTENT_TYPE } from '../../shared/skill-package-manifest'
 import type { IPtyProvider } from '../providers/pty-provider-contract'
-import { installSkillBundleOnSshHost } from './skill-bundle-ssh-relay-service'
+import {
+  installSkillBundleOnSshHost,
+  previewSkillBundleInstallOnSshHost
+} from './skill-bundle-ssh-relay-service'
 
 const roots: string[] = []
 
@@ -52,7 +58,54 @@ function result() {
   }
 }
 
+function previewRequest(count = 30): SkillBundleInstallPreviewRequest {
+  return {
+    package: {
+      packageId: 'package_1',
+      versionId: 'version_1',
+      bundleDigest: 'a'.repeat(64),
+      archiveSha256: 'b'.repeat(64),
+      compressedBytes: 100
+    },
+    selectedSkills: Array.from({ length: count }, (_, index) => ({
+      id: `skill-${index}`,
+      name: `skill-${index}`,
+      digest: String(index).padStart(64, '0')
+    })),
+    destination: { scope: 'global', executionTarget: { kind: 'host' } }
+  }
+}
+
 describe('installSkillBundleOnSshHost', () => {
+  it('adopts the current provider generation when an RPC retry follows reconnect', async () => {
+    const secondRpc = vi.fn(async () => result())
+    const secondProvider = { requestHostRpc: secondRpc } as unknown as IPtyProvider
+    let currentProvider: IPtyProvider
+    const firstRpc = vi.fn(async (method: string) => {
+      if (method === 'relay.status') {
+        return { capabilities: ['skills.install.bundle.v1'] }
+      }
+      currentProvider = secondProvider
+      throw new Error('disconnected-provider-generation')
+    })
+    currentProvider = { requestHostRpc: firstRpc } as unknown as IPtyProvider
+
+    await expect(
+      installSkillBundleOnSshHost({
+        provider: () => currentProvider,
+        userDataPath: await userDataPath(),
+        request: request(Buffer.from('archive')),
+        requireHttps: true
+      })
+    ).resolves.toEqual(result())
+
+    expect(firstRpc.mock.calls.map(([method]) => method)).toEqual([
+      'relay.status',
+      'skills.installBundle'
+    ])
+    expect(secondRpc).toHaveBeenCalledOnce()
+  })
+
   it('uses the additive method only when advertised by the SSH host', async () => {
     const bytes = Buffer.from('private bundle archive')
     const requestHostRpc = vi.fn(async (method: string) => {
@@ -177,5 +230,44 @@ describe('installSkillBundleOnSshHost', () => {
       'skills.installBundle',
       'skills.cancelUpload'
     ])
+  })
+})
+
+describe('previewSkillBundleInstallOnSshHost', () => {
+  it('previews the complete bundle with one capability check and one RPC', async () => {
+    const request = previewRequest()
+    const response = {
+      packageId: request.package.packageId,
+      versionId: request.package.versionId,
+      bundleDigest: request.package.bundleDigest,
+      destinationIdentity: 'global:ssh-host',
+      skills: request.selectedSkills.map((skill) => ({ ...skill, currentState: 'missing' }))
+    }
+    const requestHostRpc = vi.fn(async (method: string) =>
+      method === 'relay.status' ? { capabilities: ['skills.preview.bundle.v1'] } : response
+    )
+
+    await expect(
+      previewSkillBundleInstallOnSshHost({
+        provider: { requestHostRpc } as unknown as IPtyProvider,
+        request
+      })
+    ).resolves.toEqual(response)
+    expect(requestHostRpc.mock.calls.map(([method]) => method)).toEqual([
+      'relay.status',
+      'skills.previewBundleInstall'
+    ])
+  })
+
+  it('does not send an unknown preview method to an older SSH host', async () => {
+    const requestHostRpc = vi.fn(async () => ({ capabilities: ['skills.manage.v1'] }))
+
+    await expect(
+      previewSkillBundleInstallOnSshHost({
+        provider: { requestHostRpc } as unknown as IPtyProvider,
+        request: previewRequest()
+      })
+    ).rejects.toThrow('skill-bundle-ssh-update-required')
+    expect(requestHostRpc).toHaveBeenCalledOnce()
   })
 })

--- a/src/main/skills/skill-bundle-ssh-relay-service.test.ts
+++ b/src/main/skills/skill-bundle-ssh-relay-service.test.ts
@@ -291,8 +291,146 @@ describe('previewSkillBundleInstallOnSshHost', () => {
     ])
   })
 
-  it('does not send an unknown preview method to an older SSH host', async () => {
-    const requestHostRpc = vi.fn(async () => ({ capabilities: ['skills.manage.v1'] }))
+  it('falls back to bounded per-skill previews on an older SSH host', async () => {
+    const request = previewRequest()
+    let active = 0
+    let maximumActive = 0
+    const requestHostRpc = vi.fn(async (method: string, params: unknown) => {
+      if (method === 'relay.status') {
+        return { capabilities: ['skills.manage.v1'] }
+      }
+      if (method !== 'skills.previewInstall') {
+        throw new Error(`unexpected method ${method}`)
+      }
+      active += 1
+      maximumActive = Math.max(maximumActive, active)
+      await Promise.resolve()
+      active -= 1
+      const input = params as { request: { name: string; package: { packageDigest: string } } }
+      return {
+        packageDigest: input.request.package.packageDigest,
+        name: input.request.name,
+        destinationIdentity: 'global:ssh-host',
+        currentState: 'missing',
+        providers: []
+      }
+    })
+
+    await expect(
+      previewSkillBundleInstallOnSshHost({
+        provider: { requestHostRpc } as unknown as IPtyProvider,
+        request
+      })
+    ).resolves.toEqual({
+      packageId: request.package.packageId,
+      versionId: request.package.versionId,
+      bundleDigest: request.package.bundleDigest,
+      destinationIdentity: 'global:ssh-host',
+      skills: request.selectedSkills.map((skill) => ({ ...skill, currentState: 'missing' }))
+    })
+    expect(requestHostRpc.mock.calls.map(([method]) => method)).not.toContain(
+      'skills.previewBundleInstall'
+    )
+    expect(requestHostRpc).toHaveBeenCalledTimes(request.selectedSkills.length + 1)
+    expect(maximumActive).toBeLessThanOrEqual(8)
+  })
+
+  it('settles a failed legacy batch before retrying it', async () => {
+    let active = 0
+    let cancelled = 0
+    let maximumActive = 0
+    const requestHostRpc = vi.fn(
+      async (method: string, params: unknown, options?: { signal?: AbortSignal }) => {
+        if (method === 'relay.status') {
+          return { capabilities: ['skills.manage.v1'] }
+        }
+        const input = params as { request: { name: string; package: { packageDigest: string } } }
+        active += 1
+        maximumActive = Math.max(maximumActive, active)
+        try {
+          if (input.request.name === 'skill-0') {
+            throw new Error('preview transport failed')
+          }
+          await new Promise<void>((_resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('preview cancellation timeout')), 250)
+            options?.signal?.addEventListener(
+              'abort',
+              () => {
+                clearTimeout(timeout)
+                cancelled += 1
+                const error = new Error('preview aborted')
+                error.name = 'AbortError'
+                reject(error)
+              },
+              { once: true }
+            )
+          })
+          return {
+            packageDigest: input.request.package.packageDigest,
+            name: input.request.name,
+            destinationIdentity: 'global:ssh-host',
+            currentState: 'missing',
+            providers: []
+          }
+        } finally {
+          active -= 1
+        }
+      }
+    )
+
+    await expect(
+      previewSkillBundleInstallOnSshHost({
+        provider: { requestHostRpc } as unknown as IPtyProvider,
+        request: previewRequest()
+      })
+    ).rejects.toThrow('preview transport failed')
+
+    expect(maximumActive).toBeLessThanOrEqual(8)
+    expect(active).toBe(0)
+    expect(cancelled).toBe(21)
+  })
+
+  it('does not retry malformed legacy preview responses', async () => {
+    const requestHostRpc = vi.fn(async (method: string) =>
+      method === 'relay.status' ? { capabilities: ['skills.manage.v1'] } : { malformed: true }
+    )
+
+    await expect(
+      previewSkillBundleInstallOnSshHost({
+        provider: { requestHostRpc } as unknown as IPtyProvider,
+        request: previewRequest(8)
+      })
+    ).rejects.toThrow()
+
+    expect(requestHostRpc).toHaveBeenCalledTimes(9)
+  })
+
+  it('preserves first-rejection retry semantics while settling a legacy batch', async () => {
+    const nonRetryable = Object.assign(new Error('preview rejected'), { code: 400 })
+    const requestHostRpc = vi.fn(async (method: string, params: unknown) => {
+      if (method === 'relay.status') {
+        return { capabilities: ['skills.manage.v1'] }
+      }
+      const input = params as { request: { name: string } }
+      if (input.request.name === 'skill-0') {
+        await new Promise((resolve) => setTimeout(resolve, 5))
+        throw new Error('later transport failure')
+      }
+      throw nonRetryable
+    })
+
+    await expect(
+      previewSkillBundleInstallOnSshHost({
+        provider: { requestHostRpc } as unknown as IPtyProvider,
+        request: previewRequest(2)
+      })
+    ).rejects.toThrow('preview rejected')
+
+    expect(requestHostRpc).toHaveBeenCalledTimes(3)
+  })
+
+  it('requires an update when the SSH host lacks both preview capabilities', async () => {
+    const requestHostRpc = vi.fn(async () => ({ capabilities: [] }))
 
     await expect(
       previewSkillBundleInstallOnSshHost({

--- a/src/main/skills/skill-bundle-ssh-relay-service.test.ts
+++ b/src/main/skills/skill-bundle-ssh-relay-service.test.ts
@@ -78,7 +78,9 @@ function previewRequest(count = 30): SkillBundleInstallPreviewRequest {
 
 describe('installSkillBundleOnSshHost', () => {
   it('adopts the current provider generation when an RPC retry follows reconnect', async () => {
-    const secondRpc = vi.fn(async () => result())
+    const secondRpc = vi.fn(async (method: string) =>
+      method === 'relay.status' ? { capabilities: ['skills.install.bundle.v1'] } : result()
+    )
     const secondProvider = { requestHostRpc: secondRpc } as unknown as IPtyProvider
     let currentProvider: IPtyProvider
     const firstRpc = vi.fn(async (method: string) => {
@@ -103,7 +105,36 @@ describe('installSkillBundleOnSshHost', () => {
       'relay.status',
       'skills.installBundle'
     ])
-    expect(secondRpc).toHaveBeenCalledOnce()
+    expect(secondRpc.mock.calls.map(([method]) => method)).toEqual([
+      'relay.status',
+      'skills.installBundle'
+    ])
+  })
+
+  it('does not reuse newer capabilities after reconnecting to an older host', async () => {
+    const secondRpc = vi.fn(async (_method: string) => ({
+      capabilities: ['skills.install.v1']
+    }))
+    const secondProvider = { requestHostRpc: secondRpc } as unknown as IPtyProvider
+    let currentProvider: IPtyProvider
+    const firstRpc = vi.fn(async (method: string) => {
+      if (method === 'relay.status') {
+        return { capabilities: ['skills.install.bundle.v1'] }
+      }
+      currentProvider = secondProvider
+      throw new Error('disconnected-provider-generation')
+    })
+    currentProvider = { requestHostRpc: firstRpc } as unknown as IPtyProvider
+
+    await expect(
+      installSkillBundleOnSshHost({
+        provider: () => currentProvider,
+        userDataPath: await userDataPath(),
+        request: request(Buffer.from('archive')),
+        requireHttps: true
+      })
+    ).rejects.toThrow('skill-bundle-ssh-update-required')
+    expect(secondRpc.mock.calls.map(([method]) => method)).toEqual(['relay.status'])
   })
 
   it('uses the additive method only when advertised by the SSH host', async () => {
@@ -224,6 +255,7 @@ describe('installSkillBundleOnSshHost', () => {
     expect(requestHostRpc.mock.calls.map(([method]) => method)).toEqual([
       'relay.status',
       'skills.installBundle',
+      'relay.status',
       'skills.beginUpload',
       'skills.uploadChunk',
       'skills.commitUpload',

--- a/src/main/skills/skill-bundle-ssh-relay-service.ts
+++ b/src/main/skills/skill-bundle-ssh-relay-service.ts
@@ -1,12 +1,16 @@
 import {
   SkillBundleInstallProgressSchema,
+  SkillBundleInstallPreviewSchema,
   SkillBundleInstallResultSchema,
   type SkillBundleInstallProgress,
+  type SkillBundleInstallPreview,
+  type SkillBundleInstallPreviewRequest,
   type SkillBundleInstallRequest,
   type SkillBundleInstallResult
 } from '../../shared/skill-bundle-install-contract'
 import {
   SKILL_BUNDLE_INSTALL_CAPABILITY,
+  SKILL_BUNDLE_PREVIEW_CAPABILITY,
   SKILL_INSTALL_PROVIDERS_CAPABILITY,
   SKILL_INSTALL_PROGRESS_CAPABILITY,
   SKILL_UPLOAD_CAPABILITY
@@ -15,9 +19,9 @@ import {
   SKILL_SSH_RELAY_CANCEL_UPLOAD_METHOD,
   SKILL_SSH_RELAY_GET_INSTALL_PROGRESS_METHOD,
   SKILL_SSH_RELAY_INSTALL_BUNDLE_METHOD,
+  SKILL_SSH_RELAY_PREVIEW_BUNDLE_METHOD,
   type SkillSshWorkspaceAuthority
 } from '../../shared/skill-ssh-relay-contract'
-import type { IPtyProvider } from '../providers/pty-provider-contract'
 import {
   SKILL_SSH_REQUEST_TIMEOUT_MS,
   requireSkillSshRelayClient,
@@ -25,13 +29,14 @@ import {
   shouldUseSkillSshClientTransfer,
   skillSshRelayCapabilities
 } from './skill-ssh-relay-client'
+import type { SkillSshProviderSource } from './skill-ssh-relay-client'
 import { transferSkillPackageToSshHost } from './skill-ssh-package-transfer'
 import { retrySkillTransferRpc } from './skill-transfer-rpc-retry'
 import { startSkillInstallProgressPolling } from './skill-install-progress-polling'
 import { recordSkillCapabilityAbsence } from './skill-operation-observability'
 
 export async function installSkillBundleOnSshHost(input: {
-  provider: IPtyProvider
+  provider: SkillSshProviderSource
   userDataPath: string
   request: SkillBundleInstallRequest
   workspace?: SkillSshWorkspaceAuthority
@@ -127,4 +132,27 @@ export async function installSkillBundleOnSshHost(input: {
   } finally {
     stopProgress?.()
   }
+}
+
+export async function previewSkillBundleInstallOnSshHost(input: {
+  provider: SkillSshProviderSource
+  request: SkillBundleInstallPreviewRequest
+  workspace?: SkillSshWorkspaceAuthority
+}): Promise<SkillBundleInstallPreview> {
+  const client = requireSkillSshRelayClient(input.provider)
+  const supported = await skillSshRelayCapabilities(client)
+  if (!supported.includes(SKILL_BUNDLE_PREVIEW_CAPABILITY)) {
+    recordSkillCapabilityAbsence({
+      capability: SKILL_BUNDLE_PREVIEW_CAPABILITY,
+      destination: 'global-ssh'
+    })
+    throw new Error('skill-bundle-ssh-update-required')
+  }
+  return SkillBundleInstallPreviewSchema.parse(
+    await client(
+      SKILL_SSH_RELAY_PREVIEW_BUNDLE_METHOD,
+      { request: input.request, workspace: input.workspace },
+      { timeoutMs: 30_000 }
+    )
+  )
 }

--- a/src/main/skills/skill-bundle-ssh-relay-service.ts
+++ b/src/main/skills/skill-bundle-ssh-relay-service.ts
@@ -139,20 +139,27 @@ export async function previewSkillBundleInstallOnSshHost(input: {
   request: SkillBundleInstallPreviewRequest
   workspace?: SkillSshWorkspaceAuthority
 }): Promise<SkillBundleInstallPreview> {
-  const client = requireSkillSshRelayClient(input.provider)
-  const supported = await skillSshRelayCapabilities(client)
-  if (!supported.includes(SKILL_BUNDLE_PREVIEW_CAPABILITY)) {
-    recordSkillCapabilityAbsence({
-      capability: SKILL_BUNDLE_PREVIEW_CAPABILITY,
-      destination: 'global-ssh'
-    })
-    throw new Error('skill-bundle-ssh-update-required')
-  }
   return SkillBundleInstallPreviewSchema.parse(
-    await client(
-      SKILL_SSH_RELAY_PREVIEW_BUNDLE_METHOD,
-      { request: input.request, workspace: input.workspace },
-      { timeoutMs: 30_000 }
-    )
+    await retrySkillTransferRpc({
+      retryable: (error) =>
+        (error as Error)?.message !== 'skill-bundle-ssh-update-required' &&
+        retryableSkillSshTransportError(error),
+      call: async () => {
+        const provider = typeof input.provider === 'function' ? input.provider() : input.provider
+        const client = requireSkillSshRelayClient(provider)
+        if (!(await skillSshRelayCapabilities(client)).includes(SKILL_BUNDLE_PREVIEW_CAPABILITY)) {
+          recordSkillCapabilityAbsence({
+            capability: SKILL_BUNDLE_PREVIEW_CAPABILITY,
+            destination: 'global-ssh'
+          })
+          throw new Error('skill-bundle-ssh-update-required')
+        }
+        return client(
+          SKILL_SSH_RELAY_PREVIEW_BUNDLE_METHOD,
+          { request: input.request, workspace: input.workspace },
+          { timeoutMs: 30_000 }
+        )
+      }
+    })
   )
 }

--- a/src/main/skills/skill-bundle-ssh-relay-service.ts
+++ b/src/main/skills/skill-bundle-ssh-relay-service.ts
@@ -1,3 +1,4 @@
+import { ZodError } from 'zod'
 import {
   SkillBundleInstallProgressSchema,
   SkillBundleInstallPreviewSchema,
@@ -11,6 +12,7 @@ import {
 import {
   SKILL_BUNDLE_INSTALL_CAPABILITY,
   SKILL_BUNDLE_PREVIEW_CAPABILITY,
+  SKILL_MANAGEMENT_CAPABILITY,
   SKILL_INSTALL_PROVIDERS_CAPABILITY,
   SKILL_INSTALL_PROGRESS_CAPABILITY,
   SKILL_UPLOAD_CAPABILITY
@@ -20,8 +22,13 @@ import {
   SKILL_SSH_RELAY_GET_INSTALL_PROGRESS_METHOD,
   SKILL_SSH_RELAY_INSTALL_BUNDLE_METHOD,
   SKILL_SSH_RELAY_PREVIEW_BUNDLE_METHOD,
+  SKILL_SSH_RELAY_PREVIEW_METHOD,
   type SkillSshWorkspaceAuthority
 } from '../../shared/skill-ssh-relay-contract'
+import {
+  SkillInstallPreviewSchema,
+  type SkillInstallPreview
+} from '../../shared/skill-install-contract'
 import {
   SKILL_SSH_REQUEST_TIMEOUT_MS,
   requireSkillSshRelayClient,
@@ -39,6 +46,81 @@ const NON_RETRYABLE_BUNDLE_TRANSFER_ERRORS = new Set([
   'skill-bundle-ssh-update-required',
   'skill-bundle-ssh-download-unavailable'
 ])
+const LEGACY_BUNDLE_PREVIEW_CONCURRENCY = 8
+
+async function previewBundleWithLegacyRpc(
+  client: SkillSshRelayClient,
+  input: {
+    request: SkillBundleInstallPreviewRequest
+    workspace?: SkillSshWorkspaceAuthority
+  }
+): Promise<SkillBundleInstallPreview> {
+  const previews: SkillInstallPreview[] = []
+  for (
+    let offset = 0;
+    offset < input.request.selectedSkills.length;
+    offset += LEGACY_BUNDLE_PREVIEW_CONCURRENCY
+  ) {
+    const batch = input.request.selectedSkills.slice(
+      offset,
+      offset + LEGACY_BUNDLE_PREVIEW_CONCURRENCY
+    )
+    const batchAbort = new AbortController()
+    const failures: { reason: unknown }[] = []
+    const results = await Promise.allSettled(
+      batch.map(async (skill) => {
+        try {
+          return SkillInstallPreviewSchema.parse(
+            await client(
+              SKILL_SSH_RELAY_PREVIEW_METHOD,
+              {
+                request: {
+                  package: {
+                    packageId: input.request.package.packageId,
+                    versionId: input.request.package.versionId,
+                    packageDigest: skill.digest,
+                    archiveSha256: input.request.package.archiveSha256,
+                    compressedBytes: input.request.package.compressedBytes
+                  },
+                  name: skill.name,
+                  destination: input.request.destination
+                },
+                workspace: input.workspace
+              },
+              { timeoutMs: 30_000, signal: batchAbort.signal }
+            )
+          )
+        } catch (error) {
+          failures.push({ reason: error })
+          if (failures.length === 1) {
+            batchAbort.abort()
+          }
+          throw error
+        }
+      })
+    )
+    const [firstFailure] = failures
+    if (firstFailure) {
+      throw firstFailure.reason
+    }
+    for (const result of results) {
+      if (result.status !== 'fulfilled') {
+        continue
+      }
+      previews.push(result.value)
+    }
+  }
+  return SkillBundleInstallPreviewSchema.parse({
+    packageId: input.request.package.packageId,
+    versionId: input.request.package.versionId,
+    bundleDigest: input.request.package.bundleDigest,
+    destinationIdentity: previews[0]?.destinationIdentity ?? '',
+    skills: input.request.selectedSkills.map((skill, index) => ({
+      ...skill,
+      currentState: previews[index]?.currentState
+    }))
+  })
+}
 
 export async function installSkillBundleOnSshHost(input: {
   provider: SkillSshProviderSource
@@ -170,22 +252,27 @@ export async function previewSkillBundleInstallOnSshHost(input: {
   return SkillBundleInstallPreviewSchema.parse(
     await retrySkillTransferRpc({
       retryable: (error) =>
+        !(error instanceof ZodError) &&
         (error as Error)?.message !== 'skill-bundle-ssh-update-required' &&
         retryableSkillSshTransportError(error),
       call: async () => {
         const client = requireSkillSshRelayClient(input.provider)
-        if (!(await skillSshRelayCapabilities(client)).includes(SKILL_BUNDLE_PREVIEW_CAPABILITY)) {
-          recordSkillCapabilityAbsence({
-            capability: SKILL_BUNDLE_PREVIEW_CAPABILITY,
-            destination: 'global-ssh'
-          })
+        const supported = await skillSshRelayCapabilities(client)
+        if (supported.includes(SKILL_BUNDLE_PREVIEW_CAPABILITY)) {
+          return client(
+            SKILL_SSH_RELAY_PREVIEW_BUNDLE_METHOD,
+            { request: input.request, workspace: input.workspace },
+            { timeoutMs: 30_000 }
+          )
+        }
+        recordSkillCapabilityAbsence({
+          capability: SKILL_BUNDLE_PREVIEW_CAPABILITY,
+          destination: 'global-ssh'
+        })
+        if (!supported.includes(SKILL_MANAGEMENT_CAPABILITY)) {
           throw new Error('skill-bundle-ssh-update-required')
         }
-        return client(
-          SKILL_SSH_RELAY_PREVIEW_BUNDLE_METHOD,
-          { request: input.request, workspace: input.workspace },
-          { timeoutMs: 30_000 }
-        )
+        return previewBundleWithLegacyRpc(client, input)
       }
     })
   )

--- a/src/main/skills/skill-bundle-ssh-relay-service.ts
+++ b/src/main/skills/skill-bundle-ssh-relay-service.ts
@@ -29,11 +29,16 @@ import {
   shouldUseSkillSshClientTransfer,
   skillSshRelayCapabilities
 } from './skill-ssh-relay-client'
-import type { SkillSshProviderSource } from './skill-ssh-relay-client'
+import type { SkillSshProviderSource, SkillSshRelayClient } from './skill-ssh-relay-client'
 import { transferSkillPackageToSshHost } from './skill-ssh-package-transfer'
 import { retrySkillTransferRpc } from './skill-transfer-rpc-retry'
 import { startSkillInstallProgressPolling } from './skill-install-progress-polling'
 import { recordSkillCapabilityAbsence } from './skill-operation-observability'
+
+const NON_RETRYABLE_BUNDLE_TRANSFER_ERRORS = new Set([
+  'skill-bundle-ssh-update-required',
+  'skill-bundle-ssh-download-unavailable'
+])
 
 export async function installSkillBundleOnSshHost(input: {
   provider: SkillSshProviderSource
@@ -45,49 +50,60 @@ export async function installSkillBundleOnSshHost(input: {
   onProgress?: (progress: SkillBundleInstallProgress) => void
   fetcher?: typeof fetch
 }): Promise<SkillBundleInstallResult> {
-  const client = requireSkillSshRelayClient(input.provider)
-  const supported = await skillSshRelayCapabilities(client)
   const request = input.request
-  if (request.providers !== undefined && !supported.includes(SKILL_INSTALL_PROVIDERS_CAPABILITY)) {
-    throw new Error('skill-bundle-ssh-update-required')
+  let stopProgress = (): void => undefined
+  function restartProgress(client: SkillSshRelayClient, supported: string[]): void {
+    stopProgress()
+    stopProgress = (): void => undefined
+    if (input.onProgress && supported.includes(SKILL_INSTALL_PROGRESS_CAPABILITY)) {
+      stopProgress = startSkillInstallProgressPolling({
+        read: async () => {
+          const value = await client(
+            SKILL_SSH_RELAY_GET_INSTALL_PROGRESS_METHOD,
+            { operationId: request.operationId },
+            { timeoutMs: 2_000, signal: input.signal }
+          )
+          if (value === null) {
+            return null
+          }
+          const parsed = SkillBundleInstallProgressSchema.safeParse(value)
+          return parsed.success ? parsed.data : null
+        },
+        onProgress: input.onProgress
+      })
+    }
   }
-  if (!supported.includes(SKILL_BUNDLE_INSTALL_CAPABILITY)) {
-    recordSkillCapabilityAbsence({
-      capability: SKILL_BUNDLE_INSTALL_CAPABILITY,
-      destination: 'global-ssh'
-    })
-    throw new Error('skill-bundle-ssh-update-required')
-  }
-  const stopProgress =
-    input.onProgress && supported.includes(SKILL_INSTALL_PROGRESS_CAPABILITY)
-      ? startSkillInstallProgressPolling({
-          read: async () => {
-            const value = await client(
-              SKILL_SSH_RELAY_GET_INSTALL_PROGRESS_METHOD,
-              { operationId: request.operationId },
-              { timeoutMs: 2_000, signal: input.signal }
-            )
-            if (value === null) {
-              return null
-            }
-            const parsed = SkillBundleInstallProgressSchema.safeParse(value)
-            return parsed.success ? parsed.data : null
-          },
-          onProgress: input.onProgress
-        })
-      : null
   try {
     try {
       return SkillBundleInstallResultSchema.parse(
         await retrySkillTransferRpc({
           signal: input.signal,
-          retryable: retryableSkillSshTransportError,
-          call: () =>
-            client(
+          retryable: (error) =>
+            (error as Error)?.message !== 'skill-bundle-ssh-update-required' &&
+            retryableSkillSshTransportError(error),
+          call: async () => {
+            const client = requireSkillSshRelayClient(input.provider)
+            const supported = await skillSshRelayCapabilities(client)
+            if (
+              request.providers !== undefined &&
+              !supported.includes(SKILL_INSTALL_PROVIDERS_CAPABILITY)
+            ) {
+              throw new Error('skill-bundle-ssh-update-required')
+            }
+            if (!supported.includes(SKILL_BUNDLE_INSTALL_CAPABILITY)) {
+              recordSkillCapabilityAbsence({
+                capability: SKILL_BUNDLE_INSTALL_CAPABILITY,
+                destination: 'global-ssh'
+              })
+              throw new Error('skill-bundle-ssh-update-required')
+            }
+            restartProgress(client, supported)
+            return client(
               SKILL_SSH_RELAY_INSTALL_BUNDLE_METHOD,
-              { request: request, workspace: input.workspace },
+              { request, workspace: input.workspace },
               { timeoutMs: SKILL_SSH_REQUEST_TIMEOUT_MS, signal: input.signal }
             )
+          }
         })
       )
     } catch (error) {
@@ -98,17 +114,29 @@ export async function installSkillBundleOnSshHost(input: {
         throw error
       }
     }
-    if (!supported.includes(SKILL_UPLOAD_CAPABILITY)) {
-      recordSkillCapabilityAbsence({
-        capability: SKILL_UPLOAD_CAPABILITY,
-        destination: 'global-ssh'
-      })
-      throw new Error('skill-bundle-ssh-download-unavailable')
-    }
     return await retrySkillTransferRpc({
       signal: input.signal,
-      retryable: retryableSkillSshTransportError,
+      retryable: (error) =>
+        !NON_RETRYABLE_BUNDLE_TRANSFER_ERRORS.has((error as Error)?.message) &&
+        retryableSkillSshTransportError(error),
       call: async () => {
+        const client = requireSkillSshRelayClient(input.provider)
+        const supported = await skillSshRelayCapabilities(client)
+        if (
+          !supported.includes(SKILL_BUNDLE_INSTALL_CAPABILITY) ||
+          (request.providers !== undefined &&
+            !supported.includes(SKILL_INSTALL_PROVIDERS_CAPABILITY))
+        ) {
+          throw new Error('skill-bundle-ssh-update-required')
+        }
+        if (!supported.includes(SKILL_UPLOAD_CAPABILITY)) {
+          recordSkillCapabilityAbsence({
+            capability: SKILL_UPLOAD_CAPABILITY,
+            destination: 'global-ssh'
+          })
+          throw new Error('skill-bundle-ssh-download-unavailable')
+        }
+        restartProgress(client, supported)
         const uploadId = await transferSkillPackageToSshHost(client, input)
         try {
           return SkillBundleInstallResultSchema.parse(
@@ -130,7 +158,7 @@ export async function installSkillBundleOnSshHost(input: {
       }
     })
   } finally {
-    stopProgress?.()
+    stopProgress()
   }
 }
 
@@ -145,8 +173,7 @@ export async function previewSkillBundleInstallOnSshHost(input: {
         (error as Error)?.message !== 'skill-bundle-ssh-update-required' &&
         retryableSkillSshTransportError(error),
       call: async () => {
-        const provider = typeof input.provider === 'function' ? input.provider() : input.provider
-        const client = requireSkillSshRelayClient(provider)
+        const client = requireSkillSshRelayClient(input.provider)
         if (!(await skillSshRelayCapabilities(client)).includes(SKILL_BUNDLE_PREVIEW_CAPABILITY)) {
           recordSkillCapabilityAbsence({
             capability: SKILL_BUNDLE_PREVIEW_CAPABILITY,

--- a/src/main/skills/skill-install-lock-owner.ts
+++ b/src/main/skills/skill-install-lock-owner.ts
@@ -10,7 +10,9 @@ function validOwner(value: unknown): SkillInstallLockOwner | null {
   const owner = value as Partial<SkillInstallLockOwner> | null
   return owner &&
     typeof owner.token === 'string' &&
+    typeof owner.pid === 'number' &&
     Number.isInteger(owner.pid) &&
+    owner.pid > 0 &&
     typeof owner.createdAt === 'number'
     ? (owner as SkillInstallLockOwner)
     : null

--- a/src/main/skills/skill-install-lock-owner.ts
+++ b/src/main/skills/skill-install-lock-owner.ts
@@ -1,0 +1,36 @@
+import { readFile } from 'node:fs/promises'
+
+export type SkillInstallLockOwner = {
+  token: string
+  pid: number
+  createdAt: number
+}
+
+function validOwner(value: unknown): SkillInstallLockOwner | null {
+  const owner = value as Partial<SkillInstallLockOwner> | null
+  return owner &&
+    typeof owner.token === 'string' &&
+    Number.isInteger(owner.pid) &&
+    typeof owner.createdAt === 'number'
+    ? (owner as SkillInstallLockOwner)
+    : null
+}
+
+export async function readSkillInstallLockOwner(
+  path: string
+): Promise<SkillInstallLockOwner | null> {
+  try {
+    return validOwner(JSON.parse(await readFile(path, 'utf8')))
+  } catch {
+    return null
+  }
+}
+
+export function skillInstallLockOwnerProcessIsAlive(owner: SkillInstallLockOwner): boolean {
+  try {
+    process.kill(owner.pid, 0)
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM'
+  }
+}

--- a/src/main/skills/skill-install-lock-release.ts
+++ b/src/main/skills/skill-install-lock-release.ts
@@ -2,6 +2,7 @@ import { readdir, rmdir, unlink } from 'node:fs/promises'
 import { join } from 'node:path'
 
 const RELEASE_ENTRY_NAME = /^[a-f0-9-]{36}\.(?:owner|released)$/
+const RECOVERY_RMDIR_IGNORED_CODES = new Set(['ENOENT', 'ENOTEMPTY', 'EEXIST', 'EBUSY'])
 
 async function unlinkIfPresent(path: string): Promise<void> {
   await unlink(path).catch((error) => {
@@ -44,5 +45,9 @@ export async function reclaimReleasedSkillInstallLock(path: string): Promise<voi
       .filter((entry) => entry.isFile() && RELEASE_ENTRY_NAME.test(entry.name))
       .map((entry) => unlinkIfPresent(join(path, entry.name)))
   )
-  await removeDirectoryIfPresent(path, rmdir)
+  await rmdir(path).catch((error) => {
+    if (!RECOVERY_RMDIR_IGNORED_CODES.has((error as NodeJS.ErrnoException).code ?? '')) {
+      throw error
+    }
+  })
 }

--- a/src/main/skills/skill-install-lock-release.ts
+++ b/src/main/skills/skill-install-lock-release.ts
@@ -1,0 +1,48 @@
+import { readdir, rmdir, unlink } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const RELEASE_ENTRY_NAME = /^[a-f0-9-]{36}\.(?:owner|released)$/
+
+async function unlinkIfPresent(path: string): Promise<void> {
+  await unlink(path).catch((error) => {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error
+    }
+  })
+}
+
+async function removeDirectoryIfPresent(
+  path: string,
+  removeDirectory: (path: string) => Promise<void>
+): Promise<void> {
+  await removeDirectory(path).catch((error) => {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error
+    }
+  })
+}
+
+export async function cleanupReleasedSkillInstallLock(
+  path: string,
+  token: string,
+  removeDirectory: (path: string) => Promise<void> = rmdir
+): Promise<void> {
+  await unlinkIfPresent(join(path, `${token}.owner`))
+  await unlinkIfPresent(join(path, `${token}.released`))
+  await removeDirectoryIfPresent(path, removeDirectory)
+}
+
+export async function reclaimReleasedSkillInstallLock(path: string): Promise<void> {
+  const entries = await readdir(path, { withFileTypes: true }).catch((error) => {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return []
+    }
+    throw error
+  })
+  await Promise.all(
+    entries
+      .filter((entry) => entry.isFile() && RELEASE_ENTRY_NAME.test(entry.name))
+      .map((entry) => unlinkIfPresent(join(path, entry.name)))
+  )
+  await removeDirectoryIfPresent(path, rmdir)
+}

--- a/src/main/skills/skill-install-lock.test.ts
+++ b/src/main/skills/skill-install-lock.test.ts
@@ -7,6 +7,7 @@ import {
   reclaimDeadSkillInstallLocks,
   skillInstallLockPath
 } from './skill-install-lock'
+import { readSkillInstallLockOwner } from './skill-install-lock-owner'
 
 const roots: string[] = []
 
@@ -23,6 +24,15 @@ async function readPublishedOwner(lockPath: string): Promise<Record<string, unkn
 }
 
 describe('skill install lock', () => {
+  it.each([0, -1])('rejects a non-positive owner pid (%s)', async (pid) => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skill-lock-test-'))
+    roots.push(root)
+    const ownerPath = join(root, 'owner.json')
+    await writeFile(ownerPath, JSON.stringify({ token: 'invalid-pid', pid, createdAt: Date.now() }))
+
+    await expect(readSkillInstallLockOwner(ownerPath)).resolves.toBeNull()
+  })
+
   it('reclaims a fresh legacy lock whose process was killed', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-skill-lock-test-'))
     roots.push(root)
@@ -73,6 +83,10 @@ describe('skill install lock', () => {
     const mayFinishWrite = new Promise<void>((resolve) => {
       finishWrite = resolve
     })
+    let contentionObserved!: () => void
+    const firstContention = new Promise<void>((resolve) => {
+      contentionObserved = resolve
+    })
     const firstAcquire = acquireSkillInstallLock({
       path: lockPath,
       writeOwner: async (handle, value) => {
@@ -80,21 +94,35 @@ describe('skill install lock', () => {
         await handle.sync()
         ownerWritten()
         await mayFinishWrite
+      },
+      publishLock: async (candidatePath, targetPath) => {
+        try {
+          await rename(candidatePath, targetPath)
+        } catch (error) {
+          contentionObserved()
+          throw error
+        }
       }
     })
 
     await ownerIsVisible
     await expect(readdir(lockPath)).rejects.toMatchObject({ code: 'ENOENT' })
     const secondRelease = await acquireSkillInstallLock({ path: lockPath, timeoutMs: 100 })
-    finishWrite()
     let firstPublished = false
-    void firstAcquire.then(() => {
-      firstPublished = true
-    })
-    await new Promise((resolve) => setTimeout(resolve, 10))
+    const observedFirstAcquire = firstAcquire.then(
+      () => {
+        firstPublished = true
+      },
+      () => {
+        firstPublished = true
+      }
+    )
+    finishWrite()
+    await firstContention
     expect(firstPublished).toBe(false)
     await secondRelease()
     const release = await firstAcquire
+    await observedFirstAcquire
     await expect(readPublishedOwner(lockPath)).resolves.toMatchObject({ pid: process.pid })
     await release()
   })
@@ -196,6 +224,32 @@ describe('skill install lock', () => {
       reclaimed: 3,
       truncated: false
     })
+  })
+
+  it('continues startup recovery past a non-empty released lock', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skill-lock-test-'))
+    roots.push(root)
+    const stateDirectory = join(root, 'state')
+    const lockDirectory = join(stateDirectory, 'locks')
+    const releasedToken = '11111111-1111-4111-8111-111111111111'
+    const deadToken = '22222222-2222-4222-8222-222222222222'
+    const releasedPath = join(lockDirectory, `${'0'.repeat(64)}.lock.${releasedToken}.released`)
+    const deadPath = join(lockDirectory, `${'f'.repeat(64)}.lock`)
+    await mkdir(releasedPath, { recursive: true })
+    await mkdir(deadPath)
+    await writeFile(join(releasedPath, 'unexpected-entry'), 'preserve')
+    await writeFile(
+      join(deadPath, `${deadToken}.owner`),
+      JSON.stringify({ token: deadToken, pid: 2_147_483_647, createdAt: Date.now() })
+    )
+
+    await expect(reclaimDeadSkillInstallLocks(stateDirectory)).resolves.toEqual({
+      scanned: 2,
+      reclaimed: 1,
+      truncated: false
+    })
+    await expect(readdir(releasedPath)).resolves.toEqual(['unexpected-entry'])
+    await expect(readdir(deadPath)).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
   it('frees the canonical lock before release cleanup finishes', async () => {

--- a/src/main/skills/skill-install-lock.test.ts
+++ b/src/main/skills/skill-install-lock.test.ts
@@ -1,4 +1,4 @@
-import { link, mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readdir, readFile, rename, rm, rmdir, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -14,8 +14,16 @@ afterEach(async () => {
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
 })
 
+async function readPublishedOwner(lockPath: string): Promise<Record<string, unknown>> {
+  const ownerName = (await readdir(lockPath)).find((name) => name.endsWith('.owner'))
+  if (!ownerName) {
+    throw new Error('missing-owner')
+  }
+  return JSON.parse(await readFile(join(lockPath, ownerName), 'utf8')) as Record<string, unknown>
+}
+
 describe('skill install lock', () => {
-  it('reclaims a fresh lock whose process was killed', async () => {
+  it('reclaims a fresh legacy lock whose process was killed', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-skill-lock-test-'))
     roots.push(root)
     const lockPath = skillInstallLockPath(join(root, 'state'), join(root, 'skills', 'alpha'))
@@ -26,12 +34,12 @@ describe('skill install lock', () => {
     )
 
     const release = await acquireSkillInstallLock({ path: lockPath, timeoutMs: 100 })
-    expect(JSON.parse(await readFile(lockPath, 'utf8')).token).not.toBe('dead-owner')
+    expect((await readPublishedOwner(lockPath)).token).not.toBe('dead-owner')
     await release()
-    await expect(readFile(lockPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(readdir(lockPath)).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
-  it('reclaims a same-process lock after its release deletion fails', async () => {
+  it('reclaims a lock after its release deletion fails', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-skill-lock-test-'))
     roots.push(root)
     const lockPath = skillInstallLockPath(join(root, 'state'), join(root, 'skills', 'alpha'))
@@ -44,12 +52,16 @@ describe('skill install lock', () => {
     })
 
     await expect(release()).rejects.toThrow('injected-delete-failure')
+    await expect(readdir(lockPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    expect(await readdir(dirname(lockPath))).toEqual(
+      expect.arrayContaining([expect.stringMatching(/\.lock\.[a-f0-9-]+\.released$/)])
+    )
     const secondRelease = await acquireSkillInstallLock({ path: lockPath, timeoutMs: 100 })
     await secondRelease()
-    await expect(readFile(lockPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(readdir(lockPath)).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
-  it('publishes only complete owner records when acquisitions overlap', async () => {
+  it('publishes a complete candidate atomically when acquisitions overlap', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-skill-lock-test-'))
     roots.push(root)
     const lockPath = skillInstallLockPath(join(root, 'state'), join(root, 'skills', 'alpha'))
@@ -63,7 +75,6 @@ describe('skill install lock', () => {
     })
     const firstAcquire = acquireSkillInstallLock({
       path: lockPath,
-      timeoutMs: 0,
       writeOwner: async (handle, value) => {
         await handle.writeFile(value, 'utf8')
         await handle.sync()
@@ -73,12 +84,19 @@ describe('skill install lock', () => {
     })
 
     await ownerIsVisible
+    await expect(readdir(lockPath)).rejects.toMatchObject({ code: 'ENOENT' })
     const secondRelease = await acquireSkillInstallLock({ path: lockPath, timeoutMs: 100 })
     finishWrite()
-    await expect(firstAcquire).rejects.toMatchObject({
-      data: { code: 'skill-install-busy' }
+    let firstPublished = false
+    void firstAcquire.then(() => {
+      firstPublished = true
     })
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    expect(firstPublished).toBe(false)
     await secondRelease()
+    const release = await firstAcquire
+    await expect(readPublishedOwner(lockPath)).resolves.toMatchObject({ pid: process.pid })
+    await release()
   })
 
   it('does not publish a lock when writing its owner fails', async () => {
@@ -96,54 +114,37 @@ describe('skill install lock', () => {
     ).rejects.toThrow('injected-write-failure')
 
     await expect(readdir(dirname(lockPath))).resolves.toEqual([])
-
     const release = await acquireSkillInstallLock({ path: lockPath, timeoutMs: 100 })
     await release()
   })
 
-  it('falls back when the state filesystem does not support hard links', async () => {
+  it('retries when the current owner releases after a contended rename', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-skill-lock-test-'))
     roots.push(root)
     const lockPath = skillInstallLockPath(join(root, 'state'), join(root, 'skills', 'alpha'))
-    const release = await acquireSkillInstallLock({
-      path: lockPath,
-      createLink: async () => {
-        const error = new Error('hard-links-unsupported') as NodeJS.ErrnoException
-        error.code = 'ENOTSUP'
-        throw error
-      }
-    })
+    const firstRelease = await acquireSkillInstallLock({ path: lockPath })
+    let attempts = 0
 
-    await expect(readFile(lockPath, 'utf8')).resolves.toContain(`"pid":${process.pid}`)
-    await release()
-    await expect(readFile(lockPath)).rejects.toMatchObject({ code: 'ENOENT' })
-  })
-
-  it('uses a fresh owner file for each contention retry', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'orca-skill-lock-test-'))
-    roots.push(root)
-    const lockPath = skillInstallLockPath(join(root, 'state'), join(root, 'skills', 'alpha'))
-    const ownerPaths: string[] = []
-    const release = await acquireSkillInstallLock({
+    const secondRelease = await acquireSkillInstallLock({
       path: lockPath,
-      timeoutMs: 100,
-      createLink: async (ownerPath, targetPath) => {
-        ownerPaths.push(ownerPath)
-        if (ownerPaths.length === 1) {
+      timeoutMs: 500,
+      publishLock: async (candidatePath, targetPath) => {
+        attempts += 1
+        if (attempts === 1) {
+          await firstRelease()
           const error = new Error('injected-contention') as NodeJS.ErrnoException
-          error.code = 'EEXIST'
+          error.code = 'ENOTEMPTY'
           throw error
         }
-        await link(ownerPath, targetPath)
+        await rename(candidatePath, targetPath)
       }
     })
 
-    expect(ownerPaths).toHaveLength(2)
-    expect(ownerPaths[0]).not.toBe(ownerPaths[1])
-    await release()
+    expect(attempts).toBe(2)
+    await secondRelease()
   })
 
-  it('reclaims abandoned atomic owner files at startup', async () => {
+  it('reclaims abandoned legacy owner files at startup', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-skill-lock-test-'))
     roots.push(root)
     const stateDirectory = join(root, 'state')
@@ -162,10 +163,46 @@ describe('skill install lock', () => {
     await expect(readFile(ownerPath)).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
-  it('keeps ownership active until release deletion finishes', async () => {
+  it('reclaims dead locks, abandoned candidates, and completed releases at startup', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-skill-lock-test-'))
     roots.push(root)
-    const lockPath = skillInstallLockPath(join(root, 'state'), join(root, 'skills', 'alpha'))
+    const stateDirectory = join(root, 'state')
+    const deadPath = skillInstallLockPath(stateDirectory, join(root, 'skills', 'alpha'))
+    const releasedLockPath = skillInstallLockPath(stateDirectory, join(root, 'skills', 'beta'))
+    const candidateLockPath = skillInstallLockPath(stateDirectory, join(root, 'skills', 'gamma'))
+    const deadToken = '11111111-1111-4111-8111-111111111111'
+    const releasedToken = '22222222-2222-4222-8222-222222222222'
+    const candidateToken = '33333333-3333-4333-8333-333333333333'
+    await mkdir(deadPath, { recursive: true })
+    const releasedPath = `${releasedLockPath}.${releasedToken}.released`
+    const candidatePath = `${candidateLockPath}.${candidateToken}.candidate`
+    await mkdir(releasedPath, { recursive: true })
+    await mkdir(candidatePath, { recursive: true })
+    await writeFile(
+      join(deadPath, `${deadToken}.owner`),
+      JSON.stringify({ token: deadToken, pid: 2_147_483_647, createdAt: Date.now() })
+    )
+    await writeFile(
+      join(releasedPath, `${releasedToken}.owner`),
+      JSON.stringify({ token: releasedToken, pid: process.pid, createdAt: Date.now() })
+    )
+    await writeFile(
+      join(candidatePath, `${candidateToken}.owner`),
+      JSON.stringify({ token: candidateToken, pid: 2_147_483_647, createdAt: Date.now() })
+    )
+
+    await expect(reclaimDeadSkillInstallLocks(stateDirectory)).resolves.toEqual({
+      scanned: 3,
+      reclaimed: 3,
+      truncated: false
+    })
+  })
+
+  it('frees the canonical lock before release cleanup finishes', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skill-lock-test-'))
+    roots.push(root)
+    const stateDirectory = join(root, 'state')
+    const lockPath = skillInstallLockPath(stateDirectory, join(root, 'skills', 'alpha'))
     let deletionStarted!: () => void
     const deletionIsPending = new Promise<void>((resolve) => {
       deletionStarted = resolve
@@ -179,20 +216,19 @@ describe('skill install lock', () => {
       removeLock: async (path) => {
         deletionStarted()
         await mayFinishDeletion
-        await rm(path, { force: true })
+        await rmdir(path)
       }
     })
     const releasing = release()
     expect(release()).toBe(releasing)
 
     await deletionIsPending
-    await expect(acquireSkillInstallLock({ path: lockPath, timeoutMs: 0 })).rejects.toMatchObject({
-      data: { code: 'skill-install-busy' }
+    await expect(reclaimDeadSkillInstallLocks(stateDirectory)).resolves.toMatchObject({
+      reclaimed: 1
     })
-    finishDeletion()
-    await releasing
-
     const secondRelease = await acquireSkillInstallLock({ path: lockPath, timeoutMs: 100 })
     await secondRelease()
+    finishDeletion()
+    await releasing
   })
 })

--- a/src/main/skills/skill-install-lock.test.ts
+++ b/src/main/skills/skill-install-lock.test.ts
@@ -26,4 +26,22 @@ describe('skill install lock', () => {
     await release()
     await expect(readFile(lockPath)).rejects.toMatchObject({ code: 'ENOENT' })
   })
+
+  it('reclaims a same-process lock after its release deletion fails', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skill-lock-test-'))
+    roots.push(root)
+    const lockPath = skillInstallLockPath(join(root, 'state'), join(root, 'skills', 'alpha'))
+    const release = await acquireSkillInstallLock({
+      path: lockPath,
+      timeoutMs: 100,
+      removeLock: async () => {
+        throw new Error('injected-delete-failure')
+      }
+    })
+
+    await expect(release()).rejects.toThrow('injected-delete-failure')
+    const secondRelease = await acquireSkillInstallLock({ path: lockPath, timeoutMs: 100 })
+    await secondRelease()
+    await expect(readFile(lockPath)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
 })

--- a/src/main/skills/skill-install-lock.test.ts
+++ b/src/main/skills/skill-install-lock.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { link, mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -95,7 +95,51 @@ describe('skill install lock', () => {
       })
     ).rejects.toThrow('injected-write-failure')
 
+    await expect(readdir(dirname(lockPath))).resolves.toEqual([])
+
     const release = await acquireSkillInstallLock({ path: lockPath, timeoutMs: 100 })
+    await release()
+  })
+
+  it('falls back when the state filesystem does not support hard links', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skill-lock-test-'))
+    roots.push(root)
+    const lockPath = skillInstallLockPath(join(root, 'state'), join(root, 'skills', 'alpha'))
+    const release = await acquireSkillInstallLock({
+      path: lockPath,
+      createLink: async () => {
+        const error = new Error('hard-links-unsupported') as NodeJS.ErrnoException
+        error.code = 'ENOTSUP'
+        throw error
+      }
+    })
+
+    await expect(readFile(lockPath, 'utf8')).resolves.toContain(`"pid":${process.pid}`)
+    await release()
+    await expect(readFile(lockPath)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('uses a fresh owner file for each contention retry', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skill-lock-test-'))
+    roots.push(root)
+    const lockPath = skillInstallLockPath(join(root, 'state'), join(root, 'skills', 'alpha'))
+    const ownerPaths: string[] = []
+    const release = await acquireSkillInstallLock({
+      path: lockPath,
+      timeoutMs: 100,
+      createLink: async (ownerPath, targetPath) => {
+        ownerPaths.push(ownerPath)
+        if (ownerPaths.length === 1) {
+          const error = new Error('injected-contention') as NodeJS.ErrnoException
+          error.code = 'EEXIST'
+          throw error
+        }
+        await link(ownerPath, targetPath)
+      }
+    })
+
+    expect(ownerPaths).toHaveLength(2)
+    expect(ownerPaths[0]).not.toBe(ownerPaths[1])
     await release()
   })
 

--- a/src/main/skills/skill-install-lock.test.ts
+++ b/src/main/skills/skill-install-lock.test.ts
@@ -2,7 +2,11 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
-import { acquireSkillInstallLock, skillInstallLockPath } from './skill-install-lock'
+import {
+  acquireSkillInstallLock,
+  reclaimDeadSkillInstallLocks,
+  skillInstallLockPath
+} from './skill-install-lock'
 
 const roots: string[] = []
 
@@ -43,5 +47,108 @@ describe('skill install lock', () => {
     const secondRelease = await acquireSkillInstallLock({ path: lockPath, timeoutMs: 100 })
     await secondRelease()
     await expect(readFile(lockPath)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('publishes only complete owner records when acquisitions overlap', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skill-lock-test-'))
+    roots.push(root)
+    const lockPath = skillInstallLockPath(join(root, 'state'), join(root, 'skills', 'alpha'))
+    let ownerWritten!: () => void
+    const ownerIsVisible = new Promise<void>((resolve) => {
+      ownerWritten = resolve
+    })
+    let finishWrite!: () => void
+    const mayFinishWrite = new Promise<void>((resolve) => {
+      finishWrite = resolve
+    })
+    const firstAcquire = acquireSkillInstallLock({
+      path: lockPath,
+      timeoutMs: 0,
+      writeOwner: async (handle, value) => {
+        await handle.writeFile(value, 'utf8')
+        await handle.sync()
+        ownerWritten()
+        await mayFinishWrite
+      }
+    })
+
+    await ownerIsVisible
+    const secondRelease = await acquireSkillInstallLock({ path: lockPath, timeoutMs: 100 })
+    finishWrite()
+    await expect(firstAcquire).rejects.toMatchObject({
+      data: { code: 'skill-install-busy' }
+    })
+    await secondRelease()
+  })
+
+  it('does not publish a lock when writing its owner fails', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skill-lock-test-'))
+    roots.push(root)
+    const lockPath = skillInstallLockPath(join(root, 'state'), join(root, 'skills', 'alpha'))
+
+    await expect(
+      acquireSkillInstallLock({
+        path: lockPath,
+        writeOwner: async () => {
+          throw new Error('injected-write-failure')
+        }
+      })
+    ).rejects.toThrow('injected-write-failure')
+
+    const release = await acquireSkillInstallLock({ path: lockPath, timeoutMs: 100 })
+    await release()
+  })
+
+  it('reclaims abandoned atomic owner files at startup', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skill-lock-test-'))
+    roots.push(root)
+    const stateDirectory = join(root, 'state')
+    const lockPath = skillInstallLockPath(stateDirectory, join(root, 'skills', 'alpha'))
+    const ownerPath = `${lockPath}.11111111-1111-4111-8111-111111111111.owner`
+    await mkdir(dirname(ownerPath), { recursive: true })
+    await writeFile(
+      ownerPath,
+      JSON.stringify({ token: 'abandoned-owner', pid: 2_147_483_647, createdAt: Date.now() })
+    )
+
+    await expect(reclaimDeadSkillInstallLocks(stateDirectory)).resolves.toMatchObject({
+      scanned: 1,
+      reclaimed: 1
+    })
+    await expect(readFile(ownerPath)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('keeps ownership active until release deletion finishes', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skill-lock-test-'))
+    roots.push(root)
+    const lockPath = skillInstallLockPath(join(root, 'state'), join(root, 'skills', 'alpha'))
+    let deletionStarted!: () => void
+    const deletionIsPending = new Promise<void>((resolve) => {
+      deletionStarted = resolve
+    })
+    let finishDeletion!: () => void
+    const mayFinishDeletion = new Promise<void>((resolve) => {
+      finishDeletion = resolve
+    })
+    const release = await acquireSkillInstallLock({
+      path: lockPath,
+      removeLock: async (path) => {
+        deletionStarted()
+        await mayFinishDeletion
+        await rm(path, { force: true })
+      }
+    })
+    const releasing = release()
+    expect(release()).toBe(releasing)
+
+    await deletionIsPending
+    await expect(acquireSkillInstallLock({ path: lockPath, timeoutMs: 0 })).rejects.toMatchObject({
+      data: { code: 'skill-install-busy' }
+    })
+    finishDeletion()
+    await releasing
+
+    const secondRelease = await acquireSkillInstallLock({ path: lockPath, timeoutMs: 100 })
+    await secondRelease()
   })
 })

--- a/src/main/skills/skill-install-lock.ts
+++ b/src/main/skills/skill-install-lock.ts
@@ -9,6 +9,7 @@ const LOCK_RETRY_MS = 50
 const LOCK_STALE_MS = 30 * 60 * 1000
 const MAX_STARTUP_LOCKS = 128
 const LOCK_NAME = /^[a-f0-9]{64}\.lock$/
+const activeLockTokens = new Set<string>()
 
 type SkillInstallLockOwner = {
   token: string
@@ -37,6 +38,10 @@ async function removeStaleLock(path: string): Promise<void> {
     owner = null
   }
   if (owner && Number.isInteger(owner.pid)) {
+    if (owner.pid === process.pid && !activeLockTokens.has(owner.token)) {
+      await rm(path, { force: true })
+      return
+    }
     if (processIsAlive(owner.pid)) {
       return
     }
@@ -85,6 +90,7 @@ export function skillInstallLockPath(stateDirectory: string, canonicalPath: stri
 export async function acquireSkillInstallLock(input: {
   path: string
   timeoutMs?: number
+  removeLock?: (path: string) => Promise<void>
 }): Promise<() => Promise<void>> {
   await mkdir(dirname(input.path), { recursive: true, mode: 0o700 })
   const deadline = Date.now() + (input.timeoutMs ?? 5_000)
@@ -102,7 +108,9 @@ export async function acquireSkillInstallLock(input: {
       } finally {
         await handle.close()
       }
+      activeLockTokens.add(owner.token)
       return async () => {
+        activeLockTokens.delete(owner.token)
         let current: SkillInstallLockOwner | null = null
         try {
           current = JSON.parse(await readFile(input.path, 'utf8')) as SkillInstallLockOwner
@@ -110,7 +118,7 @@ export async function acquireSkillInstallLock(input: {
           current = null
         }
         if (current?.token === owner.token) {
-          await rm(input.path, { force: true })
+          await (input.removeLock ?? ((path) => rm(path, { force: true })))(input.path)
         }
       }
     } catch (error) {

--- a/src/main/skills/skill-install-lock.ts
+++ b/src/main/skills/skill-install-lock.ts
@@ -1,64 +1,138 @@
 import { randomUUID } from 'node:crypto'
-import { link, mkdir, open, readdir, readFile, rm, stat, type FileHandle } from 'node:fs/promises'
+import {
+  mkdir,
+  open,
+  readdir,
+  rename,
+  rmdir,
+  stat,
+  unlink,
+  type FileHandle
+} from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { SKILL_INSTALL_BUSY_FAILURE } from '../../shared/skill-install-failure'
 import { SkillInstallOperationError } from './skill-install-operation-error'
+import {
+  readSkillInstallLockOwner,
+  skillInstallLockOwnerProcessIsAlive,
+  type SkillInstallLockOwner
+} from './skill-install-lock-owner'
+import {
+  cleanupReleasedSkillInstallLock,
+  reclaimReleasedSkillInstallLock
+} from './skill-install-lock-release'
 import { skillInstallStateKey } from './skill-install-provenance'
 
 const LOCK_RETRY_MS = 50
 const LOCK_STALE_MS = 30 * 60 * 1000
 const MAX_STARTUP_LOCKS = 128
 const LOCK_NAME = /^[a-f0-9]{64}\.lock$/
-const LOCK_OWNER_NAME = /^[a-f0-9]{64}\.lock\.[a-f0-9-]{36}\.owner$/
+const LEGACY_OWNER_NAME = /^[a-f0-9]{64}\.lock\.[a-f0-9-]{36}\.owner$/
+const CANDIDATE_LOCK_NAME = /^[a-f0-9]{64}\.lock\.[a-f0-9-]{36}\.candidate$/
+const RELEASED_LOCK_NAME = /^[a-f0-9]{64}\.lock\.[a-f0-9-]{36}\.released$/
+const OWNER_ENTRY_NAME = /^([a-f0-9-]{36})\.owner$/
+const RELEASE_ENTRY_NAME = /^([a-f0-9-]{36})\.released$/
 const activeLockTokens = new Set<string>()
-const UNSUPPORTED_HARD_LINK_ERRORS = new Set([
-  'EACCES',
-  'ENOSYS',
-  'ENOTSUP',
-  'EOPNOTSUPP',
-  'EPERM',
-  'EXDEV'
-])
 
-type SkillInstallLockOwner = {
-  token: string
-  pid: number
-  createdAt: number
+function ownerIsReclaimable(owner: SkillInstallLockOwner): boolean {
+  if (owner.pid === process.pid && !activeLockTokens.has(owner.token)) {
+    return true
+  }
+  return !skillInstallLockOwnerProcessIsAlive(owner)
 }
 
-function processIsAlive(pid: number): boolean {
+async function removeObservedLegacyFile(path: string): Promise<void> {
   try {
-    process.kill(pid, 0)
-    return true
+    await unlink(path)
   } catch (error) {
-    return (error as NodeJS.ErrnoException).code === 'EPERM'
+    const code = (error as NodeJS.ErrnoException).code
+    if (code === 'ENOENT') {
+      return
+    }
+    if (
+      (code === 'EISDIR' || code === 'EPERM') &&
+      (await stat(path).catch(() => null))?.isDirectory()
+    ) {
+      return
+    }
+    throw error
   }
+}
+
+async function removeStaleLegacyLock(path: string): Promise<void> {
+  const lockStat = await stat(path).catch(() => null)
+  if (!lockStat?.isFile()) {
+    return
+  }
+  const owner = await readSkillInstallLockOwner(path)
+  if (owner ? ownerIsReclaimable(owner) : Date.now() - lockStat.mtimeMs >= LOCK_STALE_MS) {
+    await removeObservedLegacyFile(path)
+  }
+}
+
+async function removeStaleLockDirectory(path: string, incompleteStaleMs = 0): Promise<void> {
+  const lockStat = await stat(path).catch(() => null)
+  if (!lockStat?.isDirectory()) {
+    return
+  }
+  const entries = await readdir(path, { withFileTypes: true }).catch(() => null)
+  if (!entries) {
+    return
+  }
+  const releasedTokens = new Set(
+    entries.flatMap((entry) => {
+      const match = entry.isFile() ? RELEASE_ENTRY_NAME.exec(entry.name) : null
+      return match?.[1] ? [match[1]] : []
+    })
+  )
+  let mayRemoveDirectory = releasedTokens.size > 0
+  for (const entry of entries) {
+    const match = entry.isFile() ? OWNER_ENTRY_NAME.exec(entry.name) : null
+    if (!match?.[1]) {
+      continue
+    }
+    const ownerPath = join(path, entry.name)
+    const owner = await readSkillInstallLockOwner(ownerPath)
+    const ownerStat = owner ? null : await stat(ownerPath).catch(() => null)
+    const reclaimable =
+      releasedTokens.has(match[1]) ||
+      (owner
+        ? ownerIsReclaimable(owner)
+        : Boolean(ownerStat && Date.now() - ownerStat.mtimeMs >= incompleteStaleMs))
+    if (!reclaimable) {
+      return
+    }
+    await unlink(ownerPath).catch((error) => {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error
+      }
+    })
+    mayRemoveDirectory = true
+  }
+  for (const token of releasedTokens) {
+    await unlink(join(path, `${token}.released`)).catch((error) => {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error
+      }
+    })
+  }
+  if (!mayRemoveDirectory && Date.now() - lockStat.mtimeMs < incompleteStaleMs) {
+    return
+  }
+  await rmdir(path).catch((error) => {
+    const code = (error as NodeJS.ErrnoException).code
+    if (code !== 'ENOENT' && code !== 'ENOTEMPTY' && code !== 'EEXIST') {
+      throw error
+    }
+  })
 }
 
 async function removeStaleLock(path: string): Promise<void> {
   const lockStat = await stat(path).catch(() => null)
-  if (!lockStat) {
-    return
-  }
-  let owner: SkillInstallLockOwner | null = null
-  try {
-    owner = JSON.parse(await readFile(path, 'utf8')) as SkillInstallLockOwner
-  } catch {
-    owner = null
-  }
-  if (owner && Number.isInteger(owner.pid)) {
-    if (owner.pid === process.pid && !activeLockTokens.has(owner.token)) {
-      await rm(path, { force: true })
-      return
-    }
-    if (processIsAlive(owner.pid)) {
-      return
-    }
-    await rm(path, { force: true })
-    return
-  }
-  if (Date.now() - lockStat.mtimeMs >= LOCK_STALE_MS) {
-    await rm(path, { force: true })
+  if (lockStat?.isDirectory()) {
+    await removeStaleLockDirectory(path)
+  } else if (lockStat?.isFile()) {
+    await removeStaleLegacyLock(path)
   }
 }
 
@@ -76,13 +150,23 @@ export async function reclaimDeadSkillInstallLocks(stateDirectory: string): Prom
   })
   const locks = entries
     .filter(
-      (entry) => entry.isFile() && (LOCK_NAME.test(entry.name) || LOCK_OWNER_NAME.test(entry.name))
+      (entry) =>
+        (LOCK_NAME.test(entry.name) && (entry.isFile() || entry.isDirectory())) ||
+        (entry.isFile() && LEGACY_OWNER_NAME.test(entry.name)) ||
+        (entry.isDirectory() && CANDIDATE_LOCK_NAME.test(entry.name)) ||
+        (entry.isDirectory() && RELEASED_LOCK_NAME.test(entry.name))
     )
     .sort((left, right) => left.name.localeCompare(right.name))
   let reclaimed = 0
   for (const lock of locks.slice(0, MAX_STARTUP_LOCKS)) {
     const path = join(directory, lock.name)
-    await removeStaleLock(path)
+    await (LEGACY_OWNER_NAME.test(lock.name)
+      ? removeStaleLegacyLock(path)
+      : CANDIDATE_LOCK_NAME.test(lock.name)
+        ? removeStaleLockDirectory(path, LOCK_STALE_MS)
+        : RELEASED_LOCK_NAME.test(lock.name)
+          ? reclaimReleasedSkillInstallLock(path)
+          : removeStaleLock(path))
     if (!(await stat(path).catch(() => null))) {
       reclaimed += 1
     }
@@ -98,48 +182,31 @@ export function skillInstallLockPath(stateDirectory: string, canonicalPath: stri
   return join(stateDirectory, 'locks', `${skillInstallStateKey(canonicalPath)}.lock`)
 }
 
-async function publishExclusiveLockRecord(path: string, value: string): Promise<boolean> {
-  let handle: FileHandle
+async function writeOwnerRecord(
+  path: string,
+  value: string,
+  writer?: (handle: FileHandle, value: string) => Promise<void>
+): Promise<void> {
+  const handle = await open(path, 'wx', 0o600)
   try {
-    handle = await open(path, 'wx', 0o600)
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
-      return false
-    }
-    throw error
+    await (
+      writer ??
+      (async (lockHandle, record) => {
+        await lockHandle.writeFile(record, 'utf8')
+        await lockHandle.sync()
+      })
+    )(handle, value)
+  } finally {
+    await handle.close()
   }
-  try {
-    try {
-      await handle.writeFile(value, 'utf8')
-      await handle.sync()
-    } finally {
-      await handle.close()
-    }
-  } catch (error) {
-    await rm(path, { force: true }).catch(() => undefined)
-    throw error
-  }
-  return true
 }
 
-async function publishSkillInstallLock(input: {
-  ownerPath: string
-  lockPath: string
-  ownerRecord: string
-  createLink: (ownerPath: string, lockPath: string) => Promise<void>
-}): Promise<boolean> {
+async function markReleased(path: string): Promise<void> {
+  const handle = await open(path, 'wx', 0o600)
   try {
-    await input.createLink(input.ownerPath, input.lockPath)
-    return true
-  } catch (error) {
-    const code = (error as NodeJS.ErrnoException).code
-    if (code === 'EEXIST') {
-      return false
-    }
-    if (!code || !UNSUPPORTED_HARD_LINK_ERRORS.has(code)) {
-      throw error
-    }
-    return publishExclusiveLockRecord(input.lockPath, input.ownerRecord)
+    await handle.sync()
+  } finally {
+    await handle.close()
   }
 }
 
@@ -147,8 +214,8 @@ export async function acquireSkillInstallLock(input: {
   path: string
   timeoutMs?: number
   removeLock?: (path: string) => Promise<void>
+  publishLock?: (candidatePath: string, lockPath: string) => Promise<void>
   writeOwner?: (handle: FileHandle, value: string) => Promise<void>
-  createLink?: (ownerPath: string, lockPath: string) => Promise<void>
 }): Promise<() => Promise<void>> {
   await mkdir(dirname(input.path), { recursive: true, mode: 0o700 })
   const deadline = Date.now() + (input.timeoutMs ?? 5_000)
@@ -158,66 +225,68 @@ export async function acquireSkillInstallLock(input: {
     createdAt: Date.now()
   }
   const ownerRecord = JSON.stringify(owner)
-  for (;;) {
-    const ownerPath = `${input.path}.${randomUUID()}.owner`
-    const handle = await open(ownerPath, 'wx', 0o600)
-    try {
+  const candidatePath = `${input.path}.${owner.token}.candidate`
+  const candidateOwnerPath = join(candidatePath, `${owner.token}.owner`)
+  const ownerPath = join(input.path, `${owner.token}.owner`)
+  const releasedPath = `${input.path}.${owner.token}.released`
+  await mkdir(candidatePath, { mode: 0o700 })
+  activeLockTokens.add(owner.token)
+  let published = false
+  try {
+    await writeOwnerRecord(candidateOwnerPath, ownerRecord, input.writeOwner)
+    for (;;) {
       try {
-        await (
-          input.writeOwner ??
-          (async (lockHandle, value) => {
-            await lockHandle.writeFile(value, 'utf8')
-            await lockHandle.sync()
-          })
-        )(handle, ownerRecord)
-      } finally {
-        await handle.close()
-      }
-    } catch (error) {
-      await rm(ownerPath, { force: true }).catch(() => undefined)
-      throw error
-    }
-    activeLockTokens.add(owner.token)
-    try {
-      const published = await publishSkillInstallLock({
-        ownerPath,
-        lockPath: input.path,
-        ownerRecord,
-        createLink: input.createLink ?? link
-      })
-      if (!published) {
-        await removeStaleLock(input.path)
+        await (input.publishLock ?? rename)(candidatePath, input.path)
+        published = true
+        break
+      } catch (error) {
+        if (!(await stat(candidatePath).catch(() => null))?.isDirectory()) {
+          throw error
+        }
+        if (await stat(input.path).catch(() => null)) {
+          await removeStaleLock(input.path)
+        }
+        if (!(await stat(input.path).catch(() => null))) {
+          if (Date.now() >= deadline) {
+            throw error
+          }
+          await new Promise<void>((resolve) => setTimeout(resolve, LOCK_RETRY_MS))
+          continue
+        }
         if (Date.now() >= deadline) {
           throw new SkillInstallOperationError(SKILL_INSTALL_BUSY_FAILURE)
         }
-        activeLockTokens.delete(owner.token)
         await new Promise<void>((resolve) => setTimeout(resolve, LOCK_RETRY_MS))
-        continue
       }
-      let releasePromise: Promise<void> | null = null
-      return () => {
-        releasePromise ??= (async () => {
-          try {
-            let current: SkillInstallLockOwner | null = null
-            try {
-              current = JSON.parse(await readFile(input.path, 'utf8')) as SkillInstallLockOwner
-            } catch {
-              current = null
-            }
-            if (current?.token === owner.token) {
-              await (input.removeLock ?? ((path) => rm(path, { force: true })))(input.path)
-            }
-          } finally {
-            activeLockTokens.delete(owner.token)
-          }
-        })()
-        return releasePromise
-      }
-    } catch (error) {
-      activeLockTokens.delete(owner.token)
-      throw error
-    } finally {
-      await rm(ownerPath, { force: true }).catch(() => undefined)
     }
+  } finally {
+    if (!published) {
+      activeLockTokens.delete(owner.token)
+      await unlink(candidateOwnerPath).catch(() => undefined)
+      await rmdir(candidatePath).catch(() => undefined)
+    }
+  }
+  let releasePromise: Promise<void> | null = null
+  return () => {
+    releasePromise ??= (async () => {
+      try {
+        if ((await readSkillInstallLockOwner(ownerPath))?.token !== owner.token) {
+          return
+        }
+        await markReleased(join(input.path, `${owner.token}.released`))
+        try {
+          await rename(input.path, releasedPath)
+        } catch (error) {
+          if ((await readSkillInstallLockOwner(ownerPath))?.token === owner.token) {
+            throw error
+          }
+          return
+        }
+        await cleanupReleasedSkillInstallLock(releasedPath, owner.token, input.removeLock)
+      } finally {
+        activeLockTokens.delete(owner.token)
+      }
+    })()
+    return releasePromise
   }
 }

--- a/src/main/skills/skill-install-lock.ts
+++ b/src/main/skills/skill-install-lock.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import { mkdir, open, readdir, readFile, rm, stat } from 'node:fs/promises'
+import { link, mkdir, open, readdir, readFile, rm, stat, type FileHandle } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { SKILL_INSTALL_BUSY_FAILURE } from '../../shared/skill-install-failure'
 import { SkillInstallOperationError } from './skill-install-operation-error'
@@ -9,6 +9,7 @@ const LOCK_RETRY_MS = 50
 const LOCK_STALE_MS = 30 * 60 * 1000
 const MAX_STARTUP_LOCKS = 128
 const LOCK_NAME = /^[a-f0-9]{64}\.lock$/
+const LOCK_OWNER_NAME = /^[a-f0-9]{64}\.lock\.[a-f0-9-]{36}\.owner$/
 const activeLockTokens = new Set<string>()
 
 type SkillInstallLockOwner = {
@@ -66,7 +67,9 @@ export async function reclaimDeadSkillInstallLocks(stateDirectory: string): Prom
     throw error
   })
   const locks = entries
-    .filter((entry) => entry.isFile() && LOCK_NAME.test(entry.name))
+    .filter(
+      (entry) => entry.isFile() && (LOCK_NAME.test(entry.name) || LOCK_OWNER_NAME.test(entry.name))
+    )
     .sort((left, right) => left.name.localeCompare(right.name))
   let reclaimed = 0
   for (const lock of locks.slice(0, MAX_STARTUP_LOCKS)) {
@@ -91,6 +94,7 @@ export async function acquireSkillInstallLock(input: {
   path: string
   timeoutMs?: number
   removeLock?: (path: string) => Promise<void>
+  writeOwner?: (handle: FileHandle, value: string) => Promise<void>
 }): Promise<() => Promise<void>> {
   await mkdir(dirname(input.path), { recursive: true, mode: 0o700 })
   const deadline = Date.now() + (input.timeoutMs ?? 5_000)
@@ -100,36 +104,64 @@ export async function acquireSkillInstallLock(input: {
     createdAt: Date.now()
   }
   for (;;) {
+    const ownerPath = `${input.path}.${owner.token}.owner`
+    const handle = await open(ownerPath, 'wx', 0o600)
     try {
-      const handle = await open(input.path, 'wx', 0o600)
       try {
-        await handle.writeFile(JSON.stringify(owner), 'utf8')
-        await handle.sync()
+        await (
+          input.writeOwner ??
+          (async (lockHandle, value) => {
+            await lockHandle.writeFile(value, 'utf8')
+            await lockHandle.sync()
+          })
+        )(handle, JSON.stringify(owner))
       } finally {
         await handle.close()
       }
-      activeLockTokens.add(owner.token)
-      return async () => {
+    } catch (error) {
+      await rm(ownerPath, { force: true }).catch(() => undefined)
+      throw error
+    }
+    activeLockTokens.add(owner.token)
+    try {
+      try {
+        await link(ownerPath, input.path)
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
+          throw error
+        }
+        await removeStaleLock(input.path)
+        if (Date.now() >= deadline) {
+          throw new SkillInstallOperationError(SKILL_INSTALL_BUSY_FAILURE)
+        }
         activeLockTokens.delete(owner.token)
-        let current: SkillInstallLockOwner | null = null
-        try {
-          current = JSON.parse(await readFile(input.path, 'utf8')) as SkillInstallLockOwner
-        } catch {
-          current = null
-        }
-        if (current?.token === owner.token) {
-          await (input.removeLock ?? ((path) => rm(path, { force: true })))(input.path)
-        }
+        await new Promise<void>((resolve) => setTimeout(resolve, LOCK_RETRY_MS))
+        continue
+      }
+      let releasePromise: Promise<void> | null = null
+      return () => {
+        releasePromise ??= (async () => {
+          try {
+            let current: SkillInstallLockOwner | null = null
+            try {
+              current = JSON.parse(await readFile(input.path, 'utf8')) as SkillInstallLockOwner
+            } catch {
+              current = null
+            }
+            if (current?.token === owner.token) {
+              await (input.removeLock ?? ((path) => rm(path, { force: true })))(input.path)
+            }
+          } finally {
+            activeLockTokens.delete(owner.token)
+          }
+        })()
+        return releasePromise
       }
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
-        throw error
-      }
-      await removeStaleLock(input.path)
-      if (Date.now() >= deadline) {
-        throw new SkillInstallOperationError(SKILL_INSTALL_BUSY_FAILURE)
-      }
-      await new Promise<void>((resolve) => setTimeout(resolve, LOCK_RETRY_MS))
+      activeLockTokens.delete(owner.token)
+      throw error
+    } finally {
+      await rm(ownerPath, { force: true }).catch(() => undefined)
     }
   }
 }

--- a/src/main/skills/skill-install-lock.ts
+++ b/src/main/skills/skill-install-lock.ts
@@ -11,6 +11,14 @@ const MAX_STARTUP_LOCKS = 128
 const LOCK_NAME = /^[a-f0-9]{64}\.lock$/
 const LOCK_OWNER_NAME = /^[a-f0-9]{64}\.lock\.[a-f0-9-]{36}\.owner$/
 const activeLockTokens = new Set<string>()
+const UNSUPPORTED_HARD_LINK_ERRORS = new Set([
+  'EACCES',
+  'ENOSYS',
+  'ENOTSUP',
+  'EOPNOTSUPP',
+  'EPERM',
+  'EXDEV'
+])
 
 type SkillInstallLockOwner = {
   token: string
@@ -90,11 +98,57 @@ export function skillInstallLockPath(stateDirectory: string, canonicalPath: stri
   return join(stateDirectory, 'locks', `${skillInstallStateKey(canonicalPath)}.lock`)
 }
 
+async function publishExclusiveLockRecord(path: string, value: string): Promise<boolean> {
+  let handle: FileHandle
+  try {
+    handle = await open(path, 'wx', 0o600)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+      return false
+    }
+    throw error
+  }
+  try {
+    try {
+      await handle.writeFile(value, 'utf8')
+      await handle.sync()
+    } finally {
+      await handle.close()
+    }
+  } catch (error) {
+    await rm(path, { force: true }).catch(() => undefined)
+    throw error
+  }
+  return true
+}
+
+async function publishSkillInstallLock(input: {
+  ownerPath: string
+  lockPath: string
+  ownerRecord: string
+  createLink: (ownerPath: string, lockPath: string) => Promise<void>
+}): Promise<boolean> {
+  try {
+    await input.createLink(input.ownerPath, input.lockPath)
+    return true
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    if (code === 'EEXIST') {
+      return false
+    }
+    if (!code || !UNSUPPORTED_HARD_LINK_ERRORS.has(code)) {
+      throw error
+    }
+    return publishExclusiveLockRecord(input.lockPath, input.ownerRecord)
+  }
+}
+
 export async function acquireSkillInstallLock(input: {
   path: string
   timeoutMs?: number
   removeLock?: (path: string) => Promise<void>
   writeOwner?: (handle: FileHandle, value: string) => Promise<void>
+  createLink?: (ownerPath: string, lockPath: string) => Promise<void>
 }): Promise<() => Promise<void>> {
   await mkdir(dirname(input.path), { recursive: true, mode: 0o700 })
   const deadline = Date.now() + (input.timeoutMs ?? 5_000)
@@ -103,8 +157,9 @@ export async function acquireSkillInstallLock(input: {
     pid: process.pid,
     createdAt: Date.now()
   }
+  const ownerRecord = JSON.stringify(owner)
   for (;;) {
-    const ownerPath = `${input.path}.${owner.token}.owner`
+    const ownerPath = `${input.path}.${randomUUID()}.owner`
     const handle = await open(ownerPath, 'wx', 0o600)
     try {
       try {
@@ -114,7 +169,7 @@ export async function acquireSkillInstallLock(input: {
             await lockHandle.writeFile(value, 'utf8')
             await lockHandle.sync()
           })
-        )(handle, JSON.stringify(owner))
+        )(handle, ownerRecord)
       } finally {
         await handle.close()
       }
@@ -124,12 +179,13 @@ export async function acquireSkillInstallLock(input: {
     }
     activeLockTokens.add(owner.token)
     try {
-      try {
-        await link(ownerPath, input.path)
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
-          throw error
-        }
+      const published = await publishSkillInstallLock({
+        ownerPath,
+        lockPath: input.path,
+        ownerRecord,
+        createLink: input.createLink ?? link
+      })
+      if (!published) {
         await removeStaleLock(input.path)
         if (Date.now() >= deadline) {
           throw new SkillInstallOperationError(SKILL_INSTALL_BUSY_FAILURE)

--- a/src/main/skills/skill-install-provenance.ts
+++ b/src/main/skills/skill-install-provenance.ts
@@ -25,10 +25,13 @@ export type SkillInstallReceiptV1 = {
   wslDistro?: string
 }
 
+function normalizedSkillInstallPath(canonicalPath: string): string {
+  const normalized = resolve(canonicalPath)
+  return process.platform === 'win32' ? normalized.toLowerCase() : normalized
+}
+
 export function skillInstallStateKey(canonicalPath: string): string {
-  const normalized =
-    process.platform === 'win32' ? resolve(canonicalPath).toLowerCase() : resolve(canonicalPath)
-  return createHash('sha256').update(normalized).digest('hex')
+  return createHash('sha256').update(normalizedSkillInstallPath(canonicalPath)).digest('hex')
 }
 
 export function skillInstallReceiptPath(stateDirectory: string, canonicalPath: string): string {
@@ -136,7 +139,8 @@ export async function readSkillInstallReceipt(
     const parsed: unknown = JSON.parse(
       await readFile(skillInstallReceiptPath(stateDirectory, canonicalPath), 'utf8')
     )
-    return isReceipt(parsed) && resolve(parsed.canonicalPath) === resolve(canonicalPath)
+    return isReceipt(parsed) &&
+      normalizedSkillInstallPath(parsed.canonicalPath) === normalizedSkillInstallPath(canonicalPath)
       ? parsed
       : null
   } catch {

--- a/src/main/skills/skill-operation-observability.ts
+++ b/src/main/skills/skill-operation-observability.ts
@@ -151,7 +151,11 @@ export function startSkillPhaseOperation(input: SkillPhaseStart): SkillPhaseOper
 }
 
 export function recordSkillCapabilityAbsence(input: {
-  capability: 'skills.install.v1' | 'skills.install.bundle.v1' | 'skills.upload.v1'
+  capability:
+    | 'skills.install.v1'
+    | 'skills.install.bundle.v1'
+    | 'skills.preview.bundle.v1'
+    | 'skills.upload.v1'
   destination: 'remote-runtime' | 'global-ssh'
 }): void {
   const span = startSpan('skill.capability', {

--- a/src/main/skills/skill-package-identity.test.ts
+++ b/src/main/skills/skill-package-identity.test.ts
@@ -78,6 +78,22 @@ describe('skill package identity', () => {
     expect(observed.files.find((file) => file.path === 'SKILL.md')?.executable).toBe(false)
   })
 
+  it('matches receipt executable paths case-insensitively on Windows', async () => {
+    const root = await temporarySkill()
+    await writeFile(join(root, 'SKILL.md'), 'skill\n')
+    await writeFile(join(root, 'run.sh'), '#!/bin/sh\necho ok\n')
+
+    const observed = await observeSkillPackage(
+      root,
+      undefined,
+      new Set(['Run.sh']),
+      undefined,
+      'win32'
+    )
+
+    expect(observed.files.find((file) => file.path === 'run.sh')?.executable).toBe(true)
+  })
+
   it('orders package files by locale-independent code units', async () => {
     const root = await temporarySkill()
     await writeFile(join(root, 'apple.md'), 'apple')

--- a/src/main/skills/skill-package-identity.test.ts
+++ b/src/main/skills/skill-package-identity.test.ts
@@ -67,6 +67,17 @@ describe('skill package identity', () => {
     expect(binary.classification).toBe('binary')
   })
 
+  it('infers shebang scripts as executable on Windows filesystems', async () => {
+    const root = await temporarySkill()
+    await writeFile(join(root, 'SKILL.md'), 'skill\n')
+    await writeFile(join(root, 'run.sh'), '#!/bin/sh\necho ok\n')
+
+    const observed = await observeSkillPackage(root, undefined, undefined, undefined, 'win32', true)
+
+    expect(observed.files.find((file) => file.path === 'run.sh')?.executable).toBe(true)
+    expect(observed.files.find((file) => file.path === 'SKILL.md')?.executable).toBe(false)
+  })
+
   it('orders package files by locale-independent code units', async () => {
     const root = await temporarySkill()
     await writeFile(join(root, 'apple.md'), 'apple')

--- a/src/main/skills/skill-package-identity.ts
+++ b/src/main/skills/skill-package-identity.ts
@@ -172,7 +172,9 @@ export async function observeSkillPackage(
   packageRoot: string,
   limits: SkillPackageObservationLimits = SKILL_PACKAGE_OBSERVATION_LIMITS,
   executablePaths?: ReadonlySet<string>,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  platform: NodeJS.Platform = process.platform,
+  inferShebangExecutables = false
 ): Promise<ObservedSkillPackage> {
   const files: ObservedSkillFile[] = []
   const treeEntries: SkillGitTreeFileEntry[] = []
@@ -260,7 +262,9 @@ export async function observeSkillPackage(
         totalBytes += bytes.length
         const executable = executablePaths
           ? executablePaths.has(manifestPath)
-          : (fileStat.mode & 0o111) !== 0
+          : platform === 'win32' && inferShebangExecutables
+            ? bytes.subarray(0, 2).equals(Buffer.from('#!'))
+            : (fileStat.mode & 0o111) !== 0
         files.push(describeObservedSkillFile(manifestPath, bytes, executable))
         treeEntries.push({ path: manifestPath, executable, blobSha: gitBlobSha(bytes) })
       } else {

--- a/src/main/skills/skill-package-identity.ts
+++ b/src/main/skills/skill-package-identity.ts
@@ -179,6 +179,10 @@ export async function observeSkillPackage(
   const files: ObservedSkillFile[] = []
   const treeEntries: SkillGitTreeFileEntry[] = []
   const caseFoldedPaths = new Map<string, string>()
+  const normalizedExecutablePaths =
+    platform === 'win32' && executablePaths
+      ? new Set([...executablePaths].map((path) => path.toLocaleLowerCase('en-US')))
+      : executablePaths
   let entryCount = 0
   let totalBytes = 0
 
@@ -260,8 +264,8 @@ export async function observeSkillPackage(
           signal
         )
         totalBytes += bytes.length
-        const executable = executablePaths
-          ? executablePaths.has(manifestPath)
+        const executable = normalizedExecutablePaths
+          ? normalizedExecutablePaths.has(platform === 'win32' ? folded : manifestPath)
           : platform === 'win32' && inferShebangExecutables
             ? bytes.subarray(0, 2).equals(Buffer.from('#!'))
             : (fileStat.mode & 0o111) !== 0

--- a/src/main/skills/skill-share-preparation-service.test.ts
+++ b/src/main/skills/skill-share-preparation-service.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { SkillCloudVersion } from '../../shared/skill-cloud-contract'
 import { SkillSharePreparationService } from './skill-share-preparation-service'
+import { writeSkillInstallReceipt } from './skill-install-provenance'
 
 const temporaryDirectories: string[] = []
 
@@ -50,6 +51,62 @@ afterEach(async () => {
 })
 
 describe('SkillSharePreparationService', () => {
+  it('preserves executable modes from a managed Windows install receipt', async () => {
+    const { root, source } = await createSource()
+    await writeFile(join(source, 'run.sh'), 'echo without shebang\n')
+    const stateDirectory = join(root, 'state')
+    await writeSkillInstallReceipt(stateDirectory, {
+      schemaVersion: 1,
+      packageId: 'package_1',
+      versionId: 'version_1',
+      packageDigest: 'a'.repeat(64),
+      archiveSha256: 'b'.repeat(64),
+      scope: 'global',
+      destinationIdentity: 'global:windows',
+      canonicalPath: source,
+      placements: [],
+      installedAt: '2026-08-16T12:00:00.000Z',
+      hostIdentity: 'windows',
+      fileModes: [
+        { path: 'SKILL.md', executable: false },
+        { path: 'run.sh', executable: true }
+      ]
+    })
+    const service = new SkillSharePreparationService(
+      join(root, 'preparations'),
+      { publishVersion: vi.fn(), createShare: vi.fn() },
+      { installStateDirectory: stateDirectory, platform: 'win32' }
+    )
+
+    const prepared = await service.prepare({ sourceDirectory: source })
+
+    expect(prepared.skills?.[0]?.executablePaths).toEqual(['run.sh'])
+  })
+
+  it('retries initialization after a transient failure', async () => {
+    const { root, source } = await createSource()
+    const preparationRoot = join(root, 'preparations')
+    const initializeRoot = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error('transient-init-failure'))
+      .mockImplementationOnce(async () => {
+        await mkdir(preparationRoot, { recursive: true })
+      })
+    const service = new SkillSharePreparationService(
+      preparationRoot,
+      { publishVersion: vi.fn(), createShare: vi.fn() },
+      { initializeRoot }
+    )
+
+    await expect(service.prepare({ sourceDirectory: source })).rejects.toThrow(
+      'transient-init-failure'
+    )
+    await expect(service.prepare({ sourceDirectory: source })).resolves.toMatchObject({
+      name: 'shared-skill'
+    })
+    expect(initializeRoot).toHaveBeenCalledTimes(2)
+  })
+
   it('removes abandoned preparations from a previous process before preparing', async () => {
     const { root, source } = await createSource()
     const preparationRoot = join(root, 'preparations')

--- a/src/main/skills/skill-share-preparation-service.test.ts
+++ b/src/main/skills/skill-share-preparation-service.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readdir, realpath, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -79,6 +79,45 @@ describe('SkillSharePreparationService', () => {
     )
 
     const prepared = await service.prepare({ sourceDirectory: source })
+
+    expect(prepared.skills?.[0]?.executablePaths).toEqual(['run.sh'])
+  })
+
+  it('finds Windows install receipts through a provider junction', async () => {
+    const { root, source } = await createSource()
+    await writeFile(join(source, 'run.sh'), 'echo without shebang\n')
+    const canonicalSource = await realpath(source)
+    const providerSource = join(root, 'provider-source')
+    await symlink(
+      canonicalSource,
+      providerSource,
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
+    const stateDirectory = join(root, 'state')
+    await writeSkillInstallReceipt(stateDirectory, {
+      schemaVersion: 1,
+      packageId: 'package_1',
+      versionId: 'version_1',
+      packageDigest: 'a'.repeat(64),
+      archiveSha256: 'b'.repeat(64),
+      scope: 'global',
+      destinationIdentity: 'global:windows',
+      canonicalPath: canonicalSource,
+      placements: [],
+      installedAt: '2026-08-16T12:00:00.000Z',
+      hostIdentity: 'windows',
+      fileModes: [
+        { path: 'SKILL.md', executable: false },
+        { path: 'run.sh', executable: true }
+      ]
+    })
+    const service = new SkillSharePreparationService(
+      join(root, 'preparations'),
+      { publishVersion: vi.fn(), createShare: vi.fn() },
+      { installStateDirectory: stateDirectory, platform: 'win32' }
+    )
+
+    const prepared = await service.prepare({ sourceDirectory: providerSource })
 
     expect(prepared.skills?.[0]?.executablePaths).toEqual(['run.sh'])
   })

--- a/src/main/skills/skill-share-preparation-service.ts
+++ b/src/main/skills/skill-share-preparation-service.ts
@@ -10,6 +10,7 @@ import type {
 import type { SkillCloudVersion } from '../../shared/skill-cloud-contract'
 import { createSkillBundleArchive, type CreatedSkillBundle } from './skill-bundle-creation'
 import type { SkillCloudService } from './skill-cloud-service'
+import { readSkillInstallReceipt } from './skill-install-provenance'
 
 const PREPARATION_TTL_MS = 30 * 60 * 1000
 const MAX_PREPARATIONS = 8
@@ -65,7 +66,12 @@ export class SkillSharePreparationService {
 
   constructor(
     private readonly root: string,
-    private readonly cloud: Pick<SkillCloudService, 'createShare' | 'publishVersion'>
+    private readonly cloud: Pick<SkillCloudService, 'createShare' | 'publishVersion'>,
+    private readonly options: {
+      initializeRoot?: () => Promise<void>
+      installStateDirectory?: string
+      platform?: NodeJS.Platform
+    } = {}
   ) {}
 
   async prepare(input: {
@@ -85,8 +91,30 @@ export class SkillSharePreparationService {
     const directory = join(this.root, preparationId)
     try {
       await mkdir(directory, { recursive: true, mode: 0o700 })
-      const sources =
+      const requestedSources =
         input.sources ?? (input.sourceDirectory ? [{ sourceDirectory: input.sourceDirectory }] : [])
+      const sources = await Promise.all(
+        requestedSources.map(async (source) => {
+          if (
+            (this.options.platform ?? process.platform) !== 'win32' ||
+            !this.options.installStateDirectory
+          ) {
+            return source
+          }
+          const receipt = await readSkillInstallReceipt(
+            this.options.installStateDirectory,
+            source.sourceDirectory
+          )
+          return receipt?.fileModes
+            ? {
+                ...source,
+                executablePaths: new Set(
+                  receipt.fileModes.filter((file) => file.executable).map((file) => file.path)
+                )
+              }
+            : source
+        })
+      )
       const created = await createSkillBundleArchive({
         sources,
         bundleName: input.bundleName ?? 'shared-skill',
@@ -198,10 +226,22 @@ export class SkillSharePreparationService {
   }
 
   private async initialize(): Promise<void> {
-    this.initialized ??= (async () => {
-      await rm(this.root, { recursive: true, force: true })
-      await mkdir(this.root, { recursive: true, mode: 0o700 })
-    })()
+    if (!this.initialized) {
+      const initialization = (async () => {
+        if (this.options.initializeRoot) {
+          await this.options.initializeRoot()
+        } else {
+          await rm(this.root, { recursive: true, force: true })
+          await mkdir(this.root, { recursive: true, mode: 0o700 })
+        }
+      })()
+      this.initialized = initialization
+      void initialization.catch(() => {
+        if (this.initialized === initialization) {
+          this.initialized = null
+        }
+      })
+    }
     await this.initialized
   }
 }

--- a/src/main/skills/skill-share-preparation-service.ts
+++ b/src/main/skills/skill-share-preparation-service.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import { mkdir, rm } from 'node:fs/promises'
+import { mkdir, realpath, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import type {
   SkillSharePreview,
@@ -101,10 +101,19 @@ export class SkillSharePreparationService {
           ) {
             return source
           }
-          const receipt = await readSkillInstallReceipt(
+          let receipt = await readSkillInstallReceipt(
             this.options.installStateDirectory,
             source.sourceDirectory
           )
+          if (!receipt) {
+            const physicalSource = await realpath(source.sourceDirectory).catch(() => null)
+            if (physicalSource) {
+              receipt = await readSkillInstallReceipt(
+                this.options.installStateDirectory,
+                physicalSource
+              )
+            }
+          }
           return receipt?.fileModes
             ? {
                 ...source,

--- a/src/main/skills/skill-ssh-relay-client.ts
+++ b/src/main/skills/skill-ssh-relay-client.ts
@@ -9,12 +9,16 @@ const DEVELOPMENT_DOWNLOAD_POLICY_FAILURES = new Set([
 ])
 
 export type SkillSshRelayClient = NonNullable<IPtyProvider['requestHostRpc']>
+export type SkillSshProviderSource = IPtyProvider | (() => IPtyProvider)
 
-export function requireSkillSshRelayClient(provider: IPtyProvider): SkillSshRelayClient {
-  if (!provider.requestHostRpc) {
-    throw new Error('skill-install-ssh-relay-unavailable')
+export function requireSkillSshRelayClient(source: SkillSshProviderSource): SkillSshRelayClient {
+  return (method, params, options) => {
+    const provider = typeof source === 'function' ? source() : source
+    if (!provider.requestHostRpc) {
+      throw new Error('skill-install-ssh-relay-unavailable')
+    }
+    return provider.requestHostRpc(method, params, options)
   }
-  return provider.requestHostRpc
 }
 
 export function shouldUseSkillSshClientTransfer(error: unknown, requireHttps: boolean): boolean {

--- a/src/main/skills/skill-ssh-relay-client.ts
+++ b/src/main/skills/skill-ssh-relay-client.ts
@@ -12,13 +12,11 @@ export type SkillSshRelayClient = NonNullable<IPtyProvider['requestHostRpc']>
 export type SkillSshProviderSource = IPtyProvider | (() => IPtyProvider)
 
 export function requireSkillSshRelayClient(source: SkillSshProviderSource): SkillSshRelayClient {
-  return (method, params, options) => {
-    const provider = typeof source === 'function' ? source() : source
-    if (!provider.requestHostRpc) {
-      throw new Error('skill-install-ssh-relay-unavailable')
-    }
-    return provider.requestHostRpc(method, params, options)
+  const provider = typeof source === 'function' ? source() : source
+  if (!provider.requestHostRpc) {
+    throw new Error('skill-install-ssh-relay-unavailable')
   }
+  return provider.requestHostRpc.bind(provider)
 }
 
 export function shouldUseSkillSshClientTransfer(error: unknown, requireHttps: boolean): boolean {

--- a/src/main/skills/skill-ssh-relay-service.test.ts
+++ b/src/main/skills/skill-ssh-relay-service.test.ts
@@ -49,6 +49,30 @@ function request(bytes: Buffer) {
 }
 
 describe('installSkillOnSshHost', () => {
+  it('does not reuse newer capabilities after reconnecting to an older host', async () => {
+    const secondRpc = vi.fn(async (_method: string) => ({ capabilities: [] }))
+    const secondProvider = { requestHostRpc: secondRpc } as unknown as IPtyProvider
+    let currentProvider: IPtyProvider
+    const firstRpc = vi.fn(async (method: string) => {
+      if (method === 'relay.status') {
+        return { capabilities: ['skills.install.v1'] }
+      }
+      currentProvider = secondProvider
+      throw new Error('disconnected-provider-generation')
+    })
+    currentProvider = { requestHostRpc: firstRpc } as unknown as IPtyProvider
+
+    await expect(
+      installSkillOnSshHost({
+        provider: () => currentProvider,
+        userDataPath: await userDataPath(),
+        request: request(Buffer.from('archive')),
+        requireHttps: true
+      })
+    ).rejects.toThrow('skill-install-ssh-update-required')
+    expect(secondRpc.mock.calls.map(([method]) => method)).toEqual(['relay.status'])
+  })
+
   it('requires a relay update before sending an explicit provider choice', async () => {
     const requestHostRpc = vi.fn(async () => ({ capabilities: ['skills.install.v1'] }))
     await expect(
@@ -132,6 +156,7 @@ describe('installSkillOnSshHost', () => {
     expect(requestHostRpc.mock.calls.map(([method]) => method)).toEqual([
       'relay.status',
       'skills.install',
+      'relay.status',
       'skills.beginUpload',
       'skills.beginUpload',
       'skills.uploadChunk',

--- a/src/main/skills/skill-ssh-relay-service.ts
+++ b/src/main/skills/skill-ssh-relay-service.ts
@@ -23,7 +23,6 @@ import {
   SKILL_SSH_RELAY_REMOVE_METHOD,
   type SkillSshWorkspaceAuthority
 } from '../../shared/skill-ssh-relay-contract'
-import type { IPtyProvider } from '../providers/pty-provider-contract'
 import { recordSkillCapabilityAbsence } from './skill-operation-observability'
 import { retrySkillTransferRpc } from './skill-transfer-rpc-retry'
 import { transferSkillPackageToSshHost } from './skill-ssh-package-transfer'
@@ -34,15 +33,18 @@ import {
   shouldUseSkillSshClientTransfer,
   skillSshRelayCapabilities
 } from './skill-ssh-relay-client'
+import type { SkillSshProviderSource } from './skill-ssh-relay-client'
 
-export async function supportsSkillManagementOnSsh(provider: IPtyProvider): Promise<boolean> {
+export async function supportsSkillManagementOnSsh(
+  provider: SkillSshProviderSource
+): Promise<boolean> {
   return (await skillSshRelayCapabilities(requireSkillSshRelayClient(provider))).includes(
     SKILL_MANAGEMENT_CAPABILITY
   )
 }
 
 export async function installSkillOnSshHost(input: {
-  provider: IPtyProvider
+  provider: SkillSshProviderSource
   userDataPath: string
   request: SkillInstallRequest
   workspace?: SkillSshWorkspaceAuthority
@@ -118,7 +120,7 @@ export async function installSkillOnSshHost(input: {
 }
 
 export async function previewSkillInstallOnSshHost(input: {
-  provider: IPtyProvider
+  provider: SkillSshProviderSource
   request: SkillInstallPreviewRequest
   workspace?: SkillSshWorkspaceAuthority
 }): Promise<SkillInstallPreview> {
@@ -136,7 +138,7 @@ export async function previewSkillInstallOnSshHost(input: {
 }
 
 export async function removeSkillInstallOnSshHost(input: {
-  provider: IPtyProvider
+  provider: SkillSshProviderSource
   request: SkillRemoveRequest
   workspace?: SkillSshWorkspaceAuthority
 }): Promise<SkillInstallResult> {
@@ -154,7 +156,7 @@ export async function removeSkillInstallOnSshHost(input: {
 }
 
 export async function listSkillInstallsOnSshHost(input: {
-  provider: IPtyProvider
+  provider: SkillSshProviderSource
   connectionId: string
   workspaces: SkillSshWorkspaceAuthority[]
 }): Promise<ManagedSkillInstall[]> {

--- a/src/main/skills/skill-ssh-relay-service.ts
+++ b/src/main/skills/skill-ssh-relay-service.ts
@@ -35,6 +35,11 @@ import {
 } from './skill-ssh-relay-client'
 import type { SkillSshProviderSource } from './skill-ssh-relay-client'
 
+const NON_RETRYABLE_SKILL_TRANSFER_ERRORS = new Set([
+  'skill-install-ssh-update-required',
+  'skill-install-ssh-download-unavailable'
+])
+
 export async function supportsSkillManagementOnSsh(
   provider: SkillSshProviderSource
 ): Promise<boolean> {
@@ -52,30 +57,36 @@ export async function installSkillOnSshHost(input: {
   signal?: AbortSignal
   fetcher?: typeof fetch
 }): Promise<SkillInstallResult> {
-  const client = requireSkillSshRelayClient(input.provider)
-  const supported = await skillSshRelayCapabilities(client)
   const request = input.request
-  if (request.providers !== undefined && !supported.includes(SKILL_INSTALL_PROVIDERS_CAPABILITY)) {
-    throw new Error('skill-install-ssh-update-required')
-  }
-  if (!supported.includes(SKILL_INSTALL_CAPABILITY)) {
-    recordSkillCapabilityAbsence({
-      capability: SKILL_INSTALL_CAPABILITY,
-      destination: 'global-ssh'
-    })
-    throw new Error('skill-install-ssh-update-required')
-  }
   try {
     return SkillInstallResultSchema.parse(
       await retrySkillTransferRpc({
         signal: input.signal,
-        retryable: retryableSkillSshTransportError,
-        call: () =>
-          client(
+        retryable: (error) =>
+          (error as Error)?.message !== 'skill-install-ssh-update-required' &&
+          retryableSkillSshTransportError(error),
+        call: async () => {
+          const client = requireSkillSshRelayClient(input.provider)
+          const supported = await skillSshRelayCapabilities(client)
+          if (
+            request.providers !== undefined &&
+            !supported.includes(SKILL_INSTALL_PROVIDERS_CAPABILITY)
+          ) {
+            throw new Error('skill-install-ssh-update-required')
+          }
+          if (!supported.includes(SKILL_INSTALL_CAPABILITY)) {
+            recordSkillCapabilityAbsence({
+              capability: SKILL_INSTALL_CAPABILITY,
+              destination: 'global-ssh'
+            })
+            throw new Error('skill-install-ssh-update-required')
+          }
+          return client(
             SKILL_SSH_RELAY_INSTALL_METHOD,
-            { request: request, workspace: input.workspace },
+            { request, workspace: input.workspace },
             { timeoutMs: SKILL_SSH_REQUEST_TIMEOUT_MS, signal: input.signal }
           )
+        }
       })
     )
   } catch (error) {
@@ -86,17 +97,27 @@ export async function installSkillOnSshHost(input: {
       throw error
     }
   }
-  if (!supported.includes(SKILL_UPLOAD_CAPABILITY)) {
-    recordSkillCapabilityAbsence({
-      capability: SKILL_UPLOAD_CAPABILITY,
-      destination: 'global-ssh'
-    })
-    throw new Error('skill-install-ssh-download-unavailable')
-  }
   return retrySkillTransferRpc({
     signal: input.signal,
-    retryable: retryableSkillSshTransportError,
+    retryable: (error) =>
+      !NON_RETRYABLE_SKILL_TRANSFER_ERRORS.has((error as Error)?.message) &&
+      retryableSkillSshTransportError(error),
     call: async () => {
+      const client = requireSkillSshRelayClient(input.provider)
+      const supported = await skillSshRelayCapabilities(client)
+      if (
+        !supported.includes(SKILL_INSTALL_CAPABILITY) ||
+        (request.providers !== undefined && !supported.includes(SKILL_INSTALL_PROVIDERS_CAPABILITY))
+      ) {
+        throw new Error('skill-install-ssh-update-required')
+      }
+      if (!supported.includes(SKILL_UPLOAD_CAPABILITY)) {
+        recordSkillCapabilityAbsence({
+          capability: SKILL_UPLOAD_CAPABILITY,
+          destination: 'global-ssh'
+        })
+        throw new Error('skill-install-ssh-download-unavailable')
+      }
       const uploadId = await transferSkillPackageToSshHost(client, input)
       try {
         return SkillInstallResultSchema.parse(

--- a/src/main/skills/skill-upload-session-service.test.ts
+++ b/src/main/skills/skill-upload-session-service.test.ts
@@ -22,6 +22,24 @@ function identity(bytes: Buffer) {
 }
 
 describe('SkillUploadSessionService', () => {
+  it('retries initialization after a transient failure', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skill-upload-session-'))
+    roots.push(root)
+    const uploads = join(root, 'uploads')
+    const initializeRoot = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error('transient-init-failure'))
+      .mockImplementationOnce(async () => {
+        await mkdir(uploads, { recursive: true })
+      })
+    const service = new SkillUploadSessionService(uploads, { initializeRoot })
+    const request = { package: identity(Buffer.from('new package')) }
+
+    await expect(service.begin(request)).rejects.toThrow('transient-init-failure')
+    await expect(service.begin(request)).resolves.toMatchObject({ acknowledgedOffset: 0 })
+    expect(initializeRoot).toHaveBeenCalledTimes(2)
+  })
+
   it('removes abandoned staging bytes when a runtime starts a fresh service', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-skill-upload-session-'))
     roots.push(root)

--- a/src/main/skills/skill-upload-session-service.ts
+++ b/src/main/skills/skill-upload-session-service.ts
@@ -32,7 +32,7 @@ export class SkillUploadSessionService {
 
   constructor(
     private readonly root: string,
-    options: { idleMs?: number } = {}
+    private readonly options: { idleMs?: number; initializeRoot?: () => Promise<void> } = {}
   ) {
     this.idleMs = options.idleMs ?? SESSION_IDLE_MS
   }
@@ -220,11 +220,23 @@ export class SkillUploadSessionService {
   }
 
   private async initialize(): Promise<void> {
-    this.initialized ??= (async () => {
-      await rm(this.root, { recursive: true, force: true })
-      await mkdir(this.root, { recursive: true, mode: 0o700 })
-    })()
-    return this.initialized
+    if (!this.initialized) {
+      const initialization = (async () => {
+        if (this.options.initializeRoot) {
+          await this.options.initializeRoot()
+        } else {
+          await rm(this.root, { recursive: true, force: true })
+          await mkdir(this.root, { recursive: true, mode: 0o700 })
+        }
+      })()
+      this.initialized = initialization
+      void initialization.catch(() => {
+        if (this.initialized === initialization) {
+          this.initialized = null
+        }
+      })
+    }
+    await this.initialized
   }
 
   private async prune(): Promise<void> {

--- a/src/relay/skill-install-handler.test.ts
+++ b/src/relay/skill-install-handler.test.ts
@@ -12,6 +12,7 @@ import {
   SKILL_SSH_RELAY_INSTALL_BUNDLE_METHOD,
   SKILL_SSH_RELAY_INSTALL_METHOD,
   SKILL_SSH_RELAY_LIST_METHOD,
+  SKILL_SSH_RELAY_PREVIEW_BUNDLE_METHOD,
   SKILL_SSH_RELAY_UPLOAD_CHUNK_METHOD
 } from '../shared/skill-ssh-relay-contract'
 import {
@@ -37,7 +38,8 @@ async function fixture(
     home: string
     source: string
     state: string
-  }) => Promise<void>
+  }) => Promise<void>,
+  options: { detectProviders?: () => Promise<readonly string[]>; recovery?: Promise<unknown> } = {}
 ) {
   const root = await mkdtemp(join(tmpdir(), 'orca-relay-skill-test-'))
   roots.push(root)
@@ -64,7 +66,8 @@ async function fixture(
   new SkillInstallHandler(dispatcher, {
     homeDirectory: home,
     stateDirectory: state,
-    detectProviders: async () => []
+    detectProviders: options.detectProviders ?? (async () => []),
+    recovery: options.recovery
   })
   const call = (method: string, params: Record<string, unknown>) =>
     handlers.get(method)!(params, {
@@ -115,10 +118,49 @@ describe('SkillInstallHandler', () => {
       'skills.install.v1',
       'skills.install-providers.v1',
       'skills.install.bundle.v1',
+      'skills.preview.bundle.v1',
       'skills.install-progress.v1',
       'skills.upload.v1',
       'skills.manage.v1'
     ])
+  })
+
+  it('previews a bundle with one provider detection pass', async () => {
+    const detectProviders = vi.fn(async () => [])
+    const { call } = await fixture(undefined, { detectProviders })
+    const selectedSkills = Array.from({ length: 30 }, (_, index) => ({
+      id: `skill-${index}`,
+      name: `skill-${index}`,
+      digest: String(index).padStart(64, '0')
+    }))
+
+    const result = (await call(SKILL_SSH_RELAY_PREVIEW_BUNDLE_METHOD, {
+      request: {
+        package: {
+          packageId: 'package_1',
+          versionId: 'version_1',
+          bundleDigest: 'a'.repeat(64),
+          archiveSha256: 'b'.repeat(64),
+          compressedBytes: 100
+        },
+        selectedSkills,
+        destination: { scope: 'global', executionTarget: { kind: 'host' } }
+      }
+    })) as { skills: unknown[] }
+
+    expect(result.skills).toHaveLength(30)
+    expect(detectProviders).toHaveBeenCalledOnce()
+  })
+
+  it('continues after transient startup recovery failure', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const recovery = Promise.reject(new Error('transient-recovery-failure'))
+    void recovery.catch(() => undefined)
+    const { call } = await fixture(undefined, {
+      recovery
+    })
+
+    await expect(call(SKILL_SSH_RELAY_LIST_METHOD, { workspaces: [] })).resolves.toEqual([])
   })
 
   it('recovers a committed install before the first managed-install listing', async () => {

--- a/src/relay/skill-install-handler.ts
+++ b/src/relay/skill-install-handler.ts
@@ -2,6 +2,7 @@ import { homedir } from 'node:os'
 import { join } from 'node:path'
 import {
   SKILL_BUNDLE_INSTALL_CAPABILITY,
+  SKILL_BUNDLE_PREVIEW_CAPABILITY,
   SKILL_INSTALL_CAPABILITY,
   SKILL_INSTALL_PROVIDERS_CAPABILITY,
   SKILL_INSTALL_PROGRESS_CAPABILITY,
@@ -19,6 +20,7 @@ import {
   SKILL_SSH_RELAY_GET_INSTALL_PROGRESS_METHOD,
   SKILL_SSH_RELAY_LIST_METHOD,
   SKILL_SSH_RELAY_PREVIEW_METHOD,
+  SKILL_SSH_RELAY_PREVIEW_BUNDLE_METHOD,
   SKILL_SSH_RELAY_REMOVE_METHOD,
   SKILL_SSH_RELAY_UPLOAD_CHUNK_METHOD,
   SkillSshInstallBundleParamsSchema,
@@ -26,6 +28,7 @@ import {
   SkillSshInstallParamsSchema,
   SkillSshListParamsSchema,
   SkillSshPreviewParamsSchema,
+  SkillSshPreviewBundleParamsSchema,
   SkillSshRemoveParamsSchema,
   type SkillSshWorkspaceAuthority
 } from '../shared/skill-ssh-relay-contract'
@@ -43,6 +46,7 @@ import type { RelayDispatcher } from './dispatcher'
 import { isCommandOnPathForRelay } from './preflight-handler'
 import type { SkillInstallDestinationAuthority } from '../main/skills/skill-install-destinations'
 import {
+  previewSharedSkillBundleInstall,
   previewSharedSkillInstall,
   removeSharedSkillInstall
 } from '../main/skills/skill-install-management-service'
@@ -63,6 +67,7 @@ export const SKILL_RELAY_CAPABILITIES = [
   SKILL_INSTALL_CAPABILITY,
   SKILL_INSTALL_PROVIDERS_CAPABILITY,
   SKILL_BUNDLE_INSTALL_CAPABILITY,
+  SKILL_BUNDLE_PREVIEW_CAPABILITY,
   SKILL_INSTALL_PROGRESS_CAPABILITY,
   SKILL_UPLOAD_CAPABILITY,
   SKILL_MANAGEMENT_CAPABILITY
@@ -82,6 +87,7 @@ export class SkillInstallHandler {
       homeDirectory?: string
       stateDirectory?: string
       detectProviders?: () => Promise<readonly string[]>
+      recovery?: Promise<unknown>
     } = {}
   ) {
     this.homeDirectory = options.homeDirectory ?? homedir()
@@ -90,7 +96,12 @@ export class SkillInstallHandler {
       join(this.stateDirectory, 'skill-installs', 'remote-uploads')
     )
     this.detectProviders = options.detectProviders ?? detectRelaySkillProviders
-    this.recovery = recoverPendingSkillTransactions(join(this.stateDirectory, 'skill-installs'))
+    this.recovery = (
+      options.recovery ??
+      recoverPendingSkillTransactions(join(this.stateDirectory, 'skill-installs'))
+    ).catch((error) => {
+      console.warn('[skills] relay startup transaction recovery failed:', error)
+    })
     this.registerHandlers()
   }
 
@@ -138,6 +149,17 @@ export class SkillInstallHandler {
       const input = SkillSshPreviewParamsSchema.parse(params)
       return this.executeSkillOperation(() =>
         previewSharedSkillInstall(input.request, {
+          authority: this.authority(input.workspace),
+          stateDirectory: this.stateDirectory,
+          detectProviders: this.detectProviders,
+          resolveProviderRootOverrides: () => resolveEnvironmentSkillProviderRoots()
+        })
+      )
+    })
+    this.dispatcher.onRequest(SKILL_SSH_RELAY_PREVIEW_BUNDLE_METHOD, async (params) => {
+      const input = SkillSshPreviewBundleParamsSchema.parse(params)
+      return this.executeSkillOperation(() =>
+        previewSharedSkillBundleInstall(input.request, {
           authority: this.authority(input.workspace),
           stateDirectory: this.stateDirectory,
           detectProviders: this.detectProviders,

--- a/src/renderer/src/components/skills/SkillBundleInstallFlow.tsx
+++ b/src/renderer/src/components/skills/SkillBundleInstallFlow.tsx
@@ -23,6 +23,7 @@ import { useSkillInstallProgress } from './skill-install-progress-state'
 import { translate } from '@/i18n/i18n'
 import { checklistItemsFromVersion } from './skill-package-checklist-items'
 import { summarizeSkillInstallRisk } from './skill-package-install-risk'
+import { retryableSkillIds } from './skill-bundle-retry-selection'
 
 type BundleVersion = SkillCloudVersion & {
   manifest: Extract<SkillCloudVersion['manifest'], { skills: unknown }>
@@ -224,11 +225,7 @@ export function SkillBundleInstallFlow(props: {
     }
   }
 
-  const retryIds = new Set(
-    result?.skills
-      .filter((skill) => skill.status === 'failed' || skill.status === 'cancelled')
-      .map((skill) => skill.skillId) ?? []
-  )
+  const retryIds = retryableSkillIds(result)
 
   return (
     <>

--- a/src/renderer/src/components/skills/SkillBundleInstallOutcome.tsx
+++ b/src/renderer/src/components/skills/SkillBundleInstallOutcome.tsx
@@ -1,6 +1,7 @@
 import { AlertTriangle, Check } from 'lucide-react'
 import type { SkillBundleInstallResult } from '../../../../shared/skill-bundle-install-contract'
 import { translate } from '@/i18n/i18n'
+import { skillBundleSkillNeedsRetry } from './skill-bundle-retry-selection'
 
 const RESULT_GROUPS = [
   'installed',
@@ -70,8 +71,27 @@ export function SkillBundleInstallOutcome({
         </div>
       </div>
       <div className="space-y-2">
+        {result.skills.some(skillBundleSkillNeedsRetry) ? (
+          <section className="space-y-1">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.05em] text-muted-foreground">
+              {translate(
+                'auto.components.skills.SkillBundleInstallOutcome.01c5a12e10',
+                'Needs retry'
+              )}{' '}
+              · {result.skills.filter(skillBundleSkillNeedsRetry).length}
+            </p>
+            {result.skills.filter(skillBundleSkillNeedsRetry).map((skill) => (
+              <p key={skill.skillId} className="text-xs">
+                {skill.name}
+                {skill.errorCategory ? ` · ${skill.errorCategory}` : ''}
+              </p>
+            ))}
+          </section>
+        ) : null}
         {RESULT_GROUPS.map((status) => {
-          const skills = result.skills.filter((skill) => skill.status === status)
+          const skills = result.skills.filter(
+            (skill) => skill.status === status && !skillBundleSkillNeedsRetry(skill)
+          )
           return skills.length ? (
             <section key={status} className="space-y-1">
               <p className="text-[11px] font-semibold uppercase tracking-[0.05em] text-muted-foreground">

--- a/src/renderer/src/components/skills/SkillBundleInstallOutcome.tsx
+++ b/src/renderer/src/components/skills/SkillBundleInstallOutcome.tsx
@@ -3,14 +3,7 @@ import type { SkillBundleInstallResult } from '../../../../shared/skill-bundle-i
 import { translate } from '@/i18n/i18n'
 import { skillBundleSkillNeedsRetry } from './skill-bundle-retry-selection'
 
-const RESULT_GROUPS = [
-  'installed',
-  'updated',
-  'unchanged',
-  'kept-local',
-  'failed',
-  'cancelled'
-] as const
+const RESULT_GROUPS = ['installed', 'updated', 'unchanged', 'kept-local'] as const
 
 function resultGroupLabel(status: (typeof RESULT_GROUPS)[number]): string {
   const labels = {
@@ -26,9 +19,7 @@ function resultGroupLabel(status: (typeof RESULT_GROUPS)[number]): string {
     'kept-local': translate(
       'auto.components.skills.SkillBundleInstallOutcome.01c5a12e04',
       'Kept local'
-    ),
-    failed: translate('auto.components.skills.SkillBundleInstallOutcome.01c5a12e05', 'Failed'),
-    cancelled: translate('auto.components.skills.SkillBundleInstallOutcome.01c5a12e06', 'Cancelled')
+    )
   }
   return labels[status]
 }
@@ -39,6 +30,7 @@ export function SkillBundleInstallOutcome({
   result: SkillBundleInstallResult
 }): React.JSX.Element {
   const incomplete = result.status !== 'complete'
+  const retrySkills = result.skills.filter(skillBundleSkillNeedsRetry)
   return (
     <div className="space-y-3">
       <div
@@ -71,16 +63,16 @@ export function SkillBundleInstallOutcome({
         </div>
       </div>
       <div className="space-y-2">
-        {result.skills.some(skillBundleSkillNeedsRetry) ? (
+        {retrySkills.length ? (
           <section className="space-y-1">
             <p className="text-[11px] font-semibold uppercase tracking-[0.05em] text-muted-foreground">
               {translate(
                 'auto.components.skills.SkillBundleInstallOutcome.01c5a12e10',
                 'Needs retry'
               )}{' '}
-              · {result.skills.filter(skillBundleSkillNeedsRetry).length}
+              · {retrySkills.length}
             </p>
-            {result.skills.filter(skillBundleSkillNeedsRetry).map((skill) => (
+            {retrySkills.map((skill) => (
               <p key={skill.skillId} className="text-xs">
                 {skill.name}
                 {skill.errorCategory ? ` · ${skill.errorCategory}` : ''}

--- a/src/renderer/src/components/skills/skill-bundle-retry-selection.test.ts
+++ b/src/renderer/src/components/skills/skill-bundle-retry-selection.test.ts
@@ -39,4 +39,19 @@ describe('bundle retry selection', () => {
   it('includes skills whose provider placement is incomplete', () => {
     expect([...retryableSkillIds(result())]).toEqual(['partial-placement'])
   })
+
+  it('includes a skill whose top-level result failed', () => {
+    const failedResult = result()
+    failedResult.skills = [
+      {
+        skillId: 'failed-skill',
+        name: 'failed-skill',
+        digest: 'd'.repeat(64),
+        status: 'failed',
+        placements: []
+      }
+    ]
+
+    expect([...retryableSkillIds(failedResult)]).toEqual(['failed-skill'])
+  })
 })

--- a/src/renderer/src/components/skills/skill-bundle-retry-selection.test.ts
+++ b/src/renderer/src/components/skills/skill-bundle-retry-selection.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import type { SkillBundleInstallResult } from '../../../../shared/skill-bundle-install-contract'
+import { retryableSkillIds } from './skill-bundle-retry-selection'
+
+function result(): SkillBundleInstallResult {
+  return {
+    operationId: 'operation_1',
+    packageId: 'package_1',
+    versionId: 'version_1',
+    bundleDigest: 'a'.repeat(64),
+    status: 'partial',
+    skills: [
+      {
+        skillId: 'partial-placement',
+        name: 'partial-placement',
+        digest: 'b'.repeat(64),
+        status: 'installed',
+        placements: [
+          {
+            provider: 'claude',
+            path: '/skills/partial-placement',
+            topology: 'provider-alias',
+            status: 'skipped'
+          }
+        ]
+      },
+      {
+        skillId: 'complete-skill',
+        name: 'complete-skill',
+        digest: 'c'.repeat(64),
+        status: 'installed',
+        placements: []
+      }
+    ]
+  }
+}
+
+describe('bundle retry selection', () => {
+  it('includes skills whose provider placement is incomplete', () => {
+    expect([...retryableSkillIds(result())]).toEqual(['partial-placement'])
+  })
+})

--- a/src/renderer/src/components/skills/skill-bundle-retry-selection.ts
+++ b/src/renderer/src/components/skills/skill-bundle-retry-selection.ts
@@ -1,0 +1,20 @@
+import type {
+  SkillBundleInstallResult,
+  SkillBundleSkillResult
+} from '../../../../shared/skill-bundle-install-contract'
+
+export function skillBundleSkillNeedsRetry(skill: SkillBundleSkillResult): boolean {
+  return (
+    skill.status === 'failed' ||
+    skill.status === 'cancelled' ||
+    skill.placements.some(
+      (placement) => placement.status === 'failed' || placement.status === 'skipped'
+    )
+  )
+}
+
+export function retryableSkillIds(result: SkillBundleInstallResult | null): Set<string> {
+  return new Set(
+    result?.skills.filter(skillBundleSkillNeedsRetry).map((skill) => skill.skillId) ?? []
+  )
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4391,7 +4391,8 @@
           "01c5a12e06": "Cancelled",
           "01c5a12e07": "Bundle installation needs attention.",
           "01c5a12e08": "Skills installed and verified.",
-          "01c5a12e09": "{{value0}} selected skills checked."
+          "01c5a12e09": "{{value0}} selected skills checked.",
+          "01c5a12e10": "Needs retry"
         },
         "SkillBundleInstallReview": {
           "01c5a11e01": "Immutable version",

--- a/src/shared/skill-install-capability.ts
+++ b/src/shared/skill-install-capability.ts
@@ -4,6 +4,7 @@ export const SKILL_INSTALL_CANCEL_CAPABILITY = 'skills.install-cancel.v1' as con
 export const SKILL_UPLOAD_CAPABILITY = 'skills.upload.v1' as const
 export const SKILL_MANAGEMENT_CAPABILITY = 'skills.manage.v1' as const
 export const SKILL_BUNDLE_INSTALL_CAPABILITY = 'skills.install.bundle.v1' as const
+export const SKILL_BUNDLE_PREVIEW_CAPABILITY = 'skills.preview.bundle.v1' as const
 export const SKILL_INSTALL_PROGRESS_CAPABILITY = 'skills.install-progress.v1' as const
 /** Why: the install request schema is strict, so a host that predates the agent
  *  picker rejects the whole request rather than ignoring the new field. */

--- a/src/shared/skill-ssh-relay-contract.ts
+++ b/src/shared/skill-ssh-relay-contract.ts
@@ -4,11 +4,15 @@ import {
   SkillInstallRequestSchema,
   SkillRemoveRequestSchema
 } from './skill-install-contract'
-import { SkillBundleInstallRequestSchema } from './skill-bundle-install-contract'
+import {
+  SkillBundleInstallPreviewRequestSchema,
+  SkillBundleInstallRequestSchema
+} from './skill-bundle-install-contract'
 
 export const SKILL_SSH_RELAY_INSTALL_METHOD = 'skills.install' as const
 export const SKILL_SSH_RELAY_INSTALL_BUNDLE_METHOD = 'skills.installBundle' as const
 export const SKILL_SSH_RELAY_PREVIEW_METHOD = 'skills.previewInstall' as const
+export const SKILL_SSH_RELAY_PREVIEW_BUNDLE_METHOD = 'skills.previewBundleInstall' as const
 export const SKILL_SSH_RELAY_REMOVE_METHOD = 'skills.removeInstall' as const
 export const SKILL_SSH_RELAY_LIST_METHOD = 'skills.listManagedInstalls' as const
 export const SKILL_SSH_RELAY_BEGIN_UPLOAD_METHOD = 'skills.beginUpload' as const
@@ -49,6 +53,13 @@ export const SkillSshPreviewParamsSchema = z
   })
   .strict()
 
+export const SkillSshPreviewBundleParamsSchema = z
+  .object({
+    request: SkillBundleInstallPreviewRequestSchema,
+    workspace: SkillSshWorkspaceAuthoritySchema.optional()
+  })
+  .strict()
+
 export const SkillSshRemoveParamsSchema = z
   .object({
     request: SkillRemoveRequestSchema,
@@ -64,4 +75,5 @@ export type SkillSshWorkspaceAuthority = z.infer<typeof SkillSshWorkspaceAuthori
 export type SkillSshInstallParams = z.infer<typeof SkillSshInstallParamsSchema>
 export type SkillSshInstallBundleParams = z.infer<typeof SkillSshInstallBundleParamsSchema>
 export type SkillSshPreviewParams = z.infer<typeof SkillSshPreviewParamsSchema>
+export type SkillSshPreviewBundleParams = z.infer<typeof SkillSshPreviewBundleParamsSchema>
 export type SkillSshRemoveParams = z.infer<typeof SkillSshRemoveParamsSchema>


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​901 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​890 |
| Prod | 22 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​815 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​216 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​599 |

<!-- /orca-pr-loc -->

## Summary

- make SSH skill RPC retries resolve the current provider generation, including transfer, progress, and cleanup calls
- add a capability-gated bundle preview RPC so a 30-skill SSH review performs one provider detection instead of 30 full remote previews
- recover from transient startup/init failures and reclaim same-process locks after failed release cleanup
- preserve Windows executable intent through managed receipts, infer shebang scripts only while publishing bundles, and verify extracted bundles against manifest modes
- make partial provider placements visible and retryable without changing the mixed-version wire enum

## Compatibility

The new `skills.previewBundleInstall` SSH RPC is advertised through `skills.preview.bundle.v1`. New clients do not send it to older hosts; they return the existing update-required result instead. Existing install/result schemas are unchanged.

## Validation

- `pnpm run test:skill-sharing:release` — 541 passed, 38 skipped
- Windows 2 candidate subset — 62 passed, 2 platform-skipped, including bundle creation/extraction, Git-tree identity, lock recovery, SSH preview, and partial retry selection
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run build:relay` — linux/darwin/win32 x64+arm64
- `pnpm run build:electron-vite`
- full `pnpm test` — 53,810 passed; 2 unrelated deterministic failures in untouched IME visibility tests

Linear: https://linear.app/stably/issue/STA-4564/p1continuous-skill-sharing-reland-ssh-retrylock-poison-windows-exe-bit