### PR TITLE
fix(notifications): drop completion notifications for worktrees the catalog no longer knows

### DIFF
--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
@@ -784,4 +784,31 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markTerminalTabUnread).not.toHaveBeenCalled()
     expect(mockState.markTerminalPaneUnread).not.toHaveBeenCalled()
   })
+
+  // Issue #14806: a non-authoritative worktree rescan can drop a deleted
+  // worktree's row from `worktreesByRepo` immediately, while the PTY/tab
+  // teardown that depends on an *authoritative* scan hasn't run yet. In that
+  // window the pty is still live and a fresh completion hook can still land,
+  // so neither the live-pty gate nor the fresh-snapshot gate blocks the OS
+  // notification even though the worktree the user would open no longer exists.
+  it('drops a completion notification for a worktree removed by a non-authoritative rescan', () => {
+    mockState.worktreesByRepo = {
+      repo1: [
+        {
+          id: 'wt-secondary',
+          repoId: 'repo1',
+          displayName: 'e2e-secondary',
+          branch: 'e2e-secondary'
+        }
+      ]
+    }
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey
+    })
+
+    expect(window.api.notifications.dispatch).not.toHaveBeenCalled()
+  })
 })

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
@@ -186,6 +186,14 @@ export function dispatchTerminalNotification(
   // drop the repo label if that format ever changes. The worktree object
   // itself is the source of truth for its owning repo.
   const worktree = getWorktreeMapFromState(state).get(worktreeId)
+  // Why: a non-authoritative rescan can drop a deleted worktree's row from
+  // worktreesByRepo immediately, while the PTY/tab teardown that depends on an
+  // authoritative scan hasn't run yet. In that window hasLivePty/hasFreshAgentStatus
+  // above still pass, so an OS notification would otherwise fire for a worktree
+  // the sidebar no longer shows and the user cannot open.
+  if (event.source === 'agent-task-complete' && !worktree) {
+    return
+  }
   const repo = worktree ? getRepoMapFromState(state).get(worktree.repoId) : null
   const customSoundId = state.settings?.notifications?.customSoundId ?? 'system'
   const customSoundVolume = state.settings?.notifications?.customSoundVolume ?? null


### PR DESCRIPTION
## ELI5

A worktree is deleted, but Orca still pops an OS notification for it minutes later because the terminal/PTY bookkeeping behind that notification hadn't caught up yet, even though the worktree already vanished from the sidebar.

## What Changed

- `dispatchTerminalNotification` (`use-notification-dispatch.ts`) now skips the OS notification for an `agent-task-complete` event when the worktree lookup (`getWorktreeMapFromState`, backed by `worktreesByRepo`) comes back empty.
- In-app unread marking (`markWorktreeUnread` / tab / pane unread) is left untouched — it's harmless if this turns out to be a transient non-authoritative fallback rather than a real deletion, and still useful if the sidebar catches up later.
- Added a regression test in `use-notification-dispatch.test.ts`.

## Why

Traced the actual mechanism (this differs slightly from the originally reported root-cause location, noted below):

- `mergeWorktreesForHost` (`worktree-host-ownership.ts`, via `reuseEqualCatalogRows` in `worktree-catalog-reconciliation.ts`) replaces a host's rows in `worktreesByRepo` with whatever the latest scan says, with **no `authoritative` gate** — so a worktree can disappear from the sidebar on a non-authoritative rescan.
- Meanwhile `getRemovedWorktreeIdsAfterAuthoritativeScan` (also `worktree-host-ownership.ts`) only returns removed ids when `detected.authoritative === true`; on a non-authoritative scan it returns `[]`, so `buildWorktreePurgeState` never clears `tabsByWorktree`/`ptyIdsByTabId`/`agentStatusByPaneKey` for that worktree.
- `dispatchTerminalNotification`'s gate (`hasLivePty || hasFreshAgentStatus`) reads exactly those un-purged maps, so it still lets an `agent-task-complete` notification through for a worktree the sidebar no longer shows.

I initially assumed the fix should make PTY/tab teardown fire on non-authoritative scans too (loosen the gate in `worktree-host-ownership.ts`/`missing-worktree-terminal-teardown.ts`). I backed off that approach: `worktrees-fetch-removal-purge.test.ts` (`'does not purge remembered state from a non-authoritative partial refresh'`) deliberately keeps `tabsByWorktree` intact for a `metadata-fallback` non-authoritative scan, and every non-authoritative `DetectedWorktreeListResult` produced by `src/main/ipc/worktrees.ts` / `src/main/runtime/orca-runtime.ts` is `source: 'metadata-fallback'` (there's no `{authoritative: false, source: 'git'}` case to distinguish "really gone" from "scan just doesn't know"). Loosening that gate would reintroduce the destructive-teardown-on-unreliable-scan failure mode that #12916/#14183 fixed for the empty-scan case.

Gating the OS notification on catalog presence instead is safe either way: if the worktree really is gone, no notification for something the user can't open. If it's a transient fallback miss, suppressing one OS ping for a worktree that isn't even visible in the sidebar right now is a reasonable, low-risk trade — the in-app unread state is preserved and will surface once the sidebar catches up.

## Linked Issue

Fixes #14806

## Visual Proof

N/A — notification-dispatch logic only, no layout/color/UI change.

## Testing

- [x] Reproduced on origin/main: added the regression test first, confirmed it fails (`window.api.notifications.dispatch` called with `worktreeLabel: "wt-primary"` for a worktree absent from `worktreesByRepo`).
- [x] Same test passes with the fix; existing `use-notification-dispatch.test.ts` suite (29 tests) all pass.
- [x] Confirmed `worktrees-fetch-removal-purge.test.ts` / `worktrees-fetch-listing-merge.test.ts` / `worktree-catalog-reconciliation.test.ts` are untouched and still pass (this fix doesn't go near those files).
- [x] `oxlint` on both changed files: clean.
- [x] `tsc --noEmit -p config/tsconfig.node.json` and `-p config/tsconfig.tc.web.json`: clean.
- [x] Full `vitest run`: 53795 passed, 1 pre-existing unrelated failure (`local-pty-shell-ready-zsh-zdotdir-discovery.test.ts`, a live-zsh/locale test that fails identically on unmodified `origin/main` on this host — confirmed via `git stash`).
- [x] Automated tests added/updated, or explained why not below

## Review

Scoped entirely to `dispatchTerminalNotification`; no change to worktree reconciliation, teardown gating, or any other logic that depends on `authoritative` scans.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A) — `worktreesByRepo`/notification dispatch path is identical across local/SSH/runtime worktrees
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — ran targeted oxlint/tsc/vitest as above; did not run the full Electron `pnpm build`