### PR TITLE
fix(browser): keep cookie-import warnings readable from newer hosts

### DIFF
--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -788,7 +788,9 @@
               "undecryptableAppBoundMixed": "Orca cannot decrypt {{value0}} of this browser's cookies because they use app-bound encryption; {{value1}} more could not be decrypted for another reason. You can import cookies from a file using “From File…”.",
               "undecryptableKeyring": "{{value0}} cookies could not be decrypted because the system keyring was unavailable. Unlock your login keyring (or install a Secret Service provider such as gnome-keyring) and import again.",
               "undecryptableKeyringMixed": "{{value0}} cookies could not be decrypted because the system keyring was unavailable; {{value1}} more could not be decrypted for another reason. Unlock your login keyring (or install a Secret Service provider such as gnome-keyring) and import again.",
-              "undecryptableUnknown": "{{value0}} cookies could not be decrypted and were skipped. Close the source browser completely and try the import again."
+              "undecryptableUnknown": "{{value0}} cookies could not be decrypted and were skipped. Close the source browser completely and try the import again.",
+              "unrecognizedWarning": "The cookie import finished with a warning this version of Orca does not recognize. Update Orca to see the details, then check this profile before relying on its cookies.",
+              "undecryptableUnrecognizedReason": "{{value0}} cookies could not be decrypted and were skipped for a reason this version of Orca does not recognize. Update Orca to see the details, then try the import again."
             }
           }
         }

--- a/src/renderer/src/lib/browser-cookie-import-toast.test.ts
+++ b/src/renderer/src/lib/browser-cookie-import-toast.test.ts
@@ -101,6 +101,46 @@ describe('emitBrowserCookieImportToast', () => {
     expect(warningToastMock).not.toHaveBeenCalled()
   })
 
+  // Why: the summary crosses the runtime RPC wire and is cast, not decoded, so a newer host can
+  // publish a reason/code this client build has never heard of (#14683 follow-up).
+  it('still warns when a newer host sends an undeclared undecryptable reason', () => {
+    emitBrowserCookieImportToast(
+      {
+        ...summary,
+        warning: {
+          code: 'cookies-undecryptable',
+          failedCookies: 3,
+          reason: 'hardware-token-required'
+        } as unknown as BrowserCookieImportSummary['warning']
+      },
+      'Imported 0 cookies.',
+      'Remote Linux'
+    )
+
+    const message = warningToastMock.mock.calls[0]?.[0]
+    expect(typeof message).toBe('string')
+    expect(message).not.toBe('')
+    expect(message).toContain('3')
+  })
+
+  it('still warns when a newer host sends an undeclared warning code', () => {
+    emitBrowserCookieImportToast(
+      {
+        ...summary,
+        warning: {
+          code: 'profile-locked',
+          failedCookies: 3
+        } as unknown as BrowserCookieImportSummary['warning']
+      },
+      'Imported 0 cookies.',
+      'Remote Linux'
+    )
+
+    const message = warningToastMock.mock.calls[0]?.[0]
+    expect(typeof message).toBe('string')
+    expect(message).not.toBe('')
+  })
+
   it('keeps both applicable warnings when restart fallback is unavailable', () => {
     emitBrowserCookieImportToast(
       {

--- a/src/renderer/src/lib/browser-cookie-import-toast.test.ts
+++ b/src/renderer/src/lib/browser-cookie-import-toast.test.ts
@@ -141,6 +141,46 @@ describe('emitBrowserCookieImportToast', () => {
     expect(message).not.toBe('')
   })
 
+  // Why: hasOwn coerces its key, so a host that widened `reason` to an array sends ['unknown'],
+  // which a hasOwn-only guard admits before the switch drops it back out.
+  it('still warns when a newer host sends the reason as an array', () => {
+    emitBrowserCookieImportToast(
+      {
+        ...summary,
+        warning: {
+          code: 'cookies-undecryptable',
+          failedCookies: 3,
+          reason: ['unknown']
+        } as unknown as BrowserCookieImportSummary['warning']
+      },
+      'Imported 0 cookies.',
+      'Remote Linux'
+    )
+
+    const message = warningToastMock.mock.calls[0]?.[0]
+    expect(typeof message).toBe('string')
+    expect(message).not.toBe('')
+  })
+
+  it('still warns when a newer host sends the warning code as an array', () => {
+    emitBrowserCookieImportToast(
+      {
+        ...summary,
+        warning: {
+          code: ['cookies-undecryptable'],
+          failedCookies: 3,
+          reason: 'unknown'
+        } as unknown as BrowserCookieImportSummary['warning']
+      },
+      'Imported 0 cookies.',
+      'Remote Linux'
+    )
+
+    const message = warningToastMock.mock.calls[0]?.[0]
+    expect(typeof message).toBe('string')
+    expect(message).not.toBe('')
+  })
+
   it('keeps both applicable warnings when restart fallback is unavailable', () => {
     emitBrowserCookieImportToast(
       {

--- a/src/renderer/src/lib/browser-cookie-import-toast.ts
+++ b/src/renderer/src/lib/browser-cookie-import-toast.ts
@@ -3,8 +3,39 @@ import type { BrowserCookieImportSummary } from '../../../shared/browser-workspa
 import { translate } from '@/i18n/i18n'
 
 type CookieImportWarning = NonNullable<BrowserCookieImportSummary['warning']>
+type CookieImportWarningCode = CookieImportWarning['code']
+type UndecryptableReason = Extract<CookieImportWarning, { code: 'cookies-undecryptable' }>['reason']
+
+// Why: the summary is cast, not decoded, on the way off the runtime RPC wire, so a newer host can
+// send a code/reason this build has never heard of. The Record keys are the union itself, so a new
+// member fails typecheck here instead of silently falling out of the switch (#14683 follow-up).
+const HANDLED_WARNING_CODES: Record<CookieImportWarningCode, true> = {
+  'restart-fallback-unavailable': true,
+  'cookies-undecryptable': true
+}
+
+const HANDLED_UNDECRYPTABLE_REASONS: Record<UndecryptableReason, true> = {
+  'app-bound-encryption': true,
+  'linux-keyring-unavailable': true,
+  unknown: true
+}
+
+function isHandledWarningCode(code: string): code is CookieImportWarningCode {
+  return Object.hasOwn(HANDLED_WARNING_CODES, code)
+}
+
+function isHandledUndecryptableReason(reason: string): reason is UndecryptableReason {
+  return Object.hasOwn(HANDLED_UNDECRYPTABLE_REASONS, reason)
+}
 
 function formatCookieImportWarning(warning: CookieImportWarning): string {
+  const code: string = warning.code
+  if (!isHandledWarningCode(code)) {
+    return translate(
+      'auto.lib.browser.cookie.import.toast.unrecognizedWarning',
+      'The cookie import finished with a warning this version of Orca does not recognize. Update Orca to see the details, then check this profile before relying on its cookies.'
+    )
+  }
   switch (warning.code) {
     case 'restart-fallback-unavailable':
       return warning.loadedCookies === 0
@@ -21,7 +52,15 @@ function formatCookieImportWarning(warning: CookieImportWarning): string {
               value1: warning.loadedCookies + warning.failedCookies
             }
           )
-    case 'cookies-undecryptable':
+    case 'cookies-undecryptable': {
+      const reason: string = warning.reason
+      if (!isHandledUndecryptableReason(reason)) {
+        return translate(
+          'auto.lib.browser.cookie.import.toast.undecryptableUnrecognizedReason',
+          '{{value0}} cookies could not be decrypted and were skipped for a reason this version of Orca does not recognize. Update Orca to see the details, then try the import again.',
+          { value0: warning.failedCookies }
+        )
+      }
       switch (warning.reason) {
         case 'app-bound-encryption':
           return warning.otherFailedCookies
@@ -54,6 +93,7 @@ function formatCookieImportWarning(warning: CookieImportWarning): string {
             { value0: warning.failedCookies }
           )
       }
+    }
   }
 }
 

--- a/src/renderer/src/lib/browser-cookie-import-toast.ts
+++ b/src/renderer/src/lib/browser-cookie-import-toast.ts
@@ -20,16 +20,18 @@ const HANDLED_UNDECRYPTABLE_REASONS: Record<UndecryptableReason, true> = {
   unknown: true
 }
 
-function isHandledWarningCode(code: string): code is CookieImportWarningCode {
-  return Object.hasOwn(HANDLED_WARNING_CODES, code)
+// Why: typeof first — hasOwn coerces its key, so a host that widened `reason` to an array would
+// send ['unknown'], pass a hasOwn-only guard, then fall straight back out of the switch.
+function isHandledWarningCode(code: unknown): code is CookieImportWarningCode {
+  return typeof code === 'string' && Object.hasOwn(HANDLED_WARNING_CODES, code)
 }
 
-function isHandledUndecryptableReason(reason: string): reason is UndecryptableReason {
-  return Object.hasOwn(HANDLED_UNDECRYPTABLE_REASONS, reason)
+function isHandledUndecryptableReason(reason: unknown): reason is UndecryptableReason {
+  return typeof reason === 'string' && Object.hasOwn(HANDLED_UNDECRYPTABLE_REASONS, reason)
 }
 
 function formatCookieImportWarning(warning: CookieImportWarning): string {
-  const code: string = warning.code
+  const code: unknown = warning.code
   if (!isHandledWarningCode(code)) {
     return translate(
       'auto.lib.browser.cookie.import.toast.unrecognizedWarning',
@@ -53,7 +55,7 @@ function formatCookieImportWarning(warning: CookieImportWarning): string {
             }
           )
     case 'cookies-undecryptable': {
-      const reason: string = warning.reason
+      const reason: unknown = warning.reason
       if (!isHandledUndecryptableReason(reason)) {
         return translate(
           'auto.lib.browser.cookie.import.toast.undecryptableUnrecognizedReason',


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​80 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​80 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​46 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​44 |

<!-- /orca-pr-loc -->

## Problem

`formatCookieImportWarning` switches on `warning.code`, and inside `cookies-undecryptable` on `warning.reason`, with explicit cases only and no fallback. TypeScript believes both switches are exhaustive because each union is closed at compile time. They are not exhaustive at runtime.

The summary crosses the runtime RPC wire — `store/slices/browser.ts` → `orca-runtime-browser.ts` — and the response is **cast, not decoded** (`runtime/runtime-rpc-client.ts:91`, `response as RuntimeRpcResponse<TResult>`). A newer remote host that publishes a fourth `reason` (or a third `code`) therefore reaches an older client, nothing matches, the function returns `undefined`, and `emitBrowserCookieImportToast` renders `toast.warning(undefined)` — a **blank warning toast** on a partly-failed import.

This is a regression from #14683: the original code had a `default:` arm that absorbed unknown reasons, and it was replaced with `case 'unknown':` to satisfy `switch-exhaustiveness-check`.

## Why not just restore `default:`

`typescript/switch-exhaustiveness-check` is configured with `allowDefaultCaseForExhaustiveSwitch: false` in both `.oxlintrc.json` and `config/oxlint-code-quality-type-aware.json`. Verified directly — adding a `default:` arm produces:

```
src/renderer/src/lib/browser-cookie-import-toast.ts:56:9: error typescript(switch-exhaustiveness-check):
  The switch statement is exhaustive, so the default case is unnecessary.
```

## Fix

A runtime guard **before** each switch. The incoming value is widened to `string`, checked against the set of variants this build actually handles, and anything else routes to a generic message. The switches stay exhaustive over the narrowed union, so the lint gate stays satisfied.

The handled sets are `Record<Union, true>` keyed by the unions themselves, so this **strengthens** rather than weakens the compile-time guarantee. Adding a fourth reason to `BrowserCookieImportSummary` breaks the build here in two places:

```
browser-cookie-import-toast.ts(17,7): error TS2741: Property '"hardware-token-required"' is missing in type
  '{ 'app-bound-encryption': true; 'linux-keyring-unavailable': true; unknown: true; }'
  but required in type 'Record<...>'.
browser-cookie-import-toast.ts(31,67): error TS2366: Function lacks ending return statement
  and return type does not include 'undefined'.
```

## Fallback copy

Neither message claims a cause it cannot know, and both give the user something to do:

- **Unknown reason** (we do know the cookies failed to decrypt, and how many): _"{{value0}} cookies could not be decrypted and were skipped for a reason this version of Orca does not recognize. Update Orca to see the details, then try the import again."_
- **Unknown code** (we know only that the import was degraded): _"The cookie import finished with a warning this version of Orca does not recognize. Update Orca to see the details, then check this profile before relying on its cookies."_

Both go through `translate()` like their neighbours; `en.json` synced via `pnpm run sync:localization-catalog`.

## Test evidence — red before, green after

Four tests feed a `reason` and a `code` outside the declared unions, cast at the test boundary since the point is that the wire can carry them. Two cover unrecognized string values; two cover non-string values (for example `['unknown']`), which an independent review found still slipped through — `Object.hasOwn` coerces its key, so an array whose `toString()` matches a handled variant passed the first version of the guard and fell straight back out of the switch.

**Against unmodified main (`b6d5972ec4`):**

```
 ❯ src/renderer/src/lib/browser-cookie-import-toast.test.ts (8 tests | 2 failed)
     × still warns when a newer host sends an undeclared undecryptable reason
     × still warns when a newer host sends an undeclared warning code

AssertionError: expected 'undefined' to be 'string' // Object.is equality
Expected: "string"
Received: "undefined"

 Test Files  1 failed (1)
      Tests  2 failed | 6 passed (8)
```

**After the fix:**

```
 Test Files  1 passed (1)
      Tests  8 passed (8)
```

## Gates

| Gate | Result |
| --- | --- |
| `node config/scripts/check-changed-code-quality.mjs` | `Changed-code quality gate passed since b6d5972ec453.` — 0 findings on all three scans |
| `pnpm run typecheck` | clean |
| vitest (affected files, `--config config/vitest.config.ts`) | 202 files / 1399 tests passed |
| `verify:localization-catalog` | `Verified 12231 localization key references against en.json.` |
| `verify:localization-extraction` | passed |
| `verify:localization-coverage` | `Localization coverage check passed with 12 allowlisted candidates.` |

All three oxlint scans were proven **live**, not silently dead, by injecting violations and confirming each caught them:

```
code quality:            no-else-return + no-unneeded-ternary  → 2 findings
type-aware code quality: switch-exhaustiveness-check           → 1 finding
React Doctor:            effect-needs-cleanup                  → 1 finding
```

## Scope

Three files. No refactor of the toast module, no renames, no changes to the cookie-import main-process code.

