### PR TITLE
revert(crash-reporting): drop the dead terminal_parking_pass retained-slot reservation (#14867)

### DIFF
--- a/src/main/crash-reporting/crash-breadcrumb-store.test.ts
+++ b/src/main/crash-reporting/crash-breadcrumb-store.test.ts
@@ -49,48 +49,6 @@ describe('crash breadcrumb store', () => {
     expect(snapshot.at(-1)?.data).toEqual({ index: 31 })
   })
 
-  it('retains the newest coalesced parking census across later activity', () => {
-    vi.useFakeTimers()
-    vi.setSystemTime(new Date('2026-08-15T12:00:00.000Z'))
-    recordCrashBreadcrumb('renderer_memory_highwater', {
-      rendererSurface: 'main',
-      thresholdPct: 80
-    })
-    recordCoalescedCrashBreadcrumb({
-      name: 'terminal_parking_pass',
-      data: { managers: 49, panes: 60, sampledAtMs: Date.now() },
-      coalesceKey: 'terminal_parking_pass',
-      minIntervalMs: 30_000
-    })
-    vi.advanceTimersByTime(1_000)
-    recordCoalescedCrashBreadcrumb({
-      name: 'terminal_parking_pass',
-      data: { managers: 28, panes: 34, sampledAtMs: Date.now() },
-      coalesceKey: 'terminal_parking_pass',
-      minIntervalMs: 30_000
-    })
-    for (let index = 0; index < 32; index += 1) {
-      recordCrashBreadcrumb(`later_event_${index}`, { index })
-    }
-
-    const snapshot = getCrashBreadcrumbSnapshot()
-    const parkingPasses = snapshot.filter(
-      (breadcrumb) => breadcrumb.name === 'terminal_parking_pass'
-    )
-
-    expect(snapshot).toHaveLength(30)
-    expect(parkingPasses).toHaveLength(1)
-    expect(snapshot.some((breadcrumb) => breadcrumb.name === 'renderer_memory_highwater')).toBe(
-      true
-    )
-    expect(parkingPasses[0]?.data).toEqual({
-      managers: 28,
-      panes: 34,
-      sampledAtMs: Date.now(),
-      suppressedSinceLast: 1
-    })
-  })
-
   it('caps retained high-water profiles', () => {
     for (let index = 0; index < 5; index += 1) {
       recordCrashBreadcrumb('renderer_memory_highwater', {
@@ -102,41 +60,6 @@ describe('crash breadcrumb store', () => {
     expect(
       getCrashBreadcrumbSnapshot().map((breadcrumb) => breadcrumb.data?.rendererSurface)
     ).toEqual(['surface-1', 'surface-2', 'surface-3', 'surface-4'])
-  })
-
-  it('keeps memory profiles and parking census from starving each other', () => {
-    recordCrashBreadcrumb('terminal_parking_pass', { managers: 1, panes: 1 })
-    for (let index = 0; index < 12; index += 1) {
-      recordCrashBreadcrumb('renderer_memory_highwater', {
-        rendererSurface: `surface-${index}`,
-        thresholdPct: 80
-      })
-    }
-
-    expect(
-      getCrashBreadcrumbSnapshot().filter(
-        (breadcrumb) => breadcrumb.name === 'terminal_parking_pass'
-      )
-    ).toHaveLength(1)
-
-    for (let index = 0; index < 12; index += 1) {
-      recordCrashBreadcrumb('terminal_parking_pass', { managers: index, panes: index + 1 })
-    }
-
-    const snapshot = getCrashBreadcrumbSnapshot()
-    const memoryProfiles = snapshot.filter(
-      (breadcrumb) => breadcrumb.name === 'renderer_memory_highwater'
-    )
-
-    expect(memoryProfiles.map((breadcrumb) => breadcrumb.data?.rendererSurface)).toEqual([
-      'surface-8',
-      'surface-9',
-      'surface-10',
-      'surface-11'
-    ])
-    expect(snapshot.filter((breadcrumb) => breadcrumb.name === 'terminal_parking_pass')).toEqual([
-      expect.objectContaining({ data: { managers: 11, panes: 12 } })
-    ])
   })
 
   it('redacts sensitive breadcrumb fields before they can be snapshotted', () => {

--- a/src/main/crash-reporting/crash-breadcrumb-store.ts
+++ b/src/main/crash-reporting/crash-breadcrumb-store.ts
@@ -6,10 +6,8 @@ import {
 } from '../../shared/crash-reporting'
 
 const MAX_BREADCRUMBS = 30
-// Why: preserve four memory highwaters and one named singleton within the 30-entry snapshot.
-const MAX_RETAINED_BREADCRUMBS = 5
-const MAX_RETAINED_MEMORY_BREADCRUMBS = 4
-const RETAINED_SINGLETON_BREADCRUMB_NAMES = new Set(['terminal_parking_pass'])
+// Why: retain two thresholds for each renderer surface without growing the ring.
+const MAX_RETAINED_BREADCRUMBS = 4
 // Why: coalesceKey embeds an open-string agentType (length-trimmed only, never
 // enum-checked), so the key space is unbounded over a long multi-agent/SSH session.
 // Bound the coalesce map the same way ProcessGoneDedupe bounds its key map.
@@ -39,9 +37,6 @@ let retainedBreadcrumbs = new Map<string, CrashReportBreadcrumb>()
 let coalescedBreadcrumbs = new Map<string, CoalescedBreadcrumbState>()
 
 function retainedBreadcrumbKey(breadcrumb: CrashReportBreadcrumb): string | null {
-  if (RETAINED_SINGLETON_BREADCRUMB_NAMES.has(breadcrumb.name)) {
-    return breadcrumb.name
-  }
   if (breadcrumb.name !== 'renderer_memory_highwater') {
     return null
   }
@@ -70,15 +65,6 @@ export function recordCrashBreadcrumb(
   if (retainedKey) {
     retainedBreadcrumbs.delete(retainedKey)
     retainedBreadcrumbs.set(retainedKey, breadcrumb)
-    const memoryKeys = [...retainedBreadcrumbs.entries()]
-      .filter(([, retained]) => retained.name === 'renderer_memory_highwater')
-      .map(([key]) => key)
-    while (memoryKeys.length > MAX_RETAINED_MEMORY_BREADCRUMBS) {
-      const oldestMemoryKey = memoryKeys.shift()
-      if (oldestMemoryKey) {
-        retainedBreadcrumbs.delete(oldestMemoryKey)
-      }
-    }
     while (retainedBreadcrumbs.size > MAX_RETAINED_BREADCRUMBS) {
       const oldestKey = retainedBreadcrumbs.keys().next()
       if (oldestKey.done) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | 0 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​77 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​77 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​16 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​14 |

<!-- /orca-pr-loc -->

## ELI5

We reserved a guaranteed "save this one" slot in the crash-report breadcrumb ring for a `terminal_parking_pass` event that a sibling PR was going to start emitting. That sibling PR was closed without merging, so nothing ever produces the event. This reverts the reservation so the store doesn't carry config and tests for a breadcrumb that cannot exist.

## What Changed

Reverts #14867 (`28c93da474`) via `git revert`:

- `MAX_RETAINED_BREADCRUMBS` back to 4 with its original comment ("retain two thresholds for each renderer surface without growing the ring")
- Removes `MAX_RETAINED_MEMORY_BREADCRUMBS`, `RETAINED_SINGLETON_BREADCRUMB_NAMES`, the singleton early-return in `retainedBreadcrumbKey`, and the memory-specific trim loop in `recordCrashBreadcrumb`
- Removes the two tests that pinned `terminal_parking_pass` retention/starvation behavior

No dangling references remain: `terminal_parking_pass`, `RETAINED_SINGLETON_BREADCRUMB_NAMES`, and `MAX_RETAINED_MEMORY_BREADCRUMBS` appear nowhere in `src/` after this change.

**Memory-highwater capacity is unchanged at 4.** Pre-revert, main retained 4 memory highwaters (`MAX_RETAINED_MEMORY_BREADCRUMBS = 4`) within a total of 5. Post-revert, only `renderer_memory_highwater` breadcrumbs get a retained key (`retainedBreadcrumbKey` returns `null` for every other name), and the retained map caps at `MAX_RETAINED_BREADCRUMBS = 4` — so all 4 slots are memory highwaters, exactly as before #14867. The pre-existing "caps retained high-water profiles" test still pins this.

## Why

#14867 provisioned a retained singleton slot for `terminal_parking_pass` in anticipation of #14660, which would have emitted it as part of investigating the React #185 parking-oscillation hypothesis. #14660 has since been closed (https://github.com/stablyai/orca/pull/14660#issuecomment-5311683610): park churn appeared in 0 of 16 #185 field reports vs 3 of 336 non-#185 reports, the paired fix #14653 closed at zero diff, and the #185 cluster spans five error boundaries rather than being a terminal parking bug.

With #14660 closed, nothing in production emits `terminal_parking_pass` — it exists only in the retention set and that file's tests. The reservation is dead config, and the constant split served no purpose independent of it, so a full revert (not a targeted trim) is the right shape.

## Linked Issue

No standalone issue exists for this cleanup — it reverts #14867, whose reservation was made for the emitter proposed in the now-closed #14660.

Fixes # (revert of #14867; see #14660 for the closure that made it dead config)

## Visual Proof

N/A — main-process crash-breadcrumb retention config with no UI surface or interaction change.

## Testing

- `vitest run --config config/vitest.config.ts --no-file-parallelism src/main/crash-reporting/crash-breadcrumb-store.test.ts` — 21 passed
- Adjacent breadcrumb suites (`crash-breadcrumb-store-leak`, `crash-breadcrumb-store-orphan-cleanup`, `durable-crash-breadcrumb`, `suppressed-process-gone-breadcrumb`) — 14 passed
- `pnpm run typecheck:node` — clean
- Verified the revert restores the exact pre-#14867 file state and leaves zero references to the removed names (macOS local)

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below — the reverted tests only exercised the removed dead behavior; surviving coverage still pins the 4-slot memory-highwater cap

## AI Disclosure

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

Platform-neutral main-process config; no wire, SSH, or mobile impact. Crash-report snapshots simply stop reserving a slot for an event that is never recorded.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @BrennanKB5
