### PR TITLE
Rethrow update errors after lineage recovery attempt

### DIFF
--- a/src/renderer/src/store/slices/worktrees-lineage-state.test.ts
+++ b/src/renderer/src/store/slices/worktrees-lineage-state.test.ts
@@ -316,16 +316,18 @@ describe('worktree lineage state', () => {
     })
   })
 
-  it('refetches lineage after an update failure', async () => {
+  it('refetches lineage and rethrows after an update failure', async () => {
     const lineage = makeLineage()
     const store = createLocalLineageTestStore(lineage)
     mockApi.worktrees.updateLineage.mockRejectedValueOnce(new Error('stale parent'))
     mockApi.worktrees.listLineage.mockResolvedValue({ [lineage.worktreeId]: lineage })
     vi.spyOn(console, 'error').mockImplementation(() => {})
 
-    await store.getState().updateWorktreeLineage(lineage.worktreeId, {
-      parentWorktreeId: lineage.parentWorktreeId
-    })
+    await expect(
+      store.getState().updateWorktreeLineage(lineage.worktreeId, {
+        parentWorktreeId: lineage.parentWorktreeId
+      })
+    ).rejects.toThrow('stale parent')
 
     expect(mockApi.worktrees.listLineage).toHaveBeenCalled()
     expect(store.getState().worktreeLineageById).toEqual({ [lineage.worktreeId]: lineage })
@@ -734,7 +736,7 @@ describe('worktree lineage state', () => {
     expect(mockApi.worktrees.updateLineage).not.toHaveBeenCalled()
   })
 
-  it('resolves when the update fails and the recovery lineage refresh fails too', async () => {
+  it('rethrows the original update failure when the recovery refresh fails', async () => {
     const lineage = makeLineage()
     const store = createLocalLineageTestStore(lineage)
     mockApi.worktrees.updateLineage.mockRejectedValueOnce(new Error('unnest failed'))
@@ -743,7 +745,7 @@ describe('worktree lineage state', () => {
 
     await expect(
       store.getState().updateWorktreeLineage(lineage.worktreeId, { noParent: true })
-    ).resolves.toBeUndefined()
+    ).rejects.toThrow('unnest failed')
   })
 
   it('rethrows the original assign failure when the recovery refresh fails', async () => {

--- a/src/renderer/src/store/slices/worktrees/metadata/worktree-lineage-actions.ts
+++ b/src/renderer/src/store/slices/worktrees/metadata/worktree-lineage-actions.ts
@@ -67,6 +67,7 @@ export function createUpdateWorktreeLineage(
     } catch (err) {
       console.error('Failed to update worktree lineage:', err)
       await refreshWorktreeLineageBestEffort(ownerSettings, set)
+      throw err
     }
   }
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​8 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 |

<!-- /orca-pr-loc -->

## Problem

When a worktree lineage update failed, the error was silently swallowed. The code attempted recovery (refreshing lineage) but then resolved successfully instead of propagating the failure. This masked persistence errors from callers and logging systems.

## Solution

After attempting to recover from an update failure via `refreshWorktreeLineageBestEffort`, rethrow the original error. This ensures:
- Callers see that the operation failed
- Error is properly logged in crash reporting / observability systems
- Recovery attempts don't hide the root cause

The fix is minimal: add `throw err` after the recovery attempt in `updateWorktreeLineage`.

## Testing

- Updated tests to expect the original error to be rethrown
- Tests verify that recovery still happens before the error propagates
- Cross-platform impact: N/A, this is state-management logic

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] N/A — no UI changes
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)