### PR TITLE
Fix in-flight checkpoint cleanup in daemon shutdown test

### DIFF
--- a/src/main/daemon/daemon-shutdown-final-checkpoint-caller-deadline.test.ts
+++ b/src/main/daemon/daemon-shutdown-final-checkpoint-caller-deadline.test.ts
@@ -68,10 +68,12 @@ describe('STA-4228 keep-history stop bounds only the caller wait on the final ch
   let server: DaemonServer
   let adapter: DaemonPtyAdapter
   let subprocesses: ReturnType<typeof createMockSubprocess>[]
+  let releaseStall: (() => void) | undefined
 
   beforeEach(async () => {
     dir = mkdtempSync(join(tmpdir(), 'orca-final-checkpoint-deadline-'))
     subprocesses = []
+    releaseStall = undefined
     const log: DaemonFileLog = { log: () => {}, close: () => {} }
     server = new DaemonServer({
       socketPath: getDaemonSocketPath(dir),
@@ -92,7 +94,21 @@ describe('STA-4228 keep-history stop bounds only the caller wait on the final ch
   })
 
   afterEach(async () => {
-    adapter?.dispose()
+    // Why before rmSync: a keep-history stop abandons the exclusive checkpoint, and
+    // that write's tmp/rename will recreate files under the temp tree if we delete it first.
+    releaseStall?.()
+    releaseStall = undefined
+    if (adapter) {
+      const internals = adapter as unknown as {
+        checkpointInFlight: Promise<void> | null
+        stopCheckpointTimer: () => void
+      }
+      await internals.checkpointInFlight
+      internals.stopCheckpointTimer()
+      await internals.checkpointInFlight
+      await adapter.getHistoryManager()?.dispose()
+      adapter.dispose()
+    }
     await server?.shutdown()
     rmSync(dir, { recursive: true, force: true })
   })
@@ -106,6 +122,7 @@ describe('STA-4228 keep-history stop bounds only the caller wait on the final ch
     const stalled = new Promise<void>((resolve) => {
       release = resolve
     })
+    releaseStall = release
     vi.spyOn(manager!, 'checkpoint').mockImplementation(
       async (
         sessionId: string,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​18 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​17 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## Problem

The daemon shutdown test had a race condition during cleanup. When tests created stalled checkpoints (promises that didn't resolve immediately), the cleanup didn't wait for those in-flight operations to complete before tearing down. This caused file system issues and potential test interference.

## Solution

Enhanced the test afterEach to properly sequence cleanup:
1. Release any stalled checkpoint operations
2. Wait for in-flight checkpoint promises to complete
3. Stop checkpoint timers
4. Dispose history manager
5. Finally dispose the adapter

This ensures in-flight operations finish before the temp directory is deleted, preventing incomplete checkpoint writes from attempting to recreate files.

## Testing

- Test fixture only; fixes cleanup reliability without changing test behavior