### PR TITLE
fix(ci): run PR LoC scripts from the default branch, not PR head

### DIFF
--- a/.github/workflows/pr-test-loc.yml
+++ b/.github/workflows/pr-test-loc.yml
@@ -23,14 +23,20 @@ jobs:
     timeout-minutes: 2
     steps:
       # Why no checkout: the Files API already has per-file additions/deletions.
+      # Why the default branch and never pull/<n>/head: this job holds a write-scoped
+      # GITHUB_TOKEN, so it may only execute reviewed code. A PR that edits these
+      # scripts takes effect once merged.
       - name: Count test vs non-test LoC
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          TRUSTED_REF: ${{ github.event.repository.default_branch }}
         run: |
+          set -euo pipefail
           for script in pr-test-loc-table.mjs pr-test-loc-summary.mjs; do
-            gh api "repos/${GITHUB_REPOSITORY}/contents/.github/scripts/${script}?ref=pull/${{ github.event.pull_request.number }}/head" \
+            gh api "repos/${GITHUB_REPOSITORY}/contents/.github/scripts/${script}?ref=${TRUSTED_REF}" \
               --jq .content | base64 --decode > "$RUNNER_TEMP/${script}"
           done
-          node "$RUNNER_TEMP/pr-test-loc-summary.mjs" --update-pr "${{ github.event.pull_request.number }}"
+          node "$RUNNER_TEMP/pr-test-loc-summary.mjs" --update-pr "$PR_NUMBER"

--- a/config/scripts/pr-test-loc-summary.test.mjs
+++ b/config/scripts/pr-test-loc-summary.test.mjs
@@ -15,6 +15,11 @@ import {
 
 const projectDir = resolve(import.meta.dirname, '../..')
 const locScript = join(projectDir, '.github/scripts/pr-test-loc-summary.mjs')
+const locWorkflow = parse(
+  readFileSync(join(projectDir, '.github/workflows/pr-test-loc.yml'), 'utf8')
+)
+const locJob = locWorkflow.jobs.loc
+const locStep = locJob.steps[0]
 const tempDirs = []
 
 function runLoc(args, { env } = {}) {
@@ -178,20 +183,36 @@ describe('PR test LoC summary', () => {
   })
 
   it('is a no-checkout GitHub-hosted PR workflow', () => {
-    const workflow = parse(
-      readFileSync(join(projectDir, '.github/workflows/pr-test-loc.yml'), 'utf8')
-    )
-    const locJob = workflow.jobs.loc
-    const serialized = JSON.stringify(workflow)
-
     expect(locJob['runs-on']).toBe('ubuntu-latest')
     expect(locJob.steps).toHaveLength(1)
-    expect(locJob.steps[0].run).toContain('gh api')
-    expect(locJob.steps[0].run).toContain('pr-test-loc-table.mjs')
-    expect(locJob.steps[0].run).toContain('pr-test-loc-summary.mjs')
-    expect(locJob.steps[0].run).toContain('--update-pr')
-    expect(workflow.permissions['pull-requests']).toBe('write')
-    expect(serialized).not.toContain('actions/checkout')
-    expect(serialized).not.toContain('self-hosted')
+    expect(locStep.run).toContain('gh api')
+    expect(locStep.run).toContain('pr-test-loc-table.mjs')
+    expect(locStep.run).toContain('pr-test-loc-summary.mjs')
+    expect(locStep.run).toContain('--update-pr')
+    expect(locWorkflow.permissions['pull-requests']).toBe('write')
+    expect(JSON.stringify(locWorkflow)).not.toContain('actions/checkout')
+    expect(JSON.stringify(locWorkflow)).not.toContain('self-hosted')
+  })
+
+  // The write-scoped GITHUB_TOKEN makes any PR-authored code a privilege escalation.
+  it('executes only default-branch script code, never pull-request head code', () => {
+    const serialized = JSON.stringify(locWorkflow)
+
+    expect(locStep.env.TRUSTED_REF).toBe('${{ github.event.repository.default_branch }}')
+    expect(locStep.run).toContain('?ref=${TRUSTED_REF}')
+    expect(serialized).not.toContain('pull_request_target')
+    expect(serialized).not.toContain('pull/')
+    expect(serialized).not.toContain('pull_request.head')
+    expect(serialized).not.toContain('/merge')
+  })
+
+  it('passes event data through env instead of interpolating it into the shell', () => {
+    expect(locStep.env.PR_NUMBER).toBe('${{ github.event.pull_request.number }}')
+    expect(locStep.run).toContain('--update-pr "$PR_NUMBER"')
+    expect(locStep.run).not.toContain('${{')
+  })
+
+  it('fails the step when a script download fails instead of running a truncated file', () => {
+    expect(locStep.run).toContain('set -euo pipefail')
   })
 })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​34 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​21 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​8 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 |

<!-- /orca-pr-loc -->

## ELI5

The workflow that posts the test-vs-prod LoC table downloaded its own scripts from the pull request's own commit and ran them, while holding a token that can write to pull requests. So a PR could ship code that the CI job then executed with write access. Now it only runs the copy of those scripts that is already merged into `main`.

## What Changed

- `.github/workflows/pr-test-loc.yml` fetches `.github/scripts/pr-test-loc-*.mjs` from `${{ github.event.repository.default_branch }}` instead of `pull/<n>/head`
- Event data moves into `PR_NUMBER` / `TRUSTED_REF` env vars instead of `${{ }}` interpolation directly into the `run:` shell
- `set -euo pipefail` added to the step
- `config/scripts/pr-test-loc-summary.test.mjs` gains three contract guards for the above

## Why

The `loc` job runs under `permissions: pull-requests: write` and executed PR-authored JavaScript. That is arbitrary code execution from PR content under a write-scoped `GITHUB_TOKEN`.

The structural rule it broke: **a job holding a write token must not run PR code, and a job running PR code must not hold a write token.** This job did both at once.

Severity today is bounded — fork PRs on `pull_request` get a forced read-only token, so an outside attacker got code execution on a hosted runner but no write. Same-repo branch PRs got the full write-scoped token. The larger problem is that the pattern was a landmine: adding any secret to this workflow, or ever switching it to `pull_request_target`, would have turned it into unauthenticated RCE with repo credentials.

**Why the default branch rather than `pull_request.base.sha`:** for stacked PRs `base.sha` is an unreviewed feature-branch commit that any collaborator with push access can write to unilaterally. `main` is the only ref gated by branch protection, so it is the sole trustworthy anchor.

Accepted tradeoff, noted in a comment in the workflow: a PR that edits these scripts is now validated against the merged version, not its own. That is the correct direction for a job carrying a write token.

The `set -euo pipefail` addition is not cosmetic — without it a failed `gh api` in `gh api … | base64 --decode > file` exits 0 via `base64`, leaving a truncated script that `node` then runs.

The no-checkout design is preserved: still one API call, no clone.

## Linked Issue

STA-4484 — https://linear.app/stably/issue/STA-4484

## Visual Proof

`N/A` — CI workflow hardening, no user-facing UI or behavior change.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

`pnpm exec vitest run --config config/vitest.config.ts config/scripts/pr-test-loc-summary.test.mjs` — 12/12 pass.

The three new guards were verified to actually bite: re-running the suite against the pre-fix workflow from `HEAD` fails exactly those three and passes the other nine, so they are not vacuous.

Also audited the only other privileged-trigger workflow, `track-community-prs.yaml`. It uses `pull_request_target` but has no checkout and only inline trusted script with env-passed inputs, so it is fine. `pr-test-loc.yml` was the only offender.

Data-flow check on what remains: the Files API supplies attacker-controlled `filename` / `additions` / `deletions`, but only computed integers reach the PR body — filenames never do — so there is no content-injection path, and the two path regexes have no nested quantifiers.

## Review

Security fix. Reviewers should confirm the trust anchor choice (default branch vs `base.sha`) is the one we want.

## Agent skill upstream boundary

- [x] Not applicable

## Notes

Cross-platform / SSH / mobile / backwards compatibility: not applicable, this is a GitHub-hosted Ubuntu CI job only. No runtime or app code touched.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)