### PR TITLE
fix(terminal): dispose a deferred IME chord instead of leaving it armed

### DIFF
--- a/src/renderer/src/components/terminal-pane/keyboard-handlers-ime-composing-chord.test.tsx
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers-ime-composing-chord.test.tsx
@@ -14,6 +14,7 @@ import {
   XTERM_COMPOSITION_SESSION_END_EVENT,
   XTERM_COMPOSITION_SESSION_START_EVENT
 } from './terminal-ime-composition-route'
+import { TERMINAL_IME_DEFERRED_CHORD_ABANDON_MS } from './terminal-ime-deferred-chord'
 import { useTerminalKeyboardShortcuts } from './keyboard-handlers'
 
 type KeyboardHandlersDeps = Parameters<typeof useTerminalKeyboardShortcuts>[0]
@@ -30,12 +31,34 @@ function keyboardEvent(
   return event
 }
 
+/** Live registrations on the terminal element, so a deferral that never disposes is visible. */
+function trackCompositionListeners(element: HTMLElement): () => number {
+  const live = new Set<EventListenerOrEventListenerObject>()
+  const watched = new Set(['compositionend', XTERM_COMPOSITION_SESSION_END_EVENT])
+  const { addEventListener, removeEventListener } = element
+  element.addEventListener = function (type, listener, options): void {
+    if (watched.has(type) && listener) {
+      live.add(listener)
+    }
+    addEventListener.call(this, type, listener, options)
+  }
+  element.removeEventListener = function (type, listener, options): void {
+    if (watched.has(type) && listener) {
+      live.delete(listener)
+    }
+    removeEventListener.call(this, type, listener, options)
+  }
+  return () => live.size
+}
+
 function createHarness(): {
   deps: KeyboardHandlersDeps
   terminalElement: HTMLDivElement
   terminalInput: HTMLTextAreaElement
   /** Every byte reaching the pty, in arrival order, whichever route it took. */
   wire: string[]
+  /** Registrations added after the composition route's own, i.e. the deferrals still waiting. */
+  deferralListenerCount: () => number
   startComposition: () => void
   endComposition: (data: string) => void
   dispose: () => void
@@ -77,6 +100,8 @@ function createHarness(): {
     capturedTransport: transport,
     getCurrentTransport: () => transport
   })
+  // Installed after the route so only the deferral's own registrations are counted.
+  const deferralListenerCount = trackCompositionListeners(terminalElement)
 
   const deps: KeyboardHandlersDeps = {
     tabId: 'tab-1',
@@ -110,6 +135,7 @@ function createHarness(): {
     terminalElement,
     terminalInput,
     wire,
+    deferralListenerCount,
     startComposition: () => {
       terminalElement.dispatchEvent(
         new CustomEvent(XTERM_COMPOSITION_SESSION_START_EVENT, { detail: { id: 1 } })
@@ -217,6 +243,59 @@ describe('a cursor chord pressed during a composition', () => {
     pressCmdArrowLeft(harness, false)
 
     expect(harness.wire).toEqual(['\x01'])
+    hook.unmount()
+    harness.dispose()
+  })
+
+  // STA-4476: an indefinite wait has no exit of its own. Without a disposer the listeners outlive
+  // the pane and a later composition on the same element flushes the stale chord.
+  it('drops the held chord and its listeners when the pane tears down', () => {
+    const harness = createHarness()
+    const hook = renderHook(() => useTerminalKeyboardShortcuts(harness.deps))
+
+    harness.startComposition()
+    pressCmdArrowLeft(harness, true)
+    expect(harness.deferralListenerCount()).toBeGreaterThan(0)
+
+    hook.unmount()
+    harness.endComposition('다')
+    vi.runAllTimers()
+
+    expect(harness.wire).toEqual(['다'])
+    expect(harness.deferralListenerCount()).toBe(0)
+    harness.dispose()
+  })
+
+  it('drops the held chord and its listeners on blur', () => {
+    const harness = createHarness()
+    const hook = renderHook(() => useTerminalKeyboardShortcuts(harness.deps))
+
+    harness.startComposition()
+    pressCmdArrowLeft(harness, true)
+    window.dispatchEvent(new Event('blur'))
+    harness.endComposition('다')
+    vi.runAllTimers()
+
+    expect(harness.wire).toEqual(['다'])
+    expect(harness.deferralListenerCount()).toBe(0)
+    hook.unmount()
+    harness.dispose()
+  })
+
+  // A composition that never commits must not strand the wait forever. The chord is discarded,
+  // never sent late — a late send is #12871 again.
+  it('abandons a chord whose composition never ends', () => {
+    const harness = createHarness()
+    const hook = renderHook(() => useTerminalKeyboardShortcuts(harness.deps))
+
+    harness.startComposition()
+    pressCmdArrowLeft(harness, true)
+    vi.advanceTimersByTime(TERMINAL_IME_DEFERRED_CHORD_ABANDON_MS + 1)
+    harness.endComposition('다')
+    vi.runAllTimers()
+
+    expect(harness.wire).toEqual(['다'])
+    expect(harness.deferralListenerCount()).toBe(0)
     hook.unmount()
     harness.dispose()
   })

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -15,9 +15,9 @@ import {
   getTerminalImeModifiedEnterKind,
   isTerminalImeConsumedKey,
   isTerminalImeEnterKeyUp,
-  isTerminalImeProcessEnter,
-  sendTerminalInputAfterComposition
+  isTerminalImeProcessEnter
 } from './terminal-ime-deferred-newline'
+import { createTerminalImeDeferredChordSender } from './terminal-ime-deferred-chord'
 import { hasPendingTerminalImeComposition } from './terminal-ime-composition-route'
 import {
   requestCapturedTerminalReconfirmation,
@@ -290,6 +290,7 @@ export function useTerminalKeyboardShortcuts({
     const terminalImeEnterModifierKeydowns = new Set<'shift' | 'ctrl'>()
     const nativeOnlyShortcutTracker = createTerminalNativeOnlyShortcutTracker()
     const deferredNewlineSender = createTerminalImeDeferredNewlineSender()
+    const deferredChordSender = createTerminalImeDeferredChordSender()
     const modifiedEnterChordOwner = createTerminalImeModifiedEnterChordOwner()
     const reconcileHeldImeEnterModifiers = (
       event: KeyboardEvent,
@@ -651,11 +652,10 @@ export function useTerminalKeyboardShortcuts({
         // runs after this keydown. Sending now puts a cursor chord ahead of the text it was typed
         // after — `가나다` then Cmd+Left leaves `다가나` (#12871). Enter is handled above, where a
         // fallback timer is right because a newline arriving late still arrives; a chord arriving
-        // mid-preedit is the corruption itself, so this one waits without a deadline.
+        // mid-preedit is the corruption itself, so this one waits on the composition rather than a
+        // deadline. The sender owns the wait so blur and teardown can drop it.
         if (e.isComposing || hasPendingImeComposition) {
-          sendTerminalInputAfterComposition(pane.terminal.element, sendResolvedInput, {
-            fallbackMs: null
-          })
+          deferredChordSender.defer(pane.terminal.element, sendResolvedInput)
           return
         }
         sendResolvedInput()
@@ -986,6 +986,7 @@ export function useTerminalKeyboardShortcuts({
       terminalImeEnterModifierKeydowns.clear()
       modifiedEnterChordOwner.clear()
       deferredNewlineSender.clearRedispatchedEnters()
+      deferredChordSender.cancelPending()
       observedEnterKeydownTimeStamps.clear()
     }
 
@@ -1000,6 +1001,7 @@ export function useTerminalKeyboardShortcuts({
       optionKittyReleases.clear()
       modifiedEnterChordOwner.clear()
       deferredNewlineSender.clearRedispatchedEnters()
+      deferredChordSender.cancelPending()
       observedEnterKeydownTimeStamps.clear()
       window.removeEventListener('keydown', onModifierDown, { capture: true })
       window.removeEventListener('keyup', onKeyUp, { capture: true })

--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-chord.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-chord.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment happy-dom
+// STA-4476: the composing-chord deferral waits on the composition, not a deadline (#12871), so it
+// is the sender that has to guarantee an exit — otherwise the wait and its listeners outlive the
+// pane and a later composition flushes a stale chord.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  createTerminalImeDeferredChordSender,
+  TERMINAL_IME_DEFERRED_CHORD_ABANDON_MS
+} from './terminal-ime-deferred-chord'
+import { XTERM_COMPOSITION_SESSION_END_EVENT } from './terminal-ime-composition-route'
+
+describe('createTerminalImeDeferredChordSender', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('sends once the composition commits', () => {
+    const el = document.createElement('div')
+    const send = vi.fn()
+    const sender = createTerminalImeDeferredChordSender()
+
+    sender.defer(el, send)
+    expect(send).not.toHaveBeenCalled()
+
+    el.dispatchEvent(new Event('compositionend'))
+    vi.advanceTimersByTime(0)
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancels every pending chord and detaches its listeners', () => {
+    const el = document.createElement('div')
+    const removeEventListener = vi.spyOn(el, 'removeEventListener')
+    const first = vi.fn()
+    const second = vi.fn()
+    const sender = createTerminalImeDeferredChordSender()
+
+    sender.defer(el, first)
+    sender.defer(el, second)
+    sender.cancelPending()
+
+    expect(removeEventListener).toHaveBeenCalledTimes(4)
+
+    el.dispatchEvent(new Event('compositionend'))
+    el.dispatchEvent(new CustomEvent(XTERM_COMPOSITION_SESSION_END_EVENT))
+    vi.runAllTimers()
+    expect(first).not.toHaveBeenCalled()
+    expect(second).not.toHaveBeenCalled()
+  })
+
+  it('abandons a chord whose composition never ends rather than sending it late', () => {
+    const el = document.createElement('div')
+    const send = vi.fn()
+    const sender = createTerminalImeDeferredChordSender()
+
+    sender.defer(el, send)
+    vi.advanceTimersByTime(TERMINAL_IME_DEFERRED_CHORD_ABANDON_MS - 1)
+    expect(send).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(2)
+    el.dispatchEvent(new Event('compositionend'))
+    vi.runAllTimers()
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('stops tracking a chord that already sent, so a later cancel is inert', () => {
+    const el = document.createElement('div')
+    const send = vi.fn()
+    const sender = createTerminalImeDeferredChordSender()
+
+    sender.defer(el, send)
+    el.dispatchEvent(new Event('compositionend'))
+    vi.advanceTimersByTime(0)
+    sender.cancelPending()
+    vi.runAllTimers()
+
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-chord.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-chord.ts
@@ -1,0 +1,51 @@
+import { sendTerminalInputAfterComposition } from './terminal-ime-deferred-newline'
+
+/**
+ * Ceiling on the otherwise indefinite wait. Generous enough for a conversion candidate window,
+ * which can stay open for seconds; a chord that outlives it is discarded rather than sent late,
+ * because firing mid-preedit is the corruption the wait exists to prevent (#12871).
+ */
+export const TERMINAL_IME_DEFERRED_CHORD_ABANDON_MS = 10_000
+
+export type TerminalImeDeferredChordSender = {
+  defer: (terminalElement: HTMLElement | null | undefined, send: () => void) => void
+  cancelPending: () => void
+}
+
+/**
+ * Owns every chord held for a live composition so blur and pane teardown can drop them. An
+ * unowned deferral has no exit when compositionend never arrives: its listeners outlive the pane
+ * and a later composition flushes the stale chord against a rebound terminal.
+ */
+export function createTerminalImeDeferredChordSender(): TerminalImeDeferredChordSender {
+  const pendingStops = new Set<() => void>()
+
+  return {
+    defer: (terminalElement, send) => {
+      let abandonTimer: number | undefined
+      let stopComposingWait: (() => void) | null = null
+      const stopWaiting = (): void => {
+        window.clearTimeout(abandonTimer)
+        pendingStops.delete(stopWaiting)
+        stopComposingWait?.()
+      }
+      abandonTimer = window.setTimeout(stopWaiting, TERMINAL_IME_DEFERRED_CHORD_ABANDON_MS)
+      pendingStops.add(stopWaiting)
+      stopComposingWait = sendTerminalInputAfterComposition(
+        terminalElement,
+        () => {
+          stopWaiting()
+          send()
+        },
+        { fallbackMs: null }
+      )
+    },
+    cancelPending: () => {
+      // Each stop removes itself; deleting the visited entry is safe for a Set iterator.
+      for (const stopWaiting of pendingStops) {
+        stopWaiting()
+      }
+      pendingStops.clear()
+    }
+  }
+}

--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.test.ts
@@ -6,7 +6,8 @@ import {
   createTerminalImeModifiedEnterChordOwner,
   isTerminalImeEnterKeyUp,
   isTerminalImeProcessEnter,
-  sendTerminalInputAfterComposition
+  sendTerminalInputAfterComposition,
+  TERMINAL_IME_DEFERRED_NEWLINE_FALLBACK_MS
 } from './terminal-ime-deferred-newline'
 import {
   installTerminalImeCompositionRoute,
@@ -53,6 +54,27 @@ describe('sendTerminalInputAfterComposition', () => {
     expect(send).toHaveBeenCalledTimes(1)
   })
 
+  // STA-4476: `fallbackMs: null` has no exit of its own, so the disposer is the only thing that
+  // can detach the listeners when compositionend never arrives.
+  it('detaches its listeners and never sends once disposed', () => {
+    const el = document.createElement('div')
+    const send = vi.fn()
+    const removeEventListener = vi.spyOn(el, 'removeEventListener')
+
+    const dispose = sendTerminalInputAfterComposition(el, send, { fallbackMs: null })
+    dispose()
+
+    expect(removeEventListener).toHaveBeenCalledWith('compositionend', expect.any(Function))
+    expect(removeEventListener).toHaveBeenCalledWith(
+      XTERM_COMPOSITION_SESSION_END_EVENT,
+      expect.any(Function)
+    )
+
+    el.dispatchEvent(new Event('compositionend'))
+    vi.runAllTimers()
+    expect(send).not.toHaveBeenCalled()
+  })
+
   it('falls back to sending when no compositionend arrives', () => {
     const el = document.createElement('div')
     const send = vi.fn()
@@ -61,6 +83,22 @@ describe('sendTerminalInputAfterComposition', () => {
     vi.runAllTimers()
 
     expect(send).toHaveBeenCalledTimes(1)
+  })
+
+  // STA-4476: why the Enter path needs no disposer of its own — its fallback always runs, so the
+  // listeners cannot outlive it even when the composition never ends.
+  it('detaches its listeners on the fallback, not only on compositionend', () => {
+    const el = document.createElement('div')
+    const removeEventListener = vi.spyOn(el, 'removeEventListener')
+
+    sendTerminalInputAfterComposition(el, vi.fn())
+    vi.advanceTimersByTime(TERMINAL_IME_DEFERRED_NEWLINE_FALLBACK_MS)
+
+    expect(removeEventListener).toHaveBeenCalledWith('compositionend', expect.any(Function))
+    expect(removeEventListener).toHaveBeenCalledWith(
+      XTERM_COMPOSITION_SESSION_END_EVENT,
+      expect.any(Function)
+    )
   })
 
   it('finishes from the captured xterm transaction when deferral starts after compositionend', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.ts
@@ -10,15 +10,19 @@ export const TERMINAL_IME_DEFERRED_NEWLINE_FALLBACK_MS = 200
  * right for it; a cursor chord arriving mid-preedit reproduces the corruption the wait exists to
  * prevent, and a conversion can hold its candidate window open for seconds. Dropping the chord
  * costs one keypress, firing early costs a mangled line.
+ *
+ * Returns a disposer that stops waiting without sending. An indefinite wait has no other exit, so
+ * a caller that can outlive the composition must hold it — otherwise the listeners stay on the
+ * terminal element and a later composition flushes the stale send.
  */
 export function sendTerminalInputAfterComposition(
   terminalElement: HTMLElement | null | undefined,
   send: () => void,
   options?: { fallbackMs?: number | null }
-): void {
+): () => void {
   if (!terminalElement) {
-    window.setTimeout(send, 0)
-    return
+    const immediateTimer = window.setTimeout(send, 0)
+    return () => window.clearTimeout(immediateTimer)
   }
 
   const fallbackMs =
@@ -27,7 +31,7 @@ export function sendTerminalInputAfterComposition(
       : (options?.fallbackMs ?? TERMINAL_IME_DEFERRED_NEWLINE_FALLBACK_MS)
   let done = false
 
-  const finish = (): void => {
+  const stopWaiting = (): void => {
     if (done) {
       return
     }
@@ -40,6 +44,13 @@ export function sendTerminalInputAfterComposition(
     if (fallbackTimer !== undefined) {
       window.clearTimeout(fallbackTimer)
     }
+  }
+
+  const finish = (): void => {
+    if (done) {
+      return
+    }
+    stopWaiting()
     // xterm flushes the committed glyph after compositionend.
     window.setTimeout(send, 0)
   }
@@ -54,6 +65,8 @@ export function sendTerminalInputAfterComposition(
   terminalElement.addEventListener('compositionend', onCompositionEnd)
   terminalElement.addEventListener(XTERM_COMPOSITION_SESSION_END_EVENT, onCompositionSessionEnd)
   const fallbackTimer = fallbackMs === null ? undefined : window.setTimeout(finish, fallbackMs)
+
+  return stopWaiting
 }
 
 export type TerminalImeDeferredNewlineSender = {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​199 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​198 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​76 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​66 |

<!-- /orca-pr-loc -->

Resolves **STA-4476**. Follow-up to #14730 (`a663f1b`), which is where the defect came from.

## The defect is worse than "a leak"

#14730 deferred a cursor chord until the composing syllable commits, and passed `fallbackMs: null` — no timer — because a fallback that fires mid-preedit reintroduces the very corruption the wait prevents.

But `finish()` was the only thing that removed the two listeners, and with no timer the only callers of `finish()` were those listeners themselves. If `compositionend` never arrives, they are never detached.

**They are not merely stranded — they stay armed.** The listeners live on the *terminal element*, which outlives the deferral, so the **next composition on that pane fires the stale chord**. `createCapturedInputSender`'s guards catch a rebound pty but not the same-pane/same-pty case, which is the common one.

Measured against the pre-fix `keyboard-handlers.ts`:

```
× drops the held chord and its listeners when the pane tears down
× drops the held chord and its listeners on blur
× abandons a chord whose composition never ends
  AssertionError: expected [ '다', '' ] to deeply equal [ '다' ]
```

`\x01` arriving **after unmount** is the stale send. An earlier ordering of the same tests showed the other half directly: `expected 2 to be 0` — two listeners retained per chord, permanently.

## The fix

`sendTerminalInputAfterComposition` now returns a disposer, and a small `terminal-ime-deferred-chord.ts` (51 lines) owns every pending chord.

- **Disposer** — `finish()` split into `stopWaiting()` (detach, no send) and `finish()` (`stopWaiting()` then send). That is the only behaviour change to the existing path.
- **Ownership** — `cancelPending()` is called from the two places that already clear this class of state: the native-only blur handler and the effect teardown, right beside `deferredNewlineSender.clearRedispatchedEnters()`.
- **Ceiling** — `TERMINAL_IME_DEFERRED_CHORD_ABANDON_MS = 10_000`, which **discards rather than sends**.

That last point is a deliberate divergence from the ticket's literal "bounded fallback": a fallback that *fires* at any bound reintroduces #12871 in a narrow window. Discarding preserves #14730's accepted trade — a dropped chord costs one keypress, an early one costs a line — while making the trade **bounded** instead of unbounded.

Why all three and not fewer: a disposer alone still strands a deferral when the pane stays alive and focused, which is reachable because `finishAfterPendingComposition` only completes when the pending-composition count is zero, and the composition route's `dispose()` zeroes that count without dispatching the session-end that would re-check it. A ceiling alone leaves the stale-chord window open for 10 s. Cancel-on-new-composition fixes neither teardown nor the never-ending case.

`keyboard-handlers.ts` moves 14 lines; the bookkeeping lives in its own module. No `max-lines` disable added and nothing bumped.

## The Enter path is clean — checked, not assumed

`deferredNewlineSender.defer` calls the helper with no options, so `fallbackMs` resolves to 200 and the timer is unconditional: `finish()` always runs, so those listeners cannot outlive 200 ms whatever the IME does. Added `detaches its listeners on the fallback, not only on compositionend` to pin it, since that timer is now the only thing keeping the path safe.

## #12871 stays fixed

The four original cases in `keyboard-handlers-ime-composing-chord.test.tsx` are unchanged and green, and `tests/e2e/terminal-korean-composing-chord-order.spec.ts` has a zero-byte diff against `origin/main`. I ran that e2e — **1 passed**, `다` before `\x01` at the pty.

## Verification

- `npm run typecheck` clean; oxlint and oxfmt clean on all six touched files
- **369 files / 3611 tests pass** in the terminal pane
- The three new integration cases and the two new unit specs all fail against the pre-fix file and pass with it — quoted above
- e2e `terminal-korean-composing-chord-order.spec.ts`: 1 passed

## One note for the record

The investigating agent measured 67 pre-existing failures in this tree and baselined them as unrelated. They were an artifact of its own worktree (missing `node_modules`, producing `TypeError: … reading 'dimensions'` under happy-dom). Re-run in a healthy checkout the same suite is fully green, and the e2e it could not build runs fine. Nothing in that baseline claim affects this change, but the number should not be quoted from the ticket.
