### PR TITLE
fix(browser): stop deleting page annotations on navigate/reload

### DIFF
--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -2652,8 +2652,6 @@ function BrowserPagePane({
   const deleteBrowserPageAnnotation = useAppStore((s) => s.deleteBrowserPageAnnotation)
   const clearBrowserPageAnnotations = useAppStore((s) => s.clearBrowserPageAnnotations)
   const recordFeatureInteraction = useAppStore((s) => s.recordFeatureInteraction)
-  const clearBrowserPageAnnotationsRef = useRef(clearBrowserPageAnnotations)
-  clearBrowserPageAnnotationsRef.current = clearBrowserPageAnnotations
   const createBrowserTab = useAppStore((s) => s.createBrowserTab)
   const consumeAddressBarFocusRequest = useAppStore((s) => s.consumeAddressBarFocusRequest)
   const browserSessionProfiles = useAppStore((s) => s.browserSessionProfiles)
@@ -3358,13 +3356,25 @@ function BrowserPagePane({
   const syncBrowserAnnotationViewportBridge = useCallback((): void => {
     const pendingAnnotationPayload = pendingAnnotationPayloadRef.current
     // Why: existing badges render in-guest for smooth scroll; only the pending dialog needs viewport messages.
-    const markers = browserAnnotationsRef.current.map((annotation, index) => ({
-      id: annotation.id,
-      index,
-      isFixed: annotation.payload.target.isFixed === true,
-      rectPage: annotation.payload.target.rectPage,
-      rectViewport: annotation.payload.target.rectViewport
-    }))
+    // Annotations are kept across navigation (see browser.ts setBrowserPageUrl) so a review pass across
+    // several pages doesn't lose earlier comments, but a rectPage/rectViewport captured on a different
+    // document is meaningless on the page that's loaded now — only draw markers for annotations whose
+    // captured URL still matches what's on screen; the rest stay in the tray/send payload, marker-free.
+    const currentUrl = browserTabUrlRef.current
+    // Why: `index` here must match the tray's numbering (which counts the full, unfiltered list) so the
+    // on-page badge and the tray row for the same annotation show the same number — filter after mapping,
+    // not before, or same-page annotations would renumber from 1 and drift from the tray.
+    const markers = browserAnnotationsRef.current
+      .map((annotation, index) => ({
+        id: annotation.id,
+        index,
+        isFixed: annotation.payload.target.isFixed === true,
+        rectPage: annotation.payload.target.rectPage,
+        rectViewport: annotation.payload.target.rectViewport,
+        sanitizedUrl: annotation.payload.page.sanitizedUrl
+      }))
+      .filter((marker) => marker.sanitizedUrl === currentUrl)
+      .map(({ sanitizedUrl: _sanitizedUrl, ...marker }) => marker)
     const enabled = isActiveRef.current && (pendingAnnotationPayload !== null || markers.length > 0)
     void window.api.browser
       .setAnnotationViewportBridge({
@@ -3599,8 +3609,12 @@ function BrowserPagePane({
     }
 
     const handleDidStartLoading = (): void => {
-      // Why: a reload replaces the document without changing the URL, invalidating captured element rects like a navigation does.
-      clearBrowserPageAnnotationsRef.current(browserTab.id)
+      // Why: a reload replaces the document without changing the URL, so a captured element rect can point
+      // at stale coordinates once the new DOM settles — the same-URL marker guard in
+      // syncBrowserAnnotationViewportBridge re-checks that on the next sync. This used to also delete every
+      // annotation for the whole tab outright (including ones from other pages, and the comment text itself,
+      // not just the position), which is exactly the kind of silent data loss a review-then-send workflow
+      // can't tolerate. Keep the data; only the pending in-progress annotation draft is reload-unsafe.
       setPendingAnnotationPayload(null)
       setBrowserOverlayViewport({ scrollX: 0, scrollY: 0, version: 0 })
       if (!trackNextLoadingEventRef.current) {
@@ -5555,8 +5569,24 @@ function BrowserPagePane({
                           <div className="mt-0.5 line-clamp-2 text-muted-foreground">
                             {annotation.comment}
                           </div>
-                          <div className="mt-1 text-[11px] text-muted-foreground">
+                          <div className="mt-1 flex items-center gap-1.5 text-[11px] text-muted-foreground">
                             <span>{annotation.intent}</span>
+                            {annotation.payload.page.sanitizedUrl !== browserTab.url ? (
+                              <span
+                                className="truncate"
+                                title={annotation.payload.page.sanitizedUrl}
+                              >
+                                {translate(
+                                  'auto.components.browser.pane.BrowserPane.annotationFromOtherPage',
+                                  '· from {{title}}',
+                                  {
+                                    title:
+                                      annotation.payload.page.title ||
+                                      annotation.payload.page.sanitizedUrl
+                                  }
+                                )}
+                              </span>
+                            ) : null}
                           </div>
                         </div>
                         <Button

--- a/src/renderer/src/components/browser-pane/browser-annotation-output.ts
+++ b/src/renderer/src/components/browser-pane/browser-annotation-output.ts
@@ -159,14 +159,22 @@ export function formatBrowserAnnotationsAsMarkdown(annotations: BrowserPageAnnot
 
   const firstAnnotation = annotations[0]
   const first = firstAnnotation.payload
-  const lines: string[] = [
-    `## Design Feedback: ${formatPageHeading(first)}`,
-    '',
-    `**URL:** ${first.page.sanitizedUrl}`,
-    `**Browser tab id:** ${firstAnnotation.browserPageId}`,
-    `**Viewport:** ${first.page.viewportWidth}x${first.page.viewportHeight}`,
-    ''
-  ]
+  // Why: annotations used to always share one page (navigating away cleared them), so a single top-level
+  // URL/viewport was accurate. They now survive navigation, so a batch can span several pages — fall back
+  // to a per-item "Page:" line whenever that's the case instead of asserting one URL for everything.
+  const spansMultiplePages = annotations.some(
+    (annotation) => annotation.payload.page.sanitizedUrl !== first.page.sanitizedUrl
+  )
+  const lines: string[] = spansMultiplePages
+    ? [`## Design Feedback (${annotations.length} items across multiple pages)`, '']
+    : [
+        `## Design Feedback: ${formatPageHeading(first)}`,
+        '',
+        `**URL:** ${first.page.sanitizedUrl}`,
+        `**Browser tab id:** ${firstAnnotation.browserPageId}`,
+        `**Viewport:** ${first.page.viewportWidth}x${first.page.viewportHeight}`,
+        ''
+      ]
 
   annotations.forEach((annotation, index) => {
     const { payload } = annotation
@@ -175,6 +183,10 @@ export function formatBrowserAnnotationsAsMarkdown(annotations: BrowserPageAnnot
     const styleLines = formatStyles(target.computedStyles)
 
     lines.push(`### ${index + 1}. ${annotationElementLabel(payload)}`)
+    if (spansMultiplePages) {
+      lines.push(`**Page:** ${payload.page.sanitizedUrl}`)
+      lines.push(`**Viewport:** ${payload.page.viewportWidth}x${payload.page.viewportHeight}`)
+    }
     lines.push(`**Intent:** ${annotation.intent}`)
     lines.push(`**Selector:** ${inlineCode(target.selector)}`)
     if (target.elementPath) {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14841,7 +14841,8 @@
             "6e776f9ef9": "Download failed",
             "756bfc25c9": "Open",
             "09a9489aa5": "Show",
-            "2a4c4b8e1f": "Copy"
+            "2a4c4b8e1f": "Copy",
+            "annotationFromOtherPage": "· from {{title}}"
           },
           "BrowserToolbarMenu": {
             "429ef481f9": "Cancel",

--- a/src/renderer/src/store/slices/browser.test.ts
+++ b/src/renderer/src/store/slices/browser.test.ts
@@ -149,7 +149,12 @@ describe('createBrowserSlice annotations', () => {
     })
   })
 
-  it('clears page annotations when the browser page URL changes', () => {
+  it('keeps page annotations when the browser page URL changes', () => {
+    // Why: annotations used to be deleted outright on any real navigation, silently discarding pending
+    // feedback for a user reviewing several pages before sending. They're page-scoped (browserPageId is
+    // stable across navigation within a tab), so there's no reason navigating should drop the data —
+    // only the on-page position marker becomes stale, which BrowserPane gates separately by comparing
+    // the annotation's captured URL against the currently loaded one.
     const store = createTestStore()
     const tab = store.getState().createBrowserTab('wt-1', 'https://example.com')
     const pageId = tab.activePageId
@@ -162,7 +167,11 @@ describe('createBrowserSlice annotations', () => {
 
     store.getState().setBrowserPageUrl(pageId, 'https://example.com/next')
 
-    expect(store.getState().browserAnnotationsByPageId[pageId]).toBeUndefined()
+    const annotations = store.getState().browserAnnotationsByPageId[pageId]
+    expect(annotations).toHaveLength(1)
+    // Why: the stored annotation still records the URL it was captured on, not the page's current URL —
+    // that's what lets marker rendering tell "still on this document" apart from "page moved on".
+    expect(annotations?.[0]?.payload.page.sanitizedUrl).toBe('https://example.com')
   })
 
   it('can commit a navigation URL without hiding an active recovery error', () => {

--- a/src/renderer/src/store/slices/browser.ts
+++ b/src/renderer/src/store/slices/browser.ts
@@ -1572,8 +1572,12 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
       if (!workspace) {
         return s
       }
-      // Why: annotations point at DOM coords of the loaded document; a real URL change invalidates those markers.
-      const shouldClearAnnotations = normalizeUrl(page.url) !== nextUrl
+      // Why: annotations used to be deleted outright on any real URL change, because their DOM-coordinate
+      // markers no longer apply to a different document. That silently discarded feedback for a user who
+      // clicks through several pages meaning to review/send everything at the end (see upstream report).
+      // We now keep the annotation (comment, target snippet, screenshot-free payload) and only stop
+      // rendering its on-page position marker once the page has moved on — see the pageId+URL guard in
+      // the marker-building effect below, which is the only other place that needs to know about this.
       const nextPages = (s.browserPagesByWorkspace[workspace.id] ?? []).map((entry) =>
         entry.id === pageId
           ? {
@@ -1586,12 +1590,6 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
           : entry
       )
       const nextWorkspace = mirrorWorkspaceFromActivePage(workspace, nextPages)
-      const nextBrowserAnnotationsByPageId = shouldClearAnnotations
-        ? { ...s.browserAnnotationsByPageId }
-        : s.browserAnnotationsByPageId
-      if (shouldClearAnnotations) {
-        delete nextBrowserAnnotationsByPageId[pageId]
-      }
       return {
         browserPagesByWorkspace: {
           ...s.browserPagesByWorkspace,
@@ -1602,10 +1600,7 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
           [workspace.worktreeId]: (s.browserTabsByWorktree[workspace.worktreeId] ?? []).map((tab) =>
             tab.id === workspace.id ? nextWorkspace : tab
           )
-        },
-        ...(shouldClearAnnotations
-          ? { browserAnnotationsByPageId: nextBrowserAnnotationsByPageId }
-          : {})
+        }
       }
     })
     get().setBrowserPageCertificateFailure(pageId, null)


### PR DESCRIPTION
## Summary

Browser annotations (the click-to-comment feedback tool on a live page in the browser pane) were being deleted outright any time the page's URL changed, and again on every reload — even though `browserPageId` stays stable across both. If you click through a few elements to leave feedback, navigate to another page to check something else, then come back meaning to review and send everything at the end, the earlier annotations are just gone with no warning.

## What changed

- `setBrowserPageUrl` in `browser.ts` no longer deletes `browserAnnotationsByPageId[pageId]` when the URL changes.
- `handleDidStartLoading` in `BrowserPane.tsx` no longer wipes every annotation for the tab on reload.
- The on-page position marker (`rectPage`/`rectViewport`) is still only meaningful for the currently loaded document, so `syncBrowserAnnotationViewportBridge` now only builds a marker for annotations whose captured `payload.page.sanitizedUrl` matches what's actually loaded. Index numbering is computed before filtering so the on-page badge number still matches the tray row number for the same annotation.
- The annotation tray now shows a small "· from <page title>" hint on entries captured on a different page than the one currently open, since those no longer disappear.
- `formatBrowserAnnotationsAsMarkdown` used to assume every annotation shared one page and printed a single top-level URL/viewport. It now detects a batch spanning multiple pages and switches to a per-item `**Page:**`/`**Viewport:**` line in that case; single-page batches are unchanged.
- Updated the one existing test that asserted the old delete-on-navigate behavior (`browser.test.ts`) to assert the data survives and still records its original capture URL.
- Ran `pnpm run sync:localization-catalog` for the new tray string.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm exec oxlint` on the changed files
- [x] `pnpm run verify:localization-catalog` / `verify:localization-extraction` / `verify:localization-coverage`
- [x] `pnpm run check:max-lines-ratchet`
- [x] `vitest run` — `browser.test.ts` (17/17) and the full `browser-pane`/`settings/BrowserPane` suite (47 files, 367/367)
- [x] Manual check in the app: click-annotate an element, navigate to another page, confirm the annotation is still in the tray and the count badge; reload the page and confirm the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)