### PR TITLE
fix(worktree): skip retirement backfill on every non-local host

### DIFF
--- a/src/main/worktree-name-retirement.test.ts
+++ b/src/main/worktree-name-retirement.test.ts
@@ -336,4 +336,60 @@ describe('ensureRetiredWorktreeNamesBackfilled', () => {
 
     expect(merged).toEqual([])
   })
+
+  it('skips a runtime-owned repo, which has no connectionId but is still not local', async () => {
+    // Why: a `connectionId` check calls this repo local, so the scan reads THIS machine's
+    // directories and files them under the runtime's namespace — retiring names never used there
+    // while missing the ones that were. The host id is the only reliable local test.
+    const root = await mkdtemp(join(tmpdir(), 'orca-retirement-runtime-'))
+    const workspaceRoot = join(root, 'workspaces')
+    await mkdir(join(workspaceRoot, FIRST), { recursive: true })
+    const merged: string[] = []
+    const store = {
+      mergeRetiredWorktreeNames: (_repoId: string, names: Iterable<string>) => {
+        merged.push(...names)
+        return true
+      }
+    }
+    const runtimeRepo = {
+      ...makeRepo('repo-runtime', '/repos/runtime'),
+      executionHostId: 'runtime:env-1'
+    } as Repo
+
+    try {
+      const collisionKey = await ensureRetiredWorktreeNamesBackfilled(store, runtimeRepo, {
+        workspaceDir: workspaceRoot,
+        nestWorkspaces: false
+      })
+
+      expect(merged).toEqual([])
+      expect(collisionKey).toBeNull()
+    } finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it('still backfills a plain local repo, so the skip is scoped to non-local hosts', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-retirement-local-'))
+    const workspaceRoot = join(root, 'workspaces')
+    await mkdir(join(workspaceRoot, FIRST), { recursive: true })
+    const merged: string[] = []
+    const store = {
+      mergeRetiredWorktreeNames: (_repoId: string, names: Iterable<string>) => {
+        merged.push(...names)
+        return true
+      }
+    }
+
+    try {
+      await ensureRetiredWorktreeNamesBackfilled(store, makeRepo('repo-local', '/repos/local'), {
+        workspaceDir: workspaceRoot,
+        nestWorkspaces: false
+      })
+
+      expect(merged).toEqual([FIRST])
+    } finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
 })

--- a/src/main/worktree-name-retirement.ts
+++ b/src/main/worktree-name-retirement.ts
@@ -1,7 +1,7 @@
 import { readdir } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
-import { getRepoExecutionHostId } from '../shared/execution-host'
+import { getRepoExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../shared/execution-host'
 import {
   creatureNameTier,
   EMPTY_RETIRED_NAME_REGISTRY,
@@ -239,8 +239,13 @@ export async function ensureRetiredWorktreeNamesBackfilled(
   settings: RetirementPathSettings
 ): Promise<string | null> {
   // Remote workspaces keep their agent state on the execution host, which this scan cannot see, so
-  // a re-added SSH repo does not recover its retirements the way a local one does.
-  if (isFolderRepo(repo) || repo.connectionId) {
+  // a re-added remote repo does not recover its retirements the way a local one does.
+  //
+  // Why the host id and not `connectionId`: a runtime-owned repo carries `executionHostId` with no
+  // `connectionId`, so a connectionId check calls it local, scans THIS machine's directories, and
+  // files the result under the runtime's namespace — retiring names never used there while missing
+  // the ones that were.
+  if (isFolderRepo(repo) || getRepoExecutionHostId(repo) !== LOCAL_EXECUTION_HOST_ID) {
     return null
   }
   const probePath = await computeWorktreePathAsync(


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​56 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​56 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​8 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 |

<!-- /orca-pr-loc -->

## ELI5

Follow-up to #14350. When Orca first learns which workspace names are already spent, it scans your computer's folders. For a workspace that actually runs on a *different* machine, it was still scanning this one — so it wrote down the wrong list of used names.

## What Changed

One guard in `ensureRetiredWorktreeNamesBackfilled`:

```diff
-if (isFolderRepo(repo) || repo.connectionId) {
+if (isFolderRepo(repo) || getRepoExecutionHostId(repo) !== LOCAL_EXECUTION_HOST_ID) {
```

Plus two tests: a runtime-owned repo is skipped, and a plain local repo still backfills (so the skip is scoped, not blanket).

## Why

`getRepoExecutionHostId` returns `executionHostId` when it is set, falling back to `connectionId` only when it is not. A **runtime-owned repo carries `executionHostId` with no `connectionId`**, so the old guard read it as local. The scan then walked this machine's workspace directory and agent-transcript buckets, and merged the result under the runtime host's namespace. Two ways that is wrong:

- **Under-retirement (the one that matters):** names genuinely spent on the runtime host are never discovered, so a pre-existing workspace there can still have its name reissued — the original bug #14350 set out to fix.
- **Over-retirement:** names from *this* machine get retired against the runtime host, burning pool entries that were never used there.

Scope is bounded: retirement at create time was already correct for these repos, because it records the name the host actually created. Only the one-time historical seed was wrong.

Raised by CodeRabbit on #14350 (`🗄️ Data Integrity`, Major) and left unresolved at merge. I verified the claim against merged `main` rather than taking it on faith — `getRepoExecutionHostId` at `src/shared/execution-host.ts:150-159` confirms the precedence.

**Why not the other `connectionId` checks in this module:** the remaining three (`getRetirementProbePath`, `getRemoteRetirementNamespaceKey`, and its two readers) select SSH-specific *path computation*, where `connectionId` is the correct discriminator rather than a general "is remote" test. Deliberately unchanged. Whether runtime-owned repos should also get the shared-namespace treatment that SSH repos get — so a re-added runtime repo recovers its retirements — is a separate design question, noted below.

## Linked Issue

Follow-up to #14350 (STA-4189).

Fixes #

## Visual Proof

`N/A` — no UI change. This only affects which names the host seeds into its registry.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Two tests in `src/main/worktree-name-retirement.test.ts`:

- *"skips a runtime-owned repo, which has no connectionId but is still not local"* — asserts nothing is merged and the returned collision key is null.
- *"still backfills a plain local repo, so the skip is scoped to non-local hosts"* — guards against over-correcting into a blanket skip.

**Red-before-green verified.** I reverted the guard to the merged version and confirmed the runtime test fails on `expect(merged).toEqual([])`, then restored the fix and confirmed it passes. Without that check the test would pass either way, since the local scan finds nothing when the fixture directory is empty.

Verified locally: 78 tests pass across the retirement and suggestion suites; `tsc --noEmit` clean on the node project; `oxlint` and `oxfmt` clean.

Platforms: developed and tested on **macOS**. The change is a host-id comparison with no platform-specific behavior.

## Review

- **Cross-platform**: no path handling changed.
- **Remote SSH**: behavior unchanged — SSH repos were already skipped via `connectionId`, and are still skipped via the host id.
- **Runtime-owned repos**: now skipped. Strictly better than scanning the wrong machine; their create-time retirement is unaffected.
- **Local repos**: unchanged, and pinned by a test.
- **Performance**: strictly less work — one fewer directory scan for non-local repos.
- **Backwards compatibility**: no persisted-format or wire change.

## Known gaps

- **A re-added runtime-owned repo does not recover its retirements.** SSH repos get a shared namespace registry for this; runtime-owned repos do not. Same class as the SSH backfill gap documented in #14350, and out of scope here.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
