### PR TITLE
fix(folder-workspaces): keep the broken-folder marker when a host sends a new reason

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-list/rows/FolderPathStatusIndicator.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/FolderPathStatusIndicator.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment happy-dom
+
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import type { FolderWorkspacePathStatus } from '../../../../../../shared/folder-workspace-path-status'
+import { FolderPathStatusIndicator } from './FolderPathStatusIndicator'
+
+// Why: the status is cast, not decoded, off the runtime RPC wire, so a newer host really can put a
+// reason this build has never heard of on the wire; the cast at the boundary is the point.
+function renderIndicator(reason: unknown): string {
+  const status = {
+    path: '/srv/scans',
+    exists: false,
+    reason
+  } as unknown as FolderWorkspacePathStatus
+  return renderToStaticMarkup(
+    <TooltipProvider>
+      <FolderPathStatusIndicator status={status} />
+    </TooltipProvider>
+  )
+}
+
+describe('FolderPathStatusIndicator', () => {
+  it('marks a folder missing for a declared reason', () => {
+    const markup = renderIndicator('missing')
+
+    expect(markup).toContain('aria-label="Folder not found"')
+    expect(markup).toContain('text-destructive')
+  })
+
+  // Why: losing the marker is worse than an imprecise one — the sidebar then renders a broken
+  // folder workspace as healthy, with nothing to click and nothing to read.
+  it('still renders the marker when a newer host sends an undeclared reason', () => {
+    const markup = renderIndicator('permission-denied')
+
+    expect(markup).not.toBe('')
+    expect(markup).toContain('aria-label="')
+    expect(markup).not.toContain('aria-label=""')
+    // Why: an imprecise label must not borrow a specific cause it cannot substantiate.
+    expect(markup).not.toContain('aria-label="Folder not found"')
+    // Why: unknown is not confirmed stale, so the marker stays neutral rather than destructive.
+    expect(markup).toContain('text-muted-foreground')
+  })
+
+  it('still renders the marker when the wire carries a non-string reason', () => {
+    const markup = renderIndicator(['missing'])
+
+    expect(markup).not.toBe('')
+    expect(markup).toContain('aria-label="')
+    expect(markup).not.toContain('aria-label=""')
+    // Why: hasOwn coerces its key, so ['missing'] must not be read as the confirmed-stale 'missing'.
+    expect(markup).not.toContain('aria-label="Folder not found"')
+  })
+
+  it('renders nothing for a healthy folder', () => {
+    const markup = renderToStaticMarkup(
+      <TooltipProvider>
+        <FolderPathStatusIndicator status={{ path: '/srv/scans', exists: true }} />
+      </TooltipProvider>
+    )
+
+    expect(markup).toBe('')
+  })
+})

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -697,13 +697,15 @@
           "missing": "Folder not found",
           "notDirectory": "Path is not a folder",
           "ambiguousConnection": "Cannot determine connection",
-          "unavailable": "Cannot check folder"
+          "unavailable": "Cannot check folder",
+          "unrecognized": "Folder is not usable"
         },
         "description": {
           "missing": "Orca cannot find {{path}}. Remove and re-import this folder workspace.",
           "notDirectory": "{{path}} exists, but it is not a folder.",
           "ambiguousConnection": "Orca cannot tell which SSH connection owns this folder scope.",
-          "unavailable": "Orca cannot verify this folder right now. Check the runtime or SSH connection and try again."
+          "unavailable": "Orca cannot verify this folder right now. Check the runtime or SSH connection and try again.",
+          "unrecognized": "Orca cannot use {{path}}, and this version does not recognize the reason. Update Orca to see the details."
         },
         "createError": {
           "title": {

--- a/src/renderer/src/lib/browser-cookie-import-toast.ts
+++ b/src/renderer/src/lib/browser-cookie-import-toast.ts
@@ -1,5 +1,6 @@
 import { toast } from 'sonner'
 import type { BrowserCookieImportSummary } from '../../../shared/browser-workspace-types'
+import { isHandledWireDiscriminant } from '../../../shared/handled-wire-discriminant'
 import { translate } from '@/i18n/i18n'
 
 type CookieImportWarning = NonNullable<BrowserCookieImportSummary['warning']>
@@ -20,19 +21,9 @@ const HANDLED_UNDECRYPTABLE_REASONS: Record<UndecryptableReason, true> = {
   unknown: true
 }
 
-// Why: typeof first — hasOwn coerces its key, so a host that widened `reason` to an array would
-// send ['unknown'], pass a hasOwn-only guard, then fall straight back out of the switch.
-function isHandledWarningCode(code: unknown): code is CookieImportWarningCode {
-  return typeof code === 'string' && Object.hasOwn(HANDLED_WARNING_CODES, code)
-}
-
-function isHandledUndecryptableReason(reason: unknown): reason is UndecryptableReason {
-  return typeof reason === 'string' && Object.hasOwn(HANDLED_UNDECRYPTABLE_REASONS, reason)
-}
-
 function formatCookieImportWarning(warning: CookieImportWarning): string {
   const code: unknown = warning.code
-  if (!isHandledWarningCode(code)) {
+  if (!isHandledWireDiscriminant(code, HANDLED_WARNING_CODES)) {
     return translate(
       'auto.lib.browser.cookie.import.toast.unrecognizedWarning',
       'The cookie import finished with a warning this version of Orca does not recognize. Update Orca to see the details, then check this profile before relying on its cookies.'
@@ -56,7 +47,7 @@ function formatCookieImportWarning(warning: CookieImportWarning): string {
           )
     case 'cookies-undecryptable': {
       const reason: unknown = warning.reason
-      if (!isHandledUndecryptableReason(reason)) {
+      if (!isHandledWireDiscriminant(reason, HANDLED_UNDECRYPTABLE_REASONS)) {
         return translate(
           'auto.lib.browser.cookie.import.toast.undecryptableUnrecognizedReason',
           '{{value0}} cookies could not be decrypted and were skipped for a reason this version of Orca does not recognize. Update Orca to see the details, then try the import again.',

--- a/src/renderer/src/lib/folder-workspace-path-status.test.ts
+++ b/src/renderer/src/lib/folder-workspace-path-status.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import type { FolderWorkspacePathStatus } from '../../../shared/folder-workspace-path-status'
+import {
+  getFolderWorkspacePathStatusDescription,
+  getFolderWorkspacePathStatusTitle
+} from './folder-workspace-path-status'
+
+// Why: the status crosses the runtime RPC wire and is cast, not decoded (`result: z.unknown()`), so
+// the cast at the test boundary is the point — a newer host really can put these on the wire.
+function wireStatus(reason: unknown): FolderWorkspacePathStatus {
+  return { path: '/srv/scans', exists: false, reason } as unknown as FolderWorkspacePathStatus
+}
+
+describe('getFolderWorkspacePathStatusTitle', () => {
+  it('keeps the declared reasons on their own copy', () => {
+    expect(getFolderWorkspacePathStatusTitle(wireStatus('missing'))).toBe('Folder not found')
+    expect(getFolderWorkspacePathStatusTitle(wireStatus('not-directory'))).toBe(
+      'Path is not a folder'
+    )
+    expect(getFolderWorkspacePathStatusTitle(wireStatus('ambiguous-connection'))).toBe(
+      'Cannot determine connection'
+    )
+    expect(getFolderWorkspacePathStatusTitle(wireStatus('unavailable'))).toBe('Cannot check folder')
+    expect(getFolderWorkspacePathStatusTitle(wireStatus(undefined))).toBe('Cannot check folder')
+  })
+
+  it('still titles a broken folder when a newer host sends an undeclared reason', () => {
+    const title = getFolderWorkspacePathStatusTitle(wireStatus('permission-denied'))
+
+    expect(typeof title).toBe('string')
+    expect(title).not.toBe('')
+  })
+
+  // Why: Object.hasOwn coerces its key, so ['missing'] passes a hasOwn-only guard and then falls
+  // straight back out of the switch — the exact P1 found in review on #15002.
+  it('does not admit a non-string reason through the membership guard', () => {
+    const title = getFolderWorkspacePathStatusTitle(wireStatus(['missing']))
+
+    expect(typeof title).toBe('string')
+    expect(title).not.toBe('')
+    expect(title).not.toBe('Folder not found')
+  })
+
+  it('stays silent for a healthy or absent status', () => {
+    expect(getFolderWorkspacePathStatusTitle(null)).toBeNull()
+    expect(getFolderWorkspacePathStatusTitle({ path: '/srv/scans', exists: true })).toBeNull()
+  })
+})
+
+describe('getFolderWorkspacePathStatusDescription', () => {
+  it('keeps the declared reasons on their own copy', () => {
+    expect(getFolderWorkspacePathStatusDescription(wireStatus('missing'))).toBe(
+      'Orca cannot find /srv/scans. Remove and re-import this folder workspace.'
+    )
+    expect(getFolderWorkspacePathStatusDescription(wireStatus(undefined))).toBe(
+      'Orca cannot verify this folder right now. Check the runtime or SSH connection and try again.'
+    )
+  })
+
+  it('still describes a broken folder when a newer host sends an undeclared reason', () => {
+    const description = getFolderWorkspacePathStatusDescription(wireStatus('permission-denied'))
+
+    expect(typeof description).toBe('string')
+    expect(description).not.toBe('')
+    expect(description).toContain('/srv/scans')
+  })
+
+  it('does not admit a non-string reason through the membership guard', () => {
+    const description = getFolderWorkspacePathStatusDescription(wireStatus(['missing']))
+
+    expect(typeof description).toBe('string')
+    expect(description).not.toBe('')
+    expect(description).not.toBe(
+      'Orca cannot find /srv/scans. Remove and re-import this folder workspace.'
+    )
+  })
+})

--- a/src/renderer/src/lib/folder-workspace-path-status.ts
+++ b/src/renderer/src/lib/folder-workspace-path-status.ts
@@ -1,12 +1,38 @@
 import { translate } from '@/i18n/i18n'
-import type { FolderWorkspacePathStatus } from '../../../shared/folder-workspace-path-status'
+import type {
+  FolderWorkspacePathStatus,
+  FolderWorkspacePathStatusReason
+} from '../../../shared/folder-workspace-path-status'
 import { blocksFolderWorkspaceActivation } from '../../../shared/folder-workspace-path-status'
+import { isHandledWireDiscriminant } from '../../../shared/handled-wire-discriminant'
+
+// Why: the status is cast, not decoded, off the runtime RPC wire, so a newer host can send a fifth
+// reason. The keys are the union itself, so a new member fails typecheck here and in both switches.
+const HANDLED_PATH_STATUS_REASONS: Record<FolderWorkspacePathStatusReason, true> = {
+  missing: true,
+  'not-directory': true,
+  unavailable: true,
+  'ambiguous-connection': true
+}
+
+// An absent reason is a handled case in both switches; anything else off the wire is not.
+function isHandledPathStatusReason(reason: unknown): boolean {
+  return reason === undefined || isHandledWireDiscriminant(reason, HANDLED_PATH_STATUS_REASONS)
+}
 
 export function getFolderWorkspacePathStatusTitle(
   status: FolderWorkspacePathStatus | null | undefined
 ): string | null {
   if (!status || status.exists) {
     return null
+  }
+  // Why: without this the switch matches nothing, returns undefined, and FolderPathStatusIndicator's
+  // `!title` check drops the whole marker — a broken folder workspace then renders as healthy.
+  if (!isHandledPathStatusReason(status.reason)) {
+    return translate(
+      'auto.lib.folderWorkspacePathStatus.title.unrecognized',
+      'Folder is not usable'
+    )
   }
   switch (status.reason) {
     case 'missing':
@@ -35,6 +61,13 @@ export function getFolderWorkspacePathStatusDescription(
 ): string | null {
   if (!status || status.exists) {
     return null
+  }
+  if (!isHandledPathStatusReason(status.reason)) {
+    return translate(
+      'auto.lib.folderWorkspacePathStatus.description.unrecognized',
+      'Orca cannot use {{path}}, and this version does not recognize the reason. Update Orca to see the details.',
+      { path: status.path }
+    )
   }
   switch (status.reason) {
     case 'missing':

--- a/src/shared/handled-wire-discriminant.test.ts
+++ b/src/shared/handled-wire-discriminant.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { isHandledWireDiscriminant } from './handled-wire-discriminant'
+
+const HANDLED: Record<'missing' | 'unavailable', true> = {
+  missing: true,
+  unavailable: true
+}
+
+describe('isHandledWireDiscriminant', () => {
+  it('admits the handled members', () => {
+    expect(isHandledWireDiscriminant('missing', HANDLED)).toBe(true)
+    expect(isHandledWireDiscriminant('unavailable', HANDLED)).toBe(true)
+  })
+
+  it('rejects a member this build has never heard of', () => {
+    expect(isHandledWireDiscriminant('permission-denied', HANDLED)).toBe(false)
+  })
+
+  // Why: Object.hasOwn coerces its key, so a guard typed (x: string) admits ['missing'] — whose
+  // toString matches a handled key — and the value then falls straight back out of the switch.
+  // This is the P1 found in review on #15002; it is the reason the parameter is `unknown`.
+  it('rejects a non-string the wire can carry', () => {
+    for (const value of [['missing'], null, undefined, 0, true, { missing: true }, Symbol('x')]) {
+      expect(isHandledWireDiscriminant(value, HANDLED), String(value)).toBe(false)
+    }
+  })
+
+  // Why: hasOwn, not `in` — inherited keys are not handled members.
+  it('does not admit inherited object keys', () => {
+    expect(isHandledWireDiscriminant('toString', HANDLED)).toBe(false)
+    expect(isHandledWireDiscriminant('constructor', HANDLED)).toBe(false)
+    expect(isHandledWireDiscriminant('__proto__', HANDLED)).toBe(false)
+  })
+})

--- a/src/shared/handled-wire-discriminant.ts
+++ b/src/shared/handled-wire-discriminant.ts
@@ -1,0 +1,15 @@
+// Why: runtime RPC results are cast, not decoded — `runtime-rpc-envelope` declares `result:
+// z.unknown()` — so a host on a newer build routinely puts a discriminant on the wire that this
+// build's union has never heard of, and a switch on it falls through to `undefined`.
+//
+// Callers pass a `Record<TheUnion, true>` so a new union member fails typecheck twice: on the Record
+// (TS2741) and on the switch (`switch-exhaustiveness-check`, which forbids an absorbing `default:`).
+//
+// typeof first: `Object.hasOwn` coerces its key, so a host that widened the field to an array sends
+// `['missing']`, which a hasOwn-only guard admits before the switch drops it straight back out.
+export function isHandledWireDiscriminant<T extends string>(
+  value: unknown,
+  handled: Record<T, true>
+): value is T {
+  return typeof value === 'string' && Object.hasOwn(handled, value)
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​176 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​176 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​56 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​15 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​41 |

<!-- /orca-pr-loc -->

## The defect

`FolderWorkspacePathStatus` reaches the renderer through a **cast, not a decode**. `src/shared/runtime-rpc-envelope.ts:26` declares `result: z.unknown()` inside the zod-validated success envelope, so `unwrapRuntimeRpcResult` hands back whatever the host sent as `TResult`. Both fetch sites — `src/renderer/src/store/slices/repos.ts:1658` and `:2580` — do `callRuntimeRpc<{ status: FolderWorkspacePathStatus }>(...)`. Clients and hosts update independently, so a newer host publishing a fifth `reason` reaching an older client is the normal state, not an edge case.

`getFolderWorkspacePathStatusTitle` and `getFolderWorkspacePathStatusDescription` switched on `status.reason` with no runtime guard. An unrecognized reason matched nothing and the functions returned `undefined`. `FolderPathStatusIndicator.tsx:20` then hits `if (!status || status.exists || !title) return null` — **the indicator does not render at all**, and a broken folder workspace shows as healthy in the sidebar.

That is worse than the blank-toast bug #15002 just fixed: there the warning was empty, here it is gone. The red run for the new component test prints `expected '' not to be ''` — the marker renders as literally empty markup on `main`.

Two more consumers of the same two functions were silently degraded by this: `worktree-activation.ts:95` (which has `??` fallbacks, so it degraded rather than vanished) and `folder-workspace-composer-path-status.ts:128` (whose `title && …` guard nulled the whole composer error). Fixing the source repairs all three.

## The fix

One shared guard, `isHandledWireDiscriminant` in `src/shared/handled-wire-discriminant.ts`, applied at all four switches — the two here, and the two `#15002` landed. #15002 had to hand-write its guard twice; this change would have made it four bespoke copies. Extracting it makes the lesson structural instead of tribal.

```ts
export function isHandledWireDiscriminant<T extends string>(
  value: unknown,
  handled: Record<T, true>
): value is T {
  return typeof value === 'string' && Object.hasOwn(handled, value)
}
```

**`typeof` first is load-bearing.** `Object.hasOwn` coerces its key, so a guard typed `(x: string)` accepts `['missing']`, whose `toString()` matches a handled key — and the value then falls straight back out of the switch, reintroducing the exact bug. That was the P1 found in review on #15002 after the author's own verification missed it. There is now one implementation of it that cannot drift.

**A `default:` arm is not available**, confirmed empirically here rather than assumed: injecting one into this file produces

```
src/renderer/src/lib/folder-workspace-path-status.ts:30:5: error typescript(switch-exhaustiveness-check):
The switch statement is exhaustive, so the default case is unnecessary.
```

because `config/oxlint-code-quality-type-aware.json` sets `allowDefaultCaseForExhaustiveSwitch: false`. A guard before the switch is the shape that satisfies both the lint rule and the wire.

A `readonly Reason[]` plus `Array.includes` is the other obvious shape, and it gets coercion-safety for free (`includes` uses SameValueZero, so an array is never equal to a string). It was rejected because it gives up the property that matters most here: `const X: readonly Reason[] = ['missing', ...]` compiles happily while missing a union member, so a fifth reason would land silently. The `Record<Union, true>` form makes a missing member a type error, and the explicit `typeof` check buys back the coercion safety the array form would have given.

**Adding a fifth reason still fails typecheck in two places.** Verified by temporarily widening the union:

```
folder-workspace-path-status.ts(11,7): error TS2741: Property '"permission-denied"' is missing in type
  '{ missing: true; 'not-directory': true; unavailable: true; 'ambiguous-connection': true; }'
  but required in type 'Record<FolderWorkspacePathStatusReason, true>'.
folder-workspace-path-status.ts(25,4): error TS2366: Function lacks ending return statement...
folder-workspace-path-status.ts(61,4): error TS2366: Function lacks ending return statement...
folder-workspace-path-status.ts:37:11: error typescript(switch-exhaustiveness-check): Switch is not exhaustive. Cases not matched: "permission-denied"
folder-workspace-path-status.ts:72:11: error typescript(switch-exhaustiveness-check): Switch is not exhaustive. Cases not matched: "permission-denied"
```

## Why new copy instead of reusing `unavailable`

Reusing the existing `unavailable` strings would have avoided two new keys, and that is a real cost. It loses on remedy accuracy, which matters more here:

- `unavailable`'s description is *"Orca cannot verify this folder right now. Check the runtime or SSH connection and try again."* But the host **did** verify — it returned `exists: false` with a definite reason. It is this client that cannot name it. Sending the user to inspect a healthy SSH connection and retry is a false lead that costs them time and does not fix anything.
- The actual remedy is to update Orca, which is also the remedy #15002 chose for the same situation.
- `STYLEGUIDE.md` requires displayed copy to be "concise and specific"; `Cannot check folder` is neither, applied to a folder the host checked.

New strings, following the `#15002` precedent:

- title `unrecognized`: **Folder is not usable**
- description `unrecognized`: **Orca cannot use {{path}}, and this version does not recognize the reason. Update Orca to see the details.**

The indicator still renders, and `isConfirmedStaleFolderPathStatus` returning `false` keeps it on the neutral `text-muted-foreground` style rather than the destructive one — an imprecise visible warning, which beats a silently missing one.

## `isConfirmedStaleFolderPathStatus` and `blocksFolderWorkspaceActivation` are safe, and here is why

Both consume the same cast value, but they are not the same class of exposure. The switches lost **all** output on a miss; these two have a well-defined `false` fallback that is exactly the behavior already chosen deliberately for `unavailable`.

- `isConfirmedStaleFolderPathStatus` returns `false` for an unrecognized reason. That is literally correct by the function's own contract: an unknown reason is by definition not *confirmed* stale. The only effect is that the indicator renders muted rather than destructive — the correct call when we cannot tell.
- `blocksFolderWorkspaceActivation` returns `false`, so activation stays permitted. This is deliberate fail-open, matching `unavailable` and absent-reason. Flipping it to fail-closed would lock a user out of a working folder workspace the moment a host adds a benign informational reason, and the operation would surface its own error anyway if the folder really is gone. Fail-open on activation plus fail-visible on the warning is the right split; this PR only had to repair the second half.

## An explicit `reason: null` stays in the unrecognized bucket, deliberately

`reason` is optional, so `null` is a shape a differently-implemented host could put on the wire. It is tempting to fold `null` in with `undefined`, but that would reintroduce the bug: TypeScript sees `reason` as `Reason | undefined`, so `case undefined:` does not match `null`, and a `null` admitted by the guard would fall straight back out of the switch. Routing `null` to the unrecognized copy is the shape that cannot fall through.

## Sweep for other switches on this wire

**In this defect's blast radius (fixed here):** the two switches in `folder-workspace-path-status.ts`. The other four readers of `FolderWorkspacePathStatus.reason` (`SectionHeader.tsx:73`, `folder-row.tsx:67`, `folder-workspace-composer-path-status.ts:118,124`, and the two shared predicates) are equality comparisons with a defined `false` branch, not switches — same fail-open reasoning as above.

**Found, out of scope, filed for follow-up:** `sshHealth` in `src/shared/execution-host-registry.ts:113` is a genuine same-class exposure on a different wire field. `SshConnectionState` arrives cast from `callRuntimeRpc<{ state: SshConnectionState | null }>` at `runtime-environment-ssh-state.ts:83` and `:278`. Its switch is exhaustive over eight `SshConnectionStatus` members plus `undefined`, with no guard, and its result is assigned straight into the non-nullable `health: ExecutionHostHealth` at `:278`. A ninth status from a newer host yields `health: undefined`, and `setHost`'s `if (existing.health !== 'disconnected') return` then prevents any later registration from upgrading it. Not fixed here — different feature, different wire field.

`runtimeControlHealth` at `:99` reads the same kind of wire value but is benign: its `undefined` is absorbed by `controlHealth ?? runtimeHealth(...)` at `:167`.

Checked and cleared — their discriminants are computed in the local main process or in-renderer, not published by a paired host: `external-automation-display.ts:37,50` (`ExternalAutomationRunStatus`, produced by the local external manager over `ipcRenderer.invoke`), `skill-install-result-label.ts:4`, `skill-freshness-scan-issues.tsx:5`, `project-skill-runtime.ts:66`, and `local-base-ref-refresh-toast.ts:9`.

## Tests

Each new wire test was proven red against `main`'s version of the **source** file only, with the test files untouched:

```
× still titles a broken folder when a newer host sends an undeclared reason
    AssertionError: expected 'undefined' to be 'string'
× does not admit a non-string reason through the membership guard
    AssertionError: expected 'undefined' to be 'string'
× still describes a broken folder when a newer host sends an undeclared reason
    AssertionError: expected 'undefined' to be 'string'
× does not admit a non-string reason through the membership guard
    AssertionError: expected 'undefined' to be 'string'
× still renders the marker when a newer host sends an undeclared reason
    AssertionError: expected '' not to be ''
× still renders the marker when the wire carries a non-string reason
    AssertionError: expected '' not to be ''
Tests  6 failed | 5 passed (11)
```

Green on this branch, together with #15002's unchanged tests — which is the proof that moving its two guards onto the shared helper kept behavior identical:

```
Test Files  6 passed (6)
     Tests  43 passed (43)
```

The `['missing']` cases are the P1 from #15002, now covered at both call sites and at the indicator.

`src/shared/handled-wire-discriminant.test.ts` pins the shared primitive's own contract, including the case none of the call-site tests reach: `Object.hasOwn`, not `in`, so `'toString'` / `'constructor'` / `'__proto__'` are not handled members.

The `typeof` check was mutation-tested rather than assumed. Replacing the helper body with `Object.hasOwn(handled, value as string)` fails six tests across all four call sites plus the helper's own:

```
× rejects a non-string the wire can carry
× still warns when a newer host sends the reason as an array
× still warns when a newer host sends the warning code as an array
× does not admit a non-string reason through the membership guard   (title)
× does not admit a non-string reason through the membership guard   (description)
× still renders the marker when the wire carries a non-string reason
Tests  6 failed | 19 passed (25)
```

## Gates

```
$ node config/scripts/check-changed-code-quality.mjs
code quality: 0 new finding(s) across 5 changed file(s).
type-aware code quality: 0 new finding(s) across 5 changed file(s).
React Doctor: 0 new finding(s) across 5 changed file(s).
Changed-code quality gate passed since 81d7f9b24eb3.

$ pnpm run typecheck            # node_modules/.bin/tsc verified present first
REAL EXIT CODE: 0

$ npx vitest run --config config/vitest.config.ts <affected>
Test Files  12 passed (12)
     Tests  83 passed (83)

$ pnpm run verify:localization-catalog        EXIT 0
$ pnpm run verify:localization-extraction     EXIT 0
$ pnpm run verify:localization-coverage       EXIT 0
Localization coverage check passed with 12 allowlisted candidates.
```

A follow-up worth noting for the composer: with the fix, `folder-workspace-composer-path-status.ts:128` now produces a non-null `pathStatusProjectError` for an unrecognized reason where it previously produced `null`. That surfaces as `invalid` styling plus a message on the project field (`NewWorkspaceComposerCard.tsx:704,707`) and does **not** newly block creation — `createDisabled` is driven by `pathStatusBlocksCreate`, which this PR does not touch. Verified by reading both consumers.

The first typecheck run caught a real error in the new `.tsx` test (`TS6133: 'React' is declared but its value is never read`), which is worth noting: `src/**/*.test.tsx` *is* typechecked, unlike `tests/`.
