### PR TITLE
fix(computer): preserve accessibility value types

### DIFF
--- a/native/computer-use-macos/Sources/OrcaComputerUseMacOS/main.swift
+++ b/native/computer-use-macos/Sources/OrcaComputerUseMacOS/main.swift
@@ -810,14 +810,31 @@ final class Provider {
         guard isSettable(record.element, kAXValueAttribute as String) else {
             throw ProviderError.coded("value_not_settable", "element \(record.index) is not settable")
         }
-        let result = AXUIElementSetAttributeValue(record.element, kAXValueAttribute as CFString, expected as CFString)
+        let current = rawAttributeValue(record.element, kAXValueAttribute as String)
+        let coercion = AttributeValueCoercion(existingValue: current, requested: expected)
+        let result: AXError
+        switch coercion.writeValue {
+        case .string:
+            result = AXUIElementSetAttributeValue(record.element, kAXValueAttribute as CFString, expected as CFString)
+        case let .integer(value):
+            result = AXUIElementSetAttributeValue(record.element, kAXValueAttribute as CFString, NSNumber(value: value))
+        case let .double(value):
+            result = AXUIElementSetAttributeValue(record.element, kAXValueAttribute as CFString, NSNumber(value: value))
+        case let .boolean(value):
+            result = AXUIElementSetAttributeValue(record.element, kAXValueAttribute as CFString, value ? kCFBooleanTrue : kCFBooleanFalse)
+        }
         guard result == .success else {
             throw ProviderError.coded("accessibility_error", "AXUIElementSetAttributeValue failed with \(result.rawValue)")
         }
-        let actual = rawStringAttribute(record.element, kAXValueAttribute as String)
-        let verification = actual == expected
-            ? verifiedAction(property: "value", expected: expected, actualPreview: actual)
-            : unverifiedAction(reason: actual == nil ? "provider_unavailable" : "value_mismatch", expected: expected, actualPreview: actual)
+        let verification: [String: Any]
+        switch coercion.compare(readback: rawAttributeValue(record.element, kAXValueAttribute as String)) {
+        case let .match(actualPreview):
+            verification = verifiedAction(property: "value", expected: expected, actualPreview: actualPreview)
+        case let .mismatch(actualPreview):
+            verification = unverifiedAction(reason: "value_mismatch", expected: expected, actualPreview: actualPreview)
+        case .unsupported:
+            verification = unverifiedAction(reason: "readback_unsupported", expected: expected)
+        }
         return actionMetadata(path: "accessibility", actionName: "AXSetValue", verification: verification)
     }
 
@@ -1495,14 +1512,19 @@ private func stringAttribute(_ element: AXUIElement, _ attribute: String) -> Str
 }
 
 private func rawStringAttribute(_ element: AXUIElement, _ attribute: String) -> String? {
-    var value: CFTypeRef?
-    guard AXUIElementCopyAttributeValue(element, attribute as CFString, &value) == .success,
-          let value,
-          CFGetTypeID(value) == CFStringGetTypeID()
+    guard let value = rawAttributeValue(element, attribute), CFGetTypeID(value) == CFStringGetTypeID()
     else {
         return nil
     }
     return value as? String
+}
+
+private func rawAttributeValue(_ element: AXUIElement, _ attribute: String) -> CFTypeRef? {
+    var value: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(element, attribute as CFString, &value) == .success else {
+        return nil
+    }
+    return value
 }
 
 private func boolAttribute(_ element: AXUIElement, _ attribute: String) -> Bool? {

--- a/native/computer-use-macos/Sources/OrcaComputerUseMacOSCore/AttributeValueCoercion.swift
+++ b/native/computer-use-macos/Sources/OrcaComputerUseMacOSCore/AttributeValueCoercion.swift
@@ -54,13 +54,7 @@ public struct AttributeValueCoercion: Equatable {
         case .string:
             return .string(requested)
         case .integer:
-            if let value = Int64(trimmed) {
-                return .integer(value)
-            }
-            guard let value = Double(trimmed), value.isFinite, let integer = Int64(exactly: value) else {
-                return nil
-            }
-            return .integer(integer)
+            return parseInteger(trimmed).map(Value.integer)
         case .double:
             guard let value = Double(trimmed), value.isFinite else { return nil }
             return .double(value)
@@ -76,6 +70,26 @@ public struct AttributeValueCoercion: Equatable {
         }
     }
 
+    private static func parseInteger(_ value: String) -> Int64? {
+        if let integer = Int64(value) {
+            return integer
+        }
+
+        let parts = value.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 2 else { return nil }
+        let whole = parts[0]
+        let fraction = parts[1]
+        let unsignedWhole = whole.first == "+" || whole.first == "-" ? whole.dropFirst() : whole[...]
+        guard !unsignedWhole.isEmpty || !fraction.isEmpty,
+              fraction.allSatisfy({ $0 == "0" })
+        else {
+            return nil
+        }
+
+        let normalized = unsignedWhole.isEmpty ? "\(whole)0" : String(whole)
+        return Int64(normalized)
+    }
+
     private static func decode(_ value: CFTypeRef) -> Value? {
         let typeID = CFGetTypeID(value)
         if typeID == CFStringGetTypeID() {
@@ -86,7 +100,8 @@ public struct AttributeValueCoercion: Equatable {
         }
         guard typeID == CFNumberGetTypeID() else { return nil }
 
-        let number = unsafeDowncast(value, to: CFNumber.self)
+        guard let bridgedNumber = value as? NSNumber else { return nil }
+        let number = bridgedNumber as CFNumber
         if CFNumberIsFloatType(number) {
             var decoded = 0.0
             guard CFNumberGetValue(number, .doubleType, &decoded), decoded.isFinite else { return nil }

--- a/native/computer-use-macos/Sources/OrcaComputerUseMacOSCore/AttributeValueCoercion.swift
+++ b/native/computer-use-macos/Sources/OrcaComputerUseMacOSCore/AttributeValueCoercion.swift
@@ -75,19 +75,69 @@ public struct AttributeValueCoercion: Equatable {
             return integer
         }
 
-        let parts = value.split(separator: ".", omittingEmptySubsequences: false)
-        guard parts.count == 2 else { return nil }
+        var unsigned = value[...]
+        let isNegative = unsigned.first == "-"
+        if isNegative || unsigned.first == "+" {
+            unsigned = unsigned.dropFirst()
+        }
+
+        let exponentIndex = unsigned.firstIndex { $0 == "e" || $0 == "E" }
+        let significand = exponentIndex.map { unsigned[..<$0] } ?? unsigned
+        let exponentText = exponentIndex.map { unsigned[unsigned.index(after: $0)...] }
+        guard exponentText?.contains(where: { $0 == "e" || $0 == "E" }) != true else { return nil }
+
+        let exponent: Int?
+        if let exponentText {
+            let digits = exponentText.first == "+" || exponentText.first == "-"
+                ? exponentText.dropFirst()
+                : exponentText
+            guard !digits.isEmpty, digits.utf8.allSatisfy({ $0 >= 48 && $0 <= 57 }) else {
+                return nil
+            }
+            exponent = Int(exponentText)
+        } else {
+            exponent = 0
+        }
+
+        let parts = significand.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count <= 2 else { return nil }
         let whole = parts[0]
-        let fraction = parts[1]
-        let unsignedWhole = whole.first == "+" || whole.first == "-" ? whole.dropFirst() : whole[...]
-        guard !unsignedWhole.isEmpty || !fraction.isEmpty,
-              fraction.allSatisfy({ $0 == "0" })
+        let fraction = parts.count == 2 ? parts[1] : Substring()
+        guard !whole.isEmpty || !fraction.isEmpty,
+              whole.utf8.allSatisfy({ $0 >= 48 && $0 <= 57 }),
+              fraction.utf8.allSatisfy({ $0 >= 48 && $0 <= 57 })
         else {
             return nil
         }
 
-        let normalized = unsignedWhole.isEmpty ? "\(whole)0" : String(whole)
-        return Int64(normalized)
+        let digits = whole + fraction
+        let significant = digits.drop(while: { $0 == "0" })
+        guard !significant.isEmpty else { return 0 }
+        guard let exponent else { return nil }
+
+        let trailingZeroCount = significant.reversed().prefix(while: { $0 == "0" }).count
+        let normalized: String
+        if exponent >= fraction.count {
+            let zeroCount = exponent - fraction.count
+            guard significant.count <= 19, zeroCount <= 19 - significant.count else { return nil }
+            normalized = String(significant) + String(repeating: "0", count: zeroCount)
+        } else {
+            let removedCount: Int
+            if exponent >= 0 {
+                removedCount = fraction.count - exponent
+            } else {
+                guard fraction.count <= trailingZeroCount,
+                      exponent.magnitude <= UInt(trailingZeroCount - fraction.count)
+                else {
+                    return nil
+                }
+                removedCount = fraction.count + Int(exponent.magnitude)
+            }
+            guard removedCount <= trailingZeroCount else { return nil }
+            normalized = String(significant.dropLast(removedCount))
+        }
+
+        return Int64(isNegative ? "-\(normalized)" : normalized)
     }
 
     private static func decode(_ value: CFTypeRef) -> Value? {

--- a/native/computer-use-macos/Sources/OrcaComputerUseMacOSCore/AttributeValueCoercion.swift
+++ b/native/computer-use-macos/Sources/OrcaComputerUseMacOSCore/AttributeValueCoercion.swift
@@ -1,0 +1,100 @@
+import CoreFoundation
+import Foundation
+
+public struct AttributeValueCoercion: Equatable {
+    public enum Value: Equatable {
+        case string(String)
+        case integer(Int64)
+        case double(Double)
+        case boolean(Bool)
+
+        public var preview: String {
+            switch self {
+            case let .string(value):
+                return value
+            case let .integer(value):
+                return String(value)
+            case let .double(value):
+                return String(value)
+            case let .boolean(value):
+                return String(value)
+            }
+        }
+    }
+
+    public enum ReadbackComparison: Equatable {
+        case match(actualPreview: String)
+        case mismatch(actualPreview: String)
+        case unsupported
+    }
+
+    public let writeValue: Value
+
+    public init(existingValue: CFTypeRef?, requested: String) {
+        guard let existingValue, let current = Self.decode(existingValue) else {
+            writeValue = .string(requested)
+            return
+        }
+
+        writeValue = Self.coerce(requested, matching: current) ?? .string(requested)
+    }
+
+    public func compare(readback: CFTypeRef?) -> ReadbackComparison {
+        guard let readback, let actual = Self.decode(readback) else {
+            return .unsupported
+        }
+        return actual == writeValue
+            ? .match(actualPreview: actual.preview)
+            : .mismatch(actualPreview: actual.preview)
+    }
+
+    private static func coerce(_ requested: String, matching current: Value) -> Value? {
+        let trimmed = requested.trimmingCharacters(in: .whitespacesAndNewlines)
+        switch current {
+        case .string:
+            return .string(requested)
+        case .integer:
+            if let value = Int64(trimmed) {
+                return .integer(value)
+            }
+            guard let value = Double(trimmed), value.isFinite, let integer = Int64(exactly: value) else {
+                return nil
+            }
+            return .integer(integer)
+        case .double:
+            guard let value = Double(trimmed), value.isFinite else { return nil }
+            return .double(value)
+        case .boolean:
+            switch trimmed.lowercased() {
+            case "true", "1":
+                return .boolean(true)
+            case "false", "0":
+                return .boolean(false)
+            default:
+                return nil
+            }
+        }
+    }
+
+    private static func decode(_ value: CFTypeRef) -> Value? {
+        let typeID = CFGetTypeID(value)
+        if typeID == CFStringGetTypeID() {
+            return (value as? String).map(Value.string)
+        }
+        if typeID == CFBooleanGetTypeID() {
+            return (value as? Bool).map(Value.boolean)
+        }
+        guard typeID == CFNumberGetTypeID() else { return nil }
+
+        let number = unsafeDowncast(value, to: CFNumber.self)
+        if CFNumberIsFloatType(number) {
+            var decoded = 0.0
+            guard CFNumberGetValue(number, .doubleType, &decoded), decoded.isFinite else { return nil }
+            return .double(decoded)
+        }
+
+        var decoded: Int64 = 0
+        guard CFNumberGetValue(number, .sInt64Type, &decoded) else { return nil }
+        return .integer(decoded)
+    }
+}

--- a/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/AttributeValueCoercionTests.swift
+++ b/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/AttributeValueCoercionTests.swift
@@ -1,0 +1,90 @@
+import CoreFoundation
+import Foundation
+import XCTest
+@testable import OrcaComputerUseMacOSCore
+
+final class AttributeValueCoercionTests: XCTestCase {
+    func testStringValueRemainsAStringWithoutTrimming() {
+        let coercion = AttributeValueCoercion(existingValue: "old" as CFString, requested: "  new  ")
+
+        XCTAssertEqual(coercion.writeValue, .string("  new  "))
+    }
+
+    func testIntegerValuePreservesIntegerKind() {
+        let coercion = AttributeValueCoercion(existingValue: NSNumber(value: Int32(2)), requested: "3.0")
+
+        XCTAssertEqual(coercion.writeValue, .integer(3))
+    }
+
+    func testDoubleValuePreservesDoubleKindForIntegralInput() {
+        let coercion = AttributeValueCoercion(existingValue: NSNumber(value: 2.5), requested: "3")
+
+        XCTAssertEqual(coercion.writeValue, .double(3.0))
+    }
+
+    func testBooleanValueAcceptsWordsAndNumericAliases() {
+        XCTAssertEqual(
+            AttributeValueCoercion(existingValue: kCFBooleanFalse, requested: "TRUE").writeValue,
+            .boolean(true)
+        )
+        XCTAssertEqual(
+            AttributeValueCoercion(existingValue: kCFBooleanTrue, requested: "0").writeValue,
+            .boolean(false)
+        )
+    }
+
+    func testUnreadableAndUnhandledValuesUseStringFallback() {
+        XCTAssertEqual(
+            AttributeValueCoercion(existingValue: nil, requested: "7").writeValue,
+            .string("7")
+        )
+        XCTAssertEqual(
+            AttributeValueCoercion(existingValue: [1, 2] as CFArray, requested: "7").writeValue,
+            .string("7")
+        )
+    }
+
+    func testInvalidHandledValuesUseStringFallback() {
+        XCTAssertEqual(
+            AttributeValueCoercion(existingValue: NSNumber(value: 2), requested: "2.5").writeValue,
+            .string("2.5")
+        )
+        XCTAssertEqual(
+            AttributeValueCoercion(existingValue: NSNumber(value: 2.5), requested: "many").writeValue,
+            .string("many")
+        )
+        XCTAssertEqual(
+            AttributeValueCoercion(existingValue: kCFBooleanFalse, requested: "maybe").writeValue,
+            .string("maybe")
+        )
+    }
+
+    func testReadbackMatchesEachSupportedType() {
+        let cases: [(AttributeValueCoercion, CFTypeRef, String)] = [
+            (AttributeValueCoercion(existingValue: "old" as CFString, requested: "new"), "new" as CFString, "new"),
+            (AttributeValueCoercion(existingValue: NSNumber(value: 1), requested: "2"), NSNumber(value: 2), "2"),
+            (AttributeValueCoercion(existingValue: NSNumber(value: 1.5), requested: "2.5"), NSNumber(value: 2.5), "2.5"),
+            (AttributeValueCoercion(existingValue: kCFBooleanFalse, requested: "true"), kCFBooleanTrue, "true"),
+        ]
+
+        for (coercion, readback, preview) in cases {
+            XCTAssertEqual(coercion.compare(readback: readback), .match(actualPreview: preview))
+        }
+    }
+
+    func testSupportedMismatchedReadbackIncludesActualPreview() {
+        let coercion = AttributeValueCoercion(existingValue: NSNumber(value: 1), requested: "2")
+
+        XCTAssertEqual(
+            coercion.compare(readback: NSNumber(value: 3)),
+            .mismatch(actualPreview: "3")
+        )
+    }
+
+    func testUnreadableAndUnhandledReadbackAreUnsupported() {
+        let coercion = AttributeValueCoercion(existingValue: "old" as CFString, requested: "new")
+
+        XCTAssertEqual(coercion.compare(readback: nil), .unsupported)
+        XCTAssertEqual(coercion.compare(readback: ["new"] as CFArray), .unsupported)
+    }
+}

--- a/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/AttributeValueCoercionTests.swift
+++ b/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/AttributeValueCoercionTests.swift
@@ -29,6 +29,49 @@ final class AttributeValueCoercionTests: XCTestCase {
         )
     }
 
+    func testIntegerScientificNotationIsParsedExactly() {
+        let cases: [(String, Int64)] = [
+            ("1e3", 1_000),
+            ("9.007199254740993e15", 9_007_199_254_740_993),
+            ("10.0e-1", 1),
+            ("+0.000E999999999999999999999", 0),
+            ("-.0e-999999999999999999999", 0),
+        ]
+
+        for (requested, expected) in cases {
+            XCTAssertEqual(
+                AttributeValueCoercion(existingValue: NSNumber(value: 1), requested: requested).writeValue,
+                .integer(expected)
+            )
+        }
+    }
+
+    func testIntegerParsingPreservesInt64Boundaries() {
+        XCTAssertEqual(
+            AttributeValueCoercion(
+                existingValue: NSNumber(value: 1),
+                requested: "9223372036854775807.0"
+            ).writeValue,
+            .integer(.max)
+        )
+        XCTAssertEqual(
+            AttributeValueCoercion(
+                existingValue: NSNumber(value: 1),
+                requested: "-9.223372036854775808e18"
+            ).writeValue,
+            .integer(.min)
+        )
+    }
+
+    func testNonIntegralAndOutOfRangeIntegerFormsUseStringFallback() {
+        for requested in ["1e-1", "9223372036854775808", "-9223372036854775809", "1e999999999999999999999"] {
+            XCTAssertEqual(
+                AttributeValueCoercion(existingValue: NSNumber(value: 1), requested: requested).writeValue,
+                .string(requested)
+            )
+        }
+    }
+
     func testDoubleValuePreservesDoubleKindForIntegralInput() {
         let coercion = AttributeValueCoercion(existingValue: NSNumber(value: 2.5), requested: "3")
 

--- a/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/AttributeValueCoercionTests.swift
+++ b/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/AttributeValueCoercionTests.swift
@@ -16,6 +16,19 @@ final class AttributeValueCoercionTests: XCTestCase {
         XCTAssertEqual(coercion.writeValue, .integer(3))
     }
 
+    func testIntegerDecimalConversionIsExactAboveDoublePrecision() {
+        let coercion = AttributeValueCoercion(
+            existingValue: NSNumber(value: Int64(1)),
+            requested: "9007199254740993.0"
+        )
+
+        XCTAssertEqual(coercion.writeValue, .integer(9_007_199_254_740_993))
+        XCTAssertEqual(
+            coercion.compare(readback: NSNumber(value: Int64(9_007_199_254_740_992))),
+            .mismatch(actualPreview: "9007199254740992")
+        )
+    }
+
     func testDoubleValuePreservesDoubleKindForIntegralInput() {
         let coercion = AttributeValueCoercion(existingValue: NSNumber(value: 2.5), requested: "3")
 

--- a/src/shared/computer-use-runtime-types.ts
+++ b/src/shared/computer-use-runtime-types.ts
@@ -107,6 +107,7 @@ export type ComputerActionVerification =
         | 'synthetic_input'
         | 'clipboard_paste'
         | 'provider_unavailable'
+        | 'readback_unsupported'
         | 'window_changed'
         | 'value_mismatch'
       expected?: string | null


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​146 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​146 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​197 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​188 |

<!-- /orca-pr-loc -->

## ELI5

The set-value action now writes the same kind of value that a control already exposes, so numeric and boolean controls do not receive text by mistake.

## What Changed

- Added a pure Core coercion table for strings, integer and floating-point numbers, and booleans, with type-aware readback comparison.
- Changed setValue ordering to confirm the attribute is settable, pre-read its current value type, coerce, write, and then verify with the same type model.
- Preserved the previous CFString write exactly for unreadable pre-reads, unsupported types, and values that cannot be coerced. Wrapper value types remain on this total fallback path.
- Added readback_unsupported as the honest verification reason when a readback cannot be interpreted.

## Why

The root cause had two halves: setValue always wrote the requested value as CFString, regardless of the existing attribute type, and readback only accepted CFString. A numeric control could accept the setter call while ignoring or coercing the text, after which the string-only reader returned nil for its CFNumber and incorrectly reported provider_unavailable.

## Linked Issue

N/A — implements reviewed observability plan item 7; no linked issue was supplied.

## Visual Proof

N/A — this changes native value coercion and verification metadata, with no rendered UI change.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Commands run:

- cd native/computer-use-macos && swift test
- pnpm verify:computer-native
- pnpm typecheck
- npx oxlint on all changed files

The new Core tests cover string, integer, floating-point, and boolean writes; integer-versus-floating-point preservation; total string fallback; matching and mismatching readbacks; and unsupported readbacks. These are forward gates for newly extracted logic and therefore cannot be red before the fix.

Fixture-type finding: the settable browser number-input field exposes kAXValueAttribute as CFString. Its nested incrementor exposes CFNumber but is not settable, so this fixture has no reachable settable CFNumber target. I did not add an end-to-end test because it would exercise the old string path and pass before the fix, making it vacuous for the numeric bug; numeric correctness is covered by the Core tests only.

## Review

The pre-read adds one accessibility round trip per explicit set-value action. Read side effects on unusual controls remain unverified, while the settable guard ensures the pre-read never touches non-settable elements. Increment and decrement action driving remains deliberately out of scope.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows docs/reference/agent-skill-sharing-upstream-boundary.md and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

This is a macOS-native implementation change. Other platforms, paths, shortcuts, folder workspaces, SSH execution, and provider-specific review behavior are unchanged. The new reason is a compile-time-only union member and existing rendering is generic.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why, including ELI5
- [x] Visual proof is marked N/A with the reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and backwards-compatibility impact considered
- [ ] Full pnpm lint, pnpm test, and pnpm build are left to CI; the required targeted checks above pass

## Author

- X / Twitter: @BrennanKB5