### PR TITLE
fix(native-chat): scope optimistic echoes to the conversation they were sent into

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatView.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatView.tsx
@@ -19,20 +19,12 @@ import {
 } from './native-chat-working-suppression'
 import {
   applyCommandMarkerBoundaries,
-  appendPendingSendCache,
   commandMarkersAsMessages,
-  appendCommandMarkerCache,
   launchPromptAsMessage,
   pendingSendsAsMessages,
-  nextNativeChatPendingSendId,
-  prunePendingSends,
-  readCommandMarkerCache,
-  readPendingSendCache,
-  shouldPruneLaunchPrompt,
-  writePendingSendCache,
-  type NativeChatCommandMarker,
-  type NativeChatPendingSend
+  shouldPruneLaunchPrompt
 } from './native-chat-pending'
+import { useNativeChatPendingEchoes } from './use-native-chat-pending-echoes'
 import {
   deriveNativeChatStreamingText,
   nativeChatStreamingMessage
@@ -184,79 +176,33 @@ function NativeChatResolvedView({
   })
 
   // Optimistic "queued" sends (mobile parity): a composer send is echoed
-  // immediately and pruned once its real user turn lands in the transcript, so
-  // the message never vanishes between send and transcript catch-up.
-  const commandMarkerScope = useMemo(
-    () => ({ paneKey, agent, sessionId }),
-    [paneKey, agent, sessionId]
-  )
-  const pendingScope = useMemo(() => ({ paneKey, agent }), [paneKey, agent])
-  const [pending, setPending] = useState<NativeChatPendingSend[]>(() =>
-    readPendingSendCache(pendingScope)
-  )
-  // Slash commands aren't chat turns, so they get a small local "Ran /clear"
-  // system line instead of a user bubble. Capped + cached per conversation.
-  const [commandMarkers, setCommandMarkers] = useState<NativeChatCommandMarker[]>(() =>
-    readCommandMarkerCache(commandMarkerScope)
-  )
-  // Reset the optimistic queue only when the pane/agent changes. A fresh launch
-  // often learns its provider session id after the first send; clearing pending
-  // on that transition briefly flashes the empty state before the transcript
-  // user turn lands.
+  // immediately and retired once its real user turn lands in the transcript, so
+  // the message never vanishes between send and transcript catch-up. Scoped to
+  // the conversation it was sent into, so replacing that conversation leaves it
+  // unreachable rather than pinned at the list tail.
+  const {
+    pending,
+    commandMarkers,
+    onOptimisticSend,
+    onOptimisticSendCanceled,
+    onSlashCommand,
+    clearPendingSends
+  } = useNativeChatPendingEchoes({ paneKey, agent, sessionId, messages: session.messages })
   useEffect(() => {
-    setPending(readPendingSendCache(pendingScope))
     setWorkingInterrupted(false)
-  }, [pendingScope])
-  // Command markers are session-scoped because slash commands like /clear are
-  // local feedback for a specific transcript boundary.
-  useEffect(() => {
-    setCommandMarkers(readCommandMarkerCache(commandMarkerScope))
-    setWorkingInterrupted(false)
-  }, [commandMarkerScope])
-  // Prune echoes whose real user turn is now in the transcript.
-  useEffect(() => {
-    setPending((prev) =>
-      writePendingSendCache(pendingScope, prunePendingSends(prev, session.messages))
-    )
-  }, [session.messages, pendingScope])
+  }, [paneKey, agent, sessionId])
   useEffect(() => {
     if (!paneLaunchPrompt || !shouldPruneLaunchPrompt(paneLaunchPrompt, session.messages)) {
       return
     }
     clearNativeChatLaunchPrompt(terminalTabId)
   }, [clearNativeChatLaunchPrompt, paneLaunchPrompt, session.messages, terminalTabId])
-  const onOptimisticSend = useCallback(
+  const submitOptimisticSend = useCallback(
     (text: string, imagePaths?: string[]) => {
       setWorkingInterrupted(false)
-      const sentAt = Date.now()
-      const boundary = session.messages.at(-1)
-      const entry: NativeChatPendingSend = {
-        id: nextNativeChatPendingSendId(sentAt),
-        text,
-        sentAt,
-        afterMessageId: boundary?.id ?? null,
-        afterMessageTimestamp: boundary?.timestamp ?? null,
-        ...(imagePaths ? { imagePaths } : {})
-      }
-      setPending(appendPendingSendCache(pendingScope, entry))
-      return entry.id
+      return onOptimisticSend(text, imagePaths)
     },
-    [pendingScope, session.messages]
-  )
-  const onOptimisticSendCanceled = useCallback(
-    (pendingId: string) => {
-      // Why: detach/interrupt cancels the delayed Enter, so its optimistic echo
-      // must not come back from the pane cache as a prompt that was delivered.
-      const next = readPendingSendCache(pendingScope).filter((entry) => entry.id !== pendingId)
-      setPending(writePendingSendCache(pendingScope, next))
-    },
-    [pendingScope]
-  )
-  const onSlashCommand = useCallback(
-    (command: string) => {
-      setCommandMarkers(appendCommandMarkerCache(commandMarkerScope, command))
-    },
-    [commandMarkerScope]
+    [onOptimisticSend]
   )
 
   const launchPromptMessage = useMemo(
@@ -349,9 +295,9 @@ function NativeChatResolvedView({
     // Why: Stop after a submitted turn drops the delayed-write handle once it
     // settles, so cancelPendingSends no longer sees the optimistic id. Clear
     // the echo cache here so a cancelled prompt cannot stick as a ghost bubble.
-    setPending(writePendingSendCache(pendingScope, []))
+    clearPendingSends()
     interactiveSend.cancel()
-  }, [interactiveSend, pendingScope])
+  }, [interactiveSend, clearPendingSends])
   const nativeChatFileLinkClick = useNativeChatFileLinkClick(fileLinkContext)
 
   // Chat-only font zoom via Cmd/Ctrl +/-/0, gated to the live conversation so
@@ -439,7 +385,7 @@ function NativeChatResolvedView({
           canSend={canSend}
           isWorking={isWorking}
           onStop={stopAgent}
-          onOptimisticSend={onOptimisticSend}
+          onOptimisticSend={submitOptimisticSend}
           onOptimisticSendCanceled={onOptimisticSendCanceled}
           onSlashCommand={onSlashCommand}
           onSwitchToTerminal={onSwitchToTerminal}

--- a/src/renderer/src/components/native-chat/native-chat-pending-conversation.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending-conversation.test.ts
@@ -144,4 +144,17 @@ describe('claimBootstrapPendingSends', () => {
 
     expect(readPendingSendCache(scopeOf('session-b'))).toEqual([])
   })
+
+  it('stays closed after many other panes bind', () => {
+    appendPendingSendCache(bootstrapScope, send('p1', 'first prompt', 10))
+    claimBootstrapPendingSends(scopeOf('session-a'), [])
+    appendPendingSendCache(bootstrapScope, send('p2', 'post-bootstrap prompt', 20))
+
+    for (let index = 0; index < 129; index += 1) {
+      claimBootstrapPendingSends(scopeOf(`other-${index}`, `other-pane-${index}`), [])
+    }
+    claimBootstrapPendingSends(scopeOf('session-b'), [])
+
+    expect(textsIn(scopeOf('session-b'))).toEqual([])
+  })
 })

--- a/src/renderer/src/components/native-chat/native-chat-pending-conversation.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending-conversation.test.ts
@@ -79,13 +79,13 @@ describe('claimBootstrapPendingSends', () => {
     expect(readPendingSendCache(bootstrapScope)).toEqual([])
   })
 
-  it('appends to the claiming conversation rather than replacing its own echoes', () => {
+  it('merges into the claiming conversation by send time, keeping its own echoes', () => {
     appendPendingSendCache(bootstrapScope, send('p1', 'pre-identity prompt', 10))
     appendPendingSendCache(scopeOf('session-a'), send('p2', 'already scoped prompt', 20))
 
     claimBootstrapPendingSends(scopeOf('session-a'), [])
 
-    expect(textsIn(scopeOf('session-a'))).toEqual(['already scoped prompt', 'pre-identity prompt'])
+    expect(textsIn(scopeOf('session-a'))).toEqual(['pre-identity prompt', 'already scoped prompt'])
   })
 
   it('closes the bucket for good, so a refill cannot be claimed by a replacement', () => {

--- a/src/renderer/src/components/native-chat/native-chat-pending-conversation.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending-conversation.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  claimBootstrapPendingSends,
+  clearNativeChatConversationBindingsForTests,
+  selectClaimableBootstrapSends
+} from './native-chat-pending-conversation'
+import {
+  appendCommandMarkerCache,
+  appendPendingSendCache,
+  clearCommandMarkerCacheForTests,
+  clearPendingSendCacheForTests,
+  readPendingSendCache,
+  type NativeChatPendingSend,
+  type NativeChatPendingSendScope
+} from './native-chat-pending'
+
+const PANE = 'tab-1:leaf-1'
+const bootstrapScope: NativeChatPendingSendScope = {
+  paneKey: PANE,
+  agent: 'codex',
+  conversationId: null
+}
+const scopeOf = (conversationId: string | null, paneKey = PANE): NativeChatPendingSendScope => ({
+  paneKey,
+  agent: 'codex',
+  conversationId
+})
+
+function send(id: string, text: string, sentAt: number): NativeChatPendingSend {
+  return { id, text, sentAt, afterMessageId: null, afterMessageTimestamp: null }
+}
+
+const textsIn = (scope: NativeChatPendingSendScope): string[] =>
+  readPendingSendCache(scope).map((entry) => entry.text)
+
+describe('selectClaimableBootstrapSends', () => {
+  it('keeps everything when the window recorded no /clear', () => {
+    const entries = [send('p1', 'one', 10), send('p2', 'two', 20)]
+    expect(selectClaimableBootstrapSends(entries, [])).toEqual(entries)
+  })
+
+  it('drops sends at or before the latest /clear and keeps later ones', () => {
+    const entries = [
+      send('p1', 'before', 10),
+      send('p2', 'on the boundary', 30),
+      send('p3', 'after', 40)
+    ]
+    const markers = [
+      { id: 'm1', command: '/clear', sentAt: 20 },
+      { id: 'm2', command: '/model gpt', sentAt: 35 },
+      { id: 'm3', command: '/clear', sentAt: 30 }
+    ]
+
+    expect(selectClaimableBootstrapSends(entries, markers).map((entry) => entry.text)).toEqual([
+      'after'
+    ])
+  })
+
+  it('ignores slash commands that do not replace the conversation', () => {
+    const entries = [send('p1', 'one', 10)]
+    const markers = [{ id: 'm1', command: '/model gpt', sentAt: 20 }]
+    expect(selectClaimableBootstrapSends(entries, markers)).toEqual(entries)
+  })
+})
+
+describe('claimBootstrapPendingSends', () => {
+  beforeEach(() => {
+    clearPendingSendCacheForTests()
+    clearCommandMarkerCacheForTests()
+    clearNativeChatConversationBindingsForTests()
+  })
+
+  it('hands the pre-identity bucket to the first conversation and empties it', () => {
+    appendPendingSendCache(bootstrapScope, send('p1', 'first prompt', 10))
+
+    claimBootstrapPendingSends(scopeOf('session-a'), [])
+
+    expect(textsIn(scopeOf('session-a'))).toEqual(['first prompt'])
+    expect(readPendingSendCache(bootstrapScope)).toEqual([])
+  })
+
+  it('appends to the claiming conversation rather than replacing its own echoes', () => {
+    appendPendingSendCache(bootstrapScope, send('p1', 'pre-identity prompt', 10))
+    appendPendingSendCache(scopeOf('session-a'), send('p2', 'already scoped prompt', 20))
+
+    claimBootstrapPendingSends(scopeOf('session-a'), [])
+
+    expect(textsIn(scopeOf('session-a'))).toEqual(['already scoped prompt', 'pre-identity prompt'])
+  })
+
+  it('closes the bucket for good, so a refill cannot be claimed by a replacement', () => {
+    appendPendingSendCache(bootstrapScope, send('p1', 'first prompt', 10))
+    claimBootstrapPendingSends(scopeOf('session-a'), [])
+
+    // Anything that lands in the pre-identity bucket after the pane is bound is
+    // never handed on: adoption is a bootstrap-only event, not a standing rule.
+    appendPendingSendCache(bootstrapScope, send('p2', 'stray post-bootstrap echo', 30))
+    claimBootstrapPendingSends(scopeOf('session-b'), [])
+
+    expect(readPendingSendCache(scopeOf('session-b'))).toEqual([])
+    expect(textsIn(scopeOf('session-a'))).toEqual(['first prompt'])
+  })
+
+  it('does not bind the pane while it still has no conversation id', () => {
+    appendPendingSendCache(bootstrapScope, send('p1', 'first prompt', 10))
+
+    claimBootstrapPendingSends(bootstrapScope, [])
+    expect(textsIn(bootstrapScope)).toEqual(['first prompt'])
+
+    claimBootstrapPendingSends(scopeOf('session-a'), [])
+    expect(textsIn(scopeOf('session-a'))).toEqual(['first prompt'])
+  })
+
+  it('reads the /clear boundary recorded in the same pre-identity window', () => {
+    appendPendingSendCache(bootstrapScope, send('p1', 'sent before the clear', 10))
+    appendCommandMarkerCache({ paneKey: PANE, agent: 'codex', sessionId: null }, '/clear', 20)
+    appendPendingSendCache(bootstrapScope, send('p2', 'sent after the clear', 30))
+    const markers = [{ id: 'm1', command: '/clear', sentAt: 20 }]
+
+    claimBootstrapPendingSends(scopeOf('session-a'), markers)
+
+    expect(textsIn(scopeOf('session-a'))).toEqual(['sent after the clear'])
+    expect(readPendingSendCache(bootstrapScope)).toEqual([])
+  })
+
+  it('binds each pane independently', () => {
+    appendPendingSendCache(bootstrapScope, send('p1', 'left pane prompt', 10))
+    appendPendingSendCache(scopeOf(null, 'tab-2:leaf-2'), send('p2', 'right pane prompt', 10))
+
+    claimBootstrapPendingSends(scopeOf('session-a'), [])
+    claimBootstrapPendingSends(scopeOf('session-b', 'tab-2:leaf-2'), [])
+
+    expect(textsIn(scopeOf('session-a'))).toEqual(['left pane prompt'])
+    expect(textsIn(scopeOf('session-b', 'tab-2:leaf-2'))).toEqual(['right pane prompt'])
+  })
+
+  it('binds a pane that reported its conversation before any send', () => {
+    claimBootstrapPendingSends(scopeOf('session-a'), [])
+
+    // A pane with no pre-identity window still closes its bucket, so a send that
+    // somehow lands there later cannot be adopted by the next conversation.
+    appendPendingSendCache(bootstrapScope, send('p1', 'stray echo', 10))
+    claimBootstrapPendingSends(scopeOf('session-b'), [])
+
+    expect(readPendingSendCache(scopeOf('session-b'))).toEqual([])
+  })
+})

--- a/src/renderer/src/components/native-chat/native-chat-pending-conversation.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending-conversation.ts
@@ -22,6 +22,9 @@ import {
   type NativeChatPendingSendScope
 } from './native-chat-pending'
 
+// Why: LRU-bounded like the other per-pane caches in this folder. Shedding the
+// oldest binding is safe — the claim empties the bucket, and nothing writes to
+// it again once the pane has an identity, so a re-bound pane finds it empty.
 const boundPanes = new Map<string, true>()
 
 function panePendingKey(scope: NativeChatPendingSendScope): string {
@@ -74,7 +77,14 @@ export function claimBootstrapPendingSends(
   const claimed = selectClaimableBootstrapSends(readPendingSendCache(bootstrap), markers)
   writePendingSendCache(bootstrap, [])
   if (claimed.length > 0) {
-    writePendingSendCache(scope, [...readPendingSendCache(scope), ...claimed])
+    // Why: claimed echoes predate anything already under the conversation, and
+    // occurrence assignment reads the list in order — merge by send time rather
+    // than appending older entries after newer ones.
+    const merged = [...readPendingSendCache(scope), ...claimed]
+    writePendingSendCache(
+      scope,
+      merged.sort((left, right) => left.sentAt - right.sentAt)
+    )
   }
 }
 

--- a/src/renderer/src/components/native-chat/native-chat-pending-conversation.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending-conversation.ts
@@ -1,0 +1,83 @@
+// Bootstrap handoff for conversation-scoped optimistic echoes.
+//
+// Echoes are cached per `paneKey + agent + conversationId`, so replacing a
+// pane's conversation moves it to a different key and the predecessor's echoes
+// become unreachable without any retain pass. The one case that key cannot
+// express is a send issued before the agent has reported any session id: it is
+// written to the pane's `bootstrap` bucket, and something has to hand those
+// entries to the conversation that actually received them.
+//
+// The rule is a one-shot claim. The first conversation id a pane ever observes
+// takes the bootstrap bucket, once, and the bucket is then closed for that pane
+// for good — so every later send is written under a real conversation and no
+// replacement can reach back for a pre-identity echo.
+
+import { setBoundedScopeCacheEntry } from './native-chat-composer-scope-cache'
+import {
+  latestClearSentAt,
+  readPendingSendCache,
+  writePendingSendCache,
+  type NativeChatCommandMarker,
+  type NativeChatPendingSend,
+  type NativeChatPendingSendScope
+} from './native-chat-pending'
+
+const boundPanes = new Map<string, true>()
+
+function panePendingKey(scope: NativeChatPendingSendScope): string {
+  return `${scope.paneKey}\0${scope.agent}`
+}
+
+/** True when this call is the one that closed the pane's bootstrap bucket. */
+function claimPaneBootstrapBucket(scope: NativeChatPendingSendScope): boolean {
+  const key = panePendingKey(scope)
+  if (boundPanes.has(key)) {
+    return false
+  }
+  setBoundedScopeCacheEntry(boundPanes, key, true)
+  return true
+}
+
+/**
+ * Bootstrap echoes the arriving conversation is allowed to claim.
+ *
+ * A `/clear` recorded in the same pre-identity window is direct evidence that
+ * the conversation was replaced after the send was queued, so anything sent at
+ * or before it is dropped rather than handed on — the same transcript boundary
+ * `applyCommandMarkerBoundaries` already applies to real messages. Reused from
+ * the retain pass in #11509, where it is the one rule that is right regardless
+ * of how the cache is keyed.
+ */
+export function selectClaimableBootstrapSends<T extends Pick<NativeChatPendingSend, 'sentAt'>>(
+  entries: readonly T[],
+  markers: readonly NativeChatCommandMarker[]
+): T[] {
+  const clearSentAt = latestClearSentAt(markers)
+  return clearSentAt === null ? [...entries] : entries.filter((entry) => entry.sentAt > clearSentAt)
+}
+
+/**
+ * Hand the pane's pre-identity echoes to `scope.conversationId`, once.
+ *
+ * A no-op while the pane has no conversation id (nothing to hand them to) and
+ * on every call after the first, so the bucket cannot be claimed twice and a
+ * later conversation cannot inherit an echo a previous one already took.
+ */
+export function claimBootstrapPendingSends(
+  scope: NativeChatPendingSendScope,
+  markers: readonly NativeChatCommandMarker[]
+): void {
+  if (scope.conversationId === null || !claimPaneBootstrapBucket(scope)) {
+    return
+  }
+  const bootstrap: NativeChatPendingSendScope = { ...scope, conversationId: null }
+  const claimed = selectClaimableBootstrapSends(readPendingSendCache(bootstrap), markers)
+  writePendingSendCache(bootstrap, [])
+  if (claimed.length > 0) {
+    writePendingSendCache(scope, [...readPendingSendCache(scope), ...claimed])
+  }
+}
+
+export function clearNativeChatConversationBindingsForTests(): void {
+  boundPanes.clear()
+}

--- a/src/renderer/src/components/native-chat/native-chat-pending-conversation.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending-conversation.ts
@@ -12,7 +12,6 @@
 // for good — so every later send is written under a real conversation and no
 // replacement can reach back for a pre-identity echo.
 
-import { setBoundedScopeCacheEntry } from './native-chat-composer-scope-cache'
 import {
   latestClearSentAt,
   readPendingSendCache,
@@ -22,10 +21,9 @@ import {
   type NativeChatPendingSendScope
 } from './native-chat-pending'
 
-// Why: LRU-bounded like the other per-pane caches in this folder. Shedding the
-// oldest binding is safe — the claim empties the bucket, and nothing writes to
-// it again once the pane has an identity, so a re-bound pane finds it empty.
-const boundPanes = new Map<string, true>()
+// Why: this is a correctness tombstone, not a payload cache. Evicting it would
+// reopen the bootstrap claim for a replacement after enough other panes bind.
+const boundPanes = new Set<string>()
 
 function panePendingKey(scope: NativeChatPendingSendScope): string {
   return `${scope.paneKey}\0${scope.agent}`
@@ -37,7 +35,7 @@ function claimPaneBootstrapBucket(scope: NativeChatPendingSendScope): boolean {
   if (boundPanes.has(key)) {
     return false
   }
-  setBoundedScopeCacheEntry(boundPanes, key, true)
+  boundPanes.add(key)
   return true
 }
 

--- a/src/renderer/src/components/native-chat/native-chat-pending-occurrence.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending-occurrence.test.ts
@@ -9,7 +9,11 @@ import {
   type NativeChatPendingSendScope
 } from './native-chat-pending'
 
-const scope: NativeChatPendingSendScope = { paneKey: 'tab:leaf', agent: 'codex' }
+const scope: NativeChatPendingSendScope = {
+  paneKey: 'tab:leaf',
+  agent: 'codex',
+  conversationId: 'session-1'
+}
 
 function message(
   id: string,

--- a/src/renderer/src/components/native-chat/native-chat-pending.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.test.ts
@@ -556,7 +556,7 @@ describe('launchPromptAsMessage', () => {
 describe('pending send cache', () => {
   it('persists optimistic sends for the same pane and agent', () => {
     clearPendingSendCacheForTests()
-    const scope = { paneKey: 'tab-a:leaf-a', agent: 'codex' }
+    const scope = { paneKey: 'tab-a:leaf-a', agent: 'codex', conversationId: 'session-a' }
 
     const appended = appendPendingSendCache(scope, pendingOf('p1', 'first prompt'))
 
@@ -574,7 +574,7 @@ describe('pending send cache', () => {
 
   it('clears cached pending sends when pruning removes all entries', () => {
     clearPendingSendCacheForTests()
-    const scope = { paneKey: 'tab-a:leaf-a', agent: 'codex' }
+    const scope = { paneKey: 'tab-a:leaf-a', agent: 'codex', conversationId: 'session-a' }
     appendPendingSendCache(scope, pendingOf('p1', 'first prompt'))
 
     writePendingSendCache(scope, [])
@@ -720,11 +720,15 @@ describe('scope-cache key counts stay bounded (memory-leak regression)', () => {
     clearPendingSendCacheForTests()
     const send = (id: string): NativeChatPendingSend => ({ id, text: id, sentAt: 1 })
     for (let i = 0; i < CAP + 5; i++) {
-      writePendingSendCache({ paneKey: `tab-${i}:leaf`, agent: 'claude' }, [send(`m${i}`)])
+      writePendingSendCache({ paneKey: `tab-${i}:leaf`, agent: 'claude', conversationId: 's' }, [
+        send(`m${i}`)
+      ])
     }
-    expect(readPendingSendCache({ paneKey: 'tab-0:leaf', agent: 'claude' })).toEqual([])
-    expect(readPendingSendCache({ paneKey: `tab-${CAP + 4}:leaf`, agent: 'claude' })).toHaveLength(
-      1
-    )
+    expect(
+      readPendingSendCache({ paneKey: 'tab-0:leaf', agent: 'claude', conversationId: 's' })
+    ).toEqual([])
+    expect(
+      readPendingSendCache({ paneKey: `tab-${CAP + 4}:leaf`, agent: 'claude', conversationId: 's' })
+    ).toHaveLength(1)
   })
 })

--- a/src/renderer/src/components/native-chat/native-chat-pending.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.test.ts
@@ -581,6 +581,26 @@ describe('pending send cache', () => {
 
     expect(readPendingSendCache(scope)).toEqual([])
   })
+
+  it('keeps only the latest eight sends within a conversation', () => {
+    clearPendingSendCacheForTests()
+    const scope = { paneKey: 'tab-a:leaf-a', agent: 'codex', conversationId: 'session-a' }
+
+    for (let index = 0; index < 10; index += 1) {
+      appendPendingSendCache(scope, pendingOf(`p${index}`, `prompt ${index}`))
+    }
+
+    expect(readPendingSendCache(scope).map((entry) => entry.id)).toEqual([
+      'p2',
+      'p3',
+      'p4',
+      'p5',
+      'p6',
+      'p7',
+      'p8',
+      'p9'
+    ])
+  })
 })
 
 describe('isPendingMessageId', () => {

--- a/src/renderer/src/components/native-chat/native-chat-pending.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.ts
@@ -43,6 +43,10 @@ export type NativeChatPendingSend = {
 export type NativeChatPendingSendScope = {
   paneKey: string
   agent: string
+  /** The conversation the echo belongs to (the agent's provider session id), or
+   *  null before the agent has reported one. Replacing the conversation moves
+   *  the pane to a different key, so a predecessor's echoes are unreachable. */
+  conversationId: string | null
 }
 
 const PENDING_SEND_LIMIT = 8
@@ -50,7 +54,9 @@ const pendingSendCache = new Map<string, NativeChatPendingSend[]>()
 let pendingSendCounter = 0
 
 function pendingSendScopeKey(scope: NativeChatPendingSendScope): string {
-  return `${scope.paneKey}\0${scope.agent}`
+  // Why: the pre-identity bucket's sentinel carries a NUL so no provider session
+  // id — however malformed, including the empty string — can collide with it.
+  return `${scope.paneKey}\0${scope.agent}\0${scope.conversationId ?? '\0bootstrap'}`
 }
 
 export function readPendingSendCache(scope: NativeChatPendingSendScope): NativeChatPendingSend[] {
@@ -360,7 +366,7 @@ function isClearCommand(command: string): boolean {
   return command.trim().toLowerCase().split(/\s+/)[0] === '/clear'
 }
 
-function latestClearSentAt(markers: readonly NativeChatCommandMarker[]): number | null {
+export function latestClearSentAt(markers: readonly NativeChatCommandMarker[]): number | null {
   let latest: number | null = null
   for (const marker of markers) {
     if (isClearCommand(marker.command) && (latest === null || marker.sentAt > latest)) {

--- a/src/renderer/src/components/native-chat/use-native-chat-pending-echoes.test.tsx
+++ b/src/renderer/src/components/native-chat/use-native-chat-pending-echoes.test.tsx
@@ -104,6 +104,30 @@ describe('useNativeChatPendingEchoes', () => {
     expect(echoedTexts(view.result.current.pending, replacement)).toEqual([])
   })
 
+  it('does not expose predecessor pending during the replacement render', () => {
+    const renders: string[][] = []
+    const props: NativeChatPendingEchoesInput = {
+      paneKey: PANE,
+      agent: 'codex',
+      sessionId: 'session-a',
+      messages: []
+    }
+    const view = renderHook(
+      (next: NativeChatPendingEchoesInput) => {
+        const current = useNativeChatPendingEchoes(next)
+        renders.push(current.pending.map((entry) => entry.text))
+        return current
+      },
+      { initialProps: props }
+    )
+    act(() => view.result.current.onOptimisticSend('predecessor prompt'))
+    renders.length = 0
+
+    view.rerender({ ...props, sessionId: 'session-b' })
+
+    expect(renders[0]).toEqual([])
+  })
+
   it('keeps the predecessor echo unreachable across a remount', () => {
     const first = renderEchoes()
     act(() => {

--- a/src/renderer/src/components/native-chat/use-native-chat-pending-echoes.test.tsx
+++ b/src/renderer/src/components/native-chat/use-native-chat-pending-echoes.test.tsx
@@ -1,0 +1,252 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, renderHook } from '@testing-library/react'
+import type { NativeChatMessage } from '../../../../shared/native-chat-types'
+import { clearNativeChatConversationBindingsForTests } from './native-chat-pending-conversation'
+import {
+  clearCommandMarkerCacheForTests,
+  clearPendingSendCacheForTests,
+  pendingSendsAsMessages
+} from './native-chat-pending'
+import {
+  useNativeChatPendingEchoes,
+  type NativeChatPendingEchoesInput
+} from './use-native-chat-pending-echoes'
+
+const PANE = 'tab-1:leaf-1'
+// Echo matching compares transcript timestamps against the send's own clock, so
+// the test drives both from one fake clock rather than mixing Date.now() with
+// hand-written message timestamps.
+const CLOCK_START = 1_700_000_000_000
+
+function userMessage(id: string, text: string, timestamp: number): NativeChatMessage {
+  return { id, role: 'user', blocks: [{ type: 'text', text }], timestamp, source: 'transcript' }
+}
+
+function assistantMessage(id: string, text: string, timestamp: number): NativeChatMessage {
+  return {
+    id,
+    role: 'assistant',
+    blocks: [{ type: 'text', text }],
+    timestamp,
+    source: 'transcript'
+  }
+}
+
+function renderEchoes(initial: Partial<NativeChatPendingEchoesInput> = {}) {
+  const props: NativeChatPendingEchoesInput = {
+    paneKey: PANE,
+    agent: 'codex',
+    sessionId: 'session-a',
+    messages: [],
+    ...initial
+  }
+  return renderHook((next: NativeChatPendingEchoesInput) => useNativeChatPendingEchoes(next), {
+    initialProps: props
+  })
+}
+
+/** The prompt texts the list would render as optimistic bubbles. */
+function echoedTexts(
+  pending: ReturnType<typeof useNativeChatPendingEchoes>['pending'],
+  messages: NativeChatMessage[]
+): string[] {
+  return pendingSendsAsMessages(pending, messages).flatMap((message) =>
+    message.blocks.flatMap((block) => (block.type === 'text' ? [block.text] : []))
+  )
+}
+
+describe('useNativeChatPendingEchoes', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ now: CLOCK_START })
+    clearPendingSendCacheForTests()
+    clearCommandMarkerCacheForTests()
+    clearNativeChatConversationBindingsForTests()
+  })
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+  })
+
+  it('renders the echo until its own user turn lands, then retires it', () => {
+    const view = renderEchoes()
+    act(() => {
+      view.result.current.onOptimisticSend('summarize the release notes')
+    })
+    expect(echoedTexts(view.result.current.pending, [])).toEqual(['summarize the release notes'])
+
+    const settled = [
+      userMessage('a1', 'summarize the release notes', CLOCK_START + 100),
+      assistantMessage('a2', 'Here are the notes.', CLOCK_START + 200)
+    ]
+    view.rerender({ paneKey: PANE, agent: 'codex', sessionId: 'session-a', messages: settled })
+
+    expect(view.result.current.pending).toEqual([])
+  })
+
+  it('leaves a replaced conversation unable to reach its predecessor echo', () => {
+    const view = renderEchoes()
+    act(() => {
+      view.result.current.onOptimisticSend('summarize the release notes')
+    })
+    expect(view.result.current.pending).toHaveLength(1)
+
+    // The pane's conversation is replaced — /clear, an agent restart, or
+    // resuming a different session. paneKey and agent are unchanged; only the
+    // provider session id moves.
+    const replacement = [
+      userMessage('b1', 'what changed in v2?', CLOCK_START + 5_000),
+      assistantMessage('b2', 'Here is the v2 changelog.', CLOCK_START + 5_100)
+    ]
+    view.rerender({ paneKey: PANE, agent: 'codex', sessionId: 'session-b', messages: replacement })
+
+    expect(view.result.current.pending).toEqual([])
+    expect(echoedTexts(view.result.current.pending, replacement)).toEqual([])
+  })
+
+  it('keeps the predecessor echo unreachable across a remount', () => {
+    const first = renderEchoes()
+    act(() => {
+      first.result.current.onOptimisticSend('summarize the release notes')
+    })
+    first.unmount()
+
+    // Native/TUI view switches remount the chat surface, which re-seeds state
+    // from the pane cache. The replacement conversation reads a different key.
+    const second = renderEchoes({ sessionId: 'session-b' })
+    expect(second.result.current.pending).toEqual([])
+  })
+
+  it('restores the live conversation echo across a remount', () => {
+    const first = renderEchoes()
+    act(() => {
+      first.result.current.onOptimisticSend('still waiting on this one')
+    })
+    first.unmount()
+
+    const second = renderEchoes()
+    expect(second.result.current.pending.map((entry) => entry.text)).toEqual([
+      'still waiting on this one'
+    ])
+  })
+
+  it('hands a pre-identity echo to the first conversation the pane reports', () => {
+    const view = renderEchoes({ sessionId: null })
+    act(() => {
+      view.result.current.onOptimisticSend('first prompt in a fresh pane')
+    })
+
+    // A fresh launch learns its provider session id only after the first send.
+    view.rerender({ paneKey: PANE, agent: 'codex', sessionId: 'session-a', messages: [] })
+
+    expect(view.result.current.pending.map((entry) => entry.text)).toEqual([
+      'first prompt in a fresh pane'
+    ])
+  })
+
+  it('hands the pre-identity echo on once and no replacement gets it after', () => {
+    const view = renderEchoes({ sessionId: null })
+    act(() => {
+      view.result.current.onOptimisticSend('first prompt in a fresh pane')
+    })
+    view.rerender({ paneKey: PANE, agent: 'codex', sessionId: 'session-a', messages: [] })
+    expect(view.result.current.pending).toHaveLength(1)
+
+    view.rerender({ paneKey: PANE, agent: 'codex', sessionId: 'session-b', messages: [] })
+    expect(view.result.current.pending).toEqual([])
+
+    // And the closed bucket cannot be re-claimed by a third conversation, even
+    // though the pane briefly reports no session id in between.
+    view.rerender({ paneKey: PANE, agent: 'codex', sessionId: null, messages: [] })
+    view.rerender({ paneKey: PANE, agent: 'codex', sessionId: 'session-c', messages: [] })
+    expect(view.result.current.pending).toEqual([])
+  })
+
+  it('refuses the claim for an echo queued at or before a /clear in the same window', () => {
+    const view = renderEchoes({ sessionId: null })
+    act(() => {
+      view.result.current.onOptimisticSend('sent just before the clear')
+    })
+    act(() => {
+      vi.setSystemTime(CLOCK_START + 10)
+      view.result.current.onSlashCommand('/clear')
+    })
+    act(() => {
+      vi.setSystemTime(CLOCK_START + 20)
+      view.result.current.onOptimisticSend('sent after the clear')
+    })
+
+    view.rerender({ paneKey: PANE, agent: 'codex', sessionId: 'session-a', messages: [] })
+
+    expect(view.result.current.pending.map((entry) => entry.text)).toEqual(['sent after the clear'])
+  })
+
+  it('keeps each pane on its own conversation bucket', () => {
+    const left = renderEchoes()
+    act(() => {
+      left.result.current.onOptimisticSend('left pane prompt')
+    })
+    const right = renderEchoes({ paneKey: 'tab-2:leaf-2' })
+    act(() => {
+      right.result.current.onOptimisticSend('right pane prompt')
+    })
+
+    // Replacing the right pane's conversation must not disturb the left pane.
+    right.rerender({
+      paneKey: 'tab-2:leaf-2',
+      agent: 'codex',
+      sessionId: 'session-b',
+      messages: []
+    })
+
+    expect(right.result.current.pending).toEqual([])
+    expect(left.result.current.pending.map((entry) => entry.text)).toEqual(['left pane prompt'])
+  })
+
+  it('drops the live conversation echoes on Stop without touching a sibling pane', () => {
+    const left = renderEchoes()
+    act(() => {
+      left.result.current.onOptimisticSend('left pane prompt')
+    })
+    const right = renderEchoes({ paneKey: 'tab-2:leaf-2' })
+    act(() => {
+      right.result.current.onOptimisticSend('right pane prompt')
+    })
+
+    act(() => {
+      right.result.current.clearPendingSends()
+    })
+
+    expect(right.result.current.pending).toEqual([])
+    expect(left.result.current.pending.map((entry) => entry.text)).toEqual(['left pane prompt'])
+  })
+
+  it('cancels a single echo by id and leaves the rest queued', () => {
+    const view = renderEchoes()
+    let cancelledId = ''
+    act(() => {
+      cancelledId = view.result.current.onOptimisticSend('cancel me')
+    })
+    act(() => {
+      view.result.current.onOptimisticSend('keep me')
+    })
+
+    act(() => {
+      view.result.current.onOptimisticSendCanceled(cancelledId)
+    })
+
+    expect(view.result.current.pending.map((entry) => entry.text)).toEqual(['keep me'])
+  })
+
+  it('scopes command markers to the conversation that recorded them', () => {
+    const view = renderEchoes()
+    act(() => {
+      view.result.current.onSlashCommand('/clear')
+    })
+    expect(view.result.current.commandMarkers.map((marker) => marker.command)).toEqual(['/clear'])
+
+    view.rerender({ paneKey: PANE, agent: 'codex', sessionId: 'session-b', messages: [] })
+
+    expect(view.result.current.commandMarkers).toEqual([])
+  })
+})

--- a/src/renderer/src/components/native-chat/use-native-chat-pending-echoes.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-pending-echoes.ts
@@ -1,0 +1,135 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { NativeChatMessage } from '../../../../shared/native-chat-types'
+import { claimBootstrapPendingSends } from './native-chat-pending-conversation'
+import {
+  appendCommandMarkerCache,
+  appendPendingSendCache,
+  nextNativeChatPendingSendId,
+  prunePendingSends,
+  readCommandMarkerCache,
+  readPendingSendCache,
+  writePendingSendCache,
+  type NativeChatCommandMarker,
+  type NativeChatPendingSend
+} from './native-chat-pending'
+
+export type NativeChatPendingEchoesInput = {
+  paneKey: string
+  agent: string
+  /** The pane's conversation identity — the agent's provider session id, or
+   *  null before it has reported one. */
+  sessionId: string | null
+  /** The conversation as currently rendered, used to retire matched echoes. */
+  messages: NativeChatMessage[]
+}
+
+export type NativeChatPendingEchoes = {
+  pending: NativeChatPendingSend[]
+  commandMarkers: NativeChatCommandMarker[]
+  /** Records the echo and returns its id so the send lifecycle can cancel it. */
+  onOptimisticSend: (text: string, imagePaths?: string[]) => string
+  onOptimisticSendCanceled: (pendingId: string) => void
+  onSlashCommand: (command: string) => void
+  /** Drops every echo for the live conversation (composer Stop). */
+  clearPendingSends: () => void
+}
+
+/**
+ * Optimistic "queued" composer echoes for one pane, scoped to the conversation
+ * they were sent into.
+ *
+ * The cache key carries the conversation id, so replacing the pane's
+ * conversation (`/clear`, an agent restart, resuming a different session) moves
+ * the pane to a different key and the predecessor's echoes are unreachable —
+ * they can no longer be read, rendered, or written back. Only the pre-identity
+ * window needs a rule, and `claimBootstrapPendingSends` owns it.
+ */
+export function useNativeChatPendingEchoes({
+  paneKey,
+  agent,
+  sessionId,
+  messages
+}: NativeChatPendingEchoesInput): NativeChatPendingEchoes {
+  const pendingScope = useMemo(
+    () => ({ paneKey, agent, conversationId: sessionId }),
+    [paneKey, agent, sessionId]
+  )
+  // Slash commands aren't chat turns, so they get a small local "Ran /clear"
+  // system line instead of a user bubble. Capped + cached per conversation.
+  const commandMarkerScope = useMemo(
+    () => ({ paneKey, agent, sessionId }),
+    [paneKey, agent, sessionId]
+  )
+  const [pending, setPending] = useState<NativeChatPendingSend[]>(() =>
+    readPendingSendCache(pendingScope)
+  )
+  const [commandMarkers, setCommandMarkers] = useState<NativeChatCommandMarker[]>(() =>
+    readCommandMarkerCache(commandMarkerScope)
+  )
+
+  useEffect(() => {
+    // Why: the claim has to run before the read, or the first render after the
+    // agent reports its session id sees an empty bucket and flashes the empty
+    // state while the pre-identity echo is still waiting for its real turn.
+    // Markers come from the pre-identity marker scope because that is where a
+    // `/clear` typed in the same window was recorded.
+    claimBootstrapPendingSends(
+      pendingScope,
+      readCommandMarkerCache({ paneKey, agent, sessionId: null })
+    )
+    setPending(readPendingSendCache(pendingScope))
+  }, [pendingScope, paneKey, agent])
+  useEffect(() => {
+    setCommandMarkers(readCommandMarkerCache(commandMarkerScope))
+  }, [commandMarkerScope])
+  // Retire echoes whose real user turn is now in the transcript. Runs after the
+  // reset effect above, so its `prev` is already the live conversation's list.
+  useEffect(() => {
+    setPending((prev) => writePendingSendCache(pendingScope, prunePendingSends(prev, messages)))
+  }, [messages, pendingScope])
+
+  const onOptimisticSend = useCallback(
+    (text: string, imagePaths?: string[]) => {
+      const sentAt = Date.now()
+      const boundary = messages.at(-1)
+      const entry: NativeChatPendingSend = {
+        id: nextNativeChatPendingSendId(sentAt),
+        text,
+        sentAt,
+        afterMessageId: boundary?.id ?? null,
+        afterMessageTimestamp: boundary?.timestamp ?? null,
+        ...(imagePaths ? { imagePaths } : {})
+      }
+      setPending(appendPendingSendCache(pendingScope, entry))
+      return entry.id
+    },
+    [pendingScope, messages]
+  )
+  const onOptimisticSendCanceled = useCallback(
+    (pendingId: string) => {
+      // Why: detach/interrupt cancels the delayed Enter, so its optimistic echo
+      // must not come back from the pane cache as a prompt that was delivered.
+      const next = readPendingSendCache(pendingScope).filter((entry) => entry.id !== pendingId)
+      setPending(writePendingSendCache(pendingScope, next))
+    },
+    [pendingScope]
+  )
+  const onSlashCommand = useCallback(
+    (command: string) => {
+      setCommandMarkers(appendCommandMarkerCache(commandMarkerScope, command))
+    },
+    [commandMarkerScope]
+  )
+  const clearPendingSends = useCallback(() => {
+    setPending(writePendingSendCache(pendingScope, []))
+  }, [pendingScope])
+
+  return {
+    pending,
+    commandMarkers,
+    onOptimisticSend,
+    onOptimisticSendCanceled,
+    onSlashCommand,
+    clearPendingSends
+  }
+}

--- a/src/renderer/src/components/native-chat/use-native-chat-pending-echoes.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-pending-echoes.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import type { NativeChatMessage } from '../../../../shared/native-chat-types'
 import { claimBootstrapPendingSends } from './native-chat-pending-conversation'
 import {
@@ -63,11 +63,15 @@ export function useNativeChatPendingEchoes({
   const [pending, setPending] = useState<NativeChatPendingSend[]>(() =>
     readPendingSendCache(pendingScope)
   )
+  const renderedPendingScope = useRef(pendingScope)
+  // A conversation replacement must not render its predecessor even once
+  // before the commit-phase cache handoff resets local state.
+  const scopedPending = renderedPendingScope.current === pendingScope ? pending : []
   const [commandMarkers, setCommandMarkers] = useState<NativeChatCommandMarker[]>(() =>
     readCommandMarkerCache(commandMarkerScope)
   )
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     // Why: the claim has to run before the read, or the first render after the
     // agent reports its session id sees an empty bucket and flashes the empty
     // state while the pre-identity echo is still waiting for its real turn.
@@ -77,6 +81,7 @@ export function useNativeChatPendingEchoes({
       pendingScope,
       readCommandMarkerCache({ paneKey, agent, sessionId: null })
     )
+    renderedPendingScope.current = pendingScope
     setPending(readPendingSendCache(pendingScope))
   }, [pendingScope, paneKey, agent])
   useEffect(() => {
@@ -125,7 +130,7 @@ export function useNativeChatPendingEchoes({
   }, [pendingScope])
 
   return {
-    pending,
+    pending: scopedPending,
     commandMarkers,
     onOptimisticSend,
     onOptimisticSendCanceled,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​472 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​464 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​260 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​77 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​183 |

<!-- /orca-pr-loc -->

## ELI5

Native chat shows your message instantly as a grey "queued" bubble before the agent's transcript catches up. That bubble was filed under "this pane, this agent" with no note of *which conversation* it belonged to. So if the conversation underneath got swapped out — `/clear`, an agent restart, resuming a different session — the bubble had nowhere to go home to, and just sat at the bottom of the list pretending to be your newest message. Forever.

This files the bubble under the conversation too. Swap the conversation and the old bubbles are simply in a drawer nobody opens again.

## What Changed

`NativeChatPendingSendScope` gains `conversationId`, and the echo cache key becomes `paneKey + agent + conversationId`.

That is the whole fix for the reported symptom. A replaced conversation reads a different key, so a predecessor's echoes cannot be read, rendered, or written back — no retain pass, no adoption rules, no occurrence-slot shifting.

The one case a conversation-scoped key cannot express is a send issued **before the agent has reported any session id** (a fresh launch learns it only after the first send). Those echoes go to a per-pane `bootstrap` bucket, and `claimBootstrapPendingSends` hands them over — see the bootstrap rule below.

Supporting change: the pending / command-marker state moved into `useNativeChatPendingEchoes`, so the wiring is testable without standing up the store, and `NativeChatView.tsx` stays under its 400-line ceiling (it had 8 counted lines of headroom before this change; it now has ~60).

## Why

### The bug

Nobody had ever demonstrated this defect, so the first thing I did was prove it on unmodified `origin/main`. The repro is short because the mechanism is:

- The echo cache is keyed by `paneKey + agent` only (`pendingSendScopeKey`) — no conversation identity.
- The only retirement path is a normalized-text match against a transcript user turn (`prunePendingSends` / `pendingSendsAsMessages`).
- `NativeChatView`'s `pendingScope` was `useMemo(..., [paneKey, agent])`, and a conversation swap changes neither, so the reset effect keyed on it never fired.
- `prunePendingSends` writes its result straight back to the pane cache on every transcript tick, so an orphan it cannot retire is re-persisted; native/TUI view switches remount the surface and re-seed from that cache.

Driven against `origin/main` (send under conversation A → replace with conversation B → prune against B's transcript), both assertions fail:

```
× renders the old conversation prompt as the newest message forever
    AssertionError: expected [ { id: 'send-1', …(4) } ] to have a length of +0 but got 1
× keeps the ghost in the pane cache across a remount
    AssertionError: expected [ { id: 'send-1', …(4) } ] to have a length of +0 but got 1
```

So: an old prompt renders as the newest message in a conversation it was never part of, and it survives every remount for the rest of the pane's life.

That repro is now carried by `use-native-chat-pending-echoes.test.tsx` → *"leaves a replaced conversation unable to reach its predecessor echo"*, driven through the real production hook rather than the module functions.

### Why keying by conversation is the right layer

The defect is that a cache entry outlives the thing it describes. An echo is a claim about one conversation — "this prompt is on its way into *this* transcript". Once the conversation is gone, the claim is meaningless, and the only honest place to say that is the identity the entry is stored under.

Every alternative is downstream of the key, and therefore has to *re-derive* an identity the key threw away. #11509 does exactly that: it keeps `paneKey + agent` and adds `retainPendingSendsForConversation`, a 5-rule retain pass that runs on every transcript tick, stamps session ids onto entries, adopts null-session entries by position, and shifts per-key occurrence slots when a drop vacates one. Its own root-cause section names the real defect — *"there is no conversation identity in it"* — and then does not fix it there. The cost shows up in its own history: four review commits on that branch, three of them fixing the retain/renumber machinery rather than the bug, one reverting a boundary fix that reopened the failure mode more broadly ("a send 4 hours after one `/clear` adopted into an unrelated session").

With the identity in the key, none of that machinery has anything to do. Concretely, this PR deletes the need for: the retain pass, rules 2/3/5 (they are the key's job), `dropNativeChatPendingOccurrences` and per-key slot shifting (nothing is dropped mid-list, so no slot is ever vacated), and the marker-staleness hazard the bot review found in the retain effect (there is no retain effect).

### The bootstrap rule

**One-shot claim by the pane's first conversation, refused on observed replacement.**

1. Echoes queued while the pane has no conversation id go to a per-pane `bootstrap` bucket.
2. The **first** conversation id the pane ever observes claims that bucket **exactly once**. The claim moves the entries into that conversation's bucket and closes the bootstrap bucket for that pane permanently — so every later send is written under a real conversation, and no later conversation can reach back for a pre-identity echo.
3. The claim is **refused** for any echo queued at or before a `/clear` recorded in the same pre-identity window. A `/clear` is direct evidence the conversation moved on after the send was queued.

Rule 3 is #11509's rule 1, reused verbatim in spirit — it is the one rule in that retain pass that is right regardless of how the cache is keyed, and it matches the transcript boundary `applyCommandMarkerBoundaries` already applies to real messages.

The important difference from #11509's rule 4 ("`entry.sessionId == null` → adopt the current id") is scope in **time**, not in logic. That rule applies to any null-session entry at any point in the pane's life, which is why it is adoption-by-position and why the PR documents a residual window where an orphan is adopted into the replacement and still pins. This one applies **once**, at the only moment the pane has genuinely never had an identity, and then stops existing. `native-chat-pending-conversation.test.ts` → *"closes the bucket for good, so a refill cannot be claimed by a replacement"* pins that: it refills the bootstrap bucket after the pane is bound and asserts the next conversation gets nothing.

**Boundary I am not claiming to close, stated plainly:** if the agent is replaced *before it ever reports any session id at all*, the first id the renderer sees is the replacement's, and rule 2 hands it that echo. There is no local evidence that distinguishes that from a normal fresh launch — the "previous conversation" never had an identity for the renderer to compare against. It is bounded to that single conversation and dies with it (the next swap makes it unreachable by construction), and the pane cannot repeat it, because the bucket is closed. Worth noting the shape of the precedent here: chat clients that key optimistic messages by session id avoid this entirely by minting the session id **before** writing the optimistic entry. Orca cannot — the provider TUI mints it asynchronously, and waiting for it would defeat the point of an instant echo.

**Also inherited, not introduced:** a send queued between a `/clear` and the replacement id resolving is dropped by rule 3, so the bubble blanks until its real user turn lands. Cosmetic, and the opposite direction from the bug being fixed — a brief gap rather than a permanent ghost. Same limit #11509 documents as its Known limit 2.

### What I reused from #11509

- **The `/clear` boundary** (its rule 1) — the bootstrap claim's refusal condition. It is `selectClaimableBootstrapSends` here, tested standalone including the exclusive `>` boundary (`sentAt` exactly equal to the clear resolves as pre-clear).
- **The `useNativeChatPendingEchoes` extraction and its filename**, and `native-chat-pending-conversation.ts` — same decomposition, same reason (`NativeChatView.tsx` is at its `max-lines` ceiling, and the wiring needs to be testable without the store).
- **Test scenarios worth keeping**, re-expressed against this design: remount persistence (a dropped echo stays dropped, a live echo survives), pane independence, "the session must genuinely differ", the exact-boundary case, and negative cases so the rules cannot over-reach.

Not reused: the retain pass, adoption-by-position, and `dropNativeChatPendingOccurrences` / occurrence-slot shifting, all of which exist only to compensate for the missing key. `cancelSend`'s occurrence release stays out of scope here — that is #13513, a separate strand reachable on `main` today.

## Linked Issue

`Refs #11509` — supersedes it. #11509 closes no issue; there is no filed issue for this defect, which is why Part 1 above was to demonstrate it exists.

## Visual Proof

`N/A` — the change removes a bubble that should never have been on screen. There is no new UI, no new string, and nothing to show in the fixed state that is not just "the correct conversation". The defect and every rule are pinned by tests that fail without their fix; the `origin/main` repro output is quoted above.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

**21 new tests across 2 files**, all green; `native-chat` is green at **75 files / 787 tests** (766 before). `terminal-pane` (the only other consumer of `NativeChatView`) green at 368 files / 3602 tests.

Gates, run per-file with real exit codes (piping through `tail` masks them):

| Gate | Result |
| --- | --- |
| `npx oxlint` on all 8 changed files | exit 0 each |
| `npx oxfmt` on all 8 changed files | clean (repo formats with oxfmt, not prettier) |
| `pnpm audit:code-quality:native` | exit 0 |
| `pnpm audit:code-quality:type-aware` | exit 0 |
| `pnpm check:max-lines-ratchet` | OK — no new bypasses, no `max-lines` disable added |
| `lint-react-doctor-changed` | exit 0; warnings on this file drop 3 → 2 (net −1, no new ones) |
| `tsc --noEmit` × 3 projects | clean, run **cold** after deleting `config/*.tsbuildinfo` (7.6s / 1.5s / 7.9s — a warm run is a 1.0s no-op and proves nothing) |
| `knip` | no findings on the new modules |

**The lint gate is live, not silently dead:** planting `const plantedViolation = new Array()` in `native-chat-pending-conversation.ts` produced `error eslint(no-unused-vars)`, and removing it produced no output.

**Every new test is revert-proofed** — I mutated each guard and confirmed the tests that claim to cover it actually fail:

| Mutation | Tests that fail |
| --- | --- |
| Key back to `paneKey + agent` (the fix itself) | 4 — incl. *"leaves a replaced conversation unable to reach its predecessor echo"* |
| Bootstrap claim made re-entrant (i.e. #11509's rule 4) | 2 — incl. *"closes the bucket for good…"* |
| `/clear` guard removed | 3 |
| Claim allowed to run with a null conversation id | 4 |
| Clear boundary `>` → `>=` | 1 |

The first pass of the re-entrancy mutation was instructive: my original hook-level "claims once" test **passed** under it, because the bucket is emptied at the claim so there is nothing left to re-claim. The one-shot guard is only observable when the bucket is refilled after binding, which the hook cannot reach. I moved that guarantee to a module test that constructs the state directly, rather than shipping a test that pins nothing.

Platforms: renderer-only pure TypeScript — `Map` caches, string keys, array filtering. No path handling, no shell, no shortcuts, no `process.platform` branch, no Electron main/preload/IPC surface. Nothing here can differ across macOS / Linux / Windows.

## AI Disclosure

Claude Opus 5, via Claude Code.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Security:** no new attack surface. `conversationId` is a provider session id already present in renderer state, used only as a `Map` key — never logged, persisted, parsed, or rendered. No new IPC channel or payload, no dependencies added, no filesystem or PTY writes.
- **Remote / SSH:** unchanged. This touches no wire payload and no host-executed command; a runtime-owned pane routes its transcript reads exactly as before.
- **Mobile:** unaffected — nothing outside `src/renderer/src/components/native-chat/` imports these modules (verified by grep across `src/` and `mobile/src`).
- **Backwards compatibility:** the caches are in-memory and per-renderer-session; nothing is persisted, so there is no stored format to migrate.
- **Memory:** the key gains one dimension (conversation), so a pane that churns conversations creates more keys. Pending-send and command-marker payload caches remain LRU-bound to 128 keys via `setBoundedScopeCacheEntry`; the new `boundPanes` correctness tombstones store one boolean per `paneKey + agent` for the renderer lifetime because evicting a tombstone would reopen a replacement claim. The command-marker cache has been keyed by session id since before this PR, so this brings the echo cache in line with it rather than introducing a new growth shape.
- **Pre-existing, untouched:** echo retirement still rests on a single normalized-text match, so an agent-rewritten prompt (mention expansion, skill prefixes) still will not match — but this PR narrows that from *permanent* to *until the conversation is replaced*. The `sentAt` (renderer clock) vs `message.timestamp` (transcript host clock) mix in `messagesAfterPendingBoundary` is #11519 and is not affected by this change; the bootstrap rule deliberately uses only renderer-clock comparisons (`sentAt` vs marker `sentAt`) so it adds no new cross-clock hazard.
- **Rebase note:** #10102 and #10639 also add to `native-chat-pending.ts`. My change there is 3 lines (one type field, one key template, one export), so a conflict should be trivial — but `NativeChatView.tsx` loses ~50 lines to the hook, so anything else editing that pending block will conflict there instead. Flagging it so it is not a surprise.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — lint gates, all three typecheck projects, and the affected suites run locally and listed above. `pnpm build` not run: renderer-only change with no main/preload, packaging, or native surface touched.

## Author

- X / Twitter: @BrennanKB5

