### PR TITLE
Include descendants in Pinned section when parent is pinned

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.group-headers.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeList.group-headers.test.ts
@@ -152,6 +152,24 @@ describe('WorktreeList lineage child card renderer', () => {
     expect(markup).not.toContain('data-repo-header-collapse-affordance=""')
   })
 
+  it('uncollapses pinned reveal for a descendant that only lives under a pinned parent', () => {
+    const child = makeWorktree({
+      id: 'child-of-pinned',
+      instanceId: 'child-of-pinned-instance',
+      displayName: 'Child of pinned',
+      branch: 'child',
+      sortOrder: 2
+    })
+
+    expect(
+      getPinnedWorktreeRevealCollapsedGroupKeys({
+        worktree: child,
+        collapsedGroups: new Set(['pinned', 'all']),
+        inPinnedSection: true
+      })
+    ).toEqual(['pinned'])
+  })
+
   it('uncollapses pinned reveal through the pinned section after host expansion', () => {
     const worktree = makeWorktree({
       id: 'pinned-ssh',

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -117,6 +117,8 @@ const WorktreeList = React.memo(function WorktreeList({
     collapsedGroups,
     agentSendTargetWorktreeId,
     groupBy,
+    pinnedDisplayPolicy,
+    visibleWorktrees,
     repoMap,
     worktreeMap,
     worktreeLineageById,

--- a/src/renderer/src/components/sidebar/pinned-section-worktrees.test.ts
+++ b/src/renderer/src/components/sidebar/pinned-section-worktrees.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest'
+import type { WorktreeLineage } from '../../../../shared/worktree/lineage-types'
+import type { Worktree } from '../../../../shared/worktree/types'
+import { getPinnedSectionWorktrees, isPinnedSectionWorktree } from './pinned-section-worktrees'
+import { worktree, repoMap } from './worktree-list-groups-test-fixtures'
+import { buildRows } from './worktree-list/grouping/build-rows'
+
+function makeWorktree(id: string, overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    ...worktree,
+    id,
+    instanceId: `${id}-instance`,
+    displayName: id,
+    ...overrides
+  }
+}
+
+function makeLineage(child: Worktree, parent: Worktree): WorktreeLineage {
+  return {
+    worktreeId: child.id,
+    worktreeInstanceId: child.instanceId!,
+    parentWorktreeId: parent.id,
+    parentWorktreeInstanceId: parent.instanceId!,
+    origin: 'cli',
+    capture: { source: 'terminal-context', confidence: 'inferred' },
+    createdAt: 1
+  }
+}
+
+describe('getPinnedSectionWorktrees', () => {
+  const parent = makeWorktree('parent')
+  const child = makeWorktree('child')
+  const grandchild = makeWorktree('grandchild')
+  const sibling = makeWorktree('sibling')
+  const lineageById = {
+    [child.id]: makeLineage(child, parent),
+    [grandchild.id]: makeLineage(grandchild, child)
+  }
+  const worktreeMap = new Map([
+    [parent.id, parent],
+    [child.id, child],
+    [grandchild.id, grandchild],
+    [sibling.id, sibling]
+  ])
+
+  it('includes only explicitly pinned rows when there is no lineage', () => {
+    const pinned = makeWorktree('pinned', { isPinned: true })
+    const loose = makeWorktree('loose')
+
+    expect(getPinnedSectionWorktrees([pinned, loose], {}, new Map([[pinned.id, pinned]]))).toEqual([
+      pinned
+    ])
+  })
+
+  it('includes visible descendants of a pinned parent', () => {
+    const pinnedParent = { ...parent, isPinned: true }
+    const map = new Map(worktreeMap)
+    map.set(pinnedParent.id, pinnedParent)
+
+    expect(
+      getPinnedSectionWorktrees([pinnedParent, child, grandchild, sibling], lineageById, map).map(
+        (worktree) => worktree.id
+      )
+    ).toEqual([pinnedParent.id, child.id, grandchild.id])
+  })
+
+  it("does not pull a pinned child's unpinned parent into Pinned", () => {
+    const pinnedChild = { ...child, isPinned: true }
+    const map = new Map(worktreeMap)
+    map.set(pinnedChild.id, pinnedChild)
+
+    expect(
+      getPinnedSectionWorktrees([parent, pinnedChild], lineageById, map).map(
+        (worktree) => worktree.id
+      )
+    ).toEqual([pinnedChild.id])
+  })
+
+  it('keeps a visible grandchild when the middle parent is absent from the visible list', () => {
+    const pinnedParent = { ...parent, isPinned: true }
+    const map = new Map(worktreeMap)
+    map.set(pinnedParent.id, pinnedParent)
+
+    expect(
+      getPinnedSectionWorktrees([pinnedParent, grandchild], lineageById, map).map(
+        (worktree) => worktree.id
+      )
+    ).toEqual([pinnedParent.id, grandchild.id])
+  })
+
+  it('does not collect descendants of a pinned parent that is not itself visible', () => {
+    const pinnedParent = { ...parent, isPinned: true }
+    const map = new Map(worktreeMap)
+    map.set(pinnedParent.id, pinnedParent)
+
+    expect(
+      getPinnedSectionWorktrees([child, sibling], lineageById, map).map((worktree) => worktree.id)
+    ).toEqual([])
+  })
+
+  it('handles a deep pinned lineage without overflowing the renderer stack', () => {
+    const depth = 6_000
+    const worktrees: Worktree[] = []
+    const lineageById: Record<string, WorktreeLineage> = {}
+    for (let index = 0; index < depth; index++) {
+      const current = makeWorktree(`deep-${index}`, { isPinned: index === 0 })
+      worktrees.push(current)
+      const parent = worktrees[index - 1]
+      if (parent) {
+        lineageById[current.id] = makeLineage(current, parent)
+      }
+    }
+
+    expect(
+      getPinnedSectionWorktrees(
+        worktrees,
+        lineageById,
+        new Map(worktrees.map((worktree) => [worktree.id, worktree]))
+      )
+    ).toHaveLength(depth)
+  })
+
+  it('builds rows for a deep expanded pinned lineage without overflowing the renderer stack', () => {
+    const depth = 6_000
+    const worktrees: Worktree[] = []
+    const lineageById: Record<string, WorktreeLineage> = {}
+    for (let index = 0; index < depth; index++) {
+      const current = makeWorktree(`rendered-deep-${index}`, { isPinned: true })
+      worktrees.push(current)
+      const parent = worktrees[index - 1]
+      if (parent) {
+        lineageById[current.id] = makeLineage(current, parent)
+      }
+    }
+
+    const rows = buildRows(
+      'none',
+      worktrees,
+      repoMap,
+      null,
+      new Set(),
+      undefined,
+      undefined,
+      undefined,
+      lineageById,
+      new Map(worktrees.map((worktree) => [worktree.id, worktree])),
+      true
+    )
+
+    expect(rows.filter((row) => row.type === 'item')).toHaveLength(depth)
+  })
+})
+
+describe('isPinnedSectionWorktree', () => {
+  const parent = makeWorktree('parent', { isPinned: true })
+  const child = makeWorktree('child')
+  const lineageById = { [child.id]: makeLineage(child, parent) }
+  const worktreeMap = new Map([
+    [parent.id, parent],
+    [child.id, child]
+  ])
+
+  it('treats an unpinned child of a visible pinned parent as pinned-section membership', () => {
+    expect(isPinnedSectionWorktree(child, [parent, child], lineageById, worktreeMap)).toBe(true)
+  })
+
+  it('does not treat an unrelated unpinned workspace as pinned-section membership', () => {
+    const other = makeWorktree('other')
+    expect(isPinnedSectionWorktree(other, [parent, child, other], lineageById, worktreeMap)).toBe(
+      false
+    )
+  })
+})

--- a/src/renderer/src/components/sidebar/pinned-section-worktrees.ts
+++ b/src/renderer/src/components/sidebar/pinned-section-worktrees.ts
@@ -1,0 +1,52 @@
+import type { WorktreeLineage } from '../../../../shared/worktree/lineage-types'
+import type { Worktree } from '../../../../shared/worktree/types'
+import { getProjectedWorktreeLineageChildrenByParentId } from './worktree-lineage-projection'
+
+// Why: pin is placement of the clicked row. Descendants keep their own isPinned
+// and still follow a visible pinned ancestor into the Pinned section.
+export function getPinnedSectionWorktrees(
+  worktrees: readonly Worktree[],
+  lineageById: Readonly<Record<string, WorktreeLineage>>,
+  worktreeMap: ReadonlyMap<string, Worktree>
+): Worktree[] {
+  const visibleIds = new Set(worktrees.map((worktree) => worktree.id))
+  const childrenByParentId = getProjectedWorktreeLineageChildrenByParentId(lineageById, worktreeMap)
+  const included = new Set<string>()
+  const seen = new Set<string>()
+  const pendingIds = worktrees
+    .filter((worktree) => worktree.isPinned)
+    .map((worktree) => worktree.id)
+
+  while (pendingIds.length > 0) {
+    const id = pendingIds.pop()
+    if (!id) {
+      continue
+    }
+    if (seen.has(id)) {
+      continue
+    }
+    seen.add(id)
+    if (visibleIds.has(id)) {
+      included.add(id)
+    }
+    for (const child of childrenByParentId.get(id) ?? []) {
+      pendingIds.push(child.id)
+    }
+  }
+
+  return worktrees.filter((worktree) => included.has(worktree.id))
+}
+
+export function isPinnedSectionWorktree(
+  worktree: Worktree,
+  visibleWorktrees: readonly Worktree[],
+  lineageById: Readonly<Record<string, WorktreeLineage>>,
+  worktreeMap: ReadonlyMap<string, Worktree>
+): boolean {
+  if (worktree.isPinned) {
+    return true
+  }
+  return getPinnedSectionWorktrees(visibleWorktrees, lineageById, worktreeMap).some(
+    (candidate) => candidate.id === worktree.id
+  )
+}

--- a/src/renderer/src/components/sidebar/worktree-list-groups-lineage-nesting.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups-lineage-nesting.test.ts
@@ -464,6 +464,123 @@ describe('buildRows workspace lineage nesting', () => {
     expect(info).toMatchObject({ state: 'missing' })
   })
 
+  it('nests unpinned children under a pinned parent in Pinned', () => {
+    const pinnedParent = { ...parent, isPinned: true }
+    const rows = buildRows(
+      'none',
+      [child, pinnedParent],
+      repoMap,
+      null,
+      new Set(),
+      undefined,
+      undefined,
+      undefined,
+      { [child.id]: lineage },
+      new Map([
+        [pinnedParent.id, pinnedParent],
+        [child.id, child]
+      ]),
+      true
+    )
+
+    const items = rows.filter((row) => row.type === 'item')
+    expect(rows[0]).toMatchObject({ type: 'header', key: 'pinned', count: 2 })
+    expect(items.map((row) => [row.worktree.id, row.depth, row.sectionKey])).toEqual([
+      [pinnedParent.id, 0, 'pinned'],
+      [child.id, 1, 'pinned']
+    ])
+    expect(rows.some((row) => row.type === 'header' && row.key === 'all')).toBe(false)
+  })
+
+  it('nests grandchildren under a pinned ancestor in Pinned', () => {
+    const pinnedParent = { ...parent, isPinned: true }
+    const rows = buildRows(
+      'none',
+      [grandchild, child, pinnedParent],
+      repoMap,
+      null,
+      new Set(),
+      undefined,
+      undefined,
+      undefined,
+      { [child.id]: lineage, [grandchild.id]: grandchildLineage },
+      new Map([
+        [pinnedParent.id, pinnedParent],
+        [child.id, child],
+        [grandchild.id, grandchild]
+      ]),
+      true
+    )
+
+    expect(
+      rows.filter((row) => row.type === 'item').map((row) => [row.worktree.id, row.depth])
+    ).toEqual([
+      [pinnedParent.id, 0],
+      [child.id, 1],
+      [grandchild.id, 2]
+    ])
+  })
+
+  it('duplicates a pinned parent tree into All when the policy allows it', () => {
+    const pinnedParent = { ...parent, isPinned: true }
+    const rows = buildRows(
+      'none',
+      [child, pinnedParent],
+      repoMap,
+      null,
+      new Set(),
+      undefined,
+      undefined,
+      undefined,
+      { [child.id]: lineage },
+      new Map([
+        [pinnedParent.id, pinnedParent],
+        [child.id, child]
+      ]),
+      true,
+      { showPinnedWorktreesInGroups: true } as never
+    )
+
+    expect(
+      rows
+        .filter((row) => row.type === 'item')
+        .map((row) => [row.sectionKey, row.worktree.id, row.depth])
+    ).toEqual([
+      ['pinned', pinnedParent.id, 0],
+      ['pinned', child.id, 1],
+      ['all', pinnedParent.id, 0],
+      ['all', child.id, 1]
+    ])
+  })
+
+  it('nests a pinned child under its pinned parent in Pinned', () => {
+    const pinnedParent = { ...parent, isPinned: true }
+    const pinnedChild = { ...child, isPinned: true }
+    const rows = buildRows(
+      'none',
+      [pinnedChild, pinnedParent],
+      repoMap,
+      null,
+      new Set(),
+      undefined,
+      undefined,
+      undefined,
+      { [child.id]: lineage },
+      new Map([
+        [pinnedParent.id, pinnedParent],
+        [pinnedChild.id, pinnedChild]
+      ]),
+      true
+    )
+
+    expect(
+      rows.filter((row) => row.type === 'item').map((row) => [row.worktree.id, row.depth])
+    ).toEqual([
+      [pinnedParent.id, 0],
+      [pinnedChild.id, 1]
+    ])
+  })
+
   it('keeps pinned children in Pinned without a parent badge', () => {
     const pinnedChild = { ...child, isPinned: true }
     const rows = buildRows(

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.ts
@@ -20,6 +20,7 @@ import {
 import { buildProjectGroupingIndex } from './project-grouping'
 import type { ProjectGroupingModel } from './project-grouping'
 import { appendProjectGroupSections } from './project-group-sections'
+import { getPinnedSectionWorktrees } from '../../pinned-section-worktrees'
 import { appendWorktreeRows, buildPendingCreationRow, emitPinnedGroup } from './row-builders'
 import { getPinnedWorktreeDisplayPolicy } from './row-types'
 import type {
@@ -82,10 +83,14 @@ export function buildRows(
     }
   }
 
+  const pinnedSectionWorktrees = nestLineage
+    ? getPinnedSectionWorktrees(worktrees, lineageById, worktreeMap)
+    : worktrees.filter((worktree) => worktree.isPinned)
+  const pinnedSectionIds = new Set(pinnedSectionWorktrees.map((worktree) => worktree.id))
   const naturalWorktrees =
     pinnedDisplayPolicy === 'duplicate-in-groups'
       ? worktrees
-      : worktrees.filter((worktree) => !worktree.isPinned)
+      : worktrees.filter((worktree) => !pinnedSectionIds.has(worktree.id))
   const mixedWorktreeHostContextLabels = getMixedWorktreeHostContextLabels(
     naturalWorktrees,
     repoMap,
@@ -103,14 +108,18 @@ export function buildRows(
     projectGrouping
   })
   emitPinnedGroup(
-    worktrees,
+    pinnedSectionWorktrees,
     repoMap,
     defaultHostId,
     collapsedGroups,
     renderedNaturalAnchorRepoIds,
     importedWorktreesByRepo,
     groupBy !== 'repo',
-    result
+    result,
+    lineageById,
+    worktreeMap,
+    nestLineage,
+    cyclicLineageIds
   )
   if (groupBy === 'none') {
     if (naturalWorktrees.length > 0) {

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/row-builders.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/row-builders.ts
@@ -29,24 +29,27 @@ export function buildPendingCreationRow(
 }
 
 export function emitPinnedGroup(
-  worktrees: Worktree[],
+  pinnedSectionWorktrees: Worktree[],
   repoMap: Map<string, Repo>,
   defaultHostId: ExecutionHostId,
   collapsedGroups: Set<string>,
   renderedNaturalAnchorRepoIds: ReadonlySet<string>,
   importedWorktreesByRepo: ReadonlyMap<string, ImportedWorktreesCardCandidate>,
   allowImportedFallback: boolean,
-  result: Row[]
+  result: Row[],
+  lineageById: Record<string, WorktreeLineage>,
+  worktreeMap: Map<string, Worktree>,
+  nestLineage: boolean,
+  cyclicLineageIds: ReadonlySet<string>
 ): void {
-  const pinned = worktrees.filter((w) => w.isPinned)
-  if (pinned.length === 0) {
+  if (pinnedSectionWorktrees.length === 0) {
     return
   }
   const hostWorktreeCounts = new Map<ExecutionHostId, number>()
   const hostWorktreeIds = new Map<ExecutionHostId, string[]>()
   const pinnedRepoOrder: string[] = []
   const seenPinnedRepoIds = new Set<string>()
-  for (const worktree of pinned) {
+  for (const worktree of pinnedSectionWorktrees) {
     const hostId = getWorktreeExecutionHostId(worktree, repoMap.get(worktree.repoId), defaultHostId)
     hostWorktreeCounts.set(hostId, (hostWorktreeCounts.get(hostId) ?? 0) + 1)
     const hostIds = hostWorktreeIds.get(hostId) ?? []
@@ -62,12 +65,12 @@ export function emitPinnedGroup(
     type: 'header',
     key: PINNED_GROUP_KEY,
     label: PINNED_GROUP_META.label,
-    count: pinned.length,
+    count: pinnedSectionWorktrees.length,
     tone: PINNED_GROUP_META.tone,
     icon: PINNED_GROUP_META.icon,
     hostWorktreeCounts,
     hostWorktreeIds,
-    worktreeIds: pinned.map((worktree) => worktree.id)
+    worktreeIds: pinnedSectionWorktrees.map((worktree) => worktree.id)
   })
   if (collapsedGroups.has(PINNED_GROUP_KEY)) {
     for (const repoId of pinnedRepoOrder) {
@@ -76,31 +79,34 @@ export function emitPinnedGroup(
         result.push(buildImportedWorktreesCardRow(candidate, 'pinned-fallback'))
       }
     }
-  } else {
-    const lastPinnedIndexByRepoId = new Map<string, number>()
-    pinned.forEach((worktree, index) => lastPinnedIndexByRepoId.set(worktree.repoId, index))
-    for (const [index, worktree] of pinned.entries()) {
-      result.push(
-        buildWorktreeRow(worktree, repoMap, {
-          rowKey: `${PINNED_GROUP_KEY}:${worktree.id}`,
-          sectionKey: PINNED_GROUP_KEY,
-          depth: 0,
-          groupDepth: 0,
-          lineageTrail: [],
-          isLastLineageChild: false,
-          lineageChildCount: 0,
-          lineageCollapsed: false
-        })
-      )
-      const candidate = importedWorktreesByRepo.get(worktree.repoId)
-      if (
-        allowImportedFallback &&
-        candidate &&
-        !renderedNaturalAnchorRepoIds.has(worktree.repoId) &&
-        lastPinnedIndexByRepoId.get(worktree.repoId) === index
-      ) {
-        result.push(buildImportedWorktreesCardRow(candidate, 'pinned-fallback'))
-      }
+    return
+  }
+
+  const firstItemIndex = result.length
+  appendWorktreeRows(result, pinnedSectionWorktrees, repoMap, lineageById, worktreeMap, {
+    nestLineage,
+    collapsedGroups,
+    groupDepth: 0,
+    sectionKey: PINNED_GROUP_KEY,
+    cyclicLineageIds
+  })
+  if (!allowImportedFallback) {
+    return
+  }
+  // Why: imported fallback sits after the last row of that repo; splice from the
+  // end so earlier inserts do not shift later targets.
+  const lastResultIndexByRepoId = new Map<string, number>()
+  for (let index = firstItemIndex; index < result.length; index++) {
+    const row = result[index]
+    if (row?.type === 'item') {
+      lastResultIndexByRepoId.set(row.worktree.repoId, index)
+    }
+  }
+  const inserts = [...lastResultIndexByRepoId.entries()].sort((left, right) => right[1] - left[1])
+  for (const [repoId, index] of inserts) {
+    const candidate = importedWorktreesByRepo.get(repoId)
+    if (candidate && !renderedNaturalAnchorRepoIds.has(repoId)) {
+      result.splice(index + 1, 0, buildImportedWorktreesCardRow(candidate, 'pinned-fallback'))
     }
   }
 }
@@ -222,6 +228,51 @@ export function appendWorktreeRows(
   }
 
   const emitted = new Set<string>()
+  const pending: {
+    worktree: Worktree
+    depth: number
+    lineageTrail: boolean[]
+    isLastChild: boolean
+  }[] = []
+  const emitPending = (): void => {
+    while (pending.length > 0) {
+      const next = pending.pop()
+      if (!next || emitted.has(next.worktree.id)) {
+        continue
+      }
+      const { worktree, depth, lineageTrail, isLastChild } = next
+      const children = childrenByParentId.get(worktree.id) ?? []
+      const lineageGroupKey = getLineageGroupKey(worktree.id)
+      const lineageCollapsed = collapsedGroups.has(lineageGroupKey)
+      emitted.add(worktree.id)
+      result.push(
+        buildWorktreeRow(worktree, repoMap, {
+          rowKey: `${sectionKey}:${worktree.id}`,
+          sectionKey,
+          depth,
+          groupDepth,
+          lineageTrail,
+          isLastLineageChild: isLastChild,
+          lineageChildCount: children.length,
+          lineageCollapsed,
+          hostContextLabel:
+            hostContextLabelByWorktreeId?.get(worktree.id) ??
+            hostContextLabelByRepoId?.get(worktree.repoId)
+        })
+      )
+      if (lineageCollapsed) {
+        continue
+      }
+      for (let index = children.length - 1; index >= 0; index -= 1) {
+        pending.push({
+          worktree: children[index],
+          depth: depth + 1,
+          lineageTrail: [...lineageTrail, index < children.length - 1],
+          isLastChild: index === children.length - 1
+        })
+      }
+    }
+  }
   const emit = (
     worktree: Worktree,
     depth: number,
@@ -231,36 +282,8 @@ export function appendWorktreeRows(
     if (emitted.has(worktree.id)) {
       return
     }
-    const children = childrenByParentId.get(worktree.id) ?? []
-    const lineageGroupKey = getLineageGroupKey(worktree.id)
-    const lineageCollapsed = collapsedGroups.has(lineageGroupKey)
-    emitted.add(worktree.id)
-    result.push(
-      buildWorktreeRow(worktree, repoMap, {
-        rowKey: `${sectionKey}:${worktree.id}`,
-        sectionKey,
-        depth,
-        groupDepth,
-        lineageTrail,
-        isLastLineageChild: isLastChild,
-        lineageChildCount: children.length,
-        lineageCollapsed,
-        hostContextLabel:
-          hostContextLabelByWorktreeId?.get(worktree.id) ??
-          hostContextLabelByRepoId?.get(worktree.repoId)
-      })
-    )
-    if (lineageCollapsed) {
-      return
-    }
-    children.forEach((child, index) => {
-      emit(
-        child,
-        depth + 1,
-        [...lineageTrail, index < children.length - 1],
-        index === children.length - 1
-      )
-    })
+    pending.push({ worktree, depth, lineageTrail, isLastChild })
+    emitPending()
   }
 
   const roots = worktrees.filter((worktree) => !childIds.has(worktree.id))

--- a/src/renderer/src/components/sidebar/worktree-list/listing/use-collapsed-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/use-collapsed-groups.ts
@@ -5,9 +5,10 @@ import type { Repo } from '../../../../../../shared/repo-types'
 import type { WorkspaceStatusDefinition, Worktree } from '../../../../../../shared/worktree/types'
 import type { WorktreeLineage } from '../../../../../../shared/worktree/lineage-types'
 import { PINNED_GROUP_KEY, getLineageGroupKey } from '../grouping/group-keys'
+import type { PinnedWorktreeDisplayPolicy, WorktreeGroupBy } from '../grouping/row-types'
 import type { ProjectGroupingModel } from '../grouping/project-grouping'
-import type { WorktreeGroupBy } from '../grouping/row-types'
 import { getGroupKeysForWorktree } from '../grouping/worktree-group-keys'
+import { isPinnedSectionWorktree } from '../../pinned-section-worktrees'
 import { getWorktreeLineageAncestors } from '../../worktree-lineage-projection'
 
 // While the agent send picker targets a workspace, force open every section that hides it.
@@ -15,6 +16,8 @@ export function useEffectiveCollapsedGroups(args: {
   collapsedGroups: Set<string>
   agentSendTargetWorktreeId: string | null
   groupBy: WorktreeGroupBy
+  pinnedDisplayPolicy: PinnedWorktreeDisplayPolicy
+  visibleWorktrees: readonly Worktree[]
   repoMap: Map<string, Repo>
   worktreeMap: Map<string, Worktree>
   worktreeLineageById: Record<string, WorktreeLineage>
@@ -28,6 +31,8 @@ export function useEffectiveCollapsedGroups(args: {
     collapsedGroups,
     agentSendTargetWorktreeId,
     groupBy,
+    pinnedDisplayPolicy,
+    visibleWorktrees,
     repoMap,
     worktreeMap,
     worktreeLineageById,
@@ -46,7 +51,10 @@ export function useEffectiveCollapsedGroups(args: {
       return collapsedGroups
     }
     const next = new Set(collapsedGroups)
-    if (targetWorktree.isPinned) {
+    if (
+      pinnedDisplayPolicy === 'single-location' &&
+      isPinnedSectionWorktree(targetWorktree, visibleWorktrees, worktreeLineageById, worktreeMap)
+    ) {
       next.delete(PINNED_GROUP_KEY)
     } else {
       for (const groupKey of getGroupKeysForWorktree(
@@ -75,6 +83,8 @@ export function useEffectiveCollapsedGroups(args: {
     agentSendTargetWorktreeId,
     collapsedGroups,
     groupBy,
+    pinnedDisplayPolicy,
+    visibleWorktrees,
     prCache,
     projectGroups,
     projectGrouping,

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/pending-reveal-inputs.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/pending-reveal-inputs.ts
@@ -14,6 +14,7 @@ import { getLineageGroupKey } from '../grouping/group-keys'
 import type { ProjectGroupingModel } from '../grouping/project-grouping'
 import type { PinnedWorktreeDisplayPolicy, WorktreeGroupBy } from '../grouping/row-types'
 import { getGroupKeysForWorktree } from '../grouping/worktree-group-keys'
+import { isPinnedSectionWorktree } from '../../pinned-section-worktrees'
 import { getWorktreeLineageAncestors } from '../../worktree-lineage-projection'
 import { getFolderWorkspaceRevealGroupKeys } from './folder-reveal'
 import { getPinnedWorktreeRevealCollapsedGroupKeys } from './reveal-ancestors'
@@ -90,10 +91,17 @@ export function expandGroupsForWorktreeReveal(
   }
 
   const groupKeys =
-    targetWorktree.isPinned && args.pinnedDisplayPolicy === 'single-location'
+    args.pinnedDisplayPolicy === 'single-location' &&
+    isPinnedSectionWorktree(
+      targetWorktree,
+      args.worktrees,
+      args.worktreeLineageById,
+      args.worktreeMap
+    )
       ? getPinnedWorktreeRevealCollapsedGroupKeys({
           worktree: targetWorktree,
-          collapsedGroups: args.collapsedGroups
+          collapsedGroups: args.collapsedGroups,
+          inPinnedSection: true
         })
       : getGroupKeysForWorktree(
           args.groupBy,

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/reveal-ancestors.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/reveal-ancestors.ts
@@ -92,12 +92,14 @@ export function getSidebarRowRevealAncestorKeys(args: {
 
 export function getPinnedWorktreeRevealCollapsedGroupKeys({
   worktree,
-  collapsedGroups
+  collapsedGroups,
+  inPinnedSection = worktree.isPinned
 }: {
   worktree: Worktree
   collapsedGroups: ReadonlySet<string>
+  inPinnedSection?: boolean
 }): string[] {
-  if (!worktree.isPinned) {
+  if (!inPinnedSection) {
     return []
   }
   const keys: string[] = []

--- a/src/renderer/src/store/slices/worktrees-workspace-selection-state.test.ts
+++ b/src/renderer/src/store/slices/worktrees-workspace-selection-state.test.ts
@@ -6,7 +6,12 @@ import {
 } from '../../components/browser-pane/webview-registry'
 import { folderWorkspaceKey, worktreeWorkspaceKey } from '../../../../shared/workspace-scope'
 import { makeDetectedResult } from './worktrees-detected-listing-fixtures'
-import { createWebview, makeFolderWorkspace, makeWorktree } from './worktrees-slice-test-fixtures'
+import {
+  createWebview,
+  makeFolderWorkspace,
+  makeLineage,
+  makeWorktree
+} from './worktrees-slice-test-fixtures'
 import {
   createTestStore,
   mockApi,
@@ -381,6 +386,160 @@ describe('setWorktreesPinnedAndReveal', () => {
     store.getState().setWorktreesPinnedAndReveal([other.id], true)
 
     expect(store.getState().worktreesByRepo.repo1[1].isPinned).toBe(true)
+    expect(reveal).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    { previousPinned: false, nextPinned: true },
+    { previousPinned: true, nextPinned: false }
+  ])(
+    'reveals the focused descendant when changing its unfocused ancestor from $previousPinned to $nextPinned',
+    ({ previousPinned, nextPinned }) => {
+      const store = createTestStore()
+      const parent = makeWorktree({
+        id: 'repo1::/parent',
+        instanceId: 'parent-instance',
+        repoId: 'repo1',
+        isPinned: previousPinned
+      })
+      const child = makeWorktree({
+        id: 'repo1::/child',
+        instanceId: 'child-instance',
+        repoId: 'repo1'
+      })
+      const reveal = vi.fn()
+      store.setState({
+        worktreesByRepo: { repo1: [parent, child] },
+        worktreeLineageById: {
+          [child.id]: makeLineage({ worktreeId: child.id, parentWorktreeId: parent.id })
+        },
+        activeWorktreeId: child.id,
+        revealWorktreeInSidebar: reveal
+      } as Partial<AppState>)
+
+      store.getState().setWorktreesPinnedAndReveal([parent.id], nextPinned)
+
+      expect(reveal).toHaveBeenCalledWith(child.id, { behavior: 'smooth', highlight: true })
+    }
+  )
+
+  it('reveals the focused descendant from embedded legacy lineage', () => {
+    const store = createTestStore()
+    const parent = makeWorktree({
+      id: 'repo1::/parent',
+      instanceId: 'parent-instance',
+      repoId: 'repo1'
+    })
+    const child = {
+      ...makeWorktree({
+        id: 'repo1::/child',
+        instanceId: 'child-instance',
+        repoId: 'repo1'
+      }),
+      lineage: makeLineage({ worktreeId: 'repo1::/child', parentWorktreeId: parent.id })
+    }
+    const reveal = vi.fn()
+    store.setState({
+      worktreesByRepo: { repo1: [parent, child] },
+      activeWorktreeId: child.id,
+      revealWorktreeInSidebar: reveal
+    } as Partial<AppState>)
+
+    store.getState().setWorktreesPinnedAndReveal([parent.id], true)
+
+    expect(reveal).toHaveBeenCalledWith(child.id, { behavior: 'smooth', highlight: true })
+  })
+
+  it('does not reveal through cyclic lineage rejected by rendering', () => {
+    const store = createTestStore()
+    const first = makeWorktree({
+      id: 'repo1::/first',
+      instanceId: 'first-instance',
+      repoId: 'repo1'
+    })
+    const second = makeWorktree({
+      id: 'repo1::/second',
+      instanceId: 'second-instance',
+      repoId: 'repo1'
+    })
+    const reveal = vi.fn()
+    store.setState({
+      worktreesByRepo: { repo1: [first, second] },
+      worktreeLineageById: {
+        [first.id]: makeLineage({
+          worktreeId: first.id,
+          worktreeInstanceId: first.instanceId,
+          parentWorktreeId: second.id,
+          parentWorktreeInstanceId: second.instanceId
+        }),
+        [second.id]: makeLineage({
+          worktreeId: second.id,
+          worktreeInstanceId: second.instanceId,
+          parentWorktreeId: first.id,
+          parentWorktreeInstanceId: first.instanceId
+        })
+      },
+      activeWorktreeId: second.id,
+      revealWorktreeInSidebar: reveal
+    } as Partial<AppState>)
+
+    store.getState().setWorktreesPinnedAndReveal([first.id], true)
+
+    expect(reveal).not.toHaveBeenCalled()
+  })
+
+  it('does not reveal a focused descendant for duplicate pinned rows', () => {
+    const store = createTestStore()
+    const parent = makeWorktree({
+      id: 'repo1::/parent',
+      instanceId: 'parent-instance',
+      repoId: 'repo1'
+    })
+    const child = makeWorktree({
+      id: 'repo1::/child',
+      instanceId: 'child-instance',
+      repoId: 'repo1'
+    })
+    const reveal = vi.fn()
+    store.setState({
+      worktreesByRepo: { repo1: [parent, child] },
+      worktreeLineageById: {
+        [child.id]: makeLineage({ worktreeId: child.id, parentWorktreeId: parent.id })
+      },
+      activeWorktreeId: child.id,
+      settings: { ...store.getState().settings, showPinnedWorktreesInGroups: true },
+      revealWorktreeInSidebar: reveal
+    } as Partial<AppState>)
+
+    store.getState().setWorktreesPinnedAndReveal([parent.id], true)
+
+    expect(reveal).not.toHaveBeenCalled()
+  })
+
+  it('does not reveal through stale lineage', () => {
+    const store = createTestStore()
+    const parent = makeWorktree({
+      id: 'repo1::/parent',
+      instanceId: 'replacement-parent-instance',
+      repoId: 'repo1'
+    })
+    const child = makeWorktree({
+      id: 'repo1::/child',
+      instanceId: 'child-instance',
+      repoId: 'repo1'
+    })
+    const reveal = vi.fn()
+    store.setState({
+      worktreesByRepo: { repo1: [parent, child] },
+      worktreeLineageById: {
+        [child.id]: makeLineage({ worktreeId: child.id, parentWorktreeId: parent.id })
+      },
+      activeWorktreeId: child.id,
+      revealWorktreeInSidebar: reveal
+    } as Partial<AppState>)
+
+    store.getState().setWorktreesPinnedAndReveal([parent.id], true)
+
     expect(reveal).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/src/store/slices/worktrees/session/worktree-pin-reveal.ts
+++ b/src/renderer/src/store/slices/worktrees/session/worktree-pin-reveal.ts
@@ -4,7 +4,56 @@ import {
   getActiveSidebarWorkspaceId,
   parseWorkspaceKey
 } from '../../../../../../shared/workspace-scope'
+import {
+  getCyclicWorktreeLineageChildIds,
+  isValidResolvedWorktreeLineageEdge
+} from '../../../../../../shared/resolved-worktree-lineage'
+import type { WorktreeLineage } from '../../../../../../shared/worktree/lineage-types'
 import type { WorktreeMeta } from '../../../../../../shared/worktree/meta-types'
+import type { Worktree } from '../../../../../../shared/worktree/types'
+
+type WorktreeWithEmbeddedLineage = Worktree & { lineage?: WorktreeLineage | null }
+
+function getProjectedLineage(get: WorktreeSliceGet, worktree: Worktree): WorktreeLineage | null {
+  if (Object.hasOwn(get().worktreeLineageById, worktree.id)) {
+    return get().worktreeLineageById[worktree.id] ?? null
+  }
+  return (worktree as WorktreeWithEmbeddedLineage).lineage ?? null
+}
+
+function hasChangedLineageAncestor(
+  get: WorktreeSliceGet,
+  worktreeId: string,
+  changedWorktreeIds: ReadonlySet<string>
+): boolean {
+  const seen = new Set<string>()
+  const validLineageByChildId = new Map<string, WorktreeLineage>()
+  let child = get().getKnownWorktreeById(worktreeId)
+  while (child && !seen.has(child.id)) {
+    seen.add(child.id)
+    const lineage = getProjectedLineage(get, child)
+    const parent = lineage ? get().getKnownWorktreeById(lineage.parentWorktreeId) : null
+    if (!lineage || !parent || !isValidResolvedWorktreeLineageEdge(child, parent, lineage)) {
+      break
+    }
+    validLineageByChildId.set(child.id, lineage)
+    child = parent
+  }
+  const cyclicIds = getCyclicWorktreeLineageChildIds(validLineageByChildId)
+  child = get().getKnownWorktreeById(worktreeId)
+  while (child && !cyclicIds.has(child.id)) {
+    const lineage = getProjectedLineage(get, child)
+    const parent = lineage ? get().getKnownWorktreeById(lineage.parentWorktreeId) : null
+    if (!lineage || !parent || !isValidResolvedWorktreeLineageEdge(child, parent, lineage)) {
+      return false
+    }
+    if (changedWorktreeIds.has(parent.id)) {
+      return true
+    }
+    child = parent
+  }
+  return false
+}
 
 export function createSetWorktreesPinnedAndReveal(
   _set: WorktreeSliceSet,
@@ -18,6 +67,7 @@ export function createSetWorktreesPinnedAndReveal(
     )
     // Skip worktrees already in the target state so a no-op toggle doesn't scroll the viewport away.
     const updates = new Map<string, Partial<WorktreeMeta>>()
+    const changedWorktreeIds = new Set<string>()
     let didChange = false
     let revealWorktreeId: string | null = null
     for (const worktreeId of worktreeIds) {
@@ -26,6 +76,7 @@ export function createSetWorktreesPinnedAndReveal(
         continue
       }
       didChange = true
+      changedWorktreeIds.add(worktreeId)
       const workspaceScope = parseWorkspaceKey(worktreeId)
       if (workspaceScope?.type === 'folder') {
         void get().updateWorktreeMeta(worktreeId, { isPinned })
@@ -38,6 +89,14 @@ export function createSetWorktreesPinnedAndReveal(
     }
     if (!didChange) {
       return
+    }
+    if (
+      revealWorktreeId === null &&
+      activeSidebarWorktreeId !== null &&
+      get().settings?.showPinnedWorktreesInGroups !== true &&
+      hasChangedLineageAncestor(get, activeSidebarWorktreeId, changedWorktreeIds)
+    ) {
+      revealWorktreeId = activeSidebarWorktreeId
     }
     // updateWorktreesMeta applies the store update synchronously, so the reveal below sees the row already rendered.
     if (updates.size > 0) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​468 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​467 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​236 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​71 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​165 |

<!-- /orca-pr-loc -->

## Problem

When a parent worktree is pinned, its descendants are not automatically included in the Pinned section. Users must explicitly pin each descendant, or descendants appear only in the All section even though their ancestor is pinned.

## Solution

Use the worktree lineage graph to automatically include all visible descendants of pinned parents in the Pinned section. A worktree belongs in Pinned if it's explicitly pinned OR if it has a visible pinned ancestor. This makes the Pinned section behave as a cohesive tree: pinning the root pins the whole branch.

### Changes

- **New helper module** (`pinned-section-worktrees.ts`): `getPinnedSectionWorktrees()` and `isPinnedSectionWorktree()` to determine Pinned section membership based on pinned status or lineage.
- **Iterative rendering** (`row-builders.ts`): Refactored `appendWorktreeRows` from recursive to stack-based to handle deep lineages (tested to 6,000 levels) without stack overflow.
- **Lineage-aware navigation**: Updated `reveal-ancestors.ts`, `pending-reveal-inputs.ts`, and `use-collapsed-groups.ts` to treat unpinned children of pinned parents as Pinned section members.
- **Pin/reveal integration** (`worktree-pin-reveal.ts`): When toggling a parent's pin state, auto-reveal the active focused descendant if it's now in a different section.
- **Edge case handling**: Validates lineage edges, skips cyclic/stale lineage, respects the `showPinnedWorktreesInGroups` policy, and handles embedded legacy lineage.

## Testing

- Added `pinned-section-worktrees.test.ts` covering lineage traversal, deep nesting, and edge cases.
- Extended `worktree-list-groups-lineage-nesting.test.ts` with tests for nesting unpinned children under pinned parents.
- Added `setWorktreesPinnedAndReveal` tests for reveal behavior with pinned lineages.
- Tests verify cyclic/stale lineage rejection and policy-aware behavior.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (logic is platform-agnostic)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` should pass (comprehensive test suite added)