### PR TITLE
fix(tabs): preserve pane identity for agent-name task titles

### DIFF
--- a/src/renderer/src/lib/use-tab-agent.test.ts
+++ b/src/renderer/src/lib/use-tab-agent.test.ts
@@ -697,6 +697,16 @@ describe('useTabAgent', () => {
     expect(clearTabLaunchAgent).toHaveBeenCalledWith('tab-1')
   })
 
+  it('does not clear launch identity from a task title that only mentions its own agent name', async () => {
+    // Why: no hook/process evidence anywhere else, so a mere name mention must not arm exit-clearing.
+    const root = await renderHookProbe(baseTab)
+    await rerenderHookProbe(root, { ...baseTab, title: '⠋ Fix the codex plugin launcher' })
+    await rerenderHookProbe(root, { ...baseTab, title: 'zsh' })
+
+    expect(latestHookAgent).toBe('codex')
+    expect(clearTabLaunchAgent).not.toHaveBeenCalled()
+  })
+
   it('uses completed local hook status as launch lifecycle evidence after remount', async () => {
     const paneKey = makePaneKey('tab-1', LEAF_ID)
     useAppStore.setState({

--- a/src/renderer/src/lib/use-tab-agent.test.ts
+++ b/src/renderer/src/lib/use-tab-agent.test.ts
@@ -307,6 +307,43 @@ describe('resolveTabAgentFromSignals', () => {
     ).toBe('claude')
   })
 
+  it('keeps a Claude-owned pane Claude when its task title mentions another agent', () => {
+    for (const title of [
+      '⠋ Fix the codex plugin launcher',
+      '⠙ add grok support to the tab bar',
+      '⠹ port the gemini status parser'
+    ]) {
+      for (const signals of [
+        { hasObservedAgentSignal: true, isRemote: false },
+        {
+          hasObservedAgentSignal: true,
+          isRemote: false,
+          focusedCompletedHookAgent: 'claude' as const
+        },
+        { hasObservedAgentSignal: true, isRemote: true }
+      ]) {
+        expect(
+          resolveTabAgentFromSignals({
+            ...signals,
+            title,
+            hookAgent: null,
+            launchAgent: 'claude'
+          })
+        ).toBe('claude')
+      }
+    }
+
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: true,
+        isRemote: false,
+        title: '⠋ Codex: fix cursor offsets',
+        hookAgent: null,
+        launchAgent: 'claude'
+      })
+    ).toBe('codex')
+  })
+
   it('does not let an explicit title override launch identity before any activity is observed', () => {
     expect(
       resolveTabAgentFromSignals({

--- a/src/renderer/src/lib/use-tab-agent.ts
+++ b/src/renderer/src/lib/use-tab-agent.ts
@@ -277,8 +277,10 @@ export function useTabAgent(tab: TerminalTab): TuiAgent | null {
     }
     const explicitTitleAgent = resolveExplicitTerminalTitleAgentType(tab.title)
     // Why: only a title naming the launched agent arms its exit clearing — sibling/other-agent evidence must not.
+    // A title that only mentions the launch agent's name in task text (not its own identity
+    // frame) must not count either, or that mention alone can later clear a live launchAgent.
     const fallbackAgentSignal = tab.launchAgent
-      ? explicitTitleAgent === tab.launchAgent
+      ? explicitTitleAgent === tab.launchAgent && titlePresentsAgent(tab.title, tab.launchAgent)
       : Boolean(explicitTitleAgent || siblingHookAgent)
     // Why: a recognized foreground process arms exit clearing even for agents with no hook or title integration.
     if (focusedHookAgent || completedHookEvidence || processAgent || fallbackAgentSignal) {

--- a/src/renderer/src/lib/use-tab-agent.ts
+++ b/src/renderer/src/lib/use-tab-agent.ts
@@ -12,14 +12,12 @@ import {
   resolveSiblingRetainedTabAgent,
   resolveSiblingTabAgent
 } from './tab-agent'
-import {
-  isClaudeIdentityFrameTitle,
-  resolveExplicitTerminalTitleAgentType
-} from '../../../shared/terminal-title-agent-type'
+import { resolveExplicitTerminalTitleAgentType } from '../../../shared/terminal-title-agent-type'
 import { resolveCompatibleAgentTypeForOwner } from '../../../shared/agent-title-owner'
 import { isOpenCodeNativeTitle } from '../../../shared/opencode-terminal-title'
 import { resolvePaneAgentOwner } from '../../../shared/pane-agent-owner'
 import type { TerminalTab } from '../../../shared/terminal-tab-types'
+import { titlePresentsAgent } from '../../../shared/terminal-title-identity-claim'
 import type { TuiAgent } from '../../../shared/tui-agent'
 
 // A shell name or the tab's neutral default title (where inferred-interrupt reset parks it); blank titles are no evidence.
@@ -119,10 +117,9 @@ export function resolveTabAgentFromSignals(args: {
   )
   const priorIdentity = idleFocusedIdentity ?? launchAgent
   const nativeOpenCodeTitle = explicitTitleAgent === 'opencode' && isOpenCodeNativeTitle(args.title)
-  // Why: a "claude" token in another agent's task text is a mention, not identity, so it must
-  // not take a pane from its known owner — only a title that PRESENTS Claude may (#8940).
+  // Why: an agent name in another agent's task text is a mention, not identity (#8940, #14937).
   const titleClaimsIdentity =
-    explicitTitleAgent !== 'claude' || isClaudeIdentityFrameTitle(args.title)
+    explicitTitleAgent !== null && titlePresentsAgent(args.title, explicitTitleAgent)
   // Why: native OpenCode titles can reclaim stale launch intent before any observed hook signal.
   const titleReclaimsReusedPane =
     priorIdentity !== null &&

--- a/src/renderer/src/lib/use-tab-agent.ts
+++ b/src/renderer/src/lib/use-tab-agent.ts
@@ -277,8 +277,7 @@ export function useTabAgent(tab: TerminalTab): TuiAgent | null {
     }
     const explicitTitleAgent = resolveExplicitTerminalTitleAgentType(tab.title)
     // Why: only a title naming the launched agent arms its exit clearing — sibling/other-agent evidence must not.
-    // A title that only mentions the launch agent's name in task text (not its own identity
-    // frame) must not count either, or that mention alone can later clear a live launchAgent.
+    // Task-text mentions must not arm exit clearing.
     const fallbackAgentSignal = tab.launchAgent
       ? explicitTitleAgent === tab.launchAgent && titlePresentsAgent(tab.title, tab.launchAgent)
       : Boolean(explicitTitleAgent || siblingHookAgent)

--- a/src/shared/terminal-title-identity-claim.ts
+++ b/src/shared/terminal-title-identity-claim.ts
@@ -1,0 +1,45 @@
+import { stripLeadingAgentTitleDecorationOrEmpty } from './agent-title-decoration'
+import { isOpenCodeNativeTitle } from './opencode-terminal-title'
+import { isLegacyPiCompatibleTitle } from './pi-compatible-synthetic-title'
+import { getSyntheticAgentTitleProfile } from './synthetic-agent-title'
+import { isClaudeIdentityFrameTitle, isGrokRotatingWorkingTitle } from './terminal-title-agent-type'
+import { getWrapperTitleSegments } from './terminal-title-wrapper-segments'
+import { TUI_AGENT_DISPLAY_NAMES } from './tui-agent-display-names'
+import type { TuiAgent } from './tui-agent'
+
+/** Whether a terminal title presents an agent identity rather than mentioning it in task text. */
+export function titlePresentsAgent(title: string, agent: TuiAgent): boolean {
+  if (agent === 'claude') {
+    return isClaudeIdentityFrameTitle(title)
+  }
+  if (agent === 'opencode' && isOpenCodeNativeTitle(title)) {
+    return true
+  }
+  if (agent === 'grok' && isGrokRotatingWorkingTitle(title)) {
+    return true
+  }
+  if (agent === 'pi' && isLegacyPiCompatibleTitle(title)) {
+    return true
+  }
+
+  const displayName = TUI_AGENT_DISPLAY_NAMES[agent]
+  const profile = getSyntheticAgentTitleProfile(agent)
+  const identityNames = new Set([
+    displayName,
+    `${displayName} CLI`,
+    `${displayName} Code`,
+    `${displayName} Agent`,
+    ...(profile ? [profile.workingLabel, profile.permissionLabel, profile.idleLabel] : [])
+  ])
+  return getWrapperTitleSegments(title).some((segment) => {
+    const normalized = stripLeadingAgentTitleDecorationOrEmpty(segment).trim().toLowerCase()
+    return [...identityNames].some((name) => {
+      const identityName = name.toLowerCase()
+      const suffix = normalized.slice(identityName.length)
+      return (
+        normalized.startsWith(identityName) &&
+        (suffix.length === 0 || suffix.startsWith(':') || suffix.startsWith(' - action required'))
+      )
+    })
+  })
+}

--- a/tests/e2e/sidebar-agent-row-identity.spec.ts
+++ b/tests/e2e/sidebar-agent-row-identity.spec.ts
@@ -17,16 +17,12 @@ import { worktreeRow } from './worktree-row-locators'
  * dropped unconditionally, so a hookless Cursor pane produced no sidebar row.
  * #8940 — an incidental `claude` token inside an OpenCode task title outranked
  * the pane's known owner, flipping the row label + identity icon to Claude Code.
- * #14937 - an incidental agent token inside a Claude task title must likewise
- * not replace the pane's known Claude identity or its tab icon.
  */
 
 // The literal Cursor emits on every redraw — the pane's ONLY identity signal.
 const CURSOR_NATIVE_OSC_TITLE = 'Cursor Agent'
 // An OpenCode task title that merely MENTIONS claude (see #8940).
 const OPENCODE_TASK_OSC_TITLE = '⠋ use Claude Sonnet'
-// A Claude task title that merely MENTIONS Codex (see #14937).
-const CLAUDE_TASK_OSC_TITLE = '⠋ Fix the codex plugin launcher'
 
 /** Printed banner that proves the emitter ran; the OSC title trails it in the same chunk. */
 const PANE_HOLD_MARKER = 'agent pane holding'
@@ -74,7 +70,7 @@ function paneTitles(page: Page, tabId: string): Promise<string[]> {
 async function openAgentTab(
   page: Page,
   worktreeId: string,
-  launchAgent: 'claude' | 'cursor' | 'opencode'
+  launchAgent: 'cursor' | 'opencode'
 ): Promise<{ tabId: string; ptyId: string }> {
   const tabId = await page.evaluate(
     ({ worktreeId, launchAgent }) => {
@@ -205,30 +201,4 @@ test('sidebar keeps a Cursor pane visible and an OpenCode pane out of Claude Cod
 
   openCodeScript.cleanup()
   cursorScript.cleanup()
-})
-
-test('Claude task titles that mention Codex keep the Claude tab icon', async ({ orcaPage }) => {
-  await waitForSessionReady(orcaPage)
-  const worktreeId = await waitForActiveWorktree(orcaPage)
-  await ensureTerminalVisible(orcaPage)
-
-  const claude = await openAgentTab(orcaPage, worktreeId, 'claude')
-  const claudeScript = await runNodeScriptInTerminal(
-    orcaPage,
-    claude.ptyId,
-    oscTitleHolderScript('\\u280b Fix the codex plugin launcher')
-  )
-  await waitForTerminalOutput(orcaPage, PANE_HOLD_MARKER, 15_000)
-  await expect
-    .poll(() => paneTitles(orcaPage, claude.tabId), {
-      timeout: 15_000,
-      message: 'the Claude task title never reached the renderer'
-    })
-    .toContain(CLAUDE_TASK_OSC_TITLE)
-
-  const claudeTab = orcaPage.locator(`[data-tab-id="${claude.tabId}"]`)
-  await expect(claudeTab.locator('[data-agent-icon="claude"]')).toBeVisible()
-  await expect(claudeTab.locator('[data-agent-icon="codex"]')).toHaveCount(0)
-
-  claudeScript.cleanup()
 })

--- a/tests/e2e/sidebar-agent-row-identity.spec.ts
+++ b/tests/e2e/sidebar-agent-row-identity.spec.ts
@@ -17,12 +17,16 @@ import { worktreeRow } from './worktree-row-locators'
  * dropped unconditionally, so a hookless Cursor pane produced no sidebar row.
  * #8940 — an incidental `claude` token inside an OpenCode task title outranked
  * the pane's known owner, flipping the row label + identity icon to Claude Code.
+ * #14937 - an incidental agent token inside a Claude task title must likewise
+ * not replace the pane's known Claude identity or its tab icon.
  */
 
 // The literal Cursor emits on every redraw — the pane's ONLY identity signal.
 const CURSOR_NATIVE_OSC_TITLE = 'Cursor Agent'
 // An OpenCode task title that merely MENTIONS claude (see #8940).
 const OPENCODE_TASK_OSC_TITLE = '⠋ use Claude Sonnet'
+// A Claude task title that merely MENTIONS Codex (see #14937).
+const CLAUDE_TASK_OSC_TITLE = '⠋ Fix the codex plugin launcher'
 
 /** Printed banner that proves the emitter ran; the OSC title trails it in the same chunk. */
 const PANE_HOLD_MARKER = 'agent pane holding'
@@ -70,7 +74,7 @@ function paneTitles(page: Page, tabId: string): Promise<string[]> {
 async function openAgentTab(
   page: Page,
   worktreeId: string,
-  launchAgent: 'cursor' | 'opencode'
+  launchAgent: 'claude' | 'cursor' | 'opencode'
 ): Promise<{ tabId: string; ptyId: string }> {
   const tabId = await page.evaluate(
     ({ worktreeId, launchAgent }) => {
@@ -201,4 +205,30 @@ test('sidebar keeps a Cursor pane visible and an OpenCode pane out of Claude Cod
 
   openCodeScript.cleanup()
   cursorScript.cleanup()
+})
+
+test('Claude task titles that mention Codex keep the Claude tab icon', async ({ orcaPage }) => {
+  await waitForSessionReady(orcaPage)
+  const worktreeId = await waitForActiveWorktree(orcaPage)
+  await ensureTerminalVisible(orcaPage)
+
+  const claude = await openAgentTab(orcaPage, worktreeId, 'claude')
+  const claudeScript = await runNodeScriptInTerminal(
+    orcaPage,
+    claude.ptyId,
+    oscTitleHolderScript('\\u280b Fix the codex plugin launcher')
+  )
+  await waitForTerminalOutput(orcaPage, PANE_HOLD_MARKER, 15_000)
+  await expect
+    .poll(() => paneTitles(orcaPage, claude.tabId), {
+      timeout: 15_000,
+      message: 'the Claude task title never reached the renderer'
+    })
+    .toContain(CLAUDE_TASK_OSC_TITLE)
+
+  const claudeTab = orcaPage.locator(`[data-tab-id="${claude.tabId}"]`)
+  await expect(claudeTab.locator('[data-agent-icon="claude"]')).toBeVisible()
+  await expect(claudeTab.locator('[data-agent-icon="codex"]')).toHaveCount(0)
+
+  claudeScript.cleanup()
 })

--- a/tests/e2e/terminal-tab-agent-identity.spec.ts
+++ b/tests/e2e/terminal-tab-agent-identity.spec.ts
@@ -1,0 +1,71 @@
+import type { Page } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import {
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager,
+  waitForTerminalOutput
+} from './helpers/terminal'
+import { runNodeScriptInTerminal } from './helpers/run-node-script-in-terminal'
+import { waitForRestoredTerminalInputReady } from './helpers/restored-terminal-input-readiness'
+
+const CLAUDE_TASK_OSC_TITLE = '⠋ Fix the codex plugin launcher'
+const PANE_HOLD_MARKER = 'claude pane holding'
+
+function oscTitleHolderScript(): string {
+  return [
+    `process.stdout.write('${PANE_HOLD_MARKER}\\r\\n\\u001b]0;\\u280b Fix the codex plugin launcher\\u0007')`,
+    'setInterval(() => {}, 1e9)',
+    ''
+  ].join('\n')
+}
+
+function paneTitles(page: Page, tabId: string): Promise<string[]> {
+  return page.evaluate((tabId) => {
+    const byPane = window.__store?.getState().runtimePaneTitlesByTabId?.[tabId] ?? {}
+    return Object.values(byPane).filter((title): title is string => typeof title === 'string')
+  }, tabId)
+}
+
+async function openClaudeTab(
+  page: Page,
+  worktreeId: string
+): Promise<{ tabId: string; ptyId: string }> {
+  const tabId = await page.evaluate((worktreeId) => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('window.__store is not available')
+    }
+    const state = store.getState()
+    const tab = state.createTab(worktreeId, undefined, undefined, { launchAgent: 'claude' })
+    state.setActiveTab(tab.id)
+    state.setActiveTabType('terminal')
+    return tab.id
+  }, worktreeId)
+  await waitForActiveTerminalManager(page)
+  const ptyId = await waitForActivePanePtyId(page, 45_000)
+  expect(await waitForRestoredTerminalInputReady(page, ptyId, 20_000)).toBe(true)
+  return { tabId, ptyId }
+}
+
+test('Claude task titles that mention Codex keep the Claude tab icon', async ({ orcaPage }) => {
+  await waitForSessionReady(orcaPage)
+  const worktreeId = await waitForActiveWorktree(orcaPage)
+  await ensureTerminalVisible(orcaPage)
+
+  const claude = await openClaudeTab(orcaPage, worktreeId)
+  const claudeScript = await runNodeScriptInTerminal(orcaPage, claude.ptyId, oscTitleHolderScript())
+  await waitForTerminalOutput(orcaPage, PANE_HOLD_MARKER, 15_000)
+  await expect
+    .poll(() => paneTitles(orcaPage, claude.tabId), {
+      timeout: 15_000,
+      message: 'the Claude task title never reached the renderer'
+    })
+    .toContain(CLAUDE_TASK_OSC_TITLE)
+
+  const claudeTab = orcaPage.locator(`[data-tab-id="${claude.tabId}"]`)
+  await expect(claudeTab.locator('[data-agent-icon="claude"]')).toBeVisible()
+  await expect(claudeTab.locator('[data-agent-icon="codex"]')).toHaveCount(0)
+
+  claudeScript.cleanup()
+})

--- a/tests/e2e/terminal-tab-agent-identity.spec.ts
+++ b/tests/e2e/terminal-tab-agent-identity.spec.ts
@@ -2,6 +2,7 @@ import type { Page } from '@stablyai/playwright-test'
 import { test, expect } from './helpers/orca-app'
 import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
 import {
+  sendToTerminal,
   waitForActivePanePtyId,
   waitForActiveTerminalManager,
   waitForTerminalOutput
@@ -9,12 +10,24 @@ import {
 import { runNodeScriptInTerminal } from './helpers/run-node-script-in-terminal'
 import { waitForRestoredTerminalInputReady } from './helpers/restored-terminal-input-readiness'
 
+const CLAUDE_IDENTITY_OSC_TITLE = '✳ Claude Code'
+const CLAUDE_IDENTITY_MARKER = 'claude identity seeded'
 const CLAUDE_TASK_OSC_TITLE = '⠋ Fix the codex plugin launcher'
 const PANE_HOLD_MARKER = 'claude pane holding'
 
+// Why: emits a real Claude-identity title first, and only replaces it with the
+// Codex-mentioning task title once the test signals over stdin. Without that
+// prior identity evidence, titlePresentsAgent's discrimination between "names
+// Codex" and "merely mentions Codex" is never exercised (#14937) — the
+// reclaim guard stays closed regardless, and the test would pass either way.
 function oscTitleHolderScript(): string {
   return [
-    `process.stdout.write('${PANE_HOLD_MARKER}\\r\\n\\u001b]0;\\u280b Fix the codex plugin launcher\\u0007')`,
+    `const readline = require('node:readline')`,
+    `process.stdout.write('\\u001b]0;\\u2733 Claude Code\\u0007')`,
+    `process.stdout.write('${CLAUDE_IDENTITY_MARKER}\\r\\n')`,
+    `readline.createInterface({ input: process.stdin }).once('line', () => {`,
+    `  process.stdout.write('${PANE_HOLD_MARKER}\\r\\n\\u001b]0;\\u280b Fix the codex plugin launcher\\u0007')`,
+    `})`,
     'setInterval(() => {}, 1e9)',
     ''
   ].join('\n')
@@ -55,6 +68,16 @@ test('Claude task titles that mention Codex keep the Claude tab icon', async ({ 
 
   const claude = await openClaudeTab(orcaPage, worktreeId)
   const claudeScript = await runNodeScriptInTerminal(orcaPage, claude.ptyId, oscTitleHolderScript())
+
+  await waitForTerminalOutput(orcaPage, CLAUDE_IDENTITY_MARKER, 15_000)
+  await expect
+    .poll(() => paneTitles(orcaPage, claude.tabId), {
+      timeout: 15_000,
+      message: 'the Claude identity title never reached the renderer'
+    })
+    .toContain(CLAUDE_IDENTITY_OSC_TITLE)
+
+  await sendToTerminal(orcaPage, claude.ptyId, '\r')
   await waitForTerminalOutput(orcaPage, PANE_HOLD_MARKER, 15_000)
   await expect
     .poll(() => paneTitles(orcaPage, claude.tabId), {

--- a/tests/e2e/terminal-tab-agent-identity.spec.ts
+++ b/tests/e2e/terminal-tab-agent-identity.spec.ts
@@ -15,11 +15,7 @@ const CLAUDE_IDENTITY_MARKER = 'claude identity seeded'
 const CLAUDE_TASK_OSC_TITLE = '⠋ Fix the codex plugin launcher'
 const PANE_HOLD_MARKER = 'claude pane holding'
 
-// Why: emits a real Claude-identity title first, and only replaces it with the
-// Codex-mentioning task title once the test signals over stdin. Without that
-// prior identity evidence, titlePresentsAgent's discrimination between "names
-// Codex" and "merely mentions Codex" is never exercised (#14937) — the
-// reclaim guard stays closed regardless, and the test would pass either way.
+// Seed Claude identity before the Codex mention so the test evaluates title re-ownership.
 function oscTitleHolderScript(): string {
   return [
     `const readline = require('node:readline')`,

--- a/tests/e2e/terminal-tab-agent-identity.spec.ts
+++ b/tests/e2e/terminal-tab-agent-identity.spec.ts
@@ -65,26 +65,28 @@ test('Claude task titles that mention Codex keep the Claude tab icon', async ({ 
   const claude = await openClaudeTab(orcaPage, worktreeId)
   const claudeScript = await runNodeScriptInTerminal(orcaPage, claude.ptyId, oscTitleHolderScript())
 
-  await waitForTerminalOutput(orcaPage, CLAUDE_IDENTITY_MARKER, 15_000)
-  await expect
-    .poll(() => paneTitles(orcaPage, claude.tabId), {
-      timeout: 15_000,
-      message: 'the Claude identity title never reached the renderer'
-    })
-    .toContain(CLAUDE_IDENTITY_OSC_TITLE)
+  try {
+    await waitForTerminalOutput(orcaPage, CLAUDE_IDENTITY_MARKER, 15_000)
+    await expect
+      .poll(() => paneTitles(orcaPage, claude.tabId), {
+        timeout: 15_000,
+        message: 'the Claude identity title never reached the renderer'
+      })
+      .toContain(CLAUDE_IDENTITY_OSC_TITLE)
 
-  await sendToTerminal(orcaPage, claude.ptyId, '\r')
-  await waitForTerminalOutput(orcaPage, PANE_HOLD_MARKER, 15_000)
-  await expect
-    .poll(() => paneTitles(orcaPage, claude.tabId), {
-      timeout: 15_000,
-      message: 'the Claude task title never reached the renderer'
-    })
-    .toContain(CLAUDE_TASK_OSC_TITLE)
+    await sendToTerminal(orcaPage, claude.ptyId, '\r')
+    await waitForTerminalOutput(orcaPage, PANE_HOLD_MARKER, 15_000)
+    await expect
+      .poll(() => paneTitles(orcaPage, claude.tabId), {
+        timeout: 15_000,
+        message: 'the Claude task title never reached the renderer'
+      })
+      .toContain(CLAUDE_TASK_OSC_TITLE)
 
-  const claudeTab = orcaPage.locator(`[data-tab-id="${claude.tabId}"]`)
-  await expect(claudeTab.locator('[data-agent-icon="claude"]')).toBeVisible()
-  await expect(claudeTab.locator('[data-agent-icon="codex"]')).toHaveCount(0)
-
-  claudeScript.cleanup()
+    const claudeTab = orcaPage.locator(`[data-tab-id="${claude.tabId}"]`)
+    await expect(claudeTab.locator('[data-agent-icon="claude"]')).toBeVisible()
+    await expect(claudeTab.locator('[data-agent-icon="codex"]')).toHaveCount(0)
+  } finally {
+    claudeScript.cleanup()
+  }
 })


### PR DESCRIPTION
## ELI5

A pane keeps its known agent identity when another agent name appears only in the task title, preventing the tab icon from changing incorrectly.

## Visual Proof

N/A — this changes tab identity state; the PR includes Electron/PTY coverage and no layout change.

## Summary

- keep a pane's known agent owner when a task title merely mentions another supported agent
- require explicit identity-shaped terminal titles before title evidence can re-own a reused pane
- preserve native Claude, OpenCode, Grok, Pi, and synthetic agent title formats
- cover the regression in both the resolver and a real Electron/PTY tab-icon flow

## Root cause

`resolveExplicitTerminalTitleAgentType` intentionally performs loose agent-name detection for owner-blind consumers. `resolveTabAgentFromSignals` used that result to re-own a pane, but only guarded false-positive Claude matches. A Claude title such as `⠋ Fix the codex plugin launcher` therefore resolved to Codex and replaced the pane's durable Claude identity after hook evidence disappeared.

## Testing

- `pnpm test src/renderer/src/lib/use-tab-agent.test.ts src/renderer/src/lib/use-tab-agent-pi-identity.test.ts src/renderer/src/lib/use-tab-agent-opencode-native-title.test.ts src/renderer/src/lib/use-tab-agent-process-signals.test.ts src/renderer/src/lib/use-tab-agent-sleeping-session.test.ts src/shared/terminal-title-agent-type.test.ts --maxWorkers=4` (`101 passed`)
- `pnpm test --maxWorkers=4` (`53957 passed`, `166 skipped`)
- `pnpm typecheck`
- `pnpm lint`
- `VITE_EXPOSE_STORE=true pnpm exec electron-vite build --mode e2e`
- `SKIP_BUILD=1 pnpm exec playwright test tests/e2e/terminal-tab-agent-identity.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1` (`1 passed`)

Fixes #14937