### PR TITLE
fix(wsl): read machine output from a fenced login shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,7 @@ docs/**
 !docs/reference/renderer-agent-status-performance.md
 !docs/reference/windows-setup-shell.md
 !docs/reference/worktree-scan-fingerprint.md
+!docs/reference/wsl-command-execution.md
 
 # Stably CLI (only docs/ are tracked)
 .stably/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ Orca targets macOS, Linux, and Windows. Keep all platform-dependent behavior beh
 - **Shortcut labels in UI**: Display `⌘` / `⇧` on Mac and `Ctrl+` / `Shift+` on other platforms.
 - **File paths**: Use `path.join` or Electron/Node path utilities — never assume `/` or `\`.
 - **Windows setup scripts**: the setup/issue-command runner is a `.cmd` batch file unless the script starts with a `#!` line — never derive that from the user's terminal-shell preference, and never launch a `.cmd` runner with a bare `cmd.exe /c` from a Git Bash pane (MSYS rewrites the `/c`). See [`docs/reference/windows-setup-shell.md`](./docs/reference/windows-setup-shell.md).
+- **WSL commands**: build argv with `buildWslExecArgs` (always `--exec` — under `--`, `wsl.exe` expands `$name` in every argument and silently rewrites the script), and fence anything whose stdout you parse with `buildWslCapturedLoginShellCommand`, because the interactive login shell prints the distro banner to stdout. See [`docs/reference/wsl-command-execution.md`](./docs/reference/wsl-command-execution.md).
 - **Linux native modules**: keep the glibc floor at Ubuntu 20.04 / glibc 2.31. A module compiled from source on a newer runner can reference symbol versions absent on the floor and crash the app on startup. See [`docs/reference/linux-glibc-compatibility.md`](./docs/reference/linux-glibc-compatibility.md); packaging fails if a bundled native binary needs newer glibc.
 
 ## SSH Use Case

--- a/docs/reference/wsl-command-execution.md
+++ b/docs/reference/wsl-command-execution.md
@@ -1,0 +1,71 @@
+# Running commands inside WSL
+
+Two properties of `wsl.exe` decide how every guest invocation has to be written. Both are silent
+when you get them wrong: the command still runs and still exits 0, it just returns the wrong bytes.
+
+## 1. Always `--exec`, never `--`
+
+`wsl.exe -d <distro> -- <argv>` expands `$name` in **every argument** against the guest environment
+before the guest runs. This is `wsl.exe` itself, not the guest shell — it happens with no shell in
+the command at all:
+
+```
+$ wsl.exe -d Ubuntu-24.04 --      /usr/bin/printf %s '$HOME'
+/home/you
+$ wsl.exe -d Ubuntu-24.04 --exec  /usr/bin/printf %s '$HOME'
+$HOME
+```
+
+So under `--`, a script means something other than what it says. `awk '{print $2}'` reaches the
+guest as `awk '{print }'` and prints the whole line; `sed` backreferences and `"\$literal"` are
+rewritten the same way. Escaping `$` on the Windows side cannot fix this reliably — an earlier
+attempt skipped every `$` preceded by a backslash, which is exactly the case a POSIX script uses to
+mean a literal dollar.
+
+Build argv with `buildWslExecArgs()` in `src/shared/wsl-login-shell-command.ts`. A test walks the
+tree and fails if the `--` form reappears.
+
+The `--` inside `sh -s -- <path>` is a *shell* argument separator and is unrelated; leave it alone.
+
+## 2. Machine-read output must be fenced
+
+Orca runs guest commands through the distro user's **interactive** login shell (`-ilc` for
+bash/zsh) because that is the only shell that reads `~/.bashrc`, where `nvm`, `mise` and `asdf`
+install their PATH entries. Dropping `-i` would break tool detection for those users.
+
+The cost is that an interactive shell also runs the distro's rc/motd, and that output goes to
+**stdout** — the same stream the answer arrives on. Stock Ubuntu 24.04 needs no customization to
+reproduce it:
+
+```
+$ wsl.exe -d Ubuntu-24.04 --exec bash -ilc 'git --version'
+To run a command as administrator (user "root"), use "sudo <command>".
+See "man sudo_root" for details.
+
+git version 2.43.0
+```
+
+Any caller that parses stdout must use `buildWslCapturedLoginShellCommand()`, which fences the
+payload and returns a matching `readStdout`. `.trim()` does not help: the banner is a prefix, not
+surrounding whitespace, so a stat probe compared against `"directory"` simply never matches.
+
+The fence carries a per-call nonce so that `cat`-ing a file whose contents happen to quote a marker
+is not truncated, and it preserves the payload's exit status so `exit 2` → `ENOENT` mappings keep
+working.
+
+**Do not fence a command that `exec`s into a long-running program** (`codex app-server`, an
+interactive terminal). It never reaches the closing fence, and there the shell's own output either
+belongs to the program or is what the user wants to see.
+
+## Prefer no shell at all
+
+When a caller only needs a known binary with a known environment, skip the login shell entirely and
+run the binary directly:
+
+```
+wsl.exe -d <distro> --exec /usr/bin/env PATH=… HOME=… /usr/bin/git -C <dir> status
+```
+
+This is what the direct-git read path does. It is immune to both problems above by construction and
+avoids paying login-shell startup on every call, which also sidesteps profiles that block or print.
+Resolve the PATH/HOME once through a fenced probe, cache it per distro, then use this form.

--- a/docs/reference/wsl-command-execution.md
+++ b/docs/reference/wsl-command-execution.md
@@ -17,10 +17,11 @@ $HOME
 ```
 
 So under `--`, a script means something other than what it says. `awk '{print $2}'` reaches the
-guest as `awk '{print }'` and prints the whole line; `sed` backreferences and `"\$literal"` are
-rewritten the same way. Escaping `$` on the Windows side cannot fix this reliably — an earlier
-attempt skipped every `$` preceded by a backslash, which is exactly the case a POSIX script uses to
-mean a literal dollar.
+guest as `awk '{print }'` and prints the whole line; a positional `"$1"`, a shell local, and a
+`"\$literal"` are blanked or rewritten the same way. (Expansions with no `$` are unaffected — a
+`sed` backreference like `s/(a)(b)/\2\1/` survives either way.) Escaping `$` on the Windows side
+cannot fix this reliably — an earlier attempt skipped every `$` preceded by a backslash, which is
+exactly the case a POSIX script uses to mean a literal dollar.
 
 Build argv with `buildWslExecArgs()` in `src/shared/wsl-login-shell-command.ts`. A test walks the
 tree and fails if the `--` form reappears.

--- a/src/main/codex-accounts/wsl-codex-command.test.ts
+++ b/src/main/codex-accounts/wsl-codex-command.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildWslCodexAvailabilityArgs,
-  buildWslCodexIdentityArgs,
+  buildWslCodexIdentityProbe,
   buildWslCodexLoginArgs
 } from './wsl-codex-command'
 
@@ -26,7 +26,7 @@ describe('WSL Codex commands', () => {
   })
 
   it('reports the login-shell binary path and version for identity checks', () => {
-    const command = buildWslCodexIdentityArgs('Ubuntu').at(-1)
+    const command = buildWslCodexIdentityProbe('Ubuntu').args.at(-1)
 
     expect(command).toMatch(/printf .*"\$resolved"/)
     expect(command).toContain('exec "$resolved" --version')

--- a/src/main/codex-accounts/wsl-codex-command.ts
+++ b/src/main/codex-accounts/wsl-codex-command.ts
@@ -1,5 +1,6 @@
 import { buildPosixCommandPathLookupScript } from '../../shared/posix-command-path-lookup'
 import {
+  buildWslCapturedLoginShellCommand,
   buildWslExecArgs,
   buildWslLoginShellCommand,
   quotePosixShell
@@ -13,7 +14,22 @@ export function buildWslCodexAvailabilityArgs(distro: string): string[] {
   return buildWslCodexShellArgs(distro, command)
 }
 
-export function buildWslCodexIdentityArgs(distro: string): string[] {
+export type WslCodexIdentityProbe = {
+  args: string[]
+  /** The `<path>\n<version>` payload, or null when the fence never appeared. */
+  readStdout: (stdout: string) => string | null
+}
+
+/**
+ * Probe the distro's Codex path and version.
+ *
+ * Why fenced: this reads the login shell's stdout positionally (path before the
+ * first newline, version after), and an interactive login shell prints the
+ * distro rc/motd to stdout ahead of it — which silently moves that split into
+ * the banner. The payload ends in `exec`, so no closing fence is ever written;
+ * `readStdout` returns everything after the opening one.
+ */
+export function buildWslCodexIdentityProbe(distro: string): WslCodexIdentityProbe {
   const command = [
     buildCodexPathLookup(),
     'if [ -z "$resolved" ]; then',
@@ -23,7 +39,11 @@ export function buildWslCodexIdentityArgs(distro: string): string[] {
     'printf \'%s\\n\' "$resolved"',
     'exec "$resolved" --version'
   ].join('\n')
-  return buildWslCodexShellArgs(distro, command)
+  const captured = buildWslCapturedLoginShellCommand(command)
+  return {
+    args: buildWslExecArgs(distro, ['sh', '-c', captured.command]),
+    readStdout: captured.readStdout
+  }
 }
 
 export function buildWslCodexAppServerArgs(distro: string, linuxHomePath: string): string[] {

--- a/src/main/codex/codex-trust-grant-host.test.ts
+++ b/src/main/codex/codex-trust-grant-host.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { buildWslCodexIdentityArgs } from '../codex-accounts/wsl-codex-command'
+
 
 const { execFileSyncMock, resolveCodexCommandMock } = vi.hoisted(() => ({
   execFileSyncMock: vi.fn(),
@@ -16,7 +16,15 @@ import { resolveCodexTrustGrantHost } from './codex-trust-grant-host'
 
 beforeEach(() => {
   execFileSyncMock.mockReset()
-  execFileSyncMock.mockReturnValue('/home/alice/.local/bin/codex\ncodex-cli 1.2.3\n')
+  // Stand in for the guest shell: rc banner first, then the payload inside the
+  // command's own fence. The identity script execs, so no closing fence is written.
+  execFileSyncMock.mockImplementation((_command: string, args: string[]) => {
+    const nonce = /__ORCA_WSL_CAPTURE_BEGIN_([^_]+)__/.exec(String(args.at(-1)))?.[1] ?? ''
+    return (
+      'To run a command as administrator (user "root"), use "sudo <command>".\n\n' +
+      `__ORCA_WSL_CAPTURE_BEGIN_${nonce}__/home/alice/.local/bin/codex\ncodex-cli 1.2.3\n`
+    )
+  })
   resolveCodexCommandMock.mockReset()
   resolveCodexCommandMock.mockReturnValue(process.execPath)
 })
@@ -60,7 +68,7 @@ describe('resolveCodexTrustGrantHost', () => {
     expect(request.invocation.command).toBe('wsl.exe')
     expect(execFileSyncMock).toHaveBeenCalledWith(
       'wsl.exe',
-      buildWslCodexIdentityArgs('Ubuntu'),
+      expect.arrayContaining(['-d', 'Ubuntu', '--exec', 'sh', '-c']),
       expect.objectContaining({ encoding: 'utf-8', timeout: 5_000, windowsHide: true })
     )
     expect(resolveCodexCommandMock).not.toHaveBeenCalled()

--- a/src/main/codex/codex-trust-grant-host.ts
+++ b/src/main/codex/codex-trust-grant-host.ts
@@ -3,7 +3,7 @@ import { resolveCodexCommand } from '../codex-cli/command'
 import { getSpawnArgsForWindows } from '../win32-utils'
 import {
   buildWslCodexAppServerArgs,
-  buildWslCodexIdentityArgs,
+  buildWslCodexIdentityProbe,
   WSL_CODEX_AVAILABILITY_TIMEOUT_MS
 } from '../codex-accounts/wsl-codex-command'
 import type { CodexHookTrustGrantRequest } from './codex-app-server-client'
@@ -82,11 +82,18 @@ function buildWslCodexBinaryStamp(distro: string): CodexTrustGrantBinaryStamp | 
   try {
     // Why: WSL PATH resolution happens inside the distro's login shell. The
     // resolved path plus CLI version detects upgrades without assuming UNC access.
-    const output = execFileSync('wsl.exe', buildWslCodexIdentityArgs(distro), {
+    const probe = buildWslCodexIdentityProbe(distro)
+    const stdout = execFileSync('wsl.exe', probe.args, {
       encoding: 'utf-8',
       timeout: WSL_CODEX_AVAILABILITY_TIMEOUT_MS,
       windowsHide: true
     })
+    // Why: the split below is positional, so login-shell rc output ahead of the
+    // payload would silently become the "path" and destabilize the stamp.
+    const output = probe.readStdout(stdout)
+    if (output === null) {
+      return null
+    }
     const lineBreak = output.indexOf('\n')
     const path = lineBreak === -1 ? '' : output.slice(0, lineBreak).trim()
     const version = lineBreak === -1 ? '' : output.slice(lineBreak + 1).trim()

--- a/src/main/git/runner-wsl-direct-read.test.ts
+++ b/src/main/git/runner-wsl-direct-read.test.ts
@@ -37,6 +37,14 @@ const LOGIN_ENVIRONMENT = {
   path: '/home/user/bin:/usr/bin:/bin'
 }
 
+/** Stand in for the guest shell: rc chatter first, then the payload inside the command's own fence. */
+function fencedProbeStdout(command: unknown, payload: string): string {
+  const nonce = /__ORCA_WSL_CAPTURE_BEGIN_([^_]+)__/.exec(String(command))?.[1] ?? ''
+  return `profile banner\n__ORCA_WSL_CAPTURE_BEGIN_${nonce}__${payload}__ORCA_WSL_CAPTURE_END_${nonce}__`
+}
+
+const LOGIN_ENVIRONMENT_FIELDS = `${LOGIN_ENVIRONMENT.path}\0${LOGIN_ENVIRONMENT.gitPath}\0${LOGIN_ENVIRONMENT.home}`
+
 type MockChild = EventEmitter & {
   stdout: EventEmitter
   stderr: EventEmitter
@@ -97,7 +105,10 @@ describe('WSL direct Git reads', () => {
     expect(execFileMock).toHaveBeenCalledTimes(1)
     completeProbe?.(
       null,
-      'profile banner\n\0ORCA_WSL_GIT_READ_ENV_V1\0/home/user/bin:/usr/bin\0/home/user/bin/git\0/home/user\0',
+      fencedProbeStdout(
+        execFileMock.mock.calls[0]?.[1]?.[5],
+        '/home/user/bin:/usr/bin\0/home/user/bin/git\0/home/user'
+      ),
       ''
     )
 
@@ -131,7 +142,7 @@ describe('WSL direct Git reads', () => {
         queueMicrotask(() =>
           callback?.(
             null,
-            `\0ORCA_WSL_GIT_READ_ENV_V1\0${LOGIN_ENVIRONMENT.path}\0${LOGIN_ENVIRONMENT.gitPath}\0${LOGIN_ENVIRONMENT.home}\0`,
+            fencedProbeStdout(execFileMock.mock.calls.at(-1)?.[1]?.[5], LOGIN_ENVIRONMENT_FIELDS),
             ''
           )
         )
@@ -184,7 +195,7 @@ describe('WSL direct Git reads', () => {
       let completeProbe: ((error: Error | null, stdout: string, stderr: string) => void) | undefined
       execFileMock.mockImplementation((_command, args, _options, callback) => {
         const child = createMockChild()
-        if ((args as string[])[5]?.includes('ORCA_WSL_GIT_READ_ENV_V1')) {
+        if ((args as string[])[5]?.includes('^GIT_')) {
           completeProbe = callback
         } else {
           queueMicrotask(() => callback?.(null, 'ok', ''))
@@ -203,7 +214,7 @@ describe('WSL direct Git reads', () => {
       expect(execFileMock.mock.calls[1]?.[1]?.slice(3, 5)).toEqual(['sh', '-lc'])
       completeProbe?.(
         null,
-        `\0ORCA_WSL_GIT_READ_ENV_V1\0${LOGIN_ENVIRONMENT.path}\0${LOGIN_ENVIRONMENT.gitPath}\0${LOGIN_ENVIRONMENT.home}\0`,
+        fencedProbeStdout(execFileMock.mock.calls[1]?.[1]?.[5], LOGIN_ENVIRONMENT_FIELDS),
         ''
       )
       await Promise.resolve()

--- a/src/main/git/wsl-git-read-environment.ts
+++ b/src/main/git/wsl-git-read-environment.ts
@@ -1,9 +1,11 @@
 import { execFile } from 'node:child_process'
-import { buildWslExecArgs, buildWslLoginShellCommand } from '../../shared/wsl-login-shell-command'
+import {
+  buildWslCapturedLoginShellCommand,
+  buildWslExecArgs
+} from '../../shared/wsl-login-shell-command'
 
 export type WslGitReadEnvironment = { gitPath: string; home: string; path: string }
 
-const PROBE_MARKER = 'ORCA_WSL_GIT_READ_ENV_V1'
 const PROBE_TIMEOUT_MS = 10_000
 const PROBE_MAX_BUFFER = 64 * 1024
 const TRANSIENT_PROBE_RETRY_MS = 30_000
@@ -16,14 +18,15 @@ type ProbeOutcome =
   | { kind: 'rejected' }
   | { kind: 'transient' }
 
-function parseProbe(stdout: string): WslGitReadEnvironment | null {
-  const fields = stdout.split('\0')
-  const markerIndex = fields.lastIndexOf(PROBE_MARKER)
-  const path = fields[markerIndex + 1] ?? ''
-  const gitPath = fields[markerIndex + 2] ?? ''
-  const home = fields[markerIndex + 3] ?? ''
+function parseProbe(payload: string | null): WslGitReadEnvironment | null {
+  if (payload === null) {
+    return null
+  }
+  const fields = payload.split('\0')
+  const path = fields[0] ?? ''
+  const gitPath = fields[1] ?? ''
+  const home = fields[2] ?? ''
   if (
-    markerIndex === -1 ||
     !path.includes('/') ||
     path.length > 32_768 ||
     !gitPath.startsWith('/') ||
@@ -43,13 +46,13 @@ function probeWslGitReadEnvironment(distro: string): Promise<ProbeOutcome> {
     '_orca_git_path=$(command -v git 2>/dev/null || true)',
     'case "$_orca_git_path" in /*) [ -x "$_orca_git_path" ] || exit 127 ;; *) exit 127 ;; esac',
     'if [ -n "${XDG_CONFIG_HOME:-}" ] || [ -n "${LD_LIBRARY_PATH:-}" ] || env | grep -q \'^GIT_\'; then exit 78; fi',
-    `printf '\\0${PROBE_MARKER}\\0%s\\0%s\\0%s\\0' "$PATH" "$_orca_git_path" "$HOME"`
+    `printf '%s\\0%s\\0%s' "$PATH" "$_orca_git_path" "$HOME"`
   ].join('\n')
-  const script = buildWslLoginShellCommand(probeCommand)
+  const captured = buildWslCapturedLoginShellCommand(probeCommand)
   return new Promise((resolve) => {
     execFile(
       'wsl.exe',
-      buildWslExecArgs(distro, ['sh', '-lc', script]),
+      buildWslExecArgs(distro, ['sh', '-lc', captured.command]),
       {
         encoding: 'utf8',
         maxBuffer: PROBE_MAX_BUFFER,
@@ -62,7 +65,7 @@ function probeWslGitReadEnvironment(distro: string): Promise<ProbeOutcome> {
           resolve(code === 78 || code === 127 ? { kind: 'rejected' } : { kind: 'transient' })
           return
         }
-        const environment = parseProbe(String(stdout))
+        const environment = parseProbe(captured.readStdout(String(stdout)))
         resolve(environment ? { kind: 'resolved', environment } : { kind: 'rejected' })
       }
     )

--- a/src/main/ipc/preflight-wsl-command.ts
+++ b/src/main/ipc/preflight-wsl-command.ts
@@ -1,23 +1,31 @@
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
-import { buildWslExecArgs, buildWslLoginShellCommand } from '../../shared/wsl-login-shell-command'
+import {
+  buildWslCapturedLoginShellCommand,
+  buildWslExecArgs
+} from '../../shared/wsl-login-shell-command'
 import type { WslPreflightTarget } from './preflight-wsl-agent-detection'
 
 const execFileAsync = promisify(execFile)
 
 export type PreflightWslCommandResult = { stdout: string; stderr: string }
 
-export function runPreflightCommandInWsl(
+export async function runPreflightCommandInWsl(
   target: WslPreflightTarget,
   command: string,
   timeoutMs: number
 ): Promise<PreflightWslCommandResult> {
-  return execFileAsync(
+  // Why: callers match this stdout against version and auth-status patterns; a
+  // distro rc banner ahead of the real output makes a working CLI look missing.
+  const captured = buildWslCapturedLoginShellCommand(command)
+  const result = (await execFileAsync(
     'wsl.exe',
-    buildWslExecArgs(target.distro, ['sh', '-c', buildWslLoginShellCommand(command)]),
+    buildWslExecArgs(target.distro, ['sh', '-c', captured.command]),
     {
       encoding: 'utf-8',
       timeout: timeoutMs
     }
-  ) as Promise<PreflightWslCommandResult>
+  )) as PreflightWslCommandResult
+  const payload = captured.readStdout(result.stdout)
+  return payload === null ? result : { ...result, stdout: payload }
 }

--- a/src/main/local-worktree-filesystem-wsl-banner.wsl.test.ts
+++ b/src/main/local-worktree-filesystem-wsl-banner.wsl.test.ts
@@ -37,7 +37,7 @@ async function readThroughRawLoginShell(linuxPath: string): Promise<string> {
   return stdout
 }
 
-describe.skipIf(!runRealWsl)('WSL worktree reads are fenced from login-shell chatter', () => {
+describe.skipIf(!runRealWsl)('WSL worktree reads carry no shell chatter', () => {
   let fixtureRoot: string
 
   beforeAll(async () => {
@@ -57,13 +57,13 @@ describe.skipIf(!runRealWsl)('WSL worktree reads are fenced from login-shell cha
     expect(await readPath(unc(`${fixtureRoot}/file.txt`))).toBe(FILE_CONTENTS)
   }, 60_000)
 
-  it('drops whatever the distro login shell printed ahead of the payload', async () => {
+  it('is unaffected by what a login shell would have printed', async () => {
     const { readPath } = getLocalWorktreePathAccess({ wslDistro: DISTRO })
     const raw = await readThroughRawLoginShell(`${fixtureRoot}/file.txt`)
 
-    // On a distro whose rc files are silent the two agree; on a chatty one (stock
-    // Ubuntu ships a sudo hint) the raw read carries a prefix. Either way the
-    // fenced read must be exactly the file.
+    // Contrast: routed through a login shell the read carries whatever the rc
+    // files printed (stock Ubuntu ships a sudo hint). These reads use a plain
+    // `sh -c`, which runs no rc at all, so they are exactly the file.
     expect(raw.endsWith(FILE_CONTENTS)).toBe(true)
     expect(await readPath(unc(`${fixtureRoot}/file.txt`))).toBe(FILE_CONTENTS)
   }, 60_000)

--- a/src/main/local-worktree-filesystem-wsl-banner.wsl.test.ts
+++ b/src/main/local-worktree-filesystem-wsl-banner.wsl.test.ts
@@ -1,0 +1,87 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { buildWslLoginShellCommand, buildWslExecArgs } from '../shared/wsl-login-shell-command'
+import { getLocalWorktreePathAccess } from './local-worktree-filesystem'
+
+const execFileAsync = promisify(execFile)
+const DISTRO = process.env.ORCA_WSL_TEST_DISTRO ?? 'Ubuntu-24.04'
+const runRealWsl = process.platform === 'win32' && process.env.ORCA_REAL_WSL_BANNER_TEST === '1'
+
+const FILE_CONTENTS = 'line one\nline two\n'
+
+function unc(linuxPath: string): string {
+  return `\\\\wsl.localhost\\${DISTRO}${linuxPath.replaceAll('/', '\\')}`
+}
+
+async function wsl(command: string, ...args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync(
+    'wsl.exe',
+    ['-d', DISTRO, '--exec', 'sh', '-c', command, 'orca-wsl-test', ...args],
+    { encoding: 'utf-8', timeout: 30000 }
+  )
+  return stdout.trim()
+}
+
+/** What an unfenced login-shell read returns — the shape this suite exists to rule out. */
+async function readThroughRawLoginShell(linuxPath: string): Promise<string> {
+  const { stdout } = await execFileAsync(
+    'wsl.exe',
+    buildWslExecArgs(DISTRO, [
+      'sh',
+      '-lc',
+      buildWslLoginShellCommand(`cat -- '${linuxPath}'`)
+    ]),
+    { encoding: 'utf-8', timeout: 30000 }
+  )
+  return stdout
+}
+
+describe.skipIf(!runRealWsl)('WSL worktree reads are fenced from login-shell chatter', () => {
+  let fixtureRoot: string
+
+  beforeAll(async () => {
+    fixtureRoot = await wsl("mktemp -d -p /tmp 'orca-wsl-banner.XXXXXX'")
+    await wsl('mkdir -p "$1/dir" && printf \'%s\' "$2" > "$1/file.txt"', fixtureRoot, FILE_CONTENTS)
+  }, 120_000)
+
+  afterAll(async () => {
+    if (/^\/tmp\/orca-wsl-banner\.[A-Za-z0-9]+$/u.test(fixtureRoot)) {
+      await wsl('rm -rf -- "$1"', fixtureRoot)
+    }
+  }, 120_000)
+
+  it('returns file contents byte-for-byte', async () => {
+    const { readPath } = getLocalWorktreePathAccess({ wslDistro: DISTRO })
+
+    expect(await readPath(unc(`${fixtureRoot}/file.txt`))).toBe(FILE_CONTENTS)
+  }, 60_000)
+
+  it('drops whatever the distro login shell printed ahead of the payload', async () => {
+    const { readPath } = getLocalWorktreePathAccess({ wslDistro: DISTRO })
+    const raw = await readThroughRawLoginShell(`${fixtureRoot}/file.txt`)
+
+    // On a distro whose rc files are silent the two agree; on a chatty one (stock
+    // Ubuntu ships a sudo hint) the raw read carries a prefix. Either way the
+    // fenced read must be exactly the file.
+    expect(raw.endsWith(FILE_CONTENTS)).toBe(true)
+    expect(await readPath(unc(`${fixtureRoot}/file.txt`))).toBe(FILE_CONTENTS)
+  }, 60_000)
+
+  it.each([
+    ['dir', 'directory'],
+    ['file.txt', 'file']
+  ])('stats %s as a usable type, not shell chatter', async (entry, expectedType) => {
+    const { statPath } = getLocalWorktreePathAccess({ wslDistro: DISTRO })
+
+    const stat = (await statPath(unc(`${fixtureRoot}/${entry}`))) as { type: string }
+
+    expect(stat.type).toBe(expectedType)
+  }, 60_000)
+
+  it('still reports a missing path as ENOENT', async () => {
+    const { statPath } = getLocalWorktreePathAccess({ wslDistro: DISTRO })
+
+    await expect(statPath(unc(`${fixtureRoot}/absent`))).rejects.toMatchObject({ code: 'ENOENT' })
+  }, 60_000)
+})

--- a/src/main/local-worktree-filesystem.test.ts
+++ b/src/main/local-worktree-filesystem.test.ts
@@ -23,9 +23,17 @@ import {
   toHostRemovalPath
 } from './local-worktree-filesystem'
 
+// Stand in for the guest shell: rc banner first, then the payload inside the
+// fence the command itself carries. Reads are rejected without one.
 function completeExecFile(stdout = ''): void {
-  execFileMock.mockImplementation((_file, _args, _options, callback) => {
-    callback(null, stdout, '')
+  execFileMock.mockImplementation((_file, args, _options, callback) => {
+    const nonce = /__ORCA_WSL_CAPTURE_BEGIN_([^_]+)__/.exec(String(args.at(-1)))?.[1] ?? ''
+    callback(
+      null,
+      'To run a command as administrator (user "root"), use "sudo <command>".\n\n' +
+        `__ORCA_WSL_CAPTURE_BEGIN_${nonce}__${stdout}__ORCA_WSL_CAPTURE_END_${nonce}__`,
+      ''
+    )
   })
 }
 

--- a/src/main/local-worktree-filesystem.test.ts
+++ b/src/main/local-worktree-filesystem.test.ts
@@ -23,17 +23,9 @@ import {
   toHostRemovalPath
 } from './local-worktree-filesystem'
 
-// Stand in for the guest shell: rc banner first, then the payload inside the
-// fence the command itself carries. Reads are rejected without one.
 function completeExecFile(stdout = ''): void {
-  execFileMock.mockImplementation((_file, args, _options, callback) => {
-    const nonce = /__ORCA_WSL_CAPTURE_BEGIN_([^_]+)__/.exec(String(args.at(-1)))?.[1] ?? ''
-    callback(
-      null,
-      'To run a command as administrator (user "root"), use "sudo <command>".\n\n' +
-        `__ORCA_WSL_CAPTURE_BEGIN_${nonce}__${stdout}__ORCA_WSL_CAPTURE_END_${nonce}__`,
-      ''
-    )
+  execFileMock.mockImplementation((_file, _args, _options, callback) => {
+    callback(null, stdout, '')
   })
 }
 
@@ -176,9 +168,25 @@ describe('local worktree filesystem runtime access', () => {
       const removeArgs = execFileMock.mock.calls[2]?.[1] as string[]
       expect(removeArgs.at(-1)).toContain('rm -rf --')
       expect(removeArgs.at(-1)).toContain(
-        String.raw`rm -rf -- '\''/mnt/c/Users/me/repo feature'\''`
+        String.raw`rm -rf -- '/mnt/c/Users/me/repo feature'`
       )
       expect(rmMock).not.toHaveBeenCalled()
+    })
+  })
+
+  it('never starts a login or interactive shell for filesystem reads', async () => {
+    await withPlatform('win32', async () => {
+      completeExecFile('file')
+      await getLocalWorktreePathAccess({ wslDistro: 'Ubuntu' }).statPath('/home/me/repo/.git')
+
+      // Why: a login/interactive shell is what puts the distro's rc banner on the
+      // stdout these callers parse. cat/stat/rm need nothing from the user's PATH,
+      // so the shell mode is the fix rather than filtering what it prints.
+      const args = execFileMock.mock.calls[0]?.[1] as string[]
+      expect(args).toContain('-c')
+      expect(args).not.toContain('-lc')
+      expect(args).not.toContain('-ilc')
+      expect(args.at(-1)).not.toContain('getent passwd')
     })
   })
 

--- a/src/main/local-worktree-filesystem.ts
+++ b/src/main/local-worktree-filesystem.ts
@@ -1,10 +1,6 @@
 import { execFile } from 'node:child_process'
 import { lstat, readFile } from 'node:fs/promises'
-import {
-  buildWslCapturedLoginShellCommand,
-  buildWslExecArgs,
-  quotePosixShell
-} from '../shared/wsl-login-shell-command'
+import { buildWslExecArgs, quotePosixShell } from '../shared/wsl-login-shell-command'
 import { removeHostTree } from './host-tree-removal'
 import { toLinuxPath } from './wsl'
 import type { ReadPath, StatPath } from './worktree-orphan-gitdir-proof'
@@ -55,26 +51,18 @@ function execFileText(
   })
 }
 
-async function runWslLoginShellCommand(
-  distro: string,
-  command: string
-): Promise<ExecFileTextResult> {
-  // Why: file contents and the stat marker are read straight out of stdout, so the
-  // distro's rc banner would otherwise be prepended to every file Orca reads.
-  const captured = buildWslCapturedLoginShellCommand(command)
-  const result = await execFileText(
-    'wsl.exe',
-    buildWslExecArgs(distro, ['sh', '-lc', captured.command]),
-    { timeout: WSL_FILE_OPERATION_TIMEOUT_MS }
-  )
-  const payload = captured.readStdout(result.stdout)
-  if (payload === null) {
-    // Why throw: falling back to the raw stream would hand callers the banner as
-    // if it were file contents or a stat result -- the exact bug the fence fixes,
-    // but silently. A missing fence means the shell never reached the payload.
-    throw new Error('WSL command produced no fenced output')
-  }
-  return { ...result, stdout: payload }
+/**
+ * Run a filesystem command inside the distro.
+ *
+ * Why no login shell: these are coreutils at standard paths plus shell builtins,
+ * and need nothing from the user's PATH. A login shell would only add its rc/motd
+ * output to the stdout these callers parse -- the banner problem -- so the fix is
+ * to not start one rather than to fence what it prints.
+ */
+function runWslCommand(distro: string, command: string): Promise<ExecFileTextResult> {
+  return execFileText('wsl.exe', buildWslExecArgs(distro, ['sh', '-c', command]), {
+    timeout: WSL_FILE_OPERATION_TIMEOUT_MS
+  })
 }
 
 function isWslMissingPathError(error: unknown): boolean {
@@ -108,7 +96,7 @@ export function getLocalWorktreePathAccess(
   return {
     statPath: async (path) => {
       const target = quotePosixShell(toLinuxPath(path))
-      const { stdout } = await runWslLoginShellCommand(
+      const { stdout } = await runWslCommand(
         distro,
         [
           `target=${target}`,
@@ -124,7 +112,7 @@ export function getLocalWorktreePathAccess(
     },
     readPath: async (path) => {
       const target = quotePosixShell(toLinuxPath(path))
-      const { stdout } = await runWslLoginShellCommand(distro, `cat -- ${target}`)
+      const { stdout } = await runWslCommand(distro, `cat -- ${target}`)
       return stdout
     }
   }
@@ -142,5 +130,5 @@ export async function removeLocalWorktreePath(
 
   // Why: WSL-owned worktree directories may be POSIX paths that Node on
   // Windows cannot delete safely. Run the deletion inside the selected distro.
-  await runWslLoginShellCommand(distro, `rm -rf -- ${quotePosixShell(toLinuxPath(targetPath))}`)
+  await runWslCommand(distro, `rm -rf -- ${quotePosixShell(toLinuxPath(targetPath))}`)
 }

--- a/src/main/local-worktree-filesystem.ts
+++ b/src/main/local-worktree-filesystem.ts
@@ -68,7 +68,13 @@ async function runWslLoginShellCommand(
     { timeout: WSL_FILE_OPERATION_TIMEOUT_MS }
   )
   const payload = captured.readStdout(result.stdout)
-  return payload === null ? result : { ...result, stdout: payload }
+  if (payload === null) {
+    // Why throw: falling back to the raw stream would hand callers the banner as
+    // if it were file contents or a stat result -- the exact bug the fence fixes,
+    // but silently. A missing fence means the shell never reached the payload.
+    throw new Error('WSL command produced no fenced output')
+  }
+  return { ...result, stdout: payload }
 }
 
 function isWslMissingPathError(error: unknown): boolean {

--- a/src/main/local-worktree-filesystem.ts
+++ b/src/main/local-worktree-filesystem.ts
@@ -1,8 +1,8 @@
 import { execFile } from 'node:child_process'
 import { lstat, readFile } from 'node:fs/promises'
 import {
+  buildWslCapturedLoginShellCommand,
   buildWslExecArgs,
-  buildWslLoginShellCommand,
   quotePosixShell
 } from '../shared/wsl-login-shell-command'
 import { removeHostTree } from './host-tree-removal'
@@ -55,12 +55,20 @@ function execFileText(
   })
 }
 
-function runWslLoginShellCommand(distro: string, command: string): Promise<ExecFileTextResult> {
-  return execFileText(
+async function runWslLoginShellCommand(
+  distro: string,
+  command: string
+): Promise<ExecFileTextResult> {
+  // Why: file contents and the stat marker are read straight out of stdout, so the
+  // distro's rc banner would otherwise be prepended to every file Orca reads.
+  const captured = buildWslCapturedLoginShellCommand(command)
+  const result = await execFileText(
     'wsl.exe',
-    buildWslExecArgs(distro, ['sh', '-lc', buildWslLoginShellCommand(command)]),
+    buildWslExecArgs(distro, ['sh', '-lc', captured.command]),
     { timeout: WSL_FILE_OPERATION_TIMEOUT_MS }
   )
+  const payload = captured.readStdout(result.stdout)
+  return payload === null ? result : { ...result, stdout: payload }
 }
 
 function isWslMissingPathError(error: unknown): boolean {

--- a/src/shared/posix-command-path-lookup.test.ts
+++ b/src/shared/posix-command-path-lookup.test.ts
@@ -14,7 +14,7 @@ import { tmpdir } from 'node:os'
 import { basename, delimiter, dirname, isAbsolute, join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { buildPosixCommandPathLookupScript } from './posix-command-path-lookup'
-import { buildWslExecArgs, buildWslLoginShellCommand } from './wsl-login-shell-command'
+import { buildWslCapturedLoginShellCommand, buildWslExecArgs } from './wsl-login-shell-command'
 
 type ShellCase = {
   name: string
@@ -233,7 +233,9 @@ describe('buildPosixCommandPathLookupScript', () => {
     'resolves through the Windows-to-WSL login-shell boundary with inline masks',
     () => {
       const lookup = buildPosixCommandPathLookupScript({ kind: 'literal', value: 'sh' })
-      const command = buildWslLoginShellCommand(
+      // Why the captured form: an interactive login shell also prints the distro's
+      // rc/motd to stdout, which would land in front of the resolved path.
+      const captured = buildWslCapturedLoginShellCommand(
         [
           `sh() { printf '%s\\n' masked-function; }`,
           `alias sh='printf masked-alias'`,
@@ -241,13 +243,13 @@ describe('buildPosixCommandPathLookupScript', () => {
           `printf '%s' "$resolved"`
         ].join('\n')
       )
-      const resolved = execFileSync(
+      const stdout = execFileSync(
         'wsl.exe',
-        buildWslExecArgs(undefined, ['sh', '-lc', command]),
+        buildWslExecArgs(undefined, ['sh', '-lc', captured.command]),
         { encoding: 'utf8', timeout: WSL_TEST_COMMAND_TIMEOUT_MS }
-      ).trim()
+      )
 
-      expect(resolved).toMatch(/^\/.+\/sh$/)
+      expect(captured.readStdout(stdout)?.trim()).toMatch(/^\/.+\/sh$/)
     },
     30_000
   )

--- a/src/shared/wsl-login-shell-command.test.ts
+++ b/src/shared/wsl-login-shell-command.test.ts
@@ -212,7 +212,31 @@ describe('wsl login shell command helpers', () => {
       ).toBe('directory')
     })
 
-    it('preserves the payload exit status', () => {
+    it.skipIf(!canRunWslSh())(
+      'propagates the payload exit status to the caller',
+      () => {
+        // Why a real shell: asserting the script merely *contains* `exit $?` passes
+        // for any input. statPath maps this exit 2 to ENOENT, so it has to survive
+        // the fence for real.
+        const captured = buildWslCapturedLoginShellCommand('printf partial; exit 2')
+
+        let status: number | undefined
+        try {
+          execFileSync('wsl.exe', buildWslExecArgs(undefined, ['sh', '-lc', captured.command]), {
+            encoding: 'utf8',
+            timeout: WSL_TEST_COMMAND_TIMEOUT_MS,
+            stdio: ['pipe', 'pipe', 'pipe']
+          })
+        } catch (error) {
+          status = (error as { status?: number }).status
+        }
+
+        expect(status).toBe(2)
+      },
+      30_000
+    )
+
+    it('emits the status plumbing the payload needs', () => {
       const captured = buildWslCapturedLoginShellCommand('exit 2', 'nonce1')
 
       expect(captured.command).toContain('_orca_capture_status=$?')

--- a/src/shared/wsl-login-shell-command.test.ts
+++ b/src/shared/wsl-login-shell-command.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
+  buildWslCapturedLoginShellCommand,
   buildWslExecArgs,
   buildWslInteractiveLoginShellCommand,
   buildWslLoginShellCommand,
@@ -152,13 +153,20 @@ describe('wsl login shell command helpers', () => {
       return
     }
 
-    const command = buildWslLoginShellCommand('orca_value=ok; printf "<%s>" "$orca_value"')
+    // Why the captured form: an interactive login shell also prints the distro's
+    // rc/motd to stdout (stock Ubuntu ships a sudo hint), so a raw login-shell
+    // read cannot be compared byte-for-byte on a real distro.
+    const captured = buildWslCapturedLoginShellCommand(
+      'orca_value=ok; printf "<%s>" "$orca_value"'
+    )
 
     expect(
-      execFileSync('wsl.exe', buildWslExecArgs(undefined, ['sh', '-lc', command]), {
-        encoding: 'utf8',
-        timeout: WSL_TEST_COMMAND_TIMEOUT_MS
-      })
+      captured.readStdout(
+        execFileSync('wsl.exe', buildWslExecArgs(undefined, ['sh', '-lc', captured.command]), {
+          encoding: 'utf8',
+          timeout: WSL_TEST_COMMAND_TIMEOUT_MS
+        })
+      )
     ).toBe('<ok>')
   }, 30_000)
 
@@ -191,6 +199,75 @@ describe('wsl login shell command helpers', () => {
     },
     30_000
   )
+
+  describe('captured login shell', () => {
+    it('returns only the fenced payload, dropping rc banner noise', () => {
+      const captured = buildWslCapturedLoginShellCommand('printf directory', 'nonce1')
+
+      expect(
+        captured.readStdout(
+          'To run a command as administrator (user "root"), use "sudo <command>".\n\n' +
+            '__ORCA_WSL_CAPTURE_BEGIN_nonce1__directory__ORCA_WSL_CAPTURE_END_nonce1__'
+        )
+      ).toBe('directory')
+    })
+
+    it('preserves the payload exit status', () => {
+      const captured = buildWslCapturedLoginShellCommand('exit 2', 'nonce1')
+
+      expect(captured.command).toContain('_orca_capture_status=$?')
+      expect(captured.command).toContain('exit $_orca_capture_status')
+    })
+
+    it('keeps payload bytes that themselves contain a fence', () => {
+      // Why a per-call nonce: `cat` of a file quoting a fixed marker would
+      // otherwise be truncated at the quote.
+      const captured = buildWslCapturedLoginShellCommand('cat -- /f', 'nonce2')
+      const payload = 'see __ORCA_WSL_CAPTURE_BEGIN_nonce1__ and __ORCA_WSL_CAPTURE_END_nonce1__\n'
+
+      expect(
+        captured.readStdout(
+          `banner\n__ORCA_WSL_CAPTURE_BEGIN_nonce2__${payload}__ORCA_WSL_CAPTURE_END_nonce2__`
+        )
+      ).toBe(payload)
+    })
+
+    it('returns null when the fence never appeared', () => {
+      const captured = buildWslCapturedLoginShellCommand('printf hi', 'nonce1')
+
+      expect(captured.readStdout('bash: line 1: command not found\n')).toBeNull()
+    })
+
+    it('returns the tail when a payload exits before the closing fence', () => {
+      const captured = buildWslCapturedLoginShellCommand('printf partial; exit 2', 'nonce1')
+
+      expect(captured.readStdout('banner\n__ORCA_WSL_CAPTURE_BEGIN_nonce1__partial')).toBe(
+        'partial'
+      )
+    })
+
+    it('gives each invocation a distinct fence', () => {
+      const first = buildWslCapturedLoginShellCommand('printf hi')
+      const second = buildWslCapturedLoginShellCommand('printf hi')
+
+      expect(first.command).not.toBe(second.command)
+    })
+
+    it.skipIf(!canRunWslSh())(
+      'reads a clean payload back from a real distro login shell',
+      () => {
+        const captured = buildWslCapturedLoginShellCommand('printf directory')
+        const stdout = execFileSync(
+          'wsl.exe',
+          buildWslExecArgs(undefined, ['sh', '-lc', captured.command]),
+          { encoding: 'utf8', timeout: WSL_TEST_COMMAND_TIMEOUT_MS }
+        )
+
+        expect(captured.readStdout(stdout)).toBe('directory')
+      },
+      30_000
+    )
+  })
 
   it('starts an interactive login shell without assuming bash', () => {
     const command = buildWslInteractiveLoginShellCommand()

--- a/src/shared/wsl-login-shell-command.ts
+++ b/src/shared/wsl-login-shell-command.ts
@@ -80,7 +80,11 @@ export function buildWslCapturedLoginShellCommand(
       ].join('\n')
     ),
     readStdout: (stdout) => {
-      const beginIndex = stdout.indexOf(begin)
+      // Why lastIndexOf: a login shell can echo the command text before running
+      // it (`set -x` in an rc file), which repeats the opening fence verbatim.
+      // The real payload always follows the last one. The nonce keeps a payload
+      // that happens to quote a marker from colliding.
+      const beginIndex = stdout.lastIndexOf(begin)
       if (beginIndex === -1) {
         return null
       }

--- a/src/shared/wsl-login-shell-command.ts
+++ b/src/shared/wsl-login-shell-command.ts
@@ -38,6 +38,61 @@ export function buildWslLoginShellCommand(command: string): string {
   ].join('\n')
 }
 
+export type WslCapturedLoginShellCommand = {
+  command: string
+  /** Payload the command wrote, or null when the fence never appeared. */
+  readStdout: (stdout: string) => string | null
+}
+
+// Why: the fence has to be absent from both the rc output ahead of it and the
+// payload behind it. A per-call nonce is the only spelling that guarantees
+// both -- `cat`-ing a file that happens to quote a fixed marker would otherwise
+// truncate the file. Not security-sensitive, so Math.random is sufficient.
+function nextWslCaptureNonce(): string {
+  return `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 10)}`
+}
+
+/**
+ * Run `command` through the distro login shell and fence its stdout.
+ *
+ * Why: the login shell has to be interactive for bash/zsh so PATH matches what
+ * the user sees in their own terminal (nvm, mise and asdf all install into rc
+ * files that only interactive shells read). But an interactive shell also runs
+ * the distro's rc/motd, and stock Ubuntu writes its "run a command as
+ * administrator" hint to *stdout*. Anything parsing that stream reads the
+ * banner as data. The fence marks where the payload starts and ends so callers
+ * keep the PATH benefit without the noise.
+ */
+export function buildWslCapturedLoginShellCommand(
+  command: string,
+  nonce: string = nextWslCaptureNonce()
+): WslCapturedLoginShellCommand {
+  const begin = `__ORCA_WSL_CAPTURE_BEGIN_${nonce}__`
+  const end = `__ORCA_WSL_CAPTURE_END_${nonce}__`
+  return {
+    command: buildWslLoginShellCommand(
+      [
+        `printf %s ${quotePosixShell(begin)}`,
+        command,
+        '_orca_capture_status=$?',
+        `printf %s ${quotePosixShell(end)}`,
+        'exit $_orca_capture_status'
+      ].join('\n')
+    ),
+    readStdout: (stdout) => {
+      const beginIndex = stdout.indexOf(begin)
+      if (beginIndex === -1) {
+        return null
+      }
+      const payloadStart = beginIndex + begin.length
+      const endIndex = stdout.indexOf(end, payloadStart)
+      // A payload that exited early never prints the closing fence; the rest of
+      // the stream is still its output, and login shells run exit hooks after it.
+      return endIndex === -1 ? stdout.slice(payloadStart) : stdout.slice(payloadStart, endIndex)
+    }
+  }
+}
+
 export function buildWslInteractiveLoginShellCommand(): string {
   return [
     '_orca_wsl_shell=$(getent passwd "$(id -un)" 2>/dev/null | cut -d: -f7)',


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$â€‹246 | $\color{#cf222e}{\Huge{\mathbf{âˆ’}}}$â€‹21 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$â€‹225 |
| Prod | 9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$â€‹209 | $\color{#cf222e}{\Huge{\mathbf{âˆ’}}}$â€‹36 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$â€‹173 |

<!-- /orca-pr-loc -->

<!-- wsl-stack -->
### Stack

Merge bottom-up; each PR is based on the one above it.

| # | PR | Base | |
| ---: | :--- | :--- | :--- |
| 1 |   #15039 | `main` | fix(wsl): pass guest argv verbatim through --exec |
| 2 | ▶ #15040 | `#15039` | fix(wsl): read machine output from a fenced login shell ← **you are here** |
| 3 |   #15060 | `#15040` | fix(git): fence buffered WSL login-shell reads |
| 4 |   #15257 | `#15060` | fix(git): run WSL git reads without a shell |

<!-- /wsl-stack -->

## ELI5

To find the user's tools, Orca runs WSL commands through the *interactive* login shell â€” the same one you get in a terminal â€” because that's the only shell that reads `~/.bashrc`, where nvm/mise/asdf put things on `PATH`.

The catch: an interactive shell also prints the welcome banner. On a **stock Ubuntu 24.04, with nothing customized**, that's:

```
To run a command as administrator (user "root"), use "sudo <command>".
See "man sudo_root" for details.
```

That text goes to **stdout** â€” the same pipe Orca reads answers from. So when Orca asked "is this a file or a directory?", it got back the banner *and then* the answer, and the code compared the whole blob to `"directory"`. It never matched.

This PR puts a marker around the real answer so Orca can find it, while keeping the PATH benefit.

## Root cause

Reproduced on a stock distro, no user config:

```
$ wsl.exe -d Ubuntu-24.04 --exec bash -ilc 'git --version'
To run a command as administrator (user "root"), use "sudo <command>".
See "man sudo_root" for details.

git version 2.43.0
```

`buildWslLoginShellCommand` selects `-ilc` for bash/zsh (correctly â€” `-lc` alone misses `~/.bashrc`). Running the *actual shipped code paths* against a real distro:

| caller | returned today |
|---|---|
| `local-worktree-filesystem.statPath` | `"To run a command as administratorâ€¦\n\ndirectory"` |
| `local-worktree-filesystem.readPath` | banner prepended to the file contents it reads |
| `runPreflightCommandInWsl` | banner prepended to `gh --version` / auth output |
| `codex-trust-grant-host` binary stamp | `path` = the banner text (see below) |

`statPath` does `stdout.trim()`, which cannot recover this, so the type never equals `file`/`directory`. These two back the worktree-removal orphan-gitdir proof (`getLocalWorktreePathAccess`), so the proof reads a banner instead of a `.git` file â€” they are **not** the file-explorer listing path.

That three call sites had each grown a *different* private workaround is the tell that this belongs in one place:

- `preflight-wsl-agent-detection.ts` â€” `__ORCA_AGENT_PATH__` line prefix
- `wsl-git-read-environment.ts` â€” `ORCA_WSL_GIT_READ_ENV_V1` + `lastIndexOf`
- `rate-limits/codex-fetcher.ts` â€” an fd dance commented "before shell startup can â€¦ print banners"

The ones that *lacked* a workaround are exactly the broken ones.

### The silent one

`codex-trust-grant-host.buildWslCodexBinaryStamp` reads the identity probe **positionally** â€” path before the first newline, version after. With the banner ahead of it the first newline lands *inside* the banner, so the stamp becomes `path = "To run a command as administratorâ€¦"` with the rest as version. Both halves are non-empty, so **nothing throws**. The stamp exists to detect "the Codex binary changed", so a garbage stamp reads as a changed binary and reissues the trust grant. This is the only case where the corruption is silent rather than a loud failure.

## What changed

`buildWslCapturedLoginShellCommand(command)` returns the script plus a matching `readStdout`. The payload is fenced:

```sh
printf %s '<BEGIN>'
<command>
_orca_capture_status=$?
printf %s '<END>'
exit $_orca_capture_status
```

- rc/motd lands before `<BEGIN>` and is dropped; `~/.bash_logout` noise lands after `<END>`.
- **Exit status is preserved**, so `statPath`'s `exit 2` â†’ `ENOENT` mapping still works.
- The fence carries a **per-call nonce**. A fixed marker would truncate `cat` of any file that happens to quote it â€” an early build did exactly that, which is why the nonce exists.
- A payload that `exec`s (the Codex identity probe) never writes a closing fence; the reader returns everything after the opening one.

`wsl-git-read-environment` drops its bespoke marker and parsing. `buildWslCodexIdentityArgs` becomes `buildWslCodexIdentityProbe` and returns the reader alongside the argv so the two cannot drift apart.

**Deliberately not fenced:** paths that `exec` into a long-running program (`codex app-server`, `codex login`, terminal shells) â€” stdout belongs to that program there; and availability checks that are exit-code only. The git runner's login-shell mode also feeds *streaming* consumers, and git already has a shell-free `--exec /usr/bin/env â€¦ git` fast path that is immune by construction.

## Testing

New real-WSL E2E (`local-worktree-filesystem-wsl-banner.wsl.test.ts`, gated behind `ORCA_REAL_WSL_BANNER_TEST=1`, following the existing `.wsl.test.ts` convention). Against a live `Ubuntu-24.04`:

- **5/5 pass** with the fix.
- **4/5 fail** with fence-stripping disabled, with exactly the reported symptom:
  ```
  AssertionError: expected 'To run a command as administrator (usâ€¦' to be 'directory'
  ```

It deliberately does not modify the developer's `~/.bashrc`; it compares the fenced read against a raw login-shell read, so it is meaningful on both chatty and silent distros.

The trust-grant fix is mutation-checked the same way â€” reverting it reproduces `path: "To run a command as administratorâ€¦"`.

Unit tests cover banner stripping, exit-status preservation, payload-contains-a-fence, missing fence, early exit, and fence uniqueness.

**This PR also fixes two tests that are currently red on `main`.** `wsl-login-shell-command.test.ts` and `posix-command-path-lookup.test.ts` both assert a raw interactive login-shell read matches an expected value; on any machine with a stock Ubuntu they get the banner instead. The second sits in the `shell contracts` CI gate but *skips on Linux*, which is why the breakage stayed invisible.

## Known remaining (follow-up, not this PR)

Five call sites hand-write `bash -lc` / `sh -lc` directly, bypassing both the shell detection and the fence â€” chiefly the Claude/Codex managed-auth path probes and the WSL CLI installer, which parse a path out of stdout and feed it onward as trusted.

I measured this tier rather than assuming: on stock Ubuntu-24.04 `-lc` is **clean** â€” the banner is `-i`-gated. But that cleanliness is coincidental (`01-locale-fix.sh` happens to sort before `Z99-cloud-locale-test.sh`, which has no interactive guard and writes to stdout), and login shells read `~/.bash_profile`/`~/.profile` **unconditionally** â€” so an nvm/conda/direnv installer line or a corporate golden-image banner contaminates `-lc` exactly as much as `-ilc`:

```
$ env HOME=$tmp wsl.exe -d Ubuntu-24.04 --exec env HOME=$tmp bash -lc 'printf READY'
Welcome to Contoso Corp WSL image v3.2
READY
```

That is a real latent risk on ordinary developer machines, but it is a different tier from what this PR proves, and those sites share a common helper (`buildEncodedWslBashCommand`) that makes them a clean separate change. Left as a follow-up rather than widening this diff.



