### PR TITLE
fix(agent-status): let never-ending background shells release a finished turn

### DIFF
--- a/src/main/agent-hooks/server-interrupt-inference-guards.test.ts
+++ b/src/main/agent-hooks/server-interrupt-inference-guards.test.ts
@@ -263,6 +263,58 @@ describe('AgentHookServer listener replay', () => {
     }
   })
 
+  it('lets Escape retire a working pane held only by a listed never-ending shell', async () => {
+    // Why: mid-turn is the case that strands users — a Stop already resolves to done once the command is listed.
+    const DEV_SERVER = { id: 'dev-1', type: 'shell', status: 'running', command: 'npm run dev' }
+    const inferEscapeDuringShell = async (
+      patterns: readonly string[],
+      extraPayload: Record<string, unknown> = {}
+    ): Promise<boolean> => {
+      const server = new AgentHookServer()
+      server.setClaudeBackgroundShellIgnorePatterns(patterns)
+      await server.start({ env: 'production' })
+      try {
+        const env = server.buildPtyEnv()
+        await fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/claude`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+          },
+          body: JSON.stringify(
+            buildBody({
+              hook_event_name: 'UserPromptSubmit',
+              prompt: 'run in background',
+              background_tasks: [DEV_SERVER],
+              ...extraPayload
+            })
+          )
+        })
+        const baseline = server.getStatusSnapshot()[0]
+        expect(baseline).toMatchObject({ state: 'working' })
+        return server.inferInterrupt({
+          paneKey: PANE,
+          baselineUpdatedAt: baseline.receivedAt,
+          baselineStateStartedAt: baseline.stateStartedAt,
+          baselinePrompt: 'run in background',
+          baselineAgentType: 'claude',
+          intent: 'plain-escape'
+        })
+      } finally {
+        server.stop()
+      }
+    }
+
+    await expect(inferEscapeDuringShell([])).resolves.toBe(false)
+    // Why: an unrelated pattern must not retire a shell the user never listed.
+    await expect(inferEscapeDuringShell(['ngrok'])).resolves.toBe(false)
+    await expect(inferEscapeDuringShell(['dev'])).resolves.toBe(true)
+    // Why: only the shell gate relaxes — a session cron still owns the pane.
+    await expect(inferEscapeDuringShell(['dev'], { session_crons: [{ id: 'c' }] })).resolves.toBe(
+      false
+    )
+  })
+
   it('uses replayed Claude background metadata only before a live observation', () => {
     vi.useFakeTimers()
     vi.setSystemTime(1_000)

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -34,6 +34,7 @@ import {
   preparePendingGrokResultDiscovery,
   seedClaudeSubagentRosterFromSnapshots,
   seedCodexStateFromSnapshot,
+  setClaudeBackgroundShellIgnorePatterns,
   warnOnHookEnvOrVersionMismatch,
   writeEndpointFile,
   type AgentHookEventPayload,
@@ -636,6 +637,11 @@ export class AgentHookServer {
   private connectionTimestampWatermarkById = new Map<string, number>()
   // Why: skip disk writes when the JSON exactly matches the last write; guards against re-firing trailing timers when nothing changed.
   private lastWrittenJson: string | null = null
+
+  /** Live user setting; index.ts owns the Store read so this class stays Electron-free. */
+  setClaudeBackgroundShellIgnorePatterns(patterns: readonly string[]): void {
+    setClaudeBackgroundShellIgnorePatterns(this.state, patterns)
+  }
 
   setListener(listener: ((payload: EnrichedAgentHookEventPayload) => void) | null): void {
     this.onAgentStatus = listener

--- a/src/main/agent-hooks/wsl-hook-relay-manager.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-manager.ts
@@ -23,7 +23,11 @@ import { wireWslRelayLink } from './wsl-hook-relay-link'
 import { WslRelayRecovery } from './wsl-hook-relay-recovery'
 import { wslHookRelayStateKey } from './wsl-hook-relay-state-key'
 import { SshChannelMultiplexer, type MultiplexerTransport } from '../ssh/ssh-channel-multiplexer'
-import { AGENT_HOOK_REQUEST_REPLAY_METHOD } from '../../shared/agent-hook-relay'
+import {
+  AGENT_HOOK_REQUEST_REPLAY_METHOD,
+  AGENT_HOOK_SET_STATUS_POLICY_METHOD,
+  type AgentHookStatusPolicyParams
+} from '../../shared/agent-hook-relay'
 import {
   sanitizeWslHookInstanceKey,
   WSL_HOOK_FS_METHODS,
@@ -56,6 +60,8 @@ export class WslHookRelayManager {
   private defaultDistro: string | null = null
   private disposed = false
   private warnedBundleMissing = false
+  /** Last host settings pushed; retained so a relay started (or restarted) later adopts them too. */
+  private statusPolicy: AgentHookStatusPolicyParams = { backgroundShellIgnorePatterns: [] }
 
   constructor(deps: Partial<WslHookRelayManagerDeps> = {}) {
     this.deps = { ...defaultWslHookRelayDeps, ...deps }
@@ -78,6 +84,20 @@ export class WslHookRelayManager {
 
   setManagedHookSettingsResolver(resolve: WslHookRelayManagerDeps['managedHookSettings']): void {
     this.deps.managedHookSettings = resolve
+  }
+
+  /** Guest relays own no settings store, so the host pushes the settings that shape hook normalization. */
+  pushAgentHookStatusPolicy(policy: AgentHookStatusPolicyParams): void {
+    this.statusPolicy = policy
+    for (const state of this.states.values()) {
+      this.sendAgentHookStatusPolicy(state.mux)
+    }
+  }
+
+  private sendAgentHookStatusPolicy(mux: SshChannelMultiplexer | undefined): void {
+    void mux?.request(AGENT_HOOK_SET_STATUS_POLICY_METHOD, this.statusPolicy).catch(() => {
+      // Why: a guest relay predating the handler answers -32601 and keeps the pre-setting behavior.
+    })
   }
 
   /** Fire-and-forget from every WSL PTY spawn-env build; errors breadcrumb. */
@@ -295,6 +315,7 @@ export class WslHookRelayManager {
     void mux.request(AGENT_HOOK_REQUEST_REPLAY_METHOD).catch(() => {
       // Fresh relays have nothing to replay; tolerate.
     })
+    this.sendAgentHookStatusPolicy(mux)
   }
 
   /** Records + breadcrumbs the failure and always arms the restart timer —

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -72,6 +72,8 @@ import { triggerStartupNotificationRegistration } from './ipc/startup-notificati
 import { OrcaRuntimeService, type RuntimeWorktreeLifecycleEvent } from './runtime/orca-runtime'
 import { ArtifactCloudService } from './artifacts/artifact-cloud-service'
 import { isArtifactSharingEnabled } from '../shared/artifact-sharing-gate'
+import { resolveClaudeBackgroundShellIgnorePatterns } from '../shared/claude-background-shell-patterns'
+import type { GlobalSettings } from '../shared/global-settings-types'
 import { loadAgentSessionClaimSigner } from './runtime/agent-session-claim-identity'
 import {
   fingerprintOrchestrationPeer,
@@ -893,6 +895,14 @@ ipcMain.handle(
     logStartupMilestone(event, details && typeof details === 'object' ? details : {})
   }
 )
+
+/** Every hook host resolves Claude pane status itself, so the setting has to reach each
+ *  one. Live SSH sessions subscribe to the Store directly; local and WSL are pushed here. */
+function applyAgentStatusBackgroundShellSetting(settings: GlobalSettings): void {
+  const backgroundShellIgnorePatterns = resolveClaudeBackgroundShellIgnorePatterns(settings)
+  agentHookServer.setClaudeBackgroundShellIgnorePatterns(backgroundShellIgnorePatterns)
+  wslHookRelayManager.pushAgentHookStatusPolicy({ backgroundShellIgnorePatterns })
+}
 
 /** A PTY that dies while Orca is down never runs the teardown that clears pane
  *  state, so hydrate can rebuild a Claude subagent roster that no later hook can
@@ -2197,6 +2207,7 @@ void app.whenReady().then(async () => {
   logStartupMilestone('store-loaded')
   // Why: apply initial fallback WSL distro from store settings for global git/CLI calls.
   setDefaultWslDistroOverride(store.getSettings().terminalWindowsWslDistro ?? null)
+  applyAgentStatusBackgroundShellSetting(store.getSettings())
   store.onSettingsChanged((updates, settings) => {
     if ('terminalWindowsWslDistro' in updates) {
       // Why: synchronize fallback WSL distro updates to runner.
@@ -2221,6 +2232,12 @@ void app.whenReady().then(async () => {
     if ('showMenuBarIcon' in updates) {
       // Why: Store is the mutation authority for all settings writes, so every macOS toggle updates the native item live.
       syncMacMenuBarIcon(settings.showMenuBarIcon !== false)
+    }
+    if (
+      'agentStatusIgnoresBackgroundShells' in updates ||
+      'agentStatusBackgroundShellIgnorePatterns' in updates
+    ) {
+      applyAgentStatusBackgroundShellSetting(settings)
     }
     if ('agentStatusHooksEnabled' in updates) {
       // Why both directions: the ensure gate only blocks NEW relays, so off must stop the running

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -27,8 +27,10 @@ import {
   AGENT_HOOK_INSTALL_PLUGINS_METHOD,
   AGENT_HOOK_NOTIFICATION_METHOD,
   AGENT_HOOK_REQUEST_REPLAY_METHOD,
+  AGENT_HOOK_SET_STATUS_POLICY_METHOD,
   isRemoteAgentHooksEnabled
 } from '../../shared/agent-hook-relay'
+import { resolveClaudeBackgroundShellIgnorePatterns } from '../../shared/claude-background-shell-patterns'
 import { _internals as openCodeInternals } from '../opencode/hook-service'
 import { getPiAgentStatusExtensionSource } from '../pi/agent-status-extension-source'
 import {
@@ -304,6 +306,7 @@ export class SshRelaySession {
   private muxDisposeCleanup: (() => void) | null = null
   // Why: hold the notification-handler disposer so teardownProviders can release it on reconnect/shutdown (symmetric with muxDisposeCleanup).
   private muxNotificationCleanup: (() => void) | null = null
+  private agentHookStatusPolicyCleanup: (() => void) | null = null
   // Why: onStateChange never fires when the relay channel closes but SSH stays up; this callback lets ssh.ts drive relay-level reconnect.
   private _onRelayLost: ((targetId: string) => void) | null = null
   // Why: a version mismatch or a blocked owner admission is terminal, so it needs a separate callback
@@ -1465,6 +1468,19 @@ export class SshRelaySession {
     }
   }
 
+  private sendAgentHookStatusPolicy(mux: SshChannelMultiplexer): void {
+    const store = this.store as { getSettings?: Store['getSettings'] }
+    void mux
+      .request(AGENT_HOOK_SET_STATUS_POLICY_METHOD, {
+        backgroundShellIgnorePatterns: resolveClaudeBackgroundShellIgnorePatterns(
+          store.getSettings?.()
+        )
+      })
+      .catch(() => {
+        // Why: a relay predating the handler answers -32601 and keeps the pre-setting behavior.
+      })
+  }
+
   private areAgentStatusHooksEnabled(): boolean {
     const store = this.store as { getSettings?: Store['getSettings'] }
     return isAgentStatusHooksEnabled(store.getSettings?.())
@@ -1551,6 +1567,21 @@ export class SshRelaySession {
       )
     })
 
+    // Why: the relay resolves pane status remotely and owns no settings store, so push the
+    // status settings now and on every later change — otherwise a toggle needs a reconnect.
+    this.agentHookStatusPolicyCleanup?.()
+    this.sendAgentHookStatusPolicy(mux)
+    const store = this.store as { onSettingsChanged?: Store['onSettingsChanged'] }
+    this.agentHookStatusPolicyCleanup =
+      store.onSettingsChanged?.((updates) => {
+        if (
+          'agentStatusIgnoresBackgroundShells' in updates ||
+          'agentStatusBackgroundShellIgnorePatterns' in updates
+        ) {
+          this.sendAgentHookStatusPolicy(mux)
+        }
+      }) ?? null
+
     // Why: request replay of cached paneKeys only after the handler is wired, so replayed events can't arrive before we subscribe. Best-effort.
     void mux.request(AGENT_HOOK_REQUEST_REPLAY_METHOD).catch((err) => {
       const code = (err as { code?: unknown })?.code
@@ -1579,6 +1610,8 @@ export class SshRelaySession {
     this.releaseRelayLossWatcher()
     this.muxNotificationCleanup?.()
     this.muxNotificationCleanup = null
+    this.agentHookStatusPolicyCleanup?.()
+    this.agentHookStatusPolicyCleanup = null
     for (const cleanup of this.ptyRecoveryNotificationCleanups) {
       cleanup()
     }

--- a/src/relay/agent-hook-server.ts
+++ b/src/relay/agent-hook-server.ts
@@ -18,6 +18,7 @@ import {
   readRequestBody,
   resolveCachedClaudeCompactOwnership,
   resolveHookSource,
+  setClaudeBackgroundShellIgnorePatterns,
   writeEndpointFile,
   type AgentHookEventPayload,
   type HookListenerState
@@ -25,8 +26,10 @@ import {
 import {
   REMOTE_AGENT_HOOK_ENV,
   type AgentHookRelayEnvelope,
-  type AgentHookSource
+  type AgentHookSource,
+  type AgentHookStatusPolicyParams
 } from '../shared/agent-hook-relay'
+import { normalizeClaudeBackgroundShellIgnorePatterns } from '../shared/claude-background-shell-patterns'
 import { buildRelayHookPtyEnv, defaultEndpointDir } from './agent-hook-endpoint-coordinates'
 import { buildRelayHookEnvelope, hookBodyEnv, hookBodyVersion } from './agent-hook-envelope-build'
 import { AgentHookResultRetryScheduler } from './agent-hook-result-retry-scheduler'
@@ -186,6 +189,14 @@ export class RelayAgentHookServer {
       count++
     }
     return count
+  }
+
+  /** Adopt the host's agent-status settings; survives stop()/start() since it is config, not cache. */
+  setStatusPolicy(policy: AgentHookStatusPolicyParams): void {
+    setClaudeBackgroundShellIgnorePatterns(
+      this.state,
+      normalizeClaudeBackgroundShellIgnorePatterns(policy.backgroundShellIgnorePatterns)
+    )
   }
 
   /** Drop a paneKey's cached entries on PTY exit so a terminated pane can't resurface as a ghost event on reconnect. */

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -50,7 +50,8 @@ import { endpointDirForRelaySocket } from './agent-hook-endpoint-coordinates'
 import { PluginOverlayManager } from './plugin-overlay'
 import {
   AGENT_HOOK_INSTALL_PLUGINS_METHOD,
-  AGENT_HOOK_REQUEST_REPLAY_METHOD
+  AGENT_HOOK_REQUEST_REPLAY_METHOD,
+  AGENT_HOOK_SET_STATUS_POLICY_METHOD
 } from '../shared/agent-hook-relay'
 import { publishAgentHookEnvelope } from './agent-hook-envelope-publication'
 import {
@@ -883,6 +884,14 @@ async function main(): Promise<void> {
   dispatcher.onRequest(AGENT_HOOK_REQUEST_REPLAY_METHOD, async () => {
     const replayed = hookServer.replayCachedPayloadsForPanes()
     return { replayed }
+  })
+
+  // Why: the relay has no settings store of its own; Orca pushes the status settings that shape hook normalization.
+  dispatcher.onRequest(AGENT_HOOK_SET_STATUS_POLICY_METHOD, async (params) => {
+    hookServer.setStatusPolicy({
+      backgroundShellIgnorePatterns: params.backgroundShellIgnorePatterns as string[]
+    })
+    return { applied: true }
   })
 
   // Why: relay-local installers collapse hundreds of SFTP request/response RTTs to one RPC.

--- a/src/relay/wsl-agent-hook-relay.ts
+++ b/src/relay/wsl-agent-hook-relay.ts
@@ -21,7 +21,8 @@ import { createInstallPluginsHandler } from './wsl-install-plugins-handler'
 import { PreflightHandler } from './preflight-handler'
 import {
   AGENT_HOOK_INSTALL_PLUGINS_METHOD,
-  AGENT_HOOK_REQUEST_REPLAY_METHOD
+  AGENT_HOOK_REQUEST_REPLAY_METHOD,
+  AGENT_HOOK_SET_STATUS_POLICY_METHOD
 } from '../shared/agent-hook-relay'
 import { publishAgentHookEnvelope } from './agent-hook-envelope-publication'
 import {
@@ -75,6 +76,14 @@ async function main(): Promise<void> {
   dispatcher.onRequest(AGENT_HOOK_REQUEST_REPLAY_METHOD, async () => ({
     replayed: hookServer.replayCachedPayloadsForPanes()
   }))
+
+  // Why: the guest relay has no settings store; Orca pushes the status settings that shape hook normalization.
+  dispatcher.onRequest(AGENT_HOOK_SET_STATUS_POLICY_METHOD, async (params) => {
+    hookServer.setStatusPolicy({
+      backgroundShellIgnorePatterns: params.backgroundShellIgnorePatterns as string[]
+    })
+    return { applied: true }
+  })
 
   // Why: OpenCode reports status via a plugin (not a hooks.json script), so the
   // host ships its source over the wire and the guest materializes a config

--- a/src/renderer/src/components/settings/BackgroundShellStatusExperimentalSetting.tsx
+++ b/src/renderer/src/components/settings/BackgroundShellStatusExperimentalSetting.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from 'react'
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import { DEFAULT_CLAUDE_BACKGROUND_SHELL_IGNORE_PATTERNS } from '../../../../shared/claude-background-shell-patterns'
+import { translate } from '@/i18n/i18n'
+import { Button } from '../ui/button'
+import { Label } from '../ui/label'
+import { getExperimentalSearchEntry } from './experimental-search'
+import { SearchableSetting } from './SearchableSetting'
+import { SettingsSwitch } from './SettingsFormControls'
+
+type BackgroundShellStatusExperimentalSettingProps = {
+  settings: GlobalSettings
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+}
+
+function toPatternList(text: string): string[] {
+  return text
+    .split(/[\n,]/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+}
+
+export function BackgroundShellStatusExperimentalSetting({
+  settings,
+  updateSettings
+}: BackgroundShellStatusExperimentalSettingProps): React.JSX.Element {
+  const entry = getExperimentalSearchEntry().backgroundShellStatus
+  const enabled = settings.agentStatusIgnoresBackgroundShells === true
+  const patterns =
+    settings.agentStatusBackgroundShellIgnorePatterns ??
+    DEFAULT_CLAUDE_BACKGROUND_SHELL_IGNORE_PATTERNS
+  // Why: edit as raw text so a half-typed line isn't split into patterns on every keystroke; commit on blur.
+  const [draft, setDraft] = useState(() => patterns.join('\n'))
+  const savedText = patterns.join('\n')
+  useEffect(() => {
+    setDraft(savedText)
+  }, [savedText])
+
+  const commitDraft = (): void => {
+    const next = toPatternList(draft)
+    if (next.join('\n') !== savedText) {
+      updateSettings({ agentStatusBackgroundShellIgnorePatterns: next })
+    }
+  }
+
+  return (
+    <SearchableSetting
+      title={entry.title}
+      description={entry.description}
+      keywords={entry.keywords}
+      className="space-y-3 py-2"
+      id="experimental-background-shell-status"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 shrink space-y-0.5">
+          <Label>{entry.title}</Label>
+          <p className="text-xs text-muted-foreground">
+            {translate(
+              'auto.components.settings.ExperimentalPane.backgroundShellStatus.copy',
+              'A background shell whose command never exits on its own — a dev server, a watcher — no longer keeps the agent marked as working once its turn ends. Anything not listed below still holds it, as do running subagents and scheduled jobs.'
+            )}
+          </p>
+        </div>
+        <SettingsSwitch
+          checked={enabled}
+          ariaLabel={translate(
+            'auto.components.settings.ExperimentalPane.backgroundShellStatus.toggleLabel',
+            'Toggle ignore background shells'
+          )}
+          onChange={() => updateSettings({ agentStatusIgnoresBackgroundShells: !enabled })}
+        />
+      </div>
+      {enabled ? (
+        <div className="space-y-2">
+          <div className="flex items-center justify-between gap-3">
+            <Label htmlFor="background-shell-ignore-patterns">
+              {translate(
+                'auto.components.settings.ExperimentalPane.backgroundShellStatus.patternsLabel',
+                'Never-ending commands'
+              )}
+            </Label>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() =>
+                updateSettings({
+                  agentStatusBackgroundShellIgnorePatterns: [
+                    ...DEFAULT_CLAUDE_BACKGROUND_SHELL_IGNORE_PATTERNS
+                  ]
+                })
+              }
+            >
+              {translate(
+                'auto.components.settings.ExperimentalPane.backgroundShellStatus.restoreDefaults',
+                'Restore defaults'
+              )}
+            </Button>
+          </div>
+          <textarea
+            id="background-shell-ignore-patterns"
+            value={draft}
+            onChange={(event) => setDraft(event.target.value)}
+            onBlur={commitDraft}
+            rows={6}
+            spellCheck={false}
+            className="w-full min-w-0 resize-y rounded-md border border-input bg-transparent px-3 py-2 font-mono text-xs shadow-xs outline-none transition-[color,box-shadow] placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+          />
+          <p className="text-xs text-muted-foreground">
+            {translate(
+              'auto.components.settings.ExperimentalPane.backgroundShellStatus.patternsHelp',
+              'One per line. Each matches a whole word in the command, so "dev" matches "npm run dev" but not "dev-check.sh". A test or build command you leave off this list keeps holding the turn.'
+            )}
+          </p>
+        </div>
+      ) : null}
+    </SearchableSetting>
+  )
+}

--- a/src/renderer/src/components/settings/ExperimentalPane.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.tsx
@@ -11,6 +11,7 @@ import { translate } from '@/i18n/i18n'
 import { NativeChatExperimentalSetting } from './NativeChatExperimentalSetting'
 import { AgentDashboardExperimentalSetting } from './AgentDashboardExperimentalSetting'
 import { EphemeralVmsExperimentalSetting } from './EphemeralVmsExperimentalSetting'
+import { BackgroundShellStatusExperimentalSetting } from './BackgroundShellStatusExperimentalSetting'
 import {
   MAX_AGENT_HIBERNATION_IDLE_MS,
   MIN_AGENT_HIBERNATION_IDLE_MS,
@@ -50,6 +51,9 @@ export function ExperimentalPane({
   ])
   const showAgentHibernation = matchesSettingsSearch(searchQuery, [
     getExperimentalSearchEntry().agentHibernation
+  ])
+  const showBackgroundShellStatus = matchesSettingsSearch(searchQuery, [
+    getExperimentalSearchEntry().backgroundShellStatus
   ])
   const showNewWorktreeCardStyle = matchesSettingsSearch(searchQuery, [
     getExperimentalSearchEntry().newWorktreeCardStyle
@@ -257,6 +261,13 @@ export function ExperimentalPane({
             />
           ) : null}
         </SearchableSetting>
+      ) : null}
+
+      {showBackgroundShellStatus ? (
+        <BackgroundShellStatusExperimentalSetting
+          settings={settings}
+          updateSettings={updateSettings}
+        />
       ) : null}
 
       {showNewWorktreeCardStyle ? (

--- a/src/renderer/src/components/settings/background-shell-status-search-entry.ts
+++ b/src/renderer/src/components/settings/background-shell-status-search-entry.ts
@@ -1,0 +1,50 @@
+import type { SettingsSearchEntry } from './settings-search'
+import { translate } from '@/i18n/i18n'
+import { translateSearchKeyword } from './settings-search-keywords'
+
+export function getBackgroundShellStatusSearchEntry(): SettingsSearchEntry {
+  return {
+    title: translate(
+      'auto.components.settings.experimental.search.backgroundShellStatus.title',
+      'Ignore background shells'
+    ),
+    description: translate(
+      'auto.components.settings.experimental.search.backgroundShellStatus.description',
+      'Background shells whose command never exits, such as dev servers and watchers, stop keeping an agent marked as working once its turn ends.'
+    ),
+    keywords: [
+      ...translateSearchKeyword(
+        'auto.components.settings.experimental.search.0d24759f14',
+        'experimental'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.experimental.search.backgroundShellStatus.background',
+        'background'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.experimental.search.backgroundShellStatus.shell',
+        'shell'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.experimental.search.backgroundShellStatus.devServer',
+        'dev server'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.experimental.search.backgroundShellStatus.build',
+        'build'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.experimental.search.backgroundShellStatus.status',
+        'status'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.experimental.search.backgroundShellStatus.spinner',
+        'spinner'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.experimental.search.backgroundShellStatus.working',
+        'working'
+      )
+    ]
+  }
+}

--- a/src/renderer/src/components/settings/experimental-search.ts
+++ b/src/renderer/src/components/settings/experimental-search.ts
@@ -5,6 +5,7 @@ import { translateSearchKeyword } from './settings-search-keywords'
 import { getNewWorktreeCardStyleSearchEntry } from './new-worktree-card-style-search-entry'
 import { getNativeChatExperimentalSearchEntry } from './native-chat-experimental-search-entry'
 import { getEphemeralVmsSearchEntry } from './ephemeral-vms-search'
+import { getBackgroundShellStatusSearchEntry } from './background-shell-status-search-entry'
 
 export const getExperimentalPaneSearchEntries = createLocalizedCatalog(
   (): SettingsSearchEntry[] => [
@@ -228,6 +229,7 @@ export const getExperimentalPaneSearchEntries = createLocalizedCatalog(
         )
       ]
     },
+    getBackgroundShellStatusSearchEntry(),
     getNewWorktreeCardStyleSearchEntry(),
     getEphemeralVmsSearchEntry()
   ]
@@ -266,6 +268,12 @@ export function getExperimentalSearchEntry() {
       translate(
         'auto.components.settings.experimental.search.agentHibernation.title',
         'Agent sleep'
+      )
+    ),
+    backgroundShellStatus: findEntry(
+      translate(
+        'auto.components.settings.experimental.search.backgroundShellStatus.title',
+        'Ignore background shells'
       )
     ),
     newWorktreeCardStyle: findEntry(

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6194,6 +6194,15 @@
             "modeAriaLabel": "Agent Dashboard open mode",
             "modeInWindow": "In-window",
             "modePopout": "Pop-out"
+          },
+          "backgroundShellStatus": {
+            "title": "Ignore background shells",
+            "description": "Background shells whose command never exits, such as dev servers and watchers, stop keeping an agent marked as working once its turn ends.",
+            "copy": "A background shell whose command never exits on its own — a dev server, a watcher — no longer keeps the agent marked as working once its turn ends. Anything not listed below still holds it, as do running subagents and scheduled jobs.",
+            "toggleLabel": "Toggle ignore background shells",
+            "patternsLabel": "Never-ending commands",
+            "restoreDefaults": "Restore defaults",
+            "patternsHelp": "One per line. Each matches a whole word in the command, so \"dev\" matches \"npm run dev\" but not \"dev-check.sh\". A test or build command you leave off this list keeps holding the turn."
           }
         },
         "FloatingWorkspacePane": {
@@ -8533,6 +8542,10 @@
             "agentDashboard": {
               "title": "Agent Dashboard",
               "description": "Kanban board for monitoring agents across worktrees, in-window or as a pop-out."
+            },
+            "backgroundShellStatus": {
+              "title": "Ignore background shells",
+              "description": "Background shells whose command never exits, such as dev servers and watchers, stop keeping an agent marked as working once its turn ends."
             }
           }
         },

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -147,6 +147,8 @@ export type HookListenerState = {
   codexSubagentTranscriptByPaneKey: Map<string, CodexSubagentTranscriptState>
   /** Root Codex state/model, kept separate from child hook traffic. */
   codexLeadStateByPaneKey: Map<string, CodexLeadTurnState>
+  /** User setting, not a cache: commands matching these never terminate on their own, so a running one is not work in flight and cannot hold a finished turn at `working`. Empty keeps every shell sticky. */
+  claudeBackgroundShellIgnorePatterns: readonly string[]
 }
 
 export type ClaudeLeadTurnState = {
@@ -181,7 +183,21 @@ export function createHookListenerState(): HookListenerState {
     claudeActiveSessionCronPaneKeys: new Set(),
     codexSubagentRosterByPaneKey: new Map(),
     codexSubagentTranscriptByPaneKey: new Map(),
-    codexLeadStateByPaneKey: new Map()
+    codexLeadStateByPaneKey: new Map(),
+    claudeBackgroundShellIgnorePatterns: []
+  }
+}
+
+/** Applies the live user setting. Retained evidence was computed under the old list, so
+ *  a newly non-empty one clears it to release panes a matching shell already pinned;
+ *  emptying it cannot re-pin without a fresh payload, so those pins are left alone. */
+export function setClaudeBackgroundShellIgnorePatterns(
+  state: HookListenerState,
+  patterns: readonly string[]
+): void {
+  state.claudeBackgroundShellIgnorePatterns = patterns
+  if (patterns.length > 0) {
+    state.claudeRunningNonAgentTaskPaneKeys.clear()
   }
 }
 
@@ -2859,7 +2875,11 @@ function normalizeClaudeEvent(
       previousLead?.interrupted === true)
       ? true
       : undefined
-  const backgroundTasks = readClaudeBackgroundAgentTasks(hookPayload)
+  // Why: filtering at the read keeps one source of truth — the pane gate, interrupt inference and the relay envelope all follow from the evidence it produces.
+  const backgroundTasks = readClaudeBackgroundAgentTasks(
+    hookPayload,
+    state.claudeBackgroundShellIgnorePatterns
+  )
   const sessionCrons = hookPayload['session_crons']
   const sessionCronInventoryPresent = Array.isArray(sessionCrons)
   const hasActiveSessionCron = sessionCronInventoryPresent && sessionCrons.length > 0

--- a/src/shared/agent-hook-relay.ts
+++ b/src/shared/agent-hook-relay.ts
@@ -204,6 +204,20 @@ export const AGENT_HOOK_REQUEST_REPLAY_METHOD = 'agent_hook.requestReplay' as co
  *  overlay dirs on the remote. */
 export const AGENT_HOOK_INSTALL_PLUGINS_METHOD = 'agent_hook.installPlugins' as const
 
+/** JSON-RPC request Orca issues at hook wire-up and on every later change, so the
+ *  relay's listener resolves pane status under the same user settings as the local
+ *  host. The relay owns no settings store, and the `agent.hook` envelope cannot carry
+ *  the answer: its `claudeRunningNonAgentTask` field is already the shell/cron OR, and
+ *  `payload.state` has collapsed "lead still working" into the same `working`. An older
+ *  relay rejects this with -32601 and simply keeps the pre-setting behavior. */
+export const AGENT_HOOK_SET_STATUS_POLICY_METHOD = 'agent_hook.setStatusPolicy' as const
+
+export type AgentHookStatusPolicyParams = {
+  /** Command tokens marking a never-terminating background shell, which therefore cannot
+   *  hold a finished Claude turn at `working`. Empty means every running shell holds it. */
+  backgroundShellIgnorePatterns: string[]
+}
+
 /** JSON-RPC request method that asks the remote relay to install every
  *  managed hook using its local filesystem instead of WAN-bound SFTP. */
 export const AGENT_HOOK_INSTALL_MANAGED_HOOKS_METHOD = 'agent_hook.installManagedHooks' as const

--- a/src/shared/claude-background-shell-patterns.test.ts
+++ b/src/shared/claude-background-shell-patterns.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import {
+  claudeBackgroundShellCommandMatches,
+  DEFAULT_CLAUDE_BACKGROUND_SHELL_IGNORE_PATTERNS as DEFAULTS,
+  normalizeClaudeBackgroundShellIgnorePatterns,
+  resolveClaudeBackgroundShellIgnorePatterns
+} from './claude-background-shell-patterns'
+
+const matchesDefault = (command: string): boolean =>
+  claudeBackgroundShellCommandMatches(command, DEFAULTS)
+
+describe('claudeBackgroundShellCommandMatches', () => {
+  it('matches never-ending commands across ecosystems', () => {
+    for (const command of [
+      'npm run dev',
+      'next dev --port 3000',
+      'ng serve',
+      'python manage.py runserver',
+      'tsc --watch',
+      'cargo watch -x test',
+      'uvicorn app:main --reload',
+      'nodemon server.js',
+      'tail -f /var/log/app.log',
+      'NODE_ENV=development npm run dev'
+    ]) {
+      expect(matchesDefault(command)).toBe(true)
+    }
+  })
+
+  it('leaves commands whose result the turn may await alone', () => {
+    for (const command of [
+      'pytest -q',
+      'npm run build',
+      'curl -s http://localhost:3000/api/health',
+      'go test ./...',
+      'docker build -t app .',
+      './scripts/api-smoke.sh --json'
+    ]) {
+      expect(matchesDefault(command)).toBe(false)
+    }
+  })
+
+  it('matches whole tokens, not substrings', () => {
+    expect(claudeBackgroundShellCommandMatches('./dev-check.sh', ['dev'])).toBe(false)
+    expect(claudeBackgroundShellCommandMatches('bash dev', ['dev'])).toBe(true)
+    // Why: shell quoting must not hide a token behind punctuation.
+    expect(claudeBackgroundShellCommandMatches("nginx -g 'daemon off;'", ['off'])).toBe(true)
+  })
+
+  it('treats a pattern containing a space as a phrase', () => {
+    expect(claudeBackgroundShellCommandMatches('docker compose up', ['compose up'])).toBe(true)
+    expect(claudeBackgroundShellCommandMatches('docker compose build', ['compose up'])).toBe(false)
+  })
+
+  it('is case-insensitive and ignores non-string or empty input', () => {
+    expect(claudeBackgroundShellCommandMatches('NPM RUN DEV', ['dev'])).toBe(true)
+    expect(claudeBackgroundShellCommandMatches(undefined, ['dev'])).toBe(false)
+    expect(claudeBackgroundShellCommandMatches('npm run dev', [])).toBe(false)
+  })
+})
+
+describe('normalizeClaudeBackgroundShellIgnorePatterns', () => {
+  it('trims, lowercases, dedupes and drops unusable entries', () => {
+    expect(
+      normalizeClaudeBackgroundShellIgnorePatterns([' Dev ', 'dev', '', '  ', 42, null, 'serve'])
+    ).toEqual(['dev', 'serve'])
+    expect(normalizeClaudeBackgroundShellIgnorePatterns('nope')).toEqual([])
+  })
+
+  it('bounds a pathological list', () => {
+    const huge = Array.from({ length: 500 }, (_, i) => `p${i}`)
+    expect(normalizeClaudeBackgroundShellIgnorePatterns(huge)).toHaveLength(100)
+    expect(normalizeClaudeBackgroundShellIgnorePatterns(['x'.repeat(65)])).toEqual([])
+  })
+})
+
+describe('resolveClaudeBackgroundShellIgnorePatterns', () => {
+  it('applies nothing until the user opts in', () => {
+    expect(resolveClaudeBackgroundShellIgnorePatterns(null)).toEqual([])
+    expect(
+      resolveClaudeBackgroundShellIgnorePatterns({
+        agentStatusBackgroundShellIgnorePatterns: ['dev']
+      })
+    ).toEqual([])
+  })
+
+  it('falls back to the built-in list only when the user has none stored', () => {
+    expect(
+      resolveClaudeBackgroundShellIgnorePatterns({ agentStatusIgnoresBackgroundShells: true })
+    ).toEqual([...DEFAULTS])
+    expect(
+      resolveClaudeBackgroundShellIgnorePatterns({
+        agentStatusIgnoresBackgroundShells: true,
+        agentStatusBackgroundShellIgnorePatterns: []
+      })
+    ).toEqual([])
+  })
+})

--- a/src/shared/claude-background-shell-patterns.ts
+++ b/src/shared/claude-background-shell-patterns.ts
@@ -1,0 +1,88 @@
+import type { GlobalSettings } from './global-settings-types'
+
+/** Commands with no natural exit condition: still running at turn end means the agent
+ *  launched and walked away, not that it is waiting for a result. Tokens beat binary
+ *  names — `--watch`/`dev`/`serve` generalize across ecosystems a name list can't cover. */
+export const DEFAULT_CLAUDE_BACKGROUND_SHELL_IGNORE_PATTERNS: readonly string[] = Object.freeze([
+  'dev',
+  'serve',
+  'runserver',
+  'watch',
+  '--watch',
+  '--reload',
+  '--follow',
+  'nodemon',
+  'ngrok',
+  'http-server',
+  'uvicorn',
+  'gunicorn',
+  'caddy',
+  'mongod',
+  'redis-server',
+  'tail',
+  'journalctl'
+])
+
+// Why: bound user-supplied config so a pathological list can't cost per-hook time.
+const MAX_PATTERNS = 100
+const MAX_PATTERN_LEN = 64
+const MAX_COMMAND_SCAN_LEN = 4_096
+
+/** Trims, lowercases, dedupes and caps a raw pattern list from settings or the wire. */
+export function normalizeClaudeBackgroundShellIgnorePatterns(raw: unknown): string[] {
+  if (!Array.isArray(raw)) {
+    return []
+  }
+  const cleaned = raw
+    .filter((item): item is string => typeof item === 'string')
+    .map((item) => item.trim().toLowerCase())
+    .filter((pattern) => pattern.length > 0 && pattern.length <= MAX_PATTERN_LEN)
+  return [...new Set(cleaned)].slice(0, MAX_PATTERNS)
+}
+
+// Why: shell quoting and trailing separators would otherwise hide a token (`'daemon` != `daemon`).
+function stripTokenPunctuation(token: string): string {
+  return token.replace(/^['"`]+|['"`;,]+$/g, '')
+}
+
+/** True when the command looks like one of the never-terminating patterns. Single-word
+ *  patterns match a whole token so `dev` can't fire on `dev-smoke-test.sh`; a pattern
+ *  containing a space matches as a phrase. */
+export function claudeBackgroundShellCommandMatches(
+  command: unknown,
+  patterns: readonly string[]
+): boolean {
+  if (patterns.length === 0 || typeof command !== 'string' || command.length === 0) {
+    return false
+  }
+  const normalized = command.slice(0, MAX_COMMAND_SCAN_LEN).toLowerCase()
+  const tokens = new Set(
+    normalized
+      .split(/\s+/)
+      .map(stripTokenPunctuation)
+      .filter((token) => token.length > 0)
+  )
+  return patterns.some((pattern) =>
+    pattern.includes(' ') ? normalized.includes(pattern) : tokens.has(pattern)
+  )
+}
+
+/** The patterns a host should actually apply. Empty unless the user opted in, which is
+ *  what keeps the default behavior (every running shell holds the turn) intact. */
+export function resolveClaudeBackgroundShellIgnorePatterns(
+  settings:
+    | Pick<
+        GlobalSettings,
+        'agentStatusIgnoresBackgroundShells' | 'agentStatusBackgroundShellIgnorePatterns'
+      >
+    | null
+    | undefined
+): string[] {
+  if (settings?.agentStatusIgnoresBackgroundShells !== true) {
+    return []
+  }
+  return normalizeClaudeBackgroundShellIgnorePatterns(
+    settings.agentStatusBackgroundShellIgnorePatterns ??
+      DEFAULT_CLAUDE_BACKGROUND_SHELL_IGNORE_PATTERNS
+  )
+}

--- a/src/shared/claude-background-task-inventory.ts
+++ b/src/shared/claude-background-task-inventory.ts
@@ -1,4 +1,5 @@
 import { AGENT_STATUS_MAX_SUBAGENTS } from './agent-status-types'
+import { claudeBackgroundShellCommandMatches } from './claude-background-shell-patterns'
 
 const CLAUDE_TERMINAL_BACKGROUND_TASK_STATUSES = new Set([
   'idle',
@@ -37,8 +38,12 @@ export type ClaudeBackgroundAgentTask = {
 
 /** Read the agent-typed entries of a hook payload's `background_tasks` field.
  *  `present: false` means the field was absent/malformed (older Claude builds),
- *  so callers must keep their tracked roster instead of clearing it. */
-export function readClaudeBackgroundAgentTasks(hookPayload: Record<string, unknown>): {
+ *  so callers must keep their tracked roster instead of clearing it.
+ *  `ignoreCommandPatterns` retires typed non-agent rows whose command never terminates. */
+export function readClaudeBackgroundAgentTasks(
+  hookPayload: Record<string, unknown>,
+  ignoreCommandPatterns: readonly string[] = []
+): {
   present: boolean
   tasks: ClaudeBackgroundAgentTask[]
   truncated: boolean
@@ -68,8 +73,12 @@ export function readClaudeBackgroundAgentTasks(hookPayload: Record<string, unkno
       continue
     }
     const isAgentTask = taskType === 'subagent' || taskType === 'teammate'
-    // Why: future non-agent types and nonterminal labels must fail active; only typed agent rows or explicit terminal states can safely retire work.
-    if (!isAgentTask && !isTerminal) {
+    // Why: future non-agent types and nonterminal labels must fail active; only typed agent rows, explicit terminal states, or a user-listed never-terminating command can safely retire work.
+    if (
+      !isAgentTask &&
+      !isTerminal &&
+      !claudeBackgroundShellCommandMatches(obj.command, ignoreCommandPatterns)
+    ) {
       hasRunningNonAgentTask = true
     }
     if (!isAgentTask) {

--- a/src/shared/claude-background-task-status.test.ts
+++ b/src/shared/claude-background-task-status.test.ts
@@ -7,6 +7,7 @@ import {
   movePaneCacheState,
   normalizeHookPayload,
   seedClaudeSubagentRosterFromSnapshots,
+  setClaudeBackgroundShellIgnorePatterns,
   type HookListenerState
 } from './agent-hook-listener'
 import { AGENT_STATUS_MAX_SUBAGENTS } from './agent-status-types'
@@ -571,5 +572,120 @@ describe('Claude background task status', () => {
 
     markClaudeLeadTurnInterrupted(state, SOURCE_PANE)
     expect(state.claudeRunningNonAgentTaskPaneKeys.has(SOURCE_PANE)).toBe(false)
+  })
+})
+
+describe('background shell ignore patterns', () => {
+  const DEV_SERVER = {
+    id: 'dev-1',
+    type: 'shell',
+    status: 'running',
+    description: 'Start the dev server',
+    command: 'npm run dev'
+  }
+  const TEST_SCRIPT = {
+    id: 'test-1',
+    type: 'shell',
+    status: 'running',
+    description: 'Probe the API',
+    command: './scripts/api-smoke.sh --json'
+  }
+  const ignoring = (patterns: readonly string[]): HookListenerState => {
+    const state = createHookListenerState()
+    setClaudeBackgroundShellIgnorePatterns(state, patterns)
+    return state
+  }
+  const stopWith = (state: HookListenerState, tasks: unknown[]) => {
+    claudeEvent(state, SOURCE_PANE, { hook_event_name: 'UserPromptSubmit', prompt: 'go' })
+    return claudeEvent(state, SOURCE_PANE, {
+      hook_event_name: 'Stop',
+      background_tasks: tasks
+    })?.state
+  }
+
+  it('retires a turn whose only work left is a never-ending command', () => {
+    const state = ignoring(['dev'])
+
+    expect(stopWith(state, [DEV_SERVER])).toBe('done')
+    expect(state.claudeRunningNonAgentTaskPaneKeys.has(SOURCE_PANE)).toBe(false)
+  })
+
+  it('keeps holding the turn for a command that is not listed', () => {
+    const state = ignoring(['dev'])
+
+    expect(stopWith(state, [TEST_SCRIPT])).toBe('working')
+    expect(state.claudeRunningNonAgentTaskPaneKeys.has(SOURCE_PANE)).toBe(true)
+  })
+
+  it('holds the turn when any single running task is unlisted', () => {
+    expect(stopWith(ignoring(['dev']), [DEV_SERVER, TEST_SCRIPT])).toBe('working')
+  })
+
+  it('keeps every shell sticky while the list is empty', () => {
+    const state = createHookListenerState()
+
+    expect(stopWith(state, [DEV_SERVER])).toBe('working')
+    expect(state.claudeRunningNonAgentTaskPaneKeys.has(SOURCE_PANE)).toBe(true)
+  })
+
+  it('matches whole words only, so a lookalike script still holds the turn', () => {
+    const state = ignoring(['dev'])
+
+    expect(
+      stopWith(state, [{ id: 's', type: 'shell', status: 'running', command: './dev-check.sh' }])
+    ).toBe('working')
+  })
+
+  it('still holds the turn for a working subagent', () => {
+    const state = ignoring(['dev'])
+    claudeEvent(state, SOURCE_PANE, { hook_event_name: 'SubagentStart', agent_id: 'child-1' })
+
+    expect(
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'Stop',
+        background_tasks: [DEV_SERVER, { id: 'child-1', type: 'subagent', status: 'running' }]
+      })
+    ).toMatchObject({
+      state: 'working',
+      subagents: [expect.objectContaining({ id: 'child-1', state: 'working' })]
+    })
+  })
+
+  it('still holds the turn for an active session cron, and reports it to the host', () => {
+    const state = ignoring(['dev'])
+
+    const event = normalizeHookPayload(
+      state,
+      'claude',
+      {
+        paneKey: SOURCE_PANE,
+        payload: {
+          hook_event_name: 'Stop',
+          background_tasks: [DEV_SERVER],
+          session_crons: [{ id: 'cron-1' }]
+        }
+      },
+      'production'
+    )
+
+    expect(event?.payload.state).toBe('working')
+    // Why: the relay envelope keeps carrying cron evidence, so a remote host's interrupt inference still refuses to retire it.
+    expect(event?.claudeRunningNonAgentTask).toBe(true)
+    expect(state.claudeRunningNonAgentTaskPaneKeys.has(SOURCE_PANE)).toBe(false)
+  })
+
+  it('releases a pane an unlisted shell had already pinned once the list covers it', () => {
+    const state = createHookListenerState()
+    expect(stopWith(state, [DEV_SERVER])).toBe('working')
+
+    setClaudeBackgroundShellIgnorePatterns(state, ['dev'])
+    expect(state.claudeRunningNonAgentTaskPaneKeys.has(SOURCE_PANE)).toBe(false)
+    expect(claudeEvent(state, SOURCE_PANE, { hook_event_name: 'Stop' })?.state).toBe('done')
+  })
+
+  it('leaves malformed and untyped entries failing active regardless of the list', () => {
+    for (const task of [null, { id: 'x', status: 'running', command: 'npm run dev' }]) {
+      expect(stopWith(ignoring(['dev']), [task])).toBe('working')
+    }
   })
 })

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -7,6 +7,7 @@ import type { PersistedState } from './persisted-state-types'
 import type { PersistedUIState } from './persisted-ui-state-types'
 import type { AgentActivityDisplayMode } from './ui-chrome-types'
 import type { WorkspaceSessionState } from './workspace-session-state-types'
+import { DEFAULT_CLAUDE_BACKGROUND_SHELL_IGNORE_PATTERNS } from './claude-background-shell-patterns'
 import { EMPTY_CODEX_RESET_CREDIT_ATTEMPT_LEDGER } from './codex-reset-credit-attempt-ledger'
 import { DEFAULT_STATUS_BAR_ITEMS } from './status-bar-defaults'
 import { DEFAULT_TERMINAL_FONT_WEIGHT, DEFAULT_TERMINAL_FONT_WEIGHT_BOLD } from './terminal-fonts'
@@ -364,6 +365,10 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     experimentalTerminalAttention: false,
     experimentalAgentHibernation: false,
     agentHibernationIdleMs: 30 * 60 * 1000,
+    // Why: off keeps today's behavior — a running background shell still pins the pane 'working'.
+    agentStatusIgnoresBackgroundShells: false,
+    // Why: seeded (not left undefined) so the Experimental editor can show and edit the real list.
+    agentStatusBackgroundShellIgnorePatterns: [...DEFAULT_CLAUDE_BACKGROUND_SHELL_IGNORE_PATTERNS],
     experimentalNewWorktreeCardStyle: false,
     experimentalEphemeralVms: false,
     compactWorktreeCards: false,

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -419,6 +419,10 @@ export type GlobalSettings = {
   experimentalAgentHibernation?: boolean
   /** Milliseconds a completed agent must stay idle before hibernation can be considered. */
   agentHibernationIdleMs?: number
+  /** Background shells whose command never terminates (dev servers, watchers) stop holding an agent at "working" once its turn ends. */
+  agentStatusIgnoresBackgroundShells?: boolean
+  /** Command tokens marking a never-terminating shell. Undefined uses the built-in list; an explicit list replaces it. */
+  agentStatusBackgroundShellIgnorePatterns?: string[]
   /** Experimental: opt-in preview of the updated worktree-card layout and metadata behavior. */
   experimentalNewWorktreeCardStyle?: boolean
   /** Experimental: per-workspace on-demand environment recipes and setup surface. */


### PR DESCRIPTION
## ELI5

When Claude starts a dev server and then finishes talking to you, Orca kept showing the agent as still "working" forever — because *something* was technically still running. But a dev server never stops on its own; nobody is waiting for it. This teaches Orca to tell those apart: a `npm run dev` no longer holds the spinner, while a script whose output the agent still needs does.

## What Changed

Claude's `Stop` hook payload carries `background_tasks`. Orca counts **any** running non-agent entry as work in flight and forces the pane from `done` back to `working`, so a dev server or watcher the agent started and walked away from pins the spinner indefinitely and the completion notification never fires.

This classifies the shell instead of assuming it:

- A command with **no natural exit condition** (`npm run dev`, `tsc --watch`, `uvicorn --reload`) no longer holds the turn.
- **Anything else** — a test script or build whose result the agent may still be waiting on — keeps today's sticky behavior.

Matching is an **allowlist of whole-word command tokens**, so an unrecognized command fails toward the visible spinner rather than a silently idle agent. `dev` matches `npm run dev` but not `./dev-check.sh`.

**Off by default.** `Settings → Experimental → Ignore background shells` enables it and exposes the editable pattern list (17 built-in defaults, "Restore defaults" button).

The filtering happens where the task inventory is read (`readClaudeBackgroundAgentTasks`), so the pane gate, Esc/Ctrl-C interrupt inference, and the relay envelope all follow from one decision rather than three copies of it.

**Deliberately unchanged:** a working subagent roster or an active session cron still holds the pane at `working`. Only the shell gate relaxes.

**Remote:** SSH and WSL relays normalize hooks themselves and own no settings store, so the pattern list ships to them over a new `agent_hook.setStatusPolicy` RPC, pushed at hook wire-up and on every later change. A relay predating the handler answers `-32601` and keeps the pre-setting behavior — the setting is simply a no-op for that host until it updates. (The existing `agent.hook` envelope could not carry this: its `claudeRunningNonAgentTask` field is already the shell-OR-cron result, and `payload.state` has collapsed "lead still working" into the same `working`.)

## Why

Reported in #14253: a session that ends its turn while holding a background shell stays "working" forever, with no completion notification. Starting a dev server is extremely common agent behavior, so this hits many normal sessions.

The alternative — a simple on/off switch that ignores *all* running shells — was the first cut, but it can't tell a dev server from a test script the agent backgrounded and is genuinely waiting on. Classifying by command keeps the useful signal while dropping the noisy one, and the allowlist direction means the failure mode is "a spinner I didn't want" (visible, fixable by adding a line) rather than "my agent silently went idle while I was waiting on it".

## Linked Issue

Partially fixes #14253

That issue describes both a background **shell** and a background **subagent** holding the pane. This PR addresses the shell half only — a running subagent is real agent work and still legitimately holds `working`, so the issue stays open for that half.

## Visual Proof

Sidebar status dot, dev server (`npm run dev`) still running in both cases:

| | Background shell (dev server) | Shell the agent waits on |
|---|---|---|
| **Before** | 🟡 spinner, stuck indefinitely | 🟡 spinner |
| **After** | ⚪️ done | 🟡 spinner (unchanged) |

The "after" case for the dependent shell is the important one: with a dev server **and** a 60s script the agent depends on running in the *same* session, the pane correctly stays `working` — the ignore is selective, not blanket.

**1. Before — dev server (`npm run dev`) still running, pane stuck spinning.** The bug.

![Before: dev server running, pane stuck working](https://raw.githubusercontent.com/marwie0904/orca/pr-15041-assets/.github/pr-assets/15041/1-before-dev-server-pane-stuck-working.jpeg)

**2. Before — `probe.sh` the agent is explicitly waiting on, pane spinning.** Correct, and unchanged by this PR.

![Before: dependent script running, pane working](https://raw.githubusercontent.com/marwie0904/orca/pr-15041-assets/.github/pr-assets/15041/2-before-dependent-script-pane-working.jpeg)

**3. After — same dev server still running (shell details: `npm run dev`, 38s), pane now idle.** The fix.

![After: dev server running, pane idle](https://raw.githubusercontent.com/marwie0904/orca/pr-15041-assets/.github/pr-assets/15041/3-after-dev-server-pane-goes-idle.jpeg)

**4. After — dev server *and* a dependent `probe.sh` in the same session ("2 shells still running"), pane correctly stays working.** The classification discriminating, not just suppressing.

![After: dependent script running, pane still working](https://raw.githubusercontent.com/marwie0904/orca/pr-15041-assets/.github/pr-assets/15041/4-after-dependent-script-pane-still-working.jpeg)

## Testing

Manually tested on macOS with Claude Code v2.1.233, driving both cases in a real worktree: a `npm run dev` background shell (pane goes idle at turn end) and a 60-second script the agent explicitly waits on (pane stays working). Verified the settings toggle, the editable pattern list, blur-commit, and "Restore defaults".

Automated:

- `src/shared/claude-background-shell-patterns.test.ts` (new) — classification across ecosystems, whole-token matching (`./dev-check.sh` must not match `dev`), normalization/dedupe/bounds.
- `src/shared/claude-background-task-status.test.ts` — a listed command releases the turn; an unlisted one holds it; **any** unlisted task among several holds it; a working subagent roster and an active session cron still hold it; malformed/untyped entries still fail active.
- `src/main/agent-hooks/server-interrupt-inference-guards.test.ts` — the `inferInterrupt` relaxation, including that an unrelated pattern does *not* retire the pane and a session cron still blocks it.

`pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` all pass locally. Full suite: 52,902 passing; the only failures are 4 pre-existing date-dependent cases in `src/main/rate-limits/codex-fetcher-pty-settle.test.ts`, which fail identically on a clean checkout.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

**Not covered:** Windows/WSL and SSH were reasoned about and plumbed (the `setStatusPolicy` RPC is wired for both relays) but not manually exercised — I don't have those hosts. The relay handler degrades to a no-op on older relays, so the risk is "setting doesn't apply yet", not breakage.

## AI Disclosure

Implemented with Claude Opus 5 (Claude Code), reviewed and manually tested by the author.

## Review

- **Security:** no new trust boundary. The pattern list is user settings; the relay re-normalizes it on receipt (bounded length/count) the same way `ingestRemote` re-validates payloads.
- **Cross-platform:** no platform-specific code paths; matching is plain string tokenization.
- **Remote SSH / WSL:** new RPC is additive and version-tolerant (`-32601` → previous behavior). No stream opcode, no envelope shape change, so no capability negotiation needed per `docs/reference/remote-wire-compatibility.md`.
- **Backwards compatibility:** default off; with the setting off, behavior is byte-identical to today. Existing tests asserting the sticky behavior all still pass unchanged.
- **Performance:** one `Set` build per running task per hook event, bounded at 100 patterns and a 4 KB command scan.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
