### PR TITLE
feat(markdown): render PlantUML diagrams in preview and rich editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "@floating-ui/dom": "1.7.6",
     "@linear/sdk": "^82.1.0",
     "@parcel/watcher": "^2.5.6",
+    "@plantuml/core": "^1.2026.6",
     "@xterm/addon-serialize": "0.15.0-beta.287",
     "@xterm/headless": "6.1.0-beta.287",
     "agent-browser": "~0.27.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,19 +9,19 @@ overrides:
 
 patchedDependencies:
   '@xterm/addon-ligatures@0.11.0-beta.287':
-    hash: 47405b9994b5acf1b4e90b49250358c1ca03649854d59560e7732b72fe336920
+    hash: qlbwmvc2hvopky2zg66qvmmw74
     path: config/patches/@xterm__addon-ligatures@0.11.0-beta.287.patch
   '@xterm/addon-serialize@0.15.0-beta.287':
-    hash: af3b156143ed2ee9903b753145b63dd4a2ee72cadd7ef333ab0f4d5d3ebfc32c
+    hash: 7hdknijb37yojqegvyrcmeqafe
     path: config/patches/@xterm__addon-serialize@0.15.0-beta.287.patch
   '@xterm/addon-webgl@0.20.0-beta.286':
-    hash: 6da7d7770b6427246f2a0d057d97da418040e498068b41d0c2d3c6b20bf49258
+    hash: uksx4y4yyr4mhmhru77mgr4ska
     path: config/patches/@xterm__addon-webgl@0.20.0-beta.286.patch
   '@xterm/xterm@6.1.0-beta.287':
-    hash: 0793ce045b9ec6e19c5802658e0b28aec89517e6986c496515c4d8def083e067
+    hash: kxs43ix7hsoajdw6cayadougci
     path: config/patches/@xterm__xterm@6.1.0-beta.287.patch
   node-pty@1.1.0:
-    hash: 8fc49f17011b6611a5b8c00e83a6f12e14e75aada2b0ef26dc5393f8376d20e8
+    hash: vfz3qcyzkjqj2odzx2dm7rf6oa
     path: config/patches/node-pty@1.1.0.patch
 
 importers:
@@ -43,9 +43,12 @@ importers:
       '@parcel/watcher':
         specifier: ^2.5.6
         version: 2.5.6
+      '@plantuml/core':
+        specifier: ^1.2026.6
+        version: 1.2026.6
       '@xterm/addon-serialize':
         specifier: 0.15.0-beta.287
-        version: 0.15.0-beta.287(patch_hash=af3b156143ed2ee9903b753145b63dd4a2ee72cadd7ef333ab0f4d5d3ebfc32c)(@xterm/xterm@6.1.0-beta.287(patch_hash=0793ce045b9ec6e19c5802658e0b28aec89517e6986c496515c4d8def083e067))
+        version: 0.15.0-beta.287(patch_hash=7hdknijb37yojqegvyrcmeqafe)(@xterm/xterm@6.1.0-beta.287(patch_hash=kxs43ix7hsoajdw6cayadougci))
       '@xterm/headless':
         specifier: 6.1.0-beta.287
         version: 6.1.0-beta.287
@@ -63,7 +66,7 @@ importers:
         version: 3.3.1
       node-pty:
         specifier: ^1.1.0
-        version: 1.1.0(patch_hash=8fc49f17011b6611a5b8c00e83a6f12e14e75aada2b0ef26dc5393f8376d20e8)
+        version: 1.1.0(patch_hash=vfz3qcyzkjqj2odzx2dm7rf6oa)
       posthog-node:
         specifier: ^5.33.3
         version: 5.33.3
@@ -97,6 +100,25 @@ importers:
       zod:
         specifier: ~4.4.3
         version: 4.4.3
+    optionalDependencies:
+      sherpa-onnx-darwin-arm64:
+        specifier: 1.12.37
+        version: 1.12.37
+      sherpa-onnx-darwin-x64:
+        specifier: 1.12.37
+        version: 1.12.37
+      sherpa-onnx-linux-arm64:
+        specifier: 1.12.37
+        version: 1.12.37
+      sherpa-onnx-linux-x64:
+        specifier: 1.12.37
+        version: 1.12.37
+      sherpa-onnx-win-x64:
+        specifier: 1.12.37
+        version: 1.12.37
+      windows-native-registry:
+        specifier: 3.2.2
+        version: 3.2.2
     devDependencies:
       '@dnd-kit/core':
         specifier: ^6.3.1
@@ -208,25 +230,25 @@ importers:
         version: 5.2.0(rolldown-vite@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.8.4))
       '@xterm/addon-fit':
         specifier: 0.12.0-beta.287
-        version: 0.12.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=0793ce045b9ec6e19c5802658e0b28aec89517e6986c496515c4d8def083e067))
+        version: 0.12.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=kxs43ix7hsoajdw6cayadougci))
       '@xterm/addon-ligatures':
         specifier: 0.11.0-beta.287
-        version: 0.11.0-beta.287(patch_hash=47405b9994b5acf1b4e90b49250358c1ca03649854d59560e7732b72fe336920)(@xterm/xterm@6.1.0-beta.287(patch_hash=0793ce045b9ec6e19c5802658e0b28aec89517e6986c496515c4d8def083e067))
+        version: 0.11.0-beta.287(patch_hash=qlbwmvc2hvopky2zg66qvmmw74)(@xterm/xterm@6.1.0-beta.287(patch_hash=kxs43ix7hsoajdw6cayadougci))
       '@xterm/addon-search':
         specifier: 0.17.0-beta.287
-        version: 0.17.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=0793ce045b9ec6e19c5802658e0b28aec89517e6986c496515c4d8def083e067))
+        version: 0.17.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=kxs43ix7hsoajdw6cayadougci))
       '@xterm/addon-unicode11':
         specifier: 0.10.0-beta.287
-        version: 0.10.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=0793ce045b9ec6e19c5802658e0b28aec89517e6986c496515c4d8def083e067))
+        version: 0.10.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=kxs43ix7hsoajdw6cayadougci))
       '@xterm/addon-web-links':
         specifier: 0.13.0-beta.287
-        version: 0.13.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=0793ce045b9ec6e19c5802658e0b28aec89517e6986c496515c4d8def083e067))
+        version: 0.13.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=kxs43ix7hsoajdw6cayadougci))
       '@xterm/addon-webgl':
         specifier: 0.20.0-beta.286
-        version: 0.20.0-beta.286(patch_hash=6da7d7770b6427246f2a0d057d97da418040e498068b41d0c2d3c6b20bf49258)(@xterm/xterm@6.1.0-beta.287(patch_hash=0793ce045b9ec6e19c5802658e0b28aec89517e6986c496515c4d8def083e067))
+        version: 0.20.0-beta.286(patch_hash=uksx4y4yyr4mhmhru77mgr4ska)(@xterm/xterm@6.1.0-beta.287(patch_hash=kxs43ix7hsoajdw6cayadougci))
       '@xterm/xterm':
         specifier: 6.1.0-beta.287
-        version: 6.1.0-beta.287(patch_hash=0793ce045b9ec6e19c5802658e0b28aec89517e6986c496515c4d8def083e067)
+        version: 6.1.0-beta.287(patch_hash=kxs43ix7hsoajdw6cayadougci)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -398,25 +420,6 @@ importers:
       zustand:
         specifier: ^5.0.14
         version: 5.0.14(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
-    optionalDependencies:
-      sherpa-onnx-darwin-arm64:
-        specifier: 1.12.37
-        version: 1.12.37
-      sherpa-onnx-darwin-x64:
-        specifier: 1.12.37
-        version: 1.12.37
-      sherpa-onnx-linux-arm64:
-        specifier: 1.12.37
-        version: 1.12.37
-      sherpa-onnx-linux-x64:
-        specifier: 1.12.37
-        version: 1.12.37
-      sherpa-onnx-win-x64:
-        specifier: 1.12.37
-        version: 1.12.37
-      windows-native-registry:
-        specifier: 3.2.2
-        version: 3.2.2
 
 packages:
 
@@ -1711,6 +1714,9 @@ packages:
   '@peculiar/webcrypto@1.7.1':
     resolution: {integrity: sha512-ODOov0sGMJMf3jPonOkgGqPknTsu+DdQ7kD++gz8aI+aFMOMHFbWAA2taqXXVTdP+OTOQR/znGvSpmkeI0WTYQ==}
     engines: {node: '>=14.18.0'}
+
+  '@plantuml/core@1.2026.6':
+    resolution: {integrity: sha512-e+s8jtAKT6kb7yvOCXv0exXOp7FvyKYDcpv+aQrThwXUQgdTGP+fb9hPZQr7jbeEMuUHbxjH1HYLwNZZxw3hJg==}
 
   '@playwright/test@1.59.1':
     resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
@@ -3378,6 +3384,7 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xterm/addon-fit@0.12.0-beta.287':
     resolution: {integrity: sha512-2MDj+J4x67bjOS/SuBPxSYEWH38NbX6ENV18RbKVOhfRYCX3yERnuHBOrgH9hYdY8rCtsLQmuVgF6cmvCJiV2w==}
@@ -7948,6 +7955,8 @@ snapshots:
       tslib: 2.8.1
       webcrypto-core: 1.9.2
 
+  '@plantuml/core@1.2026.6': {}
+
   '@playwright/test@1.59.1':
     dependencies:
       playwright: 1.59.1
@@ -9591,39 +9600,39 @@ snapshots:
 
   '@xmldom/xmldom@0.8.13': {}
 
-  '@xterm/addon-fit@0.12.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=0793ce045b9ec6e19c5802658e0b28aec89517e6986c496515c4d8def083e067))':
+  '@xterm/addon-fit@0.12.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=kxs43ix7hsoajdw6cayadougci))':
     dependencies:
-      '@xterm/xterm': 6.1.0-beta.287(patch_hash=0793ce045b9ec6e19c5802658e0b28aec89517e6986c496515c4d8def083e067)
+      '@xterm/xterm': 6.1.0-beta.287(patch_hash=kxs43ix7hsoajdw6cayadougci)
 
-  '@xterm/addon-ligatures@0.11.0-beta.287(patch_hash=47405b9994b5acf1b4e90b49250358c1ca03649854d59560e7732b72fe336920)(@xterm/xterm@6.1.0-beta.287(patch_hash=0793ce045b9ec6e19c5802658e0b28aec89517e6986c496515c4d8def083e067))':
+  '@xterm/addon-ligatures@0.11.0-beta.287(patch_hash=qlbwmvc2hvopky2zg66qvmmw74)(@xterm/xterm@6.1.0-beta.287(patch_hash=kxs43ix7hsoajdw6cayadougci))':
     dependencies:
-      '@xterm/xterm': 6.1.0-beta.287(patch_hash=0793ce045b9ec6e19c5802658e0b28aec89517e6986c496515c4d8def083e067)
+      '@xterm/xterm': 6.1.0-beta.287(patch_hash=kxs43ix7hsoajdw6cayadougci)
       lru-cache: 11.5.1
       opentype.js: 2.0.0
 
-  '@xterm/addon-search@0.17.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=0793ce045b9ec6e19c5802658e0b28aec89517e6986c496515c4d8def083e067))':
+  '@xterm/addon-search@0.17.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=kxs43ix7hsoajdw6cayadougci))':
     dependencies:
-      '@xterm/xterm': 6.1.0-beta.287(patch_hash=0793ce045b9ec6e19c5802658e0b28aec89517e6986c496515c4d8def083e067)
+      '@xterm/xterm': 6.1.0-beta.287(patch_hash=kxs43ix7hsoajdw6cayadougci)
 
-  '@xterm/addon-serialize@0.15.0-beta.287(patch_hash=af3b156143ed2ee9903b753145b63dd4a2ee72cadd7ef333ab0f4d5d3ebfc32c)(@xterm/xterm@6.1.0-beta.287(patch_hash=0793ce045b9ec6e19c5802658e0b28aec89517e6986c496515c4d8def083e067))':
+  '@xterm/addon-serialize@0.15.0-beta.287(patch_hash=7hdknijb37yojqegvyrcmeqafe)(@xterm/xterm@6.1.0-beta.287(patch_hash=kxs43ix7hsoajdw6cayadougci))':
     dependencies:
-      '@xterm/xterm': 6.1.0-beta.287(patch_hash=0793ce045b9ec6e19c5802658e0b28aec89517e6986c496515c4d8def083e067)
+      '@xterm/xterm': 6.1.0-beta.287(patch_hash=kxs43ix7hsoajdw6cayadougci)
 
-  '@xterm/addon-unicode11@0.10.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=0793ce045b9ec6e19c5802658e0b28aec89517e6986c496515c4d8def083e067))':
+  '@xterm/addon-unicode11@0.10.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=kxs43ix7hsoajdw6cayadougci))':
     dependencies:
-      '@xterm/xterm': 6.1.0-beta.287(patch_hash=0793ce045b9ec6e19c5802658e0b28aec89517e6986c496515c4d8def083e067)
+      '@xterm/xterm': 6.1.0-beta.287(patch_hash=kxs43ix7hsoajdw6cayadougci)
 
-  '@xterm/addon-web-links@0.13.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=0793ce045b9ec6e19c5802658e0b28aec89517e6986c496515c4d8def083e067))':
+  '@xterm/addon-web-links@0.13.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=kxs43ix7hsoajdw6cayadougci))':
     dependencies:
-      '@xterm/xterm': 6.1.0-beta.287(patch_hash=0793ce045b9ec6e19c5802658e0b28aec89517e6986c496515c4d8def083e067)
+      '@xterm/xterm': 6.1.0-beta.287(patch_hash=kxs43ix7hsoajdw6cayadougci)
 
-  '@xterm/addon-webgl@0.20.0-beta.286(patch_hash=6da7d7770b6427246f2a0d057d97da418040e498068b41d0c2d3c6b20bf49258)(@xterm/xterm@6.1.0-beta.287(patch_hash=0793ce045b9ec6e19c5802658e0b28aec89517e6986c496515c4d8def083e067))':
+  '@xterm/addon-webgl@0.20.0-beta.286(patch_hash=uksx4y4yyr4mhmhru77mgr4ska)(@xterm/xterm@6.1.0-beta.287(patch_hash=kxs43ix7hsoajdw6cayadougci))':
     dependencies:
-      '@xterm/xterm': 6.1.0-beta.287(patch_hash=0793ce045b9ec6e19c5802658e0b28aec89517e6986c496515c4d8def083e067)
+      '@xterm/xterm': 6.1.0-beta.287(patch_hash=kxs43ix7hsoajdw6cayadougci)
 
   '@xterm/headless@6.1.0-beta.287': {}
 
-  '@xterm/xterm@6.1.0-beta.287(patch_hash=0793ce045b9ec6e19c5802658e0b28aec89517e6986c496515c4d8def083e067)': {}
+  '@xterm/xterm@6.1.0-beta.287(patch_hash=kxs43ix7hsoajdw6cayadougci)': {}
 
   abbrev@4.0.0: {}
 
@@ -12022,7 +12031,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-pty@1.1.0(patch_hash=8fc49f17011b6611a5b8c00e83a6f12e14e75aada2b0ef26dc5393f8376d20e8):
+  node-pty@1.1.0(patch_hash=vfz3qcyzkjqj2odzx2dm7rf6oa):
     dependencies:
       node-addon-api: 7.1.1
 

--- a/src/renderer/src/assets/markdown-preview.css
+++ b/src/renderer/src/assets/markdown-preview.css
@@ -710,6 +710,16 @@
   font-size: 0.85em;
   margin-bottom: 0.5em;
 }
+/* PlantUML diagram container */
+.plantuml-block svg {
+  max-width: 100%;
+  height: auto;
+}
+.plantuml-error {
+  color: var(--color-warning, #d29922);
+  font-size: 0.85em;
+  margin-bottom: 0.5em;
+}
 /* Full-file mermaid diagram viewer — used when opening .mmd/.mermaid files
    in diagram mode. Centers the rendered SVG and adds padding so diagrams
    don't press against viewport edges. */

--- a/src/renderer/src/assets/rich-markdown-editor.css
+++ b/src/renderer/src/assets/rich-markdown-editor.css
@@ -999,6 +999,12 @@
   border-top: 1px solid color-mix(in srgb, var(--foreground) 8%, transparent);
 }
 
+/* Live PlantUML diagram preview rendered below the editable source */
+.plantuml-preview {
+  padding: 12px 18px;
+  border-top: 1px solid color-mix(in srgb, var(--foreground) 8%, transparent);
+}
+
 .rich-markdown-editor pre {
   padding: 14px 18px;
   border-radius: 8px;

--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -1681,8 +1681,9 @@ export default function MarkdownPreview({
             <MermaidBlock content={String(children).trimEnd()} isDark={isDark} htmlLabels={false} />
           )
         }
-        // Why: accept `puml`/`uml` alongside `plantuml` — all three are in common use in the wild.
-        if (/language-(plantuml|puml|uml)\b/.test(className || '')) {
+        // Why: accept `puml`/`uml` alongside `plantuml` (all three are in common use), but
+        // anchor on the whole class token so `language-plantuml-extra` is left alone.
+        if (/(?:^|\s)language-(?:plantuml|puml|uml)(?=\s|$)/.test(className || '')) {
           return <PlantUmlBlock content={String(children).trimEnd()} isDark={isDark} />
         }
         return (
@@ -1691,7 +1692,7 @@ export default function MarkdownPreview({
           </code>
         )
       },
-      // Why: wrap <pre> for the copy button, but pass MermaidBlock through unwrapped (it renders via innerHTML so extractText copies nothing, and <div> in <pre> is invalid HTML).
+      // Why: wrap <pre> for the copy button, but pass the diagram blocks through unwrapped (they render SVG into a <div>, so extractText copies nothing and <div> in <pre> is invalid HTML).
       pre: ({ node, children, ...props }) => {
         const child = React.Children.toArray(children)[0]
         if (

--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -63,6 +63,7 @@ import { absolutePathToFileUri, resolveMarkdownLinkTarget } from './markdown-int
 import { useLocalImageSrc } from './useLocalImageSrc'
 import CodeBlockCopyButton from './CodeBlockCopyButton'
 import MermaidBlock from './MermaidBlock'
+import PlantUmlBlock from './PlantUmlBlock'
 import {
   applyMarkdownPreviewSearchHighlights,
   clearMarkdownPreviewSearchHighlights,
@@ -1680,6 +1681,10 @@ export default function MarkdownPreview({
             <MermaidBlock content={String(children).trimEnd()} isDark={isDark} htmlLabels={false} />
           )
         }
+        // Why: accept `puml`/`uml` alongside `plantuml` — all three are in common use in the wild.
+        if (/language-(plantuml|puml|uml)\b/.test(className || '')) {
+          return <PlantUmlBlock content={String(children).trimEnd()} isDark={isDark} />
+        }
         return (
           <code className={className} {...props}>
             {children}
@@ -1689,7 +1694,10 @@ export default function MarkdownPreview({
       // Why: wrap <pre> for the copy button, but pass MermaidBlock through unwrapped (it renders via innerHTML so extractText copies nothing, and <div> in <pre> is invalid HTML).
       pre: ({ node, children, ...props }) => {
         const child = React.Children.toArray(children)[0]
-        if (React.isValidElement(child) && child.type === MermaidBlock) {
+        if (
+          React.isValidElement(child) &&
+          (child.type === MermaidBlock || child.type === PlantUmlBlock)
+        ) {
           return <>{children}</>
         }
         return wrapAnnotatedBlock(

--- a/src/renderer/src/components/editor/PlantUmlBlock.recovery.test.tsx
+++ b/src/renderer/src/components/editor/PlantUmlBlock.recovery.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment happy-dom
+import { render } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+// Why: the real engine is a multi-megabyte TeaVM bundle needing wasm; stub it and
+// drive the two shapes that matter — a diagram, and the error card it draws for
+// bad input (which arrives through onSuccess, not onError).
+const NAG =
+  '<text>PlantUML version $version$ / $git.commit.id$ [Unknown compile time]</text>' +
+  '<text>This version of PlantUML is 210 days old, so you should</text>'
+const ERROR_CARD =
+  `<svg>${NAG}<text>[From textarea (line 2) ]</text>` +
+  '<text> Syntax Error? (Assumed diagram type: sequence)</text></svg>'
+const GOOD_SVG = '<svg><text>Alice</text></svg>'
+
+vi.mock('@plantuml/core/viz-global.js', () => ({
+  default: { instance: () => Promise.resolve({}) }
+}))
+vi.mock('@plantuml/core', () => ({
+  render: vi.fn(),
+  renderToString: (lines: string[], onSuccess: (svg: string) => void) => {
+    onSuccess(lines.join('\n').includes('BROKEN') ? ERROR_CARD : GOOD_SVG)
+  }
+}))
+
+const { default: PlantUmlBlock } = await import('./PlantUmlBlock')
+
+const BROKEN_SOURCE = '@startuml\nBROKEN\n@enduml'
+const VALID_SOURCE = '@startuml\nAlice -> Bob\n@enduml'
+
+// Why scope every query to the render container instead of `document`: this suite
+// runs without Vitest globals, so Testing Library never registers its afterEach
+// cleanup and each test's DOM outlives it.
+function settled(container: HTMLElement): Promise<void> {
+  return new Promise((resolve) => {
+    const check = (): void => {
+      if (container.querySelector('.plantuml-error, .plantuml-block *')) {
+        resolve()
+        return
+      }
+      setTimeout(check, 10)
+    }
+    check()
+  })
+}
+
+describe('PlantUmlBlock', () => {
+  it('shows our own banner instead of the upstream error picture', async () => {
+    const { container } = render(<PlantUmlBlock content={BROKEN_SOURCE} isDark={false} />)
+    await settled(container)
+
+    const banner = container.querySelector('.plantuml-error')?.textContent ?? ''
+    expect(banner).toContain('Syntax Error?')
+    expect(banner).toContain('line 2')
+    expect(banner).not.toMatch(/days old|\$version\$|textarea/i)
+    // The raw source stays visible so the user can fix it.
+    expect(container.querySelector('.plantuml-block pre code')?.textContent).toContain('BROKEN')
+  })
+
+  it('recovers once the source is fixed', async () => {
+    const { container, rerender } = render(<PlantUmlBlock content={BROKEN_SOURCE} isDark={false} />)
+    await settled(container)
+    expect(container.querySelector('.plantuml-error')).toBeTruthy()
+
+    rerender(<PlantUmlBlock content={VALID_SOURCE} isDark={false} />)
+    // Why assert on diagram *text* rather than the <svg> element: happy-dom's
+    // DOMPurify strips the outer <svg> wrapper (a real browser keeps it), so the
+    // element is absent here for reasons unrelated to this component.
+    await new Promise((r) => setTimeout(r, 100))
+
+    expect(container.querySelector('.plantuml-block')?.textContent).toContain('Alice')
+    expect(container.querySelector('.plantuml-error')).toBeNull()
+    // The raw-source fallback is gone too — we are showing a diagram, not a listing.
+    expect(container.querySelector('.plantuml-block pre code')).toBeNull()
+  })
+})

--- a/src/renderer/src/components/editor/PlantUmlBlock.tsx
+++ b/src/renderer/src/components/editor/PlantUmlBlock.tsx
@@ -1,0 +1,130 @@
+import React, { useEffect, useState } from 'react'
+import type * as plantUmlNamespace from '@plantuml/core'
+import DOMPurify from 'dompurify'
+import { detectPlantUmlErrorDiagram } from './plantuml-error-diagram'
+import { translate } from '@/i18n/i18n'
+
+type PlantUmlApi = typeof plantUmlNamespace
+
+// Why: the engine is ~8MB raw (TeaVM-compiled Java + inlined Graphviz wasm), far
+// heavier than mermaid, so a static import would wreck cold start. Load on first
+// diagram and cache the promise so later blocks reuse one instance.
+let enginePromise: Promise<PlantUmlApi> | null = null
+
+function loadPlantUml(): Promise<PlantUmlApi> {
+  if (!enginePromise) {
+    enginePromise = (async () => {
+      // Why: plantuml.js calls a bare `Viz.instance()`, resolved off the global
+      // scope. The UMD bundle self-registers on globalThis only when the bundler
+      // leaves no CJS `exports` in scope — under Vite's esbuild interop it can
+      // take the exports branch instead, so assign explicitly from the namespace.
+      const vizModule = await import('@plantuml/core/viz-global.js')
+      const globalScope = globalThis as typeof globalThis & { Viz?: unknown }
+      if (!globalScope.Viz) {
+        const candidate = (vizModule as { default?: unknown }).default ?? vizModule
+        globalScope.Viz =
+          typeof (candidate as { instance?: unknown })?.instance === 'function'
+            ? candidate
+            : vizModule
+      }
+      return import('@plantuml/core')
+    })()
+  }
+  return enginePromise
+}
+
+type PlantUmlBlockProps = {
+  content: string
+  isDark: boolean
+}
+
+// Why: the engine keeps parse/layout state in module-level globals (TeaVM statics
+// plus the shared Viz instance), so concurrent renders interleave and can emit one
+// diagram's SVG for another's source. Serialize every render through one chain,
+// collapsing it afterwards so old closures stay collectable.
+let renderQueue: Promise<void> = Promise.resolve()
+
+function enqueueRender(fn: () => Promise<void>): void {
+  renderQueue = renderQueue.then(fn, fn).then(() => {
+    renderQueue = Promise.resolve()
+  })
+}
+
+function renderDiagram(api: PlantUmlApi, content: string, isDark: boolean): Promise<string> {
+  return new Promise((resolve, reject) => {
+    api.renderToString(
+      content.split(/\r\n|\r|\n/),
+      resolve,
+      (message) => reject(new Error(message || 'Invalid PlantUML syntax')),
+      { dark: isDark }
+    )
+  })
+}
+
+/**
+ * Renders a PlantUML diagram string as SVG. Falls back to raw source with an
+ * error banner if the syntax is invalid — never breaks the rest of the preview.
+ */
+export default function PlantUmlBlock({ content, isDark }: PlantUmlBlockProps): React.JSX.Element {
+  // Why: hold the markup in state rather than writing through a ref. The error
+  // branch renders a different subtree, so a ref would be null exactly when we
+  // need to clear a stale error — leaving a fixed diagram stuck on the old banner
+  // while the user edits.
+  const [result, setResult] = useState<{ svg: string } | { error: string }>({ svg: '' })
+
+  useEffect(() => {
+    let cancelled = false
+
+    const render = async (): Promise<void> => {
+      try {
+        const api = await loadPlantUml()
+        if (cancelled) {
+          return
+        }
+        const svg = await renderDiagram(api, content, isDark)
+        if (cancelled) {
+          return
+        }
+        // Why: bad input still resolves — with a picture of the error carrying an
+        // upstream upgrade nag. Surface our own banner instead of drawing theirs.
+        const errorDiagram = detectPlantUmlErrorDiagram(svg)
+        if (errorDiagram) {
+          const where =
+            errorDiagram.line === undefined
+              ? ''
+              : `${translate('auto.components.editor.PlantUmlBlock.line', 'line')} ${errorDiagram.line}: `
+          setResult({ error: `${where}${errorDiagram.message}` })
+          return
+        }
+        // Why: the engine builds SVG from diagram text that can carry arbitrary
+        // labels and embedded links, so sanitize regardless of what it escapes.
+        setResult({ svg: DOMPurify.sanitize(svg, { USE_PROFILES: { svg: true } }) })
+      } catch (err) {
+        if (!cancelled) {
+          setResult({ error: err instanceof Error ? err.message : 'Invalid PlantUML syntax' })
+        }
+      }
+    }
+
+    enqueueRender(render)
+    return () => {
+      cancelled = true
+    }
+  }, [content, isDark])
+
+  if ('error' in result) {
+    return (
+      <div className="plantuml-block">
+        <div className="plantuml-error">
+          {translate('auto.components.editor.PlantUmlBlock.diagramError', 'Diagram error:')}{' '}
+          {result.error}
+        </div>
+        <pre>
+          <code>{content}</code>
+        </pre>
+      </div>
+    )
+  }
+
+  return <div className="plantuml-block" dangerouslySetInnerHTML={{ __html: result.svg }} />
+}

--- a/src/renderer/src/components/editor/PlantUmlBlock.tsx
+++ b/src/renderer/src/components/editor/PlantUmlBlock.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import type * as plantUmlNamespace from '@plantuml/core'
 import DOMPurify from 'dompurify'
 import { detectPlantUmlErrorDiagram } from './plantuml-error-diagram'
+import { enqueuePlantUmlRender } from './plantuml-render-queue'
 import { translate } from '@/i18n/i18n'
 
 type PlantUmlApi = typeof plantUmlNamespace
@@ -28,7 +29,13 @@ function loadPlantUml(): Promise<PlantUmlApi> {
             : vizModule
       }
       return import('@plantuml/core')
-    })()
+    })().catch((err) => {
+      // Why: without this the cache holds a rejected promise, so one failed chunk
+      // fetch (offline, or a web build served over a flaky network) disables every
+      // diagram until the app restarts. Drop it so the next block retries.
+      enginePromise = null
+      throw err
+    })
   }
   return enginePromise
 }
@@ -36,18 +43,6 @@ function loadPlantUml(): Promise<PlantUmlApi> {
 type PlantUmlBlockProps = {
   content: string
   isDark: boolean
-}
-
-// Why: the engine keeps parse/layout state in module-level globals (TeaVM statics
-// plus the shared Viz instance), so concurrent renders interleave and can emit one
-// diagram's SVG for another's source. Serialize every render through one chain,
-// collapsing it afterwards so old closures stay collectable.
-let renderQueue: Promise<void> = Promise.resolve()
-
-function enqueueRender(fn: () => Promise<void>): void {
-  renderQueue = renderQueue.then(fn, fn).then(() => {
-    renderQueue = Promise.resolve()
-  })
 }
 
 function renderDiagram(api: PlantUmlApi, content: string, isDark: boolean): Promise<string> {
@@ -106,7 +101,7 @@ export default function PlantUmlBlock({ content, isDark }: PlantUmlBlockProps): 
       }
     }
 
-    enqueueRender(render)
+    enqueuePlantUmlRender(render)
     return () => {
       cancelled = true
     }

--- a/src/renderer/src/components/editor/PlantUmlBlock.tsx
+++ b/src/renderer/src/components/editor/PlantUmlBlock.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import type * as plantUmlNamespace from '@plantuml/core'
 import DOMPurify from 'dompurify'
-import { detectPlantUmlErrorDiagram } from './plantuml-error-diagram'
+import { detectPlantUmlErrorDiagram, type PlantUmlErrorDiagram } from './plantuml-error-diagram'
 import { enqueuePlantUmlRender } from './plantuml-render-queue'
 import { translate } from '@/i18n/i18n'
 
@@ -45,6 +45,31 @@ type PlantUmlBlockProps = {
   isDark: boolean
 }
 
+/**
+ * Turns a detected error card into banner text. Our own wording is localized; the
+ * engine's diagnosis is shown verbatim because it only ever emits English.
+ */
+function describePlantUmlError(error: PlantUmlErrorDiagram): string {
+  if (error.kind === 'unsupported') {
+    return translate(
+      'auto.components.editor.PlantUmlBlock.unsupportedDiagram',
+      'Diagram not supported by this release of PlantUML'
+    )
+  }
+  const body =
+    error.kind === 'diagnosis' && error.detail !== undefined
+      ? error.detail
+      : translate(
+          'auto.components.editor.PlantUmlBlock.renderFailed',
+          'PlantUML could not render this diagram'
+        )
+  if (error.line === undefined) {
+    return body
+  }
+  const where = `${translate('auto.components.editor.PlantUmlBlock.line', 'line')} ${error.line}`
+  return `${where}: ${body}`
+}
+
 function renderDiagram(api: PlantUmlApi, content: string, isDark: boolean): Promise<string> {
   return new Promise((resolve, reject) => {
     api.renderToString(
@@ -84,11 +109,7 @@ export default function PlantUmlBlock({ content, isDark }: PlantUmlBlockProps): 
         // upstream upgrade nag. Surface our own banner instead of drawing theirs.
         const errorDiagram = detectPlantUmlErrorDiagram(svg)
         if (errorDiagram) {
-          const where =
-            errorDiagram.line === undefined
-              ? ''
-              : `${translate('auto.components.editor.PlantUmlBlock.line', 'line')} ${errorDiagram.line}: `
-          setResult({ error: `${where}${errorDiagram.message}` })
+          setResult({ error: describePlantUmlError(errorDiagram) })
           return
         }
         // Why: the engine builds SVG from diagram text that can carry arbitrary

--- a/src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx
@@ -5,6 +5,7 @@ import type { NodeViewProps } from '@tiptap/react'
 import { Copy, Check } from 'lucide-react'
 import { useAppStore } from '@/store'
 import MermaidBlock from './MermaidBlock'
+import PlantUmlBlock from './PlantUmlBlock'
 import { translate } from '@/i18n/i18n'
 
 /**
@@ -99,6 +100,12 @@ const LANGUAGES = [
     }
   },
   {
+    value: 'plantuml',
+    get label() {
+      return translate('auto.components.editor.RichMarkdownCodeBlock.plantuml', 'PlantUML')
+    }
+  },
+  {
     value: 'python',
     get label() {
       return translate('auto.components.editor.RichMarkdownCodeBlock.2391f9cda9', 'Python')
@@ -177,6 +184,8 @@ export function RichMarkdownCodeBlock({
     (settings?.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
 
   const isMermaid = language === 'mermaid'
+  // Why: `puml`/`uml` are common fence aliases in the wild, so accept all three.
+  const isPlantUml = language === 'plantuml' || language === 'puml' || language === 'uml'
 
   const clearCopiedResetTimer = useCallback((): void => {
     if (copiedResetTimerRef.current !== null) {
@@ -276,6 +285,11 @@ export function RichMarkdownCodeBlock({
       {isMermaid && node.textContent.trim() && (
         <div contentEditable={false} className="mermaid-preview">
           <MermaidBlock content={node.textContent.trim()} isDark={isDark} htmlLabels={false} />
+        </div>
+      )}
+      {isPlantUml && node.textContent.trim() && (
+        <div contentEditable={false} className="plantuml-preview">
+          <PlantUmlBlock content={node.textContent.trim()} isDark={isDark} />
         </div>
       )}
     </NodeViewWrapper>

--- a/src/renderer/src/components/editor/plantuml-error-diagram.test.ts
+++ b/src/renderer/src/components/editor/plantuml-error-diagram.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import { detectPlantUmlErrorDiagram } from './plantuml-error-diagram'
+
+// Why: the engine reports bad input by *succeeding* with an error picture rather
+// than rejecting, so these fixtures reproduce the exact marker text observed from
+// @plantuml/core 1.2026.6 output. Trimmed to the structure the detector keys on.
+const NAG =
+  '<text fill="#33FF02" font-style="italic">PlantUML version $version$ / $git.commit.id$ [Unknown compile time]</text>' +
+  '<text fill="#33FF02">This version of PlantUML is 210 days old, so you should</text>' +
+  '<text fill="#33FF02">consider upgrading from https://plantuml.com/download</text>'
+
+const syntaxErrorSvg =
+  `<svg viewBox="0 0 419 190">${NAG}` +
+  '<text>[From textarea (line 2) ]</text>' +
+  '<text>@startuml</text>' +
+  '<text>this is not valid ==== nonsense &gt;&gt;&gt;&lt;&lt;&lt;</text>' +
+  '<text> Syntax Error? (Assumed diagram type: sequence)</text></svg>'
+
+const emptyDiagramSvg =
+  `<svg viewBox="0 0 419 190">${NAG}` +
+  '<text>[From textarea (line 2) ]</text>' +
+  '<text>@startuml</text><text>@enduml</text>' +
+  '<text> Empty description (Assumed diagram type: sequence)</text></svg>'
+
+const badKeywordSvg =
+  `<svg viewBox="0 0 419 250">${NAG}` +
+  '<text>[From textarea (line 5) ]</text>' +
+  '<text>class A {</text>' +
+  '<text> Syntax Error? (Assumed diagram type: class)</text></svg>'
+
+const unsupportedSvg =
+  '<svg viewBox="0 0 401 227">' +
+  '<text fill="#000000">Diagram not supported by this release of PlantUML</text>' +
+  '<text>Sorry, but the following directive </text>' +
+  '<text>just some text</text>' +
+  '<text> is not recognized.</text>' +
+  '<text>Possible causes:</text>' +
+  '<text>- Typo in the directive or incorrect syntax.</text></svg>'
+
+const validSvg =
+  '<svg viewBox="0 0 129 188"><g><rect/><text>Alice</text><text>Bob</text><text>Hello</text></g></svg>'
+
+describe('detectPlantUmlErrorDiagram', () => {
+  it('returns null for a real diagram', () => {
+    expect(detectPlantUmlErrorDiagram(validSvg)).toBeNull()
+  })
+
+  it('reports the syntax error with its source line', () => {
+    expect(detectPlantUmlErrorDiagram(syntaxErrorSvg)).toEqual({
+      message: 'Syntax Error? (Assumed diagram type: sequence)',
+      line: 2
+    })
+  })
+
+  it('reports an empty diagram', () => {
+    expect(detectPlantUmlErrorDiagram(emptyDiagramSvg)).toEqual({
+      message: 'Empty description (Assumed diagram type: sequence)',
+      line: 2
+    })
+  })
+
+  it('carries the line number through for non-sequence diagrams', () => {
+    expect(detectPlantUmlErrorDiagram(badKeywordSvg)).toEqual({
+      message: 'Syntax Error? (Assumed diagram type: class)',
+      line: 5
+    })
+  })
+
+  it('reports unsupported diagrams, which carry no version banner', () => {
+    expect(detectPlantUmlErrorDiagram(unsupportedSvg)).toEqual({
+      message: 'Diagram not supported by this release of PlantUML'
+    })
+  })
+
+  it('never leaks the upstream upgrade nag, version placeholder, or "textarea"', () => {
+    for (const svg of [syntaxErrorSvg, emptyDiagramSvg, badKeywordSvg, unsupportedSvg]) {
+      const detected = detectPlantUmlErrorDiagram(svg)
+      expect(detected).not.toBeNull()
+      expect(detected?.message).not.toMatch(
+        /days old|plantuml\.com\/download|\$version\$|textarea/i
+      )
+    }
+  })
+
+  it('does not misfire on a diagram whose own labels mention a syntax error', () => {
+    const svg = '<svg><text>Syntax Error? (Assumed diagram type: sequence)</text></svg>'
+    expect(detectPlantUmlErrorDiagram(svg)).toBeNull()
+  })
+})

--- a/src/renderer/src/components/editor/plantuml-error-diagram.test.ts
+++ b/src/renderer/src/components/editor/plantuml-error-diagram.test.ts
@@ -2,88 +2,116 @@ import { describe, expect, it } from 'vitest'
 import { detectPlantUmlErrorDiagram } from './plantuml-error-diagram'
 
 // Why: the engine reports bad input by *succeeding* with an error picture rather
-// than rejecting, so these fixtures reproduce the exact marker text observed from
-// @plantuml/core 1.2026.6 output. Trimmed to the structure the detector keys on.
+// than rejecting, so these fixtures reproduce the marker text and node ordering
+// observed from @plantuml/core 1.2026.6 output. Both cards open with their banner
+// as the first text node; real diagrams open with diagram content.
 const NAG =
   '<text fill="#33FF02" font-style="italic">PlantUML version $version$ / $git.commit.id$ [Unknown compile time]</text>' +
   '<text fill="#33FF02">This version of PlantUML is 210 days old, so you should</text>' +
   '<text fill="#33FF02">consider upgrading from https://plantuml.com/download</text>'
 
 const syntaxErrorSvg =
-  `<svg viewBox="0 0 419 190">${NAG}` +
+  `<svg viewBox="0 0 419 190"><defs/><g>${NAG}` +
   '<text>[From textarea (line 2) ]</text>' +
   '<text>@startuml</text>' +
   '<text>this is not valid ==== nonsense &gt;&gt;&gt;&lt;&lt;&lt;</text>' +
-  '<text> Syntax Error? (Assumed diagram type: sequence)</text></svg>'
+  '<text> Syntax Error? (Assumed diagram type: sequence)</text></g></svg>'
 
 const emptyDiagramSvg =
-  `<svg viewBox="0 0 419 190">${NAG}` +
+  `<svg viewBox="0 0 419 190"><defs/><g>${NAG}` +
   '<text>[From textarea (line 2) ]</text>' +
   '<text>@startuml</text><text>@enduml</text>' +
-  '<text> Empty description (Assumed diagram type: sequence)</text></svg>'
+  '<text> Empty description (Assumed diagram type: sequence)</text></g></svg>'
 
 const badKeywordSvg =
-  `<svg viewBox="0 0 419 250">${NAG}` +
+  `<svg viewBox="0 0 419 250"><defs/><g>${NAG}` +
   '<text>[From textarea (line 5) ]</text>' +
   '<text>class A {</text>' +
-  '<text> Syntax Error? (Assumed diagram type: class)</text></svg>'
+  '<text> Syntax Error? (Assumed diagram type: class)</text></g></svg>'
 
 const unsupportedSvg =
-  '<svg viewBox="0 0 401 227">' +
+  '<svg viewBox="0 0 401 227"><defs/><g>' +
   '<text fill="#000000">Diagram not supported by this release of PlantUML</text>' +
   '<text>Sorry, but the following directive </text>' +
   '<text>just some text</text>' +
   '<text> is not recognized.</text>' +
-  '<text>Possible causes:</text>' +
-  '<text>- Typo in the directive or incorrect syntax.</text></svg>'
+  '<text>Possible causes:</text></g></svg>'
 
 const validSvg =
-  '<svg viewBox="0 0 129 188"><g><rect/><text>Alice</text><text>Bob</text><text>Hello</text></g></svg>'
+  '<svg viewBox="0 0 129 188"><defs/><g><rect/><text>Alice</text><text>Bob</text><text>Hello</text></g></svg>'
 
 describe('detectPlantUmlErrorDiagram', () => {
   it('returns null for a real diagram', () => {
     expect(detectPlantUmlErrorDiagram(validSvg)).toBeNull()
   })
 
-  it('reports the syntax error with its source line', () => {
+  it('returns null for empty output', () => {
+    expect(detectPlantUmlErrorDiagram('<svg><defs/></svg>')).toBeNull()
+  })
+
+  it('reports the engine diagnosis verbatim, with its source line', () => {
     expect(detectPlantUmlErrorDiagram(syntaxErrorSvg)).toEqual({
-      message: 'Syntax Error? (Assumed diagram type: sequence)',
+      kind: 'diagnosis',
+      detail: 'Syntax Error? (Assumed diagram type: sequence)',
       line: 2
     })
   })
 
   it('reports an empty diagram', () => {
     expect(detectPlantUmlErrorDiagram(emptyDiagramSvg)).toEqual({
-      message: 'Empty description (Assumed diagram type: sequence)',
+      kind: 'diagnosis',
+      detail: 'Empty description (Assumed diagram type: sequence)',
       line: 2
     })
   })
 
   it('carries the line number through for non-sequence diagrams', () => {
     expect(detectPlantUmlErrorDiagram(badKeywordSvg)).toEqual({
-      message: 'Syntax Error? (Assumed diagram type: class)',
+      kind: 'diagnosis',
+      detail: 'Syntax Error? (Assumed diagram type: class)',
       line: 5
     })
   })
 
   it('reports unsupported diagrams, which carry no version banner', () => {
-    expect(detectPlantUmlErrorDiagram(unsupportedSvg)).toEqual({
-      message: 'Diagram not supported by this release of PlantUML'
-    })
+    expect(detectPlantUmlErrorDiagram(unsupportedSvg)).toEqual({ kind: 'unsupported' })
   })
 
-  it('never leaks the upstream upgrade nag, version placeholder, or "textarea"', () => {
+  it('falls back to an unknown kind when the card carries no diagnosis', () => {
+    const svg = `<svg><defs/><g>${NAG}<text>[From textarea (line 3) ]</text></g></svg>`
+    expect(detectPlantUmlErrorDiagram(svg)).toEqual({ kind: 'unknown', line: 3 })
+  })
+
+  it('never returns the upstream upgrade nag or version placeholder as detail', () => {
     for (const svg of [syntaxErrorSvg, emptyDiagramSvg, badKeywordSvg, unsupportedSvg]) {
       const detected = detectPlantUmlErrorDiagram(svg)
       expect(detected).not.toBeNull()
-      expect(detected?.message).not.toMatch(
+      expect(detected?.detail ?? '').not.toMatch(
         /days old|plantuml\.com\/download|\$version\$|textarea/i
       )
     }
   })
 
-  it('does not misfire on a diagram whose own labels mention a syntax error', () => {
-    const svg = '<svg><text>Syntax Error? (Assumed diagram type: sequence)</text></svg>'
-    expect(detectPlantUmlErrorDiagram(svg)).toBeNull()
+  describe('does not misfire on diagrams that quote the card text in a label', () => {
+    it('when a label mentions a syntax error', () => {
+      const svg =
+        '<svg><defs/><g><text>Alice</text>' +
+        '<text>Syntax Error? (Assumed diagram type: sequence)</text></g></svg>'
+      expect(detectPlantUmlErrorDiagram(svg)).toBeNull()
+    })
+
+    it('when a label starts with the version banner', () => {
+      const svg =
+        '<svg><defs/><g><text>Alice</text>' +
+        '<text>PlantUML version $version$ is fine</text></g></svg>'
+      expect(detectPlantUmlErrorDiagram(svg)).toBeNull()
+    })
+
+    it('when a label starts with the unsupported banner', () => {
+      const svg =
+        '<svg><defs/><g><text>Alice</text>' +
+        '<text>Diagram not supported by this release of PlantUML</text></g></svg>'
+      expect(detectPlantUmlErrorDiagram(svg)).toBeNull()
+    })
   })
 })

--- a/src/renderer/src/components/editor/plantuml-error-diagram.ts
+++ b/src/renderer/src/components/editor/plantuml-error-diagram.ts
@@ -1,14 +1,26 @@
+export type PlantUmlErrorKind =
+  /** The engine has no renderer for this input at all. */
+  | 'unsupported'
+  /** The engine named a specific problem, carried in `detail`. */
+  | 'diagnosis'
+  /** An error card we recognize but could not read a diagnosis out of. */
+  | 'unknown'
+
 export type PlantUmlErrorDiagram = {
-  message: string
+  kind: PlantUmlErrorKind
+  /**
+   * Verbatim engine text, English only — the engine does not localize its
+   * diagnoses. Callers show it as-is rather than translating it.
+   */
+  detail?: string
   line?: number
 }
 
 // Why: @plantuml/core signals bad input by *succeeding* with a picture of the
 // error instead of calling onError, so the only way to tell a failure from a real
-// diagram is to recognize the two error cards it draws. Both carry a fixed banner
-// no legitimate diagram would render.
-const VERSION_BANNER = 'PlantUML version $version$'
+// diagram is to recognize the two error cards it draws.
 const UNSUPPORTED_BANNER = 'Diagram not supported by this release of PlantUML'
+const VERSION_BANNER = 'PlantUML version $version$'
 
 // The engine labels the offending line "[From textarea (line N) ]" — an artifact of
 // its own demo page that means nothing here, so we keep only the number.
@@ -20,32 +32,40 @@ function textNodes(svg: string): string[] {
 }
 
 /**
- * Recognizes the error cards @plantuml/core draws in place of a diagram and
- * extracts a message fit to show the user. Returns null for real diagrams.
+ * Recognizes the error cards @plantuml/core draws in place of a diagram. Returns
+ * null for real diagrams.
  *
  * Deliberately drops the upstream "your version is N days old, upgrade from
- * plantuml.com" nag and the unreplaced `$version$` placeholder — neither belongs
- * in a markdown preview.
+ * plantuml.com" nag and the unreplaced `$version$` placeholder; neither belongs in
+ * a markdown preview.
  */
 export function detectPlantUmlErrorDiagram(svg: string): PlantUmlErrorDiagram | null {
   const nodes = textNodes(svg)
-
-  if (nodes.some((n) => n.startsWith(UNSUPPORTED_BANNER))) {
-    return { message: UNSUPPORTED_BANNER }
-  }
-
-  // Why: gate on the banner rather than the diagnosis text alone, so a diagram
-  // that merely *labels a box* "Syntax Error?" still renders normally.
-  if (!nodes.some((n) => n.startsWith(VERSION_BANNER))) {
+  // Why match only the first text node: both cards open with their banner, while a
+  // real diagram opens with its own content. Searching every node would misread a
+  // diagram that quotes either banner in a label. Requiring extra card markers
+  // instead would risk the opposite and worse failure — an unrecognized card
+  // wording leaking the upstream nag into the preview.
+  const banner = nodes[0]
+  if (banner === undefined) {
     return null
   }
 
-  const diagnosis = nodes.find((n) => DIAGNOSIS.test(n))
+  if (banner.startsWith(UNSUPPORTED_BANNER)) {
+    return { kind: 'unsupported' }
+  }
+  if (!banner.startsWith(VERSION_BANNER)) {
+    return null
+  }
+
+  const detail = nodes.find((n) => DIAGNOSIS.test(n))
   const lineMatch = svg.match(SOURCE_LINE)
   const line = lineMatch ? Number(lineMatch[1]) : undefined
 
   return {
-    message: diagnosis ?? 'PlantUML could not render this diagram',
+    ...(detail === undefined
+      ? { kind: 'unknown' as const }
+      : { kind: 'diagnosis' as const, detail }),
     ...(line === undefined ? {} : { line })
   }
 }

--- a/src/renderer/src/components/editor/plantuml-error-diagram.ts
+++ b/src/renderer/src/components/editor/plantuml-error-diagram.ts
@@ -1,0 +1,51 @@
+export type PlantUmlErrorDiagram = {
+  message: string
+  line?: number
+}
+
+// Why: @plantuml/core signals bad input by *succeeding* with a picture of the
+// error instead of calling onError, so the only way to tell a failure from a real
+// diagram is to recognize the two error cards it draws. Both carry a fixed banner
+// no legitimate diagram would render.
+const VERSION_BANNER = 'PlantUML version $version$'
+const UNSUPPORTED_BANNER = 'Diagram not supported by this release of PlantUML'
+
+// The engine labels the offending line "[From textarea (line N) ]" — an artifact of
+// its own demo page that means nothing here, so we keep only the number.
+const SOURCE_LINE = /\[From textarea \(line (\d+)\)/
+const DIAGNOSIS = /\(Assumed diagram type:[^)]*\)/
+
+function textNodes(svg: string): string[] {
+  return [...svg.matchAll(/>([^<>]+)</g)].map((m) => m[1].trim()).filter(Boolean)
+}
+
+/**
+ * Recognizes the error cards @plantuml/core draws in place of a diagram and
+ * extracts a message fit to show the user. Returns null for real diagrams.
+ *
+ * Deliberately drops the upstream "your version is N days old, upgrade from
+ * plantuml.com" nag and the unreplaced `$version$` placeholder — neither belongs
+ * in a markdown preview.
+ */
+export function detectPlantUmlErrorDiagram(svg: string): PlantUmlErrorDiagram | null {
+  const nodes = textNodes(svg)
+
+  if (nodes.some((n) => n.startsWith(UNSUPPORTED_BANNER))) {
+    return { message: UNSUPPORTED_BANNER }
+  }
+
+  // Why: gate on the banner rather than the diagnosis text alone, so a diagram
+  // that merely *labels a box* "Syntax Error?" still renders normally.
+  if (!nodes.some((n) => n.startsWith(VERSION_BANNER))) {
+    return null
+  }
+
+  const diagnosis = nodes.find((n) => DIAGNOSIS.test(n))
+  const lineMatch = svg.match(SOURCE_LINE)
+  const line = lineMatch ? Number(lineMatch[1]) : undefined
+
+  return {
+    message: diagnosis ?? 'PlantUML could not render this diagram',
+    ...(line === undefined ? {} : { line })
+  }
+}

--- a/src/renderer/src/components/editor/plantuml-render-queue.test.ts
+++ b/src/renderer/src/components/editor/plantuml-render-queue.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import { enqueuePlantUmlRender } from './plantuml-render-queue'
+
+type Deferred = { promise: Promise<void>; resolve: () => void }
+
+function deferred(): Deferred {
+  let resolve!: () => void
+  const promise = new Promise<void>((r) => {
+    resolve = r
+  })
+  return { promise, resolve }
+}
+
+/** Records which renders are running at the same moment. */
+function tracker(): { active: number; maxActive: number; order: string[] } {
+  return { active: 0, maxActive: 0, order: [] }
+}
+
+describe('enqueuePlantUmlRender', () => {
+  it('runs renders one at a time, in order', async () => {
+    const t = tracker()
+    const gates = [deferred(), deferred(), deferred()]
+
+    const task = (name: string, gate: Deferred) => async (): Promise<void> => {
+      t.active += 1
+      t.maxActive = Math.max(t.maxActive, t.active)
+      t.order.push(name)
+      await gate.promise
+      t.active -= 1
+    }
+
+    enqueuePlantUmlRender(task('a', gates[0]))
+    enqueuePlantUmlRender(task('b', gates[1]))
+    enqueuePlantUmlRender(task('c', gates[2]))
+
+    for (const g of gates) {
+      g.resolve()
+      await new Promise((r) => setTimeout(r, 0))
+    }
+
+    expect(t.order).toEqual(['a', 'b', 'c'])
+    expect(t.maxActive).toBe(1)
+  })
+
+  it('does not start a later render early when an earlier one settles first', async () => {
+    // Why this exact interleaving: it is the shape that broke the previous
+    // implementation. `a` settles while `b` is still queued, then `c` arrives. If
+    // the queue reset is unconditional, `c` chains off the stale resolved promise
+    // and runs alongside `b`.
+    const t = tracker()
+    const bGate = deferred()
+
+    const instant = (name: string) => async (): Promise<void> => {
+      t.active += 1
+      t.maxActive = Math.max(t.maxActive, t.active)
+      t.order.push(name)
+      t.active -= 1
+    }
+    const slow = (name: string, gate: Deferred) => async (): Promise<void> => {
+      t.active += 1
+      t.maxActive = Math.max(t.maxActive, t.active)
+      t.order.push(name)
+      await gate.promise
+      t.active -= 1
+    }
+
+    enqueuePlantUmlRender(instant('a'))
+    enqueuePlantUmlRender(slow('b', bGate))
+    // Let `a` finish and its cleanup run while `b` is mid-flight.
+    await new Promise((r) => setTimeout(r, 0))
+    enqueuePlantUmlRender(instant('c'))
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(t.order).toEqual(['a', 'b'])
+    expect(t.maxActive).toBe(1)
+
+    bGate.resolve()
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(t.order).toEqual(['a', 'b', 'c'])
+    expect(t.maxActive).toBe(1)
+  })
+
+  it('keeps draining after a render rejects', async () => {
+    const ran: string[] = []
+
+    enqueuePlantUmlRender(async () => {
+      ran.push('boom')
+      throw new Error('render failed')
+    })
+    enqueuePlantUmlRender(async () => {
+      ran.push('after')
+    })
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(ran).toEqual(['boom', 'after'])
+  })
+})

--- a/src/renderer/src/components/editor/plantuml-render-queue.ts
+++ b/src/renderer/src/components/editor/plantuml-render-queue.ts
@@ -15,16 +15,10 @@ export function enqueuePlantUmlRender(fn: () => Promise<void>): void {
   // renderer. Why the identity check: resetting unconditionally would overwrite a
   // newer pending chain, letting the render after it start early and run
   // concurrently with one still in flight.
-  void next.then(
-    () => {
-      if (renderQueue === next) {
-        renderQueue = Promise.resolve()
-      }
-    },
-    () => {
-      if (renderQueue === next) {
-        renderQueue = Promise.resolve()
-      }
+  const collapseIfIdle = (): void => {
+    if (renderQueue === next) {
+      renderQueue = Promise.resolve()
     }
-  )
+  }
+  void next.then(collapseIfIdle, collapseIfIdle)
 }

--- a/src/renderer/src/components/editor/plantuml-render-queue.ts
+++ b/src/renderer/src/components/editor/plantuml-render-queue.ts
@@ -1,0 +1,30 @@
+// Why: the engine keeps parse/layout state in module-level globals (TeaVM statics
+// plus the shared Viz instance), so concurrent renders interleave and can emit one
+// diagram's SVG for another's source. Every render goes through one chain.
+let renderQueue: Promise<void> = Promise.resolve()
+
+/**
+ * Runs `fn` after every previously enqueued render has settled, so no two
+ * renders touch the engine's global state at once.
+ */
+export function enqueuePlantUmlRender(fn: () => Promise<void>): void {
+  const next = renderQueue.then(fn, fn)
+  renderQueue = next
+  // Why collapse the chain: the tail would otherwise keep every earlier .then()
+  // closure reachable, and those capture diagram source for the lifetime of the
+  // renderer. Why the identity check: resetting unconditionally would overwrite a
+  // newer pending chain, letting the render after it start early and run
+  // concurrently with one still in flight.
+  void next.then(
+    () => {
+      if (renderQueue === next) {
+        renderQueue = Promise.resolve()
+      }
+    },
+    () => {
+      if (renderQueue === next) {
+        renderQueue = Promise.resolve()
+      }
+    }
+  )
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14550,7 +14550,9 @@
         },
         "PlantUmlBlock": {
           "line": "line",
-          "diagramError": "Diagram error:"
+          "diagramError": "Diagram error:",
+          "unsupportedDiagram": "Diagram not supported by this release of PlantUML",
+          "renderFailed": "PlantUML could not render this diagram"
         }
       },
       "diff": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14232,7 +14232,8 @@
           "026653f21f": "CSS",
           "4daed43ae3": "C++",
           "4227cf50fe": "Bash",
-          "13822cdfda": "Plain text"
+          "13822cdfda": "Plain text",
+          "plantuml": "PlantUML"
         },
         "RichMarkdownDocLinkMenu": {
           "e17b987473": "↑↓ navigate&nbsp;&nbsp;↵ select&nbsp;&nbsp;esc dismiss",
@@ -14546,6 +14547,10 @@
           "insertColumnRight": "Insert column right",
           "deleteRow": "Delete row",
           "deleteColumn": "Delete column"
+        },
+        "PlantUmlBlock": {
+          "line": "line",
+          "diagramError": "Diagram error:"
         }
       },
       "diff": {


### PR DESCRIPTION
## ELI5

Markdown files can already draw Mermaid diagrams. This makes ` ```plantuml ` blocks draw too, in both the read-only preview and the rich editor. No Java, no external server: the whole engine runs in the renderer.

## What Changed

`plantuml`, `puml`, and `uml` fences render as SVG in `MarkdownPreview` and in `RichMarkdownCodeBlock`'s live preview, mirroring how Mermaid is already wired. PlantUML joins the rich editor's code-block language dropdown.

New files:

- `PlantUmlBlock.tsx` — lazy-loads the engine, renders, sanitizes, falls back to a banner plus raw source
- `plantuml-error-diagram.ts` — recognizes the error cards the engine draws instead of throwing
- `plantuml-render-queue.ts` — serializes renders against the engine's module-global state

## Why

PlantUML normally needs a JVM plus a native `dot` binary, and the common workaround is posting diagram text to a render server. Neither fits Orca: a Java requirement breaks on hosts that lack one, and a remote server ships user diagram content off the machine. `@plantuml/core` is the official TeaVM build with Viz.js bundled for Graphviz layout, so SSH hosts, folder workspaces, and offline use behave the same as a local worktree, and nothing leaves the machine.

`^1.2026.6` is a deliberate floor. That release is the first under MIT; 1.2026.5 and earlier are GPL-3.0-or-later. The lockfile must not drop below it.

Two engine behaviours Mermaid does not have:

**Bad input succeeds instead of failing.** The engine returns a picture of the error through `onSuccess`, never calling `onError`. That picture carries an unreplaced `$version$` placeholder, an upstream "this version is N days old, consider upgrading from plantuml.com/download" message, and a `[From textarea (line N)]` label naming a DOM element that does not exist here. `detectPlantUmlErrorDiagram` recognizes the two error cards and shows Orca's own banner with the raw source, keeping the line number and dropping the rest. Detection keys on the fixed version banner rather than the error wording, so a diagram that merely labels a box `Syntax Error?` still renders.

**Rendered markup lives in state, not behind a ref.** The error branch renders a different subtree, so a ref would be null exactly when a stale error needs clearing. Writing through one leaves a corrected diagram stuck on the old banner while the user edits, easy to hit in the rich editor since it previews on every keystroke.

### Bundle cost

The engine is large, so it loads on first diagram and the promise is cached. Measured from this repo's own `build:electron-vite` output:

| chunk | gzip | raw |
| --- | --- | --- |
| `plantuml` | 1.51 MB | 10.45 MB |
| `viz-global` | 0.58 MB | 1.40 MB |

Both emit as separate lazy chunks and neither is referenced from `index.html`, so the entry bundle and cold start are unchanged. First diagram renders in about 590ms including wasm init. The optional `emoji.js` and `openiconic.js` sprite bundles are not imported. This follows the same lazy-load discipline #6804 applied to Mermaid.

## Linked Issue

None exists. I searched issues and PRs for `plantuml` and `puml` before starting and got zero hits, so this is not continuing prior work. Happy to file one to satisfy the template if that is preferred.

## Visual Proof

Not yet attached. I verified rendering by driving Electron through Playwright rather than by eye, so what I have is assertions rather than a before/after pair; screenshots are coming as an attachment since they cannot be added from the CLI.

What the automated run asserts, across sequence, class (the Graphviz path), and activity diagrams in both light and dark with CJK labels: valid sources produce SVGs with distinct viewBoxes, invalid sources produce fallback banners, no page errors, and a full-page text scan confirms the upstream nag, `$version$`, and `textarea` never reach the DOM.

Before this change, a ` ```plantuml ` fence renders as an ordinary code block.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Automated: `plantuml-error-diagram.test.ts` covers detection across syntax errors, empty diagrams, unsupported diagrams, and the false-positive case. `plantuml-render-queue.test.ts` covers ordering, non-overlap, and draining after a rejection; its non-overlap case fails against the pre-fix queue. `PlantUmlBlock.recovery.test.tsx` covers the banner and the broken-to-fixed transition.

Local: `pnpm run lint`, `pnpm run typecheck`, and `vitest src/renderer/src/components/editor` (172 files, 1155 tests) all pass. For build I ran `pnpm run build:electron-vite` rather than the full `pnpm build`, which is where the chunk numbers above come from.

Platforms: macOS only. I have not run this on Linux, Windows, or against an SSH host. Nothing here is platform-conditional (no paths, shortcuts, or shell invocation), and rendering happens entirely in the renderer, so I would expect parity, but I have not verified it.

## AI Disclosure

Written with Claude (Claude Code, Opus 4.5). Every claim in this description that carries a number comes from a command I ran; the bundle table was corrected after an earlier revision quoted figures from a standalone harness build rather than this repo's build.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Security: rendered SVG goes through DOMPurify with the SVG profile before insertion. Nothing is fetched at render time; the Graphviz wasm is inlined in the package, so no new network surface and no new CSP allowance beyond the `wasm-unsafe-eval` the renderer already relies on.

Cross-platform: no platform-conditional code paths. Verified on macOS only, as noted above.

Remote SSH and folder workspaces: rendering is local to the renderer, so behaviour does not depend on where the workspace lives. This is the main reason for rejecting a remote render server.

Mobile: untouched. This wires desktop renderer components only.

Backwards compatibility: additive. Previously a `plantuml` fence rendered as a code block; nothing that rendered before renders differently. No wire or persisted format changes.

Performance: the engine is lazy and cached, chunks stay out of the entry bundle, and renders are serialized so concurrent diagrams cannot interleave in the engine's global state.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Scoping the last two honestly: lint and typecheck ran in full, tests ran for the editor directory rather than the whole suite, and build was `build:electron-vite` rather than full `pnpm build`.