### PR TITLE
fix(browser): keep default cookie clearing available

### DIFF
--- a/src/renderer/src/components/browser-cookie-import-google-disclosure.test.tsx
+++ b/src/renderer/src/components/browser-cookie-import-google-disclosure.test.tsx
@@ -131,9 +131,9 @@ describe('cookie-import Google disclosure footer', () => {
       )
     )
 
-    const buttons = container.querySelectorAll('button')
-    expect(buttons).toHaveLength(2)
-    expect(buttons[1]?.disabled).toBe(false)
+    const clearButton = container.querySelector('[data-testid="clear-default-cookies-button"]')
+    expect(clearButton).not.toBeNull()
+    expect((clearButton as HTMLButtonElement | null)?.disabled).toBe(false)
   })
 
   it('reads the footer copy from the catalog', () => {

--- a/src/renderer/src/components/browser-cookie-import-google-disclosure.test.tsx
+++ b/src/renderer/src/components/browser-cookie-import-google-disclosure.test.tsx
@@ -109,6 +109,33 @@ describe('cookie-import Google disclosure footer', () => {
     expect(label?.previousElementSibling?.tagName).toBe('HR')
   })
 
+  it('keeps clearing default cookies available after import metadata is removed', () => {
+    act(() =>
+      root.render(
+        <BrowserProfileRow
+          profile={
+            {
+              id: 'default',
+              label: 'Default',
+              partition: 'persist:default',
+              scope: 'default',
+              source: null
+            } as never
+          }
+          detectedBrowsers={DETECTED_BROWSERS}
+          importState={null}
+          isActive
+          isDefault
+          onSelect={vi.fn()}
+        />
+      )
+    )
+
+    const buttons = container.querySelectorAll('button')
+    expect(buttons).toHaveLength(2)
+    expect(buttons[1]?.disabled).toBe(false)
+  })
+
   it('reads the footer copy from the catalog', () => {
     expect(catalogEntry('auto.components.BrowserCookieImportDisclosure.title')).toBe(
       DISCLOSURE_TITLE

--- a/src/renderer/src/components/browser-cookie-import-google-disclosure.test.tsx
+++ b/src/renderer/src/components/browser-cookie-import-google-disclosure.test.tsx
@@ -134,6 +134,7 @@ describe('cookie-import Google disclosure footer', () => {
     const clearButton = container.querySelector('[data-testid="clear-default-cookies-button"]')
     expect(clearButton).not.toBeNull()
     expect((clearButton as HTMLButtonElement | null)?.disabled).toBe(false)
+    expect(clearButton?.getAttribute('aria-label')).toBe('Clear default cookies')
   })
 
   it('reads the footer copy from the catalog', () => {

--- a/src/renderer/src/components/settings/BrowserProfileRow.tsx
+++ b/src/renderer/src/components/settings/BrowserProfileRow.tsx
@@ -227,7 +227,6 @@ export function BrowserProfileRow({
             variant="ghost"
             size="icon"
             className="size-7 text-muted-foreground hover:text-destructive"
-            disabled={!profile.source}
             onClick={async () => {
               const ok = await useAppStore.getState().clearDefaultSessionCookies()
               if (ok) {

--- a/src/renderer/src/components/settings/BrowserProfileRow.tsx
+++ b/src/renderer/src/components/settings/BrowserProfileRow.tsx
@@ -227,6 +227,7 @@ export function BrowserProfileRow({
             variant="ghost"
             size="icon"
             className="size-7 text-muted-foreground hover:text-destructive"
+            data-testid="clear-default-cookies-button"
             onClick={async () => {
               const ok = await useAppStore.getState().clearDefaultSessionCookies()
               if (ok) {

--- a/src/renderer/src/components/settings/BrowserProfileRow.tsx
+++ b/src/renderer/src/components/settings/BrowserProfileRow.tsx
@@ -228,7 +228,7 @@ export function BrowserProfileRow({
             size="icon"
             className="size-7 text-muted-foreground hover:text-destructive"
             aria-label={translate(
-              'auto.components.settings.BrowserProfileRow.clearDefaultCookies',
+              'auto.components.settings.BrowserProfileRow.4054c458e1',
               'Clear default cookies'
             )}
             data-testid="clear-default-cookies-button"

--- a/src/renderer/src/components/settings/BrowserProfileRow.tsx
+++ b/src/renderer/src/components/settings/BrowserProfileRow.tsx
@@ -227,6 +227,10 @@ export function BrowserProfileRow({
             variant="ghost"
             size="icon"
             className="size-7 text-muted-foreground hover:text-destructive"
+            aria-label={translate(
+              'auto.components.settings.BrowserProfileRow.clearDefaultCookies',
+              'Clear default cookies'
+            )}
             data-testid="clear-default-cookies-button"
             onClick={async () => {
               const ok = await useAppStore.getState().clearDefaultSessionCookies()

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6388,7 +6388,8 @@
           "a3f8c2d1e0b4": "Imported {{value0}} cookies from {{value1}} ({{value2}}) into {{value3}}.",
           "b4e9d3f2a1c5": "Imported {{value0}} cookies from {{value1}} into {{value2}}.",
           "c5a273a809": "From {{value0}}",
-          "b5c0479e21": "Unmodified user agent"
+          "b5c0479e21": "Unmodified user agent",
+          "4054c458e1": "Clear default cookies"
         },
         "BrowserUseComputerUseNotice": {
           "15b5e680ba": "Open Computer Use",

--- a/tests/e2e/browser-default-cookie-clearing.spec.ts
+++ b/tests/e2e/browser-default-cookie-clearing.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from './helpers/orca-app'
+import { waitForSessionReady } from './helpers/store'
+
+test.describe('default browser cookie clearing', () => {
+  test.beforeEach(async ({ orcaPage }) => {
+    await waitForSessionReady(orcaPage)
+  })
+
+  test('remains available after clearing the default profile cookies', async ({ orcaPage }) => {
+    await orcaPage.evaluate(() => {
+      const state = window.__store!.getState()
+      state.openSettingsTarget({ pane: 'browser', repoId: null })
+      state.openSettingsPage()
+    })
+
+    const cookiesSection = orcaPage.locator('#browser-session-cookies')
+    await expect(cookiesSection).toBeVisible({ timeout: 10_000 })
+
+    const clearButton = cookiesSection.locator('button').last()
+    await expect(clearButton).toBeEnabled()
+    await clearButton.click()
+    await expect(clearButton).toBeEnabled()
+  })
+})

--- a/tests/e2e/browser-default-cookie-clearing.spec.ts
+++ b/tests/e2e/browser-default-cookie-clearing.spec.ts
@@ -26,14 +26,12 @@ test.describe('default browser cookie clearing', () => {
     await expect(clearButton).toBeEnabled()
 
     // Why: the regression left the button disabled after a successful clear
-    // (#14678) — a single click can't catch that, so clear again. Compare
-    // against the pre-click count rather than a fixed value, since the first
-    // toast may have already auto-dismissed by the time this one appears.
-    const successCountBeforeSecondClick = await successToasts.count()
+    // (#14678) — a single click can't catch that, so clear again. Wait for
+    // the first toast to fully dismiss first, so a stale count can't make
+    // the second wait pass (or race-timeout) on the wrong toast.
+    await expect(successToasts).toHaveCount(0, { timeout: 10_000 })
     await clearButton.click()
-    await expect
-      .poll(() => successToasts.count(), { timeout: 10_000 })
-      .toBeGreaterThan(successCountBeforeSecondClick)
+    await expect(successToasts).toHaveCount(1, { timeout: 10_000 })
     await expect(clearButton).toBeEnabled()
   })
 })

--- a/tests/e2e/browser-default-cookie-clearing.spec.ts
+++ b/tests/e2e/browser-default-cookie-clearing.spec.ts
@@ -19,6 +19,10 @@ test.describe('default browser cookie clearing', () => {
     const clearButton = cookiesSection.locator('button').last()
     await expect(clearButton).toBeEnabled()
     await clearButton.click()
+    // Why: the success toast text is localized (BrowserProfileRow only calls
+    // toast.success on this path, never toast.error), so waiting for any toast
+    // proves the async clear settled without asserting a locale-specific string.
+    await expect(orcaPage.locator('[data-sonner-toast]')).toBeVisible({ timeout: 10_000 })
     await expect(clearButton).toBeEnabled()
   })
 })

--- a/tests/e2e/browser-default-cookie-clearing.spec.ts
+++ b/tests/e2e/browser-default-cookie-clearing.spec.ts
@@ -19,9 +19,7 @@ test.describe('default browser cookie clearing', () => {
     const clearButton = cookiesSection.locator('button').last()
     await expect(clearButton).toBeEnabled()
     await clearButton.click()
-    // Why: the success toast text is localized (BrowserProfileRow only calls
-    // toast.success on this path, never toast.error), so waiting for any toast
-    // proves the async clear settled without asserting a locale-specific string.
+    // Why: wait for the localized completion toast, not a hardcoded locale-specific string.
     await expect(orcaPage.locator('[data-sonner-toast]')).toBeVisible({ timeout: 10_000 })
     await expect(clearButton).toBeEnabled()
   })

--- a/tests/e2e/browser-default-cookie-clearing.spec.ts
+++ b/tests/e2e/browser-default-cookie-clearing.spec.ts
@@ -16,22 +16,24 @@ test.describe('default browser cookie clearing', () => {
     const cookiesSection = orcaPage.locator('#browser-session-cookies')
     await expect(cookiesSection).toBeVisible({ timeout: 10_000 })
 
-    const clearButton = cookiesSection.locator('button').last()
-    // Why: wait for the localized completion toast, not a hardcoded locale-specific string.
-    const toasts = orcaPage.locator('[data-sonner-toast]')
+    const clearButton = cookiesSection.locator('[data-testid="clear-default-cookies-button"]')
+    // Why: data-type="success" is locale-independent and specific to the success path.
+    const successToasts = orcaPage.locator('[data-sonner-toast][data-type="success"]')
 
     await expect(clearButton).toBeEnabled()
     await clearButton.click()
-    await expect(toasts).toHaveCount(1, { timeout: 10_000 })
+    await expect(successToasts).toHaveCount(1, { timeout: 10_000 })
     await expect(clearButton).toBeEnabled()
 
     // Why: the regression left the button disabled after a successful clear
-    // (#14678) — a single click can't catch that, so clear again.
-    const toastCountBeforeSecondClick = await toasts.count()
+    // (#14678) — a single click can't catch that, so clear again. Compare
+    // against the pre-click count rather than a fixed value, since the first
+    // toast may have already auto-dismissed by the time this one appears.
+    const successCountBeforeSecondClick = await successToasts.count()
     await clearButton.click()
     await expect
-      .poll(() => toasts.count(), { timeout: 10_000 })
-      .toBeGreaterThan(toastCountBeforeSecondClick)
+      .poll(() => successToasts.count(), { timeout: 10_000 })
+      .toBeGreaterThan(successCountBeforeSecondClick)
     await expect(clearButton).toBeEnabled()
   })
 })

--- a/tests/e2e/browser-default-cookie-clearing.spec.ts
+++ b/tests/e2e/browser-default-cookie-clearing.spec.ts
@@ -17,10 +17,21 @@ test.describe('default browser cookie clearing', () => {
     await expect(cookiesSection).toBeVisible({ timeout: 10_000 })
 
     const clearButton = cookiesSection.locator('button').last()
+    // Why: wait for the localized completion toast, not a hardcoded locale-specific string.
+    const toasts = orcaPage.locator('[data-sonner-toast]')
+
     await expect(clearButton).toBeEnabled()
     await clearButton.click()
-    // Why: wait for the localized completion toast, not a hardcoded locale-specific string.
-    await expect(orcaPage.locator('[data-sonner-toast]')).toBeVisible({ timeout: 10_000 })
+    await expect(toasts).toHaveCount(1, { timeout: 10_000 })
+    await expect(clearButton).toBeEnabled()
+
+    // Why: the regression left the button disabled after a successful clear
+    // (#14678) — a single click can't catch that, so clear again.
+    const toastCountBeforeSecondClick = await toasts.count()
+    await clearButton.click()
+    await expect
+      .poll(() => toasts.count(), { timeout: 10_000 })
+      .toBeGreaterThan(toastCountBeforeSecondClick)
     await expect(clearButton).toBeEnabled()
   })
 })


### PR DESCRIPTION
## ELI5

The default browser profile can still clear imported Google cookies repeatedly instead of becoming permanently stuck after the first import.

## Visual Proof

N/A — browser state behavior is covered by automated Electron tests; no layout change.

## Summary

- keep the default-profile cookie-clear action enabled after import metadata is cleared
- add unit and Electron E2E coverage for clearing default cookies repeatedly

Closes #14678

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/browser-cookie-import-google-disclosure.test.tsx`
- `SKIP_BUILD=1 pnpm exec playwright test tests/e2e/browser-default-cookie-clearing.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test --maxWorkers=4`