### PR TITLE
fix(notifications): dismiss the banner id a Claude background turn announced (STA-4592)

### DIFF
--- a/src/renderer/src/components/terminal-pane/agent-background-turn-notification-identity.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-background-turn-notification-identity.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
+import { buildAgentNotificationId } from '../../../../shared/agent-notification-id'
+import { getDefaultSettings } from '../../../../shared/constants'
+import { useAppStore } from '@/store'
+import { makeWorktree } from '@/store/slices/store-test-helpers'
+import { resetAnnouncedAgentNotificationIdsForTest } from '@/lib/announced-agent-notification-ids'
+import {
+  createAgentCompletionCoordinator,
+  resetAgentCompletionCoordinatorIdentitiesForTest
+} from './agent-completion-coordinator'
+import { dispatchTerminalNotification } from './use-notification-dispatch'
+import type { AgentCompletionStatusSnapshot } from './agent-completion-coordinator-types'
+
+/**
+ * A Claude background turn announces its banner under the turn-complete stamp
+ * while the pane's status row stays `working` on the turn's start boundary. These
+ * cover the two things that identity split used to break: dismissal on
+ * acknowledge, and survival across a host clock that trails the desktop.
+ */
+
+const TAB_ID = 'tab-1'
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+const PANE_KEY = makePaneKey(TAB_ID, LEAF_ID)
+const WORKTREE_ID = 'repo::/worktree'
+const WORKING_STARTED_AT = 1_700_000_000_000
+const TURN_COMPLETED_AT = 1_700_000_005_000
+const SECOND_WORKING_STARTED_AT = 1_700_000_006_000
+const SECOND_TURN_COMPLETED_AT = 1_700_000_008_000
+const DESKTOP_WORKING_STARTED_AT = 1_700_000_030_000
+const REMOTE_TURN_COMPLETED_AT = 1_700_000_005_000
+
+const initialState = useAppStore.getInitialState()
+
+function seedLiveClaudeWorkingRow(stateStartedAt: number): void {
+  useAppStore.setState({
+    tabsByWorktree: {
+      [WORKTREE_ID]: [
+        {
+          id: TAB_ID,
+          ptyId: 'pty-1',
+          worktreeId: WORKTREE_ID,
+          title: 'Claude',
+          customTitle: null,
+          color: null,
+          sortOrder: 0,
+          createdAt: stateStartedAt
+        }
+      ]
+    },
+    ptyIdsByTabId: { [TAB_ID]: ['pty-1'] },
+    terminalLayoutsByTabId: {
+      [TAB_ID]: {
+        root: { type: 'leaf', leafId: LEAF_ID },
+        activeLeafId: LEAF_ID,
+        expandedLeafId: null,
+        ptyIdsByLeafId: { [LEAF_ID]: 'pty-1' }
+      }
+    },
+    agentStatusByPaneKey: {
+      [PANE_KEY]: {
+        state: 'working',
+        prompt: 'review the PR',
+        updatedAt: stateStartedAt,
+        stateStartedAt,
+        agentType: 'claude',
+        paneKey: PANE_KEY,
+        tabId: TAB_ID,
+        worktreeId: WORKTREE_ID,
+        terminalTitle: 'claude',
+        stateHistory: []
+      }
+    },
+    worktreesByRepo: {
+      repo: [makeWorktree({ id: WORKTREE_ID, repoId: 'repo', path: '/worktree' })]
+    },
+    repos: [{ id: 'repo', path: '/repo', displayName: 'orca', badgeColor: '#000', addedAt: 0 }],
+    settings: {
+      ...getDefaultSettings('/tmp'),
+      experimentalTerminalAttention: true
+    }
+  })
+}
+
+type BackgroundTurn = { stateStartedAt: number; turnCompletedAt: number }
+
+/**
+ * Drives the real coordinator through Claude background turns. Each turn is a
+ * `working` hook followed by a `working` hook carrying the turn-complete stamp —
+ * the pane never leaves `working`.
+ */
+function announceBackgroundTurns(
+  turns: readonly BackgroundTurn[]
+): AgentCompletionStatusSnapshot[] {
+  const announced: AgentCompletionStatusSnapshot[] = []
+  const coordinator = createAgentCompletionCoordinator({
+    paneKey: PANE_KEY,
+    getPtyId: () => 'pty-1',
+    getSettings: () => null,
+    inspectProcess: vi.fn(),
+    dispatchCompletion: (title, meta) => {
+      if (meta?.agentStatus) {
+        announced.push(meta.agentStatus)
+      }
+      dispatchTerminalNotification(WORKTREE_ID, {
+        source: 'agent-task-complete',
+        terminalTitle: title,
+        paneKey: PANE_KEY,
+        agentCompletionSource: meta?.source,
+        agentStatusSnapshot: meta?.agentStatus
+      })
+    },
+    isLive: () => true
+  })
+
+  for (const turn of turns) {
+    coordinator.observeHookStatus({
+      state: 'working',
+      prompt: 'review the PR',
+      agentType: 'claude',
+      stateStartedAt: turn.stateStartedAt
+    })
+    coordinator.observeHookStatus({
+      state: 'working',
+      prompt: 'review the PR',
+      agentType: 'claude',
+      lastAssistantMessage: 'Which cells need hand-verification?',
+      stateStartedAt: turn.stateStartedAt,
+      turnCompletedAt: turn.turnCompletedAt
+    })
+  }
+  coordinator.dispose()
+  return announced
+}
+
+function dispatchMock(): ReturnType<typeof vi.fn> {
+  return window.api.notifications.dispatch as unknown as ReturnType<typeof vi.fn>
+}
+
+function announcedNotificationIds(): (string | undefined)[] {
+  return dispatchMock().mock.calls.map(
+    (call) => (call[0] as { notificationId?: string } | undefined)?.notificationId
+  )
+}
+
+function dismissedNotificationIds(): string[] {
+  const dismiss = window.api.notifications.dismiss as unknown as ReturnType<typeof vi.fn>
+  return (dismiss.mock.calls.at(-1)?.[0] ?? []) as string[]
+}
+
+function agentNotificationId(stateStartedAt: number): string | null {
+  return buildAgentNotificationId({ worktreeId: WORKTREE_ID, paneKey: PANE_KEY, stateStartedAt })
+}
+
+describe('Claude background-turn notification identity', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(TURN_COMPLETED_AT)
+    resetAgentCompletionCoordinatorIdentitiesForTest()
+    resetAnnouncedAgentNotificationIdsForTest()
+    useAppStore.setState(initialState, true)
+    vi.stubGlobal('window', {
+      api: {
+        notifications: {
+          dispatch: vi.fn().mockResolvedValue({ delivered: true }),
+          dismiss: vi.fn().mockResolvedValue({ dismissed: 0 })
+        }
+      }
+    })
+  })
+
+  afterEach(() => {
+    useAppStore.setState(initialState, true)
+    resetAgentCompletionCoordinatorIdentitiesForTest()
+    resetAnnouncedAgentNotificationIdsForTest()
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('dismisses the announced banner id when a still-working Claude row is acknowledged', () => {
+    seedLiveClaudeWorkingRow(WORKING_STARTED_AT)
+    const [announcedSnapshot] = announceBackgroundTurns([
+      { stateStartedAt: WORKING_STARTED_AT, turnCompletedAt: TURN_COMPLETED_AT }
+    ])
+
+    const announcedId = announcedNotificationIds().at(-1)
+
+    expect(announcedSnapshot).toMatchObject({
+      state: 'done',
+      stateStartedAt: TURN_COMPLETED_AT,
+      turnCompletedAt: TURN_COMPLETED_AT
+    })
+    expect(useAppStore.getState().agentStatusByPaneKey[PANE_KEY]?.state).toBe('working')
+    expect(useAppStore.getState().agentStatusByPaneKey[PANE_KEY]?.stateStartedAt).toBe(
+      WORKING_STARTED_AT
+    )
+    expect(announcedId).toBe(agentNotificationId(TURN_COMPLETED_AT))
+
+    useAppStore.getState().acknowledgeAgents([PANE_KEY])
+
+    expect(dismissedNotificationIds()).toEqual([announcedId])
+  })
+
+  it('keeps successive background turns on one pane distinct and dismisses both', () => {
+    seedLiveClaudeWorkingRow(WORKING_STARTED_AT)
+    const announcedSnapshots = announceBackgroundTurns([
+      { stateStartedAt: WORKING_STARTED_AT, turnCompletedAt: TURN_COMPLETED_AT },
+      { stateStartedAt: SECOND_WORKING_STARTED_AT, turnCompletedAt: SECOND_TURN_COMPLETED_AT }
+    ])
+
+    expect(announcedSnapshots.map((snapshot) => snapshot.turnCompletedAt)).toEqual([
+      TURN_COMPLETED_AT,
+      SECOND_TURN_COMPLETED_AT
+    ])
+    const ids = announcedNotificationIds()
+    expect(ids).toEqual([
+      agentNotificationId(TURN_COMPLETED_AT),
+      agentNotificationId(SECOND_TURN_COMPLETED_AT)
+    ])
+    expect(new Set(ids).size).toBe(2)
+
+    useAppStore.getState().acknowledgeAgents([PANE_KEY])
+
+    expect(dismissedNotificationIds()).toEqual(ids)
+  })
+
+  it('announces a Claude background-turn completion when the remote clock trails the desktop', () => {
+    seedLiveClaudeWorkingRow(DESKTOP_WORKING_STARTED_AT)
+
+    announceBackgroundTurns([
+      {
+        stateStartedAt: REMOTE_TURN_COMPLETED_AT - 5_000,
+        turnCompletedAt: REMOTE_TURN_COMPLETED_AT
+      }
+    ])
+
+    expect(window.api.notifications.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'agent-task-complete',
+        notificationId: agentNotificationId(REMOTE_TURN_COMPLETED_AT)
+      })
+    )
+  })
+})

--- a/src/renderer/src/components/terminal-pane/agent-background-turn-notification-identity.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-background-turn-notification-identity.test.ts
@@ -201,7 +201,29 @@ describe('Claude background-turn notification identity', () => {
     expect(dismissedNotificationIds()).toEqual([announcedId])
   })
 
-  it('keeps successive background turns on one pane distinct and dismisses both', () => {
+  it('dismisses again when native delivery settles after acknowledgement', async () => {
+    let resolveDispatch!: (result: { delivered: true }) => void
+    dispatchMock().mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveDispatch = resolve
+      })
+    )
+    seedLiveClaudeWorkingRow(WORKING_STARTED_AT)
+    announceBackgroundTurns([
+      { stateStartedAt: WORKING_STARTED_AT, turnCompletedAt: TURN_COMPLETED_AT }
+    ])
+
+    useAppStore.getState().acknowledgeAgents([PANE_KEY])
+    expect(window.api.notifications.dismiss).toHaveBeenCalledTimes(1)
+
+    resolveDispatch({ delivered: true })
+    await Promise.resolve()
+
+    expect(window.api.notifications.dismiss).toHaveBeenCalledTimes(2)
+    expect(dismissedNotificationIds()).toEqual([agentNotificationId(TURN_COMPLETED_AT)])
+  })
+
+  it('replaces successive background turns on one pane and dismisses the shared id', () => {
     seedLiveClaudeWorkingRow(WORKING_STARTED_AT)
     const announcedSnapshots = announceBackgroundTurns([
       { stateStartedAt: WORKING_STARTED_AT, turnCompletedAt: TURN_COMPLETED_AT },
@@ -215,13 +237,13 @@ describe('Claude background-turn notification identity', () => {
     const ids = announcedNotificationIds()
     expect(ids).toEqual([
       agentNotificationId(TURN_COMPLETED_AT),
-      agentNotificationId(SECOND_TURN_COMPLETED_AT)
+      agentNotificationId(TURN_COMPLETED_AT)
     ])
-    expect(new Set(ids).size).toBe(2)
+    expect(new Set(ids).size).toBe(1)
 
     useAppStore.getState().acknowledgeAgents([PANE_KEY])
 
-    expect(dismissedNotificationIds()).toEqual(ids)
+    expect(dismissedNotificationIds()).toEqual([ids[0]])
   })
 
   it('announces a Claude background-turn completion when the remote clock trails the desktop', () => {

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator-types.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator-types.ts
@@ -5,7 +5,10 @@ import type { RuntimeTerminalProcessInspection } from '@/runtime/runtime-termina
 
 export type AgentCompletionStatusSnapshot = ParsedAgentStatusPayload & {
   stateStartedAt?: number
-  /** Renderer-local boundary used only to reject a delayed cross-host completion. */
+  /**
+   * The turn's working boundary in the same clock as the mirrored status row.
+   * Used only to reject a delayed completion; never sent over the wire.
+   */
   localStateStartedAt?: number
 }
 

--- a/src/renderer/src/components/terminal-pane/agent-completion-snapshot-staleness.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-snapshot-staleness.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import { isSupersededAgentCompletionSnapshot } from './agent-completion-snapshot-staleness'
+import type { AgentCompletionStatusSnapshot } from './agent-completion-coordinator-types'
+
+const DESKTOP_WORKING_STARTED_AT = 1_700_000_030_000
+const REMOTE_TURN_COMPLETED_AT = 1_700_000_005_000
+
+function workingRow(stateStartedAt: number): { state: 'working'; stateStartedAt: number } {
+  return { state: 'working', stateStartedAt }
+}
+
+function backgroundTurnSnapshot(
+  overrides: Partial<AgentCompletionStatusSnapshot> = {}
+): AgentCompletionStatusSnapshot {
+  return {
+    state: 'done',
+    prompt: 'review the PR',
+    agentType: 'claude',
+    stateStartedAt: REMOTE_TURN_COMPLETED_AT,
+    turnCompletedAt: REMOTE_TURN_COMPLETED_AT,
+    ...overrides
+  }
+}
+
+function unstampedSnapshot(
+  overrides: Partial<AgentCompletionStatusSnapshot> = {}
+): AgentCompletionStatusSnapshot {
+  return { state: 'done', prompt: 'review the PR', agentType: 'claude', ...overrides }
+}
+
+describe('isSupersededAgentCompletionSnapshot', () => {
+  it('keeps a remote-clock-trailing background-turn snapshot from looking superseded', () => {
+    expect(
+      isSupersededAgentCompletionSnapshot(
+        workingRow(DESKTOP_WORKING_STARTED_AT),
+        backgroundTurnSnapshot()
+      )
+    ).toBe(false)
+  })
+
+  it('drops a background turn whose own working boundary predates the stored row', () => {
+    expect(
+      isSupersededAgentCompletionSnapshot(
+        workingRow(DESKTOP_WORKING_STARTED_AT),
+        backgroundTurnSnapshot({ localStateStartedAt: DESKTOP_WORKING_STARTED_AT - 1 })
+      )
+    ).toBe(true)
+  })
+
+  it('accepts a background turn stamped on the stored row boundary', () => {
+    expect(
+      isSupersededAgentCompletionSnapshot(
+        workingRow(DESKTOP_WORKING_STARTED_AT),
+        backgroundTurnSnapshot({ localStateStartedAt: DESKTOP_WORKING_STARTED_AT })
+      )
+    ).toBe(false)
+  })
+
+  it('drops an unstamped completion whose boundary predates the stored row', () => {
+    expect(
+      isSupersededAgentCompletionSnapshot(
+        workingRow(DESKTOP_WORKING_STARTED_AT),
+        unstampedSnapshot({ stateStartedAt: DESKTOP_WORKING_STARTED_AT - 1 })
+      )
+    ).toBe(true)
+  })
+
+  it('drops an unstamped completion that disagrees with the stored row at the same boundary', () => {
+    expect(
+      isSupersededAgentCompletionSnapshot(
+        workingRow(DESKTOP_WORKING_STARTED_AT),
+        unstampedSnapshot({ stateStartedAt: DESKTOP_WORKING_STARTED_AT })
+      )
+    ).toBe(true)
+  })
+
+  it('accepts an unclocked completion that agrees with the stored row', () => {
+    expect(
+      isSupersededAgentCompletionSnapshot(
+        workingRow(DESKTOP_WORKING_STARTED_AT),
+        unstampedSnapshot({ state: 'working' })
+      )
+    ).toBe(false)
+  })
+
+  it('has nothing to supersede without a stored row or a snapshot', () => {
+    expect(isSupersededAgentCompletionSnapshot(undefined, backgroundTurnSnapshot())).toBe(false)
+    expect(
+      isSupersededAgentCompletionSnapshot(workingRow(DESKTOP_WORKING_STARTED_AT), undefined)
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/agent-completion-snapshot-staleness.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-snapshot-staleness.ts
@@ -8,17 +8,24 @@ export function isSupersededAgentCompletionSnapshot(
   if (!storedAgentStatus || !snapshot) {
     return false
   }
-  const comparableStateStartedAt = snapshot.localStateStartedAt ?? snapshot.stateStartedAt
+  const hasStampedTurn =
+    typeof snapshot.turnCompletedAt === 'number' && Number.isFinite(snapshot.turnCompletedAt)
+  // Why: a stamped background turn carries the agent host's turn-complete clock,
+  // which is not the clock the mirrored status row was written from. Only the
+  // boundary captured beside that row is comparable to it.
+  const comparableStateStartedAt = hasStampedTurn
+    ? snapshot.localStateStartedAt
+    : (snapshot.localStateStartedAt ?? snapshot.stateStartedAt)
   if (typeof comparableStateStartedAt !== 'number') {
-    return storedAgentStatus.state !== snapshot.state
+    // Why: a stamped turn boundary is independent evidence that the turn ended, so
+    // an unclocked completion must not be guessed stale from a foreign timestamp.
+    return hasStampedTurn ? false : storedAgentStatus.state !== snapshot.state
   }
   // Why: hook completion notifications are delayed by a quiet window; by the
   // time they fire, the same pane may already belong to a newer agent turn.
   if (storedAgentStatus.stateStartedAt > comparableStateStartedAt) {
     return true
   }
-  const hasStampedTurn =
-    typeof snapshot.turnCompletedAt === 'number' && Number.isFinite(snapshot.turnCompletedAt)
   return (
     storedAgentStatus.stateStartedAt === comparableStateStartedAt &&
     storedAgentStatus.state !== snapshot.state &&

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
@@ -6,6 +6,7 @@ import {
 } from '../../../../shared/agent-status-types'
 import type { TerminalLayoutSnapshot } from '../../../../shared/terminal-tab-types'
 import { buildAgentNotificationId } from '../../../../shared/agent-notification-id'
+import { resetAnnouncedAgentNotificationIdsForTest } from '@/lib/announced-agent-notification-ids'
 
 type MockState = {
   activeWorktreeId: string | null
@@ -99,6 +100,7 @@ describe('dispatchTerminalNotification', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    resetAnnouncedAgentNotificationIdsForTest()
     mockState = {
       activeWorktreeId: 'wt-secondary',
       activeTabId: 'tab-1',

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
@@ -4,6 +4,7 @@ import { resolveCommittedTitleAgentType } from '@/lib/pane-agent-evidence'
 import { getRepoMapFromState, getWorktreeMapFromState } from '@/store/selectors'
 import { playDesktopNotificationSound } from '@/lib/desktop-notification-sound'
 import { showBlockedNotificationFallbackToast } from '@/lib/blocked-notification-fallback'
+import { recordAnnouncedAgentNotificationId } from '@/lib/announced-agent-notification-ids'
 import { buildAgentNotificationId } from '../../../../shared/agent-notification-id'
 import { resolveCompatibleAgentTypeForOwner } from '../../../../shared/agent-title-owner'
 import {
@@ -213,6 +214,12 @@ export function dispatchTerminalNotification(
           stateStartedAt: agentNotificationStateStartedAt
         })
       : null
+  if (notificationId && event.paneKey) {
+    // Why: acknowledging the pane must dismiss what was announced. A background
+    // turn's id is the turn stamp, which the still-working status row no longer
+    // carries, so it cannot be reconstructed from the store later.
+    recordAnnouncedAgentNotificationId(event.paneKey, notificationId)
+  }
 
   void window.api.notifications
     .dispatch({

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
@@ -4,7 +4,10 @@ import { resolveCommittedTitleAgentType } from '@/lib/pane-agent-evidence'
 import { getRepoMapFromState, getWorktreeMapFromState } from '@/store/selectors'
 import { playDesktopNotificationSound } from '@/lib/desktop-notification-sound'
 import { showBlockedNotificationFallbackToast } from '@/lib/blocked-notification-fallback'
-import { recordAnnouncedAgentNotificationId } from '@/lib/announced-agent-notification-ids'
+import {
+  claimAnnouncedAgentNotificationId,
+  isAnnouncedAgentNotificationClaimCurrent
+} from '@/lib/announced-agent-notification-ids'
 import { buildAgentNotificationId } from '../../../../shared/agent-notification-id'
 import { resolveCompatibleAgentTypeForOwner } from '../../../../shared/agent-title-owner'
 import {
@@ -203,7 +206,7 @@ export function dispatchTerminalNotification(
         agentInterrupted: agentStatus.interrupted
       }
     : {}
-  const notificationId =
+  let notificationId =
     event.source === 'agent-task-complete'
       ? buildAgentNotificationId({
           worktreeId,
@@ -214,11 +217,14 @@ export function dispatchTerminalNotification(
           stateStartedAt: agentNotificationStateStartedAt
         })
       : null
+  let notificationClaim: ReturnType<typeof claimAnnouncedAgentNotificationId> | null = null
   if (notificationId && event.paneKey) {
-    // Why: acknowledging the pane must dismiss what was announced. A background
-    // turn's id is the turn stamp, which the still-working status row no longer
-    // carries, so it cannot be reconstructed from the store later.
-    recordAnnouncedAgentNotificationId(event.paneKey, notificationId)
+    const claimed = claimAnnouncedAgentNotificationId(event.paneKey, worktreeId, notificationId)
+    notificationClaim = claimed
+    notificationId = claimed.notificationId
+    if (claimed.supersededNotificationId) {
+      void window.api.notifications.dismiss([claimed.supersededNotificationId])
+    }
   }
 
   void window.api.notifications
@@ -235,6 +241,14 @@ export function dispatchTerminalNotification(
       ...agentSnapshot
     })
     .then((result) => {
+      if (
+        notificationClaim &&
+        event.paneKey &&
+        !isAnnouncedAgentNotificationClaimCurrent(notificationClaim.claimToken)
+      ) {
+        // Why: macOS delivery can finish after acknowledgement drained the claim.
+        void window.api.notifications.dismiss([notificationClaim.notificationId])
+      }
       if (result.delivered) {
         void playDesktopNotificationSound(customSoundId, customSoundVolume)
         return

--- a/src/renderer/src/hooks/useIpcEvents-agent-status-turn-completion.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents-agent-status-turn-completion.test.ts
@@ -84,6 +84,8 @@ describe('useIpcEvents agent status turn completion', () => {
           state: 'working',
           agentType: 'claude',
           turnCompletedAt: 1_700_000_005_000,
+          stateStartedAt: 1_700_000_000_000,
+          localStateStartedAt: 1_700_000_000_000,
           lastAssistantMessage: 'Which cells need hand-verification?'
         })
       })

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -3409,9 +3409,16 @@ export function useIpcEvents(): void {
       const applyPostCommitNotification = (): void => {
         if (statusWorktreeId && (options?.replay !== true || resolvedPayload.state === 'working')) {
           // Why: local Codex/Claude hooks arrive via this main-process IPC path, not the PTY OSC fallback, so task-complete notifications must observe accepted hook state here too.
+          // Why: a stamped background turn rewrites stateStartedAt to the agent's
+          // turn-complete stamp; carry the boundary this row was written from so
+          // staleness keeps comparing one clock.
           const notificationPayload =
             typeof data.stateStartedAt === 'number'
-              ? { ...resolvedPayload, stateStartedAt: data.stateStartedAt }
+              ? {
+                  ...resolvedPayload,
+                  stateStartedAt: data.stateStartedAt,
+                  localStateStartedAt: data.stateStartedAt
+                }
               : resolvedPayload
           observeAgentHookCompletionForNotification({
             paneKey,

--- a/src/renderer/src/lib/announced-agent-notification-ids.test.ts
+++ b/src/renderer/src/lib/announced-agent-notification-ids.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  claimAnnouncedAgentNotificationId,
+  isAnnouncedAgentNotificationClaimCurrent,
+  resetAnnouncedAgentNotificationIdsForTest,
+  takeAnnouncedAgentNotificationIds,
+  transferAnnouncedAgentNotificationClaim
+} from './announced-agent-notification-ids'
+
+describe('announced agent notification ids', () => {
+  beforeEach(() => resetAnnouncedAgentNotificationIdsForTest())
+
+  it('reuses one id until the pane is acknowledged', () => {
+    const first = claimAnnouncedAgentNotificationId('pane-1', 'worktree-1', 'id-1')
+    const second = claimAnnouncedAgentNotificationId('pane-1', 'worktree-1', 'id-2')
+    expect(first.notificationId).toBe('id-1')
+    expect(second).toEqual(first)
+    expect(takeAnnouncedAgentNotificationIds('pane-1')).toEqual(['id-1'])
+    expect(isAnnouncedAgentNotificationClaimCurrent(first.claimToken)).toBe(false)
+    expect(claimAnnouncedAgentNotificationId('pane-1', 'worktree-1', 'id-2')).toEqual(
+      expect.objectContaining({ notificationId: 'id-2' })
+    )
+  })
+
+  it('replaces a claim when a reused pane key moves worktrees', () => {
+    claimAnnouncedAgentNotificationId('pane-1', 'worktree-1', 'id-1')
+
+    expect(claimAnnouncedAgentNotificationId('pane-1', 'worktree-2', 'id-2')).toEqual(
+      expect.objectContaining({
+        notificationId: 'id-2',
+        supersededNotificationId: 'id-1'
+      })
+    )
+    expect(takeAnnouncedAgentNotificationIds('pane-1')).toEqual(['id-2'])
+  })
+
+  it('returns an evicted pane id for dismissal instead of orphaning it', () => {
+    for (let index = 0; index < 128; index += 1) {
+      claimAnnouncedAgentNotificationId(`pane-${index}`, 'worktree-1', `id-${index}`)
+    }
+
+    expect(claimAnnouncedAgentNotificationId('pane-128', 'worktree-1', 'id-128')).toEqual(
+      expect.objectContaining({
+        notificationId: 'id-128',
+        supersededNotificationId: 'id-0'
+      })
+    )
+    expect(takeAnnouncedAgentNotificationIds('pane-0')).toEqual([])
+  })
+
+  it('moves a claim with pane authority and returns a superseded target id', () => {
+    const source = claimAnnouncedAgentNotificationId('pane-1', 'worktree-1', 'id-1')
+    claimAnnouncedAgentNotificationId('pane-2', 'worktree-1', 'id-2')
+
+    expect(transferAnnouncedAgentNotificationClaim('pane-1', 'pane-2')).toBe('id-2')
+    expect(isAnnouncedAgentNotificationClaimCurrent(source.claimToken)).toBe(true)
+    expect(takeAnnouncedAgentNotificationIds('pane-1')).toEqual([])
+    expect(takeAnnouncedAgentNotificationIds('pane-2')).toEqual(['id-1'])
+  })
+})

--- a/src/renderer/src/lib/announced-agent-notification-ids.ts
+++ b/src/renderer/src/lib/announced-agent-notification-ids.ts
@@ -1,52 +1,88 @@
-/**
- * The notification ids a pane's agent completions were actually announced under,
- * held until that pane is acknowledged.
- *
- * Why a registry: a Claude background turn announces its banner under the
- * turn-complete stamp while the pane's status row stays on the working boundary,
- * so acknowledge cannot re-derive the id from the store. Successive background
- * turns each announce a distinct id, so every unacknowledged id has to be kept.
- */
+type AnnouncedAgentNotification = {
+  worktreeId: string
+  notificationId: string
+  claimToken: symbol
+}
 
-// Why bounded: a pane that is never acknowledged (backgrounded worktree, long
-// agent session) would otherwise accumulate one id per turn for the app's life.
+type ClaimedAgentNotificationId = {
+  notificationId: string
+  claimToken: symbol
+  supersededNotificationId?: string
+}
+
 const MAX_TRACKED_PANES = 128
-const MAX_IDS_PER_PANE = 16
 
-const announcedIdsByPaneKey = new Map<string, string[]>()
+const announcedNotificationByPaneKey = new Map<string, AnnouncedAgentNotification>()
 
-export function recordAnnouncedAgentNotificationId(paneKey: string, notificationId: string): void {
-  const ids = announcedIdsByPaneKey.get(paneKey) ?? []
-  // Why: re-announcing an id replaces the same OS banner, so one dismissal covers it.
-  if (ids.includes(notificationId)) {
-    return
+export function claimAnnouncedAgentNotificationId(
+  paneKey: string,
+  worktreeId: string,
+  candidateNotificationId: string
+): ClaimedAgentNotificationId {
+  const existing = announcedNotificationByPaneKey.get(paneKey)
+  if (existing?.worktreeId === worktreeId) {
+    // Re-insert so map order stays least-recently-announced first for eviction.
+    announcedNotificationByPaneKey.delete(paneKey)
+    announcedNotificationByPaneKey.set(paneKey, existing)
+    return { notificationId: existing.notificationId, claimToken: existing.claimToken }
   }
-  ids.push(notificationId)
-  if (ids.length > MAX_IDS_PER_PANE) {
-    ids.splice(0, ids.length - MAX_IDS_PER_PANE)
-  }
-  // Re-insert so map order stays least-recently-announced first for eviction.
-  announcedIdsByPaneKey.delete(paneKey)
-  announcedIdsByPaneKey.set(paneKey, ids)
-  while (announcedIdsByPaneKey.size > MAX_TRACKED_PANES) {
-    const oldestPaneKey = announcedIdsByPaneKey.keys().next().value
-    if (oldestPaneKey === undefined) {
-      return
+
+  let supersededNotificationId = existing?.notificationId
+  const claimToken = Symbol(paneKey)
+  announcedNotificationByPaneKey.delete(paneKey)
+  announcedNotificationByPaneKey.set(paneKey, {
+    worktreeId,
+    notificationId: candidateNotificationId,
+    claimToken
+  })
+  if (announcedNotificationByPaneKey.size > MAX_TRACKED_PANES) {
+    const oldestPaneKey = announcedNotificationByPaneKey.keys().next().value
+    if (oldestPaneKey !== undefined) {
+      const evicted = announcedNotificationByPaneKey.get(oldestPaneKey)
+      announcedNotificationByPaneKey.delete(oldestPaneKey)
+      supersededNotificationId = evicted?.notificationId
     }
-    announcedIdsByPaneKey.delete(oldestPaneKey)
+  }
+  return {
+    notificationId: candidateNotificationId,
+    claimToken,
+    ...(supersededNotificationId ? { supersededNotificationId } : {})
   }
 }
 
-/** Returns the pane's announced ids in announcement order and forgets them. */
+export function isAnnouncedAgentNotificationClaimCurrent(claimToken: symbol): boolean {
+  for (const announced of announcedNotificationByPaneKey.values()) {
+    if (announced.claimToken === claimToken) {
+      return true
+    }
+  }
+  return false
+}
+
+export function transferAnnouncedAgentNotificationClaim(
+  fromPaneKey: string,
+  toPaneKey: string
+): string | undefined {
+  const announced = announcedNotificationByPaneKey.get(fromPaneKey)
+  if (!announced || fromPaneKey === toPaneKey) {
+    return undefined
+  }
+  const supersededNotificationId = announcedNotificationByPaneKey.get(toPaneKey)?.notificationId
+  announcedNotificationByPaneKey.delete(fromPaneKey)
+  announcedNotificationByPaneKey.delete(toPaneKey)
+  announcedNotificationByPaneKey.set(toPaneKey, announced)
+  return supersededNotificationId
+}
+
 export function takeAnnouncedAgentNotificationIds(paneKey: string): readonly string[] {
-  const ids = announcedIdsByPaneKey.get(paneKey)
-  if (!ids) {
+  const announced = announcedNotificationByPaneKey.get(paneKey)
+  if (!announced) {
     return []
   }
-  announcedIdsByPaneKey.delete(paneKey)
-  return ids
+  announcedNotificationByPaneKey.delete(paneKey)
+  return [announced.notificationId]
 }
 
 export function resetAnnouncedAgentNotificationIdsForTest(): void {
-  announcedIdsByPaneKey.clear()
+  announcedNotificationByPaneKey.clear()
 }

--- a/src/renderer/src/lib/announced-agent-notification-ids.ts
+++ b/src/renderer/src/lib/announced-agent-notification-ids.ts
@@ -1,0 +1,52 @@
+/**
+ * The notification ids a pane's agent completions were actually announced under,
+ * held until that pane is acknowledged.
+ *
+ * Why a registry: a Claude background turn announces its banner under the
+ * turn-complete stamp while the pane's status row stays on the working boundary,
+ * so acknowledge cannot re-derive the id from the store. Successive background
+ * turns each announce a distinct id, so every unacknowledged id has to be kept.
+ */
+
+// Why bounded: a pane that is never acknowledged (backgrounded worktree, long
+// agent session) would otherwise accumulate one id per turn for the app's life.
+const MAX_TRACKED_PANES = 128
+const MAX_IDS_PER_PANE = 16
+
+const announcedIdsByPaneKey = new Map<string, string[]>()
+
+export function recordAnnouncedAgentNotificationId(paneKey: string, notificationId: string): void {
+  const ids = announcedIdsByPaneKey.get(paneKey) ?? []
+  // Why: re-announcing an id replaces the same OS banner, so one dismissal covers it.
+  if (ids.includes(notificationId)) {
+    return
+  }
+  ids.push(notificationId)
+  if (ids.length > MAX_IDS_PER_PANE) {
+    ids.splice(0, ids.length - MAX_IDS_PER_PANE)
+  }
+  // Re-insert so map order stays least-recently-announced first for eviction.
+  announcedIdsByPaneKey.delete(paneKey)
+  announcedIdsByPaneKey.set(paneKey, ids)
+  while (announcedIdsByPaneKey.size > MAX_TRACKED_PANES) {
+    const oldestPaneKey = announcedIdsByPaneKey.keys().next().value
+    if (oldestPaneKey === undefined) {
+      return
+    }
+    announcedIdsByPaneKey.delete(oldestPaneKey)
+  }
+}
+
+/** Returns the pane's announced ids in announcement order and forgets them. */
+export function takeAnnouncedAgentNotificationIds(paneKey: string): readonly string[] {
+  const ids = announcedIdsByPaneKey.get(paneKey)
+  if (!ids) {
+    return []
+  }
+  announcedIdsByPaneKey.delete(paneKey)
+  return ids
+}
+
+export function resetAnnouncedAgentNotificationIdsForTest(): void {
+  announcedIdsByPaneKey.clear()
+}

--- a/src/renderer/src/runtime/web-session-tabs-agent-completion-notifications.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-agent-completion-notifications.test.ts
@@ -117,9 +117,15 @@ describe('paired session-tab agent completion notifications', () => {
       payload: expect.objectContaining({
         state: 'working',
         stateStartedAt: NOW,
+        localStateStartedAt: NOW,
         turnCompletedAt
       })
     })
+    expect(
+      useAppStore.getState().agentStatusByPaneKey[
+        makePaneKey(toWebTerminalSurfaceTabId(HOST_TAB_ID), LEAF_ID)
+      ]?.stateStartedAt
+    ).toBe(NOW)
 
     applySnapshot(makeAgentSnapshot(4, NOW + 3_000, turnCompletedAt + 1_000), false)
     expect(mocks.observeAgentHookCompletionForNotification).toHaveBeenCalledTimes(4)

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -3433,7 +3433,7 @@ export function applyWebSessionTabsStorePatch(
     seedOnly?: true
     payload: ReturnType<typeof pickParsedAgentStatusPayload> & {
       stateStartedAt: number
-      localStateStartedAt?: number
+      localStateStartedAt: number
     }
   }[] = []
   useAppStore.setState((state) => {
@@ -3535,11 +3535,9 @@ export function applyWebSessionTabsStorePatch(
                 ...(turnCompletedAt !== undefined ? { turnCompletedAt } : {})
               }),
               stateStartedAt: notificationStatus.stateStartedAt,
-              ...(clientOwnedNotification
-                ? {
-                    localStateStartedAt
-                  }
-                : {})
+              // Why: staleness must compare one clock — the retained client
+              // boundary when the client owns the row, else the mirrored host one.
+              localStateStartedAt: localStateStartedAt ?? notificationStatus.stateStartedAt
             }
           })
         }

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -40,6 +40,7 @@ import {
   orchestrationLabelsMatchLiveDispatch
 } from '@/lib/agent-row-primary-text'
 import { isCompletedPiCompatibleAgentWithLiveRecoveryRecord } from '@/lib/pi-compatible-live-recovery-record'
+import { transferAnnouncedAgentNotificationClaim } from '@/lib/announced-agent-notification-ids'
 import {
   resolveAgentPaneAuthorityKey,
   retireAgentPaneAuthorityAliases,
@@ -1552,6 +1553,7 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
       }
       const from = transfer.previousOwnerPaneKey
       const to = transfer.ownerPaneKey
+      const supersededNotificationId = transferAnnouncedAgentNotificationClaim(from, to)
       const targetTabId = getTabIdFromPaneKey(to) ?? undefined
       const targetLeafId = getLeafIdFromPaneKey(to) ?? undefined
       set((s) => ({
@@ -1604,6 +1606,9 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         retentionSuppressedPaneKeys: movePaneKeyedRecord(s.retentionSuppressedPaneKeys, from, to)
       }))
       if (typeof window !== 'undefined') {
+        if (supersededNotificationId) {
+          void window.api?.notifications?.dismiss?.([supersededNotificationId])
+        }
         window.api?.agentStatus?.transferPaneAuthority?.({
           fromPaneKey: from,
           toPaneKey: to,

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -1198,12 +1198,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
 
   acknowledgedAgentsByPaneKey: {},
   acknowledgeAgents: (paneKeys) => {
-    const notificationIdsToDismiss = new Set<string>()
-    // Why: drain outside the updater — Zustand may re-run it, and each announced
-    // id is consumed once.
-    const announcedIdsByPaneKey = new Map<string, readonly string[]>(
-      paneKeys.map((key) => [key, takeAnnouncedAgentNotificationIds(key)] as const)
-    )
+    const fallbackIdsByPaneKey = new Map<string, Set<string>>()
     set((s) => {
       if (paneKeys.length === 0) {
         return s
@@ -1213,34 +1208,27 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
       let next: Record<string, number> | null = null
       for (const key of paneKeys) {
         const prev = s.acknowledgedAgentsByPaneKey[key] ?? 0
-        const announced = announcedIdsByPaneKey.get(key)
-        if (announced && announced.length > 0) {
-          // Why: these are the ids the OS actually holds. The status rows below
-          // only reconstruct an id, and a background turn's row has moved on.
-          for (const id of announced) {
-            notificationIdsToDismiss.add(id)
-          }
-        } else {
-          const liveEntry = s.agentStatusByPaneKey?.[key]
-          if (liveEntry) {
-            collectAcknowledgedAgentNotificationId({
-              ids: notificationIdsToDismiss,
-              worktreeId: resolvePaneKeyWorktreeIdFromTabs(s, key) ?? liveEntry.worktreeId,
-              paneKey: key,
-              stateStartedAt: liveEntry.stateStartedAt,
-              previousAckAt: prev
-            })
-          }
-          const retained = s.retainedAgentsByPaneKey?.[key]
-          if (retained) {
-            collectAcknowledgedAgentNotificationId({
-              ids: notificationIdsToDismiss,
-              worktreeId: retained.worktreeId,
-              paneKey: key,
-              stateStartedAt: retained.entry.stateStartedAt,
-              previousAckAt: prev
-            })
-          }
+        const fallbackIds = fallbackIdsByPaneKey.get(key) ?? new Set<string>()
+        fallbackIdsByPaneKey.set(key, fallbackIds)
+        const liveEntry = s.agentStatusByPaneKey?.[key]
+        if (liveEntry) {
+          collectAcknowledgedAgentNotificationId({
+            ids: fallbackIds,
+            worktreeId: resolvePaneKeyWorktreeIdFromTabs(s, key) ?? liveEntry.worktreeId,
+            paneKey: key,
+            stateStartedAt: liveEntry.stateStartedAt,
+            previousAckAt: prev
+          })
+        }
+        const retained = s.retainedAgentsByPaneKey?.[key]
+        if (retained) {
+          collectAcknowledgedAgentNotificationId({
+            ids: fallbackIds,
+            worktreeId: retained.worktreeId,
+            paneKey: key,
+            stateStartedAt: retained.entry.stateStartedAt,
+            previousAckAt: prev
+          })
         }
         if (prev < now) {
           if (next === null) {
@@ -1251,9 +1239,18 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
       }
       return next ? { acknowledgedAgentsByPaneKey: next } : s
     })
-    const notificationIds = [...notificationIdsToDismiss]
-    if (notificationIds.length > 0 && typeof window !== 'undefined') {
-      void window.api?.notifications?.dismiss?.(notificationIds)
+    if (typeof window !== 'undefined' && typeof window.api?.notifications?.dismiss === 'function') {
+      const notificationIdsToDismiss = new Set<string>()
+      for (const key of paneKeys) {
+        const announced = takeAnnouncedAgentNotificationIds(key)
+        const ids = announced.length > 0 ? announced : fallbackIdsByPaneKey.get(key)
+        for (const id of ids ?? []) {
+          notificationIdsToDismiss.add(id)
+        }
+      }
+      if (notificationIdsToDismiss.size > 0) {
+        void window.api.notifications.dismiss([...notificationIdsToDismiss])
+      }
     }
   },
   unacknowledgeAgents: (paneKeys) =>

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -130,6 +130,7 @@ import {
   resolveRunningAgentSendTarget
 } from '../../lib/running-agent-targets'
 import { buildAgentNotificationId } from '../../../../shared/agent-notification-id'
+import { takeAnnouncedAgentNotificationIds } from '../../lib/announced-agent-notification-ids'
 import { parsePaneKey } from '../../../../shared/stable-pane-id'
 import { translate } from '@/i18n/i18n'
 import { getRepoHostIdentity } from './repo-host-identity'
@@ -1198,6 +1199,11 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
   acknowledgedAgentsByPaneKey: {},
   acknowledgeAgents: (paneKeys) => {
     const notificationIdsToDismiss = new Set<string>()
+    // Why: drain outside the updater — Zustand may re-run it, and each announced
+    // id is consumed once.
+    const announcedIdsByPaneKey = new Map<string, readonly string[]>(
+      paneKeys.map((key) => [key, takeAnnouncedAgentNotificationIds(key)] as const)
+    )
     set((s) => {
       if (paneKeys.length === 0) {
         return s
@@ -1207,25 +1213,34 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
       let next: Record<string, number> | null = null
       for (const key of paneKeys) {
         const prev = s.acknowledgedAgentsByPaneKey[key] ?? 0
-        const liveEntry = s.agentStatusByPaneKey?.[key]
-        if (liveEntry) {
-          collectAcknowledgedAgentNotificationId({
-            ids: notificationIdsToDismiss,
-            worktreeId: resolvePaneKeyWorktreeIdFromTabs(s, key) ?? liveEntry.worktreeId,
-            paneKey: key,
-            stateStartedAt: liveEntry.stateStartedAt,
-            previousAckAt: prev
-          })
-        }
-        const retained = s.retainedAgentsByPaneKey?.[key]
-        if (retained) {
-          collectAcknowledgedAgentNotificationId({
-            ids: notificationIdsToDismiss,
-            worktreeId: retained.worktreeId,
-            paneKey: key,
-            stateStartedAt: retained.entry.stateStartedAt,
-            previousAckAt: prev
-          })
+        const announced = announcedIdsByPaneKey.get(key)
+        if (announced && announced.length > 0) {
+          // Why: these are the ids the OS actually holds. The status rows below
+          // only reconstruct an id, and a background turn's row has moved on.
+          for (const id of announced) {
+            notificationIdsToDismiss.add(id)
+          }
+        } else {
+          const liveEntry = s.agentStatusByPaneKey?.[key]
+          if (liveEntry) {
+            collectAcknowledgedAgentNotificationId({
+              ids: notificationIdsToDismiss,
+              worktreeId: resolvePaneKeyWorktreeIdFromTabs(s, key) ?? liveEntry.worktreeId,
+              paneKey: key,
+              stateStartedAt: liveEntry.stateStartedAt,
+              previousAckAt: prev
+            })
+          }
+          const retained = s.retainedAgentsByPaneKey?.[key]
+          if (retained) {
+            collectAcknowledgedAgentNotificationId({
+              ids: notificationIdsToDismiss,
+              worktreeId: retained.worktreeId,
+              paneKey: key,
+              stateStartedAt: retained.entry.stateStartedAt,
+              previousAckAt: prev
+            })
+          }
         }
         if (prev < now) {
           if (next === null) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​428 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​428 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​160 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​19 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​141 |

<!-- /orca-pr-loc -->

## ELI5

When Claude finishes a turn but keeps working in the background, Orca shows the "agent done" banner stamped with the moment the turn ended — while the pane's status row still says "working" from when the turn *started*. Those are two different timestamps, and the notification id is built out of the timestamp. So clicking into the pane tried to dismiss a banner id that never existed (the banner stayed on screen), and on SSH — where the two timestamps come from two different machines' clocks — the banner was thrown away before it was ever shown.

This PR makes the dismissal use the id we actually announced, and makes the staleness check compare timestamps that come from the same clock.

## What Changed

**Defect 1 — the announced banner id could never be dismissed.**

`agent-completion-coordinator.ts` announces a Claude background turn as a synthetic `done` snapshot whose `stateStartedAt` is the turn-complete stamp, while the store row stays `working` on the turn's start boundary. `dispatchTerminalNotification` builds the OS notification id from the snapshot (`buildAgentNotificationId` embeds `Math.trunc(stateStartedAt)`), but `acknowledgeAgents` in `store/slices/ui.ts` rebuilt the id from `liveEntry.stateStartedAt` / `retained.entry.stateStartedAt` — the working boundary. The two ids differed, so `window.api.notifications.dismiss` was handed an id the main-process registry never held and no-opped.

- New `src/renderer/src/lib/announced-agent-notification-ids.ts`: a bounded renderer-session registry that claims one notification id per pane/worktree until acknowledgement. Successive background turns reuse that id, so native and mobile replacement semantics collapse them to one banner instead of building an unacknowledged stack.
- `use-notification-dispatch.ts` submits the claimed id and re-dismisses it if asynchronous native delivery settles after the claim was acknowledged, replaced, transferred, or evicted.
- `acknowledgeAgents` dismisses the exact claimed id when present and keeps the existing row-derived reconstruction as the fallback for banners announced before this build or by paths that do not claim an id.
- Pane authority transfers move the claim with the status row. Cross-worktree pane reuse and the 128-pane bound explicitly dismiss the superseded id instead of silently forgetting it.

**Defect 2 — SSH remote-clock skew dropped the banner as stale.**

`isSupersededAgentCompletionSnapshot` compared the desktop's stored `stateStartedAt` against `snapshot.localStateStartedAt ?? snapshot.stateStartedAt`. `localStateStartedAt` was stamped in exactly one place (`web-session-tabs-sync.ts`, and only when `clientOwnedNotification` was true); the main-process hook IPC path in `useIpcEvents.ts` never stamped it. So for a remote pane the predicate fell back to the snapshot's host-clocked turn stamp, and a desktop store row a few seconds "ahead" of the remote host made every background-turn completion look superseded — the banner was dropped at `use-notification-dispatch.ts` before dispatch.

- Both producer paths now stamp `localStateStartedAt` — the working boundary **in the same clock as the status row that will be compared against it** (`useIpcEvents.ts` stamps the row's own boundary; `web-session-tabs-sync.ts` stamps the retained client boundary when the client owns the row, else the mirrored host one, and the field is now non-optional on that path so the stamping can't silently lapse).
- `agent-completion-snapshot-staleness.ts` no longer falls back to `snapshot.stateStartedAt` for a **stamped** turn. A stamped `turnCompletedAt` is independent evidence the turn ended; without a comparable same-clock boundary the predicate declines to guess rather than comparing across clocks. Unstamped completions keep their existing behavior exactly.

## Why

The main process already owns an id-keyed notification registry with replace-and-close semantics (`activeNotificationsById`). The fix therefore keeps one exact claimed id per unacknowledged pane, submits that same id for later turns, and dismisses that id on acknowledgement. This avoids both unsound re-derivation and a growing stack of banners. Keeping row-derived reconstruction as a fallback preserves compatibility for notifications that predate the claim registry.

For defect 2 the invariant is "never compare a desktop store row against a remote `turnCompletedAt`". Rather than special-casing SSH at the comparison site, each producer stamps the boundary in the clock its own row was written from, so the predicate has one comparable pair or none.

The announced-id registry lives in its own module instead of in `ui.ts` state: it is renderer-session-scoped, must not be persisted or serialized into the store, and `ui.ts` is already large. No `max-lines` disable was added anywhere and no per-file limit was bumped; the ratchet check passes (`190 grandfathered suppression(s), no new bypasses`).

## Linked Issue

STA-4592 — https://linear.app/stably/issue/STA-4592
Follow-up to #14580.

Fixes #

## Visual Proof

`N/A` — no rendered UI changes. The change is to OS-level notification identity and to a staleness predicate; the surfaces involved are the OS notification banner (unchanged in content and appearance) and its dismissal. Behavior is covered by the automated tests below, which drive the real coordinator, the real dispatcher, and the real store.

## Remote wire compatibility

Read `docs/reference/remote-wire-compatibility.md`. **Category: compatible existing-message content change; no new field or opcode.**

- `localStateStartedAt` is renderer-internal and never leaves the renderer. It flows coordinator → `dispatchTerminalNotification`, which forwards only a fixed set of `agent*` fields to `window.api.notifications.dispatch`; `localStateStartedAt` is not among them. It is not added to any RPC param, any stream frame, or anything the host publishes.
- Rule 1 (new optional JSON field) does not apply — no field crosses the wire. Rule 2 (new stream opcode) does not apply — no opcode was added. The clock stamping happens only in the renderer from values it already received.
- Rule 3 does apply to notification content: later unacknowledged turns on the same pane reuse the first claimed `notificationId`, and replacement/eviction/acknowledgement send the existing `dismiss` event with that same opaque id. Old and new mobile clients already support id-based replacement, dedupe, and dismissal, so they interpret this content safely without a capability. No pane-group operation, new message shape, or new semantic requirement was added.

## SSH / folder workspaces / cross-platform

- **SSH is defect 2.** The remote path is the one that was silently dropping banners; the fix is per-path stamping so a client-owned row compares against the retained client boundary and a mirrored host row compares against the host boundary.
- **Folder workspaces**: nothing here assumes a git worktree. Registry claims include the workspace id plus pane key, and the staleness predicate only reads timestamps and state.
- **Cross-platform**: no keyboard handling, no path handling, no platform branches touched.

## Testing

- [x] Automated tests added/updated
- [ ] Manual OS-notification testing not performed (see below)

New permanent tests (the reproduction cases were folded into properly named files; the throwaway `*.repro.test.ts` and its report were deleted, not committed):

- `src/renderer/src/components/terminal-pane/agent-background-turn-notification-identity.test.ts` — drives the real `createAgentCompletionCoordinator`, the real `dispatchTerminalNotification`, and the real `useAppStore`:
  - dismisses the announced banner id when a still-working Claude row is acknowledged
  - repeats dismissal when asynchronous native delivery settles after acknowledgement
  - replaces successive background turns on one pane and dismisses the shared id
  - announces a Claude background-turn completion when the remote clock trails the desktop
- `src/renderer/src/components/terminal-pane/agent-completion-snapshot-staleness.test.ts` — 7 unit tests pinning the predicate, including the stamped/unstamped and same-boundary edges.
- `src/renderer/src/lib/announced-agent-notification-ids.test.ts` — 4 tests cover same-pane replacement, cross-worktree pane reuse, bounded eviction, and pane-authority transfer.
- Existing IPC and paired-session tests now assert that each producer forwards `localStateStartedAt` from the same clock as its stored row.

**Mutation-checked**: reverting the six original production fixes while retaining the tests produced **5 failed / 10 passed**: all 4 end-to-end identity assertions and the cross-clock staleness assertion failed, while the 6 predicate baseline cases remained green. Reverting the four registry behaviors made all **4/4** registry tests fail. Reverting each producer stamp independently made its IPC test fail **1/1** and its paired-session test fail **1/1**.

Results (all local, macOS):

| Command | Result |
| --- | --- |
| `npx vitest run --config config/vitest.config.ts` on the three new files plus both producer tests | **5 files, 22 tests passed** |
| `… agent-completion use-notification-dispatch agent-hook-completion web-session-tabs notification agent-background-turn announced-agent-notification-ids` | **57 files, 509 tests passed** |
| `… useIpcEvents store/slices/ui- store/slices/agent-status useAutoAckViewedAgent` | **52 files, 461 tests passed** |
| `pnpm exec vitest run --config config/vitest.config.ts tests/e2e/cross-version-wire/cross-version-terminal-wire.unit.test.ts` | **1 file, 5 tests passed** |
| `pnpm run typecheck` | **exit 0** (run unpiped; exit status read directly) |
| `npx oxlint` | **exit 0** — gate proven live by planting an unused variable, which it flagged |
| `node config/scripts/check-max-lines-ratchet.mjs` | **OK — 190 grandfathered suppressions, no new bypasses** |
| formatting | `oxfmt` (not prettier) |

Not tested: a live SSH host with real clock skew, and real macOS/Windows/Linux notification-center dismissal. The SSH case is covered by the clock-skew integration test rather than a live remote.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

Security: none — no new IPC surface, no new persisted state, no user data in the registry (pane keys, worktree ids, notification ids, and in-memory claim tokens only). Performance: one bounded 128-entry map; same-pane turns use O(1) replacement instead of growing an id list. Backwards compatibility: banners announced before this build still dismiss through the retained row-derived fallback.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] `N/A` with reason for visual proof
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `typecheck`, targeted tests, `oxlint`, and the max-lines ratchet pass locally

## Author

- X / Twitter: @BrennanKB5
