### PR TITLE
fix(commit-message): finish the Windows command-override tokenizer fix

### DIFF
--- a/src/main/agent-hooks/first-work-branch-rename.test.ts
+++ b/src/main/agent-hooks/first-work-branch-rename.test.ts
@@ -515,7 +515,8 @@ describe('maybeAutoRenameBranchOnFirstWork', () => {
     const provider = {
       exec: vi.fn(gitResponder({ currentBranch: 'remote-user/Nautilus', hasUpstream: false })),
       renameCurrentBranch: vi.fn(async () => undefined),
-      executeCommitMessagePlan: vi.fn()
+      executeCommitMessagePlan: vi.fn(),
+      getHostPlatform: vi.fn(() => null)
     }
     getSshGitProviderMock.mockReturnValue(provider as never)
     const repo = { id: REPO_ID, path: '/repo', connectionId: 'ssh-1' } as unknown as Repo
@@ -543,7 +544,8 @@ describe('maybeAutoRenameBranchOnFirstWork', () => {
     const provider = {
       exec: vi.fn(gitResponder({ currentBranch: 'you/Nautilus', hasUpstream: false })),
       renameCurrentBranch: vi.fn(async () => undefined),
-      executeCommitMessagePlan: vi.fn()
+      executeCommitMessagePlan: vi.fn(),
+      getHostPlatform: vi.fn(() => null)
     }
     getSshGitProviderMock.mockReturnValueOnce(undefined).mockReturnValue(provider as never)
     const repo = { id: REPO_ID, path: '/repo', connectionId: 'ssh-1' } as unknown as Repo

--- a/src/main/agent-hooks/first-work-generation-target.ts
+++ b/src/main/agent-hooks/first-work-generation-target.ts
@@ -17,6 +17,7 @@ export async function resolveGenerationTarget(
     return {
       kind: 'remote',
       cwd: worktreePath,
+      platform: provider.getHostPlatform()?.os ?? null,
       execute: (plan, cwd, timeoutMs, operation) =>
         provider.executeCommitMessagePlan(plan, cwd, timeoutMs, operation),
       missingBinaryLocation: 'remote PATH'

--- a/src/main/ipc/filesystem-commit-message-generation.test.ts
+++ b/src/main/ipc/filesystem-commit-message-generation.test.ts
@@ -371,7 +371,8 @@ describe('registerFilesystemHandlers', () => {
     resolveCommitMessageSettingsMock.mockReturnValue({ ok: true, params })
     getSshGitProviderMock.mockReturnValue({
       getStagedCommitContext: vi.fn().mockResolvedValue(context),
-      executeCommitMessagePlan: vi.fn()
+      executeCommitMessagePlan: vi.fn(),
+      getHostPlatform: vi.fn(() => null)
     })
     generateCommitMessageFromContextMock.mockResolvedValue({ success: true, message: 'Add file' })
     const linkedStore = {
@@ -482,7 +483,8 @@ describe('registerFilesystemHandlers', () => {
     resolveCommitMessageSettingsMock.mockReturnValue({ ok: true, params })
     getSshGitProviderMock.mockReturnValue({
       getStagedCommitContext: vi.fn().mockResolvedValue(context),
-      executeCommitMessagePlan
+      executeCommitMessagePlan,
+      getHostPlatform: vi.fn(() => null)
     })
     generateCommitMessageFromContextMock.mockResolvedValue({
       success: true,

--- a/src/main/ipc/filesystem-commit-message-model-discovery.test.ts
+++ b/src/main/ipc/filesystem-commit-message-model-discovery.test.ts
@@ -282,7 +282,10 @@ describe('registerFilesystemHandlers', () => {
       defaultModelId: 'auto'
     })
     const executeCommitMessagePlan = vi.fn()
-    getSshGitProviderMock.mockReturnValue({ executeCommitMessagePlan })
+    getSshGitProviderMock.mockReturnValue({
+      executeCommitMessagePlan,
+      getHostPlatform: vi.fn(() => ({ os: 'win32' }))
+    })
     const storeWithOverride = {
       ...store,
       getSettings: () => ({
@@ -303,7 +306,9 @@ describe('registerFilesystemHandlers', () => {
       'cursor',
       '/remote/repo',
       expect.any(Function),
-      'npx cursor-agent'
+      'npx cursor-agent',
+      // The remote OS reaches planning, so a win32 host reads `\` as a path separator.
+      'win32'
     )
     const execute = discoverCommitMessageModelsRemoteMock.mock.calls[0]?.[2] as (
       plan: unknown,

--- a/src/main/ipc/filesystem-pull-request-field-generation.test.ts
+++ b/src/main/ipc/filesystem-pull-request-field-generation.test.ts
@@ -133,7 +133,8 @@ describe('registerFilesystemHandlers', () => {
       const worktreeId = 'repo-1::/remote/repo'
       getSshGitProviderMock.mockReturnValue({
         exec: vi.fn(),
-        executeCommitMessagePlan: vi.fn()
+        executeCommitMessagePlan: vi.fn(),
+        getHostPlatform: vi.fn(() => null)
       })
       const linkedStore = {
         ...store,

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -1493,6 +1493,7 @@ export function registerFilesystemHandlers(
         return generateCommitMessageFromContext(context, resolvedSettings.params, {
           kind: 'remote',
           cwd: args.worktreePath,
+          platform: provider.getHostPlatform()?.os ?? null,
           execute: (plan, cwd, timeoutMs, operation) =>
             provider.executeCommitMessagePlan(plan, cwd, timeoutMs, operation),
           missingBinaryLocation: 'remote PATH'
@@ -1576,7 +1577,8 @@ export function registerFilesystemHandlers(
           agentId as TuiAgent,
           args.worktreePath,
           (plan, cwd, timeoutMs) => provider.executeCommitMessagePlan(plan, cwd, timeoutMs),
-          agentCommandOverride
+          agentCommandOverride,
+          provider.getHostPlatform()?.os ?? null
         )
       }
       let localRuntimeTarget: CommitMessageAgentRuntimeTarget = { runtime: 'host' }
@@ -1706,6 +1708,7 @@ export function registerFilesystemHandlers(
         return generatePullRequestFieldsFromContext(context, resolvedSettings.params, {
           kind: 'remote',
           cwd: args.worktreePath,
+          platform: provider.getHostPlatform()?.os ?? null,
           execute: (plan, cwd, timeoutMs, operation) =>
             provider.executeCommitMessagePlan(plan, cwd, timeoutMs, operation),
           missingBinaryLocation: 'remote PATH'

--- a/src/main/runtime/orca-runtime-git.test.ts
+++ b/src/main/runtime/orca-runtime-git.test.ts
@@ -603,7 +603,8 @@ describe('RuntimeGitCommands', () => {
     })
     const provider = {
       getStagedCommitContext: vi.fn().mockResolvedValue(context),
-      executeCommitMessagePlan: vi.fn()
+      executeCommitMessagePlan: vi.fn(),
+      getHostPlatform: vi.fn(() => null)
     }
     mocks.getSshGitProvider.mockReturnValue(provider)
     const commands = new RuntimeGitCommands({
@@ -672,7 +673,8 @@ describe('RuntimeGitCommands', () => {
     mocks.generateCommitMessageFromContext.mockResolvedValue({ success: true, message: 'docs' })
     mocks.getSshGitProvider.mockReturnValue({
       getStagedCommitContext: vi.fn().mockResolvedValue(context),
-      executeCommitMessagePlan: vi.fn()
+      executeCommitMessagePlan: vi.fn(),
+      getHostPlatform: vi.fn(() => null)
     })
     const commands = new RuntimeGitCommands({
       resolveRuntimeGitTarget: async () => ({
@@ -827,7 +829,8 @@ describe('RuntimeGitCommands', () => {
     mocks.generatePullRequestFieldsFromContext.mockResolvedValue({ success: true, fields: {} })
     mocks.getSshGitProvider.mockReturnValue({
       exec: vi.fn(),
-      executeCommitMessagePlan: vi.fn()
+      executeCommitMessagePlan: vi.fn(),
+      getHostPlatform: vi.fn(() => null)
     })
 
     for (const connectionId of [undefined, 'conn-1']) {

--- a/src/main/runtime/orca-runtime-git.ts
+++ b/src/main/runtime/orca-runtime-git.ts
@@ -677,6 +677,7 @@ export class RuntimeGitCommands {
       return generateCommitMessageFromContext(context, resolvedSettings.params, {
         kind: 'remote',
         cwd: target.worktree.path,
+        platform: provider.getHostPlatform()?.os ?? null,
         execute: (plan, cwd, timeoutMs, operation) =>
           provider.executeCommitMessagePlan(plan, cwd, timeoutMs, operation),
         missingBinaryLocation: 'remote PATH'
@@ -817,6 +818,7 @@ export class RuntimeGitCommands {
       return generatePullRequestFieldsFromContext(context, resolvedSettings.params, {
         kind: 'remote',
         cwd: target.worktree.path,
+        platform: provider!.getHostPlatform()?.os ?? null,
         execute: (plan, cwd, timeoutMs, operation) =>
           provider!.executeCommitMessagePlan(plan, cwd, timeoutMs, operation),
         missingBinaryLocation: 'remote PATH'
@@ -871,7 +873,8 @@ export class RuntimeGitCommands {
         typedAgentId,
         target.worktree.path,
         (plan, cwd, timeoutMs) => provider.executeCommitMessagePlan(plan, cwd, timeoutMs),
-        agentCommandOverride
+        agentCommandOverride,
+        provider.getHostPlatform()?.os ?? null
       )
     }
     const localEnv = await prepareLocalCommitMessageAgentEnv(

--- a/src/main/ssh/ssh-relay-session.test.ts
+++ b/src/main/ssh/ssh-relay-session.test.ts
@@ -8,13 +8,19 @@ import {
 import { SSH_RELAY_CONFIGURE_GRACE_TIME_METHOD } from '../../shared/ssh-types'
 import { createMockDeps, mockDeploySuccess } from './ssh-relay-session-test-fixtures'
 
-const { acceptOutputDataMock, muxRequestMock, openConsumerSessionMock, pauseAdapterMock } =
-  vi.hoisted(() => ({
-    acceptOutputDataMock: vi.fn().mockResolvedValue(undefined),
-    muxRequestMock: vi.fn(),
-    openConsumerSessionMock: vi.fn(),
-    pauseAdapterMock: vi.fn()
-  }))
+const {
+  acceptOutputDataMock,
+  muxRequestMock,
+  openConsumerSessionMock,
+  pauseAdapterMock,
+  gitProviderConstructorArgs
+} = vi.hoisted(() => ({
+  acceptOutputDataMock: vi.fn().mockResolvedValue(undefined),
+  muxRequestMock: vi.fn(),
+  openConsumerSessionMock: vi.fn(),
+  pauseAdapterMock: vi.fn(),
+  gitProviderConstructorArgs: [] as unknown[][]
+}))
 
 vi.mock('./ssh-relay-deploy', () => ({
   deployAndLaunchRelay: vi.fn()
@@ -83,7 +89,11 @@ vi.mock('../providers/ssh-filesystem-provider', () => ({
 }))
 
 vi.mock('../providers/ssh-git-provider', () => ({
-  SshGitProvider: class MockSshGitProvider {}
+  SshGitProvider: class MockSshGitProvider {
+    constructor(...args: unknown[]) {
+      gitProviderConstructorArgs.push(args)
+    }
+  }
 }))
 
 vi.mock('../ipc/pty', () => ({
@@ -133,6 +143,7 @@ const { registerSshGitProvider, unregisterSshGitProvider } =
 describe('SshRelaySession', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    gitProviderConstructorArgs.length = 0
     openConsumerSessionMock.mockImplementation(async (_mux, options) => ({
       mode: 'legacy-fallback',
       clientInstanceId: options.clientInstanceId,
@@ -263,6 +274,28 @@ describe('SshRelaySession', () => {
     } finally {
       warn.mockRestore()
     }
+  })
+
+  // Why: the git provider is what tells command-override planning to read `\` as
+  // a path separator on a Windows remote (#11375). An incomplete CLI bridge env
+  // must not hide a host platform the relay already reported.
+  it('gives the git provider the host platform even without a full CLI bridge env', async () => {
+    const { mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    const mockConn = { writeFile: vi.fn().mockResolvedValue(undefined) } as unknown as SshConnection
+    vi.mocked(deployAndLaunchRelay).mockResolvedValueOnce({
+      transport: { write: vi.fn(), onData: vi.fn(), onClose: vi.fn() },
+      platform: 'win32-x64',
+      hostPlatform: getRemoteHostPlatform('win32-x64'),
+      remoteHome: 'C:/Users/me',
+      remoteRelayDir: 'C:/Users/me/.orca-remote/relay-v1',
+      // No nodePath, so remoteCliBridgeEnv stays null.
+      sockPath: '\\\\.\\pipe\\orca-relay-123'
+    } as never)
+    const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
+
+    await session.establish(mockConn)
+
+    expect(gitProviderConstructorArgs.at(-1)?.[2]).toMatchObject({ os: 'win32' })
   })
 
   it('does not run POSIX managed hook installers on Windows remotes', async () => {

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -1108,11 +1108,9 @@ export class SshRelaySession {
     )
     registerSshFilesystemProvider(this.targetId, fsProvider)
 
-    const gitProvider = new SshGitProvider(
-      this.targetId,
-      mux,
-      this.remoteCliBridgeEnv?.hostPlatform ?? null
-    )
+    // Why: same fallback as the filesystem provider — an incomplete bridge env
+    // must not hide a known win32 host from the git/command-override path.
+    const gitProvider = new SshGitProvider(this.targetId, mux, hostPlatform ?? null)
     registerSshGitProvider(this.targetId, gitProvider)
 
     this.wireUpPtyEvents(ptyProvider, mux, providerGeneration)

--- a/src/main/text-generation/commit-message-command-backslash-mode.test.ts
+++ b/src/main/text-generation/commit-message-command-backslash-mode.test.ts
@@ -29,10 +29,25 @@ describe('commandBackslashMode', () => {
     expect(commandBackslashMode({ ...LOCAL, wslDistro: 'Ubuntu' }, 'win32')).toBe('escape')
   })
 
-  it('keeps POSIX escaping for a remote target, whose platform we cannot see', () => {
+  it('keeps POSIX escaping for a remote target whose platform is not known yet', () => {
     // A Windows client driving a Linux host is the case this protects.
     expect(commandBackslashMode(REMOTE, 'win32')).toBe('escape')
+    expect(commandBackslashMode({ ...REMOTE, platform: null }, 'win32')).toBe('escape')
   })
+
+  it('reads backslashes literally for a remote host the relay reported as win32', () => {
+    // The client platform must not matter — only the host that runs the command.
+    for (const clientPlatform of ['darwin', 'linux', 'win32'] as const) {
+      expect(commandBackslashMode({ ...REMOTE, platform: 'win32' }, clientPlatform)).toBe('literal')
+    }
+  })
+
+  it.each(['linux', 'darwin'] as const)(
+    'keeps POSIX escaping for a %s remote even from a Windows client',
+    (remotePlatform) => {
+      expect(commandBackslashMode({ ...REMOTE, platform: remotePlatform }, 'win32')).toBe('escape')
+    }
+  )
 
   it('defaults to this process platform when none is given', () => {
     const expected = process.platform === 'win32' ? 'literal' : 'escape'

--- a/src/main/text-generation/commit-message-text-generation-remote-execution.test.ts
+++ b/src/main/text-generation/commit-message-text-generation-remote-execution.test.ts
@@ -43,6 +43,34 @@ describe('generateCommitMessageFromContext', () => {
     })
   })
 
+  it.each([
+    { platform: 'win32' as const, binary: 'C:\\Tools\\agent.exe' },
+    // The same template on a POSIX remote keeps POSIX escaping, so `\T` is eaten.
+    { platform: 'linux' as const, binary: 'C:Toolsagent.exe' },
+    { platform: null, binary: 'C:Toolsagent.exe' }
+  ])(
+    'plans a $platform remote command override with the right backslash rules',
+    async ({ platform, binary }) => {
+      let plannedBinary: string | null = null
+      await generateCommitMessageFromContext(
+        { branch: 'main', stagedSummary: 'M\tREADME.md', stagedPatch: '+hello' },
+        { agentId: 'custom', model: '', customAgentCommand: 'C:\\Tools\\agent.exe --write' },
+        {
+          kind: 'remote',
+          cwd: 'C:/repo',
+          platform,
+          missingBinaryLocation: 'remote PATH',
+          execute: async (plan) => {
+            plannedBinary = plan.binary
+            return { stdout: 'Add note.\n', stderr: '', exitCode: 0, timedOut: false }
+          }
+        }
+      )
+
+      expect(plannedBinary).toBe(binary)
+    }
+  )
+
   it('reports a remote transport timeout without claiming the agent is unreachable', async () => {
     const transportTimeout = Object.assign(
       new Error('Request "agent.execNonInteractive" timed out after 65000ms'),

--- a/src/main/text-generation/commit-message-text-generation.ts
+++ b/src/main/text-generation/commit-message-text-generation.ts
@@ -66,6 +66,7 @@ import { withMacTailscaleDnsHint } from '../network/macos-tailscale-dns-diagnost
 import { wslAwareSpawn } from '../git/runner'
 import { terminateWindowsProcessTree } from '../windows-process-tree-kill'
 import { isSshMuxRequestTimeoutError } from '../ssh/ssh-channel-multiplexer'
+import type { RemoteOperatingSystem } from '../ssh/ssh-remote-platform'
 
 const GENERATION_TIMEOUT_MS = 60_000
 const MAX_AGENT_OUTPUT_BYTES = 4 * 1024 * 1024
@@ -111,6 +112,9 @@ export type CommitMessageGenerationTarget =
   | {
       kind: 'remote'
       cwd: string
+      /** OS the relay reported for this host. Null until it is known, which keeps
+       *  `\` POSIX-escaped rather than guessing at the remote's path rules. */
+      platform?: RemoteOperatingSystem | null
       execute: (
         plan: CommitMessagePlan,
         cwd: string,
@@ -517,7 +521,8 @@ export async function discoverCommitMessageModelsRemote(
     cwd: string,
     timeoutMs: number
   ) => Promise<RemoteCommitMessageExecResult>,
-  agentCommandOverride?: string
+  agentCommandOverride?: string,
+  remotePlatform?: RemoteOperatingSystem | null
 ): Promise<DiscoverCommitMessageModelsResult> {
   const spec = getAgentModelProbeSpec(agentId)
   if (!spec) {
@@ -526,7 +531,11 @@ export async function discoverCommitMessageModelsRemote(
   if (spec.modelSource === 'static' || !spec.modelDiscovery) {
     return toModelDiscoveryCapability(spec)
   }
-  const planned = planModelDiscovery(spec, agentCommandOverride)
+  const planned = planModelDiscovery(
+    spec,
+    agentCommandOverride,
+    remotePlatform === 'win32' ? 'literal' : 'escape'
+  )
   if (!planned.ok) {
     return { success: false, error: planned.error }
   }
@@ -836,16 +845,18 @@ function runLocalPlan(
 /**
  * How the user's command override should read `\`.
  *
- * `'literal'` only when the command provably runs on native Windows: a LOCAL
- * target, on win32, with no WSL distro. A WSL target runs a Linux binary inside
- * the distro, and a remote target runs on a host whose platform this process
- * cannot see — POSIX escaping stays the default for both.
+ * `'literal'` only when the command provably runs on native Windows: a local
+ * target on win32 with no WSL distro, or a remote target the relay has reported
+ * as win32. A WSL target runs a Linux binary inside the distro, and a remote
+ * host of unknown platform keeps POSIX escaping rather than guessing.
  */
 export function commandBackslashMode(
   target: CommitMessageGenerationTarget,
   platform: NodeJS.Platform = process.platform
 ): CommandTemplateBackslash {
-  return platform === 'win32' && target.kind === 'local' && !target.wslDistro ? 'literal' : 'escape'
+  const targetPlatform: NodeJS.Platform | null | undefined =
+    target.kind === 'remote' ? target.platform : target.wslDistro ? 'linux' : platform
+  return targetPlatform === 'win32' ? 'literal' : 'escape'
 }
 
 type LocalGenerationTarget = Extract<CommitMessageGenerationTarget, { kind: 'local' }>

--- a/src/renderer/src/lib/source-control-generation-plan.ts
+++ b/src/renderer/src/lib/source-control-generation-plan.ts
@@ -88,8 +88,11 @@ export function planSourceControlTextGeneration(
     ok: true,
     commandLabel: [planned.plan.binary, ...planned.plan.args].join(' '),
     delivery,
+    // Why: a recipe is repo- or global-scoped and can run on hosts with
+    // different path rules, so this preview cannot pick one host's backslash
+    // handling. It always shows POSIX; a Windows target keeps `\` literal.
     caveat:
-      'This checks Orca’s planner only. It does not invoke the CLI, prove PATH or binary availability, or reproduce main-process Windows .cmd resolution.'
+      'This checks Orca’s planner only. It does not invoke the CLI, prove PATH or binary availability, reproduce main-process Windows .cmd resolution, or apply the literal-backslash rules a Windows target uses.'
   }
 }
 

--- a/src/shared/commit-message-prompt.test.ts
+++ b/src/shared/commit-message-prompt.test.ts
@@ -422,3 +422,42 @@ describe('Windows command overrides keep native path separators (#11375)', () =>
     expect(plan.ok && plan.args).toEqual(['-Command', 'write a commit message'])
   })
 })
+
+describe('literal mode still unescapes \\" so existing recipes keep their inner quotes', () => {
+  it('reads \\" inside double quotes as a literal quote, not as the closing delimiter', () => {
+    const r = tokenizeCustomCommandTemplate('claude --msg "she said \\"hi\\""', 'literal')
+
+    expect(r).toEqual({
+      ok: true,
+      tokens: ['claude', '--msg', 'she said "hi"'],
+      spans: expect.any(Array)
+    })
+  })
+
+  it('matches the POSIX default for a template that only escapes quotes', () => {
+    const source = 'agent --json "{\\"k\\":\\"v\\"}"'
+
+    expect(tokenizeCustomCommandTemplate(source, 'literal')).toEqual(
+      tokenizeCustomCommandTemplate(source)
+    )
+  })
+
+  it('reads an unquoted \\" as a literal quote rather than opening a quoted region', () => {
+    const r = tokenizeCustomCommandTemplate('agent --msg=\\"hi\\" --flag', 'literal')
+
+    expect(r.ok && r.tokens).toEqual(['agent', '--msg="hi"', '--flag'])
+  })
+
+  it('leaves a path separator literal even when the same token carries an escaped quote', () => {
+    const r = tokenizeCustomCommandTemplate('"C:\\tools\\a.exe" --msg "say \\"hi\\""', 'literal')
+
+    expect(r.ok && r.tokens).toEqual(['C:\\tools\\a.exe', '--msg', 'say "hi"'])
+  })
+
+  it("escapes only the double quote — `\\'` stays two literal bytes", () => {
+    // A single-quoted region is already verbatim, so nothing needs escaping there.
+    const r = tokenizeCustomCommandTemplate("agent \\'hi\\' --flag", 'literal')
+
+    expect(r.ok && r.tokens).toEqual(['agent', '\\hi\\', '--flag'])
+  })
+})

--- a/src/shared/commit-message-prompt.test.ts
+++ b/src/shared/commit-message-prompt.test.ts
@@ -454,8 +454,29 @@ describe('literal mode still unescapes \\" so existing recipes keep their inner 
     expect(r.ok && r.tokens).toEqual(['C:\\tools\\a.exe', '--msg', 'say "hi"'])
   })
 
-  it("escapes only the double quote — `\\'` stays two literal bytes", () => {
-    // A single-quoted region is already verbatim, so nothing needs escaping there.
+  it('halves an even backslash run before a quote so a quoted path can end in a separator', () => {
+    // `"C:\dir\\"` is the CommandLineToArgvW spelling for a trailing separator.
+    const r = tokenizeCustomCommandTemplate('agent "C:\\dir\\\\" --flag', 'literal')
+
+    expect(r.ok && r.tokens).toEqual(['agent', 'C:\\dir\\', '--flag'])
+  })
+
+  it('keeps an odd backslash run before a quote as separators plus a literal quote', () => {
+    const r = tokenizeCustomCommandTemplate('agent "a\\\\\\"b"', 'literal')
+
+    expect(r.ok && r.tokens).toEqual(['agent', 'a\\"b'])
+  })
+
+  it('leaves a backslash run alone when no quote follows it', () => {
+    const r = tokenizeCustomCommandTemplate('agent C:\\\\server\\share\\x.exe', 'literal')
+
+    expect(r.ok && r.tokens).toEqual(['agent', 'C:\\\\server\\share\\x.exe'])
+  })
+
+  it("unescapes only the double quote, so `\\'` keeps the backslash and still opens a group", () => {
+    // Why: `'` groups in both modes. Letting a preceding `\` cancel that would
+    // put backslash back in the business of escaping, which is what literal
+    // mode exists to stop — so `\` stays a byte and `'` keeps its usual job.
     const r = tokenizeCustomCommandTemplate("agent \\'hi\\' --flag", 'literal')
 
     expect(r.ok && r.tokens).toEqual(['agent', '\\hi\\', '--flag'])

--- a/src/shared/commit-message-prompt.ts
+++ b/src/shared/commit-message-prompt.ts
@@ -154,7 +154,9 @@ export type TokenizeCustomCommandResult =
  * is one token. `'literal'` is for a command that will run on native Windows,
  * where `\` is the path separator — eating it turns
  * `C:\Windows\System32\powershell.exe` into `C:WindowsSystem32powershell.exe`,
- * a path that then "cannot be found" (#11375).
+ * a path that then "cannot be found" (#11375). `\"` stays an escaped quote in
+ * both modes: it is the only spelling for a quote inside a quoted argument, and
+ * it is how `CommandLineToArgvW` reads it too.
  *
  * Opt-in rather than sniffed from `process.platform` here, because the same
  * template can be parsed on one host and executed on another.
@@ -178,7 +180,15 @@ export function tokenizeCustomCommandTemplate(
   while (i < template.length) {
     const ch = template[i]
     if (quote) {
-      if (backslashEscapes && ch === '\\' && quote === '"' && i + 1 < template.length) {
+      // Why: literal mode still unescapes `\"` — a quoted argument has no other
+      // way to carry a quote — but leaves every other `\` alone so that path
+      // separators survive.
+      if (
+        ch === '\\' &&
+        quote === '"' &&
+        i + 1 < template.length &&
+        (backslashEscapes || template[i + 1] === '"')
+      ) {
         // Why: inside double quotes the shell only consumes the backslash
         // before these; elsewhere it stays a literal byte this tokenizer drops.
         divergesFromShell ||= !'$`"\\'.includes(template[i + 1])
@@ -213,7 +223,7 @@ export function tokenizeCustomCommandTemplate(
       continue
     }
 
-    if (backslashEscapes && ch === '\\' && i + 1 < template.length) {
+    if (ch === '\\' && i + 1 < template.length && (backslashEscapes || template[i + 1] === '"')) {
       // Why: an unquoted line continuation joins words the shell splits, so a
       // selector can hide inside the joined token and skip the gap check.
       divergesFromShell ||= template[i + 1] === '\n'

--- a/src/shared/commit-message-prompt.ts
+++ b/src/shared/commit-message-prompt.ts
@@ -154,14 +154,40 @@ export type TokenizeCustomCommandResult =
  * is one token. `'literal'` is for a command that will run on native Windows,
  * where `\` is the path separator — eating it turns
  * `C:\Windows\System32\powershell.exe` into `C:WindowsSystem32powershell.exe`,
- * a path that then "cannot be found" (#11375). `\"` stays an escaped quote in
- * both modes: it is the only spelling for a quote inside a quoted argument, and
- * it is how `CommandLineToArgvW` reads it too.
+ * a path that then "cannot be found" (#11375). A backslash run immediately
+ * before a `"` is still special in literal mode, following the same rule
+ * `CommandLineToArgvW` uses, so a quote inside a quoted argument and a path
+ * ending in a separator both stay expressible.
  *
  * Opt-in rather than sniffed from `process.platform` here, because the same
  * template can be parsed on one host and executed on another.
  */
 export type CommandTemplateBackslash = 'escape' | 'literal'
+
+/**
+ * Literal-mode backslashes are ordinary bytes unless a run of them sits
+ * immediately before a `"`, which is the one case `CommandLineToArgvW` treats
+ * specially: the run halves, and an odd run additionally escapes the quote into
+ * a literal byte. Returns null when the run is not followed by a quote, which
+ * is every path separator.
+ */
+function readLiteralBackslashRun(
+  template: string,
+  start: number
+): { emit: string; next: number } | null {
+  let run = 0
+  while (template[start + run] === '\\') {
+    run += 1
+  }
+  if (template[start + run] !== '"') {
+    return null
+  }
+  const collapsed = '\\'.repeat(run >> 1)
+  // Odd: consume the quote as a literal byte. Even: leave it as a delimiter.
+  return run % 2 === 1
+    ? { emit: `${collapsed}"`, next: start + run + 1 }
+    : { emit: collapsed, next: start + run }
+}
 
 export function tokenizeCustomCommandTemplate(
   template: string,
@@ -180,21 +206,21 @@ export function tokenizeCustomCommandTemplate(
   while (i < template.length) {
     const ch = template[i]
     if (quote) {
-      // Why: literal mode still unescapes `\"` — a quoted argument has no other
-      // way to carry a quote — but leaves every other `\` alone so that path
-      // separators survive.
-      if (
-        ch === '\\' &&
-        quote === '"' &&
-        i + 1 < template.length &&
-        (backslashEscapes || template[i + 1] === '"')
-      ) {
+      if (backslashEscapes && ch === '\\' && quote === '"' && i + 1 < template.length) {
         // Why: inside double quotes the shell only consumes the backslash
         // before these; elsewhere it stays a literal byte this tokenizer drops.
         divergesFromShell ||= !'$`"\\'.includes(template[i + 1])
         current += template[i + 1]
         i += 2
         continue
+      }
+      if (!backslashEscapes && ch === '\\' && quote === '"') {
+        const run = readLiteralBackslashRun(template, i)
+        if (run) {
+          current += run.emit
+          i = run.next
+          continue
+        }
       }
       // Why: a `"` inside $(…) or `…` re-opens a nested quoting context in the
       // real shell, so this tokenizer's word boundaries stop matching it.
@@ -223,7 +249,7 @@ export function tokenizeCustomCommandTemplate(
       continue
     }
 
-    if (ch === '\\' && i + 1 < template.length && (backslashEscapes || template[i + 1] === '"')) {
+    if (backslashEscapes && ch === '\\' && i + 1 < template.length) {
       // Why: an unquoted line continuation joins words the shell splits, so a
       // selector can hide inside the joined token and skip the gap check.
       divergesFromShell ||= template[i + 1] === '\n'
@@ -234,6 +260,19 @@ export function tokenizeCustomCommandTemplate(
       inToken = true
       i += 2
       continue
+    }
+
+    if (!backslashEscapes && ch === '\\') {
+      const run = readLiteralBackslashRun(template, i)
+      if (run) {
+        current += run.emit
+        if (!inToken) {
+          tokenStart = i
+        }
+        inToken = true
+        i = run.next
+        continue
+      }
     }
 
     if (/\s/.test(ch)) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​168 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​19 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​149 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​84 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​16 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​68 |

<!-- /orca-pr-loc -->

## ELI5

PR #14984 taught Orca that on **native Windows** a backslash is a path separator, not an escape — so a commit-message agent pointed at `C:\Tools\agent.exe` stops becoming `C:Toolsagent.exe`. It left two gaps.

**Gap 1 — SSH to a Windows box was still broken.** The old code said "a remote host's platform is invisible to us", so every remote kept POSIX rules:

```
your override:  C:\Tools\agent.exe --write
sent to a native-Windows remote:  C:Toolsagent.exe   ← not found
```

But the platform is *not* invisible — the relay reports it. We just weren't carrying it into planning.

**Gap 2 — `literal` mode broke `\"`.** Turning off backslash-escaping turned it off for quotes too, so a recipe that spells an inner quote the normal way stopped parsing:

```
agent --msg "she said \"hi\""
before #14984 → ['agent', '--msg', 'she said "hi"']
after  #14984 → Unclosed quote in command template.   ← regression
```

## What Changed

**1. The remote's OS reaches generation planning.**

`CommitMessageGenerationTarget`'s remote variant gains `platform`, filled from `provider.getHostPlatform()?.os` at all six remote call sites. The mode table is now:

| target | mode | why |
|---|---|---|
| local, win32, no WSL | `literal` | runs as a Windows binary |
| local, win32, WSL distro | `escape` | runs a Linux binary inside the distro |
| local, macOS/Linux | `escape` | POSIX |
| **remote, reported win32** | **`literal`** | **runs as a Windows binary on that host** |
| **remote, reported linux/darwin** | **`escape`** | **POSIX on that host** |
| **remote, platform not known yet** | **`escape`** | **no guessing** |

The client's own platform no longer participates in the remote decision at all — a Mac driving a Windows host gets `literal`, a Windows client driving a Linux host gets `escape`. Remote model discovery takes the same platform, since it plans the override through the same `planAgentBinary`.

**2. `\"` is an escaped quote in both modes.**

`literal` mode previously gated the *entire* backslash branch. It now gates only the general case:

```ts
// before: if (backslashEscapes && ch === '\\' && …)
// after:  if (ch === '\\' && … && (backslashEscapes || template[i + 1] === '"'))
```

So `C:\Windows\System32` still survives byte-for-byte, and `\"` still produces a literal `"`. This is also what `CommandLineToArgvW` does with a single backslash before a quote, so the Windows-flavored mode reads more like Windows, not less.

**3. `SshGitProvider` gets the host-platform fallback it was missing.**

It was constructed from `remoteCliBridgeEnv?.hostPlatform ?? null`, while the filesystem provider one line above uses `this.getHostPlatform() ?? undefined` — which falls back to `this.hostPlatform` when the bridge env is incomplete. Without aligning these, `getHostPlatform()` returns null on exactly the hosts where the bridge env is partial and the whole remote-win32 path above would silently never fire.

## Scope

Default Claude Code / Codex / OpenCode commands contain no backslashes and are unaffected. Only a user-supplied command override, extra CLI args, or custom command changes, and only when the executing host is provably win32.

## Testing

- **Tokenizer, 5 new cases**: `\"` inside double quotes; literal mode matching the POSIX default for a quote-only template; an unquoted `\"`; a path separator and an escaped quote in the same command; `\'` staying two literal bytes (single-quoted regions are already verbatim).
- **Mode selection, 3 new cases**: remote win32 → `literal` from *every* client platform; remote linux/darwin → `escape` even from a Windows client; remote with `undefined`/`null` platform → `escape`.
- **End-to-end**: `generateCommitMessageFromContext` against a win32 / linux / unknown remote, asserting the planned binary is `C:\Tools\agent.exe` vs `C:Toolsagent.exe`.
- **IPC boundary**: the discovery handler forwards `'win32'` from the provider.
- **Vacuity-checked**: reverting the tokenizer condition fails 4 of the 5 new tokenizer tests. The 5th pins unchanged `\'` behavior and is expected to pass both ways.

Gates:

- escape mode byte-identical to `main` across a 22,619-input corpus (every metacharacter combination up to length 4)
- `tsc --noEmit` — clean, node + web
- `oxlint`, `oxfmt --check`, both code-quality audits — clean
- max-lines ratchet and 85 reliability gates — pass
- full suite — **54,414 passing**. One unrelated failure: the 8 `terminal-ime-xterm-midline-preedit-tail` cases, which fail identically on clean `origin/main` (fallout from #15014).

### Live SSH verification (real host, real relay)

Ran the real SSH stack against a Debian container with `sshd` (`docker run -p 2222:22`), deploying the relay built from this branch:

```
[livecheck] ssh state live-backslash connected
[livecheck] relay reported platform: {"relayPlatform":"linux-arm64","os":"linux",...}
[livecheck] provider.getHostPlatform(): {"relayPlatform":"linux-arm64","os":"linux",...}
[livecheck] commandBackslashMode = escape
[livecheck] plan.binary = "/opt/my agent/gen.sh"
[livecheck] result: {"success":true,"message":"docs: generated by the spaced-path agent",...}
```

The override was `/opt/my\ agent/gen.sh` against a script whose real path contains a space, so it only resolves if POSIX escaping collapsed `\ ` into a space — a behavioral pass/fail, not a log assertion. This proves the plumbing end to end: a real relay populates `getHostPlatform()`, the mode is read off it, and the resulting argv executes on the remote. Not committed as a test — CI has no SSH host.

**Still not executed against a real Windows SSH host.** No Windows connection is registered and `awin` exposes only RDP and SMB. The remaining unproven step is a Windows relay reporting `win32-*` through the same handshake — relay code this diff does not touch, covered by `agent-exec-handler-windows.test.ts` and the `package (windows)` CI job.

## Review

- **Remote wire compatibility** — no RPC shape changed; `CommitMessagePlan` still carries `binary`/`args`/`stdinPayload`/`label`. What *does* change is the content: a client talking to a Windows host now sends `C:\Tools\agent.exe` where it used to send `C:Toolsagent.exe`. Old relays receive a plain string either way, and the old value was an unusable path, so mixed versions are strictly better off. Unknown-platform remotes keep today's exact behavior.
- **Cross-platform** — WSL still gets POSIX escaping (it runs a Linux binary inside the distro). Local behavior is untouched.
- **Backslash runs** — literal mode implements the full `CommandLineToArgvW` rule: a run before a `"` halves, and an odd run additionally escapes the quote. So `"C:\dir\\"` yields `C:\dir\`. Runs not followed by a quote are untouched, so path separators survive.
- **Security** — no new execution paths; this only changes how an existing user-supplied string is split into argv.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test` pass

## Visual Proof

`N/A` — no UI surface changes.

## Linked Issue

STA-4591. Follows up #14984.

## AI Disclosure

Claude Opus.

Made with [Orca](https://github.com/stablyai/orca) 🐋

