### PR TITLE
fix(terminal): scope the IME composition route to captured sessions

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-ime-composition-route.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-composition-route.test.ts
@@ -149,6 +149,76 @@ describe('installTerminalImeCompositionRoute', () => {
     expect(harness.input).not.toHaveBeenCalled()
   })
 
+  // A route that never saw the start cannot deliver the commit, so cancelling the event would
+  // suppress xterm's own triggerDataEvent with nothing standing in for it.
+  it('leaves an uncaptured session to xterm when installed mid-composition', () => {
+    const harness = createHarness()
+
+    expect(harness.end(1, '한')).toBe(true)
+    expect(harness.input).not.toHaveBeenCalled()
+  })
+
+  it('does not swallow a commit when the connection re-installs the route mid-composition', () => {
+    const element = document.createElement('div')
+    const transport = createTransport('pty-original')
+    const input = vi.fn()
+    const install = () =>
+      installTerminalImeCompositionRoute({
+        terminalElement: element,
+        terminal: { input },
+        capturedTransport: transport,
+        getCurrentTransport: () => transport
+      })
+    const firstRoute = install()
+
+    element.dispatchEvent(sessionEvent(XTERM_COMPOSITION_SESSION_START_EVENT, 1))
+    // Reconnect/effect re-run swaps the route while the preedit is still open.
+    firstRoute.dispose()
+    const secondRoute = install()
+
+    expect(element.dispatchEvent(sessionEvent(XTERM_COMPOSITION_SESSION_END_EVENT, 1, '한'))).toBe(
+      true
+    )
+    expect(input).not.toHaveBeenCalled()
+
+    secondRoute.dispose()
+  })
+
+  it('still suppresses xterm insertion for a captured session it deliberately drops', () => {
+    const harness = createHarness()
+    harness.start(1)
+    harness.state.currentTransport = createTransport('pty-replacement')
+
+    // Owned, so xterm must stand down — dropping the commit is this route's decision.
+    expect(harness.end(1, '한')).toBe(false)
+    expect(harness.input).not.toHaveBeenCalled()
+  })
+
+  it('keeps a shared session pending until every overlapping route releases it', () => {
+    const element = document.createElement('div')
+    const firstTransport = createTransport('pty-first')
+    const secondTransport = createTransport('pty-second')
+    const firstRoute = installTerminalImeCompositionRoute({
+      terminalElement: element,
+      terminal: { input: vi.fn() },
+      capturedTransport: firstTransport,
+      getCurrentTransport: () => firstTransport
+    })
+    const secondRoute = installTerminalImeCompositionRoute({
+      terminalElement: element,
+      terminal: { input: vi.fn() },
+      capturedTransport: secondTransport,
+      getCurrentTransport: () => secondTransport
+    })
+
+    element.dispatchEvent(sessionEvent(XTERM_COMPOSITION_SESSION_START_EVENT, 1))
+    firstRoute.dispose()
+    expect(hasPendingTerminalImeComposition(element)).toBe(true)
+
+    secondRoute.dispose()
+    expect(hasPendingTerminalImeComposition(element)).toBe(false)
+  })
+
   it.each(['terminal close', 'tab unmount'])(
     'releases the captured session and listeners on %s',
     () => {

--- a/src/renderer/src/components/terminal-pane/terminal-ime-composition-route.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-composition-route.ts
@@ -14,21 +14,65 @@ type CapturedCompositionSession = {
   ptyId: string | null
 }
 
-const pendingCompositionCountByElement = new WeakMap<HTMLElement, number>()
+export type TerminalImeCompositionSessionSnapshot = ReadonlySet<number>
 
-function adjustPendingCompositionCount(terminalElement: HTMLElement, delta: number): void {
-  const count = Math.max(0, (pendingCompositionCountByElement.get(terminalElement) ?? 0) + delta)
-  if (count === 0) {
-    pendingCompositionCountByElement.delete(terminalElement)
-    return
-  }
-  pendingCompositionCountByElement.set(terminalElement, count)
+// Reference-counted per session id, not a bare per-element count: a caller waiting on a
+// composition must be able to tell its own sessions from ones that started after it, and two
+// overlapping routes can own the same session without clearing each other's pending state.
+const pendingCompositionSessionCountsByElement = new WeakMap<HTMLElement, Map<number, number>>()
+
+function addPendingCompositionSession(terminalElement: HTMLElement, sessionId: number): void {
+  const sessionCounts = pendingCompositionSessionCountsByElement.get(terminalElement) ?? new Map()
+  sessionCounts.set(sessionId, (sessionCounts.get(sessionId) ?? 0) + 1)
+  pendingCompositionSessionCountsByElement.set(terminalElement, sessionCounts)
 }
 
-export function hasPendingTerminalImeComposition(
+function removePendingCompositionSession(terminalElement: HTMLElement, sessionId: number): void {
+  const sessionCounts = pendingCompositionSessionCountsByElement.get(terminalElement)
+  const count = sessionCounts?.get(sessionId)
+  if (!sessionCounts || count === undefined) {
+    return
+  }
+  if (count > 1) {
+    sessionCounts.set(sessionId, count - 1)
+  } else {
+    sessionCounts.delete(sessionId)
+  }
+  if (!sessionCounts.size) {
+    pendingCompositionSessionCountsByElement.delete(terminalElement)
+  }
+}
+
+export function capturePendingTerminalImeCompositionSessions(
   terminalElement: HTMLElement | null | undefined
+): TerminalImeCompositionSessionSnapshot {
+  if (!terminalElement) {
+    return new Set()
+  }
+  return new Set(pendingCompositionSessionCountsByElement.get(terminalElement)?.keys())
+}
+
+/** With a snapshot, only the sessions it captured count as pending. */
+export function hasPendingTerminalImeComposition(
+  terminalElement: HTMLElement | null | undefined,
+  snapshot?: TerminalImeCompositionSessionSnapshot
 ): boolean {
-  return Boolean(terminalElement && pendingCompositionCountByElement.has(terminalElement))
+  if (!terminalElement) {
+    return false
+  }
+  const sessionCounts = pendingCompositionSessionCountsByElement.get(terminalElement)
+  if (!sessionCounts) {
+    return false
+  }
+  if (!snapshot) {
+    return true
+  }
+  for (const sessionId of snapshot) {
+    if (sessionCounts.has(sessionId)) {
+      return true
+    }
+  }
+  return false
 }
 
 function getCompositionDetail(event: Event): CompositionSessionDetail | null {
@@ -70,7 +114,7 @@ export function installTerminalImeCompositionRoute(args: {
       return
     }
     if (!sessions.has(detail.id)) {
-      adjustPendingCompositionCount(terminalElement, 1)
+      addPendingCompositionSession(terminalElement, detail.id)
     }
     sessions.set(detail.id, {
       ptyId: args.capturedTransport.getPtyId()
@@ -82,13 +126,16 @@ export function installTerminalImeCompositionRoute(args: {
     if (!detail) {
       return
     }
-    event.preventDefault()
     const captured = sessions.get(detail.id)
     if (!captured) {
+      // Not our session — the route was installed mid-composition, so no start was seen.
+      // Cancelling here would suppress xterm's own insertion with nothing to replace it.
       return
     }
+    // Owned, so xterm stands down even on the drop paths below: that drop is this route's call.
+    event.preventDefault()
     sessions.delete(detail.id)
-    adjustPendingCompositionCount(terminalElement, -1)
+    removePendingCompositionSession(terminalElement, detail.id)
     if (
       disposed ||
       detail.dataPendingReconciliation ||
@@ -108,7 +155,9 @@ export function installTerminalImeCompositionRoute(args: {
   return {
     dispose: () => {
       disposed = true
-      adjustPendingCompositionCount(terminalElement, -sessions.size)
+      for (const sessionId of sessions.keys()) {
+        removePendingCompositionSession(terminalElement, sessionId)
+      }
       sessions.clear()
       terminalElement.removeEventListener(XTERM_COMPOSITION_SESSION_START_EVENT, onSessionStart)
       terminalElement.removeEventListener(XTERM_COMPOSITION_SESSION_END_EVENT, onSessionEnd)

--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.test.ts
@@ -142,6 +142,37 @@ describe('sendTerminalInputAfterComposition', () => {
     route.dispose()
   })
 
+  // A composition the user starts after pressing Enter must not hold that Enter behind itself, or
+  // the terminal sees `한글\n` for what was typed as `한` Enter `글`.
+  it('does not let a composition started after the defer hold the newline', () => {
+    const el = document.createElement('div')
+    const send = vi.fn()
+    const terminal = { input: vi.fn() }
+    const transport = { getPtyId: () => 'pty-1' } as unknown as PtyTransport
+    const route = installTerminalImeCompositionRoute({
+      terminalElement: el,
+      terminal,
+      capturedTransport: transport,
+      getCurrentTransport: () => transport
+    })
+    const sessionEvent = (type: string, id: number, data: string) =>
+      new CustomEvent(type, { cancelable: true, detail: { id, data } })
+
+    el.dispatchEvent(sessionEvent(XTERM_COMPOSITION_SESSION_START_EVENT, 1, ''))
+    const stopWaiting = sendTerminalInputAfterComposition(el, send, { fallbackMs: null })
+    el.dispatchEvent(sessionEvent(XTERM_COMPOSITION_SESSION_START_EVENT, 2, ''))
+    expect(send).not.toHaveBeenCalled()
+
+    el.dispatchEvent(sessionEvent(XTERM_COMPOSITION_SESSION_END_EVENT, 1, '한'))
+    vi.advanceTimersByTime(0)
+
+    expect(send).toHaveBeenCalledTimes(1)
+    expect(terminal.input.mock.calls).toEqual([['한']])
+
+    stopWaiting()
+    route.dispose()
+  })
+
   it('sends only once and drops the listener after firing', () => {
     const el = document.createElement('div')
     const send = vi.fn()

--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.ts
@@ -1,4 +1,5 @@
 import {
+  capturePendingTerminalImeCompositionSessions,
   hasPendingTerminalImeComposition,
   XTERM_COMPOSITION_SESSION_END_EVENT
 } from './terminal-ime-composition-route'
@@ -14,6 +15,10 @@ export const TERMINAL_IME_DEFERRED_NEWLINE_FALLBACK_MS = 200
  * Returns a disposer that stops waiting without sending. An indefinite wait has no other exit, so
  * a caller that can outlive the composition must hold it — otherwise the listeners stay on the
  * terminal element and a later composition flushes the stale send.
+ *
+ * The wait is scoped to the compositions already open when it starts. A composition the user
+ * begins afterwards is behind this input, not in front of it, so letting it hold the wait would
+ * reorder the two — `한` Enter `글` reaching the terminal as `한글\n`.
  */
 export function sendTerminalInputAfterComposition(
   terminalElement: HTMLElement | null | undefined,
@@ -30,6 +35,7 @@ export function sendTerminalInputAfterComposition(
       ? null
       : (options?.fallbackMs ?? TERMINAL_IME_DEFERRED_NEWLINE_FALLBACK_MS)
   let done = false
+  const capturedSessions = capturePendingTerminalImeCompositionSessions(terminalElement)
 
   const stopWaiting = (): void => {
     if (done) {
@@ -56,7 +62,7 @@ export function sendTerminalInputAfterComposition(
   }
 
   const finishAfterPendingComposition = (): void => {
-    if (!hasPendingTerminalImeComposition(terminalElement)) {
+    if (!hasPendingTerminalImeComposition(terminalElement, capturedSessions)) {
       finish()
     }
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​101 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​101 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​68 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​55 |

<!-- /orca-pr-loc -->

Ports @yeongjunyoo's #11983 to current main, with `Co-authored-by` credit. Their design — a refcounted per-session map, snapshot capture, ownership decided before `preventDefault()` — is carried over essentially verbatim.

## Two real defects, verified on current main

**1. Committed text is silently lost when the route is reinstalled mid-composition.** `terminal-ime-composition-route.ts:85` calls `event.preventDefault()` *before* the `sessions.get(detail.id)` lookup on line 86 and the `if (!captured) return` on 87. The loss is explicit in the vendored xterm patch:

```js
this._dispatchCompositionSessionEvent(event);
prevented = event.defaultPrevented;
if (input.length > 0 && !prevented) {
  this._coreService.triggerDataEvent(input, true);   // skipped
}
```

Cancel without delivering and the committed CJK text is simply gone, with no user-visible signal.

**Reachability:** `installTerminalImeCompositionRoute` runs inside the connection effect (`pty-connection.ts:4230`), disposed by its cleanup (`:9471`). Any effect re-run mid-composition — reconnect, transport swap, StrictMode remount — disposes the route holding the session and installs a fresh one with an empty `sessions` map on the same terminal element.

**2. A deferred newline can be released by an unrelated composition.** Pending state is a bare count (`pendingCompositionCountByElement`, line 17), so an overlapping composition that starts *after* the defer satisfies the wait. `한` Enter `글` arrives as `한글\n`.

Severity split honestly: (1) is data loss and clearly worth fixing; (2) is ordering corruption, bounded by the 200 ms fallback and requiring overlapping compositions — milder, but it is what motivates the data-structure change.

## Proof it discriminates

Against unmodified `origin/main`:

```
× leaves an uncaptured session to xterm when installed mid-composition
× does not swallow a commit when the connection re-installs the route mid-composition
    AssertionError: expected false to be true
× does not let a composition started after the defer hold the newline
    AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
```

Restored, all 62 pass.

## What differs from the original PR

Their branch is stacked on **#11896, which is now closed**, and `terminal-ime-deferred-newline.ts` has since diverged on main (`fallbackMs: null` plus a disposer, from #12871 and STA-4476). A wholesale port would have regressed that. So this ports the two verified claims and leaves #11896's separate `maxIdleMs` re-arm work out.

One correction to the original rationale, recorded because it matters for anyone reading the diff: refcounts and a bare count are **numerically equivalent** for the plain "is anything pending" query. The refcount map is required for the *snapshot* query, and refcounts-over-a-Set matter only for overlapping-route ownership. The overlapping-route test passes on main too — it is kept as a design guard and is explicitly not one of the three discriminating cases.

## Reference check

A reference terminal implementation scopes preedit state **per surface/session**, never globally per view. Neither reference has runtime ownership arbitration, because both keep the composition-owning object structurally stable for the session's lifetime — one deliberately preserves its view across split rebuilds to avoid exactly this. That is a stronger guarantee than an ownership check, and it confirms the direction: per-session scoping is right, and Orca needs the explicit check precisely because its route *is* reinstallable. Both do conditionally suppress the default insert path, and one's own comments flag that suppression as a known soft spot — which is what bit us here.

## Verification

- `npm run typecheck` clean; oxlint, oxfmt clean; max-lines ratchet OK with no new bypasses
- **370 files / 3625 tests pass** in the terminal pane
- The three new cases proven to fail against unmodified main, quoted above

## Note on the original PR's CI

An earlier triage note of mine said CI had never run on that fork branch. That was wrong — PR Checks ran green on 2026-08-04. But it ran against a base so stale that Greptile bailed at 1422 changed files, so it carries no signal for current main. This run does.

## Unverified

No runtime or manual IME validation; correctness rests on the unit tests plus the xterm patch source.
