### PR TITLE
fix(ui): ignore IME composition Enter in the comment composer and replace field

### DIFF
--- a/src/renderer/src/components/editor/RichMarkdownSearchBar.ime-enter.test.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownSearchBar.ime-enter.test.tsx
@@ -1,0 +1,210 @@
+// @vitest-environment happy-dom
+
+import { act, createRef } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { RichMarkdownSearchBar } from './RichMarkdownSearchBar'
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+vi.mock('@/hooks/useShortcutLabel', () => ({
+  useOptionalShortcutLabel: () => null
+}))
+
+const QUERY = '배포'
+const REPLACEMENT = '릴리스'
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+})
+
+type BarSpies = {
+  onClose?: () => void
+  onMoveToMatch?: (direction: 1 | -1) => void
+  onReplaceCurrent?: () => void
+}
+
+function renderBar(spies: BarSpies): {
+  findInput: HTMLInputElement
+  replaceInput: HTMLInputElement
+} {
+  act(() => {
+    root.render(
+      <RichMarkdownSearchBar
+        activeMatchIndex={0}
+        isOpen
+        isReplaceMode
+        matchCase={false}
+        matchCount={2}
+        query={QUERY}
+        replaceQuery={REPLACEMENT}
+        replaceDisabled={false}
+        searchInputRef={createRef<HTMLInputElement>()}
+        wholeWord={false}
+        onClose={spies.onClose ?? vi.fn()}
+        onMoveToMatch={spies.onMoveToMatch ?? vi.fn()}
+        onQueryChange={vi.fn()}
+        onReplaceAll={vi.fn()}
+        onReplaceCurrent={spies.onReplaceCurrent ?? vi.fn()}
+        onReplaceQueryChange={vi.fn()}
+        onToggleMatchCase={vi.fn()}
+        onToggleReplaceMode={vi.fn()}
+        onToggleWholeWord={vi.fn()}
+      />
+    )
+  })
+  const inputs = [...container.querySelectorAll('input')]
+  // Why: match on value rather than order so a layout change fails loudly instead of
+  // silently pointing the assertions at the wrong field.
+  const findInput = inputs.find((candidate) => candidate.value === QUERY)
+  const replaceInput = inputs.find((candidate) => candidate.value === REPLACEMENT)
+  if (!findInput || !replaceInput) {
+    throw new Error('search bar fields not rendered')
+  }
+  return { findInput, replaceInput }
+}
+
+function pressKey(
+  input: HTMLInputElement,
+  key: string,
+  init?: KeyboardEventInit & { keyCode?: number }
+): void {
+  const event = new KeyboardEvent('keydown', {
+    key,
+    bubbles: true,
+    cancelable: true,
+    ...init
+  })
+  if (init?.keyCode !== undefined) {
+    Object.defineProperty(event, 'keyCode', { value: init.keyCode })
+  }
+  act(() => {
+    input.dispatchEvent(event)
+  })
+}
+
+describe('RichMarkdownSearchBar replace field IME guard', () => {
+  it('does not replace on the Enter that commits a CJK composition', () => {
+    const onReplaceCurrent = vi.fn()
+    const { replaceInput } = renderBar({ onReplaceCurrent })
+
+    pressKey(replaceInput, 'Enter', { isComposing: true })
+
+    expect(onReplaceCurrent).not.toHaveBeenCalled()
+  })
+
+  it('does not replace on an Enter the IME reports as keyCode 229', () => {
+    const onReplaceCurrent = vi.fn()
+    const { replaceInput } = renderBar({ onReplaceCurrent })
+
+    pressKey(replaceInput, 'Enter', { keyCode: 229 })
+
+    expect(onReplaceCurrent).not.toHaveBeenCalled()
+  })
+
+  it('does not close the bar on the Escape that cancels a composition', () => {
+    const onClose = vi.fn()
+    const { replaceInput } = renderBar({ onClose })
+
+    pressKey(replaceInput, 'Escape', { isComposing: true })
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('still replaces on a plain Enter', () => {
+    const onReplaceCurrent = vi.fn()
+    const { replaceInput } = renderBar({ onReplaceCurrent })
+
+    pressKey(replaceInput, 'Enter')
+
+    expect(onReplaceCurrent).toHaveBeenCalledTimes(1)
+  })
+
+  it('still closes the bar on a plain Escape', () => {
+    const onClose = vi.fn()
+    const { replaceInput } = renderBar({ onClose })
+
+    pressKey(replaceInput, 'Escape')
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('RichMarkdownSearchBar find field IME guard', () => {
+  it('does not move to the next match on the Enter that commits a composition', () => {
+    const onMoveToMatch = vi.fn()
+    const { findInput } = renderBar({ onMoveToMatch })
+
+    pressKey(findInput, 'Enter', { isComposing: true })
+
+    expect(onMoveToMatch).not.toHaveBeenCalled()
+  })
+
+  it('does not move to the previous match on a composing Shift+Enter', () => {
+    const onMoveToMatch = vi.fn()
+    const { findInput } = renderBar({ onMoveToMatch })
+
+    pressKey(findInput, 'Enter', { isComposing: true, shiftKey: true })
+
+    expect(onMoveToMatch).not.toHaveBeenCalled()
+  })
+
+  it('does not move on an Enter the IME reports as keyCode 229', () => {
+    const onMoveToMatch = vi.fn()
+    const { findInput } = renderBar({ onMoveToMatch })
+
+    pressKey(findInput, 'Enter', { keyCode: 229 })
+
+    expect(onMoveToMatch).not.toHaveBeenCalled()
+  })
+
+  it('does not close the bar on the Escape that cancels a composition', () => {
+    const onClose = vi.fn()
+    const { findInput } = renderBar({ onClose })
+
+    pressKey(findInput, 'Escape', { isComposing: true })
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('still moves to the next match on a plain Enter', () => {
+    const onMoveToMatch = vi.fn()
+    const { findInput } = renderBar({ onMoveToMatch })
+
+    pressKey(findInput, 'Enter')
+
+    expect(onMoveToMatch).toHaveBeenCalledWith(1)
+  })
+
+  it('still moves to the previous match on a plain Shift+Enter', () => {
+    const onMoveToMatch = vi.fn()
+    const { findInput } = renderBar({ onMoveToMatch })
+
+    pressKey(findInput, 'Enter', { shiftKey: true })
+
+    expect(onMoveToMatch).toHaveBeenCalledWith(-1)
+  })
+
+  it('still closes the bar on a plain Escape', () => {
+    const onClose = vi.fn()
+    const { findInput } = renderBar({ onClose })
+
+    pressKey(findInput, 'Escape')
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/editor/RichMarkdownSearchBar.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownSearchBar.tsx
@@ -12,6 +12,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { translate } from '@/i18n/i18n'
+import { isImeCompositionKeyDown } from '@/lib/ime-composition-keyboard-event'
 import { useOptionalShortcutLabel } from '@/hooks/useShortcutLabel'
 
 type RichMarkdownSearchBarProps = {
@@ -111,6 +112,12 @@ export function RichMarkdownSearchBar({
               value={query}
               onChange={(event) => onQueryChange(event.target.value)}
               onKeyDown={(event) => {
+                // Why: mid-composition Enter only confirms the candidate and Escape
+                // only cancels it, so navigating matches or closing the bar here acts
+                // on a keystroke that was aimed at the IME.
+                if (isImeCompositionKeyDown(event)) {
+                  return
+                }
                 if (event.key === 'Enter' && event.shiftKey) {
                   event.preventDefault()
                   onMoveToMatch(-1)
@@ -247,6 +254,12 @@ export function RichMarkdownSearchBar({
                 value={replaceQuery}
                 onChange={(event) => onReplaceQueryChange(event.target.value)}
                 onKeyDown={(event) => {
+                  // Why: replacing on the Enter that only confirms a candidate mutates
+                  // the document from a keystroke the user aimed at the IME; Escape
+                  // during composition belongs to the IME's cancel, not to the bar.
+                  if (isImeCompositionKeyDown(event)) {
+                    return
+                  }
                   if (event.key === 'Enter') {
                     event.preventDefault()
                     onReplaceCurrent()

--- a/src/renderer/src/components/right-sidebar/right-panel-comment-composer.ime-enter.test.tsx
+++ b/src/renderer/src/components/right-sidebar/right-panel-comment-composer.ime-enter.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { RightPanelCommentComposer } from './right-panel-comment-composer'
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+vi.mock('@/components/ShortcutKeyCombo', () => ({
+  ShortcutKeyCombo: () => <span />
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  TooltipTrigger: ({ children }: { children?: React.ReactNode }) => <>{children}</>
+}))
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  // Why: the composer picks its submit modifier off the user agent; pin the non-Mac
+  // branch so the test drives Ctrl+Enter regardless of the runner's platform.
+  vi.spyOn(window.navigator, 'userAgent', 'get').mockReturnValue('X11; Linux x86_64')
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+  vi.restoreAllMocks()
+})
+
+function renderComposer(onSubmit: () => Promise<{ ok: true }>): HTMLTextAreaElement {
+  act(() => {
+    root.render(
+      <RightPanelCommentComposer
+        placeholder="댓글을 입력하세요"
+        submitLabel="등록"
+        onSubmit={onSubmit}
+      />
+    )
+  })
+  const textarea = container.querySelector('textarea')
+  if (!textarea) {
+    throw new Error('comment textarea not rendered')
+  }
+  act(() => {
+    Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set?.call(
+      textarea,
+      '확인했습니다'
+    )
+    textarea.dispatchEvent(new Event('input', { bubbles: true }))
+  })
+  return textarea
+}
+
+function pressCtrlEnter(
+  textarea: HTMLTextAreaElement,
+  init?: KeyboardEventInit & { keyCode?: number }
+): void {
+  const event = new KeyboardEvent('keydown', {
+    key: 'Enter',
+    bubbles: true,
+    cancelable: true,
+    ctrlKey: true,
+    ...init
+  })
+  if (init?.keyCode !== undefined) {
+    Object.defineProperty(event, 'keyCode', { value: init.keyCode })
+  }
+  act(() => {
+    textarea.dispatchEvent(event)
+  })
+}
+
+describe('RightPanelCommentComposer IME Enter guard', () => {
+  it('does not submit on the Ctrl+Enter that commits a CJK composition', () => {
+    const onSubmit = vi.fn(async () => ({ ok: true }) as const)
+    const textarea = renderComposer(onSubmit)
+
+    pressCtrlEnter(textarea, { isComposing: true })
+
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('does not submit on a Ctrl+Enter the IME reports as keyCode 229', () => {
+    const onSubmit = vi.fn(async () => ({ ok: true }) as const)
+    const textarea = renderComposer(onSubmit)
+
+    pressCtrlEnter(textarea, { keyCode: 229 })
+
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('still submits on a plain Ctrl+Enter', () => {
+    const onSubmit = vi.fn(async () => ({ ok: true }) as const)
+    const textarea = renderComposer(onSubmit)
+
+    pressCtrlEnter(textarea)
+
+    expect(onSubmit).toHaveBeenCalledWith('확인했습니다')
+  })
+})

--- a/src/renderer/src/components/right-sidebar/right-panel-comment-composer.tsx
+++ b/src/renderer/src/components/right-sidebar/right-panel-comment-composer.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { ShortcutKeyCombo } from '@/components/ShortcutKeyCombo'
 import { cn } from '@/lib/utils'
+import { isImeCompositionKeyDown } from '@/lib/ime-composition-keyboard-event'
 import {
   getCommentBodySubmitState,
   hasBoundedCommentBodyText
@@ -171,6 +172,11 @@ export function RightPanelCommentComposer({
 
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      // Why: the Enter that only confirms a CJK candidate still reports the held
+      // modifier, so submitting here posts the comment without its last syllable.
+      if (isImeCompositionKeyDown(event)) {
+        return
+      }
       const modifierPressed = isMac ? event.metaKey : event.ctrlKey
       if (event.key === 'Enter' && modifierPressed) {
         event.preventDefault()


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​322 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​322 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 |

<!-- /orca-pr-loc -->

Ports @BaeTab's #11882 to current main with `Co-authored-by` credit. Production diff is **+19 lines across 2 files**.

## The bug

Pressing Enter to *confirm an IME candidate* also submits. A Korean, Japanese or Chinese user cannot finish composing a word in the comment composer or the find/replace field without the app acting on the keystroke that was meant for the IME.

Both targets are unguarded on current main:

- `right-panel-comment-composer.tsx:172-181` — goes straight to `if (event.key === 'Enter' && modifierPressed)`, no composition check
- `RichMarkdownSearchBar.tsx:113-128` (find) and `:249-259` (replace) — bare `event.key === 'Enter'` / `'Escape'`

The shared helper `ime-composition-keyboard-event.ts` has 8 call sites and covers neither of these. Unlike @BaeTab's sibling #11879 — which I closed because a refactor had already rescued it — nothing rescued this one.

## Why this is the right behaviour, not just a preference

W3C UI Events §3.6.5 mandates the exact shape being guarded:

> During the composition session, `keydown` and `keyup` events MUST still be sent, and these events MUST have the `isComposing` attribute set to `true`.

and its event table, row 5: **`keydown` / isComposing `true` / "This is the key event that exits the composition."** §7.3.1 supplies the legacy fallback the helper already implements — *"If an Input Method Editor is processing key input and the event is keydown, return 229."*

## The chorded-Enter question — there is no tension

I went in thinking main's helper deliberately lets a chorded Enter through as "the user aiming past the IME," which would conflict with this PR's Ctrl+Enter case. That was a misreading, and it is worth recording because the code is subtle:

- `ownsKeyDown` builds `markedEnter` from `(isComposing || composing) && (isPlainEnter || Enter/229 || Process/229)`, and `isPlainEnter` excludes only `shiftKey` — there is **no Ctrl/Meta/Alt exclusion**. A composing Ctrl+Enter *is* owned and suppressed. That is spec row 5, exactly this PR's case.
- The `hasChordModifier` early-return sits in the *second* branch, gated on `!isComposing` — the post-`compositionend` redispatch. Per §3.6.5 that event is genuinely outside the session, so treating it as the user's own submit is correct.

Main's own suite already pins this, comment included:

```ts
// The IME still owns the confirming keydown even with the modifier held.
expect(result.current.ownsKeyDown(
  gestureEvent({ key: 'Enter', keyCode: 13, isComposing: true, ...modifier })
)).toBe(true)
```

So the two helpers agree on the composing chorded Enter. This PR is consistent with main.

A mature editor corroborates: its single guard is a global `isComposing` context key that keybinding rules opt into, and its quick-input accept rule carries `not('isComposing')` on a binding whose secondary set expands to Alt/Ctrl/Cmd+Enter — chorded Enter suppressed identically to plain. The one place a chord slips through mid-composition is a gap in a surgical patch whose sibling rule five lines above *did* get the guard. Nothing anywhere combines `isComposing` with a modifier check to let chords through.

## Helper choice

Uses `isImeCompositionKeyDown`, matching @BaeTab and the 8 existing call sites. `useImeEnterGestureOwnership` is the wrong tool here: it needs `onKeyUp` and `compositionstart/end` wiring these components do not have, it does not handle Escape, and its phase-2 `preventDefault()` on a bare redispatched Enter would risk eating newlines in the composer's textarea — main already carries a regression test for that exact class of bug.

## Proof it discriminates

Production files restored from `origin/main`, tests kept:

```
× does not submit on the Ctrl+Enter that commits a CJK composition
× does not submit on a Ctrl+Enter the IME reports as keyCode 229
× does not replace on the Enter that commits a CJK composition
× does not replace on an Enter the IME reports as keyCode 229
× does not close the bar on the Escape that cancels a composition
× does not move to the next match on the Enter that commits a composition
× does not move to the previous match on a composing Shift+Enter
× does not move on an Enter the IME reports as keyCode 229
× does not close the bar on the Escape that cancels a composition

Tests  9 failed | 6 passed (15)
```

All 9 guard cases red, all 6 controls green. Restored: 15/15.

## Verification — CI had never run on the fork branch

- `npm run typecheck` clean across node, cli and web
- `components/editor` + `components/right-sidebar`: **378 files / 3009 tests pass**
- oxlint (incl. react-doctor config), oxfmt, max-lines ratchet, reliability gates (85), localization catalog and coverage — all clean

## Follow-up, deliberately not in scope

**Redispatch residual.** §3.6.5 models exactly one commit keydown, so a stateless check is spec-complete. But main's helper doc asserts real browsers redispatch a second *unmarked* `Enter`/13 after commit. If that happens in a plain React `<input>` — unconfirmed without a real IME — the find/replace fields, where bare Enter acts, would still fire on that second keydown. The composer is unaffected either way, since the redispatch carries no modifiers. Worth its own change with a real IME rather than widening this one.

@BaeTab's PR body also lists further unguarded Enter-submit handlers (Linear/GitHub Projects title fields, native-chat free-text answer, several pickers). Not touched here.
