### PR TITLE
fix(mobile): render pairing QR at scanner-safe scale

### DIFF
--- a/src/main/ipc/mobile.test.ts
+++ b/src/main/ipc/mobile.test.ts
@@ -15,6 +15,7 @@ vi.mock('electron', () => ({
 
 vi.mock('qrcode', () => ({
   default: {
+    create: vi.fn().mockReturnValue({ modules: { size: 21 } }),
     toDataURL: vi.fn().mockResolvedValue('data:image/png;base64,qr')
   }
 }))
@@ -344,6 +345,7 @@ describe('registerMobileHandlers', () => {
 
     await expect(handlers.get('mobile:getPairingQR')?.(null, {})).resolves.toMatchObject({
       available: true,
+      qrSize: 58,
       pairingUrl: 'orca://pair#mobile',
       endpoint: 'ws://100.102.47.57:6768',
       deviceId: 'mobile-1',
@@ -422,6 +424,7 @@ describe('registerMobileHandlers', () => {
     ).resolves.toEqual({
       available: true,
       qrDataUrl: null,
+      qrSize: null,
       qrError: 'encoding_failed',
       pairingUrl: 'orca://pair?code=copy-me',
       endpoint: 'wss://pair.example/oversized',

--- a/src/main/ipc/mobile.ts
+++ b/src/main/ipc/mobile.ts
@@ -132,6 +132,7 @@ export function registerMobileHandlers(
       return {
         available: true as const,
         qrDataUrl: qr.ok ? qr.qrDataUrl : null,
+        qrSize: qr.ok ? qr.qrSize : null,
         ...(!qr.ok ? { qrError: qr.reason } : {}),
         pairingUrl: offer.pairingUrl,
         // Why: with nothing advertised the offer's endpoint is the loopback fallback, which points at

--- a/src/main/runtime/mobile-pairing-qr.test.ts
+++ b/src/main/runtime/mobile-pairing-qr.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { PNG } from 'pngjs'
 import { encodePairingOffer } from '../../shared/pairing'
 import type { PairingOffer } from '../../shared/mobile-relay-pairing-offer'
 import { encodeMobilePairingQr } from './mobile-pairing-qr'
@@ -49,6 +50,30 @@ async function discoverEndpointBoundary(relay: boolean): Promise<number> {
 }
 
 describe('encodeMobilePairingQr', () => {
+  it('renders the current Relay-sized symbol at two pixels per module with a four-module quiet zone', async () => {
+    const { default: QRCode } = await import('qrcode')
+    const url = pairingUrl(100, true)
+    const moduleCount = QRCode.create(url, { errorCorrectionLevel: 'M' }).modules.size
+    expect(moduleCount).toBe(101)
+
+    const result = await encodeMobilePairingQr(url)
+    expect(result.ok).toBe(true)
+    if (!result.ok) {
+      return
+    }
+
+    const image = PNG.sync.read(Buffer.from(result.qrDataUrl.split(',')[1]!, 'base64'))
+    expect(result.qrSize).toBe(218)
+    expect(image.width).toBe(result.qrSize)
+    expect(image.height).toBe(result.qrSize)
+    expect(image.data.subarray((8 * image.width + 7) * 4, (8 * image.width + 8) * 4)).toEqual(
+      Buffer.from([255, 255, 255, 255])
+    )
+    expect(image.data.subarray((8 * image.width + 8) * 4, (8 * image.width + 9) * 4)).toEqual(
+      Buffer.from([0, 0, 0, 255])
+    )
+  })
+
   it.each([
     ['direct', false],
     ['relay', true]

--- a/src/main/runtime/mobile-pairing-qr.ts
+++ b/src/main/runtime/mobile-pairing-qr.ts
@@ -1,16 +1,21 @@
 export type MobilePairingQrResult =
-  | { ok: true; qrDataUrl: string }
+  | { ok: true; qrDataUrl: string; qrSize: number }
   | { ok: false; reason: 'encoding_failed' }
+
+const QUIET_ZONE_MODULES = 4
+const MODULE_PITCH_PX = 2
 
 export async function encodeMobilePairingQr(pairingUrl: string): Promise<MobilePairingQrResult> {
   try {
     const { default: QRCode } = await import('qrcode')
+    const qrCode = QRCode.create(pairingUrl, { errorCorrectionLevel: 'M' })
+    const qrSize = (qrCode.modules.size + QUIET_ZONE_MODULES * 2) * MODULE_PITCH_PX
     const qrDataUrl = await QRCode.toDataURL(pairingUrl, {
       errorCorrectionLevel: 'M',
-      margin: 2,
-      width: 256
+      margin: QUIET_ZONE_MODULES,
+      scale: MODULE_PITCH_PX
     })
-    return { ok: true, qrDataUrl }
+    return { ok: true, qrDataUrl, qrSize }
   } catch {
     return { ok: false, reason: 'encoding_failed' }
   }

--- a/src/preload/api/mobile-api.ts
+++ b/src/preload/api/mobile-api.ts
@@ -22,6 +22,8 @@ export type MobileApi = {
     | {
         available: true
         qrDataUrl: string | null
+        /** Natural bitmap width and height in pixels. */
+        qrSize: number | null
         qrError?: 'encoding_failed'
         pairingUrl: string
         /** Null when no direct address was advertised — the QR pairs over Relay alone. */

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4882,6 +4882,8 @@ const api = {
       | {
           available: true
           qrDataUrl: string | null
+          /** Natural bitmap width and height in pixels. */
+          qrSize: number | null
           qrError?: 'encoding_failed'
           pairingUrl: string
           /** Null when no direct address was advertised — the QR pairs over Relay alone. */

--- a/src/renderer/src/assets/mobile-page-qr-layout.test.ts
+++ b/src/renderer/src/assets/mobile-page-qr-layout.test.ts
@@ -4,8 +4,11 @@ import { describe, expect, it } from 'vitest'
 const mobilePageCss = fs.readFileSync(new URL('./mobile-page.css', import.meta.url), 'utf8')
 
 describe('mobile page QR grid layout (#9700)', () => {
-  it('defines a shared large-QR size token used by the box and grid tracks', () => {
+  it('defines separate install and adaptive pairing QR tracks', () => {
     expect(mobilePageCss).toMatch(/--mp-qr-large-size:\s*184px/)
+    expect(mobilePageCss).toMatch(
+      /--mp-pairing-qr-frame-size:\s*calc\(var\(--mp-pairing-qr-image-size\) \+ 20px\)/
+    )
     expect(mobilePageCss).toMatch(
       /\.mobile-page-root \.mp-qr-large\s*{[^}]*width:\s*var\(--mp-qr-large-size\)/s
     )
@@ -18,7 +21,7 @@ describe('mobile page QR grid layout (#9700)', () => {
       /\.mobile-page-root \.mp-step2-layout\s*{[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\)\s+var\(--mp-qr-large-size\)/s
     )
     expect(mobilePageCss).toMatch(
-      /\.mobile-page-root \.mp-pairing-layout\s*{[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\)\s+var\(--mp-qr-large-size\)/s
+      /\.mobile-page-root \.mp-pairing-layout\s*{[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\)\s+var\(--mp-pairing-qr-frame-size\)/s
     )
     expect(mobilePageCss).not.toMatch(
       /\.mobile-page-root \.mp-(?:step2|pairing)-layout\s*{[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\)\s+auto/s

--- a/src/renderer/src/assets/mobile-page.css
+++ b/src/renderer/src/assets/mobile-page.css
@@ -38,6 +38,8 @@
   --mp-flow-card-inset: calc(var(--mp-flow-card-padding) + var(--mp-flow-card-border-width));
   --mp-flow-shell-height: 400px;
   --mp-qr-large-size: 184px;
+  --mp-pairing-qr-image-size: 164px;
+  --mp-pairing-qr-frame-size: calc(var(--mp-pairing-qr-image-size) + 20px);
   --m-bg-base: #111111;
   --m-bg-panel: #1a1a1a;
   --m-bg-raised: #242424;
@@ -596,6 +598,17 @@
   height: calc(var(--mp-qr-large-size) - 20px);
 }
 
+.mobile-page-root .mp-pairing-qr .mp-qr-large {
+  width: var(--mp-pairing-qr-frame-size);
+  height: var(--mp-pairing-qr-frame-size);
+}
+
+.mobile-page-root .mp-pairing-qr .mp-qr-large img {
+  width: var(--mp-pairing-qr-image-size);
+  height: var(--mp-pairing-qr-image-size);
+  image-rendering: pixelated;
+}
+
 .mobile-page-root .mp-qr-refreshing {
   filter: blur(5px);
   opacity: 0.32;
@@ -686,7 +699,7 @@
 
 .mobile-page-root .mp-pairing-layout {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) var(--mp-qr-large-size);
+  grid-template-columns: minmax(0, 1fr) var(--mp-pairing-qr-frame-size);
   grid-template-areas:
     'copy qr'
     'relay qr'

--- a/src/renderer/src/components/mobile/MobileHero.test.tsx
+++ b/src/renderer/src/components/mobile/MobileHero.test.tsx
@@ -218,6 +218,15 @@ describe('HeroFlow height', () => {
     expect(screen.queryByTestId('relay-mint-failure-notice')).not.toBeInTheDocument()
   })
 
+  it('renders a pairing QR at its natural integer-scaled bitmap size', () => {
+    renderFlow(1, { pairQrDataUrl: 'data:image/png;base64,qr', pairQrSize: 218 })
+
+    const image = screen.getByRole('img', { name: 'Pairing QR' })
+    const layout = image.closest('.mp-pairing-layout') as HTMLElement
+    expect(layout.style.getPropertyValue('--mp-pairing-qr-image-size')).toBe('218px')
+    expect(layout.style.getPropertyValue('--mp-pairing-qr-frame-size')).toBe('238px')
+  })
+
   it('shows an encoder error while keeping the copy fallback enabled', () => {
     renderFlow(1, {
       pairingQrError: true,

--- a/src/renderer/src/components/mobile/MobileHero.tsx
+++ b/src/renderer/src/components/mobile/MobileHero.tsx
@@ -25,6 +25,7 @@ type HeroFlowProps = {
   onOpenInstallUrl: () => void
   onCopyInstallUrl: () => void
   pairQrDataUrl: string | null
+  pairQrSize?: number | null
   pairingUrl: string | null
   pairingQrError: boolean
   relayMintFailure: MobileRelayMintFailure | null
@@ -63,6 +64,7 @@ export function HeroFlow({
   onOpenInstallUrl,
   onCopyInstallUrl,
   pairQrDataUrl,
+  pairQrSize = null,
   pairingUrl,
   pairingQrError,
   relayMintFailure,
@@ -222,6 +224,7 @@ export function HeroFlow({
         >
           <MobileHeroPairingStep
             pairQrDataUrl={pairQrDataUrl}
+            pairQrSize={pairQrSize}
             pairingUrl={pairingUrl}
             pairingQrError={pairingQrError}
             relayMintFailure={relayMintFailure}

--- a/src/renderer/src/components/mobile/MobileHeroPairingStep.tsx
+++ b/src/renderer/src/components/mobile/MobileHeroPairingStep.tsx
@@ -58,6 +58,7 @@ function emptyPairingQrMessage(args: {
 
 export function MobileHeroPairingStep({
   pairQrDataUrl,
+  pairQrSize = null,
   pairingUrl,
   pairingQrError,
   relayMintFailure,
@@ -82,6 +83,7 @@ export function MobileHeroPairingStep({
   refreshingNetworkInterfaces
 }: {
   pairQrDataUrl: string | null
+  pairQrSize?: number | null
   pairingUrl: string | null
   pairingQrError: boolean
   relayMintFailure: MobileRelayMintFailure | null
@@ -105,6 +107,13 @@ export function MobileHeroPairingStep({
   onRefreshNetworkInterfaces: () => void
   refreshingNetworkInterfaces: boolean
 }): React.JSX.Element {
+  const pairingLayoutStyle =
+    pairQrSize == null
+      ? undefined
+      : ({
+          '--mp-pairing-qr-image-size': `${pairQrSize}px`,
+          '--mp-pairing-qr-frame-size': `${pairQrSize + 20}px`
+        } as React.CSSProperties)
   const copyPairingCodeRef = useRef<HTMLButtonElement | null>(null)
   const pairingWasReadyRef = useRef(pairingUrl != null && !pairLoading)
   const usingRelay = connectionMode === 'automatic'
@@ -169,7 +178,10 @@ export function MobileHeroPairingStep({
   )
 
   return (
-    <div className={cn('mp-pairing-layout', relayMintFailure != null && 'has-failure')}>
+    <div
+      className={cn('mp-pairing-layout', relayMintFailure != null && 'has-failure')}
+      style={pairingLayoutStyle}
+    >
       <div className="mp-step2-copy mp-pairing-copy">
         <div className="mp-eyebrow-row">
           <div className="mp-step-num">2</div>

--- a/src/renderer/src/components/mobile/MobilePage.test.tsx
+++ b/src/renderer/src/components/mobile/MobilePage.test.tsx
@@ -56,6 +56,7 @@ vi.mock('./MobilePageContent', () => ({
     beforeCustomAddressChange: (address: string) => Promise<boolean>
     handleContinue: () => void
     pairQrDataUrl: string | null
+    pairQrSize: number | null
     pairingUrl: string | null
     pairingQrError: boolean
     relayMintFailure: MobileRelayMintFailure | null
@@ -72,6 +73,7 @@ vi.mock('./MobilePageContent', () => ({
       <span data-testid="mode">{props.connectionMode}</span>
       <span data-testid="can-generate">{String(props.canGeneratePairing)}</span>
       <span data-testid="pairing-qr">{props.pairQrDataUrl ?? 'none'}</span>
+      <span data-testid="pairing-qr-size">{props.pairQrSize ?? 'none'}</span>
       <span data-testid="pairing-url">{props.pairingUrl ?? 'none'}</span>
       <span data-testid="pairing-qr-error">{String(props.pairingQrError)}</span>
       <span data-testid="relay-failure">{props.relayMintFailure?.stage ?? 'none'}</span>
@@ -132,6 +134,7 @@ describe('MobilePage pairing connection mode', () => {
     getPairingQR.mockReset().mockResolvedValue({
       available: true,
       qrDataUrl: 'data:image/png;base64,qr',
+      qrSize: 218,
       pairingUrl: 'orca://pair#automatic'
     })
     listNetworkInterfaces.mockReset().mockResolvedValue({ interfaces: [] })
@@ -171,6 +174,7 @@ describe('MobilePage pairing connection mode', () => {
 
     await waitFor(() => expect(getPairingQR).toHaveBeenCalledWith({ connectionMode: 'automatic' }))
     await waitFor(() => expect(screen.getByTestId('pairing-qr')).toHaveTextContent('base64,qr'))
+    expect(screen.getByTestId('pairing-qr-size')).toHaveTextContent('218')
     expect(screen.getByTestId('mode')).toHaveTextContent('automatic')
 
     let resolveRotatedLocalQr: ((value: Record<string, unknown>) => void) | undefined

--- a/src/renderer/src/components/mobile/MobilePage.tsx
+++ b/src/renderer/src/components/mobile/MobilePage.tsx
@@ -33,6 +33,7 @@ export default function MobilePage(): React.JSX.Element {
   const [iosChannel, setIosChannel] = useState<IosChannel>('preview')
 
   const [pairQrDataUrl, setPairQrDataUrl] = useState<string | null>(null)
+  const [pairQrSize, setPairQrSize] = useState<number | null>(null)
   const [pairingUrl, setPairingUrl] = useState<string | null>(null)
   const [pairingQrError, setPairingQrError] = useState(false)
   const [relayMintFailure, setRelayMintFailure] = useState<MobileRelayMintFailure | null>(null)
@@ -85,6 +86,7 @@ export default function MobilePage(): React.JSX.Element {
     hasGeneratedRef,
     pairingRequestIdRef,
     setPairQrDataUrl,
+    setPairQrSize,
     setPairingUrl,
     setPairingQrError,
     setPairLoading,
@@ -109,6 +111,7 @@ export default function MobilePage(): React.JSX.Element {
       pairingRequestIdRef.current += 1
       hasGeneratedRef.current = false
       setPairQrDataUrl(null)
+      setPairQrSize(null)
       setPairingUrl(null)
       setPairingQrError(false)
       setRelayMintFailure(null)
@@ -171,6 +174,7 @@ export default function MobilePage(): React.JSX.Element {
     hasGeneratedRef,
     pairingRequestIdRef,
     setPairQrDataUrl,
+    setPairQrSize,
     setPairingUrl,
     setPairingQrError,
     setPairLoading,
@@ -262,6 +266,7 @@ export default function MobilePage(): React.JSX.Element {
   const enterFlow = (): void => {
     hasGeneratedRef.current = false
     setPairQrDataUrl(null)
+    setPairQrSize(null)
     setPairingUrl(null)
     setPairingQrError(false)
     setRelayMintFailure(null)
@@ -273,6 +278,7 @@ export default function MobilePage(): React.JSX.Element {
   const pairAnotherDevice = (): void => {
     hasGeneratedRef.current = false
     setPairQrDataUrl(null)
+    setPairQrSize(null)
     setPairingUrl(null)
     setPairingQrError(false)
     setRelayMintFailure(null)
@@ -328,6 +334,7 @@ export default function MobilePage(): React.JSX.Element {
       connectionMode={connectionMode}
       handleConnectionModeChange={handleConnectionModeChange}
       pairQrDataUrl={pairQrDataUrl}
+      pairQrSize={pairQrSize}
       pairingUrl={pairingUrl}
       pairingQrError={pairingQrError}
       relayMintFailure={

--- a/src/renderer/src/components/mobile/MobilePageContent.tsx
+++ b/src/renderer/src/components/mobile/MobilePageContent.tsx
@@ -42,6 +42,7 @@ type MobilePageContentProps = {
   connectionMode: MobilePairingConnectionMode
   handleConnectionModeChange: (mode: MobilePairingConnectionMode) => void
   pairQrDataUrl: string | null
+  pairQrSize: number | null
   pairingUrl: string | null
   pairingQrError: boolean
   relayMintFailure: MobileRelayMintFailure | null
@@ -88,6 +89,7 @@ export function MobilePageContent({
   connectionMode,
   handleConnectionModeChange,
   pairQrDataUrl,
+  pairQrSize,
   pairingUrl,
   pairingQrError,
   relayMintFailure,
@@ -136,6 +138,7 @@ export function MobilePageContent({
               onOpenInstallUrl={openInstallUrl}
               onCopyInstallUrl={copyInstallUrl}
               pairQrDataUrl={pairQrDataUrl}
+              pairQrSize={pairQrSize}
               pairingUrl={pairingUrl}
               pairingQrError={pairingQrError}
               relayMintFailure={relayMintFailure}

--- a/src/renderer/src/components/mobile/use-mobile-pairing-generation.ts
+++ b/src/renderer/src/components/mobile/use-mobile-pairing-generation.ts
@@ -23,6 +23,7 @@ export function useMobilePairingGeneration(params: {
   hasGeneratedRef: MutableRef<boolean>
   pairingRequestIdRef: MutableRef<number>
   setPairQrDataUrl: (value: string | null) => void
+  setPairQrSize: (value: number | null) => void
   setPairingUrl: (value: string | null) => void
   setPairingQrError: (value: boolean) => void
   setPairLoading: (value: boolean) => void
@@ -42,6 +43,7 @@ export function useMobilePairingGeneration(params: {
     hasGeneratedRef,
     pairingRequestIdRef,
     setPairQrDataUrl,
+    setPairQrSize,
     setPairingUrl,
     setPairingQrError,
     setPairLoading,
@@ -76,6 +78,7 @@ export function useMobilePairingGeneration(params: {
         if (result.available) {
           if (mountedRef.current) {
             setPairQrDataUrl(result.qrDataUrl)
+            setPairQrSize(result.qrSize)
             setPairingUrl(result.pairingUrl)
             setPairingQrError(result.qrDataUrl === null)
             setRelayMintFailure(null)
@@ -84,6 +87,7 @@ export function useMobilePairingGeneration(params: {
           // Why: keep hasGenerated so step-2 auto-mint does not loop on failure.
           if (mountedRef.current) {
             setPairQrDataUrl(null)
+            setPairQrSize(null)
             setPairingUrl(null)
             setPairingQrError(false)
             if (result.reason === 'relay_mint_failed' && result.relayFailure) {
@@ -106,6 +110,7 @@ export function useMobilePairingGeneration(params: {
         if (mountedRef.current && requestId === pairingRequestIdRef.current) {
           hasGeneratedRef.current = false
           setPairQrDataUrl(null)
+          setPairQrSize(null)
           setPairingUrl(null)
           setPairingQrError(false)
           setRelayMintFailure(null)
@@ -130,6 +135,7 @@ export function useMobilePairingGeneration(params: {
       selectedAddress,
       setPairLoading,
       setPairQrDataUrl,
+      setPairQrSize,
       setPairingUrl,
       setPairingQrError,
       setRelayMintFailure,

--- a/src/renderer/src/components/mobile/use-mobile-pairing-qr-invalidation.ts
+++ b/src/renderer/src/components/mobile/use-mobile-pairing-qr-invalidation.ts
@@ -20,6 +20,7 @@ export function useMobilePairingQrInvalidation(params: {
   hasGeneratedRef: MutableRef<boolean>
   pairingRequestIdRef: MutableRef<number>
   setPairQrDataUrl: (value: string | null) => void
+  setPairQrSize: (value: number | null) => void
   setPairingUrl: (value: string | null) => void
   setPairingQrError: (value: boolean) => void
   setPairLoading: (value: boolean) => void
@@ -33,6 +34,7 @@ export function useMobilePairingQrInvalidation(params: {
     hasGeneratedRef,
     pairingRequestIdRef,
     setPairQrDataUrl,
+    setPairQrSize,
     setPairingUrl,
     setPairingQrError,
     setPairLoading,
@@ -59,6 +61,7 @@ export function useMobilePairingQrInvalidation(params: {
     setPairingUrl(null)
     setPairingQrError(false)
     setPairQrDataUrl(null)
+    setPairQrSize(null)
     setRelayMintFailure?.(null)
     if (signedIn && canMintMobilePairingOffer({ connectionMode, signedIn })) {
       // Why: rotate on the sign-in edge — the token behind the QR cleared at
@@ -73,6 +76,7 @@ export function useMobilePairingQrInvalidation(params: {
     hasGeneratedRef,
     pairingRequestIdRef,
     setPairQrDataUrl,
+    setPairQrSize,
     setPairingUrl,
     setPairingQrError,
     setPairLoading,
@@ -97,6 +101,7 @@ export function useMobilePairingQrInvalidation(params: {
     setPairingUrl(null)
     setPairingQrError(false)
     setPairQrDataUrl(null)
+    setPairQrSize(null)
     setRelayMintFailure?.(null)
     if (shouldRegenerate && canMintMobilePairingOffer({ connectionMode, signedIn })) {
       // Why: no rotate here — the main process rotates exactly once when the
@@ -115,6 +120,7 @@ export function useMobilePairingQrInvalidation(params: {
     hasGeneratedRef,
     pairingRequestIdRef,
     setPairQrDataUrl,
+    setPairQrSize,
     setPairingUrl,
     setPairingQrError,
     setPairLoading,

--- a/src/renderer/src/components/settings/MobilePairingQrSection.test.tsx
+++ b/src/renderer/src/components/settings/MobilePairingQrSection.test.tsx
@@ -98,4 +98,28 @@ describe('MobilePairingQrSection', () => {
 
     expect(persistentAction).toHaveFocus()
   })
+
+  it('keeps the QR on integer CSS scaling at normal and enlarged sizes', () => {
+    render(
+      <MobilePairingQrSection
+        qrDataUrl="data:image/png;base64,qr"
+        qrSize={218}
+        qrError={false}
+        pairingUrl="orca://pair#ready"
+        endpoint={null}
+        qrEnlarged
+        codeCopied={false}
+        onQrEnlargedChange={vi.fn()}
+        onCodeCopiedChange={vi.fn()}
+        onClearCodeCopiedTimer={vi.fn()}
+      />
+    )
+
+    const images = Array.from(
+      document.querySelectorAll<HTMLImageElement>('img[alt="QR Code for mobile pairing"]')
+    )
+    expect(images.map((image) => image.style.width).sort()).toEqual(['218px', '436px'])
+    expect(images.map((image) => image.style.height).sort()).toEqual(['218px', '436px'])
+    expect(images.every((image) => image.style.imageRendering === 'pixelated')).toBe(true)
+  })
 })

--- a/src/renderer/src/components/settings/MobilePairingQrSection.tsx
+++ b/src/renderer/src/components/settings/MobilePairingQrSection.tsx
@@ -7,6 +7,7 @@ import { translate } from '@/i18n/i18n'
 
 type MobilePairingQrSectionProps = {
   qrDataUrl: string | null
+  qrSize?: number | null
   qrError: boolean
   pairingUrl: string | null
   endpoint: string | null
@@ -19,6 +20,7 @@ type MobilePairingQrSectionProps = {
 
 export function MobilePairingQrSection({
   qrDataUrl,
+  qrSize = null,
   qrError,
   pairingUrl,
   endpoint,
@@ -28,6 +30,8 @@ export function MobilePairingQrSection({
   onCodeCopiedChange,
   onClearCodeCopiedTimer
 }: MobilePairingQrSectionProps): React.JSX.Element | null {
+  const renderedQrSize = qrSize ?? 192
+  const enlargedQrSize = qrSize == null ? 288 : qrSize * 2
   const pairingCodeButtonMountedRef = useRef(false)
   const pairingCodeButtonRef = useRef<HTMLButtonElement | null>(null)
   const hadPairingUrlRef = useRef(pairingUrl != null)
@@ -102,7 +106,12 @@ export function MobilePairingQrSection({
                 'auto.components.settings.MobilePane.6436e56546',
                 'QR Code for mobile pairing'
               )}
-              className="size-48"
+              className="block"
+              style={{
+                width: renderedQrSize,
+                height: renderedQrSize,
+                imageRendering: 'pixelated'
+              }}
             />
             <Maximize2 className="absolute top-1.5 right-1.5 size-3 text-black/30 can-hover:opacity-0 transition-opacity group-hover:opacity-100" />
           </button>
@@ -158,7 +167,7 @@ export function MobilePairingQrSection({
 
       {qrDataUrl ? (
         <Dialog open={qrEnlarged} onOpenChange={onQrEnlargedChange}>
-          <DialogContent className="sm:max-w-sm">
+          <DialogContent className="sm:max-w-lg">
             <DialogHeader>
               <DialogTitle>
                 {translate(
@@ -175,7 +184,12 @@ export function MobilePairingQrSection({
                     'auto.components.settings.MobilePane.6436e56546',
                     'QR Code for mobile pairing'
                   )}
-                  className="size-72"
+                  className="block"
+                  style={{
+                    width: enlargedQrSize,
+                    height: enlargedQrSize,
+                    imageRendering: 'pixelated'
+                  }}
                 />
               </div>
               {endpoint && (

--- a/src/renderer/src/components/settings/MobilePane.tsx
+++ b/src/renderer/src/components/settings/MobilePane.tsx
@@ -31,6 +31,7 @@ export function MobilePane(): React.JSX.Element {
   const autoRestoreFitMs = useAppStore((s) => s.settings?.mobileAutoRestoreFitMs ?? null)
   const updateSettings = useAppStore((s) => s.updateSettings)
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null)
+  const [qrSize, setQrSize] = useState<number | null>(null)
   const [pairingUrl, setPairingUrl] = useState<string | null>(null)
   const [qrError, setQrError] = useState(false)
   const [relayMintFailure, setRelayMintFailure] = useState<MobileRelayMintFailure | null>(null)
@@ -81,6 +82,7 @@ export function MobilePane(): React.JSX.Element {
     pairingRequestIdRef.current += 1
     const hadPending = qrDisplayedRef.current || loadingRef.current
     setQrDataUrl(null)
+    setQrSize(null)
     setPairingUrl(null)
     setQrError(false)
     setRelayMintFailure(null)
@@ -197,6 +199,7 @@ export function MobilePane(): React.JSX.Element {
           useAppStore.getState().recordFeatureInteraction('mobile-pairing')
           if (mountedRef.current) {
             setQrDataUrl(result.qrDataUrl)
+            setQrSize(result.qrSize)
             setPairingUrl(result.pairingUrl)
             setQrError(result.qrDataUrl === null)
             setRelayMintFailure(null)
@@ -209,6 +212,7 @@ export function MobilePane(): React.JSX.Element {
           }
         } else if (mountedRef.current) {
           setQrDataUrl(null)
+          setQrSize(null)
           setPairingUrl(null)
           setQrError(false)
           setEndpoint(null)
@@ -432,6 +436,7 @@ export function MobilePane(): React.JSX.Element {
 
       <MobilePairingQrSection
         qrDataUrl={qrDataUrl}
+        qrSize={qrSize}
         qrError={qrError}
         pairingUrl={pairingUrl}
         endpoint={endpoint}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​70 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​68 |
| Prod | 13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​88 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​79 |

<!-- /orca-pr-loc -->

## ELI5

Long Relay pairing links produce a very dense QR. Orca was shrinking that QR to a non-integer pixel grid, which blurred module edges enough that Android ML Kit could emit no barcode callback. Render each QR module on an exact pixel grid with a standards-sized quiet zone, and keep that natural size through Electron.

## What Changed

- Generate pairing QR codes with a four-module quiet zone and a two-pixel integer module pitch.
- Derive the PNG size from the actual QR version instead of forcing every payload into 256 px.
- Propagate the natural bitmap size through main IPC and preload to both Mobile Pairing surfaces.
- Render desktop and Settings QR images without fractional resampling; Settings enlargement uses an exact 2x scale.
- Size the Mobile Pairing frame and grid track from the generated QR so dense Relay symbols are not clipped.
- Add coverage for QR geometry, IPC shape, renderer sizing, state reset, and Settings enlargement.

The pairing URI, copied manual code, Android parser, and transport behavior are unchanged.

## Why

The current Relay offer is about 696 characters and encodes as QR version 21 (101 modules). Previously Orca generated a 256 px bitmap with a two-module margin, then Chromium displayed it at 164 CSS px. That yielded about 1.56 CSS pixels per module with fractional resampling. In the Android CameraX/ML Kit path, the controlled old rendering produced no barcode callback.

The same symbol now renders as 218 x 218 px: `(101 + 4 + 4) * 2`. This preserves crisp module boundaries and a standards-sized quiet zone while remaining compact. Shorter direct offers size naturally (162 px in the validated fixture).

## Linked Issue

No exact existing issue was found, and no new issue was created as part of this investigation.

- #8371 / STA-1680: distinct; scan succeeded and the WebSocket later timed out.
- #4391: distinct; the URI was rejected locally and manual entry failed too.
- #10727 / STA-2654: related pairing guidance, not scanner recognition.
- STA-3392, STA-3988, and #13174: distinct post-scan Relay rotation/recovery lifecycle.
- STA-2461: distinct; QR generation was absent for some users.

## Visual Proof

The QR payloads in all proof are synthetic controlled fixtures, not live pairing credentials.

| Controlled old geometry | Fixed geometry |
| --- | --- |
| ![Controlled old 164 px QR rendering](https://github.com/user-attachments/assets/b4d0a26b-375c-4287-a04a-9cd0c0ee8b2f) | ![Fixed 218 px integer-scaled QR rendering](https://github.com/user-attachments/assets/aeedc6cb-edd7-4d64-8164-0df82aaed382) |

Light theme:

![Fixed QR rendering in light theme](https://github.com/user-attachments/assets/060ada12-88df-4653-96f4-4c7a7c4c3ca1)

Android scanner callback parsed the synthetic offer and reached transport (`Connecting...`); the intentionally fake endpoint then failed as expected:

![Android emulator after QR scan callback and parsing](https://github.com/user-attachments/assets/f281966d-91ea-4b47-b3ee-22833d5f3efa)

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- `pnpm test`: 5,796 files passed, 53,964 tests passed; 34 files / 170 tests skipped.
- `pnpm lint`
- `pnpm typecheck`
- `pnpm run check:code-quality:changed`
- `pnpm build`
- Focused mobile QR suite: 7 files, 106 tests.
- Changed-file `oxfmt --check` and `git diff --check`.
- Offline decode: ZXing-C++/WASM and Apple Vision decoded the 218 px source and rendered fixtures.
- Electron CDP on macOS: intended worktree identity verified; direct QR 162/162 px, Relay QR 218/218 px with a 238 px unclipped frame; dark/light themes; Settings 162/324 px at 1x/2x.
- Android CameraX/ML Kit scanner path: Pixel 9 Pro AVD, Android 16 / API 36, Orca Mobile 0.0.44 (versionCode 13); camera permission granted; the 218 px synthetic Relay fixture emitted a callback, parsed, and reached `Connecting...`.

The Android result exercises the app's real CameraX/ML Kit callback/parser path on an emulator, not a physical camera. A physical Android scan remains the final field confirmation.

## Review

Please focus on the generated-size contract through IPC and the two rendering surfaces. Payload encoding and pairing transport are intentionally out of scope.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- Security: no pairing credential format, persistence, or logging changes.
- Cross-platform: sizing is DOM/CSS and QR-library behavior shared by macOS, Windows, and Linux; no platform branch added.
- SSH/folder workspaces: pairing offer generation and wire content are unchanged.
- Compatibility: main, preload, and renderer ship together; failed QR encoding retains the manual-code fallback.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
