### PR TITLE
fix(gpu): make the software-rendering rescue reachable across launches

### DIFF
--- a/src/main/crash-reporting/gpu-crash-fallback-across-launches.test.ts
+++ b/src/main/crash-reporting/gpu-crash-fallback-across-launches.test.ts
@@ -128,27 +128,22 @@ function runLaunch(
       const result = tracker.recordGpuCrash(crashAtMsSinceLaunch + crash)
       crashesInWindow = result.crashesInWindow
       if (result.shouldEngageFallback && inSessionPromptDecision !== 'restart') {
-        // index.ts: a decline over startup crashes refuses the cross-launch conclusion itself;
-        // over a mid-session burst it answers for this launch only.
-        if (gpuCrashedDuringStartup) {
-          clearGpuCrashHistory(userDataPath)
-        } else {
-          forgetGpuCrashLaunch(userDataPath, launchId)
-        }
+        // index.ts: declining answers for this launch only.
+        forgetGpuCrashLaunch(userDataPath, launchId)
         break
       }
     }
   }
   // index.ts arms this on ready-to-show and resolves it 60s later.
   if (survivesAMinutePastReadyToShow) {
-    const action = resolveGpuCrashHistoryReset({
+    const reset = resolveGpuCrashHistoryReset({
       gpuCrashedDuringStartup,
       gpuFallbackActive: decision.engage
     })
-    if (action === 'forget-this-launch') {
+    if (reset.forgetThisLaunch) {
       forgetGpuCrashLaunch(userDataPath, launchId)
-    } else if (action === 'clear-all') {
-      clearGpuCrashHistory(userDataPath)
+    }
+    if (reset.clearSupersededMarker) {
       clearSupersededGpuFallbackMarker(userDataPath, WINDOWS_ENVIRONMENT)
     }
   }
@@ -243,8 +238,11 @@ describe('GPU crash fallback across app launches', () => {
     expect(later.breadcrumbs[0]?.data?.source).toBe('marker')
   })
 
-  // Why: a launch that reached the window and survived a minute proves the driver works today.
-  it('resets after a successful launch: 2 crashes, 1 success, 2 crashes must not engage', () => {
+  // Why: the launch is the unit of evidence, so a launch that reached the window drops its own
+  // entry and nothing else. Four launches that really did die before any window existed are four
+  // dead launches inside ten minutes, whether or not a good one happened between them; the
+  // wall-clock horizon is what stops evidence accumulating, not a passing launch's veto.
+  it('does not let a launch that booted erase the launches that died at startup', () => {
     runCrashingLaunch(userDataPath, 0, startedAt)
     runCrashingLaunch(userDataPath, 1, startedAt + 10_000)
     runLaunch(userDataPath, {
@@ -253,17 +251,21 @@ describe('GPU crash fallback across app launches', () => {
       crashAtMsSinceLaunch: null,
       survivesAMinutePastReadyToShow: true
     })
+
+    expect(
+      readActiveGpuCrashHistory(userDataPath, WINDOWS_ENVIRONMENT).map((crash) => crash.launchId)
+    ).toEqual(['launch-0', 'launch-1'])
     const outcomes = [
       runCrashingLaunch(userDataPath, 2, startedAt + 5 * MINUTE_MS),
       runCrashingLaunch(userDataPath, 3, startedAt + 6 * MINUTE_MS)
     ]
 
-    expect(outcomes.map((outcome) => outcome.softwareRendering)).toEqual([false, false])
-    expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(false)
+    expect(outcomes.map((outcome) => outcome.softwareRendering)).toEqual([false, true])
   })
 
   // Why: the modal promises "Keep Running leaves graphics settings unchanged", so the silent
-  // cross-launch path must not impose on the next boot exactly what was just refused.
+  // cross-launch path must not impose on the next boot exactly what was just refused — for the
+  // launch that raised it. The launches that died before any window existed were never on trial.
   it('does not override an explicit decline of the in-session prompt', () => {
     runCrashingLaunch(userDataPath, 0, startedAt)
     runCrashingLaunch(userDataPath, 1, startedAt + 10_000)
@@ -279,6 +281,9 @@ describe('GPU crash fallback across app launches', () => {
     expect(declined.crashesInWindow).toBe(DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD)
     expect(next.softwareRendering).toBe(false)
     expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(false)
+    expect(
+      readActiveGpuCrashHistory(userDataPath, WINDOWS_ENVIRONMENT).map((crash) => crash.launchId)
+    ).toEqual(['launch-0', 'launch-1', 'launch-3'])
   })
 
   // Why: without a wall-clock horizon, ordinary background churn would eventually

--- a/src/main/crash-reporting/gpu-crash-fallback-across-launches.test.ts
+++ b/src/main/crash-reporting/gpu-crash-fallback-across-launches.test.ts
@@ -144,7 +144,7 @@ function runLaunch(
       forgetGpuCrashLaunch(userDataPath, launchId)
     }
     if (reset.clearSupersededMarker) {
-      clearSupersededGpuFallbackMarker(userDataPath, WINDOWS_ENVIRONMENT)
+      clearSupersededGpuFallbackMarker(userDataPath, WINDOWS_ENVIRONMENT, nowEpochMs)
     }
   }
   return {
@@ -376,6 +376,23 @@ describe('GPU crash fallback across app launches', () => {
     expect(fresh.softwareRendering).toBe(false)
     expect(rescue.softwareRendering).toBe(true)
     expect(rescue.breadcrumbs[0]?.data?.source).toBe('crash-history-after-update')
+  })
+
+  // Why: nothing else ever expires that record — its reaper needs a launch that survives a
+  // minute, which a machine used in short bursts never provides. A driver generation later it
+  // would still be turning one spurious startup GPU death into a build-long downgrade.
+  it('ignores a superseded-build record from months ago', () => {
+    writeGpuFallbackMarker(
+      userDataPath,
+      { engagedAt: startedAt - 13 * WEEK_MS, crashesInWindow: 3 },
+      { ...WINDOWS_ENVIRONMENT, appVersion: '1.4.183' }
+    )
+
+    const spurious = runCrashingLaunch(userDataPath, 0, startedAt)
+    const next = runCrashingLaunch(userDataPath, 1, startedAt + 10_000)
+
+    expect([spurious.softwareRendering, next.softwareRendering]).toEqual([false, false])
+    expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(false)
   })
 
   // Why: the previous build's head start is spent the moment this build proves it boots.

--- a/src/main/crash-reporting/gpu-crash-fallback-across-launches.test.ts
+++ b/src/main/crash-reporting/gpu-crash-fallback-across-launches.test.ts
@@ -1,0 +1,441 @@
+import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD,
+  DEFAULT_GPU_CRASH_FALLBACK_WINDOW_MS,
+  GpuCrashFallbackTracker
+} from './gpu-crash-fallback-decision'
+import {
+  promptForGpuFallbackRestart,
+  type GpuFallbackRestartDecision
+} from './gpu-fallback-restart-prompt'
+import {
+  GPU_CRASH_STARTUP_WINDOW_MS,
+  clearGpuCrashHistory,
+  forgetGpuCrashLaunch,
+  readActiveGpuCrashHistory,
+  recordGpuCrashInHistory,
+  type GpuCrashHistoryEntry
+} from '../startup/gpu-crash-history'
+import { resolveGpuCrashHistoryReset } from '../startup/gpu-fallback-launch-decision'
+import { engageGpuFallbackForLaunch } from '../startup/gpu-fallback-launch-engagement'
+import {
+  GPU_FALLBACK_MARKER_FILE,
+  clearGpuFallbackMarker,
+  clearSupersededGpuFallbackMarker,
+  writeGpuFallbackMarker,
+  type WindowsGpuFallbackEnvironment
+} from '../startup/gpu-fallback-marker'
+
+vi.mock('./gpu-fallback-restart-prompt', () => ({ promptForGpuFallbackRestart: vi.fn() }))
+
+/**
+ * Regression for the 2026-08-16 Windows crash cluster (reports 1cf806c8,
+ * 64e9f2a7, 8ae2b56f, af537a89, b566e1e0, e3e21dc6 — all 1.4.184 / Electron
+ * 43.1.0 / Windows 10.0.26200).
+ *
+ * Field shape: the GPU child dies with STATUS_BREAKPOINT (-2147483645) ~580ms
+ * after main_process_lifecycle_started and the launch is over. Across the six
+ * diagnostics bundles every reconstructed launch recorded exactly ONE GPU crash
+ * — never two, never three — so `GpuCrashFallbackTracker`, which needs
+ * `threshold` crashes inside one process lifetime, could never fire and
+ * gpu-fallback.json was structurally unwritable.
+ *
+ * The fix persists the evidence, so the rescue is driven across launches.
+ */
+
+const WINDOWS_ENVIRONMENT: WindowsGpuFallbackEnvironment = {
+  appVersion: '1.4.184',
+  electronVersion: '43.1.0',
+  platform: 'win32'
+}
+
+// Offset of the GPU `process_gone_suppressed` breadcrumb from
+// `main_process_lifecycle_started` in report 1cf806c8 (bundle fH9VHOQk).
+const INCIDENT_GPU_CRASH_MS = 581
+const MINUTE_MS = 60_000
+const WEEK_MS = 7 * 24 * 60 * MINUTE_MS
+
+type LaunchOutcome = {
+  /** Did startup boot without hardware acceleration? */
+  softwareRendering: boolean
+  /** Crashes the in-process tracker held when this launch died. */
+  crashesInWindow: number
+  breadcrumbs: { name: string; data?: Record<string, unknown> }[]
+  disableHardwareAccelerationCalls: number
+}
+
+/**
+ * One full app launch, wired exactly like index.ts:
+ * maybeApplyGpuFallbackForThisLaunch() -> fresh tracker -> handleGpuChildCrash()
+ * -> ready-to-show arms the reset, which resolves what it may drop when it fires.
+ * Everything the tracker held is gone when this returns.
+ */
+function runLaunch(
+  userDataPath: string,
+  {
+    launchId,
+    nowEpochMs,
+    crashAtMsSinceLaunch,
+    inSessionCrashes = 1,
+    inSessionPromptDecision = 'restart',
+    survivesAMinutePastReadyToShow = false
+  }: {
+    launchId: string
+    nowEpochMs: number
+    crashAtMsSinceLaunch: number | null
+    /** GPU deaths inside this one process; the in-session tracker only fires at 3. */
+    inSessionCrashes?: number
+    /** Answer to the in-session modal, once the tracker reaches its threshold. */
+    inSessionPromptDecision?: GpuFallbackRestartDecision
+    /** Chromium respawns a dead GPU child, so even a crashing launch can paint and live on. */
+    survivesAMinutePastReadyToShow?: boolean
+  }
+): LaunchOutcome {
+  const breadcrumbs: LaunchOutcome['breadcrumbs'] = []
+  let disableHardwareAccelerationCalls = 0
+  const decision = engageGpuFallbackForLaunch({
+    userDataPath,
+    environment: WINDOWS_ENVIRONMENT,
+    nowEpochMs,
+    hooks: {
+      disableHardwareAcceleration: () => {
+        disableHardwareAccelerationCalls += 1
+      },
+      commandLine: { appendSwitch: () => {} },
+      recordBreadcrumb: (name, data) => breadcrumbs.push({ name, data })
+    }
+  })
+  const tracker = new GpuCrashFallbackTracker({
+    windowMs: DEFAULT_GPU_CRASH_FALLBACK_WINDOW_MS,
+    threshold: DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD
+  })
+  // Why: software rendering leaves no GPU child, so it cannot die.
+  const gpuCrashed = !decision.engage && crashAtMsSinceLaunch !== null
+  let gpuCrashedDuringStartup = false
+  let crashesInWindow = 0
+  if (gpuCrashed && crashAtMsSinceLaunch !== null) {
+    for (let crash = 0; crash < inSessionCrashes; crash += 1) {
+      const entry: GpuCrashHistoryEntry = {
+        atEpochMs: nowEpochMs + crashAtMsSinceLaunch + crash,
+        msSinceLaunch: crashAtMsSinceLaunch + crash,
+        launchId
+      }
+      gpuCrashedDuringStartup ||= entry.msSinceLaunch <= GPU_CRASH_STARTUP_WINDOW_MS
+      recordGpuCrashInHistory(userDataPath, entry, WINDOWS_ENVIRONMENT)
+      const result = tracker.recordGpuCrash(crashAtMsSinceLaunch + crash)
+      crashesInWindow = result.crashesInWindow
+      if (result.shouldEngageFallback && inSessionPromptDecision !== 'restart') {
+        // index.ts: a decline over startup crashes refuses the cross-launch conclusion itself;
+        // over a mid-session burst it answers for this launch only.
+        if (gpuCrashedDuringStartup) {
+          clearGpuCrashHistory(userDataPath)
+        } else {
+          forgetGpuCrashLaunch(userDataPath, launchId)
+        }
+        break
+      }
+    }
+  }
+  // index.ts arms this on ready-to-show and resolves it 60s later.
+  if (survivesAMinutePastReadyToShow) {
+    const action = resolveGpuCrashHistoryReset({
+      gpuCrashedDuringStartup,
+      gpuFallbackActive: decision.engage
+    })
+    if (action === 'forget-this-launch') {
+      forgetGpuCrashLaunch(userDataPath, launchId)
+    } else if (action === 'clear-all') {
+      clearGpuCrashHistory(userDataPath)
+      clearSupersededGpuFallbackMarker(userDataPath, WINDOWS_ENVIRONMENT)
+    }
+  }
+  return {
+    softwareRendering: decision.engage,
+    crashesInWindow,
+    breadcrumbs,
+    disableHardwareAccelerationCalls
+  }
+}
+
+function runCrashingLaunch(userDataPath: string, index: number, startedAt: number): LaunchOutcome {
+  return runLaunch(userDataPath, {
+    launchId: `launch-${index}`,
+    nowEpochMs: startedAt,
+    crashAtMsSinceLaunch: INCIDENT_GPU_CRASH_MS
+  })
+}
+
+describe('GPU crash fallback across app launches', () => {
+  let userDataPath: string
+  const startedAt = 1_760_000_000_000
+
+  beforeEach(() => {
+    userDataPath = mkdtempSync(join(tmpdir(), 'orca-gpu-fallback-'))
+  })
+
+  afterEach(() => {
+    rmSync(userDataPath, { recursive: true, force: true })
+  })
+
+  // Why: the pinned [1,1,1,1,1,1] distribution from the six bundles IS the defect —
+  // the in-session tracker is fed once per process and forgets. Any fix that still
+  // needs a launch to reach two crashes is wrong for this failure mode.
+  it('reproduces the field data: the in-session tracker tops out at one crash per launch', () => {
+    const perLaunchCounts = Array.from({ length: 6 }, () => {
+      const tracker = new GpuCrashFallbackTracker({
+        windowMs: DEFAULT_GPU_CRASH_FALLBACK_WINDOW_MS,
+        threshold: DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD
+      })
+      return tracker.recordGpuCrash(INCIDENT_GPU_CRASH_MS).crashesInWindow
+    })
+
+    expect(perLaunchCounts).toEqual([1, 1, 1, 1, 1, 1])
+    expect(perLaunchCounts.some((count) => count >= DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD)).toBe(
+      false
+    )
+  })
+
+  it('engages software rendering on the launch after the third crash-at-startup', () => {
+    const outcomes = Array.from({ length: 4 }, (_, index) =>
+      runCrashingLaunch(userDataPath, index, startedAt + index * 10_000)
+    )
+
+    expect(outcomes.map((outcome) => outcome.softwareRendering)).toEqual([
+      false,
+      false,
+      false,
+      true
+    ])
+  })
+
+  it('engages with no window: no restart prompt, marker written, breadcrumb emitted', () => {
+    for (let index = 0; index < 3; index += 1) {
+      runCrashingLaunch(userDataPath, index, startedAt + index * 10_000)
+    }
+    const rescue = runCrashingLaunch(userDataPath, 3, startedAt + 30_000)
+
+    expect(rescue.disableHardwareAccelerationCalls).toBe(1)
+    expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(true)
+    expect(rescue.breadcrumbs).toEqual([
+      {
+        name: 'gpu_fallback_applied',
+        data: {
+          source: 'crash-history',
+          crashesInWindow: 3,
+          switches: 'disable-gpu,disable-software-rasterizer,in-process-gpu'
+        }
+      }
+    ])
+    // Why: this path runs before whenReady — there is no window to park a modal on.
+    expect(promptForGpuFallbackRestart).not.toHaveBeenCalled()
+  })
+
+  it('stays in software rendering on later launches without re-deriving the decision', () => {
+    for (let index = 0; index < 4; index += 1) {
+      runCrashingLaunch(userDataPath, index, startedAt + index * 10_000)
+    }
+    const later = runCrashingLaunch(userDataPath, 4, startedAt + 40_000)
+
+    expect(later.softwareRendering).toBe(true)
+    expect(later.breadcrumbs[0]?.data?.source).toBe('marker')
+  })
+
+  // Why: a launch that reached the window and survived a minute proves the driver works today.
+  it('resets after a successful launch: 2 crashes, 1 success, 2 crashes must not engage', () => {
+    runCrashingLaunch(userDataPath, 0, startedAt)
+    runCrashingLaunch(userDataPath, 1, startedAt + 10_000)
+    runLaunch(userDataPath, {
+      launchId: 'healthy',
+      nowEpochMs: startedAt + 20_000,
+      crashAtMsSinceLaunch: null,
+      survivesAMinutePastReadyToShow: true
+    })
+    const outcomes = [
+      runCrashingLaunch(userDataPath, 2, startedAt + 5 * MINUTE_MS),
+      runCrashingLaunch(userDataPath, 3, startedAt + 6 * MINUTE_MS)
+    ]
+
+    expect(outcomes.map((outcome) => outcome.softwareRendering)).toEqual([false, false])
+    expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(false)
+  })
+
+  // Why: the modal promises "Keep Running leaves graphics settings unchanged", so the silent
+  // cross-launch path must not impose on the next boot exactly what was just refused.
+  it('does not override an explicit decline of the in-session prompt', () => {
+    runCrashingLaunch(userDataPath, 0, startedAt)
+    runCrashingLaunch(userDataPath, 1, startedAt + 10_000)
+    const declined = runLaunch(userDataPath, {
+      launchId: 'declined',
+      nowEpochMs: startedAt + 20_000,
+      crashAtMsSinceLaunch: INCIDENT_GPU_CRASH_MS,
+      inSessionCrashes: DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD,
+      inSessionPromptDecision: 'continue'
+    })
+    const next = runCrashingLaunch(userDataPath, 3, startedAt + 30_000)
+
+    expect(declined.crashesInWindow).toBe(DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD)
+    expect(next.softwareRendering).toBe(false)
+    expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(false)
+  })
+
+  // Why: without a wall-clock horizon, ordinary background churn would eventually
+  // fall a perfectly healthy machine back to software rendering.
+  it('never accumulates: one crash a week for ten weeks must not engage', () => {
+    for (let week = 0; week < 10; week += 1) {
+      const outcome = runCrashingLaunch(userDataPath, week, startedAt + week * WEEK_MS)
+      expect(outcome.softwareRendering).toBe(false)
+    }
+
+    expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(false)
+  })
+
+  // Why: a GPU-child-only death does not kill the renderer — Chromium respawns the child and
+  // the window paints, so a launch that lived on is not evidence that Orca cannot boot. It
+  // still may not erase the launches that died before any window existed.
+  it('exonerates a launch that crashed the GPU and then painted, and only that launch', () => {
+    runCrashingLaunch(userDataPath, 0, startedAt)
+    runCrashingLaunch(userDataPath, 1, startedAt + 10_000)
+    const painted = runLaunch(userDataPath, {
+      launchId: 'crashed-then-painted',
+      nowEpochMs: startedAt + 20_000,
+      crashAtMsSinceLaunch: INCIDENT_GPU_CRASH_MS,
+      survivesAMinutePastReadyToShow: true
+    })
+    expect(
+      readActiveGpuCrashHistory(userDataPath, WINDOWS_ENVIRONMENT).map((crash) => crash.launchId)
+    ).toEqual(['launch-0', 'launch-1'])
+
+    // The painted launch no longer counts, so the rescue waits for a third launch that died.
+    const third = runCrashingLaunch(userDataPath, 3, startedAt + 30_000)
+    const rescue = runCrashingLaunch(userDataPath, 4, startedAt + 40_000)
+
+    expect([painted.softwareRendering, third.softwareRendering]).toEqual([false, false])
+    expect(rescue.softwareRendering).toBe(true)
+  })
+
+  // Why: a machine where Orca works fine but the GPU child blips once at startup must never be
+  // downgraded — three restarts inside ten minutes (an update, a Restart button, a manual one)
+  // is an ordinary morning.
+  it('never engages for launches that blipped at startup and then ran on', () => {
+    const outcomes = Array.from({ length: 4 }, (_, index) =>
+      runLaunch(userDataPath, {
+        launchId: `blip-${index}`,
+        nowEpochMs: startedAt + index * MINUTE_MS,
+        crashAtMsSinceLaunch: INCIDENT_GPU_CRASH_MS,
+        survivesAMinutePastReadyToShow: true
+      })
+    )
+
+    expect(outcomes.map((outcome) => outcome.softwareRendering)).toEqual([
+      false,
+      false,
+      false,
+      false
+    ])
+    expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(false)
+  })
+
+  // Why: the modal fires on any three GPU deaths inside 30s, including a purely mid-session
+  // burst that was never recorded as startup evidence. Declining answers for this launch only.
+  it('keeps earlier startup evidence when a mid-session burst is declined', () => {
+    runCrashingLaunch(userDataPath, 0, startedAt)
+    runCrashingLaunch(userDataPath, 1, startedAt + 10_000)
+    runLaunch(userDataPath, {
+      launchId: 'mid-session-burst',
+      nowEpochMs: startedAt + 20_000,
+      crashAtMsSinceLaunch: 20 * MINUTE_MS,
+      inSessionCrashes: DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD,
+      inSessionPromptDecision: 'continue'
+    })
+
+    expect(
+      readActiveGpuCrashHistory(userDataPath, WINDOWS_ENVIRONMENT).map((crash) => crash.launchId)
+    ).toEqual(['launch-0', 'launch-1'])
+  })
+
+  // Why: version-scoped evidence dies with the update, so the full threshold would cost this
+  // machine three unbootable launches after every release.
+  it('re-engages after one crashing launch when the previous build had fallen back', () => {
+    writeGpuFallbackMarker(
+      userDataPath,
+      { engagedAt: startedAt - WEEK_MS, crashesInWindow: 3 },
+      { ...WINDOWS_ENVIRONMENT, appVersion: '1.4.183' }
+    )
+
+    const fresh = runCrashingLaunch(userDataPath, 0, startedAt)
+    const rescue = runCrashingLaunch(userDataPath, 1, startedAt + 10_000)
+
+    expect(fresh.softwareRendering).toBe(false)
+    expect(rescue.softwareRendering).toBe(true)
+    expect(rescue.breadcrumbs[0]?.data?.source).toBe('crash-history-after-update')
+  })
+
+  // Why: the previous build's head start is spent the moment this build proves it boots.
+  it('drops the previous build record once a launch boots cleanly', () => {
+    writeGpuFallbackMarker(
+      userDataPath,
+      { engagedAt: startedAt - WEEK_MS, crashesInWindow: 3 },
+      { ...WINDOWS_ENVIRONMENT, appVersion: '1.4.183' }
+    )
+    runLaunch(userDataPath, {
+      launchId: 'healthy-after-update',
+      nowEpochMs: startedAt,
+      crashAtMsSinceLaunch: null,
+      survivesAMinutePastReadyToShow: true
+    })
+
+    const next = runCrashingLaunch(userDataPath, 1, startedAt + MINUTE_MS)
+
+    expect(next.softwareRendering).toBe(false)
+    expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(false)
+  })
+
+  // Why: a single noisy launch must not evict the other launches that make up the threshold.
+  it('survives a launch that emits a GPU crash loop', () => {
+    runCrashingLaunch(userDataPath, 0, startedAt)
+    for (let crash = 0; crash < 20; crash += 1) {
+      recordGpuCrashInHistory(
+        userDataPath,
+        { atEpochMs: startedAt + 10_000 + crash, msSinceLaunch: 600 + crash, launchId: 'noisy' },
+        WINDOWS_ENVIRONMENT
+      )
+    }
+    runCrashingLaunch(userDataPath, 2, startedAt + 20_000)
+    const rescue = runCrashingLaunch(userDataPath, 3, startedAt + 30_000)
+
+    expect(rescue.softwareRendering).toBe(true)
+  })
+
+  // Why: a crash 20 minutes in is the in-session tracker's job (#10707), not evidence Orca cannot boot.
+  it('ignores mid-session GPU crashes as cross-launch evidence', () => {
+    for (let index = 0; index < 4; index += 1) {
+      runLaunch(userDataPath, {
+        launchId: `session-${index}`,
+        nowEpochMs: startedAt + index * MINUTE_MS,
+        crashAtMsSinceLaunch: 20 * MINUTE_MS
+      })
+    }
+
+    expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(false)
+  })
+
+  it('exits software rendering once the marker and evidence are cleared', () => {
+    for (let index = 0; index < 4; index += 1) {
+      runCrashingLaunch(userDataPath, index, startedAt + index * 10_000)
+    }
+    clearGpuFallbackMarker(userDataPath)
+    clearGpuCrashHistory(userDataPath)
+
+    const retry = runLaunch(userDataPath, {
+      launchId: 'retry',
+      nowEpochMs: startedAt + 60_000,
+      crashAtMsSinceLaunch: null
+    })
+
+    expect(retry.softwareRendering).toBe(false)
+    expect(retry.disableHardwareAccelerationCalls).toBe(0)
+  })
+})

--- a/src/main/crash-reporting/gpu-crash-fallback-decision.ts
+++ b/src/main/crash-reporting/gpu-crash-fallback-decision.ts
@@ -5,6 +5,15 @@ export type GpuCrashFallbackOptions = {
   threshold: number
 }
 
+// Why 'launch-failed' is retained but unreachable on the launch-failure path: when the
+// GPU child fails to *launch* (measured on Electron 43 / Windows 11 with --gpu-launcher
+// forcing failure), Chromium retries internally 6x and then FATALs the browser process —
+// 42 internal GPU failures produced zero 'child-process-gone' events. Electron 43 exposes
+// no other signal for that mode, and the cross-launch crash history does NOT cover it
+// either: its only writer sits behind the same 'child-process-gone' event, so nothing is
+// ever recorded and that shape stays unrescued. Rescuing it needs a separate signal, e.g.
+// detecting that the previous launch exited 3 before ready-to-show. This reason is kept
+// only because a GPU child that dies *after* a successful launch can still report it.
 const GPU_FALLBACK_CRASH_REASONS = new Set(['abnormal-exit', 'crashed', 'launch-failed'])
 
 // Why: on old/flaky GPU drivers the GPU child process crashes (STATUS_BREAKPOINT

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -143,8 +143,10 @@ import {
   clearGpuFallbackMarker,
   clearSupersededGpuFallbackMarker,
   readActiveGpuFallbackMarker,
+  sweepOrphanedGpuFallbackMarkerWrites,
   writeGpuFallbackMarker,
   type GpuFallbackEnvironment,
+  type GpuFallbackMarker,
   type WindowsGpuFallbackEnvironment
 } from './startup/gpu-fallback-marker'
 import {
@@ -933,14 +935,17 @@ ipcMain.handle('ui:consumePendingSkillShare', () => {
   return skillShareDeepLinks.consume()
 })
 
-ipcMain.handle(
-  'app:getGpuFallbackStatus',
-  (): GpuFallbackStatus => ({
+ipcMain.handle('app:getGpuFallbackStatus', (): GpuFallbackStatus => {
+  const marker = readGpuFallbackMarkerForThisBuild()
+  return {
     active: gpuFallbackActiveThisLaunch,
     engagedAt: gpuFallbackEngagedAt,
-    enabledForNextLaunch: isGpuFallbackEnabledForNextLaunch()
-  })
-)
+    enabledForNextLaunch: marker !== null,
+    // Why: the marker is the standing decision. An active launch with no marker only happens
+    // when the automatic write failed, which is never a pin — so it cannot be reported as one.
+    source: marker?.source ?? (gpuFallbackActiveThisLaunch ? 'automatic' : null)
+  }
+})
 
 // Why: without an exit a user whose driver was fixed stays in software rendering until the
 // next release, and without an entry a user with a known-bad driver cannot pin the workaround.
@@ -1820,6 +1825,7 @@ function armGpuCrashHistoryReset(): void {
     // Why: everything sweepable is already older than the horizon, so it has no business on
     // the ready-to-show path — folding it in here also spaces it to once per launch.
     sweepOrphanedGpuCrashHistoryWrites(getCanonicalUserDataPath())
+    sweepOrphanedGpuFallbackMarkerWrites(getCanonicalUserDataPath())
     applyGpuCrashHistoryReset()
   }, GPU_CRASH_HISTORY_RESET_DELAY_MS)
   gpuCrashHistoryResetTimer.unref?.()
@@ -1882,11 +1888,10 @@ function clearGpuFallbackState(): void {
   recordCrashBreadcrumb('gpu_fallback_cleared')
 }
 
-function isGpuFallbackEnabledForNextLaunch(): boolean {
+/** The persisted decision in force for the next launch, pin or automatic; null off Windows. */
+function readGpuFallbackMarkerForThisBuild(): GpuFallbackMarker | null {
   const environment = getWindowsGpuFallbackEnvironment()
-  return environment
-    ? readActiveGpuFallbackMarker(getCanonicalUserDataPath(), environment) !== null
-    : false
+  return environment ? readActiveGpuFallbackMarker(getCanonicalUserDataPath(), environment) : null
 }
 
 /**

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -112,6 +112,7 @@ import {
   resolveUpdateInstallMode
 } from './updater'
 import { configureRemoteServerUpdater } from './runtime/remote-server-updater'
+import type { GpuFallbackStatus } from '../shared/gpu-fallback-status'
 import type { UpdateCheckOptions } from '../shared/update-status-types'
 import { recordUpdaterLifecycle } from './updater-lifecycle-diagnostics'
 import {
@@ -139,12 +140,22 @@ import { enableRendererHeapHeadroom } from './startup/renderer-heap-headroom'
 import { argvRequestsServeMode, normalizeServeModeArgv } from './startup/serve-mode-argv'
 import { ensureVirtualDisplayForHeadlessServe } from './startup/ensure-virtual-display'
 import {
+  clearGpuFallbackMarker,
+  clearSupersededGpuFallbackMarker,
   readActiveGpuFallbackMarker,
   writeGpuFallbackMarker,
   type GpuFallbackEnvironment,
   type WindowsGpuFallbackEnvironment
 } from './startup/gpu-fallback-marker'
-import { applyGpuFallbackCommandLineSwitches } from './startup/gpu-fallback-switches'
+import {
+  GPU_CRASH_STARTUP_WINDOW_MS,
+  clearGpuCrashHistory,
+  forgetGpuCrashLaunch,
+  recordGpuCrashInHistory,
+  sweepOrphanedGpuCrashHistoryWrites
+} from './startup/gpu-crash-history'
+import { engageGpuFallbackForLaunch } from './startup/gpu-fallback-launch-engagement'
+import { resolveGpuCrashHistoryReset } from './startup/gpu-fallback-launch-decision'
 import {
   DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD,
   DEFAULT_GPU_CRASH_FALLBACK_WINDOW_MS,
@@ -412,10 +423,21 @@ const gpuCrashFallbackTracker = new GpuCrashFallbackTracker({
   threshold: DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD
 })
 let gpuFallbackActiveThisLaunch = false
+// Why: identifies *this* engagement, so a dismissed notice reappears when a later one starts.
+let gpuFallbackEngagedAt: number | null = null
+// Why: the user answered the in-session prompt with "no"; nothing this launch records may
+// let the silent cross-launch path override that on the next boot.
+let gpuFallbackDeclinedThisLaunch = false
 let gpuFeatureStatus: Electron.GPUFeatureStatus | null = null
+let gpuCrashHistoryResetTimer: NodeJS.Timeout | null = null
+// Why: this launch contributed startup evidence, so a painted window may exonerate the launch
+// itself but not the earlier ones. Scoped to the startup window that governs recording and
+// counting — a GPU death 20 minutes in is the in-session tracker's business, not this counter's.
+let gpuCrashedDuringStartupThisLaunch = false
 let localPtyStartupReady: Promise<void> = Promise.resolve()
 let localPtyProviderStartupReady: Promise<void> = Promise.resolve()
 const AGENT_STATE_CRASH_BREADCRUMB_MIN_INTERVAL_MS = 30_000
+const GPU_CRASH_HISTORY_RESET_DELAY_MS = 60_000
 
 function handleCodexHomePtySpawned(args: {
   id: string
@@ -909,6 +931,21 @@ ipcMain.handle('ui:consumePendingOpenSettings', (event) =>
 
 ipcMain.handle('ui:consumePendingSkillShare', () => {
   return skillShareDeepLinks.consume()
+})
+
+ipcMain.handle(
+  'app:getGpuFallbackStatus',
+  (): GpuFallbackStatus => ({
+    active: gpuFallbackActiveThisLaunch,
+    engagedAt: gpuFallbackEngagedAt,
+    enabledForNextLaunch: isGpuFallbackEnabledForNextLaunch()
+  })
+)
+
+// Why: without an exit a user whose driver was fixed stays in software rendering until the
+// next release, and without an entry a user with a known-bad driver cannot pin the workaround.
+ipcMain.handle('app:setGpuFallbackEnabled', (_event, enabled: boolean) => {
+  setGpuFallbackEnabled(enabled === true)
 })
 
 ipcMain.handle(
@@ -1419,6 +1456,7 @@ function openMainWindow(options: { revealOnDidFinishLoad?: boolean } = {}): Brow
   window.once('ready-to-show', () => {
     logStartupMilestone('ready-to-show')
     setImmediate(createSystemTrayDeferred)
+    armGpuCrashHistoryReset()
   })
   window.once('show', () => {
     logStartupMilestone('window-shown')
@@ -1706,24 +1744,184 @@ function getWindowsGpuFallbackEnvironment(): WindowsGpuFallbackEnvironment | nul
   return { ...environment, platform: 'win32' }
 }
 
-// Why: read the GPU-fallback marker before app.whenReady() so app.disableHardwareAcceleration() takes effect. Windows desktop only.
+// Why: decide GPU fallback before app.whenReady() so app.disableHardwareAcceleration() takes effect. Windows desktop only.
 function maybeApplyGpuFallbackForThisLaunch(): void {
   if (isServeMode || process.platform !== 'win32') {
     return
   }
-  const marker = readActiveGpuFallbackMarker(app.getPath('userData'), getGpuFallbackEnvironment())
-  if (!marker) {
+  const decision = engageGpuFallbackForLaunch({
+    userDataPath: getCanonicalUserDataPath(),
+    environment: getGpuFallbackEnvironment(),
+    nowEpochMs: Date.now(),
+    hooks: {
+      disableHardwareAcceleration: () => app.disableHardwareAcceleration(),
+      commandLine: app.commandLine,
+      recordBreadcrumb: recordCrashBreadcrumb
+    }
+  })
+  gpuFallbackActiveThisLaunch = decision.engage
+  gpuFallbackEngagedAt = decision.engagedAt
+}
+
+/** Promotes in-session crash evidence to the sticky decision. False if it could not be written. */
+function persistGpuFallbackMarker(crashesInWindow: number, engagedAt: number): boolean {
+  const environment = getWindowsGpuFallbackEnvironment()
+  if (!environment) {
+    return false
+  }
+  const userDataPath = getCanonicalUserDataPath()
+  try {
+    writeGpuFallbackMarker(userDataPath, { engagedAt, crashesInWindow }, environment)
+  } catch (error) {
+    console.warn('[gpu-fallback] failed to persist marker:', error)
+    return false
+  }
+  // Why: the evidence has been consumed by the decision; keeping it would re-arm
+  // the same conclusion after the user asks for hardware acceleration back.
+  clearGpuCrashHistory(userDataPath)
+  return true
+}
+
+// Why: crash-at-startup kills this process before the in-session tracker can reach its threshold, so the evidence has to outlive the launch.
+function recordGpuCrashLaunchEvidence(msSinceLaunch: number): void {
+  const environment = getWindowsGpuFallbackEnvironment()
+  if (!environment || gpuFallbackDeclinedThisLaunch) {
     return
   }
-  app.disableHardwareAcceleration()
-  const appliedSwitches = applyGpuFallbackCommandLineSwitches(app.commandLine, process.platform)
-  gpuFallbackActiveThisLaunch = true
-  // Why: with no GPU child left, child-process-gone can't report a GPU fault, so
-  // name the applied switches in the trail any later crash report carries.
-  recordCrashBreadcrumb('gpu_fallback_applied', {
-    crashesInWindow: marker.crashesInWindow,
-    switches: appliedSwitches.join(',')
+  try {
+    recordGpuCrashInHistory(
+      getCanonicalUserDataPath(),
+      {
+        atEpochMs: Date.now(),
+        msSinceLaunch,
+        launchId: getMainProcessLifecycleIdentity().mainProcessLaunchId
+      },
+      environment
+    )
+  } catch (error) {
+    console.warn('[gpu-fallback] failed to persist crash history:', error)
+  }
+}
+
+/**
+ * Surviving a minute past the painted window is the proof; what it proves is
+ * resolved when the timer fires, not when it is armed, so a GPU death in between
+ * narrows the reset instead of vetoing it. The field separation is unambiguous:
+ * failing launches die inside a second, healthy ones ran for minutes.
+ */
+function armGpuCrashHistoryReset(): void {
+  if (gpuCrashHistoryResetTimer || isServeMode || process.platform !== 'win32') {
+    return
+  }
+  sweepOrphanedGpuCrashHistoryWrites(getCanonicalUserDataPath())
+  if (gpuFallbackActiveThisLaunch) {
+    return
+  }
+  gpuCrashHistoryResetTimer = setTimeout(() => {
+    gpuCrashHistoryResetTimer = null
+    applyGpuCrashHistoryReset()
+  }, GPU_CRASH_HISTORY_RESET_DELAY_MS)
+  gpuCrashHistoryResetTimer.unref?.()
+}
+
+function applyGpuCrashHistoryReset(): void {
+  const action = resolveGpuCrashHistoryReset({
+    gpuCrashedDuringStartup: gpuCrashedDuringStartupThisLaunch,
+    gpuFallbackActive: gpuFallbackActiveThisLaunch
   })
+  if (action === 'none') {
+    return
+  }
+  const userDataPath = getCanonicalUserDataPath()
+  const environment = getWindowsGpuFallbackEnvironment()
+  try {
+    if (action === 'forget-this-launch') {
+      forgetGpuCrashLaunch(userDataPath, getMainProcessLifecycleIdentity().mainProcessLaunchId)
+      return
+    }
+    clearGpuCrashHistory(userDataPath)
+    // Why: a build that boots has no use for the previous build's lowered threshold.
+    if (environment) {
+      clearSupersededGpuFallbackMarker(userDataPath, environment)
+    }
+  } catch (error) {
+    console.warn('[gpu-fallback] failed to reset crash history:', error)
+  }
+}
+
+function cancelGpuCrashHistoryReset(): void {
+  if (!gpuCrashHistoryResetTimer) {
+    return
+  }
+  clearTimeout(gpuCrashHistoryResetTimer)
+  gpuCrashHistoryResetTimer = null
+}
+
+/**
+ * The prompt said "leaves graphics settings unchanged" and the user took it, so the
+ * silent cross-launch path must not impose on the next boot what was just refused.
+ *
+ * How much that covers depends on what raised the prompt. Over startup crashes the
+ * user refused the cross-launch conclusion itself, so all of the evidence is spent.
+ * A purely mid-session burst is never recorded as startup evidence and was never
+ * what the user was asked about — earlier launches that died before any window
+ * existed are not on trial there.
+ */
+function discardGpuCrashEvidenceAfterDecline(): void {
+  gpuFallbackDeclinedThisLaunch = true
+  const userDataPath = getCanonicalUserDataPath()
+  try {
+    if (gpuCrashedDuringStartupThisLaunch) {
+      clearGpuCrashHistory(userDataPath)
+      return
+    }
+    forgetGpuCrashLaunch(userDataPath, getMainProcessLifecycleIdentity().mainProcessLaunchId)
+  } catch (error) {
+    console.warn('[gpu-fallback] failed to discard crash evidence:', error)
+  }
+}
+
+/** Drops both durable artifacts so the next launch retries hardware acceleration. */
+function clearGpuFallbackState(): void {
+  cancelGpuCrashHistoryReset()
+  const userDataPath = getCanonicalUserDataPath()
+  clearGpuFallbackMarker(userDataPath)
+  clearGpuCrashHistory(userDataPath)
+  recordCrashBreadcrumb('gpu_fallback_cleared')
+}
+
+function isGpuFallbackEnabledForNextLaunch(): boolean {
+  const environment = getWindowsGpuFallbackEnvironment()
+  return environment
+    ? readActiveGpuFallbackMarker(getCanonicalUserDataPath(), environment) !== null
+    : false
+}
+
+/**
+ * Settings' on/off for Safe Graphics Mode; the caller relaunches to apply it.
+ *
+ * A user-sourced marker survives app and Electron updates, unlike the automatic
+ * one — a user who knows their driver is broken should not have to re-earn the
+ * workaround with crashing launches after every release.
+ */
+function setGpuFallbackEnabled(enabled: boolean): void {
+  const environment = getWindowsGpuFallbackEnvironment()
+  if (!environment) {
+    return
+  }
+  if (!enabled) {
+    clearGpuFallbackState()
+    return
+  }
+  cancelGpuCrashHistoryReset()
+  const userDataPath = getCanonicalUserDataPath()
+  writeGpuFallbackMarker(
+    userDataPath,
+    { engagedAt: Date.now(), crashesInWindow: 0, source: 'user' },
+    environment
+  )
+  clearGpuCrashHistory(userDataPath)
+  recordCrashBreadcrumb('gpu_fallback_pinned')
 }
 
 // Why: a burst of GPU child crashes means HW acceleration is unusable — persist a build-scoped marker and offer software rendering.
@@ -1732,7 +1930,12 @@ async function handleGpuChildCrash(reason: string, exitCode: number | null): Pro
   if (gpuFallbackActiveThisLaunch || isQuitting || isServeMode) {
     return
   }
-  const result = gpuCrashFallbackTracker.recordGpuCrash(performance.now())
+  const msSinceLaunch = performance.now()
+  // Why: persist evidence first — this process can be FATALed milliseconds from
+  // now, and the threshold check below never survives a crash-at-startup launch.
+  gpuCrashedDuringStartupThisLaunch ||= msSinceLaunch <= GPU_CRASH_STARTUP_WINDOW_MS
+  recordGpuCrashLaunchEvidence(msSinceLaunch)
+  const result = gpuCrashFallbackTracker.recordGpuCrash(msSinceLaunch)
   if (!result.shouldEngageFallback) {
     return
   }
@@ -1759,24 +1962,11 @@ async function handleGpuChildCrash(reason: string, exitCode: number | null): Pro
     return
   }
   if (restartDecision !== 'restart') {
+    discardGpuCrashEvidenceAfterDecline()
     recordDurableCrashBreadcrumb('gpu_fallback_restart_deferred', fallbackData)
     return
   }
-  const environment = getWindowsGpuFallbackEnvironment()
-  if (!environment) {
-    return
-  }
-  try {
-    writeGpuFallbackMarker(
-      app.getPath('userData'),
-      {
-        engagedAt,
-        crashesInWindow: result.crashesInWindow
-      },
-      environment
-    )
-  } catch (error) {
-    console.warn('[gpu-fallback] failed to persist marker:', error)
+  if (!persistGpuFallbackMarker(result.crashesInWindow, engagedAt)) {
     return
   }
   isQuitting = true

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1813,35 +1813,30 @@ function armGpuCrashHistoryReset(): void {
   if (gpuCrashHistoryResetTimer || isServeMode || process.platform !== 'win32') {
     return
   }
-  sweepOrphanedGpuCrashHistoryWrites(getCanonicalUserDataPath())
-  if (gpuFallbackActiveThisLaunch) {
-    return
-  }
+  // Why: armed even in software rendering, because the timer also carries the orphan sweep;
+  // resolveGpuCrashHistoryReset is the single place that decides what the history owes.
   gpuCrashHistoryResetTimer = setTimeout(() => {
     gpuCrashHistoryResetTimer = null
+    // Why: everything sweepable is already older than the horizon, so it has no business on
+    // the ready-to-show path — folding it in here also spaces it to once per launch.
+    sweepOrphanedGpuCrashHistoryWrites(getCanonicalUserDataPath())
     applyGpuCrashHistoryReset()
   }, GPU_CRASH_HISTORY_RESET_DELAY_MS)
   gpuCrashHistoryResetTimer.unref?.()
 }
 
 function applyGpuCrashHistoryReset(): void {
-  const action = resolveGpuCrashHistoryReset({
+  const reset = resolveGpuCrashHistoryReset({
     gpuCrashedDuringStartup: gpuCrashedDuringStartupThisLaunch,
     gpuFallbackActive: gpuFallbackActiveThisLaunch
   })
-  if (action === 'none') {
-    return
-  }
   const userDataPath = getCanonicalUserDataPath()
   const environment = getWindowsGpuFallbackEnvironment()
   try {
-    if (action === 'forget-this-launch') {
+    if (reset.forgetThisLaunch) {
       forgetGpuCrashLaunch(userDataPath, getMainProcessLifecycleIdentity().mainProcessLaunchId)
-      return
     }
-    clearGpuCrashHistory(userDataPath)
-    // Why: a build that boots has no use for the previous build's lowered threshold.
-    if (environment) {
+    if (reset.clearSupersededMarker && environment) {
       clearSupersededGpuFallbackMarker(userDataPath, environment)
     }
   } catch (error) {
@@ -1861,21 +1856,18 @@ function cancelGpuCrashHistoryReset(): void {
  * The prompt said "leaves graphics settings unchanged" and the user took it, so the
  * silent cross-launch path must not impose on the next boot what was just refused.
  *
- * How much that covers depends on what raised the prompt. Over startup crashes the
- * user refused the cross-launch conclusion itself, so all of the evidence is spent.
- * A purely mid-session burst is never recorded as startup evidence and was never
- * what the user was asked about — earlier launches that died before any window
- * existed are not on trial there.
+ * Scoped to this launch like every other lifecycle operation on the history: the
+ * prompt fires on any three GPU deaths inside 30s, including a purely mid-session
+ * burst that was never recorded as startup evidence, so a decline cannot be read as
+ * a verdict on launches that died before any window existed.
  */
 function discardGpuCrashEvidenceAfterDecline(): void {
   gpuFallbackDeclinedThisLaunch = true
-  const userDataPath = getCanonicalUserDataPath()
   try {
-    if (gpuCrashedDuringStartupThisLaunch) {
-      clearGpuCrashHistory(userDataPath)
-      return
-    }
-    forgetGpuCrashLaunch(userDataPath, getMainProcessLifecycleIdentity().mainProcessLaunchId)
+    forgetGpuCrashLaunch(
+      getCanonicalUserDataPath(),
+      getMainProcessLifecycleIdentity().mainProcessLaunchId
+    )
   } catch (error) {
     console.warn('[gpu-fallback] failed to discard crash evidence:', error)
   }

--- a/src/main/startup/desktop-startup-ordering.test.ts
+++ b/src/main/startup/desktop-startup-ordering.test.ts
@@ -120,6 +120,12 @@ describe('startup ordering', () => {
     expect(arm).toContain('resolveGpuCrashHistoryReset({')
     expect(arm).toContain('gpuCrashedDuringStartup: gpuCrashedDuringStartupThisLaunch')
     expect(arm).toContain('gpuFallbackActive: gpuFallbackActiveThisLaunch')
+    // Why: the orphan sweep is a readdir + per-file stat and everything it can delete is already
+    // older than the horizon, so it belongs behind the timer, never on the ready-to-show path.
+    expect(arm.indexOf('sweepOrphanedGpuCrashHistoryWrites(')).toBeGreaterThan(
+      arm.indexOf('setTimeout(')
+    )
+    expect(arm.indexOf('setTimeout(')).toBeGreaterThanOrEqual(0)
   })
 
   it('requires daemon authority before restored-subagent liveness runs', () => {

--- a/src/main/startup/desktop-startup-ordering.test.ts
+++ b/src/main/startup/desktop-startup-ordering.test.ts
@@ -49,6 +49,79 @@ describe('startup ordering', () => {
     )
   })
 
+  // Why: app.disableHardwareAcceleration() is a no-op once whenReady resolves, and the marker/history
+  // paths must agree on one userData path — app.setName() changes how a late getPath('userData') resolves.
+  it('decides GPU fallback before whenReady and setName, off one canonical userData path', () => {
+    const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
+    const applyIndex = source.indexOf('  maybeApplyGpuFallbackForThisLaunch()')
+    const whenReadyIndex = source.indexOf('void app.whenReady().then(')
+    const setNameIndex = source.indexOf('app.setName(devInstanceIdentity.appName)')
+    const applyStart = source.indexOf('function maybeApplyGpuFallbackForThisLaunch()')
+    const applyEnd = source.indexOf('function persistGpuFallbackMarker(', applyStart)
+    const apply = source.slice(applyStart, applyEnd)
+
+    expect(applyIndex).toBeGreaterThanOrEqual(0)
+    expect(whenReadyIndex).toBeGreaterThan(applyIndex)
+    expect(setNameIndex).toBeGreaterThan(applyIndex)
+    expect(applyStart).toBeGreaterThanOrEqual(0)
+    expect(applyEnd).toBeGreaterThan(applyStart)
+    expect(apply).toContain('engageGpuFallbackForLaunch({')
+    expect(apply).toContain('userDataPath: getCanonicalUserDataPath()')
+    // Why: a modal here would block a process that has no window yet.
+    expect(apply).not.toContain('promptForGpuFallbackRestart')
+
+    // Why: the marker used to be read pre-setName and written post-setName, which resolve
+    // to different directories on a case-sensitive filesystem.
+    const persistStart = source.indexOf('function persistGpuFallbackMarker(')
+    const persistEnd = source.indexOf('function recordGpuCrashLaunchEvidence(', persistStart)
+    const persist = source.slice(persistStart, persistEnd)
+
+    expect(persistStart).toBeGreaterThanOrEqual(0)
+    expect(persistEnd).toBeGreaterThan(persistStart)
+    expect(persist).toContain('const userDataPath = getCanonicalUserDataPath()')
+    expect(persist).not.toContain("app.getPath('userData')")
+  })
+
+  // Why: the crash-at-startup shape kills the process ~600ms in, so evidence written after the
+  // threshold check or after a prompt never survives the launch that produced it.
+  it('persists GPU crash evidence before the in-session threshold check', () => {
+    const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
+    const handlerStart = source.indexOf('async function handleGpuChildCrash(')
+    const handlerEnd = source.indexOf('function recordProcessGoneCrash(', handlerStart)
+    const handler = source.slice(handlerStart, handlerEnd)
+    const evidenceIndex = handler.indexOf('recordGpuCrashLaunchEvidence(msSinceLaunch)')
+    const trackerIndex = handler.indexOf('gpuCrashFallbackTracker.recordGpuCrash(')
+    const promptIndex = handler.indexOf('promptForGpuFallbackRestart(')
+
+    expect(handlerStart).toBeGreaterThanOrEqual(0)
+    expect(handlerEnd).toBeGreaterThan(handlerStart)
+    expect(evidenceIndex).toBeGreaterThanOrEqual(0)
+    expect(trackerIndex).toBeGreaterThan(evidenceIndex)
+    expect(promptIndex).toBeGreaterThan(evidenceIndex)
+    // Why: a GPU death precedes ready-to-show, so the flag has to be set before anything can
+    // throw — and scoped to the startup window that governs recording and counting.
+    expect(
+      handler.indexOf(
+        'gpuCrashedDuringStartupThisLaunch ||= msSinceLaunch <= GPU_CRASH_STARTUP_WINDOW_MS'
+      )
+    ).toBeLessThan(evidenceIndex)
+    expect(source).toContain("window.once('ready-to-show'")
+    expect(source).toContain('armGpuCrashHistoryReset()')
+
+    const armStart = source.indexOf('function armGpuCrashHistoryReset()')
+    const armEnd = source.indexOf('function cancelGpuCrashHistoryReset()', armStart)
+    const arm = source.slice(armStart, armEnd)
+
+    expect(armStart).toBeGreaterThanOrEqual(0)
+    expect(armEnd).toBeGreaterThan(armStart)
+    // Why: what the survival proves is resolved when the timer fires, not when it is armed —
+    // a GPU death in between narrows the reset to this launch instead of vetoing it.
+    expect(arm).toContain('applyGpuCrashHistoryReset()')
+    expect(arm).toContain('resolveGpuCrashHistoryReset({')
+    expect(arm).toContain('gpuCrashedDuringStartup: gpuCrashedDuringStartupThisLaunch')
+    expect(arm).toContain('gpuFallbackActive: gpuFallbackActiveThisLaunch')
+  })
+
   it('requires daemon authority before restored-subagent liveness runs', () => {
     const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
     const sweepStart = source.indexOf('function reapRestoredSubagentsWithoutLiveAgent()')

--- a/src/main/startup/gpu-crash-history.test.ts
+++ b/src/main/startup/gpu-crash-history.test.ts
@@ -77,6 +77,29 @@ describe('gpu-crash-history', () => {
     expect(crashes.at(-1)?.launchId).toBe(`launch-${GPU_CRASH_HISTORY_MAX_ENTRIES + 3}`)
   })
 
+  // Why: this parse runs before whenReady, so the cost must not depend on a file this code
+  // never wrote — a foreign or hand-edited history cannot make the launch path do linear work.
+  it('caps on read, not only on write', () => {
+    writeFileSync(
+      join(userDataPath, GPU_CRASH_HISTORY_FILE),
+      JSON.stringify({
+        schemeVersion: 1,
+        appVersion: ENVIRONMENT.appVersion,
+        electronVersion: ENVIRONMENT.electronVersion,
+        platform: 'win32',
+        crashes: Array.from({ length: 5_000 }, (_, launch) => ({
+          atEpochMs: NOW + launch,
+          msSinceLaunch: 581,
+          launchId: `launch-${launch}`
+        }))
+      })
+    )
+    const crashes = readActiveGpuCrashHistory(userDataPath, ENVIRONMENT)
+
+    expect(crashes).toHaveLength(GPU_CRASH_HISTORY_MAX_ENTRIES)
+    expect(crashes.at(-1)?.launchId).toBe('launch-4999')
+  })
+
   // Why: a driver in a respawn loop emits dozens of crashes under one launchId; if each
   // took a cap slot, one noisy launch would evict every other launch's evidence and the
   // distinct-launch counter could never reach its threshold.

--- a/src/main/startup/gpu-crash-history.test.ts
+++ b/src/main/startup/gpu-crash-history.test.ts
@@ -1,0 +1,307 @@
+import { existsSync, mkdtempSync, readdirSync, rmSync, utimesSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  GPU_CRASH_HISTORY_FILE,
+  GPU_CRASH_HISTORY_HORIZON_MS,
+  GPU_CRASH_HISTORY_MAX_ENTRIES,
+  GPU_CRASH_STARTUP_WINDOW_MS,
+  clearGpuCrashHistory,
+  countStartupGpuCrashLaunches,
+  forgetGpuCrashLaunch,
+  readActiveGpuCrashHistory,
+  recordGpuCrashInHistory,
+  sweepOrphanedGpuCrashHistoryWrites
+} from './gpu-crash-history'
+import type { WindowsGpuFallbackEnvironment } from './gpu-fallback-marker'
+
+const ENVIRONMENT: WindowsGpuFallbackEnvironment = {
+  appVersion: '1.4.184',
+  electronVersion: '43.1.0',
+  platform: 'win32'
+}
+
+const NOW = 1_760_000_000_000
+
+describe('gpu-crash-history', () => {
+  let userDataPath: string
+
+  beforeEach(() => {
+    userDataPath = mkdtempSync(join(os.tmpdir(), 'orca-gpu-crash-history-'))
+  })
+
+  afterEach(() => {
+    rmSync(userDataPath, { recursive: true, force: true })
+  })
+
+  it('round-trips recorded crashes', () => {
+    recordGpuCrashInHistory(
+      userDataPath,
+      { atEpochMs: NOW, msSinceLaunch: 581, launchId: 'launch-1' },
+      ENVIRONMENT
+    )
+    recordGpuCrashInHistory(
+      userDataPath,
+      { atEpochMs: NOW + 5_000, msSinceLaunch: 604, launchId: 'launch-2' },
+      ENVIRONMENT
+    )
+
+    expect(readActiveGpuCrashHistory(userDataPath, ENVIRONMENT)).toEqual([
+      { atEpochMs: NOW, msSinceLaunch: 581, launchId: 'launch-1' },
+      { atEpochMs: NOW + 5_000, msSinceLaunch: 604, launchId: 'launch-2' }
+    ])
+  })
+
+  it('leaves no temp file behind after an atomic write', () => {
+    recordGpuCrashInHistory(
+      userDataPath,
+      { atEpochMs: NOW, msSinceLaunch: 581, launchId: 'launch-1' },
+      ENVIRONMENT
+    )
+    expect(readdirSync(userDataPath)).toEqual([GPU_CRASH_HISTORY_FILE])
+  })
+
+  it('caps the file at the newest entries', () => {
+    for (let launch = 0; launch < GPU_CRASH_HISTORY_MAX_ENTRIES + 4; launch += 1) {
+      recordGpuCrashInHistory(
+        userDataPath,
+        { atEpochMs: NOW + launch, msSinceLaunch: 581, launchId: `launch-${launch}` },
+        ENVIRONMENT
+      )
+    }
+    const crashes = readActiveGpuCrashHistory(userDataPath, ENVIRONMENT)
+
+    expect(crashes).toHaveLength(GPU_CRASH_HISTORY_MAX_ENTRIES)
+    expect(crashes.at(0)?.launchId).toBe('launch-4')
+    expect(crashes.at(-1)?.launchId).toBe(`launch-${GPU_CRASH_HISTORY_MAX_ENTRIES + 3}`)
+  })
+
+  // Why: a driver in a respawn loop emits dozens of crashes under one launchId; if each
+  // took a cap slot, one noisy launch would evict every other launch's evidence and the
+  // distinct-launch counter could never reach its threshold.
+  it('keeps one entry per launch so a crash loop cannot evict other launches', () => {
+    recordGpuCrashInHistory(
+      userDataPath,
+      { atEpochMs: NOW, msSinceLaunch: 581, launchId: 'earlier' },
+      ENVIRONMENT
+    )
+    for (let crash = 0; crash < GPU_CRASH_HISTORY_MAX_ENTRIES * 2; crash += 1) {
+      recordGpuCrashInHistory(
+        userDataPath,
+        { atEpochMs: NOW + 1_000 + crash, msSinceLaunch: 600 + crash, launchId: 'noisy' },
+        ENVIRONMENT
+      )
+    }
+    const crashes = readActiveGpuCrashHistory(userDataPath, ENVIRONMENT)
+
+    expect(crashes.map((crash) => crash.launchId)).toEqual(['earlier', 'noisy'])
+    expect(countStartupGpuCrashLaunches(crashes, NOW + 2_000)).toBe(2)
+  })
+
+  // Why: a mid-session crash can never be counted, so letting it take a cap slot would
+  // silently discard the startup evidence the cross-launch rescue runs on.
+  it('never persists a crash that happened after startup', () => {
+    recordGpuCrashInHistory(
+      userDataPath,
+      {
+        atEpochMs: NOW,
+        msSinceLaunch: GPU_CRASH_STARTUP_WINDOW_MS + 1,
+        launchId: 'mid-session'
+      },
+      ENVIRONMENT
+    )
+
+    expect(existsSync(join(userDataPath, GPU_CRASH_HISTORY_FILE))).toBe(false)
+  })
+
+  it('prunes crashes beyond the wall-clock horizon when counting', () => {
+    const crashes = [
+      { atEpochMs: NOW - GPU_CRASH_HISTORY_HORIZON_MS - 1, msSinceLaunch: 581, launchId: 'old' },
+      { atEpochMs: NOW - GPU_CRASH_HISTORY_HORIZON_MS, msSinceLaunch: 581, launchId: 'edge' },
+      { atEpochMs: NOW - 1_000, msSinceLaunch: 581, launchId: 'recent' }
+    ]
+
+    expect(countStartupGpuCrashLaunches(crashes, NOW)).toBe(2)
+  })
+
+  // Why: atEpochMs is stamped ~600ms into boot, before W32Time fixes a wrong RTC; a
+  // one-directional horizon would leave those entries valid for the whole build.
+  it('prunes crashes stamped in the future by a clock that was later corrected', () => {
+    const crashes = [
+      { atEpochMs: NOW + GPU_CRASH_HISTORY_HORIZON_MS + 1, msSinceLaunch: 581, launchId: 'ahead' },
+      { atEpochMs: NOW + 1_000, msSinceLaunch: 581, launchId: 'skewed-slightly' }
+    ]
+
+    expect(countStartupGpuCrashLaunches(crashes, NOW)).toBe(1)
+  })
+
+  it('counts each launch once no matter how many crashes it recorded', () => {
+    const crashes = [
+      { atEpochMs: NOW, msSinceLaunch: 581, launchId: 'launch-1' },
+      { atEpochMs: NOW + 20, msSinceLaunch: 601, launchId: 'launch-1' },
+      { atEpochMs: NOW + 40, msSinceLaunch: 621, launchId: 'launch-1' }
+    ]
+
+    expect(countStartupGpuCrashLaunches(crashes, NOW + 100)).toBe(1)
+  })
+
+  // Why: a mid-session GPU crash is the in-session tracker's job; feeding it to a
+  // counter that means "cannot even boot" would fall back a perfectly bootable app.
+  it('ignores crashes that happened after startup', () => {
+    const crashes = [
+      { atEpochMs: NOW, msSinceLaunch: GPU_CRASH_STARTUP_WINDOW_MS, launchId: 'startup' },
+      { atEpochMs: NOW, msSinceLaunch: GPU_CRASH_STARTUP_WINDOW_MS + 1, launchId: 'mid-session' },
+      { atEpochMs: NOW, msSinceLaunch: 920_000, launchId: 'much-later' }
+    ]
+
+    expect(countStartupGpuCrashLaunches(crashes, NOW)).toBe(1)
+  })
+
+  it('discards history written by a different app version', () => {
+    recordGpuCrashInHistory(
+      userDataPath,
+      { atEpochMs: NOW, msSinceLaunch: 581, launchId: 'launch-1' },
+      ENVIRONMENT
+    )
+
+    expect(
+      readActiveGpuCrashHistory(userDataPath, { ...ENVIRONMENT, appVersion: '1.4.185' })
+    ).toEqual([])
+    expect(existsSync(join(userDataPath, GPU_CRASH_HISTORY_FILE))).toBe(false)
+  })
+
+  // Why: an Electron bump replaces the whole GPU stack, so its crash evidence says nothing about the new one.
+  it('discards history written by a different Electron version', () => {
+    recordGpuCrashInHistory(
+      userDataPath,
+      { atEpochMs: NOW, msSinceLaunch: 581, launchId: 'launch-1' },
+      ENVIRONMENT
+    )
+
+    expect(
+      readActiveGpuCrashHistory(userDataPath, { ...ENVIRONMENT, electronVersion: '44.0.0' })
+    ).toEqual([])
+    expect(existsSync(join(userDataPath, GPU_CRASH_HISTORY_FILE))).toBe(false)
+  })
+
+  it('discards history off Windows', () => {
+    recordGpuCrashInHistory(
+      userDataPath,
+      { atEpochMs: NOW, msSinceLaunch: 581, launchId: 'launch-1' },
+      ENVIRONMENT
+    )
+
+    expect(readActiveGpuCrashHistory(userDataPath, { ...ENVIRONMENT, platform: 'darwin' })).toEqual(
+      []
+    )
+    expect(existsSync(join(userDataPath, GPU_CRASH_HISTORY_FILE))).toBe(false)
+  })
+
+  it('treats a missing or corrupt file as empty history', () => {
+    expect(readActiveGpuCrashHistory(userDataPath, ENVIRONMENT)).toEqual([])
+
+    writeFileSync(join(userDataPath, GPU_CRASH_HISTORY_FILE), '{ "crashes": [')
+    expect(readActiveGpuCrashHistory(userDataPath, ENVIRONMENT)).toEqual([])
+    expect(existsSync(join(userDataPath, GPU_CRASH_HISTORY_FILE))).toBe(false)
+
+    writeFileSync(
+      join(userDataPath, GPU_CRASH_HISTORY_FILE),
+      JSON.stringify({ schemeVersion: 999, crashes: [] })
+    )
+    expect(readActiveGpuCrashHistory(userDataPath, ENVIRONMENT)).toEqual([])
+    expect(existsSync(join(userDataPath, GPU_CRASH_HISTORY_FILE))).toBe(false)
+  })
+
+  it('drops individual malformed entries but keeps the readable ones', () => {
+    writeFileSync(
+      join(userDataPath, GPU_CRASH_HISTORY_FILE),
+      JSON.stringify({
+        schemeVersion: 1,
+        ...ENVIRONMENT,
+        crashes: [
+          { atEpochMs: NOW, msSinceLaunch: 581, launchId: 'good' },
+          { atEpochMs: 'nope', msSinceLaunch: 581, launchId: 'bad-time' },
+          { atEpochMs: NOW, msSinceLaunch: -1, launchId: 'negative' },
+          { atEpochMs: NOW, msSinceLaunch: 581, launchId: '' },
+          null
+        ]
+      })
+    )
+
+    expect(readActiveGpuCrashHistory(userDataPath, ENVIRONMENT)).toEqual([
+      { atEpochMs: NOW, msSinceLaunch: 581, launchId: 'good' }
+    ])
+  })
+
+  // Why: a launch answers only for itself — it painted a window, or the user declined the
+  // prompt it raised. The launches that died before any window existed are not its to erase.
+  it('forgets one launch and keeps every other launch', () => {
+    for (const launchId of ['launch-1', 'launch-2', 'launch-3']) {
+      recordGpuCrashInHistory(
+        userDataPath,
+        { atEpochMs: NOW, msSinceLaunch: 581, launchId },
+        ENVIRONMENT
+      )
+    }
+
+    forgetGpuCrashLaunch(userDataPath, 'launch-2')
+
+    expect(readActiveGpuCrashHistory(userDataPath, ENVIRONMENT).map((c) => c.launchId)).toEqual([
+      'launch-1',
+      'launch-3'
+    ])
+  })
+
+  it('removes the file once the last remembered launch is forgotten', () => {
+    recordGpuCrashInHistory(
+      userDataPath,
+      { atEpochMs: NOW, msSinceLaunch: 581, launchId: 'only' },
+      ENVIRONMENT
+    )
+
+    forgetGpuCrashLaunch(userDataPath, 'only')
+
+    expect(existsSync(join(userDataPath, GPU_CRASH_HISTORY_FILE))).toBe(false)
+  })
+
+  it('ignores a launch it never recorded, with or without a history file', () => {
+    expect(() => forgetGpuCrashLaunch(userDataPath, 'never-seen')).not.toThrow()
+    recordGpuCrashInHistory(
+      userDataPath,
+      { atEpochMs: NOW, msSinceLaunch: 581, launchId: 'kept' },
+      ENVIRONMENT
+    )
+
+    forgetGpuCrashLaunch(userDataPath, 'never-seen')
+
+    expect(readActiveGpuCrashHistory(userDataPath, ENVIRONMENT)).toHaveLength(1)
+  })
+
+  // Why: this is the machine class where a FATAL between write and rename is routine, and
+  // the temp name carries the pid, so orphans would otherwise pile up under distinct names.
+  it('sweeps a temp file orphaned by an earlier process', async () => {
+    const orphan = join(userDataPath, `${GPU_CRASH_HISTORY_FILE}.999999.1.abc.tmp`)
+    writeFileSync(orphan, '{}')
+    const staleSeconds = (Date.now() - GPU_CRASH_HISTORY_HORIZON_MS * 2) / 1000
+    utimesSync(orphan, staleSeconds, staleSeconds)
+
+    sweepOrphanedGpuCrashHistoryWrites(userDataPath)
+
+    await vi.waitFor(() => {
+      expect(existsSync(orphan)).toBe(false)
+    })
+  })
+
+  it('can explicitly clear the history', () => {
+    recordGpuCrashInHistory(
+      userDataPath,
+      { atEpochMs: NOW, msSinceLaunch: 581, launchId: 'launch-1' },
+      ENVIRONMENT
+    )
+    clearGpuCrashHistory(userDataPath)
+
+    expect(existsSync(join(userDataPath, GPU_CRASH_HISTORY_FILE))).toBe(false)
+    expect(readActiveGpuCrashHistory(userDataPath, ENVIRONMENT)).toEqual([])
+  })
+})

--- a/src/main/startup/gpu-crash-history.ts
+++ b/src/main/startup/gpu-crash-history.ts
@@ -1,0 +1,260 @@
+import { existsSync, readFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  durableWriteTempPath,
+  removeStaleDurableWriteTempFiles,
+  writeFileDurableSync
+} from '../durable-file-write'
+import type { GpuFallbackEnvironment, WindowsGpuFallbackEnvironment } from './gpu-fallback-marker'
+
+/**
+ * Persisted GPU-crash evidence, sibling of gpu-fallback.json.
+ *
+ * Why a second file: the marker is the *decision* (software rendering is on for
+ * this build), this is the *evidence* that justifies making it. The crash-at-
+ * startup shape kills the process ~600ms in, so the in-memory
+ * GpuCrashFallbackTracker never reaches its threshold and the marker was
+ * structurally unwritable — every launch crashed exactly once and forgot.
+ * Merging the two files would make version-invalidation mean two things at once.
+ */
+
+export const GPU_CRASH_HISTORY_FILE = 'gpu-crash-history.json'
+export const GPU_CRASH_HISTORY_SCHEME_VERSION = 1
+
+/** Distinct launches retained; one entry per launch, so the file stays a fixed small size. */
+export const GPU_CRASH_HISTORY_MAX_ENTRIES = 8
+/** Wall-clock horizon: crashes older than this are not evidence about today's driver. */
+export const GPU_CRASH_HISTORY_HORIZON_MS = 600_000
+/** Only crashes this early in a launch mean "cannot even boot". */
+export const GPU_CRASH_STARTUP_WINDOW_MS = 15_000
+/** Distinct crashing launches inside the horizon that engage software rendering. */
+export const CROSS_LAUNCH_GPU_FALLBACK_THRESHOLD = 3
+/**
+ * Threshold once a *previous* build already fell back: that build's evidence is
+ * gone with the update, so the full threshold would cost a chronically broken
+ * machine three unbootable launches per release. One fresh hardware attempt is
+ * kept — the update may be the fix — and the second startup crash re-engages.
+ */
+export const CROSS_LAUNCH_GPU_FALLBACK_THRESHOLD_AFTER_UPDATE = 1
+
+export type GpuCrashHistoryEntry = {
+  atEpochMs: number
+  msSinceLaunch: number
+  launchId: string
+}
+
+type GpuCrashHistory = {
+  schemeVersion: number
+  appVersion: string
+  electronVersion: string
+  platform: 'win32'
+  crashes: GpuCrashHistoryEntry[]
+}
+
+function historyPath(userDataPath: string): string {
+  return join(userDataPath, GPU_CRASH_HISTORY_FILE)
+}
+
+function parseEntry(value: unknown): GpuCrashHistoryEntry | null {
+  if (typeof value !== 'object' || value === null) {
+    return null
+  }
+  const entry = value as Partial<Record<keyof GpuCrashHistoryEntry, unknown>>
+  if (
+    typeof entry.atEpochMs !== 'number' ||
+    !Number.isFinite(entry.atEpochMs) ||
+    typeof entry.msSinceLaunch !== 'number' ||
+    !Number.isFinite(entry.msSinceLaunch) ||
+    entry.msSinceLaunch < 0 ||
+    typeof entry.launchId !== 'string' ||
+    entry.launchId.length === 0
+  ) {
+    return null
+  }
+  return {
+    atEpochMs: entry.atEpochMs,
+    msSinceLaunch: entry.msSinceLaunch,
+    launchId: entry.launchId
+  }
+}
+
+function readGpuCrashHistory(userDataPath: string): GpuCrashHistory | null {
+  try {
+    const parsed = JSON.parse(readFileSync(historyPath(userDataPath), 'utf-8')) as Partial<
+      Record<keyof GpuCrashHistory, unknown>
+    >
+    if (parsed.schemeVersion !== GPU_CRASH_HISTORY_SCHEME_VERSION) {
+      return null
+    }
+    if (
+      typeof parsed.appVersion !== 'string' ||
+      typeof parsed.electronVersion !== 'string' ||
+      parsed.platform !== 'win32' ||
+      !Array.isArray(parsed.crashes)
+    ) {
+      return null
+    }
+    return {
+      schemeVersion: GPU_CRASH_HISTORY_SCHEME_VERSION,
+      appVersion: parsed.appVersion,
+      electronVersion: parsed.electronVersion,
+      platform: parsed.platform,
+      // Why: a truncated write can leave one unreadable entry; the rest is still evidence.
+      crashes: parsed.crashes
+        .map(parseEntry)
+        .filter((entry): entry is GpuCrashHistoryEntry => entry !== null)
+    }
+  } catch {
+    // missing or corrupt means no evidence
+  }
+  return null
+}
+
+export function clearGpuCrashHistory(userDataPath: string): void {
+  try {
+    rmSync(historyPath(userDataPath), { force: true })
+  } catch {
+    // best effort; stale evidence ages out of the horizon anyway
+  }
+}
+
+/**
+ * Crash history recorded by this exact build, or an empty list. Mirrors
+ * readActiveGpuFallbackMarker: evidence from another app/Electron build says
+ * nothing about this one, so the file is discarded rather than carried forward.
+ */
+export function readActiveGpuCrashHistory(
+  userDataPath: string,
+  environment: GpuFallbackEnvironment
+): readonly GpuCrashHistoryEntry[] {
+  const history = readGpuCrashHistory(userDataPath)
+  if (!history) {
+    if (existsSync(historyPath(userDataPath))) {
+      clearGpuCrashHistory(userDataPath)
+    }
+    return []
+  }
+  if (
+    environment.platform !== 'win32' ||
+    history.platform !== environment.platform ||
+    history.appVersion !== environment.appVersion ||
+    history.electronVersion !== environment.electronVersion
+  ) {
+    clearGpuCrashHistory(userDataPath)
+    return []
+  }
+  return history.crashes
+}
+
+/**
+ * Durable (fsync + rename) because the caller is a process Chromium may FATAL
+ * milliseconds later: a torn or zero-length file destroys every earlier launch's
+ * evidence, not just this entry.
+ */
+function writeGpuCrashHistory(userDataPath: string, history: GpuCrashHistory): void {
+  const target = historyPath(userDataPath)
+  const temp = durableWriteTempPath(target)
+  try {
+    writeFileDurableSync(temp, target, JSON.stringify(history))
+  } catch (error) {
+    try {
+      rmSync(temp, { force: true })
+    } catch {
+      // sweepOrphanedGpuCrashHistoryWrites reclaims it later
+    }
+    throw error
+  }
+}
+
+/**
+ * Reclaims temp files orphaned by a death between write and rename. This is the
+ * one machine class where that death is routine, and the temp name carries the
+ * pid, so without a sweep the orphans accumulate under distinct names forever.
+ */
+export function sweepOrphanedGpuCrashHistoryWrites(userDataPath: string): void {
+  void removeStaleDurableWriteTempFiles(historyPath(userDataPath), {
+    minimumAgeMs: GPU_CRASH_HISTORY_HORIZON_MS
+  }).catch(() => {
+    // best effort; an orphaned temp file costs a few bytes
+  })
+}
+
+/**
+ * Records one crashing launch.
+ *
+ * The read-time filters are enforced here too, so an uncountable crash can never
+ * take a slot: a driver in a respawn loop emits dozens of crashes under one
+ * launchId, and appending them all would evict every other launch and hold the
+ * distinct-launch counter at 1 forever.
+ */
+export function recordGpuCrashInHistory(
+  userDataPath: string,
+  entry: GpuCrashHistoryEntry,
+  environment: WindowsGpuFallbackEnvironment
+): void {
+  if (entry.msSinceLaunch > GPU_CRASH_STARTUP_WINDOW_MS) {
+    return
+  }
+  const existing = readActiveGpuCrashHistory(userDataPath, environment)
+  if (existing.some((crash) => crash.launchId === entry.launchId)) {
+    return
+  }
+  writeGpuCrashHistory(userDataPath, {
+    schemeVersion: GPU_CRASH_HISTORY_SCHEME_VERSION,
+    appVersion: environment.appVersion,
+    electronVersion: environment.electronVersion,
+    platform: 'win32',
+    crashes: [...existing, entry].slice(-GPU_CRASH_HISTORY_MAX_ENTRIES)
+  })
+}
+
+/**
+ * Drops one launch's evidence and keeps every other launch's.
+ *
+ * Why scoped: a launch answers only for itself. It painted a window and survived,
+ * or the user declined the in-session prompt it raised — neither says anything
+ * about the earlier launches that died before any window existed.
+ */
+export function forgetGpuCrashLaunch(userDataPath: string, launchId: string): void {
+  const history = readGpuCrashHistory(userDataPath)
+  if (!history) {
+    return
+  }
+  const crashes = history.crashes.filter((crash) => crash.launchId !== launchId)
+  if (crashes.length === history.crashes.length) {
+    return
+  }
+  if (crashes.length === 0) {
+    clearGpuCrashHistory(userDataPath)
+    return
+  }
+  writeGpuCrashHistory(userDataPath, { ...history, crashes })
+}
+
+/**
+ * Distinct launches whose GPU child died during startup inside the horizon.
+ *
+ * Why both filters: without the wall-clock horizon a healthy machine
+ * accumulates a false positive over months, and without the startup window a
+ * crash 20 minutes into a session (the in-session tracker's job) would feed a
+ * counter that means "cannot even boot".
+ */
+export function countStartupGpuCrashLaunches(
+  crashes: readonly GpuCrashHistoryEntry[],
+  nowEpochMs: number
+): number {
+  const launchIds = new Set<string>()
+  for (const crash of crashes) {
+    // Why absolute: atEpochMs is stamped ~600ms into boot, before W32Time corrects a
+    // wrong RTC, so a later backward correction leaves future-dated entries that a
+    // one-directional horizon would never age out — evidence immortal for the build.
+    if (Math.abs(nowEpochMs - crash.atEpochMs) > GPU_CRASH_HISTORY_HORIZON_MS) {
+      continue
+    }
+    if (crash.msSinceLaunch > GPU_CRASH_STARTUP_WINDOW_MS) {
+      continue
+    }
+    launchIds.add(crash.launchId)
+  }
+  return launchIds.size
+}

--- a/src/main/startup/gpu-crash-history.ts
+++ b/src/main/startup/gpu-crash-history.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, rmSync } from 'node:fs'
+import { rmSync } from 'node:fs'
 import { join } from 'node:path'
 import {
   durableWriteTempPath,
@@ -6,6 +6,7 @@ import {
   writeFileDurableSync
 } from '../durable-file-write'
 import type { GpuFallbackEnvironment, WindowsGpuFallbackEnvironment } from './gpu-fallback-marker'
+import { readPersistedJson, type PersistedJsonRead } from './persisted-json-read'
 
 /**
  * Persisted GPU-crash evidence, sibling of gpu-fallback.json.
@@ -78,40 +79,40 @@ function parseEntry(value: unknown): GpuCrashHistoryEntry | null {
   }
 }
 
-function readGpuCrashHistory(userDataPath: string): GpuCrashHistory | null {
-  try {
-    const parsed = JSON.parse(readFileSync(historyPath(userDataPath), 'utf-8')) as Partial<
-      Record<keyof GpuCrashHistory, unknown>
-    >
-    if (parsed.schemeVersion !== GPU_CRASH_HISTORY_SCHEME_VERSION) {
-      return null
-    }
-    if (
-      typeof parsed.appVersion !== 'string' ||
-      typeof parsed.electronVersion !== 'string' ||
-      parsed.platform !== 'win32' ||
-      !Array.isArray(parsed.crashes)
-    ) {
-      return null
-    }
-    return {
-      schemeVersion: GPU_CRASH_HISTORY_SCHEME_VERSION,
-      appVersion: parsed.appVersion,
-      electronVersion: parsed.electronVersion,
-      platform: parsed.platform,
-      // Why: capped before parsing, not just on write. This runs before whenReady, and only
-      // the newest entries can still be inside the horizon, so a file grown by anything other
-      // than this code costs the launch path a bounded parse instead of one linear in its size.
-      // Dropping an unreadable entry keeps the rest: a truncated write is still evidence.
-      crashes: parsed.crashes
-        .slice(-GPU_CRASH_HISTORY_MAX_ENTRIES)
-        .map(parseEntry)
-        .filter((entry): entry is GpuCrashHistoryEntry => entry !== null)
-    }
-  } catch {
-    // missing or corrupt means no evidence
+function parseHistory(value: unknown): GpuCrashHistory | null {
+  if (typeof value !== 'object' || value === null) {
+    return null
   }
-  return null
+  const parsed = value as Partial<Record<keyof GpuCrashHistory, unknown>>
+  if (parsed.schemeVersion !== GPU_CRASH_HISTORY_SCHEME_VERSION) {
+    return null
+  }
+  if (
+    typeof parsed.appVersion !== 'string' ||
+    typeof parsed.electronVersion !== 'string' ||
+    parsed.platform !== 'win32' ||
+    !Array.isArray(parsed.crashes)
+  ) {
+    return null
+  }
+  return {
+    schemeVersion: GPU_CRASH_HISTORY_SCHEME_VERSION,
+    appVersion: parsed.appVersion,
+    electronVersion: parsed.electronVersion,
+    platform: parsed.platform,
+    // Why: capped before parsing, not just on write. This runs before whenReady, and only
+    // the newest entries can still be inside the horizon, so a file grown by anything other
+    // than this code costs the launch path a bounded parse instead of one linear in its size.
+    // Dropping an unreadable entry keeps the rest: a truncated write is still evidence.
+    crashes: parsed.crashes
+      .slice(-GPU_CRASH_HISTORY_MAX_ENTRIES)
+      .map(parseEntry)
+      .filter((entry): entry is GpuCrashHistoryEntry => entry !== null)
+  }
+}
+
+function readGpuCrashHistory(userDataPath: string): PersistedJsonRead<GpuCrashHistory> {
+  return readPersistedJson(historyPath(userDataPath), parseHistory)
 }
 
 /**
@@ -137,13 +138,28 @@ export function readActiveGpuCrashHistory(
   userDataPath: string,
   environment: GpuFallbackEnvironment
 ): readonly GpuCrashHistoryEntry[] {
-  const history = readGpuCrashHistory(userDataPath)
-  if (!history) {
-    if (existsSync(historyPath(userDataPath))) {
+  return loadActiveGpuCrashHistory(userDataPath, environment).crashes
+}
+
+/**
+ * `readActiveGpuCrashHistory` plus whether the empty list means "nothing recorded" or
+ * "this process could not read what is recorded" — a distinction only the write path needs.
+ */
+function loadActiveGpuCrashHistory(
+  userDataPath: string,
+  environment: GpuFallbackEnvironment
+): { crashes: readonly GpuCrashHistoryEntry[]; unreadable: boolean } {
+  const read = readGpuCrashHistory(userDataPath)
+  if (read.kind !== 'ok') {
+    // Why: delete only what parsed as not-ours. A file this process merely could not open —
+    // a Defender sharing violation right after the publishing rename is the Windows shape —
+    // is still every earlier launch's evidence, and it ages out of the horizon by itself.
+    if (read.kind === 'invalid') {
       clearGpuCrashHistory(userDataPath)
     }
-    return []
+    return { crashes: [], unreadable: read.kind === 'unreadable' }
   }
+  const history = read.value
   if (
     environment.platform !== 'win32' ||
     history.platform !== environment.platform ||
@@ -151,9 +167,9 @@ export function readActiveGpuCrashHistory(
     history.electronVersion !== environment.electronVersion
   ) {
     clearGpuCrashHistory(userDataPath)
-    return []
+    return { crashes: [], unreadable: false }
   }
-  return history.crashes
+  return { crashes: history.crashes, unreadable: false }
 }
 
 /**
@@ -205,8 +221,10 @@ export function recordGpuCrashInHistory(
   if (entry.msSinceLaunch > GPU_CRASH_STARTUP_WINDOW_MS) {
     return
   }
-  const existing = readActiveGpuCrashHistory(userDataPath, environment)
-  if (existing.some((crash) => crash.launchId === entry.launchId)) {
+  const existing = loadActiveGpuCrashHistory(userDataPath, environment)
+  // Why: publishing a one-entry file over a history we failed to read would erase the other
+  // launches just as surely as deleting it. One launch's entry is the cheaper thing to lose.
+  if (existing.unreadable || existing.crashes.some((crash) => crash.launchId === entry.launchId)) {
     return
   }
   writeGpuCrashHistory(userDataPath, {
@@ -214,7 +232,7 @@ export function recordGpuCrashInHistory(
     appVersion: environment.appVersion,
     electronVersion: environment.electronVersion,
     platform: 'win32',
-    crashes: [...existing, entry].slice(-GPU_CRASH_HISTORY_MAX_ENTRIES)
+    crashes: [...existing.crashes, entry].slice(-GPU_CRASH_HISTORY_MAX_ENTRIES)
   })
 }
 
@@ -226,10 +244,11 @@ export function recordGpuCrashInHistory(
  * about the earlier launches that died before any window existed.
  */
 export function forgetGpuCrashLaunch(userDataPath: string, launchId: string): void {
-  const history = readGpuCrashHistory(userDataPath)
-  if (!history) {
+  const read = readGpuCrashHistory(userDataPath)
+  if (read.kind !== 'ok') {
     return
   }
+  const history = read.value
   const crashes = history.crashes.filter((crash) => crash.launchId !== launchId)
   if (crashes.length === history.crashes.length) {
     return

--- a/src/main/startup/gpu-crash-history.ts
+++ b/src/main/startup/gpu-crash-history.ts
@@ -99,8 +99,12 @@ function readGpuCrashHistory(userDataPath: string): GpuCrashHistory | null {
       appVersion: parsed.appVersion,
       electronVersion: parsed.electronVersion,
       platform: parsed.platform,
-      // Why: a truncated write can leave one unreadable entry; the rest is still evidence.
+      // Why: capped before parsing, not just on write. This runs before whenReady, and only
+      // the newest entries can still be inside the horizon, so a file grown by anything other
+      // than this code costs the launch path a bounded parse instead of one linear in its size.
+      // Dropping an unreadable entry keeps the rest: a truncated write is still evidence.
       crashes: parsed.crashes
+        .slice(-GPU_CRASH_HISTORY_MAX_ENTRIES)
         .map(parseEntry)
         .filter((entry): entry is GpuCrashHistoryEntry => entry !== null)
     }
@@ -110,6 +114,12 @@ function readGpuCrashHistory(userDataPath: string): GpuCrashHistory | null {
   return null
 }
 
+/**
+ * Whole-file drop. Reserved for events that retire the evidence outright — it was
+ * promoted into the marker, or the user set Safe Graphics Mode by hand. Every
+ * per-launch lifecycle step goes through forgetGpuCrashLaunch instead, because one
+ * launch is never entitled to speak for the launches it did not live through.
+ */
 export function clearGpuCrashHistory(userDataPath: string): void {
   try {
     rmSync(historyPath(userDataPath), { force: true })

--- a/src/main/startup/gpu-fallback-launch-decision.test.ts
+++ b/src/main/startup/gpu-fallback-launch-decision.test.ts
@@ -161,18 +161,20 @@ describe('post-update threshold', () => {
 })
 
 describe('resolveGpuCrashHistoryReset', () => {
-  it('clears everything when a launch painted with no startup GPU death', () => {
+  // Why: a clean boot spends the previous build's lowered threshold, but the history is still
+  // only ever touched one launchId at a time — other launches' evidence is not this one's to drop.
+  it('forgets only this launch when it painted with no startup GPU death', () => {
     expect(
       resolveGpuCrashHistoryReset({ gpuCrashedDuringStartup: false, gpuFallbackActive: false })
-    ).toBe('clear-all')
+    ).toEqual({ forgetThisLaunch: true, clearSupersededMarker: true })
   })
 
   // Why: Chromium respawns the dead child and the window paints anyway, so this launch is not
-  // "cannot even boot" — but the launches that died before any window existed still are.
-  it('exonerates only the launch whose GPU child died during startup', () => {
+  // "cannot even boot" — but the child is still dying, so the update keeps its head start.
+  it('exonerates the launch whose GPU child died during startup without spending the head start', () => {
     expect(
       resolveGpuCrashHistoryReset({ gpuCrashedDuringStartup: true, gpuFallbackActive: false })
-    ).toBe('forget-this-launch')
+    ).toEqual({ forgetThisLaunch: true, clearSupersededMarker: false })
   })
 
   // Why: `in-process-gpu` leaves no GPU child to die, so surviving proves nothing about the
@@ -180,6 +182,6 @@ describe('resolveGpuCrashHistoryReset', () => {
   it('proves nothing when the launch only booted because software rendering was on', () => {
     expect(
       resolveGpuCrashHistoryReset({ gpuCrashedDuringStartup: false, gpuFallbackActive: true })
-    ).toBe('none')
+    ).toEqual({ forgetThisLaunch: false, clearSupersededMarker: false })
   })
 })

--- a/src/main/startup/gpu-fallback-launch-decision.test.ts
+++ b/src/main/startup/gpu-fallback-launch-decision.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CROSS_LAUNCH_GPU_FALLBACK_THRESHOLD,
+  GPU_CRASH_HISTORY_HORIZON_MS,
+  type GpuCrashHistoryEntry
+} from './gpu-crash-history'
+import {
+  decideGpuFallbackForLaunch,
+  resolveGpuCrashHistoryReset
+} from './gpu-fallback-launch-decision'
+import type { GpuFallbackEnvironment, GpuFallbackMarker } from './gpu-fallback-marker'
+
+const NOW = 1_760_000_000_000
+
+const ENVIRONMENT: GpuFallbackEnvironment = {
+  appVersion: '1.4.184',
+  electronVersion: '43.1.0',
+  platform: 'win32'
+}
+
+const MARKER: GpuFallbackMarker = {
+  schemeVersion: 2,
+  engagedAt: NOW - 1_000,
+  crashesInWindow: 3,
+  appVersion: '1.4.184',
+  electronVersion: '43.1.0',
+  platform: 'win32',
+  source: 'automatic'
+}
+
+function crashingLaunches(count: number, atEpochMs = NOW - 1_000): GpuCrashHistoryEntry[] {
+  return Array.from({ length: count }, (_, index) => ({
+    atEpochMs,
+    msSinceLaunch: 581,
+    launchId: `launch-${index}`
+  }))
+}
+
+describe('decideGpuFallbackForLaunch', () => {
+  it('does not engage without evidence', () => {
+    expect(
+      decideGpuFallbackForLaunch({
+        marker: null,
+        history: [],
+        nowEpochMs: NOW,
+        environment: ENVIRONMENT
+      })
+    ).toEqual({ engage: false, reason: 'no-evidence', crashesInWindow: 0, engagedAt: null })
+  })
+
+  it('engages from an existing marker without re-deriving', () => {
+    expect(
+      decideGpuFallbackForLaunch({
+        marker: MARKER,
+        history: crashingLaunches(1),
+        nowEpochMs: NOW,
+        environment: ENVIRONMENT
+      })
+    ).toEqual({
+      engage: true,
+      reason: 'marker',
+      crashesInWindow: 3,
+      engagedAt: MARKER.engagedAt
+    })
+  })
+
+  it('engages once enough distinct launches crashed at startup', () => {
+    expect(
+      decideGpuFallbackForLaunch({
+        marker: null,
+        history: crashingLaunches(CROSS_LAUNCH_GPU_FALLBACK_THRESHOLD),
+        nowEpochMs: NOW,
+        environment: ENVIRONMENT
+      })
+    ).toEqual({
+      engage: true,
+      reason: 'crash-history',
+      crashesInWindow: CROSS_LAUNCH_GPU_FALLBACK_THRESHOLD,
+      engagedAt: NOW
+    })
+  })
+
+  it('holds below the threshold', () => {
+    expect(
+      decideGpuFallbackForLaunch({
+        marker: null,
+        history: crashingLaunches(CROSS_LAUNCH_GPU_FALLBACK_THRESHOLD - 1),
+        nowEpochMs: NOW,
+        environment: ENVIRONMENT
+      }).engage
+    ).toBe(false)
+  })
+
+  it('ignores evidence past the wall-clock horizon', () => {
+    expect(
+      decideGpuFallbackForLaunch({
+        marker: null,
+        history: crashingLaunches(
+          CROSS_LAUNCH_GPU_FALLBACK_THRESHOLD,
+          NOW - GPU_CRASH_HISTORY_HORIZON_MS - 1
+        ),
+        nowEpochMs: NOW,
+        environment: ENVIRONMENT
+      })
+    ).toEqual({ engage: false, reason: 'no-evidence', crashesInWindow: 0, engagedAt: null })
+  })
+
+  // Why: enableMainProcessGpuFeatures() carries the macOS Graphite fix and is skipped while
+  // fallback is active, so this must never engage off Windows.
+  it('never engages off Windows', () => {
+    for (const platform of ['darwin', 'linux'] as const) {
+      expect(
+        decideGpuFallbackForLaunch({
+          marker: MARKER,
+          history: crashingLaunches(CROSS_LAUNCH_GPU_FALLBACK_THRESHOLD),
+          nowEpochMs: NOW,
+          environment: { ...ENVIRONMENT, platform }
+        })
+      ).toEqual({
+        engage: false,
+        reason: 'unsupported-platform',
+        crashesInWindow: 0,
+        engagedAt: null
+      })
+    }
+  })
+})
+
+describe('post-update threshold', () => {
+  // Why: the previous build's evidence dies with the update, so the full threshold would cost
+  // a machine that cannot boot three unusable launches after every release.
+  it('re-engages after a single crashing launch when a previous build had fallen back', () => {
+    expect(
+      decideGpuFallbackForLaunch({
+        marker: null,
+        supersededBuildMarker: { ...MARKER, appVersion: '1.4.183' },
+        history: crashingLaunches(1),
+        nowEpochMs: NOW,
+        environment: ENVIRONMENT
+      })
+    ).toEqual({
+      engage: true,
+      reason: 'crash-history-after-update',
+      crashesInWindow: 1,
+      engagedAt: NOW
+    })
+  })
+
+  // Why: the update may be the fix, so the new build still gets one hardware attempt.
+  it('still gives the new build one fresh hardware attempt', () => {
+    expect(
+      decideGpuFallbackForLaunch({
+        marker: null,
+        supersededBuildMarker: { ...MARKER, appVersion: '1.4.183' },
+        history: [],
+        nowEpochMs: NOW,
+        environment: ENVIRONMENT
+      }).engage
+    ).toBe(false)
+  })
+})
+
+describe('resolveGpuCrashHistoryReset', () => {
+  it('clears everything when a launch painted with no startup GPU death', () => {
+    expect(
+      resolveGpuCrashHistoryReset({ gpuCrashedDuringStartup: false, gpuFallbackActive: false })
+    ).toBe('clear-all')
+  })
+
+  // Why: Chromium respawns the dead child and the window paints anyway, so this launch is not
+  // "cannot even boot" — but the launches that died before any window existed still are.
+  it('exonerates only the launch whose GPU child died during startup', () => {
+    expect(
+      resolveGpuCrashHistoryReset({ gpuCrashedDuringStartup: true, gpuFallbackActive: false })
+    ).toBe('forget-this-launch')
+  })
+
+  // Why: `in-process-gpu` leaves no GPU child to die, so surviving proves nothing about the
+  // driver — and if the marker write failed, the history is the only thing keeping fallback on.
+  it('proves nothing when the launch only booted because software rendering was on', () => {
+    expect(
+      resolveGpuCrashHistoryReset({ gpuCrashedDuringStartup: false, gpuFallbackActive: true })
+    ).toBe('none')
+  })
+})

--- a/src/main/startup/gpu-fallback-launch-decision.ts
+++ b/src/main/startup/gpu-fallback-launch-decision.ts
@@ -1,0 +1,109 @@
+import {
+  CROSS_LAUNCH_GPU_FALLBACK_THRESHOLD,
+  CROSS_LAUNCH_GPU_FALLBACK_THRESHOLD_AFTER_UPDATE,
+  countStartupGpuCrashLaunches,
+  type GpuCrashHistoryEntry
+} from './gpu-crash-history'
+import type { GpuFallbackEnvironment, GpuFallbackMarker } from './gpu-fallback-marker'
+
+export type GpuFallbackLaunchDecision = {
+  /** Disable hardware acceleration before app.whenReady() for this launch. */
+  engage: boolean
+  /**
+   * `marker` = a previous launch already decided; the `crash-history` reasons mean
+   * this launch is deciding now off persisted evidence and must write the marker,
+   * `-after-update` on the lowered post-update threshold.
+   */
+  reason:
+    | 'marker'
+    | 'crash-history'
+    | 'crash-history-after-update'
+    | 'no-evidence'
+    | 'unsupported-platform'
+  /** Crashing launches (or the marker's recorded count) behind the decision. */
+  crashesInWindow: number
+  /** Epoch ms this engagement began — identity of the downgrade for the renderer notice. */
+  engagedAt: number | null
+}
+
+/**
+ * Whether this launch should boot in software rendering, decided from the two
+ * durable artifacts only. Pure so the cross-launch behavior is testable without
+ * an Electron app object or timers.
+ *
+ * Order matters: an existing marker wins, so a build that already fell back
+ * never re-derives the decision from stale evidence.
+ */
+export function decideGpuFallbackForLaunch({
+  marker,
+  supersededBuildMarker = null,
+  history,
+  nowEpochMs,
+  environment
+}: {
+  /** Build-scoped marker, already validated by readActiveGpuFallbackMarker. */
+  marker: GpuFallbackMarker | null
+  /** Marker left by a build this one replaced; lowers the threshold to one crashing launch. */
+  supersededBuildMarker?: GpuFallbackMarker | null
+  /** Build-scoped crash history, already validated by readActiveGpuCrashHistory. */
+  history: readonly GpuCrashHistoryEntry[]
+  nowEpochMs: number
+  environment: GpuFallbackEnvironment
+}): GpuFallbackLaunchDecision {
+  if (environment.platform !== 'win32') {
+    return { engage: false, reason: 'unsupported-platform', crashesInWindow: 0, engagedAt: null }
+  }
+  if (marker) {
+    return {
+      engage: true,
+      reason: 'marker',
+      crashesInWindow: marker.crashesInWindow,
+      engagedAt: marker.engagedAt
+    }
+  }
+  const crashingLaunches = countStartupGpuCrashLaunches(history, nowEpochMs)
+  const threshold = supersededBuildMarker
+    ? CROSS_LAUNCH_GPU_FALLBACK_THRESHOLD_AFTER_UPDATE
+    : CROSS_LAUNCH_GPU_FALLBACK_THRESHOLD
+  if (crashingLaunches >= threshold) {
+    return {
+      engage: true,
+      reason: supersededBuildMarker ? 'crash-history-after-update' : 'crash-history',
+      crashesInWindow: crashingLaunches,
+      engagedAt: nowEpochMs
+    }
+  }
+  return {
+    engage: false,
+    reason: 'no-evidence',
+    crashesInWindow: crashingLaunches,
+    engagedAt: null
+  }
+}
+
+/** `clear-all` = the driver works today; `forget-this-launch` = only this launch is exonerated. */
+export type GpuCrashHistoryResetAction = 'clear-all' | 'forget-this-launch' | 'none'
+
+/**
+ * What a launch that painted a window and then survived a minute has proved.
+ *
+ * With software rendering on there is no GPU child left to die, so surviving says
+ * nothing about the driver — and if the marker write failed, the history is the
+ * only thing keeping the fallback on.
+ *
+ * A launch whose GPU child died during startup and painted anyway is not "cannot
+ * even boot", so it stops counting for itself; but the launches that died before
+ * any window existed are not this launch's to exonerate.
+ */
+export function resolveGpuCrashHistoryReset({
+  gpuCrashedDuringStartup,
+  gpuFallbackActive
+}: {
+  gpuCrashedDuringStartup: boolean
+  gpuFallbackActive: boolean
+}): GpuCrashHistoryResetAction {
+  if (gpuFallbackActive) {
+    return 'none'
+  }
+  return gpuCrashedDuringStartup ? 'forget-this-launch' : 'clear-all'
+}

--- a/src/main/startup/gpu-fallback-launch-decision.ts
+++ b/src/main/startup/gpu-fallback-launch-decision.ts
@@ -81,8 +81,16 @@ export function decideGpuFallbackForLaunch({
   }
 }
 
-/** `clear-all` = the driver works today; `forget-this-launch` = only this launch is exonerated. */
-export type GpuCrashHistoryResetAction = 'clear-all' | 'forget-this-launch' | 'none'
+export type GpuCrashHistoryReset = {
+  /**
+   * Drop this launch's entry, if it has one. The history is only ever mutated one
+   * launchId at a time, so a launch answers for itself and never for the launches
+   * that died before any window existed.
+   */
+  forgetThisLaunch: boolean
+  /** Spend the previous build's lowered threshold: this build reached a window with no GPU death at all. */
+  clearSupersededMarker: boolean
+}
 
 /**
  * What a launch that painted a window and then survived a minute has proved.
@@ -91,9 +99,9 @@ export type GpuCrashHistoryResetAction = 'clear-all' | 'forget-this-launch' | 'n
  * nothing about the driver — and if the marker write failed, the history is the
  * only thing keeping the fallback on.
  *
- * A launch whose GPU child died during startup and painted anyway is not "cannot
- * even boot", so it stops counting for itself; but the launches that died before
- * any window existed are not this launch's to exonerate.
+ * Otherwise the launch demonstrably booted, so it stops counting as "cannot even
+ * boot" evidence — for itself only. A startup GPU death still bars spending the
+ * previous build's head start: the child is dying on this build too.
  */
 export function resolveGpuCrashHistoryReset({
   gpuCrashedDuringStartup,
@@ -101,9 +109,9 @@ export function resolveGpuCrashHistoryReset({
 }: {
   gpuCrashedDuringStartup: boolean
   gpuFallbackActive: boolean
-}): GpuCrashHistoryResetAction {
+}): GpuCrashHistoryReset {
   if (gpuFallbackActive) {
-    return 'none'
+    return { forgetThisLaunch: false, clearSupersededMarker: false }
   }
-  return gpuCrashedDuringStartup ? 'forget-this-launch' : 'clear-all'
+  return { forgetThisLaunch: true, clearSupersededMarker: !gpuCrashedDuringStartup }
 }

--- a/src/main/startup/gpu-fallback-launch-engagement.ts
+++ b/src/main/startup/gpu-fallback-launch-engagement.ts
@@ -1,0 +1,84 @@
+import type { CrashReportBreadcrumbData } from '../../shared/crash-reporting'
+import { clearGpuCrashHistory, readActiveGpuCrashHistory } from './gpu-crash-history'
+import {
+  decideGpuFallbackForLaunch,
+  type GpuFallbackLaunchDecision
+} from './gpu-fallback-launch-decision'
+import {
+  readGpuFallbackMarkerState,
+  writeGpuFallbackMarker,
+  type GpuFallbackEnvironment
+} from './gpu-fallback-marker'
+import {
+  applyGpuFallbackCommandLineSwitches,
+  type GpuFallbackCommandLine
+} from './gpu-fallback-switches'
+
+export type GpuFallbackLaunchHooks = {
+  /** app.disableHardwareAcceleration — must run before app.whenReady() resolves. */
+  disableHardwareAcceleration: () => void
+  commandLine: GpuFallbackCommandLine
+  recordBreadcrumb: (name: string, data?: CrashReportBreadcrumbData) => void
+}
+
+/**
+ * Decides and applies software rendering for the launch in progress.
+ *
+ * Runs before whenReady, so there is no window to prompt on: when the persisted
+ * crash history crosses the threshold this engages *silently* and promotes the
+ * evidence to a marker. The renderer notice explains it after the fact and
+ * offers the way back. The in-session prompt+relaunch path stays as-is — it is
+ * correct precisely because the app is alive enough to ask.
+ */
+export function engageGpuFallbackForLaunch({
+  userDataPath,
+  environment,
+  nowEpochMs,
+  hooks
+}: {
+  userDataPath: string
+  environment: GpuFallbackEnvironment
+  nowEpochMs: number
+  hooks: GpuFallbackLaunchHooks
+}): GpuFallbackLaunchDecision {
+  const markerState = readGpuFallbackMarkerState(userDataPath, environment)
+  const decision = decideGpuFallbackForLaunch({
+    marker: markerState.active,
+    supersededBuildMarker: markerState.supersededBuild,
+    history: readActiveGpuCrashHistory(userDataPath, environment),
+    nowEpochMs,
+    environment
+  })
+  if (!decision.engage) {
+    return decision
+  }
+  hooks.disableHardwareAcceleration()
+  const appliedSwitches = applyGpuFallbackCommandLineSwitches(
+    hooks.commandLine,
+    environment.platform
+  )
+  if (decision.reason !== 'marker' && environment.platform === 'win32') {
+    try {
+      writeGpuFallbackMarker(
+        userDataPath,
+        { engagedAt: nowEpochMs, crashesInWindow: decision.crashesInWindow },
+        { ...environment, platform: 'win32' }
+      )
+      // Why: the evidence is spent once it becomes a decision — leaving it would
+      // re-engage immediately after the user asks for hardware acceleration back.
+      clearGpuCrashHistory(userDataPath)
+    } catch (error) {
+      // Why: this runs before whenReady — a userData EPERM must not turn a
+      // graphics workaround into a startup crash. The history re-derives it.
+      console.warn('[gpu-fallback] failed to persist marker:', error)
+    }
+  }
+  // Why: with no GPU child left, child-process-gone can't report a GPU fault, so
+  // name the applied switches in the trail any later crash report carries.
+  hooks.recordBreadcrumb('gpu_fallback_applied', {
+    source: decision.reason,
+    crashesInWindow: decision.crashesInWindow,
+    switches: appliedSwitches.join(',')
+  })
+  return decision
+}

--- a/src/main/startup/gpu-fallback-launch-engagement.ts
+++ b/src/main/startup/gpu-fallback-launch-engagement.ts
@@ -41,7 +41,7 @@ export function engageGpuFallbackForLaunch({
   nowEpochMs: number
   hooks: GpuFallbackLaunchHooks
 }): GpuFallbackLaunchDecision {
-  const markerState = readGpuFallbackMarkerState(userDataPath, environment)
+  const markerState = readGpuFallbackMarkerState(userDataPath, environment, nowEpochMs)
   const decision = decideGpuFallbackForLaunch({
     marker: markerState.active,
     supersededBuildMarker: markerState.supersededBuild,

--- a/src/main/startup/gpu-fallback-marker-durability.test.ts
+++ b/src/main/startup/gpu-fallback-marker-durability.test.ts
@@ -1,0 +1,92 @@
+import { mkdtempSync, readdirSync, rmSync } from 'node:fs'
+import type * as NodeFsModule from 'node:fs'
+import os from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { GPU_FALLBACK_MARKER_FILE, writeGpuFallbackMarker } from './gpu-fallback-marker'
+
+/**
+ * The marker is written by a process Chromium may FATAL milliseconds later, and both callers
+ * drop the crash history the instant the write returns. A bare writeFileSync could therefore
+ * leave a torn marker (discarded as corrupt on the next launch) with the evidence already
+ * gone — neither artifact survives and the machine is back in the unbootable loop.
+ */
+
+const calls = vi.hoisted(() => [] as string[])
+const failRenameOnto = vi.hoisted(() => ({ path: null as string | null }))
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFsModule>()
+  const writeFileSync = (...args: Parameters<typeof actual.writeFileSync>): void => {
+    calls.push(`write:${String(args[0])}`)
+    actual.writeFileSync(...args)
+  }
+  const fsyncSync = (...args: Parameters<typeof actual.fsyncSync>): void => {
+    calls.push('fsync')
+    actual.fsyncSync(...args)
+  }
+  const renameSync = (...args: Parameters<typeof actual.renameSync>): void => {
+    calls.push(`rename:${String(args[1])}`)
+    if (failRenameOnto.path !== null && args[1] === failRenameOnto.path) {
+      throw Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' })
+    }
+    actual.renameSync(...args)
+  }
+  return {
+    ...actual,
+    default: { ...actual, writeFileSync, fsyncSync, renameSync },
+    writeFileSync,
+    fsyncSync,
+    renameSync
+  }
+})
+
+const ENVIRONMENT = {
+  appVersion: '1.4.184',
+  electronVersion: '43.1.0',
+  platform: 'win32' as const
+}
+
+describe('gpu-fallback marker durability', () => {
+  let userDataPath: string
+  let markerPath: string
+
+  beforeEach(() => {
+    userDataPath = mkdtempSync(join(os.tmpdir(), 'orca-gpu-marker-durable-'))
+    markerPath = join(userDataPath, GPU_FALLBACK_MARKER_FILE)
+    calls.length = 0
+    failRenameOnto.path = null
+  })
+
+  afterEach(() => {
+    failRenameOnto.path = null
+    rmSync(userDataPath, { recursive: true, force: true })
+  })
+
+  it('fsyncs a temp file and renames it onto the marker, never writing the marker in place', () => {
+    writeGpuFallbackMarker(
+      userDataPath,
+      { engagedAt: 1_760_000_000_000, crashesInWindow: 3 },
+      ENVIRONMENT
+    )
+
+    expect(calls).not.toContain(`write:${markerPath}`)
+    const tempWrite = calls.findIndex((call) => call.startsWith(`write:${markerPath}.`))
+    const rename = calls.indexOf(`rename:${markerPath}`)
+    expect(tempWrite).toBeGreaterThanOrEqual(0)
+    expect(rename).toBeGreaterThan(tempWrite)
+    expect(calls.slice(tempWrite, rename)).toContain('fsync')
+    expect(readdirSync(userDataPath)).toEqual([GPU_FALLBACK_MARKER_FILE])
+  })
+
+  // Why: the temp name carries the pid, so a failure that left one behind would accumulate
+  // orphans under distinct names forever on the machine that retries this write every launch.
+  it('cleans up its temp file when the publishing rename fails', () => {
+    failRenameOnto.path = markerPath
+
+    expect(() =>
+      writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 3 }, ENVIRONMENT)
+    ).toThrow()
+    expect(readdirSync(userDataPath)).toEqual([])
+  })
+})

--- a/src/main/startup/gpu-fallback-marker.test.ts
+++ b/src/main/startup/gpu-fallback-marker.test.ts
@@ -1,16 +1,20 @@
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs'
 import os from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   GPU_FALLBACK_MARKER_FILE,
+  GPU_FALLBACK_SUPERSEDED_MARKER_MAX_AGE_MS,
   clearGpuFallbackMarker,
   clearSupersededGpuFallbackMarker,
   readActiveGpuFallbackMarker,
   readGpuFallbackMarker,
   readGpuFallbackMarkerState,
+  sweepOrphanedGpuFallbackMarkerWrites,
   writeGpuFallbackMarker
 } from './gpu-fallback-marker'
+
+const NOW = 1_760_000_000_000
 
 describe('gpu-fallback-marker', () => {
   let userDataPath: string
@@ -76,27 +80,66 @@ describe('gpu-fallback-marker', () => {
   // Why: the update gets one fresh hardware attempt, but keeping the record is what stops a
   // machine that cannot boot from paying the full three-launch threshold again every release.
   it('retires an automatic marker on a new build as a superseded-build record', () => {
-    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 4 }, environment)
+    writeGpuFallbackMarker(userDataPath, { engagedAt: NOW, crashesInWindow: 4 }, environment)
     const updated = { ...environment, appVersion: '1.2.4' }
 
-    expect(readActiveGpuFallbackMarker(userDataPath, updated)).toBeNull()
-    expect(readGpuFallbackMarkerState(userDataPath, updated).supersededBuild?.crashesInWindow).toBe(
-      4
-    )
+    expect(readActiveGpuFallbackMarker(userDataPath, updated, NOW)).toBeNull()
+    expect(
+      readGpuFallbackMarkerState(userDataPath, updated, NOW).supersededBuild?.crashesInWindow
+    ).toBe(4)
     expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(true)
 
-    clearSupersededGpuFallbackMarker(userDataPath, updated)
+    clearSupersededGpuFallbackMarker(userDataPath, updated, NOW)
     expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(false)
   })
 
   it('retires an automatic marker on a new Electron build too', () => {
-    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 4 }, environment)
+    writeGpuFallbackMarker(userDataPath, { engagedAt: NOW, crashesInWindow: 4 }, environment)
     const updated = { ...environment, electronVersion: '43.0.0' }
 
-    expect(readGpuFallbackMarkerState(userDataPath, updated)).toEqual({
+    expect(readGpuFallbackMarkerState(userDataPath, updated, NOW)).toEqual({
       active: null,
       supersededBuild: expect.objectContaining({ electronVersion: '42.3.3' })
     })
+  })
+
+  // Why: the superseded record lowers the threshold to a single crashing launch and has no
+  // horizon of its own; its only reaper needs a launch that survives a minute, which a machine
+  // used in short bursts never provides. Left forever, one spurious TDR a year later pins
+  // software rendering for the whole build with no prompt.
+  it('expires an automatic superseded-build record instead of keeping it as live evidence', () => {
+    writeGpuFallbackMarker(userDataPath, { engagedAt: NOW, crashesInWindow: 4 }, environment)
+    const updated = { ...environment, appVersion: '1.2.4' }
+    const aged = NOW + GPU_FALLBACK_SUPERSEDED_MARKER_MAX_AGE_MS + 1
+
+    expect(readGpuFallbackMarkerState(userDataPath, updated, aged)).toEqual({
+      active: null,
+      supersededBuild: null
+    })
+    expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(false)
+  })
+
+  it('keeps a superseded-build record inside its age, so an update still gets the head start', () => {
+    writeGpuFallbackMarker(userDataPath, { engagedAt: NOW, crashesInWindow: 4 }, environment)
+    const updated = { ...environment, appVersion: '1.2.4' }
+    const fresh = NOW + GPU_FALLBACK_SUPERSEDED_MARKER_MAX_AGE_MS
+
+    expect(readGpuFallbackMarkerState(userDataPath, updated, fresh).supersededBuild).not.toBeNull()
+    expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(true)
+  })
+
+  // Why: a pin is a standing choice with no expiry — only the user revokes it.
+  it('never expires a user-pinned marker, however old', () => {
+    writeGpuFallbackMarker(
+      userDataPath,
+      { engagedAt: NOW, crashesInWindow: 0, source: 'user' },
+      environment
+    )
+    const updated = { ...environment, appVersion: '1.2.4', electronVersion: '43.0.0' }
+    const aged = NOW + GPU_FALLBACK_SUPERSEDED_MARKER_MAX_AGE_MS * 12
+
+    expect(readActiveGpuFallbackMarker(userDataPath, updated, aged)?.source).toBe('user')
+    expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(true)
   })
 
   // Why: the user asked for software rendering; shipping an update is not consent to undo it.
@@ -153,6 +196,21 @@ describe('gpu-fallback-marker', () => {
     expect(readGpuFallbackMarker(userDataPath)).toBeNull()
     expect(readActiveGpuFallbackMarker(userDataPath, environment)).toBeNull()
     expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(false)
+  })
+
+  // Why: the durable write can die between temp and rename on exactly the machines that write
+  // this file, and the temp name carries the pid, so orphans pile up under distinct names.
+  it('sweeps a marker temp file orphaned by an earlier process', async () => {
+    const orphan = join(userDataPath, `${GPU_FALLBACK_MARKER_FILE}.999999.1.abc.tmp`)
+    writeFileSync(orphan, '{}')
+    const staleSeconds = (Date.now() - 24 * 60 * 60 * 1000) / 1000
+    utimesSync(orphan, staleSeconds, staleSeconds)
+
+    sweepOrphanedGpuFallbackMarkerWrites(userDataPath)
+
+    await vi.waitFor(() => {
+      expect(existsSync(orphan)).toBe(false)
+    })
   })
 
   it('can explicitly clear the marker', () => {

--- a/src/main/startup/gpu-fallback-marker.test.ts
+++ b/src/main/startup/gpu-fallback-marker.test.ts
@@ -5,8 +5,10 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import {
   GPU_FALLBACK_MARKER_FILE,
   clearGpuFallbackMarker,
+  clearSupersededGpuFallbackMarker,
   readActiveGpuFallbackMarker,
   readGpuFallbackMarker,
+  readGpuFallbackMarkerState,
   writeGpuFallbackMarker
 } from './gpu-fallback-marker'
 
@@ -34,8 +36,24 @@ describe('gpu-fallback-marker', () => {
       crashesInWindow: 3,
       appVersion: '1.2.3',
       electronVersion: '42.3.3',
-      platform: 'win32'
+      platform: 'win32',
+      source: 'automatic'
     })
+  })
+
+  // Why: markers predate the Settings pin, so a missing source is not corruption.
+  it('reads a marker written before the source field existed as automatic', () => {
+    writeFileSync(
+      join(userDataPath, GPU_FALLBACK_MARKER_FILE),
+      JSON.stringify({
+        schemeVersion: 2,
+        engagedAt: 1,
+        crashesInWindow: 3,
+        ...environment
+      })
+    )
+
+    expect(readGpuFallbackMarker(userDataPath)?.source).toBe('automatic')
   })
 
   it('returns null when no marker exists', () => {
@@ -55,16 +73,44 @@ describe('gpu-fallback-marker', () => {
     expect(secondRead?.crashesInWindow).toBe(4)
   })
 
-  it('clears an active marker when the app build changes', () => {
+  // Why: the update gets one fresh hardware attempt, but keeping the record is what stops a
+  // machine that cannot boot from paying the full three-launch threshold again every release.
+  it('retires an automatic marker on a new build as a superseded-build record', () => {
     writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 4 }, environment)
+    const updated = { ...environment, appVersion: '1.2.4' }
 
-    expect(
-      readActiveGpuFallbackMarker(userDataPath, {
-        ...environment,
-        appVersion: '1.2.4'
-      })
-    ).toBeNull()
+    expect(readActiveGpuFallbackMarker(userDataPath, updated)).toBeNull()
+    expect(readGpuFallbackMarkerState(userDataPath, updated).supersededBuild?.crashesInWindow).toBe(
+      4
+    )
+    expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(true)
+
+    clearSupersededGpuFallbackMarker(userDataPath, updated)
     expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(false)
+  })
+
+  it('retires an automatic marker on a new Electron build too', () => {
+    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 4 }, environment)
+    const updated = { ...environment, electronVersion: '43.0.0' }
+
+    expect(readGpuFallbackMarkerState(userDataPath, updated)).toEqual({
+      active: null,
+      supersededBuild: expect.objectContaining({ electronVersion: '42.3.3' })
+    })
+  })
+
+  // Why: the user asked for software rendering; shipping an update is not consent to undo it.
+  it('keeps a user-pinned marker active across app and Electron updates', () => {
+    writeGpuFallbackMarker(
+      userDataPath,
+      { engagedAt: 1, crashesInWindow: 0, source: 'user' },
+      environment
+    )
+    const updated = { ...environment, appVersion: '1.2.4', electronVersion: '43.0.0' }
+
+    expect(readActiveGpuFallbackMarker(userDataPath, updated)?.source).toBe('user')
+    clearSupersededGpuFallbackMarker(userDataPath, updated)
+    expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(true)
   })
 
   it('clears an active marker outside Windows', () => {

--- a/src/main/startup/gpu-fallback-marker.ts
+++ b/src/main/startup/gpu-fallback-marker.ts
@@ -1,5 +1,12 @@
-import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { rmSync } from 'node:fs'
 import { join } from 'node:path'
+import {
+  durableWriteTempPath,
+  removeStaleDurableWriteTempFiles,
+  writeFileDurableSync
+} from '../durable-file-write'
+import type { GpuFallbackSource } from '../../shared/gpu-fallback-status'
+import { readPersistedJson } from './persisted-json-read'
 
 /**
  * Persisted "disable hardware acceleration for this build" marker.
@@ -13,6 +20,21 @@ import { join } from 'node:path'
 export const GPU_FALLBACK_MARKER_FILE = 'gpu-fallback.json'
 export const GPU_FALLBACK_SCHEME_VERSION = 2
 
+/**
+ * How long an automatic marker left by a superseded build stays live evidence.
+ *
+ * Why bounded at all: unlike the crash history it has no horizon, and its only reaper needs a
+ * launch that survives a minute — a machine used in short bursts never spends it. Without this
+ * a record from a driver generation ago would keep the post-update threshold at one crash, so
+ * a single TDR years later pins software rendering for the whole build with no prompt.
+ * Why a month and not days: the record is what spares a chronically broken machine three
+ * unbootable launches per release, and update gaps of a couple of weeks are ordinary.
+ */
+export const GPU_FALLBACK_SUPERSEDED_MARKER_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000
+
+/** Spares another instance's in-flight write; nothing this old can still be mid-rename. */
+const GPU_FALLBACK_MARKER_TEMP_MIN_AGE_MS = 600_000
+
 export type GpuFallbackEnvironment = {
   appVersion: string
   electronVersion: string
@@ -22,7 +44,7 @@ export type GpuFallbackEnvironment = {
 export type WindowsGpuFallbackEnvironment = GpuFallbackEnvironment & { platform: 'win32' }
 
 /** `user` = asked for in Settings, so it outlives app and Electron updates; `automatic` = derived from crashes. */
-export type GpuFallbackMarkerSource = 'automatic' | 'user'
+export type GpuFallbackMarkerSource = GpuFallbackSource
 
 export type GpuFallbackMarker = {
   schemeVersion: number
@@ -45,41 +67,48 @@ function markerPath(userDataPath: string): string {
   return join(userDataPath, GPU_FALLBACK_MARKER_FILE)
 }
 
-export function readGpuFallbackMarker(userDataPath: string): GpuFallbackMarker | null {
-  try {
-    const parsed = JSON.parse(readFileSync(markerPath(userDataPath), 'utf-8')) as Partial<
-      Record<keyof GpuFallbackMarker, unknown>
-    >
-    if (parsed.schemeVersion !== GPU_FALLBACK_SCHEME_VERSION) {
-      return null
-    }
-    if (
-      typeof parsed.engagedAt !== 'number' ||
-      !Number.isFinite(parsed.engagedAt) ||
-      typeof parsed.crashesInWindow !== 'number' ||
-      !Number.isFinite(parsed.crashesInWindow) ||
-      typeof parsed.appVersion !== 'string' ||
-      typeof parsed.electronVersion !== 'string' ||
-      parsed.platform !== 'win32'
-    ) {
-      return null
-    }
-    return {
-      schemeVersion: GPU_FALLBACK_SCHEME_VERSION,
-      engagedAt: parsed.engagedAt,
-      crashesInWindow: parsed.crashesInWindow,
-      appVersion: parsed.appVersion,
-      electronVersion: parsed.electronVersion,
-      platform: parsed.platform,
-      // Why: markers written before the Settings pin existed carry no source; they were all automatic.
-      source: parsed.source === 'user' ? 'user' : 'automatic'
-    }
-  } catch {
-    // missing or corrupt means no fallback requested
+function parseMarker(value: unknown): GpuFallbackMarker | null {
+  if (typeof value !== 'object' || value === null) {
+    return null
   }
-  return null
+  const parsed = value as Partial<Record<keyof GpuFallbackMarker, unknown>>
+  if (parsed.schemeVersion !== GPU_FALLBACK_SCHEME_VERSION) {
+    return null
+  }
+  if (
+    typeof parsed.engagedAt !== 'number' ||
+    !Number.isFinite(parsed.engagedAt) ||
+    typeof parsed.crashesInWindow !== 'number' ||
+    !Number.isFinite(parsed.crashesInWindow) ||
+    typeof parsed.appVersion !== 'string' ||
+    typeof parsed.electronVersion !== 'string' ||
+    parsed.platform !== 'win32'
+  ) {
+    return null
+  }
+  return {
+    schemeVersion: GPU_FALLBACK_SCHEME_VERSION,
+    engagedAt: parsed.engagedAt,
+    crashesInWindow: parsed.crashesInWindow,
+    appVersion: parsed.appVersion,
+    electronVersion: parsed.electronVersion,
+    platform: parsed.platform,
+    // Why: markers written before the Settings pin existed carry no source; they were all automatic.
+    source: parsed.source === 'user' ? 'user' : 'automatic'
+  }
 }
 
+export function readGpuFallbackMarker(userDataPath: string): GpuFallbackMarker | null {
+  const read = readPersistedJson(markerPath(userDataPath), parseMarker)
+  return read.kind === 'ok' ? read.value : null
+}
+
+/**
+ * Durable (fsync + rename) for the same reason the crash history is, and then some: this is
+ * written by a process Chromium may FATAL milliseconds later, and both callers drop the crash
+ * history the instant it returns. A torn marker paired with a deleted history would leave the
+ * machine with no evidence at all — back to the unbootable loop this rescue exists to break.
+ */
 export function writeGpuFallbackMarker(
   userDataPath: string,
   info: { engagedAt: number; crashesInWindow: number; source?: GpuFallbackMarkerSource },
@@ -94,7 +123,27 @@ export function writeGpuFallbackMarker(
     platform: 'win32',
     source: info.source ?? 'automatic'
   }
-  writeFileSync(markerPath(userDataPath), JSON.stringify(marker))
+  const target = markerPath(userDataPath)
+  const temp = durableWriteTempPath(target)
+  try {
+    writeFileDurableSync(temp, target, JSON.stringify(marker))
+  } catch (error) {
+    try {
+      rmSync(temp, { force: true })
+    } catch {
+      // sweepOrphanedGpuFallbackMarkerWrites reclaims it later
+    }
+    throw error
+  }
+}
+
+/** Reclaims temps orphaned by a death between write and rename; the name carries the pid, so they never collide. */
+export function sweepOrphanedGpuFallbackMarkerWrites(userDataPath: string): void {
+  void removeStaleDurableWriteTempFiles(markerPath(userDataPath), {
+    minimumAgeMs: GPU_FALLBACK_MARKER_TEMP_MIN_AGE_MS
+  }).catch(() => {
+    // best effort; an orphaned temp file costs a few bytes
+  })
 }
 
 export function clearGpuFallbackMarker(userDataPath: string): void {
@@ -107,15 +156,20 @@ export function clearGpuFallbackMarker(userDataPath: string): void {
 
 export function readGpuFallbackMarkerState(
   userDataPath: string,
-  environment: GpuFallbackEnvironment
+  environment: GpuFallbackEnvironment,
+  nowEpochMs: number = Date.now()
 ): GpuFallbackMarkerState {
-  const marker = readGpuFallbackMarker(userDataPath)
-  if (!marker) {
-    if (existsSync(markerPath(userDataPath))) {
+  const read = readPersistedJson(markerPath(userDataPath), parseMarker)
+  if (read.kind !== 'ok') {
+    // Why: delete only what parsed as not-ours. A marker this process could not open is still
+    // the standing decision, and deleting it would silently restore the hardware launch that
+    // the machine cannot survive. See readActiveGpuCrashHistory for the same reasoning.
+    if (read.kind === 'invalid') {
       clearGpuFallbackMarker(userDataPath)
     }
     return { active: null, supersededBuild: null }
   }
+  const marker = read.value
   if (environment.platform !== 'win32' || marker.platform !== environment.platform) {
     clearGpuFallbackMarker(userDataPath)
     return { active: null, supersededBuild: null }
@@ -128,26 +182,35 @@ export function readGpuFallbackMarkerState(
     // burst, so updates get one fresh hardware attempt — but the record is kept, or a
     // machine that cannot boot would pay the full threshold again after every release.
     // A pin is the user's standing choice and an update is not consent to undo it.
-    return marker.source === 'user'
-      ? { active: marker, supersededBuild: null }
-      : { active: null, supersededBuild: marker }
+    if (marker.source === 'user') {
+      return { active: marker, supersededBuild: null }
+    }
+    // Why absolute, as in countStartupGpuCrashLaunches: engagedAt can be stamped by a wrong
+    // RTC that W32Time later corrects backwards, and a one-directional bound never ages those.
+    if (Math.abs(nowEpochMs - marker.engagedAt) > GPU_FALLBACK_SUPERSEDED_MARKER_MAX_AGE_MS) {
+      clearGpuFallbackMarker(userDataPath)
+      return { active: null, supersededBuild: null }
+    }
+    return { active: null, supersededBuild: marker }
   }
   return { active: marker, supersededBuild: null }
 }
 
 export function readActiveGpuFallbackMarker(
   userDataPath: string,
-  environment: GpuFallbackEnvironment
+  environment: GpuFallbackEnvironment,
+  nowEpochMs: number = Date.now()
 ): GpuFallbackMarker | null {
-  return readGpuFallbackMarkerState(userDataPath, environment).active
+  return readGpuFallbackMarkerState(userDataPath, environment, nowEpochMs).active
 }
 
 /** Drops the previous build's record once this build proved it boots; never touches an active marker. */
 export function clearSupersededGpuFallbackMarker(
   userDataPath: string,
-  environment: GpuFallbackEnvironment
+  environment: GpuFallbackEnvironment,
+  nowEpochMs: number = Date.now()
 ): void {
-  if (readGpuFallbackMarkerState(userDataPath, environment).supersededBuild) {
+  if (readGpuFallbackMarkerState(userDataPath, environment, nowEpochMs).supersededBuild) {
     clearGpuFallbackMarker(userDataPath)
   }
 }

--- a/src/main/startup/gpu-fallback-marker.ts
+++ b/src/main/startup/gpu-fallback-marker.ts
@@ -21,6 +21,9 @@ export type GpuFallbackEnvironment = {
 
 export type WindowsGpuFallbackEnvironment = GpuFallbackEnvironment & { platform: 'win32' }
 
+/** `user` = asked for in Settings, so it outlives app and Electron updates; `automatic` = derived from crashes. */
+export type GpuFallbackMarkerSource = 'automatic' | 'user'
+
 export type GpuFallbackMarker = {
   schemeVersion: number
   engagedAt: number
@@ -28,6 +31,14 @@ export type GpuFallbackMarker = {
   appVersion: string
   electronVersion: string
   platform: 'win32'
+  source: GpuFallbackMarkerSource
+}
+
+export type GpuFallbackMarkerState = {
+  /** The engagement in force for this build. */
+  active: GpuFallbackMarker | null
+  /** An engagement left by a different build: this build gets one fresh hardware attempt first. */
+  supersededBuild: GpuFallbackMarker | null
 }
 
 function markerPath(userDataPath: string): string {
@@ -59,7 +70,9 @@ export function readGpuFallbackMarker(userDataPath: string): GpuFallbackMarker |
       crashesInWindow: parsed.crashesInWindow,
       appVersion: parsed.appVersion,
       electronVersion: parsed.electronVersion,
-      platform: parsed.platform
+      platform: parsed.platform,
+      // Why: markers written before the Settings pin existed carry no source; they were all automatic.
+      source: parsed.source === 'user' ? 'user' : 'automatic'
     }
   } catch {
     // missing or corrupt means no fallback requested
@@ -69,7 +82,7 @@ export function readGpuFallbackMarker(userDataPath: string): GpuFallbackMarker |
 
 export function writeGpuFallbackMarker(
   userDataPath: string,
-  info: { engagedAt: number; crashesInWindow: number },
+  info: { engagedAt: number; crashesInWindow: number; source?: GpuFallbackMarkerSource },
   environment: WindowsGpuFallbackEnvironment
 ): void {
   const marker: GpuFallbackMarker = {
@@ -78,7 +91,8 @@ export function writeGpuFallbackMarker(
     crashesInWindow: info.crashesInWindow,
     appVersion: environment.appVersion,
     electronVersion: environment.electronVersion,
-    platform: 'win32'
+    platform: 'win32',
+    source: info.source ?? 'automatic'
   }
   writeFileSync(markerPath(userDataPath), JSON.stringify(marker))
 }
@@ -91,27 +105,49 @@ export function clearGpuFallbackMarker(userDataPath: string): void {
   }
 }
 
-export function readActiveGpuFallbackMarker(
+export function readGpuFallbackMarkerState(
   userDataPath: string,
   environment: GpuFallbackEnvironment
-): GpuFallbackMarker | null {
+): GpuFallbackMarkerState {
   const marker = readGpuFallbackMarker(userDataPath)
   if (!marker) {
     if (existsSync(markerPath(userDataPath))) {
       clearGpuFallbackMarker(userDataPath)
     }
-    return null
+    return { active: null, supersededBuild: null }
+  }
+  if (environment.platform !== 'win32' || marker.platform !== environment.platform) {
+    clearGpuFallbackMarker(userDataPath)
+    return { active: null, supersededBuild: null }
   }
   if (
-    environment.platform !== 'win32' ||
-    marker.platform !== environment.platform ||
     marker.appVersion !== environment.appVersion ||
     marker.electronVersion !== environment.electronVersion
   ) {
-    // Why: the marker is sticky only for the build that observed the driver
-    // crash burst; updates get one fresh hardware attempt automatically.
-    clearGpuFallbackMarker(userDataPath)
-    return null
+    // Why: an automatic marker is sticky only for the build that observed the crash
+    // burst, so updates get one fresh hardware attempt — but the record is kept, or a
+    // machine that cannot boot would pay the full threshold again after every release.
+    // A pin is the user's standing choice and an update is not consent to undo it.
+    return marker.source === 'user'
+      ? { active: marker, supersededBuild: null }
+      : { active: null, supersededBuild: marker }
   }
-  return marker
+  return { active: marker, supersededBuild: null }
+}
+
+export function readActiveGpuFallbackMarker(
+  userDataPath: string,
+  environment: GpuFallbackEnvironment
+): GpuFallbackMarker | null {
+  return readGpuFallbackMarkerState(userDataPath, environment).active
+}
+
+/** Drops the previous build's record once this build proved it boots; never touches an active marker. */
+export function clearSupersededGpuFallbackMarker(
+  userDataPath: string,
+  environment: GpuFallbackEnvironment
+): void {
+  if (readGpuFallbackMarkerState(userDataPath, environment).supersededBuild) {
+    clearGpuFallbackMarker(userDataPath)
+  }
 }

--- a/src/main/startup/gpu-fallback-unreadable-artifacts.test.ts
+++ b/src/main/startup/gpu-fallback-unreadable-artifacts.test.ts
@@ -1,0 +1,118 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import type * as NodeFsModule from 'node:fs'
+import os from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  GPU_CRASH_HISTORY_FILE,
+  countStartupGpuCrashLaunches,
+  forgetGpuCrashLaunch,
+  readActiveGpuCrashHistory,
+  recordGpuCrashInHistory
+} from './gpu-crash-history'
+import {
+  GPU_FALLBACK_MARKER_FILE,
+  readActiveGpuFallbackMarker,
+  readGpuFallbackMarkerState,
+  writeGpuFallbackMarker
+} from './gpu-fallback-marker'
+
+/**
+ * Both durable artifacts are read on the pre-whenReady decision path and on the crash path,
+ * where a read can fail for reasons that say nothing about the contents: on Windows, Defender
+ * scanning the file the publishing rename just created returns a sharing violation
+ * (EBUSY/EACCES). Treating that as corruption and deleting the file resets the distinct-launch
+ * counter on exactly the machine the cross-launch rescue exists to rescue.
+ */
+
+const unreadablePaths = vi.hoisted(() => new Set<string>())
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFsModule>()
+  const readFileSync = (
+    ...args: Parameters<typeof actual.readFileSync>
+  ): ReturnType<typeof actual.readFileSync> => {
+    if (typeof args[0] === 'string' && unreadablePaths.has(args[0])) {
+      throw Object.assign(new Error('EBUSY: resource busy or locked'), { code: 'EBUSY' })
+    }
+    return actual.readFileSync(...args)
+  }
+  return { ...actual, default: { ...actual, readFileSync }, readFileSync }
+})
+
+const ENVIRONMENT = {
+  appVersion: '1.4.184',
+  electronVersion: '43.1.0',
+  platform: 'win32' as const
+}
+
+const NOW = 1_760_000_000_000
+
+describe('GPU fallback artifacts that cannot be read', () => {
+  let userDataPath: string
+
+  beforeEach(() => {
+    userDataPath = mkdtempSync(join(os.tmpdir(), 'orca-gpu-unreadable-'))
+    unreadablePaths.clear()
+  })
+
+  afterEach(() => {
+    unreadablePaths.clear()
+    rmSync(userDataPath, { recursive: true, force: true })
+  })
+
+  it('keeps a crash history it could not read, and the launches it counts', () => {
+    for (const launchId of ['launch-0', 'launch-1']) {
+      recordGpuCrashInHistory(
+        userDataPath,
+        { atEpochMs: NOW, msSinceLaunch: 581, launchId },
+        ENVIRONMENT
+      )
+    }
+    const path = join(userDataPath, GPU_CRASH_HISTORY_FILE)
+    const intact = readFileSync(path, 'utf-8')
+    unreadablePaths.add(path)
+
+    expect(readActiveGpuCrashHistory(userDataPath, ENVIRONMENT)).toEqual([])
+    // Why: publishing a one-entry file over evidence it could not read erases it just as surely.
+    recordGpuCrashInHistory(
+      userDataPath,
+      { atEpochMs: NOW + 1_000, msSinceLaunch: 581, launchId: 'launch-2' },
+      ENVIRONMENT
+    )
+    forgetGpuCrashLaunch(userDataPath, 'launch-0')
+    unreadablePaths.clear()
+
+    expect(readFileSync(path, 'utf-8')).toBe(intact)
+    expect(
+      countStartupGpuCrashLaunches(readActiveGpuCrashHistory(userDataPath, ENVIRONMENT), NOW)
+    ).toBe(2)
+  })
+
+  // Why: deleting a marker this process merely failed to open restores the hardware launch the
+  // machine already proved it cannot survive — silently, with no evidence left to re-derive it.
+  it('keeps a marker it could not read', () => {
+    writeGpuFallbackMarker(userDataPath, { engagedAt: NOW, crashesInWindow: 3 }, ENVIRONMENT)
+    const path = join(userDataPath, GPU_FALLBACK_MARKER_FILE)
+    const intact = readFileSync(path, 'utf-8')
+    unreadablePaths.add(path)
+
+    expect(readActiveGpuFallbackMarker(userDataPath, ENVIRONMENT, NOW)).toBeNull()
+    unreadablePaths.clear()
+
+    expect(readFileSync(path, 'utf-8')).toBe(intact)
+    expect(readGpuFallbackMarkerState(userDataPath, ENVIRONMENT, NOW).active?.crashesInWindow).toBe(
+      3
+    )
+  })
+
+  it('still discards a file that really is corrupt', () => {
+    writeFileSync(join(userDataPath, GPU_CRASH_HISTORY_FILE), '{ "crashes": [')
+    writeFileSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE), '{ not json')
+
+    expect(readActiveGpuCrashHistory(userDataPath, ENVIRONMENT)).toEqual([])
+    expect(readActiveGpuFallbackMarker(userDataPath, ENVIRONMENT, NOW)).toBeNull()
+    expect(() => readFileSync(join(userDataPath, GPU_CRASH_HISTORY_FILE), 'utf-8')).toThrow()
+    expect(() => readFileSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE), 'utf-8')).toThrow()
+  })
+})

--- a/src/main/startup/persisted-json-read.ts
+++ b/src/main/startup/persisted-json-read.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from 'node:fs'
+
+/**
+ * Classified read of a small persisted JSON artifact.
+ *
+ * Why not just null: "the file is not there" and "this process could not read the file" are
+ * opposite facts. Collapsed into one null, an unlucky read — a Defender sharing violation on
+ * the file a launch published seconds ago — looks like an absent decision, and every caller
+ * that deletes what it cannot parse then destroys intact evidence.
+ */
+export type PersistedJsonRead<T> =
+  | { kind: 'ok'; value: T }
+  | { kind: 'missing' }
+  | { kind: 'unreadable' }
+  | { kind: 'invalid' }
+
+/** Reads and validates `path`; `parse` returns null for content this build cannot use. */
+export function readPersistedJson<T>(
+  path: string,
+  parse: (value: unknown) => T | null
+): PersistedJsonRead<T> {
+  let raw: string
+  try {
+    raw = readFileSync(path, 'utf-8')
+  } catch (error) {
+    // Why: only ENOENT means nothing was ever recorded. EACCES/EBUSY (Windows sharing
+    // violation, an ACL repair mid-flight) says nothing about the contents, so the caller
+    // must leave the file alone rather than treat it as corrupt.
+    return (error as NodeJS.ErrnoException)?.code === 'ENOENT'
+      ? { kind: 'missing' }
+      : { kind: 'unreadable' }
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return { kind: 'invalid' }
+  }
+  const value = parse(parsed)
+  return value === null ? { kind: 'invalid' } : { kind: 'ok', value }
+}

--- a/src/preload/api/app-api.ts
+++ b/src/preload/api/app-api.ts
@@ -1,6 +1,7 @@
 import type { AppIdentity } from '../../shared/app-identity'
 import type { E2EConfig } from '../../shared/e2e-config'
 import type { ExecutionHostId } from '../../shared/execution-host'
+import type { GpuFallbackStatus } from '../../shared/gpu-fallback-status'
 import type {
   WriteTerminalRenderDesyncEvidenceArgs,
   WriteTerminalRenderDesyncEvidenceResult
@@ -40,6 +41,11 @@ export type AppApi = {
   awaitFirstWindowStartupServices: () => Promise<void>
   /** Reconciles legacy worker authority around persisted terminal reconnect. */
   recoverLegacyWorkerTerminalsForRendererStartup: () => Promise<void>
+  /** Reports whether this launch disabled hardware acceleration after repeated GPU crashes. */
+  getGpuFallbackStatus: () => Promise<GpuFallbackStatus>
+  /** Turns Safe Graphics Mode on (pinned across updates) or off (drops the decision and its
+   *  crash evidence, so the next launch retries hardware acceleration). Caller relaunches. */
+  setGpuFallbackEnabled: (enabled: boolean) => Promise<void>
   /** Emits a startup benchmark marker when ORCA_STARTUP_DIAGNOSTICS is enabled. */
   startupDiagnostic: (event: string, details?: Record<string, unknown>) => Promise<void>
   /** macOS active input mode, or layout ID when no IME is selected (e.g. `com.apple.keylayout.PolishPro`).

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -268,6 +268,7 @@ import { createBrowserFindSubscriptions } from './browser-find-subscriptions'
 import { createUsageProviderApi } from './usage-provider-api'
 import type { AppStarSource } from '../shared/gh-star-source'
 import type { ExecutionHostId } from '../shared/execution-host'
+import type { GpuFallbackStatus } from '../shared/gpu-fallback-status'
 import type {
   Automation,
   AutomationCreateInput,
@@ -565,6 +566,10 @@ const api = {
       ipcRenderer.invoke('app:awaitFirstWindowStartupServices'),
     recoverLegacyWorkerTerminalsForRendererStartup: (): Promise<void> =>
       ipcRenderer.invoke('app:recoverLegacyWorkerTerminalsForRendererStartup'),
+    getGpuFallbackStatus: (): Promise<GpuFallbackStatus> =>
+      ipcRenderer.invoke('app:getGpuFallbackStatus'),
+    setGpuFallbackEnabled: (enabled: boolean): Promise<void> =>
+      ipcRenderer.invoke('app:setGpuFallbackEnabled', enabled),
     startupDiagnostic: (event: string, details?: Record<string, unknown>): Promise<void> =>
       startupDiagnosticsEnabled
         ? ipcRenderer.invoke('app:startupDiagnostic', event, details)

--- a/src/renderer/src/app-shell/AppBackgroundServices.tsx
+++ b/src/renderer/src/app-shell/AppBackgroundServices.tsx
@@ -4,6 +4,7 @@ import { AgentHibernationGate } from '../components/AgentHibernationGate'
 import { AiVaultTabTitleSyncGate } from '../components/AiVaultTabTitleSyncGate'
 import RetainedAgentsSyncGate from '../components/dashboard/RetainedAgentsSyncGate'
 import { WorkspacePortScanner } from '../components/ports/WorkspacePortScanner'
+import { GpuFallbackNoticeHost } from '../hooks/GpuFallbackNoticeHost'
 import { MacosTccPromptNoticeHost } from '../hooks/MacosTccPromptNoticeHost'
 import { useAppStore } from '../store'
 
@@ -24,6 +25,8 @@ export function AppBackgroundServices(): React.JSX.Element {
       <WorkspacePortScanner enabled={workspaceSessionReady} />
       {/* Why: plugin language-pack discovery must not re-render the App shell. */}
       <MacosTccPromptNoticeHost />
+      {/* Why: fallback engages pre-window, so this is the only surface that can explain it or undo it. */}
+      <GpuFallbackNoticeHost />
       {/* Why: leaf-mounted retention sync keeps agent-status subscriptions out of the App render tree. */}
       <RetainedAgentsSyncGate />
       <AiVaultTabTitleSyncGate />

--- a/src/renderer/src/components/settings/AdvancedPane.test.tsx
+++ b/src/renderer/src/components/settings/AdvancedPane.test.tsx
@@ -1,19 +1,34 @@
 import { renderToStaticMarkup } from 'react-dom/server'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { getDefaultSettings } from '../../../../shared/constants'
 import { AdvancedPane } from './AdvancedPane'
-import { getAdvancedSearchEntry } from './advanced-search'
+import { getAdvancedPaneSearchEntries, getAdvancedSearchEntry } from './advanced-search'
+
+const rendererAppPlatform = vi.hoisted(() => vi.fn((): NodeJS.Platform => 'win32'))
+const webClientLocation = vi.hoisted(() => vi.fn(() => false))
 
 vi.mock('../../store', () => ({
   useAppStore: (selector: (state: { settingsSearchQuery: string }) => unknown) =>
     selector({ settingsSearchQuery: '' })
 }))
 
+vi.mock('@/lib/renderer-app-platform', () => ({ getRendererAppPlatform: rendererAppPlatform }))
+vi.mock('@/lib/web-client-location', () => ({ isWebClientLocation: webClientLocation }))
+
+function renderAdvancedPane(): string {
+  return renderToStaticMarkup(
+    <AdvancedPane settings={getDefaultSettings('/tmp')} updateSettings={vi.fn()} />
+  )
+}
+
 describe('AdvancedPane', () => {
+  beforeEach(() => {
+    rendererAppPlatform.mockReturnValue('win32')
+    webClientLocation.mockReturnValue(false)
+  })
+
   it('renders HTTP/1.1 compatibility as a neutral advanced setting', () => {
-    const markup = renderToStaticMarkup(
-      <AdvancedPane settings={getDefaultSettings('/tmp')} updateSettings={vi.fn()} />
-    )
+    const markup = renderAdvancedPane()
 
     expect(markup).toContain('Compatibility')
     expect(markup).toContain('HTTP/1.1 Compatibility')
@@ -21,5 +36,27 @@ describe('AdvancedPane', () => {
     expect(markup).toContain('Explain HTTP/1.1 compatibility')
     expect(getAdvancedSearchEntry().http1Compatibility.keywords).toContain('support')
     expect(getAdvancedSearchEntry().http1Compatibility.keywords).toContain('troubleshooting')
+  })
+
+  it('offers Safe Graphics Mode on the Windows desktop app', () => {
+    expect(renderAdvancedPane()).toContain('Safe Graphics Mode')
+    expect(getAdvancedPaneSearchEntries({ isWindows: true }).map((entry) => entry.title)).toContain(
+      'Safe Graphics Mode'
+    )
+  })
+
+  // Why: the fallback is win32 desktop-only, so elsewhere the row would describe recovery
+  // behavior that never happens — and search must not point at a control that cannot exist.
+  it('hides Safe Graphics Mode where the fallback can never engage', () => {
+    for (const platform of ['darwin', 'linux'] as const) {
+      rendererAppPlatform.mockReturnValue(platform)
+      expect(renderAdvancedPane()).not.toContain('Safe Graphics Mode')
+    }
+    rendererAppPlatform.mockReturnValue('win32')
+    webClientLocation.mockReturnValue(true)
+    expect(renderAdvancedPane()).not.toContain('Safe Graphics Mode')
+    expect(
+      getAdvancedPaneSearchEntries({ isWindows: false }).map((entry) => entry.title)
+    ).not.toContain('Safe Graphics Mode')
   })
 })

--- a/src/renderer/src/components/settings/AdvancedPane.tsx
+++ b/src/renderer/src/components/settings/AdvancedPane.tsx
@@ -2,10 +2,13 @@ import { useRef, useState } from 'react'
 import { Info, Loader2, RotateCw } from 'lucide-react'
 import type { GlobalSettings } from '../../../../shared/global-settings-types'
 import { useMountedRef } from '@/hooks/useMountedRef'
+import { getRendererAppPlatform } from '@/lib/renderer-app-platform'
+import { isWebClientLocation } from '@/lib/web-client-location'
 import { Button } from '../ui/button'
 import { Label } from '../ui/label'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
 import { AdvancedNetworkSettingsSection } from './AdvancedNetworkSettingsSection'
+import { SafeGraphicsModeSetting } from './SafeGraphicsModeSetting'
 import { SearchableSetting } from './SearchableSetting'
 import { SettingsSubsectionHeader, SettingsSwitch } from './SettingsFormControls'
 import { getAdvancedPaneSearchEntries, getAdvancedSearchEntry } from './advanced-search'
@@ -135,6 +138,11 @@ export function AdvancedPane({ settings, updateSettings }: AdvancedPaneProps): R
             </div>
           ) : null}
         </SearchableSetting>
+
+        {/* Why: the fallback is win32 desktop-only, so elsewhere this row would promise recovery behavior that never happens. */}
+        {getRendererAppPlatform() === 'win32' && !isWebClientLocation() ? (
+          <SafeGraphicsModeSetting />
+        ) : null}
       </section>
 
       <section className="space-y-3">

--- a/src/renderer/src/components/settings/SafeGraphicsModeSetting.test.tsx
+++ b/src/renderer/src/components/settings/SafeGraphicsModeSetting.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SafeGraphicsModeSetting } from './SafeGraphicsModeSetting'
+
+type Status = { active: boolean; engagedAt: number | null; enabledForNextLaunch: boolean }
+
+const OFF: Status = { active: false, engagedAt: null, enabledForNextLaunch: false }
+const ON: Status = { active: true, engagedAt: 1_760_000_000_000, enabledForNextLaunch: true }
+
+const getGpuFallbackStatus = vi.hoisted(() => vi.fn(async (): Promise<Status> => OFF))
+const setGpuFallbackEnabled = vi.hoisted(() => vi.fn(async (_enabled: boolean) => {}))
+const relaunch = vi.hoisted(() => vi.fn(async () => {}))
+
+vi.mock('../../store', () => ({
+  useAppStore: (selector: (state: { settingsSearchQuery: string }) => unknown) =>
+    selector({ settingsSearchQuery: '' })
+}))
+
+describe('SafeGraphicsModeSetting', () => {
+  beforeEach(() => {
+    getGpuFallbackStatus.mockReset()
+    getGpuFallbackStatus.mockResolvedValue(OFF)
+    setGpuFallbackEnabled.mockReset()
+    relaunch.mockReset()
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: { app: { getGpuFallbackStatus, setGpuFallbackEnabled, relaunch } }
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('reports hardware acceleration with the mode switched off', async () => {
+    render(<SafeGraphicsModeSetting />)
+
+    await waitFor(() => {
+      expect(getGpuFallbackStatus).toHaveBeenCalled()
+    })
+    expect(screen.getByRole('switch').getAttribute('data-state')).toBe('unchecked')
+  })
+
+  // Why: fallback engages with no consent and lasts for the whole build, so this is the
+  // persistent surface that reports it and the only exit once a driver is fixed.
+  it('confirms before relaunching out of Safe Graphics Mode', async () => {
+    getGpuFallbackStatus.mockResolvedValue(ON)
+    render(<SafeGraphicsModeSetting />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('switch').getAttribute('data-state')).toBe('checked')
+    })
+    await userEvent.click(screen.getByRole('switch'))
+
+    expect(setGpuFallbackEnabled).not.toHaveBeenCalled()
+    expect(screen.getByText('Restart with hardware acceleration?')).toBeTruthy()
+    await userEvent.click(screen.getByRole('button', { name: 'Restart' }))
+
+    await waitFor(() => {
+      expect(setGpuFallbackEnabled).toHaveBeenCalledWith(false)
+    })
+    await waitFor(() => {
+      expect(relaunch).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // Why: with no way in, a user whose driver is known bad cannot pin the workaround they
+  // already need — the automatic path makes them re-earn it with crashing launches.
+  it('turns Safe Graphics Mode on explicitly', async () => {
+    render(<SafeGraphicsModeSetting />)
+
+    await waitFor(() => {
+      expect(getGpuFallbackStatus).toHaveBeenCalled()
+    })
+    await userEvent.click(screen.getByRole('switch'))
+
+    expect(screen.getByText('Restart in Safe Graphics Mode?')).toBeTruthy()
+    await userEvent.click(screen.getByRole('button', { name: 'Restart' }))
+
+    await waitFor(() => {
+      expect(setGpuFallbackEnabled).toHaveBeenCalledWith(true)
+    })
+    await waitFor(() => {
+      expect(relaunch).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('backs out of the confirmation without touching the durable artifacts', async () => {
+    getGpuFallbackStatus.mockResolvedValue(ON)
+    render(<SafeGraphicsModeSetting />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('switch').getAttribute('data-state')).toBe('checked')
+    })
+    await userEvent.click(screen.getByRole('switch'))
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(screen.getByRole('switch').getAttribute('data-state')).toBe('checked')
+    expect(setGpuFallbackEnabled).not.toHaveBeenCalled()
+    expect(relaunch).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/settings/SafeGraphicsModeSetting.test.tsx
+++ b/src/renderer/src/components/settings/SafeGraphicsModeSetting.test.tsx
@@ -5,10 +5,22 @@ import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { SafeGraphicsModeSetting } from './SafeGraphicsModeSetting'
 
-type Status = { active: boolean; engagedAt: number | null; enabledForNextLaunch: boolean }
+type Status = {
+  active: boolean
+  engagedAt: number | null
+  enabledForNextLaunch: boolean
+  source: 'automatic' | 'user' | null
+}
 
-const OFF: Status = { active: false, engagedAt: null, enabledForNextLaunch: false }
-const ON: Status = { active: true, engagedAt: 1_760_000_000_000, enabledForNextLaunch: true }
+const OFF: Status = { active: false, engagedAt: null, enabledForNextLaunch: false, source: null }
+const ON: Status = {
+  active: true,
+  engagedAt: 1_760_000_000_000,
+  enabledForNextLaunch: true,
+  source: 'automatic'
+}
+const PINNED: Status = { ...ON, source: 'user' }
+const KEEP_ON = 'Keep on after updates'
 
 const getGpuFallbackStatus = vi.hoisted(() => vi.fn(async (): Promise<Status> => OFF))
 const setGpuFallbackEnabled = vi.hoisted(() => vi.fn(async (_enabled: boolean) => {}))
@@ -86,6 +98,52 @@ describe('SafeGraphicsModeSetting', () => {
     await waitFor(() => {
       expect(relaunch).toHaveBeenCalledTimes(1)
     })
+  })
+
+  // Why: the automatic copy blames repeated crashes, which contradicts the dialog a pinning
+  // user just accepted; and a pin has nothing to convert, so the row must not offer it.
+  it('reports a user-pinned mode as the choice the user made', async () => {
+    getGpuFallbackStatus.mockResolvedValue(PINNED)
+    render(<SafeGraphicsModeSetting />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('switch').getAttribute('data-state')).toBe('checked')
+    })
+    expect(screen.getByText(/On because you turned it on/)).toBeTruthy()
+    expect(screen.queryByText(/graphics process crashed/)).toBeNull()
+    expect(screen.queryByRole('button', { name: KEEP_ON })).toBeNull()
+  })
+
+  // Why: with only the switch, a user already in automatic fallback can reach a pin solely by
+  // turning the workaround off and taking a hardware launch on the driver that kills startup —
+  // once per update, forever. Pinning is a marker rewrite; software rendering is already on.
+  it('pins an automatic engagement without an intervening hardware launch', async () => {
+    getGpuFallbackStatus.mockResolvedValue(ON)
+    render(<SafeGraphicsModeSetting />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: KEEP_ON })).toBeTruthy()
+    })
+    await userEvent.click(screen.getByRole('button', { name: KEEP_ON }))
+
+    await waitFor(() => {
+      expect(setGpuFallbackEnabled).toHaveBeenCalledWith(true)
+    })
+    expect(relaunch).not.toHaveBeenCalled()
+    await waitFor(() => {
+      expect(screen.getByText(/On because you turned it on/)).toBeTruthy()
+    })
+    expect(screen.queryByRole('button', { name: KEEP_ON })).toBeNull()
+    expect(screen.getByRole('switch').getAttribute('data-state')).toBe('checked')
+  })
+
+  it('offers no pin while hardware acceleration is on', async () => {
+    render(<SafeGraphicsModeSetting />)
+
+    await waitFor(() => {
+      expect(getGpuFallbackStatus).toHaveBeenCalled()
+    })
+    expect(screen.queryByRole('button', { name: KEEP_ON })).toBeNull()
   })
 
   it('backs out of the confirmation without touching the durable artifacts', async () => {

--- a/src/renderer/src/components/settings/SafeGraphicsModeSetting.tsx
+++ b/src/renderer/src/components/settings/SafeGraphicsModeSetting.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react'
-import { Loader2, RotateCw } from 'lucide-react'
+import { Loader2, Pin, RotateCw } from 'lucide-react'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import { translate } from '@/i18n/i18n'
+import type { GpuFallbackSource } from '../../../../shared/gpu-fallback-status'
 import { Button } from '../ui/button'
 import { Label } from '../ui/label'
 import { SearchableSetting } from './SearchableSetting'
@@ -21,8 +22,10 @@ export function SafeGraphicsModeSetting(): React.JSX.Element {
   const mountedRef = useMountedRef()
   const [active, setActive] = useState(false)
   const [enabled, setEnabled] = useState(false)
+  const [source, setSource] = useState<GpuFallbackSource | null>(null)
   const [confirming, setConfirming] = useState<boolean | null>(null)
   const [relaunching, setRelaunching] = useState(false)
+  const [pinning, setPinning] = useState(false)
 
   useEffect(() => {
     const getGpuFallbackStatus = window.api?.app?.getGpuFallbackStatus
@@ -35,6 +38,7 @@ export function SafeGraphicsModeSetting(): React.JSX.Element {
         if (!cancelled) {
           setActive(status.active)
           setEnabled(status.enabledForNextLaunch || status.active)
+          setSource(status.source)
         }
       },
       (error: unknown) => {
@@ -45,6 +49,33 @@ export function SafeGraphicsModeSetting(): React.JSX.Element {
       cancelled = true
     }
   }, [])
+
+  /**
+   * Converts the automatic engagement in force into the user's own standing choice.
+   *
+   * Why no relaunch: software rendering is already on, so the pin is a rewrite of the marker.
+   * Without this the only way to reach a pin is to turn the workaround off first and take a
+   * hardware launch on the driver that just proved it kills startup — the exact trade the
+   * whole cross-launch rescue exists to spare this user, once per update forever.
+   */
+  const handlePin = (): void => {
+    setPinning(true)
+    void (async () => {
+      try {
+        await window.api.app.setGpuFallbackEnabled(true)
+        if (mountedRef.current) {
+          setSource('user')
+          setEnabled(true)
+        }
+      } catch (error) {
+        console.error('[gpu-fallback] failed to pin Safe Graphics Mode:', error)
+      } finally {
+        if (mountedRef.current) {
+          setPinning(false)
+        }
+      }
+    })()
+  }
 
   const handleRelaunch = (target: boolean): void => {
     setRelaunching(true)
@@ -61,6 +92,11 @@ export function SafeGraphicsModeSetting(): React.JSX.Element {
     })()
   }
 
+  const pinned = source === 'user'
+  // Why: only an engagement Orca made on its own is worth converting; a confirmation already
+  // on screen owns the next decision, and the switch alone cannot express "on, and keep it on".
+  const canPin = active && !pinned && confirming === null
+
   return (
     <SearchableSetting
       title={getAdvancedSearchEntry().safeGraphicsMode.title}
@@ -75,16 +111,36 @@ export function SafeGraphicsModeSetting(): React.JSX.Element {
             {translate('auto.components.settings.SafeGraphicsMode.title', 'Safe Graphics Mode')}
           </Label>
           <p className="text-xs text-muted-foreground">
-            {active
+            {pinned
               ? translate(
-                  'auto.components.settings.SafeGraphicsMode.activeDescription',
-                  "Hardware acceleration is off because Orca's graphics process crashed on repeated launches. Rendering may be slower."
+                  'auto.components.settings.SafeGraphicsMode.pinnedDescription',
+                  'On because you turned it on. Hardware acceleration stays off, including after Orca updates, until you turn this back off.'
                 )
-              : translate(
-                  'auto.components.settings.SafeGraphicsMode.inactiveDescription',
-                  'Off. Orca is using hardware acceleration, and turns this on by itself only after repeated graphics crashes at startup.'
-                )}
+              : active
+                ? translate(
+                    'auto.components.settings.SafeGraphicsMode.activeDescription',
+                    "Hardware acceleration is off because Orca's graphics process crashed on repeated launches. Rendering may be slower."
+                  )
+                : translate(
+                    'auto.components.settings.SafeGraphicsMode.inactiveDescription',
+                    'Off. Orca is using hardware acceleration, and turns this on by itself only after repeated graphics crashes at startup.'
+                  )}
           </p>
+          {canPin ? (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handlePin}
+              disabled={pinning || relaunching}
+              className="mt-1 gap-1.5"
+            >
+              {pinning ? <Loader2 className="animate-spin" /> : <Pin />}
+              {translate(
+                'auto.components.settings.SafeGraphicsMode.keepAfterUpdates',
+                'Keep on after updates'
+              )}
+            </Button>
+          ) : null}
         </div>
         <SettingsSwitch
           checked={confirming ?? enabled}

--- a/src/renderer/src/components/settings/SafeGraphicsModeSetting.tsx
+++ b/src/renderer/src/components/settings/SafeGraphicsModeSetting.tsx
@@ -1,0 +1,151 @@
+import { useEffect, useState } from 'react'
+import { Loader2, RotateCw } from 'lucide-react'
+import { useMountedRef } from '@/hooks/useMountedRef'
+import { translate } from '@/i18n/i18n'
+import { Button } from '../ui/button'
+import { Label } from '../ui/label'
+import { SearchableSetting } from './SearchableSetting'
+import { SettingsSwitch } from './SettingsFormControls'
+import { getAdvancedSearchEntry } from './advanced-search'
+
+/** Deep-link anchor for the Safe Graphics Mode notice toast. */
+export const SAFE_GRAPHICS_MODE_SETTING_ID = 'advanced-safe-graphics-mode'
+
+/**
+ * Safe Graphics Mode engages before any window exists and stays on for the whole
+ * build, so a transient toast cannot be the only control: this is the persistent
+ * surface that reports the state, offers the way back once a driver is fixed, and
+ * lets a user with a known-bad driver pin the workaround across updates.
+ */
+export function SafeGraphicsModeSetting(): React.JSX.Element {
+  const mountedRef = useMountedRef()
+  const [active, setActive] = useState(false)
+  const [enabled, setEnabled] = useState(false)
+  const [confirming, setConfirming] = useState<boolean | null>(null)
+  const [relaunching, setRelaunching] = useState(false)
+
+  useEffect(() => {
+    const getGpuFallbackStatus = window.api?.app?.getGpuFallbackStatus
+    if (!getGpuFallbackStatus) {
+      return
+    }
+    let cancelled = false
+    void getGpuFallbackStatus().then(
+      (status) => {
+        if (!cancelled) {
+          setActive(status.active)
+          setEnabled(status.enabledForNextLaunch || status.active)
+        }
+      },
+      (error: unknown) => {
+        console.error('[gpu-fallback] failed to read status:', error)
+      }
+    )
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const handleRelaunch = (target: boolean): void => {
+    setRelaunching(true)
+    void (async () => {
+      try {
+        await window.api.app.setGpuFallbackEnabled(target)
+        await window.api.app.relaunch()
+      } catch (error) {
+        console.error('[gpu-fallback] failed to change Safe Graphics Mode:', error)
+        if (mountedRef.current) {
+          setRelaunching(false)
+        }
+      }
+    })()
+  }
+
+  return (
+    <SearchableSetting
+      title={getAdvancedSearchEntry().safeGraphicsMode.title}
+      description={getAdvancedSearchEntry().safeGraphicsMode.description}
+      keywords={getAdvancedSearchEntry().safeGraphicsMode.keywords}
+      className="space-y-2 py-2"
+      id={SAFE_GRAPHICS_MODE_SETTING_ID}
+    >
+      <div className="flex items-center justify-between gap-4">
+        <div className="min-w-0 shrink space-y-1">
+          <Label id={`${SAFE_GRAPHICS_MODE_SETTING_ID}-label`}>
+            {translate('auto.components.settings.SafeGraphicsMode.title', 'Safe Graphics Mode')}
+          </Label>
+          <p className="text-xs text-muted-foreground">
+            {active
+              ? translate(
+                  'auto.components.settings.SafeGraphicsMode.activeDescription',
+                  "Hardware acceleration is off because Orca's graphics process crashed on repeated launches. Rendering may be slower."
+                )
+              : translate(
+                  'auto.components.settings.SafeGraphicsMode.inactiveDescription',
+                  'Off. Orca is using hardware acceleration, and turns this on by itself only after repeated graphics crashes at startup.'
+                )}
+          </p>
+        </div>
+        <SettingsSwitch
+          checked={confirming ?? enabled}
+          onChange={() => setConfirming(confirming === null ? !enabled : null)}
+          ariaLabelledBy={`${SAFE_GRAPHICS_MODE_SETTING_ID}-label`}
+          disabled={relaunching}
+        />
+      </div>
+
+      {confirming !== null ? (
+        <div className="flex items-center justify-between gap-3 rounded-md border border-border/50 bg-muted/30 px-3 py-2">
+          <div className="min-w-0">
+            <p className="text-xs font-medium">
+              {confirming
+                ? translate(
+                    'auto.components.settings.SafeGraphicsMode.confirmEnableTitle',
+                    'Restart in Safe Graphics Mode?'
+                  )
+                : translate(
+                    'auto.components.settings.SafeGraphicsMode.confirmTitle',
+                    'Restart with hardware acceleration?'
+                  )}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {confirming
+                ? translate(
+                    'auto.components.settings.SafeGraphicsMode.confirmEnableDescription',
+                    'Hardware acceleration stays off, including after Orca updates, until you turn this back off.'
+                  )
+                : translate(
+                    'auto.components.settings.SafeGraphicsMode.confirmDescription',
+                    'If the graphics driver still crashes, Orca returns to Safe Graphics Mode by itself after three failed launches.'
+                  )}
+            </p>
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setConfirming(null)}
+              disabled={relaunching}
+            >
+              {translate('auto.components.settings.SafeGraphicsMode.cancel', 'Cancel')}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => handleRelaunch(confirming)}
+              disabled={relaunching}
+              className="gap-1.5"
+            >
+              {relaunching ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : (
+                <RotateCw className="size-3.5" />
+              )}
+              {translate('auto.components.settings.SafeGraphicsMode.restart', 'Restart')}
+            </Button>
+          </div>
+        </div>
+      ) : null}
+    </SearchableSetting>
+  )
+}

--- a/src/renderer/src/components/settings/advanced-search.ts
+++ b/src/renderer/src/components/settings/advanced-search.ts
@@ -4,7 +4,7 @@ import { createLocalizedCatalog } from '@/i18n/localized-catalog'
 import { translate } from '@/i18n/i18n'
 import { translateSearchKeyword } from './settings-search-keywords'
 
-export const getAdvancedPaneSearchEntries = createLocalizedCatalog((): SettingsSearchEntry[] => [
+const getAdvancedPaneCoreSearchEntries = createLocalizedCatalog((): SettingsSearchEntry[] => [
   ...getAdvancedNetworkSearchEntries(),
   {
     title: translate(
@@ -44,8 +44,50 @@ export const getAdvancedPaneSearchEntries = createLocalizedCatalog((): SettingsS
   }
 ])
 
+const getSafeGraphicsModeSearchEntries = createLocalizedCatalog((): SettingsSearchEntry[] => [
+  {
+    title: translate('auto.components.settings.advanced.search.safeGraphics', 'Safe Graphics Mode'),
+    description: translate(
+      'auto.components.settings.advanced.search.safeGraphicsDescription',
+      'Turn software rendering on, or undo the fallback Orca applies after repeated GPU crashes.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.advanced.search.e04e9db503', 'advanced'),
+      ...translateSearchKeyword('auto.components.settings.advanced.search.gpu', 'gpu'),
+      ...translateSearchKeyword('auto.components.settings.advanced.search.graphics', 'graphics'),
+      ...translateSearchKeyword(
+        'auto.components.settings.advanced.search.hardwareAcceleration',
+        'hardware acceleration'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.advanced.search.softwareRendering',
+        'software rendering'
+      ),
+      ...translateSearchKeyword('auto.components.settings.advanced.search.driver', 'driver'),
+      ...translateSearchKeyword('auto.components.settings.advanced.search.crash', 'crash'),
+      ...translateSearchKeyword('auto.components.settings.advanced.search.safeMode', 'safe mode')
+    ]
+  }
+])
+
+/**
+ * Why the platform gate: Safe Graphics Mode only ever engages on the Windows
+ * desktop app, and the search index must mirror the visible controls — a macOS
+ * user searching "gpu" must not land on a row that can never do anything.
+ */
+export function getAdvancedPaneSearchEntries(platform: {
+  isWindows: boolean
+}): SettingsSearchEntry[] {
+  return [
+    ...getAdvancedPaneCoreSearchEntries(),
+    ...(platform.isWindows ? getSafeGraphicsModeSearchEntries() : [])
+  ]
+}
+
 function findEntry(title: string): SettingsSearchEntry {
-  const entry = getAdvancedPaneSearchEntries().find((e) => e.title === title)
+  const entry = [...getAdvancedPaneCoreSearchEntries(), ...getSafeGraphicsModeSearchEntries()].find(
+    (e) => e.title === title
+  )
   if (!entry) {
     throw new Error(`Missing advanced-pane search entry: "${title}"`)
   }
@@ -56,6 +98,9 @@ export function getAdvancedSearchEntry() {
   return {
     http1Compatibility: findEntry(
       translate('auto.components.settings.advanced.search.11eea3da72', 'HTTP/1.1 Compatibility')
+    ),
+    safeGraphicsMode: findEntry(
+      translate('auto.components.settings.advanced.search.safeGraphics', 'Safe Graphics Mode')
     )
   } as const
 }

--- a/src/renderer/src/hooks/GpuFallbackNoticeHost.tsx
+++ b/src/renderer/src/hooks/GpuFallbackNoticeHost.tsx
@@ -1,0 +1,6 @@
+import { useGpuFallbackNotice } from './useGpuFallbackNotice'
+
+export function GpuFallbackNoticeHost(): null {
+  useGpuFallbackNotice()
+  return null
+}

--- a/src/renderer/src/hooks/gpu-fallback-notice-dismissal.ts
+++ b/src/renderer/src/hooks/gpu-fallback-notice-dismissal.ts
@@ -1,0 +1,31 @@
+const DISMISSED_ENGAGEMENT_KEY = 'orca.gpu-fallback.notice-dismissed-engaged-at'
+
+/**
+ * "Don't show again" for the Safe Graphics Mode notice, scoped to one engagement.
+ *
+ * Why scoped rather than a boolean: the downgrade is sticky for the whole build,
+ * so a session-only dismissal nags on every launch for weeks. Storing the
+ * engagement's `engagedAt` instead means a *new* engagement — after the user
+ * cleared the fallback and the driver failed again — is still announced.
+ */
+export function isGpuFallbackNoticeDismissed(engagedAt: number | null): boolean {
+  if (engagedAt === null) {
+    return false
+  }
+  try {
+    return window.localStorage.getItem(DISMISSED_ENGAGEMENT_KEY) === String(engagedAt)
+  } catch {
+    return false
+  }
+}
+
+export function dismissGpuFallbackNotice(engagedAt: number | null): void {
+  if (engagedAt === null) {
+    return
+  }
+  try {
+    window.localStorage.setItem(DISMISSED_ENGAGEMENT_KEY, String(engagedAt))
+  } catch {
+    // Best-effort; without storage the notice returns on the next launch.
+  }
+}

--- a/src/renderer/src/hooks/useGpuFallbackNotice.test.tsx
+++ b/src/renderer/src/hooks/useGpuFallbackNotice.test.tsx
@@ -7,13 +7,21 @@ import { GpuFallbackNoticeHost } from './GpuFallbackNoticeHost'
 
 const ENGAGED_AT = 1_760_000_000_000
 
+type Status = {
+  active: boolean
+  engagedAt: number | null
+  enabledForNextLaunch: boolean
+  source: 'automatic' | 'user' | null
+}
+
 const getGpuFallbackStatus = vi.hoisted(() =>
   vi.fn(
-    async (): Promise<{
-      active: boolean
-      engagedAt: number | null
-      enabledForNextLaunch: boolean
-    }> => ({ active: false, engagedAt: null, enabledForNextLaunch: false })
+    async (): Promise<Status> => ({
+      active: false,
+      engagedAt: null,
+      enabledForNextLaunch: false,
+      source: null
+    })
   )
 )
 const setGpuFallbackEnabled = vi.hoisted(() => vi.fn(async () => {}))
@@ -48,7 +56,8 @@ describe('useGpuFallbackNotice', () => {
     getGpuFallbackStatus.mockResolvedValue({
       active: false,
       engagedAt: null,
-      enabledForNextLaunch: false
+      enabledForNextLaunch: false,
+      source: null
     })
     window.localStorage.clear()
     setGpuFallbackEnabled.mockReset()
@@ -80,7 +89,8 @@ describe('useGpuFallbackNotice', () => {
     getGpuFallbackStatus.mockResolvedValue({
       active: true,
       engagedAt: ENGAGED_AT,
-      enabledForNextLaunch: true
+      enabledForNextLaunch: true,
+      source: 'automatic'
     })
     render(<GpuFallbackNoticeHost />)
 
@@ -90,13 +100,32 @@ describe('useGpuFallbackNotice', () => {
     expect(vi.mocked(toast.warning).mock.calls[0]?.[0]).toBe('Orca started in Safe Graphics Mode')
   })
 
+  // Why: the copy blames repeated graphics crashes. Saying that to a user who just accepted a
+  // dialog turning Safe Graphics Mode on is false, and it trains them to distrust the warning
+  // on the machines where it is true. Settings still reports the state and owns the exit.
+  it('does not warn about a mode the user pinned themselves', async () => {
+    getGpuFallbackStatus.mockResolvedValue({
+      active: true,
+      engagedAt: ENGAGED_AT,
+      enabledForNextLaunch: true,
+      source: 'user'
+    })
+    render(<GpuFallbackNoticeHost />)
+
+    await waitFor(() => {
+      expect(getGpuFallbackStatus).toHaveBeenCalled()
+    })
+    expect(toast.warning).not.toHaveBeenCalled()
+  })
+
   // Why: the downgrade lasts for the whole build, so the toast points at the persistent
   // Settings surface instead of being the sole (and dismissible, one-shot) exit.
   it('deep-links to the Safe Graphics Mode setting rather than relaunching directly', async () => {
     getGpuFallbackStatus.mockResolvedValue({
       active: true,
       engagedAt: ENGAGED_AT,
-      enabledForNextLaunch: true
+      enabledForNextLaunch: true,
+      source: 'automatic'
     })
     render(<GpuFallbackNoticeHost />)
 
@@ -125,7 +154,8 @@ describe('useGpuFallbackNotice', () => {
     getGpuFallbackStatus.mockResolvedValue({
       active: true,
       engagedAt: ENGAGED_AT,
-      enabledForNextLaunch: true
+      enabledForNextLaunch: true,
+      source: 'automatic'
     })
     render(<GpuFallbackNoticeHost />)
 
@@ -154,7 +184,8 @@ describe('useGpuFallbackNotice', () => {
     getGpuFallbackStatus.mockResolvedValue({
       active: true,
       engagedAt: ENGAGED_AT,
-      enabledForNextLaunch: true
+      enabledForNextLaunch: true,
+      source: 'automatic'
     })
     render(<GpuFallbackNoticeHost />)
 
@@ -182,7 +213,8 @@ describe('useGpuFallbackNotice', () => {
     getGpuFallbackStatus.mockResolvedValue({
       active: true,
       engagedAt: ENGAGED_AT,
-      enabledForNextLaunch: true
+      enabledForNextLaunch: true,
+      source: 'automatic'
     })
     render(<GpuFallbackNoticeHost />)
     await waitFor(() => {
@@ -199,7 +231,8 @@ describe('useGpuFallbackNotice', () => {
     getGpuFallbackStatus.mockResolvedValue({
       active: true,
       engagedAt: ENGAGED_AT + 60_000,
-      enabledForNextLaunch: true
+      enabledForNextLaunch: true,
+      source: 'automatic'
     })
     render(<GpuFallbackNoticeHost />)
 

--- a/src/renderer/src/hooks/useGpuFallbackNotice.test.tsx
+++ b/src/renderer/src/hooks/useGpuFallbackNotice.test.tsx
@@ -1,0 +1,210 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, waitFor } from '@testing-library/react'
+import { toast } from 'sonner'
+import { GpuFallbackNoticeHost } from './GpuFallbackNoticeHost'
+
+const ENGAGED_AT = 1_760_000_000_000
+
+const getGpuFallbackStatus = vi.hoisted(() =>
+  vi.fn(
+    async (): Promise<{
+      active: boolean
+      engagedAt: number | null
+      enabledForNextLaunch: boolean
+    }> => ({ active: false, engagedAt: null, enabledForNextLaunch: false })
+  )
+)
+const setGpuFallbackEnabled = vi.hoisted(() => vi.fn(async () => {}))
+const relaunch = vi.hoisted(() => vi.fn(async () => {}))
+const openSettingsPage = vi.hoisted(() => vi.fn())
+const openSettingsTarget = vi.hoisted(() => vi.fn())
+
+vi.mock('sonner', () => ({ toast: { warning: vi.fn(), dismiss: vi.fn() } }))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ i18n: { language: 'en', hasResourceBundle: () => true } })
+}))
+
+vi.mock('@/store', () => {
+  const state = { settings: { uiLanguage: 'en' }, openSettingsPage, openSettingsTarget }
+  const useAppStore = (selector: (s: Record<string, unknown>) => unknown): unknown =>
+    selector(state)
+  useAppStore.getState = () => state
+  return { useAppStore }
+})
+
+vi.mock('@/store/plugin-language-packs', () => ({
+  usePluginLanguagePackStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({ packs: [], loaded: true })
+}))
+
+vi.mock('@/i18n/i18n', () => ({ translate: (_key: string, fallback: string) => fallback }))
+
+describe('useGpuFallbackNotice', () => {
+  beforeEach(() => {
+    getGpuFallbackStatus.mockReset()
+    getGpuFallbackStatus.mockResolvedValue({
+      active: false,
+      engagedAt: null,
+      enabledForNextLaunch: false
+    })
+    window.localStorage.clear()
+    setGpuFallbackEnabled.mockReset()
+    relaunch.mockReset()
+    openSettingsPage.mockReset()
+    openSettingsTarget.mockReset()
+    vi.mocked(toast.warning).mockReset()
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: { app: { getGpuFallbackStatus, setGpuFallbackEnabled, relaunch } }
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('stays silent when hardware acceleration is on', async () => {
+    render(<GpuFallbackNoticeHost />)
+
+    await waitFor(() => {
+      expect(getGpuFallbackStatus).toHaveBeenCalled()
+    })
+    expect(toast.warning).not.toHaveBeenCalled()
+  })
+
+  // Why: engagement happens before any window exists, so this notice is the only place the user learns of it.
+  it('explains the silent fallback once the window is up', async () => {
+    getGpuFallbackStatus.mockResolvedValue({
+      active: true,
+      engagedAt: ENGAGED_AT,
+      enabledForNextLaunch: true
+    })
+    render(<GpuFallbackNoticeHost />)
+
+    await waitFor(() => {
+      expect(toast.warning).toHaveBeenCalledTimes(1)
+    })
+    expect(vi.mocked(toast.warning).mock.calls[0]?.[0]).toBe('Orca started in Safe Graphics Mode')
+  })
+
+  // Why: the downgrade lasts for the whole build, so the toast points at the persistent
+  // Settings surface instead of being the sole (and dismissible, one-shot) exit.
+  it('deep-links to the Safe Graphics Mode setting rather than relaunching directly', async () => {
+    getGpuFallbackStatus.mockResolvedValue({
+      active: true,
+      engagedAt: ENGAGED_AT,
+      enabledForNextLaunch: true
+    })
+    render(<GpuFallbackNoticeHost />)
+
+    await waitFor(() => {
+      expect(toast.warning).toHaveBeenCalled()
+    })
+    const action = vi.mocked(toast.warning).mock.calls[0]?.[1]?.action
+    if (typeof action !== 'object' || action === null || !('onClick' in action)) {
+      throw new Error('notice is missing its action')
+    }
+    action.onClick(new MouseEvent('click') as never)
+
+    expect(openSettingsPage).toHaveBeenCalledTimes(1)
+    expect(openSettingsTarget).toHaveBeenCalledWith({
+      pane: 'advanced',
+      repoId: null,
+      sectionId: 'advanced-safe-graphics-mode'
+    })
+    expect(relaunch).not.toHaveBeenCalled()
+    expect(setGpuFallbackEnabled).not.toHaveBeenCalled()
+  })
+
+  // Why: the downgrade is sticky for the whole build, so a session-only dismissal would
+  // re-warn a user who already accepted software rendering on every launch for weeks.
+  it('stops warning about an engagement the user dismissed', async () => {
+    getGpuFallbackStatus.mockResolvedValue({
+      active: true,
+      engagedAt: ENGAGED_AT,
+      enabledForNextLaunch: true
+    })
+    render(<GpuFallbackNoticeHost />)
+
+    await waitFor(() => {
+      expect(toast.warning).toHaveBeenCalled()
+    })
+    const cancel = vi.mocked(toast.warning).mock.calls[0]?.[1]?.cancel
+    if (typeof cancel !== 'object' || cancel === null || !('onClick' in cancel)) {
+      throw new Error('notice is missing its dismiss button')
+    }
+    expect(cancel.label).toBe("Don't show again")
+    cancel.onClick(new MouseEvent('click') as never)
+
+    cleanup()
+    vi.mocked(toast.warning).mockReset()
+    render(<GpuFallbackNoticeHost />)
+    await waitFor(() => {
+      expect(getGpuFallbackStatus).toHaveBeenCalledTimes(2)
+    })
+    expect(toast.warning).not.toHaveBeenCalled()
+  })
+
+  // Why: the Toaster renders a close button, so the X is the natural way to get rid of a
+  // never-expiring toast; without this it would re-warn on every launch for weeks.
+  it('stops warning after the toast close button dismisses it', async () => {
+    getGpuFallbackStatus.mockResolvedValue({
+      active: true,
+      engagedAt: ENGAGED_AT,
+      enabledForNextLaunch: true
+    })
+    render(<GpuFallbackNoticeHost />)
+
+    await waitFor(() => {
+      expect(toast.warning).toHaveBeenCalled()
+    })
+    const onDismiss = vi.mocked(toast.warning).mock.calls[0]?.[1]?.onDismiss
+    if (typeof onDismiss !== 'function') {
+      throw new Error('notice does not persist a close-button dismissal')
+    }
+    onDismiss({ id: 'gpu-fallback-active' } as never)
+
+    cleanup()
+    vi.mocked(toast.warning).mockReset()
+    render(<GpuFallbackNoticeHost />)
+    await waitFor(() => {
+      expect(getGpuFallbackStatus).toHaveBeenCalledTimes(2)
+    })
+    expect(toast.warning).not.toHaveBeenCalled()
+  })
+
+  // Why: dismissal is scoped to one engagement — a fresh downgrade after the user asked for
+  // hardware acceleration back is news again.
+  it('announces a later engagement even after a dismissal', async () => {
+    getGpuFallbackStatus.mockResolvedValue({
+      active: true,
+      engagedAt: ENGAGED_AT,
+      enabledForNextLaunch: true
+    })
+    render(<GpuFallbackNoticeHost />)
+    await waitFor(() => {
+      expect(toast.warning).toHaveBeenCalled()
+    })
+    const cancel = vi.mocked(toast.warning).mock.calls[0]?.[1]?.cancel
+    if (typeof cancel !== 'object' || cancel === null || !('onClick' in cancel)) {
+      throw new Error('notice is missing its dismiss button')
+    }
+    cancel.onClick(new MouseEvent('click') as never)
+
+    cleanup()
+    vi.mocked(toast.warning).mockReset()
+    getGpuFallbackStatus.mockResolvedValue({
+      active: true,
+      engagedAt: ENGAGED_AT + 60_000,
+      enabledForNextLaunch: true
+    })
+    render(<GpuFallbackNoticeHost />)
+
+    await waitFor(() => {
+      expect(toast.warning).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/src/renderer/src/hooks/useGpuFallbackNotice.ts
+++ b/src/renderer/src/hooks/useGpuFallbackNotice.ts
@@ -46,6 +46,10 @@ export function useGpuFallbackNotice(): void {
         if (
           cancelled ||
           !status.active ||
+          // Why: the user pinned this in Settings and accepted a dialog saying so. Warning them
+          // that a crash caused it is false, and it teaches them to distrust a notice that is
+          // true on the machines it was written for. Settings still reports the state.
+          status.source === 'user' ||
           shownThisSession.current ||
           isGpuFallbackNoticeDismissed(status.engagedAt)
         ) {

--- a/src/renderer/src/hooks/useGpuFallbackNotice.ts
+++ b/src/renderer/src/hooks/useGpuFallbackNotice.ts
@@ -1,0 +1,86 @@
+import { useEffect, useRef } from 'react'
+import { toast } from 'sonner'
+import { SAFE_GRAPHICS_MODE_SETTING_ID } from '@/components/settings/SafeGraphicsModeSetting'
+import { translate } from '@/i18n/i18n'
+import { useLocalizedToastReady } from '@/i18n/localized-toast-readiness'
+import { useAppStore } from '@/store'
+import {
+  dismissGpuFallbackNotice,
+  isGpuFallbackNoticeDismissed
+} from './gpu-fallback-notice-dismissal'
+
+const GPU_FALLBACK_NOTICE_ID = 'gpu-fallback-active'
+
+function openSafeGraphicsModeSetting(): void {
+  const store = useAppStore.getState()
+  store.openSettingsPage()
+  store.openSettingsTarget({
+    pane: 'advanced',
+    repoId: null,
+    sectionId: SAFE_GRAPHICS_MODE_SETTING_ID
+  })
+}
+
+/**
+ * Safe Graphics Mode can engage before any window exists — repeated GPU crashes
+ * at startup leave nothing to prompt on — so after-the-fact is the only place to
+ * tell the user it happened. The toast is deliberately a pointer, not the
+ * control: the downgrade lasts for the whole build, and a dismissed toast would
+ * otherwise leave no way back. Settings > Advanced owns the state and the exit.
+ *
+ * "Don't show again" is persisted per engagement, so a user who accepts software
+ * rendering is not warned on every launch for weeks — but a later engagement is.
+ */
+export function useGpuFallbackNotice(): void {
+  const localeReady = useLocalizedToastReady()
+  const shownThisSession = useRef(false)
+
+  useEffect(() => {
+    const getGpuFallbackStatus = window.api?.app?.getGpuFallbackStatus
+    if (!localeReady || shownThisSession.current || !getGpuFallbackStatus) {
+      return
+    }
+    let cancelled = false
+    void getGpuFallbackStatus().then(
+      (status) => {
+        if (
+          cancelled ||
+          !status.active ||
+          shownThisSession.current ||
+          isGpuFallbackNoticeDismissed(status.engagedAt)
+        ) {
+          return
+        }
+        shownThisSession.current = true
+        toast.warning(
+          translate('auto.hooks.useGpuFallbackNotice.title', 'Orca started in Safe Graphics Mode'),
+          {
+            id: GPU_FALLBACK_NOTICE_ID,
+            description: translate(
+              'auto.hooks.useGpuFallbackNotice.description',
+              "Hardware acceleration is off because Orca's graphics process crashed on repeated launches. Rendering may be slower. Settings > Advanced explains it and can try hardware acceleration again."
+            ),
+            duration: Infinity,
+            // Why: the Toaster renders a close button, and dismissing a never-expiring toast
+            // that way must count too — otherwise the X re-warns on every launch for weeks.
+            onDismiss: () => dismissGpuFallbackNotice(status.engagedAt),
+            action: {
+              label: translate('auto.hooks.useGpuFallbackNotice.openSettings', 'Open Settings'),
+              onClick: openSafeGraphicsModeSetting
+            },
+            cancel: {
+              label: translate('auto.hooks.useGpuFallbackNotice.dismiss', "Don't show again"),
+              onClick: () => dismissGpuFallbackNotice(status.engagedAt)
+            }
+          }
+        )
+      },
+      () => {
+        // Why: a failed status read is not worth a second toast; the About panel still reports it.
+      }
+    )
+    return () => {
+      cancelled = true
+    }
+  }, [localeReady])
+}

--- a/src/renderer/src/hooks/useMacTccAttributionSeveredNotice.ts
+++ b/src/renderer/src/hooks/useMacTccAttributionSeveredNotice.ts
@@ -1,11 +1,8 @@
 import { useEffect, useRef } from 'react'
-import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
-import { isPluginUiLanguage } from '../../../shared/ui-language'
 import { useAppStore } from '@/store'
-import { usePluginLanguagePackStore } from '@/store/plugin-language-packs'
 import { translate } from '@/i18n/i18n'
-import { resolveUiLocale } from '@/i18n/supported-languages'
+import { useLocalizedToastReady } from '@/i18n/localized-toast-readiness'
 import { MANAGE_SESSIONS_SECTION_ID } from '@/components/settings/TerminalTccAttributionNotice'
 
 const SEVERED_TCC_NOTICE_ID = 'mac-tcc-attribution-severed'
@@ -15,20 +12,7 @@ export function useMacTccAttributionSeveredNotice(): void {
   const openSettingsPage = useAppStore((s) => s.openSettingsPage)
   const openSettingsTarget = useAppStore((s) => s.openSettingsTarget)
   const setSettingsSearchQuery = useAppStore((s) => s.setSettingsSearchQuery)
-  const uiLanguage = useAppStore((s) => s.settings?.uiLanguage ?? null)
-  const pluginLanguagePacks = usePluginLanguagePackStore((s) => s.packs)
-  const pluginLanguagePacksLoaded = usePluginLanguagePackStore((s) => s.loaded)
-  const { i18n } = useTranslation()
-  const selectedPluginLanguage = pluginLanguagePacks.find((pack) => pack.id === uiLanguage)
-  const targetLocale =
-    uiLanguage === null || (isPluginUiLanguage(uiLanguage) && !pluginLanguagePacksLoaded)
-      ? null
-      : (selectedPluginLanguage?.resourceLanguage ??
-        (isPluginUiLanguage(uiLanguage) ? 'en' : resolveUiLocale(uiLanguage)))
-  const localeReady =
-    targetLocale !== null &&
-    i18n.language === targetLocale &&
-    i18n.hasResourceBundle(targetLocale, 'translation')
+  const localeReady = useLocalizedToastReady()
   const toastedThisSession = useRef(false)
   // Why: toast was only marked after await; a focus/effect re-run mid-check could dual-toast.
   const checkInFlight = useRef(false)

--- a/src/renderer/src/hooks/useMacosTccPromptNotice.ts
+++ b/src/renderer/src/hooks/useMacosTccPromptNotice.ts
@@ -1,11 +1,8 @@
 import { useEffect } from 'react'
-import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
-import { isPluginUiLanguage } from '../../../shared/ui-language'
 import { useAppStore } from '@/store'
-import { usePluginLanguagePackStore } from '@/store/plugin-language-packs'
 import { translate } from '@/i18n/i18n'
-import { resolveUiLocale } from '@/i18n/supported-languages'
+import { useLocalizedToastReady } from '@/i18n/localized-toast-readiness'
 import { FULL_DISK_ACCESS_SETTINGS_TARGET_ID } from '@/lib/settings-navigation-types'
 import {
   dismissMacosTccPromptNotice,
@@ -19,20 +16,7 @@ import {
 export function useMacosTccPromptNotice(): void {
   const openSettingsPage = useAppStore((s) => s.openSettingsPage)
   const openSettingsTarget = useAppStore((s) => s.openSettingsTarget)
-  const uiLanguage = useAppStore((s) => s.settings?.uiLanguage ?? null)
-  const pluginLanguagePacks = usePluginLanguagePackStore((s) => s.packs)
-  const pluginLanguagePacksLoaded = usePluginLanguagePackStore((s) => s.loaded)
-  const { i18n } = useTranslation()
-  const selectedPluginLanguage = pluginLanguagePacks.find((pack) => pack.id === uiLanguage)
-  const targetLocale =
-    uiLanguage === null || (isPluginUiLanguage(uiLanguage) && !pluginLanguagePacksLoaded)
-      ? null
-      : (selectedPluginLanguage?.resourceLanguage ??
-        (isPluginUiLanguage(uiLanguage) ? 'en' : resolveUiLocale(uiLanguage)))
-  const localeReady =
-    targetLocale !== null &&
-    i18n.language === targetLocale &&
-    i18n.hasResourceBundle(targetLocale, 'translation')
+  const localeReady = useLocalizedToastReady()
 
   useEffect(() => {
     if (!localeReady) {

--- a/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
+++ b/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
@@ -614,7 +614,7 @@ export function buildSettingsNavigationMetadata({
               'Low-level compatibility settings for troubleshooting.'
             ),
             icon: Wrench,
-            searchEntries: getAdvancedPaneSearchEntries(),
+            searchEntries: getAdvancedPaneSearchEntries({ isWindows }),
             group: 'advanced'
           }
         ]

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6135,6 +6135,8 @@
         "SafeGraphicsMode": {
           "title": "Safe Graphics Mode",
           "activeDescription": "Hardware acceleration is off because Orca's graphics process crashed on repeated launches. Rendering may be slower.",
+          "pinnedDescription": "On because you turned it on. Hardware acceleration stays off, including after Orca updates, until you turn this back off.",
+          "keepAfterUpdates": "Keep on after updates",
           "inactiveDescription": "Off. Orca is using hardware acceleration, and turns this on by itself only after repeated graphics crashes at startup.",
           "confirmTitle": "Restart with hardware acceleration?",
           "confirmDescription": "If the graphics driver still crashes, Orca returns to Safe Graphics Mode by itself after three failed launches.",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -955,6 +955,12 @@
       "useLargeTextControlPaste": {
         "pasteTooLarge": "Paste is too large."
       },
+      "useGpuFallbackNotice": {
+        "title": "Orca started in Safe Graphics Mode",
+        "description": "Hardware acceleration is off because Orca's graphics process crashed on repeated launches. Rendering may be slower. Settings > Advanced explains it and can try hardware acceleration again.",
+        "openSettings": "Open Settings",
+        "dismiss": "Don't show again"
+      },
       "useMacosTccPromptNotice": {
         "title": "Seeing “Orca would like to access…” prompts?",
         "description": "Permission messages from macOS may appear when an agent or terminal tool running in Orca attempts to access protected files. Grant Full Disk Access in Settings to reduce these prompts.",
@@ -6126,6 +6132,17 @@
           "network": "Network",
           "networkDescription": "App-level network routing for proxies and corporate environments."
         },
+        "SafeGraphicsMode": {
+          "title": "Safe Graphics Mode",
+          "activeDescription": "Hardware acceleration is off because Orca's graphics process crashed on repeated launches. Rendering may be slower.",
+          "inactiveDescription": "Off. Orca is using hardware acceleration, and turns this on by itself only after repeated graphics crashes at startup.",
+          "confirmTitle": "Restart with hardware acceleration?",
+          "confirmDescription": "If the graphics driver still crashes, Orca returns to Safe Graphics Mode by itself after three failed launches.",
+          "confirmEnableTitle": "Restart in Safe Graphics Mode?",
+          "confirmEnableDescription": "Hardware acceleration stays off, including after Orca updates, until you turn this back off.",
+          "cancel": "Cancel",
+          "restart": "Restart"
+        },
         "AgentLocationSetting": {
           "92f4238f1a": "WSL default",
           "fc806485ae": "Loading WSL",
@@ -8485,7 +8502,16 @@
             "2b4d26d11e": "networking",
             "e04e9db503": "advanced",
             "585f56fae0": "Use HTTP/1.1 for Electron networking when HTTP/2 fails behind a proxy.",
-            "11eea3da72": "HTTP/1.1 Compatibility"
+            "11eea3da72": "HTTP/1.1 Compatibility",
+            "safeGraphics": "Safe Graphics Mode",
+            "safeGraphicsDescription": "Turn software rendering on, or undo the fallback Orca applies after repeated GPU crashes.",
+            "gpu": "gpu",
+            "graphics": "graphics",
+            "hardwareAcceleration": "hardware acceleration",
+            "softwareRendering": "software rendering",
+            "driver": "driver",
+            "crash": "crash",
+            "safeMode": "safe mode"
           }
         },
         "agents": {

--- a/src/renderer/src/i18n/localized-toast-readiness.ts
+++ b/src/renderer/src/i18n/localized-toast-readiness.ts
@@ -1,0 +1,27 @@
+import { useTranslation } from 'react-i18next'
+import { isPluginUiLanguage } from '../../../shared/ui-language'
+import { useAppStore } from '@/store'
+import { usePluginLanguagePackStore } from '@/store/plugin-language-packs'
+import { resolveUiLocale } from './supported-languages'
+
+/**
+ * True once the user's locale bundle is loaded, so a launch-time toast is not
+ * rendered in English and then re-rendered translated a tick later.
+ */
+export function useLocalizedToastReady(): boolean {
+  const uiLanguage = useAppStore((s) => s.settings?.uiLanguage ?? null)
+  const pluginLanguagePacks = usePluginLanguagePackStore((s) => s.packs)
+  const pluginLanguagePacksLoaded = usePluginLanguagePackStore((s) => s.loaded)
+  const { i18n } = useTranslation()
+  const selectedPluginLanguage = pluginLanguagePacks.find((pack) => pack.id === uiLanguage)
+  const targetLocale =
+    uiLanguage === null || (isPluginUiLanguage(uiLanguage) && !pluginLanguagePacksLoaded)
+      ? null
+      : (selectedPluginLanguage?.resourceLanguage ??
+        (isPluginUiLanguage(uiLanguage) ? 'en' : resolveUiLocale(uiLanguage)))
+  return (
+    targetLocale !== null &&
+    i18n.language === targetLocale &&
+    i18n.hasResourceBundle(targetLocale, 'translation')
+  )
+}

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -580,6 +580,10 @@ function createWebPreloadApi(): Partial<PreloadApi> {
       awaitBeforeUnloadCheckpoint: () => Promise.resolve(),
       awaitFirstWindowStartupServices: () => Promise.resolve(),
       recoverLegacyWorkerTerminalsForRendererStartup: () => Promise.resolve(),
+      // Safe Graphics Mode is a win32 desktop-only fallback; the browser has no equivalent.
+      getGpuFallbackStatus: () =>
+        Promise.resolve({ active: false, engagedAt: null, enabledForNextLaunch: false }),
+      setGpuFallbackEnabled: () => Promise.resolve(),
       startupDiagnostic: () => Promise.resolve(),
       getKeyboardInputSourceId: () => Promise.resolve(null),
       // The web client cannot inspect local Mission Control shortcuts.

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -582,7 +582,12 @@ function createWebPreloadApi(): Partial<PreloadApi> {
       recoverLegacyWorkerTerminalsForRendererStartup: () => Promise.resolve(),
       // Safe Graphics Mode is a win32 desktop-only fallback; the browser has no equivalent.
       getGpuFallbackStatus: () =>
-        Promise.resolve({ active: false, engagedAt: null, enabledForNextLaunch: false }),
+        Promise.resolve({
+          active: false,
+          engagedAt: null,
+          enabledForNextLaunch: false,
+          source: null
+        }),
       setGpuFallbackEnabled: () => Promise.resolve(),
       startupDiagnostic: () => Promise.resolve(),
       getKeyboardInputSourceId: () => Promise.resolve(null),

--- a/src/shared/gpu-fallback-status.ts
+++ b/src/shared/gpu-fallback-status.ts
@@ -1,0 +1,15 @@
+/** Whether this launch booted in Safe Graphics Mode (hardware acceleration disabled). */
+export type GpuFallbackStatus = {
+  active: boolean
+  /**
+   * Epoch ms the active downgrade began, null when hardware acceleration is on.
+   * Identity of the engagement: a dismissed notice returns when a new one starts.
+   */
+  engagedAt: number | null
+  /**
+   * Whether the persisted decision still applies to the next launch — an automatic
+   * engagement or an explicit pin. Diverges from `active` between a Settings change
+   * and the relaunch that carries it out.
+   */
+  enabledForNextLaunch: boolean
+}

--- a/src/shared/gpu-fallback-status.ts
+++ b/src/shared/gpu-fallback-status.ts
@@ -1,3 +1,6 @@
+/** `user` = asked for in Settings and standing until revoked; `automatic` = derived from repeated crashes. */
+export type GpuFallbackSource = 'automatic' | 'user'
+
 /** Whether this launch booted in Safe Graphics Mode (hardware acceleration disabled). */
 export type GpuFallbackStatus = {
   active: boolean
@@ -12,4 +15,10 @@ export type GpuFallbackStatus = {
    * and the relaunch that carries it out.
    */
   enabledForNextLaunch: boolean
+  /**
+   * Who decided, null when Safe Graphics Mode is neither on nor pending. The renderer must
+   * not tell a user who pinned this that a crash caused it — that contradicts the dialog
+   * they just accepted and teaches them to distrust the notice where it is true.
+   */
+  source: GpuFallbackSource | null
 }


### PR DESCRIPTION
## What this fixes

Orca has a rescue for machines whose GPU driver is unusable: after repeated GPU-child crashes it falls back to software rendering. **On the shape of failure that actually strands users — the GPU child dying during startup — that rescue could never fire.**

`GpuCrashFallbackTracker` requires **3 GPU crashes within a rolling 30s window inside one process**. Its evidence lives in an in-memory array on a module-scope singleton (`gpu-crash-fallback-decision.ts`, constructed at `index.ts:410`) fed with `performance.now()`. When the GPU child dies ~600ms into startup and the user quits and relaunches, each launch contributes exactly **one** crash and the counter dies with the process. The only persisted artifact, `gpu-fallback.json`, is written *downstream* of both the threshold **and** a modal the user must answer — so it was structurally unwritable in this scenario, and `maybeApplyGpuFallbackForThisLaunch()` read `null` forever.

Prior work (#10707 rolling window, #11295 removing the GPU child) fixed the *within-session* case. The *across-session* case was still open.

This makes the evidence durable across launches, and lets the fallback engage **before any window exists** — because on a machine that dies in 600ms there is nothing to prompt on.

## Fix evidence

### Field data — the counter provably never advances

Reconstructed **48 distinct app launches** (deduped by `mainProcessLaunchId`) from the 6 diagnostics bundles attached to the v1.4.184 crash cluster in #orca-crashes:

```
GPU crashes per launch: {1: 38, 0: 10}   <- never 2, never 3
```

`grep -c gpu_fallback` across all 12 files (6 crash reports + 6 bundles) = **0** everywhere. No `gpu_fallback_engaged`, no `gpu_fallback_applied`, no `gpu_fallback_restart_deferred`. The rescue never fired, on any of the 48 launches, on either machine.

### Before/after on real Windows — the decisive test

Run on Windows 11 build 26200, real `electron.exe` 43.1.0, linking the **real shipped modules**, fresh `--user-data-dir` per arm. GPU killed via `chrome://gpucrash` (deliberately *not* `--gpu-launcher`, which emits no `child-process-gone` at all — see Known limitation):

```
[e2e] child-process-gone type=GPU reason=crashed exitCode=-1073741819   <- real crash, not simulated
```

**Pre-fix arm** (bundles `gpu-crash-fallback-decision.ts` + `gpu-fallback-marker.ts` verbatim from `git show 71bbab72e14:`) — identical on all 7 launches:

```
launch 1..7: in-memory tracker crashesInWindow=1 shouldEngage=false
RESULT prefix launch=1..7  gpu-fallback.json=absent
```

**7 launches, marker never written.** Matches the field distribution exactly.

**Fixed arm** — evidence accumulates and engages:

```
launch 1: engage=false reason=no-evidence crashesInWindow=0  -> history [launch-1]
launch 2: engage=false reason=no-evidence crashesInWindow=1  -> history [launch-1,launch-2]
launch 3: engage=false reason=no-evidence crashesInWindow=2  -> history [launch-1,launch-2,launch-3]
launch 4: breadcrumb gpu_fallback_applied {"source":"crash-history","crashesInWindow":3,
            "switches":"disable-gpu,disable-software-rasterizer,in-process-gpu"}
          gpu-fallback.json=PRESENT   gpu-crash-history.json=absent (consumed)
launch 5-7: reason=marker
```

`gpuChildCount` goes **1 → 0 at launch 4 and stays 0**. Same machine, same induced fault: 0 markers in 7 launches before, engagement at launch 4 after.

### Healthy machines are not swept up

Control run at the shipped `GPU_CRASH_HISTORY_RESET_DELAY_MS = 60_000` (real 60s, no clock injection):

```
A: crash, dies early                    -> history [launch-a]
B: crash, dies early                    -> history [launch-a,launch-b]
C: crash at startup, PAINTS a window, survives the real 60s
     reset resolved {"forgetThisLaunch":true,"clearSupersededMarker":false}
   -> history [launch-a,launch-b]        <- C dropped ONLY its own entry
D: probe -> engage=false crashesInWindow=2
E: fully healthy launch, no crash        -> history STILL [launch-a,launch-b]
```

A launch that booted stops counting as "cannot even boot" evidence, and never destroys another launch's.

### Gates

`519 passed | 6 skipped` (main/startup + crash-reporting) and `1792 passed` (renderer hooks + settings) on **both** macOS and Windows; `typecheck` exit 0; `oxlint` 0 warnings 0 errors across 15,397 files; `check:max-lines-ratchet` OK — 192 grandfathered, **no new bypasses**; localization catalog/extraction/coverage green.

## ELI5

Orca has a spare tire for computers whose graphics driver is broken: after the graphics helper crashes 3 times quickly, Orca switches to slow-but-reliable software drawing.

The problem: Orca counted those crashes on a notepad it threw away every time it started. If the graphics helper crashed *while Orca was still starting up*, Orca wrote "1", died, and threw the notepad away. Next launch: "1" again. It never reached 3, so it never got the spare tire out — no matter how many times you tried.

This change writes the count on a **sticky note left on the fridge** instead. Three bad launches in ten minutes and the next launch quietly starts in safe graphics mode. Two extra rules keep it honest: if a launch actually works for a minute, it erases *its own* tally mark (so a computer that's fine never accumulates), and marks older than ten minutes are ignored (so one bad day a month never adds up).

## Trade-offs and negative behavior changes

**These are real. None is hypothetical.**

1. **Silent engagement with no consent.** When the threshold is met from persisted evidence, Orca disables hardware acceleration *before any window exists* — no dialog, because there is nothing to show one on. Users get a materially different rendering path without being asked. Mitigated by a non-modal notice after the window is up plus a Settings toggle, but the first they know is after the fact.

2. **False positives are now possible where they were structurally impossible.** Before this change a healthy machine could *never* be downgraded by this path, because the evidence was destroyed on every process exit. Now it survives — and that is inherent to the fix: the property that rescues a genuinely broken machine is the same one that lets a healthy one accumulate.

   To be precise about how narrow the exposure actually is, four filters stack before anything is counted:

   | Filter | Effect |
   |---|---|
   | `app.on('child-process-gone')` (`index.ts:3082`) | Child processes only. Renderer crashes — `react-error-boundary`, renderer `oom`, renderer `killed` — can never reach this path. |
   | `isGpuFallbackCrashCandidate` | `platform === 'win32'` **&&** `processType === 'gpu'` **&&** reason ∈ `{abnormal-exit, crashed, launch-failed}`. Excludes `killed` (Electron's intentional reload/update/quit shape) and `integrity-failure`. |
   | `recordGpuCrashInHistory` | Hard-bails on `msSinceLaunch > GPU_CRASH_STARTUP_WINDOW_MS` (15s). A GPU crash mid-session is the in-session tracker's job (#10707) and is never written. |
   | `countStartupGpuCrashLaunches` | Deduped by `launchId`, bounded by an absolute 10-minute wall-clock horizon, and requires **3 distinct launches** — not 3 crashes. |

   On top of that, a launch that reaches `ready-to-show` and survives 60s **drops its own entry**.

   So the residual false-positive shape is: *three separate launches within ten minutes, each with a genuine GPU-child crash inside its first 15 seconds, and each quit within ~60s of the window painting* — because any launch that sticks around exonerates itself. The realistic way to hit it is rapid restarts on a machine where the GPU child blips at startup but Chromium respawns it fine (an update relaunch, then the Restart button in Advanced, then a manual restart). It is not reachable from crash-type breadth. The risk is bounded, not eliminated, and the resulting downgrade is sticky for the build.

3. **Software rendering is genuinely worse.** `--in-process-gpu` + `--disable-gpu` degrades xterm's WebGL renderer, scrolling, and animation.

4. **`--in-process-gpu` removes process isolation** (pre-existing on `main`, but this change makes it reachable far more often). Once engaged, a GPU fault becomes fatal to the main process instead of an isolated child death — observed directly in the E2E. We trade "crashes at startup" for "may crash later, harder to attribute".

5. **Extra sync I/O on the crash path.** One `writeFileDurableSync` (~10.5ms, fsync) per crashing launch, on an already-unhealthy process. Bounded to one write per launch by the `launchId` dedupe and the 15s startup-scope bail.

6. **Startup read on every Windows launch**, before `whenReady`: measured **~5–30µs** against a file bounded to 884 bytes. **Zero** file I/O on macOS/Linux (hard-gated).

7. **Scope is larger than a minimal crash fix** — it adds a Settings row, a notice, and i18n strings. That surface exists to make the silent downgrade visible and reversible; without an exit, a user whose driver is later fixed would be stuck in software rendering until the next release (`clearGpuFallbackMarker` previously had zero callers outside its own module). It also incidentally de-duplicates `useLocalizedToastReady` out of two existing TCC notice hooks.

## Adversarial review

**5 rounds, 15 independent reviewer agents**, three fixed lenses per round (correctness · user-facing regression · crash-path durability), each round a fresh agent with no memory of the last.

| Round | Blocking findings | Outcome |
|---|---|---|
| 1 | 9 (2 major) | fixed |
| 2 | 6 | fixed |
| 3 | 6 (1 major) | **did not converge** — see below |
| 4 (verify) | 5 (0 major) | fixed |
| 5 (verify) | 1 | **false positive** — clean |

**Round 3 did not converge**, and the reason mattered: rounds 1 and 3 raised *opposite* majors about the same thing — whether a launch that recorded crash evidence may later clear it. The fixes were oscillating between two failure modes, which meant it was a design ambiguity, not a bug. Resolved by ruling that **the unit of evidence is a launch**: every lifecycle step acts on a single `launchId` and never on the whole file, which satisfies both sides. `clearGpuCrashHistory` is now reserved for events that retire the evidence outright (promotion into the marker, or a user pin).

Findings worth naming, all caught by review rather than testing:

- **A failed *read* deleted the evidence file.** `readGpuCrashHistory` collapsed "content is invalid" and "readFileSync threw" into one `null`, and the caller deleted for both. Verified empirically: a valid, correctly-versioned history made unreadable is deleted. On Windows the realistic trigger is a Defender sharing violation right after `renameSync` publishes the file — silently resetting the counter on exactly the machine the rescue exists for. Now classified via `persisted-json-read.ts` (`missing` / `unreadable` / `invalid` / `ok`); only `invalid` clears.
- **Durable evidence destroyed right after a *non-durable* marker write.** `writeGpuFallbackMarker` was a bare `writeFileSync`; the change deleted the fsynced history the instant it was called. A bugcheck microseconds later left a torn marker *and* no history. Now routed through `durableWriteTempPath` + `writeFileDurableSync`.
- **A user-pinned mode was reported as crash-caused** — after deliberately pinning software rendering, users got a warning toast saying it was off "because Orca's graphics process crashed on repeated launches", contradicting the dialog they had just accepted.

The round-5 finding was verified false: it claimed the Safe Graphics Mode search entry leaks onto the web client, but `searchEntries` sits inside `...(showDesktopOnlySettings ? [...] : [])` where `showDesktopOnlySettings = !isWebClient`, and that is already pinned by `useSettingsNavigationMetadata.test.ts:147`. No change made.

**Perf review** (`/perf`) verdict: **ship**. Measured the pre-`whenReady` read at 5–30µs on Windows and exactly zero elsewhere; confirmed the 60s timer is `unref`'d; found and fixed a `readdir` + per-file `stat` running on the `ready-to-show` path and re-running on every window open (moved into the timer body), plus an unbounded read-side array on the earliest startup path.

## Known limitation, stated explicitly

**The GPU *launch-failure* mode remains unrescued**, and the code says so. Discovered during E2E: when the GPU process fails to *launch* (as opposed to crashing after launch), Electron 43 emits **no `child-process-gone` event at all** — 0 events across 42 induced failures; Chromium retries 6× internally then FATALs the browser process. `'launch-failed'` remains in `GPU_FALLBACK_CRASH_REASONS` but is unreachable on that path, which is now documented at `gpu-crash-fallback-decision.ts:9-18` rather than left as a misleading dead branch.

## What this does *not* fix

This does **not** fix the v1.4.184 Windows crash cluster that prompted the investigation, and should not be read as doing so. Those six reports are two machines whose GPU **and renderer** both die at sandbox init with `STATUS_BREAKPOINT`; one of them (`e3e21dc6`) had **no GPU crash at all** — three renderer deaths and a circuit-breaker open — so software-rendering fallback could not have helped it.

> **Correction (updated after this PR was opened).** An earlier revision of this section said the AppContainer/LPAC ACL hypothesis had been *falsified*. That was wrong — the experiment tested the wrong variable. It checked whether *removing* `S-1-15-2-1`/`S-1-15-2-2` from a clean install directory breaks Electron. It does not, and never would; that is how every normal Electron install ships.
>
> The real precondition is the inverse: the install tree carries an **orphan / unresolvable `S-1-15-2-*` package ACE** while neither `-1` nor `-2` is present to satisfy it. Under that condition a healthy Electron 43.1.0 install flips to **10/10 launches crashing** with exactly this signature on Windows 11 26200, and an additive `icacls /grant *S-1-15-2-2:(OI)(CI)(RX)` restores it — even when the orphan is inherited from a parent directory. Corroborated upstream by [electron/electron#51761](https://github.com/electron/electron/issues/51761).
>
> The `WinSboxNoFakeGdiInit` bisection was a lab artifact: that flag is `FEATURE_DISABLED_BY_DEFAULT` and Orca never sets it, and it cannot explain the GPU deaths. Instrumentation to detect the real condition in the field ships separately in #15107.

Root cause for those six reports is still open: we have no evidence either machine actually carries the precondition, and the ~80/20 field intermittency remains unexplained by a static DACL.

What this PR does is ensure that when a machine *is* stuck in a GPU crash loop, Orca can actually dig itself out.

