### PR TITLE
fix(git): fence buffered WSL login-shell reads

### DIFF
--- a/src/main/git/runner-wsl-login-shell-capture.test.ts
+++ b/src/main/git/runner-wsl-login-shell-capture.test.ts
@@ -102,9 +102,9 @@ describe('WSL login-shell reads are fenced', () => {
   }
 
   function sshCommandFromLastGitCall(): string | undefined {
-    const gitCall = execFileMock.mock.calls
-      .filter((call) => !String(call[1]?.at(-1)).includes('core.sshCommand'))
-      .at(-1)
+    const gitCall = execFileMock.mock.calls.findLast(
+      (call) => !String(call[1]?.at(-1)).includes('core.sshCommand')
+    )
     return (gitCall?.[2] as { env?: NodeJS.ProcessEnv } | undefined)?.env?.GIT_SSH_COMMAND
   }
 

--- a/src/main/git/runner-wsl-login-shell-capture.test.ts
+++ b/src/main/git/runner-wsl-login-shell-capture.test.ts
@@ -1,0 +1,137 @@
+import { EventEmitter } from 'node:events'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { execFileMock, execFileSyncMock, spawnMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+  execFileSyncMock: vi.fn(),
+  spawnMock: vi.fn()
+}))
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock,
+  execFileSync: execFileSyncMock,
+  spawn: spawnMock
+}))
+vi.mock('../observability/instrumentation', () => ({
+  withGitSpan: (_attributes: unknown, run: () => unknown) => run()
+}))
+vi.mock('../diagnostics/main-thread-churn-probe', () => ({ recordSubprocessSpawn: vi.fn() }))
+
+import { gitExecFileAsync, gitExecFileAsyncBuffer } from './runner'
+import { resetWslGitReadEnvironmentForTests } from './wsl-git-read-environment'
+
+const DISTRO = 'Ubuntu'
+const WSL_CWD = String.raw`\\wsl.localhost\Ubuntu\home\alice\repo`
+const BANNER = 'To run a command as administrator (user "root"), use "sudo <command>".\n\n'
+
+function createMockChild(): EventEmitter & { stdout: EventEmitter; stderr: EventEmitter } {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter
+    stderr: EventEmitter
+  }
+  child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
+  return child
+}
+
+/** Stand in for the guest shell: banner first, then the payload inside the command's fence. */
+function respondWithFencedPayload(payload: Buffer | string): void {
+  execFileMock.mockImplementation((_command, args, _options, callback) => {
+    const nonce = /__ORCA_WSL_CAPTURE_BEGIN_([^_]+)__/.exec(String(args.at(-1)))?.[1] ?? ''
+    const body = typeof payload === 'string' ? Buffer.from(payload, 'utf8') : payload
+    const stdout = Buffer.concat([
+      Buffer.from(BANNER, 'utf8'),
+      Buffer.from(`__ORCA_WSL_CAPTURE_BEGIN_${nonce}__`, 'utf8'),
+      body,
+      Buffer.from(`__ORCA_WSL_CAPTURE_END_${nonce}__`, 'utf8')
+    ])
+    queueMicrotask(() => callback?.(null, stdout, Buffer.alloc(0)))
+    return createMockChild()
+  })
+}
+
+describe('WSL login-shell reads are fenced', () => {
+  beforeEach(() => {
+    execFileMock.mockReset()
+    execFileSyncMock.mockReset()
+    spawnMock.mockReset()
+    resetWslGitReadEnvironmentForTests()
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: process.platform })
+    resetWslGitReadEnvironmentForTests()
+  })
+
+  it('returns blob bytes without the login-shell banner', async () => {
+    respondWithFencedPayload('line one\nline two\n')
+
+    const { stdout } = await gitExecFileAsyncBuffer(['show', ':file.txt'], {
+      cwd: WSL_CWD,
+      wslDistro: DISTRO
+    })
+
+    expect(stdout.toString('utf8')).toBe('line one\nline two\n')
+  })
+
+  it('keeps binary blob bytes intact through the fence', async () => {
+    // Why bytes: decoding to a string to find the fence would mangle a PNG header.
+    const binary = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0xff, 0xfe, 0x0a, 0x00, 0x1b])
+    respondWithFencedPayload(binary)
+
+    const { stdout } = await gitExecFileAsyncBuffer(['show', ':image.png'], {
+      cwd: WSL_CWD,
+      wslDistro: DISTRO
+    })
+
+    expect(Buffer.compare(stdout, binary)).toBe(0)
+  })
+
+  /** Answer the core.sshCommand probe with `configured`, and any other command with ok. */
+  function respondToSshPolicyProbe(configured: string): void {
+    execFileMock.mockImplementation((_command, args, _options, callback) => {
+      const script = String(args.at(-1))
+      const nonce = /__ORCA_WSL_CAPTURE_BEGIN_([^_]+)__/.exec(script)?.[1] ?? ''
+      const stdout = script.includes('core.sshCommand')
+        ? `${BANNER}__ORCA_WSL_CAPTURE_BEGIN_${nonce}__${configured}__ORCA_WSL_CAPTURE_END_${nonce}__`
+        : 'ok'
+      queueMicrotask(() => callback?.(null, stdout, ''))
+      return createMockChild()
+    })
+  }
+
+  function sshCommandFromLastGitCall(): string | undefined {
+    const gitCall = execFileMock.mock.calls
+      .filter((call) => !String(call[1]?.at(-1)).includes('core.sshCommand'))
+      .at(-1)
+    return (gitCall?.[2] as { env?: NodeJS.ProcessEnv } | undefined)?.env?.GIT_SSH_COMMAND
+  }
+
+  it('keeps the BatchMode guard when core.sshCommand is unset behind a banner', async () => {
+    // Banner-only reply: git printed nothing, so no sshCommand is configured.
+    // Unfenced, the banner reads as a configured wrapper and the guard is dropped.
+    respondToSshPolicyProbe('')
+
+    await gitExecFileAsync(['fetch', 'origin'], {
+      cwd: WSL_CWD,
+      wslDistro: DISTRO,
+      useConfiguredSshCommandForNetwork: true
+    })
+
+    expect(sshCommandFromLastGitCall()).toBe('ssh -o BatchMode=yes')
+  })
+
+  it('still honors a genuinely configured core.sshCommand', async () => {
+    respondToSshPolicyProbe('ssh -i /home/alice/.ssh/id_ed25519\n')
+
+    await gitExecFileAsync(['fetch', 'origin'], {
+      cwd: WSL_CWD,
+      wslDistro: DISTRO,
+      useConfiguredSshCommandForNetwork: true
+    })
+
+    expect(sshCommandFromLastGitCall()).toContain('/home/alice/.ssh/id_ed25519')
+    expect(sshCommandFromLastGitCall()).toContain('BatchMode=yes')
+  })
+})

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -35,9 +35,11 @@ import {
 } from '../../shared/git-credential-prompt-env'
 import { getSpawnArgsForWindows, isWindowsBatchScript, resolveWindowsCommand } from '../win32-utils'
 import {
+  buildWslCapturedLoginShellCommand,
   buildWslExecArgs,
   buildWslLoginShellCommand,
-  quotePosixShell
+  quotePosixShell,
+  type WslCapturedLoginShellCommand
 } from '../../shared/wsl-login-shell-command'
 import { UNTRANSLATED_GIT_OUTPUT_ENV } from '../../shared/git-output-locale'
 import { endSubprocessStdin } from '../../shared/subprocess-stdin-write'
@@ -74,6 +76,8 @@ type ResolvedCommand = {
   /** Non-null when the command was routed through WSL. */
   wsl: WslPathInfo | null
   wslMode: 'direct-git' | 'login-shell' | 'non-login-shell' | null
+  /** Present only when the caller opted into a fenced login-shell read. */
+  captured?: WslCapturedLoginShellCommand
 }
 
 /**
@@ -309,6 +313,7 @@ function resolveCommand(
   wslDistroOverride?: string,
   options: {
     useWslLoginShell?: boolean
+    captureLoginShellOutput?: boolean
     wslGitReadEnvironment?: WslGitReadEnvironment
     env?: NodeJS.ProcessEnv
   } = {}
@@ -362,6 +367,21 @@ function resolveCommand(
   }
 
   if (options.useWslLoginShell) {
+    // Why opt-in: the login shell is interactive for bash/zsh, so its rc output
+    // lands on stdout ahead of the payload. Callers that buffer the whole stream
+    // fence it; streaming consumers (git grep, ls-files -z) must not, because a
+    // marker would be glued onto their first record.
+    if (options.captureLoginShellOutput) {
+      const captured = buildWslCapturedLoginShellCommand(shellCmd)
+      return {
+        binary: 'wsl.exe',
+        args: buildWslExecArgs(wsl.distro, ['sh', '-lc', captured.command]),
+        cwd: undefined,
+        wsl,
+        wslMode: 'login-shell',
+        captured
+      }
+    }
     return {
       binary: 'wsl.exe',
       args: buildWslExecArgs(wsl.distro, ['sh', '-lc', buildWslLoginShellCommand(shellCmd)]),
@@ -419,7 +439,8 @@ function wslDistroForCommand(cwd: string | undefined, override?: string): string
 function resolveGitCommand(
   args: string[],
   options: GitExecOptions,
-  forceLoginShell = false
+  forceLoginShell = false,
+  captureLoginShellOutput = false
 ): ResolvedCommand {
   if (usesHostGitForWslLinkedWorktree(options.cwd, options.wslDistro)) {
     // Why: WSL Git resolves a Windows-authored linked-worktree pointer relative to cwd.
@@ -438,7 +459,7 @@ function resolveGitCommand(
       void getWslGitReadEnvironment(distro)
     }
   }
-  return resolveGitCommandWithoutProbe(args, options)
+  return resolveGitCommandWithoutProbe(args, options, captureLoginShellOutput)
 }
 
 function shouldAttemptWslDirectGit(options: GitExecOptions): boolean {
@@ -454,9 +475,14 @@ function shouldAttemptWslDirectGit(options: GitExecOptions): boolean {
   )
 }
 
-function resolveGitCommandWithoutProbe(args: string[], options: GitExecOptions): ResolvedCommand {
+function resolveGitCommandWithoutProbe(
+  args: string[],
+  options: GitExecOptions,
+  captureLoginShellOutput = false
+): ResolvedCommand {
   return resolveCommand('git', args, options.cwd, options.wslDistro, {
-    useWslLoginShell: Boolean(options.wslDistro)
+    useWslLoginShell: Boolean(options.wslDistro),
+    captureLoginShellOutput
   })
 }
 
@@ -998,7 +1024,9 @@ async function buildNetworkSshPolicyEnv(options: GitExecOptions): Promise<{
     return { env: promptEnv, mode: 'explicit-env' }
   }
 
-  const resolved = resolveGitCommand(['config', '--get', 'core.sshCommand'], options, true)
+  // Why fenced: a login-shell banner here reads as a user-configured sshCommand,
+  // which skips the BatchMode fallback below and disarms the no-prompt guard.
+  const resolved = resolveGitCommand(['config', '--get', 'core.sshCommand'], options, true, true)
   let configuredCommand = ''
   try {
     const { stdout } = await execFileCapture(resolved.binary, resolved.args, {
@@ -1009,7 +1037,8 @@ async function buildNetworkSshPolicyEnv(options: GitExecOptions): Promise<{
       env: promptEnv,
       signal: options.signal
     })
-    configuredCommand = String(stdout).trim()
+    const payload = resolved.captured?.readStdout(String(stdout)) ?? String(stdout)
+    configuredCommand = payload.trim()
   } catch {
     configuredCommand = ''
   }
@@ -1155,19 +1184,42 @@ export async function gitExecFileAsyncBuffer(
   if (isWslLinkedWorktreeGitRoutingCandidate(options.cwd, options.wslDistro)) {
     await prepareWslLinkedWorktreeGitRouting(options.cwd, options.wslDistro)
   }
-  let resolved = resolveGitCommand(args, options, true)
+  // Why fenced: this returns raw blob bytes straight to the diff/blob viewer, so
+  // a login-shell banner would be prepended to displayed file content.
+  let resolved = resolveGitCommand(args, options, true, true)
   const environmentReady = prepareWindowsHostGitEnvironment(resolved, undefined)
   if (environmentReady) {
     await environmentReady
   }
-  resolved = resolveGitCommand(args, options, true)
+  resolved = resolveGitCommand(args, options, true, true)
   const { stdout } = (await execFileCapture(resolved.binary, resolved.args, {
     cwd: resolved.cwd,
     encoding: 'buffer',
     maxBuffer: options.maxBuffer,
     env: untranslatedGitOutputEnv()
   })) as { stdout: Buffer }
-  return { stdout }
+  return { stdout: readCapturedGitBuffer(stdout, resolved) }
+}
+
+/**
+ * Slice a fenced payload out of raw bytes.
+ *
+ * Why bytes: blob content may be binary, so decoding to a string to find the
+ * fence would corrupt it. Returns the buffer untouched when the command was not
+ * fenced or the fence is absent.
+ */
+function readCapturedGitBuffer(stdout: Buffer, resolved: ResolvedCommand): Buffer {
+  const captured = resolved.captured
+  if (!captured) {
+    return stdout
+  }
+  const beginIndex = stdout.indexOf(captured.beginMarker, 0, 'utf8')
+  if (beginIndex === -1) {
+    return stdout
+  }
+  const payloadStart = beginIndex + Buffer.byteLength(captured.beginMarker, 'utf8')
+  const endIndex = stdout.indexOf(captured.endMarker, payloadStart, 'utf8')
+  return endIndex === -1 ? stdout.subarray(payloadStart) : stdout.subarray(payloadStart, endIndex)
 }
 
 /** Result of a streamed git command; `stoppedEarly` is true when onStdout asked to stop before the child exited. */

--- a/src/shared/wsl-login-shell-command.ts
+++ b/src/shared/wsl-login-shell-command.ts
@@ -42,6 +42,11 @@ export type WslCapturedLoginShellCommand = {
   command: string
   /** Payload the command wrote, or null when the fence never appeared. */
   readStdout: (stdout: string) => string | null
+  // Why exposed: binary reads (`git show` blob content) must slice bytes rather
+  // than decode to a string first, and this module is bundled for the renderer,
+  // so it cannot reference Buffer itself.
+  beginMarker: string
+  endMarker: string
 }
 
 // Why: the fence has to be absent from both the rc output ahead of it and the
@@ -70,6 +75,8 @@ export function buildWslCapturedLoginShellCommand(
   const begin = `__ORCA_WSL_CAPTURE_BEGIN_${nonce}__`
   const end = `__ORCA_WSL_CAPTURE_END_${nonce}__`
   return {
+    beginMarker: begin,
+    endMarker: end,
     command: buildWslLoginShellCommand(
       [
         `printf %s ${quotePosixShell(begin)}`,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​137 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​137 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​69 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​59 |

<!-- /orca-pr-loc -->

<!-- wsl-stack -->
### Stack

Merge bottom-up; each PR is based on the one above it.

| # | PR | Base | |
| ---: | :--- | :--- | :--- |
| 1 |   #15039 | `main` | fix(wsl): pass guest argv verbatim through --exec |
| 2 |   #15040 | `#15039` | fix(wsl): read machine output from a fenced login shell |
| 3 | ▶ #15060 | `#15040` | fix(git): fence buffered WSL login-shell reads ← **you are here** |
| 4 |   #15257 | `#15060` | fix(git): run WSL git reads without a shell |

<!-- /wsl-stack -->

## ELI5

Same banner problem as #15040, now in git.

When Orca runs git inside WSL, it goes through the login shell, which prints the distro's welcome banner to the same pipe the answer comes back on. Two git paths read that pipe whole and never strip the banner:

- **Viewing a file** â€” the banner gets pasted on top of the file's contents in the diff viewer.
- **Checking your SSH setting** â€” Orca asks git "did the user configure a custom SSH command?". The banner is a non-empty answer, so Orca concludes *yes*, and skips the safety setting that stops SSH from hanging forever waiting for a password prompt.

## Why this wasn't in #15040

I originally left the git login-shell path alone on the belief that its consumers are *streaming*, where fencing would break them, and that the shell-free "direct git" fast path covered the important cases. **Both assumptions were wrong**, and checking them is what produced this PR:

`preferWslDirectGit` is set by exactly one options-builder, `gitStatusReadOptionsForWorktree` â€” used only for status-adjacent reads:

```
$ grep -rn "preferWslDirectGit" src --include=*.ts | grep -v test
src/main/git/git-runtime-options.ts:24:  preferWslDirectGit: true
src/main/git/git-runtime-options.ts:26:  return { ...gitOptionsForWorktree(cwd, options), preferWslDirectGit: true }
src/main/git/status.ts:328:        preferWslDirectGit: true,
```

Every other caller uses `gitOptionsForWorktree`, which never sets it. So for `git show`, remote/config reads, history, checkout and commit, the login shell isn't a cold fallback â€” **it is the only path, on every call**.

The two sites fixed here go further and pass `forceLoginShell = true`, so they never take the fast path even in principle.

## Streaming really is a hazard â€” so fencing is opt-in

The original concern was legitimate, just not universal. `searchWithGitGrep` and `runGitLsFiles` process records as they arrive (and `git grep` is killed early once `maxResults` is hit, so a closing fence may never be written). An opening marker would be glued onto their first record.

So the fence is opted into per call site rather than applied to the login-shell branch as a whole. Only the two buffered-by-construction functions opt in. The streaming consumers are untouched â€” and are incidentally immune anyway, since `ingestGitGrepLine` requires an embedded NUL and discards banner lines outright.

## Binary safety

Blob content can be binary, so the payload is sliced out of the **raw bytes**; decoding to a string to find the fence would corrupt a PNG header. The markers are exposed on the captured command because the shared module is bundled for the renderer and so cannot reference `Buffer`.

## Testing

Four tests, all mutation-checked â€” each fails with the fence disabled, with the real symptom:

| test | failure without the fix |
|---|---|
| blob text | `expected 'To run a command as administratorâ€¦' to be 'line one\nline two\n'` |
| **binary blob** | `Buffer.compare` â†’ `-1` (bytes corrupted) |
| **SSH guard** | `GIT_SSH_COMMAND` is `undefined` â€” the BatchMode guard is gone |
| configured sshCommand | still honored, still gets `BatchMode=yes` |

The SSH tests drive the real public entry point (`gitExecFileAsync` with `useConfiguredSshCommandForNetwork`) and assert on the env actually handed to git, rather than adding a test-only export.

Suite compared against `origin/main` at **test-name** granularity across `src/main/git` and `src/shared`: **zero new failures**, and 8 test-names that fail on `main` pass here. Typecheck and lint gates clean.


