### PR TITLE
fix(ai-vault): keep named Codex App tasks and parent rollouts

### DIFF
--- a/src/main/ai-vault/remote-session-scanner-sources.ts
+++ b/src/main/ai-vault/remote-session-scanner-sources.ts
@@ -200,32 +200,34 @@ function remoteCodexSources(
       'codex-runtime-home',
       'home'
     )
-  ].map((codexHome) => ({
-    agent: 'codex',
-    rootDir: joinRemotePath(hostPlatform, codexHome, 'sessions'),
-    codexHome,
-    extensions: ['.jsonl'],
-    parse: (file, content, context) =>
-      parseCodexSessionContent({
-        file,
-        content,
-        platform: context.hostPlatform.os,
-        codexHome,
-        executionHostId: context.executionHostId,
-        executionHostPlatform: context.hostPlatform.os,
-        signal: context.signal,
-        readIndexedTitle: async (sessionId) =>
-          (
-            await remoteCodexIndexTitles({
-              provider: context.provider,
-              codexHome,
-              hostPlatform,
-              titleCaches: context.titleCaches,
-              signal: context.signal
-            })
-          ).get(sessionId) ?? null
-      })
-  }))
+  ].flatMap((codexHome) =>
+    (['sessions', 'archived_sessions'] as const).map((historyDirName) => ({
+      agent: 'codex' as const,
+      rootDir: joinRemotePath(hostPlatform, codexHome, historyDirName),
+      codexHome,
+      extensions: ['.jsonl'],
+      parse: (file, content, context) =>
+        parseCodexSessionContent({
+          file,
+          content,
+          platform: context.hostPlatform.os,
+          codexHome,
+          executionHostId: context.executionHostId,
+          executionHostPlatform: context.hostPlatform.os,
+          signal: context.signal,
+          readIndexedTitle: async (sessionId) =>
+            (
+              await remoteCodexIndexTitles({
+                provider: context.provider,
+                codexHome,
+                hostPlatform,
+                titleCaches: context.titleCaches,
+                signal: context.signal
+              })
+            ).get(sessionId) ?? null
+        })
+    }))
+  )
 }
 
 function remoteOpenClawSources(

--- a/src/main/ai-vault/session-scanner-agent-sources.ts
+++ b/src/main/ai-vault/session-scanner-agent-sources.ts
@@ -3,7 +3,10 @@ import { basename, dirname, extname, join, relative } from 'node:path'
 import type { AiVaultAgent } from '../../shared/ai-vault-types'
 import type { AiVaultDeletableAgent } from '../../shared/ai-vault-session-deletion'
 import { resolveGrokSessionsDir } from '../../shared/grok-session-paths'
-import { uniqueCodexSessionsDirs } from './session-scanner-codex-paths'
+import {
+  siblingCodexArchivedSessionsDir,
+  uniqueCodexSessionsDirs
+} from './session-scanner-codex-paths'
 import { resolveKimiSessionsDir } from './session-scanner-kimi-paths'
 import { OMP_SESSION_ARTIFACT_DIR_PATTERN } from './session-scanner-omp-subagent-transcripts'
 import { claudeProjectsRootDirs, OMP_SESSIONS_DIR, sessionRootDirs } from './session-scanner-roots'
@@ -83,16 +86,18 @@ export const AI_VAULT_AGENT_SOURCES: AiVaultAgentSourceTable = {
   },
   codex: {
     rootDirs: (options, wslHomeDirs) =>
-      uniqueCodexSessionsDirs([
-        options.codexSessionsDir ?? CODEX_SESSIONS_DIR,
-        ...wslHomeDirs.map((homeDir) => join(homeDir, '.codex', 'sessions')),
-        // Why: Orca-launched WSL Codex sessions use an Orca-owned CODEX_HOME,
-        // not the user's default ~/.codex history root.
-        ...wslHomeDirs.map((homeDir) =>
-          join(homeDir, '.local', 'share', 'orca', 'codex-runtime-home', 'home', 'sessions')
-        ),
-        ...(options.additionalCodexSessionsDirs ?? [])
-      ]),
+      uniqueCodexSessionsDirs(
+        [
+          options.codexSessionsDir ?? CODEX_SESSIONS_DIR,
+          ...wslHomeDirs.map((homeDir) => join(homeDir, '.codex', 'sessions')),
+          // Why: Orca-launched WSL Codex sessions use an Orca-owned CODEX_HOME,
+          // not the user's default ~/.codex history root.
+          ...wslHomeDirs.map((homeDir) =>
+            join(homeDir, '.local', 'share', 'orca', 'codex-runtime-home', 'home', 'sessions')
+          ),
+          ...(options.additionalCodexSessionsDirs ?? [])
+        ].flatMap((sessionsDir) => [sessionsDir, siblingCodexArchivedSessionsDir(sessionsDir)])
+      ),
     extensions: ['.jsonl']
   },
   gemini: {

--- a/src/main/ai-vault/session-scanner-codex-parser.ts
+++ b/src/main/ai-vault/session-scanner-codex-parser.ts
@@ -77,10 +77,12 @@ export async function parseCodexSessionContent(args: {
   })
 }
 
+type CodexSessionOrigin = 'unknown' | 'user' | 'worker'
+
 type CodexSessionParseState = {
   accumulator: SessionAccumulator
   previousTotals: CodexUsageSnapshot | null
-  rejectedWorkerSession: boolean
+  sessionOrigin: CodexSessionOrigin
   sawSessionMeta: boolean
   historyMode: string | null
   // Which source set the current title; an index-file title outranks the raw
@@ -96,7 +98,7 @@ function createCodexParseState(file: FileWithMtime): CodexSessionParseState {
       sessionId: sessionIdFromFileName(file.path)
     }),
     previousTotals: null,
-    rejectedWorkerSession: false,
+    sessionOrigin: 'unknown',
     sawSessionMeta: false,
     historyMode: null,
     titleSource: null
@@ -112,9 +114,6 @@ function cloneCodexParseState(state: CodexSessionParseState): CodexSessionParseS
 }
 
 function consumeCodexRecordLine(state: CodexSessionParseState, line: string): void {
-  if (state.rejectedWorkerSession) {
-    return
-  }
   const record = parseJsonObject(line)
   if (!record) {
     return
@@ -125,10 +124,13 @@ function consumeCodexRecordLine(state: CodexSessionParseState, line: string): vo
 
   const payload = asRecord(record.payload)
   if (record.type === 'session_meta' && payload) {
-    if (isCodexWorkerSession(payload)) {
-      // Why: Codex writes internal worker/sub-agent transcripts into the same
-      // history tree; AI Vault should show user-started sessions only.
-      state.rejectedWorkerSession = true
+    const workerMeta = isCodexWorkerSession(payload)
+    if (state.sessionOrigin === 'unknown') {
+      // Why: only the first session_meta classifies the file. Later worker
+      // metas are copied into user rollouts (Codex App tasks / compact) and
+      // must not abort or retarget the parent transcript.
+      state.sessionOrigin = workerMeta ? 'worker' : 'user'
+    } else if (workerMeta || state.sessionOrigin === 'worker') {
       return
     }
     state.sawSessionMeta = true
@@ -233,19 +235,21 @@ async function finalizeCodexParseState(
     executionHostPlatform?: NodeJS.Platform | null
   }
 ): Promise<AiVaultSession | null> {
-  if (state.rejectedWorkerSession) {
-    return null
-  }
   // Finalize a snapshot: the live state keeps accumulating appended lines.
   const snapshot = cloneCodexParseState(state)
+  const indexedTitle = snapshot.sawSessionMeta
+    ? await args.titleReader?.(snapshot.accumulator.sessionId)
+    : null
+  if (snapshot.sessionOrigin === 'worker' && !indexedTitle) {
+    // Why: unnamed worker/sub-agent rollouts stay hidden. A session_index
+    // thread_name means the user kept the window (for example ads: Brand).
+    return null
+  }
   // Why: Codex names threads lazily in session_index.jsonl, so the lookup runs
   // per finalize (the index read is signature-cached) — a title that appears
   // after the transcript was first parsed must still replace the raw prompt.
-  if (snapshot.sawSessionMeta && snapshot.titleSource !== 'meta') {
-    const indexedTitle = await args.titleReader?.(snapshot.accumulator.sessionId)
-    if (indexedTitle) {
-      snapshot.accumulator.title = indexedTitle
-    }
+  if (indexedTitle && (snapshot.sessionOrigin === 'worker' || snapshot.titleSource !== 'meta')) {
+    snapshot.accumulator.title = indexedTitle
   }
   return finalizeSession(snapshot.accumulator, platform, {
     codexHome: args.codexHome,
@@ -292,10 +296,6 @@ async function parseCodexSessionLines(args: {
   const state = createCodexParseState(args.file)
   for await (const line of args.lines) {
     consumeCodexRecordLine(state, line)
-    if (state.rejectedWorkerSession) {
-      // Worker transcripts are excluded outright; stop reading early.
-      return null
-    }
   }
   return finalizeCodexParseState(state, args.platform, {
     codexHome: args.codexHome,

--- a/src/main/ai-vault/session-scanner-codex-paths.ts
+++ b/src/main/ai-vault/session-scanner-codex-paths.ts
@@ -1,4 +1,15 @@
-import { dirname, resolve } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
+
+export const CODEX_LIVE_SESSIONS_DIR_NAME = 'sessions'
+export const CODEX_ARCHIVED_SESSIONS_DIR_NAME = 'archived_sessions'
+
+export function isCodexHistoryDirName(name: string): boolean {
+  return name === CODEX_LIVE_SESSIONS_DIR_NAME || name === CODEX_ARCHIVED_SESSIONS_DIR_NAME
+}
+
+export function siblingCodexArchivedSessionsDir(sessionsDir: string): string {
+  return join(dirname(sessionsDir), CODEX_ARCHIVED_SESSIONS_DIR_NAME)
+}
 
 export function codexHomeForSessionsDir(
   sessionsDir: string,

--- a/src/main/ai-vault/session-scanner-codex-title-index.test.ts
+++ b/src/main/ai-vault/session-scanner-codex-title-index.test.ts
@@ -42,6 +42,25 @@ async function readTitle(codexHome: string, index: number): Promise<string | nul
 }
 
 describe('codex session index title cache', () => {
+  it('resolves Codex home from archived_sessions when home is not passed', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-codex-title-archived-'))
+    tempRoots.push(root)
+    const codexHome = join(root, 'codex-home')
+    await mkdir(join(codexHome, 'archived_sessions'), { recursive: true })
+    await writeFile(
+      join(codexHome, 'session_index.jsonl'),
+      `${JSON.stringify({ id: 'archived-session', thread_name: 'ads: WiiM US' })}\n`
+    )
+
+    expect(
+      await readCodexSessionIndexTitle(
+        join(codexHome, 'archived_sessions', 'rollout-archived-session.jsonl'),
+        null,
+        'archived-session'
+      )
+    ).toBe('ads: WiiM US')
+  })
+
   it('caps cached title indexes by Codex home', async () => {
     const homes: string[] = []
 

--- a/src/main/ai-vault/session-scanner-codex-title-index.ts
+++ b/src/main/ai-vault/session-scanner-codex-title-index.ts
@@ -1,4 +1,5 @@
 import { basename, dirname, join } from 'node:path'
+import { isCodexHistoryDirName } from './session-scanner-codex-paths'
 import { createInterface } from 'node:readline'
 import { openTranscriptReadStream, wslGatedStat } from '../native-chat/wsl-transcript-fs-access'
 import { WslTranscriptFsError } from '../native-chat/wsl-transcript-fs-gate'
@@ -65,7 +66,7 @@ export async function readCodexSessionIndexTitle(
 function codexHomeFromSessionFilePath(sessionFilePath: string): string | null {
   let currentDir = dirname(sessionFilePath)
   while (currentDir && dirname(currentDir) !== currentDir) {
-    if (basename(currentDir) === 'sessions') {
+    if (isCodexHistoryDirName(basename(currentDir))) {
       return dirname(currentDir)
     }
     currentDir = dirname(currentDir)

--- a/src/main/ai-vault/session-scanner-codex-workers.test.ts
+++ b/src/main/ai-vault/session-scanner-codex-workers.test.ts
@@ -3,10 +3,12 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import { scanAiVaultSessions } from './session-scanner'
+import { resetCodexSessionIndexTitleCacheForTests } from './session-scanner-codex-title-index'
 
 let tempRoots: string[] = []
 
 afterEach(async () => {
+  resetCodexSessionIndexTitleCacheForTests()
   await Promise.all(tempRoots.map((root) => rm(root, { recursive: true, force: true })))
   tempRoots = []
 })
@@ -130,4 +132,173 @@ describe('scanAiVaultSessions Codex worker sessions', () => {
     expect(result.sessions.map((session) => session.sessionId)).toEqual(['user-session'])
     expect(result.sessions[0]?.title).toBe('Top-level Codex task')
   })
+
+  it('keeps a user Codex transcript that later embeds a worker session_meta', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-ai-vault-codex-embedded-worker-'))
+    tempRoots.push(root)
+    const codexHome = join(root, 'codex-home')
+    const codexSessionsDir = join(codexHome, 'sessions', '2026', '08', '15')
+    await mkdir(codexSessionsDir, { recursive: true })
+
+    await writeFile(
+      join(codexSessionsDir, 'rollout-user-with-embedded-worker.jsonl'),
+      jsonLines([
+        {
+          timestamp: '2026-08-15T10:00:00.000Z',
+          type: 'session_meta',
+          payload: {
+            id: 'user-parent',
+            cwd: '/repo/ads_public',
+            thread_source: 'user',
+            source: 'vscode'
+          }
+        },
+        {
+          timestamp: '2026-08-15T10:00:01.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'user',
+            content: [{ type: 'text', text: 'Parent brand task' }]
+          }
+        },
+        {
+          timestamp: '2026-08-15T10:00:02.000Z',
+          type: 'session_meta',
+          payload: {
+            id: 'embedded-worker',
+            cwd: '/repo/ads_public',
+            thread_source: 'subagent',
+            source: {
+              subagent: {
+                thread_spawn: { parent_thread_id: 'user-parent', depth: 1 }
+              }
+            }
+          }
+        },
+        {
+          timestamp: '2026-08-15T10:00:03.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'text', text: 'Still the parent conversation' }]
+          }
+        }
+      ])
+    )
+
+    const result = await scanAiVaultSessions({
+      ...emptyAgentRoots(root),
+      codexSessionsDir: join(codexHome, 'sessions'),
+      platform: 'darwin'
+    })
+
+    expect(result.issues).toEqual([])
+    expect(result.sessions.map((session) => session.sessionId)).toEqual(['user-parent'])
+    expect(result.sessions[0]?.title).toBe('Parent brand task')
+  })
+
+  it('lists a Codex worker session that the user renamed in session_index', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-ai-vault-codex-named-worker-'))
+    tempRoots.push(root)
+    const codexHome = join(root, 'codex-home')
+    const liveDir = join(codexHome, 'sessions', '2026', '08', '14')
+    const archivedDir = join(codexHome, 'archived_sessions')
+    await mkdir(liveDir, { recursive: true })
+    await mkdir(archivedDir, { recursive: true })
+
+    await writeFile(
+      join(liveDir, 'rollout-named-worker.jsonl'),
+      jsonLines([
+        {
+          timestamp: '2026-08-14T05:00:08.000Z',
+          type: 'session_meta',
+          payload: {
+            id: 'named-worker',
+            cwd: '/repo/ads_public',
+            thread_source: 'subagent'
+          }
+        },
+        {
+          timestamp: '2026-08-14T05:00:09.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'user',
+            content: [{ type: 'text', text: '<codex_delegation> brand task' }]
+          }
+        }
+      ])
+    )
+    await writeFile(
+      join(archivedDir, 'rollout-archived-named-worker.jsonl'),
+      jsonLines([
+        {
+          timestamp: '2026-08-14T05:00:24.000Z',
+          type: 'session_meta',
+          payload: {
+            id: 'archived-named-worker',
+            cwd: '/repo/ads_public',
+            thread_source: 'subagent'
+          }
+        },
+        {
+          timestamp: '2026-08-14T05:00:25.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'user',
+            content: [{ type: 'text', text: '<codex_delegation> archived brand task' }]
+          }
+        }
+      ])
+    )
+    await writeFile(
+      join(codexHome, 'session_index.jsonl'),
+      `${JSON.stringify({ id: 'named-worker', thread_name: 'ads: MERACH US' })}\n${JSON.stringify({ id: 'archived-named-worker', thread_name: 'ads: Bluetti Power US' })}\n`
+    )
+
+    const result = await scanAiVaultSessions({
+      ...emptyAgentRoots(root),
+      codexSessionsDir: join(codexHome, 'sessions'),
+      platform: 'darwin'
+    })
+
+    expect(result.issues).toEqual([])
+    expect(result.sessions.map((session) => session.sessionId).sort()).toEqual([
+      'archived-named-worker',
+      'named-worker'
+    ])
+    expect(result.sessions.find((session) => session.sessionId === 'named-worker')?.title).toBe(
+      'ads: MERACH US'
+    )
+    expect(
+      result.sessions.find((session) => session.sessionId === 'archived-named-worker')?.title
+    ).toBe('ads: Bluetti Power US')
+  })
 })
+
+function emptyAgentRoots(root: string) {
+  return {
+    claudeProjectsDir: join(root, 'claude-projects'),
+    geminiSessionsDir: join(root, 'gemini-sessions'),
+    antigravityBrainDir: join(root, 'antigravity-brain'),
+    copilotSessionsDir: join(root, 'copilot-sessions'),
+    cursorProjectsDir: join(root, 'cursor-projects'),
+    opencodeStorageDir: join(root, 'opencode-storage'),
+    opencodeDbPaths: [] as string[],
+    grokSessionsDir: join(root, 'grok-sessions'),
+    devinTranscriptsDir: join(root, 'devin-transcripts'),
+    hermesSessionsDir: join(root, 'hermes-sessions'),
+    rovoSessionsDir: join(root, 'rovo-sessions'),
+    openclawStateDir: join(root, 'openclaw-state'),
+    openclawLegacyStateDir: join(root, 'openclaw-legacy-state'),
+    piSessionsDir: join(root, 'pi-sessions'),
+    ompSessionsDir: join(root, 'omp-sessions'),
+    primeAgentSessionsDir: join(root, 'prime-agent-sessions'),
+    droidSessionsDir: join(root, 'droid-sessions'),
+    droidProjectsDir: join(root, 'droid-projects'),
+    kimiSessionsDir: join(root, 'kimi-sessions')
+  }
+}


### PR DESCRIPTION
## ELI5

Codex App task windows that you rename, and some parent chats that later copy a child `session_meta` into the same file, were scanned and then thrown away. This keeps unnamed internal workers hidden, but shows the windows you actually named, including archived ones.

## What Changed

- Classify a Codex rollout from its **first** `session_meta` only. Later embedded worker metas no longer abort or retarget a user parent transcript.
- Still hide unnamed worker/sub-agent rollouts. If `session_index.jsonl` has a `thread_name`, keep that session and use the name as the title.
- Scan `archived_sessions` next to `sessions` locally and over SSH. Title lookup also resolves Codex home from `archived_sessions` paths.

## Why

AI Vault was treating every `thread_source != user` meta as fatal. That matches internal swarm workers, but Codex App tasks use the same flag and users rename those windows. A second bug discarded real user rollouts that later embed a child `session_meta`. Archived copies were never scanned.

## Linked Issue

Fixes #15061

## Visual Proof

N/A — Agent Session History listing logic only; no renderer/UI chrome change. Sessions that were missing now appear in the existing list.

## Testing

- [x] Automated tests added/updated, or explained why not below
- Focused: `session-scanner-codex-workers.test.ts`, `session-scanner-codex-title-index.test.ts`, `session-scanner-codex-dual-root.test.ts`, `remote-session-scanner.test.ts`, `session-scanner.test.ts`, `session-scanner-scope.test.ts` (40 tests passed)
- Platforms exercised by unit tests: path join / remote POSIX + Windows path helpers already covered by existing scanner tests. No desktop UI run of this checkout.

## AI Disclosure

Implementation and write-up by Grok 4.6 (xAI) in a local coding-agent session.

## Review

### Agent code-review summary

- Cross-platform: new roots use `path.join` / `joinRemotePath`. Archived sibling is `dirname(sessionsDir)/archived_sessions` on every OS.
- SSH/remote: `remoteCodexSources` now walks both `sessions` and `archived_sessions` under the same `CODEX_HOME` and reuses the existing title-index cache.
- Agent compatibility: Codex-only parser/source change. Claude `subagents/` pruning is untouched. Unnamed workers still hidden, so default history should not flood.
- Performance: named-worker files are fully parsed instead of early-return. Unnamed workers still exit at finalize after a title-index lookup (already cached per home).
- UI: no chrome change.
- Security: still local/read-only history files; no new network or credential paths.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Focused unit tests passed locally. Full lint/typecheck/build not run on this checkout because Electron postinstall was still downloading.

## Author

- X / Twitter: