### PR TITLE
fix(crash-reporting): report guest renderer deaths and key renderer dedupe by webContents identity

### DIFF
--- a/src/main/browser/browser-manager-guest-crash-reporting.test.ts
+++ b/src/main/browser/browser-manager-guest-crash-reporting.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const browserMocks = vi.hoisted(() => ({
+  appGetPathMock: vi.fn(() => '/downloads'),
+  shellOpenExternalMock: vi.fn(),
+  browserWindowFromWebContentsMock: vi.fn(),
+  menuBuildFromTemplateMock: vi.fn(),
+  guestOffMock: vi.fn(),
+  guestOnMock: vi.fn(),
+  guestSetBackgroundThrottlingMock: vi.fn(),
+  guestSetWindowOpenHandlerMock: vi.fn(),
+  guestOpenDevToolsMock: vi.fn(),
+  webContentsFromIdMock: vi.fn(),
+  screenGetCursorScreenPointMock: vi.fn(() => ({ x: 0, y: 0 })),
+  openPopupWithOriginBarMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: browserMocks.appGetPathMock
+  },
+  BrowserWindow: {
+    fromWebContents: browserMocks.browserWindowFromWebContentsMock
+  },
+  clipboard: { writeText: vi.fn() },
+  shell: { openExternal: browserMocks.shellOpenExternalMock },
+  Menu: {
+    buildFromTemplate: browserMocks.menuBuildFromTemplateMock
+  },
+  screen: {
+    getCursorScreenPoint: browserMocks.screenGetCursorScreenPointMock
+  },
+  webContents: {
+    fromId: browserMocks.webContentsFromIdMock
+  }
+}))
+
+vi.mock('./popup-origin-bar-window', () => ({
+  openPopupWithOriginBar: browserMocks.openPopupWithOriginBarMock
+}))
+
+import { browserManager } from './browser-manager'
+import { resetBrowserManagerMocks, resetBrowserManagerState } from './browser-manager-test-harness'
+
+const {
+  guestOffMock,
+  guestOnMock,
+  guestSetBackgroundThrottlingMock,
+  guestSetWindowOpenHandlerMock,
+  guestOpenDevToolsMock
+} = browserMocks
+
+type RenderProcessGoneHandler = (
+  event: unknown,
+  details: { reason: string; exitCode: number }
+) => void
+
+function makeGuest(id: number) {
+  return {
+    id,
+    isDestroyed: vi.fn(() => false),
+    getType: vi.fn(() => 'webview'),
+    setBackgroundThrottling: guestSetBackgroundThrottlingMock,
+    setWindowOpenHandler: guestSetWindowOpenHandlerMock,
+    on: guestOnMock,
+    off: guestOffMock,
+    openDevTools: guestOpenDevToolsMock
+  }
+}
+
+function attachedRenderProcessGoneHandler(): RenderProcessGoneHandler | undefined {
+  return guestOnMock.mock.calls.find(([event]) => event === 'render-process-gone')?.[1] as
+    | RenderProcessGoneHandler
+    | undefined
+}
+
+describe('browserManager guest crash reporting (#15052)', () => {
+  beforeEach(() => {
+    resetBrowserManagerMocks(browserMocks)
+    resetBrowserManagerState()
+  })
+
+  it('reports a guest renderer death instead of leaving zero trace', () => {
+    browserManager.attachGuestPolicies(makeGuest(104) as never)
+
+    const handler = attachedRenderProcessGoneHandler()
+    // Pre-fix: every render-process-gone listener on a guest is cleanup-only,
+    // so nothing here can ever reach the crash recorder.
+    expect(handler).toBeTypeOf('function')
+
+    const reporter = vi.fn()
+    browserManager.setGuestRendererGoneReporter(reporter)
+    const details = { reason: 'killed', exitCode: 1 }
+    handler?.({}, details)
+    expect(reporter).toHaveBeenCalledExactlyOnceWith(details, 104, 'browser-guest')
+  })
+
+  it('labels popup child windows distinctly from the primary guest', () => {
+    const reporter = vi.fn()
+    browserManager.setGuestRendererGoneReporter(reporter)
+    browserManager.attachGuestPolicies(
+      makeGuest(205) as never,
+      { browserTabId: 'browser-1', rootGuestWebContentsId: 104 } as never
+    )
+
+    const handler = attachedRenderProcessGoneHandler()
+    expect(handler).toBeTypeOf('function')
+    handler?.({}, { reason: 'crashed', exitCode: 5 })
+    expect(reporter).toHaveBeenCalledExactlyOnceWith(
+      { reason: 'crashed', exitCode: 5 },
+      205,
+      'browser-popup'
+    )
+  })
+
+  it('stops reporting after guest teardown removes the policy listeners', () => {
+    const reporter = vi.fn()
+    browserManager.setGuestRendererGoneReporter(reporter)
+    browserManager.attachGuestPolicies(makeGuest(104) as never)
+
+    const handler = attachedRenderProcessGoneHandler()
+    expect(handler).toBeTypeOf('function')
+    browserManager.unregisterAll()
+
+    expect(guestOffMock.mock.calls.some(([event]) => event === 'render-process-gone')).toBe(true)
+  })
+})

--- a/src/main/browser/browser-manager-guest-crash-reporting.test.ts
+++ b/src/main/browser/browser-manager-guest-crash-reporting.test.ts
@@ -55,10 +55,16 @@ type RenderProcessGoneHandler = (
   details: { reason: string; exitCode: number }
 ) => void
 
-function makeGuest(id: number) {
+function makeGuest(id: number, rendererProcessId?: number) {
   return {
     id,
     isDestroyed: vi.fn(() => false),
+    getProcessId: vi.fn(() => {
+      if (rendererProcessId === undefined) {
+        throw new Error('Object has been destroyed')
+      }
+      return rendererProcessId
+    }),
     getType: vi.fn(() => 'webview'),
     setBackgroundThrottling: guestSetBackgroundThrottlingMock,
     setWindowOpenHandler: guestSetWindowOpenHandlerMock,
@@ -81,7 +87,7 @@ describe('browserManager guest crash reporting (#15052)', () => {
   })
 
   it('reports a guest renderer death instead of leaving zero trace', () => {
-    browserManager.attachGuestPolicies(makeGuest(104) as never)
+    browserManager.attachGuestPolicies(makeGuest(104, 4) as never)
 
     const handler = attachedRenderProcessGoneHandler()
     // Pre-fix: every render-process-gone listener on a guest is cleanup-only,
@@ -92,14 +98,14 @@ describe('browserManager guest crash reporting (#15052)', () => {
     browserManager.setGuestRendererGoneReporter(reporter)
     const details = { reason: 'killed', exitCode: 1 }
     handler?.({}, details)
-    expect(reporter).toHaveBeenCalledExactlyOnceWith(details, 104, 'browser-guest')
+    expect(reporter).toHaveBeenCalledExactlyOnceWith(details, 104, 'browser-guest', 4)
   })
 
   it('labels popup child windows distinctly from the primary guest', () => {
     const reporter = vi.fn()
     browserManager.setGuestRendererGoneReporter(reporter)
     browserManager.attachGuestPolicies(
-      makeGuest(205) as never,
+      makeGuest(205, 4) as never,
       { browserTabId: 'browser-1', rootGuestWebContentsId: 104 } as never
     )
 
@@ -109,8 +115,22 @@ describe('browserManager guest crash reporting (#15052)', () => {
     expect(reporter).toHaveBeenCalledExactlyOnceWith(
       { reason: 'crashed', exitCode: 5 },
       205,
-      'browser-popup'
+      'browser-popup',
+      4
     )
+  })
+
+  it('still reports when the renderer process identity is unreadable', () => {
+    // makeGuest with no process id throws from getProcessId, modeling a guest
+    // torn down mid-event; the death must reach the reporter with an unknown
+    // identity instead of being dropped.
+    browserManager.attachGuestPolicies(makeGuest(104) as never)
+
+    const reporter = vi.fn()
+    browserManager.setGuestRendererGoneReporter(reporter)
+    const details = { reason: 'killed', exitCode: 1 }
+    attachedRenderProcessGoneHandler()?.({}, details)
+    expect(reporter).toHaveBeenCalledExactlyOnceWith(details, 104, 'browser-guest', undefined)
   })
 
   it('stops reporting after guest teardown removes the policy listeners', () => {

--- a/src/main/browser/browser-manager-test-harness.ts
+++ b/src/main/browser/browser-manager-test-harness.ts
@@ -53,6 +53,7 @@ export function resetBrowserManagerState(): void {
   browserManager.unregisterAll()
   browserManager.setBrowserGuestStateChangedListener(null)
   browserManager.setDictationShortcutForwardingPredicate(null)
+  browserManager.setGuestRendererGoneReporter(null)
   browserManager.setSettingsResolver(() => ({}))
 }
 

--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -2,6 +2,7 @@
 import { randomUUID } from 'node:crypto'
 
 import { shell, webContents } from 'electron'
+import { readGoneRendererProcessId } from '../crash-reporting/process-gone-renderer-identity'
 import { ORCA_BROWSER_BLANK_URL } from '../../shared/constants'
 import {
   normalizeBrowserNavigationUrl,
@@ -153,7 +154,8 @@ export type BrowserGuestRendererGoneKind = 'browser-guest' | 'browser-popup'
 export type BrowserGuestRendererGoneReporter = (
   details: Electron.RenderProcessGoneDetails,
   guestWebContentsId: number,
-  guestKind: BrowserGuestRendererGoneKind
+  guestKind: BrowserGuestRendererGoneKind,
+  guestRendererProcessId: number | undefined
 ) => void
 type PendingMainFrameNavigation = {
   currentUrl: string
@@ -919,7 +921,8 @@ export class BrowserManager {
       this.guestRendererGoneReporter?.(
         details,
         guest.id,
-        inheritedOwnerContext ? 'browser-popup' : 'browser-guest'
+        inheritedOwnerContext ? 'browser-popup' : 'browser-guest',
+        readGoneRendererProcessId(guest)
       )
     }
     guest.on('render-process-gone', renderProcessGoneHandler)

--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -149,6 +149,12 @@ type PopupOwnerContext = {
   browserTabId: string
   rootGuestWebContentsId: number
 }
+export type BrowserGuestRendererGoneKind = 'browser-guest' | 'browser-popup'
+export type BrowserGuestRendererGoneReporter = (
+  details: Electron.RenderProcessGoneDetails,
+  guestWebContentsId: number,
+  guestKind: BrowserGuestRendererGoneKind
+) => void
 type PendingMainFrameNavigation = {
   currentUrl: string
   supersededUrls: string[]
@@ -246,6 +252,7 @@ export class BrowserManager {
   // Why: did-start-navigation hides the overlay optimistically; stash the cleared error so did-fail-load(-3) can restore an aborted nav.
   private readonly clearedLoadErrorsByGuestId = new Map<number, BrowserLoadError>()
   private browserGuestStateChangedListener: ((worktreeId: string) => void) | null = null
+  private guestRendererGoneReporter: BrowserGuestRendererGoneReporter | null = null
   private certificateTrustController: BrowserCertificateTrustController | null = null
   private shouldForwardDictationShortcut: (() => boolean) | null = null
   private readonly pendingLoadFailuresByGuestId = new Map<
@@ -260,6 +267,11 @@ export class BrowserManager {
 
   setDictationShortcutForwardingPredicate(predicate: (() => boolean) | null): void {
     this.shouldForwardDictationShortcut = predicate
+  }
+
+  /** Injected so guest renderer deaths reach the crash recorder without coupling BrowserManager to the report store (#15052). */
+  setGuestRendererGoneReporter(reporter: BrowserGuestRendererGoneReporter | null): void {
+    this.guestRendererGoneReporter = reporter
   }
 
   setBrowserGuestStateChangedListener(listener: ((worktreeId: string) => void) | null): void {
@@ -898,6 +910,19 @@ export class BrowserManager {
       this.certificateTrustController?.onMainFrameNavigationCommitted(guest.id, url)
     }
 
+    const renderProcessGoneHandler = (
+      _event: Electron.Event,
+      details: Electron.RenderProcessGoneDetails
+    ): void => {
+      // Why: every other guest render-process-gone listener is cleanup-only, so
+      // without this forward a guest renderer death leaves zero trace (#15052).
+      this.guestRendererGoneReporter?.(
+        details,
+        guest.id,
+        inheritedOwnerContext ? 'browser-popup' : 'browser-guest'
+      )
+    }
+    guest.on('render-process-gone', renderProcessGoneHandler)
     guest.on('will-navigate', navigationGuard)
     guest.on('will-redirect', willRedirectHandler)
     guest.on('did-start-navigation', didStartNavigationHandler)
@@ -932,6 +957,7 @@ export class BrowserManager {
         // guest may already be destroyed
       }
       if (!guest.isDestroyed()) {
+        guest.off('render-process-gone', renderProcessGoneHandler)
         guest.off('will-navigate', navigationGuard)
         guest.off('will-redirect', willRedirectHandler)
         guest.off('did-start-navigation', didStartNavigationHandler)

--- a/src/main/crash-reporting/guest-renderer-gone-reporter.test.ts
+++ b/src/main/crash-reporting/guest-renderer-gone-reporter.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest'
+import { buildGuestRendererGoneReporter } from './guest-renderer-gone-reporter'
+
+describe('buildGuestRendererGoneReporter', () => {
+  it('routes the webContents id and render-process-host id into their named fields', () => {
+    const recordCrash = vi.fn()
+    const reporter = buildGuestRendererGoneReporter(recordCrash)
+
+    // Why: the ids deliberately differ so a transposition cannot stay green (#15063).
+    reporter(
+      { reason: 'crashed', exitCode: 133 } as Electron.RenderProcessGoneDetails,
+      41,
+      'browser-guest',
+      7
+    )
+
+    expect(recordCrash).toHaveBeenCalledExactlyOnceWith(
+      'renderer',
+      'renderer',
+      'crashed',
+      133,
+      {
+        processType: 'renderer',
+        rendererKind: 'browser-guest',
+        webContentsId: 41,
+        rendererProcessId: 7
+      },
+      { webContentsId: 41, rendererProcessId: 7 }
+    )
+  })
+
+  it('reports an unreadable process identity without inventing one', () => {
+    const recordCrash = vi.fn()
+    const reporter = buildGuestRendererGoneReporter(recordCrash)
+
+    reporter(
+      { reason: 'killed', exitCode: 1 } as Electron.RenderProcessGoneDetails,
+      205,
+      'browser-popup',
+      undefined
+    )
+
+    expect(recordCrash).toHaveBeenCalledExactlyOnceWith(
+      'renderer',
+      'renderer',
+      'killed',
+      1,
+      { processType: 'renderer', rendererKind: 'browser-popup', webContentsId: 205 },
+      { webContentsId: 205, rendererProcessId: undefined }
+    )
+    // Why: the details record must omit the key entirely, not carry undefined.
+    expect('rendererProcessId' in (recordCrash.mock.calls[0]![4] as object)).toBe(false)
+  })
+})

--- a/src/main/crash-reporting/guest-renderer-gone-reporter.ts
+++ b/src/main/crash-reporting/guest-renderer-gone-reporter.ts
@@ -1,4 +1,5 @@
 import type { BrowserGuestRendererGoneReporter } from '../browser/browser-manager'
+import type { ProcessGoneCrashDetails } from './process-gone-recorder'
 import type { ProcessGoneRendererIdentity } from './process-gone-renderer-identity'
 
 /** Mirrors the host's recordProcessGoneCrash so the wiring stays a one-line call. */
@@ -7,7 +8,7 @@ export type ProcessGoneCrashRecorder = (
   processType: string,
   reason: string,
   exitCode: number | null,
-  details: Record<string, unknown>,
+  details: ProcessGoneCrashDetails,
   rendererIdentity?: ProcessGoneRendererIdentity
 ) => void
 

--- a/src/main/crash-reporting/guest-renderer-gone-reporter.ts
+++ b/src/main/crash-reporting/guest-renderer-gone-reporter.ts
@@ -1,0 +1,38 @@
+import type { BrowserGuestRendererGoneReporter } from '../browser/browser-manager'
+import type { ProcessGoneRendererIdentity } from './process-gone-renderer-identity'
+
+/** Mirrors the host's recordProcessGoneCrash so the wiring stays a one-line call. */
+export type ProcessGoneCrashRecorder = (
+  source: 'renderer' | 'child',
+  processType: string,
+  reason: string,
+  exitCode: number | null,
+  details: Record<string, unknown>,
+  rendererIdentity?: ProcessGoneRendererIdentity
+) => void
+
+/**
+ * Why a builder: as an inline closure in index.ts this glue was only coverable
+ * by tests that bypassed it, so a transposed id pair stayed green (#15063).
+ */
+export function buildGuestRendererGoneReporter(
+  recordCrash: ProcessGoneCrashRecorder
+): BrowserGuestRendererGoneReporter {
+  return (details, guestWebContentsId, guestKind, guestRendererProcessId) => {
+    recordCrash(
+      'renderer',
+      'renderer',
+      details.reason,
+      details.exitCode ?? null,
+      {
+        processType: 'renderer',
+        rendererKind: guestKind,
+        webContentsId: guestWebContentsId,
+        ...(guestRendererProcessId !== undefined
+          ? { rendererProcessId: guestRendererProcessId }
+          : {})
+      },
+      { webContentsId: guestWebContentsId, rendererProcessId: guestRendererProcessId }
+    )
+  }
+}

--- a/src/main/crash-reporting/process-gone-dedupe.test.ts
+++ b/src/main/crash-reporting/process-gone-dedupe.test.ts
@@ -58,20 +58,26 @@ describe('ProcessGoneDedupe', () => {
     const dedupe = new ProcessGoneDedupe({ windowMs: 2_000 })
 
     expect(
-      dedupe.shouldRecord(getProcessGoneDedupeKey('renderer', 'renderer', 'crashed', -36861), 1_000)
+      dedupe.shouldRecord(
+        getProcessGoneDedupeKey('renderer', 'renderer', 'crashed', -36861, 4),
+        1_000
+      )
     ).toBe(true)
     expect(
-      dedupe.shouldRecord(getProcessGoneDedupeKey('renderer', 'renderer', 'oom', -536870904), 1_284)
+      dedupe.shouldRecord(
+        getProcessGoneDedupeKey('renderer', 'renderer', 'oom', -536870904, 4),
+        1_284
+      )
     ).toBe(false)
     expect(
       dedupe.shouldRecord(
-        getProcessGoneDedupeKey('renderer', 'renderer', 'launch-failed', 18),
+        getProcessGoneDedupeKey('renderer', 'renderer', 'launch-failed', 18, 4),
         1_898
       )
     ).toBe(false)
     expect(
       dedupe.shouldRecord(
-        getProcessGoneDedupeKey('renderer', 'renderer', 'launch-failed', 18),
+        getProcessGoneDedupeKey('renderer', 'renderer', 'launch-failed', 18, 4),
         3_000
       )
     ).toBe(true)

--- a/src/main/crash-reporting/process-gone-dedupe.ts
+++ b/src/main/crash-reporting/process-gone-dedupe.ts
@@ -80,12 +80,15 @@ export function getProcessGoneDedupeKey(
   source: 'renderer' | 'child',
   processType: string,
   reason: string,
-  exitCode: number | null
+  exitCode: number | null,
+  webContentsId?: number | null
 ): string {
   // Why: one renderer death can surface as crashed/oom/launch-failed in a
-  // burst. Coalesce that prompt noise while keeping child identities precise.
+  // burst. Coalesce that prompt noise per renderer — concurrent deaths of
+  // distinct renderers (main window + browser guests, #15052) must each
+  // report — while keeping child identities precise.
   if (source === 'renderer') {
-    return `${source}:${processType}`
+    return `${source}:${processType}:wc:${webContentsId ?? 'unknown'}`
   }
   return `${source}:${processType}:${reason}:${exitCode ?? 'null'}`
 }

--- a/src/main/crash-reporting/process-gone-dedupe.ts
+++ b/src/main/crash-reporting/process-gone-dedupe.ts
@@ -81,14 +81,22 @@ export function getProcessGoneDedupeKey(
   processType: string,
   reason: string,
   exitCode: number | null,
-  webContentsId?: number | null
+  rendererProcessId?: number | null
 ): string {
   // Why: one renderer death can surface as crashed/oom/launch-failed in a
-  // burst. Coalesce that prompt noise per renderer — concurrent deaths of
-  // distinct renderers (main window + browser guests, #15052) must each
-  // report — while keeping child identities precise.
+  // burst. Coalesce that prompt noise per renderer process — concurrent deaths
+  // of distinct renderers (main window + browser guests, #15052) must each
+  // report — while keeping child identities precise. The identity is the
+  // render-process-host id, not the webContents id: several webContents can
+  // share one OS renderer process (same-site popups, #15063), and keying on
+  // webContents filed one report per observer of a single death.
   if (source === 'renderer') {
-    return `${source}:${processType}:wc:${webContentsId ?? 'unknown'}`
+    // Why: an unreadable identity (webContents destroyed mid-event) buckets as
+    // 'unknown'. Every observation of one death goes unreadable together, so
+    // its burst still coalesces; collapsing two distinct concurrent deaths
+    // would need both unreadable inside the 2s window — degrading to the
+    // pre-#15052 missed-report, never to the duplicate noise #14667 removed.
+    return `${source}:${processType}:rph:${rendererProcessId ?? 'unknown'}`
   }
   return `${source}:${processType}:${reason}:${exitCode ?? 'null'}`
 }

--- a/src/main/crash-reporting/process-gone-recorder.ts
+++ b/src/main/crash-reporting/process-gone-recorder.ts
@@ -41,8 +41,10 @@ export type ProcessGoneCrashEvent = {
   exitCode: number | null
   expectedTeardown: ExpectedTeardownScope
   details: Record<string, unknown>
-  /** Identifies which renderer died so concurrent deaths dedupe apart (#15052). */
+  /** Which webContents observed the death — evidence for attribution, never dedupe identity (#15063). */
   webContentsId?: number
+  /** Render-process-host id of the process that died, so concurrent deaths dedupe apart (#15052) while shared-process observers coalesce (#15063). */
+  rendererProcessId?: number
 }
 
 type CrashReportRecorderStore = Pick<CrashReportStore, 'record' | 'attachDetails'>
@@ -203,7 +205,7 @@ export function recordProcessGoneCrash(
     event.processType,
     event.reason,
     event.exitCode,
-    event.webContentsId ?? null
+    event.rendererProcessId ?? null
   )
   const claim = dedupe.tryClaim(key)
   if (!claim) {
@@ -235,6 +237,9 @@ export function recordProcessGoneCrash(
       'crash.reason': event.reason,
       ...(event.webContentsId !== undefined
         ? { 'crash.web_contents_id': event.webContentsId }
+        : {}),
+      ...(event.rendererProcessId !== undefined
+        ? { 'crash.renderer_process_id': event.rendererProcessId }
         : {}),
       ...(event.exitCode !== null ? { 'crash.exit_code': event.exitCode } : {}),
       ...decodedExitCodeAttribute(event),

--- a/src/main/crash-reporting/process-gone-recorder.ts
+++ b/src/main/crash-reporting/process-gone-recorder.ts
@@ -41,6 +41,8 @@ export type ProcessGoneCrashEvent = {
   exitCode: number | null
   expectedTeardown: ExpectedTeardownScope
   details: Record<string, unknown>
+  /** Identifies which renderer died so concurrent deaths dedupe apart (#15052). */
+  webContentsId?: number
 }
 
 type CrashReportRecorderStore = Pick<CrashReportStore, 'record' | 'attachDetails'>
@@ -196,9 +198,25 @@ export function recordProcessGoneCrash(
     return
   }
 
-  const key = getProcessGoneDedupeKey(event.source, event.processType, event.reason, event.exitCode)
+  const key = getProcessGoneDedupeKey(
+    event.source,
+    event.processType,
+    event.reason,
+    event.exitCode,
+    event.webContentsId ?? null
+  )
   const claim = dedupe.tryClaim(key)
   if (!claim) {
+    // Why: a deduped drop was a bare return with no trace, indistinguishable
+    // from a wiring gap. Coalesce per dedupe key so one death's multi-reason
+    // burst costs one breadcrumb instead of flooding the 30-entry ring.
+    const dedupedData = processGoneBreadcrumbData(event)
+    recordCoalescedDurableCrashBreadcrumb({
+      name: 'process_gone_deduped',
+      data: dedupedData,
+      coalesceKey: key,
+      minIntervalMs: SUPPRESSED_PROCESS_GONE_COALESCE_MS
+    })
     return
   }
   const mainProcessLifecycle = getMainProcessLifecycleIdentity()
@@ -215,6 +233,9 @@ export function recordProcessGoneCrash(
       'crash.source': event.source,
       'crash.process_type': event.processType,
       'crash.reason': event.reason,
+      ...(event.webContentsId !== undefined
+        ? { 'crash.web_contents_id': event.webContentsId }
+        : {}),
       ...(event.exitCode !== null ? { 'crash.exit_code': event.exitCode } : {}),
       ...decodedExitCodeAttribute(event),
       'app.version': app.getVersion(),

--- a/src/main/crash-reporting/process-gone-recorder.ts
+++ b/src/main/crash-reporting/process-gone-recorder.ts
@@ -4,7 +4,8 @@ import {
   isCrashReportReason,
   sanitizeCrashReportDetails,
   sanitizeCrashReportString,
-  type CrashReportBreadcrumbData
+  type CrashReportBreadcrumbData,
+  type CrashReportRendererKind
 } from '../../shared/crash-reporting'
 import { decodePosixWaitStatus, describePosixWaitStatus } from '../../shared/posix-wait-status'
 import type { CrashReportStore } from './crash-report-store'
@@ -34,13 +35,18 @@ import {
 import { minidumpSignatureDetails } from './minidump-crash-signature'
 import { flushActiveSink, startSpan } from '../observability/tracer'
 
+/** rendererKind is typed here so it can be promoted onto the report record for prompt-eligibility policy, never string-matched out of details. */
+export type ProcessGoneCrashDetails = Record<string, unknown> & {
+  rendererKind?: CrashReportRendererKind
+}
+
 export type ProcessGoneCrashEvent = {
   source: ProcessGoneSource
   processType: string
   reason: string
   exitCode: number | null
   expectedTeardown: ExpectedTeardownScope
-  details: Record<string, unknown>
+  details: ProcessGoneCrashDetails
   /** Which webContents observed the death — evidence for attribution, never dedupe identity (#15063). */
   webContentsId?: number
   /** Render-process-host id of the process that died, so concurrent deaths dedupe apart (#15052) while shared-process observers coalesce (#15063). */
@@ -277,6 +283,11 @@ export function recordProcessGoneCrash(
       arch: process.arch,
       electronVersion: process.versions.electron ?? 'unknown',
       chromeVersion: process.versions.chrome ?? 'unknown',
+      // Why: prompt eligibility must not depend on parsing details; the kind
+      // rides the record as a typed field while details keep the display copy.
+      ...(event.details.rendererKind !== undefined
+        ? { rendererKind: event.details.rendererKind }
+        : {}),
       details: crashDetails,
       breadcrumbs
     })

--- a/src/main/crash-reporting/process-gone-renderer-identity.test.ts
+++ b/src/main/crash-reporting/process-gone-renderer-identity.test.ts
@@ -13,6 +13,7 @@ vi.mock('electron', () => ({
 
 import { clearCrashBreadcrumbsForTest, getCrashBreadcrumbSnapshot } from './crash-breadcrumb-store'
 import { getProcessGoneDedupeKey, ProcessGoneDedupe } from './process-gone-dedupe'
+import { readGoneRendererProcessId } from './process-gone-renderer-identity'
 import { recordProcessGoneCrash, type ProcessGoneCrashEvent } from './process-gone-recorder'
 import { _resetTracerForTests, setActiveSink, type TracerSink } from '../observability/tracer'
 
@@ -69,13 +70,13 @@ describe('renderer process identity in process-gone dedupe', () => {
 
     recordProcessGoneCrash(
       { record, attachDetails } as never,
-      rendererGone({ webContentsId: 1 }),
+      rendererGone({ webContentsId: 1, rendererProcessId: 1 }),
       dedupe,
       noMinidump
     )
     recordProcessGoneCrash(
       { record, attachDetails } as never,
-      rendererGone({ webContentsId: 42 }),
+      rendererGone({ webContentsId: 42, rendererProcessId: 42 }),
       dedupe,
       noMinidump
     )
@@ -94,19 +95,57 @@ describe('renderer process identity in process-gone dedupe', () => {
     ])
   })
 
+  // Live-verified on macOS (#15063): a same-site popup shares its opener's OS
+  // renderer process, so kill -9 of that one process emits render-process-gone
+  // on both webContents. One death must file one report.
+  it('records one report when two webContents share one dying renderer process', async () => {
+    const record = vi.fn().mockResolvedValue({ id: 'report-1' })
+    const dedupe = new ProcessGoneDedupe()
+
+    recordProcessGoneCrash(
+      { record, attachDetails } as never,
+      rendererGone({ reason: 'killed', exitCode: 9, webContentsId: 9, rendererProcessId: 4 }),
+      dedupe,
+      noMinidump
+    )
+    recordProcessGoneCrash(
+      { record, attachDetails } as never,
+      rendererGone({ reason: 'killed', exitCode: 9, webContentsId: 10, rendererProcessId: 4 }),
+      dedupe,
+      noMinidump
+    )
+
+    await vi.waitFor(() => expect(record).toHaveBeenCalledOnce())
+    expect(record).toHaveBeenCalledTimes(1)
+    // Why: the surviving span must name both identities — the process for
+    // dedupe audits, the webContents for attribution. The dropped observer
+    // leaves only its breadcrumb span.
+    const goneSpans = sink.records.filter(
+      (span) => (span as { name?: string }).name === 'electron.process_gone'
+    )
+    expect(goneSpans).toEqual([
+      expect.objectContaining({
+        attributes: expect.objectContaining({
+          'crash.renderer_process_id': 4,
+          'crash.web_contents_id': 9
+        })
+      })
+    ])
+  })
+
   it('still coalesces one renderer death surfacing under multiple reasons', async () => {
     const record = vi.fn().mockResolvedValue({ id: 'report-1' })
     const dedupe = new ProcessGoneDedupe()
 
     recordProcessGoneCrash(
       { record, attachDetails } as never,
-      rendererGone({ reason: 'crashed', exitCode: -36861, webContentsId: 7 }),
+      rendererGone({ reason: 'crashed', exitCode: -36861, webContentsId: 7, rendererProcessId: 3 }),
       dedupe,
       noMinidump
     )
     recordProcessGoneCrash(
       { record, attachDetails } as never,
-      rendererGone({ reason: 'oom', exitCode: -536870904, webContentsId: 7 }),
+      rendererGone({ reason: 'oom', exitCode: -536870904, webContentsId: 7, rendererProcessId: 3 }),
       dedupe,
       noMinidump
     )
@@ -120,13 +159,13 @@ describe('renderer process identity in process-gone dedupe', () => {
 
     recordProcessGoneCrash(
       { record, attachDetails } as never,
-      rendererGone({ reason: 'crashed', exitCode: 5, webContentsId: 7 }),
+      rendererGone({ reason: 'crashed', exitCode: 5, webContentsId: 7, rendererProcessId: 3 }),
       dedupe,
       noMinidump
     )
     recordProcessGoneCrash(
       { record, attachDetails } as never,
-      rendererGone({ reason: 'oom', exitCode: -536870904, webContentsId: 7 }),
+      rendererGone({ reason: 'oom', exitCode: -536870904, webContentsId: 7, rendererProcessId: 3 }),
       dedupe,
       noMinidump
     )
@@ -148,14 +187,14 @@ describe('renderer process identity in process-gone dedupe', () => {
 
     recordProcessGoneCrash(
       { record, attachDetails } as never,
-      rendererGone({ reason: 'crashed', exitCode: 5, webContentsId: 7 }),
+      rendererGone({ reason: 'crashed', exitCode: 5, webContentsId: 7, rendererProcessId: 3 }),
       dedupe,
       noMinidump
     )
     for (let i = 0; i < 40; i++) {
       recordProcessGoneCrash(
         { record, attachDetails } as never,
-        rendererGone({ reason: 'crashed', exitCode: 5, webContentsId: 7 }),
+        rendererGone({ reason: 'crashed', exitCode: 5, webContentsId: 7, rendererProcessId: 3 }),
         dedupe,
         noMinidump
       )
@@ -170,7 +209,7 @@ describe('renderer process identity in process-gone dedupe', () => {
 })
 
 describe('getProcessGoneDedupeKey renderer identity', () => {
-  it('keys distinct renderers apart while coalescing reasons per renderer', () => {
+  it('keys distinct renderer processes apart while coalescing reasons per process', () => {
     const mainWindowCrashed = getProcessGoneDedupeKey('renderer', 'renderer', 'crashed', 5, 1)
     const mainWindowOom = getProcessGoneDedupeKey('renderer', 'renderer', 'oom', -536870904, 1)
     const guestCrashed = getProcessGoneDedupeKey('renderer', 'renderer', 'crashed', 5, 42)
@@ -179,9 +218,52 @@ describe('getProcessGoneDedupeKey renderer identity', () => {
     expect(guestCrashed).not.toBe(mainWindowCrashed)
   })
 
+  // Why: a destroyed webContents makes the identity unreadable; those events
+  // must share one bucket — coalescing beats re-creating #14667's duplicates.
+  it('buckets unreadable renderer identities together', () => {
+    expect(getProcessGoneDedupeKey('renderer', 'renderer', 'crashed', 5, null)).toBe(
+      getProcessGoneDedupeKey('renderer', 'renderer', 'oom', -536870904, null)
+    )
+  })
+
   it('keeps child keys unchanged by renderer identity', () => {
     expect(getProcessGoneDedupeKey('child', 'Utility', 'crashed', 1)).toBe(
       'child:Utility:crashed:1'
     )
+  })
+})
+
+describe('readGoneRendererProcessId', () => {
+  const liveWebContents = (overrides: Record<string, unknown> = {}) =>
+    ({
+      isDestroyed: () => false,
+      getProcessId: () => 4,
+      ...overrides
+    }) as never
+
+  it('reads the render-process-host id from a live webContents', () => {
+    expect(readGoneRendererProcessId(liveWebContents())).toBe(4)
+  })
+
+  it('returns undefined once the webContents is destroyed', () => {
+    expect(readGoneRendererProcessId(liveWebContents({ isDestroyed: () => true }))).toBeUndefined()
+  })
+
+  it('returns undefined when the read throws mid-teardown', () => {
+    expect(
+      readGoneRendererProcessId(
+        liveWebContents({
+          getProcessId: () => {
+            throw new Error('Object has been destroyed')
+          }
+        })
+      )
+    ).toBeUndefined()
+  })
+
+  it('rejects the invalid child-process sentinel', () => {
+    // Why: content::ChildProcessHost::kInvalidUniqueID is -1; a sentinel key
+    // would collapse every sentinel-bearing death into one bucket by accident.
+    expect(readGoneRendererProcessId(liveWebContents({ getProcessId: () => -1 }))).toBeUndefined()
   })
 })

--- a/src/main/crash-reporting/process-gone-renderer-identity.test.ts
+++ b/src/main/crash-reporting/process-gone-renderer-identity.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { appMetricsMock } = vi.hoisted(() => ({
+  appMetricsMock: vi.fn((): unknown[] => [])
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getVersion: () => '1.2.3-test',
+    getAppMetrics: appMetricsMock
+  }
+}))
+
+import { clearCrashBreadcrumbsForTest, getCrashBreadcrumbSnapshot } from './crash-breadcrumb-store'
+import { getProcessGoneDedupeKey, ProcessGoneDedupe } from './process-gone-dedupe'
+import { recordProcessGoneCrash, type ProcessGoneCrashEvent } from './process-gone-recorder'
+import { _resetTracerForTests, setActiveSink, type TracerSink } from '../observability/tracer'
+
+type CapturingSink = TracerSink & { records: unknown[]; flushMock: ReturnType<typeof vi.fn> }
+
+/** Keeps tests off the real Crashpad directory; minidump pairing has its own suite. */
+const noMinidump = async () => null
+const attachDetails = async () => null
+
+function capturingSink(): CapturingSink {
+  const records: unknown[] = []
+  const flushMock = vi.fn()
+  return {
+    records,
+    flushMock,
+    push: (record) => records.push(record),
+    flush: flushMock,
+    close: vi.fn()
+  }
+}
+
+function rendererGone(overrides: Partial<ProcessGoneCrashEvent> = {}): ProcessGoneCrashEvent {
+  return {
+    source: 'renderer',
+    processType: 'renderer',
+    reason: 'killed',
+    exitCode: 1,
+    expectedTeardown: 'none',
+    details: { processType: 'renderer' },
+    ...overrides
+  }
+}
+
+let sink: CapturingSink
+
+beforeEach(() => {
+  sink = capturingSink()
+  setActiveSink(sink)
+  clearCrashBreadcrumbsForTest()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  _resetTracerForTests()
+  clearCrashBreadcrumbsForTest()
+})
+
+describe('renderer process identity in process-gone dedupe', () => {
+  // Field measurement (#15052): main window and a browser guest were killed
+  // 248ms apart on Windows with identical reason/exitCode — 2 deaths, 1 report.
+  it('records one report per renderer when two renderers die concurrently', async () => {
+    const record = vi.fn().mockResolvedValue({ id: 'report-1' })
+    const dedupe = new ProcessGoneDedupe()
+
+    recordProcessGoneCrash(
+      { record, attachDetails } as never,
+      rendererGone({ webContentsId: 1 }),
+      dedupe,
+      noMinidump
+    )
+    recordProcessGoneCrash(
+      { record, attachDetails } as never,
+      rendererGone({ webContentsId: 42 }),
+      dedupe,
+      noMinidump
+    )
+
+    await vi.waitFor(() => expect(record).toHaveBeenCalledTimes(2))
+    // Why: the span is what makes each death countable in diagnostics bundles.
+    expect(sink.records).toEqual([
+      expect.objectContaining({
+        name: 'electron.process_gone',
+        attributes: expect.objectContaining({ 'crash.web_contents_id': 1 })
+      }),
+      expect.objectContaining({
+        name: 'electron.process_gone',
+        attributes: expect.objectContaining({ 'crash.web_contents_id': 42 })
+      })
+    ])
+  })
+
+  it('still coalesces one renderer death surfacing under multiple reasons', async () => {
+    const record = vi.fn().mockResolvedValue({ id: 'report-1' })
+    const dedupe = new ProcessGoneDedupe()
+
+    recordProcessGoneCrash(
+      { record, attachDetails } as never,
+      rendererGone({ reason: 'crashed', exitCode: -36861, webContentsId: 7 }),
+      dedupe,
+      noMinidump
+    )
+    recordProcessGoneCrash(
+      { record, attachDetails } as never,
+      rendererGone({ reason: 'oom', exitCode: -536870904, webContentsId: 7 }),
+      dedupe,
+      noMinidump
+    )
+
+    await vi.waitFor(() => expect(record).toHaveBeenCalledOnce())
+  })
+
+  it('leaves an auditable breadcrumb when the dedupe window drops an event', async () => {
+    const record = vi.fn().mockResolvedValue({ id: 'report-1' })
+    const dedupe = new ProcessGoneDedupe()
+
+    recordProcessGoneCrash(
+      { record, attachDetails } as never,
+      rendererGone({ reason: 'crashed', exitCode: 5, webContentsId: 7 }),
+      dedupe,
+      noMinidump
+    )
+    recordProcessGoneCrash(
+      { record, attachDetails } as never,
+      rendererGone({ reason: 'oom', exitCode: -536870904, webContentsId: 7 }),
+      dedupe,
+      noMinidump
+    )
+
+    await vi.waitFor(() => expect(record).toHaveBeenCalledOnce())
+    expect(getCrashBreadcrumbSnapshot()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'process_gone_deduped',
+          data: expect.objectContaining({ reason: 'oom', webContentsId: 7 })
+        })
+      ])
+    )
+  })
+
+  it('coalesces the dedupe-drop breadcrumb so a burst cannot flood the ring', async () => {
+    const record = vi.fn().mockResolvedValue({ id: 'report-1' })
+    const dedupe = new ProcessGoneDedupe()
+
+    recordProcessGoneCrash(
+      { record, attachDetails } as never,
+      rendererGone({ reason: 'crashed', exitCode: 5, webContentsId: 7 }),
+      dedupe,
+      noMinidump
+    )
+    for (let i = 0; i < 40; i++) {
+      recordProcessGoneCrash(
+        { record, attachDetails } as never,
+        rendererGone({ reason: 'crashed', exitCode: 5, webContentsId: 7 }),
+        dedupe,
+        noMinidump
+      )
+    }
+
+    await vi.waitFor(() => expect(record).toHaveBeenCalledOnce())
+    const dropBreadcrumbs = getCrashBreadcrumbSnapshot().filter(
+      (breadcrumb) => breadcrumb.name === 'process_gone_deduped'
+    )
+    expect(dropBreadcrumbs).toHaveLength(1)
+  })
+})
+
+describe('getProcessGoneDedupeKey renderer identity', () => {
+  it('keys distinct renderers apart while coalescing reasons per renderer', () => {
+    const mainWindowCrashed = getProcessGoneDedupeKey('renderer', 'renderer', 'crashed', 5, 1)
+    const mainWindowOom = getProcessGoneDedupeKey('renderer', 'renderer', 'oom', -536870904, 1)
+    const guestCrashed = getProcessGoneDedupeKey('renderer', 'renderer', 'crashed', 5, 42)
+
+    expect(mainWindowOom).toBe(mainWindowCrashed)
+    expect(guestCrashed).not.toBe(mainWindowCrashed)
+  })
+
+  it('keeps child keys unchanged by renderer identity', () => {
+    expect(getProcessGoneDedupeKey('child', 'Utility', 'crashed', 1)).toBe(
+      'child:Utility:crashed:1'
+    )
+  })
+})

--- a/src/main/crash-reporting/process-gone-renderer-identity.ts
+++ b/src/main/crash-reporting/process-gone-renderer-identity.ts
@@ -1,0 +1,24 @@
+import type { WebContents } from 'electron'
+
+/**
+ * Reads the identity of the renderer process a render-process-gone event is
+ * about. webContents.getProcessId() is the Chromium render-process-host id:
+ * webContents sharing one OS renderer process (same-site popups, #15063)
+ * share one host, distinct processes never do, and — unlike getOSProcessId(),
+ * which already reads 0 by the time render-process-gone fires — the host
+ * outlives its process, so it stays readable inside the event handler
+ * (both verified live on Electron 43.1.0).
+ */
+export function readGoneRendererProcessId(webContents: WebContents): number | undefined {
+  try {
+    if (webContents.isDestroyed()) {
+      return undefined
+    }
+    const processId = webContents.getProcessId()
+    return Number.isInteger(processId) && processId >= 0 ? processId : undefined
+  } catch {
+    // Why: a teardown race can destroy the webContents mid-event; report the
+    // death with unknown identity rather than drop it.
+    return undefined
+  }
+}

--- a/src/main/crash-reporting/process-gone-renderer-identity.ts
+++ b/src/main/crash-reporting/process-gone-renderer-identity.ts
@@ -1,6 +1,17 @@
 import type { WebContents } from 'electron'
 
 /**
+ * Both ids travel under their names: positional `number` params let a caller
+ * transpose them silently, re-keying dedupe on the webContents id (#15063).
+ */
+export type ProcessGoneRendererIdentity = {
+  /** Which webContents observed the death — attribution evidence, never dedupe identity. */
+  webContentsId: number
+  /** Render-process-host id of the dead process; undefined when unreadable at event time. */
+  rendererProcessId: number | undefined
+}
+
+/**
  * Reads the identity of the renderer process a render-process-gone event is
  * about. webContents.getProcessId() is the Chromium render-process-host id:
  * webContents sharing one OS renderer process (same-site popups, #15063)

--- a/src/main/crash-reporting/suppressed-process-gone-breadcrumb.ts
+++ b/src/main/crash-reporting/suppressed-process-gone-breadcrumb.ts
@@ -11,7 +11,8 @@ export function buildSuppressedProcessGoneBreadcrumbData({
   reason,
   exitCode,
   expectedTeardown,
-  details
+  details,
+  webContentsId
 }: {
   source: 'renderer' | 'child'
   processType: string
@@ -19,6 +20,7 @@ export function buildSuppressedProcessGoneBreadcrumbData({
   exitCode: number | null
   expectedTeardown: ExpectedTeardownScope
   details: Record<string, unknown>
+  webContentsId?: number
 }): CrashReportBreadcrumbData {
   const breadcrumb: CrashReportBreadcrumbData = {
     source,
@@ -26,6 +28,11 @@ export function buildSuppressedProcessGoneBreadcrumbData({
     reason,
     exitCode,
     expectedTeardown
+  }
+  // Why: names which renderer a suppressed/deduped event belonged to now that
+  // several renderers (main window + browser guests) report concurrently.
+  if (typeof webContentsId === 'number') {
+    breadcrumb.webContentsId = webContentsId
   }
   const name = safeString(details.name)
   if (name) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1361,7 +1361,9 @@ function openMainWindow(options: { revealOnDidFinishLoad?: boolean } = {}): Brow
         details.reason,
         details.exitCode ?? null,
         {
-          processType: 'renderer'
+          processType: 'renderer',
+          rendererKind: 'main-window',
+          webContentsId
         },
         webContentsId
       )
@@ -1800,7 +1802,8 @@ function recordProcessGoneCrash(
     reason,
     exitCode,
     expectedTeardown: getExpectedTeardownScope(webContentsId),
-    details
+    details,
+    ...(webContentsId !== undefined ? { webContentsId } : {})
   })
 }
 
@@ -2892,6 +2895,22 @@ void app.whenReady().then(async () => {
   // Why: process-gone metrics only see survivors; retain a recent whole-app
   // snapshot for comparison in crash reports.
   startPreGoneProcessMetricsSampling()
+  // Why: only the main window's render-process-gone was wired to the recorder,
+  // so embedded-browser guest renderer deaths left zero trace (#15052).
+  browserManager.setGuestRendererGoneReporter((details, guestWebContentsId, guestKind) => {
+    recordProcessGoneCrash(
+      'renderer',
+      'renderer',
+      details.reason,
+      details.exitCode ?? null,
+      {
+        processType: 'renderer',
+        rendererKind: guestKind,
+        webContentsId: guestWebContentsId
+      },
+      guestWebContentsId
+    )
+  })
   app.on('child-process-gone', (_event, details) => {
     recordProcessGoneCrash('child', details.type, details.reason, details.exitCode ?? null, {
       name: details.name,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1354,7 +1354,7 @@ function openMainWindow(options: { revealOnDidFinishLoad?: boolean } = {}): Brow
       isQuitting = false
       clearExpectedRendererReload()
     },
-    onRendererProcessGone: (details, webContentsId) => {
+    onRendererProcessGone: (details, webContentsId, rendererProcessId) => {
       recordProcessGoneCrash(
         'renderer',
         'renderer',
@@ -1363,9 +1363,11 @@ function openMainWindow(options: { revealOnDidFinishLoad?: boolean } = {}): Brow
         {
           processType: 'renderer',
           rendererKind: 'main-window',
-          webContentsId
+          webContentsId,
+          ...(rendererProcessId !== undefined ? { rendererProcessId } : {})
         },
-        webContentsId
+        webContentsId,
+        rendererProcessId
       )
     },
     shouldRecoverRenderer: (details, webContentsId) =>
@@ -1794,7 +1796,8 @@ function recordProcessGoneCrash(
   reason: string,
   exitCode: number | null,
   details: Record<string, unknown>,
-  webContentsId?: number
+  webContentsId?: number,
+  rendererProcessId?: number
 ): void {
   recordProcessGoneCrashEvent(crashReports, {
     source,
@@ -1803,7 +1806,8 @@ function recordProcessGoneCrash(
     exitCode,
     expectedTeardown: getExpectedTeardownScope(webContentsId),
     details,
-    ...(webContentsId !== undefined ? { webContentsId } : {})
+    ...(webContentsId !== undefined ? { webContentsId } : {}),
+    ...(rendererProcessId !== undefined ? { rendererProcessId } : {})
   })
 }
 
@@ -2897,20 +2901,26 @@ void app.whenReady().then(async () => {
   startPreGoneProcessMetricsSampling()
   // Why: only the main window's render-process-gone was wired to the recorder,
   // so embedded-browser guest renderer deaths left zero trace (#15052).
-  browserManager.setGuestRendererGoneReporter((details, guestWebContentsId, guestKind) => {
-    recordProcessGoneCrash(
-      'renderer',
-      'renderer',
-      details.reason,
-      details.exitCode ?? null,
-      {
-        processType: 'renderer',
-        rendererKind: guestKind,
-        webContentsId: guestWebContentsId
-      },
-      guestWebContentsId
-    )
-  })
+  browserManager.setGuestRendererGoneReporter(
+    (details, guestWebContentsId, guestKind, guestRendererProcessId) => {
+      recordProcessGoneCrash(
+        'renderer',
+        'renderer',
+        details.reason,
+        details.exitCode ?? null,
+        {
+          processType: 'renderer',
+          rendererKind: guestKind,
+          webContentsId: guestWebContentsId,
+          ...(guestRendererProcessId !== undefined
+            ? { rendererProcessId: guestRendererProcessId }
+            : {})
+        },
+        guestWebContentsId,
+        guestRendererProcessId
+      )
+    }
+  )
   app.on('child-process-gone', (_event, details) => {
     recordProcessGoneCrash('child', details.type, details.reason, details.exitCode ?? null, {
       name: details.name,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -321,6 +321,8 @@ import {
   type ExpectedTeardownScope
 } from './crash-reporting/process-gone-classification'
 import { recordProcessGoneCrash as recordProcessGoneCrashEvent } from './crash-reporting/process-gone-recorder'
+import { buildGuestRendererGoneReporter } from './crash-reporting/guest-renderer-gone-reporter'
+import type { ProcessGoneRendererIdentity } from './crash-reporting/process-gone-renderer-identity'
 import { startCrashpadCapture } from './crash-reporting/crashpad-capture'
 import { startPreGoneProcessMetricsSampling } from './crash-reporting/process-gone-diagnostics'
 import { resolveExpectedTeardownScope } from './crash-reporting/expected-teardown-state'
@@ -1366,8 +1368,7 @@ function openMainWindow(options: { revealOnDidFinishLoad?: boolean } = {}): Brow
           webContentsId,
           ...(rendererProcessId !== undefined ? { rendererProcessId } : {})
         },
-        webContentsId,
-        rendererProcessId
+        { webContentsId, rendererProcessId }
       )
     },
     shouldRecoverRenderer: (details, webContentsId) =>
@@ -1796,18 +1797,20 @@ function recordProcessGoneCrash(
   reason: string,
   exitCode: number | null,
   details: Record<string, unknown>,
-  webContentsId?: number,
-  rendererProcessId?: number
+  // Why: two positional optional numbers let a caller transpose the ids silently (#15063).
+  rendererIdentity?: ProcessGoneRendererIdentity
 ): void {
   recordProcessGoneCrashEvent(crashReports, {
     source,
     processType,
     reason,
     exitCode,
-    expectedTeardown: getExpectedTeardownScope(webContentsId),
+    expectedTeardown: getExpectedTeardownScope(rendererIdentity?.webContentsId),
     details,
-    ...(webContentsId !== undefined ? { webContentsId } : {}),
-    ...(rendererProcessId !== undefined ? { rendererProcessId } : {})
+    ...(rendererIdentity !== undefined ? { webContentsId: rendererIdentity.webContentsId } : {}),
+    ...(rendererIdentity?.rendererProcessId !== undefined
+      ? { rendererProcessId: rendererIdentity.rendererProcessId }
+      : {})
   })
 }
 
@@ -2902,24 +2905,7 @@ void app.whenReady().then(async () => {
   // Why: only the main window's render-process-gone was wired to the recorder,
   // so embedded-browser guest renderer deaths left zero trace (#15052).
   browserManager.setGuestRendererGoneReporter(
-    (details, guestWebContentsId, guestKind, guestRendererProcessId) => {
-      recordProcessGoneCrash(
-        'renderer',
-        'renderer',
-        details.reason,
-        details.exitCode ?? null,
-        {
-          processType: 'renderer',
-          rendererKind: guestKind,
-          webContentsId: guestWebContentsId,
-          ...(guestRendererProcessId !== undefined
-            ? { rendererProcessId: guestRendererProcessId }
-            : {})
-        },
-        guestWebContentsId,
-        guestRendererProcessId
-      )
-    }
+    buildGuestRendererGoneReporter(recordProcessGoneCrash)
   )
   app.on('child-process-gone', (_event, details) => {
     recordProcessGoneCrash('child', details.type, details.reason, details.exitCode ?? null, {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -320,7 +320,10 @@ import {
   shouldRecoverRendererAfterProcessGone,
   type ExpectedTeardownScope
 } from './crash-reporting/process-gone-classification'
-import { recordProcessGoneCrash as recordProcessGoneCrashEvent } from './crash-reporting/process-gone-recorder'
+import {
+  recordProcessGoneCrash as recordProcessGoneCrashEvent,
+  type ProcessGoneCrashDetails
+} from './crash-reporting/process-gone-recorder'
 import { buildGuestRendererGoneReporter } from './crash-reporting/guest-renderer-gone-reporter'
 import type { ProcessGoneRendererIdentity } from './crash-reporting/process-gone-renderer-identity'
 import { startCrashpadCapture } from './crash-reporting/crashpad-capture'
@@ -1796,7 +1799,7 @@ function recordProcessGoneCrash(
   processType: string,
   reason: string,
   exitCode: number | null,
-  details: Record<string, unknown>,
+  details: ProcessGoneCrashDetails,
   // Why: two positional optional numbers let a caller transpose the ids silently (#15063).
   rendererIdentity?: ProcessGoneRendererIdentity
 ): void {

--- a/src/main/ipc/crash-reporting-sendable-reports.test.ts
+++ b/src/main/ipc/crash-reporting-sendable-reports.test.ts
@@ -1,0 +1,216 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { appMetricsMock } = vi.hoisted(() => ({
+  appMetricsMock: vi.fn((): unknown[] => [])
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getVersion: () => '1.2.3-test',
+    getAppMetrics: appMetricsMock
+  }
+}))
+
+import { CrashReportStore } from '../crash-reporting/crash-report-store'
+import { clearCrashBreadcrumbsForTest } from '../crash-reporting/crash-breadcrumb-store'
+import { buildGuestRendererGoneReporter } from '../crash-reporting/guest-renderer-gone-reporter'
+import { ProcessGoneDedupe } from '../crash-reporting/process-gone-dedupe'
+import { recordProcessGoneCrash } from '../crash-reporting/process-gone-recorder'
+import { _resetTracerForTests, setActiveSink } from '../observability/tracer'
+import {
+  getLatestPendingReport,
+  getRequestedCrashReport,
+  submittedReportIds
+} from './crash-reporting-sendable-reports'
+
+/** Keeps tests off the real Crashpad directory; minidump pairing has its own suite. */
+const noMinidump = async () => null
+
+let tempDir: string
+let store: CrashReportStore
+let dedupe: ProcessGoneDedupe
+
+/** Mirrors the index.ts recordProcessGoneCrash glue the guest reporter is wired to. */
+function recordRendererGone(
+  details: { reason: string; exitCode: number | null },
+  crashDetails: Record<string, unknown>,
+  identity: { webContentsId: number; rendererProcessId: number | undefined }
+): void {
+  recordProcessGoneCrash(
+    store,
+    {
+      source: 'renderer',
+      processType: 'renderer',
+      reason: details.reason,
+      exitCode: details.exitCode,
+      expectedTeardown: 'none',
+      details: crashDetails,
+      webContentsId: identity.webContentsId,
+      ...(identity.rendererProcessId !== undefined
+        ? { rendererProcessId: identity.rendererProcessId }
+        : {})
+    },
+    dedupe,
+    noMinidump
+  )
+}
+
+function guestReporter(): ReturnType<typeof buildGuestRendererGoneReporter> {
+  return buildGuestRendererGoneReporter(
+    (_source, _processType, reason, exitCode, details, identity) =>
+      recordRendererGone({ reason, exitCode }, details, {
+        webContentsId: identity?.webContentsId ?? -1,
+        rendererProcessId: identity?.rendererProcessId
+      })
+  )
+}
+
+/** Mirrors the main-window render-process-gone wiring in index.ts. */
+function recordMainWindowRendererGone(
+  details: { reason: string; exitCode: number | null },
+  identity: { webContentsId: number; rendererProcessId: number | undefined }
+): void {
+  recordRendererGone(
+    details,
+    {
+      processType: 'renderer',
+      rendererKind: 'main-window',
+      webContentsId: identity.webContentsId,
+      ...(identity.rendererProcessId !== undefined
+        ? { rendererProcessId: identity.rendererProcessId }
+        : {})
+    },
+    identity
+  )
+}
+
+async function waitForReportCount(count: number): Promise<void> {
+  await vi.waitFor(async () => {
+    expect(await store.listRecent()).toHaveLength(count)
+  })
+}
+
+beforeEach(async () => {
+  tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'crash-report-prompt-'))
+  store = new CrashReportStore(path.join(tempDir, 'crash-reports.json'))
+  dedupe = new ProcessGoneDedupe()
+  submittedReportIds.clear()
+  setActiveSink({ push: () => {}, flush: () => {}, close: () => {} })
+  clearCrashBreadcrumbsForTest()
+})
+
+afterEach(async () => {
+  _resetTracerForTests()
+  clearCrashBreadcrumbsForTest()
+  await fs.rm(tempDir, { recursive: true, force: true })
+})
+
+describe('getLatestPendingReport renderer-kind prompt eligibility', () => {
+  it('files a browser-guest renderer death without making it the startup prompt', async () => {
+    guestReporter()(
+      { reason: 'oom', exitCode: 5 } as Electron.RenderProcessGoneDetails,
+      41,
+      'browser-guest',
+      7
+    )
+    await waitForReportCount(1)
+
+    // The report must stay recorded for triage, carrying the kind as a typed
+    // field the eligibility policy reads (not a details string)...
+    const [report] = await store.listRecent()
+    expect(report).toMatchObject({
+      status: 'pending',
+      reason: 'oom',
+      rendererKind: 'browser-guest'
+    })
+    // ...but a web page crashing its own renderer is not an app crash.
+    expect(await getLatestPendingReport(store)).toBeNull()
+  })
+
+  it('files a browser-popup renderer death without making it the startup prompt', async () => {
+    guestReporter()(
+      { reason: 'crashed', exitCode: 133 } as Electron.RenderProcessGoneDetails,
+      205,
+      'browser-popup',
+      9
+    )
+    await waitForReportCount(1)
+
+    expect(await store.listRecent()).toHaveLength(1)
+    expect(await getLatestPendingReport(store)).toBeNull()
+  })
+
+  it('still prompts for a main-window renderer death', async () => {
+    recordMainWindowRendererGone(
+      { reason: 'crashed', exitCode: 5 },
+      {
+        webContentsId: 1,
+        rendererProcessId: 3
+      }
+    )
+    await waitForReportCount(1)
+
+    const prompt = await getLatestPendingReport(store)
+    expect(prompt).toMatchObject({ status: 'pending', reason: 'crashed', exitCode: 5 })
+  })
+
+  it('never lets a newer related guest death mask the main-window prompt', async () => {
+    // Same reason/exit code inside the related-crash window, distinct renderer
+    // processes: the concurrent-death shape that files two reports (#15052).
+    recordMainWindowRendererGone(
+      { reason: 'oom', exitCode: 5 },
+      {
+        webContentsId: 1,
+        rendererProcessId: 3
+      }
+    )
+    await waitForReportCount(1)
+    guestReporter()(
+      { reason: 'oom', exitCode: 5 } as Electron.RenderProcessGoneDetails,
+      41,
+      'browser-guest',
+      7
+    )
+    await waitForReportCount(2)
+
+    const prompt = await getLatestPendingReport(store)
+    expect(prompt?.rendererKind).toBe('main-window')
+  })
+
+  it('keeps prompting for reports that carry no renderer kind', async () => {
+    // Child-process and pre-existing on-disk reports have no renderer kind.
+    await store.record({
+      source: 'child',
+      processType: 'gpu',
+      reason: 'crashed',
+      exitCode: 11,
+      appVersion: '1.2.3-test',
+      platform: process.platform,
+      osRelease: 'test',
+      arch: process.arch,
+      electronVersion: '43',
+      chromeVersion: '143',
+      details: {}
+    })
+
+    const prompt = await getLatestPendingReport(store)
+    expect(prompt).toMatchObject({ processType: 'gpu', exitCode: 11 })
+  })
+
+  it('keeps a prompt-suppressed guest report reachable for Help menu diagnostics', async () => {
+    guestReporter()(
+      { reason: 'oom', exitCode: 5 } as Electron.RenderProcessGoneDetails,
+      41,
+      'browser-guest',
+      7
+    )
+    await waitForReportCount(1)
+
+    // Suppression is about the startup prompt only, never triage visibility.
+    const report = await getRequestedCrashReport(store)
+    expect(report).toMatchObject({ status: 'pending', reason: 'oom' })
+  })
+})

--- a/src/main/ipc/crash-reporting-sendable-reports.ts
+++ b/src/main/ipc/crash-reporting-sendable-reports.ts
@@ -1,3 +1,7 @@
+import {
+  isUserPromptEligibleCrashReport,
+  type CrashReportRecord
+} from '../../shared/crash-reporting'
 import type { CrashReportStore } from '../crash-reporting/crash-report-store'
 
 export const inFlightSubmissions = new Set<string>()
@@ -19,13 +23,31 @@ export function rememberSubmittedReportId(reportId: string): void {
   }
 }
 
+function latestUnsubmittedPendingReport(reports: CrashReportRecord[]): CrashReportRecord | null {
+  return (
+    reports.find((report) => report.status === 'pending' && !submittedReportIds.has(report.id)) ??
+    null
+  )
+}
+
+/**
+ * Feeds the startup "Orca crashed" prompt, so this is the prompt-eligibility
+ * gate: embedded browser-content renderer deaths stay recorded (and reachable
+ * through listRecent/getById/Help-menu paths) but are skipped here — a web
+ * page crashing its own renderer must not read as an app crash. Skipping also
+ * keeps a guest death from shadowing an eligible report recorded before it.
+ */
 export async function getLatestPendingReport(
   store: CrashReportStore
 ): Promise<Awaited<ReturnType<CrashReportStore['getLatestPending']>>> {
   const reports = await store.listRecent()
   return (
-    reports.find((report) => report.status === 'pending' && !submittedReportIds.has(report.id)) ??
-    null
+    reports.find(
+      (report) =>
+        report.status === 'pending' &&
+        !submittedReportIds.has(report.id) &&
+        isUserPromptEligibleCrashReport(report)
+    ) ?? null
   )
 }
 
@@ -51,5 +73,10 @@ export async function getRequestedCrashReport(
   }
   // Why: Help > Report Crash can intentionally submit without a report ID.
   // Do not replace that uncaptured report with a pending crash that appears later.
-  return args ? null : getLatestPendingReport(store)
+  if (args) {
+    return null
+  }
+  // Why: this fallback serves user-invoked Help-menu diagnostics, not the crash
+  // prompt, so prompt-suppressed guest-renderer reports stay reachable here.
+  return latestUnsubmittedPendingReport(await store.listRecent())
 }

--- a/src/main/startup/desktop-startup-ordering.test.ts
+++ b/src/main/startup/desktop-startup-ordering.test.ts
@@ -213,7 +213,11 @@ describe('startup ordering', () => {
     )
     expect(recorderStart).toBeGreaterThanOrEqual(0)
     expect(recorderEnd).toBeGreaterThan(recorderStart)
-    expect(recorder).toContain('expectedTeardown: getExpectedTeardownScope(webContentsId)')
+    // Why: token-anchored — the claim is scope-from-webContentsId with the single-arg
+    // (default includeSystemSessionEnd) call; exact text broke on the #15063 identity refactor.
+    expect(recorder).toMatch(
+      /expectedTeardown:\s*getExpectedTeardownScope\(\s*[\w$?.]*webContentsId\s*\)/
+    )
   })
 
   it('attaches renderer services before starting the TCC prompt watcher', () => {

--- a/src/main/window/createMainWindow-renderer-crash-recovery.test.ts
+++ b/src/main/window/createMainWindow-renderer-crash-recovery.test.ts
@@ -171,6 +171,8 @@ describe('createMainWindow', () => {
     const windowHandlers: Record<string, (...args: any[]) => void> = {}
     const webContents = {
       id: 142,
+      isDestroyed: vi.fn(() => false),
+      getProcessId: vi.fn(() => 7),
       on: vi.fn((event, handler) => {
         windowHandlers[event] = handler
       }),
@@ -203,7 +205,9 @@ describe('createMainWindow', () => {
     const details = { reason: 'crashed', exitCode: 5 } as Electron.RenderProcessGoneDetails
     windowHandlers['render-process-gone']?.({} as never, details)
 
-    expect(onRendererProcessGone).toHaveBeenCalledWith(details, 142)
+    // Why: the render-process-host id read at event time is the dedupe
+    // identity for shared-process deaths (#15063).
+    expect(onRendererProcessGone).toHaveBeenCalledWith(details, 142, 7)
   })
 
   it('passes the renderer webContents id through crash recording and recovery callbacks', () => {
@@ -212,6 +216,8 @@ describe('createMainWindow', () => {
     const windowHandlers: Record<string, (...args: any[]) => void> = {}
     const webContents = {
       id: 424,
+      isDestroyed: vi.fn(() => false),
+      getProcessId: vi.fn(() => 9),
       on: vi.fn((event, handler) => {
         windowHandlers[event] = handler
       }),
@@ -251,7 +257,7 @@ describe('createMainWindow', () => {
       windowHandlers['render-process-gone']?.({} as never, details)
       vi.advanceTimersByTime(250)
 
-      expect(onRendererProcessGone).toHaveBeenCalledWith(details, 424)
+      expect(onRendererProcessGone).toHaveBeenCalledWith(details, 424, 9)
       expect(shouldRecoverRenderer).toHaveBeenCalledWith(details, 424)
     } finally {
       consoleError.mockRestore()
@@ -300,9 +306,12 @@ describe('createMainWindow', () => {
       } as Electron.RenderProcessGoneDetails
     )
 
+    // Why: this mock webContents cannot answer getProcessId; the death must
+    // still be forwarded with an unreadable (undefined) process identity.
     expect(onRendererProcessGone).toHaveBeenCalledWith(
       expect.objectContaining({ reason: 'killed', exitCode: 15 }),
-      expect.any(Number)
+      expect.any(Number),
+      undefined
     )
 
     consoleError.mockRestore()

--- a/src/main/window/createMainWindow-renderer-crash-recovery.test.ts
+++ b/src/main/window/createMainWindow-renderer-crash-recovery.test.ts
@@ -317,6 +317,60 @@ describe('createMainWindow', () => {
     consoleError.mockRestore()
   })
 
+  it('still delivers the crash report when the window webContents getter is destroyed', () => {
+    const windowHandlers: Record<string, (...args: any[]) => void> = {}
+    const webContents = {
+      id: 142,
+      isDestroyed: vi.fn(() => false),
+      getProcessId: vi.fn(() => 7),
+      on: vi.fn((event, handler) => {
+        windowHandlers[event] = handler
+      }),
+      setZoomLevel: vi.fn(),
+      setBackgroundThrottling: vi.fn(),
+      invalidate: vi.fn(),
+      setWindowOpenHandler: vi.fn(),
+      send: vi.fn()
+    }
+    let windowDestroyed = false
+    const browserWindowInstance = {
+      // Why: BrowserWindow.webContents throws once the window is destroyed; the
+      // gone handler must read the emitting webContents, not this getter (#15063).
+      get webContents() {
+        if (windowDestroyed) {
+          throw new Error('Object has been destroyed')
+        }
+        return webContents
+      },
+      on: vi.fn(),
+      isDestroyed: vi.fn(() => windowDestroyed),
+      isMaximized: vi.fn(() => true),
+      isFullScreen: vi.fn(() => false),
+      getSize: vi.fn(() => [1200, 800]),
+      setSize: vi.fn(),
+      maximize: vi.fn(),
+      show: vi.fn(),
+      loadFile: vi.fn(),
+      loadURL: vi.fn()
+    }
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    browserWindowMock.mockImplementation(function () {
+      return browserWindowInstance
+    })
+    const onRendererProcessGone = vi.fn()
+
+    try {
+      createMainWindow(null, { onRendererProcessGone })
+
+      windowDestroyed = true
+      const details = { reason: 'killed', exitCode: 15 } as Electron.RenderProcessGoneDetails
+      expect(() => windowHandlers['render-process-gone']?.({} as never, details)).not.toThrow()
+      expect(onRendererProcessGone).toHaveBeenCalledWith(details, 142, 7)
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
+
   const createRendererRecoveryWindowHarness = () => {
     const windowHandlers: Record<string, (...args: any[]) => void> = {}
     const webContents = {

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -21,6 +21,7 @@ import { ORCA_BROWSER_GUEST_WEB_PREFERENCES } from '../../shared/browser-guest-w
 import { isCrashReportReason } from '../../shared/crash-reporting'
 import { markSystemSessionEnding } from '../crash-reporting/expected-teardown-state'
 import { recordDurableCrashBreadcrumb } from '../crash-reporting/durable-crash-breadcrumb'
+import { readGoneRendererProcessId } from '../crash-reporting/process-gone-renderer-identity'
 import {
   DEFAULT_RENDERER_RECOVERY_MAX_RECOVERIES,
   DEFAULT_RENDERER_RECOVERY_WINDOW_MS,
@@ -193,7 +194,8 @@ type CreateMainWindowOptions = {
   onQuitAborted?: () => void
   onRendererProcessGone?: (
     details: Electron.RenderProcessGoneDetails,
-    webContentsId: number
+    webContentsId: number,
+    rendererProcessId: number | undefined
   ) => void
   /** Returns true when Orca should reload after renderer loss; update-relaunch/quit tear down children intentionally, so don't fight shutdown. */
   shouldRecoverRenderer?: (
@@ -658,7 +660,13 @@ export function createMainWindow(
     // Why: macOS reports BrowserWindow teardown as renderer killed/SIGKILL after close — window noise, not a crash.
     if (!windowClosing) {
       // Why: the recorder owns crash classification; filtering here made expected-teardown evidence unreachable.
-      opts?.onRendererProcessGone?.(details, rendererWebContentsId)
+      // Why: read the process identity here, at event time — the host id is
+      // still readable while the caller may run after teardown races.
+      opts?.onRendererProcessGone?.(
+        details,
+        rendererWebContentsId,
+        readGoneRendererProcessId(mainWindow.webContents)
+      )
     }
     if (!windowClosing) {
       console.error('[window] Renderer process gone; close confirmation will be bypassed', details)

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -651,7 +651,11 @@ export function createMainWindow(
       loadMainWindow(mainWindow)
     }, 250)
   }
-  mainWindow.webContents.on('render-process-gone', (_event, details) => {
+  // Why: hold the emitting webContents directly — BrowserWindow.webContents is a
+  // getter that throws once the window is destroyed, and a throw here would drop
+  // the crash report and skip recovery (#15063).
+  const rendererWebContents = mainWindow.webContents
+  rendererWebContents.on('render-process-gone', (_event, details) => {
     rendererProcessGone = true
     resetMarkdownEditorFocus()
     resetTerminalInputFocus()
@@ -665,7 +669,7 @@ export function createMainWindow(
       opts?.onRendererProcessGone?.(
         details,
         rendererWebContentsId,
-        readGoneRendererProcessId(mainWindow.webContents)
+        readGoneRendererProcessId(rendererWebContents)
       )
     }
     if (!windowClosing) {

--- a/src/shared/crash-reporting.ts
+++ b/src/shared/crash-reporting.ts
@@ -9,6 +9,7 @@ export type { CrashReportDiagnosticBundle } from './crash-reporting-diagnostic-b
 
 export type CrashReportStatus = 'pending' | 'sent' | 'dismissed'
 export type CrashReportSource = 'renderer' | 'child'
+export type CrashReportRendererKind = 'main-window' | 'browser-guest' | 'browser-popup'
 
 export type CrashReportDetailValue = string | number | boolean | null
 export type CrashReportBreadcrumbData = Record<string, CrashReportDetailValue>
@@ -39,6 +40,8 @@ export type CrashReportRecord = {
   arch: string
   electronVersion: string
   chromeVersion: string
+  /** Typed (not a details string) so prompt-eligibility policy can consult it. Absent for child processes and pre-existing records. */
+  rendererKind?: CrashReportRendererKind
   details: Record<string, CrashReportDetailValue>
   breadcrumbs?: CrashReportBreadcrumb[]
 }
@@ -155,6 +158,16 @@ export function isCrashReportReason(reason: string): boolean {
     'memory-eviction',
     'oom'
   ].includes(reason)
+}
+
+/**
+ * Embedded browser-content renderer deaths (guest pages and their popups) are
+ * page failures, not app crashes: they must stay recorded for triage, but must
+ * never drive the user-facing "Orca crashed" prompt. Reports without a
+ * renderer kind (child processes, pre-existing records) keep prompting.
+ */
+export function isUserPromptEligibleCrashReport(report: CrashReportRecord): boolean {
+  return report.rendererKind !== 'browser-guest' && report.rendererKind !== 'browser-popup'
 }
 
 export function isReactErrorBoundaryReport(report: CrashReportRecord): boolean {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​767 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​759 |
| Prod | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​250 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​21 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​229 |

<!-- /orca-pr-loc -->

## ELI5

When a web page pane inside Orca crashed, Orca never wrote it down — only the main window's crashes were recorded. Worse, if two parts crashed at the same time, the notebook only had room for one line, so one crash silently vanished. Now every renderer death gets its own line, and anything intentionally skipped leaves a note saying so.

## What Changed

- **Guest renderer deaths now reach the crash recorder.** `BrowserManager.attachGuestPolicies` (`src/main/browser/browser-manager.ts:913`) attaches a `render-process-gone` forwarder to every browser-family guest — webview guests, popup child windows, and origin-bar popup contents all funnel through it — reporting via a setter-injected callback (`setGuestRendererGoneReporter`, `src/main/browser/browser-manager.ts:273`) wired to the recorder in `src/main/index.ts:2900`. Guest reports carry `details.rendererKind: 'browser-guest' | 'browser-popup'` and the guest `webContentsId`; the main-window path now labels itself `rendererKind: 'main-window'` (`src/main/index.ts:1365`).
- **Renderer dedupe key gains process identity.** `getProcessGoneDedupeKey` (`src/main/crash-reporting/process-gone-dedupe.ts:79`) keys renderers as `renderer:<processType>:wc:<webContentsId>`. One death surfacing as crashed/oom/launch-failed still coalesces (same webContents); N concurrent renderer deaths now produce N reports instead of collapsing into one. Child keys unchanged. `ProcessGoneCrashEvent` gains optional `webContentsId`, which also lands on the `electron.process_gone` span as `crash.web_contents_id` (`src/main/crash-reporting/process-gone-recorder.ts:236`).
- **The silent dedupe drop is now auditable.** The bare `return` in `process-gone-recorder.ts` records a coalesced `process_gone_deduped` durable breadcrumb (30s min interval, keyed by the dedupe key) so a deduped event is distinguishable from a wiring gap without letting a burst flood the 30-entry ring (`src/main/crash-reporting/process-gone-recorder.ts:214`).

Not changed: dashboard popout windows still have no `render-process-gone` recording — they are outside this issue's guest/webview scope and worth a separate issue.

## Why

Field measurement in #15052: two renderer processes killed 248 ms apart on Windows — **2 died, 1 crash report filed**. The guest's death left zero trace because `createMainWindow.ts` held the only recording listener; every other `render-process-gone` listener is cleanup-only. Fixing the wiring alone would arm a second bug: the renderer dedupe key had no process identity, so concurrent renderer deaths (exactly the whole-tree-kill case) would collapse into one report — trading one silent evidence loss for another. Both must land together, which this PR does.

Why full reports for guests rather than breadcrumbs: a dead browser pane is a user-visible failure and first-class evidence when diagnosing external whole-tree kills; breadcrumbs only surface if a *later* crash snapshots the ring. Noise is bounded by existing gates that this PR preserves and verified live: `clean-exit` is not a crash reason, expected-teardown shapes stay suppressed (with breadcrumbs), a guest torn down by its embedder's death files nothing (verified below), and the startup prompt already coalesces same-burst siblings via `isRelatedCrashEvent`, so a tree-kill still produces one prompt — just with complete evidence behind it.

## Linked Issue

Fixes #15052

## Visual Proof

N/A — main-process crash-reporting internals; no UI surface changes. Behavior proof is the Windows field measurement in Testing below.

## Testing

**Repro-first: both new tests fail on unmodified `main`:**

- `records one report per renderer when two renderers die concurrently` → `expected "vi.fn()" to be called 2 times, but got 1 times` — the exact field measurement.
- `reports a guest renderer death instead of leaving zero trace` → `expected undefined to be type of 'function'` — no guest `render-process-gone` listener can reach the recorder at all.

**Unit suites (all green post-fix):** `process-gone-renderer-identity.test.ts` (6), `browser-manager-guest-crash-reporting.test.ts` (3), plus pre-existing `process-gone-dedupe` (7), `process-gone-recorder` (23), `suppressed-process-gone-breadcrumb` (2), `process-gone-killed-one-ordering` (5), and 9 browser-manager suites exercising `attachGuestPolicies`.

**Mutation check — each hunk reverted individually, its tests go red:** identity-free dedupe key → 2 failed; drop `webContentsId` at the recorder key call → 1 failed; restore the bare-return drop path → 2 failed; drop the span attribute → 1 failed; drop breadcrumb `webContentsId` → 1 failed; never attach the guest listener → 3 failed; collapse the popup kind label → 1 failed; skip listener cleanup → 1 failed.

**Windows live verification** (isolated dev instance of this branch on the authorized "Windows high spec" host, own `ORCA_DEV_USER_DATA_PATH`, CDP ownership verified via `getIdentity().devRepoRoot` before every phase):

- Opened the main window plus an embedded-browser guest (`persist:orca-browser` webview through the real `will-attach-webview`/`attachGuestPolicies` funnel), externally killed the guest renderer then the main-window renderer ~290 ms apart (`Stop-Process -Force` by PID).
- **Result: 2 reports filed** where the pre-fix field measurement of the same scenario filed 1:
  - `source=renderer, processType=renderer, reason=crashed, exitCode=-1, rendererKind=browser-guest, webContentsId=3`
  - `source=renderer, processType=renderer, reason=crashed, exitCode=-1, rendererKind=main-window, webContentsId=1`
  - (`exitCode=-1` is `TerminateProcess(-1)` from Stop-Process; the field's external killer produced `killed`/1 — same reporting path.)
- Noise gate held: a second guest whose renderer died only because its embedding window died filed **no** report (3 reports total in the store, not 4). Minidump pairing: round-1 report reached `minidumpStatus="absent"`; the round-2 reports' async minidump attach was cut short because the instance exits after the main-window kill — the primary record and span are written synchronously before that.

**Checks:** `typecheck:node`, `oxlint` (verified live by injecting a violation), changed-code-quality gate (`0 new findings across 8 changed files`), `oxfmt`.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Internal contributor.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

- Wire format untouched: crash-report `details` gains only additive optional fields; the dedupe key is process-local state.
- Cross-platform: no platform-conditional code added; verified live on Windows, unit-tested everywhere.
- Performance: one extra listener per guest webContents, removed by the existing policy-cleanup path.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @BrennanKB5
