### PR TITLE
fix(mobile): escalate continuous Relay outages (STA-4587)

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-14",
+  "updatedAt": "2026-08-17",
   "policy": {
     "maturityLevels": ["experimental", "soak", "blocking", "accepted-gap", "deprecated"],
     "blockingPromotion": {
@@ -943,18 +943,22 @@
       "providers": ["lan", "tailscale", "cloud-relay"],
       "coveredPlatforms": ["macos"],
       "coveredProviders": ["lan", "tailscale", "cloud-relay"],
-      "coverageNotes": "Deterministic TypeScript tests cover shared close-code policy, foreground retry timers, direct-winner cancellation, credential-gated Relay presentation, and concurrent LAN/Tailscale authentication. Physical iOS/Android radios, GFE, and production relay recovery remain live-test gaps.",
-      "motivatingLinks": ["https://github.com/stablyai/orca-cloud/pull/96"],
-      "invariant": "A foregrounded paired phone must recover from relay HOST_OFFLINE without a foreground or network-change signal, while direct recovery must select the first authenticated configured LAN or Tailscale endpoint without serial timeout delays. Relay recovery presentation starts only for a failed active Relay or a dial backed by an eligible credential, and remains pending through a genuine failed-dial cooldown. Backgrounding, direct success, or stop must cancel pending work, and losing probes must close without affecting the winner.",
-      "oracle": "Inject deterministic relay close codes, missing and expired credentials, delayed credential reads, random bytes, fake timers, and independently controlled direct clients. Require HOST_OFFLINE to replace any faster transport timer with one 5-15 second retry, require no retry before the selected delay, keep Relay presentation absent when no socket can open, clear it across lifecycle races, retain it through real dial cooldowns, race all unique non-relay endpoints, select the first authenticated path, close every loser exactly once, and retain no retry after direct connectivity wins.",
+      "coverageNotes": "Deterministic TypeScript tests cover shared close-code policy, foreground retry timers, continuous-outage escalation, direct-winner cancellation, credential-gated Relay presentation, and concurrent LAN/Tailscale authentication. Physical iOS/Android radios, GFE, and production relay recovery remain live-test gaps.",
+      "motivatingLinks": [
+        "https://github.com/stablyai/orca-cloud/pull/96",
+        "https://linear.app/stably/issue/STA-4587"
+      ],
+      "invariant": "A foregrounded paired phone must recover from relay HOST_OFFLINE without a foreground or network-change signal, while direct recovery must select the first authenticated configured LAN or Tailscale endpoint without serial timeout delays. Relay recovery presentation starts only for a failed active Relay or a dial backed by an eligible credential, remains pending through a genuine failed-dial cooldown, and exposes the supervisor's consecutive failed-dial count so a continuous outage escalates to unreachable. Backgrounding, direct success, or stop must cancel pending work, and losing probes must close without affecting the winner.",
+      "oracle": "Inject deterministic relay close codes, missing and expired credentials, delayed credential reads, random bytes, fake timers, and independently controlled direct clients. Require HOST_OFFLINE to replace any faster transport timer with one 5-15 second retry, require no retry before the selected delay, keep Relay presentation absent when no socket can open, clear it across lifecycle races, retain it through real dial cooldowns, publish 12 supervisor dial failures as reconnect attempt 12 and a Relay-unreachable verdict, race all unique non-relay endpoints, select the first authenticated path, close every loser exactly once, and retain no retry after direct connectivity wins.",
       "commands": [
-        "pnpm --dir mobile exec vitest run --root .. mobile/src/transport/mobile-direct-endpoint-probe.test.ts mobile/src/transport/mobile-relay-reconnect-controller.test.ts mobile/src/transport/mobile-endpoint-supervisor.test.ts",
+        "pnpm --dir mobile exec vitest run --root .. mobile/src/transport/mobile-direct-endpoint-probe.test.ts mobile/src/transport/mobile-relay-reconnect-controller.test.ts mobile/src/transport/mobile-endpoint-supervisor.test.ts mobile/src/transport/mobile-relay-outage-escalation.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/shared/mobile-relay-close-codes.test.ts --reporter=dot"
       ],
       "testFiles": [
         "mobile/src/transport/mobile-direct-endpoint-probe.test.ts",
         "mobile/src/transport/mobile-relay-reconnect-controller.test.ts",
         "mobile/src/transport/mobile-endpoint-supervisor.test.ts",
+        "mobile/src/transport/mobile-relay-outage-escalation.test.ts",
         "src/shared/mobile-relay-close-codes.test.ts"
       ],
       "assertionRefs": [
@@ -982,19 +986,26 @@
           ]
         },
         {
+          "file": "mobile/src/transport/mobile-relay-outage-escalation.test.ts",
+          "assertions": [
+            "12 failed supervisor Relay dials publish reconnect attempt 12",
+            "the existing connection classifier escalates the continuous outage to Can't connect via Relay"
+          ]
+        },
+        {
           "file": "src/shared/mobile-relay-close-codes.test.ts",
           "assertions": ["HOST_OFFLINE maps to self-healing full-jitter recovery"]
         }
       ],
       "evidenceRuns": [
         {
-          "date": "2026-08-16",
+          "date": "2026-08-17",
           "runner": "local",
           "platform": "macos",
-          "command": "pnpm --dir mobile exec vitest run --root .. mobile/src/transport/mobile-direct-endpoint-probe.test.ts mobile/src/transport/mobile-relay-reconnect-controller.test.ts mobile/src/transport/mobile-endpoint-supervisor.test.ts",
+          "command": "pnpm --dir mobile exec vitest run --root .. mobile/src/transport/mobile-direct-endpoint-probe.test.ts mobile/src/transport/mobile-relay-reconnect-controller.test.ts mobile/src/transport/mobile-endpoint-supervisor.test.ts mobile/src/transport/mobile-relay-outage-escalation.test.ts",
           "result": "passed",
-          "durationSeconds": 1.23,
-          "summary": "Three focused mobile transport files passed with 54 assertions."
+          "durationSeconds": 1.17,
+          "summary": "Four focused mobile transport files passed with 56 assertions, including continuous-outage escalation."
         },
         {
           "date": "2026-08-16",
@@ -1016,11 +1027,11 @@
       },
       "redGreenEvidence": {
         "status": "complete",
-        "evidence": "The prior external-signal HOST_OFFLINE policy fails the retry oracle, and the prior serial direct probe fails the first-authenticated-endpoint timing oracle. Both pass with the candidate behavior."
+        "evidence": "The pre-fix continuous-outage oracle completes 12 replacement Relay failures while the public retry count remains 0; the candidate publishes 12 and reaches the existing Relay-unreachable verdict. The prior external-signal HOST_OFFLINE policy and serial direct probe also fail their respective retry and first-authenticated-endpoint timing oracles."
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "All configured direct candidates start in one turn, the first authenticated candidate wins after 100 ms in the deterministic test, and every losing client is closed. A physical-device radio and battery budget is still required before promotion."
+        "evidence": "The escalation change only projects the existing supervisor failure count to presentation subscribers: it adds no Relay dial, timer, socket, probe, or wire message. The deterministic outage still performs exactly 12 dials. All configured direct candidates start in one turn, the first authenticated candidate wins after 100 ms, and every losing client is closed."
       },
       "promotionCriteria": [
         "Collect 100 consecutive CI passes or 14 days of soak history.",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -949,9 +949,9 @@
         "https://linear.app/stably/issue/STA-4587"
       ],
       "invariant": "A foregrounded paired phone must recover from relay HOST_OFFLINE without a foreground or network-change signal, while direct recovery must select the first authenticated configured LAN or Tailscale endpoint without serial timeout delays. Relay recovery presentation starts only for a failed active Relay or a dial backed by an eligible credential, remains pending through a genuine failed-dial cooldown, and exposes the supervisor's consecutive failed-dial count so a continuous outage escalates to unreachable. Backgrounding, direct success, or stop must cancel pending work, and losing probes must close without affecting the winner.",
-      "oracle": "Inject deterministic relay close codes, missing and expired credentials, delayed credential reads, random bytes, fake timers, and independently controlled direct clients. Require HOST_OFFLINE to replace any faster transport timer with one 5-15 second retry, require no retry before the selected delay, keep Relay presentation absent when no socket can open, clear it across lifecycle races, retain it through real dial cooldowns, publish 12 supervisor dial failures as reconnect attempt 12 and a Relay-unreachable verdict, race all unique non-relay endpoints, select the first authenticated path, close every loser exactly once, and retain no retry after direct connectivity wins.",
+      "oracle": "Inject deterministic relay close codes, missing and expired credentials, delayed credential reads, random bytes, fake timers, and independently controlled direct clients. Require HOST_OFFLINE to replace any faster transport timer with one 5-15 second retry, require no retry before the selected delay, keep Relay presentation absent when no socket can open, clear it across lifecycle races, retain it through real dial cooldowns, establish Relay through the supervisor and require its active close plus 11 failed replacements to publish reconnect attempt 12 and a Relay-unreachable verdict, race all unique non-relay endpoints, select the first authenticated path, close every loser exactly once, and retain no retry after direct connectivity wins.",
       "commands": [
-        "pnpm --dir mobile exec vitest run --root .. mobile/src/transport/mobile-direct-endpoint-probe.test.ts mobile/src/transport/mobile-relay-reconnect-controller.test.ts mobile/src/transport/mobile-endpoint-supervisor.test.ts mobile/src/transport/mobile-relay-outage-escalation.test.ts",
+        "pnpm --dir mobile exec vitest run --root .. mobile/src/transport/mobile-direct-endpoint-probe.test.ts mobile/src/transport/mobile-relay-reconnect-controller.test.ts mobile/src/transport/mobile-endpoint-supervisor.test.ts mobile/src/transport/mobile-relay-outage-escalation.test.ts mobile/src/transport/stable-logical-rpc-client.test.ts mobile/src/transport/mobile-relay-runtime-failover.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/shared/mobile-relay-close-codes.test.ts --reporter=dot"
       ],
       "testFiles": [
@@ -959,6 +959,8 @@
         "mobile/src/transport/mobile-relay-reconnect-controller.test.ts",
         "mobile/src/transport/mobile-endpoint-supervisor.test.ts",
         "mobile/src/transport/mobile-relay-outage-escalation.test.ts",
+        "mobile/src/transport/stable-logical-rpc-client.test.ts",
+        "mobile/src/transport/mobile-relay-runtime-failover.test.ts",
         "src/shared/mobile-relay-close-codes.test.ts"
       ],
       "assertionRefs": [
@@ -988,8 +990,22 @@
         {
           "file": "mobile/src/transport/mobile-relay-outage-escalation.test.ts",
           "assertions": [
-            "12 failed supervisor Relay dials publish reconnect attempt 12",
+            "a supervisor-established Relay close plus 11 failed replacements publish reconnect attempt 12",
             "the existing connection classifier escalates the continuous outage to Can't connect via Relay"
+          ]
+        },
+        {
+          "file": "mobile/src/transport/stable-logical-rpc-client.test.ts",
+          "assertions": [
+            "supervisor Relay attempts overlay but never replace a larger active-session retry count",
+            "count-only changes notify connection-path subscribers and clearing recovery restores the physical count"
+          ]
+        },
+        {
+          "file": "mobile/src/transport/mobile-relay-runtime-failover.test.ts",
+          "assertions": [
+            "a fresh credential starts Relay presentation with the controller's current count",
+            "missing or expired credentials never open a Relay socket"
           ]
         },
         {
@@ -1002,10 +1018,10 @@
           "date": "2026-08-17",
           "runner": "local",
           "platform": "macos",
-          "command": "pnpm --dir mobile exec vitest run --root .. mobile/src/transport/mobile-direct-endpoint-probe.test.ts mobile/src/transport/mobile-relay-reconnect-controller.test.ts mobile/src/transport/mobile-endpoint-supervisor.test.ts mobile/src/transport/mobile-relay-outage-escalation.test.ts",
+          "command": "pnpm --dir mobile exec vitest run --root .. mobile/src/transport/mobile-direct-endpoint-probe.test.ts mobile/src/transport/mobile-relay-reconnect-controller.test.ts mobile/src/transport/mobile-endpoint-supervisor.test.ts mobile/src/transport/mobile-relay-outage-escalation.test.ts mobile/src/transport/stable-logical-rpc-client.test.ts mobile/src/transport/mobile-relay-runtime-failover.test.ts",
           "result": "passed",
-          "durationSeconds": 1.17,
-          "summary": "Four focused mobile transport files passed with 56 assertions, including continuous-outage escalation."
+          "durationSeconds": 2.31,
+          "summary": "Six focused mobile transport files passed with 82 assertions, including production-lifecycle outage escalation and logical count publication."
         },
         {
           "date": "2026-08-16",
@@ -1027,11 +1043,11 @@
       },
       "redGreenEvidence": {
         "status": "complete",
-        "evidence": "The pre-fix continuous-outage oracle completes 12 replacement Relay failures while the public retry count remains 0; the candidate publishes 12 and reaches the existing Relay-unreachable verdict. The prior external-signal HOST_OFFLINE policy and serial direct probe also fail their respective retry and first-authenticated-endpoint timing oracles."
+        "evidence": "The pre-fix production-lifecycle oracle establishes Relay through the supervisor, then completes one active close plus 11 replacement failures while the public retry count remains 0; the candidate publishes 12 and reaches the existing Relay-unreachable verdict. The prior external-signal HOST_OFFLINE policy and serial direct probe also fail their respective retry and first-authenticated-endpoint timing oracles."
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "The escalation change only projects the existing supervisor failure count to presentation subscribers: it adds no Relay dial, timer, socket, probe, or wire message. The deterministic outage still performs exactly 12 dials. All configured direct candidates start in one turn, the first authenticated candidate wins after 100 ms, and every losing client is closed."
+        "evidence": "The production diff only projects the existing supervisor failure count through local setters and subscribers; it adds no call to a Relay dial, timer, socket, probe, or wire API. The deterministic outage asserts exactly one successful establishment plus 11 failed replacements at the escalation boundary. All configured direct candidates start in one turn, the first authenticated candidate wins after 100 ms, and every losing client is closed."
       },
       "promotionCriteria": [
         "Collect 100 consecutive CI passes or 14 days of soak history.",

--- a/mobile/src/transport/logical-client-connection-path.ts
+++ b/mobile/src/transport/logical-client-connection-path.ts
@@ -3,6 +3,7 @@ import type { MobileConnectionPath } from './stable-logical-rpc-client'
 export class LogicalClientConnectionPath {
   private migration: MobileConnectionPath | null = null
   private recovery: MobileConnectionPath | null = null
+  private recoveryAttempt = 0
   private readonly listeners = new Set<() => void>()
 
   constructor(private readonly isConnected: () => boolean) {}
@@ -17,14 +18,32 @@ export class LogicalClientConnectionPath {
     })
   }
 
+  reconnectAttempt(activeAttempt: number): number {
+    return this.pending() === 'relay'
+      ? Math.max(activeAttempt, this.recoveryAttempt)
+      : activeAttempt
+  }
+
   clearAfterConnected(): void {
     this.migration = null
     this.recovery = null
+    this.recoveryAttempt = 0
   }
 
-  setRecovery(path: MobileConnectionPath | null): void {
+  setRecovery(path: MobileConnectionPath | null, attempt?: number): void {
     this.update(() => {
       this.recovery = path
+      if (path === null) {
+        this.recoveryAttempt = 0
+      } else if (attempt !== undefined) {
+        this.recoveryAttempt = Math.max(0, Math.trunc(attempt))
+      }
+    })
+  }
+
+  setRecoveryAttempt(attempt: number): void {
+    this.update(() => {
+      this.recoveryAttempt = Math.max(0, Math.trunc(attempt))
     })
   }
 
@@ -34,9 +53,10 @@ export class LogicalClientConnectionPath {
   }
 
   private update(apply: () => void): void {
-    const previous = this.pending()
+    const previousPath = this.pending()
+    const previousAttempt = this.reconnectAttempt(0)
     apply()
-    if (previous === this.pending()) {
+    if (previousPath === this.pending() && previousAttempt === this.reconnectAttempt(0)) {
       return
     }
     for (const listener of this.listeners) {

--- a/mobile/src/transport/mobile-endpoint-supervisor-test-fakes.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor-test-fakes.ts
@@ -66,6 +66,7 @@ export class FakeRelaySession extends FakeSession implements MobileRelayRpcSessi
 export class FakeLogicalClient extends FakeSession implements StableLogicalRpcClient {
   private path: MobileConnectionPath
   private recoveryPath: MobileConnectionPath | null = null
+  private recoveryAttempt = 0
   private generation = 1
   private readonly pathListeners = new Set<() => void>()
 
@@ -92,18 +93,35 @@ export class FakeLogicalClient extends FakeSession implements StableLogicalRpcCl
       }
       this.path = path
       this.recoveryPath = null
+      this.recoveryAttempt = 0
       this.generation += 1
       // Connected-state publication carries the migration cleanup.
       this.publishState('connected')
     }
   )
   suspendActiveSession = vi.fn(() => this.publishState('disconnected'))
+  getReconnectAttempt = () => (this.getPendingPath() === 'relay' ? this.recoveryAttempt : 0)
   getActivePath = () => this.path
   getPendingPath = () => (this.getState() === 'connected' ? null : this.recoveryPath)
-  setRecoveryPath = vi.fn((path: MobileConnectionPath | null) => {
+  setRecoveryPath = vi.fn((path: MobileConnectionPath | null, attempt?: number) => {
     const previous = this.getPendingPath()
+    const previousAttempt = this.getReconnectAttempt()
     this.recoveryPath = path
-    if (previous !== this.getPendingPath()) {
+    if (path === null) {
+      this.recoveryAttempt = 0
+    } else if (attempt !== undefined) {
+      this.recoveryAttempt = attempt
+    }
+    if (previous !== this.getPendingPath() || previousAttempt !== this.getReconnectAttempt()) {
+      for (const listener of this.pathListeners) {
+        listener()
+      }
+    }
+  })
+  setRecoveryAttempt = vi.fn((attempt: number) => {
+    const previous = this.getReconnectAttempt()
+    this.recoveryAttempt = attempt
+    if (previous !== this.getReconnectAttempt()) {
       for (const listener of this.pathListeners) {
         listener()
       }

--- a/mobile/src/transport/mobile-endpoint-supervisor.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.ts
@@ -58,6 +58,7 @@ export class MobileEndpointSupervisor {
     })
     this.logRelay = createRelayRecoveryLog(dependencies.now, dependencies.onLog)
     this.relayReconnect = new RelayReconnectController(dependencies, this.recoverRelay.bind(this))
+    this.relayReconnect.reportFailureCountTo(logical.setRecoveryAttempt)
     this.nudgeRouter = new MobileEndpointNudgeRouter({
       logical,
       controller: this.relayReconnect,
@@ -179,11 +180,7 @@ export class MobileEndpointSupervisor {
     } else {
       // Why: background phones must not hold billed relay data splices.
       this.relayReconnect.suspendActiveRelay(this.logical)
-      this.directProbe.clear()
-      this.relayReconnect.clear()
-      this.leaseRotation.clear()
-      this.directGrace.clear()
-      this.logical.setRecoveryPath(null)
+      this.clearScheduledRecovery()
     }
   }
 
@@ -193,6 +190,10 @@ export class MobileEndpointSupervisor {
     this.stopped = true
     this.unsubscribeState?.()
     this.unsubscribeState = null
+    this.clearScheduledRecovery()
+  }
+
+  private clearScheduledRecovery(): void {
     this.directProbe.clear()
     this.relayReconnect.clear()
     this.leaseRotation.clear()
@@ -268,7 +269,7 @@ export class MobileEndpointSupervisor {
       if (this.stopped || !this.foreground || !recoveryNeeded) {
         return
       }
-      this.logical.setRecoveryPath('relay')
+      this.logical.setRecoveryPath('relay', this.relayReconnect.getFailureCount())
       const dialed = await this.sessionEstablisher.dialEligible(selection.credentials)
       if (dialed.outcome === 'established') {
         // Why: a fresh socket satisfies any replacement intent queued mid-dial.

--- a/mobile/src/transport/mobile-relay-outage-escalation.test.ts
+++ b/mobile/src/transport/mobile-relay-outage-escalation.test.ts
@@ -26,7 +26,7 @@ describe('continuous Relay outage escalation', () => {
     const failure = new RelayOuterError(4408)
     const activeRelay = new FakeRelaySession('connected', failure)
     activeRelay.getLastConnectedAt = () => Date.now() - 120_000
-    const logical = createStableLogicalRpcClient(activeRelay, 'relay')
+    const logical = createStableLogicalRpcClient(new FakeSession('disconnected'), 'tailscale')
     const publishedAttempts: number[] = []
     logical.onConnectionPathChange(() => publishedAttempts.push(logical.getReconnectAttempt()))
     const openRelay = vi.fn(() => {
@@ -34,6 +34,7 @@ describe('continuous Relay outage escalation', () => {
       setTimeout(() => session.publishState('disconnected'), 0)
       return session
     })
+    openRelay.mockReturnValueOnce(activeRelay)
     const deps = dependencies({
       openDirect: vi.fn(() => new FakeSession('disconnected')),
       openRelay,
@@ -42,6 +43,8 @@ describe('continuous Relay outage escalation', () => {
     const supervisor = new MobileEndpointSupervisor(logical, host, deps)
 
     await supervisor.start()
+    expect(openRelay).toHaveBeenCalledOnce()
+    expect(logical.getActivePath()).toBe('relay')
     activeRelay.publishState('disconnected')
     await vi.advanceTimersByTimeAsync(3_000)
 

--- a/mobile/src/transport/mobile-relay-outage-escalation.test.ts
+++ b/mobile/src/transport/mobile-relay-outage-escalation.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { classifyConnection } from './connection-health'
+import { MobileEndpointSupervisor } from './mobile-endpoint-supervisor'
+import {
+  dependencies,
+  FakeRelaySession,
+  FakeSession,
+  host
+} from './mobile-endpoint-supervisor-test-fakes'
+import { RelayOuterError } from './mobile-relay-e2ee-link'
+import { createStableLogicalRpcClient } from './stable-logical-rpc-client'
+
+vi.mock('react-native', () => ({ Platform: { OS: 'ios' } }))
+vi.mock('expo-secure-store', () => ({ WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'when-unlocked' }))
+vi.mock('expo-crypto', () => ({ getRandomBytes: (length: number) => new Uint8Array(length) }))
+
+describe('continuous Relay outage escalation', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-17T04:00:00Z'))
+  })
+
+  afterEach(() => vi.useRealTimers())
+
+  it('publishes supervisor recovery attempts and escalates the Relay verdict', async () => {
+    const failure = new RelayOuterError(4408)
+    const activeRelay = new FakeRelaySession('connected', failure)
+    activeRelay.getLastConnectedAt = () => Date.now() - 120_000
+    const logical = createStableLogicalRpcClient(activeRelay, 'relay')
+    const publishedAttempts: number[] = []
+    logical.onConnectionPathChange(() => publishedAttempts.push(logical.getReconnectAttempt()))
+    const openRelay = vi.fn(() => {
+      const session = new FakeRelaySession('connecting', failure)
+      setTimeout(() => session.publishState('disconnected'), 0)
+      return session
+    })
+    const deps = dependencies({
+      openDirect: vi.fn(() => new FakeSession('disconnected')),
+      openRelay,
+      randomBytes: () => new Uint8Array([0, 0])
+    })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+    activeRelay.publishState('disconnected')
+    await vi.advanceTimersByTimeAsync(3_000)
+
+    expect(openRelay).toHaveBeenCalledTimes(12)
+    expect(logical.getPendingPath()).toBe('relay')
+    expect(logical.getReconnectAttempt()).toBe(12)
+    expect(publishedAttempts.at(-1)).toBe(12)
+    expect(
+      classifyConnection({
+        state: logical.getState(),
+        reconnectAttempts: logical.getReconnectAttempt(),
+        lastConnectedAt: logical.getLastConnectedAt(),
+        pendingPath: logical.getPendingPath()
+      })
+    ).toMatchObject({ kind: 'unreachable', label: "Can't connect via Relay" })
+    supervisor.stop()
+    logical.close()
+  })
+})

--- a/mobile/src/transport/mobile-relay-reconnect-controller.test.ts
+++ b/mobile/src/transport/mobile-relay-reconnect-controller.test.ts
@@ -49,6 +49,17 @@ describe('relay reconnect controller', () => {
     expect(onRetry).not.toHaveBeenCalled()
   })
 
+  it('publishes consecutive failures and the direct-connection reset', () => {
+    const published: number[] = []
+    const reconnect = createController(vi.fn(), (count) => published.push(count))
+
+    reconnect.registerFailure(new RelayOuterError(4408), false)
+    reconnect.registerFailure(new RelayOuterError(4408), false)
+    reconnect.resetForDirectConnection()
+
+    expect(published).toEqual([0, 1, 2, 0])
+  })
+
   it('reprobes slowly after rejected E2EE authentication instead of parking forever', () => {
     // Why: on a relay-only phone a permanent gate is a permanent outage — the
     // desktop can commit pairing credentials moments after the first rejection.
@@ -267,8 +278,11 @@ describe('relay reconnect controller', () => {
   })
 })
 
-function createController(onRetry: () => void): RelayReconnectController {
-  return new RelayReconnectController(
+function createController(
+  onRetry: () => void,
+  reportFailureCount: (count: number) => void = () => {}
+): RelayReconnectController {
+  const controller = new RelayReconnectController(
     {
       now: Date.now,
       randomBytes: () => new Uint8Array([128, 0]),
@@ -277,4 +291,6 @@ function createController(onRetry: () => void): RelayReconnectController {
     },
     onRetry
   )
+  controller.reportFailureCountTo(reportFailureCount)
+  return controller
 }

--- a/mobile/src/transport/mobile-relay-reconnect-controller.ts
+++ b/mobile/src/transport/mobile-relay-reconnect-controller.ts
@@ -249,8 +249,7 @@ export class RelayReconnectController {
     }
     const now = this.dependencies.now()
     const failureCount = this.failureCount.recordAfterConnection(this.activeRelayConnectedAt, now)
-    // Why: elapsed time inside a slow failed dial is not evidence of recovery;
-    // only an authenticated relay that survived the stability window resets the streak.
+    // Why: only a stable authenticated Relay resets the failure streak.
     this.activeRelayConnectedAt = null
     const delay =
       recovery?.kind === 'retry-after-host-offline'

--- a/mobile/src/transport/mobile-relay-reconnect-controller.ts
+++ b/mobile/src/transport/mobile-relay-reconnect-controller.ts
@@ -8,6 +8,7 @@ import { MobileE2EEAuthenticationError } from './mobile-e2ee-v2-physical-channel
 import { RelayOuterError } from './mobile-relay-e2ee-link'
 import { RELAY_STABLE_CONNECTION_MS, RelayRetryDelays } from './mobile-relay-retry-delays'
 import { RelayCredentialEligibility } from './relay-credential-eligibility'
+import { RelayRecoveryFailureCount } from './relay-recovery-failure-count'
 import type { StableLogicalRpcClient } from './stable-logical-rpc-client'
 import type { ConnectionState, ForegroundNudgeReason } from './types'
 
@@ -23,7 +24,7 @@ export type RelayReconnectDependencies = {
 type RecoveryGate = 'external-signal' | 'fresh-credential'
 
 export class RelayReconnectController {
-  private consecutiveFailures = 0
+  private readonly failureCount = new RelayRecoveryFailureCount(RELAY_STABLE_CONNECTION_MS)
   private activeRelayConnectedAt: number | null = null
   private nextAttemptAt = 0
   private timer: ReturnType<typeof setTimeout> | null = null
@@ -40,6 +41,14 @@ export class RelayReconnectController {
   ) {
     this.delays = new RelayRetryDelays(dependencies.randomBytes)
     this.credentials = new RelayCredentialEligibility(dependencies.now)
+  }
+
+  getFailureCount(): number {
+    return this.failureCount.current()
+  }
+
+  reportFailureCountTo(reporter: (count: number) => void): void {
+    this.failureCount.reportTo(reporter)
   }
 
   handleForeground(logical: StableLogicalRpcClient, wasForeground: boolean): void {
@@ -116,7 +125,7 @@ export class RelayReconnectController {
       // Why: the rejected credential stays unusable until its replacement is
       // durable. No reprobe timer here — direct is live, rotation over it
       // clears the gate, and any later state failure re-arms via shouldDefer.
-      this.consecutiveFailures = 0
+      this.failureCount.reset()
       this.nextAttemptAt = 0
       this.recoveryGate = 'fresh-credential'
       this.gateReprobePending = false
@@ -239,20 +248,14 @@ export class RelayReconnectController {
       return
     }
     const now = this.dependencies.now()
-    if (
-      this.activeRelayConnectedAt != null &&
-      now - this.activeRelayConnectedAt >= RELAY_STABLE_CONNECTION_MS
-    ) {
-      this.consecutiveFailures = 0
-    }
+    const failureCount = this.failureCount.recordAfterConnection(this.activeRelayConnectedAt, now)
     // Why: elapsed time inside a slow failed dial is not evidence of recovery;
     // only an authenticated relay that survived the stability window resets the streak.
     this.activeRelayConnectedAt = null
-    this.consecutiveFailures += 1
     const delay =
       recovery?.kind === 'retry-after-host-offline'
         ? this.delays.hostOfflineDelayMs()
-        : this.delays.transportDelayMs(this.consecutiveFailures)
+        : this.delays.transportDelayMs(failureCount)
     this.nextAttemptAt = now + delay
     if (error instanceof MobileE2EEAuthenticationError) {
       // Why: an E2EE rejection is usually pairing revocation, but it also fires
@@ -304,7 +307,7 @@ export class RelayReconnectController {
   }
 
   reset(): void {
-    this.consecutiveFailures = 0
+    this.failureCount.reset()
     this.activeRelayConnectedAt = null
     this.nextAttemptAt = 0
     this.liftGate()

--- a/mobile/src/transport/mobile-relay-runtime-failover.test.ts
+++ b/mobile/src/transport/mobile-relay-runtime-failover.test.ts
@@ -91,6 +91,7 @@ class FakeRelaySession extends FakeSession implements MobileRelayRpcSession {
 class FakeLogicalClient extends FakeSession implements StableLogicalRpcClient {
   private path: MobileConnectionPath
   private recoveryPath: MobileConnectionPath | null = null
+  private recoveryAttempt = 0
   private generation = 1
   private readonly pathListeners = new Set<() => void>()
 
@@ -106,17 +107,34 @@ class FakeLogicalClient extends FakeSession implements StableLogicalRpcClient {
     }
     this.path = path
     this.recoveryPath = null
+    this.recoveryAttempt = 0
     this.generation += 1
     // Connected-state publication carries the migration cleanup.
     this.publishState('connected')
   })
   suspendActiveSession = vi.fn(() => this.publishState('disconnected'))
+  getReconnectAttempt = () => (this.getPendingPath() === 'relay' ? this.recoveryAttempt : 0)
   getActivePath = () => this.path
   getPendingPath = () => (this.getState() === 'connected' ? null : this.recoveryPath)
-  setRecoveryPath = vi.fn((path: MobileConnectionPath | null) => {
+  setRecoveryPath = vi.fn((path: MobileConnectionPath | null, attempt?: number) => {
     const previous = this.getPendingPath()
+    const previousAttempt = this.getReconnectAttempt()
     this.recoveryPath = path
-    if (previous !== this.getPendingPath()) {
+    if (path === null) {
+      this.recoveryAttempt = 0
+    } else if (attempt !== undefined) {
+      this.recoveryAttempt = attempt
+    }
+    if (previous !== this.getPendingPath() || previousAttempt !== this.getReconnectAttempt()) {
+      for (const listener of this.pathListeners) {
+        listener()
+      }
+    }
+  })
+  setRecoveryAttempt = vi.fn((attempt: number) => {
+    const previous = this.getReconnectAttempt()
+    this.recoveryAttempt = attempt
+    if (previous !== this.getReconnectAttempt()) {
       for (const listener of this.pathListeners) {
         listener()
       }
@@ -266,7 +284,7 @@ describe('relay runtime recovery without direct connectivity', () => {
     await vi.advanceTimersByTimeAsync(60_000)
 
     expect(deps.openRelay).toHaveBeenCalledOnce()
-    expect(logical.setRecoveryPath).toHaveBeenCalledWith('relay')
+    expect(logical.setRecoveryPath).toHaveBeenCalledWith('relay', 0)
     expect(logical.getActivePath()).toBe('relay')
     supervisor.stop()
   })

--- a/mobile/src/transport/relay-recovery-failure-count.ts
+++ b/mobile/src/transport/relay-recovery-failure-count.ts
@@ -1,0 +1,36 @@
+export class RelayRecoveryFailureCount {
+  private count = 0
+  private reporter: ((count: number) => void) | null = null
+
+  constructor(private readonly stableConnectionMs: number) {}
+
+  current(): number {
+    return this.count
+  }
+
+  reportTo(reporter: (count: number) => void): void {
+    this.reporter = reporter
+    reporter(this.count)
+  }
+
+  record(resetFirst: boolean): number {
+    this.update((resetFirst ? 0 : this.count) + 1)
+    return this.count
+  }
+
+  recordAfterConnection(connectedAt: number | null, now: number): number {
+    return this.record(connectedAt != null && now - connectedAt >= this.stableConnectionMs)
+  }
+
+  reset(): void {
+    this.update(0)
+  }
+
+  private update(count: number): void {
+    if (this.count === count) {
+      return
+    }
+    this.count = count
+    this.reporter?.(count)
+  }
+}

--- a/mobile/src/transport/stable-logical-rpc-client.test.ts
+++ b/mobile/src/transport/stable-logical-rpc-client.test.ts
@@ -302,6 +302,25 @@ describe('stable logical RPC client', () => {
     expect(paths).toEqual(['relay', null])
   })
 
+  it('publishes supervisor Relay attempts without replacing the physical retry count', () => {
+    const direct = new FakeSession('reconnecting')
+    direct.getReconnectAttempt = () => 5
+    const client = createStableLogicalRpcClient(direct, 'tailscale')
+    const attempts: number[] = []
+    client.onConnectionPathChange(() => attempts.push(client.getReconnectAttempt()))
+
+    client.setRecoveryPath('relay', 3)
+    expect(client.getReconnectAttempt()).toBe(5)
+
+    client.setRecoveryAttempt(7)
+    expect(client.getReconnectAttempt()).toBe(7)
+    expect(attempts).toEqual([5, 7])
+
+    client.setRecoveryPath(null)
+    expect(client.getReconnectAttempt()).toBe(5)
+    expect(attempts).toEqual([5, 7, 5])
+  })
+
   it('does not revive a stale recovery path after a connection later drops', () => {
     const direct = new FakeSession('reconnecting')
     const client = createStableLogicalRpcClient(direct, 'tailscale')

--- a/mobile/src/transport/stable-logical-rpc-client.ts
+++ b/mobile/src/transport/stable-logical-rpc-client.ts
@@ -50,7 +50,9 @@ export type StableLogicalRpcClient = RpcClient & {
   getActivePath(): MobileConnectionPath
   // The path the user is waiting on while migration or scheduled recovery is active.
   getPendingPath(): MobileConnectionPath | null
-  setRecoveryPath(path: MobileConnectionPath | null): void
+  setRecoveryPath(path: MobileConnectionPath | null, attempt?: number): void
+  setRecoveryAttempt(attempt: number): void
+  // Recovery attempts share this signal so status-only changes rerender.
   onConnectionPathChange(listener: () => void): () => void
   getGeneration(): number
 }
@@ -153,7 +155,7 @@ export function createStableLogicalRpcClient(
     },
 
     getState: () => state,
-    getReconnectAttempt: () => activeSession.getReconnectAttempt(),
+    getReconnectAttempt: () => connectionPath.reconnectAttempt(activeSession.getReconnectAttempt()),
     getLastConnectedAt: () => activeSession.getLastConnectedAt(),
     onStateChange(listener) {
       stateListeners.add(listener)
@@ -272,7 +274,8 @@ export function createStableLogicalRpcClient(
     // Why: a previous session that recovers mid-dial makes the pending path a lie —
     // once we're connected the user is no longer waiting on anything.
     getPendingPath: () => connectionPath.pending(),
-    setRecoveryPath: (path) => connectionPath.setRecovery(path),
+    setRecoveryPath: (path, attempt) => connectionPath.setRecovery(path, attempt),
+    setRecoveryAttempt: (attempt) => connectionPath.setRecoveryAttempt(attempt),
     onConnectionPathChange: (listener) => connectionPath.subscribe(listener),
     getGeneration: () => generation
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​124 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​119 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​146 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​39 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​107 |

<!-- /orca-pr-loc -->

## ELI5

The Relay supervisor was retrying correctly, but the UI was reading retry count 0 from each short-lived Relay socket. During a long outage it therefore stayed on “Connecting via Relay…” forever. This PR exposes the retry count the supervisor already owns, so the existing status policy can escalate to “Cannot connect via Relay” after 12 consecutive Relay failure events.

## What Changed

- Project the supervisor Relay recovery failure count through the stable logical client.
- Notify existing connection-path subscribers when that presentation count changes.
- Synchronize the pending Relay path and current count when a real credential-backed dial starts.
- Reset or hide the projected count on direct recovery, successful migration, backgrounding, stop, missing credentials, and aborted dials.
- Add a deterministic continuous-outage integration oracle plus focused reset/subscription tests.
- Add STA-4587 to the mobile Relay reliability gate.

## Why

The supervisor already owns Relay retries, credentials, cell migration, and backoff. Making it the count authority avoids a second retry loop in each physical Relay session and keeps transport behavior unchanged.

This is presentation-only: it adds no Relay dial, timer, socket, probe, request, or wire message. The production-lifecycle oracle performs exactly one successful establishment plus 11 failed replacements at the escalation boundary; the fix changes only the public count, not that work.

## Linked Issue

[STA-4587](https://linear.app/stably/issue/STA-4587/p2continuous-mobile-relay-outage-never-escalates-retry-count-0-pr)

## Visual Proof

N/A — reproducing the rendered state requires a continuously failing paired Relay. The deterministic transport integration asserts the same production classifier output directly: one active Relay close plus 11 failed replacements produce attempt 12 and the Relay-unreachable verdict.

## Testing

- [x] I manually reproduced the pre-fix state with deterministic fake time: one active Relay close plus 11 failed replacement dials, pending Relay, public retry count 0.
- [x] Automated tests added/updated.

Validated on macOS:

- `pnpm --dir mobile test` — 454 files; 3,620 passed, 3 skipped.
- `pnpm --dir mobile typecheck`
- `pnpm --dir mobile lint`
- Focused reliability suite — 82 passed.
- Reliability manifest and max-lines ratchet.
- Changed-code quality and React checks — 0 findings.
- Formatting and diff integrity checks.

Physical iOS/Android radio behavior remains a live-test gap; no platform-specific or remote-wire code changes.

## AI Disclosure

## Review

Please focus on failure-count reset boundaries and the invariant that this changes presentation only, not Relay retry cadence or traffic.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

Security: no credential contents or persistence changes. Cross-platform/SSH/folder workspaces: transport-neutral TypeScript state only. Remote compatibility: no RPC, stream, or wire-format change. Performance: constant-time state projection and one existing subscriber notification per count change.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Visual proof is marked N/A with the deterministic classifier rationale
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and compatibility impact considered
- [ ] Full repository build/lint/typecheck/test will be covered by CI; the complete mobile suite and relevant repository gates pass locally

## Author
