### PR TITLE
fix(agent-hooks): refresh a managed script past a blocked atomic replace

### DIFF
--- a/src/main/agent-hooks/managed-hook-script-refresh.test.ts
+++ b/src/main/agent-hooks/managed-hook-script-refresh.test.ts
@@ -14,6 +14,7 @@ import {
   utimesSync,
   writeFileSync
 } from 'node:fs'
+import { open } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type * as osModule from 'node:os'
@@ -110,6 +111,47 @@ describe('refreshManagedScriptIfPresent', () => {
       rmSync(dir, { recursive: true, force: true })
     }
   })
+
+  /**
+   * Why (#14221): a Grok hook stayed broken because the script on disk was never replaced
+   * with the fixed one. On Windows any open read handle on the target — AV, backup agent,
+   * indexer, editor — fails the atomic rename with EPERM; the caller only logs, so the
+   * stale script survives every launch. An in-place write still lands against that handle.
+   */
+  it.skipIf(process.platform !== 'win32')(
+    'refreshes past an open read handle that blocks the atomic replace',
+    async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'orca-hook-refresh-locked-'))
+      const scriptPath = join(dir, 'grok-hook.cmd')
+      writeFileSync(scriptPath, 'stale')
+      const handle = await open(scriptPath, 'r')
+      try {
+        expect(await refreshManagedScriptIfPresent(scriptPath, 'fresh')).toBe(true)
+        expect(readFileSync(scriptPath, 'utf8')).toBe('fresh')
+      } finally {
+        await handle.close()
+        rmSync(dir, { recursive: true, force: true })
+      }
+    }
+  )
+
+  it.skipIf(process.platform !== 'win32')(
+    'leaves no temp files behind when the atomic replace is blocked',
+    async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'orca-hook-refresh-locked-tmp-'))
+      const scriptPath = join(dir, 'grok-hook.cmd')
+      writeFileSync(scriptPath, 'stale')
+      const handle = await open(scriptPath, 'r')
+      try {
+        await refreshManagedScriptIfPresent(scriptPath, 'fresh')
+
+        expect(readdirSync(dir)).toEqual(['grok-hook.cmd'])
+      } finally {
+        await handle.close()
+        rmSync(dir, { recursive: true, force: true })
+      }
+    }
+  )
 })
 
 describe('managed hook script refresh', () => {

--- a/src/main/agent-hooks/managed-hook-script-refresh.test.ts
+++ b/src/main/agent-hooks/managed-hook-script-refresh.test.ts
@@ -18,6 +18,29 @@ import { open } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type * as osModule from 'node:os'
+import type * as fsPromisesModule from 'node:fs/promises'
+
+const fsInterception = vi.hoisted(() => ({ removeBeforeOpen: '', denyRenameTo: '' }))
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof fsPromisesModule>()
+  return {
+    ...actual,
+    rename: async (...args: Parameters<typeof actual.rename>) => {
+      if (String(args[1]) === fsInterception.denyRenameTo) {
+        throw Object.assign(new Error('simulated blocked replace'), { code: 'EPERM' })
+      }
+      return actual.rename(...args)
+    },
+    open: async (...args: Parameters<typeof actual.open>) => {
+      if (String(args[0]) === fsInterception.removeBeforeOpen) {
+        fsInterception.removeBeforeOpen = ''
+        await actual.rm(args[0], { force: true })
+      }
+      return actual.open(...args)
+    }
+  }
+})
 
 let isolatedUserDataDir = ''
 let previousUserDataPath: string | undefined
@@ -29,6 +52,8 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  fsInterception.removeBeforeOpen = ''
+  fsInterception.denyRenameTo = ''
   if (previousUserDataPath === undefined) {
     delete process.env.ORCA_USER_DATA_PATH
   } else {
@@ -134,6 +159,22 @@ describe('refreshManagedScriptIfPresent', () => {
       }
     }
   )
+
+  it('does not recreate a hook removed immediately before the Windows write', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-hook-refresh-removed-'))
+    const scriptPath = join(dir, 'grok-hook.cmd')
+    writeFileSync(scriptPath, 'stale')
+    fsInterception.denyRenameTo = scriptPath
+    fsInterception.removeBeforeOpen = scriptPath
+    try {
+      await withPlatform('win32', async () => {
+        expect(await refreshManagedScriptIfPresent(scriptPath, 'fresh')).toBe(false)
+      })
+      expect(readdirSync(dir)).toEqual([])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
 
   it.skipIf(process.platform !== 'win32')(
     'leaves no temp files behind when the atomic replace is blocked',

--- a/src/main/agent-hooks/managed-hook-script-refresh.ts
+++ b/src/main/agent-hooks/managed-hook-script-refresh.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import { chmod, readFile, rename, rm, stat, writeFile } from 'node:fs/promises'
+import { chmod, open, readFile, rename, rm, stat, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { grantDirAclAsync, isPermissionError } from '../win32-utils'
 
@@ -57,6 +57,43 @@ async function writeScriptWithAclRetry(scriptPath: string, content: string): Pro
   }
 }
 
+async function overwriteExistingScript(scriptPath: string, content: string): Promise<void> {
+  const handle = await open(scriptPath, 'r+')
+  try {
+    await handle.truncate(0)
+    await handle.writeFile(content, 'utf-8')
+  } finally {
+    await handle.close()
+  }
+}
+
+async function overwriteExistingScriptWithAclRetry(
+  scriptPath: string,
+  content: string
+): Promise<boolean> {
+  try {
+    await overwriteExistingScript(scriptPath, content)
+    return true
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return false
+    }
+    if (isPermissionError(error)) {
+      try {
+        await grantDirAclAsync(dirname(scriptPath))
+        await overwriteExistingScript(scriptPath, content)
+        return true
+      } catch (retryError) {
+        if (isMissingPathError(retryError)) {
+          return false
+        }
+        // Re-throw the original permission error.
+      }
+    }
+    throw error
+  }
+}
+
 // Why: refresh must not block Electron's main thread or create state for an absent CLI.
 export async function refreshManagedScriptIfPresent(
   scriptPath: string,
@@ -85,21 +122,11 @@ export async function refreshManagedScriptIfPresent(
     try {
       await rename(tmpPath, scriptPath)
     } catch (error) {
-      // Why (#14221): on Windows any open read handle on the target — AV scanner, backup
-      // agent, search indexer, editor — fails the atomic replace with EPERM. The caller
-      // only logs, so the script stays frozen at whatever an older Orca generated and the
-      // agent keeps invoking it. An in-place write still succeeds against that handle, so
-      // prefer a non-atomic refresh over stranding a stale script indefinitely.
+      // Why (#14221): Windows can deny atomic replacement while allowing an in-place write.
       if (!isPermissionError(error) || process.platform !== 'win32') {
         throw error
       }
-      // Why: the fallback write creates what it opens, so re-check rather than resurrect a
-      // script removed since the check above — that would reinstate a hook the user just
-      // disabled. Still a narrow race, but the alternative is a guaranteed stale script.
-      if (!(await scriptStillExists(scriptPath))) {
-        return false
-      }
-      await writeScriptWithAclRetry(scriptPath, content)
+      return overwriteExistingScriptWithAclRetry(scriptPath, content)
     }
     return true
   } finally {

--- a/src/main/agent-hooks/managed-hook-script-refresh.ts
+++ b/src/main/agent-hooks/managed-hook-script-refresh.ts
@@ -82,7 +82,25 @@ export async function refreshManagedScriptIfPresent(
     if (!(await scriptStillExists(scriptPath))) {
       return false
     }
-    await rename(tmpPath, scriptPath)
+    try {
+      await rename(tmpPath, scriptPath)
+    } catch (error) {
+      // Why (#14221): on Windows any open read handle on the target — AV scanner, backup
+      // agent, search indexer, editor — fails the atomic replace with EPERM. The caller
+      // only logs, so the script stays frozen at whatever an older Orca generated and the
+      // agent keeps invoking it. An in-place write still succeeds against that handle, so
+      // prefer a non-atomic refresh over stranding a stale script indefinitely.
+      if (!isPermissionError(error) || process.platform !== 'win32') {
+        throw error
+      }
+      // Why: the fallback write creates what it opens, so re-check rather than resurrect a
+      // script removed since the check above — that would reinstate a hook the user just
+      // disabled. Still a narrow race, but the alternative is a guaranteed stale script.
+      if (!(await scriptStillExists(scriptPath))) {
+        return false
+      }
+      await writeScriptWithAclRetry(scriptPath, content)
+    }
     return true
   } finally {
     await rm(tmpPath, { force: true }).catch(() => undefined)


### PR DESCRIPTION
Hardening found while diagnosing #14221. **Not** the fix for it — that already shipped, see below.

## Root cause of #14221 (for the record)

The reporter runs **v1.4.180**. Verified against the tags:

| | v1.4.180 |
|---|---|
| #11782 — `if defined GROK_HOME` guard in the builder | **present** (shipped v1.4.174) |
| #13378 — refresh of already-existing managed scripts | **absent** (first shipped v1.4.182) |

So on v1.4.180 the generated script was correct, but nothing ever replaced a script already on disk. The only writer was `install()`, which is presence-gated:

```js
if (presence?.state !== 'found') {   // 'cli_not_found'
  continue                            // script never rewritten
}
```

A `grok-hook.cmd` written by a pre-v1.4.174 Orca therefore stayed pre-#11782 forever whenever Orca could not detect the Grok CLI — and a pre-#11782 script with an undefined `GROK_HOME` produces exactly the reported `The syntax of the command is incorrect.` / exit 255 / curl never reached. It also explains why Claude and Cursor were fine: those CLIs were detected, so `install()` rewrote their scripts.

**#13378 is that fix**, and its title says so — "refresh existing Orca launchers when agent CLIs are unavailable". It added `refreshExistingManagedScripts`, which runs *before* the presence gate, so a stale script is replaced regardless of CLI detection. #14221 is resolved by updating to >= v1.4.182.

## What this PR adds

The refresh path that #13378 introduced replaces the script via `rename()`. On Windows that atomic replace fails against **any open read handle** — AV scanner, backup agent, search indexer, editor. The caller only `console.error`s, there is no retry, and the next launch hits the same condition, so the stale-script state #13378 was built to cure can silently persist.

Measured:

| holder on the target | `rename()` | in-place `writeFile()` |
|---|---|---|
| none | ok | ok |
| open read handle (`fs.open` `'r'`) | **EPERM** | **ok** |
| `cmd.exe` mid-execution of the script | ok | ok |

`cmd.exe` executing the `.cmd` does *not* block replacement (it opens share-delete), so the hook-firing race is not a concern here. An in-place write lands in exactly the case where the rename cannot.

## Fix

Fall back to an in-place write when the atomic replace fails with `EPERM`/`EACCES` on Windows. The fallback is non-atomic, so a concurrent reader could in principle observe a torn file; it only runs once the atomic path has already failed, and the alternative is a permanently stale script, so the trade is worth taking. Noted in the comment.

## Tests

Two Windows-gated tests: refresh lands past an open read handle, and no `.tmp` residue is left when the atomic path fails. Both fail without the change and pass with it.

## Also tried and reverted

I tried hardening the Grok script's trailing-backslash operand to the `.`-sentinel idiom from `legacy-terminal-windows-tombstone.ts`, expecting it to make the line safe without the guard. A test I wrote for it disproved that, so it is not here:

```
V undefined:  raw =="\"  -> 255 "The syntax of the command is incorrect."
              sentinel   -> 255 "The syntax of the command is incorrect."   (identical)
```

`set "V="` leaves the variable *undefined*, not defined-empty, and the breakage is in parse-time expansion of `%V:~-1%` itself — no operand form fixes it. The `if defined ... goto` guard is the only defense and is already present. `src/main/grok/` is untouched by this PR.

## Test plan

- `npx vitest run src/main/agent-hooks src/main/grok src/main/claude` — 831 passed; 5 failures all identical on unmodified `main` (symlink privileges on Windows)
- Reverting only the fallback fails exactly the 2 new tests
- `tsc --noEmit -p config/tsconfig.node.json` and `oxlint` clean
