### PR TITLE
feat(crash-reporting): name the driver of store write chains before React #185 throws

### DIFF
--- a/src/main/ipc/crash-reporting-renderer-breadcrumbs.test.ts
+++ b/src/main/ipc/crash-reporting-renderer-breadcrumbs.test.ts
@@ -379,6 +379,46 @@ describe('renderer breadcrumb IPC routing', () => {
     ])
   })
 
+  // Why name-only: the payload is a captured dispatch stack — high-cardinality
+  // by construction, so a payload-derived key would defeat coalescing and let
+  // a sub-limit write-chain oscillation evict the pre-crash trail.
+  it('coalesces store write-chain captures by name so a storm cannot flood the ring', () => {
+    for (let index = 0; index < 5; index += 1) {
+      emitRendererBreadcrumb({
+        name: 'store_write_chain_depth',
+        data: {
+          depth: 40,
+          burstsSinceInstall: index + 1,
+          stack: `Error: store write chain depth\n    at driverEffect${index}`
+        }
+      })
+    }
+
+    expect(recordCrashBreadcrumbMock).not.toHaveBeenCalled()
+    expect(recordCoalescedCrashBreadcrumbMock).toHaveBeenCalledTimes(5)
+    for (const call of recordCoalescedCrashBreadcrumbMock.mock.calls) {
+      expect(call[0]).toMatchObject({
+        coalesceKey: 'store_write_chain_depth',
+        minIntervalMs: 30_000
+      })
+    }
+  })
+
+  it('keeps a long write-chain stack intact through renderer payload sanitizing', () => {
+    const stack = `Error: store write chain depth\n${'    at driverEffectLoop (renderer)\n'.repeat(60)}`
+    expect(stack.length).toBeGreaterThan(240)
+
+    emitRendererBreadcrumb({
+      name: 'store_write_chain_depth',
+      data: { depth: 40, burstsSinceInstall: 1, stack }
+    })
+
+    const [args] = recordCoalescedCrashBreadcrumbMock.mock.calls[0] as [{ data: { stack: string } }]
+    // `stack`-keyed fields get the 4000-char stack budget, not the 240-char
+    // string budget — the driver frames are the entire point of the crumb.
+    expect(args.data.stack).toBe(stack)
+  })
+
   it('records non-error renderer breadcrumbs without coalescing', () => {
     emitRendererBreadcrumb({ name: 'renderer_bootstrap_started', data: { dev: true } })
 

--- a/src/main/ipc/crash-reporting-renderer-breadcrumbs.ts
+++ b/src/main/ipc/crash-reporting-renderer-breadcrumbs.ts
@@ -9,6 +9,7 @@ import {
 } from '../crash-reporting/crash-breadcrumb-store'
 import { startSpan } from '../observability/tracer'
 import { TERMINAL_WEBGL_DIAGNOSTIC_BREADCRUMB } from '../../shared/terminal-webgl-diagnostics'
+import { STORE_WRITE_CHAIN_BREADCRUMB } from '../../shared/store-write-chain-diagnostics'
 
 function sanitizeRendererBreadcrumbData(value: unknown): CrashReportBreadcrumbData | undefined {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
@@ -54,7 +55,8 @@ const COALESCED_RENDERER_BREADCRUMB_NAMES = new Set([
   'terminal_safe_fit_retry_exhausted',
   DUPLICATE_TAB_OWNER_BREADCRUMB,
   PARK_VERDICT_CHURN_BREADCRUMB,
-  TERMINAL_WEBGL_DIAGNOSTIC_BREADCRUMB
+  TERMINAL_WEBGL_DIAGNOSTIC_BREADCRUMB,
+  STORE_WRITE_CHAIN_BREADCRUMB
 ])
 const RENDERER_BREADCRUMB_COALESCE_MS = 30_000
 // Why: these carry no message identity — they are per-tab telemetry whose rate,
@@ -73,6 +75,13 @@ function rendererBreadcrumbCoalesceKey(
   data: CrashReportBreadcrumbData | undefined
 ): string | undefined {
   if (NAME_ONLY_COALESCED_BREADCRUMB_NAMES.has(name)) {
+    return name
+  }
+  // Why name-only: the payload is a captured dispatch stack — high-cardinality
+  // by construction, so keying on it would defeat coalescing. One driver
+  // dominates any given write-chain storm, and pending-payload resolution
+  // keeps the newest stack in the single slot the storm owns.
+  if (name === STORE_WRITE_CHAIN_BREADCRUMB) {
     return name
   }
   // Why trigger and not name alone: `burst` means damping engaged a commit

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -52,7 +52,7 @@ import {
   registerRuntimeHttpLinkBrowserOpener
 } from '@/lib/http-link-routing'
 import { installStoreListenerCensus } from './store-listener-census'
-import { installStoreWriteChainTelemetry } from './store-write-chain-telemetry'
+import { installSharedStoreWriteChainTelemetry } from './store-write-chain-telemetry'
 import {
   registerRendererMemoryProfileContributor,
   summarizeStateCollectionSizes
@@ -62,7 +62,8 @@ import { estimateStateCollectionKB } from '@/lib/state-collection-byte-estimate'
 export const useAppStore = create<AppState>()((...a) => {
   // Why: the inner api is only reachable here, before create() copies subscribe onto the hook.
   installStoreListenerCensus(a[2])
-  installStoreWriteChainTelemetry(a[2])
+  // Shared installer: the standalone stores join the same write-chain counter.
+  installSharedStoreWriteChainTelemetry(a[2])
   // Why rebind: slices close over `set` at creation, so patching api.setState
   // alone would count useAppStore.setState callers and miss every slice action.
   a[0] = a[2].setState

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -52,6 +52,7 @@ import {
   registerRuntimeHttpLinkBrowserOpener
 } from '@/lib/http-link-routing'
 import { installStoreListenerCensus } from './store-listener-census'
+import { installStoreWriteChainTelemetry } from './store-write-chain-telemetry'
 import {
   registerRendererMemoryProfileContributor,
   summarizeStateCollectionSizes
@@ -61,6 +62,10 @@ import { estimateStateCollectionKB } from '@/lib/state-collection-byte-estimate'
 export const useAppStore = create<AppState>()((...a) => {
   // Why: the inner api is only reachable here, before create() copies subscribe onto the hook.
   installStoreListenerCensus(a[2])
+  installStoreWriteChainTelemetry(a[2])
+  // Why rebind: slices close over `set` at creation, so patching api.setState
+  // alone would count useAppStore.setState callers and miss every slice action.
+  a[0] = a[2].setState
   return {
     ...createRepoSlice(...a),
     ...createSparsePresetsSlice(...a),

--- a/src/renderer/src/store/plugin-language-packs.ts
+++ b/src/renderer/src/store/plugin-language-packs.ts
@@ -4,6 +4,7 @@ import {
   isPluginLanguagePackRegistration,
   type PluginLanguagePackRegistration
 } from '../../../shared/plugins/plugin-language-pack-artifact'
+import { installSharedStoreWriteChainTelemetry } from './store-write-chain-telemetry'
 
 type PluginLanguagePackState = {
   packs: PluginLanguagePackRegistration[]
@@ -14,39 +15,51 @@ type PluginLanguagePackState = {
 let requestGeneration = 0
 let changeSubscriptionStarted = false
 
-export const usePluginLanguagePackStore = create<PluginLanguagePackState>()((set) => ({
-  packs: [],
-  loaded: false,
-  fetchPacks: async () => {
-    const generation = ++requestGeneration
-    const api = window.api?.plugins
-    if (!api?.listLanguagePacks) {
-      if (generation === requestGeneration) {
-        set({ packs: [], loaded: true })
+export const usePluginLanguagePackStore = create<PluginLanguagePackState>()((
+  _set,
+  _get,
+  storeApi
+) => {
+  // Why rebind: actions close over `set`, so the patched setState must be the
+  // one they capture or their writes escape the shared chain counter.
+  installSharedStoreWriteChainTelemetry(storeApi)
+  const set = storeApi.setState
+  return {
+    packs: [],
+    loaded: false,
+    fetchPacks: async () => {
+      const generation = ++requestGeneration
+      const api = window.api?.plugins
+      if (!api?.listLanguagePacks) {
+        if (generation === requestGeneration) {
+          set({ packs: [], loaded: true })
+        }
+        return
       }
-      return
-    }
-    try {
-      const response = await api.listLanguagePacks()
-      const packs = Array.isArray(response) ? response.filter(isPluginLanguagePackRegistration) : []
-      // Why: a non-array response and a rejected member are different upstream bugs; keep them distinguishable in the log.
-      if (!Array.isArray(response)) {
-        console.warn(`[plugins] Ignoring non-array language-pack list (${typeof response})`)
-      } else if (packs.length !== response.length) {
-        console.warn(
-          `[plugins] Ignoring ${response.length - packs.length} of ${response.length} malformed language packs`
-        )
-      }
-      if (generation === requestGeneration) {
-        set({ packs, loaded: true })
-      }
-    } catch {
-      if (generation === requestGeneration) {
-        set({ packs: [], loaded: true })
+      try {
+        const response = await api.listLanguagePacks()
+        const packs = Array.isArray(response)
+          ? response.filter(isPluginLanguagePackRegistration)
+          : []
+        // Why: a non-array response and a rejected member are different upstream bugs; keep them distinguishable in the log.
+        if (!Array.isArray(response)) {
+          console.warn(`[plugins] Ignoring non-array language-pack list (${typeof response})`)
+        } else if (packs.length !== response.length) {
+          console.warn(
+            `[plugins] Ignoring ${response.length - packs.length} of ${response.length} malformed language packs`
+          )
+        }
+        if (generation === requestGeneration) {
+          set({ packs, loaded: true })
+        }
+      } catch {
+        if (generation === requestGeneration) {
+          set({ packs: [], loaded: true })
+        }
       }
     }
   }
-}))
+})
 
 export function ensurePluginLanguagePacksLoaded(): void {
   const state = usePluginLanguagePackStore.getState()

--- a/src/renderer/src/store/plugin-panels.ts
+++ b/src/renderer/src/store/plugin-panels.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo } from 'react'
 import { create } from 'zustand'
 import type { PluginHostListEntry, PluginHostPanel } from '../../../preload/api-types'
+import { installSharedStoreWriteChainTelemetry } from './store-write-chain-telemetry'
 
 /** A panel contribution from an enabled plugin, flattened for sidebar use. */
 export type ActivePluginPanel = PluginHostPanel & {
@@ -46,68 +47,74 @@ function schedulePluginListRetry(generation: number): void {
   }, delayMs)
 }
 
-export const usePluginPanelsStore = create<PluginPanelsState>()((set) => ({
-  plugins: [],
-  panelErrors: {},
-  fetchStatus: 'idle',
-  fetchPlugins: async () => {
-    const generation = ++pluginListGeneration
-    // Why: preload may predate the plugins namespace (web client pairing an
-    // older desktop build); treat a missing bridge as "no plugins" fail-soft.
-    const pluginsApi = window.api?.plugins
-    if (!pluginsApi) {
-      if (generation === pluginListGeneration) {
-        pluginListRetryAttempt = 0
-        set({ fetchStatus: 'ready', plugins: [], panelErrors: {} })
+export const usePluginPanelsStore = create<PluginPanelsState>()((_set, _get, api) => {
+  // Why rebind: actions close over `set`, so the patched api.setState must be
+  // the one they capture or their writes escape the shared chain counter.
+  installSharedStoreWriteChainTelemetry(api)
+  const set = api.setState
+  return {
+    plugins: [],
+    panelErrors: {},
+    fetchStatus: 'idle',
+    fetchPlugins: async () => {
+      const generation = ++pluginListGeneration
+      // Why: preload may predate the plugins namespace (web client pairing an
+      // older desktop build); treat a missing bridge as "no plugins" fail-soft.
+      const pluginsApi = window.api?.plugins
+      if (!pluginsApi) {
+        if (generation === pluginListGeneration) {
+          pluginListRetryAttempt = 0
+          set({ fetchStatus: 'ready', plugins: [], panelErrors: {} })
+        }
+        return
       }
-      return
+      set({ fetchStatus: 'loading' })
+      try {
+        const plugins = await pluginsApi.list()
+        if (generation === pluginListGeneration) {
+          pluginListRetryAttempt = 0
+          set((state) => ({
+            plugins,
+            fetchStatus: 'ready',
+            panelErrors: retainInstalledPanelErrors(state.panelErrors, plugins)
+          }))
+        }
+      } catch {
+        if (generation === pluginListGeneration) {
+          // A failed authority refresh must not leave previously enabled panel
+          // documents mounted from stale state. Bounded retries recover from a
+          // transient preload/main startup race without spinning indefinitely.
+          set({ plugins: [], panelErrors: {}, fetchStatus: 'error' })
+          schedulePluginListRetry(generation)
+        }
+      }
+    },
+    setPlugins: (plugins) => {
+      pluginListGeneration += 1
+      pluginListRetryAttempt = 0
+      if (pluginListRetryTimer) {
+        clearTimeout(pluginListRetryTimer)
+        pluginListRetryTimer = null
+      }
+      set((state) => ({
+        plugins,
+        fetchStatus: 'ready',
+        panelErrors: retainInstalledPanelErrors(state.panelErrors, plugins)
+      }))
+    },
+    setPanelHealth: (tabKey, health) => {
+      set((state) => {
+        const panelErrors = { ...state.panelErrors }
+        if (health === 'error') {
+          panelErrors[tabKey] = true
+        } else {
+          delete panelErrors[tabKey]
+        }
+        return { panelErrors }
+      })
     }
-    set({ fetchStatus: 'loading' })
-    try {
-      const plugins = await pluginsApi.list()
-      if (generation === pluginListGeneration) {
-        pluginListRetryAttempt = 0
-        set((state) => ({
-          plugins,
-          fetchStatus: 'ready',
-          panelErrors: retainInstalledPanelErrors(state.panelErrors, plugins)
-        }))
-      }
-    } catch {
-      if (generation === pluginListGeneration) {
-        // A failed authority refresh must not leave previously enabled panel
-        // documents mounted from stale state. Bounded retries recover from a
-        // transient preload/main startup race without spinning indefinitely.
-        set({ plugins: [], panelErrors: {}, fetchStatus: 'error' })
-        schedulePluginListRetry(generation)
-      }
-    }
-  },
-  setPlugins: (plugins) => {
-    pluginListGeneration += 1
-    pluginListRetryAttempt = 0
-    if (pluginListRetryTimer) {
-      clearTimeout(pluginListRetryTimer)
-      pluginListRetryTimer = null
-    }
-    set((state) => ({
-      plugins,
-      fetchStatus: 'ready',
-      panelErrors: retainInstalledPanelErrors(state.panelErrors, plugins)
-    }))
-  },
-  setPanelHealth: (tabKey, health) => {
-    set((state) => {
-      const panelErrors = { ...state.panelErrors }
-      if (health === 'error') {
-        panelErrors[tabKey] = true
-      } else {
-        delete panelErrors[tabKey]
-      }
-      return { panelErrors }
-    })
   }
-}))
+})
 
 function retainInstalledPanelErrors(
   panelErrors: Readonly<Record<string, true>>,

--- a/src/renderer/src/store/running-terminal-close-confirm.ts
+++ b/src/renderer/src/store/running-terminal-close-confirm.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import type { CloseTerminalDialogCopyKind } from '@/components/terminal-pane/CloseTerminalDialog'
+import { installSharedStoreWriteChainTelemetry } from './store-write-chain-telemetry'
 
 /** A pending confirmation for closing a terminal tab whose shell still has a
  *  running child process. `onConfirm` performs the original close. */
@@ -46,9 +47,14 @@ function mergeRequests(
 // useAppStore.getState() would throw there. Nothing outside the dialog reads this state,
 // so the AppState coupling would buy nothing.
 export const useRunningTerminalCloseConfirmStore = create<RunningTerminalCloseConfirmState>()((
-  set,
-  get
+  _set,
+  get,
+  api
 ) => {
+  // Why rebind: actions close over `set`, so the patched api.setState must be
+  // the one they capture or their writes escape the shared chain counter.
+  installSharedStoreWriteChainTelemetry(api)
+  const set = api.setState
   const queuedRequests: RunningTerminalCloseConfirmRequest[] = []
   // Why: a queued request replaces the visible one in place, so a double-click or held
   // Enter meant for the tab the user was looking at would land on the next tab's prompt and

--- a/src/renderer/src/store/store-write-chain-cross-store-wiring.test.ts
+++ b/src/renderer/src/store/store-write-chain-cross-store-wiring.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Wiring tests proving every standalone zustand store joins the app store's
+ * SHARED write-chain counter. A cascade can cross stores; if any store held a
+ * private counter (or skipped the `set` rebind), its writes would escape and
+ * an absent breadcrumb could no longer be read as "not store-mediated".
+ * Separate file from store-write-chain-wiring.test.ts so the shared tracker's
+ * capture floor starts fresh here (vitest isolates module state per file).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAppStore } from '@/store'
+import { usePluginPanelsStore } from './plugin-panels'
+import { usePluginLanguagePackStore } from './plugin-language-packs'
+import { useRunningTerminalCloseConfirmStore } from './running-terminal-close-confirm'
+import { STORE_WRITE_CHAIN_BREADCRUMB } from '../../../shared/store-write-chain-diagnostics'
+import { STORE_WRITE_CHAIN_STACK_THRESHOLD } from './store-write-chain-telemetry'
+
+const recordBreadcrumb = vi.fn()
+let nowMs = 0
+
+beforeEach(() => {
+  recordBreadcrumb.mockClear()
+  // Step past the shared tracker's renderer-side capture floor between tests.
+  nowMs += 100_000
+  vi.spyOn(performance, 'now').mockImplementation(() => nowMs)
+  // Why call-time stub: the recorder checks `window` per call, so the stores
+  // can be imported in a node environment and observed here. No `plugins`
+  // bridge on purpose — fetch actions take their synchronous fail-soft path.
+  ;(globalThis as { window?: unknown }).window = {
+    api: { crashReports: { recordBreadcrumb } }
+  }
+})
+
+afterEach(async () => {
+  vi.restoreAllMocks()
+  delete (globalThis as { window?: unknown }).window
+  // Drain the depth-reset microtask so bursts never leak across tests.
+  await Promise.resolve()
+})
+
+function writeChainBreadcrumbs(): { name: string; data?: Record<string, unknown> }[] {
+  return recordBreadcrumb.mock.calls
+    .map(([args]) => args as { name: string; data?: Record<string, unknown> })
+    .filter((args) => args.name === STORE_WRITE_CHAIN_BREADCRUMB)
+}
+
+describe('cross-store write chain telemetry wiring', () => {
+  it('sums app-store and plugin-panels writes on one counter', () => {
+    // Interleaved so neither store alone reaches the threshold: only the
+    // shared counter sees the combined chain cross it.
+    for (let i = 0; i < STORE_WRITE_CHAIN_STACK_THRESHOLD; i += 1) {
+      if (i % 2 === 0) {
+        useAppStore.getState().setSidebarWidth(200 + i)
+      } else {
+        usePluginPanelsStore.getState().setPanelHealth(`tab-${i}`, 'error')
+      }
+    }
+
+    const crumbs = writeChainBreadcrumbs()
+    expect(crumbs).toHaveLength(1)
+    expect(crumbs[0].data).toMatchObject({ depth: STORE_WRITE_CHAIN_STACK_THRESHOLD })
+  })
+
+  it('counts running-terminal-close-confirm action writes through the rebound set', () => {
+    for (let i = 0; i < STORE_WRITE_CHAIN_STACK_THRESHOLD; i += 1) {
+      // Same tab id: every call after the first merges, and each merge writes.
+      useRunningTerminalCloseConfirmStore.getState().requestRunningTerminalCloseConfirm({
+        terminalTabId: 'tab-under-test',
+        tabLabel: 'zsh',
+        copyKind: 'command',
+        onConfirm: () => {}
+      })
+    }
+
+    const crumbs = writeChainBreadcrumbs()
+    expect(crumbs).toHaveLength(1)
+    expect(String(crumbs[0].data?.stack)).toContain('requestRunningTerminalCloseConfirm')
+    useRunningTerminalCloseConfirmStore.setState({ runningTerminalCloseConfirm: null })
+  })
+
+  it('counts plugin-language-pack action writes through the rebound set', () => {
+    for (let i = 0; i < STORE_WRITE_CHAIN_STACK_THRESHOLD; i += 1) {
+      // No plugins bridge stubbed: fetchPacks writes synchronously (fail-soft
+      // path runs before any await), so the burst stays in one flush.
+      void usePluginLanguagePackStore.getState().fetchPacks()
+    }
+
+    const crumbs = writeChainBreadcrumbs()
+    expect(crumbs).toHaveLength(1)
+    expect(String(crumbs[0].data?.stack)).toContain('fetchPacks')
+  })
+})

--- a/src/renderer/src/store/store-write-chain-telemetry.test.ts
+++ b/src/renderer/src/store/store-write-chain-telemetry.test.ts
@@ -8,6 +8,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { createStore, type StoreApi } from 'zustand/vanilla'
 import {
+  createStoreWriteChainTelemetry,
   installStoreWriteChainTelemetry,
   STORE_WRITE_CHAIN_CAPTURE_INTERVAL_MS,
   STORE_WRITE_CHAIN_STACK_THRESHOLD
@@ -60,7 +61,7 @@ describe('store write chain telemetry', () => {
     expect(data.depth).toBe(STORE_WRITE_CHAIN_STACK_THRESHOLD)
     const stack = String(data.stack)
     expect(stack).toContain('driverEffectLoopWrite')
-    // The bystander sits ~39 chained hops below the capture; the raised frame
+    // The bystander sits ~24 chained hops below the capture; the raised frame
     // budget reaches the ring, not the bottom of the stack — exactly the
     // attribution React's bystander-blaming throw cannot make.
     expect(stack).not.toContain('innocentBystanderDispatch')
@@ -122,12 +123,14 @@ describe('store write chain telemetry', () => {
   it('resets the depth counter when the app genuinely yields', async () => {
     const record = vi.fn()
     const api = createInstrumentedStore({ record })
+    // Two bursts that only cross the threshold if a missing reset lets them sum.
+    const subThresholdBurst = STORE_WRITE_CHAIN_STACK_THRESHOLD - 5
 
-    for (let i = 0; i < 30; i += 1) {
+    for (let i = 0; i < subThresholdBurst; i += 1) {
       api.setState({ n: i })
     }
     await yieldMicrotasks()
-    for (let i = 0; i < 30; i += 1) {
+    for (let i = 0; i < subThresholdBurst; i += 1) {
       api.setState({ n: 100 + i })
     }
     expect(record).not.toHaveBeenCalled()
@@ -177,6 +180,32 @@ describe('store write chain telemetry', () => {
     const [, data] = record.mock.calls[1] as [string, Record<string, unknown>]
     // The skipped burst stays visible as a delta between captured crumbs.
     expect(data.burstsSinceInstall).toBe(3)
+  })
+
+  it('sums a cascade across stores sharing one tracker', () => {
+    const record = vi.fn()
+    const tracker = createStoreWriteChainTelemetry({ record })
+    const storeA = createStore<RingState>(() => ({ n: 0 }))
+    const storeB = createStore<RingState>(() => ({ n: 0 }))
+    tracker.install(storeA)
+    tracker.install(storeB)
+
+    // Alternate writes so each store alone stays well under the threshold —
+    // only the shared counter sees the combined chain cross it.
+    for (let i = 0; i < STORE_WRITE_CHAIN_STACK_THRESHOLD; i += 1) {
+      ;(i % 2 === 0 ? storeA : storeB).setState({ n: i })
+    }
+
+    expect(record).toHaveBeenCalledTimes(1)
+    const [, data] = record.mock.calls[0] as [string, Record<string, unknown>]
+    expect(data.depth).toBe(STORE_WRITE_CHAIN_STACK_THRESHOLD)
+  })
+
+  it('pins the threshold to half the React nested-update limit', () => {
+    // (1+k)·(T−1) ≤ 50 for k non-store commits per store write: T=25 keeps
+    // the capture ahead of the throw for mixed rings up to k=1 (2·24 = 48).
+    // Raising T silently gives that coverage back — see the constant's doc.
+    expect(STORE_WRITE_CHAIN_STACK_THRESHOLD).toBe(25)
   })
 
   it('never blocks or alters writes, even when recording fails', () => {

--- a/src/renderer/src/store/store-write-chain-telemetry.test.ts
+++ b/src/renderer/src/store/store-write-chain-telemetry.test.ts
@@ -1,0 +1,198 @@
+/**
+ * The synthetic ring below reproduces the #185 shape with no field repro: an
+ * innocent dispatch triggers a subscriber that chains writes past the
+ * threshold. The captured stack must name the chaining subscriber (the
+ * driver), not the initial dispatcher — the opposite of what React's own
+ * throw reports.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { createStore, type StoreApi } from 'zustand/vanilla'
+import {
+  installStoreWriteChainTelemetry,
+  STORE_WRITE_CHAIN_CAPTURE_INTERVAL_MS,
+  STORE_WRITE_CHAIN_STACK_THRESHOLD
+} from './store-write-chain-telemetry'
+import { STORE_WRITE_CHAIN_BREADCRUMB } from '../../../shared/store-write-chain-diagnostics'
+
+type RingState = { n: number }
+
+type InstallOptions = Parameters<typeof installStoreWriteChainTelemetry>[1]
+
+function createInstrumentedStore(options?: InstallOptions): StoreApi<RingState> {
+  const api = createStore<RingState>(() => ({ n: 0 }))
+  installStoreWriteChainTelemetry(api, options)
+  return api
+}
+
+/** Named so the captured stack can be asserted to contain this frame. */
+function driverEffectLoopWrite(
+  api: { getState: () => RingState; setState: (p: RingState) => void },
+  ceiling: number
+): void {
+  const { n } = api.getState()
+  if (n < ceiling) {
+    api.setState({ n: n + 1 })
+  }
+}
+
+/** Named so the captured stack can be asserted to NOT contain this frame. */
+function innocentBystanderDispatch(api: { setState: (p: RingState) => void }): void {
+  api.setState({ n: 1 })
+}
+
+async function yieldMicrotasks(): Promise<void> {
+  // Why: the depth reset is a queueMicrotask scheduled by the burst's first
+  // write, so one drained microtask tick is a genuine yield.
+  await Promise.resolve()
+}
+
+describe('store write chain telemetry', () => {
+  it('names the chaining driver, not the dispatch that merely started the flush', () => {
+    const record = vi.fn()
+    const api = createInstrumentedStore({ record })
+    api.subscribe(() => driverEffectLoopWrite(api, 60))
+
+    innocentBystanderDispatch(api)
+
+    expect(record).toHaveBeenCalledTimes(1)
+    const [name, data] = record.mock.calls[0] as [string, Record<string, unknown>]
+    expect(name).toBe(STORE_WRITE_CHAIN_BREADCRUMB)
+    expect(data.depth).toBe(STORE_WRITE_CHAIN_STACK_THRESHOLD)
+    const stack = String(data.stack)
+    expect(stack).toContain('driverEffectLoopWrite')
+    // The bystander sits ~39 chained hops below the capture; the raised frame
+    // budget reaches the ring, not the bottom of the stack — exactly the
+    // attribution React's bystander-blaming throw cannot make.
+    expect(stack).not.toContain('innocentBystanderDispatch')
+    // The default V8 budget of 10 frames would show only wrapper plumbing.
+    expect(stack.split('\n').length).toBeGreaterThan(12)
+  })
+
+  it('captures nothing when writes stay below the threshold', () => {
+    const record = vi.fn()
+    const captureStack = vi.fn(() => 'stack')
+    const api = createInstrumentedStore({ record, captureStack })
+
+    for (let i = 0; i < STORE_WRITE_CHAIN_STACK_THRESHOLD - 1; i += 1) {
+      api.setState({ n: i })
+    }
+
+    expect(captureStack).not.toHaveBeenCalled()
+    expect(record).not.toHaveBeenCalled()
+  })
+
+  it('does not construct an Error on the normal write path', () => {
+    const record = vi.fn()
+    const api = createInstrumentedStore({ record })
+    const errorSpy = vi.spyOn(globalThis, 'Error')
+    try {
+      for (let i = 0; i < STORE_WRITE_CHAIN_STACK_THRESHOLD - 1; i += 1) {
+        api.setState({ n: i })
+      }
+      expect(errorSpy).not.toHaveBeenCalled()
+
+      api.setState({ n: STORE_WRITE_CHAIN_STACK_THRESHOLD })
+      expect(errorSpy).toHaveBeenCalledTimes(1)
+    } finally {
+      errorSpy.mockRestore()
+    }
+    expect(record).toHaveBeenCalledTimes(1)
+  })
+
+  it('restores Error.stackTraceLimit after a capture', () => {
+    const record = vi.fn()
+    const api = createInstrumentedStore({ record })
+    const originalLimit = Error.stackTraceLimit
+    try {
+      // Why pin: an earlier capture that leaked the raised limit would
+      // otherwise become the "previous" value and hide a missing restore.
+      Error.stackTraceLimit = 7
+
+      for (let i = 0; i <= STORE_WRITE_CHAIN_STACK_THRESHOLD; i += 1) {
+        api.setState({ n: i })
+      }
+
+      expect(record).toHaveBeenCalledTimes(1)
+      expect(Error.stackTraceLimit).toBe(7)
+    } finally {
+      Error.stackTraceLimit = originalLimit
+    }
+  })
+
+  it('resets the depth counter when the app genuinely yields', async () => {
+    const record = vi.fn()
+    const api = createInstrumentedStore({ record })
+
+    for (let i = 0; i < 30; i += 1) {
+      api.setState({ n: i })
+    }
+    await yieldMicrotasks()
+    for (let i = 0; i < 30; i += 1) {
+      api.setState({ n: 100 + i })
+    }
+    expect(record).not.toHaveBeenCalled()
+
+    await yieldMicrotasks()
+    // The counter must still be armed after resets: a real same-flush chain
+    // crosses the threshold as if the earlier bursts never happened.
+    for (let i = 0; i < STORE_WRITE_CHAIN_STACK_THRESHOLD; i += 1) {
+      api.setState({ n: 200 + i })
+    }
+    expect(record).toHaveBeenCalledTimes(1)
+  })
+
+  it('captures once per burst even when the chain runs far past the threshold', () => {
+    const record = vi.fn()
+    // Why interval 0: the equality latch must bound the burst on its own, so
+    // the capture-frequency floor cannot mask a broken latch here.
+    const api = createInstrumentedStore({ record, captureIntervalMs: 0 })
+
+    for (let i = 0; i < STORE_WRITE_CHAIN_STACK_THRESHOLD * 3; i += 1) {
+      api.setState({ n: i })
+    }
+
+    expect(record).toHaveBeenCalledTimes(1)
+  })
+
+  it('floors capture frequency but keeps counting skipped bursts', async () => {
+    const record = vi.fn()
+    let nowMs = 0
+    const api = createInstrumentedStore({ record, now: () => nowMs })
+    const runBurst = (): void => {
+      for (let i = 0; i < STORE_WRITE_CHAIN_STACK_THRESHOLD; i += 1) {
+        api.setState({ n: Math.random() })
+      }
+    }
+
+    runBurst()
+    await yieldMicrotasks()
+    nowMs += STORE_WRITE_CHAIN_CAPTURE_INTERVAL_MS - 1
+    runBurst()
+    await yieldMicrotasks()
+    expect(record).toHaveBeenCalledTimes(1)
+
+    nowMs += STORE_WRITE_CHAIN_CAPTURE_INTERVAL_MS
+    runBurst()
+    expect(record).toHaveBeenCalledTimes(2)
+    const [, data] = record.mock.calls[1] as [string, Record<string, unknown>]
+    // The skipped burst stays visible as a delta between captured crumbs.
+    expect(data.burstsSinceInstall).toBe(3)
+  })
+
+  it('never blocks or alters writes, even when recording fails', () => {
+    const api = createInstrumentedStore({
+      record: () => {
+        throw new Error('recorder down')
+      }
+    })
+
+    for (let i = 0; i < STORE_WRITE_CHAIN_STACK_THRESHOLD + 5; i += 1) {
+      api.setState({ n: i })
+    }
+    expect(api.getState().n).toBe(STORE_WRITE_CHAIN_STACK_THRESHOLD + 4)
+
+    // Updater-function writes pass through unchanged too.
+    api.setState((state) => ({ n: state.n + 1 }))
+    expect(api.getState().n).toBe(STORE_WRITE_CHAIN_STACK_THRESHOLD + 5)
+  })
+})

--- a/src/renderer/src/store/store-write-chain-telemetry.test.ts
+++ b/src/renderer/src/store/store-write-chain-telemetry.test.ts
@@ -41,6 +41,17 @@ function innocentBystanderDispatch(api: { setState: (p: RingState) => void }): v
   api.setState({ n: 1 })
 }
 
+/** Benign bulk work (e.g. close-other-tabs) that legitimately crosses the
+ *  threshold in one flush; named so its stack can be told from the ring's. */
+function benignBulkTabCloseDispatch(
+  api: { setState: (p: RingState) => void },
+  writes: number
+): void {
+  for (let i = 0; i < writes; i += 1) {
+    api.setState({ n: i })
+  }
+}
+
 async function yieldMicrotasks(): Promise<void> {
   // Why: the depth reset is a queueMicrotask scheduled by the burst's first
   // write, so one drained microtask tick is a genuine yield.
@@ -206,6 +217,68 @@ describe('store write chain telemetry', () => {
     // the capture ahead of the throw for mixed rings up to k=1 (2·24 = 48).
     // Raising T silently gives that coverage back — see the constant's doc.
     expect(STORE_WRITE_CHAIN_STACK_THRESHOLD).toBe(25)
+  })
+
+  it('a deeper ring inside the capture floor supersedes an earlier benign burst', async () => {
+    const record = vi.fn()
+    let nowMs = 0
+    const api = createInstrumentedStore({ record, now: () => nowMs })
+
+    // Routine bulk close: 26 writes, one flush — crosses the threshold at t=0.
+    benignBulkTabCloseDispatch(api, STORE_WRITE_CHAIN_STACK_THRESHOLD + 1)
+    await yieldMicrotasks()
+
+    // A REAL ring 8s later, still inside the 10s floor window.
+    nowMs += 8_000
+    api.subscribe(() => driverEffectLoopWrite(api, 50))
+    innocentBystanderDispatch(api)
+    await yieldMicrotasks()
+
+    // The surviving record must name the ring driver, not the bulk close that
+    // merely got there first — otherwise the crash blames a bystander.
+    const [, data] = record.mock.calls.at(-1) as [string, Record<string, unknown>]
+    const stack = String(data.stack)
+    expect(stack).toContain('driverEffectLoopWrite')
+    expect(stack).not.toContain('benignBulkTabCloseDispatch')
+    expect(data.depth).toBe(50)
+  })
+
+  it('stamps the burst-end depth so benign bursts stay tellable from true rings', async () => {
+    const record = vi.fn()
+    const api = createInstrumentedStore({ record })
+
+    benignBulkTabCloseDispatch(api, STORE_WRITE_CHAIN_STACK_THRESHOLD + 7)
+    await yieldMicrotasks()
+
+    // Threshold-crossing depth alone reads 25 for every burst; the burst-end
+    // depth is the discriminator (a benign batch ends near the threshold, a
+    // #185-bound ring runs toward React's limit of 50).
+    const [, data] = record.mock.calls.at(-1) as [string, Record<string, unknown>]
+    expect(data.depth).toBe(STORE_WRITE_CHAIN_STACK_THRESHOLD + 7)
+    expect(data.depthAtCapture).toBe(STORE_WRITE_CHAIN_STACK_THRESHOLD)
+  })
+
+  it('shallower bursts inside the window neither capture nor overwrite a deeper record', async () => {
+    const record = vi.fn()
+    const captureStack = vi.fn(() => 'ring stack')
+    let nowMs = 0
+    const api = createInstrumentedStore({ record, captureStack, now: () => nowMs })
+
+    // Deep burst first: the window's record to beat.
+    benignBulkTabCloseDispatch(api, 50)
+    await yieldMicrotasks()
+    const recordsAfterDeepBurst = record.mock.calls.length
+
+    // A storm of shallower threshold-crossing bursts inside the same window
+    // must stay free: no stack capture, no record churn (reverse masking).
+    for (let burst = 0; burst < 3; burst += 1) {
+      nowMs += 1_000
+      benignBulkTabCloseDispatch(api, STORE_WRITE_CHAIN_STACK_THRESHOLD + 1)
+      await yieldMicrotasks()
+    }
+
+    expect(captureStack).toHaveBeenCalledTimes(1)
+    expect(record.mock.calls.length).toBe(recordsAfterDeepBurst)
   })
 
   it('never blocks or alters writes, even when recording fails', () => {

--- a/src/renderer/src/store/store-write-chain-telemetry.ts
+++ b/src/renderer/src/store/store-write-chain-telemetry.ts
@@ -1,0 +1,136 @@
+/**
+ * Names the driver of a store-write chain headed for React #185.
+ *
+ * react-dom counts nested sync commits in a module-level counter keyed on the
+ * root, so the #185 throw lands on whichever fiber calls setState next — the
+ * blamed component stack is an innocent bystander (#11326). Field reports
+ * therefore never name the loop. This wrapper counts consecutive app-store
+ * writes within one synchronous run and, just below React's limit, captures
+ * the dispatching call path into a crash breadcrumb — evidence recorded
+ * BEFORE the throw, naming the ring member that actually drives it.
+ *
+ * "Same flush" = one synchronous stack run, delimited by microtask drain: the
+ * first write of a burst queues a pre-bound microtask that zeroes the depth.
+ * Microtasks only run once the JS stack empties, and React's sync work loop —
+ * the loop whose commits feed the nested-update counter toward the throw —
+ * never empties the stack mid-chain (commit, layout effects, and the
+ * commit-time passive-effect flush all run inside one do/while). So any
+ * #185-bound cascade of store writes is contained in one burst, while writes
+ * separated by an await or task boundary reset: React drains its own
+ * microtask-scheduled sync work first, which is a genuine yield.
+ *
+ * Patch point mirrors store-listener-census: the inner api is only reachable
+ * as the state creator's third argument. Unlike subscribe, slices close over
+ * `set` (the first creator argument) at creation, so the caller must also
+ * rebind that argument to the patched api.setState — see store/index.ts.
+ *
+ * Cost on the normal path (every store write, ~2.4k live subscriptions): one
+ * integer increment, two branch checks, and — once per burst — queueing a
+ * pre-bound microtask. No allocation, no stack capture. `new Error().stack`
+ * is only constructed after the threshold is crossed, at most once per burst
+ * and once per STORE_WRITE_CHAIN_CAPTURE_INTERVAL_MS.
+ *
+ * Diagnostic only: observes and records, never throttles or suppresses a
+ * write. Store-driven rings are the surviving field hypothesis; a ring cycling
+ * purely through React state never touches this counter and stays invisible.
+ */
+import type { CrashReportBreadcrumbData } from '../../../shared/crash-reporting'
+import { STORE_WRITE_CHAIN_BREADCRUMB } from '../../../shared/store-write-chain-diagnostics'
+import { recordRendererCrashBreadcrumb } from '@/lib/crash-breadcrumb-recorder'
+
+/** react-dom 19.2.x nested commit limit. */
+const REACT_NESTED_UPDATE_LIMIT = 50
+/** Writes-in-one-flush that trip capture (40). Below the React limit so the
+ *  evidence lands before React throws; a ring commits at least once per store
+ *  write it chains, so write depth 40 precedes commit 50. */
+export const STORE_WRITE_CHAIN_STACK_THRESHOLD = REACT_NESTED_UPDATE_LIMIT - 10
+/** Frame budget for the capture: enough to reach through wrapper and notify
+ *  frames into the ring; V8's default 10 would show mostly plumbing. */
+const CAPTURE_STACK_FRAMES = 40
+/** Renderer-side floor between captures. A sustained sub-limit oscillation
+ *  re-crosses the threshold every frame; this bounds stack + IPC cost while
+ *  main-process coalescing separately bounds ring slots. Skipped bursts stay
+ *  countable via burstsSinceInstall deltas between captured crumbs. */
+export const STORE_WRITE_CHAIN_CAPTURE_INTERVAL_MS = 10_000
+
+type StoreWriteChainTelemetryOptions = {
+  threshold?: number
+  captureIntervalMs?: number
+  /** Monotonic clock; wall-clock jumps must not stretch the capture floor. */
+  now?: () => number
+  captureStack?: () => string | undefined
+  record?: (name: string, data: CrashReportBreadcrumbData) => void
+}
+
+/** Only called past the threshold — never on the normal write path. */
+function captureDispatchStack(): string | undefined {
+  const previousLimit = Error.stackTraceLimit
+  try {
+    Error.stackTraceLimit = CAPTURE_STACK_FRAMES
+    return new Error('store write chain depth').stack
+  } finally {
+    Error.stackTraceLimit = previousLimit
+  }
+}
+
+/** Call once from inside the store's state creator, passing its `api`
+ *  argument; then rebind the creator's `set` argument to api.setState so
+ *  slice-action writes are counted too. */
+export function installStoreWriteChainTelemetry<TSetState extends (...args: never[]) => unknown>(
+  api: { setState: TSetState },
+  options?: StoreWriteChainTelemetryOptions
+): void {
+  try {
+    const originalSetState = api.setState
+    if (typeof originalSetState !== 'function') {
+      return
+    }
+    const threshold = options?.threshold ?? STORE_WRITE_CHAIN_STACK_THRESHOLD
+    const captureIntervalMs = options?.captureIntervalMs ?? STORE_WRITE_CHAIN_CAPTURE_INTERVAL_MS
+    const now = options?.now ?? ((): number => performance.now())
+    const captureStack = options?.captureStack ?? captureDispatchStack
+    const record = options?.record ?? recordRendererCrashBreadcrumb
+
+    let depth = 0
+    let resetQueued = false
+    let burstsSinceInstall = 0
+    let lastCaptureAtMs = Number.NEGATIVE_INFINITY
+
+    const resetDepth = (): void => {
+      depth = 0
+      resetQueued = false
+    }
+
+    // Fixed arity on purpose: a rest parameter would allocate an args array on
+    // every store write. zustand's setState takes (partial, replace).
+    api.setState = ((partial: Parameters<TSetState>[0], replace: Parameters<TSetState>[1]) => {
+      depth += 1
+      if (!resetQueued) {
+        resetQueued = true
+        queueMicrotask(resetDepth)
+      }
+      // Strict equality latches capture to the crossing write: a chain running
+      // deeper than the threshold still costs one capture per burst.
+      if (depth === threshold) {
+        try {
+          burstsSinceInstall += 1
+          const nowMs = now()
+          if (nowMs - lastCaptureAtMs >= captureIntervalMs) {
+            lastCaptureAtMs = nowMs
+            const stack = captureStack()
+            record(STORE_WRITE_CHAIN_BREADCRUMB, {
+              depth,
+              burstsSinceInstall,
+              ...(stack ? { stack } : {})
+            })
+          }
+        } catch {
+          // Diagnostic only; a capture failure must never block the write.
+        }
+      }
+      return originalSetState(partial, replace)
+    }) as TSetState
+  } catch {
+    // Best-effort instrumentation; the store must work without it.
+  }
+}

--- a/src/renderer/src/store/store-write-chain-telemetry.ts
+++ b/src/renderer/src/store/store-write-chain-telemetry.ts
@@ -4,10 +4,19 @@
  * react-dom counts nested sync commits in a module-level counter keyed on the
  * root, so the #185 throw lands on whichever fiber calls setState next — the
  * blamed component stack is an innocent bystander (#11326). Field reports
- * therefore never name the loop. This wrapper counts consecutive app-store
- * writes within one synchronous run and, just below React's limit, captures
+ * therefore never name the loop. This wrapper counts consecutive zustand
+ * store writes within one synchronous run and, below React's limit, captures
  * the dispatching call path into a crash breadcrumb — evidence recorded
  * BEFORE the throw, naming the ring member that actually drives it.
+ *
+ * Scope: every renderer zustand store shares ONE counter and capture budget —
+ * useAppStore plus the standalone stores (running-terminal-close-confirm,
+ * plugin-panels, plugin-language-packs) — because a cascade can cross stores,
+ * and per-store counters would each idle under the threshold while the
+ * combined chain sails past it. NOT covered: rings cycling purely through
+ * React component state, and subscriptions built directly on
+ * useSyncExternalStore over non-zustand sources. An absent breadcrumb rules
+ * out zustand-write-driven rings only; it does not exonerate those classes.
  *
  * "Same flush" = one synchronous stack run, delimited by microtask drain: the
  * first write of a burst queues a pre-bound microtask that zeroes the depth.
@@ -40,10 +49,20 @@ import { recordRendererCrashBreadcrumb } from '@/lib/crash-breadcrumb-recorder'
 
 /** react-dom 19.2.x nested commit limit. */
 const REACT_NESTED_UPDATE_LIMIT = 50
-/** Writes-in-one-flush that trip capture (40). Below the React limit so the
- *  evidence lands before React throws; a ring commits at least once per store
- *  write it chains, so write depth 40 precedes commit 50. */
-export const STORE_WRITE_CHAIN_STACK_THRESHOLD = REACT_NESTED_UPDATE_LIMIT - 10
+/** Writes-in-one-flush that trip capture (25). Commits reach React's limit no
+ *  LATER than writes do — every write commits, and a mixed ring adds
+ *  component-state commits between writes — so the margin must budget those
+ *  non-store hops. When write T dispatches, a ring with k non-store commits
+ *  per store write has ~(1+k)·(T−1) commits behind it; the evidence lands
+ *  before the throw iff that stays ≤ 50. T=25 tolerates k=1 (2·24 = 48): a
+ *  ring alternating one store write with one component-state hop is still
+ *  captured, where T=40 required k=0 (2·39 = 78 overshoots — only ~11
+ *  non-store commits TOTAL fit in its margin). Rings with k≥2 still throw
+ *  uncaptured. Cost of the wider net: benign 25–39-write bursts capture too,
+ *  bounded to one name-only crumb per capture interval (and one ring slot per
+ *  30s by main-process coalescing); their depth/burst fields keep them
+ *  tellable from true rings. */
+export const STORE_WRITE_CHAIN_STACK_THRESHOLD = REACT_NESTED_UPDATE_LIMIT / 2
 /** Frame budget for the capture: enough to reach through wrapper and notify
  *  frames into the ring; V8's default 10 would show mostly plumbing. */
 const CAPTURE_STACK_FRAMES = 40
@@ -73,64 +92,93 @@ function captureDispatchStack(): string | undefined {
   }
 }
 
-/** Call once from inside the store's state creator, passing its `api`
- *  argument; then rebind the creator's `set` argument to api.setState so
- *  slice-action writes are counted too. */
+type StoreWriteChainTelemetry = {
+  /** Call from inside a store's state creator, passing its `api` argument;
+   *  then rebind the creator's `set` argument to api.setState so slice/action
+   *  writes are counted too. */
+  install: <TSetState extends (...args: never[]) => unknown>(api: { setState: TSetState }) => void
+}
+
+/** One depth counter, burst latch, and capture floor shared by every store
+ *  this tracker is installed on: a flush is a property of the JS stack, not
+ *  of any one store, so a cross-store cascade sums here. */
+export function createStoreWriteChainTelemetry(
+  options?: StoreWriteChainTelemetryOptions
+): StoreWriteChainTelemetry {
+  const threshold = options?.threshold ?? STORE_WRITE_CHAIN_STACK_THRESHOLD
+  const captureIntervalMs = options?.captureIntervalMs ?? STORE_WRITE_CHAIN_CAPTURE_INTERVAL_MS
+  const now = options?.now ?? ((): number => performance.now())
+  const captureStack = options?.captureStack ?? captureDispatchStack
+  const record = options?.record ?? recordRendererCrashBreadcrumb
+
+  let depth = 0
+  let resetQueued = false
+  let burstsSinceInstall = 0
+  let lastCaptureAtMs = Number.NEGATIVE_INFINITY
+
+  const resetDepth = (): void => {
+    depth = 0
+    resetQueued = false
+  }
+
+  return {
+    install: <TSetState extends (...args: never[]) => unknown>(api: {
+      setState: TSetState
+    }): void => {
+      try {
+        const originalSetState = api.setState
+        if (typeof originalSetState !== 'function') {
+          return
+        }
+        // Fixed arity on purpose: a rest parameter would allocate an args array
+        // on every store write. zustand's setState takes (partial, replace).
+        api.setState = ((partial: Parameters<TSetState>[0], replace: Parameters<TSetState>[1]) => {
+          depth += 1
+          if (!resetQueued) {
+            resetQueued = true
+            queueMicrotask(resetDepth)
+          }
+          // Strict equality latches capture to the crossing write: a chain
+          // running deeper than the threshold still costs one capture per
+          // burst, no matter which stores its writes land on.
+          if (depth === threshold) {
+            try {
+              burstsSinceInstall += 1
+              const nowMs = now()
+              if (nowMs - lastCaptureAtMs >= captureIntervalMs) {
+                lastCaptureAtMs = nowMs
+                const stack = captureStack()
+                record(STORE_WRITE_CHAIN_BREADCRUMB, {
+                  depth,
+                  burstsSinceInstall,
+                  ...(stack ? { stack } : {})
+                })
+              }
+            } catch {
+              // Diagnostic only; a capture failure must never block the write.
+            }
+          }
+          return originalSetState(partial, replace)
+        }) as TSetState
+      } catch {
+        // Best-effort instrumentation; the store must work without it.
+      }
+    }
+  }
+}
+
+/** Isolated tracker per call — unit-test convenience; production stores must
+ *  share `installSharedStoreWriteChainTelemetry` or cross-store cascades
+ *  split across counters and never trip. */
 export function installStoreWriteChainTelemetry<TSetState extends (...args: never[]) => unknown>(
   api: { setState: TSetState },
   options?: StoreWriteChainTelemetryOptions
 ): void {
-  try {
-    const originalSetState = api.setState
-    if (typeof originalSetState !== 'function') {
-      return
-    }
-    const threshold = options?.threshold ?? STORE_WRITE_CHAIN_STACK_THRESHOLD
-    const captureIntervalMs = options?.captureIntervalMs ?? STORE_WRITE_CHAIN_CAPTURE_INTERVAL_MS
-    const now = options?.now ?? ((): number => performance.now())
-    const captureStack = options?.captureStack ?? captureDispatchStack
-    const record = options?.record ?? recordRendererCrashBreadcrumb
-
-    let depth = 0
-    let resetQueued = false
-    let burstsSinceInstall = 0
-    let lastCaptureAtMs = Number.NEGATIVE_INFINITY
-
-    const resetDepth = (): void => {
-      depth = 0
-      resetQueued = false
-    }
-
-    // Fixed arity on purpose: a rest parameter would allocate an args array on
-    // every store write. zustand's setState takes (partial, replace).
-    api.setState = ((partial: Parameters<TSetState>[0], replace: Parameters<TSetState>[1]) => {
-      depth += 1
-      if (!resetQueued) {
-        resetQueued = true
-        queueMicrotask(resetDepth)
-      }
-      // Strict equality latches capture to the crossing write: a chain running
-      // deeper than the threshold still costs one capture per burst.
-      if (depth === threshold) {
-        try {
-          burstsSinceInstall += 1
-          const nowMs = now()
-          if (nowMs - lastCaptureAtMs >= captureIntervalMs) {
-            lastCaptureAtMs = nowMs
-            const stack = captureStack()
-            record(STORE_WRITE_CHAIN_BREADCRUMB, {
-              depth,
-              burstsSinceInstall,
-              ...(stack ? { stack } : {})
-            })
-          }
-        } catch {
-          // Diagnostic only; a capture failure must never block the write.
-        }
-      }
-      return originalSetState(partial, replace)
-    }) as TSetState
-  } catch {
-    // Best-effort instrumentation; the store must work without it.
-  }
+  createStoreWriteChainTelemetry(options).install(api)
 }
+
+const sharedStoreWriteChainTelemetry = createStoreWriteChainTelemetry()
+
+/** The production installer: every zustand store (see Scope above) passes its
+ *  creator `api` here so one counter sees the whole flush. */
+export const installSharedStoreWriteChainTelemetry = sharedStoreWriteChainTelemetry.install

--- a/src/renderer/src/store/store-write-chain-telemetry.ts
+++ b/src/renderer/src/store/store-write-chain-telemetry.ts
@@ -34,10 +34,13 @@
  * rebind that argument to the patched api.setState — see store/index.ts.
  *
  * Cost on the normal path (every store write, ~2.4k live subscriptions): one
- * integer increment, two branch checks, and — once per burst — queueing a
- * pre-bound microtask. No allocation, no stack capture. `new Error().stack`
- * is only constructed after the threshold is crossed, at most once per burst
- * and once per STORE_WRITE_CHAIN_CAPTURE_INTERVAL_MS.
+ * integer increment, three integer branch checks, and — once per burst —
+ * queueing a pre-bound microtask. No allocation, no stack capture.
+ * `new Error().stack` is only constructed past the threshold, at most once per
+ * burst, and inside a capture-floor window only when a burst runs strictly
+ * deeper than everything already recorded there — so a repeating storm still
+ * costs one stack per window, while a deeper burst supersedes rather than
+ * being masked (see the capture-floor doc below).
  *
  * Diagnostic only: observes and records, never throttles or suppresses a
  * write. Store-driven rings are the surviving field hypothesis; a ring cycling
@@ -58,18 +61,26 @@ const REACT_NESTED_UPDATE_LIMIT = 50
  *  ring alternating one store write with one component-state hop is still
  *  captured, where T=40 required k=0 (2·39 = 78 overshoots — only ~11
  *  non-store commits TOTAL fit in its margin). Rings with k≥2 still throw
- *  uncaptured. Cost of the wider net: benign 25–39-write bursts capture too,
- *  bounded to one name-only crumb per capture interval (and one ring slot per
- *  30s by main-process coalescing); their depth/burst fields keep them
- *  tellable from true rings. */
+ *  uncaptured. Cost of the wider net: benign bulk work crosses 25 too — a
+ *  close-other-tabs over ~8-12 tabs is ≥2 writes per close in one flush, and
+ *  N same-tick promise continuations writing once each sum to depth N. Two
+ *  things keep those from polluting the evidence: the burst-end depth stamped
+ *  on each record separates them (a benign batch ends near the threshold; a
+ *  #185-bound ring runs toward React's limit of 50), and a deeper burst
+ *  supersedes a shallower record inside the capture floor, so a routine
+ *  bulk close can never mask the ring that crashes seconds later. */
 export const STORE_WRITE_CHAIN_STACK_THRESHOLD = REACT_NESTED_UPDATE_LIMIT / 2
 /** Frame budget for the capture: enough to reach through wrapper and notify
  *  frames into the ring; V8's default 10 would show mostly plumbing. */
 const CAPTURE_STACK_FRAMES = 40
-/** Renderer-side floor between captures. A sustained sub-limit oscillation
- *  re-crosses the threshold every frame; this bounds stack + IPC cost while
- *  main-process coalescing separately bounds ring slots. Skipped bursts stay
- *  countable via burstsSinceInstall deltas between captured crumbs. */
+/** Renderer-side capture floor. A sustained sub-limit oscillation re-crosses
+ *  the threshold every frame; inside one floor window only a burst that runs
+ *  strictly DEEPER than everything already recorded earns a capture, so a
+ *  repeating storm costs one stack per window while a genuine ring is never
+ *  masked by a benign burst that crossed first (supersede, not first-wins).
+ *  Main-process coalescing separately bounds ring slots to one per 30s, and
+ *  keeps the newest payload — i.e. the deepest burst's stack. Skipped bursts
+ *  stay countable via burstsSinceInstall deltas between captured crumbs. */
 export const STORE_WRITE_CHAIN_CAPTURE_INTERVAL_MS = 10_000
 
 type StoreWriteChainTelemetryOptions = {
@@ -115,10 +126,49 @@ export function createStoreWriteChainTelemetry(
   let resetQueued = false
   let burstsSinceInstall = 0
   let lastCaptureAtMs = Number.NEGATIVE_INFINITY
+  /** Deepest depth already recorded in the current floor window: the bar a
+   *  later burst must beat to earn its own capture (supersede, not first-wins). */
+  let windowMaxRecordedDepth = 0
+  /** Per-burst capture trigger: capture fires at ceiling+1, so a burst that
+   *  never beats the window's recorded max stays capture-free. MAX_SAFE_INTEGER
+   *  outside a threshold-crossing burst keeps the trigger unreachable. */
+  let burstCaptureCeiling = Number.MAX_SAFE_INTEGER
+  /** Depth at this burst's capture; 0 when the burst has no capture pending. */
+  let pendingDepthAtCapture = 0
+  let pendingStack: string | undefined
 
   const resetDepth = (): void => {
+    const finalDepth = depth
     depth = 0
     resetQueued = false
+    burstCaptureCeiling = Number.MAX_SAFE_INTEGER
+    if (pendingDepthAtCapture === 0) {
+      return
+    }
+    const depthAtCapture = pendingDepthAtCapture
+    const stack = pendingStack
+    pendingDepthAtCapture = 0
+    pendingStack = undefined
+    // The burst ran past its capture point: upgrade the record with the final
+    // depth — the field that tells a benign batch (ends near the threshold)
+    // from a true ring (runs toward React's limit). Re-sends the stack already
+    // captured mid-burst; no new Error here, and main-side name coalescing
+    // folds this into the same ring slot with the newest payload winning.
+    if (finalDepth > depthAtCapture) {
+      try {
+        if (finalDepth > windowMaxRecordedDepth) {
+          windowMaxRecordedDepth = finalDepth
+        }
+        record(STORE_WRITE_CHAIN_BREADCRUMB, {
+          depth: finalDepth,
+          depthAtCapture,
+          burstsSinceInstall,
+          ...(stack ? { stack } : {})
+        })
+      } catch {
+        // Diagnostic only; an upgrade failure must never surface.
+      }
+    }
   }
 
   return {
@@ -138,22 +188,37 @@ export function createStoreWriteChainTelemetry(
             resetQueued = true
             queueMicrotask(resetDepth)
           }
-          // Strict equality latches capture to the crossing write: a chain
-          // running deeper than the threshold still costs one capture per
-          // burst, no matter which stores its writes land on.
+          // Once per threshold-crossing burst: pick this burst's capture bar.
+          // Fresh window → the threshold itself; inside a window → the deepest
+          // depth already recorded, so only a strictly deeper burst captures.
           if (depth === threshold) {
             try {
               burstsSinceInstall += 1
-              const nowMs = now()
-              if (nowMs - lastCaptureAtMs >= captureIntervalMs) {
-                lastCaptureAtMs = nowMs
-                const stack = captureStack()
-                record(STORE_WRITE_CHAIN_BREADCRUMB, {
-                  depth,
-                  burstsSinceInstall,
-                  ...(stack ? { stack } : {})
-                })
+              if (now() - lastCaptureAtMs >= captureIntervalMs) {
+                windowMaxRecordedDepth = 0
               }
+              burstCaptureCeiling = Math.max(threshold - 1, windowMaxRecordedDepth)
+            } catch {
+              // Diagnostic only; a clock failure must never block the write.
+            }
+          }
+          // Strict equality latches capture to the write that beats the bar:
+          // at most one stack per burst, no matter which stores the writes
+          // land on or how far past the threshold the chain runs.
+          if (depth === burstCaptureCeiling + 1) {
+            try {
+              lastCaptureAtMs = now()
+              const stack = captureStack()
+              pendingDepthAtCapture = depth
+              pendingStack = stack
+              windowMaxRecordedDepth = depth
+              // Recorded immediately — evidence must land BEFORE a #185 throw;
+              // the burst-end reset upgrades it with the final depth.
+              record(STORE_WRITE_CHAIN_BREADCRUMB, {
+                depth,
+                burstsSinceInstall,
+                ...(stack ? { stack } : {})
+              })
             } catch {
               // Diagnostic only; a capture failure must never block the write.
             }

--- a/src/renderer/src/store/store-write-chain-wiring.test.ts
+++ b/src/renderer/src/store/store-write-chain-wiring.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Wiring tests against the REAL app store. The telemetry patches the inner
+ * api.setState, but slices close over `set` (the first creator argument) at
+ * creation — index.ts must rebind it to the patched setState or every slice
+ * action write goes uncounted. These tests go red if the install or the
+ * rebind is dropped, which module-level tests cannot see.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAppStore } from '@/store'
+import { STORE_WRITE_CHAIN_BREADCRUMB } from '../../../shared/store-write-chain-diagnostics'
+import { STORE_WRITE_CHAIN_STACK_THRESHOLD } from './store-write-chain-telemetry'
+
+const recordBreadcrumb = vi.fn()
+
+beforeEach(() => {
+  recordBreadcrumb.mockClear()
+  // Why call-time stub: the recorder checks `window` per call, so the store
+  // can be imported in a node environment and observed here.
+  ;(globalThis as { window?: unknown }).window = {
+    api: { crashReports: { recordBreadcrumb } }
+  }
+})
+
+afterEach(async () => {
+  delete (globalThis as { window?: unknown }).window
+  // Drain the depth-reset microtask so bursts never leak across tests.
+  await Promise.resolve()
+})
+
+function writeChainBreadcrumbs(): { name: string; data?: Record<string, unknown> }[] {
+  return recordBreadcrumb.mock.calls
+    .map(([args]) => args as { name: string; data?: Record<string, unknown> })
+    .filter((args) => args.name === STORE_WRITE_CHAIN_BREADCRUMB)
+}
+
+describe('store write chain telemetry wiring', () => {
+  it('stays silent below the threshold on the real store', async () => {
+    for (let i = 0; i < STORE_WRITE_CHAIN_STACK_THRESHOLD - 1; i += 1) {
+      useAppStore.getState().setSidebarWidth(200 + i)
+    }
+    expect(writeChainBreadcrumbs()).toHaveLength(0)
+    await Promise.resolve()
+  })
+
+  it('counts slice-action writes, proving the rebound `set` is instrumented', () => {
+    for (let i = 0; i < STORE_WRITE_CHAIN_STACK_THRESHOLD; i += 1) {
+      useAppStore.getState().setSidebarWidth(300 + i)
+    }
+
+    const crumbs = writeChainBreadcrumbs()
+    expect(crumbs).toHaveLength(1)
+    expect(crumbs[0].data).toMatchObject({ depth: STORE_WRITE_CHAIN_STACK_THRESHOLD })
+    // The captured call path names the dispatching slice action.
+    expect(String(crumbs[0].data?.stack)).toContain('setSidebarWidth')
+  })
+})

--- a/src/shared/store-write-chain-diagnostics.ts
+++ b/src/shared/store-write-chain-diagnostics.ts
@@ -1,0 +1,4 @@
+/** Renderer breadcrumb carrying the dispatch stack of a same-flush store write
+ *  chain captured before react-dom's nested-update limit throws (#185). Shared
+ *  so the main-process breadcrumb router can coalesce storms by name. */
+export const STORE_WRITE_CHAIN_BREADCRUMB = 'store_write_chain_depth'


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​487 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​487 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​383 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​89 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​294 |

<!-- /orca-pr-loc -->

## ELI5

When the app crashes with React error #185 ("Maximum update depth exceeded"), React blames whichever component happened to update last — usually an innocent one — so the crash reports never tell us which code is actually looping. This PR adds a tiny counter to the app store that notices a runaway chain of writes just *before* React crashes, and saves the real culprit's call path into the crash breadcrumbs. Next time this happens in the field, the report names its own driver.

## What Changed

- **`src/renderer/src/store/store-write-chain-telemetry.ts`** (new): wraps the store's inner `setState` (same house pattern as `store-listener-census.ts`) to count consecutive store writes within one synchronous run. "Same flush" = one synchronous stack run, delimited by microtask drain: the burst's first write queues a pre-bound `queueMicrotask` that zeroes the counter. React's sync work loop — the loop whose commits feed the nested-update counter toward the #185 throw — never empties the JS stack mid-chain, so a #185-bound cascade is fully contained in one burst, while any genuine yield (await, task boundary) resets it. At depth 40 (React throws at 50 commits; a store-driven ring commits at least once per chained write, so write 40 precedes commit 50) it captures `new Error().stack` under a temporarily raised 40-frame budget and records it as a `store_write_chain_depth` breadcrumb.
- **`src/renderer/src/store/index.ts`**: installs the wrapper from inside the state creator and rebinds the creator's `set` argument to the patched `api.setState` — slices close over `set` at creation, so without the rebind every slice-action write would go uncounted.
- **`src/main/ipc/crash-reporting-renderer-breadcrumbs.ts`**: routes the new breadcrumb through `recordCoalescedCrashBreadcrumb` keyed by name only, so a storm costs one ring slot per 30s window instead of flushing the 30-entry ring (and the retained `renderer_memory_highwater` evidence's neighbors). Payload-newest resolution keeps the latest driver stack in the slot.
- **`src/shared/store-write-chain-diagnostics.ts`** (new): the breadcrumb name constant, shared by renderer and main.

Guardrails built in:

- **Normal path is O(1) and allocation-free**: one integer increment, two branch checks; the wrapper takes fixed `(partial, replace)` parameters deliberately — a rest parameter would allocate an args array per write. The stack is only constructed once the threshold is crossed (test-enforced with an `Error` constructor spy).
- **Once per burst** (strict-equality latch) plus a renderer-side 10s capture floor bound stack + IPC cost during a sustained sub-limit oscillation; skipped bursts stay countable via `burstsSinceInstall` deltas.
- **Diagnostic only**: observes and records; never throttles, damps, or suppresses a write. A capture failure can never block the write (test-enforced).

## Why

16 field reports of React #185 span 5 error boundaries; 12 map to 6 shipped fixes, but 4 remain unexplained on 1.4.180/1.4.182 (crash reports `685c1d06`, `05ed75b1`, `996b4cc2`, `fe2b1a30`). React's `nestedUpdateCount` is module-global keyed on the root, so the thrown component stack names a bystander, not the driver — the codebase already documents this (see `4543bb6826`, #11326). Static analysis is exhausted: 2,399 store subscriptions audited clean, no unstable selector at HEAD. The surviving hypothesis is a multi-effect ring chaining store writes within one synchronous flush — a shape per-site static reading structurally cannot see, but which this counter observes directly at the store, the one chokepoint every store-driven ring must cross. `terminal-park-verdict-flip-telemetry.ts` already derives burst budgets from React's commit headroom for one specific surface; this generalizes the missing piece — naming the driver — app-wide.

Measured cost (5-round medians, vitest/node, this machine): bare store write 25ns baseline vs 25ns instrumented (delta ±2ns, sign flips run-to-run — below noise); with 2,400 subscribed listeners a write costs ~16.5µs, instrumentation delta -0.8% to +1.0% (noise band). The normal path never allocates and never touches `Error`.

## Linked Issue

No open issue tracks the unexplained #185 cluster; the live evidence set is crash reports `685c1d06`, `05ed75b1`, `996b4cc2`, `fe2b1a30`. Relates to #2746 (a previously fixed instance of the same throw class).

## Visual Proof

N/A — renderer diagnostics with no UI surface; the only output is a crash-report breadcrumb.

## Testing

- `npx vitest run --config config/vitest.config.ts --no-file-parallelism src/renderer/src/store/store-write-chain-telemetry.test.ts` — 8 passed. Includes a synthetic #185-shaped ring (an innocent dispatch triggers a subscriber that chains writes past the threshold) asserting the captured stack **contains the driver's frame and not the bystander's**; counter reset on yield; once-per-burst latch isolated from the capture floor; no `Error` construction below threshold (constructor spy); `Error.stackTraceLimit` restore; writes unchanged even when recording throws.
- `npx vitest run --config config/vitest.config.ts --no-file-parallelism src/renderer/src/store/store-write-chain-wiring.test.ts` — 2 passed, against the REAL app store: slice-action writes (via the rebound `set`) trip the capture; below-threshold writes stay silent.
- `npx vitest run --config config/vitest.config.ts --no-file-parallelism src/main/ipc/crash-reporting-renderer-breadcrumbs.test.ts` — 20 passed (2 new: name-only coalescing bounds a storm to one slot; long stacks keep the 4000-char stack budget through sanitizing).
- Mutation checks: 12 mutations, 12 killed (counter removal, eager capture, reset removal, latch `===`→`>=`, interval-gate removal, stackTraceLimit raise/restore removal, passthrough drop, payload-stack omission, index.ts install+rebind removal, rebind-only removal, IPC coalescing removal). Two initially survived and drove test hardening: the interval gate masked a broken burst latch (fixed with `captureIntervalMs: 0` in that test), and a leaked `stackTraceLimit` masked a missing restore (fixed by pinning a known limit).
- `pnpm typecheck` clean; `oxlint`, `audit:code-quality:native`, `audit:code-quality:type-aware`, `check:code-quality:changed` (0 new findings across 7 changed files), and `check:react-doctor:changed` all pass.
- Platforms: logic is platform-independent renderer/main TS; tested on macOS. No SSH/remote wire impact — the breadcrumb is a local renderer→main IPC already in place.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @BrennanKB5
