### PR TITLE
fix(agent-hooks): heal stuck permission wait after a denied Claude tool

### DIFF
--- a/src/main/agent-hooks/claude-permission-deny-transcript-watch.test.ts
+++ b/src/main/agent-hooks/claude-permission-deny-transcript-watch.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdir, mkdtemp, rm, writeFile, appendFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { installClaudePermissionDenyTranscriptWatch } from './claude-permission-deny-transcript-watch'
+
+const PANE_KEY = 'tab-deny:33333333-3333-4333-8333-333333333333'
+const TOOL_USE_ID = 'toolu_01SR4NdZW4V8MHVEXA5C2VDH'
+
+// Real Claude transcript entry shape for a denied tool (captured from a live deny).
+function denyLine(toolUseId = TOOL_USE_ID): string {
+  return `${JSON.stringify({
+    type: 'user',
+    message: {
+      role: 'user',
+      content: [
+        {
+          type: 'tool_result',
+          content: "The user doesn't want to proceed with this tool use.",
+          is_error: true,
+          tool_use_id: toolUseId
+        }
+      ]
+    }
+  })}\n`
+}
+
+function successLine(toolUseId = TOOL_USE_ID): string {
+  return `${JSON.stringify({
+    type: 'user',
+    message: {
+      role: 'user',
+      content: [{ type: 'tool_result', content: 'ok', tool_use_id: toolUseId }]
+    }
+  })}\n`
+}
+
+type Listener = (event: {
+  paneKey: string
+  connectionId: string | null
+  receivedAt: number
+  stateStartedAt: number
+  toolUseId?: string
+  providerSession?: { transcriptPath?: string }
+  providerSessionOnly?: boolean
+  payload: { state: string; agentType?: 'claude' | 'codex'; toolName?: string; prompt: string }
+}) => void
+
+function createServerFacade(): {
+  server: Parameters<typeof installClaudePermissionDenyTranscriptWatch>[0]
+  emit: Listener
+  infer: ReturnType<typeof vi.fn>
+} {
+  let listener: Listener | null = null
+  const infer = vi.fn().mockReturnValue(true)
+  return {
+    server: {
+      subscribeEnrichedStatus: (l) => {
+        listener = l as Listener
+        return () => {
+          listener = null
+        }
+      },
+      inferClaudePermissionDenied: infer
+    },
+    emit: (event) => listener?.(event),
+    infer
+  }
+}
+
+function waitEvent(
+  transcriptPath: string,
+  overrides: Partial<Parameters<Listener>[0]> = {}
+): Parameters<Listener>[0] {
+  return {
+    paneKey: PANE_KEY,
+    connectionId: null,
+    receivedAt: Date.now(),
+    stateStartedAt: Date.now() - 50,
+    toolUseId: TOOL_USE_ID,
+    providerSession: { transcriptPath },
+    payload: { state: 'waiting', agentType: 'claude', toolName: 'Write', prompt: 'make probe' },
+    ...overrides
+  }
+}
+
+const settle = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+describe('claude permission deny transcript watch', () => {
+  let dir = ''
+  let transcriptPath = ''
+  let dispose: (() => void) | null = null
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'deny-watch-'))
+    transcriptPath = join(dir, 'session.jsonl')
+    await writeFile(transcriptPath, '{"type":"assistant"}\n')
+  })
+
+  afterEach(async () => {
+    dispose?.()
+    dispose = null
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  function install(facade: ReturnType<typeof createServerFacade>): void {
+    dispose = installClaudePermissionDenyTranscriptWatch(facade.server, { settleMs: 20 })
+  }
+
+  it('infers a deny when the rejected tool_result is appended', async () => {
+    const facade = createServerFacade()
+    install(facade)
+    const event = waitEvent(transcriptPath)
+    facade.emit(event)
+
+    await settle(40)
+    await appendFile(transcriptPath, denyLine())
+    await vi.waitFor(() => expect(facade.infer).toHaveBeenCalledTimes(1), { timeout: 2_000 })
+    expect(facade.infer).toHaveBeenCalledWith({
+      paneKey: PANE_KEY,
+      baselineUpdatedAt: event.receivedAt,
+      baselineStateStartedAt: event.stateStartedAt,
+      baselinePrompt: 'make probe',
+      baselineAgentType: 'claude'
+    })
+  })
+
+  it('infers from a deny already on disk when the wait is observed late', async () => {
+    await appendFile(transcriptPath, denyLine())
+    const facade = createServerFacade()
+    install(facade)
+    facade.emit(waitEvent(transcriptPath))
+
+    await vi.waitFor(() => expect(facade.infer).toHaveBeenCalledTimes(1), { timeout: 2_000 })
+  })
+
+  it('gives up when the watch cannot bind, without polling', async () => {
+    const missingDirPath = join(dir, 'missing', 'session.jsonl')
+    const facade = createServerFacade()
+    install(facade)
+    facade.emit(waitEvent(missingDirPath))
+
+    await settle(40)
+    await mkdir(join(dir, 'missing'))
+    await writeFile(missingDirPath, denyLine())
+    await settle(150)
+    expect(facade.infer).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['a different tool_use_id', denyLine('toolu_other')],
+    ['a successful tool_result for the pending tool', successLine()]
+  ])('ignores %s', async (_label, line) => {
+    const facade = createServerFacade()
+    install(facade)
+    facade.emit(waitEvent(transcriptPath))
+
+    await settle(40)
+    await appendFile(transcriptPath, line)
+    await settle(150)
+    expect(facade.infer).not.toHaveBeenCalled()
+  })
+
+  it('stops when a newer status replaces the wait', async () => {
+    const facade = createServerFacade()
+    install(facade)
+    facade.emit(waitEvent(transcriptPath))
+    facade.emit(
+      waitEvent(transcriptPath, {
+        receivedAt: Date.now() + 10,
+        payload: { state: 'working', agentType: 'claude', prompt: 'make probe' }
+      })
+    )
+
+    await appendFile(transcriptPath, denyLine())
+    await settle(150)
+    expect(facade.infer).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['no tool_use_id', (path: string) => waitEvent(path, { toolUseId: undefined })],
+    ['a remote pane', (path: string) => waitEvent(path, { connectionId: 'ssh-1' })],
+    ['no transcript path', (path: string) => waitEvent(path, { providerSession: {} })],
+    [
+      'an AskUserQuestion wait',
+      (path: string) =>
+        waitEvent(path, {
+          payload: {
+            state: 'waiting',
+            agentType: 'claude',
+            toolName: 'AskUserQuestion',
+            prompt: 'make probe'
+          }
+        })
+    ]
+  ])('does not watch %s', async (_label, makeEvent) => {
+    const facade = createServerFacade()
+    install(facade)
+    facade.emit(makeEvent(transcriptPath))
+
+    await appendFile(transcriptPath, denyLine())
+    await settle(150)
+    expect(facade.infer).not.toHaveBeenCalled()
+  })
+
+  it('dispose cancels pending watchers', async () => {
+    const facade = createServerFacade()
+    install(facade)
+    facade.emit(waitEvent(transcriptPath))
+    dispose?.()
+    dispose = null
+
+    await appendFile(transcriptPath, denyLine())
+    await settle(150)
+    expect(facade.infer).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/agent-hooks/claude-permission-deny-transcript-watch.ts
+++ b/src/main/agent-hooks/claude-permission-deny-transcript-watch.ts
@@ -1,0 +1,270 @@
+import { promises as fs } from 'node:fs'
+import { AGENT_STATUS_STALE_AFTER_MS, type AgentType } from '../../shared/agent-status-types'
+import {
+  isClaudeToolPermissionWait,
+  type ClaudePermissionDenyInferenceRequest
+} from '../../shared/claude-permission-deny-intent'
+import { createTranscriptNativeWatcher } from '../native-chat/transcript-native-watcher'
+
+/** Structural deny detection for local Claude panes: a denied tool never runs,
+ *  so an `is_error` tool_result for the tool_use_id that requested permission
+ *  can only appear in the session transcript when the user rejected it. An
+ *  approved tool resumes through PreToolUse first, which replaces the waiting
+ *  entry and invalidates the baseline. This does not depend on TUI wording.
+ *  Delivery is fs.watch-driven only, no polling fallback: this is best-effort
+ *  healing, so when the watch cannot bind or the filesystem never delivers
+ *  events, the pane keeps the pre-existing behavior (cleared by the next
+ *  prompt or staleness) instead of being polled for.
+ *  Known limit: panes whose transcript this process cannot read (SSH remotes,
+ *  WSL) keep the stuck waiting state until the next prompt or staleness. */
+
+/** Coalesces fs.watch event bursts into one read. */
+const FS_EVENT_TICK_DELAY_MS = 25
+/** Grace for a racing PostToolUse* hook (approved tool failing fast) to land
+ *  and replace the waiting entry before the inference is attempted. */
+const DENY_SETTLE_MS = 1_500
+/** Backscan window for waits hydrated after the deny was already written. */
+const TRANSCRIPT_BACKSCAN_BYTES = 64 * 1024
+const MAX_PENDING_LINE_CHARS = 512 * 1024
+
+type EnrichedStatusEvent = {
+  paneKey: string
+  connectionId: string | null
+  receivedAt: number
+  stateStartedAt: number
+  toolUseId?: string
+  providerSession?: { transcriptPath?: string }
+  providerSessionOnly?: boolean
+  payload: { state: string; agentType?: AgentType; toolName?: string; prompt: string }
+}
+
+type DenyWatchHookServer = {
+  subscribeEnrichedStatus(listener: (event: EnrichedStatusEvent) => void): () => void
+  inferClaudePermissionDenied(request: ClaudePermissionDenyInferenceRequest): boolean
+}
+
+type DenyWatchOptions = {
+  settleMs?: number
+  now?: () => number
+}
+
+type PaneDenyWatcher = {
+  baseline: ClaudePermissionDenyInferenceRequest
+  stop: () => void
+}
+
+function transcriptLineIsDenyResult(line: string, toolUseId: string): boolean {
+  if (!line.includes(toolUseId) || !line.includes('tool_result')) {
+    return false
+  }
+  let entry: unknown
+  try {
+    entry = JSON.parse(line)
+  } catch {
+    return false
+  }
+  if (typeof entry !== 'object' || entry === null) {
+    return false
+  }
+  const message = (entry as { message?: unknown }).message
+  const content =
+    typeof message === 'object' && message !== null
+      ? (message as { content?: unknown }).content
+      : undefined
+  if (!Array.isArray(content)) {
+    return false
+  }
+  return content.some(
+    (item) =>
+      typeof item === 'object' &&
+      item !== null &&
+      (item as { type?: unknown }).type === 'tool_result' &&
+      (item as { tool_use_id?: unknown }).tool_use_id === toolUseId &&
+      (item as { is_error?: unknown }).is_error === true
+  )
+}
+
+export function installClaudePermissionDenyTranscriptWatch(
+  server: DenyWatchHookServer,
+  options: DenyWatchOptions = {}
+): () => void {
+  const settleMs = options.settleMs ?? DENY_SETTLE_MS
+  const now = options.now ?? (() => Date.now())
+  const watchers = new Map<string, PaneDenyWatcher>()
+
+  const startWatcher = (event: EnrichedStatusEvent): void => {
+    const transcriptPath = event.providerSession?.transcriptPath
+    const toolUseId = event.toolUseId
+    if (!transcriptPath || !toolUseId) {
+      return
+    }
+    const baseline: ClaudePermissionDenyInferenceRequest = {
+      paneKey: event.paneKey,
+      baselineUpdatedAt: event.receivedAt,
+      baselineStateStartedAt: event.stateStartedAt,
+      baselinePrompt: event.payload.prompt,
+      baselineAgentType: event.payload.agentType
+    }
+    const deadline = event.receivedAt + AGENT_STATUS_STALE_AFTER_MS
+    let stopped = false
+    let ticking = false
+    let fsEventDuringTick = false
+    let offset: number | null = null
+    let pendingLine = ''
+    let pollTimer: ReturnType<typeof setTimeout> | null = null
+    let settleTimer: ReturnType<typeof setTimeout> | null = null
+
+    const stop = (): void => {
+      stopped = true
+      nativeWatcher.dispose()
+      if (pollTimer !== null) {
+        clearTimeout(pollTimer)
+        pollTimer = null
+      }
+      if (settleTimer !== null) {
+        clearTimeout(settleTimer)
+        settleTimer = null
+      }
+      if (watchers.get(event.paneKey)?.stop === stop) {
+        watchers.delete(event.paneKey)
+      }
+    }
+
+    const scheduleTick = (delayMs: number): void => {
+      if (stopped || settleTimer !== null) {
+        return
+      }
+      if (pollTimer !== null) {
+        clearTimeout(pollTimer)
+      }
+      pollTimer = setTimeout(() => void tick(), delayMs)
+    }
+
+    // Why: a watch error invalidates the binding; the scheduled tick reads any
+    // missed growth, then rebinds or stops in its tail.
+    const nativeWatcher = createTranscriptNativeWatcher(
+      transcriptPath,
+      () => {
+        if (ticking) {
+          fsEventDuringTick = true
+          return
+        }
+        scheduleTick(FS_EVENT_TICK_DELAY_MS)
+      },
+      () => scheduleTick(FS_EVENT_TICK_DELAY_MS)
+    )
+
+    const settleThenInfer = (): void => {
+      if (pollTimer !== null) {
+        clearTimeout(pollTimer)
+        pollTimer = null
+      }
+      // Why: the server re-validates the baseline, so a hook that landed during
+      // the settle window (approved tool resuming/failing) wins over this path.
+      settleTimer = setTimeout(() => {
+        const applied = server.inferClaudePermissionDenied(baseline)
+        console.debug('[agent-hooks] transcript deny watch settled', {
+          paneKey: event.paneKey,
+          applied
+        })
+        stop()
+      }, settleMs)
+    }
+
+    const scanLines = (lines: string[]): boolean =>
+      lines.some((line) => transcriptLineIsDenyResult(line, toolUseId))
+
+    const tick = async (): Promise<void> => {
+      if (stopped || ticking) {
+        return
+      }
+      ticking = true
+      try {
+        const stat = await fs.stat(transcriptPath)
+        if (offset === null || stat.size < offset) {
+          // First look (or truncation): backscan the tail for a deny that was
+          // written before this watch started, e.g. a wait hydrated after restart.
+          const start = Math.max(0, stat.size - TRANSCRIPT_BACKSCAN_BYTES)
+          const backscan = await readTranscriptRange(transcriptPath, start, stat.size)
+          offset = stat.size
+          pendingLine = ''
+          // Drop the first line: it may be cut by the backscan window.
+          if (scanLines(backscan.split('\n').slice(start > 0 ? 1 : 0))) {
+            settleThenInfer()
+            return
+          }
+        } else if (stat.size > offset) {
+          const appended = await readTranscriptRange(transcriptPath, offset, stat.size)
+          offset = stat.size
+          const lines = (pendingLine + appended).split('\n')
+          pendingLine = (lines.pop() ?? '').slice(-MAX_PENDING_LINE_CHARS)
+          if (scanLines(lines)) {
+            settleThenInfer()
+            return
+          }
+        }
+      } catch {
+        // Unreadable transcript (still flushing, WSL path, permissions): keep
+        // polling until the deadline.
+      } finally {
+        ticking = false
+      }
+      if (!stopped && settleTimer === null) {
+        if (now() > deadline) {
+          stop()
+          return
+        }
+        // Why: without a binding no further signal can arrive — release the
+        // pane to its pre-existing behavior rather than poll.
+        if (nativeWatcher.needsRebind() && !nativeWatcher.bind()) {
+          stop()
+          return
+        }
+        if (fsEventDuringTick) {
+          fsEventDuringTick = false
+          scheduleTick(FS_EVENT_TICK_DELAY_MS)
+        }
+      }
+    }
+
+    watchers.set(event.paneKey, { baseline, stop })
+    // Why: bind before the backscan so growth between the two cannot slip past
+    // both; a failed bind falls through to the first tick's tail and stops.
+    nativeWatcher.bind()
+    void tick()
+  }
+
+  const unsubscribe = server.subscribeEnrichedStatus((event) => {
+    if (event.providerSessionOnly === true) {
+      return
+    }
+    const active = watchers.get(event.paneKey)
+    if (active && event.receivedAt === active.baseline.baselineUpdatedAt) {
+      return
+    }
+    active?.stop()
+    // Why: only local panes — this process cannot read a remote transcript.
+    if (event.connectionId === null && isClaudeToolPermissionWait(event.payload)) {
+      startWatcher(event)
+    }
+  })
+
+  return () => {
+    unsubscribe()
+    for (const watcher of watchers.values()) {
+      watcher.stop()
+    }
+  }
+}
+
+async function readTranscriptRange(path: string, start: number, end: number): Promise<string> {
+  const handle = await fs.open(path, 'r')
+  try {
+    const length = end - start
+    const buffer = Buffer.alloc(length)
+    const { bytesRead } = await handle.read(buffer, 0, length, start)
+    return buffer.subarray(0, bytesRead).toString('utf8')
+  } finally {
+    await handle.close()
+  }
+}

--- a/src/main/agent-hooks/server.claude-permission-deny.test.ts
+++ b/src/main/agent-hooks/server.claude-permission-deny.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest'
+import { makePaneKey } from '../../shared/stable-pane-id'
+import { AgentHookServer } from './server'
+
+const PANE_KEY = makePaneKey('tab-deny', '22222222-2222-4222-8222-222222222222')
+
+function ingestClaudeStatus(
+  server: AgentHookServer,
+  event: {
+    state: 'working' | 'waiting'
+    hookEventName: 'PermissionRequest' | 'PreToolUse' | 'UserPromptSubmit'
+    toolName?: string
+    toolUseId?: string
+    prompt?: string
+  }
+): void {
+  server.ingestRemote(
+    {
+      paneKey: PANE_KEY,
+      tabId: 'tab-deny',
+      worktreeId: 'worktree-deny',
+      hookEventName: event.hookEventName,
+      ...(event.toolUseId ? { toolUseId: event.toolUseId } : {}),
+      payload: {
+        state: event.state,
+        agentType: 'claude',
+        ...(event.toolName ? { toolName: event.toolName } : {}),
+        ...(event.prompt !== undefined ? { prompt: event.prompt } : {})
+      }
+    },
+    'connection-1'
+  )
+}
+
+function denyRequestFromSnapshot(
+  server: AgentHookServer
+): Parameters<AgentHookServer['inferClaudePermissionDenied']>[0] {
+  const [entry] = server.getStatusSnapshot()
+  return {
+    paneKey: entry.paneKey,
+    baselineUpdatedAt: entry.receivedAt,
+    baselineStateStartedAt: entry.stateStartedAt,
+    baselinePrompt: entry.prompt as string,
+    baselineAgentType: entry.agentType
+  }
+}
+
+describe('inferClaudePermissionDenied', () => {
+  it('settles a denied permission wait as an interrupted turn', () => {
+    const server = new AgentHookServer()
+    ingestClaudeStatus(server, {
+      state: 'waiting',
+      hookEventName: 'PermissionRequest',
+      toolName: 'Write',
+      toolUseId: 'tool-denied'
+    })
+
+    expect(server.inferClaudePermissionDenied(denyRequestFromSnapshot(server))).toBe(true)
+    expect(server.getStatusSnapshot()).toEqual([
+      expect.objectContaining({
+        paneKey: PANE_KEY,
+        state: 'done',
+        agentType: 'claude',
+        interrupted: true
+      })
+    ])
+  })
+
+  it('lets a new user prompt revive the pane after the inferred deny', () => {
+    const server = new AgentHookServer()
+    ingestClaudeStatus(server, {
+      state: 'waiting',
+      hookEventName: 'PermissionRequest',
+      toolName: 'Write',
+      toolUseId: 'tool-denied'
+    })
+    server.inferClaudePermissionDenied(denyRequestFromSnapshot(server))
+
+    ingestClaudeStatus(server, {
+      state: 'working',
+      hookEventName: 'UserPromptSubmit',
+      prompt: 'try a different approach'
+    })
+    expect(server.getStatusSnapshot()).toEqual([
+      expect.objectContaining({ paneKey: PANE_KEY, state: 'working', agentType: 'claude' })
+    ])
+  })
+
+  it('refuses AskUserQuestion waits — those clear via the question inference', () => {
+    const server = new AgentHookServer()
+    ingestClaudeStatus(server, {
+      state: 'waiting',
+      hookEventName: 'PermissionRequest',
+      toolName: 'AskUserQuestion',
+      toolUseId: 'tool-question'
+    })
+
+    expect(server.inferClaudePermissionDenied(denyRequestFromSnapshot(server))).toBe(false)
+    expect(server.getStatusSnapshot()).toEqual([
+      expect.objectContaining({ state: 'waiting', toolName: 'AskUserQuestion' })
+    ])
+  })
+
+  it('refuses when the cached status changed since the baseline was captured', () => {
+    const server = new AgentHookServer()
+    ingestClaudeStatus(server, {
+      state: 'waiting',
+      hookEventName: 'PermissionRequest',
+      toolName: 'Write',
+      toolUseId: 'tool-denied'
+    })
+    const staleRequest = {
+      ...denyRequestFromSnapshot(server),
+      baselineUpdatedAt: 1
+    }
+
+    expect(server.inferClaudePermissionDenied(staleRequest)).toBe(false)
+    expect(server.getStatusSnapshot()).toEqual([
+      expect.objectContaining({ state: 'waiting', toolName: 'Write' })
+    ])
+  })
+
+  it('ignores panes that are not waiting on a permission', () => {
+    const server = new AgentHookServer()
+    ingestClaudeStatus(server, {
+      state: 'working',
+      hookEventName: 'PreToolUse',
+      toolName: 'Read',
+      toolUseId: 'tool-working'
+    })
+
+    expect(server.inferClaudePermissionDenied(denyRequestFromSnapshot(server))).toBe(false)
+    expect(server.getStatusSnapshot()).toEqual([
+      expect.objectContaining({ state: 'working', toolName: 'Read' })
+    ])
+  })
+})

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -68,6 +68,10 @@ import {
   isAskUserQuestionTool,
   type AgentQuestionAnsweredInferenceRequest
 } from '../../shared/agent-question-answered-intent'
+import {
+  isClaudeToolPermissionWait,
+  type ClaudePermissionDenyInferenceRequest
+} from '../../shared/claude-permission-deny-intent'
 import { parseLegacyNumericPaneKey, parsePaneKey } from '../../shared/stable-pane-id'
 import type { LegacyPaneKeyAliasEntry } from '../../shared/types'
 import {
@@ -831,6 +835,57 @@ export class AgentHookServer {
       }
     })
     console.debug('[agent-hooks] inferred answered question status', {
+      paneKey: inferred.paneKey,
+      state: inferred.payload.state
+    })
+    return true
+  }
+
+  /** Guarded fallback for a hook Claude never sends: denying a permission dialog aborts the turn with no
+   *  event, so the transcript's rejected tool_result (see claude-permission-deny-transcript-watch) is the
+   *  only signal. Re-validate the baseline against the cached status — a racing real hook wins — then
+   *  settle the pane as an interrupted turn, exactly like the Ctrl+C inference. */
+  inferClaudePermissionDenied(request: ClaudePermissionDenyInferenceRequest): boolean {
+    if (!isValidPaneKey(request.paneKey)) {
+      return false
+    }
+    const existing = this.state.lastStatusByPaneKey.get(request.paneKey) as
+      | EnrichedAgentHookEventPayload
+      | undefined
+    if (!existing) {
+      return false
+    }
+    const payload = existing.payload
+    if (!isClaudeToolPermissionWait(payload)) {
+      return false
+    }
+    if (
+      payload.agentType !== request.baselineAgentType ||
+      payload.prompt !== request.baselinePrompt ||
+      existing.receivedAt !== request.baselineUpdatedAt ||
+      existing.stateStartedAt !== request.baselineStateStartedAt ||
+      Date.now() - existing.receivedAt > AGENT_STATUS_STALE_AFTER_MS
+    ) {
+      return false
+    }
+    // Why: sync the lead-turn record too, or a later child event re-emits the stale waiting state.
+    markClaudeLeadTurnInterrupted(this.state, existing.paneKey)
+    const inferred = this.applyNormalizedStatus({
+      paneKey: existing.paneKey,
+      tabId: existing.tabId,
+      worktreeId: existing.worktreeId,
+      connectionId: existing.connectionId,
+      providerSession: existing.providerSession,
+      payload: {
+        state: 'done',
+        prompt: payload.prompt,
+        agentType: payload.agentType,
+        ...(payload.model ? { model: payload.model } : {}),
+        interrupted: true,
+        ...(payload.subagents ? { subagents: payload.subagents } : {})
+      }
+    })
+    console.debug('[agent-hooks] inferred denied permission status', {
       paneKey: inferred.paneKey,
       state: inferred.payload.state
     })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -221,6 +221,7 @@ import {
 } from './claude-accounts/live-pty-gate'
 import { StarNagService } from './star-nag/service'
 import { agentHookServer, type AgentHookProviderSessionIdentity } from './agent-hooks/server'
+import { installClaudePermissionDenyTranscriptWatch } from './agent-hooks/claude-permission-deny-transcript-watch'
 import { createHookProviderSessionInvalidator } from './agent-hooks/hook-provider-session-invalidation'
 import { wslHookRelayManager } from './agent-hooks/wsl-hook-relay-manager'
 import { maybeAutoRenameBranchOnFirstWork } from './agent-hooks/first-work-branch-rename'
@@ -836,6 +837,9 @@ function startTerminalRuntimeStartupServices(): Promise<void> {
         userDataPath: app.getPath('userData'),
         endpointNamespace: devAgentHookEndpointNamespace
       })
+      // Why: denying a Claude permission emits no hook; the transcript's
+      // rejected tool_result is the structural deny signal for local panes.
+      installClaudePermissionDenyTranscriptWatch(agentHookServer)
       logStartupMilestone('startup-service-done', { service: 'agent-hook-server' })
     },
     onDaemonError: (error) => {

--- a/src/shared/claude-permission-deny-intent.test.ts
+++ b/src/shared/claude-permission-deny-intent.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { isClaudeToolPermissionWait } from './claude-permission-deny-intent'
+
+describe('isClaudeToolPermissionWait', () => {
+  it('matches a real Claude tool-permission wait', () => {
+    expect(
+      isClaudeToolPermissionWait({ state: 'waiting', agentType: 'claude', toolName: 'Write' })
+    ).toBe(true)
+  })
+
+  it('rejects AskUserQuestion waits, other states, and other agents', () => {
+    expect(
+      isClaudeToolPermissionWait({
+        state: 'waiting',
+        agentType: 'claude',
+        toolName: 'AskUserQuestion'
+      })
+    ).toBe(false)
+    expect(
+      isClaudeToolPermissionWait({ state: 'working', agentType: 'claude', toolName: 'Write' })
+    ).toBe(false)
+    expect(
+      isClaudeToolPermissionWait({ state: 'waiting', agentType: 'codex', toolName: 'Write' })
+    ).toBe(false)
+  })
+})

--- a/src/shared/claude-permission-deny-intent.ts
+++ b/src/shared/claude-permission-deny-intent.ts
@@ -1,0 +1,28 @@
+import type { AgentType } from './agent-status-types'
+import { isAskUserQuestionTool } from './agent-question-answered-intent'
+
+/** Baseline snapshot captured when the transcript watch observed the deny.
+ *  The hook server re-validates every field against its own cached status so
+ *  a racing real hook always wins over the inference. */
+export type ClaudePermissionDenyInferenceRequest = {
+  paneKey: string
+  baselineUpdatedAt: number
+  baselineStateStartedAt: number
+  baselinePrompt: string
+  baselineAgentType: AgentType | undefined
+}
+
+/** A real tool-permission wait — the sticky kind no hook clears on deny.
+ *  AskUserQuestion also arrives as PermissionRequest on newer Claude, so tool
+ *  name (not hook event) discriminates; questions clear via their own inference. */
+export function isClaudeToolPermissionWait(entry: {
+  state: string
+  agentType?: string
+  toolName?: string
+}): boolean {
+  return (
+    entry.state === 'waiting' &&
+    entry.agentType === 'claude' &&
+    !isAskUserQuestionTool(entry.toolName)
+  )
+}


### PR DESCRIPTION
## Summary

Denying a Claude Code permission request (Esc / "No") emits **no hook event**, so the pane's agent status stayed stuck in `waiting` ("needs permission") until the next prompt or the 30-minute staleness cutoff. User-visible symptom: after denying a permission, review-note send targets ("send to session") stay grayed out with "Agent needs permission" even though the agent is idle.

Fix: watch the Claude session transcript for the structural deny signal. A denied tool never runs, so an `is_error` `tool_result` for the pending `tool_use_id` can only mean the user rejected it (an approved tool resumes through PreToolUse first, which replaces the waiting entry and invalidates the baseline). When the deny record appears, the hook server re-validates the captured baseline (paneKey, prompt, agentType, timestamps) and heals the status to `done` + `interrupted` — a racing real hook always wins.

Delivery is fs.watch-driven (reusing `createTranscriptNativeWatcher`) with no polling fallback: this is best-effort healing, so if a watch cannot bind or the filesystem never delivers events, the pane keeps the pre-existing behavior. Watchers exist only while a Claude tool-permission wait is active and are released on heal, replacement, or the staleness deadline.

## Screenshots

No visual change (existing send-target rows simply become clickable once the status heals, driven by already-covered derivation logic).

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build` (additionally verified via `pnpm build:mac`: the packaged app contains the watcher and was used for the real-binary verification below)
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

New tests:
- `claude-permission-deny-transcript-watch.test.ts` (11): real temp transcripts — fs.watch-only detection, append detection, backscan of a deny already on disk, different-`tool_use_id` and success-result ignored, newer status stops the watcher, no-watch guards (no tool_use_id / remote pane / no transcript path / AskUserQuestion), bind-failure gives up without polling, dispose.
- `server.claude-permission-deny.test.ts` (5): heals to done+interrupted through `ingestRemote`, next UserPromptSubmit revives the pane, refuses AskUserQuestion / stale-baseline / non-waiting entries.
- `claude-permission-deny-intent.test.ts` (2): wait-classification guard.

Manually verified end to end against a **real `claude` binary** (2.1.233) driven inside an Orca e2e instance: real PermissionRequest → pane `waiting` → Esc deny (zero hook events) → status healed to `done`+`interrupted` within seconds via the transcript watch, and the denied file was never written. (The throwaway spec was intentionally not kept in-tree.)

## AI Review Report

Review focus and outcomes:

- **Correctness of the deny signal**: verified against a captured real transcript that a deny writes `{type:"user", message.content[]: {type:"tool_result", tool_use_id, is_error:true}}`; approval replaces the waiting entry via PreToolUse before any tool_result lands, so false positives require both a matching `tool_use_id` and a stale-proof baseline match, which the server re-validates before applying. AskUserQuestion waits are excluded by tool name (they clear via the existing answered-question inference).
- **Race safety**: a 1.5 s settle window lets a racing PostToolUse/PreToolUse hook land first; the server-side baseline check (agentType/prompt/receivedAt/stateStartedAt + freshness) makes the inference lose to any newer real event. Watcher lifecycle is subscription-driven; a newer status for the pane stops it.
- **Cross-platform (macOS/Linux/Windows)**: file access uses `node:fs` promises with paths taken verbatim from hook payloads (no separator assumptions); `createTranscriptNativeWatcher` is the existing cross-platform primitive (watches the parent directory, survives file replacement, unref'd so it never blocks shutdown). No shortcuts, labels, or shell behavior involved. Windows panes work like other local panes; WSL transcript paths are unreadable from the host process, fail `stat`/bind, and the watcher releases without side effects.
- **SSH/remote and folder workspaces**: remote panes are excluded up front (`connectionId !== null`), documented as a known limit — they keep today's behavior. No git or workspace-type assumptions; the watcher keys on pane identity only.
- **Agent/provider neutrality**: strictly scoped to `agentType === 'claude'` tool-permission waits; no other agent's pipeline is touched.
- **Performance**: watchers exist only during a Claude permission wait (rare, short-lived, one per pane); no periodic polling — fs events coalesce through a 25 ms debounce; reads are incremental from a stored offset with a 64 KB backscan cap and a 512 KB partial-line cap.

## Security Audit

- **Input handling**: transcript lines are parsed with a cheap substring pre-filter, then `JSON.parse` inside try/catch; malformed or hostile lines are ignored. Reads are bounded (64 KB backscan, offset-ranged incremental reads, 512 KB pending-line cap), so a huge transcript cannot balloon memory.
- **Path handling**: the watched path comes from Claude's own hook payload (`transcript_path`) delivered over the token-authenticated localhost hook endpoint; it is only ever read, never written or executed, and only for local panes.
- **No command execution, no new IPC surface, no new dependencies, no secrets.** The inference entry point is an internal main-process method (not exposed to the renderer), and applying it requires an exact baseline match on server-held state.
- Failure modes are fail-safe: unreadable/missing transcript → watcher gives up and the pane keeps the pre-existing (pre-fix) behavior.

## Notes

- Known limit (documented in the module): panes whose transcript this process cannot read — SSH remotes and WSL — keep the stuck waiting state until the next prompt or staleness. The clean upstream fix would be a Claude Code hook fired on permission decision; this PR is the structural workaround available today.
- The deny signal depends on Claude Code continuing to record rejected tools as `is_error` tool_results in the transcript. The failure mode if that ever changes is the pre-existing behavior (stuck until next prompt/staleness), not a wrong status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
