### PR TITLE
fix(relay): let one owner hold pty.ackData instead of relying on construction order

### DIFF
--- a/src/relay/dispatcher-notification-ownership.test.ts
+++ b/src/relay/dispatcher-notification-ownership.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from 'vitest'
+import { RelayDispatcher } from './dispatcher'
+
+describe('RelayDispatcher notification ownership', () => {
+  it('refuses a second handler for a method instead of silently shadowing the first', () => {
+    const dispatcher = new RelayDispatcher(() => {})
+    const owner = vi.fn()
+
+    dispatcher.onNotification('pty.ackData', owner)
+
+    // Why: the slot holds one handler, so a second registration used to win purely by
+    // construction order — that is how a no-op ack handler nearly disabled credit acks.
+    expect(() => dispatcher.onNotification('pty.ackData', vi.fn())).toThrow(/already registered/)
+
+    // Why: the constructor arms a keepalive interval that would outlive the test.
+    dispatcher.dispose()
+  })
+})

--- a/src/relay/dispatcher.ts
+++ b/src/relay/dispatcher.ts
@@ -212,7 +212,14 @@ export class RelayDispatcher {
     this.requestHandlers.set(method, handler)
   }
 
+  // Why it throws: this is a single slot, so a second registration silently shadows the
+  // first and which one survives depends only on construction order. `pty.ackData` shipped
+  // that way — a no-op handler was saved from disabling credit acks purely by the adapter
+  // being constructed second (STA-4571). Fail loudly instead of encoding that ordering.
   onNotification(method: string, handler: NotificationHandler): void {
+    if (this.notificationHandlers.has(method)) {
+      throw new Error(`Notification handler for ${method} is already registered`)
+    }
     this.notificationHandlers.set(method, handler)
   }
 

--- a/src/relay/pty-handler-spawn-admission.test.ts
+++ b/src/relay/pty-handler-spawn-admission.test.ts
@@ -79,7 +79,10 @@ describe('PtyHandler', () => {
     const notifMethods = Array.from(dispatcher._notificationHandlers.keys())
     expect(notifMethods).toContain('pty.data')
     expect(notifMethods).toContain('pty.resize')
-    expect(notifMethods).toContain('pty.ackData')
+    // Why not `toContain('pty.ackData')`: PtyHandler must NOT own that method. It used to
+    // register a no-op here, which survived only because the consumer session adapter was
+    // constructed later and overwrote it (STA-4571).
+    expect(notifMethods).not.toContain('pty.ackData')
   })
 
   it('rejects strict process inspection for a missing relay PTY', async () => {

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -882,9 +882,6 @@ export class PtyHandler {
 
     this.dispatcher.onNotification('pty.data', (p) => this.writeData(p))
     this.dispatcher.onNotification('pty.resize', (p) => this.resize(p))
-    this.dispatcher.onNotification('pty.ackData', (_p) => {
-      /* flow control ack -- not yet enforced */
-    })
   }
 
   private isLikelyInteractiveRedraw(data: string): boolean {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​22 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​21 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 |

<!-- /orca-pr-loc -->

## ELI5

Two different places both told the relay "call me when a `pty.ackData` arrives." Only one of them can win, because that registration is a single slot — and the winner is simply whichever registered last. Today the *real* handler wins by luck of construction order. The loser is a do-nothing stub. Swap two lines in `relay.ts` and terminal output over SSH stops forever after 256 KB, with no error and no log.

This deletes the stub and makes registering twice an immediate, loud error instead of a silent coin flip.

## What Changed

- Deleted the no-op `pty.ackData` registration in `PtyHandler` (`src/relay/pty-handler.ts`). The real handler lives in `SshPtyConsumerSessionAdapter` and calls `sourceCredit.acknowledge(...)`.
- `RelayDispatcher.onNotification` now throws on a duplicate registration, matching the single-owner guard `registerPtyDataPublicationAdmission` already has (`dispatcher.ts:229-241`).
- Moved the new guard test into its own `dispatcher-notification-ownership.test.ts` — adding it to `dispatcher.test.ts` pushed that file over the 800-line cap, and a `max-lines` disable is not acceptable.

## Why

`onNotification` is `notificationHandlers.set(method, handler)` — one slot, last write wins. `PtyHandler` registers a no-op; `SshPtyConsumerSessionAdapter` registers the real credit acknowledgement. It works only because `relay.ts:699-705` constructs the adapter second.

If that order ever flips, `creditedEndSu` never advances, `reserveNextSend` returns `null` once the 256 KB window is exhausted, and every credit-mode delivery wedges permanently. Silent, and hard to trace back.

I verified `pty.ackData` is the **only** double-registered method in the tree, so making the guard strict changes no other behavior.

## Linked Issue

Fixes STA-4571

## Visual Proof

`N/A` — no UI surface. This is relay handler registration; the observable difference is an error at construction time instead of a silently shadowed handler.

## Testing

- Full relay suite: **133 files / 1363 tests pass.**
- `pnpm tc` exit 0.
- `oxfmt` + `oxlint` clean.

Both guards mutation-verified:

| mutation | caught by |
|---|---|
| strict duplicate guard removed | `dispatcher-notification-ownership.test.ts` |
| no-op `pty.ackData` re-added to `PtyHandler` | `pty-handler-spawn-admission.test.ts` — "registers all expected handlers" |

**The existing test could not have caught this.** `pty-handler-spawn-admission.test.ts:82` asserted only `expect(notifMethods).toContain('pty.ackData')` — true whether the handler is real or a shadowed stub. It now asserts `PtyHandler` does **not** own the method, which is the actual contract.

One transient failure during development (`subprocess.test.ts`, "uses configured grace after a detached relay has accepted a socket client") turned out to be a load-induced flake, not this change: it spawns a real subprocess against a 10s timeout while a mobile QA rig was running on the same machine. Confirmed by reverting to a pristine tree (passed), restoring the change (passed), and a clean full-suite run.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

- **Backwards compatibility:** no wire change, no protocol change. `pty.ackData` behaves exactly as it does today; only the dead registration is gone.
- **Blast radius of the strict guard:** verified `pty.ackData` was the sole duplicate across non-test source. Any future duplicate now fails loudly at construction rather than shipping a coin flip.
- **Cross-platform / SSH:** this is the SSH relay path specifically. Behavior is unchanged on the winning path; the fix removes the way it could silently lose.
- Found while investigating STA-4510 (#14992). Not that bug — mobile never traverses the relay pty path — and deliberately kept out of that PR.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @BrennanKB5
