### PR TITLE
fix(linux): give the CLI one entrypoint by extracting the AppImage once

### DIFF
--- a/config/scripts/package-electron-runtime-contract.test.mjs
+++ b/config/scripts/package-electron-runtime-contract.test.mjs
@@ -363,6 +363,10 @@ describe('Electron runtime package contract', () => {
     expect(afterInstallScript).toContain('chrome-sandbox')
     expect(afterInstallScript).toContain('chmod 4755 "$sandbox"')
     expect(afterInstallScript).not.toContain('chmod 0755 "$sandbox"')
+    expect(afterInstallScript).toContain('is_owned_link()')
+    expect(afterInstallScript).toContain('readlink -f -- "$link"')
+    expect(afterInstallScript).toContain('[ ! -e "$link" ] && [ ! -L "$link" ]')
+    expect(afterInstallScript).not.toContain('[ ! -e "$link" ] || [ -L "$link" ]')
   })
 
   it('advances only the skill release ledger in a taggable release-cut commit', () => {

--- a/docs/reference/headless-linux-server.md
+++ b/docs/reference/headless-linux-server.md
@@ -58,11 +58,23 @@ FUSE. On Ubuntu 24.04 and Debian 13 the package is `libfuse2t64`, though the pla
 `libfuse2` name also resolves there because nothing else provides it. FUSE is
 optional: without it, use the AppImage's supported extraction path. CLI
 registration does this once automatically, so registered commands do not need
-FUSE:
+FUSE.
+
+Download and make the AppImage executable:
+
+```bash
+sudo mkdir -p /opt/orca
+sudo curl -L https://github.com/stablyai/orca/releases/latest/download/orca-linux.AppImage \
+  -o /opt/orca/orca-linux.AppImage
+sudo chmod +x /opt/orca/orca-linux.AppImage
+```
+
+To extract it without FUSE, run the extraction as root because the installation
+directory is root-owned:
 
 ```bash
 cd /opt/orca
-./orca-linux.AppImage --appimage-extract
+sudo ./orca-linux.AppImage --appimage-extract
 sudo chmod -R a+rX /opt/orca/squashfs-root
 /opt/orca/squashfs-root/AppRun serve --port 6768
 ```
@@ -77,15 +89,6 @@ Docker commonly has no FUSE device. Use `--appimage-extract` once or
 extract-and-run wrapper can print extracted paths before Orca starts, so
 automation that requires stdout to contain only the ready JSON should extract
 once and invoke `squashfs-root/AppRun`.
-
-Download and make the AppImage executable:
-
-```bash
-sudo mkdir -p /opt/orca
-sudo curl -L https://github.com/stablyai/orca/releases/latest/download/orca-linux.AppImage \
-  -o /opt/orca/orca-linux.AppImage
-sudo chmod +x /opt/orca/orca-linux.AppImage
-```
 
 If `Xvfb` was installed somewhere other than `/usr/bin`, confirm systemd can
 find it later:

--- a/docs/reference/headless-linux-server.md
+++ b/docs/reference/headless-linux-server.md
@@ -56,7 +56,9 @@ of the libraries installed.
 On Ubuntu 20.04 and 22.04, install `libfuse2` to execute the AppImage through
 FUSE. On Ubuntu 24.04 and Debian 13 the package is `libfuse2t64`, though the plain
 `libfuse2` name also resolves there because nothing else provides it. FUSE is
-optional: without it, use the AppImage's supported extraction path:
+optional: without it, use the AppImage's supported extraction path. CLI
+registration does this once automatically, so registered commands do not need
+FUSE:
 
 ```bash
 cd /opt/orca

--- a/resources/linux/packaging/after-install.sh
+++ b/resources/linux/packaging/after-install.sh
@@ -11,6 +11,19 @@ set -e
 
 link="/usr/bin/orca-ide"
 
+is_owned_link() {
+  [ -L "$link" ] || return 1
+  local link_target candidate candidate_target
+  link_target="$(readlink -f -- "$link" 2>/dev/null || true)"
+  for candidate in /opt/Orca/resources/bin/orca-ide /opt/orca-ide/resources/bin/orca-ide /opt/orca/resources/bin/orca-ide; do
+    candidate_target="$(readlink -f -- "$candidate" 2>/dev/null || true)"
+    if [ -n "$candidate_target" ] && [ "$link_target" = "$candidate_target" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 for dir in /opt/Orca /opt/orca-ide /opt/orca; do
   sandbox="$dir/chrome-sandbox"
   if [ -f "$sandbox" ]; then
@@ -22,8 +35,8 @@ for dir in /opt/Orca /opt/orca-ide /opt/orca; do
   shim="$dir/resources/bin/orca-ide"
   if [ -x "$shim" ]; then
     # Only manage our own symlink; never clobber an unrelated /usr/bin/orca-ide.
-    if [ ! -e "$link" ] || [ -L "$link" ]; then
-      ln -sf "$shim" "$link"
+    if { [ ! -e "$link" ] && [ ! -L "$link" ]; } || is_owned_link; then
+      ln -sfn -- "$shim" "$link"
     fi
     break
   fi

--- a/src/main/appimage-runtime-identity.test.ts
+++ b/src/main/appimage-runtime-identity.test.ts
@@ -73,8 +73,7 @@ describe.skipIf(process.platform === 'win32')('resolveAppImageRuntimeIdentity', 
   ])('accepts a complete %s AppImage runtime', (_architecture, machine, appDirName) => {
     const fixture = createFixture(appDirName, machine)
     expect(resolveAppImageRuntimeIdentity(fixture.identity)).toEqual({
-      appImagePath: fixture.appImagePath,
-      appDirPath: fixture.appDirPath
+      appImagePath: fixture.appImagePath
     })
   })
 

--- a/src/main/appimage-runtime-identity.test.ts
+++ b/src/main/appimage-runtime-identity.test.ts
@@ -1,0 +1,241 @@
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  hasAppImageRuntimeEnvironment,
+  resolveAppImageRuntimeIdentity
+} from './appimage-runtime-identity'
+
+const fixtureRoots: string[] = []
+
+function appImageHeader(machine: number): Buffer {
+  const header = Buffer.alloc(64)
+  header.set([0x7f, 0x45, 0x4c, 0x46, 0x02, 0x01, 0x01])
+  header.set([0x41, 0x49, 0x02], 8)
+  header.writeUInt16LE(machine, 18)
+  return header
+}
+
+function createFixture(appDirName = '.mount_Orca123', machine = 0x3e) {
+  const root = mkdtempSync(join(tmpdir(), 'orca-appimage-identity-'))
+  const appImagePath = join(root, 'Applications', 'Orca.AppImage')
+  const appDirPath = join(root, appDirName)
+  const execPath = join(appDirPath, 'orca-ide')
+  const resourcesPath = join(appDirPath, 'resources')
+  const packageTypePath = join(resourcesPath, 'package-type')
+  const packageMarkerPath = join(resourcesPath, 'app.asar.unpacked', 'out', 'package.json')
+  fixtureRoots.push(root)
+  mkdirSync(dirname(appImagePath), { recursive: true })
+  mkdirSync(dirname(packageMarkerPath), { recursive: true })
+  writeFileSync(appImagePath, appImageHeader(machine), { mode: 0o755 })
+  writeFileSync(join(appDirPath, 'AppRun'), '#!/bin/sh\n', { mode: 0o755 })
+  writeFileSync(execPath, appImageHeader(machine), { mode: 0o755 })
+  writeFileSync(
+    packageMarkerPath,
+    JSON.stringify({ name: 'orca-compiled-output', type: 'commonjs', private: true })
+  )
+  return {
+    root,
+    appImagePath,
+    appDirPath,
+    execPath,
+    resourcesPath,
+    packageTypePath,
+    packageMarkerPath,
+    identity: {
+      platform: 'linux' as const,
+      environment: { APPIMAGE: appImagePath, APPDIR: appDirPath },
+      execPath,
+      resourcesPath
+    }
+  }
+}
+
+afterEach(() => {
+  for (const root of fixtureRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+describe.skipIf(process.platform === 'win32')('resolveAppImageRuntimeIdentity', () => {
+  it.each([
+    ['x64', 0x3e, '.mount_Orca123'],
+    ['ARM64 extract-and-run', 0xb7, 'appimage_extracted_123']
+  ])('accepts a complete %s AppImage runtime', (_architecture, machine, appDirName) => {
+    const fixture = createFixture(appDirName, machine)
+    expect(resolveAppImageRuntimeIdentity(fixture.identity)).toEqual({
+      appImagePath: fixture.appImagePath,
+      appDirPath: fixture.appDirPath
+    })
+  })
+
+  it('accepts an AppImage moved independently of its runtime directory', () => {
+    const fixture = createFixture()
+    const movedPath = join(fixture.root, 'Moved Apps', 'Orca current.AppImage')
+    mkdirSync(dirname(movedPath), { recursive: true })
+    renameSync(fixture.appImagePath, movedPath)
+    fixture.identity.environment.APPIMAGE = movedPath
+    expect(resolveAppImageRuntimeIdentity(fixture.identity)?.appImagePath).toBe(movedPath)
+  })
+
+  it('accepts the exact AppImage package-type marker', () => {
+    const fixture = createFixture()
+    rmSync(fixture.packageMarkerPath)
+    writeFileSync(fixture.packageTypePath, 'AppImage')
+    expect(resolveAppImageRuntimeIdentity(fixture.identity)).not.toBeNull()
+  })
+
+  it.each([
+    ['APPIMAGE', undefined],
+    ['APPIMAGE', 'relative/Orca.AppImage'],
+    ['APPDIR', undefined],
+    ['APPDIR', 'relative/mount'],
+    ['APPIMAGE', '/tmp/Orca\0.AppImage']
+  ] as const)('rejects an unusable %s value', (key, value) => {
+    const fixture = createFixture()
+    expect(
+      resolveAppImageRuntimeIdentity({
+        ...fixture.identity,
+        environment: { ...fixture.identity.environment, [key]: value }
+      })
+    ).toBeNull()
+  })
+
+  it.each([
+    ['an ordinary executable', (path: string) => writeFileSync(path, '#!/bin/sh\n')],
+    [
+      'bad ELF magic',
+      (path: string) => {
+        const header = appImageHeader(0x3e)
+        header[0] = 0
+        writeFileSync(path, header)
+      }
+    ],
+    [
+      'bad AppImage type magic',
+      (path: string) => {
+        const header = appImageHeader(0x3e)
+        header[10] = 1
+        writeFileSync(path, header)
+      }
+    ],
+    ['a non-executable file', (path: string) => chmodSync(path, 0o644)],
+    [
+      'a directory',
+      (path: string) => {
+        rmSync(path)
+        mkdirSync(path)
+      }
+    ]
+  ])('rejects APPIMAGE pointing to %s', (_case, mutate) => {
+    const fixture = createFixture()
+    mutate(fixture.appImagePath)
+    expect(resolveAppImageRuntimeIdentity(fixture.identity)).toBeNull()
+  })
+
+  it.each([
+    [
+      'AppRun',
+      (fixture: ReturnType<typeof createFixture>) => rmSync(join(fixture.appDirPath, 'AppRun'))
+    ],
+    [
+      'an executable AppRun',
+      (fixture: ReturnType<typeof createFixture>) =>
+        chmodSync(join(fixture.appDirPath, 'AppRun'), 0o644)
+    ],
+    [
+      'the Orca package marker',
+      (fixture: ReturnType<typeof createFixture>) => rmSync(fixture.packageMarkerPath)
+    ]
+  ])('rejects a runtime missing %s', (_case, mutate) => {
+    const fixture = createFixture()
+    mutate(fixture)
+    expect(resolveAppImageRuntimeIdentity(fixture.identity)).toBeNull()
+  })
+
+  it('rejects forged AppImage variables around an ordinary packaged layout', () => {
+    const fixture = createFixture()
+    rmSync(join(fixture.appDirPath, 'AppRun'))
+    expect(resolveAppImageRuntimeIdentity(fixture.identity)).toBeNull()
+  })
+
+  it('rejects a package marker for a different application', () => {
+    const fixture = createFixture()
+    writeFileSync(
+      fixture.packageMarkerPath,
+      JSON.stringify({ name: 'foreign-compiled-output', type: 'commonjs' })
+    )
+    expect(resolveAppImageRuntimeIdentity(fixture.identity)).toBeNull()
+  })
+
+  it('rejects an inexact package-type marker without the Orca fallback', () => {
+    const fixture = createFixture()
+    rmSync(fixture.packageMarkerPath)
+    writeFileSync(fixture.packageTypePath, 'appimage')
+    expect(resolveAppImageRuntimeIdentity(fixture.identity)).toBeNull()
+  })
+
+  it('rejects payload evidence that resolves outside APPDIR', () => {
+    const fixture = createFixture()
+    const externalAppRun = join(fixture.root, 'foreign-AppRun')
+    writeFileSync(externalAppRun, '#!/bin/sh\n', { mode: 0o755 })
+    rmSync(join(fixture.appDirPath, 'AppRun'))
+    symlinkSync(externalAppRun, join(fixture.appDirPath, 'AppRun'))
+    expect(resolveAppImageRuntimeIdentity(fixture.identity)).toBeNull()
+  })
+
+  it('rejects a package marker that resolves outside APPDIR', () => {
+    const fixture = createFixture()
+    const externalMarker = join(fixture.root, 'foreign-package.json')
+    writeFileSync(
+      externalMarker,
+      JSON.stringify({ name: 'orca-compiled-output', type: 'commonjs' })
+    )
+    rmSync(fixture.packageMarkerPath)
+    symlinkSync(externalMarker, fixture.packageMarkerPath)
+    expect(resolveAppImageRuntimeIdentity(fixture.identity)).toBeNull()
+  })
+
+  it('rejects inherited AppImage variables around a non-AppImage executable', () => {
+    const fixture = createFixture()
+    expect(
+      resolveAppImageRuntimeIdentity({
+        ...fixture.identity,
+        execPath: join(fixture.root, 'opt', 'Orca', 'orca-ide'),
+        resourcesPath: join(fixture.root, 'opt', 'Orca', 'resources')
+      })
+    ).toBeNull()
+  })
+
+  it('rejects a resources path outside the runtime root', () => {
+    const fixture = createFixture()
+    expect(
+      resolveAppImageRuntimeIdentity({
+        ...fixture.identity,
+        resourcesPath: `${fixture.appDirPath}-other/resources`
+      })
+    ).toBeNull()
+  })
+
+  it('rejects the identity off Linux', () => {
+    const fixture = createFixture()
+    expect(resolveAppImageRuntimeIdentity({ ...fixture.identity, platform: 'darwin' })).toBeNull()
+  })
+})
+
+describe('hasAppImageRuntimeEnvironment', () => {
+  it('detects either AppImage runtime variable', () => {
+    expect(hasAppImageRuntimeEnvironment({ APPIMAGE: '/tmp/Orca.AppImage' })).toBe(true)
+    expect(hasAppImageRuntimeEnvironment({ APPDIR: '/tmp/.mount_Orca123' })).toBe(true)
+    expect(hasAppImageRuntimeEnvironment({ APPIMAGE: '', APPDIR: '' })).toBe(false)
+  })
+})

--- a/src/main/appimage-runtime-identity.test.ts
+++ b/src/main/appimage-runtime-identity.test.ts
@@ -11,7 +11,7 @@ import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import {
-  hasAppImageRuntimeEnvironment,
+  hasAppImagePathEnvironment,
   resolveAppImageRuntimeIdentity
 } from './appimage-runtime-identity'
 
@@ -231,10 +231,10 @@ describe.skipIf(process.platform === 'win32')('resolveAppImageRuntimeIdentity', 
   })
 })
 
-describe('hasAppImageRuntimeEnvironment', () => {
-  it('detects either AppImage runtime variable', () => {
-    expect(hasAppImageRuntimeEnvironment({ APPIMAGE: '/tmp/Orca.AppImage' })).toBe(true)
-    expect(hasAppImageRuntimeEnvironment({ APPDIR: '/tmp/.mount_Orca123' })).toBe(true)
-    expect(hasAppImageRuntimeEnvironment({ APPIMAGE: '', APPDIR: '' })).toBe(false)
+describe('hasAppImagePathEnvironment', () => {
+  it('requires the AppImage file path before treating the runtime as verifiable', () => {
+    expect(hasAppImagePathEnvironment({ APPIMAGE: '/tmp/Orca.AppImage' })).toBe(true)
+    expect(hasAppImagePathEnvironment({ APPDIR: '/tmp/.mount_Orca123' })).toBe(false)
+    expect(hasAppImagePathEnvironment({ APPIMAGE: '', APPDIR: '/tmp/.mount_Orca123' })).toBe(false)
   })
 })

--- a/src/main/appimage-runtime-identity.ts
+++ b/src/main/appimage-runtime-identity.ts
@@ -1,0 +1,198 @@
+import {
+  closeSync,
+  constants,
+  fstatSync,
+  openSync,
+  readSync,
+  realpathSync,
+  statSync,
+  type Stats
+} from 'node:fs'
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
+
+const APPIMAGE_HEADER_LENGTH = 11
+const ORCA_PACKAGE_MARKER_MAX_BYTES = 1_024
+const PACKAGE_TYPE_MARKER_MAX_BYTES = 32
+
+export type AppImageRuntimeIdentity = {
+  appImagePath: string
+  appDirPath: string
+}
+
+export type AppImageRuntimeIdentityInput = {
+  platform?: NodeJS.Platform
+  environment?: NodeJS.ProcessEnv
+  execPath?: unknown
+  resourcesPath?: unknown
+}
+
+function isAbsolutePath(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0 && !value.includes('\0') && isAbsolute(value)
+}
+
+function readExact(fd: number, length: number): Buffer | null {
+  const bytes = Buffer.alloc(length)
+  let offset = 0
+  while (offset < length) {
+    const count = readSync(fd, bytes, offset, length - offset, offset)
+    if (count === 0) {
+      return null
+    }
+    offset += count
+  }
+  return bytes
+}
+
+function inspectRegularFile<T>(
+  filePath: string,
+  inspect: (fd: number, stats: Stats) => T
+): T | null {
+  let fd: number | undefined
+  try {
+    fd = openSync(filePath, constants.O_RDONLY | constants.O_NONBLOCK)
+    const stats = fstatSync(fd)
+    return stats.isFile() ? inspect(fd, stats) : null
+  } catch {
+    return null
+  } finally {
+    if (fd !== undefined) {
+      closeSync(fd)
+    }
+  }
+}
+
+function hasAppImageHeader(appImagePath: string): boolean {
+  return (
+    inspectRegularFile(appImagePath, (fd, stats) => {
+      const header = readExact(fd, APPIMAGE_HEADER_LENGTH)
+      return (
+        (stats.mode & 0o111) !== 0 &&
+        header?.subarray(0, 4).equals(Buffer.from([0x7f, 0x45, 0x4c, 0x46])) === true &&
+        header.subarray(8, 11).equals(Buffer.from([0x41, 0x49, 0x02]))
+      )
+    }) === true
+  )
+}
+
+function isInside(rootPath: string, candidatePath: string): boolean {
+  const candidateRelative = relative(rootPath, candidatePath)
+  return (
+    candidateRelative.length > 0 &&
+    candidateRelative !== '..' &&
+    !candidateRelative.startsWith(`..${sep}`) &&
+    !isAbsolute(candidateRelative)
+  )
+}
+
+function isExecutablePayloadFile(runtimeRoot: string, filePath: string): boolean {
+  try {
+    const canonicalPath = realpathSync(filePath)
+    const stats = statSync(canonicalPath)
+    return stats.isFile() && (stats.mode & 0o111) !== 0 && isInside(runtimeRoot, canonicalPath)
+  } catch {
+    return false
+  }
+}
+
+function readPayloadMarker(
+  runtimeRoot: string,
+  markerPath: string,
+  maxBytes: number
+): string | null {
+  try {
+    const canonicalPath = realpathSync(markerPath)
+    if (!isInside(runtimeRoot, canonicalPath)) {
+      return null
+    }
+    return inspectRegularFile(canonicalPath, (fd, stats) =>
+      stats.size === 0 || stats.size > maxBytes
+        ? null
+        : (readExact(fd, stats.size)?.toString('utf8') ?? null)
+    )
+  } catch {
+    return null
+  }
+}
+
+function hasAppImagePackageEvidence(runtimeRoot: string, resourcesPath: string): boolean {
+  const packageType = readPayloadMarker(
+    runtimeRoot,
+    join(resourcesPath, 'package-type'),
+    PACKAGE_TYPE_MARKER_MAX_BYTES
+  )
+  if (packageType === 'AppImage') {
+    return true
+  }
+
+  const content = readPayloadMarker(
+    runtimeRoot,
+    join(resourcesPath, 'app.asar.unpacked', 'out', 'package.json'),
+    ORCA_PACKAGE_MARKER_MAX_BYTES
+  )
+  try {
+    const marker: unknown = JSON.parse(content ?? '')
+    return (
+      typeof marker === 'object' &&
+      marker !== null &&
+      'name' in marker &&
+      marker.name === 'orca-compiled-output' &&
+      'type' in marker &&
+      marker.type === 'commonjs'
+    )
+  } catch {
+    return false
+  }
+}
+
+export function hasAppImageRuntimeEnvironment(
+  environment: NodeJS.ProcessEnv = process.env
+): boolean {
+  return Boolean(environment.APPIMAGE || environment.APPDIR)
+}
+
+export function resolveAppImageRuntimeIdentity(
+  input: AppImageRuntimeIdentityInput = {}
+): AppImageRuntimeIdentity | null {
+  if ((input.platform ?? process.platform) !== 'linux') {
+    return null
+  }
+
+  const environment = input.environment ?? process.env
+  const appImagePath = environment.APPIMAGE
+  const appDirPath = environment.APPDIR
+  const execPath = input.execPath ?? process.execPath
+  const resourcesPath = input.resourcesPath ?? process.resourcesPath
+  if (
+    !isAbsolutePath(appImagePath) ||
+    !isAbsolutePath(appDirPath) ||
+    !isAbsolutePath(execPath) ||
+    !isAbsolutePath(resourcesPath)
+  ) {
+    return null
+  }
+
+  const runtimeRoot = resolve(appDirPath)
+  if (
+    resolve(dirname(execPath)) !== runtimeRoot ||
+    resolve(resourcesPath) !== resolve(join(runtimeRoot, 'resources')) ||
+    !hasAppImageHeader(appImagePath)
+  ) {
+    return null
+  }
+
+  try {
+    const realRuntimeRoot = realpathSync(runtimeRoot)
+    if (
+      realpathSync(resourcesPath) !== join(realRuntimeRoot, 'resources') ||
+      !isExecutablePayloadFile(realRuntimeRoot, execPath) ||
+      !isExecutablePayloadFile(realRuntimeRoot, join(runtimeRoot, 'AppRun')) ||
+      !hasAppImagePackageEvidence(realRuntimeRoot, resourcesPath)
+    ) {
+      return null
+    }
+  } catch {
+    return null
+  }
+
+  return { appImagePath, appDirPath: runtimeRoot }
+}

--- a/src/main/appimage-runtime-identity.ts
+++ b/src/main/appimage-runtime-identity.ts
@@ -16,7 +16,6 @@ const PACKAGE_TYPE_MARKER_MAX_BYTES = 32
 
 export type AppImageRuntimeIdentity = {
   appImagePath: string
-  appDirPath: string
 }
 
 export type AppImageRuntimeIdentityInput = {
@@ -194,5 +193,5 @@ export function resolveAppImageRuntimeIdentity(
     return null
   }
 
-  return { appImagePath, appDirPath: runtimeRoot }
+  return { appImagePath }
 }

--- a/src/main/appimage-runtime-identity.ts
+++ b/src/main/appimage-runtime-identity.ts
@@ -143,10 +143,9 @@ function hasAppImagePackageEvidence(runtimeRoot: string, resourcesPath: string):
   }
 }
 
-export function hasAppImageRuntimeEnvironment(
-  environment: NodeJS.ProcessEnv = process.env
-): boolean {
-  return Boolean(environment.APPIMAGE || environment.APPDIR)
+/** Returns whether the process inherited an AppImage file path to validate. */
+export function hasAppImagePathEnvironment(environment: NodeJS.ProcessEnv = process.env): boolean {
+  return Boolean(environment.APPIMAGE)
 }
 
 export function resolveAppImageRuntimeIdentity(

--- a/src/main/cli/appimage-cache-layout.ts
+++ b/src/main/cli/appimage-cache-layout.ts
@@ -1,0 +1,34 @@
+import { isAbsolute, join, relative, resolve, sep } from 'node:path'
+import { LINUX_CLI_COMMAND_NAME } from './bundled-cli-launcher-path'
+
+const CACHE_KEY_PATTERN = /^[0-9a-f]{24}$/u
+
+export function isAppImageCacheKey(value: string): boolean {
+  return CACHE_KEY_PATTERN.test(value)
+}
+
+export function resolveCachedAppImagePayloadRoot(
+  cacheRootPath: string,
+  candidatePath: string,
+  launcherName = LINUX_CLI_COMMAND_NAME
+): string | null {
+  if (!isAbsolute(candidatePath)) {
+    return null
+  }
+  const resolvedCacheRoot = resolve(cacheRootPath)
+  const segments = relative(resolvedCacheRoot, resolve(candidatePath)).split(sep)
+  const [namespaceKey, generationKey, resources, bin, candidateLauncherName] = segments
+  if (
+    segments.length !== 5 ||
+    !namespaceKey ||
+    !generationKey ||
+    !isAppImageCacheKey(namespaceKey) ||
+    !isAppImageCacheKey(generationKey) ||
+    resources !== 'resources' ||
+    bin !== 'bin' ||
+    candidateLauncherName !== launcherName
+  ) {
+    return null
+  }
+  return join(resolvedCacheRoot, namespaceKey, generationKey)
+}

--- a/src/main/cli/appimage-extracted-root.test.ts
+++ b/src/main/cli/appimage-extracted-root.test.ts
@@ -1,0 +1,363 @@
+import { existsSync } from 'node:fs'
+import { mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  ensureAppImageExtractedRoot,
+  getAppImageCacheRootPath,
+  isAppImageExtractedLauncherPath,
+  isAppImageExtractionComplete,
+  isAppImageInstalledLauncherOwnedBySibling,
+  resolveAppImageCacheKey,
+  resolveAppImageExtractedRoot
+} from './appimage-extracted-root'
+import { getAppImageActiveExtractionPath } from './appimage-extraction-pruning'
+import {
+  publishAppImageLauncherEndpoint,
+  resolveAppImageStableLauncherPath
+} from './appimage-stable-launcher'
+
+const created: string[] = []
+
+afterEach(async () => {
+  await Promise.all(created.splice(0).map((path) => rm(path, { recursive: true, force: true })))
+})
+
+async function makeFixture(): Promise<{
+  root: string
+  appImagePath: string
+  cacheRootPath: string
+}> {
+  const root = await mkdtemp(join(tmpdir(), 'orca-appimage-extract-'))
+  created.push(root)
+  const appImagePath = join(root, 'Orca.AppImage')
+  await writeFile(appImagePath, '#!/usr/bin/env bash\n', { encoding: 'utf8', mode: 0o755 })
+  return { root, appImagePath, cacheRootPath: join(root, 'cache') }
+}
+
+/** Stands in for the AppImage runtime, which writes ./squashfs-root under cwd. */
+async function writePayload(cwd: string, content = ''): Promise<void> {
+  const launcherDir = join(cwd, 'squashfs-root', 'resources', 'bin')
+  await mkdir(launcherDir, { recursive: true })
+  await writeFile(join(launcherDir, 'orca-ide'), content, { encoding: 'utf8', mode: 0o755 })
+}
+
+describe('appimage extracted root', () => {
+  it('derives the cache root from XDG_CACHE_HOME when set', () => {
+    const previous = process.env.XDG_CACHE_HOME
+    process.env.XDG_CACHE_HOME = '/xdg-cache'
+    try {
+      expect(getAppImageCacheRootPath('/home/u')).toBe(join('/xdg-cache', 'orca', 'appimage'))
+    } finally {
+      if (previous === undefined) {
+        delete process.env.XDG_CACHE_HOME
+      } else {
+        process.env.XDG_CACHE_HOME = previous
+      }
+    }
+  })
+
+  it('ignores a relative XDG_CACHE_HOME', () => {
+    const previous = process.env.XDG_CACHE_HOME
+    process.env.XDG_CACHE_HOME = 'relative-cache'
+    try {
+      expect(getAppImageCacheRootPath('/home/u')).toBe(
+        join('/home/u', '.cache', 'orca', 'appimage')
+      )
+    } finally {
+      if (previous === undefined) {
+        delete process.env.XDG_CACHE_HOME
+      } else {
+        process.env.XDG_CACHE_HOME = previous
+      }
+    }
+  })
+
+  it('extracts once and reuses the payload on the next call', async () => {
+    const { appImagePath, cacheRootPath } = await makeFixture()
+    let extractCount = 0
+    const runExtract = async (_path: string, cwd: string): Promise<void> => {
+      extractCount += 1
+      await writePayload(cwd)
+    }
+
+    const first = await ensureAppImageExtractedRoot({ appImagePath, cacheRootPath, runExtract })
+    const second = await ensureAppImageExtractedRoot({ appImagePath, cacheRootPath, runExtract })
+
+    expect(extractCount).toBe(1)
+    expect(second?.stableLauncherPath).toBe(first?.stableLauncherPath)
+    expect(isAppImageExtractionComplete(first!)).toBe(true)
+  })
+
+  // Why: an update replaces the file in place, so stat identity must change the key or the command
+  // would keep resolving through the previous version's payload.
+  it('keys the payload on file identity and metadata, not just path', async () => {
+    const { appImagePath, cacheRootPath } = await makeFixture()
+    const before = resolveAppImageCacheKey(appImagePath)
+    await writeFile(appImagePath, '#!/usr/bin/env bash\n# newer\n', {
+      encoding: 'utf8',
+      mode: 0o755
+    })
+
+    expect(resolveAppImageCacheKey(appImagePath)).not.toBe(before)
+    expect(resolveAppImageExtractedRoot({ appImagePath, cacheRootPath })?.rootPath).toContain(
+      resolveAppImageCacheKey(appImagePath) as string
+    )
+  })
+
+  // Why: a crashed extraction must not leave a directory that later reads treat
+  // as a usable payload — the command would exec a path that does not exist.
+  it('publishes nothing when extraction fails partway', async () => {
+    const { appImagePath, cacheRootPath } = await makeFixture()
+
+    const result = await ensureAppImageExtractedRoot({
+      appImagePath,
+      cacheRootPath,
+      runExtract: async (_path, cwd) => {
+        await mkdir(join(cwd, 'squashfs-root'), { recursive: true })
+        throw new Error('extraction interrupted')
+      }
+    })
+
+    expect(result).toBeNull()
+    await expect(readdir(cacheRootPath)).resolves.toEqual([])
+  })
+
+  it('reports failure when the payload has no launcher', async () => {
+    const { appImagePath, cacheRootPath } = await makeFixture()
+
+    const result = await ensureAppImageExtractedRoot({
+      appImagePath,
+      cacheRootPath,
+      runExtract: async (_path, cwd) => {
+        await mkdir(join(cwd, 'squashfs-root'), { recursive: true })
+      }
+    })
+
+    expect(result).toBeNull()
+  })
+
+  it('retains one retry payload when a foreign stable launcher blocks publication', async () => {
+    const { appImagePath, cacheRootPath } = await makeFixture()
+    const root = resolveAppImageExtractedRoot({ appImagePath, cacheRootPath })!
+    const launcherPath = resolveAppImageStableLauncherPath(cacheRootPath)
+    let extractionCount = 0
+    await mkdir(dirname(launcherPath), { recursive: true })
+    await writeFile(launcherPath, '#!/usr/bin/env bash\nprintf foreign\n', { mode: 0o755 })
+
+    const extract = async (_path: string, cwd: string): Promise<void> => {
+      extractionCount += 1
+      await writePayload(cwd)
+    }
+    const options = { appImagePath, cacheRootPath, runExtract: extract }
+
+    await expect(ensureAppImageExtractedRoot(options)).resolves.toBeNull()
+    await expect(ensureAppImageExtractedRoot(options)).resolves.toBeNull()
+    expect(extractionCount).toBe(1)
+    expect(existsSync(root.rootPath)).toBe(true)
+    expect(existsSync(getAppImageActiveExtractionPath(root.rootPath))).toBe(false)
+    await expect(readFile(launcherPath, 'utf8')).resolves.toContain('foreign')
+  })
+
+  it.each(['directory', 'non-executable'] as const)(
+    'rejects a %s launcher entry',
+    async (entryKind) => {
+      const { appImagePath, cacheRootPath } = await makeFixture()
+
+      const result = await ensureAppImageExtractedRoot({
+        appImagePath,
+        cacheRootPath,
+        runExtract: async (_path, cwd) => {
+          const launcherPath = join(cwd, 'squashfs-root', 'resources', 'bin', 'orca-ide')
+          if (entryKind === 'directory') {
+            await mkdir(launcherPath, { recursive: true })
+          } else {
+            await mkdir(dirname(launcherPath), { recursive: true })
+            await writeFile(launcherPath, '#!/usr/bin/env bash\n', { mode: 0o644 })
+          }
+        }
+      })
+
+      expect(result).toBeNull()
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'rejects a launcher symlink even when its target is executable',
+    async () => {
+      const { root, appImagePath, cacheRootPath } = await makeFixture()
+      const executable = join(root, 'foreign-launcher')
+      await writeFile(executable, '#!/usr/bin/env bash\n', { mode: 0o755 })
+
+      const result = await ensureAppImageExtractedRoot({
+        appImagePath,
+        cacheRootPath,
+        runExtract: async (_path, cwd) => {
+          const launcherPath = join(cwd, 'squashfs-root', 'resources', 'bin', 'orca-ide')
+          await mkdir(dirname(launcherPath), { recursive: true })
+          await symlink(executable, launcherPath)
+        }
+      })
+
+      expect(result).toBeNull()
+    }
+  )
+
+  it('replaces an incomplete exact extraction root', async () => {
+    const { appImagePath, cacheRootPath } = await makeFixture()
+    const root = resolveAppImageExtractedRoot({ appImagePath, cacheRootPath })!
+    const partialPath = join(root.rootPath, 'partial')
+    await mkdir(root.rootPath, { recursive: true })
+    await writeFile(partialPath, 'interrupted')
+
+    const result = await ensureAppImageExtractedRoot({
+      appImagePath,
+      cacheRootPath,
+      runExtract: async (_path, cwd) => writePayload(cwd, 'recovered')
+    })
+
+    expect(result).toEqual(root)
+    await expect(readFile(root.payloadLauncherPath, 'utf8')).resolves.toBe('recovered')
+    expect(existsSync(partialPath)).toBe(false)
+  })
+
+  it('preserves the winner when concurrent calls repair an incomplete root', async () => {
+    const { appImagePath, cacheRootPath } = await makeFixture()
+    const root = resolveAppImageExtractedRoot({ appImagePath, cacheRootPath })!
+    await mkdir(root.rootPath, { recursive: true })
+    await writeFile(join(root.rootPath, 'partial'), 'interrupted')
+    let readyCount = 0
+    let release!: () => void
+    const bothReady = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const runExtract = async (_path: string, cwd: string): Promise<void> => {
+      readyCount += 1
+      await writePayload(cwd, `winner-${readyCount}`)
+      if (readyCount === 2) {
+        release()
+      }
+      await bothReady
+    }
+
+    const results = await Promise.all([
+      ensureAppImageExtractedRoot({ appImagePath, cacheRootPath, runExtract }),
+      ensureAppImageExtractedRoot({ appImagePath, cacheRootPath, runExtract })
+    ])
+
+    expect(results).toEqual([root, root])
+    expect(['winner-1', 'winner-2']).toContain(await readFile(root.payloadLauncherPath, 'utf8'))
+  })
+
+  it('retries with the current generation when the AppImage changes during extraction', async () => {
+    const { appImagePath, cacheRootPath } = await makeFixture()
+    const initialRoot = resolveAppImageExtractedRoot({ appImagePath, cacheRootPath })!
+    let extractCount = 0
+
+    const result = await ensureAppImageExtractedRoot({
+      appImagePath,
+      cacheRootPath,
+      runExtract: async (_path, cwd) => {
+        extractCount += 1
+        await writePayload(cwd, `generation-${extractCount}`)
+        if (extractCount === 1) {
+          await writeFile(appImagePath, '#!/usr/bin/env bash\n# replaced during extraction\n', {
+            encoding: 'utf8',
+            mode: 0o755
+          })
+        }
+      }
+    })
+
+    const currentRoot = resolveAppImageExtractedRoot({ appImagePath, cacheRootPath })!
+    expect(extractCount).toBe(2)
+    expect(result).toEqual(currentRoot)
+    expect(result?.rootPath).not.toBe(initialRoot.rootPath)
+    await expect(readFile(currentRoot.payloadLauncherPath, 'utf8')).resolves.toBe('generation-2')
+    expect(existsSync(initialRoot.rootPath)).toBe(false)
+  })
+
+  it('bounds retries when every extraction changes the AppImage generation', async () => {
+    const { appImagePath, cacheRootPath } = await makeFixture()
+    let extractCount = 0
+
+    const result = await ensureAppImageExtractedRoot({
+      appImagePath,
+      cacheRootPath,
+      runExtract: async (_path, cwd) => {
+        extractCount += 1
+        await writePayload(cwd)
+        await writeFile(appImagePath, '#'.repeat(extractCount + 1), { mode: 0o755 })
+      }
+    })
+
+    expect(result).toBeNull()
+    expect(extractCount).toBe(2)
+  })
+
+  it('returns null for an AppImage that is not there', async () => {
+    const { root, cacheRootPath } = await makeFixture()
+    const missing = join(root, 'Absent.AppImage')
+
+    expect(resolveAppImageCacheKey(missing)).toBeNull()
+    expect(resolveAppImageExtractedRoot({ appImagePath: missing, cacheRootPath })).toBeNull()
+  })
+
+  it('recognizes managed launchers across AppImage path namespaces', async () => {
+    const { root, appImagePath, cacheRootPath } = await makeFixture()
+    const current = resolveAppImageExtractedRoot({ appImagePath, cacheRootPath })!
+    const previousGeneration = join(
+      dirname(current.rootPath),
+      'a'.repeat(24),
+      'resources',
+      'bin',
+      'orca-ide'
+    )
+    const otherAppImagePath = join(root, 'Other.AppImage')
+    await writeFile(otherAppImagePath, '#!/usr/bin/env bash\n', { mode: 0o755 })
+    const other = resolveAppImageExtractedRoot({
+      appImagePath: otherAppImagePath,
+      cacheRootPath
+    })!
+
+    expect(
+      isAppImageExtractedLauncherPath({ appImagePath, cacheRootPath }, current.stableLauncherPath)
+    ).toBe(true)
+    expect(
+      isAppImageExtractedLauncherPath({ appImagePath, cacheRootPath }, previousGeneration)
+    ).toBe(true)
+    expect(
+      isAppImageExtractedLauncherPath({ appImagePath, cacheRootPath }, other.stableLauncherPath)
+    ).toBe(true)
+    expect(
+      isAppImageExtractedLauncherPath({ appImagePath, cacheRootPath }, other.payloadLauncherPath)
+    ).toBe(true)
+    expect(
+      isAppImageExtractedLauncherPath(
+        { appImagePath, cacheRootPath },
+        join(root, 'foreign', 'resources', 'bin', 'orca-ide')
+      )
+    ).toBe(false)
+  })
+
+  it('requires a sibling installed endpoint to target an executable payload', async () => {
+    const { appImagePath, cacheRootPath } = await makeFixture()
+    const siblingLauncher = join(
+      cacheRootPath,
+      'a'.repeat(24),
+      'b'.repeat(24),
+      'resources',
+      'bin',
+      'orca-ide'
+    )
+    publishAppImageLauncherEndpoint(cacheRootPath, 'installed', siblingLauncher)
+    const options = { appImagePath, cacheRootPath }
+
+    expect(isAppImageInstalledLauncherOwnedBySibling(options)).toBe(false)
+
+    await mkdir(dirname(siblingLauncher), { recursive: true })
+    await writeFile(siblingLauncher, '#!/usr/bin/env bash\n', { mode: 0o755 })
+    expect(isAppImageInstalledLauncherOwnedBySibling(options)).toBe(true)
+  })
+})

--- a/src/main/cli/appimage-extracted-root.test.ts
+++ b/src/main/cli/appimage-extracted-root.test.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs'
-import { mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -104,6 +104,19 @@ describe('appimage extracted root', () => {
     expect(resolveAppImageExtractedRoot({ appImagePath, cacheRootPath })?.rootPath).toContain(
       resolveAppImageCacheKey(appImagePath) as string
     )
+  })
+
+  // Why: `chmod +x` is what every AppImage user is told to run, and a backup restore or SELinux
+  // relabel does the same thing. Re-keying on that cost a full re-extraction of an unchanged payload.
+  it('does not re-key the payload when only inode metadata changes', async () => {
+    const { appImagePath } = await makeFixture()
+    const before = resolveAppImageCacheKey(appImagePath)
+
+    await chmod(appImagePath, 0o700)
+    expect(resolveAppImageCacheKey(appImagePath)).toBe(before)
+
+    await chmod(appImagePath, 0o755)
+    expect(resolveAppImageCacheKey(appImagePath)).toBe(before)
   })
 
   // Why: a crashed extraction must not leave a directory that later reads treat

--- a/src/main/cli/appimage-extracted-root.ts
+++ b/src/main/cli/appimage-extracted-root.ts
@@ -1,0 +1,267 @@
+import { createHash } from 'node:crypto'
+import { lstatSync, readlinkSync, statSync } from 'node:fs'
+import { mkdir, mkdtemp, rename, rm, rmdir, writeFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { dirname, isAbsolute, join, resolve } from 'node:path'
+import { runProcess } from '../../shared/child-process/run-process'
+import { resolveCachedAppImagePayloadRoot } from './appimage-cache-layout'
+import { LINUX_CLI_COMMAND_NAME } from './bundled-cli-launcher-path'
+import {
+  APPIMAGE_EXTRACTION_TIMEOUT_MS,
+  getAppImageActiveExtractionPath,
+  pruneAppImageExtractedRoots,
+  trackAppImageExtraction
+} from './appimage-extraction-pruning'
+import {
+  isAppImageStableLauncherReady,
+  publishAppImageLauncherEndpoint,
+  resolveAppImageLauncherEndpointPath,
+  resolveAppImageStableLauncherPath
+} from './appimage-stable-launcher'
+
+const CACHE_DIR_SEGMENTS = ['orca', 'appimage'] as const
+const EXTRACT_OUTPUT_DIR = 'squashfs-root'
+const MAX_GENERATION_ATTEMPTS = 2
+const EXTRACTION_STAGING_PREFIX = '.extract-'
+
+export type AppImageExtractedRoot = {
+  rootPath: string
+  payloadLauncherPath: string
+  stableLauncherPath: string
+}
+
+export type AppImageExtractionOptions = {
+  appImagePath: string
+  cacheRootPath?: string
+  runExtract?: (appImagePath: string, cwd: string) => Promise<void>
+}
+
+export function getAppImageCacheRootPath(homePath = homedir()): string {
+  const xdgCacheHome = process.env.XDG_CACHE_HOME
+  const cacheHome =
+    xdgCacheHome && isAbsolute(xdgCacheHome) ? xdgCacheHome : join(homePath, '.cache')
+  return join(cacheHome, ...CACHE_DIR_SEGMENTS)
+}
+
+export function resolveAppImageCacheKey(appImagePath: string): string | null {
+  try {
+    const stats = statSync(appImagePath)
+    return digest(`${stats.dev}\0${stats.ino}\0${stats.size}\0${stats.mtimeMs}\0${stats.ctimeMs}`)
+  } catch {
+    return null
+  }
+}
+
+export function resolveAppImageExtractedRoot(
+  options: AppImageExtractionOptions
+): AppImageExtractedRoot | null {
+  const cacheKey = resolveAppImageCacheKey(options.appImagePath)
+  if (!cacheKey) {
+    return null
+  }
+  const cacheRootPath = resolveAppImageCacheRootPath(options)
+  const rootPath = join(resolveAppImageNamespacePath(options), cacheKey)
+  return extractedRootAt(rootPath, cacheRootPath)
+}
+
+export function isAppImageExtractedLauncherPath(
+  options: AppImageExtractionOptions,
+  candidatePath: string,
+  launcherName = LINUX_CLI_COMMAND_NAME
+): boolean {
+  if (!isAbsolute(candidatePath)) {
+    return false
+  }
+  const cacheRootPath = resolveAppImageCacheRootPath(options)
+  if (
+    launcherName === LINUX_CLI_COMMAND_NAME &&
+    resolve(candidatePath) === resolveAppImageStableLauncherPath(cacheRootPath)
+  ) {
+    return true
+  }
+
+  return resolveCachedAppImagePayloadRoot(cacheRootPath, candidatePath, launcherName) !== null
+}
+
+export function isAppImageExtractionComplete(root: AppImageExtractedRoot): boolean {
+  return hasPayloadLauncher(root.rootPath)
+}
+
+export function isAppImageInstalledLauncherCurrent(options: AppImageExtractionOptions): boolean {
+  const root = resolveAppImageExtractedRoot(options)
+  const cacheRootPath = resolveAppImageCacheRootPath(options)
+  if (
+    !root ||
+    !isAppImageStableLauncherReady(cacheRootPath) ||
+    !hasPayloadLauncher(root.rootPath)
+  ) {
+    return false
+  }
+  const endpointPath = resolveAppImageLauncherEndpointPath(cacheRootPath, 'installed')
+  try {
+    return resolve(dirname(endpointPath), readlinkSync(endpointPath)) === root.payloadLauncherPath
+  } catch {
+    return false
+  }
+}
+
+export function isAppImageInstalledLauncherOwnedBySibling(
+  options: AppImageExtractionOptions
+): boolean {
+  const cacheRootPath = resolveAppImageCacheRootPath(options)
+  const endpointPath = resolveAppImageLauncherEndpointPath(cacheRootPath, 'installed')
+  try {
+    const targetPath = resolve(dirname(endpointPath), readlinkSync(endpointPath))
+    const targetRoot = resolveCachedAppImagePayloadRoot(cacheRootPath, targetPath)
+    return (
+      targetRoot !== null &&
+      hasPayloadLauncher(targetRoot) &&
+      dirname(targetRoot) !== resolveAppImageNamespacePath(options)
+    )
+  } catch {
+    return false
+  }
+}
+
+export async function ensureAppImageExtractedRoot(
+  options: AppImageExtractionOptions
+): Promise<AppImageExtractedRoot | null> {
+  for (let attempt = 0; attempt < MAX_GENERATION_ATTEMPTS; attempt += 1) {
+    const root = resolveAppImageExtractedRoot(options)
+    if (!root) {
+      return null
+    }
+    const complete =
+      isAppImageExtractionComplete(root) || (await extractAppImageGeneration(options, root))
+    if (isCurrentGeneration(options, root)) {
+      if (!complete || !isAppImageExtractionComplete(root)) {
+        await cleanFailedEndpointPublication(root)
+        continue
+      }
+      const launcherPath = publishAppImageLauncherEndpoint(
+        resolveAppImageCacheRootPath(options),
+        'installed',
+        root.payloadLauncherPath
+      )
+      if (launcherPath === root.stableLauncherPath) {
+        await rm(getAppImageActiveExtractionPath(root.rootPath), { force: true }).catch(() => {})
+        return root
+      }
+    }
+    await cleanFailedEndpointPublication(root)
+  }
+  return null
+}
+
+async function cleanFailedEndpointPublication(root: AppImageExtractedRoot): Promise<void> {
+  await rm(getAppImageActiveExtractionPath(root.rootPath), { force: true }).catch(() => {})
+  await pruneAppImageExtractedRoots(root.rootPath)
+}
+
+async function extractAppImageGeneration(
+  options: AppImageExtractionOptions,
+  root: AppImageExtractedRoot
+): Promise<boolean> {
+  const namespacePath = dirname(root.rootPath)
+  await mkdir(namespacePath, { recursive: true })
+  const stagingPath = await mkdtemp(join(namespacePath, EXTRACTION_STAGING_PREFIX))
+  const stopTracking = trackAppImageExtraction(stagingPath)
+  try {
+    await (options.runExtract ?? runAppImageExtract)(options.appImagePath, stagingPath)
+    const extractedPath = join(stagingPath, EXTRACT_OUTPUT_DIR)
+    if (!hasPayloadLauncher(extractedPath) || !isCurrentGeneration(options, root)) {
+      return false
+    }
+    await writeFile(getAppImageActiveExtractionPath(root.rootPath), '')
+    return await publishExtractedRoot(extractedPath, root)
+  } catch {
+    // A concurrent extractor may have published the same payload first.
+    return isAppImageExtractionComplete(root)
+  } finally {
+    stopTracking()
+    await rm(stagingPath, { recursive: true, force: true }).catch(() => {})
+    await rmdir(namespacePath).catch(() => {})
+  }
+}
+
+function digest(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 24)
+}
+
+export function resolveAppImageNamespacePath(options: AppImageExtractionOptions): string {
+  return join(resolveAppImageCacheRootPath(options), digest(options.appImagePath))
+}
+
+export function resolveAppImageCacheRootPath(options: AppImageExtractionOptions): string {
+  return resolve(options.cacheRootPath ?? getAppImageCacheRootPath())
+}
+
+function extractedRootAt(rootPath: string, cacheRootPath: string): AppImageExtractedRoot {
+  return {
+    rootPath,
+    payloadLauncherPath: join(rootPath, 'resources', 'bin', LINUX_CLI_COMMAND_NAME),
+    stableLauncherPath: resolveAppImageStableLauncherPath(cacheRootPath)
+  }
+}
+
+function isCurrentGeneration(
+  options: AppImageExtractionOptions,
+  root: AppImageExtractedRoot
+): boolean {
+  return resolveAppImageExtractedRoot(options)?.rootPath === root.rootPath
+}
+
+async function publishExtractedRoot(
+  extractedPath: string,
+  root: AppImageExtractedRoot
+): Promise<boolean> {
+  if ((await renameRoot(extractedPath, root.rootPath)) || isAppImageExtractionComplete(root)) {
+    return true
+  }
+
+  // Claim the destination atomically so a raced complete winner can be restored.
+  const displacedPath = `${extractedPath}.displaced`
+  if (!(await renameRoot(root.rootPath, displacedPath))) {
+    return (await renameRoot(extractedPath, root.rootPath)) || isAppImageExtractionComplete(root)
+  }
+  if (hasPayloadLauncher(displacedPath)) {
+    return (await renameRoot(displacedPath, root.rootPath)) || isAppImageExtractionComplete(root)
+  }
+  await rm(displacedPath, { recursive: true, force: true })
+  return (await renameRoot(extractedPath, root.rootPath)) || isAppImageExtractionComplete(root)
+}
+
+function hasPayloadLauncher(rootPath: string): boolean {
+  try {
+    const stats = lstatSync(join(rootPath, 'resources', 'bin', LINUX_CLI_COMMAND_NAME))
+    return stats.isFile() && (stats.mode & 0o111) !== 0
+  } catch {
+    return false
+  }
+}
+
+async function renameRoot(sourcePath: string, destinationPath: string): Promise<boolean> {
+  try {
+    await rename(sourcePath, destinationPath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function runAppImageExtract(appImagePath: string, cwd: string): Promise<void> {
+  const result = await runProcess({
+    program: appImagePath,
+    args: ['--appimage-extract'],
+    cwd,
+    timeoutMs: APPIMAGE_EXTRACTION_TIMEOUT_MS,
+    maxOutputBytes: 1024 * 1024,
+    terminationBarrier: true
+  })
+  if (result.timedOut) {
+    throw new Error('AppImage extraction timed out.')
+  }
+  if (result.code !== 0) {
+    throw new Error(result.stderr.trim() || `AppImage extraction exited ${result.code ?? 'early'}.`)
+  }
+}

--- a/src/main/cli/appimage-extracted-root.ts
+++ b/src/main/cli/appimage-extracted-root.ts
@@ -5,6 +5,7 @@ import { homedir } from 'node:os'
 import { dirname, isAbsolute, join, resolve } from 'node:path'
 import { runProcess } from '../../shared/child-process/run-process'
 import { resolveCachedAppImagePayloadRoot } from './appimage-cache-layout'
+import { removeExtractedAppImagePayload } from './appimage-payload-removal'
 import { LINUX_CLI_COMMAND_NAME } from './bundled-cli-launcher-path'
 import {
   APPIMAGE_EXTRACTION_TIMEOUT_MS,
@@ -179,7 +180,7 @@ async function extractAppImageGeneration(
     return isAppImageExtractionComplete(root)
   } finally {
     stopTracking()
-    await rm(stagingPath, { recursive: true, force: true }).catch(() => {})
+    await removeExtractedAppImagePayload(stagingPath).catch(() => {})
     await rmdir(namespacePath).catch(() => {})
   }
 }
@@ -227,7 +228,7 @@ async function publishExtractedRoot(
   if (hasPayloadLauncher(displacedPath)) {
     return (await renameRoot(displacedPath, root.rootPath)) || isAppImageExtractionComplete(root)
   }
-  await rm(displacedPath, { recursive: true, force: true })
+  await removeExtractedAppImagePayload(displacedPath)
   return (await renameRoot(extractedPath, root.rootPath)) || isAppImageExtractionComplete(root)
 }
 

--- a/src/main/cli/appimage-extracted-root.ts
+++ b/src/main/cli/appimage-extracted-root.ts
@@ -44,10 +44,19 @@ export function getAppImageCacheRootPath(homePath = homedir()): string {
   return join(cacheHome, ...CACHE_DIR_SEGMENTS)
 }
 
+/**
+ * Identity of the AppImage's *content*, used to key its extracted generation.
+ *
+ * Deliberately excludes ctime: it changes on any inode metadata write — `chmod +x` (which every
+ * AppImage user is told to run), `chown`, an ACL or SELinux relabel, a backup restore — none of
+ * which alter a byte of the payload. Including it re-keyed the cache on those, costing a full
+ * ~519 MB re-extraction and a multi-second stall for nothing. An in-place content change moves
+ * mtime and almost always size; a replacement moves the inode.
+ */
 export function resolveAppImageCacheKey(appImagePath: string): string | null {
   try {
     const stats = statSync(appImagePath)
-    return digest(`${stats.dev}\0${stats.ino}\0${stats.size}\0${stats.mtimeMs}\0${stats.ctimeMs}`)
+    return digest(`${stats.dev}\0${stats.ino}\0${stats.size}\0${stats.mtimeMs}`)
   } catch {
     return null
   }

--- a/src/main/cli/appimage-extraction-pruning.test.ts
+++ b/src/main/cli/appimage-extraction-pruning.test.ts
@@ -1,0 +1,221 @@
+import { existsSync } from 'node:fs'
+import type * as NodeFsPromises from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, readlink, rm, utimes, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { basename, dirname, join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const publicationRace = vi.hoisted(() => ({ endpointPath: '', replacementTarget: '' }))
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFsPromises>()
+  return {
+    ...actual,
+    rename: async (source: string, destination: string) => {
+      if (source === publicationRace.endpointPath && publicationRace.replacementTarget) {
+        await actual.unlink(source)
+        await actual.symlink(publicationRace.replacementTarget, source)
+        publicationRace.replacementTarget = ''
+      }
+      return actual.rename(source, destination)
+    }
+  }
+})
+
+import {
+  ensureAppImageExtractedRoot,
+  resolveAppImageExtractedRoot
+} from './appimage-extracted-root'
+import {
+  getAppImageActiveExtractionPath,
+  pruneAppImageExtractedRoots,
+  removeAppImageInstalledPayloads
+} from './appimage-extraction-pruning'
+import {
+  publishAppImageLauncherEndpoint,
+  resolveAppImageLauncherEndpointPath
+} from './appimage-stable-launcher'
+
+const created: string[] = []
+
+afterEach(async () => {
+  publicationRace.endpointPath = ''
+  publicationRace.replacementTarget = ''
+  await Promise.all(created.splice(0).map((path) => rm(path, { recursive: true, force: true })))
+})
+
+async function writePayload(rootPath: string, content = '#!/usr/bin/env bash\n'): Promise<string> {
+  const launcherPath = join(rootPath, 'resources', 'bin', 'orca-ide')
+  await mkdir(dirname(launcherPath), { recursive: true })
+  await writeFile(launcherPath, content, { mode: 0o755 })
+  return launcherPath
+}
+
+async function makeExtractionFixture() {
+  const root = await mkdtemp(join(tmpdir(), 'orca-appimage-pruning-'))
+  created.push(root)
+  const appImagePath = join(root, 'Orca.AppImage')
+  await writeFile(appImagePath, '#!/usr/bin/env bash\n', { mode: 0o755 })
+  return { root, appImagePath, cacheRootPath: join(root, 'cache') }
+}
+
+function cacheKeyApartFrom(...excluded: string[]): string {
+  return (
+    ['a', 'b', 'c'].map((value) => value.repeat(24)).find((key) => !excluded.includes(key)) ??
+    'd'.repeat(24)
+  )
+}
+
+describe('AppImage extraction pruning', () => {
+  it('prunes stale generations without touching sibling namespaces', async () => {
+    const { appImagePath, cacheRootPath } = await makeExtractionFixture()
+    const keepRoot = resolveAppImageExtractedRoot({ appImagePath, cacheRootPath })!
+    const keepKey = basename(keepRoot.rootPath)
+    const staleRoot = join(dirname(keepRoot.rootPath), cacheKeyApartFrom(keepKey))
+    const siblingRoot = join(
+      cacheRootPath,
+      cacheKeyApartFrom(basename(dirname(keepRoot.rootPath))),
+      'd'.repeat(24)
+    )
+    await Promise.all([
+      mkdir(keepRoot.rootPath, { recursive: true }),
+      mkdir(staleRoot, { recursive: true }),
+      mkdir(siblingRoot, { recursive: true })
+    ])
+
+    await pruneAppImageExtractedRoots(keepRoot.rootPath)
+
+    expect(existsSync(keepRoot.rootPath)).toBe(true)
+    expect(existsSync(staleRoot)).toBe(false)
+    expect(existsSync(siblingRoot)).toBe(true)
+  })
+
+  it('a sibling installed endpoint does not displace the owner generation', async () => {
+    const { appImagePath, cacheRootPath } = await makeExtractionFixture()
+    const ownerRoot = resolveAppImageExtractedRoot({ appImagePath, cacheRootPath })!
+    const siblingRoot = join(
+      dirname(ownerRoot.rootPath),
+      cacheKeyApartFrom(basename(ownerRoot.rootPath))
+    )
+    const [ownerLauncher, siblingLauncher] = await Promise.all([
+      writePayload(ownerRoot.rootPath, 'owner'),
+      writePayload(siblingRoot, 'installed')
+    ])
+    publishAppImageLauncherEndpoint(cacheRootPath, 'installed', siblingLauncher)
+
+    await pruneAppImageExtractedRoots(ownerRoot.rootPath)
+
+    await expect(readFile(ownerLauncher, 'utf8')).resolves.toBe('owner')
+    await expect(readFile(siblingLauncher, 'utf8')).resolves.toBe('installed')
+    await expect(
+      readlink(resolveAppImageLauncherEndpointPath(cacheRootPath, 'installed'))
+    ).resolves.toBe(siblingLauncher)
+  })
+
+  it('preserves an active extraction during pruning', async () => {
+    const { appImagePath, cacheRootPath } = await makeExtractionFixture()
+    const root = resolveAppImageExtractedRoot({ appImagePath, cacheRootPath })!
+    let reportStarted!: (stagingPath: string) => void
+    let releaseExtraction!: () => void
+    const started = new Promise<string>((resolve) => {
+      reportStarted = resolve
+    })
+    const release = new Promise<void>((resolve) => {
+      releaseExtraction = resolve
+    })
+    const extraction = ensureAppImageExtractedRoot({
+      appImagePath,
+      cacheRootPath,
+      runExtract: async (_path, cwd) => {
+        reportStarted(cwd)
+        await release
+        await writePayload(join(cwd, 'squashfs-root'), '')
+      }
+    })
+    const stagingPath = await started
+
+    try {
+      await pruneAppImageExtractedRoots(root.rootPath)
+      expect(existsSync(stagingPath)).toBe(true)
+    } finally {
+      releaseExtraction()
+    }
+    await expect(extraction).resolves.toEqual(root)
+  })
+
+  it('retains recent cross-process staging and reclaims stale staging', async () => {
+    const { appImagePath, cacheRootPath } = await makeExtractionFixture()
+    const root = resolveAppImageExtractedRoot({ appImagePath, cacheRootPath })!
+    const namespacePath = dirname(root.rootPath)
+    const recentStaging = join(namespacePath, '.extract-recent')
+    const staleStaging = join(namespacePath, '.extract-stale')
+    await Promise.all([
+      mkdir(root.rootPath, { recursive: true }),
+      mkdir(recentStaging, { recursive: true }),
+      mkdir(staleStaging, { recursive: true })
+    ])
+    await utimes(staleStaging, 0, 0)
+
+    await pruneAppImageExtractedRoots(root.rootPath)
+
+    expect(existsSync(recentStaging)).toBe(true)
+    expect(existsSync(staleStaging)).toBe(false)
+  })
+
+  it('preserves a recent active generation marker and reclaims a stale marker', async () => {
+    const { appImagePath, cacheRootPath } = await makeExtractionFixture()
+    const keepRoot = resolveAppImageExtractedRoot({ appImagePath, cacheRootPath })!
+    const keepKey = basename(keepRoot.rootPath)
+    const recentRoot = join(dirname(keepRoot.rootPath), cacheKeyApartFrom(keepKey))
+    const staleRoot = join(
+      dirname(keepRoot.rootPath),
+      cacheKeyApartFrom(keepKey, basename(recentRoot))
+    )
+    const recentMarker = getAppImageActiveExtractionPath(recentRoot)
+    const staleMarker = getAppImageActiveExtractionPath(staleRoot)
+    await Promise.all([
+      mkdir(keepRoot.rootPath, { recursive: true }),
+      mkdir(recentRoot, { recursive: true }),
+      mkdir(staleRoot, { recursive: true })
+    ])
+    await Promise.all([writeFile(recentMarker, ''), writeFile(staleMarker, '')])
+    await utimes(staleMarker, 0, 0)
+
+    await pruneAppImageExtractedRoots(keepRoot.rootPath)
+
+    expect(existsSync(recentRoot)).toBe(true)
+    expect(existsSync(recentMarker)).toBe(true)
+    expect(existsSync(staleRoot)).toBe(false)
+    expect(existsSync(staleMarker)).toBe(false)
+  })
+
+  it('tolerates a missing cache namespace', async () => {
+    const { root } = await makeExtractionFixture()
+
+    await expect(
+      pruneAppImageExtractedRoots(join(root, 'never-made', 'a'.repeat(24), 'b'.repeat(24)))
+    ).resolves.toBeUndefined()
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'restores a sibling endpoint that wins the uninstall rename race',
+    async () => {
+      const cacheRootPath = await mkdtemp(join(tmpdir(), 'orca-appimage-pruning-'))
+      created.push(cacheRootPath)
+      const ownerNamespace = join(cacheRootPath, 'a'.repeat(24))
+      const siblingNamespace = join(cacheRootPath, 'b'.repeat(24))
+      const ownerLauncher = await writePayload(join(ownerNamespace, 'c'.repeat(24)))
+      const siblingLauncher = await writePayload(join(siblingNamespace, 'd'.repeat(24)))
+      const endpointPath = resolveAppImageLauncherEndpointPath(cacheRootPath, 'installed')
+      publishAppImageLauncherEndpoint(cacheRootPath, 'installed', ownerLauncher)
+      publicationRace.endpointPath = endpointPath
+      publicationRace.replacementTarget = siblingLauncher
+
+      await removeAppImageInstalledPayloads(ownerNamespace)
+
+      await expect(readlink(endpointPath)).resolves.toBe(siblingLauncher)
+      expect(existsSync(ownerNamespace)).toBe(false)
+      expect(existsSync(siblingLauncher)).toBe(true)
+    }
+  )
+})

--- a/src/main/cli/appimage-extraction-pruning.ts
+++ b/src/main/cli/appimage-extraction-pruning.ts
@@ -4,7 +4,10 @@ import type { Dirent } from 'node:fs'
 import { lstat, readlink, readdir, rename, rm, rmdir, symlink, unlink } from 'node:fs/promises'
 import { basename, dirname, join, resolve } from 'node:path'
 import { isAppImageCacheKey, resolveCachedAppImagePayloadRoot } from './appimage-cache-layout'
-import { resolveAppImageLauncherEndpointPath } from './appimage-stable-launcher'
+import {
+  removeAppImageLegacyLiveEndpoint,
+  resolveAppImageLauncherEndpointPath
+} from './appimage-stable-launcher'
 
 const EXTRACTION_STAGING_PREFIX = '.extract-'
 const ACTIVE_EXTRACTION_PREFIX = '.active-'
@@ -39,6 +42,7 @@ export async function pruneAppImageExtractedRoots(keepRootPath: string): Promise
 export async function removeAppImageInstalledPayloads(namespacePath: string): Promise<void> {
   const resolvedNamespace = resolve(namespacePath)
   const cacheRootPath = dirname(resolvedNamespace)
+  removeAppImageLegacyLiveEndpoint(cacheRootPath)
   if (await removeInstalledEndpoint(cacheRootPath, resolvedNamespace)) {
     await pruneNamespace(resolvedNamespace, new Set())
     await rmdir(resolvedNamespace).catch(() => {})

--- a/src/main/cli/appimage-extraction-pruning.ts
+++ b/src/main/cli/appimage-extraction-pruning.ts
@@ -1,0 +1,142 @@
+import { randomUUID } from 'node:crypto'
+import { existsSync } from 'node:fs'
+import type { Dirent } from 'node:fs'
+import { lstat, readlink, readdir, rename, rm, rmdir, symlink, unlink } from 'node:fs/promises'
+import { basename, dirname, join, resolve } from 'node:path'
+import { isAppImageCacheKey, resolveCachedAppImagePayloadRoot } from './appimage-cache-layout'
+import { resolveAppImageLauncherEndpointPath } from './appimage-stable-launcher'
+
+const EXTRACTION_STAGING_PREFIX = '.extract-'
+const ACTIVE_EXTRACTION_PREFIX = '.active-'
+export const APPIMAGE_EXTRACTION_TIMEOUT_MS = 300_000
+// Cross-process extractors are bounded at five minutes; retain a second window before cleanup.
+const STALE_EXTRACTION_GRACE_MS = APPIMAGE_EXTRACTION_TIMEOUT_MS * 2
+
+const activeExtractionPaths = new Set<string>()
+
+export function trackAppImageExtraction(stagingPath: string): () => void {
+  activeExtractionPaths.add(stagingPath)
+  return () => activeExtractionPaths.delete(stagingPath)
+}
+
+export function getAppImageActiveExtractionPath(rootPath: string): string {
+  return join(dirname(rootPath), `${ACTIVE_EXTRACTION_PREFIX}${basename(rootPath)}`)
+}
+
+export async function pruneAppImageExtractedRoots(keepRootPath: string): Promise<void> {
+  const resolvedKeepRoot = resolve(keepRootPath)
+  const namespacePath = dirname(resolvedKeepRoot)
+  const cacheRootPath = dirname(namespacePath)
+  const protectedRoots = new Set([resolvedKeepRoot])
+  const installedRoot = await resolveInstalledRoot(cacheRootPath)
+  if (installedRoot && dirname(installedRoot) === namespacePath) {
+    protectedRoots.add(installedRoot)
+  }
+  await pruneNamespace(namespacePath, protectedRoots)
+  await rmdir(namespacePath).catch(() => {})
+}
+
+export async function removeAppImageInstalledPayloads(namespacePath: string): Promise<void> {
+  const resolvedNamespace = resolve(namespacePath)
+  const cacheRootPath = dirname(resolvedNamespace)
+  if (await removeInstalledEndpoint(cacheRootPath, resolvedNamespace)) {
+    await pruneNamespace(resolvedNamespace, new Set())
+    await rmdir(resolvedNamespace).catch(() => {})
+  }
+}
+
+async function resolveInstalledRoot(cacheRootPath: string): Promise<string | null> {
+  const endpointPath = resolveAppImageLauncherEndpointPath(cacheRootPath, 'installed')
+  try {
+    const targetPath = resolve(dirname(endpointPath), await readlink(endpointPath))
+    return resolveCachedAppImagePayloadRoot(cacheRootPath, targetPath)
+  } catch {
+    return null
+  }
+}
+
+async function removeInstalledEndpoint(
+  cacheRootPath: string,
+  namespacePath: string
+): Promise<boolean> {
+  const endpointPath = resolveAppImageLauncherEndpointPath(cacheRootPath, 'installed')
+  if (!(await endpointTargetsNamespace(cacheRootPath, endpointPath, namespacePath))) {
+    return true
+  }
+
+  const displacedPath = join(
+    dirname(endpointPath),
+    `.orca-preserved-installed-${process.pid}-${randomUUID()}`
+  )
+  try {
+    await rename(endpointPath, displacedPath)
+  } catch {
+    return !(await endpointTargetsNamespace(cacheRootPath, endpointPath, namespacePath))
+  }
+
+  if (await endpointTargetsNamespace(cacheRootPath, displacedPath, namespacePath)) {
+    await unlink(displacedPath).catch(() => {})
+    return true
+  }
+
+  try {
+    await symlink(await readlink(displacedPath), endpointPath)
+    await unlink(displacedPath)
+  } catch {}
+  return !(await endpointTargetsNamespace(cacheRootPath, endpointPath, namespacePath))
+}
+
+async function endpointTargetsNamespace(
+  cacheRootPath: string,
+  endpointPath: string,
+  namespacePath: string
+): Promise<boolean> {
+  try {
+    const targetPath = resolve(dirname(endpointPath), await readlink(endpointPath))
+    const targetRoot = resolveCachedAppImagePayloadRoot(cacheRootPath, targetPath)
+    return targetRoot !== null && dirname(targetRoot) === namespacePath
+  } catch {
+    return false
+  }
+}
+
+async function pruneNamespace(
+  namespacePath: string,
+  protectedRoots: ReadonlySet<string>
+): Promise<void> {
+  let entries: Dirent[]
+  try {
+    entries = await readdir(namespacePath, { withFileTypes: true })
+  } catch {
+    return
+  }
+
+  for (const entry of entries) {
+    const entryPath = join(namespacePath, entry.name)
+    if (
+      entry.name.startsWith(EXTRACTION_STAGING_PREFIX) ||
+      entry.name.startsWith(ACTIVE_EXTRACTION_PREFIX)
+    ) {
+      if (activeExtractionPaths.has(entryPath) || !(await isOlderThanGrace(entryPath))) {
+        continue
+      }
+    } else if (!isAppImageCacheKey(entry.name)) {
+      continue
+    } else if (
+      protectedRoots.has(resolve(entryPath)) ||
+      (existsSync(getAppImageActiveExtractionPath(entryPath)) &&
+        !(await isOlderThanGrace(getAppImageActiveExtractionPath(entryPath))))
+    ) {
+      continue
+    }
+    await rm(entryPath, { recursive: true, force: true }).catch(() => {})
+  }
+}
+
+async function isOlderThanGrace(candidatePath: string): Promise<boolean> {
+  try {
+    return Date.now() - (await lstat(candidatePath)).mtimeMs >= STALE_EXTRACTION_GRACE_MS
+  } catch {
+    return true
+  }
+}

--- a/src/main/cli/appimage-extraction-pruning.ts
+++ b/src/main/cli/appimage-extraction-pruning.ts
@@ -1,9 +1,10 @@
 import { randomUUID } from 'node:crypto'
 import { existsSync } from 'node:fs'
 import type { Dirent } from 'node:fs'
-import { lstat, readlink, readdir, rename, rm, rmdir, symlink, unlink } from 'node:fs/promises'
+import { lstat, readlink, readdir, rename, rmdir, symlink, unlink } from 'node:fs/promises'
 import { basename, dirname, join, resolve } from 'node:path'
 import { isAppImageCacheKey, resolveCachedAppImagePayloadRoot } from './appimage-cache-layout'
+import { removeExtractedAppImagePayload } from './appimage-payload-removal'
 import {
   removeAppImageLegacyLiveEndpoint,
   resolveAppImageLauncherEndpointPath
@@ -133,7 +134,13 @@ async function pruneNamespace(
     ) {
       continue
     }
-    await rm(entryPath, { recursive: true, force: true }).catch(() => {})
+    // Best effort, but never silent: a swallowed failure here leaks a whole payload generation.
+    await removeExtractedAppImagePayload(entryPath).catch((error: unknown) => {
+      console.warn(
+        `[cli] could not reclaim AppImage payload ${entryPath}:`,
+        error instanceof Error ? error.message : error
+      )
+    })
   }
 }
 

--- a/src/main/cli/appimage-payload-removal.reentrancy.test.ts
+++ b/src/main/cli/appimage-payload-removal.reentrancy.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// Why a mocked rm: the property under test is the ORDER in which overlapping removals settle, which
+// real filesystem timing cannot pin down. Deferreds make the interleaving exact.
+const { rmMock } = vi.hoisted(() => ({ rmMock: vi.fn() }))
+vi.mock('node:fs/promises', () => ({ rm: rmMock }))
+
+const originalNoAsar = process.noAsar
+
+afterEach(() => {
+  process.noAsar = originalNoAsar
+  vi.resetModules()
+})
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void
+  const promise = new Promise<void>((r) => {
+    resolve = r
+  })
+  return { promise, resolve }
+}
+
+describe('removeExtractedAppImagePayload reentrancy', () => {
+  // The hazard is the FIRST removal settling while a later one is still running: a naive
+  // save/restore would hand the shim back and silently leak the rest of the second removal.
+  it('keeps asar interception disabled while a later removal is still running', async () => {
+    process.noAsar = false
+    const first = deferred()
+    const second = deferred()
+    rmMock.mockReset()
+    rmMock.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise)
+    const { removeExtractedAppImagePayload } = await import('./appimage-payload-removal')
+
+    const firstCall = removeExtractedAppImagePayload('/cache/gen-a')
+    const secondCall = removeExtractedAppImagePayload('/cache/gen-b')
+    expect(process.noAsar).toBe(true)
+
+    first.resolve()
+    await firstCall
+    // gen-b is still being removed: handing the shim back here is exactly the leak.
+    expect(process.noAsar).toBe(true)
+
+    second.resolve()
+    await secondCall
+    expect(process.noAsar).toBe(false)
+  })
+
+  it('keeps the flag held when the first removal rejects mid-overlap', async () => {
+    process.noAsar = false
+    const second = deferred()
+    rmMock.mockReset()
+    rmMock.mockRejectedValueOnce(new Error('EACCES')).mockReturnValueOnce(second.promise)
+    const { removeExtractedAppImagePayload } = await import('./appimage-payload-removal')
+
+    const firstCall = removeExtractedAppImagePayload('/cache/gen-a')
+    const secondCall = removeExtractedAppImagePayload('/cache/gen-b')
+
+    await expect(firstCall).rejects.toThrow('EACCES')
+    expect(process.noAsar).toBe(true)
+
+    second.resolve()
+    await secondCall
+    expect(process.noAsar).toBe(false)
+  })
+})

--- a/src/main/cli/appimage-payload-removal.test.ts
+++ b/src/main/cli/appimage-payload-removal.test.ts
@@ -1,0 +1,66 @@
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { removeExtractedAppImagePayload } from './appimage-payload-removal'
+
+const originalNoAsar = process.noAsar
+
+afterEach(() => {
+  process.noAsar = originalNoAsar
+})
+
+async function makePayloadTree(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'orca-payload-removal-'))
+  await mkdir(join(root, 'resources'), { recursive: true })
+  // The real leak: Electron's fs patch reports a *.asar file as a directory.
+  await writeFile(join(root, 'resources', 'app.asar'), 'asar-payload')
+  await writeFile(join(root, 'AppRun'), '#!/bin/sh\n')
+  return root
+}
+
+describe('removeExtractedAppImagePayload', () => {
+  it('removes a payload tree containing an asar file', async () => {
+    const root = await makePayloadTree()
+    await removeExtractedAppImagePayload(root)
+    expect(existsSync(root)).toBe(false)
+  })
+
+  it('disables asar interception for the removal', async () => {
+    const root = await makePayloadTree()
+    let observed: boolean | undefined
+    const originalRealpath = process.noAsar
+    Object.defineProperty(process, 'noAsar', {
+      configurable: true,
+      get: () => observed ?? originalRealpath,
+      set: (value: boolean) => {
+        observed ??= value
+      }
+    })
+    try {
+      await removeExtractedAppImagePayload(root)
+    } finally {
+      Object.defineProperty(process, 'noAsar', {
+        configurable: true,
+        writable: true,
+        value: originalRealpath
+      })
+    }
+    expect(observed).toBe(true)
+  })
+
+  it('restores the previous asar setting after a failure', async () => {
+    process.noAsar = false
+    await expect(
+      removeExtractedAppImagePayload(join(tmpdir(), 'orca-missing', 'nested', '\0invalid'))
+    ).rejects.toThrow()
+    expect(process.noAsar).toBe(false)
+  })
+
+  it('is a no-op for a path that does not exist', async () => {
+    await expect(
+      removeExtractedAppImagePayload(join(tmpdir(), 'orca-payload-removal-absent'))
+    ).resolves.toBeUndefined()
+  })
+})

--- a/src/main/cli/appimage-payload-removal.ts
+++ b/src/main/cli/appimage-payload-removal.ts
@@ -1,0 +1,35 @@
+import { rm } from 'node:fs/promises'
+
+// Why a counter and not a saved value: `process.noAsar` is process-wide, so two overlapping
+// removals would race — the first to settle would restore the shim while the second is still
+// running, and the rest of that removal would silently leak again. Removals are sequential today;
+// this keeps that a property of the module rather than of its callers.
+let activeRemovals = 0
+// Captured once when the outermost removal starts; `process.noAsar` is typed boolean, and an
+// unset flag is falsy, so restoring `false` is equivalent to restoring `undefined`.
+let asarBeforeOutermostRemoval = false
+
+/**
+ * Removes an extracted AppImage payload tree.
+ *
+ * Why not a plain recursive `rm`: Electron patches `fs` so a `*.asar` file reports
+ * `isDirectory() === true`. A recursive remove then tries to `rmdir` a real file, fails with
+ * ENOTEMPTY, and strands the ~105 MB `resources/app.asar` of every superseded generation.
+ * `process.noAsar` restores real filesystem semantics; the window is ~33 ms for a full 519 MB
+ * generation, and nothing in the registration path reads asar content inside it.
+ */
+export async function removeExtractedAppImagePayload(targetPath: string): Promise<void> {
+  if (activeRemovals === 0) {
+    asarBeforeOutermostRemoval = process.noAsar === true
+  }
+  activeRemovals += 1
+  process.noAsar = true
+  try {
+    await rm(targetPath, { recursive: true, force: true })
+  } finally {
+    activeRemovals -= 1
+    if (activeRemovals === 0) {
+      process.noAsar = asarBeforeOutermostRemoval
+    }
+  }
+}

--- a/src/main/cli/appimage-registration-lock.test.ts
+++ b/src/main/cli/appimage-registration-lock.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { lockMock, mkdirMock } = vi.hoisted(() => ({ lockMock: vi.fn(), mkdirMock: vi.fn() }))
+
+vi.mock('proper-lockfile', () => ({ lock: lockMock }))
+vi.mock('node:fs/promises', () => ({ mkdir: mkdirMock }))
+
+afterEach(() => {
+  vi.resetModules()
+})
+
+async function load() {
+  mkdirMock.mockReset().mockResolvedValue(undefined)
+  return import('./appimage-registration-lock')
+}
+
+describe('withAppImageRegistrationLock', () => {
+  it('bounds the wait with a wall-clock deadline, not just an attempt count', async () => {
+    lockMock.mockReset().mockResolvedValue(vi.fn().mockResolvedValue(undefined))
+    const { withAppImageRegistrationLock } = await load()
+
+    await withAppImageRegistrationLock('/cache/orca/appimage', async () => 'done')
+
+    const options = lockMock.mock.calls[0][1]
+    // Why: `retries` alone caps attempts, not elapsed time — 1000 x 1s is ~16 minutes.
+    expect(options.retries.maxRetryTime).toBeGreaterThan(0)
+    expect(options.retries.maxRetryTime).toBeLessThanOrEqual(options.stale)
+  })
+
+  it('reports a wedged holder with a remedy instead of hanging', async () => {
+    lockMock.mockReset().mockRejectedValue(Object.assign(new Error('ELOCKED'), { code: 'ELOCKED' }))
+    const { withAppImageRegistrationLock } = await load()
+
+    await expect(
+      withAppImageRegistrationLock('/cache/orca/appimage', async () => 'done')
+    ).rejects.toThrow(/Timed out waiting for another Orca process[\s\S]*remove .*\.lock/)
+  })
+
+  it('releases the lock when the operation throws', async () => {
+    const release = vi.fn().mockResolvedValue(undefined)
+    lockMock.mockReset().mockResolvedValue(release)
+    const { withAppImageRegistrationLock } = await load()
+
+    await expect(
+      withAppImageRegistrationLock('/cache/orca/appimage', async () => {
+        throw new Error('boom')
+      })
+    ).rejects.toThrow('boom')
+    expect(release).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/cli/appimage-registration-lock.ts
+++ b/src/main/cli/appimage-registration-lock.ts
@@ -1,0 +1,32 @@
+import { mkdir } from 'node:fs/promises'
+import { join } from 'node:path'
+import { lock } from 'proper-lockfile'
+import { APPIMAGE_EXTRACTION_TIMEOUT_MS } from './appimage-extraction-pruning'
+
+const LOCK_TARGET_NAME = '.cli-registration'
+const LOCK_STALE_MS = APPIMAGE_EXTRACTION_TIMEOUT_MS * 3
+const LOCK_RETRIES = {
+  retries: 1_000,
+  factor: 1.2,
+  minTimeout: 25,
+  maxTimeout: 1_000,
+  randomize: true
+}
+
+export async function withAppImageRegistrationLock<T>(
+  cacheRootPath: string,
+  operation: () => Promise<T>
+): Promise<T> {
+  await mkdir(cacheRootPath, { recursive: true, mode: 0o700 })
+  const release = await lock(join(cacheRootPath, LOCK_TARGET_NAME), {
+    realpath: false,
+    retries: LOCK_RETRIES,
+    stale: LOCK_STALE_MS,
+    update: APPIMAGE_EXTRACTION_TIMEOUT_MS / 10
+  })
+  try {
+    return await operation()
+  } finally {
+    await release()
+  }
+}

--- a/src/main/cli/appimage-registration-lock.ts
+++ b/src/main/cli/appimage-registration-lock.ts
@@ -5,12 +5,18 @@ import { APPIMAGE_EXTRACTION_TIMEOUT_MS } from './appimage-extraction-pruning'
 
 const LOCK_TARGET_NAME = '.cli-registration'
 const LOCK_STALE_MS = APPIMAGE_EXTRACTION_TIMEOUT_MS * 3
+// Why a wall-clock deadline: `retries` alone bounds the attempt count, not the wait — 1000 attempts
+// at up to 1s each let an IPC-driven registration hang ~16 minutes against a wedged holder with no
+// feedback. A legitimate holder is bounded by the extraction timeout, so anything past that plus
+// slack is wedged, and failing with a message beats hanging.
+const LOCK_ACQUIRE_DEADLINE_MS = APPIMAGE_EXTRACTION_TIMEOUT_MS + 30_000
 const LOCK_RETRIES = {
   retries: 1_000,
   factor: 1.2,
   minTimeout: 25,
   maxTimeout: 1_000,
-  randomize: true
+  randomize: true,
+  maxRetryTime: LOCK_ACQUIRE_DEADLINE_MS
 }
 
 export async function withAppImageRegistrationLock<T>(
@@ -18,12 +24,22 @@ export async function withAppImageRegistrationLock<T>(
   operation: () => Promise<T>
 ): Promise<T> {
   await mkdir(cacheRootPath, { recursive: true, mode: 0o700 })
-  const release = await lock(join(cacheRootPath, LOCK_TARGET_NAME), {
-    realpath: false,
-    retries: LOCK_RETRIES,
-    stale: LOCK_STALE_MS,
-    update: APPIMAGE_EXTRACTION_TIMEOUT_MS / 10
-  })
+  let release: () => Promise<void>
+  try {
+    release = await lock(join(cacheRootPath, LOCK_TARGET_NAME), {
+      realpath: false,
+      retries: LOCK_RETRIES,
+      stale: LOCK_STALE_MS,
+      update: APPIMAGE_EXTRACTION_TIMEOUT_MS / 10
+    })
+  } catch (error) {
+    throw new Error(
+      `Timed out waiting for another Orca process to finish CLI registration ` +
+        `(waited ${Math.round(LOCK_ACQUIRE_DEADLINE_MS / 1000)}s). ` +
+        `If no other Orca is running, remove ${join(cacheRootPath, LOCK_TARGET_NAME)}.lock and retry.`,
+      { cause: error }
+    )
+  }
   try {
     return await operation()
   } finally {

--- a/src/main/cli/appimage-stable-launcher.test.ts
+++ b/src/main/cli/appimage-stable-launcher.test.ts
@@ -1,0 +1,185 @@
+import { existsSync } from 'node:fs'
+import type * as NodeFs from 'node:fs'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { runProcess } from '../../shared/child-process/run-process'
+
+const { filePublicationFailures } = vi.hoisted(() => ({
+  filePublicationFailures: { copy: 0, link: 0, replaceBeforeRename: '' }
+}))
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFs>()
+  return {
+    ...actual,
+    copyFileSync: (...args: Parameters<typeof actual.copyFileSync>) => {
+      if (filePublicationFailures.copy > 0) {
+        filePublicationFailures.copy -= 1
+        throw Object.assign(new Error('copy unsupported'), { code: 'ENOTSUP' })
+      }
+      return actual.copyFileSync(...args)
+    },
+    linkSync: (...args: Parameters<typeof actual.linkSync>) => {
+      if (filePublicationFailures.link > 0) {
+        filePublicationFailures.link -= 1
+        throw Object.assign(new Error('link unsupported'), { code: 'ENOTSUP' })
+      }
+      return actual.linkSync(...args)
+    },
+    renameSync: (...args: Parameters<typeof actual.renameSync>) => {
+      if (filePublicationFailures.replaceBeforeRename) {
+        actual.writeFileSync(args[0], filePublicationFailures.replaceBeforeRename, { mode: 0o755 })
+        filePublicationFailures.replaceBeforeRename = ''
+      }
+      return actual.renameSync(...args)
+    }
+  }
+})
+import {
+  publishAppImageLauncherEndpoint,
+  resolveAppImageLauncherEndpointPath,
+  resolveAppImageStableLauncherPath
+} from './appimage-stable-launcher'
+
+const created: string[] = []
+
+afterEach(async () => {
+  filePublicationFailures.copy = 0
+  filePublicationFailures.link = 0
+  filePublicationFailures.replaceBeforeRename = ''
+  await Promise.all(created.splice(0).map((path) => rm(path, { recursive: true, force: true })))
+})
+
+async function makeFixture(): Promise<string> {
+  const cacheRootPath = await mkdtemp(join(tmpdir(), 'orca-stable-appimage-launcher-'))
+  created.push(cacheRootPath)
+  return cacheRootPath
+}
+
+async function writeLauncher(path: string, output: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true })
+  await writeFile(path, `#!/usr/bin/env bash\nprintf '${output}'`, { mode: 0o755 })
+}
+
+describe('AppImage stable launcher', () => {
+  it('prefers the live mount and falls back to the installed payload', async () => {
+    const cacheRootPath = await makeFixture()
+    const livePath = join(cacheRootPath, 'payloads', 'live')
+    const installedPath = join(cacheRootPath, 'payloads', 'installed')
+    await Promise.all([writeLauncher(livePath, 'live'), writeLauncher(installedPath, 'installed')])
+
+    expect(
+      publishAppImageLauncherEndpoint(cacheRootPath, 'installed', installedPath)
+    ).not.toBeNull()
+    const launcherPath = publishAppImageLauncherEndpoint(cacheRootPath, 'live', livePath)!
+    await expect(
+      runProcess({ program: launcherPath, args: [], timeoutMs: 3_000 })
+    ).resolves.toMatchObject({ code: 0, stdout: 'live' })
+
+    await rm(livePath)
+    await expect(
+      runProcess({ program: launcherPath, args: [], timeoutMs: 3_000 })
+    ).resolves.toMatchObject({ code: 0, stdout: 'installed' })
+  })
+
+  it('observes an endpoint published after the wrapper starts', async () => {
+    const cacheRootPath = await makeFixture()
+    const missingPath = join(cacheRootPath, 'payloads', 'missing')
+    const readyPath = join(cacheRootPath, 'payloads', 'ready')
+    const launcherPath = publishAppImageLauncherEndpoint(cacheRootPath, 'live', missingPath)!
+    const invocation = runProcess({ program: launcherPath, args: [], timeoutMs: 3_000 })
+    setTimeout(() => {
+      void writeLauncher(readyPath, 'ready').then(() => {
+        publishAppImageLauncherEndpoint(cacheRootPath, 'live', readyPath)
+      })
+    }, 100)
+
+    await expect(invocation).resolves.toMatchObject({ code: 0, stdout: 'ready' })
+  })
+
+  it('atomically upgrades a stale marker-owned launcher', async () => {
+    const cacheRootPath = await makeFixture()
+    const targetPath = join(cacheRootPath, 'payloads', 'target')
+    await writeLauncher(targetPath, 'target')
+    const launcherPath = publishAppImageLauncherEndpoint(cacheRootPath, 'live', targetPath)!
+    const marker = (await readFile(launcherPath, 'utf8')).split('\n')[1]
+    await writeFile(launcherPath, `#!/usr/bin/env bash\n${marker}\nprintf stale`, { mode: 0o755 })
+
+    expect(publishAppImageLauncherEndpoint(cacheRootPath, 'live', targetPath)).toBe(launcherPath)
+    expect(await readFile(launcherPath, 'utf8')).toContain('launcher_dir=')
+    await expect(
+      runProcess({ program: launcherPath, args: [], timeoutMs: 3_000 })
+    ).resolves.toMatchObject({ code: 0, stdout: 'target' })
+  })
+
+  it('publishes on a cache filesystem without hard-link support', async () => {
+    const cacheRootPath = await makeFixture()
+    const targetPath = join(cacheRootPath, 'payloads', 'target')
+    await writeLauncher(targetPath, 'target')
+    filePublicationFailures.link = 1
+
+    const launcherPath = publishAppImageLauncherEndpoint(cacheRootPath, 'live', targetPath)
+
+    expect(launcherPath).toBe(resolveAppImageStableLauncherPath(cacheRootPath))
+    await expect(readFile(launcherPath!, 'utf8')).resolves.toContain('launcher_dir=')
+  })
+
+  it('restores a displaced owned launcher when its replacement cannot be published', async () => {
+    const cacheRootPath = await makeFixture()
+    const targetPath = join(cacheRootPath, 'payloads', 'target')
+    await writeLauncher(targetPath, 'target')
+    const launcherPath = publishAppImageLauncherEndpoint(cacheRootPath, 'live', targetPath)!
+    const marker = (await readFile(launcherPath, 'utf8')).split('\n')[1]
+    const staleContent = `#!/usr/bin/env bash\n${marker}\nprintf stale`
+    await writeFile(launcherPath, staleContent, { mode: 0o755 })
+    filePublicationFailures.link = 2
+    filePublicationFailures.copy = 2
+
+    expect(publishAppImageLauncherEndpoint(cacheRootPath, 'live', targetPath)).toBeNull()
+    await expect(readFile(launcherPath, 'utf8')).resolves.toBe(staleContent)
+  })
+
+  it('restores a displaced foreign launcher when hard links are unsupported', async () => {
+    const cacheRootPath = await makeFixture()
+    const targetPath = join(cacheRootPath, 'payloads', 'target')
+    await writeLauncher(targetPath, 'target')
+    const launcherPath = publishAppImageLauncherEndpoint(cacheRootPath, 'live', targetPath)!
+    const marker = (await readFile(launcherPath, 'utf8')).split('\n')[1]
+    await writeFile(launcherPath, `#!/usr/bin/env bash\n${marker}\nprintf stale`, { mode: 0o755 })
+    const foreignContent = '#!/usr/bin/env bash\nprintf foreign'
+    filePublicationFailures.replaceBeforeRename = foreignContent
+    filePublicationFailures.link = 2
+
+    expect(publishAppImageLauncherEndpoint(cacheRootPath, 'live', targetPath)).toBeNull()
+    await expect(readFile(launcherPath, 'utf8')).resolves.toBe(foreignContent)
+  })
+
+  it('preserves a foreign launcher and declines endpoint publication', async () => {
+    const cacheRootPath = await makeFixture()
+    const launcherPath = resolveAppImageStableLauncherPath(cacheRootPath)
+    const endpointPath = resolveAppImageLauncherEndpointPath(cacheRootPath, 'live')
+    await mkdir(dirname(launcherPath), { recursive: true })
+    await writeFile(launcherPath, '#!/usr/bin/env bash\nprintf foreign', { mode: 0o755 })
+
+    expect(
+      publishAppImageLauncherEndpoint(cacheRootPath, 'live', join(cacheRootPath, 'target'))
+    ).toBeNull()
+    await expect(readFile(launcherPath, 'utf8')).resolves.toContain('foreign')
+    expect(existsSync(endpointPath)).toBe(false)
+  })
+
+  it('preserves an oversized foreign launcher without treating its marker as ownership', async () => {
+    const cacheRootPath = await makeFixture()
+    const launcherPath = resolveAppImageStableLauncherPath(cacheRootPath)
+    const content = `#!/usr/bin/env bash\n# orca-appimage-stable-launcher\n${'x'.repeat(20_000)}`
+    await mkdir(dirname(launcherPath), { recursive: true })
+    await writeFile(launcherPath, content, { mode: 0o755 })
+
+    expect(
+      publishAppImageLauncherEndpoint(cacheRootPath, 'live', join(cacheRootPath, 'target'))
+    ).toBeNull()
+    await expect(readFile(launcherPath, 'utf8')).resolves.toBe(content)
+  })
+})

--- a/src/main/cli/appimage-stable-launcher.test.ts
+++ b/src/main/cli/appimage-stable-launcher.test.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs'
 import type * as NodeFs from 'node:fs'
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -63,36 +63,30 @@ async function writeLauncher(path: string, output: string): Promise<void> {
   await writeFile(path, `#!/usr/bin/env bash\nprintf '${output}'`, { mode: 0o755 })
 }
 
-describe('AppImage stable launcher', () => {
-  it('prefers the live mount and falls back to the installed payload', async () => {
+describe.skipIf(process.platform === 'win32')('AppImage stable launcher', () => {
+  it('uses only the installed payload and ignores a legacy live endpoint', async () => {
     const cacheRootPath = await makeFixture()
     const livePath = join(cacheRootPath, 'payloads', 'live')
     const installedPath = join(cacheRootPath, 'payloads', 'installed')
     await Promise.all([writeLauncher(livePath, 'live'), writeLauncher(installedPath, 'installed')])
 
-    expect(
-      publishAppImageLauncherEndpoint(cacheRootPath, 'installed', installedPath)
-    ).not.toBeNull()
-    const launcherPath = publishAppImageLauncherEndpoint(cacheRootPath, 'live', livePath)!
-    await expect(
-      runProcess({ program: launcherPath, args: [], timeoutMs: 3_000 })
-    ).resolves.toMatchObject({ code: 0, stdout: 'live' })
-
-    await rm(livePath)
+    const launcherPath = publishAppImageLauncherEndpoint(cacheRootPath, 'installed', installedPath)!
+    await symlink(livePath, resolveAppImageLauncherEndpointPath(cacheRootPath, 'live'))
     await expect(
       runProcess({ program: launcherPath, args: [], timeoutMs: 3_000 })
     ).resolves.toMatchObject({ code: 0, stdout: 'installed' })
+    expect(await readFile(launcherPath, 'utf8')).not.toContain('/live')
   })
 
   it('observes an endpoint published after the wrapper starts', async () => {
     const cacheRootPath = await makeFixture()
     const missingPath = join(cacheRootPath, 'payloads', 'missing')
     const readyPath = join(cacheRootPath, 'payloads', 'ready')
-    const launcherPath = publishAppImageLauncherEndpoint(cacheRootPath, 'live', missingPath)!
+    const launcherPath = publishAppImageLauncherEndpoint(cacheRootPath, 'installed', missingPath)!
     const invocation = runProcess({ program: launcherPath, args: [], timeoutMs: 3_000 })
     setTimeout(() => {
       void writeLauncher(readyPath, 'ready').then(() => {
-        publishAppImageLauncherEndpoint(cacheRootPath, 'live', readyPath)
+        publishAppImageLauncherEndpoint(cacheRootPath, 'installed', readyPath)
       })
     }, 100)
 
@@ -103,11 +97,13 @@ describe('AppImage stable launcher', () => {
     const cacheRootPath = await makeFixture()
     const targetPath = join(cacheRootPath, 'payloads', 'target')
     await writeLauncher(targetPath, 'target')
-    const launcherPath = publishAppImageLauncherEndpoint(cacheRootPath, 'live', targetPath)!
+    const launcherPath = publishAppImageLauncherEndpoint(cacheRootPath, 'installed', targetPath)!
     const marker = (await readFile(launcherPath, 'utf8')).split('\n')[1]
     await writeFile(launcherPath, `#!/usr/bin/env bash\n${marker}\nprintf stale`, { mode: 0o755 })
 
-    expect(publishAppImageLauncherEndpoint(cacheRootPath, 'live', targetPath)).toBe(launcherPath)
+    expect(publishAppImageLauncherEndpoint(cacheRootPath, 'installed', targetPath)).toBe(
+      launcherPath
+    )
     expect(await readFile(launcherPath, 'utf8')).toContain('launcher_dir=')
     await expect(
       runProcess({ program: launcherPath, args: [], timeoutMs: 3_000 })
@@ -120,7 +116,7 @@ describe('AppImage stable launcher', () => {
     await writeLauncher(targetPath, 'target')
     filePublicationFailures.link = 1
 
-    const launcherPath = publishAppImageLauncherEndpoint(cacheRootPath, 'live', targetPath)
+    const launcherPath = publishAppImageLauncherEndpoint(cacheRootPath, 'installed', targetPath)
 
     expect(launcherPath).toBe(resolveAppImageStableLauncherPath(cacheRootPath))
     await expect(readFile(launcherPath!, 'utf8')).resolves.toContain('launcher_dir=')
@@ -130,14 +126,14 @@ describe('AppImage stable launcher', () => {
     const cacheRootPath = await makeFixture()
     const targetPath = join(cacheRootPath, 'payloads', 'target')
     await writeLauncher(targetPath, 'target')
-    const launcherPath = publishAppImageLauncherEndpoint(cacheRootPath, 'live', targetPath)!
+    const launcherPath = publishAppImageLauncherEndpoint(cacheRootPath, 'installed', targetPath)!
     const marker = (await readFile(launcherPath, 'utf8')).split('\n')[1]
     const staleContent = `#!/usr/bin/env bash\n${marker}\nprintf stale`
     await writeFile(launcherPath, staleContent, { mode: 0o755 })
     filePublicationFailures.link = 2
     filePublicationFailures.copy = 2
 
-    expect(publishAppImageLauncherEndpoint(cacheRootPath, 'live', targetPath)).toBeNull()
+    expect(publishAppImageLauncherEndpoint(cacheRootPath, 'installed', targetPath)).toBeNull()
     await expect(readFile(launcherPath, 'utf8')).resolves.toBe(staleContent)
   })
 
@@ -145,26 +141,26 @@ describe('AppImage stable launcher', () => {
     const cacheRootPath = await makeFixture()
     const targetPath = join(cacheRootPath, 'payloads', 'target')
     await writeLauncher(targetPath, 'target')
-    const launcherPath = publishAppImageLauncherEndpoint(cacheRootPath, 'live', targetPath)!
+    const launcherPath = publishAppImageLauncherEndpoint(cacheRootPath, 'installed', targetPath)!
     const marker = (await readFile(launcherPath, 'utf8')).split('\n')[1]
     await writeFile(launcherPath, `#!/usr/bin/env bash\n${marker}\nprintf stale`, { mode: 0o755 })
     const foreignContent = '#!/usr/bin/env bash\nprintf foreign'
     filePublicationFailures.replaceBeforeRename = foreignContent
     filePublicationFailures.link = 2
 
-    expect(publishAppImageLauncherEndpoint(cacheRootPath, 'live', targetPath)).toBeNull()
+    expect(publishAppImageLauncherEndpoint(cacheRootPath, 'installed', targetPath)).toBeNull()
     await expect(readFile(launcherPath, 'utf8')).resolves.toBe(foreignContent)
   })
 
   it('preserves a foreign launcher and declines endpoint publication', async () => {
     const cacheRootPath = await makeFixture()
     const launcherPath = resolveAppImageStableLauncherPath(cacheRootPath)
-    const endpointPath = resolveAppImageLauncherEndpointPath(cacheRootPath, 'live')
+    const endpointPath = resolveAppImageLauncherEndpointPath(cacheRootPath, 'installed')
     await mkdir(dirname(launcherPath), { recursive: true })
     await writeFile(launcherPath, '#!/usr/bin/env bash\nprintf foreign', { mode: 0o755 })
 
     expect(
-      publishAppImageLauncherEndpoint(cacheRootPath, 'live', join(cacheRootPath, 'target'))
+      publishAppImageLauncherEndpoint(cacheRootPath, 'installed', join(cacheRootPath, 'target'))
     ).toBeNull()
     await expect(readFile(launcherPath, 'utf8')).resolves.toContain('foreign')
     expect(existsSync(endpointPath)).toBe(false)
@@ -178,7 +174,7 @@ describe('AppImage stable launcher', () => {
     await writeFile(launcherPath, content, { mode: 0o755 })
 
     expect(
-      publishAppImageLauncherEndpoint(cacheRootPath, 'live', join(cacheRootPath, 'target'))
+      publishAppImageLauncherEndpoint(cacheRootPath, 'installed', join(cacheRootPath, 'target'))
     ).toBeNull()
     await expect(readFile(launcherPath, 'utf8')).resolves.toBe(content)
   })

--- a/src/main/cli/appimage-stable-launcher.ts
+++ b/src/main/cli/appimage-stable-launcher.ts
@@ -1,0 +1,226 @@
+import { randomUUID } from 'node:crypto'
+import {
+  closeSync,
+  constants,
+  copyFileSync,
+  fstatSync,
+  linkSync,
+  mkdirSync,
+  openSync,
+  readSync,
+  renameSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync
+} from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { LINUX_CLI_COMMAND_NAME } from './bundled-cli-launcher-path'
+import { quoteShell } from './cli-install-path-format'
+
+const LAUNCHER_DIRECTORY_NAME = 'launcher'
+const LIVE_ENDPOINT_NAME = 'live'
+const INSTALLED_ENDPOINT_NAME = 'installed'
+const LAUNCHER_MARKER = '# orca-appimage-stable-launcher'
+const LAUNCHER_WAIT_SECONDS = 5
+const LAUNCHER_MAX_BYTES = 16 * 1024
+
+export type AppImageLauncherEndpoint = 'live' | 'installed'
+
+export function resolveAppImageStableLauncherPath(cacheRootPath: string): string {
+  return join(resolve(cacheRootPath), LAUNCHER_DIRECTORY_NAME, LINUX_CLI_COMMAND_NAME)
+}
+
+export function resolveAppImageLauncherEndpointPath(
+  cacheRootPath: string,
+  endpoint: AppImageLauncherEndpoint
+): string {
+  return join(
+    dirname(resolveAppImageStableLauncherPath(cacheRootPath)),
+    endpoint === 'live' ? LIVE_ENDPOINT_NAME : INSTALLED_ENDPOINT_NAME
+  )
+}
+
+export function isAppImageStableLauncherReady(cacheRootPath: string): boolean {
+  const launcherPath = resolveAppImageStableLauncherPath(cacheRootPath)
+  return isExactExecutableLauncher(launcherPath, buildStableLauncherScript(cacheRootPath))
+}
+
+export function publishAppImageLauncherEndpoint(
+  cacheRootPath: string,
+  endpoint: AppImageLauncherEndpoint,
+  targetPath: string
+): string | null {
+  const launcherPath = ensureAppImageStableLauncher(cacheRootPath)
+  if (!launcherPath) {
+    return null
+  }
+
+  const endpointPath = resolveAppImageLauncherEndpointPath(cacheRootPath, endpoint)
+  const temporaryPath = join(dirname(endpointPath), `.${endpoint}-${process.pid}-${randomUUID()}`)
+  try {
+    symlinkSync(targetPath, temporaryPath)
+    renameSync(temporaryPath, endpointPath)
+    return launcherPath
+  } catch {
+    return null
+  } finally {
+    try {
+      unlinkSync(temporaryPath)
+    } catch {}
+  }
+}
+
+function ensureAppImageStableLauncher(cacheRootPath: string): string | null {
+  const launcherPath = resolveAppImageStableLauncherPath(cacheRootPath)
+  const content = buildStableLauncherScript(cacheRootPath)
+  try {
+    mkdirSync(dirname(launcherPath), { recursive: true })
+    if (!installLauncher(launcherPath, content)) {
+      return null
+    }
+    return launcherPath
+  } catch {
+    return null
+  }
+}
+
+function installLauncher(launcherPath: string, content: string): boolean {
+  if (isExactExecutableLauncher(launcherPath, content)) {
+    return true
+  }
+  const temporaryPath = join(
+    dirname(launcherPath),
+    `.${LINUX_CLI_COMMAND_NAME}-${process.pid}-${randomUUID()}`
+  )
+  try {
+    writeFileSync(temporaryPath, content, { encoding: 'utf8', flag: 'wx', mode: 0o755 })
+    if (publishLauncherIfVacant(temporaryPath, launcherPath)) {
+      return true
+    }
+    if (!isOwnedLauncher(launcherPath)) {
+      return false
+    }
+    return replaceOwnedLauncher(launcherPath, temporaryPath, content)
+  } finally {
+    unlinkIfPresent(temporaryPath)
+  }
+}
+
+function replaceOwnedLauncher(
+  launcherPath: string,
+  replacementPath: string,
+  replacementContent: string
+): boolean {
+  const displacedPath = join(
+    dirname(launcherPath),
+    `.orca-preserved-launcher-${process.pid}-${randomUUID()}`
+  )
+  try {
+    renameSync(launcherPath, displacedPath)
+  } catch {
+    return isExactExecutableLauncher(launcherPath, replacementContent)
+  }
+
+  if (!isOwnedLauncher(displacedPath)) {
+    restoreForeignLauncher(displacedPath, launcherPath)
+    return false
+  }
+
+  if (
+    publishLauncherIfVacant(replacementPath, launcherPath) ||
+    isExactExecutableLauncher(launcherPath, replacementContent)
+  ) {
+    unlinkIfPresent(displacedPath)
+    return true
+  }
+
+  if (publishLauncherIfVacant(displacedPath, launcherPath)) {
+    unlinkIfPresent(displacedPath)
+  }
+  return isExactExecutableLauncher(launcherPath, replacementContent)
+}
+
+function restoreForeignLauncher(displacedPath: string, launcherPath: string): void {
+  if (publishLauncherIfVacant(displacedPath, launcherPath)) {
+    unlinkIfPresent(displacedPath)
+  }
+}
+
+function publishLauncherIfVacant(sourcePath: string, destinationPath: string): boolean {
+  try {
+    linkSync(sourcePath, destinationPath)
+    return true
+  } catch {}
+  try {
+    copyFileSync(sourcePath, destinationPath, constants.COPYFILE_EXCL)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function isExactExecutableLauncher(launcherPath: string, content: string): boolean {
+  const launcher = readLauncherFile(launcherPath)
+  return launcher?.executable === true && launcher.content === content
+}
+
+function isOwnedLauncher(launcherPath: string): boolean {
+  return readLauncherFile(launcherPath)?.content.split('\n')[1] === LAUNCHER_MARKER
+}
+
+function readLauncherFile(launcherPath: string): { content: string; executable: boolean } | null {
+  let fd: number | undefined
+  try {
+    fd = openSync(launcherPath, constants.O_RDONLY | constants.O_NONBLOCK | constants.O_NOFOLLOW)
+    const before = fstatSync(fd)
+    if (!before.isFile() || before.size > LAUNCHER_MAX_BYTES) {
+      return null
+    }
+    const bytes = Buffer.alloc(before.size)
+    let offset = 0
+    while (offset < bytes.length) {
+      const count = readSync(fd, bytes, offset, bytes.length - offset, offset)
+      if (count === 0) {
+        return null
+      }
+      offset += count
+    }
+    const after = fstatSync(fd)
+    if (after.size !== before.size || after.mtimeMs !== before.mtimeMs) {
+      return null
+    }
+    return { content: bytes.toString('utf8'), executable: (before.mode & 0o111) !== 0 }
+  } catch {
+    return null
+  } finally {
+    if (fd !== undefined) {
+      closeSync(fd)
+    }
+  }
+}
+
+function unlinkIfPresent(candidatePath: string): void {
+  try {
+    unlinkSync(candidatePath)
+  } catch {}
+}
+
+function buildStableLauncherScript(cacheRootPath: string): string {
+  const launcherDirectory = dirname(resolveAppImageStableLauncherPath(cacheRootPath))
+  return `#!/usr/bin/env bash
+${LAUNCHER_MARKER}
+shopt -s execfail
+launcher_dir=${quoteShell(launcherDirectory)}
+deadline=$((SECONDS + ${LAUNCHER_WAIT_SECONDS}))
+while (( SECONDS <= deadline )); do
+  for launcher in "$launcher_dir/${LIVE_ENDPOINT_NAME}" "$launcher_dir/${INSTALLED_ENDPOINT_NAME}"; do
+    if [[ -f "$launcher" && -x "$launcher" ]]; then
+      exec "$launcher" "$@"
+    fi
+  done
+  sleep 0.1
+done
+printf 'Orca CLI is not ready; reopen Orca or register the CLI again.\\n' >&2
+exit 1
+`
+}

--- a/src/main/cli/appimage-stable-launcher.ts
+++ b/src/main/cli/appimage-stable-launcher.ts
@@ -5,6 +5,7 @@ import {
   copyFileSync,
   fstatSync,
   linkSync,
+  lstatSync,
   mkdirSync,
   openSync,
   readSync,
@@ -45,12 +46,27 @@ export function isAppImageStableLauncherReady(cacheRootPath: string): boolean {
   return isExactExecutableLauncher(launcherPath, buildStableLauncherScript(cacheRootPath))
 }
 
+/** Ensures the persistent wrapper exists without publishing an endpoint. */
+export function ensureAppImageStableLauncher(cacheRootPath: string): string | null {
+  return ensureAppImageStableLauncherFile(cacheRootPath)
+}
+
+/** Removes the legacy live endpoint only when it is a symlink. */
+export function removeAppImageLegacyLiveEndpoint(cacheRootPath: string): void {
+  const endpointPath = resolveAppImageLauncherEndpointPath(cacheRootPath, 'live')
+  try {
+    if (lstatSync(endpointPath).isSymbolicLink()) {
+      unlinkSync(endpointPath)
+    }
+  } catch {}
+}
+
 export function publishAppImageLauncherEndpoint(
   cacheRootPath: string,
-  endpoint: AppImageLauncherEndpoint,
+  endpoint: 'installed',
   targetPath: string
 ): string | null {
-  const launcherPath = ensureAppImageStableLauncher(cacheRootPath)
+  const launcherPath = ensureAppImageStableLauncherFile(cacheRootPath)
   if (!launcherPath) {
     return null
   }
@@ -70,7 +86,7 @@ export function publishAppImageLauncherEndpoint(
   }
 }
 
-function ensureAppImageStableLauncher(cacheRootPath: string): string | null {
+function ensureAppImageStableLauncherFile(cacheRootPath: string): string | null {
   const launcherPath = resolveAppImageStableLauncherPath(cacheRootPath)
   const content = buildStableLauncherScript(cacheRootPath)
   try {
@@ -213,11 +229,10 @@ shopt -s execfail
 launcher_dir=${quoteShell(launcherDirectory)}
 deadline=$((SECONDS + ${LAUNCHER_WAIT_SECONDS}))
 while (( SECONDS <= deadline )); do
-  for launcher in "$launcher_dir/${LIVE_ENDPOINT_NAME}" "$launcher_dir/${INSTALLED_ENDPOINT_NAME}"; do
-    if [[ -f "$launcher" && -x "$launcher" ]]; then
-      exec "$launcher" "$@"
-    fi
-  done
+  launcher="$launcher_dir/${INSTALLED_ENDPOINT_NAME}"
+  if [[ -f "$launcher" && -x "$launcher" ]]; then
+    exec "$launcher" "$@"
+  fi
   sleep 0.1
 done
 printf 'Orca CLI is not ready; reopen Orca or register the CLI again.\\n' >&2

--- a/src/main/cli/cli-command-filesystem-transaction.ts
+++ b/src/main/cli/cli-command-filesystem-transaction.ts
@@ -1,0 +1,209 @@
+import { createHash, randomUUID } from 'node:crypto'
+import { lstat, mkdir, readFile, readlink, rename, rmdir } from 'node:fs/promises'
+import { basename, dirname, join } from 'node:path'
+import type { CliInstallStatus } from '../../shared/cli-install-types'
+import { isMissingError } from './cli-install-errors'
+import { quoteShell } from './cli-install-path-format'
+
+export type EntryIdentity = {
+  dev: bigint
+  ino: bigint
+  mode: bigint
+  size: bigint
+  ctimeNs: bigint
+}
+
+export type EntrySnapshot = { identity: EntryIdentity; isSymbolicLink: boolean }
+export type CommandQuarantine = {
+  directoryPath: string
+  heldPath: string
+  snapshot: EntrySnapshot | null
+}
+export type StableCommandInspection = {
+  fileSha256: string | null
+  rawSymlinkTarget: string | null
+  snapshot: EntrySnapshot | null
+  status: CliInstallStatus
+}
+
+const STABLE_INSPECTION_ATTEMPTS = 3
+
+export async function readEntrySnapshot(path: string): Promise<EntrySnapshot | null> {
+  try {
+    const stats = await lstat(path, { bigint: true })
+    return {
+      identity: {
+        dev: stats.dev,
+        ino: stats.ino,
+        mode: stats.mode,
+        size: stats.size,
+        ctimeNs: stats.ctimeNs
+      },
+      isSymbolicLink: stats.isSymbolicLink()
+    }
+  } catch (error) {
+    if (isMissingError(error)) {
+      return null
+    }
+    throw error
+  }
+}
+
+export function hasSameIdentity(left: EntryIdentity | null, right: EntryIdentity | null): boolean {
+  return (
+    left === right ||
+    (left !== null && right !== null && left.dev === right.dev && left.ino === right.ino)
+  )
+}
+
+export function hasSameSnapshot(left: EntrySnapshot | null, right: EntrySnapshot | null): boolean {
+  return (
+    left === right ||
+    (left !== null &&
+      right !== null &&
+      hasSameIdentity(left.identity, right.identity) &&
+      left.identity.mode === right.identity.mode &&
+      left.identity.size === right.identity.size &&
+      left.identity.ctimeNs === right.identity.ctimeNs)
+  )
+}
+
+export async function hashCommandFile(path: string): Promise<string> {
+  return createHash('sha256')
+    .update(await readFile(path))
+    .digest('hex')
+}
+
+export async function inspectStableCommand(
+  commandPath: string,
+  inspect: () => Promise<CliInstallStatus>
+): Promise<StableCommandInspection> {
+  for (let attempt = 0; attempt < STABLE_INSPECTION_ATTEMPTS; attempt += 1) {
+    const before = await readEntrySnapshot(commandPath)
+    const status = await inspect()
+    const afterInspection = await readEntrySnapshot(commandPath)
+    if (
+      !hasSameSnapshot(before, afterInspection) ||
+      (afterInspection === null) !== (status.state === 'not_installed')
+    ) {
+      continue
+    }
+    let fileSha256: string | null = null
+    let rawSymlinkTarget: string | null = null
+    try {
+      if (afterInspection?.isSymbolicLink) {
+        rawSymlinkTarget = await readlink(commandPath)
+      } else if (afterInspection && status.state !== 'conflict') {
+        fileSha256 = await hashCommandFile(commandPath)
+      }
+    } catch {
+      continue
+    }
+    const afterEvidence = await readEntrySnapshot(commandPath)
+    if (hasSameSnapshot(afterInspection, afterEvidence)) {
+      return { fileSha256, rawSymlinkTarget, snapshot: afterEvidence, status }
+    }
+  }
+  throw new Error(`The command at ${commandPath} changed while Orca inspected it.`)
+}
+
+export async function quarantineCommandPath(commandPath: string): Promise<CommandQuarantine> {
+  const commandDirectory = dirname(commandPath)
+  const directoryPath = join(commandDirectory, `.orca-cli-${process.pid}-${randomUUID()}`)
+  const heldPath = join(directoryPath, basename(commandPath))
+  await mkdir(commandDirectory, { recursive: true })
+  await mkdir(directoryPath, { mode: 0o700 })
+  try {
+    await rename(commandPath, heldPath)
+  } catch (error) {
+    if (!isMissingError(error)) {
+      await rmdir(directoryPath).catch(() => undefined)
+      throw error
+    }
+  }
+  return { directoryPath, heldPath, snapshot: await readEntrySnapshot(heldPath) }
+}
+
+export async function capturedExpectedEntry(
+  quarantine: CommandQuarantine,
+  inspected: Pick<StableCommandInspection, 'fileSha256' | 'rawSymlinkTarget' | 'snapshot'>
+): Promise<boolean> {
+  if (!quarantine.snapshot) {
+    return true
+  }
+  if (
+    !inspected.snapshot ||
+    quarantine.snapshot.isSymbolicLink !== inspected.snapshot.isSymbolicLink ||
+    !hasSameIdentity(quarantine.snapshot.identity, inspected.snapshot.identity)
+  ) {
+    return false
+  }
+  if (inspected.rawSymlinkTarget !== null) {
+    try {
+      return (await readlink(quarantine.heldPath)) === inspected.rawSymlinkTarget
+    } catch {
+      return false
+    }
+  }
+  if (!inspected.fileSha256) {
+    return true
+  }
+  try {
+    return (await hashCommandFile(quarantine.heldPath)) === inspected.fileSha256
+  } catch {
+    return false
+  }
+}
+
+type MacPrivilegedSymlinkTransaction = {
+  commandPath: string
+  expected: EntryIdentity | null
+  expectedFileSha256: string | null
+  expectedRawSymlinkTarget: string | null
+} & ({ action: 'install'; launcherPath: string } | { action: 'remove' })
+
+export function buildMacPrivilegedSymlinkTransaction(
+  args: MacPrivilegedSymlinkTransaction
+): string {
+  const commandDirectory = dirname(args.commandPath)
+  const transactionDirectory = join(commandDirectory, `.orca-cli-${process.pid}-${randomUUID()}`)
+  const heldPath = join(transactionDirectory, basename(args.commandPath))
+  const publishDirectory = join(transactionDirectory, 'publish')
+  const publishPath = join(publishDirectory, basename(args.commandPath))
+  const recoveryMessage = quoteShell(`The displaced entry is preserved at ${heldPath}.`)
+  const restore =
+    `/bin/ln -P ${quoteShell(heldPath)} ${quoteShell(commandDirectory)} && ` +
+    `/bin/rm ${quoteShell(heldPath)} && /bin/rmdir ${quoteShell(transactionDirectory)}`
+  const restoreOrPreserve = `if ${restore}; then :; else echo ${recoveryMessage} >&2; exit 74; fi`
+  const fileMismatch = args.expectedFileSha256
+    ? ` || [ "$(/usr/bin/shasum -a 256 ${quoteShell(heldPath)} | /usr/bin/awk '{print $1}')" != ${quoteShell(args.expectedFileSha256)} ]`
+    : ''
+  const symlinkMismatch = args.expectedRawSymlinkTarget
+    ? ` || [ "$(/usr/bin/readlink -n ${quoteShell(heldPath)}; /usr/bin/printf x)" != ${quoteShell(`${args.expectedRawSymlinkTarget}x`)} ]`
+    : ''
+  const rejectCaptured = args.expected
+    ? `if [ "$captured" -eq 1 ] && { [ "$(/usr/bin/stat -f '%d:%i' ${quoteShell(heldPath)})" != ${quoteShell(`${args.expected.dev}:${args.expected.ino}`)} ]${fileMismatch}${symlinkMismatch}; }; then ${restoreOrPreserve}; exit 73; fi`
+    : `if [ "$captured" -eq 1 ]; then ${restoreOrPreserve}; exit 73; fi`
+  const capture =
+    `umask 077; /bin/mkdir -p ${quoteShell(commandDirectory)} || exit $?; ` +
+    `/bin/mkdir ${quoteShell(transactionDirectory)} || exit $?; captured=0; ` +
+    `if [ -e ${quoteShell(args.commandPath)} ] || [ -L ${quoteShell(args.commandPath)} ]; then ` +
+    `/bin/mv ${quoteShell(args.commandPath)} ${quoteShell(heldPath)} && captured=1 || exit $?; fi; ` +
+    `${rejectCaptured}; `
+
+  if (args.action === 'remove') {
+    return `${capture}if [ "$captured" -eq 1 ]; then /bin/rm ${quoteShell(heldPath)}; fi; /bin/rmdir ${quoteShell(transactionDirectory)}`
+  }
+
+  const rollback =
+    `/bin/rm ${quoteShell(publishPath)}; /bin/rmdir ${quoteShell(publishDirectory)}; ` +
+    `if [ "$captured" -eq 1 ]; then ${restoreOrPreserve}; else /bin/rmdir ${quoteShell(transactionDirectory)}; fi; exit 73`
+  return (
+    `${capture}/bin/mkdir ${quoteShell(publishDirectory)} || exit $?; ` +
+    `/bin/ln -s ${quoteShell(args.launcherPath)} ${quoteShell(publishPath)} || exit $?; ` +
+    `if /bin/ln -P ${quoteShell(publishPath)} ${quoteShell(commandDirectory)}; then ` +
+    `/bin/rm ${quoteShell(publishPath)}; /bin/rmdir ${quoteShell(publishDirectory)}; ` +
+    `if [ "$captured" -eq 1 ]; then /bin/rm ${quoteShell(heldPath)}; fi; ` +
+    `/bin/rmdir ${quoteShell(transactionDirectory)}; else ${rollback}; fi`
+  )
+}

--- a/src/main/cli/cli-command-filesystem-transaction.ts
+++ b/src/main/cli/cli-command-filesystem-transaction.ts
@@ -196,12 +196,12 @@ export function buildMacPrivilegedSymlinkTransaction(
   }
 
   const rollback =
-    `/bin/rm ${quoteShell(publishPath)}; /bin/rmdir ${quoteShell(publishDirectory)}; ` +
+    `/bin/rm -f ${quoteShell(publishPath)}; /bin/rmdir ${quoteShell(publishDirectory)} 2>/dev/null || :; ` +
     `if [ "$captured" -eq 1 ]; then ${restoreOrPreserve}; else /bin/rmdir ${quoteShell(transactionDirectory)}; fi; exit 73`
   return (
-    `${capture}/bin/mkdir ${quoteShell(publishDirectory)} || exit $?; ` +
-    `/bin/ln -s ${quoteShell(args.launcherPath)} ${quoteShell(publishPath)} || exit $?; ` +
-    `if /bin/ln -P ${quoteShell(publishPath)} ${quoteShell(commandDirectory)}; then ` +
+    `${capture}if /bin/mkdir ${quoteShell(publishDirectory)} && ` +
+    `/bin/ln -s ${quoteShell(args.launcherPath)} ${quoteShell(publishPath)} && ` +
+    `/bin/ln -P ${quoteShell(publishPath)} ${quoteShell(commandDirectory)}; then ` +
     `/bin/rm ${quoteShell(publishPath)}; /bin/rmdir ${quoteShell(publishDirectory)}; ` +
     `if [ "$captured" -eq 1 ]; then /bin/rm ${quoteShell(heldPath)}; fi; ` +
     `/bin/rmdir ${quoteShell(transactionDirectory)}; else ${rollback}; fi`

--- a/src/main/cli/cli-command-inspection.ts
+++ b/src/main/cli/cli-command-inspection.ts
@@ -1,62 +1,16 @@
+import { existsSync } from 'node:fs'
 import { lstat, readFile, readlink } from 'node:fs/promises'
 import { basename, dirname, resolve } from 'node:path'
 import type { CliInstallMethod, CliInstallStatus } from '../../shared/cli-install-types'
-import { buildAppImageCliWrapper } from './appimage-cli-wrapper'
+import { isAppImageExtractedLauncherPath } from './appimage-extracted-root'
 import { DEV_COMMAND_NAME, DEV_LAUNCHER_DIR } from './cli-install-constants'
 import { buildWindowsForwarder, extractManagedUnixLauncherTarget } from './cli-dev-launcher'
 import { isMissingError } from './cli-install-errors'
 import { CliInstallLocation } from './cli-install-location'
 import { isPathInsideOrEqual, samePathEntry } from './cli-install-path-format'
+import { extractLegacyAppImageCliWrapperTarget } from './legacy-appimage-cli-wrapper'
 
 export class CliCommandInspection extends CliInstallLocation {
-  protected async inspectAppImageWrapper(
-    commandPath: string,
-    appImagePath: string
-  ): Promise<CliInstallStatus> {
-    try {
-      const stats = await lstat(commandPath)
-      if (!stats.isFile()) {
-        return this.buildStatus({
-          commandPath,
-          launcherPath: appImagePath,
-          installMethod: 'wrapper',
-          supported: true,
-          state: 'conflict',
-          currentTarget: null,
-          detail: `${commandPath} exists but is not an Orca launcher script.`
-        })
-      }
-
-      const currentContent = await readFile(commandPath, 'utf8')
-      const expectedContent = buildAppImageCliWrapper(appImagePath)
-      return this.buildStatus({
-        commandPath,
-        launcherPath: appImagePath,
-        installMethod: 'wrapper',
-        supported: true,
-        state: currentContent === expectedContent ? 'installed' : 'stale',
-        currentTarget: appImagePath,
-        detail:
-          currentContent === expectedContent
-            ? `Registered at ${commandPath}.`
-            : `${commandPath} points to a different launcher.`
-      })
-    } catch (error) {
-      if (isMissingError(error)) {
-        return this.buildStatus({
-          commandPath,
-          launcherPath: appImagePath,
-          installMethod: 'wrapper',
-          supported: true,
-          state: 'not_installed',
-          currentTarget: null,
-          detail: `Register ${commandPath} to use Orca from the terminal.`
-        })
-      }
-      throw error
-    }
-  }
-
   protected async inspectSymlink(
     commandPath: string,
     launcherPath: string
@@ -66,7 +20,9 @@ export class CliCommandInspection extends CliInstallLocation {
       if (!stats.isSymbolicLink()) {
         if (stats.isFile()) {
           const currentContent = await readFile(commandPath, 'utf8')
-          const managedTarget = extractManagedUnixLauncherTarget(currentContent)
+          const managedTarget =
+            extractManagedUnixLauncherTarget(currentContent) ??
+            extractLegacyAppImageCliWrapperTarget(currentContent)
           if (managedTarget) {
             return this.buildStatus({
               commandPath,
@@ -94,9 +50,11 @@ export class CliCommandInspection extends CliInstallLocation {
       const currentTarget = await readlink(commandPath)
       const resolvedCurrentTarget = resolve(dirname(commandPath), currentTarget)
       const resolvedLauncher = resolve(launcherPath)
-      const isInstalled = resolvedCurrentTarget === resolvedLauncher
+      const isInstalled = resolvedCurrentTarget === resolvedLauncher && existsSync(resolvedLauncher)
       const isManagedStaleTarget =
-        !isInstalled && this.isManagedSymlinkTarget(resolvedCurrentTarget, launcherPath)
+        !isInstalled &&
+        (resolvedCurrentTarget === resolvedLauncher ||
+          this.isManagedSymlinkTarget(resolvedCurrentTarget, launcherPath))
       return this.buildStatus({
         commandPath,
         launcherPath,
@@ -149,7 +107,10 @@ export class CliCommandInspection extends CliInstallLocation {
     }
 
     if (this.platform === 'linux') {
-      return /(?:^|[/\\])resources[/\\]bin[/\\][^/\\]+$/.test(resolvedTarget)
+      const extractionOptions = this.appImageExtractionOptions()
+      return extractionOptions
+        ? isAppImageExtractedLauncherPath(extractionOptions, resolvedTarget)
+        : false
     }
 
     return false

--- a/src/main/cli/cli-command-inspection.ts
+++ b/src/main/cli/cli-command-inspection.ts
@@ -10,6 +10,11 @@ import { CliInstallLocation } from './cli-install-location'
 import { isPathInsideOrEqual, samePathEntry } from './cli-install-path-format'
 import { extractLegacyAppImageCliWrapperTarget } from './legacy-appimage-cli-wrapper'
 
+// Why: electron-builder's /opt directory name varies with productName sanitization, which is why
+// resources/linux/packaging/after-install.sh enumerates all three of these. A symlink into one is a
+// previous packaged Orca and is ours to reclaim; anything else stays a conflict.
+const PACKAGED_LINUX_LAUNCHER_DIRECTORIES = ['/opt/Orca', '/opt/orca-ide', '/opt/orca']
+
 export class CliCommandInspection extends CliInstallLocation {
   protected async inspectSymlink(
     commandPath: string,
@@ -107,6 +112,9 @@ export class CliCommandInspection extends CliInstallLocation {
     }
 
     if (this.platform === 'linux') {
+      if (this.isPackagedLinuxLauncherTarget(resolvedTarget, expectedName)) {
+        return true
+      }
       const extractionOptions = this.appImageExtractionOptions()
       return extractionOptions
         ? isAppImageExtractedLauncherPath(extractionOptions, resolvedTarget)
@@ -114,6 +122,13 @@ export class CliCommandInspection extends CliInstallLocation {
     }
 
     return false
+  }
+
+  /** A launcher inside a packaged Linux install tree, left behind by a deb/rpm Orca. */
+  protected isPackagedLinuxLauncherTarget(resolvedTarget: string, expectedName: string): boolean {
+    return PACKAGED_LINUX_LAUNCHER_DIRECTORIES.some(
+      (directory) => resolvedTarget === `${directory}/resources/bin/${expectedName}`
+    )
   }
 
   protected isSiblingDevLauncherTarget(

--- a/src/main/cli/cli-command-installation-races.test.ts
+++ b/src/main/cli/cli-command-installation-races.test.ts
@@ -1,0 +1,386 @@
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  readlink,
+  rm,
+  symlink,
+  unlink,
+  writeFile
+} from 'node:fs/promises'
+import type * as NodeFsPromises from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const legacyReadlinkRace = vi.hoisted(() => ({ commandPath: '', replacementTarget: '' }))
+const reusedIdentity = vi.hoisted(() => ({
+  path: '',
+  dev: null as bigint | null,
+  ino: null as bigint | null
+}))
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFsPromises>()
+  return {
+    ...actual,
+    lstat: async (...args: Parameters<typeof actual.lstat>) => {
+      const stats = await actual.lstat(...args)
+      if (
+        args[0] !== reusedIdentity.path ||
+        reusedIdentity.dev === null ||
+        reusedIdentity.ino === null
+      ) {
+        return stats
+      }
+      return Object.create(stats, {
+        dev: { value: reusedIdentity.dev },
+        ino: { value: reusedIdentity.ino }
+      }) as typeof stats
+    },
+    readlink: async (...args: Parameters<typeof actual.readlink>) => {
+      const [path] = args
+      if (path === legacyReadlinkRace.commandPath && legacyReadlinkRace.replacementTarget) {
+        const replacementTarget = legacyReadlinkRace.replacementTarget
+        legacyReadlinkRace.commandPath = ''
+        legacyReadlinkRace.replacementTarget = ''
+        await actual.unlink(path)
+        await actual.symlink(replacementTarget, path)
+        throw Object.assign(new Error('link vanished during inspection'), { code: 'ENOENT' })
+      }
+      return actual.readlink(...args)
+    }
+  }
+})
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getPath: () => tmpdir(),
+    getAppPath: () => tmpdir()
+  }
+}))
+
+import { CliInstaller } from './cli-installer'
+import type { CommandQuarantine } from './cli-command-filesystem-transaction'
+
+const createdRoots: string[] = []
+
+afterEach(async () => {
+  legacyReadlinkRace.commandPath = ''
+  legacyReadlinkRace.replacementTarget = ''
+  reusedIdentity.path = ''
+  reusedIdentity.dev = null
+  reusedIdentity.ino = null
+  await Promise.all(
+    createdRoots.splice(0).map((root) => rm(root, { recursive: true, force: true }))
+  )
+})
+
+async function createMacCommandFixture() {
+  const root = await mkdtemp(join(tmpdir(), 'orca-cli-command-race-'))
+  createdRoots.push(root)
+  const commandDirectory = join(root, 'bin')
+  const commandPath = join(commandDirectory, 'orca')
+  const resourcesPath = join(root, 'Current.app', 'Contents', 'Resources')
+  const launcherPath = join(resourcesPath, 'bin', 'orca')
+  const staleLauncherPath = join(root, 'Old.app', 'Contents', 'Resources', 'bin', 'orca')
+  await mkdir(commandDirectory, { recursive: true })
+  await mkdir(dirname(launcherPath), { recursive: true })
+  await writeFile(launcherPath, '#!/usr/bin/env bash\n', { mode: 0o755 })
+  return { root, commandDirectory, commandPath, resourcesPath, launcherPath, staleLauncherPath }
+}
+
+function createMacInstaller(
+  fixture: Awaited<ReturnType<typeof createMacCommandFixture>>,
+  hooks: {
+    quarantine?: (commandPath: string) => Promise<void>
+    afterQuarantine?: (quarantine: CommandQuarantine) => void
+    link?: (heldPath: string, commandPath: string) => Promise<void>
+  } = {}
+): CliInstaller {
+  class RaceInjectedInstaller extends CliInstaller {
+    protected override async quarantineCommandPath(commandPath: string) {
+      await hooks.quarantine?.(commandPath)
+      const quarantine = await super.quarantineCommandPath(commandPath)
+      hooks.afterQuarantine?.(quarantine)
+      return quarantine
+    }
+
+    protected override async linkQuarantinedCommand(
+      heldPath: string,
+      commandPath: string
+    ): Promise<void> {
+      await hooks.link?.(heldPath, commandPath)
+      return super.linkQuarantinedCommand(heldPath, commandPath)
+    }
+  }
+
+  return new RaceInjectedInstaller({
+    platform: 'darwin',
+    isPackaged: true,
+    userDataPath: join(fixture.root, 'user-data'),
+    resourcesPath: fixture.resourcesPath,
+    execPath: join(fixture.root, 'Current.app', 'Contents', 'MacOS', 'Orca'),
+    appPath: join(fixture.root, 'Current.app', 'Contents', 'Resources', 'app.asar'),
+    homePath: join(fixture.root, 'home'),
+    commandPathOverride: fixture.commandPath,
+    processPathEnv: fixture.commandDirectory
+  })
+}
+
+async function recoveryPath(commandDirectory: string): Promise<string> {
+  const transactionName = (await readdir(commandDirectory)).find((name) =>
+    name.startsWith('.orca-cli-')
+  )
+  if (!transactionName) {
+    throw new Error('Expected a preserved CLI command transaction.')
+  }
+  return join(commandDirectory, transactionName, 'orca')
+}
+
+async function rejectionFrom(operation: Promise<unknown>): Promise<Error> {
+  try {
+    await operation
+  } catch (error) {
+    if (error instanceof Error) {
+      return error
+    }
+    throw error
+  }
+  throw new Error('Expected the operation to reject.')
+}
+
+describe.skipIf(process.platform === 'win32')('CLI command filesystem races', () => {
+  it('replaces and removes an unchanged stale symlink through the real filesystem', async () => {
+    const fixture = await createMacCommandFixture()
+    await symlink(fixture.staleLauncherPath, fixture.commandPath)
+    const installer = createMacInstaller(fixture)
+
+    await expect(installer.install()).resolves.toMatchObject({ state: 'installed' })
+    await expect(readlink(fixture.commandPath)).resolves.toBe(fixture.launcherPath)
+    await expect(installer.remove()).resolves.toMatchObject({ state: 'not_installed' })
+    await expect(lstat(fixture.commandPath)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('restores a foreign symlink whose quarantined inode identity is reused', async () => {
+    const fixture = await createMacCommandFixture()
+    const foreignTarget = join(fixture.root, 'foreign-command')
+    await symlink(fixture.staleLauncherPath, fixture.commandPath)
+    const original = await lstat(fixture.commandPath, { bigint: true })
+    let raced = false
+    const installer = createMacInstaller(fixture, {
+      quarantine: async (commandPath) => {
+        if (raced) {
+          return
+        }
+        raced = true
+        await unlink(commandPath)
+        await symlink(foreignTarget, commandPath)
+      },
+      afterQuarantine: (quarantine) => {
+        if (quarantine.snapshot) {
+          reusedIdentity.path = quarantine.heldPath
+          reusedIdentity.dev = original.dev
+          reusedIdentity.ino = original.ino
+          quarantine.snapshot.identity = {
+            ...quarantine.snapshot.identity,
+            dev: original.dev,
+            ino: original.ino
+          }
+        }
+      }
+    })
+
+    await expect(installer.install()).rejects.toThrow('Refusing to replace non-Orca command')
+    await expect(readlink(fixture.commandPath)).resolves.toBe(foreignTarget)
+    expect(
+      (await readdir(fixture.commandDirectory)).some((name) => name.startsWith('.orca-cli-'))
+    ).toBe(false)
+  })
+
+  it('preserves a managed file changed in place after its final inspection', async () => {
+    const fixture = await createMacCommandFixture()
+    const oldCliPath = join(fixture.root, 'old', 'out', 'cli', 'index.js')
+    await writeFile(
+      fixture.commandPath,
+      [
+        '#!/usr/bin/env bash',
+        `CLI='${oldCliPath}'`,
+        'export ORCA_NODE_OPTIONS="${NODE_OPTIONS-}"',
+        'export ORCA_NODE_REPL_EXTERNAL_MODULE="${NODE_REPL_EXTERNAL_MODULE-}"',
+        'ELECTRON_RUN_AS_NODE=1 exec electron "$CLI" "$@"'
+      ].join('\n')
+    )
+    let raced = false
+    const installer = createMacInstaller(fixture, {
+      quarantine: async (commandPath) => {
+        if (raced) {
+          return
+        }
+        raced = true
+        await writeFile(commandPath, 'foreign command written into the inspected inode')
+      }
+    })
+
+    await expect(installer.install()).rejects.toThrow('Refusing to replace non-Orca command')
+    await expect(readFile(fixture.commandPath, 'utf8')).resolves.toBe(
+      'foreign command written into the inspected inode'
+    )
+  })
+
+  it('restores a foreign symlink raced into command removal', async () => {
+    const fixture = await createMacCommandFixture()
+    const foreignTarget = join(fixture.root, 'foreign-command')
+    await symlink(fixture.launcherPath, fixture.commandPath)
+    let raced = false
+    const installer = createMacInstaller(fixture, {
+      quarantine: async (commandPath) => {
+        if (raced) {
+          return
+        }
+        raced = true
+        await unlink(commandPath)
+        await symlink(foreignTarget, commandPath)
+      }
+    })
+
+    await expect(installer.remove()).rejects.toThrow('Refusing to remove non-Orca command')
+    await expect(readlink(fixture.commandPath)).resolves.toBe(foreignTarget)
+  })
+
+  it('preserves a raced foreign directory at the reported recovery path', async () => {
+    const fixture = await createMacCommandFixture()
+    await symlink(fixture.staleLauncherPath, fixture.commandPath)
+    let raced = false
+    const installer = createMacInstaller(fixture, {
+      quarantine: async (commandPath) => {
+        if (raced) {
+          return
+        }
+        raced = true
+        await unlink(commandPath)
+        await mkdir(commandPath)
+        await writeFile(join(commandPath, 'user-data'), 'preserved')
+      }
+    })
+
+    const error = await rejectionFrom(installer.install())
+    const heldPath = await recoveryPath(fixture.commandDirectory)
+    expect(error.message).toContain(heldPath)
+    await expect(readFile(join(heldPath, 'user-data'), 'utf8')).resolves.toBe('preserved')
+    await expect(lstat(fixture.commandPath)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('preserves both entries when the original name is reclaimed during restoration', async () => {
+    const fixture = await createMacCommandFixture()
+    const contenderTarget = join(fixture.root, 'contender-command')
+    await symlink(fixture.staleLauncherPath, fixture.commandPath)
+    let raced = false
+    const installer = createMacInstaller(fixture, {
+      quarantine: async (commandPath) => {
+        if (raced) {
+          return
+        }
+        raced = true
+        await unlink(commandPath)
+        await writeFile(commandPath, 'foreign command')
+      },
+      link: async (_heldPath, commandPath) => {
+        await symlink(contenderTarget, commandPath)
+      }
+    })
+
+    const error = await rejectionFrom(installer.install())
+    const heldPath = await recoveryPath(fixture.commandDirectory)
+    expect(error.message).toContain(heldPath)
+    await expect(readFile(heldPath, 'utf8')).resolves.toBe('foreign command')
+    await expect(readlink(fixture.commandPath)).resolves.toBe(contenderTarget)
+  })
+
+  it('keeps a foreign legacy Linux command when readlink loses the inspection race', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-cli-legacy-race-'))
+    createdRoots.push(root)
+    const homePath = join(root, 'home')
+    const commandDirectory = join(homePath, '.local', 'bin')
+    const resourcesPath = join(root, 'resources')
+    const launcherPath = join(resourcesPath, 'bin', 'orca-ide')
+    const legacyPath = join(commandDirectory, 'orca')
+    const managedLegacyTarget = join(resourcesPath, 'bin', 'orca')
+    const foreignTarget = join(root, 'foreign-orca')
+    await mkdir(commandDirectory, { recursive: true })
+    await mkdir(dirname(launcherPath), { recursive: true })
+    await writeFile(launcherPath, '#!/usr/bin/env bash\n', { mode: 0o755 })
+    await symlink(managedLegacyTarget, legacyPath)
+
+    legacyReadlinkRace.commandPath = legacyPath
+    legacyReadlinkRace.replacementTarget = foreignTarget
+    const installer = new CliInstaller({
+      platform: 'linux',
+      isPackaged: true,
+      userDataPath: join(root, 'user-data'),
+      resourcesPath,
+      execPath: join(root, 'orca-ide'),
+      appPath: join(root, 'resources', 'app.asar'),
+      homePath,
+      processPathEnv: commandDirectory
+    })
+
+    await expect(installer.install()).resolves.toMatchObject({ state: 'installed' })
+    await expect(readlink(legacyPath)).resolves.toBe(foreignTarget)
+  })
+
+  it('keeps a foreign legacy Linux command whose quarantined inode is reused', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-cli-legacy-identity-race-'))
+    createdRoots.push(root)
+    const homePath = join(root, 'home')
+    const commandDirectory = join(homePath, '.local', 'bin')
+    const resourcesPath = join(root, 'resources')
+    const launcherPath = join(resourcesPath, 'bin', 'orca-ide')
+    const legacyPath = join(commandDirectory, 'orca')
+    const managedTarget = join(resourcesPath, 'bin', 'orca')
+    const foreignTarget = join(root, 'foreign-orca')
+    await mkdir(commandDirectory, { recursive: true })
+    await mkdir(dirname(launcherPath), { recursive: true })
+    await writeFile(launcherPath, '#!/usr/bin/env bash\n', { mode: 0o755 })
+    await symlink(managedTarget, legacyPath)
+    const original = await lstat(legacyPath, { bigint: true })
+
+    class LegacyRaceInstaller extends CliInstaller {
+      protected override async quarantineCommandPath(commandPath: string) {
+        if (commandPath === legacyPath) {
+          await unlink(commandPath)
+          await symlink(foreignTarget, commandPath)
+        }
+        const quarantine = await super.quarantineCommandPath(commandPath)
+        if (commandPath === legacyPath && quarantine.snapshot) {
+          reusedIdentity.path = quarantine.heldPath
+          reusedIdentity.dev = original.dev
+          reusedIdentity.ino = original.ino
+          quarantine.snapshot.identity = {
+            ...quarantine.snapshot.identity,
+            dev: original.dev,
+            ino: original.ino
+          }
+        }
+        return quarantine
+      }
+    }
+
+    const installer = new LegacyRaceInstaller({
+      platform: 'linux',
+      isPackaged: true,
+      userDataPath: join(root, 'user-data'),
+      resourcesPath,
+      execPath: join(root, 'orca-ide'),
+      appPath: join(root, 'resources', 'app.asar'),
+      homePath,
+      processPathEnv: commandDirectory
+    })
+
+    await expect(installer.install()).resolves.toMatchObject({ state: 'installed' })
+    await expect(readlink(legacyPath)).resolves.toBe(foreignTarget)
+  })
+})

--- a/src/main/cli/cli-command-installation.ts
+++ b/src/main/cli/cli-command-installation.ts
@@ -1,5 +1,5 @@
 import { link, readlink, rmdir, symlink, unlink, writeFile } from 'node:fs/promises'
-import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path'
+import { basename, dirname, join, resolve } from 'node:path'
 import type { CliInstallStatus } from '../../shared/cli-install-types'
 import {
   ensureAppImageExtractedRoot,
@@ -21,6 +21,7 @@ import {
 import { DEV_LAUNCHER_DIR, LEGACY_LINUX_COMMAND_NAME } from './cli-install-constants'
 import { buildWindowsForwarder } from './cli-dev-launcher'
 import { isMissingError, isPermissionError } from './cli-install-errors'
+import { isPathInsideOrEqual } from './cli-install-path-format'
 
 const STABLE_LEGACY_INSPECTION_ATTEMPTS = 3
 
@@ -101,16 +102,24 @@ export class CliCommandInstallation extends CliCommandInspection {
     }
 
     const commandPath = join(this.homePath, '.local', 'bin', LEGACY_LINUX_COMMAND_NAME)
-    const inspected = await this.inspectStableLegacyCommand(commandPath, launcherPath)
-    if (!inspected?.managed) {
-      return
+    try {
+      const inspected = await this.inspectStableLegacyCommand(commandPath, launcherPath)
+      if (!inspected?.managed) {
+        return
+      }
+      const quarantine = await this.quarantineCommandPath(commandPath)
+      if (!(await capturedExpectedEntry(quarantine, inspected))) {
+        await this.restoreQuarantinedCommand(quarantine, commandPath)
+        return
+      }
+      await this.discardQuarantinedCommand(quarantine)
+    } catch (error) {
+      // Why: the new command is already registered; leave legacy cleanup for a later attempt.
+      console.warn(
+        `[cli] Could not remove the legacy command at ${commandPath}:`,
+        error instanceof Error ? error.message : String(error)
+      )
     }
-    const quarantine = await this.quarantineCommandPath(commandPath)
-    if (!(await capturedExpectedEntry(quarantine, inspected))) {
-      await this.restoreQuarantinedCommand(quarantine, commandPath)
-      return
-    }
-    await this.discardQuarantinedCommand(quarantine)
   }
 
   protected async quarantineCommandPath(commandPath: string): Promise<CommandQuarantine> {
@@ -132,8 +141,7 @@ export class CliCommandInstallation extends CliCommandInspection {
     }
 
     const devLauncherDir = resolve(this.userDataPath, ...DEV_LAUNCHER_DIR)
-    const devRelative = relative(devLauncherDir, resolvedTarget)
-    if (devRelative && !devRelative.startsWith('..') && !isAbsolute(devRelative)) {
+    if (isPathInsideOrEqual(devLauncherDir, resolvedTarget)) {
       return true
     }
 

--- a/src/main/cli/cli-command-installation.ts
+++ b/src/main/cli/cli-command-installation.ts
@@ -1,49 +1,98 @@
-import { lstat, mkdir, readlink, symlink, unlink, writeFile } from 'node:fs/promises'
+import { link, readlink, rmdir, symlink, unlink, writeFile } from 'node:fs/promises'
 import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path'
 import type { CliInstallStatus } from '../../shared/cli-install-types'
-import { buildAppImageCliWrapper } from './appimage-cli-wrapper'
+import {
+  ensureAppImageExtractedRoot,
+  isAppImageExtractedLauncherPath,
+  type AppImageExtractedRoot
+} from './appimage-extracted-root'
 import { CliCommandInspection } from './cli-command-inspection'
+import {
+  buildMacPrivilegedSymlinkTransaction,
+  capturedExpectedEntry,
+  hasSameIdentity,
+  hasSameSnapshot,
+  inspectStableCommand,
+  quarantineCommandPath,
+  readEntrySnapshot,
+  type CommandQuarantine,
+  type StableCommandInspection
+} from './cli-command-filesystem-transaction'
 import { DEV_LAUNCHER_DIR, LEGACY_LINUX_COMMAND_NAME } from './cli-install-constants'
 import { buildWindowsForwarder } from './cli-dev-launcher'
 import { isMissingError, isPermissionError } from './cli-install-errors'
-import { quoteShell } from './cli-install-path-format'
+
+const STABLE_LEGACY_INSPECTION_ATTEMPTS = 3
 
 export class CliCommandInstallation extends CliCommandInspection {
   protected async installSymlink(status: CliInstallStatus): Promise<void> {
+    const commandPath = status.commandPath
+    const launcherPath = status.launcherPath
+    if (!commandPath || !launcherPath || status.state === 'installed') {
+      return
+    }
+
+    const inspected = await this.inspectStableSymlink(commandPath, launcherPath)
+    if (inspected.status.state === 'conflict') {
+      throw new Error(`Refusing to replace non-Orca command at ${commandPath}.`)
+    }
+    if (inspected.status.state === 'installed') {
+      return
+    }
+
+    let quarantine: CommandQuarantine
     try {
-      if (status.state === 'installed') {
-        return
-      }
-      if (status.state === 'stale') {
-        await unlink(status.commandPath as string)
-      }
-      // Why: mkdir stays here (not install()) so an EACCES falls into the privileged-runner catch below.
-      await mkdir(dirname(status.commandPath as string), { recursive: true })
-      await symlink(status.launcherPath as string, status.commandPath as string)
+      quarantine = await this.quarantineCommandPath(commandPath)
     } catch (error) {
       if (this.platform !== 'darwin' || !isPermissionError(error)) {
         throw error
       }
-
-      // Why: fall back to an elevated shell to place the /usr/local/bin symlink (VS Code-style) when direct write is denied.
-      await this.privilegedRunner(
-        `mkdir -p ${quoteShell(dirname(status.commandPath as string))} && ` +
-          `ln -sfn ${quoteShell(status.launcherPath as string)} ${quoteShell(status.commandPath as string)}`
-      )
+      await this.installSymlinkWithPrivileges(commandPath, launcherPath, inspected)
+      return
     }
+
+    if (!(await capturedExpectedEntry(quarantine, inspected))) {
+      await this.restoreQuarantinedCommand(quarantine, commandPath)
+      throw new Error(`Refusing to replace non-Orca command at ${commandPath}.`)
+    }
+
+    try {
+      await symlink(launcherPath, commandPath)
+    } catch (error) {
+      await this.restoreQuarantinedCommand(quarantine, commandPath)
+      throw error
+    }
+    await this.discardQuarantinedCommand(quarantine)
   }
 
   protected async removeSymlink(commandPath: string): Promise<void> {
+    const launcherPath = await this.resolveLauncherPath()
+    if (!launcherPath) {
+      throw new Error('The Orca CLI launcher is no longer available.')
+    }
+    const inspected = await this.inspectStableSymlink(commandPath, launcherPath)
+    if (inspected.status.state === 'not_installed') {
+      return
+    }
+    if (inspected.status.state === 'conflict') {
+      throw new Error(`Refusing to remove non-Orca command at ${commandPath}.`)
+    }
+
+    let quarantine: CommandQuarantine
     try {
-      await unlink(commandPath)
+      quarantine = await this.quarantineCommandPath(commandPath)
     } catch (error) {
       if (this.platform !== 'darwin' || !isPermissionError(error)) {
         throw error
       }
-      await this.privilegedRunner(
-        `if [ -L ${quoteShell(commandPath)} ]; then rm ${quoteShell(commandPath)}; fi`
-      )
+      await this.removeSymlinkWithPrivileges(commandPath, inspected)
+      return
     }
+    if (!(await capturedExpectedEntry(quarantine, inspected))) {
+      await this.restoreQuarantinedCommand(quarantine, commandPath)
+      throw new Error(`Refusing to remove non-Orca command at ${commandPath}.`)
+    }
+    await this.discardQuarantinedCommand(quarantine)
   }
 
   protected async removeLegacyLinuxCommandIfManaged(launcherPath: string | null): Promise<void> {
@@ -51,27 +100,25 @@ export class CliCommandInstallation extends CliCommandInspection {
       return
     }
 
-    const legacyCommandPath = join(this.homePath, '.local', 'bin', LEGACY_LINUX_COMMAND_NAME)
-    try {
-      const stats = await lstat(legacyCommandPath)
-      if (!stats.isSymbolicLink()) {
-        return
-      }
-
-      const currentTarget = await readlink(legacyCommandPath)
-      const resolvedCurrentTarget = resolve(dirname(legacyCommandPath), currentTarget)
-      if (!this.isManagedLegacyLinuxTarget(resolvedCurrentTarget, launcherPath)) {
-        return
-      }
-
-      // Why: after the Linux command rename, the old `orca` symlink would keep shadowing GNOME Orca.
-      await unlink(legacyCommandPath)
-    } catch (error) {
-      if (isMissingError(error)) {
-        return
-      }
-      throw error
+    const commandPath = join(this.homePath, '.local', 'bin', LEGACY_LINUX_COMMAND_NAME)
+    const inspected = await this.inspectStableLegacyCommand(commandPath, launcherPath)
+    if (!inspected?.managed) {
+      return
     }
+    const quarantine = await this.quarantineCommandPath(commandPath)
+    if (!(await capturedExpectedEntry(quarantine, inspected))) {
+      await this.restoreQuarantinedCommand(quarantine, commandPath)
+      return
+    }
+    await this.discardQuarantinedCommand(quarantine)
+  }
+
+  protected async quarantineCommandPath(commandPath: string): Promise<CommandQuarantine> {
+    return quarantineCommandPath(commandPath)
+  }
+
+  protected async linkQuarantinedCommand(heldPath: string, commandPath: string): Promise<void> {
+    await link(heldPath, commandPath)
   }
 
   protected isManagedLegacyLinuxTarget(resolvedTarget: string, launcherPath: string): boolean {
@@ -90,20 +137,174 @@ export class CliCommandInstallation extends CliCommandInspection {
       return true
     }
 
-    // Why: AppImage upgrades can strand a legacy symlink into a now-gone FUSE mount that isn't a sibling of the stable path.
-    return /(?:^|[/\\])resources[/\\]bin[/\\]orca$/.test(resolvedTarget)
+    const extractionOptions = this.appImageExtractionOptions()
+    return extractionOptions
+      ? isAppImageExtractedLauncherPath(
+          extractionOptions,
+          resolvedTarget,
+          LEGACY_LINUX_COMMAND_NAME
+        )
+      : false
   }
 
   protected async installWindowsWrapper(commandPath: string, launcherPath: string): Promise<void> {
     await writeFile(commandPath, buildWindowsForwarder(launcherPath), 'utf8')
   }
 
-  protected async installAppImageWrapper(commandPath: string, appImagePath: string): Promise<void> {
-    // Why: the AppImage command dir is user-writable, so create it before writing the wrapper.
-    await mkdir(dirname(commandPath), { recursive: true })
-    await writeFile(commandPath, buildAppImageCliWrapper(appImagePath), {
-      encoding: 'utf8',
-      mode: 0o755
-    })
+  protected async ensureLinuxAppImagePayload(): Promise<AppImageExtractedRoot | null> {
+    const extractionOptions = this.appImageExtractionOptions()
+    if (!this.isLinuxAppImage() || !extractionOptions) {
+      return null
+    }
+    const extractedRoot = await ensureAppImageExtractedRoot(extractionOptions)
+    if (!extractedRoot) {
+      throw new Error(
+        `Could not extract the Orca AppImage at ${this.appImagePath}. Check that it is executable and that ${this.appImageCacheRootPath} has free space.`
+      )
+    }
+    return extractedRoot
+  }
+
+  private async inspectStableSymlink(
+    commandPath: string,
+    launcherPath: string
+  ): Promise<StableCommandInspection> {
+    return inspectStableCommand(commandPath, () => this.inspectSymlink(commandPath, launcherPath))
+  }
+
+  private async inspectStableLegacyCommand(
+    commandPath: string,
+    launcherPath: string
+  ): Promise<
+    | (Pick<StableCommandInspection, 'fileSha256' | 'rawSymlinkTarget'> & {
+        snapshot: NonNullable<StableCommandInspection['snapshot']>
+        managed: boolean
+      })
+    | null
+  > {
+    for (let attempt = 0; attempt < STABLE_LEGACY_INSPECTION_ATTEMPTS; attempt += 1) {
+      const before = await readEntrySnapshot(commandPath)
+      if (!before) {
+        return null
+      }
+      let target: string | null = null
+      try {
+        target = before.isSymbolicLink ? await readlink(commandPath) : null
+      } catch (error) {
+        if (isMissingError(error)) {
+          continue
+        }
+        throw error
+      }
+      const after = await readEntrySnapshot(commandPath)
+      if (after && hasSameSnapshot(before, after)) {
+        const resolvedTarget = target ? resolve(dirname(commandPath), target) : null
+        return {
+          fileSha256: null,
+          rawSymlinkTarget: target,
+          snapshot: after,
+          managed: Boolean(
+            resolvedTarget && this.isManagedLegacyLinuxTarget(resolvedTarget, launcherPath)
+          )
+        }
+      }
+    }
+    throw new Error(`The command at ${commandPath} changed while Orca inspected it.`)
+  }
+
+  private async restoreQuarantinedCommand(
+    quarantine: CommandQuarantine,
+    commandPath: string
+  ): Promise<void> {
+    if (!quarantine.snapshot) {
+      await rmdir(quarantine.directoryPath)
+      return
+    }
+    await this.assertHeldIdentity(quarantine)
+    try {
+      await (quarantine.snapshot.isSymbolicLink
+        ? symlink(await readlink(quarantine.heldPath), commandPath)
+        : this.linkQuarantinedCommand(quarantine.heldPath, commandPath))
+      const restored = await readEntrySnapshot(commandPath)
+      const restoredSymlink =
+        restored?.isSymbolicLink && quarantine.snapshot.isSymbolicLink
+          ? (await readlink(commandPath)) === (await readlink(quarantine.heldPath))
+          : false
+      if (
+        !restored ||
+        (!restoredSymlink && !hasSameIdentity(restored.identity, quarantine.snapshot.identity))
+      ) {
+        throw new Error('The restored command identity could not be verified.')
+      }
+      await this.discardQuarantinedCommand(quarantine, quarantine.snapshot.isSymbolicLink)
+    } catch (error) {
+      throw new Error(
+        `The displaced entry is preserved at ${quarantine.heldPath}; ${commandPath} could not be restored without overwriting another entry.`,
+        { cause: error }
+      )
+    }
+  }
+
+  private async discardQuarantinedCommand(
+    quarantine: CommandQuarantine,
+    requireStableMetadata = true
+  ): Promise<void> {
+    if (quarantine.snapshot) {
+      await this.assertHeldIdentity(quarantine, requireStableMetadata)
+      await unlink(quarantine.heldPath)
+    }
+    await rmdir(quarantine.directoryPath)
+  }
+
+  private async assertHeldIdentity(
+    quarantine: CommandQuarantine,
+    requireStableMetadata = true
+  ): Promise<void> {
+    const current = await readEntrySnapshot(quarantine.heldPath)
+    if (
+      !current ||
+      !quarantine.snapshot ||
+      !(requireStableMetadata
+        ? hasSameSnapshot(current, quarantine.snapshot)
+        : hasSameIdentity(current.identity, quarantine.snapshot.identity))
+    ) {
+      throw new Error(`The quarantined command changed at ${quarantine.heldPath}.`)
+    }
+  }
+
+  private async installSymlinkWithPrivileges(
+    commandPath: string,
+    launcherPath: string,
+    inspected: StableCommandInspection
+  ): Promise<void> {
+    await this.privilegedRunner(
+      buildMacPrivilegedSymlinkTransaction({
+        action: 'install',
+        commandPath,
+        launcherPath,
+        expected: inspected.snapshot?.identity ?? null,
+        expectedFileSha256: inspected.fileSha256,
+        expectedRawSymlinkTarget: inspected.rawSymlinkTarget
+      })
+    )
+    const installed = await this.inspectStableSymlink(commandPath, launcherPath)
+    if (installed.status.state !== 'installed') {
+      throw new Error(`Could not register the Orca command at ${commandPath}.`)
+    }
+  }
+
+  private async removeSymlinkWithPrivileges(
+    commandPath: string,
+    inspected: StableCommandInspection
+  ): Promise<void> {
+    await this.privilegedRunner(
+      buildMacPrivilegedSymlinkTransaction({
+        action: 'remove',
+        commandPath,
+        expected: inspected.snapshot?.identity ?? null,
+        expectedFileSha256: inspected.fileSha256,
+        expectedRawSymlinkTarget: inspected.rawSymlinkTarget
+      })
+    )
   }
 }

--- a/src/main/cli/cli-command-installation.ts
+++ b/src/main/cli/cli-command-installation.ts
@@ -35,7 +35,7 @@ export class CliCommandInstallation extends CliCommandInspection {
 
     const inspected = await this.inspectStableSymlink(commandPath, launcherPath)
     if (inspected.status.state === 'conflict') {
-      throw new Error(`Refusing to replace non-Orca command at ${commandPath}.`)
+      throw new Error(`Refusing to replace non-Orca command at ${commandPath}. Remove it and register again if it is no longer needed.`)
     }
     if (inspected.status.state === 'installed') {
       return
@@ -54,7 +54,7 @@ export class CliCommandInstallation extends CliCommandInspection {
 
     if (!(await capturedExpectedEntry(quarantine, inspected))) {
       await this.restoreQuarantinedCommand(quarantine, commandPath)
-      throw new Error(`Refusing to replace non-Orca command at ${commandPath}.`)
+      throw new Error(`Refusing to replace non-Orca command at ${commandPath}. Remove it and register again if it is no longer needed.`)
     }
 
     try {
@@ -138,6 +138,10 @@ export class CliCommandInstallation extends CliCommandInspection {
 
     if (basename(resolvedTarget) !== LEGACY_LINUX_COMMAND_NAME) {
       return false
+    }
+
+    if (this.isPackagedLinuxLauncherTarget(resolvedTarget, LEGACY_LINUX_COMMAND_NAME)) {
+      return true
     }
 
     const devLauncherDir = resolve(this.userDataPath, ...DEV_LAUNCHER_DIR)

--- a/src/main/cli/cli-command-privileged-transaction.test.ts
+++ b/src/main/cli/cli-command-privileged-transaction.test.ts
@@ -1,0 +1,167 @@
+import {
+  chmod,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readlink,
+  readdir,
+  rm,
+  symlink,
+  unlink,
+  writeFile
+} from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { runProcess } from '../../shared/child-process/run-process'
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getPath: () => tmpdir(),
+    getAppPath: () => tmpdir()
+  }
+}))
+
+import { CliInstaller } from './cli-installer'
+import { buildUnixDevLauncher } from './cli-dev-launcher'
+
+const createdRoots: string[] = []
+const protectedDirectories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(protectedDirectories.splice(0).map((path) => chmod(path, 0o700)))
+  await Promise.all(
+    createdRoots.splice(0).map((root) => rm(root, { recursive: true, force: true }))
+  )
+})
+
+async function createPrivilegedFixture() {
+  const root = await mkdtemp(join(tmpdir(), 'orca-cli-privileged-transaction-'))
+  createdRoots.push(root)
+  const protectedDirectory = join(root, 'protected')
+  protectedDirectories.push(protectedDirectory)
+  const commandPath = join(protectedDirectory, 'orca')
+  const userDataPath = join(root, 'user-data')
+  const appPath = join(root, 'app')
+  await mkdir(protectedDirectory)
+  await mkdir(join(appPath, 'out', 'cli'), { recursive: true })
+  await writeFile(join(appPath, 'out', 'cli', 'index.js'), 'console.log("orca")\n')
+  return { root, protectedDirectory, commandPath, userDataPath, appPath }
+}
+
+async function executePrivilegedShell(command: string): Promise<void> {
+  const result = await runProcess({ program: '/bin/sh', args: ['-c', command] })
+  if (result.code !== 0) {
+    const error = new Error(
+      result.stderr || result.stdout || `Privileged shell exited ${result.code}.`
+    )
+    Object.assign(error, { code: result.code, stderr: result.stderr })
+    throw error
+  }
+}
+
+function fixtureInstallerOptions(fixture: Awaited<ReturnType<typeof createPrivilegedFixture>>) {
+  return {
+    platform: 'darwin' as const,
+    isPackaged: false,
+    userDataPath: fixture.userDataPath,
+    appPath: fixture.appPath,
+    execPath: '/Applications/Orca.app/Contents/MacOS/Orca',
+    commandPathOverride: fixture.commandPath,
+    processPathEnv: fixture.protectedDirectory
+  }
+}
+
+describe.skipIf(process.platform !== 'darwin' || process.getuid?.() === 0)(
+  'macOS privileged CLI command transaction',
+  () => {
+    it('installs and removes through the generated no-overwrite shell transaction', async () => {
+      const fixture = await createPrivilegedFixture()
+      const commands: string[] = []
+      const installer = new CliInstaller({
+        ...fixtureInstallerOptions(fixture),
+        privilegedRunner: async (command) => {
+          commands.push(command)
+          await chmod(fixture.protectedDirectory, 0o700)
+          await executePrivilegedShell(command)
+        }
+      })
+
+      await chmod(fixture.protectedDirectory, 0o500)
+      const installed = await installer.install()
+      expect(installed.state).toBe('installed')
+      await expect(readlink(fixture.commandPath)).resolves.toBe(installed.launcherPath)
+
+      await chmod(fixture.protectedDirectory, 0o500)
+      await expect(installer.remove()).resolves.toMatchObject({ state: 'not_installed' })
+      expect(commands).toHaveLength(2)
+      expect(commands.every((command) => command.includes('/bin/ln -P'))).toBe(true)
+      expect(commands.every((command) => !command.includes('mv -f'))).toBe(true)
+    })
+
+    it('restores a trailing-newline symlink inserted after privileged inspection', async () => {
+      const fixture = await createPrivilegedFixture()
+      const staleTarget = join(fixture.userDataPath, 'cli', 'bin', 'old', 'orca')
+      const foreignTarget = `${staleTarget}\n`
+      await symlink(staleTarget, fixture.commandPath)
+      const original = await lstat(fixture.commandPath, { bigint: true })
+      let raced = false
+      const installer = new CliInstaller({
+        ...fixtureInstallerOptions(fixture),
+        privilegedRunner: async (command) => {
+          await chmod(fixture.protectedDirectory, 0o700)
+          if (!raced) {
+            raced = true
+            await unlink(fixture.commandPath)
+            await symlink(foreignTarget, fixture.commandPath)
+          }
+          const replacement = await lstat(fixture.commandPath, { bigint: true })
+          await executePrivilegedShell(
+            command.replace(
+              `${original.dev}:${original.ino}`,
+              `${replacement.dev}:${replacement.ino}`
+            )
+          )
+        }
+      })
+
+      await chmod(fixture.protectedDirectory, 0o500)
+      await expect(installer.install()).rejects.toThrow()
+      await expect(readlink(fixture.commandPath)).resolves.toBe(foreignTarget)
+      expect(
+        (await readdir(fixture.protectedDirectory)).some((name) => name.startsWith('.orca-cli-'))
+      ).toBe(false)
+    })
+
+    it('restores a managed file changed in place after privileged inspection', async () => {
+      const fixture = await createPrivilegedFixture()
+      const oldCliPath = join(fixture.root, 'old', 'out', 'cli', 'index.js')
+      await writeFile(
+        fixture.commandPath,
+        buildUnixDevLauncher('/Applications/Old.app/Contents/MacOS/Orca', oldCliPath, 'user-data')
+      )
+      const foreignContent = 'foreign command written into the inspected inode'
+      let raced = false
+      const installer = new CliInstaller({
+        ...fixtureInstallerOptions(fixture),
+        privilegedRunner: async (command) => {
+          await chmod(fixture.protectedDirectory, 0o700)
+          if (!raced) {
+            raced = true
+            await writeFile(fixture.commandPath, foreignContent)
+          }
+          await executePrivilegedShell(command)
+        }
+      })
+
+      await chmod(fixture.protectedDirectory, 0o500)
+      await expect(installer.install()).rejects.toThrow()
+      await expect(readFile(fixture.commandPath, 'utf8')).resolves.toBe(foreignContent)
+      expect(
+        (await readdir(fixture.protectedDirectory)).some((name) => name.startsWith('.orca-cli-'))
+      ).toBe(false)
+    })
+  }
+)

--- a/src/main/cli/cli-command-privileged-transaction.test.ts
+++ b/src/main/cli/cli-command-privileged-transaction.test.ts
@@ -163,5 +163,27 @@ describe.skipIf(process.platform !== 'darwin' || process.getuid?.() === 0)(
         (await readdir(fixture.protectedDirectory)).some((name) => name.startsWith('.orca-cli-'))
       ).toBe(false)
     })
+
+    it('restores the displaced command when publication setup fails', async () => {
+      const fixture = await createPrivilegedFixture()
+      const staleTarget = join(fixture.userDataPath, 'cli', 'bin', 'old', 'orca')
+      await symlink(staleTarget, fixture.commandPath)
+      const installer = new CliInstaller({
+        ...fixtureInstallerOptions(fixture),
+        privilegedRunner: async (command) => {
+          await chmod(fixture.protectedDirectory, 0o700)
+          const sabotaged = command.replace(/\/bin\/mkdir ('[^']*\/publish')/, '/usr/bin/false')
+          expect(sabotaged).not.toBe(command)
+          await executePrivilegedShell(sabotaged)
+        }
+      })
+
+      await chmod(fixture.protectedDirectory, 0o500)
+      await expect(installer.install()).rejects.toThrow()
+      await expect(readlink(fixture.commandPath)).resolves.toBe(staleTarget)
+      expect(
+        (await readdir(fixture.protectedDirectory)).some((name) => name.startsWith('.orca-cli-'))
+      ).toBe(false)
+    })
   }
 )

--- a/src/main/cli/cli-install-location.ts
+++ b/src/main/cli/cli-install-location.ts
@@ -4,7 +4,7 @@ import { basename, dirname, join } from 'node:path'
 import { getAppEnvironment } from '../../shared/app-environment'
 import type { CliInstallStatus } from '../../shared/cli-install-types'
 import {
-  hasAppImageRuntimeEnvironment,
+  hasAppImagePathEnvironment,
   resolveAppImageRuntimeIdentity
 } from '../appimage-runtime-identity'
 import {
@@ -106,7 +106,7 @@ export abstract class CliInstallLocation {
       this.platform === 'linux' &&
       this.isPackaged &&
       !hasExplicitAppImagePath &&
-      hasAppImageRuntimeEnvironment() &&
+      hasAppImagePathEnvironment() &&
       !runtimeAppImageIdentity
     this.appImagePath =
       this.platform === 'linux' && this.isPackaged

--- a/src/main/cli/cli-install-location.ts
+++ b/src/main/cli/cli-install-location.ts
@@ -3,6 +3,16 @@ import { homedir } from 'node:os'
 import { basename, dirname, join } from 'node:path'
 import { getAppEnvironment } from '../../shared/app-environment'
 import type { CliInstallStatus } from '../../shared/cli-install-types'
+import {
+  hasAppImageRuntimeEnvironment,
+  resolveAppImageRuntimeIdentity
+} from '../appimage-runtime-identity'
+import {
+  getAppImageCacheRootPath,
+  resolveAppImageExtractedRoot,
+  type AppImageExtractionOptions
+} from './appimage-extracted-root'
+import { getBundledLauncherPath, LINUX_CLI_COMMAND_NAME } from './bundled-cli-launcher-path'
 import { DEFAULT_MAC_COMMAND_PATH, DEV_COMMAND_NAME } from './cli-install-constants'
 import { ensureDevLauncher } from './cli-dev-launcher'
 import type { CliInstallerOptions, InstallSpec } from './cli-installer-contracts'
@@ -13,7 +23,6 @@ import {
   uniquePathEntries
 } from './cli-install-path-format'
 import { runMacPrivilegedCommand, writeWindowsUserPath } from './cli-privileged-processes'
-import { getBundledLauncherPath, LINUX_CLI_COMMAND_NAME } from './bundled-cli-launcher-path'
 import {
   invalidateWindowsUserPathRegistryCache,
   readFreshWindowsUserPathRegistry,
@@ -46,6 +55,9 @@ export abstract class CliInstallLocation {
   protected readonly userPathCacheInvalidator: () => void
   protected readonly windowsEnvironment: NodeJS.ProcessEnv
   protected readonly appImagePath: string | null
+  protected readonly hasUnverifiedAppImageRuntime: boolean
+  protected readonly appImageCacheRootPath: string
+  protected readonly appImageExtractRunner?: (appImagePath: string, cwd: string) => Promise<void>
 
   protected get commandName(): string {
     if (!this.isPackaged && !this.commandPathOverride) {
@@ -84,10 +96,27 @@ export abstract class CliInstallLocation {
     this.userPathCacheInvalidator =
       options.userPathCacheInvalidator ?? invalidateWindowsUserPathRegistryCache
     this.windowsEnvironment = options.windowsEnvironment ?? process.env
+    const hasExplicitAppImagePath = Object.hasOwn(options, 'appImagePath')
+    const runtimeAppImageIdentity = resolveAppImageRuntimeIdentity({
+      platform: this.platform,
+      execPath: this.execPathValue,
+      resourcesPath: this.resourcesPath
+    })
+    this.hasUnverifiedAppImageRuntime =
+      this.platform === 'linux' &&
+      this.isPackaged &&
+      !hasExplicitAppImagePath &&
+      hasAppImageRuntimeEnvironment() &&
+      !runtimeAppImageIdentity
     this.appImagePath =
       this.platform === 'linux' && this.isPackaged
-        ? (options.appImagePath ?? process.env.APPIMAGE ?? null)
+        ? hasExplicitAppImagePath
+          ? (options.appImagePath ?? null)
+          : (runtimeAppImageIdentity?.appImagePath ?? null)
         : null
+    this.appImageCacheRootPath =
+      options.appImageCacheRootPath ?? getAppImageCacheRootPath(this.homePath)
+    this.appImageExtractRunner = options.appImageExtractRunner
   }
 
   protected resolveInstallSpec(): InstallSpec | null {
@@ -99,7 +128,7 @@ export abstract class CliInstallLocation {
     if (this.platform === 'darwin' || this.platform === 'linux') {
       return {
         commandPath,
-        installMethod: this.isLinuxAppImage() ? 'wrapper' : 'symlink'
+        installMethod: 'symlink'
       }
     }
 
@@ -212,8 +241,18 @@ export abstract class CliInstallLocation {
       return null
     }
 
+    if (this.hasUnverifiedAppImageRuntime) {
+      return null
+    }
+
     if (this.isLinuxAppImage()) {
-      return this.appImagePath && existsSync(this.appImagePath) ? this.appImagePath : null
+      if (!this.appImagePath || !existsSync(this.appImagePath)) {
+        return null
+      }
+      const extractionOptions = this.appImageExtractionOptions()
+      return extractionOptions
+        ? (resolveAppImageExtractedRoot(extractionOptions)?.stableLauncherPath ?? null)
+        : null
     }
 
     if (this.isPackaged) {
@@ -228,5 +267,15 @@ export abstract class CliInstallLocation {
       cliEntryPath: join(this.appPathValue, 'out', 'cli', 'index.js'),
       commandName: this.commandName
     })
+  }
+
+  protected appImageExtractionOptions(): AppImageExtractionOptions | null {
+    return this.appImagePath
+      ? {
+          appImagePath: this.appImagePath,
+          cacheRootPath: this.appImageCacheRootPath,
+          runExtract: this.appImageExtractRunner
+        }
+      : null
   }
 }

--- a/src/main/cli/cli-installer-appimage-ownership.test.ts
+++ b/src/main/cli/cli-installer-appimage-ownership.test.ts
@@ -1,0 +1,229 @@
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readlink,
+  readdir,
+  rename,
+  rm,
+  symlink,
+  unlink,
+  writeFile
+} from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { CliInstallStatus } from '../../shared/cli-install-types'
+import { resolveAppImageExtractedRoot, type AppImageExtractedRoot } from './appimage-extracted-root'
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getPath: () => tmpdir(),
+    getAppPath: () => tmpdir()
+  }
+}))
+
+import { CliInstaller } from './cli-installer'
+
+const created: string[] = []
+
+type Fixture = Awaited<ReturnType<typeof makeFixture>>
+
+afterEach(async () => {
+  vi.unstubAllEnvs()
+  await Promise.all(created.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+async function makeFixture() {
+  const root = await mkdtemp(join(tmpdir(), 'orca-cli-appimage-ownership-'))
+  created.push(root)
+  const appImagePath = join(root, 'Orca.AppImage')
+  const cacheRootPath = join(root, 'cache')
+  const commandDirectory = join(root, 'home', '.local', 'bin')
+  const commandPath = join(commandDirectory, 'orca-ide')
+  await mkdir(commandDirectory, { recursive: true })
+  await writeFile(appImagePath, '#!/usr/bin/env bash\n', { mode: 0o755 })
+  return { root, appImagePath, cacheRootPath, commandDirectory, commandPath }
+}
+
+async function extractPayload(_appImagePath: string, cwd: string): Promise<void> {
+  const launcherDirectory = join(cwd, 'squashfs-root', 'resources', 'bin')
+  await mkdir(launcherDirectory, { recursive: true })
+  await writeFile(join(launcherDirectory, 'orca-ide'), '#!/usr/bin/env bash\n', { mode: 0o755 })
+}
+
+function installerOptions(fixture: Fixture) {
+  return {
+    platform: 'linux' as const,
+    isPackaged: true,
+    userDataPath: join(fixture.root, 'user-data'),
+    resourcesPath: join(fixture.root, 'mount', 'resources'),
+    execPath: join(fixture.root, 'mount', 'orca-ide'),
+    appPath: join(fixture.root, 'mount', 'resources', 'app.asar'),
+    homePath: join(fixture.root, 'home'),
+    processPathEnv: fixture.commandDirectory,
+    appImagePath: fixture.appImagePath,
+    appImageCacheRootPath: fixture.cacheRootPath,
+    appImageExtractRunner: extractPayload
+  }
+}
+
+describe.skipIf(process.platform === 'win32')('AppImage CLI ownership', () => {
+  it('ignores inherited APPIMAGE without the matching runtime identity', async () => {
+    const fixture = await makeFixture()
+    const resourcesPath = join(fixture.root, 'installed', 'resources')
+    const launcherPath = join(resourcesPath, 'bin', 'orca-ide')
+    await mkdir(dirname(launcherPath), { recursive: true })
+    await writeFile(launcherPath, '#!/usr/bin/env bash\n', { mode: 0o755 })
+    vi.stubEnv('APPIMAGE', fixture.appImagePath)
+    vi.stubEnv('APPDIR', '')
+    const extract = vi.fn(extractPayload)
+
+    const installer = new CliInstaller({
+      platform: 'linux',
+      isPackaged: true,
+      userDataPath: join(fixture.root, 'user-data'),
+      resourcesPath,
+      execPath: join(fixture.root, 'installed', 'orca-ide'),
+      appPath: join(resourcesPath, 'app.asar'),
+      homePath: join(fixture.root, 'home'),
+      processPathEnv: fixture.commandDirectory,
+      appImageCacheRootPath: fixture.cacheRootPath,
+      appImageExtractRunner: extract
+    })
+
+    await expect(installer.getStatus()).resolves.toMatchObject({
+      state: 'unsupported',
+      launcherPath: null,
+      detail: expect.stringContaining('could not verify')
+    })
+    await expect(installer.install()).rejects.toThrow('could not verify')
+    expect(extract).not.toHaveBeenCalled()
+  })
+
+  it('refuses an arbitrary resources/bin/orca-ide symlink', async () => {
+    const fixture = await makeFixture()
+    const foreignTarget = join(fixture.root, 'foreign', 'resources', 'bin', 'orca-ide')
+    await symlink(foreignTarget, fixture.commandPath)
+    const extract = vi.fn(extractPayload)
+    const installer = new CliInstaller({
+      ...installerOptions(fixture),
+      appImageExtractRunner: extract
+    })
+
+    await expect(installer.getStatus()).resolves.toMatchObject({ state: 'conflict' })
+    await expect(installer.install()).rejects.toThrow('Refusing to replace non-Orca command')
+    await expect(readlink(fixture.commandPath)).resolves.toBe(foreignTarget)
+    expect(extract).not.toHaveBeenCalled()
+  })
+
+  it('leaves a foreign legacy resources/bin/orca symlink untouched', async () => {
+    const fixture = await makeFixture()
+    const legacyCommandPath = join(fixture.commandDirectory, 'orca')
+    const foreignTarget = join(fixture.root, 'foreign', 'resources', 'bin', 'orca')
+    await symlink(foreignTarget, legacyCommandPath)
+
+    await expect(new CliInstaller(installerOptions(fixture)).install()).resolves.toMatchObject({
+      state: 'installed'
+    })
+    await expect(readlink(legacyCommandPath)).resolves.toBe(foreignTarget)
+  })
+
+  it('keeps installation bound to the extracted generation', async () => {
+    const fixture = await makeFixture()
+    let extractedRoot: AppImageExtractedRoot | null = null
+    class ReplacingAppImageInstaller extends CliInstaller {
+      protected override async ensureLinuxAppImagePayload(): Promise<AppImageExtractedRoot | null> {
+        extractedRoot = await super.ensureLinuxAppImagePayload()
+        await writeFile(fixture.appImagePath, '#!/usr/bin/env bash\n# replacement generation\n', {
+          mode: 0o755
+        })
+        return extractedRoot
+      }
+    }
+
+    const installer = new ReplacingAppImageInstaller(installerOptions(fixture))
+    const installed = await installer.install()
+    const capturedRoot = extractedRoot as AppImageExtractedRoot | null
+
+    expect(capturedRoot).not.toBeNull()
+    expect(installed).toMatchObject({
+      state: 'stale',
+      launcherPath: capturedRoot!.stableLauncherPath
+    })
+    await expect(readlink(fixture.commandPath)).resolves.toBe(capturedRoot!.stableLauncherPath)
+    await expect(lstat(capturedRoot!.stableLauncherPath)).resolves.toBeDefined()
+    await expect(installer.getStatus()).resolves.toMatchObject({ state: 'stale' })
+  })
+
+  it('repairs the stable endpoint without reclaiming the prior path owner', async () => {
+    const fixture = await makeFixture()
+    const firstInstaller = new CliInstaller(installerOptions(fixture))
+    const first = await firstInstaller.install()
+    const firstRoot = resolveAppImageExtractedRoot({
+      appImagePath: fixture.appImagePath,
+      cacheRootPath: fixture.cacheRootPath
+    })!
+    const relocatedPath = join(fixture.root, 'downloads', 'Orca.AppImage')
+    await mkdir(dirname(relocatedPath), { recursive: true })
+    await rename(fixture.appImagePath, relocatedPath)
+    const relocatedFixture = { ...fixture, appImagePath: relocatedPath }
+    const relocatedInstaller = new CliInstaller(installerOptions(relocatedFixture))
+
+    await expect(relocatedInstaller.getStatus()).resolves.toMatchObject({ state: 'stale' })
+    const repaired = await relocatedInstaller.install()
+    const relocatedRoot = resolveAppImageExtractedRoot({
+      appImagePath: relocatedPath,
+      cacheRootPath: fixture.cacheRootPath
+    })!
+
+    expect(repaired).toMatchObject({ state: 'installed', launcherPath: first.launcherPath })
+    await expect(readlink(fixture.commandPath)).resolves.toBe(first.launcherPath)
+    await expect(lstat(relocatedRoot.payloadLauncherPath)).resolves.toBeDefined()
+    // A path namespace is an ownership boundary; the relocated process cannot prove that no
+    // sibling AppImage still owns the prior namespace.
+    await expect(lstat(firstRoot.rootPath)).resolves.toBeDefined()
+  })
+
+  it('preserves a foreign command that appears at the final ownership fence', async () => {
+    const fixture = await makeFixture()
+    const predictedRoot = resolveAppImageExtractedRoot({
+      appImagePath: fixture.appImagePath,
+      cacheRootPath: fixture.cacheRootPath
+    })!
+    const ownedOldTarget = join(
+      dirname(predictedRoot.rootPath),
+      'a'.repeat(24),
+      'resources',
+      'bin',
+      'orca-ide'
+    )
+    const foreignTarget = join(fixture.root, 'foreign', 'orca-ide')
+    await symlink(ownedOldTarget, fixture.commandPath)
+
+    class RacedInstaller extends CliInstaller {
+      private inspectionCount = 0
+
+      protected override async inspectSymlink(
+        commandPath: string,
+        launcherPath: string
+      ): Promise<CliInstallStatus> {
+        this.inspectionCount += 1
+        if (this.inspectionCount === 3) {
+          await unlink(commandPath)
+          await symlink(foreignTarget, commandPath)
+        }
+        return super.inspectSymlink(commandPath, launcherPath)
+      }
+    }
+
+    await expect(new RacedInstaller(installerOptions(fixture)).install()).rejects.toThrow(
+      'Refusing to replace non-Orca command'
+    )
+    await expect(readlink(fixture.commandPath)).resolves.toBe(foreignTarget)
+    expect((await readdir(fixture.commandDirectory)).some((name) => name.includes('.orca-'))).toBe(
+      false
+    )
+  })
+})

--- a/src/main/cli/cli-installer-appimage-ownership.test.ts
+++ b/src/main/cli/cli-installer-appimage-ownership.test.ts
@@ -70,6 +70,38 @@ function installerOptions(fixture: Fixture) {
 }
 
 describe.skipIf(process.platform === 'win32')('AppImage CLI ownership', () => {
+  it('uses the mounted bundled launcher when only APPDIR is inherited', async () => {
+    const fixture = await makeFixture()
+    const resourcesPath = join(fixture.root, 'mounted', 'resources')
+    const launcherPath = join(resourcesPath, 'bin', 'orca-ide')
+    await mkdir(dirname(launcherPath), { recursive: true })
+    await writeFile(launcherPath, '#!/usr/bin/env bash\n', { mode: 0o755 })
+    vi.stubEnv('APPIMAGE', '')
+    vi.stubEnv('APPDIR', dirname(resourcesPath))
+
+    const installer = new CliInstaller({
+      platform: 'linux',
+      isPackaged: true,
+      userDataPath: join(fixture.root, 'user-data'),
+      resourcesPath,
+      execPath: join(dirname(resourcesPath), 'orca-ide'),
+      appPath: join(resourcesPath, 'app.asar'),
+      homePath: join(fixture.root, 'home'),
+      processPathEnv: fixture.commandDirectory,
+      commandPathOverride: fixture.commandPath
+    })
+
+    await expect(installer.getStatus()).resolves.toMatchObject({
+      state: 'not_installed',
+      launcherPath
+    })
+    await expect(installer.install()).resolves.toMatchObject({
+      state: 'installed',
+      launcherPath
+    })
+    await expect(readlink(fixture.commandPath)).resolves.toBe(launcherPath)
+  })
+
   it('ignores inherited APPIMAGE without the matching runtime identity', async () => {
     const fixture = await makeFixture()
     const resourcesPath = join(fixture.root, 'installed', 'resources')

--- a/src/main/cli/cli-installer-appimage-ownership.test.ts
+++ b/src/main/cli/cli-installer-appimage-ownership.test.ts
@@ -258,4 +258,26 @@ describe.skipIf(process.platform === 'win32')('AppImage CLI ownership', () => {
       false
     )
   })
+
+  // #15081 review: the Linux reclaim rule was narrowed to extracted-cache launchers, which left a
+  // deb/rpm -> AppImage migration wedged on its own leftover symlink.
+  it('reclaims a symlink left by a packaged deb/rpm install', async () => {
+    for (const directory of ['/opt/Orca', '/opt/orca-ide', '/opt/orca']) {
+      const fixture = await makeFixture()
+      await symlink(`${directory}/resources/bin/orca-ide`, fixture.commandPath)
+
+      await expect(new CliInstaller(installerOptions(fixture)).getStatus()).resolves.toMatchObject({
+        state: 'stale'
+      })
+    }
+  })
+
+  it('still refuses a launcher-named symlink outside the packaged install tree', async () => {
+    const fixture = await makeFixture()
+    await symlink('/opt/not-orca/resources/bin/orca-ide', fixture.commandPath)
+
+    await expect(new CliInstaller(installerOptions(fixture)).getStatus()).resolves.toMatchObject({
+      state: 'conflict'
+    })
+  })
 })

--- a/src/main/cli/cli-installer-appimage-removal.test.ts
+++ b/src/main/cli/cli-installer-appimage-removal.test.ts
@@ -1,0 +1,190 @@
+import { existsSync } from 'node:fs'
+import { mkdir, mkdtemp, readlink, rm, unlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { runProcess } from '../../shared/child-process/run-process'
+
+vi.mock('electron', () => ({
+  app: { isPackaged: false, getPath: () => tmpdir(), getAppPath: () => tmpdir() }
+}))
+
+import { resolveAppImageExtractedRoot } from './appimage-extracted-root'
+import {
+  publishAppImageLauncherEndpoint,
+  resolveAppImageLauncherEndpointPath,
+  resolveAppImageStableLauncherPath
+} from './appimage-stable-launcher'
+import { CliInstaller } from './cli-installer'
+import type { CliInstallerOptions } from './cli-installer-contracts'
+
+const created: string[] = []
+
+afterEach(async () => {
+  await Promise.all(created.splice(0).map((path) => rm(path, { recursive: true, force: true })))
+})
+
+describe.skipIf(process.platform === 'win32')('AppImage CLI removal', () => {
+  it.each([false, true])(
+    'removes installed payloads while preserving the live PTY launcher (command missing: %s)',
+    async (removeCommandFirst) => {
+      const root = await mkdtemp(join(tmpdir(), 'orca-appimage-cli-remove-'))
+      created.push(root)
+      const appImagePath = join(root, 'Orca.AppImage')
+      const cacheRootPath = join(root, 'cache')
+      const commandPath = join(root, 'home', '.local', 'bin', 'orca-ide')
+      const resourcesPath = join(root, 'mount', 'resources')
+      const liveLauncherPath = join(resourcesPath, 'bin', 'orca-ide')
+      await mkdir(join(resourcesPath, 'bin'), { recursive: true })
+      await writeFile(appImagePath, '#!/usr/bin/env bash\n', { mode: 0o755 })
+      await writeFile(liveLauncherPath, '#!/usr/bin/env bash\nprintf live', { mode: 0o755 })
+      publishAppImageLauncherEndpoint(cacheRootPath, 'live', liveLauncherPath)
+
+      const installer = new CliInstaller({
+        platform: 'linux',
+        isPackaged: true,
+        userDataPath: join(root, 'user-data'),
+        resourcesPath,
+        execPath: join(root, 'mount', 'orca-ide'),
+        appPath: join(resourcesPath, 'app.asar'),
+        homePath: join(root, 'home'),
+        processPathEnv: join(root, 'home', '.local', 'bin'),
+        commandPathOverride: commandPath,
+        appImagePath,
+        appImageCacheRootPath: cacheRootPath,
+        appImageExtractRunner: async (_path, cwd) => {
+          const payloadDirectory = join(cwd, 'squashfs-root', 'resources', 'bin')
+          await mkdir(payloadDirectory, { recursive: true })
+          await writeFile(
+            join(payloadDirectory, 'orca-ide'),
+            '#!/usr/bin/env bash\nprintf installed',
+            {
+              mode: 0o755
+            }
+          )
+        }
+      })
+
+      const installed = await installer.install()
+      const extractedRoot = resolveAppImageExtractedRoot({ appImagePath, cacheRootPath })!
+      expect(await readlink(commandPath)).toBe(installed.launcherPath)
+      expect(existsSync(extractedRoot.rootPath)).toBe(true)
+      if (removeCommandFirst) {
+        await unlink(commandPath)
+      }
+
+      await expect(installer.remove()).resolves.toMatchObject({ state: 'not_installed' })
+
+      expect(existsSync(commandPath)).toBe(false)
+      expect(existsSync(extractedRoot.rootPath)).toBe(false)
+      expect(existsSync(resolveAppImageLauncherEndpointPath(cacheRootPath, 'installed'))).toBe(
+        false
+      )
+      expect(existsSync(resolveAppImageLauncherEndpointPath(cacheRootPath, 'live'))).toBe(true)
+      const stableLauncherPath = resolveAppImageStableLauncherPath(cacheRootPath)
+      expect(existsSync(stableLauncherPath)).toBe(true)
+      await expect(
+        runProcess({ program: stableLauncherPath, args: [], timeoutMs: 3_000 })
+      ).resolves.toMatchObject({ code: 0, stdout: 'live' })
+    }
+  )
+
+  it('does not remove a sibling AppImage registration or payload', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-appimage-cli-siblings-'))
+    created.push(root)
+    const cacheRootPath = join(root, 'cache')
+    const commandPath = join(root, 'home', '.local', 'bin', 'orca-ide')
+    const resourcesPath = join(root, 'mount', 'resources')
+    const firstAppImagePath = join(root, 'Orca-stable.AppImage')
+    const secondAppImagePath = join(root, 'Orca-nightly.AppImage')
+    await mkdir(join(resourcesPath, 'bin'), { recursive: true })
+    await Promise.all([
+      writeFile(firstAppImagePath, '#!/usr/bin/env bash\n', { mode: 0o755 }),
+      writeFile(secondAppImagePath, '#!/usr/bin/env bash\n# nightly\n', { mode: 0o755 })
+    ])
+    const installerOptions = (appImagePath: string, content: string): CliInstallerOptions => ({
+      platform: 'linux',
+      isPackaged: true,
+      userDataPath: join(root, 'user-data'),
+      resourcesPath,
+      execPath: join(root, 'mount', 'orca-ide'),
+      appPath: join(resourcesPath, 'app.asar'),
+      homePath: join(root, 'home'),
+      processPathEnv: join(root, 'home', '.local', 'bin'),
+      commandPathOverride: commandPath,
+      appImagePath,
+      appImageCacheRootPath: cacheRootPath,
+      appImageExtractRunner: async (_path, cwd) => {
+        const payloadDirectory = join(cwd, 'squashfs-root', 'resources', 'bin')
+        await mkdir(payloadDirectory, { recursive: true })
+        await writeFile(join(payloadDirectory, 'orca-ide'), content, { mode: 0o755 })
+      }
+    })
+    class HookedInstaller extends CliInstaller {
+      afterNextStatus: (() => Promise<void>) | null = null
+
+      override async getStatus() {
+        const status = await super.getStatus()
+        const hook = this.afterNextStatus
+        this.afterNextStatus = null
+        await hook?.()
+        return status
+      }
+    }
+    let siblingStatusReads = 0
+    class TrackingInstaller extends CliInstaller {
+      override async getStatus() {
+        siblingStatusReads += 1
+        return super.getStatus()
+      }
+    }
+    const firstInstaller = new HookedInstaller(installerOptions(firstAppImagePath, 'stable'))
+    const secondInstaller = new TrackingInstaller(installerOptions(secondAppImagePath, 'nightly'))
+
+    await firstInstaller.install()
+    const firstRoot = resolveAppImageExtractedRoot({
+      appImagePath: firstAppImagePath,
+      cacheRootPath
+    })!
+    await secondInstaller.install()
+    const secondRoot = resolveAppImageExtractedRoot({
+      appImagePath: secondAppImagePath,
+      cacheRootPath
+    })!
+
+    const siblingStatus = await firstInstaller.getStatus()
+    expect(firstInstaller.isAppImageRegistrationOwnedBySibling(siblingStatus)).toBe(true)
+    await rm(resolveAppImageStableLauncherPath(cacheRootPath))
+    const brokenLauncherStatus = await firstInstaller.getStatus()
+    expect(firstInstaller.isAppImageRegistrationOwnedBySibling(brokenLauncherStatus)).toBe(false)
+    publishAppImageLauncherEndpoint(cacheRootPath, 'installed', secondRoot.payloadLauncherPath)
+
+    await firstInstaller.remove()
+
+    expect(existsSync(firstRoot.rootPath)).toBe(false)
+    expect(existsSync(secondRoot.rootPath)).toBe(true)
+    expect(existsSync(commandPath)).toBe(true)
+    await expect(
+      readlink(resolveAppImageLauncherEndpointPath(cacheRootPath, 'installed'))
+    ).resolves.toBe(secondRoot.payloadLauncherPath)
+
+    await firstInstaller.install()
+    let siblingInstall: Promise<unknown> | null = null
+    siblingStatusReads = 0
+    firstInstaller.afterNextStatus = async () => {
+      siblingInstall = secondInstaller.install()
+      await Promise.resolve()
+      expect(siblingStatusReads).toBe(0)
+    }
+    await firstInstaller.remove()
+    expect(siblingInstall).not.toBeNull()
+    await siblingInstall
+
+    expect(siblingStatusReads).toBeGreaterThan(0)
+    expect(existsSync(commandPath)).toBe(true)
+    expect(existsSync(secondRoot.rootPath)).toBe(true)
+    await expect(
+      readlink(resolveAppImageLauncherEndpointPath(cacheRootPath, 'installed'))
+    ).resolves.toBe(secondRoot.payloadLauncherPath)
+  })
+})

--- a/src/main/cli/cli-installer-appimage-removal.test.ts
+++ b/src/main/cli/cli-installer-appimage-removal.test.ts
@@ -1,9 +1,8 @@
 import { existsSync } from 'node:fs'
-import { mkdir, mkdtemp, readlink, rm, unlink, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readlink, rm, symlink, unlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { runProcess } from '../../shared/child-process/run-process'
 
 vi.mock('electron', () => ({
   app: { isPackaged: false, getPath: () => tmpdir(), getAppPath: () => tmpdir() }
@@ -26,7 +25,7 @@ afterEach(async () => {
 
 describe.skipIf(process.platform === 'win32')('AppImage CLI removal', () => {
   it.each([false, true])(
-    'removes installed payloads while preserving the live PTY launcher (command missing: %s)',
+    'removes installed payloads and the legacy live endpoint (command missing: %s)',
     async (removeCommandFirst) => {
       const root = await mkdtemp(join(tmpdir(), 'orca-appimage-cli-remove-'))
       created.push(root)
@@ -38,7 +37,9 @@ describe.skipIf(process.platform === 'win32')('AppImage CLI removal', () => {
       await mkdir(join(resourcesPath, 'bin'), { recursive: true })
       await writeFile(appImagePath, '#!/usr/bin/env bash\n', { mode: 0o755 })
       await writeFile(liveLauncherPath, '#!/usr/bin/env bash\nprintf live', { mode: 0o755 })
-      publishAppImageLauncherEndpoint(cacheRootPath, 'live', liveLauncherPath)
+      const liveEndpointPath = resolveAppImageLauncherEndpointPath(cacheRootPath, 'live')
+      await mkdir(dirname(liveEndpointPath), { recursive: true })
+      await symlink(liveLauncherPath, liveEndpointPath)
 
       const installer = new CliInstaller({
         platform: 'linux',
@@ -80,12 +81,9 @@ describe.skipIf(process.platform === 'win32')('AppImage CLI removal', () => {
       expect(existsSync(resolveAppImageLauncherEndpointPath(cacheRootPath, 'installed'))).toBe(
         false
       )
-      expect(existsSync(resolveAppImageLauncherEndpointPath(cacheRootPath, 'live'))).toBe(true)
+      expect(existsSync(resolveAppImageLauncherEndpointPath(cacheRootPath, 'live'))).toBe(false)
       const stableLauncherPath = resolveAppImageStableLauncherPath(cacheRootPath)
       expect(existsSync(stableLauncherPath)).toBe(true)
-      await expect(
-        runProcess({ program: stableLauncherPath, args: [], timeoutMs: 3_000 })
-      ).resolves.toMatchObject({ code: 0, stdout: 'live' })
     }
   )
 

--- a/src/main/cli/cli-installer-appimage-removal.test.ts
+++ b/src/main/cli/cli-installer-appimage-removal.test.ts
@@ -132,8 +132,12 @@ describe.skipIf(process.platform === 'win32')('AppImage CLI removal', () => {
       }
     }
     let siblingStatusReads = 0
+    let rejectSiblingStatusRead = false
     class TrackingInstaller extends CliInstaller {
       override async getStatus() {
+        if (rejectSiblingStatusRead) {
+          throw new Error('sibling status read before registration lock release')
+        }
         siblingStatusReads += 1
         return super.getStatus()
       }
@@ -172,11 +176,11 @@ describe.skipIf(process.platform === 'win32')('AppImage CLI removal', () => {
     let siblingInstall: Promise<unknown> | null = null
     siblingStatusReads = 0
     firstInstaller.afterNextStatus = async () => {
+      rejectSiblingStatusRead = true
       siblingInstall = secondInstaller.install()
-      await Promise.resolve()
-      expect(siblingStatusReads).toBe(0)
     }
     await firstInstaller.remove()
+    rejectSiblingStatusRead = false
     expect(siblingInstall).not.toBeNull()
     await siblingInstall
 

--- a/src/main/cli/cli-installer-contracts.ts
+++ b/src/main/cli/cli-installer-contracts.ts
@@ -20,8 +20,10 @@ export type CliInstallerOptions = {
   userPathWriter?: (value: string) => Promise<void>
   userPathCacheInvalidator?: () => void
   windowsEnvironment?: NodeJS.ProcessEnv
-  /** Why: AppImage reports a stable outer file path via $APPIMAGE while bundled resources live in an ephemeral FUSE mount. */
+  /** Trusted caller override; production discovers AppImage only from a complete runtime identity. */
   appImagePath?: string | null
+  appImageCacheRootPath?: string
+  appImageExtractRunner?: (appImagePath: string, cwd: string) => Promise<void>
 }
 
 export type InstallSpec = {

--- a/src/main/cli/cli-installer.test.ts
+++ b/src/main/cli/cli-installer.test.ts
@@ -1,6 +1,17 @@
-import { chmod, lstat, mkdir, readFile, readlink, symlink, writeFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import {
+  chmod,
+  lstat,
+  mkdir,
+  readFile,
+  readdir,
+  readlink,
+  rm,
+  symlink,
+  writeFile
+} from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { dirname, join, relative, sep } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const execFileMock = vi.hoisted(() => vi.fn())
@@ -18,8 +29,20 @@ vi.mock('node:child_process', () => ({
 }))
 
 import { CliInstaller } from './cli-installer'
-import { buildAppImageCliWrapper } from './appimage-cli-wrapper'
 import { makeFixture } from './cli-installer-test-fixtures'
+import { resolveAppImageExtractedRoot } from './appimage-extracted-root'
+import { buildLegacyAppImageCliWrapper } from './legacy-appimage-cli-wrapper'
+
+// Stands in for the AppImage runtime's `--appimage-extract`, which writes the
+// payload to ./squashfs-root relative to cwd.
+async function fakeAppImageExtractRunner(_appImagePath: string, cwd: string): Promise<void> {
+  const launcherDir = join(cwd, 'squashfs-root', 'resources', 'bin')
+  await mkdir(launcherDir, { recursive: true })
+  await writeFile(join(launcherDir, 'orca-ide'), '#!/usr/bin/env bash\n', {
+    encoding: 'utf8',
+    mode: 0o755
+  })
+}
 
 describe('CliInstaller', () => {
   beforeEach(() => {
@@ -127,15 +150,18 @@ describe('CliInstaller', () => {
     }
   )
 
-  // Why: AppImage resources live under a per-launch FUSE mount, so the
-  // installed shell command must be a stable wrapper rather than a symlink.
+  // Why: an AppImage's payload is only reachable through a FUSE mount that its
+  // own AppRun sets up, and AppRun prepends `--no-sandbox` into node mode on
+  // userns-restricted hosts (#11609). Extracting once gives the command the
+  // same plain launcher a deb install ships, so registration is a symlink.
   it.skipIf(process.platform === 'win32')(
-    'creates an AppImage wrapper under the linux command path',
+    'symlinks the linux command at the extracted AppImage launcher',
     async () => {
       const fixture = await makeFixture()
       const commandDir = join(fixture.root, '.local', 'bin')
       const installPath = join(commandDir, 'orca-ide')
       const appImagePath = join(fixture.root, 'Orca.AppImage')
+      const cacheRootPath = join(fixture.root, 'cache')
       await writeFile(appImagePath, '#!/usr/bin/env bash\n', {
         encoding: 'utf8',
         mode: 0o755
@@ -144,77 +170,134 @@ describe('CliInstaller', () => {
       const installer = new CliInstaller({
         platform: 'linux',
         isPackaged: true,
+        userDataPath: fixture.userDataPath,
+        appPath: fixture.appPath,
         appImagePath,
+        appImageCacheRootPath: cacheRootPath,
+        appImageExtractRunner: fakeAppImageExtractRunner,
         commandPathOverride: installPath,
         processPathEnv: commandDir
       })
 
       const initial = await installer.getStatus()
-      expect(initial).toMatchObject({
-        state: 'not_installed',
-        installMethod: 'wrapper',
-        launcherPath: appImagePath
-      })
+      expect(initial).toMatchObject({ state: 'not_installed', installMethod: 'symlink' })
 
       const installed = await installer.install()
       expect(installed).toMatchObject({
         state: 'installed',
         commandName: 'orca-ide',
-        installMethod: 'wrapper',
-        launcherPath: appImagePath,
-        currentTarget: appImagePath,
+        installMethod: 'symlink',
         pathConfigured: true
       })
+      // The command target remains stable while its cache endpoint advances generations.
+      expect(relative(cacheRootPath, installed.launcherPath as string).split(sep)).toEqual([
+        'launcher',
+        'orca-ide'
+      ])
+      expect(installed.currentTarget).toBe(installed.launcherPath)
+      await expect(readlink(installPath)).resolves.toBe(installed.launcherPath)
 
-      const commandStats = await lstat(installPath)
-      expect(commandStats.isFile()).toBe(true)
-      expect(commandStats.mode & 0o111).not.toBe(0)
-      await expect(readlink(installPath)).rejects.toMatchObject({ code: 'EINVAL' })
-      await expect(readFile(installPath, 'utf8')).resolves.toBe(
-        buildAppImageCliWrapper(appImagePath)
-      )
+      const extractedRoot = resolveAppImageExtractedRoot({ appImagePath, cacheRootPath })!
+      await rm(extractedRoot.rootPath, { recursive: true, force: true })
+      await expect(installer.getStatus()).resolves.toMatchObject({ state: 'stale' })
+      const repaired = await installer.install()
+      expect(repaired.state).toBe('installed')
 
       const removed = await installer.remove()
       expect(removed.state).toBe('not_installed')
+      await expect(lstat(repaired.launcherPath as string)).resolves.toBeDefined()
+      expect(
+        existsSync(resolveAppImageExtractedRoot({ appImagePath, cacheRootPath })!.rootPath)
+      ).toBe(false)
     }
   )
 
   it.skipIf(process.platform === 'win32')(
-    'reports a stale AppImage wrapper when the AppImage path changes',
+    're-extracts and re-points the command when the AppImage is replaced',
     async () => {
       const fixture = await makeFixture()
       const commandDir = join(fixture.root, '.local', 'bin')
       const installPath = join(commandDir, 'orca-ide')
-      const oldAppImagePath = join(fixture.root, 'Old-Orca.AppImage')
-      const newAppImagePath = join(fixture.root, 'Orca.AppImage')
-      await mkdir(commandDir, { recursive: true })
-      await writeFile(installPath, buildAppImageCliWrapper(oldAppImagePath), {
+      const appImagePath = join(fixture.root, 'Orca.AppImage')
+      const cacheRootPath = join(fixture.root, 'cache')
+      await writeFile(appImagePath, '#!/usr/bin/env bash\n', {
         encoding: 'utf8',
         mode: 0o755
       })
-      await writeFile(newAppImagePath, '#!/usr/bin/env bash\n', {
+      const makeInstaller = (): CliInstaller =>
+        new CliInstaller({
+          platform: 'linux',
+          isPackaged: true,
+          userDataPath: fixture.userDataPath,
+          appPath: fixture.appPath,
+          appImagePath,
+          appImageCacheRootPath: cacheRootPath,
+          appImageExtractRunner: fakeAppImageExtractRunner,
+          commandPathOverride: installPath,
+          processPathEnv: commandDir
+        })
+
+      const first = await makeInstaller().install()
+      expect(first.state).toBe('installed')
+
+      // An update replaces the file in place, so size and mtime both change.
+      await writeFile(appImagePath, '#!/usr/bin/env bash\n# next version\n', {
         encoding: 'utf8',
         mode: 0o755
       })
 
+      await expect(makeInstaller().getStatus()).resolves.toMatchObject({ state: 'stale' })
+
+      const second = await makeInstaller().install()
+      expect(second.state).toBe('installed')
+      expect(second.launcherPath).toBe(first.launcherPath)
+      await expect(readlink(installPath)).resolves.toBe(second.launcherPath)
+      // Only the live payload survives the upgrade.
+      const liveRoot = resolveAppImageExtractedRoot({ appImagePath, cacheRootPath })!.rootPath
+      await expect(readdir(dirname(liveRoot))).resolves.toHaveLength(1)
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'replaces and removes the legacy AppImage wrapper',
+    async () => {
+      const fixture = await makeFixture()
+      const commandDir = join(fixture.root, '.local', 'bin')
+      const installPath = join(commandDir, 'orca-ide')
+      const appImagePath = join(fixture.root, "Orca's AppImage.AppImage")
+      const cacheRootPath = join(fixture.root, 'cache')
+      await mkdir(commandDir, { recursive: true })
+      await writeFile(appImagePath, '#!/usr/bin/env bash\n', { encoding: 'utf8', mode: 0o755 })
+      await writeFile(installPath, buildLegacyAppImageCliWrapper(appImagePath), {
+        encoding: 'utf8',
+        mode: 0o755
+      })
       const installer = new CliInstaller({
         platform: 'linux',
         isPackaged: true,
-        appImagePath: newAppImagePath,
+        userDataPath: fixture.userDataPath,
+        appPath: fixture.appPath,
+        appImagePath,
+        appImageCacheRootPath: cacheRootPath,
+        appImageExtractRunner: fakeAppImageExtractRunner,
         commandPathOverride: installPath,
         processPathEnv: commandDir
       })
 
       await expect(installer.getStatus()).resolves.toMatchObject({
         state: 'stale',
-        installMethod: 'wrapper',
-        currentTarget: newAppImagePath
+        currentTarget: appImagePath
       })
-
       await expect(installer.install()).resolves.toMatchObject({ state: 'installed' })
-      await expect(readFile(installPath, 'utf8')).resolves.toBe(
-        buildAppImageCliWrapper(newAppImagePath)
-      )
+      await expect(readlink(installPath)).resolves.toContain(cacheRootPath)
+
+      await installer.remove()
+      await writeFile(installPath, buildLegacyAppImageCliWrapper(appImagePath), {
+        encoding: 'utf8',
+        mode: 0o755
+      })
+      await expect(installer.remove()).resolves.toMatchObject({ state: 'not_installed' })
+      await expect(lstat(installPath)).rejects.toMatchObject({ code: 'ENOENT' })
     }
   )
 
@@ -239,6 +322,8 @@ describe('CliInstaller', () => {
       const installer = new CliInstaller({
         platform: 'linux',
         isPackaged: true,
+        userDataPath: fixture.userDataPath,
+        appPath: fixture.appPath,
         resourcesPath,
         homePath,
         processPathEnv: commandDir
@@ -251,24 +336,30 @@ describe('CliInstaller', () => {
   )
 
   it.skipIf(process.platform === 'win32')(
-    'removes a legacy linux orca symlink when installing an AppImage wrapper',
+    'removes a legacy linux orca symlink when registering from an AppImage',
     async () => {
       const fixture = await makeFixture()
       const homePath = join(fixture.root, 'home')
       const commandDir = join(homePath, '.local', 'bin')
       const legacyCommandPath = join(commandDir, 'orca')
       const appImagePath = join(fixture.root, 'Orca.AppImage')
+      const cacheRootPath = join(fixture.root, 'cache')
       await mkdir(commandDir, { recursive: true })
       await writeFile(appImagePath, '#!/usr/bin/env bash\n', {
         encoding: 'utf8',
         mode: 0o755
       })
-      await symlink(join('/tmp', '.mount_Orca1234', 'resources', 'bin', 'orca'), legacyCommandPath)
+      const extractedRoot = resolveAppImageExtractedRoot({ appImagePath, cacheRootPath })!
+      await symlink(join(dirname(extractedRoot.payloadLauncherPath), 'orca'), legacyCommandPath)
 
       const installer = new CliInstaller({
         platform: 'linux',
         isPackaged: true,
+        userDataPath: fixture.userDataPath,
+        appPath: fixture.appPath,
         appImagePath,
+        appImageCacheRootPath: cacheRootPath,
+        appImageExtractRunner: fakeAppImageExtractRunner,
         homePath,
         processPathEnv: commandDir
       })
@@ -315,7 +406,9 @@ describe('CliInstaller', () => {
         expect(installed.pathConfigured).toBe(true)
         expect(privilegedCommands).toHaveLength(1)
         expect(privilegedCommands[0]).toContain('mkdir -p')
-        expect(privilegedCommands[0]).toContain('ln -sfn')
+        expect(privilegedCommands[0]).toContain('ln -s')
+        expect(privilegedCommands[0]).toContain('/bin/ln -P')
+        expect(privilegedCommands[0]).not.toContain('mv -f')
         await expect(readlink(installPath)).resolves.toBe(installed.launcherPath)
       } finally {
         await chmod(protectedDir, 0o700).catch(() => undefined)

--- a/src/main/cli/cli-installer.ts
+++ b/src/main/cli/cli-installer.ts
@@ -11,7 +11,6 @@ import {
   isAppImageInstalledLauncherOwnedBySibling,
   resolveAppImageNamespacePath
 } from './appimage-extracted-root'
-import { getBundledLauncherPath } from './bundled-cli-launcher-path'
 import { isAppImageStableLauncherReady } from './appimage-stable-launcher'
 import { CliPathRegistration } from './cli-path-registration'
 
@@ -213,5 +212,3 @@ export class CliInstaller extends CliPathRegistration {
       : operation()
   }
 }
-
-export { getBundledLauncherPath }

--- a/src/main/cli/cli-installer.ts
+++ b/src/main/cli/cli-installer.ts
@@ -1,10 +1,34 @@
 import { mkdir, unlink } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import type { CliInstallStatus } from '../../shared/cli-install-types'
+import {
+  pruneAppImageExtractedRoots,
+  removeAppImageInstalledPayloads
+} from './appimage-extraction-pruning'
+import { withAppImageRegistrationLock } from './appimage-registration-lock'
+import {
+  isAppImageInstalledLauncherCurrent,
+  isAppImageInstalledLauncherOwnedBySibling,
+  resolveAppImageNamespacePath
+} from './appimage-extracted-root'
 import { getBundledLauncherPath } from './bundled-cli-launcher-path'
+import { isAppImageStableLauncherReady } from './appimage-stable-launcher'
 import { CliPathRegistration } from './cli-path-registration'
 
 export class CliInstaller extends CliPathRegistration {
+  isAppImageRegistrationOwnedBySibling(status: CliInstallStatus): boolean {
+    if (
+      status.currentTarget !== status.launcherPath ||
+      !isAppImageStableLauncherReady(this.appImageCacheRootPath)
+    ) {
+      return false
+    }
+    const extractionOptions = this.appImageExtractionOptions()
+    return Boolean(
+      extractionOptions && isAppImageInstalledLauncherOwnedBySibling(extractionOptions)
+    )
+  }
+
   async getStatus(): Promise<CliInstallStatus> {
     const defaultSpec = this.resolveInstallSpec()
     if (!defaultSpec) {
@@ -26,8 +50,9 @@ export class CliInstaller extends CliPathRegistration {
 
     const launcherPath = await this.resolveLauncherPath()
     if (!launcherPath) {
-      const detail =
-        this.isLinuxAppImage() && this.appImagePath
+      const detail = this.hasUnverifiedAppImageRuntime
+        ? 'Orca could not verify the inherited AppImage runtime identity, so CLI registration is unavailable.'
+        : this.isLinuxAppImage() && this.appImagePath
           ? `The AppImage file at ${this.appImagePath} is missing. Move it back or re-run CLI registration from the current AppImage location.`
           : this.isPackaged
             ? 'The bundled CLI launcher is missing from this Orca build.'
@@ -48,20 +73,56 @@ export class CliInstaller extends CliPathRegistration {
       }
     }
 
+    return this.getStatusForLauncher(launcherPath)
+  }
+
+  private async getStatusForLauncher(launcherPath: string): Promise<CliInstallStatus> {
+    const defaultSpec = this.resolveInstallSpec()
+    if (!defaultSpec) {
+      throw new Error('CLI registration is not implemented on this platform.')
+    }
     const spec = await this.resolveActiveInstallSpec(defaultSpec, launcherPath)
-    const baseStatus =
+    const inspectedStatus =
       spec.installMethod === 'symlink'
         ? await this.inspectSymlink(spec.commandPath, launcherPath)
-        : this.isLinuxAppImage()
-          ? await this.inspectAppImageWrapper(spec.commandPath, launcherPath)
-          : await this.inspectWindowsWrapper(spec.commandPath, launcherPath)
+        : await this.inspectWindowsWrapper(spec.commandPath, launcherPath)
+    const extractionOptions = this.appImageExtractionOptions()
+    const baseStatus =
+      inspectedStatus.state === 'installed' &&
+      extractionOptions &&
+      !isAppImageInstalledLauncherCurrent(extractionOptions)
+        ? {
+            ...inspectedStatus,
+            state: 'stale' as const,
+            detail: `${spec.commandPath} does not point to the current Orca AppImage payload.`
+          }
+        : inspectedStatus
     const pathDirectory = dirname(spec.commandPath)
     const pathProbe = await this.probePathConfiguration(pathDirectory)
     return this.withPathInfo(baseStatus, pathDirectory, pathProbe)
   }
 
   async install(): Promise<CliInstallStatus> {
-    const status = await this.getStatus()
+    return this.runAppImageRegistrationOperation(() => this.installUnlocked())
+  }
+
+  private async installUnlocked(): Promise<CliInstallStatus> {
+    const initialStatus = await this.getStatus()
+    if (
+      !initialStatus.supported ||
+      !initialStatus.commandPath ||
+      !initialStatus.launcherPath ||
+      !initialStatus.installMethod
+    ) {
+      throw new Error(initialStatus.detail ?? 'CLI registration is unavailable on this build.')
+    }
+    if (initialStatus.state === 'conflict') {
+      throw new Error(`Refusing to replace non-Orca command at ${initialStatus.commandPath}.`)
+    }
+    const extractedRoot = await this.ensureLinuxAppImagePayload()
+    const status = extractedRoot
+      ? await this.getStatusForLauncher(extractedRoot.stableLauncherPath)
+      : initialStatus
     if (!status.supported || !status.commandPath || !status.launcherPath || !status.installMethod) {
       throw new Error(status.detail ?? 'CLI registration is unavailable on this build.')
     }
@@ -72,9 +133,6 @@ export class CliInstaller extends CliPathRegistration {
     // eslint-disable-next-line unicorn/prefer-ternary -- Why: the install path performs async side effects and is easier to audit as an explicit branch than as an awaited ternary.
     if (status.installMethod === 'symlink') {
       await this.installSymlink(status)
-      await this.removeLegacyLinuxCommandIfManaged(status.launcherPath)
-    } else if (this.isLinuxAppImage()) {
-      await this.installAppImageWrapper(status.commandPath, status.launcherPath)
       await this.removeLegacyLinuxCommandIfManaged(status.launcherPath)
     } else if (this.isWindowsPackagedBundledCommand(status.commandPath, status.launcherPath)) {
       // Why: packaged Windows already ships resources/bin/orca.exe; registration only owns the PATH entry.
@@ -88,13 +146,23 @@ export class CliInstaller extends CliPathRegistration {
       // Why: Windows shells find commands via user PATH, so the installer owns that entry, not the desktop installer.
       await this.ensureWindowsPathEntry(dirname(status.commandPath))
     }
+    if (extractedRoot) {
+      await pruneAppImageExtractedRoots(extractedRoot.rootPath)
+    }
 
-    return this.getStatus()
+    return extractedRoot
+      ? this.getStatusForLauncher(extractedRoot.stableLauncherPath)
+      : this.getStatus()
   }
 
   async remove(): Promise<CliInstallStatus> {
+    return this.runAppImageRegistrationOperation(() => this.removeUnlocked())
+  }
+
+  private async removeUnlocked(): Promise<CliInstallStatus> {
     const status = await this.getStatus()
     if (!status.supported || !status.commandPath || !status.launcherPath || !status.installMethod) {
+      await this.removeLinuxAppImagePayloads()
       return status
     }
     if (status.state === 'not_installed') {
@@ -103,13 +171,19 @@ export class CliInstaller extends CliPathRegistration {
         await this.removeWindowsPathEntry(dirname(status.commandPath))
         return this.getStatus()
       }
+      await this.removeLinuxAppImagePayloads()
       return status
     }
     if (status.state === 'conflict') {
       throw new Error(`Refusing to remove non-Orca command at ${status.commandPath}.`)
     }
-    if (status.state === 'stale') {
+    if (status.state === 'stale' && status.installMethod !== 'symlink') {
       throw new Error(`Refusing to remove a command not owned by Orca at ${status.commandPath}.`)
+    }
+
+    if (status.state === 'stale' && this.isAppImageRegistrationOwnedBySibling(status)) {
+      await this.removeLinuxAppImagePayloads()
+      return this.getStatus()
     }
 
     if (status.installMethod === 'symlink') {
@@ -122,7 +196,21 @@ export class CliInstaller extends CliPathRegistration {
       await this.removeWindowsPathEntry(dirname(status.commandPath))
     }
 
+    await this.removeLinuxAppImagePayloads()
     return this.getStatus()
+  }
+
+  private async removeLinuxAppImagePayloads(): Promise<void> {
+    const extractionOptions = this.appImageExtractionOptions()
+    if (this.isLinuxAppImage() && extractionOptions) {
+      await removeAppImageInstalledPayloads(resolveAppImageNamespacePath(extractionOptions))
+    }
+  }
+
+  private runAppImageRegistrationOperation<T>(operation: () => Promise<T>): Promise<T> {
+    return this.isLinuxAppImage()
+      ? withAppImageRegistrationLock(this.appImageCacheRootPath, operation)
+      : operation()
   }
 }
 

--- a/src/main/cli/cli-installer.ts
+++ b/src/main/cli/cli-installer.ts
@@ -116,7 +116,7 @@ export class CliInstaller extends CliPathRegistration {
       throw new Error(initialStatus.detail ?? 'CLI registration is unavailable on this build.')
     }
     if (initialStatus.state === 'conflict') {
-      throw new Error(`Refusing to replace non-Orca command at ${initialStatus.commandPath}.`)
+      throw new Error(`Refusing to replace non-Orca command at ${initialStatus.commandPath}. Remove it and register again if it is no longer needed.`)
     }
     const extractedRoot = await this.ensureLinuxAppImagePayload()
     const status = extractedRoot
@@ -126,7 +126,7 @@ export class CliInstaller extends CliPathRegistration {
       throw new Error(status.detail ?? 'CLI registration is unavailable on this build.')
     }
     if (status.state === 'conflict') {
-      throw new Error(`Refusing to replace non-Orca command at ${status.commandPath}.`)
+      throw new Error(`Refusing to replace non-Orca command at ${status.commandPath}. Remove it and register again if it is no longer needed.`)
     }
 
     // eslint-disable-next-line unicorn/prefer-ternary -- Why: the install path performs async side effects and is easier to audit as an explicit branch than as an awaited ternary.

--- a/src/main/cli/legacy-appimage-cli-wrapper.test.ts
+++ b/src/main/cli/legacy-appimage-cli-wrapper.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildLegacyAppImageCliWrapper,
+  extractLegacyAppImageCliWrapperTarget
+} from './legacy-appimage-cli-wrapper'
+
+describe('legacy AppImage CLI wrapper', () => {
+  it('recovers a path containing a newline', () => {
+    const appImagePath = "/tmp/Orca\nnightly's.AppImage"
+    expect(extractLegacyAppImageCliWrapperTarget(buildLegacyAppImageCliWrapper(appImagePath))).toBe(
+      appImagePath
+    )
+  })
+
+  it('rejects a wrapper with a changed command body', () => {
+    const wrapper = buildLegacyAppImageCliWrapper('/tmp/Orca.AppImage')
+    expect(
+      extractLegacyAppImageCliWrapperTarget(wrapper.replace('set -euo pipefail', 'set -u'))
+    ).toBe(null)
+  })
+})

--- a/src/main/cli/legacy-appimage-cli-wrapper.ts
+++ b/src/main/cli/legacy-appimage-cli-wrapper.ts
@@ -1,3 +1,5 @@
+import { quoteShell } from './cli-install-path-format'
+
 const APPIMAGE_CLI_SCRIPT = [
   '(async()=>{',
   'try{',
@@ -12,9 +14,15 @@ const APPIMAGE_CLI_SCRIPT = [
   '})();'
 ].join('')
 
-export function buildAppImageCliWrapper(appImagePath: string): string {
-  // Why: AppImage mounts resources under a fresh FUSE path per launch, so the
-  // installed command must call the stable outer AppImage and resolve APPDIR.
+export function extractLegacyAppImageCliWrapperTarget(content: string): string | null {
+  const assignment = /^APPIMAGE=(.+)$/mu.exec(content)?.[1]
+  const appImagePath = assignment ? unquoteShell(assignment) : null
+  return appImagePath && content === buildLegacyAppImageCliWrapper(appImagePath)
+    ? appImagePath
+    : null
+}
+
+export function buildLegacyAppImageCliWrapper(appImagePath: string): string {
   return `#!/usr/bin/env bash
 set -euo pipefail
 APPIMAGE=${quoteShell(appImagePath)}
@@ -32,6 +40,10 @@ ELECTRON_RUN_AS_NODE=1 exec "$APPIMAGE" -e ${quoteShell(APPIMAGE_CLI_SCRIPT)} --
 `
 }
 
-export function quoteShell(value: string): string {
-  return `'${value.replaceAll("'", `'"'"'`)}'`
+function unquoteShell(value: string): string | null {
+  if (!value.startsWith("'") || !value.endsWith("'")) {
+    return null
+  }
+  const decoded = value.slice(1, -1).split(`'"'"'`).join("'")
+  return quoteShell(decoded) === value ? decoded : null
 }

--- a/src/main/cli/legacy-appimage-cli-wrapper.ts
+++ b/src/main/cli/legacy-appimage-cli-wrapper.ts
@@ -15,7 +15,7 @@ const APPIMAGE_CLI_SCRIPT = [
 ].join('')
 
 export function extractLegacyAppImageCliWrapperTarget(content: string): string | null {
-  const assignment = /^APPIMAGE=(.+)$/mu.exec(content)?.[1]
+  const assignment = /^APPIMAGE=([\s\S]+?)\nif \[ ! -f "\$APPIMAGE" \]; then/mu.exec(content)?.[1]
   const appImagePath = assignment ? unquoteShell(assignment) : null
   return appImagePath && content === buildLegacyAppImageCliWrapper(appImagePath)
     ? appImagePath

--- a/src/main/cli/linux-bare-orca-dispatcher.test.ts
+++ b/src/main/cli/linux-bare-orca-dispatcher.test.ts
@@ -72,6 +72,7 @@ async function makeFixture(): Promise<{ homePath: string; resourcesPath: string 
 }
 
 afterEach(async () => {
+  vi.unstubAllEnvs()
   filePublicationFailures.link = 0
   filePublicationFailures.replaceBeforeRename = ''
   registrationLock.completed = null
@@ -81,6 +82,17 @@ afterEach(async () => {
 })
 
 describe('installLinuxBareOrcaDispatcher', () => {
+  it('uses the mounted bundled launcher when only APPDIR is inherited', async () => {
+    const { homePath, resourcesPath } = await makeFixture()
+    vi.stubEnv('APPIMAGE', '')
+    vi.stubEnv('APPDIR', resourcesPath)
+
+    const result = await installLinuxBareOrcaDispatcher({ resourcesPath, homePath })
+
+    expect(result.state).toBe('installed')
+    expect(result.target).toBe(join(resourcesPath, 'bin', 'orca-ide'))
+  })
+
   it('writes an executable bare-orca dispatcher that execs the bundled orca-ide launcher', async () => {
     const { homePath, resourcesPath } = await makeFixture()
 

--- a/src/main/cli/linux-bare-orca-dispatcher.test.ts
+++ b/src/main/cli/linux-bare-orca-dispatcher.test.ts
@@ -1,13 +1,63 @@
+import { existsSync } from 'node:fs'
+import type * as NodeFsPromises from 'node:fs/promises'
 import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join, relative, resolve, sep } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { filePublicationFailures } = vi.hoisted(() => ({
+  filePublicationFailures: { link: 0, replaceBeforeRename: '' }
+}))
+const registrationLock = vi.hoisted(() => ({
+  completed: null as ((cacheRootPath: string) => void) | null,
+  entered: null as ((cacheRootPath: string) => void) | null,
+  pause: null as Promise<void> | null
+}))
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFsPromises>()
+  return {
+    ...actual,
+    link: async (...args: Parameters<typeof actual.link>) => {
+      if (filePublicationFailures.link > 0) {
+        filePublicationFailures.link -= 1
+        throw Object.assign(new Error('link unsupported'), { code: 'ENOTSUP' })
+      }
+      return actual.link(...args)
+    },
+    rename: async (...args: Parameters<typeof actual.rename>) => {
+      if (filePublicationFailures.replaceBeforeRename) {
+        await actual.writeFile(args[0], filePublicationFailures.replaceBeforeRename, {
+          mode: 0o755
+        })
+        filePublicationFailures.replaceBeforeRename = ''
+      }
+      return actual.rename(...args)
+    }
+  }
+})
 
 vi.mock('electron', () => ({
   app: { isPackaged: true }
 }))
 
+vi.mock('./appimage-registration-lock', () => ({
+  withAppImageRegistrationLock: async <T>(
+    cacheRootPath: string,
+    operation: () => Promise<T>
+  ): Promise<T> => {
+    registrationLock.entered?.(cacheRootPath)
+    const pause = registrationLock.pause
+    registrationLock.pause = null
+    await pause
+    const result = await operation()
+    registrationLock.completed?.(cacheRootPath)
+    return result
+  }
+}))
+
 import { installLinuxBareOrcaDispatcher } from './linux-bare-orca-dispatcher'
+import { resolveAppImageExtractedRoot } from './appimage-extracted-root'
 
 const created: string[] = []
 
@@ -22,6 +72,11 @@ async function makeFixture(): Promise<{ homePath: string; resourcesPath: string 
 }
 
 afterEach(async () => {
+  filePublicationFailures.link = 0
+  filePublicationFailures.replaceBeforeRename = ''
+  registrationLock.completed = null
+  registrationLock.entered = null
+  registrationLock.pause = null
   await Promise.all(created.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
 })
 
@@ -67,6 +122,39 @@ describe('installLinuxBareOrcaDispatcher', () => {
     expect(second.state).toBe('installed')
   })
 
+  it('publishes when the home filesystem does not support hard links', async () => {
+    const { homePath, resourcesPath } = await makeFixture()
+    filePublicationFailures.link = 1
+
+    const result = await installLinuxBareOrcaDispatcher({
+      resourcesPath,
+      homePath,
+      appImagePath: null
+    })
+
+    expect(result.state).toBe('installed')
+    await expect(readFile(result.dispatcherPath, 'utf8')).resolves.toContain(
+      '# orca-serve-bare-orca-dispatcher'
+    )
+  })
+
+  it('restores a displaced foreign dispatcher when hard links are unsupported', async () => {
+    const { homePath, resourcesPath } = await makeFixture()
+    await installLinuxBareOrcaDispatcher({ resourcesPath, homePath, appImagePath: null })
+    const foreignContent = '#!/bin/sh\necho foreign\n'
+    filePublicationFailures.replaceBeforeRename = foreignContent
+    filePublicationFailures.link = 2
+
+    const result = await installLinuxBareOrcaDispatcher({
+      resourcesPath,
+      homePath,
+      appImagePath: null
+    })
+
+    expect(result.state).toBe('skipped-foreign')
+    await expect(readFile(result.dispatcherPath, 'utf8')).resolves.toBe(foreignContent)
+  })
+
   it('quotes a resources path containing spaces so the exec line cannot be split', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-bare-dispatcher-space-'))
     created.push(root)
@@ -84,34 +172,152 @@ describe('installLinuxBareOrcaDispatcher', () => {
     expect(content).toContain(`exec '${join(resourcesPath, 'bin', 'orca-ide')}' "$@"`)
   })
 
-  it('execs the stable AppImage (not the ephemeral mount) when running from an AppImage', async () => {
-    const { homePath, resourcesPath } = await makeFixture()
-    const appImagePath = join(homePath, 'Applications', 'Orca.AppImage')
+  // Why: this dispatcher must survive a restart, and an AppImage's resourcesPath
+  // is a mount that dies with the app. Point it at the extracted payload, which
+  // also keeps it clear of AppRun's `--no-sandbox` injection (#11609).
+  it.skipIf(process.platform === 'win32')(
+    'execs the extracted payload (not the ephemeral mount) when running from an AppImage',
+    async () => {
+      const { homePath, resourcesPath } = await makeFixture()
+      const appImagePath = join(homePath, 'Orca.AppImage')
+      await mkdir(homePath, { recursive: true })
+      await writeFile(appImagePath, '#!/usr/bin/env bash\n', { encoding: 'utf8', mode: 0o755 })
+      const cacheRootPath = join(homePath, 'cache')
 
-    const result = await installLinuxBareOrcaDispatcher({ resourcesPath, homePath, appImagePath })
+      const result = await installLinuxBareOrcaDispatcher({
+        resourcesPath,
+        homePath,
+        appImagePath,
+        appImageCacheRootPath: cacheRootPath,
+        appImageExtractRunner: async (_appImagePath, cwd) => {
+          const launcherDir = join(cwd, 'squashfs-root', 'resources', 'bin')
+          await mkdir(launcherDir, { recursive: true })
+          await writeFile(join(launcherDir, 'orca-ide'), '', { encoding: 'utf8', mode: 0o755 })
+        }
+      })
 
-    expect(result.state).toBe('installed')
-    expect(result.target).toBe(appImagePath)
-    const content = await readFile(result.dispatcherPath, 'utf8')
-    // The AppImage wrapper references the stable outer path, never resourcesPath.
-    expect(content).toContain(appImagePath)
-    expect(content).not.toContain(resourcesPath)
-  })
+      expect(result.state).toBe('installed')
+      expect(relative(cacheRootPath, result.target as string).split(sep)).toEqual([
+        'launcher',
+        'orca-ide'
+      ])
+      const content = await readFile(result.dispatcherPath, 'utf8')
+      expect(content).toContain(result.target as string)
+      expect(content).not.toContain(resourcesPath)
+      expect(content).not.toContain(appImagePath)
+    }
+  )
 
   it('skips (does not clobber) a user-owned orca already at ~/.local/bin', async () => {
     const { homePath, resourcesPath } = await makeFixture()
     const dispatcherPath = join(homePath, '.local', 'bin', 'orca')
+    const appImagePath = join(homePath, 'Orca.AppImage')
     await mkdir(join(homePath, '.local', 'bin'), { recursive: true })
     await writeFile(dispatcherPath, '#!/bin/sh\necho my own orca\n', 'utf8')
+    await writeFile(appImagePath, '#!/usr/bin/env bash\n', 'utf8')
+    const extract = vi.fn()
 
     const result = await installLinuxBareOrcaDispatcher({
       resourcesPath,
       homePath,
-      appImagePath: null
+      appImagePath,
+      appImageExtractRunner: extract
     })
 
     expect(result.state).toBe('skipped-foreign')
+    expect(result.target).toBeNull()
+    expect(extract).not.toHaveBeenCalled()
     expect(await readFile(dispatcherPath, 'utf8')).toBe('#!/bin/sh\necho my own orca\n')
+  })
+
+  it('preserves a foreign dispatcher created while AppImage extraction is in flight', async () => {
+    const { homePath, resourcesPath } = await makeFixture()
+    const appImagePath = join(homePath, 'Orca.AppImage')
+    const cacheRootPath = join(homePath, 'cache')
+    const dispatcherPath = join(homePath, '.local', 'bin', 'orca')
+    await mkdir(homePath, { recursive: true })
+    await writeFile(appImagePath, '#!/usr/bin/env bash\n', { mode: 0o755 })
+    let reportStarted!: () => void
+    let releaseExtraction!: () => void
+    const started = new Promise<void>((resolve) => {
+      reportStarted = resolve
+    })
+    const released = new Promise<void>((resolve) => {
+      releaseExtraction = resolve
+    })
+
+    const installation = installLinuxBareOrcaDispatcher({
+      resourcesPath,
+      homePath,
+      appImagePath,
+      appImageCacheRootPath: cacheRootPath,
+      appImageExtractRunner: async (_path, cwd) => {
+        await writePayload(cwd)
+        reportStarted()
+        await released
+      }
+    })
+    await started
+    await mkdir(dirname(dispatcherPath), { recursive: true })
+    await writeFile(dispatcherPath, '#!/bin/sh\necho foreign\n', { mode: 0o755 })
+    releaseExtraction()
+
+    await expect(installation).resolves.toMatchObject({
+      state: 'skipped-foreign',
+      target: null
+    })
+    await expect(readFile(dispatcherPath, 'utf8')).resolves.toBe('#!/bin/sh\necho foreign\n')
+  })
+
+  it('prunes old owner generations without touching a sibling namespace', async () => {
+    const { homePath, resourcesPath } = await makeFixture()
+    const appImagePath = join(homePath, 'Orca.AppImage')
+    const cacheRootPath = join(homePath, 'cache', 'unused', '..')
+    await mkdir(homePath, { recursive: true })
+    await writeFile(appImagePath, '#!/usr/bin/env bash\n', { mode: 0o755 })
+    const events: string[] = []
+    const options = {
+      resourcesPath,
+      homePath,
+      appImagePath,
+      appImageCacheRootPath: cacheRootPath,
+      appImageExtractRunner: async (_path: string, cwd: string) => {
+        events.push('extract')
+        await writePayload(cwd)
+      }
+    }
+
+    await installLinuxBareOrcaDispatcher(options)
+    const previous = resolveAppImageExtractedRoot({ appImagePath, cacheRootPath })!
+    const sibling = join(resolve(cacheRootPath), 'f'.repeat(24), 'e'.repeat(24))
+    await mkdir(sibling, { recursive: true })
+    await writeFile(appImagePath, '#!/usr/bin/env bash\n# next\n', { mode: 0o755 })
+    const lockEntered = Promise.withResolvers<string>()
+    const releaseLock = Promise.withResolvers<void>()
+    events.length = 0
+    registrationLock.pause = releaseLock.promise
+    registrationLock.entered = (rootPath) => {
+      events.push('lock-entered')
+      lockEntered.resolve(rootPath)
+    }
+    registrationLock.completed = () => {
+      events.push(
+        existsSync(previous.rootPath) ? 'lock-left-before-prune' : 'lock-left-after-prune'
+      )
+    }
+
+    const installation = installLinuxBareOrcaDispatcher(options)
+    await expect(lockEntered.promise).resolves.toBe(resolve(cacheRootPath))
+    expect(events).toEqual(['lock-entered'])
+    expect(existsSync(previous.rootPath)).toBe(true)
+    releaseLock.resolve()
+    await installation
+    const current = resolveAppImageExtractedRoot({ appImagePath, cacheRootPath })!
+
+    expect(events).toEqual(['lock-entered', 'extract', 'lock-left-after-prune'])
+    expect(existsSync(previous.rootPath)).toBe(false)
+    expect(existsSync(current.rootPath)).toBe(true)
+    expect(existsSync(sibling)).toBe(true)
   })
 
   it('skips when the bundled orca-ide launcher is missing from the build', async () => {
@@ -128,3 +334,9 @@ describe('installLinuxBareOrcaDispatcher', () => {
     expect(result.target).toBeNull()
   })
 })
+
+async function writePayload(cwd: string): Promise<void> {
+  const launcherDirectory = join(cwd, 'squashfs-root', 'resources', 'bin')
+  await mkdir(launcherDirectory, { recursive: true })
+  await writeFile(join(launcherDirectory, 'orca-ide'), '#!/usr/bin/env bash\n', { mode: 0o755 })
+}

--- a/src/main/cli/linux-bare-orca-dispatcher.ts
+++ b/src/main/cli/linux-bare-orca-dispatcher.ts
@@ -4,7 +4,7 @@ import { copyFile, link, lstat, mkdir, readFile, rename, unlink, writeFile } fro
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 import {
-  hasAppImageRuntimeEnvironment,
+  hasAppImagePathEnvironment,
   resolveAppImageRuntimeIdentity
 } from '../appimage-runtime-identity'
 import {
@@ -89,7 +89,7 @@ async function resolveStableLauncherPath(
 ): Promise<string | null> {
   const hasExplicitAppImagePath = Object.hasOwn(options, 'appImagePath')
   const runtimeIdentity = resolveAppImageRuntimeIdentity({ resourcesPath: options.resourcesPath })
-  if (!hasExplicitAppImagePath && hasAppImageRuntimeEnvironment() && !runtimeIdentity) {
+  if (!hasExplicitAppImagePath && hasAppImagePathEnvironment() && !runtimeIdentity) {
     return null
   }
   const appImagePath = hasExplicitAppImagePath

--- a/src/main/cli/linux-bare-orca-dispatcher.ts
+++ b/src/main/cli/linux-bare-orca-dispatcher.ts
@@ -13,8 +13,8 @@ import {
 } from './appimage-extracted-root'
 import { pruneAppImageExtractedRoots } from './appimage-extraction-pruning'
 import { withAppImageRegistrationLock } from './appimage-registration-lock'
+import { getBundledLauncherPath } from './bundled-cli-launcher-path'
 import { quoteShell } from './cli-install-path-format'
-import { getBundledLauncherPath } from './cli-installer'
 
 // Why: marks a dispatcher this function wrote so repeat serve starts overwrite
 // our own file idempotently but never clobber a user's own ~/.local/bin/orca.

--- a/src/main/cli/linux-bare-orca-dispatcher.ts
+++ b/src/main/cli/linux-bare-orca-dispatcher.ts
@@ -1,8 +1,19 @@
-import { existsSync } from 'node:fs'
-import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises'
+import { randomUUID } from 'node:crypto'
+import { constants, existsSync } from 'node:fs'
+import { copyFile, link, lstat, mkdir, readFile, rename, unlink, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
-import { buildAppImageCliWrapper, quoteShell } from './appimage-cli-wrapper'
+import {
+  hasAppImageRuntimeEnvironment,
+  resolveAppImageRuntimeIdentity
+} from '../appimage-runtime-identity'
+import {
+  ensureAppImageExtractedRoot,
+  resolveAppImageCacheRootPath
+} from './appimage-extracted-root'
+import { pruneAppImageExtractedRoots } from './appimage-extraction-pruning'
+import { withAppImageRegistrationLock } from './appimage-registration-lock'
+import { quoteShell } from './cli-install-path-format'
 import { getBundledLauncherPath } from './cli-installer'
 
 // Why: marks a dispatcher this function wrote so repeat serve starts overwrite
@@ -14,8 +25,12 @@ export type LinuxBareOrcaDispatcherOptions = {
   resourcesPath: string
   /** Test seam — defaults to the real home directory. */
   homePath?: string
-  /** Test seam — defaults to $APPIMAGE (set only when running from an AppImage). */
+  /** Trusted caller override; production requires the complete AppImage runtime identity. */
   appImagePath?: string | null
+  /** Test seam — defaults to $XDG_CACHE_HOME/orca/appimage. */
+  appImageCacheRootPath?: string
+  /** Test seam — defaults to running the AppImage's own `--appimage-extract`. */
+  appImageExtractRunner?: (appImagePath: string, cwd: string) => Promise<void>
 }
 
 export type LinuxBareOrcaDispatcherState =
@@ -26,7 +41,7 @@ export type LinuxBareOrcaDispatcherState =
 export type LinuxBareOrcaDispatcherResult = {
   state: LinuxBareOrcaDispatcherState
   dispatcherPath: string
-  /** What the dispatcher execs: the stable AppImage, or the bundled orca-ide. */
+  /** The bundled `orca-ide` launcher the dispatcher execs. */
   target: string | null
 }
 
@@ -41,73 +56,176 @@ export async function installLinuxBareOrcaDispatcher(
   options: LinuxBareOrcaDispatcherOptions
 ): Promise<LinuxBareOrcaDispatcherResult> {
   const dispatcherPath = join(options.homePath ?? homedir(), '.local', 'bin', 'orca')
-  const appImagePath = options.appImagePath ?? process.env.APPIMAGE ?? null
+  if (existsSync(dispatcherPath) && !(await isOwnedDispatcher(dispatcherPath))) {
+    return { state: 'skipped-foreign', dispatcherPath, target: null }
+  }
 
-  const resolved = resolveDispatcherScript(options.resourcesPath, appImagePath)
-  if (!resolved) {
+  const launcher = await resolveStableLauncherPath(options)
+  if (!launcher) {
     return { state: 'skipped-launcher-missing', dispatcherPath, target: null }
   }
 
-  // Why: only (re)write a dispatcher we previously created; leave a user's own
-  // `orca` untouched rather than silently clobbering it on every serve start.
-  if (existsSync(dispatcherPath) && !(await isOwnedDispatcher(dispatcherPath))) {
-    return { state: 'skipped-foreign', dispatcherPath, target: resolved.target }
-  }
-
-  await mkdir(dirname(dispatcherPath), { recursive: true })
-  await writeFile(dispatcherPath, resolved.script, 'utf8')
-  await chmod(dispatcherPath, 0o755)
-  return { state: 'installed', dispatcherPath, target: resolved.target }
+  const installed = await publishDispatcher(
+    dispatcherPath,
+    insertDispatcherMarker(buildBareOrcaCliScript(launcher))
+  )
+  return installed
+    ? { state: 'installed', dispatcherPath, target: launcher }
+    : { state: 'skipped-foreign', dispatcherPath, target: null }
 }
 
-/** Bare-`orca` script that execs the Orca CLI: the stable AppImage when running
- *  from one, otherwise the bundled `orca-ide` launcher. Shared by the serve
- *  dispatcher and the managed-terminal PATH shim. */
-export function buildBareOrcaCliScript(
-  resourcesPath: string,
-  appImagePath: string | null
-): { script: string; target: string } | null {
-  if (appImagePath) {
-    // Why: an AppImage mounts resources under an ephemeral FUSE path per launch,
-    // so the script must exec the stable outer AppImage — reuse the same
-    // wrapper CliInstaller installs for the AppImage command.
-    return { script: buildAppImageCliWrapper(appImagePath), target: appImagePath }
-  }
+/** Bare-`orca` script that execs the one Linux CLI launcher. */
+export function buildBareOrcaCliScript(launcherPath: string): string {
+  return `#!/usr/bin/env bash\nexec ${quoteShell(launcherPath)} "$@"\n`
+}
 
-  const launcher = getBundledLauncherPath('linux', resourcesPath)
+/**
+ * The launcher path this dispatcher can still reach on a later boot. Under an
+ * AppImage `process.resourcesPath` is an ephemeral FUSE mount that dies with the
+ * app, so extract the payload once and point at that stable copy instead.
+ */
+async function resolveStableLauncherPath(
+  options: LinuxBareOrcaDispatcherOptions
+): Promise<string | null> {
+  const hasExplicitAppImagePath = Object.hasOwn(options, 'appImagePath')
+  const runtimeIdentity = resolveAppImageRuntimeIdentity({ resourcesPath: options.resourcesPath })
+  if (!hasExplicitAppImagePath && hasAppImageRuntimeEnvironment() && !runtimeIdentity) {
+    return null
+  }
+  const appImagePath = hasExplicitAppImagePath
+    ? (options.appImagePath ?? null)
+    : (runtimeIdentity?.appImagePath ?? null)
+  if (appImagePath) {
+    const extractionOptions = {
+      appImagePath,
+      cacheRootPath: options.appImageCacheRootPath,
+      runExtract: options.appImageExtractRunner
+    }
+    return withAppImageRegistrationLock(
+      resolveAppImageCacheRootPath(extractionOptions),
+      async () => {
+        const extractedRoot = await ensureAppImageExtractedRoot(extractionOptions)
+        if (extractedRoot) {
+          await pruneAppImageExtractedRoots(extractedRoot.rootPath)
+        }
+        return extractedRoot?.stableLauncherPath ?? null
+      }
+    )
+  }
+  const launcher = getBundledLauncherPath('linux', options.resourcesPath)
   // Why: getBundledLauncherPath only joins the path; guard existence so we never
   // write a script pointing at a missing launcher (which would fail at exec
   // time with a confusing error instead of the command-not-found we fix).
-  if (!launcher || !existsSync(launcher)) {
-    return null
-  }
-  return {
-    script: `#!/usr/bin/env bash\nexec ${quoteShell(launcher)} "$@"\n`,
-    target: launcher
-  }
+  return launcher && existsSync(launcher) ? launcher : null
 }
 
-function resolveDispatcherScript(
-  resourcesPath: string,
-  appImagePath: string | null
-): { script: string; target: string } | null {
-  const resolved = buildBareOrcaCliScript(resourcesPath, appImagePath)
-  return resolved && { script: withMarker(resolved.script), target: resolved.target }
-}
-
-function withMarker(script: string): string {
-  const firstNewline = script.indexOf('\n')
-  if (firstNewline === -1) {
-    return `${script}\n${DISPATCHER_MARKER}\n`
-  }
-  // Keep the shebang on line 1; insert the marker immediately after it.
-  return `${script.slice(0, firstNewline + 1)}${DISPATCHER_MARKER}\n${script.slice(firstNewline + 1)}`
+function insertDispatcherMarker(script: string): string {
+  return script.replace('\n', `\n${DISPATCHER_MARKER}\n`)
 }
 
 async function isOwnedDispatcher(dispatcherPath: string): Promise<boolean> {
   try {
-    return (await readFile(dispatcherPath, 'utf8')).includes(DISPATCHER_MARKER)
+    return (
+      (await lstat(dispatcherPath)).isFile() &&
+      (await readFile(dispatcherPath, 'utf8')).split('\n')[1] === DISPATCHER_MARKER
+    )
   } catch {
     return false
   }
+}
+
+async function publishDispatcher(dispatcherPath: string, content: string): Promise<boolean> {
+  const directoryPath = dirname(dispatcherPath)
+  const temporaryPath = join(directoryPath, `.orca-dispatcher-${process.pid}-${randomUUID()}`)
+  await mkdir(directoryPath, { recursive: true })
+  await writeFile(temporaryPath, content, { encoding: 'utf8', flag: 'wx', mode: 0o755 })
+  try {
+    if (await publishIfVacant(temporaryPath, dispatcherPath)) {
+      return true
+    }
+
+    const displacedPath = join(
+      directoryPath,
+      `.orca-preserved-dispatcher-${process.pid}-${randomUUID()}`
+    )
+    try {
+      await rename(dispatcherPath, displacedPath)
+    } catch (error) {
+      if (!hasErrorCode(error, 'ENOENT')) {
+        throw error
+      }
+      return await publishIfVacant(temporaryPath, dispatcherPath)
+    }
+
+    if (!(await isOwnedDispatcher(displacedPath))) {
+      await restoreDisplacedDispatcher(displacedPath, dispatcherPath)
+      return false
+    }
+
+    try {
+      if (
+        (await publishIfVacant(temporaryPath, dispatcherPath)) ||
+        (await isExactExecutableDispatcher(dispatcherPath, content))
+      ) {
+        await unlink(displacedPath)
+        return true
+      }
+      // A concurrently published foreign command owns the public path now.
+      await unlink(displacedPath)
+      return false
+    } catch (error) {
+      await restoreDisplacedDispatcher(displacedPath, dispatcherPath)
+      throw error
+    }
+  } finally {
+    await unlink(temporaryPath).catch(() => {})
+  }
+}
+
+async function publishIfVacant(sourcePath: string, destinationPath: string): Promise<boolean> {
+  try {
+    await link(sourcePath, destinationPath)
+    return true
+  } catch (error) {
+    if (hasErrorCode(error, 'EEXIST')) {
+      return false
+    }
+  }
+  try {
+    await copyFile(sourcePath, destinationPath, constants.COPYFILE_EXCL)
+    return true
+  } catch (error) {
+    if (hasErrorCode(error, 'EEXIST')) {
+      return false
+    }
+    throw error
+  }
+}
+
+async function restoreDisplacedDispatcher(
+  displacedPath: string,
+  dispatcherPath: string
+): Promise<void> {
+  if (await publishIfVacant(displacedPath, dispatcherPath)) {
+    await unlink(displacedPath)
+  }
+}
+
+async function isExactExecutableDispatcher(
+  dispatcherPath: string,
+  content: string
+): Promise<boolean> {
+  try {
+    const [actual, metadata] = await Promise.all([
+      readFile(dispatcherPath, 'utf8'),
+      lstat(dispatcherPath)
+    ])
+    return metadata.isFile() && (metadata.mode & 0o111) !== 0 && actual === content
+  } catch {
+    return false
+  }
+}
+
+function hasErrorCode(error: unknown, code: string): boolean {
+  return error instanceof Error && 'code' in error && error.code === code
 }

--- a/src/main/cli/linux-terminal-orca-cli-shim.test.ts
+++ b/src/main/cli/linux-terminal-orca-cli-shim.test.ts
@@ -26,10 +26,24 @@ async function makeFixture(): Promise<{ userDataPath: string; resourcesPath: str
 }
 
 afterEach(async () => {
+  vi.unstubAllEnvs()
   await Promise.all(created.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
 })
 
 describe('ensureLinuxTerminalOrcaCliShimDir', () => {
+  it('uses the mounted bundled launcher when only APPDIR is inherited', async () => {
+    const { userDataPath, resourcesPath } = await makeFixture()
+    vi.stubEnv('APPIMAGE', '')
+    vi.stubEnv('APPDIR', resourcesPath)
+
+    const shimDir = ensureLinuxTerminalOrcaCliShimDir({ userDataPath, resourcesPath })
+
+    expect(shimDir).toBe(join(userDataPath, 'linux-orca-cli-shim'))
+    expect(readFileSync(join(shimDir!, 'orca'), 'utf8')).toContain(
+      `exec '${join(resourcesPath, 'bin', 'orca-ide')}' "$@"`
+    )
+  })
+
   it('writes an executable bare-orca shim that execs the bundled orca-ide launcher', async () => {
     const { userDataPath, resourcesPath } = await makeFixture()
 

--- a/src/main/cli/linux-terminal-orca-cli-shim.test.ts
+++ b/src/main/cli/linux-terminal-orca-cli-shim.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdirSync, readFileSync, readlinkSync, statSync, writeFileSync } from 'node:fs'
+import { chmodSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -9,13 +9,11 @@ vi.mock('electron', () => ({
   app: { isPackaged: true }
 }))
 
-import {
-  resolveAppImageLauncherEndpointPath,
-  resolveAppImageStableLauncherPath
-} from './appimage-stable-launcher'
+import { resolveAppImageLauncherEndpointPath } from './appimage-stable-launcher'
 import { ensureLinuxTerminalOrcaCliShimDir } from './linux-terminal-orca-cli-shim'
 
 const created: string[] = []
+const canFenceAppImageRuntime = process.platform === 'linux' && existsSync('/proc/self/stat')
 
 async function makeFixture(): Promise<{ userDataPath: string; resourcesPath: string }> {
   const root = await mkdtemp(join(tmpdir(), 'orca-terminal-cli-shim-'))
@@ -80,93 +78,131 @@ describe('ensureLinuxTerminalOrcaCliShimDir', () => {
     expect(statSync(healedPath).mode & 0o111).not.toBe(0)
   })
 
-  it('routes AppImage terminals through the stable cache without extracting', async () => {
-    const { userDataPath, resourcesPath } = await makeFixture()
-    const appImagePath = join(userDataPath, 'Orca.AppImage')
-    await mkdir(userDataPath, { recursive: true })
-    await writeFile(appImagePath, '#!/usr/bin/env bash\n', { encoding: 'utf8', mode: 0o755 })
-    const cacheRootPath = join(userDataPath, 'cache')
-    const liveLauncherPath = join(resourcesPath, 'bin', 'orca-ide')
-    writeFileSync(liveLauncherPath, '#!/usr/bin/env bash\nprintf live', 'utf8')
-    chmodSync(liveLauncherPath, 0o755)
-    const shimDir = ensureLinuxTerminalOrcaCliShimDir({
-      userDataPath,
-      resourcesPath,
-      appImagePath,
-      appImageCacheRootPath: cacheRootPath
-    })
+  it.skipIf(!canFenceAppImageRuntime)(
+    'routes first-use AppImage terminals through a fenced current mount without a live endpoint',
+    async () => {
+      const { userDataPath, resourcesPath } = await makeFixture()
+      const appImagePath = join(userDataPath, 'Orca.AppImage')
+      await mkdir(userDataPath, { recursive: true })
+      await writeFile(appImagePath, '#!/usr/bin/env bash\n', { encoding: 'utf8', mode: 0o755 })
+      const cacheRootPath = join(userDataPath, 'cache')
+      const liveLauncherPath = join(resourcesPath, 'bin', 'orca-ide')
+      writeFileSync(liveLauncherPath, '#!/usr/bin/env bash\nprintf live', 'utf8')
+      chmodSync(liveLauncherPath, 0o755)
+      const shimDir = ensureLinuxTerminalOrcaCliShimDir({
+        userDataPath,
+        resourcesPath,
+        appImagePath,
+        appImageCacheRootPath: cacheRootPath
+      })
 
-    const shimPath = join(shimDir!, 'orca')
-    const stableLauncherPath = resolveAppImageStableLauncherPath(cacheRootPath)
-    const content = readFileSync(shimPath, 'utf8')
-    expect(content).toContain(stableLauncherPath)
-    expect(content).not.toContain(resourcesPath)
-    expect(content).not.toContain(appImagePath)
-    await expect(
-      runProcess({ program: shimPath, args: [], timeoutMs: 3_000 })
-    ).resolves.toMatchObject({ code: 0, stdout: 'live' })
-  })
-
-  it('updates restored terminals to the current AppImage mount without rewriting the shim', async () => {
-    const { userDataPath, resourcesPath } = await makeFixture()
-    const appImagePath = join(userDataPath, 'Orca.AppImage')
-    await mkdir(userDataPath, { recursive: true })
-    await writeFile(appImagePath, '#!/usr/bin/env bash\n', { encoding: 'utf8', mode: 0o755 })
-    const cacheRootPath = join(userDataPath, 'cache')
-    const firstLauncher = join(resourcesPath, 'bin', 'orca-ide')
-    writeFileSync(firstLauncher, '#!/usr/bin/env bash\nprintf first', 'utf8')
-    chmodSync(firstLauncher, 0o755)
-    const options = {
-      userDataPath,
-      resourcesPath,
-      appImagePath,
-      appImageCacheRootPath: cacheRootPath
+      const shimPath = join(shimDir!, 'orca')
+      const content = readFileSync(shimPath, 'utf8')
+      expect(content).toContain(liveLauncherPath)
+      expect(content).toContain('runtime_pid=')
+      expect(content).toContain('/proc/$runtime_pid/stat')
+      expect(existsSync(resolveAppImageLauncherEndpointPath(cacheRootPath, 'live'))).toBe(false)
+      await expect(
+        runProcess({ program: shimPath, args: [], timeoutMs: 3_000 })
+      ).resolves.toMatchObject({ code: 0, stdout: 'live' })
     }
-    const shimDir = ensureLinuxTerminalOrcaCliShimDir(options)
-    const shimPath = join(shimDir!, 'orca')
-    const originalShim = readFileSync(shimPath, 'utf8')
+  )
 
-    const nextResourcesPath = join(userDataPath, 'next-mount', 'resources')
-    const nextLauncher = join(nextResourcesPath, 'bin', 'orca-ide')
-    await mkdir(join(nextResourcesPath, 'bin'), { recursive: true })
-    await writeFile(nextLauncher, '#!/usr/bin/env bash\nprintf next', { mode: 0o755 })
-    await rm(firstLauncher)
-    expect(
-      ensureLinuxTerminalOrcaCliShimDir({ ...options, resourcesPath: nextResourcesPath })
-    ).toBe(shimDir)
+  it.skipIf(!canFenceAppImageRuntime)(
+    'refreshes restored terminals to the current AppImage mount',
+    async () => {
+      const { userDataPath, resourcesPath } = await makeFixture()
+      const appImagePath = join(userDataPath, 'Orca.AppImage')
+      await mkdir(userDataPath, { recursive: true })
+      await writeFile(appImagePath, '#!/usr/bin/env bash\n', { encoding: 'utf8', mode: 0o755 })
+      const cacheRootPath = join(userDataPath, 'cache')
+      const firstLauncher = join(resourcesPath, 'bin', 'orca-ide')
+      writeFileSync(firstLauncher, '#!/usr/bin/env bash\nprintf first', 'utf8')
+      chmodSync(firstLauncher, 0o755)
+      const options = {
+        userDataPath,
+        resourcesPath,
+        appImagePath,
+        appImageCacheRootPath: cacheRootPath
+      }
+      const shimDir = ensureLinuxTerminalOrcaCliShimDir(options)
+      const shimPath = join(shimDir!, 'orca')
+      const originalShim = readFileSync(shimPath, 'utf8')
 
-    expect(readFileSync(shimPath, 'utf8')).toBe(originalShim)
-    expect(readlinkSync(resolveAppImageLauncherEndpointPath(cacheRootPath, 'live'))).toBe(
-      nextLauncher
-    )
-    await expect(
-      runProcess({ program: shimPath, args: [], timeoutMs: 3_000 })
-    ).resolves.toMatchObject({ code: 0, stdout: 'next' })
-  })
+      const nextResourcesPath = join(userDataPath, 'next-mount', 'resources')
+      const nextLauncher = join(nextResourcesPath, 'bin', 'orca-ide')
+      await mkdir(join(nextResourcesPath, 'bin'), { recursive: true })
+      await writeFile(nextLauncher, '#!/usr/bin/env bash\nprintf next', { mode: 0o755 })
+      await rm(firstLauncher)
+      expect(
+        ensureLinuxTerminalOrcaCliShimDir({ ...options, resourcesPath: nextResourcesPath })
+      ).toBe(shimDir)
 
-  it('waits briefly for a temporarily unavailable live endpoint', async () => {
-    const { userDataPath, resourcesPath } = await makeFixture()
-    const appImagePath = join(userDataPath, 'Orca.AppImage')
-    const cacheRootPath = join(userDataPath, 'cache')
-    await mkdir(userDataPath, { recursive: true })
-    await writeFile(appImagePath, '#!/usr/bin/env bash\n', { mode: 0o755 })
-    const liveLauncher = join(resourcesPath, 'bin', 'orca-ide')
-    chmodSync(liveLauncher, 0o755)
-    const shimDir = ensureLinuxTerminalOrcaCliShimDir({
-      userDataPath,
-      resourcesPath,
-      appImagePath,
-      appImageCacheRootPath: cacheRootPath
-    })
-    const shimPath = join(shimDir!, 'orca')
-    await rm(liveLauncher)
-    const invocation = runProcess({ program: shimPath, args: [], timeoutMs: 3_000 })
-    setTimeout(() => {
-      writeFileSync(liveLauncher, '#!/usr/bin/env bash\nprintf recovered', { mode: 0o755 })
-    }, 100)
+      const refreshedShim = readFileSync(shimPath, 'utf8')
+      expect(refreshedShim).not.toBe(originalShim)
+      expect(refreshedShim).toContain(nextLauncher)
+      expect(existsSync(resolveAppImageLauncherEndpointPath(cacheRootPath, 'live'))).toBe(false)
+      await expect(
+        runProcess({ program: shimPath, args: [], timeoutMs: 3_000 })
+      ).resolves.toMatchObject({ code: 0, stdout: 'next' })
+    }
+  )
 
-    await expect(invocation).resolves.toMatchObject({ code: 0, stdout: 'recovered' })
-  })
+  it.skipIf(!canFenceAppImageRuntime)(
+    'rejects a stale shim when its mount path is removed and reused',
+    async () => {
+      const { userDataPath, resourcesPath } = await makeFixture()
+      const appImagePath = join(userDataPath, 'Orca.AppImage')
+      const cacheRootPath = join(userDataPath, 'cache')
+      await mkdir(userDataPath, { recursive: true })
+      await writeFile(appImagePath, '#!/usr/bin/env bash\n', { mode: 0o755 })
+      const liveLauncher = join(resourcesPath, 'bin', 'orca-ide')
+      writeFileSync(liveLauncher, '#!/usr/bin/env bash\nprintf original', { mode: 0o755 })
+      const shimDir = ensureLinuxTerminalOrcaCliShimDir({
+        userDataPath,
+        resourcesPath,
+        appImagePath,
+        appImageCacheRootPath: cacheRootPath
+      })
+      const shimPath = join(shimDir!, 'orca')
+      await rm(liveLauncher)
+      await writeFile(liveLauncher, '#!/usr/bin/env bash\nprintf replaced-by-another-mount', {
+        mode: 0o755
+      })
+
+      await expect(
+        runProcess({ program: shimPath, args: [], timeoutMs: 3_000 })
+      ).resolves.toMatchObject({ code: 1, stdout: '' })
+    }
+  )
+
+  it.skipIf(!canFenceAppImageRuntime)(
+    'rejects a shim after its owning AppImage process generation changes',
+    async () => {
+      const { userDataPath, resourcesPath } = await makeFixture()
+      const appImagePath = join(userDataPath, 'Orca.AppImage')
+      await mkdir(userDataPath, { recursive: true })
+      await writeFile(appImagePath, '#!/usr/bin/env bash\n', { mode: 0o755 })
+      const liveLauncher = join(resourcesPath, 'bin', 'orca-ide')
+      writeFileSync(liveLauncher, '#!/usr/bin/env bash\nprintf original', { mode: 0o755 })
+      const shimDir = ensureLinuxTerminalOrcaCliShimDir({
+        userDataPath,
+        resourcesPath,
+        appImagePath,
+        appImageCacheRootPath: join(userDataPath, 'cache')
+      })
+      const shimPath = join(shimDir!, 'orca')
+      const staleContent = readFileSync(shimPath, 'utf8').replace(
+        /runtime_start_time='[^']*'/,
+        "runtime_start_time='stale-process'"
+      )
+      writeFileSync(shimPath, staleContent, { mode: 0o755 })
+
+      await expect(
+        runProcess({ program: shimPath, args: [], timeoutMs: 3_000 })
+      ).resolves.toMatchObject({ code: 1, stdout: '' })
+    }
+  )
 
   it('returns null (and does not memoize) when the bundled launcher is missing', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-terminal-cli-shim-missing-'))

--- a/src/main/cli/linux-terminal-orca-cli-shim.test.ts
+++ b/src/main/cli/linux-terminal-orca-cli-shim.test.ts
@@ -89,14 +89,11 @@ describe('ensureLinuxTerminalOrcaCliShimDir', () => {
     const liveLauncherPath = join(resourcesPath, 'bin', 'orca-ide')
     writeFileSync(liveLauncherPath, '#!/usr/bin/env bash\nprintf live', 'utf8')
     chmodSync(liveLauncherPath, 0o755)
-    const extract = vi.fn()
-
     const shimDir = ensureLinuxTerminalOrcaCliShimDir({
       userDataPath,
       resourcesPath,
       appImagePath,
-      appImageCacheRootPath: cacheRootPath,
-      appImageExtractRunner: extract
+      appImageCacheRootPath: cacheRootPath
     })
 
     const shimPath = join(shimDir!, 'orca')
@@ -108,7 +105,6 @@ describe('ensureLinuxTerminalOrcaCliShimDir', () => {
     await expect(
       runProcess({ program: shimPath, args: [], timeoutMs: 3_000 })
     ).resolves.toMatchObject({ code: 0, stdout: 'live' })
-    expect(extract).not.toHaveBeenCalled()
   })
 
   it('updates restored terminals to the current AppImage mount without rewriting the shim', async () => {
@@ -120,13 +116,11 @@ describe('ensureLinuxTerminalOrcaCliShimDir', () => {
     const firstLauncher = join(resourcesPath, 'bin', 'orca-ide')
     writeFileSync(firstLauncher, '#!/usr/bin/env bash\nprintf first', 'utf8')
     chmodSync(firstLauncher, 0o755)
-    const extract = vi.fn()
     const options = {
       userDataPath,
       resourcesPath,
       appImagePath,
-      appImageCacheRootPath: cacheRootPath,
-      appImageExtractRunner: extract
+      appImageCacheRootPath: cacheRootPath
     }
     const shimDir = ensureLinuxTerminalOrcaCliShimDir(options)
     const shimPath = join(shimDir!, 'orca')
@@ -148,7 +142,6 @@ describe('ensureLinuxTerminalOrcaCliShimDir', () => {
     await expect(
       runProcess({ program: shimPath, args: [], timeoutMs: 3_000 })
     ).resolves.toMatchObject({ code: 0, stdout: 'next' })
-    expect(extract).not.toHaveBeenCalled()
   })
 
   it('waits briefly for a temporarily unavailable live endpoint', async () => {
@@ -159,14 +152,11 @@ describe('ensureLinuxTerminalOrcaCliShimDir', () => {
     await writeFile(appImagePath, '#!/usr/bin/env bash\n', { mode: 0o755 })
     const liveLauncher = join(resourcesPath, 'bin', 'orca-ide')
     chmodSync(liveLauncher, 0o755)
-    const extract = vi.fn()
-
     const shimDir = ensureLinuxTerminalOrcaCliShimDir({
       userDataPath,
       resourcesPath,
       appImagePath,
-      appImageCacheRootPath: cacheRootPath,
-      appImageExtractRunner: extract
+      appImageCacheRootPath: cacheRootPath
     })
     const shimPath = join(shimDir!, 'orca')
     await rm(liveLauncher)
@@ -176,7 +166,6 @@ describe('ensureLinuxTerminalOrcaCliShimDir', () => {
     }, 100)
 
     await expect(invocation).resolves.toMatchObject({ code: 0, stdout: 'recovered' })
-    expect(extract).not.toHaveBeenCalled()
   })
 
   it('returns null (and does not memoize) when the bundled launcher is missing', async () => {

--- a/src/main/cli/linux-terminal-orca-cli-shim.test.ts
+++ b/src/main/cli/linux-terminal-orca-cli-shim.test.ts
@@ -1,13 +1,18 @@
-import { chmodSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { chmodSync, mkdirSync, readFileSync, readlinkSync, statSync, writeFileSync } from 'node:fs'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { runProcess } from '../../shared/child-process/run-process'
 
 vi.mock('electron', () => ({
   app: { isPackaged: true }
 }))
 
+import {
+  resolveAppImageLauncherEndpointPath,
+  resolveAppImageStableLauncherPath
+} from './appimage-stable-launcher'
 import { ensureLinuxTerminalOrcaCliShimDir } from './linux-terminal-orca-cli-shim'
 
 const created: string[] = []
@@ -44,7 +49,7 @@ describe('ensureLinuxTerminalOrcaCliShimDir', () => {
     expect(mode & 0o111).not.toBe(0)
   })
 
-  it('memoizes per userDataPath and re-asserts the exec bit for a stale shim', async () => {
+  it('reuses the shim path and re-asserts its exec bit', async () => {
     const { userDataPath, resourcesPath } = await makeFixture()
     const options = { userDataPath, resourcesPath, appImagePath: null }
 
@@ -53,10 +58,9 @@ describe('ensureLinuxTerminalOrcaCliShimDir', () => {
     const shimPath = join(first!, 'orca')
     chmodSync(shimPath, 0o644)
 
-    // A distinct userData path is not memoized, so ensure runs again and heals
-    // the exec bit lost above only when it actually processes that path.
     const second = ensureLinuxTerminalOrcaCliShimDir(options)
     expect(second).toBe(first)
+    expect(statSync(shimPath).mode & 0o111).not.toBe(0)
 
     const root = await mkdtemp(join(tmpdir(), 'orca-terminal-cli-shim-2-'))
     created.push(root)
@@ -76,19 +80,103 @@ describe('ensureLinuxTerminalOrcaCliShimDir', () => {
     expect(statSync(healedPath).mode & 0o111).not.toBe(0)
   })
 
-  it('execs the stable AppImage (not the ephemeral mount) when running from an AppImage', async () => {
+  it('routes AppImage terminals through the stable cache without extracting', async () => {
     const { userDataPath, resourcesPath } = await makeFixture()
-    const appImagePath = join(userDataPath, 'Applications', 'Orca.AppImage')
+    const appImagePath = join(userDataPath, 'Orca.AppImage')
+    await mkdir(userDataPath, { recursive: true })
+    await writeFile(appImagePath, '#!/usr/bin/env bash\n', { encoding: 'utf8', mode: 0o755 })
+    const cacheRootPath = join(userDataPath, 'cache')
+    const liveLauncherPath = join(resourcesPath, 'bin', 'orca-ide')
+    writeFileSync(liveLauncherPath, '#!/usr/bin/env bash\nprintf live', 'utf8')
+    chmodSync(liveLauncherPath, 0o755)
+    const extract = vi.fn()
 
     const shimDir = ensureLinuxTerminalOrcaCliShimDir({
       userDataPath,
       resourcesPath,
-      appImagePath
+      appImagePath,
+      appImageCacheRootPath: cacheRootPath,
+      appImageExtractRunner: extract
     })
 
-    const content = readFileSync(join(shimDir!, 'orca'), 'utf8')
-    expect(content).toContain(appImagePath)
+    const shimPath = join(shimDir!, 'orca')
+    const stableLauncherPath = resolveAppImageStableLauncherPath(cacheRootPath)
+    const content = readFileSync(shimPath, 'utf8')
+    expect(content).toContain(stableLauncherPath)
     expect(content).not.toContain(resourcesPath)
+    expect(content).not.toContain(appImagePath)
+    await expect(
+      runProcess({ program: shimPath, args: [], timeoutMs: 3_000 })
+    ).resolves.toMatchObject({ code: 0, stdout: 'live' })
+    expect(extract).not.toHaveBeenCalled()
+  })
+
+  it('updates restored terminals to the current AppImage mount without rewriting the shim', async () => {
+    const { userDataPath, resourcesPath } = await makeFixture()
+    const appImagePath = join(userDataPath, 'Orca.AppImage')
+    await mkdir(userDataPath, { recursive: true })
+    await writeFile(appImagePath, '#!/usr/bin/env bash\n', { encoding: 'utf8', mode: 0o755 })
+    const cacheRootPath = join(userDataPath, 'cache')
+    const firstLauncher = join(resourcesPath, 'bin', 'orca-ide')
+    writeFileSync(firstLauncher, '#!/usr/bin/env bash\nprintf first', 'utf8')
+    chmodSync(firstLauncher, 0o755)
+    const extract = vi.fn()
+    const options = {
+      userDataPath,
+      resourcesPath,
+      appImagePath,
+      appImageCacheRootPath: cacheRootPath,
+      appImageExtractRunner: extract
+    }
+    const shimDir = ensureLinuxTerminalOrcaCliShimDir(options)
+    const shimPath = join(shimDir!, 'orca')
+    const originalShim = readFileSync(shimPath, 'utf8')
+
+    const nextResourcesPath = join(userDataPath, 'next-mount', 'resources')
+    const nextLauncher = join(nextResourcesPath, 'bin', 'orca-ide')
+    await mkdir(join(nextResourcesPath, 'bin'), { recursive: true })
+    await writeFile(nextLauncher, '#!/usr/bin/env bash\nprintf next', { mode: 0o755 })
+    await rm(firstLauncher)
+    expect(
+      ensureLinuxTerminalOrcaCliShimDir({ ...options, resourcesPath: nextResourcesPath })
+    ).toBe(shimDir)
+
+    expect(readFileSync(shimPath, 'utf8')).toBe(originalShim)
+    expect(readlinkSync(resolveAppImageLauncherEndpointPath(cacheRootPath, 'live'))).toBe(
+      nextLauncher
+    )
+    await expect(
+      runProcess({ program: shimPath, args: [], timeoutMs: 3_000 })
+    ).resolves.toMatchObject({ code: 0, stdout: 'next' })
+    expect(extract).not.toHaveBeenCalled()
+  })
+
+  it('waits briefly for a temporarily unavailable live endpoint', async () => {
+    const { userDataPath, resourcesPath } = await makeFixture()
+    const appImagePath = join(userDataPath, 'Orca.AppImage')
+    const cacheRootPath = join(userDataPath, 'cache')
+    await mkdir(userDataPath, { recursive: true })
+    await writeFile(appImagePath, '#!/usr/bin/env bash\n', { mode: 0o755 })
+    const liveLauncher = join(resourcesPath, 'bin', 'orca-ide')
+    chmodSync(liveLauncher, 0o755)
+    const extract = vi.fn()
+
+    const shimDir = ensureLinuxTerminalOrcaCliShimDir({
+      userDataPath,
+      resourcesPath,
+      appImagePath,
+      appImageCacheRootPath: cacheRootPath,
+      appImageExtractRunner: extract
+    })
+    const shimPath = join(shimDir!, 'orca')
+    await rm(liveLauncher)
+    const invocation = runProcess({ program: shimPath, args: [], timeoutMs: 3_000 })
+    setTimeout(() => {
+      writeFileSync(liveLauncher, '#!/usr/bin/env bash\nprintf recovered', { mode: 0o755 })
+    }, 100)
+
+    await expect(invocation).resolves.toMatchObject({ code: 0, stdout: 'recovered' })
+    expect(extract).not.toHaveBeenCalled()
   })
 
   it('returns null (and does not memoize) when the bundled launcher is missing', async () => {

--- a/src/main/cli/linux-terminal-orca-cli-shim.ts
+++ b/src/main/cli/linux-terminal-orca-cli-shim.ts
@@ -1,13 +1,28 @@
-import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { join } from 'node:path'
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+  type Stats
+} from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
 import {
   hasAppImageRuntimeEnvironment,
   resolveAppImageRuntimeIdentity
 } from '../appimage-runtime-identity'
-import { getAppImageCacheRootPath } from './appimage-extracted-root'
-import { publishAppImageLauncherEndpoint } from './appimage-stable-launcher'
+import {
+  getAppImageCacheRootPath,
+  isAppImageInstalledLauncherCurrent
+} from './appimage-extracted-root'
+import {
+  ensureAppImageStableLauncher,
+  removeAppImageLegacyLiveEndpoint
+} from './appimage-stable-launcher'
 import { getBundledLauncherPath } from './bundled-cli-launcher-path'
 import { buildBareOrcaCliScript } from './linux-bare-orca-dispatcher'
+import { quoteShell } from './cli-install-path-format'
 
 const SHIM_DIR_NAME = 'linux-orca-cli-shim'
 
@@ -42,7 +57,7 @@ export function ensureLinuxTerminalOrcaCliShimDir(
     ? (options.appImagePath ?? null)
     : (runtimeIdentity?.appImagePath ?? null)
   if (appImagePath) {
-    return ensureAppImageShim(options, resourcesPath)
+    return ensureAppImageShim(options, resourcesPath, appImagePath)
   }
 
   if (!resourcesPath) {
@@ -56,26 +71,149 @@ export function ensureLinuxTerminalOrcaCliShimDir(
 
 function ensureAppImageShim(
   options: LinuxTerminalOrcaCliShimOptions,
-  resourcesPath: string | null
+  resourcesPath: string | null,
+  appImagePath: string
 ): string | null {
   if (!resourcesPath) {
     return null
   }
+  const cacheRootPath = options.appImageCacheRootPath ?? getAppImageCacheRootPath()
+  removeAppImageLegacyLiveEndpoint(cacheRootPath)
+
   const liveLauncherPath = getBundledLauncherPath('linux', resourcesPath)
   if (!liveLauncherPath || !existsSync(liveLauncherPath)) {
     return null
   }
-  const stableLauncherPath = publishAppImageLauncherEndpoint(
-    options.appImageCacheRootPath ?? getAppImageCacheRootPath(),
-    'live',
-    liveLauncherPath
-  )
-  return stableLauncherPath ? ensureShimForLauncher(options.userDataPath, stableLauncherPath) : null
+
+  const stableLauncherPath = ensureAppImageStableLauncher(cacheRootPath)
+  if (
+    stableLauncherPath &&
+    isAppImageInstalledLauncherCurrent({
+      appImagePath,
+      cacheRootPath
+    })
+  ) {
+    return ensureShimForLauncher(options.userDataPath, stableLauncherPath)
+  }
+
+  const fence = captureAppImageRuntimeFence(liveLauncherPath)
+  return fence
+    ? ensureShimForScript(
+        options.userDataPath,
+        buildAppImageLiveLauncherScript(fence.launcherPath, fence)
+      )
+    : null
+}
+
+type AppImageRuntimeFence = {
+  pid: number
+  startTime: string
+  runtimeRoot: string
+  runtimeIdentity: string
+  launcherIdentity: string
+  launcherPath: string
+}
+
+function captureAppImageRuntimeFence(launcherPath: string): AppImageRuntimeFence | null {
+  if (process.platform !== 'linux') {
+    return null
+  }
+  const resolvedLauncherPath = resolve(launcherPath)
+  const runtimeRoot = dirname(dirname(dirname(resolvedLauncherPath)))
+  const runtimeIdentity = readFileIdentity(runtimeRoot)
+  const launcherIdentity = readFileIdentity(resolvedLauncherPath)
+  const startTime = readLinuxProcessStartTime(process.pid)
+  return runtimeIdentity && launcherIdentity && startTime
+    ? {
+        pid: process.pid,
+        startTime,
+        runtimeRoot,
+        runtimeIdentity,
+        launcherIdentity,
+        launcherPath: resolvedLauncherPath
+      }
+    : null
+}
+
+function readFileIdentity(path: string): string | null {
+  try {
+    const stats = statSync(path)
+    return formatFileIdentity(stats)
+  } catch {
+    return null
+  }
+}
+
+function formatFileIdentity(stats: Stats): string {
+  return [
+    stats.dev,
+    stats.ino,
+    stats.size,
+    Math.floor(stats.mtimeMs / 1000),
+    Math.floor(stats.ctimeMs / 1000)
+  ].join(':')
+}
+
+function readLinuxProcessStartTime(pid: number): string | null {
+  try {
+    const content = readFileSync(join('/proc', String(pid), 'stat'), 'utf8')
+    const commandEnd = content.lastIndexOf(') ')
+    if (commandEnd === -1) {
+      return null
+    }
+    const fields = content
+      .slice(commandEnd + 2)
+      .trim()
+      .split(/\s+/)
+    return fields[19] ?? null
+  } catch {
+    return null
+  }
+}
+
+function buildAppImageLiveLauncherScript(
+  launcherPath: string,
+  fence: AppImageRuntimeFence
+): string {
+  const runtimePid = quoteShell(String(fence.pid))
+  const runtimeStartTime = quoteShell(fence.startTime)
+  const runtimeRoot = quoteShell(fence.runtimeRoot)
+  const expectedRuntimeIdentity = quoteShell(fence.runtimeIdentity)
+  const expectedLauncherIdentity = quoteShell(fence.launcherIdentity)
+  const quotedLauncherPath = quoteShell(launcherPath)
+  return `#!/usr/bin/env bash
+runtime_pid=${runtimePid}
+runtime_start_time=${runtimeStartTime}
+runtime_root=${runtimeRoot}
+launcher=${quotedLauncherPath}
+expected_runtime_identity=${expectedRuntimeIdentity}
+expected_launcher_identity=${expectedLauncherIdentity}
+fail() {
+  printf 'Orca CLI is unavailable; reopen Orca or register the CLI again.\\n' >&2
+  exit 1
+}
+proc_stat_path="/proc/$runtime_pid/stat"
+[[ -r "$proc_stat_path" ]] || fail
+proc_stat="$(<"$proc_stat_path")" || fail
+proc_fields=()
+read -r -a proc_fields <<< "\${proc_stat##*) }" || fail
+[[ "\${proc_fields[19]:-}" == "$runtime_start_time" ]] || fail
+runtime_identity="$(stat -Lc '%d:%i:%s:%Y:%Z' -- "$runtime_root" 2>/dev/null)" || fail
+[[ "$runtime_identity" == "$expected_runtime_identity" ]] || fail
+launcher_identity="$(stat -Lc '%d:%i:%s:%Y:%Z' -- "$launcher" 2>/dev/null)" || fail
+[[ "$launcher_identity" == "$expected_launcher_identity" ]] || fail
+[[ -f "$launcher" && -x "$launcher" ]] || fail
+exec "$launcher" "$@"
+`
 }
 
 function ensureShimForLauncher(userDataPath: string, launcherPath: string): string | null {
   const script = buildBareOrcaCliScript(launcherPath)
 
+  return ensureShimForScript(userDataPath, script)
+}
+
+function ensureShimForScript(userDataPath: string, script: string): string | null {
   const shimDir = join(userDataPath, SHIM_DIR_NAME)
   const shimPath = join(shimDir, 'orca')
   try {

--- a/src/main/cli/linux-terminal-orca-cli-shim.ts
+++ b/src/main/cli/linux-terminal-orca-cli-shim.ts
@@ -1,20 +1,26 @@
-import { chmodSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
+import {
+  hasAppImageRuntimeEnvironment,
+  resolveAppImageRuntimeIdentity
+} from '../appimage-runtime-identity'
+import { getAppImageCacheRootPath } from './appimage-extracted-root'
+import { publishAppImageLauncherEndpoint } from './appimage-stable-launcher'
+import { getBundledLauncherPath } from './bundled-cli-launcher-path'
 import { buildBareOrcaCliScript } from './linux-bare-orca-dispatcher'
 
 const SHIM_DIR_NAME = 'linux-orca-cli-shim'
-
-// Why: rewriting the shim on every PTY spawn is wasted fs work; the target only
-// changes with the install itself, so one successful write per process is enough.
-// Failures are NOT cached so a transient fs error retries on the next spawn.
-const ensuredShimDirs = new Map<string, string>()
 
 export type LinuxTerminalOrcaCliShimOptions = {
   userDataPath: string
   /** Test seam — defaults to the packaged resources root. */
   resourcesPath?: string | null
-  /** Test seam — defaults to $APPIMAGE (set only when running from an AppImage). */
+  /** Trusted caller override; production requires the complete AppImage runtime identity. */
   appImagePath?: string | null
+  /** Test seam — defaults to $XDG_CACHE_HOME/orca/appimage. */
+  appImageCacheRootPath?: string
+  /** Regression seam: opening a PTY must never invoke AppImage extraction. */
+  appImageExtractRunner?: (appImagePath: string, cwd: string) => Promise<void>
 }
 
 // Why: on Linux the CLI installs as `orca-ide` so it never shadows the GNOME
@@ -27,37 +33,62 @@ export type LinuxTerminalOrcaCliShimOptions = {
 export function ensureLinuxTerminalOrcaCliShimDir(
   options: LinuxTerminalOrcaCliShimOptions
 ): string | null {
-  const cached = ensuredShimDirs.get(options.userDataPath)
-  if (cached !== undefined) {
-    return cached
+  const resourcesPath =
+    options.resourcesPath === undefined ? process.resourcesPath : options.resourcesPath
+  const hasExplicitAppImagePath = Object.hasOwn(options, 'appImagePath')
+  const runtimeIdentity = resolveAppImageRuntimeIdentity({ resourcesPath })
+  if (!hasExplicitAppImagePath && hasAppImageRuntimeEnvironment() && !runtimeIdentity) {
+    return null
+  }
+  const appImagePath = hasExplicitAppImagePath
+    ? (options.appImagePath ?? null)
+    : (runtimeIdentity?.appImagePath ?? null)
+  if (appImagePath) {
+    return ensureAppImageShim(options, resourcesPath)
   }
 
-  const resourcesPath = options.resourcesPath ?? process.resourcesPath
   if (!resourcesPath) {
     return null
   }
-  const resolved = buildBareOrcaCliScript(
-    resourcesPath,
-    options.appImagePath ?? process.env.APPIMAGE ?? null
-  )
-  if (!resolved) {
+  const launcherPath = getBundledLauncherPath('linux', resourcesPath)
+  return launcherPath && existsSync(launcherPath)
+    ? ensureShimForLauncher(options.userDataPath, launcherPath)
+    : null
+}
+
+function ensureAppImageShim(
+  options: LinuxTerminalOrcaCliShimOptions,
+  resourcesPath: string | null
+): string | null {
+  if (!resourcesPath) {
     return null
   }
+  const liveLauncherPath = getBundledLauncherPath('linux', resourcesPath)
+  if (!liveLauncherPath || !existsSync(liveLauncherPath)) {
+    return null
+  }
+  const stableLauncherPath = publishAppImageLauncherEndpoint(
+    options.appImageCacheRootPath ?? getAppImageCacheRootPath(),
+    'live',
+    liveLauncherPath
+  )
+  return stableLauncherPath ? ensureShimForLauncher(options.userDataPath, stableLauncherPath) : null
+}
 
-  const shimDir = join(options.userDataPath, SHIM_DIR_NAME)
+function ensureShimForLauncher(userDataPath: string, launcherPath: string): string | null {
+  const script = buildBareOrcaCliScript(launcherPath)
+
+  const shimDir = join(userDataPath, SHIM_DIR_NAME)
   const shimPath = join(shimDir, 'orca')
   try {
-    if (readShim(shimPath) !== resolved.script) {
+    if (readShim(shimPath) !== script) {
       mkdirSync(shimDir, { recursive: true })
-      writeFileSync(shimPath, resolved.script, 'utf8')
+      writeFileSync(shimPath, script, 'utf8')
     }
-    // Why: always re-assert the exec bit — a shim written by an older run (or
-    // restored from backup) with mode stripped would fail every agent CLI call.
     chmodSync(shimPath, 0o755)
   } catch {
     return null
   }
-  ensuredShimDirs.set(options.userDataPath, shimDir)
   return shimDir
 }
 

--- a/src/main/cli/linux-terminal-orca-cli-shim.ts
+++ b/src/main/cli/linux-terminal-orca-cli-shim.ts
@@ -9,7 +9,7 @@ import {
 } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import {
-  hasAppImageRuntimeEnvironment,
+  hasAppImagePathEnvironment,
   resolveAppImageRuntimeIdentity
 } from '../appimage-runtime-identity'
 import {
@@ -50,7 +50,7 @@ export function ensureLinuxTerminalOrcaCliShimDir(
     options.resourcesPath === undefined ? process.resourcesPath : options.resourcesPath
   const hasExplicitAppImagePath = Object.hasOwn(options, 'appImagePath')
   const runtimeIdentity = resolveAppImageRuntimeIdentity({ resourcesPath })
-  if (!hasExplicitAppImagePath && hasAppImageRuntimeEnvironment() && !runtimeIdentity) {
+  if (!hasExplicitAppImagePath && hasAppImagePathEnvironment() && !runtimeIdentity) {
     return null
   }
   const appImagePath = hasExplicitAppImagePath

--- a/src/main/cli/linux-terminal-orca-cli-shim.ts
+++ b/src/main/cli/linux-terminal-orca-cli-shim.ts
@@ -19,8 +19,6 @@ export type LinuxTerminalOrcaCliShimOptions = {
   appImagePath?: string | null
   /** Test seam — defaults to $XDG_CACHE_HOME/orca/appimage. */
   appImageCacheRootPath?: string
-  /** Regression seam: opening a PTY must never invoke AppImage extraction. */
-  appImageExtractRunner?: (appImagePath: string, cwd: string) => Promise<void>
 }
 
 // Why: on Linux the CLI installs as `orca-ide` so it never shadows the GNOME

--- a/src/main/cli/packaged-cli-assets.test.ts
+++ b/src/main/cli/packaged-cli-assets.test.ts
@@ -5,7 +5,6 @@ import { tmpdir } from 'node:os'
 import { dirname, join, sep } from 'node:path'
 import { promisify } from 'node:util'
 import { describe, expect, it } from 'vitest'
-import { buildAppImageCliWrapper } from './appimage-cli-wrapper'
 
 const require = createRequire(import.meta.url)
 const execFileAsync = promisify(execFile)
@@ -246,55 +245,47 @@ printf 'arg=%s\\n' "$@"
     }
   )
 
-  itRunsUnixShell('runs the AppImage CLI wrapper through APPDIR at runtime', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'orca-appimage-cli-'))
+  // Why: registration on every Linux install method now points at this one
+  // launcher, so its env sanitation and argv passthrough are the contract the
+  // AppImage, deb, and extracted-tree commands all depend on.
+  itRunsUnixShell('sanitizes node env and forwards argv verbatim', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-linux-cli-env-'))
     try {
-      const appDir = join(root, 'Orca.AppDir')
-      const cliDir = join(appDir, 'resources', 'app.asar.unpacked', 'out', 'cli')
+      const appDir = join(root, 'Orca')
+      const resourcesDir = join(appDir, 'resources')
+      const launcherDir = join(resourcesDir, 'bin')
+      const cliDir = join(resourcesDir, 'app.asar.unpacked', 'out', 'cli')
+      const launcherPath = join(launcherDir, 'orca-ide')
       const cliPath = join(cliDir, 'index.js')
-      const appImagePath = join(root, "Orca's AppImage.AppImage")
-      const commandPath = join(root, 'orca-ide')
+
+      await mkdir(launcherDir, { recursive: true })
       await mkdir(cliDir, { recursive: true })
+      await copyFile(linuxLauncherAsset, launcherPath)
+      await writeFile(cliPath, '', 'utf8')
       await writeFile(
-        cliPath,
-        `exports.main = (argv) => {
-  console.log(JSON.stringify({
-    argv,
-    appDir: process.env.APPDIR,
-    runAsNode: process.env.ELECTRON_RUN_AS_NODE,
-    nodeOptions: process.env.NODE_OPTIONS ?? null,
-    orcaNodeOptions: process.env.ORCA_NODE_OPTIONS ?? null,
-    nodeReplExternalModule: process.env.NODE_REPL_EXTERNAL_MODULE ?? null,
-    orcaNodeReplExternalModule: process.env.ORCA_NODE_REPL_EXTERNAL_MODULE ?? null
-  }))
-}
-`,
-        'utf8'
-      )
-      await writeFile(
-        appImagePath,
+        join(appDir, 'orca-ide'),
         `#!/usr/bin/env bash
-export APPDIR="$FAKE_APPDIR"
-exec node "$@"
+node -e 'console.log(JSON.stringify({
+  argv: process.argv.slice(1),
+  runAsNode: process.env.ELECTRON_RUN_AS_NODE,
+  nodeOptions: process.env.NODE_OPTIONS ?? null,
+  orcaNodeOptions: process.env.ORCA_NODE_OPTIONS ?? null,
+  nodeReplExternalModule: process.env.NODE_REPL_EXTERNAL_MODULE ?? null,
+  orcaNodeReplExternalModule: process.env.ORCA_NODE_REPL_EXTERNAL_MODULE ?? null
+}))' -- "$@"
 `,
         { encoding: 'utf8', mode: 0o755 }
       )
-      await writeFile(commandPath, buildAppImageCliWrapper(appImagePath), {
-        encoding: 'utf8',
-        mode: 0o755
-      })
 
-      const result = await execFileAsync(commandPath, ['--help', 'two words'], {
+      const result = await execFileAsync(launcherPath, ['--help', 'two words'], {
         env: {
           ...process.env,
-          FAKE_APPDIR: appDir,
           NODE_OPTIONS: '--trace-warnings',
           NODE_REPL_EXTERNAL_MODULE: 'external-loader'
         }
       })
       const payload = JSON.parse(result.stdout) as {
         argv: string[]
-        appDir: string
         runAsNode: string
         nodeOptions: string | null
         orcaNodeOptions: string | null
@@ -302,9 +293,10 @@ exec node "$@"
         orcaNodeReplExternalModule: string | null
       }
 
-      expect(payload.argv).toEqual(['--help', 'two words'])
-      expect(payload.appDir).toBe(appDir)
+      expect(payload.argv).toEqual([cliPath, '--help', 'two words'])
       expect(payload.runAsNode).toBe('1')
+      // Why: Electron's node bootstrap must not inherit these, but the CLI
+      // still needs to see what the user set.
       expect(payload.nodeOptions).toBeNull()
       expect(payload.orcaNodeOptions).toBe('--trace-warnings')
       expect(payload.nodeReplExternalModule).toBeNull()

--- a/src/main/cli/wsl-cli-installer.ts
+++ b/src/main/cli/wsl-cli-installer.ts
@@ -207,7 +207,7 @@ export class WslCliInstaller {
       throw new Error(status.detail ?? 'WSL CLI registration is unavailable.')
     }
     if (status.state === 'conflict') {
-      throw new Error(`Refusing to replace non-Orca command at ${status.commandPath}.`)
+      throw new Error(`Refusing to replace non-Orca command at ${status.commandPath}. Remove it and register again if it is no longer needed.`)
     }
 
     await this.run(

--- a/src/main/ipc/cli-appimage-stale-registration.test.ts
+++ b/src/main/ipc/cli-appimage-stale-registration.test.ts
@@ -105,8 +105,7 @@ beforeEach(() => {
   mocks.resolveAppImageRuntimeIdentity.mockReset().mockImplementation(() =>
     process.platform === 'linux'
       ? {
-          appImagePath: '/opt/Orca.AppImage',
-          appDirPath: '/tmp/.mount_Orca123'
+          appImagePath: '/opt/Orca.AppImage'
         }
       : null
   )

--- a/src/main/ipc/cli-appimage-stale-registration.test.ts
+++ b/src/main/ipc/cli-appimage-stale-registration.test.ts
@@ -1,0 +1,382 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { CliInstallState, CliInstallStatus } from '../../shared/cli-install-types'
+
+const mocks = vi.hoisted(() => ({
+  getStatus: vi.fn(),
+  handle: vi.fn(),
+  hydrateShellPath: vi.fn(),
+  install: vi.fn(),
+  isAppImageRegistrationOwnedBySibling: vi.fn(),
+  mergePathSegments: vi.fn(),
+  remove: vi.fn(),
+  resolveAppImageCacheKey: vi.fn(),
+  resolveAppImageRuntimeIdentity: vi.fn()
+}))
+
+vi.mock('electron', () => ({ ipcMain: { handle: mocks.handle } }))
+
+vi.mock('../cli/cli-installer', () => ({
+  CliInstaller: class {
+    getStatus = mocks.getStatus
+    install = mocks.install
+    isAppImageRegistrationOwnedBySibling = mocks.isAppImageRegistrationOwnedBySibling
+    remove = mocks.remove
+  }
+}))
+
+vi.mock('../appimage-runtime-identity', () => ({
+  resolveAppImageRuntimeIdentity: mocks.resolveAppImageRuntimeIdentity
+}))
+
+vi.mock('../cli/appimage-extracted-root', () => ({
+  resolveAppImageCacheKey: mocks.resolveAppImageCacheKey
+}))
+
+vi.mock('../cli/wsl-cli-installer', () => ({
+  WslCliInstaller: class {
+    getStatus = mocks.getStatus
+    install = mocks.install
+    remove = mocks.remove
+  }
+}))
+
+vi.mock('../cli/wsl-cli-registration-registry', () => ({
+  recordWslCliRegistrationInstalled: vi.fn(),
+  recordWslCliRegistrationRemoved: vi.fn()
+}))
+
+vi.mock('../cli/wsl-cli-registration-operation', () => ({
+  runSerializedWslCliRegistrationOperation: vi.fn()
+}))
+
+vi.mock('../persistence', () => ({ getCanonicalUserDataPath: vi.fn() }))
+
+vi.mock('../startup/hydrate-shell-path', () => ({
+  hydrateShellPath: mocks.hydrateShellPath,
+  mergePathSegments: mocks.mergePathSegments
+}))
+
+vi.mock('../wsl', () => ({ getDefaultWslDistro: vi.fn() }))
+
+import { registerCliHandlers } from './cli'
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+function status(
+  state: CliInstallState,
+  launcherPath = '/cache/current/resources/bin/orca-ide'
+): CliInstallStatus {
+  return {
+    platform: 'linux',
+    commandName: 'orca-ide',
+    commandPath: '/home/me/.local/bin/orca-ide',
+    pathDirectory: '/home/me/.local/bin',
+    pathConfigured: true,
+    launcherPath,
+    installMethod: 'symlink',
+    supported: true,
+    state,
+    currentTarget: state === 'not_installed' ? null : '/cache/old/resources/bin/orca-ide',
+    unsupportedReason: null,
+    detail: null
+  }
+}
+
+function installStatusHandler(): () => Promise<CliInstallStatus> {
+  registerCliHandlers()
+  return cliHandler('cli:getInstallStatus')
+}
+
+function cliHandler(channelName: string): () => Promise<CliInstallStatus> {
+  const call = mocks.handle.mock.calls.find(([channel]) => channel === channelName)
+  expect(call).toBeTruthy()
+  return call![1]
+}
+
+beforeEach(() => {
+  mocks.getStatus.mockReset()
+  mocks.handle.mockReset()
+  mocks.hydrateShellPath.mockReset().mockResolvedValue({ ok: false })
+  mocks.install.mockReset()
+  mocks.isAppImageRegistrationOwnedBySibling.mockReset().mockReturnValue(false)
+  mocks.mergePathSegments.mockReset()
+  mocks.remove.mockReset()
+  mocks.resolveAppImageCacheKey.mockReset().mockReturnValue('generation-1')
+  mocks.resolveAppImageRuntimeIdentity.mockReset().mockImplementation(() =>
+    process.platform === 'linux'
+      ? {
+          appImagePath: '/opt/Orca.AppImage',
+          appDirPath: '/tmp/.mount_Orca123'
+        }
+      : null
+  )
+  Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })
+  vi.stubEnv('APPIMAGE', '/opt/Orca.AppImage')
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  if (originalPlatform) {
+    Object.defineProperty(process, 'platform', originalPlatform)
+  }
+  vi.restoreAllMocks()
+})
+
+describe('AppImage CLI registration startup repair', () => {
+  it('repairs a managed stale registration and returns the installed status', async () => {
+    const stale = status('stale')
+    const installed = status('installed')
+    mocks.getStatus.mockResolvedValue(stale)
+    mocks.install.mockResolvedValue(installed)
+
+    await expect(installStatusHandler()()).resolves.toBe(installed)
+    expect(mocks.install).toHaveBeenCalledOnce()
+  })
+
+  it('keeps the stale status when automatic repair fails', async () => {
+    const stale = status('stale')
+    mocks.getStatus.mockResolvedValue(stale)
+    mocks.install.mockRejectedValue(new Error('read-only filesystem'))
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await expect(installStatusHandler()()).resolves.toBe(stale)
+    expect(warn).toHaveBeenCalledWith(
+      '[cli] Failed to repair stale AppImage registration:',
+      'read-only filesystem'
+    )
+  })
+
+  it('retries a failed automatic repair after the cooldown', async () => {
+    const stale = status('stale')
+    const installed = status('installed')
+    let now = 1_000
+    mocks.getStatus.mockResolvedValue(stale)
+    mocks.install
+      .mockRejectedValueOnce(new Error('read-only filesystem'))
+      .mockResolvedValueOnce(installed)
+    vi.spyOn(Date, 'now').mockImplementation(() => now)
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const handler = installStatusHandler()
+
+    await expect(handler()).resolves.toBe(stale)
+    await expect(handler()).resolves.toBe(stale)
+    expect(mocks.install).toHaveBeenCalledOnce()
+    expect(warn).toHaveBeenCalledOnce()
+
+    now += 30_000
+    await expect(handler()).resolves.toBe(installed)
+    expect(mocks.install).toHaveBeenCalledTimes(2)
+  })
+
+  it('shares one automatic repair across concurrent status polls', async () => {
+    const stale = status('stale')
+    const installed = status('installed')
+    let finishRepair: (result: CliInstallStatus) => void = () => {}
+    const repair = new Promise<CliInstallStatus>((resolve) => {
+      finishRepair = resolve
+    })
+    mocks.getStatus.mockResolvedValue(stale)
+    mocks.install.mockReturnValue(repair)
+    const handler = installStatusHandler()
+
+    const first = handler()
+    const second = handler()
+    await vi.waitFor(() => expect(mocks.install).toHaveBeenCalledOnce())
+    finishRepair(installed)
+
+    await expect(Promise.all([first, second])).resolves.toEqual([installed, installed])
+  })
+
+  it('repairs a later AppImage generation after an earlier repair succeeds', async () => {
+    const firstStale = status('stale', '/cache/launcher/orca-ide')
+    const firstInstalled = status('installed', '/cache/launcher/orca-ide')
+    const nextStale = status('stale', '/cache/launcher/orca-ide')
+    const nextInstalled = status('installed', '/cache/launcher/orca-ide')
+    mocks.getStatus
+      .mockResolvedValueOnce(firstStale)
+      .mockResolvedValueOnce(firstStale)
+      .mockResolvedValueOnce(nextStale)
+      .mockResolvedValueOnce(nextStale)
+    mocks.install.mockResolvedValueOnce(firstInstalled).mockResolvedValueOnce(nextInstalled)
+    mocks.resolveAppImageCacheKey
+      .mockReturnValueOnce('generation-1')
+      .mockReturnValueOnce('generation-1')
+      .mockReturnValueOnce('generation-2')
+      .mockReturnValueOnce('generation-2')
+    const handler = installStatusHandler()
+
+    await expect(handler()).resolves.toBe(firstInstalled)
+    await expect(handler()).resolves.toBe(nextInstalled)
+    expect(mocks.install).toHaveBeenCalledTimes(2)
+  })
+
+  it('waits for the cooldown before repairing a newer AppImage generation', async () => {
+    const firstStale = status('stale', '/cache/launcher/orca-ide')
+    const nextStale = status('stale', '/cache/launcher/orca-ide')
+    const nextInstalled = status('installed', '/cache/launcher/orca-ide')
+    let now = 1_000
+    mocks.getStatus
+      .mockResolvedValueOnce(firstStale)
+      .mockResolvedValueOnce(firstStale)
+      .mockResolvedValueOnce(nextStale)
+      .mockResolvedValueOnce(nextStale)
+      .mockResolvedValueOnce(nextStale)
+    mocks.install
+      .mockRejectedValueOnce(new Error('temporary failure'))
+      .mockResolvedValueOnce(nextInstalled)
+    mocks.resolveAppImageCacheKey
+      .mockReturnValueOnce('generation-1')
+      .mockReturnValueOnce('generation-1')
+      .mockReturnValueOnce('generation-2')
+      .mockReturnValueOnce('generation-2')
+      .mockReturnValueOnce('generation-2')
+    vi.spyOn(Date, 'now').mockImplementation(() => now)
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const handler = installStatusHandler()
+
+    await expect(handler()).resolves.toBe(firstStale)
+    await expect(handler()).resolves.toBe(nextStale)
+    expect(mocks.install).toHaveBeenCalledOnce()
+
+    now += 30_000
+    await expect(handler()).resolves.toBe(nextInstalled)
+    expect(mocks.install).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps the explicit install action retryable after automatic repair fails', async () => {
+    const stale = status('stale')
+    const installed = status('installed')
+    mocks.getStatus.mockResolvedValue(stale)
+    mocks.install
+      .mockRejectedValueOnce(new Error('temporary failure'))
+      .mockResolvedValueOnce(installed)
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    registerCliHandlers()
+
+    await expect(cliHandler('cli:getInstallStatus')()).resolves.toBe(stale)
+    await expect(cliHandler('cli:install')()).resolves.toBe(installed)
+    expect(mocks.install).toHaveBeenCalledTimes(2)
+  })
+
+  it('serializes concurrent explicit installs', async () => {
+    const installed = status('installed')
+    let finishFirstInstall: (result: CliInstallStatus) => void = () => {}
+    const firstInstall = new Promise<CliInstallStatus>((resolve) => {
+      finishFirstInstall = resolve
+    })
+    mocks.install.mockReturnValueOnce(firstInstall).mockResolvedValueOnce(installed)
+    registerCliHandlers()
+    const handler = cliHandler('cli:install')
+
+    const first = handler()
+    const second = handler()
+    await vi.waitFor(() => expect(mocks.install).toHaveBeenCalledOnce())
+
+    finishFirstInstall(installed)
+    await expect(Promise.all([first, second])).resolves.toEqual([installed, installed])
+    expect(mocks.install).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not undo a queued removal with a stale automatic repair', async () => {
+    const stale = status('stale')
+    const notInstalled = status('not_installed')
+    let finishRemove: (result: CliInstallStatus) => void = () => {}
+    const removal = new Promise<CliInstallStatus>((resolve) => {
+      finishRemove = resolve
+    })
+    mocks.getStatus.mockResolvedValueOnce(stale).mockResolvedValueOnce(notInstalled)
+    mocks.remove.mockReturnValue(removal)
+    registerCliHandlers()
+
+    const remove = cliHandler('cli:remove')()
+    await vi.waitFor(() => expect(mocks.remove).toHaveBeenCalledOnce())
+    const poll = cliHandler('cli:getInstallStatus')()
+    finishRemove(notInstalled)
+
+    await expect(remove).resolves.toBe(notInstalled)
+    await expect(poll).resolves.toBe(notInstalled)
+    expect(mocks.install).not.toHaveBeenCalled()
+  })
+
+  it('keys a queued repair cooldown to the generation it rechecks', async () => {
+    const stale = status('stale')
+    const notInstalled = status('not_installed')
+    let finishRemove: (result: CliInstallStatus) => void = () => {}
+    const removal = new Promise<CliInstallStatus>((resolve) => {
+      finishRemove = resolve
+    })
+    mocks.getStatus.mockResolvedValue(stale)
+    mocks.remove.mockReturnValue(removal)
+    mocks.install.mockRejectedValue(new Error('temporary failure'))
+    mocks.resolveAppImageCacheKey
+      .mockReturnValueOnce('generation-1')
+      .mockReturnValue('generation-2')
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    registerCliHandlers()
+
+    const remove = cliHandler('cli:remove')()
+    await vi.waitFor(() => expect(mocks.remove).toHaveBeenCalledOnce())
+    const oldGenerationPoll = cliHandler('cli:getInstallStatus')()
+    finishRemove(notInstalled)
+
+    await expect(remove).resolves.toBe(notInstalled)
+    await expect(oldGenerationPoll).resolves.toBe(stale)
+    await expect(cliHandler('cli:getInstallStatus')()).resolves.toBe(stale)
+    await expect(cliHandler('cli:getInstallStatus')()).resolves.toBe(stale)
+    expect(mocks.install).toHaveBeenCalledOnce()
+  })
+
+  it.each(['conflict', 'not_installed'] as const)(
+    'does not mutate a %s registration',
+    async (state) => {
+      const current = status(state)
+      mocks.getStatus.mockResolvedValue(current)
+
+      await expect(installStatusHandler()()).resolves.toBe(current)
+      expect(mocks.install).not.toHaveBeenCalled()
+    }
+  )
+
+  it('does not mutate a stale non-AppImage registration', async () => {
+    const stale = status('stale')
+    mocks.getStatus.mockResolvedValue(stale)
+    mocks.resolveAppImageRuntimeIdentity.mockReturnValue(null)
+
+    await expect(installStatusHandler()()).resolves.toBe(stale)
+    expect(mocks.install).not.toHaveBeenCalled()
+  })
+
+  it('does not claim a sibling AppImage registration during a status poll', async () => {
+    const stale = {
+      ...status('stale'),
+      currentTarget: '/cache/current/resources/bin/orca-ide'
+    }
+    mocks.getStatus.mockResolvedValue(stale)
+    mocks.isAppImageRegistrationOwnedBySibling.mockReturnValue(true)
+
+    await expect(installStatusHandler()()).resolves.toBe(stale)
+    expect(mocks.install).not.toHaveBeenCalled()
+  })
+
+  it('migrates a legacy AppImage target even when a sibling owns the stable endpoint', async () => {
+    const stale = status('stale')
+    const installed = status('installed')
+    mocks.getStatus.mockResolvedValue(stale)
+    mocks.install.mockResolvedValue(installed)
+    mocks.isAppImageRegistrationOwnedBySibling.mockImplementation(
+      (current: CliInstallStatus) => current.currentTarget === current.launcherPath
+    )
+
+    await expect(installStatusHandler()()).resolves.toBe(installed)
+    expect(mocks.install).toHaveBeenCalledOnce()
+  })
+
+  it('does not mutate a stale registration off Linux', async () => {
+    const stale = status('stale')
+    mocks.getStatus.mockResolvedValue(stale)
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'darwin' })
+
+    await expect(installStatusHandler()()).resolves.toBe(stale)
+    expect(mocks.install).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/ipc/cli.ts
+++ b/src/main/ipc/cli.ts
@@ -1,6 +1,8 @@
 import { ipcMain } from 'electron'
 import type { CliInstallStatus } from '../../shared/cli-install-types'
+import { resolveAppImageCacheKey } from '../cli/appimage-extracted-root'
 import { CliInstaller } from '../cli/cli-installer'
+import { runKeyedSerializedOperation } from '../cli/keyed-promise-queue'
 import {
   recordWslCliRegistrationInstalled,
   recordWslCliRegistrationRemoved
@@ -10,6 +12,31 @@ import { runSerializedWslCliRegistrationOperation } from '../cli/wsl-cli-registr
 import { getCanonicalUserDataPath } from '../persistence'
 import { hydrateShellPath, mergePathSegments } from '../startup/hydrate-shell-path'
 import { getDefaultWslDistro } from '../wsl'
+import { resolveAppImageRuntimeIdentity } from '../appimage-runtime-identity'
+
+const APPIMAGE_REPAIR_RETRY_MS = 30_000
+const localCliRegistrationQueues = new Map<string, Promise<void>>()
+
+function runLocalCliRegistrationOperation<T>(operation: () => Promise<T>): Promise<T> {
+  return runKeyedSerializedOperation(localCliRegistrationQueues, 'local', operation)
+}
+
+function resolveStaleAppImageRepairKey(status: CliInstallStatus): string | null {
+  if (status.state !== 'stale') {
+    return null
+  }
+  const runtimeIdentity = resolveAppImageRuntimeIdentity()
+  if (!runtimeIdentity) {
+    return null
+  }
+  const cacheKey = resolveAppImageCacheKey(runtimeIdentity.appImagePath)
+  if (!cacheKey) {
+    return null
+  }
+  return [status.commandPath, status.launcherPath, runtimeIdentity.appImagePath, cacheKey].join(
+    '\0'
+  )
+}
 
 function normalizeWslCliDistro(args?: { distro?: string | null }): string | undefined {
   return args?.distro?.trim() || undefined
@@ -57,19 +84,57 @@ async function hydrateLocalShellPathForCli(force = false): Promise<void> {
 }
 
 export function registerCliHandlers(): void {
+  let staleAppImageRepairAttempt: {
+    promise: Promise<CliInstallStatus | null>
+    retryAfter: number
+  } | null = null
+
   ipcMain.handle('cli:getInstallStatus', async (): Promise<CliInstallStatus> => {
     await hydrateLocalShellPathForCli()
-    return new CliInstaller().getStatus()
+    const installer = new CliInstaller()
+    const status = await installer.getStatus()
+    // Why: an AppImage update replaces the outer file while the managed symlink still targets the prior extracted payload.
+    const repairKey = resolveStaleAppImageRepairKey(status)
+    if (!repairKey || installer.isAppImageRegistrationOwnedBySibling(status)) {
+      return status
+    }
+
+    if (!staleAppImageRepairAttempt || Date.now() >= staleAppImageRepairAttempt.retryAfter) {
+      const promise = runLocalCliRegistrationOperation(async () => {
+        const currentInstaller = new CliInstaller()
+        const currentStatus = await currentInstaller.getStatus()
+        return resolveStaleAppImageRepairKey(currentStatus) === repairKey &&
+          !currentInstaller.isAppImageRegistrationOwnedBySibling(currentStatus)
+          ? currentInstaller.install()
+          : currentStatus
+      }).catch((error) => {
+        console.warn(
+          '[cli] Failed to repair stale AppImage registration:',
+          error instanceof Error ? error.message : String(error)
+        )
+        return null
+      })
+      staleAppImageRepairAttempt = { promise, retryAfter: Number.POSITIVE_INFINITY }
+      void promise.then((result) => {
+        if (staleAppImageRepairAttempt?.promise !== promise) {
+          return
+        }
+        staleAppImageRepairAttempt = result
+          ? null
+          : { ...staleAppImageRepairAttempt, retryAfter: Date.now() + APPIMAGE_REPAIR_RETRY_MS }
+      })
+    }
+    return (await staleAppImageRepairAttempt.promise) ?? status
   })
 
   ipcMain.handle('cli:install', async (): Promise<CliInstallStatus> => {
     await hydrateLocalShellPathForCli(true)
-    return new CliInstaller().install()
+    return runLocalCliRegistrationOperation(() => new CliInstaller().install())
   })
 
   ipcMain.handle('cli:remove', async (): Promise<CliInstallStatus> => {
     await hydrateLocalShellPathForCli()
-    return new CliInstaller().remove()
+    return runLocalCliRegistrationOperation(() => new CliInstaller().remove())
   })
 
   ipcMain.handle(

--- a/src/main/ipc/pty-ipc-mock-registry.ts
+++ b/src/main/ipc/pty-ipc-mock-registry.ts
@@ -1,4 +1,3 @@
-import { join } from 'node:path'
 import { vi } from 'vitest'
 import type { Mock } from 'vitest'
 import type * as Wsl from '../wsl'
@@ -17,6 +16,7 @@ export const mkdirSyncMock: Mock = vi.fn()
 export const readFileSyncMock: Mock = vi.fn()
 export const writeFileSyncMock: Mock = vi.fn()
 export const chmodSyncMock: Mock = vi.fn()
+export const linuxCliShimMock: Mock = vi.fn()
 export const renameSyncMock: Mock = vi.fn()
 export const rmSyncMock: Mock = vi.fn()
 export const getPathMock: Mock = vi.fn()
@@ -152,8 +152,7 @@ export const classifyErrorModuleMock = () => ({
 
 // Why: the real ensure writes to process.resourcesPath (absent under vitest); env assembly only needs the returned dir path.
 export const linuxCliShimModuleMock = () => ({
-  ensureLinuxTerminalOrcaCliShimDir: (options: { userDataPath: string }) =>
-    join(options.userDataPath, 'linux-orca-cli-shim')
+  ensureLinuxTerminalOrcaCliShimDir: linuxCliShimMock
 })
 
 export const ptyRegistryModuleMock = () => ({

--- a/src/main/ipc/pty-ipc-suite-environment.ts
+++ b/src/main/ipc/pty-ipc-suite-environment.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, vi } from 'vitest'
 import * as electron from 'electron'
+import { join } from 'node:path'
 import { installFakeAppEnvironment } from '../../../config/scripts/vitest-host-ports-setup'
 import { setPtyHostBindings } from './pty-host-bindings'
 import { testPtyIpcSurface } from './pty-ipc-test-surface'
@@ -16,6 +17,7 @@ import {
   readFileSyncMock,
   writeFileSyncMock,
   chmodSyncMock,
+  linuxCliShimMock,
   getPathMock,
   loginPreflightExecFileMock,
   spawnMock,
@@ -139,6 +141,10 @@ export function createPtyIpcSuiteEnvironment(): PtyIpcSuiteEnvironment {
     readFileSyncMock.mockReset()
     writeFileSyncMock.mockReset()
     chmodSyncMock.mockReset()
+    linuxCliShimMock.mockReset()
+    linuxCliShimMock.mockImplementation((options: { userDataPath: string }) =>
+      join(options.userDataPath, 'linux-orca-cli-shim')
+    )
     getPathMock.mockReset()
     loginPreflightExecFileMock.mockReset()
     spawnMock.mockReset()

--- a/src/main/ipc/pty-restored-appimage-cli-shim-refresh.test.ts
+++ b/src/main/ipc/pty-restored-appimage-cli-shim-refresh.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { setupPtyIpcSuite } from './pty-ipc-test-harness'
+import { linuxCliShimMock } from './pty-ipc-mock-registry'
+
+vi.mock('electron', () => import('./pty-ipc-mock-registry').then((m) => m.electronModuleMock()))
+vi.mock('fs', () => import('./pty-ipc-mock-registry').then((m) => m.fsModuleMock()))
+vi.mock('node-pty', () => import('./pty-ipc-mock-registry').then((m) => m.nodePtyModuleMock()))
+vi.mock('node:child_process', async (importOriginal) =>
+  (await import('./pty-ipc-mock-registry')).childProcessModuleMock(await importOriginal())
+)
+vi.mock('../opencode/hook-service', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.openCodeHookServiceModuleMock())
+)
+vi.mock('../mimo/hook-service', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.mimoHookServiceModuleMock())
+)
+vi.mock('../agent-hooks/server', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.agentHookServerModuleMock())
+)
+vi.mock('../pi/titlebar-extension-service', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.piTitlebarExtensionModuleMock())
+)
+vi.mock('../pwsh', () => import('./pty-ipc-mock-registry').then((m) => m.pwshModuleMock()))
+vi.mock('../wsl', async (importOriginal) =>
+  (await import('./pty-ipc-mock-registry')).wslModuleMock(await importOriginal())
+)
+vi.mock('../telemetry/client', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.telemetryClientModuleMock())
+)
+vi.mock('../telemetry/classify-error', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.classifyErrorModuleMock())
+)
+vi.mock('../cli/linux-terminal-orca-cli-shim', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.linuxCliShimModuleMock())
+)
+vi.mock('../memory/pty-registry', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.ptyRegistryModuleMock())
+)
+vi.mock('../agent-hooks/migration-unsupported-pty-state', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.migrationUnsupportedPtyModuleMock())
+)
+vi.mock('../codex/codex-pane-account-registry', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.codexPaneAccountRegistryModuleMock())
+)
+vi.mock('../codex/codex-state-db-backfill-recovery', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.codexBackfillRecoveryModuleMock())
+)
+
+import { registerPtyHandlers } from './pty'
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
+
+afterEach(() => {
+  Object.defineProperty(process, 'platform', originalPlatform)
+})
+
+describe('restored AppImage CLI shim refresh', () => {
+  const { mainWindow } = setupPtyIpcSuite()
+
+  it('refreshes the live launcher before any restored pane reattaches', () => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })
+
+    registerPtyHandlers(mainWindow as never)
+
+    expect(linuxCliShimMock).toHaveBeenCalledOnce()
+    expect(linuxCliShimMock).toHaveBeenCalledWith({ userDataPath: '/tmp/orca-user-data' })
+  })
+
+  it('does not publish a host launcher on a non-Linux host', () => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+
+    registerPtyHandlers(mainWindow as never)
+
+    expect(linuxCliShimMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/ipc/pty/register-handlers.ts
+++ b/src/main/ipc/pty/register-handlers.ts
@@ -1,4 +1,5 @@
 import type { BrowserWindow } from 'electron'
+import { getAppEnvironment } from '../../../shared/app-environment'
 import type { OrcaRuntimeService } from '../../runtime/orca-runtime'
 import type { Store } from '../../persistence'
 import type { GlobalSettings } from '../../../shared/global-settings-types'
@@ -58,6 +59,7 @@ import {
   resolveCodexResumeLaunch,
   stripSequencedStartupResumeArgv
 } from './host-env/codex-resume'
+import { ensureLinuxTerminalOrcaCliShimDir } from '../../cli/linux-terminal-orca-cli-shim'
 
 export function registerPtyHandlers(
   mainWindow: BrowserWindow,
@@ -68,6 +70,12 @@ export function registerPtyHandlers(
   store?: Store,
   options?: PtyIpcSessionOptions
 ): void {
+  if (process.platform === 'linux') {
+    const appEnvironment = getAppEnvironment()
+    if (appEnvironment.isPackaged()) {
+      ensureLinuxTerminalOrcaCliShimDir({ userDataPath: appEnvironment.getPath('userData') })
+    }
+  }
   const ipcMain = getPtyIpc()
   // Why first: the outgoing session owns the producer pauses, so its real reset must run
   // before the bridge is neutralized or a PTY paused during re-registration stays paused.


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 19 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3273 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​105 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3168 |
| Prod | 23 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2130 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​219 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1911 |

<!-- /orca-pr-loc -->

## ELI5

The registered Linux CLI used to reopen the outer AppImage for every command. That path can require FUSE and can inject Chromium flags that Electron's Node mode rejects, so the CLI was broken on stock modern Ubuntu and in containers. Orca now extracts the payload once and installs one stable launcher whose target can move safely across app restarts and upgrades.

## What Changed

### One stable entrypoint

- AppImage payloads live under `${XDG_CACHE_HOME:-~/.cache}/orca/appimage/<namespace>/<generation>`.
- The registered command points to `launcher/orca-ide`, never to the outer AppImage or a transient mount.
- The stable launcher resolves only the `installed` endpoint; legacy `live` links are ignored by the launcher and removed during migration.
- A short bounded wait bridges endpoint replacement without exposing a half-published target.

### Extraction and publication are transactional

- The namespace is derived from the AppImage path; the generation is derived from filesystem identity (`dev`, `ino`, size, mtime, and ctime).
- Registration is serialized with a cache-scoped cross-process lock.
- Extraction happens in a private staging directory, validates the executable launcher, rechecks that the AppImage generation is still current, and publishes with atomic renames.
- A raced or malformed destination is displaced and inspected before Orca restores a valid winner or replaces an incomplete tree.
- A generation change during extraction gets one bounded retry; failures never publish an endpoint.

### Ownership, install, and removal are fenced

- `installed` ownership is namespace-scoped, so one AppImage path cannot unregister or prune another path's payload.
- Command inspection captures inode identity and, for regular files, a hash. Install/remove quarantines the observed entry before publishing and restores or preserves it if the path changed.
- Privileged symlink transactions apply the same capture/verify/publish/rollback shape.
- Legacy wrapper registrations remain detectable and migrate on the next install.

### Cleanup preserves live work

- Pruning retains the selected generation, the installed endpoint target, in-process extractions, and recent cross-process extraction markers.
- Unregister removes only payloads owned by that AppImage namespace and leaves the `live` endpoint intact.
- Managed terminal startup refreshes `live` without performing extraction, so PTY creation does not block on AppImage I/O.

## Why

The old registered wrapper re-entered `AppRun`. On Ubuntu 24.04, restricted user namespaces make `AppRun` prepend `--no-sandbox`; Electron Node mode rejects that option before Orca runs (#11609). The same wrapper also depended on mounting the outer AppImage, so it failed where `/dev/fuse` was unavailable (#12530).

Extracting once removes both dependencies while preserving normal CLI latency. The cache cost is bounded to active/installed generations and reclaimed on later registration or unregister.

## Linked Issue

Fixes #11609
Fixes #12530
Fixes #16650

## Visual Proof

N/A — Linux packaging and CLI entrypoint behavior only; no rendered UI changes.

## Testing

- 16 changed test files / 160 tests passed, with 4 platform-gated skips, on the published commit
- `pnpm tc:node`
- changed-code quality, max-lines ratchet, reliability gates, full lint, and `git diff --check`
- stack-level hostile-container artifact coverage is added by #15085

Stack readiness evidence on the published rebased stack (main@212c0e42): 56 changed test files, 785 tests passed, and 4 platform-gated skips. Typecheck, reliability/max-lines/runtime-Electron ratchets, changed-code quality/React Doctor, formatting, oxlint, shellcheck, and `git diff --check` passed. The full-suite control run had 7 failures in 3 untouched files: the zsh non-ASCII wrapper rename collision, the SSH host-key mock's missing `ssh2.utils`, and a renderer context-menu failure seen only in the full run (the isolated test passed). The zsh and SSH failures reproduce on pristine `origin/main`; fresh CI is running on the published heads.

The tests cover concurrent registration, AppImage replacement during extraction, partial/malformed destinations, endpoint publication races, namespace isolation, privileged and unprivileged command-path races, stale registrations, restored-terminal refresh, pruning grace, legacy migration, and rollback/preservation failures.

The concurrent-registration test now fails if the sibling reads status before the first operation releases the cache-scoped lock.

The headless AppImage instructions now download the artifact before extraction and run extraction with `sudo` for the root-owned `/opt/orca` directory.

The elegance pass removed the unnecessary `cli-installer` re-export; the dispatcher imports the narrow bundled-launcher module directly.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

<!-- internal contributor -->

## Review

PR 1 of 7; reviewable on its own. The complete stack is ordered as follows:

1. **#15081 — one stable AppImage CLI entrypoint**
2. #15083 — unified CLI launch redirect
3. #15084 — missing-display diagnosis
4. #15085 — packaged-artifact launch contract and rpm parity
5. #17319 — static AppImage runtime validation
6. #17318 — manual deb/rpm package installation handoff
7. #17320 — orcad restart-ownership safety documentation

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- No RPC, IPC, mobile, relay, or persisted user-data contract changes; no mobile-facing RPC/protocol/pairing surface was touched.
- SSH/folder workspaces are unaffected; AppImage handling runs only on the local packaged Linux host.
- macOS and Windows installation behavior remains covered, including privileged macOS command replacement.
- Existing wrapper registrations are treated as stale and replaced rather than silently trusted.

## Residual follow-ups

- #17321 — bind extraction to an already-open, no-follow AppImage descriptor and fence it with `fstat`.
- #17322 — replace time-based cross-process pruning grace with explicit process ownership markers.

Both are defense-in-depth P2 follow-ups; current publication and pruning behavior remains bounded and tested.

## Checklist

- [x] Rebased onto current `main`
- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Review fixes applied after review (2026-09-01)

Three defects found in review, all fixed in `c23953a5a00` and verified on Ubuntu 24.04 hardware.

**Superseded generations leaked ~105 MB each.** Pruning removed 3215 of 3216 files and always stranded `resources/app.asar`. Electron's asar shim reports a `*.asar` file as a directory, so the recursive remove tried to `rmdir` a real file, failed with `ENOTEMPTY`, and `.catch(() => {})` hid it. Reproduced end to end twice with different cache hashes (519M → 623M across a single version change), then confirmed reclaimed in a packaged build: registration 2 leaves `du` at 519M with one generation, no manual step and no warning.

`removeExtractedAppImagePayload` now holds `process.noAsar` for the removal, counted so overlapping removals cannot hand the shim back early. All three removal sites use it — staging cleanup (`appimage-extracted-root.ts:182`) and displaced roots (`:230`) leaked identically, not just the prune site. The prune site now warns with the path instead of swallowing the rejection.

**A deb → AppImage migration wedged on its own leftover symlink.** The Linux reclaim rule recognised only extracted-cache launchers, so a symlink into `/opt/Orca/resources/bin/orca-ide` from a previous packaged install became a hard conflict. Packaged-install prefixes are reclaimable again; the existing refusal of arbitrary `resources/bin` paths is unchanged and still covered by its test.

**The conflict error named the offending path but not the remedy.** It now says what to do.

### Verification

`pnpm tc` clean. The packaged CLI launch contract passes 8/8 in a restricted Ubuntu container with no `/dev/fuse` and unprivileged user namespaces denied, and fails 4/8 against a stock release AppImage — three of those at status 133 (SIGTRAP) — so the harness has real detection power rather than rubber-stamping any binary.

### Known gaps, tracked rather than fixed

Registration lock has no acquisition deadline (~15 min worst case against a wedged holder); pruning protects only the current and `installed` roots, so a root another running version is exec'ing from is eligible; a crash mid-unregister can leave a gutted root that reports complete.


## User-facing regressions

Not zero. Three, plus three known gaps.

1. **First CLI registration costs ~2.5s and ~519 MB of disk per generation.** Previously nothing was extracted. Measured on Ubuntu 24.04; the payback is a ~9x faster CLI on every later invocation (0.09s vs 0.85s through FUSE).
2. **Rolling back to a pre-PR build wedges registration.** `cli-install-location.ts` now reports `installMethod: 'symlink'` unconditionally on Linux, dropping the AppImage `'wrapper'` branch, so an older build finds a symlink where it expects a wrapper. Workaround: delete `~/.local/bin/orca-ide` and re-register. Only bites on downgrade.
~~3. A wedged registration lock can hang an IPC-driven install for ~15 minutes.~~ **Removed.** `retries` caps the attempt count, not elapsed time; a `maxRetryTime` wall-clock deadline is now forwarded to `proper-lockfile`, and a wedged holder produces a message naming the lock file instead of a silent hang.

Known gaps, tracked not fixed: pruning protects only the current and `installed` roots, so a root a *different* running Orca version is exec'ing from is eligible for removal; and a crash mid-unregister can leave a gutted root that reports complete and then fails at exec.

Found in review and **fixed here**: superseded generations leaked ~105 MB each (reproduced twice, verified reclaimed in a packaged build), and a deb → AppImage migration wedged on its own leftover `/opt/Orca` symlink.

