### PR TITLE
fix(mobile): offer the host's real Claude model list in native chat

### DIFF
--- a/mobile/src/session/mobile-agent-model-discovery.test.ts
+++ b/mobile/src/session/mobile-agent-model-discovery.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RpcClient } from '../transport/rpc-client'
+import {
+  clearMobileAgentModelDiscoveryForTests,
+  discoverMobileAgentCatalogModels
+} from './mobile-agent-model-discovery'
+
+function probeResponse(): { ok: true; result: unknown } {
+  return {
+    ok: true,
+    result: {
+      success: true,
+      catalogOrigin: 'probe',
+      models: [
+        { id: 'opus', label: 'Opus' },
+        { id: 'opus[1m]', label: 'Opus (1M context)' }
+      ]
+    }
+  }
+}
+
+function makeClient(): { sendRequest: ReturnType<typeof vi.fn> } {
+  return { sendRequest: vi.fn() }
+}
+
+function discover(
+  client: { sendRequest: ReturnType<typeof vi.fn> },
+  overrides?: { hostId?: string; worktreeId?: string }
+): Promise<unknown> {
+  return discoverMobileAgentCatalogModels({
+    client: client as unknown as RpcClient,
+    hostId: overrides?.hostId ?? 'host-a',
+    worktreeId: overrides?.worktreeId ?? 'wt-1',
+    agent: 'claude'
+  })
+}
+
+describe('discoverMobileAgentCatalogModels', () => {
+  beforeEach(() => {
+    clearMobileAgentModelDiscoveryForTests()
+  })
+
+  it('returns the host list and probes a given worktree only once', async () => {
+    const client = makeClient()
+    client.sendRequest.mockResolvedValue(probeResponse())
+
+    const models = await discover(client)
+    expect(models).toEqual([
+      expect.objectContaining({ id: 'opus' }),
+      expect.objectContaining({ id: 'opus[1m]' })
+    ])
+    expect(client.sendRequest.mock.calls[0]?.[0]).toBe('git.discoverCommitMessageModels')
+    expect(client.sendRequest.mock.calls[0]?.[1]).toEqual({
+      worktree: 'id:wt-1',
+      agentId: 'claude'
+    })
+
+    await discover(client)
+    expect(client.sendRequest).toHaveBeenCalledTimes(1)
+  })
+
+  it('probes each host and worktree separately', async () => {
+    const client = makeClient()
+    client.sendRequest.mockResolvedValue(probeResponse())
+
+    await discover(client)
+    await discover(client, { worktreeId: 'wt-2' })
+    await discover(client, { hostId: 'host-b' })
+    expect(client.sendRequest).toHaveBeenCalledTimes(3)
+  })
+
+  it('stops probing a host that does not support the method, for every worktree', async () => {
+    const client = makeClient()
+    client.sendRequest.mockResolvedValue({
+      ok: false,
+      error: { code: 'method_not_found', message: 'unknown method' }
+    })
+
+    expect(await discover(client)).toBeNull()
+    expect(await discover(client, { worktreeId: 'wt-2' })).toBeNull()
+    expect(client.sendRequest).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries after a transport failure instead of pinning the seed for the session', async () => {
+    const client = makeClient()
+    client.sendRequest.mockRejectedValueOnce(new Error('Request timed out'))
+    expect(await discover(client)).toBeNull()
+
+    client.sendRequest.mockResolvedValue(probeResponse())
+    expect(await discover(client)).toHaveLength(2)
+    expect(client.sendRequest).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps the seed when the host answers with a spec list rather than a probe', async () => {
+    const client = makeClient()
+    client.sendRequest.mockResolvedValue({
+      ok: true,
+      result: {
+        success: true,
+        catalogOrigin: 'spec',
+        models: [{ id: 'opus', label: 'Opus' }]
+      }
+    })
+    expect(await discover(client)).toBeNull()
+    // A definitive host answer is cached; only transport failures retry.
+    expect(await discover(client)).toBeNull()
+    expect(client.sendRequest).toHaveBeenCalledTimes(1)
+  })
+})

--- a/mobile/src/session/mobile-agent-model-discovery.ts
+++ b/mobile/src/session/mobile-agent-model-discovery.ts
@@ -1,0 +1,148 @@
+import { useEffect, useState } from 'react'
+import type { AgentType } from '../../../src/shared/agent-status-types'
+import type { CatalogModel } from '../../../src/shared/agent-session-option-catalog'
+import {
+  toDiscoveredCatalogModels,
+  type DiscoveredAgentModelsResult
+} from '../../../src/shared/discovered-agent-model-catalog'
+import type { RpcClient } from '../transport/rpc-client'
+
+// Why: the probe shells out to the agent CLI on the host, which is slow to cold
+// start. Desktop allows the same budget for this call.
+const MODEL_DISCOVERY_TIMEOUT_MS = 75_000
+
+// Keyed by host + worktree, not host alone: worktrees on one host can execute on
+// different SSH targets whose CLIs differ, so one probe result must not speak for
+// another execution host. Bounded so a long session across many worktrees cannot
+// grow this unbounded.
+const MODEL_DISCOVERY_CACHE_CAP = 32
+const modelsByScope = new Map<string, Promise<CatalogModel[] | null>>()
+const hostsWithoutDiscovery = new Set<string>()
+
+function discoveryScopeKey(hostId: string, worktreeId: string, agent: AgentType): string {
+  return `${hostId}\0${worktreeId}\0${agent}`
+}
+
+function rememberScope(key: string, models: Promise<CatalogModel[] | null>): void {
+  modelsByScope.set(key, models)
+  while (modelsByScope.size > MODEL_DISCOVERY_CACHE_CAP) {
+    const oldest = modelsByScope.keys().next().value
+    if (oldest === undefined) {
+      break
+    }
+    modelsByScope.delete(oldest)
+  }
+}
+
+type ProbeOutcome = {
+  models: CatalogModel[] | null
+  /** A transport failure answered nothing about the host — retry on a later mount. */
+  retryable: boolean
+}
+
+async function probeCatalogModels(args: {
+  client: RpcClient
+  hostId: string
+  worktreeId: string
+  agent: AgentType
+}): Promise<ProbeOutcome> {
+  let response
+  try {
+    response = await args.client.sendRequest(
+      'git.discoverCommitMessageModels',
+      { worktree: `id:${args.worktreeId}`, agentId: args.agent },
+      { timeoutMs: MODEL_DISCOVERY_TIMEOUT_MS }
+    )
+  } catch {
+    // Timeout or disconnect. The seed list stays in place and a reconnect re-probes.
+    return { models: null, retryable: true }
+  }
+  if (!response.ok) {
+    if (response.error.code === 'method_not_found') {
+      // Why: RPC availability is host-wide; a host predating this method must not
+      // be re-probed for every worktree the user opens.
+      hostsWithoutDiscovery.add(args.hostId)
+    }
+    return { models: null, retryable: false }
+  }
+  return {
+    models: toDiscoveredCatalogModels(args.agent, response.result as DiscoveredAgentModelsResult),
+    retryable: false
+  }
+}
+
+/**
+ * The host's live model list for this agent, or null to keep the seed catalog.
+ * Probes once per host+worktree+agent; concurrent callers share one request.
+ */
+export function discoverMobileAgentCatalogModels(args: {
+  client: RpcClient
+  hostId: string
+  worktreeId: string
+  agent: AgentType
+}): Promise<CatalogModel[] | null> {
+  if (hostsWithoutDiscovery.has(args.hostId)) {
+    return Promise.resolve(null)
+  }
+  const key = discoveryScopeKey(args.hostId, args.worktreeId, args.agent)
+  const cached = modelsByScope.get(key)
+  if (cached) {
+    return cached
+  }
+  const outcome = probeCatalogModels(args).catch(
+    (): ProbeOutcome => ({ models: null, retryable: true })
+  )
+  const pending = outcome.then(({ models }) => models)
+  rememberScope(key, pending)
+  void outcome.then(({ retryable }) => {
+    // Why: a transport failure must not pin "no models" for the rest of the
+    // session — drop the entry so a later mount retries against a live connection.
+    if (retryable && modelsByScope.get(key) === pending) {
+      modelsByScope.delete(key)
+    }
+  })
+  return pending
+}
+
+export function clearMobileAgentModelDiscoveryForTests(): void {
+  modelsByScope.clear()
+  hostsWithoutDiscovery.clear()
+}
+
+/**
+ * The host's live model list for this agent+worktree, or null while it is
+ * unknown. Why: the seed catalog carries version-neutral family aliases only, so
+ * without this the picker cannot offer host-specific variants such as `opus[1m]`.
+ * A failed or unsupported probe simply leaves the seed in place.
+ */
+export function useDiscoveredAgentCatalogModels(args: {
+  agent: string | null
+  client: RpcClient | null
+  hostId: string
+  worktreeId: string
+  enabled: boolean
+}): CatalogModel[] | null {
+  const { agent, client, hostId, worktreeId, enabled } = args
+  const [models, setModels] = useState<CatalogModel[] | null>(null)
+  useEffect(() => {
+    setModels(null)
+    if (!enabled || !client || !agent) {
+      return
+    }
+    let cancelled = false
+    void discoverMobileAgentCatalogModels({
+      client,
+      hostId,
+      worktreeId,
+      agent: agent as AgentType
+    }).then((discovered) => {
+      if (!cancelled && discovered && discovered.length > 0) {
+        setModels(discovered)
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [agent, client, enabled, hostId, worktreeId])
+  return models
+}

--- a/mobile/src/session/mobile-native-chat-session-option-records.ts
+++ b/mobile/src/session/mobile-native-chat-session-option-records.ts
@@ -1,0 +1,47 @@
+import { createNativeChatSessionOptionRecord } from '../../../src/shared/native-chat-session-option-state'
+import type { NativeChatSessionOptionRecord } from '../../../src/shared/native-chat-session-option-state'
+
+// Why: per-tab records survive chat↔terminal flips and remounts, like desktop's
+// scope cache. Bounded so long sessions across many tabs can't grow unbounded.
+const MOBILE_SESSION_OPTION_RECORD_CAP = 32
+const recordsByScope = new Map<string, NativeChatSessionOptionRecord>()
+// The catalog model id last taken from a hook report, per scope. Mobile cannot
+// read the agent's screen, so a repeat of the same report is not new evidence.
+const appliedReportByScope = new Map<string, string>()
+
+export function getScopedRecord(scopeKey: string, agent: string): NativeChatSessionOptionRecord {
+  const existing = recordsByScope.get(scopeKey)
+  const record =
+    existing && existing.agent === agent ? existing : createNativeChatSessionOptionRecord(agent)
+  if (record !== existing) {
+    appliedReportByScope.delete(scopeKey)
+  }
+  // Why: delete-then-set on every read makes the touched scope most-recent, so
+  // eviction only sheds the oldest UNTOUCHED tab. Insertion order alone would let
+  // a long-lived active tab be the oldest key and lose its tracked model.
+  recordsByScope.delete(scopeKey)
+  recordsByScope.set(scopeKey, record)
+  while (recordsByScope.size > MOBILE_SESSION_OPTION_RECORD_CAP) {
+    const oldest = recordsByScope.keys().next().value
+    if (oldest === undefined) {
+      break
+    }
+    recordsByScope.delete(oldest)
+    appliedReportByScope.delete(oldest)
+  }
+  return record
+}
+
+/** The model id last applied from an agent report for this scope, if any. */
+export function getAppliedReportModelId(scopeKey: string): string | undefined {
+  return appliedReportByScope.get(scopeKey)
+}
+
+export function setAppliedReportModelId(scopeKey: string, modelId: string): void {
+  appliedReportByScope.set(scopeKey, modelId)
+}
+
+export function clearMobileSessionOptionRecordsForTests(): void {
+  recordsByScope.clear()
+  appliedReportByScope.clear()
+}

--- a/mobile/src/session/use-mobile-native-chat-controller.ts
+++ b/mobile/src/session/use-mobile-native-chat-controller.ts
@@ -239,6 +239,9 @@ export function useMobileNativeChatController(args: {
     agent: activeChatResolution?.agent ?? null,
     scopeKey: mobileNativeChatScopeKey(hostId, worktreeId, activeSessionTabId),
     reportedModel: activeSessionTab?.agentStatus?.model ?? null,
+    client,
+    hostId,
+    worktreeId,
     dispatchCommand: handleNativeChatDispatchCommand,
     onAgentPicker: handleAgentPicker
   })

--- a/mobile/src/session/use-mobile-native-chat-session-options.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-session-options.test.ts
@@ -1,6 +1,8 @@
 import { createElement } from 'react'
 import { act, create, type ReactTestRenderer } from 'react-test-renderer'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RpcClient } from '../transport/rpc-client'
+import { clearMobileAgentModelDiscoveryForTests } from './mobile-agent-model-discovery'
 import type { MobileNativeChatSendOutcome } from './mobile-native-chat-send'
 import {
   clearMobileSessionOptionRecordsForTests,
@@ -27,6 +29,9 @@ describe('useMobileNativeChatSessionOptions', () => {
       agent: 'claude',
       scopeKey: 'host\0worktree\0tab',
       reportedModel: null,
+      client: null,
+      hostId: 'host',
+      worktreeId: 'worktree',
       dispatchCommand,
       onAgentPicker,
       ...overrides
@@ -45,6 +50,7 @@ describe('useMobileNativeChatSessionOptions', () => {
 
   beforeEach(() => {
     clearMobileSessionOptionRecordsForTests()
+    clearMobileAgentModelDiscoveryForTests()
     dispatchCommand.mockReset()
     dispatchCommand.mockResolvedValue('accepted')
     onAgentPicker.mockReset()
@@ -283,5 +289,67 @@ describe('useMobileNativeChatSessionOptions', () => {
     await expect(first).resolves.toBe(true)
     await expect(queued).resolves.toBe(false)
     expect(dispatchCommand).toHaveBeenCalledTimes(1)
+  })
+
+  it('offers the host list, including a 1M-context variant the seed cannot name', async () => {
+    const client = { sendRequest: vi.fn() }
+    client.sendRequest.mockResolvedValue({
+      ok: true,
+      result: {
+        success: true,
+        catalogOrigin: 'probe',
+        models: [
+          { id: 'sonnet', label: 'Sonnet' },
+          { id: 'opus', label: 'Opus' },
+          { id: 'opus[1m]', label: 'Opus (1M context)' }
+        ]
+      }
+    })
+    mount({ client: client as unknown as RpcClient })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    const model = api!.snapshot[0]!.kind as { choices: { value: string }[] }
+    expect(model.choices.map((choice) => choice.value)).toEqual(['sonnet', 'opus', 'opus[1m]'])
+  })
+
+  it('reports a 1M-context model against its own row, not the plain family row', async () => {
+    const client = { sendRequest: vi.fn() }
+    client.sendRequest.mockResolvedValue({
+      ok: true,
+      result: {
+        success: true,
+        catalogOrigin: 'probe',
+        models: [
+          { id: 'opus', label: 'Opus' },
+          { id: 'opus[1m]', label: 'Opus (1M context)' }
+        ]
+      }
+    })
+    mount({ client: client as unknown as RpcClient })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    update({ reportedModel: 'claude-opus-5[1m]' })
+    expect(api!.snapshot[0]!.kind).toMatchObject({ currentValue: 'opus[1m]' })
+  })
+
+  it('keeps the seed catalog when the host cannot answer the probe', async () => {
+    const client = { sendRequest: vi.fn() }
+    client.sendRequest.mockResolvedValue({
+      ok: false,
+      error: { code: 'method_not_found', message: 'unknown method' }
+    })
+    mount({ client: client as unknown as RpcClient })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    const model = api!.snapshot[0]!.kind as { choices: { value: string }[] }
+    expect(model.choices.map((choice) => choice.value)).toEqual([
+      'fable',
+      'opus',
+      'sonnet',
+      'haiku'
+    ])
   })
 })

--- a/mobile/src/session/use-mobile-native-chat-session-options.ts
+++ b/mobile/src/session/use-mobile-native-chat-session-options.ts
@@ -5,6 +5,13 @@ import {
   type CatalogCommandDelivery,
   type CatalogModel
 } from '../../../src/shared/agent-session-option-catalog'
+import type { RpcClient } from '../transport/rpc-client'
+import { useDiscoveredAgentCatalogModels } from './mobile-agent-model-discovery'
+import {
+  getAppliedReportModelId,
+  getScopedRecord,
+  setAppliedReportModelId
+} from './mobile-native-chat-session-option-records'
 import type {
   SessionOptionDescriptor,
   SessionOptionValue
@@ -21,7 +28,6 @@ import {
 import {
   applyNativeChatReportedSessionOptions,
   clearNativeChatSessionModel,
-  createNativeChatSessionOptionRecord,
   getTrackedSessionOption,
   isFlipOnlyMidSession,
   matchNativeChatCatalogModelId,
@@ -43,51 +49,19 @@ export type MobileNativeChatSessionOptionsController = {
 
 type PendingOperation = { id: string; token: number }
 
-// Why: per-tab records survive chat↔terminal flips and remounts, like desktop's
-// scope cache. Bounded so long sessions across many tabs can't grow unbounded.
-const MOBILE_SESSION_OPTION_RECORD_CAP = 32
-const recordsByScope = new Map<string, NativeChatSessionOptionRecord>()
-// The catalog model id last taken from a hook report, per scope. Mobile cannot
-// read the agent's screen, so a repeat of the same report is not new evidence.
-const appliedReportByScope = new Map<string, string>()
-
-function getScopedRecord(scopeKey: string, agent: string): NativeChatSessionOptionRecord {
-  const existing = recordsByScope.get(scopeKey)
-  const record =
-    existing && existing.agent === agent ? existing : createNativeChatSessionOptionRecord(agent)
-  if (record !== existing) {
-    appliedReportByScope.delete(scopeKey)
-  }
-  // Why: delete-then-set on every read makes the touched scope most-recent, so
-  // eviction only sheds the oldest UNTOUCHED tab. Insertion order alone would let
-  // a long-lived active tab be the oldest key and lose its tracked model.
-  recordsByScope.delete(scopeKey)
-  recordsByScope.set(scopeKey, record)
-  while (recordsByScope.size > MOBILE_SESSION_OPTION_RECORD_CAP) {
-    const oldest = recordsByScope.keys().next().value
-    if (oldest === undefined) {
-      break
-    }
-    recordsByScope.delete(oldest)
-    appliedReportByScope.delete(oldest)
-  }
-  return record
-}
-
-export function clearMobileSessionOptionRecordsForTests(): void {
-  recordsByScope.clear()
-  appliedReportByScope.clear()
-}
+export { clearMobileSessionOptionRecordsForTests } from './mobile-native-chat-session-option-records'
 
 const EMPTY_SNAPSHOT: SessionOptionDescriptor[] = []
 
-/** The model list every consumer must see: the catalog's, plus the tracked model
- *  when the catalog no longer lists it. Desktop reconciles identically. */
+/** The model list every consumer must see: the host's live list when a probe
+ *  returned one (desktop replaces the seed identically), plus the tracked model
+ *  when that list no longer names it. */
 function activeModels(
   catalog: AgentSessionOptionCatalog,
-  record: NativeChatSessionOptionRecord
+  record: NativeChatSessionOptionRecord,
+  discovered: CatalogModel[] | null
 ): CatalogModel[] {
-  return withTrackedNativeChatModel(catalog, catalog.models, record)
+  return withTrackedNativeChatModel(catalog, discovered ?? catalog.models, record)
 }
 
 export function useMobileNativeChatSessionOptions(args: {
@@ -96,6 +70,10 @@ export function useMobileNativeChatSessionOptions(args: {
   scopeKey: string | null
   /** Provider model from live agent status, when the hook reported one. */
   reportedModel: string | null
+  /** Null until the host connection is up; model discovery waits for it. */
+  client: RpcClient | null
+  hostId: string
+  worktreeId: string
   dispatchCommand: (
     command: string,
     options?: { delivery?: CatalogCommandDelivery }
@@ -104,7 +82,8 @@ export function useMobileNativeChatSessionOptions(args: {
    *  dispatched — bring the terminal view forward. */
   onAgentPicker?: () => void
 }): MobileNativeChatSessionOptionsController {
-  const { agent, scopeKey, reportedModel, dispatchCommand, onAgentPicker } = args
+  const { agent, scopeKey, reportedModel, client, hostId, worktreeId, dispatchCommand } = args
+  const { onAgentPicker } = args
   const catalog = useMemo(
     // Widening this to a `defaultModelIsCliDefault` catalog (grok) also needs the
     // effective-model resolution desktop does — `previousModelId` below is tracked-only,
@@ -130,13 +109,28 @@ export function useMobileNativeChatSessionOptions(args: {
     }
   }, [identity])
 
+  // Why: the seed catalog carries version-neutral family aliases only, so without
+  // this probe the picker cannot offer host-specific variants such as `opus[1m]`.
+  const discoveredModels = useDiscoveredAgentCatalogModels({
+    agent,
+    client,
+    hostId,
+    worktreeId,
+    enabled: Boolean(catalog?.listModels)
+  })
+
   // Seed the current model from live agent status; hook reports are authority
   // over locally dispatched guesses (desktop 'reported' source parity).
   useEffect(() => {
     if (!catalog || !scopeKey || !agent || !reportedModel) {
       return
     }
-    const matched = matchNativeChatCatalogModelId(catalog, reportedModel)
+    // The host's live list first: `claude-opus-5[1m]` would otherwise fall through
+    // to the seed's substring rule and match the plain `opus` family row.
+    const matched =
+      (discoveredModels
+        ? matchNativeChatCatalogModelId({ ...catalog, models: discoveredModels }, reportedModel)
+        : null) ?? matchNativeChatCatalogModelId(catalog, reportedModel)
     if (!matched) {
       return
     }
@@ -144,15 +138,15 @@ export function useMobileNativeChatSessionOptions(args: {
     // status stream reconnects, and a session-start report cannot have observed a
     // `/model` sent after it. Re-applying it would revert the user's pick. Only a
     // report that CHANGES is evidence; the value itself still wins when it does.
-    if (appliedReportByScope.get(scopeKey) === matched) {
+    if (getAppliedReportModelId(scopeKey) === matched) {
       return
     }
-    appliedReportByScope.set(scopeKey, matched)
+    setAppliedReportModelId(scopeKey, matched)
     const record = getScopedRecord(scopeKey, agent)
     if (applyNativeChatReportedSessionOptions(record, { model: matched })) {
       bump()
     }
-  }, [agent, bump, catalog, reportedModel, scopeKey])
+  }, [agent, bump, catalog, discoveredModels, reportedModel, scopeKey])
 
   const snapshot = useMemo(() => {
     if (!catalog || !scopeKey || !agent) {
@@ -165,12 +159,12 @@ export function useMobileNativeChatSessionOptions(args: {
       catalog,
       // The snapshot no longer self-heals an unlisted tracked model; every caller
       // reconciles it in, so a value the seed dropped keeps its row and options.
-      models: activeModels(catalog, record),
+      models: activeModels(catalog, record, discoveredModels),
       record,
       mode: 'live',
       modelLabel: 'Model'
     })
-  }, [agent, catalog, scopeKey, version])
+  }, [agent, catalog, discoveredModels, scopeKey, version])
 
   const runSerialized = useCallback(
     (operationIdentity: string, id: string, run: () => Promise<boolean>): Promise<boolean> => {
@@ -218,7 +212,7 @@ export function useMobileNativeChatSessionOptions(args: {
         const apply =
           id === 'model'
             ? catalog.modelApply
-            : activeModels(catalog, record)
+            : activeModels(catalog, record, discoveredModels)
                 .find((model) => model.id === previousModelId)
                 ?.options.find((option) => option.id === id)?.apply
         if (!apply || apply.midSession?.kind === 'agent-picker') {
@@ -242,7 +236,7 @@ export function useMobileNativeChatSessionOptions(args: {
           apply,
           modelId: previousModelId,
           catalog,
-          models: activeModels(catalog, record),
+          models: activeModels(catalog, record, discoveredModels),
           record
         })
         if (!command) {
@@ -282,7 +276,7 @@ export function useMobileNativeChatSessionOptions(args: {
         return true
       })
     },
-    [agent, bump, catalog, dispatchCommand, identity, runSerialized, scopeKey]
+    [agent, bump, catalog, discoveredModels, dispatchCommand, identity, runSerialized, scopeKey]
   )
 
   const invokeAction = useCallback(
@@ -296,7 +290,7 @@ export function useMobileNativeChatSessionOptions(args: {
         const apply =
           id === 'model'
             ? catalog.modelApply
-            : activeModels(catalog, record)
+            : activeModels(catalog, record, discoveredModels)
                 .find((model) => model.id === modelId)
                 ?.options.find((option) => option.id === id)?.apply
         const midSession = apply?.midSession
@@ -319,7 +313,17 @@ export function useMobileNativeChatSessionOptions(args: {
         return false
       })
     },
-    [agent, bump, catalog, dispatchCommand, identity, onAgentPicker, runSerialized, scopeKey]
+    [
+      agent,
+      bump,
+      catalog,
+      discoveredModels,
+      dispatchCommand,
+      identity,
+      onAgentPicker,
+      runSerialized,
+      scopeKey
+    ]
   )
 
   const recordCommand = useCallback(
@@ -330,7 +334,7 @@ export function useMobileNativeChatSessionOptions(args: {
       const record = getScopedRecord(scopeKey, agent)
       const result = recordNativeChatSessionOptionCommand({
         catalog,
-        models: activeModels(catalog, record),
+        models: activeModels(catalog, record, discoveredModels),
         record,
         command
       })

--- a/src/renderer/src/components/native-chat/native-chat-session-option-discovery.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-discovery.ts
@@ -1,9 +1,6 @@
 import type { AgentType } from '../../../../shared/agent-status-types'
-import {
-  createClaudeCatalogOptions,
-  getAgentSessionOptionCatalog,
-  type CatalogModel
-} from '../../../../shared/agent-session-option-catalog'
+import type { CatalogModel } from '../../../../shared/agent-session-option-catalog'
+import { toDiscoveredCatalogModels } from '../../../../shared/discovered-agent-model-catalog'
 import {
   getCommitMessageModelDiscoveryHostKeyForLocalRuntime,
   getCommitMessageModelDiscoveryHostKeyForScope
@@ -74,28 +71,5 @@ export async function discoverNativeChatCatalogModels(
   context: RuntimeGitContext
 ): Promise<CatalogModel[] | null> {
   const result = await discoverRuntimeCommitMessageModels(context, agent)
-  const catalog = getAgentSessionOptionCatalog(agent)
-  if (
-    !result.success ||
-    result.models.length === 0 ||
-    // Why: a spec's static fallback list must never pass as a probe result for an
-    // agent whose published list replaces rather than extends the seed.
-    ((agent === 'claude' || catalog?.discoveredModelsAreAuthoritative) &&
-      result.catalogOrigin !== 'probe')
-  ) {
-    return null
-  }
-  return result.models.map((model) => ({
-    id: model.id,
-    label: model.label,
-    ...(model.description ? { description: model.description } : {}),
-    ...(model.isDefault ? { isDefault: true as const } : {}),
-    options:
-      agent === 'claude'
-        ? createClaudeCatalogOptions({
-            effortLevelIds: model.thinkingLevels?.map(({ id }) => id) ?? [],
-            supportsFastMode: model.supportsFastMode
-          })
-        : []
-  }))
+  return toDiscoveredCatalogModels(agent, result)
 }

--- a/src/shared/discovered-agent-model-catalog.test.ts
+++ b/src/shared/discovered-agent-model-catalog.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { toDiscoveredCatalogModels } from './discovered-agent-model-catalog'
+
+const OPUS_1M = {
+  id: 'opus[1m]',
+  label: 'Opus (1M context)',
+  description: 'Opus 5 with 1M context',
+  thinkingLevels: [
+    { id: 'low', label: 'Low' },
+    { id: 'high', label: 'High' }
+  ],
+  supportsFastMode: true
+}
+
+describe('toDiscoveredCatalogModels', () => {
+  it('keeps a probed 1M-context variant with its effort and fast-mode options', () => {
+    const models = toDiscoveredCatalogModels('claude', {
+      success: true,
+      models: [{ id: 'opus', label: 'Opus' }, OPUS_1M],
+      catalogOrigin: 'probe'
+    })
+    const longContext = models?.find((model) => model.id === 'opus[1m]')
+    expect(longContext?.label).toBe('Opus (1M context)')
+    expect(longContext?.options.map((option) => option.id)).toEqual(['effort', 'fastMode'])
+    const effort = longContext?.options.find((option) => option.id === 'effort')?.kind
+    expect(effort?.type === 'select' && effort.choices.map((choice) => choice.value)).toEqual([
+      'low',
+      'high'
+    ])
+  })
+
+  it('rejects a spec fallback list for Claude', () => {
+    expect(
+      toDiscoveredCatalogModels('claude', {
+        success: true,
+        models: [OPUS_1M],
+        catalogOrigin: 'spec'
+      })
+    ).toBeNull()
+  })
+
+  it('rejects a response from a runtime too old to report catalogOrigin', () => {
+    expect(toDiscoveredCatalogModels('claude', { success: true, models: [OPUS_1M] })).toBeNull()
+  })
+
+  it('returns null for a failed or empty probe', () => {
+    expect(toDiscoveredCatalogModels('claude', { success: false, error: 'boom' })).toBeNull()
+    expect(
+      toDiscoveredCatalogModels('claude', { success: true, models: [], catalogOrigin: 'probe' })
+    ).toBeNull()
+    expect(toDiscoveredCatalogModels('claude', null)).toBeNull()
+  })
+
+  it('carries the discovered default flag', () => {
+    const models = toDiscoveredCatalogModels('claude', {
+      success: true,
+      models: [{ id: 'sonnet', label: 'Sonnet', isDefault: true }],
+      catalogOrigin: 'probe'
+    })
+    expect(models?.[0]?.isDefault).toBe(true)
+  })
+})

--- a/src/shared/discovered-agent-model-catalog.ts
+++ b/src/shared/discovered-agent-model-catalog.ts
@@ -1,0 +1,55 @@
+import type { AgentType } from './agent-status-types'
+import {
+  createClaudeCatalogOptions,
+  getAgentSessionOptionCatalog,
+  type CatalogModel
+} from './agent-session-option-catalog'
+import type { CommitMessageModelCapability } from './commit-message-agent-spec'
+
+/** The `git.discoverCommitMessageModels` payload, structurally. Declared here so
+ *  mobile can read it without importing the desktop runtime client. */
+export type DiscoveredAgentModelsResult =
+  | {
+      success: true
+      models: CommitMessageModelCapability[]
+      defaultModelId?: string
+      /** Missing only when an older remote runtime produced the response. */
+      catalogOrigin?: 'probe' | 'spec'
+    }
+  | { success: false; error?: string }
+
+/**
+ * The host's live model list as catalog rows, or null when the response is not
+ * usable evidence. Null means "keep the seed", never "the host has no models".
+ */
+export function toDiscoveredCatalogModels(
+  agent: AgentType,
+  result: DiscoveredAgentModelsResult | null | undefined
+): CatalogModel[] | null {
+  if (!result?.success || result.models.length === 0) {
+    return null
+  }
+  const catalog = getAgentSessionOptionCatalog(agent)
+  // Why: a spec's static fallback list must never pass as a probe result for an
+  // agent whose published list replaces rather than extends the seed. An older
+  // runtime omits catalogOrigin entirely, so absence counts as "not a probe".
+  if (
+    (agent === 'claude' || catalog?.discoveredModelsAreAuthoritative) &&
+    result.catalogOrigin !== 'probe'
+  ) {
+    return null
+  }
+  return result.models.map((model) => ({
+    id: model.id,
+    label: model.label,
+    ...(model.description ? { description: model.description } : {}),
+    ...(model.isDefault ? { isDefault: true as const } : {}),
+    options:
+      agent === 'claude'
+        ? createClaudeCatalogOptions({
+            effortLevelIds: model.thinkingLevels?.map(({ id }) => id) ?? [],
+            supportsFastMode: model.supportsFastMode
+          })
+        : []
+  }))
+}

--- a/src/shared/native-chat-session-option-state.test.ts
+++ b/src/shared/native-chat-session-option-state.test.ts
@@ -61,4 +61,20 @@ describe('matchNativeChatCatalogModelId', () => {
     expect(matchNativeChatCatalogModelId(CLAUDE_SESSION_OPTION_CATALOG, 'mystery-model')).toBeNull()
     expect(matchNativeChatCatalogModelId(CLAUDE_SESSION_OPTION_CATALOG, '')).toBeNull()
   })
+
+  it('keeps a bracketed context variant distinct from its family alias', () => {
+    const withLongContext = {
+      ...CLAUDE_SESSION_OPTION_CATALOG,
+      models: [
+        ...CLAUDE_SESSION_OPTION_CATALOG.models,
+        { id: 'opus[1m]', label: 'Opus (1M context)', options: [] }
+      ]
+    }
+    expect(matchNativeChatCatalogModelId(withLongContext, 'claude-opus-5[1m]')).toBe('opus[1m]')
+    expect(matchNativeChatCatalogModelId(withLongContext, 'claude-opus-5')).toBe('opus')
+    // A 1M report with no 1M row listed must not silently claim the 200k row.
+    expect(
+      matchNativeChatCatalogModelId(CLAUDE_SESSION_OPTION_CATALOG, 'claude-opus-5[1m]')
+    ).toBeNull()
+  })
 })

--- a/src/shared/native-chat-session-option-state.ts
+++ b/src/shared/native-chat-session-option-state.ts
@@ -146,6 +146,13 @@ export function applyNativeChatReportedSessionOptions(
   return changed
 }
 
+/** Splits `opus[1m]` into the family alias and its bracketed variant. A variant
+ *  is a distinct model choice, so it must match exactly on both sides. */
+function splitModelVariant(value: string): { base: string; variant: string } {
+  const match = /^(.*?)(\[[^\]]+\])$/.exec(value)
+  return match ? { base: match[1]!, variant: match[2]! } : { base: value, variant: '' }
+}
+
 export function matchNativeChatCatalogModelId(
   catalog: AgentSessionOptionCatalog,
   reported: string
@@ -162,8 +169,16 @@ export function matchNativeChatCatalogModelId(
   if (byLabel) {
     return byLabel.id
   }
+  // Why: the resolved provider model carries a version the alias omits
+  // (`claude-opus-5[1m]` vs `opus[1m]`), so the family is matched by substring —
+  // but the variant is not optional. Without this, `claude-opus-5[1m]` lands on
+  // the plain `opus` row and the picker claims a 200k window.
+  const reportedParts = splitModelVariant(normalized)
   const containing = [...catalog.models]
     .sort((left, right) => right.id.length - left.id.length)
-    .find((model) => normalized.includes(model.id.toLowerCase()))
+    .find((model) => {
+      const parts = splitModelVariant(model.id.toLowerCase())
+      return parts.variant === reportedParts.variant && reportedParts.base.includes(parts.base)
+    })
   return containing?.id ?? null
 }


### PR DESCRIPTION
## Problem

Mobile's native-chat model picker renders only the static seed catalog — the version-neutral `fable / opus / sonnet / haiku` family aliases in `src/shared/agent-session-option-catalog-claude-codex.ts`. A host CLI variant such as `opus[1m]` is therefore unreachable from chat UI, and a user who wants the 1M context window has to abandon native chat and drive `/model` from the terminal view.

Desktop has no such gap: it probes `list_models` once per host and lets the result replace the seed (`native-chat-session-option-enrichment.ts`). Mobile never joined that path — `use-mobile-native-chat-session-options.ts` only ever read the static catalog.

## Change

- Mobile now calls `git.discoverCommitMessageModels`, the RPC the host has long exposed, and uses the probed list in the picker. **No new RPC method, no wire-format change, no protocol bump.**
- Cached once per **host + worktree + agent**: worktrees on one host can execute on different SSH targets whose CLIs differ, so one probe must not speak for another execution host.
- A host predating the method answers `method_not_found` and is marked host-wide as unsupported, so it is not re-probed for every worktree (same pattern as `smart-source-paste-intent.ts`). Any other failure returns null and leaves the seed in place — identical to today's behavior. Transport failures are not cached, so a reconnect retries.
- Model matching needed the variant to be significant: a reported `claude-opus-5[1m]` fell through `matchNativeChatCatalogModelId`'s substring rule onto the plain `opus` row, so the picker claimed a 200k window while the agent actually ran at 1M. A bracketed variant now has to match on both sides.
- The probe-response → catalog-row mapping moves from the renderer into `src/shared/discovered-agent-model-catalog.ts` so desktop and mobile share one implementation — including the rule that a spec fallback, or a runtime too old to report `catalogOrigin`, is never accepted as probe evidence. Desktop behavior is unchanged.

## Out of scope

`claude-opus-5` has no long-context pricing tier in `src/main/claude-usage/claude-model-pricing.ts` (compare `SONNET_LONG_CONTEXT_PRICING`), and `normalizeModelForPricing` folds `claude-opus-5[1m]` into it — so 1M sessions above 200k are under-counted. That is a separate defect and is not touched here.

## Verification

- `mobile`: `pnpm exec vitest run src/session` — 131 files, 1154 tests pass, including new coverage for the probe cache (per-worktree isolation, `method_not_found` poisoning, transport retry, spec rejection) and for the picker listing `opus[1m]` / reporting onto its own row / falling back to the seed when the probe fails.
- desktop: `vitest run --config config/vitest.config.ts src/renderer/src/components/native-chat src/shared/native-chat src/shared/discovered-agent-model-catalog.test.ts` — 90 files, 944 tests pass.
- `oxlint`, `oxfmt --check`, and `tsc --noEmit` clean for both trees (no `max-lines` disable added; the hook was split into `mobile-native-chat-session-option-records.ts` and a discovery hook to stay under the limit).
- Not run: end-to-end on a device against a live host with a `list_models`-capable Claude CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)