### PR TITLE
fix(remote): bind remote setup-hook execution to the exact approved content

### DIFF
--- a/mobile/app/h/[hostId]/tasks.tsx
+++ b/mobile/app/h/[hostId]/tasks.tsx
@@ -70,6 +70,7 @@ import {
 } from '../../../src/tasks/mobile-hosted-check-status'
 import { buildTaskWorkspaceCreateParams } from '../../../src/tasks/workspace-create-params'
 import { MOBILE_TASKS_CAPABILITY } from '../../../src/tasks/mobile-tasks-capability'
+import { MOBILE_WORKTREE_SETUP_HOOK_APPROVAL_CAPABILITY } from '../../../src/tasks/worktree-create-capability'
 import {
   filterWorkspaceAgents,
   isWorkspaceAgentEnabled,
@@ -108,8 +109,12 @@ import {
 } from '../../../src/tasks/workspace-ssh-gate'
 import { WORKTREE_CREATE_TIMEOUT_MS } from '../../../src/tasks/workspace-create-timeout'
 import {
+  bindSetupHookCreate,
+  resolveSetupHookCreate,
+  type SetupHookCreateResolution
+} from '../../../src/tasks/setup-hook-create-binding'
+import {
   isSetupHookTrusted,
-  normalizeSetupHookTrust,
   trustedOrcaHooksWithSetupApproval,
   wasSetupHookPreviouslyApproved
 } from '../../../src/tasks/setup-hook-trust'
@@ -232,7 +237,7 @@ type TaskRuntimeStatus = {
 
 type TasksSupportState =
   | { kind: 'unknown'; client: RpcClient | null }
-  | { kind: 'supported'; client: RpcClient }
+  | { kind: 'supported'; client: RpcClient; setupHookApprovalSupported: boolean }
   | { kind: 'unsupported'; client: RpcClient }
 type GitLabWorkItem = {
   id: string
@@ -276,17 +281,6 @@ type GitPushTarget = {
 }
 
 type SetupDecision = 'inherit' | 'run' | 'skip'
-type SetupRunPolicy = 'ask' | 'run-by-default' | 'skip-by-default'
-
-type RepoHooksResponse = {
-  hooks: { scripts?: { setup?: string } } | null
-  source: string | null
-  setupRunPolicy?: SetupRunPolicy
-  setupTrust?: {
-    contentHash: string
-    scriptContent: string
-  }
-}
 
 type LinearProject = {
   id: string
@@ -2357,6 +2351,8 @@ export default function MobileTasksScreen() {
     client != null &&
     tasksSupportState.kind === 'unsupported' &&
     tasksSupportState.client === client
+  const setupHookApprovalSupported =
+    tasksSupportState.kind === 'supported' && tasksSupportState.setupHookApprovalSupported
   const taskUiReady = tasksSupported && taskStateHydrated
   const activeGitHubProject = githubProjectSettings.activeProject
   const activeGitHubProjectHost = githubProjectHost(
@@ -2947,7 +2943,13 @@ export default function MobileTasksScreen() {
         setTaskStateHydrated(false)
         return
       }
-      setTasksSupportState({ kind: 'supported', client })
+      setTasksSupportState({
+        kind: 'supported',
+        client,
+        setupHookApprovalSupported: Boolean(
+          status.capabilities?.includes(MOBILE_WORKTREE_SETUP_HOOK_APPROVAL_CAPABILITY)
+        )
+      })
       setError('')
       const [settingsResponse, uiResponse, preflightResponse, linearStatusResponse] =
         await Promise.all([
@@ -5346,43 +5348,14 @@ export default function MobileTasksScreen() {
     workspaceDetectedAgentIds === null
 
   const resolveCreateSetupDecision = useCallback(
-    async (
+    (
       repo: RepoSummary,
       override?: Exclude<SetupDecision, 'inherit'>
-    ): Promise<
-      | { kind: 'decision'; decision: SetupDecision; setupTrust?: RepoHooksResponse['setupTrust'] }
-      | {
-          kind: 'prompt'
-          command: string
-          source: string | null
-          setupTrust?: RepoHooksResponse['setupTrust']
-        }
-    > => {
+    ): Promise<SetupHookCreateResolution> => {
       if (!client || !tasksSupported) {
-        return { kind: 'decision', decision: override ?? 'inherit' }
+        return Promise.resolve({ kind: 'decision' as const, decision: override ?? 'inherit' })
       }
-      const response = await client.sendRequest('repo.hooks', { repo: `id:${repo.id}` })
-      if (!isSuccess(response)) {
-        throw new Error(response.error.message)
-      }
-      const result = response.result as RepoHooksResponse
-      const setupCommand = result.hooks?.scripts?.setup?.trim()
-      const setupTrust = normalizeSetupHookTrust(result.setupTrust) ?? undefined
-      if (!setupCommand) {
-        return { kind: 'decision', decision: 'inherit' }
-      }
-      if (override) {
-        return { kind: 'decision', decision: override, setupTrust }
-      }
-      const setupRunPolicy = result.setupRunPolicy ?? 'run-by-default'
-      if (setupRunPolicy === 'ask') {
-        return { kind: 'prompt', command: setupCommand, source: result.source, setupTrust }
-      }
-      return {
-        kind: 'decision',
-        decision: setupRunPolicy === 'run-by-default' ? 'run' : 'skip',
-        setupTrust
-      }
+      return resolveSetupHookCreate({ client, repoId: repo.id, override })
     },
     [client, tasksSupported]
   )
@@ -5462,7 +5435,12 @@ export default function MobileTasksScreen() {
           })
           return
         }
-        const setupDecision = setupResolution.decision
+        const setupBinding = bindSetupHookCreate({
+          decision: setupResolution.decision,
+          setupTrust: setupResolution.setupTrust,
+          approvalSupported: setupHookApprovalSupported
+        })
+        const setupDecision = setupBinding.decision
         if (
           setupDecision === 'run' &&
           setupResolution.setupTrust &&
@@ -5495,6 +5473,7 @@ export default function MobileTasksScreen() {
           })
           return
         }
+        const setupHookApproval = setupBinding.approval
         let params: Record<string, unknown>
         if (item.provider === 'github') {
           const source = item.source
@@ -5597,6 +5576,9 @@ export default function MobileTasksScreen() {
             sparseCheckout: sparseCheckoutOverride
           })
         }
+        if (setupHookApproval) {
+          params.setupHookApproval = setupHookApproval
+        }
         const response = await client.sendRequest('worktree.create', params, {
           timeoutMs: WORKTREE_CREATE_TIMEOUT_MS
         })
@@ -5612,8 +5594,11 @@ export default function MobileTasksScreen() {
         setSetupPrompt(null)
         const name = result.worktree.displayName ?? item.title
         const queryParams = new URLSearchParams({ name, created: '1' })
-        if (result.warning) {
-          queryParams.set('warning', result.warning)
+        // Why: an old host returns no warning for a client-side downgrade, so a locally
+        // suppressed setup hook would otherwise be invisible.
+        const warning = result.warning ?? setupBinding.suppressedWarning
+        if (warning) {
+          queryParams.set('warning', warning)
         }
         router.push(
           `/h/${hostId}/session/${encodeURIComponent(result.worktree.id)}?${queryParams.toString()}`
@@ -5632,6 +5617,7 @@ export default function MobileTasksScreen() {
       resolveCreateSetupDecision,
       router,
       runtimeTaskSettings,
+      setupHookApprovalSupported,
       taskStateHydrated,
       tasksSupported,
       trustedOrcaHooks,

--- a/mobile/src/components/NewWorktreeModal.tsx
+++ b/mobile/src/components/NewWorktreeModal.tsx
@@ -26,6 +26,7 @@ import {
   isSetupHookTrusted,
   normalizeSetupHookTrust,
   persistSetupHookTrustApproval,
+  setupHookApprovalFromTrust,
   wasSetupHookPreviouslyApproved,
   type SetupHookTrust
 } from '../tasks/setup-hook-trust'
@@ -225,8 +226,12 @@ function NewWorktreeModalContent({
   const [sshConnectingTargetId, setSshConnectingTargetId] = useState<string | null>(null)
   const [note, setNote] = useState('')
   const [availableProviders, setAvailableProviders] = useState<TaskProvider[]>([])
-  const { tasksSupported, hostPlatform, getWorktreeCreateCutoverSupport } =
-    useNewWorktreeRuntimeCapabilities(client, visible)
+  const {
+    tasksSupported,
+    hostPlatform,
+    getWorktreeCreateCutoverSupport,
+    getSetupHookApprovalSupport
+  } = useNewWorktreeRuntimeCapabilities(client, visible)
   const [showAdvanced, setShowAdvanced] = useState(false)
   const [setupHookDetails, setSetupHookDetails] = useState<SetupHookDetails | null>(null)
   const [trustedOrcaHooks, setTrustedOrcaHooks] = useState<PersistedTrustedOrcaHooks>({})
@@ -508,13 +513,14 @@ function NewWorktreeModalContent({
         }
         if (response.ok) {
           const result = (response as RpcSuccess).result as RepoHooksResponse
-          const cmd = result.hooks?.scripts?.setup?.trim() || null
+          const trust = normalizeSetupHookTrust(result.setupTrust)
+          const cmd = trust?.scriptContent ?? result.hooks?.scripts?.setup?.trim() ?? null
           const policy = result.setupRunPolicy ?? 'run-by-default'
           setSetupHookDetails({
             repoId: selectedRepo.id,
             command: cmd,
             source: result.source,
-            trust: normalizeSetupHookTrust(result.setupTrust),
+            trust,
             runPolicy: policy
           })
           setSetupDecisionChoice(null)
@@ -642,6 +648,11 @@ function NewWorktreeModalContent({
           setupDecision = runSetup ? 'run' : 'skip'
         }
       }
+      const setupApprovalSupported =
+        setupDecision === 'skip' ? true : await getSetupHookApprovalSupport()
+      if (!setupApprovalSupported) {
+        setupDecision = 'skip'
+      }
       if (
         setupDecision === 'run' &&
         setupTrust &&
@@ -661,6 +672,12 @@ function NewWorktreeModalContent({
         return
       }
 
+      const setupHookApproval =
+        setupDecision === 'run' ? setupHookApprovalFromTrust(setupTrust) : undefined
+      if (setupDecision === 'run' && setupCommand && !setupHookApproval) {
+        setupDecision = 'skip'
+      }
+
       const createdWithAgentId = selectedAgent.id !== '__blank__' ? selectedAgent.id : undefined
       const trimmedNote = note.trim() || undefined
       const createSelection = composer.createSelection
@@ -670,6 +687,7 @@ function NewWorktreeModalContent({
             selection: createSelection,
             targetRepoId: selectedRepo.id,
             setupDecision,
+            ...(setupHookApproval ? { setupHookApproval } : {}),
             agent: { choice: normalizeWorkspaceAgent(selectedAgent.id) ?? 'blank' },
             workspaceName: trimmedName || undefined,
             note: trimmedNote,
@@ -686,6 +704,7 @@ function NewWorktreeModalContent({
             createdWithAgentId,
             comment: trimmedNote,
             setupDecision,
+            ...(setupHookApproval ? { setupHookApproval } : {}),
             supportsIdempotentCutoverRetry: getWorktreeCreateCutoverSupport()
           })
       if ('error' in result) {

--- a/mobile/src/tasks/blank-workspace-create.ts
+++ b/mobile/src/tasks/blank-workspace-create.ts
@@ -1,4 +1,5 @@
 import type { TuiAgent } from '../../../src/shared/tui-agent'
+import type { SetupHookApproval } from '../../../src/shared/setup-hook-approval'
 import type { RpcClient } from '../transport/rpc-client'
 import { createWorktreeWithNameRetry, type WorktreeCreateResult } from './worktree-create-retry'
 import {
@@ -16,6 +17,7 @@ export async function createBlankWorkspace(args: {
   createdWithAgentId: TuiAgent | undefined
   comment: string | undefined
   setupDecision: WorkspaceCreateSetupDecision
+  setupHookApproval?: SetupHookApproval
   /** True when `baseName` is a generated creature name rather than one the user typed; only then
    *  may the host retire it. */
   nameWasGenerated: boolean
@@ -30,6 +32,7 @@ export async function createBlankWorkspace(args: {
       const params: Record<string, unknown> = {
         repo: `id:${args.repoId}`,
         setupDecision: args.setupDecision,
+        ...(args.setupHookApproval ? { setupHookApproval: args.setupHookApproval } : {}),
         name,
         ...(args.nameWasGenerated ? { nameWasGenerated: true } : {}),
         ...agentLaunchCreateFields(args.createdWithAgentId)

--- a/mobile/src/tasks/setup-hook-create-binding.test.ts
+++ b/mobile/src/tasks/setup-hook-create-binding.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import type { RpcClient } from '../transport/rpc-client'
+import { bindSetupHookCreate, resolveSetupHookCreate } from './setup-hook-create-binding'
+import { hashSetupHookTrustContent } from './setup-hook-trust'
+
+const SETUP_CONTENT = 'pnpm install'
+const HASH = hashSetupHookTrustContent(SETUP_CONTENT)
+
+function hooksClient(result: unknown): RpcClient {
+  return {
+    sendRequest: async () => ({ id: '1', ok: true, result, _meta: { runtimeId: 'runtime' } })
+  } as unknown as RpcClient
+}
+
+describe('setup hook create binding', () => {
+  it('uses host-canonical trust content even when only default-tab commands run', async () => {
+    const canonicalContent = '# defaultTabs[1]\npnpm dev'
+    await expect(
+      resolveSetupHookCreate({
+        client: hooksClient({
+          hooks: { defaultTabs: [{ command: 'pnpm dev' }] },
+          source: 'orca.yaml',
+          setupRunPolicy: 'ask',
+          setupTrust: {
+            contentHash: hashSetupHookTrustContent(canonicalContent),
+            scriptContent: canonicalContent,
+            approvalToken: 'token'
+          }
+        }),
+        repoId: 'repo-1'
+      })
+    ).resolves.toMatchObject({
+      kind: 'prompt',
+      command: '# defaultTabs[1]\npnpm dev',
+      setupTrust: { approvalToken: 'token' }
+    })
+  })
+
+  it('binds current hosts and forces old or malformed hosts to skip', () => {
+    const setupTrust = {
+      contentHash: HASH,
+      scriptContent: SETUP_CONTENT,
+      approvalToken: 'token'
+    }
+
+    expect(bindSetupHookCreate({ decision: 'run', setupTrust, approvalSupported: true })).toEqual({
+      decision: 'run',
+      approval: { kind: 'setup', token: 'token', contentHash: HASH }
+    })
+    // A downgraded run must carry a reason; an old host returns no warning of its own.
+    expect(bindSetupHookCreate({ decision: 'run', setupTrust, approvalSupported: false })).toEqual({
+      decision: 'skip',
+      suppressedWarning: expect.stringContaining('update the remote Orca server')
+    })
+    expect(
+      bindSetupHookCreate({ decision: 'run', setupTrust: null, approvalSupported: true })
+    ).toEqual({
+      decision: 'skip',
+      suppressedWarning: expect.stringContaining('could be verified')
+    })
+    // Nothing to run, so nothing to explain.
+    expect(
+      bindSetupHookCreate({ decision: 'inherit', setupTrust: null, approvalSupported: false })
+    ).toEqual({ decision: 'skip' })
+    expect(bindSetupHookCreate({ decision: 'skip', setupTrust, approvalSupported: true })).toEqual({
+      decision: 'skip'
+    })
+  })
+})

--- a/mobile/src/tasks/setup-hook-create-binding.ts
+++ b/mobile/src/tasks/setup-hook-create-binding.ts
@@ -1,0 +1,87 @@
+import type { RpcClient } from '../transport/rpc-client'
+import type { RpcSuccess } from '../transport/types'
+import {
+  normalizeSetupHookTrust,
+  setupHookApprovalFromTrust,
+  type SetupHookApproval,
+  type SetupHookTrust
+} from './setup-hook-trust'
+
+export type MobileSetupDecision = 'inherit' | 'run' | 'skip'
+type SetupRunPolicy = 'ask' | 'run-by-default' | 'skip-by-default'
+
+export type RepoHooksResponse = {
+  hooks: { scripts?: { setup?: string } } | null
+  source: string | null
+  setupRunPolicy?: SetupRunPolicy
+  setupTrust?: SetupHookTrust
+}
+
+export type SetupHookCreateResolution =
+  | { kind: 'decision'; decision: MobileSetupDecision; setupTrust?: SetupHookTrust }
+  | { kind: 'prompt'; command: string; source: string | null; setupTrust?: SetupHookTrust }
+
+export async function resolveSetupHookCreate(args: {
+  client: RpcClient
+  repoId: string
+  override?: Exclude<MobileSetupDecision, 'inherit'>
+}): Promise<SetupHookCreateResolution> {
+  const response = await args.client.sendRequest('repo.hooks', { repo: `id:${args.repoId}` })
+  if (!response.ok) {
+    throw new Error(response.error.message)
+  }
+  const result = (response as RpcSuccess).result as RepoHooksResponse
+  const setupTrust = normalizeSetupHookTrust(result.setupTrust) ?? undefined
+  const setupCommand = setupTrust?.scriptContent ?? result.hooks?.scripts?.setup?.trim()
+  if (!setupCommand) {
+    return { kind: 'decision', decision: 'inherit' }
+  }
+  if (args.override) {
+    return { kind: 'decision', decision: args.override, setupTrust }
+  }
+  const setupRunPolicy = result.setupRunPolicy ?? 'run-by-default'
+  if (setupRunPolicy === 'ask') {
+    return { kind: 'prompt', command: setupCommand, source: result.source, setupTrust }
+  }
+  return {
+    kind: 'decision',
+    decision: setupRunPolicy === 'run-by-default' ? 'run' : 'skip',
+    setupTrust
+  }
+}
+
+export type SetupHookCreateBinding = {
+  decision: MobileSetupDecision
+  approval?: SetupHookApproval
+  /** Present when an intended run was downgraded, so the caller can say why. */
+  suppressedWarning?: string
+}
+
+const HOST_UNSUPPORTED_WARNING =
+  'Setup hook skipped: update the remote Orca server to run approved setup hooks.'
+const UNVERIFIABLE_WARNING =
+  'Setup hook skipped: this host did not issue an approval that could be verified.'
+
+export function bindSetupHookCreate(args: {
+  decision: MobileSetupDecision
+  setupTrust?: SetupHookTrust | null
+  approvalSupported: boolean
+}): SetupHookCreateBinding {
+  if (args.decision === 'skip') {
+    return { decision: 'skip' }
+  }
+  if (!args.approvalSupported) {
+    // Why: 'inherit' only reaches here when the repo has no setup content, so only an
+    // explicit run is a suppression the user needs told about.
+    return args.decision === 'run'
+      ? { decision: 'skip', suppressedWarning: HOST_UNSUPPORTED_WARNING }
+      : { decision: 'skip' }
+  }
+  if (args.decision !== 'run') {
+    return { decision: args.decision }
+  }
+  const approval = setupHookApprovalFromTrust(args.setupTrust)
+  return approval
+    ? { decision: 'run', approval }
+    : { decision: 'skip', suppressedWarning: UNVERIFIABLE_WARNING }
+}

--- a/mobile/src/tasks/setup-hook-trust.test.ts
+++ b/mobile/src/tasks/setup-hook-trust.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   isSetupHookTrusted,
+  hashSetupHookTrustContent,
   normalizeSetupHookTrust,
   persistSetupHookTrustApproval,
   trustedOrcaHooksWithSetupApproval,
@@ -10,6 +11,8 @@ import type { PersistedTrustedOrcaHooks } from '../../../src/shared/orca-yaml-ho
 import type { RpcClient } from '../transport/rpc-client'
 
 describe('setup hook trust', () => {
+  const validHash = hashSetupHookTrustContent('pnpm install')
+
   it('trusts a setup script only when the approved hash matches', () => {
     const trust: PersistedTrustedOrcaHooks = {
       'repo-1': { setup: { contentHash: 'hash-1', approvedAt: 1000 } }
@@ -101,12 +104,20 @@ describe('setup hook trust', () => {
         'repo-1'
       )
     ).toBe(true)
-    expect(normalizeSetupHookTrust({ contentHash: 'hash-1', scriptContent: '' })).toBe(null)
+    expect(normalizeSetupHookTrust({ contentHash: validHash, scriptContent: '' })).toBe(null)
     expect(
-      normalizeSetupHookTrust({ contentHash: 'hash-1', scriptContent: 'pnpm install' })
+      normalizeSetupHookTrust({
+        contentHash: validHash,
+        scriptContent: 'pnpm install',
+        approvalToken: 'operation-token'
+      })
     ).toEqual({
-      contentHash: 'hash-1',
-      scriptContent: 'pnpm install'
+      contentHash: validHash,
+      scriptContent: 'pnpm install',
+      approvalToken: 'operation-token'
     })
+    expect(normalizeSetupHookTrust({ contentHash: 'not-a-hash', scriptContent: 'pnpm i' })).toBe(
+      null
+    )
   })
 })

--- a/mobile/src/tasks/setup-hook-trust.ts
+++ b/mobile/src/tasks/setup-hook-trust.ts
@@ -1,10 +1,13 @@
 import type { PersistedTrustedOrcaHooks } from '../../../src/shared/orca-yaml-hook-types'
+import { sha256 } from '@noble/hashes/sha256'
+import {
+  parseSetupHookTrust,
+  setupHookApprovalFromTrust,
+  type SetupHookApproval,
+  type SetupHookTrust
+} from '../../../src/shared/setup-hook-approval'
 import type { RpcClient } from '../transport/rpc-client'
-
-export type SetupHookTrust = {
-  contentHash: string
-  scriptContent: string
-}
+export type { SetupHookApproval, SetupHookTrust }
 
 export function isSetupHookTrusted(
   trust: PersistedTrustedOrcaHooks,
@@ -55,8 +58,16 @@ export async function persistSetupHookTrustApproval(args: {
 export function normalizeSetupHookTrust(
   setupTrust: SetupHookTrust | null | undefined
 ): SetupHookTrust | null {
-  if (!setupTrust?.contentHash || !setupTrust.scriptContent) {
+  const parsed = parseSetupHookTrust(setupTrust)
+  if (!parsed || hashSetupHookTrustContent(parsed.scriptContent) !== parsed.contentHash) {
     return null
   }
-  return setupTrust
+  return parsed
+}
+
+export { setupHookApprovalFromTrust }
+
+export function hashSetupHookTrustContent(content: string): string {
+  const bytes = new TextEncoder().encode(content.trim())
+  return Array.from(sha256(bytes), (byte) => byte.toString(16).padStart(2, '0')).join('')
 }

--- a/mobile/src/tasks/source-workspace-create.ts
+++ b/mobile/src/tasks/source-workspace-create.ts
@@ -1,4 +1,5 @@
 import type { RpcClient } from '../transport/rpc-client'
+import type { SetupHookApproval } from '../../../src/shared/setup-hook-approval'
 import { resolveComposerMrBase, resolveComposerPrBase } from './composer-source-base-resolve'
 import type {
   MobileComposerCreateSelection,
@@ -25,6 +26,7 @@ export type CreateWorkspaceFromComposerArgs = {
   selection: MobileComposerCreateSelection
   targetRepoId: string
   setupDecision: WorkspaceCreateSetupDecision
+  setupHookApproval?: SetupHookApproval
   agent: WorkspaceCreateAgentBundle
   workspaceName: string | undefined
   note: string | undefined
@@ -88,6 +90,7 @@ async function createWorkItemWorkspace(args: {
   selection: Extract<MobileComposerCreateSelection, { kind: 'work-item' }>
   targetRepoId: string
   setupDecision: WorkspaceCreateSetupDecision
+  setupHookApproval?: SetupHookApproval
   agent: WorkspaceCreateAgentBundle
   workspaceName: string | undefined
   note: string | undefined
@@ -129,7 +132,8 @@ async function createWorkItemWorkspace(args: {
     compareBaseRef,
     branchNameOverride,
     pushTarget,
-    nameIsAutoManaged: args.nameIsAutoManaged
+    nameIsAutoManaged: args.nameIsAutoManaged,
+    setupHookApproval: args.setupHookApproval
   })
   // buildTaskWorkspaceCreateParams computes the name; reuse it as the retry base
   // so collisions still append -2, -3, ... like the blank path does.
@@ -147,6 +151,7 @@ async function createBranchWorkspace(args: {
   selection: Extract<MobileComposerCreateSelection, { kind: 'branch' }>
   targetRepoId: string
   setupDecision: WorkspaceCreateSetupDecision
+  setupHookApproval?: SetupHookApproval
   agent: WorkspaceCreateAgentBundle
   workspaceName: string | undefined
   note: string | undefined
@@ -181,6 +186,7 @@ async function createBranchWorkspace(args: {
           repo: `id:${targetRepoId}`,
           name,
           setupDecision,
+          ...(args.setupHookApproval ? { setupHookApproval: args.setupHookApproval } : {}),
           baseBranch: selection.refName,
           branchNameOverride: selection.localBranchName
         })
@@ -202,6 +208,7 @@ async function createBranchWorkspace(args: {
         repo: `id:${targetRepoId}`,
         name: candidate,
         setupDecision,
+        ...(args.setupHookApproval ? { setupHookApproval: args.setupHookApproval } : {}),
         baseBranch: selection.baseBranch
       }
       if (selection.branchNameOverride) {
@@ -217,6 +224,7 @@ async function createNewBranchWorkspace(args: {
   selection: Extract<MobileComposerCreateSelection, { kind: 'new-branch' }>
   targetRepoId: string
   setupDecision: WorkspaceCreateSetupDecision
+  setupHookApproval?: SetupHookApproval
   agent: WorkspaceCreateAgentBundle
   workspaceName: string | undefined
   note: string | undefined
@@ -238,6 +246,7 @@ async function createNewBranchWorkspace(args: {
         repo: `id:${targetRepoId}`,
         name: candidate,
         setupDecision,
+        ...(args.setupHookApproval ? { setupHookApproval: args.setupHookApproval } : {}),
         branchNameOverride: candidate,
         ...agentLaunchCreateFields(createdWithAgentId)
       }

--- a/mobile/src/tasks/workspace-create-params.ts
+++ b/mobile/src/tasks/workspace-create-params.ts
@@ -1,4 +1,5 @@
 import type { TuiAgent } from '../../../src/shared/tui-agent'
+import type { SetupHookApproval } from '../../../src/shared/setup-hook-approval'
 import type {
   CreateSparseCheckoutRequest,
   SetupDecision
@@ -87,6 +88,7 @@ export function buildTaskWorkspaceCreateParams(args: {
   sparseCheckout?: WorkspaceCreateSparseCheckout
   hostedStartPoint?: WorkspaceCreateHostedStartPoint
   nameIsAutoManaged?: boolean
+  setupHookApproval?: SetupHookApproval
 }): WorkspaceCreateParams {
   const {
     item,
@@ -132,7 +134,8 @@ export function buildTaskWorkspaceCreateParams(args: {
     ...(branchNameOverride ? { branchNameOverride } : {}),
     ...(selectedPushTarget ? { pushTarget: selectedPushTarget } : {}),
     ...(sparseCheckout ? { sparseCheckout } : {}),
-    ...(comment ? { comment } : {})
+    ...(comment ? { comment } : {}),
+    ...(args.setupHookApproval ? { setupHookApproval: args.setupHookApproval } : {})
   }
 
   if (item.provider === 'github') {

--- a/mobile/src/tasks/worktree-create-capability.test.ts
+++ b/mobile/src/tasks/worktree-create-capability.test.ts
@@ -29,11 +29,14 @@ describe('readNewWorktreeRuntimeCapabilities', () => {
   it('reads task and idempotent-create support from status.get', async () => {
     await expect(
       readNewWorktreeRuntimeCapabilities(
-        statusClient([['mobile.tasks.v1', 'worktree.create-idempotency.v1']])
+        statusClient([
+          ['mobile.tasks.v1', 'worktree.create-idempotency.v1', 'worktree.setup-hook-approval.v1']
+        ])
       )
     ).resolves.toEqual({
       tasksSupported: true,
       idempotentWorktreeCreateSupported: true,
+      setupHookApprovalSupported: true,
       hostPlatform: 'darwin'
     })
   })
@@ -46,6 +49,7 @@ describe('readNewWorktreeRuntimeCapabilities', () => {
     ).resolves.toEqual({
       tasksSupported: false,
       idempotentWorktreeCreateSupported: true,
+      setupHookApprovalSupported: false,
       hostPlatform: 'darwin'
     })
   })
@@ -54,6 +58,7 @@ describe('readNewWorktreeRuntimeCapabilities', () => {
     await expect(readNewWorktreeRuntimeCapabilities(statusClient(['error']))).resolves.toEqual({
       tasksSupported: false,
       idempotentWorktreeCreateSupported: false,
+      setupHookApprovalSupported: false,
       hostPlatform: null
     })
   })

--- a/mobile/src/tasks/worktree-create-capability.ts
+++ b/mobile/src/tasks/worktree-create-capability.ts
@@ -9,18 +9,21 @@ import { MOBILE_TASKS_CAPABILITY } from './mobile-tasks-capability'
 // replay an ambiguous create unless the host advertises idempotency support.
 // Mirrors WORKTREE_CREATE_IDEMPOTENCY_RUNTIME_CAPABILITY in the shared protocol.
 export const MOBILE_WORKTREE_CREATE_IDEMPOTENCY_CAPABILITY = 'worktree.create-idempotency.v1'
+export const MOBILE_WORKTREE_SETUP_HOOK_APPROVAL_CAPABILITY = 'worktree.setup-hook-approval.v1'
 
 const STATUS_CUTOVER_MAX_RETRIES = 5
 
 export type NewWorktreeRuntimeCapabilities = {
   tasksSupported: boolean
   idempotentWorktreeCreateSupported: boolean
+  setupHookApprovalSupported: boolean
   hostPlatform: NodeJS.Platform | null
 }
 
 const UNSUPPORTED_CAPABILITIES: NewWorktreeRuntimeCapabilities = {
   tasksSupported: false,
   idempotentWorktreeCreateSupported: false,
+  setupHookApprovalSupported: false,
   hostPlatform: null
 }
 
@@ -42,6 +45,9 @@ export async function readNewWorktreeRuntimeCapabilities(
         idempotentWorktreeCreateSupported: capabilities.includes(
           MOBILE_WORKTREE_CREATE_IDEMPOTENCY_CAPABILITY
         ),
+        setupHookApprovalSupported: capabilities.includes(
+          MOBILE_WORKTREE_SETUP_HOOK_APPROVAL_CAPABILITY
+        ),
         hostPlatform: readMobileRuntimeHostPlatform(result)
       }
     } catch (error) {
@@ -59,6 +65,7 @@ export function useNewWorktreeRuntimeCapabilities(
   tasksSupported: boolean
   hostPlatform: NodeJS.Platform | null
   getWorktreeCreateCutoverSupport: () => Promise<boolean>
+  getSetupHookApprovalSupport: () => Promise<boolean>
 } {
   const [tasksSupported, setTasksSupported] = useState(false)
   const [hostPlatform, setHostPlatform] = useState<NodeJS.Platform | null>(null)
@@ -100,5 +107,14 @@ export function useNewWorktreeRuntimeCapabilities(
     () => getCapabilities().then((capabilities) => capabilities.idempotentWorktreeCreateSupported),
     [getCapabilities]
   )
-  return { tasksSupported, hostPlatform, getWorktreeCreateCutoverSupport }
+  const getSetupHookApprovalSupport = useCallback(
+    () => getCapabilities().then((capabilities) => capabilities.setupHookApprovalSupported),
+    [getCapabilities]
+  )
+  return {
+    tasksSupported,
+    hostPlatform,
+    getWorktreeCreateCutoverSupport,
+    getSetupHookApprovalSupport
+  }
 }

--- a/src/main/effective-hook-config.ts
+++ b/src/main/effective-hook-config.ts
@@ -77,8 +77,8 @@ export function shouldRunSetupForCreate(repo: Repo, decision: SetupDecision = 'i
   return policy === 'run-by-default'
 }
 
-export function getDefaultTabCommandTrustContent(hooks: OrcaHooks | null): string {
-  const commands = (hooks?.defaultTabs ?? [])
+function getDefaultTabsTrustContent(hooks: OrcaHooks | null): string {
+  return (hooks?.defaultTabs ?? [])
     .map((tab, index) => {
       const command = tab.command?.trim()
       if (!command) {
@@ -88,7 +88,17 @@ export function getDefaultTabCommandTrustContent(hooks: OrcaHooks | null): strin
       return `# defaultTabs[${index + 1}]${label}\n${command}`
     })
     .filter((entry): entry is string => entry !== null)
-  return [hooks?.scripts.setup?.trim(), ...commands].filter(Boolean).join('\n\n')
+    .join('\n\n')
+}
+
+export function getSetupHookTrustContent(repo: Repo, yamlHooks: OrcaHooks | null): string {
+  const effectiveSetup = getEffectiveHooksFromConfig(repo, yamlHooks)?.scripts.setup?.trim()
+  const sourcePolicy = resolveHookCommandSourcePolicy(repo.hookSettings?.commandSourcePolicy, {
+    hasLocalScript: Boolean(repo.hookSettings?.scripts.setup?.trim())
+  })
+  const defaultTabCommands =
+    sourcePolicy === 'local-only' ? '' : getDefaultTabsTrustContent(yamlHooks)
+  return [effectiveSetup, defaultTabCommands].filter(Boolean).join('\n\n')
 }
 
 export function getDefaultTabsLaunch(

--- a/src/main/hooks-effective-hook-resolution.test.ts
+++ b/src/main/hooks-effective-hook-resolution.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { getDefaultTabsLaunch } from './effective-hook-config'
+import { getDefaultTabsLaunch, getSetupHookTrustContent } from './effective-hook-config'
 import {
   makeHookTestRepo,
   TEST_REPO_ORCA_YAML_PATH,
@@ -398,5 +398,35 @@ describe('getDefaultTabsLaunch', () => {
       tabs: hooks.defaultTabs,
       runCommands: false
     })
+  })
+})
+
+describe('getSetupHookTrustContent', () => {
+  it('binds run-both approval to shared and host-local setup content', () => {
+    const repo = makeHookTestRepo({
+      commandSourcePolicy: 'run-both',
+      scripts: { setup: 'echo local', archive: '' }
+    })
+    const hooks = {
+      scripts: { setup: 'echo shared' },
+      defaultTabs: [{ title: 'Server', command: 'pnpm dev' }]
+    }
+
+    expect(getSetupHookTrustContent(repo, hooks)).toBe(
+      'echo shared\necho local\n\n# defaultTabs[1] Server\npnpm dev'
+    )
+  })
+
+  it('binds local-only approval to the host-local command and excludes shared tab commands', () => {
+    const repo = makeHookTestRepo({
+      commandSourcePolicy: 'local-only',
+      scripts: { setup: 'echo local', archive: '' }
+    })
+    const hooks = {
+      scripts: { setup: 'echo shared' },
+      defaultTabs: [{ title: 'Server', command: 'pnpm dev' }]
+    }
+
+    expect(getSetupHookTrustContent(repo, hooks)).toBe('echo local')
   })
 })

--- a/src/main/hooks.ts
+++ b/src/main/hooks.ts
@@ -118,10 +118,11 @@ export function runHook(
   cwd: string,
   repo: Repo,
   hooksPath?: string,
-  projectRuntime?: ProjectExecutionRuntimeResolution | HookRuntimeTarget
+  projectRuntime?: ProjectExecutionRuntimeResolution | HookRuntimeTarget,
+  /** Bytes an approval was already verified against; skips a re-read that could differ. */
+  verifiedScript?: string
 ): Promise<{ success: boolean; output: string }> {
-  const hooks = getEffectiveHooks(repo, hooksPath)
-  const script = hooks?.scripts[hookName]
+  const script = verifiedScript ?? getEffectiveHooks(repo, hooksPath)?.scripts[hookName]
 
   if (!script) {
     return Promise.resolve({ success: true, output: '' })

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -15,6 +15,7 @@ import type {
 import type {
   CreateWorktreeArgs,
   CreateWorktreeResult,
+  SetupDecision,
   WorktreeCreateBaseFallback
 } from '../../shared/worktree/create-types'
 import type { WorktreeMeta } from '../../shared/worktree/meta-types'
@@ -55,6 +56,7 @@ import { getSetupRunnerEnvVars } from '../setup-hook-env-vars'
 import {
   getDefaultTabsLaunch,
   getEffectiveHooksFromConfig,
+  getSetupHookTrustContent,
   shouldRunSetupForCreate
 } from '../effective-hook-config'
 import { requireSshGitProvider } from '../providers/ssh-git-dispatch'
@@ -1494,7 +1496,8 @@ export async function createRemoteWorktree(
   args: CreateWorktreeArgsWithSystemProvenance,
   repo: Repo,
   store: Store,
-  mainWindow: BrowserWindow
+  mainWindow: BrowserWindow,
+  options?: { resolveSetupDecision?: (trustContent: string) => SetupDecision }
 ): Promise<CreateWorktreeResult> {
   const timing = createWorktreeCreateTimingRecorder()
   const provider = requireSshGitProvider(repo.connectionId!)
@@ -1890,8 +1893,11 @@ export async function createRemoteWorktree(
     await timing.time('prepare_setup', async () => {
       const yamlHooks = await readRemoteOrcaYaml(fsProvider, created.path)
       const hooks = getEffectiveHooksFromConfig(repo, yamlHooks)
+      const setupDecision =
+        options?.resolveSetupDecision?.(getSetupHookTrustContent(repo, yamlHooks)) ??
+        args.setupDecision
       try {
-        defaultTabs = getDefaultTabsLaunch(yamlHooks, repo, args.setupDecision)
+        defaultTabs = getDefaultTabsLaunch(yamlHooks, repo, setupDecision)
       } catch (error) {
         // Why: default tab commands share setup's run policy; without a renderer decision, create the tabs but don't run them.
         console.warn(`[hooks] default tab commands skipped for ${created.path}:`, error)
@@ -1903,7 +1909,7 @@ export async function createRemoteWorktree(
       let shouldLaunchSetup = false
       if (setupScript) {
         try {
-          shouldLaunchSetup = shouldRunSetupForCreate(repo, args.setupDecision)
+          shouldLaunchSetup = shouldRunSetupForCreate(repo, setupDecision)
         } catch (error) {
           // Why: worktree already exists; skip setup rather than fail a successful git create when the branch adds a hook without a renderer decision.
           console.warn(`[hooks] setup hook skipped for ${created.path}:`, error)

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -492,8 +492,23 @@ vi.mock('../setup-hook-env-vars', () => ({
 
 vi.mock('../effective-hook-config', () => ({
   getEffectiveHooksFromConfig: vi.fn().mockReturnValue(null),
-  getDefaultTabCommandTrustContent: vi.fn(
-    (hooks: { scripts?: { setup?: string } } | null) => hooks?.scripts?.setup?.trim() ?? ''
+  getSetupHookTrustContent: vi.fn(
+    (
+      repo: { hookSettings?: { commandSourcePolicy?: string; scripts?: { setup?: string } } },
+      hooks: { scripts?: { setup?: string }; defaultTabs?: { command?: string }[] } | null
+    ) => {
+      const shared = hooks?.scripts?.setup?.trim()
+      const local = repo.hookSettings?.scripts?.setup?.trim()
+      const policy =
+        repo.hookSettings?.commandSourcePolicy ?? (local ? 'local-only' : 'shared-only')
+      if (policy === 'local-only') {
+        return local ?? ''
+      }
+      if (policy === 'run-both') {
+        return [shared, local].filter(Boolean).join('\n')
+      }
+      return shared ?? ''
+    }
   ),
   getDefaultTabsLaunch: vi.fn().mockReturnValue(undefined),
   shouldRunSetupForCreate: vi
@@ -740,7 +755,9 @@ function resetRuntimeTestMocks(): void {
   vi.mocked(shouldRunSetupForCreate).mockReset()
   vi.mocked(shouldRunSetupForCreate).mockImplementation((_repo, decision) => decision === 'run')
   vi.mocked(getEffectiveHooks).mockReturnValue(null)
-  vi.mocked(getEffectiveHooksFromConfig).mockReturnValue(null)
+  vi.mocked(getEffectiveHooksFromConfig).mockImplementation((repo) =>
+    getEffectiveHooks(repo, repo.path)
+  )
   vi.mocked(getDefaultTabsLaunch).mockReturnValue(undefined)
   vi.mocked(loadHooks).mockReturnValue(null)
   vi.mocked(resolveSetupRunnerShell).mockReturnValue(undefined)
@@ -6593,6 +6610,32 @@ describe('OrcaRuntimeService', () => {
     expect(removeWorktree).not.toHaveBeenCalled()
   })
 
+  // Why: folder workspaces never run setup hooks, so a token they could present as
+  // proof must never exist (checkRepoHooks already refuses them outright).
+  it('never mints a setup approval token for a folder workspace', async () => {
+    vi.mocked(hasHooksFile).mockReturnValue(true)
+    vi.mocked(loadHooks).mockReturnValue({ scripts: { setup: 'pnpm install' } })
+    vi.mocked(getEffectiveHooks).mockReturnValue({ scripts: { setup: 'pnpm install' } })
+    const folderStore = {
+      ...store,
+      getRepos: () => [
+        {
+          id: TEST_REPO_ID,
+          path: '/tmp/folder',
+          displayName: 'folder',
+          badgeColor: 'blue',
+          addedAt: 1,
+          kind: 'folder'
+        }
+      ]
+    }
+    const runtime = new OrcaRuntimeService(folderStore as never)
+
+    const hooks = await runtime.getRepoHooks('id:repo-1', 'device-a')
+
+    expect(hooks.setupTrust?.approvalToken).toBeUndefined()
+  })
+
   it('reads SSH repo hooks through the SSH filesystem provider', async () => {
     const remoteStore = {
       ...store,
@@ -6636,7 +6679,7 @@ describe('OrcaRuntimeService', () => {
     expect(getEffectiveHooks).not.toHaveBeenCalled()
   })
 
-  it('hashes only the shared orca.yaml setup script for local run-both hooks', async () => {
+  it('hashes the exact effective setup script for local run-both hooks', async () => {
     vi.mocked(hasHooksFile).mockReturnValue(true)
     vi.mocked(loadHooks).mockReturnValue({ scripts: { setup: 'echo yaml setup' } })
     vi.mocked(getEffectiveHooks).mockReturnValue({
@@ -6663,10 +6706,239 @@ describe('OrcaRuntimeService', () => {
     await expect(runtime.getRepoHooks('id:repo-1')).resolves.toMatchObject({
       hooks: { scripts: { setup: 'echo yaml setup\necho local setup' } },
       setupTrust: {
-        contentHash: '9bc9f57699fe0390d263cca1aec01235cccc8fa5fc87cd87fd51ba1c8483ec84',
-        scriptContent: 'echo yaml setup'
+        contentHash: '7fc980d77b3bfc14ade5c691be25a397d505569f99c17e4e0d217186e86da159',
+        scriptContent: 'echo yaml setup\necho local setup'
       }
     })
+  })
+
+  it('runs exact paired approval and skips an old client without one', async () => {
+    const script = 'node approved.js'
+    const worktreePath = '/tmp/workspaces/paired-approved'
+    vi.mocked(hasHooksFile).mockReturnValue(true)
+    vi.mocked(loadHooks).mockReturnValue({ scripts: { setup: script } })
+    vi.mocked(getEffectiveHooks).mockReturnValue({ scripts: { setup: script } })
+    vi.mocked(getEffectiveHooksFromConfig).mockReturnValue({ scripts: { setup: script } })
+    vi.mocked(shouldRunSetupForCreate).mockImplementation((_repo, decision) => decision === 'run')
+    vi.mocked(runHook).mockResolvedValue({ success: true, output: '' })
+    computeWorktreePathMock.mockReturnValue(worktreePath)
+    ensurePathWithinWorkspaceMock.mockReturnValue(worktreePath)
+    vi.mocked(listWorktrees).mockResolvedValue([
+      {
+        path: worktreePath,
+        head: 'def',
+        branch: 'paired-approved',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+    const runtime = new OrcaRuntimeService(store)
+    const trust = (await runtime.getRepoHooks('id:repo-1', 'device-a')).setupTrust
+    if (!trust?.approvalToken) {
+      throw new Error('missing setup approval challenge')
+    }
+
+    const result = await runtime.createManagedWorktree({
+      repoSelector: 'id:repo-1',
+      name: 'paired-approved',
+      setupDecision: 'run',
+      setupHookApproval: {
+        kind: 'setup',
+        token: trust.approvalToken,
+        contentHash: trust.contentHash
+      },
+      creatorProvenance: { kind: 'paired-device', deviceId: 'device-a' },
+      awaitTerminalProvisioning: true
+    })
+
+    expect(runHook).toHaveBeenCalledWith(
+      'setup',
+      worktreePath,
+      expect.objectContaining({ id: 'repo-1' }),
+      worktreePath,
+      undefined,
+      // The verified bytes travel with the call so execution cannot re-read a changed file.
+      'node approved.js'
+    )
+    expect(result.setupReceipt).toMatchObject({ requested: 'run', state: 'running' })
+
+    const legacyPath = '/tmp/workspaces/paired-old-client'
+    vi.mocked(runHook).mockClear()
+    vi.mocked(createSetupRunnerScript).mockClear()
+    computeWorktreePathMock.mockReturnValue(legacyPath)
+    ensurePathWithinWorkspaceMock.mockReturnValue(legacyPath)
+    vi.mocked(listWorktrees).mockResolvedValue([
+      {
+        path: legacyPath,
+        head: 'ghi',
+        branch: 'paired-old-client',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    const legacyResult = await runtime.createManagedWorktree({
+      repoSelector: 'id:repo-1',
+      name: 'paired-old-client',
+      setupDecision: 'run',
+      creatorProvenance: { kind: 'paired-device', deviceId: 'device-a' },
+      awaitTerminalProvisioning: true
+    })
+
+    expect(runHook).not.toHaveBeenCalled()
+    expect(createSetupRunnerScript).not.toHaveBeenCalled()
+    expect(legacyResult.warning).toContain('approval could not be verified')
+    expect(legacyResult.setupReceipt).toMatchObject({ requested: 'run', state: 'skipped' })
+    expect(legacyResult.setupApprovalRejected).toBe(true)
+    expect(result.setupApprovalRejected).toBeUndefined()
+  })
+
+  // Why: one approval must authorize exactly one operation, so a second create from the
+  // same device cannot ride an already-spent token even when the content still matches.
+  it('refuses a replayed setup approval on a second create from the same device', async () => {
+    const script = 'node approved.js'
+    vi.mocked(hasHooksFile).mockReturnValue(true)
+    vi.mocked(loadHooks).mockReturnValue({ scripts: { setup: script } })
+    vi.mocked(getEffectiveHooks).mockReturnValue({ scripts: { setup: script } })
+    vi.mocked(getEffectiveHooksFromConfig).mockReturnValue({ scripts: { setup: script } })
+    vi.mocked(shouldRunSetupForCreate).mockImplementation((_repo, decision) => decision === 'run')
+    vi.mocked(runHook).mockResolvedValue({ success: true, output: '' })
+    const runtime = new OrcaRuntimeService(store)
+    const trust = (await runtime.getRepoHooks('id:repo-1', 'device-a')).setupTrust
+    if (!trust?.approvalToken) {
+      throw new Error('missing setup approval challenge')
+    }
+    const approval = {
+      kind: 'setup' as const,
+      token: trust.approvalToken,
+      contentHash: trust.contentHash
+    }
+    const createWithApproval = async (name: string, head: string) => {
+      const worktreePath = `/tmp/workspaces/${name}`
+      computeWorktreePathMock.mockReturnValue(worktreePath)
+      ensurePathWithinWorkspaceMock.mockReturnValue(worktreePath)
+      vi.mocked(listWorktrees).mockResolvedValue([
+        { path: worktreePath, head, branch: name, isBare: false, isMainWorktree: false }
+      ])
+      return runtime.createManagedWorktree({
+        repoSelector: 'id:repo-1',
+        name,
+        setupDecision: 'run',
+        setupHookApproval: approval,
+        creatorProvenance: { kind: 'paired-device', deviceId: 'device-a' },
+        awaitTerminalProvisioning: true
+      })
+    }
+
+    const first = await createWithApproval('replay-first', 'aa1')
+    expect(first.setupApprovalRejected).toBeUndefined()
+    expect(runHook).toHaveBeenCalled()
+
+    vi.mocked(runHook).mockClear()
+    vi.mocked(createSetupRunnerScript).mockClear()
+    const replay = await createWithApproval('replay-second', 'aa2')
+
+    expect(runHook).not.toHaveBeenCalled()
+    expect(createSetupRunnerScript).not.toHaveBeenCalled()
+    expect(replay.setupApprovalRejected).toBe(true)
+    expect(replay.setupReceipt).toMatchObject({ requested: 'run', state: 'skipped' })
+    // The second worktree is still created — only the hook is withheld.
+    expect(replay.worktree.path).toBe('/tmp/workspaces/replay-second')
+  })
+
+  // Why: desktop creates omit awaitTerminalProvisioning, so setupReceipt is absent and
+  // the explicit flag is the only refusal signal the paired client can see.
+  it('reports a rejected setup approval without awaitTerminalProvisioning', async () => {
+    const approvedScript = 'node approved-a.js'
+    const hostScript = 'node host-b.js'
+    const worktreePath = '/tmp/workspaces/paired-no-receipt'
+    vi.mocked(hasHooksFile).mockReturnValue(true)
+    vi.mocked(loadHooks).mockReturnValue({ scripts: { setup: approvedScript } })
+    vi.mocked(getEffectiveHooks).mockReturnValue({ scripts: { setup: approvedScript } })
+    computeWorktreePathMock.mockReturnValue(worktreePath)
+    ensurePathWithinWorkspaceMock.mockReturnValue(worktreePath)
+    vi.mocked(listWorktrees).mockResolvedValue([
+      {
+        path: worktreePath,
+        head: 'def',
+        branch: 'paired-no-receipt',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+    const runtime = new OrcaRuntimeService(store)
+    const trust = (await runtime.getRepoHooks('id:repo-1', 'device-a')).setupTrust
+    if (!trust?.approvalToken) {
+      throw new Error('missing setup approval challenge')
+    }
+    vi.mocked(loadHooks).mockReturnValue({ scripts: { setup: hostScript } })
+    vi.mocked(getEffectiveHooksFromConfig).mockReturnValue({ scripts: { setup: hostScript } })
+    vi.mocked(shouldRunSetupForCreate).mockImplementation((_repo, decision) => decision === 'run')
+
+    const result = await runtime.createManagedWorktree({
+      repoSelector: 'id:repo-1',
+      name: 'paired-no-receipt',
+      setupDecision: 'run',
+      setupHookApproval: {
+        kind: 'setup',
+        token: trust.approvalToken,
+        contentHash: trust.contentHash
+      },
+      creatorProvenance: { kind: 'paired-device', deviceId: 'device-a' }
+    })
+
+    expect(runHook).not.toHaveBeenCalled()
+    expect(createSetupRunnerScript).not.toHaveBeenCalled()
+    expect(result.setupReceipt).toBeUndefined()
+    expect(result.setupApprovalRejected).toBe(true)
+    expect(result.warning).toContain('approval could not be verified')
+  })
+
+  it('skips paired setup when host content changes after approval', async () => {
+    const approvedScript = 'node approved-a.js'
+    const hostScript = 'node host-b.js'
+    const worktreePath = '/tmp/workspaces/paired-mutated'
+    vi.mocked(hasHooksFile).mockReturnValue(true)
+    vi.mocked(loadHooks).mockReturnValue({ scripts: { setup: approvedScript } })
+    vi.mocked(getEffectiveHooks).mockReturnValue({ scripts: { setup: approvedScript } })
+    computeWorktreePathMock.mockReturnValue(worktreePath)
+    ensurePathWithinWorkspaceMock.mockReturnValue(worktreePath)
+    vi.mocked(listWorktrees).mockResolvedValue([
+      {
+        path: worktreePath,
+        head: 'def',
+        branch: 'paired-mutated',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+    const runtime = new OrcaRuntimeService(store)
+    const trust = (await runtime.getRepoHooks('id:repo-1', 'device-a')).setupTrust
+    if (!trust?.approvalToken) {
+      throw new Error('missing setup approval challenge')
+    }
+    vi.mocked(loadHooks).mockReturnValue({ scripts: { setup: hostScript } })
+    vi.mocked(getEffectiveHooksFromConfig).mockReturnValue({ scripts: { setup: hostScript } })
+    vi.mocked(shouldRunSetupForCreate).mockImplementation((_repo, decision) => decision === 'run')
+
+    const result = await runtime.createManagedWorktree({
+      repoSelector: 'id:repo-1',
+      name: 'paired-mutated',
+      setupDecision: 'run',
+      setupHookApproval: {
+        kind: 'setup',
+        token: trust.approvalToken,
+        contentHash: trust.contentHash
+      },
+      creatorProvenance: { kind: 'paired-device', deviceId: 'device-a' },
+      awaitTerminalProvisioning: true
+    })
+
+    expect(runHook).not.toHaveBeenCalled()
+    expect(createSetupRunnerScript).not.toHaveBeenCalled()
+    expect(result.warning).toContain('approval could not be verified')
+    expect(result.setupReceipt).toMatchObject({ requested: 'run', state: 'skipped' })
+    expect(result.setupApprovalRejected).toBe(true)
   })
 
   it('uses remote path joins for SSH hook checks and issue-command files', async () => {
@@ -43557,7 +43829,8 @@ describe('OrcaRuntimeService', () => {
       '/tmp/workspaces/runtime-hook-no-pty',
       expect.objectContaining({ id: 'repo-1' }),
       '/tmp/workspaces/runtime-hook-no-pty',
-      undefined
+      undefined,
+      'pnpm worktree:setup'
     )
     expect(result.setupReceipt).toMatchObject({ state: 'running' })
   })

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -331,7 +331,8 @@ import type {
 import type {
   CreateWorktreeResult,
   ForceDeleteWorktreeBranchResult,
-  RemoveWorktreeResult
+  RemoveWorktreeResult,
+  SetupDecision
 } from '../../shared/worktree/create-types'
 import type { WorktreeStartupLaunch } from '../../shared/worktree/launch-types'
 import type {
@@ -1008,11 +1009,17 @@ import {
 } from '../hooks'
 import { createSetupRunnerScript, resolveSetupRunnerShell } from '../worktree-runner-script'
 import {
-  getDefaultTabCommandTrustContent,
   getDefaultTabsLaunch,
+  getEffectiveHooksFromConfig,
   getEffectiveSetupRunPolicy,
+  getSetupHookTrustContent,
   shouldRunSetupForCreate
 } from '../effective-hook-config'
+import type { SetupHookApproval, SetupHookTrust } from '../../shared/setup-hook-approval'
+import {
+  SetupHookApprovalChallenges,
+  withSetupApprovalRejectedWarning
+} from './setup-hook-approval-challenges'
 import { readIssueCommand, writeIssueCommand } from '../issue-command-file'
 import {
   DEFAULT_REPO_BADGE_COLOR,
@@ -2853,6 +2860,7 @@ export type RuntimeRendererReloadFence = Readonly<{
 export class OrcaRuntimeService {
   private readonly runtimeId = randomUUID()
   private readonly startedAt = Date.now()
+  private readonly setupHookApprovalChallenges = new SetupHookApprovalChallenges()
   private readonly store: RuntimeStore | null
   private managedHookReconciliationGeneration = 0
   private managedHookReconciliationTail: Promise<void> = Promise.resolve()
@@ -21969,30 +21977,72 @@ export class OrcaRuntimeService {
 
   private getSetupHookTrustPayload(
     repo: Repo,
-    scriptContentValue: string | undefined
-  ): { contentHash: string; scriptContent: string } | undefined {
+    scriptContentValue: string | undefined,
+    approvalOwnerDeviceId?: string
+  ): SetupHookTrust | undefined {
     const scriptContent = scriptContentValue?.trim()
-    if (!scriptContent || repo.hookSettings?.commandSourcePolicy === 'local-only') {
+    if (!scriptContent) {
       return undefined
     }
+    const contentHash = createHash('sha256').update(scriptContent).digest('hex')
     return {
-      contentHash: createHash('sha256').update(scriptContent).digest('hex'),
-      scriptContent
+      contentHash,
+      scriptContent,
+      ...(approvalOwnerDeviceId
+        ? {
+            approvalToken: this.setupHookApprovalChallenges.issue({
+              repoId: repo.id,
+              deviceId: approvalOwnerDeviceId,
+              contentHash
+            })
+          }
+        : {})
     }
   }
 
-  private getSharedSetupHookTrustPayload(
-    repo: Repo,
-    sharedSetupScript: string | undefined
-  ): { contentHash: string; scriptContent: string } | undefined {
-    if (repo.hookSettings?.commandSourcePolicy === 'local-only') {
-      return undefined
+  private resolvePairedSetupHookDecision(args: {
+    repo: Repo
+    requestedDecision: SetupDecision
+    approval?: SetupHookApproval
+    creatorProvenance?: Worktree['creatorProvenance']
+    trustContent: string
+  }): { decision: SetupDecision; approvalRejected: boolean } {
+    const deviceId =
+      args.creatorProvenance?.kind === 'paired-device' ? args.creatorProvenance.deviceId : undefined
+    if (!deviceId || !args.trustContent) {
+      return { decision: args.requestedDecision, approvalRejected: false }
     }
-    return this.getSetupHookTrustPayload(repo, sharedSetupScript)
+    const contentHash = createHash('sha256').update(args.trustContent.trim()).digest('hex')
+    const consumeApproval = (): boolean =>
+      this.setupHookApprovalChallenges.consume(args.approval, {
+        repoId: args.repo.id,
+        deviceId,
+        contentHash
+      })
+    if (args.requestedDecision === 'skip') {
+      consumeApproval()
+      return { decision: args.requestedDecision, approvalRejected: false }
+    }
+    try {
+      if (!shouldRunSetupForCreate(args.repo, args.requestedDecision)) {
+        consumeApproval()
+        return { decision: args.requestedDecision, approvalRejected: false }
+      }
+    } catch {
+      consumeApproval()
+      return { decision: 'skip', approvalRejected: true }
+    }
+    const approved = consumeApproval()
+    return approved
+      ? { decision: args.requestedDecision, approvalRejected: false }
+      : { decision: 'skip', approvalRejected: true }
   }
 
-  async getRepoHooks(repoSelector: string) {
+  async getRepoHooks(repoSelector: string, requestedApprovalOwnerDeviceId?: string) {
     const repo = await this.resolveRepoSelector(repoSelector)
+    // Why: folder workspaces never run setup hooks, so they must never mint an approval
+    // token a client could present as proof (mirrors the guard in checkRepoHooks).
+    const approvalOwnerDeviceId = isFolderRepo(repo) ? undefined : requestedApprovalOwnerDeviceId
     if (repo.connectionId) {
       const fsProvider = getSshFilesystemProvider(repo.connectionId)
       if (!fsProvider) {
@@ -22011,9 +22061,10 @@ export class OrcaRuntimeService {
           hooks,
           setupRunPolicy: getEffectiveSetupRunPolicy(repo),
           source: hooks ? 'orca.yaml' : null,
-          setupTrust: this.getSharedSetupHookTrustPayload(
+          setupTrust: this.getSetupHookTrustPayload(
             repo,
-            getDefaultTabCommandTrustContent(hooks)
+            getSetupHookTrustContent(repo, hooks),
+            approvalOwnerDeviceId
           )
         }
       } catch {
@@ -22034,14 +22085,15 @@ export class OrcaRuntimeService {
       hooks,
       setupRunPolicy,
       source: hasFile ? 'orca.yaml' : hooks ? 'legacy' : null,
-      setupTrust: this.getSharedSetupHookTrustPayload(
+      setupTrust: this.getSetupHookTrustPayload(
         repo,
-        getDefaultTabCommandTrustContent(sharedHooks)
+        getSetupHookTrustContent(repo, sharedHooks),
+        approvalOwnerDeviceId
       )
     }
   }
 
-  async checkRepoHooks(repoSelector: string) {
+  async checkRepoHooks(repoSelector: string, approvalOwnerDeviceId?: string) {
     const repo = await this.resolveRepoSelector(repoSelector)
     if (isFolderRepo(repo)) {
       return { status: 'ok' as const, hasHooks: false, hooks: null, mayNeedUpdate: false }
@@ -22060,11 +22112,17 @@ export class OrcaRuntimeService {
         if (result.isBinary) {
           return { status: 'ok' as const, hasHooks: false, hooks: null, mayNeedUpdate: false }
         }
+        const hooks = parseOrcaYaml(result.content)
         return {
           status: 'ok' as const,
           hasHooks: true,
-          hooks: parseOrcaYaml(result.content),
-          mayNeedUpdate: false
+          hooks,
+          mayNeedUpdate: false,
+          setupTrust: this.getSetupHookTrustPayload(
+            repo,
+            getSetupHookTrustContent(repo, hooks),
+            approvalOwnerDeviceId
+          )
         }
       } catch (error) {
         return {
@@ -22082,7 +22140,12 @@ export class OrcaRuntimeService {
       status: 'ok' as const,
       hasHooks: has,
       hooks,
-      mayNeedUpdate: has && !hooks && hasUnrecognizedOrcaYamlKeys(repo.path)
+      mayNeedUpdate: has && !hooks && hasUnrecognizedOrcaYamlKeys(repo.path),
+      setupTrust: this.getSetupHookTrustPayload(
+        repo,
+        getSetupHookTrustContent(repo, hooks),
+        approvalOwnerDeviceId
+      )
     }
   }
 
@@ -23231,6 +23294,7 @@ export class OrcaRuntimeService {
     runHooks?: boolean
     activate?: boolean
     setupDecision?: 'run' | 'skip' | 'inherit'
+    setupHookApproval?: SetupHookApproval
     awaitTerminalProvisioning?: boolean
     observeSetupCompletion?: boolean
     createdWithAgent?: TuiAgent
@@ -24022,16 +24086,24 @@ export class OrcaRuntimeService {
 
     let setup: CreateWorktreeResult['setup']
     let warning: string | undefined = includeCopyWarning
-    // Why: CLI-created worktrees do not have a renderer preview to mismatch
-    // against. Trust is granted by the direct CLI invocation (`--run-hooks`),
-    // so loading the setup hook from the created worktree is intentional here.
     const yamlHooks = loadHooks(worktreePath)
-    const hooks = getEffectiveHooks(repo, worktreePath)
+    const hooks = getEffectiveHooksFromConfig(repo, yamlHooks)
     // Why: setupDecision lets mobile/CLI callers control whether the setup
     // script runs. 'skip' suppresses it, 'run' forces it, 'inherit' (default)
     // defers to the repo's orca.yaml setupRunPolicy. runHooks === true maps
     // to 'run' for backwards compatibility with the desktop create flow.
-    const effectiveDecision = args.runHooks ? 'run' : (args.setupDecision ?? 'inherit')
+    const requestedDecision = args.runHooks ? 'run' : (args.setupDecision ?? 'inherit')
+    const approvalResolution = this.resolvePairedSetupHookDecision({
+      repo,
+      requestedDecision,
+      approval: args.setupHookApproval,
+      creatorProvenance: args.creatorProvenance,
+      trustContent: getSetupHookTrustContent(repo, yamlHooks)
+    })
+    const effectiveDecision = approvalResolution.decision
+    if (approvalResolution.approvalRejected) {
+      warning = withSetupApprovalRejectedWarning(warning)
+    }
     let defaultTabs: CreateWorktreeResult['defaultTabs']
     try {
       defaultTabs = getDefaultTabsLaunch(yamlHooks, repo, effectiveDecision)
@@ -24077,7 +24149,9 @@ export class OrcaRuntimeService {
           worktreePath,
           repo,
           worktreePath,
-          this.getLocalGitExecutionOptionArgs(repo)[0]
+          this.getLocalGitExecutionOptionArgs(repo)[0],
+          // Why: run the bytes the approval was verified against, not a fresh disk read.
+          hooks.scripts.setup
         ).then((result) => {
           if (!result.success) {
             console.error(`[hooks] setup hook failed for ${worktreePath}:`, result.output)
@@ -24306,7 +24380,7 @@ export class OrcaRuntimeService {
       ...(args.awaitTerminalProvisioning
         ? {
             setupReceipt: {
-              requested: effectiveDecision,
+              requested: requestedDecision,
               hookFound: Boolean(hooks?.scripts.setup),
               startupPolicy: setup?.waitForAgentStartup
                 ? ('wait-for-setup' as const)
@@ -24326,6 +24400,9 @@ export class OrcaRuntimeService {
         : {}),
       ...(defaultTabs ? { defaultTabs } : {}),
       ...(warning ? { warning } : {}),
+      // Why: setupReceipt only exists for awaitTerminalProvisioning callers, so paired
+      // clients need this flag to warn that an approved hook was refused.
+      ...(approvalResolution.approvalRejected ? { setupApprovalRejected: true } : {}),
       ...(addResult.localBaseRefRefresh
         ? { localBaseRefRefresh: addResult.localBaseRefRefresh }
         : {}),
@@ -24376,12 +24453,14 @@ export class OrcaRuntimeService {
       runHooks?: boolean
       activate?: boolean
       setupDecision?: 'run' | 'skip' | 'inherit'
+      setupHookApproval?: SetupHookApproval
       awaitTerminalProvisioning?: boolean
       observeSetupCompletion?: boolean
       createdWithAgent?: TuiAgent
       pendingFirstAgentMessageRename?: boolean
       automationProvenance?: AutomationWorkspaceProvenance
       cliProvenance?: CliWorkspaceProvenance
+      creatorProvenance?: Worktree['creatorProvenance']
       startup?: WorktreeStartupLaunch
       startupFollowup?: WorktreeStartupFollowup
       startupDraftPaste?: WorktreeStartupDraftPaste
@@ -24399,6 +24478,8 @@ export class OrcaRuntimeService {
       webContents: { send: () => undefined }
     } as unknown as BrowserWindow
 
+    const requestedSetupDecision = args.runHooks ? 'run' : (args.setupDecision ?? 'inherit')
+    let setupApprovalRejected = false
     const result = await createRemoteWorktree(
       {
         repoId: repo.id,
@@ -24410,6 +24491,7 @@ export class OrcaRuntimeService {
         ...(args.branchNameOverride ? { branchNameOverride: args.branchNameOverride } : {}),
         ...(args.runHooks ? { setupDecision: 'run' as const } : {}),
         ...(!args.runHooks && args.setupDecision ? { setupDecision: args.setupDecision } : {}),
+        ...(args.setupHookApproval ? { setupHookApproval: args.setupHookApproval } : {}),
         ...(args.sparseCheckout ? { sparseCheckout: args.sparseCheckout } : {}),
         ...(args.linkedIssue != null ? { linkedIssue: args.linkedIssue } : {}),
         ...(args.linkedPR != null ? { linkedPR: args.linkedPR } : {}),
@@ -24443,7 +24525,20 @@ export class OrcaRuntimeService {
       },
       repo,
       this.store as unknown as Store,
-      headlessWindow
+      headlessWindow,
+      {
+        resolveSetupDecision: (trustContent) => {
+          const resolution = this.resolvePairedSetupHookDecision({
+            repo,
+            requestedDecision: requestedSetupDecision,
+            approval: args.setupHookApproval,
+            creatorProvenance: args.creatorProvenance,
+            trustContent
+          })
+          setupApprovalRejected = resolution.approvalRejected
+          return resolution.decision
+        }
+      }
     )
 
     if (args.comment !== undefined) {
@@ -24457,6 +24552,9 @@ export class OrcaRuntimeService {
 
     const shouldActivate = args.activate === true || args.runHooks === true
     let warning = result.warning
+    if (setupApprovalRejected) {
+      warning = withSetupApprovalRejectedWarning(warning)
+    }
     let didSpawnStartup = false
     // Why: same no-double-spawn contract as the local path — once runtime
     // provisions setup, omit it from activation and the RPC result.
@@ -24658,15 +24756,16 @@ export class OrcaRuntimeService {
           }
         : resultForRenderer
 
-    const requestedSetupDecision = args.runHooks ? 'run' : (args.setupDecision ?? 'inherit')
     const setupReceipt = {
       requested: requestedSetupDecision,
-      hookFound: Boolean(result.setup),
+      // Why: a refused approval forces `skip`, so `result.setup` is empty even though a hook
+      // exists — report it as found-but-skipped rather than 'not_configured'.
+      hookFound: Boolean(result.setup) || setupApprovalRejected,
       startupPolicy: result.setup?.waitForAgentStartup
         ? ('wait-for-setup' as const)
         : ('start-immediately' as const),
       state:
-        requestedSetupDecision === 'skip'
+        requestedSetupDecision === 'skip' || setupApprovalRejected
           ? ('skipped' as const)
           : !result.setup
             ? ('not_configured' as const)
@@ -24678,7 +24777,12 @@ export class OrcaRuntimeService {
     const resultWithSetupReceipt = args.awaitTerminalProvisioning
       ? { ...resultWithStartupTerminal, setupReceipt }
       : resultWithStartupTerminal
-    return warning ? { ...resultWithSetupReceipt, warning } : resultWithSetupReceipt
+    // Why: setupReceipt only exists for awaitTerminalProvisioning callers, so paired
+    // clients need this flag to warn that an approved hook was refused.
+    const resultWithApproval = setupApprovalRejected
+      ? { ...resultWithSetupReceipt, setupApprovalRejected: true }
+      : resultWithSetupReceipt
+    return warning ? { ...resultWithApproval, warning } : resultWithApproval
   }
 
   /**

--- a/src/main/runtime/remote-setup-hook-approval-wire.integration.test.ts
+++ b/src/main/runtime/remote-setup-hook-approval-wire.integration.test.ts
@@ -1,0 +1,122 @@
+import { createHash } from 'node:crypto'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { getDefaultRepoHookSettings } from '../../shared/constants'
+import { parsePairingCode } from '../../shared/pairing'
+import { RemoteRuntimeRequestConnection } from '../../shared/remote-runtime-request-connection'
+import type { Repo } from '../../shared/repo-types'
+import type { OrcaRuntimeService } from './orca-runtime'
+import { OrcaRuntimeRpcServer } from './runtime-rpc'
+
+const REQUEST_TIMEOUT_MS = 5_000
+
+type SetupHookApproval = {
+  kind: 'setup'
+  token: string
+  contentHash: string
+}
+
+function hash(content: string): string {
+  return createHash('sha256').update(content.trim()).digest('hex')
+}
+
+describe('remote setup-hook approval wire binding', () => {
+  it('does not execute host content that differs from the paired-client approval', async () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-setup-approval-wire-'))
+    const markerPath = join(userDataPath, 'executed-hook.txt')
+    const repo: Repo = {
+      id: 'repo-1',
+      path: join(userDataPath, 'repo'),
+      displayName: 'repo',
+      badgeColor: 'blue',
+      addedAt: 1,
+      hookSettings: getDefaultRepoHookSettings(),
+      worktreeBaseRef: 'main',
+      kind: 'git'
+    }
+    const approvedContent = 'node approved-a.js'
+    const hostContent = 'node host-b.js'
+    const approval: SetupHookApproval = {
+      kind: 'setup',
+      token: 'approval-for-a',
+      contentHash: hash(approvedContent)
+    }
+    let forwardedApproval: SetupHookApproval | undefined
+    const runtime = {
+      getRuntimeId: () => 'setup-approval-runtime',
+      getStartedAt: () => 1,
+      cleanupSubscriptionsForConnection: () => {},
+      cancelMobileDictationForConnection: () => {},
+      onClientDisconnected: () => {},
+      showRepo: () => repo,
+      dedupeWorktreeCreate: <T>(
+        _repo: string,
+        _mutationId: string | undefined,
+        run: () => Promise<T>
+      ) => run(),
+      createManagedWorktree: async (args: Record<string, unknown>) => {
+        forwardedApproval = args.setupHookApproval as SetupHookApproval | undefined
+        // Mirrors the legacy host: absent proof means setupDecision alone authorizes execution.
+        if (!forwardedApproval || forwardedApproval.contentHash === hash(hostContent)) {
+          writeFileSync(markerPath, hostContent)
+        }
+        return {
+          worktree: {
+            id: `${repo.id}::created`,
+            repoId: repo.id,
+            path: join(userDataPath, 'created'),
+            branch: 'created',
+            displayName: 'created',
+            isMainWorktree: false
+          }
+        }
+      }
+    } as unknown as OrcaRuntimeService
+    const server = new OrcaRuntimeRpcServer({
+      runtime,
+      userDataPath,
+      enableWebSocket: true,
+      wsPort: 0
+    })
+
+    await server.start()
+    try {
+      const offer = server.createPairingOffer({ name: 'paired-client', scope: 'runtime' })
+      if (!offer.available) {
+        throw new Error('pairing unavailable')
+      }
+      const pairing = parsePairingCode(offer.pairingUrl)
+      if (!pairing) {
+        throw new Error('invalid pairing')
+      }
+      const connection = new RemoteRuntimeRequestConnection(pairing)
+      try {
+        const response = await connection.request(
+          'worktree.create',
+          {
+            repo: repo.id,
+            name: 'created',
+            setupDecision: 'run',
+            setupHookApproval: approval
+          },
+          REQUEST_TIMEOUT_MS
+        )
+
+        expect(response).toMatchObject({ ok: true })
+        expect(hash(hostContent)).not.toBe(approval.contentHash)
+        expect.soft(forwardedApproval).toEqual(approval)
+        expect.soft(existsSync(markerPath)).toBe(false)
+      } finally {
+        connection.close()
+      }
+    } finally {
+      await server.stop()
+      if (existsSync(markerPath)) {
+        expect(readFileSync(markerPath, 'utf8')).toBe(hostContent)
+      }
+      rmSync(userDataPath, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/main/runtime/rpc/methods/repo.test.ts
+++ b/src/main/runtime/rpc/methods/repo.test.ts
@@ -10,6 +10,24 @@ function makeRequest(method: string, params?: unknown): RpcRequest {
 }
 
 describe('repo RPC methods', () => {
+  it('binds hook trust challenges to the authenticated paired device', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      getRepoHooks: vi.fn().mockResolvedValue({ hasHooksFile: false, hooks: null })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: REPO_METHODS })
+    const replies: string[] = []
+
+    await dispatcher.dispatchStreaming(
+      makeRequest('repo.hooks', { repo: 'repo-1' }),
+      (reply) => replies.push(reply),
+      { clientKind: 'runtime', pairedDeviceId: 'device-a' }
+    )
+
+    expect(replies).toHaveLength(1)
+    expect(runtime.getRepoHooks).toHaveBeenCalledWith('repo-1', 'device-a')
+  })
+
   it('projects inherited visibility for old clients but preserves inheritance for capable clients', async () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',
@@ -300,12 +318,12 @@ describe('repo RPC methods', () => {
       })
     )
 
-    expect(runtime.getRepoHooks).toHaveBeenCalledWith('repo-1')
+    expect(runtime.getRepoHooks).toHaveBeenCalledWith('repo-1', undefined)
     expect(hooksResponse).toMatchObject({
       ok: true,
       result: { setupTrust: { contentHash: 'hash-1', scriptContent: 'pnpm install' } }
     })
-    expect(runtime.checkRepoHooks).toHaveBeenCalledWith('repo-1')
+    expect(runtime.checkRepoHooks).toHaveBeenCalledWith('repo-1', undefined)
     expect(runtime.inspectRepoSetupScriptImports).toHaveBeenCalledWith('repo-1')
     expect(runtime.readRepoIssueCommand).toHaveBeenCalledWith('repo-1')
     expect(runtime.writeRepoIssueCommand).toHaveBeenCalledWith('repo-1', 'Fix it')

--- a/src/main/runtime/rpc/methods/repo.ts
+++ b/src/main/runtime/rpc/methods/repo.ts
@@ -273,12 +273,14 @@ export const REPO_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'repo.hooks',
     params: RepoSelector,
-    handler: async (params, { runtime }) => runtime.getRepoHooks(params.repo)
+    handler: async (params, { runtime, pairedDeviceId }) =>
+      runtime.getRepoHooks(params.repo, pairedDeviceId)
   }),
   defineMethod({
     name: 'repo.hooksCheck',
     params: RepoSelector,
-    handler: async (params, { runtime }) => runtime.checkRepoHooks(params.repo)
+    handler: async (params, { runtime, pairedDeviceId }) =>
+      runtime.checkRepoHooks(params.repo, pairedDeviceId)
   }),
   defineMethod({
     name: 'repo.setupScriptImports',

--- a/src/main/runtime/rpc/methods/worktree-create-args.ts
+++ b/src/main/runtime/rpc/methods/worktree-create-args.ts
@@ -45,6 +45,7 @@ export function buildManagedWorktreeCreateArgs(
     runHooks: params.runHooks === true,
     activate: params.activate === true,
     setupDecision: params.setupDecision,
+    setupHookApproval: params.setupHookApproval,
     createdWithAgent: params.createdWithAgent ?? params.startupAgent,
     ...provenance,
     startup: params.startupCommand

--- a/src/main/runtime/rpc/methods/worktree-schemas.test.ts
+++ b/src/main/runtime/rpc/methods/worktree-schemas.test.ts
@@ -32,6 +32,26 @@ describe('worktree RPC schemas', () => {
     expect(parsed.success).toBe(false)
   })
 
+  it('accepts exact setup approvals and normalizes malformed legacy values to absent', () => {
+    const approval = {
+      kind: 'setup' as const,
+      token: 'operation-token',
+      contentHash: 'a'.repeat(64)
+    }
+
+    expect(
+      WorktreeCreate.parse({ repo: 'repo-1', name: 'approved', setupHookApproval: approval })
+        .setupHookApproval
+    ).toEqual(approval)
+    expect(
+      WorktreeCreate.parse({
+        repo: 'repo-1',
+        name: 'malformed',
+        setupHookApproval: { ...approval, contentHash: 'not-a-hash' }
+      }).setupHookApproval
+    ).toBeUndefined()
+  })
+
   it('normalizes durable Jira linked-item metadata and rejects provider mismatches', () => {
     const linkedWorkItem = {
       provider: 'jira',

--- a/src/main/runtime/rpc/methods/worktree-schemas.ts
+++ b/src/main/runtime/rpc/methods/worktree-schemas.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { parseSetupHookApproval } from '../../../../shared/setup-hook-approval'
 import { isTuiAgent } from '../../../../shared/tui-agent-config'
 import type { TuiAgent } from '../../../../shared/tui-agent'
 import { workspaceSourceSchema } from '../../../../shared/telemetry-events'
@@ -169,6 +170,10 @@ export const WorktreeCreate = z
         typeof v === 'string' && (v === 'run' || v === 'skip' || v === 'inherit') ? v : undefined
       )
       .pipe(z.union([z.enum(['run', 'skip', 'inherit']), z.undefined()]))
+      .optional(),
+    setupHookApproval: z
+      .unknown()
+      .transform((value) => parseSetupHookApproval(value))
       .optional(),
     // Why: some clients (e.g. desktop) pass a pre-built launch command so the
     // first terminal pane launches the selected agent instead of an idle shell.

--- a/src/main/runtime/setup-hook-approval-challenges.test.ts
+++ b/src/main/runtime/setup-hook-approval-challenges.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest'
+import { SetupHookApprovalChallenges } from './setup-hook-approval-challenges'
+
+const HASH_A = 'a'.repeat(64)
+const HASH_B = 'b'.repeat(64)
+const HASH_C = 'c'.repeat(64)
+
+describe('SetupHookApprovalChallenges', () => {
+  it('consumes an exact owner-bound challenge once', () => {
+    const challenges = new SetupHookApprovalChallenges()
+    const token = challenges.issue({ repoId: 'repo-a', deviceId: 'device-a', contentHash: HASH_A })
+    const approval = { kind: 'setup' as const, token, contentHash: HASH_A }
+
+    expect(
+      challenges.consume(approval, {
+        repoId: 'repo-a',
+        deviceId: 'device-a',
+        contentHash: HASH_A
+      })
+    ).toBe(true)
+    expect(
+      challenges.consume(approval, {
+        repoId: 'repo-a',
+        deviceId: 'device-a',
+        contentHash: HASH_A
+      })
+    ).toBe(false)
+  })
+
+  it.each([
+    ['repo', { repoId: 'repo-b', deviceId: 'device-a', contentHash: HASH_A }],
+    ['device', { repoId: 'repo-a', deviceId: 'device-b', contentHash: HASH_A }],
+    ['content', { repoId: 'repo-a', deviceId: 'device-a', contentHash: HASH_B }]
+  ])('rejects %s replay', (_label, expected) => {
+    const challenges = new SetupHookApprovalChallenges()
+    const token = challenges.issue({ repoId: 'repo-a', deviceId: 'device-a', contentHash: HASH_A })
+
+    expect(challenges.consume({ kind: 'setup', token, contentHash: HASH_A }, expected)).toBe(false)
+  })
+
+  it('rejects stale challenges', () => {
+    let now = 1
+    const challenges = new SetupHookApprovalChallenges(10, 10, () => now)
+    const token = challenges.issue({ repoId: 'repo-a', deviceId: 'device-a', contentHash: HASH_A })
+    now = 12
+
+    expect(
+      challenges.consume(
+        { kind: 'setup', token, contentHash: HASH_A },
+        { repoId: 'repo-a', deviceId: 'device-a', contentHash: HASH_A }
+      )
+    ).toBe(false)
+  })
+
+  it('rejects an approval whose claimed hash disagrees with the issued challenge', () => {
+    const challenges = new SetupHookApprovalChallenges()
+    const token = challenges.issue({ repoId: 'repo-a', deviceId: 'device-a', contentHash: HASH_A })
+
+    // Client claims it approved the content the host is about to run (B) with a token minted for A.
+    expect(
+      challenges.consume(
+        { kind: 'setup', token, contentHash: HASH_B },
+        { repoId: 'repo-a', deviceId: 'device-a', contentHash: HASH_B }
+      )
+    ).toBe(false)
+  })
+
+  it('fails closed when capacity eviction drops a pending challenge', () => {
+    const challenges = new SetupHookApprovalChallenges(10_000, 2)
+    const evicted = challenges.issue({
+      repoId: 'repo-a',
+      deviceId: 'device-a',
+      contentHash: HASH_A
+    })
+    challenges.issue({ repoId: 'repo-a', deviceId: 'device-a', contentHash: HASH_B })
+    const kept = challenges.issue({ repoId: 'repo-a', deviceId: 'device-a', contentHash: HASH_C })
+
+    expect(
+      challenges.consume(
+        { kind: 'setup', token: evicted, contentHash: HASH_A },
+        { repoId: 'repo-a', deviceId: 'device-a', contentHash: HASH_A }
+      )
+    ).toBe(false)
+    expect(
+      challenges.consume(
+        { kind: 'setup', token: kept, contentHash: HASH_C },
+        { repoId: 'repo-a', deviceId: 'device-a', contentHash: HASH_C }
+      )
+    ).toBe(true)
+  })
+
+  it('reuses one challenge for repeated reads of the same repo, device and content', () => {
+    let now = 1
+    const challenges = new SetupHookApprovalChallenges(10, 2, () => now)
+    const args = { repoId: 'repo-a', deviceId: 'device-a', contentHash: HASH_A }
+
+    const first = challenges.issue(args)
+    now = 6
+    // A later read extends the window the host already vouched for instead of minting again.
+    expect(challenges.issue(args)).toBe(first)
+    now = 12
+
+    expect(challenges.consume({ kind: 'setup', token: first, contentHash: HASH_A }, args)).toBe(
+      true
+    )
+  })
+
+  it('does not let one device evict another device pending approval', () => {
+    const challenges = new SetupHookApprovalChallenges(10_000, 2)
+    const honest = challenges.issue({ repoId: 'repo-a', deviceId: 'device-a', contentHash: HASH_A })
+    // device-b crowds the map; only its own oldest entry may be dropped.
+    challenges.issue({ repoId: 'repo-a', deviceId: 'device-b', contentHash: HASH_B })
+    challenges.issue({ repoId: 'repo-a', deviceId: 'device-b', contentHash: HASH_C })
+
+    expect(
+      challenges.consume(
+        { kind: 'setup', token: honest, contentHash: HASH_A },
+        { repoId: 'repo-a', deviceId: 'device-a', contentHash: HASH_A }
+      )
+    ).toBe(true)
+  })
+
+  it('rejects missing proof and tokens from another runtime generation', () => {
+    const oldRuntime = new SetupHookApprovalChallenges()
+    const newRuntime = new SetupHookApprovalChallenges()
+    const token = oldRuntime.issue({
+      repoId: 'repo-a',
+      deviceId: 'device-a',
+      contentHash: HASH_A
+    })
+    const expected = { repoId: 'repo-a', deviceId: 'device-a', contentHash: HASH_A }
+
+    expect(newRuntime.consume(undefined, expected)).toBe(false)
+    expect(newRuntime.consume({ kind: 'setup', token, contentHash: HASH_A }, expected)).toBe(false)
+  })
+})

--- a/src/main/runtime/setup-hook-approval-challenges.ts
+++ b/src/main/runtime/setup-hook-approval-challenges.ts
@@ -1,0 +1,115 @@
+import { randomUUID } from 'node:crypto'
+import type { SetupHookApproval } from '../../shared/setup-hook-approval'
+
+const DEFAULT_TTL_MS = 15 * 60_000
+const DEFAULT_MAX_CHALLENGES = 1_024
+
+export const SETUP_APPROVAL_REJECTED_WARNING =
+  'orca.yaml setup hook skipped because the paired-client approval could not be verified.'
+
+/** Keeps the refusal visible to old clients that only surface `warning`. */
+export function withSetupApprovalRejectedWarning(warning: string | undefined): string {
+  return warning ? `${warning} ${SETUP_APPROVAL_REJECTED_WARNING}` : SETUP_APPROVAL_REJECTED_WARNING
+}
+
+type SetupHookApprovalChallenge = {
+  repoId: string
+  deviceId: string
+  contentHash: string
+  expiresAt: number
+}
+
+/** Why: JSON encoding keeps the three parts unambiguous, so no repo or device id can
+ * impersonate another binding by embedding the separator. */
+function bindingKey(args: { repoId: string; deviceId: string; contentHash: string }): string {
+  return JSON.stringify([args.repoId, args.deviceId, args.contentHash])
+}
+
+export class SetupHookApprovalChallenges {
+  private readonly challenges = new Map<string, SetupHookApprovalChallenge>()
+  private readonly tokensByBinding = new Map<string, string>()
+
+  constructor(
+    private readonly ttlMs = DEFAULT_TTL_MS,
+    private readonly maxChallenges = DEFAULT_MAX_CHALLENGES,
+    private readonly now: () => number = Date.now
+  ) {}
+
+  issue(args: { repoId: string; deviceId: string; contentHash: string }): string {
+    this.prune()
+    const binding = bindingKey(args)
+    // Why: clients re-read repo.hooks on every prompt, so minting per read would let
+    // routine polling evict a still-valid approval. An identical binding reuses its
+    // token and only extends the window the host already vouched for.
+    const existing = this.tokensByBinding.get(binding)
+    const live = existing ? this.challenges.get(existing) : undefined
+    if (existing && live) {
+      live.expiresAt = this.now() + this.ttlMs
+      return existing
+    }
+    this.evictForCapacity(args.deviceId)
+    const token = randomUUID()
+    this.challenges.set(token, { ...args, expiresAt: this.now() + this.ttlMs })
+    this.tokensByBinding.set(binding, token)
+    return token
+  }
+
+  consume(
+    approval: SetupHookApproval | undefined,
+    expected: { repoId: string; deviceId: string; contentHash: string }
+  ): boolean {
+    if (!approval) {
+      return false
+    }
+    const challenge = this.challenges.get(approval.token)
+    this.delete(approval.token)
+    return Boolean(
+      challenge &&
+      challenge.expiresAt >= this.now() &&
+      approval.kind === 'setup' &&
+      approval.contentHash === challenge.contentHash &&
+      challenge.repoId === expected.repoId &&
+      challenge.deviceId === expected.deviceId &&
+      challenge.contentHash === expected.contentHash
+    )
+  }
+
+  private evictForCapacity(deviceId: string): void {
+    while (this.challenges.size >= this.maxChallenges) {
+      // Why: charge capacity pressure to the crowding device first, so one paired
+      // device cannot evict another device's pending approval and force a skip.
+      const victim = this.oldestTokenForDevice(deviceId) ?? this.challenges.keys().next().value
+      if (victim === undefined) {
+        return
+      }
+      this.delete(victim)
+    }
+  }
+
+  /** Insertion order is issue order, so the first match is that device's oldest. */
+  private oldestTokenForDevice(deviceId: string): string | undefined {
+    for (const [token, challenge] of this.challenges) {
+      if (challenge.deviceId === deviceId) {
+        return token
+      }
+    }
+    return undefined
+  }
+
+  private delete(token: string): void {
+    const challenge = this.challenges.get(token)
+    this.challenges.delete(token)
+    if (challenge && this.tokensByBinding.get(bindingKey(challenge)) === token) {
+      this.tokensByBinding.delete(bindingKey(challenge))
+    }
+  }
+
+  private prune(): void {
+    const now = this.now()
+    for (const [token, challenge] of this.challenges) {
+      if (challenge.expiresAt < now) {
+        this.delete(token)
+      }
+    }
+  }
+}

--- a/src/renderer/src/components/terminal-pane/terminal-agent-session-fork-workspace.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-agent-session-fork-workspace.ts
@@ -1,0 +1,59 @@
+import type { AppState } from '@/store/types'
+import { ensureSetupHookConfirmed } from '@/lib/ensure-hooks-confirmed'
+import { getSettingsForRepoRuntimeOwner } from '@/lib/repo-runtime-owner'
+import { getRepoExecutionHostId } from '../../../../shared/execution-host'
+import type { Repo } from '../../../../shared/repo-types'
+import type { TuiAgent } from '../../../../shared/tui-agent'
+
+/**
+ * Create the workspace behind a session fork.
+ *
+ * Why: a fork is a real create, so it needs the same per-operation setup approval as
+ * every other create path — an authoritative host refuses an unproven hook, which
+ * would otherwise strand forks with no setup and no stated reason.
+ */
+export async function createAgentSessionForkWorkspace(args: {
+  store: AppState
+  repoId: string
+  repo: Repo | undefined
+  forkName: string
+  sourceBranch: string
+  displayName: string
+  agent: TuiAgent | null
+}): ReturnType<AppState['createWorktree']> {
+  const repoOwnerSettings = getSettingsForRepoRuntimeOwner(args.store, args.repoId)
+  const setupTrust = await ensureSetupHookConfirmed(
+    args.store,
+    args.repoId,
+    args.repo ? getRepoExecutionHostId(args.repo) : undefined,
+    repoOwnerSettings?.activeRuntimeEnvironmentId
+  )
+  return args.store.createWorktree(
+    args.repoId,
+    args.forkName,
+    args.sourceBranch,
+    setupTrust.decision === 'skip' ? 'skip' : 'inherit',
+    undefined,
+    'terminal_context_menu',
+    args.displayName,
+    undefined,
+    undefined,
+    undefined,
+    args.agent ?? undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    setupTrust.approval ? { setupHookApproval: setupTrust.approval } : undefined
+  )
+}

--- a/src/renderer/src/components/terminal-pane/terminal-agent-session-fork.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-agent-session-fork.test.ts
@@ -12,6 +12,10 @@ const mockToast = {
 }
 const mockWriteClipboardText = vi.fn(async () => undefined)
 const mockMarkTrusted = vi.fn(async () => undefined)
+const mockEnsureSetupHookConfirmed = vi.fn(async () => ({
+  decision: 'run' as const,
+  approvalRequired: false
+}))
 const LEAF_ID = '11111111-1111-4111-8111-111111111111'
 
 const store = {
@@ -52,6 +56,10 @@ vi.mock('@/lib/worktree-activation', () => ({
 
 vi.mock('sonner', () => ({
   toast: mockToast
+}))
+
+vi.mock('@/lib/ensure-hooks-confirmed', () => ({
+  ensureSetupHookConfirmed: mockEnsureSetupHookConfirmed
 }))
 
 function makePane(capturedText: string): ManagedPane {
@@ -130,7 +138,7 @@ describe('forkAgentSessionFromPane', () => {
       groupId: 'group-1'
     })
 
-    expect(mockCreateWorktree).toHaveBeenCalledWith(
+    expect(mockCreateWorktree.mock.calls[0].slice(0, 11)).toEqual([
       'repo-1',
       'auth-feature-fork',
       'feature/auth',
@@ -142,7 +150,9 @@ describe('forkAgentSessionFromPane', () => {
       undefined,
       undefined,
       'codex'
-    )
+    ])
+    // Nothing to approve here, so no approval rides along.
+    expect(mockCreateWorktree.mock.calls[0].at(-1)).toBeUndefined()
 
     expect(mockLaunchAgentInNewTab).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -159,6 +169,46 @@ describe('forkAgentSessionFromPane', () => {
     expect(mockToast.success).toHaveBeenCalledWith(
       'Top-level session fork opened in a new workspace'
     )
+  })
+
+  it('forwards the host-issued setup approval so the fork can run its setup hook', async () => {
+    const approval = { kind: 'setup' as const, token: 'tok-fork', contentHash: 'f'.repeat(64) }
+    mockEnsureSetupHookConfirmed.mockResolvedValueOnce({
+      decision: 'run',
+      approvalRequired: true,
+      approval
+    } as never)
+    const { forkAgentSessionFromPane } = await import('./terminal-agent-session-fork')
+
+    await forkAgentSessionFromPane({
+      pane: makePane('User: compare OAuth options'),
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      groupId: null
+    })
+
+    const call = mockCreateWorktree.mock.calls[0]
+    expect(call[3]).toBe('inherit')
+    expect(call.at(-1)).toEqual({ setupHookApproval: approval })
+  })
+
+  it('skips the fork setup hook when the trust check is declined', async () => {
+    mockEnsureSetupHookConfirmed.mockResolvedValueOnce({
+      decision: 'skip',
+      approvalRequired: true
+    } as never)
+    const { forkAgentSessionFromPane } = await import('./terminal-agent-session-fork')
+
+    await forkAgentSessionFromPane({
+      pane: makePane('User: compare OAuth options'),
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      groupId: null
+    })
+
+    const call = mockCreateWorktree.mock.calls[0]
+    expect(call[3]).toBe('skip')
+    expect(call.at(-1)).toBeUndefined()
   })
 
   it('pre-marks trust for the created fork workspace before launching a trusted agent', async () => {
@@ -332,7 +382,7 @@ describe('forkAgentSessionFromPane', () => {
       groupId: null
     })
 
-    expect(mockCreateWorktree).toHaveBeenCalledWith(
+    expect(mockCreateWorktree.mock.calls[0].slice(0, 11)).toEqual([
       'repo-1',
       'auth-feature-fork',
       'feature/auth',
@@ -344,7 +394,7 @@ describe('forkAgentSessionFromPane', () => {
       undefined,
       undefined,
       undefined
-    )
+    ])
     expect(mockLaunchAgentInNewTab).not.toHaveBeenCalled()
     expect(mockActivateAndRevealWorktree).toHaveBeenCalledWith('wt-fork', {
       sidebarRevealBehavior: 'auto'

--- a/src/renderer/src/components/terminal-pane/terminal-agent-session-fork.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-agent-session-fork.ts
@@ -15,6 +15,7 @@ import type { TuiAgent } from '../../../../shared/tui-agent'
 import { isWslUncPath } from '../../../../shared/wsl-paths'
 import type { ProjectExecutionRuntimeResolution } from '../../../../shared/project-execution-runtime'
 import { getLocalProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
+import { createAgentSessionForkWorkspace } from './terminal-agent-session-fork-workspace'
 import { translate } from '@/i18n/i18n'
 
 type ForkAgentSessionFromPaneArgs = {
@@ -237,19 +238,15 @@ export async function startAgentSessionFork(fork: PreparedAgentSessionFork): Pro
   const forkName = buildForkWorkspaceName(sourceWorktree.displayName || sourceBranch)
   let created: Awaited<ReturnType<typeof store.createWorktree>>
   try {
-    created = await store.createWorktree(
-      sourceWorktree.repoId,
+    created = await createAgentSessionForkWorkspace({
+      store,
+      repoId: sourceWorktree.repoId,
+      repo: sourceRepo,
       forkName,
       sourceBranch,
-      'inherit',
-      undefined,
-      'terminal_context_menu',
-      `Fork of ${sourceWorktree.displayName || forkName}`,
-      undefined,
-      undefined,
-      undefined,
-      fork.agent ?? undefined
-    )
+      displayName: `Fork of ${sourceWorktree.displayName || forkName}`,
+      agent: fork.agent
+    })
   } catch (error) {
     toast.error(
       error instanceof Error

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -182,6 +182,7 @@ import { CONTEXTUAL_TOUR_ENABLE_AUTO_WORKSPACE_NAME_EVENT } from '@/components/c
 import {
   confirmRuntimeIssueCommandRead,
   ensureHooksConfirmed,
+  ensureSetupHookConfirmed,
   readAndConfirmRuntimeIssueCommand
 } from '@/lib/ensure-hooks-confirmed'
 import { normalizeSparseDirectoryLines, sparseDirectoriesMatch } from '@/lib/sparse-paths'
@@ -3740,21 +3741,21 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
 
       const setupTrustSettlement = await settleComposerSubmit(
         selectedRepoIsGit
-          ? ensureHooksConfirmed(
+          ? ensureSetupHookConfirmed(
               useAppStore.getState(),
               repoId,
-              'setup',
               selectedRepoExecutionHostId ?? undefined,
               undefined,
               isSubmissionCancelled
             )
-          : Promise.resolve<'skip'>('skip'),
+          : Promise.resolve({ decision: 'skip' as const, approvalRequired: false }),
         isSubmissionCancelled
       )
       if (setupTrustSettlement.status === 'cancelled') {
         return
       }
-      const setupTrustDecision = setupTrustSettlement.value
+      const setupTrust = setupTrustSettlement.value
+      const setupTrustDecision = setupTrust.decision
       const effectiveSetupDecision: SetupDecision =
         setupTrustDecision === 'skip'
           ? 'skip'
@@ -3923,6 +3924,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
           linkedWorkItem: toFolderWorkspaceLinkedTask(submitLinkedWorkItem),
           linkedTaskSourceContext: taskSourceContext,
           nameWasGenerated,
+          ...(setupTrust.approval ? { setupHookApproval: setupTrust.approval } : {}),
           ...(!backendStartup && startupPlan?.draftPrompt
             ? { startupDraft: startupPlan.draftPrompt }
             : {})
@@ -4275,21 +4277,21 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
 
         const setupTrustSettlement = await settleComposerSubmit(
           selectedRepoIsGit
-            ? ensureHooksConfirmed(
+            ? ensureSetupHookConfirmed(
                 useAppStore.getState(),
                 repoId,
-                'setup',
                 selectedRepoExecutionHostId ?? undefined,
                 undefined,
                 isSubmissionCancelled
               )
-            : Promise.resolve<'skip'>('skip'),
+            : Promise.resolve({ decision: 'skip' as const, approvalRequired: false }),
           isSubmissionCancelled
         )
         if (setupTrustSettlement.status === 'cancelled') {
           return
         }
-        const trustDecision = setupTrustSettlement.value
+        const setupTrust = setupTrustSettlement.value
+        const trustDecision = setupTrust.decision
         const effectiveSetupDecision: SetupDecision =
           trustDecision === 'skip'
             ? 'skip'
@@ -4549,6 +4551,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
             ? { compareBaseRef: submitCompareBaseRef }
             : {}),
           setupDecision: effectiveSetupDecision,
+          ...(setupTrust.approval ? { setupHookApproval: setupTrust.approval } : {}),
           ...(selectedRepoIsGit && sparseEnabled
             ? {
                 sparseCheckout: {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -336,6 +336,11 @@
           "runtimeScopeForbiddenDescription": "Workspaces are unavailable on a mobile-scope pairing. Reconnect using the browser access link from Settings → Runtime Environments → Share this Orca server.",
           "a17f4d2e93": "Could not update this workspace.",
           "preservedBranchCleanupHostAmbiguous": "Multiple preserved branch cleanups are pending for \"{{value0}}\"; specify the host.",
+          "create": {
+            "setupHookSkipped": "Setup hook skipped",
+            "setupApprovalUnverified": "The remote Orca server could not verify your approval, so the setup hook did not run.",
+            "updateRemoteForSetupHooks": "Update the remote Orca server to run approved setup hooks."
+          },
           "metadata": {
             "worktree": {
               "meta": {

--- a/src/renderer/src/lib/ensure-hooks-confirmed.test.ts
+++ b/src/renderer/src/lib/ensure-hooks-confirmed.test.ts
@@ -4,6 +4,7 @@ import type { PersistedTrustedOrcaHooks } from '../../../shared/orca-yaml-hook-t
 import {
   __resetTrustPromptChainForTests,
   ensureHooksConfirmed,
+  ensureSetupHookConfirmed,
   readAndConfirmRuntimeIssueCommand
 } from './ensure-hooks-confirmed'
 import { hashOrcaHookScript } from './orca-hook-trust'
@@ -578,5 +579,122 @@ describe('ensureHooksConfirmed', () => {
 
     expect(decision).toBe('skip')
     expect(pending).toHaveLength(0)
+  })
+
+  it('echoes a fresh host challenge even when the runtime repo is always trusted', async () => {
+    const scriptContent = 'pnpm install --frozen-lockfile'
+    const contentHash = await hashOrcaHookScript(scriptContent)
+    const { state, pending } = createTestState({
+      trustedOrcaHooks: { 'repo-1': { all: { approvedAt: 1 } } },
+      repos: [{ id: 'repo-1', displayName: 'Runtime', executionHostId: 'runtime:env-1' }]
+    } as unknown as Partial<AppState>)
+    runtimeEnvironmentCallMock.mockResolvedValue({
+      id: 'rpc-hooks',
+      ok: true,
+      result: {
+        hasHooks: true,
+        hooks: { scripts: { setup: 'different client serialization' } },
+        mayNeedUpdate: false,
+        setupTrust: { contentHash, scriptContent, approvalToken: 'fresh-token' }
+      },
+      _meta: { runtimeId: 'runtime-owner' }
+    })
+
+    await expect(ensureSetupHookConfirmed(state, 'repo-1', 'runtime:env-1')).resolves.toEqual({
+      decision: 'run',
+      approvalRequired: true,
+      approval: { kind: 'setup', token: 'fresh-token', contentHash }
+    })
+    expect(pending).toHaveLength(0)
+  })
+
+  it('requires a host challenge for paired local-only setup content', async () => {
+    const scriptContent = 'echo host-local'
+    const contentHash = await hashOrcaHookScript(scriptContent)
+    const { state, pending } = createTestState({
+      repos: [
+        {
+          id: 'repo-1',
+          displayName: 'Runtime',
+          executionHostId: 'runtime:env-1',
+          hookSettings: {
+            mode: 'auto',
+            commandSourcePolicy: 'local-only',
+            scripts: { setup: scriptContent, archive: '' }
+          }
+        }
+      ]
+    } as unknown as Partial<AppState>)
+    runtimeEnvironmentCallMock.mockResolvedValue({
+      id: 'rpc-hooks',
+      ok: true,
+      result: {
+        hasHooks: true,
+        hooks: { scripts: { setup: scriptContent } },
+        mayNeedUpdate: false,
+        setupTrust: { contentHash, scriptContent, approvalToken: 'local-token' }
+      },
+      _meta: { runtimeId: 'runtime-owner' }
+    })
+
+    const confirmation = ensureSetupHookConfirmed(state, 'repo-1', 'runtime:env-1')
+    await vi.waitFor(() => expect(pending).toHaveLength(1))
+    pending[0].resolve('run')
+
+    await expect(confirmation).resolves.toEqual({
+      decision: 'run',
+      approvalRequired: true,
+      approval: { kind: 'setup', token: 'local-token', contentHash }
+    })
+  })
+
+  it('prompts with host-canonical bytes and rejects an inconsistent host hash', async () => {
+    const scriptContent = 'host-canonical bytes'
+    const contentHash = await hashOrcaHookScript(scriptContent)
+    const { state, pending } = createTestState({
+      repos: [{ id: 'repo-1', displayName: 'Runtime', executionHostId: 'runtime:env-1' }]
+    } as unknown as Partial<AppState>)
+    runtimeEnvironmentCallMock.mockResolvedValueOnce({
+      id: 'rpc-hooks',
+      ok: true,
+      result: {
+        hasHooks: true,
+        hooks: { scripts: { setup: 'client-derived bytes' } },
+        mayNeedUpdate: false,
+        setupTrust: { contentHash, scriptContent, approvalToken: 'token' }
+      },
+      _meta: { runtimeId: 'runtime-owner' }
+    })
+
+    const confirmation = ensureSetupHookConfirmed(state, 'repo-1', 'runtime:env-1')
+    await vi.waitFor(() => expect(pending).toHaveLength(1))
+    expect(pending[0].data.scriptContent).toBe(scriptContent)
+    pending[0].resolve('run')
+    await expect(confirmation).resolves.toMatchObject({
+      decision: 'run',
+      approval: { token: 'token', contentHash }
+    })
+
+    runtimeEnvironmentCallMock.mockResolvedValueOnce({
+      id: 'rpc-hooks',
+      ok: true,
+      result: {
+        hasHooks: true,
+        hooks: { scripts: { setup: 'client-derived bytes' } },
+        mayNeedUpdate: false,
+        setupTrust: {
+          contentHash: 'a'.repeat(64),
+          scriptContent,
+          approvalToken: 'token'
+        }
+      },
+      _meta: { runtimeId: 'runtime-owner' }
+    })
+
+    await expect(ensureSetupHookConfirmed(state, 'repo-1', 'runtime:env-1')).resolves.toEqual({
+      decision: 'skip',
+      approvalRequired: true
+    })
+    expect(pending).toHaveLength(1)
   })
 })

--- a/src/renderer/src/lib/ensure-hooks-confirmed.ts
+++ b/src/renderer/src/lib/ensure-hooks-confirmed.ts
@@ -7,16 +7,27 @@ import {
   readRuntimeIssueCommand,
   type IssueCommandReadResult
 } from '@/runtime/runtime-hooks-client'
-import { getRuntimeEnvironmentIdForRepo } from './repo-runtime-owner'
+import { parseExecutionHostId, type ExecutionHostId } from '../../../shared/execution-host'
 import {
-  getRepoExecutionHostId,
-  parseExecutionHostId,
-  type ExecutionHostId
-} from '../../../shared/execution-host'
+  parseSetupHookTrust,
+  setupHookApprovalFromTrust,
+  type SetupHookApproval
+} from '../../../shared/setup-hook-approval'
+import {
+  NEVER_CANCEL_TRUST_CHECK,
+  canUseRepoWideTrust,
+  confirmScriptContent,
+  findHookRepo,
+  settingsForHookRepoOwner
+} from './hook-trust-confirmation'
 
 export type HookScriptKind = OrcaHookScriptKind
 
-const NEVER_CANCEL_TRUST_CHECK = (): boolean => false
+export type ConfirmedSetupHook = {
+  decision: 'run' | 'skip'
+  approval?: SetupHookApproval
+  approvalRequired: boolean
+}
 
 // Serialize the singleton modal callback so overlapping worktree actions cannot replace it.
 let trustPromptChain: Promise<unknown> = Promise.resolve()
@@ -65,79 +76,6 @@ function getVmRecipeTrustContent(yamlHooks: OrcaHooks | null): string {
         .join('\n')
     )
     .join('\n\n')
-}
-
-function findHookRepo(state: AppState, repoId: string, hostId?: ExecutionHostId) {
-  return hostId
-    ? state.repos.find((repo) => repo.id === repoId && getRepoExecutionHostId(repo) === hostId)
-    : state.repos.find((repo) => repo.id === repoId)
-}
-
-function settingsForHookRepoOwner(
-  state: AppState,
-  repoId: string,
-  hostId?: ExecutionHostId,
-  runtimeOwnerEnvironmentId?: string | null
-): AppState['settings'] {
-  const parsedHost = hostId ? parseExecutionHostId(hostId) : null
-  const runtimeEnvironmentId =
-    runtimeOwnerEnvironmentId?.trim() ||
-    (hostId
-      ? parsedHost?.kind === 'runtime'
-        ? parsedHost.environmentId
-        : null
-      : getRuntimeEnvironmentIdForRepo(state, repoId))
-  // Why: hook inspection must follow the repo owner. SSH/local repos execute
-  // through desktop IPC, while runtime repos may differ from the focused host.
-  return state.settings
-    ? { ...state.settings, activeRuntimeEnvironmentId: runtimeEnvironmentId }
-    : ({ activeRuntimeEnvironmentId: runtimeEnvironmentId } as AppState['settings'])
-}
-
-function canUseRepoWideTrust(state: AppState, repoId: string): boolean {
-  const hasDuplicateRepoId = state.repos.filter((repo) => repo.id === repoId).length > 1
-  return Boolean(state.trustedOrcaHooks[repoId]?.all) && !hasDuplicateRepoId
-}
-
-async function confirmScriptContent(
-  state: AppState,
-  repoId: string,
-  scriptKind: HookScriptKind,
-  scriptContent: string,
-  hostId?: ExecutionHostId,
-  isCancelled: () => boolean = NEVER_CANCEL_TRUST_CHECK
-): Promise<'run' | 'skip'> {
-  if (isCancelled()) {
-    return 'skip'
-  }
-  if (canUseRepoWideTrust(state, repoId) || !scriptContent) {
-    return 'run'
-  }
-
-  const contentHash = await hashOrcaHookScript(scriptContent)
-  if (isCancelled()) {
-    return 'skip'
-  }
-  const existingHash = state.trustedOrcaHooks[repoId]?.[scriptKind]?.contentHash
-  if (existingHash === contentHash) {
-    return 'run'
-  }
-
-  const repo = findHookRepo(state, repoId, hostId)
-  const repoName = repo?.displayName ?? 'this repository'
-  const previouslyApproved = Boolean(existingHash)
-
-  return new Promise<'run' | 'skip'>((resolve) => {
-    state.openModal('confirm-orca-yaml-hooks', {
-      repoId,
-      repoName,
-      scriptKind,
-      scriptContent,
-      contentHash,
-      previouslyApproved,
-      onResolve: (decision: 'run' | 'skip') => resolve(decision)
-    })
-  })
 }
 
 function getIssueCommandTrustContent(result: IssueCommandReadResult): string {
@@ -230,6 +168,11 @@ export async function ensureHooksConfirmed(
   runtimeOwnerEnvironmentId?: string | null,
   isCancelled: () => boolean = NEVER_CANCEL_TRUST_CHECK
 ): Promise<'run' | 'skip'> {
+  if (scriptKind === 'setup') {
+    return (
+      await ensureSetupHookConfirmed(state, repoId, hostId, runtimeOwnerEnvironmentId, isCancelled)
+    ).decision
+  }
   return enqueueTrustPrompt(async () => {
     if (isCancelled()) {
       return 'skip'
@@ -281,11 +224,9 @@ export async function ensureHooksConfirmed(
         }
         const yamlHooks = (result.hooks as OrcaHooks | null) ?? null
         scriptContent =
-          scriptKind === 'setup'
-            ? getSetupTrustContent(yamlHooks)
-            : scriptKind === 'vmRecipe'
-              ? getVmRecipeTrustContent(yamlHooks)
-              : (yamlHooks?.scripts?.[scriptKind] ?? '').trim()
+          scriptKind === 'vmRecipe'
+            ? getVmRecipeTrustContent(yamlHooks)
+            : (yamlHooks?.scripts?.[scriptKind] ?? '').trim()
       }
     } catch {
       // Fail closed: if we cannot inspect the script, we cannot trust it.
@@ -293,5 +234,68 @@ export async function ensureHooksConfirmed(
     }
 
     return confirmScriptContent(state, repoId, scriptKind, scriptContent, hostId, isCancelled)
+  })
+}
+
+export async function ensureSetupHookConfirmed(
+  state: AppState,
+  repoId: string,
+  hostId?: ExecutionHostId,
+  runtimeOwnerEnvironmentId?: string | null,
+  isCancelled: () => boolean = NEVER_CANCEL_TRUST_CHECK
+): Promise<ConfirmedSetupHook> {
+  return enqueueTrustPrompt(async () => {
+    if (isCancelled()) {
+      return { decision: 'skip', approvalRequired: false }
+    }
+    const repo = findHookRepo(state, repoId, hostId)
+    const remoteApprovalRequired =
+      parseExecutionHostId(hostId)?.kind === 'runtime' || Boolean(runtimeOwnerEnvironmentId?.trim())
+    if (canUseRepoWideTrust(state, repoId) && !remoteApprovalRequired) {
+      return { decision: 'run', approvalRequired: false }
+    }
+    const localScript = repo?.hookSettings?.scripts?.setup?.trim()
+    const sourcePolicy = resolveHookCommandSourcePolicy(repo?.hookSettings?.commandSourcePolicy, {
+      hasLocalScript: Boolean(localScript)
+    })
+    if (sourcePolicy === 'local-only' && !remoteApprovalRequired) {
+      return { decision: 'run', approvalRequired: false }
+    }
+
+    try {
+      const result = await checkRuntimeHooks(
+        settingsForHookRepoOwner(state, repoId, hostId, runtimeOwnerEnvironmentId),
+        repoId,
+        hostId
+      )
+      if (result.status === 'error') {
+        return { decision: 'skip', approvalRequired: false }
+      }
+      const yamlHooks = (result.hooks as OrcaHooks | null) ?? null
+      const setupTrust = parseSetupHookTrust(result.setupTrust)
+      const scriptContent = setupTrust?.scriptContent ?? getSetupTrustContent(yamlHooks)
+      const approvalRequired = Boolean(scriptContent)
+      if (
+        setupTrust &&
+        (await hashOrcaHookScript(setupTrust.scriptContent)) !== setupTrust.contentHash
+      ) {
+        return { decision: 'skip', approvalRequired }
+      }
+      const decision = await confirmScriptContent(
+        state,
+        repoId,
+        'setup',
+        scriptContent,
+        hostId,
+        isCancelled
+      )
+      return {
+        decision,
+        approvalRequired,
+        ...(decision === 'run' ? { approval: setupHookApprovalFromTrust(setupTrust) } : {})
+      }
+    } catch {
+      return { decision: 'skip', approvalRequired: false }
+    }
   })
 }

--- a/src/renderer/src/lib/hook-trust-confirmation.ts
+++ b/src/renderer/src/lib/hook-trust-confirmation.ts
@@ -1,0 +1,78 @@
+import type { AppState } from '@/store/types'
+import {
+  getRepoExecutionHostId,
+  parseExecutionHostId,
+  type ExecutionHostId
+} from '../../../shared/execution-host'
+import { hashOrcaHookScript, type OrcaHookScriptKind } from './orca-hook-trust'
+import { getRuntimeEnvironmentIdForRepo } from './repo-runtime-owner'
+
+export const NEVER_CANCEL_TRUST_CHECK = (): boolean => false
+
+export function findHookRepo(state: AppState, repoId: string, hostId?: ExecutionHostId) {
+  return hostId
+    ? state.repos.find((repo) => repo.id === repoId && getRepoExecutionHostId(repo) === hostId)
+    : state.repos.find((repo) => repo.id === repoId)
+}
+
+export function settingsForHookRepoOwner(
+  state: AppState,
+  repoId: string,
+  hostId?: ExecutionHostId,
+  runtimeOwnerEnvironmentId?: string | null
+): AppState['settings'] {
+  const parsedHost = hostId ? parseExecutionHostId(hostId) : null
+  const runtimeEnvironmentId =
+    runtimeOwnerEnvironmentId?.trim() ||
+    (hostId
+      ? parsedHost?.kind === 'runtime'
+        ? parsedHost.environmentId
+        : null
+      : getRuntimeEnvironmentIdForRepo(state, repoId))
+  return state.settings
+    ? { ...state.settings, activeRuntimeEnvironmentId: runtimeEnvironmentId }
+    : ({ activeRuntimeEnvironmentId: runtimeEnvironmentId } as AppState['settings'])
+}
+
+export function canUseRepoWideTrust(state: AppState, repoId: string): boolean {
+  const hasDuplicateRepoId = state.repos.filter((repo) => repo.id === repoId).length > 1
+  return Boolean(state.trustedOrcaHooks[repoId]?.all) && !hasDuplicateRepoId
+}
+
+export async function confirmScriptContent(
+  state: AppState,
+  repoId: string,
+  scriptKind: OrcaHookScriptKind,
+  scriptContent: string,
+  hostId?: ExecutionHostId,
+  isCancelled: () => boolean = NEVER_CANCEL_TRUST_CHECK
+): Promise<'run' | 'skip'> {
+  if (isCancelled()) {
+    return 'skip'
+  }
+  if (canUseRepoWideTrust(state, repoId) || !scriptContent) {
+    return 'run'
+  }
+
+  const contentHash = await hashOrcaHookScript(scriptContent)
+  if (isCancelled()) {
+    return 'skip'
+  }
+  const existingHash = state.trustedOrcaHooks[repoId]?.[scriptKind]?.contentHash
+  if (existingHash === contentHash) {
+    return 'run'
+  }
+
+  const repoName = findHookRepo(state, repoId, hostId)?.displayName ?? 'this repository'
+  return new Promise<'run' | 'skip'>((resolve) => {
+    state.openModal('confirm-orca-yaml-hooks', {
+      repoId,
+      repoName,
+      scriptKind,
+      scriptContent,
+      contentHash,
+      previouslyApproved: Boolean(existingHash),
+      onResolve: (decision: 'run' | 'skip') => resolve(decision)
+    })
+  })
+}

--- a/src/renderer/src/lib/launch-work-item-direct.test.ts
+++ b/src/renderer/src/lib/launch-work-item-direct.test.ts
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   openModalFallback: vi.fn(),
   resolvePrBase: vi.fn(),
   getConnectionId: vi.fn(),
+  ensureSetupHookConfirmed: vi.fn(),
   store: {} as Record<string, unknown> & {
     ensureDetectedAgents: ReturnType<typeof vi.fn>
     ensureRemoteDetectedAgents: ReturnType<typeof vi.fn>
@@ -52,7 +53,8 @@ vi.mock('@/lib/worktree-activation', () => ({
 }))
 
 vi.mock('@/lib/ensure-hooks-confirmed', () => ({
-  ensureHooksConfirmed: vi.fn().mockResolvedValue('run')
+  ensureHooksConfirmed: vi.fn().mockResolvedValue('run'),
+  ensureSetupHookConfirmed: mocks.ensureSetupHookConfirmed
 }))
 
 vi.mock('@/lib/connection-context', () => ({
@@ -153,6 +155,10 @@ describe('launchWorkItemDirect', () => {
     mocks.ensureDetectedAgents.mockResolvedValue(['codex'])
     mocks.ensureRemoteDetectedAgents.mockResolvedValue(['codex'])
     mocks.getConnectionId.mockReturnValue(null)
+    mocks.ensureSetupHookConfirmed.mockResolvedValue({
+      decision: 'run',
+      approvalRequired: false
+    })
     mocks.createWorktree.mockResolvedValue({
       worktree: { id: 'repo-1::/repo/worktree', path: '/repo/worktree' },
       setup: undefined
@@ -226,6 +232,53 @@ describe('launchWorkItemDirect', () => {
     )
   })
 
+  it('forwards the host-issued setup approval from the direct launch path', async () => {
+    const approval = { kind: 'setup' as const, token: 'tok-1', contentHash: 'a'.repeat(64) }
+    mocks.ensureSetupHookConfirmed.mockResolvedValue({
+      decision: 'run',
+      approvalRequired: true,
+      approval
+    })
+    const { launchWorkItemDirect } = await import('./launch-work-item-direct')
+
+    await launchWorkItemDirect({
+      repoId: 'repo-1',
+      launchSource: 'task_page',
+      openModalFallback: vi.fn(),
+      item: {
+        type: 'issue',
+        number: 42,
+        title: 'Forward approval',
+        url: 'https://github.com/acme/repo/issues/42'
+      }
+    })
+
+    const call = mocks.createWorktree.mock.calls[0]
+    expect(call[3]).toBe('inherit')
+    expect(call[25]).toEqual({ setupHookApproval: approval })
+  })
+
+  it('skips the setup hook and sends no approval when the trust check is declined', async () => {
+    mocks.ensureSetupHookConfirmed.mockResolvedValue({ decision: 'skip', approvalRequired: true })
+    const { launchWorkItemDirect } = await import('./launch-work-item-direct')
+
+    await launchWorkItemDirect({
+      repoId: 'repo-1',
+      launchSource: 'task_page',
+      openModalFallback: vi.fn(),
+      item: {
+        type: 'issue',
+        number: 42,
+        title: 'Declined approval',
+        url: 'https://github.com/acme/repo/issues/42'
+      }
+    })
+
+    const call = mocks.createWorktree.mock.calls[0]
+    expect(call[3]).toBe('skip')
+    expect(call[25]).toBeUndefined()
+  })
+
   it('passes a resolved PR branch override while using a short PR identity for workspace names', async () => {
     mocks.ensureDetectedAgents.mockResolvedValue([])
     mocks.store.settings = {}
@@ -279,7 +332,8 @@ describe('launchWorkItemDirect', () => {
       undefined,
       undefined,
       undefined,
-      'refs/remotes/origin/main'
+      'refs/remotes/origin/main',
+      undefined
     )
   })
 
@@ -348,6 +402,7 @@ describe('launchWorkItemDirect', () => {
       undefined,
       undefined,
       'ENG-42',
+      undefined,
       undefined,
       undefined,
       undefined,

--- a/src/renderer/src/lib/launch-work-item-direct.ts
+++ b/src/renderer/src/lib/launch-work-item-direct.ts
@@ -12,7 +12,7 @@ import {
   unavailableAgentErrorMessage,
   workspaceActivationErrorMessage
 } from '@/lib/launch-work-item-direct-messages'
-import { ensureHooksConfirmed } from '@/lib/ensure-hooks-confirmed'
+import { ensureSetupHookConfirmed } from '@/lib/ensure-hooks-confirmed'
 import { seedNativeChatLaunchDraftForAgentTab } from '@/lib/agent-launch-prompt-delivery'
 import { getConnectionId } from '@/lib/connection-context'
 import { isNativeChatTranscriptLocalReadable } from '@/lib/native-chat-transcript-readability'
@@ -38,6 +38,7 @@ import {
   getLocalProjectExecutionRuntimeContext,
   getLocalRepoProjectExecutionRuntimeContext
 } from '@/lib/local-preflight-context'
+import { getRepoExecutionHostId } from '../../../shared/execution-host'
 
 /**
  * "Use" flow: create the workspace, activate it, launch the default agent,
@@ -117,9 +118,14 @@ export async function launchWorkItemDirect(args: LaunchWorkItemDirectArgs): Prom
     return false
   }
 
-  const trustDecision = await ensureHooksConfirmed(useAppStore.getState(), repoId, 'setup')
+  const setupTrust = await ensureSetupHookConfirmed(
+    useAppStore.getState(),
+    repoId,
+    getRepoExecutionHostId(repo),
+    repoOwnerSettings?.activeRuntimeEnvironmentId
+  )
   const finalSetupDecision: SetupDecision =
-    trustDecision === 'skip' ? 'skip' : setupResolution.decision
+    setupTrust.decision === 'skip' ? 'skip' : setupResolution.decision
 
   const workspaceIntentName =
     itemNumber !== null
@@ -189,7 +195,8 @@ export async function launchWorkItemDirect(args: LaunchWorkItemDirectArgs): Prom
       undefined,
       undefined,
       undefined,
-      resolvedCompareBaseRef
+      resolvedCompareBaseRef,
+      setupTrust.approval ? { setupHookApproval: setupTrust.approval } : undefined
     )
     worktreeId = result.worktree.id
     const worktreePath = result.worktree.path

--- a/src/renderer/src/lib/pending-worktree-creation.ts
+++ b/src/renderer/src/lib/pending-worktree-creation.ts
@@ -5,6 +5,7 @@ import type {
   SetupDecision
 } from '../../../shared/worktree/create-types'
 import type { WorktreeStartupLaunch } from '../../../shared/worktree/launch-types'
+import type { SetupHookApproval } from '../../../shared/setup-hook-approval'
 import type {
   GitPushTarget,
   WorkspaceLinkedItem,
@@ -69,6 +70,7 @@ export type WorktreeCreationRequest = {
   baseBranch?: string
   compareBaseRef?: string
   setupDecision: SetupDecision
+  setupHookApproval?: SetupHookApproval
   sparseCheckout?: CreateSparseCheckoutRequest
   telemetrySource?: WorkspaceCreateTelemetrySource
   linkedIssue?: number

--- a/src/renderer/src/lib/worktree-creation-flow.ts
+++ b/src/renderer/src/lib/worktree-creation-flow.ts
@@ -135,6 +135,9 @@ async function executeWorktreeCreation(
         preparedRequest.compareBaseRef,
         {
           ...(preparedRequest.nameWasGenerated ? { nameWasGenerated: true } : {}),
+          ...(preparedRequest.setupHookApproval
+            ? { setupHookApproval: preparedRequest.setupHookApproval }
+            : {}),
           ...(preparedRequest.linkedWorkItem !== undefined
             ? { linkedWorkItem: preparedRequest.linkedWorkItem }
             : {}),

--- a/src/renderer/src/runtime/runtime-hooks-client.ts
+++ b/src/renderer/src/runtime/runtime-hooks-client.ts
@@ -2,6 +2,7 @@ import type { GlobalSettings } from '../../../shared/global-settings-types'
 import type { OrcaHooks } from '../../../shared/orca-yaml-hook-types'
 import { parseExecutionHostId, type ExecutionHostId } from '../../../shared/execution-host'
 import type { SetupScriptImportCandidate } from '../../../shared/setup-script-imports'
+import type { SetupHookTrust } from '../../../shared/setup-hook-approval'
 import { callRuntimeRpc, getActiveRuntimeTarget } from './runtime-rpc-client'
 
 function getHookInspectionTarget(
@@ -20,6 +21,7 @@ export type HookCheckResult = {
   hasHooks: boolean
   hooks: OrcaHooks | null
   mayNeedUpdate: boolean
+  setupTrust?: SetupHookTrust
 }
 
 export type IssueCommandReadResult = {

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -207,7 +207,7 @@ export type WorktreeSlice = {
     linkedAzureDevOpsPR?: number | null,
     linkedGiteaPR?: number | null,
     compareBaseRef?: string,
-    options?: {
+    options?: Pick<CreateWorktreeArgs, 'setupHookApproval'> & {
       automationProvenanceRequest?: CreateWorktreeArgs['automationProvenanceRequest']
       linkedWorkItem?: WorkspaceLinkedItem | null
       linkedTaskSourceContext?: TaskSourceContext | null

--- a/src/renderer/src/store/slices/worktrees-remote-runtime-create.test.ts
+++ b/src/renderer/src/store/slices/worktrees-remote-runtime-create.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { toast } from 'sonner'
 import type { AppState } from '../types'
 import {
   createCompatibleRuntimeStatusResponse,
@@ -434,5 +435,167 @@ describe('worktree remote runtime mutations', () => {
         })
       })
     )
+  })
+
+  it('forwards the setup approval commitment to a capable runtime', async () => {
+    const store = createTestStore()
+    const wt = makeWorktree({ id: 'repo1::/path/approved', repoId: 'repo1' })
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-create',
+      ok: true,
+      result: { worktree: wt },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      worktreesByRepo: { repo1: [] }
+    } as Partial<AppState>)
+    const createWorktree = store.getState().createWorktree
+    const args: Parameters<typeof createWorktree> = ['repo1', 'approved', undefined, 'run']
+    const approval = {
+      kind: 'setup' as const,
+      token: 'operation-token',
+      contentHash: 'a'.repeat(64)
+    }
+    args[25] = { setupHookApproval: approval }
+
+    await createWorktree(...args)
+
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'worktree.create',
+        params: expect.objectContaining({ setupDecision: 'run', setupHookApproval: approval })
+      })
+    )
+  })
+
+  // Why: desktop creates omit awaitTerminalProvisioning, so the host sends no
+  // setupReceipt; only the explicit flag can surface a refused approval.
+  it('warns when the host rejects a setup approval without a setup receipt', async () => {
+    const store = createTestStore()
+    const wt = makeWorktree({ id: 'repo1::/path/rejected', repoId: 'repo1' })
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-create',
+      ok: true,
+      result: {
+        worktree: wt,
+        warning: 'orca.yaml setup hook skipped because approval could not be verified.',
+        setupApprovalRejected: true
+      },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      worktreesByRepo: { repo1: [] }
+    } as Partial<AppState>)
+
+    await store.getState().createWorktree('repo1', 'rejected', undefined, 'run')
+
+    expect(toast.warning).toHaveBeenCalledWith('Setup hook skipped', {
+      description:
+        'The remote Orca server could not verify your approval, so the setup hook did not run.'
+    })
+  })
+
+  it('does not warn when a capable host runs the approved setup hook', async () => {
+    const store = createTestStore()
+    const wt = makeWorktree({ id: 'repo1::/path/ran', repoId: 'repo1' })
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-create',
+      ok: true,
+      result: { worktree: wt, setup: { command: 'echo hi' } },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      worktreesByRepo: { repo1: [] }
+    } as Partial<AppState>)
+
+    await store.getState().createWorktree('repo1', 'ran', undefined, 'run')
+
+    expect(toast.warning).not.toHaveBeenCalled()
+  })
+
+  it('forces setup to skip when the runtime lacks approval binding', async () => {
+    const oldRuntimeStatus = createCompatibleRuntimeStatusResponse('runtime-old')
+    if (oldRuntimeStatus.ok) {
+      oldRuntimeStatus.result.capabilities = oldRuntimeStatus.result.capabilities?.filter(
+        (capability) => capability !== 'worktree.setup-hook-approval.v1'
+      )
+    }
+    runtimeEnvironmentTransportCall.mockImplementation((request: RuntimeEnvironmentCallRequest) =>
+      request.method === 'status.get' ? oldRuntimeStatus : runtimeEnvironmentCall(request)
+    )
+    const store = createTestStore()
+    const wt = makeWorktree({ id: 'repo1::/path/legacy', repoId: 'repo1' })
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-create',
+      ok: true,
+      result: { worktree: wt },
+      _meta: { runtimeId: 'runtime-old' }
+    })
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      worktreesByRepo: { repo1: [] }
+    } as Partial<AppState>)
+    const createWorktree = store.getState().createWorktree
+    const args: Parameters<typeof createWorktree> = ['repo1', 'legacy', undefined, 'run']
+
+    await createWorktree(...args)
+
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'worktree.create',
+        params: expect.objectContaining({ setupDecision: 'skip' })
+      })
+    )
+    expect(toast.warning).toHaveBeenCalledWith('Setup hook skipped', {
+      description: 'Update the remote Orca server to run approved setup hooks.'
+    })
+  })
+
+  // Why: paths like the session fork send 'inherit', so an approved hook must not be
+  // downgraded silently just because the verb is not the literal 'run'.
+  it('warns when an old runtime downgrades an approved inherit decision', async () => {
+    const oldRuntimeStatus = createCompatibleRuntimeStatusResponse('runtime-old')
+    if (oldRuntimeStatus.ok) {
+      oldRuntimeStatus.result.capabilities = oldRuntimeStatus.result.capabilities?.filter(
+        (capability) => capability !== 'worktree.setup-hook-approval.v1'
+      )
+    }
+    runtimeEnvironmentTransportCall.mockImplementation((request: RuntimeEnvironmentCallRequest) =>
+      request.method === 'status.get' ? oldRuntimeStatus : runtimeEnvironmentCall(request)
+    )
+    const store = createTestStore()
+    const wt = makeWorktree({ id: 'repo1::/path/inherited', repoId: 'repo1' })
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-create',
+      ok: true,
+      result: { worktree: wt },
+      _meta: { runtimeId: 'runtime-old' }
+    })
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      worktreesByRepo: { repo1: [] }
+    } as Partial<AppState>)
+    const createWorktree = store.getState().createWorktree
+    const args = ['repo1', 'inherited', undefined, 'inherit'] as unknown as Parameters<
+      typeof createWorktree
+    >
+    args[25] = {
+      setupHookApproval: { kind: 'setup', token: 'tok', contentHash: 'a'.repeat(64) }
+    }
+
+    await createWorktree(...args)
+
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'worktree.create',
+        params: expect.objectContaining({ setupDecision: 'skip' })
+      })
+    )
+    expect(toast.warning).toHaveBeenCalledWith('Setup hook skipped', {
+      description: 'Update the remote Orca server to run approved setup hooks.'
+    })
   })
 })

--- a/src/renderer/src/store/slices/worktrees/create/create-worktree.ts
+++ b/src/renderer/src/store/slices/worktrees/create/create-worktree.ts
@@ -13,6 +13,10 @@ import {
   getActiveRuntimeTarget
 } from '../../../../runtime/runtime-rpc-client'
 import { WORKTREE_LINKED_WORK_ITEM_CONTEXT_RUNTIME_CAPABILITY } from '../../../../../../shared/protocol-version'
+import {
+  notifyRejectedSetupApproval,
+  resolveRemoteSetupDecision
+} from './setup-hook-approval-notice'
 import { showLocalBaseRefUpdateSuggestionToast } from '@/components/sidebar/local-base-ref-suggestion-toast'
 import { requestWorktreeBaseFallbackNotice } from '@/components/worktree-base-fallback-notice'
 import { showLocalBaseRefRefreshToast } from './local-base-ref-refresh-toast'
@@ -61,6 +65,12 @@ export function createCreateWorktree(
     const startupDraft = options?.startupDraft
     const provisionedRoot = options?.provisionedRoot
     try {
+      const target = getActiveRuntimeTarget(settingsForRepoOwner(get(), repoId))
+      const remoteSetupDecision = await resolveRemoteSetupDecision(
+        target,
+        setupDecision,
+        Boolean(options?.setupHookApproval)
+      )
       for (let attempt = 0; attempt < CLIENT_WORKTREE_CREATE_MAX_ATTEMPTS; attempt += 1) {
         const candidateName = options?.nameWasGenerated
           ? getGeneratedWorktreeCreateRetryCandidate(name, attempt)
@@ -116,7 +126,6 @@ export function createCreateWorktree(
             ...(creationId ? { creationId } : {}),
             ...(automationProvenanceRequest ? { automationProvenanceRequest } : {})
           }
-          const target = getActiveRuntimeTarget(settingsForRepoOwner(get(), repoId))
           if (
             target.kind === 'environment' &&
             (linkedWorkItem?.provider === 'jira' || linkedTaskSourceContext?.provider === 'jira')
@@ -149,7 +158,10 @@ export function createCreateWorktree(
                     ...(candidateBranchNameOverride
                       ? { branchNameOverride: candidateBranchNameOverride }
                       : {}),
-                    setupDecision,
+                    setupDecision: remoteSetupDecision,
+                    ...(options?.setupHookApproval
+                      ? { setupHookApproval: options.setupHookApproval }
+                      : {}),
                     sparseCheckout,
                     ...(displayName ? { displayName } : {}),
                     ...(telemetrySource ? { telemetrySource } : {}),
@@ -236,6 +248,11 @@ export function createCreateWorktree(
                 : {}),
               sortEpoch: s.sortEpoch + 1
             }
+          })
+          notifyRejectedSetupApproval({
+            target,
+            remoteSetupDecision,
+            setupApprovalRejected: result.setupApprovalRejected
           })
           showLocalBaseRefRefreshToast(result.localBaseRefRefresh, result.worktree)
           if (result.baseFallback) {

--- a/src/renderer/src/store/slices/worktrees/create/setup-hook-approval-notice.ts
+++ b/src/renderer/src/store/slices/worktrees/create/setup-hook-approval-notice.ts
@@ -1,0 +1,66 @@
+import { toast } from 'sonner'
+import { translate } from '@/i18n/i18n'
+import type { SetupDecision } from '../../../../../../shared/worktree/create-types'
+import { WORKTREE_SETUP_HOOK_APPROVAL_RUNTIME_CAPABILITY } from '../../../../../../shared/protocol-version'
+import { runtimeEnvironmentSupportsCapability } from '../../../../runtime/runtime-rpc-client'
+import type { RuntimeClientTarget } from '../../../../runtime/runtime-client-target'
+
+function warnSetupHookSkipped(descriptionKey: string, description: string): void {
+  toast.warning(
+    translate('auto.store.slices.worktrees.create.setupHookSkipped', 'Setup hook skipped'),
+    { description: translate(descriptionKey, description) }
+  )
+}
+
+/**
+ * Downgrade a remote setup request to `skip` when the host cannot bind the
+ * approval to exact content, so an unverifiable host never runs setup hooks.
+ */
+export async function resolveRemoteSetupDecision(
+  target: RuntimeClientTarget,
+  setupDecision: SetupDecision,
+  /** True when the user approved real content, so a silent downgrade would lose their choice. */
+  hasApproval = false
+): Promise<SetupDecision> {
+  if (
+    target.kind !== 'environment' ||
+    setupDecision === 'skip' ||
+    (await runtimeEnvironmentSupportsCapability(
+      target.environmentId,
+      WORKTREE_SETUP_HOOK_APPROVAL_RUNTIME_CAPABILITY
+    ))
+  ) {
+    return setupDecision
+  }
+  // Why: 'inherit' also reaches here from paths that never prompt, and warning on every
+  // hookless create would be noise — an approval is the proof content existed.
+  if (setupDecision === 'run' || hasApproval) {
+    warnSetupHookSkipped(
+      'auto.store.slices.worktrees.create.updateRemoteForSetupHooks',
+      'Update the remote Orca server to run approved setup hooks.'
+    )
+  }
+  return 'skip'
+}
+
+/**
+ * Surface a host-side refusal. `setupReceipt` is absent unless the caller awaits
+ * provisioning, so the explicit flag is the only signal on the desktop path.
+ */
+export function notifyRejectedSetupApproval(args: {
+  target: RuntimeClientTarget
+  remoteSetupDecision: SetupDecision
+  setupApprovalRejected?: boolean
+}): void {
+  if (
+    args.target.kind !== 'environment' ||
+    args.remoteSetupDecision === 'skip' ||
+    !args.setupApprovalRejected
+  ) {
+    return
+  }
+  warnSetupHookSkipped(
+    'auto.store.slices.worktrees.create.setupApprovalUnverified',
+    'The remote Orca server could not verify your approval, so the setup hook did not run.'
+  )
+}

--- a/src/shared/protocol-version.ts
+++ b/src/shared/protocol-version.ts
@@ -86,6 +86,9 @@ export const TERMINAL_QUICK_COMMANDS_RUNTIME_CAPABILITY = 'terminal.quick-comman
 // replay ambiguous cutovers when the host advertises idempotent create support.
 export const WORKTREE_CREATE_IDEMPOTENCY_RUNTIME_CAPABILITY =
   'worktree.create-idempotency.v1' as const
+// Why: hosts without this strip setupHookApproval and may execute content the paired client did not approve.
+export const WORKTREE_SETUP_HOOK_APPROVAL_RUNTIME_CAPABILITY =
+  'worktree.setup-hook-approval.v1' as const
 export const CODEX_RESET_CREDIT_RUNTIME_CAPABILITY = 'accounts.codex-reset-credit.v1' as const
 export const ACCOUNT_IMPORT_RUNTIME_CAPABILITY = 'accounts.import-host-credentials.v1' as const
 // Why: older hosts cannot reconcile terminal.create's mutation after losing the reply, so clients may only retry unknown outcomes when advertised.
@@ -135,6 +138,7 @@ export const RUNTIME_CAPABILITIES = [
   TERMINAL_PAIRED_PARKING_RUNTIME_CAPABILITY,
   TERMINAL_QUICK_COMMANDS_RUNTIME_CAPABILITY,
   WORKTREE_CREATE_IDEMPOTENCY_RUNTIME_CAPABILITY,
+  WORKTREE_SETUP_HOOK_APPROVAL_RUNTIME_CAPABILITY,
   TERMINAL_CREATE_IDEMPOTENCY_RUNTIME_CAPABILITY,
   SESSION_TAB_CLOSE_INTENT_RUNTIME_CAPABILITY,
   AGENT_SESSION_BOUNDARY_RUNTIME_CAPABILITY,

--- a/src/shared/setup-hook-approval.ts
+++ b/src/shared/setup-hook-approval.ts
@@ -1,0 +1,68 @@
+export type SetupHookApproval = {
+  kind: 'setup'
+  token: string
+  contentHash: string
+}
+
+export type SetupHookTrust = {
+  contentHash: string
+  scriptContent: string
+  approvalToken?: string
+}
+
+const SHA256_HEX = /^[a-f0-9]{64}$/
+
+export function parseSetupHookApproval(value: unknown): SetupHookApproval | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined
+  }
+  const candidate = value as Record<string, unknown>
+  if (
+    candidate.kind !== 'setup' ||
+    typeof candidate.token !== 'string' ||
+    candidate.token.length < 1 ||
+    candidate.token.length > 200 ||
+    typeof candidate.contentHash !== 'string' ||
+    !SHA256_HEX.test(candidate.contentHash)
+  ) {
+    return undefined
+  }
+  return {
+    kind: 'setup',
+    token: candidate.token,
+    contentHash: candidate.contentHash
+  }
+}
+
+export function parseSetupHookTrust(value: unknown): SetupHookTrust | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined
+  }
+  const candidate = value as Record<string, unknown>
+  if (
+    typeof candidate.contentHash !== 'string' ||
+    !SHA256_HEX.test(candidate.contentHash) ||
+    typeof candidate.scriptContent !== 'string' ||
+    candidate.scriptContent.length < 1 ||
+    (candidate.approvalToken !== undefined &&
+      (typeof candidate.approvalToken !== 'string' ||
+        candidate.approvalToken.length < 1 ||
+        candidate.approvalToken.length > 200))
+  ) {
+    return undefined
+  }
+  return {
+    contentHash: candidate.contentHash,
+    scriptContent: candidate.scriptContent,
+    ...(candidate.approvalToken ? { approvalToken: candidate.approvalToken } : {})
+  }
+}
+
+export function setupHookApprovalFromTrust(
+  trust: SetupHookTrust | null | undefined
+): SetupHookApproval | undefined {
+  if (!trust?.approvalToken || !SHA256_HEX.test(trust.contentHash)) {
+    return undefined
+  }
+  return { kind: 'setup', token: trust.approvalToken, contentHash: trust.contentHash }
+}

--- a/src/shared/worktree/create-types.ts
+++ b/src/shared/worktree/create-types.ts
@@ -3,6 +3,7 @@ import type { WorkspaceSource } from '../workspace-source'
 import type { TaskSourceContext } from '../task-source-context'
 import type { WorkspaceKey } from '../folder-workspace-types'
 import type { TuiAgent } from '../tui-agent'
+import type { SetupHookApproval } from '../setup-hook-approval'
 import type {
   AutomationWorkspaceProvenanceRequest,
   GitPushTarget,
@@ -76,6 +77,7 @@ export type CreateWorktreeArgs = {
    *  legitimately contains `/` while the worktree directory must not. */
   branchNameOverride?: string
   setupDecision?: SetupDecision
+  setupHookApproval?: SetupHookApproval
   sparseCheckout?: CreateSparseCheckoutRequest
   linkedIssue?: number
   linkedPR?: number
@@ -146,6 +148,8 @@ export type CreateWorktreeResult = {
     terminalHandle?: string
   }
   defaultTabs?: WorktreeDefaultTabsLaunch
+  /** Host refused the setup hook because the paired-client approval did not verify. */
+  setupApprovalRejected?: boolean
   warning?: string
   baseFallback?: WorktreeCreateBaseFallback
   initialBaseStatus?: WorktreeBaseStatusEvent


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1091 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​21 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1070 |
| Prod | 32 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​917 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​220 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​697 |

<!-- /orca-pr-loc -->

## Problem

An authoritative Orca host would run whatever `orca.yaml` setup script it found on disk whenever a paired client asked for a create with setup enabled. The client's trust prompt and the host's execution were two independent reads of two different files at two different times, so nothing proved they saw the same bytes.

Concretely, on `main` today:

- A shared `orca.yaml` that changes between the client's prompt and the host's create runs unapproved content.
- A create replayed or re-issued with a different `setupDecision` runs setup the user never approved for that operation.
- A client that never prompts at all (the terminal session-fork path passed a hardcoded `'inherit'`) still got setup executed.
- The host's own trust payload hashed shared `defaultTabs` commands even for a `local-only` repo that would never run them, so the hash did not describe what would execute.

## Invariant this defends

> For every remotely executed setup hook, the authoritative host must prove that the exact canonical host-derived trust content it is about to execute matches the exact content the user approved **for this operation**. A mismatch, stale commitment, malformed value, or unverifiable state must never silently run different content or route execution elsewhere.

## Approach

The host issues a **short-lived (15 min), one-time approval challenge** bound to `repoId` + paired `deviceId` + SHA-256 of its own canonical trust content + runtime generation, and hands the client both the token and the exact content it hashed. On create, the host recomputes the hash of the content it is about to execute and refuses to run setup unless the presented approval matches.

Key properties:

- **Host-derived only.** The canonical content comes from `getSetupHookTrustContent(repo, yamlHooks)` on the host; the client hashes the host-supplied `setupTrust.scriptContent`, so platform newline divergence is impossible and the client cannot choose what gets hashed.
- **Unspoofable owner.** `deviceId` comes from `creatorProvenance`, resolved host-side from the RPC context — not from the wire.
- **One-time use, delete-before-validate.** `consume()` removes the token before checking it, so a failed validation cannot be retried.
- **Fail closed, everywhere.** Malformed approval, expired/evicted challenge, host restart (new runtime generation), unreadable `orca.yaml`, or a host without the capability → skip the hook, keep the workspace, surface a warning. Never "run anyway", never route elsewhere.
- **Executes the verified bytes.** `runHook` takes an optional `verifiedScript`, so the no-runner branch runs what the approval covered rather than re-reading the file after validation.
- **Polling can't starve an approval.** Clients re-read `repo.hooks` on every prompt; identical bindings now reuse and refresh one token, and capacity eviction is charged to the crowding device, so one paired device cannot evict another's pending approval.
- **Folder workspaces never mint a token**, matching the existing `checkRepoHooks` refusal — they never run setup hooks, so no token they could present as proof should exist.

## Wire compatibility

Gated by the new `worktree.setup-hook-approval.v1` runtime capability. All wire additions are **optional RPC fields** — no new stream opcodes. Per `docs/reference/remote-wire-compatibility.md`:

| Direction | Behavior |
| --- | --- |
| New client → old host | Client detects the missing capability and downgrades to `skip`, with a toast explaining why. It does **not** silently drop the user's choice. |
| Old client → new host | Host enforces. A create with no approval is refused and the refusal is folded into `warning`, which old clients already surface. |
| New client → new host | Full binding. |

**Accepted consequence:** old *desktop* clients that ignore `warning` on this path won't render the refusal text. Capability-gating host enforcement instead would leave every old client fully vulnerable, which defeats the fix — so enforcement is unconditional and the legibility gap is accepted and documented here.

`issueCommand` keeps its own independent trust path (`confirmIssueCommandReadResult`), returns only `'run' | 'skip'`, and never passes through `runHook` — verified unchanged, with its suites re-run.

## Coverage

- `setup-hook-approval-challenges.test.ts` — replay by repo/device/content, expiry, hash disagreement, capacity eviction fails closed, binding reuse refreshes TTL, cross-device eviction isolation, cross-runtime-generation rejection.
- `remote-setup-hook-approval-wire.integration.test.ts` — end-to-end oracle over the real wire shapes.
- `orca-runtime.test.ts` — exact paired approval runs, old client without one is skipped, folder workspace mints no token, verified bytes reach `runHook`.
- `worktrees-remote-runtime-create.test.ts` — old-host downgrade of an approved `inherit` warns and sends `skip`.
- `terminal-agent-session-fork.test.ts` — the fork path forwards the approval, and declines to `skip`.
- Mobile `setup-hook-create-binding.test.ts` — host-canonical content, old/malformed hosts forced to skip, locally suppressed runs surface a warning.

## Gates

`pnpm run typecheck`, `pnpm run lint`, `pnpm run check:code-quality:changed` (0 new findings incl. React Doctor), `pnpm run build:cli`, `pnpm run build:electron-vite`, mobile `tsc` + `oxlint`, and all focused desktop + mobile suites — all green. No `max-lines` disable or bump was added; the fork module was split into `terminal-agent-session-fork-workspace.ts` instead.

## Follow-ups

Filed as parented children of STA-4532 rather than expanded here, to keep this PR to one invariant:

1. Archive hooks still take boolean consent and re-read from the host.
2. Automations persist a save-time decision across later `orca.yaml` changes.
3. Orchestration-created worktrees have no per-operation approval flow (threading provenance without one would make their setup hooks never run).
4. Mint the challenge against the base-ref committed `orca.yaml` (including over SSH) so branch-specific hooks are usable — today they hash the primary tree and fail closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
