### PR TITLE
fix(automations): remove the unselectable Blank Terminal option from the automation agent picker

### DIFF
--- a/src/renderer/src/components/automations/AutomationEditorDialogFooter.test.tsx
+++ b/src/renderer/src/components/automations/AutomationEditorDialogFooter.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment happy-dom
+
+import React from 'react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../../../shared/repo-types'
+import { AGENT_CATALOG } from '@/lib/agent-catalog'
+import { AutomationEditorDialogFooter } from './AutomationEditorDialogFooter'
+import type { AutomationDraft } from './AutomationEditorDialog'
+
+// Why: Tooltip needs a provider in the app; stub so the footer renders standalone.
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+// Why: the project picker reads repos from the app store, which this test does not exercise.
+vi.mock('./AutomationProjectCombobox', () => ({
+  default: () => <div />
+}))
+
+afterEach(cleanup)
+
+const REPO: Repo = {
+  id: 'repo-1',
+  path: '/repo',
+  displayName: 'Repo',
+  badgeColor: '#000000',
+  addedAt: 1
+}
+
+const DRAFT: AutomationDraft = {
+  name: 'nightly',
+  prompt: 'Run checks',
+  agentId: 'codex',
+  projectId: REPO.id,
+  workspaceMode: 'existing',
+  workspaceId: 'worktree-1',
+  baseBranch: '',
+  reuseSession: false,
+  precheckCommand: '',
+  precheckTimeoutSeconds: '60',
+  preset: 'daily',
+  time: '09:00',
+  dayOfWeek: '1',
+  customSchedule: '',
+  missedRunGraceMinutes: '60',
+  scheduleWarning: null
+}
+
+function renderFooter(): void {
+  render(
+    <AutomationEditorDialogFooter
+      isEditing={false}
+      isEditingExternal={false}
+      isHermesTarget={false}
+      isHermesCreate={false}
+      isSaving={false}
+      canSave
+      repos={[REPO]}
+      projectHostSetups={[]}
+      automationYamlHooksByRepoKey={{}}
+      getAutomationHooksCacheKey={(repoId) => repoId}
+      repoMap={new Map([[REPO.id, REPO]])}
+      worktrees={[]}
+      settings={null}
+      draft={DRAFT}
+      visibleAgents={AGENT_CATALOG}
+      scheduleField={null}
+      pickerTriggerClassName=""
+      modeToggleItemClassName=""
+      onProjectChange={vi.fn()}
+      onDraftChange={vi.fn()}
+      onSetupDecisionTouched={vi.fn()}
+      onOpenChange={vi.fn()}
+      onSave={vi.fn()}
+    />
+  )
+}
+
+describe('AutomationEditorDialogFooter agent picker', () => {
+  it('does not offer Blank Terminal, which the draft cannot store', () => {
+    renderFooter()
+
+    const agentTrigger = document.querySelector('button[data-agent-combobox-root="true"]')
+    expect(agentTrigger?.textContent).toContain('Codex')
+    fireEvent.click(agentTrigger as Element)
+
+    expect(screen.getByRole('option', { name: 'Claude' })).toBeTruthy()
+    expect(screen.queryByRole('option', { name: 'Blank Terminal' })).toBeNull()
+  })
+})

--- a/src/renderer/src/components/automations/AutomationEditorDialogFooter.tsx
+++ b/src/renderer/src/components/automations/AutomationEditorDialogFooter.tsx
@@ -230,6 +230,10 @@ export function AutomationEditorDialogFooter({
                 }
                 defaultAgent={settings?.defaultTuiAgent ?? null}
                 triggerClassName={`h-9 w-full min-w-0 ${pickerTriggerClassName}`}
+                // Why: an automation always dispatches its prompt to an agent,
+                // so offering Blank Terminal here is a dead option — picking it
+                // emits null and the draft keeps the previous agent.
+                allowBlankTerminal={false}
                 allowNarrowTrigger
               />
             </Field>


### PR DESCRIPTION
## ELI5

When you create an automation, the **Agent** dropdown listed a "Blank Terminal" option — but clicking it did nothing. Automations always need an agent to run their prompt, so this removes the dead option instead of leaving a choice you can't make.

## What Changed

- `AutomationEditorDialogFooter` now passes `allowBlankTerminal={false}` to `AgentCombobox`, the same opt-out `AgentSessionContinuationDialog` already uses.
- New `AutomationEditorDialogFooter.test.tsx`: opens the agent picker and asserts the agent rows still render while "Blank Terminal" is gone.

## Why

`AgentCombobox` defaults to `allowBlankTerminal = true`, so the automation editor got the "Blank Terminal" row for free. Selecting it calls `onValueChange(null)`, and the footer's handler is `agentId && onDraftChange(...)` — `null` is dropped, so the dropdown closed and the draft kept the previous agent.

The guard is correct, not the bug: an automation always dispatches its prompt to an agent. `AutomationDraft.agentId`, `Automation.agentId` and `AutomationCreateInput.agentId` are all non-nullable `TuiAgent`, and `AutomationsPage` already falls back off a `'blank'` default-agent preference when seeding a draft. Making blank terminals a real automation target would mean a nullable agent through the draft, persistence, CLI and dispatcher; hiding the row that can never be honored is the fix that matches the current model.

## Linked Issue

Fixes #15089

## Visual Proof

<!-- before: Agent dropdown with "Blank Terminal" as the first row -->
<!-- after: same dropdown, option gone -->
<!-- extra: clicking "Blank Terminal" on main leaves the previous agent selected -->

## Testing

Captured against a fresh build of this branch in the Electron app (Automations → Add new → Agent dropdown), and on `main` for the before shot.

- `npx vitest run --config config/vitest.config.ts src/renderer/src/components/automations/` — 28 files, 166 tests pass
- Confirmed the new test fails when `allowBlankTerminal={false}` is removed
- `pnpm typecheck:web`
- `oxlint` and `oxlint --config config/oxlint-code-quality-native-plugins.json --deny-warnings` on the changed files, plus `oxfmt --check`
- Platforms: verified on macOS. No platform-specific code paths are touched.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

<!-- -->

## Review

- **Cross-platform (macOS / Linux / Windows):** renderer-only prop on a picker; no paths, shells, or accelerators involved.
- **Remote / SSH / mobile:** no RPC params, stream frames, or host-published content change. The picker's option list is computed client-side, so mixed client/host versions are unaffected.
- **Agent & integration compatibility:** every catalog agent still renders; only the non-agent row is removed. No git-provider or integration surface touched.
- **Backwards compatibility:** stored automations already carry a non-nullable `agentId`, so existing rows and the edit dialog behave exactly as before.
- **Performance:** one static prop; no added work or re-renders.
- **UI quality:** the dropdown loses a row that could never be applied. The trigger label is unchanged because the automation draft always holds an agent, so the `emptyLabel`/blank trigger state is unreachable here.
- **Security:** none — no input handling, IPC, or credential surface.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Renderer-only change, no wire or persistence impact.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter:
