### PR TITLE
fix(native-chat): keep paged-in history on no-op tail refresh

### DIFF
--- a/src/shared/structured-agent-session-reducer.test.ts
+++ b/src/shared/structured-agent-session-reducer.test.ts
@@ -67,6 +67,64 @@ describe('structured agent session reducer', () => {
     expect(afterRefresh).toBe(streamed)
   })
 
+  it('keeps paged-in older items when a focus refresh carries nothing new', () => {
+    const snapshot = reduceStructuredAgentSession(EMPTY_STRUCTURED_AGENT_SESSION, {
+      type: 'event',
+      event: {
+        type: 'snapshot',
+        sessionId: 'session-a',
+        fence: 1,
+        snapshot: {
+          sessionId: 'session-a',
+          cursor: { epoch: 'epoch-a', sequence: 50 },
+          items: [item('newest', 50)],
+          submissions: []
+        }
+      }
+    })
+    const withOlder = reduceStructuredAgentSession(snapshot, {
+      type: 'older-page',
+      requestedEpoch: 'epoch-a',
+      page: {
+        sessionId: 'session-a',
+        epoch: 'epoch-a',
+        direction: 'before',
+        items: [item('older', 10)],
+        removedItemIds: [],
+        submissions: [],
+        window: {
+          oldest: { epoch: 'epoch-a', sequence: 10 },
+          newest: { epoch: 'epoch-a', sequence: 10 },
+          nextCursor: { epoch: 'epoch-a', sequence: 10 }
+        },
+        hasOlder: false,
+        hasNewer: true
+      }
+    })
+    const afterRefresh = reduceStructuredAgentSession(withOlder, {
+      type: 'tail-page',
+      page: {
+        sessionId: 'session-a',
+        epoch: 'epoch-a',
+        direction: 'tail',
+        items: [item('newest', 50)],
+        removedItemIds: [],
+        submissions: [],
+        window: {
+          oldest: { epoch: 'epoch-a', sequence: 50 },
+          newest: { epoch: 'epoch-a', sequence: 50 },
+          nextCursor: { epoch: 'epoch-a', sequence: 50 }
+        },
+        liveCursor: { epoch: 'epoch-a', sequence: 50 },
+        hasOlder: true,
+        hasNewer: false
+      }
+    })
+
+    expect(afterRefresh).toBe(withOlder)
+    expect(afterRefresh.items.map((entry) => entry.itemId)).toEqual(['older', 'newest'])
+  })
+
   it('keeps rapid-send submissions when a newer tail refresh contains only the last one', () => {
     const initial = reduceStructuredAgentSession(EMPTY_STRUCTURED_AGENT_SESSION, {
       type: 'event',

--- a/src/shared/structured-agent-session-reducer.ts
+++ b/src/shared/structured-agent-session-reducer.ts
@@ -106,10 +106,12 @@ export function reduceStructuredAgentSession(
   }
   if (action.type === 'tail-page') {
     const pageCursor = action.page.liveCursor ?? action.page.window.newest
+    // An equal cursor means the page holds nothing the stream has not already
+    // delivered; replacing would throw away paged-in older items mid-scroll.
     if (
       state.epoch === action.page.epoch &&
       state.cursor &&
-      (!pageCursor || pageCursor.sequence < state.cursor.sequence)
+      (!pageCursor || pageCursor.sequence <= state.cursor.sequence)
     ) {
       return state
     }


### PR DESCRIPTION
## Defect

`reduceStructuredAgentSession`'s `tail-page` guard only skipped pages whose cursor was **strictly older** than the client's live cursor. A tail refresh whose cursor **equals** the live cursor (nothing new) fell through to the replace path, which resets `items` to the newest 40 rows and resets `hasOlder`.

The desktop read hook (`use-structured-agent-session-read.ts`) refetches the tail on **every window focus**, even while the subscription is healthy. So a user who paged back through history and then alt-tabbed away and back lost every paged-in older item: the list snapped to the newest 40 rows and the scroll position jumped.

## Failure scenario

1. Open a structured Codex chat with >40 items; scroll up so `loadOlder` pages in older rows.
2. Focus another app, then refocus Orca (no new journal rows in between).
3. `refreshOnFocus` → `tail-page` with cursor equal to live cursor → state replaced → older rows vanish and the view jumps to the tail.

## Fix

Treat an equal-cursor tail page as a no-op (`<` → `<=`). Pages that do carry new rows still replace state exactly as before, and the stale-page guard is unchanged.

## Verification

- New test: `keeps paged-in older items when a focus refresh carries nothing new` (asserts identical state and preserved item order).
- Mutation-tested: reverting the fix (`<=` → `<`) makes the new test fail; with the fix all 4 reducer tests pass.
- Full desktop `src/shared` + `src/renderer/src/components/native-chat` + `src/renderer/src/lib` suites: 960 files / 9569 tests green.
- Mobile `src/session` + `src/transport` suites: 222 files / 1746 tests green (mobile shares this reducer).
- Desktop and mobile typechecks green.