### PR TITLE
fix(mobile-ios): pin fastlane and gate the Fastfile in CI

### DIFF
--- a/.github/workflows/mobile-ios-release.yml
+++ b/.github/workflows/mobile-ios-release.yml
@@ -32,6 +32,14 @@ jobs:
     runs-on: macos-26
     # Archive + upload is ~30–40m when healthy; 90m leaves margin for setup.
     timeout-minutes: 90
+
+    env:
+      # Why: this job and ios-distribute resolve gems ~25 minutes apart, so both
+      # must install the committed Gemfile.lock exactly. Frozen turns a lockfile
+      # drift into a setup failure instead of two different fastlane versions in
+      # one release.
+      BUNDLE_FROZEN: 'true'
+
     outputs:
       release_version: ${{ steps.release_metadata.outputs.version }}
       build_number: ${{ steps.release_metadata.outputs.build_number }}
@@ -148,6 +156,10 @@ jobs:
     # Fastlane's processing wait fails after 20m; this outer bound leaves setup
     # margin without allowing App Store Connect polling to hang for hours.
     timeout-minutes: 30
+
+    env:
+      # Same fastlane as ios-build, or fail before touching App Store Connect.
+      BUNDLE_FROZEN: 'true'
 
     defaults:
       run:

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -21,6 +21,12 @@ jobs:
   verify:
     runs-on: ubuntu-latest
 
+    env:
+      # Why: an unfrozen bundler silently re-resolves when Gemfile.lock drifts
+      # from the Gemfile, which is how the release jobs could land on different
+      # fastlane versions in the first place. Fail here instead.
+      BUNDLE_FROZEN: 'true'
+
     defaults:
       run:
         working-directory: mobile

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -12,6 +12,10 @@ on:
       # Why: the mobile terminal link parsers are conformance-tested against
       # these shared fixtures; desktop-side fixture edits must re-run this suite.
       - 'src/shared/terminal-file-link-conformance.ts'
+      # Why: this job holds the only checks that load the Fastfile, so edits to
+      # it or to the release workflow it guards must re-run them.
+      - '.github/workflows/mobile.yml'
+      - '.github/workflows/mobile-ios-release.yml'
 
 jobs:
   verify:
@@ -30,10 +34,15 @@ jobs:
         with:
           node-version-file: package.json
 
-      - name: Setup Ruby
+      # bundler-cache installs mobile/Gemfile.lock, so this job is also what
+      # proves the pinned fastlane the release workflow depends on still
+      # resolves — before a release run finds out.
+      - name: Setup Ruby and fastlane
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.3'
+          bundler-cache: true
+          working-directory: mobile
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
@@ -63,6 +72,20 @@ jobs:
 
       - name: Test iOS release version resolution
         run: ruby fastlane/ios_release_version_test.rb
+
+      - name: Test TestFlight lane arguments
+        run: ruby fastlane/fastfile_testflight_arguments_test.rb
+
+      # Why: nothing else in CI loads the Fastfile, so a syntax error, a broken
+      # require, or an undefined constant only surfaces mid-release — the
+      # ios-distribute job failed every run for six days that way. `lanes` just
+      # loads and lists, so it needs no App Store Connect credentials and makes
+      # no network calls to Apple.
+      - name: Smoke-check the Fastfile
+        env:
+          FASTLANE_SKIP_UPDATE_CHECK: '1'
+          FASTLANE_OPT_OUT_USAGE: '1'
+        run: bundle exec fastlane lanes
 
       - name: Lint
         run: pnpm lint

--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,8 @@ tests/tools/benchmarks/results/terminal-pipeline-*.json
 
 # Old release trees the cross-version wire harness extracts on demand
 tests/e2e/.cross-version-checkouts/
+
+# Bundler's install path for the mobile release toolchain (mobile/Gemfile.lock
+# IS committed). Also keeps oxfmt/oxlint, which honor this file, from walking
+# vendored gems.
+/mobile/vendor/

--- a/mobile/Gemfile
+++ b/mobile/Gemfile
@@ -1,6 +1,12 @@
-# Pins fastlane for reproducible iOS releases in CI (see fastlane/Fastfile and
-# .github/workflows/mobile-build.yml). macOS runners ship a fastlane, but
-# pinning here keeps the release toolchain stable across runner image bumps.
+# Pins fastlane for reproducible iOS releases in CI (see fastlane/Fastfile,
+# .github/workflows/mobile-ios-release.yml, and the Fastfile smoke check in
+# .github/workflows/mobile.yml). macOS runners ship a fastlane, but pinning here
+# keeps the release toolchain stable across runner image bumps.
+#
+# Why an exact version plus a committed Gemfile.lock: ios-build (macos) and
+# ios-distribute (ubuntu) resolve gems ~25 minutes apart, so an unpinned
+# fastlane could split a single release across two versions. Bump deliberately
+# in a PR so the Fastfile smoke check runs against the new version first.
 source "https://rubygems.org"
 
-gem "fastlane"
+gem "fastlane", "2.238.0"

--- a/mobile/Gemfile.lock
+++ b/mobile/Gemfile.lock
@@ -252,9 +252,9 @@ GEM
 
 PLATFORMS
   arm64-darwin
-  arm64-darwin-25
   ruby
   x86_64-linux
+  x86_64-linux-gnu
 
 DEPENDENCIES
   fastlane (= 2.238.0)

--- a/mobile/Gemfile.lock
+++ b/mobile/Gemfile.lock
@@ -1,0 +1,366 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    CFPropertyList (3.0.8)
+    abbrev (0.1.2)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
+    artifactory (3.0.17)
+    atomos (0.1.3)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1281.0)
+    aws-sdk-core (3.254.1)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-kms (1.130.0)
+      aws-sdk-core (~> 3, >= 3.254.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.229.0)
+      aws-sdk-core (~> 3, >= 3.254.1)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
+    babosa (1.0.4)
+    base64 (0.3.0)
+    benchmark (0.5.0)
+    bigdecimal (4.1.2)
+    claide (1.1.0)
+    colored (1.2)
+    colored2 (3.1.2)
+    commander (4.6.0)
+      highline (~> 2.0.0)
+    csv (3.3.6)
+    declarative (0.0.20)
+    digest-crc (0.7.0)
+      rake (>= 12.0.0, < 14.0.0)
+    domain_name (0.6.20240107)
+    dotenv (2.8.1)
+    emoji_regex (3.2.3)
+    erb (6.0.7)
+    excon (1.7.0)
+      logger
+    faraday (2.14.3)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-cookie_jar (0.0.8)
+      faraday (>= 0.8.0)
+      http-cookie (>= 1.0.0)
+    faraday-follow_redirects (0.5.0)
+      faraday (>= 1, < 3)
+    faraday-multipart (1.2.0)
+      multipart-post (~> 2.0)
+    faraday-net_http (3.4.4)
+      net-http (~> 0.5)
+    faraday-retry (2.4.0)
+      faraday (~> 2.0)
+    fastimage (2.4.1)
+    fastlane (2.238.0)
+      CFPropertyList (>= 2.3, < 5.0.0)
+      abbrev (~> 0.1)
+      addressable (>= 2.9.0, < 3.0.0)
+      artifactory (~> 3.0)
+      aws-sdk-s3 (~> 1.197)
+      babosa (>= 1.0.3, < 2.0.0)
+      base64 (~> 0.2)
+      benchmark (>= 0.1.0)
+      bundler (>= 2.4.0, < 5.0.0)
+      colored (~> 1.2)
+      commander (~> 4.6)
+      csv (~> 3.3)
+      dotenv (>= 2.1.1, < 3.0.0)
+      emoji_regex (>= 0.1, < 4.0)
+      excon (>= 0.71.0, < 2.0.0)
+      faraday (~> 2.7)
+      faraday-cookie_jar (~> 0.0.8)
+      faraday-follow_redirects (~> 0.3)
+      faraday-multipart (~> 1.0)
+      faraday-retry (~> 2.0)
+      fastimage (>= 2.1.0, < 3.0.0)
+      fastlane-sirp (>= 1.1.0)
+      gh_inspector (>= 1.1.2, < 2.0.0)
+      google-apis-androidpublisher_v3 (~> 0.3)
+      google-apis-playcustomapp_v1 (~> 0.1)
+      google-cloud-env (>= 1.6.0, < 2.3.0)
+      google-cloud-storage (~> 1.31)
+      highline (~> 2.0)
+      http-cookie (~> 1.0.5)
+      irb (>= 1.8)
+      json (< 3.0.0)
+      jwt (>= 2.10.3, < 4)
+      logger (>= 1.6, < 2.0)
+      mini_magick (>= 4.9.4, < 5.0.0)
+      multi_json (~> 1.12)
+      multipart-post (>= 2.0.0, < 3.0.0)
+      mutex_m (~> 0.3)
+      naturally (~> 2.2)
+      nkf (~> 0.2)
+      optparse (>= 0.1.1, < 1.0.0)
+      ostruct (>= 0.1.0)
+      plist (>= 3.1.0, < 4.0.0)
+      rubyzip (>= 2.0.0, < 3.0.0)
+      security (= 0.1.5)
+      simctl (~> 1.6.3)
+      terminal-notifier (>= 2.0.0, < 3.0.0)
+      terminal-table (~> 4)
+      tty-screen (>= 0.6.3, < 1.0.0)
+      tty-spinner (>= 0.8.0, < 1.0.0)
+      word_wrap (~> 1.0.0)
+      xcodeproj (>= 1.13.0, < 2.0.0)
+      xcpretty (~> 0.4.1)
+      xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
+    fastlane-sirp (1.1.0)
+    gh_inspector (1.1.3)
+    google-apis-androidpublisher_v3 (0.106.0)
+      google-apis-core (>= 0.15.0, < 2.a)
+    google-apis-core (1.2.5)
+      addressable (~> 2.9)
+      faraday (~> 2.13)
+      faraday-follow_redirects (~> 0.3)
+      googleauth (~> 1.14)
+      mini_mime (~> 1.1)
+      multi_json (~> 1.11)
+      representable (~> 3.0)
+      retriable (>= 3.1, < 5.0)
+    google-apis-iamcredentials_v1 (0.28.0)
+      google-apis-core (>= 0.15.0, < 2.a)
+    google-apis-playcustomapp_v1 (0.18.0)
+      google-apis-core (>= 0.15.0, < 2.a)
+    google-apis-storage_v1 (0.66.0)
+      google-apis-core (>= 0.15.0, < 2.a)
+    google-cloud-core (1.9.0)
+      google-cloud-env (>= 1.0, < 3.a)
+      google-cloud-errors (~> 1.0)
+    google-cloud-env (2.2.2)
+      base64 (~> 0.2)
+      faraday (>= 1.0, < 3.a)
+    google-cloud-errors (1.7.0)
+    google-cloud-storage (1.62.0)
+      addressable (~> 2.8)
+      digest-crc (~> 0.4)
+      google-apis-core (>= 0.18, < 2)
+      google-apis-iamcredentials_v1 (~> 0.18)
+      google-apis-storage_v1 (>= 0.42)
+      google-cloud-core (~> 1.6)
+      googleauth (~> 1.9)
+      mini_mime (~> 1.0)
+    google-logging-utils (0.2.0)
+    googleauth (1.17.3)
+      faraday (>= 1.0, < 3.a)
+      google-cloud-env (~> 2.2)
+      google-logging-utils (~> 0.1)
+      jwt (>= 1.4, < 4.0)
+      os (>= 0.9, < 2.0)
+      pstore (~> 0.1)
+      signet (>= 0.16, < 2.a)
+    highline (2.0.3)
+    http-cookie (1.0.8)
+      domain_name (~> 0.5)
+    io-console (0.9.2)
+    irb (1.18.0)
+      pp (>= 0.6.0)
+      prism (>= 1.3.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
+    jmespath (1.6.2)
+    json (2.21.2)
+    jwt (3.2.0)
+      base64
+    logger (1.7.0)
+    mini_magick (4.13.2)
+    mini_mime (1.1.5)
+    multi_json (1.21.1)
+    multipart-post (2.4.1)
+    mutex_m (0.3.0)
+    nanaimo (0.4.0)
+    naturally (2.3.0)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
+    nkf (0.3.0)
+    optparse (0.8.1)
+    os (1.1.4)
+    ostruct (0.6.3)
+    plist (3.7.2)
+    pp (0.6.4)
+      prettyprint
+    prettyprint (0.2.0)
+    prism (1.9.0)
+    pstore (0.2.1)
+    public_suffix (7.0.5)
+    rake (13.4.2)
+    rbs (4.1.3)
+      logger
+      prism (>= 1.6.0)
+      tsort
+    rdoc (8.0.0)
+      erb
+      prism (>= 1.6.0)
+      rbs (>= 4.0.0)
+      tsort
+    reline (0.7.0)
+      io-console (~> 0.5)
+    representable (3.2.0)
+      declarative (< 0.1.0)
+      trailblazer-option (>= 0.1.1, < 0.2.0)
+      uber (< 0.2.0)
+    retriable (4.2.0)
+    rexml (3.4.4)
+    rouge (3.28.0)
+    rubyzip (2.4.1)
+    security (0.1.5)
+    signet (0.22.0)
+      addressable (~> 2.8)
+      faraday (>= 0.17.5, < 3.a)
+      jwt (>= 1.5, < 4.0)
+    simctl (1.6.10)
+      CFPropertyList
+      naturally
+    terminal-notifier (2.0.0)
+    terminal-table (4.0.0)
+      unicode-display_width (>= 1.1.1, < 4)
+    trailblazer-option (0.1.2)
+    tsort (0.2.0)
+    tty-cursor (0.7.1)
+    tty-screen (0.8.2)
+    tty-spinner (0.9.3)
+      tty-cursor (~> 0.7)
+    uber (0.1.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
+    uri (1.1.1)
+    word_wrap (1.0.0)
+    xcodeproj (1.28.1)
+      CFPropertyList (>= 2.3.3, < 4.0)
+      atomos (~> 0.1.3)
+      base64
+      claide (>= 1.0.2, < 2.0)
+      colored2 (~> 3.1)
+      nanaimo (~> 0.4.0)
+      nkf
+      rexml (>= 3.3.6, < 4.0)
+    xcpretty (0.4.1)
+      rouge (~> 3.28.0)
+    xcpretty-travis-formatter (1.0.1)
+      xcpretty (~> 0.2, >= 0.0.7)
+
+PLATFORMS
+  arm64-darwin
+  arm64-darwin-25
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  fastlane (= 2.238.0)
+
+CHECKSUMS
+  CFPropertyList (3.0.8) sha256=2c99d0d980536d3d7ab252f7bd59ac8be50fbdd1ff487c98c949bb66bb114261
+  abbrev (0.1.2) sha256=ad1b4eaaaed4cb722d5684d63949e4bde1d34f2a95e20db93aecfe7cbac74242
+  addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  artifactory (3.0.17) sha256=3023d5c964c31674090d655a516f38ca75665c15084140c08b7f2841131af263
+  atomos (0.1.3) sha256=7d43b22f2454a36bace5532d30785b06de3711399cb1c6bf932573eda536789f
+  aws-eventstream (1.4.0) sha256=116bf85c436200d1060811e6f5d2d40c88f65448f2125bc77ffce5121e6e183b
+  aws-partitions (1.1281.0) sha256=97fcc7d6a068ab790a1efcd8c6587c08fb108b4bed7ff1409cb47e0d642782ec
+  aws-sdk-core (3.254.1) sha256=518089e32134c3478cd4ec63d07fb966546a45e9e4cbf5f80d2cf16d5699d29b
+  aws-sdk-kms (1.130.0) sha256=a2e83662ca31b77a2a19c9aa2f40a98165a67270c18c718fe1c70d0cbd7cd749
+  aws-sdk-s3 (1.229.0) sha256=7dd11a111875b3505d2ec0a0a383a6aab6c1badb3d4e94e7fbb958a24451f596
+  aws-sigv4 (1.12.1) sha256=6973ff95cb0fd0dc58ba26e90e9510a2219525d07620c8babeb70ef831826c00
+  babosa (1.0.4) sha256=18dea450f595462ed7cb80595abd76b2e535db8c91b350f6c4b3d73986c5bc99
+  base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
+  bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
+  claide (1.1.0) sha256=6d3c5c089dde904d96aa30e73306d0d4bd444b1accb9b3125ce14a3c0183f82e
+  colored (1.2) sha256=9d82b47ac589ce7f6cab64b1f194a2009e9fd00c326a5357321f44afab2c1d2c
+  colored2 (3.1.2) sha256=b13c2bd7eeae2cf7356a62501d398e72fde78780bd26aec6a979578293c28b4a
+  commander (4.6.0) sha256=7d1ddc3fccae60cc906b4131b916107e2ef0108858f485fdda30610c0f2913d9
+  csv (3.3.6) sha256=aba61e7e507a66f03d45cb1f3c4b6359861c3504038b422962875dce099e4456
+  declarative (0.0.20) sha256=8021dd6cb17ab2b61233c56903d3f5a259c5cf43c80ff332d447d395b17d9ff9
+  digest-crc (0.7.0) sha256=64adc23a26a241044cbe6732477ca1b3c281d79e2240bcff275a37a5a0d78c07
+  domain_name (0.6.20240107) sha256=5f693b2215708476517479bf2b3802e49068ad82167bcd2286f899536a17d933
+  dotenv (2.8.1) sha256=c5944793349ae03c432e1780a2ca929d60b88c7d14d52d630db0508c3a8a17d8
+  emoji_regex (3.2.3) sha256=ecd8be856b7691406c6bf3bb3a5e55d6ed683ffab98b4aa531bb90e1ddcc564b
+  erb (6.0.7) sha256=c5ca6dc25b0ef974a44dc8f59fe847577122483b1968a38dec305c60bf91ee92
+  excon (1.7.0) sha256=b8deec2bf978123b7e4b13a103ffec61557c6feaba34706dbc1ce4a94dec33e0
+  faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
+  faraday-cookie_jar (0.0.8) sha256=0140605823f8cc63c7028fccee486aaed8e54835c360cffc1f7c8c07c4299dbb
+  faraday-follow_redirects (0.5.0) sha256=5cde93c894b30943a5d2b93c2fe9284216a6b756f7af406a1e55f211d97d10ad
+  faraday-multipart (1.2.0) sha256=7d89a949693714176f612323ca13746a2ded204031a6ba528adee788694ef757
+  faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
+  faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
+  fastimage (2.4.1) sha256=c64bebd46b6fd8943ab70c1e6e85ff728f970f2e48f92ecd249b6bc3a540ad20
+  fastlane (2.238.0) sha256=78e9252df2224c7e427012638e41051edfa29b133a40fda883fd2f1c13a77b98
+  fastlane-sirp (1.1.0) sha256=10bc94f9682efd8e1badfb31452a76dd8981f1f3a33717c765fde6d75b54d847
+  gh_inspector (1.1.3) sha256=04cca7171b87164e053aa43147971d3b7f500fcb58177698886b48a9fc4a1939
+  google-apis-androidpublisher_v3 (0.106.0) sha256=b90b5312b70f8f731def88f24a2b8fb791fe1b979a7c2c14a905cb6cae19cf3f
+  google-apis-core (1.2.5) sha256=e21562b5627a0fc6a0c3165e429c3afed0f6a628eaa514e83f7204dda1adff69
+  google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
+  google-apis-playcustomapp_v1 (0.18.0) sha256=44b277b9dee4a59ac5e9d98be1485edc5e382d2f9d73c79ae8908a455786a254
+  google-apis-storage_v1 (0.66.0) sha256=fdf6d65d3fc77e7046b3494333a818ece9e2afd763bb161e1a7a9e70cf198351
+  google-cloud-core (1.9.0) sha256=ab55409f51488e8deefb6edcc1ce4771dfb5da2fe7b3bc075709a030c2b682a4
+  google-cloud-env (2.2.2) sha256=94bed40e05a67e9468ce1cb38389fba9a90aa8fc62fc9e173204c1dca59e21e7
+  google-cloud-errors (1.7.0) sha256=6e682f42d89aae08689f36f28495de629d756da076bafff0003bac7f8042ebb3
+  google-cloud-storage (1.62.0) sha256=e2c3c08bf8fd40d50be92304084942203314d4fc0ee52028e99f9359c3ad1330
+  google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
+  googleauth (1.17.3) sha256=9a655455885c0c17a8b70537acd2a992a7c7842c43c06c6612dfb0d93e755d58
+  highline (2.0.3) sha256=2ddd5c127d4692721486f91737307236fe005352d12a4202e26c48614f719479
+  http-cookie (1.0.8) sha256=b14fe0445cf24bf9ae098633e9b8d42e4c07c3c1f700672b09fbfe32ffd41aa6
+  io-console (0.9.2) sha256=efa74f891dd03c0939a931dfc6e74c2813d904763d456ea9762b0525e748db08
+  irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
+  jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
+  json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
+  jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  mini_magick (4.13.2) sha256=71d6258e0e8a3d04a9a0a09784d5d857b403a198a51dd4f882510435eb95ddd9
+  mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
+  multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
+  multipart-post (2.4.1) sha256=9872d03a8e552020ca096adadbf5e3cb1cd1cdd6acd3c161136b8a5737cdb4a8
+  mutex_m (0.3.0) sha256=cfcb04ac16b69c4813777022fdceda24e9f798e48092a2b817eb4c0a782b0751
+  nanaimo (0.4.0) sha256=faf069551bab17f15169c1f74a1c73c220657e71b6e900919897a10d991d0723
+  naturally (2.3.0) sha256=459923cf76c2e6613048301742363200c3c7e4904c324097d54a67401e179e01
+  net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
+  nkf (0.3.0) sha256=357a8dbeba38b727b75930f665146546076a394a1c243faf634ff176e3588895
+  optparse (0.8.1) sha256=42bea10d53907ccff4f080a69991441d611fbf8733b60ed1ce9ee365ce03bd1a
+  os (1.1.4) sha256=57816d6a334e7bd6aed048f4b0308226c5fb027433b67d90a9ab435f35108d3f
+  ostruct (0.6.3) sha256=95a2ed4a4bd1d190784e666b47b2d3f078e4a9efda2fccf18f84ddc6538ed912
+  plist (3.7.2) sha256=d37a4527cc1116064393df4b40e1dbbc94c65fa9ca2eec52edf9a13616718a42
+  pp (0.6.4) sha256=dfcb0fce700c41456265922884f9fe195d7fbb0674a3578e6c0f69588e82b570
+  prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
+  pstore (0.2.1) sha256=03904d0f2c66579e96d1e6704cdabc0c88df7ea8ed8782d9f3569f6f6c702c1a
+  public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
+  rbs (4.1.3) sha256=0c4474a9751cdc14364bfad0b3e53678323bbdc2c31683b0445932867dbab8c4
+  rdoc (8.0.0) sha256=03bf8c08a9639658855a0cfd77c0abca8325c227693f7f33f82957811348c469
+  reline (0.7.0) sha256=5b012d8e55dbf9d450f12bde2cf7d15ff546ae80b3f8f3b30e570d431815583d
+  representable (3.2.0) sha256=cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace
+  retriable (4.2.0) sha256=90c3b257472a1c02f2a3dfa64dd35a420f7a624cef1a5981e20fdac5730f8cdc
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rouge (3.28.0) sha256=0d6de482c7624000d92697772ab14e48dca35629f8ddf3f4b21c99183fd70e20
+  rubyzip (2.4.1) sha256=8577c88edc1fde8935eb91064c5cb1aef9ad5494b940cf19c775ee833e075615
+  security (0.1.5) sha256=3a977a0eca7706e804c96db0dd9619e0a94969fe3aac9680fcfc2bf9b8a833b7
+  signet (0.22.0) sha256=b76d495ccb07ad35dbc89f3e920665a9d8ed717141955034005d7843dcfe4780
+  simctl (1.6.10) sha256=b99077f4d13ad81eace9f86bf5ba4df1b0b893a4d1b368bd3ed59b5b27f9236b
+  terminal-notifier (2.0.0) sha256=7a0d2b2212ab9835c07f4b2e22a94cff64149dba1eed203c04835f7991078cea
+  terminal-table (4.0.0) sha256=f504793203f8251b2ea7c7068333053f0beeea26093ec9962e62ea79f94301d2
+  trailblazer-option (0.1.2) sha256=20e4f12ea4e1f718c8007e7944ca21a329eee4eed9e0fa5dde6e8ad8ac4344a3
+  tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
+  tty-cursor (0.7.1) sha256=79534185e6a777888d88628b14b6a1fdf5154a603f285f80b1753e1908e0bf48
+  tty-screen (0.8.2) sha256=c090652115beae764336c28802d633f204fb84da93c6a968aa5d8e319e819b50
+  tty-spinner (0.9.3) sha256=0e036f047b4ffb61f2aa45f5a770ec00b4d04130531558a94bfc5b192b570542
+  uber (0.1.0) sha256=5beeb407ff807b5db994f82fa9ee07cfceaa561dad8af20be880bc67eba935dc
+  unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
+  unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
+  uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
+  word_wrap (1.0.0) sha256=f556d4224c812e371000f12a6ee8102e0daa724a314c3f246afaad76d82accc7
+  xcodeproj (1.28.1) sha256=6f12670f00739d9817ca27ac89d6ef01cc86050e22a0bc08a3131487e5b5cddc
+  xcpretty (0.4.1) sha256=b14c50e721f6589ee3d6f5353e2c2cfcd8541fa1ea16d6c602807dd7327f3892
+  xcpretty-travis-formatter (1.0.1) sha256=aacc332f17cb7b2cba222994e2adc74223db88724fe76341483ad3098e232f93
+
+BUNDLED WITH
+  4.0.11

--- a/mobile/fastlane/Fastfile
+++ b/mobile/fastlane/Fastfile
@@ -261,6 +261,12 @@ platform :ios do
       distribute_only: true,
       skip_waiting_for_build_processing: false,
       wait_processing_timeout_duration: TESTFLIGHT_PROCESSING_TIMEOUT_SECONDS,
+      # submit_beta_review is on by default, so a superseded build of this same
+      # version train still sitting in beta review blocks the new submission
+      # ("Another build is in review" killed the 2026-08-05/08-06 runs).
+      # Fastlane filters by this build's preReleaseVersion, so it can only
+      # expire a build of the train this run is already replacing.
+      reject_build_waiting_for_review: true,
       distribute_external: true,
       groups: TESTFLIGHT_GROUPS,
       notify_external_testers: true,

--- a/mobile/fastlane/fastfile_testflight_arguments_test.rb
+++ b/mobile/fastlane/fastfile_testflight_arguments_test.rb
@@ -80,9 +80,6 @@ class FastfileTestflightArgumentsTest < Minitest::Test
   end
 
   def test_distribute_only_uploads_pass_the_app_platform
-    distribute_only_calls = @calls.select { |arguments| arguments["distribute_only"] == "true" }
-
-    refute_empty(distribute_only_calls, "expected a distribute_only upload_to_testflight call")
     distribute_only_calls.each do |arguments|
       # Without a local .ipa to sniff, pilot falls through to an interactive
       # platform prompt and crashes the ubuntu distribute job (#14087).
@@ -91,7 +88,7 @@ class FastfileTestflightArgumentsTest < Minitest::Test
   end
 
   def test_distribute_only_uploads_clear_a_build_stuck_in_beta_review
-    @calls.select { |arguments| arguments["distribute_only"] == "true" }.each do |arguments|
+    distribute_only_calls.each do |arguments|
       # submit_beta_review defaults on, so a superseded same-train build left in
       # beta review fails the submission with "Another build is in review".
       assert_equal("true", arguments["reject_build_waiting_for_review"])
@@ -114,5 +111,16 @@ class FastfileTestflightArgumentsTest < Minitest::Test
 
     assert_equal("true", arguments["distribute_only"])
     assert_nil(arguments["app_platform"])
+  end
+
+  private
+
+  # Asserting on an empty selection would pass vacuously, so the lane's presence
+  # is part of the contract.
+  def distribute_only_calls
+    calls = @calls.select { |arguments| arguments["distribute_only"] == "true" }
+    refute_empty(calls, "expected a distribute_only upload_to_testflight call")
+
+    calls
   end
 end

--- a/mobile/fastlane/fastfile_testflight_arguments_test.rb
+++ b/mobile/fastlane/fastfile_testflight_arguments_test.rb
@@ -1,0 +1,118 @@
+require "minitest/autorun"
+require "ripper"
+
+# Pins the upload_to_testflight arguments that two release outages proved a
+# release cannot run without. `bundle exec fastlane lanes` loads and parses the
+# Fastfile but exits 0 with either argument missing — both failures only surface
+# once a real release is already mid-flight — so the arguments are asserted here
+# statically instead.
+module FastfileTestflightArguments
+  module_function
+
+  # [{ "app_platform" => "ios", ... }] for every upload_to_testflight call in
+  # `source`. Values are flattened to the first meaningful token so a keyword's
+  # presence and its literal can both be asserted.
+  def calls(source, action: "upload_to_testflight")
+    found = []
+    each_node(Ripper.sexp(source) || []) do |node|
+      next unless node[0] == :method_add_arg
+      next unless identifier(node[1]) == action
+
+      found << keyword_arguments(node[2])
+    end
+    found
+  end
+
+  def each_node(node, &block)
+    return unless node.is_a?(Array)
+
+    block.call(node) if node[0].is_a?(Symbol)
+    node.each { |child| each_node(child, &block) }
+  end
+
+  def identifier(node)
+    return nil unless node.is_a?(Array) && node[0] == :fcall
+
+    token(node[1], %i[@ident @const])
+  end
+
+  def keyword_arguments(node)
+    arguments = {}
+    each_node(node) do |child|
+      next unless child[0] == :assoc_new
+
+      label = token(child[1], [:@label])
+      arguments[label.delete_suffix(":")] = describe_value(child[2]) if label
+    end
+    arguments
+  end
+
+  # Strings collapse to their content; everything else (true, a constant, a
+  # local) collapses to its first token, which is enough to assert intent.
+  def describe_value(node)
+    contents = []
+    each_node(node) { |child| contents << child[1] if child[0] == :@tstring_content }
+    return contents.join unless contents.empty?
+
+    token(node, %i[@kw @const @ident @int])
+  end
+
+  def token(node, types)
+    found = nil
+    each_node(node) do |child|
+      found ||= child[1] if types.include?(child[0]) && child[1].is_a?(String)
+    end
+    found
+  end
+end
+
+class FastfileTestflightArgumentsTest < Minitest::Test
+  FASTFILE = File.expand_path("Fastfile", __dir__).freeze
+
+  def setup
+    @calls = FastfileTestflightArguments.calls(File.read(FASTFILE))
+  end
+
+  # Anchor: a parse that silently finds nothing would make every other
+  # assertion here pass vacuously.
+  def test_finds_the_upload_and_distribute_calls
+    assert_operator(@calls.size, :>=, 2, "expected upload_to_testflight in the build and distribute lanes")
+  end
+
+  def test_distribute_only_uploads_pass_the_app_platform
+    distribute_only_calls = @calls.select { |arguments| arguments["distribute_only"] == "true" }
+
+    refute_empty(distribute_only_calls, "expected a distribute_only upload_to_testflight call")
+    distribute_only_calls.each do |arguments|
+      # Without a local .ipa to sniff, pilot falls through to an interactive
+      # platform prompt and crashes the ubuntu distribute job (#14087).
+      assert_equal("ios", arguments["app_platform"])
+    end
+  end
+
+  def test_distribute_only_uploads_clear_a_build_stuck_in_beta_review
+    @calls.select { |arguments| arguments["distribute_only"] == "true" }.each do |arguments|
+      # submit_beta_review defaults on, so a superseded same-train build left in
+      # beta review fails the submission with "Another build is in review".
+      assert_equal("true", arguments["reject_build_waiting_for_review"])
+    end
+  end
+
+  # The detector itself must be able to go red, or it is not a gate.
+  def test_reports_a_distribute_only_call_that_omits_the_app_platform
+    source = <<~RUBY
+      lane :distribute_testflight do
+        upload_to_testflight(
+          api_key: api_key,
+          distribute_only: true,
+          groups: TESTFLIGHT_GROUPS,
+        )
+      end
+    RUBY
+
+    arguments = FastfileTestflightArguments.calls(source).first
+
+    assert_equal("true", arguments["distribute_only"])
+    assert_nil(arguments["app_platform"])
+  end
+end


### PR DESCRIPTION
## ELI5

An iOS release lane was missing one argument, and nothing in CI ever loads the release script — so the mistake was only discovered by a real release failing. External TestFlight testers got nothing for six days. This pins the release toolchain and makes CI load and check the release script on every mobile PR, so the same class of mistake goes red in a PR instead of mid-release.

## What Changed

**1. Pinned the release toolchain**

- `mobile/Gemfile`: `gem "fastlane"` → `gem "fastlane", "2.238.0"`, plus a committed `mobile/Gemfile.lock` (101 gems). `ios-build` (macos-26) and `ios-distribute` (ubuntu-latest) resolved gems independently ~25 minutes apart, so a fastlane release landing mid-run could split one release across two versions.
- `BUNDLE_FROZEN: 'true'` on both release jobs and the checks job — without it a lockfile that drifts from the Gemfile is silently re-resolved per job, which is exactly the split the pin exists to prevent.
- `mobile/Gemfile.lock` was **not** gitignored (`git check-ignore` says no rule matched), so nothing had to be un-ignored — it just never existed.
- `/mobile/vendor/` gitignored: `bundler-cache` installs gems to `mobile/vendor/bundle`, and `oxfmt`/`oxlint` honor `.gitignore` (verified — the vendored `rdoc` gem ships 11 `.js` files that `oxfmt --check .` picks up otherwise, which would have turned `Check formatting` red for reasons unrelated to the PR).
- Fixed the Gemfile comment's dead `.github/workflows/mobile-build.yml` reference (the real file is `mobile.yml`) and its false claim that the file pinned anything.

**2. Two new gates in Mobile Checks** (`.github/workflows/mobile.yml`)

- **Smoke-check the Fastfile** — `bundle exec fastlane lanes`, which loads and parses the Fastfile. Offline: `lanes` only lists lanes, so no App Store Connect credentials and no calls to Apple.
- **Test TestFlight lane arguments** — `mobile/fastlane/fastfile_testflight_arguments_test.rb`, a Ripper-based static contract over `upload_to_testflight` calls. **This is the check that catches the actual outage**: I reintroduced the `#14087` bug and `fastlane lanes` still exited **0** (see Testing). Parsing the Fastfile cannot catch a missing *optional* argument, because `app_platform` is optional to fastlane and only fails at pilot's interactive prompt. So the arguments two outages proved a release cannot run without are asserted directly.
- Added both workflow files to the `paths` filter so the gate cannot be edited without running.

**3. `reject_build_waiting_for_review: true` in `distribute_testflight`** — decision and risk analysis below.

No app code touched. No release workflow triggered, no tags pushed.

## Why

The `ios-distribute` job (added 2026-08-10 by #13419) failed on **every** run until 2026-08-13. `distribute_testflight` called `upload_to_testflight` with `distribute_only: true` but no `app_platform:`. Verified in fastlane 2.238.0 source: with `distribute_only`, the action skips `.ipa`/`.pkg` resolution (`upload_to_testflight.rb:13-18`), so `Manager#fetch_app_platform` has nothing to sniff and falls through to `UI.input("Please enter the app's platform...")` (`pilot/manager.rb:88`) — an interactive prompt on a headless ubuntu runner, which crashes as `FastlaneCore::Interface::FastlaneCrash`. #14087 fixed it with `app_platform: "ios"`.

**External TestFlight testers received nothing for six days**, and the reason it took six days is structural: nothing in CI loads the Fastfile. The only Ruby step in `mobile.yml` was `ruby fastlane/ios_release_version_test.rb`, which requires `ios_release_version.rb` and never touches the Fastfile. Any lane-level mistake — a missing argument, a bad `require`, a typo'd constant, a syntax error — first surfaces during a real release, and for the distribute job that means after a 40-minute build has already uploaded a binary.

**On `reject_build_waiting_for_review` — set to true, deliberately.** `submit_beta_review` defaults to `true` and `reject_build_waiting_for_review` defaults to `false`, so a superseded build of the same train left in beta review blocks the new submission — the "Another build is in review" failure that killed the 2026-08-05 and 2026-08-06 runs. It is not a blind flip; I read the implementation (`pilot/build_manager.rb:379-392`) before deciding:

- The query is **filtered by `preReleaseVersion.version` — the version train of the build being distributed**. It cannot touch a build of a different marketing version, so a release candidate someone deliberately submitted on another version is not at risk.
- Within that train, the only build it can expire is one this pipeline is *already replacing*: the lane runs with an explicit `version`/`build_number` from `ios-build`, i.e. a strictly newer build of the same train that we are about to hand to the peeps group. Superseding it is the intent of the run.
- Known cost, accepted: the filter also matches `IN_REVIEW`, not just `WAITING_FOR_REVIEW`, and `expire!` retires the old build rather than only withdrawing its submission — so an in-flight beta review of the *same train* is cancelled and that older build stops being installable by internal testers. That build is superseded seconds later anyway; the alternative is a hard release block, which is what actually happened twice.
- This is safe *because* the train is automation-owned: `TESTFLIGHT_GROUPS = ["peeps"]` and this workflow is the only thing that submits. If a human-submitted, still-wanted build could share a train with an automated release, this flag would be the wrong tool.

## Linked Issue

No filed issue. This is the recurrence gate for the 2026-08-10 → 2026-08-13 `ios-distribute` outage; the root cause itself was already fixed by #14087 (introduced by #13419), and the "no CI check loads the Fastfile" gap had no ticket of its own.

## Visual Proof

`N/A` — release-pipeline only (CI workflow, Gemfile/lockfile, fastlane lane arguments, a Ruby test). No renderer, mobile app, or user-visible surface changes, so there is nothing to screenshot.

## Testing

Ruby: local `4.0.5` and system `2.6.10`, which bracket CI's `3.3` (the Ripper node shapes the contract test relies on are identical on both — extraction output compared and byte-identical). Gems installed to a temp `BUNDLE_PATH` from the committed lockfile in frozen mode.

```
ruby -c mobile/fastlane/Fastfile                              → Syntax OK
ruby -c mobile/fastlane/fastfile_testflight_arguments_test.rb  → Syntax OK
ruby mobile/fastlane/ios_release_version_test.rb   → 11 runs, 23 assertions, 0 failures  (existing suite)
ruby mobile/fastlane/fastfile_testflight_arguments_test.rb → 4 runs, 10 assertions, 0 failures  (new)
bundle exec fastlane lanes  → exit 0, lists all four ios lanes, offline, no credentials
```

**A check that cannot go red is worthless, so each gate was broken deliberately and restored:**

| Deliberate break | `fastlane lanes` | contract test |
| --- | --- | --- |
| Baseline (as committed) | 0 ✅ | 0 ✅ |
| Drop `app_platform` — the exact #14087 bug | **0 — misses it** | **1 (red)** |
| Drop `reject_build_waiting_for_review` | 0 | **1 (red)** |
| `app_platform: "osx"` (wrong platform) | 0 | **1 (red)** |
| Drop `distribute_only` (vacuity guard) | 0 | **1 (red)** |
| Rename the action call (parse-anchor guard) | 0 | **1 (red)** |
| Fastfile syntax error | **1 (red)** | 1 (red) |
| Bad `require_relative` | **1 (red)** | — |
| Undefined constant at load | **1 (red)** | — |

That first row is the reason both gates exist: `fastlane lanes` alone cannot catch the bug that caused this outage.

`BUNDLE_FROZEN` was verified load-bearing too: pointing the Gemfile at `2.237.0` while the lockfile said `2.238.0` failed with exit `16` ("the lockfile can't be updated because frozen mode is set"); restoring the pin returned exit `0`.

Lockfile safety, since a bad lockfile would break the very releases this hardens:
- Resolved under Ruby 4.0.5 but **every one of the 101 locked gem versions was checked against Ruby 3.3** via the rubygems compact index (`ruby:` requirement) — all satisfied.
- `PLATFORMS` covers `x86_64-linux` + `x86_64-linux-gnu` (ubuntu jobs), `arm64-darwin` (macos build job), and `ruby` as a universal fallback, canonicalized with `bundle lock --normalize-platforms`. No platform-specific gem pins, so a runner image bump cannot strand it.
- `bundler-cache: true` in Mobile Checks means CI itself installs this lockfile on ubuntu + Ruby 3.3 on every mobile PR — the pin the release depends on is now continuously proven.

**Confirmed on CI, not just locally** (Mobile Checks, this PR): Ruby 3.3.12 x86_64-linux installed `fastlane 2.238.0` and all 101 locked gems from the committed lockfile, `Test TestFlight lane arguments` passed (4 runs, 9 assertions), `Smoke-check the Fastfile` loaded the Fastfile and listed all four `ios` lanes, and `Lint` / `Check formatting` still pass with `mobile/vendor/bundle` present on disk — which is the gitignore entry doing its job.

One log note for reviewers: `bundle install` prints `Cannot write a changed lockfile while frozen.` immediately before `Bundle complete! ... 101 gems now installed`. It is informational and not drift — `setup-ruby` also sets `deployment true`, so bundler cannot substitute a version; it would abort rather than install a different one. I chased it rather than assuming: adding the runner's `x86_64-linux-gnu` triple and running bundler's own `--normalize-platforms` both left the line unchanged (a cache-hit run prints it too), so it is a platform-local detail bundler would re-record on linux, not a resolution difference. Versions installed match the lockfile exactly.

Not run per instruction: full `pnpm typecheck` / `tsc -b`. No release workflow was triggered and no tags were pushed. Verified separately that the vendored gem tree contains **zero** `.ts`/`.tsx` files, so `mobile/tsconfig.json`'s `**/*.ts` include is unaffected by the new `vendor/bundle` directory.

Platforms: the changed surfaces are the two GitHub-hosted runners (ubuntu-latest, macos-26) plus Ruby-version portability, covered above. No SSH, remote-wire, folder-workspace, or Git-binary surface is touched.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

- **Security**: no new secrets or permissions. The pin plus committed lockfile with checksums *narrows* the release supply chain — previously each job installed whatever fastlane rubygems served at that minute. `fastlane lanes` runs with no App Store Connect env vars, so a malicious PR cannot use it to reach Apple with our credentials.
- **Backwards compatibility**: `reject_build_waiting_for_review` only changes behavior when a same-train build is sitting in beta review, i.e. only in the case that was already failing. Lane names, inputs, and outputs are unchanged.
- **Performance**: adds a bundler install (cached by lockfile hash) plus two sub-second Ruby steps to Mobile Checks. Release jobs get a cache hit on the same lockfile instead of a cold resolve.
- **Mobile/app**: no app code, no runtime code, no wire changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — Ruby syntax checks and both fastlane suites run locally (above); the TS gates are untouched by this PR and left to CI per instruction not to run a full typecheck

## Author

- X / Twitter: @BrennanKB5
