### PR TITLE
fix(codex): stop resuming a session under the wrong account when a sessions tree is locked

### DIFF
--- a/src/main/codex/codex-legacy-session-resume.test.ts
+++ b/src/main/codex/codex-legacy-session-resume.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   existsSync,
   linkSync,
@@ -11,11 +11,35 @@ import {
 } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { basename, dirname, join } from 'node:path'
+import type * as NodeFsPromises from 'node:fs/promises'
 import {
   codexRolloutHardlinkIdentity,
   dedupeCodexRolloutFileAliases
 } from '../ai-vault/codex-session-root-dedup'
 import { prepareLegacySharedCodexSessionResume } from './codex-legacy-session-resume'
+import { ManagedCodexHomeTemporarilyUnavailableError } from '../codex-accounts/host-codex-managed-home-ownership'
+
+const lstatFaults = vi.hoisted(() => ({
+  path: null as string | null,
+  reset(): void {
+    lstatFaults.path = null
+  }
+}))
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFsPromises>()
+  return {
+    ...actual,
+    lstat: async (...args: Parameters<typeof actual.lstat>) => {
+      if (args[0] === lstatFaults.path) {
+        const error: NodeJS.ErrnoException = new Error(`EBUSY: locked '${args[0]}'`)
+        error.code = 'EBUSY'
+        throw error
+      }
+      return actual.lstat(...args)
+    }
+  }
+})
 
 describe('prepareLegacySharedCodexSessionResume', () => {
   let root: string
@@ -24,6 +48,7 @@ describe('prepareLegacySharedCodexSessionResume', () => {
   let rolloutPath: string
 
   beforeEach(() => {
+    lstatFaults.reset()
     root = mkdtempSync(join(tmpdir(), 'orca-legacy-codex-resume-'))
     legacyHome = join(root, 'codex-runtime-home', 'home')
     systemHome = join(root, 'real-codex-home')
@@ -40,6 +65,7 @@ describe('prepareLegacySharedCodexSessionResume', () => {
   })
 
   afterEach(() => {
+    lstatFaults.reset()
     rmSync(root, { recursive: true, force: true })
   })
 
@@ -267,6 +293,22 @@ describe('per-account resume repin', () => {
     )
 
     expect(result).toEqual({ useRealCodexHome: false })
+  })
+
+  it('refuses when the selected rollout is temporarily unreadable', async () => {
+    lstatFaults.path = recordedRolloutPath
+
+    await expect(
+      prepareLegacySharedCodexSessionResume(
+        {
+          agent: 'codex',
+          filePath: bridgedRolloutPath,
+          codexHome: peerHome,
+          executionHostId: 'local'
+        },
+        repinOptions()
+      )
+    ).rejects.toBeInstanceOf(ManagedCodexHomeTemporarilyUnavailableError)
   })
 
   it('declines a session owned by another host', async () => {

--- a/src/main/codex/codex-legacy-session-resume.ts
+++ b/src/main/codex/codex-legacy-session-resume.ts
@@ -18,6 +18,7 @@ import {
   isAtomicNoReplaceUnsupportedError
 } from './codex-session-backfill-copy'
 import { resolveCodexSessionBackfillPaths } from './codex-session-backfill'
+import { ManagedCodexHomeTemporarilyUnavailableError } from '../codex-accounts/host-codex-managed-home-ownership'
 
 const RETRYABLE_RESUME_ERROR =
   'Orca could not safely move this legacy Codex session into your system Codex home. Retry resume; if it still fails, check that both Codex session folders are readable and writable.'
@@ -120,8 +121,16 @@ async function resolveSelectedAccountCodexHomeForResume(
     const candidateStat = await lstat(candidatePath)
     // Why: the bridge is async, so an unbridged rollout is a real state — decline rather than pin a home codex cannot resume from.
     return candidateStat.isFile() && !candidateStat.isSymbolicLink() ? selectedCodexHome : null
-  } catch {
-    return null
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | null)?.code
+    if (code === 'ENOENT' || code === 'ENOTDIR') {
+      return null
+    }
+    // Why: a blanket catch here declined the SELECTED account on a briefly
+    // locked file and kept the source per-account home, resuming under another
+    // account's credentials while the UI still showed the selected one. Only a
+    // definitive absence means "not bridged here" (STA-4607).
+    throw new ManagedCodexHomeTemporarilyUnavailableError(undefined, { cause: error })
   }
 }
 

--- a/src/main/codex/codex-session-resume-home.ts
+++ b/src/main/codex/codex-session-resume-home.ts
@@ -1,4 +1,4 @@
-import { existsSync, lstatSync } from 'node:fs'
+import { lstatSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import {
   getRuntimePathBasename,
@@ -6,6 +6,7 @@ import {
   relativePathInsideRoot
 } from '../../shared/cross-platform-path'
 import { listCodexSessionRolloutFilesIncrementally } from './codex-session-file-listing'
+import { ManagedCodexHomeTemporarilyUnavailableError } from '../codex-accounts/host-codex-managed-home-ownership'
 
 // Why: only Codex's dated rollout layout may establish account-home provenance; nested/misplaced JSONL must not select credentials.
 const CLAIMED_CODEX_ROLLOUT_TAIL = String.raw`\d{4}/\d{2}/\d{2}/rollout-[^/]+\.jsonl(?:\.zst)?`
@@ -213,6 +214,40 @@ function rankTrustedCodexHomesForRescan(args: {
     .map((entry) => entry.homePath)
 }
 
+function isSelectedAccountHome(selectedAccountHome: string | null, homePath: string): boolean {
+  return (
+    selectedAccountHome !== null &&
+    normalizeRuntimePathForComparison(selectedAccountHome) ===
+      normalizeRuntimePathForComparison(homePath)
+  )
+}
+
+/**
+ * Why: `existsSync` reports false for *any* stat error, so a briefly locked
+ * sessions tree (antivirus, backup, indexer) reads as "this rollout is not
+ * bridged here" and the scan moves on to the next ranked home. For the selected
+ * account that silently resumes the session under a DIFFERENT account's
+ * credentials while the UI still shows the selected one, so only a definitive
+ * absence may skip it (STA-4607).
+ */
+function sessionsTreeIsPresent(sessionsRoot: string, isSelectedAccount: boolean): boolean {
+  try {
+    statSync(sessionsRoot)
+    return true
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | null)?.code
+    if (code === 'ENOENT' || code === 'ENOTDIR') {
+      return false
+    }
+    if (isSelectedAccount) {
+      throw new ManagedCodexHomeTemporarilyUnavailableError(undefined, { cause: error })
+    }
+    // Why: an unreadable home that is NOT the selected account cannot cause a
+    // wrong-account resume; skipping it only forgoes a candidate.
+    return false
+  }
+}
+
 export async function findTrustedCodexSessionResume(args: {
   sessionId: string
   transcriptPath: string | undefined
@@ -241,6 +276,7 @@ export async function findTrustedCodexSessionResume(args: {
       listCodexSessionRolloutFilesIncrementally(sessionsRoot, { batchSize: 64, yieldMs: 0 }))
   const expectedSuffix = `-${args.sessionId}.jsonl`.toLowerCase()
   const seenHomes = new Set<string>()
+  const selectedAccountHome = args.getSelectedAccountCodexHome()
   for (const homePath of rankTrustedCodexHomesForRescan(args)) {
     const comparisonHome = normalizeRuntimePathForComparison(homePath)
     if (seenHomes.has(comparisonHome)) {
@@ -248,7 +284,10 @@ export async function findTrustedCodexSessionResume(args: {
     }
     seenHomes.add(comparisonHome)
     const sessionsRoot = join(homePath, 'sessions')
-    if (!args.listSessionFiles && !existsSync(sessionsRoot)) {
+    if (
+      !args.listSessionFiles &&
+      !sessionsTreeIsPresent(sessionsRoot, isSelectedAccountHome(selectedAccountHome, homePath))
+    ) {
       continue
     }
     for await (const filePath of listSessionFiles(sessionsRoot)) {

--- a/src/main/codex/codex-session-resume-home.ts
+++ b/src/main/codex/codex-session-resume-home.ts
@@ -176,17 +176,20 @@ export async function resolveCodexSessionResumeProvenance(args: {
  * account's ownership marker, and the far more common provenance-present
  * resume never reaches the ranking at all.
  */
-function rankTrustedCodexHomesForRescan(args: {
-  trustedCodexHomes: readonly string[]
-  getSelectedAccountCodexHome: () => string | null
-  systemCodexHomePath: string | null
-  sharedRuntimeCodexHomePath: string | null
-}): string[] {
+function rankTrustedCodexHomesForRescan(
+  args: {
+    trustedCodexHomes: readonly string[]
+    getSelectedAccountCodexHome: () => string | null
+    systemCodexHomePath: string | null
+    sharedRuntimeCodexHomePath: string | null
+  },
+  selectedAccountHome = args.getSelectedAccountCodexHome()
+): string[] {
   const toComparisonHome = (value: string | null | undefined): string | null => {
     const trimmed = value?.trim()
     return trimmed ? normalizeRuntimePathForComparison(trimmed) : null
   }
-  const selectedComparison = toComparisonHome(args.getSelectedAccountCodexHome())
+  const selectedComparison = toComparisonHome(selectedAccountHome)
   const systemComparison = toComparisonHome(args.systemCodexHomePath)
   const sharedRuntimeComparison = toComparisonHome(args.sharedRuntimeCodexHomePath)
   const rankOf = (comparisonHome: string): number => {
@@ -248,6 +251,11 @@ function sessionsTreeIsPresent(sessionsRoot: string, isSelectedAccount: boolean)
   }
 }
 
+function isDefinitiveSessionTreeAbsence(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | null)?.code
+  return code === 'ENOENT' || code === 'ENOTDIR'
+}
+
 export async function findTrustedCodexSessionResume(args: {
   sessionId: string
   transcriptPath: string | undefined
@@ -270,14 +278,28 @@ export async function findTrustedCodexSessionResume(args: {
     return null
   }
 
+  const selectedAccountHome = args.getSelectedAccountCodexHome()
+  const selectedSessionsRoot = selectedAccountHome
+    ? normalizeRuntimePathForComparison(join(selectedAccountHome, 'sessions'))
+    : null
   const listSessionFiles =
     args.listSessionFiles ??
     ((sessionsRoot: string) =>
-      listCodexSessionRolloutFilesIncrementally(sessionsRoot, { batchSize: 64, yieldMs: 0 }))
+      listCodexSessionRolloutFilesIncrementally(
+        sessionsRoot,
+        { batchSize: 64, yieldMs: 0 },
+        (_directoryPath, error) => {
+          if (
+            selectedSessionsRoot === normalizeRuntimePathForComparison(sessionsRoot) &&
+            !isDefinitiveSessionTreeAbsence(error)
+          ) {
+            throw new ManagedCodexHomeTemporarilyUnavailableError(undefined, { cause: error })
+          }
+        }
+      ))
   const expectedSuffix = `-${args.sessionId}.jsonl`.toLowerCase()
   const seenHomes = new Set<string>()
-  const selectedAccountHome = args.getSelectedAccountCodexHome()
-  for (const homePath of rankTrustedCodexHomesForRescan(args)) {
+  for (const homePath of rankTrustedCodexHomesForRescan(args, selectedAccountHome)) {
     const comparisonHome = normalizeRuntimePathForComparison(homePath)
     if (seenHomes.has(comparisonHome)) {
       continue

--- a/src/main/codex/codex-session-resume-wrong-account.test.ts
+++ b/src/main/codex/codex-session-resume-wrong-account.test.ts
@@ -1,0 +1,175 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import type * as NodeFs from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// STA-4607: a briefly unreadable sessions tree used to read as "this rollout is
+// not bridged here", so the scan fell through to another account's home — and
+// that home becomes the resumed pane's CODEX_HOME. The session resumed under
+// account B's credentials while the UI still showed account A.
+
+const statFaults = vi.hoisted(() => {
+  const state = {
+    held: new Set<string>(),
+    reads: new Map<string, number>(),
+    hold(path: string): void {
+      state.held.add(path)
+    },
+    reset(): void {
+      state.held.clear()
+      state.reads.clear()
+    },
+    readsFor(path: string): number {
+      return state.reads.get(path) ?? 0
+    },
+    consume(target: unknown): void {
+      if (typeof target !== 'string' || !state.held.has(target)) {
+        return
+      }
+      state.reads.set(target, (state.reads.get(target) ?? 0) + 1)
+      const error: NodeJS.ErrnoException = new Error(
+        `EBUSY: resource busy or locked, stat '${target}'`
+      )
+      error.code = 'EBUSY'
+      error.syscall = 'stat'
+      error.path = target
+      throw error
+    }
+  }
+  return state
+})
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFs>()
+  const originalStat = actual.statSync as (...args: unknown[]) => unknown
+  const patched: Record<string, unknown> = {
+    ...actual,
+    statSync: Object.assign((...args: unknown[]): unknown => {
+      statFaults.consume(args[0])
+      return originalStat(...args)
+    }, originalStat)
+  }
+  return { ...patched, default: patched }
+})
+
+const { findTrustedCodexSessionResume } = await import('./codex-session-resume-home')
+const { ManagedCodexHomeTemporarilyUnavailableError } =
+  await import('../codex-accounts/host-codex-managed-home-ownership')
+
+const tempRoots: string[] = []
+const SESSION_ID = '11111111-2222-3333-4444-555555555555'
+
+function makeHomeWithRollout(root: string, name: string): string {
+  const homePath = join(root, name)
+  const datedDir = join(homePath, 'sessions', '2026', '07', '20')
+  mkdirSync(datedDir, { recursive: true })
+  writeFileSync(join(datedDir, `rollout-${SESSION_ID}.jsonl`), '{}\n', 'utf-8')
+  return homePath
+}
+
+beforeEach(() => {
+  statFaults.reset()
+})
+
+afterEach(() => {
+  statFaults.reset()
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+describe('STA-4607 session resume under a briefly unreadable sessions tree', () => {
+  it('refuses rather than resuming the selected account under another account home', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-sta4607-'))
+    tempRoots.push(root)
+    // Both accounts hold the same rollout id — exactly the bridged state where
+    // the id alone no longer names an account.
+    const selectedHome = makeHomeWithRollout(root, 'account-a')
+    const otherHome = makeHomeWithRollout(root, 'account-b')
+
+    const args = {
+      sessionId: SESSION_ID,
+      transcriptPath: undefined,
+      trustedCodexHomes: [selectedHome, otherHome],
+      getSelectedAccountCodexHome: (): string | null => selectedHome,
+      systemCodexHomePath: null,
+      sharedRuntimeCodexHomePath: null
+    }
+
+    // Anchor: with a readable tree the selected account wins, as designed.
+    await expect(findTrustedCodexSessionResume(args)).resolves.toEqual({
+      homePath: selectedHome,
+      transcriptPath: join(
+        selectedHome,
+        'sessions',
+        '2026',
+        '07',
+        '20',
+        `rollout-${SESSION_ID}.jsonl`
+      )
+    })
+
+    // Now hold the selected account's sessions tree, the way an antivirus scan does.
+    const selectedSessionsRoot = join(selectedHome, 'sessions')
+    statFaults.hold(selectedSessionsRoot)
+
+    // THE FIX: refuse. Before it, this resolved to account B's home.
+    await expect(findTrustedCodexSessionResume(args)).rejects.toBeInstanceOf(
+      ManagedCodexHomeTemporarilyUnavailableError
+    )
+    expect(statFaults.readsFor(selectedSessionsRoot)).toBeGreaterThan(0)
+  })
+
+  it('still skips a definitively absent sessions tree', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-sta4607-'))
+    tempRoots.push(root)
+    const selectedHome = join(root, 'account-a-no-sessions')
+    mkdirSync(selectedHome, { recursive: true })
+    const otherHome = makeHomeWithRollout(root, 'account-b')
+
+    // Why: absence is a real answer — the rollout genuinely is not bridged into
+    // the selected home — so the scan must still fall through. The fix must not
+    // turn every miss into a refusal.
+    await expect(
+      findTrustedCodexSessionResume({
+        sessionId: SESSION_ID,
+        transcriptPath: undefined,
+        trustedCodexHomes: [selectedHome, otherHome],
+        getSelectedAccountCodexHome: (): string | null => selectedHome,
+        systemCodexHomePath: null,
+        sharedRuntimeCodexHomePath: null
+      })
+    ).resolves.toEqual({
+      homePath: otherHome,
+      transcriptPath: join(otherHome, 'sessions', '2026', '07', '20', `rollout-${SESSION_ID}.jsonl`)
+    })
+  })
+
+  it('skips an unreadable home that is NOT the selected account', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-sta4607-'))
+    tempRoots.push(root)
+    const selectedHome = join(root, 'account-a-empty')
+    mkdirSync(join(selectedHome, 'sessions'), { recursive: true })
+    const otherHome = makeHomeWithRollout(root, 'account-b')
+    const unrelatedHome = makeHomeWithRollout(root, 'account-c')
+
+    // Why: an unreadable home that is not the selected account cannot cause a
+    // wrong-account resume, so refusing there would strand the user for no gain.
+    statFaults.hold(join(unrelatedHome, 'sessions'))
+
+    await expect(
+      findTrustedCodexSessionResume({
+        sessionId: SESSION_ID,
+        transcriptPath: undefined,
+        trustedCodexHomes: [selectedHome, unrelatedHome, otherHome],
+        getSelectedAccountCodexHome: (): string | null => selectedHome,
+        systemCodexHomePath: null,
+        sharedRuntimeCodexHomePath: null
+      })
+    ).resolves.toEqual({
+      homePath: otherHome,
+      transcriptPath: join(otherHome, 'sessions', '2026', '07', '20', `rollout-${SESSION_ID}.jsonl`)
+    })
+  })
+})

--- a/src/main/codex/codex-session-resume-wrong-account.test.ts
+++ b/src/main/codex/codex-session-resume-wrong-account.test.ts
@@ -198,6 +198,31 @@ describe('STA-4607 session resume under a briefly unreadable sessions tree', () 
     ).rejects.toBeInstanceOf(ManagedCodexHomeTemporarilyUnavailableError)
   })
 
+  // Why: CodeRabbit read the callback's guard as matching only the exact sessions
+  // root and reported nested failures as leaking. The guard actually keys on the
+  // root being LISTED, not the failing directory, so a lock on a dated
+  // subdirectory is covered too. Pinned so the question cannot recur.
+  it('refuses when a NESTED dated directory locks and the root stats fine', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-sta4607-'))
+    tempRoots.push(root)
+    const selectedHome = makeHomeWithRollout(root, 'account-a')
+    const otherHome = makeHomeWithRollout(root, 'account-b')
+    // Only the dated directory faults; the sessions root itself reads fine, so
+    // the preliminary stat guard cannot be what catches this.
+    listingFaults.hold(join(selectedHome, 'sessions', '2026', '07', '20'))
+
+    await expect(
+      findTrustedCodexSessionResume({
+        sessionId: SESSION_ID,
+        transcriptPath: undefined,
+        trustedCodexHomes: [selectedHome, otherHome],
+        getSelectedAccountCodexHome: (): string | null => selectedHome,
+        systemCodexHomePath: null,
+        sharedRuntimeCodexHomePath: null
+      })
+    ).rejects.toBeInstanceOf(ManagedCodexHomeTemporarilyUnavailableError)
+  })
+
   it('skips an unreadable home that is NOT the selected account', async () => {
     const root = mkdtempSync(join(tmpdir(), 'orca-sta4607-'))
     tempRoots.push(root)

--- a/src/main/codex/codex-session-resume-wrong-account.test.ts
+++ b/src/main/codex/codex-session-resume-wrong-account.test.ts
@@ -1,5 +1,6 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import type * as NodeFs from 'node:fs'
+import type * as NodeFsPromises from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -40,6 +41,16 @@ const statFaults = vi.hoisted(() => {
   return state
 })
 
+const listingFaults = vi.hoisted(() => ({
+  held: new Set<string>(),
+  hold(path: string): void {
+    listingFaults.held.add(path)
+  },
+  reset(): void {
+    listingFaults.held.clear()
+  }
+}))
+
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof NodeFs>()
   const originalStat = actual.statSync as (...args: unknown[]) => unknown
@@ -51,6 +62,25 @@ vi.mock('node:fs', async (importOriginal) => {
     }, originalStat)
   }
   return { ...patched, default: patched }
+})
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFsPromises>()
+  return {
+    ...actual,
+    opendir: async (...args: Parameters<typeof actual.opendir>) => {
+      if (typeof args[0] === 'string' && listingFaults.held.has(args[0])) {
+        const error: NodeJS.ErrnoException = new Error(
+          `EBUSY: resource busy or locked, opendir '${args[0]}'`
+        )
+        error.code = 'EBUSY'
+        error.syscall = 'opendir'
+        error.path = args[0]
+        throw error
+      }
+      return actual.opendir(...args)
+    }
+  }
 })
 
 const { findTrustedCodexSessionResume } = await import('./codex-session-resume-home')
@@ -70,10 +100,12 @@ function makeHomeWithRollout(root: string, name: string): string {
 
 beforeEach(() => {
   statFaults.reset()
+  listingFaults.reset()
 })
 
 afterEach(() => {
   statFaults.reset()
+  listingFaults.reset()
   for (const root of tempRoots.splice(0)) {
     rmSync(root, { recursive: true, force: true })
   }
@@ -144,6 +176,26 @@ describe('STA-4607 session resume under a briefly unreadable sessions tree', () 
       homePath: otherHome,
       transcriptPath: join(otherHome, 'sessions', '2026', '07', '20', `rollout-${SESSION_ID}.jsonl`)
     })
+  })
+
+  it('refuses when the selected tree locks during listing after stat succeeds', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-sta4607-'))
+    tempRoots.push(root)
+    const selectedHome = makeHomeWithRollout(root, 'account-a')
+    const otherHome = makeHomeWithRollout(root, 'account-b')
+    const selectedSessionsRoot = join(selectedHome, 'sessions')
+    listingFaults.hold(selectedSessionsRoot)
+
+    await expect(
+      findTrustedCodexSessionResume({
+        sessionId: SESSION_ID,
+        transcriptPath: undefined,
+        trustedCodexHomes: [selectedHome, otherHome],
+        getSelectedAccountCodexHome: (): string | null => selectedHome,
+        systemCodexHomePath: null,
+        sharedRuntimeCodexHomePath: null
+      })
+    ).rejects.toBeInstanceOf(ManagedCodexHomeTemporarilyUnavailableError)
   })
 
   it('skips an unreadable home that is NOT the selected account', async () => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1188,6 +1188,12 @@ async function prepareCodexSessionResumeForLaunch(args: {
           }
         )
       } catch (error) {
+        // Why: this launch path pins CODEX_HOME to the account that OWNS the
+        // rollout and deliberately refuses to repin onto whichever account is
+        // selected now (#10793), so it does not wire
+        // getSelectedHostAccountCodexHomePath and this branch cannot fire today.
+        // It stays as a contract guard: the blanket catch below must never
+        // silently swallow a typed refusal if that ever changes.
         if (error instanceof ManagedCodexHomeTemporarilyUnavailableError) {
           throw error
         }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -245,6 +245,7 @@ import {
 import { createCodexSessionMigrationScheduler } from './codex/codex-session-migration-scheduler'
 import { prepareCodexAiVaultSessionResume } from './codex/codex-ai-vault-session-resume'
 import { prepareLegacySharedCodexSessionResume } from './codex/codex-legacy-session-resume'
+import { ManagedCodexHomeTemporarilyUnavailableError } from './codex-accounts/host-codex-managed-home-ownership'
 import { resolveHostCodexSessionSourceHome } from './codex/codex-session-source-home'
 import type { CodexSessionResumePreparation } from './codex/codex-session-resume-home'
 import { prepareCodexSessionResume } from './codex/codex-session-resume-preparation'
@@ -1187,6 +1188,9 @@ async function prepareCodexSessionResumeForLaunch(args: {
           }
         )
       } catch (error) {
+        if (error instanceof ManagedCodexHomeTemporarilyUnavailableError) {
+          throw error
+        }
         // Why: migration is a compatibility repair; its failure must not prevent the PTY from resuming from its trusted origin home.
         console.warn(
           '[codex-session-resume] Legacy rollout migration failed; using origin home:',


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​295 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​294 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​93 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​80 |

<!-- /orca-pr-loc -->

Fixes STA-4607. Split out of STA-4422 / #15046 as a deliberately separate change.

## The bug

A Codex session could resume under a **different account than the one selected**, while the UI still showed the selected one. Two probes reported "this rollout is not bridged here" for *any* filesystem error, not just a genuine absence:

**1. Legacy id rescan** — `codex-session-resume-home.ts`
```ts
if (!args.listSessionFiles && !existsSync(sessionsRoot)) {
  continue
}
```
`existsSync` returns `false` on `EBUSY`/`EPERM`, so a briefly locked sessions tree made the scan `continue` to the next ranked home. Per that file's own comment, *"The winning home becomes the resumed pane's CODEX_HOME, so it picks the account."*

**2. AI Vault repinning** — `codex-legacy-session-resume.ts`: a blanket `catch { return null }` around the selected account's candidate rollout `lstat`, after which the caller keeps the source per-account home.

**On what actually triggers this — corrected after Windows validation.** I originally described antivirus file locks as the trigger. I tested that on a real Windows host and **could not reproduce it**: a `FileShare.None` lock on a rollout file leaves `stat`, `lstat` and `opendir` all succeeding, because those read metadata rather than file contents (unlike STA-4422's `readFileSync`, which did fail 100% under the same lock). Directories cannot be locked that way at all — `File.Open` on a directory throws.

So the demonstrated trigger for *this* pair of probes is not an antivirus lock. The fix still stands on its own terms: `EPERM`/`EACCES` from permissions or network/remote filesystems, `EMFILE` under descriptor exhaustion, and delete-pending states all reach these paths, and treating "couldn't read" as "not bridged here" is wrong regardless of which errno produces it. But the specific antivirus story was unverified and is withdrawn.

## The fix

Only a definitive `ENOENT`/`ENOTDIR` now means "not bridged here". Any other error raises the typed `ManagedCodexHomeTemporarilyUnavailableError` that #15046 introduced, which both PTY paths already convert into a clean abort before spawn.

**The refusal is scoped to the selected account's home.** An unreadable home that is *not* the selected account cannot cause a wrong-account resume, so it is still skipped — refusing there would strand the user for no gain. That distinction is what the third test pins.

## Not a regression of #15046

These route to another account **today**, with the ownership gate uninvolved: the selected account's marker can be perfectly owned while its *sessions tree* is unreadable, so #15046's eager marker gate passes and doesn't help. Filed and split precisely because they're independent.

## Testing

Three tests, each with a healthy anchor:

- **The fix** — two accounts holding the same rollout id (the bridged state where the id alone no longer names an account), selected account's tree held with an injected `EBUSY`. Anchor first: with a readable tree the selected account wins. Then: refuses instead of resolving to account B.
- **Definitive absence still skips** — the fix must not turn every miss into a refusal.
- **A non-selected unreadable home is still skipped** — pins the scoping.

Mutation-checked: removing the refusal fails the first test with `promise resolved instead of rejecting`, while the other two stay green — so it proves the fix without over-refusing.

Verified: both typechecks clean, changed-code-quality gate 0 findings across all three sub-checks, 4,017 tests passing across `codex/`, `ipc/` and `codex-accounts/`.

